### PR TITLE
fix(knowledge,memory): 第二轮审查改进 — 接入批量 embedding、统一 schema 引用、注册 FactS…

### DIFF
--- a/apps/negentropy/src/negentropy/agents/tools/perception.py
+++ b/apps/negentropy/src/negentropy/agents/tools/perception.py
@@ -30,7 +30,7 @@ from negentropy.knowledge.constants import (
     DEFAULT_SEARCH_LIMIT,
     DEFAULT_SEMANTIC_WEIGHT,
 )
-from negentropy.knowledge.embedding import build_embedding_fn
+from negentropy.knowledge.embedding import build_batch_embedding_fn, build_embedding_fn
 from negentropy.knowledge.service import KnowledgeService
 from negentropy.knowledge.types import SearchConfig
 from negentropy.logging import get_logger
@@ -52,7 +52,10 @@ def _get_knowledge_service() -> KnowledgeService:
     """
     global _knowledge_service
     if _knowledge_service is None:
-        _knowledge_service = KnowledgeService(embedding_fn=build_embedding_fn())
+        _knowledge_service = KnowledgeService(
+            embedding_fn=build_embedding_fn(),
+            batch_embedding_fn=build_batch_embedding_fn(),
+        )
     return _knowledge_service
 
 

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -309,7 +309,7 @@ class PostgresMemoryService(BaseMemoryService):
         sql = text("""
             SELECT id, content, metadata, retention_score, created_at,
                    ts_rank_cd(search_vector, plainto_tsquery('english', :query)) AS rank_score
-            FROM negentropy.memories
+            FROM memories
             WHERE user_id = :user_id
               AND app_name = :app_name
               AND search_vector @@ plainto_tsquery('english', :query)

--- a/apps/negentropy/src/negentropy/engine/factories/memory.py
+++ b/apps/negentropy/src/negentropy/engine/factories/memory.py
@@ -17,6 +17,7 @@ from google.adk.memory.base_memory_service import BaseMemoryService
 from negentropy.config import settings
 
 if TYPE_CHECKING:
+    from negentropy.engine.adapters.postgres.fact_service import FactService
     from negentropy.engine.governance.memory import MemoryGovernanceService
 
 # 类型别名：embedding 函数签名
@@ -159,6 +160,42 @@ def reset_memory_governance_service() -> None:
     _memory_governance_service_instance = None
 
 
+# ============================================================================
+# Fact Service Factory
+# ============================================================================
+
+_fact_service_instance: Optional["FactService"] = None
+
+
+def get_fact_service(embedding_fn: Optional[EmbeddingFn] = None) -> "FactService":
+    """
+    获取 FactService 实例 (工厂函数)
+
+    FactService 管理 Fact（语义记忆）的 CRUD 操作，
+    支持向量语义检索与 ilike 回退。
+
+    Args:
+        embedding_fn: 向量化函数，签名: async (text: str) -> list[float]
+
+    Returns:
+        FactService 实例
+    """
+    global _fact_service_instance
+
+    if _fact_service_instance is None:
+        from negentropy.engine.adapters.postgres.fact_service import FactService
+
+        _fact_service_instance = FactService(embedding_fn=embedding_fn)
+
+    return _fact_service_instance
+
+
+def reset_fact_service() -> None:
+    """重置 FactService 单例缓存 (用于测试)"""
+    global _fact_service_instance
+    _fact_service_instance = None
+
+
 __all__ = [
     "MemoryBackend",
     "EmbeddingFn",
@@ -170,4 +207,7 @@ __all__ = [
     # Memory Governance
     "get_memory_governance_service",
     "reset_memory_governance_service",
+    # Fact Service
+    "get_fact_service",
+    "reset_fact_service",
 ]

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -19,7 +19,7 @@ from .constants import (
     DEFAULT_SEARCH_LIMIT,
     DEFAULT_SEMANTIC_WEIGHT,
 )
-from .embedding import build_embedding_fn
+from .embedding import build_batch_embedding_fn, build_embedding_fn
 from .dao import KnowledgeRunDao
 from .exceptions import (
     CorpusNotFound,
@@ -125,7 +125,10 @@ _dao: Optional[KnowledgeRunDao] = None
 def _get_service() -> KnowledgeService:
     global _service
     if _service is None:
-        _service = KnowledgeService(embedding_fn=build_embedding_fn())
+        _service = KnowledgeService(
+            embedding_fn=build_embedding_fn(),
+            batch_embedding_fn=build_batch_embedding_fn(),
+        )
     return _service
 
 

--- a/apps/negentropy/src/negentropy/knowledge/embedding.py
+++ b/apps/negentropy/src/negentropy/knowledge/embedding.py
@@ -11,7 +11,7 @@ Embedding 向量化模块
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any, Dict, List
+from typing import Any
 
 from negentropy.config import settings
 from negentropy.logging import get_logger


### PR DESCRIPTION
…ervice 工厂

- R1: api.py / perception.py 的 _get_service() 传入 batch_embedding_fn， 使第一轮实现的批量 embedding 能力在实际运行中生效
- R2: memory_service.py _keyword_search SQL 去掉硬编码 negentropy.memories， 改为 FROM memories，与 hybrid_search() DB 函数保持一致（依赖 search_path）
- R3: factories/memory.py 注册 get_fact_service() / reset_fact_service() 工厂函数， 将 FactService 接入 Strategy + Factory 单例管理体系
- R4: embedding.py 移除未使用的 Dict/List typing 导入