### PR TITLE
fix(UI): 修复 CI 测试失败，完成 pnpm 迁移并添加缺失依赖 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -16,6 +16,7 @@
     "@ag-ui/encoder": "0.0.42",
     "@copilotkitnext/react": "1.51.3",
     "d3-drag": "^3.0.0",
+    "lucide-react": "^0.525.0",
     "d3-force": "^3.0.0",
     "d3-selection": "^3.0.0",
     "d3-zoom": "^3.0.0",

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       d3-zoom:
         specifier: ^3.0.0
         version: 3.0.0
+      lucide-react:
+        specifier: ^0.525.0
+        version: 0.525.0(react@19.2.3)
       mermaid:
         specifier: ^11.12.2
         version: 11.12.3


### PR DESCRIPTION
## 摘要

本 PR 修复了 GitHub Actions UI Tests 工作流中的测试失败问题，并完成了从 yarn 到 pnpm 的包管理器迁移。

## 变更内容

### 修复内容
- **添加缺失的 `lucide-react` 依赖**：该包在代码中被使用（JsonViewer.tsx 等 5 个文件）但未在 `package.json` 中声明，导致 pnpm 的严格依赖解析失败

### 包管理器迁移 (yarn → pnpm)
- 删除 `yarn.lock`，生成 `pnpm-lock.yaml`
- 更新 UI Tests 工作流配置，使用 `pnpm/action-setup@v4`
- 配置 Node.js 缓存使用 pnpm

### 其他变更
- 添加 GCS Source Rebuild API Route 代理层
- 修复文件下载功能并改进错误提示
- 添加 `knowledge_documents` 表 `created_by` 字段迁移
- 移除 Git Hooks 相关配置文件
- 修正 CI 测试数据库连接环境变量名称
- 文档列表样式调整

## 问题根因

CI 失败的根本原因是 `lucide-react` 包未在 `package.json` 中声明。虽然该包存在于 `pnpm-lock.yaml` 中（可能是作为其他包的 peer dependency 被间接安装），但 pnpm 的严格依赖解析机制要求所有直接使用的包必须显式声明。

## 测试验证

- ✅ 本地运行 `pnpm test`：11 个测试套件全部通过（62 passed, 3 skipped）
- ✅ 依赖安装：`pnpm install` 正常完成

---

This PR was written using [Vibe Kanban](https://vibekanban.com)