### PR TITLE
fix(UI): 禁用 Turbopack 修复 Git worktree 环境下的 panic 错误 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary

- **禁用 Turbopack**：在 `package.json` 的 dev 脚本中添加 `--webpack` 标志，回退到 Webpack 打包器
- **修复 panic 错误**：解决 Next.js 16 在 Git worktree 环境下 Turbopack 的路径识别问题

## 变更内容

### 修改文件
- `apps/negentropy-ui/package.json` - 将 `"dev": "next dev"` 改为 `"dev": "next dev --webpack"`

## 背景

在 Next.js 16 中，Turbopack 已成为默认的开发服务器打包器。然而，在 Git worktree 环境（特别是 macOS 临时目录 `/private/var/folders/...`）下，Turbopack 存在已知问题：

```
FATAL: An unexpected Turbopack error occurred. A panic log has been written to...
Resource path "apps/negentropy-ui/app/page.tsx" need to be on project filesystem ""
```

这是 Turbopack 在非标准路径环境下的兼容性问题，导致 HMR 更新时发生 panic。

## 解决方案

通过添加 `--webpack` 标志，禁用 Turbopack 并回退到 Webpack。Webpack 对非标准路径和符号链接的支持更加成熟稳定。

## 相关 Issue

- [GitHub Issue #87692](https://github.com/vercel/next.js/issues/87692) - Turbopack symlink 问题
- [GitHub Discussion #87335](https://github.com/vercel/next.js/discussions/87335) - Turbopack symlink 修复

## Test plan

- [x] 修改 `package.json` 的 dev 脚本
- [x] 清理 `.next` 缓存目录
- [ ] 运行 `pnpm dev` 验证服务正常启动
- [ ] 访问 http://localhost:3000 确认页面加载正常
- [ ] 测试 HMR 功能（修改页面内容，确认热更新正常）

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*