### PR TITLE
fix(Documents): 移除 File Hash 列的问号光标样式 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -49,7 +49,7 @@ function truncateHash(hash: string | null): JSX.Element {
   if (!hash) return <span className="text-muted">-</span>;
   const truncated = `${hash.slice(0, 8)}...${hash.slice(-4)}`;
   return (
-    <span className="font-mono text-xs text-muted cursor-help" title={hash}>
+    <span className="font-mono text-xs text-muted" title={hash}>
       {truncated}
     </span>
   );


### PR DESCRIPTION
## Summary

- 移除 Documents 页面 Files 列表中 File Hash 列的 `cursor-help` 样式类
- 使 File Hash 列的鼠标悬停光标与其他列保持一致（默认指针）

## 变更详情

**修改文件**: `apps/negentropy-ui/app/knowledge/documents/page.tsx`

**修改内容**: 在 `truncateHash` 函数中移除了 `cursor-help` Tailwind CSS 类。

```diff
- <span className="font-mono text-xs text-muted cursor-help" title={hash}>
+ <span className="font-mono text-xs text-muted" title={hash}>
```

## 原因

之前 File Hash 列使用了 `cursor-help` 样式，导致鼠标悬停时显示问号光标（带问号的箭头）。这与用户期望不符，用户希望该列的光标样式与其他列保持一致。

## 验证

- tooltip 功能仍然保留，鼠标悬停时会显示完整的 hash 值

---

This PR was written using [Vibe Kanban](https://vibekanban.com)