### PR TITLE
fix(CI): 修复 GitHub Actions 集成测试失败问题 (Vibe Kanban)

### DIFF
--- a/.github/workflows/negentropy-backend-tests.yml
+++ b/.github/workflows/negentropy-backend-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_db
@@ -56,6 +56,26 @@ jobs:
 
       - name: Run unit tests
         run: uv run pytest tests/unit_tests/ -v
+        env:
+          NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+
+      - name: Initialize database schema
+        run: |
+          uv run python -c "
+          import asyncio
+          from sqlalchemy import text
+          from sqlalchemy.ext.asyncio import create_async_engine
+
+          async def init_db():
+              engine = create_async_engine('postgresql+asyncpg://postgres:postgres@localhost:5432/test_db')
+              async with engine.begin() as conn:
+                  await conn.execute(text('CREATE SCHEMA IF NOT EXISTS negentropy'))
+                  await conn.execute(text('CREATE EXTENSION IF NOT EXISTS vector'))
+              await engine.dispose()
+
+          asyncio.run(init_db())
+          "
+          uv run alembic upgrade head
         env:
           NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
 

--- a/apps/negentropy/src/negentropy/db/migrations/env.py
+++ b/apps/negentropy/src/negentropy/db/migrations/env.py
@@ -89,6 +89,10 @@ def do_run_migrations(connection: Connection) -> None:
     connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {NEGENTROPY_SCHEMA}"))
     connection.commit()
 
+    # 启用 pgvector 扩展（用于 vector 类型的 embedding 列）
+    connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    connection.commit()
+
     def include_object(object, name, type_, reflected, compare_to):
         """
         过滤器：仅管理 negentropy schema 中的对象。


### PR DESCRIPTION
## Summary

- 将 PostgreSQL 服务镜像从 `postgres:16` 替换为 `pgvector/pgvector:pg16`，解决 pgvector 扩展缺失问题
- 在集成测试前新增数据库初始化步骤：创建 schema、启用 vector 扩展、运行 Alembic 迁移
- 在 `alembic/env.py` 中确保迁移执行前启用 pgvector 扩展

## 问题根因

GitHub Actions 集成测试失败，错误信息：
- `asyncpg.exceptions.UndefinedObjectError: type "vector" does not exist`
- `asyncpg.exceptions.UndefinedTableError: relation "negentropy.threads" does not exist`

**根本原因**：
1. 标准 `postgres:16` 镜像不包含 pgvector 扩展，而项目的数据库 schema 使用了 `vector` 类型存储 embedding
2. 集成测试直接连接空数据库，未执行 Alembic 迁移创建表结构

## 实现细节

### 1. 更换 PostgreSQL 镜像
```yaml
services:
  postgres:
    image: pgvector/pgvector:pg16  # 预装 pgvector 扩展
```

### 2. 添加数据库初始化步骤
在运行集成测试前，执行：
- `CREATE SCHEMA IF NOT EXISTS negentropy`
- `CREATE EXTENSION IF NOT EXISTS vector`
- `alembic upgrade head`

### 3. 修改 Alembic 迁移环境
在 `do_run_migrations` 函数中添加 pgvector 扩展创建语句，确保迁移在任何环境下都能正常执行。

## Test Plan

- [x] 推送变更后观察 GitHub Actions workflow 运行结果
- [x] 确认所有集成测试通过

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*