### PR TITLE
fix(Knowledge): 修复 ingest_text Pipeline 状态未更新为 completed 的问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -276,7 +276,7 @@ class KnowledgeService:
         )
 
         try:
-            return await self._ingest_text_with_tracker(
+            records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
                 text=text,
@@ -285,6 +285,16 @@ class KnowledgeService:
                 chunking_config=config,
                 tracker=tracker,
             )
+
+            # 完成 Pipeline
+            if tracker:
+                await tracker.complete(
+                    {
+                        "chunk_count": len(records),
+                    }
+                )
+
+            return records
         except Exception as exc:
             if tracker and tracker.current_stage:
                 await tracker.fail_stage(


### PR DESCRIPTION
## 问题描述

Knowledge Pipeline 页面的 Run 执行成功后，状态仍显示为 `running` 而非 `completed`。

### 问题表现
- 持久化阶段已完成（显示 155ms, 39 records）
- 但页面状态仍停留在 `running`
- Completed 和 Duration 字段显示为 `-`（未完成）

## 修复内容

在 `ingest_text` 方法中添加 `tracker.complete()` 调用，确保 Pipeline Run 执行成功后状态正确更新为 `completed`。

### 修改文件
- `apps/negentropy/src/negentropy/knowledge/service.py`

### 实现细节
```python
# 修改前
try:
    return await self._ingest_text_with_tracker(...)

# 修改后
try:
    records = await self._ingest_text_with_tracker(...)
    
    # 完成 Pipeline
    if tracker:
        await tracker.complete({"chunk_count": len(records)})
    
    return records
```

### 问题根因
`ingest_text` 方法调用 `_ingest_text_with_tracker` 完成各阶段后，缺少 `tracker.complete()` 调用。而其他类似方法（`ingest_url`、`replace_source`、`sync_source`、`rebuild_source`）都正确调用了 `tracker.complete()`。

---

This PR was written using [Vibe Kanban](https://vibekanban.com)