### PR TITLE
fix(Tests): 修复性能测试 Event loop is closed 错误 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -73,6 +73,8 @@ line-ending = "auto"
 [tool.pytest.ini_options]
 # Automatically treat async def functions as async tests (no manual @pytest.mark.asyncio needed)
 asyncio_mode = "auto"
+# Set event loop fixture scope to function to match db_engine fixture scope
+asyncio_default_fixture_loop_scope = "function"
 # Add src to pythonpath so tests can import the package directly without installation
 pythonpath = ["src"]
 # Restrict test discovery to the tests directory to avoid picking up scripts or other files


### PR DESCRIPTION
## 问题描述

GitHub Actions 的 `negentropy-backend-tests` workflow 在执行**性能测试**阶段时报错 `Event loop is closed`，导致 CI 流水线失败。

**失败日志**: https://github.com/ThreeFish-AI/negentropy/actions/runs/22522184638/job/65248612835

## 根本原因

`pytest-asyncio` 的 event loop 作用域与 `conftest.py` 中的 fixture 作用域不匹配：

1. `conftest.py` 中的 `db_engine` fixture 使用 `scope="function"`
2. 每个测试函数结束后，`engine.dispose()` 被调用，event loop 关闭
3. 但 `KnowledgeService` 内部通过 `KnowledgeRepository` 引用了全局 `db/session.py` 中的模块级 `engine`
4. 后续测试尝试复用已关闭的 event loop 时触发错误

## 解决方案

在 `apps/negentropy/pyproject.toml` 的 `[tool.pytest.ini_options]` 部分添加配置：

```toml
asyncio_default_fixture_loop_scope = "function"
```

确保 pytest-asyncio 的 event loop fixture 作用域与 `db_engine` fixture 一致，避免跨测试函数复用已关闭的 event loop。

## 变更文件

- `apps/negentropy/pyproject.toml`: 添加 `asyncio_default_fixture_loop_scope` 配置项

## 验证方法

1. 本地验证: `cd apps/negentropy && uv run pytest tests/performance_tests/ -v`
2. CI 验证: 推送后观察 GitHub Actions workflow 执行结果

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*