### PR TITLE
fix(Knowledge): GCS 存储文件强制使用 gcs_uri 作为 source_uri (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -857,8 +857,12 @@ async def ingest_file(
                 detail={"code": "EMPTY_CONTENT", "message": "No text content extracted from file"},
             )
 
-        # 使用 source_uri 参数 > GCS URI > 清理后的文件名
-        final_source_uri = source_uri or gcs_uri or safe_filename
+        # GCS 存储的文件强制使用 gcs_uri 作为 source_uri（支持 Rebuild 功能）
+        # 只有非 GCS 存储时才使用用户提供的 source_uri 或文件名
+        if store_to_gcs and gcs_uri:
+            final_source_uri = gcs_uri
+        else:
+            final_source_uri = source_uri or safe_filename
 
         # 获取服务并执行摄入
         service = _get_service()


### PR DESCRIPTION
## Summary

修复 Knowledge Base 页面中 GCS 上存储的 PDF 文件未显示 Rebuild 选项的问题。

## Changes

- 修改 `apps/negentropy/src/negentropy/knowledge/api.py` 中 `final_source_uri` 的赋值逻辑
- 当 `store_to_gcs=True` 且成功上传到 GCS 时，强制使用 `gcs_uri` 作为 `source_uri`
- 非 GCS 存储场景保持原有逻辑不变

## Why

**问题根因**：

1. 前端上传文件时默认使用文件名作为 `source_uri`（如 `document.pdf`）
2. 原后端逻辑 `final_source_uri = source_uri or gcs_uri or safe_filename` 优先使用用户传入的 `source_uri`
3. 导致存储的 `source_uri` 是 `document.pdf` 而非 `gs://bucket/path/document.pdf`
4. 前端 `isGcsSource()` 检测不以 `gs://` 开头，因此不显示 Rebuild 选项

**修复方案**：

GCS 存储的文件强制使用 `gcs_uri` 作为 `source_uri`，确保前端正确识别为 GCS 类型并显示 Rebuild 选项。

## Test plan

- [ ] 上传 PDF 文件到 Knowledge Base
- [ ] 确认 Source 显示为 `gs://...` 格式
- [ ] 确认 Rebuild 选项可见并可点击
- [ ] 确认 Replace 功能仍正常工作

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*