### PR TITLE
fix(Knowledge): GCS 文件显示 Rebuild 选项及 Source 列友好文件名 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx
@@ -28,6 +28,20 @@ function isGcsSource(uri: string): boolean {
   return uri.startsWith("gs://");
 }
 
+/**
+ * 获取 Source 的显示名称
+ * - GCS URI: 提取最后一部分作为文件名
+ * - URL: 保持原样
+ * - 其他: 保持原样
+ */
+function getDisplayUri(uri: string): string {
+  if (uri.startsWith("gs://")) {
+    const parts = uri.split("/");
+    return parts[parts.length - 1] || uri;
+  }
+  return uri;
+}
+
 export function SourceList({
   sourceStats,
   selectedUri,
@@ -80,7 +94,7 @@ export function SourceList({
 
       {/* 具体 Source 列表 */}
       {sortedSources.map(({ uri, count }) => {
-        const displayUri = uri || "(无来源)";
+        const displayUri = uri ? getDisplayUri(uri) : "(无来源)";
         const key = uri ?? "__no_source__";
         const showMenu = uri && (onReplaceSource || onSyncSource || onRebuildSource);
         const isUrl = uri ? isUrlSource(uri) : false;
@@ -95,7 +109,7 @@ export function SourceList({
                   : "text-muted hover:bg-muted/50 hover:text-foreground"
               }`}
               onClick={() => onSelect(uri)}
-              title={displayUri}
+              title={uri || "(无来源)"}
             >
               <span className="block truncate">{displayUri}</span>
               <span className="text-[10px] opacity-70">


### PR DESCRIPTION
## Summary

修复 Knowledge Base 页面中 GCS 上存储的 PDF 文件两个相关问题：
1. 未显示 **Rebuild** 选项
2. Source 列显示完整 GCS URI 而非友好的文件名

## Changes

### 后端 (`apps/negentropy/src/negentropy/knowledge/api.py`)
- 修改 `ingest_file` 函数中 `final_source_uri` 的赋值逻辑
- 当 `store_to_gcs=True` 且成功上传到 GCS 时，强制使用 `gcs_uri` 作为 `source_uri`
- 确保 GCS 文件的 `source_uri` 以 `gs://` 开头，用于 Rebuild 功能判断

### 前端 (`apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx`)
- 添加 `getDisplayUri` 辅助函数，从 GCS URI 中提取文件名用于显示
- Source 列显示友好文件名（如 `file.pdf`）而非完整 GCS URI
- `title` 属性保持显示完整 URI（鼠标悬停时可见）

## Why

**问题 1: Rebuild 选项不显示**

根因：前端上传文件时默认使用文件名作为 `source_uri`，后端优先使用用户传入的值而非 `gcs_uri`，导致存储的 `source_uri` 不以 `gs://` 开头。

**问题 2: Source 列显示完整 GCS URI**

上一个修复引入的副作用：`source_uri` 改为 `gs://` 格式后，Source 列直接显示了完整路径。

## Implementation Details

- **关注点分离**: `source_uri` 保持 `gs://` 格式用于功能判断，显示层通过 `getDisplayUri` 函数提取友好名称
- **最小改动**: 仅修改前端一个函数，不影响后端 API 和数据结构
- **兼容性**: URL 类型和纯文本类型的 Source 显示保持不变

## Test plan

- [x] 上传 PDF 文件到 Knowledge Base
- [x] 确认 Source 列显示友好文件名
- [x] 确认鼠标悬停显示完整 GCS URI
- [x] 确认 Rebuild 选项正常显示
- [x] 确认 Replace 功能正常工作

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*