### PR TITLE
feat(Documents): 添加文档 Markdown 预览功能 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
+import { DocumentViewDialog } from "./_components/DocumentViewDialog";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
@@ -74,6 +75,7 @@ export default function DocumentsPage() {
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [deleteHard, setDeleteHard] = useState(false);
   const [downloadingIds, setDownloadingIds] = useState<Set<string>>(new Set());
+  const [viewingDoc, setViewingDoc] = useState<KnowledgeDocument | null>(null);
 
   // 加载语料库列表
   const loadCorpora = useCallback(async () => {
@@ -263,6 +265,16 @@ export default function DocumentsPage() {
                         ) : (
                           <>
                             <button
+                              onClick={() => setViewingDoc(doc)}
+                              className="rounded p-1.5 text-muted hover:text-green-600 hover:bg-green-50 transition-colors"
+                              title="View document content"
+                            >
+                              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                              </svg>
+                            </button>
+                            <button
                               onClick={() => handleDownload(doc)}
                               disabled={downloadingIds.has(doc.id)}
                               className="rounded p-1.5 text-muted hover:text-blue-600 hover:bg-blue-50 transition-colors disabled:opacity-50"
@@ -322,6 +334,13 @@ export default function DocumentsPage() {
           </div>
         </main>
       </div>
+
+      {/* Document View Dialog */}
+      <DocumentViewDialog
+        isOpen={viewingDoc !== null}
+        document={viewingDoc}
+        onClose={() => setViewingDoc(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概述

在 Knowledge Base 的 Documents 页面新增文档预览功能，用户可以通过点击 View 按钮在弹窗中以 Markdown 格式查看文档内容。

## 变更内容

### 前端变更

- **Documents 页面** (`page.tsx`):
  - 导入 `DocumentViewDialog` 组件
  - 新增 `viewingDoc` 状态管理当前预览的文档
  - 在 Actions 列添加 View 按钮（绿色眼睛图标）
  - 集成 `DocumentViewDialog` 弹窗组件

## 功能特性

1. **View 操作按钮**: 在每行文档的 Actions 列新增绿色眼睛图标按钮
2. **Markdown 预览弹窗**: 点击后弹出居中模态框显示文档内容
3. **状态展示**: 支持加载中、提取中、完成、失败等多种状态展示
4. **响应式设计**: 弹窗最大宽度 4xl，最大高度 90vh，内容可滚动

## 实现细节

- 复用已有的 `DocumentViewDialog` 组件（基于 react-markdown + remark-gfm）
- View 按钮位于 Download 按钮之前，使用绿色主题色
- 弹窗支持点击背景关闭

## 测试计划

- [ ] 进入 Documents 页面
- [ ] 点击文档行的 View 按钮
- [ ] 验证弹窗正确显示文档 Markdown 内容
- [ ] 验证各种状态（loading/pending/completed/failed）展示正确
- [ ] 验证关闭按钮和点击背景关闭功能

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*