### PR TITLE
feat(UI): 优化导航栏布局，缩小高度并迁移定位描述 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/layout.tsx
+++ b/apps/negentropy-ui/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { AuthProvider } from "@/components/providers/AuthProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { ToastProvider } from "@/components/providers/ToastProvider";
+import { NavigationProvider } from "@/components/providers/NavigationProvider";
 import { SiteHeader } from "@/components/layout/SiteHeader";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import "./globals.css";
@@ -36,10 +37,12 @@ export default function RootLayout({
           <ThemeProvider>
             <ToastProvider />
             <AuthProvider>
-              <div className="flex flex-col h-screen overflow-hidden">
-                <SiteHeader />
-                <main className="flex-1 overflow-hidden relative">{children}</main>
-              </div>
+              <NavigationProvider>
+                <div className="flex flex-col h-screen overflow-hidden">
+                  <SiteHeader />
+                  <main className="flex-1 overflow-hidden relative">{children}</main>
+                </div>
+              </NavigationProvider>
             </AuthProvider>
           </ThemeProvider>
         </ErrorBoundary>

--- a/apps/negentropy-ui/components/layout/SiteHeader.tsx
+++ b/apps/negentropy-ui/components/layout/SiteHeader.tsx
@@ -5,23 +5,39 @@ import { MainNav } from "./MainNav";
 import { UserNav } from "./UserNav";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { mainNavConfig } from "@/config/navigation";
+import { useNavigation } from "@/components/providers/NavigationProvider";
 
 export function SiteHeader({ children }: { children?: React.ReactNode }) {
+  const { navigationInfo } = useNavigation();
+
   return (
-    <div className="border-b border-zinc-200 bg-white px-6 py-4 sticky top-0 z-50 dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        {/* Brand */}
-        <div className="flex items-center gap-9">
+    <div className="border-b border-zinc-200 bg-white px-6 py-2 sticky top-0 z-50 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        {/* Brand + Location */}
+        <div className="flex items-center gap-6">
           <Link href="/" className="flex items-center gap-0">
             <img
               src="/logo.svg"
               alt="Negentropy"
-              className="h-9 w-16 object-contain"
+              className="h-6 w-12 object-contain"
             />
-            <span className="text-[15px] font-bold tracking-[0.1em] text-black dark:text-white">
+            <span className="text-sm font-bold tracking-[0.1em] text-black dark:text-white">
               Negentropy
             </span>
           </Link>
+
+          {/* Location breadcrumb from secondary nav */}
+          {navigationInfo && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-zinc-500 dark:text-zinc-400">
+                {navigationInfo.moduleLabel}
+              </span>
+              <span className="text-zinc-300 dark:text-zinc-600">/</span>
+              <span className="font-semibold text-foreground">
+                {navigationInfo.pageTitle}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* User Area and Actions */}

--- a/apps/negentropy-ui/components/providers/NavigationProvider.tsx
+++ b/apps/negentropy-ui/components/providers/NavigationProvider.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface NavigationInfo {
+  moduleLabel: string;
+  pageTitle: string;
+}
+
+interface NavigationContextValue {
+  navigationInfo: NavigationInfo | null;
+  setNavigationInfo: (info: NavigationInfo | null) => void;
+}
+
+const NavigationContext = createContext<NavigationContextValue | null>(null);
+
+export function useNavigation() {
+  const context = useContext(NavigationContext);
+  if (!context) {
+    throw new Error("useNavigation must be used within a NavigationProvider");
+  }
+  return context;
+}
+
+interface NavigationProviderProps {
+  children: ReactNode;
+}
+
+export function NavigationProvider({ children }: NavigationProviderProps) {
+  const [navigationInfo, setNavigationInfo] = useState<NavigationInfo | null>(
+    null,
+  );
+
+  return (
+    <NavigationContext.Provider value={{ navigationInfo, setNavigationInfo }}>
+      {children}
+    </NavigationContext.Provider>
+  );
+}

--- a/apps/negentropy-ui/components/ui/AdminNav.tsx
+++ b/apps/negentropy-ui/components/ui/AdminNav.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useNavigation } from "@/components/providers/NavigationProvider";
 
 const NAV_ITEMS = [
   { href: "/admin", label: "Users" },
@@ -16,24 +18,21 @@ export function AdminNav({
   description?: string;
 }) {
   const pathname = usePathname();
+  const { setNavigationInfo } = useNavigation();
+
+  useEffect(() => {
+    setNavigationInfo({ moduleLabel: "Admin", pageTitle: title });
+    return () => {
+      setNavigationInfo(null);
+    };
+  }, [title, setNavigationInfo]);
 
   const isActive = (href: string) =>
     href === "/admin" ? pathname === "/admin" : pathname.startsWith(href);
 
   return (
-    <div className="border-b border-border bg-card px-6 py-4">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-muted">Admin</span>
-            <span className="text-border-muted">/</span>
-            <span className="font-semibold text-foreground">{title}</span>
-          </div>
-          {description && (
-            <p className="mt-1 text-xs text-muted">{description}</p>
-          )}
-        </div>
-
+    <div className="border-b border-border bg-card px-6 py-2">
+      <div className="flex flex-wrap items-center justify-end gap-4">
         <nav className="flex flex-wrap items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => (
             <Link

--- a/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
+++ b/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useNavigation } from "@/components/providers/NavigationProvider";
 
 const NAV_ITEMS = [
   { href: "/knowledge", label: "Dashboard" },
@@ -20,6 +22,14 @@ export function KnowledgeNav({
   description?: string;
 }) {
   const pathname = usePathname();
+  const { setNavigationInfo } = useNavigation();
+
+  useEffect(() => {
+    setNavigationInfo({ moduleLabel: "Knowledge", pageTitle: title });
+    return () => {
+      setNavigationInfo(null);
+    };
+  }, [title, setNavigationInfo]);
 
   const isActive = (href: string) =>
     href === "/knowledge"
@@ -27,44 +37,27 @@ export function KnowledgeNav({
       : pathname.startsWith(href);
 
   return (
-    <>
-      <div className="border-b border-border bg-card px-6 py-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-zinc-500 dark:text-zinc-400">
-                Knowledge
-              </span>
-              <span className="text-zinc-300 dark:text-zinc-600">/</span>
-              <span className="font-semibold text-foreground">{title}</span>
-            </div>
-            {description && (
-              <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                {description}
-              </p>
-            )}
-          </div>
-
-          <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
-            {NAV_ITEMS.map((item) => {
-              const active = isActive(item.href);
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`px-4 py-1.5 rounded-full text-xs font-semibold transition-colors ${
-                    active
-                      ? "bg-foreground text-background shadow-sm ring-1 ring-border"
-                      : "text-muted hover:text-foreground"
-                  }`}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
+    <div className="border-b border-border bg-card px-6 py-2">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
+          {NAV_ITEMS.map((item) => {
+            const active = isActive(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`px-4 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+                  active
+                    ? "bg-foreground text-background shadow-sm ring-1 ring-border"
+                    : "text-muted hover:text-foreground"
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/negentropy-ui/components/ui/MemoryNav.tsx
+++ b/apps/negentropy-ui/components/ui/MemoryNav.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useNavigation } from "@/components/providers/NavigationProvider";
 
 const NAV_ITEMS = [
   { href: "/memory", label: "Dashboard" },
@@ -18,42 +20,37 @@ export function MemoryNav({
   description?: string;
 }) {
   const pathname = usePathname();
+  const { setNavigationInfo } = useNavigation();
+
+  useEffect(() => {
+    setNavigationInfo({ moduleLabel: "Memory", pageTitle: title });
+    return () => {
+      setNavigationInfo(null);
+    };
+  }, [title, setNavigationInfo]);
 
   const isActive = (href: string) =>
     href === "/memory" ? pathname === "/memory" : pathname.startsWith(href);
 
   return (
-    <>
-      <div className="border-b border-border bg-card px-6 py-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <div className="flex items-center gap-2 text-sm">
-              <span className="text-muted">Memory</span>
-              <span className="text-border-muted">/</span>
-              <span className="font-semibold text-foreground">{title}</span>
-            </div>
-            {description && (
-              <p className="mt-1 text-xs text-muted">{description}</p>
-            )}
-          </div>
-
-          <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
-            {NAV_ITEMS.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={`px-4 py-1.5 rounded-full text-xs font-semibold transition-colors ${
-                  isActive(item.href)
-                    ? "bg-foreground text-background shadow-sm ring-1 ring-border"
-                    : "text-muted hover:text-foreground"
-                }`}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-        </div>
+    <div className="border-b border-border bg-card px-6 py-2">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`px-4 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+                isActive(item.href)
+                  ? "bg-foreground text-background shadow-sm ring-1 ring-border"
+                  : "text-muted hover:text-foreground"
+              }`}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## 概述

本 PR 对导航栏进行了两项优化：
1. **缩小主导航栏高度**：将主导航栏高度缩小到约原来的 2/3
2. **迁移定位描述**：将二级导航栏中的定位描述（如 "Knowledge / Dashboard"）迁移到主导航栏中

## 变更内容

### 新增文件
- `components/providers/NavigationProvider.tsx` - 创建导航上下文，用于在主导航和二级导航之间共享定位信息

### 修改文件
- `components/layout/SiteHeader.tsx` - 缩小主导航栏高度，添加定位描述显示区域
- `components/ui/KnowledgeNav.tsx` - 移除定位描述，仅保留子导航项
- `components/ui/MemoryNav.tsx` - 移除定位描述，仅保留子导航项
- `components/ui/AdminNav.tsx` - 移除定位描述，仅保留子导航项
- `app/layout.tsx` - 集成 NavigationProvider

## 实现细节

### 导航栏高度优化
- 主导航栏 padding: `py-4` → `py-2`
- Logo 高度: `h-9` → `h-6`
- Logo 文字: `text-[15px]` → `text-sm`

### 定位描述迁移
通过 React Context (`NavigationProvider`) 实现定位信息的跨组件共享：
- 二级导航组件在挂载时设置定位信息（模块名 + 页面标题）
- 主导航栏消费 Context 并显示定位描述
- 组件卸载时自动清除定位信息

### 最终布局效果
```
┌──────────────────────────────────────────────────────────────────┐
│ Logo  Knowledge / Dashboard  [Chat | Knowledge | Memory | Admin] │ ← 主导航栏（高度缩小）
├──────────────────────────────────────────────────────────────────┤
│                                              [Dashboard | ...]   │ ← 二级导航栏（仅子导航项）
└──────────────────────────────────────────────────────────────────┘
```

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*