### PR TITLE
Fix default AGUI app_name fallback to negentropy across UI and docs (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/apis/_components/hooks/useCorporaList.ts
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/hooks/useCorporaList.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { CorpusRecord, fetchCorpora } from "@/features/knowledge";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 interface UseCorporaListResult {
   corpora: CorpusRecord[];

--- a/apps/negentropy-ui/app/knowledge/apis/_components/utils/ApiExecutor.ts
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/utils/ApiExecutor.ts
@@ -15,7 +15,7 @@ import {
   deleteCorpus,
 } from "@/features/knowledge";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type ExecutorResult = Promise<unknown>;
 

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -15,7 +15,7 @@ import { SourceList } from "./_components/SourceList";
 import { AddSourceDialog } from "./_components/AddSourceDialog";
 import { ReplaceSourceDialog } from "./_components/ReplaceSourceDialog";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
 
 /**

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -15,7 +15,7 @@ import {
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { DocumentViewDialog } from "./_components/DocumentViewDialog";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
 
 function formatFileSize(bytes: number): string {

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -9,7 +9,7 @@ import {
   upsertGraph,
 } from "@/features/knowledge";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type GraphNode = { id: string; label?: string; type?: string };
 type GraphEdge = { source: string; target: string; label?: string };

--- a/apps/negentropy-ui/app/knowledge/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { fetchDashboard, KnowledgeDashboard, PipelineRunList } from "@/features/knowledge";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 export default function KnowledgeDashboardPage() {
   const [data, setData] = useState<KnowledgeDashboard | null>(null);

--- a/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
@@ -10,7 +10,7 @@ import {
   upsertPipelines,
 } from "@/features/knowledge";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type RunRecord = PipelineRunRecord;
 

--- a/apps/negentropy-ui/app/memory/audit/page.tsx
+++ b/apps/negentropy-ui/app/memory/audit/page.tsx
@@ -9,7 +9,7 @@ import {
   fetchAuditHistory,
 } from "@/features/memory";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type AuditAction = "retain" | "delete" | "anonymize";
 

--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import { MemoryNav } from "@/components/ui/MemoryNav";
 import { FactListPayload, fetchFacts, searchFacts } from "@/features/memory";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 export default function MemoryFactsPage() {
   const [userId, setUserId] = useState("");

--- a/apps/negentropy-ui/app/memory/page.tsx
+++ b/apps/negentropy-ui/app/memory/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import { MemoryNav } from "@/components/ui/MemoryNav";
 import { fetchMemoryDashboard, MemoryDashboard } from "@/features/memory";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 export default function MemoryDashboardPage() {
   const [dashboard, setDashboard] = useState<MemoryDashboard | null>(null);

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from "react";
 import { MemoryNav } from "@/components/ui/MemoryNav";
 import { useMemoryTimeline } from "@/features/memory";
 
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 export default function MemoryTimelinePage() {
   const {

--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -56,7 +56,7 @@ import type {
 } from "@/types/common";
 
 const AGENT_ID = "negentropy";
-const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents";
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const EMPTY_MESSAGES: Message[] = [];
 
 export function HomeBody({

--- a/docs/negentropy-ui-plan.md
+++ b/docs/negentropy-ui-plan.md
@@ -517,7 +517,7 @@ flowchart LR
 
 ```json
 {
-  "app_name": "agents",
+  "app_name": "negentropy",
   "user_id": "ui",
   "session_id": "optional",
   "state": {}

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -228,7 +228,7 @@ NE_AUTH_ADMIN_EMAILS=admin@example.com
 ```
 AUTH_BASE_URL=https://<backend-host>
 NEXT_PUBLIC_AGUI_BASE_URL=https://<backend-host>
-NEXT_PUBLIC_AGUI_APP_NAME=agents
+NEXT_PUBLIC_AGUI_APP_NAME=negentropy
 ```
 
 ## 9. 安全与运维要点


### PR DESCRIPTION
## Summary
This PR standardizes the default AGUI `app_name` fallback to `negentropy` across the frontend and aligns related documentation examples.

## What changed
- Replaced `process.env.NEXT_PUBLIC_AGUI_APP_NAME || "agents"` with `process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy"` in 12 frontend files under `apps/negentropy-ui`.
- Updated docs examples to match the runtime default:
  - `docs/sso.md`
  - `docs/negentropy-ui-plan.md`

## Why
Task context indicated unexpected runtime behavior from frontend logs where `app_name` could fall back to `agents` instead of the expected `negentropy`. This caused inconsistent app scoping when env vars were absent. The change ensures a single default value across UI entry points and docs.

## Important implementation details
- Scope is intentionally minimal: only fallback default literals were updated.
- No API shape, backend contract, or business logic changes.
- Backend config already defaults to `negentropy`; this PR closes the frontend/documentation mismatch.
- The missing module error (`./_components/DocumentViewDialog`) seen in the log is a separate issue and is not addressed by this PR.

This PR was written using [Vibe Kanban](https://vibekanban.com)
