### PR TITLE
feat(Knowledge): 简化 Dashboard 页面标题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/page.tsx
@@ -58,7 +58,7 @@ export default function KnowledgeDashboardPage() {
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
       <KnowledgeNav
-        title="Knowledge Dashboard"
+        title="Dashboard"
         description="Knowledge 指标、构建与告警概览"
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">


### PR DESCRIPTION
## 变更内容

简化 Knowledge Dashboard 页面的标题显示：
- 将页面标题从 `Knowledge Dashboard` 改为 `Dashboard`
- 面包屑显示从 `Knowledge / Knowledge Dashboard` 优化为 `Knowledge / Dashboard`

## 变更原因

原有标题「Knowledge Dashboard」与模块名「Knowledge」存在冗余，简化后使页面定位更加简洁清晰。

## 实现细节

- 修改文件：`apps/negentropy-ui/app/knowledge/page.tsx`
- 变更：将 `<KnowledgeNav>` 组件的 `title` 属性从 `"Knowledge Dashboard"` 改为 `"Dashboard"`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)