### PR TITLE
feat: render Markdown in Documents View via async ingest extraction pipeline (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/route.ts
@@ -1,4 +1,16 @@
-import { proxyDelete } from "../../../../_proxy";
+import { proxyDelete, proxyGet } from "../../../../_proxy";
+
+/**
+ * GET /api/knowledge/base/{corpusId}/documents/{documentId}
+ * Get single document detail with markdown content
+ */
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ corpusId: string; documentId: string }> },
+) {
+  const { corpusId, documentId } = await context.params;
+  return proxyGet(request, `/knowledge/base/${corpusId}/documents/${documentId}`);
+}
 
 /**
  * DELETE /api/knowledge/base/{corpusId}/documents/{documentId}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -58,6 +58,7 @@ export {
   // Document Management
   fetchDocuments,
   fetchAllDocuments,
+  fetchDocumentDetail,
   deleteDocument,
   downloadDocument,
   // Graph Enhanced API (Phase 1)
@@ -98,6 +99,7 @@ export type {
   KnowledgeListResponse,
   // Document Management
   KnowledgeDocument,
+  KnowledgeDocumentDetail,
   DocumentListResponse,
   // Graph Enhanced Types (Phase 1)
   GraphSearchMode,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -486,6 +486,14 @@ export interface KnowledgeDocument {
   status: string;
   created_at: string | null;
   created_by: string | null;
+  markdown_extract_status?: "pending" | "processing" | "completed" | "failed" | string;
+  markdown_extracted_at?: string | null;
+  markdown_extract_error?: string | null;
+}
+
+export interface KnowledgeDocumentDetail extends KnowledgeDocument {
+  markdown_content: string | null;
+  markdown_gcs_uri: string | null;
 }
 
 export interface DocumentListResponse {
@@ -555,6 +563,23 @@ export async function deleteDocument(
   if (!res.ok) {
     throw new Error(`Failed to delete document: ${res.statusText}`);
   }
+}
+
+export async function fetchDocumentDetail(
+  corpusId: string,
+  documentId: string,
+  params?: {
+    appName?: string;
+  },
+): Promise<KnowledgeDocumentDetail> {
+  const query = new URLSearchParams();
+  if (params?.appName) query.set("app_name", params.appName);
+
+  const res = await fetch(
+    `/api/knowledge/base/${corpusId}/documents/${documentId}?${query.toString()}`,
+    { cache: "no-store" },
+  );
+  return handleKnowledgeError(res);
 }
 
 export async function downloadDocument(

--- a/apps/negentropy/src/negentropy/db/migrations/versions/c3f4e5a6b7c8_add_markdown_fields_to_knowledge_documents.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/c3f4e5a6b7c8_add_markdown_fields_to_knowledge_documents.py
@@ -1,0 +1,70 @@
+"""add markdown fields to knowledge_documents
+
+Revision ID: c3f4e5a6b7c8
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-01
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c3f4e5a6b7c8"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "knowledge_documents",
+        sa.Column("markdown_content", sa.Text(), nullable=True),
+        schema="negentropy",
+    )
+    op.add_column(
+        "knowledge_documents",
+        sa.Column("markdown_gcs_uri", sa.Text(), nullable=True),
+        schema="negentropy",
+    )
+    op.add_column(
+        "knowledge_documents",
+        sa.Column(
+            "markdown_extract_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="'pending'",
+        ),
+        schema="negentropy",
+    )
+    op.add_column(
+        "knowledge_documents",
+        sa.Column("markdown_extract_error", sa.Text(), nullable=True),
+        schema="negentropy",
+    )
+    op.add_column(
+        "knowledge_documents",
+        sa.Column("markdown_extracted_at", sa.DateTime(timezone=True), nullable=True),
+        schema="negentropy",
+    )
+    op.create_index(
+        "ix_knowledge_documents_markdown_extract_status",
+        "knowledge_documents",
+        ["markdown_extract_status"],
+        unique=False,
+        schema="negentropy",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_knowledge_documents_markdown_extract_status",
+        table_name="knowledge_documents",
+        schema="negentropy",
+    )
+    op.drop_column("knowledge_documents", "markdown_extracted_at", schema="negentropy")
+    op.drop_column("knowledge_documents", "markdown_extract_error", schema="negentropy")
+    op.drop_column("knowledge_documents", "markdown_extract_status", schema="negentropy")
+    op.drop_column("knowledge_documents", "markdown_gcs_uri", schema="negentropy")
+    op.drop_column("knowledge_documents", "markdown_content", schema="negentropy")

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy import Float, ForeignKey, Integer, String, Text, UniqueConstraint, Index
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, Index
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
@@ -75,6 +75,18 @@ class KnowledgeDocument(Base, UUIDMixin, TimestampMixin):
     # 上传者信息
     created_by: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 
+    # 预处理后的 Markdown 内容与状态
+    markdown_content: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    markdown_gcs_uri: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    markdown_extract_status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="pending",
+        server_default="'pending'",
+    )
+    markdown_extract_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    markdown_extracted_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
     # 可选元数据
     metadata_: Mapped[Optional[Dict[str, Any]]] = mapped_column("metadata", JSONB, server_default="{}")
 
@@ -83,6 +95,7 @@ class KnowledgeDocument(Base, UUIDMixin, TimestampMixin):
         Index("ix_knowledge_documents_file_hash", "file_hash"),
         Index("ix_knowledge_documents_app_name", "app_name"),
         Index("ix_knowledge_documents_status", "status"),
+        Index("ix_knowledge_documents_markdown_extract_status", "markdown_extract_status"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_content.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_content.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from negentropy.knowledge.content import extract_file_markdown, optimize_markdown_content
+
+
+def test_optimize_markdown_content_normalizes_whitespace() -> None:
+    raw = "line1  \r\n\r\n\r\nline2\t \r\n\r\n\r\n\r\nline3  "
+    optimized = optimize_markdown_content(raw)
+
+    assert optimized == "line1\n\nline2\n\nline3"
+
+
+@pytest.mark.asyncio
+async def test_extract_file_markdown_for_text_file() -> None:
+    content = b"Hello  \r\n\r\n\r\nWorld  "
+
+    markdown = await extract_file_markdown(
+        content=content,
+        filename="sample.txt",
+        content_type="text/plain",
+    )
+
+    assert markdown == "Hello\n\nWorld"


### PR DESCRIPTION
## What Changes Were Made
- Added Markdown persistence fields to `knowledge_documents` with a new migration:
  - `markdown_content`
  - `markdown_gcs_uri`
  - `markdown_extract_status`
  - `markdown_extract_error`
  - `markdown_extracted_at`
- Extended the ingest flow (`ingest_file`) to run asynchronous Markdown extraction in background tasks.
- Implemented Markdown extraction + optimization utilities and persisted results to both PostgreSQL and GCS.
- Added document-level detail API to return Markdown content and extraction status.
- Added Next.js proxy route and frontend API client support (`fetchDocumentDetail`, detail types).
- Updated Documents `View` dialog to fetch and render Markdown content (with status-aware UI for pending/processing/failed/completed).
- Added unit tests for Markdown normalization and extraction behavior.

## Why These Changes Were Made
The task context requires that `Documents -> View` display the actual Markdown content of the document instead of metadata/summary information. It also requires Markdown extraction to happen asynchronously during Knowledge Source ingest and be stored in durable backends (PostgreSQL and GCS). This PR implements that end-to-end flow while keeping existing list/download behavior compatible.

## Important Implementation Details
- Extraction lifecycle is explicit and observable: `pending -> processing -> completed/failed`.
- For duplicate uploads, extraction is only scheduled when Markdown is not already completed.
- Markdown retrieval uses PostgreSQL first, then falls back to GCS (and backfills PostgreSQL on successful fallback load).
- The UI now requests per-document detail when opening `View`, so the modal shows real content plus extraction status/error.
- Existing document listing APIs remain backward compatible, with additional optional extraction status metadata.

This PR was written using [Vibe Kanban](https://vibekanban.com)
