### PR TITLE
fix(Knowledge): 优化 Ingest 操作为异步 Fire-and-Forget 模式 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
@@ -22,30 +22,29 @@ export function ReplaceSourceDialog({
   onSuccess,
 }: ReplaceSourceDialogProps) {
   const [text, setText] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleReplace = async () => {
-    if (!corpusId || !sourceUri || !text.trim() || isSubmitting) return;
+  const handleReplace = () => {
+    if (!corpusId || !sourceUri || !text.trim()) return;
 
-    setIsSubmitting(true);
-    setError(null);
-    try {
-      await onReplace({ text, source_uri: sourceUri });
-      toast.success("已开始替换知识源", {
-        description: "可在 Pipeline 页面查看构建进度",
-      });
-      setText("");
-      onSuccess?.();
-    } catch (err) {
+    // 保存当前值用于 API 调用
+    const currentText = text;
+    const currentSourceUri = sourceUri;
+
+    // 立即关闭模态框并重置表单
+    setText("");
+    onSuccess?.();
+
+    // 显示 Toast 提示
+    toast.success("已开始替换知识源", {
+      description: "可在 Pipeline 页面查看构建进度",
+    });
+
+    // Fire-and-forget: 不等待 API 完成
+    onReplace({ text: currentText, source_uri: currentSourceUri }).catch((err) => {
       const errorMessage = err instanceof Error ? err.message : String(err);
-      setError(errorMessage);
-      toast.error("替换失败", {
-        description: errorMessage,
-      });
-    } finally {
-      setIsSubmitting(false);
-    }
+      toast.error("替换失败", { description: errorMessage });
+    });
   };
 
   const handleClose = () => {
@@ -135,16 +134,15 @@ export function ReplaceSourceDialog({
           <button
             onClick={handleClose}
             className="rounded-lg px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
-            disabled={isSubmitting}
           >
             Cancel
           </button>
           <button
             onClick={handleReplace}
             className="rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-amber-700 disabled:opacity-50"
-            disabled={isSubmitting || !corpusId || !sourceUri || !text.trim()}
+            disabled={!corpusId || !sourceUri || !text.trim()}
           >
-            {isSubmitting ? "Processing..." : "Replace"}
+            Replace
           </button>
         </div>
       </div>


### PR DESCRIPTION
## 问题背景

Knowledge Base 页面的 Ingest 功能存在问题：点击 Ingest 后，模态框会一直停留在 "Processing..." 状态，直到后台整个 Ingest 操作完成后才关闭模态框。

**预期行为**：
1. 用户点击 Ingest 按钮后，立即关闭模态框
2. 同时显示 Toast 提示，告知用户后台正在执行 Ingest 操作
3. 用户可在 Pipeline 页面查看进度

## 解决方案

采用 **Fire-and-Forget** 模式 —— 发起请求后立即关闭模态框并显示 Toast，不等待 API 完成。

## 变更内容

### 修改文件
- `apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx`
- `apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx`

### 关键变更
1. 将 `handleIngest` 和 `handleReplace` 函数从 `async/await` 模式改为 Fire-and-Forget 模式
2. 点击 Ingest/Replace 按钮后立即关闭模态框，不再等待 API 完成
3. 通过 Toast 提示用户后台正在处理，可在 Pipeline 页面查看进度
4. 移除 `isSubmitting` 状态，简化组件逻辑
5. API 调用失败时通过 Toast 显示错误信息

### 技术细节
- 保存当前表单值到局部变量，避免闭包问题
- 使用 `.catch()` 处理 API 错误，失败时单独显示错误 Toast

## 测试验证

1. 打开 Knowledge Base 页面
2. 点击 Add Source 按钮，输入一个 URL
3. 点击 Ingest 按钮
4. **预期**：模态框立即关闭，Toast 提示 "已开始从 URL 摄入知识源"
5. 导航到 Pipeline 页面，确认可以看到正在运行的 Pipeline

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*