### PR TITLE
fix: re-parse document markdown from GCS in View and fail empty extraction (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/refresh_markdown/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/refresh_markdown/route.ts
@@ -1,0 +1,16 @@
+import { proxyPost } from "../../../../../_proxy";
+
+/**
+ * POST /api/knowledge/base/{corpusId}/documents/{documentId}/refresh_markdown
+ * Re-parse markdown content from source document in GCS
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ corpusId: string; documentId: string }> },
+) {
+  const { corpusId, documentId } = await context.params;
+  return proxyPost(
+    request,
+    `/knowledge/base/${corpusId}/documents/${documentId}/refresh_markdown`,
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -59,6 +59,7 @@ export {
   fetchDocuments,
   fetchAllDocuments,
   fetchDocumentDetail,
+  refreshDocumentMarkdown,
   deleteDocument,
   downloadDocument,
   // Graph Enhanced API (Phase 1)
@@ -100,6 +101,7 @@ export type {
   // Document Management
   KnowledgeDocument,
   KnowledgeDocumentDetail,
+  DocumentMarkdownRefreshResponse,
   DocumentListResponse,
   // Graph Enhanced Types (Phase 1)
   GraphSearchMode,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -496,6 +496,12 @@ export interface KnowledgeDocumentDetail extends KnowledgeDocument {
   markdown_gcs_uri: string | null;
 }
 
+export interface DocumentMarkdownRefreshResponse {
+  document_id: string;
+  status: string;
+  message: string;
+}
+
 export interface DocumentListResponse {
   count: number;
   items: KnowledgeDocument[];
@@ -578,6 +584,26 @@ export async function fetchDocumentDetail(
   const res = await fetch(
     `/api/knowledge/base/${corpusId}/documents/${documentId}?${query.toString()}`,
     { cache: "no-store" },
+  );
+  return handleKnowledgeError(res);
+}
+
+export async function refreshDocumentMarkdown(
+  corpusId: string,
+  documentId: string,
+  params?: {
+    appName?: string;
+  },
+): Promise<DocumentMarkdownRefreshResponse> {
+  const res = await fetch(
+    `/api/knowledge/base/${corpusId}/documents/${documentId}/refresh_markdown`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        app_name: params?.appName,
+      }),
+    },
   );
   return handleKnowledgeError(res);
 }

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -403,7 +403,7 @@ class DocumentStorageService:
         if not doc:
             return None
 
-        if doc.markdown_content:
+        if doc.markdown_content and doc.markdown_content.strip():
             return doc.markdown_content
 
         if not doc.markdown_gcs_uri:
@@ -412,6 +412,13 @@ class DocumentStorageService:
         try:
             gcs_client = self._get_gcs_client()
             content = gcs_client.download(doc.markdown_gcs_uri).decode("utf-8")
+            if not content.strip():
+                logger.warning(
+                    "markdown_content_empty",
+                    document_id=str(document_id),
+                    markdown_gcs_uri=doc.markdown_gcs_uri,
+                )
+                return None
             # 最佳努力回填 PostgreSQL，避免后续重复读 GCS。
             await self.save_markdown_content(
                 document_id=document_id,


### PR DESCRIPTION
## What Changes Were Made
- Added a new backend endpoint to re-parse Markdown directly from the source document in GCS:
  - `POST /knowledge/base/{corpus_id}/documents/{document_id}/refresh_markdown`
- Added a backend re-parse flow that:
  - Loads the source file from GCS
  - Re-runs Markdown extraction
  - Updates extraction state (`processing`, `failed`, etc.)
- Improved extraction correctness by treating empty extracted Markdown as a failure (instead of marking it as completed).
- Hardened Markdown loading in storage service to ignore blank Markdown payloads.
- Added a new UI action in Documents View modal:
  - `Re-Parse from GCS` button
  - Triggers backend re-parse and refreshes state
- Added frontend API wiring and Next.js proxy route for the new refresh endpoint.

## Why These Changes Were Made
In task context, users opening `Documents -> View` for PDF files could see `No markdown content available.` even when a source file existed in GCS. This created a dead-end experience: no in-place recovery path and unclear extraction quality state. The goal was to make the View flow resilient and self-recoverable by allowing users to re-extract Markdown from source documents on demand.

## Important Implementation Details
- Empty Markdown now fails fast during extraction (`strip()` check), preventing false "completed" states.
- Re-parse is asynchronous: the endpoint immediately sets status to `processing` and runs extraction in background tasks.
- The modal polls document detail while status is `processing`, so users can see progress and updated results without reopening the dialog.
- Frontend sends `app_name` in request body for compatibility with the existing proxy behavior.
- Existing download/list behavior remains unchanged; this PR focuses on recovery and correctness for View content.

This PR was written using [Vibe Kanban](https://vibekanban.com)
