### PR TITLE
CI: run backend and UI test workflows on all branches with safer defaults (Vibe Kanban)

### DIFF
--- a/.github/workflows/negentropy-backend-tests.yml
+++ b/.github/workflows/negentropy-backend-tests.yml
@@ -2,19 +2,33 @@ name: negentropy-backend-tests
 
 on:
   push:
+    branches:
+      - "**"
     paths:
       - "apps/negentropy/**"
       - "apps/negentropy-ui/lib/adk.ts"
       - ".github/workflows/negentropy-backend-tests.yml"
   pull_request:
+    branches:
+      - "**"
     paths:
       - "apps/negentropy/**"
       - "apps/negentropy-ui/lib/adk.ts"
       - ".github/workflows/negentropy-backend-tests.yml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
 
     services:
       postgres:
@@ -52,12 +66,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: apps/negentropy
-        run: uv sync
+        run: uv sync --frozen
 
       - name: Run unit tests
         run: uv run pytest tests/unit_tests/ -v
-        env:
-          NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
 
       - name: Initialize database schema
         run: |
@@ -76,15 +88,9 @@ jobs:
           asyncio.run(init_db())
           "
           uv run alembic upgrade head
-        env:
-          NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
 
       - name: Run integration tests
         run: uv run pytest tests/integration_tests/ -v
-        env:
-          NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
 
       - name: Run performance tests
         run: uv run pytest tests/performance_tests/ -v
-        env:
-          NE_DB_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db

--- a/.github/workflows/negentropy-ui-tests.yml
+++ b/.github/workflows/negentropy-ui-tests.yml
@@ -2,17 +2,29 @@ name: negentropy-ui-tests
 
 on:
   push:
+    branches:
+      - "**"
     paths:
       - "apps/negentropy-ui/**"
       - ".github/workflows/negentropy-ui-tests.yml"
   pull_request:
+    branches:
+      - "**"
     paths:
       - "apps/negentropy-ui/**"
       - ".github/workflows/negentropy-ui-tests.yml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: apps/negentropy-ui
@@ -35,7 +47,7 @@ jobs:
         run: pnpm config set registry https://registry.npmmirror.com
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: pnpm test


### PR DESCRIPTION
## What changed
- Updated both workflows: `.github/workflows/negentropy-backend-tests.yml` and `.github/workflows/negentropy-ui-tests.yml`.
- Added explicit `branches: ["**"]` under both `push` and `pull_request`, while preserving existing `paths` filters.
- Added minimal workflow permissions: `permissions: contents: read`.
- Added concurrency control to cancel superseded runs on the same ref:
  - `group: ${{ github.workflow }}-${{ github.ref }}`
  - `cancel-in-progress: true`
- Added job timeouts:
  - Backend tests: `timeout-minutes: 30`
  - UI tests: `timeout-minutes: 20`
- Hardened dependency install behavior for reproducibility:
  - Backend: `uv sync --frozen`
  - UI: `pnpm install --frozen-lockfile`
- Backend cleanup: moved `NE_DB_URL` to job-level `env` to remove repeated step-level env blocks.

## Why these changes
- The task context was to broaden workflow execution scope from `master` to all branches and optimize the workflow where appropriate.
- Explicit branch targeting prevents accidental branch coverage gaps and makes trigger intent clear.
- Concurrency cancellation reduces redundant CI runs and shortens feedback cycles.
- Minimal permissions and frozen lockfile installs improve CI security posture and deterministic builds.
- Timeouts protect CI capacity from stalled runs.

## Important implementation details
- Existing `paths` filters were intentionally retained to keep CI scoped to relevant file changes.
- Backend database service setup and test sequencing remain functionally unchanged; improvements are focused on workflow reliability and governance.
- This PR only changes GitHub Actions workflow configuration and does not modify application logic.

This PR was written using [Vibe Kanban](https://vibekanban.com)
