### PR TITLE
Fix Documents markdown re-parse reliability and error transparency (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -42,6 +42,25 @@ function errorResponse(code: string, message: string, status = 500) {
   );
 }
 
+function upstreamErrorResponse(text: string, status: number) {
+  if (text) {
+    try {
+      const errorJson = JSON.parse(text);
+      if (errorJson && typeof errorJson === "object") {
+        return NextResponse.json(errorJson, { status });
+      }
+    } catch {
+      // fallthrough to generic wrapper
+    }
+  }
+
+  return errorResponse(
+    "KNOWLEDGE_UPSTREAM_ERROR",
+    text || "Upstream returned non-OK status",
+    status,
+  );
+}
+
 export async function proxyGet(request: Request, path: string) {
   const baseUrl = getBaseUrl();
   if (!baseUrl) {
@@ -73,11 +92,7 @@ export async function proxyGet(request: Request, path: string) {
 
   const text = await upstreamResponse.text();
   if (!upstreamResponse.ok) {
-    return errorResponse(
-      "KNOWLEDGE_UPSTREAM_ERROR",
-      text || "Upstream returned non-OK status",
-      upstreamResponse.status,
-    );
+    return upstreamErrorResponse(text, upstreamResponse.status);
   }
 
   return NextResponse.json(JSON.parse(text));
@@ -126,11 +141,7 @@ export async function proxyPost(request: Request, path: string) {
 
   const text = await upstreamResponse.text();
   if (!upstreamResponse.ok) {
-    return errorResponse(
-      "KNOWLEDGE_UPSTREAM_ERROR",
-      text || "Upstream returned non-OK status",
-      upstreamResponse.status,
-    );
+    return upstreamErrorResponse(text, upstreamResponse.status);
   }
 
   return NextResponse.json(JSON.parse(text));

--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/refresh-markdown/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/refresh-markdown/route.ts
@@ -1,0 +1,16 @@
+import { proxyPost } from "../../../../../_proxy";
+
+/**
+ * POST /api/knowledge/base/{corpusId}/documents/{documentId}/refresh-markdown
+ * Backward-compatible alias for markdown refresh endpoint.
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ corpusId: string; documentId: string }> },
+) {
+  const { corpusId, documentId } = await context.params;
+  return proxyPost(
+    request,
+    `/knowledge/base/${corpusId}/documents/${documentId}/refresh_markdown`,
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/documents/_components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/_components/DocumentViewDialog.tsx
@@ -95,6 +95,7 @@ export function DocumentViewDialog({
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [detail, setDetail] = useState<KnowledgeDocumentDetail | null>(null);
+  const requestAppName = document?.app_name || APP_NAME;
 
   const loadDetail = useCallback(async () => {
     if (!isOpen || !document) return;
@@ -103,7 +104,7 @@ export function DocumentViewDialog({
     setDetailError(null);
     try {
       const res = await fetchDocumentDetail(document.corpus_id, document.id, {
-        appName: APP_NAME,
+        appName: requestAppName,
       });
       setDetail(res);
     } catch (err) {
@@ -113,7 +114,7 @@ export function DocumentViewDialog({
     } finally {
       setLoadingDetail(false);
     }
-  }, [isOpen, document]);
+  }, [isOpen, document, requestAppName]);
 
   useEffect(() => {
     if (!isOpen || !document) {
@@ -124,7 +125,7 @@ export function DocumentViewDialog({
     }
 
     void loadDetail();
-  }, [isOpen, document?.id, document?.corpus_id, loadDetail]);
+  }, [isOpen, document, loadDetail]);
 
   useEffect(() => {
     if (!isOpen || !document) return;
@@ -143,7 +144,9 @@ export function DocumentViewDialog({
 
     setIsDownloading(true);
     try {
-      await downloadDocument(document.corpus_id, document.id, { appName: APP_NAME });
+      await downloadDocument(document.corpus_id, document.id, {
+        appName: requestAppName,
+      });
       toast.success(`Downloaded: ${document.original_filename}`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to download document");
@@ -158,7 +161,7 @@ export function DocumentViewDialog({
     setIsRefreshingMarkdown(true);
     try {
       const result = await refreshDocumentMarkdown(document.corpus_id, document.id, {
-        appName: APP_NAME,
+        appName: requestAppName,
       });
       toast.success(result.message || "Markdown re-parse started");
       setDetail((prev) =>

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -246,6 +246,64 @@ export interface PipelineUpsertResult {
 /**
  * 从响应中解析错误并映射到对应的异常类型
  */
+function extractKnowledgeErrorPayload(
+  errorData: unknown,
+): KnowledgeErrorResponse | null {
+  if (!errorData || typeof errorData !== "object") {
+    return null;
+  }
+
+  const normalizePayload = (
+    payload: Record<string, unknown>,
+  ): KnowledgeErrorResponse | null => {
+    const code = typeof payload.code === "string" ? payload.code : undefined;
+    const message =
+      typeof payload.message === "string"
+        ? payload.message
+        : typeof payload.detail === "string"
+          ? payload.detail
+          : undefined;
+    const details =
+      payload.details && typeof payload.details === "object"
+        ? (payload.details as Record<string, unknown>)
+        : undefined;
+
+    if (!code && !message) {
+      return null;
+    }
+
+    return {
+      code: code || "UNKNOWN_ERROR",
+      message: message || "Unknown error",
+      details,
+    };
+  };
+
+  const root = errorData as Record<string, unknown>;
+
+  const direct = normalizePayload(root);
+  if (direct) return direct;
+
+  if (root.error && typeof root.error === "object") {
+    const nested = normalizePayload(root.error as Record<string, unknown>);
+    if (nested) return nested;
+  }
+
+  if (root.detail && typeof root.detail === "object") {
+    const nested = normalizePayload(root.detail as Record<string, unknown>);
+    if (nested) return nested;
+  }
+
+  if (typeof root.detail === "string") {
+    return {
+      code: "UNKNOWN_ERROR",
+      message: root.detail,
+    };
+  }
+
+  return null;
+}
+
 async function parseKnowledgeError(res: Response): Promise<KnowledgeError> {
   let errorData: unknown;
   try {
@@ -254,9 +312,12 @@ async function parseKnowledgeError(res: Response): Promise<KnowledgeError> {
     errorData = null;
   }
 
-  const errorResponse = errorData as KnowledgeErrorResponse | null;
+  const errorResponse = extractKnowledgeErrorPayload(errorData);
   const code = errorResponse?.code || "UNKNOWN_ERROR";
-  const message = errorResponse?.message || res.statusText;
+  const message =
+    errorResponse?.message ||
+    res.statusText ||
+    `Request failed with status ${res.status}`;
   const details = errorResponse?.details;
 
   switch (code) {
@@ -595,16 +656,27 @@ export async function refreshDocumentMarkdown(
     appName?: string;
   },
 ): Promise<DocumentMarkdownRefreshResponse> {
-  const res = await fetch(
+  const payload = JSON.stringify({
+    app_name: params?.appName,
+  });
+  const requestInit: RequestInit = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+  };
+
+  let res = await fetch(
     `/api/knowledge/base/${corpusId}/documents/${documentId}/refresh_markdown`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        app_name: params?.appName,
-      }),
-    },
+    requestInit,
   );
+  if (res.status === 404) {
+    // Backward-compatible fallback for deployments using kebab-case route naming.
+    res = await fetch(
+      `/api/knowledge/base/${corpusId}/documents/${documentId}/refresh-markdown`,
+      requestInit,
+    );
+  }
+
   return handleKnowledgeError(res);
 }
 

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1252,6 +1252,11 @@ async def get_document_detail(
 
 
 @router.post(
+    "/base/{corpus_id}/documents/{document_id}/refresh-markdown",
+    response_model=DocumentMarkdownRefreshResponse,
+    include_in_schema=False,
+)
+@router.post(
     "/base/{corpus_id}/documents/{document_id}/refresh_markdown",
     response_model=DocumentMarkdownRefreshResponse,
 )


### PR DESCRIPTION
## Summary
This PR fixes the Documents View markdown re-parse failure path where users saw empty markdown content and got a generic `Not Found` after clicking **Re-Parse from GCS**.

## What changed
- Updated `DocumentViewDialog` to use the current document's `app_name` (`document.app_name`) for detail fetch, download, and re-parse requests, instead of always using a global app name.
- Improved knowledge API error parsing in the UI client to handle multiple upstream payload shapes:
  - `{ code, message, details }`
  - `{ error: { ... } }`
  - `{ detail: { ... } }` and `{ detail: "..." }`
- Added better upstream error passthrough in knowledge proxy (`proxyGet`/`proxyPost`) so backend error payloads are preserved instead of being collapsed into a generic wrapper.
- Added route compatibility for markdown refresh:
  - New UI API alias route: `/refresh-markdown`
  - Existing route remains: `/refresh_markdown`
  - Client now falls back to `/refresh-markdown` when `/refresh_markdown` returns 404
  - Backend also accepts `/refresh-markdown` as an alias (hidden from schema) to keep compatibility across environments.

## Why
Based on task context, the expected behavior is:
- **View** should show full markdown content for the selected document.
- When markdown is missing, **Re-Parse from GCS** should reliably trigger regeneration.

The observed failure came from a combination of issues:
- Request context mismatch (`app_name`) could make the document lookup fail even though the file existed.
- Error envelope mismatch between proxy and client made real backend errors appear as a generic `Not Found`.
- Route naming differences (`refresh_markdown` vs `refresh-markdown`) could break re-parse in some deployments.

## Important implementation details
- The fix is backward-compatible and minimizes blast radius:
  - No schema-breaking API removal.
  - Existing underscore route remains valid.
  - Alias + fallback strategy avoids tight coupling to one route style.
- Error handling now preserves diagnostic fidelity from backend to UI, improving debuggability and reducing false-negative UX.

This PR was written using [Vibe Kanban](https://vibekanban.com)
