### PR TITLE
feat(Plugins): 新增插件管理模块支持 MCP/Skills/SubAgents (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/layout.tsx
+++ b/apps/negentropy-ui/app/plugins/layout.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/components/providers/AuthProvider";
+
+export default function PluginsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user, status } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "loading") return;
+    if (!user) {
+      router.replace("/");
+    }
+  }, [user, status, router]);
+
+  if (status === "loading") {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-sm text-zinc-500 dark:text-zinc-400">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+interface McpServer {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  transport_type: string;
+  command: string | null;
+  args: string[];
+  env: Record<string, string>;
+  url: string | null;
+  is_enabled: boolean;
+  auto_start: boolean;
+  config: Record<string, unknown>;
+  tool_count: number;
+}
+
+interface McpServerCardProps {
+  server: McpServer;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function McpServerCard({ server, onEdit, onDelete }: McpServerCardProps) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              {server.display_name || server.name}
+            </h3>
+            {server.is_enabled ? (
+              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                Enabled
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                Disabled
+              </span>
+            )}
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+              {server.visibility}
+            </span>
+          </div>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
+            {server.description || "No description"}
+          </p>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
+            <span className="inline-flex items-center gap-1">
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+              </svg>
+              {server.transport_type}
+            </span>
+            {server.tool_count > 0 && (
+              <span className="inline-flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                {server.tool_count} tools
+              </span>
+            )}
+            {server.auto_start && (
+              <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                Auto-start
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onEdit}
+            className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
+          <button
+            onClick={onDelete}
+            className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface McpServer {
+  id: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  transport_type: string;
+  command: string | null;
+  args: string[];
+  env: Record<string, string>;
+  url: string | null;
+  is_enabled: boolean;
+  auto_start: boolean;
+  config: Record<string, unknown>;
+  visibility: string;
+}
+
+interface McpServerFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: Record<string, unknown>) => Promise<void>;
+  server: McpServer | null;
+}
+
+export function McpServerFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  server,
+}: McpServerFormDialogProps) {
+  const [formData, setFormData] = useState({
+    name: "",
+    display_name: "",
+    description: "",
+    transport_type: "stdio",
+    command: "",
+    args: "",
+    env: "",
+    url: "",
+    is_enabled: true,
+    auto_start: false,
+    visibility: "private",
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (server) {
+      setFormData({
+        name: server.name,
+        display_name: server.display_name || "",
+        description: server.description || "",
+        transport_type: server.transport_type,
+        command: server.command || "",
+        args: Array.isArray(server.args) ? server.args.join("\n") : "",
+        env: typeof server.env === "object" ? JSON.stringify(server.env, null, 2) : "{}",
+        url: server.url || "",
+        is_enabled: server.is_enabled,
+        auto_start: server.auto_start,
+        visibility: server.visibility,
+      });
+    } else {
+      setFormData({
+        name: "",
+        display_name: "",
+        description: "",
+        transport_type: "stdio",
+        command: "",
+        args: "",
+        env: "{}",
+        url: "",
+        is_enabled: true,
+        auto_start: false,
+        visibility: "private",
+      });
+    }
+    setError(null);
+  }, [server, open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data: Record<string, unknown> = {
+        name: formData.name,
+        display_name: formData.display_name || null,
+        description: formData.description || null,
+        transport_type: formData.transport_type,
+        is_enabled: formData.is_enabled,
+        auto_start: formData.auto_start,
+        visibility: formData.visibility,
+      };
+
+      if (formData.transport_type === "stdio") {
+        data.command = formData.command || null;
+        data.args = formData.args
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        try {
+          data.env = JSON.parse(formData.env || "{}");
+        } catch {
+          throw new Error("Invalid JSON in environment variables");
+        }
+      } else {
+        data.url = formData.url || null;
+      }
+
+      await onSubmit(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-lg rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+          {server ? "Edit MCP Server" : "Add MCP Server"}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Name *
+              </label>
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="my-mcp-server"
+                required
+                disabled={!!server}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Display Name
+              </label>
+              <input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="My MCP Server"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              Description
+            </label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={2}
+              placeholder="Description of this MCP server"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Transport Type *
+              </label>
+              <select
+                value={formData.transport_type}
+                onChange={(e) => setFormData({ ...formData, transport_type: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              >
+                <option value="stdio">STDIO</option>
+                <option value="sse">SSE</option>
+                <option value="websocket">WebSocket</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Visibility
+              </label>
+              <select
+                value={formData.visibility}
+                onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              >
+                <option value="private">Private</option>
+                <option value="shared">Shared</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+          </div>
+
+          {formData.transport_type === "stdio" ? (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                  Command *
+                </label>
+                <input
+                  type="text"
+                  value={formData.command}
+                  onChange={(e) => setFormData({ ...formData, command: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 font-mono"
+                  placeholder="npx"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                  Arguments (one per line)
+                </label>
+                <textarea
+                  value={formData.args}
+                  onChange={(e) => setFormData({ ...formData, args: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 font-mono"
+                  rows={3}
+                  placeholder="-y&#10;@modelcontextprotocol/server-filesystem&#10;/path/to/allowed/dir"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                  Environment Variables (JSON)
+                </label>
+                <textarea
+                  value={formData.env}
+                  onChange={(e) => setFormData({ ...formData, env: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 font-mono"
+                  rows={3}
+                  placeholder='{"API_KEY": "xxx"}'
+                />
+              </div>
+            </>
+          ) : (
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                URL *
+              </label>
+              <input
+                type="url"
+                value={formData.url}
+                onChange={(e) => setFormData({ ...formData, url: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="http://localhost:8080/mcp"
+              />
+            </div>
+          )}
+
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={formData.is_enabled}
+                onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
+                className="rounded border-zinc-300 dark:border-zinc-600"
+              />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300">Enabled</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={formData.auto_start}
+                onChange={(e) => setFormData({ ...formData, auto_start: e.target.checked })}
+                className="rounded border-zinc-300 dark:border-zinc-600"
+              />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300">Auto-start</span>
+            </label>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              {loading ? "Saving..." : server ? "Update" : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/mcp/page.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { PluginsNav } from "@/components/ui/PluginsNav";
+import { McpServerCard } from "./_components/McpServerCard";
+import { McpServerFormDialog } from "./_components/McpServerFormDialog";
+
+interface McpServer {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  transport_type: string;
+  command: string | null;
+  args: string[];
+  env: Record<string, string>;
+  url: string | null;
+  is_enabled: boolean;
+  auto_start: boolean;
+  config: Record<string, unknown>;
+  tool_count: number;
+}
+
+export default function McpServersPage() {
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingServer, setEditingServer] = useState<McpServer | null>(null);
+
+  const fetchServers = async () => {
+    try {
+      const response = await fetch("/api/plugins/mcp/servers");
+      if (!response.ok) {
+        throw new Error("Failed to fetch servers");
+      }
+      const data = await response.json();
+      setServers(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchServers();
+  }, []);
+
+  const handleCreate = () => {
+    setEditingServer(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (server: McpServer) => {
+    setEditingServer(server);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (serverId: string) => {
+    if (!confirm("Are you sure you want to delete this server?")) {
+      return;
+    }
+    try {
+      const response = await fetch(`/api/plugins/mcp/servers/${serverId}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error("Failed to delete server");
+      }
+      fetchServers();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "An error occurred");
+    }
+  };
+
+  const handleDialogClose = () => {
+    setDialogOpen(false);
+    setEditingServer(null);
+  };
+
+  const handleFormSubmit = async (data: Record<string, unknown>) => {
+    try {
+      const url = editingServer
+        ? `/api/plugins/mcp/servers/${editingServer.id}`
+        : "/api/plugins/mcp/servers";
+      const method = editingServer ? "PATCH" : "POST";
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || "Failed to save server");
+      }
+
+      handleDialogClose();
+      fetchServers();
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <PluginsNav title="MCP Servers" />
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 py-6">
+          <div className="mx-auto max-w-4xl">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  MCP Servers
+                </h1>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  Manage Model Context Protocol servers for external tool integration.
+                </p>
+              </div>
+              <button
+                onClick={handleCreate}
+                className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Add Server
+              </button>
+            </div>
+
+            {loading ? (
+              <div className="text-sm text-zinc-500">Loading...</div>
+            ) : error ? (
+              <div className="text-sm text-red-500">{error}</div>
+            ) : servers.length === 0 ? (
+              <div className="text-center py-12">
+                <div className="text-zinc-400 dark:text-zinc-500 mb-4">
+                  No MCP servers registered yet.
+                </div>
+                <button
+                  onClick={handleCreate}
+                  className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
+                >
+                  Add your first server →
+                </button>
+              </div>
+            ) : (
+              <div className="grid gap-4">
+                {servers.map((server) => (
+                  <McpServerCard
+                    key={server.id}
+                    server={server}
+                    onEdit={() => handleEdit(server)}
+                    onDelete={() => handleDelete(server.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <McpServerFormDialog
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        onSubmit={handleFormSubmit}
+        server={editingServer}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/page.tsx
+++ b/apps/negentropy-ui/app/plugins/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { PluginsNav } from "@/components/ui/PluginsNav";
+
+interface Stats {
+  mcp_servers: { total: number; enabled: number };
+  skills: { total: number; enabled: number };
+  subagents: { total: number; enabled: number };
+}
+
+export default function PluginsPage() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchStats() {
+      try {
+        const response = await fetch("/api/plugins/stats");
+        if (!response.ok) {
+          throw new Error("Failed to fetch stats");
+        }
+        const data = await response.json();
+        setStats(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchStats();
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <PluginsNav title="Dashboard" />
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 py-6">
+          <div className="mx-auto max-w-4xl">
+            <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100 mb-2">
+              Plugin Management
+            </h1>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-6">
+              Manage MCP servers, Skills, and SubAgents for your AI agents.
+            </p>
+
+            {loading ? (
+              <div className="text-sm text-zinc-500">Loading...</div>
+            ) : error ? (
+              <div className="text-sm text-red-500">{error}</div>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-3">
+                <StatCard
+                  title="MCP Servers"
+                  total={stats?.mcp_servers.total || 0}
+                  enabled={stats?.mcp_servers.enabled || 0}
+                  href="/plugins/mcp"
+                  description="Model Context Protocol servers"
+                />
+                <StatCard
+                  title="Skills"
+                  total={stats?.skills.total || 0}
+                  enabled={stats?.skills.enabled || 0}
+                  href="/plugins/skills"
+                  description="Reusable skill modules"
+                />
+                <StatCard
+                  title="SubAgents"
+                  total={stats?.subagents.total || 0}
+                  enabled={stats?.subagents.enabled || 0}
+                  href="/plugins/subagents"
+                  description="Sub-agent configurations"
+                />
+              </div>
+            )}
+
+            <div className="mt-8">
+              <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+                Quick Links
+              </h2>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <QuickLink
+                  href="/plugins/mcp"
+                  title="Register MCP Server"
+                  description="Connect external tools via MCP protocol"
+                />
+                <QuickLink
+                  href="/plugins/skills"
+                  title="Create Skill"
+                  description="Define reusable prompt templates"
+                />
+                <QuickLink
+                  href="/plugins/subagents"
+                  title="Configure SubAgent"
+                  description="Set up specialized sub-agents"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  title,
+  total,
+  enabled,
+  href,
+  description,
+}: {
+  title: string;
+  total: number;
+  enabled: number;
+  href: string;
+  description: string;
+}) {
+  return (
+    <a
+      href={href}
+      className="rounded-xl border border-zinc-200 bg-white p-4 hover:border-zinc-300 transition-colors dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600"
+    >
+      <div className="text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
+        {title}
+      </div>
+      <div className="text-xs text-zinc-400 dark:text-zinc-500 mb-3">
+        {description}
+      </div>
+      <div className="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
+        {total}
+      </div>
+      <div className="text-xs text-emerald-600 dark:text-emerald-400 mt-1">
+        {enabled} enabled
+      </div>
+    </a>
+  );
+}
+
+function QuickLink({
+  href,
+  title,
+  description,
+}: {
+  href: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <a
+      href={href}
+      className="flex items-center gap-3 rounded-lg border border-zinc-200 bg-white p-3 hover:border-zinc-300 transition-colors dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600"
+    >
+      <div className="flex-1">
+        <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+          {title}
+        </div>
+        <div className="text-xs text-zinc-500 dark:text-zinc-400">
+          {description}
+        </div>
+      </div>
+      <svg
+        className="w-4 h-4 text-zinc-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M9 5l7 7-7 7"
+        />
+      </svg>
+    </a>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/skills/_components/SkillCard.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/_components/SkillCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+interface Skill {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  category: string;
+  version: string;
+  prompt_template: string | null;
+  config_schema: Record<string, unknown>;
+  default_config: Record<string, unknown>;
+  required_tools: string[];
+  is_enabled: boolean;
+  priority: number;
+}
+
+interface SkillCardProps {
+  skill: Skill;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function SkillCard({ skill, onEdit, onDelete }: SkillCardProps) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              {skill.display_name || skill.name}
+            </h3>
+            {skill.is_enabled ? (
+              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                Enabled
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                Disabled
+              </span>
+            )}
+            <span className="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
+              {skill.category}
+            </span>
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+              {skill.visibility}
+            </span>
+          </div>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
+            {skill.description || "No description"}
+          </p>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
+            <span className="inline-flex items-center gap-1">
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+              </svg>
+              v{skill.version}
+            </span>
+            {skill.priority > 0 && (
+              <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                </svg>
+                Priority: {skill.priority}
+              </span>
+            )}
+            {skill.required_tools && skill.required_tools.length > 0 && (
+              <span className="inline-flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                {skill.required_tools.length} tools required
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onEdit}
+            className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
+          <button
+            onClick={onDelete}
+            className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Skill {
+  id: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  category: string;
+  version: string;
+  prompt_template: string | null;
+  config_schema: Record<string, unknown>;
+  default_config: Record<string, unknown>;
+  required_tools: string[];
+  is_enabled: boolean;
+  priority: number;
+  visibility: string;
+}
+
+interface SkillFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: Record<string, unknown>) => Promise<void>;
+  skill: Skill | null;
+}
+
+export function SkillFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  skill,
+}: SkillFormDialogProps) {
+  const [formData, setFormData] = useState({
+    name: "",
+    display_name: "",
+    description: "",
+    category: "general",
+    version: "1.0.0",
+    prompt_template: "",
+    config_schema: "{}",
+    default_config: "{}",
+    required_tools: "",
+    is_enabled: true,
+    priority: 0,
+    visibility: "private",
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (skill) {
+      setFormData({
+        name: skill.name,
+        display_name: skill.display_name || "",
+        description: skill.description || "",
+        category: skill.category,
+        version: skill.version,
+        prompt_template: skill.prompt_template || "",
+        config_schema: JSON.stringify(skill.config_schema || {}, null, 2),
+        default_config: JSON.stringify(skill.default_config || {}, null, 2),
+        required_tools: Array.isArray(skill.required_tools) ? skill.required_tools.join("\n") : "",
+        is_enabled: skill.is_enabled,
+        priority: skill.priority,
+        visibility: skill.visibility,
+      });
+    } else {
+      setFormData({
+        name: "",
+        display_name: "",
+        description: "",
+        category: "general",
+        version: "1.0.0",
+        prompt_template: "",
+        config_schema: "{}",
+        default_config: "{}",
+        required_tools: "",
+        is_enabled: true,
+        priority: 0,
+        visibility: "private",
+      });
+    }
+    setError(null);
+  }, [skill, open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      let configSchema = {};
+      let defaultConfig = {};
+      try {
+        configSchema = JSON.parse(formData.config_schema || "{}");
+      } catch {
+        throw new Error("Invalid JSON in config schema");
+      }
+      try {
+        defaultConfig = JSON.parse(formData.default_config || "{}");
+      } catch {
+        throw new Error("Invalid JSON in default config");
+      }
+
+      const data: Record<string, unknown> = {
+        name: formData.name,
+        display_name: formData.display_name || null,
+        description: formData.description || null,
+        category: formData.category,
+        version: formData.version,
+        prompt_template: formData.prompt_template || null,
+        config_schema: configSchema,
+        default_config: defaultConfig,
+        required_tools: formData.required_tools
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        is_enabled: formData.is_enabled,
+        priority: formData.priority,
+        visibility: formData.visibility,
+      };
+
+      await onSubmit(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900 my-8">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+          {skill ? "Edit Skill" : "Add Skill"}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Name *
+              </label>
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="my-skill"
+                required
+                disabled={!!skill}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Display Name
+              </label>
+              <input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="My Skill"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              Description
+            </label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={2}
+              placeholder="Description of this skill"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Category
+              </label>
+              <input
+                type="text"
+                value={formData.category}
+                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="general"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Version
+              </label>
+              <input
+                type="text"
+                value={formData.version}
+                onChange={(e) => setFormData({ ...formData, version: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="1.0.0"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Visibility
+              </label>
+              <select
+                value={formData.visibility}
+                onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              >
+                <option value="private">Private</option>
+                <option value="shared">Shared</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              Prompt Template
+            </label>
+            <textarea
+              value={formData.prompt_template}
+              onChange={(e) => setFormData({ ...formData, prompt_template: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={4}
+              placeholder="Enter the skill's prompt template..."
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Config Schema (JSON)
+              </label>
+              <textarea
+                value={formData.config_schema}
+                onChange={(e) => setFormData({ ...formData, config_schema: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                rows={3}
+                placeholder='{"type": "object"}'
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Default Config (JSON)
+              </label>
+              <textarea
+                value={formData.default_config}
+                onChange={(e) => setFormData({ ...formData, default_config: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                rows={3}
+                placeholder='{}'
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              Required Tools (one per line)
+            </label>
+            <textarea
+              value={formData.required_tools}
+              onChange={(e) => setFormData({ ...formData, required_tools: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={2}
+              placeholder="get_file&#10;write_file"
+            />
+          </div>
+
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={formData.is_enabled}
+                onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
+                className="rounded border-zinc-300 dark:border-zinc-600"
+              />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300">Enabled</span>
+            </label>
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-zinc-700 dark:text-zinc-300">Priority:</label>
+              <input
+                type="number"
+                value={formData.priority}
+                onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value) || 0 })}
+                className="w-20 rounded-md border border-zinc-300 px-2 py-1 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              {loading ? "Saving..." : skill ? "Update" : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/skills/page.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/page.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { PluginsNav } from "@/components/ui/PluginsNav";
+import { SkillCard } from "./_components/SkillCard";
+import { SkillFormDialog } from "./_components/SkillFormDialog";
+
+interface Skill {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  category: string;
+  version: string;
+  prompt_template: string | null;
+  config_schema: Record<string, unknown>;
+  default_config: Record<string, unknown>;
+  required_tools: string[];
+  is_enabled: boolean;
+  priority: number;
+}
+
+export default function SkillsPage() {
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string>("");
+
+  const fetchSkills = async () => {
+    try {
+      const url = categoryFilter
+        ? `/api/plugins/skills?category=${encodeURIComponent(categoryFilter)}`
+        : "/api/plugins/skills";
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error("Failed to fetch skills");
+      }
+      const data = await response.json();
+      setSkills(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSkills();
+  }, [categoryFilter]);
+
+  const handleCreate = () => {
+    setEditingSkill(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (skill: Skill) => {
+    setEditingSkill(skill);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (skillId: string) => {
+    if (!confirm("Are you sure you want to delete this skill?")) {
+      return;
+    }
+    try {
+      const response = await fetch(`/api/plugins/skills/${skillId}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error("Failed to delete skill");
+      }
+      fetchSkills();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "An error occurred");
+    }
+  };
+
+  const handleDialogClose = () => {
+    setDialogOpen(false);
+    setEditingSkill(null);
+  };
+
+  const handleFormSubmit = async (data: Record<string, unknown>) => {
+    try {
+      const url = editingSkill
+        ? `/api/plugins/skills/${editingSkill.id}`
+        : "/api/plugins/skills";
+      const method = editingSkill ? "PATCH" : "POST";
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || "Failed to save skill");
+      }
+
+      handleDialogClose();
+      fetchSkills();
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  const categories = [...new Set(skills.map((s) => s.category))];
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <PluginsNav title="Skills" />
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 py-6">
+          <div className="mx-auto max-w-4xl">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  Skills
+                </h1>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  Define reusable skill modules with prompt templates.
+                </p>
+              </div>
+              <button
+                onClick={handleCreate}
+                className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Add Skill
+              </button>
+            </div>
+
+            {categories.length > 0 && (
+              <div className="mb-4 flex items-center gap-2">
+                <span className="text-sm text-zinc-500 dark:text-zinc-400">Filter:</span>
+                <select
+                  value={categoryFilter}
+                  onChange={(e) => setCategoryFilter(e.target.value)}
+                  className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                >
+                  <option value="">All categories</option>
+                  {categories.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {loading ? (
+              <div className="text-sm text-zinc-500">Loading...</div>
+            ) : error ? (
+              <div className="text-sm text-red-500">{error}</div>
+            ) : skills.length === 0 ? (
+              <div className="text-center py-12">
+                <div className="text-zinc-400 dark:text-zinc-500 mb-4">
+                  No skills defined yet.
+                </div>
+                <button
+                  onClick={handleCreate}
+                  className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
+                >
+                  Create your first skill →
+                </button>
+              </div>
+            ) : (
+              <div className="grid gap-4">
+                {skills.map((skill) => (
+                  <SkillCard
+                    key={skill.id}
+                    skill={skill}
+                    onEdit={() => handleEdit(skill)}
+                    onDelete={() => handleDelete(skill.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <SkillFormDialog
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        onSubmit={handleFormSubmit}
+        skill={editingSkill}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+interface SubAgent {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  agent_type: string;
+  system_prompt: string | null;
+  model: string | null;
+  config: Record<string, unknown>;
+  skills: string[];
+  tools: string[];
+  is_enabled: boolean;
+}
+
+interface SubAgentCardProps {
+  agent: SubAgent;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+              {agent.display_name || agent.name}
+            </h3>
+            {agent.is_enabled ? (
+              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                Enabled
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                Disabled
+              </span>
+            )}
+            <span className="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
+              {agent.agent_type}
+            </span>
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+              {agent.visibility}
+            </span>
+          </div>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
+            {agent.description || "No description"}
+          </p>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
+            {agent.model && (
+              <span className="inline-flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                {agent.model}
+              </span>
+            )}
+            {agent.skills && agent.skills.length > 0 && (
+              <span className="inline-flex items-center gap-1 text-purple-600 dark:text-purple-400">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                </svg>
+                {agent.skills.length} skills
+              </span>
+            )}
+            {agent.tools && agent.tools.length > 0 && (
+              <span className="inline-flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+                {agent.tools.length} tools
+              </span>
+            )}
+          </div>
+          {agent.skills && agent.skills.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {agent.skills.slice(0, 3).map((skill) => (
+                <span
+                  key={skill}
+                  className="inline-flex items-center rounded bg-purple-50 px-2 py-0.5 text-xs text-purple-600 dark:bg-purple-900/20 dark:text-purple-400"
+                >
+                  {skill}
+                </span>
+              ))}
+              {agent.skills.length > 3 && (
+                <span className="text-xs text-zinc-400">+{agent.skills.length - 3} more</span>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onEdit}
+            className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
+          <button
+            onClick={onDelete}
+            className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface SubAgent {
+  id: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  agent_type: string;
+  system_prompt: string | null;
+  model: string | null;
+  config: Record<string, unknown>;
+  skills: string[];
+  tools: string[];
+  is_enabled: boolean;
+  visibility: string;
+}
+
+interface SubAgentFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: Record<string, unknown>) => Promise<void>;
+  agent: SubAgent | null;
+}
+
+export function SubAgentFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  agent,
+}: SubAgentFormDialogProps) {
+  const [formData, setFormData] = useState({
+    name: "",
+    display_name: "",
+    description: "",
+    agent_type: "llm_agent",
+    system_prompt: "",
+    model: "",
+    config: "{}",
+    skills: "",
+    tools: "",
+    is_enabled: true,
+    visibility: "private",
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (agent) {
+      setFormData({
+        name: agent.name,
+        display_name: agent.display_name || "",
+        description: agent.description || "",
+        agent_type: agent.agent_type,
+        system_prompt: agent.system_prompt || "",
+        model: agent.model || "",
+        config: JSON.stringify(agent.config || {}, null, 2),
+        skills: Array.isArray(agent.skills) ? agent.skills.join("\n") : "",
+        tools: Array.isArray(agent.tools) ? agent.tools.join("\n") : "",
+        is_enabled: agent.is_enabled,
+        visibility: agent.visibility,
+      });
+    } else {
+      setFormData({
+        name: "",
+        display_name: "",
+        description: "",
+        agent_type: "llm_agent",
+        system_prompt: "",
+        model: "",
+        config: "{}",
+        skills: "",
+        tools: "",
+        is_enabled: true,
+        visibility: "private",
+      });
+    }
+    setError(null);
+  }, [agent, open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      let config = {};
+      try {
+        config = JSON.parse(formData.config || "{}");
+      } catch {
+        throw new Error("Invalid JSON in config");
+      }
+
+      const data: Record<string, unknown> = {
+        name: formData.name,
+        display_name: formData.display_name || null,
+        description: formData.description || null,
+        agent_type: formData.agent_type,
+        system_prompt: formData.system_prompt || null,
+        model: formData.model || null,
+        config: config,
+        skills: formData.skills
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        tools: formData.tools
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        is_enabled: formData.is_enabled,
+        visibility: formData.visibility,
+      };
+
+      await onSubmit(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto">
+      <div className="fixed inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-900 my-8">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+          {agent ? "Edit SubAgent" : "Add SubAgent"}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Name *
+              </label>
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="my-subagent"
+                required
+                disabled={!!agent}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Display Name
+              </label>
+              <input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="My SubAgent"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              Description
+            </label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={2}
+              placeholder="Description of this subagent"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Agent Type *
+              </label>
+              <select
+                value={formData.agent_type}
+                onChange={(e) => setFormData({ ...formData, agent_type: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              >
+                <option value="llm_agent">LLM Agent</option>
+                <option value="workflow">Workflow</option>
+                <option value="router">Router</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Model
+              </label>
+              <input
+                type="text"
+                value={formData.model}
+                onChange={(e) => setFormData({ ...formData, model: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                placeholder="claude-sonnet-4"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Visibility
+              </label>
+              <select
+                value={formData.visibility}
+                onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              >
+                <option value="private">Private</option>
+                <option value="shared">Shared</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              System Prompt
+            </label>
+            <textarea
+              value={formData.system_prompt}
+              onChange={(e) => setFormData({ ...formData, system_prompt: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={4}
+              placeholder="You are a specialized agent for..."
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Skills (one per line)
+              </label>
+              <textarea
+                value={formData.skills}
+                onChange={(e) => setFormData({ ...formData, skills: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                rows={3}
+                placeholder="code-review&#10;document-analysis"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Tools (one per line)
+              </label>
+              <textarea
+                value={formData.tools}
+                onChange={(e) => setFormData({ ...formData, tools: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                rows={3}
+                placeholder="get_file&#10;write_file"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              Config (JSON)
+            </label>
+            <textarea
+              value={formData.config}
+              onChange={(e) => setFormData({ ...formData, config: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={3}
+              placeholder='{"temperature": 0.7}'
+            />
+          </div>
+
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={formData.is_enabled}
+                onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
+                className="rounded border-zinc-300 dark:border-zinc-600"
+              />
+              <span className="text-sm text-zinc-700 dark:text-zinc-300">Enabled</span>
+            </label>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            >
+              {loading ? "Saving..." : agent ? "Update" : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { PluginsNav } from "@/components/ui/PluginsNav";
+import { SubAgentCard } from "./_components/SubAgentCard";
+import { SubAgentFormDialog } from "./_components/SubAgentFormDialog";
+
+interface SubAgent {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  agent_type: string;
+  system_prompt: string | null;
+  model: string | null;
+  config: Record<string, unknown>;
+  skills: string[];
+  tools: string[];
+  is_enabled: boolean;
+}
+
+export default function SubAgentsPage() {
+  const [agents, setAgents] = useState<SubAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingAgent, setEditingAgent] = useState<SubAgent | null>(null);
+
+  const fetchAgents = async () => {
+    try {
+      const response = await fetch("/api/plugins/subagents");
+      if (!response.ok) {
+        throw new Error("Failed to fetch subagents");
+      }
+      const data = await response.json();
+      setAgents(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAgents();
+  }, []);
+
+  const handleCreate = () => {
+    setEditingAgent(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (agent: SubAgent) => {
+    setEditingAgent(agent);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (agentId: string) => {
+    if (!confirm("Are you sure you want to delete this subagent?")) {
+      return;
+    }
+    try {
+      const response = await fetch(`/api/plugins/subagents/${agentId}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error("Failed to delete subagent");
+      }
+      fetchAgents();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "An error occurred");
+    }
+  };
+
+  const handleDialogClose = () => {
+    setDialogOpen(false);
+    setEditingAgent(null);
+  };
+
+  const handleFormSubmit = async (data: Record<string, unknown>) => {
+    try {
+      const url = editingAgent
+        ? `/api/plugins/subagents/${editingAgent.id}`
+        : "/api/plugins/subagents";
+      const method = editingAgent ? "PATCH" : "POST";
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || "Failed to save subagent");
+      }
+
+      handleDialogClose();
+      fetchAgents();
+    } catch (err) {
+      throw err;
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <PluginsNav title="SubAgents" />
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 py-6">
+          <div className="mx-auto max-w-4xl">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  SubAgents
+                </h1>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  Configure specialized sub-agents for complex tasks.
+                </p>
+              </div>
+              <button
+                onClick={handleCreate}
+                className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Add SubAgent
+              </button>
+            </div>
+
+            {loading ? (
+              <div className="text-sm text-zinc-500">Loading...</div>
+            ) : error ? (
+              <div className="text-sm text-red-500">{error}</div>
+            ) : agents.length === 0 ? (
+              <div className="text-center py-12">
+                <div className="text-zinc-400 dark:text-zinc-500 mb-4">
+                  No subagents configured yet.
+                </div>
+                <button
+                  onClick={handleCreate}
+                  className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
+                >
+                  Create your first subagent →
+                </button>
+              </div>
+            ) : (
+              <div className="grid gap-4">
+                {agents.map((agent) => (
+                  <SubAgentCard
+                    key={agent.id}
+                    agent={agent}
+                    onEdit={() => handleEdit(agent)}
+                    onDelete={() => handleDelete(agent.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <SubAgentFormDialog
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        onSubmit={handleFormSubmit}
+        agent={editingAgent}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/PluginsNav.tsx
+++ b/apps/negentropy-ui/components/ui/PluginsNav.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useNavigation } from "@/components/providers/NavigationProvider";
+
+const NAV_ITEMS = [
+  { href: "/plugins", label: "Dashboard" },
+  { href: "/plugins/mcp", label: "MCP Servers" },
+  { href: "/plugins/skills", label: "Skills" },
+  { href: "/plugins/subagents", label: "SubAgents" },
+];
+
+export function PluginsNav({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) {
+  const pathname = usePathname();
+  const { setNavigationInfo } = useNavigation();
+
+  useEffect(() => {
+    setNavigationInfo({ moduleLabel: "Plugins", pageTitle: title });
+    return () => {
+      setNavigationInfo(null);
+    };
+  }, [title, setNavigationInfo]);
+
+  const isActive = (href: string) =>
+    href === "/plugins" ? pathname === "/plugins" : pathname.startsWith(href);
+
+  return (
+    <div className="border-b border-border bg-card px-6 py-1">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <nav className="flex flex-wrap items-center gap-1 bg-muted/50 p-1 rounded-full">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`px-4 py-1 rounded-full text-xs font-semibold transition-colors ${
+                isActive(item.href)
+                  ? "bg-foreground text-background shadow-sm ring-1 ring-border"
+                  : "text-muted hover:text-foreground"
+              }`}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/config/navigation.ts
+++ b/apps/negentropy-ui/config/navigation.ts
@@ -22,6 +22,10 @@ export const mainNavConfig: MainNavItem[] = [
     href: "/memory",
   },
   {
+    title: "Plugins",
+    href: "/plugins",
+  },
+  {
     title: "Admin",
     href: "/admin",
     roles: ["admin"],

--- a/apps/negentropy/src/negentropy/auth/rbac.py
+++ b/apps/negentropy/src/negentropy/auth/rbac.py
@@ -29,6 +29,9 @@ PERMISSIONS = {
     # Chat
     "chat:read": "View chat history",
     "chat:write": "Send messages",
+    # Plugins
+    "plugins:read": "View plugins (MCP, Skills, SubAgents)",
+    "plugins:write": "Create and manage own plugins",
 }
 
 # Role-permission mappings
@@ -40,11 +43,14 @@ ROLE_PERMISSIONS: dict[str, list[str]] = {
         "knowledge:*",
         "memory:*",
         "chat:*",
+        "plugins:*",
     ],
     "user": [
         "knowledge:read",
         "memory:read",
         "chat:*",
+        "plugins:read",
+        "plugins:write",
     ],
 }
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/a1b2c3d4e5f6_add_plugins_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/a1b2c3d4e5f6_add_plugins_tables.py
@@ -1,0 +1,209 @@
+"""Add plugins tables for MCP, Skills, SubAgents
+
+Revision ID: a1b2c3d4e5f6
+Revises: c1640a4711b5
+Create Date: 2026-03-02 10:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "c1640a4711b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create plugins tables for MCP servers, Skills, SubAgents and permissions."""
+
+    # ==========================================================================
+    # Plugin Permissions 表 (需要先创建，因为其他表可能引用)
+    # ==========================================================================
+    op.create_table(
+        "plugin_permissions",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("plugin_type", sa.String(50), nullable=False),
+        sa.Column("plugin_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.String(255), nullable=False),
+        sa.Column(
+            "permission",
+            sa.Enum("view", "edit", name="plugin_permission_type"),
+            nullable=False,
+            server_default="view",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("plugin_type", "plugin_id", "user_id", name="plugin_permissions_unique"),
+        schema="negentropy",
+    )
+    op.create_index("ix_plugin_permissions_plugin", "plugin_permissions", ["plugin_type", "plugin_id"], schema="negentropy")
+    op.create_index("ix_plugin_permissions_user", "plugin_permissions", ["user_id"], schema="negentropy")
+
+    # ==========================================================================
+    # MCP Servers 表
+    # ==========================================================================
+    op.create_table(
+        "mcp_servers",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        # Ownership and visibility
+        sa.Column("owner_id", sa.String(255), nullable=False),
+        sa.Column(
+            "visibility",
+            sa.Enum("private", "shared", "public", name="plugin_visibility"),
+            nullable=False,
+            server_default="private",
+        ),
+        # Basic info
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        # Transport config
+        sa.Column("transport_type", sa.String(50), nullable=False),
+        sa.Column("command", sa.Text(), nullable=True),
+        sa.Column("args", postgresql.JSONB(astext_type=sa.Text()), server_default="[]", nullable=True),
+        sa.Column("env", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("url", sa.String(500), nullable=True),
+        # Status and config
+        sa.Column("is_enabled", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("auto_start", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="mcp_servers_name_unique"),
+        schema="negentropy",
+    )
+    op.create_index("ix_mcp_servers_owner", "mcp_servers", ["owner_id"], schema="negentropy")
+    op.create_index("ix_mcp_servers_visibility", "mcp_servers", ["visibility"], schema="negentropy")
+
+    # ==========================================================================
+    # MCP Tools 表
+    # ==========================================================================
+    op.create_table(
+        "mcp_tools",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("server_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("input_schema", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.Column("is_enabled", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("call_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["server_id"], ["negentropy.mcp_servers.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("server_id", "name", name="mcp_tools_server_name_unique"),
+        schema="negentropy",
+    )
+    op.create_index("ix_mcp_tools_server_id", "mcp_tools", ["server_id"], schema="negentropy")
+
+    # ==========================================================================
+    # Skills 表
+    # ==========================================================================
+    op.create_table(
+        "skills",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        # Ownership and visibility
+        sa.Column("owner_id", sa.String(255), nullable=False),
+        sa.Column(
+            "visibility",
+            sa.Enum("private", "shared", "public", name="plugin_visibility"),
+            nullable=False,
+            server_default="private",
+        ),
+        # Basic info
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("category", sa.String(100), server_default="general", nullable=False),
+        sa.Column("version", sa.String(50), server_default="1.0.0", nullable=False),
+        # Skill definition
+        sa.Column("prompt_template", sa.Text(), nullable=True),
+        sa.Column("config_schema", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("default_config", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("required_tools", postgresql.JSONB(astext_type=sa.Text()), server_default="[]", nullable=True),
+        # Status
+        sa.Column("is_enabled", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("priority", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="skills_name_unique"),
+        schema="negentropy",
+    )
+    op.create_index("ix_skills_owner", "skills", ["owner_id"], schema="negentropy")
+    op.create_index("ix_skills_category", "skills", ["category"], schema="negentropy")
+
+    # ==========================================================================
+    # SubAgents 表
+    # ==========================================================================
+    op.create_table(
+        "sub_agents",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        # Ownership and visibility
+        sa.Column("owner_id", sa.String(255), nullable=False),
+        sa.Column(
+            "visibility",
+            sa.Enum("private", "shared", "public", name="plugin_visibility"),
+            nullable=False,
+            server_default="private",
+        ),
+        # Basic info
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("agent_type", sa.String(100), nullable=False),
+        # Agent config
+        sa.Column("system_prompt", sa.Text(), nullable=True),
+        sa.Column("model", sa.String(100), nullable=True),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("skills", postgresql.JSONB(astext_type=sa.Text()), server_default="[]", nullable=True),
+        sa.Column("tools", postgresql.JSONB(astext_type=sa.Text()), server_default="[]", nullable=True),
+        # Status
+        sa.Column("is_enabled", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="sub_agents_name_unique"),
+        schema="negentropy",
+    )
+    op.create_index("ix_sub_agents_owner", "sub_agents", ["owner_id"], schema="negentropy")
+
+
+def downgrade() -> None:
+    """Drop plugins tables."""
+
+    # Drop SubAgents
+    op.drop_index("ix_sub_agents_owner", table_name="sub_agents", schema="negentropy")
+    op.drop_table("sub_agents", schema="negentropy")
+
+    # Drop Skills
+    op.drop_index("ix_skills_category", table_name="skills", schema="negentropy")
+    op.drop_index("ix_skills_owner", table_name="skills", schema="negentropy")
+    op.drop_table("skills", schema="negentropy")
+
+    # Drop MCP Tools
+    op.drop_index("ix_mcp_tools_server_id", table_name="mcp_tools", schema="negentropy")
+    op.drop_table("mcp_tools", schema="negentropy")
+
+    # Drop MCP Servers
+    op.drop_index("ix_mcp_servers_visibility", table_name="mcp_servers", schema="negentropy")
+    op.drop_index("ix_mcp_servers_owner", table_name="mcp_servers", schema="negentropy")
+    op.drop_table("mcp_servers", schema="negentropy")
+
+    # Drop Plugin Permissions
+    op.drop_index("ix_plugin_permissions_user", table_name="plugin_permissions", schema="negentropy")
+    op.drop_index("ix_plugin_permissions_plugin", table_name="plugin_permissions", schema="negentropy")
+    op.drop_table("plugin_permissions", schema="negentropy")
+
+    # Drop enums
+    op.execute("DROP TYPE IF EXISTS negentropy.plugin_visibility")
+    op.execute("DROP TYPE IF EXISTS negentropy.plugin_permission_type")

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -221,6 +221,7 @@ def apply_adk_patches():
         from negentropy.engine.sessions_api import router as sessions_router
         from negentropy.auth.api import router as auth_router
         from negentropy.auth.middleware import AuthMiddleware
+        from negentropy.plugins.api import router as plugins_router
 
         class TracingInitMiddleware(BaseHTTPMiddleware):
             async def dispatch(self, request: Request, call_next):
@@ -330,6 +331,9 @@ def apply_adk_patches():
         if not any(route.path.startswith("/memory") for route in app.router.routes):
             app.include_router(memory_router)
             logger.info("Memory API router mounted under /memory")
+        if not any(route.path.startswith("/plugins") for route in app.router.routes):
+            app.include_router(plugins_router)
+            logger.info("Plugins API router mounted under /plugins")
         if not any(route.path.startswith("/auth") for route in app.router.routes):
             app.include_router(auth_router)
             logger.info("Auth API router mounted under /auth")

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -4,6 +4,7 @@ from .internalization import ConsolidationJob, Fact, Instruction, Memory, Memory
 from .knowledge_runtime import KnowledgeGraphRun, KnowledgePipelineRun
 from .observability import Trace
 from .perception import Corpus, Knowledge
+from .plugin import McpServer, McpTool, PluginPermission, PluginPermissionType, PluginVisibility, Skill, SubAgent
 from .pulse import AppState, Event, Message, Run, Snapshot, Thread, UserState
 from .security import Credential
 
@@ -42,4 +43,12 @@ __all__ = [
     "KnowledgePipelineRun",
     # Security
     "Credential",
+    # Plugin
+    "PluginVisibility",
+    "PluginPermissionType",
+    "PluginPermission",
+    "McpServer",
+    "McpTool",
+    "Skill",
+    "SubAgent",
 ]

--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -1,0 +1,184 @@
+"""
+Plugin 模块数据模型。
+
+包含 MCP Server、Skill、SubAgent 以及权限管理相关的模型定义。
+"""
+
+import enum
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy import Boolean, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .base import NEGENTROPY_SCHEMA, TIMESTAMP, Base, TimestampMixin, UUIDMixin, fk
+
+
+class PluginVisibility(str, enum.Enum):
+    """插件可见性枚举"""
+
+    PRIVATE = "private"  # 仅创建者可见
+    SHARED = "shared"  # 指定用户可见（通过 PluginPermission）
+    PUBLIC = "public"  # 所有人可见
+
+
+class PluginPermissionType(str, enum.Enum):
+    """插件权限类型枚举"""
+
+    VIEW = "view"  # 查看权限
+    EDIT = "edit"  # 编辑权限
+
+
+class PluginPermission(Base, UUIDMixin, TimestampMixin):
+    """插件权限授权记录"""
+
+    __tablename__ = "plugin_permissions"
+
+    plugin_type: Mapped[str] = mapped_column(String(50), nullable=False)  # mcp_server, skill, sub_agent
+    plugin_id: Mapped[UUID] = mapped_column(UUID, nullable=False)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    permission: Mapped[PluginPermissionType] = mapped_column(
+        Enum(PluginPermissionType), nullable=False, default=PluginPermissionType.VIEW
+    )
+
+    __table_args__ = (
+        UniqueConstraint("plugin_type", "plugin_id", "user_id", name="plugin_permissions_unique"),
+        Index("ix_plugin_permissions_plugin", "plugin_type", "plugin_id"),
+        Index("ix_plugin_permissions_user", "user_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class McpServer(Base, UUIDMixin, TimestampMixin):
+    """MCP 服务器配置"""
+
+    __tablename__ = "mcp_servers"
+
+    # 所有权和可见性
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    visibility: Mapped[PluginVisibility] = mapped_column(
+        Enum(PluginVisibility), nullable=False, default=PluginVisibility.PRIVATE
+    )
+
+    # 基本信息
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+
+    # 传输配置
+    transport_type: Mapped[str] = mapped_column(String(50), nullable=False)  # stdio, sse, websocket
+    command: Mapped[Optional[str]] = mapped_column(Text)  # for stdio transport
+    args: Mapped[Optional[List[str]]] = mapped_column(JSONB, server_default="[]")
+    env: Mapped[Optional[Dict[str, str]]] = mapped_column(JSONB, server_default="{}")
+    url: Mapped[Optional[str]] = mapped_column(String(500))  # for sse/websocket
+
+    # 状态和配置
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    auto_start: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    config: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, server_default="{}")
+
+    __table_args__ = (
+        UniqueConstraint("name", name="mcp_servers_name_unique"),
+        Index("ix_mcp_servers_owner", "owner_id"),
+        Index("ix_mcp_servers_visibility", "visibility"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+    # Relationships
+    tools: Mapped[List["McpTool"]] = relationship(back_populates="server", cascade="all, delete-orphan")
+
+
+class McpTool(Base, UUIDMixin, TimestampMixin):
+    """MCP 工具（从 McpServer 动态发现）"""
+
+    __tablename__ = "mcp_tools"
+
+    server_id: Mapped[UUID] = mapped_column(fk("mcp_servers", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    input_schema: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    call_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+
+    __table_args__ = (
+        UniqueConstraint("server_id", "name", name="mcp_tools_server_name_unique"),
+        Index("ix_mcp_tools_server_id", "server_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+    # Relationships
+    server: Mapped["McpServer"] = relationship(back_populates="tools")
+
+
+class Skill(Base, UUIDMixin, TimestampMixin):
+    """技能模块定义"""
+
+    __tablename__ = "skills"
+
+    # 所有权和可见性
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    visibility: Mapped[PluginVisibility] = mapped_column(
+        Enum(PluginVisibility), nullable=False, default=PluginVisibility.PRIVATE
+    )
+
+    # 基本信息
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    category: Mapped[str] = mapped_column(String(100), nullable=False, server_default="general")
+    version: Mapped[str] = mapped_column(String(50), nullable=False, server_default="1.0.0")
+
+    # 技能定义
+    prompt_template: Mapped[Optional[str]] = mapped_column(Text)
+    config_schema: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, server_default="{}")
+    default_config: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, server_default="{}")
+    required_tools: Mapped[Optional[List[str]]] = mapped_column(JSONB, server_default="[]")
+
+    # 状态
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+
+    __table_args__ = (
+        UniqueConstraint("name", name="skills_name_unique"),
+        Index("ix_skills_owner", "owner_id"),
+        Index("ix_skills_category", "category"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class SubAgent(Base, UUIDMixin, TimestampMixin):
+    """子智能体配置"""
+
+    __tablename__ = "sub_agents"
+
+    # 所有权和可见性
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    visibility: Mapped[PluginVisibility] = mapped_column(
+        Enum(PluginVisibility), nullable=False, default=PluginVisibility.PRIVATE
+    )
+
+    # 基本信息
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String(255))
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    agent_type: Mapped[str] = mapped_column(String(100), nullable=False)  # llm_agent, workflow, etc.
+
+    # Agent 配置
+    system_prompt: Mapped[Optional[str]] = mapped_column(Text)
+    model: Mapped[Optional[str]] = mapped_column(String(100))
+    config: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, server_default="{}")
+    skills: Mapped[Optional[List[str]]] = mapped_column(JSONB, server_default="[]")
+    tools: Mapped[Optional[List[str]]] = mapped_column(JSONB, server_default="[]")
+
+    # 状态
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+
+    __table_args__ = (
+        UniqueConstraint("name", name="sub_agents_name_unique"),
+        Index("ix_sub_agents_owner", "owner_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )

--- a/apps/negentropy/src/negentropy/plugins/__init__.py
+++ b/apps/negentropy/src/negentropy/plugins/__init__.py
@@ -1,0 +1,9 @@
+"""
+Plugins 模块。
+
+提供 MCP Server、Skill、SubAgent 的管理和权限控制功能。
+"""
+
+from .api import router
+
+__all__ = ["router"]

--- a/apps/negentropy/src/negentropy/plugins/api.py
+++ b/apps/negentropy/src/negentropy/plugins/api.py
@@ -1,0 +1,817 @@
+"""
+Plugins API 模块。
+
+提供 MCP Server、Skill、SubAgent 的 CRUD 端点。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select, and_, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from negentropy.auth.deps import get_current_user
+from negentropy.auth.rbac import has_permission
+from negentropy.auth.service import AuthUser
+from negentropy.config import settings
+from negentropy.db.session import AsyncSessionLocal
+from negentropy.logging import get_logger
+from negentropy.models.plugin import (
+    McpServer,
+    McpTool,
+    PluginPermission,
+    PluginPermissionType,
+    PluginVisibility,
+    Skill,
+    SubAgent,
+)
+
+from .permissions import check_plugin_access, check_plugin_ownership, get_visible_plugin_ids
+
+logger = get_logger("negentropy.plugins.api")
+router = APIRouter(prefix="/plugins", tags=["plugins"])
+
+
+def _resolve_app_name(app_name: Optional[str]) -> str:
+    return app_name or settings.app_name
+
+
+# =============================================================================
+# Common Response Models
+# =============================================================================
+
+
+class StatsResponse(BaseModel):
+    """Dashboard 统计响应"""
+
+    mcp_servers: Dict[str, int]
+    skills: Dict[str, int]
+    subagents: Dict[str, int]
+
+
+class PermissionGrantRequest(BaseModel):
+    """授权请求"""
+
+    user_id: str
+    permission: str  # "view" or "edit"
+
+
+class PermissionResponse(BaseModel):
+    """授权记录响应"""
+
+    id: UUID
+    user_id: str
+    permission: str
+
+    class Config:
+        from_attributes = True
+
+
+# =============================================================================
+# MCP Server Models
+# =============================================================================
+
+
+class McpServerCreateRequest(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    transport_type: str  # stdio, sse, websocket
+    command: Optional[str] = None
+    args: List[str] = Field(default_factory=list)
+    env: Dict[str, str] = Field(default_factory=dict)
+    url: Optional[str] = None
+    is_enabled: bool = True
+    auto_start: bool = False
+    config: Dict[str, Any] = Field(default_factory=dict)
+    visibility: str = "private"
+
+
+class McpServerUpdateRequest(BaseModel):
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    command: Optional[str] = None
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
+    url: Optional[str] = None
+    is_enabled: Optional[bool] = None
+    auto_start: Optional[bool] = None
+    config: Optional[Dict[str, Any]] = None
+    visibility: Optional[str] = None
+
+
+class McpServerResponse(BaseModel):
+    id: UUID
+    owner_id: str
+    visibility: str
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    transport_type: str
+    command: Optional[str] = None
+    args: List[str] = Field(default_factory=list)
+    env: Dict[str, str] = Field(default_factory=dict)
+    url: Optional[str] = None
+    is_enabled: bool = True
+    auto_start: bool = False
+    config: Dict[str, Any] = Field(default_factory=dict)
+    tool_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+# =============================================================================
+# Skill Models
+# =============================================================================
+
+
+class SkillCreateRequest(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    category: str = "general"
+    version: str = "1.0.0"
+    prompt_template: Optional[str] = None
+    config_schema: Dict[str, Any] = Field(default_factory=dict)
+    default_config: Dict[str, Any] = Field(default_factory=dict)
+    required_tools: List[str] = Field(default_factory=list)
+    is_enabled: bool = True
+    priority: int = 0
+    visibility: str = "private"
+
+
+class SkillUpdateRequest(BaseModel):
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    version: Optional[str] = None
+    prompt_template: Optional[str] = None
+    config_schema: Optional[Dict[str, Any]] = None
+    default_config: Optional[Dict[str, Any]] = None
+    required_tools: Optional[List[str]] = None
+    is_enabled: Optional[bool] = None
+    priority: Optional[int] = None
+    visibility: Optional[str] = None
+
+
+class SkillResponse(BaseModel):
+    id: UUID
+    owner_id: str
+    visibility: str
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    category: str
+    version: str
+    prompt_template: Optional[str] = None
+    config_schema: Dict[str, Any] = Field(default_factory=dict)
+    default_config: Dict[str, Any] = Field(default_factory=dict)
+    required_tools: List[str] = Field(default_factory=list)
+    is_enabled: bool
+    priority: int
+
+    class Config:
+        from_attributes = True
+
+
+# =============================================================================
+# SubAgent Models
+# =============================================================================
+
+
+class SubAgentCreateRequest(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    agent_type: str
+    system_prompt: Optional[str] = None
+    model: Optional[str] = None
+    config: Dict[str, Any] = Field(default_factory=dict)
+    skills: List[str] = Field(default_factory=list)
+    tools: List[str] = Field(default_factory=list)
+    is_enabled: bool = True
+    visibility: str = "private"
+
+
+class SubAgentUpdateRequest(BaseModel):
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    agent_type: Optional[str] = None
+    system_prompt: Optional[str] = None
+    model: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None
+    skills: Optional[List[str]] = None
+    tools: Optional[List[str]] = None
+    is_enabled: Optional[bool] = None
+    visibility: Optional[str] = None
+
+
+class SubAgentResponse(BaseModel):
+    id: UUID
+    owner_id: str
+    visibility: str
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    agent_type: str
+    system_prompt: Optional[str] = None
+    model: Optional[str] = None
+    config: Dict[str, Any] = Field(default_factory=dict)
+    skills: List[str] = Field(default_factory=list)
+    tools: List[str] = Field(default_factory=list)
+    is_enabled: bool
+
+    class Config:
+        from_attributes = True
+
+
+# =============================================================================
+# Stats Endpoint
+# =============================================================================
+
+
+@router.get("/stats", response_model=StatsResponse)
+async def get_stats(user: AuthUser = Depends(get_current_user)) -> StatsResponse:
+    """获取 Dashboard 统计数据"""
+    async with AsyncSessionLocal() as db:
+        # MCP Servers
+        visible_mcp_ids = await get_visible_plugin_ids(db, "mcp_server", user)
+        mcp_total = len(visible_mcp_ids)
+        mcp_enabled_result = await db.scalar(
+            select(func.count()).where(
+                and_(McpServer.id.in_(visible_mcp_ids), McpServer.is_enabled == True)
+            )
+        )
+        mcp_enabled = mcp_enabled_result or 0
+
+        # Skills
+        visible_skill_ids = await get_visible_plugin_ids(db, "skill", user)
+        skill_total = len(visible_skill_ids)
+        skill_enabled_result = await db.scalar(
+            select(func.count()).where(and_(Skill.id.in_(visible_skill_ids), Skill.is_enabled == True))
+        )
+        skill_enabled = skill_enabled_result or 0
+
+        # SubAgents
+        visible_subagent_ids = await get_visible_plugin_ids(db, "sub_agent", user)
+        subagent_total = len(visible_subagent_ids)
+        subagent_enabled_result = await db.scalar(
+            select(func.count()).where(and_(SubAgent.id.in_(visible_subagent_ids), SubAgent.is_enabled == True))
+        )
+        subagent_enabled = subagent_enabled_result or 0
+
+    return StatsResponse(
+        mcp_servers={"total": mcp_total, "enabled": mcp_enabled},
+        skills={"total": skill_total, "enabled": skill_enabled},
+        subagents={"total": subagent_total, "enabled": subagent_enabled},
+    )
+
+
+# =============================================================================
+# MCP Server Endpoints
+# =============================================================================
+
+
+@router.get("/mcp/servers", response_model=List[McpServerResponse])
+async def list_mcp_servers(user: AuthUser = Depends(get_current_user)) -> List[McpServerResponse]:
+    """列出用户可见的 MCP 服务器"""
+    async with AsyncSessionLocal() as db:
+        visible_ids = await get_visible_plugin_ids(db, "mcp_server", user)
+        if not visible_ids:
+            return []
+
+        stmt = (
+            select(McpServer, func.count(McpTool.id))
+            .outerjoin(McpTool, McpTool.server_id == McpServer.id)
+            .where(McpServer.id.in_(visible_ids))
+            .group_by(McpServer.id)
+            .order_by(McpServer.created_at.desc())
+        )
+        result = await db.execute(stmt)
+        rows = result.all()
+
+    return [_mcp_server_to_response(server, count) for server, count in rows]
+
+
+@router.post("/mcp/servers", response_model=McpServerResponse, status_code=status.HTTP_201_CREATED)
+async def create_mcp_server(
+    payload: McpServerCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> McpServerResponse:
+    """创建新的 MCP 服务器"""
+    async with AsyncSessionLocal() as db:
+        # Check duplicate name
+        existing = await db.scalar(select(McpServer).where(McpServer.name == payload.name))
+        if existing:
+            raise HTTPException(status_code=400, detail="Server name already exists")
+
+        server = McpServer(
+            owner_id=user.user_id,
+            visibility=PluginVisibility(payload.visibility),
+            name=payload.name,
+            display_name=payload.display_name,
+            description=payload.description,
+            transport_type=payload.transport_type,
+            command=payload.command,
+            args=payload.args,
+            env=payload.env,
+            url=payload.url,
+            is_enabled=payload.is_enabled,
+            auto_start=payload.auto_start,
+            config=payload.config,
+        )
+        db.add(server)
+        await db.commit()
+        await db.refresh(server)
+
+    return _mcp_server_to_response(server, 0)
+
+
+@router.get("/mcp/servers/{server_id}", response_model=McpServerResponse)
+async def get_mcp_server(
+    server_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> McpServerResponse:
+    """获取 MCP 服务器详情"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "view")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        stmt = (
+            select(McpServer, func.count(McpTool.id))
+            .outerjoin(McpTool, McpTool.server_id == McpServer.id)
+            .where(McpServer.id == server_id)
+            .group_by(McpServer.id)
+        )
+        result = await db.execute(stmt)
+        row = result.first()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Server not found")
+
+    server, count = row
+    return _mcp_server_to_response(server, count)
+
+
+@router.patch("/mcp/servers/{server_id}", response_model=McpServerResponse)
+async def update_mcp_server(
+    server_id: UUID,
+    payload: McpServerUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> McpServerResponse:
+    """更新 MCP 服务器"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "edit")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        server = await db.get(McpServer, server_id)
+        if not server:
+            raise HTTPException(status_code=404, detail="Server not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        if "visibility" in update_data:
+            update_data["visibility"] = PluginVisibility(update_data["visibility"])
+
+        for key, value in update_data.items():
+            setattr(server, key, value)
+
+        await db.commit()
+        await db.refresh(server)
+
+    return _mcp_server_to_response(server, 0)
+
+
+@router.delete("/mcp/servers/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_mcp_server(
+    server_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> None:
+    """删除 MCP 服务器（仅 owner 可删除）"""
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, "mcp_server", server_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        server = await db.get(McpServer, server_id)
+        if not server:
+            raise HTTPException(status_code=404, detail="Server not found")
+        await db.delete(server)
+        await db.commit()
+
+
+def _mcp_server_to_response(server: McpServer, tool_count: int) -> McpServerResponse:
+    return McpServerResponse(
+        id=server.id,
+        owner_id=server.owner_id,
+        visibility=server.visibility.value,
+        name=server.name,
+        display_name=server.display_name,
+        description=server.description,
+        transport_type=server.transport_type,
+        command=server.command,
+        args=server.args or [],
+        env=server.env or {},
+        url=server.url,
+        is_enabled=server.is_enabled,
+        auto_start=server.auto_start,
+        config=server.config or {},
+        tool_count=tool_count or 0,
+    )
+
+
+# =============================================================================
+# Skills Endpoints
+# =============================================================================
+
+
+@router.get("/skills", response_model=List[SkillResponse])
+async def list_skills(
+    category: Optional[str] = Query(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> List[SkillResponse]:
+    """列出用户可见的 Skills"""
+    async with AsyncSessionLocal() as db:
+        visible_ids = await get_visible_plugin_ids(db, "skill", user)
+        if not visible_ids:
+            return []
+
+        stmt = select(Skill).where(Skill.id.in_(visible_ids))
+        if category:
+            stmt = stmt.where(Skill.category == category)
+        stmt = stmt.order_by(Skill.priority.desc(), Skill.created_at.desc())
+        result = await db.execute(stmt)
+        skills = result.scalars().all()
+
+    return [_skill_to_response(s) for s in skills]
+
+
+@router.post("/skills", response_model=SkillResponse, status_code=status.HTTP_201_CREATED)
+async def create_skill(
+    payload: SkillCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> SkillResponse:
+    """创建新的 Skill"""
+    async with AsyncSessionLocal() as db:
+        existing = await db.scalar(select(Skill).where(Skill.name == payload.name))
+        if existing:
+            raise HTTPException(status_code=400, detail="Skill name already exists")
+
+        skill = Skill(
+            owner_id=user.user_id,
+            visibility=PluginVisibility(payload.visibility),
+            name=payload.name,
+            display_name=payload.display_name,
+            description=payload.description,
+            category=payload.category,
+            version=payload.version,
+            prompt_template=payload.prompt_template,
+            config_schema=payload.config_schema,
+            default_config=payload.default_config,
+            required_tools=payload.required_tools,
+            is_enabled=payload.is_enabled,
+            priority=payload.priority,
+        )
+        db.add(skill)
+        await db.commit()
+        await db.refresh(skill)
+
+    return _skill_to_response(skill)
+
+
+@router.get("/skills/{skill_id}", response_model=SkillResponse)
+async def get_skill(
+    skill_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> SkillResponse:
+    """获取 Skill 详情"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "skill", skill_id, user, "view")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        skill = await db.get(Skill, skill_id)
+        if not skill:
+            raise HTTPException(status_code=404, detail="Skill not found")
+    return _skill_to_response(skill)
+
+
+@router.patch("/skills/{skill_id}", response_model=SkillResponse)
+async def update_skill(
+    skill_id: UUID,
+    payload: SkillUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> SkillResponse:
+    """更新 Skill"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "skill", skill_id, user, "edit")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        skill = await db.get(Skill, skill_id)
+        if not skill:
+            raise HTTPException(status_code=404, detail="Skill not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        if "visibility" in update_data:
+            update_data["visibility"] = PluginVisibility(update_data["visibility"])
+
+        for key, value in update_data.items():
+            setattr(skill, key, value)
+
+        await db.commit()
+        await db.refresh(skill)
+
+    return _skill_to_response(skill)
+
+
+@router.delete("/skills/{skill_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_skill(
+    skill_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> None:
+    """删除 Skill（仅 owner 可删除）"""
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, "skill", skill_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        skill = await db.get(Skill, skill_id)
+        if not skill:
+            raise HTTPException(status_code=404, detail="Skill not found")
+        await db.delete(skill)
+        await db.commit()
+
+
+def _skill_to_response(skill: Skill) -> SkillResponse:
+    return SkillResponse(
+        id=skill.id,
+        owner_id=skill.owner_id,
+        visibility=skill.visibility.value,
+        name=skill.name,
+        display_name=skill.display_name,
+        description=skill.description,
+        category=skill.category,
+        version=skill.version,
+        prompt_template=skill.prompt_template,
+        config_schema=skill.config_schema or {},
+        default_config=skill.default_config or {},
+        required_tools=skill.required_tools or [],
+        is_enabled=skill.is_enabled,
+        priority=skill.priority,
+    )
+
+
+# =============================================================================
+# SubAgents Endpoints
+# =============================================================================
+
+
+@router.get("/subagents", response_model=List[SubAgentResponse])
+async def list_subagents(user: AuthUser = Depends(get_current_user)) -> List[SubAgentResponse]:
+    """列出用户可见的 SubAgents"""
+    async with AsyncSessionLocal() as db:
+        visible_ids = await get_visible_plugin_ids(db, "sub_agent", user)
+        if not visible_ids:
+            return []
+
+        stmt = select(SubAgent).where(SubAgent.id.in_(visible_ids)).order_by(SubAgent.created_at.desc())
+        result = await db.execute(stmt)
+        agents = result.scalars().all()
+
+    return [_subagent_to_response(a) for a in agents]
+
+
+@router.post("/subagents", response_model=SubAgentResponse, status_code=status.HTTP_201_CREATED)
+async def create_subagent(
+    payload: SubAgentCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> SubAgentResponse:
+    """创建新的 SubAgent"""
+    async with AsyncSessionLocal() as db:
+        existing = await db.scalar(select(SubAgent).where(SubAgent.name == payload.name))
+        if existing:
+            raise HTTPException(status_code=400, detail="SubAgent name already exists")
+
+        agent = SubAgent(
+            owner_id=user.user_id,
+            visibility=PluginVisibility(payload.visibility),
+            name=payload.name,
+            display_name=payload.display_name,
+            description=payload.description,
+            agent_type=payload.agent_type,
+            system_prompt=payload.system_prompt,
+            model=payload.model,
+            config=payload.config,
+            skills=payload.skills,
+            tools=payload.tools,
+            is_enabled=payload.is_enabled,
+        )
+        db.add(agent)
+        await db.commit()
+        await db.refresh(agent)
+
+    return _subagent_to_response(agent)
+
+
+@router.get("/subagents/{agent_id}", response_model=SubAgentResponse)
+async def get_subagent(
+    agent_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> SubAgentResponse:
+    """获取 SubAgent 详情"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "sub_agent", agent_id, user, "view")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        agent = await db.get(SubAgent, agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail="SubAgent not found")
+    return _subagent_to_response(agent)
+
+
+@router.patch("/subagents/{agent_id}", response_model=SubAgentResponse)
+async def update_subagent(
+    agent_id: UUID,
+    payload: SubAgentUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> SubAgentResponse:
+    """更新 SubAgent"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "sub_agent", agent_id, user, "edit")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        agent = await db.get(SubAgent, agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail="SubAgent not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        if "visibility" in update_data:
+            update_data["visibility"] = PluginVisibility(update_data["visibility"])
+
+        for key, value in update_data.items():
+            setattr(agent, key, value)
+
+        await db.commit()
+        await db.refresh(agent)
+
+    return _subagent_to_response(agent)
+
+
+@router.delete("/subagents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_subagent(
+    agent_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> None:
+    """删除 SubAgent（仅 owner 可删除）"""
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, "sub_agent", agent_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        agent = await db.get(SubAgent, agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail="SubAgent not found")
+        await db.delete(agent)
+        await db.commit()
+
+
+def _subagent_to_response(agent: SubAgent) -> SubAgentResponse:
+    return SubAgentResponse(
+        id=agent.id,
+        owner_id=agent.owner_id,
+        visibility=agent.visibility.value,
+        name=agent.name,
+        display_name=agent.display_name,
+        description=agent.description,
+        agent_type=agent.agent_type,
+        system_prompt=agent.system_prompt,
+        model=agent.model,
+        config=agent.config or {},
+        skills=agent.skills or [],
+        tools=agent.tools or [],
+        is_enabled=agent.is_enabled,
+    )
+
+
+# =============================================================================
+# Permission Management Endpoints
+# =============================================================================
+
+
+@router.get("/{plugin_type}/{plugin_id}/permissions", response_model=List[PermissionResponse])
+async def list_permissions(
+    plugin_type: str,
+    plugin_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> List[PermissionResponse]:
+    """获取插件的授权列表（仅 owner 可查看）"""
+    if plugin_type not in ["mcp_server", "skill", "sub_agent"]:
+        raise HTTPException(status_code=400, detail="Invalid plugin type")
+
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, plugin_type, plugin_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        result = await db.execute(
+            select(PluginPermission).where(
+                and_(
+                    PluginPermission.plugin_type == plugin_type,
+                    PluginPermission.plugin_id == plugin_id,
+                )
+            )
+        )
+        permissions = result.scalars().all()
+
+    return [
+        PermissionResponse(id=p.id, user_id=p.user_id, permission=p.permission.value) for p in permissions
+    ]
+
+
+@router.post("/{plugin_type}/{plugin_id}/permissions", response_model=PermissionResponse, status_code=status.HTTP_201_CREATED)
+async def grant_permission(
+    plugin_type: str,
+    plugin_id: UUID,
+    payload: PermissionGrantRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> PermissionResponse:
+    """授权给指定用户（仅 owner 可操作）"""
+    if plugin_type not in ["mcp_server", "skill", "sub_agent"]:
+        raise HTTPException(status_code=400, detail="Invalid plugin type")
+
+    if payload.permission not in ["view", "edit"]:
+        raise HTTPException(status_code=400, detail="Invalid permission type")
+
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, plugin_type, plugin_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        # Check if permission already exists
+        existing = await db.scalar(
+            select(PluginPermission).where(
+                and_(
+                    PluginPermission.plugin_type == plugin_type,
+                    PluginPermission.plugin_id == plugin_id,
+                    PluginPermission.user_id == payload.user_id,
+                )
+            )
+        )
+        if existing:
+            # Update existing permission
+            existing.permission = PluginPermissionType(payload.permission)
+            await db.commit()
+            await db.refresh(existing)
+            return PermissionResponse(id=existing.id, user_id=existing.user_id, permission=existing.permission.value)
+
+        # Create new permission
+        permission = PluginPermission(
+            plugin_type=plugin_type,
+            plugin_id=plugin_id,
+            user_id=payload.user_id,
+            permission=PluginPermissionType(payload.permission),
+        )
+        db.add(permission)
+        await db.commit()
+        await db.refresh(permission)
+
+    return PermissionResponse(id=permission.id, user_id=permission.user_id, permission=permission.permission.value)
+
+
+@router.delete("/{plugin_type}/{plugin_id}/permissions/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_permission(
+    plugin_type: str,
+    plugin_id: UUID,
+    user_id: str,
+    user: AuthUser = Depends(get_current_user),
+) -> None:
+    """撤销用户授权（仅 owner 可操作）"""
+    if plugin_type not in ["mcp_server", "skill", "sub_agent"]:
+        raise HTTPException(status_code=400, detail="Invalid plugin type")
+
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, plugin_type, plugin_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        permission = await db.scalar(
+            select(PluginPermission).where(
+                and_(
+                    PluginPermission.plugin_type == plugin_type,
+                    PluginPermission.plugin_id == plugin_id,
+                    PluginPermission.user_id == user_id,
+                )
+            )
+        )
+        if permission:
+            await db.delete(permission)
+            await db.commit()

--- a/apps/negentropy/src/negentropy/plugins/permissions.py
+++ b/apps/negentropy/src/negentropy/plugins/permissions.py
@@ -1,0 +1,191 @@
+"""
+Plugins 权限检查模块。
+
+提供插件访问权限的检查和管理功能。
+"""
+
+from typing import Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from negentropy.auth.rbac import has_permission
+from negentropy.auth.service import AuthUser
+from negentropy.models.plugin import (
+    McpServer,
+    PluginPermission,
+    PluginPermissionType,
+    PluginVisibility,
+    Skill,
+    SubAgent,
+)
+
+
+async def check_plugin_access(
+    db: AsyncSession,
+    plugin_type: str,
+    plugin_id: UUID,
+    user: AuthUser,
+    required_permission: str,  # "view" or "edit"
+) -> Tuple[bool, Optional[str]]:
+    """
+    检查用户是否有权限访问指定插件。
+
+    Args:
+        db: 数据库会话
+        plugin_type: 插件类型 ("mcp_server", "skill", "sub_agent")
+        plugin_id: 插件 UUID
+        user: 当前用户
+        required_permission: 需要的权限 ("view" or "edit")
+
+    Returns:
+        Tuple[bool, Optional[str]]: (是否有权限, 错误消息)
+    """
+    # 1. admin 角色拥有所有权限
+    if "admin" in user.roles:
+        return True, None
+
+    # 2. 获取插件记录检查 owner 和 visibility
+    plugin = await _get_plugin_by_type_and_id(db, plugin_type, plugin_id)
+    if not plugin:
+        return False, "Plugin not found"
+
+    # 3. owner 拥有所有权限
+    if plugin.owner_id == user.user_id:
+        return True, None
+
+    # 4. 检查 visibility
+    if plugin.visibility == PluginVisibility.PUBLIC and required_permission == "view":
+        return True, None
+
+    # 5. 检查授权记录
+    if plugin.visibility in (PluginVisibility.SHARED, PluginVisibility.PUBLIC):
+        permission_record = await db.scalar(
+            select(PluginPermission).where(
+                and_(
+                    PluginPermission.plugin_type == plugin_type,
+                    PluginPermission.plugin_id == plugin_id,
+                    PluginPermission.user_id == user.user_id,
+                )
+            )
+        )
+        if permission_record:
+            if required_permission == "view":
+                return True, None
+            if required_permission == "edit" and permission_record.permission == PluginPermissionType.EDIT:
+                return True, None
+
+    return False, "Permission denied"
+
+
+async def check_plugin_ownership(
+    db: AsyncSession,
+    plugin_type: str,
+    plugin_id: UUID,
+    user: AuthUser,
+) -> Tuple[bool, Optional[str]]:
+    """
+    检查用户是否是插件的所有者。
+
+    只有 owner 可以删除插件和管理授权。
+
+    Args:
+        db: 数据库会话
+        plugin_type: 插件类型
+        plugin_id: 插件 UUID
+        user: 当前用户
+
+    Returns:
+        Tuple[bool, Optional[str]]: (是否是所有者, 错误消息)
+    """
+    # admin 可以执行所有操作
+    if "admin" in user.roles:
+        return True, None
+
+    plugin = await _get_plugin_by_type_and_id(db, plugin_type, plugin_id)
+    if not plugin:
+        return False, "Plugin not found"
+
+    if plugin.owner_id == user.user_id:
+        return True, None
+
+    return False, "Only the owner can perform this action"
+
+
+async def get_visible_plugin_ids(
+    db: AsyncSession,
+    plugin_type: str,
+    user: AuthUser,
+) -> list[UUID]:
+    """
+    获取用户可见的所有插件 ID 列表。
+
+    包括：
+    1. 用户拥有的插件 (owner_id == user_id)
+    2. 公开的插件 (visibility == PUBLIC)
+    3. 被授权的插件 (在 plugin_permissions 中有记录)
+
+    Args:
+        db: 数据库会话
+        plugin_type: 插件类型
+        user: 当前用户
+
+    Returns:
+        list[UUID]: 可见的插件 ID 列表
+    """
+    # 根据插件类型选择模型
+    model_map = {
+        "mcp_server": McpServer,
+        "skill": Skill,
+        "sub_agent": SubAgent,
+    }
+    model = model_map.get(plugin_type)
+    if not model:
+        return []
+
+    # admin 可以看到所有
+    if "admin" in user.roles:
+        result = await db.scalars(select(model.id))
+        return list(result.all())
+
+    # 复杂查询：owner_id == user_id OR visibility == PUBLIC OR 有授权记录
+    # 使用 union 来组合这些条件
+    owned_query = select(model.id).where(model.owner_id == user.user_id)
+    public_query = select(model.id).where(model.visibility == PluginVisibility.PUBLIC)
+
+    # 获取有授权记录的插件 ID
+    shared_query = (
+        select(PluginPermission.plugin_id)
+        .where(
+            and_(
+                PluginPermission.plugin_type == plugin_type,
+                PluginPermission.user_id == user.user_id,
+            )
+        )
+        .distinct()
+    )
+
+    # 组合查询
+    from sqlalchemy import union
+
+    combined = union(owned_query, public_query, shared_query)
+    result = await db.execute(combined)
+    return [row[0] for row in result.fetchall()]
+
+
+async def _get_plugin_by_type_and_id(
+    db: AsyncSession,
+    plugin_type: str,
+    plugin_id: UUID,
+):
+    """根据类型和 ID 获取插件记录。"""
+    model_map = {
+        "mcp_server": McpServer,
+        "skill": Skill,
+        "sub_agent": SubAgent,
+    }
+    model = model_map.get(plugin_type)
+    if not model:
+        return None
+    return await db.get(model, plugin_id)


### PR DESCRIPTION
## 概述

在主导航栏的 Memory 和 Admin 之间新增 **Plugins** 菜单，实现 AI Agent 扩展能力的统一管理平台。

## 变更内容

### 后端实现

**数据模型** (`models/plugin.py`)
- `PluginVisibility` 枚举：支持 private/shared/public 三种可见性级别
- `PluginPermission` 模型：细粒度权限授权（view/edit）
- `McpServer` / `McpTool` 模型：MCP 服务器和工具配置
- `Skill` 模型：技能模块定义（含 prompt_template、config_schema）
- `SubAgent` 模型：子智能体配置（含 system_prompt、model、绑定技能和工具）

**API 端点** (`plugins/api.py`)
- `/plugins/stats` - Dashboard 统计数据
- `/plugins/mcp/servers` - MCP 服务器 CRUD
- `/plugins/skills` - Skills CRUD（支持分类筛选）
- `/plugins/subagents` - SubAgents CRUD
- `/plugins/{type}/{id}/permissions` - 权限管理（仅 owner 可操作）

**权限控制** (`plugins/permissions.py`)
- 基于所有权的访问控制（owner 拥有完全权限）
- 支持公开/共享/私有三种可见性
- 授权记录支持 view/edit 两种权限级别

**RBAC 扩展** (`auth/rbac.py`)
- 新增 `plugins:read` / `plugins:write` 权限
- admin 角色：完整 plugins 权限
- user 角色：可查看和创建自己的插件

**数据库迁移**
- 创建 `plugin_permissions`、`mcp_servers`、`mcp_tools`、`skills`、`sub_agents` 五张表

### 前端实现

**导航更新**
- 在 Memory 和 Admin 之间添加 Plugins 菜单项
- 所有登录用户可见

**页面结构**
- `/plugins` - Dashboard（统计卡片 + 快捷入口）
- `/plugins/mcp` - MCP 服务器管理（支持 stdio/sse/websocket 传输）
- `/plugins/skills` - Skills 管理（支持分类筛选、优先级排序）
- `/plugins/subagents` - SubAgents 管理（支持绑定技能和工具）

**组件实现**
- `PluginsNav` - 二级导航组件
- `*Card` - 列表卡片组件
- `*FormDialog` - 创建/编辑表单对话框

## 权限模型

| 可见性 | 创建者 | 被授权用户 | 其他用户 |
|--------|--------|-----------|---------|
| private | 读写 | - | 不可见 |
| shared | 读写 | 按授权 | 不可见 |
| public | 读写 | 按授权 | 只读 |

## 验证方式

1. 运行数据库迁移：`uv run alembic upgrade head`
2. 启动后端服务，访问 `/docs` 确认 API 端点已注册
3. 启动前端服务，验证导航和 CRUD 功能

## 技术栈

- 后端：Python 3.13 + FastAPI + SQLAlchemy 2.0 + PostgreSQL
- 前端：Next.js 16 + React 19 + TypeScript + Tailwind CSS

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*