### PR TITLE
fix(Models): 修复 SQLAlchemy UUID 列类型定义错误 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from sqlalchemy import Boolean, Enum, ForeignKey, Index, Integer, String, Text, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -38,7 +38,7 @@ class PluginPermission(Base, UUIDMixin, TimestampMixin):
     __tablename__ = "plugin_permissions"
 
     plugin_type: Mapped[str] = mapped_column(String(50), nullable=False)  # mcp_server, skill, sub_agent
-    plugin_id: Mapped[UUID] = mapped_column(UUID, nullable=False)
+    plugin_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
     user_id: Mapped[str] = mapped_column(String(255), nullable=False)
     permission: Mapped[PluginPermissionType] = mapped_column(
         Enum(PluginPermissionType), nullable=False, default=PluginPermissionType.VIEW

--- a/apps/negentropy/src/negentropy/models/pulse.py
+++ b/apps/negentropy/src/negentropy/models/pulse.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, Integer, Sequence, String, Text, UniqueConstraint, text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
@@ -42,7 +42,7 @@ class Event(Base, UUIDMixin):
     thread_id: Mapped[UUID] = mapped_column(
         ForeignKey(f"{NEGENTROPY_SCHEMA}.threads.id", ondelete="CASCADE"), nullable=False
     )
-    invocation_id: Mapped[UUID] = mapped_column(nullable=False)
+    invocation_id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
     author: Mapped[str] = mapped_column(String(50), nullable=False)  # 'user', 'agent', 'tool'
     event_type: Mapped[str] = mapped_column(String(50), nullable=False)  # 'message', 'tool_call', 'state_update'
     content: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")


### PR DESCRIPTION
## 问题背景

GitHub Actions 测试失败，错误信息：
```
sqlalchemy.exc.ArgumentError: 'SchemaItem' object, such as a 'Column' or a 'Constraint' expected, got <class 'uuid.UUID'>
```

## 修复内容

修复 SQLAlchemy 模型中 UUID 列类型定义错误：

### 1. `apps/negentropy/src/negentropy/models/plugin.py`
- 添加 `UUID as PG_UUID` 导入
- 将 `plugin_id` 的列类型从 Python `UUID` 改为 `PG_UUID(as_uuid=True)`

### 2. `apps/negentropy/src/negentropy/models/pulse.py`
- 添加 `UUID as PG_UUID` 导入
- 为 `invocation_id` 添加缺失的 `PG_UUID(as_uuid=True)` 列类型

## 技术说明

SQLAlchemy 的 `mapped_column` 需要使用 SQLAlchemy 的列类型（如 `PG_UUID`），而不是 Python 标准库的 `uuid.UUID` 类型。这是因为 `mapped_column` 的第一个参数应该是 SQLAlchemy 的 `SchemaItem`（如 `Column` 或 `Constraint`），而 Python 的 `UUID` 类型不符合这个要求。

## 测试验证

- ✅ 所有 187 个单元测试通过

---

This PR was written using [Vibe Kanban](https://vibekanban.com)