### PR TITLE
fix(Migrations): 修复 Alembic 迁移冲突问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
@@ -1,7 +1,7 @@
 """Add plugins tables for MCP, Skills, SubAgents
 
-Revision ID: a1b2c3d4e5f6
-Revises: c1640a4711b5
+Revision ID: d1e2f3a4b5c6
+Revises: c3f4e5a6b7c8
 Create Date: 2026-03-02 10:00:00.000000+00:00
 
 """
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
-down_revision: Union[str, None] = "c1640a4711b5"
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, None] = "c3f4e5a6b7c8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## 问题背景

GitHub Actions 在 `Initialize database schema` 步骤失败，错误信息：
```
Revision a1b2c3d4e5f6 is present more than once
Multiple head revisions are present for given argument 'head'
```

## 修复内容

修复 Alembic 迁移冲突问题：

### 问题分析

1. **重复的 revision ID**: 两个迁移文件使用了相同的 revision ID `a1b2c3d4e5f6`：
   - `a1b2c3d4e5f6_add_created_by_to_knowledge_documents.py`
   - `a1b2c3d4e5f6_add_plugins_tables.py`

2. **多个 head**: `add_plugins_tables.py` 依赖于 `c1640a4711b5`，而该节点已经存在其他下游迁移，导致多个 head

### 具体修改

1. 将 `add_plugins_tables.py` 的 revision ID 从 `a1b2c3d4e5f6` 改为 `d1e2f3a4b5c6`
2. 将 `down_revision` 从 `c1640a4711b5` 改为 `c3f4e5a6b7c8`（当前最新 head）
3. 重命名迁移文件以匹配新的 revision ID

### 修改后的迁移链

```
... → f9a4b3c2d1e6 → a1b2c3d4e5f6 (add_created_by) → c3f4e5a6b7c8 → d1e2f3a4b5c6 (add_plugins_tables)
```

## 测试验证

- ✅ `alembic heads` 现在只显示一个 head：`d1e2f3a4b5c6`
- ✅ 所有 187 个单元测试通过

---

This PR was written using [Vibe Kanban](https://vibekanban.com)