### PR TITLE
fix(Plugins): 补全 MCP Servers/Skills/SubAgents 的 Next.js API 代理路由 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/api/plugins/_proxy.ts
+++ b/apps/negentropy-ui/app/api/plugins/_proxy.ts
@@ -1,0 +1,268 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+
+/**
+ * Plugins API 代理工具函数
+ *
+ * 用于将前端的 /api/plugins/* 请求代理到后端 /plugins/* API
+ */
+
+function getBaseUrl() {
+  return (
+    process.env.AGUI_BASE_URL ||
+    process.env.NEXT_PUBLIC_AGUI_BASE_URL
+  );
+}
+
+function extractForwardHeaders(request: Request) {
+  const headers = buildAuthHeaders(request);
+
+  const auth = request.headers.get("authorization");
+  if (auth) {
+    headers.set("authorization", auth);
+  }
+
+  const sessionId = request.headers.get("x-session-id");
+  if (sessionId) {
+    headers.set("x-session-id", sessionId);
+  }
+
+  const userId = request.headers.get("x-user-id");
+  if (userId) {
+    headers.set("x-user-id", userId);
+  }
+
+  return headers;
+}
+
+function errorResponse(code: string, message: string, status = 500) {
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+      },
+    },
+    { status },
+  );
+}
+
+function upstreamErrorResponse(text: string, status: number) {
+  if (text) {
+    try {
+      const errorJson = JSON.parse(text);
+      if (errorJson && typeof errorJson === "object") {
+        return NextResponse.json(errorJson, { status });
+      }
+    } catch {
+      // fallthrough to generic wrapper
+    }
+  }
+
+  return errorResponse(
+    "PLUGINS_UPSTREAM_ERROR",
+    text || "Upstream returned non-OK status",
+    status,
+  );
+}
+
+export async function proxyGet(request: Request, path: string) {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorResponse(
+      "PLUGINS_INTERNAL_ERROR",
+      "AGUI_BASE_URL is not configured",
+      500,
+    );
+  }
+
+  const upstreamUrl = new URL(path, baseUrl);
+  const incomingUrl = new URL(request.url);
+  upstreamUrl.search = incomingUrl.search;
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "GET",
+      headers: extractForwardHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      `Upstream connection failed: ${String(error)}`,
+      502,
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return upstreamErrorResponse(text, upstreamResponse.status);
+  }
+
+  return NextResponse.json(JSON.parse(text));
+}
+
+export async function proxyPost(request: Request, path: string) {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorResponse(
+      "PLUGINS_INTERNAL_ERROR",
+      "AGUI_BASE_URL is not configured",
+      500,
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_BAD_REQUEST",
+      `Invalid JSON body: ${String(error)}`,
+      400,
+    );
+  }
+
+  const upstreamUrl = new URL(path, baseUrl);
+  const headers = extractForwardHeaders(request);
+  headers.set("content-type", "application/json");
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      `Upstream connection failed: ${String(error)}`,
+      502,
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return upstreamErrorResponse(text, upstreamResponse.status);
+  }
+
+  return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+}
+
+export async function proxyPatch(request: Request, path: string) {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorResponse(
+      "PLUGINS_INTERNAL_ERROR",
+      "AGUI_BASE_URL is not configured",
+      500,
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_BAD_REQUEST",
+      `Invalid JSON body: ${String(error)}`,
+      400,
+    );
+  }
+
+  const upstreamUrl = new URL(path, baseUrl);
+  const headers = extractForwardHeaders(request);
+  headers.set("content-type", "application/json");
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify(body),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      `Upstream connection failed: ${String(error)}`,
+      502,
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    try {
+      const errorJson = JSON.parse(text);
+      return NextResponse.json(errorJson, { status: upstreamResponse.status });
+    } catch {
+      // Fallback if not JSON
+    }
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      text || "Upstream returned non-OK status",
+      upstreamResponse.status,
+    );
+  }
+
+  return NextResponse.json(JSON.parse(text));
+}
+
+export async function proxyDelete(request: Request, path: string) {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorResponse(
+      "PLUGINS_INTERNAL_ERROR",
+      "AGUI_BASE_URL is not configured",
+      500,
+    );
+  }
+
+  const upstreamUrl = new URL(path, baseUrl);
+  const incomingUrl = new URL(request.url);
+  upstreamUrl.search = incomingUrl.search;
+
+  let upstreamResponse: Response;
+  try {
+    const headers = extractForwardHeaders(request);
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "DELETE",
+      headers,
+      cache: "no-store",
+    });
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      `Upstream connection failed: ${String(error)}`,
+      502,
+    );
+  }
+
+  if (upstreamResponse.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    try {
+      const errorJson = JSON.parse(text);
+      return NextResponse.json(errorJson, { status: upstreamResponse.status });
+    } catch {
+      // fallback
+    }
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      text || "Upstream returned non-OK status",
+      upstreamResponse.status,
+    );
+  }
+
+  try {
+    return NextResponse.json(JSON.parse(text));
+  } catch {
+    return new NextResponse(text, { status: upstreamResponse.status });
+  }
+}

--- a/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/route.ts
@@ -1,0 +1,33 @@
+import { proxyGet, proxyPatch, proxyDelete } from "@/app/api/plugins/_proxy";
+
+/**
+ * 单个 MCP Server API 代理端点
+ *
+ * GET    /api/plugins/mcp/servers/{serverId} - 获取 MCP 服务器详情
+ * PATCH  /api/plugins/mcp/servers/{serverId} - 更新 MCP 服务器
+ * DELETE /api/plugins/mcp/servers/{serverId} - 删除 MCP 服务器
+ */
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ serverId: string }> },
+) {
+  const { serverId } = await params;
+  return proxyGet(request, `/plugins/mcp/servers/${serverId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ serverId: string }> },
+) {
+  const { serverId } = await params;
+  return proxyPatch(request, `/plugins/mcp/servers/${serverId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ serverId: string }> },
+) {
+  const { serverId } = await params;
+  return proxyDelete(request, `/plugins/mcp/servers/${serverId}`);
+}

--- a/apps/negentropy-ui/app/api/plugins/mcp/servers/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/mcp/servers/route.ts
@@ -1,0 +1,16 @@
+import { proxyGet, proxyPost } from "@/app/api/plugins/_proxy";
+
+/**
+ * MCP Servers 集合 API 代理端点
+ *
+ * GET  /api/plugins/mcp/servers - 列出 MCP 服务器
+ * POST /api/plugins/mcp/servers - 创建 MCP 服务器
+ */
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/plugins/mcp/servers");
+}
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/plugins/mcp/servers");
+}

--- a/apps/negentropy-ui/app/api/plugins/skills/[skillId]/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/skills/[skillId]/route.ts
@@ -1,0 +1,33 @@
+import { proxyGet, proxyPatch, proxyDelete } from "@/app/api/plugins/_proxy";
+
+/**
+ * 单个 Skill API 代理端点
+ *
+ * GET    /api/plugins/skills/{skillId} - 获取 Skill 详情
+ * PATCH  /api/plugins/skills/{skillId} - 更新 Skill
+ * DELETE /api/plugins/skills/{skillId} - 删除 Skill
+ */
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ skillId: string }> },
+) {
+  const { skillId } = await params;
+  return proxyGet(request, `/plugins/skills/${skillId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ skillId: string }> },
+) {
+  const { skillId } = await params;
+  return proxyPatch(request, `/plugins/skills/${skillId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ skillId: string }> },
+) {
+  const { skillId } = await params;
+  return proxyDelete(request, `/plugins/skills/${skillId}`);
+}

--- a/apps/negentropy-ui/app/api/plugins/skills/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/skills/route.ts
@@ -1,0 +1,16 @@
+import { proxyGet, proxyPost } from "@/app/api/plugins/_proxy";
+
+/**
+ * Skills 集合 API 代理端点
+ *
+ * GET  /api/plugins/skills - 列出 Skills (支持 category 查询参数)
+ * POST /api/plugins/skills - 创建 Skill
+ */
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/plugins/skills");
+}
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/plugins/skills");
+}

--- a/apps/negentropy-ui/app/api/plugins/subagents/[agentId]/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/subagents/[agentId]/route.ts
@@ -1,0 +1,33 @@
+import { proxyGet, proxyPatch, proxyDelete } from "@/app/api/plugins/_proxy";
+
+/**
+ * 单个 SubAgent API 代理端点
+ *
+ * GET    /api/plugins/subagents/{agentId} - 获取 SubAgent 详情
+ * PATCH  /api/plugins/subagents/{agentId} - 更新 SubAgent
+ * DELETE /api/plugins/subagents/{agentId} - 删除 SubAgent
+ */
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  const { agentId } = await params;
+  return proxyGet(request, `/plugins/subagents/${agentId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  const { agentId } = await params;
+  return proxyPatch(request, `/plugins/subagents/${agentId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string }> },
+) {
+  const { agentId } = await params;
+  return proxyDelete(request, `/plugins/subagents/${agentId}`);
+}

--- a/apps/negentropy-ui/app/api/plugins/subagents/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/subagents/route.ts
@@ -1,0 +1,16 @@
+import { proxyGet, proxyPost } from "@/app/api/plugins/_proxy";
+
+/**
+ * SubAgents 集合 API 代理端点
+ *
+ * GET  /api/plugins/subagents - 列出 SubAgents
+ * POST /api/plugins/subagents - 创建 SubAgent
+ */
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/plugins/subagents");
+}
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/plugins/subagents");
+}


### PR DESCRIPTION
## Summary

- 修复 Plugins 页面下 MCP Servers、Skills、SubAgents 子页面在创建/更新/删除时报错 `Unexpected token '<', "<!DOCTYPE "... is not valid JSON` 的问题
- 补全缺失的 Next.js API 代理路由，使前端能够正确代理请求到后端 FastAPI

## Problem

前端调用 `/api/plugins/mcp/servers`、`/api/plugins/skills`、`/api/plugins/subagents` 等路由时，Next.js 缺少对应的 API 代理处理器，导致返回 404 HTML 页面而非 JSON 响应，引发 JSON 解析错误。

## Solution

参照项目中 `knowledge` 模块的代理模式，创建完整的 Plugins API 代理层：

### 新增文件

| 文件 | 描述 |
|------|------|
| `apps/negentropy-ui/app/api/plugins/_proxy.ts` | 通用代理工具函数 (proxyGet/Post/Patch/Delete) |
| `apps/negentropy-ui/app/api/plugins/mcp/servers/route.ts` | MCP Servers 集合路由 (GET/POST) |
| `apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/route.ts` | 单个 MCP Server 路由 (GET/PATCH/DELETE) |
| `apps/negentropy-ui/app/api/plugins/skills/route.ts` | Skills 集合路由 (GET/POST) |
| `apps/negentropy-ui/app/api/plugins/skills/[skillId]/route.ts` | 单个 Skill 路由 (GET/PATCH/DELETE) |
| `apps/negentropy-ui/app/api/plugins/subagents/route.ts` | SubAgents 集合路由 (GET/POST) |
| `apps/negentropy-ui/app/api/plugins/subagents/[agentId]/route.ts` | 单个 SubAgent 路由 (GET/PATCH/DELETE) |

### 实现细节

- 使用 `buildAuthHeaders` 构建认证头，支持 `authorization`、`x-session-id`、`x-user-id` 等请求头转发
- 通过 `AGUI_BASE_URL` 环境变量确定后端地址
- 统一的错误处理：解析后端返回的 JSON 错误信息，或包装为标准错误响应
- 支持 204 No Content 响应处理（DELETE 操作）

## Test Plan

- [ ] 导航到 Plugins / MCP Servers 页面
- [ ] 点击 "Add Server"，填写表单并提交，验证创建成功
- [ ] 编辑已有 Server，验证更新成功
- [ ] 删除 Server，验证删除成功
- [ ] 同样测试 Skills 和 SubAgents 页面的 CRUD 操作

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*