### PR TITLE
fix(Plugins): 修复 Plugins 模块 API 代理路由和数据库迁移枚举类型问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
@@ -25,19 +25,19 @@ def upgrade() -> None:
     # ==========================================================================
     # 首先创建枚举类型
     # ==========================================================================
-    # Create plugin_visibility enum
+    # Create pluginvisibility enum (SQLAlchemy default naming: class name lowercase)
     op.execute("""
         DO $$ BEGIN
-            CREATE TYPE negentropy.plugin_visibility AS ENUM ('private', 'shared', 'public');
+            CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
         EXCEPTION
             WHEN duplicate_object THEN null;
         END $$;
     """)
 
-    # Create plugin_permission_type enum
+    # Create pluginpermissiontype enum (SQLAlchemy default naming: class name lowercase)
     op.execute("""
         DO $$ BEGIN
-            CREATE TYPE negentropy.plugin_permission_type AS ENUM ('view', 'edit');
+            CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
         EXCEPTION
             WHEN duplicate_object THEN null;
         END $$;
@@ -54,7 +54,7 @@ def upgrade() -> None:
         sa.Column("user_id", sa.String(255), nullable=False),
         sa.Column(
             "permission",
-            postgresql.ENUM("view", "edit", name="plugin_permission_type", schema="negentropy"),
+            postgresql.ENUM("view", "edit", name="pluginpermissiontype", schema="negentropy"),
             nullable=False,
             server_default="view",
         ),
@@ -77,7 +77,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="plugin_visibility", schema="negentropy"),
+            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy"),
             nullable=False,
             server_default="private",
         ),
@@ -136,7 +136,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="plugin_visibility", schema="negentropy"),
+            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy"),
             nullable=False,
             server_default="private",
         ),
@@ -173,7 +173,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="plugin_visibility", schema="negentropy"),
+            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy"),
             nullable=False,
             server_default="private",
         ),
@@ -225,6 +225,6 @@ def downgrade() -> None:
     op.drop_index("ix_plugin_permissions_plugin", table_name="plugin_permissions", schema="negentropy")
     op.drop_table("plugin_permissions", schema="negentropy")
 
-    # Drop enums with correct schema
-    op.execute("DROP TYPE IF EXISTS negentropy.plugin_visibility")
-    op.execute("DROP TYPE IF EXISTS negentropy.plugin_permission_type")
+    # Drop enums with correct schema (SQLAlchemy default naming)
+    op.execute("DROP TYPE IF EXISTS negentropy.pluginvisibility")
+    op.execute("DROP TYPE IF EXISTS negentropy.pluginpermissiontype")


### PR DESCRIPTION
## Summary

本 PR 修复了 Plugins 模块（MCP Servers/Skills/SubAgents）的三个关键问题：

1. **Next.js API 代理路由缺失**：前端调用 `/api/plugins/*` 时返回 404 HTML 页面，导致 JSON 解析错误
2. **数据库迁移枚举类型未创建**：PostgreSQL ENUM 类型在迁移时未被创建
3. **枚举类型命名不一致**：迁移文件中的 ENUM 类型名称与 SQLAlchemy ORM 期望的名称不匹配

## Problem

### 问题 1：API 代理路由缺失

错误信息：
```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

**原因**：前端调用 `/api/plugins/mcp/servers` 等路由时，Next.js 缺少对应的 API 代理处理器，返回了默认的 404 HTML 页面。

### 问题 2：数据库迁移枚举类型缺失

错误信息：
```
asyncpg.exceptions.UndefinedObjectError: type "negentropy.pluginvisibility" does not exist
```

**原因**：迁移文件 `d1e2f3a4b5c6_add_plugins_tables.py` 在 `create_table()` 中使用 `postgresql.ENUM()` 时，没有先显式创建 ENUM 类型。

### 问题 3：枚举类型命名不一致

**原因**：SQLAlchemy 在使用 `Enum(PluginVisibility)` 而不指定 `name` 参数时，会将 Python 类名 `PluginVisibility` 转换为全小写 `pluginvisibility` 作为 PostgreSQL ENUM 类型名称，但迁移文件中创建的是 `plugin_visibility`（蛇形命名）。

## Solution

### 修复 1：补全 API 代理路由

参照项目中 `knowledge` 模块的代理模式，创建完整的 Plugins API 代理层：

| 新增文件 | 描述 |
|---------|------|
| `apps/negentropy-ui/app/api/plugins/_proxy.ts` | 通用代理工具函数 |
| `apps/negentropy-ui/app/api/plugins/mcp/servers/route.ts` | MCP Servers GET/POST |
| `apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/route.ts` | MCP Server GET/PATCH/DELETE |
| `apps/negentropy-ui/app/api/plugins/skills/route.ts` | Skills GET/POST |
| `apps/negentropy-ui/app/api/plugins/skills/[skillId]/route.ts` | Skill GET/PATCH/DELETE |
| `apps/negentropy-ui/app/api/plugins/subagents/route.ts` | SubAgents GET/POST |
| `apps/negentropy-ui/app/api/plugins/subagents/[agentId]/route.ts` | SubAgent GET/PATCH/DELETE |

### 修复 2 & 3：修复数据库迁移

在迁移文件 `d1e2f3a4b5c6_add_plugins_tables.py` 中：

1. 在 `upgrade()` 函数开头添加显式的枚举类型创建语句
2. 修正 ENUM 类型名称为 SQLAlchemy 默认命名：
   - `plugin_visibility` → `pluginvisibility`
   - `plugin_permission_type` → `pluginpermissiontype`

```python
# Create pluginvisibility enum (SQLAlchemy default naming: class name lowercase)
op.execute("""
    DO $$ BEGIN
        CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
    EXCEPTION
        WHEN duplicate_object THEN null;
    END $$;
""")
```

## Commits

- `dbe98d5` fix(Plugins): 补全 MCP Servers/Skills/SubAgents 的 Next.js API 代理路由;
- `1d6ec98` fix(Plugins): 修复数据库迁移中枚举类型未创建的问题;
- `053b67c` fix(Plugins): 修复数据库迁移中枚举类型命名不一致问题;

## Test Plan

- [ ] 启动开发服务器：`pnpm dev`
- [ ] 导航到 Plugins / MCP Servers 页面
- [ ] 点击 "Add Server"，填写表单并提交
- [ ] 验证创建成功，无 JSON 解析错误
- [ ] 同样测试 Skills 和 SubAgents 页面的 CRUD 操作

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*