### PR TITLE
fix(Migrations): 修复 ENUM 类型重复创建导致 CI 失败的问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
@@ -54,7 +54,7 @@ def upgrade() -> None:
         sa.Column("user_id", sa.String(255), nullable=False),
         sa.Column(
             "permission",
-            postgresql.ENUM("view", "edit", name="pluginpermissiontype", schema="negentropy"),
+            postgresql.ENUM("view", "edit", name="pluginpermissiontype", schema="negentropy", create_type=False),
             nullable=False,
             server_default="view",
         ),
@@ -77,7 +77,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy"),
+            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy", create_type=False),
             nullable=False,
             server_default="private",
         ),
@@ -136,7 +136,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy"),
+            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy", create_type=False),
             nullable=False,
             server_default="private",
         ),
@@ -173,7 +173,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy"),
+            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy", create_type=False),
             nullable=False,
             server_default="private",
         ),


### PR DESCRIPTION
## Summary

修复 GitHub Actions Workflow 中 "Initialize database schema" 步骤执行失败的问题。

## Changes

在迁移文件 `d1e2f3a4b5c6_add_plugins_tables.py` 中，为所有 `postgresql.ENUM` 调用添加 `create_type=False` 参数：

- `pluginpermissiontype` ENUM (plugin_permissions 表)
- `pluginvisibility` ENUM (mcp_servers, skills, sub_agents 表)

## Root Cause

迁移文件中存在 ENUM 类型重复创建问题：

1. 迁移首先通过 `op.execute()` 手动创建 ENUM 类型（带 `EXCEPTION WHEN duplicate_object` 保护）
2. 随后在 `op.create_table()` 中使用 `postgresql.ENUM(...)` 时，默认 `create_type=True`
3. SQLAlchemy 会再次尝试发出 `CREATE TYPE` 语句
4. 在空数据库（如 CI 环境）中，虽然第一步成功创建了类型，但第二步会因为类型已存在而失败

## Solution

```python
# Before
postgresql.ENUM("view", "edit", name="pluginpermissiontype", schema="negentropy")

# After
postgresql.ENUM("view", "edit", name="pluginpermissiontype", schema="negentropy", create_type=False)
```

添加 `create_type=False` 告诉 SQLAlchemy 不要在 `create_table` 时自动创建 ENUM 类型，因为我们已经手动创建了。

## Verification

- ✅ GitHub Actions Workflow `negentropy-backend-tests` 通过
- ✅ Unit tests 通过
- ✅ Initialize database schema 通过
- ✅ Integration tests 通过
- ✅ Performance tests 通过

**Workflow Run**: https://github.com/ThreeFish-AI/negentropy/actions/runs/22617089749

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*