### PR TITLE
fix(Plugins): 修复迁移脚本中枚举类型重复创建的问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py
@@ -23,29 +23,41 @@ def upgrade() -> None:
     This migration handles the case where the database might have old enum type
     names (snake_case) from previous migrations, and ensures the correct names
     (lowercase class names as per SQLAlchemy default) exist.
+
+    Uses EXCEPTION WHEN duplicate_object to ensure idempotency regardless of
+    the current database state.
     """
 
+    # ==========================================================================
     # 1. Handle plugin_visibility -> pluginvisibility
+    # ==========================================================================
+
+    # Step 1: 重命名旧类型（如果存在）
     op.execute("""
         DO $$ BEGIN
-            -- 如果旧类型存在，重命名为新类型
             IF EXISTS (SELECT 1 FROM pg_type t
                        JOIN pg_namespace n ON t.typnamespace = n.oid
                        WHERE t.typname = 'plugin_visibility' AND n.nspname = 'negentropy')
             THEN
                 ALTER TYPE negentropy.plugin_visibility RENAME TO pluginvisibility;
             END IF;
-            -- 如果新类型不存在（可能从未运行过任何迁移），创建它
-            IF NOT EXISTS (SELECT 1 FROM pg_type t
-                           JOIN pg_namespace n ON t.typnamespace = n.oid
-                           WHERE t.typname = 'pluginvisibility' AND n.nspname = 'negentropy')
-            THEN
-                CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
-            END IF;
         END $$;
     """)
 
+    # Step 2: 确保新类型存在（使用异常捕获保证幂等性）
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # ==========================================================================
     # 2. Handle plugin_permission_type -> pluginpermissiontype
+    # ==========================================================================
+
+    # Step 1: 重命名旧类型（如果存在）
     op.execute("""
         DO $$ BEGIN
             IF EXISTS (SELECT 1 FROM pg_type t
@@ -54,12 +66,15 @@ def upgrade() -> None:
             THEN
                 ALTER TYPE negentropy.plugin_permission_type RENAME TO pluginpermissiontype;
             END IF;
-            IF NOT EXISTS (SELECT 1 FROM pg_type t
-                           JOIN pg_namespace n ON t.typnamespace = n.oid
-                           WHERE t.typname = 'pluginpermissiontype' AND n.nspname = 'negentropy')
-            THEN
-                CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
-            END IF;
+        END $$;
+    """)
+
+    # Step 2: 确保新类型存在（使用异常捕获保证幂等性）
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
         END $$;
     """)
 


### PR DESCRIPTION
## Summary

- 修复 Alembic 迁移脚本 `f1a2b3c4d5e6_fix_enum_type_naming.py` 中枚举类型重复创建导致 `DuplicateObjectError` 的问题
- 将 RENAME 和 CREATE 操作分离到独立的 `DO` 块中，避免事务内的竞态条件
- 使用 `EXCEPTION WHEN duplicate_object` 作为最终保障，确保迁移的幂等性

## Changes

### 问题根因

原迁移脚本中，`IF NOT EXISTS` 检查与 `CREATE TYPE` 存在逻辑问题：

```sql
-- 问题代码：RENAME 和 CREATE 在同一个 DO 块中
DO $$ BEGIN
    IF EXISTS (旧类型) THEN
        ALTER TYPE ... RENAME TO ...;
    END IF;
    IF NOT EXISTS (新类型) THEN  -- 检查可能失效
        CREATE TYPE ...;
    END IF;
END $$;
```

当 `pluginvisibility` 已存在时，`CREATE TYPE` 仍然被执行，抛出 `DuplicateObjectError`。

### 修复方案

采用与 `d1e2f3a4b5c6_add_plugins_tables.py` 相同的成功模式：

```sql
-- Step 1: 重命名旧类型（独立 DO 块）
DO $$ BEGIN
    IF EXISTS (旧类型) THEN
        ALTER TYPE ... RENAME TO ...;
    END IF;
END $$;

-- Step 2: 确保新类型存在（使用异常捕获保证幂等性）
DO $$ BEGIN
    CREATE TYPE ...;
EXCEPTION
    WHEN duplicate_object THEN null;
END $$;
```

### 涉及的枚举类型

| Python 类名 | PostgreSQL 类型名 | 枚举值 |
|------------|------------------|--------|
| `PluginVisibility` | `negentropy.pluginvisibility` | `'private', 'shared', 'public'` |
| `PluginPermissionType` | `negentropy.pluginpermissiontype` | `'view', 'edit'` |

## Test plan

- [x] 运行 `uv run alembic upgrade head` 验证迁移成功
- [ ] 验证枚举类型存在：
  ```sql
  SELECT typname FROM pg_type t
  JOIN pg_namespace n ON t.typnamespace = n.oid
  WHERE n.nspname = 'negentropy' AND typname IN ('pluginvisibility', 'pluginpermissiontype');
  ```
- [ ] 验证应用启动正常

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*