### PR TITLE
fix(Migrations): 修复 ENUM 类型迁移脚本的幂等性问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py
@@ -24,32 +24,45 @@ def upgrade() -> None:
     names (snake_case) from previous migrations, and ensures the correct names
     (lowercase class names as per SQLAlchemy default) exist.
 
-    Uses EXCEPTION WHEN duplicate_object to ensure idempotency regardless of
-    the current database state.
+    Uses conditional logic to ensure idempotency regardless of the current
+    database state. Key scenarios:
+    1. Old type exists, new type doesn't exist -> RENAME
+    2. Both old and new types exist -> DROP old, keep new
+    3. Only new type exists -> No-op
+    4. Neither exists -> CREATE new
     """
 
     # ==========================================================================
     # 1. Handle plugin_visibility -> pluginvisibility
     # ==========================================================================
 
-    # Step 1: 重命名旧类型（如果存在）
     op.execute("""
         DO $$ BEGIN
+            -- Check if old type exists
             IF EXISTS (SELECT 1 FROM pg_type t
                        JOIN pg_namespace n ON t.typnamespace = n.oid
                        WHERE t.typname = 'plugin_visibility' AND n.nspname = 'negentropy')
             THEN
-                ALTER TYPE negentropy.plugin_visibility RENAME TO pluginvisibility;
+                -- Check if new type also exists
+                IF EXISTS (SELECT 1 FROM pg_type t
+                           JOIN pg_namespace n ON t.typnamespace = n.oid
+                           WHERE t.typname = 'pluginvisibility' AND n.nspname = 'negentropy')
+                THEN
+                    -- Both exist: drop old type (new type takes precedence)
+                    DROP TYPE negentropy.plugin_visibility CASCADE;
+                ELSE
+                    -- Only old exists: rename to new
+                    ALTER TYPE negentropy.plugin_visibility RENAME TO pluginvisibility;
+                END IF;
+            ELSE
+                -- Old type doesn't exist, ensure new type exists
+                IF NOT EXISTS (SELECT 1 FROM pg_type t
+                               JOIN pg_namespace n ON t.typnamespace = n.oid
+                               WHERE t.typname = 'pluginvisibility' AND n.nspname = 'negentropy')
+                THEN
+                    CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
+                END IF;
             END IF;
-        END $$;
-    """)
-
-    # Step 2: 确保新类型存在（使用异常捕获保证幂等性）
-    op.execute("""
-        DO $$ BEGIN
-            CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
-        EXCEPTION
-            WHEN duplicate_object THEN null;
         END $$;
     """)
 
@@ -57,24 +70,33 @@ def upgrade() -> None:
     # 2. Handle plugin_permission_type -> pluginpermissiontype
     # ==========================================================================
 
-    # Step 1: 重命名旧类型（如果存在）
     op.execute("""
         DO $$ BEGIN
+            -- Check if old type exists
             IF EXISTS (SELECT 1 FROM pg_type t
                        JOIN pg_namespace n ON t.typnamespace = n.oid
                        WHERE t.typname = 'plugin_permission_type' AND n.nspname = 'negentropy')
             THEN
-                ALTER TYPE negentropy.plugin_permission_type RENAME TO pluginpermissiontype;
+                -- Check if new type also exists
+                IF EXISTS (SELECT 1 FROM pg_type t
+                           JOIN pg_namespace n ON t.typnamespace = n.oid
+                           WHERE t.typname = 'pluginpermissiontype' AND n.nspname = 'negentropy')
+                THEN
+                    -- Both exist: drop old type (new type takes precedence)
+                    DROP TYPE negentropy.plugin_permission_type CASCADE;
+                ELSE
+                    -- Only old exists: rename to new
+                    ALTER TYPE negentropy.plugin_permission_type RENAME TO pluginpermissiontype;
+                END IF;
+            ELSE
+                -- Old type doesn't exist, ensure new type exists
+                IF NOT EXISTS (SELECT 1 FROM pg_type t
+                               JOIN pg_namespace n ON t.typnamespace = n.oid
+                               WHERE t.typname = 'pluginpermissiontype' AND n.nspname = 'negentropy')
+                THEN
+                    CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
+                END IF;
             END IF;
-        END $$;
-    """)
-
-    # Step 2: 确保新类型存在（使用异常捕获保证幂等性）
-    op.execute("""
-        DO $$ BEGIN
-            CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
-        EXCEPTION
-            WHEN duplicate_object THEN null;
         END $$;
     """)
 


### PR DESCRIPTION
## Summary

修复数据库迁移中 ENUM 类型重复创建导致的 `DuplicateObjectError` 错误。

## Problem

执行 `alembic upgrade head` 时，迁移脚本 `f1a2b3c4d5e6_fix_enum_type_naming.py` 尝试将旧的 `plugin_visibility` 类型重命名为 `pluginvisibility`，但由于 `d1e2f3a4b5c6_add_plugins_tables.py` 已经创建了 `pluginvisibility` 类型，导致 `ALTER TYPE ... RENAME TO` 失败。

PostgreSQL 的 RENAME TO 不支持目标名称已存在的情况，无法通过 EXCEPTION 捕获此错误。

## Solution

重写 `f1a2b3c4d5e6_fix_enum_type_naming.py` 迁移脚本，使用条件判断替代异常捕获，处理四种场景：

| 场景 | 操作 |
|------|------|
| 旧类型存在，新类型不存在 | 重命名旧类型 → 新类型 |
| 新旧类型都存在 | 删除旧类型（保留新类型） |
| 只有新类型存在 | 无操作 |
| 都不存在 | 创建新类型 |

## Changes

- `apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py` - 重写 upgrade() 函数

## Verification

- ✅ 完整迁移测试通过 (`alembic upgrade head`)
- ✅ 幂等性验证通过（重复执行无错误）
- ✅ 回滚后重新升级测试通过

---

This PR was written using [Vibe Kanban](https://vibekanban.com)