### PR TITLE
fix(Plugins): 修复 MCP Server 创建时 ENUM 类型大小写不匹配问题 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/a2b3c4d5e6f7_fix_enum_values_case.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/a2b3c4d5e6f7_fix_enum_values_case.py
@@ -1,0 +1,257 @@
+"""Fix enum values case to match SQLAlchemy behavior
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-03-03 21:30:00.000000+08:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Fix enum values case to match SQLAlchemy default behavior.
+
+    SQLAlchemy uses the enum's name (e.g., 'PRIVATE') rather than its value
+    (e.g., 'private') when serializing to PostgreSQL. This migration updates
+    the database enum values to use uppercase to match SQLAlchemy's behavior.
+
+    Reference: https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum
+    """
+
+    # ==========================================================================
+    # 1. Fix pluginvisibility enum: lowercase -> uppercase
+    # ==========================================================================
+
+    # Step 1: Create new enum type with uppercase values
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE negentropy.pluginvisibility_new AS ENUM ('PRIVATE', 'SHARED', 'PUBLIC');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Step 2: Update mcp_servers.visibility column
+    # Drop default first, then alter type, then set new default
+    op.execute("ALTER TABLE negentropy.mcp_servers ALTER COLUMN visibility DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.mcp_servers
+        ALTER COLUMN visibility TYPE text
+        USING visibility::text
+    """)
+    op.execute("""
+        UPDATE negentropy.mcp_servers
+        SET visibility = UPPER(visibility)
+        WHERE visibility IN ('private', 'shared', 'public')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.mcp_servers
+        ALTER COLUMN visibility TYPE negentropy.pluginvisibility_new
+        USING visibility::negentropy.pluginvisibility_new
+    """)
+    op.execute("ALTER TABLE negentropy.mcp_servers ALTER COLUMN visibility SET DEFAULT 'PRIVATE'::negentropy.pluginvisibility_new")
+
+    # Step 3: Update skills.visibility column
+    op.execute("ALTER TABLE negentropy.skills ALTER COLUMN visibility DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.skills
+        ALTER COLUMN visibility TYPE text
+        USING visibility::text
+    """)
+    op.execute("""
+        UPDATE negentropy.skills
+        SET visibility = UPPER(visibility)
+        WHERE visibility IN ('private', 'shared', 'public')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.skills
+        ALTER COLUMN visibility TYPE negentropy.pluginvisibility_new
+        USING visibility::negentropy.pluginvisibility_new
+    """)
+    op.execute("ALTER TABLE negentropy.skills ALTER COLUMN visibility SET DEFAULT 'PRIVATE'::negentropy.pluginvisibility_new")
+
+    # Step 4: Update sub_agents.visibility column
+    op.execute("ALTER TABLE negentropy.sub_agents ALTER COLUMN visibility DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.sub_agents
+        ALTER COLUMN visibility TYPE text
+        USING visibility::text
+    """)
+    op.execute("""
+        UPDATE negentropy.sub_agents
+        SET visibility = UPPER(visibility)
+        WHERE visibility IN ('private', 'shared', 'public')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.sub_agents
+        ALTER COLUMN visibility TYPE negentropy.pluginvisibility_new
+        USING visibility::negentropy.pluginvisibility_new
+    """)
+    op.execute("ALTER TABLE negentropy.sub_agents ALTER COLUMN visibility SET DEFAULT 'PRIVATE'::negentropy.pluginvisibility_new")
+
+    # Step 5: Drop old enum and rename new one
+    op.execute("DROP TYPE negentropy.pluginvisibility")
+    op.execute("ALTER TYPE negentropy.pluginvisibility_new RENAME TO pluginvisibility")
+
+    # ==========================================================================
+    # 2. Fix pluginpermissiontype enum: lowercase -> uppercase
+    # ==========================================================================
+
+    # Step 1: Create new enum type with uppercase values
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE negentropy.pluginpermissiontype_new AS ENUM ('VIEW', 'EDIT');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Step 2: Update plugin_permissions.permission column
+    op.execute("ALTER TABLE negentropy.plugin_permissions ALTER COLUMN permission DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.plugin_permissions
+        ALTER COLUMN permission TYPE text
+        USING permission::text
+    """)
+    op.execute("""
+        UPDATE negentropy.plugin_permissions
+        SET permission = UPPER(permission)
+        WHERE permission IN ('view', 'edit')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.plugin_permissions
+        ALTER COLUMN permission TYPE negentropy.pluginpermissiontype_new
+        USING permission::negentropy.pluginpermissiontype_new
+    """)
+    op.execute("ALTER TABLE negentropy.plugin_permissions ALTER COLUMN permission SET DEFAULT 'VIEW'::negentropy.pluginpermissiontype_new")
+
+    # Step 3: Drop old enum and rename new one
+    op.execute("DROP TYPE negentropy.pluginpermissiontype")
+    op.execute("ALTER TYPE negentropy.pluginpermissiontype_new RENAME TO pluginpermissiontype")
+
+
+def downgrade() -> None:
+    """Revert enum values to lowercase.
+
+    This downgrade is provided for completeness but should be used with caution
+    as it may cause issues with SQLAlchemy's default enum handling.
+    """
+
+    # ==========================================================================
+    # 1. Revert pluginvisibility enum: uppercase -> lowercase
+    # ==========================================================================
+
+    # Step 1: Create new enum type with lowercase values
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE negentropy.pluginvisibility_new AS ENUM ('private', 'shared', 'public');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Step 2: Update mcp_servers.visibility column
+    op.execute("ALTER TABLE negentropy.mcp_servers ALTER COLUMN visibility DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.mcp_servers
+        ALTER COLUMN visibility TYPE text
+        USING visibility::text
+    """)
+    op.execute("""
+        UPDATE negentropy.mcp_servers
+        SET visibility = LOWER(visibility)
+        WHERE visibility IN ('PRIVATE', 'SHARED', 'PUBLIC')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.mcp_servers
+        ALTER COLUMN visibility TYPE negentropy.pluginvisibility_new
+        USING visibility::negentropy.pluginvisibility_new
+    """)
+    op.execute("ALTER TABLE negentropy.mcp_servers ALTER COLUMN visibility SET DEFAULT 'private'::negentropy.pluginvisibility_new")
+
+    # Step 3: Update skills.visibility column
+    op.execute("ALTER TABLE negentropy.skills ALTER COLUMN visibility DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.skills
+        ALTER COLUMN visibility TYPE text
+        USING visibility::text
+    """)
+    op.execute("""
+        UPDATE negentropy.skills
+        SET visibility = LOWER(visibility)
+        WHERE visibility IN ('PRIVATE', 'SHARED', 'PUBLIC')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.skills
+        ALTER COLUMN visibility TYPE negentropy.pluginvisibility_new
+        USING visibility::negentropy.pluginvisibility_new
+    """)
+    op.execute("ALTER TABLE negentropy.skills ALTER COLUMN visibility SET DEFAULT 'private'::negentropy.pluginvisibility_new")
+
+    # Step 4: Update sub_agents.visibility column
+    op.execute("ALTER TABLE negentropy.sub_agents ALTER COLUMN visibility DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.sub_agents
+        ALTER COLUMN visibility TYPE text
+        USING visibility::text
+    """)
+    op.execute("""
+        UPDATE negentropy.sub_agents
+        SET visibility = LOWER(visibility)
+        WHERE visibility IN ('PRIVATE', 'SHARED', 'PUBLIC')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.sub_agents
+        ALTER COLUMN visibility TYPE negentropy.pluginvisibility_new
+        USING visibility::negentropy.pluginvisibility_new
+    """)
+    op.execute("ALTER TABLE negentropy.sub_agents ALTER COLUMN visibility SET DEFAULT 'private'::negentropy.pluginvisibility_new")
+
+    # Step 5: Drop old enum and rename new one
+    op.execute("DROP TYPE negentropy.pluginvisibility")
+    op.execute("ALTER TYPE negentropy.pluginvisibility_new RENAME TO pluginvisibility")
+
+    # ==========================================================================
+    # 2. Revert pluginpermissiontype enum: uppercase -> lowercase
+    # ==========================================================================
+
+    # Step 1: Create new enum type with lowercase values
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE negentropy.pluginpermissiontype_new AS ENUM ('view', 'edit');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Step 2: Update plugin_permissions.permission column
+    op.execute("ALTER TABLE negentropy.plugin_permissions ALTER COLUMN permission DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE negentropy.plugin_permissions
+        ALTER COLUMN permission TYPE text
+        USING permission::text
+    """)
+    op.execute("""
+        UPDATE negentropy.plugin_permissions
+        SET permission = LOWER(permission)
+        WHERE permission IN ('VIEW', 'EDIT')
+    """)
+    op.execute("""
+        ALTER TABLE negentropy.plugin_permissions
+        ALTER COLUMN permission TYPE negentropy.pluginpermissiontype_new
+        USING permission::negentropy.pluginpermissiontype_new
+    """)
+    op.execute("ALTER TABLE negentropy.plugin_permissions ALTER COLUMN permission SET DEFAULT 'view'::negentropy.pluginpermissiontype_new")
+
+    # Step 3: Drop old enum and rename new one
+    op.execute("DROP TYPE negentropy.pluginpermissiontype")
+    op.execute("ALTER TYPE negentropy.pluginpermissiontype_new RENAME TO pluginpermissiontype")

--- a/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/d1e2f3a4b5c6_add_plugins_tables.py
@@ -26,18 +26,20 @@ def upgrade() -> None:
     # 首先创建枚举类型
     # ==========================================================================
     # Create pluginvisibility enum (SQLAlchemy default naming: class name lowercase)
+    # Note: SQLAlchemy uses enum member names (UPPERCASE) when serializing to PostgreSQL
     op.execute("""
         DO $$ BEGIN
-            CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
+            CREATE TYPE negentropy.pluginvisibility AS ENUM ('PRIVATE', 'SHARED', 'PUBLIC');
         EXCEPTION
             WHEN duplicate_object THEN null;
         END $$;
     """)
 
     # Create pluginpermissiontype enum (SQLAlchemy default naming: class name lowercase)
+    # Note: SQLAlchemy uses enum member names (UPPERCASE) when serializing to PostgreSQL
     op.execute("""
         DO $$ BEGIN
-            CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
+            CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('VIEW', 'EDIT');
         EXCEPTION
             WHEN duplicate_object THEN null;
         END $$;
@@ -54,9 +56,9 @@ def upgrade() -> None:
         sa.Column("user_id", sa.String(255), nullable=False),
         sa.Column(
             "permission",
-            postgresql.ENUM("view", "edit", name="pluginpermissiontype", schema="negentropy", create_type=False),
+            postgresql.ENUM("VIEW", "EDIT", name="pluginpermissiontype", schema="negentropy", create_type=False),
             nullable=False,
-            server_default="view",
+            server_default="VIEW",
         ),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
@@ -77,9 +79,9 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy", create_type=False),
+            postgresql.ENUM("PRIVATE", "SHARED", "PUBLIC", name="pluginvisibility", schema="negentropy", create_type=False),
             nullable=False,
-            server_default="private",
+            server_default="PRIVATE",
         ),
         # Basic info
         sa.Column("name", sa.String(255), nullable=False),
@@ -136,9 +138,9 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy", create_type=False),
+            postgresql.ENUM("PRIVATE", "SHARED", "PUBLIC", name="pluginvisibility", schema="negentropy", create_type=False),
             nullable=False,
-            server_default="private",
+            server_default="PRIVATE",
         ),
         # Basic info
         sa.Column("name", sa.String(255), nullable=False),
@@ -173,9 +175,9 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.String(255), nullable=False),
         sa.Column(
             "visibility",
-            postgresql.ENUM("private", "shared", "public", name="pluginvisibility", schema="negentropy", create_type=False),
+            postgresql.ENUM("PRIVATE", "SHARED", "PUBLIC", name="pluginvisibility", schema="negentropy", create_type=False),
             nullable=False,
-            server_default="private",
+            server_default="PRIVATE",
         ),
         # Basic info
         sa.Column("name", sa.String(255), nullable=False),

--- a/apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/f1a2b3c4d5e6_fix_enum_type_naming.py
@@ -60,7 +60,7 @@ def upgrade() -> None:
                                JOIN pg_namespace n ON t.typnamespace = n.oid
                                WHERE t.typname = 'pluginvisibility' AND n.nspname = 'negentropy')
                 THEN
-                    CREATE TYPE negentropy.pluginvisibility AS ENUM ('private', 'shared', 'public');
+                    CREATE TYPE negentropy.pluginvisibility AS ENUM ('PRIVATE', 'SHARED', 'PUBLIC');
                 END IF;
             END IF;
         END $$;
@@ -94,7 +94,7 @@ def upgrade() -> None:
                                JOIN pg_namespace n ON t.typnamespace = n.oid
                                WHERE t.typname = 'pluginpermissiontype' AND n.nspname = 'negentropy')
                 THEN
-                    CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('view', 'edit');
+                    CREATE TYPE negentropy.pluginpermissiontype AS ENUM ('VIEW', 'EDIT');
                 END IF;
             END IF;
         END $$;


### PR DESCRIPTION
## 问题背景

在 Plugins / MCP Servers / Add MCP Server 页面点击 Create 时，出现 \`Failed to save server\` 错误。服务端日志显示：

\`\`\`
asyncpg.exceptions.InvalidTextRepresentationError: invalid input value for enum negentropy.pluginvisibility: "PRIVATE"
\`\`\`

## 根因分析

SQLAlchemy 在序列化 Python 枚举值 \`PluginVisibility\` 时，使用枚举的 **name**（如 \`PRIVATE\`）而非 **value**（如 \`private\`），而数据库中的 ENUM 类型定义为小写值（\`'private'\`, \`'shared'\`, \`'public'\`），导致类型不匹配错误。

## 修复方案

1. **创建新的迁移脚本** (\`a2b3c4d5e6f7_fix_enum_values_case.py\`)
   - 将 \`pluginvisibility\` 枚举值从 \`'private', 'shared', 'public'\` 改为 \`'PRIVATE', 'SHARED', 'PUBLIC'\`
   - 将 \`pluginpermissiontype\` 枚举值从 \`'view', 'edit'\` 改为 \`'VIEW', 'EDIT'\`
   - 迁移过程中正确处理了列默认值的删除和重新设置

2. **更新初始迁移脚本** (\`d1e2f3a4b5c6_add_plugins_tables.py\`)
   - 枚举创建语句中的值改为大写
   - 所有表的 \`server_default\` 值改为大写

3. **更新命名修复迁移脚本** (\`f1a2b3c4d5e6_fix_enum_type_naming.py\`)
   - 枚举创建语句中的值改为大写

## 技术细节

- 迁移脚本采用幂等性设计，使用 \`EXCEPTION WHEN duplicate_object\` 处理重复创建
- 数据类型转换通过临时转换为 \`text\` 类型，更新值后重新转换回枚举类型
- 默认值处理：先 \`DROP DEFAULT\`，完成类型转换后再 \`SET DEFAULT\`

## 影响范围

- \`PluginVisibility\` 枚举被以下模型使用：
  - \`McpServer\`
  - \`Skill\`
  - \`SubAgent\`
- \`PluginPermissionType\` 枚举被以下模型使用：
  - \`PluginPermission\`

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*