### PR TITLE
feat(Plugins): 优化 MCP Server 工具卡片的 Markdown/JSON 渲染与 Schema 表格展示 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -1,6 +1,410 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { JsonViewer } from "@/components/ui/JsonViewer";
+
+const MARKDOWN_CONTENT_CLASS = [
+  "space-y-2 overflow-hidden break-words whitespace-normal text-sm leading-relaxed",
+  "[&>p]:mb-2 [&>p:last-child]:mb-0",
+  "[&_a]:text-blue-600 [&_a]:underline [&_a]:underline-offset-2 dark:[&_a]:text-blue-400",
+  "[&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-5",
+  "[&_ol]:list-decimal [&_ol]:space-y-1 [&_ol]:pl-5",
+  "[&_li]:leading-relaxed",
+  "[&_h1]:text-base [&_h1]:font-semibold [&_h1]:mb-2",
+  "[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mb-2",
+  "[&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mb-1",
+  "[&_code]:rounded [&_code]:bg-zinc-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs dark:[&_code]:bg-zinc-800",
+  "[&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-zinc-950 [&_pre]:p-3 [&_pre]:text-zinc-100 dark:[&_pre]:bg-zinc-900",
+  "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
+  "[&_table]:my-3 [&_table]:w-full [&_table]:border-collapse [&_table]:text-xs",
+  "[&_th]:border [&_th]:border-zinc-200 [&_th]:bg-zinc-100 [&_th]:px-2 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-medium [&_th]:text-zinc-700",
+  "[&_td]:border [&_td]:border-zinc-200 [&_td]:px-2 [&_td]:py-1.5 [&_td]:align-top [&_td]:text-zinc-600",
+  "dark:[&_th]:border-zinc-700 dark:[&_th]:bg-zinc-800 dark:[&_th]:text-zinc-200",
+  "dark:[&_td]:border-zinc-700 dark:[&_td]:text-zinc-300",
+].join(" ");
+
+type ParsedContent =
+  | { kind: "empty" }
+  | { kind: "json"; value: unknown }
+  | { kind: "markdown"; value: string };
+
+interface SchemaFieldRow {
+  path: string;
+  type: string;
+  required: boolean;
+  description: string;
+  constraints: string;
+}
+
+interface JsonSchemaNode {
+  type?: string | string[];
+  description?: string;
+  default?: unknown;
+  enum?: unknown[];
+  format?: string;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  minItems?: number;
+  maxItems?: number;
+  pattern?: string;
+  additionalProperties?: boolean | JsonSchemaNode;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  items?: JsonSchemaNode | JsonSchemaNode[];
+  oneOf?: JsonSchemaNode[];
+  anyOf?: JsonSchemaNode[];
+  allOf?: JsonSchemaNode[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseContent(content: string | null | undefined): ParsedContent {
+  if (!content || content.trim().length === 0) {
+    return { kind: "empty" };
+  }
+
+  const trimmed = content.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed) || isRecord(parsed)) {
+        return { kind: "json", value: parsed };
+      }
+    } catch {
+      // ignore parse error and fallback to markdown rendering
+    }
+  }
+
+  return { kind: "markdown", value: content };
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getSchemaNode(value: unknown): JsonSchemaNode | null {
+  return isRecord(value) ? (value as JsonSchemaNode) : null;
+}
+
+function getArrayItemSchema(
+  items: JsonSchemaNode | JsonSchemaNode[] | undefined
+): JsonSchemaNode | null {
+  if (!items) {
+    return null;
+  }
+  if (Array.isArray(items)) {
+    const candidate = items.find((item) => isRecord(item));
+    return candidate ? (candidate as JsonSchemaNode) : null;
+  }
+  return isRecord(items) ? (items as JsonSchemaNode) : null;
+}
+
+function getComposedNodes(node: JsonSchemaNode): JsonSchemaNode[] {
+  return [
+    ...(Array.isArray(node.anyOf) ? node.anyOf : []),
+    ...(Array.isArray(node.oneOf) ? node.oneOf : []),
+    ...(Array.isArray(node.allOf) ? node.allOf : []),
+  ];
+}
+
+function normalizeType(node: JsonSchemaNode): string {
+  if (Array.isArray(node.type) && node.type.length > 0) {
+    return node.type.join(" | ");
+  }
+
+  if (typeof node.type === "string") {
+    if (node.type === "array") {
+      const itemSchema = getArrayItemSchema(node.items);
+      if (itemSchema) {
+        const itemType = normalizeType(itemSchema);
+        return itemType === "unknown" ? "array" : `array<${itemType}>`;
+      }
+    }
+    return node.type;
+  }
+
+  const composedNodes = getComposedNodes(node);
+  if (composedNodes.length > 0) {
+    const composedTypes = Array.from(
+      new Set(
+        composedNodes
+          .map((item) => normalizeType(item))
+          .filter((item) => item.length > 0 && item !== "unknown")
+      )
+    );
+    if (composedTypes.length > 0) {
+      return composedTypes.join(" | ");
+    }
+  }
+
+  if (node.enum && node.enum.length > 0) {
+    return "enum";
+  }
+  if (isRecord(node.properties)) {
+    return "object";
+  }
+  if (node.items) {
+    return "array";
+  }
+  return "unknown";
+}
+
+function buildConstraints(node: JsonSchemaNode): string {
+  const parts: string[] = [];
+  if (node.format) {
+    parts.push(`format: ${node.format}`);
+  }
+  if (Array.isArray(node.enum) && node.enum.length > 0) {
+    parts.push(`enum: ${node.enum.map((item) => formatValue(item)).join(", ")}`);
+  }
+  if (typeof node.minimum === "number") {
+    parts.push(`minimum: ${node.minimum}`);
+  }
+  if (typeof node.maximum === "number") {
+    parts.push(`maximum: ${node.maximum}`);
+  }
+  if (typeof node.minLength === "number") {
+    parts.push(`minLength: ${node.minLength}`);
+  }
+  if (typeof node.maxLength === "number") {
+    parts.push(`maxLength: ${node.maxLength}`);
+  }
+  if (typeof node.minItems === "number") {
+    parts.push(`minItems: ${node.minItems}`);
+  }
+  if (typeof node.maxItems === "number") {
+    parts.push(`maxItems: ${node.maxItems}`);
+  }
+  if (typeof node.pattern === "string" && node.pattern.length > 0) {
+    parts.push(`pattern: ${node.pattern}`);
+  }
+  if (typeof node.additionalProperties === "boolean") {
+    parts.push(`additionalProperties: ${node.additionalProperties}`);
+  } else if (isRecord(node.additionalProperties)) {
+    parts.push("additionalProperties: object");
+  }
+  if (node.default !== undefined) {
+    parts.push(`default: ${formatValue(node.default)}`);
+  }
+  return parts.join(" | ");
+}
+
+function collectSchemaRows(schema: Record<string, unknown>): SchemaFieldRow[] {
+  const root = getSchemaNode(schema);
+  if (!root) {
+    return [];
+  }
+
+  const rows: SchemaFieldRow[] = [];
+  const pathSeen = new Set<string>();
+
+  const walkObjectSchema = (node: JsonSchemaNode, basePath = "") => {
+    const properties = isRecord(node.properties) ? node.properties : null;
+    if (!properties) {
+      return;
+    }
+
+    const requiredSet = new Set(
+      Array.isArray(node.required)
+        ? node.required.filter(
+            (item): item is string => typeof item === "string" && item.length > 0
+          )
+        : []
+    );
+
+    for (const [fieldName, rawChild] of Object.entries(properties)) {
+      const child = getSchemaNode(rawChild);
+      if (!child) {
+        continue;
+      }
+
+      const path = basePath ? `${basePath}.${fieldName}` : fieldName;
+      if (!pathSeen.has(path)) {
+        pathSeen.add(path);
+        rows.push({
+          path,
+          type: normalizeType(child),
+          required: requiredSet.has(fieldName),
+          description: child.description ?? "",
+          constraints: buildConstraints(child),
+        });
+      }
+
+      if (isRecord(child.properties)) {
+        walkObjectSchema(child, path);
+      }
+
+      const arrayItemSchema = getArrayItemSchema(child.items);
+      if (arrayItemSchema && isRecord(arrayItemSchema.properties)) {
+        walkObjectSchema(arrayItemSchema, `${path}[]`);
+      }
+
+      for (const composedSchema of getComposedNodes(child)) {
+        if (isRecord(composedSchema.properties)) {
+          walkObjectSchema(composedSchema, path);
+        }
+        const composedItemSchema = getArrayItemSchema(composedSchema.items);
+        if (composedItemSchema && isRecord(composedItemSchema.properties)) {
+          walkObjectSchema(composedItemSchema, `${path}[]`);
+        }
+      }
+    }
+  };
+
+  walkObjectSchema(root);
+
+  if (rows.length === 0) {
+    for (const item of getComposedNodes(root)) {
+      walkObjectSchema(item);
+    }
+  }
+
+  return rows;
+}
+
+function RichTextContent({
+  content,
+  emptyText,
+}: {
+  content: string | null;
+  emptyText: string;
+}) {
+  const parsed = useMemo(() => parseContent(content), [content]);
+
+  if (parsed.kind === "empty") {
+    return (
+      <p className="text-sm text-zinc-500 dark:text-zinc-400">{emptyText}</p>
+    );
+  }
+
+  if (parsed.kind === "json") {
+    return (
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-900/70">
+        <JsonViewer data={parsed.value} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${MARKDOWN_CONTENT_CLASS} text-zinc-600 dark:text-zinc-300`}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{parsed.value}</ReactMarkdown>
+    </div>
+  );
+}
+
+function InputSchemaSection({ schema }: { schema: Record<string, unknown> }) {
+  const rows = useMemo(() => collectSchemaRows(schema), [schema]);
+
+  if (Object.keys(schema).length === 0) {
+    return null;
+  }
+
+  const requiredCount = rows.filter((row) => row.required).length;
+
+  return (
+    <div className="mt-3 rounded-lg border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+        <span className="font-medium text-zinc-700 dark:text-zinc-300">
+          Input Schema
+        </span>
+        {rows.length > 0 && (
+          <span className="inline-flex items-center rounded-full bg-zinc-200 px-2 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+            {rows.length} fields
+          </span>
+        )}
+        {requiredCount > 0 && (
+          <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+            {requiredCount} required
+          </span>
+        )}
+      </div>
+
+      {rows.length > 0 ? (
+        <div className="overflow-x-auto rounded-md border border-zinc-200 dark:border-zinc-700">
+          <table className="min-w-[640px] w-full text-left text-xs">
+            <thead className="bg-zinc-100 dark:bg-zinc-800/70">
+              <tr>
+                <th className="px-3 py-2 font-medium text-zinc-600 dark:text-zinc-300">
+                  Field
+                </th>
+                <th className="px-3 py-2 font-medium text-zinc-600 dark:text-zinc-300">
+                  Type
+                </th>
+                <th className="px-3 py-2 font-medium text-zinc-600 dark:text-zinc-300">
+                  Required
+                </th>
+                <th className="px-3 py-2 font-medium text-zinc-600 dark:text-zinc-300">
+                  Description
+                </th>
+                <th className="px-3 py-2 font-medium text-zinc-600 dark:text-zinc-300">
+                  Constraints
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 bg-white dark:divide-zinc-700 dark:bg-zinc-900">
+              {rows.map((row) => (
+                <tr key={row.path}>
+                  <td className="px-3 py-2 font-mono text-zinc-700 dark:text-zinc-200">
+                    {row.path}
+                  </td>
+                  <td className="px-3 py-2 text-zinc-600 dark:text-zinc-300">
+                    {row.type}
+                  </td>
+                  <td className="px-3 py-2">
+                    {row.required ? (
+                      <span className="text-rose-600 dark:text-rose-400">Yes</span>
+                    ) : (
+                      <span className="text-zinc-400">No</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-zinc-600 dark:text-zinc-300">
+                    {row.description || "-"}
+                  </td>
+                  <td className="px-3 py-2 text-zinc-500 dark:text-zinc-400">
+                    {row.constraints || "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-xs text-zinc-500 dark:text-zinc-400">
+          Schema structure cannot be flattened. Use raw JSON view below.
+        </p>
+      )}
+
+      <details className="mt-3">
+        <summary className="cursor-pointer text-xs text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-300">
+          Raw JSON
+        </summary>
+        <div className="mt-2 rounded-md border border-zinc-200 bg-white p-2 dark:border-zinc-700 dark:bg-zinc-900">
+          <JsonViewer data={schema} />
+        </div>
+      </details>
+    </div>
+  );
+}
 
 interface McpServer {
   id: string;
@@ -53,7 +457,7 @@ export function McpServerCard({
   const [showTools, setShowTools] = useState(false);
 
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+    <div className="rounded-2xl border border-zinc-200/80 bg-gradient-to-b from-white to-zinc-50/60 p-4 shadow-sm transition-shadow hover:shadow-md dark:border-zinc-700/80 dark:from-zinc-900 dark:to-zinc-900">
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-1">
@@ -73,9 +477,12 @@ export function McpServerCard({
               {server.visibility}
             </span>
           </div>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
-            {server.description || "No description"}
-          </p>
+          <div className="mb-2">
+            <RichTextContent
+              content={server.description}
+              emptyText="No description"
+            />
+          </div>
           <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
             <span className="inline-flex items-center gap-1">
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -172,35 +579,40 @@ export function McpServerCard({
               {tools.map((tool) => (
                 <div
                   key={tool.name}
-                  className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-800"
+                  className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900"
                 >
-                  <div className="flex items-center justify-between">
-                    <h4 className="font-mono text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                      {tool.display_name || tool.name}
-                    </h4>
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <h4 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                        {tool.display_name || tool.name}
+                      </h4>
+                      {tool.display_name && (
+                        <p className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
+                          {tool.name}
+                        </p>
+                      )}
+                    </div>
                     <div className="flex items-center gap-2">
                       {tool.is_enabled ? (
-                        <span className="text-xs text-emerald-600 dark:text-emerald-400">Enabled</span>
+                        <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+                          Enabled
+                        </span>
                       ) : (
-                        <span className="text-xs text-zinc-400">Disabled</span>
+                        <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                          Disabled
+                        </span>
                       )}
-                      <span className="text-xs text-zinc-400">{tool.call_count} calls</span>
+                      <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                        {tool.call_count} calls
+                      </span>
                     </div>
                   </div>
                   {tool.description && (
-                    <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">{tool.description}</p>
+                    <div className="mt-2 rounded-lg border border-zinc-200 bg-zinc-50/80 p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
+                      <RichTextContent content={tool.description} emptyText="No description" />
+                    </div>
                   )}
-                  {/* Input Schema 展示 */}
-                  {Object.keys(tool.input_schema).length > 0 && (
-                    <details className="mt-2">
-                      <summary className="cursor-pointer text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300">
-                        Input Schema
-                      </summary>
-                      <pre className="mt-2 overflow-x-auto rounded bg-zinc-100 p-2 text-xs dark:bg-zinc-900">
-                        {JSON.stringify(tool.input_schema, null, 2)}
-                      </pre>
-                    </details>
-                  )}
+                  <InputSchemaSection schema={tool.input_schema} />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## 背景
当前 MCP Servers 页面中，`data-extractor` 服务器的 14 个 Tools 已可加载，但卡片内的描述与 `input_schema` 展示可读性较差：
- 描述仅按纯文本展示，无法承载 Markdown/结构化内容
- Schema 仅以原始 JSON 输出，缺少可快速扫描的参数视图

本 PR 聚焦前端展示层优化，在不改动后端接口与数据模型的前提下，提升工具卡片的可读性与信息密度。

## 变更内容
- 增强 `McpServerCard` 的描述渲染能力：
  - 新增 `RichTextContent`，自动识别并渲染 `Markdown / JSON / plain text`
  - 对 Markdown 启用 GFM 能力（列表、表格、代码块等）
  - JSON 内容改用 `JsonViewer`，替代单纯 `JSON.stringify`
- 增强 `input_schema` 展示能力：
  - 新增 `InputSchemaSection`
  - 将 JSON Schema 展平为参数表（Field / Type / Required / Description / Constraints）
  - 保留 `Raw JSON` 折叠区，兼顾结构化阅读与原始数据排查
- 完善 Schema 解析覆盖面：
  - 支持 `properties/required/items`
  - 支持 `anyOf/oneOf/allOf` 组合类型
  - 补充常见约束字段展示（如 `enum/default/min/max/pattern/additionalProperties`）
- 卡片 UI 层级优化：
  - 优化 server/tool 卡片的边框、分区、徽标与间距
  - 保持现有深色模式风格一致，不引入新的交互路径

## 变更动机
- 对齐任务目标：针对 `data-extractor` 的 14 个 Tools 元信息进行卡片显示优化
- 提升工具发现与理解效率：让使用者快速识别参数、约束与必填项
- 降低排错成本：结构化表格与原始 JSON 双视图并存，便于比对与调试

## 实现细节
- 仅修改一个文件：`apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx`
- 采用最小侵入策略：
  - 不变更 API 响应结构
  - 不引入后端改动
  - 不新增业务状态字段
- 复用项目现有依赖：`react-markdown`、`remark-gfm`、`JsonViewer`

## 验证
- 已执行：
  - `pnpm -C apps/negentropy-ui lint app/plugins/mcp/_components/McpServerCard.tsx`
- 备注：仓库当前存在与本 PR 无关的全局 TypeScript 历史错误，本 PR 未扩散该问题面。

This PR was written using [Vibe Kanban](https://vibekanban.com)
