### PR TITLE
feat(Plugins): MCP Tools 列表支持 Hover 预览与按需展开详情 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -406,6 +406,54 @@ function InputSchemaSection({ schema }: { schema: Record<string, unknown> }) {
   );
 }
 
+function getToolLabel(tool: McpTool): string {
+  return tool.display_name || tool.name;
+}
+
+function getToolTooltipText(tool: McpTool): string {
+  const text = tool.description?.trim();
+  return text && text.length > 0 ? text : "No description";
+}
+
+function ToolDetailPanel({ tool }: { tool: McpTool }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h4 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            {getToolLabel(tool)}
+          </h4>
+          {tool.display_name && (
+            <p className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
+              {tool.name}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {tool.is_enabled ? (
+            <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+              Enabled
+            </span>
+          ) : (
+            <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+              Disabled
+            </span>
+          )}
+          <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+            {tool.call_count} calls
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-2 rounded-lg border border-zinc-200 bg-zinc-50/80 p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
+        <RichTextContent content={tool.description} emptyText="No description" />
+      </div>
+
+      <InputSchemaSection schema={tool.input_schema} />
+    </div>
+  );
+}
+
 interface McpServer {
   id: string;
   owner_id: string;
@@ -455,6 +503,12 @@ export function McpServerCard({
   loadError = null,
 }: McpServerCardProps) {
   const [showTools, setShowTools] = useState(false);
+  const [expandedToolName, setExpandedToolName] = useState<string | null>(null);
+
+  const expandedTool = useMemo(
+    () => tools.find((tool) => tool.name === expandedToolName) || null,
+    [expandedToolName, tools]
+  );
 
   return (
     <div className="rounded-2xl border border-zinc-200/80 bg-gradient-to-b from-white to-zinc-50/60 p-4 shadow-sm transition-shadow hover:shadow-md dark:border-zinc-700/80 dark:from-zinc-900 dark:to-zinc-900">
@@ -560,7 +614,12 @@ export function McpServerCard({
       {tools.length > 0 && (
         <div className="mt-4 border-t border-zinc-200 pt-4 dark:border-zinc-700">
           <button
-            onClick={() => setShowTools(!showTools)}
+            onClick={() => {
+              if (showTools) {
+                setExpandedToolName(null);
+              }
+              setShowTools((prev) => !prev);
+            }}
             className="flex items-center gap-2 text-sm font-medium text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
           >
             <svg
@@ -576,45 +635,50 @@ export function McpServerCard({
 
           {showTools && (
             <div className="mt-3 space-y-3">
-              {tools.map((tool) => (
-                <div
-                  key={tool.name}
-                  className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-2">
-                    <div>
-                      <h4 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                        {tool.display_name || tool.name}
-                      </h4>
-                      {tool.display_name && (
-                        <p className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
-                          {tool.name}
-                        </p>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {tool.is_enabled ? (
-                        <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
-                          Enabled
-                        </span>
-                      ) : (
-                        <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                          Disabled
-                        </span>
-                      )}
-                      <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                        {tool.call_count} calls
-                      </span>
-                    </div>
-                  </div>
-                  {tool.description && (
-                    <div className="mt-2 rounded-lg border border-zinc-200 bg-zinc-50/80 p-3 dark:border-zinc-700 dark:bg-zinc-900/60">
-                      <RichTextContent content={tool.description} emptyText="No description" />
-                    </div>
-                  )}
-                  <InputSchemaSection schema={tool.input_schema} />
+              <div className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+                <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
+                  Hover to preview description. Click a tool to expand details.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {tools.map((tool) => {
+                    const isExpanded = expandedToolName === tool.name;
+
+                    return (
+                      <div key={tool.name} className="group relative">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedToolName((prev) =>
+                              prev === tool.name ? null : tool.name
+                            )
+                          }
+                          aria-expanded={isExpanded}
+                          title={getToolTooltipText(tool)}
+                          className={`inline-flex items-center rounded-lg border px-3 py-1.5 font-mono text-sm transition-colors ${
+                            isExpanded
+                              ? "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-300"
+                              : "border-zinc-200 bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
+                          }`}
+                        >
+                          {getToolLabel(tool)}
+                        </button>
+
+                        <div className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 hidden w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-lg border border-zinc-200 bg-white/95 p-2 text-xs text-zinc-600 shadow-lg backdrop-blur group-hover:block group-focus-within:block dark:border-zinc-700 dark:bg-zinc-900/95 dark:text-zinc-300">
+                          <p className="max-h-40 overflow-y-auto whitespace-pre-wrap break-words leading-relaxed">
+                            {getToolTooltipText(tool)}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
-              ))}
+              </div>
+
+              {expandedTool && (
+                <div className="rounded-xl border border-zinc-200/70 bg-zinc-50/60 p-2 dark:border-zinc-700/70 dark:bg-zinc-900/40">
+                  <ToolDetailPanel tool={expandedTool} />
+                </div>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## 背景
在前一轮已完成 Markdown/JSON/Schema 可读性优化后，MCP Tools 区域仍存在信息密度与交互成本问题：
- 默认状态下直接渲染所有 Tool 详情，列表较长时扫描成本高
- 需要快速预览 description 与按需查看单个 Tool 详情的交互路径

本 PR 针对 `data-extractor` 等包含多 Tool（如 14 个 Tools）的场景，补齐“默认简洁、悬停预览、点击展开”的交互模式。

## 本次改动
- 将 Tools 默认展示改为「名称胶囊列表」而非全部详情展开
- 新增 hover 预览：鼠标悬停 Tool 时显示 description tooltip
- 新增 click 展开/收起：
  - 点击某个 Tool 展开该 Tool 的完整详情
  - 再次点击同一 Tool 收起
  - 点击其他 Tool 时切换展开目标
- 抽取 `ToolDetailPanel` 复用既有详情 UI，确保展开态内容与现有单 Tool 详情一致（含 description + input schema）
- 在折叠 Tools 面板时清理展开状态，避免状态残留

## 为什么这样改
- 贴合任务要求：默认简洁展示 + tooltip 预览 + 单项按需展开
- 降低认知负担：先看“有哪些工具”，再看“某个工具细节”
- 保持系统稳定：不改后端接口/数据模型，仅在前端组件内演进交互

## 关键实现细节
- 修改文件：`apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx`
- 状态模型：新增 `expandedToolName` 管理当前展开项
- 辅助函数：新增 `getToolLabel`、`getToolTooltipText`
- 复用策略：新增 `ToolDetailPanel` 组件，复用当前详情渲染能力，避免重复实现
- 兼容性与风险控制：
  - 保留原有 `Load Tools`、`Tools Loaded` 展开行为
  - 不影响 `RichTextContent` / `InputSchemaSection` 的现有能力
  - 通过组件级 lint 验证

## 验证
- `pnpm -C apps/negentropy-ui lint app/plugins/mcp/_components/McpServerCard.tsx`

This PR was written using [Vibe Kanban](https://vibekanban.com)
