### PR TITLE
优化 MCP Servers 中 MCP Server 卡片 tools 展开间距 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -655,8 +655,8 @@ export function McpServerCard({
 
       {/* Tools 展示区域 */}
       {showTools && tools.length > 0 && (
-        <div className="mt-4 border-t border-zinc-200 pt-4 dark:border-zinc-700">
-          <div className="mt-3 space-y-3">
+        <div className="mt-2 border-t border-zinc-200 pt-2 dark:border-zinc-700">
+          <div className="space-y-3">
             <div className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
               <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
                 Hover to preview description. Click a tool to expand details.


### PR DESCRIPTION
## What Changed
- Updated spacing in the MCP Server card tools expansion section on the `MCP Servers` page.
- In `apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx`:
  - Changed the tools container spacing from `mt-4 pt-4` to `mt-2 pt-2`.
  - Removed the inner wrapper `mt-3` while preserving `space-y-3` for internal vertical rhythm.

## Why
- The task context requested reducing the highlighted empty gap that appears when expanding tools in MCP Server cards.
- The target was to make that gap approximately one-third of the previous visual spacing, while keeping the rest of the card layout and interaction behavior unchanged.

## Implementation Details
- Scope is intentionally minimal: one file, style-only class adjustments (`2 insertions, 2 deletions`).
- No logic/state/API changes were introduced.
- Existing structural cues were preserved:
  - Top divider (`border-t`) remains.
  - Dark mode and light mode style tokens remain consistent.
  - Tools chip layout and expanded detail panel behavior remain unchanged.
- This follows a minimal-intervention UI refinement pattern: adjust local spacing tokens without altering component contracts.

This PR was written using [Vibe Kanban](https://vibekanban.com)
