### PR TITLE
feat(Plugins): 对齐 ADK SubAgents 并支持 Negentropy 五系部模板/同步 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/api/plugins/subagents/sync/negentropy/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/subagents/sync/negentropy/route.ts
@@ -1,0 +1,10 @@
+import { proxyPost } from "@/app/api/plugins/_proxy";
+
+/**
+ * Negentropy 内置 SubAgents 同步代理
+ *
+ * POST /api/plugins/subagents/sync/negentropy
+ */
+export async function POST(request: Request) {
+  return proxyPost(request, "/plugins/subagents/sync/negentropy");
+}

--- a/apps/negentropy-ui/app/api/plugins/subagents/templates/negentropy/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/subagents/templates/negentropy/route.ts
@@ -1,0 +1,10 @@
+import { proxyGet } from "@/app/api/plugins/_proxy";
+
+/**
+ * Negentropy 内置 SubAgent 模板代理
+ *
+ * GET /api/plugins/subagents/templates/negentropy
+ */
+export async function GET(request: Request) {
+  return proxyGet(request, "/plugins/subagents/templates/negentropy");
+}

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
@@ -11,8 +11,11 @@ interface SubAgent {
   system_prompt: string | null;
   model: string | null;
   config: Record<string, unknown>;
+  adk_config: Record<string, unknown>;
   skills: string[];
   tools: string[];
+  source: string;
+  is_builtin: boolean;
   is_enabled: boolean;
 }
 
@@ -46,6 +49,11 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
             <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
               {agent.visibility}
             </span>
+            {agent.is_builtin && (
+              <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                Negentropy Built-in
+              </span>
+            )}
           </div>
           <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
             {agent.description || "No description"}
@@ -57,6 +65,15 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
                 {agent.model}
+              </span>
+            )}
+            {"agent_class" in agent.adk_config &&
+              typeof agent.adk_config["agent_class"] === "string" && (
+              <span className="inline-flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {String(agent.adk_config["agent_class"])}
               </span>
             )}
             {agent.skills && agent.skills.length > 0 && (
@@ -76,6 +93,12 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
                 {agent.tools.length} tools
               </span>
             )}
+            <span className="inline-flex items-center gap-1">
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              source: {agent.source}
+            </span>
           </div>
           {agent.skills && agent.skills.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1">

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
@@ -11,6 +11,7 @@ interface SubAgent {
   system_prompt: string | null;
   model: string | null;
   config: Record<string, unknown>;
+  adk_config?: Record<string, unknown>;
   skills: string[];
   tools: string[];
   is_enabled: boolean;
@@ -22,6 +23,17 @@ interface SubAgentFormDialogProps {
   onClose: () => void;
   onSubmit: (data: Record<string, unknown>) => Promise<void>;
   agent: SubAgent | null;
+}
+
+interface NegentropyTemplate {
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  agent_type: string;
+  system_prompt: string | null;
+  model: string | null;
+  adk_config: Record<string, unknown>;
+  tools: string[];
 }
 
 export function SubAgentFormDialog({
@@ -38,6 +50,7 @@ export function SubAgentFormDialog({
     system_prompt: "",
     model: "",
     config: "{}",
+    adk_config: "{}",
     skills: "",
     tools: "",
     is_enabled: true,
@@ -45,6 +58,25 @@ export function SubAgentFormDialog({
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [templates, setTemplates] = useState<NegentropyTemplate[]>([]);
+  const [selectedTemplateName, setSelectedTemplateName] = useState("");
+
+  const applyTemplate = (template: NegentropyTemplate) => {
+    setFormData({
+      name: template.name,
+      display_name: template.display_name || template.name,
+      description: template.description || "",
+      agent_type: template.agent_type,
+      system_prompt: template.system_prompt || "",
+      model: template.model || "",
+      config: JSON.stringify({ source: "negentropy_builtin" }, null, 2),
+      adk_config: JSON.stringify(template.adk_config || {}, null, 2),
+      skills: "",
+      tools: (template.tools || []).join("\n"),
+      is_enabled: true,
+      visibility: "private",
+    });
+  };
 
   useEffect(() => {
     if (agent) {
@@ -56,11 +88,13 @@ export function SubAgentFormDialog({
         system_prompt: agent.system_prompt || "",
         model: agent.model || "",
         config: JSON.stringify(agent.config || {}, null, 2),
+        adk_config: JSON.stringify(agent.adk_config || (agent.config as { adk_config?: unknown })?.adk_config || {}, null, 2),
         skills: Array.isArray(agent.skills) ? agent.skills.join("\n") : "",
         tools: Array.isArray(agent.tools) ? agent.tools.join("\n") : "",
         is_enabled: agent.is_enabled,
         visibility: agent.visibility,
       });
+      setSelectedTemplateName("");
     } else {
       setFormData({
         name: "",
@@ -70,14 +104,37 @@ export function SubAgentFormDialog({
         system_prompt: "",
         model: "",
         config: "{}",
+        adk_config: "{}",
         skills: "",
         tools: "",
         is_enabled: true,
         visibility: "private",
       });
+      setSelectedTemplateName("");
     }
     setError(null);
   }, [agent, open]);
+
+  useEffect(() => {
+    if (!open || agent) return;
+    let mounted = true;
+    const fetchTemplates = async () => {
+      try {
+        const response = await fetch("/api/plugins/subagents/templates/negentropy");
+        if (!response.ok) return;
+        const data = (await response.json()) as NegentropyTemplate[];
+        if (mounted) {
+          setTemplates(data);
+        }
+      } catch {
+        // keep silent; template loading is optional
+      }
+    };
+    fetchTemplates();
+    return () => {
+      mounted = false;
+    };
+  }, [open, agent]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -86,11 +143,32 @@ export function SubAgentFormDialog({
 
     try {
       let config = {};
+      let adkConfig = {};
       try {
         config = JSON.parse(formData.config || "{}");
       } catch {
         throw new Error("Invalid JSON in config");
       }
+      try {
+        adkConfig = JSON.parse(formData.adk_config || "{}");
+      } catch {
+        throw new Error("Invalid JSON in ADK config");
+      }
+
+      const normalizedAdkConfig =
+        adkConfig && Object.keys(adkConfig).length > 0
+          ? adkConfig
+          : {
+              agent_type: formData.agent_type,
+              name: formData.name,
+              description: formData.description || null,
+              instruction: formData.system_prompt || null,
+              model: formData.model || null,
+              tools: formData.tools
+                .split("\n")
+                .map((s) => s.trim())
+                .filter(Boolean),
+            };
 
       const data: Record<string, unknown> = {
         name: formData.name,
@@ -100,6 +178,7 @@ export function SubAgentFormDialog({
         system_prompt: formData.system_prompt || null,
         model: formData.model || null,
         config: config,
+        adk_config: normalizedAdkConfig,
         skills: formData.skills
           .split("\n")
           .map((s) => s.trim())
@@ -131,6 +210,39 @@ export function SubAgentFormDialog({
         </h2>
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {!agent && templates.length > 0 && (
+            <div className="rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/50">
+              <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                Negentropy Built-in Templates
+              </label>
+              <div className="flex items-center gap-2">
+                <select
+                  value={selectedTemplateName}
+                  onChange={(e) => setSelectedTemplateName(e.target.value)}
+                  className="flex-1 rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                >
+                  <option value="">Select template</option>
+                  {templates.map((template) => (
+                    <option key={template.name} value={template.name}>
+                      {template.display_name || template.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  disabled={!selectedTemplateName}
+                  onClick={() => {
+                    const target = templates.find((item) => item.name === selectedTemplateName);
+                    if (target) applyTemplate(target);
+                  }}
+                  className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-200 dark:hover:bg-zinc-700"
+                >
+                  Apply
+                </button>
+              </div>
+            </div>
+          )}
+
           {error && (
             <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
               {error}
@@ -190,8 +302,10 @@ export function SubAgentFormDialog({
                 className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
               >
                 <option value="llm_agent">LLM Agent</option>
-                <option value="workflow">Workflow</option>
-                <option value="router">Router</option>
+                <option value="sequential_agent">Sequential Agent</option>
+                <option value="parallel_agent">Parallel Agent</option>
+                <option value="loop_agent">Loop Agent</option>
+                <option value="custom_agent">Custom Agent</option>
               </select>
             </div>
             <div>
@@ -273,6 +387,22 @@ export function SubAgentFormDialog({
               rows={3}
               placeholder='{"temperature": 0.7}'
             />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+              ADK Config (JSON, full-fidelity)
+            </label>
+            <textarea
+              value={formData.adk_config}
+              onChange={(e) => setFormData({ ...formData, adk_config: e.target.value })}
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+              rows={8}
+              placeholder='{"agent_class":"LlmAgent","output_key":"perception_output","disallow_transfer_to_parent":true}'
+            />
+            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              Use this field to capture all ADK sub-agent capabilities. Empty value will auto-generate a minimal ADK config.
+            </p>
           </div>
 
           <div className="flex items-center gap-4">

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -16,15 +16,26 @@ interface SubAgent {
   system_prompt: string | null;
   model: string | null;
   config: Record<string, unknown>;
+  adk_config: Record<string, unknown>;
   skills: string[];
   tools: string[];
+  source: string;
+  is_builtin: boolean;
   is_enabled: boolean;
+}
+
+interface SyncResponse {
+  created: number;
+  updated: number;
+  skipped: number;
 }
 
 export default function SubAgentsPage() {
   const [agents, setAgents] = useState<SubAgent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingAgent, setEditingAgent] = useState<SubAgent | null>(null);
 
@@ -50,6 +61,31 @@ export default function SubAgentsPage() {
   const handleCreate = () => {
     setEditingAgent(null);
     setDialogOpen(true);
+  };
+
+  const handleSyncNegentropy = async () => {
+    setSyncing(true);
+    setSyncMessage(null);
+    try {
+      const response = await fetch("/api/plugins/subagents/sync/negentropy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || "Failed to sync Negentropy subagents");
+      }
+      const data = (await response.json()) as SyncResponse;
+      setSyncMessage(
+        `Synced: created ${data.created}, updated ${data.updated}, skipped ${data.skipped}.`,
+      );
+      await fetchAgents();
+    } catch (err) {
+      setSyncMessage(err instanceof Error ? err.message : "An error occurred during sync");
+    } finally {
+      setSyncing(false);
+    }
   };
 
   const handleEdit = (agent: SubAgent) => {
@@ -116,16 +152,31 @@ export default function SubAgentsPage() {
                   SubAgents
                 </h1>
                 <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                  Configure specialized sub-agents for complex tasks.
+                  Configure ADK-compatible sub-agents for complex tasks.
                 </p>
               </div>
-              <button
-                onClick={handleCreate}
-                className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-              >
-                Add SubAgent
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleSyncNegentropy}
+                  disabled={syncing}
+                  className="inline-flex items-center justify-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                >
+                  {syncing ? "Syncing..." : "Sync Negentropy 5"}
+                </button>
+                <button
+                  onClick={handleCreate}
+                  className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  Add SubAgent
+                </button>
+              </div>
             </div>
+
+            {syncMessage && (
+              <div className="mb-4 rounded-md border border-zinc-200 bg-zinc-100/60 px-3 py-2 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+                {syncMessage}
+              </div>
+            )}
 
             {loading ? (
               <div className="text-sm text-zinc-500">Loading...</div>
@@ -136,12 +187,20 @@ export default function SubAgentsPage() {
                 <div className="text-zinc-400 dark:text-zinc-500 mb-4">
                   No subagents configured yet.
                 </div>
-                <button
-                  onClick={handleCreate}
-                  className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
-                >
-                  Create your first subagent →
-                </button>
+                <div className="flex items-center justify-center gap-3">
+                  <button
+                    onClick={handleSyncNegentropy}
+                    className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
+                  >
+                    Sync Negentropy 5 →
+                  </button>
+                  <button
+                    onClick={handleCreate}
+                    className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
+                  >
+                    Create manually →
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="grid gap-4">

--- a/apps/negentropy/src/negentropy/plugins/api.py
+++ b/apps/negentropy/src/negentropy/plugins/api.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
 
 from negentropy.auth.deps import get_current_user
 from negentropy.auth.rbac import has_permission
@@ -31,6 +32,7 @@ from negentropy.models.plugin import (
 )
 
 from .permissions import check_plugin_access, check_plugin_ownership, get_visible_plugin_ids
+from .subagent_presets import build_negentropy_subagent_payloads
 
 logger = get_logger("negentropy.plugins.api")
 router = APIRouter(prefix="/plugins", tags=["plugins"])
@@ -232,6 +234,7 @@ class SubAgentCreateRequest(BaseModel):
     system_prompt: Optional[str] = None
     model: Optional[str] = None
     config: Dict[str, Any] = Field(default_factory=dict)
+    adk_config: Dict[str, Any] = Field(default_factory=dict)
     skills: List[str] = Field(default_factory=list)
     tools: List[str] = Field(default_factory=list)
     is_enabled: bool = True
@@ -245,6 +248,7 @@ class SubAgentUpdateRequest(BaseModel):
     system_prompt: Optional[str] = None
     model: Optional[str] = None
     config: Optional[Dict[str, Any]] = None
+    adk_config: Optional[Dict[str, Any]] = None
     skills: Optional[List[str]] = None
     tools: Optional[List[str]] = None
     is_enabled: Optional[bool] = None
@@ -262,12 +266,33 @@ class SubAgentResponse(BaseModel):
     system_prompt: Optional[str] = None
     model: Optional[str] = None
     config: Dict[str, Any] = Field(default_factory=dict)
+    adk_config: Dict[str, Any] = Field(default_factory=dict)
     skills: List[str] = Field(default_factory=list)
     tools: List[str] = Field(default_factory=list)
+    source: str = "user_defined"
+    is_builtin: bool = False
     is_enabled: bool
 
     class Config:
         from_attributes = True
+
+
+class NegentropySubAgentTemplateResponse(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    agent_type: str
+    system_prompt: Optional[str] = None
+    model: Optional[str] = None
+    adk_config: Dict[str, Any] = Field(default_factory=dict)
+    tools: List[str] = Field(default_factory=list)
+
+
+class NegentropySubAgentSyncResponse(BaseModel):
+    created: int
+    updated: int
+    skipped: int
+    agents: List[SubAgentResponse] = Field(default_factory=list)
 
 
 # =============================================================================
@@ -767,6 +792,134 @@ def _skill_to_response(skill: Skill) -> SkillResponse:
 # =============================================================================
 
 
+def _json_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _build_adk_config_from_payload(
+    payload: Dict[str, Any],
+    existing_adk_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """构建 SubAgent 的 ADK 配置（可回放）。"""
+    adk_config: Dict[str, Any] = dict(existing_adk_config or {})
+    incoming_adk = payload.get("adk_config")
+    if isinstance(incoming_adk, dict):
+        adk_config.update(incoming_adk)
+
+    # 核心字段始终由结构化列驱动，避免双写漂移
+    name = payload.get("name")
+    if isinstance(name, str) and name:
+        adk_config["name"] = name
+
+    description = payload.get("description")
+    if description is None or isinstance(description, str):
+        adk_config["description"] = description
+
+    agent_type = payload.get("agent_type")
+    if isinstance(agent_type, str) and agent_type:
+        adk_config["agent_type"] = agent_type
+
+    system_prompt = payload.get("system_prompt")
+    if system_prompt is None or isinstance(system_prompt, str):
+        adk_config["instruction"] = system_prompt
+
+    model = payload.get("model")
+    if model is None or isinstance(model, str):
+        adk_config["model"] = model
+
+    tools = payload.get("tools")
+    if isinstance(tools, list):
+        adk_config["tools"] = tools
+
+    return adk_config
+
+
+def _merge_subagent_config(
+    *,
+    current_config: Optional[Dict[str, Any]],
+    update_config: Optional[Dict[str, Any]],
+    adk_config: Dict[str, Any],
+    source: str,
+) -> Dict[str, Any]:
+    merged = dict(current_config or {})
+    if isinstance(update_config, dict):
+        merged.update(update_config)
+    merged["adk_config"] = adk_config
+    merged["source"] = source
+    return merged
+
+
+def _materialize_subagent_payload(
+    agent: Optional[SubAgent],
+    incoming: Dict[str, Any],
+) -> Dict[str, Any]:
+    """将数据库对象与变更 payload 合并为完整视图，便于构建 adk_config。"""
+    if agent is None:
+        base = {
+            "name": incoming.get("name"),
+            "display_name": incoming.get("display_name"),
+            "description": incoming.get("description"),
+            "agent_type": incoming.get("agent_type"),
+            "system_prompt": incoming.get("system_prompt"),
+            "model": incoming.get("model"),
+            "config": _json_dict(incoming.get("config")),
+            "adk_config": _json_dict(incoming.get("adk_config")),
+            "skills": incoming.get("skills") or [],
+            "tools": incoming.get("tools") or [],
+            "is_enabled": incoming.get("is_enabled", True),
+            "visibility": incoming.get("visibility", "private"),
+        }
+        return base
+
+    config = _json_dict(agent.config)
+    base = {
+        "name": agent.name,
+        "display_name": agent.display_name,
+        "description": agent.description,
+        "agent_type": agent.agent_type,
+        "system_prompt": agent.system_prompt,
+        "model": agent.model,
+        "config": config,
+        "adk_config": _json_dict(config.get("adk_config")),
+        "skills": agent.skills or [],
+        "tools": agent.tools or [],
+        "is_enabled": agent.is_enabled,
+        "visibility": agent.visibility.value,
+    }
+    base.update(incoming)
+
+    if "config" in incoming:
+        base["config"] = _json_dict(incoming["config"])
+    if "adk_config" in incoming:
+        base["adk_config"] = _json_dict(incoming["adk_config"])
+    return base
+
+
+def _resolve_subagent_source(config: Dict[str, Any]) -> str:
+    source = config.get("source")
+    if isinstance(source, str) and source:
+        return source
+    return "user_defined"
+
+
+def _extract_adk_config(agent: SubAgent) -> Dict[str, Any]:
+    config = _json_dict(agent.config)
+    adk_config = config.get("adk_config")
+    if isinstance(adk_config, dict):
+        return adk_config
+
+    # 兼容历史记录：若不存在 adk_config，则由结构化列推导最小可回放配置
+    fallback_payload = {
+        "name": agent.name,
+        "description": agent.description,
+        "agent_type": agent.agent_type,
+        "system_prompt": agent.system_prompt,
+        "model": agent.model,
+        "tools": agent.tools or [],
+    }
+    return _build_adk_config_from_payload(fallback_payload)
+
+
 @router.get("/subagents", response_model=List[SubAgentResponse])
 async def list_subagents(user: AuthUser = Depends(get_current_user)) -> List[SubAgentResponse]:
     """列出用户可见的 SubAgents"""
@@ -782,6 +935,115 @@ async def list_subagents(user: AuthUser = Depends(get_current_user)) -> List[Sub
     return [_subagent_to_response(a) for a in agents]
 
 
+@router.get("/subagents/templates/negentropy", response_model=List[NegentropySubAgentTemplateResponse])
+async def list_negentropy_subagent_templates(
+    user: AuthUser = Depends(get_current_user),
+) -> List[NegentropySubAgentTemplateResponse]:
+    """返回 Negentropy 内置 5 个 Faculty SubAgent 模板（来自代码定义）。"""
+    _ = user  # 显式依赖鉴权
+    payloads = build_negentropy_subagent_payloads()
+    return [
+        NegentropySubAgentTemplateResponse(
+            name=payload["name"],
+            display_name=payload.get("display_name"),
+            description=payload.get("description"),
+            agent_type=payload.get("agent_type", "llm_agent"),
+            system_prompt=payload.get("system_prompt"),
+            model=payload.get("model"),
+            adk_config=payload.get("adk_config", {}),
+            tools=payload.get("tools", []),
+        )
+        for payload in payloads
+    ]
+
+
+@router.post("/subagents/sync/negentropy", response_model=NegentropySubAgentSyncResponse)
+async def sync_negentropy_subagents(
+    user: AuthUser = Depends(get_current_user),
+) -> NegentropySubAgentSyncResponse:
+    """
+    将代码中的 5 个 Faculty SubAgent 同步到插件表。
+
+    幂等语义：
+    - 已存在且归属当前用户：更新为最新代码定义；
+    - 已存在但归属其他用户：跳过；
+    - 不存在：创建。
+    """
+    payloads = build_negentropy_subagent_payloads()
+    created_count = 0
+    updated_count = 0
+    skipped_count = 0
+    touched_agents: List[SubAgent] = []
+
+    async with AsyncSessionLocal() as db:
+        for payload in payloads:
+            existing = await db.scalar(select(SubAgent).where(SubAgent.name == payload["name"]))
+            materialized = _materialize_subagent_payload(existing, payload)
+            adk_config = _build_adk_config_from_payload(
+                materialized,
+                existing_adk_config=_json_dict(materialized.get("adk_config")),
+            )
+            merged_config = _merge_subagent_config(
+                current_config=_json_dict(existing.config) if existing else None,
+                update_config=_json_dict(materialized.get("config")),
+                adk_config=adk_config,
+                source="negentropy_builtin",
+            )
+
+            if existing:
+                if existing.owner_id != user.user_id:
+                    skipped_count += 1
+                    continue
+
+                existing.display_name = materialized.get("display_name")
+                existing.description = materialized.get("description")
+                existing.agent_type = materialized.get("agent_type")
+                existing.system_prompt = materialized.get("system_prompt")
+                existing.model = materialized.get("model")
+                existing.config = merged_config
+                existing.skills = materialized.get("skills") or []
+                existing.tools = materialized.get("tools") or []
+                existing.is_enabled = bool(materialized.get("is_enabled", True))
+                existing.visibility = PluginVisibility(materialized.get("visibility", "private"))
+                updated_count += 1
+                touched_agents.append(existing)
+                continue
+
+            new_agent = SubAgent(
+                owner_id=user.user_id,
+                visibility=PluginVisibility(materialized.get("visibility", "private")),
+                name=materialized["name"],
+                display_name=materialized.get("display_name"),
+                description=materialized.get("description"),
+                agent_type=materialized.get("agent_type", "llm_agent"),
+                system_prompt=materialized.get("system_prompt"),
+                model=materialized.get("model"),
+                config=merged_config,
+                skills=materialized.get("skills") or [],
+                tools=materialized.get("tools") or [],
+                is_enabled=bool(materialized.get("is_enabled", True)),
+            )
+            db.add(new_agent)
+            created_count += 1
+            touched_agents.append(new_agent)
+
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail=f"SubAgent sync conflict: {exc}") from exc
+
+        for agent in touched_agents:
+            await db.refresh(agent)
+
+    return NegentropySubAgentSyncResponse(
+        created=created_count,
+        updated=updated_count,
+        skipped=skipped_count,
+        agents=[_subagent_to_response(agent) for agent in touched_agents],
+    )
+
+
 @router.post("/subagents", response_model=SubAgentResponse, status_code=status.HTTP_201_CREATED)
 async def create_subagent(
     payload: SubAgentCreateRequest,
@@ -793,22 +1055,40 @@ async def create_subagent(
         if existing:
             raise HTTPException(status_code=400, detail="SubAgent name already exists")
 
+        incoming = payload.model_dump()
+        materialized = _materialize_subagent_payload(None, incoming)
+        adk_config = _build_adk_config_from_payload(
+            materialized,
+            existing_adk_config=_json_dict(materialized.get("adk_config")),
+        )
+        source = _resolve_subagent_source(_json_dict(materialized.get("config")))
+        merged_config = _merge_subagent_config(
+            current_config=None,
+            update_config=_json_dict(materialized.get("config")),
+            adk_config=adk_config,
+            source=source,
+        )
+
         agent = SubAgent(
             owner_id=user.user_id,
             visibility=PluginVisibility(payload.visibility),
             name=payload.name,
-            display_name=payload.display_name,
-            description=payload.description,
-            agent_type=payload.agent_type,
-            system_prompt=payload.system_prompt,
-            model=payload.model,
-            config=payload.config,
-            skills=payload.skills,
-            tools=payload.tools,
-            is_enabled=payload.is_enabled,
+            display_name=materialized.get("display_name"),
+            description=materialized.get("description"),
+            agent_type=materialized.get("agent_type", "llm_agent"),
+            system_prompt=materialized.get("system_prompt"),
+            model=materialized.get("model"),
+            config=merged_config,
+            skills=materialized.get("skills") or [],
+            tools=materialized.get("tools") or [],
+            is_enabled=bool(materialized.get("is_enabled", True)),
         )
         db.add(agent)
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail=f"SubAgent create conflict: {exc}") from exc
         await db.refresh(agent)
 
     return _subagent_to_response(agent)
@@ -847,14 +1127,45 @@ async def update_subagent(
         if not agent:
             raise HTTPException(status_code=404, detail="SubAgent not found")
 
-        update_data = payload.model_dump(exclude_unset=True)
-        if "visibility" in update_data:
-            update_data["visibility"] = PluginVisibility(update_data["visibility"])
+        incoming = payload.model_dump(exclude_unset=True)
+        materialized = _materialize_subagent_payload(agent, incoming)
+        adk_config = _build_adk_config_from_payload(
+            materialized,
+            existing_adk_config=_json_dict(materialized.get("adk_config")),
+        )
+        source = _resolve_subagent_source(_json_dict(materialized.get("config")))
+        merged_config = _merge_subagent_config(
+            current_config=_json_dict(agent.config),
+            update_config=_json_dict(materialized.get("config")),
+            adk_config=adk_config,
+            source=source,
+        )
 
-        for key, value in update_data.items():
-            setattr(agent, key, value)
+        if "display_name" in incoming:
+            agent.display_name = materialized.get("display_name")
+        if "description" in incoming:
+            agent.description = materialized.get("description")
+        if "agent_type" in incoming:
+            agent.agent_type = materialized.get("agent_type", agent.agent_type)
+        if "system_prompt" in incoming:
+            agent.system_prompt = materialized.get("system_prompt")
+        if "model" in incoming:
+            agent.model = materialized.get("model")
+        if "skills" in incoming:
+            agent.skills = materialized.get("skills") or []
+        if "tools" in incoming:
+            agent.tools = materialized.get("tools") or []
+        if "is_enabled" in incoming:
+            agent.is_enabled = bool(materialized.get("is_enabled"))
+        if "visibility" in incoming:
+            agent.visibility = PluginVisibility(str(materialized.get("visibility")))
+        agent.config = merged_config
 
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail=f"SubAgent update conflict: {exc}") from exc
         await db.refresh(agent)
 
     return _subagent_to_response(agent)
@@ -879,6 +1190,9 @@ async def delete_subagent(
 
 
 def _subagent_to_response(agent: SubAgent) -> SubAgentResponse:
+    config = _json_dict(agent.config)
+    source = _resolve_subagent_source(config)
+    adk_config = _extract_adk_config(agent)
     return SubAgentResponse(
         id=agent.id,
         owner_id=agent.owner_id,
@@ -889,9 +1203,12 @@ def _subagent_to_response(agent: SubAgent) -> SubAgentResponse:
         agent_type=agent.agent_type,
         system_prompt=agent.system_prompt,
         model=agent.model,
-        config=agent.config or {},
+        config=config,
+        adk_config=adk_config,
         skills=agent.skills or [],
         tools=agent.tools or [],
+        source=source,
+        is_builtin=source == "negentropy_builtin",
         is_enabled=agent.is_enabled,
     )
 

--- a/apps/negentropy/src/negentropy/plugins/subagent_presets.py
+++ b/apps/negentropy/src/negentropy/plugins/subagent_presets.py
@@ -1,0 +1,157 @@
+"""
+SubAgent 预设与 ADK 配置序列化。
+
+遵循 AGENTS.md「单一事实源」原则：
+- Negentropy 内置 5 个 Faculty SubAgent 的定义直接来源于代码中的 Agent 实例；
+- Plugins/SubAgents 页面通过该模块读取可序列化配置，避免手工复制导致漂移。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from google.adk.agents import BaseAgent, LlmAgent, LoopAgent, ParallelAgent, SequentialAgent
+
+from negentropy.agents.faculties import (
+    action_agent,
+    contemplation_agent,
+    influence_agent,
+    internalization_agent,
+    perception_agent,
+)
+
+
+NEGENTROPY_SUBAGENT_ORDER = [
+    perception_agent,
+    internalization_agent,
+    contemplation_agent,
+    action_agent,
+    influence_agent,
+]
+
+NEGENTROPY_SUBAGENT_NAMES = [agent.name for agent in NEGENTROPY_SUBAGENT_ORDER]
+
+
+def _callable_name(callback: Any) -> Optional[str]:
+    if callback is None:
+        return None
+    if isinstance(callback, str):
+        return callback
+    name = getattr(callback, "__name__", None)
+    if isinstance(name, str) and name:
+        return name
+    attr_name = getattr(callback, "name", None)
+    if isinstance(attr_name, str) and attr_name:
+        return attr_name
+    return callback.__class__.__name__
+
+
+def _tool_name(tool: Any) -> str:
+    name = getattr(tool, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    func_name = getattr(tool, "__name__", None)
+    if isinstance(func_name, str) and func_name:
+        return func_name
+    return tool.__class__.__name__
+
+
+def _model_name(model: Any) -> Optional[str]:
+    if model is None:
+        return None
+    model_name = getattr(model, "model", None)
+    if isinstance(model_name, str) and model_name:
+        return model_name
+    as_text = str(model)
+    return as_text or None
+
+
+def _to_json_compatible(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _to_json_compatible(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_to_json_compatible(v) for v in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return _to_json_compatible(model_dump())
+    to_dict = getattr(value, "dict", None)
+    if callable(to_dict):
+        return _to_json_compatible(to_dict())
+    return str(value)
+
+
+def _agent_type(agent: BaseAgent) -> str:
+    if isinstance(agent, LlmAgent):
+        return "llm_agent"
+    if isinstance(agent, SequentialAgent):
+        return "sequential_agent"
+    if isinstance(agent, ParallelAgent):
+        return "parallel_agent"
+    if isinstance(agent, LoopAgent):
+        return "loop_agent"
+    return "custom_agent"
+
+
+def serialize_adk_config(agent: BaseAgent) -> Dict[str, Any]:
+    """将 ADK Agent 实例序列化为可存储的配置对象。"""
+    base: Dict[str, Any] = {
+        "agent_type": _agent_type(agent),
+        "agent_class": agent.__class__.__name__,
+        "name": agent.name,
+        "description": agent.description,
+        "before_agent_callback": _callable_name(getattr(agent, "before_agent_callback", None)),
+        "after_agent_callback": _callable_name(getattr(agent, "after_agent_callback", None)),
+        "sub_agents": [sub.name for sub in (getattr(agent, "sub_agents", None) or [])],
+    }
+
+    if isinstance(agent, LlmAgent):
+        base.update(
+            {
+                "instruction": agent.instruction,
+                "model": _model_name(agent.model),
+                "tools": [_tool_name(tool) for tool in (agent.tools or [])],
+                "output_key": agent.output_key,
+                "include_contents": _to_json_compatible(agent.include_contents),
+                "disallow_transfer_to_parent": agent.disallow_transfer_to_parent,
+                "disallow_transfer_to_peers": agent.disallow_transfer_to_peers,
+                "input_schema": _to_json_compatible(agent.input_schema),
+                "output_schema": _to_json_compatible(agent.output_schema),
+                "generate_content_config": _to_json_compatible(agent.generate_content_config),
+                "planner": _to_json_compatible(getattr(agent, "planner", None)),
+                "before_model_callback": _callable_name(getattr(agent, "before_model_callback", None)),
+                "after_model_callback": _callable_name(getattr(agent, "after_model_callback", None)),
+                "before_tool_callback": _callable_name(getattr(agent, "before_tool_callback", None)),
+                "after_tool_callback": _callable_name(getattr(agent, "after_tool_callback", None)),
+                "on_model_error_callback": _callable_name(getattr(agent, "on_model_error_callback", None)),
+                "on_tool_error_callback": _callable_name(getattr(agent, "on_tool_error_callback", None)),
+            }
+        )
+    elif isinstance(agent, LoopAgent):
+        base["max_iterations"] = agent.max_iterations
+
+    return base
+
+
+def build_negentropy_subagent_payloads() -> List[Dict[str, Any]]:
+    """构建 Negentropy 内置 5 个 Faculty SubAgent 的标准 payload。"""
+    payloads: List[Dict[str, Any]] = []
+    for agent in NEGENTROPY_SUBAGENT_ORDER:
+        adk_config = serialize_adk_config(agent)
+        payloads.append(
+            {
+                "name": agent.name,
+                "display_name": agent.name,
+                "description": agent.description,
+                "agent_type": adk_config["agent_type"],
+                "system_prompt": adk_config.get("instruction"),
+                "model": adk_config.get("model"),
+                "skills": [],
+                "tools": adk_config.get("tools", []),
+                "is_enabled": True,
+                "visibility": "private",
+                "adk_config": adk_config,
+            }
+        )
+    return payloads

--- a/apps/negentropy/tests/unit_tests/plugins/test_subagent_presets.py
+++ b/apps/negentropy/tests/unit_tests/plugins/test_subagent_presets.py
@@ -1,0 +1,40 @@
+"""SubAgent 预设测试：确保 UI 同步源与代码定义一致。"""
+
+from negentropy.agents.faculties import (
+    action_agent,
+    contemplation_agent,
+    influence_agent,
+    internalization_agent,
+    perception_agent,
+)
+from negentropy.plugins.subagent_presets import (
+    NEGENTROPY_SUBAGENT_NAMES,
+    build_negentropy_subagent_payloads,
+)
+
+
+def _tool_names(agent) -> list[str]:
+    names: list[str] = []
+    for tool in agent.tools or []:
+        name = getattr(tool, "name", None) or getattr(tool, "__name__", None) or tool.__class__.__name__
+        names.append(name)
+    return names
+
+
+def test_builtin_payload_count_and_order():
+    payloads = build_negentropy_subagent_payloads()
+    assert len(payloads) == 5
+    assert [payload["name"] for payload in payloads] == NEGENTROPY_SUBAGENT_NAMES
+
+
+def test_builtin_payload_matches_faculty_definition():
+    payloads = {payload["name"]: payload for payload in build_negentropy_subagent_payloads()}
+    for faculty in [perception_agent, internalization_agent, contemplation_agent, action_agent, influence_agent]:
+        payload = payloads[faculty.name]
+        assert payload["description"] == faculty.description
+        assert payload["system_prompt"] == faculty.instruction
+        assert payload["agent_type"] == "llm_agent"
+        assert payload["tools"] == _tool_names(faculty)
+        assert payload["adk_config"]["name"] == faculty.name
+        assert payload["adk_config"]["instruction"] == faculty.instruction
+        assert payload["adk_config"]["tools"] == _tool_names(faculty)


### PR DESCRIPTION
## 背景与目标
本 PR 围绕 Plugins/SubAgents 页面进行增强，目标是让 Negentropy 的 5 个内置子 Agent 能在 UI 中以**与代码定义一致**的方式配置，并对齐 ADK 多 Agent 设计范式，支持后续直接替换/复用为运行时 SubAgents 配置。

## 变更内容
- 后端新增 SubAgent 预设序列化模块：从代码中真实 Faculty Agent 实例提取配置，生成可持久化 payload（单一事实源）。
- SubAgent API 扩展 `adk_config` 能力：创建/更新/查询均可携带并返回 ADK 全量配置；兼容旧数据的最小回放配置推导。
- 新增模板与同步端点：
  - `GET /plugins/subagents/templates/negentropy`
  - `POST /plugins/subagents/sync/negentropy`（幂等同步 5 个内置子 Agent）
- 前端 SubAgents 页面升级：
  - 新增“一键同步 Negentropy 5”操作
  - Add SubAgent 对话框支持内置模板套用
  - 支持 `ADK Config (JSON, full-fidelity)` 编辑
  - 卡片展示 `agent_class/source/is_builtin` 关键信息
- 增加后端单测，验证内置 payload 与 Faculty 代码定义保持一致。

## 为什么这样改
- 任务要求明确指出：5 个子 Agent 的定义必须与代码完全一致，且未来可直接应用/替代。手工维护配置容易发生漂移，因此采用“代码定义 -> 序列化模板”的单一事实源策略。
- 任务要求参考 ADK Agents（含 multi-agents / workflow patterns）并覆盖 SubAgents 特性，因此引入 `adk_config` 作为完整能力承载层，避免只停留在 `model/system_prompt/tools` 的简化配置。
- 通过模板预览 + 幂等同步 + UI 直接套用，降低配置熵并提升持续演进的可维护性。

## 关键实现细节
- `subagent_presets.py` 负责：
  - 统一提取 agent type / model / tools / callbacks / transfer 边界等 ADK 关键字段
  - 生成 Negentropy 五系部标准 payload
- `plugins/api.py` 负责：
  - 新增 `adk_config` 入参/出参模型
  - 将结构化字段与 `config.adk_config` 做标准化合并
  - 新增模板与同步路由，并在同步时处理 owner 边界和冲突
- UI 负责：
  - 通过 `/api/plugins/subagents/templates/negentropy` 和 `/api/plugins/subagents/sync/negentropy` 代理路由对接后端
  - 在 Add SubAgent 中支持“模板套用 + 高保真 ADK JSON 编辑”

## 验证
- 通过后端测试：
  - `uv run pytest tests/unit_tests/plugins/test_subagent_presets.py tests/unit_tests/agents/test_agent_graph.py`
- 前端改动路径 ESLint 通过：
  - `pnpm exec eslint app/plugins/subagents app/api/plugins/subagents --max-warnings=0`

This PR was written using [Vibe Kanban](https://vibekanban.com)
