### PR TITLE
feat(plugins): improve form dialog accessibility and enable safe renaming across SubAgents/Skills/MCP (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx
@@ -134,7 +134,7 @@ export function McpServerFormDialog({
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/55" onClick={onClose} />
       <div className="relative flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6">
-        <div className="my-3 w-full max-w-6xl rounded-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900">
           <div className="border-b border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {server ? "Edit MCP Server" : "Add MCP Server"}
@@ -144,8 +144,8 @@ export function McpServerFormDialog({
             </p>
           </div>
 
-          <form onSubmit={handleSubmit} className="flex max-h-[calc(100vh-4.5rem)] flex-col">
-            <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
               {error && (
                 <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
                   {error}
@@ -168,7 +168,6 @@ export function McpServerFormDialog({
                       className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
                       placeholder="my-mcp-server"
                       required
-                      disabled={!!server}
                     />
                   </div>
                   <div>
@@ -333,7 +332,7 @@ export function McpServerFormDialog({
               </section>
             </div>
 
-            <div className="sticky bottom-0 flex justify-end gap-3 border-t border-zinc-200 bg-white px-5 py-4 sm:px-6 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="flex shrink-0 justify-end gap-3 border-t border-zinc-200 bg-white px-5 py-4 sm:px-6 dark:border-zinc-800 dark:bg-zinc-900">
               <button
                 type="button"
                 onClick={onClose}

--- a/apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx
@@ -134,7 +134,7 @@ export function SkillFormDialog({
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/55" onClick={onClose} />
       <div className="relative flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6">
-        <div className="my-3 w-full max-w-6xl rounded-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900">
           <div className="border-b border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {skill ? "Edit Skill" : "Add Skill"}
@@ -144,8 +144,8 @@ export function SkillFormDialog({
             </p>
           </div>
 
-          <form onSubmit={handleSubmit} className="flex max-h-[calc(100vh-4.5rem)] flex-col">
-            <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
               {error && (
                 <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
                   {error}
@@ -168,7 +168,6 @@ export function SkillFormDialog({
                       className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
                       placeholder="my-skill"
                       required
-                      disabled={!!skill}
                     />
                   </div>
                   <div>
@@ -329,7 +328,7 @@ export function SkillFormDialog({
               </section>
             </div>
 
-            <div className="sticky bottom-0 flex justify-end gap-3 border-t border-zinc-200 bg-white px-5 py-4 sm:px-6 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="flex shrink-0 justify-end gap-3 border-t border-zinc-200 bg-white px-5 py-4 sm:px-6 dark:border-zinc-800 dark:bg-zinc-900">
               <button
                 type="button"
                 onClick={onClose}

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
@@ -16,6 +16,7 @@ interface SubAgent {
   tools: string[];
   is_enabled: boolean;
   visibility: string;
+  is_builtin?: boolean;
 }
 
 interface SubAgentFormDialogProps {
@@ -138,6 +139,18 @@ export function SubAgentFormDialog({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    let confirmBuiltinRename = false;
+    if (agent?.is_builtin && formData.name !== agent.name) {
+      const confirmed = confirm(
+        "Renaming a Negentropy built-in SubAgent may cause future sync to create a duplicate. Continue?",
+      );
+      if (!confirmed) {
+        return;
+      }
+      confirmBuiltinRename = true;
+    }
+
     setLoading(true);
     setError(null);
 
@@ -190,6 +203,9 @@ export function SubAgentFormDialog({
         is_enabled: formData.is_enabled,
         visibility: formData.visibility,
       };
+      if (confirmBuiltinRename) {
+        data.confirm_builtin_rename = true;
+      }
 
       await onSubmit(data);
     } catch (err) {
@@ -205,7 +221,7 @@ export function SubAgentFormDialog({
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/55" onClick={onClose} />
       <div className="relative flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6">
-        <div className="my-3 w-full max-w-6xl rounded-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900">
           <div className="border-b border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {agent ? "Edit SubAgent" : "Add SubAgent"}
@@ -215,8 +231,8 @@ export function SubAgentFormDialog({
             </p>
           </div>
 
-          <form onSubmit={handleSubmit} className="flex max-h-[calc(100vh-4.5rem)] flex-col">
-            <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
               {!agent && templates.length > 0 && (
                 <section className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
                   <label className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
@@ -272,7 +288,6 @@ export function SubAgentFormDialog({
                       className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
                       placeholder="my-subagent"
                       required
-                      disabled={!!agent}
                     />
                   </div>
                   <div>
@@ -439,7 +454,7 @@ export function SubAgentFormDialog({
               </section>
             </div>
 
-            <div className="sticky bottom-0 flex justify-end gap-3 border-t border-zinc-200 bg-white px-5 py-4 sm:px-6 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="flex shrink-0 justify-end gap-3 border-t border-zinc-200 bg-white px-5 py-4 sm:px-6 dark:border-zinc-800 dark:bg-zinc-900">
               <button
                 type="button"
                 onClick={onClose}

--- a/apps/negentropy/src/negentropy/plugins/api.py
+++ b/apps/negentropy/src/negentropy/plugins/api.py
@@ -95,6 +95,7 @@ class McpServerCreateRequest(BaseModel):
 
 
 class McpServerUpdateRequest(BaseModel):
+    name: Optional[str] = None
     display_name: Optional[str] = None
     description: Optional[str] = None
     command: Optional[str] = None
@@ -188,6 +189,7 @@ class SkillCreateRequest(BaseModel):
 
 
 class SkillUpdateRequest(BaseModel):
+    name: Optional[str] = None
     display_name: Optional[str] = None
     description: Optional[str] = None
     category: Optional[str] = None
@@ -242,6 +244,7 @@ class SubAgentCreateRequest(BaseModel):
 
 
 class SubAgentUpdateRequest(BaseModel):
+    name: Optional[str] = None
     display_name: Optional[str] = None
     description: Optional[str] = None
     agent_type: Optional[str] = None
@@ -253,6 +256,7 @@ class SubAgentUpdateRequest(BaseModel):
     tools: Optional[List[str]] = None
     is_enabled: Optional[bool] = None
     visibility: Optional[str] = None
+    confirm_builtin_rename: Optional[bool] = False
 
 
 class SubAgentResponse(BaseModel):
@@ -442,6 +446,19 @@ async def update_mcp_server(
             raise HTTPException(status_code=404, detail="Server not found")
 
         update_data = payload.model_dump(exclude_unset=True)
+        if "name" in update_data:
+            new_name = str(update_data["name"] or "").strip()
+            if not new_name:
+                raise HTTPException(status_code=400, detail="Server name cannot be empty")
+            if new_name != server.name:
+                existing = await db.scalar(
+                    select(McpServer).where(
+                        and_(McpServer.name == new_name, McpServer.id != server_id)
+                    )
+                )
+                if existing:
+                    raise HTTPException(status_code=400, detail="Server name already exists")
+            update_data["name"] = new_name
         if "visibility" in update_data:
             update_data["visibility"] = PluginVisibility(update_data["visibility"])
 
@@ -738,6 +755,17 @@ async def update_skill(
             raise HTTPException(status_code=404, detail="Skill not found")
 
         update_data = payload.model_dump(exclude_unset=True)
+        if "name" in update_data:
+            new_name = str(update_data["name"] or "").strip()
+            if not new_name:
+                raise HTTPException(status_code=400, detail="Skill name cannot be empty")
+            if new_name != skill.name:
+                existing = await db.scalar(
+                    select(Skill).where(and_(Skill.name == new_name, Skill.id != skill_id))
+                )
+                if existing:
+                    raise HTTPException(status_code=400, detail="Skill name already exists")
+            update_data["name"] = new_name
         if "visibility" in update_data:
             update_data["visibility"] = PluginVisibility(update_data["visibility"])
 
@@ -1128,6 +1156,29 @@ async def update_subagent(
             raise HTTPException(status_code=404, detail="SubAgent not found")
 
         incoming = payload.model_dump(exclude_unset=True)
+        confirm_builtin_rename = bool(incoming.pop("confirm_builtin_rename", False))
+
+        if "name" in incoming:
+            new_name = str(incoming["name"] or "").strip()
+            if not new_name:
+                raise HTTPException(status_code=400, detail="SubAgent name cannot be empty")
+            if new_name != agent.name:
+                current_source = _resolve_subagent_source(_json_dict(agent.config))
+                if current_source == "negentropy_builtin" and not confirm_builtin_rename:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            "Renaming a Negentropy built-in SubAgent may cause sync to create "
+                            "a duplicate. Set confirm_builtin_rename=true to continue."
+                        ),
+                    )
+                existing = await db.scalar(
+                    select(SubAgent).where(and_(SubAgent.name == new_name, SubAgent.id != agent_id))
+                )
+                if existing:
+                    raise HTTPException(status_code=400, detail="SubAgent name already exists")
+            incoming["name"] = new_name
+
         materialized = _materialize_subagent_payload(agent, incoming)
         adk_config = _build_adk_config_from_payload(
             materialized,
@@ -1141,6 +1192,8 @@ async def update_subagent(
             source=source,
         )
 
+        if "name" in incoming:
+            agent.name = materialized.get("name", agent.name)
         if "display_name" in incoming:
             agent.display_name = materialized.get("display_name")
         if "description" in incoming:


### PR DESCRIPTION
## What changes were made
- Updated the three Plugins form dialogs (`SubAgent`, `Skill`, `MCP Server`) to fix footer action accessibility, so `Cancel`, `Update`, and `Create` remain reachable and clickable on smaller viewports.
- Unified modal height behavior using bounded container height + internal scroll region + non-collapsing footer area.
- Enabled name editing in edit mode for SubAgents, Skills, and MCP Servers.
- Extended backend PATCH contracts to accept `name` updates for all three plugin types.
- Added server-side rename validation:
  - Empty names are rejected.
  - Duplicate names are rejected (excluding the current record).
- Added built-in SubAgent rename safeguard:
  - Renaming Negentropy built-ins requires explicit confirmation (`confirm_builtin_rename=true`), otherwise update is rejected with a conflict response.

## Why these changes were made
- The task context identified that the dialog became too tall, causing footer actions to be hard or impossible to click.
- Users also needed to modify names during edit flows, but current UI/API contracts prevented this.
- Built-in SubAgents are sync-sensitive by name; explicit confirmation was added to reduce accidental duplicate risks after future sync operations.

## Important implementation details
- Frontend scope:
  - `apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx`
  - `apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx`
  - `apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx`
- Backend scope:
  - `apps/negentropy/src/negentropy/plugins/api.py`
- API contract updates:
  - `McpServerUpdateRequest.name?: string`
  - `SkillUpdateRequest.name?: string`
  - `SubAgentUpdateRequest.name?: string`
  - `SubAgentUpdateRequest.confirm_builtin_rename?: boolean`
- Validation behavior aligns with existing API style (HTTP 400 for invalid/duplicate rename attempts; conflict guard for built-in rename without confirmation).
- No database migration was introduced; existing unique constraints on `name` are reused.

This PR was written using [Vibe Kanban](https://vibekanban.com)
