### PR TITLE
refactor(plugins-ui): convert SubAgents cards to responsive tiled layout with fixed height and coverage tests (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
@@ -27,10 +27,10 @@ interface SubAgentCardProps {
 
 export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <div className="flex items-center gap-2 mb-1">
+    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex min-h-0 flex-1 items-start justify-between gap-3">
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="mb-1 flex flex-wrap items-center gap-2">
             <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {agent.display_name || agent.name}
             </h3>
@@ -55,25 +55,31 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
               </span>
             )}
           </div>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
+          <p
+            className="mb-2 line-clamp-3 text-sm text-zinc-500 dark:text-zinc-400"
+            title={agent.description || "No description"}
+          >
             {agent.description || "No description"}
           </p>
           <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
             {agent.model && (
-              <span className="inline-flex items-center gap-1">
+              <span className="inline-flex max-w-full items-center gap-1 truncate" title={agent.model}>
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
-                {agent.model}
+                <span className="truncate">{agent.model}</span>
               </span>
             )}
             {"agent_class" in agent.adk_config &&
               typeof agent.adk_config["agent_class"] === "string" && (
-              <span className="inline-flex items-center gap-1">
+              <span
+                className="inline-flex max-w-full items-center gap-1 truncate"
+                title={String(agent.adk_config["agent_class"])}
+              >
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
-                {String(agent.adk_config["agent_class"])}
+                <span className="truncate">{String(agent.adk_config["agent_class"])}</span>
               </span>
             )}
             {agent.skills && agent.skills.length > 0 && (
@@ -93,19 +99,20 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
                 {agent.tools.length} tools
               </span>
             )}
-            <span className="inline-flex items-center gap-1">
+            <span className="inline-flex items-center gap-1 truncate" title={`source: ${agent.source}`}>
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
-              source: {agent.source}
+              <span className="truncate">source: {agent.source}</span>
             </span>
           </div>
           {agent.skills && agent.skills.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
+            <div className="mt-2 flex flex-wrap gap-1 overflow-hidden">
               {agent.skills.slice(0, 3).map((skill) => (
                 <span
                   key={skill}
                   className="inline-flex items-center rounded bg-purple-50 px-2 py-0.5 text-xs text-purple-600 dark:bg-purple-900/20 dark:text-purple-400"
+                  title={skill}
                 >
                   {skill}
                 </span>
@@ -116,9 +123,11 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <button
             onClick={onEdit}
+            title="Edit SubAgent"
+            aria-label={`Edit ${agent.display_name || agent.name}`}
             className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -127,6 +136,8 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
           </button>
           <button
             onClick={onDelete}
+            title="Delete SubAgent"
+            aria-label={`Delete ${agent.display_name || agent.name}`}
             className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -145,7 +145,7 @@ export default function SubAgentsPage() {
       <PluginsNav title="SubAgents" />
       <div className="flex-1 overflow-auto">
         <div className="px-6 py-6">
-          <div className="mx-auto max-w-4xl">
+          <div className="mx-auto max-w-6xl">
             <div className="flex items-center justify-between mb-6">
               <div>
                 <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
@@ -203,14 +203,18 @@ export default function SubAgentsPage() {
                 </div>
               </div>
             ) : (
-              <div className="grid gap-4">
+              <div
+                data-testid="subagents-grid"
+                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+              >
                 {agents.map((agent) => (
-                  <SubAgentCard
-                    key={agent.id}
-                    agent={agent}
-                    onEdit={() => handleEdit(agent)}
-                    onDelete={() => handleDelete(agent.id)}
-                  />
+                  <div key={agent.id} className="h-[280px]" data-testid="subagent-grid-item">
+                    <SubAgentCard
+                      agent={agent}
+                      onEdit={() => handleEdit(agent)}
+                      onDelete={() => handleDelete(agent.id)}
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/apps/negentropy-ui/tests/unit/plugins/SubAgentCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/SubAgentCard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SubAgentCard } from "@/app/plugins/subagents/_components/SubAgentCard";
+
+const baseAgent = {
+  id: "a1",
+  owner_id: "u1",
+  visibility: "private",
+  name: "PerceptionFaculty",
+  display_name: "PerceptionFaculty",
+  description:
+    "Handles long description text for responsive card layout testing and tooltip fallback.",
+  agent_type: "llm_agent",
+  system_prompt: null,
+  model: "zai/glm-5",
+  config: {},
+  adk_config: { agent_class: "LlmAgent" },
+  skills: ["skill_a", "skill_b", "skill_c", "skill_d"],
+  tools: ["tool_a", "tool_b"],
+  source: "negentropy_builtin",
+  is_builtin: true,
+  is_enabled: true,
+};
+
+describe("SubAgentCard", () => {
+  it("calls edit and delete handlers", async () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(<SubAgentCard agent={baseAgent} onEdit={onEdit} onDelete={onDelete} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit PerceptionFaculty" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete PerceptionFaculty" }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps fixed-height layout classes and title tooltip for description", () => {
+    const { container } = render(
+      <SubAgentCard agent={baseAgent} onEdit={vi.fn()} onDelete={vi.fn()} />
+    );
+
+    const root = container.firstElementChild;
+    expect(root).toHaveClass("h-full");
+
+    const description = screen.getByText((content) => content.includes("Handles long description"));
+    expect(description).toHaveAttribute("title", baseAgent.description);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import SubAgentsPage from "@/app/plugins/subagents/page";
+
+vi.mock("@/components/ui/PluginsNav", () => ({
+  PluginsNav: ({ title }: { title: string }) => <div data-testid="plugins-nav">{title}</div>,
+}));
+
+vi.mock("@/app/plugins/subagents/_components/SubAgentFormDialog", () => ({
+  SubAgentFormDialog: () => null,
+}));
+
+vi.mock("@/app/plugins/subagents/_components/SubAgentCard", () => ({
+  SubAgentCard: ({ agent }: { agent: { name: string } }) => (
+    <div data-testid="subagent-card">{agent.name}</div>
+  ),
+}));
+
+describe("SubAgentsPage layout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders responsive grid classes and fixed-height items", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "a1",
+          owner_id: "u1",
+          visibility: "private",
+          name: "PerceptionFaculty",
+          display_name: null,
+          description: "desc",
+          agent_type: "llm_agent",
+          system_prompt: null,
+          model: null,
+          config: {},
+          adk_config: {},
+          skills: [],
+          tools: [],
+          source: "negentropy_builtin",
+          is_builtin: true,
+          is_enabled: true,
+        },
+      ],
+    } as Response);
+
+    render(<SubAgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subagent-card")).toBeInTheDocument();
+    });
+
+    const grid = screen.getByTestId("subagents-grid");
+    expect(grid).toHaveClass("grid-cols-1");
+    expect(grid).toHaveClass("md:grid-cols-2");
+    expect(grid).toHaveClass("xl:grid-cols-3");
+
+    const item = screen.getByTestId("subagent-grid-item");
+    expect(item).toHaveClass("h-[280px]");
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves the `Plugins / SubAgents` page by replacing the previous single-column stacked card presentation with a responsive tiled layout while preserving existing behavior.

## What changed

- Updated SubAgents list layout from a single-column stack to a responsive grid:
  - `1 column` on small screens
  - `2 columns` on medium screens (`md`)
  - `3 columns` on extra-large screens (`xl`, max 3 visible cards per row)
- Increased page content container width (`max-w-4xl` -> `max-w-6xl`) to better support 3-column readability.
- Set each SubAgent card slot to a fixed height (`h-[280px]`) for consistent visual rhythm.
- Refactored `SubAgentCard` to fit fixed-height tiling:
  - card root uses full-height/flex layout
  - long text is truncated in-place to avoid card overflow
  - added `title` tooltips for truncated description/model/agent_class/source/skills
  - kept edit/delete actions always visible and added accessibility labels
- Added tests:
  - `SubAgentCard` behavior and tooltip/fixed-height class checks
  - `SubAgentsPage` responsive grid class and fixed-height item checks

## Why

The task required moving from a stacked card layout to a tiled layout with:
- fixed card height,
- width evenly scaled with viewport,
- maximum 3 cards per row,
- automatic fallback to fewer columns as viewport narrows,
while ensuring no regression to existing SubAgent features.

This implementation follows a minimal-intervention UI refactor approach:
- separate layout concerns at the page grid level,
- keep interaction/data logic unchanged,
- add targeted tests to reduce regression risk.

## Implementation details

- Main layout changes:
  - `apps/negentropy-ui/app/plugins/subagents/page.tsx`
- Card structure and truncation/accessibility updates:
  - `apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx`
- New tests:
  - `apps/negentropy-ui/tests/unit/plugins/SubAgentCard.test.tsx`
  - `apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx`

## Validation

- Unit and integration test suite passes in `apps/negentropy-ui` via:
  - `pnpm test`

This PR was written using [Vibe Kanban](https://vibekanban.com)
