### PR TITLE
fix(plugins-ui): reduce SubAgents card height to 2/3 and align page content to nav edges (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -145,7 +145,7 @@ export default function SubAgentsPage() {
       <PluginsNav title="SubAgents" />
       <div className="flex-1 overflow-auto">
         <div className="px-6 py-6">
-          <div className="mx-auto max-w-6xl">
+          <div className="w-full">
             <div className="flex items-center justify-between mb-6">
               <div>
                 <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
@@ -208,7 +208,7 @@ export default function SubAgentsPage() {
                 className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
               >
                 {agents.map((agent) => (
-                  <div key={agent.id} className="h-[280px]" data-testid="subagent-grid-item">
+                  <div key={agent.id} className="h-[187px]" data-testid="subagent-grid-item">
                     <SubAgentCard
                       agent={agent}
                       onEdit={() => handleEdit(agent)}

--- a/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
@@ -57,6 +57,6 @@ describe("SubAgentsPage layout", () => {
     expect(grid).toHaveClass("xl:grid-cols-3");
 
     const item = screen.getByTestId("subagent-grid-item");
-    expect(item).toHaveClass("h-[280px]");
+    expect(item).toHaveClass("h-[187px]");
   });
 });


### PR DESCRIPTION
## Summary

This PR fine-tunes the `Plugins / SubAgents` layout after the tiled-card rollout by reducing card height and removing extra horizontal whitespace.

## What changes were made

- Updated SubAgents page container width handling:
  - changed from `mx-auto max-w-6xl` to `w-full`
  - this allows content to use available width and align with top navigation horizontal edges.
- Reduced each SubAgent grid item height:
  - from `h-[280px]` to `h-[187px]` (approximately 2/3 of the previous height).
- Updated unit test to match the new fixed height:
  - `SubAgentsLayout.test.tsx` assertion updated from `h-[280px]` to `h-[187px]`.

## Why these changes were made

Based on task feedback, the previous version still had:
- cards that felt too tall for the desired visual density,
- noticeable side whitespace caused by a centered max-width container.

This update addresses both requirements directly:
- card height is reduced to the requested ~2/3,
- page content now stretches to align with the primary navigation’s horizontal boundaries,
while keeping existing behavior and responsive grid logic unchanged.

## Important implementation details

- Responsive grid behavior remains the same (`1/2/3` columns via breakpoints).
- Only presentation-layer classes were adjusted; no data flow, API call, or interaction logic changed.
- Corresponding unit test was updated to keep verification consistent with the UI contract.

This PR was written using [Vibe Kanban](https://vibekanban.com)
