### PR TITLE
fix(plugins-ui): expand SubAgents description to 4 lines and rebalance card height spacing (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
@@ -79,7 +79,7 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
           )}
         </div>
         <p
-          className="mb-1 min-w-0 w-full line-clamp-2 text-sm text-zinc-500 dark:text-zinc-400"
+          className="mb-1 min-w-0 w-full line-clamp-4 text-sm text-zinc-500 dark:text-zinc-400"
           title={agent.description || "No description"}
         >
           {agent.description || "No description"}

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -208,7 +208,7 @@ export default function SubAgentsPage() {
                 className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
               >
                 {agents.map((agent) => (
-                  <div key={agent.id} className="h-[187px]" data-testid="subagent-grid-item">
+                  <div key={agent.id} className="h-[232px]" data-testid="subagent-grid-item">
                     <SubAgentCard
                       agent={agent}
                       onEdit={() => handleEdit(agent)}

--- a/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
@@ -57,6 +57,6 @@ describe("SubAgentsPage layout", () => {
     expect(grid).toHaveClass("xl:grid-cols-3");
 
     const item = screen.getByTestId("subagent-grid-item");
-    expect(item).toHaveClass("h-[187px]");
+    expect(item).toHaveClass("h-[232px]");
   });
 });


### PR DESCRIPTION
## Summary

This PR improves the SubAgents card readability by expanding the description area and rebalancing card height for consistent visual spacing.

## What changes were made

- Expanded the SubAgents description block from 2 lines to 4 lines:
  - `line-clamp-2` → `line-clamp-4` in `SubAgentCard.tsx`.
- Increased fixed card item height to preserve top/bottom spacing balance after the 4-line description change:
  - `h-[187px]` → `h-[232px]` in `page.tsx`.
- Updated unit test assertion to match the new fixed height:
  - `SubAgentsLayout.test.tsx` now validates `h-[232px]`.

## Why these changes were made

Based on the latest UI feedback, the description content area needed to present more text (4 lines) while keeping card spacing visually balanced.  
Without increasing card height, the lower spacing would become compressed and inconsistent with the upper area.  
This update applies a minimal, targeted layout adjustment to improve readability without changing behavior.

## Important implementation details

- Changes are purely presentational (UI class-level updates only).
- Existing interactions and data flow remain unchanged.
- Responsive grid behavior is preserved; only the card height baseline and description clamp were adjusted.
- Test coverage was updated in lockstep to keep the layout contract explicit.

This PR was written using [Vibe Kanban](https://vibekanban.com)
