### PR TITLE
fix(plugins-ui): pin SubAgents config row to card bottom and eliminate extra vertical whitespace (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
@@ -79,12 +79,12 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
           )}
         </div>
         <p
-          className="mb-1 min-w-0 w-full line-clamp-4 text-sm text-zinc-500 dark:text-zinc-400"
+          className="mb-1 h-20 min-w-0 w-full overflow-hidden leading-5 line-clamp-4 text-sm text-zinc-500 dark:text-zinc-400"
           title={agent.description || "No description"}
         >
           {agent.description || "No description"}
         </p>
-        <div className="flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap text-xs text-zinc-400 dark:text-zinc-500">
+        <div className="mt-auto flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-zinc-400 dark:text-zinc-500">
           {agent.model && (
             <span className="inline-flex min-w-0 items-center gap-1 truncate" title={agent.model}>
               <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -208,7 +208,7 @@ export default function SubAgentsPage() {
                 className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
               >
                 {agents.map((agent) => (
-                  <div key={agent.id} className="h-[232px]" data-testid="subagent-grid-item">
+                  <div key={agent.id} className="h-[196px]" data-testid="subagent-grid-item">
                     <SubAgentCard
                       agent={agent}
                       onEdit={() => handleEdit(agent)}

--- a/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/SubAgentsLayout.test.tsx
@@ -57,6 +57,6 @@ describe("SubAgentsPage layout", () => {
     expect(grid).toHaveClass("xl:grid-cols-3");
 
     const item = screen.getByTestId("subagent-grid-item");
-    expect(item).toHaveClass("h-[232px]");
+    expect(item).toHaveClass("h-[196px]");
   });
 });


### PR DESCRIPTION
## Summary

This PR refines SubAgents card vertical layout by pinning the config row to the card bottom and removing extra vertical whitespace while keeping the description area fixed to four lines.

## What changes were made

- Updated SubAgent card description block to a strict 4-line fixed-height area:
  - `line-clamp-4` retained
  - `h-20` + `leading-5` + `overflow-hidden` added for deterministic 4-line height.
- Anchored the bottom config row to the lower area of the card:
  - added `mt-auto` and `pt-1` to keep it consistently docked near the bottom edge with controlled spacing.
- Reduced fixed card height on SubAgents page:
  - from `h-[232px]` to `h-[196px]` to remove redundant vertical blank space.
- Updated layout unit test assertion accordingly:
  - `SubAgentsLayout.test.tsx` now validates `h-[196px]`.

## Why these changes were made

Based on the latest UI feedback, cards still had unnecessary vertical slack and inconsistent lower alignment.  
This change applies a minimal, layout-only adjustment so that:
- description keeps an exact 4-line visual budget,
- config row stays stably docked at the bottom,
- overall card height matches content density without extra whitespace.

## Important implementation details

- No API, schema, route, or interaction logic changes.
- Edit/Delete behaviors and data flow remain unchanged.
- Changes are strictly presentational and test-synchronized.

This PR was written using [Vibe Kanban](https://vibekanban.com)
