### PR TITLE
统一 Skills 与 MCP Servers 为 SubAgents 同款响应式平铺卡片布局 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -506,6 +506,7 @@ export function McpServerCard({
   const [expandedToolName, setExpandedToolName] = useState<string | null>(null);
   const visibleToolCount = tools.length > 0 ? tools.length : server.tool_count;
   const showToolToggle = visibleToolCount > 0 || loadingTools;
+  const summaryDescription = server.description?.trim() || "No description";
 
   const expandedTool = useMemo(
     () => tools.find((tool) => tool.name === expandedToolName) || null,
@@ -526,62 +527,99 @@ export function McpServerCard({
   };
 
   return (
-    <div className="rounded-2xl border border-zinc-200/80 bg-gradient-to-b from-white to-zinc-50/60 p-4 shadow-sm transition-shadow hover:shadow-md dark:border-zinc-700/80 dark:from-zinc-900 dark:to-zinc-900">
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <div className="flex items-center gap-2 mb-1">
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+    <div className="space-y-2">
+      <div className="flex h-[196px] flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
+            <h3 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {server.display_name || server.name}
             </h3>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                onClick={onLoad}
+                disabled={loadingTools}
+                className="rounded-md p-2 text-zinc-400 hover:bg-blue-50 hover:text-blue-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
+                title="Load Tools from Server"
+                aria-label={`Load tools for ${server.display_name || server.name}`}
+              >
+                {loadingTools ? (
+                  <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                ) : (
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                )}
+              </button>
+              <button
+                onClick={onEdit}
+                title="Edit Server"
+                aria-label={`Edit ${server.display_name || server.name}`}
+                className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
+              <button
+                onClick={onDelete}
+                title="Delete Server"
+                aria-label={`Delete ${server.display_name || server.name}`}
+                className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
             {server.is_enabled ? (
-              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+              <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
                 Enabled
               </span>
             ) : (
-              <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              <span className="inline-flex shrink-0 items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
                 Disabled
               </span>
             )}
-            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+            <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
+              {server.transport_type}
+            </span>
+            <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
               {server.visibility}
             </span>
           </div>
-          <div className="mb-2">
-            <RichTextContent
-              content={server.description}
-              emptyText="No description"
-            />
-          </div>
-          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
-            <span className="inline-flex items-center gap-1">
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+
+          <p
+            className="mb-1 h-20 min-w-0 w-full overflow-hidden text-sm leading-5 text-zinc-500 line-clamp-4 dark:text-zinc-400"
+            title={summaryDescription}
+          >
+            {summaryDescription}
+          </p>
+
+          <div className="mt-auto flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-zinc-400 dark:text-zinc-500">
+            <span className="inline-flex shrink-0 items-center gap-1">
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
               </svg>
-              {server.transport_type}
+              {loadingTools && visibleToolCount === 0 ? "Loading tools..." : `${visibleToolCount} tools`}
             </span>
             {showToolToggle && (
               <button
                 type="button"
                 onClick={handleToggleTools}
-                className="inline-flex items-center gap-1 rounded px-1 py-0.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                className="inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
                 aria-expanded={showTools}
                 title="Toggle tools list"
               >
                 {loadingTools ? (
                   <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="3"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V1a11 11 0 00-8 19l2-2.4A8 8 0 014 12z"
-                    />
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V1a11 11 0 00-8 19l2-2.4A8 8 0 014 12z" />
                   </svg>
                 ) : (
                   <svg
@@ -593,12 +631,12 @@ export function McpServerCard({
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                 )}
-                {loadingTools && visibleToolCount === 0 ? "Loading tools..." : `${visibleToolCount} tools`}
+                Tools
               </button>
             )}
             {server.auto_start && (
-              <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <span className="inline-flex shrink-0 items-center gap-1 text-amber-600 dark:text-amber-400">
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
                 Auto-start
@@ -606,56 +644,16 @@ export function McpServerCard({
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Load 按钮 */}
-          <button
-            onClick={onLoad}
-            disabled={loadingTools}
-            className="rounded-md p-2 text-zinc-400 hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-900/20 dark:hover:text-blue-400 disabled:opacity-50 disabled:cursor-not-allowed"
-            title="Load Tools from Server"
-          >
-            {loadingTools ? (
-              <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-            )}
-          </button>
-          {/* Edit 按钮 */}
-          <button
-            onClick={onEdit}
-            className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
-          </button>
-          {/* Delete 按钮 */}
-          <button
-            onClick={onDelete}
-            className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          </button>
-        </div>
       </div>
 
-      {/* 错误提示 */}
       {loadError && (
-        <div className="mt-3 rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+        <div className="rounded-md bg-red-50 p-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
           {loadError}
         </div>
       )}
 
-      {/* Tools 展示区域 */}
       {showTools && tools.length > 0 && (
-        <div className="mt-2 border-t border-zinc-200 pt-2 dark:border-zinc-700">
+        <div className="border-t border-zinc-200 pt-2 dark:border-zinc-700">
           <div className="space-y-3">
             <div className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
               <p className="mb-2 text-xs text-zinc-500 dark:text-zinc-400">
@@ -670,9 +668,7 @@ export function McpServerCard({
                       <button
                         type="button"
                         onClick={() =>
-                          setExpandedToolName((prev) =>
-                            prev === tool.name ? null : tool.name
-                          )
+                          setExpandedToolName((prev) => (prev === tool.name ? null : tool.name))
                         }
                         aria-expanded={isExpanded}
                         title={getToolTooltipText(tool)}

--- a/apps/negentropy-ui/app/plugins/mcp/page.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/page.tsx
@@ -212,7 +212,7 @@ export default function McpServersPage() {
       <PluginsNav title="MCP Servers" />
       <div className="flex-1 overflow-auto">
         <div className="px-6 py-6">
-          <div className="mx-auto max-w-4xl">
+          <div className="w-full">
             <div className="flex items-center justify-between mb-6">
               <div>
                 <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
@@ -247,18 +247,22 @@ export default function McpServersPage() {
                 </button>
               </div>
             ) : (
-              <div className="grid gap-4">
+              <div
+                data-testid="mcp-grid"
+                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+              >
                 {servers.map((server) => (
-                  <McpServerCard
-                    key={server.id}
-                    server={server}
-                    onEdit={() => handleEdit(server)}
-                    onDelete={() => handleDelete(server.id)}
-                    onLoad={() => handleLoadTools(server.id)}
-                    tools={server.tools}
-                    loadingTools={server.loadingTools}
-                    loadError={server.loadError}
-                  />
+                  <div key={server.id} data-testid="mcp-grid-item">
+                    <McpServerCard
+                      server={server}
+                      onEdit={() => handleEdit(server)}
+                      onDelete={() => handleDelete(server.id)}
+                      onLoad={() => handleLoadTools(server.id)}
+                      tools={server.tools}
+                      loadingTools={server.loadingTools}
+                      loadError={server.loadError}
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/apps/negentropy-ui/app/plugins/skills/_components/SkillCard.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/_components/SkillCard.tsx
@@ -25,75 +25,82 @@ interface SkillCardProps {
 
 export function SkillCard({ skill, onEdit, onDelete }: SkillCardProps) {
   return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <div className="flex items-center gap-2 mb-1">
-            <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-              {skill.display_name || skill.name}
-            </h3>
-            {skill.is_enabled ? (
-              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
-                Enabled
-              </span>
-            ) : (
-              <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
-                Disabled
-              </span>
-            )}
-            <span className="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
-              {skill.category}
-            </span>
-            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-              {skill.visibility}
-            </span>
-          </div>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-2">
-            {skill.description || "No description"}
-          </p>
-          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400 dark:text-zinc-500">
-            <span className="inline-flex items-center gap-1">
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
+          <h3 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            {skill.display_name || skill.name}
+          </h3>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              onClick={onEdit}
+              title="Edit Skill"
+              aria-label={`Edit ${skill.display_name || skill.name}`}
+              className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
               </svg>
-              v{skill.version}
-            </span>
-            {skill.priority > 0 && (
-              <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                </svg>
-                Priority: {skill.priority}
-              </span>
-            )}
-            {skill.required_tools && skill.required_tools.length > 0 && (
-              <span className="inline-flex items-center gap-1">
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                {skill.required_tools.length} tools required
-              </span>
-            )}
+            </button>
+            <button
+              onClick={onDelete}
+              title="Delete Skill"
+              aria-label={`Delete ${skill.display_name || skill.name}`}
+              className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={onEdit}
-            className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
+          {skill.is_enabled ? (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+              Enabled
+            </span>
+          ) : (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              Disabled
+            </span>
+          )}
+          <span className="inline-flex shrink-0 items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
+            {skill.category}
+          </span>
+          <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+            {skill.visibility}
+          </span>
+        </div>
+        <p
+          className="mb-1 h-20 min-w-0 w-full overflow-hidden text-sm leading-5 text-zinc-500 line-clamp-4 dark:text-zinc-400"
+          title={skill.description || "No description"}
+        >
+          {skill.description || "No description"}
+        </p>
+        <div className="mt-auto flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-zinc-400 dark:text-zinc-500">
+          <span className="inline-flex shrink-0 items-center gap-1">
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
             </svg>
-          </button>
-          <button
-            onClick={onDelete}
-            className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-          </button>
+            v{skill.version}
+          </span>
+          {skill.priority > 0 && (
+            <span className="inline-flex shrink-0 items-center gap-1 text-amber-600 dark:text-amber-400">
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+              </svg>
+              Priority: {skill.priority}
+            </span>
+          )}
+          {skill.required_tools && skill.required_tools.length > 0 && (
+            <span className="inline-flex shrink-0 items-center gap-1">
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              {skill.required_tools.length} tools required
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/app/plugins/skills/page.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/page.tsx
@@ -116,7 +116,7 @@ export default function SkillsPage() {
       <PluginsNav title="Skills" />
       <div className="flex-1 overflow-auto">
         <div className="px-6 py-6">
-          <div className="mx-auto max-w-4xl">
+          <div className="w-full">
             <div className="flex items-center justify-between mb-6">
               <div>
                 <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
@@ -169,14 +169,18 @@ export default function SkillsPage() {
                 </button>
               </div>
             ) : (
-              <div className="grid gap-4">
+              <div
+                data-testid="skills-grid"
+                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+              >
                 {skills.map((skill) => (
-                  <SkillCard
-                    key={skill.id}
-                    skill={skill}
-                    onEdit={() => handleEdit(skill)}
-                    onDelete={() => handleDelete(skill.id)}
-                  />
+                  <div key={skill.id} className="h-[196px]" data-testid="skill-grid-item">
+                    <SkillCard
+                      skill={skill}
+                      onEdit={() => handleEdit(skill)}
+                      onDelete={() => handleDelete(skill.id)}
+                    />
+                  </div>
                 ))}
               </div>
             )}

--- a/apps/negentropy-ui/tests/unit/plugins/McpLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/McpLayout.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import McpServersPage from "@/app/plugins/mcp/page";
+
+vi.mock("@/components/ui/PluginsNav", () => ({
+  PluginsNav: ({ title }: { title: string }) => <div data-testid="plugins-nav">{title}</div>,
+}));
+
+vi.mock("@/app/plugins/mcp/_components/McpServerFormDialog", () => ({
+  McpServerFormDialog: () => null,
+}));
+
+vi.mock("@/app/plugins/mcp/_components/McpServerCard", () => ({
+  McpServerCard: ({ server }: { server: { name: string } }) => (
+    <div data-testid="mcp-card">{server.name}</div>
+  ),
+}));
+
+describe("McpServersPage layout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders responsive grid classes", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "m1",
+          owner_id: "u1",
+          visibility: "private",
+          name: "local-mcp",
+          display_name: null,
+          description: "desc",
+          transport_type: "stdio",
+          command: "uvx",
+          args: [],
+          env: {},
+          url: null,
+          headers: {},
+          is_enabled: false,
+          auto_start: false,
+          config: {},
+          tool_count: 0,
+        },
+      ],
+    } as Response);
+
+    render(<McpServersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-card")).toBeInTheDocument();
+    });
+
+    const grid = screen.getByTestId("mcp-grid");
+    expect(grid).toHaveClass("grid-cols-1");
+    expect(grid).toHaveClass("md:grid-cols-2");
+    expect(grid).toHaveClass("xl:grid-cols-3");
+
+    expect(screen.getByTestId("mcp-grid-item")).toBeInTheDocument();
+  });
+});

--- a/apps/negentropy-ui/tests/unit/plugins/SkillsLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/SkillsLayout.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import SkillsPage from "@/app/plugins/skills/page";
+
+vi.mock("@/components/ui/PluginsNav", () => ({
+  PluginsNav: ({ title }: { title: string }) => <div data-testid="plugins-nav">{title}</div>,
+}));
+
+vi.mock("@/app/plugins/skills/_components/SkillFormDialog", () => ({
+  SkillFormDialog: () => null,
+}));
+
+vi.mock("@/app/plugins/skills/_components/SkillCard", () => ({
+  SkillCard: ({ skill }: { skill: { name: string } }) => (
+    <div data-testid="skill-card">{skill.name}</div>
+  ),
+}));
+
+describe("SkillsPage layout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders responsive grid classes and fixed-height items", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          id: "s1",
+          owner_id: "u1",
+          visibility: "private",
+          name: "CodeReview",
+          display_name: null,
+          description: "desc",
+          category: "analysis",
+          version: "1.0.0",
+          prompt_template: null,
+          config_schema: {},
+          default_config: {},
+          required_tools: [],
+          is_enabled: true,
+          priority: 0,
+        },
+      ],
+    } as Response);
+
+    render(<SkillsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("skill-card")).toBeInTheDocument();
+    });
+
+    const grid = screen.getByTestId("skills-grid");
+    expect(grid).toHaveClass("grid-cols-1");
+    expect(grid).toHaveClass("md:grid-cols-2");
+    expect(grid).toHaveClass("xl:grid-cols-3");
+
+    const item = screen.getByTestId("skill-grid-item");
+    expect(item).toHaveClass("h-[196px]");
+  });
+});


### PR DESCRIPTION
## 变更内容

本 PR 将 Plugins 区域中已在 SubAgents 验证通过的卡片布局模式复用到 **Skills** 与 **MCP Servers**，并保持现有功能行为不变。

### UI / 布局改动
- 将 `Skills` 卡片结构调整为与 SubAgents 一致的信息层次：
  - 标题 + 操作按钮行
  - 标签单行（状态/分类/可见性）
  - 描述区固定 4 行高度
  - 底部信息行
- 将 `Skills` 页面列表改为响应式平铺网格：
  - 小屏 `grid-cols-1`
  - 中屏 `md:grid-cols-2`
  - 大屏 `xl:grid-cols-3`
  - 卡片项固定高度 `h-[196px]`，保证对齐一致
- 将 `MCP Servers` 卡片摘要区调整为同款结构，同时保留 tools 加载与展开交互能力。
- 将 `MCP Servers` 页面列表改为相同的 1/2/3 列响应式网格。

### 测试覆盖
- 新增布局测试：
  - `apps/negentropy-ui/tests/unit/plugins/SkillsLayout.test.tsx`
  - `apps/negentropy-ui/tests/unit/plugins/McpLayout.test.tsx`
- 相关插件布局/卡片测试在本次验证中保持通过。

## 变更原因

任务要求将 SubAgents 已验证的卡片布局规范扩展到同域页面，确保：
- 卡片固定高度与信息分层一致
- 宽度随视口均分缩放
- 横向最多 3 列，收窄后自动降级为 2/1 列
- 不影响既有功能

该实现遵循复用驱动与最小干预原则：复用成熟布局范式，而非新增平行实现。

## 关键实现细节

- `Skills` 与 `MCP` 页面采用与 SubAgents 一致的断点与网格策略。
- `MCP` 卡片保留 `Load / Edit / Delete` 与 tools 展开逻辑，仅统一摘要区排版与层次。
- 通过新增测试锚点与单测，显式锁定布局行为，降低回归风险。

This PR was written using [Vibe Kanban](https://vibekanban.com)
