### PR TITLE
Fix Pipeline run visibility race after ingest navigation (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import {
@@ -11,6 +11,9 @@ import {
 } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+const RUNNING_POLL_INTERVAL_MS = 3000;
+const BOOTSTRAP_POLL_INTERVAL_MS = 1000;
+const BOOTSTRAP_POLL_MAX_TICKS = 8;
 
 type RunRecord = PipelineRunRecord;
 
@@ -110,6 +113,34 @@ const hasRunningRuns = (runs: PipelineRunRecord[] | undefined): boolean => {
   );
 };
 
+interface RunsSnapshot {
+  count: number;
+  firstRunId: string | null;
+  firstStatus: string | null;
+  firstVersion: number | null;
+}
+
+const createRunsSnapshot = (
+  runs: PipelineRunRecord[] | undefined,
+): RunsSnapshot => {
+  const first = runs?.[0];
+  return {
+    count: runs?.length ?? 0,
+    firstRunId: first?.run_id ?? null,
+    firstStatus: first?.status ?? null,
+    firstVersion: first?.version ?? null,
+  };
+};
+
+const isSameRunsSnapshot = (a: RunsSnapshot, b: RunsSnapshot): boolean => {
+  return (
+    a.count === b.count &&
+    a.firstRunId === b.firstRunId &&
+    a.firstStatus === b.firstStatus &&
+    a.firstVersion === b.firstVersion
+  );
+};
+
 // 计算 Stage 宽度（基于平方根比例，更好体现耗时差异）
 const calculateStageWidth = (
   stage: { duration_ms?: number },
@@ -148,53 +179,98 @@ export default function KnowledgePipelinesPage() {
   const [selected, setSelected] = useState<RunRecord | null>(null);
   const [saveStatus, setSaveStatus] = useState<string | null>(null);
   const [retryQueue, setRetryQueue] = useState<RunRecord[]>([]);
+  const [hasInitialLoad, setHasInitialLoad] = useState(false);
+
+  const applyPayload = useCallback((data: KnowledgePipelinesPayload) => {
+    setPayload(data);
+    setError(null);
+    setSelected((prev) => {
+      if (!data.runs?.length) return null;
+      if (!prev) return data.runs[0];
+      const updated = data.runs.find((r) => r.id === prev.id);
+      return updated ?? data.runs[0];
+    });
+  }, []);
+
+  const loadPipelines = useCallback(async () => {
+    const data = await fetchPipelines(APP_NAME);
+    applyPayload(data);
+    return data;
+  }, [applyPayload]);
 
   useEffect(() => {
     let active = true;
-    fetchPipelines(APP_NAME)
-      .then((data) => {
-        if (active) {
-          setPayload(data);
-          if (data.runs?.length) {
-            setSelected(data.runs[0]);
-          }
-        }
-      })
-      .catch((err) => {
+    (async () => {
+      try {
+        const data = await fetchPipelines(APP_NAME);
+        if (!active) return;
+        applyPayload(data);
+        setHasInitialLoad(true);
+      } catch (err) {
         if (active) {
           setError(String(err));
         }
-      });
+      }
+    })();
     return () => {
       active = false;
     };
-  }, []);
+  }, [applyPayload]);
+
+  // 首屏兜底轮询（避免刚跳转时因时序空窗漏掉新 Run）
+  useEffect(() => {
+    if (!hasInitialLoad) return;
+    if (hasRunningRuns(payload?.runs)) return;
+
+    let active = true;
+    let tick = 0;
+    const baseline = createRunsSnapshot(payload?.runs);
+
+    const intervalId = setInterval(async () => {
+      tick += 1;
+      try {
+        const data = await fetchPipelines(APP_NAME);
+        if (!active) return;
+
+        const nextSnapshot = createRunsSnapshot(data.runs);
+        const changed = !isSameRunsSnapshot(baseline, nextSnapshot);
+        const running = hasRunningRuns(data.runs);
+
+        if (changed || running) {
+          applyPayload(data);
+          clearInterval(intervalId);
+          return;
+        }
+      } catch (err) {
+        if (!active) return;
+        setError(String(err));
+      }
+
+      if (tick >= BOOTSTRAP_POLL_MAX_TICKS) {
+        clearInterval(intervalId);
+      }
+    }, BOOTSTRAP_POLL_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      clearInterval(intervalId);
+    };
+  }, [applyPayload, hasInitialLoad, payload?.runs]);
 
   // 自动刷新 Effect（当有 running 状态时启动）
   useEffect(() => {
     if (!hasRunningRuns(payload?.runs)) return;
 
-    const intervalId = setInterval(async () => {
-      try {
-        const data = await fetchPipelines(APP_NAME);
-        setPayload(data);
-        setError(null);
-
-        // 保持选中状态，更新数据
-        setSelected((prev) => {
-          if (!prev) return data.runs?.[0] ?? null;
-          const updated = data.runs?.find((r) => r.id === prev.id);
-          return updated ?? prev;
-        });
-      } catch (err) {
+    const intervalId = setInterval(() => {
+      loadPipelines().catch((err) => {
         setError(String(err));
-      }
-    }, 3000);
+      });
+    }, RUNNING_POLL_INTERVAL_MS);
 
     return () => {
       clearInterval(intervalId);
     };
-  }, [payload?.runs]);
+  }, [loadPipelines, payload?.runs]);
 
   const runs = payload?.runs || [];
   const statusColor = (status?: string) => {

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
@@ -1,0 +1,111 @@
+import { act, render, screen } from "@testing-library/react";
+
+const { fetchPipelinesMock, upsertPipelinesMock } = vi.hoisted(() => ({
+  fetchPipelinesMock: vi.fn(),
+  upsertPipelinesMock: vi.fn(),
+}));
+
+vi.mock("@/components/ui/KnowledgeNav", () => ({
+  KnowledgeNav: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/features/knowledge", () => ({
+  fetchPipelines: (...args: unknown[]) => fetchPipelinesMock(...args),
+  upsertPipelines: (...args: unknown[]) => upsertPipelinesMock(...args),
+}));
+
+import KnowledgePipelinesPage from "@/app/knowledge/pipelines/page";
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const settle = async () => {
+  await act(async () => {
+    await flushPromises();
+  });
+};
+
+const makeRun = (overrides?: Partial<{ id: string; run_id: string; status: string; version: number }>) => ({
+  id: overrides?.id ?? "run-1-id",
+  run_id: overrides?.run_id ?? "run-1",
+  status: overrides?.status ?? "completed",
+  version: overrides?.version ?? 1,
+});
+
+describe("KnowledgePipelinesPage polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchPipelinesMock.mockReset();
+    upsertPipelinesMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("在首屏无数据时，会通过兜底轮询自动显示新 Run", async () => {
+    fetchPipelinesMock
+      .mockResolvedValueOnce({ runs: [], last_updated_at: "t0" })
+      .mockResolvedValueOnce({ runs: [], last_updated_at: "t1" })
+      .mockResolvedValueOnce({
+        runs: [makeRun({ run_id: "run-new", id: "run-new-id" })],
+        last_updated_at: "t2",
+      });
+
+    render(<KnowledgePipelinesPage />);
+    await settle();
+    expect(fetchPipelinesMock).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByText("暂无作业")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await settle();
+
+    expect(screen.getAllByText("run-new").length).toBeGreaterThan(0);
+  });
+
+  it("兜底轮询在达到 8 秒窗口后停止继续请求", async () => {
+    fetchPipelinesMock.mockResolvedValue({
+      runs: [],
+      last_updated_at: "t0",
+    });
+
+    render(<KnowledgePipelinesPage />);
+    await settle();
+    expect(fetchPipelinesMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8000);
+    });
+    await settle();
+    expect(fetchPipelinesMock).toHaveBeenCalledTimes(9);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    await settle();
+
+    expect(fetchPipelinesMock).toHaveBeenCalledTimes(9);
+  });
+
+  it("存在 running Run 时按 3 秒节奏轮询", async () => {
+    fetchPipelinesMock.mockResolvedValue({
+      runs: [makeRun({ status: "running" })],
+      last_updated_at: "t0",
+    });
+
+    render(<KnowledgePipelinesPage />);
+    await settle();
+    expect(fetchPipelinesMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    await settle();
+    expect(fetchPipelinesMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a race condition where a newly created ingest run may not appear immediately in the **Knowledge → Pipelines** page when users navigate there right after clicking **Ingest** in **Knowledge Base**.

## What Changed

- Updated `app/knowledge/pipelines/page.tsx`:
  - Added a **bootstrap polling window** (`8s @ 1s`) for first-load eventual consistency.
  - Kept existing running-state polling (`3s`) and refactored shared fetch/apply logic to avoid duplicated state update paths.
  - Added run-list snapshot comparison logic to stop bootstrap polling early once data changes are detected.
- Added tests in `tests/unit/knowledge/PipelinesPage.test.tsx`:
  - Verifies new runs become visible automatically during bootstrap polling.
  - Verifies bootstrap polling stops after the configured time window.
  - Verifies running runs continue to poll on the normal 3-second cadence.

## Why

Task context indicated that users were told to check Pipeline progress after ingest, but immediate navigation sometimes showed no corresponding run until manual browser refresh.
The root cause was a timing gap: if initial Pipeline fetch happened before the new run was visible, the page could remain stale without a short first-load revalidation window.

## Important Implementation Details

- Introduced two polling phases:
  - **Bootstrap phase**: short-lived revalidation for eventual consistency on first load.
  - **Running phase**: existing long-running status refresh while runs are in progress.
- Implemented snapshot-based change detection (`count`, first `run_id`, first `status`, first `version`) to minimize unnecessary state churn and requests.
- Ensured interval cleanup and active guards to avoid updates after unmount and prevent polling leaks.

This PR was written using [Vibe Kanban](https://vibekanban.com)
