### PR TITLE
fix(knowledge-ui): center source deletion modal and show source name in confirmation (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+interface DeleteSourceDialogProps {
+  isOpen: boolean;
+  sourceName: string | null;
+  isDeleting?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteSourceDialog({
+  isOpen,
+  sourceName,
+  isDeleting = false,
+  onClose,
+  onConfirm,
+}: DeleteSourceDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            Delete Source
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={isDeleting}
+            className="text-zinc-400 hover:text-zinc-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:text-zinc-300"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+          确定彻底删除来源{" "}
+          <span className="font-semibold">
+            {sourceName ?? "-"}
+          </span>{" "}
+          吗？此操作会删除关联 chunks 与存储文件，且不可恢复。
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isDeleting}
+            className="rounded-lg px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isDeleting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx
@@ -11,7 +11,7 @@ interface SourceListProps {
   onReplaceSource?: (uri: string) => void;
   onSyncSource?: (uri: string) => void;
   onRebuildSource?: (uri: string) => void;
-  onDeleteSource?: (uri: string) => void;
+  onDeleteSource?: (payload: { uri: string; name: string }) => void;
   onArchiveSource?: (uri: string) => void;
   onUnarchiveSource?: (uri: string) => void;
 }
@@ -137,7 +137,7 @@ function SourceMenu({
   onReplace?: (uri: string) => void;
   onSync?: (uri: string) => void;
   onRebuild?: (uri: string) => void;
-  onDelete?: (uri: string) => void;
+  onDelete?: (payload: { uri: string; name: string }) => void;
   onArchive?: (uri: string) => void;
   onUnarchive?: (uri: string) => void;
 }) {
@@ -146,6 +146,14 @@ function SourceMenu({
   const closeAndRun = (fn?: (uri: string) => void) => {
     setIsOpen(false);
     fn?.(uri);
+  };
+
+  const closeAndRunDelete = () => {
+    setIsOpen(false);
+    onDelete?.({
+      uri,
+      name: getDisplayUri(uri),
+    });
   };
 
   const isFile = sourceType === "file";
@@ -207,7 +215,7 @@ function SourceMenu({
             )}
             {onDelete && (
               <button
-                onClick={() => closeAndRun(onDelete)}
+                onClick={closeAndRunDelete}
                 className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-red-600 hover:bg-red-50"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -21,6 +21,7 @@ import { ContentExplorer } from "./_components/ContentExplorer";
 import { SourceList } from "./_components/SourceList";
 import { AddSourceDialog } from "./_components/AddSourceDialog";
 import { ReplaceSourceDialog } from "./_components/ReplaceSourceDialog";
+import { DeleteSourceDialog } from "./_components/DeleteSourceDialog";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
@@ -62,6 +63,10 @@ export default function KnowledgeBasePage() {
   const [isAddSourceOpen, setIsAddSourceOpen] = useState(false);
   const [isReplaceOpen, setIsReplaceOpen] = useState(false);
   const [replaceSourceUri, setReplaceSourceUri] = useState<string | null>(null);
+  const [isDeleteSourceOpen, setIsDeleteSourceOpen] = useState(false);
+  const [deleteSourceUri, setDeleteSourceUri] = useState<string | null>(null);
+  const [deleteSourceName, setDeleteSourceName] = useState<string | null>(null);
+  const [isDeletingSource, setIsDeletingSource] = useState(false);
 
   const kb = useKnowledgeBase({
     appName: APP_NAME,
@@ -295,25 +300,42 @@ export default function KnowledgeBasePage() {
     loadChunks();
   }, [loadChunks]);
 
-  const handleDeleteSource = useCallback(
-    async (uri: string) => {
-      if (!confirm(`确定彻底删除来源 "${uri}" 吗？此操作会删除关联 chunks 与存储文件，且不可恢复。`)) {
-        return;
-      }
-      try {
-        const result = await kb.deleteSource({ source_uri: uri });
-        const warningText = result.warnings?.length ? `（${result.warnings.length} 条告警）` : "";
-        toast.success("来源已删除", {
-          description: `删除 chunks: ${result.deleted_count ?? 0}，文档: ${result.deleted_documents ?? 0}${warningText}`,
-        });
-        await loadChunks();
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        toast.error("删除来源失败", { description: errorMessage });
-      }
+  const handleRequestDeleteSource = useCallback(
+    (payload: { uri: string; name: string }) => {
+      setDeleteSourceUri(payload.uri);
+      setDeleteSourceName(payload.name);
+      setIsDeleteSourceOpen(true);
     },
-    [kb, loadChunks],
+    [],
   );
+
+  const handleCancelDeleteSource = useCallback(() => {
+    if (isDeletingSource) return;
+    setIsDeleteSourceOpen(false);
+    setDeleteSourceUri(null);
+    setDeleteSourceName(null);
+  }, [isDeletingSource]);
+
+  const handleConfirmDeleteSource = useCallback(async () => {
+    if (!deleteSourceUri || isDeletingSource) return;
+    setIsDeletingSource(true);
+    try {
+      const result = await kb.deleteSource({ source_uri: deleteSourceUri });
+      const warningText = result.warnings?.length ? `（${result.warnings.length} 条告警）` : "";
+      toast.success("来源已删除", {
+        description: `删除 chunks: ${result.deleted_count ?? 0}，文档: ${result.deleted_documents ?? 0}${warningText}`,
+      });
+      setIsDeleteSourceOpen(false);
+      setDeleteSourceUri(null);
+      setDeleteSourceName(null);
+      await loadChunks();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      toast.error("删除来源失败", { description: errorMessage });
+    } finally {
+      setIsDeletingSource(false);
+    }
+  }, [deleteSourceUri, isDeletingSource, kb, loadChunks]);
 
   const handleArchiveSource = useCallback(
     async (uri: string, archived: boolean) => {
@@ -430,7 +452,7 @@ export default function KnowledgeBasePage() {
                             onReplaceSource={handleOpenReplace}
                             onSyncSource={handleSyncSource}
                             onRebuildSource={handleRebuildSource}
-                            onDeleteSource={handleDeleteSource}
+                            onDeleteSource={handleRequestDeleteSource}
                             onArchiveSource={(uri) => handleArchiveSource(uri, true)}
                             onUnarchiveSource={(uri) => handleArchiveSource(uri, false)}
                           />
@@ -528,6 +550,14 @@ export default function KnowledgeBasePage() {
         onClose={() => setIsReplaceOpen(false)}
         onReplace={handleReplace}
         onSuccess={handleReplaceSuccess}
+      />
+
+      <DeleteSourceDialog
+        isOpen={isDeleteSourceOpen}
+        sourceName={deleteSourceName}
+        isDeleting={isDeletingSource}
+        onClose={handleCancelDeleteSource}
+        onConfirm={handleConfirmDeleteSource}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

This PR improves the Source deletion UX in **Knowledge Base > Sources** by replacing browser confirm behavior with a centered in-app modal and by showing a user-facing Source name instead of the raw GCS URI in delete confirmation text.

## What Changes Were Made

### UI/Interaction changes
- Added a dedicated centered delete confirmation modal:
  - `DeleteSourceDialog`
  - Modal is rendered at viewport center (`fixed inset-0 ... items-center justify-center`) to match existing dialog behavior and visual consistency.
- Replaced `window.confirm(...)` flow in the Knowledge Base page with state-driven modal flow:
  - request delete -> open modal -> confirm -> execute delete -> refresh list
- Updated delete callback wiring in `SourceList`:
  - delete action now carries both `uri` (backend identifier) and `name` (display label)
  - confirmation text uses display name rather than storage URI

### Files touched
- `apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx` (new)
- `apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx`
- `apps/negentropy-ui/app/knowledge/base/page.tsx`

## Why These Changes Were Made

Based on task context and UX requirements:
- Delete confirmation should appear in the visual center to avoid weak focus and accidental misreads.
- The delete target should be understandable to users; therefore confirmation should display a Source name instead of a backend GCS path.
- Keep deletion semantics unchanged while improving clarity and consistency with existing in-app dialog patterns.

## Important Implementation Details

- The modal is implemented as a reusable focused component (`DeleteSourceDialog`) instead of inline ad-hoc markup.
- `SourceList` now passes `{ uri, name }` for delete requests:
  - `uri` remains the deletion key for API calls.
  - `name` is derived from display logic and used in confirmation copy.
- `page.tsx` handles:
  - dialog open/close state
  - in-flight delete state (`isDeletingSource`)
  - success/error toast behavior
  - post-delete `loadChunks()` refresh
- This follows minimal-intervention principles: no backend API contract changes were introduced.

This PR was written using [Vibe Kanban](https://vibekanban.com)
