### PR TITLE
fix(knowledge-ui): improve delete prompt readability with middle-ellipsis source name formatting (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx
@@ -8,6 +8,16 @@ interface DeleteSourceDialogProps {
   onConfirm: () => void;
 }
 
+function formatSourceNameForPrompt(name: string | null, maxLen = 36): string {
+  const normalized = (name ?? "").trim();
+  if (!normalized) return "-";
+  if (normalized.length <= maxLen) return normalized;
+
+  const headLen = Math.floor((maxLen - 3) / 2);
+  const tailLen = maxLen - 3 - headLen;
+  return `${normalized.slice(0, headLen)}...${normalized.slice(-tailLen)}`;
+}
+
 export function DeleteSourceDialog({
   isOpen,
   sourceName,
@@ -16,6 +26,7 @@ export function DeleteSourceDialog({
   onConfirm,
 }: DeleteSourceDialogProps) {
   if (!isOpen) return null;
+  const displaySourceName = formatSourceNameForPrompt(sourceName);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
@@ -47,8 +58,8 @@ export function DeleteSourceDialog({
 
         <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
           确定彻底删除来源{" "}
-          <span className="font-semibold">
-            {sourceName ?? "-"}
+          <span className="font-semibold break-all">
+            「{displaySourceName}」
           </span>{" "}
           吗？此操作会删除关联 chunks 与存储文件，且不可恢复。
         </div>


### PR DESCRIPTION
## Summary

This PR improves readability of the Source deletion warning text in the Knowledge Base delete dialog by formatting long Source names with middle ellipsis and clearer visual delimiters.

## What Changes Were Made

- Updated `DeleteSourceDialog` to format Source names shown in the delete warning text.
- Added a name-formatting utility to:
  - handle empty/null names safely
  - keep names under a maximum display length
  - truncate overly long names using **middle ellipsis** (`...`) instead of tail-only truncation
- Updated prompt copy to wrap the display name with `「...」` for higher visual scannability.
- Added defensive text wrapping behavior in the highlighted warning line to avoid overflow from long continuous strings.

### File touched
- `apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx`

## Why These Changes Were Made

Based on task context, users reported that long Source names could overflow the red warning area and reduce prompt readability during destructive actions.  
This change ensures the delete target remains recognizable while preserving layout stability and reducing cognitive load in a high-risk confirmation step.

## Important Implementation Details

- The formatting is performed at render time in the dialog component and does not alter backend identifiers or deletion semantics.
- Middle-ellipsis strategy preserves both head and tail information, which is more useful than tail truncation for filename/path-like strings.
- Existing delete flow, API behavior, and state transitions remain unchanged (minimal intervention and low regression risk).

This PR was written using [Vibe Kanban](https://vibekanban.com)
