### PR TITLE
Improve Knowledge Base Content UX with Expandable Rows and Coverage Tests (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/ContentExplorer.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ContentExplorer.tsx
@@ -1,5 +1,6 @@
-"use strict";
+"use client";
 
+import { useState } from "react";
 import { KnowledgeItem } from "@/features/knowledge";
 
 interface ContentExplorerProps {
@@ -10,6 +11,22 @@ interface ContentExplorerProps {
 }
 
 export function ContentExplorer({ items, loading, error, offset = 0 }: ContentExplorerProps) {
+  const [expandedState, setExpandedState] = useState<{
+    id: string;
+    contextToken: string;
+  } | null>(null);
+
+  const contextToken = `${offset}:${items.length}:${items[0]?.id ?? "empty"}`;
+
+  const toggleRow = (id: string) => {
+    setExpandedState((prev) => {
+      if (prev?.id === id && prev.contextToken === contextToken) {
+        return null;
+      }
+      return { id, contextToken };
+    });
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-border bg-card p-5 shadow-sm">
       <h2 className="shrink-0 text-sm font-semibold text-card-foreground">
@@ -39,24 +56,60 @@ export function ContentExplorer({ items, loading, error, offset = 0 }: ContentEx
               </tr>
             </thead>
             <tbody className="text-foreground">
-              {items.map((item, index) => (
+              {items.map((item, index) => {
+                const isExpanded =
+                  expandedState?.id === item.id &&
+                  expandedState.contextToken === contextToken;
+                return (
                 <tr
                   key={item.id}
-                  className="border-b border-border last:border-0 hover:bg-muted/50"
+                  className={`border-b border-border last:border-0 transition-colors ${
+                    isExpanded ? "bg-muted/30" : "hover:bg-muted/50"
+                  }`}
                 >
                   <td className="whitespace-nowrap py-2 pr-2 text-muted/70">
                     {offset + index + 1}
                   </td>
-                  <td className="max-w-[400px] py-2 pr-4">
-                    <p className="line-clamp-2" title={item.content}>
-                      {item.content}
-                    </p>
+                  <td className="max-w-[400px] py-2 pr-4 align-top">
+                    <button
+                      type="button"
+                      data-testid={`content-toggle-${item.id}`}
+                      aria-expanded={isExpanded}
+                      aria-controls={`content-body-${item.id}`}
+                      onClick={() => toggleRow(item.id)}
+                      className="w-full rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border/70 hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    >
+                      <div className="relative">
+                        <div
+                          id={`content-body-${item.id}`}
+                          data-testid={`content-body-${item.id}`}
+                          className={`text-xs leading-5 break-words transition-all duration-200 ease-out ${
+                            isExpanded
+                              ? "max-h-[1000rem] scale-100 opacity-100 whitespace-pre-wrap"
+                              : "line-clamp-2 max-h-10 scale-[0.99] opacity-90"
+                          }`}
+                          title={isExpanded ? undefined : item.content}
+                        >
+                          {item.content}
+                        </div>
+                        {!isExpanded && (
+                          <div
+                            aria-hidden="true"
+                            className="pointer-events-none absolute inset-x-0 bottom-0 h-5 bg-gradient-to-t from-card to-transparent"
+                          />
+                        )}
+                      </div>
+                      <div className="mt-1 text-[11px] text-muted/80">
+                        {isExpanded ? "Collapse" : "Expand"}
+                      </div>
+                    </button>
                   </td>
                   <td className="whitespace-nowrap py-2 text-muted/70">
                     {new Date(item.created_at).toLocaleString()}
                   </td>
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/apps/negentropy-ui/tests/unit/knowledge/ContentExplorer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/ContentExplorer.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ContentExplorer } from "@/app/knowledge/base/_components/ContentExplorer";
+import type { KnowledgeItem } from "@/features/knowledge";
+
+const makeItem = (id: string, content: string): KnowledgeItem => ({
+  id,
+  content,
+  source_uri: "test://source",
+  created_at: "2026-03-05T10:00:00.000Z",
+  chunk_index: 0,
+  metadata: {},
+});
+
+describe("ContentExplorer", () => {
+  it("默认以折叠态渲染内容", () => {
+    render(
+      <ContentExplorer
+        items={[makeItem("item-1", "第一行内容，默认应为折叠状态展示。".repeat(8))]}
+      />,
+    );
+
+    const toggle = screen.getByTestId("content-toggle-item-1");
+    const body = screen.getByTestId("content-body-item-1");
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(body.className).toContain("line-clamp-2");
+  });
+
+  it("支持点击展开/收起，且同一时间仅展开一行", async () => {
+    render(
+      <ContentExplorer
+        items={[
+          makeItem("item-1", "Chunk 1 内容。".repeat(12)),
+          makeItem("item-2", "Chunk 2 内容。".repeat(12)),
+        ]}
+      />,
+    );
+
+    const firstToggle = screen.getByTestId("content-toggle-item-1");
+    const secondToggle = screen.getByTestId("content-toggle-item-2");
+    const firstBody = screen.getByTestId("content-body-item-1");
+    const secondBody = screen.getByTestId("content-body-item-2");
+
+    await userEvent.click(firstToggle);
+    expect(firstToggle).toHaveAttribute("aria-expanded", "true");
+    expect(firstBody.className).toContain("whitespace-pre-wrap");
+    expect(firstBody.className).not.toContain("line-clamp-2");
+
+    await userEvent.click(secondToggle);
+    expect(firstToggle).toHaveAttribute("aria-expanded", "false");
+    expect(secondToggle).toHaveAttribute("aria-expanded", "true");
+    expect(secondBody.className).toContain("whitespace-pre-wrap");
+    expect(firstBody.className).toContain("line-clamp-2");
+
+    await userEvent.click(secondToggle);
+    expect(secondToggle).toHaveAttribute("aria-expanded", "false");
+    expect(secondBody.className).toContain("line-clamp-2");
+  });
+
+  it("数据更新后会重置展开状态", async () => {
+    const { rerender } = render(
+      <ContentExplorer
+        items={[
+          makeItem("item-1", "Chunk 1 内容。".repeat(12)),
+          makeItem("item-2", "Chunk 2 内容。".repeat(12)),
+        ]}
+      />,
+    );
+
+    const firstToggle = screen.getByTestId("content-toggle-item-1");
+    await userEvent.click(firstToggle);
+    expect(firstToggle).toHaveAttribute("aria-expanded", "true");
+
+    rerender(
+      <ContentExplorer
+        items={[makeItem("item-3", "新数据。".repeat(12))]}
+      />,
+    );
+
+    const newToggle = screen.getByTestId("content-toggle-item-3");
+    expect(newToggle).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
## Summary
This PR improves the **Knowledge Base -> Content** viewing experience by introducing row-level progressive disclosure while preserving existing behavior (pagination, source filtering, loading/error/empty states).

## What Changed
- Refactored `ContentExplorer` to support clickable per-row content expansion/collapse.
- Kept the default truncated preview behavior (2-line clamp) for fast scanning.
- Added **single-row exclusive expansion** to reduce visual noise in dense tables.
- Added smooth visual transitions and collapsed-state fade masking for better readability.
- Added accessibility semantics for disclosure behavior:
  - `aria-expanded`
  - `aria-controls`
- Added unit tests for:
  - default collapsed rendering
  - expand/collapse interaction
  - single-row exclusivity
  - reset behavior when item data changes

## Why
The task required improving the Content display quality and adding a row-level "collapsed by default, expandable on click" interaction without regressing existing features.
This implementation follows common best practices:
- **Progressive Disclosure** (show summary first, reveal detail on demand)
- **Single-focus expansion** for high-density table readability
- **A11y-aware interactive controls** for robust UX

## Important Implementation Details
- Expansion state is tracked with a lightweight `contextToken` (derived from pagination/data context), so expanded state naturally resets when page data changes, preventing stale expansion across data contexts.
- Existing public interfaces and backend API contracts remain unchanged.
- Styling and behavior are localized to the Content explorer component, minimizing blast radius.
- Added targeted unit coverage in `tests/unit/knowledge/ContentExplorer.test.tsx`.

This PR was written using [Vibe Kanban](https://vibekanban.com)
