### PR TITLE
Fix Knowledge Base corpus navigation loop and error handling (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -88,7 +88,17 @@ export default function KnowledgeBasePage() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const kb = useKnowledgeBase({ appName: APP_NAME });
+  const {
+    corpora,
+    isLoading,
+    loadCorpora,
+    loadCorpus,
+    createCorpus,
+    updateCorpus,
+    deleteCorpus: deleteCorpusById,
+    ingestUrl,
+    ingestFile,
+  } = useKnowledgeBase({ appName: APP_NAME });
 
   const [viewMode, setViewMode] = useState<ViewMode>("overview");
   const [selectedCorpusId, setSelectedCorpusId] = useState<string | null>(null);
@@ -120,8 +130,8 @@ export default function KnowledgeBasePage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const selectedCorpus = useMemo(
-    () => kb.corpora.find((item) => item.id === selectedCorpusId) || null,
-    [kb.corpora, selectedCorpusId],
+    () => corpora.find((item) => item.id === selectedCorpusId) || null,
+    [corpora, selectedCorpusId],
   );
 
   const syncQueryState = useCallback(
@@ -140,9 +150,8 @@ export default function KnowledgeBasePage() {
   );
 
   useEffect(() => {
-    kb.loadCorpora();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void loadCorpora();
+  }, [loadCorpora]);
 
   useEffect(() => {
     const nextView = (searchParams.get("view") as ViewMode) || "overview";
@@ -158,9 +167,9 @@ export default function KnowledgeBasePage() {
 
   useEffect(() => {
     if (selectedCorpusId) {
-      kb.loadCorpus(selectedCorpusId);
+      void loadCorpus(selectedCorpusId);
     }
-  }, [kb, selectedCorpusId]);
+  }, [loadCorpus, selectedCorpusId]);
 
   const loadDocuments = useCallback(async () => {
     if (!selectedCorpusId) return;
@@ -207,7 +216,7 @@ export default function KnowledgeBasePage() {
   const handleRetrieve = async () => {
     const corpusIds = selectedRetrievalCorpusIds.length > 0
       ? selectedRetrievalCorpusIds
-      : kb.corpora.map((c) => c.id);
+      : corpora.map((c) => c.id);
     if (!query.trim() || corpusIds.length === 0) return;
 
     setRetrievalLoading(true);
@@ -252,7 +261,7 @@ export default function KnowledgeBasePage() {
   const handleDeleteCorpus = async (corpus: CorpusRecord) => {
     if (!confirm(`确定删除 Corpus \"${corpus.name}\" 吗？`)) return;
     try {
-      await kb.deleteCorpus(corpus.id);
+      await deleteCorpusById(corpus.id);
       toast.success("Corpus deleted");
       if (selectedCorpusId === corpus.id) {
         syncQueryState({ view: "overview", corpusId: null, tab: null, documentId: null });
@@ -268,12 +277,12 @@ export default function KnowledgeBasePage() {
     config?: Record<string, unknown>;
   }) => {
     if (dialogMode === "create") {
-      const created = await kb.createCorpus(params);
+      const created = await createCorpus(params);
       syncQueryState({ view: "corpus", corpusId: created.id, tab: "documents", documentId: null });
     } else if (editingCorpus) {
-      await kb.updateCorpus(editingCorpus.id, params);
+      await updateCorpus(editingCorpus.id, params);
       if (selectedCorpusId === editingCorpus.id) {
-        await kb.loadCorpus(editingCorpus.id);
+        await loadCorpus(editingCorpus.id);
       }
     }
     setIsDialogOpen(false);
@@ -284,7 +293,7 @@ export default function KnowledgeBasePage() {
     const url = window.prompt("请输入 URL");
     if (!url?.trim()) return;
     try {
-      await kb.ingestUrl({
+      await ingestUrl({
         url: url.trim(),
         as_document: true,
         chunkingConfig: selectedCorpus?.config as ChunkingConfig | undefined,
@@ -299,7 +308,7 @@ export default function KnowledgeBasePage() {
   const handleIngestFile = async (file: File) => {
     if (!selectedCorpusId) return;
     try {
-      await kb.ingestFile({
+      await ingestFile({
         file,
         source_uri: file.name,
         chunkingConfig: selectedCorpus?.config as ChunkingConfig | undefined,
@@ -362,8 +371,8 @@ export default function KnowledgeBasePage() {
   const handleSaveCorpusSettings = async (config: Record<string, unknown>) => {
     if (!selectedCorpus) return;
     try {
-      await kb.updateCorpus(selectedCorpus.id, { config });
-      await kb.loadCorpus(selectedCorpus.id);
+      await updateCorpus(selectedCorpus.id, { config });
+      await loadCorpus(selectedCorpus.id);
       toast.success("Settings saved");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Save settings failed");
@@ -409,7 +418,7 @@ export default function KnowledgeBasePage() {
       <div className="mt-3">
         <div className="mb-1 text-xs text-muted">Target Corpus（可多选）</div>
         <div className="flex flex-wrap gap-2">
-          {kb.corpora.map((corpus) => {
+          {corpora.map((corpus) => {
             const checked = selectedRetrievalCorpusIds.includes(corpus.id);
             return (
               <label key={corpus.id} className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs">
@@ -450,11 +459,11 @@ export default function KnowledgeBasePage() {
           Add Corpus
         </button>
       </div>
-      {kb.corpora.length === 0 ? (
+      {corpora.length === 0 ? (
         <p className="text-xs text-muted">暂无 Corpus</p>
       ) : (
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {kb.corpora.map((corpus) => (
+          {corpora.map((corpus) => (
             <div
               key={corpus.id}
               className="cursor-pointer rounded-xl border border-border bg-background p-4 transition hover:border-foreground/40"
@@ -693,7 +702,7 @@ export default function KnowledgeBasePage() {
         isOpen={isDialogOpen}
         mode={dialogMode}
         initialData={editingCorpus}
-        isLoading={kb.isLoading}
+        isLoading={isLoading}
         onClose={() => setIsDialogOpen(false)}
         onSubmit={handleDialogSubmit}
       />

--- a/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeBase.ts
+++ b/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeBase.ts
@@ -11,7 +11,7 @@
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CorpusRecord,
   IngestResult,
@@ -178,6 +178,7 @@ export function useKnowledgeBase(
   const [corpus, setCorpus] = useState<CorpusRecord | null>(null);
   const [corpora, setCorpora] = useState<CorpusRecord[]>([]);
   const [state, setState] = useState(DEFAULT_LOADING_STATE);
+  const activeCorpusId = corpus?.id;
 
   // 加载语料库
   const loadCorpus = useCallback(
@@ -252,7 +253,7 @@ export function useKnowledgeBase(
         setCorpora((prev) =>
           prev.map((c) => (c.id === id ? { ...c, ...result } : c)),
         );
-        if (corpus?.id === id) {
+        if (activeCorpusId === id) {
           setCorpus((prev) => (prev ? { ...prev, ...result } : result));
         }
         setState({ isLoading: false, error: null });
@@ -264,7 +265,7 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, onError],
+    [activeCorpusId, onError],
   );
 
   // 删除语料库
@@ -274,7 +275,7 @@ export function useKnowledgeBase(
       try {
         await deleteCorpus(id);
         setCorpora((prev) => prev.filter((c) => c.id !== id));
-        if (corpus?.id === id) {
+        if (activeCorpusId === id) {
           setCorpus(null);
         }
         setState({ isLoading: false, error: null });
@@ -285,7 +286,7 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, onError],
+    [activeCorpusId, onError],
   );
 
   // 摄取文本
@@ -296,13 +297,13 @@ export function useKnowledgeBase(
       metadata?: Record<string, unknown>;
       chunkingConfig?: ChunkingConfig;
     }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await ingestText(corpus.id, {
+        const result = await ingestText(activeCorpusId, {
           app_name: appName,
           text: params.text,
           source_uri: params.source_uri,
@@ -322,7 +323,7 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError, onIngestSuccess],
+    [activeCorpusId, appName, onError, onIngestSuccess],
   );
 
   // 摄取 URL
@@ -333,13 +334,13 @@ export function useKnowledgeBase(
       metadata?: Record<string, unknown>;
       chunkingConfig?: ChunkingConfig;
     }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await ingestUrl(corpus.id, {
+        const result = await ingestUrl(activeCorpusId, {
           app_name: appName,
           url: params.url,
           as_document: params.as_document,
@@ -359,7 +360,7 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError, onIngestSuccess],
+    [activeCorpusId, appName, onError, onIngestSuccess],
   );
 
   // 摄取文件
@@ -370,13 +371,13 @@ export function useKnowledgeBase(
       metadata?: Record<string, unknown>;
       chunkingConfig?: ChunkingConfig;
     }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await ingestFileApi(corpus.id, {
+        const result = await ingestFileApi(activeCorpusId, {
           app_name: appName,
           file: params.file,
           source_uri: params.source_uri,
@@ -395,7 +396,7 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError, onIngestSuccess],
+    [activeCorpusId, appName, onError],
   );
 
   // 替换源文本
@@ -406,13 +407,13 @@ export function useKnowledgeBase(
       metadata?: Record<string, unknown>;
       chunkingConfig?: ChunkingConfig;
     }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await replaceSource(corpus.id, {
+        const result = await replaceSource(activeCorpusId, {
           app_name: appName,
           text: params.text,
           source_uri: params.source_uri,
@@ -431,19 +432,19 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError],
+    [activeCorpusId, appName, onError],
   );
 
   // 同步 URL 源
   const syncSourceHandler = useCallback(
     async (params: { source_uri: string; chunkingConfig?: ChunkingConfig }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await syncSourceApi(corpus.id, {
+        const result = await syncSourceApi(activeCorpusId, {
           app_name: appName,
           source_uri: params.source_uri,
           chunk_size: params.chunkingConfig?.chunk_size,
@@ -461,19 +462,19 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError, onIngestSuccess],
+    [activeCorpusId, appName, onError, onIngestSuccess],
   );
 
   // 重建 GCS 源
   const rebuildSourceHandler = useCallback(
     async (params: { source_uri: string; chunkingConfig?: ChunkingConfig }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await rebuildSourceApi(corpus.id, {
+        const result = await rebuildSourceApi(activeCorpusId, {
           app_name: appName,
           source_uri: params.source_uri,
           chunk_size: params.chunkingConfig?.chunk_size,
@@ -491,19 +492,19 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError, onIngestSuccess],
+    [activeCorpusId, appName, onError, onIngestSuccess],
   );
 
   // 搜索知识库
   const searchHandler = useCallback(
     async (query: string, config?: SearchConfig) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await searchKnowledge(corpus.id, {
+        const result = await searchKnowledge(activeCorpusId, {
           app_name: appName,
           query,
           mode: config?.mode,
@@ -522,19 +523,19 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError, onSearchSuccess],
+    [activeCorpusId, appName, onError, onSearchSuccess],
   );
 
   // 删除源
   const deleteSourceHandler = useCallback(
     async (params: { source_uri: string }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await deleteSourceApi(corpus.id, {
+        const result = await deleteSourceApi(activeCorpusId, {
           app_name: appName,
           source_uri: params.source_uri,
         });
@@ -547,19 +548,19 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError],
+    [activeCorpusId, appName, onError],
   );
 
   // 归档/解档源
   const archiveSourceHandler = useCallback(
     async (params: { source_uri: string; archived?: boolean }) => {
-      if (!corpus?.id) {
+      if (!activeCorpusId) {
         throw new Error("No corpus selected");
       }
 
       setState({ isLoading: true, error: null });
       try {
-        const result = await archiveSourceApi(corpus.id, {
+        const result = await archiveSourceApi(activeCorpusId, {
           app_name: appName,
           source_uri: params.source_uri,
           archived: params.archived ?? true,
@@ -573,34 +574,58 @@ export function useKnowledgeBase(
         throw err;
       }
     },
-    [corpus?.id, appName, onError],
+    [activeCorpusId, appName, onError],
   );
 
   // 初始化：如果有 corpusId，加载语料库
   useEffect(() => {
     if (initialCorpusId) {
-      loadCorpus(initialCorpusId);
+      queueMicrotask(() => {
+        void loadCorpus(initialCorpusId);
+      });
     }
   }, [initialCorpusId, loadCorpus]);
 
-  return {
-    corpus,
-    corpora,
-    isLoading: state.isLoading,
-    error: state.error,
-    loadCorpus,
-    loadCorpora,
-    createCorpus: createCorpusHandler,
-    updateCorpus: updateCorpusHandler,
-    deleteCorpus: deleteCorpusHandler,
-    ingestText: ingestTextHandler,
-    ingestUrl: ingestUrlHandler,
-    ingestFile: ingestFileHandler,
-    replaceSource: replaceSourceHandler,
-    syncSource: syncSourceHandler,
-    rebuildSource: rebuildSourceHandler,
-    deleteSource: deleteSourceHandler,
-    archiveSource: archiveSourceHandler,
-    search: searchHandler,
-  };
+  return useMemo(
+    () => ({
+      corpus,
+      corpora,
+      isLoading: state.isLoading,
+      error: state.error,
+      loadCorpus,
+      loadCorpora,
+      createCorpus: createCorpusHandler,
+      updateCorpus: updateCorpusHandler,
+      deleteCorpus: deleteCorpusHandler,
+      ingestText: ingestTextHandler,
+      ingestUrl: ingestUrlHandler,
+      ingestFile: ingestFileHandler,
+      replaceSource: replaceSourceHandler,
+      syncSource: syncSourceHandler,
+      rebuildSource: rebuildSourceHandler,
+      deleteSource: deleteSourceHandler,
+      archiveSource: archiveSourceHandler,
+      search: searchHandler,
+    }),
+    [
+      corpus,
+      corpora,
+      state.isLoading,
+      state.error,
+      loadCorpus,
+      loadCorpora,
+      createCorpusHandler,
+      updateCorpusHandler,
+      deleteCorpusHandler,
+      ingestTextHandler,
+      ingestUrlHandler,
+      ingestFileHandler,
+      replaceSourceHandler,
+      syncSourceHandler,
+      rebuildSourceHandler,
+      deleteSourceHandler,
+      archiveSourceHandler,
+      searchHandler,
+    ],
+  );
 }

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -403,10 +403,7 @@ export async function fetchCorpus(
   if (res.status === 404) {
     return null;
   }
-  if (!res.ok) {
-    throw new Error(`Failed to fetch corpus: ${res.statusText}`);
-  }
-  return res.json();
+  return handleKnowledgeError(res);
 }
 
 export interface KnowledgeItem {

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1,0 +1,101 @@
+import { act, render } from "@testing-library/react";
+
+const {
+  replaceMock,
+  useKnowledgeBaseMock,
+  loadCorpusMock,
+  loadCorporaMock,
+} = vi.hoisted(() => ({
+  replaceMock: vi.fn(),
+  useKnowledgeBaseMock: vi.fn(),
+  loadCorpusMock: vi.fn(),
+  loadCorporaMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+  usePathname: () => "/knowledge/base",
+  useSearchParams: () =>
+    new URLSearchParams("view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/ui/KnowledgeNav", () => ({
+  KnowledgeNav: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/app/knowledge/base/_components/CorpusFormDialog", () => ({
+  CorpusFormDialog: () => null,
+}));
+
+vi.mock("@/app/knowledge/base/_components/ReplaceDocumentDialog", () => ({
+  ReplaceDocumentDialog: () => null,
+}));
+
+vi.mock("@/features/knowledge", () => ({
+  useKnowledgeBase: (...args: unknown[]) => useKnowledgeBaseMock(...args),
+  fetchDocuments: vi.fn().mockResolvedValue({ items: [] }),
+  fetchDocumentChunks: vi.fn().mockResolvedValue({ items: [] }),
+  searchAcrossCorpora: vi.fn().mockResolvedValue({ items: [] }),
+  syncDocument: vi.fn(),
+  rebuildDocument: vi.fn(),
+  replaceDocument: vi.fn(),
+  archiveDocument: vi.fn(),
+  unarchiveDocument: vi.fn(),
+  downloadDocument: vi.fn(),
+  deleteDocument: vi.fn(),
+}));
+
+import KnowledgeBasePage from "@/app/knowledge/base/page";
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("KnowledgeBasePage", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+    loadCorpusMock.mockReset();
+    loadCorporaMock.mockReset();
+
+    loadCorpusMock.mockResolvedValue(undefined);
+    loadCorporaMock.mockResolvedValue(undefined);
+
+    useKnowledgeBaseMock.mockImplementation(() => ({
+      corpora: [],
+      isLoading: false,
+      loadCorpora: loadCorporaMock,
+      loadCorpus: loadCorpusMock,
+      createCorpus: vi.fn(),
+      updateCorpus: vi.fn(),
+      deleteCorpus: vi.fn(),
+      ingestUrl: vi.fn(),
+      ingestFile: vi.fn(),
+    }));
+  });
+
+  it("重新渲染时不会因为 hook 返回新对象而重复触发 loadCorpus", async () => {
+    const { rerender } = render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(loadCorpusMock).toHaveBeenCalledTimes(1);
+
+    rerender(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(loadCorpusMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -1,0 +1,38 @@
+import { fetchCorpus, KnowledgeError } from "@/features/knowledge/utils/knowledge-api";
+
+describe("fetchCorpus", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("在 404 时返回 null", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, { status: 404, statusText: "Not Found" }),
+    );
+
+    await expect(fetchCorpus("missing-id", "negentropy")).resolves.toBeNull();
+  });
+
+  it("在 422 时透传结构化错误而不是仅使用 statusText", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          detail: {
+            code: "INVALID_CORPUS_ID",
+            message: "Corpus id is not a valid UUID",
+          },
+        }),
+        {
+          status: 422,
+          statusText: "Unprocessable Entity",
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await expect(fetchCorpus("bad-id", "negentropy")).rejects.toMatchObject({
+      code: "INVALID_CORPUS_ID",
+      message: "Corpus id is not a valid UUID",
+    } satisfies Partial<KnowledgeError>);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from "@testing-library/react";
+
+const { fetchCorpusMock, fetchCorporaMock } = vi.hoisted(() => ({
+  fetchCorpusMock: vi.fn(),
+  fetchCorporaMock: vi.fn(),
+}));
+
+vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
+  const actual = await vi.importActual<typeof import("@/features/knowledge/utils/knowledge-api")>(
+    "@/features/knowledge/utils/knowledge-api",
+  );
+
+  return {
+    ...actual,
+    fetchCorpus: (...args: unknown[]) => fetchCorpusMock(...args),
+    fetchCorpora: (...args: unknown[]) => fetchCorporaMock(...args),
+    createCorpus: vi.fn(),
+    updateCorpus: vi.fn(),
+    deleteCorpus: vi.fn(),
+    ingestText: vi.fn(),
+    ingestUrl: vi.fn(),
+    ingestFile: vi.fn(),
+    replaceSource: vi.fn(),
+    syncSource: vi.fn(),
+    rebuildSource: vi.fn(),
+    deleteSource: vi.fn(),
+    archiveSource: vi.fn(),
+    searchKnowledge: vi.fn(),
+  };
+});
+
+import { useKnowledgeBase } from "@/features/knowledge/hooks/useKnowledgeBase";
+
+describe("useKnowledgeBase", () => {
+  beforeEach(() => {
+    fetchCorpusMock.mockReset();
+    fetchCorporaMock.mockReset();
+    fetchCorporaMock.mockResolvedValue([]);
+  });
+
+  it("在相同输入下保持返回对象和 loadCorpus 引用稳定", () => {
+    const { result, rerender } = renderHook(
+      ({ appName }: { appName: string }) => useKnowledgeBase({ appName }),
+      {
+        initialProps: { appName: "negentropy" },
+      },
+    );
+
+    const initialValue = result.current;
+    const initialLoadCorpus = result.current.loadCorpus;
+
+    rerender({ appName: "negentropy" });
+
+    expect(result.current).toBe(initialValue);
+    expect(result.current.loadCorpus).toBe(initialLoadCorpus);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a regression in the Knowledge Base corpus navigation flow that could cause the page to enter a render loop, surface an `Unprocessable Entity` error, and become unresponsive when opening a corpus from the Knowledge Base overview.

## What Changed

### Knowledge Base page stability
- Fixed the corpus detail navigation flow in the Knowledge Base page.
- Removed the effect dependency pattern that could repeatedly trigger `loadCorpus` on rerender.
- Reworked the page to depend on stable, destructured hook outputs instead of the entire hook return object.

### Hook stability
- Stabilized the `useKnowledgeBase` return value with memoization so consumers do not receive a fresh API object on every render.
- Normalized the hook’s callback dependencies around the active corpus id to avoid React Compiler / dependency drift issues.

### Error handling
- Updated `fetchCorpus` to preserve structured backend error information instead of collapsing failures into a generic `statusText` error.
- Kept the existing `404 -> null` behavior intact while improving non-404 error reporting.

### Tests
- Added regression coverage for:
  - stable `useKnowledgeBase` return references
  - preventing repeated `loadCorpus` calls when the page rerenders
  - preserving structured `fetchCorpus` errors for non-404 responses
  - keeping `404` behavior unchanged

## Why These Changes Were Made

The task context for this branch was a production-facing regression in the new Knowledge Base workflow:

- clicking a corpus card could trigger a render loop
- the page could freeze and block further navigation
- the UI only surfaced a generic `Unprocessable Entity` error, which obscured the actual backend response

These changes were made to eliminate the render loop at its source, harden the hook/page contract, and improve error observability so future failures are diagnosable instead of opaque.

## Important Implementation Details

- The root cause was an effect in the Knowledge Base page depending on the entire `useKnowledgeBase()` return object, while the hook returned a new object on each render.
- That created a loop of `loadCorpus -> setState -> rerender -> effect`.
- The fix addresses both sides of the contract:
  - the page now depends only on stable hook members
  - the hook now returns a memoized object
- `fetchCorpus` now routes non-404 failures through the shared structured error parser, so backend `code/message/details` are preserved.
- Regression tests were added at the page, hook, and API utility levels to lock this behavior down.

## Validation

Validated with targeted frontend lint and focused Vitest coverage for the new regression scenarios.

This PR was written using [Vibe Kanban](https://vibekanban.com)
