### PR TITLE
Center the Knowledge Base corpus delete confirmation dialog (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/DeleteCorpusDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/DeleteCorpusDialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+interface DeleteCorpusDialogProps {
+  isOpen: boolean;
+  corpusName: string | null;
+  isDeleting?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteCorpusDialog({
+  isOpen,
+  corpusName,
+  isDeleting = false,
+  onClose,
+  onConfirm,
+}: DeleteCorpusDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-corpus-dialog-title"
+        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2
+            id="delete-corpus-dialog-title"
+            className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
+          >
+            Delete Corpus
+          </h2>
+          <button
+            onClick={onClose}
+            disabled={isDeleting}
+            className="text-zinc-400 hover:text-zinc-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:text-zinc-300"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+          确定删除 Corpus{" "}
+          <span className="font-semibold break-all">
+            「{corpusName || "-"}」
+          </span>{" "}
+          吗？此操作不可恢复。
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            disabled={isDeleting}
+            className="rounded-lg px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isDeleting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -25,6 +25,7 @@ import {
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { CorpusFormDialog } from "./_components/CorpusFormDialog";
+import { DeleteCorpusDialog } from "./_components/DeleteCorpusDialog";
 import { ReplaceDocumentDialog } from "./_components/ReplaceDocumentDialog";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -124,6 +125,9 @@ export default function KnowledgeBasePage() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<"create" | "edit">("create");
   const [editingCorpus, setEditingCorpus] = useState<CorpusRecord | undefined>(undefined);
+  const [isDeleteCorpusDialogOpen, setIsDeleteCorpusDialogOpen] = useState(false);
+  const [deletingCorpus, setDeletingCorpus] = useState<CorpusRecord | null>(null);
+  const [isDeletingCorpus, setIsDeletingCorpus] = useState(false);
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] = useState(false);
   const [replacingDocument, setReplacingDocument] = useState<KnowledgeDocument | null>(null);
 
@@ -259,15 +263,25 @@ export default function KnowledgeBasePage() {
   };
 
   const handleDeleteCorpus = async (corpus: CorpusRecord) => {
-    if (!confirm(`确定删除 Corpus \"${corpus.name}\" 吗？`)) return;
+    setDeletingCorpus(corpus);
+    setIsDeleteCorpusDialogOpen(true);
+  };
+
+  const handleConfirmDeleteCorpus = async () => {
+    if (!deletingCorpus || isDeletingCorpus) return;
+    setIsDeletingCorpus(true);
     try {
-      await deleteCorpusById(corpus.id);
+      await deleteCorpusById(deletingCorpus.id);
       toast.success("Corpus deleted");
-      if (selectedCorpusId === corpus.id) {
+      if (selectedCorpusId === deletingCorpus.id) {
         syncQueryState({ view: "overview", corpusId: null, tab: null, documentId: null });
       }
+      setIsDeleteCorpusDialogOpen(false);
+      setDeletingCorpus(null);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setIsDeletingCorpus(false);
     }
   };
 
@@ -716,6 +730,18 @@ export default function KnowledgeBasePage() {
           setReplacingDocument(null);
         }}
         onSubmit={handleReplaceDocumentSubmit}
+      />
+
+      <DeleteCorpusDialog
+        isOpen={isDeleteCorpusDialogOpen}
+        corpusName={deletingCorpus?.name ?? null}
+        isDeleting={isDeletingCorpus}
+        onClose={() => {
+          if (isDeletingCorpus) return;
+          setIsDeleteCorpusDialogOpen(false);
+          setDeletingCorpus(null);
+        }}
+        onConfirm={handleConfirmDeleteCorpus}
       />
     </div>
   );

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1,22 +1,28 @@
-import { act, render } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const {
   replaceMock,
   useKnowledgeBaseMock,
   loadCorpusMock,
   loadCorporaMock,
+  deleteCorpusMock,
+  searchParamsState,
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
   loadCorpusMock: vi.fn(),
   loadCorporaMock: vi.fn(),
+  deleteCorpusMock: vi.fn(),
+  searchParamsState: {
+    value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
+  },
 }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
   usePathname: () => "/knowledge/base",
-  useSearchParams: () =>
-    new URLSearchParams("view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents"),
+  useSearchParams: () => new URLSearchParams(searchParamsState.value),
 }));
 
 vi.mock("sonner", () => ({
@@ -64,18 +70,29 @@ describe("KnowledgeBasePage", () => {
     replaceMock.mockReset();
     loadCorpusMock.mockReset();
     loadCorporaMock.mockReset();
+    deleteCorpusMock.mockReset();
+    searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
 
     loadCorpusMock.mockResolvedValue(undefined);
     loadCorporaMock.mockResolvedValue(undefined);
+    deleteCorpusMock.mockResolvedValue(undefined);
 
     useKnowledgeBaseMock.mockImplementation(() => ({
-      corpora: [],
+      corpora: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "Corpus Alpha",
+          app_name: "negentropy",
+          knowledge_count: 3,
+          config: {},
+        },
+      ],
       isLoading: false,
       loadCorpora: loadCorporaMock,
       loadCorpus: loadCorpusMock,
       createCorpus: vi.fn(),
       updateCorpus: vi.fn(),
-      deleteCorpus: vi.fn(),
+      deleteCorpus: deleteCorpusMock,
       ingestUrl: vi.fn(),
       ingestFile: vi.fn(),
     }));
@@ -97,5 +114,49 @@ describe("KnowledgeBasePage", () => {
     });
 
     expect(loadCorpusMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("点击 Delete 后会在页面中央打开确认框，并可取消", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Delete Corpus" });
+    expect(within(dialog).getByText(/Corpus Alpha/)).toBeInTheDocument();
+    expect(deleteCorpusMock).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Delete Corpus")).not.toBeInTheDocument();
+    expect(deleteCorpusMock).not.toHaveBeenCalled();
+  });
+
+  it("确认删除当前 Corpus 后会执行删除并跳回 overview", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = screen.getByRole("dialog", { name: "Delete Corpus" });
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(deleteCorpusMock).toHaveBeenCalledWith("11111111-1111-1111-1111-111111111111");
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This PR replaces the browser-native corpus delete confirmation in the Knowledge Base page with an in-app centered confirmation dialog and adds regression coverage for the new interaction.

## What Changed

### UI behavior
- Replaced the native `confirm()` flow used when deleting a corpus from the Knowledge Base page.
- Added a dedicated `DeleteCorpusDialog` component that renders as a centered modal inside the app UI.
- Kept the existing delete behavior, success handling, and navigation fallback logic intact.

### Interaction handling
- Added explicit local state to manage:
  - which corpus is pending deletion
  - whether the delete dialog is open
  - whether a delete request is in progress
- Disabled closing and repeated submission while deletion is in flight.

### Tests
- Added page-level regression coverage for:
  - opening the delete dialog from a corpus card
  - cancelling the delete flow
  - confirming deletion successfully

## Why These Changes Were Made

The task context for this branch was a UX defect in the Knowledge Base page: the delete confirmation for corpus removal was still using the browser-native confirmation dialog, which does not follow the product’s modal system and does not reliably present as an intentional, centered in-app experience.

This change aligns corpus deletion with the existing dialog patterns already used elsewhere in the Knowledge Base workflow, while preserving the underlying delete semantics.

## Important Implementation Details

- The new dialog follows the same modal pattern already used by other Knowledge Base dialogs:
  - fullscreen overlay
  - centered container
  - explicit cancel / confirm actions
- The delete action was split into two stages:
  - selecting a corpus and opening the dialog
  - executing deletion only after explicit confirmation
- The dialog is disabled while the delete request is pending to prevent duplicate submissions or inconsistent local state.
- Basic accessibility hooks were added to the dialog (`role="dialog"`, `aria-modal`, and label wiring) so the interaction is easier to test and behaves more like a proper application modal.

## Validation

Validated with targeted frontend lint and focused Vitest coverage for the corpus delete confirmation flow.

This PR was written using [Vibe Kanban](https://vibekanban.com)
