### PR TITLE
Align Knowledge Base document paging limits with API constraints (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -179,7 +179,7 @@ export default function KnowledgeBasePage() {
     if (!selectedCorpusId) return;
     setDocumentsLoading(true);
     try {
-      const res = await fetchDocuments(selectedCorpusId, { appName: APP_NAME, limit: 200, offset: 0 });
+      const res = await fetchDocuments(selectedCorpusId, { appName: APP_NAME, limit: 100, offset: 0 });
       setDocuments(res.items);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to load documents");
@@ -200,7 +200,7 @@ export default function KnowledgeBasePage() {
     try {
       const res = await fetchDocumentChunks(selectedCorpusId, selectedDocumentId, {
         appName: APP_NAME,
-        limit: 500,
+        limit: 200,
         offset: 0,
       });
       setDocumentChunks(res.items);

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -605,6 +605,22 @@ export interface DocumentChunksResponse {
 // Document Management API Functions
 // ============================================================================
 
+const DOCUMENTS_PAGE_LIMIT_MAX = 100;
+const DOCUMENTS_PAGE_LIMIT_DEFAULT = 50;
+const DOCUMENT_CHUNKS_PAGE_LIMIT_MAX = 200;
+const DOCUMENT_CHUNKS_PAGE_LIMIT_DEFAULT = 50;
+
+function clampPositiveInt(
+  value: number | undefined,
+  max: number,
+  fallback: number,
+): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.min(Math.trunc(value), max);
+}
+
 export async function fetchDocuments(
   corpusId: string,
   params?: {
@@ -614,8 +630,13 @@ export async function fetchDocuments(
   },
 ): Promise<DocumentListResponse> {
   const query = new URLSearchParams();
+  const limit = clampPositiveInt(
+    params?.limit,
+    DOCUMENTS_PAGE_LIMIT_MAX,
+    DOCUMENTS_PAGE_LIMIT_DEFAULT,
+  );
   if (params?.appName) query.set("app_name", params.appName);
-  if (params?.limit) query.set("limit", String(params.limit));
+  query.set("limit", String(limit));
   if (params?.offset) query.set("offset", String(params.offset));
 
   const res = await fetch(
@@ -783,8 +804,13 @@ export async function fetchDocumentChunks(
   },
 ): Promise<DocumentChunksResponse> {
   const query = new URLSearchParams();
+  const limit = clampPositiveInt(
+    params?.limit,
+    DOCUMENT_CHUNKS_PAGE_LIMIT_MAX,
+    DOCUMENT_CHUNKS_PAGE_LIMIT_DEFAULT,
+  );
   if (params?.appName) query.set("app_name", params.appName);
-  if (params?.limit !== undefined) query.set("limit", String(params.limit));
+  query.set("limit", String(limit));
   if (params?.offset !== undefined) query.set("offset", String(params.offset));
   if (params?.includeArchived !== undefined) {
     query.set("include_archived", String(params.includeArchived));

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -8,12 +8,16 @@ const {
   loadCorporaMock,
   deleteCorpusMock,
   searchParamsState,
+  fetchDocumentsMock,
+  fetchDocumentChunksMock,
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
   loadCorpusMock: vi.fn(),
   loadCorporaMock: vi.fn(),
   deleteCorpusMock: vi.fn(),
+  fetchDocumentsMock: vi.fn(),
+  fetchDocumentChunksMock: vi.fn(),
   searchParamsState: {
     value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
   },
@@ -46,8 +50,8 @@ vi.mock("@/app/knowledge/base/_components/ReplaceDocumentDialog", () => ({
 
 vi.mock("@/features/knowledge", () => ({
   useKnowledgeBase: (...args: unknown[]) => useKnowledgeBaseMock(...args),
-  fetchDocuments: vi.fn().mockResolvedValue({ items: [] }),
-  fetchDocumentChunks: vi.fn().mockResolvedValue({ items: [] }),
+  fetchDocuments: (...args: unknown[]) => fetchDocumentsMock(...args),
+  fetchDocumentChunks: (...args: unknown[]) => fetchDocumentChunksMock(...args),
   searchAcrossCorpora: vi.fn().mockResolvedValue({ items: [] }),
   syncDocument: vi.fn(),
   rebuildDocument: vi.fn(),
@@ -71,11 +75,15 @@ describe("KnowledgeBasePage", () => {
     loadCorpusMock.mockReset();
     loadCorporaMock.mockReset();
     deleteCorpusMock.mockReset();
+    fetchDocumentsMock.mockReset();
+    fetchDocumentChunksMock.mockReset();
     searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
 
     loadCorpusMock.mockResolvedValue(undefined);
     loadCorporaMock.mockResolvedValue(undefined);
     deleteCorpusMock.mockResolvedValue(undefined);
+    fetchDocumentsMock.mockResolvedValue({ items: [] });
+    fetchDocumentChunksMock.mockResolvedValue({ items: [] });
 
     useKnowledgeBaseMock.mockImplementation(() => ({
       corpora: [
@@ -158,5 +166,35 @@ describe("KnowledgeBasePage", () => {
 
     expect(deleteCorpusMock).toHaveBeenCalledWith("11111111-1111-1111-1111-111111111111");
     expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("进入 documents 视图时使用不超过后端约束的 limit=100", async () => {
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(fetchDocumentsMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      { appName: "negentropy", limit: 100, offset: 0 },
+    );
+  });
+
+  it("进入 document-chunks 视图时使用不超过后端约束的 limit=200", async () => {
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=document-chunks&documentId=doc-1";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(fetchDocumentChunksMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "doc-1",
+      { appName: "negentropy", limit: 200, offset: 0 },
+    );
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -1,4 +1,9 @@
-import { fetchCorpus, KnowledgeError } from "@/features/knowledge/utils/knowledge-api";
+import {
+  fetchCorpus,
+  fetchDocumentChunks,
+  fetchDocuments,
+  KnowledgeError,
+} from "@/features/knowledge/utils/knowledge-api";
 
 describe("fetchCorpus", () => {
   afterEach(() => {
@@ -34,5 +39,45 @@ describe("fetchCorpus", () => {
       code: "INVALID_CORPUS_ID",
       message: "Corpus id is not a valid UUID",
     } satisfies Partial<KnowledgeError>);
+  });
+
+  it("fetchDocuments 会把超限 limit 截断到 100", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ count: 0, items: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchDocuments("corpus-1", {
+      appName: "negentropy",
+      limit: 200,
+      offset: 0,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/knowledge/base/corpus-1/documents?app_name=negentropy&limit=100",
+      { cache: "no-store" },
+    );
+  });
+
+  it("fetchDocumentChunks 会把超限 limit 截断到 200", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ count: 0, items: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await fetchDocumentChunks("corpus-1", "doc-1", {
+      appName: "negentropy",
+      limit: 500,
+      offset: 0,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/knowledge/base/corpus-1/documents/doc-1/chunks?app_name=negentropy&limit=200&offset=0",
+      { cache: "no-store" },
+    );
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes a request contract mismatch in the Knowledge Base corpus detail flow by aligning frontend document/chunk paging limits with the backend API constraints and adding regression coverage for the affected paths.

## What Changed

### Request limit alignment
- Updated the Knowledge Base page so corpus document loading no longer requests an out-of-range `limit`.
- Updated the document chunk loading path so chunk browsing also stays within the backend-supported pagination bounds.

### API utility hardening
- Added client-side limit clamping in the Knowledge Base API utilities for:
  - corpus document listing
  - document chunk listing
- This ensures future callers cannot accidentally send page sizes larger than the backend accepts.

### Tests
- Added regression coverage to verify:
  - the Knowledge Base page uses backend-safe limits when loading documents
  - the Knowledge Base page uses backend-safe limits when loading chunks
  - API utility helpers clamp oversized limits before issuing requests

## Why These Changes Were Made

The task context for this branch was a `422 Unprocessable Entity` failure when entering a corpus detail page. The immediate cause was that the frontend requested document lists with a page size larger than the backend route allowed.

This fix was made to eliminate the current failure, prevent the same class of bug in the chunk view, and harden the API utility layer so future UI code cannot reintroduce the same contract mismatch.

## Important Implementation Details

- The backend already enforced the correct pagination constraints; the bug was on the frontend side.
- The page-level requests were corrected first so the current user flow stops failing immediately.
- The API utility layer was then updated with explicit limit clamping so the request contract is enforced in one place instead of relying on individual pages to remember the allowed maxima.
- Regression tests were added at both the page layer and the API utility layer to cover both the concrete user path and the shared request normalization behavior.

## Validation

Validated with targeted frontend lint and focused Vitest coverage for the affected Knowledge Base paging paths.

This PR was written using [Vibe Kanban](https://vibekanban.com)
