### PR TITLE
Add a toggleable corpus panel to docked retrieval results (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -113,6 +113,7 @@ export default function KnowledgeBasePage() {
   const [retrievalLoading, setRetrievalLoading] = useState(false);
   const [retrievalError, setRetrievalError] = useState<string | null>(null);
   const [retrievalDocked, setRetrievalDocked] = useState(false);
+  const [isCorpusPanelExpanded, setIsCorpusPanelExpanded] = useState(false);
 
   const [documents, setDocuments] = useState<KnowledgeDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
@@ -175,6 +176,12 @@ export default function KnowledgeBasePage() {
     }
   }, [loadCorpus, selectedCorpusId]);
 
+  useEffect(() => {
+    if (!retrievalDocked) {
+      setIsCorpusPanelExpanded(false);
+    }
+  }, [retrievalDocked]);
+
   const loadDocuments = useCallback(async () => {
     if (!selectedCorpusId) return;
     setDocumentsLoading(true);
@@ -234,6 +241,7 @@ export default function KnowledgeBasePage() {
       });
       setRetrievalResults(res.items);
       setRetrievalDocked(true);
+      setIsCorpusPanelExpanded(false);
     } catch (err) {
       setRetrievalError(err instanceof Error ? err.message : "Retrieve failed");
     } finally {
@@ -462,8 +470,8 @@ export default function KnowledgeBasePage() {
     </div>
   );
 
-  const renderCorpusCards = () => (
-    <div className="rounded-2xl border border-border bg-card p-4 shadow-sm">
+  const renderCorpusCards = ({ embedded = false }: { embedded?: boolean } = {}) => (
+    <div className={embedded ? "rounded-2xl border border-border bg-card p-4" : "rounded-2xl border border-border bg-card p-4 shadow-sm"}>
       <div className="mb-3 flex items-center justify-between">
         <h2 className="text-sm font-semibold">Corpus</h2>
         <button
@@ -554,11 +562,27 @@ export default function KnowledgeBasePage() {
             )}
 
             {!retrievalDocked && renderRetrievalModule()}
-            {renderCorpusCards()}
+            {!retrievalDocked && renderCorpusCards()}
 
             {retrievalDocked && (
               <div className="fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 px-6 py-3 backdrop-blur">
-                {renderRetrievalModule()}
+                <div className="mx-auto max-h-[70vh] max-w-[1400px] overflow-y-auto">
+                  {renderRetrievalModule()}
+                  <div className="mt-3 rounded-2xl border border-border bg-card p-3 shadow-sm">
+                    <button
+                      type="button"
+                      onClick={() => setIsCorpusPanelExpanded((prev) => !prev)}
+                      className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm font-semibold hover:bg-muted"
+                    >
+                      {isCorpusPanelExpanded ? "收起 Corpus" : "Corpus"}
+                    </button>
+                  </div>
+                  {isCorpusPanelExpanded && (
+                    <div className="mt-3">
+                      {renderCorpusCards({ embedded: true })}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -10,6 +10,7 @@ const {
   searchParamsState,
   fetchDocumentsMock,
   fetchDocumentChunksMock,
+  searchAcrossCorporaMock,
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
@@ -18,6 +19,7 @@ const {
   deleteCorpusMock: vi.fn(),
   fetchDocumentsMock: vi.fn(),
   fetchDocumentChunksMock: vi.fn(),
+  searchAcrossCorporaMock: vi.fn(),
   searchParamsState: {
     value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
   },
@@ -52,7 +54,7 @@ vi.mock("@/features/knowledge", () => ({
   useKnowledgeBase: (...args: unknown[]) => useKnowledgeBaseMock(...args),
   fetchDocuments: (...args: unknown[]) => fetchDocumentsMock(...args),
   fetchDocumentChunks: (...args: unknown[]) => fetchDocumentChunksMock(...args),
-  searchAcrossCorpora: vi.fn().mockResolvedValue({ items: [] }),
+  searchAcrossCorpora: (...args: unknown[]) => searchAcrossCorporaMock(...args),
   syncDocument: vi.fn(),
   rebuildDocument: vi.fn(),
   replaceDocument: vi.fn(),
@@ -77,6 +79,7 @@ describe("KnowledgeBasePage", () => {
     deleteCorpusMock.mockReset();
     fetchDocumentsMock.mockReset();
     fetchDocumentChunksMock.mockReset();
+    searchAcrossCorporaMock.mockReset();
     searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
 
     loadCorpusMock.mockResolvedValue(undefined);
@@ -84,6 +87,17 @@ describe("KnowledgeBasePage", () => {
     deleteCorpusMock.mockResolvedValue(undefined);
     fetchDocumentsMock.mockResolvedValue({ items: [] });
     fetchDocumentChunksMock.mockResolvedValue({ items: [] });
+    searchAcrossCorporaMock.mockResolvedValue({
+      items: [
+        {
+          id: "chunk-1",
+          content: "retrieved chunk content",
+          source_uri: "https://example.com/doc",
+          combined_score: 0.91,
+          metadata: { corpus_id: "11111111-1111-1111-1111-111111111111" },
+        },
+      ],
+    });
 
     useKnowledgeBaseMock.mockImplementation(() => ({
       corpora: [
@@ -196,5 +210,71 @@ describe("KnowledgeBasePage", () => {
       "doc-1",
       { appName: "negentropy", limit: 200, offset: 0 },
     );
+  });
+
+  it("检索后默认隐藏 Corpus 集合，并通过底部按钮展开与收起", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getByText("Retrieved Chunks")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Corpus" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Corpus" }));
+
+    expect(screen.getByRole("button", { name: "收起 Corpus" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Corpus" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "收起 Corpus" }));
+
+    expect(screen.getByRole("button", { name: "Corpus" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
+  });
+
+  it("新的检索会重置已展开的 Corpus 面板为收起状态", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "first query");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Corpus" }));
+    expect(screen.getByRole("button", { name: "收起 Corpus" })).toBeInTheDocument();
+
+    const dockedInput = screen.getByPlaceholderText("输入检索内容");
+    await user.clear(dockedInput);
+    await user.type(dockedInput, "second query");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getByRole("button", { name: "Corpus" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "收起 Corpus" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

This PR refines the docked retrieval experience in the Knowledge Base page by hiding the corpus card collection by default after retrieval, and replacing it with an explicit toggleable corpus panel inside the docked retrieval module.

## What Changed

### Docked retrieval interaction
- Updated the Knowledge Base overview so that, after a retrieval runs, the main content area shows retrieved chunks without immediately rendering the corpus card collection underneath.
- Added a full-width `Corpus` button to the bottom of the docked retrieval module.
- When clicked, the button expands an embedded corpus panel inside the docked retrieval area.
- When clicked again, the corpus panel collapses and the docked retrieval module returns to its compact bottom-anchored state.

### Layout behavior
- Added explicit local UI state to control whether the embedded corpus panel is expanded.
- Reset the corpus panel to the collapsed state whenever a new retrieval is executed.
- Adjusted the docked retrieval container so expanded content remains usable within the viewport instead of being pushed off-screen.

### Tests
- Added page-level regression coverage for:
  - hiding the corpus collection by default after retrieval
  - expanding the corpus panel via the docked retrieval button
  - collapsing the corpus panel back to the compact state
  - resetting the panel to collapsed on a new retrieval

## Why These Changes Were Made

The task context for this branch was a UX refinement to the new Knowledge Base retrieval workflow.

The previous implementation still exposed the corpus card collection directly below retrieved chunks after retrieval completed. That made the retrieval state feel visually overloaded and did not match the desired interaction model, where users should first focus on results and only open the corpus collection when needed.

This change makes the interaction more intentional:
- retrieval results remain the primary focus
- corpus browsing becomes an explicit secondary action
- the docked retrieval module remains compact by default while still allowing corpus access on demand

## Important Implementation Details

- The corpus collection was not removed; it was moved behind an explicit toggle in the docked retrieval module.
- The retrieval page now uses a dedicated expansion state so the corpus panel behaves predictably across repeated searches.
- A new retrieval always collapses the corpus panel, preventing stale expansion state from leaking across result sets.
- The docked container was adjusted to support internal scrolling and bounded height so expanded corpus content does not overflow the viewport.
- Regression tests were added at the page level because this behavior is fundamentally a UI state orchestration change rather than an isolated utility change.

## Validation

Validated with targeted frontend lint and focused Vitest coverage for the updated Knowledge Base retrieval flow.

This PR was written using [Vibe Kanban](https://vibekanban.com)
