### PR TITLE
Enforce explicit corpus selection for retrieval and restore full-width docked layout (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -225,9 +225,7 @@ export default function KnowledgeBasePage() {
   }, [viewMode, corpusTab, selectedCorpusId, selectedDocumentId, loadDocumentChunks]);
 
   const handleRetrieve = async () => {
-    const corpusIds = selectedRetrievalCorpusIds.length > 0
-      ? selectedRetrievalCorpusIds
-      : corpora.map((c) => c.id);
+    const corpusIds = selectedRetrievalCorpusIds;
     if (!query.trim() || corpusIds.length === 0) return;
 
     setRetrievalLoading(true);
@@ -430,7 +428,7 @@ export default function KnowledgeBasePage() {
         />
         <button
           onClick={handleRetrieve}
-          disabled={retrievalLoading || !query.trim()}
+          disabled={retrievalLoading || !query.trim() || selectedRetrievalCorpusIds.length === 0}
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
         >
           {retrievalLoading ? "Retrieving..." : "Retrieve"}
@@ -460,6 +458,11 @@ export default function KnowledgeBasePage() {
             );
           })}
         </div>
+        {selectedRetrievalCorpusIds.length === 0 && (
+          <div className="mt-2 text-[11px] text-amber-600">
+            请至少选择一个 Corpus 后再执行 Retrieve
+          </div>
+        )}
       </div>
 
       {retrievalError && (
@@ -566,7 +569,10 @@ export default function KnowledgeBasePage() {
 
             {retrievalDocked && (
               <div className="fixed bottom-0 left-0 right-0 z-30 border-t border-border bg-background/95 px-6 py-3 backdrop-blur">
-                <div className="mx-auto max-h-[70vh] max-w-[1400px] overflow-y-auto">
+                <div
+                  data-testid="docked-retrieval-container"
+                  className="max-h-[70vh] w-full overflow-y-auto"
+                >
                   {renderRetrievalModule()}
                   <div className="mt-3 rounded-2xl border border-border bg-card p-3 shadow-sm">
                     <button

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -222,6 +222,7 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
+    await user.click(screen.getByRole("checkbox"));
     await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
     await user.click(screen.getByRole("button", { name: "Retrieve" }));
 
@@ -254,6 +255,7 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
+    await user.click(screen.getByRole("checkbox"));
     await user.type(screen.getByPlaceholderText("输入检索内容"), "first query");
     await user.click(screen.getByRole("button", { name: "Retrieve" }));
 
@@ -276,5 +278,85 @@ describe("KnowledgeBasePage", () => {
     expect(screen.getByRole("button", { name: "Corpus" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "收起 Corpus" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
+  });
+
+  it("未选中任何 Corpus 时禁用 Retrieve，并且不会发起检索", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+
+    const retrieveButton = screen.getByRole("button", { name: "Retrieve" });
+    expect(retrieveButton).toBeDisabled();
+    expect(screen.getByText("请至少选择一个 Corpus 后再执行 Retrieve")).toBeInTheDocument();
+    expect(searchAcrossCorporaMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Retrieved Chunks")).not.toBeInTheDocument();
+  });
+
+  it("仅将选中的 Corpus 传给检索接口，并使用全宽停靠容器", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    useKnowledgeBaseMock.mockImplementation(() => ({
+      corpora: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "Corpus Alpha",
+          app_name: "negentropy",
+          knowledge_count: 3,
+          config: {},
+        },
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          name: "Corpus Beta",
+          app_name: "negentropy",
+          knowledge_count: 5,
+          config: {},
+        },
+      ],
+      isLoading: false,
+      loadCorpora: loadCorporaMock,
+      loadCorpus: loadCorpusMock,
+      createCorpus: vi.fn(),
+      updateCorpus: vi.fn(),
+      deleteCorpus: deleteCorpusMock,
+      ingestUrl: vi.fn(),
+      ingestFile: vi.fn(),
+    }));
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const betaCheckbox = screen.getByRole("checkbox", { name: /Corpus Beta/ });
+    await user.click(betaCheckbox);
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(searchAcrossCorporaMock).toHaveBeenCalledWith(
+      ["22222222-2222-2222-2222-222222222222"],
+      {
+        app_name: "negentropy",
+        query: "context engineering",
+        mode: "hybrid",
+        limit: 50,
+      },
+    );
+
+    const dockedContainer = screen.getByTestId("docked-retrieval-container");
+    expect(dockedContainer).toHaveClass("w-full");
+    expect(dockedContainer).not.toHaveClass("max-w-[1400px]");
   });
 });


### PR DESCRIPTION
## Summary

This PR tightens the Knowledge Base retrieval workflow by enforcing explicit corpus selection before retrieval and restoring the full-width layout for the docked retrieval module after results are shown.

## What Changed

### Retrieval scope enforcement
- Updated the Knowledge Base retrieval flow so searches only run against the explicitly selected corpus set.
- Removed the previous fallback that searched across all corpora when no corpus was selected.
- Disabled the `Retrieve` action when the query is empty or no corpus is selected.
- Added a lightweight inline hint to explain that at least one corpus must be selected before retrieval.

### Docked retrieval layout
- Removed the fixed max-width constraint from the docked retrieval container.
- Updated the docked retrieval module and embedded corpus panel to use the same full-width content span as the initial overview layout.

### Tests
- Added regression coverage for:
  - disabling retrieval when no corpus is selected
  - ensuring no retrieval request is sent for an empty corpus selection
  - passing only the selected corpus IDs to the retrieval API
  - verifying the docked retrieval container uses the full-width layout

## Why These Changes Were Made

The task context for this branch was a behavior mismatch in the new Knowledge Base retrieval experience:

- after clicking `Retrieve`, the docked retrieval area became visually narrower than the original overview layout
- when no corpus was selected, retrieval still searched across all corpora, which violated the intended requirement that retrieval must always be limited to the selected corpus set

These changes make the workflow consistent and predictable:
- retrieval scope now strictly matches explicit user selection
- the docked retrieval state preserves the same horizontal layout expectations as the overview state
- the UI now prevents invalid retrieval attempts instead of silently expanding scope

## Important Implementation Details

- The retrieval page logic was changed at the page layer, not the shared search utility layer, so the fix stays narrowly scoped to the Knowledge Base UI contract.
- The previous implicit fallback from `selected corpus set -> all corpora` was removed entirely.
- The `Retrieve` button state now mirrors the true execution contract, which prevents “click but nothing should happen” ambiguity.
- A stable test hook was added to the docked retrieval container so layout-related regression coverage does not depend on brittle DOM traversal.
- Page-level tests were expanded because the failure mode was caused by UI state orchestration, not a backend contract problem.

## Validation

Implementation was completed and regression tests were added. In the current workspace snapshot, frontend dependencies are not installed under `apps/negentropy-ui`, so `eslint` and `vitest` executables were not available for local command execution.

This PR was written using [Vibe Kanban](https://vibekanban.com)
