### PR TITLE
feat(knowledge): 支持 Ingest 四种 Chunking 策略并打通前后端链路 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { CorpusRecord, ChunkingStrategy } from "@/features/knowledge";
 
 interface CorpusFormDialogProps {
@@ -16,6 +16,36 @@ interface CorpusFormDialogProps {
   }) => Promise<void>;
 }
 
+function buildInitialState(
+  mode: "create" | "edit",
+  initialData?: CorpusRecord,
+) {
+  const conf = mode === "edit" && initialData ? (initialData.config || {}) : {};
+  return {
+    name: mode === "edit" && initialData ? initialData.name : "",
+    description:
+      mode === "edit" && initialData ? initialData.description || "" : "",
+    showAdvanced: false,
+    strategy: ((conf.strategy as ChunkingStrategy) || "recursive") as ChunkingStrategy,
+    chunkSize: String(conf.chunk_size || "800"),
+    overlap: String(conf.overlap || "100"),
+    preserveNewlines: conf.preserve_newlines !== false,
+    separators: Array.isArray(conf.separators)
+      ? (conf.separators as string[]).join("\n")
+      : "",
+    semanticThreshold: String(conf.semantic_threshold || "0.85"),
+    minChunkSize: String(conf.min_chunk_size || "50"),
+    maxChunkSize: String(conf.max_chunk_size || "2000"),
+    hierarchicalParentChunkSize: String(
+      conf.hierarchical_parent_chunk_size || "1024",
+    ),
+    hierarchicalChildChunkSize: String(
+      conf.hierarchical_child_chunk_size || "256",
+    ),
+    hierarchicalChildOverlap: String(conf.hierarchical_child_overlap || "51"),
+  };
+}
+
 export function CorpusFormDialog({
   isOpen,
   mode,
@@ -24,59 +54,28 @@ export function CorpusFormDialog({
   onClose,
   onSubmit,
 }: CorpusFormDialogProps) {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const initialState = buildInitialState(mode, initialData);
+  const [name, setName] = useState(initialState.name);
+  const [description, setDescription] = useState(initialState.description);
+  const [showAdvanced, setShowAdvanced] = useState(initialState.showAdvanced);
 
   // Chunking Config State
-  const [strategy, setStrategy] = useState<ChunkingStrategy>("recursive");
-  const [chunkSize, setChunkSize] = useState<string>("800");
-  const [overlap, setOverlap] = useState<string>("100");
-  const [preserveNewlines, setPreserveNewlines] = useState(true);
-  const [separators, setSeparators] = useState("");
+  const [strategy, setStrategy] = useState<ChunkingStrategy>(initialState.strategy);
+  const [chunkSize, setChunkSize] = useState<string>(initialState.chunkSize);
+  const [overlap, setOverlap] = useState<string>(initialState.overlap);
+  const [preserveNewlines, setPreserveNewlines] = useState(initialState.preserveNewlines);
+  const [separators, setSeparators] = useState(initialState.separators);
 
   // Semantic specific
-  const [semanticThreshold, setSemanticThreshold] = useState<string>("0.85");
-  const [minChunkSize, setMinChunkSize] = useState<string>("50");
-  const [maxChunkSize, setMaxChunkSize] = useState<string>("2000");
-
-  useEffect(() => {
-    if (isOpen) {
-      if (mode === "edit" && initialData) {
-        setName(initialData.name);
-        setDescription(initialData.description || "");
-
-        const conf = initialData.config || {};
-        setStrategy((conf.strategy as ChunkingStrategy) || "recursive");
-        setChunkSize(String(conf.chunk_size || "800"));
-        setOverlap(String(conf.overlap || "100"));
-        setPreserveNewlines(conf.preserve_newlines !== false);
-
-        setSemanticThreshold(String(conf.semantic_threshold || "0.85"));
-        setMinChunkSize(String(conf.min_chunk_size || "50"));
-        setMaxChunkSize(String(conf.max_chunk_size || "2000"));
-        setSeparators(
-          Array.isArray(conf.separators)
-            ? (conf.separators as string[]).join("\n")
-            : "",
-        );
-
-        setShowAdvanced(false);
-      } else {
-        setName("");
-        setDescription("");
-        setStrategy("recursive");
-        setChunkSize("800");
-        setOverlap("100");
-        setPreserveNewlines(true);
-        setSemanticThreshold("0.85");
-        setMinChunkSize("50");
-        setMaxChunkSize("2000");
-        setSeparators("");
-        setShowAdvanced(false);
-      }
-    }
-  }, [isOpen, mode, initialData]);
+  const [semanticThreshold, setSemanticThreshold] = useState<string>(initialState.semanticThreshold);
+  const [minChunkSize, setMinChunkSize] = useState<string>(initialState.minChunkSize);
+  const [maxChunkSize, setMaxChunkSize] = useState<string>(initialState.maxChunkSize);
+  const [hierarchicalParentChunkSize, setHierarchicalParentChunkSize] =
+    useState<string>(initialState.hierarchicalParentChunkSize);
+  const [hierarchicalChildChunkSize, setHierarchicalChildChunkSize] =
+    useState<string>(initialState.hierarchicalChildChunkSize);
+  const [hierarchicalChildOverlap, setHierarchicalChildOverlap] =
+    useState<string>(initialState.hierarchicalChildOverlap);
 
   const handleSubmit = async () => {
     if (!name.trim() || isLoading) return;
@@ -98,6 +97,15 @@ export function CorpusFormDialog({
       if (!isNaN(thresh)) config.semantic_threshold = thresh;
       if (!isNaN(minSize)) config.min_chunk_size = minSize;
       if (!isNaN(maxSize)) config.max_chunk_size = maxSize;
+    }
+
+    if (strategy === "hierarchical") {
+      const parentSize = parseInt(hierarchicalParentChunkSize, 10);
+      const childSize = parseInt(hierarchicalChildChunkSize, 10);
+      const childOverlap = parseInt(hierarchicalChildOverlap, 10);
+      if (!isNaN(parentSize)) config.hierarchical_parent_chunk_size = parentSize;
+      if (!isNaN(childSize)) config.hierarchical_child_chunk_size = childSize;
+      if (!isNaN(childOverlap)) config.hierarchical_child_overlap = childOverlap;
     }
 
     config.separators = separators
@@ -212,6 +220,9 @@ export function CorpusFormDialog({
                     <option value="semantic">
                       Semantic (Embedding Similarity)
                     </option>
+                    <option value="hierarchical">
+                      Hierarchical (Parent + Child)
+                    </option>
                   </select>
                 </div>
 
@@ -288,6 +299,50 @@ export function CorpusFormDialog({
                   </div>
                 )}
 
+                {strategy === "hierarchical" && (
+                  <div className="grid grid-cols-3 gap-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Parent Size
+                      </label>
+                      <input
+                        type="number"
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        value={hierarchicalParentChunkSize}
+                        onChange={(e) =>
+                          setHierarchicalParentChunkSize(e.target.value)
+                        }
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Child Size
+                      </label>
+                      <input
+                        type="number"
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        value={hierarchicalChildChunkSize}
+                        onChange={(e) =>
+                          setHierarchicalChildChunkSize(e.target.value)
+                        }
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Child Overlap
+                      </label>
+                      <input
+                        type="number"
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        value={hierarchicalChildOverlap}
+                        onChange={(e) =>
+                          setHierarchicalChildOverlap(e.target.value)
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+
                 <div className="border-t border-zinc-200 pt-3 dark:border-zinc-700">
                   <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
                     Separators (one per line)
@@ -324,6 +379,8 @@ export function CorpusFormDialog({
                     "递归切分 (段落 > 句子 > 词)，保持文段结构完整。"}
                   {strategy === "semantic" &&
                     "基于 Embedding 相似度切分，确保 Chunk 语义连贯，需消耗 Token。"}
+                  {strategy === "hierarchical" &&
+                    "先构建父块再切子块，检索命中子块但返回父块，适合长文档与手册。"}
                 </div>
               </div>
             )}

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import {
   CorpusRecord,
   ChunkingConfig,
+  ChunkingStrategy,
   DocumentChunkItem,
   KnowledgeDocument,
   KnowledgeMatch,
@@ -84,6 +93,205 @@ function ChunkDetailDrawer({
   );
 }
 
+function ChunkingStrategyPanel({
+  config,
+  onChange,
+  title,
+  description,
+}: {
+  config: ChunkingConfig;
+  onChange: Dispatch<SetStateAction<ChunkingConfig>>;
+  title: string;
+  description?: string;
+}) {
+  const strategyDescriptions: Record<ChunkingStrategy, string> = {
+    fixed: "固定长度切分，简单可预测，但可能割裂句子或段落。",
+    recursive: "按段落、句子、词递归切分，适合大多数技术文档。",
+    semantic: "基于语义相似度断点切分，完整性更高，但计算成本更高。",
+    hierarchical: "构建父子块结构，检索子块并返回父块上下文，适合长文与手册。",
+  };
+
+  const updateConfig = (patch: Partial<ChunkingConfig>) => {
+    onChange((prev) => ({ ...prev, ...patch }));
+  };
+
+  return (
+    <div className="rounded-2xl border border-border bg-background p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold">{title}</h3>
+          {description && (
+            <p className="mt-1 text-xs text-muted">{description}</p>
+          )}
+        </div>
+        <div className="text-[11px] text-muted">大小单位: 字符近似值</div>
+      </div>
+
+      <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+        {(["fixed", "recursive", "semantic", "hierarchical"] as const).map(
+          (strategy) => (
+            <button
+              key={strategy}
+              type="button"
+              onClick={() => updateConfig({ strategy })}
+              className={`rounded-xl border px-3 py-3 text-left ${
+                config.strategy === strategy
+                  ? "border-foreground bg-foreground text-background"
+                  : "border-border hover:bg-muted"
+              }`}
+            >
+              <div className="text-xs font-semibold capitalize">{strategy}</div>
+              <div
+                className={`mt-1 text-[11px] ${
+                  config.strategy === strategy ? "text-background/80" : "text-muted"
+                }`}
+              >
+                {strategyDescriptions[strategy]}
+              </div>
+            </button>
+          ),
+        )}
+      </div>
+
+      <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <label className="text-xs">
+          <div className="mb-1 text-muted">Chunk Size</div>
+          <input
+            type="number"
+            value={String(config.chunk_size ?? 800)}
+            onChange={(e) =>
+              updateConfig({ chunk_size: Number(e.target.value || 0) || 800 })
+            }
+            className="w-full rounded border border-border bg-card px-2 py-2"
+          />
+        </label>
+        <label className="text-xs">
+          <div className="mb-1 text-muted">Overlap</div>
+          <input
+            type="number"
+            value={String(config.overlap ?? 100)}
+            onChange={(e) =>
+              updateConfig({ overlap: Number(e.target.value || 0) || 0 })
+            }
+            className="w-full rounded border border-border bg-card px-2 py-2"
+          />
+        </label>
+        <label className="text-xs md:col-span-2">
+          <div className="mb-1 text-muted">Separators（每行一个）</div>
+          <textarea
+            value={(config.separators || []).join("\n")}
+            onChange={(e) =>
+              updateConfig({
+                separators: e.target.value
+                  .split("\n")
+                  .map((item) => item.trim())
+                  .filter(Boolean),
+              })
+            }
+            rows={3}
+            className="w-full rounded border border-border bg-card px-2 py-2"
+          />
+        </label>
+      </div>
+
+      <label className="mt-3 inline-flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={config.preserve_newlines !== false}
+          onChange={(e) => updateConfig({ preserve_newlines: e.target.checked })}
+        />
+        <span>保留换行</span>
+      </label>
+
+      {config.strategy === "semantic" && (
+        <div className="mt-3 grid gap-3 md:grid-cols-3">
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Similarity Threshold</div>
+            <input
+              type="number"
+              step="0.05"
+              min="0"
+              max="1"
+              value={String(config.semantic_threshold ?? 0.85)}
+              onChange={(e) =>
+                updateConfig({ semantic_threshold: Number(e.target.value) || 0.85 })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Min Chunk Size</div>
+            <input
+              type="number"
+              value={String(config.min_chunk_size ?? 50)}
+              onChange={(e) =>
+                updateConfig({ min_chunk_size: Number(e.target.value) || 50 })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Max Chunk Size</div>
+            <input
+              type="number"
+              value={String(config.max_chunk_size ?? 2000)}
+              onChange={(e) =>
+                updateConfig({ max_chunk_size: Number(e.target.value) || 2000 })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+        </div>
+      )}
+
+      {config.strategy === "hierarchical" && (
+        <div className="mt-3 grid gap-3 md:grid-cols-3">
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Parent Size</div>
+            <input
+              type="number"
+              value={String(config.hierarchical_parent_chunk_size ?? 1024)}
+              onChange={(e) =>
+                updateConfig({
+                  hierarchical_parent_chunk_size:
+                    Number(e.target.value) || 1024,
+                })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Child Size</div>
+            <input
+              type="number"
+              value={String(config.hierarchical_child_chunk_size ?? 256)}
+              onChange={(e) =>
+                updateConfig({
+                  hierarchical_child_chunk_size: Number(e.target.value) || 256,
+                })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Child Overlap</div>
+            <input
+              type="number"
+              value={String(config.hierarchical_child_overlap ?? 51)}
+              onChange={(e) =>
+                updateConfig({
+                  hierarchical_child_overlap: Number(e.target.value) || 0,
+                })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function KnowledgeBasePage() {
   const router = useRouter();
   const pathname = usePathname();
@@ -117,6 +325,25 @@ export default function KnowledgeBasePage() {
 
   const [documents, setDocuments] = useState<KnowledgeDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
+  const [documentChunkingState, setDocumentChunkingState] = useState<{
+    corpusId: string | null;
+    config: ChunkingConfig;
+  }>({
+    corpusId: null,
+    config: {
+      strategy: "recursive",
+      chunk_size: 800,
+      overlap: 100,
+      preserve_newlines: true,
+      separators: [],
+      semantic_threshold: 0.85,
+      min_chunk_size: 50,
+      max_chunk_size: 2000,
+      hierarchical_parent_chunk_size: 1024,
+      hierarchical_child_chunk_size: 256,
+      hierarchical_child_overlap: 51,
+    },
+  });
 
   const [documentChunks, setDocumentChunks] = useState<DocumentChunkItem[]>([]);
   const [chunksLoading, setChunksLoading] = useState(false);
@@ -138,6 +365,29 @@ export default function KnowledgeBasePage() {
     () => corpora.find((item) => item.id === selectedCorpusId) || null,
     [corpora, selectedCorpusId],
   );
+  const derivedCorpusChunkingConfig = useMemo<ChunkingConfig>(() => {
+    const config = (selectedCorpus?.config || {}) as ChunkingConfig;
+    return {
+      strategy: (config.strategy as ChunkingStrategy) || "recursive",
+      chunk_size: config.chunk_size || 800,
+      overlap: config.overlap || 100,
+      preserve_newlines: config.preserve_newlines !== false,
+      separators: Array.isArray(config.separators) ? config.separators : [],
+      semantic_threshold: config.semantic_threshold || 0.85,
+      min_chunk_size: config.min_chunk_size || 50,
+      max_chunk_size: config.max_chunk_size || 2000,
+      hierarchical_parent_chunk_size:
+        config.hierarchical_parent_chunk_size || 1024,
+      hierarchical_child_chunk_size:
+        config.hierarchical_child_chunk_size || 256,
+      hierarchical_child_overlap:
+        config.hierarchical_child_overlap || 51,
+    };
+  }, [selectedCorpus]);
+  const documentChunkingConfig =
+    documentChunkingState.corpusId === selectedCorpus?.id
+      ? documentChunkingState.config
+      : derivedCorpusChunkingConfig;
 
   const syncQueryState = useCallback(
     (next: Partial<Record<"view" | "corpusId" | "tab" | "documentId", string | null>>) => {
@@ -316,7 +566,7 @@ export default function KnowledgeBasePage() {
       await ingestUrl({
         url: url.trim(),
         as_document: true,
-        chunkingConfig: selectedCorpus?.config as ChunkingConfig | undefined,
+        chunkingConfig: documentChunkingConfig,
       });
       toast.success("URL ingest started");
       await loadDocuments();
@@ -331,7 +581,7 @@ export default function KnowledgeBasePage() {
       await ingestFile({
         file,
         source_uri: file.name,
-        chunkingConfig: selectedCorpus?.config as ChunkingConfig | undefined,
+        chunkingConfig: documentChunkingConfig,
       });
       toast.success("File ingest started");
       await loadDocuments();
@@ -347,9 +597,15 @@ export default function KnowledgeBasePage() {
     if (!selectedCorpusId) return;
     try {
       if (action === "sync") {
-        await syncDocument(selectedCorpusId, doc.id, { app_name: APP_NAME });
+        await syncDocument(selectedCorpusId, doc.id, {
+          app_name: APP_NAME,
+          ...documentChunkingConfig,
+        });
       } else if (action === "rebuild") {
-        await rebuildDocument(selectedCorpusId, doc.id, { app_name: APP_NAME });
+        await rebuildDocument(selectedCorpusId, doc.id, {
+          app_name: APP_NAME,
+          ...documentChunkingConfig,
+        });
       } else if (action === "archive") {
         await archiveDocument(selectedCorpusId, doc.id, { app_name: APP_NAME });
       } else if (action === "unarchive") {
@@ -381,6 +637,7 @@ export default function KnowledgeBasePage() {
     await replaceDocument(selectedCorpusId, replacingDocument.id, {
       app_name: APP_NAME,
       text: payload.text,
+      ...documentChunkingConfig,
     });
     toast.success("replace success");
     setIsReplaceDialogOpen(false);
@@ -557,6 +814,11 @@ export default function KnowledgeBasePage() {
                         <span>score: {(item.combined_score || 0).toFixed(4)}</span>
                         <span>corpus: {String(item.metadata?.corpus_id || "-")}</span>
                         <span>source: {item.source_uri || "-"}</span>
+                        {item.metadata?.returned_parent_chunk && (
+                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-700">
+                            父块返回 · 子块命中
+                          </span>
+                        )}
                       </div>
                     </button>
                   ))}
@@ -621,6 +883,24 @@ export default function KnowledgeBasePage() {
             <main className="min-w-0 flex-1 rounded-2xl border border-border bg-card p-4 shadow-sm">
               {corpusTab === "documents" && (
                 <div className="space-y-3">
+                  <ChunkingStrategyPanel
+                    config={documentChunkingConfig}
+                    onChange={(next) =>
+                      setDocumentChunkingState((prev) => ({
+                        corpusId: selectedCorpus?.id || null,
+                        config:
+                          typeof next === "function"
+                            ? next(
+                                prev.corpusId === selectedCorpus?.id
+                                  ? prev.config
+                                  : documentChunkingConfig,
+                              )
+                            : next,
+                      }))
+                    }
+                    title="Chunking Strategy"
+                    description="当前摄入与文档重建按字符近似控制大小；hierarchical 会检索子块并返回父块。"
+                  />
                   <div className="flex items-center justify-between">
                     <h2 className="text-sm font-semibold">Documents</h2>
                     <div className="flex items-center gap-2">
@@ -718,8 +998,11 @@ export default function KnowledgeBasePage() {
                           className="block w-full rounded-lg border border-border bg-background p-3 text-left hover:bg-muted/40"
                         >
                           <p className="line-clamp-3 text-xs">{chunk.content}</p>
-                          <div className="mt-2 text-[11px] text-muted">
+                          <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted">
                             chunk_index: {chunk.chunk_index} · source: {chunk.source_uri || "-"}
+                            <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-zinc-700">
+                              role: {String(chunk.metadata?.chunk_role || "leaf")}
+                            </span>
                           </div>
                         </button>
                       ))}
@@ -743,6 +1026,7 @@ export default function KnowledgeBasePage() {
       <ChunkDetailDrawer chunk={selectedChunk} onClose={() => setSelectedChunk(null)} />
 
       <CorpusFormDialog
+        key={`${dialogMode}-${editingCorpus?.id || "new"}-${isDialogOpen ? "open" : "closed"}`}
         isOpen={isDialogOpen}
         mode={dialogMode}
         initialData={editingCorpus}
@@ -784,88 +1068,44 @@ function CorpusSettingsPanel({
   corpus: CorpusRecord;
   onSave: (config: Record<string, unknown>) => Promise<void>;
 }) {
-  const [strategy, setStrategy] = useState<string>(String(corpus.config?.strategy || "recursive"));
-  const [chunkSize, setChunkSize] = useState<string>(String(corpus.config?.chunk_size || 800));
-  const [overlap, setOverlap] = useState<string>(String(corpus.config?.overlap || 100));
-  const [preserveNewlines, setPreserveNewlines] = useState<boolean>(corpus.config?.preserve_newlines !== false);
-  const [separators, setSeparators] = useState<string>(
-    Array.isArray(corpus.config?.separators)
-      ? (corpus.config?.separators as string[]).join("\n")
-      : "",
-  );
+  const [formConfig, setFormConfig] = useState<ChunkingConfig>({
+    strategy: (corpus.config?.strategy as ChunkingStrategy) || "recursive",
+    chunk_size: Number(corpus.config?.chunk_size || 800),
+    overlap: Number(corpus.config?.overlap || 100),
+    preserve_newlines: corpus.config?.preserve_newlines !== false,
+    separators: Array.isArray(corpus.config?.separators)
+      ? (corpus.config?.separators as string[])
+      : [],
+    semantic_threshold: Number(corpus.config?.semantic_threshold || 0.85),
+    min_chunk_size: Number(corpus.config?.min_chunk_size || 50),
+    max_chunk_size: Number(corpus.config?.max_chunk_size || 2000),
+    hierarchical_parent_chunk_size: Number(
+      corpus.config?.hierarchical_parent_chunk_size || 1024,
+    ),
+    hierarchical_child_chunk_size: Number(
+      corpus.config?.hierarchical_child_chunk_size || 256,
+    ),
+    hierarchical_child_overlap: Number(
+      corpus.config?.hierarchical_child_overlap || 51,
+    ),
+  });
 
   const handleSubmit = async () => {
-    const config: Record<string, unknown> = {
+    const payload: Record<string, unknown> = {
       ...(corpus.config || {}),
-      strategy,
-      chunk_size: Number(chunkSize),
-      overlap: Number(overlap),
-      preserve_newlines: preserveNewlines,
-      separators: separators
-        .split("\n")
-        .map((item) => item.trim())
-        .filter(Boolean),
+      ...formConfig,
     };
-    await onSave(config);
+    await onSave(payload);
   };
 
   return (
     <div className="space-y-3">
-      <h2 className="text-sm font-semibold">Settings</h2>
-      <div className="grid gap-3 md:grid-cols-2">
-        <label className="text-xs">
-          <div className="mb-1 text-muted">Chunking Strategy</div>
-          <select
-            value={strategy}
-            onChange={(e) => setStrategy(e.target.value)}
-            className="w-full rounded border border-border bg-background px-2 py-2"
-          >
-            <option value="fixed">Fixed Character Size</option>
-            <option value="recursive">Recursive Aware</option>
-            <option value="semantic">Semantic (Embedding Similarity)</option>
-          </select>
-        </label>
-
-        <label className="text-xs">
-          <div className="mb-1 text-muted">Chunk Size</div>
-          <input
-            type="number"
-            value={chunkSize}
-            onChange={(e) => setChunkSize(e.target.value)}
-            className="w-full rounded border border-border bg-background px-2 py-2"
-          />
-        </label>
-
-        <label className="text-xs">
-          <div className="mb-1 text-muted">Overlap</div>
-          <input
-            type="number"
-            value={overlap}
-            onChange={(e) => setOverlap(e.target.value)}
-            className="w-full rounded border border-border bg-background px-2 py-2"
-          />
-        </label>
-
-        <label className="inline-flex items-center gap-2 text-xs">
-          <input
-            type="checkbox"
-            checked={preserveNewlines}
-            onChange={(e) => setPreserveNewlines(e.target.checked)}
-          />
-          <span>Preserve Newlines</span>
-        </label>
-      </div>
-
-      <label className="block text-xs">
-        <div className="mb-1 text-muted">Separators（每行一个）</div>
-        <textarea
-          value={separators}
-          onChange={(e) => setSeparators(e.target.value)}
-          rows={5}
-          className="w-full rounded border border-border bg-background px-2 py-2"
-          placeholder={"\\n\\n\n\\n\n. \n, "}
-        />
-      </label>
+      <ChunkingStrategyPanel
+        config={formConfig}
+        onChange={setFormConfig}
+        title="Settings"
+        description="保存后作为该 Corpus 的默认分块配置。"
+      />
 
       <div className="flex justify-end">
         <button

--- a/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeBase.ts
+++ b/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeBase.ts
@@ -140,6 +140,22 @@ const DEFAULT_LOADING_STATE = {
   error: null as Error | null,
 };
 
+function toChunkingPayload(config?: ChunkingConfig) {
+  return {
+    strategy: config?.strategy,
+    chunk_size: config?.chunk_size,
+    overlap: config?.overlap,
+    preserve_newlines: config?.preserve_newlines,
+    separators: config?.separators,
+    semantic_threshold: config?.semantic_threshold,
+    min_chunk_size: config?.min_chunk_size,
+    max_chunk_size: config?.max_chunk_size,
+    hierarchical_parent_chunk_size: config?.hierarchical_parent_chunk_size,
+    hierarchical_child_chunk_size: config?.hierarchical_child_chunk_size,
+    hierarchical_child_overlap: config?.hierarchical_child_overlap,
+  };
+}
+
 /**
  * 知识库管理 Hook
  *
@@ -308,10 +324,7 @@ export function useKnowledgeBase(
           text: params.text,
           source_uri: params.source_uri,
           metadata: params.metadata,
-          chunk_size: params.chunkingConfig?.chunk_size,
-          overlap: params.chunkingConfig?.overlap,
-          preserve_newlines: params.chunkingConfig?.preserve_newlines,
-          separators: params.chunkingConfig?.separators,
+          ...toChunkingPayload(params.chunkingConfig),
         });
         setState({ isLoading: false, error: null });
         onIngestSuccess?.(result);
@@ -345,10 +358,7 @@ export function useKnowledgeBase(
           url: params.url,
           as_document: params.as_document,
           metadata: params.metadata,
-          chunk_size: params.chunkingConfig?.chunk_size,
-          overlap: params.chunkingConfig?.overlap,
-          preserve_newlines: params.chunkingConfig?.preserve_newlines,
-          separators: params.chunkingConfig?.separators,
+          ...toChunkingPayload(params.chunkingConfig),
         });
         setState({ isLoading: false, error: null });
         onIngestSuccess?.(result);
@@ -382,10 +392,7 @@ export function useKnowledgeBase(
           file: params.file,
           source_uri: params.source_uri,
           metadata: params.metadata,
-          chunk_size: params.chunkingConfig?.chunk_size,
-          overlap: params.chunkingConfig?.overlap,
-          preserve_newlines: params.chunkingConfig?.preserve_newlines,
-          separators: params.chunkingConfig?.separators,
+          ...toChunkingPayload(params.chunkingConfig),
         });
         setState({ isLoading: false, error: null });
         return result;
@@ -418,10 +425,7 @@ export function useKnowledgeBase(
           text: params.text,
           source_uri: params.source_uri,
           metadata: params.metadata,
-          chunk_size: params.chunkingConfig?.chunk_size,
-          overlap: params.chunkingConfig?.overlap,
-          preserve_newlines: params.chunkingConfig?.preserve_newlines,
-          separators: params.chunkingConfig?.separators,
+          ...toChunkingPayload(params.chunkingConfig),
         });
         setState({ isLoading: false, error: null });
         return result;
@@ -447,10 +451,7 @@ export function useKnowledgeBase(
         const result = await syncSourceApi(activeCorpusId, {
           app_name: appName,
           source_uri: params.source_uri,
-          chunk_size: params.chunkingConfig?.chunk_size,
-          overlap: params.chunkingConfig?.overlap,
-          preserve_newlines: params.chunkingConfig?.preserve_newlines,
-          separators: params.chunkingConfig?.separators,
+          ...toChunkingPayload(params.chunkingConfig),
         });
         setState({ isLoading: false, error: null });
         onIngestSuccess?.(result);
@@ -477,10 +478,7 @@ export function useKnowledgeBase(
         const result = await rebuildSourceApi(activeCorpusId, {
           app_name: appName,
           source_uri: params.source_uri,
-          chunk_size: params.chunkingConfig?.chunk_size,
-          overlap: params.chunkingConfig?.overlap,
-          preserve_newlines: params.chunkingConfig?.preserve_newlines,
-          separators: params.chunkingConfig?.separators,
+          ...toChunkingPayload(params.chunkingConfig),
         });
         setState({ isLoading: false, error: null });
         onIngestSuccess?.(result);

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -11,7 +11,11 @@
 
 export type SearchMode = "semantic" | "keyword" | "hybrid";
 
-export type ChunkingStrategy = "fixed" | "recursive" | "semantic";
+export type ChunkingStrategy =
+  | "fixed"
+  | "recursive"
+  | "semantic"
+  | "hierarchical";
 
 export interface ChunkingConfig {
   strategy?: ChunkingStrategy;
@@ -23,6 +27,10 @@ export interface ChunkingConfig {
   semantic_threshold?: number;
   min_chunk_size?: number;
   max_chunk_size?: number;
+  // Hierarchical chunking specific
+  hierarchical_parent_chunk_size?: number;
+  hierarchical_child_chunk_size?: number;
+  hierarchical_child_overlap?: number;
 }
 
 export interface SearchConfig {
@@ -467,10 +475,17 @@ export async function ingestText(
     text: string;
     source_uri?: string;
     metadata?: Record<string, unknown>;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
     separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<AsyncPipelineResult> {
   // 前端配置验证（对齐后端 types.py）
@@ -500,10 +515,17 @@ export async function ingestUrl(
     url: string;
     as_document?: boolean;
     metadata?: Record<string, unknown>;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
     separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<AsyncPipelineResult> {
   const res = await fetch(`/api/knowledge/base/${id}/ingest_url`, {
@@ -521,10 +543,17 @@ export async function ingestFile(
     file: File;
     source_uri?: string;
     metadata?: Record<string, unknown>;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
     separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<IngestResult> {
   const formData = new FormData();
@@ -534,12 +563,40 @@ export async function ingestFile(
   if (params.source_uri) formData.set("source_uri", params.source_uri);
   if (params.metadata) formData.set("metadata", JSON.stringify(params.metadata));
   if (params.chunk_size) formData.set("chunk_size", String(params.chunk_size));
-  if (params.overlap) formData.set("overlap", String(params.overlap));
+  if (params.overlap !== undefined) formData.set("overlap", String(params.overlap));
+  if (params.strategy) formData.set("strategy", params.strategy);
   if (params.preserve_newlines !== undefined) {
     formData.set("preserve_newlines", String(params.preserve_newlines));
   }
   if (params.separators && params.separators.length > 0) {
     formData.set("separators", JSON.stringify(params.separators));
+  }
+  if (params.semantic_threshold !== undefined) {
+    formData.set("semantic_threshold", String(params.semantic_threshold));
+  }
+  if (params.min_chunk_size !== undefined) {
+    formData.set("min_chunk_size", String(params.min_chunk_size));
+  }
+  if (params.max_chunk_size !== undefined) {
+    formData.set("max_chunk_size", String(params.max_chunk_size));
+  }
+  if (params.hierarchical_parent_chunk_size !== undefined) {
+    formData.set(
+      "hierarchical_parent_chunk_size",
+      String(params.hierarchical_parent_chunk_size),
+    );
+  }
+  if (params.hierarchical_child_chunk_size !== undefined) {
+    formData.set(
+      "hierarchical_child_chunk_size",
+      String(params.hierarchical_child_chunk_size),
+    );
+  }
+  if (params.hierarchical_child_overlap !== undefined) {
+    formData.set(
+      "hierarchical_child_overlap",
+      String(params.hierarchical_child_overlap),
+    );
   }
 
   const res = await fetch(`/api/knowledge/base/${id}/ingest_file`, {
@@ -845,9 +902,17 @@ export async function syncDocument(
   documentId: string,
   params: {
     app_name?: string;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
+    separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   } = {},
 ): Promise<AsyncPipelineResult> {
   return postDocumentAction(corpusId, documentId, "sync", params) as Promise<AsyncPipelineResult>;
@@ -858,9 +923,17 @@ export async function rebuildDocument(
   documentId: string,
   params: {
     app_name?: string;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
+    separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   } = {},
 ): Promise<AsyncPipelineResult> {
   return postDocumentAction(corpusId, documentId, "rebuild", params) as Promise<AsyncPipelineResult>;
@@ -872,9 +945,17 @@ export async function replaceDocument(
   params: {
     app_name?: string;
     text: string;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
+    separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<AsyncPipelineResult> {
   return postDocumentAction(corpusId, documentId, "replace", params) as Promise<AsyncPipelineResult>;
@@ -907,10 +988,17 @@ export async function replaceSource(
     text: string;
     source_uri: string;
     metadata?: Record<string, unknown>;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
     separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<AsyncPipelineResult> {
   const res = await fetch(`/api/knowledge/base/${id}/replace_source`, {
@@ -926,10 +1014,17 @@ export async function syncSource(
   params: {
     app_name?: string;
     source_uri: string;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
     separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<AsyncPipelineResult> {
   const res = await fetch(`/api/knowledge/base/${id}/sync_source`, {
@@ -945,10 +1040,17 @@ export async function rebuildSource(
   params: {
     app_name?: string;
     source_uri: string;
+    strategy?: ChunkingStrategy;
     chunk_size?: number;
     overlap?: number;
     preserve_newlines?: boolean;
     separators?: string[];
+    semantic_threshold?: number;
+    min_chunk_size?: number;
+    max_chunk_size?: number;
+    hierarchical_parent_chunk_size?: number;
+    hierarchical_child_chunk_size?: number;
+    hierarchical_child_overlap?: number;
   },
 ): Promise<AsyncPipelineResult> {
   const res = await fetch(`/api/knowledge/base/${id}/rebuild_source`, {

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -2,6 +2,8 @@ import {
   fetchCorpus,
   fetchDocumentChunks,
   fetchDocuments,
+  ingestFile,
+  ingestText,
   KnowledgeError,
 } from "@/features/knowledge/utils/knowledge-api";
 
@@ -79,5 +81,71 @@ describe("fetchCorpus", () => {
       "/api/knowledge/base/corpus-1/documents/doc-1/chunks?app_name=negentropy&limit=200&offset=0",
       { cache: "no-store" },
     );
+  });
+
+  it("ingestText 会透传 semantic 与 hierarchical 配置", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ run_id: "run-1", status: "running", message: "ok" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await ingestText("corpus-1", {
+      text: "hello",
+      strategy: "hierarchical",
+      chunk_size: 800,
+      overlap: 100,
+      semantic_threshold: 0.9,
+      hierarchical_parent_chunk_size: 1024,
+      hierarchical_child_chunk_size: 256,
+      hierarchical_child_overlap: 51,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/knowledge/base/corpus-1/ingest",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: "hello",
+          strategy: "hierarchical",
+          chunk_size: 800,
+          overlap: 100,
+          semantic_threshold: 0.9,
+          hierarchical_parent_chunk_size: 1024,
+          hierarchical_child_chunk_size: 256,
+          hierarchical_child_overlap: 51,
+        }),
+      }),
+    );
+  });
+
+  it("ingestFile 会把层次分块字段写入 FormData", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ count: 1, items: ["chunk-1"] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await ingestFile("corpus-1", {
+      file: new File(["hello"], "a.txt", { type: "text/plain" }),
+      strategy: "hierarchical",
+      hierarchical_parent_chunk_size: 1024,
+      hierarchical_child_chunk_size: 256,
+      hierarchical_child_overlap: 51,
+    });
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const formData = init?.body as FormData;
+
+    expect(formData.get("strategy")).toBe("hierarchical");
+    expect(formData.get("hierarchical_parent_chunk_size")).toBe("1024");
+    expect(formData.get("hierarchical_child_chunk_size")).toBe("256");
+    expect(formData.get("hierarchical_child_overlap")).toBe("51");
   });
 });

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -72,10 +72,17 @@ class IngestRequest(BaseModel):
     text: str
     source_uri: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    strategy: Optional[str] = None
     chunk_size: Optional[int] = None
     overlap: Optional[int] = None
     preserve_newlines: Optional[bool] = None
     separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
 
 
 class IngestUrlRequest(BaseModel):
@@ -83,10 +90,17 @@ class IngestUrlRequest(BaseModel):
     url: str
     as_document: bool = False
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    strategy: Optional[str] = None
     chunk_size: Optional[int] = None
     overlap: Optional[int] = None
     preserve_newlines: Optional[bool] = None
     separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
 
 
 class ReplaceSourceRequest(BaseModel):
@@ -94,28 +108,49 @@ class ReplaceSourceRequest(BaseModel):
     text: str
     source_uri: str
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    strategy: Optional[str] = None
     chunk_size: Optional[int] = None
     overlap: Optional[int] = None
     preserve_newlines: Optional[bool] = None
     separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
 
 
 class SyncSourceRequest(BaseModel):
     app_name: Optional[str] = None
     source_uri: str
+    strategy: Optional[str] = None
     chunk_size: Optional[int] = None
     overlap: Optional[int] = None
     preserve_newlines: Optional[bool] = None
     separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
 
 
 class RebuildSourceRequest(BaseModel):
     app_name: Optional[str] = None
     source_uri: str
+    strategy: Optional[str] = None
     chunk_size: Optional[int] = None
     overlap: Optional[int] = None
     preserve_newlines: Optional[bool] = None
     separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
 
 
 class DeleteSourceRequest(BaseModel):
@@ -339,22 +374,50 @@ def _map_exception_to_http(exc: KnowledgeError) -> HTTPException:
 
 def _build_chunking_config(
     *,
+    strategy: Optional[str],
     chunk_size: Optional[int],
     overlap: Optional[int],
     preserve_newlines: Optional[bool],
     separators: Optional[list[str]] = None,
+    semantic_threshold: Optional[float] = None,
+    min_chunk_size: Optional[int] = None,
+    max_chunk_size: Optional[int] = None,
+    hierarchical_parent_chunk_size: Optional[int] = None,
+    hierarchical_child_chunk_size: Optional[int] = None,
+    hierarchical_child_overlap: Optional[int] = None,
 ) -> Optional[ChunkingConfig]:
     """构建分块配置
 
     使用常量而非魔法数字，遵循 Single Source of Truth 原则。
     """
-    if chunk_size is None and overlap is None and preserve_newlines is None and separators is None:
+    if (
+        strategy is None
+        and chunk_size is None
+        and overlap is None
+        and preserve_newlines is None
+        and separators is None
+        and semantic_threshold is None
+        and min_chunk_size is None
+        and max_chunk_size is None
+        and hierarchical_parent_chunk_size is None
+        and hierarchical_child_chunk_size is None
+        and hierarchical_child_overlap is None
+    ):
         return None
     return ChunkingConfig(
+        strategy=strategy or "recursive",
         chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
         overlap=overlap or DEFAULT_OVERLAP,
         preserve_newlines=True if preserve_newlines is None else preserve_newlines,
         separators=separators or [],
+        semantic_threshold=0.85 if semantic_threshold is None else semantic_threshold,
+        min_chunk_size=50 if min_chunk_size is None else min_chunk_size,
+        max_chunk_size=2000 if max_chunk_size is None else max_chunk_size,
+        hierarchical_parent_chunk_size=1024
+        if hierarchical_parent_chunk_size is None
+        else hierarchical_parent_chunk_size,
+        hierarchical_child_chunk_size=256 if hierarchical_child_chunk_size is None else hierarchical_child_chunk_size,
+        hierarchical_child_overlap=51 if hierarchical_child_overlap is None else hierarchical_child_overlap,
     )
 
 
@@ -366,6 +429,16 @@ def _infer_source_type(source_uri: Optional[str]) -> str:
     if source_uri:
         return "text"
     return "unknown"
+
+
+def _resolve_chunking_option(
+    request_value: Any,
+    corpus_config: Dict[str, Any],
+    key: str,
+) -> Any:
+    if request_value is not None:
+        return request_value
+    return corpus_config.get(key)
 
 
 def _normalize_source_metadata(
@@ -580,18 +653,42 @@ async def ingest_text(
         corpus_config = corpus.config if corpus else {}
 
         # 构建配置：请求参数 > corpus 配置 > 默认值
-        chunk_size = payload.chunk_size or corpus_config.get("chunk_size")
-        overlap = payload.overlap or corpus_config.get("overlap")
-        separators = payload.separators if payload.separators is not None else corpus_config.get("separators")
-        preserve_newlines = payload.preserve_newlines
-        if preserve_newlines is None:
-            preserve_newlines = corpus_config.get("preserve_newlines")
+        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
+        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
+        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
+        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
+        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
+        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
+        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
+        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
+        hierarchical_parent_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_parent_chunk_size,
+            corpus_config,
+            "hierarchical_parent_chunk_size",
+        )
+        hierarchical_child_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_child_chunk_size,
+            corpus_config,
+            "hierarchical_child_chunk_size",
+        )
+        hierarchical_child_overlap = _resolve_chunking_option(
+            payload.hierarchical_child_overlap,
+            corpus_config,
+            "hierarchical_child_overlap",
+        )
 
         chunking_config = _build_chunking_config(
+            strategy=strategy,
             chunk_size=chunk_size,
             overlap=overlap,
             preserve_newlines=preserve_newlines,
             separators=separators,
+            semantic_threshold=semantic_threshold,
+            min_chunk_size=min_chunk_size,
+            max_chunk_size=max_chunk_size,
+            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
+            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
+            hierarchical_child_overlap=hierarchical_child_overlap,
         )
 
         # 创建 Pipeline 记录
@@ -733,18 +830,42 @@ async def ingest_url(
         corpus_config = corpus.config if corpus else {}
 
         # 构建配置：请求参数 > corpus 配置 > 默认值
-        chunk_size = payload.chunk_size or corpus_config.get("chunk_size")
-        overlap = payload.overlap or corpus_config.get("overlap")
-        separators = payload.separators if payload.separators is not None else corpus_config.get("separators")
-        preserve_newlines = payload.preserve_newlines
-        if preserve_newlines is None:
-            preserve_newlines = corpus_config.get("preserve_newlines")
+        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
+        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
+        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
+        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
+        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
+        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
+        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
+        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
+        hierarchical_parent_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_parent_chunk_size,
+            corpus_config,
+            "hierarchical_parent_chunk_size",
+        )
+        hierarchical_child_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_child_chunk_size,
+            corpus_config,
+            "hierarchical_child_chunk_size",
+        )
+        hierarchical_child_overlap = _resolve_chunking_option(
+            payload.hierarchical_child_overlap,
+            corpus_config,
+            "hierarchical_child_overlap",
+        )
 
         chunking_config = _build_chunking_config(
+            strategy=strategy,
             chunk_size=chunk_size,
             overlap=overlap,
             preserve_newlines=preserve_newlines,
             separators=separators,
+            semantic_threshold=semantic_threshold,
+            min_chunk_size=min_chunk_size,
+            max_chunk_size=max_chunk_size,
+            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
+            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
+            hierarchical_child_overlap=hierarchical_child_overlap,
         )
 
         # URL 文档模式: 先落库为 Document，再异步入索引
@@ -969,10 +1090,17 @@ async def ingest_file(
     app_name: Optional[str] = Form(default=None),
     source_uri: Optional[str] = Form(default=None),
     metadata: Optional[str] = Form(default=None),
+    strategy: Optional[str] = Form(default=None),
     chunk_size: Optional[int] = Form(default=None),
     overlap: Optional[int] = Form(default=None),
     preserve_newlines: Optional[bool] = Form(default=None),
     separators: Optional[str] = Form(default=None),
+    semantic_threshold: Optional[float] = Form(default=None),
+    min_chunk_size: Optional[int] = Form(default=None),
+    max_chunk_size: Optional[int] = Form(default=None),
+    hierarchical_parent_chunk_size: Optional[int] = Form(default=None),
+    hierarchical_child_chunk_size: Optional[int] = Form(default=None),
+    hierarchical_child_overlap: Optional[int] = Form(default=None),
     store_to_gcs: bool = Form(default=True),
 ) -> Dict[str, Any]:
     """从上传文件导入内容到知识库
@@ -1122,18 +1250,50 @@ async def ingest_file(
         corpus_config = corpus.config if corpus else {}
 
         # 构建分块配置
-        final_chunk_size = chunk_size or corpus_config.get("chunk_size")
-        final_overlap = overlap or corpus_config.get("overlap")
-        final_separators = parsed_separators if parsed_separators is not None else corpus_config.get("separators")
-        final_preserve_newlines = preserve_newlines
-        if final_preserve_newlines is None:
-            final_preserve_newlines = corpus_config.get("preserve_newlines")
+        final_strategy = _resolve_chunking_option(strategy, corpus_config, "strategy")
+        final_chunk_size = _resolve_chunking_option(chunk_size, corpus_config, "chunk_size")
+        final_overlap = _resolve_chunking_option(overlap, corpus_config, "overlap")
+        final_separators = _resolve_chunking_option(parsed_separators, corpus_config, "separators")
+        final_preserve_newlines = _resolve_chunking_option(
+            preserve_newlines,
+            corpus_config,
+            "preserve_newlines",
+        )
+        final_semantic_threshold = _resolve_chunking_option(
+            semantic_threshold,
+            corpus_config,
+            "semantic_threshold",
+        )
+        final_min_chunk_size = _resolve_chunking_option(min_chunk_size, corpus_config, "min_chunk_size")
+        final_max_chunk_size = _resolve_chunking_option(max_chunk_size, corpus_config, "max_chunk_size")
+        final_hierarchical_parent_chunk_size = _resolve_chunking_option(
+            hierarchical_parent_chunk_size,
+            corpus_config,
+            "hierarchical_parent_chunk_size",
+        )
+        final_hierarchical_child_chunk_size = _resolve_chunking_option(
+            hierarchical_child_chunk_size,
+            corpus_config,
+            "hierarchical_child_chunk_size",
+        )
+        final_hierarchical_child_overlap = _resolve_chunking_option(
+            hierarchical_child_overlap,
+            corpus_config,
+            "hierarchical_child_overlap",
+        )
 
         chunking_config = _build_chunking_config(
+            strategy=final_strategy,
             chunk_size=final_chunk_size,
             overlap=final_overlap,
             preserve_newlines=final_preserve_newlines,
             separators=final_separators,
+            semantic_threshold=final_semantic_threshold,
+            min_chunk_size=final_min_chunk_size,
+            max_chunk_size=final_max_chunk_size,
+            hierarchical_parent_chunk_size=final_hierarchical_parent_chunk_size,
+            hierarchical_child_chunk_size=final_hierarchical_child_chunk_size,
+            hierarchical_child_overlap=final_hierarchical_child_overlap,
         )
 
         # 添加文件元数据
@@ -1251,10 +1411,17 @@ class DocumentChunksResponse(BaseModel):
 
 class DocumentActionRequest(BaseModel):
     app_name: Optional[str] = None
+    strategy: Optional[str] = None
     chunk_size: Optional[int] = None
     overlap: Optional[int] = None
     preserve_newlines: Optional[bool] = None
     separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
 
 
 class DocumentReplaceRequest(DocumentActionRequest):
@@ -1605,17 +1772,41 @@ def _resolve_chunking_config_from_doc_request(
     payload: DocumentActionRequest,
     corpus_config: Dict[str, Any],
 ) -> Optional[ChunkingConfig]:
-    chunk_size = payload.chunk_size or corpus_config.get("chunk_size")
-    overlap = payload.overlap or corpus_config.get("overlap")
-    preserve_newlines = payload.preserve_newlines
-    separators = payload.separators if payload.separators is not None else corpus_config.get("separators")
-    if preserve_newlines is None:
-        preserve_newlines = corpus_config.get("preserve_newlines")
+    strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
+    chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
+    overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
+    preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
+    separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
+    semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
+    min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
+    max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
+    hierarchical_parent_chunk_size = _resolve_chunking_option(
+        payload.hierarchical_parent_chunk_size,
+        corpus_config,
+        "hierarchical_parent_chunk_size",
+    )
+    hierarchical_child_chunk_size = _resolve_chunking_option(
+        payload.hierarchical_child_chunk_size,
+        corpus_config,
+        "hierarchical_child_chunk_size",
+    )
+    hierarchical_child_overlap = _resolve_chunking_option(
+        payload.hierarchical_child_overlap,
+        corpus_config,
+        "hierarchical_child_overlap",
+    )
     return _build_chunking_config(
+        strategy=strategy,
         chunk_size=chunk_size,
         overlap=overlap,
         preserve_newlines=preserve_newlines,
         separators=separators,
+        semantic_threshold=semantic_threshold,
+        min_chunk_size=min_chunk_size,
+        max_chunk_size=max_chunk_size,
+        hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
+        hierarchical_child_chunk_size=hierarchical_child_chunk_size,
+        hierarchical_child_overlap=hierarchical_child_overlap,
     )
 
 
@@ -2023,10 +2214,17 @@ async def replace_source(
     try:
         service = _get_service()
         chunking_config = _build_chunking_config(
+            strategy=payload.strategy,
             chunk_size=payload.chunk_size,
             overlap=payload.overlap,
             preserve_newlines=payload.preserve_newlines,
             separators=payload.separators,
+            semantic_threshold=payload.semantic_threshold,
+            min_chunk_size=payload.min_chunk_size,
+            max_chunk_size=payload.max_chunk_size,
+            hierarchical_parent_chunk_size=payload.hierarchical_parent_chunk_size,
+            hierarchical_child_chunk_size=payload.hierarchical_child_chunk_size,
+            hierarchical_child_overlap=payload.hierarchical_child_overlap,
         )
 
         # 创建 Pipeline 记录
@@ -2109,18 +2307,42 @@ async def sync_source(
         corpus_config = corpus.config if corpus else {}
 
         # 构建配置：请求参数 > corpus 配置 > 默认值
-        chunk_size = payload.chunk_size or corpus_config.get("chunk_size")
-        overlap = payload.overlap or corpus_config.get("overlap")
-        separators = payload.separators if payload.separators is not None else corpus_config.get("separators")
-        preserve_newlines = payload.preserve_newlines
-        if preserve_newlines is None:
-            preserve_newlines = corpus_config.get("preserve_newlines")
+        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
+        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
+        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
+        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
+        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
+        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
+        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
+        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
+        hierarchical_parent_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_parent_chunk_size,
+            corpus_config,
+            "hierarchical_parent_chunk_size",
+        )
+        hierarchical_child_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_child_chunk_size,
+            corpus_config,
+            "hierarchical_child_chunk_size",
+        )
+        hierarchical_child_overlap = _resolve_chunking_option(
+            payload.hierarchical_child_overlap,
+            corpus_config,
+            "hierarchical_child_overlap",
+        )
 
         chunking_config = _build_chunking_config(
+            strategy=strategy,
             chunk_size=chunk_size,
             overlap=overlap,
             preserve_newlines=preserve_newlines,
             separators=separators,
+            semantic_threshold=semantic_threshold,
+            min_chunk_size=min_chunk_size,
+            max_chunk_size=max_chunk_size,
+            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
+            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
+            hierarchical_child_overlap=hierarchical_child_overlap,
         )
 
         # 创建 Pipeline 记录
@@ -2206,18 +2428,42 @@ async def rebuild_source(
         corpus_config = corpus.config if corpus else {}
 
         # 构建配置：请求参数 > corpus 配置 > 默认值
-        chunk_size = payload.chunk_size or corpus_config.get("chunk_size")
-        overlap = payload.overlap or corpus_config.get("overlap")
-        separators = payload.separators if payload.separators is not None else corpus_config.get("separators")
-        preserve_newlines = payload.preserve_newlines
-        if preserve_newlines is None:
-            preserve_newlines = corpus_config.get("preserve_newlines")
+        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
+        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
+        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
+        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
+        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
+        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
+        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
+        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
+        hierarchical_parent_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_parent_chunk_size,
+            corpus_config,
+            "hierarchical_parent_chunk_size",
+        )
+        hierarchical_child_chunk_size = _resolve_chunking_option(
+            payload.hierarchical_child_chunk_size,
+            corpus_config,
+            "hierarchical_child_chunk_size",
+        )
+        hierarchical_child_overlap = _resolve_chunking_option(
+            payload.hierarchical_child_overlap,
+            corpus_config,
+            "hierarchical_child_overlap",
+        )
 
         chunking_config = _build_chunking_config(
+            strategy=strategy,
             chunk_size=chunk_size,
             overlap=overlap,
             preserve_newlines=preserve_newlines,
             separators=separators,
+            semantic_threshold=semantic_threshold,
+            min_chunk_size=min_chunk_size,
+            max_chunk_size=max_chunk_size,
+            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
+            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
+            hierarchical_child_overlap=hierarchical_child_overlap,
         )
 
         # 创建 Pipeline 记录

--- a/apps/negentropy/src/negentropy/knowledge/chunking.py
+++ b/apps/negentropy/src/negentropy/knowledge/chunking.py
@@ -315,6 +315,8 @@ def chunk_text(text: str, config: ChunkingConfig) -> list[str]:
             hint="Use semantic_chunk_async() instead for semantic chunking",
         )
         return []
+    elif strategy == ChunkingStrategy.HIERARCHICAL:
+        return _hierarchical_chunk(text, config)
     elif strategy == ChunkingStrategy.RECURSIVE:
         return _recursive_chunk(text, config)
     else:  # ChunkingStrategy.FIXED
@@ -455,6 +457,37 @@ def _recursive_chunk(text: str, config: ChunkingConfig) -> list[str]:
         return chunks_with_overlap
 
     return chunks
+
+
+def _hierarchical_chunk(text: str, config: ChunkingConfig) -> list[str]:
+    """层次分块
+
+    先生成父块，再在每个父块内生成子块。
+    该函数仅返回子块文本；父子关系元数据由 service.py 补充。
+    """
+    if not text or not text.strip():
+        return []
+
+    parent_config = config.model_copy(
+        update={
+            "strategy": ChunkingStrategy.RECURSIVE,
+            "chunk_size": config.hierarchical_parent_chunk_size,
+            "overlap": 0,
+        }
+    )
+    child_config = config.model_copy(
+        update={
+            "strategy": ChunkingStrategy.RECURSIVE,
+            "chunk_size": config.hierarchical_child_chunk_size,
+            "overlap": config.hierarchical_child_overlap,
+        }
+    )
+
+    parent_chunks = _recursive_chunk(text, parent_config)
+    child_chunks: list[str] = []
+    for parent_chunk in parent_chunks:
+        child_chunks.extend(_recursive_chunk(parent_chunk, child_config))
+    return child_chunks
 
 
 async def semantic_chunk_async(

--- a/apps/negentropy/src/negentropy/knowledge/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/repository.py
@@ -414,6 +414,7 @@ class KnowledgeRepository:
                         Knowledge.app_name == app_name,
                         Knowledge.embedding.is_not(None),
                         self._active_filter_expr(),
+                        self._searchable_filter_expr(),
                     )
                     .order_by(distance.asc())
                     .limit(limit)
@@ -480,6 +481,7 @@ class KnowledgeRepository:
             WHERE corpus_id = :corpus_id
               AND app_name = :app_name
               AND COALESCE((metadata->>'archived')::boolean, false) = false
+              AND COALESCE((metadata->>'searchable')::boolean, true) = true
               AND search_vector @@ plainto_tsquery('english', :query)
             """
             + filters
@@ -579,7 +581,7 @@ class KnowledgeRepository:
             matches: list[KnowledgeMatch] = []
             for row in rows:
                 metadata = row.get("metadata") or {}
-                if self._is_archived(metadata):
+                if self._is_archived(metadata) or not self._is_searchable(metadata):
                     continue
                 matches.append(
                     KnowledgeMatch(
@@ -721,7 +723,7 @@ class KnowledgeRepository:
             matches: list[KnowledgeMatch] = []
             for row in rows:
                 metadata = row.get("metadata") or {}
-                if self._is_archived(metadata):
+                if self._is_archived(metadata) or not self._is_searchable(metadata):
                     continue
                 matches.append(
                     KnowledgeMatch(
@@ -826,6 +828,54 @@ class KnowledgeRepository:
         ordered = sorted(merged, key=lambda item: item.combined_score, reverse=True)
         return ordered[:limit]
 
+    async def get_hierarchical_parent_matches(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        source_uri: Optional[str],
+        family_ids: Iterable[str],
+    ) -> list[KnowledgeMatch]:
+        family_id_list = [item for item in family_ids if item]
+        if not family_id_list:
+            return []
+
+        try:
+            async with self._get_session_factory()() as db:
+                stmt = select(Knowledge).where(
+                    Knowledge.corpus_id == corpus_id,
+                    Knowledge.app_name == app_name,
+                    self._active_filter_expr(),
+                    cast(Knowledge.metadata_["chunk_role"].astext, String) == "parent",
+                    cast(Knowledge.metadata_["chunk_family_id"].astext, String).in_(family_id_list),
+                )
+                if source_uri is None:
+                    stmt = stmt.where(Knowledge.source_uri.is_(None))
+                else:
+                    stmt = stmt.where(Knowledge.source_uri == source_uri)
+
+                result = await db.execute(stmt)
+                rows = result.scalars().all()
+
+            return [
+                KnowledgeMatch(
+                    id=row.id,
+                    content=row.content,
+                    source_uri=row.source_uri,
+                    metadata=row.metadata_ or {},
+                    semantic_score=0.0,
+                    keyword_score=0.0,
+                    combined_score=0.0,
+                )
+                for row in rows
+            ]
+        except Exception as exc:
+            raise SearchError(
+                corpus_id=str(corpus_id),
+                search_mode="hierarchical_parent_lookup",
+                reason=str(exc),
+            ) from exc
+
     @staticmethod
     def _to_corpus_record(corpus: Corpus) -> CorpusRecord:
         return CorpusRecord(
@@ -873,6 +923,11 @@ class KnowledgeRepository:
         return bool((metadata or {}).get("archived") is True)
 
     @staticmethod
+    def _is_searchable(metadata: Optional[Dict[str, Any]]) -> bool:
+        value = (metadata or {}).get("searchable")
+        return value is not False
+
+    @staticmethod
     def _infer_display_name(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
         raw = (metadata or {}).get("original_filename")
         return raw if isinstance(raw, str) and raw.strip() else None
@@ -880,3 +935,7 @@ class KnowledgeRepository:
     @staticmethod
     def _active_filter_expr() -> Any:
         return func.coalesce(cast(Knowledge.metadata_["archived"].astext, Boolean), False).is_(False)
+
+    @staticmethod
+    def _searchable_filter_expr() -> Any:
+        return func.coalesce(cast(Knowledge.metadata_["searchable"].astext, Boolean), True).is_(True)

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -36,6 +36,10 @@ from .types import (
 
 logger = get_logger("negentropy.knowledge.service")
 
+CHUNK_ROLE_PARENT = "parent"
+CHUNK_ROLE_CHILD = "child"
+CHUNK_ROLE_LEAF = "leaf"
+
 EmbeddingFn = Callable[[str], Awaitable[list[float]]]
 BatchEmbeddingFn = Callable[[list[str]], Awaitable[list[list[float]]]]
 
@@ -1711,7 +1715,12 @@ class KnowledgeService:
                     mode="keyword_fallback",
                     result_count=len(keyword_matches),
                 )
-                return keyword_matches
+                return await self._lift_hierarchical_matches(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    matches=keyword_matches,
+                    limit=config.limit,
+                )
 
             query_embedding = await self._embedding_fn(query)
             results = await self._repository.rrf_search(
@@ -1725,6 +1734,12 @@ class KnowledgeService:
 
             # L1 精排
             results = await self._reranker.rerank(query, results)
+            results = await self._lift_hierarchical_matches(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                matches=results,
+                limit=config.limit,
+            )
 
             logger.info(
                 "search_completed",
@@ -1774,6 +1789,12 @@ class KnowledgeService:
         if config.mode == "semantic":
             # L1 精排
             semantic_matches = await self._reranker.rerank(query, semantic_matches)
+            semantic_matches = await self._lift_hierarchical_matches(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                matches=semantic_matches,
+                limit=config.limit,
+            )
             logger.info(
                 "search_completed",
                 corpus_id=str(corpus_id),
@@ -1785,6 +1806,12 @@ class KnowledgeService:
         if config.mode == "keyword":
             # L1 精排
             keyword_matches = await self._reranker.rerank(query, keyword_matches)
+            keyword_matches = await self._lift_hierarchical_matches(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                matches=keyword_matches,
+                limit=config.limit,
+            )
             logger.info(
                 "search_completed",
                 corpus_id=str(corpus_id),
@@ -1804,6 +1831,12 @@ class KnowledgeService:
 
         # L1 精排
         results = await self._reranker.rerank(query, results)
+        results = await self._lift_hierarchical_matches(
+            corpus_id=corpus_id,
+            app_name=app_name,
+            matches=results,
+            limit=config.limit,
+        )
 
         logger.info(
             "search_completed",
@@ -1829,6 +1862,14 @@ class KnowledgeService:
         # Determine strategy and call appropriate chunking function
         from .types import ChunkingStrategy
 
+        if chunking_config.strategy == ChunkingStrategy.HIERARCHICAL:
+            return await self._build_hierarchical_chunks(
+                text=text,
+                source_uri=source_uri,
+                metadata=metadata,
+                chunking_config=chunking_config,
+            )
+
         if chunking_config.strategy == ChunkingStrategy.SEMANTIC:
             if not self._embedding_fn:
                 # Fallback to recursive if no embedding function
@@ -1852,6 +1893,84 @@ class KnowledgeService:
             )
         return chunks
 
+    async def _build_hierarchical_chunks(
+        self,
+        *,
+        text: str,
+        source_uri: Optional[str],
+        metadata: Dict[str, Any],
+        chunking_config: ChunkingConfig,
+    ) -> list[KnowledgeChunk]:
+        parent_config = chunking_config.model_copy(
+            update={
+                "strategy": ChunkingStrategy.RECURSIVE,
+                "chunk_size": chunking_config.hierarchical_parent_chunk_size,
+                "overlap": 0,
+            }
+        )
+        child_config = chunking_config.model_copy(
+            update={
+                "strategy": ChunkingStrategy.RECURSIVE,
+                "chunk_size": chunking_config.hierarchical_child_chunk_size,
+                "overlap": chunking_config.hierarchical_child_overlap,
+            }
+        )
+
+        parent_texts = chunk_text(text, parent_config)
+        chunks: list[KnowledgeChunk] = []
+        chunk_index = 0
+
+        for parent_index, parent_text in enumerate(parent_texts):
+            family_id = uuid.uuid4().hex
+            parent_metadata = {
+                **metadata,
+                "chunking_strategy": ChunkingStrategy.HIERARCHICAL.value,
+                "chunk_role": CHUNK_ROLE_PARENT,
+                "hierarchy_level": 0,
+                "chunk_family_id": family_id,
+                "parent_chunk_index": parent_index,
+                "searchable": False,
+            }
+            chunks.append(
+                KnowledgeChunk(
+                    content=parent_text,
+                    source_uri=source_uri,
+                    chunk_index=chunk_index,
+                    metadata=parent_metadata,
+                    embedding=None,
+                )
+            )
+            chunk_index += 1
+
+            child_texts = chunk_text(parent_text, child_config)
+            if not child_texts:
+                child_texts = [parent_text]
+
+            for child_index, child_text in enumerate(child_texts):
+                child_metadata = {
+                    **metadata,
+                    "chunking_strategy": ChunkingStrategy.HIERARCHICAL.value,
+                    "chunk_role": CHUNK_ROLE_CHILD,
+                    "hierarchy_level": 1,
+                    "chunk_family_id": family_id,
+                    "hierarchical_parent_id": family_id,
+                    "parent_chunk_index": parent_index,
+                    "child_chunk_index": child_index,
+                    "searchable": True,
+                }
+                chunks.append(
+                    KnowledgeChunk(
+                        content=child_text,
+                        source_uri=source_uri,
+                        chunk_index=chunk_index,
+                        metadata=child_metadata,
+                        embedding=None,
+                    )
+                )
+                chunk_index += 1
+
+        return chunks
+
     async def _attach_embeddings(self, chunks: Iterable[KnowledgeChunk]) -> list[KnowledgeChunk]:
         chunk_list = list(chunks)
 
@@ -1860,17 +1979,23 @@ class KnowledgeService:
 
         # 优先使用批量向量化（一次 API 调用完成所有 chunk）
         if self._batch_embedding_fn:
-            texts = [c.content for c in chunk_list]
-            embeddings = await self._batch_embedding_fn(texts)
+            searchable_chunks = [c for c in chunk_list if self._is_searchable_chunk(c)]
+            if not searchable_chunks:
+                return chunk_list
+            embeddings = await self._batch_embedding_fn([c.content for c in searchable_chunks])
+            embedding_by_key = {
+                (chunk.source_uri, chunk.chunk_index): emb
+                for chunk, emb in zip(searchable_chunks, embeddings)
+            }
             return [
                 KnowledgeChunk(
                     content=c.content,
                     source_uri=c.source_uri,
                     chunk_index=c.chunk_index,
                     metadata=c.metadata,
-                    embedding=emb,
+                    embedding=embedding_by_key.get((c.source_uri, c.chunk_index)),
                 )
-                for c, emb in zip(chunk_list, embeddings)
+                for c in chunk_list
             ]
 
         # 回退到逐条向量化
@@ -1879,7 +2004,9 @@ class KnowledgeService:
 
         enriched: list[KnowledgeChunk] = []
         for chunk in chunk_list:
-            embedding = await self._embedding_fn(chunk.content)
+            embedding = None
+            if self._is_searchable_chunk(chunk):
+                embedding = await self._embedding_fn(chunk.content)
             enriched.append(
                 KnowledgeChunk(
                     content=chunk.content,
@@ -1890,6 +2017,81 @@ class KnowledgeService:
                 )
             )
         return enriched
+
+    @staticmethod
+    def _is_searchable_chunk(chunk: KnowledgeChunk) -> bool:
+        return chunk.metadata.get("searchable") is not False
+
+    async def _lift_hierarchical_matches(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        matches: Iterable[KnowledgeMatch],
+        limit: int,
+    ) -> list[KnowledgeMatch]:
+        match_list = list(matches)
+        grouped: dict[tuple[Optional[str], str], list[KnowledgeMatch]] = {}
+        passthrough: list[KnowledgeMatch] = []
+
+        for match in match_list:
+            family_id = match.metadata.get("chunk_family_id")
+            role = match.metadata.get("chunk_role")
+            if role == CHUNK_ROLE_CHILD and isinstance(family_id, str) and family_id:
+                grouped.setdefault((match.source_uri, family_id), []).append(match)
+            else:
+                passthrough.append(match)
+
+        if not grouped:
+            return match_list[:limit]
+
+        lifted: list[KnowledgeMatch] = []
+        for (source_uri, family_id), child_matches in grouped.items():
+            parent_candidates = await self._repository.get_hierarchical_parent_matches(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                source_uri=source_uri,
+                family_ids=[family_id],
+            )
+            if not parent_candidates:
+                passthrough.extend(child_matches)
+                continue
+
+            parent = parent_candidates[0]
+            best_child = max(child_matches, key=lambda item: item.combined_score)
+            matched_child_indices = [
+                item.metadata.get("child_chunk_index")
+                for item in child_matches
+                if item.metadata.get("child_chunk_index") is not None
+            ]
+            lifted.append(
+                KnowledgeMatch(
+                    id=parent.id,
+                    content=parent.content,
+                    source_uri=parent.source_uri,
+                    metadata={
+                        **parent.metadata,
+                        "matched_child_chunk_indices": matched_child_indices,
+                        "returned_parent_chunk": True,
+                    },
+                    semantic_score=best_child.semantic_score,
+                    keyword_score=best_child.keyword_score,
+                    combined_score=best_child.combined_score,
+                )
+            )
+
+        merged = passthrough + lifted
+        merged.sort(key=lambda item: item.combined_score, reverse=True)
+        deduped: list[KnowledgeMatch] = []
+        seen_ids = set()
+        for item in merged:
+            if item.id in seen_ids:
+                continue
+            deduped.append(item)
+            seen_ids.add(item.id)
+            if len(deduped) >= limit:
+                break
+        return deduped
 
     def _merge_matches(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Dict, Iterable, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator, ValidationInfo
+from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator, model_validator
 
 from .constants import (
     MAX_OVERLAP_RATIO,
@@ -27,6 +27,7 @@ class ChunkingStrategy(Enum):
     FIXED = "fixed"  # 固定大小分块（字符级别）
     RECURSIVE = "recursive"  # 递归分块（段落 > 句子 > 词）
     SEMANTIC = "semantic"  # 语义分块（基于句子相似度）
+    HIERARCHICAL = "hierarchical"  # 层次分块（检索子块，返回父块）
 
 
 @dataclass(frozen=True)
@@ -144,6 +145,9 @@ class ChunkingConfig(BaseModel):
     semantic_threshold: float = 0.85  # 相似度阈值，低于此值时切分
     min_chunk_size: int = 50  # 最小块大小（字符数）
     max_chunk_size: int = 2000  # 最大块大小（字符数），用于滑动窗口合并
+    hierarchical_parent_chunk_size: int = 1024
+    hierarchical_child_chunk_size: int = 256
+    hierarchical_child_overlap: int = 51
 
     @field_validator("strategy", mode="before")
     @classmethod
@@ -215,6 +219,22 @@ class ChunkingConfig(BaseModel):
             raise ValueError(f"max_chunk_size must be at least 100, got {v}")
         return v
 
+    @field_validator(
+        "hierarchical_parent_chunk_size",
+        "hierarchical_child_chunk_size",
+        "hierarchical_child_overlap",
+    )
+    @classmethod
+    def validate_hierarchical_sizes(cls, v: int, info: ValidationInfo) -> int:
+        field_name = info.field_name or "hierarchical_size"
+        if "overlap" in field_name:
+            if v < 0:
+                raise ValueError(f"{field_name} must be non-negative, got {v}")
+            return v
+        if v < 1:
+            raise ValueError(f"{field_name} must be at least 1, got {v}")
+        return v
+
     @field_validator("separators")
     @classmethod
     def validate_separators(cls, v: List[str]) -> List[str]:
@@ -226,6 +246,25 @@ class ChunkingConfig(BaseModel):
             if item not in deduped:
                 deduped.append(item)
         return deduped
+
+    @model_validator(mode="after")
+    def validate_chunking_relationships(self) -> "ChunkingConfig":
+        if self.min_chunk_size > self.max_chunk_size:
+            raise ValueError(
+                f"min_chunk_size ({self.min_chunk_size}) must be <= max_chunk_size ({self.max_chunk_size})"
+            )
+
+        if self.hierarchical_parent_chunk_size < self.hierarchical_child_chunk_size:
+            raise ValueError(
+                "hierarchical_parent_chunk_size must be >= hierarchical_child_chunk_size"
+            )
+
+        if self.hierarchical_child_overlap >= self.hierarchical_child_chunk_size:
+            raise ValueError(
+                "hierarchical_child_overlap must be less than hierarchical_child_chunk_size"
+            )
+
+        return self
 
 
 class SearchConfig(BaseModel):

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException
 
 from negentropy.knowledge import api as knowledge_api
-from negentropy.knowledge.types import KnowledgeRecord
+from negentropy.knowledge.types import ChunkingStrategy, KnowledgeRecord
 
 
 class FakeStorageService:
@@ -221,8 +221,36 @@ async def test_rebuild_document_url_requires_markdown(monkeypatch):
             background_tasks=BackgroundTasks(),
         )
 
-    assert exc_info.value.status_code == 400
-    assert exc_info.value.detail["code"] == "INVALID_DOCUMENT_SOURCE"
+
+def test_resolve_chunking_config_from_doc_request_prefers_payload_over_corpus():
+    payload = knowledge_api.DocumentActionRequest(
+        app_name="negentropy",
+        strategy="hierarchical",
+        chunk_size=900,
+        semantic_threshold=0.9,
+        hierarchical_parent_chunk_size=1200,
+        hierarchical_child_chunk_size=300,
+        hierarchical_child_overlap=60,
+    )
+
+    config = knowledge_api._resolve_chunking_config_from_doc_request(
+        payload=payload,
+        corpus_config={
+            "strategy": "recursive",
+            "chunk_size": 800,
+            "overlap": 100,
+            "hierarchical_child_overlap": 40,
+        },
+    )
+
+    assert config is not None
+    assert config.strategy == ChunkingStrategy.HIERARCHICAL
+    assert config.chunk_size == 900
+    assert config.overlap == 100
+    assert config.semantic_threshold == 0.9
+    assert config.hierarchical_parent_chunk_size == 1200
+    assert config.hierarchical_child_chunk_size == 300
+    assert config.hierarchical_child_overlap == 60
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_chunking.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_chunking.py
@@ -186,6 +186,28 @@ class TestChunkingConfigValidation:
         with pytest.raises(ValidationError, match="chunk_size must be at least"):
             ChunkingConfig(chunk_size=-1, overlap=0)
 
+    def test_hierarchical_parent_smaller_than_child_raises(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="hierarchical_parent_chunk_size must be >=",
+        ):
+            ChunkingConfig(
+                strategy=ChunkingStrategy.HIERARCHICAL,
+                hierarchical_parent_chunk_size=128,
+                hierarchical_child_chunk_size=256,
+            )
+
+    def test_hierarchical_child_overlap_must_be_smaller_than_child_size(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="hierarchical_child_overlap must be less than hierarchical_child_chunk_size",
+        ):
+            ChunkingConfig(
+                strategy=ChunkingStrategy.HIERARCHICAL,
+                hierarchical_child_chunk_size=128,
+                hierarchical_child_overlap=128,
+            )
+
 
 class TestChunkingDeterminism:
     """确定性测试"""
@@ -199,6 +221,27 @@ class TestChunkingDeterminism:
         result2 = chunk_text(text, config)
 
         assert result1 == result2
+
+
+class TestHierarchicalChunking:
+    def test_hierarchical_chunk_returns_child_chunks(self) -> None:
+        text = (
+            "第一章介绍系统背景。第一章继续补充实现细节。\n\n"
+            "第二章描述检索链路。第二章继续描述父子分块。"
+        )
+        config = ChunkingConfig(
+            strategy=ChunkingStrategy.HIERARCHICAL,
+            hierarchical_parent_chunk_size=20,
+            hierarchical_child_chunk_size=10,
+            hierarchical_child_overlap=2,
+        )
+
+        result = chunk_text(text, config)
+
+        assert len(result) >= 2
+        combined = " ".join(result)
+        assert "系统背景" in combined
+        assert "父子分块" in combined
 
 
 # ================================

--- a/docs/knowledges.md
+++ b/docs/knowledges.md
@@ -159,7 +159,7 @@ flowchart LR
 **Knowledge 模块** (`negentropy.knowledge`):
 
 - [types.py](../apps/negentropy/src/negentropy/knowledge/types.py) - 领域类型（SearchMode, ChunkingConfig, SearchConfig, GraphNode/Edge 等）
-- [chunking.py](../apps/negentropy/src/negentropy/knowledge/chunking.py) - 文本分块（Fixed/Recursive/Semantic 三种策略）
+- [chunking.py](../apps/negentropy/src/negentropy/knowledge/chunking.py) - 文本分块（Fixed/Recursive/Semantic/Hierarchical 四种策略）
 - [repository.py](../apps/negentropy/src/negentropy/knowledge/repository.py) - 数据访问（CRUD + 四种检索模式），使用 `NEGENTROPY_SCHEMA` 常量
 - [service.py](../apps/negentropy/src/negentropy/knowledge/service.py) - 业务逻辑（Ingestion + Search + L1 Reranking 集成）
 - [api.py](../apps/negentropy/src/negentropy/knowledge/api.py) - REST API（Dashboard/Base CRUD/Graph/Pipelines）


### PR DESCRIPTION
## 变更概述

本 PR 为 Knowledge Base 页面中的 Ingest 文档链路补齐四种 Chunking 策略支持：`fixed`、`recursive`、`semantic`、`hierarchical`，并完成前后端、检索逻辑、UI 配置、测试与文档的全链路打通。

## 为什么要做

当前 Knowledge Base 已具备部分分块能力，但配置透传和策略覆盖不完整，尤其缺少对 `hierarchical` 的系统级支持，也缺少在 UI 中对各类策略的清晰说明。这会导致：

- Ingest 请求无法稳定表达完整的 chunking 意图
- 前后端对策略参数的理解不一致
- reviewer 和使用者难以理解不同策略的适用场景
- `hierarchical` 无法落实为“检索子块、返回父块上下文”的真实行为

本次改动的目标，是把 Chunking 从“局部能力”提升为 Knowledge Base Ingest 的一等配置能力，并保证默认行为与现有语义兼容。

## 具体改动

### 1. 后端补齐四种 Chunking 策略与配置模型

- 扩展 `ChunkingStrategy`，新增 `hierarchical`
- 扩展 `ChunkingConfig`，补齐：
  - `strategy`
  - `semantic_threshold`
  - `min_chunk_size`
  - `max_chunk_size`
  - `hierarchical_parent_chunk_size`
  - `hierarchical_child_chunk_size`
  - `hierarchical_child_overlap`
- 为 hierarchical 相关参数增加约束校验，避免父子块尺寸和 overlap 配置非法

### 2. API 请求模型与配置合并逻辑统一

- 为 ingest / ingest_url / replace_source / sync_source / rebuild_source / document action 等请求模型统一补齐 chunking 字段
- 后端统一采用：
  - 请求参数
  - `corpus.config`
  - 系统默认值
 这一优先级构建 chunking 配置，保证 Single Source of Truth 与请求级覆盖共存

### 3. 实现 hierarchical 分块与检索父块提升

- 在 chunking 层增加 hierarchical 分块逻辑
- 在 service 层为 hierarchical 建模父子 chunk 元数据
- 让父块默认不参与召回，子块参与召回
- 当检索命中子块时，服务层会提升为返回对应父块内容，从而提供更完整的上下文

### 4. 前端 Knowledge Base 页面支持四种策略配置

- 在 Knowledge Base 的 Documents / Settings 相关 UI 中补齐四种策略的配置入口
- 为不同策略增加简要说明，帮助用户理解适用场景与取舍
- 统一前端 `ChunkingConfig` 类型与请求透传逻辑，避免前后端配置漂移
- 文档重建、同步、替换等动作也复用同一套 chunking 配置

### 5. 测试与文档同步更新

- 新增和扩展后端单测，覆盖：
  - hierarchical 配置校验
  - hierarchical 分块行为
  - document 路由配置合并逻辑
- 新增和扩展前端单测，覆盖 chunking 请求参数透传
- 更新知识库设计文档，明确四种 chunking 策略的范围

## 重要实现细节

- `hierarchical` 采用父子 chunk 元数据建模，而不是引入新的独立表结构，控制了改动爆炸半径
- 检索时通过“子块召回、父块返回”实现更强的上下文完整性
- 前端说明文案保持简洁，避免把复杂策略细节直接暴露为难以理解的配置噪音
- 保留默认 `recursive` 行为，尽量降低现有知识库的回归风险

## 影响范围

- Knowledge Base 文档摄入链路
- Chunking 配置透传
- 文档重建 / 同步 / 替换相关调用
- 部分检索结果呈现逻辑
- 相关测试与知识库文档

This PR was written using [Vibe Kanban](https://vibekanban.com)