### PR TITLE
fix(knowledge-ui): 将 Chunking Strategy 收敛到 Settings 页签 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -325,25 +325,6 @@ export default function KnowledgeBasePage() {
 
   const [documents, setDocuments] = useState<KnowledgeDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
-  const [documentChunkingState, setDocumentChunkingState] = useState<{
-    corpusId: string | null;
-    config: ChunkingConfig;
-  }>({
-    corpusId: null,
-    config: {
-      strategy: "recursive",
-      chunk_size: 800,
-      overlap: 100,
-      preserve_newlines: true,
-      separators: [],
-      semantic_threshold: 0.85,
-      min_chunk_size: 50,
-      max_chunk_size: 2000,
-      hierarchical_parent_chunk_size: 1024,
-      hierarchical_child_chunk_size: 256,
-      hierarchical_child_overlap: 51,
-    },
-  });
 
   const [documentChunks, setDocumentChunks] = useState<DocumentChunkItem[]>([]);
   const [chunksLoading, setChunksLoading] = useState(false);
@@ -365,29 +346,7 @@ export default function KnowledgeBasePage() {
     () => corpora.find((item) => item.id === selectedCorpusId) || null,
     [corpora, selectedCorpusId],
   );
-  const derivedCorpusChunkingConfig = useMemo<ChunkingConfig>(() => {
-    const config = (selectedCorpus?.config || {}) as ChunkingConfig;
-    return {
-      strategy: (config.strategy as ChunkingStrategy) || "recursive",
-      chunk_size: config.chunk_size || 800,
-      overlap: config.overlap || 100,
-      preserve_newlines: config.preserve_newlines !== false,
-      separators: Array.isArray(config.separators) ? config.separators : [],
-      semantic_threshold: config.semantic_threshold || 0.85,
-      min_chunk_size: config.min_chunk_size || 50,
-      max_chunk_size: config.max_chunk_size || 2000,
-      hierarchical_parent_chunk_size:
-        config.hierarchical_parent_chunk_size || 1024,
-      hierarchical_child_chunk_size:
-        config.hierarchical_child_chunk_size || 256,
-      hierarchical_child_overlap:
-        config.hierarchical_child_overlap || 51,
-    };
-  }, [selectedCorpus]);
-  const documentChunkingConfig =
-    documentChunkingState.corpusId === selectedCorpus?.id
-      ? documentChunkingState.config
-      : derivedCorpusChunkingConfig;
+  const corpusChunkingConfig = selectedCorpus?.config as ChunkingConfig | undefined;
 
   const syncQueryState = useCallback(
     (next: Partial<Record<"view" | "corpusId" | "tab" | "documentId", string | null>>) => {
@@ -566,7 +525,7 @@ export default function KnowledgeBasePage() {
       await ingestUrl({
         url: url.trim(),
         as_document: true,
-        chunkingConfig: documentChunkingConfig,
+        chunkingConfig: corpusChunkingConfig,
       });
       toast.success("URL ingest started");
       await loadDocuments();
@@ -581,7 +540,7 @@ export default function KnowledgeBasePage() {
       await ingestFile({
         file,
         source_uri: file.name,
-        chunkingConfig: documentChunkingConfig,
+        chunkingConfig: corpusChunkingConfig,
       });
       toast.success("File ingest started");
       await loadDocuments();
@@ -599,12 +558,12 @@ export default function KnowledgeBasePage() {
       if (action === "sync") {
         await syncDocument(selectedCorpusId, doc.id, {
           app_name: APP_NAME,
-          ...documentChunkingConfig,
+          ...corpusChunkingConfig,
         });
       } else if (action === "rebuild") {
         await rebuildDocument(selectedCorpusId, doc.id, {
           app_name: APP_NAME,
-          ...documentChunkingConfig,
+          ...corpusChunkingConfig,
         });
       } else if (action === "archive") {
         await archiveDocument(selectedCorpusId, doc.id, { app_name: APP_NAME });
@@ -637,7 +596,7 @@ export default function KnowledgeBasePage() {
     await replaceDocument(selectedCorpusId, replacingDocument.id, {
       app_name: APP_NAME,
       text: payload.text,
-      ...documentChunkingConfig,
+      ...corpusChunkingConfig,
     });
     toast.success("replace success");
     setIsReplaceDialogOpen(false);
@@ -883,24 +842,6 @@ export default function KnowledgeBasePage() {
             <main className="min-w-0 flex-1 rounded-2xl border border-border bg-card p-4 shadow-sm">
               {corpusTab === "documents" && (
                 <div className="space-y-3">
-                  <ChunkingStrategyPanel
-                    config={documentChunkingConfig}
-                    onChange={(next) =>
-                      setDocumentChunkingState((prev) => ({
-                        corpusId: selectedCorpus?.id || null,
-                        config:
-                          typeof next === "function"
-                            ? next(
-                                prev.corpusId === selectedCorpus?.id
-                                  ? prev.config
-                                  : documentChunkingConfig,
-                              )
-                            : next,
-                      }))
-                    }
-                    title="Chunking Strategy"
-                    description="当前摄入与文档重建按字符近似控制大小；hierarchical 会检索子块并返回父块。"
-                  />
                   <div className="flex items-center justify-between">
                     <h2 className="text-sm font-semibold">Documents</h2>
                     <div className="flex items-center gap-2">

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -195,6 +195,35 @@ describe("KnowledgeBasePage", () => {
     );
   });
 
+  it("documents 视图不显示 Chunking Strategy 配置模块", async () => {
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: "Chunking Strategy" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Save Settings")).not.toBeInTheDocument();
+  });
+
+  it("settings 视图显示 Settings 配置模块", async () => {
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=settings";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(
+      screen.getByRole("heading", { name: "Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
+  });
+
   it("进入 document-chunks 视图时使用不超过后端约束的 limit=200", async () => {
     searchParamsState.value =
       "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=document-chunks&documentId=doc-1";


### PR DESCRIPTION
## 变更概述

本 PR 对 Knowledge Base 页面进行了一个职责收敛修正：移除了 `Documents` 页签下重复展示的 `Chunking Strategy` 配置模块，只保留 `Settings` 页签中的 `Settings` 作为 Chunking 默认配置的唯一编辑入口。

## 为什么要做

在前一轮改动后，`Chunking Strategy` 同时出现在 `Documents` 和 `Settings` 两个页签中，导致页面职责边界变得模糊：

- `Documents` 本应只负责文档列表、摄入和文档操作
- `Settings` 才是 Corpus 级默认配置的编辑入口
- 同一份配置在两个位置同时出现，会让用户误以为 `Documents` 页也承担配置管理职责
- 这会增加理解成本，也偏离了 Single Source of Truth 的设计原则

本次修正的目标，是把配置编辑能力收敛回 `Settings` 页签，使 `Documents` 页重新聚焦于文档操作本身。

## 具体改动

### 1. 移除 Documents 页签中的 Chunking Strategy 模块

- 删除 `Documents` 视图顶部的 `ChunkingStrategyPanel`
- 让 `Documents` 页面恢复为纯文档操作界面，只保留：
  - 文档列表
  - `Ingest From URL`
  - `Ingest From File`
  - 文档级别的 `View / Download / Replace / Rebuild / Sync / Archive / Delete` 等操作

### 2. 将文档相关操作重新绑定到 Corpus 默认配置

- 去掉 `Documents` 页内为临时 chunking 配置引入的局部状态
- 文档摄入、重建、同步、替换等动作重新统一使用 `selectedCorpus.config`
- 恢复由 Corpus 配置统一驱动的行为，避免页面局部状态与设置页配置分裂

### 3. 保留 Settings 页签作为唯一配置入口

- `Settings` 页签中的 `Settings` 面板保持不变
- `Save Settings` 仍然是保存 Chunking 默认配置的唯一入口
- 页面语义更清晰：内容操作与配置管理彻底分离

### 4. 补充页面测试

- 新增测试确保：
  - `Documents` 页签不再显示 `Chunking Strategy`
  - `Settings` 页签仍然显示 `Settings` 与 `Save Settings`
- 同时保留现有页面行为断言，避免因为 UI 收敛引入回归

## 重要实现细节

- 本次没有修改后端接口、Chunking 类型或数据模型，只调整前端页面职责边界
- 通过删除 `Documents` 页内的临时 chunking 配置状态，恢复 `selectedCorpus.config` 作为单一事实源
- 这是一次最小干预的 UI 收敛修正，不引入新的交互复杂度

## 影响范围

- Knowledge Base 页面 UI 结构
- 文档操作对默认 chunking 配置的读取路径
- 对应页面单元测试

This PR was written using [Vibe Kanban](https://vibekanban.com)