### PR TITLE
fix(Knowledge): 修复冻结配置模型哈希异常并恢复后端 CI

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Dict, Iterable, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from .constants import (
     MAX_OVERLAP_RATIO,
@@ -140,7 +140,7 @@ class ChunkingConfig(BaseModel):
     chunk_size: int = 800
     overlap: int = 100
     preserve_newlines: bool = True
-    separators: List[str] = []
+    separators: tuple[str, ...] = Field(default_factory=tuple)
     # 语义分块专用参数
     semantic_threshold: float = 0.85  # 相似度阈值，低于此值时切分
     min_chunk_size: int = 50  # 最小块大小（字符数）
@@ -237,7 +237,7 @@ class ChunkingConfig(BaseModel):
 
     @field_validator("separators")
     @classmethod
-    def validate_separators(cls, v: List[str]) -> List[str]:
+    def validate_separators(cls, v: List[str] | tuple[str, ...]) -> tuple[str, ...]:
         """验证分隔符配置"""
         normalized = [item for item in (s.strip() for s in v) if item]
         # 去重并保持顺序
@@ -245,7 +245,7 @@ class ChunkingConfig(BaseModel):
         for item in normalized:
             if item not in deduped:
                 deduped.append(item)
-        return deduped
+        return tuple(deduped)
 
     @model_validator(mode="after")
     def validate_chunking_relationships(self) -> "ChunkingConfig":
@@ -596,8 +596,8 @@ class GraphBuildConfigModel(BaseModel):
 
     enable_llm_extraction: bool = True
     llm_model: Optional[str] = None
-    entity_types: List[str] = field(default_factory=list)
-    relation_types: List[str] = field(default_factory=list)
+    entity_types: tuple[str, ...] = Field(default_factory=tuple)
+    relation_types: tuple[str, ...] = Field(default_factory=tuple)
     min_entity_confidence: float = 0.5
     min_relation_confidence: float = 0.5
     batch_size: int = 10
@@ -630,3 +630,13 @@ class GraphBuildConfigModel(BaseModel):
         if v > 10:
             raise ValueError(f"max_concurrency must be at most 10, got {v}")
         return v
+
+    @field_validator("entity_types", "relation_types")
+    @classmethod
+    def validate_graph_type_filters(cls, v: List[str] | tuple[str, ...]) -> tuple[str, ...]:
+        normalized = [item for item in (s.strip() for s in v) if item]
+        deduped: List[str] = []
+        for item in normalized:
+            if item not in deduped:
+                deduped.append(item)
+        return tuple(deduped)

--- a/apps/negentropy/tests/unit_tests/knowledge/test_types.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_types.py
@@ -13,6 +13,7 @@ from negentropy.knowledge.types import (
     ChunkingConfig,
     CorpusRecord,
     CorpusSpec,
+    GraphBuildConfigModel,
     KnowledgeChunk,
     KnowledgeMatch,
     KnowledgeRecord,
@@ -135,6 +136,11 @@ class TestChunkingConfig:
         config = ChunkingConfig(chunk_size=100, overlap=50)
         assert config.overlap < config.chunk_size
 
+    def test_separators_normalized_to_hashable_tuple(self) -> None:
+        """separators 应标准化为可哈希的不可变元组"""
+        config = ChunkingConfig(separators=["###", " ", "###", "\t", "---"])
+        assert config.separators == ("###", "---")
+
 
 class TestSearchConfig:
     """SearchConfig 配置测试"""
@@ -189,6 +195,25 @@ class TestImmutability:
         config1 = ChunkingConfig(chunk_size=500, overlap=50)
         config2 = ChunkingConfig(chunk_size=500, overlap=50)
         # frozen Pydantic model 应可哈希
+        assert hash(config1) == hash(config2)
+
+
+class TestGraphBuildConfig:
+    """GraphBuildConfigModel 配置测试"""
+
+    def test_graph_build_config_hashable(self) -> None:
+        """图谱构建配置应保持可哈希"""
+        config1 = GraphBuildConfigModel(
+            entity_types=["person", "organization", "person"],
+            relation_types=["WORKS_FOR", "  ", "WORKS_FOR"],
+        )
+        config2 = GraphBuildConfigModel(
+            entity_types=("person", "organization"),
+            relation_types=("WORKS_FOR",),
+        )
+
+        assert config1.entity_types == ("person", "organization")
+        assert config1.relation_types == ("WORKS_FOR",)
         assert hash(config1) == hash(config2)
 
 


### PR DESCRIPTION
## 变更概述

本 PR 修复 Knowledge 类型配置模型在冻结场景下仍持有可变列表字段的问题，恢复 negentropy-backend-tests 在 GitHub Actions 中的稳定执行。

## 根因分析

失败的 Workflow 为 negentropy-backend-tests，异常发生在单元测试 tests/unit_tests/knowledge/test_types.py::TestImmutability::test_frozen_dataclass_hashable。

直接原因是：

- ChunkingConfig 使用了 ConfigDict(frozen=True)，但 separators 仍是 list
- GraphBuildConfigModel 也存在同类问题，entity_types 和 relation_types 仍使用可变集合

这会破坏冻结配置对象的值对象语义，使 hash(model) 在运行时抛出 TypeError: unhashable type: list。

## 修复内容

### 1. 收敛 frozen 配置模型到真正不可变的值对象表示

- 将 ChunkingConfig.separators 改为 tuple[str, ...]
- 将 GraphBuildConfigModel.entity_types 和 relation_types 改为 tuple[str, ...]
- 使用 pydantic.Field(default_factory=tuple)，避免在 BaseModel 中继续保留可变默认值

### 2. 保持输入兼容与既有清洗语义

- 校验器继续接受 list 或 tuple 输入
- 保持原有空白清理、去重、保序行为不变
- 仅把内部存储收敛为可哈希的不可变结构

### 3. 补齐同类回归测试

新增测试覆盖：

- ChunkingConfig 的 hash 契约
- separators 规范化后返回 tuple
- GraphBuildConfigModel 的 hash 契约
- 图谱类型过滤字段的去重与不可变性

## 验证结果

本地已按后端 Workflow 等价链路验证通过：

- uv run pytest tests/unit_tests/ -v
- uv run alembic upgrade head
- uv run pytest tests/integration_tests/ -v
- uv run pytest tests/performance_tests/ -v

结果：

- unit tests: 206 passed
- integration tests: 10 passed
- performance tests: 4 passed, 1 skipped

## 风险控制

- 不修改 HTTP / API 入参结构
- 不改变默认 chunking 和 graph build 行为
- 仅修正冻结配置模型的内部数据表示与回归测试
- 将修复边界限制在同根因对象，避免引入无关改动

This PR was written using Vibe Kanban
