### PR TITLE
fix(Knowledge): 修复冻结配置模型哈希异常并恢复后端 CI (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Any, Dict, Iterable, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from .constants import (
     MAX_OVERLAP_RATIO,
@@ -140,7 +140,7 @@ class ChunkingConfig(BaseModel):
     chunk_size: int = 800
     overlap: int = 100
     preserve_newlines: bool = True
-    separators: List[str] = []
+    separators: tuple[str, ...] = Field(default_factory=tuple)
     # 语义分块专用参数
     semantic_threshold: float = 0.85  # 相似度阈值，低于此值时切分
     min_chunk_size: int = 50  # 最小块大小（字符数）
@@ -237,7 +237,7 @@ class ChunkingConfig(BaseModel):
 
     @field_validator("separators")
     @classmethod
-    def validate_separators(cls, v: List[str]) -> List[str]:
+    def validate_separators(cls, v: List[str] | tuple[str, ...]) -> tuple[str, ...]:
         """验证分隔符配置"""
         normalized = [item for item in (s.strip() for s in v) if item]
         # 去重并保持顺序
@@ -245,7 +245,7 @@ class ChunkingConfig(BaseModel):
         for item in normalized:
             if item not in deduped:
                 deduped.append(item)
-        return deduped
+        return tuple(deduped)
 
     @model_validator(mode="after")
     def validate_chunking_relationships(self) -> "ChunkingConfig":
@@ -596,8 +596,8 @@ class GraphBuildConfigModel(BaseModel):
 
     enable_llm_extraction: bool = True
     llm_model: Optional[str] = None
-    entity_types: List[str] = field(default_factory=list)
-    relation_types: List[str] = field(default_factory=list)
+    entity_types: tuple[str, ...] = Field(default_factory=tuple)
+    relation_types: tuple[str, ...] = Field(default_factory=tuple)
     min_entity_confidence: float = 0.5
     min_relation_confidence: float = 0.5
     batch_size: int = 10
@@ -630,3 +630,13 @@ class GraphBuildConfigModel(BaseModel):
         if v > 10:
             raise ValueError(f"max_concurrency must be at most 10, got {v}")
         return v
+
+    @field_validator("entity_types", "relation_types")
+    @classmethod
+    def validate_graph_type_filters(cls, v: List[str] | tuple[str, ...]) -> tuple[str, ...]:
+        normalized = [item for item in (s.strip() for s in v) if item]
+        deduped: List[str] = []
+        for item in normalized:
+            if item not in deduped:
+                deduped.append(item)
+        return tuple(deduped)

--- a/apps/negentropy/tests/unit_tests/knowledge/test_types.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_types.py
@@ -13,6 +13,7 @@ from negentropy.knowledge.types import (
     ChunkingConfig,
     CorpusRecord,
     CorpusSpec,
+    GraphBuildConfigModel,
     KnowledgeChunk,
     KnowledgeMatch,
     KnowledgeRecord,
@@ -135,6 +136,11 @@ class TestChunkingConfig:
         config = ChunkingConfig(chunk_size=100, overlap=50)
         assert config.overlap < config.chunk_size
 
+    def test_separators_normalized_to_hashable_tuple(self) -> None:
+        """separators 应标准化为可哈希的不可变元组"""
+        config = ChunkingConfig(separators=["###", " ", "###", "\t", "---"])
+        assert config.separators == ("###", "---")
+
 
 class TestSearchConfig:
     """SearchConfig 配置测试"""
@@ -189,6 +195,25 @@ class TestImmutability:
         config1 = ChunkingConfig(chunk_size=500, overlap=50)
         config2 = ChunkingConfig(chunk_size=500, overlap=50)
         # frozen Pydantic model 应可哈希
+        assert hash(config1) == hash(config2)
+
+
+class TestGraphBuildConfig:
+    """GraphBuildConfigModel 配置测试"""
+
+    def test_graph_build_config_hashable(self) -> None:
+        """图谱构建配置应保持可哈希"""
+        config1 = GraphBuildConfigModel(
+            entity_types=["person", "organization", "person"],
+            relation_types=["WORKS_FOR", "  ", "WORKS_FOR"],
+        )
+        config2 = GraphBuildConfigModel(
+            entity_types=("person", "organization"),
+            relation_types=("WORKS_FOR",),
+        )
+
+        assert config1.entity_types == ("person", "organization")
+        assert config1.relation_types == ("WORKS_FOR",)
         assert hash(config1) == hash(config2)
 
 


### PR DESCRIPTION
## 变更概述

本 PR 修复 Knowledge 类型配置模型在冻结场景下仍持有可变列表字段的问题，恢复 negentropy-backend-tests 在 GitHub Actions 中的稳定执行。

## 为什么要做

本次修复来自一次真实的 GitHub Actions 失败排查。失败的 Workflow 为 negentropy-backend-tests，异常出现在单元测试 `tests/unit_tests/knowledge/test_types.py::TestImmutability::test_frozen_dataclass_hashable`。

根因是部分 Pydantic 冻结配置模型虽然声明了 `frozen=True`，但内部仍保存可变 `list` 字段，导致对象在参与 `hash()` 时抛出 `TypeError: unhashable type: 'list'`。这破坏了配置对象作为不可变值对象的契约，也直接导致后端 CI 失败。

## 本次改动

### 1. 修复冻结配置模型的不可哈希问题

在 `apps/negentropy/src/negentropy/knowledge/types.py` 中：

- 将 `ChunkingConfig.separators` 从可变列表收敛为不可变元组
- 将 `GraphBuildConfigModel.entity_types` 和 `relation_types` 从可变列表收敛为不可变元组
- 使用 `pydantic.Field(default_factory=tuple)` 作为默认值工厂，避免在冻结模型中继续保留可变集合

### 2. 保持输入兼容与现有语义稳定

- 校验器继续接受 `list` 和 `tuple` 输入
- 保留原有的空白清理、去重和顺序保持逻辑
- 仅调整模型内部存储形态，使其满足冻结模型的值对象语义

### 3. 增补回归测试

在 `apps/negentropy/tests/unit_tests/knowledge/test_types.py` 中新增测试，覆盖：

- `ChunkingConfig` 的哈希契约
- `separators` 规范化后返回不可变元组
- `GraphBuildConfigModel` 的哈希契约
- 图谱类型过滤字段的去重与不可变性

## 重要实现细节

- 本次修复采用不可变值对象思路，而不是通过规避测试或弱化断言来掩盖问题
- 修复范围严格限制在同根因的配置模型与测试，避免扩大改动爆炸半径
- 对外输入兼容性保持不变，因此不会影响现有调用方以列表形式传参的路径
- 本次改动同时补上 `GraphBuildConfigModel` 的同类风险，避免只修当前失败点而遗留同源隐患

## 验证情况

本地已按后端 Workflow 等价链路完成验证：

- `uv run pytest tests/unit_tests/ -v`
- `uv run alembic upgrade head`
- `uv run pytest tests/integration_tests/ -v`
- `uv run pytest tests/performance_tests/ -v`

结合任务上下文，线上 GitHub Actions 也已完成验证，后端 Workflow 恢复正常。

This PR was written using [Vibe Kanban](https://vibekanban.com)
