### PR TITLE
统一 Knowledge Base 与 Documents 的文档预览入口行为 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -15,6 +15,7 @@ import {
   CorpusRecord,
   ChunkingConfig,
   ChunkingStrategy,
+  DocumentViewDialog,
   DocumentChunkItem,
   KnowledgeDocument,
   KnowledgeMatch,
@@ -339,6 +340,7 @@ export default function KnowledgeBasePage() {
   const [isDeletingCorpus, setIsDeletingCorpus] = useState(false);
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] = useState(false);
   const [replacingDocument, setReplacingDocument] = useState<KnowledgeDocument | null>(null);
+  const [viewingDoc, setViewingDoc] = useState<KnowledgeDocument | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -576,7 +578,7 @@ export default function KnowledgeBasePage() {
       } else if (action === "download") {
         await downloadDocument(selectedCorpusId, doc.id, { appName: APP_NAME });
       } else if (action === "view") {
-        syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id });
+        setViewingDoc(doc);
         return;
       } else if (action === "delete") {
         if (!window.confirm("确定删除该文档吗？")) return;
@@ -965,6 +967,12 @@ export default function KnowledgeBasePage() {
       </div>
 
       <ChunkDetailDrawer chunk={selectedChunk} onClose={() => setSelectedChunk(null)} />
+
+      <DocumentViewDialog
+        isOpen={viewingDoc !== null}
+        document={viewingDoc}
+        onClose={() => setViewingDoc(null)}
+      />
 
       <CorpusFormDialog
         key={`${dialogMode}-${editingCorpus?.id || "new"}-${isDialogOpen ? "open" : "closed"}`}

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
+  DocumentViewDialog,
   KnowledgeDocument,
   fetchAllDocuments,
   deleteDocument,
@@ -13,7 +14,6 @@ import {
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
-import { DocumentViewDialog } from "./_components/DocumentViewDialog";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -2,14 +2,17 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-import {
+
+import type {
   KnowledgeDocument,
   KnowledgeDocumentDetail,
+} from "../utils/knowledge-api";
+import {
   downloadDocument,
   fetchDocumentDetail,
-  formatRelativeTime,
   refreshDocumentMarkdown,
-} from "@/features/knowledge";
+} from "../utils/knowledge-api";
+import { formatRelativeTime } from "../utils/pipeline-helpers";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -82,7 +85,7 @@ function displayUser(createdBy: string | null): string {
   if (createdBy.includes("@")) {
     return createdBy.split("@")[0];
   }
-  return createdBy.length > 20 ? createdBy.slice(0, 20) + "..." : createdBy;
+  return createdBy.length > 20 ? `${createdBy.slice(0, 20)}...` : createdBy;
 }
 
 export function DocumentViewDialog({
@@ -187,7 +190,8 @@ export function DocumentViewDialog({
 
   const viewedDoc: KnowledgeDocument = detail ?? document;
   const statusBadge = getStatusBadge(viewedDoc.status);
-  const markdownStatus = detail?.markdown_extract_status || document.markdown_extract_status || "pending";
+  const markdownStatus =
+    detail?.markdown_extract_status || document.markdown_extract_status || "pending";
   const markdownBadge = getMarkdownStatusBadge(markdownStatus);
 
   return (

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -170,6 +170,7 @@ export type {
 
 export { PipelineRunCard, PipelineRunList } from "./components/PipelineRunCard";
 export type { PipelineRunCardProps } from "./components/PipelineRunCard";
+export { DocumentViewDialog } from "./components/DocumentViewDialog";
 
 // ============================================================================
 // Utils (Pipeline Helpers)

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -11,6 +11,7 @@ const {
   fetchDocumentsMock,
   fetchDocumentChunksMock,
   searchAcrossCorporaMock,
+  documentViewDialogMock,
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
@@ -20,6 +21,7 @@ const {
   fetchDocumentsMock: vi.fn(),
   fetchDocumentChunksMock: vi.fn(),
   searchAcrossCorporaMock: vi.fn(),
+  documentViewDialogMock: vi.fn(),
   searchParamsState: {
     value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
   },
@@ -55,6 +57,17 @@ vi.mock("@/features/knowledge", () => ({
   fetchDocuments: (...args: unknown[]) => fetchDocumentsMock(...args),
   fetchDocumentChunks: (...args: unknown[]) => fetchDocumentChunksMock(...args),
   searchAcrossCorpora: (...args: unknown[]) => searchAcrossCorporaMock(...args),
+  DocumentViewDialog: ({
+    isOpen,
+    document,
+  }: {
+    isOpen: boolean;
+    document: { original_filename: string } | null;
+  }) => {
+    documentViewDialogMock({ isOpen, document });
+    if (!isOpen || !document) return null;
+    return <div>Viewing {document.original_filename}</div>;
+  },
   syncDocument: vi.fn(),
   rebuildDocument: vi.fn(),
   replaceDocument: vi.fn(),
@@ -80,12 +93,26 @@ describe("KnowledgeBasePage", () => {
     fetchDocumentsMock.mockReset();
     fetchDocumentChunksMock.mockReset();
     searchAcrossCorporaMock.mockReset();
+    documentViewDialogMock.mockReset();
     searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
 
     loadCorpusMock.mockResolvedValue(undefined);
     loadCorporaMock.mockResolvedValue(undefined);
     deleteCorpusMock.mockResolvedValue(undefined);
-    fetchDocumentsMock.mockResolvedValue({ items: [] });
+    fetchDocumentsMock.mockResolvedValue({
+      items: [
+        {
+          id: "doc-1",
+          corpus_id: "11111111-1111-1111-1111-111111111111",
+          original_filename: "Context Engineering.pdf",
+          content_type: "application/pdf",
+          status: "active",
+          file_size: 2371045,
+          metadata: { source_type: "file" },
+          markdown_extract_status: "completed",
+        },
+      ],
+    });
     fetchDocumentChunksMock.mockResolvedValue({ items: [] });
     searchAcrossCorporaMock.mockResolvedValue({
       items: [
@@ -192,6 +219,43 @@ describe("KnowledgeBasePage", () => {
     expect(fetchDocumentsMock).toHaveBeenCalledWith(
       "11111111-1111-1111-1111-111111111111",
       { appName: "negentropy", limit: 100, offset: 0 },
+    );
+  });
+
+  it("点击 View 会打开文档预览弹窗，而不是跳到 chunks 视图", async () => {
+    const user = userEvent.setup();
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: "View" }));
+
+    expect(screen.getByText("Viewing Context Engineering.pdf")).toBeInTheDocument();
+    expect(fetchDocumentChunksMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("tab=document-chunks"),
+    );
+  });
+
+  it("点击文档标题仍然进入 document-chunks 视图", async () => {
+    const user = userEvent.setup();
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Context Engineering\.pdf/ }));
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      expect.stringContaining("tab=document-chunks"),
+    );
+    expect(replaceMock).toHaveBeenCalledWith(
+      expect.stringContaining("documentId=doc-1"),
     );
   });
 


### PR DESCRIPTION
## 变更内容

本次 PR 统一了 Knowledge Base 与 Documents 页面中的文档预览行为，主要改动如下：

- 将 `DocumentViewDialog` 从 `app/knowledge/documents/_components` 提升为知识域共享组件，并通过 `features/knowledge/index.ts` 对外导出
- 将 `Knowledge Base` 页面中每个文档的 `View` 按钮行为，从“跳转到当前文档对应的 chunks 视图”调整为“打开与 Documents 页眼睛按钮一致的文档预览弹窗”
- 保留原有 chunks 查看能力：点击文档标题/主体区域仍然进入 `document-chunks` 视图
- 更新 `Documents` 页面 import，改为复用共享的 `DocumentViewDialog`
- 补充 `KnowledgeBasePage` 单元测试，覆盖：
  - 点击 `View` 打开预览弹窗
  - 点击 `View` 不再跳转到 chunks
  - 点击文档标题仍然进入 chunks

## 变更原因

任务上下文明确要求：

- `Knowledge Base` 中的 `View` 应当与 `Documents` 页红框中的 view（眼睛图标）提供同等功能
- 点击后应弹出文档预览弹窗
- 不应再打开当前 Document 对应的 Chunks 队列

现状的问题是，同样命名为 `View`，但两个页面的实际行为不一致：
- `Documents` 页的 view 是“预览文档”
- `Knowledge Base` 页的 `View` 却是“进入 chunks 队列”

这会造成明显的语义错位和认知负担。此次调整的目标就是消除这种同名异义，保持系统交互的一致性与可预期性。

## 重要实现细节

- 本次改动仅涉及前端 UI 复用与交互语义调整，没有新增后端接口，也没有修改数据模型
- 采用共享组件复用，而不是在 `Knowledge Base` 页面复制一套预览弹窗实现，避免后续两处逻辑漂移
- `Knowledge Base` 页面新增本地 `viewingDoc` 状态用于控制弹窗开关
- chunks 能力没有被删除，只是从 `View` 按钮解耦，继续保留在文档标题点击链路上
- 该实现符合“组合优于重复构造”的复用驱动原则，也降低了后续维护成本

## 验证结果

已执行前端测试，Vitest 全量结果为：

- 21 个 test files 通过
- 94 个测试通过
- 3 个测试跳过

其中重点覆盖了 `KnowledgeBasePage` 的新旧行为边界，确保本次调整不会把 chunks 查看入口一并破坏。

This PR was written using [Vibe Kanban](https://vibekanban.com)
