### PR TITLE
优化 GitHub Actions 检查命名与 UI 测试文档描述 (Vibe Kanban)

### DIFF
--- a/.github/workflows/negentropy-backend-tests.yml
+++ b/.github/workflows/negentropy-backend-tests.yml
@@ -1,4 +1,4 @@
-name: negentropy-backend-tests
+name: Backend Test Suite
 
 on:
   push:
@@ -24,7 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  backend-tests:
+    name: Backend Test Suite
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/negentropy-ui-tests.yml
+++ b/.github/workflows/negentropy-ui-tests.yml
@@ -1,4 +1,4 @@
-name: negentropy-ui-tests
+name: UI Test Suite
 
 on:
   push:
@@ -22,7 +22,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  ui-tests:
+    name: UI Test Suite
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:

--- a/docs/negentropy-ui-plan.md
+++ b/docs/negentropy-ui-plan.md
@@ -181,7 +181,7 @@
 - ✅ 已完成：UI 侧埋点（事件耗时、连接重试次数、错误次数）。实现见 [apps/negentropy-ui/app/page.tsx](../apps/negentropy-ui/app/page.tsx)。
 - `session_id`/`user_id` 贯穿前后端（参见 [apps/negentropy/src/negentropy/engine/bootstrap.py](../apps/negentropy/src/negentropy/engine/bootstrap.py)）。
 - ✅ 已完成：最小回归测试（单元 + 集成）。覆盖 `lib/adk` 事件映射、核心 UI 组件（ChatStream/EventTimeline/StateSnapshot/Composer），并在 `tests/integration` mock `useAgent` 验证页面级交互流程；配置 `vitest`。实现见 [apps/negentropy-ui/tests](../apps/negentropy-ui/tests)、[apps/negentropy-ui/vitest.config.ts](../apps/negentropy-ui/vitest.config.ts)。
-- ✅ 已完成：CI 回归（GitHub Actions）在 `apps/negentropy-ui` 变更时执行 `yarn test`。实现见 [.github/workflows/negentropy-ui-tests.yml](../.github/workflows/negentropy-ui-tests.yml)。
+- ✅ 已完成：CI 回归（GitHub Actions）在 `apps/negentropy-ui` 变更时执行 `pnpm test`。实现见 [.github/workflows/negentropy-ui-tests.yml](../.github/workflows/negentropy-ui-tests.yml)。
 
 ## 10. 风险与验证（Feedback Loop）
 


### PR DESCRIPTION
## 变更内容

本次改动主要优化了 GitHub Actions 中 Checks 的命名可读性，并同步修正了一处与 UI 测试流程相关的文档描述。

具体包括：

- 将后端测试 workflow 的展示名从文件名式命名调整为更清晰的 `Backend Test Suite`
- 将前端测试 workflow 的展示名从文件名式命名调整为更清晰的 `UI Test Suite`
- 将两个 workflow 中泛化的 job 标识 `test` 分别改为更具职责语义的 `backend-tests` 与 `ui-tests`
- 为两个 job 显式补充 `name`，避免 GitHub PR / Checks 视图中出现多个同名 `test` 检查
- 修正 [docs/negentropy-ui-plan.md](./docs/negentropy-ui-plan.md) 中过时的 UI CI 描述，将 `yarn test` 更正为当前实际执行的 `pnpm test`

## 变更原因

当前 GitHub PR / Checks 视图中，多个检查项统一显示为 `test`，会带来两个问题：

1. reviewer 无法快速判断某个检查对应的是后端还是前端流水线；
2. 合并前定位失败检查时，认知成本较高，不利于 CI 可观测性与后续维护。

结合本次任务上下文，这一轮调整的核心目标是对 CI 展示层做最小干预式治理：不改变 workflow 文件路径、不改变触发规则、不改变测试命令，只把对外展示的名称与 job 语义收敛到更明确的职责命名上，从而降低 PR 审阅与故障排查的歧义。

同时，相关文档里仍写着 `yarn test`，与当前 workflow 实际执行的 `pnpm test` 不一致。此次顺手修正该描述，保持文档与实现一致，避免形成新的信息分裂。

## 重要实现细节

- 本次没有重命名 workflow 文件本身，仍保留：
  - `.github/workflows/negentropy-backend-tests.yml`
  - `.github/workflows/negentropy-ui-tests.yml`
- 仅调整 workflow 级 `name`、job id，以及显式 `jobs.<id>.name`
- 没有修改：
  - `paths` 触发条件
  - 并发控制 `concurrency`
  - Python / Node / pnpm / uv 安装逻辑
  - 后端单元、集成、性能测试执行链路
  - 前端 `pnpm test` 执行方式
- 该改动的主要影响面在 GitHub UI 展示层；如果仓库的 required status checks 绑定了旧检查名，合并前需要在 GitHub 仓库设置中同步核对

## 受影响文件

- [.github/workflows/negentropy-backend-tests.yml](./.github/workflows/negentropy-backend-tests.yml)
- [.github/workflows/negentropy-ui-tests.yml](./.github/workflows/negentropy-ui-tests.yml)
- [docs/negentropy-ui-plan.md](./docs/negentropy-ui-plan.md)

## 验证关注点

建议在 GitHub 上重点确认以下结果：

- PR / Checks 视图中不再出现多个同名 `test`
- 后端检查显示为 `Backend Test Suite`
- 前端检查显示为 `UI Test Suite`
- 两个 workflow 的触发行为与原先保持一致
- 若仓库启用了 required status checks，确认其名称映射未失效

This PR was written using [Vibe Kanban](https://vibekanban.com)
