### PR TITLE
统一中央弹框与右侧抽屉的空白区关闭交互 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/apis/_components/DynamicApiForm.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/DynamicApiForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { Loader2, Play, ChevronRight } from "lucide-react";
 import { ApiEndpoint, InteractiveFormConfig, FormFieldConfig } from "@/features/knowledge/utils/api-specs";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { FormFieldRenderer } from "./FormFieldRenderer";
 import { executeApiCall } from "./utils/ApiExecutor";
 
@@ -193,8 +194,13 @@ export function DynamicApiForm({
 
       {/* 确认对话框 */}
       {showConfirmDialog && config.confirmDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900">
+        <OverlayDismissLayer
+          open={showConfirmDialog}
+          onClose={handleCancelConfirm}
+          busy={loading}
+          containerClassName="flex min-h-full items-center justify-center p-4"
+          contentClassName="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+        >
             <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {config.confirmDialog.title}
             </h3>
@@ -210,13 +216,13 @@ export function DynamicApiForm({
               </button>
               <button
                 onClick={handleConfirm}
+                disabled={loading}
                 className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-700"
               >
                 确认
               </button>
             </div>
-          </div>
-        </div>
+        </OverlayDismissLayer>
       )}
     </div>
   );

--- a/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { IngestResult, AsyncPipelineResult, ChunkingConfig } from "@/features/knowledge";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 // 支持的文件扩展名
 const SUPPORTED_EXTENSIONS = [".txt", ".md", ".markdown", ".pdf"];
@@ -175,13 +176,19 @@ export function AddSourceDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="add-source-dialog-title"
-        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
-      >
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={handleClose}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": "add-source-dialog-title",
+        "data-testid": "overlay-content",
+      }}
+      backdropTestId="overlay-backdrop"
+    >
         {/* Header */}
         <div className="mb-4 flex items-center justify-between">
           <h2
@@ -366,7 +373,6 @@ export function AddSourceDialog({
             Ingest
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { CorpusRecord, ChunkingStrategy } from "@/features/knowledge";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface CorpusFormDialogProps {
   isOpen: boolean;
@@ -123,8 +124,13 @@ export function CorpusFormDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={onClose}
+      busy={isLoading}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+    >
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             {mode === "create" ? "新建数据源" : "编辑数据源"}
@@ -407,7 +413,6 @@ export function CorpusFormDialog({
                 : "保存修改"}
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/DeleteCorpusDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/DeleteCorpusDialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+
 interface DeleteCorpusDialogProps {
   isOpen: boolean;
   corpusName: string | null;
@@ -18,13 +20,18 @@ export function DeleteCorpusDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="delete-corpus-dialog-title"
-        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
-      >
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={onClose}
+      busy={isDeleting}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": "delete-corpus-dialog-title",
+      }}
+    >
         <div className="mb-4 flex items-center justify-between">
           <h2
             id="delete-corpus-dialog-title"
@@ -77,7 +84,6 @@ export function DeleteCorpusDialog({
             {isDeleting ? "Deleting..." : "Delete"}
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/DeleteSourceDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface DeleteSourceDialogProps {
   isOpen: boolean;
@@ -39,13 +40,18 @@ export function DeleteSourceDialog({
   const displaySourceName = formatSourceNameForPrompt(sourceName);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="delete-source-dialog-title"
-        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
-      >
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={onClose}
+      busy={isDeleting}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": "delete-source-dialog-title",
+      }}
+    >
         <div className="mb-4 flex items-center justify-between">
           <h2
             id="delete-source-dialog-title"
@@ -102,7 +108,6 @@ export function DeleteSourceDialog({
             {isDeleting ? "Deleting..." : confirmLabel}
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/ReplaceDocumentDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ReplaceDocumentDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { KnowledgeDocument, fetchDocumentDetail } from "@/features/knowledge";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -94,8 +95,13 @@ export function ReplaceDocumentDialog({
   if (!isOpen || !document) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="flex h-[86vh] w-full max-w-6xl flex-col rounded-2xl bg-white p-6 shadow-xl dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={isOpen && document !== null}
+      onClose={handleClose}
+      busy={submitting}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="flex h-[86vh] w-full max-w-6xl flex-col rounded-2xl bg-white p-6 shadow-xl dark:bg-zinc-900"
+    >
         <div className="mb-4 flex items-start justify-between gap-3">
           <div className="min-w-0">
             <h2 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100">
@@ -168,7 +174,6 @@ export function ReplaceDocumentDialog({
             {submitting ? "Replacing..." : "Replace"}
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { AsyncPipelineResult } from "@/features/knowledge";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface ReplaceSourceDialogProps {
   isOpen: boolean;
@@ -56,8 +57,12 @@ export function ReplaceSourceDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={handleClose}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+    >
         {/* Header */}
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
@@ -145,7 +150,6 @@ export function ReplaceSourceDialog({
             Replace
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { AddSourceDialog } from "./_components/AddSourceDialog";
 import { CorpusFormDialog } from "./_components/CorpusFormDialog";
 import { DeleteCorpusDialog } from "./_components/DeleteCorpusDialog";
@@ -71,7 +72,13 @@ function ChunkDetailDrawer({
   const metadata = "metadata" in chunk ? chunk.metadata : {};
   const content = "content" in chunk ? chunk.content : "";
   return (
-    <div className="fixed inset-y-0 right-0 z-50 w-[420px] border-l border-border bg-card p-4 shadow-2xl">
+    <OverlayDismissLayer
+      open={chunk !== null}
+      onClose={onClose}
+      containerClassName="flex min-h-full justify-end"
+      contentClassName="h-full w-[420px] border-l border-border bg-card p-4 shadow-2xl"
+      backdropTestId="chunk-drawer-backdrop"
+    >
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-semibold">Chunk Detail</h3>
         <button
@@ -92,7 +99,7 @@ function ChunkDetailDrawer({
           </pre>
         </div>
       </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }
 

--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerFormDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface McpServer {
   id: string;
@@ -131,10 +132,14 @@ export function McpServerFormDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50">
-      <div className="absolute inset-0 bg-black/55" onClick={onClose} />
-      <div className="relative flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6">
-        <div className="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={loading}
+      backdropClassName="bg-black/55"
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900"
+    >
           <div className="border-b border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {server ? "Edit MCP Server" : "Add MCP Server"}
@@ -349,8 +354,6 @@ export function McpServerFormDialog({
               </button>
             </div>
           </form>
-        </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/skills/_components/SkillFormDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface Skill {
   id: string;
@@ -131,10 +132,14 @@ export function SkillFormDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50">
-      <div className="absolute inset-0 bg-black/55" onClick={onClose} />
-      <div className="relative flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6">
-        <div className="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={loading}
+      backdropClassName="bg-black/55"
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900"
+    >
           <div className="border-b border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {skill ? "Edit Skill" : "Add Skill"}
@@ -345,8 +350,6 @@ export function SkillFormDialog({
               </button>
             </div>
           </form>
-        </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface SubAgent {
   id: string;
@@ -218,10 +219,14 @@ export function SubAgentFormDialog({
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50">
-      <div className="absolute inset-0 bg-black/55" onClick={onClose} />
-      <div className="relative flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6">
-        <div className="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={loading}
+      backdropClassName="bg-black/55"
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900"
+    >
           <div className="border-b border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
               {agent ? "Edit SubAgent" : "Add SubAgent"}
@@ -471,8 +476,6 @@ export function SubAgentFormDialog({
               </button>
             </div>
           </form>
-        </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/components/ui/OverlayDismissLayer.tsx
+++ b/apps/negentropy-ui/components/ui/OverlayDismissLayer.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface OverlayDismissLayerProps {
+  open: boolean;
+  onClose: () => void;
+  dismissible?: boolean;
+  busy?: boolean;
+  wrapperClassName?: string;
+  backdropClassName?: string;
+  containerClassName?: string;
+  contentClassName?: string;
+  contentProps?: HTMLAttributes<HTMLDivElement>;
+  backdropTestId?: string;
+  children: ReactNode;
+}
+
+export function OverlayDismissLayer({
+  open,
+  onClose,
+  dismissible = true,
+  busy = false,
+  wrapperClassName,
+  backdropClassName,
+  containerClassName,
+  contentClassName,
+  contentProps,
+  backdropTestId,
+  children,
+}: OverlayDismissLayerProps) {
+  if (!open) return null;
+
+  const { className: contentPropsClassName, onClick, ...restContentProps } =
+    contentProps ?? {};
+
+  const handleBackdropClick = () => {
+    if (!dismissible || busy) return;
+    onClose();
+  };
+
+  const handleContentClick: NonNullable<HTMLAttributes<HTMLDivElement>["onClick"]> = (
+    event,
+  ) => {
+    event.stopPropagation();
+    onClick?.(event);
+  };
+
+  return (
+    <div className={cn("fixed inset-0 z-50", wrapperClassName)}>
+      <div
+        data-testid={backdropTestId ?? "overlay-backdrop"}
+        className={cn("absolute inset-0 bg-black/50 backdrop-blur-sm", backdropClassName)}
+        onClick={handleBackdropClick}
+      />
+      <div className={cn("relative", containerClassName)}>
+        <div
+          {...restContentProps}
+          className={cn(contentClassName, contentPropsClassName)}
+          onClick={handleContentClick}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 import type {
   KnowledgeDocument,
@@ -195,8 +196,12 @@ export function DocumentViewDialog({
   const markdownBadge = getMarkdownStatusBadge(markdownStatus);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="flex h-[86vh] w-full max-w-5xl flex-col rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900">
+    <OverlayDismissLayer
+      open={isOpen && document !== null}
+      onClose={onClose}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="flex h-[86vh] w-full max-w-5xl flex-col rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
+    >
         <div className="mb-4 flex items-start justify-between">
           <div className="flex items-center gap-3">
             {getFileIcon(viewedDoc.content_type)}
@@ -333,7 +338,6 @@ export function DocumentViewDialog({
             {isDownloading ? "Downloading..." : "Download"}
           </button>
         </div>
-      </div>
-    </div>
+    </OverlayDismissLayer>
   );
 }

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -199,6 +199,25 @@ describe("KnowledgeBasePage", () => {
     expect(deleteCorpusMock).not.toHaveBeenCalled();
   });
 
+  it("点击删除确认框空白处会关闭弹框", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.getByRole("dialog", { name: "Delete Corpus" })).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("overlay-backdrop"));
+
+    expect(screen.queryByRole("dialog", { name: "Delete Corpus" })).not.toBeInTheDocument();
+    expect(deleteCorpusMock).not.toHaveBeenCalled();
+  });
+
   it("确认删除当前 Corpus 后会执行删除并跳回 overview", async () => {
     const user = userEvent.setup();
     searchParamsState.value = "view=overview";
@@ -501,6 +520,31 @@ describe("KnowledgeBasePage", () => {
     expect(screen.getByRole("button", { name: "Corpus" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "收起 Corpus" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
+  });
+
+  it("点击右侧抽屉空白处会关闭 Chunk Detail", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByText("retrieved chunk content"));
+    expect(screen.getByText("Chunk Detail")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("chunk-drawer-backdrop"));
+    expect(screen.queryByText("Chunk Detail")).not.toBeInTheDocument();
   });
 
   it("未选中任何 Corpus 时禁用 Retrieve，并且不会发起检索", async () => {

--- a/apps/negentropy-ui/tests/unit/ui/OverlayDismissLayer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/OverlayDismissLayer.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+
+describe("OverlayDismissLayer", () => {
+  it("点击 backdrop 会触发关闭，点击内容区不会", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <OverlayDismissLayer
+        open
+        onClose={onClose}
+        backdropTestId="overlay-backdrop"
+        contentProps={{ "data-testid": "overlay-content" }}
+      >
+        <button type="button">Inner Action</button>
+      </OverlayDismissLayer>,
+    );
+
+    await user.click(screen.getByTestId("overlay-content"));
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("overlay-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("busy 状态下点击 backdrop 不会触发关闭", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <OverlayDismissLayer
+        open
+        onClose={onClose}
+        busy
+        backdropTestId="overlay-backdrop"
+      >
+        <div>Busy Content</div>
+      </OverlayDismissLayer>,
+    );
+
+    await user.click(screen.getByTestId("overlay-backdrop"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 变更内容

本 PR 统一补齐了前端弹层的“点击空白处自动关闭”交互，覆盖中央弹框与右侧抽屉式弹层。

具体包括：

- 新增共享弹层容器 `OverlayDismissLayer`，集中处理 backdrop 点击关闭、内容区阻断冒泡，以及 busy 状态下禁止误关闭
- 将知识库中的中央弹框接入统一弹层能力，包括新增来源、编辑 Corpus、删除确认、替换来源、替换文档、文档预览等场景
- 将插件管理相关表单弹框接入统一弹层能力，包括 MCP Server、Skill、SubAgent 的表单弹框
- 将知识库右侧 `Chunk Detail` 抽屉改为带遮罩的临时弹层，支持点击空白区域关闭
- 为 API 动态确认弹框补齐相同的 backdrop 关闭语义，并在 loading 时禁用误关闭
- 新增 `OverlayDismissLayer` 单测，并在 `KnowledgeBasePage` 中补充删除确认框与右侧抽屉的交互回归测试

## 变更原因

本次改动对应的任务背景，是希望所有中央弹框和右侧栏弹框都具备一致的空白区关闭体验。

此前项目内的弹层实现存在两类问题：

- 不同弹框的关闭语义不一致，部分只能点右上角或按钮关闭
- 右侧抽屉与中央弹框缺少统一抽象，容易在后续迭代中继续分叉

这次改动的目标是用最小干预方式统一交互，降低 UI 熵增，同时避免在提交、删除等关键动作执行中因误点 backdrop 导致状态丢失。

## 重要实现细节

- 采用了轻量共享容器的方式复用关闭逻辑，而不是对每个弹框分别补丁式修改
- 共享容器统一负责：
  - 渲染遮罩层
  - 处理 backdrop click close
  - 在内容区调用 `stopPropagation()`，避免内部点击误触关闭
  - 在 `busy` 状态下禁止 backdrop 自动关闭
- 本次没有引入新的第三方依赖，也没有改动现有业务数据流
- 主聊天页的常驻右侧栏不在本次范围内，本次仅处理“弹层式”右侧抽屉
- 测试覆盖重点放在：
  - backdrop 点击会关闭
  - 内容区点击不会关闭
  - busy 状态不会被 backdrop 误关闭

## 验证情况

已补充并通过与本次改动直接相关的单元测试，覆盖共享弹层容器与知识库页面中的关键交互路径。

This PR was written using [Vibe Kanban](https://vibekanban.com)
