### PR TITLE
优化 Knowledge Base Retrieved Chunks 卡片与详情模态框体验 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useId, useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  FileText,
+  Grip,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { RetrievedChunkViewModel } from "./retrieved-chunk-presenter";
+
+interface RetrievedChunkCardProps {
+  chunk: RetrievedChunkViewModel;
+  onOpen: () => void;
+}
+
+function formatScore(score: number): string {
+  return score.toFixed(2);
+}
+
+export function RetrievedChunkCard({
+  chunk,
+  onOpen,
+}: RetrievedChunkCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const childSectionId = useId();
+  const hasChildren = chunk.variant === "hierarchical" && chunk.childHitCount > 0;
+
+  const handleOpen = () => {
+    onOpen();
+  };
+
+  return (
+    <article
+      role="button"
+      tabIndex={0}
+      onClick={handleOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          handleOpen();
+        }
+      }}
+      className={cn(
+        "rounded-2xl border border-border bg-card text-left shadow-sm transition",
+        "hover:border-border-muted hover:bg-card/95",
+      )}
+    >
+      <div className="flex items-start justify-between gap-4 px-4 pt-4">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+          <Grip className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate text-zinc-600 dark:text-zinc-400">{chunk.title}</span>
+          <span className="shrink-0 text-zinc-400 dark:text-zinc-500">·</span>
+          <span className="shrink-0 text-zinc-600 dark:text-zinc-400">{chunk.characterCount} characters</span>
+        </div>
+        <span className="shrink-0 rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white">
+          SCORE {formatScore(chunk.score)}
+        </span>
+      </div>
+
+      <div className="px-4 pb-3 pt-2">
+        <p className="line-clamp-2 whitespace-pre-wrap text-[15px] font-medium text-foreground">
+          {chunk.preview}
+        </p>
+      </div>
+
+      {hasChildren && (
+        <div className="px-4 pb-4">
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            aria-controls={childSectionId}
+            onClick={(event) => {
+              event.stopPropagation();
+              setIsExpanded((prev) => !prev);
+            }}
+            className="flex items-center gap-2 text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-300"
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+            <span>HIT {chunk.childHitCount} CHILD CHUNKS</span>
+          </button>
+
+          {isExpanded && chunk.childChunks.length > 0 && (
+            <div id={childSectionId} className="mt-3 flex flex-col gap-2">
+              {chunk.childChunks.map((childChunk) => (
+                <div
+                  key={childChunk.id}
+                  className="flex flex-wrap items-center gap-2 text-sm text-foreground"
+                >
+                  <span className="rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white">
+                    {childChunk.label}
+                  </span>
+                  <span className="rounded bg-blue-600/85 px-2 py-1 text-[11px] font-semibold text-white">
+                    SCORE {formatScore(childChunk.score)}
+                  </span>
+                  <span className="line-clamp-1 min-w-0 flex-1 rounded bg-blue-500/20 px-2 py-1 text-sm text-foreground">
+                    {childChunk.content}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-4 border-t border-border px-4 py-3 text-sm">
+        <div className="flex min-w-0 items-center gap-2 text-zinc-700 dark:text-zinc-200">
+          <FileText className="h-4 w-4 shrink-0 text-red-500" />
+          <span className="truncate" title={chunk.sourceTitle}>
+            {chunk.sourceLabel}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            handleOpen();
+          }}
+          className="inline-flex items-center gap-1 text-sm font-medium uppercase tracking-wide text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        >
+          <span>Open</span>
+          <ExternalLink className="h-4 w-4" />
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkDetailDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkDetailDialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useId } from "react";
+import { FileText, Grip, X } from "lucide-react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import type { RetrievedChunkViewModel } from "./retrieved-chunk-presenter";
+
+interface RetrievedChunkDetailDialogProps {
+  chunk: RetrievedChunkViewModel | null;
+  onClose: () => void;
+}
+
+function formatScore(score: number): string {
+  return score.toFixed(2);
+}
+
+export function RetrievedChunkDetailDialog({
+  chunk,
+  onClose,
+}: RetrievedChunkDetailDialogProps) {
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!chunk) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [chunk, onClose]);
+
+  if (!chunk) return null;
+
+  const isHierarchical = chunk.variant === "hierarchical";
+
+  return (
+    <OverlayDismissLayer
+      open={chunk !== null}
+      onClose={onClose}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="flex h-[82vh] w-full max-w-6xl flex-col overflow-hidden rounded-[28px] border border-border bg-card shadow-2xl"
+      backdropTestId="retrieved-chunk-dialog-backdrop"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": titleId,
+      }}
+    >
+      <div className="flex items-start justify-between gap-4 px-5 py-5">
+        <h2 id={titleId} className="text-3xl font-semibold text-foreground">
+          Chunk Detail
+        </h2>
+        <button
+          type="button"
+          aria-label="Close chunk detail"
+          onClick={onClose}
+          className="rounded-full border border-border p-2 text-zinc-400 hover:text-foreground"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 px-5 pb-5">
+        <div className={`grid h-full min-h-0 gap-5 ${isHierarchical ? "lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]" : "grid-cols-1"}`}>
+          <section className="min-h-0 rounded-3xl bg-card px-1">
+            <div className="mb-4 flex flex-wrap items-center gap-3 text-sm font-medium text-zinc-400">
+              <span className="inline-flex items-center gap-2">
+                <Grip className="h-3.5 w-3.5" />
+                {chunk.title}
+              </span>
+              <span className="inline-flex items-center gap-2">
+                <FileText className="h-4 w-4 text-red-500" />
+                <span title={chunk.sourceTitle}>{chunk.sourceLabel}</span>
+              </span>
+            </div>
+            <div className="mb-4 flex items-center justify-between gap-4">
+              <div className="text-sm text-zinc-500 dark:text-zinc-400">
+                {chunk.characterCount} characters
+              </div>
+              <span className="rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white">
+                SCORE {formatScore(chunk.score)}
+              </span>
+            </div>
+            <div className="h-[calc(100%-4.5rem)] overflow-y-auto pr-2">
+              <p className="whitespace-pre-wrap text-[16px] leading-9 text-foreground">
+                {chunk.fullContent}
+              </p>
+            </div>
+          </section>
+
+          {isHierarchical && (
+            <aside className="flex min-h-0 flex-col rounded-3xl border border-border bg-background/30 p-4">
+              <div className="mb-4 text-xl font-semibold text-foreground">
+                HIT {chunk.childHitCount} CHILD CHUNKS
+              </div>
+              <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+                {chunk.childChunks.map((childChunk) => (
+                  <div key={childChunk.id} className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white">
+                        {childChunk.label}
+                      </span>
+                      <span className="rounded bg-blue-600/85 px-2 py-1 text-[11px] font-semibold text-white">
+                        SCORE {formatScore(childChunk.score)}
+                      </span>
+                    </div>
+                    <p className="whitespace-pre-wrap break-words rounded bg-blue-500/20 px-3 py-2 text-sm text-foreground">
+                      {childChunk.content}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </aside>
+          )}
+        </div>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/base/_components/retrieved-chunk-presenter.ts
+++ b/apps/negentropy-ui/app/knowledge/base/_components/retrieved-chunk-presenter.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import type { KnowledgeMatch } from "@/features/knowledge";
+
+export interface RetrievedChildChunkViewModel {
+  id: string;
+  label: string;
+  content: string;
+  score: number;
+}
+
+export interface RetrievedChunkViewModel {
+  id: string;
+  variant: "hierarchical" | "standard";
+  title: string;
+  characterCount: number;
+  preview: string;
+  fullContent: string;
+  sourceLabel: string;
+  sourceTitle: string;
+  score: number;
+  childHitCount: number;
+  childChunks: RetrievedChildChunkViewModel[];
+  raw: KnowledgeMatch;
+}
+
+interface RetrievedChunkMetadata extends Record<string, unknown> {
+  returned_parent_chunk?: boolean;
+  parent_chunk_index?: number;
+  chunk_index?: number;
+  original_filename?: string;
+  matched_child_chunk_indices?: unknown[];
+  matched_child_chunks?: Array<{
+    id?: string;
+    child_chunk_index?: number | null;
+    content?: string;
+    combined_score?: number;
+  }>;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function toRetrievedChunkMetadata(
+  metadata: KnowledgeMatch["metadata"],
+): RetrievedChunkMetadata {
+  return (metadata || {}) as RetrievedChunkMetadata;
+}
+
+function formatChunkNumber(value: number | null | undefined): string {
+  if (!isFiniteNumber(value)) {
+    return "?";
+  }
+  return String(value).padStart(2, "0");
+}
+
+function basenameFromUri(sourceUri?: string): string | null {
+  if (!sourceUri) return null;
+  const normalized = sourceUri.split("?")[0]?.split("#")[0] || sourceUri;
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.at(-1) || sourceUri;
+}
+
+function resolveSourceLabel(match: KnowledgeMatch, metadata: RetrievedChunkMetadata) {
+  const explicit = typeof metadata.original_filename === "string"
+    ? metadata.original_filename.trim()
+    : "";
+  if (explicit) {
+    return {
+      label: explicit,
+      title: explicit,
+    };
+  }
+
+  const fallback = basenameFromUri(match.source_uri);
+  if (fallback) {
+    return {
+      label: fallback,
+      title: match.source_uri || fallback,
+    };
+  }
+
+  return {
+    label: match.source_uri || "-",
+    title: match.source_uri || "-",
+  };
+}
+
+export function buildRetrievedChunkViewModel(
+  match: KnowledgeMatch,
+): RetrievedChunkViewModel {
+  const metadata = toRetrievedChunkMetadata(match.metadata);
+  const variant = metadata.returned_parent_chunk ? "hierarchical" : "standard";
+  const indexValue =
+    variant === "hierarchical"
+      ? metadata.parent_chunk_index
+      : metadata.chunk_index;
+  const source = resolveSourceLabel(match, metadata);
+  const childChunks = Array.isArray(metadata.matched_child_chunks)
+    ? metadata.matched_child_chunks
+        .map((item, index) => ({
+          id: item.id || `${match.id}-child-${index}`,
+          label: `C-${formatChunkNumber(item.child_chunk_index ?? undefined)}`,
+          content: item.content || "",
+          score: isFiniteNumber(item.combined_score) ? item.combined_score : 0,
+        }))
+        .filter((item) => item.content.trim().length > 0)
+    : [];
+  const childHitCount = childChunks.length > 0
+    ? childChunks.length
+    : Array.isArray(metadata.matched_child_chunk_indices)
+      ? metadata.matched_child_chunk_indices.length
+      : 0;
+
+  return {
+    id: String(match.id),
+    variant,
+    title:
+      variant === "hierarchical"
+        ? `Parent-Chunk-${formatChunkNumber(indexValue)}`
+        : `Chunk-${formatChunkNumber(indexValue)}`,
+    characterCount: match.content.length,
+    preview: match.content,
+    fullContent: match.content,
+    sourceLabel: source.label,
+    sourceTitle: source.title,
+    score: match.combined_score ?? 0,
+    childHitCount,
+    childChunks,
+    raw: match,
+  };
+}

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -39,7 +39,10 @@ import { AddSourceDialog } from "./_components/AddSourceDialog";
 import { CorpusFormDialog } from "./_components/CorpusFormDialog";
 import { DeleteCorpusDialog } from "./_components/DeleteCorpusDialog";
 import { DeleteSourceDialog } from "./_components/DeleteSourceDialog";
+import { RetrievedChunkCard } from "./_components/RetrievedChunkCard";
+import { RetrievedChunkDetailDialog } from "./_components/RetrievedChunkDetailDialog";
 import { ReplaceDocumentDialog } from "./_components/ReplaceDocumentDialog";
+import { buildRetrievedChunkViewModel } from "./_components/retrieved-chunk-presenter";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -65,12 +68,12 @@ function ChunkDetailDrawer({
   chunk,
   onClose,
 }: {
-  chunk: KnowledgeMatch | DocumentChunkItem | null;
+  chunk: DocumentChunkItem | null;
   onClose: () => void;
 }) {
   if (!chunk) return null;
-  const metadata = "metadata" in chunk ? chunk.metadata : {};
-  const content = "content" in chunk ? chunk.content : "";
+  const metadata = chunk.metadata;
+  const content = chunk.content;
   return (
     <OverlayDismissLayer
       open={chunk !== null}
@@ -339,7 +342,8 @@ export default function KnowledgeBasePage() {
   const [documentChunks, setDocumentChunks] = useState<DocumentChunkItem[]>([]);
   const [chunksLoading, setChunksLoading] = useState(false);
 
-  const [selectedChunk, setSelectedChunk] = useState<KnowledgeMatch | DocumentChunkItem | null>(null);
+  const [selectedRetrievedChunk, setSelectedRetrievedChunk] = useState<KnowledgeMatch | null>(null);
+  const [selectedDocumentChunk, setSelectedDocumentChunk] = useState<DocumentChunkItem | null>(null);
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<"create" | "edit">("create");
@@ -362,6 +366,17 @@ export default function KnowledgeBasePage() {
     [corpora, selectedCorpusId],
   );
   const corpusChunkingConfig = selectedCorpus?.config as ChunkingConfig | undefined;
+  const retrievedChunkCards = useMemo(
+    () => retrievalResults.map((item) => buildRetrievedChunkViewModel(item)),
+    [retrievalResults],
+  );
+  const selectedRetrievedChunkCard = useMemo(
+    () =>
+      selectedRetrievedChunk
+        ? buildRetrievedChunkViewModel(selectedRetrievedChunk)
+        : null,
+    [selectedRetrievedChunk],
+  );
 
   const syncQueryState = useCallback(
     (next: Partial<Record<"view" | "corpusId" | "tab" | "documentId", string | null>>) => {
@@ -797,27 +812,16 @@ export default function KnowledgeBasePage() {
           <div className="space-y-4 pb-28">
             {retrievalDocked && retrievalResults.length > 0 && (
               <div className="rounded-2xl border border-border bg-card p-4 shadow-sm">
-                <div className="mb-2 text-sm font-semibold">Retrieved Chunks</div>
+                <div className="mb-3 text-3xl font-semibold text-foreground">
+                  {retrievedChunkCards.length} Retrieved Chunks
+                </div>
                 <div className="space-y-2">
-                  {retrievalResults.map((item) => (
-                    <button
-                      type="button"
-                      key={`${item.id}-${item.metadata?.corpus_id || "na"}`}
-                      onClick={() => setSelectedChunk(item)}
-                      className="block w-full rounded-lg border border-border bg-background p-3 text-left hover:bg-muted/40"
-                    >
-                      <p className="line-clamp-3 text-xs text-foreground">{item.content}</p>
-                      <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-muted">
-                        <span>score: {(item.combined_score || 0).toFixed(4)}</span>
-                        <span>corpus: {String(item.metadata?.corpus_id || "-")}</span>
-                        <span>source: {item.source_uri || "-"}</span>
-                        {item.metadata?.returned_parent_chunk && (
-                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-700">
-                            父块返回 · 子块命中
-                          </span>
-                        )}
-                      </div>
-                    </button>
+                  {retrievedChunkCards.map((item) => (
+                    <RetrievedChunkCard
+                      key={`${item.id}-${item.raw.metadata?.corpus_id || "na"}`}
+                      chunk={item}
+                      onOpen={() => setSelectedRetrievedChunk(item.raw)}
+                    />
                   ))}
                 </div>
               </div>
@@ -973,7 +977,7 @@ export default function KnowledgeBasePage() {
                         <button
                           type="button"
                           key={chunk.id}
-                          onClick={() => setSelectedChunk(chunk)}
+                          onClick={() => setSelectedDocumentChunk(chunk)}
                           className="block w-full rounded-lg border border-border bg-background p-3 text-left hover:bg-muted/40"
                         >
                           <p className="line-clamp-3 text-xs">{chunk.content}</p>
@@ -1002,7 +1006,15 @@ export default function KnowledgeBasePage() {
         )}
       </div>
 
-      <ChunkDetailDrawer chunk={selectedChunk} onClose={() => setSelectedChunk(null)} />
+      <ChunkDetailDrawer
+        chunk={selectedDocumentChunk}
+        onClose={() => setSelectedDocumentChunk(null)}
+      />
+
+      <RetrievedChunkDetailDialog
+        chunk={selectedRetrievedChunkCard}
+        onClose={() => setSelectedRetrievedChunk(null)}
+      />
 
       <DocumentViewDialog
         isOpen={viewingDoc !== null}

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -133,7 +133,11 @@ describe("KnowledgeBasePage", () => {
           content: "retrieved chunk content",
           source_uri: "https://example.com/doc",
           combined_score: 0.91,
-          metadata: { corpus_id: "11111111-1111-1111-1111-111111111111" },
+          metadata: {
+            corpus_id: "11111111-1111-1111-1111-111111111111",
+            chunk_index: 47,
+            original_filename: "2512.13564v1.pdf",
+          },
         },
       ],
     });
@@ -472,7 +476,10 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
-    expect(screen.getByText("Retrieved Chunks")).toBeInTheDocument();
+    expect(screen.getByText("1 Retrieved Chunks")).toBeInTheDocument();
+    expect(screen.getByText("Chunk-47")).toBeInTheDocument();
+    expect(screen.getByText("2512.13564v1.pdf")).toBeInTheDocument();
+    expect(screen.getByText("SCORE 0.91")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Corpus" })).toBeInTheDocument();
 
@@ -522,7 +529,7 @@ describe("KnowledgeBasePage", () => {
     expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
   });
 
-  it("点击右侧抽屉空白处会关闭 Chunk Detail", async () => {
+  it("点击检索结果会打开居中 Chunk Detail 模态框，并可通过遮罩关闭", async () => {
     const user = userEvent.setup();
     searchParamsState.value = "view=overview";
 
@@ -540,11 +547,112 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
-    await user.click(screen.getByText("retrieved chunk content"));
+    await user.click(screen.getByText("Open"));
     expect(screen.getByText("Chunk Detail")).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog", { name: "Chunk Detail" });
+    expect(within(dialog).getByText("Chunk-47")).toBeInTheDocument();
+    expect(within(dialog).getByText("2512.13564v1.pdf")).toBeInTheDocument();
+    expect(within(dialog).getByText("23 characters")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("retrieved-chunk-dialog-backdrop"));
+    expect(screen.queryByText("Chunk Detail")).not.toBeInTheDocument();
+  });
+
+  it("hierarchical 检索结果会显示 child chunks 并在模态框中展示详情", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+    searchAcrossCorporaMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: "chunk-parent-1",
+          content: "parent chunk content with enough text to preview",
+          source_uri: "https://example.com/hierarchical",
+          combined_score: 0.43,
+          metadata: {
+            corpus_id: "11111111-1111-1111-1111-111111111111",
+            original_filename: "Understanding and Using Context.pdf",
+            returned_parent_chunk: true,
+            parent_chunk_index: 6,
+            matched_child_chunk_indices: [13, 8],
+            matched_child_chunks: [
+              {
+                id: "child-13",
+                child_chunk_index: 13,
+                content: "Context is any information that can be used to characterize the",
+                combined_score: 0.43,
+              },
+              {
+                id: "child-8",
+                child_chunk_index: 8,
+                content: "specific. Context is all about the whole situation relevant and its",
+                combined_score: 0.4,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getByText("Parent-Chunk-06")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "HIT 2 CHILD CHUNKS" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "HIT 2 CHILD CHUNKS" }));
+    expect(screen.getByText("C-13")).toBeInTheDocument();
+    expect(screen.getByText("C-08")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Open"));
+
+    const dialog = screen.getByRole("dialog", { name: "Chunk Detail" });
+    expect(within(dialog).getByText("Understanding and Using Context.pdf")).toBeInTheDocument();
+    expect(within(dialog).getByText("HIT 2 CHILD CHUNKS")).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("Context is any information that can be used to characterize the"),
+    ).toBeInTheDocument();
+  });
+
+  it("document-chunks 视图仍使用右侧抽屉展示详情", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=document-chunks&documentId=doc-1";
+    fetchDocumentChunksMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: "doc-chunk-1",
+          content: "document chunk content",
+          source_uri: "doc://alpha",
+          chunk_index: 2,
+          metadata: { chunk_role: "leaf" },
+        },
+      ],
+    });
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByText("document chunk content"));
+
+    expect(screen.getByText("Chunk Detail")).toBeInTheDocument();
+    expect(screen.getByText("Metadata")).toBeInTheDocument();
 
     await user.click(screen.getByTestId("chunk-drawer-backdrop"));
-    expect(screen.queryByText("Chunk Detail")).not.toBeInTheDocument();
+    expect(screen.queryByText("Metadata")).not.toBeInTheDocument();
   });
 
   it("未选中任何 Corpus 时禁用 Retrieve，并且不会发起检索", async () => {
@@ -563,7 +671,7 @@ describe("KnowledgeBasePage", () => {
     expect(retrieveButton).toBeDisabled();
     expect(screen.getByText("请至少选择一个 Corpus 后再执行 Retrieve")).toBeInTheDocument();
     expect(searchAcrossCorporaMock).not.toHaveBeenCalled();
-    expect(screen.queryByText("Retrieved Chunks")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Retrieved Chunks$/)).not.toBeInTheDocument();
   });
 
   it("仅将选中的 Corpus 传给检索接口，并使用全宽停靠容器", async () => {

--- a/apps/negentropy/src/negentropy/knowledge/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/repository.py
@@ -876,6 +876,40 @@ class KnowledgeRepository:
                 reason=str(exc),
             ) from exc
 
+    async def get_search_match_metadata(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        match_ids: Iterable[UUID],
+    ) -> dict[UUID, dict[str, Any]]:
+        id_list = [item for item in match_ids]
+        if not id_list:
+            return {}
+
+        try:
+            async with self._get_session_factory()() as db:
+                stmt = select(Knowledge.id, Knowledge.chunk_index).where(
+                    Knowledge.corpus_id == corpus_id,
+                    Knowledge.app_name == app_name,
+                    Knowledge.id.in_(id_list),
+                )
+                result = await db.execute(stmt)
+                rows = result.all()
+
+            return {
+                row.id: {
+                    "chunk_index": row.chunk_index,
+                }
+                for row in rows
+            }
+        except Exception as exc:
+            raise SearchError(
+                corpus_id=str(corpus_id),
+                search_mode="search_match_metadata_lookup",
+                reason=str(exc),
+            ) from exc
+
     @staticmethod
     def _to_corpus_record(corpus: Corpus) -> CorpusRecord:
         return CorpusRecord(

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -1709,6 +1709,11 @@ class KnowledgeService:
                     limit=config.limit,
                     metadata_filter=config.metadata_filter,
                 )
+                keyword_matches = await self._hydrate_match_metadata(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    matches=keyword_matches,
+                )
                 logger.info(
                     "search_completed",
                     corpus_id=str(corpus_id),
@@ -1730,6 +1735,11 @@ class KnowledgeService:
                 query_embedding=query_embedding,
                 limit=config.limit,
                 k=config.rrf_k,
+            )
+            results = await self._hydrate_match_metadata(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                matches=results,
             )
 
             # L1 精排
@@ -1766,6 +1776,11 @@ class KnowledgeService:
                 limit=config.limit,
                 metadata_filter=config.metadata_filter,
             )
+            semantic_matches = await self._hydrate_match_metadata(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                matches=semantic_matches,
+            )
             logger.debug(
                 "semantic_search_completed",
                 corpus_id=str(corpus_id),
@@ -1779,6 +1794,11 @@ class KnowledgeService:
                 query=query,
                 limit=config.limit,
                 metadata_filter=config.metadata_filter,
+            )
+            keyword_matches = await self._hydrate_match_metadata(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                matches=keyword_matches,
             )
             logger.debug(
                 "keyword_search_completed",
@@ -2064,6 +2084,21 @@ class KnowledgeService:
                 for item in child_matches
                 if item.metadata.get("child_chunk_index") is not None
             ]
+            matched_child_chunks = [
+                {
+                    "id": str(item.id),
+                    "child_chunk_index": item.metadata.get("child_chunk_index"),
+                    "content": item.content,
+                    "semantic_score": item.semantic_score,
+                    "keyword_score": item.keyword_score,
+                    "combined_score": item.combined_score,
+                }
+                for item in sorted(
+                    child_matches,
+                    key=lambda item: item.combined_score,
+                    reverse=True,
+                )
+            ]
             lifted.append(
                 KnowledgeMatch(
                     id=parent.id,
@@ -2072,6 +2107,7 @@ class KnowledgeService:
                     metadata={
                         **parent.metadata,
                         "matched_child_chunk_indices": matched_child_indices,
+                        "matched_child_chunks": matched_child_chunks,
                         "returned_parent_chunk": True,
                     },
                     semantic_score=best_child.semantic_score,
@@ -2092,6 +2128,49 @@ class KnowledgeService:
             if len(deduped) >= limit:
                 break
         return deduped
+
+    async def _hydrate_match_metadata(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        matches: Iterable[KnowledgeMatch],
+    ) -> list[KnowledgeMatch]:
+        match_list = list(matches)
+        if not match_list:
+            return []
+
+        metadata_by_id = await self._repository.get_search_match_metadata(
+            corpus_id=corpus_id,
+            app_name=app_name,
+            match_ids=[item.id for item in match_list],
+        )
+        if not metadata_by_id:
+            return match_list
+
+        hydrated: list[KnowledgeMatch] = []
+        for item in match_list:
+            extra_metadata = metadata_by_id.get(item.id)
+            if not extra_metadata:
+                hydrated.append(item)
+                continue
+
+            hydrated.append(
+                KnowledgeMatch(
+                    id=item.id,
+                    content=item.content,
+                    source_uri=item.source_uri,
+                    metadata={
+                        **item.metadata,
+                        **extra_metadata,
+                    },
+                    semantic_score=item.semantic_score,
+                    keyword_score=item.keyword_score,
+                    combined_score=item.combined_score,
+                )
+            )
+
+        return hydrated
 
     def _merge_matches(
         self,

--- a/apps/negentropy/tests/integration_tests/knowledge/test_knowledge_service.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_knowledge_service.py
@@ -34,6 +34,8 @@ class FakeRepository:
         self.deleted_sources: list[Dict[str, Any]] = []
         self.semantic_results: list[KnowledgeMatch] = []
         self.keyword_results: list[KnowledgeMatch] = []
+        self.parent_results: list[KnowledgeMatch] = []
+        self.chunk_indices: dict[UUID, int] = {}
 
     async def add_knowledge(
         self,
@@ -83,6 +85,29 @@ class FakeRepository:
         metadata_filter: Optional[Dict[str, Any]] = None,
     ) -> list[KnowledgeMatch]:
         return self.keyword_results[:limit]
+
+    async def get_search_match_metadata(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        match_ids: Iterable[UUID],
+    ) -> dict[UUID, dict[str, Any]]:
+        return {
+            item: {"chunk_index": self.chunk_indices[item]}
+            for item in match_ids
+            if item in self.chunk_indices
+        }
+
+    async def get_hierarchical_parent_matches(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        source_uri: Optional[str],
+        family_ids: Iterable[str],
+    ) -> list[KnowledgeMatch]:
+        return list(self.parent_results)
 
 
 async def _embedding_fn(text: str) -> list[float]:
@@ -145,6 +170,10 @@ async def test_ingest_search_replace_source_flow():
             combined_score=0.0,
         ),
     ]
+    repo.chunk_indices = {
+        first_id: 7,
+        second_id: 11,
+    }
 
     matches = await service.search(
         corpus_id=corpus_id,
@@ -156,6 +185,9 @@ async def test_ingest_search_replace_source_flow():
     assert {m.id for m in matches} == {first_id, second_id}
     combined = {m.id: m.combined_score for m in matches}
     assert combined[first_id] > combined[second_id]
+    metadata = {m.id: m.metadata for m in matches}
+    assert metadata[first_id]["chunk_index"] == 7
+    assert metadata[second_id]["chunk_index"] == 11
 
     replaced = await service.replace_source(
         corpus_id=corpus_id,
@@ -167,3 +199,93 @@ async def test_ingest_search_replace_source_flow():
     assert replaced
     assert repo.deleted_sources
     assert repo.deleted_sources[-1]["source_uri"] == "doc://alpha"
+
+
+async def test_search_lifts_hierarchical_matches_with_child_details():
+    repo = FakeRepository()
+    service = KnowledgeService(repository=repo, embedding_fn=_embedding_fn)
+
+    corpus_id = uuid4()
+    app_name = "negentropy"
+    parent_id = uuid4()
+    first_child_id = uuid4()
+    second_child_id = uuid4()
+
+    repo.parent_results = [
+        KnowledgeMatch(
+            id=parent_id,
+            content="parent chunk content",
+            source_uri="doc://hierarchical",
+            metadata={
+                "chunk_role": "parent",
+                "chunk_family_id": "family-1",
+                "parent_chunk_index": 6,
+            },
+            semantic_score=0.0,
+            keyword_score=0.0,
+            combined_score=0.0,
+        )
+    ]
+    repo.chunk_indices = {
+        first_child_id: 13,
+        second_child_id: 8,
+    }
+    repo.keyword_results = [
+        KnowledgeMatch(
+            id=first_child_id,
+            content="first child snippet",
+            source_uri="doc://hierarchical",
+            metadata={
+                "chunk_role": "child",
+                "chunk_family_id": "family-1",
+                "child_chunk_index": 13,
+            },
+            semantic_score=0.0,
+            keyword_score=0.43,
+            combined_score=0.43,
+        ),
+        KnowledgeMatch(
+            id=second_child_id,
+            content="second child snippet",
+            source_uri="doc://hierarchical",
+            metadata={
+                "chunk_role": "child",
+                "chunk_family_id": "family-1",
+                "child_chunk_index": 8,
+            },
+            semantic_score=0.0,
+            keyword_score=0.40,
+            combined_score=0.40,
+        ),
+    ]
+
+    matches = await service.search(
+        corpus_id=corpus_id,
+        app_name=app_name,
+        query="context",
+        config=SearchConfig(mode="keyword", limit=10),
+    )
+
+    assert len(matches) == 1
+    parent_match = matches[0]
+    assert parent_match.id == parent_id
+    assert parent_match.metadata["returned_parent_chunk"] is True
+    assert parent_match.metadata["matched_child_chunk_indices"] == [13, 8]
+    assert parent_match.metadata["matched_child_chunks"] == [
+        {
+            "id": str(first_child_id),
+            "child_chunk_index": 13,
+            "content": "first child snippet",
+            "semantic_score": 0.0,
+            "keyword_score": 0.43,
+            "combined_score": 0.43,
+        },
+        {
+            "id": str(second_child_id),
+            "child_chunk_index": 8,
+            "content": "second child snippet",
+            "semantic_score": 0.0,
+            "keyword_score": 0.4,
+            "combined_score": 0.4,
+        },
+    ]


### PR DESCRIPTION
## 变更概述

本 PR 优化了 `Knowledge Base` 页面中 `Retrieved Chunks` 的展示与详情查看体验，目标是将检索结果从原先的信息密度较低的简单列表，升级为更适合扫描、比较和深入查看的卡片化结构，并对齐任务图例中的 hierarchical / non-hierarchical 两类展示形态。

## 做了哪些改动

### 前端展示层

- 为 `Retrieved Chunks` 引入了独立的展示模型与专用组件：
  - `RetrievedChunkCard`
  - `RetrievedChunkDetailDialog`
  - `retrieved-chunk-presenter`
- 将检索结果拆分为两种视图变体：
  - 普通 chunk：展示 `Chunk-XX`、characters、摘要、文档源、score、Open
  - hierarchical parent chunk：展示 `Parent-Chunk-XX`、characters、摘要、命中的 child chunks 数量、可折叠 child chunk 详情、文档源、score、Open
- 将 retrieval 详情从原有的右侧抽屉中解耦，改为居中的详情模态框：
  - 普通 chunk 使用单栏详情
  - hierarchical chunk 使用 parent / child 双栏详情
- 保留 `document-chunks` 视图现有的右侧抽屉，不与 retrieval modal 共用状态，避免交互串扰
- 检索结果标题从静态文案调整为带数量的摘要形式，例如 `1 Retrieved Chunks`

### 后端检索数据增强

- 为检索命中补充 `chunk_index` 元数据，以支持普通 chunk 场景下稳定渲染 `Chunk-XX`
- 为 hierarchical 抬升后的 parent chunk 结果补充 `matched_child_chunks`，使前端能够展示命中的 child chunk 编号、摘要与分数
- 保留既有 `matched_child_chunk_indices` 与 `returned_parent_chunk`，确保兼容已有逻辑

### 测试覆盖

- 更新并扩展了前端单测，覆盖：
  - 普通 chunk 卡片展示
  - hierarchical child chunks disclosure
  - 居中 `Chunk Detail` 模态框
  - retrieval modal 与 `document-chunks` drawer 的职责隔离
- 增加后端集成测试，验证：
  - 检索结果元数据补水
  - hierarchical parent chunk 抬升时 child chunk 详情的返回

## 为什么要这样改

这次改动直接对应任务中的两个核心目标：

1. 让 `Retrieved Chunks` 卡片在信息层级上更清晰  
   用户需要在检索结果列表中快速判断：
   - 这是普通 chunk 还是 hierarchical parent chunk
   - 命中了哪些 child chunks
   - 当前 chunk 的来源、分数和大致内容

2. 让详情查看更聚焦、更符合阅读路径  
   原有简单列表 + 右侧抽屉的方式，不足以承载 hierarchical parent / child 的完整上下文关系。改为卡片化摘要 + 居中模态框后，既保留列表扫描效率，也能在需要时提供完整上下文。

## 重要实现细节

- 前端没有直接在页面内联堆叠判断逻辑，而是增加了 presenter 层，将 `KnowledgeMatch` 先归一化为稳定的展示模型，降低页面复杂度
- retrieval 详情状态与 `document-chunks` 状态拆分，避免一个 `selectedChunk` 同时控制两种不同详情容器
- 后端采用加性扩展方式返回新元数据，没有破坏已有字段语义，降低了回归风险
- child chunk 详情按 score 保序，便于前端与用户视线优先级保持一致

## 验证情况

已针对本次改动执行定向验证：

- 前端：`pnpm test -- KnowledgeBasePage.test.tsx`
- 后端：`uv run pytest tests/integration_tests/knowledge/test_knowledge_service.py`

相关测试通过后，再提交本次分支变更。

This PR was written using [Vibe Kanban](https://vibekanban.com)
