### PR TITLE
修复 Retrieved Chunks 卡片编号展示与搜索元数据兼容性 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/retrieved-chunk-presenter.ts
+++ b/apps/negentropy-ui/app/knowledge/base/_components/retrieved-chunk-presenter.ts
@@ -26,20 +26,29 @@ export interface RetrievedChunkViewModel {
 
 interface RetrievedChunkMetadata extends Record<string, unknown> {
   returned_parent_chunk?: boolean;
-  parent_chunk_index?: number;
-  chunk_index?: number;
+  parent_chunk_index?: number | string;
+  chunk_index?: number | string;
   original_filename?: string;
   matched_child_chunk_indices?: unknown[];
   matched_child_chunks?: Array<{
     id?: string;
-    child_chunk_index?: number | null;
+    child_chunk_index?: number | string | null;
     content?: string;
     combined_score?: number;
   }>;
 }
 
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
+function toChunkNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
 }
 
 function toRetrievedChunkMetadata(
@@ -49,10 +58,11 @@ function toRetrievedChunkMetadata(
 }
 
 function formatChunkNumber(value: number | null | undefined): string {
-  if (!isFiniteNumber(value)) {
+  const normalized = toChunkNumber(value);
+  if (normalized === null) {
     return "?";
   }
-  return String(value).padStart(2, "0");
+  return String(normalized).padStart(2, "0");
 }
 
 function basenameFromUri(sourceUri?: string): string | null {
@@ -103,7 +113,7 @@ export function buildRetrievedChunkViewModel(
           id: item.id || `${match.id}-child-${index}`,
           label: `C-${formatChunkNumber(item.child_chunk_index ?? undefined)}`,
           content: item.content || "",
-          score: isFiniteNumber(item.combined_score) ? item.combined_score : 0,
+          score: toChunkNumber(item.combined_score) ?? 0,
         }))
         .filter((item) => item.content.trim().length > 0)
     : [];

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -624,6 +624,101 @@ describe("KnowledgeBasePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("字符串形式的 chunk 编号也能正确展示", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+    searchAcrossCorporaMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: "chunk-string-1",
+          content: "string indexed chunk",
+          source_uri: "https://example.com/string",
+          combined_score: 0.56,
+          metadata: {
+            corpus_id: "11111111-1111-1111-1111-111111111111",
+            chunk_index: "47",
+            original_filename: "string-indexed.pdf",
+          },
+        },
+        {
+          id: "chunk-parent-string-1",
+          content: "hierarchical string indexed chunk",
+          source_uri: "https://example.com/hierarchical-string",
+          combined_score: 0.41,
+          metadata: {
+            corpus_id: "11111111-1111-1111-1111-111111111111",
+            original_filename: "hierarchical-string.pdf",
+            returned_parent_chunk: true,
+            parent_chunk_index: "6",
+            matched_child_chunks: [
+              {
+                id: "child-string-13",
+                child_chunk_index: "13",
+                content: "child chunk with string index",
+                combined_score: 0.41,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "string indices");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getByText("Chunk-47")).toBeInTheDocument();
+    expect(screen.getByText("Parent-Chunk-06")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "HIT 1 CHILD CHUNKS" }));
+    expect(screen.getByText("C-13")).toBeInTheDocument();
+  });
+
+  it("缺失 chunk 编号时会明确降级为问号", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+    searchAcrossCorporaMock.mockResolvedValueOnce({
+      items: [
+        {
+          id: "chunk-no-index-1",
+          content: "chunk without index",
+          source_uri: "https://example.com/no-index",
+          combined_score: 0.21,
+          metadata: {
+            corpus_id: "11111111-1111-1111-1111-111111111111",
+            original_filename: "missing-index.pdf",
+          },
+        },
+      ],
+    });
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "missing index");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getByText("Chunk-?")).toBeInTheDocument();
+  });
+
   it("document-chunks 视图仍使用右侧抽屉展示详情", async () => {
     const user = userEvent.setup();
     searchParamsState.value =

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException
 
 from negentropy.knowledge import api as knowledge_api
-from negentropy.knowledge.types import ChunkingStrategy, KnowledgeRecord
+from negentropy.knowledge.types import ChunkingStrategy, KnowledgeMatch, KnowledgeRecord
 
 
 class FakeStorageService:
@@ -42,6 +42,7 @@ class FakeKnowledgeService:
     def __init__(self):
         self.list_knowledge_calls = []
         self.pipeline_calls = []
+        self.search_calls = []
 
     async def list_knowledge(self, **kwargs):
         self.list_knowledge_calls.append(kwargs)
@@ -72,6 +73,32 @@ class FakeKnowledgeService:
 
     async def execute_rebuild_source_pipeline(self, **kwargs):
         _ = kwargs
+
+    async def search(self, **kwargs):
+        self.search_calls.append(kwargs)
+        return [
+            KnowledgeMatch(
+                id=uuid4(),
+                content="search chunk content",
+                source_uri="https://example.com/search",
+                metadata={
+                    "chunk_index": "47",
+                    "returned_parent_chunk": True,
+                    "parent_chunk_index": "6",
+                    "matched_child_chunks": [
+                        {
+                            "id": "child-13",
+                            "child_chunk_index": "13",
+                            "content": "child chunk content",
+                            "combined_score": 0.42,
+                        }
+                    ],
+                },
+                semantic_score=0.0,
+                keyword_score=0.42,
+                combined_score=0.42,
+            )
+        ]
 
 
 @pytest.mark.asyncio
@@ -334,3 +361,27 @@ async def test_rebuild_document_file_success(monkeypatch):
     assert result.status == "running"
     assert fake_service.pipeline_calls[-1]["operation"] == "rebuild_source"
     assert fake_service.pipeline_calls[-1]["input_data"]["source_uri"] == gcs_uri
+
+
+@pytest.mark.asyncio
+async def test_search_route_preserves_chunk_indices_in_metadata(monkeypatch):
+    corpus_id = uuid4()
+    fake_service = FakeKnowledgeService()
+
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+
+    result = await knowledge_api.search(
+        corpus_id=corpus_id,
+        payload=knowledge_api.SearchRequest(
+            app_name="negentropy",
+            query="context engineering",
+            mode="hybrid",
+            limit=10,
+        ),
+    )
+
+    assert result["count"] == 1
+    assert fake_service.search_calls[0]["query"] == "context engineering"
+    assert result["items"][0]["metadata"]["chunk_index"] == "47"
+    assert result["items"][0]["metadata"]["parent_chunk_index"] == "6"
+    assert result["items"][0]["metadata"]["matched_child_chunks"][0]["child_chunk_index"] == "13"


### PR DESCRIPTION
## 变更概述

本 PR 修复了 `Knowledge Base` 页面中 `Retrieved Chunks` 卡片编号展示异常的问题，重点解决普通 chunk、parent chunk 以及 child chunk 在真实搜索结果中退化为 `?` 的场景，并补齐对应的前端与 API 边界测试，提升编号展示链路的稳定性。

## 做了哪些改动

### 前端编号解析增强

- 更新 `retrieved-chunk-presenter` 中的编号归一化逻辑
- 让以下编号字段同时兼容 `number` 与 `string` 类型输入：
  - `chunk_index`
  - `parent_chunk_index`
  - `child_chunk_index`
- 修复以下展示退化问题：
  - `Chunk-47` 错误显示为 `Chunk-?`
  - `Parent-Chunk-06` 错误显示为 `Parent-Chunk-?`
  - `C-13` 错误显示为 `C-?`

### 降级行为明确化

- 当编号字段真实缺失或无法解析时，仍然明确显示 `?`
- 不使用前端列表顺序伪造 chunk 编号，避免制造错误事实源

### 测试补齐

- 补充前端单测，覆盖：
  - 字符串 `chunk_index` 正常渲染为 `Chunk-47`
  - 字符串 `parent_chunk_index` 正常渲染为 `Parent-Chunk-06`
  - 字符串 `child_chunk_index` 正常渲染为 `C-13`
  - 缺失编号时显式降级为 `?`
- 补充搜索 API 路由测试，验证搜索响应中的以下字段可以稳定透传到 HTTP payload：
  - `chunk_index`
  - `parent_chunk_index`
  - `matched_child_chunks[].child_chunk_index`

## 为什么要这样改

这次改动直接来源于 UI 验收时发现的问题：`Retrieved Chunks` 卡片中的 chunk 编号没有按预期展示，影响用户对搜索结果的定位与理解。

从实现链路上看，这不是单纯的样式问题，而是编号字段在真实数据流中的兼容性问题：

- 前端此前对编号字段的类型假设过于严格
- 一旦后端返回的是字符串形式编号，或响应边界存在轻微形态差异，UI 就会退化为 `?`

因此，本次修复采用“最小干预 + 韧性增强”的方式，在不伪造编号、不改变接口语义的前提下，提高展示稳定性，并通过测试锁定行为。

## 重要实现细节

- 编号解析统一通过归一化逻辑处理，而不是在多个渲染分支中重复判断
- 只接受可安全转换为有限数字的值，避免把无效字符串错误显示为编号
- 缺失编号时保留 `?` 的显式降级，避免把列表顺序误当成真实 chunk 编号
- API 路由测试补的是“服务层到 HTTP 响应”的边界空白，防止再次出现“服务里有值但页面看不到”的断裂

## 验证情况

本次改动补充并覆盖了以下关键场景：

- 普通 chunk 编号正常显示
- hierarchical parent chunk 编号正常显示
- child chunk 编号正常显示
- 缺失字段时降级行为明确
- 搜索 API 响应不会丢失编号相关元数据

This PR was written using [Vibe Kanban](https://vibekanban.com)
