### PR TITLE
feat(Chat): 落地 A2UI 消息树与递归事件渲染 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -12,13 +12,11 @@ import { BaseEvent, EventType, Message } from "@ag-ui/core";
 
 import { ChatStream } from "../components/ui/ChatStream";
 import { Composer } from "../components/ui/Composer";
-import { EventTimeline, TimelineItem } from "../components/ui/EventTimeline";
-import { SiteHeader } from "../components/layout/SiteHeader";
+import { EventTimeline } from "../components/ui/EventTimeline";
 import { useAuth } from "../components/providers/AuthProvider";
 import { LogBufferPanel } from "../components/ui/LogBufferPanel";
 import { SessionList } from "../components/ui/SessionList";
 import { StateSnapshot } from "../components/ui/StateSnapshot";
-import { ConfirmationToolCard } from "../components/ui/ConfirmationToolCard";
 import {
   AdkEventPayload,
   adkEventToAguiEvents,
@@ -26,33 +24,25 @@ import {
   adkEventsToSnapshot,
 } from "@/lib/adk";
 
-// 提取的 Hooks
-import { useSessionManager } from "@/hooks/useSessionManager";
-import { useEventProcessor } from "@/hooks/useEventProcessor";
-import { useUIState } from "@/hooks/useUIState";
-import {
-  useConfirmationTool,
-  type ConfirmationToolArgs,
-} from "@/hooks/useConfirmationTool";
+import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 
 // 提取的工具函数
 import { createSessionLabel, buildAgentUrl } from "@/utils/session";
 import {
   normalizeMessageContent,
-  buildChatMessagesFromEventsWithFallback,
-  ensureUniqueMessageIds,
 } from "@/utils/message";
 import { buildTimelineItems } from "@/utils/timeline";
 import { buildStateSnapshotFromEvents } from "@/utils/state";
+import {
+  buildConversationTree,
+  buildNodeTimestampIndex,
+} from "@/utils/conversation-tree";
 
 // 统一的类型定义
 import type {
   ConnectionState,
   SessionRecord,
   LogEntry,
-  AuthUser,
-  AuthStatus,
-  ChatMessage,
 } from "@/types/common";
 
 const AGENT_ID = "negentropy";
@@ -62,19 +52,15 @@ const EMPTY_MESSAGES: Message[] = [];
 export function HomeBody({
   sessionId,
   userId,
-  user,
   setSessionId,
   sessions,
   setSessions,
-  onLogout,
 }: {
   sessionId: string | null;
   userId: string;
-  user: AuthUser | null;
   setSessionId: (id: string | null) => void;
   sessions: SessionRecord[];
   setSessions: React.Dispatch<React.SetStateAction<SessionRecord[]>>;
-  onLogout: () => void;
 }) {
   const { agent } = useAgent({
     agentId: AGENT_ID,
@@ -101,9 +87,7 @@ export function HomeBody({
     unknown
   > | null>(null);
   const [loadedSessionId, setLoadedSessionId] = useState<string | null>(null);
-  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(
-    null,
-  );
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === sessionId) || null,
@@ -238,67 +222,44 @@ export function HomeBody({
     rawEvents.forEach((event) => {
       if (
         event.type === EventType.TOOL_CALL_START &&
+        "toolCallName" in event &&
         event.toolCallName === "ui.confirmation"
       ) {
-        pending.add(event.toolCallId);
+        pending.add(String(event.toolCallId));
       }
-      if (event.type === EventType.TOOL_CALL_RESULT) {
-        pending.delete(event.toolCallId);
+      if (event.type === EventType.TOOL_CALL_RESULT && "toolCallId" in event) {
+        pending.delete(String(event.toolCallId));
       }
     });
     return pending.size;
   }, [rawEvents]);
 
-  // Build message-timestamp map from raw events for filtering
-  const messageTimestamps = useMemo(() => {
-    const timestampMap = new Map<string, number>();
+  // 根据选中的节点时间范围过滤事件，右侧保持历史视图能力
+  const nodeTimestampIndex = useMemo(() => {
+    const merged = [...sessionMessages, ...optimisticMessages];
+    return buildNodeTimestampIndex(
+      buildConversationTree({
+        events: rawEvents,
+        fallbackMessages: merged,
+      }),
+    );
+  }, [optimisticMessages, rawEvents, sessionMessages]);
 
-    // Process all TEXT_MESSAGE events to build the map
-    rawEvents.forEach((event) => {
-      if (
-        event.type === EventType.TEXT_MESSAGE_START ||
-        event.type === EventType.TEXT_MESSAGE_CONTENT ||
-        event.type === EventType.TEXT_MESSAGE_END
-      ) {
-        const messageId = "messageId" in event ? event.messageId : undefined;
-        const timestamp = "timestamp" in event ? event.timestamp : undefined;
-
-        if (messageId && timestamp !== undefined) {
-          // Store the timestamp for this message
-          if (!timestampMap.has(messageId)) {
-            timestampMap.set(messageId, timestamp);
-          }
-        }
-      }
-    });
-
-    // Also backfill from sessionMessages for any messages without event timestamps
-    sessionMessages.forEach((message) => {
-      if (!timestampMap.has(message.id) && message.createdAt) {
-        timestampMap.set(message.id, message.createdAt.getTime() / 1000);
-      }
-    });
-
-    return timestampMap;
-  }, [rawEvents, sessionMessages]);
-
-  // Filter events based on selected message timestamp
   const filteredRawEvents = useMemo(() => {
-    if (!selectedMessageId) {
-      return rawEvents; // Show all events (current behavior)
+    if (!selectedNodeId) {
+      return rawEvents;
     }
 
-    const cutoffTimestamp = messageTimestamps.get(selectedMessageId);
+    const cutoffTimestamp = nodeTimestampIndex.get(selectedNodeId);
     if (cutoffTimestamp === undefined) {
-      return rawEvents; // Message not found, show all
+      return rawEvents;
     }
 
-    // Filter events to only those before/at the selected message's timestamp
     return rawEvents.filter((event) => {
       const eventTimestamp = event.timestamp || 0;
       return eventTimestamp <= cutoffTimestamp;
     });
-  }, [rawEvents, selectedMessageId, messageTimestamps]);
+  }, [nodeTimestampIndex, rawEvents, selectedNodeId]);
 
   const compactedEvents = useMemo(
     () => compactEvents(filteredRawEvents),
@@ -447,11 +408,7 @@ export function HomeBody({
       const payload = await response.json();
       if (!response.ok) {
         if (response.status === 404) {
-          addLog("warn", "session_not_found", { sessionId: id });
-          setSessions((prev) => prev.filter((session) => session.id !== id));
-          if (sessionId === id) {
-            setSessionId(null);
-          }
+          addLog("warn", "session_not_found", { context: "startNewSession" });
         }
         return;
       }
@@ -516,7 +473,6 @@ export function HomeBody({
     ],
   );
 
-  const resolvedThreadId = sessionId ?? "pending";
   const handleConfirmationFollowup = useCallback(
     async (payload: { action: string; note: string }) => {
       if (!agent || !sessionId || agent.isRunning) {
@@ -531,7 +487,6 @@ export function HomeBody({
         setConnectionWithMetrics("connecting");
         await agent.runAgent({
           runId: randomUUID(),
-          threadId: resolvedThreadId,
         });
         await loadSessions();
       } catch (error) {
@@ -540,7 +495,7 @@ export function HomeBody({
         console.warn("Failed to submit HITL response", error);
       }
     },
-    [agent, loadSessions, resolvedThreadId, sessionId],
+    [agent, addLog, loadSessions, sessionId, setConnectionWithMetrics],
   );
 
   useConfirmationTool(handleConfirmationFollowup);
@@ -548,14 +503,14 @@ export function HomeBody({
   // Escape key to return to live view
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && selectedMessageId) {
-        setSelectedMessageId(null);
+      if (e.key === "Escape" && selectedNodeId) {
+        setSelectedNodeId(null);
         setShowRightPanel(false);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedMessageId]);
+  }, [selectedNodeId]);
 
   const sendInput = async () => {
     if (!agent || !sessionId || !inputValue.trim()) {
@@ -566,13 +521,11 @@ export function HomeBody({
     }
 
     const messageId = crypto.randomUUID();
-    const timestamp = Date.now() / 1000;
-    const newMessage: Message = {
+    const newMessage = {
       id: messageId,
       role: "user",
       content: inputValue.trim(),
-      createdAt: new Date(timestamp * 1000),
-    };
+    } as Message;
     // 仅使用 optimisticMessages 进行乐观更新，不再向 rawEvents 添加乐观事件
     // 避免消息在 buildChatMessagesFromEventsWithFallback 中重复
     setOptimisticMessages((prev) => [...prev, newMessage]);
@@ -586,7 +539,7 @@ export function HomeBody({
       (!activeSession || activeSession.label === createSessionLabel(sessionId));
     try {
       setConnectionWithMetrics("connecting");
-      await agent.runAgent({ runId: randomUUID(), threadId: resolvedThreadId });
+      await agent.runAgent({ runId: randomUUID() });
       await loadSessions();
       if (shouldPollTitle) {
         scheduleTitleRefresh();
@@ -612,6 +565,7 @@ export function HomeBody({
       setSessionSnapshot(null);
       setRawEvents([]);
       setLoadedSessionId(null);
+      setSelectedNodeId(null);
     }
   }, []);
 
@@ -648,13 +602,11 @@ export function HomeBody({
   );
 
   const snapshotForDisplay = useMemo(() => {
-    // If no message selected, use current/live snapshot
-    if (!selectedMessageId) {
+    if (!selectedNodeId) {
       return snapshotForRender;
     }
-    // Otherwise use reconstructed historical snapshot
     return historicalSnapshot;
-  }, [selectedMessageId, snapshotForRender, historicalSnapshot]);
+  }, [selectedNodeId, snapshotForRender, historicalSnapshot]);
 
   const mergedMessagesForRender = useMemo(() => {
     const knownIds = new Set(
@@ -687,44 +639,39 @@ export function HomeBody({
       }
       const existing = merged[index];
       if (!existing.content && message.content) {
-        merged[index] = { ...existing, content: message.content };
+        merged[index] = {
+          ...existing,
+          content: normalizeMessageContent(message),
+        } as Message;
       }
     });
     return merged;
   }, [messagesForRenderBase, optimisticMessages]);
 
-  // 使用事件驱动构建聊天消息：
-  // - rawEvents 中按 messageId 拼接 delta（避免流式token逐词换行）
-  // - 从事件提取 runId（支持多轮次答复 \n\n 分隔）
-  // - mergedMessagesForRender 作为 fallback 补充非流窗口中的历史消息
-  const chatMessages = useMemo(
+  const conversationTree = useMemo(
     () =>
-      ensureUniqueMessageIds(
-        buildChatMessagesFromEventsWithFallback(
-          rawEvents,
-          mergedMessagesForRender,
-        ),
-      ),
-    [rawEvents, mergedMessagesForRender],
+      buildConversationTree({
+        events: rawEvents,
+        fallbackMessages: mergedMessagesForRender,
+      }),
+    [mergedMessagesForRender, rawEvents],
   );
 
   // Filter log entries based on selected message timestamp
   const filteredLogEntries = useMemo(() => {
-    if (!selectedMessageId) {
-      return logEntries; // Show all logs when no selection
+    if (!selectedNodeId) {
+      return logEntries;
     }
 
-    const cutoffTimestamp = messageTimestamps.get(selectedMessageId);
+    const cutoffTimestamp = nodeTimestampIndex.get(selectedNodeId);
     if (cutoffTimestamp === undefined) {
-      return logEntries; // Message not found, show all
+      return logEntries;
     }
 
-    // LogEntry.timestamp is in milliseconds (Date.now()), event timestamps are seconds
-    // Convert cutoff to milliseconds for comparison
     const cutoffMs = cutoffTimestamp * 1000;
 
     return logEntries.filter((entry) => entry.timestamp <= cutoffMs);
-  }, [logEntries, selectedMessageId, messageTimestamps]);
+  }, [logEntries, nodeTimestampIndex, selectedNodeId]);
 
   const contentWidthClass = "max-w-4xl";
 
@@ -801,19 +748,16 @@ export function HomeBody({
           {/* Chat Stream Area */}
           <div className="flex-1 overflow-hidden flex flex-col relative">
             <ChatStream
-              messages={chatMessages}
-              selectedMessageId={selectedMessageId}
-              onMessageSelect={(id) => {
-                // 右侧栏未打开时，点击消息不产生任何影响
+              nodes={conversationTree.roots}
+              selectedNodeId={selectedNodeId}
+              onNodeSelect={(id) => {
                 if (!showRightPanel) {
                   return;
                 }
-                if (selectedMessageId === id) {
-                  // Toggle off: just deselect
-                  setSelectedMessageId(null);
+                if (selectedNodeId === id) {
+                  setSelectedNodeId(null);
                 } else {
-                  // Select new message（右侧栏已处于打开状态）
-                  setSelectedMessageId(id);
+                  setSelectedNodeId(id);
                 }
               }}
               contentClassName={contentWidthClass}
@@ -846,7 +790,7 @@ export function HomeBody({
         >
           <div className="w-80 h-full overflow-y-auto p-6">
             {/* View mode indicator + minimal interaction hint */}
-            {selectedMessageId ? (
+            {selectedNodeId ? (
               <div className="mb-4 p-3 rounded-lg bg-amber-50 border border-amber-200 dark:border-amber-800 dark:bg-amber-950/50">
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-semibold text-amber-800 dark:text-amber-200">
@@ -854,7 +798,7 @@ export function HomeBody({
                   </span>
                   <button
                     onClick={() => {
-                      setSelectedMessageId(null);
+                      setSelectedNodeId(null);
                     }}
                     className="text-xs text-amber-600 hover:text-amber-800 underline dark:text-amber-400 dark:hover:text-amber-300"
                   >
@@ -873,14 +817,14 @@ export function HomeBody({
                   </span>
                 </div>
                 <p className="text-[10px] text-zinc-500 mt-1 dark:text-zinc-400">
-                  点击任意消息进入历史视图，再次点击或点"返回实时"回到实时
+                  点击任意消息进入历史视图，再次点击或点“返回实时”回到实时
                 </p>
               </div>
             )}
 
             <StateSnapshot
               snapshot={snapshotForDisplay}
-              connection={selectedMessageId ? "idle" : connection}
+              connection={selectedNodeId ? "idle" : connection}
             />
             <EventTimeline events={timelineItems} />
             <LogBufferPanel
@@ -972,11 +916,9 @@ export default function Home() {
       <HomeBody
         sessionId={sessionId}
         userId={user.userId}
-        user={user}
         setSessionId={setSessionId}
         sessions={sessions}
         setSessions={setSessions}
-        onLogout={logout}
       />
     </CopilotKitProvider>
   );

--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -1,74 +1,21 @@
 import { useEffect, useRef } from "react";
-import { MessageBubble } from "./MessageBubble";
-import type { ChatMessage } from "@/types/common";
-
-/**
- * 轮次分隔组件
- * 当 runId 变化时显示视觉分隔
- */
-function RunDivider() {
-  return (
-    <div className="flex items-center gap-2 my-4 opacity-40">
-      <div className="flex-1 h-px bg-border" />
-      <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
-        新一轮
-      </span>
-      <div className="flex-1 h-px bg-border" />
-    </div>
-  );
-}
+import { ConversationNodeRenderer } from "./conversation/ConversationNodeRenderer";
+import type { ConversationNode } from "@/types/a2ui";
 
 type ChatStreamProps = {
-  messages: ChatMessage[];
-  selectedMessageId?: string | null;
-  onMessageSelect?: (messageId: string) => void;
+  nodes: ConversationNode[];
+  selectedNodeId?: string | null;
+  onNodeSelect?: (nodeId: string) => void;
   contentClassName?: string;
 };
 
 export function ChatStream({
-  messages,
-  selectedMessageId,
-  onMessageSelect,
+  nodes,
+  selectedNodeId,
+  onNodeSelect,
   contentClassName,
 }: ChatStreamProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-
-  // Sticky scroll logic
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (!element) return;
-
-    const isAtBottom =
-      element.scrollHeight - element.scrollTop - element.clientHeight < 100;
-
-    // Use requestAnimationFrame to ensure we scroll after DOM update
-    if (isAtBottom) {
-      // Ideally we want to scroll *after* rendering.
-      // But here we rely on the fact that if they were at bottom, we keep them there
-      // actually, isAtBottom needs to be checked BEFORE the update?
-      // The effect runs AFTER the update (new message rendered).
-      // So 'scrollTop' is the OLD position (mostly), but 'scrollHeight' is NEW?
-      // No, layout happens before effect.
-      // So isAtBottom will be FALSE if content grew?
-      // Correct approach:
-      // We need to use LayoutEffect or store 'wasAtBottom' in a ref before render?
-      // Or simpler: just scroll to bottom if we are *close* to bottom.
-      element.scrollTop = element.scrollHeight;
-    }
-    // Alternatively, just force scroll if it's a new message and user hasn't scrolled up far?
-    // Let's use a simpler heuristic for now: always scroll if near bottom.
-    // But since this effect runs AFTER render, the content has already expanded.
-    // So 'element.scrollTop' is effectively "scrolled up" relative to new height.
-    // So we check if (scrollHeight - scrollTop - clientHeight) is basically equal to the *added content height*?
-    // That's hard.
-
-    // Better strategy:
-    // Auto-scroll on mount.
-    // For updates: scroll ONLY if the user was at bottom *before* update.
-    // We need useLayoutEffect or a ref updated on scroll events.
-  }, [messages]);
-
-  // Let's implement robust version:
   const isUserAtBottomRef = useRef(true);
 
   const onScroll = () => {
@@ -82,7 +29,7 @@ export function ChatStream({
     if (isUserAtBottomRef.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [messages]);
+  }, [nodes]);
 
   return (
     <div
@@ -91,32 +38,22 @@ export function ChatStream({
       className="flex-1 overflow-y-auto custom-scrollbar"
     >
       <div
-        className={`mx-auto w-full px-6 py-6 space-y-4 ${contentClassName ?? ""}`}
+        className={`mx-auto w-full space-y-4 px-6 py-6 ${contentClassName ?? ""}`}
       >
-        {messages.length === 0 ? (
+        {nodes.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">
-            发送指令开始对话。事件流将实时展示在右侧。
+            发送指令开始对话。主区将以 A2UI 模块树实时展示消息、工具、活动与状态。
           </div>
         ) : (
-          messages.map((message, index) => {
-            const prevMessage = messages[index - 1];
-            // 当 runId 变化时显示分隔（只对 assistant 消息显示分隔）
-            const showDivider =
-              prevMessage?.runId &&
-              message.runId !== prevMessage.runId &&
-              message.role === "assistant";
-
-            return (
-              <div key={message.id}>
-                {showDivider && <RunDivider />}
-                <MessageBubble
-                  message={message}
-                  isSelected={message.id === selectedMessageId}
-                  onSelect={onMessageSelect}
-                />
-              </div>
-            );
-          })
+          nodes.map((node) => (
+            <ConversationNodeRenderer
+              key={node.id}
+              node={node}
+              depth={0}
+              selectedNodeId={selectedNodeId}
+              onNodeSelect={onNodeSelect}
+            />
+          ))
         )}
       </div>
     </div>

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -2,7 +2,6 @@
 
 import { useAuth } from "@/components/providers/AuthProvider";
 import { cn } from "@/lib/utils";
-import type { Message } from "@ag-ui/core";
 import type { ChatMessage } from "@/types/common";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useMemo } from "react";
+import { JsonViewer } from "@/components/ui/JsonViewer";
+import { MessageBubble } from "@/components/ui/MessageBubble";
+import type { ChatMessage } from "@/types/common";
+import type { ConversationNode } from "@/types/a2ui";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  node: ConversationNode;
+  depth: number;
+  selectedNodeId?: string | null;
+  onNodeSelect?: (nodeId: string) => void;
+};
+
+function formatTimestamp(timestamp?: number): string {
+  if (!timestamp) {
+    return "";
+  }
+  return new Date(timestamp * 1000).toLocaleTimeString("zh-CN", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function DepthRail({ depth }: { depth: number }) {
+  if (depth <= 0) {
+    return null;
+  }
+  return (
+    <div
+      aria-hidden="true"
+      className="absolute bottom-0 left-0 top-0 border-l border-zinc-200/80 dark:border-zinc-800"
+      style={{ left: `${depth * 18 - 10}px` }}
+    />
+  );
+}
+
+function NodeCard({
+  node,
+  selected,
+  children,
+  onClick,
+}: {
+  node: ConversationNode;
+  selected: boolean;
+  children: React.ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border p-3 shadow-sm transition-colors",
+        selected
+          ? "border-amber-300 bg-amber-50/80 dark:border-amber-700 dark:bg-amber-950/30"
+          : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900",
+      )}
+      onClick={onClick}
+    >
+      <div className="mb-2 flex items-center justify-between gap-4 text-[10px] uppercase tracking-[0.16em] text-zinc-500 dark:text-zinc-400">
+        <span>{node.title}</span>
+        <span>{formatTimestamp(node.timestamp)}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <div className="max-h-64 overflow-auto rounded-xl border border-zinc-200/70 bg-zinc-50 p-2 text-xs dark:border-zinc-800 dark:bg-zinc-950/70">
+      <JsonViewer data={value} />
+    </div>
+  );
+}
+
+function TextNode({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: ConversationNode;
+  selected: boolean;
+  onSelect?: (nodeId: string) => void;
+}) {
+  const message = useMemo<ChatMessage>(
+    () => ({
+      id: node.id,
+      role: node.role === "user" ? "user" : node.role === "system" ? "system" : "assistant",
+      content: String(node.payload.content || ""),
+      author:
+        typeof node.payload.author === "string" ? String(node.payload.author) : undefined,
+      timestamp: node.timestamp,
+      runId: node.runId,
+    }),
+    [node],
+  );
+
+  return (
+    <MessageBubble
+      message={message}
+      isSelected={selected}
+      onSelect={() => onSelect?.(node.id)}
+    />
+  );
+}
+
+function TurnNode({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: ConversationNode;
+  selected: boolean;
+  onSelect?: (nodeId: string) => void;
+}) {
+  const childCount = node.children.length;
+  return (
+    <div
+      className={cn(
+        "rounded-[28px] border px-4 py-3",
+        selected
+          ? "border-amber-300 bg-white dark:border-amber-700 dark:bg-zinc-900"
+          : "border-zinc-200/80 bg-zinc-100/60 dark:border-zinc-800 dark:bg-zinc-900/50",
+      )}
+      onClick={() => onSelect?.(node.id)}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+            {node.title}
+          </div>
+          <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+            {node.status === "finished" ? "已完成" : node.status === "error" ? "异常" : "进行中"}
+            {" · "}
+            {childCount} 个子模块
+          </div>
+        </div>
+        <div className="text-[10px] text-zinc-400 dark:text-zinc-500">
+          {formatTimestamp(node.timestamp)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TechnicalNode({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: ConversationNode;
+  selected: boolean;
+  onSelect?: (nodeId: string) => void;
+}) {
+  const content = (() => {
+    switch (node.type) {
+      case "tool-call":
+        return (
+          <div className="space-y-2">
+            <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              {String(node.payload.toolCallName || node.title)}
+            </div>
+            <JsonBlock value={node.payload.args ? safeJson(node.payload.args) : {}} />
+          </div>
+        );
+      case "tool-result":
+        return <JsonBlock value={safeJson(node.payload.content)} />;
+      case "activity":
+        return <JsonBlock value={node.payload.content} />;
+      case "reasoning":
+        return (
+          <div className="text-sm text-zinc-700 dark:text-zinc-300">
+            {node.summary || "推理阶段更新"}
+          </div>
+        );
+      case "step":
+        return (
+          <div className="space-y-2 text-sm text-zinc-700 dark:text-zinc-300">
+            <div>{node.status === "done" ? "步骤已完成" : "步骤执行中"}</div>
+            {"result" in node.payload && node.payload.result !== undefined ? (
+              <JsonBlock value={node.payload.result} />
+            ) : null}
+          </div>
+        );
+      case "state-delta":
+        return <JsonBlock value={node.payload.delta} />;
+      case "state-snapshot":
+        return <JsonBlock value={node.payload.snapshot} />;
+      case "raw":
+        return <JsonBlock value={node.payload.data} />;
+      case "custom":
+        return <JsonBlock value={node.payload.data} />;
+      case "error":
+        return (
+          <div className="space-y-1 text-sm text-red-700 dark:text-red-300">
+            <div>{String(node.payload.message || "未知错误")}</div>
+            {node.payload.code ? (
+              <div className="text-xs uppercase tracking-wider text-red-500">
+                {String(node.payload.code)}
+              </div>
+            ) : null}
+          </div>
+        );
+      default:
+        return <JsonBlock value={node.payload} />;
+    }
+  })();
+
+  return (
+    <NodeCard node={node} selected={selected} onClick={() => onSelect?.(node.id)}>
+      {content}
+      {node.children.length > 0 ? (
+        <div className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
+          {node.children.length} 个子模块
+        </div>
+      ) : null}
+    </NodeCard>
+  );
+}
+
+function safeJson(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function ConversationNodeRenderer({
+  node,
+  depth,
+  selectedNodeId,
+  onNodeSelect,
+}: Props) {
+  const selected = node.id === selectedNodeId;
+  const content = (() => {
+    if (node.type === "turn") {
+      return <TurnNode node={node} selected={selected} onSelect={onNodeSelect} />;
+    }
+    if (node.type === "text") {
+      return <TextNode node={node} selected={selected} onSelect={onNodeSelect} />;
+    }
+    return <TechnicalNode node={node} selected={selected} onSelect={onNodeSelect} />;
+  })();
+
+  return (
+    <div className="relative">
+      <DepthRail depth={depth} />
+      <div style={{ marginLeft: `${depth * 18}px` }}>
+        {content}
+        {node.type !== "turn" && node.children.length > 0 ? (
+          <div className="mt-3 space-y-3">
+            {node.children.map((child) => (
+              <ConversationNodeRenderer
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                selectedNodeId={selectedNodeId}
+                onNodeSelect={onNodeSelect}
+              />
+            ))}
+          </div>
+        ) : null}
+        {node.type === "turn" && node.children.length > 0 ? (
+          <div className="mt-4 space-y-3">
+            {node.children.map((child) => (
+              <ConversationNodeRenderer
+                key={child.id}
+                node={child}
+                depth={depth + 1}
+                selectedNodeId={selectedNodeId}
+                onNodeSelect={onNodeSelect}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/lib/adk.ts
+++ b/apps/negentropy-ui/lib/adk.ts
@@ -1,4 +1,4 @@
-import { BaseEvent, EventType, Message } from "@ag-ui/core";
+import { BaseEvent, Message } from "@ag-ui/core";
 import {
   createTextMessageStartEvent,
   createTextMessageContentEvent,
@@ -78,6 +78,19 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
     messageId: payload.id,
     author: payload.author,
   };
+  const pushLinkEvent = (childId: string, parentId: string, relation: string) => {
+    events.push(
+      createCustomEvent(common, "ne.a2ui.link", {
+        childId,
+        parentId,
+        relation,
+      }),
+    );
+  };
+  const normalizeTextRole = (
+    value: string | undefined,
+  ): "user" | "agent" | "system" =>
+    value === "user" || value === "system" ? value : "agent";
 
   // 1. Text Messages
   // 过滤掉包含工具调用（functionCall/functionResponse）的 part，
@@ -108,7 +121,7 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
     payload.message?.role !== "tool" &&
     !isToolResponsePart
   ) {
-    const role = payload.message?.role || payload.author || "assistant";
+    const role = normalizeTextRole(payload.message?.role || payload.author);
 
     events.push(createTextMessageStartEvent(common, role));
 
@@ -130,6 +143,7 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
       }
 
       events.push(createToolCallEndEvent(common, tc.id));
+      pushLinkEvent(`tool:${tc.id}`, `message:${payload.id}`, "child");
     });
   }
 
@@ -144,6 +158,7 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
         events.push(createToolCallArgsEvent(common, fc.id, argsString));
 
         events.push(createToolCallEndEvent(common, fc.id));
+        pushLinkEvent(`tool:${fc.id}`, `message:${payload.id}`, "child");
       }
     });
   }
@@ -152,6 +167,11 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
   if (payload.message?.role === "tool" && payload.message.tool_call_id) {
     const content = textParts.join("") || payload.delta || "";
     events.push(createToolCallResultEvent(common, payload.message.tool_call_id, content));
+    pushLinkEvent(
+      `tool-result:${payload.message.tool_call_id}`,
+      `tool:${payload.message.tool_call_id}`,
+      "child",
+    );
   }
 
   // 3b. Tool Result (Gemini/Parts Style)
@@ -163,6 +183,7 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
         const content =
           typeof result === "string" ? result : JSON.stringify(result);
         events.push(createToolCallResultEvent(common, fr.id, content));
+        pushLinkEvent(`tool-result:${fr.id}`, `tool:${fr.id}`, "child");
       }
     });
   }
@@ -196,10 +217,24 @@ export function adkEventToAguiEvents(payload: AdkEventPayload): BaseEvent[] {
   // 8. Step Started/Finished（细粒度进度）
   if (payload.actions?.stepStarted) {
     events.push(createStepStartedEvent(common, payload.actions.stepStarted.id, payload.actions.stepStarted.name));
+    events.push(
+      createCustomEvent(common, "ne.a2ui.reasoning", {
+        stepId: payload.actions.stepStarted.id,
+        phase: "started",
+        title: payload.actions.stepStarted.name,
+      }),
+    );
   }
 
   if (payload.actions?.stepFinished) {
     events.push(createStepFinishedEvent(common, payload.actions.stepFinished.id, payload.actions.stepFinished.result));
+    events.push(
+      createCustomEvent(common, "ne.a2ui.reasoning", {
+        stepId: payload.actions.stepFinished.id,
+        phase: "finished",
+        result: payload.actions.stepFinished.result,
+      }),
+    );
   }
 
   // 9. RAW/CUSTOM 事件（透传机制）

--- a/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
@@ -1,39 +1,74 @@
 import { render, screen } from "@testing-library/react";
 import { ChatStream } from "../../components/ui/ChatStream";
-import { AuthProvider } from "@/components/providers/AuthProvider";
+import type { ConversationNode } from "@/types/a2ui";
 
-// Mock AuthProvider for tests
 vi.mock("@/components/providers/AuthProvider", () => ({
-  AuthProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="auth-provider">{children}</div>
-  ),
   useAuth: () => ({ user: null }),
 }));
 
 describe("ChatStream", () => {
-  it("renders placeholder when empty", () => {
-    render(
-      <AuthProvider>
-        <ChatStream messages={[]} />
-      </AuthProvider>
-    );
-    expect(screen.getByText("发送指令开始对话。事件流将实时展示在右侧。"))
-      .toBeInTheDocument();
+  it("在空树时渲染占位文案", () => {
+    render(<ChatStream nodes={[]} />);
+    expect(
+      screen.getByText("发送指令开始对话。主区将以 A2UI 模块树实时展示消息、工具、活动与状态。"),
+    ).toBeInTheDocument();
   });
 
-  it("renders messages", () => {
-    render(
-      <AuthProvider>
-        <ChatStream
-          messages={[
-            { id: "1", role: "user", content: "hi" },
-            { id: "2", role: "assistant", content: "hello" },
-          ]}
-        />
-      </AuthProvider>
-    );
-    // MessageBubble uses ReactMarkdown which may render text in nested elements
-    expect(screen.getByText((content) => content.includes("hi"))).toBeInTheDocument();
-    expect(screen.getByText((content) => content.includes("hello"))).toBeInTheDocument();
+  it("递归渲染父子节点", () => {
+    const nodes: ConversationNode[] = [
+      {
+        id: "turn:1",
+        type: "turn",
+        parentId: null,
+        children: [
+          {
+            id: "message:1",
+            type: "text",
+            parentId: "turn:1",
+            children: [
+              {
+                id: "tool:1",
+                type: "tool-call",
+                parentId: "message:1",
+                children: [],
+                threadId: "thread-1",
+                runId: "run-1",
+                toolCallId: "tool-1",
+                timestamp: 1002,
+                timeRange: { start: 1002, end: 1002 },
+                title: "search",
+                payload: { args: "{\"q\":\"hello\"}", toolCallName: "search" },
+                sourceEventTypes: ["tool_call_start"],
+                relatedMessageIds: ["msg-1"],
+              },
+            ],
+            threadId: "thread-1",
+            runId: "run-1",
+            messageId: "msg-1",
+            timestamp: 1001,
+            timeRange: { start: 1001, end: 1001 },
+            title: "助手消息",
+            role: "assistant",
+            payload: { content: "你好" },
+            sourceEventTypes: ["text_message_start"],
+            relatedMessageIds: ["msg-1"],
+          },
+        ],
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1003 },
+        title: "轮次 run-1",
+        payload: {},
+        sourceEventTypes: ["run_started"],
+        relatedMessageIds: [],
+      },
+    ];
+
+    render(<ChatStream nodes={nodes} />);
+
+    expect(screen.getByText("轮次 run-1")).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes("你好"))).toBeInTheDocument();
+    expect(screen.getAllByText("search").length).toBeGreaterThan(0);
   });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { EventType, type BaseEvent, type Message } from "@ag-ui/core";
+import { buildConversationTree } from "@/utils/conversation-tree";
+
+describe("buildConversationTree", () => {
+  it("将文本、工具和结果构造成父子树", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        role: "assistant",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "你好",
+        timestamp: 1002,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        toolCallId: "tool-1",
+        toolCallName: "search",
+        timestamp: 1003,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        toolCallId: "tool-1",
+        delta: "{\"q\":\"hello\"}",
+        timestamp: 1004,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        toolCallId: "tool-1",
+        content: "{\"items\":1}",
+        timestamp: 1005,
+      } as BaseEvent,
+    ];
+
+    const tree = buildConversationTree({ events });
+    expect(tree.roots).toHaveLength(1);
+    const turn = tree.roots[0];
+    expect(turn.type).toBe("turn");
+    expect(turn.children[0].type).toBe("text");
+    expect(turn.children[0].children[0].type).toBe("tool-call");
+    expect(turn.children[0].children[0].children[0].type).toBe("tool-result");
+  });
+
+  it("在没有事件时用 fallback message 建树", () => {
+    const fallbackMessages: Message[] = [
+      {
+        id: "msg-user",
+        role: "user",
+        content: "hello",
+        createdAt: new Date(1000 * 1000),
+      } as Message,
+    ];
+
+    const tree = buildConversationTree({ events: [], fallbackMessages });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].type).toBe("text");
+    expect(tree.roots[0].payload.content).toBe("hello");
+  });
+});

--- a/apps/negentropy-ui/types/a2ui.ts
+++ b/apps/negentropy-ui/types/a2ui.ts
@@ -1,0 +1,53 @@
+import type { BaseEvent, Message } from "@ag-ui/core";
+
+export type ConversationNodeType =
+  | "turn"
+  | "text"
+  | "tool-call"
+  | "tool-result"
+  | "activity"
+  | "reasoning"
+  | "state-delta"
+  | "state-snapshot"
+  | "step"
+  | "raw"
+  | "custom"
+  | "event"
+  | "error";
+
+export interface NodeTimeRange {
+  start: number;
+  end: number;
+}
+
+export interface ConversationNode {
+  id: string;
+  type: ConversationNodeType;
+  parentId: string | null;
+  children: ConversationNode[];
+  threadId: string;
+  runId?: string;
+  messageId?: string;
+  toolCallId?: string;
+  timestamp: number;
+  timeRange: NodeTimeRange;
+  title: string;
+  status?: string;
+  role?: "user" | "assistant" | "system";
+  summary?: string;
+  payload: Record<string, unknown>;
+  sourceEventTypes: string[];
+  relatedMessageIds: string[];
+}
+
+export interface ConversationTree {
+  roots: ConversationNode[];
+  nodeIndex: Map<string, ConversationNode>;
+  messageNodeIndex: Map<string, string>;
+  toolNodeIndex: Map<string, string>;
+}
+
+export interface BuildConversationTreeOptions {
+  events: BaseEvent[];
+  fallbackMessages?: Message[];
+}

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -1,0 +1,736 @@
+import { EventType, type BaseEvent, type Message } from "@ag-ui/core";
+import type {
+  BuildConversationTreeOptions,
+  ConversationNode,
+  ConversationNodeType,
+  ConversationTree,
+} from "@/types/a2ui";
+
+type MutableNode = ConversationNode;
+
+type LinkInstruction = {
+  childId: string;
+  parentId: string;
+};
+
+type CustomPayload = {
+  eventType?: string;
+  data?: unknown;
+};
+
+const DEFAULT_THREAD_ID = "default";
+const DEFAULT_RUN_ID = "default";
+
+function normalizeRole(value: unknown): "user" | "assistant" | "system" {
+  if (value === "user") return "user";
+  if (value === "system") return "system";
+  return "assistant";
+}
+
+function normalizeTimestamp(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : Date.now() / 1000;
+}
+
+function createNode(input: {
+  id: string;
+  type: ConversationNodeType;
+  parentId?: string | null;
+  threadId?: string;
+  runId?: string;
+  messageId?: string;
+  toolCallId?: string;
+  timestamp?: number;
+  title: string;
+  status?: string;
+  role?: "user" | "assistant" | "system";
+  summary?: string;
+  payload?: Record<string, unknown>;
+  sourceEventTypes?: string[];
+  relatedMessageIds?: string[];
+}): MutableNode {
+  const timestamp = normalizeTimestamp(input.timestamp);
+  return {
+    id: input.id,
+    type: input.type,
+    parentId: input.parentId ?? null,
+    children: [],
+    threadId: input.threadId || DEFAULT_THREAD_ID,
+    runId: input.runId,
+    messageId: input.messageId,
+    toolCallId: input.toolCallId,
+    timestamp,
+    timeRange: { start: timestamp, end: timestamp },
+    title: input.title,
+    status: input.status,
+    role: input.role,
+    summary: input.summary,
+    payload: input.payload || {},
+    sourceEventTypes: input.sourceEventTypes || [],
+    relatedMessageIds: input.relatedMessageIds || [],
+  };
+}
+
+function addChild(parent: MutableNode, child: MutableNode) {
+  if (parent.children.some((existing) => existing.id === child.id)) {
+    return;
+  }
+  parent.children.push(child);
+}
+
+function removeChild(parent: MutableNode, childId: string) {
+  parent.children = parent.children.filter((child) => child.id !== childId);
+}
+
+function mergeEventMeta(node: MutableNode, event: BaseEvent) {
+  const eventType = String(event.type);
+  if (!node.sourceEventTypes.includes(eventType)) {
+    node.sourceEventTypes.push(eventType);
+  }
+  const timestamp = normalizeTimestamp(event.timestamp);
+  node.timestamp = Math.min(node.timestamp, timestamp);
+  node.timeRange.start = Math.min(node.timeRange.start, timestamp);
+  node.timeRange.end = Math.max(node.timeRange.end, timestamp);
+  if ("messageId" in event && typeof event.messageId === "string") {
+    node.messageId = event.messageId;
+    if (!node.relatedMessageIds.includes(event.messageId)) {
+      node.relatedMessageIds.push(event.messageId);
+    }
+  }
+}
+
+function ensureTurn(
+  turns: Map<string, MutableNode>,
+  roots: MutableNode[],
+  event: BaseEvent,
+): MutableNode {
+  const runId =
+    "runId" in event && typeof event.runId === "string"
+      ? event.runId
+      : DEFAULT_RUN_ID;
+  const existing = turns.get(runId);
+  if (existing) {
+    mergeEventMeta(existing, event);
+    return existing;
+  }
+
+  const turn = createNode({
+    id: `turn:${runId}`,
+    type: "turn",
+    threadId:
+      "threadId" in event && typeof event.threadId === "string"
+        ? event.threadId
+        : DEFAULT_THREAD_ID,
+    runId,
+    timestamp: event.timestamp,
+    title: runId === DEFAULT_RUN_ID ? "默认轮次" : `轮次 ${runId.slice(0, 8)}`,
+    status: event.type === EventType.RUN_FINISHED ? "finished" : "running",
+    payload: {},
+    sourceEventTypes: [String(event.type)],
+  });
+  turns.set(runId, turn);
+  roots.push(turn);
+  return turn;
+}
+
+function upsertNode(
+  nodeIndex: Map<string, MutableNode>,
+  roots: MutableNode[],
+  turns: Map<string, MutableNode>,
+  input: Parameters<typeof createNode>[0],
+): MutableNode {
+  const existing = nodeIndex.get(input.id);
+  if (existing) {
+    if (input.parentId !== undefined) {
+      existing.parentId = input.parentId;
+    }
+    if (input.status) {
+      existing.status = input.status;
+    }
+    if (input.summary) {
+      existing.summary = input.summary;
+    }
+    if (input.role) {
+      existing.role = input.role;
+    }
+    existing.title = input.title || existing.title;
+    existing.payload = { ...existing.payload, ...(input.payload || {}) };
+    existing.timestamp = Math.min(
+      existing.timestamp,
+      normalizeTimestamp(input.timestamp),
+    );
+    existing.timeRange.start = Math.min(
+      existing.timeRange.start,
+      normalizeTimestamp(input.timestamp),
+    );
+    existing.timeRange.end = Math.max(
+      existing.timeRange.end,
+      normalizeTimestamp(input.timestamp),
+    );
+    (input.sourceEventTypes || []).forEach((eventType) => {
+      if (!existing.sourceEventTypes.includes(eventType)) {
+        existing.sourceEventTypes.push(eventType);
+      }
+    });
+    (input.relatedMessageIds || []).forEach((messageId) => {
+      if (!existing.relatedMessageIds.includes(messageId)) {
+        existing.relatedMessageIds.push(messageId);
+      }
+    });
+    return existing;
+  }
+
+  const node = createNode(input);
+  nodeIndex.set(node.id, node);
+
+  if (!node.parentId) {
+    roots.push(node);
+    return node;
+  }
+
+  const parent =
+    nodeIndex.get(node.parentId) ||
+    turns.get(node.parentId.replace(/^turn:/, ""));
+  if (parent) {
+    addChild(parent, node);
+  } else {
+    roots.push(node);
+  }
+  return node;
+}
+
+function attachNode(
+  nodeIndex: Map<string, MutableNode>,
+  roots: MutableNode[],
+  childId: string,
+  parentId: string | null,
+) {
+  const child = nodeIndex.get(childId);
+  if (!child) return;
+
+  if (child.parentId && nodeIndex.has(child.parentId)) {
+    removeChild(nodeIndex.get(child.parentId)!, childId);
+  } else if (!child.parentId) {
+    const rootIndex = roots.findIndex((node) => node.id === childId);
+    if (rootIndex >= 0) {
+      roots.splice(rootIndex, 1);
+    }
+  }
+
+  child.parentId = parentId;
+  if (!parentId) {
+    roots.push(child);
+    return;
+  }
+  const parent = nodeIndex.get(parentId);
+  if (parent) {
+    addChild(parent, child);
+  } else {
+    roots.push(child);
+  }
+}
+
+function chooseParentMessageId(
+  assistantByRun: Map<string, string>,
+  runId: string,
+): string | null {
+  return assistantByRun.get(runId) || null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function formatJson(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value, null, 2);
+}
+
+function getMessageTimestamp(message: Message): number {
+  const createdAt = (message as { createdAt?: Date }).createdAt;
+  return createdAt instanceof Date ? createdAt.getTime() / 1000 : Date.now() / 1000;
+}
+
+export function buildConversationTree(
+  options: BuildConversationTreeOptions,
+): ConversationTree {
+  const { events, fallbackMessages = [] } = options;
+  const roots: MutableNode[] = [];
+  const nodeIndex = new Map<string, MutableNode>();
+  const messageNodeIndex = new Map<string, string>();
+  const toolNodeIndex = new Map<string, string>();
+  const turns = new Map<string, MutableNode>();
+  const assistantMessageByRun = new Map<string, string>();
+  const pendingLinks: LinkInstruction[] = [];
+
+  const orderedEvents = [...events].sort((a, b) => {
+    const timeDiff = normalizeTimestamp(a.timestamp) - normalizeTimestamp(b.timestamp);
+    if (timeDiff !== 0) return timeDiff;
+    return String(a.type).localeCompare(String(b.type));
+  });
+
+  orderedEvents.forEach((event) => {
+    const turn = ensureTurn(turns, roots, event);
+    const runId = turn.runId || DEFAULT_RUN_ID;
+    const messageId =
+      "messageId" in event && typeof event.messageId === "string"
+        ? event.messageId
+        : undefined;
+    const eventType = String(event.type);
+
+    switch (event.type) {
+      case EventType.RUN_STARTED: {
+        turn.status = "running";
+        turn.title = `轮次 ${runId.slice(0, 8)}`;
+        mergeEventMeta(turn, event);
+        return;
+      }
+      case EventType.RUN_FINISHED: {
+        turn.status = "finished";
+        mergeEventMeta(turn, event);
+        return;
+      }
+      case EventType.RUN_ERROR: {
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `error:${runId}:${normalizeTimestamp(event.timestamp)}`,
+          type: "error",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          timestamp: event.timestamp,
+          title: "运行错误",
+          status: "error",
+          payload: {
+            message: "message" in event ? event.message : "",
+            code: "code" in event ? event.code : "",
+          },
+          sourceEventTypes: [eventType],
+        });
+        addChild(turn, node);
+        return;
+      }
+      case EventType.TEXT_MESSAGE_START:
+      case EventType.TEXT_MESSAGE_CONTENT:
+      case EventType.TEXT_MESSAGE_END: {
+        if (!messageId) return;
+        const role =
+          event.type === EventType.TEXT_MESSAGE_START && "role" in event
+            ? normalizeRole(event.role)
+            : undefined;
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `message:${messageId}`,
+          type: "text",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: role === "user" ? "用户消息" : "助手消息",
+          role,
+          payload: {
+            content: "",
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: [messageId],
+        });
+        mergeEventMeta(node, event);
+        if (role) {
+          node.role = role;
+          node.title = role === "user" ? "用户消息" : "助手消息";
+        }
+        if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+          const delta = "delta" in event ? String(event.delta || "") : "";
+          const existing = String(node.payload.content || "");
+          node.payload.content =
+            delta.length >= existing.length || existing.length === 0
+              ? delta
+              : `${existing}${delta}`;
+        }
+        messageNodeIndex.set(messageId, node.id);
+        if (node.role === "assistant") {
+          assistantMessageByRun.set(runId, node.id);
+        }
+        addChild(turn, node);
+        return;
+      }
+      case EventType.TOOL_CALL_START:
+      case EventType.TOOL_CALL_ARGS:
+      case EventType.TOOL_CALL_END: {
+        const toolCallId =
+          "toolCallId" in event && typeof event.toolCallId === "string"
+            ? event.toolCallId
+            : undefined;
+        if (!toolCallId) return;
+        const parentMessageNodeId = chooseParentMessageId(
+          assistantMessageByRun,
+          runId,
+        );
+        const parentId = parentMessageNodeId || turn.id;
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `tool:${toolCallId}`,
+          type: "tool-call",
+          parentId,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          toolCallId,
+          timestamp: event.timestamp,
+          title:
+            event.type === EventType.TOOL_CALL_START &&
+            "toolCallName" in event &&
+            typeof event.toolCallName === "string"
+              ? event.toolCallName
+              : "工具调用",
+          status:
+            event.type === EventType.TOOL_CALL_END ? "done" : "running",
+          payload: {
+            args: "",
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        if (
+          event.type === EventType.TOOL_CALL_START &&
+          "toolCallName" in event &&
+          typeof event.toolCallName === "string"
+        ) {
+          node.title = event.toolCallName;
+          node.payload.toolCallName = event.toolCallName;
+        }
+        if (event.type === EventType.TOOL_CALL_ARGS && "delta" in event) {
+          node.payload.args = `${String(node.payload.args || "")}${String(
+            event.delta || "",
+          )}`;
+        }
+        toolNodeIndex.set(toolCallId, node.id);
+        attachNode(nodeIndex, roots, node.id, parentId);
+        return;
+      }
+      case EventType.TOOL_CALL_RESULT: {
+        const toolCallId =
+          "toolCallId" in event && typeof event.toolCallId === "string"
+            ? event.toolCallId
+            : undefined;
+        if (!toolCallId) return;
+        const toolNodeId = toolNodeIndex.get(toolCallId);
+        const parentId = toolNodeId || turn.id;
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `tool-result:${toolCallId}`,
+          type: "tool-result",
+          parentId,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          toolCallId,
+          timestamp: event.timestamp,
+          title: "工具结果",
+          status: "completed",
+          payload: {
+            content: "content" in event ? event.content : "",
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        attachNode(nodeIndex, roots, node.id, parentId);
+        return;
+      }
+      case EventType.ACTIVITY_SNAPSHOT: {
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `activity:${runId}:${normalizeTimestamp(event.timestamp)}:${messageId || "none"}`,
+          type: "activity",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title:
+            "activityType" in event && typeof event.activityType === "string"
+              ? event.activityType
+              : "活动",
+          payload: {
+            content: "content" in event ? event.content : {},
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(turn, node);
+        return;
+      }
+      case EventType.STATE_DELTA: {
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `state-delta:${runId}:${normalizeTimestamp(event.timestamp)}:${messageId || "none"}`,
+          type: "state-delta",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: "状态增量",
+          payload: {
+            delta: "delta" in event ? event.delta : [],
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(turn, node);
+        return;
+      }
+      case EventType.STATE_SNAPSHOT: {
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `state-snapshot:${runId}:${normalizeTimestamp(event.timestamp)}:${messageId || "none"}`,
+          type: "state-snapshot",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: "状态快照",
+          payload: {
+            snapshot: "snapshot" in event ? event.snapshot : {},
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(turn, node);
+        return;
+      }
+      case EventType.STEP_STARTED:
+      case EventType.STEP_FINISHED: {
+        const stepId =
+          "stepId" in event && typeof event.stepId === "string"
+            ? event.stepId
+            : `step-${normalizeTimestamp(event.timestamp)}`;
+        const baseParentId =
+          chooseParentMessageId(assistantMessageByRun, runId) || turn.id;
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `step:${stepId}`,
+          type: "step",
+          parentId: baseParentId,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title:
+            event.type === EventType.STEP_STARTED &&
+            "stepName" in event &&
+            typeof event.stepName === "string"
+              ? event.stepName
+              : `步骤 ${stepId}`,
+          status: event.type === EventType.STEP_FINISHED ? "done" : "running",
+          payload: {
+            result:
+              event.type === EventType.STEP_FINISHED && "result" in event
+                ? event.result
+                : undefined,
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        attachNode(nodeIndex, roots, node.id, baseParentId);
+        upsertNode(nodeIndex, roots, turns, {
+          id: `reasoning:${stepId}`,
+          type: "reasoning",
+          parentId: node.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: "推理阶段",
+          status: node.status,
+          summary:
+            event.type === EventType.STEP_STARTED
+              ? `阶段开始：${node.title}`
+              : `阶段完成：${node.title}`,
+          payload: {
+            stepId,
+            phase:
+              event.type === EventType.STEP_STARTED ? "started" : "finished",
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(node, nodeIndex.get(`reasoning:${stepId}`)!);
+        return;
+      }
+      case EventType.RAW: {
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `raw:${runId}:${normalizeTimestamp(event.timestamp)}`,
+          type: "raw",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: "原始事件",
+          payload: {
+            data: "data" in event ? event.data : {},
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(turn, node);
+        return;
+      }
+      case EventType.CUSTOM: {
+        const customEvent = event as BaseEvent & CustomPayload;
+        const eventTypeName =
+          typeof customEvent.eventType === "string"
+            ? customEvent.eventType
+            : "custom";
+        if (eventTypeName === "ne.a2ui.link") {
+          const data = asRecord(customEvent.data);
+          if (
+            data &&
+            typeof data.childId === "string" &&
+            typeof data.parentId === "string"
+          ) {
+            pendingLinks.push({
+              childId: data.childId,
+              parentId: data.parentId,
+            });
+          }
+        }
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `custom:${runId}:${eventTypeName}:${normalizeTimestamp(event.timestamp)}`,
+          type: "custom",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: eventTypeName,
+          payload: {
+            data: customEvent.data,
+            eventType: eventTypeName,
+          },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(turn, node);
+        return;
+      }
+      default: {
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: `event:${runId}:${eventType}:${normalizeTimestamp(event.timestamp)}`,
+          type: "event",
+          parentId: turn.id,
+          threadId: turn.threadId,
+          runId,
+          messageId,
+          timestamp: event.timestamp,
+          title: eventType,
+          payload: { event },
+          sourceEventTypes: [eventType],
+          relatedMessageIds: messageId ? [messageId] : [],
+        });
+        addChild(turn, node);
+      }
+    }
+  });
+
+  fallbackMessages.forEach((message) => {
+    const messageId = message.id;
+    if (messageNodeIndex.has(messageId)) {
+      return;
+    }
+    const runId =
+      typeof (message as { runId?: unknown }).runId === "string"
+        ? String((message as { runId?: unknown }).runId)
+        : undefined;
+    if (runId) {
+      ensureTurn(
+        turns,
+        roots,
+        {
+          type: EventType.RUN_STARTED,
+          threadId: DEFAULT_THREAD_ID,
+          runId,
+          timestamp: getMessageTimestamp(message),
+        } as BaseEvent,
+      );
+    }
+    const parentId = runId ? `turn:${runId}` : null;
+    const role = normalizeRole(message.role);
+    const node = upsertNode(nodeIndex, roots, turns, {
+      id: `message:${messageId}`,
+      type: "text",
+      parentId,
+      threadId: DEFAULT_THREAD_ID,
+      runId,
+      messageId,
+      timestamp: getMessageTimestamp(message),
+      title: role === "user" ? "用户消息" : "助手消息",
+      role,
+      payload: {
+        content:
+          typeof message.content === "string"
+            ? message.content
+            : formatJson(message.content),
+      },
+      sourceEventTypes: ["fallback.message"],
+      relatedMessageIds: [messageId],
+    });
+    messageNodeIndex.set(messageId, node.id);
+    if (role === "assistant" && runId) {
+      assistantMessageByRun.set(runId, node.id);
+    }
+    if (parentId) {
+      attachNode(nodeIndex, roots, node.id, parentId);
+    }
+  });
+
+  pendingLinks.forEach((link) => {
+    if (!nodeIndex.has(link.childId) || !nodeIndex.has(link.parentId)) {
+      return;
+    }
+    attachNode(nodeIndex, roots, link.childId, link.parentId);
+  });
+
+  const sortNodes = (nodes: MutableNode[]) => {
+    nodes.sort((a, b) => {
+      const timeDiff = a.timeRange.start - b.timeRange.start;
+      if (timeDiff !== 0) return timeDiff;
+      return a.id.localeCompare(b.id);
+    });
+    nodes.forEach((node) => sortNodes(node.children));
+  };
+
+  sortNodes(roots);
+
+  return {
+    roots,
+    nodeIndex,
+    messageNodeIndex,
+    toolNodeIndex,
+  };
+}
+
+export function buildNodeTimestampIndex(tree: ConversationTree): Map<string, number> {
+  const result = new Map<string, number>();
+  tree.nodeIndex.forEach((node) => {
+    result.set(node.id, node.timeRange.end);
+  });
+  return result;
+}
+
+export function getNodeRelatedMessageIds(
+  tree: ConversationTree,
+  nodeId: string | null,
+): string[] {
+  if (!nodeId) {
+    return [];
+  }
+  const node = tree.nodeIndex.get(nodeId);
+  if (!node) {
+    return [];
+  }
+  const messageIds = new Set<string>();
+  const visit = (current: ConversationNode) => {
+    current.relatedMessageIds.forEach((messageId) => messageIds.add(messageId));
+    current.children.forEach(visit);
+  };
+  visit(node);
+  return [...messageIds];
+}

--- a/docs/a2ui.md
+++ b/docs/a2ui.md
@@ -1,0 +1,229 @@
+# A2UI 协议调研与 Negentropy Chat 落地
+
+## 1. 摘要
+
+本文档作为本项目 A2UI 调研、实施方案、实施进度与验证记录的单一事实源。
+
+- 传输层：沿用现有 [AG-UI BFF 路由](../apps/negentropy-ui/app/api/agui/route.ts)
+- 语义层：在前端新增 A2UI 风格的消息树/组件树适配
+- 首期目标：让 Chat 页以“完整消息模块/事件模块”为单位渲染，并支持父子事件嵌套展示
+
+## 2. 协议定义与关系
+
+### 2.1 A2UI 在本项目中的工作定义
+
+本项目中的 A2UI 指向一种“面向 Agent 的生成式 UI 语义层”：
+
+- 以事件流作为事实源
+- 以父子节点树作为渲染模型
+- 以组件注册表承载不同事件类型的可视化
+- 允许标准协议事件与项目自定义事件共存
+
+### 2.2 A2UI 与 AG-UI 的关系
+
+- AG-UI 负责传输与基础事件定义：消息、工具、状态、步骤、原始事件等<sup>[[1]](#ref1)</sup>
+- A2UI 负责把这些事件适配为可递归渲染的 UI 树，并引入更强的组件化表达
+
+在本项目中采用：
+
+- `AG-UI transport`
+- `A2UI renderer`
+
+而不是双协议并存。
+
+## 3. 协议原理
+
+### 3.1 事件溯源
+
+UI 不直接把流式片段当最终事实，而是把线性事件流重建为稳定读模型。该模式与事件溯源、快照回放一致，可降低流式拼接带来的状态漂移风险。
+
+### 3.2 组合模式
+
+消息、工具、活动、状态、推理步骤都抽象为统一节点，由父节点递归持有子节点。这样能自然表达：
+
+- assistant 文本 -> tool call -> tool result
+- turn -> step -> reasoning note
+- turn -> activity/state/raw/custom
+
+### 3.3 数据绑定与 JSON 结构
+
+状态增量与快照保持 JSON 结构，便于沿用 JSON Pointer / JSON Patch 的标准语义<sup>[[6]](#ref6)</sup><sup>[[7]](#ref7)</sup>。
+
+## 4. 经典设计模式与场景用例
+
+### 4.1 Adapter
+
+- 场景：`ADK payload -> AG-UI event -> A2UI node`
+- 本项目锚点：[adk.ts](../apps/negentropy-ui/lib/adk.ts)、[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
+
+### 4.2 Composite
+
+- 场景：父子消息、父子工具、轮次容器递归渲染
+- 本项目锚点：[ConversationNodeRenderer.tsx](../apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx)
+
+### 4.3 Registry / Polymorphic Renderer
+
+- 场景：不同节点类型绑定不同渲染卡片
+- 本项目首期采用轻量映射；后续可演进为正式组件注册表
+
+### 4.4 Event Sourcing + Read Model
+
+- 场景：历史回放与实时流统一建模
+- 本项目锚点：[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
+
+## 5. 本项目现状与问题
+
+改造前，Chat 页主路径为：
+
+```mermaid
+flowchart LR
+  A[AG-UI Raw Events] --> B[buildChatMessagesFromEventsWithFallback]
+  B --> C[ChatMessage[]]
+  C --> D[ChatStream]
+```
+
+问题：
+
+- 工具调用按 `runId` 粗粒度挂载，父子关系不稳定
+- `TEXT_MESSAGE_CONTENT` 被压扁为文本，活动/状态/原始事件无法成为一级模块
+- 主聊天区与右侧观察区职责失衡，导致真正的“交互结构”不可见
+
+## 6. 实施方案
+
+### 6.1 目标结构
+
+```mermaid
+flowchart TD
+  subgraph Transport
+    A[ADK SSE]
+    B[/api/agui]
+    C[AG-UI Events]
+  end
+
+  subgraph A2UI
+    D[Conversation Tree Builder]
+    E[Conversation Nodes]
+    F[Recursive Renderer]
+  end
+
+  A --> B --> C --> D --> E --> F
+```
+
+### 6.2 节点模型
+
+首期支持：
+
+- `turn`
+- `text`
+- `tool-call`
+- `tool-result`
+- `activity`
+- `reasoning`
+- `state-delta`
+- `state-snapshot`
+- `step`
+- `raw`
+- `custom`
+- `event`
+- `error`
+
+### 6.3 父子关系规则
+
+- 同一 `runId` 建立 `turn` 根节点
+- `TEXT_MESSAGE_*` 聚合为 `text` 节点
+- `TOOL_CALL_*` 聚合为 `tool-call` 节点，优先挂到最近 assistant 消息下
+- `TOOL_CALL_RESULT` 挂到对应 `tool-call`
+- `STEP_*` 生成 `step` + `reasoning`
+- `STATE_*`、`ACTIVITY_*`、`RAW`、`CUSTOM` 默认挂到 `turn`
+- `ne.a2ui.link` 可显式重定父子关系
+
+### 6.4 组件支持矩阵
+
+| 节点类型 | 主聊天区 | 嵌套 | 首期状态 |
+| --- | --- | --- | --- |
+| `text` | 是 | 是 | 已实现 |
+| `tool-call` | 是 | 是 | 已实现 |
+| `tool-result` | 是 | 是 | 已实现 |
+| `activity` | 是 | 是 | 已实现 |
+| `reasoning` | 是 | 是 | 已实现 |
+| `step` | 是 | 是 | 已实现 |
+| `state-delta` | 是 | 是 | 已实现 |
+| `state-snapshot` | 是 | 是 | 已实现 |
+| `raw` | 是 | 是 | 已实现 |
+| `custom` | 是 | 是 | 已实现 |
+| `event` | 是 | 是 | 已实现 |
+| `error` | 是 | 是 | 已实现 |
+
+## 7. 类图
+
+```mermaid
+classDiagram
+  class ConversationNode {
+    +id
+    +type
+    +parentId
+    +children[]
+    +threadId
+    +runId
+    +messageId
+    +toolCallId
+    +timeRange
+    +payload
+  }
+
+  class ConversationTree {
+    +roots[]
+    +nodeIndex
+    +messageNodeIndex
+    +toolNodeIndex
+  }
+
+  class ConversationNodeRenderer
+  class MessageBubble
+
+  ConversationTree --> ConversationNode
+  ConversationNodeRenderer --> ConversationNode
+  ConversationNodeRenderer --> MessageBubble
+```
+
+## 8. 实施进度
+
+| 事项 | 状态 | 文件锚点 | 验证证据 | 风险 |
+| --- | --- | --- | --- | --- |
+| A2UI 文档建档 | 已完成 | [a2ui.md](./a2ui.md) | 文档已创建 | 后续需持续维护 |
+| 新增节点类型 | 已完成 | [a2ui.ts](../apps/negentropy-ui/types/a2ui.ts) | 类型已落地 | 仍需随协议演进补字段 |
+| 事件到树构建器 | 已完成 | [conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts) | 可处理文本/工具/状态/步骤 | 复杂链路仍需更多用例覆盖 |
+| Chat 树形渲染 | 已完成 | [ChatStream.tsx](../apps/negentropy-ui/components/ui/ChatStream.tsx) | 主区已切换为递归节点渲染 | 视觉细节仍可继续打磨 |
+| A2UI 自定义关联事件 | 已完成 | [adk.ts](../apps/negentropy-ui/lib/adk.ts) | 已注入 `ne.a2ui.link` / `ne.a2ui.reasoning` | 上游若提供原生父子关系，可进一步收敛 |
+| 单元测试补齐 | 进行中 | [tests/unit](../apps/negentropy-ui/tests/unit) | 待依赖安装后完整复验 | 当前本地缺少前端依赖 |
+
+## 9. 最佳实践
+
+- 始终保留原始事件流，节点树只作为派生读模型
+- 父子关系优先显式链路，缺失时再推断
+- 不暴露私有推理原文，仅渲染安全摘要或阶段状态
+- 主聊天区负责“交互结构”，右侧面板负责“观测镜像”
+- 新类型先走 `custom` 回退，再决定是否升级为正式组件
+
+## 10. 后续建议
+
+- 补正式组件注册表，支持插件化节点渲染
+- 为 `ne.a2ui.activity-meta` 增加更丰富的活动语义
+- 给技术节点增加折叠态与过滤器
+- 为历史会话回放增加树差异比对测试
+
+## 11. 参考文献
+
+<a id="ref1"></a>[1] AG-UI Docs, "Events," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/concepts/events
+
+<a id="ref2"></a>[2] AG-UI Docs, "Serialization," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/concepts/serialization
+
+<a id="ref3"></a>[3] AG-UI Docs, "Generative User Interfaces," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/draft-proposals/generative-user-interfaces
+
+<a id="ref4"></a>[4] A2UI, "A2UI Specification," *A2UI*, 2026. [Online]. Available: https://a2ui.org/specification
+
+<a id="ref5"></a>[5] A2UI, "A2UI Message Types," *A2UI*, 2026. [Online]. Available: https://a2ui.org/message-types
+
+<a id="ref6"></a>[6] P. Bryan, Ed., "JavaScript Object Notation (JSON) Pointer," RFC 6901, Apr. 2013.
+
+<a id="ref7"></a>[7] P. Bryan and M. Nottingham, "JavaScript Object Notation (JSON) Patch," RFC 6902, Apr. 2013.


### PR DESCRIPTION
## 变更内容

本 PR 在 Chat 页落地 A2UI 风格的消息树与递归事件渲染能力，并同步补充 A2UI 调研文档与测试覆盖。

具体包括：

- 新增 [`docs/a2ui.md`](./docs/a2ui.md)，集中维护 A2UI 协议调研、设计模式、项目实施方案与进度
- 新增 A2UI 节点类型定义与会话树构建器：
  - [`apps/negentropy-ui/types/a2ui.ts`](./apps/negentropy-ui/types/a2ui.ts)
  - [`apps/negentropy-ui/utils/conversation-tree.ts`](./apps/negentropy-ui/utils/conversation-tree.ts)
- 重构 Chat 主区渲染链路，将原来的线性消息展示升级为基于节点树的递归渲染：
  - [`apps/negentropy-ui/app/page.tsx`](./apps/negentropy-ui/app/page.tsx)
  - [`apps/negentropy-ui/components/ui/ChatStream.tsx`](./apps/negentropy-ui/components/ui/ChatStream.tsx)
  - [`apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx`](./apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx)
- 增强 AG-UI 到 UI 的适配逻辑，在 [`apps/negentropy-ui/lib/adk.ts`](./apps/negentropy-ui/lib/adk.ts) 中补充更适合 A2UI 消息树消费的关联事件
- 更新单元测试，覆盖聊天树渲染与会话树构建逻辑：
  - [`apps/negentropy-ui/tests/unit/ChatStream.test.tsx`](./apps/negentropy-ui/tests/unit/ChatStream.test.tsx)
  - [`apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts`](./apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts)

## 变更动机

本次改动来自 Chat 页的明确交互目标：

- 用户发送消息后，NE 的回复不能再只以扁平文本流展示
- 需要以“每一个完整消息体 / 每一个完整 AG-UI 事件模块”为单位在对话区中呈现
- 需要支持父子消息体（或父子 AG-UI 事件）的嵌套渲染
- 需要支持更多 A2UI 组件与更清晰的渲染效果

换句话说，这次改动的核心不是单纯“美化聊天框”，而是把现有 AG-UI 事件流升级为更适合复杂 Agent 交互的 A2UI 视图模型，让文本、工具、活动、推理、状态等内容能够以结构化方式进入主聊天区。

## 关键实现细节

### 1. 保持 AG-UI 传输层不变，引入 A2UI 语义层

本次没有替换现有 AG-UI 链路，而是在其上新增 A2UI 风格的节点树建模与渲染层。这样可以控制爆炸半径，并复用当前的事件流基础设施。

### 2. 使用会话树读模型承接原始事件流

新增 `conversation-tree` 构建器，将原始事件与 fallback 消息重建为统一的节点树。这样可以稳定表达以下层级关系：

- turn
- text
- tool-call
- tool-result
- activity
- reasoning
- state-delta / state-snapshot
- raw / custom / error

### 3. Chat 主区切换为递归渲染

`ChatStream` 不再只消费平铺消息数组，而是改为消费节点树，并通过递归渲染器展示父子消息和父子事件模块。这使得 assistant 文本、工具调用、工具结果、活动和状态能够在主对话区中形成可追踪的结构。

### 4. 为后续扩展预留了 A2UI 适配点

在 `adk.ts` 中补充了更适合树构建消费的关联事件，便于后续继续扩展更多 A2UI 组件，而不必反复重写 Chat 主链路。

## 验证

已补充对应单元测试，覆盖：

- Chat 树形渲染
- 会话树构建与父子关系重建

This PR was written using [Vibe Kanban](https://vibekanban.com)
