### PR TITLE
fix(Knowledge Base): 增加 Retrieved Trunks 检索态回收入口 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -463,6 +463,14 @@ export default function KnowledgeBasePage() {
     }
   }, [viewMode, corpusTab, selectedCorpusId, selectedDocumentId, loadDocumentChunks]);
 
+  const resetRetrievalView = useCallback(() => {
+    setRetrievalResults([]);
+    setRetrievalError(null);
+    setRetrievalDocked(false);
+    setIsCorpusPanelExpanded(false);
+    setSelectedRetrievedChunk(null);
+  }, []);
+
   const handleRetrieve = async () => {
     const corpusIds = selectedRetrievalCorpusIds;
     if (!query.trim() || corpusIds.length === 0) return;
@@ -670,18 +678,29 @@ export default function KnowledgeBasePage() {
 
   const renderRetrievalModule = () => (
     <div className="rounded-2xl border border-border bg-card p-4 shadow-sm">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h2 className="text-sm font-semibold">Retrieval</h2>
-        <div className="flex items-center gap-1 rounded-full bg-muted/60 p-1 text-xs">
-          {(["semantic", "keyword", "hybrid"] as const).map((item) => (
+        <div className="flex items-center gap-2">
+          {retrievalDocked && (
             <button
-              key={item}
-              onClick={() => setMode(item)}
-              className={`rounded-full px-3 py-1 ${mode === item ? "bg-foreground text-background" : "text-muted hover:text-foreground"}`}
+              type="button"
+              onClick={resetRetrievalView}
+              className="rounded-lg border border-border bg-background px-3 py-1.5 text-xs font-semibold hover:bg-muted"
             >
-              {item}
+              收起结果
             </button>
-          ))}
+          )}
+          <div className="flex items-center gap-1 rounded-full bg-muted/60 p-1 text-xs">
+            {(["semantic", "keyword", "hybrid"] as const).map((item) => (
+              <button
+                key={item}
+                onClick={() => setMode(item)}
+                className={`rounded-full px-3 py-1 ${mode === item ? "bg-foreground text-background" : "text-muted hover:text-foreground"}`}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -529,6 +529,66 @@ describe("KnowledgeBasePage", () => {
     expect(screen.queryByRole("heading", { name: "Corpus" })).not.toBeInTheDocument();
   });
 
+  it("点击收起结果后回到默认布局并保留检索条件", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const corpusCheckbox = screen.getByRole("checkbox", { name: /Corpus Alpha/ });
+    await user.click(corpusCheckbox);
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getByText("1 Retrieved Chunks")).toBeInTheDocument();
+    expect(screen.getByTestId("docked-retrieval-container")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "收起结果" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "收起结果" }));
+
+    expect(screen.queryByTestId("docked-retrieval-container")).not.toBeInTheDocument();
+    expect(screen.queryByText("1 Retrieved Chunks")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Corpus" })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("输入检索内容")).toHaveValue("context engineering");
+    expect(screen.getByRole("checkbox", { name: /Corpus Alpha/ })).toBeChecked();
+    expect(screen.getByRole("button", { name: "hybrid" })).toHaveClass("bg-foreground");
+  });
+
+  it("点击收起结果会关闭已打开的检索结果模态框", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("checkbox"));
+    await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
+    await user.click(screen.getByRole("button", { name: "Retrieve" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByText("Open"));
+    expect(screen.getByRole("dialog", { name: "Chunk Detail" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "收起结果" }));
+
+    expect(screen.queryByRole("dialog", { name: "Chunk Detail" })).not.toBeInTheDocument();
+    expect(screen.queryByText("1 Retrieved Chunks")).not.toBeInTheDocument();
+  });
+
   it("点击检索结果会打开居中 Chunk Detail 模态框，并可通过遮罩关闭", async () => {
     const user = userEvent.setup();
     searchParamsState.value = "view=overview";


### PR DESCRIPTION
## 变更内容

本 PR 为 `Knowledge Base` 页面中的检索结果展开态补充了显式回收能力，主要包括：

- 在 `Retrieval` 模块头部增加“收起结果”操作入口
- 引入统一的检索态重置逻辑，用于退出 `Retrieved Trunks` 展开态
- 在退出检索态时恢复默认页面布局，同时保留 query、检索模式与已选 Corpus
- 在退出检索态时同步关闭已打开的检索结果详情模态框
- 补充 `KnowledgeBasePage` 单测，覆盖检索态回收后的关键行为

## 变更原因

当前 `Knowledge Base` 页面在点击 `Retrieve` 进入 `Retrieved Trunks` 展开态后，用户只能继续留在 docked 检索布局中，缺少一个明确、低成本的回退入口，无法直接回到检索前的默认页面状态。

本次改动旨在补齐这条逆向交互路径，使检索体验满足“可进入、可退出、可继续微调再检索”的基本闭环，降低页面状态切换的认知负担，并避免用户误以为必须刷新页面才能回到默认布局。

## 实现细节

### 页面状态管理

本次在 `apps/negentropy-ui/app/knowledge/base/page.tsx` 中新增统一的检索态 reset handler，用单一入口回收以下状态：

- `retrievalResults`
- `retrievalError`
- `retrievalDocked`
- `isCorpusPanelExpanded`
- `selectedRetrievedChunk`

这样可以避免退出检索态时出现状态残留，符合单一事实源与最小干预原则。

### 交互行为

“收起结果”按钮放置在 `Retrieval` 模块头部，并且仅在检索结果已进入 docked 状态时显示。点击后：

- 页面恢复为默认 `overview` 布局
- `Retrieved Trunks` 列表消失
- 底部 docked Retrieval 容器消失
- 默认位置的 Retrieval 模块与 Corpus 列表重新可见
- 当前 query、mode、已选 Corpus 保持不变，便于用户继续微调后再次检索

### 测试覆盖

本次补充的前端单测重点验证：

- 点击“收起结果”后页面恢复默认布局
- 检索输入与已选 Corpus 在回收后仍被保留
- 若已打开 `Chunk Detail` 模态框，回收检索态时会同步关闭模态框

## 验证说明

PR 中已包含对应单测补充。当前实现面向的关键风险点主要是：

- 检索态回收不完整导致 UI 残留
- 页面恢复默认布局时丢失检索上下文
- 检索结果详情模态框在回收后悬挂显示

本次实现已针对这些风险点补充明确断言。

This PR was written using [Vibe Kanban](https://vibekanban.com)
