### PR TITLE
fix(Chat): 收敛 A2UI 消息排序与技术事件渲染 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -222,8 +222,19 @@ export async function POST(request: Request) {
                   normalizeAguiEvent({
                     ...event,
                     threadId:
-                      "threadId" in event ? event.threadId : resolvedThreadId,
-                    runId: "runId" in event ? event.runId : resolvedRunId,
+                      "threadId" in event &&
+                      typeof event.threadId === "string" &&
+                      event.threadId.trim() &&
+                      event.threadId !== "default"
+                        ? event.threadId
+                        : resolvedThreadId,
+                    runId:
+                      "runId" in event &&
+                      typeof event.runId === "string" &&
+                      event.runId.trim() &&
+                      event.runId !== "default"
+                        ? event.runId
+                        : resolvedRunId,
                   }),
                 );
                 for (const event of events) {

--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -17,6 +17,7 @@ export function ChatStream({
 }: ChatStreamProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isUserAtBottomRef = useRef(true);
+  const visibleNodes = nodes.filter((node) => node.visibility !== "debug-only");
 
   const onScroll = () => {
     if (!scrollRef.current) return;
@@ -29,7 +30,7 @@ export function ChatStream({
     if (isUserAtBottomRef.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [nodes]);
+  }, [visibleNodes]);
 
   return (
     <div
@@ -40,12 +41,12 @@ export function ChatStream({
       <div
         className={`mx-auto w-full space-y-4 px-6 py-6 ${contentClassName ?? ""}`}
       >
-        {nodes.length === 0 ? (
+        {visibleNodes.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">
             发送指令开始对话。主区将以 A2UI 模块树实时展示消息、工具、活动与状态。
           </div>
         ) : (
-          nodes.map((node) => (
+          visibleNodes.map((node) => (
             <ConversationNodeRenderer
               key={node.id}
               node={node}

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useState } from "react";
 import { JsonViewer } from "@/components/ui/JsonViewer";
 import { MessageBubble } from "@/components/ui/MessageBubble";
 import type { ChatMessage } from "@/types/common";
 import type { ConversationNode } from "@/types/a2ui";
+import { buildNodeSummary, safeJsonParse } from "@/utils/conversation-summary";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -39,6 +40,14 @@ function DepthRail({ depth }: { depth: number }) {
   );
 }
 
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <div className="max-h-64 overflow-auto rounded-xl border border-zinc-200/70 bg-zinc-50 p-2 text-xs dark:border-zinc-800 dark:bg-zinc-950/70">
+      <JsonViewer data={value} />
+    </div>
+  );
+}
+
 function NodeCard({
   node,
   selected,
@@ -69,10 +78,47 @@ function NodeCard({
   );
 }
 
-function JsonBlock({ value }: { value: unknown }) {
+function SummaryLines({ lines }: { lines: string[] }) {
+  if (lines.length === 0) {
+    return (
+      <div className="text-sm text-zinc-500 dark:text-zinc-400">
+        暂无可展示摘要
+      </div>
+    );
+  }
   return (
-    <div className="max-h-64 overflow-auto rounded-xl border border-zinc-200/70 bg-zinc-50 p-2 text-xs dark:border-zinc-800 dark:bg-zinc-950/70">
-      <JsonViewer data={value} />
+    <div className="space-y-1">
+      {lines.map((line) => (
+        <div key={line} className="text-sm text-zinc-700 dark:text-zinc-300">
+          {line}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ExpandableDetails({
+  label,
+  value,
+}: {
+  label: string;
+  value: unknown;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="mt-3 space-y-2">
+      <button
+        type="button"
+        className="text-xs font-medium text-zinc-500 underline-offset-2 hover:text-zinc-700 hover:underline dark:text-zinc-400 dark:hover:text-zinc-200"
+        onClick={(event) => {
+          event.stopPropagation();
+          setExpanded((current) => !current);
+        }}
+      >
+        {expanded ? `收起${label}` : `展开${label}`}
+      </button>
+      {expanded ? <JsonBlock value={value} /> : null}
     </div>
   );
 }
@@ -86,18 +132,46 @@ function TextNode({
   selected: boolean;
   onSelect?: (nodeId: string) => void;
 }) {
-  const message = useMemo<ChatMessage>(
-    () => ({
-      id: node.id,
-      role: node.role === "user" ? "user" : node.role === "system" ? "system" : "assistant",
-      content: String(node.payload.content || ""),
-      author:
-        typeof node.payload.author === "string" ? String(node.payload.author) : undefined,
-      timestamp: node.timestamp,
-      runId: node.runId,
-    }),
-    [node],
-  );
+  const parsedContent = safeJsonParse(node.payload.content);
+  const shouldRenderAsJson =
+    parsedContent !== null &&
+    typeof parsedContent === "object" &&
+    !Array.isArray(parsedContent);
+
+  const message: ChatMessage = {
+    id: node.id,
+    role:
+      node.role === "user"
+        ? "user"
+        : node.role === "system"
+          ? "system"
+          : "assistant",
+    content: String(node.payload.content || ""),
+    author:
+      typeof node.payload.author === "string"
+        ? String(node.payload.author)
+        : undefined,
+    timestamp: node.timestamp,
+    runId: node.runId,
+  };
+
+  if (shouldRenderAsJson) {
+    const summary = buildNodeSummary({
+      ...node,
+      type: "custom",
+      payload: {
+        data: parsedContent,
+        eventType: "json.message",
+      },
+    });
+
+    return (
+      <NodeCard node={node} selected={selected} onClick={() => onSelect?.(node.id)}>
+        <SummaryLines lines={summary} />
+        <ExpandableDetails label="JSON 详情" value={parsedContent} />
+      </NodeCard>
+    );
+  }
 
   return (
     <MessageBubble
@@ -117,7 +191,8 @@ function TurnNode({
   selected: boolean;
   onSelect?: (nodeId: string) => void;
 }) {
-  const childCount = node.children.length;
+  const childCount = node.children.filter((child) => child.visibility !== "debug-only")
+    .length;
   return (
     <div
       className={cn(
@@ -156,81 +231,41 @@ function TechnicalNode({
   selected: boolean;
   onSelect?: (nodeId: string) => void;
 }) {
-  const content = (() => {
+  const summary = buildNodeSummary(node);
+  const detailValue = (() => {
     switch (node.type) {
       case "tool-call":
-        return (
-          <div className="space-y-2">
-            <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-              {String(node.payload.toolCallName || node.title)}
-            </div>
-            <JsonBlock value={node.payload.args ? safeJson(node.payload.args) : {}} />
-          </div>
-        );
+        return safeJsonParse(node.payload.args);
       case "tool-result":
-        return <JsonBlock value={safeJson(node.payload.content)} />;
+        return safeJsonParse(node.payload.content);
       case "activity":
-        return <JsonBlock value={node.payload.content} />;
-      case "reasoning":
-        return (
-          <div className="text-sm text-zinc-700 dark:text-zinc-300">
-            {node.summary || "推理阶段更新"}
-          </div>
-        );
-      case "step":
-        return (
-          <div className="space-y-2 text-sm text-zinc-700 dark:text-zinc-300">
-            <div>{node.status === "done" ? "步骤已完成" : "步骤执行中"}</div>
-            {"result" in node.payload && node.payload.result !== undefined ? (
-              <JsonBlock value={node.payload.result} />
-            ) : null}
-          </div>
-        );
+        return node.payload.content;
       case "state-delta":
-        return <JsonBlock value={node.payload.delta} />;
+        return node.payload.delta;
       case "state-snapshot":
-        return <JsonBlock value={node.payload.snapshot} />;
+        return node.payload.snapshot;
       case "raw":
-        return <JsonBlock value={node.payload.data} />;
+        return node.payload.data;
       case "custom":
-        return <JsonBlock value={node.payload.data} />;
-      case "error":
-        return (
-          <div className="space-y-1 text-sm text-red-700 dark:text-red-300">
-            <div>{String(node.payload.message || "未知错误")}</div>
-            {node.payload.code ? (
-              <div className="text-xs uppercase tracking-wider text-red-500">
-                {String(node.payload.code)}
-              </div>
-            ) : null}
-          </div>
-        );
+        return node.payload.data;
       default:
-        return <JsonBlock value={node.payload} />;
+        return node.payload;
     }
   })();
 
   return (
     <NodeCard node={node} selected={selected} onClick={() => onSelect?.(node.id)}>
-      {content}
+      <SummaryLines lines={summary} />
+      {node.type === "error" ? null : (
+        <ExpandableDetails label="详情" value={detailValue} />
+      )}
       {node.children.length > 0 ? (
         <div className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
-          {node.children.length} 个子模块
+          {node.children.filter((child) => child.visibility !== "debug-only").length} 个子模块
         </div>
       ) : null}
     </NodeCard>
   );
-}
-
-function safeJson(value: unknown): unknown {
-  if (typeof value !== "string") {
-    return value;
-  }
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
 }
 
 export function ConversationNodeRenderer({
@@ -239,7 +274,12 @@ export function ConversationNodeRenderer({
   selectedNodeId,
   onNodeSelect,
 }: Props) {
+  if (node.visibility === "debug-only") {
+    return null;
+  }
+
   const selected = node.id === selectedNodeId;
+  const visibleChildren = node.children.filter((child) => child.visibility !== "debug-only");
   const content = (() => {
     if (node.type === "turn") {
       return <TurnNode node={node} selected={selected} onSelect={onNodeSelect} />;
@@ -255,22 +295,9 @@ export function ConversationNodeRenderer({
       <DepthRail depth={depth} />
       <div style={{ marginLeft: `${depth * 18}px` }}>
         {content}
-        {node.type !== "turn" && node.children.length > 0 ? (
+        {visibleChildren.length > 0 ? (
           <div className="mt-3 space-y-3">
-            {node.children.map((child) => (
-              <ConversationNodeRenderer
-                key={child.id}
-                node={child}
-                depth={depth + 1}
-                selectedNodeId={selectedNodeId}
-                onNodeSelect={onNodeSelect}
-              />
-            ))}
-          </div>
-        ) : null}
-        {node.type === "turn" && node.children.length > 0 ? (
-          <div className="mt-4 space-y-3">
-            {node.children.map((child) => (
+            {visibleChildren.map((child) => (
               <ConversationNodeRenderer
                 key={child.id}
                 node={child}

--- a/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
@@ -37,6 +37,8 @@ describe("ChatStream", () => {
                 timestamp: 1002,
                 timeRange: { start: 1002, end: 1002 },
                 title: "search",
+                visibility: "chat",
+                isStructural: false,
                 payload: { args: "{\"q\":\"hello\"}", toolCallName: "search" },
                 sourceEventTypes: ["tool_call_start"],
                 relatedMessageIds: ["msg-1"],
@@ -49,6 +51,8 @@ describe("ChatStream", () => {
             timeRange: { start: 1001, end: 1001 },
             title: "助手消息",
             role: "assistant",
+            visibility: "chat",
+            isStructural: false,
             payload: { content: "你好" },
             sourceEventTypes: ["text_message_start"],
             relatedMessageIds: ["msg-1"],
@@ -59,6 +63,8 @@ describe("ChatStream", () => {
         timestamp: 1000,
         timeRange: { start: 1000, end: 1003 },
         title: "轮次 run-1",
+        visibility: "chat",
+        isStructural: false,
         payload: {},
         sourceEventTypes: ["run_started"],
         relatedMessageIds: [],
@@ -70,5 +76,48 @@ describe("ChatStream", () => {
     expect(screen.getByText("轮次 run-1")).toBeInTheDocument();
     expect(screen.getByText((content) => content.includes("你好"))).toBeInTheDocument();
     expect(screen.getAllByText("search").length).toBeGreaterThan(0);
+  });
+
+  it("不渲染 debug-only 根节点，并将技术节点折叠为摘要卡片", () => {
+    const nodes: ConversationNode[] = [
+      {
+        id: "raw:1",
+        type: "raw",
+        parentId: null,
+        children: [],
+        threadId: "thread-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1000 },
+        title: "原始事件",
+        visibility: "debug-only",
+        isStructural: false,
+        payload: { data: { ignored: true } },
+        sourceEventTypes: ["raw"],
+        relatedMessageIds: [],
+      },
+      {
+        id: "activity:1",
+        type: "activity",
+        parentId: null,
+        children: [],
+        threadId: "thread-1",
+        timestamp: 1001,
+        timeRange: { start: 1001, end: 1001 },
+        title: "LOG_ACTIVITY",
+        visibility: "collapsed",
+        isStructural: false,
+        payload: { content: { status: "ok", message: "已记录" } },
+        sourceEventTypes: ["activity_snapshot"],
+        relatedMessageIds: [],
+      },
+    ];
+
+    render(<ChatStream nodes={nodes} />);
+
+    expect(screen.queryByText("原始事件")).not.toBeInTheDocument();
+    expect(screen.getByText("LOG_ACTIVITY")).toBeInTheDocument();
+    expect(screen.getByText("状态: ok")).toBeInTheDocument();
+    expect(screen.queryByText(/ignored/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "展开详情" })).toBeInTheDocument();
   });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -80,4 +80,90 @@ describe("buildConversationTree", () => {
     expect(tree.roots[0].type).toBe("text");
     expect(tree.roots[0].payload.content).toBe("hello");
   });
+
+  it("忽略结构性 link 事件并把 fallback 用户消息挂到当前轮次顶部", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "default",
+        messageId: "msg-1",
+        role: "assistant",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "default",
+        messageId: "msg-1",
+        delta: "结果",
+        timestamp: 1002,
+      } as BaseEvent,
+      {
+        type: EventType.CUSTOM,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1003,
+        eventType: "ne.a2ui.link",
+        data: { childId: "message:msg-1", parentId: "turn:run-1" },
+      } as BaseEvent,
+    ];
+    const fallbackMessages: Message[] = [
+      {
+        id: "msg-user",
+        role: "user",
+        content: "hello",
+        createdAt: new Date(999 * 1000),
+      } as Message,
+    ];
+
+    const tree = buildConversationTree({ events, fallbackMessages });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].type).toBe("turn");
+    expect(tree.roots[0].children.map((child) => child.type)).toEqual(["text", "text"]);
+    expect(tree.roots[0].children[0].role).toBe("user");
+    expect(tree.roots[0].children[1].role).toBe("assistant");
+    expect(
+      tree.roots[0].children.some(
+        (child) =>
+          child.type === "custom" &&
+          String(child.payload.eventType || "") === "ne.a2ui.link",
+      ),
+    ).toBe(false);
+  });
+
+  it("裁剪无内容的空文本节点", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        role: "assistant",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        timestamp: 1002,
+      } as BaseEvent,
+    ];
+
+    const tree = buildConversationTree({ events });
+    expect(tree.roots).toHaveLength(0);
+  });
 });

--- a/apps/negentropy-ui/types/a2ui.ts
+++ b/apps/negentropy-ui/types/a2ui.ts
@@ -35,6 +35,8 @@ export interface ConversationNode {
   status?: string;
   role?: "user" | "assistant" | "system";
   summary?: string;
+  visibility: "chat" | "collapsed" | "debug-only";
+  isStructural?: boolean;
   payload: Record<string, unknown>;
   sourceEventTypes: string[];
   relatedMessageIds: string[];

--- a/apps/negentropy-ui/utils/conversation-summary.ts
+++ b/apps/negentropy-ui/utils/conversation-summary.ts
@@ -1,0 +1,179 @@
+import type { ConversationNode } from "@/types/a2ui";
+
+export function safeJsonParse(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isNodePayloadEmpty(node: ConversationNode): boolean {
+  switch (node.type) {
+    case "text":
+      return String(node.payload.content || "").trim().length === 0;
+    case "tool-call":
+      return (
+        String(node.payload.toolCallName || node.title || "").trim().length === 0 &&
+        String(node.payload.args || "").trim().length === 0
+      );
+    case "tool-result": {
+      const content = safeJsonParse(node.payload.content);
+      if (typeof content === "string") {
+        return content.trim().length === 0;
+      }
+      if (Array.isArray(content)) {
+        return content.length === 0;
+      }
+      if (isPlainObject(content)) {
+        return Object.keys(content).length === 0;
+      }
+      return content == null;
+    }
+    case "activity":
+    case "raw":
+    case "custom": {
+      const payload =
+        node.type === "activity"
+          ? node.payload.content
+          : node.type === "raw"
+            ? node.payload.data
+            : node.payload.data;
+      const value = safeJsonParse(payload);
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      }
+      if (isPlainObject(value)) {
+        return Object.keys(value).length === 0;
+      }
+      return value == null || String(value).trim().length === 0;
+    }
+    case "state-delta":
+      return Array.isArray(node.payload.delta)
+        ? node.payload.delta.length === 0
+        : isPlainObject(node.payload.delta)
+          ? Object.keys(node.payload.delta).length === 0
+          : true;
+    case "state-snapshot":
+      return isPlainObject(node.payload.snapshot)
+        ? Object.keys(node.payload.snapshot).length === 0
+        : true;
+    default:
+      return false;
+  }
+}
+
+export function classifyNodeVisibility(
+  node: ConversationNode,
+): "chat" | "collapsed" | "debug-only" {
+  if (node.type === "turn" || node.type === "text" || node.type === "tool-call" || node.type === "tool-result") {
+    return "chat";
+  }
+  if (node.type === "custom") {
+    const eventType = String(node.payload.eventType || "");
+    if (eventType === "ne.a2ui.link") {
+      return "debug-only";
+    }
+    if (eventType === "ne.a2ui.reasoning") {
+      return "debug-only";
+    }
+  }
+  if (node.type === "raw") {
+    return "debug-only";
+  }
+  if (isNodePayloadEmpty(node)) {
+    return "debug-only";
+  }
+  if (
+    node.type === "activity" ||
+    node.type === "reasoning" ||
+    node.type === "step" ||
+    node.type === "state-delta" ||
+    node.type === "state-snapshot" ||
+    node.type === "custom" ||
+    node.type === "error" ||
+    node.type === "event"
+  ) {
+    return "collapsed";
+  }
+  return "chat";
+}
+
+export function buildNodeSummary(node: ConversationNode): string[] {
+  const lines: string[] = [];
+
+  if (node.type === "tool-call") {
+    const parsed = safeJsonParse(node.payload.args);
+    if (isPlainObject(parsed)) {
+      const keys = Object.keys(parsed).slice(0, 3);
+      if (keys.length > 0) {
+        lines.push(`参数 ${keys.join("、")}`);
+      }
+    } else if (typeof parsed === "string" && parsed.trim()) {
+      lines.push(parsed.trim().slice(0, 120));
+    }
+  }
+
+  if (node.type === "tool-result" || node.type === "activity") {
+    const parsed = safeJsonParse(
+      node.type === "tool-result" ? node.payload.content : node.payload.content,
+    );
+    if (isPlainObject(parsed)) {
+      const status = parsed.status;
+      const message = parsed.message;
+      const record = isPlainObject(parsed.record) ? parsed.record : null;
+      const activity = record?.activity;
+      if (typeof status === "string") lines.push(`状态: ${status}`);
+      if (typeof activity === "string") lines.push(activity);
+      if (typeof message === "string") lines.push(message);
+      if (lines.length === 0) {
+        lines.push(`${Object.keys(parsed).length} 个字段`);
+      }
+    } else if (typeof parsed === "string" && parsed.trim()) {
+      lines.push(parsed.trim().slice(0, 160));
+    }
+  }
+
+  if (node.type === "state-delta") {
+    const delta = node.payload.delta;
+    if (Array.isArray(delta)) {
+      lines.push(`${delta.length} 个变更操作`);
+    } else if (isPlainObject(delta)) {
+      lines.push(`${Object.keys(delta).length} 个状态字段`);
+    }
+  }
+
+  if (node.type === "state-snapshot" && isPlainObject(node.payload.snapshot)) {
+    lines.push(`${Object.keys(node.payload.snapshot).length} 个状态字段`);
+  }
+
+  if (node.type === "reasoning" || node.type === "step") {
+    if (node.summary) {
+      lines.push(node.summary);
+    } else if (typeof node.payload.phase === "string") {
+      lines.push(`阶段: ${node.payload.phase}`);
+    }
+  }
+
+  if (node.type === "custom") {
+    const eventType = String(node.payload.eventType || node.title || "custom");
+    lines.push(eventType);
+    const data = safeJsonParse(node.payload.data);
+    if (isPlainObject(data)) {
+      lines.push(`${Object.keys(data).length} 个字段`);
+    }
+  }
+
+  if (node.type === "error" && typeof node.payload.message === "string") {
+    lines.push(node.payload.message);
+  }
+
+  return lines.slice(0, 3);
+}

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -5,6 +5,11 @@ import type {
   ConversationNodeType,
   ConversationTree,
 } from "@/types/a2ui";
+import {
+  buildNodeSummary,
+  classifyNodeVisibility,
+  isNodePayloadEmpty,
+} from "@/utils/conversation-summary";
 
 type MutableNode = ConversationNode;
 
@@ -20,6 +25,13 @@ type CustomPayload = {
 
 const DEFAULT_THREAD_ID = "default";
 const DEFAULT_RUN_ID = "default";
+
+function normalizeRunId(value: string | undefined, fallbackRunId?: string): string {
+  if (!value || value === DEFAULT_RUN_ID) {
+    return fallbackRunId || DEFAULT_RUN_ID;
+  }
+  return value;
+}
 
 function normalizeRole(value: unknown): "user" | "assistant" | "system" {
   if (value === "user") return "user";
@@ -66,6 +78,8 @@ function createNode(input: {
     status: input.status,
     role: input.role,
     summary: input.summary,
+    visibility: "chat",
+    isStructural: false,
     payload: input.payload || {},
     sourceEventTypes: input.sourceEventTypes || [],
     relatedMessageIds: input.relatedMessageIds || [],
@@ -104,11 +118,14 @@ function ensureTurn(
   turns: Map<string, MutableNode>,
   roots: MutableNode[],
   event: BaseEvent,
+  fallbackRunId?: string,
 ): MutableNode {
-  const runId =
+  const runId = normalizeRunId(
     "runId" in event && typeof event.runId === "string"
       ? event.runId
-      : DEFAULT_RUN_ID;
+      : undefined,
+    fallbackRunId,
+  );
   const existing = turns.get(runId);
   if (existing) {
     mergeEventMeta(existing, event);
@@ -203,14 +220,20 @@ function upsertNode(
 function attachNode(
   nodeIndex: Map<string, MutableNode>,
   roots: MutableNode[],
+  turns: Map<string, MutableNode>,
   childId: string,
   parentId: string | null,
 ) {
   const child = nodeIndex.get(childId);
   if (!child) return;
 
-  if (child.parentId && nodeIndex.has(child.parentId)) {
-    removeChild(nodeIndex.get(child.parentId)!, childId);
+  if (child.parentId) {
+    const previousParent =
+      nodeIndex.get(child.parentId) ||
+      turns.get(child.parentId.replace(/^turn:/, ""));
+    if (previousParent) {
+      removeChild(previousParent, childId);
+    }
   } else if (!child.parentId) {
     const rootIndex = roots.findIndex((node) => node.id === childId);
     if (rootIndex >= 0) {
@@ -223,7 +246,7 @@ function attachNode(
     roots.push(child);
     return;
   }
-  const parent = nodeIndex.get(parentId);
+  const parent = nodeIndex.get(parentId) || turns.get(parentId.replace(/^turn:/, ""));
   if (parent) {
     addChild(parent, child);
   } else {
@@ -236,6 +259,15 @@ function chooseParentMessageId(
   runId: string,
 ): string | null {
   return assistantByRun.get(runId) || null;
+}
+
+function getLatestTurn(turns: Map<string, MutableNode>): MutableNode | null {
+  const values = [...turns.values()];
+  if (values.length === 0) {
+    return null;
+  }
+  values.sort((a, b) => b.timeRange.start - a.timeRange.start);
+  return values[0] || null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -253,6 +285,75 @@ function getMessageTimestamp(message: Message): number {
   return createdAt instanceof Date ? createdAt.getTime() / 1000 : Date.now() / 1000;
 }
 
+function pruneNode(node: MutableNode): MutableNode | null {
+  node.children = node.children
+    .map((child) => pruneNode(child))
+    .filter((child): child is MutableNode => child !== null);
+
+  const summaryLines = buildNodeSummary(node);
+  node.summary = node.summary || summaryLines.join(" · ");
+  node.visibility = classifyNodeVisibility(node);
+  node.isStructural =
+    node.type === "custom" && String(node.payload.eventType || "") === "ne.a2ui.link";
+
+  const isEmptyTextNode =
+    node.type === "text" &&
+    String(node.payload.content || "").trim().length === 0 &&
+    node.children.length === 0;
+  const isEmptyNode =
+    node.type !== "turn" &&
+    node.type !== "text" &&
+    isNodePayloadEmpty(node) &&
+    node.children.length === 0;
+
+  if (node.type === "turn" && node.children.length === 0) {
+    return null;
+  }
+  if (node.visibility === "debug-only" && node.children.length === 0) {
+    return null;
+  }
+  if (isEmptyTextNode || isEmptyNode) {
+    return null;
+  }
+
+  return node;
+}
+
+function sortNodeChildren(node: MutableNode) {
+  const typeOrder: Record<ConversationNodeType, number> = {
+    turn: 0,
+    text: 1,
+    "tool-call": 2,
+    "tool-result": 3,
+    activity: 4,
+    reasoning: 5,
+    step: 6,
+    "state-delta": 7,
+    "state-snapshot": 8,
+    custom: 9,
+    raw: 10,
+    event: 11,
+    error: 12,
+  };
+
+  node.children.sort((a, b) => {
+    if (a.type === "text" && b.type === "text" && a.role !== b.role) {
+      return a.role === "user" ? -1 : 1;
+    }
+    const typeDiff = typeOrder[a.type] - typeOrder[b.type];
+    if (typeDiff !== 0) {
+      return typeDiff;
+    }
+    const timeDiff = a.timeRange.start - b.timeRange.start;
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    return a.id.localeCompare(b.id);
+  });
+
+  node.children.forEach(sortNodeChildren);
+}
+
 export function buildConversationTree(
   options: BuildConversationTreeOptions,
 ): ConversationTree {
@@ -264,6 +365,7 @@ export function buildConversationTree(
   const turns = new Map<string, MutableNode>();
   const assistantMessageByRun = new Map<string, string>();
   const pendingLinks: LinkInstruction[] = [];
+  let activeRunId: string | undefined;
 
   const orderedEvents = [...events].sort((a, b) => {
     const timeDiff = normalizeTimestamp(a.timestamp) - normalizeTimestamp(b.timestamp);
@@ -272,39 +374,53 @@ export function buildConversationTree(
   });
 
   orderedEvents.forEach((event) => {
-    const turn = ensureTurn(turns, roots, event);
+    const normalizedRunId = normalizeRunId(
+      "runId" in event && typeof event.runId === "string"
+        ? event.runId
+        : undefined,
+      activeRunId,
+    );
+    const normalizedEvent = {
+      ...event,
+      runId: normalizedRunId,
+    } as BaseEvent;
+    const turn = ensureTurn(turns, roots, normalizedEvent, activeRunId);
     const runId = turn.runId || DEFAULT_RUN_ID;
     const messageId =
-      "messageId" in event && typeof event.messageId === "string"
-        ? event.messageId
+      "messageId" in normalizedEvent && typeof normalizedEvent.messageId === "string"
+        ? normalizedEvent.messageId
         : undefined;
-    const eventType = String(event.type);
+    const eventType = String(normalizedEvent.type);
 
-    switch (event.type) {
+    switch (normalizedEvent.type) {
       case EventType.RUN_STARTED: {
+        activeRunId = runId;
         turn.status = "running";
         turn.title = `轮次 ${runId.slice(0, 8)}`;
-        mergeEventMeta(turn, event);
+        mergeEventMeta(turn, normalizedEvent);
         return;
       }
       case EventType.RUN_FINISHED: {
         turn.status = "finished";
-        mergeEventMeta(turn, event);
+        mergeEventMeta(turn, normalizedEvent);
+        if (activeRunId === runId) {
+          activeRunId = undefined;
+        }
         return;
       }
       case EventType.RUN_ERROR: {
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `error:${runId}:${normalizeTimestamp(event.timestamp)}`,
+          id: `error:${runId}:${normalizeTimestamp(normalizedEvent.timestamp)}`,
           type: "error",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: "运行错误",
           status: "error",
           payload: {
-            message: "message" in event ? event.message : "",
-            code: "code" in event ? event.code : "",
+            message: "message" in normalizedEvent ? normalizedEvent.message : "",
+            code: "code" in normalizedEvent ? normalizedEvent.code : "",
           },
           sourceEventTypes: [eventType],
         });
@@ -316,8 +432,8 @@ export function buildConversationTree(
       case EventType.TEXT_MESSAGE_END: {
         if (!messageId) return;
         const role =
-          event.type === EventType.TEXT_MESSAGE_START && "role" in event
-            ? normalizeRole(event.role)
+          normalizedEvent.type === EventType.TEXT_MESSAGE_START && "role" in normalizedEvent
+            ? normalizeRole(normalizedEvent.role)
             : undefined;
         const node = upsertNode(nodeIndex, roots, turns, {
           id: `message:${messageId}`,
@@ -326,7 +442,7 @@ export function buildConversationTree(
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: role === "user" ? "用户消息" : "助手消息",
           role,
           payload: {
@@ -335,13 +451,14 @@ export function buildConversationTree(
           sourceEventTypes: [eventType],
           relatedMessageIds: [messageId],
         });
-        mergeEventMeta(node, event);
+        mergeEventMeta(node, normalizedEvent);
         if (role) {
           node.role = role;
           node.title = role === "user" ? "用户消息" : "助手消息";
         }
-        if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
-          const delta = "delta" in event ? String(event.delta || "") : "";
+        if (normalizedEvent.type === EventType.TEXT_MESSAGE_CONTENT) {
+          const delta =
+            "delta" in normalizedEvent ? String(normalizedEvent.delta || "") : "";
           const existing = String(node.payload.content || "");
           node.payload.content =
             delta.length >= existing.length || existing.length === 0
@@ -359,8 +476,8 @@ export function buildConversationTree(
       case EventType.TOOL_CALL_ARGS:
       case EventType.TOOL_CALL_END: {
         const toolCallId =
-          "toolCallId" in event && typeof event.toolCallId === "string"
-            ? event.toolCallId
+          "toolCallId" in normalizedEvent && typeof normalizedEvent.toolCallId === "string"
+            ? normalizedEvent.toolCallId
             : undefined;
         if (!toolCallId) return;
         const parentMessageNodeId = chooseParentMessageId(
@@ -376,15 +493,15 @@ export function buildConversationTree(
           runId,
           messageId,
           toolCallId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title:
-            event.type === EventType.TOOL_CALL_START &&
-            "toolCallName" in event &&
-            typeof event.toolCallName === "string"
-              ? event.toolCallName
+            normalizedEvent.type === EventType.TOOL_CALL_START &&
+            "toolCallName" in normalizedEvent &&
+            typeof normalizedEvent.toolCallName === "string"
+              ? normalizedEvent.toolCallName
               : "工具调用",
           status:
-            event.type === EventType.TOOL_CALL_END ? "done" : "running",
+            normalizedEvent.type === EventType.TOOL_CALL_END ? "done" : "running",
           payload: {
             args: "",
           },
@@ -392,26 +509,26 @@ export function buildConversationTree(
           relatedMessageIds: messageId ? [messageId] : [],
         });
         if (
-          event.type === EventType.TOOL_CALL_START &&
-          "toolCallName" in event &&
-          typeof event.toolCallName === "string"
+          normalizedEvent.type === EventType.TOOL_CALL_START &&
+          "toolCallName" in normalizedEvent &&
+          typeof normalizedEvent.toolCallName === "string"
         ) {
-          node.title = event.toolCallName;
-          node.payload.toolCallName = event.toolCallName;
+          node.title = normalizedEvent.toolCallName;
+          node.payload.toolCallName = normalizedEvent.toolCallName;
         }
-        if (event.type === EventType.TOOL_CALL_ARGS && "delta" in event) {
+        if (normalizedEvent.type === EventType.TOOL_CALL_ARGS && "delta" in normalizedEvent) {
           node.payload.args = `${String(node.payload.args || "")}${String(
-            event.delta || "",
+            normalizedEvent.delta || "",
           )}`;
         }
         toolNodeIndex.set(toolCallId, node.id);
-        attachNode(nodeIndex, roots, node.id, parentId);
+        attachNode(nodeIndex, roots, turns, node.id, parentId);
         return;
       }
       case EventType.TOOL_CALL_RESULT: {
         const toolCallId =
-          "toolCallId" in event && typeof event.toolCallId === "string"
-            ? event.toolCallId
+          "toolCallId" in normalizedEvent && typeof normalizedEvent.toolCallId === "string"
+            ? normalizedEvent.toolCallId
             : undefined;
         if (!toolCallId) return;
         const toolNodeId = toolNodeIndex.get(toolCallId);
@@ -424,33 +541,34 @@ export function buildConversationTree(
           runId,
           messageId,
           toolCallId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: "工具结果",
           status: "completed",
           payload: {
-            content: "content" in event ? event.content : "",
+            content: "content" in normalizedEvent ? normalizedEvent.content : "",
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
         });
-        attachNode(nodeIndex, roots, node.id, parentId);
+        attachNode(nodeIndex, roots, turns, node.id, parentId);
         return;
       }
       case EventType.ACTIVITY_SNAPSHOT: {
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `activity:${runId}:${normalizeTimestamp(event.timestamp)}:${messageId || "none"}`,
+          id: `activity:${runId}:${normalizeTimestamp(normalizedEvent.timestamp)}:${messageId || "none"}`,
           type: "activity",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title:
-            "activityType" in event && typeof event.activityType === "string"
-              ? event.activityType
+            "activityType" in normalizedEvent &&
+            typeof normalizedEvent.activityType === "string"
+              ? normalizedEvent.activityType
               : "活动",
           payload: {
-            content: "content" in event ? event.content : {},
+            content: "content" in normalizedEvent ? normalizedEvent.content : {},
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
@@ -460,16 +578,16 @@ export function buildConversationTree(
       }
       case EventType.STATE_DELTA: {
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `state-delta:${runId}:${normalizeTimestamp(event.timestamp)}:${messageId || "none"}`,
+          id: `state-delta:${runId}:${normalizeTimestamp(normalizedEvent.timestamp)}:${messageId || "none"}`,
           type: "state-delta",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: "状态增量",
           payload: {
-            delta: "delta" in event ? event.delta : [],
+            delta: "delta" in normalizedEvent ? normalizedEvent.delta : [],
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
@@ -479,16 +597,16 @@ export function buildConversationTree(
       }
       case EventType.STATE_SNAPSHOT: {
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `state-snapshot:${runId}:${normalizeTimestamp(event.timestamp)}:${messageId || "none"}`,
+          id: `state-snapshot:${runId}:${normalizeTimestamp(normalizedEvent.timestamp)}:${messageId || "none"}`,
           type: "state-snapshot",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: "状态快照",
           payload: {
-            snapshot: "snapshot" in event ? event.snapshot : {},
+            snapshot: "snapshot" in normalizedEvent ? normalizedEvent.snapshot : {},
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
@@ -499,9 +617,9 @@ export function buildConversationTree(
       case EventType.STEP_STARTED:
       case EventType.STEP_FINISHED: {
         const stepId =
-          "stepId" in event && typeof event.stepId === "string"
-            ? event.stepId
-            : `step-${normalizeTimestamp(event.timestamp)}`;
+          "stepId" in normalizedEvent && typeof normalizedEvent.stepId === "string"
+            ? normalizedEvent.stepId
+            : `step-${normalizeTimestamp(normalizedEvent.timestamp)}`;
         const baseParentId =
           chooseParentMessageId(assistantMessageByRun, runId) || turn.id;
         const node = upsertNode(nodeIndex, roots, turns, {
@@ -511,24 +629,25 @@ export function buildConversationTree(
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title:
-            event.type === EventType.STEP_STARTED &&
-            "stepName" in event &&
-            typeof event.stepName === "string"
-              ? event.stepName
+            normalizedEvent.type === EventType.STEP_STARTED &&
+            "stepName" in normalizedEvent &&
+            typeof normalizedEvent.stepName === "string"
+              ? normalizedEvent.stepName
               : `步骤 ${stepId}`,
-          status: event.type === EventType.STEP_FINISHED ? "done" : "running",
+          status: normalizedEvent.type === EventType.STEP_FINISHED ? "done" : "running",
           payload: {
             result:
-              event.type === EventType.STEP_FINISHED && "result" in event
-                ? event.result
+              normalizedEvent.type === EventType.STEP_FINISHED &&
+              "result" in normalizedEvent
+                ? normalizedEvent.result
                 : undefined,
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
         });
-        attachNode(nodeIndex, roots, node.id, baseParentId);
+        attachNode(nodeIndex, roots, turns, node.id, baseParentId);
         upsertNode(nodeIndex, roots, turns, {
           id: `reasoning:${stepId}`,
           type: "reasoning",
@@ -536,17 +655,17 @@ export function buildConversationTree(
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: "推理阶段",
           status: node.status,
           summary:
-            event.type === EventType.STEP_STARTED
+            normalizedEvent.type === EventType.STEP_STARTED
               ? `阶段开始：${node.title}`
               : `阶段完成：${node.title}`,
           payload: {
             stepId,
             phase:
-              event.type === EventType.STEP_STARTED ? "started" : "finished",
+              normalizedEvent.type === EventType.STEP_STARTED ? "started" : "finished",
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
@@ -556,16 +675,16 @@ export function buildConversationTree(
       }
       case EventType.RAW: {
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `raw:${runId}:${normalizeTimestamp(event.timestamp)}`,
+          id: `raw:${runId}:${normalizeTimestamp(normalizedEvent.timestamp)}`,
           type: "raw",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: "原始事件",
           payload: {
-            data: "data" in event ? event.data : {},
+            data: "data" in normalizedEvent ? normalizedEvent.data : {},
           },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
@@ -574,7 +693,7 @@ export function buildConversationTree(
         return;
       }
       case EventType.CUSTOM: {
-        const customEvent = event as BaseEvent & CustomPayload;
+        const customEvent = normalizedEvent as BaseEvent & CustomPayload;
         const eventTypeName =
           typeof customEvent.eventType === "string"
             ? customEvent.eventType
@@ -591,15 +710,19 @@ export function buildConversationTree(
               parentId: data.parentId,
             });
           }
+          return;
+        }
+        if (eventTypeName === "ne.a2ui.reasoning") {
+          return;
         }
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `custom:${runId}:${eventTypeName}:${normalizeTimestamp(event.timestamp)}`,
+          id: `custom:${runId}:${eventTypeName}:${normalizeTimestamp(normalizedEvent.timestamp)}`,
           type: "custom",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: eventTypeName,
           payload: {
             data: customEvent.data,
@@ -613,15 +736,15 @@ export function buildConversationTree(
       }
       default: {
         const node = upsertNode(nodeIndex, roots, turns, {
-          id: `event:${runId}:${eventType}:${normalizeTimestamp(event.timestamp)}`,
+          id: `event:${runId}:${eventType}:${normalizeTimestamp(normalizedEvent.timestamp)}`,
           type: "event",
           parentId: turn.id,
           threadId: turn.threadId,
           runId,
           messageId,
-          timestamp: event.timestamp,
+          timestamp: normalizedEvent.timestamp,
           title: eventType,
-          payload: { event },
+          payload: { event: normalizedEvent },
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
         });
@@ -651,14 +774,15 @@ export function buildConversationTree(
         } as BaseEvent,
       );
     }
-    const parentId = runId ? `turn:${runId}` : null;
+    const fallbackTurn = (runId && turns.get(runId)) || getLatestTurn(turns);
+    const parentId = fallbackTurn?.id ?? null;
     const role = normalizeRole(message.role);
     const node = upsertNode(nodeIndex, roots, turns, {
       id: `message:${messageId}`,
       type: "text",
       parentId,
       threadId: DEFAULT_THREAD_ID,
-      runId,
+      runId: fallbackTurn?.runId || runId,
       messageId,
       timestamp: getMessageTimestamp(message),
       title: role === "user" ? "用户消息" : "助手消息",
@@ -673,11 +797,11 @@ export function buildConversationTree(
       relatedMessageIds: [messageId],
     });
     messageNodeIndex.set(messageId, node.id);
-    if (role === "assistant" && runId) {
-      assistantMessageByRun.set(runId, node.id);
+    if (role === "assistant" && (fallbackTurn?.runId || runId)) {
+      assistantMessageByRun.set(fallbackTurn?.runId || runId || DEFAULT_RUN_ID, node.id);
     }
     if (parentId) {
-      attachNode(nodeIndex, roots, node.id, parentId);
+      attachNode(nodeIndex, roots, turns, node.id, parentId);
     }
   });
 
@@ -685,22 +809,23 @@ export function buildConversationTree(
     if (!nodeIndex.has(link.childId) || !nodeIndex.has(link.parentId)) {
       return;
     }
-    attachNode(nodeIndex, roots, link.childId, link.parentId);
+    attachNode(nodeIndex, roots, turns, link.childId, link.parentId);
   });
 
-  const sortNodes = (nodes: MutableNode[]) => {
-    nodes.sort((a, b) => {
-      const timeDiff = a.timeRange.start - b.timeRange.start;
-      if (timeDiff !== 0) return timeDiff;
-      return a.id.localeCompare(b.id);
-    });
-    nodes.forEach((node) => sortNodes(node.children));
-  };
-
-  sortNodes(roots);
+  const prunedRoots = roots
+    .map((node) => pruneNode(node))
+    .filter((node): node is MutableNode => node !== null);
+  prunedRoots.sort((a, b) => {
+    const timeDiff = a.timeRange.start - b.timeRange.start;
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    return a.id.localeCompare(b.id);
+  });
+  prunedRoots.forEach(sortNodeChildren);
 
   return {
-    roots,
+    roots: prunedRoots,
     nodeIndex,
     messageNodeIndex,
     toolNodeIndex,

--- a/docs/a2ui.md
+++ b/docs/a2ui.md
@@ -87,6 +87,22 @@ flowchart LR
 - 工具调用按 `runId` 粗粒度挂载，父子关系不稳定
 - `TEXT_MESSAGE_CONTENT` 被压扁为文本，活动/状态/原始事件无法成为一级模块
 - 主聊天区与右侧观察区职责失衡，导致真正的“交互结构”不可见
+- 纯结构性事件和空 payload 技术事件会污染主聊天区，造成空白消息块、重复 JSON 模块和错误时序
+
+### 5.1 Chat-friendly A2UI 规则
+
+为避免把“协议完整性”直接等价成“主聊天区全部直出”，Chat 页采用面向阅读的三层可见性模型：
+
+- `chat`：用户消息、助手消息、工具调用、工具结果
+- `collapsed`：活动、步骤、推理、状态、自定义业务事件，默认以摘要卡片显示
+- `debug-only`：纯结构性链接事件、原始事件、空 payload 技术事件，仅保留在调试链路
+
+对应策略：
+
+- `ne.a2ui.link` 仅用于树关系回填，不进入主聊天区
+- 空文本节点与空技术节点在树构建阶段裁剪
+- fallback 用户消息优先挂到最近轮次，避免作为裸 root 插入响应中部
+- JSON 默认走“摘要卡片 + 按需展开详情”，而不是直接作为消息气泡展示
 
 ## 6. 实施方案
 
@@ -195,7 +211,8 @@ classDiagram
 | 事件到树构建器 | 已完成 | [conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts) | 可处理文本/工具/状态/步骤 | 复杂链路仍需更多用例覆盖 |
 | Chat 树形渲染 | 已完成 | [ChatStream.tsx](../apps/negentropy-ui/components/ui/ChatStream.tsx) | 主区已切换为递归节点渲染 | 视觉细节仍可继续打磨 |
 | A2UI 自定义关联事件 | 已完成 | [adk.ts](../apps/negentropy-ui/lib/adk.ts) | 已注入 `ne.a2ui.link` / `ne.a2ui.reasoning` | 上游若提供原生父子关系，可进一步收敛 |
-| 单元测试补齐 | 进行中 | [tests/unit](../apps/negentropy-ui/tests/unit) | 待依赖安装后完整复验 | 当前本地缺少前端依赖 |
+| Chat 乱序与空白节点治理 | 已完成 | [conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts) | 已修复默认 `runId` 归并、空节点裁剪、fallback 消息挂靠与技术节点过滤 | 后续仍需补更多真实流量样例 |
+| 单元测试补齐 | 已完成 | [tests/unit](../apps/negentropy-ui/tests/unit) | `pnpm --dir apps/negentropy-ui test` 通过，23 个测试文件全部通过 | `lint/build` 仍受整仓存量问题影响 |
 
 ## 9. 最佳实践
 
@@ -204,6 +221,8 @@ classDiagram
 - 不暴露私有推理原文，仅渲染安全摘要或阶段状态
 - 主聊天区负责“交互结构”，右侧面板负责“观测镜像”
 - 新类型先走 `custom` 回退，再决定是否升级为正式组件
+- 主聊天区必须做信息分层，不能把结构性事件和调试载荷直接视作聊天消息
+- 技术类 JSON 默认展示摘要卡片，并提供显式展开入口，避免噪音淹没主对话
 
 ## 10. 后续建议
 


### PR DESCRIPTION
## 变更内容

本 PR 对 Chat 页已落地的 A2UI 渲染链路进行收敛修复，重点解决消息乱序、空白消息块、结构性事件误渲染，以及技术类 JSON 在主聊天区直接裸露的问题。

具体包括：

- 修正 [`apps/negentropy-ui/app/api/agui/route.ts`](./apps/negentropy-ui/app/api/agui/route.ts) 中 AG-UI 事件的 `runId` / `threadId` 归并逻辑，避免上游 `"default"` 标识导致真实轮次空置、子节点挂错轮次
- 扩展 A2UI 节点模型，在 [`apps/negentropy-ui/types/a2ui.ts`](./apps/negentropy-ui/types/a2ui.ts) 中增加可见性分层字段，区分：
  - `chat`
  - `collapsed`
  - `debug-only`
- 新增 [`apps/negentropy-ui/utils/conversation-summary.ts`](./apps/negentropy-ui/utils/conversation-summary.ts)，集中封装技术节点的：
  - JSON 安全解析
  - 空 payload 判断
  - 可见性分类
  - 摘要提取
- 重构 [`apps/negentropy-ui/utils/conversation-tree.ts`](./apps/negentropy-ui/utils/conversation-tree.ts)，修复会话树构建规则：
  - `ne.a2ui.link` 仅用于父子关系回填，不再渲染为主聊天区节点
  - 空文本节点、空技术节点在构建阶段直接裁剪
  - fallback 用户消息优先挂到最近 turn，避免跑到响应中间
  - turn 内子节点按聊天友好顺序稳定排序
- 更新 [`apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx`](./apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx) 与 [`apps/negentropy-ui/components/ui/ChatStream.tsx`](./apps/negentropy-ui/components/ui/ChatStream.tsx)，将技术节点从“直接 JSON 输出”收敛为“摘要卡片 + 按需展开详情”，并过滤 `debug-only` 节点
- 补充与更新单元测试：
  - [`apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts`](./apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts)
  - [`apps/negentropy-ui/tests/unit/ChatStream.test.tsx`](./apps/negentropy-ui/tests/unit/ChatStream.test.tsx)
- 同步更新 [`docs/a2ui.md`](./docs/a2ui.md)，补充 Chat-friendly A2UI 的可见性分层规则与实施进度

## 变更动机

这次修复直接来自 Chat 页在真实交互中的可用性问题：

- 用户首条消息会出现在 assistant 响应中间
- 主区出现多个空白消息块或无意义事件块
- `ne.a2ui.link` 这类结构性事件进入了主聊天区，造成视觉噪音
- activity / custom / state / raw 等技术载荷直接以 JSON 形式裸露，缺乏模块化和卡片化表达

这些问题说明，A2UI 在 Chat 页不能只是“把所有事件都渲染出来”，而必须做面向阅读的读模型收敛。主聊天区需要优先展示用户真正关心的交互结构，而把结构性事件和低信噪比调试载荷降级为折叠或调试视图。

## 关键实现细节

### 1. 保持 AG-UI 传输层不变，修正事件归并

本次没有更换现有 AG-UI 传输协议，而是在 `/api/agui` 的适配层修正 `"default"` `runId/threadId` 的归并逻辑，确保事件能稳定落到真实轮次。这是解决“默认轮次”和消息错位问题的根因修复。

### 2. 将会话树从“全事件树”收敛为“聊天友好树”

会话树构建器不再无差别把所有事件都视为主聊天区节点，而是引入三层可见性模型：

- `chat`：主聊天区直接展示
- `collapsed`：以摘要卡片方式保留
- `debug-only`：不进入主聊天区，仅保留在原始事件与调试链路

这样可以在不丢失结构信息的前提下，把聊天体验从“事件流水账”恢复成“面向消息阅读”的界面。

### 3. 结构性事件只参与建模，不参与展示

`ne.a2ui.link` 现在只作为父子关系的内部指令使用，不再在主聊天区中形成独立模块。这符合经典的 Adapter + Composite 设计思路：结构元数据用于构造 UI 树，而不是直接暴露给终端用户。

### 4. JSON 渲染改为摘要优先

技术节点默认展示摘要卡片，只有在用户主动展开时才显示完整 JSON。这样既保留了调试能力，也避免大块结构化数据淹没主对话内容。

## 验证

已执行：

- `pnpm --dir apps/negentropy-ui test`

结果：

- 23 个测试文件通过
- 113 个测试通过
- 3 个测试跳过

本次新增和更新的断言重点覆盖：

- 结构性 link 事件不进入主聊天区
- fallback 用户消息挂到正确轮次
- 空文本节点裁剪
- `debug-only` 节点过滤
- 技术节点改为摘要卡片展示

This PR was written using [Vibe Kanban](https://vibekanban.com)
