### PR TITLE
feat(knowledge): 对齐四种 Chunk 策略配置并移除冗余字段 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusDetail.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusDetail.tsx
@@ -1,12 +1,15 @@
 import { useMemo } from "react";
-import { CorpusRecord } from "@/features/knowledge";
+import { CorpusRecord, normalizeChunkingConfig } from "@/features/knowledge";
 
 interface CorpusDetailProps {
   corpus: CorpusRecord | null;
 }
 
 export function CorpusDetail({ corpus }: CorpusDetailProps) {
-  const config = useMemo(() => corpus?.config ?? {}, [corpus]);
+  const config = useMemo(
+    () => normalizeChunkingConfig((corpus?.config ?? {}) as Record<string, unknown>),
+    [corpus],
+  );
 
   if (!corpus) {
     return (
@@ -41,19 +44,52 @@ export function CorpusDetail({ corpus }: CorpusDetailProps) {
         <p>
           <span className="text-muted/70">Strategy</span>{" "}
           <span className="capitalize">
-            {String(config.strategy || "recursive")}
+            {config.strategy}
           </span>
         </p>
-        <p>
-          <span className="text-muted/70">Chunk Size</span>{" "}
-          {config.chunk_size || 800}
-        </p>
-        <p>
-          <span className="text-muted/70">Overlap</span> {config.overlap || 100}
-        </p>
+        {config.strategy === "fixed" && (
+          <>
+            <p>
+              <span className="text-muted/70">Chunk Size</span> {config.chunk_size}
+            </p>
+            <p>
+              <span className="text-muted/70">Overlap</span> {config.overlap}
+            </p>
+          </>
+        )}
+        {config.strategy === "recursive" && (
+          <>
+            <p>
+              <span className="text-muted/70">Chunk Size</span> {config.chunk_size}
+            </p>
+            <p>
+              <span className="text-muted/70">Overlap</span> {config.overlap}
+            </p>
+          </>
+        )}
+        {config.strategy === "semantic" && (
+          <>
+            <p>
+              <span className="text-muted/70">Threshold</span> {config.semantic_threshold}
+            </p>
+            <p>
+              <span className="text-muted/70">Buffer Size</span> {config.semantic_buffer_size}
+            </p>
+          </>
+        )}
+        {config.strategy === "hierarchical" && (
+          <>
+            <p>
+              <span className="text-muted/70">Parent Size</span> {config.hierarchical_parent_chunk_size}
+            </p>
+            <p>
+              <span className="text-muted/70">Child Size</span> {config.hierarchical_child_chunk_size}
+            </p>
+          </>
+        )}
         <p>
           <span className="text-muted/70">Embedding</span>{" "}
-          {config.embedding_model || "default"}
+          {(corpus?.config?.embedding_model as string | undefined) || "default"}
         </p>
       </div>
     </div>

--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { CorpusRecord, ChunkingStrategy } from "@/features/knowledge";
+import {
+  CorpusRecord,
+  ChunkingConfig,
+  ChunkingStrategy,
+  createDefaultChunkingConfig,
+  normalizeChunkingConfig,
+} from "@/features/knowledge";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface CorpusFormDialogProps {
@@ -21,29 +27,16 @@ function buildInitialState(
   mode: "create" | "edit",
   initialData?: CorpusRecord,
 ) {
-  const conf = mode === "edit" && initialData ? (initialData.config || {}) : {};
+  const conf =
+    mode === "edit" && initialData
+      ? normalizeChunkingConfig((initialData.config || {}) as Record<string, unknown>)
+      : createDefaultChunkingConfig("recursive");
   return {
     name: mode === "edit" && initialData ? initialData.name : "",
     description:
       mode === "edit" && initialData ? initialData.description || "" : "",
     showAdvanced: false,
-    strategy: ((conf.strategy as ChunkingStrategy) || "recursive") as ChunkingStrategy,
-    chunkSize: String(conf.chunk_size || "800"),
-    overlap: String(conf.overlap || "100"),
-    preserveNewlines: conf.preserve_newlines !== false,
-    separators: Array.isArray(conf.separators)
-      ? (conf.separators as string[]).join("\n")
-      : "",
-    semanticThreshold: String(conf.semantic_threshold || "0.85"),
-    minChunkSize: String(conf.min_chunk_size || "50"),
-    maxChunkSize: String(conf.max_chunk_size || "2000"),
-    hierarchicalParentChunkSize: String(
-      conf.hierarchical_parent_chunk_size || "1024",
-    ),
-    hierarchicalChildChunkSize: String(
-      conf.hierarchical_child_chunk_size || "256",
-    ),
-    hierarchicalChildOverlap: String(conf.hierarchical_child_overlap || "51"),
+    config: conf,
   };
 }
 
@@ -59,65 +52,15 @@ export function CorpusFormDialog({
   const [name, setName] = useState(initialState.name);
   const [description, setDescription] = useState(initialState.description);
   const [showAdvanced, setShowAdvanced] = useState(initialState.showAdvanced);
-
-  // Chunking Config State
-  const [strategy, setStrategy] = useState<ChunkingStrategy>(initialState.strategy);
-  const [chunkSize, setChunkSize] = useState<string>(initialState.chunkSize);
-  const [overlap, setOverlap] = useState<string>(initialState.overlap);
-  const [preserveNewlines, setPreserveNewlines] = useState(initialState.preserveNewlines);
-  const [separators, setSeparators] = useState(initialState.separators);
-
-  // Semantic specific
-  const [semanticThreshold, setSemanticThreshold] = useState<string>(initialState.semanticThreshold);
-  const [minChunkSize, setMinChunkSize] = useState<string>(initialState.minChunkSize);
-  const [maxChunkSize, setMaxChunkSize] = useState<string>(initialState.maxChunkSize);
-  const [hierarchicalParentChunkSize, setHierarchicalParentChunkSize] =
-    useState<string>(initialState.hierarchicalParentChunkSize);
-  const [hierarchicalChildChunkSize, setHierarchicalChildChunkSize] =
-    useState<string>(initialState.hierarchicalChildChunkSize);
-  const [hierarchicalChildOverlap, setHierarchicalChildOverlap] =
-    useState<string>(initialState.hierarchicalChildOverlap);
+  const [config, setConfig] = useState<ChunkingConfig>(initialState.config);
 
   const handleSubmit = async () => {
     if (!name.trim() || isLoading) return;
 
-    const config: Record<string, unknown> = {
-      strategy,
-      preserve_newlines: preserveNewlines,
-    };
-
-    const size = parseInt(chunkSize, 10);
-    const ov = parseInt(overlap, 10);
-    if (!isNaN(size)) config.chunk_size = size;
-    if (!isNaN(ov)) config.overlap = ov;
-
-    if (strategy === "semantic") {
-      const thresh = parseFloat(semanticThreshold);
-      const minSize = parseInt(minChunkSize, 10);
-      const maxSize = parseInt(maxChunkSize, 10);
-      if (!isNaN(thresh)) config.semantic_threshold = thresh;
-      if (!isNaN(minSize)) config.min_chunk_size = minSize;
-      if (!isNaN(maxSize)) config.max_chunk_size = maxSize;
-    }
-
-    if (strategy === "hierarchical") {
-      const parentSize = parseInt(hierarchicalParentChunkSize, 10);
-      const childSize = parseInt(hierarchicalChildChunkSize, 10);
-      const childOverlap = parseInt(hierarchicalChildOverlap, 10);
-      if (!isNaN(parentSize)) config.hierarchical_parent_chunk_size = parentSize;
-      if (!isNaN(childSize)) config.hierarchical_child_chunk_size = childSize;
-      if (!isNaN(childOverlap)) config.hierarchical_child_overlap = childOverlap;
-    }
-
-    config.separators = separators
-      .split("\n")
-      .map((item) => item.trim())
-      .filter(Boolean);
-
     await onSubmit({
       name: name.trim(),
       description: description.trim() || undefined,
-      config,
+      config: config as unknown as Record<string, unknown>,
     });
   };
 
@@ -214,9 +157,11 @@ export function CorpusFormDialog({
                   </label>
                   <select
                     className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                    value={strategy}
+                    value={config.strategy}
                     onChange={(e) =>
-                      setStrategy(e.target.value as ChunkingStrategy)
+                      setConfig(
+                        createDefaultChunkingConfig(e.target.value as ChunkingStrategy),
+                      )
                     }
                   >
                     <option value="fixed">Fixed (Fixed Character Size)</option>
@@ -232,32 +177,104 @@ export function CorpusFormDialog({
                   </select>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
-                      Chunk Size (Target)
-                    </label>
-                    <input
-                      type="number"
-                      className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                      value={chunkSize}
-                      onChange={(e) => setChunkSize(e.target.value)}
-                    />
+                {config.strategy === "fixed" && (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Chunk Size (Target)
+                      </label>
+                      <input
+                        type="number"
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        value={String(config.chunk_size)}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            chunk_size: Number(e.target.value) || 800,
+                          })
+                        }
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Overlap (Chars)
+                      </label>
+                      <input
+                        type="number"
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        value={String(config.overlap)}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            overlap: Number(e.target.value) || 0,
+                          })
+                        }
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
-                      Overlap (Chars)
-                    </label>
-                    <input
-                      type="number"
-                      className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                      value={overlap}
-                      onChange={(e) => setOverlap(e.target.value)}
-                    />
-                  </div>
-                </div>
+                )}
 
-                {strategy === "semantic" && (
+                {config.strategy === "recursive" && (
+                  <div className="space-y-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                          Chunk Size (Target)
+                        </label>
+                        <input
+                          type="number"
+                          className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                          value={String(config.chunk_size)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              chunk_size: Number(e.target.value) || 800,
+                            })
+                          }
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                          Overlap (Chars)
+                        </label>
+                        <input
+                          type="number"
+                          className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                          value={String(config.overlap)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              overlap: Number(e.target.value) || 0,
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Separators (one per line)
+                      </label>
+                      <textarea
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        rows={4}
+                        placeholder={"\\n\\n\\n.\\n,\\n;"}
+                        value={config.separators.join("\n")}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            separators: e.target.value
+                              .split("\n")
+                              .map((item) => item.trim())
+                              .filter(Boolean),
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {config.strategy === "semantic" && (
                   <div className="grid grid-cols-2 gap-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
                     <div className="col-span-2">
                       <label className="mb-1 block text-[10px] font-medium text-blue-600 dark:text-blue-400">
@@ -274,8 +291,29 @@ export function CorpusFormDialog({
                         max="1.0"
                         min="0.0"
                         className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                        value={semanticThreshold}
-                        onChange={(e) => setSemanticThreshold(e.target.value)}
+                        value={String(config.semantic_threshold)}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            semantic_threshold: Number(e.target.value) || 0.85,
+                          })
+                        }
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                        Buffer Size
+                      </label>
+                      <input
+                        type="number"
+                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        value={String(config.semantic_buffer_size)}
+                        onChange={(e) =>
+                          setConfig({
+                            ...config,
+                            semantic_buffer_size: Number(e.target.value) || 1,
+                          })
+                        }
                       />
                     </div>
                     <div className="grid grid-cols-2 gap-2">
@@ -286,8 +324,13 @@ export function CorpusFormDialog({
                         <input
                           type="number"
                           className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                          value={maxChunkSize}
-                          onChange={(e) => setMaxChunkSize(e.target.value)}
+                          value={String(config.max_chunk_size)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              max_chunk_size: Number(e.target.value) || 2000,
+                            })
+                          }
                         />
                       </div>
                       <div>
@@ -297,95 +340,130 @@ export function CorpusFormDialog({
                         <input
                           type="number"
                           className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                          value={minChunkSize}
-                          onChange={(e) => setMinChunkSize(e.target.value)}
+                          value={String(config.min_chunk_size)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              min_chunk_size: Number(e.target.value) || 50,
+                            })
+                          }
                         />
                       </div>
                     </div>
                   </div>
                 )}
 
-                {strategy === "hierarchical" && (
-                  <div className="grid grid-cols-3 gap-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
-                    <div>
-                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
-                        Parent Size
-                      </label>
-                      <input
-                        type="number"
-                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                        value={hierarchicalParentChunkSize}
-                        onChange={(e) =>
-                          setHierarchicalParentChunkSize(e.target.value)
-                        }
-                      />
+                {config.strategy === "hierarchical" && (
+                  <div className="space-y-3 border-t border-zinc-200 pt-3 dark:border-zinc-700">
+                    <div className="grid grid-cols-3 gap-3">
+                      <div>
+                        <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                          Parent Size
+                        </label>
+                        <input
+                          type="number"
+                          className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                          value={String(config.hierarchical_parent_chunk_size)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              hierarchical_parent_chunk_size:
+                                Number(e.target.value) || 1024,
+                            })
+                          }
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                          Child Size
+                        </label>
+                        <input
+                          type="number"
+                          className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                          value={String(config.hierarchical_child_chunk_size)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              hierarchical_child_chunk_size:
+                                Number(e.target.value) || 256,
+                            })
+                          }
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+                          Child Overlap
+                        </label>
+                        <input
+                          type="number"
+                          className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                          value={String(config.hierarchical_child_overlap)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              hierarchical_child_overlap:
+                                Number(e.target.value) || 0,
+                            })
+                          }
+                        />
+                      </div>
                     </div>
                     <div>
                       <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
-                        Child Size
+                        Separators (one per line)
                       </label>
-                      <input
-                        type="number"
+                      <textarea
                         className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                        value={hierarchicalChildChunkSize}
+                        rows={4}
+                        placeholder={"\\n\\n\\n.\\n,\\n;"}
+                        value={config.separators.join("\n")}
                         onChange={(e) =>
-                          setHierarchicalChildChunkSize(e.target.value)
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
-                        Child Overlap
-                      </label>
-                      <input
-                        type="number"
-                        className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                        value={hierarchicalChildOverlap}
-                        onChange={(e) =>
-                          setHierarchicalChildOverlap(e.target.value)
+                          setConfig({
+                            ...config,
+                            separators: e.target.value
+                              .split("\n")
+                              .map((item) => item.trim())
+                              .filter(Boolean),
+                          })
                         }
                       />
                     </div>
                   </div>
                 )}
 
-                <div className="border-t border-zinc-200 pt-3 dark:border-zinc-700">
-                  <label className="mb-1 block text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
-                    Separators (one per line)
-                  </label>
-                  <textarea
-                    className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                    rows={4}
-                    placeholder={"\\n\\n\\n.\\n,\\n;"}
-                    value={separators}
-                    onChange={(e) => setSeparators(e.target.value)}
-                  />
-                </div>
-
-                <div className="flex items-center pt-1">
-                  <input
-                    type="checkbox"
-                    id="preserve-newlines"
-                    className="h-3 w-3 rounded border-zinc-300"
-                    checked={preserveNewlines}
-                    onChange={(e) => setPreserveNewlines(e.target.checked)}
-                  />
-                  <label
-                    htmlFor="preserve-newlines"
-                    className="ml-2 text-xs text-zinc-600 dark:text-zinc-400"
-                  >
-                    Preserve Newlines
-                  </label>
-                </div>
+                {(config.strategy === "fixed" ||
+                  config.strategy === "recursive" ||
+                  config.strategy === "hierarchical") && (
+                  <div className="flex items-center pt-1">
+                    <input
+                      type="checkbox"
+                      id="preserve-newlines"
+                      className="h-3 w-3 rounded border-zinc-300"
+                      checked={config.preserve_newlines}
+                      onChange={(e) =>
+                        setConfig({
+                          ...config,
+                          preserve_newlines: e.target.checked,
+                        })
+                      }
+                    />
+                    <label
+                      htmlFor="preserve-newlines"
+                      className="ml-2 text-xs text-zinc-600 dark:text-zinc-400"
+                    >
+                      Preserve Newlines
+                    </label>
+                  </div>
+                )}
 
                 <div className="text-[10px] text-zinc-400 dark:text-zinc-500">
-                  {strategy === "fixed" &&
+                  {config.strategy === "fixed" &&
                     "按固定字符数切分，简单高效但不感知语义。"}
-                  {strategy === "recursive" &&
+                  {config.strategy === "recursive" &&
                     "递归切分 (段落 > 句子 > 词)，保持文段结构完整。"}
-                  {strategy === "semantic" &&
+                  {config.strategy === "semantic" &&
                     "基于 Embedding 相似度切分，确保 Chunk 语义连贯，需消耗 Token。"}
-                  {strategy === "hierarchical" &&
+                  {config.strategy === "hierarchical" &&
                     "先构建父块再切子块，检索命中子块但返回父块，适合长文档与手册。"}
                 </div>
               </div>

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -31,6 +31,8 @@ import {
   unarchiveDocument,
   downloadDocument,
   deleteDocument,
+  createDefaultChunkingConfig,
+  normalizeChunkingConfig,
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
@@ -124,8 +126,12 @@ function ChunkingStrategyPanel({
     hierarchical: "构建父子块结构，检索子块并返回父块上下文，适合长文与手册。",
   };
 
-  const updateConfig = (patch: Partial<ChunkingConfig>) => {
-    onChange((prev) => ({ ...prev, ...patch }));
+  const setStrategy = (strategy: ChunkingStrategy) => {
+    onChange(createDefaultChunkingConfig(strategy));
+  };
+
+  const updateConfig = (nextConfig: ChunkingConfig) => {
+    onChange(nextConfig);
   };
 
   return (
@@ -146,7 +152,7 @@ function ChunkingStrategyPanel({
             <button
               key={strategy}
               type="button"
-              onClick={() => updateConfig({ strategy })}
+              onClick={() => setStrategy(strategy)}
               className={`rounded-xl border px-3 py-3 text-left ${
                 config.strategy === strategy
                   ? "border-foreground bg-foreground text-background"
@@ -166,55 +172,116 @@ function ChunkingStrategyPanel({
         )}
       </div>
 
-      <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <label className="text-xs">
-          <div className="mb-1 text-muted">Chunk Size</div>
-          <input
-            type="number"
-            value={String(config.chunk_size ?? 800)}
-            onChange={(e) =>
-              updateConfig({ chunk_size: Number(e.target.value || 0) || 800 })
-            }
-            className="w-full rounded border border-border bg-card px-2 py-2"
-          />
-        </label>
-        <label className="text-xs">
-          <div className="mb-1 text-muted">Overlap</div>
-          <input
-            type="number"
-            value={String(config.overlap ?? 100)}
-            onChange={(e) =>
-              updateConfig({ overlap: Number(e.target.value || 0) || 0 })
-            }
-            className="w-full rounded border border-border bg-card px-2 py-2"
-          />
-        </label>
-        <label className="text-xs md:col-span-2">
-          <div className="mb-1 text-muted">Separators（每行一个）</div>
-          <textarea
-            value={(config.separators || []).join("\n")}
-            onChange={(e) =>
-              updateConfig({
-                separators: e.target.value
-                  .split("\n")
-                  .map((item) => item.trim())
-                  .filter(Boolean),
-              })
-            }
-            rows={3}
-            className="w-full rounded border border-border bg-card px-2 py-2"
-          />
-        </label>
-      </div>
+      {config.strategy === "fixed" && (
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Chunk Size</div>
+            <input
+              type="number"
+              value={String(config.chunk_size)}
+              onChange={(e) =>
+                updateConfig({
+                  ...config,
+                  chunk_size: Number(e.target.value || 0) || 800,
+                })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Overlap</div>
+            <input
+              type="number"
+              value={String(config.overlap)}
+              onChange={(e) =>
+                updateConfig({
+                  ...config,
+                  overlap: Number(e.target.value || 0) || 0,
+                })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="inline-flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={config.preserve_newlines}
+              onChange={(e) =>
+                updateConfig({
+                  ...config,
+                  preserve_newlines: e.target.checked,
+                })
+              }
+            />
+            <span>保留换行</span>
+          </label>
+        </div>
+      )}
 
-      <label className="mt-3 inline-flex items-center gap-2 text-xs">
-        <input
-          type="checkbox"
-          checked={config.preserve_newlines !== false}
-          onChange={(e) => updateConfig({ preserve_newlines: e.target.checked })}
-        />
-        <span>保留换行</span>
-      </label>
+      {config.strategy === "recursive" && (
+        <div className="mt-3 space-y-3">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <label className="text-xs">
+              <div className="mb-1 text-muted">Chunk Size</div>
+              <input
+                type="number"
+                value={String(config.chunk_size)}
+                onChange={(e) =>
+                  updateConfig({
+                    ...config,
+                    chunk_size: Number(e.target.value || 0) || 800,
+                  })
+                }
+                className="w-full rounded border border-border bg-card px-2 py-2"
+              />
+            </label>
+            <label className="text-xs">
+              <div className="mb-1 text-muted">Overlap</div>
+              <input
+                type="number"
+                value={String(config.overlap)}
+                onChange={(e) =>
+                  updateConfig({
+                    ...config,
+                    overlap: Number(e.target.value || 0) || 0,
+                  })
+                }
+                className="w-full rounded border border-border bg-card px-2 py-2"
+              />
+            </label>
+            <label className="text-xs md:col-span-2">
+              <div className="mb-1 text-muted">Separators（每行一个）</div>
+              <textarea
+                value={config.separators.join("\n")}
+                onChange={(e) =>
+                  updateConfig({
+                    ...config,
+                    separators: e.target.value
+                      .split("\n")
+                      .map((item) => item.trim())
+                      .filter(Boolean),
+                  })
+                }
+                rows={3}
+                className="w-full rounded border border-border bg-card px-2 py-2"
+              />
+            </label>
+          </div>
+          <label className="inline-flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={config.preserve_newlines}
+              onChange={(e) =>
+                updateConfig({
+                  ...config,
+                  preserve_newlines: e.target.checked,
+                })
+              }
+            />
+            <span>保留换行</span>
+          </label>
+        </div>
+      )}
 
       {config.strategy === "semantic" && (
         <div className="mt-3 grid gap-3 md:grid-cols-3">
@@ -225,9 +292,26 @@ function ChunkingStrategyPanel({
               step="0.05"
               min="0"
               max="1"
-              value={String(config.semantic_threshold ?? 0.85)}
+              value={String(config.semantic_threshold)}
               onChange={(e) =>
-                updateConfig({ semantic_threshold: Number(e.target.value) || 0.85 })
+                updateConfig({
+                  ...config,
+                  semantic_threshold: Number(e.target.value) || 0.85,
+                })
+              }
+              className="w-full rounded border border-border bg-card px-2 py-2"
+            />
+          </label>
+          <label className="text-xs">
+            <div className="mb-1 text-muted">Buffer Size</div>
+            <input
+              type="number"
+              value={String(config.semantic_buffer_size)}
+              onChange={(e) =>
+                updateConfig({
+                  ...config,
+                  semantic_buffer_size: Number(e.target.value) || 1,
+                })
               }
               className="w-full rounded border border-border bg-card px-2 py-2"
             />
@@ -236,9 +320,12 @@ function ChunkingStrategyPanel({
             <div className="mb-1 text-muted">Min Chunk Size</div>
             <input
               type="number"
-              value={String(config.min_chunk_size ?? 50)}
+              value={String(config.min_chunk_size)}
               onChange={(e) =>
-                updateConfig({ min_chunk_size: Number(e.target.value) || 50 })
+                updateConfig({
+                  ...config,
+                  min_chunk_size: Number(e.target.value) || 50,
+                })
               }
               className="w-full rounded border border-border bg-card px-2 py-2"
             />
@@ -247,9 +334,12 @@ function ChunkingStrategyPanel({
             <div className="mb-1 text-muted">Max Chunk Size</div>
             <input
               type="number"
-              value={String(config.max_chunk_size ?? 2000)}
+              value={String(config.max_chunk_size)}
               onChange={(e) =>
-                updateConfig({ max_chunk_size: Number(e.target.value) || 2000 })
+                updateConfig({
+                  ...config,
+                  max_chunk_size: Number(e.target.value) || 2000,
+                })
               }
               className="w-full rounded border border-border bg-card px-2 py-2"
             />
@@ -258,46 +348,80 @@ function ChunkingStrategyPanel({
       )}
 
       {config.strategy === "hierarchical" && (
-        <div className="mt-3 grid gap-3 md:grid-cols-3">
+        <div className="mt-3 space-y-3">
+          <div className="grid gap-3 md:grid-cols-3">
+            <label className="text-xs">
+              <div className="mb-1 text-muted">Parent Size</div>
+              <input
+                type="number"
+                value={String(config.hierarchical_parent_chunk_size)}
+                onChange={(e) =>
+                  updateConfig({
+                    ...config,
+                    hierarchical_parent_chunk_size: Number(e.target.value) || 1024,
+                  })
+                }
+                className="w-full rounded border border-border bg-card px-2 py-2"
+              />
+            </label>
+            <label className="text-xs">
+              <div className="mb-1 text-muted">Child Size</div>
+              <input
+                type="number"
+                value={String(config.hierarchical_child_chunk_size)}
+                onChange={(e) =>
+                  updateConfig({
+                    ...config,
+                    hierarchical_child_chunk_size: Number(e.target.value) || 256,
+                  })
+                }
+                className="w-full rounded border border-border bg-card px-2 py-2"
+              />
+            </label>
+            <label className="text-xs">
+              <div className="mb-1 text-muted">Child Overlap</div>
+              <input
+                type="number"
+                value={String(config.hierarchical_child_overlap)}
+                onChange={(e) =>
+                  updateConfig({
+                    ...config,
+                    hierarchical_child_overlap: Number(e.target.value) || 0,
+                  })
+                }
+                className="w-full rounded border border-border bg-card px-2 py-2"
+              />
+            </label>
+          </div>
           <label className="text-xs">
-            <div className="mb-1 text-muted">Parent Size</div>
-            <input
-              type="number"
-              value={String(config.hierarchical_parent_chunk_size ?? 1024)}
+            <div className="mb-1 text-muted">Separators（每行一个）</div>
+            <textarea
+              value={config.separators.join("\n")}
               onChange={(e) =>
                 updateConfig({
-                  hierarchical_parent_chunk_size:
-                    Number(e.target.value) || 1024,
+                  ...config,
+                  separators: e.target.value
+                    .split("\n")
+                    .map((item) => item.trim())
+                    .filter(Boolean),
                 })
               }
+              rows={3}
               className="w-full rounded border border-border bg-card px-2 py-2"
             />
           </label>
-          <label className="text-xs">
-            <div className="mb-1 text-muted">Child Size</div>
+          <label className="inline-flex items-center gap-2 text-xs">
             <input
-              type="number"
-              value={String(config.hierarchical_child_chunk_size ?? 256)}
+              type="checkbox"
+              checked={config.preserve_newlines}
               onChange={(e) =>
                 updateConfig({
-                  hierarchical_child_chunk_size: Number(e.target.value) || 256,
+                  ...config,
+                  preserve_newlines: e.target.checked,
                 })
               }
-              className="w-full rounded border border-border bg-card px-2 py-2"
             />
-          </label>
-          <label className="text-xs">
-            <div className="mb-1 text-muted">Child Overlap</div>
-            <input
-              type="number"
-              value={String(config.hierarchical_child_overlap ?? 51)}
-              onChange={(e) =>
-                updateConfig({
-                  hierarchical_child_overlap: Number(e.target.value) || 0,
-                })
-              }
-              className="w-full rounded border border-border bg-card px-2 py-2"
-            />
+            <span>保留换行</span>
           </label>
         </div>
       )}
@@ -365,7 +489,9 @@ export default function KnowledgeBasePage() {
     () => corpora.find((item) => item.id === selectedCorpusId) || null,
     [corpora, selectedCorpusId],
   );
-  const corpusChunkingConfig = selectedCorpus?.config as ChunkingConfig | undefined;
+  const corpusChunkingConfig = selectedCorpus?.config
+    ? normalizeChunkingConfig(selectedCorpus.config as Record<string, unknown>)
+    : undefined;
   const retrievedChunkCards = useMemo(
     () => retrievalResults.map((item) => buildRetrievedChunkViewModel(item)),
     [retrievalResults],
@@ -1119,34 +1245,12 @@ function CorpusSettingsPanel({
   corpus: CorpusRecord;
   onSave: (config: Record<string, unknown>) => Promise<void>;
 }) {
-  const [formConfig, setFormConfig] = useState<ChunkingConfig>({
-    strategy: (corpus.config?.strategy as ChunkingStrategy) || "recursive",
-    chunk_size: Number(corpus.config?.chunk_size || 800),
-    overlap: Number(corpus.config?.overlap || 100),
-    preserve_newlines: corpus.config?.preserve_newlines !== false,
-    separators: Array.isArray(corpus.config?.separators)
-      ? (corpus.config?.separators as string[])
-      : [],
-    semantic_threshold: Number(corpus.config?.semantic_threshold || 0.85),
-    min_chunk_size: Number(corpus.config?.min_chunk_size || 50),
-    max_chunk_size: Number(corpus.config?.max_chunk_size || 2000),
-    hierarchical_parent_chunk_size: Number(
-      corpus.config?.hierarchical_parent_chunk_size || 1024,
-    ),
-    hierarchical_child_chunk_size: Number(
-      corpus.config?.hierarchical_child_chunk_size || 256,
-    ),
-    hierarchical_child_overlap: Number(
-      corpus.config?.hierarchical_child_overlap || 51,
-    ),
-  });
+  const [formConfig, setFormConfig] = useState<ChunkingConfig>(
+    normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
+  );
 
   const handleSubmit = async () => {
-    const payload: Record<string, unknown> = {
-      ...(corpus.config || {}),
-      ...formConfig,
-    };
-    await onSave(payload);
+    await onSave(formConfig as unknown as Record<string, unknown>);
   };
 
   return (

--- a/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeBase.ts
+++ b/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeBase.ts
@@ -141,19 +141,7 @@ const DEFAULT_LOADING_STATE = {
 };
 
 function toChunkingPayload(config?: ChunkingConfig) {
-  return {
-    strategy: config?.strategy,
-    chunk_size: config?.chunk_size,
-    overlap: config?.overlap,
-    preserve_newlines: config?.preserve_newlines,
-    separators: config?.separators,
-    semantic_threshold: config?.semantic_threshold,
-    min_chunk_size: config?.min_chunk_size,
-    max_chunk_size: config?.max_chunk_size,
-    hierarchical_parent_chunk_size: config?.hierarchical_parent_chunk_size,
-    hierarchical_child_chunk_size: config?.hierarchical_child_chunk_size,
-    hierarchical_child_overlap: config?.hierarchical_child_overlap,
-  };
+  return config ? { chunking_config: config } : {};
 }
 
 /**

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -86,6 +86,10 @@ export {
 export type {
   SearchMode,
   ChunkingStrategy,
+  FixedChunkingConfig,
+  RecursiveChunkingConfig,
+  SemanticChunkingConfig,
+  HierarchicalChunkingConfig,
   ChunkingConfig,
   SearchConfig,
   KnowledgeErrorResponse,
@@ -126,6 +130,11 @@ export type {
   GraphPathResult,
   GraphBuildRunRecord,
   GraphBuildHistoryResult,
+} from "./utils/knowledge-api";
+
+export {
+  createDefaultChunkingConfig,
+  normalizeChunkingConfig,
 } from "./utils/knowledge-api";
 
 // ============================================================================

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -17,20 +17,298 @@ export type ChunkingStrategy =
   | "semantic"
   | "hierarchical";
 
-export interface ChunkingConfig {
-  strategy?: ChunkingStrategy;
-  chunk_size?: number;
-  overlap?: number;
-  preserve_newlines?: boolean;
-  separators?: string[];
-  // Semantic chunking specific
-  semantic_threshold?: number;
-  min_chunk_size?: number;
-  max_chunk_size?: number;
-  // Hierarchical chunking specific
-  hierarchical_parent_chunk_size?: number;
-  hierarchical_child_chunk_size?: number;
-  hierarchical_child_overlap?: number;
+export interface FixedChunkingConfig {
+  strategy: "fixed";
+  chunk_size: number;
+  overlap: number;
+  preserve_newlines: boolean;
+}
+
+export interface RecursiveChunkingConfig {
+  strategy: "recursive";
+  chunk_size: number;
+  overlap: number;
+  preserve_newlines: boolean;
+  separators: string[];
+}
+
+export interface SemanticChunkingConfig {
+  strategy: "semantic";
+  semantic_threshold: number;
+  semantic_buffer_size: number;
+  min_chunk_size: number;
+  max_chunk_size: number;
+}
+
+export interface HierarchicalChunkingConfig {
+  strategy: "hierarchical";
+  preserve_newlines: boolean;
+  separators: string[];
+  hierarchical_parent_chunk_size: number;
+  hierarchical_child_chunk_size: number;
+  hierarchical_child_overlap: number;
+}
+
+export type ChunkingConfig =
+  | FixedChunkingConfig
+  | RecursiveChunkingConfig
+  | SemanticChunkingConfig
+  | HierarchicalChunkingConfig;
+
+export function createDefaultChunkingConfig(
+  strategy: ChunkingStrategy = "recursive",
+): ChunkingConfig {
+  switch (strategy) {
+    case "fixed":
+      return {
+        strategy,
+        chunk_size: 800,
+        overlap: 100,
+        preserve_newlines: true,
+      };
+    case "semantic":
+      return {
+        strategy,
+        semantic_threshold: 0.85,
+        semantic_buffer_size: 1,
+        min_chunk_size: 50,
+        max_chunk_size: 2000,
+      };
+    case "hierarchical":
+      return {
+        strategy,
+        preserve_newlines: true,
+        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+        hierarchical_parent_chunk_size: 1024,
+        hierarchical_child_chunk_size: 256,
+        hierarchical_child_overlap: 51,
+      };
+    case "recursive":
+    default:
+      return {
+        strategy: "recursive",
+        chunk_size: 800,
+        overlap: 100,
+        preserve_newlines: true,
+        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+      };
+  }
+}
+
+export function normalizeChunkingConfig(
+  config?: Record<string, unknown> | null,
+): ChunkingConfig {
+  const strategy = (config?.strategy as ChunkingStrategy | undefined) || "recursive";
+
+  switch (strategy) {
+    case "fixed": {
+      const defaults = createDefaultChunkingConfig("fixed") as FixedChunkingConfig;
+      return {
+        strategy,
+        chunk_size: Number(config?.chunk_size ?? defaults.chunk_size),
+        overlap: Number(config?.overlap ?? defaults.overlap),
+        preserve_newlines:
+          typeof config?.preserve_newlines === "boolean"
+            ? config.preserve_newlines
+            : defaults.preserve_newlines,
+      };
+    }
+    case "semantic": {
+      const defaults = createDefaultChunkingConfig("semantic") as SemanticChunkingConfig;
+      return {
+        strategy,
+        semantic_threshold: Number(config?.semantic_threshold ?? defaults.semantic_threshold),
+        semantic_buffer_size: Number(config?.semantic_buffer_size ?? defaults.semantic_buffer_size),
+        min_chunk_size: Number(config?.min_chunk_size ?? defaults.min_chunk_size),
+        max_chunk_size: Number(config?.max_chunk_size ?? defaults.max_chunk_size),
+      };
+    }
+    case "hierarchical": {
+      const defaults = createDefaultChunkingConfig("hierarchical") as HierarchicalChunkingConfig;
+      return {
+        strategy,
+        preserve_newlines:
+          typeof config?.preserve_newlines === "boolean"
+            ? config.preserve_newlines
+            : defaults.preserve_newlines,
+        separators: Array.isArray(config?.separators)
+          ? (config.separators as string[])
+          : defaults.separators,
+        hierarchical_parent_chunk_size: Number(
+          config?.hierarchical_parent_chunk_size ?? defaults.hierarchical_parent_chunk_size,
+        ),
+        hierarchical_child_chunk_size: Number(
+          config?.hierarchical_child_chunk_size ?? defaults.hierarchical_child_chunk_size,
+        ),
+        hierarchical_child_overlap: Number(
+          config?.hierarchical_child_overlap ?? defaults.hierarchical_child_overlap,
+        ),
+      };
+    }
+    case "recursive":
+    default: {
+      const defaults = createDefaultChunkingConfig("recursive") as RecursiveChunkingConfig;
+      return {
+        strategy: "recursive",
+        chunk_size: Number(config?.chunk_size ?? defaults.chunk_size),
+        overlap: Number(config?.overlap ?? defaults.overlap),
+        preserve_newlines:
+          typeof config?.preserve_newlines === "boolean"
+            ? config.preserve_newlines
+            : defaults.preserve_newlines,
+        separators: Array.isArray(config?.separators)
+          ? (config.separators as string[])
+          : defaults.separators,
+      };
+    }
+  }
+}
+
+function buildChunkingConfigFromLegacyFields(
+  params: LegacyChunkingFields,
+): ChunkingConfig | undefined {
+  const strategy = params.strategy;
+  if (!strategy) return undefined;
+
+  return normalizeChunkingConfig({
+    strategy,
+    chunk_size: params.chunk_size,
+    overlap: params.overlap,
+    preserve_newlines: params.preserve_newlines,
+    separators: params.separators,
+    semantic_threshold: params.semantic_threshold,
+    semantic_buffer_size: params.semantic_buffer_size,
+    min_chunk_size: params.min_chunk_size,
+    max_chunk_size: params.max_chunk_size,
+    hierarchical_parent_chunk_size: params.hierarchical_parent_chunk_size,
+    hierarchical_child_chunk_size: params.hierarchical_child_chunk_size,
+    hierarchical_child_overlap: params.hierarchical_child_overlap,
+  });
+}
+
+function resolveChunkingConfig(
+  params?: ChunkingRequestFields,
+): ChunkingConfig | undefined {
+  if (!params) return undefined;
+  if (params.chunking_config) {
+    return normalizeChunkingConfig(params.chunking_config as unknown as Record<string, unknown>);
+  }
+  return buildChunkingConfigFromLegacyFields(params as LegacyChunkingFields);
+}
+
+function validateChunkingConfig(config?: ChunkingConfig): void {
+  if (!config) return;
+
+  if (config.strategy === "fixed" || config.strategy === "recursive") {
+    if (config.chunk_size < 1 || config.chunk_size > 100000) {
+      throw new InvalidChunkSizeError({ chunk_size: config.chunk_size });
+    }
+    const maxOverlap = Math.floor(config.chunk_size * 0.5);
+    if (config.overlap < 0 || config.overlap > maxOverlap) {
+      throw new InvalidChunkSizeError({
+        overlap: config.overlap,
+        max_overlap: maxOverlap,
+      });
+    }
+  }
+
+  if (config.strategy === "semantic") {
+    if (config.semantic_buffer_size < 1 || config.semantic_buffer_size > 5) {
+      throw new ValidationError({
+        field: "semantic_buffer_size",
+        min: 1,
+        max: 5,
+        value: config.semantic_buffer_size,
+      });
+    }
+    if (config.min_chunk_size < 1 || config.max_chunk_size < config.min_chunk_size) {
+      throw new ValidationError({
+        field: "semantic_chunk_size_range",
+        min_chunk_size: config.min_chunk_size,
+        max_chunk_size: config.max_chunk_size,
+      });
+    }
+  }
+
+  if (config.strategy === "hierarchical") {
+    if (config.hierarchical_parent_chunk_size < config.hierarchical_child_chunk_size) {
+      throw new ValidationError({
+        field: "hierarchical_parent_chunk_size",
+        parent: config.hierarchical_parent_chunk_size,
+        child: config.hierarchical_child_chunk_size,
+      });
+    }
+    if (
+      config.hierarchical_child_overlap < 0 ||
+      config.hierarchical_child_overlap >= config.hierarchical_child_chunk_size
+    ) {
+      throw new ValidationError({
+        field: "hierarchical_child_overlap",
+        overlap: config.hierarchical_child_overlap,
+        max_overlap: config.hierarchical_child_chunk_size - 1,
+      });
+    }
+  }
+}
+
+function buildJsonChunkingPayload(params?: ChunkingRequestFields): Record<string, unknown> {
+  const config = resolveChunkingConfig(params);
+  validateChunkingConfig(config);
+  return config ? { chunking_config: config } : {};
+}
+
+function appendChunkingConfigToFormData(
+  formData: FormData,
+  params?: ChunkingRequestFields,
+): void {
+  const config = resolveChunkingConfig(params);
+  validateChunkingConfig(config);
+
+  if (!config) return;
+
+  formData.set("strategy", config.strategy);
+
+  if (config.strategy === "fixed") {
+    formData.set("chunk_size", String(config.chunk_size));
+    formData.set("overlap", String(config.overlap));
+    formData.set("preserve_newlines", String(config.preserve_newlines));
+    return;
+  }
+
+  if (config.strategy === "recursive") {
+    formData.set("chunk_size", String(config.chunk_size));
+    formData.set("overlap", String(config.overlap));
+    formData.set("preserve_newlines", String(config.preserve_newlines));
+    if (config.separators.length > 0) {
+      formData.set("separators", JSON.stringify(config.separators));
+    }
+    return;
+  }
+
+  if (config.strategy === "semantic") {
+    formData.set("semantic_threshold", String(config.semantic_threshold));
+    formData.set("semantic_buffer_size", String(config.semantic_buffer_size));
+    formData.set("min_chunk_size", String(config.min_chunk_size));
+    formData.set("max_chunk_size", String(config.max_chunk_size));
+    return;
+  }
+
+  formData.set("preserve_newlines", String(config.preserve_newlines));
+  if (config.separators.length > 0) {
+    formData.set("separators", JSON.stringify(config.separators));
+  }
+  formData.set(
+    "hierarchical_parent_chunk_size",
+    String(config.hierarchical_parent_chunk_size),
+  );
+  formData.set(
+    "hierarchical_child_chunk_size",
+    String(config.hierarchical_child_chunk_size),
+  );
+  formData.set(
+    "hierarchical_child_overlap",
+    String(config.hierarchical_child_overlap),
+  );
 }
 
 export interface SearchConfig {
@@ -134,12 +412,7 @@ export interface CorpusRecord {
   app_name: string;
   description?: string;
   knowledge_count: number;
-  config?: {
-    chunk_size?: number;
-    overlap?: number;
-    embedding_model?: string;
-    [key: string]: unknown;
-  };
+  config?: Record<string, unknown>;
 }
 
 export interface KnowledgeMatch {
@@ -225,6 +498,29 @@ export interface IngestResult {
   count: number;
   items: string[];
 }
+
+type LegacyChunkingFields = {
+  strategy?: ChunkingStrategy;
+  chunk_size?: number;
+  overlap?: number;
+  preserve_newlines?: boolean;
+  separators?: string[];
+  semantic_threshold?: number;
+  semantic_buffer_size?: number;
+  min_chunk_size?: number;
+  max_chunk_size?: number;
+  hierarchical_parent_chunk_size?: number;
+  hierarchical_child_chunk_size?: number;
+  hierarchical_child_overlap?: number;
+};
+
+type ChunkingRequestFields =
+  | {
+      chunking_config?: ChunkingConfig;
+    }
+  | (LegacyChunkingFields & {
+      chunking_config?: ChunkingConfig;
+    });
 
 // 异步 Pipeline 响应类型
 export interface AsyncPipelineResult {
@@ -475,35 +771,19 @@ export async function ingestText(
     text: string;
     source_uri?: string;
     metadata?: Record<string, unknown>;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<AsyncPipelineResult> {
-  // 前端配置验证（对齐后端 types.py）
-  const { chunk_size, overlap } = params;
-  if (chunk_size !== undefined && (chunk_size < 1 || chunk_size > 100000)) {
-    throw new InvalidChunkSizeError({ chunk_size });
-  }
-  if (overlap !== undefined) {
-    const maxSize = chunk_size || 800;
-    if (overlap < 0 || overlap >= maxSize) {
-      throw new InvalidChunkSizeError({ overlap, max_overlap: maxSize - 1 });
-    }
-  }
-
+  const { app_name, text, source_uri, metadata, ...chunkingParams } = params;
   const res = await fetch(`/api/knowledge/base/${id}/ingest`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
+    body: JSON.stringify({
+      app_name,
+      text,
+      source_uri,
+      metadata,
+      ...buildJsonChunkingPayload(chunkingParams),
+    }),
   });
   return handleKnowledgeError(res);
 }
@@ -515,23 +795,19 @@ export async function ingestUrl(
     url: string;
     as_document?: boolean;
     metadata?: Record<string, unknown>;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<AsyncPipelineResult> {
+  const { app_name, url, as_document, metadata, ...chunkingParams } = params;
   const res = await fetch(`/api/knowledge/base/${id}/ingest_url`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
+    body: JSON.stringify({
+      app_name,
+      url,
+      as_document,
+      metadata,
+      ...buildJsonChunkingPayload(chunkingParams),
+    }),
   });
   return handleKnowledgeError(res);
 }
@@ -543,18 +819,7 @@ export async function ingestFile(
     file: File;
     source_uri?: string;
     metadata?: Record<string, unknown>;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<IngestResult> {
   const formData = new FormData();
 
@@ -562,42 +827,7 @@ export async function ingestFile(
   formData.set("file", params.file);
   if (params.source_uri) formData.set("source_uri", params.source_uri);
   if (params.metadata) formData.set("metadata", JSON.stringify(params.metadata));
-  if (params.chunk_size) formData.set("chunk_size", String(params.chunk_size));
-  if (params.overlap !== undefined) formData.set("overlap", String(params.overlap));
-  if (params.strategy) formData.set("strategy", params.strategy);
-  if (params.preserve_newlines !== undefined) {
-    formData.set("preserve_newlines", String(params.preserve_newlines));
-  }
-  if (params.separators && params.separators.length > 0) {
-    formData.set("separators", JSON.stringify(params.separators));
-  }
-  if (params.semantic_threshold !== undefined) {
-    formData.set("semantic_threshold", String(params.semantic_threshold));
-  }
-  if (params.min_chunk_size !== undefined) {
-    formData.set("min_chunk_size", String(params.min_chunk_size));
-  }
-  if (params.max_chunk_size !== undefined) {
-    formData.set("max_chunk_size", String(params.max_chunk_size));
-  }
-  if (params.hierarchical_parent_chunk_size !== undefined) {
-    formData.set(
-      "hierarchical_parent_chunk_size",
-      String(params.hierarchical_parent_chunk_size),
-    );
-  }
-  if (params.hierarchical_child_chunk_size !== undefined) {
-    formData.set(
-      "hierarchical_child_chunk_size",
-      String(params.hierarchical_child_chunk_size),
-    );
-  }
-  if (params.hierarchical_child_overlap !== undefined) {
-    formData.set(
-      "hierarchical_child_overlap",
-      String(params.hierarchical_child_overlap),
-    );
-  }
+  appendChunkingConfigToFormData(formData, params);
 
   const res = await fetch(`/api/knowledge/base/${id}/ingest_file`, {
     method: "POST",
@@ -902,20 +1132,13 @@ export async function syncDocument(
   documentId: string,
   params: {
     app_name?: string;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  } = {},
+  } & ChunkingRequestFields = {},
 ): Promise<AsyncPipelineResult> {
-  return postDocumentAction(corpusId, documentId, "sync", params) as Promise<AsyncPipelineResult>;
+  const { app_name, ...chunkingParams } = params;
+  return postDocumentAction(corpusId, documentId, "sync", {
+    app_name,
+    ...buildJsonChunkingPayload(chunkingParams),
+  }) as Promise<AsyncPipelineResult>;
 }
 
 export async function rebuildDocument(
@@ -923,20 +1146,13 @@ export async function rebuildDocument(
   documentId: string,
   params: {
     app_name?: string;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  } = {},
+  } & ChunkingRequestFields = {},
 ): Promise<AsyncPipelineResult> {
-  return postDocumentAction(corpusId, documentId, "rebuild", params) as Promise<AsyncPipelineResult>;
+  const { app_name, ...chunkingParams } = params;
+  return postDocumentAction(corpusId, documentId, "rebuild", {
+    app_name,
+    ...buildJsonChunkingPayload(chunkingParams),
+  }) as Promise<AsyncPipelineResult>;
 }
 
 export async function replaceDocument(
@@ -945,20 +1161,14 @@ export async function replaceDocument(
   params: {
     app_name?: string;
     text: string;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<AsyncPipelineResult> {
-  return postDocumentAction(corpusId, documentId, "replace", params) as Promise<AsyncPipelineResult>;
+  const { app_name, text, ...chunkingParams } = params;
+  return postDocumentAction(corpusId, documentId, "replace", {
+    app_name,
+    text,
+    ...buildJsonChunkingPayload(chunkingParams),
+  }) as Promise<AsyncPipelineResult>;
 }
 
 export async function archiveDocument(
@@ -988,23 +1198,19 @@ export async function replaceSource(
     text: string;
     source_uri: string;
     metadata?: Record<string, unknown>;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<AsyncPipelineResult> {
+  const { app_name, text, source_uri, metadata, ...chunkingParams } = params;
   const res = await fetch(`/api/knowledge/base/${id}/replace_source`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
+    body: JSON.stringify({
+      app_name,
+      text,
+      source_uri,
+      metadata,
+      ...buildJsonChunkingPayload(chunkingParams),
+    }),
   });
   return handleKnowledgeError(res);
 }
@@ -1014,23 +1220,17 @@ export async function syncSource(
   params: {
     app_name?: string;
     source_uri: string;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<AsyncPipelineResult> {
+  const { app_name, source_uri, ...chunkingParams } = params;
   const res = await fetch(`/api/knowledge/base/${id}/sync_source`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
+    body: JSON.stringify({
+      app_name,
+      source_uri,
+      ...buildJsonChunkingPayload(chunkingParams),
+    }),
   });
   return handleKnowledgeError(res);
 }
@@ -1040,23 +1240,17 @@ export async function rebuildSource(
   params: {
     app_name?: string;
     source_uri: string;
-    strategy?: ChunkingStrategy;
-    chunk_size?: number;
-    overlap?: number;
-    preserve_newlines?: boolean;
-    separators?: string[];
-    semantic_threshold?: number;
-    min_chunk_size?: number;
-    max_chunk_size?: number;
-    hierarchical_parent_chunk_size?: number;
-    hierarchical_child_chunk_size?: number;
-    hierarchical_child_overlap?: number;
-  },
+  } & ChunkingRequestFields,
 ): Promise<AsyncPipelineResult> {
+  const { app_name, source_uri, ...chunkingParams } = params;
   const res = await fetch(`/api/knowledge/base/${id}/rebuild_source`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
+    body: JSON.stringify({
+      app_name,
+      source_uri,
+      ...buildJsonChunkingPayload(chunkingParams),
+    }),
   });
   return handleKnowledgeError(res);
 }

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -63,6 +63,52 @@ vi.mock("@/features/knowledge", () => ({
   fetchDocuments: (...args: unknown[]) => fetchDocumentsMock(...args),
   fetchDocumentChunks: (...args: unknown[]) => fetchDocumentChunksMock(...args),
   searchAcrossCorpora: (...args: unknown[]) => searchAcrossCorporaMock(...args),
+  createDefaultChunkingConfig: (strategy: string = "recursive") => {
+    if (strategy === "semantic") {
+      return {
+        strategy: "semantic",
+        semantic_threshold: 0.85,
+        semantic_buffer_size: 1,
+        min_chunk_size: 50,
+        max_chunk_size: 2000,
+      };
+    }
+    if (strategy === "hierarchical") {
+      return {
+        strategy: "hierarchical",
+        preserve_newlines: true,
+        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+        hierarchical_parent_chunk_size: 1024,
+        hierarchical_child_chunk_size: 256,
+        hierarchical_child_overlap: 51,
+      };
+    }
+    if (strategy === "fixed") {
+      return {
+        strategy: "fixed",
+        chunk_size: 800,
+        overlap: 100,
+        preserve_newlines: true,
+      };
+    }
+    return {
+      strategy: "recursive",
+      chunk_size: 800,
+      overlap: 100,
+      preserve_newlines: true,
+      separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+    };
+  },
+  normalizeChunkingConfig: (config: Record<string, unknown> | null | undefined) =>
+    config?.strategy
+      ? config
+      : {
+          strategy: "recursive",
+          chunk_size: 800,
+          overlap: 100,
+          preserve_newlines: true,
+          separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+        },
   DocumentViewDialog: ({
     isOpen,
     document,
@@ -421,7 +467,13 @@ describe("KnowledgeBasePage", () => {
     expect(ingestUrlMock).toHaveBeenCalledWith({
       url: "https://example.com/article",
       as_document: true,
-      chunkingConfig: {},
+      chunkingConfig: {
+        strategy: "recursive",
+        chunk_size: 800,
+        overlap: 100,
+        preserve_newlines: true,
+        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+      },
     });
   });
 
@@ -439,6 +491,34 @@ describe("KnowledgeBasePage", () => {
       screen.getByRole("heading", { name: "Settings" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
+  });
+
+  it("settings 视图中 semantic 与 hierarchical 只展示各自有效字段", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=settings";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await user.click(screen.getByRole("button", { name: /semantic/i }));
+
+    expect(screen.queryByText("Chunk Size")).not.toBeInTheDocument();
+    expect(screen.queryByText("Overlap")).not.toBeInTheDocument();
+    expect(screen.getByText("Buffer Size")).toBeInTheDocument();
+    expect(screen.getByText("Min Chunk Size")).toBeInTheDocument();
+    expect(screen.getByText("Max Chunk Size")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /hierarchical/i }));
+
+    expect(screen.queryByText("Chunk Size")).not.toBeInTheDocument();
+    expect(screen.queryByText("Overlap")).not.toBeInTheDocument();
+    expect(screen.getByText("Parent Size")).toBeInTheDocument();
+    expect(screen.getByText("Child Size")).toBeInTheDocument();
+    expect(screen.getByText("Child Overlap")).toBeInTheDocument();
   });
 
   it("进入 document-chunks 视图时使用不超过后端约束的 limit=200", async () => {

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -1,4 +1,5 @@
 import {
+  createDefaultChunkingConfig,
   fetchCorpus,
   fetchDocumentChunks,
   fetchDocuments,
@@ -96,13 +97,14 @@ describe("fetchCorpus", () => {
 
     await ingestText("corpus-1", {
       text: "hello",
-      strategy: "hierarchical",
-      chunk_size: 800,
-      overlap: 100,
-      semantic_threshold: 0.9,
-      hierarchical_parent_chunk_size: 1024,
-      hierarchical_child_chunk_size: 256,
-      hierarchical_child_overlap: 51,
+      chunking_config: {
+        strategy: "hierarchical",
+        preserve_newlines: true,
+        separators: ["\n\n", "\n"],
+        hierarchical_parent_chunk_size: 1024,
+        hierarchical_child_chunk_size: 256,
+        hierarchical_child_overlap: 51,
+      },
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -112,13 +114,14 @@ describe("fetchCorpus", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           text: "hello",
-          strategy: "hierarchical",
-          chunk_size: 800,
-          overlap: 100,
-          semantic_threshold: 0.9,
-          hierarchical_parent_chunk_size: 1024,
-          hierarchical_child_chunk_size: 256,
-          hierarchical_child_overlap: 51,
+          chunking_config: {
+            strategy: "hierarchical",
+            preserve_newlines: true,
+            separators: ["\n\n", "\n"],
+            hierarchical_parent_chunk_size: 1024,
+            hierarchical_child_chunk_size: 256,
+            hierarchical_child_overlap: 51,
+          },
         }),
       }),
     );
@@ -134,10 +137,7 @@ describe("fetchCorpus", () => {
 
     await ingestFile("corpus-1", {
       file: new File(["hello"], "a.txt", { type: "text/plain" }),
-      strategy: "hierarchical",
-      hierarchical_parent_chunk_size: 1024,
-      hierarchical_child_chunk_size: 256,
-      hierarchical_child_overlap: 51,
+      chunking_config: createDefaultChunkingConfig("hierarchical"),
     });
 
     const [, init] = fetchSpy.mock.calls[0];

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -39,6 +39,13 @@ from .exceptions import (
 from .graph_service import GraphService, GraphBuildConfig, GraphQueryConfig, get_graph_service
 from .service import KnowledgeService
 from .types import ChunkingConfig, CorpusSpec, SearchConfig, GraphSearchConfig
+from .types import (
+    chunking_config_summary,
+    create_chunking_config,
+    default_chunking_config,
+    normalize_chunking_config,
+    serialize_chunking_config,
+)
 
 
 logger = get_logger("negentropy.knowledge.api")
@@ -67,90 +74,51 @@ class CorpusResponse(BaseModel):
     knowledge_count: int = 0
 
 
-class IngestRequest(BaseModel):
+class _LegacyChunkingRequest(BaseModel):
+    chunking_config: Optional[Dict[str, Any]] = None
+    strategy: Optional[str] = None
+    chunk_size: Optional[int] = None
+    overlap: Optional[int] = None
+    preserve_newlines: Optional[bool] = None
+    separators: Optional[list[str]] = None
+    semantic_threshold: Optional[float] = None
+    semantic_buffer_size: Optional[int] = None
+    min_chunk_size: Optional[int] = None
+    max_chunk_size: Optional[int] = None
+    hierarchical_parent_chunk_size: Optional[int] = None
+    hierarchical_child_chunk_size: Optional[int] = None
+    hierarchical_child_overlap: Optional[int] = None
+
+
+class IngestRequest(_LegacyChunkingRequest):
     app_name: Optional[str] = None
     text: str
     source_uri: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    strategy: Optional[str] = None
-    chunk_size: Optional[int] = None
-    overlap: Optional[int] = None
-    preserve_newlines: Optional[bool] = None
-    separators: Optional[list[str]] = None
-    semantic_threshold: Optional[float] = None
-    min_chunk_size: Optional[int] = None
-    max_chunk_size: Optional[int] = None
-    hierarchical_parent_chunk_size: Optional[int] = None
-    hierarchical_child_chunk_size: Optional[int] = None
-    hierarchical_child_overlap: Optional[int] = None
 
 
-class IngestUrlRequest(BaseModel):
+class IngestUrlRequest(_LegacyChunkingRequest):
     app_name: Optional[str] = None
     url: str
     as_document: bool = False
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    strategy: Optional[str] = None
-    chunk_size: Optional[int] = None
-    overlap: Optional[int] = None
-    preserve_newlines: Optional[bool] = None
-    separators: Optional[list[str]] = None
-    semantic_threshold: Optional[float] = None
-    min_chunk_size: Optional[int] = None
-    max_chunk_size: Optional[int] = None
-    hierarchical_parent_chunk_size: Optional[int] = None
-    hierarchical_child_chunk_size: Optional[int] = None
-    hierarchical_child_overlap: Optional[int] = None
 
 
-class ReplaceSourceRequest(BaseModel):
+class ReplaceSourceRequest(_LegacyChunkingRequest):
     app_name: Optional[str] = None
     text: str
     source_uri: str
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    strategy: Optional[str] = None
-    chunk_size: Optional[int] = None
-    overlap: Optional[int] = None
-    preserve_newlines: Optional[bool] = None
-    separators: Optional[list[str]] = None
-    semantic_threshold: Optional[float] = None
-    min_chunk_size: Optional[int] = None
-    max_chunk_size: Optional[int] = None
-    hierarchical_parent_chunk_size: Optional[int] = None
-    hierarchical_child_chunk_size: Optional[int] = None
-    hierarchical_child_overlap: Optional[int] = None
 
 
-class SyncSourceRequest(BaseModel):
+class SyncSourceRequest(_LegacyChunkingRequest):
     app_name: Optional[str] = None
     source_uri: str
-    strategy: Optional[str] = None
-    chunk_size: Optional[int] = None
-    overlap: Optional[int] = None
-    preserve_newlines: Optional[bool] = None
-    separators: Optional[list[str]] = None
-    semantic_threshold: Optional[float] = None
-    min_chunk_size: Optional[int] = None
-    max_chunk_size: Optional[int] = None
-    hierarchical_parent_chunk_size: Optional[int] = None
-    hierarchical_child_chunk_size: Optional[int] = None
-    hierarchical_child_overlap: Optional[int] = None
 
 
-class RebuildSourceRequest(BaseModel):
+class RebuildSourceRequest(_LegacyChunkingRequest):
     app_name: Optional[str] = None
     source_uri: str
-    strategy: Optional[str] = None
-    chunk_size: Optional[int] = None
-    overlap: Optional[int] = None
-    preserve_newlines: Optional[bool] = None
-    separators: Optional[list[str]] = None
-    semantic_threshold: Optional[float] = None
-    min_chunk_size: Optional[int] = None
-    max_chunk_size: Optional[int] = None
-    hierarchical_parent_chunk_size: Optional[int] = None
-    hierarchical_child_chunk_size: Optional[int] = None
-    hierarchical_child_overlap: Optional[int] = None
 
 
 class DeleteSourceRequest(BaseModel):
@@ -373,52 +341,11 @@ def _map_exception_to_http(exc: KnowledgeError) -> HTTPException:
 
 
 def _build_chunking_config(
-    *,
-    strategy: Optional[str],
-    chunk_size: Optional[int],
-    overlap: Optional[int],
-    preserve_newlines: Optional[bool],
-    separators: Optional[list[str]] = None,
-    semantic_threshold: Optional[float] = None,
-    min_chunk_size: Optional[int] = None,
-    max_chunk_size: Optional[int] = None,
-    hierarchical_parent_chunk_size: Optional[int] = None,
-    hierarchical_child_chunk_size: Optional[int] = None,
-    hierarchical_child_overlap: Optional[int] = None,
+    payload: Optional[Dict[str, Any]],
 ) -> Optional[ChunkingConfig]:
-    """构建分块配置
-
-    使用常量而非魔法数字，遵循 Single Source of Truth 原则。
-    """
-    if (
-        strategy is None
-        and chunk_size is None
-        and overlap is None
-        and preserve_newlines is None
-        and separators is None
-        and semantic_threshold is None
-        and min_chunk_size is None
-        and max_chunk_size is None
-        and hierarchical_parent_chunk_size is None
-        and hierarchical_child_chunk_size is None
-        and hierarchical_child_overlap is None
-    ):
+    if not payload:
         return None
-    return ChunkingConfig(
-        strategy=strategy or "recursive",
-        chunk_size=chunk_size or DEFAULT_CHUNK_SIZE,
-        overlap=overlap or DEFAULT_OVERLAP,
-        preserve_newlines=True if preserve_newlines is None else preserve_newlines,
-        separators=separators or [],
-        semantic_threshold=0.85 if semantic_threshold is None else semantic_threshold,
-        min_chunk_size=50 if min_chunk_size is None else min_chunk_size,
-        max_chunk_size=2000 if max_chunk_size is None else max_chunk_size,
-        hierarchical_parent_chunk_size=1024
-        if hierarchical_parent_chunk_size is None
-        else hierarchical_parent_chunk_size,
-        hierarchical_child_chunk_size=256 if hierarchical_child_chunk_size is None else hierarchical_child_chunk_size,
-        hierarchical_child_overlap=51 if hierarchical_child_overlap is None else hierarchical_child_overlap,
-    )
+    return normalize_chunking_config(payload)
 
 
 def _infer_source_type(source_uri: Optional[str]) -> str:
@@ -439,6 +366,43 @@ def _resolve_chunking_option(
     if request_value is not None:
         return request_value
     return corpus_config.get(key)
+
+
+def _extract_legacy_chunking_payload(payload: _LegacyChunkingRequest) -> Dict[str, Any]:
+    candidate = {
+        "strategy": payload.strategy,
+        "chunk_size": payload.chunk_size,
+        "overlap": payload.overlap,
+        "preserve_newlines": payload.preserve_newlines,
+        "separators": payload.separators,
+        "semantic_threshold": payload.semantic_threshold,
+        "semantic_buffer_size": payload.semantic_buffer_size,
+        "min_chunk_size": payload.min_chunk_size,
+        "max_chunk_size": payload.max_chunk_size,
+        "hierarchical_parent_chunk_size": payload.hierarchical_parent_chunk_size,
+        "hierarchical_child_chunk_size": payload.hierarchical_child_chunk_size,
+        "hierarchical_child_overlap": payload.hierarchical_child_overlap,
+    }
+    return {key: value for key, value in candidate.items() if value is not None}
+
+
+def _resolve_chunking_config(
+    *,
+    chunking_config: Optional[Dict[str, Any]],
+    legacy_payload: Optional[Dict[str, Any]],
+    corpus_config: Dict[str, Any],
+) -> Optional[ChunkingConfig]:
+    if chunking_config:
+        return normalize_chunking_config(chunking_config)
+    if legacy_payload:
+        strategy = legacy_payload.get("strategy") or corpus_config.get("strategy") or "recursive"
+        merged = dict(corpus_config)
+        merged.update(legacy_payload)
+        merged["strategy"] = strategy
+        return normalize_chunking_config(merged)
+    if corpus_config:
+        return normalize_chunking_config(corpus_config)
+    return None
 
 
 def _normalize_source_metadata(
@@ -500,7 +464,7 @@ async def list_corpora(app_name: Optional[str] = Query(default=None)) -> list[Co
             app_name=corpus.app_name,
             name=corpus.name,
             description=corpus.description,
-            config=corpus.config or {},
+            config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
             knowledge_count=count or 0,
         )
         for corpus, count in rows
@@ -510,11 +474,12 @@ async def list_corpora(app_name: Optional[str] = Query(default=None)) -> list[Co
 @router.post("/base", response_model=CorpusResponse)
 async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
     service = _get_service()
+    normalized_config = serialize_chunking_config(normalize_chunking_config(payload.config or None))
     spec = CorpusSpec(
         app_name=_resolve_app_name(payload.app_name),
         name=payload.name,
         description=payload.description,
-        config=payload.config,
+        config=normalized_config,
     )
     corpus = await service.ensure_corpus(spec=spec)
     return CorpusResponse(
@@ -522,7 +487,7 @@ async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
         app_name=corpus.app_name,
         name=corpus.name,
         description=corpus.description,
-        config=corpus.config,
+        config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
         knowledge_count=0,
     )
 
@@ -549,7 +514,7 @@ async def get_corpus(corpus_id: UUID, app_name: Optional[str] = Query(default=No
         app_name=corpus.app_name,
         name=corpus.name,
         description=corpus.description,
-        config=corpus.config or {},
+        config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
         knowledge_count=count or 0,
     )
 
@@ -558,6 +523,8 @@ async def get_corpus(corpus_id: UUID, app_name: Optional[str] = Query(default=No
 async def update_corpus(corpus_id: UUID, payload: CorpusUpdateRequest) -> CorpusResponse:
     service = _get_service()
     update_data = payload.model_dump(exclude_unset=True)
+    if "config" in update_data:
+        update_data["config"] = serialize_chunking_config(normalize_chunking_config(update_data["config"] or None))
     if not update_data:
         raise HTTPException(status_code=400, detail="No fields to update")
 
@@ -580,7 +547,7 @@ async def update_corpus(corpus_id: UUID, payload: CorpusUpdateRequest) -> Corpus
             app_name=corpus.app_name,
             name=corpus.name,
             description=corpus.description,
-            config=corpus.config or {},
+            config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
             knowledge_count=knowledge_count or 0,
         )
     except ValueError as exc:
@@ -652,43 +619,10 @@ async def ingest_text(
         corpus = await service.get_corpus_by_id(corpus_id)
         corpus_config = corpus.config if corpus else {}
 
-        # 构建配置：请求参数 > corpus 配置 > 默认值
-        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
-        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
-        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
-        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
-        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
-        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
-        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
-        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
-        hierarchical_parent_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_parent_chunk_size,
-            corpus_config,
-            "hierarchical_parent_chunk_size",
-        )
-        hierarchical_child_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_child_chunk_size,
-            corpus_config,
-            "hierarchical_child_chunk_size",
-        )
-        hierarchical_child_overlap = _resolve_chunking_option(
-            payload.hierarchical_child_overlap,
-            corpus_config,
-            "hierarchical_child_overlap",
-        )
-
-        chunking_config = _build_chunking_config(
-            strategy=strategy,
-            chunk_size=chunk_size,
-            overlap=overlap,
-            preserve_newlines=preserve_newlines,
-            separators=separators,
-            semantic_threshold=semantic_threshold,
-            min_chunk_size=min_chunk_size,
-            max_chunk_size=max_chunk_size,
-            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
-            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
-            hierarchical_child_overlap=hierarchical_child_overlap,
+        chunking_config = _resolve_chunking_config(
+            chunking_config=payload.chunking_config,
+            legacy_payload=_extract_legacy_chunking_payload(payload),
+            corpus_config=corpus_config,
         )
 
         # 创建 Pipeline 记录
@@ -699,8 +633,7 @@ async def ingest_text(
                 "corpus_id": str(corpus_id),
                 "source_uri": payload.source_uri,
                 "text_length": len(payload.text),
-                "chunk_size": chunking_config.chunk_size if chunking_config else None,
-                "overlap": chunking_config.overlap if chunking_config else None,
+                "chunking_config": chunking_config_summary(chunking_config),
             },
         )
 
@@ -829,43 +762,10 @@ async def ingest_url(
         corpus = await service.get_corpus_by_id(corpus_id)
         corpus_config = corpus.config if corpus else {}
 
-        # 构建配置：请求参数 > corpus 配置 > 默认值
-        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
-        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
-        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
-        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
-        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
-        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
-        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
-        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
-        hierarchical_parent_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_parent_chunk_size,
-            corpus_config,
-            "hierarchical_parent_chunk_size",
-        )
-        hierarchical_child_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_child_chunk_size,
-            corpus_config,
-            "hierarchical_child_chunk_size",
-        )
-        hierarchical_child_overlap = _resolve_chunking_option(
-            payload.hierarchical_child_overlap,
-            corpus_config,
-            "hierarchical_child_overlap",
-        )
-
-        chunking_config = _build_chunking_config(
-            strategy=strategy,
-            chunk_size=chunk_size,
-            overlap=overlap,
-            preserve_newlines=preserve_newlines,
-            separators=separators,
-            semantic_threshold=semantic_threshold,
-            min_chunk_size=min_chunk_size,
-            max_chunk_size=max_chunk_size,
-            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
-            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
-            hierarchical_child_overlap=hierarchical_child_overlap,
+        chunking_config = _resolve_chunking_config(
+            chunking_config=payload.chunking_config,
+            legacy_payload=_extract_legacy_chunking_payload(payload),
+            corpus_config=corpus_config,
         )
 
         # URL 文档模式: 先落库为 Document，再异步入索引
@@ -915,8 +815,7 @@ async def ingest_url(
                     "as_document": True,
                     "document_id": str(doc_record.id),
                     "duplicate_document": not is_new_doc,
-                    "chunk_size": chunking_config.chunk_size if chunking_config else None,
-                    "overlap": chunking_config.overlap if chunking_config else None,
+                    "chunking_config": chunking_config_summary(chunking_config),
                 },
             )
 
@@ -953,8 +852,7 @@ async def ingest_url(
             input_data={
                 "corpus_id": str(corpus_id),
                 "url": payload.url,
-                "chunk_size": chunking_config.chunk_size if chunking_config else None,
-                "overlap": chunking_config.overlap if chunking_config else None,
+                "chunking_config": chunking_config_summary(chunking_config),
             },
         )
 
@@ -1096,6 +994,7 @@ async def ingest_file(
     preserve_newlines: Optional[bool] = Form(default=None),
     separators: Optional[str] = Form(default=None),
     semantic_threshold: Optional[float] = Form(default=None),
+    semantic_buffer_size: Optional[int] = Form(default=None),
     min_chunk_size: Optional[int] = Form(default=None),
     max_chunk_size: Optional[int] = Form(default=None),
     hierarchical_parent_chunk_size: Optional[int] = Form(default=None),
@@ -1249,51 +1148,27 @@ async def ingest_file(
         corpus = await service.get_corpus_by_id(corpus_id)
         corpus_config = corpus.config if corpus else {}
 
-        # 构建分块配置
-        final_strategy = _resolve_chunking_option(strategy, corpus_config, "strategy")
-        final_chunk_size = _resolve_chunking_option(chunk_size, corpus_config, "chunk_size")
-        final_overlap = _resolve_chunking_option(overlap, corpus_config, "overlap")
-        final_separators = _resolve_chunking_option(parsed_separators, corpus_config, "separators")
-        final_preserve_newlines = _resolve_chunking_option(
-            preserve_newlines,
-            corpus_config,
-            "preserve_newlines",
-        )
-        final_semantic_threshold = _resolve_chunking_option(
-            semantic_threshold,
-            corpus_config,
-            "semantic_threshold",
-        )
-        final_min_chunk_size = _resolve_chunking_option(min_chunk_size, corpus_config, "min_chunk_size")
-        final_max_chunk_size = _resolve_chunking_option(max_chunk_size, corpus_config, "max_chunk_size")
-        final_hierarchical_parent_chunk_size = _resolve_chunking_option(
-            hierarchical_parent_chunk_size,
-            corpus_config,
-            "hierarchical_parent_chunk_size",
-        )
-        final_hierarchical_child_chunk_size = _resolve_chunking_option(
-            hierarchical_child_chunk_size,
-            corpus_config,
-            "hierarchical_child_chunk_size",
-        )
-        final_hierarchical_child_overlap = _resolve_chunking_option(
-            hierarchical_child_overlap,
-            corpus_config,
-            "hierarchical_child_overlap",
-        )
-
-        chunking_config = _build_chunking_config(
-            strategy=final_strategy,
-            chunk_size=final_chunk_size,
-            overlap=final_overlap,
-            preserve_newlines=final_preserve_newlines,
-            separators=final_separators,
-            semantic_threshold=final_semantic_threshold,
-            min_chunk_size=final_min_chunk_size,
-            max_chunk_size=final_max_chunk_size,
-            hierarchical_parent_chunk_size=final_hierarchical_parent_chunk_size,
-            hierarchical_child_chunk_size=final_hierarchical_child_chunk_size,
-            hierarchical_child_overlap=final_hierarchical_child_overlap,
+        chunking_config = _resolve_chunking_config(
+            chunking_config=None,
+            legacy_payload={
+                key: value
+                for key, value in {
+                    "strategy": strategy,
+                    "chunk_size": chunk_size,
+                    "overlap": overlap,
+                    "preserve_newlines": preserve_newlines,
+                    "separators": parsed_separators,
+                    "semantic_threshold": semantic_threshold,
+                    "semantic_buffer_size": semantic_buffer_size,
+                    "min_chunk_size": min_chunk_size,
+                    "max_chunk_size": max_chunk_size,
+                    "hierarchical_parent_chunk_size": hierarchical_parent_chunk_size,
+                    "hierarchical_child_chunk_size": hierarchical_child_chunk_size,
+                    "hierarchical_child_overlap": hierarchical_child_overlap,
+                }.items()
+                if value is not None
+            },
+            corpus_config=corpus_config,
         )
 
         # 添加文件元数据
@@ -1409,19 +1284,8 @@ class DocumentChunksResponse(BaseModel):
     items: list[Dict[str, Any]]
 
 
-class DocumentActionRequest(BaseModel):
+class DocumentActionRequest(_LegacyChunkingRequest):
     app_name: Optional[str] = None
-    strategy: Optional[str] = None
-    chunk_size: Optional[int] = None
-    overlap: Optional[int] = None
-    preserve_newlines: Optional[bool] = None
-    separators: Optional[list[str]] = None
-    semantic_threshold: Optional[float] = None
-    min_chunk_size: Optional[int] = None
-    max_chunk_size: Optional[int] = None
-    hierarchical_parent_chunk_size: Optional[int] = None
-    hierarchical_child_chunk_size: Optional[int] = None
-    hierarchical_child_overlap: Optional[int] = None
 
 
 class DocumentReplaceRequest(DocumentActionRequest):
@@ -1772,41 +1636,10 @@ def _resolve_chunking_config_from_doc_request(
     payload: DocumentActionRequest,
     corpus_config: Dict[str, Any],
 ) -> Optional[ChunkingConfig]:
-    strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
-    chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
-    overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
-    preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
-    separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
-    semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
-    min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
-    max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
-    hierarchical_parent_chunk_size = _resolve_chunking_option(
-        payload.hierarchical_parent_chunk_size,
-        corpus_config,
-        "hierarchical_parent_chunk_size",
-    )
-    hierarchical_child_chunk_size = _resolve_chunking_option(
-        payload.hierarchical_child_chunk_size,
-        corpus_config,
-        "hierarchical_child_chunk_size",
-    )
-    hierarchical_child_overlap = _resolve_chunking_option(
-        payload.hierarchical_child_overlap,
-        corpus_config,
-        "hierarchical_child_overlap",
-    )
-    return _build_chunking_config(
-        strategy=strategy,
-        chunk_size=chunk_size,
-        overlap=overlap,
-        preserve_newlines=preserve_newlines,
-        separators=separators,
-        semantic_threshold=semantic_threshold,
-        min_chunk_size=min_chunk_size,
-        max_chunk_size=max_chunk_size,
-        hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
-        hierarchical_child_chunk_size=hierarchical_child_chunk_size,
-        hierarchical_child_overlap=hierarchical_child_overlap,
+    return _resolve_chunking_config(
+        chunking_config=payload.chunking_config,
+        legacy_payload=_extract_legacy_chunking_payload(payload),
+        corpus_config=corpus_config,
     )
 
 
@@ -1936,8 +1769,7 @@ async def sync_document(
             "source_uri": source_uri,
             "document_id": str(document_id),
             "sync_document": True,
-            "chunk_size": chunking_config.chunk_size if chunking_config else None,
-            "overlap": chunking_config.overlap if chunking_config else None,
+            "chunking_config": chunking_config_summary(chunking_config),
         },
     )
     background_tasks.add_task(
@@ -2213,18 +2045,11 @@ async def replace_source(
 
     try:
         service = _get_service()
-        chunking_config = _build_chunking_config(
-            strategy=payload.strategy,
-            chunk_size=payload.chunk_size,
-            overlap=payload.overlap,
-            preserve_newlines=payload.preserve_newlines,
-            separators=payload.separators,
-            semantic_threshold=payload.semantic_threshold,
-            min_chunk_size=payload.min_chunk_size,
-            max_chunk_size=payload.max_chunk_size,
-            hierarchical_parent_chunk_size=payload.hierarchical_parent_chunk_size,
-            hierarchical_child_chunk_size=payload.hierarchical_child_chunk_size,
-            hierarchical_child_overlap=payload.hierarchical_child_overlap,
+        corpus = await service.get_corpus_by_id(corpus_id)
+        chunking_config = _resolve_chunking_config(
+            chunking_config=payload.chunking_config,
+            legacy_payload=_extract_legacy_chunking_payload(payload),
+            corpus_config=corpus.config if corpus else {},
         )
 
         # 创建 Pipeline 记录
@@ -2235,8 +2060,7 @@ async def replace_source(
                 "corpus_id": str(corpus_id),
                 "source_uri": payload.source_uri,
                 "text_length": len(payload.text),
-                "chunk_size": chunking_config.chunk_size if chunking_config else None,
-                "overlap": chunking_config.overlap if chunking_config else None,
+                "chunking_config": chunking_config_summary(chunking_config),
             },
         )
 
@@ -2306,43 +2130,10 @@ async def sync_source(
         corpus = await service.get_corpus_by_id(corpus_id)
         corpus_config = corpus.config if corpus else {}
 
-        # 构建配置：请求参数 > corpus 配置 > 默认值
-        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
-        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
-        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
-        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
-        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
-        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
-        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
-        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
-        hierarchical_parent_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_parent_chunk_size,
-            corpus_config,
-            "hierarchical_parent_chunk_size",
-        )
-        hierarchical_child_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_child_chunk_size,
-            corpus_config,
-            "hierarchical_child_chunk_size",
-        )
-        hierarchical_child_overlap = _resolve_chunking_option(
-            payload.hierarchical_child_overlap,
-            corpus_config,
-            "hierarchical_child_overlap",
-        )
-
-        chunking_config = _build_chunking_config(
-            strategy=strategy,
-            chunk_size=chunk_size,
-            overlap=overlap,
-            preserve_newlines=preserve_newlines,
-            separators=separators,
-            semantic_threshold=semantic_threshold,
-            min_chunk_size=min_chunk_size,
-            max_chunk_size=max_chunk_size,
-            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
-            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
-            hierarchical_child_overlap=hierarchical_child_overlap,
+        chunking_config = _resolve_chunking_config(
+            chunking_config=payload.chunking_config,
+            legacy_payload=_extract_legacy_chunking_payload(payload),
+            corpus_config=corpus_config,
         )
 
         # 创建 Pipeline 记录
@@ -2352,8 +2143,7 @@ async def sync_source(
             input_data={
                 "corpus_id": str(corpus_id),
                 "source_uri": source_uri,
-                "chunk_size": chunking_config.chunk_size if chunking_config else None,
-                "overlap": chunking_config.overlap if chunking_config else None,
+                "chunking_config": chunking_config_summary(chunking_config),
             },
         )
 
@@ -2427,43 +2217,10 @@ async def rebuild_source(
         corpus = await service.get_corpus_by_id(corpus_id)
         corpus_config = corpus.config if corpus else {}
 
-        # 构建配置：请求参数 > corpus 配置 > 默认值
-        strategy = _resolve_chunking_option(payload.strategy, corpus_config, "strategy")
-        chunk_size = _resolve_chunking_option(payload.chunk_size, corpus_config, "chunk_size")
-        overlap = _resolve_chunking_option(payload.overlap, corpus_config, "overlap")
-        separators = _resolve_chunking_option(payload.separators, corpus_config, "separators")
-        preserve_newlines = _resolve_chunking_option(payload.preserve_newlines, corpus_config, "preserve_newlines")
-        semantic_threshold = _resolve_chunking_option(payload.semantic_threshold, corpus_config, "semantic_threshold")
-        min_chunk_size = _resolve_chunking_option(payload.min_chunk_size, corpus_config, "min_chunk_size")
-        max_chunk_size = _resolve_chunking_option(payload.max_chunk_size, corpus_config, "max_chunk_size")
-        hierarchical_parent_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_parent_chunk_size,
-            corpus_config,
-            "hierarchical_parent_chunk_size",
-        )
-        hierarchical_child_chunk_size = _resolve_chunking_option(
-            payload.hierarchical_child_chunk_size,
-            corpus_config,
-            "hierarchical_child_chunk_size",
-        )
-        hierarchical_child_overlap = _resolve_chunking_option(
-            payload.hierarchical_child_overlap,
-            corpus_config,
-            "hierarchical_child_overlap",
-        )
-
-        chunking_config = _build_chunking_config(
-            strategy=strategy,
-            chunk_size=chunk_size,
-            overlap=overlap,
-            preserve_newlines=preserve_newlines,
-            separators=separators,
-            semantic_threshold=semantic_threshold,
-            min_chunk_size=min_chunk_size,
-            max_chunk_size=max_chunk_size,
-            hierarchical_parent_chunk_size=hierarchical_parent_chunk_size,
-            hierarchical_child_chunk_size=hierarchical_child_chunk_size,
-            hierarchical_child_overlap=hierarchical_child_overlap,
+        chunking_config = _resolve_chunking_config(
+            chunking_config=payload.chunking_config,
+            legacy_payload=_extract_legacy_chunking_payload(payload),
+            corpus_config=corpus_config,
         )
 
         # 创建 Pipeline 记录
@@ -2473,8 +2230,7 @@ async def rebuild_source(
             input_data={
                 "corpus_id": str(corpus_id),
                 "source_uri": source_uri,
-                "chunk_size": chunking_config.chunk_size if chunking_config else None,
-                "overlap": chunking_config.overlap if chunking_config else None,
+                "chunking_config": chunking_config_summary(chunking_config),
             },
         )
 

--- a/apps/negentropy/src/negentropy/knowledge/chunking.py
+++ b/apps/negentropy/src/negentropy/knowledge/chunking.py
@@ -21,7 +21,14 @@ from typing import Any, Awaitable, Callable, Literal
 
 from negentropy.logging import get_logger
 
-from .types import ChunkingConfig, ChunkingStrategy
+from .types import (
+    ChunkingConfig,
+    ChunkingStrategy,
+    FixedChunkingConfig,
+    HierarchicalChunkingConfig,
+    RecursiveChunkingConfig,
+    SemanticChunkingConfig,
+)
 
 logger = get_logger("negentropy.knowledge.chunking")
 
@@ -45,6 +52,10 @@ _DEFAULT_MAX_ADJUSTMENT_RATIO = 0.3
 _CN_SENTENCE_DELIMITERS = ("。", "！", "？", "；", "\n")
 # 英文句子结束符
 _EN_SENTENCE_DELIMITERS = (".", "!", "?", ";", "\n")
+
+
+def _semantic_fallback_config() -> RecursiveChunkingConfig:
+    return RecursiveChunkingConfig()
 
 
 def _split_into_sentences(text: str) -> list[str]:
@@ -386,6 +397,8 @@ def _recursive_chunk(text: str, config: ChunkingConfig) -> list[str]:
     if config.separators:
         paragraphs = [text.strip()]
         for sep in config.separators:
+            if sep == "":
+                continue
             next_parts: list[str] = []
             for segment in paragraphs:
                 next_parts.extend(segment.split(sep))
@@ -468,19 +481,20 @@ def _hierarchical_chunk(text: str, config: ChunkingConfig) -> list[str]:
     if not text or not text.strip():
         return []
 
-    parent_config = config.model_copy(
-        update={
-            "strategy": ChunkingStrategy.RECURSIVE,
-            "chunk_size": config.hierarchical_parent_chunk_size,
-            "overlap": 0,
-        }
+    if not isinstance(config, HierarchicalChunkingConfig):
+        raise TypeError("hierarchical chunking requires HierarchicalChunkingConfig")
+
+    parent_config = RecursiveChunkingConfig(
+        chunk_size=config.hierarchical_parent_chunk_size,
+        overlap=0,
+        preserve_newlines=config.preserve_newlines,
+        separators=config.separators,
     )
-    child_config = config.model_copy(
-        update={
-            "strategy": ChunkingStrategy.RECURSIVE,
-            "chunk_size": config.hierarchical_child_chunk_size,
-            "overlap": config.hierarchical_child_overlap,
-        }
+    child_config = RecursiveChunkingConfig(
+        chunk_size=config.hierarchical_child_chunk_size,
+        overlap=config.hierarchical_child_overlap,
+        preserve_newlines=config.preserve_newlines,
+        separators=config.separators,
     )
 
     parent_chunks = _recursive_chunk(text, parent_config)
@@ -527,7 +541,10 @@ async def semantic_chunk_async(
             strategy=config.strategy.value,
             falling_back="recursive",
         )
-        return _recursive_chunk(text, config)
+        return _recursive_chunk(text, _semantic_fallback_config())
+
+    if not isinstance(config, SemanticChunkingConfig):
+        raise TypeError("semantic chunking requires SemanticChunkingConfig")
 
     # 1. 分割为句子
     sentences = _split_into_sentences(text)
@@ -546,14 +563,15 @@ async def semantic_chunk_async(
 
     # 2. 计算句子嵌入
     try:
-        embeddings = await _batch_embed_sentences(sentences, embedding_fn)
+        windows = _build_sentence_windows(sentences, config.semantic_buffer_size)
+        embeddings = await _batch_embed_sentences(windows, embedding_fn)
     except Exception as exc:
         logger.error("sentence_embedding_failed", exc_info=exc)
         # 回退到递归分块
-        return _recursive_chunk(text, config)
+        return _recursive_chunk(text, _semantic_fallback_config())
 
     # 3. 计算相邻句子相似度并确定分割点
-    split_indices = await _find_split_points(sentences, embeddings, config.semantic_threshold)
+    split_indices = await _find_split_points(embeddings, config.semantic_threshold)
 
     # 4. 在分割点处切分
     chunks = []
@@ -600,8 +618,19 @@ async def _batch_embed_sentences(
     return embeddings
 
 
+def _build_sentence_windows(sentences: list[str], buffer_size: int) -> list[str]:
+    if buffer_size <= 1:
+        return sentences
+
+    windows: list[str] = []
+    for index in range(len(sentences)):
+        start = max(0, index - (buffer_size - 1))
+        end = min(len(sentences), index + buffer_size)
+        windows.append(" ".join(sentences[start:end]))
+    return windows
+
+
 async def _find_split_points(
-    sentences: list[str],
     embeddings: list[list[float]],
     threshold: float,
 ) -> list[int]:
@@ -652,7 +681,7 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
 
 async def _merge_small_chunks(
     chunks: list[str],
-    config: ChunkingConfig,
+    config: SemanticChunkingConfig,
 ) -> list[str]:
     """合并小块
 
@@ -674,7 +703,7 @@ async def _merge_small_chunks(
             combined = current + " " + next_chunk
 
             # 检查合并后是否超过 chunk_size
-            if len(combined) <= config.chunk_size:
+            if len(combined) <= config.max_chunk_size:
                 current = combined
                 i += 2  # 跳过下一个块
             else:
@@ -723,3 +752,8 @@ async def _split_large_chunks(
             result.append(current.strip())
 
     return result
+    if not isinstance(config, FixedChunkingConfig):
+        raise TypeError("fixed chunking requires FixedChunkingConfig")
+
+    if not isinstance(config, RecursiveChunkingConfig):
+        raise TypeError("recursive chunking requires RecursiveChunkingConfig")

--- a/apps/negentropy/src/negentropy/knowledge/constants.py
+++ b/apps/negentropy/src/negentropy/knowledge/constants.py
@@ -43,6 +43,33 @@ DEFAULT_CHUNK_SIZE = 800
 # 默认重叠大小（与 types.py 中 ChunkingConfig 默认值对齐）
 DEFAULT_OVERLAP = 100
 
+# 默认递归分隔符（中英混排友好）
+DEFAULT_RECURSIVE_SEPARATORS = (
+    "\n\n",
+    "\n",
+    "。",
+    "！",
+    "？",
+    ". ",
+    "! ",
+    "? ",
+    "；",
+    ";",
+    " ",
+    "",
+)
+
+# 语义分块默认参数
+DEFAULT_SEMANTIC_THRESHOLD = 0.85
+DEFAULT_SEMANTIC_BUFFER_SIZE = 1
+DEFAULT_SEMANTIC_MIN_CHUNK_SIZE = 50
+DEFAULT_SEMANTIC_MAX_CHUNK_SIZE = 2000
+
+# 层次分块默认参数
+DEFAULT_HIERARCHICAL_PARENT_CHUNK_SIZE = 1024
+DEFAULT_HIERARCHICAL_CHILD_CHUNK_SIZE = 256
+DEFAULT_HIERARCHICAL_CHILD_OVERLAP = 51
+
 
 # ================================
 # 性能相关常量

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -11,13 +11,7 @@ from .chunking import chunk_text, semantic_chunk_async
 
 if TYPE_CHECKING:
     from .dao import KnowledgeRunDao
-from .constants import (
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_KEYWORD_WEIGHT,
-    DEFAULT_OVERLAP,
-    DEFAULT_SEMANTIC_WEIGHT,
-    TEXT_PREVIEW_MAX_LENGTH,
-)
+from .constants import DEFAULT_KEYWORD_WEIGHT, DEFAULT_SEMANTIC_WEIGHT, TEXT_PREVIEW_MAX_LENGTH
 from .exceptions import SearchError
 from .content import fetch_content
 from .reranking import NoopReranker, Reranker
@@ -26,10 +20,14 @@ from .types import (
     ChunkingConfig,
     CorpusRecord,
     CorpusSpec,
+    HierarchicalChunkingConfig,
     KnowledgeChunk,
     KnowledgeMatch,
     KnowledgeRecord,
+    RecursiveChunkingConfig,
     SearchConfig,
+    chunking_config_summary,
+    default_chunking_config,
     SourceSummary,
     merge_search_results,
 )
@@ -213,7 +211,7 @@ class KnowledgeService:
         self._repository = repository or KnowledgeRepository()
         self._embedding_fn = embedding_fn
         self._batch_embedding_fn = batch_embedding_fn
-        self._chunking_config = chunking_config or ChunkingConfig()
+        self._chunking_config = chunking_config or default_chunking_config()
         self._reranker = reranker or NoopReranker()
         self._pipeline_dao = pipeline_dao
 
@@ -773,8 +771,7 @@ class KnowledgeService:
                     "corpus_id": str(corpus_id),
                     "source_uri": source_uri,
                     "text_length": len(text),
-                    "chunk_size": config.chunk_size,
-                    "overlap": config.overlap,
+                    "chunking_config": chunking_config_summary(config),
                 }
             )
 
@@ -784,8 +781,7 @@ class KnowledgeService:
             app_name=app_name,
             text_length=len(text),
             source_uri=source_uri,
-            chunk_size=config.chunk_size,
-            overlap=config.overlap,
+            chunking_config=chunking_config_summary(config),
             run_id=tracker.run_id if tracker else None,
         )
 
@@ -937,8 +933,7 @@ class KnowledgeService:
                     "corpus_id": str(corpus_id),
                     "source_uri": source_uri,
                     "text_length": len(text),
-                    "chunk_size": config.chunk_size,
-                    "overlap": config.overlap,
+                    "chunking_config": chunking_config_summary(config),
                 }
             )
 
@@ -1157,8 +1152,7 @@ class KnowledgeService:
                 {
                     "corpus_id": str(corpus_id),
                     "url": url,
-                    "chunk_size": config.chunk_size,
-                    "overlap": config.overlap,
+                    "chunking_config": chunking_config_summary(config),
                 }
             )
 
@@ -1282,8 +1276,7 @@ class KnowledgeService:
                 {
                     "corpus_id": str(corpus_id),
                     "source_uri": source_uri,
-                    "chunk_size": config.chunk_size,
-                    "overlap": config.overlap,
+                    "chunking_config": chunking_config_summary(config),
                 }
             )
 
@@ -1453,8 +1446,7 @@ class KnowledgeService:
                 {
                     "corpus_id": str(corpus_id),
                     "source_uri": source_uri,
-                    "chunk_size": config.chunk_size,
-                    "overlap": config.overlap,
+                    "chunking_config": chunking_config_summary(config),
                 }
             )
 
@@ -1921,19 +1913,20 @@ class KnowledgeService:
         metadata: Dict[str, Any],
         chunking_config: ChunkingConfig,
     ) -> list[KnowledgeChunk]:
-        parent_config = chunking_config.model_copy(
-            update={
-                "strategy": ChunkingStrategy.RECURSIVE,
-                "chunk_size": chunking_config.hierarchical_parent_chunk_size,
-                "overlap": 0,
-            }
+        if not isinstance(chunking_config, HierarchicalChunkingConfig):
+            raise TypeError("hierarchical chunk builder requires HierarchicalChunkingConfig")
+
+        parent_config = RecursiveChunkingConfig(
+            chunk_size=chunking_config.hierarchical_parent_chunk_size,
+            overlap=0,
+            preserve_newlines=chunking_config.preserve_newlines,
+            separators=chunking_config.separators,
         )
-        child_config = chunking_config.model_copy(
-            update={
-                "strategy": ChunkingStrategy.RECURSIVE,
-                "chunk_size": chunking_config.hierarchical_child_chunk_size,
-                "overlap": chunking_config.hierarchical_child_overlap,
-            }
+        child_config = RecursiveChunkingConfig(
+            chunk_size=chunking_config.hierarchical_child_chunk_size,
+            overlap=chunking_config.hierarchical_child_overlap,
+            preserve_newlines=chunking_config.preserve_newlines,
+            separators=chunking_config.separators,
         )
 
         parent_texts = chunk_text(text, parent_config)

--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Literal, Optional
+from typing import Annotated, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeAlias
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationInfo, field_validator, model_validator
 
 from .constants import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_HIERARCHICAL_CHILD_CHUNK_SIZE,
+    DEFAULT_HIERARCHICAL_CHILD_OVERLAP,
+    DEFAULT_HIERARCHICAL_PARENT_CHUNK_SIZE,
+    DEFAULT_OVERLAP,
+    DEFAULT_RECURSIVE_SEPARATORS,
+    DEFAULT_SEMANTIC_BUFFER_SIZE,
+    DEFAULT_SEMANTIC_MAX_CHUNK_SIZE,
+    DEFAULT_SEMANTIC_MIN_CHUNK_SIZE,
+    DEFAULT_SEMANTIC_THRESHOLD,
     MAX_OVERLAP_RATIO,
     MIN_CHUNK_SIZE,
 )
@@ -119,94 +129,88 @@ class KnowledgeMatch:
     combined_score: float = 0.0
 
 
-class ChunkingConfig(BaseModel):
-    """分块配置
+class _ChunkingConfigBase(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
-    控制文本如何被分割成可索引的块。
 
-    支持三种分块策略:
-    - "fixed": 固定大小分块（字符级别），简单高效
-    - "recursive": 递归分块（段落 > 句子 > 词），保持结构
-    - "semantic": 语义分块（基于句子相似度），保持语义完整性
-
-    语义分块参考文献:
-    [1] G. Kamalloo and A. K. G., "Semantic Chunking for RAG Applications," 2024.
-    [2] LlamaIndex, "Semantic Chunking," GitHub, 2024.
-    """
-
-    model_config = ConfigDict(frozen=True)
-
-    strategy: ChunkingStrategy = ChunkingStrategy.RECURSIVE
-    chunk_size: int = 800
-    overlap: int = 100
-    preserve_newlines: bool = True
-    separators: tuple[str, ...] = Field(default_factory=tuple)
-    # 语义分块专用参数
-    semantic_threshold: float = 0.85  # 相似度阈值，低于此值时切分
-    min_chunk_size: int = 50  # 最小块大小（字符数）
-    max_chunk_size: int = 2000  # 最大块大小（字符数），用于滑动窗口合并
-    hierarchical_parent_chunk_size: int = 1024
-    hierarchical_child_chunk_size: int = 256
-    hierarchical_child_overlap: int = 51
-
-    @field_validator("strategy", mode="before")
-    @classmethod
-    def validate_strategy(cls, v: ChunkingStrategy | str) -> ChunkingStrategy:
-        """验证分块策略"""
-        if isinstance(v, ChunkingStrategy):
-            return v
-        try:
-            return ChunkingStrategy(v)
-        except ValueError:
-            raise ValueError(f"strategy must be one of {[s.value for s in ChunkingStrategy]}, got {v}")
+class _ChunkingConfigWithOverlap(_ChunkingConfigBase):
+    chunk_size: int = DEFAULT_CHUNK_SIZE
+    overlap: int = DEFAULT_OVERLAP
 
     @field_validator("chunk_size")
     @classmethod
     def validate_chunk_size(cls, v: int) -> int:
-        """验证分块大小
-
-        确保 chunk_size 为正数且在合理范围内。
-        """
         if v < MIN_CHUNK_SIZE:
             raise ValueError(f"chunk_size must be at least {MIN_CHUNK_SIZE}, got {v}")
-        if v > 100000:  # 100K 字符上限
+        if v > 100000:
             raise ValueError(f"chunk_size must be at most 100000, got {v}")
         return v
 
     @field_validator("overlap")
     @classmethod
     def validate_overlap(cls, v: int, info: ValidationInfo) -> int:
-        """验证重叠大小
-
-        确保 overlap 为非负数且小于 chunk_size。
-        """
         if v < 0:
             raise ValueError(f"overlap must be non-negative, got {v}")
-
-        # 获取 chunk_size 的值（如果可用）
-        chunk_size = info.data.get("chunk_size", 800)
+        chunk_size = info.data.get("chunk_size", DEFAULT_CHUNK_SIZE)
         if v >= chunk_size:
             raise ValueError(f"overlap must be less than chunk_size ({chunk_size}), got {v}")
-
-        # 验证重叠比例
         max_overlap = int(chunk_size * MAX_OVERLAP_RATIO)
         if v > max_overlap:
             raise ValueError(f"overlap ({v}) exceeds {MAX_OVERLAP_RATIO * 100}% of chunk_size ({chunk_size})")
-
         return v
+
+
+class _ChunkingConfigWithSeparators(_ChunkingConfigBase):
+    preserve_newlines: bool = True
+    separators: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator("separators")
+    @classmethod
+    def validate_separators(cls, v: List[str] | tuple[str, ...]) -> tuple[str, ...]:
+        normalized = [item for item in (s.strip() for s in v) if item]
+        deduped: List[str] = []
+        for item in normalized:
+            if item not in deduped:
+                deduped.append(item)
+        return tuple(deduped)
+
+
+class FixedChunkingConfig(_ChunkingConfigWithOverlap):
+    strategy: Literal[ChunkingStrategy.FIXED] = ChunkingStrategy.FIXED
+    preserve_newlines: bool = True
+
+
+class RecursiveChunkingConfig(_ChunkingConfigWithOverlap, _ChunkingConfigWithSeparators):
+    strategy: Literal[ChunkingStrategy.RECURSIVE] = ChunkingStrategy.RECURSIVE
+    separators: tuple[str, ...] = DEFAULT_RECURSIVE_SEPARATORS
+
+
+class SemanticChunkingConfig(_ChunkingConfigBase):
+    strategy: Literal[ChunkingStrategy.SEMANTIC] = ChunkingStrategy.SEMANTIC
+    semantic_threshold: float = DEFAULT_SEMANTIC_THRESHOLD
+    semantic_buffer_size: int = DEFAULT_SEMANTIC_BUFFER_SIZE
+    min_chunk_size: int = DEFAULT_SEMANTIC_MIN_CHUNK_SIZE
+    max_chunk_size: int = DEFAULT_SEMANTIC_MAX_CHUNK_SIZE
 
     @field_validator("semantic_threshold")
     @classmethod
     def validate_semantic_threshold(cls, v: float) -> float:
-        """验证语义相似度阈值"""
         if not (0.0 <= v <= 1.0):
             raise ValueError(f"semantic_threshold must be between 0 and 1, got {v}")
+        return v
+
+    @field_validator("semantic_buffer_size")
+    @classmethod
+    def validate_semantic_buffer_size(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"semantic_buffer_size must be at least 1, got {v}")
+        if v > 5:
+            raise ValueError(f"semantic_buffer_size must be at most 5, got {v}")
         return v
 
     @field_validator("min_chunk_size")
     @classmethod
     def validate_min_chunk_size(cls, v: int) -> int:
-        """验证最小块大小"""
         if v < 1:
             raise ValueError(f"min_chunk_size must be at least 1, got {v}")
         return v
@@ -214,10 +218,25 @@ class ChunkingConfig(BaseModel):
     @field_validator("max_chunk_size")
     @classmethod
     def validate_max_chunk_size(cls, v: int) -> int:
-        """验证最大块大小"""
         if v < 100:
             raise ValueError(f"max_chunk_size must be at least 100, got {v}")
         return v
+
+    @model_validator(mode="after")
+    def validate_semantic_relationships(self) -> "SemanticChunkingConfig":
+        if self.min_chunk_size > self.max_chunk_size:
+            raise ValueError(
+                f"min_chunk_size ({self.min_chunk_size}) must be <= max_chunk_size ({self.max_chunk_size})"
+            )
+        return self
+
+
+class HierarchicalChunkingConfig(_ChunkingConfigWithSeparators):
+    strategy: Literal[ChunkingStrategy.HIERARCHICAL] = ChunkingStrategy.HIERARCHICAL
+    separators: tuple[str, ...] = DEFAULT_RECURSIVE_SEPARATORS
+    hierarchical_parent_chunk_size: int = DEFAULT_HIERARCHICAL_PARENT_CHUNK_SIZE
+    hierarchical_child_chunk_size: int = DEFAULT_HIERARCHICAL_CHILD_CHUNK_SIZE
+    hierarchical_child_overlap: int = DEFAULT_HIERARCHICAL_CHILD_OVERLAP
 
     @field_validator(
         "hierarchical_parent_chunk_size",
@@ -233,38 +252,149 @@ class ChunkingConfig(BaseModel):
             return v
         if v < 1:
             raise ValueError(f"{field_name} must be at least 1, got {v}")
+        if v > 100000:
+            raise ValueError(f"{field_name} must be at most 100000, got {v}")
         return v
 
-    @field_validator("separators")
-    @classmethod
-    def validate_separators(cls, v: List[str] | tuple[str, ...]) -> tuple[str, ...]:
-        """验证分隔符配置"""
-        normalized = [item for item in (s.strip() for s in v) if item]
-        # 去重并保持顺序
-        deduped: List[str] = []
-        for item in normalized:
-            if item not in deduped:
-                deduped.append(item)
-        return tuple(deduped)
-
     @model_validator(mode="after")
-    def validate_chunking_relationships(self) -> "ChunkingConfig":
-        if self.min_chunk_size > self.max_chunk_size:
-            raise ValueError(
-                f"min_chunk_size ({self.min_chunk_size}) must be <= max_chunk_size ({self.max_chunk_size})"
-            )
-
+    def validate_hierarchical_relationships(self) -> "HierarchicalChunkingConfig":
         if self.hierarchical_parent_chunk_size < self.hierarchical_child_chunk_size:
-            raise ValueError(
-                "hierarchical_parent_chunk_size must be >= hierarchical_child_chunk_size"
-            )
-
+            raise ValueError("hierarchical_parent_chunk_size must be >= hierarchical_child_chunk_size")
         if self.hierarchical_child_overlap >= self.hierarchical_child_chunk_size:
+            raise ValueError("hierarchical_child_overlap must be less than hierarchical_child_chunk_size")
+        max_overlap = int(self.hierarchical_child_chunk_size * MAX_OVERLAP_RATIO)
+        if self.hierarchical_child_overlap > max_overlap:
             raise ValueError(
-                "hierarchical_child_overlap must be less than hierarchical_child_chunk_size"
+                "hierarchical_child_overlap "
+                f"({self.hierarchical_child_overlap}) exceeds {MAX_OVERLAP_RATIO * 100}% "
+                f"of hierarchical_child_chunk_size ({self.hierarchical_child_chunk_size})"
             )
-
         return self
+
+
+ChunkingConfigValue: TypeAlias = Annotated[
+    FixedChunkingConfig | RecursiveChunkingConfig | SemanticChunkingConfig | HierarchicalChunkingConfig,
+    Field(discriminator="strategy"),
+]
+
+_CHUNKING_CONFIG_ADAPTER = TypeAdapter(ChunkingConfigValue)
+
+
+def create_chunking_config(**data: Any) -> ChunkingConfigValue:
+    return _CHUNKING_CONFIG_ADAPTER.validate_python(data)
+
+
+def ChunkingConfig(**data: Any) -> ChunkingConfigValue:
+    if not data:
+        return default_chunking_config()
+    strategy = data.get("strategy")
+    if strategy is None:
+        if any(key.startswith("hierarchical_") for key in data):
+            strategy = ChunkingStrategy.HIERARCHICAL
+        elif any(key in {"semantic_threshold", "semantic_buffer_size", "min_chunk_size", "max_chunk_size"} for key in data):
+            strategy = ChunkingStrategy.SEMANTIC
+        else:
+            strategy = ChunkingStrategy.RECURSIVE
+    elif not isinstance(strategy, ChunkingStrategy):
+        strategy = ChunkingStrategy(strategy)
+
+    data["strategy"] = strategy
+    return create_chunking_config(**data)
+
+
+def default_chunking_config() -> ChunkingConfigValue:
+    return RecursiveChunkingConfig()
+
+
+def serialize_chunking_config(config: ChunkingConfigValue | None) -> Dict[str, Any]:
+    if config is None:
+        return {}
+    return config.model_dump(mode="python")
+
+
+def normalize_chunking_config(
+    raw: Mapping[str, Any] | ChunkingConfigValue | None,
+    *,
+    preserve_unknown_strategy_fields: bool = False,
+) -> ChunkingConfigValue | None:
+    if raw is None:
+        return None
+    if isinstance(
+        raw,
+        (FixedChunkingConfig, RecursiveChunkingConfig, SemanticChunkingConfig, HierarchicalChunkingConfig),
+    ):
+        return raw
+
+    payload = dict(raw)
+    strategy = payload.get("strategy", ChunkingStrategy.RECURSIVE)
+    if not isinstance(strategy, ChunkingStrategy):
+        strategy = ChunkingStrategy(strategy)
+
+    strategy_fields: dict[ChunkingStrategy, set[str]] = {
+        ChunkingStrategy.FIXED: {"strategy", "chunk_size", "overlap", "preserve_newlines"},
+        ChunkingStrategy.RECURSIVE: {"strategy", "chunk_size", "overlap", "preserve_newlines", "separators"},
+        ChunkingStrategy.SEMANTIC: {
+            "strategy",
+            "semantic_threshold",
+            "semantic_buffer_size",
+            "min_chunk_size",
+            "max_chunk_size",
+        },
+        ChunkingStrategy.HIERARCHICAL: {
+            "strategy",
+            "preserve_newlines",
+            "separators",
+            "hierarchical_parent_chunk_size",
+            "hierarchical_child_chunk_size",
+            "hierarchical_child_overlap",
+        },
+    }
+
+    if not preserve_unknown_strategy_fields:
+        payload = {key: value for key, value in payload.items() if key in strategy_fields[strategy]}
+
+    payload["strategy"] = strategy
+    return create_chunking_config(**payload)
+
+
+def chunking_config_summary(config: ChunkingConfigValue | None) -> Dict[str, Any]:
+    if config is None:
+        return {}
+
+    if isinstance(config, FixedChunkingConfig):
+        return {
+            "strategy": config.strategy.value,
+            "chunk_size": config.chunk_size,
+            "overlap": config.overlap,
+            "preserve_newlines": config.preserve_newlines,
+        }
+
+    if isinstance(config, RecursiveChunkingConfig):
+        return {
+            "strategy": config.strategy.value,
+            "chunk_size": config.chunk_size,
+            "overlap": config.overlap,
+            "preserve_newlines": config.preserve_newlines,
+            "separators": list(config.separators),
+        }
+
+    if isinstance(config, SemanticChunkingConfig):
+        return {
+            "strategy": config.strategy.value,
+            "semantic_threshold": config.semantic_threshold,
+            "semantic_buffer_size": config.semantic_buffer_size,
+            "min_chunk_size": config.min_chunk_size,
+            "max_chunk_size": config.max_chunk_size,
+        }
+
+    return {
+        "strategy": config.strategy.value,
+        "preserve_newlines": config.preserve_newlines,
+        "separators": list(config.separators),
+        "hierarchical_parent_chunk_size": config.hierarchical_parent_chunk_size,
+        "hierarchical_child_chunk_size": config.hierarchical_child_chunk_size,
+        "hierarchical_child_overlap": config.hierarchical_child_overlap,
+    }
 
 
 class SearchConfig(BaseModel):

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
@@ -272,9 +272,6 @@ def test_resolve_chunking_config_from_doc_request_prefers_payload_over_corpus():
 
     assert config is not None
     assert config.strategy == ChunkingStrategy.HIERARCHICAL
-    assert config.chunk_size == 900
-    assert config.overlap == 100
-    assert config.semantic_threshold == 0.9
     assert config.hierarchical_parent_chunk_size == 1200
     assert config.hierarchical_child_chunk_size == 300
     assert config.hierarchical_child_overlap == 60

--- a/apps/negentropy/tests/unit_tests/knowledge/test_chunking.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_chunking.py
@@ -383,7 +383,6 @@ class TestSemanticChunking:
         text = "第一句。第二句。第三句。第四句。"
         config = ChunkingConfig(
             strategy=ChunkingStrategy.SEMANTIC,
-            chunk_size=100,
             semantic_threshold=0.85,
         )
 
@@ -423,7 +422,7 @@ class TestSemanticChunking:
     async def test_semantic_chunk_fallback_on_embedding_failure(self) -> None:
         """测试嵌入失败时回退到递归分块"""
         text = "第一句。第二句。第三句。"
-        config = ChunkingConfig(strategy=ChunkingStrategy.SEMANTIC, chunk_size=200)
+        config = ChunkingConfig(strategy=ChunkingStrategy.SEMANTIC)
 
         async def failing_embedding(text: str) -> list[float]:
             raise RuntimeError("Embedding failed")
@@ -468,7 +467,7 @@ class TestChunkingStrategy:
 
     def test_config_strategy_invalid_string(self) -> None:
         """测试无效策略字符串"""
-        with pytest.raises(ValidationError, match="strategy must be one of"):
+        with pytest.raises(ValueError, match="not a valid ChunkingStrategy"):
             ChunkingConfig(strategy="invalid")
 
 
@@ -484,9 +483,8 @@ class TestChunkingConfigExtended:
         """测试默认配置"""
         config = ChunkingConfig()
         assert config.strategy == ChunkingStrategy.RECURSIVE
-        assert config.semantic_threshold == 0.85
-        assert config.min_chunk_size == 50
-        assert config.max_chunk_size == 2000
+        assert config.chunk_size == 800
+        assert config.overlap == 100
 
     def test_config_custom_semantic_threshold(self) -> None:
         """测试自定义语义阈值"""

--- a/docs/knowledges.md
+++ b/docs/knowledges.md
@@ -238,11 +238,16 @@ KnowledgeError
 
 ### 6.5 配置验证
 
-**ChunkingConfig 验证规则**：
+**ChunkingConfig 验证规则**（按 `strategy` 判别）：
 
-- `chunk_size`: 1 ~ 100000
-- `overlap`: 0 ~ chunk_size \* 0.5
-- `preserve_newlines`: true/false
+- `fixed`: `chunk_size`, `overlap`, `preserve_newlines`
+- `recursive`: `chunk_size`, `overlap`, `separators`, `preserve_newlines`
+- `semantic`: `semantic_threshold`, `semantic_buffer_size`, `min_chunk_size`, `max_chunk_size`
+- `hierarchical`: `hierarchical_parent_chunk_size`, `hierarchical_child_chunk_size`, `hierarchical_child_overlap`, `separators`, `preserve_newlines`
+- `fixed/recursive`: `chunk_size` 范围 `1 ~ 100000`，`overlap` 范围 `0 ~ chunk_size * 0.5`
+- `semantic`: `semantic_buffer_size` 范围 `1 ~ 5`，`max_chunk_size >= min_chunk_size`
+- `hierarchical`: `hierarchical_parent_chunk_size >= hierarchical_child_chunk_size`，`hierarchical_child_overlap < hierarchical_child_chunk_size`
+- 新请求统一优先发送 `chunking_config`；服务端兼容旧的扁平字段，但写回 `corpus.config` 时只保留 canonical 结构
 
 **SearchConfig 验证规则**：
 
@@ -471,7 +476,11 @@ logger.error("database_error", details=exc.details)
 
 1. 在 Corpus 列表项右侧点击 **更多操作** (三点图标)。
 2. 选择 **编辑配置**。
-3. 修改 `Name`, `Description` 或 `Config` (Chunk Size, Overlap 等)。
+3. 修改 `Name`, `Description` 或 `Config`。
+   - `Fixed`: `Chunk Size / Overlap / 保留换行`
+   - `Recursive`: `Chunk Size / Overlap / Separators / 保留换行`
+   - `Semantic`: `Similarity Threshold / Buffer Size / Min Chunk Size / Max Chunk Size`
+   - `Hierarchical`: `Parent Size / Child Size / Child Overlap / Separators / 保留换行`
 4. 点击 **Save** 保存更改。
    - **注意**: 修改 Chunking Config 不会自动重新索引现有文档，仅对新 ingestion 生效。如需应用新配置，请重新 ingest 文档。
 


### PR DESCRIPTION
## 背景

当前 Knowledge Base 的 4 种分片策略在前后端存在配置语义不一致的问题，尤其是 `Semantic` 和 `Hierarchical` 设置中重复暴露了 `Chunk Size`、`Overlap` 等并不真正属于该策略的字段，导致 Corpus Settings、Documents 页 Settings、API 请求与运行时 chunking 逻辑之间出现 split-brain 风险。

本 PR 基于 4 种分片策略的经典设计模式与最佳实践，对本系统中的 Chunk 策略配置进行了统一收敛，确保前端展示、接口契约、服务端规范化、运行时行为和测试基线保持一致。

## 本次改动

### 1. 后端：将 ChunkingConfig 重构为按 strategy 判别的配置模型

- 将原先“单一扁平超集配置”改为按 `strategy` 判别的配置结构
- 为 `fixed / recursive / semantic / hierarchical` 分别定义独立配置边界
- 新增配置规范化与序列化逻辑，统一服务端读取、兼容旧配置并写回 canonical 结构
- 统一 API 对 corpus config、ingest、replace、sync、rebuild、document action 的 chunking 配置解析逻辑

### 2. 后端：按策略校正运行时 chunking 行为

- `fixed`：保留固定长度切分语义
- `recursive`：收敛为结构感知递归切分，并统一默认 separators
- `semantic`：
  - 去除对通用 `chunk_size / overlap` 的依赖
  - 引入并真正使用 `semantic_buffer_size`
  - 保留 `semantic_threshold / min_chunk_size / max_chunk_size` 作为语义分片的核心参数
- `hierarchical`：
  - 明确使用 `hierarchical_parent_chunk_size / hierarchical_child_chunk_size / hierarchical_child_overlap`
  - 避免继续暴露无效的顶层 `chunk_size / overlap`

### 3. 前端：去掉 Semantic / Hierarchical 的冗余设置项

- 重构 Corpus Settings 与 Documents 页 Settings 的策略配置面板
- 切换为“按策略渲染字段”，每种策略只展示真实有效的配置项
- `Semantic` 只展示：
  - `Similarity Threshold`
  - `Buffer Size`
  - `Min Chunk Size`
  - `Max Chunk Size`
- `Hierarchical` 只展示：
  - `Parent Size`
  - `Child Size`
  - `Child Overlap`
  - `Separators`
  - `Preserve Newlines`
- 同步更新详情展示与前端 API client，统一使用 `chunking_config` 作为 JSON 请求的单一事实源

### 4. 兼容与文档

- 服务端兼容旧的扁平 chunking 字段请求
- 新写入的 corpus config 统一收敛为 canonical 结构
- 更新知识库文档，补充分策略参数矩阵与约束说明

## 为什么这样改

这次修改的核心目的是消除 4 种 Chunk 策略在“展示层、接口层、配置层、执行层”之间的不一致问题，避免出现以下风险：

- UI 展示了某策略实际上不会生效的字段
- 前端请求带入了与当前策略无关的配置
- 后端以超集模型解析，导致策略边界不清晰
- 存量 corpus config 与新建 corpus config 长期漂移
- Semantic / Hierarchical 的参数语义被通用 chunk 字段误导

通过按策略拆分配置模型，并在前后端统一 canonical 结构，可以让配置项与算法语义一一对应，降低维护成本，也避免后续继续累积隐式兼容逻辑。

## 重要实现细节

- 后端使用按 `strategy` 判别的配置模型统一 chunking 配置边界
- API 层统一优先处理 `chunking_config`，同时兼容旧的扁平字段
- `semantic_buffer_size` 被纳入正式配置与运行时逻辑，不再只是表单层概念
- `hierarchical` 的父子块配置被明确收敛，不再复用通用 chunk 字段
- 前端设置页和创建/编辑对话框都已切换为策略专属字段渲染
- 相关单元测试与页面测试已同步更新，确保 UI 和 API 契约一致

## 验证

已完成的验证包括：

- 后端：
  - `uv run --group dev pytest tests/unit_tests/knowledge/test_types.py tests/unit_tests/knowledge/test_chunking.py tests/unit_tests/knowledge/test_api_document_routes.py -q`
- 前端：
  - `pnpm --dir apps/negentropy-ui test -- tests/unit/knowledge/knowledge-api.test.ts tests/unit/knowledge/KnowledgeBasePage.test.tsx`
  - 定向 ESLint 校验本次改动涉及文件

## 影响范围

- Knowledge 后端类型、API 与 chunking 运行时
- Knowledge Base 设置页与 Corpus 编辑对话框
- 前端 knowledge API client 与 hook
- 相关测试与文档

This PR was written using [Vibe Kanban](https://vibekanban.com)
