### PR TITLE
docs(knowledge-api): 同步 API 示例页到 canonical chunking_config 契约 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/apis/_components/utils/ApiExecutor.ts
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/utils/ApiExecutor.ts
@@ -13,6 +13,7 @@ import {
   fetchKnowledgeItems,
   createCorpus,
   deleteCorpus,
+  ChunkingConfig,
 } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -47,9 +48,7 @@ const API_EXECUTORS: Record<string, ExecutorFn> = {
       text: params.text as string,
       source_uri: params.source_uri as string | undefined,
       metadata: params.metadata as Record<string, unknown> | undefined,
-      chunk_size: params.chunk_size as number | undefined,
-      overlap: params.overlap as number | undefined,
-      preserve_newlines: params.preserve_newlines as boolean | undefined,
+      chunking_config: params.chunking_config as ChunkingConfig | undefined,
     });
   },
 
@@ -59,9 +58,7 @@ const API_EXECUTORS: Record<string, ExecutorFn> = {
       app_name: APP_NAME,
       url: params.url as string,
       metadata: params.metadata as Record<string, unknown> | undefined,
-      chunk_size: params.chunk_size as number | undefined,
-      overlap: params.overlap as number | undefined,
-      preserve_newlines: params.preserve_newlines as boolean | undefined,
+      chunking_config: params.chunking_config as ChunkingConfig | undefined,
     });
   },
 
@@ -72,9 +69,7 @@ const API_EXECUTORS: Record<string, ExecutorFn> = {
       text: params.text as string,
       source_uri: params.source_uri as string,
       metadata: params.metadata as Record<string, unknown> | undefined,
-      chunk_size: params.chunk_size as number | undefined,
-      overlap: params.overlap as number | undefined,
-      preserve_newlines: params.preserve_newlines as boolean | undefined,
+      chunking_config: params.chunking_config as ChunkingConfig | undefined,
     });
   },
 
@@ -93,12 +88,7 @@ const API_EXECUTORS: Record<string, ExecutorFn> = {
       app_name: APP_NAME,
       name: params.name as string,
       description: params.description as string | undefined,
-      config: params.chunk_size || params.overlap
-        ? {
-            chunk_size: params.chunk_size as number | undefined,
-            overlap: params.overlap as number | undefined,
-          }
-        : undefined,
+      config: params.config as Record<string, unknown> | undefined,
     });
   },
 

--- a/apps/negentropy-ui/features/knowledge/utils/api-specs.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/api-specs.ts
@@ -4,6 +4,8 @@
  * 用于生成 API 文档、参数校验和代码示例
  */
 
+import { createDefaultChunkingConfig } from "./knowledge-api";
+
 export type HttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
 
 export interface ApiParameter {
@@ -103,6 +105,9 @@ export interface ApiEndpoint {
 }
 
 const BASE_URL = "http://localhost:8000";
+const DEFAULT_CHUNKING_CONFIG = createDefaultChunkingConfig("recursive");
+const DEFAULT_CHUNKING_CONFIG_DESCRIPTION =
+  "canonical chunking 配置，按 strategy 判别。支持 fixed / recursive / semantic / hierarchical。";
 
 export const KNOWLEDGE_API_ENDPOINTS: ApiEndpoint[] = [
   {
@@ -319,17 +324,17 @@ results.items.forEach(item => {
           text: { type: "string", description: "要摄入的文本内容" },
           source_uri: { type: "string", description: "来源 URI，用于追溯" },
           metadata: { type: "object", description: "自定义元数据" },
-          chunk_size: { type: "integer", default: 800, min: 1, max: 100000 },
-          overlap: { type: "integer", default: 100 },
-          preserve_newlines: { type: "boolean", default: false },
+          chunking_config: {
+            type: "object",
+            description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
+          },
         },
       },
       example: {
         text: "这是一段需要摄入到知识库的文本内容。系统会自动进行分块和向量化处理。",
         source_uri: "docs://example/doc1",
         metadata: { category: "tutorial", version: "1.0" },
-        chunk_size: 800,
-        overlap: 100,
+        chunking_config: DEFAULT_CHUNKING_CONFIG,
       },
     },
     responses: [
@@ -353,7 +358,13 @@ results.items.forEach(item => {
   -d '{
     "text": "这是一段需要摄入到知识库的文本内容。",
     "source_uri": "docs://example/doc1",
-    "chunk_size": 800
+    "chunking_config": {
+      "strategy": "recursive",
+      "chunk_size": 800,
+      "overlap": 100,
+      "preserve_newlines": true,
+      "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+    }
   }'`,
       python: `import requests
 
@@ -362,7 +373,13 @@ response = requests.post(
     json={
         "text": "这是一段需要摄入到知识库的文本内容。",
         "source_uri": "docs://example/doc1",
-        "chunk_size": 800
+        "chunking_config": {
+            "strategy": "recursive",
+            "chunk_size": 800,
+            "overlap": 100,
+            "preserve_newlines": True,
+            "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+        }
     }
 )
 result = response.json()
@@ -373,7 +390,13 @@ print(f"Ingested {result['count']} chunks")`,
   body: JSON.stringify({
     text: '这是一段需要摄入到知识库的文本内容。',
     source_uri: 'docs://example/doc1',
-    chunk_size: 800
+    chunking_config: {
+      strategy: 'recursive',
+      chunk_size: 800,
+      overlap: 100,
+      preserve_newlines: true,
+      separators: ['\\n\\n', '\\n', '。', '！', '？', '. ', '! ', '? ', '；', ';', ' ', '']
+    }
   })
 });
 
@@ -413,30 +436,13 @@ console.log(\`Ingested \${result.count} chunks\`);`,
           description: "自定义元数据字段",
         },
         {
-          name: "chunk_size",
-          type: "number",
-          label: "分块大小",
+          name: "chunking_config",
+          type: "json",
+          label: "Chunking Config",
           required: false,
-          defaultValue: 800,
-          min: 1,
-          max: 100000,
+          defaultValue: DEFAULT_CHUNKING_CONFIG,
           group: "advanced",
-        },
-        {
-          name: "overlap",
-          type: "number",
-          label: "重叠字符数",
-          required: false,
-          defaultValue: 100,
-          group: "advanced",
-        },
-        {
-          name: "preserve_newlines",
-          type: "checkbox",
-          label: "保留换行符",
-          required: false,
-          defaultValue: false,
-          group: "advanced",
+          description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
         },
       ],
       submitLabel: "摄入文本",
@@ -475,14 +481,16 @@ console.log(\`Ingested \${result.count} chunks\`);`,
           app_name: { type: "string", description: "应用名称" },
           url: { type: "string", description: "要抓取的 URL" },
           metadata: { type: "object" },
-          chunk_size: { type: "integer", default: 800 },
-          overlap: { type: "integer", default: 100 },
-          preserve_newlines: { type: "boolean", default: true, description: "是否保留换行符" },
+          chunking_config: {
+            type: "object",
+            description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
+          },
         },
       },
       example: {
         url: "https://docs.example.com/guide",
         metadata: { type: "documentation" },
+        chunking_config: DEFAULT_CHUNKING_CONFIG,
       },
     },
     responses: [
@@ -495,7 +503,14 @@ console.log(\`Ingested \${result.count} chunks\`);`,
   -H "Content-Type: application/json" \\
   -d '{
     "url": "https://docs.example.com/guide",
-    "metadata": { "type": "documentation" }
+    "metadata": { "type": "documentation" },
+    "chunking_config": {
+      "strategy": "recursive",
+      "chunk_size": 800,
+      "overlap": 100,
+      "preserve_newlines": true,
+      "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+    }
   }'`,
       python: `import requests
 
@@ -503,7 +518,14 @@ response = requests.post(
     "${BASE_URL}/knowledge/base/{corpus_id}/ingest_url",
     json={
         "url": "https://docs.example.com/guide",
-        "metadata": {"type": "documentation"}
+        "metadata": {"type": "documentation"},
+        "chunking_config": {
+            "strategy": "recursive",
+            "chunk_size": 800,
+            "overlap": 100,
+            "preserve_newlines": True,
+            "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+        }
     }
 )
 result = response.json()
@@ -513,7 +535,14 @@ print(f"Ingested from URL: {result['count']} chunks")`,
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
     url: 'https://docs.example.com/guide',
-    metadata: { type: 'documentation' }
+    metadata: { type: 'documentation' },
+    chunking_config: {
+      strategy: 'recursive',
+      chunk_size: 800,
+      overlap: 100,
+      preserve_newlines: true,
+      separators: ['\\n\\n', '\\n', '。', '！', '？', '. ', '! ', '? ', '；', ';', ' ', '']
+    }
   })
 });
 
@@ -546,31 +575,13 @@ console.log(\`Ingested from URL: \${result.count} chunks\`);`,
           description: "自定义元数据字段",
         },
         {
-          name: "chunk_size",
-          type: "number",
-          label: "分块大小",
+          name: "chunking_config",
+          type: "json",
+          label: "Chunking Config",
           required: false,
-          defaultValue: 800,
-          min: 1,
-          max: 100000,
+          defaultValue: DEFAULT_CHUNKING_CONFIG,
           group: "advanced",
-        },
-        {
-          name: "overlap",
-          type: "number",
-          label: "重叠字符数",
-          required: false,
-          defaultValue: 100,
-          group: "advanced",
-        },
-        {
-          name: "preserve_newlines",
-          type: "checkbox",
-          label: "保留换行符",
-          required: false,
-          defaultValue: true,
-          group: "advanced",
-          description: "分块时是否保留换行符",
+          description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
         },
       ],
       submitLabel: "从 URL 摄入",
@@ -602,14 +613,16 @@ console.log(\`Ingested from URL: \${result.count} chunks\`);`,
           text: { type: "string", description: "新的文本内容" },
           source_uri: { type: "string", description: "要替换的来源 URI" },
           metadata: { type: "object" },
-          chunk_size: { type: "integer", default: 800 },
-          overlap: { type: "integer", default: 100 },
-          preserve_newlines: { type: "boolean", default: true, description: "是否保留换行符" },
+          chunking_config: {
+            type: "object",
+            description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
+          },
         },
       },
       example: {
         text: "这是更新后的文档内容。",
         source_uri: "docs://example/doc1",
+        chunking_config: DEFAULT_CHUNKING_CONFIG,
       },
     },
     responses: [
@@ -621,7 +634,14 @@ console.log(\`Ingested from URL: \${result.count} chunks\`);`,
   -H "Content-Type: application/json" \\
   -d '{
     "text": "这是更新后的文档内容。",
-    "source_uri": "docs://example/doc1"
+    "source_uri": "docs://example/doc1",
+    "chunking_config": {
+      "strategy": "recursive",
+      "chunk_size": 800,
+      "overlap": 100,
+      "preserve_newlines": true,
+      "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+    }
   }'`,
       python: `import requests
 
@@ -629,7 +649,14 @@ response = requests.post(
     "${BASE_URL}/knowledge/base/{corpus_id}/replace_source",
     json={
         "text": "这是更新后的文档内容。",
-        "source_uri": "docs://example/doc1"
+        "source_uri": "docs://example/doc1",
+        "chunking_config": {
+            "strategy": "recursive",
+            "chunk_size": 800,
+            "overlap": 100,
+            "preserve_newlines": True,
+            "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+        }
     }
 )
 result = response.json()
@@ -639,7 +666,14 @@ print(f"Replaced source: {result['count']} chunks")`,
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
     text: '这是更新后的文档内容。',
-    source_uri: 'docs://example/doc1'
+    source_uri: 'docs://example/doc1',
+    chunking_config: {
+      strategy: 'recursive',
+      chunk_size: 800,
+      overlap: 100,
+      preserve_newlines: true,
+      separators: ['\\n\\n', '\\n', '。', '！', '？', '. ', '! ', '? ', '；', ';', ' ', '']
+    }
   })
 });
 
@@ -679,31 +713,13 @@ console.log(\`Replaced source: \${result.count} chunks\`);`,
           description: "自定义元数据字段",
         },
         {
-          name: "chunk_size",
-          type: "number",
-          label: "分块大小",
+          name: "chunking_config",
+          type: "json",
+          label: "Chunking Config",
           required: false,
-          defaultValue: 800,
-          min: 1,
-          max: 100000,
+          defaultValue: DEFAULT_CHUNKING_CONFIG,
           group: "advanced",
-        },
-        {
-          name: "overlap",
-          type: "number",
-          label: "重叠字符数",
-          required: false,
-          defaultValue: 100,
-          group: "advanced",
-        },
-        {
-          name: "preserve_newlines",
-          type: "checkbox",
-          label: "保留换行符",
-          required: false,
-          defaultValue: true,
-          group: "advanced",
-          description: "分块时是否保留换行符",
+          description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
         },
       ],
       submitLabel: "替换来源",
@@ -890,21 +906,14 @@ result.items.forEach(item => {
           description: { type: "string", description: "语料库描述" },
           config: {
             type: "object",
-            properties: {
-              chunk_size: { type: "integer", default: 800 },
-              overlap: { type: "integer", default: 100 },
-              embedding_model: { type: "string", default: "text-embedding-3-small" },
-            },
+            description: "canonical corpus 配置，按 strategy 判别。",
           },
         },
       },
       example: {
         name: "产品文档",
         description: "产品相关文档和知识",
-        config: {
-          chunk_size: 800,
-          overlap: 100,
-        },
+        config: DEFAULT_CHUNKING_CONFIG,
       },
     },
     responses: [
@@ -930,7 +939,13 @@ result.items.forEach(item => {
   -d '{
     "name": "产品文档",
     "description": "产品相关文档和知识",
-    "config": { "chunk_size": 800 }
+    "config": {
+      "strategy": "recursive",
+      "chunk_size": 800,
+      "overlap": 100,
+      "preserve_newlines": true,
+      "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+    }
   }'`,
       python: `import requests
 
@@ -939,7 +954,13 @@ response = requests.post(
     json={
         "name": "产品文档",
         "description": "产品相关文档和知识",
-        "config": {"chunk_size": 800}
+        "config": {
+            "strategy": "recursive",
+            "chunk_size": 800,
+            "overlap": 100,
+            "preserve_newlines": True,
+            "separators": ["\\n\\n", "\\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""]
+        }
     }
 )
 corpus = response.json()
@@ -950,7 +971,13 @@ print(f"Created corpus: {corpus['id']}")`,
   body: JSON.stringify({
     name: '产品文档',
     description: '产品相关文档和知识',
-    config: { chunk_size: 800 }
+    config: {
+      strategy: 'recursive',
+      chunk_size: 800,
+      overlap: 100,
+      preserve_newlines: true,
+      separators: ['\\n\\n', '\\n', '。', '！', '？', '. ', '! ', '? ', '；', ';', ' ', '']
+    }
   })
 });
 
@@ -974,22 +1001,13 @@ console.log(\`Created corpus: \${corpus.id}\`);`,
           placeholder: "简要描述该语料库的内容用途...",
         },
         {
-          name: "chunk_size",
-          type: "number",
-          label: "分块大小",
+          name: "config",
+          type: "json",
+          label: "Corpus Config",
           required: false,
-          defaultValue: 800,
-          min: 1,
-          max: 100000,
+          defaultValue: DEFAULT_CHUNKING_CONFIG,
           group: "advanced",
-        },
-        {
-          name: "overlap",
-          type: "number",
-          label: "重叠字符数",
-          required: false,
-          defaultValue: 100,
-          group: "advanced",
+          description: DEFAULT_CHUNKING_CONFIG_DESCRIPTION,
         },
       ],
       submitLabel: "创建语料库",

--- a/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
@@ -1,0 +1,132 @@
+const {
+  ingestTextMock,
+  ingestUrlMock,
+  replaceSourceMock,
+  createCorpusMock,
+} = vi.hoisted(() => ({
+  ingestTextMock: vi.fn(),
+  ingestUrlMock: vi.fn(),
+  replaceSourceMock: vi.fn(),
+  createCorpusMock: vi.fn(),
+}));
+
+vi.mock("@/features/knowledge", () => ({
+  searchKnowledge: vi.fn(),
+  ingestText: (...args: unknown[]) => ingestTextMock(...args),
+  ingestUrl: (...args: unknown[]) => ingestUrlMock(...args),
+  replaceSource: (...args: unknown[]) => replaceSourceMock(...args),
+  fetchKnowledgeItems: vi.fn(),
+  createCorpus: (...args: unknown[]) => createCorpusMock(...args),
+  deleteCorpus: vi.fn(),
+}));
+
+import { executeApiCall } from "@/app/knowledge/apis/_components/utils/ApiExecutor";
+import { KNOWLEDGE_API_ENDPOINTS } from "@/features/knowledge/utils/api-specs";
+
+const getEndpoint = (id: string) => {
+  const endpoint = KNOWLEDGE_API_ENDPOINTS.find((item) => item.id === id);
+  expect(endpoint).toBeDefined();
+  return endpoint!;
+};
+
+describe("ApiExecutor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ingestTextMock.mockResolvedValue({ ok: true });
+    ingestUrlMock.mockResolvedValue({ ok: true });
+    replaceSourceMock.mockResolvedValue({ ok: true });
+    createCorpusMock.mockResolvedValue({ ok: true });
+  });
+
+  it("ingest 通过 chunking_config 透传 canonical 配置", async () => {
+    await executeApiCall(getEndpoint("ingest"), {
+      corpus_id: "corpus-1",
+      text: "hello",
+      chunking_config: {
+        strategy: "semantic",
+        semantic_threshold: 0.9,
+        semantic_buffer_size: 2,
+        min_chunk_size: 100,
+        max_chunk_size: 1200,
+      },
+    });
+
+    expect(ingestTextMock).toHaveBeenCalledWith("corpus-1", {
+      app_name: "negentropy",
+      text: "hello",
+      source_uri: undefined,
+      metadata: undefined,
+      chunking_config: {
+        strategy: "semantic",
+        semantic_threshold: 0.9,
+        semantic_buffer_size: 2,
+        min_chunk_size: 100,
+        max_chunk_size: 1200,
+      },
+    });
+  });
+
+  it("ingest_url 和 replace_source 使用 chunking_config 而不是旧扁平字段", async () => {
+    const chunkingConfig = {
+      strategy: "hierarchical",
+      preserve_newlines: true,
+      separators: ["\n\n", "\n"],
+      hierarchical_parent_chunk_size: 1024,
+      hierarchical_child_chunk_size: 256,
+      hierarchical_child_overlap: 51,
+    };
+
+    await executeApiCall(getEndpoint("ingest_url"), {
+      corpus_id: "corpus-1",
+      url: "https://example.com",
+      chunking_config: chunkingConfig,
+    });
+    await executeApiCall(getEndpoint("replace_source"), {
+      corpus_id: "corpus-1",
+      text: "updated",
+      source_uri: "docs://example/doc1",
+      chunking_config: chunkingConfig,
+    });
+
+    expect(ingestUrlMock).toHaveBeenCalledWith("corpus-1", {
+      app_name: "negentropy",
+      url: "https://example.com",
+      metadata: undefined,
+      chunking_config: chunkingConfig,
+    });
+    expect(replaceSourceMock).toHaveBeenCalledWith("corpus-1", {
+      app_name: "negentropy",
+      text: "updated",
+      source_uri: "docs://example/doc1",
+      metadata: undefined,
+      chunking_config: chunkingConfig,
+    });
+  });
+
+  it("create_corpus 直接透传 canonical config 对象", async () => {
+    await executeApiCall(getEndpoint("create_corpus"), {
+      name: "产品文档",
+      description: "desc",
+      config: {
+        strategy: "recursive",
+        chunk_size: 800,
+        overlap: 100,
+        preserve_newlines: true,
+        separators: ["\n\n", "\n"],
+      },
+    });
+
+    expect(createCorpusMock).toHaveBeenCalledWith({
+      app_name: "negentropy",
+      name: "产品文档",
+      description: "desc",
+      config: {
+        strategy: "recursive",
+        chunk_size: 800,
+        overlap: 100,
+        preserve_newlines: true,
+        separators: ["\n\n", "\n"],
+      },
+    });
+  });
+});

--- a/apps/negentropy-ui/tests/unit/knowledge/api-specs.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/api-specs.test.ts
@@ -1,0 +1,55 @@
+import { KNOWLEDGE_API_ENDPOINTS } from "@/features/knowledge/utils/api-specs";
+
+const getEndpoint = (id: string) => {
+  const endpoint = KNOWLEDGE_API_ENDPOINTS.find((item) => item.id === id);
+  expect(endpoint).toBeDefined();
+  return endpoint!;
+};
+
+describe("knowledge api specs", () => {
+  it("ingest 类 JSON endpoint 使用 canonical chunking_config", () => {
+    for (const id of ["ingest", "ingest_url", "replace_source"]) {
+      const endpoint = getEndpoint(id);
+      const properties = endpoint.requestBody?.schema.properties as
+        | Record<string, unknown>
+        | undefined;
+      const example = endpoint.requestBody?.example as Record<string, unknown> | undefined;
+      const advancedFields = endpoint.interactiveForm?.fields.filter(
+        (field) => field.group === "advanced",
+      );
+
+      expect(properties).toHaveProperty("chunking_config");
+      expect(properties).not.toHaveProperty("chunk_size");
+      expect(properties).not.toHaveProperty("overlap");
+      expect(example?.chunking_config).toMatchObject({
+        strategy: "recursive",
+        chunk_size: 800,
+        overlap: 100,
+      });
+      expect(advancedFields).toHaveLength(2);
+      expect(advancedFields?.[1]).toMatchObject({
+        name: "chunking_config",
+        type: "json",
+      });
+    }
+  });
+
+  it("create_corpus 使用 canonical config JSON 字段", () => {
+    const endpoint = getEndpoint("create_corpus");
+    const example = endpoint.requestBody?.example as Record<string, unknown> | undefined;
+    const advancedFields = endpoint.interactiveForm?.fields.filter(
+      (field) => field.group === "advanced",
+    );
+
+    expect(example?.config).toMatchObject({
+      strategy: "recursive",
+      chunk_size: 800,
+      overlap: 100,
+    });
+    expect(advancedFields).toHaveLength(1);
+    expect(advancedFields?.[0]).toMatchObject({
+      name: "config",
+      type: "json",
+    });
+  });
+});


### PR DESCRIPTION
## 背景

在完成 4 种 Chunk 策略的前后端 canonical 配置对齐后，Knowledge API 示例页仍然沿用旧的扁平 chunk 字段示例，例如 `chunk_size`、`overlap`、`preserve_newlines` 等。这会导致 API 文档、Try It 面板和真实业务入口之间再次出现契约漂移，后续新增入口也容易继续沿用旧的 flat payload。

本 PR 的目标是把 Knowledge API 示例页统一收敛到 canonical `chunking_config` 契约，确保文档示例、交互式调用和执行器转发逻辑与当前系统真实接口保持一致。

## 本次改动

### 1. 同步 API 示例定义到 canonical `chunking_config`

更新了 Knowledge API 示例定义：

- `ingest`
- `ingest_url`
- `replace_source`

这些 JSON body 类接口不再在示例页中暴露旧的顶层 chunk 字段，而是统一使用：

- `chunking_config`

同时将 `create_corpus` 的示例配置改为 canonical `config` 对象，而不是旧式 `{ chunk_size, overlap }` 结构。

### 2. 同步 Try It 执行器的真实请求结构

更新 API 执行器逻辑，使 Try It 面板在调用以下接口时直接转发 canonical 配置：

- `ingest`
- `ingest_url`
- `replace_source`
- `create_corpus`

这样示例页实际发出的请求不再退回到旧的扁平超集字段。

### 3. 更新示例代码与交互式表单

统一更新了：

- request schema
- example JSON
- curl 示例
- Python 示例
- JavaScript 示例
- interactive form 的高级字段定义

其中高级配置改为单个 JSON 输入字段承载 canonical config，而不是分别暴露多个 flat chunk 参数。

### 4. 增加回归测试

新增测试覆盖两类风险：

- `api-specs` 是否仍错误展示旧的 flat chunk 字段
- `ApiExecutor` 是否仍把 Try It 参数映射为旧 payload

## 为什么这样改

这次改动的核心目的是防止 Knowledge API 示例页成为新的 split-brain 来源。

如果 API 示例页继续展示旧字段，会产生几个直接问题：

- reviewer 和调用方会误以为旧的顶层 chunk 字段仍是推荐契约
- Try It 实际请求可能与业务页面配置不一致
- 后续新入口很容易复制示例页里的旧 payload 结构
- canonical `chunking_config` 设计无法在文档层形成稳定事实源

通过这次收敛，Knowledge API 示例页、Try It 执行器和业务 API client 的 JSON 契约将保持一致，避免配置语义再次发散。

## 重要实现细节

- 示例页 JSON body 类接口统一使用 `chunking_config`
- `create_corpus` 示例统一使用 canonical `config`
- 没有在 API 示例页重复实现一套策略切换 UI，而是复用现有 JSON 输入字段承载 canonical config
- 这样做能避免在示例页复制业务 Settings 页的复杂逻辑，降低后续维护成本
- 新增测试用于锁定“文档示例”和“真实执行请求”两个最容易再次漂移的点

## 验证

已完成验证：

- `pnpm --dir apps/negentropy-ui test -- tests/unit/knowledge/api-specs.test.ts tests/unit/knowledge/ApiExecutor.test.ts tests/unit/knowledge/knowledge-api.test.ts tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- 定向 ESLint 校验：
  - `features/knowledge/utils/api-specs.ts`
  - `app/knowledge/apis/_components/utils/ApiExecutor.ts`
  - 新增测试文件

## 影响范围

- Knowledge API 文档示例
- Knowledge API Try It 面板
- API 示例页执行器
- 对应回归测试

This PR was written using [Vibe Kanban](https://vibekanban.com)
