### PR TITLE
fix(observability): 统一 GLM 模型命名并修复 Langfuse 监控聚合分叉

### DIFF
--- a/apps/negentropy/src/negentropy/config/llm.py
+++ b/apps/negentropy/src/negentropy/config/llm.py
@@ -17,6 +17,8 @@ import os
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from negentropy.model_names import canonicalize_model_name, pricing_lookup_model_name
+
 
 class LlmVendor(str, Enum):
     """Supported LLM vendors."""
@@ -107,8 +109,8 @@ class LlmSettings(BaseSettings):
     def full_model_name(self) -> str:
         """Returns the LiteLLM-compatible model string (e.g. 'zai/glm-4.7')."""
         if "/" in self.model_name:
-            return self.model_name
-        return f"{self.vendor.value}/{self.model_name}"
+            return canonicalize_model_name(self.model_name) or self.model_name
+        return canonicalize_model_name(f"{self.vendor.value}/{self.model_name}") or f"{self.vendor.value}/{self.model_name}"
 
     @property
     def model_pricing(self) -> Optional[Dict[str, float]]:
@@ -122,16 +124,19 @@ class LlmSettings(BaseSettings):
         """
         from negentropy.config.pricing import get_model_pricing_usd
 
-        return get_model_pricing_usd(self.model_name)
+        lookup_name = pricing_lookup_model_name(self.model_name)
+        if lookup_name is None:
+            return None
+        return get_model_pricing_usd(lookup_name)
 
     @property
     def embedding_full_model_name(self) -> str:
         env_model = os.getenv("NE_LLM_EMBEDDING_MODEL")
         model_name = self.embedding_model_name or env_model or self.model_name
         if "/" in model_name:
-            return model_name
+            return canonicalize_model_name(model_name) or model_name
         vendor = self.embedding_vendor or self.vendor
-        return f"{vendor.value}/{model_name}"
+        return canonicalize_model_name(f"{vendor.value}/{model_name}") or f"{vendor.value}/{model_name}"
 
     def to_litellm_embedding_kwargs(self) -> Dict[str, Any]:
         kwargs: Dict[str, Any] = {}

--- a/apps/negentropy/src/negentropy/instrumentation.py
+++ b/apps/negentropy/src/negentropy/instrumentation.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 import json
 
 from negentropy.logging import get_logger
+from negentropy.model_names import canonicalize_model_name
 from opentelemetry import trace
 from litellm.integrations.opentelemetry import OpenTelemetry
 
@@ -15,16 +16,7 @@ def _normalize_model_name(model: str) -> str:
 
     Ensures GLM models always have the 'zai/' prefix for consistent naming.
     """
-    if not model:
-        return model
-    # If already has vendor prefix, return as-is
-    if "/" in model:
-        return model
-    # Add zai prefix for GLM models
-    model_lower = model.lower()
-    if model_lower.startswith("glm"):
-        return f"zai/{model}"
-    return model
+    return canonicalize_model_name(model) or model
 
 
 def _calculate_custom_cost(kwargs: dict, response_obj: Any) -> Optional[float]:
@@ -91,7 +83,7 @@ class LiteLLMLoggingCallback:
         """Log successful LLM interaction."""
         self._ensure_tracing()
         try:
-            model = kwargs.get("model", "unknown")
+            model = _normalize_model_name(kwargs.get("model", "unknown"))
             input_tokens = 0
             output_tokens = 0
 
@@ -137,7 +129,7 @@ class LiteLLMLoggingCallback:
     def log_failure_event(self, kwargs: dict, response_obj: Any, start_time: Any, end_time: Any) -> None:
         """Log failed LLM interaction."""
         try:
-            model = kwargs.get("model", "unknown")
+            model = _normalize_model_name(kwargs.get("model", "unknown"))
             exception = kwargs.get("exception", "unknown error")
 
             latency_ms = (end_time - start_time).total_seconds() * 1000
@@ -209,8 +201,15 @@ def patch_litellm_otel_cost() -> None:
             # Normalize model name for consistent Langfuse reporting
             model = kwargs.get("model", "unknown")
             normalized_model = _normalize_model_name(model)
+            response_model = None
+            if response_obj is not None and hasattr(response_obj, "get"):
+                response_model = response_obj.get("model")
+            normalized_response_model = _normalize_model_name(response_model) if response_model else None
+
             if normalized_model != model:
                 self.safe_set_attribute(span, "gen_ai.request.model", normalized_model)
+            if normalized_response_model and normalized_response_model != response_model:
+                self.safe_set_attribute(span, "gen_ai.response.model", normalized_response_model)
 
             # Extract and inject cost
             cost = _extract_total_cost(kwargs, response_obj)

--- a/apps/negentropy/src/negentropy/knowledge/graph_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph_service.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from negentropy.config import settings
 from negentropy.logging import get_logger
+from negentropy.model_names import canonicalize_model_name
 
 from .graph_repository import (
     AgeGraphRepository,
@@ -198,6 +199,7 @@ class GraphService:
             构建结果统计
         """
         build_config = config or self._config
+        normalized_llm_model = canonicalize_model_name(build_config.llm_model)
         run_id = f"build-{uuid.uuid4().hex[:8]}-{int(time.time())}"
         start_time = time.time()
 
@@ -216,11 +218,11 @@ class GraphService:
             run_id=run_id,
             extractor_config={
                 "enable_llm": build_config.enable_llm_extraction,
-                "llm_model": build_config.llm_model,
+                "llm_model": normalized_llm_model,
                 "entity_types": build_config.entity_types,
                 "relation_types": build_config.relation_types,
             },
-            model_name=build_config.llm_model,
+            model_name=normalized_llm_model,
         )
 
         try:

--- a/apps/negentropy/src/negentropy/model_names.py
+++ b/apps/negentropy/src/negentropy/model_names.py
@@ -1,0 +1,49 @@
+"""
+LLM 模型名规范化工具。
+
+提供全局唯一的模型名规范化与查表键转换逻辑，避免观测、日志、
+持久化和定价等链路各自维护不同的命名规则。
+"""
+
+from __future__ import annotations
+
+
+def canonicalize_model_name(model_name: str | None) -> str | None:
+    """返回全局规范模型名。
+
+    当前规则：
+    - `glm*` 系列统一规范为 `zai/<model>`
+    - 已带前缀的模型保持幂等
+    - 非 GLM 模型保持原样
+    """
+    if not model_name:
+        return model_name
+
+    normalized = model_name.strip()
+    if not normalized:
+        return normalized
+
+    if "/" in normalized:
+        vendor, raw_model = normalized.split("/", 1)
+        if raw_model.lower().startswith("glm"):
+            return f"zai/{raw_model}"
+        return normalized
+
+    if normalized.lower().startswith("glm"):
+        return f"zai/{normalized}"
+
+    return normalized
+
+
+def pricing_lookup_model_name(model_name: str | None) -> str | None:
+    """返回用于定价查表的模型键。
+
+    定价表当前以裸模型名为键，例如 `glm-5`，因此需要在查表前
+    去掉供应商前缀；其它模型保持原样。
+    """
+    canonical = canonicalize_model_name(model_name)
+    if not canonical:
+        return canonical
+
+    _, separator, raw_model = canonical.partition("/")
+    return raw_model if separator else canonical

--- a/apps/negentropy/src/negentropy/plugins/subagent_presets.py
+++ b/apps/negentropy/src/negentropy/plugins/subagent_presets.py
@@ -19,6 +19,7 @@ from negentropy.agents.faculties import (
     internalization_agent,
     perception_agent,
 )
+from negentropy.model_names import canonicalize_model_name
 
 
 NEGENTROPY_SUBAGENT_ORDER = [
@@ -61,9 +62,9 @@ def _model_name(model: Any) -> Optional[str]:
         return None
     model_name = getattr(model, "model", None)
     if isinstance(model_name, str) and model_name:
-        return model_name
+        return canonicalize_model_name(model_name)
     as_text = str(model)
-    return as_text or None
+    return canonicalize_model_name(as_text) or None
 
 
 def _to_json_compatible(value: Any) -> Any:

--- a/apps/negentropy/tests/unit_tests/knowledge/test_graph_service_model_name.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_graph_service_model_name.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.graph_service import GraphBuildConfig, GraphService
+
+
+class _FakeGraphRepository:
+    def __init__(self) -> None:
+        self.create_build_run_kwargs = None
+        self.update_build_run_kwargs = None
+
+    async def create_build_run(self, **kwargs):
+        self.create_build_run_kwargs = kwargs
+        return "run-uuid"
+
+    async def clear_graph(self, corpus_id):
+        return None
+
+    async def create_entities(self, entities, corpus_id):
+        return []
+
+    async def create_relations(self, relations):
+        return None
+
+    async def update_build_run(self, **kwargs):
+        self.update_build_run_kwargs = kwargs
+        return None
+
+
+@pytest.mark.asyncio
+async def test_build_graph_persists_canonical_model_name():
+    repository = _FakeGraphRepository()
+    service = GraphService(repository=repository, config=GraphBuildConfig(llm_model="glm-5"))
+
+    result = await service.build_graph(
+        corpus_id=uuid4(),
+        app_name="test-app",
+        chunks=[],
+    )
+
+    assert result.status == "completed"
+    assert repository.create_build_run_kwargs["model_name"] == "zai/glm-5"
+    assert repository.create_build_run_kwargs["extractor_config"]["llm_model"] == "zai/glm-5"

--- a/apps/negentropy/tests/unit_tests/plugins/test_subagent_presets.py
+++ b/apps/negentropy/tests/unit_tests/plugins/test_subagent_presets.py
@@ -7,6 +7,7 @@ from negentropy.agents.faculties import (
     internalization_agent,
     perception_agent,
 )
+from negentropy.model_names import canonicalize_model_name
 from negentropy.plugins.subagent_presets import (
     NEGENTROPY_SUBAGENT_NAMES,
     build_negentropy_subagent_payloads,
@@ -35,6 +36,9 @@ def test_builtin_payload_matches_faculty_definition():
         assert payload["system_prompt"] == faculty.instruction
         assert payload["agent_type"] == "llm_agent"
         assert payload["tools"] == _tool_names(faculty)
+        expected_model = canonicalize_model_name(getattr(faculty.model, "model", str(faculty.model)))
+        assert payload["model"] == expected_model
         assert payload["adk_config"]["name"] == faculty.name
         assert payload["adk_config"]["instruction"] == faculty.instruction
         assert payload["adk_config"]["tools"] == _tool_names(faculty)
+        assert payload["adk_config"]["model"] == expected_model

--- a/apps/negentropy/tests/unit_tests/test_instrumentation.py
+++ b/apps/negentropy/tests/unit_tests/test_instrumentation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from litellm.integrations.opentelemetry import OpenTelemetry
+
+from negentropy.instrumentation import patch_litellm_otel_cost
+
+
+class _FakeSpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+
+
+class _FakeOpenTelemetryCallback:
+    callback_name = "otel"
+
+    @staticmethod
+    def safe_set_attribute(span: _FakeSpan, key: str, value: object) -> None:
+        span.attributes[key] = value
+
+
+def test_patch_litellm_otel_cost_normalizes_request_and_response_model(monkeypatch):
+    original = OpenTelemetry.set_attributes
+
+    def _original_set_attributes(self, span, kwargs, response_obj):
+        self.safe_set_attribute(span, "gen_ai.request.model", kwargs.get("model"))
+        self.safe_set_attribute(span, "gen_ai.response.model", response_obj.get("model"))
+
+    monkeypatch.setattr(OpenTelemetry, "set_attributes", _original_set_attributes)
+
+    try:
+        patch_litellm_otel_cost()
+
+        span = _FakeSpan()
+        callback = _FakeOpenTelemetryCallback()
+        kwargs = {"model": "zai/glm-5", "response_cost": 0.12}
+        response_obj = {"model": "glm-5"}
+
+        OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
+
+        assert span.attributes["gen_ai.request.model"] == "zai/glm-5"
+        assert span.attributes["gen_ai.response.model"] == "zai/glm-5"
+        assert span.attributes["gen_ai.usage.cost"] == 0.12
+    finally:
+        monkeypatch.setattr(OpenTelemetry, "set_attributes", original)

--- a/apps/negentropy/tests/unit_tests/test_model_names.py
+++ b/apps/negentropy/tests/unit_tests/test_model_names.py
@@ -1,0 +1,26 @@
+from negentropy.config.llm import LlmSettings, LlmVendor
+from negentropy.model_names import canonicalize_model_name, pricing_lookup_model_name
+
+
+def test_canonicalize_model_name_for_glm_models():
+    assert canonicalize_model_name("glm-5") == "zai/glm-5"
+    assert canonicalize_model_name("zai/glm-5") == "zai/glm-5"
+    assert canonicalize_model_name("openai/glm-5") == "zai/glm-5"
+
+
+def test_canonicalize_model_name_keeps_non_glm_models():
+    assert canonicalize_model_name("text-embedding-005") == "text-embedding-005"
+    assert canonicalize_model_name("openai/gpt-4o-mini") == "openai/gpt-4o-mini"
+
+
+def test_pricing_lookup_model_name_strips_vendor_prefix():
+    assert pricing_lookup_model_name("glm-5") == "glm-5"
+    assert pricing_lookup_model_name("zai/glm-5") == "glm-5"
+
+
+def test_llm_settings_uses_canonical_model_name_and_pricing():
+    settings = LlmSettings(vendor=LlmVendor.ZAI, model_name="glm-5")
+
+    assert settings.full_model_name == "zai/glm-5"
+    assert settings.embedding_full_model_name == "zai/glm-5"
+    assert settings.model_pricing == {"input": 0.571429, "output": 2.571429}


### PR DESCRIPTION
## 背景

监控中发现，同一个 GLM-5 模型在 Langfuse 被聚合成了两个名称：`glm-5` 与 `zai/glm-5`。

根因是观测链路同时写入了 request / response 两侧的模型名，但现有标准化逻辑只覆盖了 request 侧，导致同一请求在不同字段中出现不同命名，最终被监控平台拆分聚合。

## 变更内容

本 PR 采用单一事实源（Single Source of Truth）方式统一模型命名：

- 新增统一模型名规范化入口，将 `glm-*` 系列规范化为 `zai/glm-*`
- 配置层统一输出规范模型名，同时保留定价查表对裸模型名的兼容
- 修复 LiteLLM OpenTelemetry 补丁，同时标准化：
  - `gen_ai.request.model`
  - `gen_ai.response.model`
- 统一知识图谱构建落库时记录的模型名
- 统一 SubAgent 序列化输出中的模型名
- 补充回归测试，覆盖模型名规范化、OTel 双字段一致性、图谱构建落库与 SubAgent 配置输出

## 验证结果

已执行：

```bash
uv run pytest tests/unit_tests/test_model_names.py tests/unit_tests/test_instrumentation.py tests/unit_tests/plugins/test_subagent_presets.py tests/unit_tests/knowledge/test_graph_service_model_name.py
```

结果：

- `8 passed`

## 兼容性与风险控制

- 仅影响未来新上报的监控数据，不回填历史 Langfuse 数据
- 不修改数据库 schema
- 非 GLM 模型命名行为保持不变
- pricing fallback 继续兼容裸模型名，避免前缀引入后导致定价失配

## 预期收益

- Langfuse 中同一 GLM 模型不再被拆分为多个名称
- 监控、日志、持久化输出的模型命名口径一致
- 降低后续多供应商场景下再次出现命名漂移的风险
