### PR TITLE
fix(Knowledge Base): 收敛 Corpus 卡片摘要与底部操作区 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -66,6 +66,22 @@ function CorpusStatusBadge({ corpus }: { corpus: CorpusRecord }) {
   );
 }
 
+function formatCorpusConfigSummary(corpus: CorpusRecord): string {
+  const config = normalizeChunkingConfig(
+    (corpus.config ?? {}) as Record<string, unknown>,
+  );
+
+  if (config.strategy === "semantic") {
+    return `chunks: ${corpus.knowledge_count} · strategy: semantic · threshold: ${config.semantic_threshold.toFixed(2)} · buffer: ${config.semantic_buffer_size}`;
+  }
+
+  if (config.strategy === "hierarchical") {
+    return `chunks: ${corpus.knowledge_count} · strategy: hierarchical · parent: ${config.hierarchical_parent_chunk_size} · child: ${config.hierarchical_child_chunk_size}`;
+  }
+
+  return `chunks: ${corpus.knowledge_count} · strategy: ${config.strategy} · size: ${config.chunk_size} · overlap: ${config.overlap}`;
+}
+
 function ChunkDetailDrawer({
   chunk,
   onClose,
@@ -905,38 +921,35 @@ export default function KnowledgeBasePage() {
           {corpora.map((corpus) => (
             <div
               key={corpus.id}
-              className="cursor-pointer rounded-xl border border-border bg-background p-4 transition hover:border-foreground/40"
+              className="flex h-full cursor-pointer flex-col rounded-xl border border-border bg-background p-3 transition hover:border-foreground/40"
               onClick={() => openCorpusWorkspace(corpus.id, "documents")}
             >
-              <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="flex items-center justify-between gap-2">
                 <h3 className="truncate text-base font-semibold">{corpus.name}</h3>
                 <CorpusStatusBadge corpus={corpus} />
               </div>
-              <p className="line-clamp-2 h-10 text-xs text-muted">
+              <p className="mt-1 truncate text-xs text-muted" title={corpus.description || "No description"}>
                 {corpus.description || "No description"}
               </p>
-              <div className="mt-2 text-[11px] text-muted">
-                chunks: {corpus.knowledge_count}
+              <div
+                className="mt-2 truncate text-[11px] text-muted"
+                title={formatCorpusConfigSummary(corpus)}
+              >
+                {formatCorpusConfigSummary(corpus)}
               </div>
-              <div className="mt-1 text-[11px] text-muted">
-                strategy: {String((corpus.config?.strategy as string) || "recursive")}
-              </div>
-              <div className="mt-3 flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+              <div
+                className="mt-auto flex items-center justify-end gap-2 pt-3"
+                onClick={(e) => e.stopPropagation()}
+              >
                 <button
                   onClick={() => handleEditCorpus(corpus)}
-                  className="rounded border border-border px-2 py-1 text-[11px] hover:bg-muted"
+                  className="inline-flex h-7 items-center rounded border border-border px-2.5 text-[11px] hover:bg-muted"
                 >
                   Settings
                 </button>
                 <button
-                  onClick={() => openCorpusWorkspace(corpus.id, "documents")}
-                  className="rounded border border-border px-2 py-1 text-[11px] hover:bg-muted"
-                >
-                  Add Documents
-                </button>
-                <button
                   onClick={() => handleDeleteCorpus(corpus)}
-                  className="rounded border border-red-300 px-2 py-1 text-[11px] text-red-600 hover:bg-red-50"
+                  className="inline-flex h-7 items-center rounded border border-red-300 px-2.5 text-[11px] text-red-600 hover:bg-red-50"
                 >
                   Delete
                 </button>

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -249,6 +249,26 @@ describe("KnowledgeBasePage", () => {
     expect(deleteCorpusMock).not.toHaveBeenCalled();
   });
 
+  it("overview Corpus 卡片收敛展示 canonical 摘要并移除 Add Documents", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value = "view=overview";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.queryByRole("button", { name: "Add Documents" })).not.toBeInTheDocument();
+    expect(
+      screen.getByText("chunks: 3 · strategy: recursive · size: 800 · overlap: 100"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
   it("点击删除确认框空白处会关闭弹框", async () => {
     const user = userEvent.setup();
     searchParamsState.value = "view=overview";


### PR DESCRIPTION
## 变更内容

本次改动聚焦 `Knowledge Base` 页面中的 `Corpus` 卡片展示与交互，主要包括：

- 将卡片中的 chunking 配置摘要收敛为单行展示，并与实际 canonical chunking config 对齐
- 整体压缩 Corpus 卡片高度，减少 overview 场景下的纵向占用
- 移除卡片内的 `Add Documents` 按钮
- 将保留的 `Settings` 与 `Delete` 按钮统一停靠到卡片底部右侧
- 修复 `Settings` 按钮在 hover 场景下停靠不稳定的问题
- 补充页面级单测，覆盖新的摘要展示和按钮行为

## 变更原因

该调整来自 Knowledge Base 页面信息收敛需求。现有 Corpus 卡片中，`chunks`、`strategy` 等配置分散在多行展示，按钮区也占用较多垂直空间，在 overview 场景下会降低扫描效率；同时 `Settings` 按钮在鼠标悬停时存在停靠表现不稳定的问题。

本次改动的目标是：

- 提升 Corpus 列表的可扫读性，降低卡片高度
- 让配置摘要与真实 chunking 配置保持一致，避免展示语义与实际配置脱节
- 收敛操作入口，减少重复入口带来的界面噪音
- 修复卡片 hover 过程中的布局漂移，保证交互稳定性

## 关键实现细节

- 在前端卡片渲染逻辑中新增基于 `normalizeChunkingConfig()` 的摘要格式化逻辑，统一从 canonical config 生成单行摘要，而不是直接依赖零散字段
- 按不同 chunking strategy 分别展示有效摘要字段：
  - `fixed` / `recursive`：展示 `chunks`、`strategy`、`size`、`overlap`
  - `semantic`：展示 `chunks`、`strategy`、`threshold`、`buffer`
  - `hierarchical`：展示 `chunks`、`strategy`、`parent`、`child`
- 将 Corpus 卡片重构为稳定的纵向 `flex` 布局，通过 `mt-auto` 将操作区固定在卡片底部，从根源上消除 hover 状态下按钮位置漂移
- 保留点击整张卡片进入 `documents` 工作区的主路径，因此移除 `Add Documents` 后不影响主要操作链路
- 新增测试覆盖：
  - `Add Documents` 已移除
  - 单行 canonical 摘要可见
  - 点击 `Settings` 不会误触发整卡跳转

## 验证说明

- 已补充 `KnowledgeBasePage` 相关单测断言
- 当前工作区缺少前端 `node_modules`，本地未能实际执行 `vitest`，失败原因是 `vitest: command not found`

This PR was written using [Vibe Kanban](https://vibekanban.com)
