### PR TITLE
fix(ui): 修复会话水合与生成态分裂导致的回复空白 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -17,11 +17,7 @@ import { useAuth } from "../components/providers/AuthProvider";
 import { LogBufferPanel } from "../components/ui/LogBufferPanel";
 import { SessionList } from "../components/ui/SessionList";
 import { StateSnapshot } from "../components/ui/StateSnapshot";
-import {
-  AdkEventPayload,
-  adkEventsToMessages,
-  adkEventsToSnapshot,
-} from "@/lib/adk";
+import { AdkEventPayload } from "@/lib/adk";
 
 import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 
@@ -36,7 +32,13 @@ import {
   buildConversationTree,
   buildNodeTimestampIndex,
 } from "@/utils/conversation-tree";
-import { mapAdkPayloadToNormalizedAguiEvents } from "@/utils/agui-normalization";
+import {
+  deriveConnectionState,
+  deriveRunStates,
+  hydrateSessionDetail,
+  mergeEvents,
+  mergeMessages,
+} from "@/utils/session-hydration";
 
 // 统一的类型定义
 import type {
@@ -47,7 +49,6 @@ import type {
 
 const AGENT_ID = "negentropy";
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
-const EMPTY_MESSAGES: Message[] = [];
 
 export function HomeBody({
   sessionId,
@@ -77,6 +78,7 @@ export function HomeBody({
     lastRunMs: 0,
   });
   const titleRefreshTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const hydrationTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [rawEvents, setRawEvents] = useState<BaseEvent[]>([]);
@@ -88,11 +90,21 @@ export function HomeBody({
   > | null>(null);
   const [loadedSessionId, setLoadedSessionId] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const loadedSessionIdRef = useRef<string | null>(null);
+  const rawEventsRef = useRef<BaseEvent[]>([]);
 
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === sessionId) || null,
     [sessions, sessionId],
   );
+
+  useEffect(() => {
+    loadedSessionIdRef.current = loadedSessionId;
+  }, [loadedSessionId]);
+
+  useEffect(() => {
+    rawEventsRef.current = rawEvents;
+  }, [rawEvents]);
 
   const addLog = useCallback(
     (
@@ -141,16 +153,6 @@ export function HomeBody({
     },
     [addLog],
   );
-
-  // ... (keeping intervening code if any, but replacing the function block to be safe)
-  // Wait, replace_file_content needs contiguous block.
-  // I will split this into two replacements if needed or just target updateCurrentSessionTime first.
-
-  // Actually, I can do it in two chunks? No, replace_file_content is single contiguous.
-  // I will use multi_replace_file_content for safety if I need to touch multiple places,
-  // or just replace updateCurrentSessionTime block first.
-
-  // use multi_replace_file_content to fix both locations.
 
   const setConnectionWithMetrics = useCallback(
     (next: ConnectionState) => {
@@ -209,7 +211,7 @@ export function HomeBody({
       },
       onEvent: ({ event }) =>
         setRawEvents((prev) => {
-          const next = [...prev, event];
+          const next = mergeEvents(prev, [event]);
           return next.slice(-10000);
         }),
     });
@@ -233,6 +235,28 @@ export function HomeBody({
     });
     return pending.size;
   }, [rawEvents]);
+
+  const derivedRunStates = useMemo(() => deriveRunStates(rawEvents), [rawEvents]);
+  const latestRunState = useMemo(
+    () => derivedRunStates[derivedRunStates.length - 1] || null,
+    [derivedRunStates],
+  );
+  const effectiveConnection = useMemo(() => {
+    const derived = deriveConnectionState(rawEvents);
+    if (derived === "blocked" || derived === "error") {
+      return derived;
+    }
+    if (connection === "connecting" || connection === "streaming") {
+      return connection;
+    }
+    if (connection === "error") {
+      return connection;
+    }
+    if (connection === "idle" && derived === "streaming") {
+      return "idle";
+    }
+    return derived;
+  }, [connection, rawEvents]);
 
   // 根据选中的节点时间范围过滤事件，右侧保持历史视图能力
   const nodeTimestampIndex = useMemo(() => {
@@ -380,7 +404,20 @@ export function HomeBody({
     titleRefreshTimersRef.current = [];
   }, []);
 
-  useEffect(() => () => clearTitleRefreshTimers(), [clearTitleRefreshTimers]);
+  const clearHydrationTimers = useCallback(() => {
+    hydrationTimersRef.current.forEach((timer) => {
+      clearTimeout(timer);
+    });
+    hydrationTimersRef.current = [];
+  }, []);
+
+  useEffect(
+    () => () => {
+      clearTitleRefreshTimers();
+      clearHydrationTimers();
+    },
+    [clearHydrationTimers, clearTitleRefreshTimers],
+  );
 
   const scheduleTitleRefresh = useCallback(() => {
     clearTitleRefreshTimers();
@@ -442,23 +479,31 @@ export function HomeBody({
         const events = Array.isArray(payload.events)
           ? (payload.events as AdkEventPayload[])
           : [];
-        const messages = adkEventsToMessages(events);
-        const snapshot = adkEventsToSnapshot(events);
-        const mappedEvents = events.flatMap((event) =>
-          mapAdkPayloadToNormalizedAguiEvents(event, {
-            threadId: id,
-            runId: event.runId || id,
-          }),
-        );
+        const hydrated = hydrateSessionDetail(events, id);
+        const currentLoadedSessionId = loadedSessionIdRef.current;
+        const currentRawEvents = rawEventsRef.current;
 
-        setRawEvents(mappedEvents);
-        setSessionMessages(messages);
-        setSessionSnapshot(snapshot || null);
+        setRawEvents((prev) => {
+          const shouldMerge =
+            currentLoadedSessionId === id ||
+            (sessionId === id && currentRawEvents.length > 0);
+          return shouldMerge ? mergeEvents(prev, hydrated.events) : hydrated.events;
+        });
+        setSessionMessages((prev) => {
+          const shouldMerge =
+            currentLoadedSessionId === id ||
+            (sessionId === id && currentRawEvents.length > 0);
+          return shouldMerge
+            ? mergeMessages(prev, hydrated.messages)
+            : hydrated.messages;
+        });
+        setSessionSnapshot((prev) =>
+          currentLoadedSessionId === id ||
+          (sessionId === id && currentRawEvents.length > 0)
+            ? (hydrated.snapshot ?? prev)
+            : hydrated.snapshot,
+        );
         setLoadedSessionId(id);
-        if (agent) {
-          agent.setMessages(messages);
-          agent.setState(snapshot || {});
-        }
       } catch (error) {
         setConnectionWithMetrics("error");
         addLog("error", "load_session_detail_failed", {
@@ -468,19 +513,36 @@ export function HomeBody({
       }
     },
     [
-      agent,
       userId,
       setConnectionWithMetrics,
       addLog,
       sessionId,
-      setSessionId,
-      setSessions,
     ],
+  );
+
+  const scheduleSessionHydration = useCallback(
+    (id: string) => {
+      clearHydrationTimers();
+      const delays = [0, 250, 800, 1600];
+      delays.forEach((delay) => {
+        const timer = setTimeout(() => {
+          void loadSessionDetail(id);
+        }, delay);
+        hydrationTimersRef.current.push(timer);
+      });
+    },
+    [clearHydrationTimers, loadSessionDetail],
   );
 
   const handleConfirmationFollowup = useCallback(
     async (payload: { action: string; note: string }) => {
-      if (!agent || !sessionId || agent.isRunning) {
+      if (
+        !agent ||
+        !sessionId ||
+        agent.isRunning ||
+        effectiveConnection === "streaming" ||
+        effectiveConnection === "connecting"
+      ) {
         return;
       }
       agent.addMessage({
@@ -495,7 +557,7 @@ export function HomeBody({
           runId: randomUUID(),
           threadId: sessionId,
         });
-        await loadSessionDetail(sessionId);
+        scheduleSessionHydration(sessionId);
         await loadSessions();
       } catch (error) {
         setConnectionWithMetrics("error");
@@ -503,7 +565,15 @@ export function HomeBody({
         console.warn("Failed to submit HITL response", error);
       }
     },
-    [agent, addLog, loadSessionDetail, loadSessions, sessionId, setConnectionWithMetrics],
+    [
+      agent,
+      addLog,
+      effectiveConnection,
+      loadSessions,
+      scheduleSessionHydration,
+      sessionId,
+      setConnectionWithMetrics,
+    ],
   );
 
   useConfirmationTool(handleConfirmationFollowup);
@@ -524,7 +594,12 @@ export function HomeBody({
     if (!agent || !sessionId || !inputValue.trim()) {
       return;
     }
-    if (pendingConfirmations > 0) {
+    if (
+      pendingConfirmations > 0 ||
+      effectiveConnection === "streaming" ||
+      effectiveConnection === "connecting" ||
+      effectiveConnection === "blocked"
+    ) {
       return;
     }
 
@@ -552,7 +627,7 @@ export function HomeBody({
         runId: randomUUID(),
         threadId: sessionId,
       });
-      await loadSessionDetail(sessionId);
+      scheduleSessionHydration(sessionId);
       await loadSessions();
       if (shouldPollTitle) {
         scheduleTitleRefresh();
@@ -573,6 +648,8 @@ export function HomeBody({
   const handleSessionChange = useCallback((newId: string | null) => {
     setSessionId(newId);
     if (newId) {
+      clearHydrationTimers();
+      clearTitleRefreshTimers();
       setSessionMessages([]);
       setOptimisticMessages([]);
       setSessionSnapshot(null);
@@ -580,7 +657,7 @@ export function HomeBody({
       setLoadedSessionId(null);
       setSelectedNodeId(null);
     }
-  }, []);
+  }, [clearHydrationTimers, clearTitleRefreshTimers, setSessionId]);
 
   useEffect(() => {
     if (!sessionId) {
@@ -591,22 +668,8 @@ export function HomeBody({
   }, [sessionId, agent, loadSessionDetail]);
 
   const hasLoadedSession = loadedSessionId === sessionId;
-
-  const agentMessages = agent ? (agent.messages as Message[]) : EMPTY_MESSAGES;
-  const agentSnapshot = agent ? (agent.state as Record<string, unknown>) : null;
-
-  /* Removed problematic effect that caused cascading renders:
-     useEffect(() => { ... setOptimisticMessages ... }, [agentMessages])
-     Instead, we filter optimistic messages during derived state calculation.
-  */
-
-  const messagesForRenderBase =
-    hasLoadedSession && agentMessages.length > 0
-      ? agentMessages
-      : sessionMessages;
-  const snapshotForRender = hasLoadedSession
-    ? (agentSnapshot ?? sessionSnapshot)
-    : sessionSnapshot;
+  const messagesForRenderBase = hasLoadedSession ? sessionMessages : [];
+  const snapshotForRender = hasLoadedSession ? sessionSnapshot : null;
 
   // Reconstruct state snapshot from filtered events for historical viewing
   const historicalSnapshot = useMemo(
@@ -738,7 +801,9 @@ export function HomeBody({
             </button>
 
             <div className="text-xs font-medium text-zinc-400 max-w-md truncate mx-4 dark:text-zinc-500">
-              {activeSession ? activeSession.label : "Negentropy"}
+              {activeSession
+                ? `${activeSession.label}${latestRunState?.status === "blocked" ? " · 等待确认" : ""}`
+                : "Negentropy"}
             </div>
 
             <button
@@ -782,10 +847,13 @@ export function HomeBody({
                 value={inputValue}
                 onChange={setInputValue}
                 onSend={sendInput}
-                isGenerating={connection === "streaming"}
+                isGenerating={effectiveConnection === "streaming"}
+                isBlocked={effectiveConnection === "blocked"}
                 disabled={
                   !sessionId ||
-                  connection === "streaming" ||
+                  effectiveConnection === "streaming" ||
+                  effectiveConnection === "connecting" ||
+                  effectiveConnection === "blocked" ||
                   pendingConfirmations > 0
                 }
               />
@@ -837,7 +905,7 @@ export function HomeBody({
 
             <StateSnapshot
               snapshot={snapshotForDisplay}
-              connection={selectedNodeId ? "idle" : connection}
+              connection={selectedNodeId ? "idle" : effectiveConnection}
             />
             <EventTimeline events={timelineItems} />
             <LogBufferPanel

--- a/apps/negentropy-ui/components/ui/Composer.tsx
+++ b/apps/negentropy-ui/components/ui/Composer.tsx
@@ -4,6 +4,7 @@ type ComposerProps = {
   onSend: () => void;
   disabled: boolean;
   isGenerating?: boolean;
+  isBlocked?: boolean;
 };
 
 export function Composer({
@@ -12,6 +13,7 @@ export function Composer({
   onSend,
   disabled,
   isGenerating,
+  isBlocked,
 }: ComposerProps) {
   return (
     <form
@@ -47,7 +49,7 @@ export function Composer({
           {isGenerating && (
             <span className="h-2 w-2 rounded-full bg-background animate-pulse" />
           )}
-          {isGenerating ? "Generating..." : "Send"}
+          {isBlocked ? "Waiting..." : isGenerating ? "Generating..." : "Send"}
         </button>
       </div>
     </form>

--- a/apps/negentropy-ui/components/ui/StateSnapshot.tsx
+++ b/apps/negentropy-ui/components/ui/StateSnapshot.tsx
@@ -22,6 +22,8 @@ export function StateSnapshot({ snapshot, connection }: StateSnapshotProps) {
                 ? "bg-muted text-muted"
                 : connection === "streaming"
                   ? "bg-emerald-100 text-emerald-600 animate-pulse border border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400 dark:border-emerald-800"
+                  : connection === "blocked"
+                    ? "bg-blue-100 text-blue-600 border border-blue-200 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-800"
                   : connection === "error"
                     ? "bg-red-100 text-red-600 border border-red-200 dark:bg-red-900/30 dark:text-red-400 dark:border-red-800"
                     : connection === "connecting"

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -204,7 +204,9 @@ function TurnNode({
       child.type === "error"),
   );
   const statusHint =
-    node.status === "running" && !hasMeaningfulReply
+    node.status === "blocked"
+      ? "等待用户确认后继续"
+      : node.status === "running" && !hasMeaningfulReply
       ? "NE 正在生成回复..."
       : node.status === "finished" && !hasMeaningfulReply
         ? "本轮未生成可展示回复"
@@ -225,7 +227,13 @@ function TurnNode({
             {node.title}
           </div>
           <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-            {node.status === "finished" ? "已完成" : node.status === "error" ? "异常" : "进行中"}
+            {node.status === "finished"
+              ? "已完成"
+              : node.status === "error"
+                ? "异常"
+                : node.status === "blocked"
+                  ? "等待确认"
+                  : "进行中"}
             {" · "}
             {childCount} 个子模块
           </div>

--- a/apps/negentropy-ui/tests/integration/home-flow.test.tsx
+++ b/apps/negentropy-ui/tests/integration/home-flow.test.tsx
@@ -1,11 +1,13 @@
 import { ReactNode, useState } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { EventType, type BaseEvent } from "@ag-ui/core";
 import { HomeBody } from "../../app/page";
 
 let mockAgent: any;
 let lastHitlConfig: any;
 let detailEvents: any[];
+let subscriptionHandlers: Record<string, (...args: any[]) => void> | null;
 
 vi.mock("@copilotkitnext/react", () => ({
   CopilotKitProvider: ({ children }: { children: ReactNode }) => children,
@@ -40,37 +42,81 @@ function Wrapper({ sessionId }: { sessionId: string | null }) {
   );
 }
 
+function emitEvent(event: BaseEvent) {
+  subscriptionHandlers?.onEvent?.({ event });
+}
+
+function emitAssistantReply(sessionId: string, messageId: string, content: string) {
+  emitEvent({
+    type: EventType.RUN_STARTED,
+    threadId: sessionId,
+    runId: sessionId,
+    timestamp: 1001,
+  } as BaseEvent);
+  emitEvent({
+    type: EventType.TEXT_MESSAGE_START,
+    threadId: sessionId,
+    runId: sessionId,
+    messageId,
+    role: "assistant",
+    timestamp: 1002,
+  } as BaseEvent);
+  emitEvent({
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    threadId: sessionId,
+    runId: sessionId,
+    messageId,
+    delta: content,
+    timestamp: 1003,
+  } as BaseEvent);
+  emitEvent({
+    type: EventType.TEXT_MESSAGE_END,
+    threadId: sessionId,
+    runId: sessionId,
+    messageId,
+    timestamp: 1004,
+  } as BaseEvent);
+}
+
+async function waitForInitialHydration() {
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/agui/sessions/s1"),
+    );
+  });
+}
+
 describe("HomeBody integration", () => {
   beforeEach(() => {
     detailEvents = [];
+    subscriptionHandlers = null;
     mockAgent = {
       messages: [],
       state: { stage: "ready" },
       isRunning: false,
-      subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+      subscribe: vi.fn((handlers) => {
+        subscriptionHandlers = handlers;
+        return { unsubscribe: vi.fn() };
+      }),
       addMessage: vi.fn((message) => {
         mockAgent.messages = [...mockAgent.messages, message];
       }),
       runAgent: vi.fn().mockImplementation(async () => {
+        subscriptionHandlers?.onRunInitialized?.();
+        subscriptionHandlers?.onRunStartedEvent?.();
+        emitAssistantReply("s1", "assistant-1", "world");
         detailEvents = [
           {
             id: "assistant-1",
             runId: "s1",
             threadId: "s1",
-            timestamp: 1002,
+            timestamp: 1004,
             message: { role: "assistant", content: "world" },
           },
         ];
-        mockAgent.messages = [
-          ...mockAgent.messages,
-          { id: "assistant-1", role: "assistant", content: "world" },
-        ];
+        subscriptionHandlers?.onRunFinishedEvent?.();
         return { result: "ok" };
       }),
-      setMessages: vi.fn((messages) => {
-        mockAgent.messages = messages;
-      }),
-      setState: vi.fn(),
     };
     lastHitlConfig = null;
 
@@ -101,50 +147,103 @@ describe("HomeBody integration", () => {
     }) as unknown as typeof fetch;
   });
 
-  it("发送消息时显式带 threadId，并在运行后回拉会话详情", async () => {
+  it("发送消息时显式带 threadId，并在运行后展示 assistant 回复", async () => {
+    const user = userEvent.setup();
     render(<Wrapper sessionId="s1" />);
+    await waitForInitialHydration();
 
-    await userEvent.type(screen.getByPlaceholderText("输入指令..."), "ping");
-    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    await user.type(screen.getByPlaceholderText("输入指令..."), "ping");
+    await user.click(screen.getByRole("button", { name: "Send" }));
 
     await waitFor(() => {
-      expect(mockAgent.runAgent).toHaveBeenCalled();
+      expect(mockAgent.runAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "s1",
+          runId: expect.any(String),
+        }),
+      );
     });
 
-    expect(mockAgent.runAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        threadId: "s1",
-        runId: expect.any(String),
-      }),
+    expect(await screen.findByText((content) => content.includes("world"))).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(screen.queryByText("NE 正在生成回复...")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
     );
+  }, 10000);
 
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("/api/agui/sessions/s1"),
-      );
+  it("历史回拉暂时为空时，实时 assistant 回复不会被清空", async () => {
+    const user = userEvent.setup();
+    mockAgent.runAgent.mockImplementationOnce(async () => {
+      subscriptionHandlers?.onRunInitialized?.();
+      subscriptionHandlers?.onRunStartedEvent?.();
+      emitAssistantReply("s1", "assistant-delayed", "delayed world");
+      detailEvents = [];
+      setTimeout(() => {
+        detailEvents = [
+          {
+            id: "assistant-delayed",
+            runId: "s1",
+            threadId: "s1",
+            timestamp: 1004,
+            message: { role: "assistant", content: "delayed world" },
+          },
+        ];
+      }, 500);
+      subscriptionHandlers?.onRunFinishedEvent?.();
+      return { result: "ok" };
     });
 
-    await waitFor(() => {
-      expect(mockAgent.setMessages).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ content: "world", role: "assistant" }),
-        ]),
-      );
+    render(<Wrapper sessionId="s1" />);
+    await waitForInitialHydration();
+
+    await user.type(screen.getByPlaceholderText("输入指令..."), "Hi");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(
+      await screen.findByText((content) => content.includes("delayed world")),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
     });
-  });
+    expect(
+      screen.getByText((content) => content.includes("delayed world")),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1800));
+    });
+    expect(
+      screen.getByText((content) => content.includes("delayed world")),
+    ).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(screen.queryByText("NE 正在生成回复...")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  }, 10000);
 
   it("连续发送两条消息时保持用户消息显示顺序", async () => {
+    const user = userEvent.setup();
     render(<Wrapper sessionId="s1" />);
+    await waitForInitialHydration();
 
     const input = screen.getByPlaceholderText("输入指令...");
-    await userEvent.type(input, "Hello");
-    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    await user.type(input, "Hello");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(screen.getByText((content) => content.includes("world"))).toBeInTheDocument();
+    });
 
     mockAgent.runAgent.mockResolvedValueOnce({ result: "ok" });
     detailEvents = [];
 
-    await userEvent.type(input, "Hi");
-    await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    await user.type(input, "Hi");
+    await user.click(screen.getByRole("button", { name: "Send" }));
 
     const hello = await screen.findByText((content) => content.includes("Hello"));
     const hi = await screen.findByText((content) => content.includes("Hi"));
@@ -152,10 +251,12 @@ describe("HomeBody integration", () => {
     expect(
       hello.compareDocumentPosition(hi) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-  });
+  }, 10000);
 
   it("handles HITL confirmation flow", async () => {
+    const user = userEvent.setup();
     render(<Wrapper sessionId="s1" />);
+    await waitForInitialHydration();
     const respond = vi.fn().mockResolvedValue(undefined);
     const ui = lastHitlConfig.render({
       status: "inProgress",
@@ -163,11 +264,11 @@ describe("HomeBody integration", () => {
       respond,
     });
     render(ui);
-    await userEvent.click(screen.getByRole("button", { name: "确认" }));
+    await user.click(screen.getByRole("button", { name: "确认" }));
     expect(respond).toHaveBeenCalled();
     expect(mockAgent.addMessage).toHaveBeenCalled();
     expect(mockAgent.runAgent).toHaveBeenCalledWith(
       expect.objectContaining({ threadId: "s1" }),
     );
-  });
+  }, 10000);
 });

--- a/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
@@ -153,6 +153,33 @@ describe("ChatStream", () => {
     expect(screen.getByText("NE 正在生成回复...")).toBeInTheDocument();
   });
 
+  it("在 HITL 阻塞时展示等待确认提示", () => {
+    const nodes: ConversationNode[] = [
+      {
+        id: "turn:blocked",
+        type: "turn",
+        parentId: null,
+        children: [],
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1000 },
+        sourceOrder: 0,
+        title: "轮次 run-1",
+        status: "blocked",
+        visibility: "chat",
+        isStructural: false,
+        payload: {},
+        sourceEventTypes: ["tool_call_start"],
+        relatedMessageIds: [],
+      },
+    ];
+
+    render(<ChatStream nodes={nodes} />);
+
+    expect(screen.getByText("等待用户确认后继续")).toBeInTheDocument();
+  });
+
   it("直接展示错误节点而不是折叠隐藏", () => {
     const nodes: ConversationNode[] = [
       {

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -242,4 +242,111 @@ describe("buildConversationTree", () => {
     expect(tree.roots[0].children[0].type).toBe("error");
     expect(tree.roots[0].children[0].visibility).toBe("chat");
   });
+
+  it("confirmation 工具在运行结束后仍保持 blocked 状态", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        toolCallId: "tool-1",
+        toolCallName: "ui.confirmation",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1002,
+      } as BaseEvent,
+    ];
+
+    const tree = buildConversationTree({ events });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].status).toBe("blocked");
+  });
+
+  it("文本消息在 TEXT_MESSAGE_END 后保留累计内容", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        role: "assistant",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        delta: "world",
+        timestamp: 1002,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        timestamp: 1003,
+      } as BaseEvent,
+    ];
+
+    const tree = buildConversationTree({ events });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].children).toHaveLength(1);
+    expect(tree.roots[0].children[0].payload.content).toBe("world");
+  });
+
+  it("工具参数在 TOOL_CALL_END 后保留累计内容", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        toolCallId: "tool-1",
+        toolCallName: "search",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_ARGS,
+        threadId: "thread-1",
+        runId: "run-1",
+        toolCallId: "tool-1",
+        delta: "{\"q\":\"hello\"}",
+        timestamp: 1002,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        toolCallId: "tool-1",
+        timestamp: 1003,
+      } as BaseEvent,
+    ];
+
+    const tree = buildConversationTree({ events });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].children).toHaveLength(1);
+    expect(tree.roots[0].children[0].payload.args).toBe("{\"q\":\"hello\"}");
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { EventType, type BaseEvent } from "@ag-ui/core";
+import {
+  deriveConnectionState,
+  deriveRunStates,
+  hydrateSessionDetail,
+  mergeEvents,
+} from "@/utils/session-hydration";
+
+describe("session-hydration", () => {
+  it("为历史回放补齐缺失的运行生命周期事件", () => {
+    const result = hydrateSessionDetail(
+      [
+        {
+          id: "msg-1",
+          runId: "run-1",
+          threadId: "session-1",
+          timestamp: 1000,
+          message: { role: "assistant", content: "hello" },
+        },
+      ],
+      "session-1",
+    );
+
+    expect(result.events[0].type).toBe(EventType.RUN_STARTED);
+    expect(result.events[result.events.length - 1].type).toBe(EventType.RUN_FINISHED);
+  });
+
+  it("将 confirmation 工具轮次派生为 blocked", () => {
+    const events: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "session-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TOOL_CALL_START,
+        threadId: "session-1",
+        runId: "run-1",
+        toolCallId: "tool-1",
+        toolCallName: "ui.confirmation",
+        timestamp: 1001,
+      } as BaseEvent,
+    ];
+
+    const states = deriveRunStates(events);
+    expect(states[0]?.status).toBe("blocked");
+    expect(deriveConnectionState(events)).toBe("blocked");
+  });
+
+  it("合并历史事件时保留实时唯一事件而不重复", () => {
+    const realtime: BaseEvent[] = [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "session-1",
+        runId: "run-1",
+        timestamp: 1000,
+      } as BaseEvent,
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "hello",
+        timestamp: 1001,
+      } as BaseEvent,
+    ];
+
+    const historical: BaseEvent[] = [
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "hello",
+        timestamp: 1001,
+      } as BaseEvent,
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "session-1",
+        runId: "run-1",
+        timestamp: 1002,
+      } as BaseEvent,
+    ];
+
+    const merged = mergeEvents(realtime, historical);
+    expect(
+      merged.filter(
+        (event) =>
+          event.type === EventType.TEXT_MESSAGE_CONTENT &&
+          "messageId" in event &&
+          event.messageId === "msg-1",
+      ),
+    ).toHaveLength(1);
+    expect(merged[merged.length - 1].type).toBe(EventType.RUN_FINISHED);
+  });
+});

--- a/apps/negentropy-ui/types/common.ts
+++ b/apps/negentropy-ui/types/common.ts
@@ -10,7 +10,12 @@ import type { Message } from "@ag-ui/core";
 /**
  * 连接状态类型
  */
-export type ConnectionState = "idle" | "connecting" | "streaming" | "error";
+export type ConnectionState =
+  | "idle"
+  | "connecting"
+  | "streaming"
+  | "blocked"
+  | "error";
 
 /**
  * 会话记录类型

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -376,6 +376,7 @@ export function buildConversationTree(
   const toolNodeIndex = new Map<string, string>();
   const turns = new Map<string, MutableNode>();
   const assistantMessageByRun = new Map<string, string>();
+  const pendingConfirmationCountByRun = new Map<string, number>();
   const pendingLinks: LinkInstruction[] = [];
   let activeRunId: string | undefined;
 
@@ -413,7 +414,10 @@ export function buildConversationTree(
         return;
       }
       case EventType.RUN_FINISHED: {
-        turn.status = "finished";
+        turn.status =
+          (pendingConfirmationCountByRun.get(runId) || 0) > 0
+            ? "blocked"
+            : "finished";
         mergeEventMeta(turn, normalizedEvent);
         if (activeRunId === runId) {
           activeRunId = undefined;
@@ -459,9 +463,13 @@ export function buildConversationTree(
           sourceOrder: eventIndex,
           title: role === "user" ? "用户消息" : "助手消息",
           role,
-          payload: {
-            content: "",
-          },
+          payload:
+            normalizedEvent.type === EventType.TEXT_MESSAGE_CONTENT &&
+            "delta" in normalizedEvent
+              ? {
+                  content: String(normalizedEvent.delta || ""),
+                }
+              : {},
           sourceEventTypes: [eventType],
           relatedMessageIds: [messageId],
         });
@@ -517,9 +525,7 @@ export function buildConversationTree(
               : "工具调用",
           status:
             normalizedEvent.type === EventType.TOOL_CALL_END ? "done" : "running",
-          payload: {
-            args: "",
-          },
+          payload: {},
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
         });
@@ -530,6 +536,11 @@ export function buildConversationTree(
         ) {
           node.title = normalizedEvent.toolCallName;
           node.payload.toolCallName = normalizedEvent.toolCallName;
+          if (normalizedEvent.toolCallName === "ui.confirmation") {
+            const nextCount = (pendingConfirmationCountByRun.get(runId) || 0) + 1;
+            pendingConfirmationCountByRun.set(runId, nextCount);
+            turn.status = "blocked";
+          }
         }
         if (normalizedEvent.type === EventType.TOOL_CALL_ARGS && "delta" in normalizedEvent) {
           node.payload.args = `${String(node.payload.args || "")}${String(
@@ -566,6 +577,15 @@ export function buildConversationTree(
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
         });
+        if ((pendingConfirmationCountByRun.get(runId) || 0) > 0) {
+          pendingConfirmationCountByRun.set(
+            runId,
+            Math.max(0, (pendingConfirmationCountByRun.get(runId) || 0) - 1),
+          );
+          if (turn.status === "blocked") {
+            turn.status = "running";
+          }
+        }
         attachNode(nodeIndex, roots, turns, node.id, parentId);
         return;
       }

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -1,0 +1,342 @@
+import { type BaseEvent, EventType, type Message } from "@ag-ui/core";
+import type { AdkEventPayload } from "@/lib/adk";
+import { adkEventsToMessages, adkEventsToSnapshot } from "@/lib/adk";
+import { mapAdkPayloadToNormalizedAguiEvents } from "@/utils/agui-normalization";
+import type { ConnectionState } from "@/types/common";
+
+export type HydratedSessionDetail = {
+  events: BaseEvent[];
+  messages: Message[];
+  snapshot: Record<string, unknown> | null;
+};
+
+function normalizeTimestamp(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : Date.now() / 1000;
+}
+
+function fallbackRunId(payload: AdkEventPayload, sessionId: string): string {
+  return payload.runId || payload.threadId || sessionId;
+}
+
+function fallbackThreadId(payload: AdkEventPayload, sessionId: string): string {
+  return payload.threadId || sessionId;
+}
+
+function eventKey(event: BaseEvent): string {
+  const type = String(event.type);
+  const threadId =
+    "threadId" in event && typeof event.threadId === "string"
+      ? event.threadId
+      : "";
+  const runId =
+    "runId" in event && typeof event.runId === "string" ? event.runId : "";
+  const messageId =
+    "messageId" in event && typeof event.messageId === "string"
+      ? event.messageId
+      : "";
+  const toolCallId =
+    "toolCallId" in event && typeof event.toolCallId === "string"
+      ? event.toolCallId
+      : "";
+  const timestamp = normalizeTimestamp(event.timestamp);
+
+  switch (event.type) {
+    case EventType.TEXT_MESSAGE_START:
+      return [
+        type,
+        threadId,
+        runId,
+        messageId,
+        "role" in event ? String(event.role || "") : "",
+      ].join("|");
+    case EventType.TEXT_MESSAGE_CONTENT:
+      return [
+        type,
+        threadId,
+        runId,
+        messageId,
+        "delta" in event ? String(event.delta || "") : "",
+      ].join("|");
+    case EventType.TEXT_MESSAGE_END:
+      return [type, threadId, runId, messageId].join("|");
+    case EventType.TOOL_CALL_START:
+      return [
+        type,
+        threadId,
+        runId,
+        toolCallId,
+        "toolCallName" in event ? String(event.toolCallName || "") : "",
+      ].join("|");
+    case EventType.TOOL_CALL_ARGS:
+      return [
+        type,
+        threadId,
+        runId,
+        toolCallId,
+        "delta" in event ? String(event.delta || "") : "",
+      ].join("|");
+    case EventType.TOOL_CALL_END:
+      return [type, threadId, runId, toolCallId].join("|");
+    case EventType.TOOL_CALL_RESULT:
+      return [
+        type,
+        threadId,
+        runId,
+        toolCallId,
+        "content" in event ? String(event.content || "") : "",
+      ].join("|");
+    case EventType.RUN_STARTED:
+    case EventType.RUN_FINISHED:
+      return [type, threadId, runId].join("|");
+    case EventType.RUN_ERROR:
+      return [
+        type,
+        threadId,
+        runId,
+        "code" in event ? String(event.code || "") : "",
+        "message" in event ? String(event.message || "") : "",
+      ].join("|");
+    case EventType.CUSTOM:
+      return [
+        type,
+        threadId,
+        runId,
+        "eventType" in event ? String(event.eventType || "") : "",
+        JSON.stringify("data" in event ? event.data : null),
+      ].join("|");
+    default:
+      return [type, threadId, runId, messageId, toolCallId, String(timestamp)].join(
+        "|",
+      );
+  }
+}
+
+export function mergeEvents(baseEvents: BaseEvent[], incomingEvents: BaseEvent[]): BaseEvent[] {
+  const merged = new Map<string, BaseEvent>();
+  [...baseEvents, ...incomingEvents].forEach((event) => {
+    merged.set(eventKey(event), event);
+  });
+
+  return [...merged.values()].sort((a, b) => {
+    const timeDiff = normalizeTimestamp(a.timestamp) - normalizeTimestamp(b.timestamp);
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    return eventKey(a).localeCompare(eventKey(b));
+  });
+}
+
+export function mergeMessages(baseMessages: Message[], incomingMessages: Message[]): Message[] {
+  const merged = new Map<string, Message>();
+
+  [...baseMessages, ...incomingMessages].forEach((message) => {
+    const existing = merged.get(message.id);
+    if (!existing) {
+      merged.set(message.id, message);
+      return;
+    }
+
+    const existingContent =
+      typeof existing.content === "string"
+        ? existing.content
+        : JSON.stringify(existing.content);
+    const incomingContent =
+      typeof message.content === "string"
+        ? message.content
+        : JSON.stringify(message.content);
+
+    if (incomingContent.length >= existingContent.length) {
+      merged.set(message.id, { ...existing, ...message });
+    }
+  });
+
+  return [...merged.values()].sort((a, b) => {
+    const aTime =
+      a.createdAt instanceof Date ? a.createdAt.getTime() : Number.MAX_SAFE_INTEGER;
+    const bTime =
+      b.createdAt instanceof Date ? b.createdAt.getTime() : Number.MAX_SAFE_INTEGER;
+    if (aTime !== bTime) {
+      return aTime - bTime;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function hydrateSessionDetail(
+  payloads: AdkEventPayload[],
+  sessionId: string,
+): HydratedSessionDetail {
+  const runBuckets = new Map<string, BaseEvent[]>();
+
+  payloads.forEach((payload) => {
+    const runId = fallbackRunId(payload, sessionId);
+    const threadId = fallbackThreadId(payload, sessionId);
+    const events = mapAdkPayloadToNormalizedAguiEvents(payload, {
+      threadId,
+      runId,
+    });
+    const bucket = runBuckets.get(runId) || [];
+    bucket.push(...events);
+    runBuckets.set(runId, bucket);
+  });
+
+  const normalizedEvents = [...runBuckets.entries()].flatMap(([runId, events]) => {
+    const ordered = [...events].sort((a, b) => {
+      const timeDiff = normalizeTimestamp(a.timestamp) - normalizeTimestamp(b.timestamp);
+      if (timeDiff !== 0) {
+        return timeDiff;
+      }
+      return eventKey(a).localeCompare(eventKey(b));
+    });
+
+    if (ordered.length === 0) {
+      return ordered;
+    }
+
+    const first = ordered[0];
+    const hasRunStarted = ordered.some((event) => event.type === EventType.RUN_STARTED);
+    const hasRunFinished = ordered.some((event) => event.type === EventType.RUN_FINISHED);
+    const hasRunError = ordered.some((event) => event.type === EventType.RUN_ERROR);
+    const threadId =
+      "threadId" in first && typeof first.threadId === "string"
+        ? first.threadId
+        : sessionId;
+
+    if (!hasRunStarted) {
+      ordered.unshift({
+        type: EventType.RUN_STARTED,
+        threadId,
+        runId,
+        timestamp: Math.max(0, normalizeTimestamp(first.timestamp) - 0.001),
+      } as BaseEvent);
+    }
+
+    if (!hasRunFinished && !hasRunError) {
+      const last = ordered[ordered.length - 1];
+      ordered.push({
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId,
+        result: "completed_from_history",
+        timestamp: normalizeTimestamp(last.timestamp) + 0.001,
+      } as BaseEvent);
+    }
+
+    return ordered;
+  });
+
+  const messages = adkEventsToMessages(payloads);
+  const snapshot = adkEventsToSnapshot(payloads) || null;
+
+  return {
+    events: mergeEvents([], normalizedEvents),
+    messages,
+    snapshot,
+  };
+}
+
+export type DerivedRunState = {
+  runId: string;
+  status: "streaming" | "blocked" | "completed" | "error";
+  startedAt?: number;
+  finishedAt?: number;
+  pendingConfirmationCount: number;
+  hasRenderableOutput: boolean;
+};
+
+function isRenderableEvent(event: BaseEvent): boolean {
+  switch (event.type) {
+    case EventType.TEXT_MESSAGE_CONTENT:
+      return "delta" in event && String(event.delta || "").trim().length > 0;
+    case EventType.TOOL_CALL_START:
+    case EventType.TOOL_CALL_RESULT:
+    case EventType.ACTIVITY_SNAPSHOT:
+    case EventType.STATE_DELTA:
+    case EventType.STATE_SNAPSHOT:
+    case EventType.RUN_ERROR:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function deriveRunStates(events: BaseEvent[]): DerivedRunState[] {
+  const states = new Map<string, DerivedRunState>();
+
+  events.forEach((event) => {
+    const runId =
+      "runId" in event && typeof event.runId === "string"
+        ? event.runId
+        : "default";
+    const current = states.get(runId) || {
+      runId,
+      status: "streaming" as const,
+      pendingConfirmationCount: 0,
+      hasRenderableOutput: false,
+    };
+
+    if (event.type === EventType.RUN_STARTED) {
+      current.startedAt = normalizeTimestamp(event.timestamp);
+      current.status = "streaming";
+    }
+
+    if (event.type === EventType.RUN_FINISHED) {
+      current.finishedAt = normalizeTimestamp(event.timestamp);
+      current.status = current.pendingConfirmationCount > 0 ? "blocked" : "completed";
+    }
+
+    if (event.type === EventType.RUN_ERROR) {
+      current.finishedAt = normalizeTimestamp(event.timestamp);
+      current.status = "error";
+    }
+
+    if (
+      event.type === EventType.TOOL_CALL_START &&
+      "toolCallName" in event &&
+      event.toolCallName === "ui.confirmation"
+    ) {
+      current.pendingConfirmationCount += 1;
+      current.status = "blocked";
+    }
+
+    if (event.type === EventType.TOOL_CALL_RESULT && current.pendingConfirmationCount > 0) {
+      current.pendingConfirmationCount -= 1;
+      if (current.status === "blocked") {
+        current.status = current.finishedAt ? "completed" : "streaming";
+      }
+    }
+
+    if (isRenderableEvent(event)) {
+      current.hasRenderableOutput = true;
+    }
+
+    states.set(runId, current);
+  });
+
+  return [...states.values()].sort((a, b) => {
+    const aTime = a.finishedAt ?? a.startedAt ?? 0;
+    const bTime = b.finishedAt ?? b.startedAt ?? 0;
+    return aTime - bTime;
+  });
+}
+
+export function deriveConnectionState(events: BaseEvent[]): ConnectionState {
+  const runStates = deriveRunStates(events);
+  const current = runStates[runStates.length - 1];
+
+  if (!current) {
+    return "idle";
+  }
+  if (current.status === "error") {
+    return "error";
+  }
+  if (current.status === "blocked") {
+    return "blocked";
+  }
+  if (current.status === "streaming") {
+    return "streaming";
+  }
+  return "idle";
+}


### PR DESCRIPTION
## 背景

在用户发送 `Hi` 等消息后，Negentropy UI 出现了明显的会话状态分裂：

- 页面顶部仍显示“正在生成回复”
- 底部 Composer 已恢复为可再次发送
- 主聊天区中央没有渲染出任何 assistant 回复，界面长期保持空白

这说明实时事件流、历史会话回拉以及 AUI/HUI 渲染语义之间存在 split-brain，导致前端在“看起来已经完成”时仍丢失了实际可展示的答复内容。

## 本次改动

### 1. 统一会话 hydration 与事件归并
- 新增统一的 session hydration 入口，将历史会话详情归一化为一致的 AG-UI 事件、消息和状态快照
- 为历史回放补齐缺失的 `RUN_STARTED` / `RUN_FINISHED`
- 对实时事件与历史事件执行幂等 merge，避免重复节点和回放覆盖实时结果

### 2. 修复主聊天区 assistant 回复被裁掉的问题
- 修复会话树构建逻辑中 `TEXT_MESSAGE_END` / `TOOL_CALL_END` 覆盖已累计 payload 的问题
- 只有真正携带增量内容的事件才更新文本或工具参数，避免结束事件把已有内容重置为空
- 解决历史回放合并后事件重排导致 assistant 文本节点被 prune 的问题

### 3. 对齐生成态、阻塞态与 HUI 确认语义
- 将顶部 turn 状态、底部 Composer 状态、右侧状态面板统一收敛到同一运行状态派生
- 新增 `blocked` 连接态，明确区分“正在生成”和“等待用户确认”
- `ui.confirmation` 未完成时，界面展示“等待确认”，不再误报为“生成中”

### 4. 优化历史回拉策略，避免清空实时回复
- 发送消息后不再用历史空结果直接覆盖当前实时状态
- 改为“实时事件优先、历史仅补全”的合并模型
- 当上游持久化存在延迟时，已经到达前端的 assistant 回复会继续保留，不会被短暂的空回包抹掉

### 5. 补充回归测试
- 新增 session hydration 单测
- 补充 conversation tree 单测，覆盖文本/工具参数在结束事件后仍保留内容
- 扩展 ChatStream 与首页集成测试，覆盖：
  - assistant 回复正常展示
  - 历史回拉暂时为空时不再出现中央空白
  - 顶部/底部生成态不再分裂
  - HITL confirmation 的 blocked 语义

## 重要实现细节
- 前端渲染改为以统一事件流为主真值，历史详情仅用于补全 read model
- `effectiveConnection` 成为顶部标题、Composer、StateSnapshot 等 UI 状态的单一事实源
- 会话树构建逻辑改为只接受真正的增量写入，避免结束类事件造成内容回退
- 保持 AUI 展示语义与 HUI 阻塞语义一致，减少刷新前后和实时/历史之间的不一致渲染

This PR was written using [Vibe Kanban](https://vibekanban.com)
