### PR TITLE
feat(knowledge): 通过可配置 MCP Data Extractor 重构 Knowledge Base 文档摄入 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -12,7 +12,9 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import {
+  buildCorpusConfig,
   CorpusRecord,
+  CorpusExtractorRoutes,
   ChunkingConfig,
   ChunkingStrategy,
   DocumentViewDialog,
@@ -32,6 +34,7 @@ import {
   downloadDocument,
   deleteDocument,
   createDefaultChunkingConfig,
+  normalizeCorpusExtractorRoutes,
   normalizeChunkingConfig,
 } from "@/features/knowledge";
 
@@ -1277,9 +1280,66 @@ function CorpusSettingsPanel({
   const [formConfig, setFormConfig] = useState<ChunkingConfig>(
     normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
   );
+  const [extractorRoutes, setExtractorRoutes] = useState<CorpusExtractorRoutes>(
+    normalizeCorpusExtractorRoutes((corpus.config || {}) as Record<string, unknown>),
+  );
+  const [servers, setServers] = useState<Array<{ id: string; name: string; display_name: string | null; is_enabled: boolean }>>([]);
+  const [toolsByServer, setToolsByServer] = useState<Record<string, Array<{ name: string; display_name: string | null; is_enabled: boolean }>>>({});
+
+  useEffect(() => {
+    let active = true;
+
+    const loadServers = async () => {
+      const response = await fetch("/api/plugins/mcp/servers");
+      if (!response.ok) {
+        throw new Error("Failed to load MCP servers");
+      }
+      const data = (await response.json()) as Array<{
+        id: string;
+        name: string;
+        display_name: string | null;
+        is_enabled: boolean;
+      }>;
+      if (!active) return;
+      const enabledServers = data.filter((item) => item.is_enabled);
+      setServers(enabledServers);
+
+      const toolEntries = await Promise.all(
+        enabledServers.map(async (server) => {
+          const toolsResponse = await fetch(`/api/plugins/mcp/servers/${server.id}/tools`);
+          if (!toolsResponse.ok) {
+            return [server.id, []] as const;
+          }
+          const tools = (await toolsResponse.json()) as Array<{
+            name: string;
+            display_name: string | null;
+            is_enabled: boolean;
+          }>;
+          return [server.id, tools.filter((item) => item.is_enabled)] as const;
+        }),
+      );
+      if (!active) return;
+      setToolsByServer(Object.fromEntries(toolEntries));
+    };
+
+    void loadServers().catch((err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to load MCP servers");
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleSubmit = async () => {
-    await onSave(formConfig as unknown as Record<string, unknown>);
+    await onSave(buildCorpusConfig(formConfig, extractorRoutes));
+  };
+
+  const updateRouteTargets = (routeKey: keyof CorpusExtractorRoutes, targets: CorpusExtractorRoutes[keyof CorpusExtractorRoutes]["targets"]) => {
+    setExtractorRoutes((prev) => ({
+      ...prev,
+      [routeKey]: { targets },
+    }));
   };
 
   return (
@@ -1290,6 +1350,115 @@ function CorpusSettingsPanel({
         title="Settings"
         description="保存后作为该 Corpus 的默认分块配置。"
       />
+
+      <div className="rounded-2xl border border-border bg-background p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-semibold">Data Extractor MCP</h3>
+            <p className="mt-1 text-xs text-muted">
+              为当前 Knowledge Base 分别绑定 URL 与 PDF 的主备 MCP Server / Tool。已配置类型严格依赖所选 MCP，只会在主备之间切换。
+            </p>
+          </div>
+        </div>
+
+        {([
+          ["url", "URL 文档", "页面抓取、正文抽取、Markdown 化"],
+          ["file_pdf", "PDF 文档", "PDF 解析、Markdown 转换、图片提取"],
+        ] as const).map(([routeKey, title, description]) => {
+          const targets = extractorRoutes[routeKey]?.targets || [];
+          return (
+            <div key={routeKey} className="mt-4 rounded-xl border border-border p-3">
+              <div className="mb-3">
+                <div className="text-xs font-semibold">{title}</div>
+                <div className="text-[11px] text-muted">{description}</div>
+              </div>
+              <div className="space-y-3">
+                {[0, 1].map((index) => {
+                  const target = targets[index];
+                  const selectedServerId = target?.server_id || "";
+                  const toolOptions = selectedServerId ? (toolsByServer[selectedServerId] || []) : [];
+
+                  const nextTargets = [...targets];
+                  const nextTarget = target || {
+                    server_id: "",
+                    tool_name: "",
+                    priority: index,
+                    enabled: true,
+                  };
+
+                  const setTarget = (patch: Record<string, unknown>) => {
+                    nextTargets[index] = {
+                      ...nextTarget,
+                      ...patch,
+                      priority: index,
+                      enabled: true,
+                    };
+                    updateRouteTargets(
+                      routeKey,
+                      nextTargets.filter((item) => item.server_id && item.tool_name),
+                    );
+                  };
+
+                  const clearTarget = () => {
+                    nextTargets.splice(index, 1);
+                    updateRouteTargets(routeKey, nextTargets);
+                  };
+
+                  return (
+                    <div key={`${routeKey}-${index}`} className="grid gap-3 rounded-lg border border-border bg-card p-3 md:grid-cols-[120px_1fr_1fr_auto]">
+                      <div className="text-xs font-semibold text-zinc-600 dark:text-zinc-300">
+                        {index === 0 ? "主用" : "备用"}
+                      </div>
+                      <label className="text-xs">
+                        <div className="mb-1 text-muted">MCP Server</div>
+                        <select
+                          value={selectedServerId}
+                          onChange={(e) =>
+                            setTarget({ server_id: e.target.value, tool_name: "" })
+                          }
+                          className="w-full rounded border border-border bg-background px-2 py-2"
+                        >
+                          <option value="">未配置</option>
+                          {servers.map((server) => (
+                            <option key={server.id} value={server.id}>
+                              {server.display_name || server.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-xs">
+                        <div className="mb-1 text-muted">Tool</div>
+                        <select
+                          value={target?.tool_name || ""}
+                          onChange={(e) => setTarget({ tool_name: e.target.value })}
+                          disabled={!selectedServerId}
+                          className="w-full rounded border border-border bg-background px-2 py-2 disabled:opacity-50"
+                        >
+                          <option value="">未配置</option>
+                          {toolOptions.map((tool) => (
+                            <option key={tool.name} value={tool.name}>
+                              {tool.display_name || tool.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <div className="flex items-end">
+                        <button
+                          type="button"
+                          onClick={clearTarget}
+                          className="rounded border border-border px-3 py-2 text-[11px] hover:bg-muted"
+                        >
+                          清空
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
 
       <div className="flex justify-end">
         <button

--- a/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
@@ -19,18 +19,42 @@ const BOOTSTRAP_POLL_MAX_TICKS = 8;
 type RunRecord = PipelineRunRecord;
 
 // 阶段顺序定义（用于排序显示）
-const STAGE_ORDER = ["fetch", "delete", "chunk", "embed", "persist"];
+const STAGE_ORDER = [
+  "extract_resolve",
+  "extract_primary",
+  "extract_failover_1",
+  "extract_failover_2",
+  "extract_assets_store",
+  "extract_finalize",
+  "fetch",
+  "download",
+  "extract",
+  "delete",
+  "chunk",
+  "embed",
+  "persist",
+];
 
 // 操作类型中文名称
 const OPERATION_LABELS: Record<string, string> = {
   ingest_text: "文本摄入",
   ingest_url: "URL 摄入",
   replace_source: "替换源",
+  sync_source: "同步源",
+  rebuild_source: "重建源",
 };
 
 // 阶段名称中文名称
 const STAGE_LABELS: Record<string, string> = {
   fetch: "获取内容",
+  download: "下载源文件",
+  extract: "提取内容",
+  extract_resolve: "解析提取路由",
+  extract_primary: "主 MCP 提取",
+  extract_failover_1: "备用 MCP 提取 1",
+  extract_failover_2: "备用 MCP 提取 2",
+  extract_assets_store: "存储提取资源",
+  extract_finalize: "整理提取结果",
   delete: "删除旧记录",
   chunk: "文本分块",
   embed: "向量化",

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -95,6 +95,10 @@ export type {
   KnowledgeErrorResponse,
   KnowledgeDashboard,
   CorpusRecord,
+  ExtractorSourceKind,
+  McpExtractorTargetConfig,
+  CorpusExtractorRouteConfig,
+  CorpusExtractorRoutes,
   KnowledgeMatch,
   KnowledgeGraphPayload,
   KnowledgePipelinesPayload,
@@ -135,6 +139,8 @@ export type {
 export {
   createDefaultChunkingConfig,
   normalizeChunkingConfig,
+  normalizeCorpusExtractorRoutes,
+  buildCorpusConfig,
 } from "./utils/knowledge-api";
 
 // ============================================================================

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -415,6 +415,87 @@ export interface CorpusRecord {
   config?: Record<string, unknown>;
 }
 
+export type ExtractorSourceKind = "url" | "file_pdf";
+
+export interface McpExtractorTargetConfig {
+  server_id: string;
+  tool_name: string;
+  priority: number;
+  enabled: boolean;
+  timeout_ms?: number;
+  tool_options?: Record<string, unknown>;
+}
+
+export interface CorpusExtractorRouteConfig {
+  targets: McpExtractorTargetConfig[];
+}
+
+export interface CorpusExtractorRoutes {
+  url?: CorpusExtractorRouteConfig;
+  file_pdf?: CorpusExtractorRouteConfig;
+}
+
+function normalizeExtractorTargets(
+  value: unknown,
+): McpExtractorTargetConfig[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null,
+    )
+    .map((item) => ({
+      server_id: String(item.server_id || ""),
+      tool_name: String(item.tool_name || ""),
+      priority: Number(item.priority || 0),
+      enabled: item.enabled !== false,
+      timeout_ms:
+        item.timeout_ms === undefined ? undefined : Number(item.timeout_ms),
+      tool_options:
+        typeof item.tool_options === "object" && item.tool_options !== null
+          ? (item.tool_options as Record<string, unknown>)
+          : {},
+    }))
+    .filter((item) => item.server_id && item.tool_name)
+    .sort((a, b) => a.priority - b.priority);
+}
+
+export function normalizeCorpusExtractorRoutes(
+  config?: Record<string, unknown> | null,
+): CorpusExtractorRoutes {
+  const raw =
+    typeof config?.extractor_routes === "object" &&
+    config.extractor_routes !== null
+      ? (config.extractor_routes as Record<string, unknown>)
+      : {};
+
+  const normalizeRoute = (route: unknown): CorpusExtractorRouteConfig => ({
+    targets: normalizeExtractorTargets(
+      typeof route === "object" && route !== null
+        ? (route as Record<string, unknown>).targets
+        : undefined,
+    ),
+  });
+
+  return {
+    url: normalizeRoute(raw.url),
+    file_pdf: normalizeRoute(raw.file_pdf),
+  };
+}
+
+export function buildCorpusConfig(
+  chunkingConfig: ChunkingConfig,
+  extractorRoutes?: CorpusExtractorRoutes,
+): Record<string, unknown> {
+  return {
+    ...(chunkingConfig as unknown as Record<string, unknown>),
+    extractor_routes: {
+      url: { targets: extractorRoutes?.url?.targets || [] },
+      file_pdf: { targets: extractorRoutes?.file_pdf?.targets || [] },
+    },
+  };
+}
+
 export interface KnowledgeMatch {
   id: string;
   content: string;

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -109,6 +109,18 @@ vi.mock("@/features/knowledge", () => ({
           preserve_newlines: true,
           separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
         },
+  normalizeCorpusExtractorRoutes: (config: Record<string, unknown> | null | undefined) =>
+    (config?.extractor_routes as Record<string, unknown> | undefined) || {
+      url: { targets: [] },
+      file_pdf: { targets: [] },
+    },
+  buildCorpusConfig: (
+    chunkingConfig: Record<string, unknown>,
+    extractorRoutes: Record<string, unknown>,
+  ) => ({
+    ...chunkingConfig,
+    extractor_routes: extractorRoutes,
+  }),
   DocumentViewDialog: ({
     isOpen,
     document,

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import urllib.parse
 from io import BytesIO
 from typing import Any, Dict, Optional
 from uuid import UUID
@@ -24,6 +23,15 @@ from .constants import (
     DEFAULT_SEMANTIC_WEIGHT,
 )
 from .embedding import build_batch_embedding_fn, build_embedding_fn
+from .extraction import (
+    ROUTE_URL,
+    build_url_document_filename,
+    extract_source,
+    get_chunking_config_only,
+    merge_corpus_config,
+    persist_extracted_assets,
+    resolve_source_kind,
+)
 from .dao import KnowledgeRunDao
 from .exceptions import (
     CorpusNotFound,
@@ -401,8 +409,12 @@ def _resolve_chunking_config(
         merged["strategy"] = strategy
         return normalize_chunking_config(merged)
     if corpus_config:
-        return normalize_chunking_config(corpus_config)
+        return normalize_chunking_config(get_chunking_config_only(corpus_config))
     return None
+
+
+def _serialize_corpus_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return merge_corpus_config(config, serialize_chunking_config(normalize_chunking_config(get_chunking_config_only(config))))
 
 
 def _normalize_source_metadata(
@@ -464,7 +476,7 @@ async def list_corpora(app_name: Optional[str] = Query(default=None)) -> list[Co
             app_name=corpus.app_name,
             name=corpus.name,
             description=corpus.description,
-            config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
+            config=_serialize_corpus_config(corpus.config or None),
             knowledge_count=count or 0,
         )
         for corpus, count in rows
@@ -474,7 +486,7 @@ async def list_corpora(app_name: Optional[str] = Query(default=None)) -> list[Co
 @router.post("/base", response_model=CorpusResponse)
 async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
     service = _get_service()
-    normalized_config = serialize_chunking_config(normalize_chunking_config(payload.config or None))
+    normalized_config = _serialize_corpus_config(payload.config or None)
     spec = CorpusSpec(
         app_name=_resolve_app_name(payload.app_name),
         name=payload.name,
@@ -487,7 +499,7 @@ async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
         app_name=corpus.app_name,
         name=corpus.name,
         description=corpus.description,
-        config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
+        config=_serialize_corpus_config(corpus.config or None),
         knowledge_count=0,
     )
 
@@ -514,7 +526,7 @@ async def get_corpus(corpus_id: UUID, app_name: Optional[str] = Query(default=No
         app_name=corpus.app_name,
         name=corpus.name,
         description=corpus.description,
-        config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
+        config=_serialize_corpus_config(corpus.config or None),
         knowledge_count=count or 0,
     )
 
@@ -524,7 +536,7 @@ async def update_corpus(corpus_id: UUID, payload: CorpusUpdateRequest) -> Corpus
     service = _get_service()
     update_data = payload.model_dump(exclude_unset=True)
     if "config" in update_data:
-        update_data["config"] = serialize_chunking_config(normalize_chunking_config(update_data["config"] or None))
+        update_data["config"] = _serialize_corpus_config(update_data["config"] or None)
     if not update_data:
         raise HTTPException(status_code=400, detail="No fields to update")
 
@@ -547,7 +559,7 @@ async def update_corpus(corpus_id: UUID, payload: CorpusUpdateRequest) -> Corpus
             app_name=corpus.app_name,
             name=corpus.name,
             description=corpus.description,
-            config=serialize_chunking_config(normalize_chunking_config(corpus.config or None)),
+            config=_serialize_corpus_config(corpus.config or None),
             knowledge_count=knowledge_count or 0,
         )
     except ValueError as exc:
@@ -771,19 +783,22 @@ async def ingest_url(
         # URL 文档模式: 先落库为 Document，再异步入索引
         if payload.as_document:
             from negentropy.storage.service import DocumentStorageService
-            from .content import fetch_content, optimize_markdown_content, sanitize_filename
 
-            markdown_text = optimize_markdown_content(await fetch_content(payload.url))
+            extraction_result = await extract_source(
+                app_name=resolved_app,
+                corpus_id=corpus_id,
+                corpus_config=corpus_config,
+                source_kind=ROUTE_URL,
+                url=payload.url,
+            )
+            markdown_text = extraction_result.markdown_content
             if not markdown_text:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail={"code": "EMPTY_CONTENT", "message": "No content extracted from URL"},
                 )
 
-            parsed = urllib.parse.urlparse(payload.url)
-            raw_name = sanitize_filename(parsed.path.split("/")[-1] or parsed.netloc or "url_document")
-            if "." not in raw_name:
-                raw_name = f"{raw_name}.md"
+            raw_name = build_url_document_filename(payload.url)
             markdown_bytes = markdown_text.encode("utf-8")
 
             storage_service = DocumentStorageService()
@@ -800,11 +815,18 @@ async def ingest_url(
                 markdown_content=markdown_text,
                 markdown_gcs_uri=doc_record.gcs_uri,
             )
+            stored_assets = await persist_extracted_assets(
+                document_id=doc_record.id,
+                assets=extraction_result.assets,
+            )
 
             meta = _normalize_source_metadata(source_uri=payload.url, metadata=payload.metadata)
             meta["source_type"] = "url"
             meta["origin_url"] = payload.url
             meta["document_id"] = str(doc_record.id)
+            meta["extractor_trace"] = extraction_result.trace
+            if stored_assets:
+                meta["extracted_assets"] = stored_assets
 
             run_id = await service.create_pipeline(
                 app_name=resolved_app,
@@ -824,7 +846,7 @@ async def ingest_url(
                 run_id=run_id,
                 corpus_id=corpus_id,
                 app_name=resolved_app,
-                text=markdown_text,
+                text=extraction_result.plain_text,
                 source_uri=payload.url,
                 metadata=meta,
                 chunking_config=chunking_config,
@@ -1079,7 +1101,7 @@ async def ingest_file(
                 parsed_separators = [item.strip() for item in separators.split(",") if item.strip()]
 
         # 提取文本
-        from .content import extract_file_content, sanitize_filename
+        from .content import sanitize_filename
 
         # 保留用于展示的原始文件名（仅去除路径前缀并限制长度）
         raw_filename = (file.filename or "unknown").split("/")[-1].split("\\")[-1][:255] or "unknown"
@@ -1090,7 +1112,6 @@ async def ingest_file(
         doc_record = None
         is_new_doc = True
         gcs_uri = None
-        schedule_markdown_extraction = False
 
         if store_to_gcs:
             from negentropy.storage.service import DocumentStorageService
@@ -1115,20 +1136,25 @@ async def ingest_file(
                     is_new=is_new_doc,
                     gcs_uri=gcs_uri,
                 )
-                schedule_markdown_extraction = (
-                    is_new_doc
-                    or doc_record.markdown_extract_status != "completed"
-                )
             except StorageError as exc:
                 logger.warning("gcs_storage_failed_proceeding_without_storage", error=str(exc))
                 # 继续处理，但不存储到 GCS
 
-        # 提取文本内容
-        text = await extract_file_content(
+        service = _get_service()
+        corpus = await service.get_corpus_by_id(corpus_id)
+        corpus_config = corpus.config if corpus else {}
+
+        source_kind = resolve_source_kind(filename=raw_filename, content_type=file.content_type)
+        extraction_result = await extract_source(
+            app_name=resolved_app,
+            corpus_id=corpus_id,
+            corpus_config=corpus_config,
+            source_kind=source_kind,
             content=content,
             filename=raw_filename,
             content_type=file.content_type,
         )
+        text = extraction_result.plain_text
 
         if not text.strip():
             raise HTTPException(
@@ -1142,11 +1168,6 @@ async def ingest_file(
             final_source_uri = gcs_uri
         else:
             final_source_uri = source_uri or safe_filename
-
-        # 获取服务并执行摄入
-        service = _get_service()
-        corpus = await service.get_corpus_by_id(corpus_id)
-        corpus_config = corpus.config if corpus else {}
 
         chunking_config = _resolve_chunking_config(
             chunking_config=None,
@@ -1178,6 +1199,9 @@ async def ingest_file(
         meta["source_type"] = "file"
         if gcs_uri:
             meta["gcs_uri"] = gcs_uri
+        meta["extractor_trace"] = extraction_result.trace
+        if doc_record:
+            meta["document_id"] = str(doc_record.id)
 
         # 调用现有的 ingest_text
         records = await service.ingest_text(
@@ -1203,14 +1227,21 @@ async def ingest_file(
             result["duplicate"] = not is_new_doc
             result["markdown_extract_status"] = doc_record.markdown_extract_status
 
-            if schedule_markdown_extraction:
-                background_tasks.add_task(
-                    _extract_and_store_document_markdown,
-                    document_id=doc_record.id,
-                    content=content,
-                    filename=raw_filename,
-                    content_type=file.content_type,
-                )
+            markdown_gcs_uri = await storage_service.upload_markdown_derivative(
+                document_id=doc_record.id,
+                markdown_content=extraction_result.markdown_content,
+            )
+            await storage_service.save_markdown_content(
+                document_id=doc_record.id,
+                markdown_content=extraction_result.markdown_content,
+                markdown_gcs_uri=markdown_gcs_uri,
+            )
+            stored_assets = await persist_extracted_assets(
+                document_id=doc_record.id,
+                assets=extraction_result.assets,
+            )
+            if stored_assets:
+                result["extracted_assets"] = stored_assets
 
         return result
 
@@ -1708,7 +1739,6 @@ async def sync_document(
 ) -> AsyncPipelineResponse:
     resolved_app = _resolve_app_name(payload.app_name)
     from negentropy.storage.service import DocumentStorageService
-    from .content import fetch_content, optimize_markdown_content
 
     storage_service = DocumentStorageService()
     doc = await storage_service.get_document(
@@ -1734,7 +1764,16 @@ async def sync_document(
             detail={"code": "INVALID_DOCUMENT_SOURCE", "message": "Document source_uri not available"},
         )
 
-    markdown_text = optimize_markdown_content(await fetch_content(source_uri))
+    service = _get_service()
+    corpus = await service.get_corpus_by_id(corpus_id)
+    extraction_result = await extract_source(
+        app_name=resolved_app,
+        corpus_id=corpus_id,
+        corpus_config=corpus.config if corpus else {},
+        source_kind=ROUTE_URL,
+        url=source_uri,
+    )
+    markdown_text = extraction_result.markdown_content
     if not markdown_text:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -1750,9 +1789,10 @@ async def sync_document(
         markdown_content=markdown_text,
         markdown_gcs_uri=markdown_gcs_uri,
     )
-
-    service = _get_service()
-    corpus = await service.get_corpus_by_id(corpus_id)
+    stored_assets = await persist_extracted_assets(
+        document_id=document_id,
+        assets=extraction_result.assets,
+    )
     chunking_config = _resolve_chunking_config_from_doc_request(
         payload=payload,
         corpus_config=corpus.config if corpus else {},
@@ -1761,6 +1801,9 @@ async def sync_document(
         source_uri=source_uri,
         metadata={"source_type": "url", "origin_url": source_uri, "document_id": str(document_id)},
     )
+    metadata["extractor_trace"] = extraction_result.trace
+    if stored_assets:
+        metadata["extracted_assets"] = stored_assets
     run_id = await service.create_pipeline(
         app_name=resolved_app,
         operation="replace_source",
@@ -1777,7 +1820,7 @@ async def sync_document(
         run_id=run_id,
         corpus_id=corpus_id,
         app_name=resolved_app,
-        text=markdown_text,
+        text=extraction_result.plain_text,
         source_uri=source_uri,
         metadata=metadata,
         chunking_config=chunking_config,

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import base64
+import json
+import urllib.parse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Optional
+from uuid import UUID
+
+from sqlalchemy import select, update
+
+from negentropy.db.session import AsyncSessionLocal
+from negentropy.logging import get_logger
+from negentropy.models.plugin import McpServer, McpTool
+from negentropy.storage.service import DocumentStorageService
+
+from .content import (
+    extract_file_content,
+    extract_file_markdown,
+    fetch_content,
+    optimize_markdown_content,
+    sanitize_filename,
+)
+
+logger = get_logger("negentropy.knowledge.extraction")
+
+SourceKind = Literal["url", "file_pdf", "file_generic"]
+
+EXTRACTOR_ROUTES_KEY = "extractor_routes"
+ROUTE_URL = "url"
+ROUTE_FILE_PDF = "file_pdf"
+ROUTE_FILE_GENERIC = "file_generic"
+
+
+@dataclass(slots=True)
+class ExtractionAsset:
+    name: str
+    content_type: str
+    uri: str | None = None
+    data_base64: str | None = None
+    text: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ExtractionAttempt:
+    server_id: str
+    server_name: str
+    tool_name: str
+    status: str
+    duration_ms: int
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class ExtractedDocumentResult:
+    plain_text: str
+    markdown_content: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    assets: list[ExtractionAsset] = field(default_factory=list)
+    trace: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class McpToolTarget:
+    server_id: UUID
+    tool_name: str
+    priority: int = 0
+    enabled: bool = True
+    timeout_ms: int | None = None
+    tool_options: dict[str, Any] = field(default_factory=dict)
+
+
+def resolve_source_kind(*, source_uri: str | None = None, filename: str | None = None, content_type: str | None = None) -> SourceKind:
+    if source_uri and (source_uri.startswith("http://") or source_uri.startswith("https://")):
+        return ROUTE_URL
+
+    lower_filename = (filename or "").lower()
+    lower_content_type = (content_type or "").lower()
+    if lower_filename.endswith(".pdf") or "application/pdf" in lower_content_type:
+        return ROUTE_FILE_PDF
+
+    return ROUTE_FILE_GENERIC
+
+
+def get_chunking_config_only(raw: dict[str, Any] | None) -> dict[str, Any]:
+    payload = dict(raw or {})
+    payload.pop(EXTRACTOR_ROUTES_KEY, None)
+    return payload
+
+
+def merge_corpus_config(raw: dict[str, Any] | None, chunking_config: dict[str, Any] | None) -> dict[str, Any]:
+    merged = dict(raw or {})
+    if chunking_config:
+        merged.update(chunking_config)
+    return merged
+
+
+def extract_route_config(raw: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    routes = raw.get(EXTRACTOR_ROUTES_KEY)
+    return routes if isinstance(routes, dict) else {}
+
+
+def resolve_targets(raw: dict[str, Any] | None, source_kind: SourceKind) -> list[McpToolTarget]:
+    routes = extract_route_config(raw)
+    route_payload = routes.get(source_kind)
+    if not isinstance(route_payload, dict):
+        return []
+
+    targets_payload = route_payload.get("targets")
+    if not isinstance(targets_payload, list):
+        return []
+
+    targets: list[McpToolTarget] = []
+    for item in targets_payload:
+        if not isinstance(item, dict):
+            continue
+        server_id = item.get("server_id")
+        tool_name = str(item.get("tool_name") or "").strip()
+        if not server_id or not tool_name:
+            continue
+        try:
+            targets.append(
+                McpToolTarget(
+                    server_id=UUID(str(server_id)),
+                    tool_name=tool_name,
+                    priority=int(item.get("priority") or 0),
+                    enabled=bool(item.get("enabled", True)),
+                    timeout_ms=int(item["timeout_ms"]) if item.get("timeout_ms") is not None else None,
+                    tool_options=item.get("tool_options") if isinstance(item.get("tool_options"), dict) else {},
+                )
+            )
+        except (TypeError, ValueError):
+            logger.warning("invalid_extractor_target_ignored", target=item)
+
+    return sorted((target for target in targets if target.enabled), key=lambda item: item.priority)
+
+
+def _result_text_from_content_items(content_items: list[Any]) -> str:
+    text_chunks: list[str] = []
+    for item in content_items:
+        if getattr(item, "type", None) == "text" and getattr(item, "text", None):
+            text_chunks.append(item.text)
+    return "\n".join(text_chunks).strip()
+
+
+def _parse_structured_payload(payload: Any, content_items: list[Any]) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+
+    if isinstance(payload, str):
+        try:
+            parsed = json.loads(payload)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            return {}
+
+    fallback_text = _result_text_from_content_items(content_items)
+    if fallback_text:
+        try:
+            parsed = json.loads(fallback_text)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
+    if not isinstance(raw_assets, list):
+        return []
+
+    assets: list[ExtractionAsset] = []
+    for index, item in enumerate(raw_assets):
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("filename") or f"asset-{index + 1}")
+        content_type = str(item.get("content_type") or item.get("mime_type") or "application/octet-stream")
+        assets.append(
+            ExtractionAsset(
+                name=name,
+                content_type=content_type,
+                uri=item.get("uri") if isinstance(item.get("uri"), str) else None,
+                data_base64=item.get("data_base64") if isinstance(item.get("data_base64"), str) else item.get("content_base64"),
+                text=item.get("text") if isinstance(item.get("text"), str) else None,
+                metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
+            )
+        )
+    return assets
+
+
+async def _increment_tool_call_count(*, server_id: UUID, tool_name: str) -> None:
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            update(McpTool)
+            .where(McpTool.server_id == server_id, McpTool.name == tool_name)
+            .values(call_count=McpTool.call_count + 1)
+        )
+        await db.commit()
+
+
+class LegacyExtractionProvider:
+    async def extract_url(self, *, url: str) -> ExtractedDocumentResult:
+        markdown = optimize_markdown_content(await fetch_content(url))
+        return ExtractedDocumentResult(
+            plain_text=markdown,
+            markdown_content=markdown,
+            metadata={"provider": "legacy", "source_kind": ROUTE_URL},
+            trace={"provider": "legacy"},
+        )
+
+    async def extract_file(
+        self,
+        *,
+        content: bytes,
+        filename: str,
+        content_type: str | None = None,
+    ) -> ExtractedDocumentResult:
+        text = await extract_file_content(content=content, filename=filename, content_type=content_type)
+        markdown = await extract_file_markdown(content=content, filename=filename, content_type=content_type)
+        return ExtractedDocumentResult(
+            plain_text=text,
+            markdown_content=markdown,
+            metadata={"provider": "legacy", "source_kind": resolve_source_kind(filename=filename, content_type=content_type)},
+            trace={"provider": "legacy"},
+        )
+
+
+class DataExtractorProvider:
+    def __init__(self) -> None:
+        from negentropy.plugins.mcp_client import McpClientService
+
+        self._client = McpClientService()
+
+    async def extract(
+        self,
+        *,
+        app_name: str,
+        corpus_id: UUID,
+        source_kind: SourceKind,
+        corpus_config: dict[str, Any] | None,
+        url: str | None = None,
+        content: bytes | None = None,
+        filename: str | None = None,
+        content_type: str | None = None,
+        tracker: Any | None = None,
+    ) -> ExtractedDocumentResult:
+        targets = resolve_targets(corpus_config, source_kind)
+        if not targets:
+            raise ValueError(f"No extractor route configured for source kind: {source_kind}")
+
+        if tracker:
+            await tracker.start_stage("extract_resolve")
+            await tracker.complete_stage(
+                "extract_resolve",
+                {
+                    "source_kind": source_kind,
+                    "target_count": len(targets),
+                    "targets": [{"server_id": str(item.server_id), "tool_name": item.tool_name} for item in targets],
+                },
+            )
+
+        attempts: list[ExtractionAttempt] = []
+        last_error: str | None = None
+
+        for index, target in enumerate(targets):
+            stage_name = "extract_primary" if index == 0 else f"extract_failover_{index}"
+            if tracker:
+                await tracker.start_stage(stage_name)
+
+            attempt = await self._invoke_target(
+                app_name=app_name,
+                corpus_id=corpus_id,
+                target=target,
+                source_kind=source_kind,
+                url=url,
+                content=content,
+                filename=filename,
+                content_type=content_type,
+            )
+            attempts.append(attempt["attempt"])
+
+            if attempt["success"]:
+                result = attempt["result"]
+                result.trace = {
+                    "provider": "mcp",
+                    "source_kind": source_kind,
+                    "selected_target": {"server_id": str(target.server_id), "tool_name": target.tool_name},
+                    "attempts": [item.__dict__ for item in attempts],
+                }
+                if tracker:
+                    await tracker.complete_stage(
+                        stage_name,
+                        {
+                            "server_id": str(target.server_id),
+                            "tool_name": target.tool_name,
+                            "duration_ms": attempt["attempt"].duration_ms,
+                            "asset_count": len(result.assets),
+                            "markdown_length": len(result.markdown_content),
+                        },
+                    )
+                    await tracker.start_stage("extract_finalize")
+                    await tracker.complete_stage(
+                        "extract_finalize",
+                        {
+                            "plain_text_length": len(result.plain_text),
+                            "markdown_length": len(result.markdown_content),
+                            "asset_count": len(result.assets),
+                        },
+                    )
+                return result
+
+            last_error = attempt["attempt"].error
+            if tracker:
+                await tracker.fail_stage(
+                    stage_name,
+                    {
+                        "server_id": str(target.server_id),
+                        "tool_name": target.tool_name,
+                        "message": last_error,
+                    },
+                )
+
+        raise ValueError(last_error or "All extractor MCP targets failed")
+
+    async def _invoke_target(
+        self,
+        *,
+        app_name: str,
+        corpus_id: UUID,
+        target: McpToolTarget,
+        source_kind: SourceKind,
+        url: str | None,
+        content: bytes | None,
+        filename: str | None,
+        content_type: str | None,
+    ) -> dict[str, Any]:
+        async with AsyncSessionLocal() as db:
+            server = await db.get(McpServer, target.server_id)
+            if not server or not server.is_enabled:
+                error = "MCP server not found or disabled"
+                return {
+                    "success": False,
+                    "attempt": ExtractionAttempt(
+                        server_id=str(target.server_id),
+                        server_name="unknown",
+                        tool_name=target.tool_name,
+                        status="failed",
+                        duration_ms=0,
+                        error=error,
+                    ),
+                }
+
+            tool = await db.scalar(
+                select(McpTool).where(McpTool.server_id == target.server_id, McpTool.name == target.tool_name)
+            )
+            if tool and not tool.is_enabled:
+                error = "MCP tool is disabled"
+                return {
+                    "success": False,
+                    "attempt": ExtractionAttempt(
+                        server_id=str(target.server_id),
+                        server_name=server.name,
+                        tool_name=target.tool_name,
+                        status="failed",
+                        duration_ms=0,
+                        error=error,
+                    ),
+                }
+
+        arguments: dict[str, Any] = {
+            "source_type": source_kind,
+            "options": target.tool_options,
+            "context": {
+                "app_name": app_name,
+                "corpus_id": str(corpus_id),
+            },
+        }
+        if url:
+            arguments["url"] = url
+        if content is not None:
+            arguments["filename"] = filename
+            arguments["content_type"] = content_type
+            arguments["content_base64"] = base64.b64encode(content).decode("ascii")
+
+        result = await self._client.call_tool(
+            transport_type=server.transport_type,
+            tool_name=target.tool_name,
+            arguments=arguments,
+            command=server.command,
+            args=server.args,
+            env=server.env,
+            url=server.url,
+            headers=server.headers,
+            timeout_seconds=(target.timeout_ms / 1000.0) if target.timeout_ms else None,
+        )
+        await _increment_tool_call_count(server_id=target.server_id, tool_name=target.tool_name)
+
+        attempt = ExtractionAttempt(
+            server_id=str(target.server_id),
+            server_name=server.name,
+            tool_name=target.tool_name,
+            status="completed" if result.success else "failed",
+            duration_ms=result.duration_ms,
+            error=result.error,
+        )
+        if not result.success:
+            return {"success": False, "attempt": attempt}
+
+        payload = _parse_structured_payload(result.structured_content, result.content)
+        markdown = str(payload.get("markdown") or payload.get("markdown_content") or "").strip()
+        plain_text = str(payload.get("text") or payload.get("plain_text") or "").strip()
+        if not markdown and plain_text:
+            markdown = optimize_markdown_content(plain_text)
+        if not plain_text and markdown:
+            plain_text = markdown
+        if not plain_text:
+            return {
+                "success": False,
+                "attempt": ExtractionAttempt(
+                    server_id=attempt.server_id,
+                    server_name=attempt.server_name,
+                    tool_name=attempt.tool_name,
+                    status="failed",
+                    duration_ms=attempt.duration_ms,
+                    error="Extractor returned empty content",
+                ),
+            }
+
+        return {
+            "success": True,
+            "attempt": attempt,
+            "result": ExtractedDocumentResult(
+                plain_text=plain_text,
+                markdown_content=markdown,
+                metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
+                assets=_normalize_assets(payload.get("assets")),
+            ),
+        }
+
+
+async def extract_source(
+    *,
+    app_name: str,
+    corpus_id: UUID,
+    corpus_config: dict[str, Any] | None,
+    source_kind: SourceKind,
+    url: str | None = None,
+    content: bytes | None = None,
+    filename: str | None = None,
+    content_type: str | None = None,
+    tracker: Any | None = None,
+) -> ExtractedDocumentResult:
+    targets = resolve_targets(corpus_config, source_kind)
+    if targets:
+        provider = DataExtractorProvider()
+        return await provider.extract(
+            app_name=app_name,
+            corpus_id=corpus_id,
+            source_kind=source_kind,
+            corpus_config=corpus_config,
+            url=url,
+            content=content,
+            filename=filename,
+            content_type=content_type,
+            tracker=tracker,
+        )
+
+    legacy = LegacyExtractionProvider()
+    if source_kind == ROUTE_URL:
+        result = await legacy.extract_url(url=url or "")
+    else:
+        result = await legacy.extract_file(content=content or b"", filename=filename or "unknown", content_type=content_type)
+    result.trace = {"provider": "legacy", "source_kind": source_kind, "attempts": []}
+    return result
+
+
+async def persist_extracted_assets(
+    *,
+    document_id: UUID,
+    assets: list[ExtractionAsset],
+    tracker: Any | None = None,
+) -> list[dict[str, Any]]:
+    if not assets:
+        return []
+
+    if tracker:
+        await tracker.start_stage("extract_assets_store")
+
+    storage_service = DocumentStorageService()
+    stored_assets: list[dict[str, Any]] = []
+    for asset in assets:
+        uri = asset.uri
+        if not uri:
+            content_bytes: bytes | None = None
+            if asset.data_base64:
+                try:
+                    content_bytes = base64.b64decode(asset.data_base64)
+                except (ValueError, TypeError):
+                    logger.warning("invalid_asset_base64_skipped", document_id=str(document_id), asset_name=asset.name)
+            elif asset.text is not None:
+                content_bytes = asset.text.encode("utf-8")
+
+            if content_bytes:
+                uri = await storage_service.upload_extraction_asset(
+                    document_id=document_id,
+                    filename=asset.name,
+                    content=content_bytes,
+                    content_type=asset.content_type,
+                )
+
+        stored_assets.append(
+            {
+                "name": asset.name,
+                "content_type": asset.content_type,
+                "uri": uri,
+                "metadata": asset.metadata,
+            }
+        )
+
+    if tracker:
+        await tracker.complete_stage("extract_assets_store", {"asset_count": len(stored_assets)})
+    return stored_assets
+
+
+def build_url_document_filename(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    raw_name = sanitize_filename(parsed.path.split("/")[-1] or parsed.netloc or "url_document")
+    if "." not in raw_name:
+        raw_name = f"{raw_name}.md"
+    return raw_name
+
+
+def build_asset_filename(source_name: str, fallback_suffix: str) -> str:
+    stem = Path(source_name).stem or "document"
+    safe_stem = sanitize_filename(stem)
+    return f"{safe_stem}-{fallback_suffix}"

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .dao import KnowledgeRunDao
 from .constants import DEFAULT_KEYWORD_WEIGHT, DEFAULT_SEMANTIC_WEIGHT, TEXT_PREVIEW_MAX_LENGTH
 from .exceptions import SearchError
-from .content import fetch_content
+from .extraction import ROUTE_URL, extract_source, resolve_source_kind
 from .reranking import NoopReranker, Reranker
 from .repository import KnowledgeRepository
 from .types import (
@@ -215,6 +215,50 @@ class KnowledgeService:
         self._reranker = reranker or NoopReranker()
         self._pipeline_dao = pipeline_dao
 
+    async def _get_corpus_config(self, corpus_id: UUID) -> dict[str, Any]:
+        corpus = await self.get_corpus_by_id(corpus_id)
+        return corpus.config if corpus and corpus.config else {}
+
+    async def _extract_url_content(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        url: str,
+        tracker: Optional[PipelineTracker] = None,
+    ) -> str:
+        result = await extract_source(
+            app_name=app_name,
+            corpus_id=corpus_id,
+            corpus_config=await self._get_corpus_config(corpus_id),
+            source_kind=ROUTE_URL,
+            url=url,
+            tracker=tracker,
+        )
+        return result.plain_text
+
+    async def _extract_file_content(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        content: bytes,
+        filename: str,
+        content_type: str | None,
+        tracker: Optional[PipelineTracker] = None,
+    ) -> str:
+        result = await extract_source(
+            app_name=app_name,
+            corpus_id=corpus_id,
+            corpus_config=await self._get_corpus_config(corpus_id),
+            source_kind=resolve_source_kind(filename=filename, content_type=content_type),
+            content=content,
+            filename=filename,
+            content_type=content_type,
+            tracker=tracker,
+        )
+        return result.plain_text
+
     # =========================================================================
     # Pipeline 创建与执行（支持异步后台任务）
     # =========================================================================
@@ -370,22 +414,21 @@ class KnowledgeService:
         )
 
         try:
-            # 阶段 1: Fetch
-            await tracker.start_stage("fetch")
             try:
-                text = await fetch_content(url)
+                text = await self._extract_url_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    url=url,
+                    tracker=tracker,
+                )
             except ValueError as exc:
                 from .exceptions import KnowledgeError
 
-                await tracker.fail_stage("fetch", {"type": "CONTENT_FETCH_FAILED", "message": str(exc)})
                 raise KnowledgeError(
                     code="CONTENT_FETCH_FAILED", message=f"Failed to fetch content from URL: {exc}"
                 ) from exc
 
-            await tracker.complete_stage("fetch", {"content_length": len(text) if text else 0, "url": url})
-
             if not text:
-                await tracker.fail_stage("fetch", {"type": "NO_CONTENT", "message": "No content extracted from URL"})
                 raise ValueError("No content extracted from URL")
 
             # Merge metadata
@@ -531,22 +574,21 @@ class KnowledgeService:
         )
 
         try:
-            # 阶段 1: Fetch
-            await tracker.start_stage("fetch")
             try:
-                text = await fetch_content(source_uri)
+                text = await self._extract_url_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    url=source_uri,
+                    tracker=tracker,
+                )
             except ValueError as exc:
                 from .exceptions import KnowledgeError
 
-                await tracker.fail_stage("fetch", {"type": "CONTENT_FETCH_FAILED", "message": str(exc)})
                 raise KnowledgeError(
                     code="CONTENT_FETCH_FAILED", message=f"Failed to fetch content from URL: {exc}"
                 ) from exc
 
-            await tracker.complete_stage("fetch", {"content_length": len(text) if text else 0, "source_uri": source_uri})
-
             if not text:
-                await tracker.fail_stage("fetch", {"type": "NO_CONTENT", "message": "No content extracted from URL"})
                 raise ValueError("No content extracted from URL")
 
             # 阶段 2: Delete
@@ -649,32 +691,27 @@ class KnowledgeService:
 
             await tracker.complete_stage("download", {"content_length": len(content) if content else 0, "source_uri": source_uri})
 
-            # 阶段 1.5: Extract
-            await tracker.start_stage("extract")
             try:
-                from .content import extract_file_content
-
                 filename = source_uri.split("/")[-1]
                 content_type = _guess_content_type(filename)
 
-                text = await extract_file_content(
+                text = await self._extract_file_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
                     content=content,
                     filename=filename,
                     content_type=content_type,
+                    tracker=tracker,
                 )
             except ValueError as exc:
                 from .exceptions import KnowledgeError
 
-                await tracker.fail_stage("extract", {"type": "CONTENT_EXTRACTION_FAILED", "message": str(exc)})
                 raise KnowledgeError(
                     code="CONTENT_EXTRACTION_FAILED",
                     message=f"Failed to extract content: {exc}",
                 ) from exc
 
-            await tracker.complete_stage("extract", {"text_length": len(text) if text else 0, "source_uri": source_uri})
-
             if not text:
-                await tracker.fail_stage("extract", {"type": "NO_CONTENT", "message": "No text content extracted from file"})
                 raise ValueError("No text content extracted from file")
 
             # 阶段 2: Delete
@@ -1164,45 +1201,21 @@ class KnowledgeService:
         )
 
         try:
-            # 阶段 1: Fetch
-            if tracker:
-                await tracker.start_stage("fetch")
-
             try:
-                text = await fetch_content(url)
+                text = await self._extract_url_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    url=url,
+                    tracker=tracker,
+                )
             except ValueError as exc:
                 from .exceptions import KnowledgeError
 
-                if tracker:
-                    await tracker.fail_stage(
-                        "fetch",
-                        {
-                            "type": "CONTENT_FETCH_FAILED",
-                            "message": str(exc),
-                        },
-                    )
                 raise KnowledgeError(
                     code="CONTENT_FETCH_FAILED", message=f"Failed to fetch content from URL: {exc}"
                 ) from exc
 
-            if tracker:
-                await tracker.complete_stage(
-                    "fetch",
-                    {
-                        "content_length": len(text) if text else 0,
-                        "url": url,
-                    },
-                )
-
             if not text:
-                if tracker:
-                    await tracker.fail_stage(
-                        "fetch",
-                        {
-                            "type": "NO_CONTENT",
-                            "message": "No content extracted from URL",
-                        },
-                    )
                 raise ValueError("No content extracted from URL")
 
             # Merge metadata
@@ -1289,45 +1302,21 @@ class KnowledgeService:
         )
 
         try:
-            # 阶段 1: Fetch - 从原始 URL 获取最新内容
-            if tracker:
-                await tracker.start_stage("fetch")
-
             try:
-                text = await fetch_content(source_uri)
+                text = await self._extract_url_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    url=source_uri,
+                    tracker=tracker,
+                )
             except ValueError as exc:
                 from .exceptions import KnowledgeError
 
-                if tracker:
-                    await tracker.fail_stage(
-                        "fetch",
-                        {
-                            "type": "CONTENT_FETCH_FAILED",
-                            "message": str(exc),
-                        },
-                    )
                 raise KnowledgeError(
                     code="CONTENT_FETCH_FAILED", message=f"Failed to fetch content from URL: {exc}"
                 ) from exc
 
-            if tracker:
-                await tracker.complete_stage(
-                    "fetch",
-                    {
-                        "content_length": len(text) if text else 0,
-                        "source_uri": source_uri,
-                    },
-                )
-
             if not text:
-                if tracker:
-                    await tracker.fail_stage(
-                        "fetch",
-                        {
-                            "type": "NO_CONTENT",
-                            "message": "No content extracted from URL",
-                        },
-                    )
                 raise ValueError("No content extracted from URL")
 
             # 阶段 2: Delete - 删除该 source_uri 下的旧记录
@@ -1497,56 +1486,28 @@ class KnowledgeService:
                     },
                 )
 
-            # 阶段 1.5: Extract - 提取文本内容
-            if tracker:
-                await tracker.start_stage("extract")
-
             try:
-                from .content import extract_file_content
-
                 # 从 GCS URI 提取文件名
                 filename = source_uri.split("/")[-1]
                 content_type = _guess_content_type(filename)
 
-                text = await extract_file_content(
+                text = await self._extract_file_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
                     content=content,
                     filename=filename,
                     content_type=content_type,
+                    tracker=tracker,
                 )
             except ValueError as exc:
                 from .exceptions import KnowledgeError
 
-                if tracker:
-                    await tracker.fail_stage(
-                        "extract",
-                        {
-                            "type": "CONTENT_EXTRACTION_FAILED",
-                            "message": str(exc),
-                        },
-                    )
                 raise KnowledgeError(
                     code="CONTENT_EXTRACTION_FAILED",
                     message=f"Failed to extract content: {exc}",
                 ) from exc
 
-            if tracker:
-                await tracker.complete_stage(
-                    "extract",
-                    {
-                        "text_length": len(text) if text else 0,
-                        "source_uri": source_uri,
-                    },
-                )
-
             if not text:
-                if tracker:
-                    await tracker.fail_stage(
-                        "extract",
-                        {
-                            "type": "NO_CONTENT",
-                            "message": "No text content extracted from file",
-                        },
-                    )
                 raise ValueError("No text content extracted from file")
 
             # 阶段 2: Delete - 删除该 source_uri 下的旧记录

--- a/apps/negentropy/src/negentropy/plugins/mcp_client.py
+++ b/apps/negentropy/src/negentropy/plugins/mcp_client.py
@@ -8,6 +8,7 @@ MCP Client Service Module.
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -45,11 +46,100 @@ class McpConnectionResult:
     duration_ms: int = 0
 
 
+@dataclass
+class McpToolCallResult:
+    """MCP Tool 调用结果"""
+
+    success: bool
+    content: list[Any] = field(default_factory=list)
+    structured_content: dict[str, Any] | None = None
+    error: str | None = None
+    duration_ms: int = 0
+
+
 class McpClientService:
     """MCP Server 连接与 Tool 发现服务"""
 
     def __init__(self, timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS):
         self.timeout_seconds = timeout_seconds
+
+    async def call_tool(
+        self,
+        *,
+        transport_type: str,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        url: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> McpToolCallResult:
+        start_time = time.time()
+        effective_timeout = timeout_seconds or self.timeout_seconds
+
+        try:
+            if transport_type == "stdio":
+                if not command:
+                    return McpToolCallResult(success=False, error="Command is required for stdio transport")
+                result = await self._call_tool_stdio(
+                    command=command,
+                    args=args or [],
+                    env=env or {},
+                    tool_name=tool_name,
+                    arguments=arguments or {},
+                    timeout_seconds=effective_timeout,
+                )
+            elif transport_type == "sse":
+                if not url:
+                    return McpToolCallResult(success=False, error="URL is required for sse transport")
+                result = await self._call_tool_sse(
+                    url=url,
+                    headers=headers or {},
+                    tool_name=tool_name,
+                    arguments=arguments or {},
+                    timeout_seconds=effective_timeout,
+                )
+            elif transport_type == "http":
+                if not url:
+                    return McpToolCallResult(success=False, error="URL is required for http transport")
+                result = await self._call_tool_http(
+                    url=url,
+                    headers=headers or {},
+                    tool_name=tool_name,
+                    arguments=arguments or {},
+                    timeout_seconds=effective_timeout,
+                )
+            else:
+                return McpToolCallResult(success=False, error=f"Unsupported transport type: {transport_type}")
+
+            result.duration_ms = int((time.time() - start_time) * 1000)
+            return result
+        except TimeoutError:
+            return McpToolCallResult(
+                success=False,
+                error=f"Connection timeout after {effective_timeout}s",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+        except FileNotFoundError as exc:
+            return McpToolCallResult(
+                success=False,
+                error=f"Command not found: {exc.filename}",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+        except ExceptionGroup as exc:
+            return McpToolCallResult(
+                success=False,
+                error=self._extract_exception_group_error(exc),
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+        except Exception as exc:
+            return McpToolCallResult(
+                success=False,
+                error=self._extract_error_message(exc),
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
 
     async def discover_tools(
         self,
@@ -209,6 +299,33 @@ class McpClientService:
                     logger.info(f"Discovered {len(tools)} tools via stdio from {command}")
                     return McpConnectionResult(success=True, tools=tools)
 
+    async def _call_tool_stdio(
+        self,
+        *,
+        command: str,
+        args: list[str],
+        env: dict[str, str],
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float,
+    ) -> McpToolCallResult:
+        server_params = StdioServerParameters(command=command, args=args, env=env)
+        async with asyncio.timeout(timeout_seconds):
+            async with stdio_client(server_params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(
+                        tool_name,
+                        arguments=arguments,
+                        read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                    )
+                    return McpToolCallResult(
+                        success=not bool(result.isError),
+                        content=list(result.content or []),
+                        structured_content=result.structuredContent if isinstance(result.structuredContent, dict) else None,
+                        error=_extract_call_error(result),
+                    )
+
     async def _discover_sse(
         self,
         url: str,
@@ -233,6 +350,31 @@ class McpClientService:
                     logger.info(f"Discovered {len(tools)} tools via sse from {url}")
                     return McpConnectionResult(success=True, tools=tools)
 
+    async def _call_tool_sse(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str],
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float,
+    ) -> McpToolCallResult:
+        async with asyncio.timeout(timeout_seconds):
+            async with sse_client(url, headers=headers) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(
+                        tool_name,
+                        arguments=arguments,
+                        read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                    )
+                    return McpToolCallResult(
+                        success=not bool(result.isError),
+                        content=list(result.content or []),
+                        structured_content=result.structuredContent if isinstance(result.structuredContent, dict) else None,
+                        error=_extract_call_error(result),
+                    )
+
     async def _discover_http(
         self,
         url: str,
@@ -256,3 +398,39 @@ class McpClientService:
 
                     logger.info(f"Discovered {len(tools)} tools via http from {url}")
                     return McpConnectionResult(success=True, tools=tools)
+
+    async def _call_tool_http(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str],
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout_seconds: float,
+    ) -> McpToolCallResult:
+        async with asyncio.timeout(timeout_seconds):
+            async with streamablehttp_client(url, headers=headers) as (read, write, _session_id):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(
+                        tool_name,
+                        arguments=arguments,
+                        read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                    )
+                    return McpToolCallResult(
+                        success=not bool(result.isError),
+                        content=list(result.content or []),
+                        structured_content=result.structuredContent if isinstance(result.structuredContent, dict) else None,
+                        error=_extract_call_error(result),
+                    )
+
+
+def _extract_call_error(result: Any) -> str | None:
+    if not getattr(result, "isError", None):
+        return None
+    content = getattr(result, "content", None) or []
+    parts: list[str] = []
+    for item in content:
+        if getattr(item, "type", None) == "text" and getattr(item, "text", None):
+            parts.append(item.text)
+    return "\n".join(parts).strip() or "MCP tool returned an error"

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -52,6 +52,17 @@ class DocumentStorageService:
         safe_stem = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in stem)[:120] or "document"
         return f"knowledge/{app_name}/{corpus_id}/derived/{document_id}/{safe_stem}.md"
 
+    @staticmethod
+    def _build_asset_gcs_path(
+        *,
+        app_name: str,
+        corpus_id: UUID,
+        document_id: UUID,
+        filename: str,
+    ) -> str:
+        safe_name = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in filename)[:180] or "asset"
+        return f"knowledge/{app_name}/{corpus_id}/derived/{document_id}/assets/{safe_name}"
+
     async def check_duplicate(
         self,
         corpus_id: UUID,
@@ -401,6 +412,41 @@ class DocumentStorageService:
             logger.warning(
                 "markdown_derivative_upload_failed",
                 document_id=str(document_id),
+                error=str(exc),
+            )
+            return None
+
+    async def upload_extraction_asset(
+        self,
+        *,
+        document_id: UUID,
+        filename: str,
+        content: bytes,
+        content_type: str,
+    ) -> Optional[str]:
+        """上传 Data Extractor 生成的衍生资源。"""
+        doc = await self.get_document(document_id=document_id)
+        if not doc:
+            return None
+
+        try:
+            gcs_client = self._get_gcs_client()
+            gcs_path = self._build_asset_gcs_path(
+                app_name=doc.app_name,
+                corpus_id=doc.corpus_id,
+                document_id=doc.id,
+                filename=filename,
+            )
+            return gcs_client.upload(
+                content=content,
+                gcs_path=gcs_path,
+                content_type=content_type,
+            )
+        except Exception as exc:  # noqa: BLE001 - 衍生存储失败不应影响主流程
+            logger.warning(
+                "extraction_asset_upload_failed",
+                document_id=str(document_id),
+                filename=filename,
                 error=str(exc),
             )
             return None

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
@@ -186,6 +186,7 @@ async def test_sync_document_success(monkeypatch):
     monkeypatch.setattr("negentropy.storage.service.DocumentStorageService", lambda: fake_storage)
     monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
     monkeypatch.setattr("negentropy.knowledge.content.fetch_content", fake_fetch_content)
+    monkeypatch.setattr("negentropy.knowledge.extraction.fetch_content", fake_fetch_content)
 
     result = await knowledge_api.sync_document(
         corpus_id=corpus_id,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction.py
@@ -1,0 +1,65 @@
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.extraction import (
+    ROUTE_FILE_PDF,
+    ROUTE_URL,
+    extract_source,
+    resolve_source_kind,
+    resolve_targets,
+)
+
+
+def test_resolve_source_kind_for_url_and_pdf() -> None:
+    assert resolve_source_kind(source_uri="https://example.com/doc") == ROUTE_URL
+    assert resolve_source_kind(filename="report.pdf") == ROUTE_FILE_PDF
+    assert resolve_source_kind(content_type="application/pdf") == ROUTE_FILE_PDF
+
+
+def test_resolve_targets_sorts_and_filters_invalid_items() -> None:
+    server_id = str(uuid4())
+    targets = resolve_targets(
+        {
+            "extractor_routes": {
+                "url": {
+                    "targets": [
+                        {"server_id": server_id, "tool_name": "secondary", "priority": 2},
+                        {"server_id": server_id, "tool_name": "primary", "priority": 1},
+                        {"server_id": "", "tool_name": "ignored"},
+                    ]
+                }
+            }
+        },
+        ROUTE_URL,
+    )
+
+    assert [item.tool_name for item in targets] == ["primary", "secondary"]
+
+
+@pytest.mark.asyncio
+async def test_extract_source_uses_legacy_provider_without_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_extract_url(self, *, url: str):  # type: ignore[no-untyped-def]
+        from negentropy.knowledge.extraction import ExtractedDocumentResult
+
+        return ExtractedDocumentResult(
+            plain_text="legacy text",
+            markdown_content="legacy markdown",
+        )
+
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction.LegacyExtractionProvider.extract_url",
+        fake_extract_url,
+    )
+
+    result = await extract_source(
+        app_name="negentropy",
+        corpus_id=uuid4(),
+        corpus_config={},
+        source_kind=ROUTE_URL,
+        url="https://example.com",
+    )
+
+    assert result.plain_text == "legacy text"
+    assert result.markdown_content == "legacy markdown"
+    assert result.trace["provider"] == "legacy"


### PR DESCRIPTION
## 变更内容

本 PR 将 Knowledge Base 中 URL / PDF 文档的摄入链路从项目内硬编码提取流程，重构为通过可配置的 MCP Data Extractor 执行。

具体包括：

- 新增统一的文档提取编排层，将 URL 抓取、文件读取、Markdown 转换、图片/衍生资源处理抽象为独立的 extraction pipeline
- 支持按 **Knowledge Base（corpus）维度** 配置 `extractor_routes`
- 支持按文档类型分别配置 MCP 主备链路：
  - `url`
  - `file_pdf`
- URL / PDF 类型文档会根据当前 source kind 自动选择对应的 MCP Server / Tool，而不是共享同一个提取器
- 当某一类型配置了 MCP 主备链路时，运行时会在主备之间顺序切换；未配置时仍走 legacy 提取路径，保证兼容现有可用能力
- 扩展 MCP client，支持实际 `call_tool` 调用，而不再仅仅是 tool discovery
- 在 MCP tool 调用后累计 `mcp_tools.call_count`，使 Plugins / MCP Servers 页面可以显示真实调用次数
- 将 extraction 相关阶段接入 Knowledge Pipelines 页面，补充提取路由解析、主 MCP 提取、备用提取、资源存储、提取结果整理等状态展示
- 为提取后的 Markdown 衍生物和资源文件补充存储能力
- 补充后端 extraction 单测，并更新前端 Knowledge Base 页面测试以覆盖新的配置导出

## 变更原因

这次改动对应的任务目标，是把 Knowledge Base 文档 ingest 过程中关于页面爬取、文档摄入、内容读取与优化、Markdown 目标转换、图片提取与存储管理等流程，从“项目内硬编码实现”迁移为“通过 Plugins / MCP Servers 下预置的 Data Extractor MCP 处理”。

这样做的原因是：

- 降低摄入链路中的硬编码耦合，避免不同文档类型的处理逻辑继续散落在 API / service 中
- 让 URL 与 PDF 这两类本质上处理方式不同的文档，能够分别绑定最合适的 MCP 工具
- 提升可替换性与可演进性，使后续新增 extractor 或调整主备策略时不需要再次改动核心 ingest 逻辑
- 提高可观测性，让 MCP 调用过程、失败切换和工具使用量都能被追踪与审计
- 在引入新架构的同时，通过未配置 route 时回落 legacy provider 的方式，尽量避免影响当前已经正常可用的文档摄入功能

## 重要实现细节

### 1. 后端提取架构
- 新增 `knowledge/extraction.py` 作为统一编排层
- 将 source kind 解析、corpus 配置读取、主备 MCP target 解析、legacy fallback、提取结果标准化收敛到同一处
- `extractor_routes` 保存在 corpus config 中，并与 chunking config 共存，不破坏现有配置结构

### 2. MCP 调用与主备切换
- MCP 配置不是全局生效，而是按 corpus 单独配置
- 每个类型下维护 `targets`，按优先级顺序执行
- 当前 target 失败时切换到备用 target
- 每次真实调用都会累计 `mcp_tools.call_count`

### 3. Knowledge ingest 接入点
以下链路已改为通过新的 extraction 编排层处理：
- `ingest_url`
- `ingest_file`
- URL 类型 document `sync`
- 与 GCS 文档重建相关的提取路径

### 4. 可观测性
- Pipeline stages 新增 extraction 相关阶段
- 提取 trace、命中的 target、衍生资源摘要会被写入 metadata / pipeline output
- Pipelines 页面补充对应阶段标签，便于定位当前走的是主 MCP 还是备用 MCP

### 5. 前端配置入口
- 在 Knowledge Base Settings 页面新增 Data Extractor MCP 配置区
- 审阅者可直接看到并配置当前 corpus 的：
  - URL 主/备 MCP Server + Tool
  - PDF 主/备 MCP Server + Tool

## 验证情况

已执行的验证包括：

- `uv run pytest tests/unit_tests/knowledge/test_extraction.py tests/unit_tests/knowledge/test_content.py`
- `uv run pytest tests/unit_tests/knowledge/test_api_document_routes.py::test_sync_document_success`
- `pnpm test -- tests/unit/knowledge/knowledge-api.test.ts tests/unit/knowledge/KnowledgeBasePage.test.tsx`

## 说明

本次 PR 聚焦于“以 MCP 可配置提取链路替代 Knowledge Base 文档摄入中的硬编码提取流程”，未额外扩散修改无关模块。

This PR was written using [Vibe Kanban](https://vibekanban.com)
