### PR TITLE
fix(Knowledge Base): 收敛 Corpus 卡片布局与摘要展示 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -75,14 +75,14 @@ function formatCorpusConfigSummary(corpus: CorpusRecord): string {
   );
 
   if (config.strategy === "semantic") {
-    return `chunks: ${corpus.knowledge_count} · strategy: semantic · threshold: ${config.semantic_threshold.toFixed(2)} · buffer: ${config.semantic_buffer_size}`;
+    return `strategy: semantic · threshold: ${config.semantic_threshold.toFixed(2)} · buffer: ${config.semantic_buffer_size}`;
   }
 
   if (config.strategy === "hierarchical") {
-    return `chunks: ${corpus.knowledge_count} · strategy: hierarchical · parent: ${config.hierarchical_parent_chunk_size} · child: ${config.hierarchical_child_chunk_size}`;
+    return `strategy: hierarchical · parent: ${config.hierarchical_parent_chunk_size} · child: ${config.hierarchical_child_chunk_size}`;
   }
 
-  return `chunks: ${corpus.knowledge_count} · strategy: ${config.strategy} · size: ${config.chunk_size} · overlap: ${config.overlap}`;
+  return `strategy: ${config.strategy} · size: ${config.chunk_size} · overlap: ${config.overlap}`;
 }
 
 function ChunkDetailDrawer({
@@ -940,38 +940,55 @@ export default function KnowledgeBasePage() {
           {corpora.map((corpus) => (
             <div
               key={corpus.id}
-              className="flex h-full cursor-pointer flex-col rounded-xl border border-border bg-background p-3 transition hover:border-foreground/40"
+              data-testid={`corpus-card-${corpus.id}`}
+              className="flex h-40 cursor-pointer flex-col rounded-xl border border-border bg-background p-3 transition hover:border-foreground/40"
               onClick={() => openCorpusWorkspace(corpus.id, "documents")}
             >
               <div className="flex items-center justify-between gap-2">
-                <h3 className="truncate text-base font-semibold">{corpus.name}</h3>
-                <CorpusStatusBadge corpus={corpus} />
+                <h3 className="min-w-0 flex-1 truncate text-base font-semibold">{corpus.name}</h3>
+                <div className="flex shrink-0 items-center justify-end gap-2">
+                  <span
+                    data-testid={`corpus-chunks-${corpus.id}`}
+                    className="text-[11px] font-medium text-muted"
+                  >
+                    chunks: {corpus.knowledge_count}
+                  </span>
+                  <CorpusStatusBadge corpus={corpus} />
+                </div>
               </div>
-              <p className="mt-1 truncate text-xs text-muted" title={corpus.description || "No description"}>
+              <p
+                data-testid={`corpus-description-${corpus.id}`}
+                className="mt-2 line-clamp-2 min-h-10 text-xs leading-5 text-muted"
+                title={corpus.description || "No description"}
+              >
                 {corpus.description || "No description"}
               </p>
               <div
-                className="mt-2 truncate text-[11px] text-muted"
-                title={formatCorpusConfigSummary(corpus)}
-              >
-                {formatCorpusConfigSummary(corpus)}
-              </div>
-              <div
-                className="mt-auto flex items-center justify-end gap-2 pt-3"
+                data-testid={`corpus-footer-${corpus.id}`}
+                className="mt-auto flex items-end justify-between gap-3 pt-3"
                 onClick={(e) => e.stopPropagation()}
               >
-                <button
-                  onClick={() => handleEditCorpus(corpus)}
-                  className="inline-flex h-7 items-center rounded border border-border px-2.5 text-[11px] hover:bg-muted"
+                <div
+                  data-testid={`corpus-summary-${corpus.id}`}
+                  className="min-w-0 flex-1 truncate text-[11px] text-muted"
+                  title={formatCorpusConfigSummary(corpus)}
                 >
-                  Settings
-                </button>
-                <button
-                  onClick={() => handleDeleteCorpus(corpus)}
-                  className="inline-flex h-7 items-center rounded border border-red-300 px-2.5 text-[11px] text-red-600 hover:bg-red-50"
-                >
-                  Delete
-                </button>
+                  {formatCorpusConfigSummary(corpus)}
+                </div>
+                <div className="flex shrink-0 items-center justify-end gap-2">
+                  <button
+                    onClick={() => handleEditCorpus(corpus)}
+                    className="inline-flex h-7 items-center rounded border border-border px-2.5 text-[11px] hover:bg-muted"
+                  >
+                    Settings
+                  </button>
+                  <button
+                    onClick={() => handleDeleteCorpus(corpus)}
+                    className="inline-flex h-7 items-center rounded border border-red-300 px-2.5 text-[11px] text-red-600 hover:bg-red-50"
+                  >
+                    Delete
+                  </button>
+                </div>
               </div>
             </div>
           ))}

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -272,9 +272,21 @@ describe("KnowledgeBasePage", () => {
     });
 
     expect(screen.queryByRole("button", { name: "Add Documents" })).not.toBeInTheDocument();
-    expect(
-      screen.getByText("chunks: 3 · strategy: recursive · size: 800 · overlap: 100"),
-    ).toBeInTheDocument();
+    const card = screen.getByTestId("corpus-card-11111111-1111-1111-1111-111111111111");
+    const chunks = screen.getByTestId("corpus-chunks-11111111-1111-1111-1111-111111111111");
+    const description = screen.getByTestId(
+      "corpus-description-11111111-1111-1111-1111-111111111111",
+    );
+    const summary = screen.getByTestId("corpus-summary-11111111-1111-1111-1111-111111111111");
+
+    expect(chunks).toHaveTextContent("chunks: 3");
+    expect(within(card).getByText("Ready")).toBeInTheDocument();
+    expect(description).toHaveTextContent("No description");
+    expect(description.className).toContain("line-clamp-2");
+    expect(card.className).toContain("h-40");
+    expect(summary).toHaveTextContent("strategy: recursive · size: 800 · overlap: 100");
+    expect(summary).not.toHaveTextContent("chunks:");
+    expect(summary.className).toContain("truncate");
 
     await user.click(screen.getByRole("button", { name: "Settings" }));
 


### PR DESCRIPTION
## 变更内容

本次调整聚焦 Knowledge Base 概览页的 Corpus 卡片信息层级与空间分配：

- 将 `chunks` 数移动到卡片顶部右侧，并放置在状态标签左侧，使核心状态信息集中展示。
- 将 `strategy`、`size`、`overlap`、`threshold`、`buffer` 等配置摘要下沉到卡片底部左侧，与 `Settings`、`Delete` 操作形成同一行布局。
- 将中间描述区限制为最多两行显示，超出部分截断，避免描述文本继续挤压卡片高度。
- 将卡片容器收敛为固定高度，保证同一网格中的 Corpus 卡片在不同内容长度下仍保持稳定、整齐的视觉节奏。
- 同步更新单元测试，改为校验新的布局语义与关键样式约束，覆盖顶部 `chunks`、状态标签、两行描述、固定高度与底部摘要展示。

## 变更原因

当前 Corpus 卡片把配置摘要堆叠在中部内容区域，描述和配置文案会共同拉高卡片，导致信息层级不清晰，也破坏列表网格的一致性。
本次调整的目标是按经典卡片分区模式收敛布局：顶部聚焦状态，中部保留描述，底部承载配置与操作，从而提升扫描效率、降低视觉噪音，并让卡片高度在不同 Corpus 间保持一致。

## 实现细节

- 在 `page.tsx` 中重构概览卡片为稳定的 `header / body / footer` 结构，而不是继续线性堆叠内容。
- 配置摘要函数去除了 `chunks` 字段，避免顶部与底部重复表达同一信息，保持单一事实源。
- 描述区使用两行截断约束，底部配置摘要保持单行截断，以确保固定高度卡片不会被文本重新撑开。
- 测试不再依赖旧的整串摘要文案，而是转为验证分区后的语义节点与关键 class，降低后续样式演进时的脆弱性。

This PR was written using [Vibe Kanban](https://vibekanban.com)
