### PR TITLE
fix(ui): 对齐 Knowledge Base Corpus 卡片 footer 并增强 Settings 交互反馈 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -965,12 +965,12 @@ export default function KnowledgeBasePage() {
               </p>
               <div
                 data-testid={`corpus-footer-${corpus.id}`}
-                className="mt-auto flex items-end justify-between gap-3 pt-3"
+                className="mt-auto flex items-center justify-between gap-3 pt-3"
                 onClick={(e) => e.stopPropagation()}
               >
                 <div
                   data-testid={`corpus-summary-${corpus.id}`}
-                  className="min-w-0 flex-1 truncate text-[11px] text-muted"
+                  className="min-w-0 flex-1 self-center truncate text-[11px] leading-5 text-muted"
                   title={formatCorpusConfigSummary(corpus)}
                 >
                   {formatCorpusConfigSummary(corpus)}
@@ -978,7 +978,7 @@ export default function KnowledgeBasePage() {
                 <div className="flex shrink-0 items-center justify-end gap-2">
                   <button
                     onClick={() => handleEditCorpus(corpus)}
-                    className="inline-flex h-7 items-center rounded border border-border px-2.5 text-[11px] hover:bg-muted"
+                    className="inline-flex h-7 items-center rounded border border-border px-2.5 text-[11px] text-muted transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20"
                   >
                     Settings
                   </button>

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -277,18 +277,26 @@ describe("KnowledgeBasePage", () => {
     const description = screen.getByTestId(
       "corpus-description-11111111-1111-1111-1111-111111111111",
     );
+    const footer = screen.getByTestId("corpus-footer-11111111-1111-1111-1111-111111111111");
     const summary = screen.getByTestId("corpus-summary-11111111-1111-1111-1111-111111111111");
+    const settingsButton = within(card).getByRole("button", { name: "Settings" });
 
     expect(chunks).toHaveTextContent("chunks: 3");
     expect(within(card).getByText("Ready")).toBeInTheDocument();
     expect(description).toHaveTextContent("No description");
     expect(description.className).toContain("line-clamp-2");
     expect(card.className).toContain("h-40");
+    expect(footer.className).toContain("items-center");
     expect(summary).toHaveTextContent("strategy: recursive · size: 800 · overlap: 100");
     expect(summary).not.toHaveTextContent("chunks:");
     expect(summary.className).toContain("truncate");
+    expect(summary.className).toContain("self-center");
+    expect(settingsButton.className).toContain("transition-colors");
+    expect(settingsButton.className).toContain("hover:bg-muted");
+    expect(settingsButton.className).toContain("hover:text-foreground");
+    expect(settingsButton.className).toContain("focus-visible:ring-2");
 
-    await user.click(screen.getByRole("button", { name: "Settings" }));
+    await user.click(settingsButton);
 
     expect(replaceMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## 变更内容

本次 PR 聚焦于 `Knowledge Base` 页面 `Corpus` 卡片的两个展示层问题修复：

- 调整 `Corpus` 卡片 footer 的布局对齐方式，将摘要文案与右侧操作按钮组从底边对齐改为纵向中轴对齐，修复红框区域文字视觉轴线不一致的问题。
- 为 `Settings` 按钮补充更明确的交互反馈，新增更清晰的 hover/focus 样式，包括文字、边框、背景和焦点 ring 的反馈强化。
- 补充对应单元测试断言，覆盖 footer 对齐类名以及 `Settings` 按钮的 hover/focus/transition 样式，降低后续样式回归风险。

## 变更原因

该修复来自 `Knowledge Base` 页面实际使用反馈：

- `Corpus` 卡片底部左侧摘要信息与右侧按钮组在纵向视觉上未对齐，导致卡片信息层次不稳定，影响可读性与整体观感。
- `Settings` 按钮在鼠标悬停时缺少足够明确的高亮反馈，用户难以感知该按钮处于可交互状态。

本次改动遵循最小干预原则，仅修正样式与测试，不改变页面信息架构、业务逻辑或交互语义。

## 重要实现细节

- 在 `Knowledge Base` 页面中，将 `Corpus` 卡片 footer 容器由 `items-end` 调整为 `items-center`，并为摘要文本补充 `self-center` 与更稳定的行高设置，以保证摘要区与按钮组在不同内容长度下保持一致的纵向对齐。
- `Settings` 按钮保持次级操作按钮定位，但增强其状态表达：默认使用较弱文本色，hover 时同步提升背景、边框与文字对比度，并增加 `focus-visible` ring，兼顾鼠标与键盘可访问性。
- 单元测试侧新增对 `corpus-footer`、`corpus-summary` 与 `Settings` 按钮样式类的断言，并继续验证点击 `Settings` 不会引入额外交互回归。

## 验证情况

- 已通过 diff 复核确认改动范围仅限 UI 样式与对应测试。
- 当前工作树环境缺少前端依赖，`pnpm test -- KnowledgeBasePage.test.tsx` 会因 `vitest: command not found` 无法执行；因此本次以静态改动审查与测试补强为主，待依赖安装后可继续做定向验证。

This PR was written using [Vibe Kanban](https://vibekanban.com)
