### PR TITLE
调整 Knowledge Base 检索区 Corpus 选择提示位置 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -887,7 +887,14 @@ export default function KnowledgeBasePage() {
       </div>
 
       <div className="mt-3">
-        <div className="mb-1 text-xs text-muted">Target Corpus（可多选）</div>
+        <div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+          <span className="text-muted">Target Corpus（可多选）</span>
+          {selectedRetrievalCorpusIds.length === 0 && (
+            <span className="text-[11px] text-amber-600">
+              请至少选择一个 Corpus 后再执行 Retrieve
+            </span>
+          )}
+        </div>
         <div className="flex flex-wrap gap-2">
           {corpora.map((corpus) => {
             const checked = selectedRetrievalCorpusIds.includes(corpus.id);
@@ -909,11 +916,6 @@ export default function KnowledgeBasePage() {
             );
           })}
         </div>
-        {selectedRetrievalCorpusIds.length === 0 && (
-          <div className="mt-2 text-[11px] text-amber-600">
-            请至少选择一个 Corpus 后再执行 Retrieve
-          </div>
-        )}
       </div>
 
       {retrievalError && (

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -955,8 +955,12 @@ describe("KnowledgeBasePage", () => {
     await user.type(screen.getByPlaceholderText("输入检索内容"), "context engineering");
 
     const retrieveButton = screen.getByRole("button", { name: "Retrieve" });
+    const corpusLabelRow = screen.getByText("Target Corpus（可多选）").parentElement;
     expect(retrieveButton).toBeDisabled();
-    expect(screen.getByText("请至少选择一个 Corpus 后再执行 Retrieve")).toBeInTheDocument();
+    expect(corpusLabelRow).not.toBeNull();
+    expect(
+      within(corpusLabelRow as HTMLElement).getByText("请至少选择一个 Corpus 后再执行 Retrieve"),
+    ).toBeInTheDocument();
     expect(searchAcrossCorporaMock).not.toHaveBeenCalled();
     expect(screen.queryByText(/Retrieved Chunks$/)).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## 变更内容

本次变更调整了 Knowledge Base 页面检索区的提示信息展示位置，并同步补充了对应的回归测试。

- 将“请至少选择一个 Corpus 后再执行 Retrieve”从 `Target Corpus（可多选）` 选项列表下方，移动到字段标题后方显示
- 保持原有交互约束不变：未选择任何 Corpus 时，提示仍会显示，`Retrieve` 按钮仍保持禁用
- 更新单元测试，明确校验该提示文案存在于标题行容器内，而不是作为列表下方的独立提示块

## 变更原因

这次调整来自页面使用场景中的信息层级优化需求。原先提示文案位于 Corpus 选项区域下方，用户在浏览检索条件时，提示与字段标签之间的关联不够直接。将提示移动到 `Target Corpus（可多选）` 标题后方，可以让约束信息更贴近触发对象，降低认知跳转成本，使界面反馈更符合表单字段级提示的常见设计模式。

## 实现细节

实现上采用了最小干预策略，没有引入新的状态、组件或交互逻辑。

- 将检索区标题改为可换行的横向容器，在同一标题行内组合字段标签与条件提示
- 保留现有的条件渲染逻辑，仅在未选择任何 Corpus 时显示提示
- 保留现有 Tailwind 样式语义，确保窄屏场景下标题与提示可以自然换行，避免布局挤压
- 补充测试断言，确保后续重构不会把提示重新放回列表区域下方

## 验证情况

已运行前端测试并确认相关页面行为未回归，`KnowledgeBasePage` 对应测试通过。

This PR was written using [Vibe Kanban](https://vibekanban.com)
