### PR TITLE
修复 Google 头像限流导致的加载失败并统一头像回退 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/app/admin/page.tsx
+++ b/apps/negentropy-ui/app/admin/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/components/providers/AuthProvider";
 import { AdminNav } from "@/components/ui/AdminNav";
+import { UserAvatar } from "@/components/ui/UserAvatar";
 
 interface UserItem {
   userId: string;
@@ -100,13 +101,13 @@ export default function AdminPage() {
               Current User
             </div>
             <div className="flex items-center gap-3">
-              {user?.picture && (
-                <img
-                  src={user.picture}
-                  alt=""
-                  className="h-10 w-10 rounded-full"
-                />
-              )}
+              <UserAvatar
+                picture={user?.picture}
+                name={user?.name}
+                email={user?.email}
+                className="h-10 w-10 object-cover"
+                fallbackClassName="text-sm"
+              />
               <div>
                 <div className="font-medium text-zinc-900 dark:text-zinc-100">{user?.name}</div>
                 <div className="text-sm text-zinc-500 dark:text-zinc-400">{user?.email}</div>

--- a/apps/negentropy-ui/app/api/auth/avatar/route.ts
+++ b/apps/negentropy-ui/app/api/auth/avatar/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+
+const ALLOWED_AVATAR_HOSTS = ["googleusercontent.com"];
+const AVATAR_CACHE_CONTROL = "private, max-age=3600, stale-while-revalidate=86400";
+
+function isAllowedAvatarUrl(value: string): boolean {
+  let url: URL;
+
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "https:") {
+    return false;
+  }
+
+  return ALLOWED_AVATAR_HOSTS.some(
+    (hostname) => url.hostname === hostname || url.hostname.endsWith(`.${hostname}`),
+  );
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const src = searchParams.get("src");
+
+  if (!src) {
+    return NextResponse.json({ error: "src is required" }, { status: 400 });
+  }
+
+  if (!isAllowedAvatarUrl(src)) {
+    return NextResponse.json({ error: "avatar source is not allowed" }, { status: 400 });
+  }
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(src, {
+      headers: {
+        accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+      },
+      cache: "force-cache",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Avatar upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: `Avatar upstream returned ${upstreamResponse.status}` },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  const headers = new Headers();
+  headers.set(
+    "content-type",
+    upstreamResponse.headers.get("content-type") || "image/jpeg",
+  );
+  headers.set("cache-control", AVATAR_CACHE_CONTROL);
+
+  const contentLength = upstreamResponse.headers.get("content-length");
+  if (contentLength) {
+    headers.set("content-length", contentLength);
+  }
+
+  return new NextResponse(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers,
+  });
+}

--- a/apps/negentropy-ui/components/layout/UserNav.tsx
+++ b/apps/negentropy-ui/components/layout/UserNav.tsx
@@ -1,18 +1,14 @@
 "use client";
 
 import { useAuth } from "@/components/providers/AuthProvider";
+import { UserAvatar } from "@/components/ui/UserAvatar";
 import { useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 export function UserNav() {
   const { user, login, logout, status } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
-  const [avatarLoadFailed, setAvatarLoadFailed] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setAvatarLoadFailed(false);
-  }, [user?.picture]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -55,18 +51,12 @@ export function UserNav() {
             : "hover:bg-muted hover:border-border",
         )}
       >
-        {user.picture && !avatarLoadFailed ? (
-          <img
-            src={user.picture}
-            alt={user.name || "User"}
-            className="h-7 w-7 rounded-full border border-border object-cover"
-            onError={() => setAvatarLoadFailed(true)}
-          />
-        ) : (
-          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/10 text-[10px] font-bold text-primary">
-            {(user.name || user.email || "?").slice(0, 1).toUpperCase()}
-          </div>
-        )}
+        <UserAvatar
+          picture={user.picture}
+          name={user.name}
+          email={user.email}
+          className="h-7 w-7 border border-border object-cover"
+        />
         <span className="text-xs font-medium text-muted-foreground hidden sm:inline-block max-w-[100px] truncate hover:text-foreground">
           {user.name || "User"}
         </span>

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -7,6 +7,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { ToolCallList } from "./ToolCallBubble";
+import { UserAvatar } from "./UserAvatar";
 
 type ChatMessageProps = {
   message: ChatMessage;
@@ -250,17 +251,14 @@ export function MessageBubble({
       {/* Avatar */}
       <div className="shrink-0">
         {isUser ? (
-          user?.picture ? (
-            <img
-              src={user.picture}
-              alt="Me"
-              className="w-8 h-8 rounded-full border border-border"
-            />
-          ) : (
-            <div className="w-8 h-8 rounded-full bg-foreground text-background flex items-center justify-center text-xs font-bold">
-              U
-            </div>
-          )
+          <UserAvatar
+            picture={user?.picture}
+            name={user?.name}
+            email={user?.email}
+            alt="Me"
+            className="h-8 w-8 border border-border object-cover"
+            fallbackClassName="bg-foreground text-background text-xs"
+          />
         ) : (
           <div className="w-8 h-8 rounded-full bg-card border border-border flex items-center justify-center shadow-sm ring-2 ring-primary/20 shrink-0 overflow-hidden">
             <img src="/logo.svg" alt="AI" className="w-5 h-5 object-contain" />

--- a/apps/negentropy-ui/components/ui/UserAvatar.tsx
+++ b/apps/negentropy-ui/components/ui/UserAvatar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+import { buildAvatarProxyUrl } from "@/lib/avatar";
+import { cn } from "@/lib/utils";
+
+type UserAvatarProps = {
+  picture?: string;
+  name?: string;
+  email?: string;
+  className?: string;
+  fallbackClassName?: string;
+  alt?: string;
+};
+
+function getInitial(name?: string, email?: string): string {
+  return (name || email || "?").slice(0, 1).toUpperCase();
+}
+
+export function UserAvatar({
+  picture,
+  name,
+  email,
+  className,
+  fallbackClassName,
+  alt,
+}: UserAvatarProps) {
+  const [failedPicture, setFailedPicture] = useState<string | null>(null);
+
+  const avatarSrc =
+    picture && picture !== failedPicture ? buildAvatarProxyUrl(picture) : null;
+  const avatarAlt = alt || name || email || "User";
+
+  if (avatarSrc) {
+    return (
+      <img
+        src={avatarSrc}
+        alt={avatarAlt}
+        className={className}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        onError={() => setFailedPicture(picture)}
+      />
+    );
+  }
+
+  return (
+    <div
+      aria-label={avatarAlt}
+      className={cn(
+        "flex items-center justify-center rounded-full bg-primary/10 text-[10px] font-bold text-primary",
+        className,
+        fallbackClassName,
+      )}
+    >
+      {getInitial(name, email)}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/lib/avatar.ts
+++ b/apps/negentropy-ui/lib/avatar.ts
@@ -1,0 +1,10 @@
+const AVATAR_PROXY_PATH = "/api/auth/avatar";
+
+export function buildAvatarProxyUrl(picture?: string): string | null {
+  if (!picture) {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams({ src: picture });
+  return `${AVATAR_PROXY_PATH}?${searchParams.toString()}`;
+}

--- a/apps/negentropy-ui/tests/integration/auth-avatar-route.test.ts
+++ b/apps/negentropy-ui/tests/integration/auth-avatar-route.test.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "@/app/api/auth/avatar/route";
+
+describe("GET /api/auth/avatar", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("缺少 src 时返回 400", async () => {
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/auth/avatar"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("src is required");
+  });
+
+  it("拒绝非白名单头像域名", async () => {
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/auth/avatar?src=https%3A%2F%2Fexample.com%2Favatar.png",
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("avatar source is not allowed");
+  });
+
+  it("成功代理 Google 头像并写入缓存头", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("avatar-binary", {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "content-length": "13",
+        },
+      }),
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/auth/avatar?src=https%3A%2F%2Flh3.googleusercontent.com%2Fa%2Favatar",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, max-age=3600, stale-while-revalidate=86400",
+    );
+    expect(await response.text()).toBe("avatar-binary");
+  });
+
+  it("透传上游限流状态码", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("rate limited", { status: 429 }),
+    );
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost:3000/api/auth/avatar?src=https%3A%2F%2Flh3.googleusercontent.com%2Fa%2Favatar",
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data.error).toBe("Avatar upstream returned 429");
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/UserAvatar.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/UserAvatar.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { UserAvatar } from "@/components/ui/UserAvatar";
+
+describe("UserAvatar", () => {
+  it("图片加载失败时回退到首字母头像", () => {
+    render(
+      <UserAvatar
+        picture="https://lh3.googleusercontent.com/a/avatar"
+        name="Aurelius Huang"
+        email="aurelius@example.com"
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Aurelius Huang" });
+    fireEvent.error(image);
+
+    expect(screen.getByLabelText("Aurelius Huang")).toHaveTextContent("A");
+  });
+
+  it("无头像地址时直接渲染首字母回退", () => {
+    render(<UserAvatar name="Negentropy" email="negentropy@example.com" />);
+
+    expect(screen.getByLabelText("Negentropy")).toHaveTextContent("N");
+  });
+});


### PR DESCRIPTION
## 变更内容

本 PR 修复了已登录用户 Google 头像在 UI 中无法稳定显示的问题，并统一了头像渲染链路。

具体改动包括：

- 新增同源头像代理接口 `/api/auth/avatar`，由前端通过同源地址加载头像，而不再在多个 UI 位置直接热链 `lh3.googleusercontent.com`
- 新增共享头像组件 `UserAvatar`，统一处理头像展示、失败回退和首字母占位逻辑
- 将顶部用户导航、聊天消息气泡、Admin 当前用户信息卡片切换为共享头像组件
- 新增头像代理路由集成测试，以及头像组件的单元测试，覆盖白名单校验、上游限流透传和失败回退行为

## 变更原因

根据任务上下文和实际排查结果，问题并不是“后端没有拿到 Google 头像地址”，而是浏览器在页面多个位置直接请求 Google 头像外链时，`lh3.googleusercontent.com` 返回了 `429 Too Many Requests`。

这导致了两个用户可见问题：

- 顶部导航头像加载失败后退回首字母
- 聊天气泡中的用户头像没有统一回退逻辑，直接显示破图

因此，本次修复的目标不是修改 OAuth 登录链路，而是对头像加载策略做稳定性收敛，减少第三方外链依赖，并统一失败回退体验。

## 重要实现细节

- 头像代理仅允许 `googleusercontent.com` 白名单域名，避免把接口变成任意外链代理
- 代理响应增加私有缓存头，降低浏览器重复请求头像源时触发限流的概率
- 展示层继续保留 `picture` 作为身份源原始地址，不修改认证接口 schema，也不引入新的数据库字段
- `UserAvatar` 组件内部统一处理错误回退，确保不同页面和组件不会再出现“有些地方回退、有些地方破图”的不一致问题

## 验证结果

已执行头像相关回归验证：

- `pnpm test -- UserAvatar UserNav auth-avatar-route`

该命令实际触发并通过了当前测试集中的 34 个测试文件、163 个测试用例，其中包含本次新增的：

- 头像代理路由集成测试
- 头像组件回退测试

This PR was written using [Vibe Kanban](https://vibekanban.com)
