### PR TITLE
统一 MCP 子进程 stderr 日志为项目标准格式 (Vibe Kanban)

### DIFF
--- a/apps/negentropy/src/negentropy/logging/core.py
+++ b/apps/negentropy/src/negentropy/logging/core.py
@@ -6,16 +6,15 @@ from __future__ import annotations
 
 import logging
 import sys
+from datetime import UTC, datetime
 from typing import Any
-from datetime import datetime, timezone
 
 import structlog
 from structlog.typing import EventDict, WrappedLogger
-from structlog import stdlib
 
-from .sinks import BaseSink, StdioSink, FileSink, GCloudSink, LogFormat
 from .formatters import ConsoleFormatter
 from .io import StreamToLogger
+from .sinks import BaseSink, FileSink, GCloudSink, LogFormat, StdioSink
 
 # =============================================================================
 # Global State
@@ -36,7 +35,7 @@ def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
 
 def add_timestamp(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
     """Add ISO 8601 timestamp to log event."""
-    event_dict["timestamp"] = datetime.now(timezone.utc).isoformat()
+    event_dict.setdefault("timestamp", datetime.now(UTC).isoformat())
     return event_dict
 
 

--- a/apps/negentropy/src/negentropy/logging/io.py
+++ b/apps/negentropy/src/negentropy/logging/io.py
@@ -2,8 +2,14 @@
 I/O redirection utilities.
 """
 
-from typing import Any
+from __future__ import annotations
+
 import inspect
+import logging
+import os
+import re
+from typing import Any
+
 import structlog
 
 
@@ -82,3 +88,86 @@ class StreamToLogger:
     @property
     def encoding(self) -> str:
         return getattr(self.original_stream, "encoding", "utf-8")
+
+
+class ExternalProcessLogStream:
+    """Adapt external process stderr writes into the unified logging pipeline."""
+
+    _PREFIX_PATTERN = re.compile(
+        r"^\[(?P<timestamp>[^\]]+)\]\s+(?P<level>[A-Z]+):\s*(?P<message>.*)$"
+    )
+    _LEVELS = {
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARN": logging.WARNING,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+        "FATAL": logging.CRITICAL,
+        "CRITICAL": logging.CRITICAL,
+    }
+
+    def __init__(
+        self,
+        logger: structlog.stdlib.BoundLogger,
+        *,
+        source: str,
+        default_level: int = logging.INFO,
+        encoding: str = "utf-8",
+    ) -> None:
+        self.logger = logger
+        self.source = source
+        self.default_level = default_level
+        self._encoding = encoding
+        self._linebuf = ""
+
+    def write(self, buf: str | bytes) -> int:
+        if isinstance(buf, bytes):
+            buf = buf.decode(self._encoding, errors="replace")
+
+        self._linebuf += buf
+        while "\n" in self._linebuf:
+            line, self._linebuf = self._linebuf.split("\n", 1)
+            self._emit_line(line.rstrip("\r"))
+
+        return len(buf)
+
+    def flush(self) -> None:
+        if self._linebuf:
+            self._emit_line(self._linebuf.rstrip("\r"))
+            self._linebuf = ""
+
+    def isatty(self) -> bool:
+        return False
+
+    @property
+    def encoding(self) -> str:
+        return self._encoding
+
+    def _emit_line(self, line: str) -> None:
+        if not line:
+            return
+
+        match = self._PREFIX_PATTERN.match(line)
+        event: dict[str, Any] = {"source": self.source}
+        level = self.default_level
+        message = line
+
+        if match:
+            message = match.group("message")
+            level = self._LEVELS.get(match.group("level"), self.default_level)
+            timestamp = match.group("timestamp")
+            if timestamp:
+                event["timestamp"] = timestamp
+
+        self.logger.log(level, event=message, **event)
+
+
+def derive_external_process_source(command: str, args: list[str] | None = None) -> str:
+    """Generate a stable source label for external process log streams."""
+
+    candidates = [arg for arg in (args or []) if arg and not arg.startswith("-")]
+    raw_label = candidates[0] if candidates else command
+    normalized = os.path.basename(raw_label.rstrip("/")) or command
+    if normalized.startswith("@") and "/" in raw_label:
+        normalized = raw_label.split("/")[-1]
+    return f"mcp.{normalized}"

--- a/apps/negentropy/src/negentropy/plugins/mcp_client.py
+++ b/apps/negentropy/src/negentropy/plugins/mcp_client.py
@@ -8,9 +8,9 @@ MCP Client Service Module.
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
 import time
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import Any
 
 import httpx
@@ -20,8 +20,10 @@ from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
 from negentropy.logging import get_logger
+from negentropy.logging.io import ExternalProcessLogStream, derive_external_process_source
 
 logger = get_logger("negentropy.plugins.mcp_client")
+stderr_logger = get_logger("stderr")
 
 # 连接超时时间（秒）
 DEFAULT_TIMEOUT_SECONDS = 30
@@ -282,7 +284,7 @@ class McpClientService:
         )
 
         async with asyncio.timeout(self.timeout_seconds):
-            async with stdio_client(server_params) as (read, write):
+            async with stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (read, write):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
                     tools_result = await session.list_tools()
@@ -311,7 +313,7 @@ class McpClientService:
     ) -> McpToolCallResult:
         server_params = StdioServerParameters(command=command, args=args, env=env)
         async with asyncio.timeout(timeout_seconds):
-            async with stdio_client(server_params) as (read, write):
+            async with stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (read, write):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
                     result = await session.call_tool(
@@ -322,9 +324,18 @@ class McpClientService:
                     return McpToolCallResult(
                         success=not bool(result.isError),
                         content=list(result.content or []),
-                        structured_content=result.structuredContent if isinstance(result.structuredContent, dict) else None,
+                        structured_content=(
+                            result.structuredContent if isinstance(result.structuredContent, dict) else None
+                        ),
                         error=_extract_call_error(result),
                     )
+
+    @staticmethod
+    def _build_stdio_errlog(command: str, args: list[str]) -> ExternalProcessLogStream:
+        return ExternalProcessLogStream(
+            stderr_logger,
+            source=derive_external_process_source(command, args),
+        )
 
     async def _discover_sse(
         self,
@@ -371,7 +382,9 @@ class McpClientService:
                     return McpToolCallResult(
                         success=not bool(result.isError),
                         content=list(result.content or []),
-                        structured_content=result.structuredContent if isinstance(result.structuredContent, dict) else None,
+                        structured_content=(
+                            result.structuredContent if isinstance(result.structuredContent, dict) else None
+                        ),
                         error=_extract_call_error(result),
                     )
 
@@ -420,7 +433,9 @@ class McpClientService:
                     return McpToolCallResult(
                         success=not bool(result.isError),
                         content=list(result.content or []),
-                        structured_content=result.structuredContent if isinstance(result.structuredContent, dict) else None,
+                        structured_content=(
+                            result.structuredContent if isinstance(result.structuredContent, dict) else None
+                        ),
                         error=_extract_call_error(result),
                     )
 

--- a/apps/negentropy/tests/unit_tests/logging/test_logging_pipeline.py
+++ b/apps/negentropy/tests/unit_tests/logging/test_logging_pipeline.py
@@ -8,7 +8,7 @@ from negentropy.logging import core
 from negentropy.logging.core import add_logger_name, multi_sink_renderer, rename_event_key
 from negentropy.logging.formatters import ConsoleFormatter
 from negentropy.logging.interceptors import RedirectStdLibHandler
-from negentropy.logging.io import StreamToLogger
+from negentropy.logging.io import ExternalProcessLogStream, StreamToLogger, derive_external_process_source
 from negentropy.logging.sinks import FileSink, StdioSink
 
 
@@ -132,3 +132,44 @@ def test_stream_to_logger_buffers_until_newline() -> None:
     stream.flush()
 
     assert messages[0][1] == "hello world"
+
+
+def test_external_process_log_stream_parses_prefixed_lines() -> None:
+    messages: list[tuple[int, str, dict]] = []
+
+    class _Logger:
+        def log(self, level, event=None, **kwargs):
+            messages.append((level, event, kwargs))
+
+    stream = ExternalProcessLogStream(_Logger(), source="mcp.zai-mcp-server")
+    stream.write("[2026-03-07T06:29:09.030Z] INFO: MCP Server Application initialized\n")
+
+    assert messages == [
+        (
+            logging.INFO,
+            "MCP Server Application initialized",
+            {"source": "mcp.zai-mcp-server", "timestamp": "2026-03-07T06:29:09.030Z"},
+        )
+    ]
+
+
+def test_external_process_log_stream_buffers_and_falls_back_for_plain_lines() -> None:
+    messages: list[tuple[int, str, dict]] = []
+
+    class _Logger:
+        def log(self, level, event=None, **kwargs):
+            messages.append((level, event, kwargs))
+
+    stream = ExternalProcessLogStream(_Logger(), source="mcp.npx")
+    stream.write("partial line")
+    assert messages == []
+
+    stream.write(" completed")
+    stream.flush()
+
+    assert messages == [(logging.INFO, "partial line completed", {"source": "mcp.npx"})]
+
+
+def test_derive_external_process_source_prefers_first_non_flag_arg() -> None:
+    assert derive_external_process_source("npx", ["-y", "@zilliz/zai-mcp-server"]) == "mcp.zai-mcp-server"
+    assert derive_external_process_source("uvx", ["mcp-server-fetch"]) == "mcp.mcp-server-fetch"

--- a/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
+++ b/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+from negentropy.plugins.mcp_client import McpClientService
+
+
+@pytest.mark.asyncio
+async def test_discover_stdio_passes_structured_errlog(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_stdio_client(server_params, errlog):
+        captured["server_params"] = server_params
+        captured["errlog"] = errlog
+        yield object(), object()
+
+    class _Tool:
+        def __init__(self) -> None:
+            self.name = "demo"
+            self.description = "demo tool"
+            self.inputSchema = {"type": "object"}
+
+    class _ToolsResult:
+        tools = [_Tool()]
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def initialize(self) -> None:
+            captured["initialized"] = True
+
+        async def list_tools(self):
+            return _ToolsResult()
+
+    monkeypatch.setattr("negentropy.plugins.mcp_client.stdio_client", fake_stdio_client)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.ClientSession", lambda read, write: _Session())
+
+    service = McpClientService(timeout_seconds=5)
+    result = await service.discover_tools(
+        "stdio",
+        command="npx",
+        args=["-y", "@zilliz/zai-mcp-server"],
+        env={},
+    )
+
+    assert result.success is True
+    assert captured["initialized"] is True
+    assert captured["errlog"].source == "mcp.zai-mcp-server"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_stdio_passes_structured_errlog(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_stdio_client(server_params, errlog):
+        captured["server_params"] = server_params
+        captured["errlog"] = errlog
+        yield object(), object()
+
+    class _Result:
+        isError = False
+        content = [{"type": "text", "text": "ok"}]
+        structuredContent = {"ok": True}
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def initialize(self) -> None:
+            captured["initialized"] = True
+
+        async def call_tool(self, tool_name, arguments, read_timeout_seconds):
+            captured["tool_name"] = tool_name
+            captured["arguments"] = arguments
+            captured["read_timeout_seconds"] = read_timeout_seconds
+            return _Result()
+
+    monkeypatch.setattr("negentropy.plugins.mcp_client.stdio_client", fake_stdio_client)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.ClientSession", lambda read, write: _Session())
+
+    service = McpClientService(timeout_seconds=5)
+    result = await service.call_tool(
+        transport_type="stdio",
+        command="uvx",
+        args=["mcp-server-fetch"],
+        env={},
+        tool_name="fetch",
+        arguments={"url": "https://example.com"},
+    )
+
+    assert result.success is True
+    assert captured["initialized"] is True
+    assert captured["tool_name"] == "fetch"
+    assert captured["errlog"].source == "mcp.mcp-server-fetch"


### PR DESCRIPTION
## 变更内容

本次改动将 `stdio` 型 MCP 子进程输出到 `stderr` 的日志接入项目统一日志管线，避免第三方进程日志绕过既有的结构化格式化流程。

具体包括：

- 在日志 I/O 层新增外部进程日志桥接器，对子进程 `stderr` 做按行缓冲，并将日志转发到统一 logger
- 识别并解析形如 `[timestamp] LEVEL: message` 的上游日志前缀，尽量保留原始时间戳与级别语义
- 在 MCP 客户端的 `stdio` 路径中，显式将 `errlog` 接入该桥接器，而不是继续使用库默认的 `sys.stderr`
- 调整日志时间戳补写逻辑，仅在事件未显式携带 `timestamp` 时才补当前时间，避免覆盖上游时间信息
- 补充 logging 与 MCP client 单元测试，覆盖 stderr 桥接、前缀解析、source 推导和 `errlog` 接线行为

## 变更原因

这次修改来自一个明确的日志一致性问题：运行 MCP Server 时，终端中间一段日志没有遵循项目统一的输出格式，而上下两段日志是符合规范的。

根因是 `mcp.client.stdio` 默认将子进程 `stderr` 直接输出到父进程终端，这条链路绕过了项目现有的 `structlog`/formatter 管线，导致日志表现割裂、可读性下降，也增加了排障时的上下文切换成本。

本次修复的目标是让 MCP 子进程日志也进入统一日志体系，提升观测一致性和调试效率，同时避免影响 MCP 协议本身依赖的 `stdout` 通道。

## 重要实现细节

- 只接管 `stdio` MCP 子进程的 `stderr`，不触碰 `stdout`，避免破坏 JSON-RPC 通信
- 对可识别前缀执行轻量解析；对无法识别的普通文本行回退为原样消息转发，避免因严格解析导致日志丢失
- `source` 标签会根据命令与参数推导稳定的进程标识，便于在统一日志格式中区分日志来源
- 新增测试覆盖确保 `discover_tools()` 与 `call_tool()` 两条 `stdio` 路径都显式传入结构化 `errlog`
- 这次变更属于最小干预：不修改 MCP 协议交互语义，只修复日志旁路输出问题

This PR was written using [Vibe Kanban](https://vibekanban.com)
