### PR TITLE
fix(chat-ui): 优化聊天头像外移布局并移除边框 (Vibe Kanban)

### DIFF
--- a/apps/negentropy-ui/components/layout/UserNav.tsx
+++ b/apps/negentropy-ui/components/layout/UserNav.tsx
@@ -55,7 +55,7 @@ export function UserNav() {
           picture={user.picture}
           name={user.name}
           email={user.email}
-          className="h-7 w-7 border border-border object-cover"
+          className="h-7 w-7 object-cover"
         />
         <span className="text-xs font-medium text-muted-foreground hidden sm:inline-block max-w-[100px] truncate hover:text-foreground">
           {user.name || "User"}

--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -39,7 +39,7 @@ export function ChatStream({
       className="flex-1 overflow-y-auto custom-scrollbar"
     >
       <div
-        className={`mx-auto w-full space-y-4 px-6 py-6 ${contentClassName ?? ""}`}
+        className={`mx-auto w-full space-y-4 px-10 py-6 sm:px-12 ${contentClassName ?? ""}`}
       >
         {visibleNodes.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -228,6 +228,9 @@ export function MessageBubble({
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const content = normalizeContent(message.content);
+  const avatarPositionClass = isUser
+    ? "absolute right-0 top-2 translate-x-[calc(100%+0.75rem)]"
+    : "absolute left-0 top-2 -translate-x-[calc(100%+0.75rem)]";
 
   if (isSystem) {
     return (
@@ -242,43 +245,41 @@ export function MessageBubble({
   return (
     <div
       className={cn(
-        "flex w-full gap-4 group cursor-pointer", // Added cursor-pointer for clickability
+        "group relative flex w-full cursor-pointer",
         isUser ? "flex-row-reverse" : "flex-row",
-        isSelected && "bg-muted/50", // Highlight when selected
+        isSelected && "bg-muted/50",
       )}
       onClick={() => onSelect?.(message.id)}
     >
-      {/* Avatar */}
-      <div className="shrink-0">
+      <div className={cn("shrink-0", avatarPositionClass)}>
         {isUser ? (
           <UserAvatar
             picture={user?.picture}
             name={user?.name}
             email={user?.email}
             alt="Me"
-            className="h-8 w-8 border border-border object-cover"
+            className="h-8 w-8 rounded-md object-cover"
             fallbackClassName="bg-foreground text-background text-xs"
           />
         ) : (
-          <div className="w-8 h-8 rounded-full bg-card border border-border flex items-center justify-center shadow-sm ring-2 ring-primary/20 shrink-0 overflow-hidden">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-card">
             <img src="/logo.svg" alt="AI" className="w-5 h-5 object-contain" />
           </div>
         )}
       </div>
 
-      {/* Bubble Container */}
       <div
         className={cn(
-          "flex flex-col",
-          isUser ? "max-w-[85%]" : "w-full max-w-full",
+          "flex w-full flex-col",
+          isUser ? "items-end" : "items-start",
         )}
       >
         <div
           className={cn(
             "rounded-2xl px-5 py-3 text-sm shadow-sm transition-all",
             isUser
-              ? "bg-foreground text-background rounded-tr-sm leading-relaxed"
-              : "bg-card text-foreground border border-border rounded-tl-sm leading-snug",
+              ? "max-w-[85%] rounded-tr-sm bg-foreground leading-relaxed text-background"
+              : "w-full max-w-full rounded-tl-sm border border-border bg-card leading-snug text-foreground",
           )}
         >
           <div

--- a/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MessageBubble } from "@/components/ui/MessageBubble";
+
+vi.mock("@/components/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      name: "Aurelius Huang",
+      email: "aurelius@example.com",
+      picture: "https://example.com/avatar.png",
+    },
+  }),
+}));
+
+describe("MessageBubble", () => {
+  it("用户头像无边框并定位在消息外侧", () => {
+    render(
+      <MessageBubble
+        message={{ id: "u-1", role: "user", content: "你好" }}
+      />,
+    );
+
+    const avatar = screen.getByRole("img", { name: "Me" });
+    expect(avatar.className).not.toContain("border");
+    expect(avatar.className).toContain("rounded-md");
+
+    const avatarRail = avatar.parentElement;
+    expect(avatarRail?.className).toContain("absolute");
+    expect(avatarRail?.className).toContain("right-0");
+    expect(avatarRail?.className).toContain("translate-x-[calc(100%+0.75rem)]");
+  });
+
+  it("智能体头像去掉边框与 ring 并定位在消息外侧", () => {
+    render(
+      <MessageBubble
+        message={{ id: "a-1", role: "assistant", content: "收到" }}
+      />,
+    );
+
+    const avatar = screen.getByAltText("AI").parentElement;
+    expect(avatar?.className).not.toContain("border");
+    expect(avatar?.className).not.toContain("ring");
+    expect(avatar?.className).not.toContain("shadow-sm");
+    expect(avatar?.className).toContain("rounded-full");
+
+    const avatarRail = avatar?.parentElement;
+    expect(avatarRail?.className).toContain("absolute");
+    expect(avatarRail?.className).toContain("left-0");
+    expect(avatarRail?.className).toContain("-translate-x-[calc(100%+0.75rem)]");
+  });
+});


### PR DESCRIPTION
## 变更说明

本次改动围绕聊天区域的头像展示做了收敛，主要包含以下内容：

- 调整对话消息中的头像样式，去掉用户头像的方形边框，以及智能体头像的圆形边框、ring 和阴影。
- 将用户头像和智能体头像从消息主内容流中抽离，改为定位到消息区域两侧外缘，使头像不再占用消息正文宽度。
- 为聊天流内容层补充左右 gutter，避免头像外移后被滚动容器裁切，同时保持现有消息对齐和阅读流不变。
- 同步移除顶部用户导航头像的边框，统一整体界面视觉。
- 新增 `MessageBubble` 单测，覆盖用户头像与智能体头像的无边框样式和左右外移定位约束。

## 变更原因

这次调整直接对应任务中的界面需求：去掉红框中头像的边框，并将对话中的用户头像移动到消息区域右侧外部，将智能体头像移动到消息区域左侧外部。这样处理后，消息区的视觉层次更清晰，头像不会继续挤压正文宽度，聊天界面的左右结构也更接近目标稿。

## 实现细节

实现上沿用了现有 `MessageBubble`、`ChatStream` 和 `UserAvatar` 的组合方式，没有引入新的业务接口、消息结构或全局样式机制，属于最小干预式的 UI 收敛：

- 在 `MessageBubble` 中通过绝对定位将头像锚定到消息左右外侧。
- 在 `ChatStream` 中增加内容层左右留白，为外移头像预留稳定可视空间。
- 在 `UserNav` 中仅移除顶部用户头像边框，不改变交互逻辑。
- 通过新增单测锁定用户头像无边框、智能体头像无 border/ring/shadow，以及左右外移定位这几个关键回归点。

This PR was written using [Vibe Kanban](https://vibekanban.com)
