### PR TITLE
refactor(agui): 下沉边界校验并收缩守卫层;

### DIFF
--- a/apps/negentropy-ui/lib/adk.ts
+++ b/apps/negentropy-ui/lib/adk.ts
@@ -1,6 +1,14 @@
 import type { BaseEvent, Message } from "@ag-ui/core";
 import { EventType } from "@ag-ui/core";
 import {
+  createActivitySnapshotEvent,
+  createCustomEvent,
+  createMessagesSnapshotEvent,
+  createRawEvent,
+  createStateDeltaEvent,
+  createStateSnapshotEvent,
+  createStepFinishedEvent,
+  createStepStartedEvent,
   createTextMessageStartEvent,
   createTextMessageContentEvent,
   createTextMessageEndEvent,
@@ -8,15 +16,7 @@ import {
   createToolCallArgsEvent,
   createToolCallEndEvent,
   createToolCallResultEvent,
-  createStateDeltaEvent,
-  createStateSnapshotEvent,
-  createActivitySnapshotEvent,
-  createMessagesSnapshotEvent,
-  createStepStartedEvent,
-  createStepFinishedEvent,
-  createRawEvent,
-  createCustomEvent,
-} from "./adk/guards";
+} from "@/lib/agui/factories";
 import {
   createAgUiMessage,
   getEventDelta,

--- a/apps/negentropy-ui/lib/adk/guards.js
+++ b/apps/negentropy-ui/lib/adk/guards.js
@@ -1,153 +1,222 @@
 "use strict";
+
 /**
- * ADK 事件类型守卫
+ * ADK 兼容入口
  *
- * 提供类型安全的运行时检查，替代 `as unknown as` 类型断言
- * 遵循 AGENTS.md 原则：循证工程、类型安全
+ * 该文件用于避免历史 `.js` 导入命中旧实现。
+ * 新代码应优先使用 `@/lib/agui/schema` 与 `@/lib/agui/factories`。
  */
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
+
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.hasBaseEventProps = hasBaseEventProps;
-exports.createTextMessageStartEvent = createTextMessageStartEvent;
+exports.asBaseEvent = asBaseEvent;
+exports.createActivitySnapshotEvent = createActivitySnapshotEvent;
+exports.createCustomEvent = createCustomEvent;
+exports.createMessageWithMeta = createMessageWithMeta;
+exports.createMessagesSnapshotEvent = createMessagesSnapshotEvent;
+exports.createOptimisticTextEvents = createOptimisticTextEvents;
+exports.createRawEvent = createRawEvent;
+exports.createStateDeltaEvent = createStateDeltaEvent;
+exports.createStateSnapshotEvent = createStateSnapshotEvent;
+exports.createStepFinishedEvent = createStepFinishedEvent;
+exports.createStepStartedEvent = createStepStartedEvent;
 exports.createTextMessageContentEvent = createTextMessageContentEvent;
 exports.createTextMessageEndEvent = createTextMessageEndEvent;
-exports.createToolCallStartEvent = createToolCallStartEvent;
+exports.createTextMessageStartEvent = createTextMessageStartEvent;
 exports.createToolCallArgsEvent = createToolCallArgsEvent;
 exports.createToolCallEndEvent = createToolCallEndEvent;
 exports.createToolCallResultEvent = createToolCallResultEvent;
-exports.createStateDeltaEvent = createStateDeltaEvent;
-exports.createStateSnapshotEvent = createStateSnapshotEvent;
-exports.createActivitySnapshotEvent = createActivitySnapshotEvent;
-exports.createMessagesSnapshotEvent = createMessagesSnapshotEvent;
-exports.createStepStartedEvent = createStepStartedEvent;
-exports.createStepFinishedEvent = createStepFinishedEvent;
-exports.createRawEvent = createRawEvent;
-exports.createCustomEvent = createCustomEvent;
-exports.asBaseEvent = asBaseEvent;
-var core_1 = require("@ag-ui/core");
-/**
- * 检查对象是否包含基础事件属性
- */
+exports.createToolCallStartEvent = createToolCallStartEvent;
+exports.hasBaseEventProps = hasBaseEventProps;
+
+const { EventType } = require("@ag-ui/core");
+const { z } = require("zod");
+
+const baseEventPropsSchema = z
+  .object({
+    threadId: z.string(),
+    runId: z.string(),
+    timestamp: z.number().finite(),
+    messageId: z.string().optional(),
+    author: z.string().optional(),
+  })
+  .passthrough();
+
+const baseEventSchema = baseEventPropsSchema
+  .extend({
+    type: z.nativeEnum(EventType),
+  })
+  .passthrough();
+
 function hasBaseEventProps(obj) {
-    if (typeof obj !== "object" || obj === null) {
-        return false;
-    }
-    var props = obj;
-    return (typeof props.threadId === "string" &&
-        typeof props.runId === "string" &&
-        typeof props.timestamp === "number" &&
-        (props.messageId === undefined || typeof props.messageId === "string"));
+  return baseEventPropsSchema.safeParse(obj).success;
 }
-/**
- * 创建 TEXT_MESSAGE_START 事件
- */
+
 function createTextMessageStartEvent(props, role) {
-    return __assign({ type: core_1.EventType.TEXT_MESSAGE_START, role: role }, props);
+  return {
+    type: EventType.TEXT_MESSAGE_START,
+    role,
+    ...props,
+  };
 }
-/**
- * 创建 TEXT_MESSAGE_CONTENT 事件
- */
+
 function createTextMessageContentEvent(props, delta) {
-    return __assign({ type: core_1.EventType.TEXT_MESSAGE_CONTENT, delta: delta }, props);
+  return {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    delta,
+    ...props,
+  };
 }
-/**
- * 创建 TEXT_MESSAGE_END 事件
- */
+
 function createTextMessageEndEvent(props) {
-    return __assign({ type: core_1.EventType.TEXT_MESSAGE_END }, props);
+  return {
+    type: EventType.TEXT_MESSAGE_END,
+    ...props,
+  };
 }
-/**
- * 创建 TOOL_CALL_START 事件
- */
+
 function createToolCallStartEvent(props, toolCallId, toolCallName) {
-    return __assign({ type: core_1.EventType.TOOL_CALL_START, toolCallId: toolCallId, toolCallName: toolCallName }, props);
+  return {
+    type: EventType.TOOL_CALL_START,
+    toolCallId,
+    toolCallName,
+    ...props,
+  };
 }
-/**
- * 创建 TOOL_CALL_ARGS 事件
- */
+
 function createToolCallArgsEvent(props, toolCallId, delta) {
-    return __assign({ type: core_1.EventType.TOOL_CALL_ARGS, toolCallId: toolCallId, delta: delta }, props);
+  return {
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId,
+    delta,
+    ...props,
+  };
 }
-/**
- * 创建 TOOL_CALL_END 事件
- */
+
 function createToolCallEndEvent(props, toolCallId) {
-    return __assign({ type: core_1.EventType.TOOL_CALL_END, toolCallId: toolCallId }, props);
+  return {
+    type: EventType.TOOL_CALL_END,
+    toolCallId,
+    ...props,
+  };
 }
-/**
- * 创建 TOOL_CALL_RESULT 事件
- */
+
 function createToolCallResultEvent(props, toolCallId, content) {
-    return __assign({ type: core_1.EventType.TOOL_CALL_RESULT, toolCallId: toolCallId, content: content }, props);
+  return {
+    type: EventType.TOOL_CALL_RESULT,
+    toolCallId,
+    content,
+    ...props,
+  };
 }
-/**
- * 创建 STATE_DELTA 事件
- */
+
 function createStateDeltaEvent(props, delta) {
-    return __assign({ type: core_1.EventType.STATE_DELTA, delta: delta }, props);
+  return {
+    type: EventType.STATE_DELTA,
+    delta,
+    ...props,
+  };
 }
-/**
- * 创建 STATE_SNAPSHOT 事件
- */
+
 function createStateSnapshotEvent(props, snapshot) {
-    return __assign({ type: core_1.EventType.STATE_SNAPSHOT, snapshot: snapshot }, props);
+  return {
+    type: EventType.STATE_SNAPSHOT,
+    snapshot,
+    ...props,
+  };
 }
-/**
- * 创建 ACTIVITY_SNAPSHOT 事件
- */
+
 function createActivitySnapshotEvent(props, activityType, content) {
-    return __assign({ type: core_1.EventType.ACTIVITY_SNAPSHOT, activityType: activityType, content: content }, props);
+  return {
+    type: EventType.ACTIVITY_SNAPSHOT,
+    activityType,
+    content,
+    ...props,
+  };
 }
-/**
- * 创建 MESSAGES_SNAPSHOT 事件
- */
+
 function createMessagesSnapshotEvent(props, messages) {
-    return __assign({ type: core_1.EventType.MESSAGES_SNAPSHOT, messages: messages }, props);
+  return {
+    type: EventType.MESSAGES_SNAPSHOT,
+    messages,
+    ...props,
+  };
 }
-/**
- * 创建 STEP_STARTED 事件
- */
+
 function createStepStartedEvent(props, stepId, stepName) {
-    return __assign({ type: core_1.EventType.STEP_STARTED, stepId: stepId, stepName: stepName }, props);
+  return {
+    type: EventType.STEP_STARTED,
+    stepId,
+    stepName,
+    ...props,
+  };
 }
-/**
- * 创建 STEP_FINISHED 事件
- */
+
 function createStepFinishedEvent(props, stepId, result) {
-    return __assign({ type: core_1.EventType.STEP_FINISHED, stepId: stepId, result: result }, props);
+  return {
+    type: EventType.STEP_FINISHED,
+    stepId,
+    result,
+    ...props,
+  };
 }
-/**
- * 创建 RAW 事件
- */
+
 function createRawEvent(props, data) {
-    return __assign({ type: core_1.EventType.RAW, data: data }, props);
+  return {
+    type: EventType.RAW,
+    data,
+    ...props,
+  };
 }
-/**
- * 创建 CUSTOM 事件
- */
+
 function createCustomEvent(props, eventType, eventData) {
-    return __assign({ type: core_1.EventType.CUSTOM, eventType: eventType, data: eventData }, props);
+  return {
+    type: EventType.CUSTOM,
+    eventType,
+    data: eventData,
+    ...props,
+  };
 }
-/**
- * 类型守卫：安全地将未知类型转换为 BaseEvent
- *
- * 注意：这仅用于已知的、受信任的事件结构
- * 对于不受信任的输入，应使用 Zod 验证
- */
+
+function createOptimisticTextEvents(input) {
+  return [
+    createTextMessageStartEvent(
+      {
+        threadId: input.threadId,
+        runId: input.runId,
+        messageId: input.messageId,
+        timestamp: input.timestamp,
+      },
+      input.role,
+    ),
+    createTextMessageContentEvent(
+      {
+        threadId: input.threadId,
+        runId: input.runId,
+        messageId: input.messageId,
+        timestamp: input.timestamp,
+      },
+      input.content,
+    ),
+    createTextMessageEndEvent({
+      threadId: input.threadId,
+      runId: input.runId,
+      messageId: input.messageId,
+      timestamp: input.timestamp,
+    }),
+  ];
+}
+
+function createMessageWithMeta(input) {
+  return {
+    id: input.id,
+    role: input.role,
+    content: input.content,
+    createdAt: input.createdAt,
+    author: input.author,
+    runId: input.runId,
+  };
+}
+
 function asBaseEvent(event) {
-    if (!hasBaseEventProps(event)) {
-        throw new Error("Invalid event: missing base properties");
-    }
-    // 扩展检查可以在这里添加
-    return event;
+  return baseEventSchema.parse(event);
 }

--- a/apps/negentropy-ui/lib/adk/guards.ts
+++ b/apps/negentropy-ui/lib/adk/guards.ts
@@ -1,408 +1,49 @@
 /**
- * ADK 事件类型守卫
+ * ADK 兼容入口
  *
- * 提供类型安全的运行时检查，替代 `as unknown as` 类型断言
- * 遵循 AGENTS.md 原则：循证工程、类型安全
+ * 运行时校验已下沉到 `@/lib/agui/schema`，
+ * 事件构造已迁移到 `@/lib/agui/factories`。
+ * 该文件仅保留兼容导出，避免旧调用面直接断裂。
  */
 
-import type { BaseEvent, Message } from "@ag-ui/core";
-import { EventType } from "@ag-ui/core";
-import type {
-  AgUiMessage,
-  TextMessageStartEvent,
-  TextMessageContentEvent,
-  TextMessageEndEvent,
-  ToolCallStartEvent,
-  ToolCallArgsEvent,
-  ToolCallEndEvent,
-  ToolCallResultEvent,
-  StateDeltaEvent,
-  StateSnapshotEvent,
-  ActivitySnapshotEvent,
-  MessagesSnapshotEvent,
-  StepStartedEvent,
-  StepFinishedEvent,
-  RawEvent,
-  CustomEvent,
-} from "@/types/agui";
-import { createAgUiMessage } from "@/types/agui";
+import type { BaseEvent } from "@ag-ui/core";
+import { parseBaseEvent, safeParseBaseEventProps } from "@/lib/agui/schema";
+import type { BaseEventProps } from "@/types/agui";
+
+export {
+  createActivitySnapshotEvent,
+  createCustomEvent,
+  createMessageWithMeta,
+  createMessagesSnapshotEvent,
+  createRawEvent,
+  createStateDeltaEvent,
+  createStateSnapshotEvent,
+  createStepFinishedEvent,
+  createStepStartedEvent,
+  createTextMessageContentEvent,
+  createTextMessageEndEvent,
+  createTextMessageStartEvent,
+  createToolCallArgsEvent,
+  createToolCallEndEvent,
+  createToolCallResultEvent,
+  createToolCallStartEvent,
+} from "@/lib/agui/factories";
+export { createOptimisticTextEvents } from "@/types/agui";
 
 /**
- * 检查对象是否包含基础事件属性
- */
-export function hasBaseEventProps(obj: unknown): obj is {
-  threadId: string;
-  runId: string;
-  timestamp: number;
-  messageId?: string;
-} {
-  if (typeof obj !== "object" || obj === null) {
-    return false;
-  }
-  const props = obj as Record<string, unknown>;
-  return (
-    typeof props.threadId === "string" &&
-    typeof props.runId === "string" &&
-    typeof props.timestamp === "number" &&
-    (props.messageId === undefined || typeof props.messageId === "string")
-  );
-}
-
-/**
- * 创建 TEXT_MESSAGE_START 事件
- */
-export function createTextMessageStartEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-    author?: string;
-  },
-  role: "user" | "agent" | "system",
-): TextMessageStartEvent {
-  return {
-    type: EventType.TEXT_MESSAGE_START,
-    role,
-    ...props,
-  };
-}
-
-/**
- * 创建 TEXT_MESSAGE_CONTENT 事件
- */
-export function createTextMessageContentEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  delta: string,
-): TextMessageContentEvent {
-  return {
-    type: EventType.TEXT_MESSAGE_CONTENT,
-    delta,
-    ...props,
-  };
-}
-
-/**
- * 创建 TEXT_MESSAGE_END 事件
- */
-export function createTextMessageEndEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-): TextMessageEndEvent {
-  return {
-    type: EventType.TEXT_MESSAGE_END,
-    ...props,
-  };
-}
-
-/**
- * 创建 TOOL_CALL_START 事件
- */
-export function createToolCallStartEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  toolCallId: string,
-  toolCallName: string,
-): ToolCallStartEvent {
-  return {
-    type: EventType.TOOL_CALL_START,
-    toolCallId,
-    toolCallName,
-    ...props,
-  };
-}
-
-/**
- * 创建 TOOL_CALL_ARGS 事件
- */
-export function createToolCallArgsEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  toolCallId: string,
-  delta: string,
-): ToolCallArgsEvent {
-  return {
-    type: EventType.TOOL_CALL_ARGS,
-    toolCallId,
-    delta,
-    ...props,
-  };
-}
-
-/**
- * 创建 TOOL_CALL_END 事件
- */
-export function createToolCallEndEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  toolCallId: string,
-): ToolCallEndEvent {
-  return {
-    type: EventType.TOOL_CALL_END,
-    toolCallId,
-    ...props,
-  };
-}
-
-/**
- * 创建 TOOL_CALL_RESULT 事件
- */
-export function createToolCallResultEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  toolCallId: string,
-  content: string,
-): ToolCallResultEvent {
-  return {
-    type: EventType.TOOL_CALL_RESULT,
-    toolCallId,
-    content,
-    ...props,
-  };
-}
-
-/**
- * 创建 STATE_DELTA 事件
- */
-export function createStateDeltaEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  delta: Record<string, unknown>,
-): StateDeltaEvent {
-  return {
-    type: EventType.STATE_DELTA,
-    delta,
-    ...props,
-  };
-}
-
-/**
- * 创建 STATE_SNAPSHOT 事件
- */
-export function createStateSnapshotEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  snapshot: Record<string, unknown>,
-): StateSnapshotEvent {
-  return {
-    type: EventType.STATE_SNAPSHOT,
-    snapshot,
-    ...props,
-  };
-}
-
-/**
- * 创建 ACTIVITY_SNAPSHOT 事件
- */
-export function createActivitySnapshotEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  activityType: string,
-  content: Record<string, unknown>,
-): ActivitySnapshotEvent {
-  return {
-    type: EventType.ACTIVITY_SNAPSHOT,
-    activityType,
-    content,
-    ...props,
-  };
-}
-
-/**
- * 创建 MESSAGES_SNAPSHOT 事件
- */
-export function createMessagesSnapshotEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  messages: unknown[],
-): MessagesSnapshotEvent {
-  return {
-    type: EventType.MESSAGES_SNAPSHOT,
-    messages,
-    ...props,
-  };
-}
-
-/**
- * 创建 STEP_STARTED 事件
- */
-export function createStepStartedEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  stepId: string,
-  stepName: string,
-): StepStartedEvent {
-  return {
-    type: EventType.STEP_STARTED,
-    stepId,
-    stepName,
-    ...props,
-  };
-}
-
-/**
- * 创建 STEP_FINISHED 事件
- */
-export function createStepFinishedEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  stepId: string,
-  result: unknown,
-): StepFinishedEvent {
-  return {
-    type: EventType.STEP_FINISHED,
-    stepId,
-    result,
-    ...props,
-  };
-}
-
-/**
- * 创建 RAW 事件
- */
-export function createRawEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  data: Record<string, unknown>,
-): RawEvent {
-  return {
-    type: EventType.RAW,
-    data,
-    ...props,
-  };
-}
-
-/**
- * 创建 CUSTOM 事件
- */
-export function createCustomEvent(
-  props: {
-    threadId: string;
-    runId: string;
-    timestamp: number;
-    messageId: string;
-  },
-  eventType: string,
-  eventData: unknown,
-): CustomEvent {
-  return {
-    type: EventType.CUSTOM,
-    eventType,
-    data: eventData,
-    ...props,
-  };
-}
-
-export function createOptimisticTextEvents(input: {
-  threadId: string;
-  runId: string;
-  messageId: string;
-  timestamp: number;
-  role: "user" | "agent" | "system";
-  content: string;
-}): BaseEvent[] {
-  return [
-    createTextMessageStartEvent(
-      {
-        threadId: input.threadId,
-        runId: input.runId,
-        messageId: input.messageId,
-        timestamp: input.timestamp,
-      },
-      input.role,
-    ),
-    createTextMessageContentEvent(
-      {
-        threadId: input.threadId,
-        runId: input.runId,
-        messageId: input.messageId,
-        timestamp: input.timestamp,
-      },
-      input.content,
-    ),
-    createTextMessageEndEvent({
-      threadId: input.threadId,
-      runId: input.runId,
-      messageId: input.messageId,
-      timestamp: input.timestamp,
-    }),
-  ];
-}
-
-export function createMessageWithMeta(input: {
-  id: string;
-  role: Message["role"];
-  content: Message["content"];
-  createdAt?: Date;
-  author?: string;
-  runId?: string;
-}): AgUiMessage {
-  return createAgUiMessage(input);
-}
-
-/**
- * 类型守卫：安全地将未知类型转换为 BaseEvent
+ * 兼容旧调用面的基础事件属性检查。
  *
- * 注意：这仅用于已知的、受信任的事件结构
- * 对于不受信任的输入，应使用 Zod 验证
+ * 新代码应直接使用 `@/lib/agui/schema` 中的 validator。
+ */
+export function hasBaseEventProps(obj: unknown): obj is BaseEventProps {
+  return safeParseBaseEventProps(obj).success;
+}
+
+/**
+ * 兼容旧调用面的 BaseEvent 解析。
+ *
+ * 新代码应直接使用 `parseBaseEvent` / `parseAgUiEvent`。
  */
 export function asBaseEvent(event: unknown): BaseEvent {
-  if (!hasBaseEventProps(event)) {
-    throw new Error("Invalid event: missing base properties");
-  }
-  // 扩展检查可以在这里添加
-  return event as unknown as BaseEvent;
+  return parseBaseEvent(event);
 }

--- a/apps/negentropy-ui/lib/agui/factories.ts
+++ b/apps/negentropy-ui/lib/agui/factories.ts
@@ -1,0 +1,212 @@
+import type { Message } from "@ag-ui/core";
+import { EventType } from "@ag-ui/core";
+import type {
+  ActivitySnapshotEvent,
+  AgUiMessage,
+  BaseEventProps,
+  CustomEvent,
+  MessagesSnapshotEvent,
+  RawEvent,
+  StateDeltaEvent,
+  StateSnapshotEvent,
+  StepFinishedEvent,
+  StepStartedEvent,
+  TextMessageContentEvent,
+  TextMessageEndEvent,
+  TextMessageStartEvent,
+  ToolCallArgsEvent,
+  ToolCallEndEvent,
+  ToolCallResultEvent,
+  ToolCallStartEvent,
+} from "@/types/agui";
+import { createAgUiMessage } from "@/types/agui";
+
+type RequiredMessageEventProps = BaseEventProps & { messageId: string };
+
+export function createTextMessageStartEvent(
+  props: RequiredMessageEventProps,
+  role: "user" | "agent" | "system",
+): TextMessageStartEvent {
+  return {
+    type: EventType.TEXT_MESSAGE_START,
+    role,
+    ...props,
+  };
+}
+
+export function createTextMessageContentEvent(
+  props: RequiredMessageEventProps,
+  delta: string,
+): TextMessageContentEvent {
+  return {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    delta,
+    ...props,
+  };
+}
+
+export function createTextMessageEndEvent(
+  props: RequiredMessageEventProps,
+): TextMessageEndEvent {
+  return {
+    type: EventType.TEXT_MESSAGE_END,
+    ...props,
+  };
+}
+
+export function createToolCallStartEvent(
+  props: RequiredMessageEventProps,
+  toolCallId: string,
+  toolCallName: string,
+): ToolCallStartEvent {
+  return {
+    type: EventType.TOOL_CALL_START,
+    toolCallId,
+    toolCallName,
+    ...props,
+  };
+}
+
+export function createToolCallArgsEvent(
+  props: RequiredMessageEventProps,
+  toolCallId: string,
+  delta: string,
+): ToolCallArgsEvent {
+  return {
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId,
+    delta,
+    ...props,
+  };
+}
+
+export function createToolCallEndEvent(
+  props: RequiredMessageEventProps,
+  toolCallId: string,
+): ToolCallEndEvent {
+  return {
+    type: EventType.TOOL_CALL_END,
+    toolCallId,
+    ...props,
+  };
+}
+
+export function createToolCallResultEvent(
+  props: RequiredMessageEventProps,
+  toolCallId: string,
+  content: string,
+): ToolCallResultEvent {
+  return {
+    type: EventType.TOOL_CALL_RESULT,
+    toolCallId,
+    content,
+    ...props,
+  };
+}
+
+export function createStateDeltaEvent(
+  props: RequiredMessageEventProps,
+  delta: Record<string, unknown>,
+): StateDeltaEvent {
+  return {
+    type: EventType.STATE_DELTA,
+    delta,
+    ...props,
+  };
+}
+
+export function createStateSnapshotEvent(
+  props: RequiredMessageEventProps,
+  snapshot: Record<string, unknown>,
+): StateSnapshotEvent {
+  return {
+    type: EventType.STATE_SNAPSHOT,
+    snapshot,
+    ...props,
+  };
+}
+
+export function createActivitySnapshotEvent(
+  props: RequiredMessageEventProps,
+  activityType: string,
+  content: Record<string, unknown>,
+): ActivitySnapshotEvent {
+  return {
+    type: EventType.ACTIVITY_SNAPSHOT,
+    activityType,
+    content,
+    ...props,
+  };
+}
+
+export function createMessagesSnapshotEvent(
+  props: RequiredMessageEventProps,
+  messages: unknown[],
+): MessagesSnapshotEvent {
+  return {
+    type: EventType.MESSAGES_SNAPSHOT,
+    messages,
+    ...props,
+  };
+}
+
+export function createStepStartedEvent(
+  props: RequiredMessageEventProps,
+  stepId: string,
+  stepName: string,
+): StepStartedEvent {
+  return {
+    type: EventType.STEP_STARTED,
+    stepId,
+    stepName,
+    ...props,
+  };
+}
+
+export function createStepFinishedEvent(
+  props: RequiredMessageEventProps,
+  stepId: string,
+  result: unknown,
+): StepFinishedEvent {
+  return {
+    type: EventType.STEP_FINISHED,
+    stepId,
+    result,
+    ...props,
+  };
+}
+
+export function createRawEvent(
+  props: RequiredMessageEventProps,
+  data: Record<string, unknown>,
+): RawEvent {
+  return {
+    type: EventType.RAW,
+    data,
+    ...props,
+  };
+}
+
+export function createCustomEvent(
+  props: RequiredMessageEventProps,
+  eventType: string,
+  eventData: unknown,
+): CustomEvent {
+  return {
+    type: EventType.CUSTOM,
+    eventType,
+    data: eventData,
+    ...props,
+  };
+}
+
+export function createMessageWithMeta(input: {
+  id: string;
+  role: Message["role"];
+  content: Message["content"];
+  createdAt?: Date;
+  author?: string;
+  runId?: string;
+}): AgUiMessage {
+  return createAgUiMessage(input);
+}

--- a/apps/negentropy-ui/lib/agui/schema.ts
+++ b/apps/negentropy-ui/lib/agui/schema.ts
@@ -1,0 +1,145 @@
+import type { BaseEvent } from "@ag-ui/core";
+import { EventType } from "@ag-ui/core";
+import { z } from "zod";
+import type { AguiEvent, BaseEventProps } from "@/types/agui";
+
+const metadataRecordSchema = z.record(z.unknown());
+
+export const baseEventPropsSchema = z
+  .object({
+    threadId: z.string(),
+    runId: z.string(),
+    timestamp: z.number().finite(),
+    messageId: z.string().optional(),
+    author: z.string().optional(),
+  })
+  .passthrough();
+
+export const baseEventSchema = baseEventPropsSchema
+  .extend({
+    type: z.nativeEnum(EventType),
+  })
+  .passthrough();
+
+const textMessageStartEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TEXT_MESSAGE_START),
+  role: z.enum(["user", "agent", "system"]),
+});
+
+const textMessageContentEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TEXT_MESSAGE_CONTENT),
+  delta: z.string(),
+});
+
+const textMessageEndEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TEXT_MESSAGE_END),
+});
+
+const toolCallStartEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TOOL_CALL_START),
+  toolCallId: z.string(),
+  toolCallName: z.string(),
+});
+
+const toolCallArgsEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TOOL_CALL_ARGS),
+  toolCallId: z.string(),
+  delta: z.string(),
+});
+
+const toolCallEndEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TOOL_CALL_END),
+  toolCallId: z.string(),
+});
+
+const toolCallResultEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.TOOL_CALL_RESULT),
+  toolCallId: z.string(),
+  content: z.string(),
+});
+
+const stateDeltaEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.STATE_DELTA),
+  delta: metadataRecordSchema,
+});
+
+const stateSnapshotEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.STATE_SNAPSHOT),
+  snapshot: metadataRecordSchema,
+});
+
+const activitySnapshotEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.ACTIVITY_SNAPSHOT),
+  activityType: z.string(),
+  content: metadataRecordSchema,
+});
+
+const messagesSnapshotEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.MESSAGES_SNAPSHOT),
+  messages: z.array(z.unknown()),
+});
+
+const stepStartedEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.STEP_STARTED),
+  stepId: z.string(),
+  stepName: z.string(),
+});
+
+const stepFinishedEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.STEP_FINISHED),
+  stepId: z.string(),
+  result: z.unknown(),
+});
+
+const rawEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.RAW),
+  data: metadataRecordSchema,
+});
+
+const customEventSchema = baseEventPropsSchema.extend({
+  type: z.literal(EventType.CUSTOM),
+  eventType: z.string(),
+  data: z.unknown(),
+});
+
+export const agUiEventSchema = z.discriminatedUnion("type", [
+  textMessageStartEventSchema,
+  textMessageContentEventSchema,
+  textMessageEndEventSchema,
+  toolCallStartEventSchema,
+  toolCallArgsEventSchema,
+  toolCallEndEventSchema,
+  toolCallResultEventSchema,
+  stateDeltaEventSchema,
+  stateSnapshotEventSchema,
+  activitySnapshotEventSchema,
+  messagesSnapshotEventSchema,
+  stepStartedEventSchema,
+  stepFinishedEventSchema,
+  rawEventSchema,
+  customEventSchema,
+]) as z.ZodType<AguiEvent>;
+
+export function parseBaseEventProps(input: unknown): BaseEventProps {
+  return baseEventPropsSchema.parse(input);
+}
+
+export function safeParseBaseEventProps(input: unknown) {
+  return baseEventPropsSchema.safeParse(input);
+}
+
+export function parseBaseEvent(input: unknown): BaseEvent {
+  return baseEventSchema.parse(input) as BaseEvent;
+}
+
+export function safeParseBaseEvent(input: unknown) {
+  return baseEventSchema.safeParse(input);
+}
+
+export function parseAgUiEvent(input: unknown): AguiEvent {
+  return agUiEventSchema.parse(input);
+}
+
+export function safeParseAgUiEvent(input: unknown) {
+  return agUiEventSchema.safeParse(input);
+}

--- a/apps/negentropy-ui/tests/helpers/agui.ts
+++ b/apps/negentropy-ui/tests/helpers/agui.ts
@@ -3,7 +3,7 @@ import {
   createTextMessageContentEvent,
   createTextMessageEndEvent,
   createTextMessageStartEvent,
-} from "@/lib/adk/guards";
+} from "@/lib/agui/factories";
 import { createAgUiMessage, type AgUiEvent, type AgUiMessage } from "@/types/agui";
 
 export function createTestMessage(input: {

--- a/apps/negentropy-ui/tests/unit/lib/agui/schema.test.ts
+++ b/apps/negentropy-ui/tests/unit/lib/agui/schema.test.ts
@@ -1,0 +1,69 @@
+import { EventType } from "@ag-ui/core";
+import {
+  parseAgUiEvent,
+  parseBaseEvent,
+  safeParseAgUiEvent,
+  safeParseBaseEventProps,
+} from "@/lib/agui/schema";
+
+describe("AGUI schema validators", () => {
+  it("accepts valid base event props", () => {
+    const result = safeParseBaseEventProps({
+      threadId: "thread-1",
+      runId: "run-1",
+      timestamp: 123,
+      messageId: "message-1",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid base event props", () => {
+    const result = safeParseBaseEventProps({
+      threadId: "thread-1",
+      runId: 123,
+      timestamp: "bad",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("parses generic base events with type metadata", () => {
+    const event = parseBaseEvent({
+      type: EventType.TEXT_MESSAGE_END,
+      threadId: "thread-1",
+      runId: "run-1",
+      timestamp: 123,
+      messageId: "message-1",
+    });
+
+    expect(event.type).toBe(EventType.TEXT_MESSAGE_END);
+  });
+
+  it("parses typed AGUI events", () => {
+    const event = parseAgUiEvent({
+      type: EventType.TOOL_CALL_START,
+      threadId: "thread-1",
+      runId: "run-1",
+      timestamp: 123,
+      messageId: "message-1",
+      toolCallId: "call-1",
+      toolCallName: "search",
+    });
+
+    expect(event.type).toBe(EventType.TOOL_CALL_START);
+  });
+
+  it("rejects typed AGUI events with mismatched payload shape", () => {
+    const result = safeParseAgUiEvent({
+      type: EventType.TOOL_CALL_START,
+      threadId: "thread-1",
+      runId: "run-1",
+      timestamp: 123,
+      messageId: "message-1",
+      toolCallId: "call-1",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/negentropy-ui/types/agui.ts
+++ b/apps/negentropy-ui/types/agui.ts
@@ -7,6 +7,7 @@
 
 import type { BaseEvent, Message } from "@ag-ui/core";
 import { EventType } from "@ag-ui/core";
+import { safeParseBaseEventProps } from "@/lib/agui/schema";
 
 /**
  * 基础事件属性
@@ -347,15 +348,7 @@ export function createOptimisticTextEvents(input: {
  * 类型守卫：检查是否为 BaseEventProps
  */
 export function isBaseEventProps(obj: unknown): obj is BaseEventProps {
-  if (typeof obj !== "object" || obj === null) {
-    return false;
-  }
-  const props = obj as Partial<BaseEventProps>;
-  return (
-    typeof props.threadId === "string" &&
-    typeof props.runId === "string" &&
-    typeof props.timestamp === "number"
-  );
+  return safeParseBaseEventProps(obj).success;
 }
 
 /**


### PR DESCRIPTION
## 背景
- 当前 AGUI 事件链路里，`guards.ts` 同时承担边界输入校验、受信任输入转换和内部事件工厂三类职责。
- 这种混合职责会让类型演进时的失败点分散在手写 guard、局部强转和工厂实现之间，增加回归风险。
- 本 PR 将受信任输入转换进一步下沉到统一 schema/validator 层，并把 `guards` 收缩为兼容入口。

## 核心变更
- 新增统一 AGUI schema/validator 层，使用 `zod` 定义基础事件属性、基础事件和已支持的 AGUI 事件联合校验。
- 新增内部 event factory 层，承接文本消息、tool call、state snapshot、custom/raw event 等构造逻辑。
- `lib/adk.ts` 与测试 helper 改为直接依赖新 factory，不再从 `guards.ts` 取内部构造能力。
- `guards.ts` 收缩为兼容导出，旧的 `hasBaseEventProps` / `asBaseEvent` 改为委托统一 validator。
- 同步收敛历史 `guards.js`，避免命中旧的手写 guard + 强转路径。
- 新增 schema 单元测试，覆盖合法/非法 base event 与 typed AGUI event 的 parse 行为。

## 变更原因
- 这是上一轮 AGUI 扩展类型收敛后的继续加固，目标是彻底分离“边界验证”和“内部访问”，降低下一轮类型演进时的构建失败与运行时漂移风险。
- 通过把 validator、factory、兼容层分开，系统边界更清晰，后续 `AdkEventPayload` 等协议演进也更容易纳入统一约束。

## 重要实现细节
- validator 层采用 `zod`，复用现有依赖与协议建模范式。
- 本次不修改外部 payload 结构，不改变消息渲染顺序、事件语义或 hydration 逻辑。
- 兼容层仍保留旧导出，避免现有调用面直接断裂。

## 验证证据
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 新增 `tests/unit/lib/agui/schema.test.ts`，覆盖 validator 的成功/失败路径

## Next Best Action
- 继续把 `AdkEventPayload` 的边界解析也纳入同一 validator 体系，让 `lib/adk.ts` 进一步收敛成显式 parse 后再归一化的结构。
