### PR TITLE
refactor(adk): 下沉载荷边界校验并显式解析;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -1,6 +1,9 @@
 import { EventEncoder } from "@ag-ui/encoder";
 import { BaseEvent, EventType } from "@ag-ui/core";
-import { AdkEventPayload, AdkMessageStreamNormalizer } from "@/lib/adk";
+import {
+  AdkMessageStreamNormalizer,
+  safeParseAdkEventPayload,
+} from "@/lib/adk";
 import { buildAuthHeaders } from "@/lib/sso";
 import {
   errorResponse as aguiErrorResponse,
@@ -188,9 +191,13 @@ export async function POST(request: Request) {
               }
 
               try {
-                const parsed = JSON.parse(jsonText) as AdkEventPayload;
+                const rawPayload = JSON.parse(jsonText) as unknown;
+                const parsedResult = safeParseAdkEventPayload(rawPayload);
+                if (!parsedResult.success) {
+                  throw new Error("Invalid ADK event payload");
+                }
                 const events = normalizer
-                  .consume(parsed, {
+                  .consume(parsedResult.data, {
                     threadId: resolvedThreadId,
                     runId: resolvedRunId,
                   })

--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -18,6 +18,7 @@ import { LogBufferPanel } from "../components/ui/LogBufferPanel";
 import { SessionList } from "../components/ui/SessionList";
 import { StateSnapshot } from "../components/ui/StateSnapshot";
 import { AdkEventPayload } from "@/lib/adk";
+import { collectAdkEventPayloads } from "@/lib/adk";
 
 import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 
@@ -580,9 +581,13 @@ export function HomeBody({
         if (!response.ok) {
           return;
         }
-        const events = Array.isArray(payload.events)
-          ? (payload.events as AdkEventPayload[])
-          : [];
+        const { payloads: events, invalidCount } = collectAdkEventPayloads(payload.events);
+        if (invalidCount > 0) {
+          addLog("warn", "session_detail_events_filtered", {
+            sessionId: id,
+            invalidCount,
+          });
+        }
         const hydrated = hydrateSessionDetail(events, id);
         const currentLoadedSessionId = loadedSessionIdRef.current;
         const currentRawEvents = rawEventsRef.current;

--- a/apps/negentropy-ui/hooks/useSessionManager.ts
+++ b/apps/negentropy-ui/hooks/useSessionManager.ts
@@ -15,8 +15,8 @@ import { createSessionLabel } from "@/utils/session";
 import { HttpAgent } from "@ag-ui/client";
 import { Message } from "@ag-ui/core";
 import {
-  AdkEventPayload,
   adkEventToAguiEvents,
+  collectAdkEventPayloads,
   adkEventsToMessages,
   adkEventsToSnapshot,
 } from "@/lib/adk";
@@ -141,9 +141,7 @@ export function useSessionManager(
         if (!response.ok) {
           return;
         }
-        const events = (Array.isArray(payload.events)
-          ? (payload.events as AdkEventPayload[])
-          : []) as AdkEventPayload[];
+        const { payloads: events, invalidCount } = collectAdkEventPayloads(payload.events);
         const messages = adkEventsToMessages(events);
         const snapshot = adkEventsToSnapshot(events);
         const mappedEvents = events.flatMap(adkEventToAguiEvents);
@@ -154,7 +152,11 @@ export function useSessionManager(
           agent.setState(snapshot || {});
         }
 
-        addLog?.("info", "session_detail_loaded", { sessionId: id, messageCount: messages.length });
+        addLog?.("info", "session_detail_loaded", {
+          sessionId: id,
+          messageCount: messages.length,
+          invalidEventCount: invalidCount,
+        });
       } catch (error) {
         setConnectionWithMetrics?.("error");
         addLog?.("error", "load_session_detail_failed", {

--- a/apps/negentropy-ui/lib/adk.ts
+++ b/apps/negentropy-ui/lib/adk.ts
@@ -23,57 +23,14 @@ import {
   getEventMessageId,
   getEventRole,
 } from "@/types/agui";
-
-// ... (imports)
-
-export type AdkEventPayload = {
-  id: string;
-  threadId?: string;
-  runId?: string;
-  timestamp?: number;
-  author?: string;
-  content?: {
-    parts?: Array<{
-      text?: string;
-      type?: string;
-      functionCall?: {
-        id: string;
-        name: string;
-        args: Record<string, unknown>;
-      };
-      functionResponse?: {
-        id: string;
-        name: string;
-        response: {
-          result: unknown;
-        };
-      };
-    }>;
-  };
-  message?: {
-    role: string;
-    content: string | Array<{ text?: string; type?: string }>;
-    // Standard OpenAI/ADK tool calls
-    tool_calls?: Array<{
-      id: string;
-      type: "function";
-      function: { name: string; arguments: string };
-    }>;
-    // Standard OpenAI/ADK tool result
-    tool_call_id?: string;
-  };
-  actions?: {
-    stateDelta?: Record<string, unknown>;
-    artifactDelta?: Record<string, unknown>;
-    stateSnapshot?: Record<string, unknown>;
-    messagesSnapshot?: Message[];
-    stepStarted?: { id: string; name: string };
-    stepFinished?: { id: string; result: unknown };
-  };
-  delta?: string;
-  raw?: Record<string, unknown>;
-  custom?: { type: string; data: unknown };
-};
+import type { AdkEventPayload } from "@/lib/adk/schema";
+export {
+  adkEventPayloadSchema,
+  collectAdkEventPayloads,
+  parseAdkEventPayload,
+  safeParseAdkEventPayload,
+  type AdkEventPayload,
+} from "@/lib/adk/schema";
 
 type NormalizedRole = "user" | "agent" | "system";
 

--- a/apps/negentropy-ui/lib/adk/schema.ts
+++ b/apps/negentropy-ui/lib/adk/schema.ts
@@ -1,0 +1,142 @@
+import type { Message } from "@ag-ui/core";
+import { z } from "zod";
+
+const metadataRecordSchema = z.record(z.unknown());
+const looseObjectSchema = z.object({}).passthrough();
+
+const adkFunctionCallSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    args: metadataRecordSchema,
+  })
+  .passthrough();
+
+const adkFunctionResponseSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    response: looseObjectSchema.passthrough(),
+  })
+  .passthrough();
+
+const adkContentPartSchema = z
+  .object({
+    text: z.string().optional(),
+    type: z.string().optional(),
+    functionCall: adkFunctionCallSchema.optional(),
+    functionResponse: adkFunctionResponseSchema.optional(),
+  })
+  .passthrough();
+
+const adkMessageContentPartSchema = z
+  .object({
+    text: z.string().optional(),
+    type: z.string().optional(),
+  })
+  .passthrough();
+
+const adkToolCallSchema = z
+  .object({
+    id: z.string(),
+    type: z.literal("function"),
+    function: z
+      .object({
+        name: z.string(),
+        arguments: z.string(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const adkMessageSchema = z
+  .object({
+    role: z.string(),
+    content: z.union([z.string(), z.array(adkMessageContentPartSchema)]),
+    tool_calls: z.array(adkToolCallSchema).optional(),
+    tool_call_id: z.string().optional(),
+  })
+  .passthrough();
+
+const adkActionsSchema = z
+  .object({
+    stateDelta: metadataRecordSchema.optional(),
+    artifactDelta: metadataRecordSchema.optional(),
+    stateSnapshot: metadataRecordSchema.optional(),
+    messagesSnapshot: z.array(z.custom<Message>()).optional(),
+    stepStarted: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+      })
+      .passthrough()
+      .optional(),
+    stepFinished: z
+      .object({
+        id: z.string(),
+        result: z.unknown(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export const adkEventPayloadSchema = z
+  .object({
+    id: z.string(),
+    threadId: z.string().optional(),
+    runId: z.string().optional(),
+    timestamp: z.number().finite().optional(),
+    author: z.string().optional(),
+    content: z
+      .object({
+        parts: z.array(adkContentPartSchema).optional(),
+      })
+      .passthrough()
+      .optional(),
+    message: adkMessageSchema.optional(),
+    actions: adkActionsSchema.optional(),
+    delta: z.string().optional(),
+    raw: metadataRecordSchema.optional(),
+    custom: z
+      .object({
+        type: z.string(),
+        data: z.unknown(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type AdkEventPayload = z.infer<typeof adkEventPayloadSchema>;
+
+export function parseAdkEventPayload(input: unknown): AdkEventPayload {
+  return adkEventPayloadSchema.parse(input);
+}
+
+export function safeParseAdkEventPayload(input: unknown) {
+  return adkEventPayloadSchema.safeParse(input);
+}
+
+export function collectAdkEventPayloads(input: unknown): {
+  payloads: AdkEventPayload[];
+  invalidCount: number;
+} {
+  if (!Array.isArray(input)) {
+    return { payloads: [], invalidCount: 0 };
+  }
+
+  const payloads: AdkEventPayload[] = [];
+  let invalidCount = 0;
+
+  input.forEach((item) => {
+    const parsed = safeParseAdkEventPayload(item);
+    if (parsed.success) {
+      payloads.push(parsed.data);
+      return;
+    }
+    invalidCount += 1;
+  });
+
+  return { payloads, invalidCount };
+}

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -46,6 +46,7 @@ describe("POST /api/agui", () => {
     delete process.env.AGUI_BASE_URL;
     delete process.env.NEXT_PUBLIC_AGUI_APP_NAME;
     delete process.env.NEXT_PUBLIC_AGUI_USER_ID;
+    vi.restoreAllMocks();
   });
 
   it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
@@ -110,6 +111,53 @@ describe("POST /api/agui", () => {
     expect(response.status).toBe(400);
     expect(data.error.code).toBe("AGUI_BAD_REQUEST");
     expect(data.error.message).toContain("RunAgentInput requires a user message");
+  });
+
+  it("遇到非法 ADK 事件时应跳过坏事件并继续输出后续合法事件", async () => {
+    const upstreamStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        controller.enqueue(
+          encoder.encode(
+            [
+              'data: {"author":"assistant"}',
+              "",
+              'data: {"id":"evt-1","author":"assistant","content":{"parts":[{"text":"hello"}]}}',
+              "",
+              "",
+            ].join("\n"),
+          ),
+        );
+        controller.close();
+      },
+    });
+
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(upstreamStream, {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+        },
+      }),
+    );
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=session-1",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "test" }],
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("ADK_EVENT_PARSE_ERROR");
+    expect(body).toContain("TEXT_MESSAGE_CONTENT");
+    expect(body).toContain("hello");
   });
 });
 

--- a/apps/negentropy-ui/tests/unit/adk.test.ts
+++ b/apps/negentropy-ui/tests/unit/adk.test.ts
@@ -4,6 +4,9 @@ import {
   adkEventToAguiEvents,
   adkEventsToMessages,
   aguiEventsToMessages,
+  collectAdkEventPayloads,
+  parseAdkEventPayload,
+  safeParseAdkEventPayload,
 } from "../../lib/adk";
 
 describe("adk event mapping", () => {
@@ -154,5 +157,47 @@ describe("adk event mapping", () => {
       .map((event) => String(event.messageId));
     expect(textStartIds).toEqual(["chunk-1", "chunk-2"]);
     expect(events.some((event) => event.type === EventType.TOOL_CALL_START)).toBe(true);
+  });
+
+  it("parses valid ADK event payloads through the shared validator", () => {
+    const payload = parseAdkEventPayload({
+      id: "evt_6",
+      author: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+      },
+    });
+
+    expect(payload.id).toBe("evt_6");
+    expect(payload.message?.role).toBe("assistant");
+  });
+
+  it("rejects malformed ADK event payloads", () => {
+    const result = safeParseAdkEventPayload({
+      author: "assistant",
+      message: {
+        role: "assistant",
+        content: "ok",
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("collects valid ADK payloads and drops invalid entries", () => {
+    const result = collectAdkEventPayloads([
+      {
+        id: "evt_7",
+        author: "assistant",
+        content: { parts: [{ text: "ok" }] },
+      },
+      {
+        author: "assistant",
+      },
+    ]);
+
+    expect(result.payloads).toHaveLength(1);
+    expect(result.invalidCount).toBe(1);
   });
 });

--- a/apps/negentropy-ui/tests/unit/hooks/useSessionManager.test.tsx
+++ b/apps/negentropy-ui/tests/unit/hooks/useSessionManager.test.tsx
@@ -7,6 +7,10 @@ vi.mock("@/lib/adk", () => ({
   adkEventToAguiEvents: vi.fn(() => []),
   adkEventsToMessages: vi.fn(() => [{ id: "m1", role: "assistant", content: "hello" }]),
   adkEventsToSnapshot: vi.fn(() => ({ ready: true })),
+  collectAdkEventPayloads: vi.fn((input: unknown) => ({
+    payloads: Array.isArray(input) ? input : [],
+    invalidCount: 0,
+  })),
 }));
 
 describe("useSessionManager", () => {

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -97,4 +97,22 @@ describe("session-hydration", () => {
     ).toHaveLength(1);
     expect(merged[merged.length - 1].type).toBe(EventType.RUN_FINISHED);
   });
+
+  it("历史事件中混入坏 payload 时只保留合法项继续 hydration", () => {
+    const result = hydrateSessionDetail(
+      [
+        {
+          id: "msg-1",
+          runId: "run-1",
+          threadId: "session-1",
+          timestamp: 1000,
+          message: { role: "assistant", content: "hello" },
+        },
+      ],
+      "session-1",
+    );
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.content).toBe("hello");
+  });
 });


### PR DESCRIPTION
## 背景
- 当前 `AdkEventPayload` 仍以静态类型别名形式定义在 `lib/adk.ts` 中，并在多个边界入口通过 `JSON.parse(...) as AdkEventPayload` 或 `payload.events as AdkEventPayload[]` 直接进入归一化链路。
- 这会把“边界解析”和“内部归一化”混在一起，导致协议演进时容易出现静态类型断言失真和运行时漂移。
- 本 PR 将 ADK payload 的边界校验下沉到统一 validator 层，让 `lib/adk.ts` 收敛为“已验证 payload -> AGUI event/message/snapshot”的纯归一化层。

## 核心变更
- 新增 `lib/adk/schema.ts`，使用 `zod` 定义 `AdkEventPayload` 的统一 schema，并由 schema 推导 payload 类型。
- 提供 `parseAdkEventPayload`、`safeParseAdkEventPayload`、`collectAdkEventPayloads` 三个入口，分别处理单条 parse、单条 fail-soft 和数组逐项过滤。
- `lib/adk.ts` 移除手写 payload type alias，改为 re-export schema 与类型，只保留归一化职责。
- `/api/agui` 的 SSE 流解析改为显式 `safeParse` 后再归一化；单条坏事件只发出 `RUN_ERROR`，不会阻断后续合法事件。
- `app/page.tsx` 与 `hooks/useSessionManager.ts` 的 session history 入口改为 `collectAdkEventPayloads`，对混合数组执行“保留合法项、统计非法项数”的弹性策略，并记录可观测日志。
- 新增 ADK validator 回归测试与 API 集成测试，覆盖坏 payload 过滤和坏 SSE event 不阻断后续合法事件的场景。

## 变更原因
- 这是上一轮 AGUI event/message validator 分层后的继续加固，目标是彻底分离“边界验证”和“内部访问/归一化”。
- 通过把 ADK 协议校验集中到 validator 层，可以让后续 `AdkEventPayload` 字段演进时的影响面更清晰，也能把异常从隐式断言失败转为显式 parse 失败和可观测日志。

## 重要实现细节
- validator 层继续采用 `zod`，与现有 AGUI schema 方案保持一致，但单独放在 `lib/adk/schema.ts`，避免把上游协议与内部 AGUI 协议耦在一起。
- 数组边界采用“逐项过滤 + 统计 invalidCount”的 fail-soft 策略，不因单条坏历史记录阻断整个 session 恢复。
- 本次不修改外部 payload 字段名，不改变 `AdkMessageStreamNormalizer` 的事件语义、消息顺序、flush 策略或 snapshot 合并逻辑。

## 验证证据
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 全量测试通过：36 个测试文件 / 175 个测试
- 新增 API 集成覆盖：坏 SSE event 触发 `ADK_EVENT_PARSE_ERROR` 但后续合法事件仍继续输出

## Next Best Action
- 继续把 sessions list / detail 等其余 AGUI BFF JSON 代理响应逐步纳入 schema 化边界校验，进一步收紧前端对上游协议漂移的容错路径。
