### PR TITLE
fix(chat-ui): 去除消息竖线并对齐输入区边界;

### DIFF
--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -39,7 +39,7 @@ export function ChatStream({
       className="flex-1 overflow-y-auto custom-scrollbar"
     >
       <div
-        className={`mx-auto w-full space-y-4 px-10 py-6 sm:px-12 ${contentClassName ?? ""}`}
+        className={`mx-auto w-full space-y-4 py-6 ${contentClassName ?? ""}`}
       >
         {visibleNodes.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -27,19 +27,6 @@ function formatTimestamp(timestamp?: number): string {
   });
 }
 
-function DepthRail({ depth }: { depth: number }) {
-  if (depth <= 0) {
-    return null;
-  }
-  return (
-    <div
-      aria-hidden="true"
-      className="absolute bottom-0 left-0 top-0 border-l border-zinc-200/80 dark:border-zinc-800"
-      style={{ left: `${depth * 18 - 10}px` }}
-    />
-  );
-}
-
 function JsonBlock({ value }: { value: unknown }) {
   return (
     <div className="max-h-64 overflow-auto rounded-xl border border-zinc-200/70 bg-zinc-50 p-2 text-xs dark:border-zinc-800 dark:bg-zinc-950/70">
@@ -328,7 +315,6 @@ export function ConversationNodeRenderer({
 
   return (
     <div className="relative">
-      <DepthRail depth={depth} />
       <div style={{ marginLeft: `${depth * 18}px` }}>
         {content}
         {visibleChildren.length > 0 ? (

--- a/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
@@ -81,6 +81,79 @@ describe("ChatStream", () => {
     expect(screen.getAllByText("search").length).toBeGreaterThan(0);
   });
 
+  it("不渲染消息左侧层级竖线，且保留页面级宽度控制", () => {
+    const nodes: ConversationNode[] = [
+      {
+        id: "turn:1",
+        type: "turn",
+        parentId: null,
+        children: [
+          {
+            id: "message:1",
+            type: "text",
+            parentId: "turn:1",
+            children: [
+              {
+                id: "message:2",
+                type: "text",
+                parentId: "message:1",
+                children: [],
+                threadId: "thread-1",
+                runId: "run-1",
+                messageId: "msg-2",
+                timestamp: 1002,
+                timeRange: { start: 1002, end: 1002 },
+                sourceOrder: 2,
+                title: "继续回复",
+                role: "assistant",
+                visibility: "chat",
+                isStructural: false,
+                payload: { content: "继续说明" },
+                sourceEventTypes: ["text_message_content"],
+                relatedMessageIds: ["msg-2"],
+              },
+            ],
+            threadId: "thread-1",
+            runId: "run-1",
+            messageId: "msg-1",
+            timestamp: 1001,
+            timeRange: { start: 1001, end: 1001 },
+            sourceOrder: 1,
+            title: "助手消息",
+            role: "assistant",
+            visibility: "chat",
+            isStructural: false,
+            payload: { content: "你好" },
+            sourceEventTypes: ["text_message_start"],
+            relatedMessageIds: ["msg-1"],
+          },
+        ],
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1003 },
+        sourceOrder: 0,
+        title: "轮次 run-1",
+        visibility: "chat",
+        isStructural: false,
+        payload: {},
+        sourceEventTypes: ["run_started"],
+        relatedMessageIds: [],
+      },
+    ];
+
+    const { container } = render(
+      <ChatStream nodes={nodes} contentClassName="max-w-4xl" />,
+    );
+
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+
+    const contentWrapper = container.querySelector(".space-y-4");
+    expect(contentWrapper?.className).toContain("max-w-4xl");
+    expect(contentWrapper?.className).not.toContain("px-10");
+    expect(contentWrapper?.className).not.toContain("sm:px-12");
+  });
+
   it("不渲染 debug-only 根节点，并将技术节点折叠为摘要卡片", () => {
     const nodes: ConversationNode[] = [
       {


### PR DESCRIPTION
## 变更内容

本次改动聚焦聊天主区的布局收敛，主要包含以下三项：

- 移除聊天消息左侧用于表示层级关系的竖线渲染，避免 Agent 消息旁继续出现多余的装饰性轨道。
- 调整 `ChatStream` 的内容容器，去掉内部额外的横向 padding，让消息体直接复用页面级宽度控制，从而使消息区左右边缘与输入框外层边缘对齐。
- 新增 `ChatStream` 回归测试，覆盖“消息左侧不再渲染竖线”以及“聊天流不再带额外横向 gutter”这两个关键约束。

## 变更原因

这次调整直接对应任务中的界面需求：去掉 Agent 每个消息左侧的竖线，并让对话框消息体的左右边缘与输入框左右边缘保持一致。此前聊天流内部额外叠加了一层横向留白，导致消息区域和输入区采用了两套边界策略，视觉上产生了错位；同时层级竖线也增加了不必要的干扰。此次改动的目标是以最小干预方式统一布局基线，提升聊天区域的视觉秩序，同时避免影响现有消息渲染与交互功能。

## 实现细节

实现上沿用了现有组件组合与页面宽度控制策略，没有引入新的接口、状态或样式系统：

- 在 `ConversationNodeRenderer` 中删除装饰性的 `DepthRail` 渲染逻辑，保留现有递归节点结构与层级缩进机制。
- 在 `ChatStream` 中移除内部的 `px-10` / `sm:px-12` 横向 padding，继续以页面级 `max-w-4xl` 作为聊天主区和输入区共享的宽度单一事实源。
- 通过补充单测，将“无竖线”和“无额外横向 gutter”固化为可验证约束，降低后续 UI 回归风险。
