### PR TITLE
fix(mcp): 修复stdio日志桥接的stderr句柄契约;

### DIFF
--- a/apps/negentropy/src/negentropy/plugins/mcp_client.py
+++ b/apps/negentropy/src/negentropy/plugins/mcp_client.py
@@ -9,14 +9,17 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
 
+import anyio
 import httpx
 from mcp import ClientSession
+from mcp.client import stdio as mcp_stdio
 from mcp.client.sse import sse_client
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.stdio import StdioServerParameters
 from mcp.client.streamable_http import streamablehttp_client
 
 from negentropy.logging import get_logger
@@ -27,6 +30,124 @@ stderr_logger = get_logger("stderr")
 
 # 连接超时时间（秒）
 DEFAULT_TIMEOUT_SECONDS = 30
+
+
+@asynccontextmanager
+async def logged_stdio_client(
+    server: StdioServerParameters,
+    errlog: ExternalProcessLogStream,
+):
+    """
+    Spawn stdio MCP servers with stderr piped, then forward stderr lines
+    into the project's unified logging pipeline.
+    """
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+    try:
+        command = mcp_stdio._get_executable_command(server.command)
+        process = await anyio.open_process(
+            [command, *server.args],
+            env=(
+                {**mcp_stdio.get_default_environment(), **server.env}
+                if server.env is not None
+                else mcp_stdio.get_default_environment()
+            ),
+            stderr=-1,
+            cwd=server.cwd,
+            start_new_session=True,
+        )
+    except OSError:
+        await read_stream.aclose()
+        await write_stream.aclose()
+        await read_stream_writer.aclose()
+        await write_stream_reader.aclose()
+        raise
+
+    async def stdout_reader() -> None:
+        assert process.stdout, "Opened process is missing stdout"
+
+        try:
+            async with read_stream_writer:
+                buffer = ""
+                async for chunk in mcp_stdio.TextReceiveStream(
+                    process.stdout,
+                    encoding=server.encoding,
+                    errors=server.encoding_error_handler,
+                ):
+                    lines = (buffer + chunk).split("\n")
+                    buffer = lines.pop()
+
+                    for line in lines:
+                        try:
+                            message = mcp_stdio.types.JSONRPCMessage.model_validate_json(line)
+                        except Exception as exc:  # pragma: no cover
+                            logger.exception("Failed to parse JSONRPC message from server")
+                            await read_stream_writer.send(exc)
+                            continue
+
+                        await read_stream_writer.send(mcp_stdio.SessionMessage(message))
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+
+    async def stderr_reader() -> None:
+        assert process.stderr, "Opened process is missing stderr"
+
+        try:
+            async for chunk in mcp_stdio.TextReceiveStream(
+                process.stderr,
+                encoding=server.encoding,
+                errors=server.encoding_error_handler,
+            ):
+                errlog.write(chunk)
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+        finally:
+            errlog.flush()
+
+    async def stdin_writer() -> None:
+        assert process.stdin, "Opened process is missing stdin"
+
+        try:
+            async with write_stream_reader:
+                async for session_message in write_stream_reader:
+                    payload = session_message.message.model_dump_json(by_alias=True, exclude_none=True)
+                    await process.stdin.send(
+                        (payload + "\n").encode(
+                            encoding=server.encoding,
+                            errors=server.encoding_error_handler,
+                        )
+                    )
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+
+    async with (
+        anyio.create_task_group() as tg,
+        process,
+    ):
+        tg.start_soon(stdout_reader)
+        tg.start_soon(stderr_reader)
+        tg.start_soon(stdin_writer)
+        try:
+            yield read_stream, write_stream
+        finally:
+            if process.stdin:  # pragma: no branch
+                try:
+                    await process.stdin.aclose()
+                except Exception:  # pragma: no cover
+                    pass
+
+            try:
+                with anyio.fail_after(mcp_stdio.PROCESS_TERMINATION_TIMEOUT):
+                    await process.wait()
+            except TimeoutError:
+                await mcp_stdio._terminate_process_tree(process)
+            except ProcessLookupError:  # pragma: no cover
+                pass
+            await read_stream.aclose()
+            await write_stream.aclose()
+            await read_stream_writer.aclose()
+            await write_stream_reader.aclose()
 
 
 @dataclass
@@ -284,7 +405,10 @@ class McpClientService:
         )
 
         async with asyncio.timeout(self.timeout_seconds):
-            async with stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (read, write):
+            async with logged_stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (
+                read,
+                write,
+            ):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
                     tools_result = await session.list_tools()
@@ -313,7 +437,10 @@ class McpClientService:
     ) -> McpToolCallResult:
         server_params = StdioServerParameters(command=command, args=args, env=env)
         async with asyncio.timeout(timeout_seconds):
-            async with stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (read, write):
+            async with logged_stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (
+                read,
+                write,
+            ):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
                     result = await session.call_tool(

--- a/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
+++ b/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 
+import anyio
 import pytest
 
-from negentropy.plugins.mcp_client import McpClientService
+from negentropy.logging.io import ExternalProcessLogStream
+from negentropy.plugins.mcp_client import McpClientService, logged_stdio_client
 
 
 @pytest.mark.asyncio
-async def test_discover_stdio_passes_structured_errlog(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_discover_stdio_uses_logged_stdio_client(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
     @asynccontextmanager
-    async def fake_stdio_client(server_params, errlog):
+    async def fake_logged_stdio_client(server_params, errlog):
         captured["server_params"] = server_params
         captured["errlog"] = errlog
         yield object(), object()
@@ -39,7 +42,7 @@ async def test_discover_stdio_passes_structured_errlog(monkeypatch: pytest.Monke
         async def list_tools(self):
             return _ToolsResult()
 
-    monkeypatch.setattr("negentropy.plugins.mcp_client.stdio_client", fake_stdio_client)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.logged_stdio_client", fake_logged_stdio_client)
     monkeypatch.setattr("negentropy.plugins.mcp_client.ClientSession", lambda read, write: _Session())
 
     service = McpClientService(timeout_seconds=5)
@@ -60,7 +63,7 @@ async def test_call_tool_stdio_passes_structured_errlog(monkeypatch: pytest.Monk
     captured: dict[str, object] = {}
 
     @asynccontextmanager
-    async def fake_stdio_client(server_params, errlog):
+    async def fake_logged_stdio_client(server_params, errlog):
         captured["server_params"] = server_params
         captured["errlog"] = errlog
         yield object(), object()
@@ -86,7 +89,7 @@ async def test_call_tool_stdio_passes_structured_errlog(monkeypatch: pytest.Monk
             captured["read_timeout_seconds"] = read_timeout_seconds
             return _Result()
 
-    monkeypatch.setattr("negentropy.plugins.mcp_client.stdio_client", fake_stdio_client)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.logged_stdio_client", fake_logged_stdio_client)
     monkeypatch.setattr("negentropy.plugins.mcp_client.ClientSession", lambda read, write: _Session())
 
     service = McpClientService(timeout_seconds=5)
@@ -103,3 +106,97 @@ async def test_call_tool_stdio_passes_structured_errlog(monkeypatch: pytest.Monk
     assert captured["initialized"] is True
     assert captured["tool_name"] == "fetch"
     assert captured["errlog"].source == "mcp.mcp-server-fetch"
+
+
+@pytest.mark.asyncio
+async def test_logged_stdio_client_pipes_stderr_and_forwards_logs(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    events: list[tuple[int, str, dict[str, object]]] = []
+
+    class _Logger:
+        def log(self, level, event=None, **kwargs):
+            events.append((level, event, kwargs))
+
+    class _FakeStdin:
+        async def send(self, data: bytes) -> None:
+            captured["stdin_payload"] = data
+
+        async def aclose(self) -> None:
+            captured["stdin_closed"] = True
+
+    class _FakeProcess:
+        def __init__(self, stdout, stderr) -> None:
+            self.stdin = _FakeStdin()
+            self.stdout = stdout
+            self.stderr = stderr
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def wait(self) -> None:
+            captured["wait_called"] = True
+
+    _stdout_send, stdout_recv = anyio.create_memory_object_stream[bytes](10)
+    stderr_send, stderr_recv = anyio.create_memory_object_stream[bytes](10)
+
+    process = _FakeProcess(stdout_recv, stderr_recv)
+
+    async def fake_open_process(command, **kwargs):
+        captured["command"] = command
+        captured["stderr"] = kwargs.get("stderr")
+        return process
+
+    class _TextReceiveStream:
+        def __init__(self, stream, encoding: str, errors: str):
+            self.stream = stream
+            self.encoding = encoding
+            self.errors = errors
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                chunk = await self.stream.receive()
+            except anyio.EndOfStream:
+                raise StopAsyncIteration from None
+            return chunk.decode(self.encoding, errors=self.errors)
+
+    monkeypatch.setattr("negentropy.plugins.mcp_client.anyio.open_process", fake_open_process)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.mcp_stdio._get_executable_command", lambda command: command)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.mcp_stdio.get_default_environment", lambda: {"PATH": "x"})
+    monkeypatch.setattr("negentropy.plugins.mcp_client.mcp_stdio.TextReceiveStream", _TextReceiveStream)
+
+    server_params = type(
+        "_Params",
+        (),
+        {
+            "command": "npx",
+            "args": ["-y", "@zilliz/zai-mcp-server"],
+            "env": {"FOO": "bar"},
+            "cwd": None,
+            "encoding": "utf-8",
+            "encoding_error_handler": "replace",
+        },
+    )()
+
+    errlog = ExternalProcessLogStream(_Logger(), source="mcp.zai-mcp-server")
+
+    async with logged_stdio_client(server_params, errlog) as (_read, _write):
+        await stderr_send.send(b"[2026-03-07T06:29:09.030Z] INFO: MCP Server Application initialized\n")
+        await stderr_send.aclose()
+        await _stdout_send.aclose()
+        await anyio.sleep(0)
+
+    assert captured["command"] == ["npx", "-y", "@zilliz/zai-mcp-server"]
+    assert captured["stderr"] == -1
+    assert events == [
+        (
+            logging.INFO,
+            "MCP Server Application initialized",
+            {"source": "mcp.zai-mcp-server", "timestamp": "2026-03-07T06:29:09.030Z"},
+        )
+    ]


### PR DESCRIPTION
## 变更内容

本次改动修复了 `stdio` 型 MCP Server 在接入统一日志桥接后引入的回归问题。

具体包括：

- 在 `McpClientService` 内为 `stdio` 传输增加本地包装器，显式以管道方式接管子进程 `stderr`
- 不再将 Python 层日志 writer 直接传给底层 subprocess 作为 `stderr` 句柄
- 将子进程 `stderr` 按行读取后再转发到现有统一日志管线，继续复用既有的日志解析与格式化能力
- 补充单元测试，覆盖 `stdio` MCP tools load 路径、stderr 管道转发行为以及回归场景

## 变更原因

这次修改是对上一轮日志统一化改动的回归修复。

在打开 MCP Servers 页并加载 `stdio` 型 MCP Server 时，页面与后台同时报错：`'ExternalProcessLogStream' object has no attribute 'fileno'`。根因是底层 `anyio.open_process` / `subprocess.Popen` 对 `stderr` 参数的契约是文件句柄或可用于底层进程重定向的对象，而不是普通 Python writer。

因此，虽然之前的实现能表达“把外部进程日志导入统一 logger”的意图，但接入位置放错了边界，导致子进程创建阶段直接失败，影响 MCP Servers 页的可用性。

## 重要实现细节

- 修复方案遵循最小干预原则：保留现有日志统一化目标，不回退功能，只修正 stderr 桥接所在层次
- `stdout` 上的 JSON-RPC 通信链路不受影响，修复只作用于 `stderr` 日志采集
- 本地包装器通过管道读取 `stderr`，再将日志逐行喂给现有日志桥接逻辑，避免破坏协议层与日志层的职责边界
- 新增的测试不仅验证调用链路，还覆盖了这次真实回归的核心约束：`stderr` 必须走底层句柄语义，而不是直接注入 Python writer
- 这次改动不引入新的对外接口，不改变 MCP Server 配置模型，只修复运行时行为
