### PR TITLE
refactor(session): 收敛会话代理响应校验与DTO映射;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
@@ -1,20 +1,13 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { safeParseSessionDetailResponse } from "@/lib/agui/session-schema";
+import {
+  errorResponse as aguiErrorResponse,
+  AGUI_ERROR_CODES,
+} from "@/lib/errors";
 
 function getBaseUrl() {
   return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
-function errorResponse(code: string, message: string, status = 500) {
-  return NextResponse.json(
-    {
-      error: {
-        code,
-        message,
-      },
-    },
-    { status }
-  );
 }
 
 export async function GET(
@@ -23,7 +16,10 @@ export async function GET(
 ) {
   const baseUrl = getBaseUrl();
   if (!baseUrl) {
-    return errorResponse("AGUI_INTERNAL_ERROR", "AGUI_BASE_URL is not configured", 500);
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.INTERNAL_ERROR,
+      "AGUI_BASE_URL is not configured",
+    );
   }
 
   const { sessionId } = await params;
@@ -32,7 +28,10 @@ export async function GET(
   const userId = searchParams.get("user_id");
 
   if (!appName || !userId) {
-    return errorResponse("AGUI_BAD_REQUEST", "app_name and user_id are required", 400);
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.BAD_REQUEST,
+      "app_name and user_id are required",
+    );
   }
 
   const upstreamUrl = new URL(
@@ -53,17 +52,34 @@ export async function GET(
       cache: "no-store",
     });
   } catch (error) {
-    return errorResponse("AGUI_UPSTREAM_ERROR", `Upstream connection failed: ${String(error)}`, 502);
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      `Upstream connection failed: ${String(error)}`,
+    );
   }
 
   const text = await upstreamResponse.text();
   if (!upstreamResponse.ok) {
-    return errorResponse("AGUI_UPSTREAM_ERROR", text || "Upstream returned non-OK status", upstreamResponse.status);
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      text || "Upstream returned non-OK status",
+    );
   }
 
   try {
-    return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+    const payload = JSON.parse(text) as unknown;
+    const parsed = safeParseSessionDetailResponse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        "Invalid upstream session detail payload",
+      );
+    }
+    return NextResponse.json(parsed.data, { status: upstreamResponse.status });
   } catch {
-    return NextResponse.json({ raw: text }, { status: upstreamResponse.status });
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      "Invalid upstream session detail JSON",
+    );
   }
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { safeParseSessionListResponse } from "@/lib/agui/session-schema";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -49,23 +50,31 @@ export async function GET(request: Request) {
   }
 
   try {
-    const payload = JSON.parse(text);
-    if (!Array.isArray(payload)) {
-      return NextResponse.json(payload, { status: upstreamResponse.status });
+    const payload = JSON.parse(text) as unknown;
+    const parsed = safeParseSessionListResponse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        "Invalid upstream session list payload",
+      );
     }
+    const sessions = parsed.data;
 
     if (archived !== "true" && archived !== "false") {
-      return NextResponse.json(payload, { status: upstreamResponse.status });
+      return NextResponse.json(sessions, { status: upstreamResponse.status });
     }
 
     const includeArchived = archived === "true";
-    const filtered = payload.filter((session) => {
+    const filtered = sessions.filter((session) => {
       const isArchived = session?.state?.metadata?.archived === true;
       return includeArchived ? isArchived : !isArchived;
     });
 
     return NextResponse.json(filtered, { status: upstreamResponse.status });
   } catch {
-    return NextResponse.json({ raw: text }, { status: upstreamResponse.status });
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      "Invalid upstream session list JSON",
+    );
   }
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { safeParseCreateSessionResponse } from "@/lib/agui/session-schema";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -64,8 +65,19 @@ export async function POST(request: Request) {
   }
 
   try {
-    return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+    const payload = JSON.parse(text) as unknown;
+    const parsed = safeParseCreateSessionResponse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        "Invalid upstream session create payload",
+      );
+    }
+    return NextResponse.json(parsed.data, { status: upstreamResponse.status });
   } catch {
-    return NextResponse.json({ raw: text }, { status: upstreamResponse.status });
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      "Invalid upstream session create JSON",
+    );
   }
 }

--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -23,7 +23,7 @@ import { collectAdkEventPayloads } from "@/lib/adk";
 import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 
 // 提取的工具函数
-import { createSessionLabel, buildAgentUrl } from "@/utils/session";
+import { createSessionLabel, buildAgentUrl, toSessionRecord } from "@/utils/session";
 import type { SessionListView } from "@/utils/session";
 import {
   normalizeMessageContent,
@@ -338,19 +338,7 @@ export function HomeBody({
         return;
       }
       const nextSessions = payload
-        .map(
-          (session: {
-            id: string;
-            lastUpdateTime?: number;
-            state?: { metadata?: { title?: string; archived?: boolean } };
-          }) => ({
-            id: session.id,
-            label:
-              session.state?.metadata?.title || createSessionLabel(session.id),
-            lastUpdateTime: session.lastUpdateTime,
-            archived: session.state?.metadata?.archived === true,
-          }),
-        )
+        .map(toSessionRecord)
         .sort(
           (a: SessionRecord, b: SessionRecord) =>
             (b.lastUpdateTime || 0) - (a.lastUpdateTime || 0),

--- a/apps/negentropy-ui/hooks/useSessionManager.ts
+++ b/apps/negentropy-ui/hooks/useSessionManager.ts
@@ -11,7 +11,7 @@
  */
 
 import { useState, useCallback } from "react";
-import { createSessionLabel } from "@/utils/session";
+import { createSessionLabel, toSessionRecord } from "@/utils/session";
 import { HttpAgent } from "@ag-ui/client";
 import { Message } from "@ag-ui/core";
 import {
@@ -71,17 +71,7 @@ export function useSessionManager(
         return;
       }
       const nextSessions = payload
-        .map(
-          (session: {
-            id: string;
-            lastUpdateTime?: number;
-            state?: { metadata?: { title?: string } };
-          }) => ({
-            id: session.id,
-            label: session.state?.metadata?.title || createSessionLabel(session.id),
-            lastUpdateTime: session.lastUpdateTime,
-          })
-        )
+        .map(toSessionRecord)
         .sort(
           (a: SessionRecord, b: SessionRecord) =>
             (b.lastUpdateTime || 0) - (a.lastUpdateTime || 0)

--- a/apps/negentropy-ui/lib/agui/session-schema.ts
+++ b/apps/negentropy-ui/lib/agui/session-schema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+const sessionMetadataSchema = z
+  .object({
+    title: z.string().optional(),
+    archived: z.boolean().optional(),
+  })
+  .passthrough();
+
+const sessionStateSchema = z
+  .object({
+    metadata: sessionMetadataSchema.optional(),
+  })
+  .passthrough();
+
+export const aguiSessionSummarySchema = z
+  .object({
+    id: z.string(),
+    lastUpdateTime: z.number().finite().optional(),
+    state: sessionStateSchema.optional(),
+  })
+  .passthrough();
+
+export const aguiSessionListSchema = z.array(aguiSessionSummarySchema);
+
+export const aguiSessionDetailSchema = z
+  .object({
+    id: z.string(),
+    lastUpdateTime: z.number().finite().optional(),
+    state: z.record(z.unknown()).optional(),
+    events: z.array(z.unknown()).optional(),
+  })
+  .passthrough();
+
+export const aguiCreateSessionResponseSchema = z
+  .object({
+    id: z.string(),
+    lastUpdateTime: z.number().finite().optional(),
+  })
+  .passthrough();
+
+export type AguiSessionSummary = z.infer<typeof aguiSessionSummarySchema>;
+export type AguiSessionDetail = z.infer<typeof aguiSessionDetailSchema>;
+export type AguiCreateSessionResponse = z.infer<typeof aguiCreateSessionResponseSchema>;
+
+export function safeParseSessionListResponse(input: unknown) {
+  return aguiSessionListSchema.safeParse(input);
+}
+
+export function safeParseSessionDetailResponse(input: unknown) {
+  return aguiSessionDetailSchema.safeParse(input);
+}
+
+export function safeParseCreateSessionResponse(input: unknown) {
+  return aguiCreateSessionResponseSchema.safeParse(input);
+}

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { POST } from "@/app/api/agui/route";
 import { GET } from "@/app/api/agui/sessions/list/route";
+import { GET as getSessionDetail } from "@/app/api/agui/sessions/[sessionId]/route";
 import { POST as createSession } from "@/app/api/agui/sessions/route";
 
 // Mock 环境变量
@@ -228,6 +229,88 @@ describe("GET /api/agui/sessions/list", () => {
     expect(response.status).toBe(200);
     expect(data).toEqual([{ id: "archived-1", state: { metadata: { archived: true } } }]);
   });
+
+  it("当上游 session list 结构非法时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([{ lastUpdateTime: 100 }]),
+    } as Response);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui/sessions/list?app_name=negentropy&user_id=test",
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session list payload");
+  });
+});
+
+describe("GET /api/agui/sessions/[sessionId]", () => {
+  beforeEach(() => {
+    process.env.AGUI_BASE_URL = mockEnv.AGUI_BASE_URL;
+    process.env.NEXT_PUBLIC_AGUI_APP_NAME = mockEnv.NEXT_PUBLIC_AGUI_APP_NAME;
+    process.env.NEXT_PUBLIC_AGUI_USER_ID = mockEnv.NEXT_PUBLIC_AGUI_USER_ID;
+  });
+
+  afterEach(() => {
+    delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_APP_NAME;
+    delete process.env.NEXT_PUBLIC_AGUI_USER_ID;
+    vi.restoreAllMocks();
+  });
+
+  it("应该返回结构化 session detail", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          id: "s1",
+          lastUpdateTime: 100,
+          state: { metadata: { title: "Session 1" } },
+          events: [{ id: "evt-1" }],
+        }),
+    } as Response);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui/sessions/s1?app_name=negentropy&user_id=test",
+    );
+
+    const response = await getSessionDetail(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBe("s1");
+    expect(data.events).toHaveLength(1);
+  });
+
+  it("当上游 session detail 结构非法时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ events: {} }),
+    } as Response);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui/sessions/s1?app_name=negentropy&user_id=test",
+    );
+
+    const response = await getSessionDetail(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session detail payload");
+  });
 });
 
 describe("POST /api/agui/sessions", () => {
@@ -302,5 +385,28 @@ describe("POST /api/agui/sessions", () => {
 
     expect(response.status).toBe(400);
     expect(data.error.code).toBe("AGUI_BAD_REQUEST");
+  });
+
+  it("当上游创建响应结构非法时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ lastUpdateTime: 300 }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await createSession(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session create payload");
   });
 });

--- a/apps/negentropy-ui/utils/session.ts
+++ b/apps/negentropy-ui/utils/session.ts
@@ -1,3 +1,6 @@
+import type { AguiSessionSummary } from "@/lib/agui/session-schema";
+import type { SessionRecord } from "@/types/common";
+
 /**
  * 会话相关工具函数
  *
@@ -19,6 +22,15 @@ export function isSessionArchived(session: {
   state?: { metadata?: { archived?: boolean } };
 }): boolean {
   return session.state?.metadata?.archived === true;
+}
+
+export function toSessionRecord(session: AguiSessionSummary): SessionRecord {
+  return {
+    id: session.id,
+    label: session.state?.metadata?.title || createSessionLabel(session.id),
+    lastUpdateTime: session.lastUpdateTime,
+    archived: session.state?.metadata?.archived === true,
+  };
 }
 
 /**


### PR DESCRIPTION
## 背景
- 当前 `sessions/list`、`sessions/[id]` 与 `sessions` 创建接口仍是上游 JSON 透传后由页面或 Hook 做手写映射的模式。
- 这种做法会让上游协议漂移直接穿透到前端状态层，和前面已经完成的 AGUI event / ADK payload validator 分层方向不一致。
- 本 PR 将会话相关 BFF 响应逐步 schema 化，在代理层先完成边界校验，再由前端消费稳定 DTO。

## 核心变更
- 新增 `apps/negentropy-ui/lib/agui/session-schema.ts`，集中定义并导出：
  - `aguiSessionSummarySchema`
  - `aguiSessionListSchema`
  - `aguiSessionDetailSchema`
  - `aguiCreateSessionResponseSchema`
  - `safeParseSessionListResponse`
  - `safeParseSessionDetailResponse`
  - `safeParseCreateSessionResponse`
- `app/api/agui/sessions/list/route.ts` 改为先校验上游列表响应，再执行 archived 过滤；无效 JSON 或无效 payload 统一返回 `AGUI_UPSTREAM_ERROR`。
- `app/api/agui/sessions/[sessionId]/route.ts` 改为先校验 detail envelope，再返回已验证结构；事件项的逐条 fail-soft 仍由现有 ADK payload validator 负责。
- `app/api/agui/sessions/route.ts` 改为在创建成功后校验 create response，避免非法上游响应直接进入页面状态。
- `utils/session.ts` 新增 `toSessionRecord`，统一把 session summary DTO 映射为 `SessionRecord`。
- `app/page.tsx` 与 `hooks/useSessionManager.ts` 的 session 列表加载逻辑改为共享 `toSessionRecord`，去掉重复手写映射。
- `tests/integration/api.test.ts` 新增 session list/detail/create 的 schema 回归测试，覆盖无效 payload、无效 JSON 和正常返回路径。

## 变更原因
- 目标是把 session BFF 代理层收敛为明确的 anti-corruption layer，阻断上游协议漂移直接影响页面状态。
- 同时通过单一 schema 与单一 DTO mapper，消除页面和 Hook 之间重复实现的 summary 映射逻辑，降低后续字段演进时的分叉风险。

## 重要实现细节
- validator 层继续使用 `zod`，但单独放在 session schema 模块中，避免与 ADK payload / AGUI event schema 混在同一职责层。
- detail schema 只验证 envelope 和 `events` 是否为数组，不在这一层重复展开事件项校验；事件级合法性继续委托给现有 `collectAdkEventPayloads`，职责边界保持明确。
- schema 失败时，BFF 不再把原始上游 payload 或 `{ raw: text }` 透传给前端，而是返回结构化 `AGUI_UPSTREAM_ERROR`，把异常限制在边界层。
- 本次不修改上游 API 字段名，不改变 archived 过滤规则、session hydration 语义或页面行为。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/integration/api.test.ts tests/unit/hooks/useSessionManager.test.tsx`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 全量结果：36 个测试文件、180 个测试全部通过

## 风险与回滚
- 风险主要集中在 BFF 对上游响应的容错边界收紧，若上游返回字段形状和现有消费假设不一致，将更早以 `AGUI_UPSTREAM_ERROR` 形式暴露。
- 回滚方式明确：回退本 PR 对 session schema、route validator 和 DTO mapper 的改动，即可恢复现有透传行为。

## Next Best Action
- 继续把 `archive` / `title` / `unarchive` 等 session 代理响应也纳入同一 schema 体系，彻底消除 session BFF 层剩余的透传入口。
