### PR TITLE
fix(knowledge): 修复 Documents 设置保存时的分块配置序列化错误;

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -309,7 +309,7 @@ def default_chunking_config() -> ChunkingConfigValue:
 def serialize_chunking_config(config: ChunkingConfigValue | None) -> Dict[str, Any]:
     if config is None:
         return {}
-    return config.model_dump(mode="python")
+    return config.model_dump(mode="json")
 
 
 def normalize_chunking_config(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
@@ -38,11 +38,25 @@ class FakeStorageService:
         return self.markdown
 
 
+class FakeScalarSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def scalar(self, stmt):
+        _ = stmt
+        return 0
+
+
 class FakeKnowledgeService:
     def __init__(self):
         self.list_knowledge_calls = []
         self.pipeline_calls = []
         self.search_calls = []
+        self.ensure_corpus_calls = []
+        self.update_corpus_calls = []
 
     async def list_knowledge(self, **kwargs):
         self.list_knowledge_calls.append(kwargs)
@@ -67,6 +81,26 @@ class FakeKnowledgeService:
     async def create_pipeline(self, **kwargs):
         self.pipeline_calls.append(kwargs)
         return "run-test-001"
+
+    async def ensure_corpus(self, spec):
+        self.ensure_corpus_calls.append(spec)
+        return SimpleNamespace(
+            id=uuid4(),
+            app_name=spec.app_name,
+            name=spec.name,
+            description=spec.description,
+            config=spec.config,
+        )
+
+    async def update_corpus(self, corpus_id, spec):
+        self.update_corpus_calls.append({"corpus_id": corpus_id, "spec": spec})
+        return SimpleNamespace(
+            id=corpus_id,
+            app_name="negentropy",
+            name=spec.get("name", "updated-corpus"),
+            description=spec.get("description"),
+            config=spec.get("config", {}),
+        )
 
     async def execute_replace_source_pipeline(self, **kwargs):
         _ = kwargs
@@ -129,6 +163,65 @@ async def test_list_document_chunks_success(monkeypatch):
     assert len(result.items) == 1
     assert result.items[0]["source_uri"] == "https://example.com/a"
     assert fake_service.list_knowledge_calls[0]["source_uri"] == "https://example.com/a"
+
+
+@pytest.mark.asyncio
+async def test_create_corpus_serializes_chunking_strategy_to_string(monkeypatch):
+    fake_service = FakeKnowledgeService()
+
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+
+    result = await knowledge_api.create_corpus(
+        knowledge_api.CorpusCreateRequest(
+            app_name="negentropy",
+            name="docs",
+            description="Knowledge base",
+            config={
+                "strategy": "hierarchical",
+                "preserve_newlines": True,
+                "separators": ["###"],
+                "hierarchical_parent_chunk_size": 1500,
+                "hierarchical_child_chunk_size": 500,
+                "hierarchical_child_overlap": 150,
+            },
+        )
+    )
+
+    spec = fake_service.ensure_corpus_calls[0]
+    assert spec.config["strategy"] == "hierarchical"
+    assert isinstance(spec.config["strategy"], str)
+    assert spec.config["separators"] == ["###"]
+    assert result.config["strategy"] == "hierarchical"
+
+
+@pytest.mark.asyncio
+async def test_update_corpus_serializes_chunking_strategy_to_string(monkeypatch):
+    corpus_id = uuid4()
+    fake_service = FakeKnowledgeService()
+
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+    monkeypatch.setattr(knowledge_api, "AsyncSessionLocal", lambda: FakeScalarSession())
+
+    result = await knowledge_api.update_corpus(
+        corpus_id=corpus_id,
+        payload=knowledge_api.CorpusUpdateRequest(
+            config={
+                "strategy": "hierarchical",
+                "preserve_newlines": True,
+                "separators": ["###"],
+                "hierarchical_parent_chunk_size": 1500,
+                "hierarchical_child_chunk_size": 500,
+                "hierarchical_child_overlap": 150,
+            }
+        ),
+    )
+
+    update_call = fake_service.update_corpus_calls[0]
+    assert update_call["corpus_id"] == corpus_id
+    assert update_call["spec"]["config"]["strategy"] == "hierarchical"
+    assert isinstance(update_call["spec"]["config"]["strategy"], str)
+    assert update_call["spec"]["config"]["separators"] == ["###"]
+    assert result.config["strategy"] == "hierarchical"
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_types.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_types.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from negentropy.knowledge.types import (
     ChunkingConfig,
+    ChunkingStrategy,
     CorpusRecord,
     CorpusSpec,
     GraphBuildConfigModel,
@@ -18,6 +19,7 @@ from negentropy.knowledge.types import (
     KnowledgeMatch,
     KnowledgeRecord,
     SearchConfig,
+    serialize_chunking_config,
 )
 from negentropy.knowledge.constants import (
     DEFAULT_CHUNK_SIZE,
@@ -140,6 +142,51 @@ class TestChunkingConfig:
         """separators 应标准化为可哈希的不可变元组"""
         config = ChunkingConfig(separators=["###", " ", "###", "\t", "---"])
         assert config.separators == ("###", "---")
+
+    def test_serialize_chunking_config_returns_json_safe_recursive_payload(self) -> None:
+        """序列化结果应只包含 JSON 原生类型"""
+        config = ChunkingConfig(
+            strategy=ChunkingStrategy.RECURSIVE,
+            chunk_size=500,
+            overlap=50,
+            preserve_newlines=False,
+            separators=["###", "---"],
+        )
+
+        payload = serialize_chunking_config(config)
+
+        assert payload == {
+            "strategy": "recursive",
+            "chunk_size": 500,
+            "overlap": 50,
+            "preserve_newlines": False,
+            "separators": ["###", "---"],
+        }
+        assert isinstance(payload["strategy"], str)
+
+    def test_serialize_chunking_config_returns_json_safe_hierarchical_payload(self) -> None:
+        """层级分块配置序列化后不应保留枚举或元组"""
+        config = ChunkingConfig(
+            strategy=ChunkingStrategy.HIERARCHICAL,
+            preserve_newlines=True,
+            separators=["###"],
+            hierarchical_parent_chunk_size=1500,
+            hierarchical_child_chunk_size=500,
+            hierarchical_child_overlap=150,
+        )
+
+        payload = serialize_chunking_config(config)
+
+        assert payload == {
+            "strategy": "hierarchical",
+            "preserve_newlines": True,
+            "separators": ["###"],
+            "hierarchical_parent_chunk_size": 1500,
+            "hierarchical_child_chunk_size": 500,
+            "hierarchical_child_overlap": 150,
+        }
+        assert isinstance(payload["strategy"], str)
+        assert isinstance(payload["separators"], list)
 
 
 class TestSearchConfig:


### PR DESCRIPTION
## 背景

Knowledge Base 页的 Documents 视图中，用户在 Settings 面板点击 `Save Settings` 时会触发 `PATCH /knowledge/base/{corpus_id}`。当分块策略为 `hierarchical` 等枚举配置时，后端会将 `ChunkingStrategy` 枚举实例直接写入 JSONB，最终在 SQLAlchemy `json.dumps` 序列化阶段报错：

- 前端报错：`Failed to update corpus: Internal Server Error`
- 后端根因：`Object of type ChunkingStrategy is not JSON serializable`

## 本次改动

- 将 knowledge chunking 配置的统一序列化出口切换为 JSON-safe 输出，确保 `strategy` 等字段在持久化前已被转换为 JSON 原生类型
- 保持领域层内部仍可使用 `ChunkingStrategy` 枚举，不改变现有 chunking 配置的业务语义
- 新增回归测试，覆盖：
  - `serialize_chunking_config()` 的 JSON-safe 序列化行为
  - `create_corpus` / `update_corpus` 两条 corpus settings 链路，确保传入 service/repository 的 `config.strategy` 为字符串而非枚举对象

## 为什么这样改

这次问题的根因不在 repository 或数据库模型本身，而在配置对象跨越“领域模型 -> 持久化 JSON”边界时缺少统一的 JSON 规范化。按照边界收敛与单一事实源原则，本次修复收敛在现有的统一序列化出口，避免把枚举兼容逻辑散落到 repository 或数据库层，降低后续同类回归风险。

## 实现细节

- 修复点位于 `apps/negentropy/src/negentropy/knowledge/types.py`
- `serialize_chunking_config()` 从 Python 模式序列化改为 JSON 模式序列化
- API 层现有 `_serialize_corpus_config()` 继续作为 corpus 配置的统一出口，无需改动接口契约
- 响应与持久化中的 `config.strategy` 继续保持字符串值，不引入前端兼容性变化

## 验证

已执行：

```bash
uv run --project apps/negentropy --group dev python -m pytest \
  apps/negentropy/tests/unit_tests/knowledge/test_types.py \
  apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py -q
```

结果：

- `38 passed`

## 影响面

- 仅影响 Knowledge Base corpus settings 的配置序列化与相关测试
- 不修改 API schema
- 不涉及数据库 migration
- 不改变现有 UI 请求格式与返回字段
