### PR TITLE
fix(knowledge): 修复文档提取设置面板状态回退问题;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -15,7 +15,7 @@ import {
   buildCorpusConfig,
   CorpusRecord,
   CorpusExtractorRouteKey,
-  CorpusExtractorTargets,
+  McpExtractorTargetConfig,
   NormalizedCorpusExtractorRoutes,
   ChunkingConfig,
   ChunkingStrategy,
@@ -55,6 +55,61 @@ const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type ViewMode = "overview" | "corpus";
 type CorpusTab = "documents" | "settings" | "document-chunks";
+type ExtractorDraftTarget = McpExtractorTargetConfig;
+type ExtractorDraftRoute = [ExtractorDraftTarget, ExtractorDraftTarget];
+type ExtractorDraftRoutes = Record<CorpusExtractorRouteKey, ExtractorDraftRoute>;
+
+function createEmptyExtractorTarget(priority: number): ExtractorDraftTarget {
+  return {
+    server_id: "",
+    tool_name: "",
+    priority,
+    enabled: true,
+  };
+}
+
+function createExtractorDraftTargets(
+  targets: ReadonlyArray<McpExtractorTargetConfig>,
+): ExtractorDraftRoute {
+  return [0, 1].map((priority) => {
+    const existing = targets.find((item) => item.priority === priority) || targets[priority];
+    return existing
+      ? {
+          ...existing,
+          priority,
+          enabled: existing.enabled !== false,
+        }
+      : createEmptyExtractorTarget(priority);
+  }) as ExtractorDraftRoute;
+}
+
+function createExtractorDraftRoutes(
+  config?: Record<string, unknown> | null,
+): ExtractorDraftRoutes {
+  const normalized = normalizeCorpusExtractorRoutes(config);
+  return {
+    url: createExtractorDraftTargets(normalized.url.targets),
+    file_pdf: createExtractorDraftTargets(normalized.file_pdf.targets),
+  };
+}
+
+function buildExtractorRoutesFromDraft(
+  draft: ExtractorDraftRoutes,
+): NormalizedCorpusExtractorRoutes {
+  const buildTargets = (targets: ExtractorDraftRoute) =>
+    targets
+      .filter((item) => item.server_id && item.tool_name)
+      .map((item, priority) => ({
+        ...item,
+        priority,
+        enabled: item.enabled !== false,
+      }));
+
+  return {
+    url: { targets: buildTargets(draft.url) },
+    file_pdf: { targets: buildTargets(draft.file_pdf) },
+  };
+}
 
 function CorpusStatusBadge({ corpus }: { corpus: CorpusRecord }) {
   const hasKnowledge = corpus.knowledge_count > 0;
@@ -1301,11 +1356,20 @@ function CorpusSettingsPanel({
   const [formConfig, setFormConfig] = useState<ChunkingConfig>(
     normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
   );
-  const [extractorRoutes, setExtractorRoutes] = useState<NormalizedCorpusExtractorRoutes>(
-    normalizeCorpusExtractorRoutes((corpus.config || {}) as Record<string, unknown>),
+  const [extractorDraftRoutes, setExtractorDraftRoutes] = useState<ExtractorDraftRoutes>(
+    createExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
   );
   const [servers, setServers] = useState<Array<{ id: string; name: string; display_name: string | null; is_enabled: boolean }>>([]);
   const [toolsByServer, setToolsByServer] = useState<Record<string, Array<{ name: string; display_name: string | null; is_enabled: boolean }>>>({});
+
+  useEffect(() => {
+    setFormConfig(
+      normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
+    );
+    setExtractorDraftRoutes(
+      createExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
+    );
+  }, [corpus.id, corpus.config]);
 
   useEffect(() => {
     let active = true;
@@ -1353,17 +1417,9 @@ function CorpusSettingsPanel({
   }, []);
 
   const handleSubmit = async () => {
-    await onSave(buildCorpusConfig(formConfig, extractorRoutes));
-  };
-
-  const updateRouteTargets = (
-    routeKey: CorpusExtractorRouteKey,
-    targets: CorpusExtractorTargets,
-  ) => {
-    setExtractorRoutes((prev) => ({
-      ...prev,
-      [routeKey]: { targets },
-    }));
+    await onSave(
+      buildCorpusConfig(formConfig, buildExtractorRoutesFromDraft(extractorDraftRoutes)),
+    );
   };
 
   return (
@@ -1371,14 +1427,14 @@ function CorpusSettingsPanel({
       <ChunkingStrategyPanel
         config={formConfig}
         onChange={setFormConfig}
-        title="Settings"
+        title="Chunking Settings"
         description="保存后作为该 Corpus 的默认分块配置。"
       />
 
       <div className="rounded-2xl border border-border bg-background p-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-sm font-semibold">Data Extractor MCP</h3>
+            <h3 className="text-sm font-semibold">Document Extraction Settings</h3>
             <p className="mt-1 text-xs text-muted">
               为当前 Knowledge Base 分别绑定 URL 与 PDF 的主备 MCP Server / Tool。已配置类型严格依赖所选 MCP，只会在主备之间切换。
             </p>
@@ -1389,7 +1445,7 @@ function CorpusSettingsPanel({
           ["url", "URL 文档", "页面抓取、正文抽取、Markdown 化"],
           ["file_pdf", "PDF 文档", "PDF 解析、Markdown 转换、图片提取"],
         ] as const).map(([routeKey, title, description]) => {
-          const targets = extractorRoutes[routeKey].targets;
+          const targets = extractorDraftRoutes[routeKey];
           return (
             <div key={routeKey} className="mt-4 rounded-xl border border-border p-3">
               <div className="mb-3">
@@ -1400,32 +1456,63 @@ function CorpusSettingsPanel({
                 {[0, 1].map((index) => {
                   const target = targets[index];
                   const selectedServerId = target?.server_id || "";
-                  const toolOptions = selectedServerId ? (toolsByServer[selectedServerId] || []) : [];
+                  const toolOptions = selectedServerId
+                    ? (toolsByServer[selectedServerId] || [])
+                    : [];
+                  const selectedServer =
+                    servers.find((server) => server.id === selectedServerId) || null;
+                  const hasSelectedTool = toolOptions.some(
+                    (tool) => tool.name === target.tool_name,
+                  );
 
-                  const nextTargets = [...targets];
-                  const nextTarget = target || {
-                    server_id: "",
-                    tool_name: "",
-                    priority: index,
-                    enabled: true,
-                  };
+                  const serverOptions = selectedServerId && !selectedServer
+                    ? [
+                        {
+                          id: selectedServerId,
+                          name: selectedServerId,
+                          display_name: "已配置 MCP（当前不可用）",
+                          is_enabled: false,
+                        },
+                        ...servers,
+                      ]
+                    : servers;
+                  const visibleToolOptions =
+                    target.tool_name && !hasSelectedTool
+                      ? [
+                          {
+                            name: target.tool_name,
+                            display_name: "已配置 Tool（当前不可用）",
+                            is_enabled: false,
+                          },
+                          ...toolOptions,
+                        ]
+                      : toolOptions;
 
-                  const setTarget = (patch: Record<string, unknown>) => {
-                    nextTargets[index] = {
-                      ...nextTarget,
-                      ...patch,
-                      priority: index,
-                      enabled: true,
-                    };
-                    updateRouteTargets(
-                      routeKey,
-                      nextTargets.filter((item) => item.server_id && item.tool_name),
-                    );
+                  const setTarget = (patch: Partial<ExtractorDraftTarget>) => {
+                    setExtractorDraftRoutes((prev) => {
+                      const nextRoute = [...prev[routeKey]] as ExtractorDraftRoute;
+                      nextRoute[index] = {
+                        ...nextRoute[index],
+                        ...patch,
+                        priority: index,
+                        enabled: true,
+                      };
+                      return {
+                        ...prev,
+                        [routeKey]: nextRoute,
+                      };
+                    });
                   };
 
                   const clearTarget = () => {
-                    nextTargets.splice(index, 1);
-                    updateRouteTargets(routeKey, nextTargets);
+                    setExtractorDraftRoutes((prev) => {
+                      const nextRoute = [...prev[routeKey]] as ExtractorDraftRoute;
+                      nextRoute[index] = createEmptyExtractorTarget(index);
+                      return {
+                        ...prev,
+                        [routeKey]: nextRoute,
+                      };
+                    });
                   };
 
                   return (
@@ -1443,7 +1530,7 @@ function CorpusSettingsPanel({
                           className="w-full rounded border border-border bg-background px-2 py-2"
                         >
                           <option value="">未配置</option>
-                          {servers.map((server) => (
+                          {serverOptions.map((server) => (
                             <option key={server.id} value={server.id}>
                               {server.display_name || server.name}
                             </option>
@@ -1459,7 +1546,7 @@ function CorpusSettingsPanel({
                           className="w-full rounded border border-border bg-background px-2 py-2 disabled:opacity-50"
                         >
                           <option value="">未配置</option>
-                          {toolOptions.map((tool) => (
+                          {visibleToolOptions.map((tool) => (
                             <option key={tool.name} value={tool.name}>
                               {tool.display_name || tool.name}
                             </option>

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -6,6 +6,7 @@ const {
   useKnowledgeBaseMock,
   loadCorpusMock,
   loadCorporaMock,
+  updateCorpusMock,
   deleteCorpusMock,
   deleteDocumentMock,
   ingestUrlMock,
@@ -15,11 +16,13 @@ const {
   fetchDocumentChunksMock,
   searchAcrossCorporaMock,
   documentViewDialogMock,
+  fetchMock,
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
   loadCorpusMock: vi.fn(),
   loadCorporaMock: vi.fn(),
+  updateCorpusMock: vi.fn(),
   deleteCorpusMock: vi.fn(),
   deleteDocumentMock: vi.fn(),
   ingestUrlMock: vi.fn(),
@@ -28,6 +31,7 @@ const {
   fetchDocumentChunksMock: vi.fn(),
   searchAcrossCorporaMock: vi.fn(),
   documentViewDialogMock: vi.fn(),
+  fetchMock: vi.fn(),
   searchParamsState: {
     value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
   },
@@ -153,6 +157,7 @@ describe("KnowledgeBasePage", () => {
     replaceMock.mockReset();
     loadCorpusMock.mockReset();
     loadCorporaMock.mockReset();
+    updateCorpusMock.mockReset();
     deleteCorpusMock.mockReset();
     deleteDocumentMock.mockReset();
     ingestUrlMock.mockReset();
@@ -161,10 +166,20 @@ describe("KnowledgeBasePage", () => {
     fetchDocumentChunksMock.mockReset();
     searchAcrossCorporaMock.mockReset();
     documentViewDialogMock.mockReset();
+    fetchMock.mockReset();
     searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
+
+    global.fetch = fetchMock;
 
     loadCorpusMock.mockResolvedValue(undefined);
     loadCorporaMock.mockResolvedValue(undefined);
+    updateCorpusMock.mockResolvedValue({
+      id: "11111111-1111-1111-1111-111111111111",
+      name: "Corpus Alpha",
+      app_name: "negentropy",
+      knowledge_count: 3,
+      config: {},
+    });
     deleteCorpusMock.mockResolvedValue(undefined);
     deleteDocumentMock.mockResolvedValue(undefined);
     ingestUrlMock.mockResolvedValue({});
@@ -200,6 +215,42 @@ describe("KnowledgeBasePage", () => {
       ],
     });
 
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/plugins/mcp/servers") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: "server-1",
+              name: "doc-extractor",
+              display_name: "Doc Extractor",
+              is_enabled: true,
+            },
+          ],
+        } as Response;
+      }
+
+      if (url === "/api/plugins/mcp/servers/server-1/tools") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              name: "extract_markdown",
+              display_name: "Extract Markdown",
+              is_enabled: true,
+            },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({ detail: "not found" }),
+      } as Response;
+    });
+
     useKnowledgeBaseMock.mockImplementation(() => ({
       corpora: [
         {
@@ -214,7 +265,7 @@ describe("KnowledgeBasePage", () => {
       loadCorpora: loadCorporaMock,
       loadCorpus: loadCorpusMock,
       createCorpus: vi.fn(),
-      updateCorpus: vi.fn(),
+      updateCorpus: updateCorpusMock,
       deleteCorpus: deleteCorpusMock,
       ingestUrl: ingestUrlMock,
       ingestFile: ingestFileMock,
@@ -540,9 +591,67 @@ describe("KnowledgeBasePage", () => {
     });
 
     expect(
-      screen.getByRole("heading", { name: "Settings" }),
+      screen.getByRole("heading", { name: "Chunking Settings" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Document Extraction Settings" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
+  });
+
+  it("settings 视图选择 MCP Server 后不会回退为未配置，并可继续选择 Tool 后保存", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=settings";
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const serverSelect = screen.getAllByLabelText("MCP Server")[0];
+    const toolSelect = screen.getAllByLabelText("Tool")[0];
+
+    expect(serverSelect).toHaveValue("");
+    expect(toolSelect).toBeDisabled();
+
+    await user.selectOptions(serverSelect, "server-1");
+
+    expect(serverSelect).toHaveValue("server-1");
+    expect(toolSelect).not.toBeDisabled();
+    expect(toolSelect).toHaveValue("");
+
+    await user.selectOptions(toolSelect, "extract_markdown");
+
+    expect(toolSelect).toHaveValue("extract_markdown");
+
+    await user.click(screen.getByRole("button", { name: "Save Settings" }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(updateCorpusMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      {
+        config: expect.objectContaining({
+          extractor_routes: {
+            url: {
+              targets: [
+                {
+                  server_id: "server-1",
+                  tool_name: "extract_markdown",
+                  priority: 0,
+                  enabled: true,
+                },
+              ],
+            },
+            file_pdf: { targets: [] },
+          },
+        }),
+      },
+    );
   });
 
   it("settings 视图中 semantic 与 hierarchical 只展示各自有效字段", async () => {
@@ -990,7 +1099,7 @@ describe("KnowledgeBasePage", () => {
       loadCorpora: loadCorporaMock,
       loadCorpus: loadCorpusMock,
       createCorpus: vi.fn(),
-      updateCorpus: vi.fn(),
+      updateCorpus: updateCorpusMock,
       deleteCorpus: deleteCorpusMock,
       ingestUrl: vi.fn(),
       ingestFile: vi.fn(),


### PR DESCRIPTION
## 变更说明

本次改动修复 `Knowledge Base` 页面 `Documents` 视图下 `Settings` 面板的两类问题：

1. 调整设置区文案命名，使分块配置与文档提取配置的语义更清晰：
   - `Settings` -> `Chunking Settings`
   - `Data Extractor MCP` -> `Document Extraction Settings`

2. 修复文档提取配置中选择 MCP Server 后立即回退为“未配置”、导致无法继续选择 Tool 的问题，并补齐相关状态同步与回显兼容逻辑。

## 为什么要改

该问题会直接破坏 `Knowledge Base` 的文档提取配置链路：用户在设置 URL/PDF 文档的 MCP Server / Tool 时，刚选中的 Server 会立刻被清空，Tool 下拉也因此无法稳定进入可选状态，导致配置无法完成。

从实现上看，这不是单点 bug，而是多个状态管理问题叠加导致的：

- 前端在编辑过程中把“未同时选中 server_id + tool_name”的条目直接过滤掉，导致刚选完 Server、尚未选 Tool 的中间态被立即删除；
- `select` 组件使用受控值绑定到被过滤后的状态，进而出现回退到“未配置”的现象；
- 设置面板本地 state 仅在首次挂载时初始化，后续 `corpus.config` 更新后不会同步，存在保存后回显漂移风险；
- 已保存但当前不可用的 MCP Server / Tool 缺少兼容回显，存在历史配置被静默吞掉的风险。

## 具体实现

### 1. 重构提取配置的前端状态模型
在 `apps/negentropy-ui/app/knowledge/base/page.tsx` 中，将提取配置从“即时过滤后的持久态”改为“固定双槽位草稿态”：

- 为 `url` 和 `file_pdf` 各保留两个稳定槽位（主用 / 备用）；
- 允许槽位处于“已选 Server、未选 Tool”的合法中间态；
- 仅在点击保存时，才把草稿态转换为 `extractor_routes` 并过滤掉不完整项。

这遵循受控表单的经典做法：编辑态与提交态分离，避免用户输入过程中因数据清洗过早介入而破坏交互。

### 2. 修复配置回显与 props/state 同步
新增对 `corpus.id` 与 `corpus.config` 变化的同步逻辑：

- 切换 corpus 或保存后重新加载配置时，设置面板会重新从最新配置规范化本地 state；
- 避免面板停留在旧 state，保证保存后回显一致。

### 3. 增强不可用配置的兼容显示
当已保存的配置引用了当前不可用的 MCP Server / Tool 时：

- Server 下拉会保留一个“已配置 MCP（当前不可用）”选项；
- Tool 下拉会保留一个“已配置 Tool（当前不可用）”选项。

这样不会因为服务禁用、权限变化或工具下线而把历史配置静默清空，降低误配置与回归风险。

### 4. 补充回归测试
在 `apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx` 中补充并更新测试，覆盖：

- Settings 区标题文案更新；
- 选择 MCP Server 后不再回退为“未配置”；
- 选中 Server 后可以继续选择 Tool；
- 保存时 `extractor_routes` 载荷正确；
- 相关 mock 补齐，确保设置面板依赖的 MCP server/tool 请求路径可验证。

## 验证结果

已通过前端测试验证：

- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/KnowledgeBasePage.test.tsx`

实际运行结果为前端测试全集通过：

- 36 个 test files passed
- 181 个 tests passed

## 影响范围与兼容性

- 不修改后端 API 结构；
- 不修改 `extractor_routes` 的持久化格式；
- 不影响现有 chunking 配置保存逻辑；
- 兼容已保存但暂时不可用的 MCP Server / Tool 配置，避免引入新的配置丢失问题。
