### PR TITLE
refactor(session): 收敛会话ACK响应校验与透传入口;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -68,20 +68,26 @@ export async function POST(
 
   const text = await upstreamResponse.text();
   if (!upstreamResponse.ok) {
-    return NextResponse.json(
-      {
-        error: {
-          code: AGUI_ERROR_CODES.UPSTREAM_ERROR,
-          message: text || "Upstream returned non-OK status",
-        },
-      },
-      { status: upstreamResponse.status }
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      text || "Upstream returned non-OK status"
     );
   }
 
   try {
-    return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+    const payload = JSON.parse(text) as unknown;
+    const parsed = safeParseSessionArchiveResponse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        "Invalid upstream session archive payload"
+      );
+    }
+    return Response.json(parsed.data, { status: upstreamResponse.status });
   } catch {
-    return NextResponse.json({ raw: text }, { status: upstreamResponse.status });
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      "Invalid upstream session archive JSON"
+    );
   }
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { safeParseSessionTitleResponse } from "@/lib/agui/session-schema";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -72,20 +72,26 @@ export async function PATCH(
 
   const text = await upstreamResponse.text();
   if (!upstreamResponse.ok) {
-    return NextResponse.json(
-      {
-        error: {
-          code: AGUI_ERROR_CODES.UPSTREAM_ERROR,
-          message: text || "Upstream returned non-OK status",
-        },
-      },
-      { status: upstreamResponse.status },
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      text || "Upstream returned non-OK status"
     );
   }
 
   try {
-    return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+    const payload = JSON.parse(text) as unknown;
+    const parsed = safeParseSessionTitleResponse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        "Invalid upstream session title payload"
+      );
+    }
+    return Response.json(parsed.data, { status: upstreamResponse.status });
   } catch {
-    return NextResponse.json({ raw: text }, { status: upstreamResponse.status });
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      "Invalid upstream session title JSON"
+    );
   }
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -68,20 +68,26 @@ export async function POST(
 
   const text = await upstreamResponse.text();
   if (!upstreamResponse.ok) {
-    return NextResponse.json(
-      {
-        error: {
-          code: AGUI_ERROR_CODES.UPSTREAM_ERROR,
-          message: text || "Upstream returned non-OK status",
-        },
-      },
-      { status: upstreamResponse.status }
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      text || "Upstream returned non-OK status"
     );
   }
 
   try {
-    return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+    const payload = JSON.parse(text) as unknown;
+    const parsed = safeParseSessionArchiveResponse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        "Invalid upstream session unarchive payload"
+      );
+    }
+    return Response.json(parsed.data, { status: upstreamResponse.status });
   } catch {
-    return NextResponse.json({ raw: text }, { status: upstreamResponse.status });
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      "Invalid upstream session unarchive JSON"
+    );
   }
 }

--- a/apps/negentropy-ui/lib/agui/session-schema.ts
+++ b/apps/negentropy-ui/lib/agui/session-schema.ts
@@ -39,9 +39,25 @@ export const aguiCreateSessionResponseSchema = z
   })
   .passthrough();
 
+export const aguiSessionArchiveResponseSchema = z
+  .object({
+    status: z.literal("ok"),
+    archived: z.boolean(),
+  })
+  .passthrough();
+
+export const aguiSessionTitleResponseSchema = z
+  .object({
+    status: z.literal("ok"),
+    title: z.string().nullable(),
+  })
+  .passthrough();
+
 export type AguiSessionSummary = z.infer<typeof aguiSessionSummarySchema>;
 export type AguiSessionDetail = z.infer<typeof aguiSessionDetailSchema>;
 export type AguiCreateSessionResponse = z.infer<typeof aguiCreateSessionResponseSchema>;
+export type AguiSessionArchiveResponse = z.infer<typeof aguiSessionArchiveResponseSchema>;
+export type AguiSessionTitleResponse = z.infer<typeof aguiSessionTitleResponseSchema>;
 
 export function safeParseSessionListResponse(input: unknown) {
   return aguiSessionListSchema.safeParse(input);
@@ -53,4 +69,12 @@ export function safeParseSessionDetailResponse(input: unknown) {
 
 export function safeParseCreateSessionResponse(input: unknown) {
   return aguiCreateSessionResponseSchema.safeParse(input);
+}
+
+export function safeParseSessionArchiveResponse(input: unknown) {
+  return aguiSessionArchiveResponseSchema.safeParse(input);
+}
+
+export function safeParseSessionTitleResponse(input: unknown) {
+  return aguiSessionTitleResponseSchema.safeParse(input);
 }

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -10,6 +10,9 @@ import { POST } from "@/app/api/agui/route";
 import { GET } from "@/app/api/agui/sessions/list/route";
 import { GET as getSessionDetail } from "@/app/api/agui/sessions/[sessionId]/route";
 import { POST as createSession } from "@/app/api/agui/sessions/route";
+import { POST as archiveSession } from "@/app/api/agui/sessions/[sessionId]/archive/route";
+import { PATCH as updateSessionTitle } from "@/app/api/agui/sessions/[sessionId]/title/route";
+import { POST as unarchiveSession } from "@/app/api/agui/sessions/[sessionId]/unarchive/route";
 
 // Mock 环境变量
 const mockEnv = {
@@ -408,5 +411,245 @@ describe("POST /api/agui/sessions", () => {
     expect(response.status).toBe(502);
     expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
     expect(data.error.message).toContain("Invalid upstream session create payload");
+  });
+});
+
+describe("Session mutation proxy routes", () => {
+  beforeEach(() => {
+    process.env.AGUI_BASE_URL = mockEnv.AGUI_BASE_URL;
+    process.env.NEXT_PUBLIC_AGUI_APP_NAME = mockEnv.NEXT_PUBLIC_AGUI_APP_NAME;
+    process.env.NEXT_PUBLIC_AGUI_USER_ID = mockEnv.NEXT_PUBLIC_AGUI_USER_ID;
+  });
+
+  afterEach(() => {
+    delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_APP_NAME;
+    delete process.env.NEXT_PUBLIC_AGUI_USER_ID;
+    vi.restoreAllMocks();
+  });
+
+  it("archive 成功时应返回结构化 ACK", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok", archived: true }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/archive", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await archiveSession(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: "ok", archived: true });
+  });
+
+  it("archive 非法 payload 时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok" }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/archive", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await archiveSession(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session archive payload");
+  });
+
+  it("archive 非法 JSON 时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => "not-json",
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/archive", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await archiveSession(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session archive JSON");
+  });
+
+  it("unarchive 成功时应返回结构化 ACK", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok", archived: false }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/unarchive", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await unarchiveSession(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: "ok", archived: false });
+  });
+
+  it("unarchive 非法 payload 时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok", archived: "nope" }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/unarchive", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await unarchiveSession(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session unarchive payload");
+  });
+
+  it("unarchive 非法 JSON 时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => "not-json",
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/unarchive", {
+      method: "POST",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+      }),
+    });
+
+    const response = await unarchiveSession(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session unarchive JSON");
+  });
+
+  it("title 成功时应返回结构化 ACK", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok", title: "Renamed" }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/title", {
+      method: "PATCH",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+        title: "Renamed",
+      }),
+    });
+
+    const response = await updateSessionTitle(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: "ok", title: "Renamed" });
+  });
+
+  it("title 非法 payload 时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok" }),
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/title", {
+      method: "PATCH",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+        title: "Renamed",
+      }),
+    });
+
+    const response = await updateSessionTitle(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session title payload");
+  });
+
+  it("title 非法 JSON 时应返回结构化错误", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => "not-json",
+    } as Response);
+
+    const request = createMockRequest("http://localhost:3000/api/agui/sessions/s1/title", {
+      method: "PATCH",
+      body: JSON.stringify({
+        app_name: "negentropy",
+        user_id: "test",
+        title: "Renamed",
+      }),
+    });
+
+    const response = await updateSessionTitle(request, {
+      params: Promise.resolve({ sessionId: "s1" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toContain("Invalid upstream session title JSON");
   });
 });


### PR DESCRIPTION
## 背景
- 上一轮已经把 `sessions/list`、`sessions/[id]` 和 `sessions` create 收敛到统一 session schema，但 `archive`、`title`、`unarchive` 三个剩余 session 代理路由仍在透传上游响应。
- 当前实现里，这三个路由在上游返回 200 时直接 `JSON.parse(text)`，解析失败则回退 `{ raw: text }`，错误分支也没有统一走结构化 `AGUI_UPSTREAM_ERROR`。
- 本 PR 继续沿用既有 session validator 分层模式，把剩余 session ACK 类响应全部纳入 schema 体系，彻底清掉 session BFF 层的透传入口。

## 核心变更
- 在 `apps/negentropy-ui/lib/agui/session-schema.ts` 中新增 session ACK validator：
  - archive / unarchive：`{ status: "ok", archived: boolean }`
  - title：`{ status: "ok", title: string | null }`
- `archive`、`title`、`unarchive` 三条代理路由统一改为：
  - 上游非 `ok` 响应返回结构化 `AGUI_UPSTREAM_ERROR`
  - 上游 `ok` 响应先 parse JSON，再做 schema 校验
  - payload 非法或 JSON 非法时返回结构化 `AGUI_UPSTREAM_ERROR`
  - 成功时仅返回已验证 ACK DTO，不再透传任意 JSON，也不再回 `{ raw: text }`
- API 集成测试补充 archive/title/unarchive 的成功、非法 payload、非法 JSON 三类用例，覆盖这轮新增边界。

## 变更原因
- 目标是把 session BFF 层彻底收敛为 anti-corruption layer，避免上游协议漂移继续直接穿透到页面状态或调用方错误处理。
- 这次补齐剩余 ACK 响应后，session 相关代理链路在 validator 责任划分上就不再分裂成“部分 schema 化、部分透传”两套模式。

## 重要实现细节
- ACK schema 的最小契约直接对齐后端 `apps/negentropy/src/negentropy/engine/sessions_api.py` 的权威返回模型，而不是在 UI 侧重新猜测完整响应结构。
- 前端消费侧行为保持不变：`archiveSession`、`unarchiveSession`、`renameSession` 仍只在失败分支读取 `payload.error.message`，成功后的状态更新逻辑不调整。
- 本次不引入新的页面状态字段，不改变 archived 列表切换、rename 成功后 reload、或当前会话清理逻辑。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 全量结果：36 个测试文件、189 个测试全部通过
- GitHub Actions：
  - `UI Test Suite` pull_request run `22796406163` 成功
  - `UI Test Suite` push run `22796400099` 成功

## Next Best Action
- 把 session 代理层里重复的“读取上游文本 -> parse -> schema -> 结构化错误”流程再抽成一个轻量 route helper，后续新增 session 端点时可以直接复用，继续降低实现偏差。
