### PR TITLE
fix(chat): 修复 Chat 页对话流与输入框边界对齐;

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -17,6 +17,7 @@ import { useAuth } from "../components/providers/AuthProvider";
 import { LogBufferPanel } from "../components/ui/LogBufferPanel";
 import { SessionList } from "../components/ui/SessionList";
 import { StateSnapshot } from "../components/ui/StateSnapshot";
+import { CHAT_CONTENT_RAIL_CLASS } from "../components/ui/chat-layout";
 import { AdkEventPayload } from "@/lib/adk";
 import { collectAdkEventPayloads } from "@/lib/adk";
 
@@ -843,8 +844,6 @@ export function HomeBody({
     return logEntries.filter((entry) => entry.timestamp <= cutoffMs);
   }, [logEntries, nodeTimestampIndex, selectedNodeId]);
 
-  const contentWidthClass = "max-w-4xl";
-
   return (
     <div className="h-full flex flex-col bg-zinc-50 text-zinc-900 overflow-hidden dark:bg-zinc-950 dark:text-zinc-100">
       <div className="flex h-full overflow-hidden relative">
@@ -936,10 +935,9 @@ export function HomeBody({
                   setSelectedNodeId(id);
                 }
               }}
-              contentClassName={contentWidthClass}
             />
             <div
-              className={`p-6 pt-2 shrink-0 w-full mx-auto ${contentWidthClass}`}
+              className={`${CHAT_CONTENT_RAIL_CLASS} shrink-0 w-full pt-2 pb-6`}
             >
               <Composer
                 value={inputValue}

--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { ConversationNodeRenderer } from "./conversation/ConversationNodeRenderer";
+import { CHAT_CONTENT_RAIL_CLASS } from "./chat-layout";
 import type { ConversationNode } from "@/types/a2ui";
 
 type ChatStreamProps = {
@@ -39,7 +40,7 @@ export function ChatStream({
       className="flex-1 overflow-y-auto custom-scrollbar"
     >
       <div
-        className={`mx-auto w-full space-y-4 py-6 ${contentClassName ?? ""}`}
+        className={`${CHAT_CONTENT_RAIL_CLASS} space-y-4 py-6 ${contentClassName ?? ""}`}
       >
         {visibleNodes.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">

--- a/apps/negentropy-ui/components/ui/chat-layout.ts
+++ b/apps/negentropy-ui/components/ui/chat-layout.ts
@@ -1,0 +1,2 @@
+export const CHAT_CONTENT_RAIL_CLASS =
+  "mx-auto w-full max-w-4xl px-6 sm:px-8";

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -303,6 +303,11 @@ export function ConversationNodeRenderer({
 
   const selected = node.id === selectedNodeId;
   const visibleChildren = node.children.filter((child) => child.visibility !== "debug-only");
+  const shouldOffset = node.type !== "turn" && node.type !== "text";
+  const offsetStyle =
+    shouldOffset && depth > 0
+      ? { marginLeft: `${Math.min(depth, 3) * 18}px` }
+      : undefined;
   const content = (() => {
     if (node.type === "turn") {
       return <TurnNode node={node} selected={selected} onSelect={onNodeSelect} />;
@@ -315,7 +320,7 @@ export function ConversationNodeRenderer({
 
   return (
     <div className="relative">
-      <div style={{ marginLeft: `${depth * 18}px` }}>
+      <div style={offsetStyle}>
         {content}
         {visibleChildren.length > 0 ? (
           <div className="mt-3 space-y-3">

--- a/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { ChatStream } from "../../components/ui/ChatStream";
+import { CHAT_CONTENT_RAIL_CLASS } from "../../components/ui/chat-layout";
 import type { ConversationNode } from "@/types/a2ui";
 
 vi.mock("@/components/providers/AuthProvider", () => ({
@@ -81,7 +82,7 @@ describe("ChatStream", () => {
     expect(screen.getAllByText("search").length).toBeGreaterThan(0);
   });
 
-  it("不渲染消息左侧层级竖线，且保留页面级宽度控制", () => {
+  it("使用统一内容轨道类控制主聊天区宽度与水平留白", () => {
     const nodes: ConversationNode[] = [
       {
         id: "turn:1",
@@ -142,16 +143,14 @@ describe("ChatStream", () => {
       },
     ];
 
-    const { container } = render(
-      <ChatStream nodes={nodes} contentClassName="max-w-4xl" />,
-    );
+    const { container } = render(<ChatStream nodes={nodes} />);
 
     expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
 
     const contentWrapper = container.querySelector(".space-y-4");
-    expect(contentWrapper?.className).toContain("max-w-4xl");
-    expect(contentWrapper?.className).not.toContain("px-10");
-    expect(contentWrapper?.className).not.toContain("sm:px-12");
+    CHAT_CONTENT_RAIL_CLASS.split(" ").forEach((className) => {
+      expect(contentWrapper?.className).toContain(className);
+    });
   });
 
   it("不渲染 debug-only 根节点，并将技术节点折叠为摘要卡片", () => {

--- a/apps/negentropy-ui/tests/unit/Composer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/Composer.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Composer } from "../../components/ui/Composer";
+import { CHAT_CONTENT_RAIL_CLASS } from "../../components/ui/chat-layout";
 
 describe("Composer", () => {
   it("calls onSend on button click", async () => {
@@ -24,5 +25,11 @@ describe("Composer", () => {
     const onChange = vi.fn();
     render(<Composer value="" onChange={onChange} onSend={onSend} disabled={false} />);
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("聊天输入区与消息流复用同一内容轨道常量", () => {
+    expect(CHAT_CONTENT_RAIL_CLASS).toContain("max-w-4xl");
+    expect(CHAT_CONTENT_RAIL_CLASS).toContain("px-6");
+    expect(CHAT_CONTENT_RAIL_CLASS).toContain("sm:px-8");
   });
 });


### PR DESCRIPTION
## 变更说明

本次改动聚焦于 Chat 页主对话区的布局一致性，修复对话框与输入框在不同侧栏状态下左右边界不共线的问题。

### 做了什么

- 提取统一的聊天内容轨道常量，供消息流与输入区共同复用
- 调整 Chat 主页面布局，使消息列表和输入框始终落在同一组宽度与水平留白约束上
- 调整会话树渲染逻辑，避免 `turn` / `text` 主对话节点因外层层级缩进而改变卡片边界
- 更新单元测试，增加对统一内容轨道约束的回归校验

### 为什么这样改

原始问题是 Chat 页中轮次卡片、消息气泡和输入框的左右边界没有严格落在同一条竖线上，且在 `Sessions`、`State` 两侧面板展开或收起时更容易出现错位。

这次修复采用了业界常见的“共享内容轨道（shared content rail）”布局思路：主内容区的关键元素统一复用同一套宽度与水平 padding 约束，而不是分别维护各自的宽度或通过层级缩进改变外框边界。这样可以在不影响现有交互功能的前提下，稳定保证视觉对齐。

### 关键实现细节

- 新增 `CHAT_CONTENT_RAIL_CLASS` 作为聊天主内容区的单一事实源
- `ChatStream` 与输入区容器统一复用该轨道定义，避免宽度策略分叉
- `ConversationNodeRenderer` 仅对技术性节点保留有限缩进，不再让主对话节点的外框随深度发生水平偏移
- 测试覆盖统一内容轨道常量的复用关系，降低后续样式回归风险

### 影响范围

- 仅涉及 Chat 页前端布局与对应测试
- 不涉及后端接口、数据结构、业务流程变更
- 不改变现有消息发送、会话切换、历史视图、侧栏开关等功能行为
