### PR TITLE
fix(knowledge): 收敛文档提取设置面板状态与回归覆盖;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1363,13 +1363,14 @@ function CorpusSettingsPanel({
   const [toolsByServer, setToolsByServer] = useState<Record<string, Array<{ name: string; display_name: string | null; is_enabled: boolean }>>>({});
 
   useEffect(() => {
+    // 仅在切换 corpus 时重置本地草稿，避免外部刷新覆盖未保存编辑。
     setFormConfig(
       normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
     );
     setExtractorDraftRoutes(
       createExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
     );
-  }, [corpus.id, corpus.config]);
+  }, [corpus.id]);
 
   useEffect(() => {
     let active = true;

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -654,6 +654,146 @@ describe("KnowledgeBasePage", () => {
     );
   });
 
+  it("settings 视图会保留当前不可用的已配置 MCP Server 与 Tool 回显", async () => {
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=settings";
+
+    useKnowledgeBaseMock.mockImplementation(() => ({
+      corpora: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "Corpus Alpha",
+          app_name: "negentropy",
+          knowledge_count: 3,
+          config: {
+            extractor_routes: {
+              url: {
+                targets: [
+                  {
+                    server_id: "server-legacy",
+                    tool_name: "tool-legacy",
+                    priority: 0,
+                    enabled: true,
+                  },
+                ],
+              },
+              file_pdf: { targets: [] },
+            },
+          },
+        },
+      ],
+      isLoading: false,
+      loadCorpora: loadCorporaMock,
+      loadCorpus: loadCorpusMock,
+      createCorpus: vi.fn(),
+      updateCorpus: updateCorpusMock,
+      deleteCorpus: deleteCorpusMock,
+      ingestUrl: ingestUrlMock,
+      ingestFile: ingestFileMock,
+    }));
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const serverSelect = screen.getAllByLabelText("MCP Server")[0];
+    const toolSelect = screen.getAllByLabelText("Tool")[0];
+
+    expect(serverSelect).toHaveValue("server-legacy");
+    expect(toolSelect).toHaveValue("tool-legacy");
+    expect(
+      within(serverSelect).getByRole("option", { name: "已配置 MCP（当前不可用）" }),
+    ).toBeInTheDocument();
+    expect(
+      within(toolSelect).getByRole("option", { name: "已配置 Tool（当前不可用）" }),
+    ).toBeInTheDocument();
+  });
+
+  it("外部 corpus 刷新不会覆盖 settings 视图中未保存的 MCP 草稿", async () => {
+    const user = userEvent.setup();
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=settings";
+
+    const baseCorpus = {
+      id: "11111111-1111-1111-1111-111111111111",
+      name: "Corpus Alpha",
+      app_name: "negentropy",
+      knowledge_count: 3,
+      config: {},
+    };
+    const refreshedCorpus = {
+      ...baseCorpus,
+      config: {
+        strategy: "fixed",
+        chunk_size: 1024,
+        overlap: 50,
+        extractor_routes: {
+          url: {
+            targets: [
+              {
+                server_id: "server-from-refresh",
+                tool_name: "tool-from-refresh",
+                priority: 0,
+                enabled: true,
+              },
+            ],
+          },
+          file_pdf: { targets: [] },
+        },
+      },
+    };
+
+    useKnowledgeBaseMock.mockImplementation(() => ({
+      corpora: [baseCorpus],
+      isLoading: false,
+      loadCorpora: loadCorporaMock,
+      loadCorpus: loadCorpusMock,
+      createCorpus: vi.fn(),
+      updateCorpus: updateCorpusMock,
+      deleteCorpus: deleteCorpusMock,
+      ingestUrl: ingestUrlMock,
+      ingestFile: ingestFileMock,
+    }));
+
+    const { rerender } = render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const serverSelect = screen.getAllByLabelText("MCP Server")[0];
+    const toolSelect = screen.getAllByLabelText("Tool")[0];
+
+    await user.selectOptions(serverSelect, "server-1");
+    await user.selectOptions(toolSelect, "extract_markdown");
+
+    expect(serverSelect).toHaveValue("server-1");
+    expect(toolSelect).toHaveValue("extract_markdown");
+
+    useKnowledgeBaseMock.mockImplementation(() => ({
+      corpora: [refreshedCorpus],
+      isLoading: false,
+      loadCorpora: loadCorporaMock,
+      loadCorpus: loadCorpusMock,
+      createCorpus: vi.fn(),
+      updateCorpus: updateCorpusMock,
+      deleteCorpus: deleteCorpusMock,
+      ingestUrl: ingestUrlMock,
+      ingestFile: ingestFileMock,
+    }));
+
+    rerender(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getAllByLabelText("MCP Server")[0]).toHaveValue("server-1");
+    expect(screen.getAllByLabelText("Tool")[0]).toHaveValue("extract_markdown");
+  });
+
   it("settings 视图中 semantic 与 hierarchical 只展示各自有效字段", async () => {
     const user = userEvent.setup();
     searchParamsState.value =


### PR DESCRIPTION
## 变更说明

本次改动围绕 `Knowledge Base` 页面 `Documents` 视图下的设置面板，完成了两层收敛：

1. 修正文案命名，使设置区语义更清晰：
   - `Settings` -> `Chunking Settings`
   - `Data Extractor MCP` -> `Document Extraction Settings`

2. 修复并进一步收敛文档提取配置的状态管理：
   - 解决选择 MCP Server 后立即回退为“未配置”、导致 Tool 无法继续选择的问题；
   - 继续收敛设置面板的草稿态同步策略，避免外部配置刷新覆盖未保存编辑；
   - 补齐围绕不可用 MCP/Tool 回显与草稿保护的回归测试。

## 为什么要改

原始问题会直接阻断文档提取配置链路：在 URL/PDF 文档提取配置中，用户刚选中的 MCP Server 会被前端状态过滤逻辑立即清空，导致 Tool 下拉无法稳定进入可选状态，最终设置无法完成。

在首轮修复后，虽然交互主路径已恢复，但进一步审查发现，设置面板的长期状态模型仍存在收敛空间：

- 本地草稿态如果过度依赖 `corpus.config` 变化进行同步，外部刷新可能会静默覆盖用户尚未保存的编辑；
- 已保存但当前不可用的 MCP Server / Tool 需要稳定回显，否则历史配置会被误判为丢失；
- 仅覆盖“选择后不回退”的测试不足以支撑长期维护，还需要锁住“不可用配置回显”和“草稿不被刷新覆盖”这两类更容易回归的路径。

因此本次 PR 不只是一次 bug fix，也包含对设置面板状态管理模式的进一步收敛，使其更符合受控表单的经典实践：**UI 草稿态与持久化配置分离，切换实体时显式重置，而不是被任意外部刷新打断。**

## 具体实现

### 1. 修复文档提取设置的核心交互问题
在 `apps/negentropy-ui/app/knowledge/base/page.tsx` 中，将文档提取配置的编辑过程从“即时过滤后的持久态”调整为“固定双槽位草稿态”：

- 为 `url` 与 `file_pdf` 分别保留主用 / 备用两个稳定槽位；
- 允许槽位处于“已选 Server、未选 Tool”的合法中间态；
- 仅在点击保存时，才把草稿态转换成 `extractor_routes` 并过滤不完整项。

这样避免了编辑过程中因过早清洗数据而导致 `select` 受控值失配、回退成“未配置”。

### 2. 收敛草稿态同步策略
继续收敛设置面板本地状态的重置时机：

- 保留“切换不同 corpus 时重置本地草稿”的行为；
- 避免仅因外部 `corpus.config` 引用刷新，就无条件覆盖正在编辑中的本地草稿；
- 从而防止用户尚未保存的 MCP 配置被后台刷新或重新加载 silently 覆盖。

这符合长期可维护的设置面板模式：**用户编辑优先，显式切换时重置，避免 props 抖动吞掉输入。**

### 3. 增强不可用配置的兼容回显
对于已保存但当前不可用的 MCP Server / Tool：

- Server 下拉会保留“已配置 MCP（当前不可用）”占位选项；
- Tool 下拉会保留“已配置 Tool（当前不可用）”占位选项。

这样即使后续服务禁用、权限变化或工具下线，页面仍能正确表达“已有配置但当前不可用”，而不是把历史配置静默吞掉。

### 4. 补齐回归测试
在 `apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx` 中新增并强化了测试，覆盖：

- Settings 区标题文案更新；
- 选择 MCP Server 后不再回退为“未配置”；
- 选中 Server 后可以继续选择 Tool，并能正确保存 payload；
- 已保存但当前不可用的 MCP Server / Tool 仍然可以稳定回显；
- 外部 corpus 刷新不会覆盖 settings 视图中未保存的 MCP 草稿。

## 验证结果

已通过前端测试验证：

- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/KnowledgeBasePage.test.tsx`

实际运行结果为前端测试全集通过：

- 36 个 test files passed
- 183 个 tests passed

## 影响范围与兼容性

- 不修改后端 API 协议；
- 不修改 `extractor_routes` 的持久化格式；
- 不影响现有 chunking 配置保存逻辑；
- 强化了设置页在“外部刷新 / 不可用配置 / 未保存草稿”场景下的稳定性，降低后续状态回归风险。
