### PR TITLE
refactor(session): 抽取会话代理响应解析助手;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -66,28 +67,15 @@ export async function POST(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status"
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionArchiveResponse,
+    invalidPayloadMessage: "Invalid upstream session archive payload",
+    invalidJsonMessage: "Invalid upstream session archive JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionArchiveResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session archive payload"
-      );
-    }
-    return Response.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session archive JSON"
-    );
-  }
+  return Response.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionDetailResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -58,28 +59,15 @@ export async function GET(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status",
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionDetailResponse,
+    invalidPayloadMessage: "Invalid upstream session detail payload",
+    invalidJsonMessage: "Invalid upstream session detail JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionDetailResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session detail payload",
-      );
-    }
-    return NextResponse.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session detail JSON",
-    );
-  }
+  return NextResponse.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionTitleResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -70,28 +71,15 @@ export async function PATCH(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status"
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionTitleResponse,
+    invalidPayloadMessage: "Invalid upstream session title payload",
+    invalidJsonMessage: "Invalid upstream session title JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionTitleResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session title payload"
-      );
-    }
-    return Response.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session title JSON"
-    );
-  }
+  return Response.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -66,28 +67,15 @@ export async function POST(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status"
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionArchiveResponse,
+    invalidPayloadMessage: "Invalid upstream session unarchive payload",
+    invalidJsonMessage: "Invalid upstream session unarchive JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionArchiveResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session unarchive payload"
-      );
-    }
-    return Response.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session unarchive JSON"
-    );
-  }
+  return Response.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/_response.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/_response.ts
@@ -1,0 +1,53 @@
+import type { SafeParseReturnType } from "zod";
+import {
+  errorResponse as aguiErrorResponse,
+  AGUI_ERROR_CODES,
+} from "@/lib/errors";
+
+interface ParseSessionUpstreamJsonOptions<T> {
+  upstreamResponse: Response;
+  parse: (input: unknown) => SafeParseReturnType<unknown, T>;
+  invalidPayloadMessage: string;
+  invalidJsonMessage: string;
+}
+
+export interface ParsedSessionUpstreamJson<T> {
+  data: T;
+  status: number;
+}
+
+export async function parseSessionUpstreamJson<T>({
+  upstreamResponse,
+  parse,
+  invalidPayloadMessage,
+  invalidJsonMessage,
+}: ParseSessionUpstreamJsonOptions<T>): Promise<Response | ParsedSessionUpstreamJson<T>> {
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      text || "Upstream returned non-OK status",
+    );
+  }
+
+  try {
+    const payload = JSON.parse(text) as unknown;
+    const parsed = parse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        invalidPayloadMessage,
+      );
+    }
+
+    return {
+      data: parsed.data,
+      status: upstreamResponse.status,
+    };
+  } catch {
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      invalidJsonMessage,
+    );
+  }
+}

--- a/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionListResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -44,37 +45,26 @@ export async function GET(request: Request) {
     return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, `Upstream connection failed: ${String(error)}`);
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, text || "Upstream returned non-OK status");
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionListResponse,
+    invalidPayloadMessage: "Invalid upstream session list payload",
+    invalidJsonMessage: "Invalid upstream session list JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionListResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session list payload",
-      );
-    }
-    const sessions = parsed.data;
-
-    if (archived !== "true" && archived !== "false") {
-      return NextResponse.json(sessions, { status: upstreamResponse.status });
-    }
-
-    const includeArchived = archived === "true";
-    const filtered = sessions.filter((session) => {
-      const isArchived = session?.state?.metadata?.archived === true;
-      return includeArchived ? isArchived : !isArchived;
-    });
-
-    return NextResponse.json(filtered, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session list JSON",
-    );
+  const sessions = parsed.data;
+  if (archived !== "true" && archived !== "false") {
+    return NextResponse.json(sessions, { status: parsed.status });
   }
+
+  const includeArchived = archived === "true";
+  const filtered = sessions.filter((session) => {
+    const isArchived = session?.state?.metadata?.archived === true;
+    return includeArchived ? isArchived : !isArchived;
+  });
+
+  return NextResponse.json(filtered, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseCreateSessionResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -59,25 +60,15 @@ export async function POST(request: Request) {
     return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, `Upstream connection failed: ${String(error)}`);
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, text || "Upstream returned non-OK status");
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseCreateSessionResponse,
+    invalidPayloadMessage: "Invalid upstream session create payload",
+    invalidJsonMessage: "Invalid upstream session create JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseCreateSessionResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session create payload",
-      );
-    }
-    return NextResponse.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session create JSON",
-    );
-  }
+  return NextResponse.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/tests/unit/api/agui-session-response.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-session-response.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+
+const sessionAckSchema = z.object({
+  status: z.literal("ok"),
+  archived: z.boolean(),
+});
+
+describe("parseSessionUpstreamJson", () => {
+  it("当上游非 ok 时应返回结构化错误响应", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response("boom", { status: 503 }),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toBe("boom");
+  });
+
+  it("当上游 JSON 非法时应返回结构化错误响应", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response("not-json", { status: 200 }),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(502);
+    expect(data.error.message).toBe("Invalid JSON");
+  });
+
+  it("当上游 payload 非法时应返回结构化错误响应", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(502);
+    expect(data.error.message).toBe("Invalid payload");
+  });
+
+  it("当上游 payload 合法时应返回已验证数据和状态码", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response(
+        JSON.stringify({ status: "ok", archived: true }),
+        { status: 201 },
+      ),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).not.toBeInstanceOf(Response);
+    expect(result).toEqual({
+      data: { status: "ok", archived: true },
+      status: 201,
+    });
+  });
+});


### PR DESCRIPTION
## 背景
- 当前 session BFF 路由已经统一收敛到了“读取上游文本 -> JSON.parse -> schema safeParse -> 结构化错误”的模式，但这段逻辑仍然重复散落在 `list`、`detail`、`create`、`archive`、`title`、`unarchive` 六条路由里。
- 重复逻辑虽然语义一致，但容易在错误文案、状态码处理和返回包装上继续漂移，后续新增 session 端点时也需要再次复制。
- 本 PR 在不改变现有外部行为的前提下，抽取一个仅服务于 session BFF 的轻量响应解析 helper，继续压低实现偏差。

## 核心变更
- 新增 `apps/negentropy-ui/app/api/agui/sessions/_response.ts`，封装上游成功响应的统一解析流程：
  - 读取 upstream response text
  - 处理非 `ok` 响应并返回结构化 `AGUI_UPSTREAM_ERROR`
  - 解析 JSON
  - 执行调用方传入的 `safeParse`
  - 在 payload 非法或 JSON 非法时返回结构化 `AGUI_UPSTREAM_ERROR`
  - 在合法时返回已验证数据和原始状态码
- `sessions/list`、`sessions/[id]`、`sessions`、`archive`、`title`、`unarchive` 六条 session 路由改为统一复用该 helper。
- 路由仍然各自保留请求参数校验、upstream URL/headers/body 组装，以及 `list` 的 archived 过滤等业务后处理。
- 新增 helper 单测，直接覆盖非 `ok`、非法 JSON、非法 payload、合法 payload 四类核心分支。

## 变更原因
- 目标是把 session BFF 层已经事实收敛的解析链路正式提升为单一事实源，减少重复实现和未来继续漂移的机会。
- 通过把 helper 控制在 session 私有目录内，本次改动只收敛 session 代理层，不把 knowledge/plugins/memory 等不同错误语义的 proxy 机制强行耦合到一起。

## 重要实现细节
- helper 只抽取“上游成功响应解析 + schema 校验 + 结构化错误”这一段，不合并请求体校验、fetch 调用或路由业务逻辑，避免职责膨胀。
- `list` 路由仍在 helper 返回已验证 sessions 后执行 archived 过滤，保持当前行为不变。
- 现有 session DTO schema 和前端消费语义都不变；这轮是纯收敛重构，不引入新的 API 字段或 UI 状态逻辑。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 全量覆盖通过，新增 helper 单测与既有 session API 集成测试均成功

## Next Best Action
- 如果后续还要继续降熵，可以再把 session 路由里重复的 base URL 读取和 auth header 组装也抽成 session 私有 helper，但保持在 session 边界内，不和其他 proxy 体系强行合并。
