### PR TITLE
refactor(session): 抽取会话代理响应解析助手;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -66,28 +67,15 @@ export async function POST(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status"
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionArchiveResponse,
+    invalidPayloadMessage: "Invalid upstream session archive payload",
+    invalidJsonMessage: "Invalid upstream session archive JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionArchiveResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session archive payload"
-      );
-    }
-    return Response.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session archive JSON"
-    );
-  }
+  return Response.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionDetailResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -58,28 +59,15 @@ export async function GET(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status",
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionDetailResponse,
+    invalidPayloadMessage: "Invalid upstream session detail payload",
+    invalidJsonMessage: "Invalid upstream session detail JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionDetailResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session detail payload",
-      );
-    }
-    return NextResponse.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session detail JSON",
-    );
-  }
+  return NextResponse.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionTitleResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -70,28 +71,15 @@ export async function PATCH(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status"
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionTitleResponse,
+    invalidPayloadMessage: "Invalid upstream session title payload",
+    invalidJsonMessage: "Invalid upstream session title JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionTitleResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session title payload"
-      );
-    }
-    return Response.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session title JSON"
-    );
-  }
+  return Response.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
@@ -1,5 +1,6 @@
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -66,28 +67,15 @@ export async function POST(
     );
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      text || "Upstream returned non-OK status"
-    );
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionArchiveResponse,
+    invalidPayloadMessage: "Invalid upstream session unarchive payload",
+    invalidJsonMessage: "Invalid upstream session unarchive JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionArchiveResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session unarchive payload"
-      );
-    }
-    return Response.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session unarchive JSON"
-    );
-  }
+  return Response.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/_response.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/_response.ts
@@ -1,0 +1,53 @@
+import type { SafeParseReturnType } from "zod";
+import {
+  errorResponse as aguiErrorResponse,
+  AGUI_ERROR_CODES,
+} from "@/lib/errors";
+
+interface ParseSessionUpstreamJsonOptions<T> {
+  upstreamResponse: Response;
+  parse: (input: unknown) => SafeParseReturnType<unknown, T>;
+  invalidPayloadMessage: string;
+  invalidJsonMessage: string;
+}
+
+export interface ParsedSessionUpstreamJson<T> {
+  data: T;
+  status: number;
+}
+
+export async function parseSessionUpstreamJson<T>({
+  upstreamResponse,
+  parse,
+  invalidPayloadMessage,
+  invalidJsonMessage,
+}: ParseSessionUpstreamJsonOptions<T>): Promise<Response | ParsedSessionUpstreamJson<T>> {
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      text || "Upstream returned non-OK status",
+    );
+  }
+
+  try {
+    const payload = JSON.parse(text) as unknown;
+    const parsed = parse(payload);
+    if (!parsed.success) {
+      return aguiErrorResponse(
+        AGUI_ERROR_CODES.UPSTREAM_ERROR,
+        invalidPayloadMessage,
+      );
+    }
+
+    return {
+      data: parsed.data,
+      status: upstreamResponse.status,
+    };
+  } catch {
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.UPSTREAM_ERROR,
+      invalidJsonMessage,
+    );
+  }
+}

--- a/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionListResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -44,37 +45,26 @@ export async function GET(request: Request) {
     return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, `Upstream connection failed: ${String(error)}`);
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, text || "Upstream returned non-OK status");
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseSessionListResponse,
+    invalidPayloadMessage: "Invalid upstream session list payload",
+    invalidJsonMessage: "Invalid upstream session list JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseSessionListResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session list payload",
-      );
-    }
-    const sessions = parsed.data;
-
-    if (archived !== "true" && archived !== "false") {
-      return NextResponse.json(sessions, { status: upstreamResponse.status });
-    }
-
-    const includeArchived = archived === "true";
-    const filtered = sessions.filter((session) => {
-      const isArchived = session?.state?.metadata?.archived === true;
-      return includeArchived ? isArchived : !isArchived;
-    });
-
-    return NextResponse.json(filtered, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session list JSON",
-    );
+  const sessions = parsed.data;
+  if (archived !== "true" && archived !== "false") {
+    return NextResponse.json(sessions, { status: parsed.status });
   }
+
+  const includeArchived = archived === "true";
+  const filtered = sessions.filter((session) => {
+    const isArchived = session?.state?.metadata?.archived === true;
+    return includeArchived ? isArchived : !isArchived;
+  });
+
+  return NextResponse.json(filtered, { status: parsed.status });
 }

--- a/apps/negentropy-ui/app/api/agui/sessions/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseCreateSessionResponse } from "@/lib/agui/session-schema";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
@@ -59,25 +60,15 @@ export async function POST(request: Request) {
     return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, `Upstream connection failed: ${String(error)}`);
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return aguiErrorResponse(AGUI_ERROR_CODES.UPSTREAM_ERROR, text || "Upstream returned non-OK status");
+  const parsed = await parseSessionUpstreamJson({
+    upstreamResponse,
+    parse: safeParseCreateSessionResponse,
+    invalidPayloadMessage: "Invalid upstream session create payload",
+    invalidJsonMessage: "Invalid upstream session create JSON",
+  });
+  if (parsed instanceof Response) {
+    return parsed;
   }
 
-  try {
-    const payload = JSON.parse(text) as unknown;
-    const parsed = safeParseCreateSessionResponse(payload);
-    if (!parsed.success) {
-      return aguiErrorResponse(
-        AGUI_ERROR_CODES.UPSTREAM_ERROR,
-        "Invalid upstream session create payload",
-      );
-    }
-    return NextResponse.json(parsed.data, { status: upstreamResponse.status });
-  } catch {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.UPSTREAM_ERROR,
-      "Invalid upstream session create JSON",
-    );
-  }
+  return NextResponse.json(parsed.data, { status: parsed.status });
 }

--- a/apps/negentropy-ui/tests/unit/api/agui-session-response.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-session-response.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+
+const sessionAckSchema = z.object({
+  status: z.literal("ok"),
+  archived: z.boolean(),
+});
+
+describe("parseSessionUpstreamJson", () => {
+  it("当上游非 ok 时应返回结构化错误响应", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response("boom", { status: 503 }),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(502);
+    expect(data.error.code).toBe("AGUI_UPSTREAM_ERROR");
+    expect(data.error.message).toBe("boom");
+  });
+
+  it("当上游 JSON 非法时应返回结构化错误响应", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response("not-json", { status: 200 }),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(502);
+    expect(data.error.message).toBe("Invalid JSON");
+  });
+
+  it("当上游 payload 非法时应返回结构化错误响应", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(502);
+    expect(data.error.message).toBe("Invalid payload");
+  });
+
+  it("当上游 payload 合法时应返回已验证数据和状态码", async () => {
+    const result = await parseSessionUpstreamJson({
+      upstreamResponse: new Response(
+        JSON.stringify({ status: "ok", archived: true }),
+        { status: 201 },
+      ),
+      parse: (input) => sessionAckSchema.safeParse(input),
+      invalidPayloadMessage: "Invalid payload",
+      invalidJsonMessage: "Invalid JSON",
+    });
+
+    expect(result).not.toBeInstanceOf(Response);
+    expect(result).toEqual({
+      data: { status: "ok", archived: true },
+      status: 201,
+    });
+  });
+});


### PR DESCRIPTION
## 背景
- 前几轮已经把 session BFF 的 list/detail/create 以及 archive/title/unarchive 响应逐步纳入 schema 校验，但各路由内部仍重复实现同一段上游响应处理流程：
  - 读取 upstream 文本
  - `JSON.parse`
  - schema `safeParse`
  - 失败时返回结构化 `AGUI_UPSTREAM_ERROR`
- 这种重复实现虽然行为一致，但会持续放大后续新增 session 端点时的实现偏差风险。
- 本 PR 将这段重复链路抽成 session 私有 helper，继续压缩 session BFF 层的熵增面。

## 核心变更
- 新增 session 路由私有 helper，统一处理：
  - upstream 非 `ok` 响应的结构化错误返回
  - `text -> JSON.parse -> schema safeParse` 的成功/失败分支
  - 非法 JSON / 非法 payload 的结构化 `AGUI_UPSTREAM_ERROR`
- `sessions/list`、`sessions/[id]`、`sessions`、`archive`、`title`、`unarchive` 六条 route 全部改为复用该 helper。
- 路由层只保留各自的参数校验、upstream URL 组装、fetch 逻辑和少量业务后处理。
- `list` 路由仍在 helper 返回已验证数据后执行 archived 过滤，其余路由继续直接返回已验证 DTO。
- 新增 helper 单元测试，覆盖 non-ok、非法 JSON、非法 payload、合法 payload 四个核心分支。

## 变更原因
- 目标是把 session BFF 层里重复的响应解析路径收敛为单一事实源，降低后续新增或修改 session 端点时出现错误处理漂移的概率。
- 这也是对前几轮 session schema 化工作的继续收口，使 session 代理层更符合 anti-corruption layer、单一职责和复用驱动的设计原则。

## 重要实现细节
- helper 只负责响应解析、schema 校验和结构化错误，不接管 fetch、base URL 读取、header 组装或请求体校验，避免抽象过度。
- 继续沿用现有 `safeParse` 风格和 `AGUI_ERROR_CODES.UPSTREAM_ERROR` 语义，不引入新的错误模型。
- 本次不修改 session DTO schema，不改变页面侧的 archived 过滤、会话加载、重命名或归档行为。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- GitHub Actions：
  - `UI Test Suite` pull_request run `22796711253` 成功
  - `UI Test Suite` push run `22796704903` 成功

## Next Best Action
- 如果继续收敛 session BFF，可以把 session 私有的 base URL 读取和 auth header 组装也提炼成同边界内的 helper，但保持在 session 代理层内部，不与其他 proxy 体系混抽。
