### PR TITLE
fix(knowledge): 收敛文档提取设置面板状态管理与共享转换;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -12,20 +12,22 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import {
+  buildExtractorRoutesFromDraft,
   buildCorpusConfig,
   CorpusRecord,
-  CorpusExtractorRouteKey,
-  McpExtractorTargetConfig,
-  NormalizedCorpusExtractorRoutes,
   ChunkingConfig,
   ChunkingStrategy,
   DocumentViewDialog,
   DocumentChunkItem,
+  ExtractorDraftRoutes,
+  ExtractorDraftTarget,
   KnowledgeDocument,
   KnowledgeMatch,
   SearchMode,
+  createEmptyExtractorDraftTarget,
   fetchDocumentChunks,
   fetchDocuments,
+  normalizeExtractorDraftRoutes,
   searchAcrossCorpora,
   useKnowledgeBase,
   syncDocument,
@@ -36,7 +38,6 @@ import {
   downloadDocument,
   deleteDocument,
   createDefaultChunkingConfig,
-  normalizeCorpusExtractorRoutes,
   normalizeChunkingConfig,
 } from "@/features/knowledge";
 
@@ -55,61 +56,6 @@ const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type ViewMode = "overview" | "corpus";
 type CorpusTab = "documents" | "settings" | "document-chunks";
-type ExtractorDraftTarget = McpExtractorTargetConfig;
-type ExtractorDraftRoute = [ExtractorDraftTarget, ExtractorDraftTarget];
-type ExtractorDraftRoutes = Record<CorpusExtractorRouteKey, ExtractorDraftRoute>;
-
-function createEmptyExtractorTarget(priority: number): ExtractorDraftTarget {
-  return {
-    server_id: "",
-    tool_name: "",
-    priority,
-    enabled: true,
-  };
-}
-
-function createExtractorDraftTargets(
-  targets: ReadonlyArray<McpExtractorTargetConfig>,
-): ExtractorDraftRoute {
-  return [0, 1].map((priority) => {
-    const existing = targets.find((item) => item.priority === priority) || targets[priority];
-    return existing
-      ? {
-          ...existing,
-          priority,
-          enabled: existing.enabled !== false,
-        }
-      : createEmptyExtractorTarget(priority);
-  }) as ExtractorDraftRoute;
-}
-
-function createExtractorDraftRoutes(
-  config?: Record<string, unknown> | null,
-): ExtractorDraftRoutes {
-  const normalized = normalizeCorpusExtractorRoutes(config);
-  return {
-    url: createExtractorDraftTargets(normalized.url.targets),
-    file_pdf: createExtractorDraftTargets(normalized.file_pdf.targets),
-  };
-}
-
-function buildExtractorRoutesFromDraft(
-  draft: ExtractorDraftRoutes,
-): NormalizedCorpusExtractorRoutes {
-  const buildTargets = (targets: ExtractorDraftRoute) =>
-    targets
-      .filter((item) => item.server_id && item.tool_name)
-      .map((item, priority) => ({
-        ...item,
-        priority,
-        enabled: item.enabled !== false,
-      }));
-
-  return {
-    url: { targets: buildTargets(draft.url) },
-    file_pdf: { targets: buildTargets(draft.file_pdf) },
-  };
-}
 
 function CorpusStatusBadge({ corpus }: { corpus: CorpusRecord }) {
   const hasKnowledge = corpus.knowledge_count > 0;
@@ -1357,7 +1303,7 @@ function CorpusSettingsPanel({
     normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
   );
   const [extractorDraftRoutes, setExtractorDraftRoutes] = useState<ExtractorDraftRoutes>(
-    createExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
+    normalizeExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
   );
   const [servers, setServers] = useState<Array<{ id: string; name: string; display_name: string | null; is_enabled: boolean }>>([]);
   const [toolsByServer, setToolsByServer] = useState<Record<string, Array<{ name: string; display_name: string | null; is_enabled: boolean }>>>({});
@@ -1368,7 +1314,7 @@ function CorpusSettingsPanel({
       normalizeChunkingConfig((corpus.config || {}) as Record<string, unknown>),
     );
     setExtractorDraftRoutes(
-      createExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
+      normalizeExtractorDraftRoutes((corpus.config || {}) as Record<string, unknown>),
     );
   }, [corpus.id]);
 
@@ -1491,7 +1437,7 @@ function CorpusSettingsPanel({
 
                   const setTarget = (patch: Partial<ExtractorDraftTarget>) => {
                     setExtractorDraftRoutes((prev) => {
-                      const nextRoute = [...prev[routeKey]] as ExtractorDraftRoute;
+                      const nextRoute = [...prev[routeKey]] as typeof prev[typeof routeKey];
                       nextRoute[index] = {
                         ...nextRoute[index],
                         ...patch,
@@ -1507,8 +1453,8 @@ function CorpusSettingsPanel({
 
                   const clearTarget = () => {
                     setExtractorDraftRoutes((prev) => {
-                      const nextRoute = [...prev[routeKey]] as ExtractorDraftRoute;
-                      nextRoute[index] = createEmptyExtractorTarget(index);
+                      const nextRoute = [...prev[routeKey]] as typeof prev[typeof routeKey];
+                      nextRoute[index] = createEmptyExtractorDraftTarget(index);
                       return {
                         ...prev,
                         [routeKey]: nextRoute,

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -102,6 +102,9 @@ export type {
   CorpusExtractorTargets,
   CorpusExtractorRoutes,
   NormalizedCorpusExtractorRoutes,
+  ExtractorDraftTarget,
+  ExtractorDraftRoute,
+  ExtractorDraftRoutes,
   KnowledgeMatch,
   KnowledgeGraphPayload,
   KnowledgePipelinesPayload,
@@ -143,6 +146,9 @@ export {
   createDefaultChunkingConfig,
   normalizeChunkingConfig,
   normalizeCorpusExtractorRoutes,
+  createEmptyExtractorDraftTarget,
+  normalizeExtractorDraftRoutes,
+  buildExtractorRoutesFromDraft,
   buildCorpusConfig,
 } from "./utils/knowledge-api";
 

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -432,6 +432,9 @@ export interface CorpusExtractorRouteConfig {
 
 export type CorpusExtractorRouteKey = "url" | "file_pdf";
 export type CorpusExtractorTargets = McpExtractorTargetConfig[];
+export type ExtractorDraftTarget = McpExtractorTargetConfig;
+export type ExtractorDraftRoute = [ExtractorDraftTarget, ExtractorDraftTarget];
+export type ExtractorDraftRoutes = Record<CorpusExtractorRouteKey, ExtractorDraftRoute>;
 
 export interface CorpusExtractorRoutes {
   url?: CorpusExtractorRouteConfig;
@@ -442,6 +445,33 @@ export type NormalizedCorpusExtractorRoutes = Record<
   CorpusExtractorRouteKey,
   CorpusExtractorRouteConfig
 >;
+
+export function createEmptyExtractorDraftTarget(
+  priority: number,
+): ExtractorDraftTarget {
+  return {
+    server_id: "",
+    tool_name: "",
+    priority,
+    enabled: true,
+  };
+}
+
+function createExtractorDraftRoute(
+  targets: ReadonlyArray<McpExtractorTargetConfig>,
+): ExtractorDraftRoute {
+  return [0, 1].map((priority) => {
+    const existing =
+      targets.find((item) => item.priority === priority) || targets[priority];
+    return existing
+      ? {
+          ...existing,
+          priority,
+          enabled: existing.enabled !== false,
+        }
+      : createEmptyExtractorDraftTarget(priority);
+  }) as ExtractorDraftRoute;
+}
 
 function normalizeExtractorTargets(
   value: unknown,
@@ -488,6 +518,34 @@ export function normalizeCorpusExtractorRoutes(
   return {
     url: normalizeRoute(raw.url),
     file_pdf: normalizeRoute(raw.file_pdf),
+  };
+}
+
+export function normalizeExtractorDraftRoutes(
+  config?: Record<string, unknown> | null,
+): ExtractorDraftRoutes {
+  const normalized = normalizeCorpusExtractorRoutes(config);
+  return {
+    url: createExtractorDraftRoute(normalized.url.targets),
+    file_pdf: createExtractorDraftRoute(normalized.file_pdf.targets),
+  };
+}
+
+export function buildExtractorRoutesFromDraft(
+  draft: ExtractorDraftRoutes,
+): NormalizedCorpusExtractorRoutes {
+  const buildTargets = (targets: ExtractorDraftRoute) =>
+    targets
+      .filter((item) => item.server_id && item.tool_name)
+      .map((item, priority) => ({
+        ...item,
+        priority,
+        enabled: item.enabled !== false,
+      }));
+
+  return {
+    url: { targets: buildTargets(draft.url) },
+    file_pdf: { targets: buildTargets(draft.file_pdf) },
   };
 }
 

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -118,6 +118,62 @@ vi.mock("@/features/knowledge", () => ({
       url: { targets: [] },
       file_pdf: { targets: [] },
     },
+  createEmptyExtractorDraftTarget: (priority: number) => ({
+    server_id: "",
+    tool_name: "",
+    priority,
+    enabled: true,
+  }),
+  normalizeExtractorDraftRoutes: (config: Record<string, unknown> | null | undefined) => {
+    const extractorRoutes =
+      (config?.extractor_routes as Record<string, { targets?: Array<Record<string, unknown>> }> | undefined) ||
+      {};
+    const toDraftRoute = (targets?: Array<Record<string, unknown>>) =>
+      ([0, 1].map((priority) => {
+        const existing = targets?.find((item) => Number(item.priority || 0) === priority) || targets?.[priority];
+        return existing
+          ? {
+              server_id: String(existing.server_id || ""),
+              tool_name: String(existing.tool_name || ""),
+              priority,
+              enabled: existing.enabled !== false,
+            }
+          : {
+              server_id: "",
+              tool_name: "",
+              priority,
+              enabled: true,
+            };
+      })) as [
+        { server_id: string; tool_name: string; priority: number; enabled: boolean },
+        { server_id: string; tool_name: string; priority: number; enabled: boolean },
+      ];
+
+    return {
+      url: toDraftRoute(extractorRoutes.url?.targets),
+      file_pdf: toDraftRoute(extractorRoutes.file_pdf?.targets),
+    };
+  },
+  buildExtractorRoutesFromDraft: (draft: Record<string, Array<Record<string, unknown>>>) => ({
+    url: {
+      targets: (draft.url || [])
+        .filter((item) => item.server_id && item.tool_name)
+        .map((item, priority) => ({
+          ...item,
+          priority,
+          enabled: item.enabled !== false,
+        })),
+    },
+    file_pdf: {
+      targets: (draft.file_pdf || [])
+        .filter((item) => item.server_id && item.tool_name)
+        .map((item, priority) => ({
+          ...item,
+          priority,
+          enabled: item.enabled !== false,
+        })),
+    },
+  }),
   buildCorpusConfig: (
     chunkingConfig: Record<string, unknown>,
     extractorRoutes: Record<string, unknown>,

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -1,5 +1,7 @@
 import {
+  buildExtractorRoutesFromDraft,
   buildCorpusConfig,
+  createEmptyExtractorDraftTarget,
   createDefaultChunkingConfig,
   fetchCorpus,
   fetchDocumentChunks,
@@ -7,6 +9,7 @@ import {
   ingestFile,
   ingestText,
   KnowledgeError,
+  normalizeExtractorDraftRoutes,
   normalizeCorpusExtractorRoutes,
 } from "@/features/knowledge/utils/knowledge-api";
 
@@ -190,6 +193,103 @@ describe("fetchCorpus", () => {
           ],
         },
         file_pdf: { targets: [] },
+      },
+    });
+  });
+
+  it("normalizeExtractorDraftRoutes 会为每个 route 生成固定双槽位 draft", () => {
+    const draft = normalizeExtractorDraftRoutes({
+      extractor_routes: {
+        url: {
+          targets: [
+            {
+              server_id: "server-1",
+              tool_name: "fetch_markdown",
+              priority: 0,
+              enabled: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.url).toEqual([
+      expect.objectContaining({
+        server_id: "server-1",
+        tool_name: "fetch_markdown",
+        priority: 0,
+        enabled: true,
+      }),
+      expect.objectContaining({
+        server_id: "",
+        tool_name: "",
+        priority: 1,
+        enabled: true,
+      }),
+    ]);
+    expect(draft.file_pdf).toEqual([
+      expect.objectContaining({
+        server_id: "",
+        tool_name: "",
+        priority: 0,
+        enabled: true,
+      }),
+      expect.objectContaining({
+        server_id: "",
+        tool_name: "",
+        priority: 1,
+        enabled: true,
+      }),
+    ]);
+  });
+
+  it("buildExtractorRoutesFromDraft 会过滤不完整槽位并重排 priority", () => {
+    const routes = buildExtractorRoutesFromDraft({
+      url: [
+        {
+          server_id: "",
+          tool_name: "",
+          priority: 0,
+          enabled: true,
+        },
+        {
+          server_id: "server-2",
+          tool_name: "parse_pdf",
+          priority: 1,
+          enabled: true,
+        },
+      ],
+      file_pdf: [
+        {
+          server_id: "server-3",
+          tool_name: "extract_pdf",
+          priority: 0,
+          enabled: true,
+        },
+        createEmptyExtractorDraftTarget(1),
+      ],
+    });
+
+    expect(routes).toEqual({
+      url: {
+        targets: [
+          expect.objectContaining({
+            server_id: "server-2",
+            tool_name: "parse_pdf",
+            priority: 0,
+            enabled: true,
+          }),
+        ],
+      },
+      file_pdf: {
+        targets: [
+          expect.objectContaining({
+            server_id: "server-3",
+            tool_name: "extract_pdf",
+            priority: 0,
+            enabled: true,
+          }),
+        ],
       },
     });
   });


### PR DESCRIPTION
## 变更说明

本次改动围绕 `Knowledge Base` 页面 `Documents` 视图下的设置面板，分三步完成了文档提取配置的状态管理收敛：

1. 修正文案命名，使设置区语义更清晰：
   - `Settings` -> `Chunking Settings`
   - `Data Extractor MCP` -> `Document Extraction Settings`

2. 修复文档提取配置的核心交互问题：
   - 解决选择 MCP Server 后立即回退为“未配置”、导致 Tool 无法继续选择的问题；
   - 引入固定双槽位草稿态，允许“已选 Server、未选 Tool”的中间态稳定存在；
   - 补齐围绕选择与保存链路的回归测试。

3. 继续收敛长期可维护性：
   - 调整草稿态同步策略，避免外部 `corpus` 刷新覆盖未保存编辑；
   - 将 `ExtractorDraftRoutes` 的双向转换抽取到共享 helper，减少页面组件中的 UI 配置转换逻辑；
   - 为共享 helper 补充独立单测，降低后续状态漂移的风险。

## 为什么要改

原始问题会直接阻断文档提取配置链路：在 URL/PDF 文档提取配置中，用户刚选中的 MCP Server 会被前端状态过滤逻辑立即清空，Tool 下拉无法稳定进入可选状态，最终导致配置无法完成。

在首轮 bug fix 后，虽然主路径已经恢复，但继续审查后发现，设置面板仍有两个长期风险：

- 草稿态如果依赖外部 `corpus.config` 的引用变化做同步，后台刷新或重新加载时可能会静默覆盖用户尚未保存的输入；
- `ExtractorDraftRoutes` 的双向转换规则如果继续散落在页面组件中，页面状态管理和共享配置转换会逐渐形成双源事实，增加未来回归概率。

因此这次 PR 不只是修复一个交互 bug，而是进一步将设置面板收敛到更稳定的模式：**UI 草稿态与持久化配置分离，切换实体时显式重置，转换规则沉淀到共享 helper 作为单一事实源。**

## 具体实现

### 1. 修复文档提取设置的主路径交互
在 `apps/negentropy-ui/app/knowledge/base/page.tsx` 中，文档提取配置不再依赖“编辑过程中即时过滤并回写”的状态模型，而是使用固定双槽位草稿态：

- 为 `url` 与 `file_pdf` 各保留主用 / 备用两个稳定槽位；
- 允许槽位处于“已选 Server、未选 Tool”的合法中间态；
- 仅在点击保存时，才把草稿态转换成 `extractor_routes` 并过滤不完整项。

这样避免了 `select` 的受控值在中间态被清洗掉，从而回退为“未配置”。

### 2. 收敛草稿态同步策略
进一步调整设置面板本地状态的 reset 时机：

- 保留“切换不同 corpus 时重置本地草稿”的行为；
- 避免仅因外部 `corpus.config` 刷新，就无条件覆盖正在编辑中的本地草稿；
- 新增回归测试锁定“外部刷新不会覆盖未保存 MCP 草稿”。

这符合受控表单的长期最佳实践：**用户编辑优先，显式切换时重置，而不是被任意 props 抖动打断。**

### 3. 抽取共享转换 helper
在 `apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts` 中新增并导出了与 UI 草稿态相关的共享 helper：

- `createEmptyExtractorDraftTarget`
- `normalizeExtractorDraftRoutes`
- `buildExtractorRoutesFromDraft`

同时在 `apps/negentropy-ui/features/knowledge/index.ts` 中统一导出这些能力，让页面层只消费 feature 边界，不再自己维护一份转换规则。

这一步的目标是把“持久化配置 <-> 双槽位草稿态”的转换规则沉淀为共享事实源，避免页面组件演进过程中再次出现 split-brain。

### 4. 补齐回归与契约测试
在测试层做了两类补强：

- `apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx`
  - 覆盖“选择 MCP Server 不回退”“不可用 MCP/Tool 回显”“外部 corpus 刷新不覆盖未保存草稿”等页面行为；
  - 更新 feature mock，使其与新的共享 helper 契约保持一致。
- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts`
  - 新增 `normalizeExtractorDraftRoutes` 和 `buildExtractorRoutesFromDraft` 的单测；
  - 直接锁定“固定双槽位生成”“不完整槽位过滤”“priority 重排”等转换语义。

## 验证结果

已通过前端测试验证：

- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/knowledge-api.test.ts`

实际运行结果为前端测试全集通过：

- 36 个 test files passed
- 185 个 tests passed

## 影响范围与兼容性

- 不修改后端 API 协议；
- 不修改 `extractor_routes` 的持久化格式；
- 不影响现有 chunking 配置保存逻辑；
- 通过共享 helper 集中化配置转换规则，降低后续页面状态漂移与测试契约失配的风险。
