### PR TITLE
refactor(session): 抽取会话代理请求上下文助手;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
@@ -1,25 +1,21 @@
-import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ sessionId: string }> }
 ) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured"
-    );
+  const baseUrl = getSessionAguiBaseUrl();
+  if (baseUrl instanceof Response) {
+    return baseUrl;
   }
 
   let body: {
@@ -54,10 +50,7 @@ export async function POST(
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "POST",
-      headers: {
-        ...Object.fromEntries(buildAuthHeaders(request)),
-        "Content-Type": "application/json",
-      },
+      headers: buildSessionUpstreamHeaders(request, "json-write"),
       cache: "no-store",
     });
   } catch (error) {

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
@@ -1,26 +1,22 @@
 import { NextResponse } from "next/server";
-import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionDetailResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ sessionId: string }> }
 ) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured",
-    );
+  const baseUrl = getSessionAguiBaseUrl();
+  if (baseUrl instanceof Response) {
+    return baseUrl;
   }
 
   const { sessionId } = await params;
@@ -46,10 +42,7 @@ export async function GET(
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "GET",
-      headers: {
-        ...Object.fromEntries(buildAuthHeaders(request)),
-        Accept: "application/json",
-      },
+      headers: buildSessionUpstreamHeaders(request, "json-read"),
       cache: "no-store",
     });
   } catch (error) {

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
@@ -1,25 +1,21 @@
-import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionTitleResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ sessionId: string }> }
 ) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured"
-    );
+  const baseUrl = getSessionAguiBaseUrl();
+  if (baseUrl instanceof Response) {
+    return baseUrl;
   }
 
   let body: {
@@ -55,10 +51,7 @@ export async function PATCH(
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "PATCH",
-      headers: {
-        ...Object.fromEntries(buildAuthHeaders(request)),
-        "Content-Type": "application/json",
-      },
+      headers: buildSessionUpstreamHeaders(request, "json-write"),
       body: JSON.stringify({
         title: body.title ?? null,
       }),

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
@@ -1,25 +1,21 @@
-import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ sessionId: string }> }
 ) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured"
-    );
+  const baseUrl = getSessionAguiBaseUrl();
+  if (baseUrl instanceof Response) {
+    return baseUrl;
   }
 
   let body: {
@@ -54,10 +50,7 @@ export async function POST(
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "POST",
-      headers: {
-        ...Object.fromEntries(buildAuthHeaders(request)),
-        "Content-Type": "application/json",
-      },
+      headers: buildSessionUpstreamHeaders(request, "json-write"),
       cache: "no-store",
     });
   } catch (error) {

--- a/apps/negentropy-ui/app/api/agui/sessions/_request.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/_request.ts
@@ -1,0 +1,31 @@
+import { buildAuthHeaders } from "@/lib/sso";
+import {
+  errorResponse as aguiErrorResponse,
+  AGUI_ERROR_CODES,
+} from "@/lib/errors";
+
+export function getSessionAguiBaseUrl(): string | Response {
+  const baseUrl = process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
+  if (!baseUrl) {
+    return aguiErrorResponse(
+      AGUI_ERROR_CODES.INTERNAL_ERROR,
+      "AGUI_BASE_URL is not configured",
+    );
+  }
+
+  return baseUrl;
+}
+
+export function buildSessionUpstreamHeaders(
+  request: Request,
+  kind: "json-read" | "json-write",
+): HeadersInit {
+  const headers = new Headers(buildAuthHeaders(request));
+  if (kind === "json-read") {
+    headers.set("Accept", "application/json");
+  } else {
+    headers.set("Content-Type", "application/json");
+  }
+
+  return headers;
+}

--- a/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
@@ -1,20 +1,19 @@
 import { NextResponse } from "next/server";
-import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseSessionListResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
 export async function GET(request: Request) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(AGUI_ERROR_CODES.INTERNAL_ERROR, "AGUI_BASE_URL is not configured");
+  const baseUrl = getSessionAguiBaseUrl();
+  if (baseUrl instanceof Response) {
+    return baseUrl;
   }
 
   const { searchParams } = new URL(request.url);
@@ -35,10 +34,7 @@ export async function GET(request: Request) {
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "GET",
-      headers: {
-        ...Object.fromEntries(buildAuthHeaders(request)),
-        Accept: "application/json",
-      },
+      headers: buildSessionUpstreamHeaders(request, "json-read"),
       cache: "no-store",
     });
   } catch (error) {

--- a/apps/negentropy-ui/app/api/agui/sessions/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/route.ts
@@ -1,20 +1,19 @@
 import { NextResponse } from "next/server";
-import { buildAuthHeaders } from "@/lib/sso";
 import { safeParseCreateSessionResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
 import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
-
 export async function POST(request: Request) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(AGUI_ERROR_CODES.INTERNAL_ERROR, "AGUI_BASE_URL is not configured");
+  const baseUrl = getSessionAguiBaseUrl();
+  if (baseUrl instanceof Response) {
+    return baseUrl;
   }
 
   let body: {
@@ -49,10 +48,7 @@ export async function POST(request: Request) {
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "POST",
-      headers: {
-        ...Object.fromEntries(buildAuthHeaders(request)),
-        "Content-Type": "application/json",
-      },
+      headers: buildSessionUpstreamHeaders(request, "json-write"),
       body: JSON.stringify(payload),
       cache: "no-store",
     });

--- a/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildSessionUpstreamHeaders,
+  getSessionAguiBaseUrl,
+} from "@/app/api/agui/sessions/_request";
+
+describe("session request helpers", () => {
+  afterEach(() => {
+    delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
+  });
+
+  it("应优先使用 AGUI_BASE_URL", () => {
+    process.env.AGUI_BASE_URL = "http://internal-agui";
+    process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://public-agui";
+
+    expect(getSessionAguiBaseUrl()).toBe("http://internal-agui");
+  });
+
+  it("在 AGUI_BASE_URL 缺失时回退到 NEXT_PUBLIC_AGUI_BASE_URL", () => {
+    process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://public-agui";
+
+    expect(getSessionAguiBaseUrl()).toBe("http://public-agui");
+  });
+
+  it("在 base url 缺失时返回结构化内部错误", async () => {
+    const result = getSessionAguiBaseUrl();
+
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    const data = await response.json();
+    expect(response.status).toBe(500);
+    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
+    expect(data.error.message).toContain("AGUI_BASE_URL is not configured");
+  });
+
+  it("json-read header 应透传鉴权并补齐 Accept", () => {
+    const request = new Request("http://localhost/api/agui/sessions/list", {
+      headers: {
+        cookie: "sid=1",
+        authorization: "Bearer token",
+      },
+    });
+
+    const headers = new Headers(buildSessionUpstreamHeaders(request, "json-read"));
+    expect(headers.get("cookie")).toBe("sid=1");
+    expect(headers.get("authorization")).toBe("Bearer token");
+    expect(headers.get("accept")).toBe("application/json");
+    expect(headers.get("content-type")).toBeNull();
+  });
+
+  it("json-write header 应透传鉴权并补齐 Content-Type", () => {
+    const request = new Request("http://localhost/api/agui/sessions", {
+      headers: {
+        cookie: "sid=1",
+        authorization: "Bearer token",
+      },
+    });
+
+    const headers = new Headers(buildSessionUpstreamHeaders(request, "json-write"));
+    expect(headers.get("cookie")).toBe("sid=1");
+    expect(headers.get("authorization")).toBe("Bearer token");
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("accept")).toBeNull();
+  });
+});


### PR DESCRIPTION
## 背景
- 前一轮已经把 session BFF 的上游响应解析抽成统一 helper，但 `AGUI_BASE_URL` 读取、缺失时报错、以及鉴权 header 与 `Accept` / `Content-Type` 的组装仍散落在多条 session route 中。
- 这些逻辑都属于同一个 session 代理边界，继续留在各 route 内部会放大新增端点时的实现偏差。
- 本 PR 在不跨越到 knowledge/plugins/memory proxy 的前提下，把 session 路由里的 request 上下文准备逻辑进一步收口到私有 helper。

## 核心变更
- 新增 session 私有 request helper，统一处理：
  - `AGUI_BASE_URL` 与 `NEXT_PUBLIC_AGUI_BASE_URL` 的读取优先级
  - base URL 缺失时的结构化 `AGUI_INTERNAL_ERROR`
  - `buildAuthHeaders(request)` 与 `Accept` / `Content-Type` 的最小 header 组装
- `sessions/list`、`sessions/[id]`、`sessions`、`archive`、`title`、`unarchive` 六条 route 全部改为复用该 helper。
- 路由层只保留各自的 query/body 校验、upstream URL 拼装、fetch 方法和少量业务后处理；`list` 的 archived 过滤逻辑保持不变。
- 新增 request helper 单元测试，覆盖 base URL 优先级、缺失分支、鉴权 header 透传，以及 `json-read` / `json-write` 两种 header 语义。

## 变更原因
- 目标是继续压低 session BFF 层的实现偏差，把同一边界内重复出现的 request 上下文准备逻辑收敛为单一事实源。
- 这样后续继续新增或维护 session 端点时，错误模型、环境变量语义和 header 组装不会再在多处独立漂移。

## 重要实现细节
- helper 只负责 base URL 与 header 组装，不接管 URL path 构造、请求体验证或上游响应解析，避免抽象膨胀。
- 继续沿用现有 `buildAuthHeaders`、`AGUI_ERROR_CODES` 和 session response helper，不引入新的错误模型。
- 本次不修改任何 session DTO、页面行为、archived 过滤规则或 session hydration 语义。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/unit/api/agui-session-request.test.ts tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 本地结果：38 个测试文件、202 个测试全部通过

## Next Best Action
- 如果继续收口 session BFF，可以把 session 私有的 upstream URL path builder 也做成同边界内的轻量 helper，但应继续保持在 session 路由内部，不和其他 proxy 体系混合抽象。
