### PR TITLE
feat(mcp): 补齐工具卡片的输出结构与官方元信息展示;

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -39,6 +39,7 @@ interface SchemaFieldRow {
 }
 
 interface JsonSchemaNode {
+  $schema?: string;
   type?: string | string[];
   description?: string;
   default?: unknown;
@@ -58,6 +59,24 @@ interface JsonSchemaNode {
   oneOf?: JsonSchemaNode[];
   anyOf?: JsonSchemaNode[];
   allOf?: JsonSchemaNode[];
+}
+
+interface McpToolIcon {
+  src?: string;
+  mimeType?: string;
+  sizes?: string;
+}
+
+interface McpToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+interface McpToolExecution {
+  taskSupport?: "forbidden" | "optional" | "required" | string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -312,7 +331,23 @@ function RichTextContent({
   );
 }
 
-function InputSchemaSection({ schema }: { schema: Record<string, unknown> }) {
+function getSchemaDialectLabel(schema: Record<string, unknown>): string {
+  const schemaNode = getSchemaNode(schema);
+  if (!schemaNode || typeof schemaNode.$schema !== "string" || schemaNode.$schema.trim().length === 0) {
+    return "JSON Schema 2020-12";
+  }
+
+  const parts = schemaNode.$schema.split("/");
+  return parts[parts.length - 1] || schemaNode.$schema;
+}
+
+function SchemaSection({
+  title,
+  schema,
+}: {
+  title: string;
+  schema: Record<string, unknown>;
+}) {
   const rows = useMemo(() => collectSchemaRows(schema), [schema]);
 
   if (Object.keys(schema).length === 0) {
@@ -325,13 +360,16 @@ function InputSchemaSection({ schema }: { schema: Record<string, unknown> }) {
     <div className="mt-3 rounded-lg border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
       <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
         <span className="font-medium text-zinc-700 dark:text-zinc-300">
-          Input Schema
+          {title}
         </span>
         {rows.length > 0 && (
           <span className="inline-flex items-center rounded-full bg-zinc-200 px-2 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
             {rows.length} fields
           </span>
         )}
+        <span className="inline-flex items-center rounded-full bg-sky-100 px-2 py-0.5 text-[11px] text-sky-700 dark:bg-sky-900/30 dark:text-sky-300">
+          {getSchemaDialectLabel(schema)}
+        </span>
         {requiredCount > 0 && (
           <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
             {requiredCount} required
@@ -406,8 +444,37 @@ function InputSchemaSection({ schema }: { schema: Record<string, unknown> }) {
   );
 }
 
+function isSafeIconSrc(src: string): boolean {
+  if (src.startsWith("https://") || src.startsWith("http://")) {
+    return true;
+  }
+  return /^data:image\/(png|jpeg|jpg|gif|webp|avif);base64,/i.test(src);
+}
+
+function getPrimaryIcon(tool: McpTool): McpToolIcon | null {
+  for (const candidate of tool.icons) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    const icon = candidate as McpToolIcon;
+    if (typeof icon.src === "string" && icon.src.length > 0 && isSafeIconSrc(icon.src)) {
+      return icon;
+    }
+  }
+  return null;
+}
+
+function getToolAnnotations(tool: McpTool): McpToolAnnotations {
+  return isRecord(tool.annotations) ? (tool.annotations as McpToolAnnotations) : {};
+}
+
+function getToolExecution(tool: McpTool): McpToolExecution {
+  return isRecord(tool.execution) ? (tool.execution as McpToolExecution) : {};
+}
+
 function getToolLabel(tool: McpTool): string {
-  return tool.display_name || tool.name;
+  const annotations = getToolAnnotations(tool);
+  return tool.title || annotations.title || tool.display_name || tool.name;
 }
 
 function getToolTooltipText(tool: McpTool): string {
@@ -415,19 +482,83 @@ function getToolTooltipText(tool: McpTool): string {
   return text && text.length > 0 ? text : "No description";
 }
 
+function getBehaviorBadges(tool: McpTool): Array<{ label: string; tone: string }> {
+  const annotations = getToolAnnotations(tool);
+  const badges: Array<{ label: string; tone: string }> = [];
+
+  if (annotations.readOnlyHint) {
+    badges.push({
+      label: "Read Only Hint",
+      tone: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+    });
+  }
+  if (annotations.destructiveHint) {
+    badges.push({
+      label: "Destructive Hint",
+      tone: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+    });
+  }
+  if (annotations.idempotentHint) {
+    badges.push({
+      label: "Idempotent Hint",
+      tone: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300",
+    });
+  }
+  if (annotations.openWorldHint) {
+    badges.push({
+      label: "Open World Hint",
+      tone: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+    });
+  }
+
+  return badges;
+}
+
 function ToolDetailPanel({ tool }: { tool: McpTool }) {
+  const primaryIcon = getPrimaryIcon(tool);
+  const annotations = getToolAnnotations(tool);
+  const behaviorBadges = getBehaviorBadges(tool);
+  const execution = getToolExecution(tool);
+
   return (
     <div className="rounded-xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
       <div className="flex flex-wrap items-start justify-between gap-2">
-        <div>
-          <h4 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            {getToolLabel(tool)}
-          </h4>
-          {tool.display_name && (
-            <p className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
-              {tool.name}
-            </p>
+        <div className="flex items-start gap-3">
+          {primaryIcon ? (
+            // MCP icons come from dynamic server metadata, so Next/Image remote allowlists are not viable here.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={primaryIcon.src}
+              alt=""
+              aria-hidden="true"
+              className="mt-0.5 h-9 w-9 rounded-lg border border-zinc-200 bg-white object-contain p-1 dark:border-zinc-700 dark:bg-zinc-950"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="mt-0.5 flex h-9 w-9 items-center justify-center rounded-lg border border-zinc-200 bg-zinc-50 text-xs font-semibold text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400">
+              {getToolLabel(tool).slice(0, 1).toUpperCase()}
+            </div>
           )}
+          <div>
+            <h4 className="font-mono text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              {getToolLabel(tool)}
+            </h4>
+            {(tool.title || annotations.title || tool.display_name) && (
+              <p className="mt-0.5 font-mono text-[11px] text-zinc-500 dark:text-zinc-400">
+                {tool.name}
+              </p>
+            )}
+            {(tool.title || annotations.title) && tool.display_name && (
+              <p className="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+                Local display name: {tool.display_name}
+              </p>
+            )}
+            {primaryIcon?.mimeType && (
+              <p className="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+                Icon: {primaryIcon.mimeType}
+              </p>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           {tool.is_enabled ? (
@@ -449,7 +580,54 @@ function ToolDetailPanel({ tool }: { tool: McpTool }) {
         <RichTextContent content={tool.description} emptyText="No description" />
       </div>
 
-      <InputSchemaSection schema={tool.input_schema} />
+      {(behaviorBadges.length > 0 || execution.taskSupport) && (
+        <div className="mt-3 rounded-lg border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
+          <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+            <span className="font-medium text-zinc-700 dark:text-zinc-300">
+              Tool Metadata
+            </span>
+            <span className="inline-flex items-center rounded-full bg-zinc-200 px-2 py-0.5 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              Hints
+            </span>
+          </div>
+          {behaviorBadges.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {behaviorBadges.map((badge) => (
+                <span
+                  key={badge.label}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${badge.tone}`}
+                >
+                  {badge.label}
+                </span>
+              ))}
+            </div>
+          )}
+          {execution.taskSupport && (
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-zinc-600 dark:text-zinc-300">
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                Task support
+              </span>
+              <span className="inline-flex items-center rounded-full bg-violet-100 px-2 py-0.5 text-[11px] text-violet-700 dark:bg-violet-900/30 dark:text-violet-300">
+                {execution.taskSupport}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <SchemaSection title="Input Schema" schema={tool.input_schema} />
+      <SchemaSection title="Output Schema" schema={tool.output_schema} />
+
+      {Object.keys(tool.meta).length > 0 && (
+        <details className="mt-3 rounded-lg border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
+          <summary className="cursor-pointer text-xs font-medium text-zinc-600 hover:text-zinc-800 dark:text-zinc-300 dark:hover:text-zinc-100">
+            Advanced Metadata
+          </summary>
+          <div className="mt-2 rounded-md border border-zinc-200 bg-white p-2 dark:border-zinc-700 dark:bg-zinc-900">
+            <JsonViewer data={tool.meta} />
+          </div>
+        </details>
+      )}
     </div>
   );
 }
@@ -476,9 +654,15 @@ interface McpServer {
 interface McpTool {
   id: string | null;
   name: string;
+  title: string | null;
   display_name: string | null;
   description: string | null;
   input_schema: Record<string, unknown>;
+  output_schema: Record<string, unknown>;
+  icons: Array<Record<string, unknown>>;
+  annotations: Record<string, unknown>;
+  execution: Record<string, unknown>;
+  meta: Record<string, unknown>;
   is_enabled: boolean;
   call_count: number;
 }
@@ -614,6 +798,7 @@ export function McpServerCard({
                 onClick={handleToggleTools}
                 className="inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
                 aria-expanded={showTools}
+                aria-label={`Toggle tools list for ${server.display_name || server.name}`}
                 title="Toggle tools list"
               >
                 {loadingTools ? (

--- a/apps/negentropy-ui/app/plugins/mcp/page.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/page.tsx
@@ -8,9 +8,15 @@ import { McpServerFormDialog } from "./_components/McpServerFormDialog";
 interface McpTool {
   id: string | null;
   name: string;
+  title: string | null;
   display_name: string | null;
   description: string | null;
   input_schema: Record<string, unknown>;
+  output_schema: Record<string, unknown>;
+  icons: Array<Record<string, unknown>>;
+  annotations: Record<string, unknown>;
+  execution: Record<string, unknown>;
+  meta: Record<string, unknown>;
   is_enabled: boolean;
   call_count: number;
 }

--- a/apps/negentropy-ui/tests/unit/plugins/McpServerCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/McpServerCard.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { McpServerCard } from "@/app/plugins/mcp/_components/McpServerCard";
+
+const server = {
+  id: "server-1",
+  owner_id: "user-1",
+  visibility: "private",
+  name: "demo-server",
+  display_name: "Demo Server",
+  description: "Demo MCP server",
+  transport_type: "stdio",
+  command: "uvx",
+  args: [],
+  env: {},
+  url: null,
+  headers: {},
+  is_enabled: true,
+  auto_start: false,
+  config: {},
+  tool_count: 1,
+};
+
+const tool = {
+  id: "tool-1",
+  name: "demo_tool",
+  title: "Demo Tool",
+  display_name: null,
+  description: "Tool description",
+  input_schema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Search query",
+      },
+    },
+    required: ["query"],
+  },
+  output_schema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: {
+      result: {
+        type: "string",
+        description: "Search result",
+      },
+    },
+  },
+  icons: [{ src: "https://example.com/icon.png", mimeType: "image/png" }],
+  annotations: {
+    readOnlyHint: true,
+    idempotentHint: true,
+  },
+  execution: {
+    taskSupport: "optional",
+  },
+  meta: {
+    source: "official",
+  },
+  is_enabled: true,
+  call_count: 3,
+};
+
+describe("McpServerCard", () => {
+  it("renders tool output schema and official metadata", () => {
+    render(
+      <McpServerCard
+        server={server}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onLoad={vi.fn()}
+        tools={[tool]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle tools list/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Demo Tool" }));
+
+    expect(screen.getByText("Output Schema")).toBeInTheDocument();
+    expect(screen.getByText("Tool Metadata")).toBeInTheDocument();
+    expect(screen.getByText("Read Only Hint")).toBeInTheDocument();
+    expect(screen.getByText("Idempotent Hint")).toBeInTheDocument();
+    expect(screen.getByText("Task support")).toBeInTheDocument();
+    expect(screen.getByText("optional")).toBeInTheDocument();
+    expect(screen.getByText("JSON Schema 2020-12")).toBeInTheDocument();
+    expect(screen.getByText("Advanced Metadata")).toBeInTheDocument();
+  });
+
+  it("hides empty output schema section", () => {
+    render(
+      <McpServerCard
+        server={server}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onLoad={vi.fn()}
+        tools={[{ ...tool, output_schema: {}, meta: {} }]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle tools list/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Demo Tool" }));
+
+    expect(screen.queryByText("Output Schema")).not.toBeInTheDocument();
+    expect(screen.queryByText("Advanced Metadata")).not.toBeInTheDocument();
+  });
+});

--- a/apps/negentropy/src/negentropy/db/migrations/versions/c6f8d9e1a2b3_add_mcp_tool_metadata_fields.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/c6f8d9e1a2b3_add_mcp_tool_metadata_fields.py
@@ -1,0 +1,66 @@
+"""Add MCP tool metadata fields
+
+Revision ID: c6f8d9e1a2b3
+Revises: a2b3c4d5e6f7
+Create Date: 2026-03-07 16:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c6f8d9e1a2b3"
+down_revision: Union[str, None] = "a2b3c4d5e6f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add MCP tool metadata fields defined by the MCP spec."""
+
+    op.add_column(
+        "mcp_tools",
+        sa.Column("title", sa.String(length=255), nullable=True),
+        schema="negentropy",
+    )
+    op.add_column(
+        "mcp_tools",
+        sa.Column("output_schema", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        schema="negentropy",
+    )
+    op.add_column(
+        "mcp_tools",
+        sa.Column("icons", postgresql.JSONB(astext_type=sa.Text()), server_default="[]", nullable=False),
+        schema="negentropy",
+    )
+    op.add_column(
+        "mcp_tools",
+        sa.Column("annotations", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        schema="negentropy",
+    )
+    op.add_column(
+        "mcp_tools",
+        sa.Column("execution", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        schema="negentropy",
+    )
+    op.add_column(
+        "mcp_tools",
+        sa.Column("meta", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        schema="negentropy",
+    )
+
+
+def downgrade() -> None:
+    """Drop MCP tool metadata fields."""
+
+    op.drop_column("mcp_tools", "meta", schema="negentropy")
+    op.drop_column("mcp_tools", "execution", schema="negentropy")
+    op.drop_column("mcp_tools", "annotations", schema="negentropy")
+    op.drop_column("mcp_tools", "icons", schema="negentropy")
+    op.drop_column("mcp_tools", "output_schema", schema="negentropy")
+    op.drop_column("mcp_tools", "title", schema="negentropy")

--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -99,9 +99,15 @@ class McpTool(Base, UUIDMixin, TimestampMixin):
 
     server_id: Mapped[UUID] = mapped_column(fk("mcp_servers", ondelete="CASCADE"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
+    title: Mapped[Optional[str]] = mapped_column(String(255))
     display_name: Mapped[Optional[str]] = mapped_column(String(255))
     description: Mapped[Optional[str]] = mapped_column(Text)
     input_schema: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    output_schema: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    icons: Mapped[List[Dict[str, Any]]] = mapped_column(JSONB, nullable=False, server_default="[]")
+    annotations: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    execution: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    meta: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
     is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
     call_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 

--- a/apps/negentropy/src/negentropy/plugins/api.py
+++ b/apps/negentropy/src/negentropy/plugins/api.py
@@ -141,9 +141,15 @@ class McpToolResponse(BaseModel):
 
     id: Optional[UUID] = None
     name: str
+    title: Optional[str] = None
     display_name: Optional[str] = None
     description: Optional[str] = None
     input_schema: Dict[str, Any] = Field(default_factory=dict)
+    output_schema: Dict[str, Any] = Field(default_factory=dict)
+    icons: List[Dict[str, Any]] = Field(default_factory=list)
+    annotations: Dict[str, Any] = Field(default_factory=dict)
+    execution: Dict[str, Any] = Field(default_factory=dict)
+    meta: Dict[str, Any] = Field(default_factory=dict)
     is_enabled: bool = True
     call_count: int = 0
 
@@ -515,9 +521,15 @@ def _mcp_tool_to_response(tool: McpTool) -> McpToolResponse:
     return McpToolResponse(
         id=tool.id,
         name=tool.name,
+        title=tool.title,
         display_name=tool.display_name,
         description=tool.description,
         input_schema=tool.input_schema or {},
+        output_schema=tool.output_schema or {},
+        icons=tool.icons or [],
+        annotations=tool.annotations or {},
+        execution=tool.execution or {},
+        meta=tool.meta or {},
         is_enabled=tool.is_enabled,
         call_count=tool.call_count or 0,
     )
@@ -585,16 +597,28 @@ async def load_mcp_server_tools(
             if tool_info.name in existing_map:
                 # 更新现有 Tool
                 existing = existing_map[tool_info.name]
+                existing.title = tool_info.title
                 existing.description = tool_info.description
                 existing.input_schema = tool_info.input_schema
+                existing.output_schema = tool_info.output_schema
+                existing.icons = tool_info.icons
+                existing.annotations = tool_info.annotations
+                existing.execution = tool_info.execution
+                existing.meta = tool_info.meta
                 updated_tools.append(existing)
             else:
                 # 新增 Tool
                 new_tool = McpTool(
                     server_id=server_id,
                     name=tool_info.name,
+                    title=tool_info.title,
                     description=tool_info.description,
                     input_schema=tool_info.input_schema,
+                    output_schema=tool_info.output_schema,
+                    icons=tool_info.icons,
+                    annotations=tool_info.annotations,
+                    execution=tool_info.execution,
+                    meta=tool_info.meta,
                     is_enabled=True,
                 )
                 db.add(new_tool)

--- a/apps/negentropy/src/negentropy/plugins/mcp_client.py
+++ b/apps/negentropy/src/negentropy/plugins/mcp_client.py
@@ -155,8 +155,14 @@ class McpToolInfo:
     """MCP Tool 元信息"""
 
     name: str
+    title: str | None = None
     description: str | None = None
     input_schema: dict[str, Any] = field(default_factory=dict)
+    output_schema: dict[str, Any] = field(default_factory=dict)
+    icons: list[dict[str, Any]] = field(default_factory=list)
+    annotations: dict[str, Any] = field(default_factory=dict)
+    execution: dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -416,8 +422,14 @@ class McpClientService:
                     tools = [
                         McpToolInfo(
                             name=t.name,
+                            title=t.title,
                             description=t.description,
                             input_schema=t.inputSchema or {},
+                            output_schema=t.outputSchema or {},
+                            icons=[icon.model_dump(mode="json") for icon in (t.icons or [])],
+                            annotations=t.annotations.model_dump(mode="json") if t.annotations else {},
+                            execution=t.execution.model_dump(mode="json") if t.execution else {},
+                            meta=t.meta or {},
                         )
                         for t in tools_result.tools
                     ]
@@ -479,8 +491,14 @@ class McpClientService:
                     tools = [
                         McpToolInfo(
                             name=t.name,
+                            title=t.title,
                             description=t.description,
                             input_schema=t.inputSchema or {},
+                            output_schema=t.outputSchema or {},
+                            icons=[icon.model_dump(mode="json") for icon in (t.icons or [])],
+                            annotations=t.annotations.model_dump(mode="json") if t.annotations else {},
+                            execution=t.execution.model_dump(mode="json") if t.execution else {},
+                            meta=t.meta or {},
                         )
                         for t in tools_result.tools
                     ]
@@ -530,8 +548,14 @@ class McpClientService:
                     tools = [
                         McpToolInfo(
                             name=t.name,
+                            title=t.title,
                             description=t.description,
                             input_schema=t.inputSchema or {},
+                            output_schema=t.outputSchema or {},
+                            icons=[icon.model_dump(mode="json") for icon in (t.icons or [])],
+                            annotations=t.annotations.model_dump(mode="json") if t.annotations else {},
+                            execution=t.execution.model_dump(mode="json") if t.execution else {},
+                            meta=t.meta or {},
                         )
                         for t in tools_result.tools
                     ]

--- a/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
+++ b/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
@@ -23,8 +23,31 @@ async def test_discover_stdio_uses_logged_stdio_client(monkeypatch: pytest.Monke
     class _Tool:
         def __init__(self) -> None:
             self.name = "demo"
+            self.title = "Demo Tool"
             self.description = "demo tool"
             self.inputSchema = {"type": "object"}
+            self.outputSchema = {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+            self.icons = [type("_Icon", (), {"model_dump": lambda self, mode="json": {"src": "https://example.com/icon.png"}})()]
+            self.annotations = type(
+                "_Annotations",
+                (),
+                {
+                    "model_dump": lambda self, mode="json": {
+                        "title": "Annotated Demo",
+                        "readOnlyHint": True,
+                    }
+                },
+            )()
+            self.execution = type(
+                "_Execution",
+                (),
+                {
+                    "model_dump": lambda self, mode="json": {
+                        "taskSupport": "optional",
+                    }
+                },
+            )()
+            self.meta = {"source": "spec"}
 
     class _ToolsResult:
         tools = [_Tool()]
@@ -56,6 +79,12 @@ async def test_discover_stdio_uses_logged_stdio_client(monkeypatch: pytest.Monke
     assert result.success is True
     assert captured["initialized"] is True
     assert captured["errlog"].source == "mcp.zai-mcp-server"
+    assert result.tools[0].title == "Demo Tool"
+    assert result.tools[0].output_schema == {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+    assert result.tools[0].icons == [{"src": "https://example.com/icon.png"}]
+    assert result.tools[0].annotations == {"title": "Annotated Demo", "readOnlyHint": True}
+    assert result.tools[0].execution == {"taskSupport": "optional"}
+    assert result.tools[0].meta == {"source": "spec"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更摘要

本次改动补齐了 MCP Server Tools 卡片对官方 Tool 元信息的展示能力，重点解决此前只能看到 `input schema`、无法看到 `output schema` 的问题，并把相关元信息的后端发现、数据库持久化、API 响应与前端渲染链路一并对齐。

## 为什么要改

当前 MCP Tools 卡片只能展示 `input schema`，用户无法直接在 UI 中判断工具的结构化输出形态，也看不到 MCP 官方规范中已经定义但对理解工具行为有帮助的元信息。这会带来两个问题：

1. Tool 的输入和输出认知不对称，使用者难以快速判断调用结果结构。
2. 后端虽然可以从 MCP Server 发现更多官方字段，但现有链路没有持久化和展示，导致信息丢失。

这次改动的目标是以最小干预方式补齐整条链路，在不影响现有工具加载与展示逻辑的前提下，提高 Tools 卡片的可读性与协议一致性。

## 具体改动

### 1. 后端补齐 MCP Tool 元信息链路

- 扩展 MCP Tool 发现结果，新增读取并返回以下官方字段：
  - `title`
  - `output_schema`
  - `icons`
  - `annotations`
  - `execution`
  - `meta`
- 更新 Tool 同步逻辑，在 `tools:load` 时统一写入上述字段，避免只在前端临时展示、刷新后丢失。

### 2. 数据模型与数据库迁移

- 为 `mcp_tools` 表新增以下字段：
  - `title`
  - `output_schema`
  - `icons`
  - `annotations`
  - `execution`
  - `meta`
- 更新 ORM 模型与 API 响应模型，保证数据库、服务层和前端消费类型一致。

### 3. 前端 MCP Tools 卡片增强

- 将原先仅用于 `input schema` 的展示逻辑抽象为可复用的 `SchemaSection`。
- 在 Tool 详情面板中新增：
  - `Output Schema`
  - Schema draft/dialect 提示
  - Tool metadata 区块
  - `taskSupport` 展示
  - `Advanced Metadata` 原始 JSON 折叠区
- Tool 标题展示按更贴近 MCP 官方语义的优先级回退。
- 增加工具列表切换按钮的 `aria-label`，补一处可访问性细节。
- 对动态图标源做了安全约束，只渲染受限的安全地址形式。

## 实现细节

- 这次改动没有修改现有的 Tool 加载入口、权限模型、调用统计或交互主流程，主要是在既有链路上做对称补全。
- 图标展示没有直接切到 `next/image`，因为 MCP 图标来源于运行时服务端元数据，无法预先稳定配置远端白名单；因此保留受限 `<img>` 渲染，并显式加了安全约束与说明。
- `meta` 作为开放扩展字段，只放在高级区块做原样展示，不参与业务逻辑判断，避免引入隐式契约。

## 验证情况

已完成定向验证：

- `uv run pytest tests/unit_tests/plugins/test_mcp_client.py`
- `pnpm exec vitest run tests/unit/plugins/McpServerCard.test.tsx tests/unit/plugins/McpLayout.test.tsx`
- `uv run alembic heads` 返回新迁移为当前 head
- `pnpm exec eslint` 针对本次改动文件通过

补充说明：

- 未将全量 `pnpm exec tsc --noEmit` 作为本次阻塞项，因为仓库中已存在与本次改动无关的既有测试类型问题。
