### PR TITLE
fix(knowledge): 收敛文档提取设置面板状态与测试契约;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -1,0 +1,21 @@
+import {
+  buildCorpusConfig,
+  buildExtractorRoutesFromDraft,
+  createDefaultChunkingConfig,
+  createEmptyExtractorDraftTarget,
+  normalizeChunkingConfig,
+  normalizeCorpusExtractorRoutes,
+  normalizeExtractorDraftRoutes,
+} from "@/features/knowledge/utils/knowledge-api";
+
+export function createKnowledgeConfigTestExports() {
+  return {
+    createDefaultChunkingConfig,
+    normalizeChunkingConfig,
+    normalizeCorpusExtractorRoutes,
+    createEmptyExtractorDraftTarget,
+    normalizeExtractorDraftRoutes,
+    buildExtractorRoutesFromDraft,
+    buildCorpusConfig,
+  };
+}

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createKnowledgeConfigTestExports } from "@/tests/helpers/knowledge";
 
 const {
   replaceMock,
@@ -67,120 +68,7 @@ vi.mock("@/features/knowledge", () => ({
   fetchDocuments: (...args: unknown[]) => fetchDocumentsMock(...args),
   fetchDocumentChunks: (...args: unknown[]) => fetchDocumentChunksMock(...args),
   searchAcrossCorpora: (...args: unknown[]) => searchAcrossCorporaMock(...args),
-  createDefaultChunkingConfig: (strategy: string = "recursive") => {
-    if (strategy === "semantic") {
-      return {
-        strategy: "semantic",
-        semantic_threshold: 0.85,
-        semantic_buffer_size: 1,
-        min_chunk_size: 50,
-        max_chunk_size: 2000,
-      };
-    }
-    if (strategy === "hierarchical") {
-      return {
-        strategy: "hierarchical",
-        preserve_newlines: true,
-        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
-        hierarchical_parent_chunk_size: 1024,
-        hierarchical_child_chunk_size: 256,
-        hierarchical_child_overlap: 51,
-      };
-    }
-    if (strategy === "fixed") {
-      return {
-        strategy: "fixed",
-        chunk_size: 800,
-        overlap: 100,
-        preserve_newlines: true,
-      };
-    }
-    return {
-      strategy: "recursive",
-      chunk_size: 800,
-      overlap: 100,
-      preserve_newlines: true,
-      separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
-    };
-  },
-  normalizeChunkingConfig: (config: Record<string, unknown> | null | undefined) =>
-    config?.strategy
-      ? config
-      : {
-          strategy: "recursive",
-          chunk_size: 800,
-          overlap: 100,
-          preserve_newlines: true,
-          separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
-        },
-  normalizeCorpusExtractorRoutes: (config: Record<string, unknown> | null | undefined) =>
-    (config?.extractor_routes as Record<string, unknown> | undefined) || {
-      url: { targets: [] },
-      file_pdf: { targets: [] },
-    },
-  createEmptyExtractorDraftTarget: (priority: number) => ({
-    server_id: "",
-    tool_name: "",
-    priority,
-    enabled: true,
-  }),
-  normalizeExtractorDraftRoutes: (config: Record<string, unknown> | null | undefined) => {
-    const extractorRoutes =
-      (config?.extractor_routes as Record<string, { targets?: Array<Record<string, unknown>> }> | undefined) ||
-      {};
-    const toDraftRoute = (targets?: Array<Record<string, unknown>>) =>
-      ([0, 1].map((priority) => {
-        const existing = targets?.find((item) => Number(item.priority || 0) === priority) || targets?.[priority];
-        return existing
-          ? {
-              server_id: String(existing.server_id || ""),
-              tool_name: String(existing.tool_name || ""),
-              priority,
-              enabled: existing.enabled !== false,
-            }
-          : {
-              server_id: "",
-              tool_name: "",
-              priority,
-              enabled: true,
-            };
-      })) as [
-        { server_id: string; tool_name: string; priority: number; enabled: boolean },
-        { server_id: string; tool_name: string; priority: number; enabled: boolean },
-      ];
-
-    return {
-      url: toDraftRoute(extractorRoutes.url?.targets),
-      file_pdf: toDraftRoute(extractorRoutes.file_pdf?.targets),
-    };
-  },
-  buildExtractorRoutesFromDraft: (draft: Record<string, Array<Record<string, unknown>>>) => ({
-    url: {
-      targets: (draft.url || [])
-        .filter((item) => item.server_id && item.tool_name)
-        .map((item, priority) => ({
-          ...item,
-          priority,
-          enabled: item.enabled !== false,
-        })),
-    },
-    file_pdf: {
-      targets: (draft.file_pdf || [])
-        .filter((item) => item.server_id && item.tool_name)
-        .map((item, priority) => ({
-          ...item,
-          priority,
-          enabled: item.enabled !== false,
-        })),
-    },
-  }),
-  buildCorpusConfig: (
-    chunkingConfig: Record<string, unknown>,
-    extractorRoutes: Record<string, unknown>,
-  ) => ({
-    ...chunkingConfig,
-    extractor_routes: extractorRoutes,
-  }),
+  ...createKnowledgeConfigTestExports(),
   DocumentViewDialog: ({
     isOpen,
     document,

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -293,4 +293,109 @@ describe("fetchCorpus", () => {
       },
     });
   });
+
+  it("normalizeExtractorDraftRoutes 会保留 timeout_ms 与 tool_options 等扩展字段", () => {
+    const draft = normalizeExtractorDraftRoutes({
+      extractor_routes: {
+        url: {
+          targets: [
+            {
+              server_id: "server-advanced",
+              tool_name: "fetch_structured",
+              priority: 0,
+              enabled: true,
+              timeout_ms: 15000,
+              tool_options: {
+                mode: "markdown",
+                include_images: true,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.url[0]).toEqual(
+      expect.objectContaining({
+        server_id: "server-advanced",
+        tool_name: "fetch_structured",
+        priority: 0,
+        enabled: true,
+        timeout_ms: 15000,
+        tool_options: {
+          mode: "markdown",
+          include_images: true,
+        },
+      }),
+    );
+  });
+
+  it("buildExtractorRoutesFromDraft 会稳定处理 url 与 file_pdf 双 route", () => {
+    const routes = buildExtractorRoutesFromDraft({
+      url: [
+        {
+          server_id: "server-url-primary",
+          tool_name: "fetch_markdown",
+          priority: 0,
+          enabled: true,
+          timeout_ms: 12000,
+          tool_options: { format: "md" },
+        },
+        createEmptyExtractorDraftTarget(1),
+      ],
+      file_pdf: [
+        {
+          server_id: "server-pdf-primary",
+          tool_name: "parse_pdf",
+          priority: 0,
+          enabled: true,
+          timeout_ms: 20000,
+          tool_options: { ocr: false },
+        },
+        {
+          server_id: "server-pdf-backup",
+          tool_name: "parse_pdf_backup",
+          priority: 1,
+          enabled: true,
+          timeout_ms: 25000,
+          tool_options: { ocr: true },
+        },
+      ],
+    });
+
+    expect(routes).toEqual({
+      url: {
+        targets: [
+          expect.objectContaining({
+            server_id: "server-url-primary",
+            tool_name: "fetch_markdown",
+            priority: 0,
+            enabled: true,
+            timeout_ms: 12000,
+            tool_options: { format: "md" },
+          }),
+        ],
+      },
+      file_pdf: {
+        targets: [
+          expect.objectContaining({
+            server_id: "server-pdf-primary",
+            tool_name: "parse_pdf",
+            priority: 0,
+            enabled: true,
+            timeout_ms: 20000,
+            tool_options: { ocr: false },
+          }),
+          expect.objectContaining({
+            server_id: "server-pdf-backup",
+            tool_name: "parse_pdf_backup",
+            priority: 1,
+            enabled: true,
+            timeout_ms: 25000,
+            tool_options: { ocr: true },
+          }),
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
## 变更说明

本次改动围绕 `Knowledge Base` 页面 `Documents` 视图下的设置面板，分四步完成了文档提取配置的状态管理与测试契约收敛：

1. 修正文案命名，使设置区语义更清晰：
   - `Settings` -> `Chunking Settings`
   - `Data Extractor MCP` -> `Document Extraction Settings`

2. 修复文档提取配置的核心交互问题：
   - 解决选择 MCP Server 后立即回退为“未配置”、导致 Tool 无法继续选择的问题；
   - 引入固定双槽位草稿态，允许“已选 Server、未选 Tool”的中间态稳定存在；
   - 保证保存时再将草稿态转换为 `extractor_routes`，避免编辑过程中受控值失配。

3. 继续收敛长期状态管理：
   - 调整草稿态同步策略，避免外部 `corpus` 刷新覆盖未保存编辑；
   - 抽取 `ExtractorDraftRoutes` 的双向转换为共享 helper，减少页面组件内的 UI 配置转换逻辑；
   - 保持页面层只关注交互状态与展示，降低页面状态漂移风险。

4. 收敛测试侧单一事实源：
   - 新增共享测试工厂，复用真实 knowledge helper 导出，而不是在页面测试里重复维护一份 draft 转换语义；
   - 补强 `knowledge-api` 契约测试，锁定共享 helper 的边界与往返语义。

## 为什么要改

原始问题会直接阻断文档提取配置链路：在 URL/PDF 文档提取配置中，用户刚选中的 MCP Server 会被前端状态过滤逻辑立即清空，Tool 下拉无法稳定进入可选状态，最终导致配置无法完成。

在首轮 bug fix 后，继续审查发现还有三个长期风险需要一起收敛：

- 草稿态如果依赖外部 `corpus.config` 的引用变化做同步，后台刷新或重新加载时可能会静默覆盖用户尚未保存的输入；
- `ExtractorDraftRoutes` 的双向转换规则如果继续散落在页面组件中，页面状态管理和共享配置转换会逐渐形成双源事实；
- 页面测试如果继续手写 helper mock 语义，测试代码会再次复制一份 draft 转换规则，造成测试侧 split-brain。

因此这次 PR 不只是修复一个交互 bug，而是进一步将设置面板收敛到更稳定的模式：**UI 草稿态与持久化配置分离，切换实体时显式重置，转换规则沉淀到共享 helper，测试也复用同一事实源。**

## 具体实现

### 1. 修复文档提取设置的主路径交互
在 `apps/negentropy-ui/app/knowledge/base/page.tsx` 中，文档提取配置使用固定双槽位草稿态：

- 为 `url` 与 `file_pdf` 各保留主用 / 备用两个稳定槽位；
- 允许槽位处于“已选 Server、未选 Tool”的合法中间态；
- 仅在点击保存时，才把草稿态转换成 `extractor_routes` 并过滤不完整项。

这样避免了 `select` 的受控值在中间态被过早清洗，从而回退为“未配置”。

### 2. 收敛草稿态同步策略
设置面板本地状态只在切换不同 `corpus` 时重置，不再仅因外部 `corpus.config` 刷新就无条件覆盖正在编辑中的本地草稿。

这符合受控表单的长期最佳实践：**用户编辑优先，显式切换时重置，而不是被任意 props 抖动打断。**

### 3. 抽取共享转换 helper
在 `apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts` 中新增并导出了与 UI 草稿态相关的共享 helper：

- `createEmptyExtractorDraftTarget`
- `normalizeExtractorDraftRoutes`
- `buildExtractorRoutesFromDraft`

并通过 `apps/negentropy-ui/features/knowledge/index.ts` 统一导出，让页面层只消费 feature 边界，不再自己维护一份转换规则。

### 4. 收敛测试工厂与契约覆盖
测试层分两部分补强：

- `apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx`
  - 改为通过共享测试工厂复用真实 helper 导出；
  - 覆盖“选择 MCP Server 不回退”“不可用 MCP/Tool 回显”“外部 corpus 刷新不覆盖未保存草稿”等页面行为。
- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts`
  - 补充共享 helper 的契约测试；
  - 覆盖固定双槽位生成、不完整槽位过滤、priority 重排、`timeout_ms` / `tool_options` 等扩展字段保留，以及 `url` / `file_pdf` 双 route 并存场景。

## 验证结果

已通过前端测试验证：

- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/knowledge-api.test.ts`

实际运行结果为前端测试全集通过：

- 36 个 test files passed
- 187 个 tests passed

## 影响范围与兼容性

- 不修改后端 API 协议；
- 不修改 `extractor_routes` 的持久化格式；
- 不影响现有 chunking 配置保存逻辑；
- 通过共享 helper 与共享测试工厂集中化配置转换规则，降低后续页面状态漂移与测试契约失配的风险。
