### PR TITLE
test(knowledge): 收敛页面测试到统一 knowledge harness;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -8,6 +8,57 @@ import {
   normalizeExtractorDraftRoutes,
 } from "@/features/knowledge/utils/knowledge-api";
 
+export interface KnowledgeFeatureMockSet {
+  searchKnowledgeMock: ReturnType<typeof vi.fn>;
+  ingestTextMock: ReturnType<typeof vi.fn>;
+  ingestUrlMock: ReturnType<typeof vi.fn>;
+  replaceSourceMock: ReturnType<typeof vi.fn>;
+  fetchKnowledgeItemsMock: ReturnType<typeof vi.fn>;
+  createCorpusMock: ReturnType<typeof vi.fn>;
+  deleteCorpusMock: ReturnType<typeof vi.fn>;
+  fetchPipelinesMock: ReturnType<typeof vi.fn>;
+  upsertPipelinesMock: ReturnType<typeof vi.fn>;
+  fetchDocumentsMock: ReturnType<typeof vi.fn>;
+  fetchDocumentChunksMock: ReturnType<typeof vi.fn>;
+  searchAcrossCorporaMock: ReturnType<typeof vi.fn>;
+  syncDocumentMock: ReturnType<typeof vi.fn>;
+  rebuildDocumentMock: ReturnType<typeof vi.fn>;
+  replaceDocumentMock: ReturnType<typeof vi.fn>;
+  archiveDocumentMock: ReturnType<typeof vi.fn>;
+  unarchiveDocumentMock: ReturnType<typeof vi.fn>;
+  downloadDocumentMock: ReturnType<typeof vi.fn>;
+  deleteDocumentMock: ReturnType<typeof vi.fn>;
+}
+
+export interface KnowledgeFeatureTestHarness {
+  exports: Record<string, unknown>;
+  mocks: KnowledgeFeatureMockSet;
+}
+
+export function createKnowledgeFeatureMockSet(): KnowledgeFeatureMockSet {
+  return {
+    searchKnowledgeMock: vi.fn(),
+    ingestTextMock: vi.fn(),
+    ingestUrlMock: vi.fn(),
+    replaceSourceMock: vi.fn(),
+    fetchKnowledgeItemsMock: vi.fn(),
+    createCorpusMock: vi.fn(),
+    deleteCorpusMock: vi.fn(),
+    fetchPipelinesMock: vi.fn(),
+    upsertPipelinesMock: vi.fn(),
+    fetchDocumentsMock: vi.fn(),
+    fetchDocumentChunksMock: vi.fn(),
+    searchAcrossCorporaMock: vi.fn(),
+    syncDocumentMock: vi.fn(),
+    rebuildDocumentMock: vi.fn(),
+    replaceDocumentMock: vi.fn(),
+    archiveDocumentMock: vi.fn(),
+    unarchiveDocumentMock: vi.fn(),
+    downloadDocumentMock: vi.fn(),
+    deleteDocumentMock: vi.fn(),
+  };
+}
+
 export function createKnowledgeConfigTestExports() {
   return {
     createDefaultChunkingConfig,
@@ -17,5 +68,37 @@ export function createKnowledgeConfigTestExports() {
     normalizeExtractorDraftRoutes,
     buildExtractorRoutesFromDraft,
     buildCorpusConfig,
+  };
+}
+
+export function createKnowledgeFeatureTestHarness(
+  mocks: KnowledgeFeatureMockSet,
+  overrides: Record<string, unknown> = {},
+): KnowledgeFeatureTestHarness {
+  return {
+    mocks,
+    exports: {
+      searchKnowledge: (...args: unknown[]) => mocks.searchKnowledgeMock(...args),
+      ingestText: (...args: unknown[]) => mocks.ingestTextMock(...args),
+      ingestUrl: (...args: unknown[]) => mocks.ingestUrlMock(...args),
+      replaceSource: (...args: unknown[]) => mocks.replaceSourceMock(...args),
+      fetchKnowledgeItems: (...args: unknown[]) => mocks.fetchKnowledgeItemsMock(...args),
+      createCorpus: (...args: unknown[]) => mocks.createCorpusMock(...args),
+      deleteCorpus: (...args: unknown[]) => mocks.deleteCorpusMock(...args),
+      fetchPipelines: (...args: unknown[]) => mocks.fetchPipelinesMock(...args),
+      upsertPipelines: (...args: unknown[]) => mocks.upsertPipelinesMock(...args),
+      fetchDocuments: (...args: unknown[]) => mocks.fetchDocumentsMock(...args),
+      fetchDocumentChunks: (...args: unknown[]) => mocks.fetchDocumentChunksMock(...args),
+      searchAcrossCorpora: (...args: unknown[]) => mocks.searchAcrossCorporaMock(...args),
+      syncDocument: (...args: unknown[]) => mocks.syncDocumentMock(...args),
+      rebuildDocument: (...args: unknown[]) => mocks.rebuildDocumentMock(...args),
+      replaceDocument: (...args: unknown[]) => mocks.replaceDocumentMock(...args),
+      archiveDocument: (...args: unknown[]) => mocks.archiveDocumentMock(...args),
+      unarchiveDocument: (...args: unknown[]) => mocks.unarchiveDocumentMock(...args),
+      downloadDocument: (...args: unknown[]) => mocks.downloadDocumentMock(...args),
+      deleteDocument: (...args: unknown[]) => mocks.deleteDocumentMock(...args),
+      ...createKnowledgeConfigTestExports(),
+      ...overrides,
+    },
   };
 }

--- a/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
@@ -1,24 +1,28 @@
-const {
-  ingestTextMock,
-  ingestUrlMock,
-  replaceSourceMock,
-  createCorpusMock,
-} = vi.hoisted(() => ({
+const knowledgeMocks = vi.hoisted(() => ({
+  searchKnowledgeMock: vi.fn(),
   ingestTextMock: vi.fn(),
   ingestUrlMock: vi.fn(),
   replaceSourceMock: vi.fn(),
+  fetchKnowledgeItemsMock: vi.fn(),
   createCorpusMock: vi.fn(),
+  deleteCorpusMock: vi.fn(),
+  fetchPipelinesMock: vi.fn(),
+  upsertPipelinesMock: vi.fn(),
+  fetchDocumentsMock: vi.fn(),
+  fetchDocumentChunksMock: vi.fn(),
+  searchAcrossCorporaMock: vi.fn(),
+  syncDocumentMock: vi.fn(),
+  rebuildDocumentMock: vi.fn(),
+  replaceDocumentMock: vi.fn(),
+  archiveDocumentMock: vi.fn(),
+  unarchiveDocumentMock: vi.fn(),
+  downloadDocumentMock: vi.fn(),
+  deleteDocumentMock: vi.fn(),
 }));
-
-vi.mock("@/features/knowledge", () => ({
-  searchKnowledge: vi.fn(),
-  ingestText: (...args: unknown[]) => ingestTextMock(...args),
-  ingestUrl: (...args: unknown[]) => ingestUrlMock(...args),
-  replaceSource: (...args: unknown[]) => replaceSourceMock(...args),
-  fetchKnowledgeItems: vi.fn(),
-  createCorpus: (...args: unknown[]) => createCorpusMock(...args),
-  deleteCorpus: vi.fn(),
-}));
+vi.mock("@/features/knowledge", async () => {
+  const { createKnowledgeFeatureTestHarness } = await import("@/tests/helpers/knowledge");
+  return createKnowledgeFeatureTestHarness(knowledgeMocks).exports;
+});
 
 import { executeApiCall } from "@/app/knowledge/apis/_components/utils/ApiExecutor";
 import { KNOWLEDGE_API_ENDPOINTS } from "@/features/knowledge/utils/api-specs";
@@ -32,10 +36,10 @@ const getEndpoint = (id: string) => {
 describe("ApiExecutor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    ingestTextMock.mockResolvedValue({ ok: true });
-    ingestUrlMock.mockResolvedValue({ ok: true });
-    replaceSourceMock.mockResolvedValue({ ok: true });
-    createCorpusMock.mockResolvedValue({ ok: true });
+    knowledgeMocks.ingestTextMock.mockResolvedValue({ ok: true });
+    knowledgeMocks.ingestUrlMock.mockResolvedValue({ ok: true });
+    knowledgeMocks.replaceSourceMock.mockResolvedValue({ ok: true });
+    knowledgeMocks.createCorpusMock.mockResolvedValue({ ok: true });
   });
 
   it("ingest 通过 chunking_config 透传 canonical 配置", async () => {
@@ -51,7 +55,7 @@ describe("ApiExecutor", () => {
       },
     });
 
-    expect(ingestTextMock).toHaveBeenCalledWith("corpus-1", {
+    expect(knowledgeMocks.ingestTextMock).toHaveBeenCalledWith("corpus-1", {
       app_name: "negentropy",
       text: "hello",
       source_uri: undefined,
@@ -88,13 +92,13 @@ describe("ApiExecutor", () => {
       chunking_config: chunkingConfig,
     });
 
-    expect(ingestUrlMock).toHaveBeenCalledWith("corpus-1", {
+    expect(knowledgeMocks.ingestUrlMock).toHaveBeenCalledWith("corpus-1", {
       app_name: "negentropy",
       url: "https://example.com",
       metadata: undefined,
       chunking_config: chunkingConfig,
     });
-    expect(replaceSourceMock).toHaveBeenCalledWith("corpus-1", {
+    expect(knowledgeMocks.replaceSourceMock).toHaveBeenCalledWith("corpus-1", {
       app_name: "negentropy",
       text: "updated",
       source_uri: "docs://example/doc1",
@@ -116,7 +120,7 @@ describe("ApiExecutor", () => {
       },
     });
 
-    expect(createCorpusMock).toHaveBeenCalledWith({
+    expect(knowledgeMocks.createCorpusMock).toHaveBeenCalledWith({
       app_name: "negentropy",
       name: "产品文档",
       description: "desc",

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1,6 +1,5 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createKnowledgeConfigTestExports } from "@/tests/helpers/knowledge";
 
 const {
   replaceMock,
@@ -18,6 +17,12 @@ const {
   searchAcrossCorporaMock,
   documentViewDialogMock,
   fetchMock,
+  syncDocumentMock,
+  rebuildDocumentMock,
+  replaceDocumentFeatureMock,
+  archiveDocumentMock,
+  unarchiveDocumentMock,
+  downloadDocumentMock,
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
@@ -33,6 +38,12 @@ const {
   searchAcrossCorporaMock: vi.fn(),
   documentViewDialogMock: vi.fn(),
   fetchMock: vi.fn(),
+  syncDocumentMock: vi.fn(),
+  rebuildDocumentMock: vi.fn(),
+  replaceDocumentFeatureMock: vi.fn(),
+  archiveDocumentMock: vi.fn(),
+  unarchiveDocumentMock: vi.fn(),
+  downloadDocumentMock: vi.fn(),
   searchParamsState: {
     value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
   },
@@ -63,31 +74,46 @@ vi.mock("@/app/knowledge/base/_components/ReplaceDocumentDialog", () => ({
   ReplaceDocumentDialog: () => null,
 }));
 
-vi.mock("@/features/knowledge", () => ({
-  useKnowledgeBase: (...args: unknown[]) => useKnowledgeBaseMock(...args),
-  fetchDocuments: (...args: unknown[]) => fetchDocumentsMock(...args),
-  fetchDocumentChunks: (...args: unknown[]) => fetchDocumentChunksMock(...args),
-  searchAcrossCorpora: (...args: unknown[]) => searchAcrossCorporaMock(...args),
-  ...createKnowledgeConfigTestExports(),
-  DocumentViewDialog: ({
-    isOpen,
-    document,
-  }: {
-    isOpen: boolean;
-    document: { original_filename: string } | null;
-  }) => {
-    documentViewDialogMock({ isOpen, document });
-    if (!isOpen || !document) return null;
-    return <div>Viewing {document.original_filename}</div>;
-  },
-  syncDocument: vi.fn(),
-  rebuildDocument: vi.fn(),
-  replaceDocument: vi.fn(),
-  archiveDocument: vi.fn(),
-  unarchiveDocument: vi.fn(),
-  downloadDocument: vi.fn(),
-  deleteDocument: (...args: unknown[]) => deleteDocumentMock(...args),
-}));
+vi.mock("@/features/knowledge", async () => {
+  const { createKnowledgeFeatureTestHarness } = await import("@/tests/helpers/knowledge");
+  return createKnowledgeFeatureTestHarness(
+    {
+      searchKnowledgeMock: vi.fn(),
+      ingestTextMock: vi.fn(),
+      ingestUrlMock,
+      replaceSourceMock: vi.fn(),
+      fetchKnowledgeItemsMock: vi.fn(),
+      createCorpusMock: vi.fn(),
+      deleteCorpusMock,
+      fetchPipelinesMock: vi.fn(),
+      upsertPipelinesMock: vi.fn(),
+      fetchDocumentsMock,
+      fetchDocumentChunksMock,
+      searchAcrossCorporaMock,
+      syncDocumentMock,
+      rebuildDocumentMock,
+      replaceDocumentMock: replaceDocumentFeatureMock,
+      archiveDocumentMock,
+      unarchiveDocumentMock,
+      downloadDocumentMock,
+      deleteDocumentMock,
+    },
+    {
+      useKnowledgeBase: (...args: unknown[]) => useKnowledgeBaseMock(...args),
+      DocumentViewDialog: ({
+        isOpen,
+        document,
+      }: {
+        isOpen: boolean;
+        document: { original_filename: string } | null;
+      }) => {
+        documentViewDialogMock({ isOpen, document });
+        if (!isOpen || !document) return null;
+        return <div>Viewing {document.original_filename}</div>;
+      },
+    },
+  ).exports;
+});
 
 import KnowledgeBasePage from "@/app/knowledge/base/page";
 
@@ -111,6 +137,12 @@ describe("KnowledgeBasePage", () => {
     searchAcrossCorporaMock.mockReset();
     documentViewDialogMock.mockReset();
     fetchMock.mockReset();
+    syncDocumentMock.mockReset();
+    rebuildDocumentMock.mockReset();
+    replaceDocumentFeatureMock.mockReset();
+    archiveDocumentMock.mockReset();
+    unarchiveDocumentMock.mockReset();
+    downloadDocumentMock.mockReset();
     searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
 
     global.fetch = fetchMock;

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
@@ -1,18 +1,34 @@
 import { act, render, screen } from "@testing-library/react";
 
-const { fetchPipelinesMock, upsertPipelinesMock } = vi.hoisted(() => ({
+const knowledgeMocks = vi.hoisted(() => ({
+  searchKnowledgeMock: vi.fn(),
+  ingestTextMock: vi.fn(),
+  ingestUrlMock: vi.fn(),
+  replaceSourceMock: vi.fn(),
+  fetchKnowledgeItemsMock: vi.fn(),
+  createCorpusMock: vi.fn(),
+  deleteCorpusMock: vi.fn(),
   fetchPipelinesMock: vi.fn(),
   upsertPipelinesMock: vi.fn(),
+  fetchDocumentsMock: vi.fn(),
+  fetchDocumentChunksMock: vi.fn(),
+  searchAcrossCorporaMock: vi.fn(),
+  syncDocumentMock: vi.fn(),
+  rebuildDocumentMock: vi.fn(),
+  replaceDocumentMock: vi.fn(),
+  archiveDocumentMock: vi.fn(),
+  unarchiveDocumentMock: vi.fn(),
+  downloadDocumentMock: vi.fn(),
+  deleteDocumentMock: vi.fn(),
 }));
-
 vi.mock("@/components/ui/KnowledgeNav", () => ({
   KnowledgeNav: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
-vi.mock("@/features/knowledge", () => ({
-  fetchPipelines: (...args: unknown[]) => fetchPipelinesMock(...args),
-  upsertPipelines: (...args: unknown[]) => upsertPipelinesMock(...args),
-}));
+vi.mock("@/features/knowledge", async () => {
+  const { createKnowledgeFeatureTestHarness } = await import("@/tests/helpers/knowledge");
+  return createKnowledgeFeatureTestHarness(knowledgeMocks).exports;
+});
 
 import KnowledgePipelinesPage from "@/app/knowledge/pipelines/page";
 
@@ -37,8 +53,8 @@ const makeRun = (overrides?: Partial<{ id: string; run_id: string; status: strin
 describe("KnowledgePipelinesPage polling", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    fetchPipelinesMock.mockReset();
-    upsertPipelinesMock.mockReset();
+    knowledgeMocks.fetchPipelinesMock.mockReset();
+    knowledgeMocks.upsertPipelinesMock.mockReset();
   });
 
   afterEach(() => {
@@ -46,7 +62,7 @@ describe("KnowledgePipelinesPage polling", () => {
   });
 
   it("在首屏无数据时，会通过兜底轮询自动显示新 Run", async () => {
-    fetchPipelinesMock
+    knowledgeMocks.fetchPipelinesMock
       .mockResolvedValueOnce({ runs: [], last_updated_at: "t0" })
       .mockResolvedValueOnce({ runs: [], last_updated_at: "t1" })
       .mockResolvedValueOnce({
@@ -56,7 +72,7 @@ describe("KnowledgePipelinesPage polling", () => {
 
     render(<KnowledgePipelinesPage />);
     await settle();
-    expect(fetchPipelinesMock).toHaveBeenCalledTimes(1);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(1);
 
     expect(screen.getByText("暂无作业")).toBeInTheDocument();
 
@@ -69,43 +85,43 @@ describe("KnowledgePipelinesPage polling", () => {
   });
 
   it("兜底轮询在达到 8 秒窗口后停止继续请求", async () => {
-    fetchPipelinesMock.mockResolvedValue({
+    knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
       runs: [],
       last_updated_at: "t0",
     });
 
     render(<KnowledgePipelinesPage />);
     await settle();
-    expect(fetchPipelinesMock).toHaveBeenCalledTimes(1);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(8000);
     });
     await settle();
-    expect(fetchPipelinesMock).toHaveBeenCalledTimes(9);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(9);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(3000);
     });
     await settle();
 
-    expect(fetchPipelinesMock).toHaveBeenCalledTimes(9);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(9);
   });
 
   it("存在 running Run 时按 3 秒节奏轮询", async () => {
-    fetchPipelinesMock.mockResolvedValue({
+    knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
       runs: [makeRun({ status: "running" })],
       last_updated_at: "t0",
     });
 
     render(<KnowledgePipelinesPage />);
     await settle();
-    expect(fetchPipelinesMock).toHaveBeenCalledTimes(1);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(6000);
     });
     await settle();
-    expect(fetchPipelinesMock).toHaveBeenCalledTimes(3);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-test-harness.test.ts
@@ -1,0 +1,41 @@
+import {
+  buildCorpusConfig,
+  createDefaultChunkingConfig,
+} from "@/features/knowledge/utils/knowledge-api";
+import {
+  createKnowledgeFeatureMockSet,
+  createKnowledgeFeatureTestHarness,
+} from "@/tests/helpers/knowledge";
+
+describe("knowledge test harness", () => {
+  it("默认复用真实配置 helper，并把 exports 与 mocks 绑定到同一组函数", () => {
+    const mocks = createKnowledgeFeatureMockSet();
+    const harness = createKnowledgeFeatureTestHarness(mocks);
+
+    expect(harness.exports.createDefaultChunkingConfig).toBe(
+      createDefaultChunkingConfig,
+    );
+    expect(harness.exports.buildCorpusConfig).toBe(buildCorpusConfig);
+
+    const fetchPipelines = harness.exports.fetchPipelines as (
+      ...args: unknown[]
+    ) => unknown;
+    fetchPipelines("negentropy");
+
+    expect(mocks.fetchPipelinesMock).toHaveBeenCalledWith("negentropy");
+  });
+
+  it("允许局部 override，而不会替换真实配置 helper", () => {
+    const mocks = createKnowledgeFeatureMockSet();
+    const overrideUseKnowledgeBase = vi.fn();
+    const harness = createKnowledgeFeatureTestHarness(mocks, {
+      useKnowledgeBase: overrideUseKnowledgeBase,
+    });
+
+    expect(harness.exports.useKnowledgeBase).toBe(overrideUseKnowledgeBase);
+    expect(harness.exports.normalizeChunkingConfig).toBeDefined();
+    expect(harness.exports.createDefaultChunkingConfig).toBe(
+      createDefaultChunkingConfig,
+    );
+  });
+});


### PR DESCRIPTION
## 变更说明

本次改动聚焦 `knowledge` 模块的测试基础设施收敛，不涉及生产运行时代码，主要完成了三件事：

1. 为 `@/features/knowledge` 建立统一的 test harness 入口；
2. 将 `KnowledgeBasePage`、`PipelinesPage`、`ApiExecutor` 三组页面/工具测试迁移到同一套 harness；
3. 新增 harness 契约测试，锁定共享 helper 与 mock 绑定关系。

## 为什么要改

在这次收敛前，`knowledge` 相关测试已经开始复用部分共享 helper，但页面测试层仍然存在明显分叉：

- `KnowledgeBasePage.test.tsx`、`PipelinesPage.test.tsx`、`ApiExecutor.test.ts` 各自维护一份 `@/features/knowledge` mock；
- 相同的模块边界在不同测试文件中被重复拼装，增加了测试侧语义漂移与 split-brain 风险；
- 一旦 `@/features/knowledge` 的导出面继续扩展，测试维护成本会继续线性上升；
- Vitest 的 `vi.mock` 是 hoisted 的，如果各个测试文件继续手工拼 mock，后续更容易反复踩到初始化顺序和闭包引用问题。

这次改动的目标，是把 `knowledge` 测试替身收敛到单一入口，遵循“Single Source of Truth” 与 “Composition over Construction”的原则：页面测试复用统一 harness，真实稳定 helper 只维护一份，mock 句柄集中暴露，局部差异通过 override 处理，而不是每个测试再复制一套实现。

## 具体实现

### 1. 扩展统一 `knowledge` 测试工厂
在 `apps/negentropy-ui/tests/helpers/knowledge.ts` 中新增统一 harness 能力：

- `createKnowledgeFeatureMockSet`
  - 统一创建 `@/features/knowledge` 常用 API 的 `vi.fn()` mock 句柄；
- `createKnowledgeFeatureTestHarness`
  - 统一组装 `exports` 与 `mocks`；
  - 默认复用真实配置 helper，例如：
    - `createDefaultChunkingConfig`
    - `normalizeChunkingConfig`
    - `normalizeCorpusExtractorRoutes`
    - `createEmptyExtractorDraftTarget`
    - `normalizeExtractorDraftRoutes`
    - `buildExtractorRoutesFromDraft`
    - `buildCorpusConfig`
  - 同时挂载页面测试常用的 API mock，例如：
    - `fetchPipelines`
    - `upsertPipelines`
    - `ingestText`
    - `ingestUrl`
    - `replaceSource`
    - `createCorpus`
    - `deleteCorpus`
    - `fetchDocuments`
    - `fetchDocumentChunks`
    - `searchAcrossCorpora`
    - `deleteDocument`
    - 以及相关 document pipeline API

这样测试层可以复用真实纯函数 helper，同时继续对副作用 API 做隔离验证。

### 2. 页面测试迁移到统一 harness
以下三组测试改为通过统一 harness 构造 `@/features/knowledge` mock：

- `apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- `apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx`
- `apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts`

迁移后的规则是：

- 通用 `knowledge` 模块导出统一来自 harness；
- 页面专属差异，例如 `useKnowledgeBase`、`DocumentViewDialog` 等，仅通过 override 注入；
- 不再在每个测试文件里重复手写一份 `@/features/knowledge` mock 结构；
- 通过 `vi.hoisted` + mock factory 内懒加载 harness 的方式，兼容 Vitest 的 hoist 顺序，避免 top-level 变量初始化时序问题。

### 3. 新增 harness 契约测试
新增：

- `apps/negentropy-ui/tests/unit/knowledge/knowledge-test-harness.test.ts`

重点验证：

- harness 默认复用真实配置 helper，而不是复制一份实现；
- `exports` 中的方法与 `mocks` 中的 `vi.fn()` 指向同一组调用通道；
- override 只覆盖局部导出，不会污染共享 helper 的真实语义。

这让 unified harness 本身也成为被测试的契约，而不是新的隐式基础设施。

## 实现细节

这次改动遵循了两个关键测试设计原则：

1. **测试基础设施单一事实源**
   - 把 `@/features/knowledge` 的 mock 入口统一到 `tests/helpers/knowledge.ts`；
   - 页面测试不再各自复制模块边界定义。

2. **真实 helper 复用 + 副作用隔离**
   - 配置转换类 helper 继续复用生产代码中的真实实现；
   - 只对副作用 API 使用 `vi.fn()` mock；
   - 避免页面测试和共享 helper 契约再次分叉。

同时，针对 Vitest `vi.mock` 的 hoist 行为，本次实现显式采用了“hoisted mock 句柄 + mock factory 内构造 harness”的方式，避免再次出现由于初始化顺序导致的测试加载失败。

## 验证结果

已执行并通过以下验证：

- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/PipelinesPage.test.tsx`
- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/ApiExecutor.test.ts`
- `pnpm --dir apps/negentropy-ui test -- --run tests/unit/knowledge/knowledge-api.test.ts tests/unit/knowledge/knowledge-test-harness.test.ts`

实际运行结果为前端测试全集通过：

- 40 个 test files passed
- 210 个 tests passed

## 影响范围与兼容性

- 不修改任何生产运行时代码；
- 不修改后端 API、前端页面行为或持久化结构；
- 仅收敛 `knowledge` 测试侧 mock 组织方式与契约验证；
- 降低后续新增 `@/features/knowledge` 导出时的测试扩散成本与 mock 语义漂移风险。
