### PR TITLE
fix(chat): 修复 A2UI 对话乱序、漂移与重复流式显示问题;

### DIFF
--- a/apps/negentropy-ui/app/globals.css
+++ b/apps/negentropy-ui/app/globals.css
@@ -93,9 +93,17 @@
 }
 
 body {
-  background: var(--background);
+  background:
+    radial-gradient(circle at top, rgba(245, 158, 11, 0.10), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 244, 245, 0.94));
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
+}
+
+.dark body {
+  background:
+    radial-gradient(circle at top, rgba(245, 158, 11, 0.08), transparent 26%),
+    linear-gradient(180deg, rgba(9, 9, 11, 1), rgba(24, 24, 27, 0.96));
 }
 
 .mermaid-diagram svg {

--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -30,6 +30,7 @@ import {
   normalizeMessageContent,
 } from "@/utils/message";
 import {
+  mergeOptimisticMessages,
   reconcileOptimisticMessages,
 } from "@/utils/message-merge";
 import { buildTimelineItems } from "@/utils/timeline";
@@ -99,6 +100,8 @@ export function HomeBody({
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const loadedSessionIdRef = useRef<string | null>(null);
   const rawEventsRef = useRef<BaseEvent[]>([]);
+  const activeSessionIdRef = useRef<string | null>(sessionId);
+  const hydrationRequestVersionRef = useRef(0);
 
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === sessionId) || null,
@@ -112,6 +115,10 @@ export function HomeBody({
   useEffect(() => {
     rawEventsRef.current = rawEvents;
   }, [rawEvents]);
+
+  useEffect(() => {
+    activeSessionIdRef.current = sessionId;
+  }, [sessionId]);
 
   const addLog = useCallback(
     (
@@ -560,6 +567,7 @@ export function HomeBody({
 
   const loadSessionDetail = useCallback(
     async (id: string) => {
+      const requestVersion = ++hydrationRequestVersionRef.current;
       try {
         const response = await fetch(
           `/api/agui/sessions/${encodeURIComponent(id)}?app_name=${encodeURIComponent(
@@ -568,6 +576,12 @@ export function HomeBody({
         );
         const payload = await response.json();
         if (!response.ok) {
+          return;
+        }
+        if (
+          hydrationRequestVersionRef.current !== requestVersion ||
+          activeSessionIdRef.current !== id
+        ) {
           return;
         }
         const { payloads: events, invalidCount } = collectAdkEventPayloads(payload.events);
@@ -700,6 +714,7 @@ export function HomeBody({
       return;
     }
 
+    const runId = randomUUID();
     const messageId = crypto.randomUUID();
     const createdAt = new Date();
     const newMessage = {
@@ -707,6 +722,9 @@ export function HomeBody({
       role: "user",
       content: inputValue.trim(),
       createdAt,
+      runId,
+      threadId: sessionId,
+      streaming: false,
     } as Message;
     // 仅使用 optimisticMessages 进行乐观更新，不再向 rawEvents 添加乐观事件
     // 避免消息在 buildChatMessagesFromEventsWithFallback 中重复
@@ -722,7 +740,7 @@ export function HomeBody({
     try {
       setConnectionWithMetrics("connecting");
       await agent.runAgent({
-        runId: randomUUID(),
+        runId,
       });
       scheduleSessionHydration(sessionId);
       await loadSessions();
@@ -781,42 +799,15 @@ export function HomeBody({
       messagesForRenderBase,
       optimisticMessages,
     );
-    const knownIds = new Set(
-      messagesForRenderBase
-        .filter((message) => normalizeMessageContent(message).trim().length > 0)
-        .map((message) => message.id),
+    return mergeOptimisticMessages(messagesForRenderBase, pendingOptimistic).map(
+      (message) =>
+        !normalizeMessageContent(message).trim().length
+          ? ({
+              ...message,
+              content: normalizeMessageContent(message),
+            } as Message)
+          : message,
     );
-
-    const validOptimistic = pendingOptimistic.filter(
-      (message) => !knownIds.has(message.id),
-    );
-
-    if (validOptimistic.length === 0) {
-      return messagesForRenderBase;
-    }
-
-    const merged = [...messagesForRenderBase];
-    const indexById = new Map<string, number>();
-    merged.forEach((message, index) => {
-      indexById.set(message.id, index);
-    });
-
-    validOptimistic.forEach((message) => {
-      const index = indexById.get(message.id);
-      if (index === undefined) {
-        merged.push(message);
-        indexById.set(message.id, merged.length - 1);
-        return;
-      }
-      const existing = merged[index];
-      if (!existing.content && message.content) {
-        merged[index] = {
-          ...existing,
-          content: normalizeMessageContent(message),
-        } as Message;
-      }
-    });
-    return merged;
   }, [messagesForRenderBase, optimisticMessages]);
 
   const conversationTree = useMemo(

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useAuth } from "@/components/providers/AuthProvider";
 import { cn } from "@/lib/utils";
 import type { ChatMessage } from "@/types/common";
@@ -48,10 +49,6 @@ function formatTimestamp(timestamp: number): string {
 function normalizeContent(content: string): string {
   return content;
 }
-
-import { useState } from "react";
-
-// ... (imports remain)
 
 function MessageActions({ content }: { content: string }) {
   const [copied, setCopied] = useState(false);
@@ -228,6 +225,7 @@ export function MessageBubble({
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const content = normalizeContent(message.content);
+  const isStreaming = message.streaming === true && !isUser && content.trim().length > 0;
   const avatarPositionClass = isUser
     ? "absolute right-0 top-2 translate-x-[calc(100%+0.75rem)]"
     : "absolute left-0 top-2 -translate-x-[calc(100%+0.75rem)]";
@@ -245,9 +243,9 @@ export function MessageBubble({
   return (
     <div
       className={cn(
-        "group relative flex w-full cursor-pointer",
+        "group relative flex w-full cursor-pointer rounded-[2rem] px-2 py-1 transition-colors duration-200",
         isUser ? "flex-row-reverse" : "flex-row",
-        isSelected && "bg-muted/50",
+        isSelected && "bg-[linear-gradient(90deg,rgba(245,158,11,0.10),transparent_75%)]",
       )}
       onClick={() => onSelect?.(message.id)}
     >
@@ -276,10 +274,12 @@ export function MessageBubble({
       >
         <div
           className={cn(
-            "rounded-2xl px-5 py-3 text-sm shadow-sm transition-all",
+            "rounded-[1.6rem] px-5 py-3.5 text-sm shadow-sm transition-all duration-300",
             isUser
-              ? "max-w-[85%] rounded-tr-sm bg-foreground leading-relaxed text-background"
-              : "w-full max-w-full rounded-tl-sm border border-border bg-card leading-snug text-foreground",
+              ? "max-w-[85%] rounded-tr-md border border-zinc-900/90 bg-[linear-gradient(135deg,#18181b,#27272a)] text-zinc-50 shadow-[0_14px_34px_rgba(24,24,27,0.18)]"
+              : "w-full max-w-full rounded-tl-md border border-zinc-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(244,244,245,0.9))] text-foreground shadow-[0_16px_40px_rgba(24,24,27,0.06)] dark:border-zinc-800 dark:bg-[linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.9))]",
+            isStreaming &&
+              "ring-1 ring-amber-300/70 shadow-[0_16px_46px_rgba(245,158,11,0.12)] dark:ring-amber-700/60",
           )}
         >
           <div
@@ -376,14 +376,20 @@ export function MessageBubble({
             >
               {content}
             </ReactMarkdown>
+            {isStreaming ? (
+              <div className="mt-3 flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-amber-600 dark:text-amber-300">
+                <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-current" />
+                <span>Streaming</span>
+              </div>
+            ) : null}
           </div>
         </div>
 
         {/* 元信息栏：显示作者和时间戳 */}
-        {!isUser && (message.author || message.timestamp) && (
-          <div className="flex items-center gap-2 mt-1.5 px-1">
+        {!isUser && (message.author || message.timestamp || isStreaming) && (
+          <div className="mt-2 flex items-center gap-2 px-1">
             {message.author && (
-              <span className="text-[10px] text-muted-foreground bg-muted/50 dark:bg-muted/30 px-1.5 py-0.5 rounded font-medium">
+              <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-semibold tracking-[0.14em] text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300">
                 {message.author}
               </span>
             )}
@@ -392,6 +398,11 @@ export function MessageBubble({
                 {formatTimestamp(message.timestamp)}
               </span>
             )}
+            {isStreaming ? (
+              <span className="text-[10px] font-medium text-amber-600 dark:text-amber-300">
+                实时生成中
+              </span>
+            ) : null}
           </div>
         )}
 

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { EventType } from "@ag-ui/core";
 import { JsonViewer } from "@/components/ui/JsonViewer";
 import { MessageBubble } from "@/components/ui/MessageBubble";
 import type { ChatMessage } from "@/types/common";
@@ -140,6 +141,11 @@ function TextNode({
         : undefined,
     timestamp: node.timestamp,
     runId: node.runId,
+    threadId: node.threadId,
+    streaming:
+      node.role !== "user" &&
+      node.sourceEventTypes.includes(EventType.TEXT_MESSAGE_CONTENT) &&
+      !node.sourceEventTypes.includes(EventType.TEXT_MESSAGE_END),
   };
 
   if (shouldRenderAsJson) {

--- a/apps/negentropy-ui/lib/adk.ts
+++ b/apps/negentropy-ui/lib/adk.ts
@@ -22,7 +22,10 @@ import {
   getEventDelta,
   getEventMessageId,
   getEventRole,
+  getEventRunId,
+  getEventThreadId,
 } from "@/types/agui";
+import { accumulateTextContent } from "@/utils/message";
 import type { AdkEventPayload } from "@/lib/adk/schema";
 export {
   adkEventPayloadSchema,
@@ -93,14 +96,6 @@ function createGeneratedMessageId(
 
 function messageShouldFlushAfterPayload(payload: AdkEventPayload): boolean {
   return hasToolCalls(payload) || hasToolResults(payload);
-}
-
-function appendTextDelta(existing: string, delta: string): string {
-  if (!existing) return delta;
-  if (!delta) return existing;
-  if (delta === existing || existing.endsWith(delta)) return existing;
-  if (delta.startsWith(existing)) return delta;
-  return `${existing}${delta}`;
 }
 
 function normalizeUiMessageRole(value: string | undefined): Message["role"] {
@@ -549,6 +544,8 @@ export function adkEventsToMessages(events: AdkEventPayload[]): Message[] {
         role: normalizeUiMessageRole(e.message?.role || e.author),
         content,
         createdAt: new Date((e.timestamp || Date.now() / 1000) * 1000),
+        threadId: e.threadId,
+        runId: e.runId,
       }),
     };
   });
@@ -576,6 +573,9 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
       role: string;
       content: string;
       createdAt: Date;
+      runId?: string;
+      threadId?: string;
+      streaming: boolean;
     }
   >();
 
@@ -608,6 +608,9 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
         getEventRole(event) || "assistant",
       content: "",
       createdAt,
+      runId: getEventRunId(event),
+      threadId: getEventThreadId(event),
+      streaming: true,
     };
 
     if (
@@ -618,7 +621,7 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
     }
 
     if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
-      existing.content = appendTextDelta(
+      existing.content = accumulateTextContent(
         existing.content,
         String(getEventDelta(event) || ""),
       );
@@ -626,6 +629,12 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
 
     if (createdAt.getTime() < existing.createdAt.getTime()) {
       existing.createdAt = createdAt;
+    }
+
+    existing.runId = existing.runId || getEventRunId(event);
+    existing.threadId = existing.threadId || getEventThreadId(event);
+    if (event.type === EventType.TEXT_MESSAGE_END) {
+      existing.streaming = false;
     }
 
     messageMap.set(messageId, existing);
@@ -646,6 +655,9 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
         role: normalizeUiMessageRole(message.role),
         content: message.content,
         createdAt: message.createdAt,
+        runId: message.runId,
+        threadId: message.threadId,
+        streaming: message.streaming,
       }),
     );
 }

--- a/apps/negentropy-ui/tests/helpers/agui.ts
+++ b/apps/negentropy-ui/tests/helpers/agui.ts
@@ -13,6 +13,8 @@ export function createTestMessage(input: {
   createdAt?: Date;
   author?: string;
   runId?: string;
+  threadId?: string;
+  streaming?: boolean;
 }): AgUiMessage {
   return createAgUiMessage({
     ...input,

--- a/apps/negentropy-ui/tests/unit/adk.test.ts
+++ b/apps/negentropy-ui/tests/unit/adk.test.ts
@@ -8,6 +8,7 @@ import {
   parseAdkEventPayload,
   safeParseAdkEventPayload,
 } from "../../lib/adk";
+import { getMessageStreaming, type AgUiEvent } from "../../types/agui";
 
 describe("adk event mapping", () => {
   it("maps text parts to AG-UI text events", () => {
@@ -110,6 +111,46 @@ describe("adk event mapping", () => {
     const messages = aguiEventsToMessages(events);
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toBe("你好");
+    expect(getMessageStreaming(messages[0])).toBe(false);
+  });
+
+  it("treats snapshot-style repeated content as one growing assistant message", () => {
+    const messages = aguiEventsToMessages([
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        role: "assistant",
+        timestamp: 1000,
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        delta: "Hel",
+        timestamp: 1001,
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        delta: "Hello",
+        timestamp: 1002,
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        timestamp: 1003,
+      },
+    ] as AgUiEvent[]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe("Hello");
   });
 
   it("flushes assistant text before tool calls and starts a new segment after tool results", () => {

--- a/apps/negentropy-ui/tests/unit/features/messaging/message-merge.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/messaging/message-merge.test.ts
@@ -151,4 +151,39 @@ describe("reconcileOptimisticMessages", () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("local-2");
   });
+
+  it("应该优先按 runId 和 threadId 回收被服务端确认的乐观消息", () => {
+    const base: AgUiMessage[] = [
+      createTestMessage({
+        id: "server-1",
+        role: "user",
+        content: "Hello",
+        createdAt: new Date("2026-03-07T10:00:02.000Z"),
+        runId: "run-1",
+        threadId: "thread-1",
+      }),
+    ];
+    const optimistic: AgUiMessage[] = [
+      createTestMessage({
+        id: "local-1",
+        role: "user",
+        content: "Hello",
+        createdAt: new Date("2026-03-07T10:00:01.000Z"),
+        runId: "run-1",
+        threadId: "thread-1",
+      }),
+      createTestMessage({
+        id: "local-2",
+        role: "user",
+        content: "Hello",
+        createdAt: new Date("2026-03-07T10:00:01.500Z"),
+        runId: "run-2",
+        threadId: "thread-1",
+      }),
+    ];
+
+    const result = reconcileOptimisticMessages(base, optimistic);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("local-2");
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -221,6 +221,89 @@ describe("buildConversationTree", () => {
     expect(tree.roots[0].children[1].payload.content).toBe("second");
   });
 
+  it("无 runId 的 fallback 用户消息不会错误挂到最近轮次", () => {
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-hi",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-hi",
+        messageId: "assistant-hi",
+        role: "assistant",
+        timestamp: 1001,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-hi",
+        messageId: "assistant-hi",
+        delta: "Hi",
+        timestamp: 1002,
+      }),
+    ];
+    const fallbackMessages: AgUiMessage[] = [
+      createTestMessage({
+        id: "local-hello",
+        role: "user",
+        content: "Hello",
+        createdAt: new Date(1003 * 1000),
+      }),
+    ];
+
+    const tree = buildConversationTree({ events, fallbackMessages });
+
+    expect(tree.roots).toHaveLength(2);
+    expect(tree.roots[0].type).toBe("turn");
+    expect(tree.roots[1].type).toBe("text");
+    expect(tree.roots[1].payload.content).toBe("Hello");
+  });
+
+  it("fallback assistant 快照命中已有事件节点时不重复新增 bubble", () => {
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-stream",
+        role: "assistant",
+        timestamp: 1001,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-stream",
+        delta: "Hello",
+        timestamp: 1002,
+      }),
+    ];
+    const fallbackMessages: AgUiMessage[] = [
+      createTestMessage({
+        id: "assistant-history",
+        role: "assistant",
+        content: "Hello",
+        createdAt: new Date(1002 * 1000),
+        runId: "run-1",
+        threadId: "thread-1",
+      }),
+    ];
+
+    const tree = buildConversationTree({ events, fallbackMessages });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].children.filter((child) => child.type === "text")).toHaveLength(1);
+  });
+
   it("将运行错误节点保留在主聊天区", () => {
     const events: AgUiEvent[] = [
       createTestEvent({

--- a/apps/negentropy-ui/types/agui.ts
+++ b/apps/negentropy-ui/types/agui.ts
@@ -25,6 +25,8 @@ export interface ExtendedMessageProps {
   createdAt?: Date;
   author?: string;
   runId?: string;
+  threadId?: string;
+  streaming?: boolean;
 }
 
 export type AgUiMessage = Message & ExtendedMessageProps;
@@ -291,6 +293,16 @@ export function getMessageRunId(message: Message): string | undefined {
   return typeof record.runId === "string" ? record.runId : undefined;
 }
 
+export function getMessageThreadId(message: Message): string | undefined {
+  const record = asAgUiMessage(message);
+  return typeof record.threadId === "string" ? record.threadId : undefined;
+}
+
+export function getMessageStreaming(message: Message): boolean | undefined {
+  const record = asAgUiMessage(message);
+  return typeof record.streaming === "boolean" ? record.streaming : undefined;
+}
+
 export function createAgUiMessage(input: {
   id: string;
   role: Message["role"];
@@ -298,6 +310,8 @@ export function createAgUiMessage(input: {
   createdAt?: Date;
   author?: string;
   runId?: string;
+  threadId?: string;
+  streaming?: boolean;
 }): AgUiMessage {
   return {
     id: input.id,
@@ -306,6 +320,8 @@ export function createAgUiMessage(input: {
     createdAt: input.createdAt,
     author: input.author,
     runId: input.runId,
+    threadId: input.threadId,
+    streaming: input.streaming,
   } as AgUiMessage;
 }
 

--- a/apps/negentropy-ui/types/common.ts
+++ b/apps/negentropy-ui/types/common.ts
@@ -96,6 +96,10 @@ export type ChatMessage = Pick<Message, "id" | "role"> & {
   timestamp?: number;
   /** 运行 ID，用于标识消息所属的轮次 */
   runId?: string;
+  /** 线程 ID，用于标识消息所属会话 */
+  threadId?: string;
+  /** 当前消息是否仍在流式生成中 */
+  streaming?: boolean;
   /** 关联的工具调用列表（内嵌显示在消息气泡中） */
   toolCalls?: ToolCallInfo[];
 };

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -15,12 +15,14 @@ import {
   getEventToolCallId,
   getMessageCreatedAt,
   getMessageRunId,
+  getMessageThreadId,
 } from "@/types/agui";
 import {
   buildNodeSummary,
   classifyNodeVisibility,
   isNodePayloadEmpty,
 } from "@/utils/conversation-summary";
+import { accumulateTextContent, normalizeMessageContent } from "@/utils/message";
 
 type MutableNode = ConversationNode;
 
@@ -264,27 +266,38 @@ function attachNode(
 function chooseParentMessageId(
   assistantByRun: Map<string, string>,
   runId: string,
+  messageId?: string,
+  messageNodeIndex?: Map<string, string>,
 ): string | null {
+  if (messageId && messageNodeIndex?.has(messageId)) {
+    return messageNodeIndex.get(messageId) || null;
+  }
   return assistantByRun.get(runId) || null;
 }
 
-function getLatestTurn(turns: Map<string, MutableNode>): MutableNode | null {
-  const values = [...turns.values()];
-  if (values.length === 0) {
-    return null;
+function findFallbackTurnByTimestamp(
+  turns: Map<string, MutableNode>,
+  timestamp: number,
+): MutableNode | null {
+  const orderedTurns = [...turns.values()].sort(
+    (a, b) => a.timeRange.start - b.timeRange.start,
+  );
+
+  const containingTurn = orderedTurns.find(
+    (turn) => timestamp >= turn.timeRange.start && timestamp <= turn.timeRange.end + 0.001,
+  );
+  if (containingTurn) {
+    return containingTurn;
   }
-  values.sort((a, b) => b.timeRange.start - a.timeRange.start);
-  return values[0] || null;
+
+  const futureTurn = orderedTurns.find((turn) => timestamp <= turn.timeRange.end + 0.001);
+  return futureTurn || null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null
     ? (value as Record<string, unknown>)
     : null;
-}
-
-function formatJson(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value, null, 2);
 }
 
 function getMessageTimestamp(message: Message): number {
@@ -344,9 +357,6 @@ function sortNodeChildren(node: MutableNode) {
   };
 
   node.children.sort((a, b) => {
-    if (a.type === "text" && b.type === "text" && a.role !== b.role) {
-      return a.role === "user" ? -1 : 1;
-    }
     const typeDiff = typeOrder[a.type] - typeOrder[b.type];
     if (typeDiff !== 0) {
       return typeDiff;
@@ -473,10 +483,7 @@ export function buildConversationTree(
           const delta =
             "delta" in normalizedEvent ? String(normalizedEvent.delta || "") : "";
           const existing = String(node.payload.content || "");
-          node.payload.content =
-            delta.length >= existing.length || existing.length === 0
-              ? delta
-              : `${existing}${delta}`;
+          node.payload.content = accumulateTextContent(existing, delta);
         }
         messageNodeIndex.set(messageId, node.id);
         if (node.role === "assistant") {
@@ -493,6 +500,8 @@ export function buildConversationTree(
         const parentMessageNodeId = chooseParentMessageId(
           assistantMessageByRun,
           runId,
+          messageId,
+          messageNodeIndex,
         );
         const parentId = parentMessageNodeId || turn.id;
         const node = upsertNode(nodeIndex, roots, turns, {
@@ -645,7 +654,12 @@ export function buildConversationTree(
             ? normalizedEvent.stepId
             : `step-${normalizeTimestamp(normalizedEvent.timestamp)}`;
         const baseParentId =
-          chooseParentMessageId(assistantMessageByRun, runId) || turn.id;
+          chooseParentMessageId(
+            assistantMessageByRun,
+            runId,
+            messageId,
+            messageNodeIndex,
+          ) || turn.id;
         const node = upsertNode(nodeIndex, roots, turns, {
           id: `step:${stepId}`,
           type: "step",
@@ -784,39 +798,68 @@ export function buildConversationTree(
       return;
     }
     const runId = getMessageRunId(message);
-    if (runId) {
+    const threadId = getMessageThreadId(message) || DEFAULT_THREAD_ID;
+    const timestamp = getMessageTimestamp(message);
+    const role = normalizeRole(message.role);
+    const content = normalizeMessageContent(message).trim();
+    const duplicateNode = [...nodeIndex.values()].find((node) => {
+      if (node.type !== "text" || node.role !== role) {
+        return false;
+      }
+      if (String(node.payload.content || "").trim() !== content) {
+        return false;
+      }
+      const existingRunId = node.runId || undefined;
+      const runMatches =
+        existingRunId === runId ||
+        !existingRunId ||
+        !runId;
+      if (!runMatches) {
+        return false;
+      }
+      if (node.threadId !== threadId) {
+        return false;
+      }
+      return Math.abs(node.timestamp - timestamp) <= 2;
+    });
+    if (duplicateNode) {
+      if (!duplicateNode.relatedMessageIds.includes(messageId)) {
+        duplicateNode.relatedMessageIds.push(messageId);
+      }
+      return;
+    }
+
+    let fallbackTurn =
+      (runId && turns.get(runId)) || findFallbackTurnByTimestamp(turns, timestamp);
+    if (runId && !fallbackTurn) {
       ensureTurn(
         turns,
         roots,
         asAgUiEvent({
           type: EventType.RUN_STARTED,
-          threadId: DEFAULT_THREAD_ID,
+          threadId,
           runId,
-          timestamp: getMessageTimestamp(message),
+          timestamp,
         }),
         undefined,
         orderedEvents.length + fallbackIndex,
       );
+      fallbackTurn = turns.get(runId) || null;
     }
-    const fallbackTurn = (runId && turns.get(runId)) || getLatestTurn(turns);
     const parentId = fallbackTurn?.id ?? null;
-    const role = normalizeRole(message.role);
     const node = upsertNode(nodeIndex, roots, turns, {
       id: `message:${messageId}`,
       type: "text",
       parentId,
-      threadId: DEFAULT_THREAD_ID,
+      threadId,
       runId: fallbackTurn?.runId || runId,
       messageId,
-      timestamp: getMessageTimestamp(message),
+      timestamp,
       sourceOrder: orderedEvents.length + fallbackIndex,
       title: role === "user" ? "用户消息" : "助手消息",
       role,
       payload: {
-        content:
-          typeof message.content === "string"
-            ? message.content
-            : formatJson(message.content),
+        content,
       },
       sourceEventTypes: ["fallback.message"],
       relatedMessageIds: [messageId],

--- a/apps/negentropy-ui/utils/message-merge.ts
+++ b/apps/negentropy-ui/utils/message-merge.ts
@@ -6,8 +6,17 @@
  */
 
 import type { Message } from "@ag-ui/core";
-import { getMessageCreatedAt, type AgUiMessage } from "@/types/agui";
-import { normalizeMessageContent } from "./message";
+import {
+  getMessageCreatedAt,
+  getMessageRunId,
+  getMessageThreadId,
+  type AgUiMessage,
+} from "@/types/agui";
+import {
+  getMessageIdentityKey,
+  getMessageTimestampMs,
+  normalizeMessageContent,
+} from "./message";
 
 /**
  * 合并乐观消息到基础消息列表
@@ -31,47 +40,30 @@ export function mergeOptimisticMessages(
   messagesForRenderBase: Message[],
   optimisticMessages: Message[],
 ): Message[] {
-  // 收集已知消息 ID（仅包含有内容的消息）
-  const knownIds = new Set(
-    messagesForRenderBase
-      .filter((message) => normalizeMessageContent(message).trim().length > 0)
-      .map((message) => message.id),
-  );
+  const merged = new Map<string, Message>();
 
-  // 过滤掉已在基础消息中的乐观消息
-  const validOptimistic = optimisticMessages.filter(
-    (message) => !knownIds.has(message.id),
-  );
-
-  // 没有有效的乐观消息，直接返回基础消息
-  if (validOptimistic.length === 0) {
-    return messagesForRenderBase;
-  }
-
-  // 开始合并
-  const merged = [...messagesForRenderBase];
-  const indexById = new Map<string, number>();
-  merged.forEach((message, index) => {
-    indexById.set(message.id, index);
-  });
-
-  // 处理每个有效的乐观消息
-  validOptimistic.forEach((message) => {
-    const index = indexById.get(message.id);
-    // 消息不存在，直接添加
-    if (index === undefined) {
-      merged.push(message);
-      indexById.set(message.id, merged.length - 1);
+  [...messagesForRenderBase, ...optimisticMessages].forEach((message) => {
+    const key = getMessageIdentityKey(message);
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, message);
       return;
     }
-    // 消息已存在，进行内容合并
-    const existing = merged[index];
-    if (!existing.content && message.content) {
-      merged[index] = message;
+
+    const existingContent = normalizeMessageContent(existing);
+    const incomingContent = normalizeMessageContent(message);
+    if (incomingContent.length >= existingContent.length) {
+      merged.set(key, message);
     }
   });
 
-  return merged;
+  return [...merged.values()].sort((a, b) => {
+    const timeDiff = getMessageTimestampMs(a) - getMessageTimestampMs(b);
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    return getMessageIdentityKey(a).localeCompare(getMessageIdentityKey(b));
+  });
 }
 
 export function reconcileOptimisticMessages(
@@ -121,10 +113,19 @@ export function reconcileOptimisticMessages(
 
     const optimisticTime =
       getMessageCreatedAt(optimisticMessage)?.getTime() || Date.now();
+    const optimisticThreadId = getMessageThreadId(optimisticMessage);
     const canonicalIndex = bucket.findIndex((candidate) => {
       const candidateTime =
         getMessageCreatedAt(candidate)?.getTime() || optimisticTime;
-      return candidateTime >= optimisticTime - 2000;
+      const sameThreadId =
+        !optimisticThreadId ||
+        !getMessageThreadId(candidate) ||
+        getMessageThreadId(candidate) === optimisticThreadId;
+      return (
+        sameThreadId &&
+        candidateTime >= optimisticTime - 2000 &&
+        candidateTime <= optimisticTime + 10000
+      );
     });
 
     if (canonicalIndex === -1) {

--- a/apps/negentropy-ui/utils/message.ts
+++ b/apps/negentropy-ui/utils/message.ts
@@ -18,6 +18,8 @@ import {
   getMessageAuthor,
   getMessageCreatedAt,
   getMessageRunId,
+  getMessageStreaming,
+  getMessageThreadId,
   type AgUiMessage,
 } from "@/types/agui";
 
@@ -50,6 +52,54 @@ export function normalizeMessageContent(message: Message): string {
   return message.content ? JSON.stringify(message.content) : "";
 }
 
+function findOverlapSuffixPrefix(existing: string, incoming: string): number {
+  const maxOverlap = Math.min(existing.length, incoming.length);
+  for (let size = maxOverlap; size > 0; size -= 1) {
+    if (existing.slice(-size) === incoming.slice(0, size)) {
+      return size;
+    }
+  }
+  return 0;
+}
+
+export function accumulateTextContent(existing: string, incoming: string): string {
+  if (!incoming) {
+    return existing;
+  }
+  if (!existing) {
+    return incoming;
+  }
+  if (incoming === existing || existing.endsWith(incoming)) {
+    return existing;
+  }
+  if (incoming.startsWith(existing)) {
+    return incoming;
+  }
+  if (existing.startsWith(incoming)) {
+    return existing;
+  }
+
+  const overlap = findOverlapSuffixPrefix(existing, incoming);
+  if (overlap > 0) {
+    return `${existing}${incoming.slice(overlap)}`;
+  }
+  return `${existing}${incoming}`;
+}
+
+export function getMessageTimestampMs(message: Message): number {
+  return getMessageCreatedAt(message)?.getTime() || Number.MAX_SAFE_INTEGER;
+}
+
+export function getMessageIdentityKey(message: Message): string {
+  const threadId = getMessageThreadId(message) || "default-thread";
+  const runId = getMessageRunId(message) || "default-run";
+  return `${threadId}|${runId}|${message.id}`;
+}
+
+export function isMessageStreaming(message: Message): boolean {
+  return getMessageStreaming(message) === true;
+}
+
 /**
  * 将消息数组映射为聊天消息格式
  * @param messages 原始消息数组
@@ -78,6 +128,8 @@ export function mapMessagesToChat(messages: Message[]): ChatMessage[] {
     const createdAt = getMessageCreatedAt(message);
     const timestamp = createdAt ? createdAt.getTime() / 1000 : undefined;
     const runId = getMessageRunId(message);
+    const threadId = getMessageThreadId(message);
+    const streaming = getMessageStreaming(message);
 
     // 4. 添加到结果
     chatMessages.push({
@@ -87,6 +139,8 @@ export function mapMessagesToChat(messages: Message[]): ChatMessage[] {
       author,
       timestamp,
       runId,
+      threadId,
+      streaming,
     });
   });
   return chatMessages;

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -23,6 +23,7 @@ import {
   getMessageCreatedAt,
   type AgUiMessage,
 } from "@/types/agui";
+import { getMessageIdentityKey, normalizeMessageContent } from "@/utils/message";
 
 export type HydratedSessionDetail = {
   events: BaseEvent[];
@@ -143,23 +144,25 @@ export function mergeMessages(baseMessages: Message[], incomingMessages: Message
 
   [...baseMessages, ...incomingMessages].forEach((message) => {
     const timedMessage = message as AgUiMessage;
-    const existing = merged.get(message.id);
+    const key = getMessageIdentityKey(message);
+    const existing = merged.get(key);
     if (!existing) {
-      merged.set(message.id, timedMessage);
+      merged.set(key, timedMessage);
       return;
     }
 
-    const existingContent =
-      typeof existing.content === "string"
-        ? existing.content
-        : JSON.stringify(existing.content);
-    const incomingContent =
-      typeof message.content === "string"
-        ? message.content
-        : JSON.stringify(message.content);
+    const existingContent = normalizeMessageContent(existing);
+    const incomingContent = normalizeMessageContent(message);
+    const existingStreaming = existing.streaming === true;
+    const incomingStreaming = timedMessage.streaming === true;
 
-    if (incomingContent.length >= existingContent.length) {
-      merged.set(message.id, { ...existing, ...timedMessage } as AgUiMessage);
+    if (
+      incomingContent.length > existingContent.length ||
+      (incomingContent.length === existingContent.length &&
+        existingStreaming &&
+        !incomingStreaming)
+    ) {
+      merged.set(key, { ...existing, ...timedMessage } as AgUiMessage);
     }
   });
 


### PR DESCRIPTION
## 变更摘要

本 PR 修复了 `negentropy-ui` 聊天主链路中的一组 A2UI/AG-UI 交互问题，重点解决以下异常：

- 在已有历史对话时，新输入的用户消息会插到旧消息前面，导致时序错误
- 消息在 optimistic、实时事件流、session 回拉之间发生节点漂移，位置不稳定
- assistant 回复不能以单一 bubble 正常流式增长，最终会重复显示为两个内容相同的 bubble
- Chat 区的层次与流式反馈不足，影响阅读连续性与交互质感

## 做了什么

### 1. 修复消息身份与归并逻辑

- 为前端消息补充 `threadId`、`runId`、`streaming` 等扩展元数据
- 统一 optimistic message、实时 SSE 事件、session hydration 三类来源的消息身份与排序依据
- 调整消息合并与回收策略，避免仅靠内容长度或随机 ID 导致重复和错位

### 2. 修复 A2UI 对话树构建与流式文本聚合

- 重写 fallback message 的挂载规则，优先按时间锚点和已有 turn 归属，而不是简单挂到“最近轮次”
- 修复文本内容聚合逻辑，兼容 delta / snapshot 风格的上游消息片段，保证拼接幂等
- 强化 assistant/tool/result 节点的父子关系推断，避免消息在不同阶段跳到错误节点
- 让 assistant 在流式阶段持续更新同一个 bubble，结束后不再生成重复 bubble

### 3. 优化聊天体验与视觉反馈

- 增强 assistant bubble 的流式生成态表现
- 调整消息卡片的层次、边框、阴影和背景氛围，保留现有布局结构下做中度焕新
- 保持技术节点与正文消息的信息分层，减少噪音对主对话流的干扰

### 4. 补充关键回归测试

补充并更新了以下测试覆盖：

- `conversation-tree`：fallback 挂载、顺序稳定性、重复节点去重
- `message-merge`：optimistic message 与服务端确认回收
- `adk`：assistant 流式文本聚合与单 bubble 行为
- `home-flow`：历史回拉不清空实时消息、连续发送顺序稳定、用户消息不重复

## 为什么要这样改

这次改动直接对应 Chat 主链路中的真实交互问题：用户消息时序错误、消息节点漂移、assistant 流式显示异常和最终重复渲染。这些问题本质上都来自“多来源消息状态缺乏统一读模型”，即 optimistic UI、实时事件流和历史回拉之间没有共享同一套稳定身份与归并规则。

因此，本次修复采用了更稳健的前端建模方式：

- 将事件流视为事实源，A2UI 树作为派生读模型
- 用显式身份和时间锚点做消息归并，而不是依赖脆弱的内容猜测
- 用统一 reconciliation 机制处理 optimistic 与服务端确认之间的收敛

这能在不改动后端接口契约的前提下，稳定修复聊天时序和流式交互问题，并降低后续继续演进 A2UI 渲染层的熵增风险。

## 关键实现细节

- 未修改后端 API 契约，变更主要位于 `negentropy-ui` 前端归并、建树与渲染层
- `page.tsx` 中增加了 hydration 请求保护，避免旧请求覆盖当前会话状态
- `conversation-tree` 中收紧了 fallback message 归属规则与去重逻辑
- `adk` / `session-hydration` / `message-merge` 复用了统一的文本聚合与消息归并语义
- UI 层新增 streaming 状态透传与单 bubble 流式反馈，避免“生成中”和“最终结果”分裂成两个节点

## 验证结果

已通过前端测试命令：

```bash
pnpm --dir apps/negentropy-ui test
```

结果：`39` 个测试文件、`210` 个测试全部通过。
