### PR TITLE
refactor(session): 抽取会话代理路径构造助手;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/archive/route.ts
@@ -1,6 +1,7 @@
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
+  buildSessionArchiveUpstreamUrl,
   buildSessionUpstreamHeaders,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
@@ -39,12 +40,11 @@ export async function POST(
   }
 
   const { sessionId } = await params;
-  const upstreamUrl = new URL(
-    `/apps/${encodeURIComponent(body.app_name)}/users/${encodeURIComponent(
-      body.user_id
-    )}/sessions/${encodeURIComponent(sessionId)}/archive`,
-    baseUrl
-  );
+  const upstreamUrl = buildSessionArchiveUpstreamUrl(baseUrl, {
+    appName: body.app_name,
+    userId: body.user_id,
+    sessionId,
+  });
 
   let upstreamResponse: Response;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { safeParseSessionDetailResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
+  buildSessionDetailUpstreamUrl,
   buildSessionUpstreamHeaders,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
@@ -31,12 +32,11 @@ export async function GET(
     );
   }
 
-  const upstreamUrl = new URL(
-    `/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(
-      sessionId
-    )}`,
-    baseUrl
-  );
+  const upstreamUrl = buildSessionDetailUpstreamUrl(baseUrl, {
+    appName,
+    userId,
+    sessionId,
+  });
 
   let upstreamResponse: Response;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/title/route.ts
@@ -1,6 +1,7 @@
 import { safeParseSessionTitleResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
+  buildSessionTitleUpstreamUrl,
   buildSessionUpstreamHeaders,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
@@ -40,12 +41,11 @@ export async function PATCH(
   }
 
   const { sessionId } = await params;
-  const upstreamUrl = new URL(
-    `/apps/${encodeURIComponent(body.app_name)}/users/${encodeURIComponent(
-      body.user_id
-    )}/sessions/${encodeURIComponent(sessionId)}/title`,
-    baseUrl
-  );
+  const upstreamUrl = buildSessionTitleUpstreamUrl(baseUrl, {
+    appName: body.app_name,
+    userId: body.user_id,
+    sessionId,
+  });
 
   let upstreamResponse: Response;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/[sessionId]/unarchive/route.ts
@@ -1,6 +1,7 @@
 import { safeParseSessionArchiveResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
+  buildSessionUnarchiveUpstreamUrl,
   buildSessionUpstreamHeaders,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
@@ -39,12 +40,11 @@ export async function POST(
   }
 
   const { sessionId } = await params;
-  const upstreamUrl = new URL(
-    `/apps/${encodeURIComponent(body.app_name)}/users/${encodeURIComponent(
-      body.user_id
-    )}/sessions/${encodeURIComponent(sessionId)}/unarchive`,
-    baseUrl
-  );
+  const upstreamUrl = buildSessionUnarchiveUpstreamUrl(baseUrl, {
+    appName: body.app_name,
+    userId: body.user_id,
+    sessionId,
+  });
 
   let upstreamResponse: Response;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/_request.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/_request.ts
@@ -29,3 +29,44 @@ export function buildSessionUpstreamHeaders(
 
   return headers;
 }
+
+interface SessionScope {
+  appName: string;
+  userId: string;
+}
+
+interface SessionTarget extends SessionScope {
+  sessionId: string;
+}
+
+function buildSessionCollectionPath({ appName, userId }: SessionScope): string {
+  return `/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions`;
+}
+
+function buildSessionItemPath({ appName, userId, sessionId }: SessionTarget): string {
+  return `${buildSessionCollectionPath({ appName, userId })}/${encodeURIComponent(sessionId)}`;
+}
+
+export function buildSessionListUpstreamUrl(baseUrl: string, scope: SessionScope): URL {
+  return new URL(buildSessionCollectionPath(scope), baseUrl);
+}
+
+export function buildSessionCreateUpstreamUrl(baseUrl: string, scope: SessionScope): URL {
+  return new URL(buildSessionCollectionPath(scope), baseUrl);
+}
+
+export function buildSessionDetailUpstreamUrl(baseUrl: string, target: SessionTarget): URL {
+  return new URL(buildSessionItemPath(target), baseUrl);
+}
+
+export function buildSessionArchiveUpstreamUrl(baseUrl: string, target: SessionTarget): URL {
+  return new URL(`${buildSessionItemPath(target)}/archive`, baseUrl);
+}
+
+export function buildSessionTitleUpstreamUrl(baseUrl: string, target: SessionTarget): URL {
+  return new URL(`${buildSessionItemPath(target)}/title`, baseUrl);
+}
+
+export function buildSessionUnarchiveUpstreamUrl(baseUrl: string, target: SessionTarget): URL {
+  return new URL(`${buildSessionItemPath(target)}/unarchive`, baseUrl);
+}

--- a/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/list/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { safeParseSessionListResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
+  buildSessionListUpstreamUrl,
   buildSessionUpstreamHeaders,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
@@ -25,10 +26,10 @@ export async function GET(request: Request) {
     return aguiErrorResponse(AGUI_ERROR_CODES.BAD_REQUEST, "app_name and user_id are required");
   }
 
-  const upstreamUrl = new URL(
-    `/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions`,
-    baseUrl
-  );
+  const upstreamUrl = buildSessionListUpstreamUrl(baseUrl, {
+    appName,
+    userId,
+  });
 
   let upstreamResponse: Response;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/route.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { safeParseCreateSessionResponse } from "@/lib/agui/session-schema";
 import { parseSessionUpstreamJson } from "@/app/api/agui/sessions/_response";
 import {
+  buildSessionCreateUpstreamUrl,
   buildSessionUpstreamHeaders,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
@@ -33,10 +34,10 @@ export async function POST(request: Request) {
     return aguiErrorResponse(AGUI_ERROR_CODES.BAD_REQUEST, "app_name and user_id are required");
   }
 
-  const upstreamUrl = new URL(
-    `/apps/${encodeURIComponent(body.app_name)}/users/${encodeURIComponent(body.user_id)}/sessions`,
-    baseUrl
-  );
+  const upstreamUrl = buildSessionCreateUpstreamUrl(baseUrl, {
+    appName: body.app_name,
+    userId: body.user_id,
+  });
 
   const payload = {
     session_id: body.session_id,

--- a/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildSessionArchiveUpstreamUrl,
+  buildSessionCreateUpstreamUrl,
+  buildSessionDetailUpstreamUrl,
+  buildSessionListUpstreamUrl,
+  buildSessionTitleUpstreamUrl,
   buildSessionUpstreamHeaders,
+  buildSessionUnarchiveUpstreamUrl,
   getSessionAguiBaseUrl,
 } from "@/app/api/agui/sessions/_request";
 
@@ -62,5 +68,43 @@ describe("session request helpers", () => {
     expect(headers.get("authorization")).toBe("Bearer token");
     expect(headers.get("content-type")).toBe("application/json");
     expect(headers.get("accept")).toBeNull();
+  });
+
+  it("应构造 collection 级 session upstream URL", () => {
+    const baseUrl = "http://internal-agui/";
+    expect(
+      buildSessionListUpstreamUrl(baseUrl, {
+        appName: "negentropy app",
+        userId: "user/1",
+      }).toString(),
+    ).toBe("http://internal-agui/apps/negentropy%20app/users/user%2F1/sessions");
+    expect(
+      buildSessionCreateUpstreamUrl("http://internal-agui", {
+        appName: "negentropy app",
+        userId: "user/1",
+      }).toString(),
+    ).toBe("http://internal-agui/apps/negentropy%20app/users/user%2F1/sessions");
+  });
+
+  it("应构造 item 级 session upstream URL 及动作变体", () => {
+    const baseUrl = "http://internal-agui/";
+    const target = {
+      appName: "negentropy app",
+      userId: "user/1",
+      sessionId: "session a/b",
+    };
+
+    expect(buildSessionDetailUpstreamUrl(baseUrl, target).toString()).toBe(
+      "http://internal-agui/apps/negentropy%20app/users/user%2F1/sessions/session%20a%2Fb",
+    );
+    expect(buildSessionArchiveUpstreamUrl(baseUrl, target).toString()).toBe(
+      "http://internal-agui/apps/negentropy%20app/users/user%2F1/sessions/session%20a%2Fb/archive",
+    );
+    expect(buildSessionTitleUpstreamUrl(baseUrl, target).toString()).toBe(
+      "http://internal-agui/apps/negentropy%20app/users/user%2F1/sessions/session%20a%2Fb/title",
+    );
+    expect(buildSessionUnarchiveUpstreamUrl(baseUrl, target).toString()).toBe(
+      "http://internal-agui/apps/negentropy%20app/users/user%2F1/sessions/session%20a%2Fb/unarchive",
+    );
   });
 });


### PR DESCRIPTION
## 背景
- 前一轮已经把 session BFF 的 response helper 和 request 上下文 helper 收口到私有边界，但 upstream URL path 仍散落在多条 session route 里手写拼接。
- 这些路径规则都属于同一个 session 代理边界，继续保留在 route 内部会让 URL 编码、路径演进和新增端点实现发生偏差。
- 本 PR 继续沿用 session 私有 helper 模式，把 upstream URL path builder 下沉到 `app/api/agui/sessions` 内部，不跨越到其他 proxy 体系。

## 核心变更
- 在 session 私有 request helper 中新增 upstream URL builder，统一构造：
  - session list / create
  - session detail
  - session archive
  - session title
  - session unarchive
- builder 统一负责 path 模板、`encodeURIComponent` 和 `new URL(path, baseUrl)` 拼装。
- `sessions/list`、`sessions/[id]`、`sessions`、`archive`、`title`、`unarchive` 六条 route 全部改为复用该 builder，不再手写 path 模板。
- 新增 URL builder 单元测试，覆盖：
  - collection 级与 item 级路径输出
  - `appName`、`userId`、`sessionId` 的特殊字符编码
  - `baseUrl` 带或不带尾斜杠时输出一致

## 变更原因
- 目标是继续压低 session BFF 层的实现偏差，把同一边界内重复出现的路径语义收敛为单一事实源。
- 这样后续继续新增或维护 session 端点时，路径模板、编码规则和 route 间一致性不会再在多处独立漂移。

## 重要实现细节
- builder 只负责 upstream URL path 构造，不接管 query/body 校验、fetch、header 组装或 response parse，避免抽象膨胀。
- list 与 create 继续共享同一路径模板，但在 helper 层保留语义化导出，保证调用点意图清晰。
- 本次不修改 public API、不改变页面行为、session DTO 或任何 archived/session hydration 语义。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/unit/api/agui-session-request.test.ts tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 本地结果：39 个测试文件、208 个测试全部通过
- GitHub Actions：
  - `UI Test Suite` pull_request run `22797309279` 成功
  - `UI Test Suite` push run `22797304838` 成功

## Next Best Action
- 如果继续收口 session BFF，可以把 query/body 参数读取后的 request DTO 归一化也抽到同边界 helper，但应继续保持最小干预，只处理 session 路由内部真实重复的输入整形逻辑。
