### PR TITLE
test(knowledge): 收敛 hooks 到 knowledge-api util harness;

### DIFF
--- a/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeSearch.ts
+++ b/apps/negentropy-ui/features/knowledge/hooks/useKnowledgeSearch.ts
@@ -17,7 +17,7 @@ import {
   SearchConfig,
   searchKnowledge,
   KnowledgeError,
-} from "../index";
+} from "../utils/knowledge-api";
 
 // ============================================================================
 // Types

--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -1,0 +1,89 @@
+import {
+  buildCorpusConfig,
+  buildExtractorRoutesFromDraft,
+  createDefaultChunkingConfig,
+  createEmptyExtractorDraftTarget,
+  normalizeChunkingConfig,
+  normalizeCorpusExtractorRoutes,
+  normalizeExtractorDraftRoutes,
+} from "@/features/knowledge/utils/knowledge-api";
+
+export interface KnowledgeApiMockSet {
+  fetchCorpusMock: ReturnType<typeof vi.fn>;
+  fetchCorporaMock: ReturnType<typeof vi.fn>;
+  createCorpusMock: ReturnType<typeof vi.fn>;
+  updateCorpusMock: ReturnType<typeof vi.fn>;
+  deleteCorpusMock: ReturnType<typeof vi.fn>;
+  ingestTextMock: ReturnType<typeof vi.fn>;
+  ingestUrlMock: ReturnType<typeof vi.fn>;
+  ingestFileMock: ReturnType<typeof vi.fn>;
+  replaceSourceMock: ReturnType<typeof vi.fn>;
+  syncSourceMock: ReturnType<typeof vi.fn>;
+  rebuildSourceMock: ReturnType<typeof vi.fn>;
+  deleteSourceMock: ReturnType<typeof vi.fn>;
+  archiveSourceMock: ReturnType<typeof vi.fn>;
+  searchKnowledgeMock: ReturnType<typeof vi.fn>;
+}
+
+export interface KnowledgeApiTestHarness {
+  exports: Record<string, unknown>;
+  mocks: KnowledgeApiMockSet;
+}
+
+export function createKnowledgeApiMockSet(): KnowledgeApiMockSet {
+  return {
+    fetchCorpusMock: vi.fn(),
+    fetchCorporaMock: vi.fn(),
+    createCorpusMock: vi.fn(),
+    updateCorpusMock: vi.fn(),
+    deleteCorpusMock: vi.fn(),
+    ingestTextMock: vi.fn(),
+    ingestUrlMock: vi.fn(),
+    ingestFileMock: vi.fn(),
+    replaceSourceMock: vi.fn(),
+    syncSourceMock: vi.fn(),
+    rebuildSourceMock: vi.fn(),
+    deleteSourceMock: vi.fn(),
+    archiveSourceMock: vi.fn(),
+    searchKnowledgeMock: vi.fn(),
+  };
+}
+
+export function createKnowledgeApiConfigTestExports() {
+  return {
+    createDefaultChunkingConfig,
+    normalizeChunkingConfig,
+    normalizeCorpusExtractorRoutes,
+    createEmptyExtractorDraftTarget,
+    normalizeExtractorDraftRoutes,
+    buildExtractorRoutesFromDraft,
+    buildCorpusConfig,
+  };
+}
+
+export function createKnowledgeApiTestHarness(
+  mocks: KnowledgeApiMockSet,
+  overrides: Record<string, unknown> = {},
+): KnowledgeApiTestHarness {
+  return {
+    mocks,
+    exports: {
+      fetchCorpus: (...args: unknown[]) => mocks.fetchCorpusMock(...args),
+      fetchCorpora: (...args: unknown[]) => mocks.fetchCorporaMock(...args),
+      createCorpus: (...args: unknown[]) => mocks.createCorpusMock(...args),
+      updateCorpus: (...args: unknown[]) => mocks.updateCorpusMock(...args),
+      deleteCorpus: (...args: unknown[]) => mocks.deleteCorpusMock(...args),
+      ingestText: (...args: unknown[]) => mocks.ingestTextMock(...args),
+      ingestUrl: (...args: unknown[]) => mocks.ingestUrlMock(...args),
+      ingestFile: (...args: unknown[]) => mocks.ingestFileMock(...args),
+      replaceSource: (...args: unknown[]) => mocks.replaceSourceMock(...args),
+      syncSource: (...args: unknown[]) => mocks.syncSourceMock(...args),
+      rebuildSource: (...args: unknown[]) => mocks.rebuildSourceMock(...args),
+      deleteSource: (...args: unknown[]) => mocks.deleteSourceMock(...args),
+      archiveSource: (...args: unknown[]) => mocks.archiveSourceMock(...args),
+      searchKnowledge: (...args: unknown[]) => mocks.searchKnowledgeMock(...args),
+      ...createKnowledgeApiConfigTestExports(),
+      ...overrides,
+    },
+  };
+}

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
@@ -1,0 +1,39 @@
+import {
+  buildCorpusConfig,
+  createDefaultChunkingConfig,
+} from "@/features/knowledge/utils/knowledge-api";
+import {
+  createKnowledgeApiMockSet,
+  createKnowledgeApiTestHarness,
+} from "@/tests/helpers/knowledge-api";
+
+describe("knowledge api test harness", () => {
+  it("默认复用真实配置 helper，并把 exports 与 mocks 绑定到同一组函数", () => {
+    const mocks = createKnowledgeApiMockSet();
+    const harness = createKnowledgeApiTestHarness(mocks);
+
+    expect(harness.exports.createDefaultChunkingConfig).toBe(
+      createDefaultChunkingConfig,
+    );
+    expect(harness.exports.buildCorpusConfig).toBe(buildCorpusConfig);
+
+    const fetchCorpus = harness.exports.fetchCorpus as (...args: unknown[]) => unknown;
+    fetchCorpus("corpus-1", "negentropy");
+
+    expect(mocks.fetchCorpusMock).toHaveBeenCalledWith("corpus-1", "negentropy");
+  });
+
+  it("允许局部 override，而不会污染真实 helper 导出", () => {
+    const mocks = createKnowledgeApiMockSet();
+    const overrideSearchKnowledge = vi.fn();
+    const harness = createKnowledgeApiTestHarness(mocks, {
+      searchKnowledge: overrideSearchKnowledge,
+    });
+
+    expect(harness.exports.searchKnowledge).toBe(overrideSearchKnowledge);
+    expect(harness.exports.normalizeChunkingConfig).toBeDefined();
+    expect(harness.exports.createDefaultChunkingConfig).toBe(
+      createDefaultChunkingConfig,
+    );
+  });
+});

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
@@ -1,41 +1,34 @@
 import { renderHook } from "@testing-library/react";
 
-const { fetchCorpusMock, fetchCorporaMock } = vi.hoisted(() => ({
+const knowledgeApiMocks = vi.hoisted(() => ({
   fetchCorpusMock: vi.fn(),
   fetchCorporaMock: vi.fn(),
+  createCorpusMock: vi.fn(),
+  updateCorpusMock: vi.fn(),
+  deleteCorpusMock: vi.fn(),
+  ingestTextMock: vi.fn(),
+  ingestUrlMock: vi.fn(),
+  ingestFileMock: vi.fn(),
+  replaceSourceMock: vi.fn(),
+  syncSourceMock: vi.fn(),
+  rebuildSourceMock: vi.fn(),
+  deleteSourceMock: vi.fn(),
+  archiveSourceMock: vi.fn(),
+  searchKnowledgeMock: vi.fn(),
 }));
 
 vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
-  const actual = await vi.importActual<typeof import("@/features/knowledge/utils/knowledge-api")>(
-    "@/features/knowledge/utils/knowledge-api",
-  );
-
-  return {
-    ...actual,
-    fetchCorpus: (...args: unknown[]) => fetchCorpusMock(...args),
-    fetchCorpora: (...args: unknown[]) => fetchCorporaMock(...args),
-    createCorpus: vi.fn(),
-    updateCorpus: vi.fn(),
-    deleteCorpus: vi.fn(),
-    ingestText: vi.fn(),
-    ingestUrl: vi.fn(),
-    ingestFile: vi.fn(),
-    replaceSource: vi.fn(),
-    syncSource: vi.fn(),
-    rebuildSource: vi.fn(),
-    deleteSource: vi.fn(),
-    archiveSource: vi.fn(),
-    searchKnowledge: vi.fn(),
-  };
+  const { createKnowledgeApiTestHarness } = await import("@/tests/helpers/knowledge-api");
+  return createKnowledgeApiTestHarness(knowledgeApiMocks).exports;
 });
 
 import { useKnowledgeBase } from "@/features/knowledge/hooks/useKnowledgeBase";
 
 describe("useKnowledgeBase", () => {
   beforeEach(() => {
-    fetchCorpusMock.mockReset();
-    fetchCorporaMock.mockReset();
-    fetchCorporaMock.mockResolvedValue([]);
+    knowledgeApiMocks.fetchCorpusMock.mockReset();
+    knowledgeApiMocks.fetchCorporaMock.mockReset();
+    knowledgeApiMocks.fetchCorporaMock.mockResolvedValue([]);
   });
 
   it("在相同输入下保持返回对象和 loadCorpus 引用稳定", () => {
@@ -53,5 +46,30 @@ describe("useKnowledgeBase", () => {
 
     expect(result.current).toBe(initialValue);
     expect(result.current.loadCorpus).toBe(initialLoadCorpus);
+  });
+
+  it("loadCorpora 成功时会刷新 corpora 列表并恢复 loading 状态", async () => {
+    knowledgeApiMocks.fetchCorporaMock.mockResolvedValueOnce([
+      {
+        id: "corpus-1",
+        app_name: "negentropy",
+        name: "Corpus One",
+        knowledge_count: 2,
+      },
+    ]);
+
+    const { result } = renderHook(() => useKnowledgeBase({ appName: "negentropy" }));
+
+    await result.current.loadCorpora();
+
+    expect(knowledgeApiMocks.fetchCorporaMock).toHaveBeenCalledWith("negentropy");
+    expect(result.current.corpora).toEqual([
+      expect.objectContaining({
+        id: "corpus-1",
+        name: "Corpus One",
+      }),
+    ]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
@@ -1,20 +1,32 @@
 import { renderHook, act } from "@testing-library/react";
-import { vi } from "vitest";
+
+const knowledgeApiMocks = vi.hoisted(() => ({
+  fetchCorpusMock: vi.fn(),
+  fetchCorporaMock: vi.fn(),
+  createCorpusMock: vi.fn(),
+  updateCorpusMock: vi.fn(),
+  deleteCorpusMock: vi.fn(),
+  ingestTextMock: vi.fn(),
+  ingestUrlMock: vi.fn(),
+  ingestFileMock: vi.fn(),
+  replaceSourceMock: vi.fn(),
+  syncSourceMock: vi.fn(),
+  rebuildSourceMock: vi.fn(),
+  deleteSourceMock: vi.fn(),
+  archiveSourceMock: vi.fn(),
+  searchKnowledgeMock: vi.fn(),
+}));
 
 vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
-  const actual = await vi.importActual<object>("@/features/knowledge/utils/knowledge-api");
-  return {
-    ...actual,
-    searchKnowledge: vi.fn(),
-  };
+  const { createKnowledgeApiTestHarness } = await import("@/tests/helpers/knowledge-api");
+  return createKnowledgeApiTestHarness(knowledgeApiMocks).exports;
 });
 
 import { useKnowledgeSearch } from "@/features/knowledge/hooks/useKnowledgeSearch";
-import { searchKnowledge } from "@/features/knowledge/utils/knowledge-api";
 
 describe("useKnowledgeSearch", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    knowledgeApiMocks.searchKnowledgeMock.mockReset();
   });
 
   it("空查询会直接返回空结果且不请求后端", async () => {
@@ -27,12 +39,15 @@ describe("useKnowledgeSearch", () => {
     });
 
     expect(result.current.results).toEqual({ count: 0, items: [] });
-    expect(searchKnowledge).not.toHaveBeenCalled();
+    expect(knowledgeApiMocks.searchKnowledgeMock).not.toHaveBeenCalled();
   });
 
   it("search 会合并默认配置并透传成功结果", async () => {
     const onSuccess = vi.fn();
-    vi.mocked(searchKnowledge).mockResolvedValue({ count: 1, items: [{ id: "m1" }] } as never);
+    knowledgeApiMocks.searchKnowledgeMock.mockResolvedValue({
+      count: 1,
+      items: [{ id: "m1" }],
+    } as never);
 
     const { result } = renderHook(() =>
       useKnowledgeSearch({
@@ -47,7 +62,7 @@ describe("useKnowledgeSearch", () => {
       await result.current.search("hello", { semantic_weight: 0.9 });
     });
 
-    expect(searchKnowledge).toHaveBeenCalledWith(
+    expect(knowledgeApiMocks.searchKnowledgeMock).toHaveBeenCalledWith(
       "c1",
       expect.objectContaining({
         app_name: "negentropy",
@@ -65,7 +80,7 @@ describe("useKnowledgeSearch", () => {
   it("search 失败时会暴露错误并回调 onError", async () => {
     const error = new Error("search failed");
     const onError = vi.fn();
-    vi.mocked(searchKnowledge).mockRejectedValue(error);
+    knowledgeApiMocks.searchKnowledgeMock.mockRejectedValue(error);
 
     const { result } = renderHook(() =>
       useKnowledgeSearch({ corpusId: "c1", onError }),


### PR DESCRIPTION
## 变更说明

本次改动继续收敛 `knowledge` 模块的测试分层，但范围已经从页面级 feature harness 下沉到 hook / util 层，主要包含三部分：

1. 新增 `knowledge-api` util test harness；
2. 将 `useKnowledgeBase` 与 `useKnowledgeSearch` 两组 hook 测试迁移到 util-level mock 入口；
3. 收紧 `useKnowledgeSearch` 的依赖边界，使其直接依赖 `knowledge-api` 子模块，而不是通过 feature barrel 间接导入。

## 为什么要改

上一轮已经把页面测试收敛到统一的 `@/features/knowledge` feature-level harness，但 hook 测试仍直接在各自测试文件里手写 `@/features/knowledge/utils/knowledge-api` mock，存在两类问题：

- **分层不一致**：页面测试已经统一到 feature harness，但 hook 测试仍散落维护 util mock，测试边界与基础设施层次不清晰；
- **语义漂移风险**：如果 `knowledge-api` 子模块导出面继续演进，`useKnowledgeBase.test.tsx` 与 `useKnowledgeSearch.test.tsx` 会再次各自维护一份 mock 语义，重新引入 split-brain。

从职责上看，这两组测试本质上都是 **util-level / hook-level unit test**：
- 它们验证的是 hook 的状态编排、参数透传、成功/失败回调与引用稳定性；
- 它们不是在验证 `@/features/knowledge` 根模块的 feature 边界。

因此，这次改动选择的不是“把 hook 测试硬迁到 feature harness”，而是建立第二层、专门面向 `knowledge-api` 子模块的 util harness，保持分层清晰：

- 页面与 feature 边界测试 -> 继续走 `knowledge` harness；
- hook 与 util 级测试 -> 收敛到 `knowledge-api` util harness。

## 具体实现

### 1. 新增 `knowledge-api` util harness
新增：

- `apps/negentropy-ui/tests/helpers/knowledge-api.ts`

在这个文件中提供：

- `createKnowledgeApiMockSet`
  - 集中创建 `fetchCorpus`、`fetchCorpora`、`createCorpus`、`updateCorpus`、`deleteCorpus`、`ingestText`、`ingestUrl`、`ingestFile`、`replaceSource`、`syncSource`、`rebuildSource`、`deleteSource`、`archiveSource`、`searchKnowledge` 等 util-level `vi.fn()`；
- `createKnowledgeApiTestHarness`
  - 统一组装 `@/features/knowledge/utils/knowledge-api` 的 mock 导出；
  - 默认保留真实配置 helper，例如：
    - `createDefaultChunkingConfig`
    - `normalizeChunkingConfig`
    - `normalizeCorpusExtractorRoutes`
    - `createEmptyExtractorDraftTarget`
    - `normalizeExtractorDraftRoutes`
    - `buildExtractorRoutesFromDraft`
    - `buildCorpusConfig`

这让 util-level 单测也拥有和 feature harness 对应的“单一 mock 入口”。

### 2. hook 测试迁移到 util harness
以下两组测试不再在文件内手写完整的 `knowledge-api` mock，而是统一通过 util harness 构造：

- `apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx`
- `apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx`

其中：

- `useKnowledgeBase.test.tsx`
  - 保持 util-level unit test 定位；
  - 继续验证相同输入下返回对象与 `loadCorpus` 引用稳定；
  - 额外补充 `loadCorpora` 成功后状态恢复与列表更新的断言，提高该文件的行为覆盖密度。
- `useKnowledgeSearch.test.tsx`
  - 继续验证空查询短路、默认配置合并、成功结果透传、失败状态与 `onError` 回调。

### 3. 收紧 `useKnowledgeSearch` 的实现边界
修改：

- `apps/negentropy-ui/features/knowledge/hooks/useKnowledgeSearch.ts`

将 `searchKnowledge` 及相关类型的导入从 `../index` 改为直接来自 `../utils/knowledge-api`。

原因是：

- `useKnowledgeSearch` 本质是对底层搜索 API 的 hook 封装；
- 直接依赖 util 层更符合正交分解，也更容易让单测保持 util-level 边界；
- 避免 hook 单测被迫感知 feature barrel，从而放大测试耦合面。

### 4. 新增 util harness 契约测试
新增：

- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts`

重点验证：

- util harness 默认复用真实配置 helper；
- `exports` 与 `mocks` 指向同一组调用通道；
- override 只覆盖局部 API，不会污染真实 helper 语义。

这样 util harness 本身也有独立契约，而不是隐式基础设施。

## 实现细节

这次改动延续了测试基础设施的分层思路：

- `tests/helpers/knowledge.ts`
  - 负责 `@/features/knowledge` 根模块的 feature-level harness；
- `tests/helpers/knowledge-api.ts`
  - 负责 `@/features/knowledge/utils/knowledge-api` 的 util-level harness。

这种“两层 harness”设计符合单一事实源与正交分层原则：

- 页面测试不再感知 util mock 细节；
- hook 测试也不需要错误依赖 feature-level mock；
- `knowledge` 模块测试基础设施的职责边界更清晰。

同时，这次实现仍然兼容 Vitest 的 `vi.mock` / `vi.hoisted` 执行顺序约束：hoisted mock 句柄由测试文件本地持有，harness 负责统一导出装配，避免再次出现 top-level 初始化顺序导致的 mock 失效问题。

## 验证结果

本次改动覆盖的文件为：

- `apps/negentropy-ui/features/knowledge/hooks/useKnowledgeSearch.ts`
- `apps/negentropy-ui/tests/helpers/knowledge-api.ts`
- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts`
- `apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx`
- `apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx`

另外，相关 `knowledge` 测试链路已作为回归范围重新执行，重点确认：

- util harness 与其契约测试可运行；
- 页面级 `knowledge` harness 不受这次 util harness 收敛影响；
- `KnowledgeBasePage`、`PipelinesPage`、`ApiExecutor` 等既有 feature-level 测试仍保持稳定。

## 影响范围与兼容性

- 不修改后端 API；
- 不修改页面功能行为；
- 仅收敛 hook / util 层的测试基础设施与依赖边界；
- 通过把 hook 测试固定在 util-level harness，降低未来再次出现测试边界漂移的风险。
