### PR TITLE
fix(test): 修复知识测试辅助类型兼容问题;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -1,0 +1,93 @@
+import { vi, type Mock } from "vitest";
+
+import {
+  buildCorpusConfig,
+  buildExtractorRoutesFromDraft,
+  createDefaultChunkingConfig,
+  createEmptyExtractorDraftTarget,
+  normalizeChunkingConfig,
+  normalizeCorpusExtractorRoutes,
+  normalizeExtractorDraftRoutes,
+} from "@/features/knowledge/utils/knowledge-api";
+
+type VitestMock = Mock<(...args: unknown[]) => unknown>;
+
+export interface KnowledgeApiMockSet {
+  fetchCorpusMock: VitestMock;
+  fetchCorporaMock: VitestMock;
+  createCorpusMock: VitestMock;
+  updateCorpusMock: VitestMock;
+  deleteCorpusMock: VitestMock;
+  ingestTextMock: VitestMock;
+  ingestUrlMock: VitestMock;
+  ingestFileMock: VitestMock;
+  replaceSourceMock: VitestMock;
+  syncSourceMock: VitestMock;
+  rebuildSourceMock: VitestMock;
+  deleteSourceMock: VitestMock;
+  archiveSourceMock: VitestMock;
+  searchKnowledgeMock: VitestMock;
+}
+
+export interface KnowledgeApiTestHarness {
+  exports: Record<string, unknown>;
+  mocks: KnowledgeApiMockSet;
+}
+
+export function createKnowledgeApiMockSet(): KnowledgeApiMockSet {
+  return {
+    fetchCorpusMock: vi.fn(),
+    fetchCorporaMock: vi.fn(),
+    createCorpusMock: vi.fn(),
+    updateCorpusMock: vi.fn(),
+    deleteCorpusMock: vi.fn(),
+    ingestTextMock: vi.fn(),
+    ingestUrlMock: vi.fn(),
+    ingestFileMock: vi.fn(),
+    replaceSourceMock: vi.fn(),
+    syncSourceMock: vi.fn(),
+    rebuildSourceMock: vi.fn(),
+    deleteSourceMock: vi.fn(),
+    archiveSourceMock: vi.fn(),
+    searchKnowledgeMock: vi.fn(),
+  };
+}
+
+export function createKnowledgeApiConfigTestExports() {
+  return {
+    createDefaultChunkingConfig,
+    normalizeChunkingConfig,
+    normalizeCorpusExtractorRoutes,
+    createEmptyExtractorDraftTarget,
+    normalizeExtractorDraftRoutes,
+    buildExtractorRoutesFromDraft,
+    buildCorpusConfig,
+  };
+}
+
+export function createKnowledgeApiTestHarness(
+  mocks: KnowledgeApiMockSet,
+  overrides: Record<string, unknown> = {},
+): KnowledgeApiTestHarness {
+  return {
+    mocks,
+    exports: {
+      fetchCorpus: (...args: unknown[]) => mocks.fetchCorpusMock(...args),
+      fetchCorpora: (...args: unknown[]) => mocks.fetchCorporaMock(...args),
+      createCorpus: (...args: unknown[]) => mocks.createCorpusMock(...args),
+      updateCorpus: (...args: unknown[]) => mocks.updateCorpusMock(...args),
+      deleteCorpus: (...args: unknown[]) => mocks.deleteCorpusMock(...args),
+      ingestText: (...args: unknown[]) => mocks.ingestTextMock(...args),
+      ingestUrl: (...args: unknown[]) => mocks.ingestUrlMock(...args),
+      ingestFile: (...args: unknown[]) => mocks.ingestFileMock(...args),
+      replaceSource: (...args: unknown[]) => mocks.replaceSourceMock(...args),
+      syncSource: (...args: unknown[]) => mocks.syncSourceMock(...args),
+      rebuildSource: (...args: unknown[]) => mocks.rebuildSourceMock(...args),
+      deleteSource: (...args: unknown[]) => mocks.deleteSourceMock(...args),
+      archiveSource: (...args: unknown[]) => mocks.archiveSourceMock(...args),
+      searchKnowledge: (...args: unknown[]) => mocks.searchKnowledgeMock(...args),
+      ...createKnowledgeApiConfigTestExports(),
+      ...overrides,
+    },
+  };
+}


### PR DESCRIPTION
## 背景
- `refactor(session): 收敛会话请求参数归一化助手;` 合并后，后续 push 在 GitHub Actions 的 `UI Build Smoke` 中连续暴露了知识测试辅助的严格 TypeScript 兼容问题。
- 这些问题都出现在 `next build` 的 merge-ref 构建阶段，而不是运行时逻辑：本质上是 Vitest mock 在类型空间里的显式建模不足，导致测试辅助在严格 TS 检查下失配。
- 本 PR 只处理这轮合并态新增的测试辅助类型问题，不改页面行为、不改 session BFF 逻辑。

## 核心变更
- 在 `apps/negentropy-ui/tests/helpers/knowledge.ts` 中显式引入 `Mock` 类型，并把 `KnowledgeFeatureMockSet` 从 `ReturnType<typeof vi.fn>` 收敛为可调用的 `VitestMock` 别名，修复 helper 内部 `mocks.xxx(...args)` 的调用类型错误。
- 新增并修正 `apps/negentropy-ui/tests/helpers/knowledge-api.ts`，把基线新增的 knowledge API 测试辅助提前纳入当前分支，同时为其补齐 `vi` 类型上下文与统一的 `VitestMock` 建模，避免 merge-ref 构建再次因为 `typeof vi.fn` 和 mock 可调用性失败。
- 保持知识测试 helper 的对外语义不变：仍然只负责把真实配置 helper 与 mock 函数绑定到同一组导出上，不引入新的测试行为。

## 变更原因
- 目标是修复 GitHub Actions 在 merge-ref 构建阶段暴露的测试辅助类型漂移，确保严格 TypeScript 检查与 Vitest mock 建模保持一致。
- 这属于测试基础设施加固，而不是业务逻辑调整；如果不修，后续任何依赖这些 helper 的知识测试增量都会继续在 PR 构建阶段被阻断。

## 重要实现细节
- 继续沿用最小干预原则：只修正测试辅助的类型定义和导入，不重写测试结构、不改 hooks 或 API 逻辑。
- `knowledge-api.ts` 采用与 `knowledge.ts` 一致的 `VitestMock` 别名，保持同类 helper 的类型策略一致，避免再次出现一处修好、另一处继续漂移的 split-brain。
- 已在本地额外用临时 merge worktree 复现 `pull_request` merge-ref，并确认修复后的 `next build` 可以在合并态通过。

## 验证证据
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/useKnowledgeBase.test.tsx tests/unit/knowledge/useKnowledgeSearch.test.tsx tests/unit/knowledge/knowledge-test-harness.test.ts tests/unit/api/agui-session-request.test.ts tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 临时 merge worktree 复现并通过：将修正后的 `tests/helpers/knowledge-api.ts` 带入 PR merge ref 后，`pnpm build` 成功

## Next Best Action
- 把 knowledge 测试辅助里其余 `ReturnType<typeof vi.fn>` 模式统一替换成同一套显式 mock 别名，避免未来继续靠 merge-ref 构建失败来暴露类型漂移。
