### PR TITLE
fix(chat): 修复对话流式闪烁与重复气泡问题;

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -42,6 +42,8 @@ import {
 import {
   deriveConnectionState,
   deriveRunStates,
+  hasSameEventSequence,
+  hasSameMessageSequence,
   hydrateSessionDetail,
   mergeEvents,
   mergeMessages,
@@ -599,15 +601,17 @@ export function HomeBody({
           const shouldMerge =
             currentLoadedSessionId === id ||
             (sessionId === id && currentRawEvents.length > 0);
-          return shouldMerge ? mergeEvents(prev, hydrated.events) : hydrated.events;
+          const next = shouldMerge ? mergeEvents(prev, hydrated.events) : hydrated.events;
+          return hasSameEventSequence(prev, next) ? prev : next;
         });
         setSessionMessages((prev) => {
           const shouldMerge =
             currentLoadedSessionId === id ||
             (sessionId === id && currentRawEvents.length > 0);
-          return shouldMerge
+          const next = shouldMerge
             ? mergeMessages(prev, hydrated.messages)
             : hydrated.messages;
+          return hasSameMessageSequence(prev, next) ? prev : next;
         });
         setSessionSnapshot((prev) =>
           currentLoadedSessionId === id ||
@@ -635,7 +639,13 @@ export function HomeBody({
   const scheduleSessionHydration = useCallback(
     (id: string) => {
       clearHydrationTimers();
-      const delays = [0, 250, 800, 1600];
+      const hasLiveAssistantOutput = rawEventsRef.current.some(
+        (event) =>
+          event.type === EventType.TEXT_MESSAGE_CONTENT &&
+          "threadId" in event &&
+          event.threadId === id,
+      );
+      const delays = hasLiveAssistantOutput ? [1200, 2800] : [0, 250, 800, 1600];
       delays.forEach((delay) => {
         const timer = setTimeout(() => {
           void loadSessionDetail(id);

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -216,6 +216,14 @@ function CopyButton({ code }: { code: string }) {
   );
 }
 
+function StreamingText({ content }: { content: string }) {
+  return (
+    <div className="whitespace-pre-wrap break-words text-sm leading-7 text-inherit">
+      {content}
+    </div>
+  );
+}
+
 export function MessageBubble({
   message,
   isSelected,
@@ -311,71 +319,51 @@ export function MessageBubble({
                 "[&_th]:border-border/20 [&_th]:bg-background/10 [&_td]:border-border/20",
             )}
           >
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                code({ className, children, ...props }) {
-                  const match = /language-(\w+)/.exec(className || "");
-                  const isMermaid = match && match[1] === "mermaid";
-                  // @ts-expect-error - 'inline' is sometimes passed by react-markdown but missing in types depending on version
-                  const isInline = props.inline;
+            {isStreaming ? (
+              <StreamingText content={content} />
+            ) : (
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  code({ className, children, ...props }) {
+                    const match = /language-(\w+)/.exec(className || "");
+                    const isMermaid = match && match[1] === "mermaid";
+                    // @ts-expect-error - 'inline' is sometimes passed by react-markdown but missing in types depending on version
+                    const isInline = props.inline;
 
-                  if (isMermaid) {
+                    if (isMermaid) {
+                      return (
+                        <MermaidDiagram
+                          code={String(children).replace(/\n$/, "")}
+                        />
+                      );
+                    }
+
+                    if (!isInline && match) {
+                      return (
+                        <div className="relative group">
+                          <code className={className} {...props}>
+                            {children}
+                          </code>
+                          <CopyButton code={String(children)} />
+                        </div>
+                      );
+                    }
+
                     return (
-                      <MermaidDiagram
-                        code={String(children).replace(/\n$/, "")}
-                      />
+                      <code className={className} {...props}>
+                        {children}
+                      </code>
                     );
-                  }
-
-                  if (!isInline && match) {
-                    return (
-                      <div className="relative group">
-                        {/* Native code element will be rendered inside pre by default, but here we are inside code.
-                             Actually, if we are in 'code' component, we are INSIDE the 'pre' if it's a block.
-                             If we render a div here, we are inside pre.
-                             Styling might be tricky.
-                             Better approach: just use the pre style for the block, and add a copy button relative to it?
-                             React-Markdown renders 'pre' then 'code'.
-                             If we want to add a button, we ideally want to be properly positioned.
-                             Let's just return the code as is, but maybe use 'pre' override?
-                             No, 'pre' override is safer for the button placement.
-                             Let's revert to simple code return here and override PRE.
-                          */}
-                        <code className={className} {...props}>
-                          {children}
-                        </code>
-                        <CopyButton code={String(children)} />
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <code className={className} {...props}>
-                      {children}
-                    </code>
-                  );
-                },
-                // Override pre to handle positioning if needed, or just handle it in code.
-                // Actually, doing it in 'code' inside 'pre' is messy because 'pre' has the background.
-                // Let's rely on MessageBubble css for pre.
-                // If I modify code to return a div, 'pre > div' is valid HTML5? No, pre should contain phrasing content (code).
-                // But for React rendering it works visually.
-                // Let's try to keeping it simple: Just add the button in 'code' and position it.
-                // The 'pre' has relative positioning?
-                pre({ children }) {
-                  // Extract code string? Children of pre is code.
-                  // It's hard to get the raw text easily from pre children if it's a React element.
-                  // So doing it in 'code' is easier for accessing text.
-                  // If we render a div inside pre, we might break the 'pre' scrolling or styling if not careful.
-                  // Let's use a simpler approach: Just add the button in 'code' and position it.
-                  // The 'pre' has relative positioning?
-                  return <pre className="relative group">{children}</pre>;
-                },
-              }}
-            >
-              {content}
-            </ReactMarkdown>
+                  },
+                  pre({ children }) {
+                    return <pre className="relative group">{children}</pre>;
+                  },
+                }}
+              >
+                {content}
+              </ReactMarkdown>
+            )}
             {isStreaming ? (
               <div className="mt-3 flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-amber-600 dark:text-amber-300">
                 <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-current" />

--- a/apps/negentropy-ui/tests/integration/home-flow.test.tsx
+++ b/apps/negentropy-ui/tests/integration/home-flow.test.tsx
@@ -298,6 +298,82 @@ describe("HomeBody integration", () => {
     });
   }, 10000);
 
+  it("assistant 实时流与最终回拉 messageId 不同时仍只显示一个最终 bubble", async () => {
+    const user = userEvent.setup();
+    const finalReply = "我可以帮助你规划任务、分析代码并直接修改实现。";
+
+    mockAgent.runAgent.mockImplementationOnce(async () => {
+      const timestamp = Date.now() / 1000;
+      subscriptionHandlers?.onRunInitialized?.();
+      subscriptionHandlers?.onRunStartedEvent?.();
+      emitEvent(createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "s1",
+        runId: "s1",
+        timestamp,
+      }));
+      emitEvent(createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "s1",
+        runId: "s1",
+        messageId: "assistant-live",
+        role: "assistant",
+        timestamp: timestamp + 0.001,
+      }));
+      emitEvent(createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "s1",
+        runId: "s1",
+        messageId: "assistant-live",
+        delta: "我可以帮助你规划任务",
+        timestamp: timestamp + 0.002,
+      }));
+      emitEvent(createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "s1",
+        runId: "s1",
+        messageId: "assistant-live",
+        delta: finalReply,
+        timestamp: timestamp + 0.003,
+      }));
+      emitEvent(createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "s1",
+        runId: "s1",
+        messageId: "assistant-live",
+        timestamp: timestamp + 0.004,
+      }));
+
+      detailEvents = [
+        {
+          id: "assistant-final",
+          runId: "s1",
+          threadId: "s1",
+          timestamp: timestamp + 0.02,
+          message: { role: "assistant", content: finalReply },
+        },
+      ];
+      subscriptionHandlers?.onRunFinishedEvent?.();
+      return { result: "ok" };
+    });
+
+    render(<Wrapper sessionId="s1" />);
+    await waitForInitialHydration();
+
+    await user.type(screen.getByPlaceholderText("输入指令..."), "你能帮我做什么？");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(finalReply)).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1800));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(finalReply)).toHaveLength(1);
+    });
+  }, 10000);
+
   it("handles HITL confirmation flow", async () => {
     const user = userEvent.setup();
     render(<Wrapper sessionId="s1" />);

--- a/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
@@ -49,4 +49,29 @@ describe("MessageBubble", () => {
     expect(avatarRail?.className).toContain("left-0");
     expect(avatarRail?.className).toContain("-translate-x-[calc(100%+0.75rem)]");
   });
+
+  it("流式回复在结束前按纯文本稳定渲染并显示状态", () => {
+    render(
+      <MessageBubble
+        message={{
+          id: "a-stream",
+          role: "assistant",
+          content: "**加粗**\n- 列表项",
+          streaming: true,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element?.tagName === "DIV" &&
+          content.includes("**加粗**") &&
+          content.includes("- 列表项")
+        );
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Streaming")).toBeInTheDocument();
+    expect(screen.getByText("实时生成中")).toBeInTheDocument();
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -304,6 +304,51 @@ describe("buildConversationTree", () => {
     expect(tree.roots[0].children.filter((child) => child.type === "text")).toHaveLength(1);
   });
 
+  it("同一轮次中不同 messageId 的 assistant 最终快照会收敛到同一个节点", () => {
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-live",
+        role: "assistant",
+        timestamp: 1001,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-live",
+        delta: "我可以帮助你规划任务",
+        timestamp: 1002,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-final",
+        delta: "我可以帮助你规划任务、分析代码并执行修改。",
+        timestamp: 1003,
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].children.filter((child) => child.type === "text")).toHaveLength(1);
+    expect(tree.roots[0].children[0].payload.content).toBe(
+      "我可以帮助你规划任务、分析代码并执行修改。",
+    );
+    expect(tree.roots[0].children[0].relatedMessageIds).toEqual(
+      expect.arrayContaining(["assistant-live", "assistant-final"]),
+    );
+  });
+
   it("将运行错误节点保留在主聊天区", () => {
     const events: AgUiEvent[] = [
       createTestEvent({

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -22,7 +22,11 @@ import {
   classifyNodeVisibility,
   isNodePayloadEmpty,
 } from "@/utils/conversation-summary";
-import { accumulateTextContent, normalizeMessageContent } from "@/utils/message";
+import {
+  accumulateTextContent,
+  isEquivalentMessageContent,
+  normalizeMessageContent,
+} from "@/utils/message";
 
 type MutableNode = ConversationNode;
 
@@ -305,6 +309,54 @@ function getMessageTimestamp(message: Message): number {
   return createdAt instanceof Date ? createdAt.getTime() / 1000 : Date.now() / 1000;
 }
 
+function findMatchingTextNodeId(
+  nodeIndex: Map<string, MutableNode>,
+  input: {
+    threadId: string;
+    runId?: string;
+    role: "user" | "assistant" | "system";
+    content: string;
+    timestamp: number;
+  },
+): string | null {
+  const normalizedContent = input.content.trim();
+  if (!normalizedContent) {
+    return null;
+  }
+
+  const timeWindowSeconds = input.role === "assistant" ? 30 : 5;
+
+  for (const node of nodeIndex.values()) {
+    if (node.type !== "text" || node.role !== input.role) {
+      continue;
+    }
+    if (node.threadId !== input.threadId) {
+      continue;
+    }
+    if (input.runId && node.runId && node.runId !== input.runId) {
+      continue;
+    }
+    if (Math.abs(node.timeRange.end - input.timestamp) > timeWindowSeconds) {
+      continue;
+    }
+
+    const existingContent = String(node.payload.content || "").trim();
+    if (!existingContent) {
+      continue;
+    }
+
+    const isMatch =
+      input.role === "assistant"
+        ? isEquivalentMessageContent(existingContent, normalizedContent)
+        : existingContent === normalizedContent;
+    if (isMatch) {
+      return node.id;
+    }
+  }
+
+  return null;
+}
+
 function pruneNode(node: MutableNode): MutableNode | null {
   node.children = node.children
     .map((child) => pruneNode(child))
@@ -385,6 +437,16 @@ export function buildConversationTree(
   const toolNodeIndex = new Map<string, string>();
   const turns = new Map<string, MutableNode>();
   const assistantMessageByRun = new Map<string, string>();
+  const messageRoleById = new Map<string, "user" | "assistant" | "system">();
+  const messageMetaById = new Map<
+    string,
+    {
+      threadId: string;
+      runId: string;
+      timestamp: number;
+      sourceOrder: number;
+    }
+  >();
   const pendingConfirmationCountByRun = new Map<string, number>();
   const pendingLinks: LinkInstruction[] = [];
   let activeRunId: string | undefined;
@@ -452,25 +514,54 @@ export function buildConversationTree(
         const role =
           normalizedEvent.type === EventType.TEXT_MESSAGE_START && "role" in normalizedEvent
             ? normalizeRole(normalizedEvent.role)
-            : undefined;
-        const node = upsertNode(nodeIndex, roots, turns, {
-          id: `message:${messageId}`,
-          type: "text",
-          parentId: turn.id,
+            : (messageRoleById.get(messageId) ?? "assistant");
+        if (normalizedEvent.type === EventType.TEXT_MESSAGE_START && role) {
+          messageRoleById.set(messageId, role);
+          messageMetaById.set(messageId, {
+            threadId: turn.threadId,
+            runId,
+            timestamp: normalizeTimestamp(normalizedEvent.timestamp),
+            sourceOrder: eventIndex,
+          });
+          return;
+        }
+
+        const meta = messageMetaById.get(messageId) || {
           threadId: turn.threadId,
           runId,
-          messageId,
-          timestamp: normalizedEvent.timestamp,
+          timestamp: normalizeTimestamp(normalizedEvent.timestamp),
           sourceOrder: eventIndex,
+        };
+        messageMetaById.set(messageId, meta);
+
+        const delta =
+          normalizedEvent.type === EventType.TEXT_MESSAGE_CONTENT && "delta" in normalizedEvent
+            ? String(normalizedEvent.delta || "")
+            : "";
+        const existingNodeId = messageNodeIndex.get(messageId);
+        const matchedNodeId =
+          !existingNodeId && role === "assistant" && delta
+            ? findMatchingTextNodeId(nodeIndex, {
+                threadId: meta.threadId,
+                runId: meta.runId,
+                role,
+                content: delta,
+                timestamp: normalizeTimestamp(normalizedEvent.timestamp),
+              })
+            : null;
+        const nodeId = matchedNodeId || existingNodeId || `message:${messageId}`;
+        const node = upsertNode(nodeIndex, roots, turns, {
+          id: nodeId,
+          type: "text",
+          parentId: turn.id,
+          threadId: meta.threadId,
+          runId: meta.runId,
+          messageId,
+          timestamp: meta.timestamp,
+          sourceOrder: meta.sourceOrder,
           title: role === "user" ? "用户消息" : "助手消息",
           role,
-          payload:
-            normalizedEvent.type === EventType.TEXT_MESSAGE_CONTENT &&
-            "delta" in normalizedEvent
-              ? {
-                  content: String(normalizedEvent.delta || ""),
-                }
-              : {},
+          payload: delta ? { content: delta } : {},
           sourceEventTypes: [eventType],
           relatedMessageIds: [messageId],
         });
@@ -478,18 +569,20 @@ export function buildConversationTree(
         if (role) {
           node.role = role;
           node.title = role === "user" ? "用户消息" : "助手消息";
+          messageRoleById.set(messageId, role);
         }
-        if (normalizedEvent.type === EventType.TEXT_MESSAGE_CONTENT) {
-          const delta =
-            "delta" in normalizedEvent ? String(normalizedEvent.delta || "") : "";
+        if (delta) {
           const existing = String(node.payload.content || "");
           node.payload.content = accumulateTextContent(existing, delta);
         }
         messageNodeIndex.set(messageId, node.id);
-        if (node.role === "assistant") {
-          assistantMessageByRun.set(runId, node.id);
+        if (matchedNodeId && matchedNodeId !== `message:${messageId}`) {
+          node.messageId = node.messageId || messageId;
         }
-        addChild(turn, node);
+        if (node.role === "assistant") {
+          assistantMessageByRun.set(meta.runId, node.id);
+        }
+        attachNode(nodeIndex, roots, turns, node.id, turn.id);
         return;
       }
       case EventType.TOOL_CALL_START:
@@ -806,9 +899,12 @@ export function buildConversationTree(
       if (node.type !== "text" || node.role !== role) {
         return false;
       }
-      if (String(node.payload.content || "").trim() !== content) {
-        return false;
-      }
+      const existingContent = String(node.payload.content || "").trim();
+      const contentMatches =
+        role === "assistant"
+          ? isEquivalentMessageContent(existingContent, content)
+          : existingContent === content;
+      if (!contentMatches) return false;
       const existingRunId = node.runId || undefined;
       const runMatches =
         existingRunId === runId ||
@@ -820,7 +916,8 @@ export function buildConversationTree(
       if (node.threadId !== threadId) {
         return false;
       }
-      return Math.abs(node.timestamp - timestamp) <= 2;
+      const timeWindow = role === "assistant" ? 30 : 5;
+      return Math.abs(node.timestamp - timestamp) <= timeWindow;
     });
     if (duplicateNode) {
       if (!duplicateNode.relatedMessageIds.includes(messageId)) {

--- a/apps/negentropy-ui/utils/message.ts
+++ b/apps/negentropy-ui/utils/message.ts
@@ -157,7 +157,7 @@ export function mapMessagesToChat(messages: Message[]): ChatMessage[] {
  * @param content2 第二个内容
  * @returns 是否相似
  */
-function isContentSimilar(content1: string, content2: string): boolean {
+export function isContentSimilar(content1: string, content2: string): boolean {
   // 空内容不相似
   if (!content1.trim() || !content2.trim()) return false;
 
@@ -198,6 +198,38 @@ function isContentSimilar(content1: string, content2: string): boolean {
   const jaccardSimilarity = intersection.size / union.size;
 
   return jaccardSimilarity > 0.7;
+}
+
+export function isEquivalentMessageContent(
+  content1: string,
+  content2: string,
+): boolean {
+  const normalized1 = content1.trim();
+  const normalized2 = content2.trim();
+
+  if (!normalized1 || !normalized2) {
+    return false;
+  }
+  if (normalized1 === normalized2) {
+    return true;
+  }
+  if (
+    (normalized1.startsWith(normalized2) || normalized2.startsWith(normalized1)) &&
+    Math.min(normalized1.length, normalized2.length) >= 6
+  ) {
+    return true;
+  }
+
+  const shorter = Math.min(normalized1.length, normalized2.length);
+  const longer = Math.max(normalized1.length, normalized2.length);
+  if (
+    shorter / longer >= 0.8 &&
+    (normalized1.includes(normalized2) || normalized2.includes(normalized1))
+  ) {
+    return true;
+  }
+
+  return isContentSimilar(normalized1, normalized2);
 }
 
 /**

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -139,6 +139,22 @@ export function mergeEvents(baseEvents: BaseEvent[], incomingEvents: BaseEvent[]
   });
 }
 
+export function hasSameEventSequence(left: BaseEvent[], right: BaseEvent[]): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    if (eventKey(left[index]!) !== eventKey(right[index]!)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function mergeMessages(baseMessages: Message[], incomingMessages: Message[]): Message[] {
   const merged = new Map<string, AgUiMessage>();
 
@@ -174,6 +190,31 @@ export function mergeMessages(baseMessages: Message[], incomingMessages: Message
     }
     return a.id.localeCompare(b.id);
   });
+}
+
+export function hasSameMessageSequence(left: Message[], right: Message[]): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftMessage = left[index] as AgUiMessage;
+    const rightMessage = right[index] as AgUiMessage;
+    if (getMessageIdentityKey(leftMessage) !== getMessageIdentityKey(rightMessage)) {
+      return false;
+    }
+    if (normalizeMessageContent(leftMessage) !== normalizeMessageContent(rightMessage)) {
+      return false;
+    }
+    if ((leftMessage.streaming === true) !== (rightMessage.streaming === true)) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function hydrateSessionDetail(


### PR DESCRIPTION
## 变更摘要

本 PR 聚焦 `negentropy-ui` 聊天主链路的稳定性修复，并补齐因此暴露出来的 UI CI / TypeScript 配置问题，重点解决以下问题：

- assistant 在流式阶段以整段 chunk 快速替换的方式闪动，阅读体验不稳定
- run 结束后的 session hydration 会触发主区明显重绘，造成“页面闪一下”的观感
- 实时流中的 assistant 回复与历史回拉中的最终回复没有正确收敛，导致相同内容重复显示为两个 bubble
- UI Build Smoke 将 `tests/` 一并纳入 Next 构建型 TypeScript 检查，导致测试侧 Vitest globals 与测试辅助类型问题直接打断 `next build`

## 做了什么

### 1. 收紧 hydration 与实时流的归并策略

- 为 session hydration 增加事件序列和消息序列的幂等比较
- 当 hydration 合并结果与当前前端状态等价时，直接复用旧 state，避免无意义的整区重渲染
- 当当前会话已经收到 live assistant 文本 chunk 时，延后 hydration 时机，降低实时流与历史回拉并发竞争导致的闪烁

### 2. 强化 A2UI 对话树的 canonical merge

- 为 assistant 文本节点增加基于 `thread/run/时间窗口/语义内容` 的匹配与收敛规则
- 允许 live stream 与 persisted final message 在 `messageId` 不同的情况下仍归并到同一个 assistant 节点
- fallback assistant 快照也复用相同的语义去重逻辑，避免同一答复被二次物化

### 3. 优化 assistant 的流式渲染路径

- assistant 在 `streaming` 阶段改为稳定的纯文本渲染，不再每个 chunk 都走完整 Markdown 重渲染
- 继续保留生成中状态提示，但把渲染更新收敛到单一 bubble 内完成
- 在流结束后再回到正常的 Markdown 呈现路径，兼顾流式稳定性与最终富文本展示

### 4. 拆分 UI 的 TypeScript 构建与测试边界

- 为 `negentropy-ui` 增加共享 `tsconfig.base.json`
- 将 `tsconfig.json` 收敛为应用构建配置，显式排除 `tests/**`
- 新增 `tsconfig.vitest.json`，为测试代码显式注入 `vitest/globals` 与 `node` 类型
- 在 `next.config.ts` 中固定 Next 构建使用应用配置，避免测试目录误入生产构建型检查

### 5. 补充 UI CI 反馈闭环

- 在 UI workflow 中新增 `UI Type Checks`
- 分别执行应用代码 `pnpm typecheck` 与测试代码 `pnpm typecheck:test`
- 让测试类型问题在显式步骤中暴露，而不是以 `next build` 的副作用形式失败

### 6. 修复测试类型问题并补充回归测试

- 修正 knowledge test harness 中的 Vitest mock 类型声明
- 修正 `adk.test.ts` 对宽类型事件字段的直接访问
- 修正 `state.test.ts` 中 `STATE_DELTA` 测试夹具的类型桥接方式
- 新增并更新了覆盖以下场景的测试：
  - 不同 `messageId` 的 live assistant 与最终 hydration assistant 会收敛为单个节点
  - streaming bubble 在结束前按纯文本稳定渲染并显示实时状态
  - 聊天主链路中，live assistant 与最终回拉并存时最终只显示一个完整 bubble

## 为什么这样改

这次改动直接对应聊天界面的真实交互缺陷：用户看到的不是“单一回复逐步长出来”，而是“chunk 快速替换后页面闪一下，再出现两个一模一样的最终答复”。从 A2UI / AG-UI 的建模角度看，这本质上是实时事件流、session hydration 与对话树读模型之间没有共享同一套 canonical identity 和 reconciliation 语义。

同时，最新 UI 改动也暴露出另一个工程问题：当前 UI 工程把测试代码与生产代码放在同一个 TypeScript 构建边界里，导致本应由测试链路负责的 Vitest globals / 测试辅助类型问题，直接中断了 `next build`。因此本次修复一并做了最小但完整的边界治理：

- 将实时事件流视为主事实源
- 将 hydration 视为补全和收敛，而不是重新物化一份新的 assistant 回复
- 用统一的语义匹配规则让 live message 与 persisted final message 最终收敛到同一个对话节点
- 将应用构建类型检查与测试类型检查分离，分别建立单独反馈闭环

这样可以在不修改后端协议的前提下，稳定修复流式闪烁、主区重绘和重复 bubble 问题，同时降低聊天读模型和 UI CI 继续演化时的回归风险。

## 关键实现细节

- 未修改后端 API 契约，改动集中在 `negentropy-ui` 前端归并、建树、渲染与 TypeScript 配置层
- session hydration 新增序列级幂等检查，避免无变化状态反复进入 React 更新链路
- assistant 文本节点新增语义去重与别名归并逻辑，支持跨 `messageId` 收敛
- streaming 渲染路径在生成阶段使用稳定纯文本显示，减少 Markdown 反复重算带来的闪动
- UI workflow 新增显式类型检查步骤，避免 `next build` 再次承担测试类型守门职责

## 验证结果

已本地执行：

```bash
pnpm --dir apps/negentropy-ui typecheck
pnpm --dir apps/negentropy-ui typecheck:test
pnpm --dir apps/negentropy-ui test:coverage
pnpm --dir apps/negentropy-ui build
pnpm --dir apps/negentropy-ui test:e2e
```

结果：

- `40` 个测试文件、`219` 个测试全部通过
- `next build` 成功完成生产构建
- Playwright smoke `3` 个场景全部通过
