### PR TITLE
fix(test): 修复知识API测试辅助类型兼容问题;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -1,3 +1,4 @@
+import { vi, type Mock } from "vitest";
 import {
   buildCorpusConfig,
   buildExtractorRoutesFromDraft,
@@ -8,21 +9,23 @@ import {
   normalizeExtractorDraftRoutes,
 } from "@/features/knowledge/utils/knowledge-api";
 
+type VitestMock = Mock<(...args: unknown[]) => unknown>;
+
 export interface KnowledgeApiMockSet {
-  fetchCorpusMock: ReturnType<typeof vi.fn>;
-  fetchCorporaMock: ReturnType<typeof vi.fn>;
-  createCorpusMock: ReturnType<typeof vi.fn>;
-  updateCorpusMock: ReturnType<typeof vi.fn>;
-  deleteCorpusMock: ReturnType<typeof vi.fn>;
-  ingestTextMock: ReturnType<typeof vi.fn>;
-  ingestUrlMock: ReturnType<typeof vi.fn>;
-  ingestFileMock: ReturnType<typeof vi.fn>;
-  replaceSourceMock: ReturnType<typeof vi.fn>;
-  syncSourceMock: ReturnType<typeof vi.fn>;
-  rebuildSourceMock: ReturnType<typeof vi.fn>;
-  deleteSourceMock: ReturnType<typeof vi.fn>;
-  archiveSourceMock: ReturnType<typeof vi.fn>;
-  searchKnowledgeMock: ReturnType<typeof vi.fn>;
+  fetchCorpusMock: VitestMock;
+  fetchCorporaMock: VitestMock;
+  createCorpusMock: VitestMock;
+  updateCorpusMock: VitestMock;
+  deleteCorpusMock: VitestMock;
+  ingestTextMock: VitestMock;
+  ingestUrlMock: VitestMock;
+  ingestFileMock: VitestMock;
+  replaceSourceMock: VitestMock;
+  syncSourceMock: VitestMock;
+  rebuildSourceMock: VitestMock;
+  deleteSourceMock: VitestMock;
+  archiveSourceMock: VitestMock;
+  searchKnowledgeMock: VitestMock;
 }
 
 export interface KnowledgeApiTestHarness {


### PR DESCRIPTION
## 背景
- 在将 `vk/98ac-github-actions-w` rebase 到 `feature/1.0.0` 时，`apps/negentropy-ui/tests/helpers/knowledge-api.ts` 出现 add/add 冲突。
- 冲突的本质不是行为分歧，而是同一测试辅助文件同时承载了两类演进：基线分支新增了 knowledge API test harness，本分支则补了 Vitest mock 的严格 TypeScript 类型修复。
- 本 PR 只解决这次 rebase 合并态里的测试辅助类型兼容问题，不改页面行为、不改 session BFF 逻辑。

## 核心变更
- 保留基线中的 `knowledge-api` test harness 结构与导出语义。
- 显式引入 `import { vi, type Mock } from "vitest"`。
- 新增统一的 `VitestMock` 别名，并将 `KnowledgeApiMockSet` 全部字段从 `ReturnType<typeof vi.fn>` 收敛为 `VitestMock`。
- 保持 `createKnowledgeApiMockSet`、`createKnowledgeApiConfigTestExports`、`createKnowledgeApiTestHarness` 的实现和外部调用方式不变。

## 变更原因
- 目标是让 rebase 后的分支在严格 TypeScript 和 Next.js build 的 merge-ref 检查下保持可编译，避免 `typeof vi.fn` 与 mock 可调用性在知识测试辅助中再次漂移。
- 这次修复属于测试基础设施稳定性加固，不改变任何业务逻辑或用户可见行为。

## 重要实现细节
- 冲突解决策略采用“保留基线结构 + 吸收类型修复”的语义并集，而不是回退到任一单边版本。
- `VitestMock` 的做法与现有 `tests/helpers/knowledge.ts` 保持一致，避免同类 helper 再次出现 split-brain。
- rebase 通过 `GIT_EDITOR=true git rebase --continue` 非交互完成，避免流程卡在编辑器。

## 验证证据
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/useKnowledgeBase.test.tsx tests/unit/knowledge/useKnowledgeSearch.test.tsx tests/unit/knowledge/knowledge-test-harness.test.ts tests/unit/api/agui-session-request.test.ts tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui test:coverage`
  - 本地用例已全部执行完成；CLI 收尾阶段出现挂起，但未出现失败输出

## Next Best Action
- 把 knowledge 测试辅助里剩余 `ReturnType<typeof vi.fn>` 的用法统一替换为同一套显式 `Mock` 别名，避免未来继续在 merge-ref 构建阶段暴露类型漂移。
