### PR TITLE
fix(knowledge): 修复 hook 测试退出不干净问题;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -1,13 +1,3 @@
-import {
-  buildCorpusConfig,
-  buildExtractorRoutesFromDraft,
-  createDefaultChunkingConfig,
-  createEmptyExtractorDraftTarget,
-  normalizeChunkingConfig,
-  normalizeCorpusExtractorRoutes,
-  normalizeExtractorDraftRoutes,
-} from "@/features/knowledge/utils/knowledge-api";
-
 export interface KnowledgeApiMockSet {
   fetchCorpusMock: ReturnType<typeof vi.fn>;
   fetchCorporaMock: ReturnType<typeof vi.fn>;
@@ -30,6 +20,12 @@ export interface KnowledgeApiTestHarness {
   mocks: KnowledgeApiMockSet;
 }
 
+export async function importKnowledgeApiActual() {
+  return vi.importActual<typeof import("@/features/knowledge/utils/knowledge-api")>(
+    "@/features/knowledge/utils/knowledge-api",
+  );
+}
+
 export function createKnowledgeApiMockSet(): KnowledgeApiMockSet {
   return {
     fetchCorpusMock: vi.fn(),
@@ -49,22 +45,24 @@ export function createKnowledgeApiMockSet(): KnowledgeApiMockSet {
   };
 }
 
-export function createKnowledgeApiConfigTestExports() {
+export async function createKnowledgeApiConfigTestExports() {
+  const actual = await importKnowledgeApiActual();
   return {
-    createDefaultChunkingConfig,
-    normalizeChunkingConfig,
-    normalizeCorpusExtractorRoutes,
-    createEmptyExtractorDraftTarget,
-    normalizeExtractorDraftRoutes,
-    buildExtractorRoutesFromDraft,
-    buildCorpusConfig,
+    createDefaultChunkingConfig: actual.createDefaultChunkingConfig,
+    normalizeChunkingConfig: actual.normalizeChunkingConfig,
+    normalizeCorpusExtractorRoutes: actual.normalizeCorpusExtractorRoutes,
+    createEmptyExtractorDraftTarget: actual.createEmptyExtractorDraftTarget,
+    normalizeExtractorDraftRoutes: actual.normalizeExtractorDraftRoutes,
+    buildExtractorRoutesFromDraft: actual.buildExtractorRoutesFromDraft,
+    buildCorpusConfig: actual.buildCorpusConfig,
   };
 }
 
-export function createKnowledgeApiTestHarness(
+export async function createKnowledgeApiTestHarness(
   mocks: KnowledgeApiMockSet,
   overrides: Record<string, unknown> = {},
-): KnowledgeApiTestHarness {
+): Promise<KnowledgeApiTestHarness> {
+  const configExports = await createKnowledgeApiConfigTestExports();
   return {
     mocks,
     exports: {
@@ -82,7 +80,7 @@ export function createKnowledgeApiTestHarness(
       deleteSource: (...args: unknown[]) => mocks.deleteSourceMock(...args),
       archiveSource: (...args: unknown[]) => mocks.archiveSourceMock(...args),
       searchKnowledge: (...args: unknown[]) => mocks.searchKnowledgeMock(...args),
-      ...createKnowledgeApiConfigTestExports(),
+      ...configExports,
       ...overrides,
     },
   };

--- a/apps/negentropy-ui/tests/setup.ts
+++ b/apps/negentropy-ui/tests/setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
@@ -8,9 +8,9 @@ import {
 } from "@/tests/helpers/knowledge-api";
 
 describe("knowledge api test harness", () => {
-  it("默认复用真实配置 helper，并把 exports 与 mocks 绑定到同一组函数", () => {
+  it("默认复用真实配置 helper，并把 exports 与 mocks 绑定到同一组函数", async () => {
     const mocks = createKnowledgeApiMockSet();
-    const harness = createKnowledgeApiTestHarness(mocks);
+    const harness = await createKnowledgeApiTestHarness(mocks);
 
     expect(harness.exports.createDefaultChunkingConfig).toBe(
       createDefaultChunkingConfig,
@@ -23,10 +23,10 @@ describe("knowledge api test harness", () => {
     expect(mocks.fetchCorpusMock).toHaveBeenCalledWith("corpus-1", "negentropy");
   });
 
-  it("允许局部 override，而不会污染真实 helper 导出", () => {
+  it("允许局部 override，而不会污染真实 helper 导出", async () => {
     const mocks = createKnowledgeApiMockSet();
     const overrideSearchKnowledge = vi.fn();
-    const harness = createKnowledgeApiTestHarness(mocks, {
+    const harness = await createKnowledgeApiTestHarness(mocks, {
       searchKnowledge: overrideSearchKnowledge,
     });
 

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 const knowledgeApiMocks = vi.hoisted(() => ({
   fetchCorpusMock: vi.fn(),
@@ -19,7 +19,7 @@ const knowledgeApiMocks = vi.hoisted(() => ({
 
 vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
   const { createKnowledgeApiTestHarness } = await import("@/tests/helpers/knowledge-api");
-  return createKnowledgeApiTestHarness(knowledgeApiMocks).exports;
+  return (await createKnowledgeApiTestHarness(knowledgeApiMocks)).exports;
 });
 
 import { useKnowledgeBase } from "@/features/knowledge/hooks/useKnowledgeBase";
@@ -60,7 +60,13 @@ describe("useKnowledgeBase", () => {
 
     const { result } = renderHook(() => useKnowledgeBase({ appName: "negentropy" }));
 
-    await result.current.loadCorpora();
+    await act(async () => {
+      await result.current.loadCorpora();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
 
     expect(knowledgeApiMocks.fetchCorporaMock).toHaveBeenCalledWith("negentropy");
     expect(result.current.corpora).toEqual([

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 
 const knowledgeApiMocks = vi.hoisted(() => ({
   fetchCorpusMock: vi.fn(),
@@ -19,7 +19,7 @@ const knowledgeApiMocks = vi.hoisted(() => ({
 
 vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
   const { createKnowledgeApiTestHarness } = await import("@/tests/helpers/knowledge-api");
-  return createKnowledgeApiTestHarness(knowledgeApiMocks).exports;
+  return (await createKnowledgeApiTestHarness(knowledgeApiMocks)).exports;
 });
 
 import { useKnowledgeSearch } from "@/features/knowledge/hooks/useKnowledgeSearch";
@@ -36,6 +36,10 @@ describe("useKnowledgeSearch", () => {
 
     await act(async () => {
       await expect(result.current.search("   ")).resolves.toEqual({ count: 0, items: [] });
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual({ count: 0, items: [] });
     });
 
     expect(result.current.results).toEqual({ count: 0, items: [] });
@@ -60,6 +64,11 @@ describe("useKnowledgeSearch", () => {
 
     await act(async () => {
       await result.current.search("hello", { semantic_weight: 0.9 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.results).toEqual({ count: 1, items: [{ id: "m1" }] });
     });
 
     expect(knowledgeApiMocks.searchKnowledgeMock).toHaveBeenCalledWith(
@@ -88,6 +97,11 @@ describe("useKnowledgeSearch", () => {
 
     await act(async () => {
       await expect(result.current.search("hello")).rejects.toThrow("search failed");
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.error).toBe(error);
     });
 
     expect(result.current.error).toBe(error);


### PR DESCRIPTION
## 变更说明

本次改动聚焦 `knowledge` 模块 hook 单测的退出不干净问题，主要包含三类修复：

1. 修复 `knowledge-api` util harness 的循环依赖；
2. 显式补齐 Testing Library 的全局 cleanup；
3. 收敛 `useKnowledgeBase` / `useKnowledgeSearch` 单测中的异步状态 flush 方式。

## 为什么要改

在上一轮将 hook 测试收敛到 `knowledge-api` util harness 后，`useKnowledgeBase.test.tsx` 和 `useKnowledgeSearch.test.tsx` 在单文件运行时会出现“无断言失败但 runner 不正常退出”的问题。

根因不是 hook 本身残留了真实 timer，而是测试基础设施与异步状态处理叠加导致的：

- `tests/helpers/knowledge-api.ts` 顶层直接导入了它自己正在 mock 的 `@/features/knowledge/utils/knowledge-api`，在单文件运行场景下形成循环依赖；
- 测试环境没有显式注册 `afterEach(cleanup)`，使 Testing Library 的渲染树清理依赖隐式行为；
- hook 测试中的异步状态更新没有完全统一到 `act` / `waitFor`，导致 React state commit 与断言时机存在不确定性。

这会直接破坏测试的可预期性：断言本身可能通过，但进程不退出，影响本地调试、CI 稳定性以及后续测试基础设施演进。

## 具体实现

### 1. 修复 util harness 的循环依赖
修改：

- `apps/negentropy-ui/tests/helpers/knowledge-api.ts`

核心调整：

- 去掉对 `@/features/knowledge/utils/knowledge-api` 的顶层直接导入；
- 改为在 harness 构造过程中通过 `vi.importActual` 惰性获取真实导出；
- `createKnowledgeApiTestHarness` 改为异步装配，以便在 mock factory 中安全复用真实 helper。

这样既保留了“复用真实配置 helper”的设计目标，又切断了 util harness mock 自己时的循环依赖。

### 2. 显式补齐全局测试清理
修改：

- `apps/negentropy-ui/tests/setup.ts`

新增：

- `afterEach(cleanup)`

目的：

- 显式清理 Testing Library 渲染树；
- 避免依赖当前版本下 RTL/Vitest 的隐式自动清理行为；
- 降低 jsdom 树、effect、MutationObserver 等残留导致的退出不确定性。

### 3. 收敛 hook 单测的异步状态处理
修改：

- `apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx`
- `apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx`

具体做法：

- `useKnowledgeBase.test.tsx`
  - 将 `loadCorpora()` 包裹进 `act(async () => ...)`；
  - 补充 `waitFor(() => expect(result.current.isLoading).toBe(false))`，确保状态完全稳定后再断言。
- `useKnowledgeSearch.test.tsx`
  - 保留现有 `act` 包裹；
  - 对空查询、成功路径、失败路径补 `waitFor`，显式等待 `results` / `error` / `isSearching` 状态落稳。

这使 hook 测试与 React 异步状态更新的协调方式更符合 Testing Library 最佳实践。

### 4. 调整 util harness 契约测试
修改：

- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts`

因为 util harness 现在是异步装配，所以契约测试也同步改为 `await createKnowledgeApiTestHarness(...)`，继续验证：

- 真实 helper 复用未丢失；
- `exports` 与 `mocks` 仍绑定到同一组调用通道；
- override 行为保持稳定。

## 实现细节

这次修复延续了前一轮的测试分层原则，但把重点从“分层”进一步推进到“运行稳定性”：

- `knowledge-api` util harness 仍然作为 util-level 单测的单一 mock 入口；
- 真实配置 helper 仍继续复用生产实现，不回退到复制逻辑；
- 通过异步装配 + 显式 cleanup + `act`/`waitFor`，把之前的隐式时序依赖改成可观测、可验证的测试流程。

这是一次典型的测试稳定性修复，而不是功能行为变更。

## 验证结果

已验证以下测试链路可以正常通过并退出：

- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/useKnowledgeBase.test.tsx --reporter=verbose`
  - 1 个 test file / 2 个 tests passed
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/useKnowledgeSearch.test.tsx --reporter=verbose`
  - 1 个 test file / 3 个 tests passed
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/knowledge-api.test.ts tests/unit/knowledge/knowledge-api-test-harness.test.ts`
  - 2 个 test files / 13 个 tests passed
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/KnowledgeBasePage.test.tsx tests/unit/knowledge/PipelinesPage.test.tsx tests/unit/knowledge/ApiExecutor.test.ts`
  - 3 个 test files / 36 个 tests passed

## 影响范围与兼容性

- 不修改后端 API；
- 不修改页面运行时逻辑；
- 不改变 `useKnowledgeBase` / `useKnowledgeSearch` 的对外接口；
- 仅修复测试基础设施与 hook 单测的退出稳定性问题；
- 兼容现有 feature-level harness，不影响已通过的页面级回归测试。
