### PR TITLE
fix(knowledge): 修复文档抽取协议适配并补充设置说明;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1385,6 +1385,10 @@ function CorpusSettingsPanel({
             <p className="mt-1 text-xs text-muted">
               为当前 Knowledge Base 分别绑定 URL 与 PDF 的主备 MCP Server / Tool。已配置类型严格依赖所选 MCP，只会在主备之间切换。
             </p>
+            <p className="mt-2 text-[11px] leading-5 text-muted">
+              可用于此处的 Tool 需提供可发现的 input/output schema，并能返回正文 Markdown 或文本；当前兼容单文档扁平协议，以及单个
+              sources 数组的 batch 协议，系统会自动把单个 URL/PDF 请求包装为对应格式。
+            </p>
           </div>
         </div>
 

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -685,6 +685,9 @@ describe("KnowledgeBasePage", () => {
     expect(
       within(toolSelect).getByRole("option", { name: "已配置 Tool（当前不可用）" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/可用于此处的 Tool 需提供可发现的 input\/output schema/i),
+    ).toBeInTheDocument();
   });
 
   it("外部 corpus 刷新不会覆盖 settings 视图中未保存的 MCP 草稿", async () => {

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -72,6 +72,30 @@ class McpToolTarget:
     tool_options: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(slots=True)
+class CanonicalExtractionSource:
+    source_kind: SourceKind
+    url: str | None = None
+    filename: str | None = None
+    content_type: str | None = None
+    content_base64: str | None = None
+
+
+@dataclass(slots=True)
+class CanonicalExtractionRequest:
+    source_kind: SourceKind
+    source: CanonicalExtractionSource
+    options: dict[str, Any] = field(default_factory=dict)
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ExtractionToolAdapter:
+    name: str
+    arguments: dict[str, Any]
+    schema_summary: dict[str, Any] = field(default_factory=dict)
+
+
 def resolve_source_kind(*, source_uri: str | None = None, filename: str | None = None, content_type: str | None = None) -> SourceKind:
     if source_uri and (source_uri.startswith("http://") or source_uri.startswith("https://")):
         return ROUTE_URL
@@ -193,6 +217,199 @@ def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
     return assets
 
 
+def _schema_properties(schema: Any) -> dict[str, Any]:
+    if not isinstance(schema, dict):
+        return {}
+    properties = schema.get("properties")
+    return properties if isinstance(properties, dict) else {}
+
+
+def _schema_property_names(schema: Any) -> set[str]:
+    return set(_schema_properties(schema).keys())
+
+
+def _is_url_source_schema(schema: Any) -> bool:
+    properties = _schema_property_names(schema)
+    return "url" in properties or "uri" in properties
+
+
+def _is_file_source_schema(schema: Any) -> bool:
+    properties = _schema_property_names(schema)
+    return bool({"filename", "content_base64", "data_base64"} & properties)
+
+
+def _detect_batch_sources_property(*, input_schema: dict[str, Any] | None, source_kind: SourceKind) -> str | None:
+    properties = _schema_properties(input_schema)
+    preferred_keys = (
+        ("url_sources", "sources", "documents", "items")
+        if source_kind == ROUTE_URL
+        else ("pdf_sources", "sources", "documents", "items")
+    )
+    for name in preferred_keys:
+        schema = properties.get(name)
+        if not isinstance(schema, dict) or schema.get("type") != "array":
+            continue
+        item_schema = schema.get("items")
+        if source_kind == ROUTE_URL and _is_url_source_schema(item_schema):
+            return name
+        if source_kind != ROUTE_URL and _is_file_source_schema(item_schema):
+            return name
+    for name, schema in properties.items():
+        if not isinstance(schema, dict) or schema.get("type") != "array":
+            continue
+        item_schema = schema.get("items")
+        if source_kind == ROUTE_URL and _is_url_source_schema(item_schema):
+            return name
+        if source_kind != ROUTE_URL and _is_file_source_schema(item_schema):
+            return name
+    return None
+
+
+def _build_canonical_request(
+    *,
+    source_kind: SourceKind,
+    app_name: str,
+    corpus_id: UUID,
+    tool_options: dict[str, Any],
+    url: str | None,
+    content: bytes | None,
+    filename: str | None,
+    content_type: str | None,
+) -> CanonicalExtractionRequest:
+    return CanonicalExtractionRequest(
+        source_kind=source_kind,
+        source=CanonicalExtractionSource(
+            source_kind=source_kind,
+            url=url,
+            filename=filename,
+            content_type=content_type,
+            content_base64=base64.b64encode(content).decode("ascii") if content is not None else None,
+        ),
+        options=dict(tool_options),
+        context={
+            "app_name": app_name,
+            "corpus_id": str(corpus_id),
+        },
+    )
+
+
+def _filter_declared_fields(payload: dict[str, Any], schema: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(schema, dict):
+        return {}
+    allowed = _schema_property_names(schema)
+    if not allowed:
+        return {}
+    return {key: value for key, value in payload.items() if key in allowed}
+
+
+def _build_source_item(
+    *,
+    request: CanonicalExtractionRequest,
+    item_schema: dict[str, Any] | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    allowed = _schema_property_names(item_schema) if isinstance(item_schema, dict) else set()
+    if request.source_kind == ROUTE_URL:
+        url_value = request.source.url or ""
+        if not allowed or "url" in allowed:
+            payload["url"] = url_value
+        elif "uri" in allowed:
+            payload["uri"] = url_value
+    else:
+        base64_value = request.source.content_base64 or ""
+        if not allowed or "filename" in allowed:
+            payload["filename"] = request.source.filename
+        if not allowed or "content_type" in allowed:
+            payload["content_type"] = request.source.content_type
+        if not allowed or "content_base64" in allowed:
+            payload["content_base64"] = base64_value
+        elif "data_base64" in allowed:
+            payload["data_base64"] = base64_value
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def build_tool_adapter(
+    *,
+    input_schema: dict[str, Any] | None,
+    request: CanonicalExtractionRequest,
+) -> ExtractionToolAdapter:
+    batch_property = _detect_batch_sources_property(
+        input_schema=input_schema,
+        source_kind=request.source_kind,
+    )
+    if batch_property:
+        properties = _schema_properties(input_schema)
+        item_schema = properties.get(batch_property, {}).get("items")
+        arguments = {
+            batch_property: [_build_source_item(request=request, item_schema=item_schema)],
+        }
+        option_fields = _filter_declared_fields(request.options, properties.get("options"))
+        if option_fields and "options" in properties:
+            arguments["options"] = option_fields
+        context_fields = _filter_declared_fields(request.context, properties.get("context"))
+        if context_fields and "context" in properties:
+            arguments["context"] = context_fields
+        return ExtractionToolAdapter(
+            name="batch_sources_v1",
+            arguments=arguments,
+            schema_summary={
+                "batch_property": batch_property,
+                "top_level_fields": sorted(arguments.keys()),
+            },
+        )
+
+    arguments: dict[str, Any] = {
+        "source_type": request.source_kind,
+        "options": request.options,
+        "context": request.context,
+    }
+    if request.source.url:
+        arguments["url"] = request.source.url
+    if request.source.content_base64 is not None:
+        arguments["filename"] = request.source.filename
+        arguments["content_type"] = request.source.content_type
+        arguments["content_base64"] = request.source.content_base64
+    return ExtractionToolAdapter(
+        name="canonical_flat_v1",
+        arguments=arguments,
+        schema_summary={"top_level_fields": sorted(arguments.keys())},
+    )
+
+
+def _looks_like_document_payload(payload: Any) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    return any(
+        key in payload
+        for key in ("markdown", "markdown_content", "text", "plain_text", "assets", "metadata")
+    )
+
+
+def _extract_document_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    if _looks_like_document_payload(payload):
+        return payload
+    for key in ("result", "document", "data"):
+        candidate = payload.get(key)
+        if _looks_like_document_payload(candidate):
+            return candidate
+    for key in ("results", "items", "documents"):
+        candidates = payload.get(key)
+        if not isinstance(candidates, list):
+            continue
+        for item in candidates:
+            if not isinstance(item, dict):
+                continue
+            status = str(item.get("status") or "").lower()
+            if item.get("success") is False or status in {"failed", "error"}:
+                continue
+            direct = _extract_document_payload(item)
+            if direct:
+                return direct
+    return payload
+
+
 async def _increment_tool_call_count(*, server_id: UUID, tool_name: str) -> None:
     async with AsyncSessionLocal() as db:
         await db.execute(
@@ -289,6 +506,7 @@ class DataExtractorProvider:
                 result.trace = {
                     "provider": "mcp",
                     "source_kind": source_kind,
+                    **(result.trace if isinstance(result.trace, dict) else {}),
                     "selected_target": {"server_id": str(target.server_id), "tool_name": target.tool_name},
                     "attempts": [item.__dict__ for item in attempts],
                 }
@@ -339,6 +557,7 @@ class DataExtractorProvider:
         filename: str | None,
         content_type: str | None,
     ) -> dict[str, Any]:
+        tool: McpTool | None = None
         async with AsyncSessionLocal() as db:
             server = await db.get(McpServer, target.server_id)
             if not server or not server.is_enabled:
@@ -372,25 +591,25 @@ class DataExtractorProvider:
                     ),
                 }
 
-        arguments: dict[str, Any] = {
-            "source_type": source_kind,
-            "options": target.tool_options,
-            "context": {
-                "app_name": app_name,
-                "corpus_id": str(corpus_id),
-            },
-        }
-        if url:
-            arguments["url"] = url
-        if content is not None:
-            arguments["filename"] = filename
-            arguments["content_type"] = content_type
-            arguments["content_base64"] = base64.b64encode(content).decode("ascii")
+        request = _build_canonical_request(
+            source_kind=source_kind,
+            app_name=app_name,
+            corpus_id=corpus_id,
+            tool_options=target.tool_options,
+            url=url,
+            content=content,
+            filename=filename,
+            content_type=content_type,
+        )
+        adapter = build_tool_adapter(
+            input_schema=tool.input_schema if tool else None,
+            request=request,
+        )
 
         result = await self._client.call_tool(
             transport_type=server.transport_type,
             tool_name=target.tool_name,
-            arguments=arguments,
+            arguments=adapter.arguments,
             command=server.command,
             args=server.args,
             env=server.env,
@@ -411,7 +630,9 @@ class DataExtractorProvider:
         if not result.success:
             return {"success": False, "attempt": attempt}
 
-        payload = _parse_structured_payload(result.structured_content, result.content)
+        payload = _extract_document_payload(
+            _parse_structured_payload(result.structured_content, result.content)
+        )
         markdown = str(payload.get("markdown") or payload.get("markdown_content") or "").strip()
         plain_text = str(payload.get("text") or payload.get("plain_text") or "").strip()
         if not markdown and plain_text:
@@ -437,8 +658,15 @@ class DataExtractorProvider:
             "result": ExtractedDocumentResult(
                 plain_text=plain_text,
                 markdown_content=markdown,
-                metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
+                metadata={
+                    **(payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}),
+                    "adapter_name": adapter.name,
+                },
                 assets=_normalize_assets(payload.get("assets")),
+                trace={
+                    "adapter_name": adapter.name,
+                    "adapter_schema_summary": adapter.schema_summary,
+                },
             ),
         }
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction.py
@@ -1,10 +1,13 @@
 from uuid import uuid4
 
 import pytest
+from types import SimpleNamespace
 
 from negentropy.knowledge.extraction import (
     ROUTE_FILE_PDF,
     ROUTE_URL,
+    DataExtractorProvider,
+    build_tool_adapter,
     extract_source,
     resolve_source_kind,
     resolve_targets,
@@ -63,3 +66,170 @@ async def test_extract_source_uses_legacy_provider_without_routes(monkeypatch: p
     assert result.plain_text == "legacy text"
     assert result.markdown_content == "legacy markdown"
     assert result.trace["provider"] == "legacy"
+
+
+def test_build_tool_adapter_wraps_pdf_request_into_batch_sources_schema() -> None:
+    request = build_tool_adapter(
+        input_schema={
+            "type": "object",
+            "properties": {
+                "pdf_sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "filename": {"type": "string"},
+                            "content_type": {"type": "string"},
+                            "content_base64": {"type": "string"},
+                        },
+                    },
+                },
+                "options": {
+                    "type": "object",
+                    "properties": {
+                        "ocr": {"type": "boolean"},
+                    },
+                },
+            },
+        },
+        request=SimpleNamespace(
+            source_kind=ROUTE_FILE_PDF,
+            source=SimpleNamespace(
+                url=None,
+                filename="report.pdf",
+                content_type="application/pdf",
+                content_base64="cGRm",
+            ),
+            options={"ocr": True, "ignored": "value"},
+            context={"app_name": "negentropy", "corpus_id": "cid"},
+        ),
+    )
+
+    assert request.name == "batch_sources_v1"
+    assert request.arguments == {
+        "pdf_sources": [
+            {
+                "filename": "report.pdf",
+                "content_type": "application/pdf",
+                "content_base64": "cGRm",
+            }
+        ],
+        "options": {"ocr": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_data_extractor_provider_uses_pdf_batch_schema_and_normalizes_batch_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server_id = uuid4()
+    captured_arguments: dict[str, object] = {}
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, model, key):  # type: ignore[no-untyped-def]
+            _ = (model, key)
+            return SimpleNamespace(
+                id=server_id,
+                name="pdf-extractor",
+                is_enabled=True,
+                transport_type="http",
+                command=None,
+                args=[],
+                env={},
+                url="https://example.com/mcp",
+                headers={},
+            )
+
+        async def scalar(self, stmt):  # type: ignore[no-untyped-def]
+            _ = stmt
+            return SimpleNamespace(
+                is_enabled=True,
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "pdf_sources": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "filename": {"type": "string"},
+                                    "content_type": {"type": "string"},
+                                    "content_base64": {"type": "string"},
+                                },
+                            },
+                        },
+                    },
+                },
+            )
+
+    class FakeClient:
+        async def call_tool(self, **kwargs):  # type: ignore[no-untyped-def]
+            captured_arguments.update(kwargs["arguments"])
+            return SimpleNamespace(
+                success=True,
+                structured_content={
+                    "results": [
+                        {
+                            "success": True,
+                            "result": {
+                                "markdown_content": "# Title",
+                                "plain_text": "Title",
+                                "metadata": {"provider": "batch"},
+                            },
+                        }
+                    ]
+                },
+                content=[],
+                error=None,
+                duration_ms=18,
+            )
+
+    async def fake_increment_tool_call_count(**_: object) -> None:
+        return None
+
+    monkeypatch.setattr("negentropy.knowledge.extraction.AsyncSessionLocal", lambda: FakeSession())
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._increment_tool_call_count",
+        fake_increment_tool_call_count,
+    )
+
+    provider = DataExtractorProvider()
+    provider._client = FakeClient()
+
+    result = await provider._invoke_target(
+        app_name="negentropy",
+        corpus_id=uuid4(),
+        target=SimpleNamespace(
+            server_id=server_id,
+            tool_name="batch_convert_pdfs_to_markdown",
+            timeout_ms=None,
+            tool_options={},
+        ),
+        source_kind=ROUTE_FILE_PDF,
+        url=None,
+        content=b"%PDF-1.5",
+        filename="report.pdf",
+        content_type="application/pdf",
+    )
+
+    assert result["success"] is True
+    assert captured_arguments == {
+        "pdf_sources": [
+            {
+                "filename": "report.pdf",
+                "content_type": "application/pdf",
+                "content_base64": "JVBERi0xLjU=",
+            }
+        ]
+    }
+    extracted = result["result"]
+    assert extracted.markdown_content == "# Title"
+    assert extracted.plain_text == "Title"
+    assert extracted.metadata["provider"] == "batch"
+    assert extracted.metadata["adapter_name"] == "batch_sources_v1"


### PR DESCRIPTION
## 变更内容
- 在 Knowledge Base 文档抽取链路中引入内部统一的 extraction 请求模型，收敛 URL 与 PDF 的 Documents Extraction 入参边界。
- 基于 MCP Tool 的 `input_schema` 自动适配两类协议：现有扁平单文档协议，以及单个 `sources` 数组的 batch 协议。
- 对 batch Tool 的返回结果增加统一解包与归一化逻辑，能够从 `results` / `items` / `documents` 等结构中提取首个成功文档结果。
- 在 Knowledge Base 的 `Document Extraction Settings` 区域补充精简说明，明确可用于此处的 MCP Tool 需要提供可发现的 schema，并说明当前兼容的协议形态。
- 补充后端 extraction 单测与前端页面单测，覆盖 PDF batch schema 适配和设置页协议说明回显。

## 变更原因
在 Deep Research corpus 中执行 PDF `Ingest from File` 时，外部 MCP Tool `batch_convert_pdfs_to_markdown` 期望接收 `pdf_sources` 参数；旧实现将内部扁平字段（如 `source_type`、`filename`、`content_base64`）直接透传给 Tool，导致出现 `pdf_sources missing` 与多个 `unexpected keyword argument` 校验错误。

本次修复的目标不是仅兼容单个 Tool，而是在 Knowledge Base 的 Documents Extraction 层建立稳定的协议适配边界，使 URL / PDF 两类文档摄取都能复用任意同类 MCP Server Tool，避免后续继续把外部 Tool 的 schema 差异泄漏到内部逻辑。

## 关键实现细节
- 适配逻辑集中在 `apps/negentropy/src/negentropy/knowledge/extraction.py`，继续作为 Documents Extraction 的单一事实源。
- 适配器依据 Tool schema 选择参数包装方式，而不是对某个 Tool 名称硬编码分支，采用典型 Adapter / Anti-Corruption Layer 思路隔离外部契约差异。
- 对于没有 schema 或 schema 无法识别的 Tool，仍保留原有扁平调用路径，降低对既有 MCP 配置的兼容性风险。
- UI 侧仅增加协议要求说明，不引入新的配置项或额外操作负担。

## 验证
- `uv run --group dev pytest tests/unit_tests/knowledge/test_extraction.py tests/unit_tests/knowledge/test_api_document_routes.py`
- `pnpm exec vitest run tests/unit/knowledge/KnowledgeBasePage.test.tsx`
