### PR TITLE
test(knowledge): 补强 util harness 冷启动契约测试;

### DIFF
--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
@@ -8,6 +8,23 @@ import {
 } from "@/tests/helpers/knowledge-api";
 
 describe("knowledge api test harness", () => {
+  it("冷启动时也能完成异步装配，不会因循环依赖卡住", async () => {
+    const mocks = createKnowledgeApiMockSet();
+    const harness = await createKnowledgeApiTestHarness(mocks);
+
+    expect(harness.exports.createDefaultChunkingConfig).toBeDefined();
+    expect(harness.exports.normalizeChunkingConfig).toBeDefined();
+    expect(harness.exports.buildCorpusConfig).toBeDefined();
+
+    const fetchCorpus = harness.exports.fetchCorpus as (...args: unknown[]) => unknown;
+    fetchCorpus("cold-start-corpus", "negentropy");
+
+    expect(mocks.fetchCorpusMock).toHaveBeenCalledWith(
+      "cold-start-corpus",
+      "negentropy",
+    );
+  });
+
   it("默认复用真实配置 helper，并把 exports 与 mocks 绑定到同一组函数", async () => {
     const mocks = createKnowledgeApiMockSet();
     const harness = await createKnowledgeApiTestHarness(mocks);


### PR DESCRIPTION
## 变更说明

本次改动只包含一项测试补强：

- 为 `knowledge-api` util harness 新增一条冷启动 smoke test，用于验证异步装配在未预热场景下也能完成，不会再次因为循环依赖卡住。

## 为什么要改

上一轮已经完成了 `knowledge-api` util harness 的异步装配修复，并且通过单文件 `vitest` 运行确认了 `useKnowledgeBase` / `useKnowledgeSearch` 单测可以正常通过并退出。

但从防回归角度看，原有契约测试仍然有一个薄弱点：

- 它验证了 harness 会复用真实 helper、mock 通道与 override 行为正常；
- 但没有直接锁住“冷启动场景下，异步装配本身不会再次形成循环依赖并卡死”。

这类问题很容易在后续重构中被无意引回，例如有人再次把真实 `knowledge-api` 导出顶层导入到 util harness 中。为了把这条最关键的稳定性边界显式固化下来，本次 PR 新增了一条更直接的冷启动 smoke test。

## 具体实现

修改文件：

- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts`

新增测试重点验证：

1. 在不依赖额外预热前提下，`await createKnowledgeApiTestHarness(createKnowledgeApiMockSet())` 可以直接完成；
2. 返回的 `exports` 中，真实配置 helper 已经可用，例如：
   - `createDefaultChunkingConfig`
   - `normalizeChunkingConfig`
   - `buildCorpusConfig`
3. mock API 导出仍然绑定到同一组 `mocks`，说明异步装配没有破坏现有契约。

这条测试的目的不是扩大功能覆盖，而是把“异步装配不会卡住”本身作为正式契约固定下来。

## 实现细节

这次补强延续了前一轮的单一事实源原则：

- `knowledge-api` util harness 继续通过异步装配复用真实 helper；
- 契约测试继续承担“边界不漂移”的职责；
- 新增的 smoke test 专门覆盖之前最容易被忽略的冷启动路径。

换句话说，这个 PR 是在补“稳定性证据”，而不是在增加新的行为分支。

## 验证结果

已验证：

- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/knowledge-api-test-harness.test.ts --reporter=verbose`
  - 1 个 test file / 3 个 tests passed

同时相关 hook 单测也保持通过并正常退出：

- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/useKnowledgeBase.test.tsx --reporter=verbose`
  - 1 个 test file / 2 个 tests passed
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/useKnowledgeSearch.test.tsx --reporter=verbose`
  - 1 个 test file / 3 个 tests passed

## 影响范围与兼容性

- 不修改任何生产代码；
- 不修改 hook 行为；
- 仅补强 util harness 的防回归测试证据；
- 不影响现有 `knowledge` 页面级与 hook 级测试结构。
