### PR TITLE
fix(test): 修复知识API测试辅助类型错误;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -1,18 +1,30 @@
+import { vi, type Mock } from "vitest";
+import {
+  buildCorpusConfig,
+  buildExtractorRoutesFromDraft,
+  createDefaultChunkingConfig,
+  createEmptyExtractorDraftTarget,
+  normalizeChunkingConfig,
+  normalizeCorpusExtractorRoutes,
+  normalizeExtractorDraftRoutes,
+} from "@/features/knowledge/utils/knowledge-api";
+
+type VitestMock = Mock<(...args: unknown[]) => unknown>;
 export interface KnowledgeApiMockSet {
-  fetchCorpusMock: ReturnType<typeof vi.fn>;
-  fetchCorporaMock: ReturnType<typeof vi.fn>;
-  createCorpusMock: ReturnType<typeof vi.fn>;
-  updateCorpusMock: ReturnType<typeof vi.fn>;
-  deleteCorpusMock: ReturnType<typeof vi.fn>;
-  ingestTextMock: ReturnType<typeof vi.fn>;
-  ingestUrlMock: ReturnType<typeof vi.fn>;
-  ingestFileMock: ReturnType<typeof vi.fn>;
-  replaceSourceMock: ReturnType<typeof vi.fn>;
-  syncSourceMock: ReturnType<typeof vi.fn>;
-  rebuildSourceMock: ReturnType<typeof vi.fn>;
-  deleteSourceMock: ReturnType<typeof vi.fn>;
-  archiveSourceMock: ReturnType<typeof vi.fn>;
-  searchKnowledgeMock: ReturnType<typeof vi.fn>;
+  fetchCorpusMock: VitestMock;
+  fetchCorporaMock: VitestMock;
+  createCorpusMock: VitestMock;
+  updateCorpusMock: VitestMock;
+  deleteCorpusMock: VitestMock;
+  ingestTextMock: VitestMock;
+  ingestUrlMock: VitestMock;
+  ingestFileMock: VitestMock;
+  replaceSourceMock: VitestMock;
+  syncSourceMock: VitestMock;
+  rebuildSourceMock: VitestMock;
+  deleteSourceMock: VitestMock;
+  archiveSourceMock: VitestMock;
+  searchKnowledgeMock: VitestMock;
 }
 
 export interface KnowledgeApiTestHarness {


### PR DESCRIPTION
## 背景
- 这次变更来自 `vk/98ac-github-actions-w` rebase 到 `feature/1.0.0` 时对 `apps/negentropy-ui/tests/helpers/knowledge-api.ts` 的冲突修复。
- 冲突的核心不是业务逻辑分歧，而是同一测试辅助文件上叠加了两类演进：
  - 基线分支已经把 knowledge API test harness 演进为异步 `importActual` / async harness 结构
  - 当前分支补充了 Vitest mock 在严格 TypeScript 下所需的类型修复
- 本 PR 的目标是保留基线当前正确的 helper 行为结构，同时吸收必要的类型兼容修复，确保 merge-ref 构建可通过。

## 核心变更
- 在 `tests/helpers/knowledge-api.ts` 中显式引入 `import { vi, type Mock } from "vitest"`。
- 新增统一的 `VitestMock` 别名，并将 `KnowledgeApiMockSet` 全部字段从 `ReturnType<typeof vi.fn>` 收敛为 `VitestMock`。
- 保留基线已有的异步 helper 结构：
  - `importKnowledgeApiActual`
  - `async createKnowledgeApiConfigTestExports`
  - `async createKnowledgeApiTestHarness`
- 不改变 helper 对外导出的键名、mock 名称或测试调用方式。

## 变更原因
- 目标是修复 rebase 合并态下的知识测试辅助类型漂移，避免 `typeof vi.fn` 与 mock 可调用性问题在严格 TypeScript 和 Next.js build 的 merge-ref 检查中再次暴露。
- 这次修复属于测试基础设施稳定性加固，不改变任何业务逻辑、页面行为或 session BFF 功能。

## 重要实现细节
- 冲突解决采用“保留 HEAD 的 async 行为结构 + 吸收待重放提交的类型修复”的语义并集，而不是回退为同步旧版本。
- `VitestMock` 的处理方式与仓库内其他 knowledge test helper 的类型收敛方向保持一致，避免再次出现 split-brain。
- 变更范围被严格限制在测试辅助文件，不扩大到 hooks、knowledge API 实现或页面组件。

## 验证证据
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/useKnowledgeBase.test.tsx tests/unit/knowledge/useKnowledgeSearch.test.tsx tests/unit/knowledge/knowledge-test-harness.test.ts tests/unit/knowledge/knowledge-api-test-harness.test.ts tests/unit/api/agui-session-request.test.ts tests/unit/api/agui-session-response.test.ts tests/integration/api.test.ts`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 覆盖结果：41 个测试文件 / 227 个测试全部通过

## Next Best Action
- 继续把 knowledge 测试辅助里剩余 `ReturnType<typeof vi.fn>` 的用法统一收敛到显式 `Mock` 别名，避免未来再次在 rebase / merge-ref 构建阶段暴露类型漂移。
