### PR TITLE
test(knowledge): 收紧 util harness 冷启动防回归边界;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -1,13 +1,4 @@
 import { vi, type Mock } from "vitest";
-import {
-  buildCorpusConfig,
-  buildExtractorRoutesFromDraft,
-  createDefaultChunkingConfig,
-  createEmptyExtractorDraftTarget,
-  normalizeChunkingConfig,
-  normalizeCorpusExtractorRoutes,
-  normalizeExtractorDraftRoutes,
-} from "@/features/knowledge/utils/knowledge-api";
 
 type VitestMock = Mock<(...args: unknown[]) => unknown>;
 export interface KnowledgeApiMockSet {
@@ -32,7 +23,9 @@ export interface KnowledgeApiTestHarness {
   mocks: KnowledgeApiMockSet;
 }
 
-export async function importKnowledgeApiActual() {
+export async function importKnowledgeApiActual(): Promise<
+  typeof import("@/features/knowledge/utils/knowledge-api")
+> {
   return vi.importActual<typeof import("@/features/knowledge/utils/knowledge-api")>(
     "@/features/knowledge/utils/knowledge-api",
   );

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
@@ -1,9 +1,6 @@
 import {
-  buildCorpusConfig,
-  createDefaultChunkingConfig,
-} from "@/features/knowledge/utils/knowledge-api";
-import {
   createKnowledgeApiMockSet,
+  importKnowledgeApiActual,
   createKnowledgeApiTestHarness,
 } from "@/tests/helpers/knowledge-api";
 
@@ -27,12 +24,13 @@ describe("knowledge api test harness", () => {
 
   it("默认复用真实配置 helper，并把 exports 与 mocks 绑定到同一组函数", async () => {
     const mocks = createKnowledgeApiMockSet();
+    const actual = await importKnowledgeApiActual();
     const harness = await createKnowledgeApiTestHarness(mocks);
 
     expect(harness.exports.createDefaultChunkingConfig).toBe(
-      createDefaultChunkingConfig,
+      actual.createDefaultChunkingConfig,
     );
-    expect(harness.exports.buildCorpusConfig).toBe(buildCorpusConfig);
+    expect(harness.exports.buildCorpusConfig).toBe(actual.buildCorpusConfig);
 
     const fetchCorpus = harness.exports.fetchCorpus as (...args: unknown[]) => unknown;
     fetchCorpus("corpus-1", "negentropy");
@@ -43,6 +41,7 @@ describe("knowledge api test harness", () => {
   it("允许局部 override，而不会污染真实 helper 导出", async () => {
     const mocks = createKnowledgeApiMockSet();
     const overrideSearchKnowledge = vi.fn();
+    const actual = await importKnowledgeApiActual();
     const harness = await createKnowledgeApiTestHarness(mocks, {
       searchKnowledge: overrideSearchKnowledge,
     });
@@ -50,7 +49,7 @@ describe("knowledge api test harness", () => {
     expect(harness.exports.searchKnowledge).toBe(overrideSearchKnowledge);
     expect(harness.exports.normalizeChunkingConfig).toBeDefined();
     expect(harness.exports.createDefaultChunkingConfig).toBe(
-      createDefaultChunkingConfig,
+      actual.createDefaultChunkingConfig,
     );
   });
 });


### PR DESCRIPTION
## 变更说明

本次改动只聚焦 `knowledge-api` util harness 的冷启动防回归边界收紧，包含两项测试侧收口：

1. 去掉 util harness 中对真实 `knowledge-api` 模块的文件级静态预热依赖；
2. 调整 `knowledge-api-test-harness` 契约测试，使“冷启动 smoke test”真正运行在未预热场景下。

## 为什么要改

上一轮已经引入了 `knowledge-api` util harness，并补了 cold-start smoke test，用来防止异步装配再次因为循环依赖卡住。

但进一步复核后发现，当时的“冷启动”证据还不够严格，存在两个隐患：

- `tests/helpers/knowledge-api.ts` 仍然在文件顶部静态导入真实 `@/features/knowledge/utils/knowledge-api` 导出，这会让 util harness 自身继续带着运行时预热依赖；
- `knowledge-api-test-harness.test.ts` 在文件顶部直接导入真实 helper，导致所谓“冷启动”测试实际上已经预热了目标模块，无法真正覆盖未预热场景。

这意味着测试虽然能通过，但没有把最关键的防回归边界锁死：**如果后续有人再次把真实 `knowledge-api` 导出放回顶层导入，现有 smoke test 可能依然通过，却无法第一时间暴露 cold-start 退化。**

因此本次改动的目标不是增加新功能，而是把“异步装配在未预热场景下也不会重新形成循环依赖”固化为更严格的契约。

## 具体实现

### 1. 收紧 util harness 的真实依赖获取方式
修改：

- `apps/negentropy-ui/tests/helpers/knowledge-api.ts`

关键调整：

- 删除顶层对真实 `@/features/knowledge/utils/knowledge-api` 的静态导入；
- 真实 helper 一律通过 `vi.importActual` 在异步装配阶段获取；
- `createKnowledgeApiConfigTestExports()` 继续作为真实配置 helper 的唯一装配入口。

这样 util harness 本身不再持有文件级运行时预热依赖，更符合“单一事实源 + 惰性装配”的测试基础设施设计。

### 2. 让 cold-start smoke test 真正覆盖未预热场景
修改：

- `apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts`

关键调整：

- 删除文件顶部对真实 `knowledge-api` helper 的直接导入；
- 第一条 cold-start smoke test 只依赖：
  - `createKnowledgeApiMockSet`
  - `createKnowledgeApiTestHarness`
- 对“真实 helper 复用”相关断言，改为在测试体内部通过 `importKnowledgeApiActual()` 异步获取真实模块，再做引用一致性校验。

这样测试就不会在文件加载阶段提前预热目标模块，能够更真实地锁定 cold-start 装配路径。

## 实现细节

这次收紧遵循了测试基础设施的一条核心原则：**不要让契约测试自己绕开它想要保护的边界。**

具体来说：

- util harness 继续复用真实配置 helper，不复制生产逻辑；
- 但真实 helper 的获取必须延后到异步装配阶段，避免顶层依赖穿透；
- cold-start 契约测试必须避免任何文件级真实模块导入，否则 smoke test 会退化成“预热后仍可用”的弱验证。

这属于典型的测试可靠性修复，而不是行为变更。

## 验证结果

已验证以下单文件测试通过：

- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/knowledge-api-test-harness.test.ts --reporter=verbose`
  - 1 个 test file / 3 个 tests passed
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/useKnowledgeBase.test.tsx --reporter=verbose`
  - 1 个 test file / 2 个 tests passed
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/useKnowledgeSearch.test.tsx --reporter=verbose`
  - 1 个 test file / 3 个 tests passed

重点确认点是：

- cold-start harness 契约测试仍通过；
- 两组 hook 单测继续通过且 runner 正常退出，没有因这次去预热调整而回退。

## 影响范围与兼容性

- 不修改任何生产代码；
- 不修改 hook 或页面行为；
- 仅收紧 util harness 与契约测试的冷启动防回归边界；
- 不影响现有 `knowledge` feature-level / util-level 测试分层结构。
