### PR TITLE
test(knowledge): 收敛测试辅助mock装配来源;

### DIFF
--- a/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
@@ -1,26 +1,12 @@
-const knowledgeMocks = vi.hoisted(() => ({
-  searchKnowledgeMock: vi.fn(),
-  ingestTextMock: vi.fn(),
-  ingestUrlMock: vi.fn(),
-  replaceSourceMock: vi.fn(),
-  fetchKnowledgeItemsMock: vi.fn(),
-  createCorpusMock: vi.fn(),
-  deleteCorpusMock: vi.fn(),
-  fetchPipelinesMock: vi.fn(),
-  upsertPipelinesMock: vi.fn(),
-  fetchDocumentsMock: vi.fn(),
-  fetchDocumentChunksMock: vi.fn(),
-  searchAcrossCorporaMock: vi.fn(),
-  syncDocumentMock: vi.fn(),
-  rebuildDocumentMock: vi.fn(),
-  replaceDocumentMock: vi.fn(),
-  archiveDocumentMock: vi.fn(),
-  unarchiveDocumentMock: vi.fn(),
-  downloadDocumentMock: vi.fn(),
-  deleteDocumentMock: vi.fn(),
-}));
+import type { KnowledgeFeatureMockSet } from "@/tests/helpers/knowledge";
+
+const knowledgeMocks = vi.hoisted(() => ({}) as KnowledgeFeatureMockSet);
+
 vi.mock("@/features/knowledge", async () => {
-  const { createKnowledgeFeatureTestHarness } = await import("@/tests/helpers/knowledge");
+  const { createKnowledgeFeatureMockSet, createKnowledgeFeatureTestHarness } = await import(
+    "@/tests/helpers/knowledge"
+  );
+  Object.assign(knowledgeMocks, createKnowledgeFeatureMockSet());
   return createKnowledgeFeatureTestHarness(knowledgeMocks).exports;
 });
 

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1,12 +1,10 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { KnowledgeFeatureMockSet } from "@/tests/helpers/knowledge";
 
 const {
   replaceMock,
   useKnowledgeBaseMock,
-  loadCorpusMock,
-  loadCorporaMock,
-  updateCorpusMock,
   deleteCorpusMock,
   deleteDocumentMock,
   ingestUrlMock,
@@ -26,9 +24,6 @@ const {
 } = vi.hoisted(() => ({
   replaceMock: vi.fn(),
   useKnowledgeBaseMock: vi.fn(),
-  loadCorpusMock: vi.fn(),
-  loadCorporaMock: vi.fn(),
-  updateCorpusMock: vi.fn(),
   deleteCorpusMock: vi.fn(),
   deleteDocumentMock: vi.fn(),
   ingestUrlMock: vi.fn(),
@@ -48,6 +43,11 @@ const {
     value: "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents",
   },
 }));
+
+const knowledgeMocks = vi.hoisted(() => ({}) as KnowledgeFeatureMockSet);
+const loadCorpusMock = vi.fn();
+const loadCorporaMock = vi.fn();
+const updateCorpusMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
@@ -75,30 +75,24 @@ vi.mock("@/app/knowledge/base/_components/ReplaceDocumentDialog", () => ({
 }));
 
 vi.mock("@/features/knowledge", async () => {
-  const { createKnowledgeFeatureTestHarness } = await import("@/tests/helpers/knowledge");
-  return createKnowledgeFeatureTestHarness(
-    {
-      searchKnowledgeMock: vi.fn(),
-      ingestTextMock: vi.fn(),
-      ingestUrlMock,
-      replaceSourceMock: vi.fn(),
-      fetchKnowledgeItemsMock: vi.fn(),
-      createCorpusMock: vi.fn(),
-      deleteCorpusMock,
-      fetchPipelinesMock: vi.fn(),
-      upsertPipelinesMock: vi.fn(),
-      fetchDocumentsMock,
-      fetchDocumentChunksMock,
-      searchAcrossCorporaMock,
-      syncDocumentMock,
-      rebuildDocumentMock,
-      replaceDocumentMock: replaceDocumentFeatureMock,
-      archiveDocumentMock,
-      unarchiveDocumentMock,
-      downloadDocumentMock,
-      deleteDocumentMock,
-    },
-    {
+  const { createKnowledgeFeatureMockSet, createKnowledgeFeatureTestHarness } = await import(
+    "@/tests/helpers/knowledge"
+  );
+  Object.assign(knowledgeMocks, createKnowledgeFeatureMockSet());
+  knowledgeMocks.ingestUrlMock = ingestUrlMock;
+  knowledgeMocks.deleteCorpusMock = deleteCorpusMock;
+  knowledgeMocks.fetchDocumentsMock = fetchDocumentsMock;
+  knowledgeMocks.fetchDocumentChunksMock = fetchDocumentChunksMock;
+  knowledgeMocks.searchAcrossCorporaMock = searchAcrossCorporaMock;
+  knowledgeMocks.syncDocumentMock = syncDocumentMock;
+  knowledgeMocks.rebuildDocumentMock = rebuildDocumentMock;
+  knowledgeMocks.replaceDocumentMock = replaceDocumentFeatureMock;
+  knowledgeMocks.archiveDocumentMock = archiveDocumentMock;
+  knowledgeMocks.unarchiveDocumentMock = unarchiveDocumentMock;
+  knowledgeMocks.downloadDocumentMock = downloadDocumentMock;
+  knowledgeMocks.deleteDocumentMock = deleteDocumentMock;
+
+  return createKnowledgeFeatureTestHarness(knowledgeMocks, {
       useKnowledgeBase: (...args: unknown[]) => useKnowledgeBaseMock(...args),
       DocumentViewDialog: ({
         isOpen,

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
@@ -1,32 +1,17 @@
 import { act, render, screen } from "@testing-library/react";
+import type { KnowledgeFeatureMockSet } from "@/tests/helpers/knowledge";
 
-const knowledgeMocks = vi.hoisted(() => ({
-  searchKnowledgeMock: vi.fn(),
-  ingestTextMock: vi.fn(),
-  ingestUrlMock: vi.fn(),
-  replaceSourceMock: vi.fn(),
-  fetchKnowledgeItemsMock: vi.fn(),
-  createCorpusMock: vi.fn(),
-  deleteCorpusMock: vi.fn(),
-  fetchPipelinesMock: vi.fn(),
-  upsertPipelinesMock: vi.fn(),
-  fetchDocumentsMock: vi.fn(),
-  fetchDocumentChunksMock: vi.fn(),
-  searchAcrossCorporaMock: vi.fn(),
-  syncDocumentMock: vi.fn(),
-  rebuildDocumentMock: vi.fn(),
-  replaceDocumentMock: vi.fn(),
-  archiveDocumentMock: vi.fn(),
-  unarchiveDocumentMock: vi.fn(),
-  downloadDocumentMock: vi.fn(),
-  deleteDocumentMock: vi.fn(),
-}));
+const knowledgeMocks = vi.hoisted(() => ({}) as KnowledgeFeatureMockSet);
+
 vi.mock("@/components/ui/KnowledgeNav", () => ({
   KnowledgeNav: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
 vi.mock("@/features/knowledge", async () => {
-  const { createKnowledgeFeatureTestHarness } = await import("@/tests/helpers/knowledge");
+  const { createKnowledgeFeatureMockSet, createKnowledgeFeatureTestHarness } = await import(
+    "@/tests/helpers/knowledge"
+  );
+  Object.assign(knowledgeMocks, createKnowledgeFeatureMockSet());
   return createKnowledgeFeatureTestHarness(knowledgeMocks).exports;
 });
 

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
@@ -1,24 +1,13 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import type { KnowledgeApiMockSet } from "@/tests/helpers/knowledge-api";
 
-const knowledgeApiMocks = vi.hoisted(() => ({
-  fetchCorpusMock: vi.fn(),
-  fetchCorporaMock: vi.fn(),
-  createCorpusMock: vi.fn(),
-  updateCorpusMock: vi.fn(),
-  deleteCorpusMock: vi.fn(),
-  ingestTextMock: vi.fn(),
-  ingestUrlMock: vi.fn(),
-  ingestFileMock: vi.fn(),
-  replaceSourceMock: vi.fn(),
-  syncSourceMock: vi.fn(),
-  rebuildSourceMock: vi.fn(),
-  deleteSourceMock: vi.fn(),
-  archiveSourceMock: vi.fn(),
-  searchKnowledgeMock: vi.fn(),
-}));
+const knowledgeApiMocks = vi.hoisted(() => ({}) as KnowledgeApiMockSet);
 
 vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
-  const { createKnowledgeApiTestHarness } = await import("@/tests/helpers/knowledge-api");
+  const { createKnowledgeApiMockSet, createKnowledgeApiTestHarness } = await import(
+    "@/tests/helpers/knowledge-api"
+  );
+  Object.assign(knowledgeApiMocks, createKnowledgeApiMockSet());
   return (await createKnowledgeApiTestHarness(knowledgeApiMocks)).exports;
 });
 

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
@@ -1,24 +1,13 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
+import type { KnowledgeApiMockSet } from "@/tests/helpers/knowledge-api";
 
-const knowledgeApiMocks = vi.hoisted(() => ({
-  fetchCorpusMock: vi.fn(),
-  fetchCorporaMock: vi.fn(),
-  createCorpusMock: vi.fn(),
-  updateCorpusMock: vi.fn(),
-  deleteCorpusMock: vi.fn(),
-  ingestTextMock: vi.fn(),
-  ingestUrlMock: vi.fn(),
-  ingestFileMock: vi.fn(),
-  replaceSourceMock: vi.fn(),
-  syncSourceMock: vi.fn(),
-  rebuildSourceMock: vi.fn(),
-  deleteSourceMock: vi.fn(),
-  archiveSourceMock: vi.fn(),
-  searchKnowledgeMock: vi.fn(),
-}));
+const knowledgeApiMocks = vi.hoisted(() => ({}) as KnowledgeApiMockSet);
 
 vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
-  const { createKnowledgeApiTestHarness } = await import("@/tests/helpers/knowledge-api");
+  const { createKnowledgeApiMockSet, createKnowledgeApiTestHarness } = await import(
+    "@/tests/helpers/knowledge-api"
+  );
+  Object.assign(knowledgeApiMocks, createKnowledgeApiMockSet());
   return (await createKnowledgeApiTestHarness(knowledgeApiMocks)).exports;
 });
 


### PR DESCRIPTION
## 背景
- knowledge 测试辅助层已经把 `KnowledgeFeatureMockSet` 和 `KnowledgeApiMockSet` 收敛到显式 `Mock` 类型，但部分单测文件仍在本地重复声明整份 `vi.fn()` mock map。
- 这些裸 mock map 虽然可用，但会绕过现有 helper 的类型事实源，后续在 rebase 或 merge-ref 构建时更容易再次出现类型漂移。
- 本 PR 继续沿用现有 helper 体系，把 knowledge 相关单测里的 mock 装配统一切回共享 factory，同时保持 `vi.hoisted` 的提升约束不变。

## 核心变更
- `useKnowledgeBase.test.tsx` 与 `useKnowledgeSearch.test.tsx` 改为复用 `createKnowledgeApiMockSet()`，不再手写整份 knowledge API mock map。
- `PipelinesPage.test.tsx` 与 `ApiExecutor.test.ts` 改为复用 `createKnowledgeFeatureMockSet()`，由共享 factory 提供 knowledge feature mock 集合。
- `KnowledgeBasePage.test.tsx` 保留页面局部 mock，但 knowledge feature 那部分改为先创建共享 mock set，再按页面测试需要覆盖少量特例 mock。
- 各测试文件统一采用“`vi.hoisted` 预创建稳定容器 + `Object.assign` 注入共享 mock set”的装配方式，兼容 Vitest 的 hoist 规则。

## 变更原因
- 目标是把 knowledge 测试里的 mock 类型来源重新收敛到单一事实源，避免同一组 mock 键在多个测试文件里各自漂移。
- 这样可以减少未来 rebase / merge-ref 构建阶段才暴露的类型问题，同时保留现有测试行为和断言结构。

## 重要实现细节
- 本次只改测试文件，不改运行时代码，不改变 knowledge 页面、hooks 或 session BFF 的业务逻辑。
- 没有强行抽象页面局部 mock；仅把真实重复的 knowledge mock 集合切回 helper，保持最小干预。
- `vi.mock` 工厂仍保持异步装配，不回退到会破坏 Vitest 提升语义的写法。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/useKnowledgeBase.test.tsx tests/unit/knowledge/useKnowledgeSearch.test.tsx tests/unit/knowledge/PipelinesPage.test.tsx tests/unit/knowledge/ApiExecutor.test.ts tests/unit/knowledge/KnowledgeBasePage.test.tsx tests/unit/knowledge/knowledge-test-harness.test.ts tests/unit/knowledge/knowledge-api-test-harness.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 本地结果：41 个测试文件 / 228 个测试全部通过
- GitHub Actions：
  - `pull_request` run `22799371314` 成功
  - `push` run `22799364205` 成功
  - `UI Build Smoke`、`UI Unit And Integration Tests`、`UI Playwright Smoke` 全部成功

## Next Best Action
- 继续把 knowledge 测试里零散的 setup/reset 模板做轻量归并，但只收口 helper 已稳定覆盖的范围，避免把页面特有 mock 过度抽象。
