### PR TITLE
feat(knowledge): 为 Corpus 注入文档解析默认配置;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1383,7 +1383,7 @@ function CorpusSettingsPanel({
           <div>
             <h3 className="text-sm font-semibold">Document Extraction Settings</h3>
             <p className="mt-1 text-xs text-muted">
-              为当前 Knowledge Base 分别绑定 URL 与 PDF 的主备 MCP Server / Tool。已配置类型严格依赖所选 MCP，只会在主备之间切换。
+              通过 MCP Tools 为当前 Corpus 注入 URL、PDF 等源文档解释器。
             </p>
             <p className="mt-2 text-[11px] leading-5 text-muted">
               可用于此处的 Tool 需提供可发现的 input/output schema，并能返回正文 Markdown 或文本；当前兼容单文档扁平协议，以及单个

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -572,7 +572,58 @@ describe("KnowledgeBasePage", () => {
     expect(
       screen.getByRole("heading", { name: "Document Extraction Settings" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("通过 MCP Tools 为当前 Corpus 注入 URL、PDF 等源文档解释器。"),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save Settings" })).toBeInTheDocument();
+  });
+
+  it("settings 视图会回显新建 corpus 由后端注入的默认 extraction routes", async () => {
+    searchParamsState.value =
+      "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=settings";
+
+    useKnowledgeBaseMock.mockImplementation(() => ({
+      corpora: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "Corpus Alpha",
+          app_name: "negentropy",
+          knowledge_count: 3,
+          config: {
+            extractor_routes: {
+              url: {
+                targets: [
+                  {
+                    server_id: "server-1",
+                    tool_name: "extract_markdown",
+                    priority: 0,
+                    enabled: true,
+                  },
+                ],
+              },
+              file_pdf: { targets: [] },
+            },
+          },
+        },
+      ],
+      isLoading: false,
+      loadCorpora: loadCorporaMock,
+      loadCorpus: loadCorpusMock,
+      createCorpus: vi.fn(),
+      updateCorpus: updateCorpusMock,
+      deleteCorpus: deleteCorpusMock,
+      ingestUrl: ingestUrlMock,
+      ingestFile: ingestFileMock,
+    }));
+
+    render(<KnowledgeBasePage />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(screen.getAllByLabelText("MCP Server")[0]).toHaveValue("server-1");
+    expect(screen.getAllByLabelText("Tool")[0]).toHaveValue("extract_markdown");
   });
 
   it("settings 视图选择 MCP Server 后不会回退为未配置，并可继续选择 Tool 后保存", async () => {

--- a/apps/negentropy/src/negentropy/config/__init__.py
+++ b/apps/negentropy/src/negentropy/config/__init__.py
@@ -39,6 +39,7 @@ from .app import AppSettings
 from .auth import AuthSettings
 from .database import DatabaseSettings
 from .environment import EnvironmentSettings, get_env_files
+from .knowledge import KnowledgeSettings
 from .llm import LlmSettings
 from .logging import LoggingSettings
 from .observability import ObservabilitySettings
@@ -110,6 +111,10 @@ class Settings(BaseSettings):
     @cached_property
     def search(self) -> SearchSettings:
         return SearchSettings(_env_file=_get_env_files())
+
+    @cached_property
+    def knowledge(self) -> KnowledgeSettings:
+        return KnowledgeSettings(_env_file=_get_env_files())
 
     # =========================================================================
     # Legacy Compatibility Layer
@@ -241,6 +246,7 @@ __all__ = [
     "settings",
     "AppSettings",
     "EnvironmentSettings",
+    "KnowledgeSettings",
     "LlmSettings",
     "LoggingSettings",
     "ObservabilitySettings",

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -1,0 +1,70 @@
+"""
+Knowledge Configuration.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DefaultExtractorTargetSettings(BaseModel):
+    """后台默认的 MCP Tool 绑定。"""
+
+    server_name: str
+    tool_name: str
+    enabled: bool = True
+    timeout_ms: int | None = None
+    tool_options: dict[str, object] = Field(default_factory=dict)
+
+
+class DefaultExtractorRouteSettings(BaseModel):
+    """单一路由的主备默认配置。"""
+
+    primary: DefaultExtractorTargetSettings | None = None
+    secondary: DefaultExtractorTargetSettings | None = None
+
+
+class DefaultExtractorRoutesSettings(BaseModel):
+    """Document Extraction Settings 默认路由集合。"""
+
+    url: DefaultExtractorRouteSettings = Field(
+        default_factory=lambda: DefaultExtractorRouteSettings(
+            primary=DefaultExtractorTargetSettings(
+                server_name="Data Extractor",
+                tool_name="convert_webpage_to_markdown",
+            ),
+            secondary=DefaultExtractorTargetSettings(
+                server_name="Data Extractor",
+                tool_name="batch_convert_webpages_to_markdown",
+            ),
+        )
+    )
+    file_pdf: DefaultExtractorRouteSettings = Field(
+        default_factory=lambda: DefaultExtractorRouteSettings(
+            primary=DefaultExtractorTargetSettings(
+                server_name="Data Extractor",
+                tool_name="convert_pdfs_to_markdown",
+            ),
+            secondary=DefaultExtractorTargetSettings(
+                server_name="Data Extractor",
+                tool_name="batch_convert_pdfs_to_markdown",
+            ),
+        )
+    )
+
+
+class KnowledgeSettings(BaseSettings):
+    """Knowledge 相关后台配置。"""
+
+    model_config = SettingsConfigDict(
+        env_prefix="NE_KNOWLEDGE_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        frozen=True,
+    )
+
+    default_extractor_routes: DefaultExtractorRoutesSettings = Field(
+        default_factory=DefaultExtractorRoutesSettings,
+    )

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -14,6 +14,7 @@ from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.perception import Corpus, Knowledge
+from negentropy.models.plugin import McpServer, McpTool
 
 from .constants import (
     DEFAULT_CHUNK_SIZE,
@@ -417,6 +418,101 @@ def _serialize_corpus_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]
     return merge_corpus_config(config, serialize_chunking_config(normalize_chunking_config(get_chunking_config_only(config))))
 
 
+def _has_explicit_extractor_routes(config: Optional[Dict[str, Any]]) -> bool:
+    return isinstance(config, dict) and "extractor_routes" in config
+
+
+async def _resolve_default_extractor_routes() -> Dict[str, Any]:
+    default_routes = settings.knowledge.default_extractor_routes.model_dump(mode="python")
+    resolved_routes: Dict[str, Any] = {
+        "url": {"targets": []},
+        "file_pdf": {"targets": []},
+    }
+    candidates: list[tuple[str, int, Dict[str, Any]]] = []
+    server_names: set[str] = set()
+
+    for route_key in ("url", "file_pdf"):
+        route_config = default_routes.get(route_key) or {}
+        for priority, slot_key in enumerate(("primary", "secondary")):
+            target = route_config.get(slot_key)
+            if not isinstance(target, dict) or target.get("enabled") is False:
+                continue
+            server_name = str(target.get("server_name") or "").strip()
+            tool_name = str(target.get("tool_name") or "").strip()
+            if not server_name or not tool_name:
+                continue
+            server_names.add(server_name)
+            candidates.append((route_key, priority, target))
+
+    if not candidates:
+        return resolved_routes
+
+    async with AsyncSessionLocal() as db:
+        server_rows = (
+            await db.execute(
+                select(McpServer.id, McpServer.name)
+                .where(McpServer.name.in_(server_names), McpServer.is_enabled.is_(True))
+            )
+        ).all()
+        servers_by_name = {name: server_id for server_id, name in server_rows}
+
+        server_ids = [server_id for server_id, _ in server_rows]
+        enabled_tools_by_server: dict[tuple[str, str], bool] = {}
+        if server_ids:
+            tool_rows = (
+                await db.execute(
+                    select(McpTool.server_id, McpTool.name)
+                    .where(McpTool.server_id.in_(server_ids), McpTool.is_enabled.is_(True))
+                )
+            ).all()
+            enabled_tools_by_server = {
+                (str(server_id), tool_name): True for server_id, tool_name in tool_rows
+            }
+
+    for route_key, priority, target in candidates:
+        server_name = str(target["server_name"]).strip()
+        tool_name = str(target["tool_name"]).strip()
+        server_id = servers_by_name.get(server_name)
+        if not server_id:
+            logger.warning(
+                "knowledge_default_extractor_server_not_found",
+                route_key=route_key,
+                server_name=server_name,
+                tool_name=tool_name,
+            )
+            continue
+
+        if not enabled_tools_by_server.get((str(server_id), tool_name)):
+            logger.warning(
+                "knowledge_default_extractor_tool_not_found",
+                route_key=route_key,
+                server_name=server_name,
+                tool_name=tool_name,
+            )
+            continue
+
+        resolved_routes[route_key]["targets"].append(
+            {
+                "server_id": str(server_id),
+                "tool_name": tool_name,
+                "priority": priority,
+                "enabled": True,
+                **(
+                    {"timeout_ms": int(target["timeout_ms"])}
+                    if target.get("timeout_ms") is not None
+                    else {}
+                ),
+                **(
+                    {"tool_options": target["tool_options"]}
+                    if isinstance(target.get("tool_options"), dict) and target["tool_options"]
+                    else {}
+                ),
+            }
+        )
+
+    return resolved_routes
+
+
 def _normalize_source_metadata(
     *,
     source_uri: Optional[str],
@@ -486,7 +582,10 @@ async def list_corpora(app_name: Optional[str] = Query(default=None)) -> list[Co
 @router.post("/base", response_model=CorpusResponse)
 async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
     service = _get_service()
-    normalized_config = _serialize_corpus_config(payload.config or None)
+    request_config = dict(payload.config or {})
+    if not _has_explicit_extractor_routes(request_config):
+        request_config["extractor_routes"] = await _resolve_default_extractor_routes()
+    normalized_config = _serialize_corpus_config(request_config)
     spec = CorpusSpec(
         app_name=_resolve_app_name(payload.app_name),
         name=payload.name,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py
@@ -50,6 +50,29 @@ class FakeScalarSession:
         return 0
 
 
+class FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class FakeDefaultRouteSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, stmt):
+        _ = stmt
+        return FakeExecuteResult(self._responses.pop(0))
+
+
 class FakeKnowledgeService:
     def __init__(self):
         self.list_knowledge_calls = []
@@ -169,7 +192,11 @@ async def test_list_document_chunks_success(monkeypatch):
 async def test_create_corpus_serializes_chunking_strategy_to_string(monkeypatch):
     fake_service = FakeKnowledgeService()
 
+    async def fake_default_routes():
+        return {"url": {"targets": []}, "file_pdf": {"targets": []}}
+
     monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+    monkeypatch.setattr(knowledge_api, "_resolve_default_extractor_routes", fake_default_routes)
 
     result = await knowledge_api.create_corpus(
         knowledge_api.CorpusCreateRequest(
@@ -192,6 +219,147 @@ async def test_create_corpus_serializes_chunking_strategy_to_string(monkeypatch)
     assert isinstance(spec.config["strategy"], str)
     assert spec.config["separators"] == ["###"]
     assert result.config["strategy"] == "hierarchical"
+
+
+@pytest.mark.asyncio
+async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatch):
+    fake_service = FakeKnowledgeService()
+    server_id = uuid4()
+
+    class FakeDefaultExtractorRoutes:
+        def model_dump(self, mode="python"):
+            _ = mode
+            return {
+                "url": {
+                    "primary": {
+                        "server_name": "Data Extractor",
+                        "tool_name": "convert_webpage_to_markdown",
+                    },
+                    "secondary": {
+                        "server_name": "Data Extractor",
+                        "tool_name": "batch_convert_webpages_to_markdown",
+                    },
+                },
+                "file_pdf": {
+                    "primary": {
+                        "server_name": "Data Extractor",
+                        "tool_name": "convert_pdfs_to_markdown",
+                    },
+                    "secondary": {
+                        "server_name": "Data Extractor",
+                        "tool_name": "batch_convert_pdfs_to_markdown",
+                    },
+                },
+            }
+
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+    monkeypatch.setattr(
+        knowledge_api,
+        "settings",
+        SimpleNamespace(
+            knowledge=SimpleNamespace(
+                default_extractor_routes=FakeDefaultExtractorRoutes(),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        knowledge_api,
+        "AsyncSessionLocal",
+        lambda: FakeDefaultRouteSession(
+            responses=[
+                [(server_id, "Data Extractor")],
+                [
+                    (server_id, "convert_webpage_to_markdown"),
+                    (server_id, "batch_convert_webpages_to_markdown"),
+                    (server_id, "convert_pdfs_to_markdown"),
+                    (server_id, "batch_convert_pdfs_to_markdown"),
+                ],
+            ]
+        ),
+    )
+
+    result = await knowledge_api.create_corpus(
+        knowledge_api.CorpusCreateRequest(
+            app_name="negentropy",
+            name="docs",
+            config={},
+        )
+    )
+
+    spec = fake_service.ensure_corpus_calls[0]
+    assert spec.config["extractor_routes"] == {
+        "url": {
+            "targets": [
+                {
+                    "server_id": str(server_id),
+                    "tool_name": "convert_webpage_to_markdown",
+                    "priority": 0,
+                    "enabled": True,
+                },
+                {
+                    "server_id": str(server_id),
+                    "tool_name": "batch_convert_webpages_to_markdown",
+                    "priority": 1,
+                    "enabled": True,
+                },
+            ]
+        },
+        "file_pdf": {
+            "targets": [
+                {
+                    "server_id": str(server_id),
+                    "tool_name": "convert_pdfs_to_markdown",
+                    "priority": 0,
+                    "enabled": True,
+                },
+                {
+                    "server_id": str(server_id),
+                    "tool_name": "batch_convert_pdfs_to_markdown",
+                    "priority": 1,
+                    "enabled": True,
+                },
+            ]
+        },
+    }
+    assert result.config["extractor_routes"]["url"]["targets"][0]["tool_name"] == "convert_webpage_to_markdown"
+
+
+@pytest.mark.asyncio
+async def test_create_corpus_keeps_explicit_extractor_routes_without_backend_override(monkeypatch):
+    fake_service = FakeKnowledgeService()
+    explicit_routes = {
+        "url": {
+            "targets": [
+                {
+                    "server_id": "server-explicit",
+                    "tool_name": "explicit_web",
+                    "priority": 0,
+                    "enabled": True,
+                }
+            ]
+        },
+        "file_pdf": {"targets": []},
+    }
+
+    async def should_not_resolve_defaults():
+        pytest.fail("should not resolve backend defaults when extractor_routes already provided")
+
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+    monkeypatch.setattr(knowledge_api, "_resolve_default_extractor_routes", should_not_resolve_defaults)
+
+    await knowledge_api.create_corpus(
+        knowledge_api.CorpusCreateRequest(
+            app_name="negentropy",
+            name="docs",
+            config={
+                "strategy": "recursive",
+                "extractor_routes": explicit_routes,
+            },
+        )
+    )
+
+    spec = fake_service.ensure_corpus_calls[0]
+    assert spec.config["extractor_routes"] == explicit_routes
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更摘要

本 PR 完成了 Knowledge Base 中 Document Extraction Settings 的两项收敛改造：

1. 将设置页说明文案从“为当前 Knowledge Base 分别绑定 URL 与 PDF 的主备 MCP Server / Tool。已配置类型严格依赖所选 MCP，只会在主备之间切换。”更新为“通过 MCP Tools 为当前 Corpus 注入 URL、PDF 等源文档解释器。”
2. 通过后端配置为新建 Corpus 注入默认的 Document Extraction Settings，避免前端硬编码默认值，并保持现有功能与配置结构兼容。

## 为什么要改

当前实现存在两个问题：

- 设置页文案过度暴露“主备 MCP Server / Tool”实现细节，不利于从 Corpus 视角理解该配置的业务语义。
- Document Extraction Settings 缺少后端单一事实源，默认值只能依赖前端或人工配置，容易在不同环境之间产生漂移，也不利于后续运维调整。

本次改动遵循 Single Source of Truth 与 Composition over Construction 的思路，将默认解析器配置收敛到后端配置域，由服务端在创建 Corpus 时统一解析和注入，降低前后端分叉与环境漂移风险。

## 具体改动

### 1. 新增 Knowledge 配置域
- 新增 `KnowledgeSettings` 与 `default_extractor_routes` 配置模型。
- 后端默认以 `server_name + tool_name` 描述 URL / PDF 的主备解析器，而不是直接写死数据库 `server_id`。
- 默认配置覆盖：
  - URL 主用：`Data Extractor / convert_webpage_to_markdown`
  - URL 备用：`Data Extractor / batch_convert_webpages_to_markdown`
  - PDF 主用：`Data Extractor / convert_pdfs_to_markdown`
  - PDF 备用：`Data Extractor / batch_convert_pdfs_to_markdown`

### 2. 在创建 Corpus 时注入默认 extraction routes
- `create_corpus` 新增默认路由解析逻辑：
  - 如果请求中未显式提供 `extractor_routes`，服务端读取 `settings.knowledge.default_extractor_routes`
  - 通过 MCP Server 名称与 Tool 名称查找当前环境中已启用的 Server / Tool
  - 解析成功后，写入现有的 `Corpus.config.extractor_routes` 结构
- 保持兼容性：
  - 若请求已显式提供 `extractor_routes`，则完全尊重请求值，不做覆盖
  - 若后端默认配置中某个 Server 或 Tool 当前不存在 / 未启用，仅跳过该项并记录 warning，不影响 Corpus 创建
  - 不改变现有 `extractor_routes` 持久化结构，也不引入数据库迁移

### 3. 更新前端文案与回归测试
- 更新 Knowledge Base settings 页的说明文案，使其从“主备绑定”转为“为 Corpus 注入源文档解释器”的业务表达。
- 补充前端测试，覆盖：
  - 新文案展示
  - 后端注入默认 extraction routes 后，settings 页能够正确回显

### 4. 补充后端测试
- 新增后端单测，验证：
  - 创建 Corpus 时会自动注入后端默认 extraction routes
  - 显式传入 `extractor_routes` 时不会被后端默认覆盖
  - chunking 配置序列化行为未被回归破坏

## 关键实现细节
- 默认 extraction routes 的配置载体是后端 `KnowledgeSettings`，不是前端常量。
- 默认配置使用“稳定标识解析 -> 写入现有结构”的 Adapter 方式，避免把环境相关 UUID 暴露到配置层。
- 注入时机只放在 `create_corpus`，因此旧 Corpus 不会被隐式重写，现有行为保持稳定。
- 前端仅消费后端返回的 `config.extractor_routes`，不引入新的前端默认值来源。

## 验证
已执行并通过以下定向测试：

- `uv run --project apps/negentropy python -m pytest apps/negentropy/tests/unit_tests/knowledge/test_api_document_routes.py`
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/knowledge/KnowledgeBasePage.test.tsx`
