### PR TITLE
test(knowledge): 收敛测试辅助重置与预置模板;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -57,6 +57,24 @@ export function createKnowledgeApiMockSet(): KnowledgeApiMockSet {
   };
 }
 
+export function resetKnowledgeApiMocks(mocks: KnowledgeApiMockSet): void {
+  Object.values(mocks).forEach((mock) => {
+    mock.mockReset();
+  });
+}
+
+export function primeKnowledgeApiMocks(
+  mocks: KnowledgeApiMockSet,
+  overrides: Partial<Pick<KnowledgeApiMockSet, "fetchCorporaMock">> = {},
+): void {
+  const stableDefaults = {
+    fetchCorporaMock: mocks.fetchCorporaMock,
+    ...overrides,
+  };
+
+  stableDefaults.fetchCorporaMock.mockResolvedValue([]);
+}
+
 export async function createKnowledgeApiConfigTestExports() {
   const actual = await importKnowledgeApiActual();
   return {

--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -62,6 +62,34 @@ export function createKnowledgeFeatureMockSet(): KnowledgeFeatureMockSet {
   };
 }
 
+export function resetKnowledgeFeatureMocks(mocks: KnowledgeFeatureMockSet): void {
+  Object.values(mocks).forEach((mock) => {
+    mock.mockReset();
+  });
+}
+
+export function primeKnowledgeFeatureMocks(
+  mocks: KnowledgeFeatureMockSet,
+  overrides: Partial<
+    Pick<
+      KnowledgeFeatureMockSet,
+      "ingestTextMock" | "ingestUrlMock" | "replaceSourceMock" | "createCorpusMock"
+    >
+  > = {},
+): void {
+  const stableSuccessMocks = {
+    ingestTextMock: mocks.ingestTextMock,
+    ingestUrlMock: mocks.ingestUrlMock,
+    replaceSourceMock: mocks.replaceSourceMock,
+    createCorpusMock: mocks.createCorpusMock,
+    ...overrides,
+  };
+
+  Object.values(stableSuccessMocks).forEach((mock) => {
+    mock.mockResolvedValue({ ok: true });
+  });
+}
+
 export function createKnowledgeConfigTestExports() {
   return {
     createDefaultChunkingConfig,

--- a/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/ApiExecutor.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/features/knowledge", async () => {
 
 import { executeApiCall } from "@/app/knowledge/apis/_components/utils/ApiExecutor";
 import { KNOWLEDGE_API_ENDPOINTS } from "@/features/knowledge/utils/api-specs";
+import { primeKnowledgeFeatureMocks, resetKnowledgeFeatureMocks } from "@/tests/helpers/knowledge";
 
 const getEndpoint = (id: string) => {
   const endpoint = KNOWLEDGE_API_ENDPOINTS.find((item) => item.id === id);
@@ -21,11 +22,8 @@ const getEndpoint = (id: string) => {
 
 describe("ApiExecutor", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    knowledgeMocks.ingestTextMock.mockResolvedValue({ ok: true });
-    knowledgeMocks.ingestUrlMock.mockResolvedValue({ ok: true });
-    knowledgeMocks.replaceSourceMock.mockResolvedValue({ ok: true });
-    knowledgeMocks.createCorpusMock.mockResolvedValue({ ok: true });
+    resetKnowledgeFeatureMocks(knowledgeMocks);
+    primeKnowledgeFeatureMocks(knowledgeMocks);
   });
 
   it("ingest 通过 chunking_config 透传 canonical 配置", async () => {

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { KnowledgeFeatureMockSet } from "@/tests/helpers/knowledge";
+import { resetKnowledgeFeatureMocks } from "@/tests/helpers/knowledge";
 
 const {
   replaceMock,
@@ -118,25 +119,14 @@ const flushPromises = async () => {
 
 describe("KnowledgeBasePage", () => {
   beforeEach(() => {
+    resetKnowledgeFeatureMocks(knowledgeMocks);
     replaceMock.mockReset();
     loadCorpusMock.mockReset();
     loadCorporaMock.mockReset();
     updateCorpusMock.mockReset();
-    deleteCorpusMock.mockReset();
-    deleteDocumentMock.mockReset();
-    ingestUrlMock.mockReset();
     ingestFileMock.mockReset();
-    fetchDocumentsMock.mockReset();
-    fetchDocumentChunksMock.mockReset();
-    searchAcrossCorporaMock.mockReset();
     documentViewDialogMock.mockReset();
     fetchMock.mockReset();
-    syncDocumentMock.mockReset();
-    rebuildDocumentMock.mockReset();
-    replaceDocumentFeatureMock.mockReset();
-    archiveDocumentMock.mockReset();
-    unarchiveDocumentMock.mockReset();
-    downloadDocumentMock.mockReset();
     searchParamsState.value = "view=corpus&corpusId=11111111-1111-1111-1111-111111111111&tab=documents";
 
     global.fetch = fetchMock;

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/features/knowledge", async () => {
 });
 
 import KnowledgePipelinesPage from "@/app/knowledge/pipelines/page";
+import { resetKnowledgeFeatureMocks } from "@/tests/helpers/knowledge";
 
 const flushPromises = async () => {
   await Promise.resolve();
@@ -38,8 +39,7 @@ const makeRun = (overrides?: Partial<{ id: string; run_id: string; status: strin
 describe("KnowledgePipelinesPage polling", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    knowledgeMocks.fetchPipelinesMock.mockReset();
-    knowledgeMocks.upsertPipelinesMock.mockReset();
+    resetKnowledgeFeatureMocks(knowledgeMocks);
   });
 
   afterEach(() => {

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api-test-harness.test.ts
@@ -5,6 +5,8 @@ import {
 import {
   createKnowledgeApiMockSet,
   createKnowledgeApiTestHarness,
+  primeKnowledgeApiMocks,
+  resetKnowledgeApiMocks,
 } from "@/tests/helpers/knowledge-api";
 
 describe("knowledge api test harness", () => {
@@ -52,5 +54,16 @@ describe("knowledge api test harness", () => {
     expect(harness.exports.createDefaultChunkingConfig).toBe(
       createDefaultChunkingConfig,
     );
+  });
+
+  it("支持统一 reset 与稳定默认装配", async () => {
+    const mocks = createKnowledgeApiMockSet();
+    primeKnowledgeApiMocks(mocks);
+
+    await expect(mocks.fetchCorporaMock()).resolves.toEqual([]);
+
+    resetKnowledgeApiMocks(mocks);
+
+    expect(mocks.fetchCorporaMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-test-harness.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-test-harness.test.ts
@@ -4,6 +4,8 @@ import {
 } from "@/features/knowledge/utils/knowledge-api";
 import {
   createKnowledgeFeatureMockSet,
+  primeKnowledgeFeatureMocks,
+  resetKnowledgeFeatureMocks,
   createKnowledgeFeatureTestHarness,
 } from "@/tests/helpers/knowledge";
 
@@ -37,5 +39,18 @@ describe("knowledge test harness", () => {
     expect(harness.exports.createDefaultChunkingConfig).toBe(
       createDefaultChunkingConfig,
     );
+  });
+
+  it("支持统一 reset 与稳定默认装配", async () => {
+    const mocks = createKnowledgeFeatureMockSet();
+    primeKnowledgeFeatureMocks(mocks);
+
+    await expect(mocks.ingestTextMock()).resolves.toEqual({ ok: true });
+    await expect(mocks.createCorpusMock()).resolves.toEqual({ ok: true });
+
+    resetKnowledgeFeatureMocks(mocks);
+
+    expect(mocks.ingestTextMock).not.toHaveBeenCalled();
+    expect(mocks.createCorpusMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeBase.test.tsx
@@ -12,12 +12,12 @@ vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
 });
 
 import { useKnowledgeBase } from "@/features/knowledge/hooks/useKnowledgeBase";
+import { primeKnowledgeApiMocks, resetKnowledgeApiMocks } from "@/tests/helpers/knowledge-api";
 
 describe("useKnowledgeBase", () => {
   beforeEach(() => {
-    knowledgeApiMocks.fetchCorpusMock.mockReset();
-    knowledgeApiMocks.fetchCorporaMock.mockReset();
-    knowledgeApiMocks.fetchCorporaMock.mockResolvedValue([]);
+    resetKnowledgeApiMocks(knowledgeApiMocks);
+    primeKnowledgeApiMocks(knowledgeApiMocks);
   });
 
   it("在相同输入下保持返回对象和 loadCorpus 引用稳定", () => {

--- a/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/useKnowledgeSearch.test.tsx
@@ -12,10 +12,11 @@ vi.mock("@/features/knowledge/utils/knowledge-api", async () => {
 });
 
 import { useKnowledgeSearch } from "@/features/knowledge/hooks/useKnowledgeSearch";
+import { resetKnowledgeApiMocks } from "@/tests/helpers/knowledge-api";
 
 describe("useKnowledgeSearch", () => {
   beforeEach(() => {
-    knowledgeApiMocks.searchKnowledgeMock.mockReset();
+    resetKnowledgeApiMocks(knowledgeApiMocks);
   });
 
   it("空查询会直接返回空结果且不请求后端", async () => {


### PR DESCRIPTION
## 背景
- 上一轮已经把 knowledge 测试里的 mock 集合收敛到共享 factory，但 setup/reset 模板仍分散在多个测试文件里重复实现。
- 重复主要集中在两类：knowledge mock set 的 `mockReset()` 模板，以及少量稳定默认值的成功响应装配。
- 本 PR 继续沿用现有 helper 体系，把这些已稳定覆盖的模板下沉到 helper，同时刻意不抽象页面特有 mock，避免过度设计。

## 核心变更
- 在 knowledge helper 中新增统一的 reset/setup 工具：
  - `resetKnowledgeApiMocks`
  - `resetKnowledgeFeatureMocks`
  - `primeKnowledgeApiMocks`
  - `primeKnowledgeFeatureMocks`
- `useKnowledgeBase.test.tsx`、`useKnowledgeSearch.test.tsx`、`PipelinesPage.test.tsx`、`ApiExecutor.test.ts` 改为复用上述 helper，不再各自重复写 reset 与稳定默认值装配。
- `KnowledgeBasePage.test.tsx` 只把 knowledge mock set 的 reset 部分切到 helper；页面特有的 router、dialog、fetch、searchParams 和 hook 局部 mock 继续保留在测试文件内。
- 补充 helper 测试，锁定 reset 与 prime 的基础语义，避免后续 helper 演化再次引入 split-brain。

## 变更原因
- 目标是继续压低 knowledge 测试层的实现偏差，把已经稳定的 setup/reset 模板收敛为单一事实源。
- 这样后续再调整 knowledge mock 字段或默认成功响应时，不需要同时修改多个测试文件，也能减少 rebase / merge-ref 场景下的隐性类型和行为漂移。

## 重要实现细节
- 本次只改测试 helper 和测试文件，不改任何运行时代码、页面逻辑或 API 行为。
- `prime...` 只覆盖当前多个测试都在复用的稳定成功模板，不把 `KnowledgeBasePage` 里的 documents/search results/MCP fetch 等页面语义数据硬塞进通用 helper。
- `ApiExecutor.test.ts` 用显式 knowledge reset 替代了 `vi.clearAllMocks()`，从而把清理边界收回到 knowledge mock set 本身，避免对其它 mock 产生不必要副作用。

## 验证证据
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/useKnowledgeBase.test.tsx tests/unit/knowledge/useKnowledgeSearch.test.tsx tests/unit/knowledge/PipelinesPage.test.tsx tests/unit/knowledge/ApiExecutor.test.ts tests/unit/knowledge/KnowledgeBasePage.test.tsx tests/unit/knowledge/knowledge-test-harness.test.ts tests/unit/knowledge/knowledge-api-test-harness.test.ts`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 本地结果：41 个测试文件 / 230 个测试全部通过

## Next Best Action
- 如果继续收口 knowledge 测试层，可以把高频的页面局部 setup 模板做同边界内的轻量 builder，但要继续坚持“只抽稳定重复项，不抽页面语义”。
