### PR TITLE
test(knowledge): 收敛settings视图route配置样本;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-base-page.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-base-page.ts
@@ -152,6 +152,41 @@ export function createKnowledgeBaseDocumentChunk(
   };
 }
 
+export function createKnowledgeBaseExtractorRouteTarget(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    server_id: "server-1",
+    tool_name: "extract_markdown",
+    priority: 0,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+export function createKnowledgeBaseExtractorRoutes(
+  urlTargets: Array<Record<string, unknown>> = [],
+): Record<string, unknown> {
+  return {
+    url: {
+      targets: urlTargets,
+    },
+    file_pdf: { targets: [] },
+  };
+}
+
+export const knowledgeBasePageExtractorRouteFixtures = {
+  defaultConfigured: createKnowledgeBaseExtractorRouteTarget(),
+  legacyConfigured: createKnowledgeBaseExtractorRouteTarget({
+    server_id: "server-legacy",
+    tool_name: "tool-legacy",
+  }),
+  refreshedConfigured: createKnowledgeBaseExtractorRouteTarget({
+    server_id: "server-from-refresh",
+    tool_name: "tool-from-refresh",
+  }),
+} as const;
+
 export function resetKnowledgeBasePageLocalMocks(
   mocks: KnowledgeBasePageLocalMocks,
 ): void {

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -7,8 +7,10 @@ import {
   createKnowledgeBaseCorpus,
   createKnowledgeBaseDocument,
   createKnowledgeBaseDocumentChunk,
+  createKnowledgeBaseExtractorRoutes,
   createKnowledgeBaseHierarchicalSearchResult,
   createKnowledgeBaseSearchResult,
+  knowledgeBasePageExtractorRouteFixtures,
   knowledgeBasePageSearchParams,
   primeKnowledgeBasePageLocalMocks,
   resetKnowledgeBasePageLocalMocks,
@@ -492,19 +494,9 @@ describe("KnowledgeBasePage", () => {
       corpora: [
         createKnowledgeBaseCorpus({
           config: {
-            extractor_routes: {
-              url: {
-                targets: [
-                  {
-                    server_id: "server-1",
-                    tool_name: "extract_markdown",
-                    priority: 0,
-                    enabled: true,
-                  },
-                ],
-              },
-              file_pdf: { targets: [] },
-            },
+            extractor_routes: createKnowledgeBaseExtractorRoutes([
+              knowledgeBasePageExtractorRouteFixtures.defaultConfigured,
+            ]),
           },
         }),
       ],
@@ -564,19 +556,9 @@ describe("KnowledgeBasePage", () => {
       "11111111-1111-1111-1111-111111111111",
       {
         config: expect.objectContaining({
-          extractor_routes: {
-            url: {
-              targets: [
-                {
-                  server_id: "server-1",
-                  tool_name: "extract_markdown",
-                  priority: 0,
-                  enabled: true,
-                },
-              ],
-            },
-            file_pdf: { targets: [] },
-          },
+          extractor_routes: createKnowledgeBaseExtractorRoutes([
+            knowledgeBasePageExtractorRouteFixtures.defaultConfigured,
+          ]),
         }),
       },
     );
@@ -589,19 +571,9 @@ describe("KnowledgeBasePage", () => {
       corpora: [
         createKnowledgeBaseCorpus({
           config: {
-            extractor_routes: {
-              url: {
-                targets: [
-                  {
-                    server_id: "server-legacy",
-                    tool_name: "tool-legacy",
-                    priority: 0,
-                    enabled: true,
-                  },
-                ],
-              },
-              file_pdf: { targets: [] },
-            },
+            extractor_routes: createKnowledgeBaseExtractorRoutes([
+              knowledgeBasePageExtractorRouteFixtures.legacyConfigured,
+            ]),
           },
         }),
       ],
@@ -648,19 +620,9 @@ describe("KnowledgeBasePage", () => {
         strategy: "fixed",
         chunk_size: 1024,
         overlap: 50,
-        extractor_routes: {
-          url: {
-            targets: [
-              {
-                server_id: "server-from-refresh",
-                tool_name: "tool-from-refresh",
-                priority: 0,
-                enabled: true,
-              },
-            ],
-          },
-          file_pdf: { targets: [] },
-        },
+        extractor_routes: createKnowledgeBaseExtractorRoutes([
+          knowledgeBasePageExtractorRouteFixtures.refreshedConfigured,
+        ]),
       },
     };
 


### PR DESCRIPTION
## 背景
- `KnowledgeBasePage` 的 settings 视图测试里，前一轮已经把 query 与通用页面样本收口成命名 fixture，但 extractor route 配置样本仍然散落在多个用例里重复声明。
- 当前重复主要集中在三类稳定数据：默认已配置 route、legacy 已配置但当前不可用 route、以及外部刷新后回流的 route。
- 本 PR 继续保持最小干预，只把这些稳定 route 样本命名化，不抽用户交互流程，也不把页面语义断言隐藏进 helper。

## 核心变更
- 在 `tests/helpers/knowledge-base-page.ts` 中新增 settings 视图专用 extractor route fixture 与构造器：
  - `createKnowledgeBaseExtractorRouteTarget`
  - `createKnowledgeBaseExtractorRoutes`
  - `knowledgeBasePageExtractorRouteFixtures`
- `KnowledgeBasePage.test.tsx` 改为复用上述 fixture，替换 settings 相关重复的 route 配置样本：
  - 默认回显 route
  - 保存后的 `updateCorpus` payload
  - legacy 不可用 route 回显
  - refresh 后 route 样本
- `file_pdf: { targets: [] }` 等稳定壳结构一并下沉到 helper，避免测试继续重复补齐 route envelope。
- 各 `it(...)` 内的交互步骤、保存流程、rerender 逻辑与断言文本保持原地，不新增测试 DSL。

## 变更原因
- 目标是继续压低 knowledge 页面测试层的实现偏差，让 settings 视图里的 route 样本和页面默认 fixture 保持同一事实源。
- 这样后续如果 extractor route 的稳定样板需要调整，只需要修改 helper，不需要同步改多处测试数据副本。

## 重要实现细节
- 本次只改测试 helper 和页面测试文件，不改任何运行时代码、knowledge API 或页面组件行为。
- helper 只提供稳定 route 数据样本和完整 envelope，不接管交互语义。
- 默认、legacy、refresh 三类 route fixture 分别命名，避免把不同测试意图压平成匿名对象。

## 验证证据
- `pnpm --dir apps/negentropy-ui typecheck`
- `pnpm --dir apps/negentropy-ui typecheck:test`
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 本地结果：41 个测试文件 / 231 个测试全部通过

## Next Best Action
- 如果继续收口 knowledge 测试层，可以把 settings 视图中与 extractor route 相邻的 MCP server/tool option 样本也命名化，但仍应只抽稳定数据，不抽交互语义。
