### PR TITLE
test(knowledge): 收敛MCP选项断言样本;

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge-base-page.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-base-page.ts
@@ -1,4 +1,6 @@
+import { expect } from "vitest";
 import { vi, type Mock } from "vitest";
+import { screen, within } from "@testing-library/react";
 
 type VitestMock = Mock<(...args: unknown[]) => unknown>;
 type FetchMock = Mock<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>;
@@ -246,6 +248,42 @@ export const knowledgeBasePageMcpOptionFixtures = {
     display_name: "Refresh Tool",
   }),
 } as const;
+
+export const knowledgeBasePageMcpSelectionFixtures = {
+  defaultConfigured: {
+    serverValue: String(knowledgeBasePageMcpOptionFixtures.defaultServer.id),
+    toolValue: String(knowledgeBasePageMcpOptionFixtures.defaultTool.name),
+  },
+  legacyConfigured: {
+    serverValue: String(knowledgeBasePageMcpOptionFixtures.legacyServer.id),
+    toolValue: String(knowledgeBasePageMcpOptionFixtures.legacyTool.name),
+    serverLabel: String(knowledgeBasePageMcpOptionFixtures.legacyServer.display_name),
+    toolLabel: String(knowledgeBasePageMcpOptionFixtures.legacyTool.display_name),
+  },
+} as const;
+
+export function expectKnowledgeBaseSelectedMcpOptions(selection: {
+  serverValue: string;
+  toolValue: string;
+}): void {
+  expect(screen.getAllByLabelText("MCP Server")[0]).toHaveValue(selection.serverValue);
+  expect(screen.getAllByLabelText("Tool")[0]).toHaveValue(selection.toolValue);
+}
+
+export function expectKnowledgeBaseUnavailableMcpOptions(selection: {
+  serverValue: string;
+  toolValue: string;
+  serverLabel: string;
+  toolLabel: string;
+}): void {
+  expectKnowledgeBaseSelectedMcpOptions(selection);
+
+  const serverSelect = screen.getAllByLabelText("MCP Server")[0];
+  const toolSelect = screen.getAllByLabelText("Tool")[0];
+
+  expect(within(serverSelect).getByRole("option", { name: selection.serverLabel })).toBeInTheDocument();
+  expect(within(toolSelect).getByRole("option", { name: selection.toolLabel })).toBeInTheDocument();
+}
 
 export function resetKnowledgeBasePageLocalMocks(
   mocks: KnowledgeBasePageLocalMocks,

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -9,7 +9,10 @@ import {
   createKnowledgeBaseDocumentChunk,
   createKnowledgeBaseExtractorRoutes,
   createKnowledgeBaseHierarchicalSearchResult,
+  expectKnowledgeBaseSelectedMcpOptions,
+  expectKnowledgeBaseUnavailableMcpOptions,
   knowledgeBasePageMcpOptionFixtures,
+  knowledgeBasePageMcpSelectionFixtures,
   createKnowledgeBaseSearchResult,
   knowledgeBasePageExtractorRouteFixtures,
   knowledgeBasePageSearchParams,
@@ -516,12 +519,8 @@ describe("KnowledgeBasePage", () => {
     await act(async () => {
       await flushPromises();
     });
-
-    expect(screen.getAllByLabelText("MCP Server")[0]).toHaveValue(
-      String(knowledgeBasePageMcpOptionFixtures.defaultServer.id),
-    );
-    expect(screen.getAllByLabelText("Tool")[0]).toHaveValue(
-      String(knowledgeBasePageMcpOptionFixtures.defaultTool.name),
+    expectKnowledgeBaseSelectedMcpOptions(
+      knowledgeBasePageMcpSelectionFixtures.defaultConfigured,
     );
   });
 
@@ -546,7 +545,7 @@ describe("KnowledgeBasePage", () => {
       String(knowledgeBasePageMcpOptionFixtures.defaultServer.id),
     );
 
-    expect(serverSelect).toHaveValue(String(knowledgeBasePageMcpOptionFixtures.defaultServer.id));
+    expect(serverSelect).toHaveValue(knowledgeBasePageMcpSelectionFixtures.defaultConfigured.serverValue);
     expect(toolSelect).not.toBeDisabled();
     expect(toolSelect).toHaveValue("");
 
@@ -555,7 +554,7 @@ describe("KnowledgeBasePage", () => {
       String(knowledgeBasePageMcpOptionFixtures.defaultTool.name),
     );
 
-    expect(toolSelect).toHaveValue(String(knowledgeBasePageMcpOptionFixtures.defaultTool.name));
+    expect(toolSelect).toHaveValue(knowledgeBasePageMcpSelectionFixtures.defaultConfigured.toolValue);
 
     await user.click(screen.getByRole("button", { name: "Save Settings" }));
 
@@ -607,14 +606,9 @@ describe("KnowledgeBasePage", () => {
     const serverSelect = screen.getAllByLabelText("MCP Server")[0];
     const toolSelect = screen.getAllByLabelText("Tool")[0];
 
-    expect(serverSelect).toHaveValue(String(knowledgeBasePageMcpOptionFixtures.legacyServer.id));
-    expect(toolSelect).toHaveValue(String(knowledgeBasePageMcpOptionFixtures.legacyTool.name));
-    expect(
-      within(serverSelect).getByRole("option", { name: "已配置 MCP（当前不可用）" }),
-    ).toBeInTheDocument();
-    expect(
-      within(toolSelect).getByRole("option", { name: "已配置 Tool（当前不可用）" }),
-    ).toBeInTheDocument();
+    expectKnowledgeBaseUnavailableMcpOptions(
+      knowledgeBasePageMcpSelectionFixtures.legacyConfigured,
+    );
     expect(
       screen.getByText(/可用于此处的 Tool 需提供可发现的 input\/output schema/i),
     ).toBeInTheDocument();
@@ -667,8 +661,8 @@ describe("KnowledgeBasePage", () => {
       String(knowledgeBasePageMcpOptionFixtures.defaultTool.name),
     );
 
-    expect(serverSelect).toHaveValue(String(knowledgeBasePageMcpOptionFixtures.defaultServer.id));
-    expect(toolSelect).toHaveValue(String(knowledgeBasePageMcpOptionFixtures.defaultTool.name));
+    expect(serverSelect).toHaveValue(knowledgeBasePageMcpSelectionFixtures.defaultConfigured.serverValue);
+    expect(toolSelect).toHaveValue(knowledgeBasePageMcpSelectionFixtures.defaultConfigured.toolValue);
 
     useKnowledgeBaseMock.mockImplementation(() => ({
       corpora: [refreshedCorpus],
@@ -688,11 +682,8 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
-    expect(screen.getAllByLabelText("MCP Server")[0]).toHaveValue(
-      String(knowledgeBasePageMcpOptionFixtures.defaultServer.id),
-    );
-    expect(screen.getAllByLabelText("Tool")[0]).toHaveValue(
-      String(knowledgeBasePageMcpOptionFixtures.defaultTool.name),
+    expectKnowledgeBaseSelectedMcpOptions(
+      knowledgeBasePageMcpSelectionFixtures.defaultConfigured,
     );
   });
 


### PR DESCRIPTION
## 背景
- knowledge 测试层前几轮已经把通用 mock、页面局部 setup、extractor route 样本和 MCP option 数据样本逐步收口到 helper。
- 但 `KnowledgeBasePage` settings 视图里，仍保留少量稳定重复的 MCP 断言样本，主要集中在：
  - 默认 server/tool 的 selected value 断言
  - legacy 不可用 server/tool 的 option label 断言
  - 刷新后仍保持当前草稿选择的 selected value 断言
- 这些内容已经足够稳定，适合继续命名化；但交互流程本身仍应保留在测试用例内，不抽成测试 DSL。

## 核心变更
- 在 `tests/helpers/knowledge-base-page.ts` 中新增：
  - `knowledgeBasePageMcpSelectionFixtures`
  - 最小断言 helper：已选中 MCP 断言、不可用 MCP option 断言
- `KnowledgeBasePage.test.tsx` 改为复用上述 fixture/helper，替换 settings 场景里重复的 selected value 与 option label 断言。
- `selectOptions`、保存按钮点击、rerender、页面说明文案和业务断言全部保持原地，只收口稳定样本与固定断言模板。

## 变更原因
- 目标是继续压低 knowledge 页面测试层的实现偏差，把 settings 场景里已稳定的 MCP 断言样本也收回单一事实源。
- 这样后续如果 MCP option 默认值或 label 发生变化，只需要在 helper 侧调整一次，不需要同步修改多处测试断言副本。

## 重要实现细节
- 本次只改测试 helper 与测试文件，不改任何运行时代码、knowledge API 或页面组件行为。
- helper 只负责稳定数据与固定断言模板，不接管用户动作或业务语义。
- 新增断言 helper 直接消费现有的 MCP fixture，避免再复制一层字符串常量。

## 验证证据
- `pnpm --dir apps/negentropy-ui typecheck`
- `pnpm --dir apps/negentropy-ui typecheck:test`
- `pnpm --dir apps/negentropy-ui test tests/unit/knowledge/KnowledgeBasePage.test.tsx`
- `pnpm --dir apps/negentropy-ui build`
- `pnpm --dir apps/negentropy-ui test:coverage`
- 本地结果：41 个测试文件 / 231 个测试全部通过

## Next Best Action
- 如果继续收口 knowledge 测试层，可以把 settings 视图里仍零散存在、但已稳定的 MCP server/tool option 列表文案样本继续命名化；前提仍然是只抽稳定数据，不抽交互语义。
