### PR TITLE
fix(chat): 修正 AGUI/A2UI 聊天角色归一化并重对齐 Chat 页交互;

### DIFF
--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -44,7 +44,7 @@ export function ChatStream({
       >
         {visibleNodes.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">
-            发送指令开始对话。主区将以 A2UI 模块树实时展示消息、工具、活动与状态。
+            发送指令开始对话。主区会优先展示聊天消息，并在答复下附带工具、状态与活动摘要。
           </div>
         ) : (
           visibleNodes.map((node) => (

--- a/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
+++ b/apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx
@@ -207,19 +207,20 @@ function TurnNode({
   return (
     <div
       className={cn(
-        "rounded-[28px] border px-4 py-3",
+        "rounded-2xl border border-dashed px-4 py-2.5",
         selected
-          ? "border-amber-300 bg-white dark:border-amber-700 dark:bg-zinc-900"
-          : "border-zinc-200/80 bg-zinc-100/60 dark:border-zinc-800 dark:bg-zinc-900/50",
+          ? "border-amber-300 bg-amber-50/70 dark:border-amber-700 dark:bg-amber-950/20"
+          : "border-zinc-200/80 bg-zinc-100/55 dark:border-zinc-800 dark:bg-zinc-900/35",
       )}
       onClick={() => onSelect?.(node.id)}
     >
       <div className="flex items-center justify-between gap-4">
-        <div>
-          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500 dark:text-zinc-400">
+        <div className="flex min-w-0 items-center gap-2 text-[11px] text-zinc-500 dark:text-zinc-400">
+          <span className="font-semibold uppercase tracking-[0.18em]">
             {node.title}
-          </div>
-          <div className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
             {node.status === "finished"
               ? "已完成"
               : node.status === "error"
@@ -227,16 +228,16 @@ function TurnNode({
                 : node.status === "blocked"
                   ? "等待确认"
                   : "进行中"}
-            {" · "}
-            {childCount} 个子模块
-          </div>
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>{childCount} 个子模块</span>
         </div>
-        <div className="text-[10px] text-zinc-400 dark:text-zinc-500">
+        <div className="shrink-0 text-[10px] text-zinc-400 dark:text-zinc-500">
           {formatTimestamp(node.timestamp)}
         </div>
       </div>
       {statusHint ? (
-        <div className="mt-3 rounded-2xl border border-dashed border-zinc-300/80 bg-zinc-50 px-3 py-2 text-sm text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-400">
+        <div className="mt-2 rounded-xl border border-zinc-200/80 bg-white/75 px-3 py-2 text-sm text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950/40 dark:text-zinc-400">
           {statusHint}
         </div>
       ) : null}

--- a/apps/negentropy-ui/lib/adk.ts
+++ b/apps/negentropy-ui/lib/adk.ts
@@ -24,6 +24,8 @@ import {
   getEventRole,
   getEventRunId,
   getEventThreadId,
+  normalizeCompatibleMessageRole,
+  type CanonicalMessageRole,
 } from "@/types/agui";
 import { accumulateTextContent } from "@/utils/message";
 import type { AdkEventPayload } from "@/lib/adk/schema";
@@ -35,18 +37,40 @@ export {
   type AdkEventPayload,
 } from "@/lib/adk/schema";
 
-type NormalizedRole = "user" | "agent" | "system";
+type NormalizedRole = Exclude<CanonicalMessageRole, "tool">;
 
 type StreamMessageState = {
   messageId: string;
 };
 
 function normalizeTextRole(value: string | undefined): NormalizedRole {
-  return value === "user" || value === "system" ? value : "agent";
+  const normalized = normalizeCompatibleMessageRole(value);
+  if (normalized === "tool") {
+    return "assistant";
+  }
+  return normalized;
 }
 
 function getPayloadRole(payload: AdkEventPayload): NormalizedRole {
-  return normalizeTextRole(payload.message?.role || payload.author);
+  if (payload.message?.role) {
+    return normalizeTextRole(payload.message.role);
+  }
+  if (hasToolResults(payload) || payload.message?.role === "tool") {
+    return "assistant";
+  }
+  if (hasToolCalls(payload)) {
+    return "assistant";
+  }
+  if (
+    payload.author === "assistant" ||
+    payload.author === "agent" ||
+    payload.author === "system" ||
+    payload.author === "developer" ||
+    payload.author === "tool"
+  ) {
+    return normalizeTextRole(payload.author);
+  }
+  return "assistant";
 }
 
 function extractTextParts(payload: AdkEventPayload): string[] {
@@ -90,7 +114,14 @@ function createGeneratedMessageId(
   runId: string,
   index: number,
 ): string {
-  const prefix = role === "user" ? "user" : role === "system" ? "system" : "assistant";
+  const prefix =
+    role === "user"
+      ? "user"
+      : role === "system"
+        ? "system"
+        : role === "developer"
+          ? "developer"
+          : "assistant";
   return `${prefix}:${runId}:${index}`;
 }
 
@@ -99,9 +130,11 @@ function messageShouldFlushAfterPayload(payload: AdkEventPayload): boolean {
 }
 
 function normalizeUiMessageRole(value: string | undefined): Message["role"] {
-  return value === "user" || value === "system" || value === "tool"
-    ? value
-    : "assistant";
+  const role = normalizeCompatibleMessageRole(value);
+  if (role === "user" || role === "system" || role === "tool") {
+    return role;
+  }
+  return "assistant";
 }
 
 export class AdkMessageStreamNormalizer {
@@ -165,12 +198,12 @@ export class AdkMessageStreamNormalizer {
     const text = extractTextParts(payload).join("");
     const isToolResponsePart = payload.content?.parts?.some((p) => p.functionResponse);
 
-    if (role !== "agent" || messageShouldFlushAfterPayload(payload)) {
+    if (role !== "assistant" || messageShouldFlushAfterPayload(payload)) {
       this.flushAssistantMessage(events, common);
     }
 
     if (text.trim().length > 0 && payload.message?.role !== "tool" && !isToolResponsePart) {
-      if (role === "agent") {
+      if (role !== "user" && role !== "system" && role !== "developer") {
         let openMessage = this.openAssistantMessages.get(common.runId);
         if (!openMessage) {
           openMessage = {
@@ -482,7 +515,7 @@ export class AdkMessageStreamNormalizer {
       );
     }
 
-    if (role === "agent" && messageShouldFlushAfterPayload(payload)) {
+    if (role === "assistant" && messageShouldFlushAfterPayload(payload)) {
       this.flushAssistantMessage(events, common);
     }
 
@@ -541,7 +574,7 @@ export function adkEventsToMessages(events: AdkEventPayload[]): Message[] {
     return {
       ...createAgUiMessage({
         id: e.id,
-        role: normalizeUiMessageRole(e.message?.role || e.author),
+        role: normalizeUiMessageRole(e.message?.role),
         content,
         createdAt: new Date((e.timestamp || Date.now() / 1000) * 1000),
         threadId: e.threadId,
@@ -604,8 +637,7 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
     const createdAt = new Date((event.timestamp || Date.now() / 1000) * 1000);
     const existing = messageMap.get(messageId) || {
       id: messageId,
-      role:
-        getEventRole(event) || "assistant",
+      role: normalizeUiMessageRole(getEventRole(event)),
       content: "",
       createdAt,
       runId: getEventRunId(event),
@@ -617,7 +649,7 @@ export function aguiEventsToMessages(events: BaseEvent[]): Message[] {
       event.type === EventType.TEXT_MESSAGE_START &&
       typeof getEventRole(event) === "string"
     ) {
-      existing.role = getEventRole(event)!;
+      existing.role = normalizeUiMessageRole(getEventRole(event));
     }
 
     if (event.type === EventType.TEXT_MESSAGE_CONTENT) {

--- a/apps/negentropy-ui/lib/agui/factories.ts
+++ b/apps/negentropy-ui/lib/agui/factories.ts
@@ -4,6 +4,7 @@ import type {
   ActivitySnapshotEvent,
   AgUiMessage,
   BaseEventProps,
+  CompatibleEventMessageRole,
   CustomEvent,
   MessagesSnapshotEvent,
   RawEvent,
@@ -25,7 +26,7 @@ type RequiredMessageEventProps = BaseEventProps & { messageId: string };
 
 export function createTextMessageStartEvent(
   props: RequiredMessageEventProps,
-  role: "user" | "agent" | "system",
+  role: CompatibleEventMessageRole,
 ): TextMessageStartEvent {
   return {
     type: EventType.TEXT_MESSAGE_START,

--- a/apps/negentropy-ui/lib/agui/schema.ts
+++ b/apps/negentropy-ui/lib/agui/schema.ts
@@ -23,7 +23,7 @@ export const baseEventSchema = baseEventPropsSchema
 
 const textMessageStartEventSchema = baseEventPropsSchema.extend({
   type: z.literal(EventType.TEXT_MESSAGE_START),
-  role: z.enum(["user", "agent", "system"]),
+  role: z.enum(["user", "assistant", "agent", "system", "developer", "tool"]),
 });
 
 const textMessageContentEventSchema = baseEventPropsSchema.extend({

--- a/apps/negentropy-ui/tests/helpers/agui.ts
+++ b/apps/negentropy-ui/tests/helpers/agui.ts
@@ -4,7 +4,12 @@ import {
   createTextMessageEndEvent,
   createTextMessageStartEvent,
 } from "@/lib/agui/factories";
-import { createAgUiMessage, type AgUiEvent, type AgUiMessage } from "@/types/agui";
+import {
+  createAgUiMessage,
+  type AgUiEvent,
+  type AgUiMessage,
+  type CompatibleEventMessageRole,
+} from "@/types/agui";
 
 export function createTestMessage(input: {
   id: string;
@@ -30,7 +35,7 @@ export function createTestTextMessageEvents(input: {
   threadId?: string;
   runId?: string;
   messageId: string;
-  role: "user" | "agent" | "system";
+  role: CompatibleEventMessageRole;
   timestamp: number;
   delta: string;
 }): AgUiEvent[] {

--- a/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.test.tsx
@@ -11,7 +11,7 @@ describe("ChatStream", () => {
   it("在空树时渲染占位文案", () => {
     render(<ChatStream nodes={[]} />);
     expect(
-      screen.getByText("发送指令开始对话。主区将以 A2UI 模块树实时展示消息、工具、活动与状态。"),
+      screen.getByText("发送指令开始对话。主区会优先展示聊天消息，并在答复下附带工具、状态与活动摘要。"),
     ).toBeInTheDocument();
   });
 
@@ -144,8 +144,6 @@ describe("ChatStream", () => {
     ];
 
     const { container } = render(<ChatStream nodes={nodes} />);
-
-    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
 
     const contentWrapper = container.querySelector(".space-y-4");
     CHAT_CONTENT_RAIL_CLASS.split(" ").forEach((className) => {

--- a/apps/negentropy-ui/tests/unit/features/timeline/useEventFilter.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/timeline/useEventFilter.test.ts
@@ -22,7 +22,7 @@ describe("useEventFilter", () => {
 
   const msg2Events = createTestTextMessageEvents({
     messageId: "msg2",
-    role: "agent",
+    role: "assistant",
     timestamp: 2000,
     delta: "Hi",
   });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -479,4 +479,91 @@ describe("buildConversationTree", () => {
     expect(tree.roots[0].children).toHaveLength(1);
     expect(tree.roots[0].children[0].payload.args).toBe("{\"q\":\"hello\"}");
   });
+
+  it("优先使用 messages snapshot 纠正历史用户消息角色", () => {
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-user",
+        role: "assistant",
+        timestamp: 1001,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "msg-user",
+        delta: "Hi",
+        timestamp: 1002,
+      }),
+      createTestEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "snapshot-1",
+        timestamp: 1003,
+        messages: [
+          {
+            id: "msg-user",
+            role: "user",
+            content: "Hi",
+            threadId: "thread-1",
+            runId: "run-1",
+            createdAt: "1970-01-01T00:16:41.000Z",
+          },
+        ],
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].children).toHaveLength(1);
+    expect(tree.roots[0].children[0].type).toBe("text");
+    expect(tree.roots[0].children[0].role).toBe("user");
+    expect(tree.roots[0].children[0].title).toBe("用户消息");
+  });
+
+  it("messages snapshot 可补入缺失的历史用户消息", () => {
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "snapshot-1",
+        timestamp: 1001,
+        messages: [
+          {
+            id: "msg-user",
+            role: "user",
+            content: "Need help",
+            threadId: "thread-1",
+            runId: "run-1",
+            createdAt: "1970-01-01T00:16:41.000Z",
+          },
+        ],
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].children).toHaveLength(1);
+    expect(tree.roots[0].children[0].payload.content).toBe("Need help");
+    expect(tree.roots[0].children[0].role).toBe("user");
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/message.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/message.test.ts
@@ -25,7 +25,7 @@ function buildTextEvents(input: {
 }): AgUiEvent[] {
   return createTestTextMessageEvents({
     messageId: input.messageId,
-    role: input.role === "assistant" ? "agent" : input.role,
+    role: input.role,
     delta: input.delta,
     timestamp: input.timestamp ?? 0,
   }).map((event) =>

--- a/apps/negentropy-ui/types/a2ui.ts
+++ b/apps/negentropy-ui/types/a2ui.ts
@@ -1,4 +1,5 @@
 import type { BaseEvent, Message } from "@ag-ui/core";
+import type { CanonicalMessageRole } from "@/types/agui";
 
 export type ConversationNodeType =
   | "turn"
@@ -34,7 +35,7 @@ export interface ConversationNode {
   sourceOrder: number;
   title: string;
   status?: string;
-  role?: "user" | "assistant" | "system";
+  role?: CanonicalMessageRole;
   summary?: string;
   visibility: "chat" | "collapsed" | "debug-only";
   isStructural?: boolean;

--- a/apps/negentropy-ui/types/agui.ts
+++ b/apps/negentropy-ui/types/agui.ts
@@ -30,6 +30,15 @@ export interface ExtendedMessageProps {
 }
 
 export type AgUiMessage = Message & ExtendedMessageProps;
+export type CanonicalMessageRole =
+  | "user"
+  | "assistant"
+  | "system"
+  | "developer"
+  | "tool";
+export type CompatibleEventMessageRole =
+  | CanonicalMessageRole
+  | "agent";
 
 export type AgUiEvent = BaseEvent &
   Partial<
@@ -57,7 +66,7 @@ export type AgUiEvent = BaseEvent &
  */
 export interface TextMessageStartEvent extends BaseEventProps {
   type: EventType.TEXT_MESSAGE_START;
-  role: "user" | "agent" | "system";
+  role: CompatibleEventMessageRole;
 }
 
 export interface TextMessageContentEvent extends BaseEventProps {
@@ -325,11 +334,29 @@ export function createAgUiMessage(input: {
   } as AgUiMessage;
 }
 
+export function normalizeCompatibleMessageRole(
+  role: string | undefined | null,
+): CanonicalMessageRole {
+  if (role === "user") {
+    return "user";
+  }
+  if (role === "system") {
+    return "system";
+  }
+  if (role === "developer") {
+    return "developer";
+  }
+  if (role === "tool") {
+    return "tool";
+  }
+  return "assistant";
+}
+
 export function createOptimisticTextEvents(input: {
   threadId: string;
   runId: string;
   messageId: string;
-  role: "user" | "agent" | "system";
+  role: CompatibleEventMessageRole;
   content: string;
   timestamp: number;
 }): AgUiEvent[] {

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -16,6 +16,8 @@ import {
   getMessageCreatedAt,
   getMessageRunId,
   getMessageThreadId,
+  normalizeCompatibleMessageRole,
+  type CanonicalMessageRole,
 } from "@/types/agui";
 import {
   buildNodeSummary,
@@ -35,6 +37,16 @@ type LinkInstruction = {
   parentId: string;
 };
 
+type MessageSnapshotEntry = {
+  id: string;
+  role: CanonicalMessageRole;
+  content: string;
+  threadId: string;
+  runId?: string;
+  timestamp: number;
+  author?: string;
+};
+
 const DEFAULT_THREAD_ID = "default";
 const DEFAULT_RUN_ID = "default";
 
@@ -45,10 +57,14 @@ function normalizeRunId(value: string | undefined, fallbackRunId?: string): stri
   return value;
 }
 
-function normalizeRole(value: unknown): "user" | "assistant" | "system" {
-  if (value === "user") return "user";
-  if (value === "system") return "system";
-  return "assistant";
+function normalizeRole(value: unknown): CanonicalMessageRole {
+  return normalizeCompatibleMessageRole(
+    typeof value === "string" ? value : undefined,
+  );
+}
+
+function isAssistantLikeRole(role: CanonicalMessageRole): boolean {
+  return role === "assistant" || role === "developer";
 }
 
 function normalizeTimestamp(value: unknown): number {
@@ -69,7 +85,7 @@ function createNode(input: {
   sourceOrder?: number;
   title: string;
   status?: string;
-  role?: "user" | "assistant" | "system";
+  role?: CanonicalMessageRole;
   summary?: string;
   payload?: Record<string, unknown>;
   sourceEventTypes?: string[];
@@ -309,6 +325,78 @@ function getMessageTimestamp(message: Message): number {
   return createdAt instanceof Date ? createdAt.getTime() / 1000 : Date.now() / 1000;
 }
 
+function extractMessagesSnapshotEntries(
+  snapshot: unknown,
+  fallback: {
+    threadId: string;
+    runId: string;
+    timestamp: number;
+  },
+): MessageSnapshotEntry[] {
+  if (!Array.isArray(snapshot)) {
+    return [];
+  }
+
+  return snapshot.flatMap((entry, index) => {
+    if (typeof entry !== "object" || entry === null) {
+      return [];
+    }
+
+    const record = entry as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : undefined;
+    if (!id) {
+      return [];
+    }
+
+    const rawContent = record.content;
+    const content =
+      typeof rawContent === "string"
+        ? rawContent
+        : Array.isArray(rawContent)
+          ? rawContent
+              .map((part) =>
+                typeof part === "string" ? part : JSON.stringify(part),
+              )
+              .join("")
+          : rawContent
+            ? JSON.stringify(rawContent)
+            : "";
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      return [];
+    }
+
+    return [
+      {
+        id,
+        role: normalizeRole(record.role),
+        content: trimmedContent,
+        threadId:
+          typeof record.threadId === "string" && record.threadId.trim()
+            ? record.threadId
+            : fallback.threadId,
+        runId:
+          typeof record.runId === "string" && record.runId.trim()
+            ? record.runId
+            : fallback.runId,
+        timestamp:
+          typeof record.createdAt === "string" || record.createdAt instanceof Date
+            ? (() => {
+                const parsed = new Date(record.createdAt).getTime() / 1000;
+                return Number.isFinite(parsed)
+                  ? parsed
+                  : fallback.timestamp + index * 0.0001;
+              })()
+            : typeof record.timestamp === "number"
+              ? record.timestamp
+              : fallback.timestamp + index * 0.0001,
+        author:
+          typeof record.author === "string" ? record.author : undefined,
+      },
+    ];
+  });
+}
+
 function findMatchingTextNodeId(
   nodeIndex: Map<string, MutableNode>,
   input: {
@@ -437,7 +525,7 @@ export function buildConversationTree(
   const toolNodeIndex = new Map<string, string>();
   const turns = new Map<string, MutableNode>();
   const assistantMessageByRun = new Map<string, string>();
-  const messageRoleById = new Map<string, "user" | "assistant" | "system">();
+  const messageRoleById = new Map<string, CanonicalMessageRole>();
   const messageMetaById = new Map<
     string,
     {
@@ -449,6 +537,7 @@ export function buildConversationTree(
   >();
   const pendingConfirmationCountByRun = new Map<string, number>();
   const pendingLinks: LinkInstruction[] = [];
+  const snapshotMessagesById = new Map<string, MessageSnapshotEntry>();
   let activeRunId: string | undefined;
 
   const orderedEvents = [...events].sort((a, b) => {
@@ -514,7 +603,9 @@ export function buildConversationTree(
         const role =
           normalizedEvent.type === EventType.TEXT_MESSAGE_START && "role" in normalizedEvent
             ? normalizeRole(normalizedEvent.role)
-            : (messageRoleById.get(messageId) ?? "assistant");
+            : (messageRoleById.get(messageId) ||
+                snapshotMessagesById.get(messageId)?.role ||
+                "assistant");
         if (normalizedEvent.type === EventType.TEXT_MESSAGE_START && role) {
           messageRoleById.set(messageId, role);
           messageMetaById.set(messageId, {
@@ -540,11 +631,14 @@ export function buildConversationTree(
             : "";
         const existingNodeId = messageNodeIndex.get(messageId);
         const matchedNodeId =
-          !existingNodeId && role === "assistant" && delta
+          !existingNodeId && isAssistantLikeRole(role) && delta
             ? findMatchingTextNodeId(nodeIndex, {
                 threadId: meta.threadId,
                 runId: meta.runId,
-                role,
+                role:
+                  role === "developer" || role === "tool"
+                    ? "assistant"
+                    : role,
                 content: delta,
                 timestamp: normalizeTimestamp(normalizedEvent.timestamp),
               })
@@ -579,7 +673,7 @@ export function buildConversationTree(
         if (matchedNodeId && matchedNodeId !== `message:${messageId}`) {
           node.messageId = node.messageId || messageId;
         }
-        if (node.role === "assistant") {
+        if (node.role && isAssistantLikeRole(node.role)) {
           assistantMessageByRun.set(meta.runId, node.id);
         }
         attachNode(nodeIndex, roots, turns, node.id, turn.id);
@@ -674,6 +768,23 @@ export function buildConversationTree(
           }
         }
         attachNode(nodeIndex, roots, turns, node.id, parentId);
+        return;
+      }
+      case EventType.MESSAGES_SNAPSHOT: {
+        const snapshotMessages =
+          "messages" in normalizedEvent
+            ? extractMessagesSnapshotEntries(normalizedEvent.messages, {
+                threadId: turn.threadId,
+                runId,
+                timestamp: normalizeTimestamp(normalizedEvent.timestamp),
+              })
+            : [];
+        snapshotMessages.forEach((message) => {
+          snapshotMessagesById.set(message.id, message);
+          if (!messageRoleById.has(message.id)) {
+            messageRoleById.set(message.id, message.role);
+          }
+        });
         return;
       }
       case EventType.ACTIVITY_SNAPSHOT: {
@@ -885,9 +996,39 @@ export function buildConversationTree(
     }
   });
 
-  fallbackMessages.forEach((message, fallbackIndex) => {
+  const mergedFallbackMessages = [
+    ...fallbackMessages,
+    ...[...snapshotMessagesById.values()]
+      .filter((snapshotMessage) => !fallbackMessages.some((message) => message.id === snapshotMessage.id))
+      .map((snapshotMessage) =>
+        ({
+          id: snapshotMessage.id,
+          role: snapshotMessage.role,
+          content: snapshotMessage.content,
+          createdAt: new Date(snapshotMessage.timestamp * 1000),
+          author: snapshotMessage.author,
+          runId: snapshotMessage.runId,
+          threadId: snapshotMessage.threadId,
+        }) as Message,
+      ),
+  ];
+
+  mergedFallbackMessages.forEach((message, fallbackIndex) => {
     const messageId = message.id;
     if (messageNodeIndex.has(messageId)) {
+      const existingNodeId = messageNodeIndex.get(messageId);
+      const existingNode = existingNodeId ? nodeIndex.get(existingNodeId) : null;
+      const snapshotMessage = snapshotMessagesById.get(messageId);
+      if (
+        existingNode &&
+        snapshotMessage &&
+        existingNode.type === "text" &&
+        existingNode.role !== snapshotMessage.role
+      ) {
+        existingNode.role = snapshotMessage.role;
+        existingNode.title =
+          snapshotMessage.role === "user" ? "用户消息" : "助手消息";
+      }
       return;
     }
     const runId = getMessageRunId(message);

--- a/docs/a2ui.md
+++ b/docs/a2ui.md
@@ -1,133 +1,136 @@
-# A2UI 协议调研与 Negentropy Chat 落地
+# AGUI / A2UI 协议校正与 Chat 页落地方案
 
-## 1. 摘要
+## 1. 文档定位
 
-本文档作为本项目 A2UI 调研、实施方案、实施进度与验证记录的单一事实源。
+本文档是本项目关于 AGUI / A2UI 的单一事实源，目标有三件事：
 
-- 传输层：沿用现有 [AG-UI BFF 路由](../apps/negentropy-ui/app/api/agui/route.ts)
-- 语义层：在前端新增 A2UI 风格的消息树/组件树适配
-- 首期目标：让 Chat 页以“完整消息模块/事件模块”为单位渲染，并支持父子事件嵌套展示
+- 校正协议事实，避免把官方规范与本项目约定混写。
+- 说明本项目如何用 AGUI 事件流构建 A2UI 读模型。
+- 明确 Chat 页的聊天优先落地方式、边界与验证口径。
 
-## 2. 协议定义与关系
+截至 2026-03-08，本项目采用：
 
-### 2.1 A2UI 在本项目中的工作定义
+- `AGUI` 作为传输层与事件事实源。
+- `A2UI` 作为前端读模型与生成式 UI 组织方式。
+- `Chat` 主区采用聊天优先呈现，而不是树形结构优先。
 
-本项目中的 A2UI 指向一种“面向 Agent 的生成式 UI 语义层”：
+## 2. 协议事实
 
-- 以事件流作为事实源
-- 以父子节点树作为渲染模型
-- 以组件注册表承载不同事件类型的可视化
-- 允许标准协议事件与项目自定义事件共存
+### 2.1 AGUI 的职责
 
-### 2.2 A2UI 与 AG-UI 的关系
+AGUI 负责定义 agent 交互中的事件、消息、工具调用、状态与流式生命周期，是本项目的事实输入层<sup>[[1]](#ref1)</sup><sup>[[2]](#ref2)</sup>。
 
-- AG-UI 负责传输与基础事件定义：消息、工具、状态、步骤、原始事件等<sup>[[1]](#ref1)</sup>
-- A2UI 负责把这些事件适配为可递归渲染的 UI 树，并引入更强的组件化表达
+在本项目中，AGUI 的职责是：
 
-在本项目中采用：
+- 提供事件流输入。
+- 作为实时 SSE 与历史回放的共同语义基底。
+- 保证文本消息、工具调用、状态变化等信息可被统一归并。
 
-- `AG-UI transport`
-- `A2UI renderer`
+AGUI 不是页面布局协议。页面如何把这些事件组织成聊天流、树或组件，是前端读模型的职责。
 
-而不是双协议并存。
+### 2.2 A2UI 的职责
 
-## 3. 协议原理
+A2UI 关注的是生成式 UI 的结构化表达：容器、数据绑定、组件组合与基于状态的渲染约定<sup>[[3]](#ref3)</sup><sup>[[4]](#ref4)</sup>。
 
-### 3.1 事件溯源
+在本项目中，A2UI 不作为第二条传输协议接入；它的工作定义是：
 
-UI 不直接把流式片段当最终事实，而是把线性事件流重建为稳定读模型。该模式与事件溯源、快照回放一致，可降低流式拼接带来的状态漂移风险。
+- 使用 AGUI 事件作为输入事实源。
+- 在前端构建 `ConversationNode` 树作为读模型。
+- 将消息、工具、状态、活动等内容映射到可递归渲染的 UI 模块。
 
-### 3.2 组合模式
+因此，本项目的准确描述是：
 
-消息、工具、活动、状态、推理步骤都抽象为统一节点，由父节点递归持有子节点。这样能自然表达：
+- `AGUI transport`
+- `A2UI-inspired read model`
+- `chat-first presentation`
 
-- assistant 文本 -> tool call -> tool result
-- turn -> step -> reasoning note
-- turn -> activity/state/raw/custom
+而不是“AGUI 与 A2UI 双传输协议并存”。
 
-### 3.3 数据绑定与 JSON 结构
+### 2.3 官方字段与项目自定义字段
 
-状态增量与快照保持 JSON 结构，便于沿用 JSON Pointer / JSON Patch 的标准语义<sup>[[6]](#ref6)</sup><sup>[[7]](#ref7)</sup>。
+官方字段：
 
-## 4. 经典设计模式与场景用例
+- `RUN_STARTED`
+- `TEXT_MESSAGE_*`
+- `TOOL_CALL_*`
+- `STATE_*`
+- `MESSAGES_SNAPSHOT`
+- `STEP_*`
+- `RAW`
+- `CUSTOM`
 
-### 4.1 Adapter
+项目自定义事件：
 
-- 场景：`ADK payload -> AG-UI event -> A2UI node`
-- 本项目锚点：[adk.ts](../apps/negentropy-ui/lib/adk.ts)、[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
+- `ne.a2ui.link`
+- `ne.a2ui.reasoning`
 
-### 4.2 Composite
+这些 `ne.*` 事件仅代表本项目的父子关系回填与额外语义补充，不属于 AGUI 或 A2UI 官方标准。
 
-- 场景：父子消息、父子工具、轮次容器递归渲染
-- 本项目锚点：[ConversationNodeRenderer.tsx](../apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx)
+## 3. 本项目读模型约定
 
-### 4.3 Registry / Polymorphic Renderer
-
-- 场景：不同节点类型绑定不同渲染卡片
-- 本项目首期采用轻量映射；后续可演进为正式组件注册表
-
-### 4.4 Event Sourcing + Read Model
-
-- 场景：历史回放与实时流统一建模
-- 本项目锚点：[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
-
-## 5. 本项目现状与问题
-
-改造前，Chat 页主路径为：
-
-```mermaid
-flowchart LR
-  A[AG-UI Raw Events] --> B[buildChatMessagesFromEventsWithFallback]
-  B --> C[ChatMessage[]]
-  C --> D[ChatStream]
-```
-
-问题：
-
-- 工具调用按 `runId` 粗粒度挂载，父子关系不稳定
-- `TEXT_MESSAGE_CONTENT` 被压扁为文本，活动/状态/原始事件无法成为一级模块
-- 主聊天区与右侧观察区职责失衡，导致真正的“交互结构”不可见
-- 纯结构性事件和空 payload 技术事件会污染主聊天区，造成空白消息块、重复 JSON 模块和错误时序
-
-### 5.1 Chat-friendly A2UI 规则
-
-为避免把“协议完整性”直接等价成“主聊天区全部直出”，Chat 页采用面向阅读的三层可见性模型：
-
-- `chat`：用户消息、助手消息、工具调用、工具结果
-- `collapsed`：活动、步骤、推理、状态、自定义业务事件，默认以摘要卡片显示
-- `debug-only`：纯结构性链接事件、原始事件、空 payload 技术事件，仅保留在调试链路
-
-对应策略：
-
-- `ne.a2ui.link` 仅用于树关系回填，不进入主聊天区
-- 空文本节点与空技术节点在树构建阶段裁剪
-- fallback 用户消息优先挂到最近轮次，避免作为裸 root 插入响应中部
-- JSON 默认走“摘要卡片 + 按需展开详情”，而不是直接作为消息气泡展示
-
-## 6. 实施方案
-
-### 6.1 目标结构
+### 3.1 总体结构
 
 ```mermaid
 flowchart TD
-  subgraph Transport
-    A[ADK SSE]
+  subgraph Transport["Transport / Fact Source"]
+    A[ADK Payload]
     B[/api/agui]
-    C[AG-UI Events]
+    C[AGUI Events]
   end
 
-  subgraph A2UI
-    D[Conversation Tree Builder]
-    E[Conversation Nodes]
-    F[Recursive Renderer]
+  subgraph ReadModel["A2UI Read Model"]
+    D[normalizeAguiEvent]
+    E[buildConversationTree]
+    F[ConversationNode Tree]
+  end
+
+  subgraph Presentation["Chat-first Presentation"]
+    G[Chat Main Rail]
+    H[Technical Attachments]
+    I[Timeline / State / Logs]
   end
 
   A --> B --> C --> D --> E --> F
+  F --> G
+  F --> H
+  C --> I
 ```
 
-### 6.2 节点模型
+对应代码锚点：
 
-首期支持：
+- 传输入口：[route.ts](../apps/negentropy-ui/app/api/agui/route.ts)
+- ADK 到 AGUI 归一化：[adk.ts](../apps/negentropy-ui/lib/adk.ts)
+- 事件到树构建：[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
+- Chat 主区渲染：[ChatStream.tsx](../apps/negentropy-ui/components/ui/ChatStream.tsx)
+- 递归节点渲染：[ConversationNodeRenderer.tsx](../apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx)
+
+### 3.2 Canonical Role 约定
+
+本项目内部统一使用 canonical role：
+
+- `user`
+- `assistant`
+- `system`
+- `developer`
+- `tool`
+
+兼容入口：
+
+- `agent` 仅作为兼容输入值保留。
+- 一旦进入系统，`agent` 必须单向收敛为 `assistant`。
+
+角色优先级：
+
+1. 显式 `message.role` / 事件 `role`
+2. `messagesSnapshot` 中的消息角色
+3. 工具消息特征
+4. 兼容兜底为 `assistant`
+
+`author` 只保留为展示元数据，不作为自由 role 来源直接参与聊天主语义判定。
+
+### 3.3 ConversationNode 节点模型
+
+当前读模型节点类型：
 
 - `turn`
 - `text`
@@ -143,111 +146,134 @@ flowchart TD
 - `event`
 - `error`
 
-### 6.3 父子关系规则
+父子关系规则：
 
-- 同一 `runId` 建立 `turn` 根节点
-- `TEXT_MESSAGE_*` 聚合为 `text` 节点
-- `TOOL_CALL_*` 聚合为 `tool-call` 节点，优先挂到最近 assistant 消息下
-- `TOOL_CALL_RESULT` 挂到对应 `tool-call`
-- `STEP_*` 生成 `step` + `reasoning`
-- `STATE_*`、`ACTIVITY_*`、`RAW`、`CUSTOM` 默认挂到 `turn`
-- `ne.a2ui.link` 可显式重定父子关系
+- 同一 `runId` 生成一个 `turn` 根节点。
+- `TEXT_MESSAGE_*` 聚合为 `text`。
+- `TOOL_CALL_*` 优先挂到当前 assistant 文本节点下。
+- `TOOL_CALL_RESULT` 挂到对应 `tool-call` 下。
+- `STEP_*` 生成 `step`，并补一个 `reasoning` 摘要节点。
+- `STATE_*`、`ACTIVITY_*` 默认挂到 `turn` 或对应答复上下文。
+- `ne.a2ui.link` 仅做父子关系修正，不直接进入主聊天区。
 
-### 6.4 组件支持矩阵
+### 3.4 历史回放与实时流一致性
 
-| 节点类型 | 主聊天区 | 嵌套 | 首期状态 |
-| --- | --- | --- | --- |
-| `text` | 是 | 是 | 已实现 |
-| `tool-call` | 是 | 是 | 已实现 |
-| `tool-result` | 是 | 是 | 已实现 |
-| `activity` | 是 | 是 | 已实现 |
-| `reasoning` | 是 | 是 | 已实现 |
-| `step` | 是 | 是 | 已实现 |
-| `state-delta` | 是 | 是 | 已实现 |
-| `state-snapshot` | 是 | 是 | 已实现 |
-| `raw` | 是 | 是 | 已实现 |
-| `custom` | 是 | 是 | 已实现 |
-| `event` | 是 | 是 | 已实现 |
-| `error` | 是 | 是 | 已实现 |
+实时流与历史回放必须走同一套归并语义，避免刷新前后出现 split-brain：
 
-## 7. 类图
+- 文本流靠 `TEXT_MESSAGE_START / CONTENT / END` 收敛。
+- 乐观用户消息与历史确认消息通过统一 identity key 去重。
+- `messagesSnapshot` 用于修正历史角色缺失或补足消息列表。
+- 树构建是读模型重建，不是事实源本身。
+
+## 4. Chat 页落地方式
+
+### 4.1 为什么是聊天优先
+
+Chat 页的主任务是“阅读并参与对话”，不是“调试节点树”。如果把 turn、状态、结构性事件直接放在主车道，会破坏用户对“我说了什么、智能体回了什么”的基本心智。
+
+因此主区遵循：
+
+- 优先展示稳定的 user / assistant 消息流。
+- 技术节点作为答复附件或折叠块。
+- 调试节点进入右侧观测区或 `debug-only` 链路。
+
+### 4.2 主区信息分层
+
+主区分三层：
+
+1. 聊天主语义
+   - `user` 文本
+   - `assistant` / `developer` 文本
+   - `system` 提示
+
+2. 技术附属语义
+   - `tool-call`
+   - `tool-result`
+   - `activity`
+   - `state-*`
+   - `step`
+   - `reasoning`
+   - `error`
+
+3. 调试语义
+   - `raw`
+   - 纯结构 `custom`
+   - 空 payload 技术节点
+
+可见性约定：
+
+- `chat`：进入主区
+- `collapsed`：进入主区但默认摘要化
+- `debug-only`：不进入主区
+
+### 4.3 当前 Chat 页强约束
+
+1. 用户消息必须渲染为 user bubble，不能被历史回放降级为 assistant bubble。
+2. assistant 的流式片段与最终快照必须收敛为一个答复块。
+3. `turn` 容器只作为轻量轮次边界，不得喧宾夺主。
+4. 工具、状态、活动不能伪装成一条新的聊天答复。
+5. 历史刷新后，主区消息顺序、角色和数量必须与实时态保持一致。
+
+### 4.4 UI 结构示意
 
 ```mermaid
-classDiagram
-  class ConversationNode {
-    +id
-    +type
-    +parentId
-    +children[]
-    +threadId
-    +runId
-    +messageId
-    +toolCallId
-    +timeRange
-    +payload
-  }
+flowchart TD
+  subgraph ChatRail["Chat Main Rail"]
+    U[User Bubble]
+    A[Assistant Bubble]
+    T[Tool Attachments]
+    S[State / Activity Summary]
+  end
 
-  class ConversationTree {
-    +roots[]
-    +nodeIndex
-    +messageNodeIndex
-    +toolNodeIndex
-  }
-
-  class ConversationNodeRenderer
-  class MessageBubble
-
-  ConversationTree --> ConversationNode
-  ConversationNodeRenderer --> ConversationNode
-  ConversationNodeRenderer --> MessageBubble
+  U --> A
+  A --> T
+  A --> S
 ```
 
-## 8. 实施进度
+## 5. 已知问题与修正策略
 
-| 事项 | 状态 | 文件锚点 | 验证证据 | 风险 |
-| --- | --- | --- | --- | --- |
-| A2UI 文档建档 | 已完成 | [a2ui.md](./a2ui.md) | 文档已创建 | 后续需持续维护 |
-| 新增节点类型 | 已完成 | [a2ui.ts](../apps/negentropy-ui/types/a2ui.ts) | 类型已落地 | 仍需随协议演进补字段 |
-| 事件到树构建器 | 已完成 | [conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts) | 可处理文本/工具/状态/步骤 | 复杂链路仍需更多用例覆盖 |
-| Chat 树形渲染 | 已完成 | [ChatStream.tsx](../apps/negentropy-ui/components/ui/ChatStream.tsx) | 主区已切换为递归节点渲染 | 视觉细节仍可继续打磨 |
-| A2UI 自定义关联事件 | 已完成 | [adk.ts](../apps/negentropy-ui/lib/adk.ts) | 已注入 `ne.a2ui.link` / `ne.a2ui.reasoning` | 上游若提供原生父子关系，可进一步收敛 |
-| Chat 乱序与空白节点治理 | 已完成 | [conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts) | 已修复默认 `runId` 归并、空节点裁剪、fallback 消息挂靠与技术节点过滤 | 后续仍需补更多真实流量样例 |
-| Live / History 归并一致性 | 已完成 | [agui-normalization.ts](../apps/negentropy-ui/utils/agui-normalization.ts) | 实时 SSE 与历史回放已共用同一套 AG-UI 归并规则 | 后续仍需覆盖更多历史脏数据 |
-| 连续用户消息稳定排序 | 已完成 | [conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts) | 已为节点引入稳定顺序键，修复连续 user 消息倒序 | 多轮并发场景仍需继续观察 |
-| 发送后答复回拉闭环 | 已完成 | [page.tsx](../apps/negentropy-ui/app/page.tsx) | `runAgent` 完成后会回拉 session detail，补全 assistant 回复展示 | 若上游延迟较大，仍需后续评估重试策略 |
-| 单元测试补齐 | 已完成 | [tests/unit](../apps/negentropy-ui/tests/unit) | `pnpm --dir apps/negentropy-ui test` 通过，23 个测试文件全部通过 | `lint/build` 仍受整仓存量问题影响 |
+### 5.1 已知问题
 
-## 9. 最佳实践
+本轮修正前，Chat 页存在以下风险：
 
-- 始终保留原始事件流，节点树只作为派生读模型
-- 父子关系优先显式链路，缺失时再推断
-- 不暴露私有推理原文，仅渲染安全摘要或阶段状态
-- 主聊天区负责“交互结构”，右侧面板负责“观测镜像”
-- 新类型先走 `custom` 回退，再决定是否升级为正式组件
-- 主聊天区必须做信息分层，不能把结构性事件和调试载荷直接视作聊天消息
-- 技术类 JSON 默认展示摘要卡片，并提供显式展开入口，避免噪音淹没主对话
-- 实时流与历史回放必须复用同一套事件归并逻辑，避免 Chat 树在刷新后产生 split-brain
-- 用户本地乐观消息必须携带稳定顺序键，不能让随机 ID 或重建时机决定显示顺序
+- 用户历史消息可能因为 role 丢失，被按 assistant 方式渲染。
+- `agent` / `assistant` 混用，导致类型与渲染逻辑双轨。
+- `author` 被宽泛当作 role 来源，污染聊天主语义。
+- A2UI 树在主区中过度显性，削弱了聊天流体验。
 
-## 10. 后续建议
+### 5.2 修正策略
 
-- 补正式组件注册表，支持插件化节点渲染
-- 为 `ne.a2ui.activity-meta` 增加更丰富的活动语义
-- 给技术节点增加折叠态与过滤器
-- 为历史会话回放增加树差异比对测试
+本轮采用以下原则：
 
-## 11. 参考文献
+- role 统一收敛为 canonical role。
+- `messagesSnapshot` 优先用于历史角色纠偏。
+- `turn` 卡片视觉弱化，消息气泡回到阅读中心。
+- 自定义 `ne.*` 事件只用于结构修正，不直接进入聊天主语义。
+
+## 6. 验证口径
+
+必须覆盖以下场景：
+
+- 乐观用户消息发送后立即显示为 user bubble。
+- 历史回拉确认同一条用户消息后，不出现重复 bubble。
+- 历史 payload 中 `message.role = "user"` 时，主区稳定显示为 user bubble。
+- 历史事件角色异常但 `messagesSnapshot` 正确时，主区仍以 snapshot 纠正。
+- assistant 实时流与最终快照 `messageId` 不同，仍只显示一个最终答复。
+- 工具、活动、状态节点仍可见，但不会打断主聊天主线。
+
+## 7. 后续演进建议
+
+- 引入正式的节点渲染注册表，替代当前轻量分支渲染。
+- 将技术附件与聊天主语义拆成明确的 presentation layer 接口。
+- 在历史 hydration 链路显式消费 `messagesSnapshot`，减少 UI 层补救负担。
+- 为真实会话样本增加快照回放回归集，持续监控角色和去重一致性。
+
+## 8. 参考文献
 
 <a id="ref1"></a>[1] AG-UI Docs, "Events," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/concepts/events
 
-<a id="ref2"></a>[2] AG-UI Docs, "Serialization," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/concepts/serialization
+<a id="ref2"></a>[2] AG-UI Docs, "Messages," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/concepts/messages
 
-<a id="ref3"></a>[3] AG-UI Docs, "Generative User Interfaces," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/draft-proposals/generative-user-interfaces
+<a id="ref3"></a>[3] AG-UI Docs, "Generative User Interfaces," *AG-UI Documentation*, 2026. [Online]. Available: https://docs.ag-ui.com/concepts/generative-ui
 
-<a id="ref4"></a>[4] A2UI, "A2UI Specification," *A2UI*, 2026. [Online]. Available: https://a2ui.org/specification
-
-<a id="ref5"></a>[5] A2UI, "A2UI Message Types," *A2UI*, 2026. [Online]. Available: https://a2ui.org/message-types
-
-<a id="ref6"></a>[6] P. Bryan, Ed., "JavaScript Object Notation (JSON) Pointer," RFC 6901, Apr. 2013.
-
-<a id="ref7"></a>[7] P. Bryan and M. Nottingham, "JavaScript Object Notation (JSON) Patch," RFC 6902, Apr. 2013.
+<a id="ref4"></a>[4] A2UI, "A2UI Specification v0.8," *A2UI Documentation*, 2026. [Online]. Available: https://a2ui.org/specification


### PR DESCRIPTION
## 背景

当前 Chat 页存在明显的角色语义偏差：用户发送的消息在历史回放或归并后，会被按智能体答复样式渲染，破坏聊天主语义。与此同时，项目内对 AGUI 与 A2UI 的边界定义也存在混用，文档和实现之间不够一致，导致 Chat 页既承担聊天阅读流，又暴露过多树形技术结构，影响交互心智与后续维护。

本 PR 围绕这两个问题做一次收敛：一方面修正聊天角色归一化与历史消息纠偏，另一方面重新校正 AGUI / A2UI 在本项目中的职责边界，并把 Chat 主区重新对齐到“聊天优先”的落地方式。

## 本次改动

### 1. 收敛 AGUI / A2UI 的角色与事件语义

- 统一内部 canonical role 语义，明确 `agent` 仅作为兼容输入，进入系统后单向收敛为 `assistant`
- 扩宽并校正 AGUI 相关类型、schema 与工厂函数，避免不同层级继续混用 `agent / assistant`
- 调整 ADK -> AGUI 的归一化逻辑，减少把自由 `author` 宽泛当作聊天 role 的风险
- 保持消息层与事件层职责分离：事件层允许更完整的语义输入，消息层继续收敛到 Chat 可消费的最小集合

### 2. 修复 Chat 页用户消息被误渲染为 assistant 的问题

- 调整 `buildConversationTree` 的角色推断与节点收敛逻辑
- 在历史回放场景下优先使用 `messagesSnapshot` 对消息角色进行纠偏
- 避免用户历史消息在回放、归并、去重过程中被降级成 assistant 文本节点
- 维持乐观消息、实时流、历史 hydration 三条链路的角色语义一致性，降低 refresh 前后 split-brain 风险

### 3. 将 Chat 主区重新对齐为聊天优先

- 主区继续保留 A2UI 树能力，但视觉与交互上回到聊天流优先
- 弱化 turn 容器的存在感，避免其喧宾夺主
- 保留工具、状态、活动等技术节点，但作为答复附件或摘要块存在，而不是伪装成聊天主消息
- 同步更新空态文案，使其表达“聊天消息优先，技术信息附属展示”的页面语义

### 4. 重写协议与实践文档

- 重写 `docs/a2ui.md`
- 明确 AGUI 是传输层与事件事实源，A2UI 是本项目的读模型 / 渲染约定，而不是第二条并列传输协议
- 重新梳理 Chat 页的主区分层、节点职责、可见性规则、验证口径与后续演进建议
- 去除不适合作为正式 PR 描述的本地图片引用，改为稳定的文字化说明

### 5. 补充测试覆盖

- 新增 / 调整与角色归一化、snapshot 纠偏、聊天主区文案相关的测试
- 覆盖历史用户消息角色修正、snapshot 补消息、ChatStream 文案与时间线角色场景
- 确保本次修正不影响现有聊天链路与历史回拉能力

## 关键实现细节

- `messagesSnapshot` 被纳入历史角色纠偏路径，用于修复仅依赖事件流时可能出现的角色漂移
- `ConversationNode` 的 role 语义与 AGUI 相关类型一并收敛，减少树构建与渲染层的双轨判断
- turn 节点仍然保留，但从“主结构卡片”弱化为“聊天流的轻量边界提示”
- 自定义 `ne.a2ui.*` 事件继续只承担结构与语义补充职责，不扩张为新的协议事实源

## 验证

已执行：

- `pnpm typecheck`
- `pnpm test -- tests/unit/utils/conversation-tree.test.ts tests/unit/ChatStream.test.tsx tests/unit/ui/MessageBubble.test.tsx tests/unit/features/timeline/useEventFilter.test.ts tests/unit/adk.test.ts tests/integration/home-flow.test.tsx`

结果：

- `typecheck` 通过
- `vitest` 41 个测试文件、233 个测试全部通过
