### PR TITLE
fix(knowledge): 修复 MCP 文档提取参数适配与失败回退;

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from uuid import UUID
 
+import litellm
 from sqlalchemy import select, update
 
+from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.plugin import McpServer, McpTool
@@ -96,7 +99,40 @@ class ExtractionToolAdapter:
     schema_summary: dict[str, Any] = field(default_factory=dict)
 
 
-def resolve_source_kind(*, source_uri: str | None = None, filename: str | None = None, content_type: str | None = None) -> SourceKind:
+@dataclass(slots=True)
+class NormalizedToolContract:
+    mode: Literal["batch", "nested_single", "flat", "unknown"]
+    schema_shape: str
+    root_schema: dict[str, Any] | None = None
+    object_schema: dict[str, Any] | None = None
+    batch_property: str | None = None
+    source_property: str | None = None
+    item_schema: dict[str, Any] | None = None
+    top_level_fields: set[str] = field(default_factory=set)
+    source_fields: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class AdaptiveToolInvocationPlan:
+    adapter_name: str
+    arguments: dict[str, Any]
+    reasoning_source: Literal["schema", "validation_retry", "llm"]
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ValidationErrorSummary:
+    missing_fields: list[str] = field(default_factory=list)
+    unexpected_fields: list[str] = field(default_factory=list)
+    raw_error: str = ""
+
+
+def resolve_source_kind(
+    *,
+    source_uri: str | None = None,
+    filename: str | None = None,
+    content_type: str | None = None,
+) -> SourceKind:
     if source_uri and (source_uri.startswith("http://") or source_uri.startswith("https://")):
         return ROUTE_URL
 
@@ -209,7 +245,11 @@ def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
                 name=name,
                 content_type=content_type,
                 uri=item.get("uri") if isinstance(item.get("uri"), str) else None,
-                data_base64=item.get("data_base64") if isinstance(item.get("data_base64"), str) else item.get("content_base64"),
+                data_base64=(
+                    item.get("data_base64")
+                    if isinstance(item.get("data_base64"), str)
+                    else item.get("content_base64")
+                ),
                 text=item.get("text") if isinstance(item.get("text"), str) else None,
                 metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
             )
@@ -238,31 +278,144 @@ def _is_file_source_schema(schema: Any) -> bool:
     return bool({"filename", "content_base64", "data_base64"} & properties)
 
 
-def _detect_batch_sources_property(*, input_schema: dict[str, Any] | None, source_kind: SourceKind) -> str | None:
-    properties = _schema_properties(input_schema)
-    preferred_keys = (
-        ("url_sources", "sources", "documents", "items")
-        if source_kind == ROUTE_URL
-        else ("pdf_sources", "sources", "documents", "items")
-    )
-    for name in preferred_keys:
-        schema = properties.get(name)
-        if not isinstance(schema, dict) or schema.get("type") != "array":
+def _schema_path(schema: dict[str, Any], ref: str) -> dict[str, Any] | None:
+    if not ref.startswith("#/"):
+        return None
+    current: Any = schema
+    for part in ref[2:].split("/"):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current if isinstance(current, dict) else None
+
+
+def _expand_schema_variants(
+    schema: dict[str, Any] | None,
+    *,
+    root_schema: dict[str, Any] | None = None,
+    _seen_refs: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    if not isinstance(schema, dict):
+        return []
+    root = root_schema or schema
+    seen_refs = _seen_refs or set()
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        if ref in seen_refs:
+            return []
+        target = _schema_path(root, ref)
+        if not target:
+            return []
+        return _expand_schema_variants(target, root_schema=root, _seen_refs=seen_refs | {ref})
+
+    variants: list[dict[str, Any]] = []
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        branches = schema.get(combinator)
+        if isinstance(branches, list):
+            for branch in branches:
+                variants.extend(_expand_schema_variants(branch, root_schema=root, _seen_refs=seen_refs))
+
+    if variants:
+        properties = _schema_properties(schema)
+        if properties:
+            merged: list[dict[str, Any]] = []
+            for variant in variants:
+                variant_properties = dict(_schema_properties(variant))
+                merged_schema = dict(variant)
+                merged_schema["properties"] = {**properties, **variant_properties}
+                merged.append(merged_schema)
+            return merged
+        return variants
+
+    return [schema]
+
+
+def _preferred_batch_keys(source_kind: SourceKind) -> tuple[str, ...]:
+    if source_kind == ROUTE_URL:
+        return ("url_sources", "sources", "documents", "items")
+    return ("pdf_sources", "sources", "documents", "items")
+
+
+def _preferred_source_keys(source_kind: SourceKind) -> tuple[str, ...]:
+    if source_kind == ROUTE_URL:
+        return ("source", "url_source", "webpage_source", "document", "item")
+    return ("source", "pdf_source", "file_source", "document", "item")
+
+
+def _matches_source_schema(schema: Any, source_kind: SourceKind) -> bool:
+    if source_kind == ROUTE_URL:
+        return _is_url_source_schema(schema)
+    return _is_file_source_schema(schema)
+
+
+def normalize_tool_contract(
+    *,
+    input_schema: dict[str, Any] | None,
+    source_kind: SourceKind,
+) -> NormalizedToolContract:
+    if not isinstance(input_schema, dict):
+        return NormalizedToolContract(mode="unknown", schema_shape="missing")
+
+    variants = _expand_schema_variants(input_schema, root_schema=input_schema)
+    for variant in variants:
+        properties = _schema_properties(variant)
+        if not properties:
             continue
-        item_schema = schema.get("items")
-        if source_kind == ROUTE_URL and _is_url_source_schema(item_schema):
-            return name
-        if source_kind != ROUTE_URL and _is_file_source_schema(item_schema):
-            return name
-    for name, schema in properties.items():
-        if not isinstance(schema, dict) or schema.get("type") != "array":
-            continue
-        item_schema = schema.get("items")
-        if source_kind == ROUTE_URL and _is_url_source_schema(item_schema):
-            return name
-        if source_kind != ROUTE_URL and _is_file_source_schema(item_schema):
-            return name
-    return None
+
+        for name in [*_preferred_batch_keys(source_kind), *properties.keys()]:
+            schema = properties.get(name)
+            if not isinstance(schema, dict) or schema.get("type") != "array":
+                continue
+            item_schema = _expand_schema_variants(schema.get("items"), root_schema=input_schema)
+            selected_item_schema = next(
+                (item for item in item_schema if _matches_source_schema(item, source_kind)),
+                None,
+            )
+            if selected_item_schema:
+                return NormalizedToolContract(
+                    mode="batch",
+                    schema_shape="object.array",
+                    root_schema=input_schema,
+                    object_schema=variant,
+                    batch_property=name,
+                    item_schema=selected_item_schema,
+                    top_level_fields=set(properties.keys()),
+                    source_fields=_schema_property_names(selected_item_schema),
+                )
+
+        for name in [*_preferred_source_keys(source_kind), *properties.keys()]:
+            schema = properties.get(name)
+            if not isinstance(schema, dict):
+                continue
+            nested_variants = _expand_schema_variants(schema, root_schema=input_schema)
+            selected_variant = next(
+                (item for item in nested_variants if _matches_source_schema(item, source_kind)),
+                None,
+            )
+            if selected_variant:
+                return NormalizedToolContract(
+                    mode="nested_single",
+                    schema_shape="object.object",
+                    root_schema=input_schema,
+                    object_schema=variant,
+                    source_property=name,
+                    item_schema=selected_variant,
+                    top_level_fields=set(properties.keys()),
+                    source_fields=_schema_property_names(selected_variant),
+                )
+
+        if _matches_source_schema(variant, source_kind):
+            return NormalizedToolContract(
+                mode="flat",
+                schema_shape="object.flat",
+                root_schema=input_schema,
+                object_schema=variant,
+                top_level_fields=set(properties.keys()),
+                source_fields=set(properties.keys()),
+            )
+
+    return NormalizedToolContract(mode="unknown", schema_shape="unresolved", root_schema=input_schema)
 
 
 def _build_canonical_request(
@@ -328,51 +481,264 @@ def _build_source_item(
     return {key: value for key, value in payload.items() if value is not None}
 
 
+def _build_flat_payload(
+    *,
+    request: CanonicalExtractionRequest,
+    allowed_fields: set[str],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if request.source_kind == ROUTE_URL:
+        url_value = request.source.url or ""
+        if not allowed_fields or "url" in allowed_fields:
+            payload["url"] = url_value
+        elif "uri" in allowed_fields:
+            payload["uri"] = url_value
+    else:
+        base64_value = request.source.content_base64 or ""
+        if not allowed_fields or "filename" in allowed_fields:
+            payload["filename"] = request.source.filename
+        if not allowed_fields or "content_type" in allowed_fields:
+            payload["content_type"] = request.source.content_type
+        if not allowed_fields or "content_base64" in allowed_fields:
+            payload["content_base64"] = base64_value
+        elif "data_base64" in allowed_fields:
+            payload["data_base64"] = base64_value
+
+    if not allowed_fields or "source_type" in allowed_fields:
+        payload["source_type"] = request.source_kind
+    if not allowed_fields or "options" in allowed_fields:
+        payload["options"] = request.options
+    if not allowed_fields or "context" in allowed_fields:
+        payload["context"] = request.context
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _build_plan_from_contract(
+    *,
+    contract: NormalizedToolContract,
+    request: CanonicalExtractionRequest,
+    adapter_name: str,
+    reasoning_source: Literal["schema", "validation_retry"],
+    diagnostics: dict[str, Any] | None = None,
+) -> AdaptiveToolInvocationPlan:
+    diagnostics = dict(diagnostics or {})
+    arguments: dict[str, Any]
+    if contract.mode == "batch" and contract.batch_property:
+        arguments = {
+            contract.batch_property: [_build_source_item(request=request, item_schema=contract.item_schema)],
+        }
+        top_properties = _schema_properties(contract.object_schema)
+        option_fields = _filter_declared_fields(request.options, top_properties.get("options"))
+        if option_fields and "options" in top_properties:
+            arguments["options"] = option_fields
+        context_fields = _filter_declared_fields(request.context, top_properties.get("context"))
+        if context_fields and "context" in top_properties:
+            arguments["context"] = context_fields
+    elif contract.mode == "nested_single" and contract.source_property:
+        arguments = {
+            contract.source_property: _build_source_item(request=request, item_schema=contract.item_schema),
+        }
+        top_properties = _schema_properties(contract.object_schema)
+        option_fields = _filter_declared_fields(request.options, top_properties.get("options"))
+        if option_fields and "options" in top_properties:
+            arguments["options"] = option_fields
+        context_fields = _filter_declared_fields(request.context, top_properties.get("context"))
+        if context_fields and "context" in top_properties:
+            arguments["context"] = context_fields
+    elif contract.mode == "flat":
+        arguments = _build_flat_payload(request=request, allowed_fields=contract.source_fields)
+    else:
+        arguments = _build_flat_payload(request=request, allowed_fields=set())
+
+    diagnostics.setdefault("contract_mode", contract.mode)
+    diagnostics.setdefault("schema_shape", contract.schema_shape)
+    if contract.batch_property:
+        diagnostics.setdefault("batch_property", contract.batch_property)
+    if contract.source_property:
+        diagnostics.setdefault("source_property", contract.source_property)
+    return AdaptiveToolInvocationPlan(
+        adapter_name=adapter_name,
+        arguments=arguments,
+        reasoning_source=reasoning_source,
+        diagnostics=diagnostics,
+    )
+
+
 def build_tool_adapter(
     *,
     input_schema: dict[str, Any] | None,
     request: CanonicalExtractionRequest,
 ) -> ExtractionToolAdapter:
-    batch_property = _detect_batch_sources_property(
+    contract = normalize_tool_contract(
         input_schema=input_schema,
         source_kind=request.source_kind,
     )
-    if batch_property:
-        properties = _schema_properties(input_schema)
-        item_schema = properties.get(batch_property, {}).get("items")
-        arguments = {
-            batch_property: [_build_source_item(request=request, item_schema=item_schema)],
-        }
-        option_fields = _filter_declared_fields(request.options, properties.get("options"))
-        if option_fields and "options" in properties:
-            arguments["options"] = option_fields
-        context_fields = _filter_declared_fields(request.context, properties.get("context"))
-        if context_fields and "context" in properties:
-            arguments["context"] = context_fields
-        return ExtractionToolAdapter(
-            name="batch_sources_v1",
-            arguments=arguments,
-            schema_summary={
-                "batch_property": batch_property,
-                "top_level_fields": sorted(arguments.keys()),
-            },
-        )
+    plan = _build_plan_from_contract(
+        contract=contract,
+        request=request,
+        adapter_name=(
+            "batch_sources_v2"
+            if contract.mode == "batch"
+            else "nested_single_v2"
+            if contract.mode == "nested_single"
+            else "canonical_flat_v2"
+        ),
+        reasoning_source="schema",
+        diagnostics={
+            "top_level_fields": sorted(contract.top_level_fields),
+        },
+    )
+    return ExtractionToolAdapter(
+        name=plan.adapter_name,
+        arguments=plan.arguments,
+        schema_summary=plan.diagnostics,
+    )
 
-    arguments: dict[str, Any] = {
-        "source_type": request.source_kind,
+
+def _is_validation_error(error: str | None) -> bool:
+    if not error:
+        return False
+    lowered = error.lower()
+    return any(
+        token in lowered
+        for token in (
+            "validation errors for call",
+            "missing required argument",
+            "unexpected keyword argument",
+            "field required",
+        )
+    )
+
+
+def _summarize_validation_error(error: str | None) -> ValidationErrorSummary:
+    raw = str(error or "")
+    missing = re.findall(r"\n([A-Za-z0-9_]+)\n\s+Missing required argument", raw)
+    unexpected = re.findall(r"\n([A-Za-z0-9_]+)\n\s+Unexpected keyword argument", raw)
+    return ValidationErrorSummary(
+        missing_fields=missing,
+        unexpected_fields=unexpected,
+        raw_error=raw,
+    )
+
+
+def _source_fields_for_kind(source_kind: SourceKind) -> set[str]:
+    return {"url", "uri"} if source_kind == ROUTE_URL else {"filename", "content_type", "content_base64", "data_base64"}
+
+
+def _build_retry_contract_from_error(
+    *,
+    input_schema: dict[str, Any] | None,
+    request: CanonicalExtractionRequest,
+    validation_error: ValidationErrorSummary,
+) -> NormalizedToolContract | None:
+    missing = validation_error.missing_fields
+    if not missing:
+        return None
+
+    source_fields = _source_fields_for_kind(request.source_kind)
+    for field_name in missing:
+        if field_name in _preferred_batch_keys(request.source_kind) or field_name.endswith("_sources"):
+            return NormalizedToolContract(
+                mode="batch",
+                schema_shape="validation_retry.batch",
+                root_schema=input_schema,
+                batch_property=field_name,
+                item_schema={"type": "object", "properties": {name: {"type": "string"} for name in source_fields}},
+                source_fields=source_fields,
+            )
+        if field_name in _preferred_source_keys(request.source_kind) or field_name.endswith("_source"):
+            return NormalizedToolContract(
+                mode="nested_single",
+                schema_shape="validation_retry.nested",
+                root_schema=input_schema,
+                source_property=field_name,
+                item_schema={"type": "object", "properties": {name: {"type": "string"} for name in source_fields}},
+                source_fields=source_fields,
+            )
+    return None
+
+
+def _sanitize_payload_by_schema(
+    payload: Any,
+    schema: dict[str, Any] | None,
+    *,
+    root_schema: dict[str, Any] | None = None,
+) -> Any:
+    if not isinstance(schema, dict):
+        return payload
+    variants = _expand_schema_variants(schema, root_schema=root_schema or schema)
+    if not variants:
+        return payload
+    variant = variants[0]
+    if variant.get("type") == "array" and isinstance(payload, list):
+        item_schema = variant.get("items") if isinstance(variant.get("items"), dict) else None
+        return [_sanitize_payload_by_schema(item, item_schema, root_schema=root_schema or schema) for item in payload]
+
+    properties = _schema_properties(variant)
+    if properties and isinstance(payload, dict):
+        sanitized: dict[str, Any] = {}
+        for key, value in payload.items():
+            if key not in properties:
+                continue
+            sanitized[key] = _sanitize_payload_by_schema(value, properties.get(key), root_schema=root_schema or schema)
+        return sanitized
+    return payload
+
+
+async def _build_llm_retry_plan(
+    *,
+    tool_name: str,
+    tool_description: str | None,
+    input_schema: dict[str, Any] | None,
+    request: CanonicalExtractionRequest,
+    validation_error: ValidationErrorSummary,
+) -> AdaptiveToolInvocationPlan | None:
+    if not isinstance(input_schema, dict):
+        return None
+
+    canonical_request_payload = {
+        "source": request.source.__dict__,
         "options": request.options,
         "context": request.context,
     }
-    if request.source.url:
-        arguments["url"] = request.source.url
-    if request.source.content_base64 is not None:
-        arguments["filename"] = request.source.filename
-        arguments["content_type"] = request.source.content_type
-        arguments["content_base64"] = request.source.content_base64
-    return ExtractionToolAdapter(
-        name="canonical_flat_v1",
-        arguments=arguments,
-        schema_summary={"top_level_fields": sorted(arguments.keys())},
+    prompt = (
+        "You are adapting arguments for an MCP tool call.\n"
+        "Return only a JSON object containing valid tool arguments.\n"
+        "Do not include explanations.\n\n"
+        f"tool_name: {tool_name}\n"
+        f"tool_description: {tool_description or ''}\n"
+        f"source_kind: {request.source_kind}\n"
+        f"canonical_request: {json.dumps(canonical_request_payload, ensure_ascii=False)}\n"
+        f"input_schema: {json.dumps(input_schema, ensure_ascii=False)}\n"
+        f"validation_error: {validation_error.raw_error}\n"
+    )
+
+    response = await litellm.acompletion(
+        model=settings.llm.full_model_name,
+        messages=[{"role": "user", "content": prompt}],
+        response_format={"type": "json_object"},
+        **settings.llm.to_litellm_kwargs(),
+    )
+    content = response.choices[0].message.content or "{}"
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("extractor_llm_retry_invalid_json", tool_name=tool_name)
+        return None
+    if not isinstance(payload, dict):
+        return None
+    sanitized = _sanitize_payload_by_schema(payload, input_schema, root_schema=input_schema)
+    if not isinstance(sanitized, dict) or not sanitized:
+        return None
+    return AdaptiveToolInvocationPlan(
+        adapter_name="llm_adaptive_v1",
+        arguments=sanitized,
+        reasoning_source="llm",
+        diagnostics={
+            "contract_mode": "llm",
+            "schema_shape": "llm_retry",
+            "top_level_fields": sorted(sanitized.keys()),
+        },
     )
 
 
@@ -442,7 +808,10 @@ class LegacyExtractionProvider:
         return ExtractedDocumentResult(
             plain_text=text,
             markdown_content=markdown,
-            metadata={"provider": "legacy", "source_kind": resolve_source_kind(filename=filename, content_type=content_type)},
+            metadata={
+                "provider": "legacy",
+                "source_kind": resolve_source_kind(filename=filename, content_type=content_type),
+            },
             trace={"provider": "legacy"},
         )
 
@@ -601,15 +970,127 @@ class DataExtractorProvider:
             filename=filename,
             content_type=content_type,
         )
-        adapter = build_tool_adapter(
+        contract = normalize_tool_contract(
             input_schema=tool.input_schema if tool else None,
-            request=request,
+            source_kind=source_kind,
         )
+        plans: list[AdaptiveToolInvocationPlan] = [
+            _build_plan_from_contract(
+                contract=contract,
+                request=request,
+                adapter_name=(
+                    "batch_sources_v2"
+                    if contract.mode == "batch"
+                    else "nested_single_v2"
+                    if contract.mode == "nested_single"
+                    else "canonical_flat_v2"
+                ),
+                reasoning_source="schema",
+                diagnostics={"top_level_fields": sorted(contract.top_level_fields)},
+            )
+        ]
+        invocation_trace: list[dict[str, Any]] = []
 
-        result = await self._client.call_tool(
+        for index, plan in enumerate(plans):
+            result = await self._call_tool_with_plan(
+                server=server,
+                target=target,
+                plan=plan,
+            )
+            await _increment_tool_call_count(server_id=target.server_id, tool_name=target.tool_name)
+            invocation_trace.append(
+                {
+                    "attempt": index + 1,
+                    "adapter_name": plan.adapter_name,
+                    "reasoning_source": plan.reasoning_source,
+                    "diagnostics": plan.diagnostics,
+                    "success": result.success,
+                    "error": result.error,
+                    "duration_ms": result.duration_ms,
+                }
+            )
+            if result.success:
+                return self._build_success_result(
+                    target=target,
+                    server=server,
+                    result=result,
+                    plan=plan,
+                    invocation_trace=invocation_trace,
+                    contract=contract,
+                )
+
+            if index > 0 or not _is_validation_error(result.error):
+                break
+
+            validation_error = _summarize_validation_error(result.error)
+            retry_contract = _build_retry_contract_from_error(
+                input_schema=tool.input_schema if tool else None,
+                request=request,
+                validation_error=validation_error,
+            )
+            if retry_contract:
+                plans.append(
+                    _build_plan_from_contract(
+                        contract=retry_contract,
+                        request=request,
+                        adapter_name=(
+                            "batch_sources_retry_v1"
+                            if retry_contract.mode == "batch"
+                            else "nested_single_retry_v1"
+                        ),
+                        reasoning_source="validation_retry",
+                        diagnostics={
+                            "retry_reason": "validation_error",
+                            "validation_error_summary": {
+                                "missing_fields": validation_error.missing_fields,
+                                "unexpected_fields": validation_error.unexpected_fields,
+                            },
+                        },
+                    )
+                )
+                continue
+
+            llm_plan = await _build_llm_retry_plan(
+                tool_name=target.tool_name,
+                tool_description=tool.description if tool else None,
+                input_schema=tool.input_schema if tool else None,
+                request=request,
+                validation_error=validation_error,
+            )
+            if llm_plan:
+                llm_plan.diagnostics.setdefault(
+                    "validation_error_summary",
+                    {
+                        "missing_fields": validation_error.missing_fields,
+                        "unexpected_fields": validation_error.unexpected_fields,
+                    },
+                )
+                plans.append(llm_plan)
+
+        last_result = invocation_trace[-1] if invocation_trace else None
+        return {
+            "success": False,
+            "attempt": ExtractionAttempt(
+                server_id=str(target.server_id),
+                server_name=server.name,
+                tool_name=target.tool_name,
+                status="failed",
+                duration_ms=int(last_result["duration_ms"]) if last_result else 0,
+                error=str(last_result["error"]) if last_result else "MCP invocation failed",
+            ),
+        }
+
+    async def _call_tool_with_plan(
+        self,
+        *,
+        server: McpServer,
+        target: McpToolTarget,
+        plan: AdaptiveToolInvocationPlan,
+    ) -> Any:
+        return await self._client.call_tool(
             transport_type=server.transport_type,
             tool_name=target.tool_name,
-            arguments=adapter.arguments,
+            arguments=plan.arguments,
             command=server.command,
             args=server.args,
             env=server.env,
@@ -617,19 +1098,25 @@ class DataExtractorProvider:
             headers=server.headers,
             timeout_seconds=(target.timeout_ms / 1000.0) if target.timeout_ms else None,
         )
-        await _increment_tool_call_count(server_id=target.server_id, tool_name=target.tool_name)
 
+    def _build_success_result(
+        self,
+        *,
+        target: McpToolTarget,
+        server: McpServer,
+        result: Any,
+        plan: AdaptiveToolInvocationPlan,
+        invocation_trace: list[dict[str, Any]],
+        contract: NormalizedToolContract,
+    ) -> dict[str, Any]:
         attempt = ExtractionAttempt(
             server_id=str(target.server_id),
             server_name=server.name,
             tool_name=target.tool_name,
-            status="completed" if result.success else "failed",
+            status="completed",
             duration_ms=result.duration_ms,
-            error=result.error,
+            error=None,
         )
-        if not result.success:
-            return {"success": False, "attempt": attempt}
-
         payload = _extract_document_payload(
             _parse_structured_payload(result.structured_content, result.content)
         )
@@ -660,12 +1147,15 @@ class DataExtractorProvider:
                 markdown_content=markdown,
                 metadata={
                     **(payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}),
-                    "adapter_name": adapter.name,
+                    "adapter_name": plan.adapter_name,
                 },
                 assets=_normalize_assets(payload.get("assets")),
                 trace={
-                    "adapter_name": adapter.name,
-                    "adapter_schema_summary": adapter.schema_summary,
+                    "adapter_name": plan.adapter_name,
+                    "adapter_schema_summary": plan.diagnostics,
+                    "adapter_attempts": invocation_trace,
+                    "contract_shape": contract.schema_shape,
+                    "llm_fallback_used": any(item.get("reasoning_source") == "llm" for item in invocation_trace),
                 },
             ),
         }
@@ -702,7 +1192,11 @@ async def extract_source(
     if source_kind == ROUTE_URL:
         result = await legacy.extract_url(url=url or "")
     else:
-        result = await legacy.extract_file(content=content or b"", filename=filename or "unknown", content_type=content_type)
+        result = await legacy.extract_file(
+            content=content or b"",
+            filename=filename or "unknown",
+            content_type=content_type,
+        )
     result.trace = {"provider": "legacy", "source_kind": source_kind, "attempts": []}
     return result
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction.py
@@ -1,7 +1,7 @@
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
-from types import SimpleNamespace
 
 from negentropy.knowledge.extraction import (
     ROUTE_FILE_PDF,
@@ -9,6 +9,7 @@ from negentropy.knowledge.extraction import (
     DataExtractorProvider,
     build_tool_adapter,
     extract_source,
+    normalize_tool_contract,
     resolve_source_kind,
     resolve_targets,
 )
@@ -105,7 +106,7 @@ def test_build_tool_adapter_wraps_pdf_request_into_batch_sources_schema() -> Non
         ),
     )
 
-    assert request.name == "batch_sources_v1"
+    assert request.name == "batch_sources_v2"
     assert request.arguments == {
         "pdf_sources": [
             {
@@ -116,6 +117,34 @@ def test_build_tool_adapter_wraps_pdf_request_into_batch_sources_schema() -> Non
         ],
         "options": {"ocr": True},
     }
+
+
+def test_normalize_tool_contract_supports_ref_wrapped_batch_schema() -> None:
+    contract = normalize_tool_contract(
+        input_schema={
+            "type": "object",
+            "properties": {
+                "pdf_sources": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/PdfSource"},
+                }
+            },
+            "$defs": {
+                "PdfSource": {
+                    "type": "object",
+                    "properties": {
+                        "filename": {"type": "string"},
+                        "data_base64": {"type": "string"},
+                    },
+                }
+            },
+        },
+        source_kind=ROUTE_FILE_PDF,
+    )
+
+    assert contract.mode == "batch"
+    assert contract.batch_property == "pdf_sources"
+    assert contract.source_fields == {"filename", "data_base64"}
 
 
 @pytest.mark.asyncio
@@ -232,4 +261,119 @@ async def test_data_extractor_provider_uses_pdf_batch_schema_and_normalizes_batc
     assert extracted.markdown_content == "# Title"
     assert extracted.plain_text == "Title"
     assert extracted.metadata["provider"] == "batch"
-    assert extracted.metadata["adapter_name"] == "batch_sources_v1"
+    assert extracted.metadata["adapter_name"] == "batch_sources_v2"
+    assert extracted.trace["llm_fallback_used"] is False
+
+
+@pytest.mark.asyncio
+async def test_data_extractor_provider_retries_after_validation_error_with_batch_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server_id = uuid4()
+    call_arguments: list[dict[str, object]] = []
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, model, key):  # type: ignore[no-untyped-def]
+            _ = (model, key)
+            return SimpleNamespace(
+                id=server_id,
+                name="pdf-extractor",
+                is_enabled=True,
+                transport_type="http",
+                command=None,
+                args=[],
+                env={},
+                url="https://example.com/mcp",
+                headers={},
+            )
+
+        async def scalar(self, stmt):  # type: ignore[no-untyped-def]
+            _ = stmt
+            return SimpleNamespace(
+                is_enabled=True,
+                description="Convert PDFs to markdown",
+                input_schema={"type": "object"},
+            )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def call_tool(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.calls += 1
+            call_arguments.append(kwargs["arguments"])
+            if self.calls == 1:
+                return SimpleNamespace(
+                    success=False,
+                    structured_content=None,
+                    content=[],
+                    error=(
+                        "7 validation errors for call[batch_convert_pdfs_to_markdown]\n"
+                        "pdf_sources\n  Missing required argument\n"
+                        "source_type\n  Unexpected keyword argument\n"
+                        "content_base64\n  Unexpected keyword argument\n"
+                    ),
+                    duration_ms=12,
+                )
+            return SimpleNamespace(
+                success=True,
+                structured_content={
+                    "result": {
+                        "markdown_content": "# Retried",
+                        "plain_text": "Retried",
+                    }
+                },
+                content=[],
+                error=None,
+                duration_ms=20,
+            )
+
+    async def fake_increment_tool_call_count(**_: object) -> None:
+        return None
+
+    monkeypatch.setattr("negentropy.knowledge.extraction.AsyncSessionLocal", lambda: FakeSession())
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._increment_tool_call_count",
+        fake_increment_tool_call_count,
+    )
+
+    provider = DataExtractorProvider()
+    provider._client = FakeClient()
+
+    result = await provider._invoke_target(
+        app_name="negentropy",
+        corpus_id=uuid4(),
+        target=SimpleNamespace(
+            server_id=server_id,
+            tool_name="batch_convert_pdfs_to_markdown",
+            timeout_ms=None,
+            tool_options={},
+        ),
+        source_kind=ROUTE_FILE_PDF,
+        url=None,
+        content=b"%PDF-1.5",
+        filename="report.pdf",
+        content_type="application/pdf",
+    )
+
+    assert result["success"] is True
+    assert call_arguments[0]["source_type"] == ROUTE_FILE_PDF
+    assert call_arguments[1] == {
+        "pdf_sources": [
+            {
+                "filename": "report.pdf",
+                "content_type": "application/pdf",
+                "content_base64": "JVBERi0xLjU=",
+            }
+        ]
+    }
+    extracted = result["result"]
+    assert extracted.metadata["adapter_name"] == "batch_sources_retry_v1"
+    assert extracted.trace["adapter_attempts"][0]["success"] is False
+    assert extracted.trace["adapter_attempts"][1]["reasoning_source"] == "validation_retry"


### PR DESCRIPTION
## 背景

在 Rebuild `Deep Research: A Survey of Autonomous Research Agents.pdf` 时，Pipelines 页面出现 `failed`，后端日志显示 `batch_convert_pdfs_to_markdown` 的参数校验失败：服务端向 MCP Tool 传入了平铺字段（如 `source_type`、`filename`、`content_base64`），而该 Tool 实际要求的是 `pdf_sources` 这类批量容器参数。

这暴露出当前文档提取链路对 MCP Tool 输入契约的适配还不够泛化：一旦 Tool schema 不是简单的顶层平铺结构，就可能触发提取失败。此次修改的目标是让服务端不仅修复当前 PDF 场景，也能更稳健地兼容同类型的其他 MCP Tool。

## 变更内容

### 1. 增强 MCP Tool 输入契约识别
- 在 `apps/negentropy/src/negentropy/knowledge/extraction.py` 中新增归一化契约层，识别 MCP Tool 的输入 schema 形态。
- 支持批量、嵌套单对象、平铺三类输入模式。
- 支持解析 `$ref`、`anyOf`、`oneOf`、`allOf` 等复杂 schema 结构，避免只依赖顶层 `properties` 的脆弱判断。

### 2. 重构文档提取参数构造逻辑
- 将原先直接基于简单 schema 判断的参数拼装，升级为“契约归一化 + 调用计划构建”。
- 根据 Tool 契约动态生成更合适的参数结构，例如：
  - `batch_sources_v2`
  - `nested_single_v2`
  - `canonical_flat_v2`
- 保留 legacy 提取路径，避免影响未配置 MCP extractor routes 的现有功能。

### 3. 增加参数校验失败后的自适应重试
- 当 MCP Tool 返回明确的参数校验错误时，解析 `Missing required argument` / `Unexpected keyword argument` 等错误信息。
- 基于 validation error 生成更贴近 Tool 预期的参数结构，并自动重试一次。
- 为未来异构 MCP Tool 的适配保留扩展空间，而不是只对当前 PDF Tool 做硬编码修补。

### 4. 增加 LLM 驱动的参数映射回退能力
- 当静态规则仍无法完成参数重组时，引入基于系统 LLM 配置的参数映射回退逻辑。
- 复用系统配置的模型入口（如 `NE_LLM_VENDOR=zai`、`NE_LLM_MODEL_NAME=glm-5` 对应的 `settings.llm`），而不是新增独立模型配置源。
- 同时对 LLM 输出按 schema 做本地裁剪，降低把无效字段再次传入 MCP Tool 的风险。

### 5. 丰富 trace 与测试覆盖
- 为成功调用结果补充更完整的 trace 信息，包括：
  - 适配器名称
  - 契约形态
  - 每次参数尝试的诊断信息
  - 是否使用了 LLM fallback
- 在 `apps/negentropy/tests/unit_tests/knowledge/test_extraction.py` 中补充单测，覆盖：
  - 复杂 `$ref` 包装的 batch schema 识别
  - PDF batch 参数构造成功路径
  - 遇到 validation error 后自动重试并恢复成功的路径

## 为什么要这样改

这次修改并不是单纯修补 `batch_convert_pdfs_to_markdown` 的个例，而是针对“服务端如何适配不同 MCP Tool 输入契约”这个抽象层问题做收敛。

如果继续沿用只识别简单顶层 schema 的方式，系统在接入新的同类 MCP Tool 时仍然容易因为参数结构不匹配而失败；而通过引入契约归一化、策略化参数构造和失败后自适应重试，可以把这类问题从“个别工具 hardcode”提升为“统一适配层治理”，更符合 Adapter / Strategy 等经典设计模式所强调的边界隔离与可扩展性。

## 关键实现细节

- 外部 HTTP API 与现有 corpus 配置结构未变。
- 变更集中在知识提取内部实现，不影响已有未走 MCP extractor 的 legacy 路径。
- 自适应重试仅在检测到明确参数校验失败时触发，避免无意义重试。
- LLM fallback 不是默认每次都调用，而是在静态规则无法恢复时作为兜底手段使用，兼顾泛化能力与运行成本。

## 验证

已补充并通过针对性的提取层测试，验证以下链路：
- 复杂 schema 可以被正确识别为 batch contract
- PDF 内容可以按 `pdf_sources` 结构发送给 MCP Tool
- 遇到 validation error 后可以自动重组参数并成功恢复

对应验证命令：
- `uv run --project . ruff check src/negentropy/knowledge/extraction.py tests/unit_tests/knowledge/test_extraction.py`
- `uv run --project . python -m pytest tests/unit_tests/knowledge/test_extraction.py`
