### PR TITLE
fix(agui): 修复 messages snapshot 事件类型缺失导致的 UI 类型检查失败;

### DIFF
--- a/apps/negentropy-ui/types/agui.ts
+++ b/apps/negentropy-ui/types/agui.ts
@@ -55,6 +55,7 @@ export type AgUiEvent = BaseEvent &
       result: unknown;
       eventType: string;
       data: unknown;
+      messages: unknown[];
       code: string;
       message: string;
       rawEvent: unknown;


### PR DESCRIPTION
## 背景

本 PR 由 UI Workflow 的类型检查失败驱动。失败发生在 GitHub Actions `UI Test Suite` 的 `UI Type Checks -> Typecheck tests` 阶段，典型报错为：

- `tests/unit/utils/conversation-tree.test.ts(513,9): error TS2561`
- `tests/unit/utils/conversation-tree.test.ts(549,9): error TS2561`

根因是静态类型定义与现有运行时契约不一致：仓库内已经存在 `EventType.MESSAGES_SNAPSHOT` 的消费逻辑、schema 约束和测试用例，但 `AgUiEvent` 的宽表型中缺少 `messages` 字段，导致 CI 在干净环境下进行测试类型检查时失败。

关联故障上下文：
- https://github.com/ThreeFish-AI/negentropy/actions/runs/22812999977/job/66173157316

## 本次改动

- 在 `apps/negentropy-ui/types/agui.ts` 中为 `AgUiEvent` 增补 `messages: unknown[]`
- 使 `AgUiEvent` 与仓库内既有的 `MESSAGES_SNAPSHOT` 事件契约保持一致
- 不调整运行时逻辑、不改动事件语义、不引入新的兼容分支，仅修复静态类型缺口

## 为什么这样改

当前问题不是业务逻辑错误，而是“单一事实源”被静态类型遗漏后的分裂状态：

- 运行时 schema 已支持 `messages`
- `conversation-tree` 等消费路径已按 `messages snapshot` 工作
- 测试用例也已显式构造 `messages`
- 只有 `AgUiEvent` 的宽类型没有同步该字段

因此，最小且正确的修复方式不是改测试、绕过检查或重写事件模型，而是补齐缺失的类型字段，让静态定义回归到现有协议事实源，避免新的行为回归或协议漂移。

## 关键实现细节

- 修复点仅限一个类型定义字段，爆炸半径极小
- 本次改动不会改变任何运行时序列化、解析、渲染或事件处理逻辑
- 该修复同时覆盖本地增量缓存可能掩盖的问题，因此验证时使用了禁用增量缓存的方式确认 CI 等价结果

## 验证

本地已执行：

- `pnpm exec tsc -p tsconfig.json --noEmit --incremental false`
- `pnpm exec tsc -p tsconfig.vitest.json --noEmit --incremental false`
- `pnpm exec vitest run tests/unit/utils/conversation-tree.test.ts`

结果：

- 应用类型检查通过
- 测试类型检查通过
- `conversation-tree` 定向单测 15/15 通过

该改动的目标是修复 UI 类型检查链路，同时保持现有功能与事件语义不变。
