### PR TITLE
fix(ui): 统一描边按钮悬停高亮反馈;

### DIFF
--- a/apps/negentropy-ui/app/admin/roles/page.tsx
+++ b/apps/negentropy-ui/app/admin/roles/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AdminNav } from "@/components/ui/AdminNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 
 type RoleMap = Record<string, string[]>;
 type PermissionMap = Record<string, string>;
@@ -262,7 +263,7 @@ export default function RoleManagementPage() {
             <button
               type="button"
               onClick={load}
-              className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 transition-colors dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+              className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
               disabled={loading}
             >
               {loading ? "Refreshing..." : "Refresh"}
@@ -271,7 +272,7 @@ export default function RoleManagementPage() {
               <button
                 type="button"
                 onClick={resetAll}
-                className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 transition-colors dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+                className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
               >
                 Reset All
               </button>
@@ -330,7 +331,7 @@ export default function RoleManagementPage() {
                         <button
                           type="button"
                           onClick={() => resetRole(role)}
-                          className="rounded-full border border-zinc-200 px-3 py-1 text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 transition-colors dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+                          className={outlineButtonClassName("neutral", "rounded-full px-3 py-1")}
                           disabled={!dirty}
                         >
                           Reset

--- a/apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import type { SourceSummary } from "@/features/knowledge";
 
 interface SourceListProps {
@@ -61,7 +62,10 @@ export function SourceList({
       {onAddSource && (
         <button
           onClick={onAddSource}
-          className="w-full rounded-lg border border-dashed border-border px-2 py-1.5 text-xs text-muted hover:border-foreground hover:text-foreground"
+          className={outlineButtonClassName(
+            "neutral",
+            "w-full rounded-lg border-dashed px-2 py-1.5 text-xs",
+          )}
         >
           + Add Source
         </button>
@@ -166,7 +170,7 @@ function SourceMenu({
     <div className="relative shrink-0">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="rounded p-1 text-muted hover:bg-muted/50 hover:text-foreground"
+        className="rounded p-1 text-muted transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20"
         title="Source actions"
       >
         <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -186,7 +190,7 @@ function SourceMenu({
             {onReplace && !isFile && (
               <button
                 onClick={() => closeAndRun(onReplace)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted hover:bg-muted/50 hover:text-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted transition-colors hover:bg-muted hover:text-foreground"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536M9 13l6.232-6.232a2.5 2.5 0 113.536 3.536L12.536 16.536a4 4 0 01-1.79 1.024L7 18l.44-3.746A4 4 0 018.464 12.464z" />
@@ -197,7 +201,7 @@ function SourceMenu({
             {onSync && isUrl && (
               <button
                 onClick={() => closeAndRun(onSync)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted hover:bg-muted/50 hover:text-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted transition-colors hover:bg-muted hover:text-foreground"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -208,7 +212,7 @@ function SourceMenu({
             {onRebuild && isFile && (
               <button
                 onClick={() => closeAndRun(onRebuild)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted hover:bg-muted/50 hover:text-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted transition-colors hover:bg-muted hover:text-foreground"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -219,7 +223,7 @@ function SourceMenu({
             {onDelete && (
               <button
                 onClick={closeAndRunDelete}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-red-600 hover:bg-red-50"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-red-600 transition-colors hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/40 dark:hover:text-red-300"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
@@ -230,7 +234,7 @@ function SourceMenu({
             {!archived && onArchive && (
               <button
                 onClick={() => closeAndRun(onArchive)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted hover:bg-muted/50 hover:text-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted transition-colors hover:bg-muted hover:text-foreground"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8l1 11h12l1-11M9 8V5a3 3 0 016 0v3" />
@@ -241,7 +245,7 @@ function SourceMenu({
             {archived && onUnarchive && (
               <button
                 onClick={() => closeAndRun(onUnarchive)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted hover:bg-muted/50 hover:text-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted transition-colors hover:bg-muted hover:text-foreground"
               >
                 <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14m-7-7v14" />

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -43,6 +43,7 @@ import {
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { AddSourceDialog } from "./_components/AddSourceDialog";
 import { CorpusFormDialog } from "./_components/CorpusFormDialog";
 import { DeleteCorpusDialog } from "./_components/DeleteCorpusDialog";
@@ -110,7 +111,7 @@ function ChunkDetailDrawer({
         <h3 className="text-sm font-semibold">Chunk Detail</h3>
         <button
           onClick={onClose}
-          className="rounded border border-border px-2 py-1 text-xs hover:bg-muted"
+          className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-xs")}
         >
           Close
         </button>
@@ -849,7 +850,10 @@ export default function KnowledgeBasePage() {
             <button
               type="button"
               onClick={resetRetrievalView}
-              className="rounded-lg border border-border bg-background px-3 py-1.5 text-xs font-semibold hover:bg-muted"
+              className={outlineButtonClassName(
+                "neutral",
+                "rounded-lg px-3 py-1.5 text-xs font-semibold",
+              )}
             >
               收起结果
             </button>
@@ -983,13 +987,19 @@ export default function KnowledgeBasePage() {
                 <div className="flex shrink-0 items-center justify-end gap-2">
                   <button
                     onClick={() => handleEditCorpus(corpus)}
-                    className="inline-flex h-7 items-center rounded border border-border px-2.5 text-[11px] text-muted transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20"
+                    className={outlineButtonClassName(
+                      "neutral",
+                      "inline-flex h-7 items-center rounded px-2.5 text-[11px]",
+                    )}
                   >
                     Settings
                   </button>
                   <button
                     onClick={() => handleDeleteCorpus(corpus)}
-                    className="inline-flex h-7 items-center rounded border border-red-300 px-2.5 text-[11px] text-red-600 hover:bg-red-50"
+                    className={outlineButtonClassName(
+                      "danger",
+                      "inline-flex h-7 items-center rounded px-2.5 text-[11px]",
+                    )}
                   >
                     Delete
                   </button>
@@ -1041,7 +1051,10 @@ export default function KnowledgeBasePage() {
                       <button
                         type="button"
                         onClick={() => setIsCorpusPanelExpanded((prev) => !prev)}
-                        className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm font-semibold hover:bg-muted"
+                        className={outlineButtonClassName(
+                          "neutral",
+                          "w-full rounded-lg px-4 py-3 text-sm font-semibold",
+                        )}
                       >
                         {isCorpusPanelExpanded ? "收起 Corpus" : "Corpus"}
                       </button>
@@ -1065,7 +1078,7 @@ export default function KnowledgeBasePage() {
               >
                 <button
                   onClick={() => syncQueryState({ view: "overview", corpusId: null, tab: null, documentId: null })}
-                  className="mb-3 rounded border border-border px-2 py-1 text-xs hover:bg-muted"
+                  className={outlineButtonClassName("neutral", "mb-3 rounded px-2 py-1 text-xs")}
                 >
                   ← Back
                 </button>
@@ -1098,13 +1111,13 @@ export default function KnowledgeBasePage() {
                     <div className="flex items-center gap-2">
                       <button
                         onClick={() => setIsIngestUrlDialogOpen(true)}
-                        className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
+                        className={outlineButtonClassName("neutral", "rounded px-3 py-1.5 text-xs")}
                       >
                         Ingest From URL
                       </button>
                       <button
                         onClick={() => fileInputRef.current?.click()}
-                        className="rounded border border-border px-3 py-1.5 text-xs hover:bg-muted"
+                        className={outlineButtonClassName("neutral", "rounded px-3 py-1.5 text-xs")}
                       >
                         Ingest From File
                       </button>
@@ -1145,16 +1158,16 @@ export default function KnowledgeBasePage() {
                                 <p className="text-[11px] text-muted">{sourceType} · {doc.status} · {doc.file_size} bytes</p>
                               </button>
                               <div className="flex flex-wrap items-center justify-end gap-1">
-                                <button onClick={() => runDocumentAction("view", doc)} className="rounded border border-border px-2 py-1 text-[11px]">View</button>
-                                <button onClick={() => runDocumentAction("download", doc)} className="rounded border border-border px-2 py-1 text-[11px]">Download</button>
-                                <button onClick={() => runDocumentAction("replace", doc)} className="rounded border border-border px-2 py-1 text-[11px]">Replace</button>
-                                <button onClick={() => runDocumentAction("rebuild", doc)} className="rounded border border-border px-2 py-1 text-[11px]">Rebuild</button>
+                                <button onClick={() => runDocumentAction("view", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>View</button>
+                                <button onClick={() => runDocumentAction("download", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Download</button>
+                                <button onClick={() => runDocumentAction("replace", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Replace</button>
+                                <button onClick={() => runDocumentAction("rebuild", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Rebuild</button>
                                 {sourceType === "url" && (
-                                  <button onClick={() => runDocumentAction("sync", doc)} className="rounded border border-border px-2 py-1 text-[11px]">Sync</button>
+                                  <button onClick={() => runDocumentAction("sync", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Sync</button>
                                 )}
-                                <button onClick={() => runDocumentAction("archive", doc)} className="rounded border border-border px-2 py-1 text-[11px]">Archive</button>
-                                <button onClick={() => runDocumentAction("unarchive", doc)} className="rounded border border-border px-2 py-1 text-[11px]">Unarchive</button>
-                                <button onClick={() => runDocumentAction("delete", doc)} className="rounded border border-red-300 px-2 py-1 text-[11px] text-red-600">Delete</button>
+                                <button onClick={() => runDocumentAction("archive", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Archive</button>
+                                <button onClick={() => runDocumentAction("unarchive", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Unarchive</button>
+                                <button onClick={() => runDocumentAction("delete", doc)} className={outlineButtonClassName("danger", "rounded px-2 py-1 text-[11px]")}>Delete</button>
                               </div>
                             </div>
                           </div>
@@ -1171,7 +1184,7 @@ export default function KnowledgeBasePage() {
                     <h2 className="text-sm font-semibold">Document Chunks</h2>
                     <button
                       onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "documents", documentId: null })}
-                      className="rounded border border-border px-2 py-1 text-xs"
+                      className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-xs")}
                     >
                       Back to Documents
                     </button>
@@ -1187,7 +1200,10 @@ export default function KnowledgeBasePage() {
                           type="button"
                           key={chunk.id}
                           onClick={() => setSelectedDocumentChunk(chunk)}
-                          className="block w-full rounded-lg border border-border bg-background p-3 text-left hover:bg-muted/40"
+                          className={outlineButtonClassName(
+                            "neutral",
+                            "block w-full rounded-lg p-3 text-left hover:bg-muted/40",
+                          )}
                         >
                           <p className="line-clamp-3 text-xs">{chunk.content}</p>
                           <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted">
@@ -1520,7 +1536,7 @@ function CorpusSettingsPanel({
                         <button
                           type="button"
                           onClick={clearTarget}
-                          className="rounded border border-border px-3 py-2 text-[11px] hover:bg-muted"
+                          className={outlineButtonClassName("neutral", "rounded px-3 py-2 text-[11px]")}
                         >
                           清空
                         </button>

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
@@ -314,7 +315,7 @@ export default function DocumentsPage() {
                   <button
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
                     disabled={page === 1 || loading}
-                    className="rounded border border-border bg-background px-2 py-1 text-xs disabled:opacity-50 hover:bg-muted/50"
+                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-xs")}
                   >
                     Previous
                   </button>
@@ -324,7 +325,7 @@ export default function DocumentsPage() {
                   <button
                     onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                     disabled={page >= totalPages || loading}
-                    className="rounded border border-border bg-background px-2 py-1 text-xs disabled:opacity-50 hover:bg-muted/50"
+                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-xs")}
                   >
                     Next
                   </button>

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import {
   fetchGraph,
   KnowledgeGraphPayload,
@@ -206,7 +207,7 @@ export default function KnowledgeGraphPage() {
                   <div className="flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
                     <span>点击节点查看详情</span>
                     <button
-                      className="rounded-full border border-zinc-200 px-3 py-1 text-[11px] text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+                      className={outlineButtonClassName("neutral", "rounded-full px-3 py-1 text-[11px]")}
                       onClick={async () => {
                         if (!payload) return;
                         setSaveStatus("saving");

--- a/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import {
   fetchPipelines,
   KnowledgePipelinesPayload,
@@ -370,7 +371,7 @@ export default function KnowledgePipelinesPage() {
                   <div className="flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
                     <span>{payload?.last_updated_at || "-"}</span>
                     <button
-                      className="rounded-full border border-zinc-200 px-3 py-1 text-[11px] text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+                      className={outlineButtonClassName("neutral", "rounded-full px-3 py-1 text-[11px]")}
                       onClick={async () => {
                         if (!selected) return;
                         setSaveStatus("saving");

--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { FactListPayload, fetchFacts, searchFacts } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -96,13 +97,13 @@ export default function MemoryFactsPage() {
                     onKeyDown={(e) => e.key === "Enter" && handleSearch()}
                   />
                   <button
-                    className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+                    className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                     onClick={handleSearch}
                   >
                     Search
                   </button>
                   <button
-                    className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+                    className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                     onClick={handleClearSearch}
                   >
                     Clear

--- a/apps/negentropy-ui/app/memory/page.tsx
+++ b/apps/negentropy-ui/app/memory/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { fetchMemoryDashboard, MemoryDashboard } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -83,7 +84,7 @@ export default function MemoryDashboardPage() {
               </button>
               {activeUserId && (
                 <button
-                  className="rounded-lg border border-border px-3 py-2 text-xs text-muted hover:border-foreground hover:text-foreground transition-colors"
+                  className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                   onClick={handleClearFilter}
                 >
                   Clear
@@ -91,7 +92,7 @@ export default function MemoryDashboardPage() {
               )}
               <div className="flex-1" />
               <button
-                className="rounded-lg border border-border px-3 py-2 text-xs text-muted hover:border-foreground hover:text-foreground transition-colors"
+                className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                 onClick={loadDashboard}
                 disabled={isLoading}
               >

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { useMemoryTimeline } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -135,7 +136,7 @@ export default function MemoryTimelinePage() {
                       onKeyDown={(e) => e.key === "Enter" && handleSearch()}
                     />
                     <button
-                      className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 transition-colors dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+                      className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                       onClick={handleSearch}
                       disabled={!searchQuery.trim()}
                     >
@@ -143,7 +144,7 @@ export default function MemoryTimelinePage() {
                     </button>
                     {searchResult && (
                       <button
-                        className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-600 hover:border-zinc-900 hover:text-zinc-900 transition-colors dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+                        className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                         onClick={handleClearSearch}
                       >
                         Clear

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentFormDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 
 interface SubAgent {
   id: string;
@@ -263,7 +264,10 @@ export function SubAgentFormDialog({
                         const target = templates.find((item) => item.name === selectedTemplateName);
                         if (target) applyTemplate(target);
                       }}
-                      className="rounded-md border border-zinc-300 px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-200 dark:hover:bg-zinc-700"
+                      className={outlineButtonClassName(
+                        "neutral",
+                        "rounded-md px-3 py-2 text-sm font-medium",
+                      )}
                     >
                       Apply
                     </button>

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { PluginsNav } from "@/components/ui/PluginsNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { SubAgentCard } from "./_components/SubAgentCard";
 import { SubAgentFormDialog } from "./_components/SubAgentFormDialog";
 
@@ -159,7 +160,10 @@ export default function SubAgentsPage() {
                 <button
                   onClick={handleSyncNegentropy}
                   disabled={syncing}
-                  className="inline-flex items-center justify-center rounded-md border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+                  className={outlineButtonClassName(
+                    "neutral",
+                    "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium",
+                  )}
                 >
                   {syncing ? "Syncing..." : "Sync Negentropy 5"}
                 </button>

--- a/apps/negentropy-ui/components/ui/SessionList.tsx
+++ b/apps/negentropy-ui/components/ui/SessionList.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import { Archive, ArchiveRestore, ChevronLeft } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 import type { SessionListView } from "@/utils/session";
 
 type SessionItem = {
@@ -68,7 +69,10 @@ export function SessionList({
           {view === "active" ? (
             <>
               <button
-                className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-[10px] font-semibold text-text-secondary transition-colors hover:bg-muted"
+                className={outlineButtonClassName(
+                  "neutral",
+                  "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-semibold",
+                )}
                 onClick={() => onSwitchView("archived")}
                 type="button"
               >
@@ -87,7 +91,10 @@ export function SessionList({
             </>
           ) : (
             <button
-              className="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-1 text-[10px] font-semibold text-text-secondary transition-colors hover:bg-muted"
+              className={outlineButtonClassName(
+                "neutral",
+                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-semibold",
+              )}
               onClick={() => onSwitchView("active")}
               type="button"
             >

--- a/apps/negentropy-ui/components/ui/button-styles.ts
+++ b/apps/negentropy-ui/components/ui/button-styles.ts
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+type OutlineButtonTone = "neutral" | "danger";
+
+const outlineButtonBaseClassName =
+  "border bg-background transition-colors transition-[color,background-color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+
+const outlineButtonToneClassNames: Record<OutlineButtonTone, string> = {
+  neutral:
+    "border-border text-text-secondary hover:border-foreground/20 hover:bg-muted hover:text-foreground focus-visible:ring-foreground/20",
+  danger:
+    "border-red-300 text-red-600 hover:border-red-400 hover:bg-red-50 hover:text-red-700 focus-visible:ring-red-200 dark:border-red-900/70 dark:text-red-400 dark:hover:border-red-700 dark:hover:bg-red-950/40 dark:hover:text-red-300 dark:focus-visible:ring-red-900/50",
+};
+
+export function outlineButtonClassName(
+  tone: OutlineButtonTone = "neutral",
+  className?: string,
+) {
+  return cn(
+    outlineButtonBaseClassName,
+    outlineButtonToneClassNames[tone],
+    className,
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
 
 import type {
   KnowledgeDocument,
@@ -320,7 +321,10 @@ export function DocumentViewDialog({
           <button
             onClick={handleRefreshMarkdown}
             disabled={isRefreshingMarkdown || !document}
-            className="flex items-center gap-2 rounded-lg border border-zinc-300 bg-white px-4 py-2 text-sm font-semibold text-zinc-700 shadow-sm hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
+            className={outlineButtonClassName(
+              "neutral",
+              "flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold shadow-sm",
+            )}
           >
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h5M20 20v-5h-5M5.636 18.364A9 9 0 103.22 9.88" />

--- a/apps/negentropy-ui/tests/unit/ui/button-styles.test.ts
+++ b/apps/negentropy-ui/tests/unit/ui/button-styles.test.ts
@@ -1,0 +1,23 @@
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+
+describe("outlineButtonClassName", () => {
+  it("为中性描边按钮返回统一交互状态类", () => {
+    const className = outlineButtonClassName("neutral", "rounded-lg px-3");
+
+    expect(className).toContain("border-border");
+    expect(className).toContain("hover:bg-muted");
+    expect(className).toContain("hover:text-foreground");
+    expect(className).toContain("focus-visible:ring-foreground/20");
+    expect(className).toContain("rounded-lg px-3");
+  });
+
+  it("为危险描边按钮保留红色语义与交互状态类", () => {
+    const className = outlineButtonClassName("danger");
+
+    expect(className).toContain("border-red-300");
+    expect(className).toContain("hover:bg-red-50");
+    expect(className).toContain("hover:text-red-700");
+    expect(className).toContain("dark:hover:bg-red-950/40");
+    expect(className).toContain("focus-visible:ring-red-200");
+  });
+});


### PR DESCRIPTION
## 变更内容

本 PR 统一补齐了前端描边按钮缺失的交互反馈，新增了一个共享按钮状态样式工具，并将知识库页面及全局命中的同类按钮切换到统一样式。

具体包括：

- 新增共享描边按钮样式入口，统一收敛 `hover`、`focus-visible`、`disabled` 状态
- 修复 `Knowledge Base` 页面中的返回、导入、文档操作、收起结果等按钮缺少高亮反馈的问题
- 扫描并同步修复其他页面的同类描边按钮，包括 `memory`、`admin roles`、`knowledge graph`、`knowledge pipelines`、`plugins subagents`、`documents`、`SessionList` 等位置
- 保留危险按钮的红色语义，只增强交互态，不改变业务行为
- 新增样式工具单测，锁定中性/危险描边按钮的关键状态类

## 变更原因

本次修改来自一个明确的交互缺陷：知识库页面中一批按钮在鼠标悬停时缺少应有的高亮反馈，导致可点击性弱、交互一致性不足。

为避免继续在页面内零散手写 `className`，本次采用了复用驱动的方式，将这类按钮的状态层抽取为共享样式入口。这样做有两个直接收益：

- 保证 `hover`、`focus-visible`、`disabled` 状态在全局同类按钮上保持一致
- 降低后续新页面或局部修复时再次漏配交互态的概率

这也符合常见设计系统的实践：把按钮的状态层作为可复用能力统一维护，而不是让每个页面各自拼接 hover 规则。

## 重要实现细节

- 新增 `apps/negentropy-ui/components/ui/button-styles.ts`，提供统一的描边按钮状态样式
- 样式工具只负责状态层，不接管尺寸、排版和布局，尽量降低回归风险
- 支持中性描边和危险描边两种语义，危险按钮继续保持红色边框与文本语义
- 为键盘导航补齐 `focus-visible` ring，避免只修复鼠标 hover 而忽略可访问性
- 新增 `apps/negentropy-ui/tests/unit/ui/button-styles.test.ts`，并通过知识库相关测试验证修复未破坏现有功能

## 验证

已完成的验证包括：

- `pnpm test -- tests/unit/ui/button-styles.test.ts tests/unit/knowledge/KnowledgeBasePage.test.tsx tests/unit/knowledge/SourceList.test.tsx`
- `pnpm typecheck`
