### PR TITLE
fix(chat): 前移 session 级消息台账并收敛会话投影;

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import {
   CopilotKitProvider,
@@ -39,15 +39,18 @@ import {
   buildConversationTree,
   buildNodeTimestampIndex,
 } from "@/utils/conversation-tree";
-import { buildMessageLedger } from "@/utils/message-ledger";
+import {
+  buildMessageLedger,
+  ledgerEntriesToMessages,
+  mergeMessageLedger,
+} from "@/utils/message-ledger";
 import {
   deriveConnectionState,
   deriveRunStates,
   hasSameEventSequence,
-  hasSameMessageSequence,
   hydrateSessionDetail,
   mergeEvents,
-  mergeMessages,
+  type HydratedSessionDetail,
 } from "@/utils/session-hydration";
 
 // 统一的类型定义
@@ -55,10 +58,77 @@ import type {
   ConnectionState,
   SessionRecord,
   LogEntry,
+  SessionProjectionState,
 } from "@/types/common";
 
 const AGENT_ID = "negentropy";
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+
+const EMPTY_SESSION_PROJECTION: SessionProjectionState = {
+  loadedSessionId: null,
+  rawEvents: [],
+  messageLedger: [],
+  snapshot: null,
+};
+
+type SessionProjectionAction =
+  | {
+      type: "reset";
+    }
+  | {
+      type: "append_realtime_events";
+      events: BaseEvent[];
+    }
+  | {
+      type: "hydrate_session";
+      sessionId: string;
+      detail: HydratedSessionDetail;
+      shouldMerge: boolean;
+    };
+
+function sessionProjectionReducer(
+  state: SessionProjectionState,
+  action: SessionProjectionAction,
+): SessionProjectionState {
+  switch (action.type) {
+    case "reset":
+      return EMPTY_SESSION_PROJECTION;
+    case "append_realtime_events": {
+      const nextRawEvents = mergeEvents(state.rawEvents, action.events).slice(-10000);
+      if (hasSameEventSequence(state.rawEvents, nextRawEvents)) {
+        return state;
+      }
+      return {
+        ...state,
+        rawEvents: nextRawEvents,
+        messageLedger: buildMessageLedger({ events: nextRawEvents }),
+      };
+    }
+    case "hydrate_session": {
+      if (!action.shouldMerge) {
+        return {
+          loadedSessionId: action.sessionId,
+          rawEvents: action.detail.events,
+          messageLedger: action.detail.messageLedger,
+          snapshot: action.detail.snapshot,
+        };
+      }
+
+      const nextRawEvents = mergeEvents(state.rawEvents, action.detail.events);
+      return {
+        loadedSessionId: action.sessionId,
+        rawEvents: nextRawEvents,
+        messageLedger: mergeMessageLedger(
+          state.messageLedger,
+          action.detail.messageLedger,
+        ),
+        snapshot: action.detail.snapshot ?? state.snapshot,
+      };
+    }
+    default:
+      return state;
+  }
+}
 
 export function HomeBody({
   sessionId,
@@ -92,19 +162,17 @@ export function HomeBody({
   const hydrationTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [inputValue, setInputValue] = useState("");
-  const [rawEvents, setRawEvents] = useState<BaseEvent[]>([]);
-  const [sessionMessages, setSessionMessages] = useState<Message[]>([]);
+  const [sessionProjection, dispatchSessionProjection] = useReducer(
+    sessionProjectionReducer,
+    EMPTY_SESSION_PROJECTION,
+  );
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
-  const [sessionSnapshot, setSessionSnapshot] = useState<Record<
-    string,
-    unknown
-  > | null>(null);
-  const [loadedSessionId, setLoadedSessionId] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-  const loadedSessionIdRef = useRef<string | null>(null);
-  const rawEventsRef = useRef<BaseEvent[]>([]);
+  const loadedSessionIdRef = useRef<string | null>(sessionProjection.loadedSessionId);
+  const rawEventsRef = useRef<BaseEvent[]>(sessionProjection.rawEvents);
   const activeSessionIdRef = useRef<string | null>(sessionId);
   const hydrationRequestVersionRef = useRef(0);
+  const rawEvents = sessionProjection.rawEvents;
 
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === sessionId) || null,
@@ -112,12 +180,12 @@ export function HomeBody({
   );
 
   useEffect(() => {
-    loadedSessionIdRef.current = loadedSessionId;
-  }, [loadedSessionId]);
+    loadedSessionIdRef.current = sessionProjection.loadedSessionId;
+  }, [sessionProjection.loadedSessionId]);
 
   useEffect(() => {
-    rawEventsRef.current = rawEvents;
-  }, [rawEvents]);
+    rawEventsRef.current = sessionProjection.rawEvents;
+  }, [sessionProjection.rawEvents]);
 
   useEffect(() => {
     activeSessionIdRef.current = sessionId;
@@ -227,9 +295,9 @@ export function HomeBody({
         setConnectionWithMetrics("error");
       },
       onEvent: ({ event }) =>
-        setRawEvents((prev) => {
-          const next = mergeEvents(prev, [event]);
-          return next.slice(-10000);
+        dispatchSessionProjection({
+          type: "append_realtime_events",
+          events: [event],
         }),
     });
 
@@ -276,21 +344,53 @@ export function HomeBody({
     return derived;
   }, [connection, rawEvents]);
 
+  const hasLoadedSession = sessionProjection.loadedSessionId === sessionId;
+  const confirmedMessageLedger = hasLoadedSession
+    ? sessionProjection.messageLedger
+    : [];
+  const snapshotForRender = hasLoadedSession ? sessionProjection.snapshot : null;
+  const messagesForRenderBase = useMemo(
+    () => ledgerEntriesToMessages(confirmedMessageLedger),
+    [confirmedMessageLedger],
+  );
+  const mergedMessagesForRender = useMemo(() => {
+    const pendingOptimistic = reconcileOptimisticMessages(
+      messagesForRenderBase,
+      optimisticMessages,
+    );
+    return mergeOptimisticMessages(messagesForRenderBase, pendingOptimistic).map(
+      (message) =>
+        !normalizeMessageContent(message).trim().length
+          ? ({
+              ...message,
+              content: normalizeMessageContent(message),
+            } as Message)
+          : message,
+    );
+  }, [messagesForRenderBase, optimisticMessages]);
+  const optimisticMessageLedger = useMemo(
+    () =>
+      buildMessageLedger({
+        events: [],
+        fallbackMessages: optimisticMessages,
+      }),
+    [optimisticMessages],
+  );
+  const renderMessageLedger = useMemo(
+    () => mergeMessageLedger(confirmedMessageLedger, optimisticMessageLedger),
+    [confirmedMessageLedger, optimisticMessageLedger],
+  );
+
   // 根据选中的节点时间范围过滤事件，右侧保持历史视图能力
   const nodeTimestampIndex = useMemo(() => {
-    const merged = [...sessionMessages, ...optimisticMessages];
-    const messageLedger = buildMessageLedger({
-      events: rawEvents,
-      fallbackMessages: merged,
-    });
     return buildNodeTimestampIndex(
       buildConversationTree({
         events: rawEvents,
-        fallbackMessages: merged,
-        messageLedger,
+        fallbackMessages: mergedMessagesForRender,
+        messageLedger: renderMessageLedger,
       }),
     );
-  }, [optimisticMessages, rawEvents, sessionMessages]);
+  }, [mergedMessagesForRender, rawEvents, renderMessageLedger]);
 
   const filteredRawEvents = useMemo(() => {
     if (!selectedNodeId) {
@@ -334,11 +434,8 @@ export function HomeBody({
   const clearSessionState = useCallback(() => {
     clearHydrationTimers();
     clearTitleRefreshTimers();
-    setSessionMessages([]);
     setOptimisticMessages([]);
-    setSessionSnapshot(null);
-    setRawEvents([]);
-    setLoadedSessionId(null);
+    dispatchSessionProjection({ type: "reset" });
     setSelectedNodeId(null);
   }, [clearHydrationTimers, clearTitleRefreshTimers]);
 
@@ -602,30 +699,16 @@ export function HomeBody({
         const hydrated = hydrateSessionDetail(events, id);
         const currentLoadedSessionId = loadedSessionIdRef.current;
         const currentRawEvents = rawEventsRef.current;
-
-        setRawEvents((prev) => {
-          const shouldMerge =
-            currentLoadedSessionId === id ||
-            (sessionId === id && currentRawEvents.length > 0);
-          const next = shouldMerge ? mergeEvents(prev, hydrated.events) : hydrated.events;
-          return hasSameEventSequence(prev, next) ? prev : next;
-        });
-        setSessionMessages((prev) => {
-          const shouldMerge =
-            currentLoadedSessionId === id ||
-            (sessionId === id && currentRawEvents.length > 0);
-          const next = shouldMerge
-            ? mergeMessages(prev, hydrated.messages)
-            : hydrated.messages;
-          return hasSameMessageSequence(prev, next) ? prev : next;
-        });
-        setSessionSnapshot((prev) =>
+        const shouldMerge =
           currentLoadedSessionId === id ||
-          (sessionId === id && currentRawEvents.length > 0)
-            ? (hydrated.snapshot ?? prev)
-            : hydrated.snapshot,
-        );
-        setLoadedSessionId(id);
+          (sessionId === id && currentRawEvents.length > 0);
+
+        dispatchSessionProjection({
+          type: "hydrate_session",
+          sessionId: id,
+          detail: hydrated,
+          shouldMerge,
+        });
       } catch (error) {
         setConnectionWithMetrics("error");
         addLog("error", "load_session_detail_failed", {
@@ -793,10 +876,6 @@ export function HomeBody({
     loadSessionDetail(sessionId);
   }, [sessionId, agent, loadSessionDetail]);
 
-  const hasLoadedSession = loadedSessionId === sessionId;
-  const messagesForRenderBase = hasLoadedSession ? sessionMessages : [];
-  const snapshotForRender = hasLoadedSession ? sessionSnapshot : null;
-
   // Reconstruct state snapshot from filtered events for historical viewing
   const historicalSnapshot = useMemo(
     () => buildStateSnapshotFromEvents(filteredRawEvents),
@@ -810,39 +889,14 @@ export function HomeBody({
     return historicalSnapshot;
   }, [selectedNodeId, snapshotForRender, historicalSnapshot]);
 
-  const mergedMessagesForRender = useMemo(() => {
-    const pendingOptimistic = reconcileOptimisticMessages(
-      messagesForRenderBase,
-      optimisticMessages,
-    );
-    return mergeOptimisticMessages(messagesForRenderBase, pendingOptimistic).map(
-      (message) =>
-        !normalizeMessageContent(message).trim().length
-          ? ({
-              ...message,
-              content: normalizeMessageContent(message),
-            } as Message)
-          : message,
-    );
-  }, [messagesForRenderBase, optimisticMessages]);
-
-  const messageLedger = useMemo(
-    () =>
-      buildMessageLedger({
-        events: rawEvents,
-        fallbackMessages: mergedMessagesForRender,
-      }),
-    [mergedMessagesForRender, rawEvents],
-  );
-
   const conversationTree = useMemo(
     () =>
       buildConversationTree({
         events: rawEvents,
         fallbackMessages: mergedMessagesForRender,
-        messageLedger,
+        messageLedger: renderMessageLedger,
       }),
-    [messageLedger, mergedMessagesForRender, rawEvents],
+    [mergedMessagesForRender, rawEvents, renderMessageLedger],
   );
 
   // Filter log entries based on selected message timestamp

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -6,6 +6,10 @@ import {
   hydrateSessionDetail,
   mergeEvents,
 } from "@/utils/session-hydration";
+import {
+  ledgerEntriesToMessages,
+  mergeMessageLedger,
+} from "@/utils/message-ledger";
 import { createTestEvent } from "@/tests/helpers/agui";
 import type { AgUiEvent } from "@/types/agui";
 
@@ -151,6 +155,89 @@ describe("session-hydration", () => {
       content: "Hello there",
     });
     expect(result.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+  });
+
+  it("合并 message ledger 时保留更强角色来源与更完整内容", () => {
+    const merged = mergeMessageLedger(
+      [
+        {
+          id: "msg-1",
+          threadId: "session-1",
+          runId: "run-1",
+          resolvedRole: "assistant",
+          resolutionSource: "fallback_assistant",
+          content: "He",
+          createdAt: new Date("2026-03-08T00:00:02.000Z"),
+          streaming: true,
+          sourceEventTypes: ["TEXT_MESSAGE_START"],
+          relatedMessageIds: ["msg-1"],
+        },
+      ],
+      [
+        {
+          id: "msg-1",
+          threadId: "session-1",
+          runId: "run-1",
+          resolvedRole: "user",
+          resolutionSource: "snapshot_role",
+          content: "Hello",
+          createdAt: new Date("2026-03-08T00:00:01.000Z"),
+          streaming: false,
+          sourceEventTypes: ["MESSAGES_SNAPSHOT"],
+          relatedMessageIds: ["msg-1"],
+        },
+      ],
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      resolvedRole: "user",
+      resolutionSource: "snapshot_role",
+      content: "Hello",
+      streaming: false,
+    });
+    expect(merged[0]?.sourceEventTypes).toEqual([
+      "TEXT_MESSAGE_START",
+      "MESSAGES_SNAPSHOT",
+    ]);
+  });
+
+  it("将 message ledger 派生为按时间排序的聊天消息", () => {
+    const messages = ledgerEntriesToMessages([
+      {
+        id: "assistant-msg",
+        threadId: "session-1",
+        runId: "run-1",
+        resolvedRole: "assistant",
+        resolutionSource: "explicit_role",
+        content: "World",
+        createdAt: new Date("2026-03-08T00:00:02.000Z"),
+        streaming: false,
+        sourceEventTypes: ["TEXT_MESSAGE_END"],
+        relatedMessageIds: ["assistant-msg"],
+      },
+      {
+        id: "user-msg",
+        threadId: "session-1",
+        runId: "run-1",
+        resolvedRole: "user",
+        resolutionSource: "explicit_role",
+        content: "Hello",
+        createdAt: new Date("2026-03-08T00:00:01.000Z"),
+        streaming: false,
+        sourceEventTypes: ["TEXT_MESSAGE_END"],
+        relatedMessageIds: ["user-msg"],
+      },
+    ]);
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "user-msg",
+      "assistant-msg",
+    ]);
+    expect(messages.map((message) => message.role)).toEqual([
       "user",
       "assistant",
     ]);

--- a/apps/negentropy-ui/types/common.ts
+++ b/apps/negentropy-ui/types/common.ts
@@ -125,3 +125,10 @@ export type MessageLedgerEntry = {
   sourceEventTypes: string[];
   relatedMessageIds: string[];
 };
+
+export type SessionProjectionState = {
+  loadedSessionId: string | null;
+  rawEvents: import("@ag-ui/core").BaseEvent[];
+  messageLedger: MessageLedgerEntry[];
+  snapshot: Record<string, unknown> | null;
+};

--- a/apps/negentropy-ui/utils/message-ledger.ts
+++ b/apps/negentropy-ui/utils/message-ledger.ts
@@ -1,5 +1,6 @@
 import { EventType, type BaseEvent, type Message } from "@ag-ui/core";
 import {
+  createAgUiMessage,
   getEventAuthor,
   getEventDelta,
   getEventMessageId,
@@ -28,6 +29,11 @@ type SnapshotMessage = {
 };
 
 const DEFAULT_THREAD_ID = "default";
+const DEFAULT_RUN_ID = "default-run";
+
+function getLedgerIdentityKey(entry: Pick<MessageLedgerEntry, "id" | "threadId" | "runId">): string {
+  return `${entry.threadId}|${entry.runId || DEFAULT_RUN_ID}|${entry.id}`;
+}
 
 function normalizeTimestamp(value: unknown): Date {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -186,7 +192,7 @@ export function buildMessageLedger(input: {
 
     const threadId = getEventThreadId(event) || DEFAULT_THREAD_ID;
     const runId = getEventRunId(event);
-    const key = `${threadId}|${runId || "default-run"}|${messageId}`;
+    const key = `${threadId}|${runId || DEFAULT_RUN_ID}|${messageId}`;
     const existing = entries.get(key);
     const snapshotMessage = snapshotMessageById.get(messageId);
     const resolved = snapshotMessage
@@ -263,4 +269,85 @@ export function buildMessageLedger(input: {
       }
       return a.id.localeCompare(b.id);
     });
+}
+
+export function mergeMessageLedger(
+  baseEntries: MessageLedgerEntry[],
+  incomingEntries: MessageLedgerEntry[],
+): MessageLedgerEntry[] {
+  const merged = new Map<string, MessageLedgerEntry>();
+
+  [...baseEntries, ...incomingEntries].forEach((entry) => {
+    const key = getLedgerIdentityKey(entry);
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, {
+        ...entry,
+        sourceEventTypes: [...entry.sourceEventTypes],
+        relatedMessageIds: [...entry.relatedMessageIds],
+      });
+      return;
+    }
+
+    if (shouldReplaceResolvedRole(existing.resolutionSource, entry.resolutionSource)) {
+      existing.resolvedRole = entry.resolvedRole;
+      existing.resolutionSource = entry.resolutionSource;
+    }
+    if (entry.content.length > existing.content.length) {
+      existing.content = entry.content;
+    }
+    if (entry.createdAt.getTime() < existing.createdAt.getTime()) {
+      existing.createdAt = entry.createdAt;
+    }
+    existing.threadId = existing.threadId || entry.threadId;
+    existing.runId = existing.runId || entry.runId;
+    existing.author = existing.author || entry.author;
+    existing.streaming = existing.streaming && entry.streaming;
+    entry.sourceEventTypes.forEach((eventType) => {
+      if (!existing.sourceEventTypes.includes(eventType)) {
+        existing.sourceEventTypes.push(eventType);
+      }
+    });
+    entry.relatedMessageIds.forEach((messageId) => {
+      if (!existing.relatedMessageIds.includes(messageId)) {
+        existing.relatedMessageIds.push(messageId);
+      }
+    });
+  });
+
+  return [...merged.values()].sort((a, b) => {
+    const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function ledgerEntriesToMessages(entries: MessageLedgerEntry[]): Message[] {
+  return [...entries]
+    .sort((a, b) => {
+      const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
+      if (timeDiff !== 0) {
+        return timeDiff;
+      }
+      return a.id.localeCompare(b.id);
+    })
+    .map((entry) =>
+    createAgUiMessage({
+      id: entry.id,
+      role:
+        entry.resolvedRole === "user" ||
+        entry.resolvedRole === "system" ||
+        entry.resolvedRole === "tool"
+          ? entry.resolvedRole
+          : "assistant",
+      content: entry.content,
+      createdAt: entry.createdAt,
+      runId: entry.runId,
+      threadId: entry.threadId,
+      author: entry.author,
+      streaming: entry.streaming,
+    }),
+  );
 }

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -25,8 +25,7 @@ import {
   type AgUiMessage,
 } from "@/types/agui";
 import { getMessageIdentityKey, normalizeMessageContent } from "@/utils/message";
-import { buildMessageLedger } from "@/utils/message-ledger";
-import { createAgUiMessage } from "@/types/agui";
+import { buildMessageLedger, ledgerEntriesToMessages } from "@/utils/message-ledger";
 
 export type HydratedSessionDetail = {
   events: BaseEvent[];
@@ -308,23 +307,7 @@ export function hydrateSessionDetail(
   const messageLedger = buildMessageLedger({ events: normalizedEvents });
   const messages =
     messageLedger.length > 0
-      ? messageLedger.map((entry) =>
-          createAgUiMessage({
-            id: entry.id,
-            role:
-              entry.resolvedRole === "user" ||
-              entry.resolvedRole === "system" ||
-              entry.resolvedRole === "tool"
-                ? entry.resolvedRole
-                : "assistant",
-            content: entry.content,
-            createdAt: entry.createdAt,
-            runId: entry.runId,
-            threadId: entry.threadId,
-            author: entry.author,
-            streaming: entry.streaming,
-          }),
-        )
+      ? ledgerEntriesToMessages(messageLedger)
       : aguiEventsToMessages(normalizedEvents);
   const snapshot = adkEventsToSnapshot(payloads) || null;
 

--- a/docs/a2ui.md
+++ b/docs/a2ui.md
@@ -80,8 +80,10 @@ flowchart TD
 
   subgraph ReadModel["A2UI Read Model"]
     D[normalizeAguiEvent]
-    E[buildConversationTree]
-    F[ConversationNode Tree]
+    E[Session Projection]
+    F[Message Ledger]
+    J[buildConversationTree]
+    K[ConversationNode Tree]
   end
 
   subgraph Presentation["Chat-first Presentation"]
@@ -90,9 +92,11 @@ flowchart TD
     I[Timeline / State / Logs]
   end
 
-  A --> B --> C --> D --> E --> F
+  A --> B --> C --> D --> E
+  E --> F
+  E --> J
   F --> G
-  F --> H
+  J --> K --> H
   C --> I
 ```
 
@@ -100,11 +104,23 @@ flowchart TD
 
 - 传输入口：[route.ts](../apps/negentropy-ui/app/api/agui/route.ts)
 - ADK 到 AGUI 归一化：[adk.ts](../apps/negentropy-ui/lib/adk.ts)
+- Session Projection / Message Ledger：[message-ledger.ts](../apps/negentropy-ui/utils/message-ledger.ts)
 - 事件到树构建：[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
 - Chat 主区渲染：[ChatStream.tsx](../apps/negentropy-ui/components/ui/ChatStream.tsx)
 - 递归节点渲染：[ConversationNodeRenderer.tsx](../apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx)
 
-### 3.2 Canonical Role 约定
+### 3.2 Session Projection 约定
+
+本项目当前把 `Message Ledger` 前移为 session 级显式状态，而不是在页面渲染期临时从 `rawEvents` 全量重建。
+
+- `rawEvents`：保留 AGUI 事件事实源。
+- `messageLedger`：保留聊天消息事实与角色纠偏结果。
+- `snapshot`：保留状态快照事实。
+- `conversationTree`、timeline、state 面板都属于从 session projection 派生出的 surface projection。
+
+这样做的目标是把“协议输入”“消息事实”“页面结构”三层职责拆开，避免聊天主区、历史回放与技术面板各自维护不同事实源。
+
+### 3.3 Canonical Role 约定
 
 本项目内部统一使用 canonical role：
 


### PR DESCRIPTION
## 背景

当前分支已经完成 AGUI / A2UI 职责校正、聊天角色归一化与历史消息保真修复，但页面主链路里 `Message Ledger` 仍然是渲染期派生物：`HomeBody` 会在多个 `useMemo` 中基于 `rawEvents` 和 fallback messages 临时重建 ledger。

这种结构虽然能工作，但仍存在两个系统性问题：

1. Chat、Timeline、历史回放和状态面板没有共用一个 session 级显式 projection，仍然容易形成“事件已经更新、消息读模型稍后才补算”的事实窗口。
2. 后续如果继续接 A2UI 的多 surface / tool / state projection，页面层会持续承担过多 projection orchestration 逻辑，扩展性和稳定性都不足。

本 PR 的目标就是把 `Message Ledger` 继续前移到 session 边界，建立明确的 `SessionProjectionState`，让页面主链路围绕单一事实源展开，而不是在渲染阶段重复派生。

## 本次改动

### 1. 将 Message Ledger 前移为 session 级显式状态

- 在页面层引入 `SessionProjectionState`
- 统一维护：
  - `rawEvents`
  - `messageLedger`
  - `snapshot`
  - `loadedSessionId`
- 不再把 `sessionMessages` 作为独立事实状态继续维护
- 保留 `optimisticMessages` 作为本地 overlay，避免把未确认消息污染到 session 级 confirmed projection

### 2. 收敛页面主链路的会话投影

- `HomeBody` 改为通过 reducer 统一处理 session projection 更新
- realtime event 进入时，先更新 `rawEvents`，再同步刷新 `messageLedger`
- hydration 回放时，直接消费 `hydrateSessionDetail()` 输出的 `messageLedger`，并通过合并逻辑更新当前 session projection
- `nodeTimestampIndex`、`conversationTree`、Chat 主区不再各自从 `rawEvents` 全量重建 ledger，而是消费显式的 session projection

### 3. 补齐 Message Ledger 的正式工具接口

- 在 `message-ledger.ts` 中新增：
  - `mergeMessageLedger`
  - `ledgerEntriesToMessages`
- 让 hydration、页面渲染和 projection 合并逻辑都复用这组接口
- 统一 message ledger 到聊天消息的派生方式，减少各处重复 `createAgUiMessage` 映射与角色兜底分支

### 4. 保持现有聊天行为稳定不回退

- Chat 主区继续保持聊天优先
- 历史消息、实时流与 optimistic 消息仍能正常协作
- 不改变 AGUI / ADK 上游协议，不扩大改动边界到后端
- `buildConversationTree()` 仍保留 fallback 构建能力作为兼容护栏，但页面主路径改为显式传入 ledger

### 5. 同步更新文档与测试

- 更新 `docs/a2ui.md`
- 明确 session projection / message ledger 在本项目中的职责
- 增加 ledger 合并与 message 派生测试
- 保留并继续验证历史用户消息、snapshot 纠偏、实时回拉与 bubble 去重等回归场景

## 关键实现细节

- `Message Ledger` 现在不再只是“页面 render helper”，而是 session 级 projection 的正式组成部分
- reducer 负责把事件事实与消息事实同步推进，降低渲染期补算导致的 split-brain 风险
- `optimisticMessages` 继续留在 projection 之外，只在 render 阶段与 confirmed ledger 合并，这是为了维持“confirmed fact”和“local pending state”的边界清晰
- `ledgerEntriesToMessages()` 把 ledger -> message 的映射收口为单一实现，后续接更多 A2UI surface 时可继续复用

## 验证

相关改动已补充并通过类型检查与回归测试，覆盖：

- `tests/unit/utils/session-hydration.test.ts`
- `tests/unit/utils/conversation-tree.test.ts`
- `tests/integration/home-flow.test.tsx`
- `tests/unit/adk.test.ts`

重点验证场景包括：

- session projection 合并后仍能正确保留历史用户消息
- ledger 合并时角色优先级与内容完整性保持稳定
- realtime event、hydration 回放与 optimistic overlay 不会造成重复、丢失或换边
- Chat 主区、conversation tree 与节点时间索引消费的是同一份 ledger 事实
