### PR TITLE
refactor(session): 校正 AGUI/A2UI 实践并抽离会话投影模块;

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   CopilotKitProvider,
   UseAgentUpdate,
   useAgent,
 } from "@copilotkitnext/react";
-import { HttpAgent, compactEvents, randomUUID } from "@ag-ui/client";
-import { BaseEvent, EventType, Message } from "@ag-ui/core";
+import { HttpAgent, randomUUID } from "@ag-ui/client";
+import { EventType, Message } from "@ag-ui/core";
 
 import { ChatStream } from "../components/ui/ChatStream";
 import { Composer } from "../components/ui/Composer";
@@ -20,6 +20,7 @@ import { StateSnapshot } from "../components/ui/StateSnapshot";
 import { CHAT_CONTENT_RAIL_CLASS } from "../components/ui/chat-layout";
 import { AdkEventPayload } from "@/lib/adk";
 import { collectAdkEventPayloads } from "@/lib/adk";
+import { useSessionProjection } from "@/features/session/hooks/useSessionProjection";
 
 import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 
@@ -27,30 +28,8 @@ import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 import { createSessionLabel, buildAgentUrl, toSessionRecord } from "@/utils/session";
 import type { SessionListView } from "@/utils/session";
 import {
-  normalizeMessageContent,
-} from "@/utils/message";
-import {
-  mergeOptimisticMessages,
-  reconcileOptimisticMessages,
-} from "@/utils/message-merge";
-import { buildTimelineItems } from "@/utils/timeline";
-import { buildStateSnapshotFromEvents } from "@/utils/state";
-import {
-  buildConversationTree,
-  buildNodeTimestampIndex,
-} from "@/utils/conversation-tree";
-import {
-  buildMessageLedger,
-  ledgerEntriesToMessages,
-  mergeMessageLedger,
-} from "@/utils/message-ledger";
-import {
   deriveConnectionState,
-  deriveRunStates,
-  hasSameEventSequence,
   hydrateSessionDetail,
-  mergeEvents,
-  type HydratedSessionDetail,
 } from "@/utils/session-hydration";
 
 // 统一的类型定义
@@ -58,77 +37,10 @@ import type {
   ConnectionState,
   SessionRecord,
   LogEntry,
-  SessionProjectionState,
 } from "@/types/common";
 
 const AGENT_ID = "negentropy";
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
-
-const EMPTY_SESSION_PROJECTION: SessionProjectionState = {
-  loadedSessionId: null,
-  rawEvents: [],
-  messageLedger: [],
-  snapshot: null,
-};
-
-type SessionProjectionAction =
-  | {
-      type: "reset";
-    }
-  | {
-      type: "append_realtime_events";
-      events: BaseEvent[];
-    }
-  | {
-      type: "hydrate_session";
-      sessionId: string;
-      detail: HydratedSessionDetail;
-      shouldMerge: boolean;
-    };
-
-function sessionProjectionReducer(
-  state: SessionProjectionState,
-  action: SessionProjectionAction,
-): SessionProjectionState {
-  switch (action.type) {
-    case "reset":
-      return EMPTY_SESSION_PROJECTION;
-    case "append_realtime_events": {
-      const nextRawEvents = mergeEvents(state.rawEvents, action.events).slice(-10000);
-      if (hasSameEventSequence(state.rawEvents, nextRawEvents)) {
-        return state;
-      }
-      return {
-        ...state,
-        rawEvents: nextRawEvents,
-        messageLedger: buildMessageLedger({ events: nextRawEvents }),
-      };
-    }
-    case "hydrate_session": {
-      if (!action.shouldMerge) {
-        return {
-          loadedSessionId: action.sessionId,
-          rawEvents: action.detail.events,
-          messageLedger: action.detail.messageLedger,
-          snapshot: action.detail.snapshot,
-        };
-      }
-
-      const nextRawEvents = mergeEvents(state.rawEvents, action.detail.events);
-      return {
-        loadedSessionId: action.sessionId,
-        rawEvents: nextRawEvents,
-        messageLedger: mergeMessageLedger(
-          state.messageLedger,
-          action.detail.messageLedger,
-        ),
-        snapshot: action.detail.snapshot ?? state.snapshot,
-      };
-    }
-    default:
-      return state;
-  }
-}
 
 export function HomeBody({
   sessionId,
@@ -162,30 +74,33 @@ export function HomeBody({
   const hydrationTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [inputValue, setInputValue] = useState("");
-  const [sessionProjection, dispatchSessionProjection] = useReducer(
-    sessionProjectionReducer,
-    EMPTY_SESSION_PROJECTION,
-  );
-  const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-  const loadedSessionIdRef = useRef<string | null>(sessionProjection.loadedSessionId);
-  const rawEventsRef = useRef<BaseEvent[]>(sessionProjection.rawEvents);
   const activeSessionIdRef = useRef<string | null>(sessionId);
   const hydrationRequestVersionRef = useRef(0);
-  const rawEvents = sessionProjection.rawEvents;
+  const {
+    rawEvents,
+    snapshotForDisplay,
+    conversationTree,
+    nodeTimestampIndex,
+    filteredRawEvents,
+    timelineItems,
+    pendingConfirmations,
+    latestRunState,
+    loadedSessionIdRef,
+    rawEventsRef,
+    appendRealtimeEvent,
+    appendOptimisticMessage,
+    clearSessionProjection,
+    applyHydratedSession,
+  } = useSessionProjection({
+    sessionId,
+    selectedNodeId,
+  });
 
   const activeSession = useMemo(
     () => sessions.find((session) => session.id === sessionId) || null,
     [sessions, sessionId],
   );
-
-  useEffect(() => {
-    loadedSessionIdRef.current = sessionProjection.loadedSessionId;
-  }, [sessionProjection.loadedSessionId]);
-
-  useEffect(() => {
-    rawEventsRef.current = sessionProjection.rawEvents;
-  }, [sessionProjection.rawEvents]);
 
   useEffect(() => {
     activeSessionIdRef.current = sessionId;
@@ -294,39 +209,12 @@ export function HomeBody({
         });
         setConnectionWithMetrics("error");
       },
-      onEvent: ({ event }) =>
-        dispatchSessionProjection({
-          type: "append_realtime_events",
-          events: [event],
-        }),
+      onEvent: ({ event }) => appendRealtimeEvent(event),
     });
 
     return () => subscription.unsubscribe();
-  }, [agent, reportMetric, setConnectionWithMetrics]);
+  }, [agent, appendRealtimeEvent, reportMetric, setConnectionWithMetrics]);
 
-  const pendingConfirmations = useMemo(() => {
-    const pending = new Set<string>();
-    rawEvents.forEach((event) => {
-      if (
-        event.type === EventType.TOOL_CALL_START &&
-        "toolCallName" in event &&
-        "toolCallId" in event &&
-        event.toolCallName === "ui.confirmation"
-      ) {
-        pending.add(String(event.toolCallId));
-      }
-      if (event.type === EventType.TOOL_CALL_RESULT && "toolCallId" in event) {
-        pending.delete(String(event.toolCallId));
-      }
-    });
-    return pending.size;
-  }, [rawEvents]);
-
-  const derivedRunStates = useMemo(() => deriveRunStates(rawEvents), [rawEvents]);
-  const latestRunState = useMemo(
-    () => derivedRunStates[derivedRunStates.length - 1] || null,
-    [derivedRunStates],
-  );
   const effectiveConnection = useMemo(() => {
     const derived = deriveConnectionState(rawEvents);
     if (derived === "blocked" || derived === "error") {
@@ -343,79 +231,6 @@ export function HomeBody({
     }
     return derived;
   }, [connection, rawEvents]);
-
-  const hasLoadedSession = sessionProjection.loadedSessionId === sessionId;
-  const confirmedMessageLedger = hasLoadedSession
-    ? sessionProjection.messageLedger
-    : [];
-  const snapshotForRender = hasLoadedSession ? sessionProjection.snapshot : null;
-  const messagesForRenderBase = useMemo(
-    () => ledgerEntriesToMessages(confirmedMessageLedger),
-    [confirmedMessageLedger],
-  );
-  const mergedMessagesForRender = useMemo(() => {
-    const pendingOptimistic = reconcileOptimisticMessages(
-      messagesForRenderBase,
-      optimisticMessages,
-    );
-    return mergeOptimisticMessages(messagesForRenderBase, pendingOptimistic).map(
-      (message) =>
-        !normalizeMessageContent(message).trim().length
-          ? ({
-              ...message,
-              content: normalizeMessageContent(message),
-            } as Message)
-          : message,
-    );
-  }, [messagesForRenderBase, optimisticMessages]);
-  const optimisticMessageLedger = useMemo(
-    () =>
-      buildMessageLedger({
-        events: [],
-        fallbackMessages: optimisticMessages,
-      }),
-    [optimisticMessages],
-  );
-  const renderMessageLedger = useMemo(
-    () => mergeMessageLedger(confirmedMessageLedger, optimisticMessageLedger),
-    [confirmedMessageLedger, optimisticMessageLedger],
-  );
-
-  // 根据选中的节点时间范围过滤事件，右侧保持历史视图能力
-  const nodeTimestampIndex = useMemo(() => {
-    return buildNodeTimestampIndex(
-      buildConversationTree({
-        events: rawEvents,
-        fallbackMessages: mergedMessagesForRender,
-        messageLedger: renderMessageLedger,
-      }),
-    );
-  }, [mergedMessagesForRender, rawEvents, renderMessageLedger]);
-
-  const filteredRawEvents = useMemo(() => {
-    if (!selectedNodeId) {
-      return rawEvents;
-    }
-
-    const cutoffTimestamp = nodeTimestampIndex.get(selectedNodeId);
-    if (cutoffTimestamp === undefined) {
-      return rawEvents;
-    }
-
-    return rawEvents.filter((event) => {
-      const eventTimestamp = event.timestamp || 0;
-      return eventTimestamp <= cutoffTimestamp;
-    });
-  }, [nodeTimestampIndex, rawEvents, selectedNodeId]);
-
-  const compactedEvents = useMemo(
-    () => compactEvents(filteredRawEvents),
-    [filteredRawEvents],
-  );
-  const timelineItems = useMemo(
-    () => buildTimelineItems(compactedEvents),
-    [compactedEvents],
-  );
 
   const clearTitleRefreshTimers = useCallback(() => {
     titleRefreshTimersRef.current.forEach((timer) => {
@@ -434,10 +249,9 @@ export function HomeBody({
   const clearSessionState = useCallback(() => {
     clearHydrationTimers();
     clearTitleRefreshTimers();
-    setOptimisticMessages([]);
-    dispatchSessionProjection({ type: "reset" });
+    clearSessionProjection();
     setSelectedNodeId(null);
-  }, [clearHydrationTimers, clearTitleRefreshTimers]);
+  }, [clearHydrationTimers, clearSessionProjection, clearTitleRefreshTimers]);
 
   const loadSessions = useCallback(async () => {
     try {
@@ -697,17 +511,10 @@ export function HomeBody({
           });
         }
         const hydrated = hydrateSessionDetail(events, id);
-        const currentLoadedSessionId = loadedSessionIdRef.current;
-        const currentRawEvents = rawEventsRef.current;
-        const shouldMerge =
-          currentLoadedSessionId === id ||
-          (sessionId === id && currentRawEvents.length > 0);
-
-        dispatchSessionProjection({
-          type: "hydrate_session",
+        applyHydratedSession({
           sessionId: id,
           detail: hydrated,
-          shouldMerge,
+          activeSessionId: sessionId,
         });
       } catch (error) {
         setConnectionWithMetrics("error");
@@ -718,6 +525,7 @@ export function HomeBody({
       }
     },
     [
+      applyHydratedSession,
       userId,
       setConnectionWithMetrics,
       addLog,
@@ -825,9 +633,8 @@ export function HomeBody({
       threadId: sessionId,
       streaming: false,
     } as Message;
-    // 仅使用 optimisticMessages 进行乐观更新，不再向 rawEvents 添加乐观事件
-    // 避免消息在 buildChatMessagesFromEventsWithFallback 中重复
-    setOptimisticMessages((prev) => [...prev, newMessage]);
+    // optimistic message 交给 session projection hook 管理，页面不再直接编排 render projection
+    appendOptimisticMessage(newMessage);
     agent.addMessage(newMessage);
     setInputValue("");
     if (sessionId) {
@@ -875,29 +682,6 @@ export function HomeBody({
     // Only fetch data in effect
     loadSessionDetail(sessionId);
   }, [sessionId, agent, loadSessionDetail]);
-
-  // Reconstruct state snapshot from filtered events for historical viewing
-  const historicalSnapshot = useMemo(
-    () => buildStateSnapshotFromEvents(filteredRawEvents),
-    [filteredRawEvents],
-  );
-
-  const snapshotForDisplay = useMemo(() => {
-    if (!selectedNodeId) {
-      return snapshotForRender;
-    }
-    return historicalSnapshot;
-  }, [selectedNodeId, snapshotForRender, historicalSnapshot]);
-
-  const conversationTree = useMemo(
-    () =>
-      buildConversationTree({
-        events: rawEvents,
-        fallbackMessages: mergedMessagesForRender,
-        messageLedger: renderMessageLedger,
-      }),
-    [mergedMessagesForRender, rawEvents, renderMessageLedger],
-  );
 
   // Filter log entries based on selected message timestamp
   const filteredLogEntries = useMemo(() => {

--- a/apps/negentropy-ui/features/session/hooks/useSessionProjection.ts
+++ b/apps/negentropy-ui/features/session/hooks/useSessionProjection.ts
@@ -1,0 +1,289 @@
+import {
+  useCallback,
+  useMemo,
+  useReducer,
+  useRef,
+  useEffect,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+} from "react";
+import { compactEvents } from "@ag-ui/client";
+import type { BaseEvent, Message } from "@ag-ui/core";
+import { EventType } from "@ag-ui/core";
+import type { SessionProjectionState } from "@/types/common";
+import { buildConversationTree, buildNodeTimestampIndex } from "@/utils/conversation-tree";
+import {
+  buildMessageLedger,
+  ledgerEntriesToMessages,
+  mergeMessageLedger,
+} from "@/utils/message-ledger";
+import { normalizeMessageContent } from "@/utils/message";
+import {
+  mergeOptimisticMessages,
+  reconcileOptimisticMessages,
+} from "@/utils/message-merge";
+import { buildStateSnapshotFromEvents } from "@/utils/state";
+import { buildTimelineItems } from "@/utils/timeline";
+import {
+  EMPTY_SESSION_PROJECTION,
+  sessionProjectionReducer,
+  shouldMergeHydratedProjection,
+  type SessionProjectionAction,
+} from "@/features/session/utils/session-projection";
+import type { HydratedSessionDetail } from "@/utils/session-hydration";
+import { deriveRunStates } from "@/utils/session-hydration";
+
+export interface UseSessionProjectionOptions {
+  sessionId: string | null;
+  selectedNodeId: string | null;
+  maxEvents?: number;
+}
+
+export interface UseSessionProjectionReturnValue {
+  sessionProjection: SessionProjectionState;
+  rawEvents: BaseEvent[];
+  snapshotForRender: Record<string, unknown> | null;
+  snapshotForDisplay: Record<string, unknown> | null;
+  confirmedMessageLedger: SessionProjectionState["messageLedger"];
+  renderMessageLedger: SessionProjectionState["messageLedger"];
+  messagesForRenderBase: Message[];
+  mergedMessagesForRender: Message[];
+  conversationTree: ReturnType<typeof buildConversationTree>;
+  nodeTimestampIndex: Map<string, number>;
+  filteredRawEvents: BaseEvent[];
+  compactedEvents: BaseEvent[];
+  timelineItems: ReturnType<typeof buildTimelineItems>;
+  pendingConfirmations: number;
+  latestRunState: ReturnType<typeof import("@/utils/session-hydration").deriveRunStates>[number] | null;
+  optimisticMessages: Message[];
+  loadedSessionIdRef: MutableRefObject<string | null>;
+  rawEventsRef: MutableRefObject<BaseEvent[]>;
+  dispatchSessionProjection: Dispatch<SessionProjectionAction>;
+  appendRealtimeEvent: (event: BaseEvent) => void;
+  appendOptimisticMessage: (message: Message) => void;
+  clearOptimisticMessages: () => void;
+  clearSessionProjection: () => void;
+  applyHydratedSession: (input: {
+    sessionId: string;
+    detail: HydratedSessionDetail;
+    activeSessionId: string | null;
+  }) => void;
+}
+
+export function useSessionProjection(
+  options: UseSessionProjectionOptions,
+): UseSessionProjectionReturnValue {
+  const { sessionId, selectedNodeId, maxEvents = 10000 } = options;
+  const [sessionProjection, dispatchSessionProjection] = useReducer(
+    sessionProjectionReducer,
+    EMPTY_SESSION_PROJECTION,
+  );
+  const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
+  const loadedSessionIdRef = useRef<string | null>(sessionProjection.loadedSessionId);
+  const rawEventsRef = useRef<BaseEvent[]>(sessionProjection.rawEvents);
+
+  useEffect(() => {
+    loadedSessionIdRef.current = sessionProjection.loadedSessionId;
+  }, [sessionProjection.loadedSessionId]);
+
+  useEffect(() => {
+    rawEventsRef.current = sessionProjection.rawEvents;
+  }, [sessionProjection.rawEvents]);
+
+  const rawEvents = sessionProjection.rawEvents;
+  const hasLoadedSession = sessionProjection.loadedSessionId === sessionId;
+  const confirmedMessageLedger = hasLoadedSession
+    ? sessionProjection.messageLedger
+    : [];
+  const snapshotForRender = hasLoadedSession ? sessionProjection.snapshot : null;
+
+  const messagesForRenderBase = useMemo(
+    () => ledgerEntriesToMessages(confirmedMessageLedger),
+    [confirmedMessageLedger],
+  );
+
+  const mergedMessagesForRender = useMemo(() => {
+    const pendingOptimistic = reconcileOptimisticMessages(
+      messagesForRenderBase,
+      optimisticMessages,
+    );
+    return mergeOptimisticMessages(messagesForRenderBase, pendingOptimistic).map(
+      (message) =>
+        !normalizeMessageContent(message).trim().length
+          ? ({
+              ...message,
+              content: normalizeMessageContent(message),
+            } as Message)
+          : message,
+    );
+  }, [messagesForRenderBase, optimisticMessages]);
+
+  const optimisticMessageLedger = useMemo(
+    () =>
+      buildMessageLedger({
+        events: [],
+        fallbackMessages: optimisticMessages,
+      }),
+    [optimisticMessages],
+  );
+
+  const renderMessageLedger = useMemo(
+    () => mergeMessageLedger(confirmedMessageLedger, optimisticMessageLedger),
+    [confirmedMessageLedger, optimisticMessageLedger],
+  );
+
+  const nodeTimestampIndex = useMemo(
+    () =>
+      buildNodeTimestampIndex(
+        buildConversationTree({
+          events: rawEvents,
+          fallbackMessages: mergedMessagesForRender,
+          messageLedger: renderMessageLedger,
+        }),
+      ),
+    [mergedMessagesForRender, rawEvents, renderMessageLedger],
+  );
+
+  const filteredRawEvents = useMemo(() => {
+    if (!selectedNodeId) {
+      return rawEvents;
+    }
+
+    const cutoffTimestamp = nodeTimestampIndex.get(selectedNodeId);
+    if (cutoffTimestamp === undefined) {
+      return rawEvents;
+    }
+
+    return rawEvents.filter((event) => {
+      const eventTimestamp = event.timestamp || 0;
+      return eventTimestamp <= cutoffTimestamp;
+    });
+  }, [nodeTimestampIndex, rawEvents, selectedNodeId]);
+
+  const compactedEvents = useMemo(
+    () => compactEvents(filteredRawEvents),
+    [filteredRawEvents],
+  );
+  const timelineItems = useMemo(
+    () => buildTimelineItems(compactedEvents),
+    [compactedEvents],
+  );
+
+  const conversationTree = useMemo(
+    () =>
+      buildConversationTree({
+        events: rawEvents,
+        fallbackMessages: mergedMessagesForRender,
+        messageLedger: renderMessageLedger,
+      }),
+    [mergedMessagesForRender, rawEvents, renderMessageLedger],
+  );
+
+  const pendingConfirmations = useMemo(() => {
+    const pending = new Set<string>();
+    rawEvents.forEach((event) => {
+      if (
+        event.type === EventType.TOOL_CALL_START &&
+        "toolCallName" in event &&
+        "toolCallId" in event &&
+        event.toolCallName === "ui.confirmation"
+      ) {
+        pending.add(String(event.toolCallId));
+      }
+      if (event.type === EventType.TOOL_CALL_RESULT && "toolCallId" in event) {
+        pending.delete(String(event.toolCallId));
+      }
+    });
+    return pending.size;
+  }, [rawEvents]);
+
+  const latestRunState = useMemo(() => {
+    const runStates = deriveRunStates(rawEvents);
+    return runStates[runStates.length - 1] || null;
+  }, [rawEvents]);
+
+  const historicalSnapshot = useMemo(
+    () => buildStateSnapshotFromEvents(filteredRawEvents),
+    [filteredRawEvents],
+  );
+  const snapshotForDisplay = useMemo(() => {
+    if (!selectedNodeId) {
+      return snapshotForRender;
+    }
+    return historicalSnapshot;
+  }, [historicalSnapshot, selectedNodeId, snapshotForRender]);
+
+  const appendRealtimeEvent = useCallback(
+    (event: BaseEvent) => {
+      dispatchSessionProjection({
+        type: "append_realtime_events",
+        events: [event],
+        maxEvents,
+      });
+    },
+    [maxEvents],
+  );
+
+  const appendOptimisticMessage = useCallback((message: Message) => {
+    setOptimisticMessages((prev) => [...prev, message]);
+  }, []);
+
+  const clearOptimisticMessages = useCallback(() => {
+    setOptimisticMessages([]);
+  }, []);
+
+  const clearSessionProjection = useCallback(() => {
+    setOptimisticMessages([]);
+    dispatchSessionProjection({ type: "reset" });
+  }, []);
+
+  const applyHydratedSessionAction = useCallback(
+    (input: {
+      sessionId: string;
+      detail: HydratedSessionDetail;
+      activeSessionId: string | null;
+    }) => {
+      const shouldMerge = shouldMergeHydratedProjection({
+        currentLoadedSessionId: loadedSessionIdRef.current,
+        activeSessionId: input.activeSessionId,
+        incomingSessionId: input.sessionId,
+        currentRawEvents: rawEventsRef.current,
+      });
+      dispatchSessionProjection({
+        type: "hydrate_session",
+        sessionId: input.sessionId,
+        detail: input.detail,
+        shouldMerge,
+      });
+    },
+    [],
+  );
+
+  return {
+    sessionProjection,
+    rawEvents,
+    snapshotForRender,
+    snapshotForDisplay,
+    confirmedMessageLedger,
+    renderMessageLedger,
+    messagesForRenderBase,
+    mergedMessagesForRender,
+    conversationTree,
+    nodeTimestampIndex,
+    filteredRawEvents,
+    compactedEvents,
+    timelineItems,
+    pendingConfirmations,
+    latestRunState,
+    optimisticMessages,
+    loadedSessionIdRef,
+    rawEventsRef,
+    dispatchSessionProjection,
+    appendRealtimeEvent,
+    appendOptimisticMessage,
+    clearOptimisticMessages,
+    clearSessionProjection,
+    applyHydratedSession: applyHydratedSessionAction,
+  };
+}

--- a/apps/negentropy-ui/features/session/index.ts
+++ b/apps/negentropy-ui/features/session/index.ts
@@ -14,3 +14,4 @@ export { SessionList } from "@/components/ui/SessionList";
 
 // Hooks (re-export from hooks/ for now)
 export { useSessionManager } from "@/hooks/useSessionManager";
+export { useSessionProjection } from "@/features/session/hooks/useSessionProjection";

--- a/apps/negentropy-ui/features/session/utils/session-projection.ts
+++ b/apps/negentropy-ui/features/session/utils/session-projection.ts
@@ -1,0 +1,107 @@
+import type { BaseEvent } from "@ag-ui/core";
+import type {
+  SessionProjectionState,
+} from "@/types/common";
+import { buildMessageLedger, mergeMessageLedger } from "@/utils/message-ledger";
+import {
+  hasSameEventSequence,
+  mergeEvents,
+  type HydratedSessionDetail,
+} from "@/utils/session-hydration";
+
+export const EMPTY_SESSION_PROJECTION: SessionProjectionState = {
+  loadedSessionId: null,
+  rawEvents: [],
+  messageLedger: [],
+  snapshot: null,
+};
+
+export type SessionProjectionAction =
+  | {
+      type: "reset";
+    }
+  | {
+      type: "append_realtime_events";
+      events: BaseEvent[];
+      maxEvents?: number;
+    }
+  | {
+      type: "hydrate_session";
+      sessionId: string;
+      detail: HydratedSessionDetail;
+      shouldMerge: boolean;
+    };
+
+export function shouldMergeHydratedProjection(input: {
+  currentLoadedSessionId: string | null;
+  activeSessionId: string | null;
+  incomingSessionId: string;
+  currentRawEvents: BaseEvent[];
+}): boolean {
+  return (
+    input.currentLoadedSessionId === input.incomingSessionId ||
+    (input.activeSessionId === input.incomingSessionId &&
+      input.currentRawEvents.length > 0)
+  );
+}
+
+export function applyRealtimeEvents(
+  state: SessionProjectionState,
+  events: BaseEvent[],
+  maxEvents = 10000,
+): SessionProjectionState {
+  const nextRawEvents = mergeEvents(state.rawEvents, events).slice(-maxEvents);
+  if (hasSameEventSequence(state.rawEvents, nextRawEvents)) {
+    return state;
+  }
+  return {
+    ...state,
+    rawEvents: nextRawEvents,
+    messageLedger: buildMessageLedger({ events: nextRawEvents }),
+  };
+}
+
+export function applyHydratedSession(
+  state: SessionProjectionState,
+  input: {
+    sessionId: string;
+    detail: HydratedSessionDetail;
+    shouldMerge: boolean;
+  },
+): SessionProjectionState {
+  if (!input.shouldMerge) {
+    return {
+      loadedSessionId: input.sessionId,
+      rawEvents: input.detail.events,
+      messageLedger: input.detail.messageLedger,
+      snapshot: input.detail.snapshot,
+    };
+  }
+
+  const nextRawEvents = mergeEvents(state.rawEvents, input.detail.events);
+  return {
+    loadedSessionId: input.sessionId,
+    rawEvents: nextRawEvents,
+    messageLedger: mergeMessageLedger(
+      state.messageLedger,
+      input.detail.messageLedger,
+    ),
+    snapshot: input.detail.snapshot ?? state.snapshot,
+  };
+}
+
+export function sessionProjectionReducer(
+  state: SessionProjectionState,
+  action: SessionProjectionAction,
+): SessionProjectionState {
+  switch (action.type) {
+    case "reset":
+      return EMPTY_SESSION_PROJECTION;
+    case "append_realtime_events":
+      return applyRealtimeEvents(state, action.events, action.maxEvents);
+    case "hydrate_session":
+      return applyHydratedSession(state, action);
+    default:
+      return state;
+  }
+}

--- a/apps/negentropy-ui/tests/unit/features/session/session-projection.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/session/session-projection.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import { EventType } from "@ag-ui/core";
+import { createTestEvent } from "@/tests/helpers/agui";
+import {
+  applyHydratedSession,
+  applyRealtimeEvents,
+  EMPTY_SESSION_PROJECTION,
+  sessionProjectionReducer,
+  shouldMergeHydratedProjection,
+} from "@/features/session/utils/session-projection";
+import { ledgerEntriesToMessages } from "@/utils/message-ledger";
+
+describe("session-projection", () => {
+  it("appendRealtimeEvents 会同步推进 rawEvents 与 messageLedger", () => {
+    const next = applyRealtimeEvents(
+      EMPTY_SESSION_PROJECTION,
+      [
+        createTestEvent({
+          type: EventType.TEXT_MESSAGE_START,
+          threadId: "thread-1",
+          runId: "run-1",
+          messageId: "msg-1",
+          role: "assistant",
+          timestamp: 1000,
+        }),
+        createTestEvent({
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          threadId: "thread-1",
+          runId: "run-1",
+          messageId: "msg-1",
+          delta: "hello",
+          timestamp: 1001,
+        }),
+        createTestEvent({
+          type: EventType.TEXT_MESSAGE_END,
+          threadId: "thread-1",
+          runId: "run-1",
+          messageId: "msg-1",
+          timestamp: 1002,
+        }),
+      ],
+    );
+
+    expect(next.rawEvents).toHaveLength(3);
+    expect(next.messageLedger).toHaveLength(1);
+    expect(next.messageLedger[0]).toMatchObject({
+      id: "msg-1",
+      resolvedRole: "assistant",
+      content: "hello",
+    });
+  });
+
+  it("applyHydratedSession 在 shouldMerge=false 时直接替换 projection", () => {
+    const next = applyHydratedSession(EMPTY_SESSION_PROJECTION, {
+      sessionId: "s1",
+      shouldMerge: false,
+      detail: {
+        events: [
+          createTestEvent({
+            type: EventType.RUN_STARTED,
+            threadId: "s1",
+            runId: "run-1",
+            timestamp: 1000,
+          }),
+        ],
+        messages: [],
+        messageLedger: [
+          {
+            id: "msg-1",
+            threadId: "s1",
+            runId: "run-1",
+            resolvedRole: "user",
+            resolutionSource: "explicit_role",
+            content: "Hi",
+            createdAt: new Date("2026-03-08T00:00:01.000Z"),
+            streaming: false,
+            sourceEventTypes: ["TEXT_MESSAGE_END"],
+            relatedMessageIds: ["msg-1"],
+          },
+        ],
+        snapshot: { ready: true },
+      },
+    });
+
+    expect(next.loadedSessionId).toBe("s1");
+    expect(next.messageLedger).toHaveLength(1);
+    expect(next.snapshot).toEqual({ ready: true });
+  });
+
+  it("applyHydratedSession 在 shouldMerge=true 时合并 ledger 与 snapshot", () => {
+    const base = {
+      loadedSessionId: "s1",
+      rawEvents: [
+        createTestEvent({
+          type: EventType.RUN_STARTED,
+          threadId: "s1",
+          runId: "run-1",
+          timestamp: 1000,
+        }),
+      ],
+      messageLedger: [
+        {
+          id: "msg-1",
+          threadId: "s1",
+          runId: "run-1",
+          resolvedRole: "assistant" as const,
+          resolutionSource: "fallback_assistant" as const,
+          content: "He",
+          createdAt: new Date("2026-03-08T00:00:02.000Z"),
+          streaming: true,
+          sourceEventTypes: ["TEXT_MESSAGE_START"],
+          relatedMessageIds: ["msg-1"],
+        },
+      ],
+      snapshot: { stage: "running" },
+    };
+
+    const next = applyHydratedSession(base, {
+      sessionId: "s1",
+      shouldMerge: true,
+      detail: {
+        events: [
+          createTestEvent({
+            type: EventType.RUN_FINISHED,
+            threadId: "s1",
+            runId: "run-1",
+            timestamp: 1003,
+          }),
+        ],
+        messages: [],
+        messageLedger: [
+          {
+            id: "msg-1",
+            threadId: "s1",
+            runId: "run-1",
+            resolvedRole: "user",
+            resolutionSource: "snapshot_role",
+            content: "Hello",
+            createdAt: new Date("2026-03-08T00:00:01.000Z"),
+            streaming: false,
+            sourceEventTypes: ["MESSAGES_SNAPSHOT"],
+            relatedMessageIds: ["msg-1"],
+          },
+        ],
+        snapshot: { stage: "done" },
+      },
+    });
+
+    expect(next.rawEvents).toHaveLength(2);
+    expect(next.messageLedger[0]).toMatchObject({
+      resolvedRole: "user",
+      content: "Hello",
+      streaming: false,
+    });
+    expect(next.snapshot).toEqual({ stage: "done" });
+    expect(ledgerEntriesToMessages(next.messageLedger)[0]?.role).toBe("user");
+  });
+
+  it("shouldMergeHydratedProjection 正确判断 session 合并条件", () => {
+    expect(
+      shouldMergeHydratedProjection({
+        currentLoadedSessionId: "s1",
+        activeSessionId: "s1",
+        incomingSessionId: "s1",
+        currentRawEvents: [],
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldMergeHydratedProjection({
+        currentLoadedSessionId: null,
+        activeSessionId: "s1",
+        incomingSessionId: "s1",
+        currentRawEvents: [
+          createTestEvent({
+            type: EventType.RUN_STARTED,
+            threadId: "s1",
+            runId: "run-1",
+            timestamp: 1000,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("sessionProjectionReducer 支持 reset action", () => {
+    const state = {
+      loadedSessionId: "s1",
+      rawEvents: [
+        createTestEvent({
+          type: EventType.RUN_STARTED,
+          threadId: "s1",
+          runId: "run-1",
+          timestamp: 1000,
+        }),
+      ],
+      messageLedger: [],
+      snapshot: { ready: true },
+    };
+
+    expect(sessionProjectionReducer(state, { type: "reset" })).toEqual(
+      EMPTY_SESSION_PROJECTION,
+    );
+  });
+});

--- a/docs/a2ui.md
+++ b/docs/a2ui.md
@@ -80,9 +80,9 @@ flowchart TD
 
   subgraph ReadModel["A2UI Read Model"]
     D[normalizeAguiEvent]
-    E[Session Projection]
+    E[Session Projection Feature]
     F[Message Ledger]
-    J[buildConversationTree]
+    J[ConversationTree Projection]
     K[ConversationNode Tree]
   end
 
@@ -105,6 +105,7 @@ flowchart TD
 - 传输入口：[route.ts](../apps/negentropy-ui/app/api/agui/route.ts)
 - ADK 到 AGUI 归一化：[adk.ts](../apps/negentropy-ui/lib/adk.ts)
 - Session Projection / Message Ledger：[message-ledger.ts](../apps/negentropy-ui/utils/message-ledger.ts)
+- Session Projection Hook：[useSessionProjection.ts](../apps/negentropy-ui/features/session/hooks/useSessionProjection.ts)
 - 事件到树构建：[conversation-tree.ts](../apps/negentropy-ui/utils/conversation-tree.ts)
 - Chat 主区渲染：[ChatStream.tsx](../apps/negentropy-ui/components/ui/ChatStream.tsx)
 - 递归节点渲染：[ConversationNodeRenderer.tsx](../apps/negentropy-ui/components/ui/conversation/ConversationNodeRenderer.tsx)
@@ -119,6 +120,8 @@ flowchart TD
 - `conversationTree`、timeline、state 面板都属于从 session projection 派生出的 surface projection。
 
 这样做的目标是把“协议输入”“消息事实”“页面结构”三层职责拆开，避免聊天主区、历史回放与技术面板各自维护不同事实源。
+
+当前实现进一步把这套 projection orchestration 从页面组件中抽离到 `features/session`，页面只消费 session feature 暴露的 projection 与 action，不再直接持有 reducer 和投影拼装逻辑。
 
 ### 3.3 Canonical Role 约定
 


### PR DESCRIPTION
## 背景

本分支围绕 Chat 页聊天链路做了一次系统性收敛。

最初的问题是用户消息在 Chat 页被按 assistant 样式渲染，甚至在历史回放和归并后出现角色漂移或消息丢失。继续排查后发现，根因不只是单点 UI bug，而是协议边界、角色归一化、消息读模型和页面投影视图之间长期耦合，导致页面层承担了过多事实拼装与投影编排逻辑。

因此，这个 PR 不只是修一个显示问题，而是顺着同一条主线完成四个层面的改进：

1. 校正 AGUI / A2UI 在本项目中的职责定义
2. 重新对齐 Chat 页的聊天优先交互
3. 建立 `Message Ledger` 作为聊天消息事实源
4. 继续把 `SessionProjectionState` 从页面内联实现前移并抽离为独立 session feature

目标是让 Chat、Timeline、历史回放和后续 A2UI 多 surface projection 都建立在同一套 session 级事实源之上，避免 split-brain 和重复编排。

## 本次改动

### 1. 校正 AGUI / A2UI 文档与项目实践边界

- 重写 `docs/a2ui.md`
- 明确 AGUI 是事件与消息语义的事实输入层
- 明确 A2UI 在本项目里是前端读模型 / 结构化展示约定，而不是第二条并行传输协议
- 补充 session projection、message ledger、conversation tree projection 与聊天主区之间的关系
- 把自定义 `ne.*` 事件与官方协议字段边界说清楚，减少后续继续扩展时的语义漂移

### 2. 修复聊天角色语义与历史消息保真问题

- 收敛 canonical role，`agent` 只保留兼容输入并统一归并为 `assistant`
- 抽出统一的角色解析逻辑，避免多个模块各自做 role fallback
- 修复历史 payload 仅通过 `author: "user"` 表达用户消息时，被错误视为 assistant 或在回放过程中被吞并的问题
- 让 `messagesSnapshot` 正式参与历史消息纠偏，而不是继续作为 UI 层补丁

### 3. 引入并强化 Message Ledger 读模型

- 新增 `MessageRoleResolver`
- 新增 `Message Ledger` 作为聊天链路的消息事实源
- 补齐：
  - `mergeMessageLedger`
  - `ledgerEntriesToMessages`
- 让 hydration、历史回放、实时事件与 fallback message 统一通过 ledger 合并，减少消息事实在不同层之间重复派生

### 4. 将 SessionProjectionState 抽离为独立 session feature

- 新增 session projection 纯函数状态机与 reducer
- 新增 `useSessionProjection` hook
- 把原来散落在 `page.tsx` 中的：
  - reducer
  - dispatch
  - message ledger 拼装
  - render projection 派生
  - conversation tree / timestamp index / filtered events / timeline projection
  统一收敛到 `features/session`
- 页面层改为消费 projection 和 action，不再直接承担会话投影 orchestration

### 5. 保持现有聊天行为和页面功能稳定

- Chat 主区继续保持聊天优先
- 历史消息、实时流和 optimistic message 仍然协同工作
- 保留 `buildConversationTree()` 的兼容 fallback 能力，但页面主路径改为显式消费 session projection
- 不修改 AGUI / ADK 后端协议，不扩大改动面到服务端

### 6. 补充回归与 feature 级测试

- 新增 session projection 状态机测试
- 新增历史用户消息、snapshot 纠偏、ledger 合并与消息派生测试
- 保留并继续验证：
  - Chat 主区消息顺序
  - 历史回拉不清空实时 assistant 回复
  - assistant 实时流与最终回拉去重
  - 历史 `author: "user"` 场景不丢失、不换边、不伪装成 assistant

## 关键实现细节

- `Message Ledger` 已从“页面渲染辅助结构”提升为 session 级正式 projection 组成部分
- `SessionProjectionState` 现在承担 confirmed projection，页面只保留 UI 状态与 agent/network orchestration
- optimistic message 继续作为本地 overlay 存在，但 overlay 的合并已经纳入 session feature，而不是留在页面里手工编排
- `useSessionProjection` 将 conversation tree、node timestamp index、filtered events、timeline items 等都统一建立在同一份 session projection 上，为后续扩展 A2UI 多 surface projection 留出明确边界
- 文档、实现、测试三者现在围绕同一套 session projection / message ledger 心智保持一致

## 验证

本分支已补充并通过类型检查与回归测试，覆盖：

- `tests/unit/features/session/session-projection.test.ts`
- `tests/unit/utils/session-hydration.test.ts`
- `tests/unit/utils/conversation-tree.test.ts`
- `tests/integration/home-flow.test.tsx`
- `tests/unit/adk.test.ts`

重点验证场景包括：

- `author: "user"` 的历史消息恢复为 user bubble
- `messagesSnapshot` 对历史角色与缺失消息的纠偏继续生效
- session projection 抽离后，页面不再自己拼 projection 也能稳定显示 Chat 主区
- realtime event、hydration 回放与 optimistic overlay 不会造成重复、丢失或换边
- conversation tree、timeline 与聊天主区消费的是同一份 projection 事实
