### PR TITLE
fix(pipeline): 修复失败作业时间线回写丢失;

### DIFF
--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -605,7 +605,9 @@ export type PipelineStageStatus =
 export type PipelineOperation =
   | "ingest_text"
   | "ingest_url"
-  | "replace_source";
+  | "replace_source"
+  | "sync_source"
+  | "rebuild_source";
 
 // Pipeline 阶段结果
 export interface PipelineStageResult {

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -19,6 +19,8 @@ export const OPERATION_LABELS: Record<string, string> = {
   ingest_text: "文本摄入",
   ingest_url: "URL 摄入",
   replace_source: "替换源",
+  sync_source: "同步源",
+  rebuild_source: "重建源",
 };
 
 /**

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
@@ -29,11 +29,26 @@ const settle = async () => {
   });
 };
 
-const makeRun = (overrides?: Partial<{ id: string; run_id: string; status: string; version: number }>) => ({
+const makeRun = (
+  overrides?: Partial<{
+    id: string;
+    run_id: string;
+    status: string;
+    version: number;
+    operation: string;
+    started_at: string;
+    completed_at: string;
+    duration_ms: number;
+  }>
+) => ({
   id: overrides?.id ?? "run-1-id",
   run_id: overrides?.run_id ?? "run-1",
   status: overrides?.status ?? "completed",
   version: overrides?.version ?? 1,
+  operation: overrides?.operation,
+  started_at: overrides?.started_at,
+  completed_at: overrides?.completed_at,
+  duration_ms: overrides?.duration_ms,
 });
 
 describe("KnowledgePipelinesPage polling", () => {
@@ -165,5 +180,29 @@ describe("KnowledgePipelinesPage polling", () => {
 
     expect(screen.getAllByText(/run-id-with-a-very-long-identifier/).length).toBeGreaterThan(0);
     expect(screen.getByText(/https:\/\/example\.com/)).toBeInTheDocument();
+  });
+
+  it("失败的重建源 Run 会在 Timeline 中显示开始与结束时间", async () => {
+    knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      runs: [
+        makeRun({
+          id: "run-failed-id",
+          run_id: "run-failed",
+          status: "failed",
+          operation: "rebuild_source",
+          started_at: "2026-03-08T10:00:00Z",
+          completed_at: "2026-03-08T10:02:00Z",
+          duration_ms: 120000,
+        }),
+      ],
+      last_updated_at: "t0",
+    });
+
+    render(<KnowledgePipelinesPage />);
+    await settle();
+
+    expect(screen.getAllByText("重建源").length).toBeGreaterThan(0);
+    expect(screen.getByText("开始 2026-03-08T10:00:00Z")).toBeInTheDocument();
+    expect(screen.getByText("结束 2026-03-08T10:02:00Z")).toBeInTheDocument();
   });
 });

--- a/apps/negentropy/src/negentropy/knowledge/dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/dao.py
@@ -20,6 +20,15 @@ class KnowledgeRunDao:
     def __init__(self, session_factory=AsyncSessionLocal):
         self._session_factory = session_factory
 
+    async def get_pipeline_run(self, app_name: str, run_id: str) -> Optional[KnowledgePipelineRun]:
+        async with self._session_factory() as db:
+            stmt = select(KnowledgePipelineRun).where(
+                KnowledgePipelineRun.app_name == app_name,
+                KnowledgePipelineRun.run_id == run_id,
+            )
+            result = await db.execute(stmt)
+            return result.scalar_one_or_none()
+
     async def get_latest_graph(self, app_name: str) -> Optional[KnowledgeGraphRun]:
         async with self._session_factory() as db:
             stmt = (

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -42,7 +42,7 @@ EmbeddingFn = Callable[[str], Awaitable[list[float]]]
 BatchEmbeddingFn = Callable[[list[str]], Awaitable[list[list[float]]]]
 
 # Pipeline 操作类型
-PipelineOperation = str  # "ingest_text" | "ingest_url" | "replace_source"
+PipelineOperation = str  # "ingest_text" | "ingest_url" | "replace_source" | "sync_source" | "rebuild_source"
 
 # Pipeline 阶段状态
 PipelineStageStatus = str  # "pending" | "running" | "completed" | "failed" | "skipped"
@@ -84,6 +84,33 @@ class PipelineTracker:
     def current_stage(self) -> Optional[str]:
         return self._current_stage
 
+    @staticmethod
+    def _calculate_duration_ms(started_at: Optional[str], completed_at: str) -> Optional[int]:
+        if not started_at:
+            return None
+        try:
+            start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+            return int((end_dt - start_dt).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            return None
+
+    async def resume(self) -> None:
+        """从已有持久化记录恢复上下文，避免后台执行覆盖 create_pipeline 初始载荷。"""
+        record = await self._dao.get_pipeline_run(self._app_name, self._run_id)
+        if not record:
+            return
+
+        payload = record.payload or {}
+        self._started_at = payload.get("started_at")
+        self._completed_at = payload.get("completed_at")
+        self._duration_ms = payload.get("duration_ms")
+        self._stages = dict(payload.get("stages") or {})
+        self._input = dict(payload.get("input") or {})
+        self._output = payload.get("output")
+        self._error = payload.get("error")
+        self._status = record.status
+
     async def start(self, input_data: Dict[str, Any]) -> None:
         """开始 Pipeline 执行"""
         self._started_at = datetime.now(timezone.utc).isoformat()
@@ -110,20 +137,11 @@ class PipelineTracker:
         stage_data = self._stages.get(stage, {})
         started_at = stage_data.get("started_at")
 
-        duration_ms = None
-        if started_at:
-            try:
-                start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
-                end_dt = datetime.fromisoformat(now.replace("Z", "+00:00"))
-                duration_ms = int((end_dt - start_dt).total_seconds() * 1000)
-            except (ValueError, TypeError):
-                pass
-
         self._stages[stage] = {
             "status": "completed",
             "started_at": started_at,
             "completed_at": now,
-            "duration_ms": duration_ms,
+            "duration_ms": self._calculate_duration_ms(started_at, now),
             "output": output,
         }
         self._current_stage = None
@@ -135,17 +153,33 @@ class PipelineTracker:
         error: Dict[str, Any],
     ) -> None:
         """阶段执行失败"""
-        now = datetime.now(timezone.utc).isoformat()
-        stage_data = self._stages.get(stage, {})
+        await self.fail(error, stage=stage)
 
-        self._stages[stage] = {
-            "status": "failed",
-            "started_at": stage_data.get("started_at"),
-            "completed_at": now,
-            "error": error,
-        }
+    async def fail(
+        self,
+        error: Dict[str, Any],
+        *,
+        stage: Optional[str] = None,
+    ) -> None:
+        """统一写入失败终态，确保 run 与 stage 的结束信息同时落盘。"""
+        now = datetime.now(timezone.utc).isoformat()
+        target_stage = stage or self._current_stage
+
+        if target_stage:
+            stage_data = self._stages.get(target_stage, {})
+            stage_started_at = stage_data.get("started_at")
+            self._stages[target_stage] = {
+                "status": "failed",
+                "started_at": stage_started_at,
+                "completed_at": now,
+                "duration_ms": self._calculate_duration_ms(stage_started_at, now),
+                "error": error,
+            }
+
         self._status = "failed"
         self._error = error
+        self._completed_at = now
+        self._duration_ms = self._calculate_duration_ms(self._started_at, now)
         self._current_stage = None
         await self._persist()
 
@@ -162,15 +196,7 @@ class PipelineTracker:
         now = datetime.now(timezone.utc).isoformat()
         self._status = "completed"
         self._output = output
-
-        if self._started_at:
-            try:
-                start_dt = datetime.fromisoformat(self._started_at.replace("Z", "+00:00"))
-                end_dt = datetime.fromisoformat(now.replace("Z", "+00:00"))
-                self._duration_ms = int((end_dt - start_dt).total_seconds() * 1000)
-            except (ValueError, TypeError):
-                pass
-
+        self._duration_ms = self._calculate_duration_ms(self._started_at, now)
         self._completed_at = now
         await self._persist()
 
@@ -214,6 +240,25 @@ class KnowledgeService:
         self._chunking_config = chunking_config or default_chunking_config()
         self._reranker = reranker or NoopReranker()
         self._pipeline_dao = pipeline_dao
+
+    async def _resume_async_pipeline_tracker(self, tracker: PipelineTracker) -> PipelineTracker:
+        await tracker.resume()
+        tracker._status = "running"
+        tracker._completed_at = None
+        tracker._duration_ms = None
+        tracker._error = None
+        return tracker
+
+    @staticmethod
+    async def _fail_pipeline_execution(tracker: Optional[PipelineTracker], exc: Exception) -> None:
+        if not tracker:
+            return
+        await tracker.fail(
+            {
+                "type": type(exc).__name__,
+                "message": str(exc),
+            }
+        )
 
     async def _get_corpus_config(self, corpus_id: UUID) -> dict[str, Any]:
         corpus = await self.get_corpus_by_id(corpus_id)
@@ -338,8 +383,7 @@ class KnowledgeService:
             operation="ingest_text",
             run_id=run_id,
         )
-        # 恢复 tracker 状态（已由 create_pipeline 初始化）
-        tracker._status = "running"
+        await self._resume_async_pipeline_tracker(tracker)
 
         logger.info(
             "pipeline_execution_started",
@@ -371,16 +415,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {"type": type(exc).__name__, "message": str(exc)},
-                )
-            else:
-                # 如果没有当前阶段，直接标记整个 Pipeline 失败
-                tracker._status = "failed"
-                tracker._error = {"type": type(exc).__name__, "message": str(exc)}
-                await tracker._persist()
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def execute_ingest_url_pipeline(
@@ -403,7 +438,7 @@ class KnowledgeService:
             operation="ingest_url",
             run_id=run_id,
         )
-        tracker._status = "running"
+        await self._resume_async_pipeline_tracker(tracker)
 
         logger.info(
             "pipeline_execution_started",
@@ -457,15 +492,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {"type": type(exc).__name__, "message": str(exc)},
-                )
-            else:
-                tracker._status = "failed"
-                tracker._error = {"type": type(exc).__name__, "message": str(exc)}
-                await tracker._persist()
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def execute_replace_source_pipeline(
@@ -489,7 +516,7 @@ class KnowledgeService:
             operation="replace_source",
             run_id=run_id,
         )
-        tracker._status = "running"
+        await self._resume_async_pipeline_tracker(tracker)
         config = chunking_config or self._chunking_config
 
         logger.info(
@@ -532,15 +559,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {"type": type(exc).__name__, "message": str(exc)},
-                )
-            else:
-                tracker._status = "failed"
-                tracker._error = {"type": type(exc).__name__, "message": str(exc)}
-                await tracker._persist()
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def execute_sync_source_pipeline(
@@ -562,7 +581,7 @@ class KnowledgeService:
             operation="sync_source",
             run_id=run_id,
         )
-        tracker._status = "running"
+        await self._resume_async_pipeline_tracker(tracker)
         config = chunking_config or self._chunking_config
 
         logger.info(
@@ -627,15 +646,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {"type": type(exc).__name__, "message": str(exc)},
-                )
-            else:
-                tracker._status = "failed"
-                tracker._error = {"type": type(exc).__name__, "message": str(exc)}
-                await tracker._persist()
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def execute_rebuild_source_pipeline(
@@ -657,7 +668,7 @@ class KnowledgeService:
             operation="rebuild_source",
             run_id=run_id,
         )
-        tracker._status = "running"
+        await self._resume_async_pipeline_tracker(tracker)
         config = chunking_config or self._chunking_config
 
         logger.info(
@@ -682,8 +693,6 @@ class KnowledgeService:
                     raise ValueError(f"Document not found in GCS: {source_uri}")
             except StorageError as exc:
                 from .exceptions import KnowledgeError
-
-                await tracker.fail_stage("download", {"type": "GCS_DOWNLOAD_FAILED", "message": str(exc)})
                 raise KnowledgeError(
                     code="GCS_DOWNLOAD_FAILED",
                     message=f"Failed to download content from GCS: {exc}",
@@ -750,15 +759,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {"type": type(exc).__name__, "message": str(exc)},
-                )
-            else:
-                tracker._status = "failed"
-                tracker._error = {"type": type(exc).__name__, "message": str(exc)}
-                await tracker._persist()
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def ensure_corpus(self, spec: CorpusSpec) -> CorpusRecord:
@@ -844,14 +845,7 @@ class KnowledgeService:
 
             return records
         except Exception as exc:
-            if tracker and tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {
-                        "type": type(exc).__name__,
-                        "message": str(exc),
-                    },
-                )
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def _ingest_text_with_tracker(
@@ -1031,14 +1025,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker and tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {
-                        "type": type(exc).__name__,
-                        "message": str(exc),
-                    },
-                )
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def delete_source(
@@ -1244,14 +1231,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker and tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {
-                        "type": type(exc).__name__,
-                        "message": str(exc),
-                    },
-                )
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def sync_source(
@@ -1382,14 +1362,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker and tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {
-                        "type": type(exc).__name__,
-                        "message": str(exc),
-                    },
-                )
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def rebuild_source(
@@ -1464,14 +1437,6 @@ class KnowledgeService:
             except StorageError as exc:
                 from .exceptions import KnowledgeError
 
-                if tracker:
-                    await tracker.fail_stage(
-                        "download",
-                        {
-                            "type": "GCS_DOWNLOAD_FAILED",
-                            "message": str(exc),
-                        },
-                    )
                 raise KnowledgeError(
                     code="GCS_DOWNLOAD_FAILED",
                     message=f"Failed to download content from GCS: {exc}",
@@ -1573,14 +1538,7 @@ class KnowledgeService:
             return records
 
         except Exception as exc:
-            if tracker and tracker.current_stage:
-                await tracker.fail_stage(
-                    tracker.current_stage,
-                    {
-                        "type": type(exc).__name__,
-                        "message": str(exc),
-                    },
-                )
+            await self._fail_pipeline_execution(tracker, exc)
             raise
 
     async def list_knowledge(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.dao import UpsertResult
+from negentropy.knowledge.service import KnowledgeService
+
+
+@dataclass
+class FakePipelineRun:
+    app_name: str
+    run_id: str
+    status: str
+    payload: dict
+
+
+class FakePipelineDao:
+    def __init__(self) -> None:
+        self.records: dict[tuple[str, str], FakePipelineRun] = {}
+
+    async def get_pipeline_run(self, app_name: str, run_id: str):
+        return self.records.get((app_name, run_id))
+
+    async def upsert_pipeline_run(
+        self,
+        *,
+        app_name: str,
+        run_id: str,
+        status: str,
+        payload: dict,
+        idempotency_key,
+        expected_version,
+    ):
+        _ = (idempotency_key, expected_version)
+        record = FakePipelineRun(app_name=app_name, run_id=run_id, status=status, payload=payload)
+        self.records[(app_name, run_id)] = record
+        return UpsertResult(
+            status="updated",
+            record={
+                "run_id": run_id,
+                "status": status,
+                "payload": payload,
+            },
+        )
+
+
+class FakeRepository:
+    async def delete_knowledge_by_source(self, *, corpus_id, app_name, source_uri):
+        _ = (corpus_id, app_name, source_uri)
+        raise RuntimeError("delete failed")
+
+
+class FakeStorageService:
+    async def get_document_content_by_uri(self, source_uri: str):
+        _ = source_uri
+        return b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_async_rebuild_pipeline_failure_persists_input_and_terminal_timestamps(monkeypatch):
+    dao = FakePipelineDao()
+    service = KnowledgeService(repository=FakeRepository(), pipeline_dao=dao)
+    corpus_id = uuid4()
+    app_name = "negentropy"
+    source_uri = "gs://bucket/doc.md"
+
+    monkeypatch.setattr("negentropy.storage.service.DocumentStorageService", lambda: FakeStorageService())
+
+    async def fake_extract_file_content(**kwargs):
+        _ = kwargs
+        return "plain text"
+
+    monkeypatch.setattr(service, "_extract_file_content", fake_extract_file_content)
+
+    run_id = await service.create_pipeline(
+        app_name=app_name,
+        operation="rebuild_source",
+        input_data={
+            "corpus_id": str(corpus_id),
+            "source_uri": source_uri,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        await service.execute_rebuild_source_pipeline(
+            run_id=run_id,
+            corpus_id=corpus_id,
+            app_name=app_name,
+            source_uri=source_uri,
+        )
+
+    record = dao.records[(app_name, run_id)]
+    payload = record.payload
+
+    assert record.status == "failed"
+    assert payload["operation"] == "rebuild_source"
+    assert payload["input"]["source_uri"] == source_uri
+    assert payload["started_at"] is not None
+    assert payload["completed_at"] is not None
+    assert isinstance(payload["duration_ms"], int)
+    assert payload["duration_ms"] >= 0
+    assert payload["error"]["type"] == "RuntimeError"
+    assert payload["error"]["message"] == "delete failed"
+    assert payload["stages"]["download"]["status"] == "completed"
+    assert payload["stages"]["delete"]["status"] == "failed"
+    assert payload["stages"]["delete"]["completed_at"] is not None


### PR DESCRIPTION
## 变更说明

本次变更修复了 Pipelines 页面中失败 Runs 的状态回写缺失问题，重点覆盖 `rebuild_source` / `sync_source` 等异步 Pipeline Run 在失败场景下的 Timeline 与后端存储一致性。

### 做了什么

- 在后端 `PipelineTracker` 中补齐统一的失败终态写回逻辑：
  - 失败时统一写入 run 级 `status=failed`
  - 回写 `completed_at` 与 `duration_ms`
  - 同步保留并落库顶层 `error`
  - 若存在当前阶段，同时回写阶段级 `completed_at`、`duration_ms` 与失败状态
- 为异步 Pipeline 执行补齐上下文恢复能力：
  - 后台任务重新创建 tracker 时，先从已有 pipeline run 记录恢复 `input`、`started_at`、已记录 stages 等上下文
  - 避免执行阶段第一次持久化时覆盖 `create_pipeline()` 已写入的 `source_uri`、开始时间等信息
- 新增 DAO 查询能力，用于按 `app_name + run_id` 读取已有 pipeline run，支撑 tracker 恢复
- 补齐前端共享类型与标签映射：
  - 将 `sync_source`、`rebuild_source` 纳入 `PipelineOperation`
  - 补齐对应中文展示标签，确保 Timeline 与详情页展示一致
- 新增回归测试：
  - 后端单测覆盖 `rebuild_source` 失败时仍保留 `input.source_uri`、`started_at`、`completed_at`、`duration_ms`、失败阶段信息
  - 前端单测覆盖失败的 `rebuild_source` Run 在 Timeline 中展示开始时间和结束时间

### 为什么这么改

任务背景是：Pipelines 页面中失败 Runs 的“重建源 / 开始时间 / 结束时间”没有正确回写到 Timeline，也没有稳定落入后端相关存储，导致失败 Run 的审计链路不完整。

根因不是单纯前端渲染，而是后端异步执行链路存在两个问题：

1. `create_pipeline()` 创建 run 后，后台执行重新初始化 tracker，但没有恢复已有上下文，导致后续持久化可能覆盖掉原先的 `input` 和 `started_at`
2. 失败路径没有像成功路径一样走统一的 terminal-state 持久化，导致 `completed_at`、`duration_ms` 等终态字段缺失

本次修复采用“单一终态收口 + 运行上下文恢复”的方式，属于工作流状态跟踪中的经典做法，可在不扩大改动面的前提下保证成功/失败路径的行为对齐，并降低后续新增 Pipeline 操作时再次漏写终态字段的风险。

### 重要实现细节

- 修复集中在 pipeline tracking 与 run persistence 边界，没有修改对外 API 结构
- 保留现有 run payload 组织方式，只补足失败场景下缺失的终态字段与上下文恢复逻辑，属于最小干预
- 失败时不再依赖各执行分支手工拼装终态，而是统一通过 tracker 收口，减少分支漂移
- 前端改动仅限类型与回归测试，不改变既有页面交互

## 验证

已执行：

- `uv run python -m pytest tests/unit_tests/knowledge/test_pipeline_tracker.py -q`
- `uv run python -m py_compile src/negentropy/knowledge/service.py src/negentropy/knowledge/dao.py tests/unit_tests/knowledge/test_pipeline_tracker.py`
- `pnpm -C apps/negentropy-ui typecheck:test`
- `pnpm -C apps/negentropy-ui test -- --run tests/unit/knowledge/PipelinesPage.test.tsx`

其中最后一条按当前脚本行为实际跑完整套 Vitest，结果全部通过。
