### PR TITLE
feat(memory): 新增 Memory Automation 控制面与受管调度能力;

### DIFF
--- a/apps/negentropy-ui/app/api/memory/automation/config/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/config/route.ts
@@ -1,0 +1,5 @@
+import { proxyPost } from "../../_proxy";
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/memory/automation/config");
+}

--- a/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/disable/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/disable/route.ts
@@ -1,0 +1,9 @@
+import { proxyPost } from "../../../../_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ jobKey: string }> },
+) {
+  const { jobKey } = await params;
+  return proxyPost(request, `/memory/automation/jobs/${jobKey}/disable`);
+}

--- a/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/enable/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/enable/route.ts
@@ -1,0 +1,9 @@
+import { proxyPost } from "../../../../_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ jobKey: string }> },
+) {
+  const { jobKey } = await params;
+  return proxyPost(request, `/memory/automation/jobs/${jobKey}/enable`);
+}

--- a/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/reconcile/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/reconcile/route.ts
@@ -1,0 +1,9 @@
+import { proxyPost } from "../../../../_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ jobKey: string }> },
+) {
+  const { jobKey } = await params;
+  return proxyPost(request, `/memory/automation/jobs/${jobKey}/reconcile`);
+}

--- a/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/run/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/jobs/[jobKey]/run/route.ts
@@ -1,0 +1,9 @@
+import { proxyPost } from "../../../../_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ jobKey: string }> },
+) {
+  const { jobKey } = await params;
+  return proxyPost(request, `/memory/automation/jobs/${jobKey}/run`);
+}

--- a/apps/negentropy-ui/app/api/memory/automation/logs/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/logs/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "../../_proxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/memory/automation/logs");
+}

--- a/apps/negentropy-ui/app/api/memory/automation/route.ts
+++ b/apps/negentropy-ui/app/api/memory/automation/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "../_proxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/memory/automation");
+}

--- a/apps/negentropy-ui/app/memory/automation/page.tsx
+++ b/apps/negentropy-ui/app/memory/automation/page.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+
+import { useAuth } from "@/components/providers/AuthProvider";
+import { MemoryNav } from "@/components/ui/MemoryNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+import {
+  fetchMemoryAutomation,
+  fetchMemoryAutomationLogs,
+  runMemoryAutomationJob,
+  triggerMemoryAutomationJobAction,
+  updateMemoryAutomationConfig,
+  type MemoryAutomationLog,
+  type MemoryAutomationSnapshot,
+} from "@/features/memory";
+
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+
+export default function MemoryAutomationPage() {
+  const { user, status } = useAuth();
+  const [snapshot, setSnapshot] = useState<MemoryAutomationSnapshot | null>(null);
+  const [logs, setLogs] = useState<MemoryAutomationLog[]>([]);
+  const [form, setForm] = useState<MemoryAutomationSnapshot["config"] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [statusText, setStatusText] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const isAdmin = Boolean(user?.roles?.includes("admin"));
+
+  const load = async () => {
+    setError(null);
+    const [nextSnapshot, nextLogs] = await Promise.all([
+      fetchMemoryAutomation(APP_NAME),
+      fetchMemoryAutomationLogs(APP_NAME, 10),
+    ]);
+    setSnapshot(nextSnapshot);
+    setForm(nextSnapshot.config);
+    setLogs(nextLogs.items);
+  };
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    load().catch((err) => {
+      setError(err instanceof Error ? err.message : String(err));
+    });
+  }, [isAdmin]);
+
+  const updateField = (
+    section: keyof MemoryAutomationSnapshot["config"],
+    key: string,
+    value: string | number | boolean,
+  ) => {
+    setForm((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        [section]: {
+          ...prev[section],
+          [key]: value,
+        },
+      };
+    });
+  };
+
+  const handleSave = () => {
+    if (!form) return;
+    startTransition(async () => {
+      try {
+        const nextSnapshot = await updateMemoryAutomationConfig({
+          app_name: APP_NAME,
+          config: form,
+        });
+        setSnapshot(nextSnapshot);
+        setForm(nextSnapshot.config);
+        setStatusText("配置已保存并完成 reconcile。");
+        const nextLogs = await fetchMemoryAutomationLogs(APP_NAME, 10);
+        setLogs(nextLogs.items);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  };
+
+  const handleJobAction = (jobKey: string, action: "enable" | "disable" | "reconcile") => {
+    startTransition(async () => {
+      try {
+        const nextSnapshot = await triggerMemoryAutomationJobAction(jobKey, action, APP_NAME);
+        setSnapshot(nextSnapshot);
+        setForm(nextSnapshot.config);
+        setStatusText(`任务 ${jobKey} 已执行 ${action}。`);
+        const nextLogs = await fetchMemoryAutomationLogs(APP_NAME, 10);
+        setLogs(nextLogs.items);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  };
+
+  const handleRun = (jobKey: string) => {
+    startTransition(async () => {
+      try {
+        const result = await runMemoryAutomationJob(jobKey, APP_NAME);
+        setSnapshot(result.snapshot);
+        setForm(result.snapshot.config);
+        setStatusText(`任务 ${jobKey} 已手动触发，返回结果：${result.result ?? "-"}`);
+        const nextLogs = await fetchMemoryAutomationLogs(APP_NAME, 10);
+        setLogs(nextLogs.items);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  };
+
+  if (status === "loading") {
+    return (
+      <div className="flex h-full items-center justify-center bg-background">
+        <div className="text-sm text-muted">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="flex h-full flex-col bg-background">
+        <MemoryNav title="Automation" description="仿生记忆自动化控制面" />
+        <div className="flex flex-1 items-center justify-center px-6">
+          <div className="max-w-lg rounded-3xl border border-border bg-card p-8 text-center shadow-sm">
+            <h1 className="text-lg font-semibold text-foreground">仅管理员可访问</h1>
+            <p className="mt-3 text-sm text-muted">
+              Memory Automation 控制面包含 retention、cron 调度与过程重建操作，当前账号无权访问。
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      <MemoryNav title="Automation" description="仿生记忆自动化控制面" />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-h-0 flex-1 gap-6 px-6 py-6">
+          <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+            <div className="space-y-4 pb-4 pr-2">
+              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+                <h2 className="text-sm font-semibold text-foreground">系统能力</h2>
+                <div className="mt-4 space-y-3 text-xs text-muted">
+                  <div className="flex items-center justify-between">
+                    <span>pg_cron</span>
+                    <span>{snapshot?.capabilities.pg_cron_installed ? "installed" : "missing"}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>管理模式</span>
+                    <span>{snapshot?.capabilities.management_mode || "-"}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>健康状态</span>
+                    <span>{snapshot?.health.status || "-"}</span>
+                  </div>
+                </div>
+                {snapshot?.capabilities.degraded_reasons?.length ? (
+                  <div className="mt-4 rounded-2xl border border-amber-300 bg-amber-50 p-3 text-[11px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+                    {snapshot.capabilities.degraded_reasons.join(" / ")}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+                <h2 className="text-sm font-semibold text-foreground">过程摘要</h2>
+                <div className="mt-4 space-y-3">
+                  {snapshot?.processes.map((process) => (
+                    <div key={process.key} className="rounded-2xl border border-border p-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-xs font-semibold text-foreground">{process.label}</p>
+                        <span className="text-[11px] text-muted">
+                          {process.job?.status || "function-only"}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-[11px] text-muted">{process.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </aside>
+
+          <main className="min-h-0 min-w-0 flex-[1.6] overflow-y-auto">
+            <div className="space-y-6 pb-4 pr-2">
+              <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold text-foreground">Automation Config</h2>
+                    <p className="mt-1 text-xs text-muted">后端托管配置，保存后自动 reconcile 预定义函数与任务。</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                      onClick={() => load().catch((err) => setError(String(err)))}
+                    >
+                      刷新
+                    </button>
+                    <button
+                      className="rounded-lg bg-foreground px-4 py-2 text-xs font-semibold text-background disabled:opacity-50"
+                      disabled={!form || isPending}
+                      onClick={handleSave}
+                    >
+                      {isPending ? "保存中..." : "保存并同步"}
+                    </button>
+                  </div>
+                </div>
+
+                {error ? (
+                  <div className="mt-4 rounded-2xl border border-rose-300 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
+                    {error}
+                  </div>
+                ) : null}
+                {statusText ? (
+                  <div className="mt-4 rounded-2xl border border-emerald-300 bg-emerald-50 p-4 text-xs text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300">
+                    {statusText}
+                  </div>
+                ) : null}
+
+                {form ? (
+                  <div className="mt-6 grid gap-5 md:grid-cols-2">
+                    <section className="rounded-2xl border border-border p-4">
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted">Retention</h3>
+                      <div className="mt-4 grid gap-3">
+                        <label className="text-xs text-muted">
+                          decay_lambda
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            type="number"
+                            step="0.01"
+                            value={form.retention.decay_lambda}
+                            onChange={(e) => updateField("retention", "decay_lambda", Number(e.target.value))}
+                          />
+                        </label>
+                        <label className="text-xs text-muted">
+                          low_retention_threshold
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            type="number"
+                            step="0.01"
+                            value={form.retention.low_retention_threshold}
+                            onChange={(e) =>
+                              updateField("retention", "low_retention_threshold", Number(e.target.value))
+                            }
+                          />
+                        </label>
+                        <label className="text-xs text-muted">
+                          min_age_days
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            type="number"
+                            step="1"
+                            value={form.retention.min_age_days}
+                            onChange={(e) => updateField("retention", "min_age_days", Number(e.target.value))}
+                          />
+                        </label>
+                        <label className="text-xs text-muted">
+                          cleanup_schedule
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            value={form.retention.cleanup_schedule}
+                            onChange={(e) => updateField("retention", "cleanup_schedule", e.target.value)}
+                          />
+                        </label>
+                        <label className="flex items-center gap-2 text-xs text-muted">
+                          <input
+                            type="checkbox"
+                            checked={form.retention.auto_cleanup_enabled}
+                            onChange={(e) =>
+                              updateField("retention", "auto_cleanup_enabled", e.target.checked)
+                            }
+                          />
+                          启用 cleanup cron
+                        </label>
+                      </div>
+                    </section>
+
+                    <section className="rounded-2xl border border-border p-4">
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted">Consolidation</h3>
+                      <div className="mt-4 grid gap-3">
+                        <label className="text-xs text-muted">
+                          schedule
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            value={form.consolidation.schedule}
+                            onChange={(e) => updateField("consolidation", "schedule", e.target.value)}
+                          />
+                        </label>
+                        <label className="text-xs text-muted">
+                          lookback_interval
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            value={form.consolidation.lookback_interval}
+                            onChange={(e) => updateField("consolidation", "lookback_interval", e.target.value)}
+                          />
+                        </label>
+                        <label className="flex items-center gap-2 text-xs text-muted">
+                          <input
+                            type="checkbox"
+                            checked={form.consolidation.enabled}
+                            onChange={(e) => updateField("consolidation", "enabled", e.target.checked)}
+                          />
+                          启用 consolidation cron
+                        </label>
+                      </div>
+                    </section>
+
+                    <section className="rounded-2xl border border-border p-4 md:col-span-2">
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted">Context Assembler</h3>
+                      <div className="mt-4 grid gap-3 md:grid-cols-3">
+                        <label className="text-xs text-muted">
+                          max_tokens
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            type="number"
+                            step="1"
+                            value={form.context_assembler.max_tokens}
+                            onChange={(e) =>
+                              updateField("context_assembler", "max_tokens", Number(e.target.value))
+                            }
+                          />
+                        </label>
+                        <label className="text-xs text-muted">
+                          memory_ratio
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            type="number"
+                            step="0.05"
+                            value={form.context_assembler.memory_ratio}
+                            onChange={(e) =>
+                              updateField("context_assembler", "memory_ratio", Number(e.target.value))
+                            }
+                          />
+                        </label>
+                        <label className="text-xs text-muted">
+                          history_ratio
+                          <input
+                            className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-foreground"
+                            type="number"
+                            step="0.05"
+                            value={form.context_assembler.history_ratio}
+                            onChange={(e) =>
+                              updateField("context_assembler", "history_ratio", Number(e.target.value))
+                            }
+                          />
+                        </label>
+                      </div>
+                    </section>
+                  </div>
+                ) : (
+                  <p className="mt-6 text-xs text-muted">Loading automation config...</p>
+                )}
+              </div>
+
+              <div className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="text-sm font-semibold text-foreground">Managed Jobs</h2>
+                <div className="mt-4 space-y-3">
+                  {snapshot?.jobs.map((job) => (
+                    <div key={job.job_key} className="rounded-2xl border border-border p-4">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="text-xs font-semibold text-foreground">{job.process_label}</p>
+                          <p className="mt-1 text-[11px] text-muted">{job.schedule}</p>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="rounded-full border border-border px-2 py-1 text-[11px] text-muted">
+                            {job.status}
+                          </span>
+                          <button
+                            className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                            onClick={() => handleJobAction(job.job_key, job.enabled ? "disable" : "enable")}
+                            disabled={isPending || !snapshot.capabilities.pg_cron_installed}
+                          >
+                            {job.enabled ? "停用" : "启用"}
+                          </button>
+                          <button
+                            className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                            onClick={() => handleJobAction(job.job_key, "reconcile")}
+                            disabled={isPending}
+                          >
+                            重建
+                          </button>
+                          <button
+                            className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                            onClick={() => handleRun(job.job_key)}
+                            disabled={isPending}
+                          >
+                            手动触发
+                          </button>
+                        </div>
+                      </div>
+                      <pre className="mt-3 overflow-x-auto rounded-xl bg-muted/40 p-3 text-[11px] text-muted">
+                        {job.command}
+                      </pre>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </main>
+
+          <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+            <div className="space-y-4 pb-4 pr-2">
+              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+                <h2 className="text-sm font-semibold text-foreground">Functions</h2>
+                <div className="mt-4 space-y-3">
+                  {snapshot?.functions.map((fn) => (
+                    <details key={fn.name} className="rounded-2xl border border-border p-3">
+                      <summary className="cursor-pointer text-xs font-semibold text-foreground">
+                        {fn.name} · {fn.status}
+                      </summary>
+                      <pre className="mt-3 max-h-64 overflow-auto rounded-xl bg-muted/40 p-3 text-[11px] text-muted">
+                        {fn.definition}
+                      </pre>
+                    </details>
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-3xl border border-border bg-card p-5 shadow-sm">
+                <h2 className="text-sm font-semibold text-foreground">Recent Logs</h2>
+                <div className="mt-4 space-y-3">
+                  {logs.length ? (
+                    logs.map((item) => (
+                      <div key={`${item.run_id}-${item.job_id}`} className="rounded-2xl border border-border p-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-[11px] font-semibold text-foreground">
+                            job #{item.job_id ?? "-"} / run #{item.run_id ?? "-"}
+                          </span>
+                          <span className="text-[11px] text-muted">{item.status || "-"}</span>
+                        </div>
+                        <p className="mt-2 text-[11px] text-muted">{item.start_time || "-"}</p>
+                        <p className="mt-2 break-all text-[11px] text-muted">{item.return_message || item.command}</p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-xs text-muted">暂无执行日志。</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/MemoryNav.tsx
+++ b/apps/negentropy-ui/components/ui/MemoryNav.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: "/memory/timeline", label: "Timeline" },
   { href: "/memory/facts", label: "Facts" },
   { href: "/memory/audit", label: "Audit" },
+  { href: "/memory/automation", label: "Automation" },
 ];
 
 export function MemoryNav({

--- a/apps/negentropy-ui/features/memory/index.ts
+++ b/apps/negentropy-ui/features/memory/index.ts
@@ -50,6 +50,11 @@ export {
   searchFacts,
   submitAudit,
   fetchAuditHistory,
+  fetchMemoryAutomation,
+  fetchMemoryAutomationLogs,
+  updateMemoryAutomationConfig,
+  triggerMemoryAutomationJobAction,
+  runMemoryAutomationJob,
 } from "./utils/memory-api";
 
 // ============================================================================
@@ -66,4 +71,11 @@ export type {
   AuditRecord,
   AuditResponse,
   AuditHistoryPayload,
+  MemoryAutomationFunction,
+  MemoryAutomationJob,
+  MemoryAutomationProcess,
+  MemoryAutomationSnapshot,
+  MemoryAutomationLog,
+  MemoryAutomationLogsPayload,
+  MemoryAutomationRunResponse,
 } from "./utils/memory-api";

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -84,6 +84,94 @@ export interface AuditHistoryPayload {
   items: AuditRecord[];
 }
 
+export interface MemoryAutomationFunction {
+  name: string;
+  schema: string;
+  status: string;
+  definition: string;
+  managed: boolean;
+}
+
+export interface MemoryAutomationJob {
+  job_key: string;
+  process_label: string;
+  function_name: string;
+  enabled: boolean;
+  status: string;
+  job_id?: number | null;
+  schedule: string;
+  command: string;
+  active: boolean;
+}
+
+export interface MemoryAutomationProcess {
+  key: string;
+  label: string;
+  description: string;
+  config: Record<string, unknown>;
+  job?: MemoryAutomationJob | null;
+  functions: MemoryAutomationFunction[];
+}
+
+export interface MemoryAutomationSnapshot {
+  capabilities: {
+    pg_cron_installed: boolean;
+    pg_cron_available: boolean;
+    management_mode: string;
+    degraded_reasons: string[];
+  };
+  config: {
+    retention: {
+      decay_lambda: number;
+      low_retention_threshold: number;
+      min_age_days: number;
+      auto_cleanup_enabled: boolean;
+      cleanup_schedule: string;
+    };
+    consolidation: {
+      enabled: boolean;
+      schedule: string;
+      lookback_interval: string;
+    };
+    context_assembler: {
+      max_tokens: number;
+      memory_ratio: number;
+      history_ratio: number;
+    };
+  };
+  processes: MemoryAutomationProcess[];
+  functions: MemoryAutomationFunction[];
+  jobs: MemoryAutomationJob[];
+  health: {
+    status: string;
+    recent_log_count: number;
+  };
+}
+
+export interface MemoryAutomationLog {
+  job_id?: number | null;
+  run_id?: number | null;
+  database?: string | null;
+  username?: string | null;
+  command?: string | null;
+  status?: string | null;
+  return_message?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+}
+
+export interface MemoryAutomationLogsPayload {
+  count: number;
+  items: MemoryAutomationLog[];
+}
+
+export interface MemoryAutomationRunResponse {
+  job_key: string;
+  process_label: string;
+  result?: number | null;
+  snapshot: MemoryAutomationSnapshot;
+}
+
 // ============================================================================
 // Dashboard
 // ============================================================================
@@ -226,6 +314,97 @@ export async function fetchAuditHistory(
   });
   if (!res.ok) {
     throw new Error(`Failed to fetch audit history: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// ============================================================================
+// Automation
+// ============================================================================
+
+export async function fetchMemoryAutomation(
+  appName?: string,
+): Promise<MemoryAutomationSnapshot> {
+  const params = new URLSearchParams();
+  if (appName) params.set("app_name", appName);
+  const qs = params.toString() ? `?${params.toString()}` : "";
+
+  const res = await fetch(`/api/memory/automation${qs}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch memory automation: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function fetchMemoryAutomationLogs(
+  appName?: string,
+  limit?: number,
+): Promise<MemoryAutomationLogsPayload> {
+  const params = new URLSearchParams();
+  if (appName) params.set("app_name", appName);
+  if (limit) params.set("limit", String(limit));
+
+  const res = await fetch(`/api/memory/automation/logs?${params.toString()}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch memory automation logs: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function updateMemoryAutomationConfig(params: {
+  app_name?: string;
+  config: MemoryAutomationSnapshot["config"];
+}): Promise<MemoryAutomationSnapshot> {
+  const res = await fetch("/api/memory/automation/config", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to update memory automation config: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function triggerMemoryAutomationJobAction(
+  jobKey: string,
+  action: "enable" | "disable" | "reconcile",
+  appName?: string,
+): Promise<MemoryAutomationSnapshot> {
+  const params = new URLSearchParams();
+  if (appName) params.set("app_name", appName);
+  const qs = params.toString() ? `?${params.toString()}` : "";
+
+  const res = await fetch(`/api/memory/automation/jobs/${jobKey}/${action}${qs}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to ${action} memory automation job: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function runMemoryAutomationJob(
+  jobKey: string,
+  appName?: string,
+): Promise<MemoryAutomationRunResponse> {
+  const params = new URLSearchParams();
+  if (appName) params.set("app_name", appName);
+  const qs = params.toString() ? `?${params.toString()}` : "";
+
+  const res = await fetch(`/api/memory/automation/jobs/${jobKey}/run${qs}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to run memory automation job: ${res.statusText}`);
   }
   return res.json();
 }

--- a/apps/negentropy-ui/tests/unit/features/memory-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/memory-api.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import {
+  runMemoryAutomationJob,
+  triggerMemoryAutomationJobAction,
+} from "@/features/memory";
+
+describe("memory automation api", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("任务动作请求会发送空 JSON body 以兼容代理层", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ jobs: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await triggerMemoryAutomationJobAction("cleanup_memories", "reconcile", "negentropy");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/memory/automation/jobs/cleanup_memories/reconcile?app_name=negentropy",
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+      }),
+    );
+  });
+
+  it("手动触发任务请求会发送空 JSON body", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ job_key: "cleanup_memories", snapshot: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await runMemoryAutomationJob("cleanup_memories", "negentropy");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/memory/automation/jobs/cleanup_memories/run?app_name=negentropy",
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+      }),
+    );
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/MemoryNav.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MemoryNav.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryNav } from "@/components/ui/MemoryNav";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/memory/automation",
+}));
+
+vi.mock("@/components/providers/NavigationProvider", () => ({
+  useNavigation: () => ({
+    setNavigationInfo: vi.fn(),
+  }),
+}));
+
+describe("MemoryNav", () => {
+  it("显示 Automation 二级导航项并能高亮当前页面", () => {
+    render(<MemoryNav title="Automation" />);
+
+    const automationLink = screen.getByRole("link", { name: "Automation" });
+    expect(automationLink).toBeInTheDocument();
+    expect(automationLink.className).toContain("bg-foreground");
+  });
+});

--- a/apps/negentropy/src/negentropy/db/migrations/versions/9c7f8e6d5b4a_add_memory_automation_configs.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/9c7f8e6d5b4a_add_memory_automation_configs.py
@@ -1,0 +1,43 @@
+"""add memory automation configs
+
+Revision ID: 9c7f8e6d5b4a
+Revises: bd9c65e1bf99
+Create Date: 2026-03-08 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9c7f8e6d5b4a"
+down_revision: Union[str, Sequence[str], None] = "bd9c65e1bf99"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_automation_configs",
+        sa.Column("app_name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("updated_by", sa.String(length=255), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("app_name"),
+        schema="negentropy",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("memory_automation_configs", schema="negentropy")

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_automation_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_automation_service.py
@@ -1,0 +1,584 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlalchemy import select, text
+
+from negentropy.db.session import AsyncSessionLocal
+from negentropy.logging import get_logger
+from negentropy.models.base import NEGENTROPY_SCHEMA
+from negentropy.models.internalization import MemoryAutomationConfig
+
+logger = get_logger("negentropy.engine.adapters.postgres.memory_automation_service")
+
+JobKey = Literal["cleanup_memories", "trigger_consolidation"]
+
+
+DEFAULT_AUTOMATION_CONFIG: dict[str, Any] = {
+    "retention": {
+        "decay_lambda": 0.1,
+        "low_retention_threshold": 0.1,
+        "min_age_days": 7,
+        "auto_cleanup_enabled": False,
+        "cleanup_schedule": "0 2 * * *",
+    },
+    "consolidation": {
+        "enabled": False,
+        "schedule": "0 * * * *",
+        "lookback_interval": "1 hour",
+    },
+    "context_assembler": {
+        "max_tokens": 4000,
+        "memory_ratio": 0.3,
+        "history_ratio": 0.5,
+    },
+}
+
+FUNCTION_DEFINITIONS: dict[str, str] = {
+    "calculate_retention_score": f"""
+CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.calculate_retention_score(
+    p_access_count INTEGER,
+    p_last_accessed_at TIMESTAMP WITH TIME ZONE,
+    p_decay_rate FLOAT DEFAULT 0.1
+)
+RETURNS FLOAT AS $$
+DECLARE
+    days_elapsed FLOAT;
+    time_decay FLOAT;
+    frequency_boost FLOAT;
+BEGIN
+    days_elapsed := EXTRACT(EPOCH FROM (NOW() - p_last_accessed_at)) / 86400.0;
+    time_decay := EXP(-p_decay_rate * days_elapsed);
+    frequency_boost := 1.0 + LN(1.0 + p_access_count);
+    RETURN LEAST(1.0, time_decay * frequency_boost / 5.0);
+END;
+$$ LANGUAGE plpgsql;
+""".strip(),
+    "cleanup_low_value_memories": f"""
+CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.cleanup_low_value_memories(
+    p_threshold FLOAT DEFAULT 0.1,
+    p_min_age_days INTEGER DEFAULT 7,
+    p_decay_rate FLOAT DEFAULT 0.1
+)
+RETURNS INTEGER AS $$
+DECLARE
+    deleted_count INTEGER;
+BEGIN
+    UPDATE {NEGENTROPY_SCHEMA}.memories
+    SET retention_score = {NEGENTROPY_SCHEMA}.calculate_retention_score(
+        access_count,
+        COALESCE(last_accessed_at, created_at),
+        p_decay_rate
+    );
+
+    DELETE FROM {NEGENTROPY_SCHEMA}.memories
+    WHERE retention_score < p_threshold
+      AND created_at < NOW() - make_interval(days => p_min_age_days);
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+""".strip(),
+    "get_context_window": f"""
+CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.get_context_window(
+    p_user_id VARCHAR(255),
+    p_app_name VARCHAR(255),
+    p_query TEXT,
+    p_query_embedding vector(1536),
+    p_max_tokens INTEGER DEFAULT 4000,
+    p_memory_ratio FLOAT DEFAULT 0.3,
+    p_history_ratio FLOAT DEFAULT 0.5
+)
+RETURNS TABLE (
+    context_type VARCHAR(50),
+    content TEXT,
+    relevance_score FLOAT,
+    token_estimate INTEGER
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        'memory'::VARCHAR(50),
+        m.content,
+        (1 - (m.embedding <=> p_query_embedding)) * m.retention_score AS relevance_score,
+        (LENGTH(m.content) / 4)::INTEGER AS token_estimate
+    FROM {NEGENTROPY_SCHEMA}.memories m
+    WHERE m.user_id = p_user_id
+      AND m.app_name = p_app_name
+    ORDER BY relevance_score DESC
+    LIMIT GREATEST(1, (p_max_tokens * p_memory_ratio / 256)::INTEGER);
+
+    RETURN QUERY
+    SELECT
+        'history'::VARCHAR(50),
+        e.content::TEXT,
+        1.0::FLOAT,
+        (LENGTH(e.content::TEXT) / 4)::INTEGER
+    FROM {NEGENTROPY_SCHEMA}.events e
+    JOIN {NEGENTROPY_SCHEMA}.threads t ON e.thread_id = t.id
+    WHERE t.user_id = p_user_id
+      AND t.app_name = p_app_name
+    ORDER BY e.created_at DESC
+    LIMIT GREATEST(1, (p_max_tokens * p_history_ratio / 256)::INTEGER);
+END;
+$$ LANGUAGE plpgsql;
+""".strip(),
+    "trigger_maintenance_consolidation": f"""
+CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(
+    p_interval INTERVAL DEFAULT '1 hour'
+)
+RETURNS INTEGER AS $$
+DECLARE
+    job_count INTEGER;
+BEGIN
+    WITH new_jobs AS (
+        INSERT INTO {NEGENTROPY_SCHEMA}.consolidation_jobs (thread_id, job_type, status)
+        SELECT t.id, 'full_consolidation', 'pending'
+        FROM {NEGENTROPY_SCHEMA}.threads t
+        WHERE t.updated_at > NOW() - p_interval
+          AND NOT EXISTS (
+              SELECT 1
+              FROM {NEGENTROPY_SCHEMA}.consolidation_jobs cj
+              WHERE cj.thread_id = t.id
+                AND cj.created_at > NOW() - p_interval
+          )
+        RETURNING 1
+    )
+    SELECT COUNT(*) INTO job_count FROM new_jobs;
+
+    RETURN job_count;
+END;
+$$ LANGUAGE plpgsql;
+""".strip(),
+}
+
+
+@dataclass(frozen=True)
+class JobTemplate:
+    key: JobKey
+    process_label: str
+    function_name: str
+
+
+JOB_TEMPLATES: dict[JobKey, JobTemplate] = {
+    "cleanup_memories": JobTemplate(
+        key="cleanup_memories",
+        process_label="Ebbinghaus Cleanup",
+        function_name="cleanup_low_value_memories",
+    ),
+    "trigger_consolidation": JobTemplate(
+        key="trigger_consolidation",
+        process_label="Maintenance Consolidation",
+        function_name="trigger_maintenance_consolidation",
+    ),
+}
+
+
+class MemoryAutomationService:
+    async def get_snapshot(self, *, app_name: str) -> dict[str, Any]:
+        config = await self.get_effective_config(app_name=app_name)
+        capabilities = await self._get_capabilities()
+        functions = await self._get_function_states()
+        jobs = await self._get_job_states(config=config, capabilities=capabilities)
+        logs = await self.get_logs(limit=10)
+
+        degraded_reasons: list[str] = []
+        if not capabilities["pg_cron_installed"]:
+            degraded_reasons.append("pg_cron_not_installed")
+        if any(item["status"] == "missing" for item in functions):
+            degraded_reasons.append("function_missing")
+
+        return {
+            "capabilities": {
+                **capabilities,
+                "management_mode": "backend-managed",
+                "degraded_reasons": degraded_reasons,
+            },
+            "config": config,
+            "functions": functions,
+            "jobs": jobs,
+            "health": {
+                "status": "degraded" if degraded_reasons else "healthy",
+                "recent_log_count": len(logs),
+            },
+            "processes": self._build_processes(config=config, jobs=jobs, functions=functions),
+        }
+
+    async def get_logs(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        if not await self._is_pg_cron_installed():
+            return []
+
+        sql = text(
+            """
+            SELECT jobid, runid, database, username, command, status, return_message, start_time, end_time
+            FROM cron.job_run_details
+            ORDER BY start_time DESC
+            LIMIT :limit
+            """
+        )
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(sql, {"limit": limit})
+            rows = result.mappings().all()
+
+        return [
+            {
+                "job_id": row["jobid"],
+                "run_id": row["runid"],
+                "database": row["database"],
+                "username": row["username"],
+                "command": row["command"],
+                "status": row["status"],
+                "return_message": row["return_message"],
+                "start_time": row["start_time"].isoformat() if row["start_time"] else None,
+                "end_time": row["end_time"].isoformat() if row["end_time"] else None,
+            }
+            for row in rows
+        ]
+
+    async def get_effective_config(self, *, app_name: str) -> dict[str, Any]:
+        stored = await self._load_stored_config(app_name=app_name)
+        return self._merge_config(DEFAULT_AUTOMATION_CONFIG, stored)
+
+    async def update_config(self, *, app_name: str, config: dict[str, Any], updated_by: str) -> dict[str, Any]:
+        merged = self._merge_config(DEFAULT_AUTOMATION_CONFIG, config)
+        self._validate_config(merged)
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                select(MemoryAutomationConfig).where(MemoryAutomationConfig.app_name == app_name)
+            )
+            entity = result.scalar_one_or_none()
+            if entity is None:
+                entity = MemoryAutomationConfig(app_name=app_name, config=merged, updated_by=updated_by)
+                db.add(entity)
+            else:
+                entity.config = merged
+                entity.updated_by = updated_by
+            await db.commit()
+
+        await self.reconcile_all(app_name=app_name)
+        return merged
+
+    async def enable_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
+        config = await self.get_effective_config(app_name=app_name)
+        self._set_job_enabled(config, job_key, True)
+        await self.update_config(app_name=app_name, config=config, updated_by="system:job-enable")
+        return await self.get_snapshot(app_name=app_name)
+
+    async def disable_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
+        config = await self.get_effective_config(app_name=app_name)
+        self._set_job_enabled(config, job_key, False)
+        await self.update_config(app_name=app_name, config=config, updated_by="system:job-disable")
+        return await self.get_snapshot(app_name=app_name)
+
+    async def reconcile_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
+        await self._reconcile_functions()
+        if await self._is_pg_cron_installed():
+            config = await self.get_effective_config(app_name=app_name)
+            await self._reconcile_single_job(job_key=job_key, config=config)
+        return await self.get_snapshot(app_name=app_name)
+
+    async def reconcile_all(self, *, app_name: str) -> None:
+        await self._reconcile_functions()
+        if not await self._is_pg_cron_installed():
+            return
+        config = await self.get_effective_config(app_name=app_name)
+        for job_key in JOB_TEMPLATES:
+            await self._reconcile_single_job(job_key=job_key, config=config)
+
+    async def run_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
+        config = await self.get_effective_config(app_name=app_name)
+        await self._reconcile_functions()
+        template = self._get_job_template(job_key)
+        sql = self._build_manual_run_sql(job_key=job_key, config=config)
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(text(sql))
+            row = result.first()
+            await db.commit()
+        return {
+            "job_key": job_key,
+            "process_label": template.process_label,
+            "result": row[0] if row else None,
+            "snapshot": await self.get_snapshot(app_name=app_name),
+        }
+
+    async def list_policy_summary(self, *, app_name: str) -> dict[str, Any]:
+        config = await self.get_effective_config(app_name=app_name)
+        capabilities = await self._get_capabilities()
+        jobs = await self._get_job_states(config=config, capabilities=capabilities)
+        return {
+            "decay_lambda": config["retention"]["decay_lambda"],
+            "low_retention_threshold": config["retention"]["low_retention_threshold"],
+            "auto_cleanup_enabled": config["retention"]["auto_cleanup_enabled"],
+            "cleanup_cron": config["retention"]["cleanup_schedule"],
+            "consolidation_enabled": config["consolidation"]["enabled"],
+            "consolidation_cron": config["consolidation"]["schedule"],
+            "pg_cron_installed": capabilities["pg_cron_installed"],
+            "managed_jobs": {job["job_key"]: job["status"] for job in jobs},
+        }
+
+    async def _load_stored_config(self, *, app_name: str) -> dict[str, Any]:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                select(MemoryAutomationConfig).where(MemoryAutomationConfig.app_name == app_name)
+            )
+            entity = result.scalar_one_or_none()
+        return entity.config if entity and entity.config else {}
+
+    async def _reconcile_functions(self) -> None:
+        async with AsyncSessionLocal() as db:
+            for sql in FUNCTION_DEFINITIONS.values():
+                await db.execute(text(sql))
+            await db.commit()
+
+    async def _reconcile_single_job(self, *, job_key: JobKey, config: dict[str, Any]) -> None:
+        template = self._get_job_template(job_key)
+        enabled, schedule, command = self._build_job_runtime(job_key=job_key, config=config)
+        async with AsyncSessionLocal() as db:
+            if not enabled:
+                await db.execute(
+                    text("SELECT cron.unschedule(jobid) FROM cron.job WHERE jobname = :job_name"),
+                    {"job_name": template.key},
+                )
+                await db.commit()
+                return
+
+            existing = await db.execute(
+                text(
+                    """
+                    SELECT jobid, schedule, command
+                    FROM cron.job
+                    WHERE jobname = :job_name
+                    LIMIT 1
+                    """
+                ),
+                {"job_name": template.key},
+            )
+            row = existing.mappings().first()
+            if row is None:
+                await db.execute(
+                    text("SELECT cron.schedule(:job_name, :schedule, :command)"),
+                    {"job_name": template.key, "schedule": schedule, "command": command},
+                )
+            elif row["schedule"] != schedule or row["command"] != command:
+                await db.execute(
+                    text("SELECT cron.unschedule(:job_id)"),
+                    {"job_id": row["jobid"]},
+                )
+                await db.execute(
+                    text("SELECT cron.schedule(:job_name, :schedule, :command)"),
+                    {"job_name": template.key, "schedule": schedule, "command": command},
+                )
+            await db.commit()
+
+    async def _get_capabilities(self) -> dict[str, Any]:
+        installed = await self._is_pg_cron_installed()
+        return {
+            "pg_cron_installed": installed,
+            "pg_cron_available": installed,
+        }
+
+    async def _get_function_states(self) -> list[dict[str, Any]]:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                text(
+                    """
+                    SELECT p.proname AS name, pg_get_functiondef(p.oid) AS definition
+                    FROM pg_proc p
+                    JOIN pg_namespace n ON p.pronamespace = n.oid
+                    WHERE n.nspname = :schema
+                    """
+                ),
+                {"schema": NEGENTROPY_SCHEMA},
+            )
+            rows = {
+                row["name"]: row["definition"]
+                for row in result.mappings().all()
+                if row["name"] in FUNCTION_DEFINITIONS
+            }
+
+        states = []
+        for name, expected in FUNCTION_DEFINITIONS.items():
+            definition = rows.get(name)
+            normalized_expected = self._normalize_sql(expected)
+            normalized_actual = self._normalize_sql(definition or "")
+            status = "present"
+            if definition is None:
+                status = "missing"
+            elif normalized_expected != normalized_actual:
+                status = "drifted"
+            states.append(
+                {
+                    "name": name,
+                    "schema": NEGENTROPY_SCHEMA,
+                    "status": status,
+                    "definition": definition or expected,
+                    "managed": True,
+                }
+            )
+        return states
+
+    async def _get_job_states(self, *, config: dict[str, Any], capabilities: dict[str, Any]) -> list[dict[str, Any]]:
+        cron_rows: dict[str, dict[str, Any]] = {}
+        if capabilities["pg_cron_installed"]:
+            async with AsyncSessionLocal() as db:
+                result = await db.execute(
+                    text(
+                        """
+                        SELECT jobid, jobname, schedule, command, active
+                        FROM cron.job
+                        """
+                    ),
+                )
+                cron_rows = {
+                    row["jobname"]: dict(row)
+                    for row in result.mappings().all()
+                    if row["jobname"] in JOB_TEMPLATES
+                }
+
+        jobs = []
+        for job_key, template in JOB_TEMPLATES.items():
+            enabled, schedule, command = self._build_job_runtime(job_key=job_key, config=config)
+            row = cron_rows.get(job_key)
+            status = "disabled"
+            if row:
+                status = "scheduled"
+                if row["schedule"] != schedule or row["command"] != command:
+                    status = "drifted"
+            elif enabled and not capabilities["pg_cron_installed"]:
+                status = "degraded"
+            elif enabled:
+                status = "missing"
+
+            jobs.append(
+                {
+                    "job_key": job_key,
+                    "process_label": template.process_label,
+                    "function_name": template.function_name,
+                    "enabled": enabled,
+                    "status": status,
+                    "job_id": row["jobid"] if row else None,
+                    "schedule": schedule,
+                    "command": command,
+                    "active": bool(row["active"]) if row and "active" in row else False,
+                }
+            )
+        return jobs
+
+    async def _is_pg_cron_installed(self) -> bool:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                text("SELECT 1 FROM pg_extension WHERE extname = 'pg_cron' LIMIT 1")
+            )
+            return result.scalar() == 1
+
+    def _build_processes(
+        self,
+        *,
+        config: dict[str, Any],
+        jobs: list[dict[str, Any]],
+        functions: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        function_map = {item["name"]: item for item in functions}
+        job_map = {item["job_key"]: item for item in jobs}
+        return [
+            {
+                "key": "retention_cleanup",
+                "label": "Retention Cleanup",
+                "description": "基于艾宾浩斯遗忘曲线清理低价值记忆。",
+                "config": config["retention"],
+                "job": job_map["cleanup_memories"],
+                "functions": [
+                    function_map["calculate_retention_score"],
+                    function_map["cleanup_low_value_memories"],
+                ],
+            },
+            {
+                "key": "context_assembler",
+                "label": "Context Assembler",
+                "description": "按 token 预算组装长期记忆与对话历史。",
+                "config": config["context_assembler"],
+                "job": None,
+                "functions": [function_map["get_context_window"]],
+            },
+            {
+                "key": "maintenance_consolidation",
+                "label": "Maintenance Consolidation",
+                "description": "按时间窗口批量触发会话巩固任务。",
+                "config": config["consolidation"],
+                "job": job_map["trigger_consolidation"],
+                "functions": [function_map["trigger_maintenance_consolidation"]],
+            },
+        ]
+
+    def _merge_config(self, base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+        merged = deepcopy(base)
+        for key, value in patch.items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = self._merge_config(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
+
+    def _validate_config(self, config: dict[str, Any]) -> None:
+        retention = config["retention"]
+        context = config["context_assembler"]
+        if retention["decay_lambda"] <= 0:
+            raise ValueError("retention.decay_lambda must be > 0")
+        if not 0 < retention["low_retention_threshold"] < 1:
+            raise ValueError("retention.low_retention_threshold must be between 0 and 1")
+        if retention["min_age_days"] < 1:
+            raise ValueError("retention.min_age_days must be >= 1")
+        if context["max_tokens"] < 256:
+            raise ValueError("context_assembler.max_tokens must be >= 256")
+        if context["memory_ratio"] <= 0 or context["history_ratio"] <= 0:
+            raise ValueError("context_assembler ratios must be > 0")
+        if context["memory_ratio"] + context["history_ratio"] > 1:
+            raise ValueError("context_assembler ratios must sum to <= 1")
+
+    def _set_job_enabled(self, config: dict[str, Any], job_key: JobKey, enabled: bool) -> None:
+        if job_key == "cleanup_memories":
+            config["retention"]["auto_cleanup_enabled"] = enabled
+            return
+        if job_key == "trigger_consolidation":
+            config["consolidation"]["enabled"] = enabled
+            return
+        raise ValueError(f"Unsupported job key: {job_key}")
+
+    def _build_job_runtime(self, *, job_key: JobKey, config: dict[str, Any]) -> tuple[bool, str, str]:
+        if job_key == "cleanup_memories":
+            retention = config["retention"]
+            return (
+                bool(retention["auto_cleanup_enabled"]),
+                retention["cleanup_schedule"],
+                "SELECT "
+                f"{NEGENTROPY_SCHEMA}.cleanup_low_value_memories("
+                f"{retention['low_retention_threshold']}, "
+                f"{retention['min_age_days']}, "
+                f"{retention['decay_lambda']}"
+                ")",
+            )
+        consolidation = config["consolidation"]
+        interval = str(consolidation["lookback_interval"]).replace("'", "''")
+        return (
+            bool(consolidation["enabled"]),
+            consolidation["schedule"],
+            "SELECT "
+            f"{NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation('{interval}'::interval)",
+        )
+
+    def _build_manual_run_sql(self, *, job_key: JobKey, config: dict[str, Any]) -> str:
+        _, _, command = self._build_job_runtime(job_key=job_key, config=config)
+        return command
+
+    def _normalize_sql(self, sql: str) -> str:
+        return " ".join(sql.split()).strip().lower()
+
+    def _get_job_template(self, job_key: JobKey) -> JobTemplate:
+        template = JOB_TEMPLATES.get(job_key)
+        if template is None:
+            raise ValueError(f"Unsupported job key: {job_key}")
+        return template

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 
+from negentropy.auth.deps import get_current_user
+from negentropy.auth.service import AuthUser
 from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
@@ -41,6 +43,7 @@ from negentropy.models.internalization import Fact, Memory, MemoryAuditLog
 
 from .factories.memory import (
     get_fact_service,
+    get_memory_automation_service,
     get_memory_governance_service,
     get_memory_service,
 )
@@ -140,6 +143,85 @@ class MemoryDashboardResponse(BaseModel):
     recent_audit_count: int
 
 
+class MemoryAutomationFunctionResponse(BaseModel):
+    name: str
+    schema: str
+    status: str
+    definition: str
+    managed: bool = True
+
+
+class MemoryAutomationJobResponse(BaseModel):
+    job_key: str
+    process_label: str
+    function_name: str
+    enabled: bool
+    status: str
+    job_id: Optional[int] = None
+    schedule: str
+    command: str
+    active: bool = False
+
+
+class MemoryAutomationProcessResponse(BaseModel):
+    key: str
+    label: str
+    description: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+    job: Optional[MemoryAutomationJobResponse] = None
+    functions: List[MemoryAutomationFunctionResponse] = Field(default_factory=list)
+
+
+class MemoryAutomationCapabilitiesResponse(BaseModel):
+    pg_cron_installed: bool
+    pg_cron_available: bool
+    management_mode: str
+    degraded_reasons: List[str] = Field(default_factory=list)
+
+
+class MemoryAutomationHealthResponse(BaseModel):
+    status: str
+    recent_log_count: int
+
+
+class MemoryAutomationSnapshotResponse(BaseModel):
+    capabilities: MemoryAutomationCapabilitiesResponse
+    config: Dict[str, Any]
+    processes: List[MemoryAutomationProcessResponse]
+    functions: List[MemoryAutomationFunctionResponse]
+    jobs: List[MemoryAutomationJobResponse]
+    health: MemoryAutomationHealthResponse
+
+
+class MemoryAutomationLogItemResponse(BaseModel):
+    job_id: Optional[int] = None
+    run_id: Optional[int] = None
+    database: Optional[str] = None
+    username: Optional[str] = None
+    command: Optional[str] = None
+    status: Optional[str] = None
+    return_message: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+
+
+class MemoryAutomationLogsResponse(BaseModel):
+    count: int
+    items: List[MemoryAutomationLogItemResponse] = Field(default_factory=list)
+
+
+class MemoryAutomationConfigUpdateRequest(BaseModel):
+    app_name: Optional[str] = None
+    config: Dict[str, Any]
+
+
+class MemoryAutomationRunResponse(BaseModel):
+    job_key: str
+    process_label: str
+    result: Optional[int] = None
+    snapshot: MemoryAutomationSnapshotResponse
+
+
 # ============================================================================
 # Helpers
 # ============================================================================
@@ -151,6 +233,12 @@ def _resolve_app_name(app_name: Optional[str]) -> str:
 
 def _iso(dt: Optional[datetime]) -> Optional[str]:
     return dt.isoformat() if dt else None
+
+
+def _require_admin(user: AuthUser) -> AuthUser:
+    if "admin" not in user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+    return user
 
 
 # ============================================================================
@@ -242,6 +330,7 @@ async def list_memories(
     返回用户列表、记忆时间线和当前治理策略。
     """
     resolved_app = _resolve_app_name(app_name)
+    automation = get_memory_automation_service()
 
     async with AsyncSessionLocal() as db:
         # 获取用户列表
@@ -282,13 +371,7 @@ async def list_memories(
         for m in memories
     ]
 
-    # 治理策略（可配置化，当前返回默认值）
-    policies = {
-        "decay_lambda": 0.1,
-        "low_retention_threshold": 0.1,
-        "auto_cleanup_enabled": False,
-        "cleanup_cron": "0 2 * * *",
-    }
+    policies = await automation.list_policy_summary(app_name=resolved_app)
 
     return MemoryListResponse(
         users=users,
@@ -475,3 +558,108 @@ async def get_audit_history(
             for r in records
         ],
     }
+
+
+@router.get("/automation", response_model=MemoryAutomationSnapshotResponse)
+async def get_memory_automation_snapshot(
+    app_name: Optional[str] = Query(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationSnapshotResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    snapshot = await service.get_snapshot(app_name=_resolve_app_name(app_name))
+    return MemoryAutomationSnapshotResponse.model_validate(snapshot)
+
+
+@router.get("/automation/logs", response_model=MemoryAutomationLogsResponse)
+async def get_memory_automation_logs(
+    app_name: Optional[str] = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationLogsResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    _ = _resolve_app_name(app_name)
+    items = await service.get_logs(limit=limit)
+    return MemoryAutomationLogsResponse(count=len(items), items=items)
+
+
+@router.post("/automation/config", response_model=MemoryAutomationSnapshotResponse)
+async def update_memory_automation_config(
+    payload: MemoryAutomationConfigUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationSnapshotResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    resolved_app = _resolve_app_name(payload.app_name)
+    try:
+        await service.update_config(
+            app_name=resolved_app,
+            config=payload.config,
+            updated_by=user.user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    snapshot = await service.get_snapshot(app_name=resolved_app)
+    return MemoryAutomationSnapshotResponse.model_validate(snapshot)
+
+
+@router.post("/automation/jobs/{job_key}/enable", response_model=MemoryAutomationSnapshotResponse)
+async def enable_memory_automation_job(
+    job_key: str,
+    app_name: Optional[str] = Query(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationSnapshotResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    try:
+        snapshot = await service.enable_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return MemoryAutomationSnapshotResponse.model_validate(snapshot)
+
+
+@router.post("/automation/jobs/{job_key}/disable", response_model=MemoryAutomationSnapshotResponse)
+async def disable_memory_automation_job(
+    job_key: str,
+    app_name: Optional[str] = Query(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationSnapshotResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    try:
+        snapshot = await service.disable_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return MemoryAutomationSnapshotResponse.model_validate(snapshot)
+
+
+@router.post("/automation/jobs/{job_key}/reconcile", response_model=MemoryAutomationSnapshotResponse)
+async def reconcile_memory_automation_job(
+    job_key: str,
+    app_name: Optional[str] = Query(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationSnapshotResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    try:
+        snapshot = await service.reconcile_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return MemoryAutomationSnapshotResponse.model_validate(snapshot)
+
+
+@router.post("/automation/jobs/{job_key}/run", response_model=MemoryAutomationRunResponse)
+async def run_memory_automation_job(
+    job_key: str,
+    app_name: Optional[str] = Query(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> MemoryAutomationRunResponse:
+    _require_admin(user)
+    service = get_memory_automation_service()
+    try:
+        result = await service.run_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    result["snapshot"] = MemoryAutomationSnapshotResponse.model_validate(result["snapshot"])
+    return MemoryAutomationRunResponse.model_validate(result)

--- a/apps/negentropy/src/negentropy/engine/factories/memory.py
+++ b/apps/negentropy/src/negentropy/engine/factories/memory.py
@@ -18,6 +18,7 @@ from negentropy.config import settings
 
 if TYPE_CHECKING:
     from negentropy.engine.adapters.postgres.fact_service import FactService
+    from negentropy.engine.adapters.postgres.memory_automation_service import MemoryAutomationService
     from negentropy.engine.governance.memory import MemoryGovernanceService
 
 # 类型别名：embedding 函数签名
@@ -165,6 +166,7 @@ def reset_memory_governance_service() -> None:
 # ============================================================================
 
 _fact_service_instance: Optional["FactService"] = None
+_memory_automation_service_instance: Optional["MemoryAutomationService"] = None
 
 
 def get_fact_service(embedding_fn: Optional[EmbeddingFn] = None) -> "FactService":
@@ -196,6 +198,22 @@ def reset_fact_service() -> None:
     _fact_service_instance = None
 
 
+def get_memory_automation_service() -> "MemoryAutomationService":
+    global _memory_automation_service_instance
+
+    if _memory_automation_service_instance is None:
+        from negentropy.engine.adapters.postgres.memory_automation_service import MemoryAutomationService
+
+        _memory_automation_service_instance = MemoryAutomationService()
+
+    return _memory_automation_service_instance
+
+
+def reset_memory_automation_service() -> None:
+    global _memory_automation_service_instance
+    _memory_automation_service_instance = None
+
+
 __all__ = [
     "MemoryBackend",
     "EmbeddingFn",
@@ -210,4 +228,6 @@ __all__ = [
     # Fact Service
     "get_fact_service",
     "reset_fact_service",
+    "get_memory_automation_service",
+    "reset_memory_automation_service",
 ]

--- a/apps/negentropy/src/negentropy/models/internalization.py
+++ b/apps/negentropy/src/negentropy/models/internalization.py
@@ -94,6 +94,14 @@ class Instruction(Base, UUIDMixin):
     )
 
 
+class MemoryAutomationConfig(Base, UUIDMixin, TimestampMixin):
+    __tablename__ = "memory_automation_configs"
+
+    app_name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    config: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    updated_by: Mapped[Optional[str]] = mapped_column(String(255))
+
+
 class MemoryAuditLog(Base, UUIDMixin, TimestampMixin):
     """
     Memory Audit Log Model

--- a/apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from negentropy.engine.adapters.postgres.memory_automation_service import (
+    DEFAULT_AUTOMATION_CONFIG,
+    MemoryAutomationService,
+)
+
+
+@pytest.fixture
+def service() -> MemoryAutomationService:
+    return MemoryAutomationService()
+
+
+def test_merge_config_preserves_defaults(service: MemoryAutomationService):
+    merged = service._merge_config(  # noqa: SLF001
+        DEFAULT_AUTOMATION_CONFIG,
+        {
+            "retention": {
+                "auto_cleanup_enabled": True,
+            }
+        },
+    )
+
+    assert merged["retention"]["auto_cleanup_enabled"] is True
+    assert merged["retention"]["cleanup_schedule"] == DEFAULT_AUTOMATION_CONFIG["retention"]["cleanup_schedule"]
+    assert merged["consolidation"]["enabled"] is False
+
+
+def test_validate_config_rejects_invalid_ratios(service: MemoryAutomationService):
+    invalid = service._merge_config(  # noqa: SLF001
+        DEFAULT_AUTOMATION_CONFIG,
+        {
+            "context_assembler": {
+                "memory_ratio": 0.8,
+                "history_ratio": 0.5,
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="sum to <= 1"):
+        service._validate_config(invalid)  # noqa: SLF001
+
+
+def test_build_cleanup_job_runtime_uses_managed_sql(service: MemoryAutomationService):
+    enabled, schedule, command = service._build_job_runtime(  # noqa: SLF001
+        job_key="cleanup_memories",
+        config=DEFAULT_AUTOMATION_CONFIG,
+    )
+
+    assert enabled is False
+    assert schedule == "0 2 * * *"
+    assert "cleanup_low_value_memories" in command
+    assert "negentropy.cleanup_low_value_memories" in command

--- a/docs/knowledges.md
+++ b/docs/knowledges.md
@@ -6,6 +6,7 @@
 
 - **底层存储模型**：[apps/negentropy/src/negentropy/models/perception.py](../apps/negentropy/src/negentropy/models/perception.py)（`Corpus` / `Knowledge`）。
 - **Memory 模型**：[apps/negentropy/src/negentropy/models/internalization.py](../apps/negentropy/src/negentropy/models/internalization.py)（`Memory` / `Fact` / `MemoryAuditLog`）。
+- **Memory 专项文档**：[memory.md](./memory.md)（Memory Automation 控制面、实施过程与验收记录）。
 - **数据库权威定义**：[docs/schema/perception_schema.sql](./schema/perception_schema.sql)（`corpus` / `knowledge` 表、索引、触发器、`kb_hybrid_search` / `kb_rrf_search`）。
 - **前端扩展约束**：[docs/negentropy-ui-plan.md](./negentropy-ui-plan.md) 的「11. 未来扩展：知识库/知识图谱/用户记忆管理」。
 - **调研文档**：[034-knowledge-base.md](https://github.com/ThreeFish-AI/agentic-ai-cognizes/blob/master/docs/research/034-knowledge-base.md)、[035-knowledge-base-platform.md](https://github.com/ThreeFish-AI/agentic-ai-cognizes/blob/master/docs/research/035-knowledge-base-platform.md)。

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,94 @@
+# Memory 设计与实施管理
+
+## 1. 定位
+
+Memory 模块负责用户长期记忆的形成、保留、检索与治理，区别于静态共享的 Knowledge。为避免控制面与数据面耦合，本次新增 **Memory / Automation** 二级导航页，统一展示与管理仿生记忆自动化过程，包括：
+
+- 艾宾浩斯遗忘曲线参数
+- Memory Retention 清理任务
+- Context Assembler 组装预算
+- Maintenance Consolidation 周期触发
+- PostgreSQL 受管函数与 `pg_cron` 调度状态
+- 最近执行日志与受控运维动作
+
+## 2. 设计原则
+
+- **控制面/数据面分离**：前端不直接编辑任意 SQL，不直接面向 `cron.job` 暴露数据库内部结构。
+- **Single Source of Truth**：自动化配置以服务端 `memory_automation_configs` 为唯一事实源，UI 仅读写该契约。
+- **受控运维**：只允许对预定义过程执行 `enable / disable / reconcile / run`。
+- **渐进降级**：未安装 `pg_cron` 时仍可查看配置和函数定义，但调度能力退化为只读。
+
+## 3. 核心对象
+
+```mermaid
+flowchart TD
+    subgraph ControlPlane[Memory Automation Control Plane]
+        UI[Memory / Automation]
+        API[/memory/automation/*]
+        CFG[(memory_automation_configs)]
+    end
+
+    subgraph ManagedProcess[Managed Processes]
+        RET[Retention Cleanup]
+        ASM[Context Assembler]
+        CON[Maintenance Consolidation]
+    end
+
+    subgraph Postgres[PostgreSQL Runtime]
+        FN[Managed SQL Functions]
+        CRON[cron.job]
+        LOG[cron.job_run_details]
+    end
+
+    UI --> API --> CFG
+    API --> RET
+    API --> ASM
+    API --> CON
+    RET --> FN
+    ASM --> FN
+    CON --> FN
+    RET --> CRON
+    CON --> CRON
+    CRON --> LOG
+```
+
+## 4. 受管过程
+
+| 过程 | 受管函数 | 受管任务 | 说明 |
+| :-- | :-- | :-- | :-- |
+| Retention Cleanup | `calculate_retention_score`, `cleanup_low_value_memories` | `cleanup_memories` | 定时更新 retention 并清理低价值记忆 |
+| Context Assembler | `get_context_window` | 无 | 按 token budget 组装记忆与历史 |
+| Maintenance Consolidation | `trigger_maintenance_consolidation` | `trigger_consolidation` | 批量创建巩固任务 |
+
+## 5. 一期接口
+
+- `GET /memory/automation`
+- `GET /memory/automation/logs`
+- `POST /memory/automation/config`
+- `POST /memory/automation/jobs/{job_key}/enable`
+- `POST /memory/automation/jobs/{job_key}/disable`
+- `POST /memory/automation/jobs/{job_key}/reconcile`
+- `POST /memory/automation/jobs/{job_key}/run`
+
+## 6. 实施记录
+
+- 新增 Memory Automation service，封装配置持久化、函数 reconcile、`pg_cron` 任务管理与日志读取。
+- 新增 `memory_automation_configs` 表，保存后端托管配置。
+- 新增 `/memory/automation` 页面与 API 代理，管理员可对白盒化过程执行受控运维动作。
+- 将 `/memory` 现有 `policies` 摘要改为从 automation 配置派生，避免双源。
+
+## 7. 验证清单
+
+- Memory 主导航出现 `Automation` 二级入口。
+- 管理员可查看配置、函数、任务与日志。
+- 保存配置后自动 reconcile 预定义函数与任务。
+- `pg_cron` 未安装时页面进入降级只读态。
+- 现有 Dashboard / Timeline / Facts / Audit 行为不回归。
+
+## 参考文献
+
+<a id="ref1"></a>[1] H. Ebbinghaus, "Memory: A Contribution to Experimental Psychology," _Teachers College, Columbia University_, 1885/1913.
+
+<a id="ref2"></a>[2] Google, "Memory: Long-Term Knowledge with MemoryService," _Agent Development Kit Documentation_, 2026. [Online]. Available: https://google.github.io/adk-docs/sessions/memory/
+
+<a id="ref3"></a>[3] Citus Data, "pg_cron," _GitHub README_, 2026. [Online]. Available: https://github.com/citusdata/pg_cron


### PR DESCRIPTION
## 变更内容

- 新增 Memory 二级导航 `Automation` 页面，并补齐前端 `/api/memory/automation/*` 代理与强类型 API 客户端。
- 新增后端 `/memory/automation/*` 控制面接口，用于统一返回配置快照、受管 SQL 函数状态、`pg_cron` 任务状态与最近执行日志。
- 新增 `MemoryAutomationService`，将仿生记忆自动化过程收敛到后端托管配置，统一管理 retention、context assembler、maintenance consolidation 的配置持久化、函数 reconcile、任务启停/重建与手动触发。
- 新增 `memory_automation_configs` 持久化模型与 Alembic migration，用于保存 Memory automation 的唯一事实源配置。
- 将现有 `/memory` 返回的 `policies` 摘要改为从 automation 配置派生，避免控制面配置出现双源分裂。
- 新增 [`docs/memory.md`](./docs/memory.md)，集中梳理 Memory Automation 控制面设计、实施过程与验证清单，并在 [`docs/knowledges.md`](./docs/knowledges.md) 中补充跳转。
- 补充前后端测试，覆盖 `MemoryNav` 新导航项、automation API 请求行为，以及后端配置合并/校验与受管任务 SQL 生成逻辑。

## 变更原因

本次改动用于响应 Memory 模块“仿生记忆机制自动化过程可视化与可管理”的需求，将原本偏数据库运维脚本层的能力，提升为产品内可观测、可受控的 Memory Automation 控制面。

结合 Agent Memory / Context Engineering 的经典实践，本实现遵循以下原则：

- **控制面 / 数据面分离**：前端不直接操作 `cron.job` 或任意 SQL，而是通过受约束的后端 API 管理预定义过程。
- **Single Source of Truth**：Memory automation 配置统一落到服务端持久化配置，避免 Dashboard、Timeline、运维脚本各自维护不同 policy 口径。
- **Composition over Construction**：在现有 Memory API、`PostgresMemoryService`、Memory 导航和文档体系基础上增量扩展，不破坏既有 Dashboard / Timeline / Facts / Audit 链路。
- **Graceful Degradation**：在 `pg_cron` 缺失时仍可查看配置和函数状态，只禁用调度相关动作，降低环境差异带来的功能中断风险。

## 关键实现细节

- 前端控制面一期仅开放受控运维动作：保存配置、启停任务、重建任务、手动触发一次；不开放任意 SQL 编辑，避免把数据库内部细节泄漏到 UI。
- 受管任务以稳定的业务键管理，而不是让前端依赖 `cron.job.jobid`：
  - `cleanup_memories`
  - `trigger_consolidation`
- 受管 SQL 函数状态纳入快照接口统一返回，覆盖：
  - `calculate_retention_score`
  - `cleanup_low_value_memories`
  - `get_context_window`
  - `trigger_maintenance_consolidation`
- 保存 automation 配置后，后端会自动 reconcile 预定义函数与任务，确保配置与运行态尽量收敛。
- 文档层新增 [`docs/memory.md`](./docs/memory.md) 作为 Memory 专项事实源，避免继续把 Memory 方案散落在 `docs/knowledges.md` 与 schema 注释中。

## 验证

已完成以下验证：

```bash
uv run --project apps/negentropy pytest apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py -q
pnpm --dir apps/negentropy-ui exec vitest run tests/unit/ui/MemoryNav.test.tsx tests/unit/features/memory-api.test.ts
pnpm --dir apps/negentropy-ui typecheck
```

## 风险与兼容性

- 本次改动不调整现有 Memory/Facts/Audit 的既有接口语义，仅新增 automation 控制面接口并收敛 policy 摘要来源。
- `pg_cron` 相关能力在未安装扩展时会降级为只读观测，不应影响现有 Memory 主流程。
- 真正的数据库级任务调度与执行日志表现，仍需在目标 PostgreSQL 环境执行 migration 后做一次联调验收。
