### PR TITLE
fix(migration): 修正 Memory Automation 迁移链路分叉;

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/9c7f8e6d5b4a_add_memory_automation_configs.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/9c7f8e6d5b4a_add_memory_automation_configs.py
@@ -1,7 +1,7 @@
 """add memory automation configs
 
 Revision ID: 9c7f8e6d5b4a
-Revises: bd9c65e1bf99
+Revises: c6f8d9e1a2b3
 Create Date: 2026-03-08 12:00:00.000000
 """
 
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "9c7f8e6d5b4a"
-down_revision: Union[str, Sequence[str], None] = "bd9c65e1bf99"
+down_revision: Union[str, Sequence[str], None] = "c6f8d9e1a2b3"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## 变更内容

- 修正 [`9c7f8e6d5b4a_add_memory_automation_configs.py`](./apps/negentropy/src/negentropy/db/migrations/versions/9c7f8e6d5b4a_add_memory_automation_configs.py) 的迁移链路定义。
- 将该 migration 的 `down_revision` 从旧节点 `bd9c65e1bf99` 调整为当前主链 head `c6f8d9e1a2b3`。
- 同步更新 migration 文件头部注释中的 `Revises` 元数据，保证代码注释与 Alembic 实际 DAG 一致。

## 变更原因

在执行：

```bash
uv run alembic upgrade head
```

时，Alembic 报错存在多个 head。排查结果表明，新加的 Memory Automation migration 被错误地挂在了旧的 branchpoint `bd9c65e1bf99` 上，而仓库当前真实迁移主链已经继续推进到 `c6f8d9e1a2b3`。这使得 migration 图被分叉成两个 head：

- `9c7f8e6d5b4a`
- `c6f8d9e1a2b3`

对于这种“单个新 migration 接错父节点”的场景，最小风险修复不是增加 merge revision，而是直接把这条 migration 重新接回当前主链，恢复单链拓扑，避免未来继续积累迁移图复杂度。

## 关键实现细节

- 本次只修复 Alembic DAG，不修改任何运行时业务逻辑、API 契约或表结构语义。
- 没有新增 merge migration，因为这不是两个合法长期分支需要合流，而是单条 migration 的父节点选择错误。
- 修复后 `alembic heads` 应只剩一个 head，即 `9c7f8e6d5b4a`。
- 修复后 `alembic upgrade head` 可以直接执行，不再要求使用 `heads` 或显式指定分支头。

## 验证

已完成以下验证：

```bash
uv run --project apps/negentropy alembic heads
uv run --project apps/negentropy alembic upgrade head
uv run --project apps/negentropy pytest apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py -q
pnpm --dir apps/negentropy-ui exec vitest run tests/unit/ui/MemoryNav.test.tsx tests/unit/features/memory-api.test.ts
pnpm --dir apps/negentropy-ui typecheck
```

验证结果：

- `alembic heads` 已收敛为单头 `9c7f8e6d5b4a`
- `alembic upgrade head` 已成功执行
- 相关前后端回归验证通过

## 风险与兼容性

- 本次修改仅影响 migration 依赖关系，对现有功能无行为变更。
- 对尚未执行该 migration 的环境是透明修复。
- 若某环境之前已经通过人工方式执行了错误分叉链上的 revision，仍应在部署时额外检查 `alembic_version` 与目标链路是否一致。
