### PR TITLE
feat(memory): 新增 Memory Automation 控制面与受管调度能力;

### DIFF
--- a/apps/negentropy-ui/app/memory/automation/page.tsx
+++ b/apps/negentropy-ui/app/memory/automation/page.tsx
@@ -27,6 +27,7 @@ export default function MemoryAutomationPage() {
   const [isPending, startTransition] = useTransition();
 
   const isAdmin = Boolean(user?.roles?.includes("admin"));
+  const isSchedulerReadonly = snapshot ? !snapshot.capabilities.pg_cron_available : false;
 
   const load = async () => {
     setError(null);
@@ -162,6 +163,11 @@ export default function MemoryAutomationPage() {
                 {snapshot?.capabilities.degraded_reasons?.length ? (
                   <div className="mt-4 rounded-2xl border border-amber-300 bg-amber-50 p-3 text-[11px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
                     {snapshot.capabilities.degraded_reasons.join(" / ")}
+                  </div>
+                ) : null}
+                {isSchedulerReadonly ? (
+                  <div className="mt-4 rounded-2xl border border-border bg-muted/40 p-3 text-[11px] text-muted">
+                    当前 `pg_cron` 不可用，调度相关操作已降级为只读；配置和函数状态仍可查看与保存。
                   </div>
                 ) : null}
               </div>
@@ -373,21 +379,21 @@ export default function MemoryAutomationPage() {
                           <button
                             className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                             onClick={() => handleJobAction(job.job_key, job.enabled ? "disable" : "enable")}
-                            disabled={isPending || !snapshot.capabilities.pg_cron_installed}
+                            disabled={isPending || isSchedulerReadonly}
                           >
                             {job.enabled ? "停用" : "启用"}
                           </button>
                           <button
                             className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                             onClick={() => handleJobAction(job.job_key, "reconcile")}
-                            disabled={isPending}
+                            disabled={isPending || isSchedulerReadonly}
                           >
                             重建
                           </button>
                           <button
                             className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
                             onClick={() => handleRun(job.job_key)}
-                            disabled={isPending}
+                            disabled={isPending || isSchedulerReadonly}
                           >
                             手动触发
                           </button>

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -117,6 +117,7 @@ export interface MemoryAutomationSnapshot {
   capabilities: {
     pg_cron_installed: boolean;
     pg_cron_available: boolean;
+    pg_cron_logs_accessible?: boolean;
     management_mode: string;
     degraded_reasons: string[];
   };

--- a/apps/negentropy-ui/tests/unit/memory/MemoryAutomationPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/memory/MemoryAutomationPage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import MemoryAutomationPage from "@/app/memory/automation/page";
+
+const fetchMemoryAutomation = vi.fn();
+const fetchMemoryAutomationLogs = vi.fn();
+
+vi.mock("@/components/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { roles: ["admin"] },
+    status: "authenticated",
+  }),
+}));
+
+vi.mock("@/components/ui/MemoryNav", () => ({
+  MemoryNav: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/features/memory", () => ({
+  fetchMemoryAutomation: (...args: unknown[]) => fetchMemoryAutomation(...args),
+  fetchMemoryAutomationLogs: (...args: unknown[]) => fetchMemoryAutomationLogs(...args),
+  updateMemoryAutomationConfig: vi.fn(),
+  triggerMemoryAutomationJobAction: vi.fn(),
+  runMemoryAutomationJob: vi.fn(),
+}));
+
+describe("MemoryAutomationPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    fetchMemoryAutomation.mockResolvedValue({
+      capabilities: {
+        pg_cron_installed: true,
+        pg_cron_available: false,
+        pg_cron_logs_accessible: false,
+        management_mode: "backend-managed",
+        degraded_reasons: ["pg_cron_unavailable"],
+      },
+      config: {
+        retention: {
+          decay_lambda: 0.1,
+          low_retention_threshold: 0.1,
+          min_age_days: 7,
+          auto_cleanup_enabled: true,
+          cleanup_schedule: "0 2 * * *",
+        },
+        consolidation: {
+          enabled: true,
+          schedule: "0 * * * *",
+          lookback_interval: "1 hour",
+        },
+        context_assembler: {
+          max_tokens: 4000,
+          memory_ratio: 0.3,
+          history_ratio: 0.5,
+        },
+      },
+      processes: [],
+      functions: [],
+      jobs: [
+        {
+          job_key: "cleanup_memories",
+          process_label: "Ebbinghaus Cleanup",
+          function_name: "cleanup_low_value_memories",
+          enabled: true,
+          status: "degraded",
+          job_id: null,
+          schedule: "0 2 * * *",
+          command: "SELECT 1",
+          active: false,
+        },
+      ],
+      health: {
+        status: "degraded",
+        recent_log_count: 0,
+      },
+    });
+    fetchMemoryAutomationLogs.mockResolvedValue({ count: 0, items: [] });
+  });
+
+  it("pg_cron 不可用时将调度动作降级为只读", async () => {
+    render(<MemoryAutomationPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/pg_cron_unavailable/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/调度相关操作已降级为只读/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "停用" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "重建" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "手动触发" })).toBeDisabled();
+  });
+});

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_automation_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_automation_service.py
@@ -36,12 +36,37 @@ DEFAULT_AUTOMATION_CONFIG: dict[str, Any] = {
     },
 }
 
-FUNCTION_DEFINITIONS: dict[str, str] = {
-    "calculate_retention_score": f"""
+class MemoryAutomationUnavailableError(RuntimeError):
+    """Raised when automation runtime capabilities are not available."""
+
+
+def _format_float(value: float) -> str:
+    return f"{value:.6f}".rstrip("0").rstrip(".")
+
+
+def _escape_sql_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _build_function_definitions(config: dict[str, Any]) -> dict[str, str]:
+    retention = config["retention"]
+    consolidation = config["consolidation"]
+    context = config["context_assembler"]
+
+    decay_lambda = _format_float(retention["decay_lambda"])
+    low_retention_threshold = _format_float(retention["low_retention_threshold"])
+    min_age_days = int(retention["min_age_days"])
+    max_tokens = int(context["max_tokens"])
+    memory_ratio = _format_float(context["memory_ratio"])
+    history_ratio = _format_float(context["history_ratio"])
+    lookback_interval = _escape_sql_literal(str(consolidation["lookback_interval"]))
+
+    return {
+        "calculate_retention_score": f"""
 CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.calculate_retention_score(
     p_access_count INTEGER,
     p_last_accessed_at TIMESTAMP WITH TIME ZONE,
-    p_decay_rate FLOAT DEFAULT 0.1
+    p_decay_rate FLOAT DEFAULT {decay_lambda}
 )
 RETURNS FLOAT AS $$
 DECLARE
@@ -56,11 +81,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 """.strip(),
-    "cleanup_low_value_memories": f"""
+        "cleanup_low_value_memories": f"""
 CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.cleanup_low_value_memories(
-    p_threshold FLOAT DEFAULT 0.1,
-    p_min_age_days INTEGER DEFAULT 7,
-    p_decay_rate FLOAT DEFAULT 0.1
+    p_threshold FLOAT DEFAULT {low_retention_threshold},
+    p_min_age_days INTEGER DEFAULT {min_age_days},
+    p_decay_rate FLOAT DEFAULT {decay_lambda}
 )
 RETURNS INTEGER AS $$
 DECLARE
@@ -82,15 +107,15 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 """.strip(),
-    "get_context_window": f"""
+        "get_context_window": f"""
 CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.get_context_window(
     p_user_id VARCHAR(255),
     p_app_name VARCHAR(255),
     p_query TEXT,
     p_query_embedding vector(1536),
-    p_max_tokens INTEGER DEFAULT 4000,
-    p_memory_ratio FLOAT DEFAULT 0.3,
-    p_history_ratio FLOAT DEFAULT 0.5
+    p_max_tokens INTEGER DEFAULT {max_tokens},
+    p_memory_ratio FLOAT DEFAULT {memory_ratio},
+    p_history_ratio FLOAT DEFAULT {history_ratio}
 )
 RETURNS TABLE (
     context_type VARCHAR(50),
@@ -126,9 +151,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 """.strip(),
-    "trigger_maintenance_consolidation": f"""
+        "trigger_maintenance_consolidation": f"""
 CREATE OR REPLACE FUNCTION {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(
-    p_interval INTERVAL DEFAULT '1 hour'
+    p_interval INTERVAL DEFAULT '{lookback_interval}'
 )
 RETURNS INTEGER AS $$
 DECLARE
@@ -153,7 +178,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 """.strip(),
-}
+    }
 
 
 @dataclass(frozen=True)
@@ -181,15 +206,23 @@ class MemoryAutomationService:
     async def get_snapshot(self, *, app_name: str) -> dict[str, Any]:
         config = await self.get_effective_config(app_name=app_name)
         capabilities = await self._get_capabilities()
-        functions = await self._get_function_states()
+        functions = await self._get_function_states(config=config)
         jobs = await self._get_job_states(config=config, capabilities=capabilities)
         logs = await self.get_logs(limit=10)
 
         degraded_reasons: list[str] = []
         if not capabilities["pg_cron_installed"]:
             degraded_reasons.append("pg_cron_not_installed")
+        elif not capabilities["pg_cron_available"]:
+            degraded_reasons.append("pg_cron_unavailable")
+        if not capabilities.get("pg_cron_logs_accessible", True):
+            degraded_reasons.append("pg_cron_logs_unavailable")
         if any(item["status"] == "missing" for item in functions):
             degraded_reasons.append("function_missing")
+        if any(item["status"] == "drifted" for item in functions):
+            degraded_reasons.append("function_drifted")
+        if any(item["status"] in {"drifted", "missing", "degraded"} for item in jobs):
+            degraded_reasons.append("job_drifted")
 
         return {
             "capabilities": {
@@ -208,7 +241,8 @@ class MemoryAutomationService:
         }
 
     async def get_logs(self, *, limit: int = 20) -> list[dict[str, Any]]:
-        if not await self._is_pg_cron_installed():
+        capabilities = await self._get_capabilities()
+        if not capabilities["pg_cron_installed"] or not capabilities.get("pg_cron_logs_accessible", False):
             return []
 
         sql = text(
@@ -259,7 +293,7 @@ class MemoryAutomationService:
                 entity.updated_by = updated_by
             await db.commit()
 
-        await self.reconcile_all(app_name=app_name)
+        await self.reconcile_all(app_name=app_name, config=merged)
         return merged
 
     async def enable_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
@@ -275,23 +309,25 @@ class MemoryAutomationService:
         return await self.get_snapshot(app_name=app_name)
 
     async def reconcile_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
-        await self._reconcile_functions()
-        if await self._is_pg_cron_installed():
-            config = await self.get_effective_config(app_name=app_name)
-            await self._reconcile_single_job(job_key=job_key, config=config)
+        config = await self.get_effective_config(app_name=app_name)
+        await self._reconcile_functions(config=config)
+        await self._ensure_scheduler_available(job_key=job_key)
+        await self._reconcile_single_job(job_key=job_key, config=config)
         return await self.get_snapshot(app_name=app_name)
 
-    async def reconcile_all(self, *, app_name: str) -> None:
-        await self._reconcile_functions()
-        if not await self._is_pg_cron_installed():
+    async def reconcile_all(self, *, app_name: str, config: dict[str, Any] | None = None) -> None:
+        effective_config = config or await self.get_effective_config(app_name=app_name)
+        await self._reconcile_functions(config=effective_config)
+        capabilities = await self._get_capabilities()
+        if not capabilities["pg_cron_available"]:
             return
-        config = await self.get_effective_config(app_name=app_name)
         for job_key in JOB_TEMPLATES:
-            await self._reconcile_single_job(job_key=job_key, config=config)
+            await self._reconcile_single_job(job_key=job_key, config=effective_config)
 
     async def run_job(self, *, app_name: str, job_key: JobKey) -> dict[str, Any]:
         config = await self.get_effective_config(app_name=app_name)
-        await self._reconcile_functions()
+        await self._reconcile_functions(config=config)
+        await self._ensure_scheduler_available(job_key=job_key)
         template = self._get_job_template(job_key)
         sql = self._build_manual_run_sql(job_key=job_key, config=config)
         async with AsyncSessionLocal() as db:
@@ -328,9 +364,10 @@ class MemoryAutomationService:
             entity = result.scalar_one_or_none()
         return entity.config if entity and entity.config else {}
 
-    async def _reconcile_functions(self) -> None:
+    async def _reconcile_functions(self, *, config: dict[str, Any]) -> None:
+        function_definitions = _build_function_definitions(config)
         async with AsyncSessionLocal() as db:
-            for sql in FUNCTION_DEFINITIONS.values():
+            for sql in function_definitions.values():
                 await db.execute(text(sql))
             await db.commit()
 
@@ -376,12 +413,21 @@ class MemoryAutomationService:
 
     async def _get_capabilities(self) -> dict[str, Any]:
         installed = await self._is_pg_cron_installed()
+        scheduler_accessible = False
+        logs_accessible = False
+
+        if installed:
+            scheduler_accessible = await self._probe_pg_cron_table("cron.job")
+            logs_accessible = await self._probe_pg_cron_table("cron.job_run_details")
+
         return {
             "pg_cron_installed": installed,
-            "pg_cron_available": installed,
+            "pg_cron_available": installed and scheduler_accessible,
+            "pg_cron_logs_accessible": installed and logs_accessible,
         }
 
-    async def _get_function_states(self) -> list[dict[str, Any]]:
+    async def _get_function_states(self, *, config: dict[str, Any]) -> list[dict[str, Any]]:
+        function_definitions = _build_function_definitions(config)
         async with AsyncSessionLocal() as db:
             result = await db.execute(
                 text(
@@ -397,11 +443,11 @@ class MemoryAutomationService:
             rows = {
                 row["name"]: row["definition"]
                 for row in result.mappings().all()
-                if row["name"] in FUNCTION_DEFINITIONS
+                if row["name"] in function_definitions
             }
 
         states = []
-        for name, expected in FUNCTION_DEFINITIONS.items():
+        for name, expected in function_definitions.items():
             definition = rows.get(name)
             normalized_expected = self._normalize_sql(expected)
             normalized_actual = self._normalize_sql(definition or "")
@@ -424,6 +470,21 @@ class MemoryAutomationService:
     async def _get_job_states(self, *, config: dict[str, Any], capabilities: dict[str, Any]) -> list[dict[str, Any]]:
         cron_rows: dict[str, dict[str, Any]] = {}
         if capabilities["pg_cron_installed"]:
+            if not capabilities["pg_cron_available"]:
+                return [
+                    {
+                        "job_key": job_key,
+                        "process_label": template.process_label,
+                        "function_name": template.function_name,
+                        "enabled": self._build_job_runtime(job_key=job_key, config=config)[0],
+                        "status": "degraded" if self._build_job_runtime(job_key=job_key, config=config)[0] else "disabled",
+                        "job_id": None,
+                        "schedule": self._build_job_runtime(job_key=job_key, config=config)[1],
+                        "command": self._build_job_runtime(job_key=job_key, config=config)[2],
+                        "active": False,
+                    }
+                    for job_key, template in JOB_TEMPLATES.items()
+                ]
             async with AsyncSessionLocal() as db:
                 result = await db.execute(
                     text(
@@ -474,6 +535,22 @@ class MemoryAutomationService:
                 text("SELECT 1 FROM pg_extension WHERE extname = 'pg_cron' LIMIT 1")
             )
             return result.scalar() == 1
+
+    async def _probe_pg_cron_table(self, table_name: str) -> bool:
+        try:
+            async with AsyncSessionLocal() as db:
+                await db.execute(text(f"SELECT 1 FROM {table_name} LIMIT 1"))
+                return True
+        except Exception as exc:
+            logger.warning("memory_automation_pg_cron_probe_failed", table=table_name, error=str(exc))
+            return False
+
+    async def _ensure_scheduler_available(self, *, job_key: JobKey) -> None:
+        capabilities = await self._get_capabilities()
+        if not capabilities["pg_cron_available"]:
+            raise MemoryAutomationUnavailableError(
+                f"Scheduler job '{job_key}' is unavailable because pg_cron is not installed or not accessible"
+            )
 
     def _build_processes(
         self,

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -47,6 +47,7 @@ from .factories.memory import (
     get_memory_governance_service,
     get_memory_service,
 )
+from .adapters.postgres.memory_automation_service import MemoryAutomationUnavailableError
 
 logger = get_logger("negentropy.engine.api")
 router = APIRouter(prefix="/memory", tags=["memory"])
@@ -614,6 +615,8 @@ async def enable_memory_automation_job(
     service = get_memory_automation_service()
     try:
         snapshot = await service.enable_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except MemoryAutomationUnavailableError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return MemoryAutomationSnapshotResponse.model_validate(snapshot)
@@ -629,6 +632,8 @@ async def disable_memory_automation_job(
     service = get_memory_automation_service()
     try:
         snapshot = await service.disable_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except MemoryAutomationUnavailableError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return MemoryAutomationSnapshotResponse.model_validate(snapshot)
@@ -644,6 +649,8 @@ async def reconcile_memory_automation_job(
     service = get_memory_automation_service()
     try:
         snapshot = await service.reconcile_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except MemoryAutomationUnavailableError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return MemoryAutomationSnapshotResponse.model_validate(snapshot)
@@ -659,6 +666,8 @@ async def run_memory_automation_job(
     service = get_memory_automation_service()
     try:
         result = await service.run_job(app_name=_resolve_app_name(app_name), job_key=job_key)  # type: ignore[arg-type]
+    except MemoryAutomationUnavailableError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     result["snapshot"] = MemoryAutomationSnapshotResponse.model_validate(result["snapshot"])

--- a/apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py
@@ -4,7 +4,9 @@ import pytest
 
 from negentropy.engine.adapters.postgres.memory_automation_service import (
     DEFAULT_AUTOMATION_CONFIG,
+    MemoryAutomationUnavailableError,
     MemoryAutomationService,
+    _build_function_definitions,
 )
 
 
@@ -53,3 +55,35 @@ def test_build_cleanup_job_runtime_uses_managed_sql(service: MemoryAutomationSer
     assert schedule == "0 2 * * *"
     assert "cleanup_low_value_memories" in command
     assert "negentropy.cleanup_low_value_memories" in command
+
+
+def test_context_assembler_config_updates_managed_function_defaults():
+    config = {
+        **DEFAULT_AUTOMATION_CONFIG,
+        "context_assembler": {
+            "max_tokens": 8192,
+            "memory_ratio": 0.4,
+            "history_ratio": 0.4,
+        },
+    }
+
+    function_sql = _build_function_definitions(config)["get_context_window"]
+
+    assert "p_max_tokens INTEGER DEFAULT 8192" in function_sql
+    assert "p_memory_ratio FLOAT DEFAULT 0.4" in function_sql
+    assert "p_history_ratio FLOAT DEFAULT 0.4" in function_sql
+
+
+@pytest.mark.asyncio
+async def test_scheduler_actions_raise_when_pg_cron_unavailable(service: MemoryAutomationService, monkeypatch: pytest.MonkeyPatch):
+    async def fake_capabilities():
+        return {
+            "pg_cron_installed": True,
+            "pg_cron_available": False,
+            "pg_cron_logs_accessible": False,
+        }
+
+    monkeypatch.setattr(service, "_get_capabilities", fake_capabilities)
+
+    with pytest.raises(MemoryAutomationUnavailableError):
+        await service._ensure_scheduler_available(job_key="cleanup_memories")  # noqa: SLF001

--- a/docs/knowledges.md
+++ b/docs/knowledges.md
@@ -531,71 +531,17 @@ logger.error("database_error", details=exc.details)
   - `Failed`: 执行失败（红色），点击可查看 Error Stack Trace。
 - **Alerts**: 系统自动捕获的异常（如 Embedding API Rate Limit, DB Connection Timeout）。
 
-## 12. Memory System User Guide (记忆系统指南)
+## 12. Memory System Guide (摘要)
 
-面向 User ID 的长期记忆审计与动态干预面板，包含 Episodic Memory (Timeline) 与 Semantic Memory (Facts) 双重视图。
+Memory 运行时能力分为两层：
 
-### 12.1 Dashboard (记忆概览)
+- **User Memory 面板**：Dashboard / Timeline / Facts / Audit，用于用户长期记忆的查看、审计与治理。
+- **Memory Automation 控制面**：用于仿生记忆自动化过程的配置、受管函数、调度任务与降级状态管理。
+
+为避免文档双源，Memory Automation 的设计、接口、降级矩阵与实施记录统一以 [memory.md](./memory.md) 为准；本文件仅保留 Knowledge 与 Memory 的边界说明。
 
 > [!NOTE]
-> **Admin Access**: 管理员 (`admin` 角色) 可查看任意用户的 Memory Dashboard 以进行审计与合规检查。普通用户仅能查看自己的数据。
-
-#### 12.1.1 功能特性 (Features)
-
-- **Metrics**: 全局统计，包括 User Count, Memory Count, Fact Count 及平均 Retention Score。
-- **Retention Alert**: "Low Retention" 指标，识别即将遗忘的关键记忆，便于人工干预。
-- **User Filtering**: 支持按 `User ID` 筛选，查看特定用户的完整记忆轨迹。
-
-#### 12.1.2 操作步骤 (Operation Steps)
-
-1. 进入 **Memory System** -> **Dashboard**。
-2. 观察顶部 **Metrics Cards** 了解系统整体记忆健康度。
-3. 在搜索栏输入目标 `User ID` 并回车，面板数据将刷新为该用户的专属视图。
-
-### 12.2 Memory Audit (行为审计)
-
-#### 12.2.1 功能特性 (Features)
-
-- **Audit Queue**: 待审列表，优先展示低置信度或低 Retention Score 的记忆片段。
-- **Governance Actions**: 符合 GDPR 的治理操作：
-  - **Retain**: 确认保留（提升 Retention Score 至 1.0）。
-  - **Delete**: 物理删除 Memory + 关联 Fact。
-  - **Anonymize**: 匿名化处理（保留统计价值但移除 PII）。
-
-#### 12.2.2 操作步骤 (Operation Steps)
-
-1. 切换至 **Audit** 标签页。
-2. 选中一条待审记忆（Memory Item）。
-3. 阅读 Content 与 Context。
-4. 点击底部操作按钮 (**Retain** / **Delete** / **Anonymize**)。
-5. 系统自动生成 `MemoryAuditLog` 记录操作。
-
-### 12.3 Facts Management (事实管理)
-
-#### 12.3.1 功能特性 (Features)
-
-- **Semantic View**: 查看从对话中提取的结构化事实（如 User Preferences, Biographical Info）。
-- **Validity Period**: 每个 Fact 包含 `valid_from` 与 `valid_until`，支持时效性管理。
-
-#### 12.3.2 操作步骤 (Operation Steps)
-
-1. 切换至 **Facts** 标签页。
-2. 浏览 Key-Value 列表。
-3. 如发现错误事实，点击 **Edit** 修正 Value 或 **Delete** 移除。
-4. 修改立即生效，并同步影响下游 Agent 的 Context。
-
-### 12.4 Timeline (时间轴视图)
-
-#### 12.4.1 功能特性 (Features)
-
-- **Chronological View**: 按时间倒序展示用户的交互 Memory 片段。
-- **Access Tracking**: 显示每次记忆的 `Access Count` 与 `Last Accessed` 时间，直观展示遗忘曲线效果。
-
-#### 12.4.2 操作步骤 (Operation Steps)
-
-1. 切换至 **Timeline** 标签页。
-2. 滚动浏览用户的历史记忆流。
-3. 悬停在某条 Memory 上，查看其 Embedding 维度信息或原始来源。
+> 管理员 (`admin` 角色) 可访问 Memory Dashboard 与 Memory Automation 控制面；调度能力是否可写取决于 `pg_cron` 是否可安装且可访问，详见 [memory.md](./memory.md)。
 
 ## 13. 测试覆盖
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -70,19 +70,41 @@ flowchart TD
 - `POST /memory/automation/jobs/{job_key}/reconcile`
 - `POST /memory/automation/jobs/{job_key}/run`
 
-## 6. 实施记录
+## 6. 配置到运行时的映射
+
+- `retention.decay_lambda`：映射到 `calculate_retention_score()` 与 `cleanup_low_value_memories()` 的默认衰减参数。
+- `retention.low_retention_threshold` / `retention.min_age_days`：映射到 `cleanup_low_value_memories()` 的默认清理阈值与最小保留天数。
+- `context_assembler.max_tokens` / `memory_ratio` / `history_ratio`：映射到 `get_context_window()` 的默认参数，控制记忆与历史的预算切分。
+- `consolidation.lookback_interval`：映射到 `trigger_maintenance_consolidation()` 的默认时间窗口。
+- `retention.auto_cleanup_enabled` / `consolidation.enabled` 与各自 `schedule`：映射到受管 `pg_cron` 任务是否启用及其 cron 表达式。
+
+## 7. 降级矩阵
+
+| 场景 | 配置查看 | 函数状态 | 调度任务查看 | 调度动作 | 执行日志 |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| `pg_cron` 已安装且可访问 | 可用 | 可用 | 可用 | 可用 | 可用 |
+| `pg_cron` 未安装 | 可用 | 可用 | 降级 | 只读禁用 | 空列表 |
+| `pg_cron` 已安装但 `cron.job` 不可访问 | 可用 | 可用 | 降级 | 只读禁用 | 降级 |
+| `pg_cron` 已安装但 `cron.job_run_details` 不可访问 | 可用 | 可用 | 可用 | 可用 | 空列表 + 降级告警 |
+
+说明：
+
+- “降级”表示 snapshot 仍然返回，但 `health.status` 为 `degraded`，并在 `degraded_reasons` 中给出原因。
+- 调度相关动作包括 `enable / disable / reconcile / run`，在调度能力不可用时统一进入只读。
+
+## 8. 实施记录
 
 - 新增 Memory Automation service，封装配置持久化、函数 reconcile、`pg_cron` 任务管理与日志读取。
 - 新增 `memory_automation_configs` 表，保存后端托管配置。
 - 新增 `/memory/automation` 页面与 API 代理，管理员可对白盒化过程执行受控运维动作。
 - 将 `/memory` 现有 `policies` 摘要改为从 automation 配置派生，避免双源。
 
-## 7. 验证清单
+## 9. 验证清单
 
 - Memory 主导航出现 `Automation` 二级入口。
 - 管理员可查看配置、函数、任务与日志。
-- 保存配置后自动 reconcile 预定义函数与任务。
-- `pg_cron` 未安装时页面进入降级只读态。
+- 保存配置后自动 reconcile 预定义函数，并在调度可用时同步 reconcile 预定义任务。
+- `pg_cron` 未安装或不可访问时页面进入降级只读态，但配置与函数状态仍可查看。
 - 现有 Dashboard / Timeline / Facts / Audit 行为不回归。
 
 ## 参考文献


### PR DESCRIPTION
## 变更内容

本 PR 在 Memory 主导航下新增 `Automation` 二级导航页，用于展示和管理后端 Memory 模块中仿生记忆自动化处理过程的配置、受管函数、调度任务和执行日志。整体采用控制面/数据面分离的实现方式，前端不直接操作数据库内部对象，而是通过受限 API 管理后端托管配置与预定义过程。

本次改动主要包括：

- 新增 Memory Automation 页面与前端 API 代理，支持查看和管理：
  - 艾宾浩斯遗忘曲线相关 retention 参数
  - Memory Retention 清理任务
  - Context Assembler 组装预算
  - Maintenance Consolidation 周期触发
  - PostgreSQL 受管函数与 `pg_cron` 调度状态
  - 最近执行日志与受控运维动作
- 新增后端 `MemoryAutomationService` 与 `/memory/automation/*` 接口，统一处理：
  - 自动化配置持久化
  - 预定义 SQL 函数 reconcile
  - `pg_cron` 任务 enable / disable / reconcile / run
  - 调度日志读取与健康状态聚合
- 新增 `memory_automation_configs` 持久化表及对应 migration
- 修正新增 migration 的 `down_revision`，消除 Alembic 多 head 分叉，恢复单链迁移结构
- 补齐前后端测试，覆盖导航入口、Automation API、降级态 UI、后端服务行为
- 新增 [docs/memory.md](./docs/memory.md) 作为 Memory Automation 的实施与设计文档，并将 [docs/knowledges.md](./docs/knowledges.md) 中重复的 Memory 细节收敛为摘要与跳转

## 变更原因

这次改动对应 Memory 模块“仿生记忆机制自动化过程可视化与可管理”的需求。目标不是暴露一组零散 SQL 或运维脚本，而是为 Memory 的自动化治理建立一个受控控制面，将业界关于 Agent Memory / Context Engineering 的经典模式落到产品能力中，包括：

- 长期记忆与运行时上下文解耦
- 自动化过程通过后端托管配置管理，避免前端直接依赖数据库内部实现
- 记忆 retention、context assembly、maintenance consolidation 等机制统一可观测、可追踪、可受控
- 文档和配置保持单一事实源，降低实现与运维之间的分叉风险

同时，这个分支也处理了两个落地问题：

- 修复了 Memory Automation migration 挂错父节点导致的 Alembic 多 head 问题
- 补强了 `pg_cron` 缺失或不可访问时的降级行为，确保页面进入只读而不是部分路径直接报错

## 关键实现细节

### 1. 受管函数与任务边界

后端只管理预定义的 Memory automation 过程，不开放任意 SQL 编辑。当前受管范围包括：

- `calculate_retention_score`
- `cleanup_low_value_memories`
- `get_context_window`
- `trigger_maintenance_consolidation`
- `cleanup_memories`
- `trigger_consolidation`

调度相关动作统一以稳定的 `job_key` 识别，而不是让前端依赖 `cron.job.jobid`。

### 2. Context Assembler 配置真正接入运行时

`context_assembler.max_tokens`、`memory_ratio`、`history_ratio` 不再只是持久化占位字段，而是会参与 `get_context_window()` 的函数定义生成。保存配置后，后端会基于当前 effective config 重新 reconcile 受管函数，确保页面配置与数据库侧默认参数保持一致。

### 3. pg_cron 渐进降级

能力探测不再只判断 `pg_cron` 扩展是否安装，还会区分：

- 扩展是否已安装
- `cron.job` 是否可访问
- `cron.job_run_details` 是否可访问

在 `pg_cron` 缺失、schema 不可读、日志表不可读等情况下：

- snapshot 仍可返回
- 配置和函数状态仍可查看
- 调度动作进入只读禁用
- 日志返回空列表并标记降级原因
- API 对不可执行的调度动作返回明确的不可用语义，而不是让页面落入 500

### 4. 文档边界收敛

`docs/memory.md` 被收敛为 Memory Automation 的设计与实施单一事实源，集中说明：

- 控制面/数据面分离原则
- 配置项到运行时函数的映射
- 受管函数与受管任务清单
- `pg_cron` 降级矩阵
- 实施记录与验证清单

`docs/knowledges.md` 保留摘要与跳转，避免继续并行承载完整的 Memory 操作说明。

## 验证

已执行的主要验证包括：

- `uv run --project apps/negentropy pytest apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py -q`
- `pnpm --dir apps/negentropy-ui exec vitest run tests/unit/ui/MemoryNav.test.tsx tests/unit/features/memory-api.test.ts tests/unit/memory/MemoryAutomationPage.test.tsx`
- `pnpm --dir apps/negentropy-ui typecheck`
- `uv run --project apps/negentropy alembic heads`
- `uv run --project apps/negentropy alembic upgrade head`

## 兼容性与风险控制

- 不改变现有 Dashboard / Timeline / Facts / Audit 的既有行为
- 不开放任意 SQL 管理入口，避免控制面穿透到数据库内部实现
- migration 采用“重接真实主链 head”而不是新增 merge revision，降低后续迁移维护复杂度
- `pg_cron` 不可用时采用只读降级，避免影响配置查看与函数观测
