### PR TITLE
ci(session): 增加旧会话入口导入守卫;

### DIFF
--- a/.github/workflows/negentropy-ui-tests.yml
+++ b/.github/workflows/negentropy-ui-tests.yml
@@ -22,6 +22,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ui-legacy-import-guard:
+    name: UI Legacy Import Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/negentropy-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: apps/negentropy-ui/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Block legacy session manager imports
+        run: pnpm lint:legacy-session-imports
+
   ui-typecheck:
     name: UI Type Checks
     runs-on: ubuntu-latest
@@ -117,7 +145,7 @@ jobs:
 
   ui-e2e-smoke:
     name: UI Playwright Smoke
-    needs: [ui-typecheck, ui-unit-integration, ui-build-smoke]
+    needs: [ui-legacy-import-guard, ui-typecheck, ui-unit-integration, ui-build-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:

--- a/apps/negentropy-ui/eslint.config.mjs
+++ b/apps/negentropy-ui/eslint.config.mjs
@@ -5,6 +5,35 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@/hooks/useSessionManager",
+              message:
+                "useSessionManager 已废弃。会话列表逻辑请改用 useSessionListService；会话详情、hydration 与 projection 逻辑请改用 useSessionService。",
+            },
+            {
+              name: "@/hooks/useSessionManager.ts",
+              message:
+                "useSessionManager 已废弃。会话列表逻辑请改用 useSessionListService；会话详情、hydration 与 projection 逻辑请改用 useSessionService。",
+            },
+          ],
+          patterns: [
+            {
+              group: ["**/hooks/useSessionManager", "**/hooks/useSessionManager.*"],
+              message:
+                "禁止新增对 legacy hook useSessionManager 的依赖。请迁移到 useSessionListService 或 useSessionService。",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "lint:legacy-session-imports": "node ./scripts/check-no-legacy-session-manager-imports.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:test": "tsc -p tsconfig.vitest.json --noEmit",
     "test": "vitest run",

--- a/apps/negentropy-ui/scripts/check-no-legacy-session-manager-imports.mjs
+++ b/apps/negentropy-ui/scripts/check-no-legacy-session-manager-imports.mjs
@@ -1,0 +1,78 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = process.cwd();
+const hookPath = path.join(rootDir, "hooks", "useSessionManager.ts");
+const ignoredDirs = new Set([".git", ".next", "build", "coverage", "dist", "node_modules", "playwright-report"]);
+const sourceExtensions = new Set([".ts", ".tsx"]);
+const importPattern =
+  /\b(?:import\s*\(|(?:import|export)\s+[^;]*?\s+from\s*)["']([^"']*useSessionManager(?:\.[^"']+)?)["']/g;
+
+async function collectSourceFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (ignoredDirs.has(entry.name)) {
+        continue;
+      }
+      files.push(...(await collectSourceFiles(fullPath)));
+      continue;
+    }
+
+    if (sourceExtensions.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function resolveLineNumber(text, index) {
+  return text.slice(0, index).split("\n").length;
+}
+
+async function main() {
+  const files = await collectSourceFiles(rootDir);
+  const violations = [];
+
+  for (const file of files) {
+    if (file === hookPath) {
+      continue;
+    }
+
+    const content = await readFile(file, "utf8");
+
+    for (const match of content.matchAll(importPattern)) {
+      const specifier = match[1];
+      if (!specifier) {
+        continue;
+      }
+
+      violations.push({
+        file: path.relative(rootDir, file),
+        line: resolveLineNumber(content, match.index ?? 0),
+        specifier,
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log("No legacy useSessionManager imports found.");
+    return;
+  }
+
+  console.error("Forbidden legacy useSessionManager imports detected:");
+  for (const violation of violations) {
+    console.error(`- ${violation.file}:${violation.line} -> ${violation.specifier}`);
+  }
+  console.error(
+    "Please migrate session list logic to useSessionListService, and session detail/hydration logic to useSessionService.",
+  );
+  process.exitCode = 1;
+}
+
+await main();

--- a/docs/a2ui.md
+++ b/docs/a2ui.md
@@ -142,6 +142,7 @@ flowchart TD
 遗留兼容入口：
 
 - `useSessionManager` 仅为兼容旧调用面暂时保留，已不代表当前 session feature 的推荐架构边界。
+- 新增代码已通过 lint 与 UI CI 明确禁止导入 `useSessionManager`，避免 legacy 入口重新漂移回主路径。
 - 新增能力、回归测试与文档描述一律以 `useSessionListService + useSessionService + useSessionProjection` 为准。
 
 ### 3.3 Canonical Role 约定


### PR DESCRIPTION
## 背景

在前序改动中，`useSessionManager` 已经被正式降级为 legacy 兼容入口，当前推荐的 session feature 边界已经收口为：

- `useSessionListService`
- `useSessionService`
- `useSessionProjection`

但仅靠文档说明和 `@deprecated` 注释还不够稳。只要没有工具链级约束，新的代码路径仍然可能再次导入 `useSessionManager`，让旧入口重新漂移回主链路。

本 PR 的目标是为这个 legacy 入口补上一层真正可执行的架构护栏：本地 lint 规则负责即时提示，CI guard 负责在 PR 流水线中阻断新增导入，同时避免把当前仓库中与本任务无关的既有 lint 债务一起点燃。

## 本次改动

### 1. 在 ESLint 中禁止新增导入 `useSessionManager`

- 更新 `apps/negentropy-ui/eslint.config.mjs`
- 增加 `no-restricted-imports` 规则
- 显式禁止：
  - `@/hooks/useSessionManager`
  - `@/hooks/useSessionManager.ts`
  - 以及相对路径形式的 `hooks/useSessionManager` 导入
- 错误信息直接给出迁移指引：
  - 会话列表逻辑改用 `useSessionListService`
  - 会话详情 / hydration / projection 逻辑改用 `useSessionService`

### 2. 增加独立的 legacy import guard 脚本

- 新增 `apps/negentropy-ui/scripts/check-no-legacy-session-manager-imports.mjs`
- 脚本递归扫描 `apps/negentropy-ui` 下的 `.ts` / `.tsx` 文件
- 排除 `hooks/useSessionManager.ts` 自身
- 检测静态 `import` / `export from` 和动态 `import()` 中对 `useSessionManager` 的引用
- 一旦发现违规导入，输出文件、行号与迁移提示，并以非零退出码失败

### 3. 将 import guard 接入 UI CI

- 更新 `.github/workflows/negentropy-ui-tests.yml`
- 新增独立 job：`UI Legacy Import Guard`
- 通过新的 `pnpm lint:legacy-session-imports` 脚本在 CI 中执行专项检查
- `ui-e2e-smoke` 增加对该 job 的依赖，使其成为正式门禁之一

### 4. 保持现有 lint 基线不被无关问题打爆

- `apps/negentropy-ui/package.json` 中新增 `lint:legacy-session-imports`
- 没有把全量 `pnpm lint` 直接升格为当前 CI 门禁
- 原因是当前 UI 仓库仍有一批与本 PR 无关的既有 ESLint 错误与 warning；直接切换会扩大爆炸半径并引入无关失败
- 本次采用“专项 guard”而不是“全量 lint gate”，属于最小干预方案

### 5. 同步文档边界

- 更新 `docs/a2ui.md`
- 明确 `useSessionManager` 虽然仍为兼容保留，但新增代码已经被 lint 与 UI CI 禁止导入
- 文档、实现、CI 三者在 session feature 正式入口上保持一致

## 关键实现细节

- 这次不是删除 `useSessionManager`，而是把它彻底降格为只能被动兼容、不能继续被新代码依赖的遗留入口
- 架构护栏采用“两层设计”：
  - ESLint 负责开发期即时反馈
  - CI guard 负责 PR 级强制阻断
- CI guard 选择独立脚本而不是直接跑全量 lint，是为了避免当前仓库历史 lint 债务影响本次边界收口目标
- 该策略符合最小干预原则：既增加了真实约束，又没有把现有无关问题一并升级成发布阻塞

## 验证

已执行：

- `pnpm --dir apps/negentropy-ui lint:legacy-session-imports`
- `pnpm --dir apps/negentropy-ui typecheck`
- `pnpm --dir apps/negentropy-ui test -- tests/unit/features/session/useSessionListService.test.ts tests/unit/features/session/useSessionService.test.ts tests/integration/home-flow.test.tsx`

结果：

- legacy import guard 通过
- `typecheck` 通过
- `vitest` 43 个测试文件、249 个测试全部通过

附加说明：

- 额外确认过全量 `pnpm --dir apps/negentropy-ui lint` 当前仍会因为仓库既有无关问题失败，因此本 PR 没有把它直接提升为新的 CI 门禁
