### PR TITLE
fix(knowledge): 统一 Pipelines 与 Dashboard 的 Runs 状态样式;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
@@ -5,11 +5,17 @@ import { useCallback, useEffect, useState } from "react";
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import {
+  calculateStageWidth,
   fetchPipelines,
+  formatDuration,
+  getPipelineStatusColor,
+  getSortedStages,
+  getStageColor,
   KnowledgePipelinesPayload,
+  PipelineStatusBadge,
   PipelineRunRecord,
-  PipelineStageResult,
   upsertPipelines,
+  STAGE_LABELS,
 } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -19,23 +25,6 @@ const BOOTSTRAP_POLL_MAX_TICKS = 8;
 
 type RunRecord = PipelineRunRecord;
 
-// 阶段顺序定义（用于排序显示）
-const STAGE_ORDER = [
-  "extract_resolve",
-  "extract_primary",
-  "extract_failover_1",
-  "extract_failover_2",
-  "extract_assets_store",
-  "extract_finalize",
-  "fetch",
-  "download",
-  "extract",
-  "delete",
-  "chunk",
-  "embed",
-  "persist",
-];
-
 // 操作类型中文名称
 const OPERATION_LABELS: Record<string, string> = {
   ingest_text: "文本摄入",
@@ -43,90 +32,6 @@ const OPERATION_LABELS: Record<string, string> = {
   replace_source: "替换源",
   sync_source: "同步源",
   rebuild_source: "重建源",
-};
-
-// 阶段名称中文名称
-const STAGE_LABELS: Record<string, string> = {
-  fetch: "获取内容",
-  download: "下载源文件",
-  extract: "提取内容",
-  extract_resolve: "解析提取路由",
-  extract_primary: "主 MCP 提取",
-  extract_failover_1: "备用 MCP 提取 1",
-  extract_failover_2: "备用 MCP 提取 2",
-  extract_assets_store: "存储提取资源",
-  extract_finalize: "整理提取结果",
-  delete: "删除旧记录",
-  chunk: "文本分块",
-  embed: "向量化",
-  persist: "持久化",
-};
-
-// 阶段颜色定义（每个阶段固定颜色，通过亮度区分状态）
-const STAGE_COLORS: Record<
-  string,
-  { running: string; completed: string; failed: string; skipped: string }
-> = {
-  fetch: {
-    running: "bg-sky-400",
-    completed: "bg-sky-500",
-    failed: "bg-sky-700",
-    skipped: "bg-sky-300 dark:bg-sky-600",
-  },
-  delete: {
-    running: "bg-rose-400",
-    completed: "bg-rose-500",
-    failed: "bg-rose-700",
-    skipped: "bg-rose-300 dark:bg-rose-600",
-  },
-  chunk: {
-    running: "bg-amber-400",
-    completed: "bg-amber-500",
-    failed: "bg-amber-700",
-    skipped: "bg-amber-300 dark:bg-amber-600",
-  },
-  embed: {
-    running: "bg-violet-400",
-    completed: "bg-violet-500",
-    failed: "bg-violet-700",
-    skipped: "bg-violet-300 dark:bg-violet-600",
-  },
-  persist: {
-    running: "bg-emerald-400",
-    completed: "bg-emerald-500",
-    failed: "bg-emerald-700",
-    skipped: "bg-emerald-300 dark:bg-emerald-600",
-  },
-};
-
-// 默认阶段颜色（未知阶段）
-const DEFAULT_STAGE_COLOR = {
-  running: "bg-zinc-400",
-  completed: "bg-zinc-500",
-  failed: "bg-zinc-700",
-  skipped: "bg-zinc-300 dark:bg-zinc-600",
-};
-
-// 获取阶段颜色
-const getStageColor = (stageName: string, status?: string): string => {
-  const colors = STAGE_COLORS[stageName] || DEFAULT_STAGE_COLOR;
-  const statusKey = (status || "").toLowerCase();
-
-  switch (statusKey) {
-    case "running":
-    case "in_progress":
-      return colors.running;
-    case "completed":
-    case "success":
-      return colors.completed;
-    case "failed":
-    case "error":
-      return colors.failed;
-    case "skipped":
-      return colors.skipped;
-    default:
-      return colors.completed;
-  }
 };
 
 // 检查是否有运行中的 Run
@@ -165,38 +70,6 @@ const isSameRunsSnapshot = (a: RunsSnapshot, b: RunsSnapshot): boolean => {
     a.firstStatus === b.firstStatus &&
     a.firstVersion === b.firstVersion
   );
-};
-
-// 计算 Stage 宽度（基于平方根比例，更好体现耗时差异）
-const calculateStageWidth = (
-  stage: { duration_ms?: number },
-  allStages: Record<string, { duration_ms?: number }>
-): string => {
-  const entries = Object.entries(allStages);
-  const stageCount = entries.length;
-
-  if (stageCount <= 1) return "100%";
-
-  // 使用平方根比例（比 log10 更能体现差异）
-  let totalSqrtDuration = 0;
-  for (const [, s] of entries) {
-    const duration = Math.max(s.duration_ms || 100, 10); // 最小 10ms
-    totalSqrtDuration += Math.sqrt(duration);
-  }
-
-  const currentDuration = Math.max(stage.duration_ms || 100, 10);
-  const currentSqrtDuration = Math.sqrt(currentDuration);
-
-  // 按比例分配
-  let width = (currentSqrtDuration / totalSqrtDuration) * 100;
-
-  // 动态最小宽度：stage 越多，最小宽度越小
-  const dynamicMinWidth = Math.max(5, Math.floor(100 / stageCount / 2));
-  const maxWidth = 100 - dynamicMinWidth * (stageCount - 1);
-
-  width = Math.max(dynamicMinWidth, Math.min(maxWidth, width));
-
-  return `${width.toFixed(1)}%`;
 };
 
 export default function KnowledgePipelinesPage() {
@@ -299,64 +172,10 @@ export default function KnowledgePipelinesPage() {
   }, [loadPipelines, payload?.runs]);
 
   const runs = payload?.runs || [];
-  const statusColor = (status?: string) => {
-    switch ((status || "").toLowerCase()) {
-      case "completed":
-      case "success":
-        return "bg-emerald-500";
-      case "running":
-      case "in_progress":
-        return "bg-amber-500";
-      case "failed":
-      case "error":
-        return "bg-rose-500";
-      case "skipped":
-        return "bg-zinc-300 dark:bg-zinc-600";
-      default:
-        return "bg-zinc-400";
-    }
-  };
-
-  const formatDuration = (durationMs?: number, startedAt?: string, completedAt?: string) => {
-    if (durationMs && durationMs > 0) {
-      if (durationMs < 1000) {
-        return `${durationMs}ms`;
-      }
-      const seconds = Math.round(durationMs / 1000);
-      return `${seconds}s`;
-    }
-    if (startedAt && completedAt) {
-      const start = new Date(startedAt).getTime();
-      const end = new Date(completedAt).getTime();
-      if (!Number.isNaN(start) && !Number.isNaN(end) && end >= start) {
-        const ms = end - start;
-        if (ms < 1000) {
-          return `${ms}ms`;
-        }
-        const seconds = Math.round(ms / 1000);
-        return `${seconds}s`;
-      }
-    }
-    return "-";
-  };
-
   const detailJsonClassName =
     "mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-zinc-50 p-3 text-[11px] dark:bg-zinc-800";
   const errorJsonClassName =
     "mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-rose-50 p-3 text-[11px] text-rose-700 dark:bg-rose-900/20 dark:text-rose-400";
-
-  // 获取排序后的阶段列表
-  const getSortedStages = (stages?: Record<string, PipelineStageResult>) => {
-    if (!stages) return [];
-    return Object.entries(stages).sort(([a], [b]) => {
-      const indexA = STAGE_ORDER.indexOf(a);
-      const indexB = STAGE_ORDER.indexOf(b);
-      if (indexA === -1 && indexB === -1) return a.localeCompare(b);
-      if (indexA === -1) return 1;
-      if (indexB === -1) return -1;
-      return indexA - indexB;
-    });
-  };
 
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
@@ -417,11 +236,10 @@ export default function KnowledgePipelinesPage() {
                         onClick={() => setSelected(run)}
                       >
                         <div className="flex min-w-0 items-center justify-between gap-3">
-                          <div className="flex min-w-0 items-center gap-2">
-                            <span className={`h-2 w-2 shrink-0 rounded-full ${statusColor(run.status)}`} />
+                          <div className="flex min-w-0 items-center gap-3">
                             <span className="truncate text-xs font-semibold">{run.run_id || run.id}</span>
                           </div>
-                          <span className="shrink-0 text-[11px] opacity-70">{run.status || "unknown"}</span>
+                          <PipelineStatusBadge status={run.status} className="shrink-0" />
                         </div>
                         <div className="mt-1 flex min-w-0 items-center justify-between gap-3 text-[11px] opacity-70">
                           <span className="truncate">
@@ -432,11 +250,13 @@ export default function KnowledgePipelinesPage() {
                         {/* 阶段进度条 */}
                         {run.stages && Object.keys(run.stages).length > 0 && (
                           <div className="mt-2 flex min-w-0 items-center gap-1 overflow-hidden">
-                            {getSortedStages(run.stages as Record<string, PipelineStageResult>).map(([stageName, stage]) => (
+                            {(() => {
+                              const stages = run.stages;
+                              return getSortedStages(stages).map(([stageName, stage]) => (
                               <div
                                 key={stageName}
                                 className="group relative min-w-0"
-                                style={{ width: calculateStageWidth(stage, run.stages as Record<string, PipelineStageResult>) }}
+                                style={{ width: calculateStageWidth(stage, stages) }}
                               >
                                 <div className={`h-1.5 w-full rounded-full ${getStageColor(stageName, stage.status)}`} />
                                 {/* Hover Tooltip */}
@@ -461,7 +281,8 @@ export default function KnowledgePipelinesPage() {
                                   )}
                                 </div>
                               </div>
-                            ))}
+                              ));
+                            })()}
                           </div>
                         )}
                       </button>
@@ -501,7 +322,7 @@ export default function KnowledgePipelinesPage() {
                         <div className="mt-2 space-y-2">
                           {getSortedStages(selected.stages).map(([stageName, stage]) => (
                             <div key={stageName} className="flex min-w-0 items-center gap-2 text-[11px]">
-                              <span className={`h-2 w-2 shrink-0 rounded-full ${statusColor(stage.status)}`} />
+                              <span className={`h-2 w-2 shrink-0 rounded-full ${getPipelineStatusColor(stage.status)}`} />
                               <span className="min-w-0 truncate font-medium text-zinc-700 dark:text-zinc-300">
                                 {STAGE_LABELS[stageName] || stageName}
                               </span>
@@ -570,7 +391,7 @@ export default function KnowledgePipelinesPage() {
                     {runs.map((run) => (
                       <div key={run.id} className="flex min-w-0 gap-3 text-xs text-zinc-600 dark:text-zinc-400">
                         <div className="flex shrink-0 flex-col items-center">
-                          <span className={`h-2 w-2 rounded-full ${statusColor(run.status)}`} />
+                          <span className={`h-2 w-2 rounded-full ${getPipelineStatusColor(run.status)}`} />
                           <span className="h-full w-px bg-zinc-200 dark:bg-zinc-700" />
                         </div>
                         <div className="min-w-0">

--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -2,9 +2,8 @@
 
 import Link from "next/link";
 import type { PipelineStageResult } from "../utils/knowledge-api";
+import { PipelineStatusBadge } from "./PipelineStatusBadge";
 import {
-  getPipelineStatusColor,
-  getPipelineStatusTextColor,
   formatRelativeTime,
   truncateRunId,
   OPERATION_LABELS,
@@ -77,27 +76,14 @@ export function PipelineRunCard({
                  dark:border-zinc-700 dark:bg-zinc-800/50 dark:hover:border-zinc-500
                  dark:hover:bg-zinc-800"
     >
-      {/* 第一行：状态指示器 + Run ID + 状态标签 */}
+      {/* 第一行：Run ID + 共享状态标签 */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          {/* 状态指示灯 */}
-          <span
-            className={`h-2 w-2 shrink-0 rounded-full ${getPipelineStatusColor(status)}`}
-            title={status}
-            role="status"
-            aria-label={`状态: ${status}`}
-          />
-          {/* Run ID */}
           <span className="font-mono text-xs font-medium text-zinc-700 dark:text-zinc-300">
             {truncateRunId(run_id)}
           </span>
         </div>
-        {/* 状态标签 */}
-        <span
-          className={`text-[11px] font-medium uppercase ${getPipelineStatusTextColor(status)}`}
-        >
-          {status}
-        </span>
+        <PipelineStatusBadge status={status} />
       </div>
 
       {/* 第二行：操作类型 + 触发方式 + 时长 + 版本 */}

--- a/apps/negentropy-ui/features/knowledge/components/PipelineStatusBadge.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineStatusBadge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  getPipelineStatusColor,
+  getPipelineStatusTextColor,
+} from "../utils/pipeline-helpers";
+
+interface PipelineStatusBadgeProps {
+  status?: string;
+  className?: string;
+}
+
+function joinClassNames(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+/**
+ * Pipeline 运行状态展示
+ *
+ * 采用 Dashboard 现有的状态点 + 文本语义，供 Dashboard / Pipelines 共享，
+ * 避免状态样式在多个页面漂移。
+ */
+export function PipelineStatusBadge({
+  status,
+  className,
+}: PipelineStatusBadgeProps) {
+  const label = status || "unknown";
+
+  return (
+    <span
+      className={joinClassNames("inline-flex items-center gap-2", className)}
+      role="status"
+      aria-label={`状态: ${label}`}
+    >
+      <span
+        className={joinClassNames(
+          "h-2 w-2 shrink-0 rounded-full",
+          getPipelineStatusColor(status),
+        )}
+        title={label}
+      />
+      <span
+        className={joinClassNames(
+          "text-[11px] font-medium uppercase",
+          getPipelineStatusTextColor(status),
+        )}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -194,6 +194,7 @@ export type {
 
 export { PipelineRunCard, PipelineRunList } from "./components/PipelineRunCard";
 export type { PipelineRunCardProps } from "./components/PipelineRunCard";
+export { PipelineStatusBadge } from "./components/PipelineStatusBadge";
 export { DocumentViewDialog } from "./components/DocumentViewDialog";
 
 // ============================================================================

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -35,13 +35,35 @@ export const TRIGGER_LABELS: Record<string, string> = {
 /**
  * 阶段顺序定义（用于排序显示）
  */
-export const STAGE_ORDER = ["fetch", "delete", "chunk", "embed", "persist"];
+export const STAGE_ORDER = [
+  "extract_resolve",
+  "extract_primary",
+  "extract_failover_1",
+  "extract_failover_2",
+  "extract_assets_store",
+  "extract_finalize",
+  "fetch",
+  "download",
+  "extract",
+  "delete",
+  "chunk",
+  "embed",
+  "persist",
+];
 
 /**
  * 阶段名称中文标签
  */
 export const STAGE_LABELS: Record<string, string> = {
   fetch: "获取内容",
+  download: "下载源文件",
+  extract: "提取内容",
+  extract_resolve: "解析提取路由",
+  extract_primary: "主 MCP 提取",
+  extract_failover_1: "备用 MCP 提取 1",
+  extract_failover_2: "备用 MCP 提取 2",
+  extract_assets_store: "存储提取资源",
+  extract_finalize: "整理提取结果",
   delete: "删除旧记录",
   chunk: "文本分块",
   embed: "向量化",
@@ -60,6 +82,54 @@ export const STAGE_COLORS: Record<
     completed: "bg-sky-500",
     failed: "bg-sky-700",
     skipped: "bg-sky-300 dark:bg-sky-600",
+  },
+  download: {
+    running: "bg-cyan-400",
+    completed: "bg-cyan-500",
+    failed: "bg-cyan-700",
+    skipped: "bg-cyan-300 dark:bg-cyan-600",
+  },
+  extract: {
+    running: "bg-indigo-400",
+    completed: "bg-indigo-500",
+    failed: "bg-indigo-700",
+    skipped: "bg-indigo-300 dark:bg-indigo-600",
+  },
+  extract_resolve: {
+    running: "bg-blue-400",
+    completed: "bg-blue-500",
+    failed: "bg-blue-700",
+    skipped: "bg-blue-300 dark:bg-blue-600",
+  },
+  extract_primary: {
+    running: "bg-fuchsia-400",
+    completed: "bg-fuchsia-500",
+    failed: "bg-fuchsia-700",
+    skipped: "bg-fuchsia-300 dark:bg-fuchsia-600",
+  },
+  extract_failover_1: {
+    running: "bg-pink-400",
+    completed: "bg-pink-500",
+    failed: "bg-pink-700",
+    skipped: "bg-pink-300 dark:bg-pink-600",
+  },
+  extract_failover_2: {
+    running: "bg-purple-400",
+    completed: "bg-purple-500",
+    failed: "bg-purple-700",
+    skipped: "bg-purple-300 dark:bg-purple-600",
+  },
+  extract_assets_store: {
+    running: "bg-teal-400",
+    completed: "bg-teal-500",
+    failed: "bg-teal-700",
+    skipped: "bg-teal-300 dark:bg-teal-600",
+  },
+  extract_finalize: {
+    running: "bg-lime-400",
+    completed: "bg-lime-500",
+    failed: "bg-lime-700",
+    skipped: "bg-lime-300 dark:bg-lime-600",
   },
   delete: {
     running: "bg-rose-400",

--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -8,6 +8,16 @@ import {
   normalizeCorpusExtractorRoutes,
   normalizeExtractorDraftRoutes,
 } from "@/features/knowledge/utils/knowledge-api";
+import {
+  calculateStageWidth,
+  formatDuration,
+  getPipelineStatusColor,
+  getSortedStages,
+  getStageColor,
+  OPERATION_LABELS,
+  STAGE_LABELS,
+} from "@/features/knowledge/utils/pipeline-helpers";
+import { PipelineStatusBadge } from "@/features/knowledge/components/PipelineStatusBadge";
 
 type VitestMock = Mock<(...args: unknown[]) => unknown>;
 
@@ -99,6 +109,14 @@ export function createKnowledgeConfigTestExports() {
     normalizeExtractorDraftRoutes,
     buildExtractorRoutesFromDraft,
     buildCorpusConfig,
+    OPERATION_LABELS,
+    STAGE_LABELS,
+    getPipelineStatusColor,
+    getStageColor,
+    formatDuration,
+    calculateStageWidth,
+    getSortedStages,
+    PipelineStatusBadge,
   };
 }
 

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelinesPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import type { KnowledgeFeatureMockSet } from "@/tests/helpers/knowledge";
 
 const knowledgeMocks = vi.hoisted(() => ({}) as KnowledgeFeatureMockSet);
@@ -204,5 +204,49 @@ describe("KnowledgePipelinesPage polling", () => {
     expect(screen.getAllByText("重建源").length).toBeGreaterThan(0);
     expect(screen.getByText("开始 2026-03-08T10:00:00Z")).toBeInTheDocument();
     expect(screen.getByText("结束 2026-03-08T10:02:00Z")).toBeInTheDocument();
+  });
+
+  it("Runs 列表状态标签复用 Dashboard 的共享状态样式", async () => {
+    knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      runs: [
+        makeRun({
+          id: "run-running-id",
+          run_id: "run-running",
+          status: "running",
+        }),
+        makeRun({
+          id: "run-completed-id",
+          run_id: "run-completed",
+          status: "completed",
+        }),
+        makeRun({
+          id: "run-failed-id",
+          run_id: "run-failed",
+          status: "failed",
+        }),
+      ],
+      last_updated_at: "t0",
+    });
+
+    const { container } = render(<KnowledgePipelinesPage />);
+    await settle();
+
+    const runningBadge = screen.getByLabelText("状态: running");
+    expect(runningBadge.className).toContain("inline-flex");
+    expect(runningBadge.querySelector("span")?.className).toContain("animate-pulse");
+    expect(within(runningBadge).getByText("running").className).toContain("text-amber-600");
+
+    const completedBadge = screen.getByLabelText("状态: completed");
+    expect(completedBadge.className).toContain("inline-flex");
+    expect(within(completedBadge).getByText("completed").className).toContain("text-emerald-600");
+
+    const failedBadge = screen.getByLabelText("状态: failed");
+    expect(failedBadge.className).toContain("inline-flex");
+    expect(within(failedBadge).getByText("failed").className).toContain("text-rose-600");
+
+    const selectedRunButton = Array.from(container.querySelectorAll("button")).find((element) =>
+      element.textContent?.includes("run-running")
+    );
+    expect(selectedRunButton?.className).toContain("bg-zinc-900");
   });
 });


### PR DESCRIPTION
## 变更内容

本次改动将 `Knowledge / Pipelines` 页面左侧 `Runs` 列表中的状态标签样式，与 `Knowledge / Dashboard` 页面 `Pipeline Runs` 中的状态呈现方式对齐，并将相关状态样式逻辑收敛为共享实现。

具体包括：
- 新增共享组件 `PipelineStatusBadge`，统一渲染 Pipeline 运行状态的圆点与文本标签。
- 将 `Knowledge / Dashboard` 的 `PipelineRunCard` 切换为复用共享状态组件。
- 将 `Knowledge / Pipelines` 页面中原本散落在页面内的状态颜色、时长格式化、阶段排序与阶段颜色逻辑改为复用 `features/knowledge` 下的共享 helper。
- 扩充共享阶段定义，补齐 `extract_*`、`download`、`extract` 等阶段的顺序、文案和颜色映射，避免页面对齐后丢失已有阶段语义。
- 更新测试桩与页面单测，验证 `Runs` 列表状态标签已复用 Dashboard 的共享样式，并保持原有轮询与选中态行为不回归。

## 改动原因

本次任务来自 UI 对齐需求：`Knowledge / Pipelines` 页的 `Runs` 状态标签样式需要与 `Dashboard` 页下的 `Runs` 状态样式保持一致。

在实现前，页面间存在两套状态呈现逻辑：
- `Dashboard` 使用 `features/knowledge` 中的共享 helper；
- `Pipelines` 页面在页内维护独立的状态颜色、阶段顺序和时长格式化逻辑。

这会带来典型的“双源定义”问题，后续一旦任一页面继续演进，就容易出现视觉漂移和维护成本上升。因此本次除了完成视觉对齐，还顺手按 Single Source of Truth / Reuse-Driven 原则，把状态样式与阶段语义收敛为共享实现，降低后续回归风险。

## 关键实现细节

- 状态标签对齐不是简单拷贝样式，而是抽出共享组件后由 `Dashboard` 和 `Pipelines` 同时消费。
- `Pipelines` 页面保留了原有业务行为，包括：
  - 首屏兜底轮询
  - running 状态自动刷新
  - Run 选中态与详情面板联动
  - 阶段进度条与 Timeline 展示
- 共享 helper 中补齐了扩展阶段的顺序与颜色映射，确保对齐过程中不引入功能退化。
- 测试层同步补齐 `@/features/knowledge` 的 mock 导出，避免页面改为共享组件后单测失真。

## 验证结果

已执行并通过：
- `cd apps/negentropy-ui && pnpm exec vitest --run tests/unit/knowledge/PipelinesPage.test.tsx`
- `cd apps/negentropy-ui && pnpm typecheck`