### PR TITLE
fix(Negentropy UI): 修复 @ag-ui/core@0.0.47 与 @copilotkitnext 类型不兼容导致的 TypeScript 编译失败

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -270,13 +270,13 @@ export function HomeBody({
       const createdAt = new Date();
       const newMessage = {
         id: messageId,
-        role: "user",
+        role: "user" as const,
         content: input.trim(),
         createdAt,
         runId,
         threadId: sessionId,
         streaming: false,
-      } as Message;
+      };
       appendOptimisticMessage(newMessage);
       agent.addMessage(newMessage);
       setScrollToBottomTrigger((prev) => prev + 1);

--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -62,10 +62,11 @@ export default function Home() {
     );
   }
 
-  const copilotAgents = agent ? { [AGENT_ID]: agent } : {};
+  const copilotAgents = agent ? { [AGENT_ID]: agent } : undefined;
 
   return (
     <CopilotKitProvider
+      // @ts-expect-error @ag-ui/core@0.0.47 新增 "reasoning" Message 角色与 @copilotkitnext 捆绑的旧版 @ag-ui/client 类型不兼容
       agents__unsafe_dev_only={copilotAgents}
       showDevConsole="auto"
     >

--- a/apps/negentropy-ui/types/agui.ts
+++ b/apps/negentropy-ui/types/agui.ts
@@ -13,6 +13,7 @@ import { safeParseBaseEventProps } from "@/lib/agui/schema";
  * 基础事件属性
  */
 export interface BaseEventProps {
+  [key: string]: unknown;
   threadId: string;
   runId: string;
   timestamp: number;


### PR DESCRIPTION
## 概要

修复 `pnpm build` 在 TypeScript 类型检查阶段因 `@ag-ui/core@0.0.47` 与 `@copilotkitnext/react` 捆绑的旧版 `@ag-ui/client` 之间的**钻石依赖类型冲突**导致的编译失败。

## 根因分析

`@ag-ui/core@0.0.47` 的 `Message` 联合类型新增了 `"reasoning"` 角色（7 种），而 `@copilotkitnext/react@1.51.3` 内部捆绑的 `@ag-ui/client` 仍使用旧版 `Message`（6 种，不含 `"reasoning"`）。两者的 `AbstractAgent` 在结构上不兼容，导致类型检查失败。

## 变更明细

| 文件 | 改动 | 说明 |
|------|------|------|
| `app/page.tsx:65` | `{} → undefined` | 三元表达式 falsy 分支返回 `undefined`，匹配 prop 的 `Record<string, AbstractAgent> \| undefined` 类型 |
| `app/page.tsx:69` | 添加 `@ts-expect-error` | 桥接 `@ag-ui/core` 新增 `"reasoning"` 角色与 `@copilotkitnext` 旧版类型的钻石依赖冲突 |
| `app/home-body.tsx:273` | `"user" as const` 替代 `as Message` | 使用精确字面量类型替代宽泛的联合类型断言，使 `addMessage()` 调用类型安全 |
| `types/agui.ts:15` | `BaseEventProps` 添加 `[key: string]: unknown` | 对齐 Zod passthrough schema 输出的 `BaseEvent` 索引签名约束 |

## 验证

- `pnpm build` 编译通过，无 TypeScript 错误
- 零功能影响：所有改动均为类型层面的调整，运行时行为不变

---

🤖 Generated with [Claude Code](https://github.com/claude)