### PR TITLE
fix(Negentropy UI): 移除无用 @ts-expect-error 指令，通过 pnpm overrides 统一 @ag-ui/* 版本消除类型分裂

### DIFF
--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -66,7 +66,6 @@ export default function Home() {
 
   return (
     <CopilotKitProvider
-      // @ts-expect-error @ag-ui/core@0.0.47 新增 "reasoning" Message 角色与 @copilotkitnext 捆绑的旧版 @ag-ui/client 类型不兼容
       agents__unsafe_dev_only={copilotAgents}
       showDevConsole="auto"
     >

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -38,6 +38,12 @@
     "sonner": "^2.0.7",
     "zod": "3.24.4"
   },
+  "pnpm": {
+    "overrides": {
+      "@ag-ui/client": "0.0.47",
+      "@ag-ui/core": "0.0.47"
+    }
+  },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ag-ui/client': 0.0.47
+  '@ag-ui/core': 0.0.47
+
 importers:
 
   .:
@@ -150,26 +154,14 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ag-ui/client@0.0.42':
-    resolution: {integrity: sha512-zAbP+sZJImR5bUpR2ni7RtuuNZMuesaxviynyIgzKlr1k2VCM49mFpbDUKU4TH4Cneu+Xe7OEnO8qCOCIzBAww==}
-
   '@ag-ui/client@0.0.47':
     resolution: {integrity: sha512-zciVwYV6gmYzdMyWwSDR/VBcOj5x1lHPG/ZGDKyxDHbCeIdGp7sKoGORKHAiPAsfUhReGLKXsR/4IknqwY2PgQ==}
-
-  '@ag-ui/core@0.0.42':
-    resolution: {integrity: sha512-C2hMg4Gs5oiUDgK9cA2RsTwSSmFZdIsqPklDrFw/Ue+quH6EU3vKp5YoOq7nuaQYO4pO8Em+Z+l5/M5PpcvP1g==}
 
   '@ag-ui/core@0.0.47':
     resolution: {integrity: sha512-fHat7ZErAH028R90psYclTWaj6PdcvN2GJxzwWPF/j1c5ceqbF2+6xe+t06Psg+gCzZneI9QE3IkOkdJNplZ5A==}
 
-  '@ag-ui/encoder@0.0.42':
-    resolution: {integrity: sha512-97B5MMCSs82t/y41uk2NrLBYFhbvn4kYsKQHMCfy8tjSWubyxh3zP7N9yHo8zJeSPe3WvzTvclyXNiGxSOsorg==}
-
   '@ag-ui/encoder@0.0.47':
     resolution: {integrity: sha512-AgKTM/DEHtaNrcbMa0z1UQ7lKiKtalbFAjBTTP0vCh+lJ6JWIu9LrpCJQ4EjON1IRoAZtJBORlCj1KY+F14HXQ==}
-
-  '@ag-ui/proto@0.0.42':
-    resolution: {integrity: sha512-NDUwSgMnGEqxZGkWIJ1ge5t3Q7Kiddj360x2JAWaIfv9w+7tDJ0pmgyzf3/SXp605aY2wZiDLBtJ6jKZeg1lFg==}
 
   '@ag-ui/proto@0.0.47':
     resolution: {integrity: sha512-+KCrkeVeR6MulWoYUq9Fwm22gFlI9aKG50eKYRtbTM/Yuei/Che5vjbF297XfSnGUunzScrOmdnTeTCprrtb7A==}
@@ -4326,19 +4318,6 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ag-ui/client@0.0.42':
-    dependencies:
-      '@ag-ui/core': 0.0.42
-      '@ag-ui/encoder': 0.0.42
-      '@ag-ui/proto': 0.0.42
-      '@types/uuid': 10.0.0
-      compare-versions: 6.1.1
-      fast-json-patch: 3.1.1
-      rxjs: 7.8.1
-      untruncate-json: 0.0.1
-      uuid: 11.1.0
-      zod: 3.24.4
-
   '@ag-ui/client@0.0.47':
     dependencies:
       '@ag-ui/core': 0.0.47
@@ -4352,31 +4331,15 @@ snapshots:
       uuid: 11.1.0
       zod: 3.24.4
 
-  '@ag-ui/core@0.0.42':
-    dependencies:
-      rxjs: 7.8.1
-      zod: 3.24.4
-
   '@ag-ui/core@0.0.47':
     dependencies:
       rxjs: 7.8.1
       zod: 3.24.4
 
-  '@ag-ui/encoder@0.0.42':
-    dependencies:
-      '@ag-ui/core': 0.0.42
-      '@ag-ui/proto': 0.0.42
-
   '@ag-ui/encoder@0.0.47':
     dependencies:
       '@ag-ui/core': 0.0.47
       '@ag-ui/proto': 0.0.47
-
-  '@ag-ui/proto@0.0.42':
-    dependencies:
-      '@ag-ui/core': 0.0.42
-      '@bufbuild/protobuf': 2.11.0
-      '@protobuf-ts/protoc': 2.11.1
 
   '@ag-ui/proto@0.0.47':
     dependencies:
@@ -4552,7 +4515,7 @@ snapshots:
 
   '@copilotkitnext/core@1.51.3':
     dependencies:
-      '@ag-ui/client': 0.0.42
+      '@ag-ui/client': 0.0.47
       '@copilotkitnext/shared': 1.51.3
       rxjs: 7.8.1
       zod: 3.25.76
@@ -4560,8 +4523,8 @@ snapshots:
 
   '@copilotkitnext/react@1.51.3(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@ag-ui/client': 0.0.42
-      '@ag-ui/core': 0.0.42
+      '@ag-ui/client': 0.0.47
+      '@ag-ui/core': 0.0.47
       '@copilotkitnext/core': 1.51.3
       '@copilotkitnext/shared': 1.51.3
       '@copilotkitnext/web-inspector': 1.51.3
@@ -4591,13 +4554,13 @@ snapshots:
 
   '@copilotkitnext/shared@1.51.3':
     dependencies:
-      '@ag-ui/client': 0.0.42
+      '@ag-ui/client': 0.0.47
       partial-json: 0.1.7
       uuid: 11.1.0
 
   '@copilotkitnext/web-inspector@1.51.3':
     dependencies:
-      '@ag-ui/client': 0.0.42
+      '@ag-ui/client': 0.0.47
       '@copilotkitnext/core': 1.51.3
       lit: 3.3.2
       lucide: 0.525.0


### PR DESCRIPTION
## 问题

`pnpm build` 编译失败：

```
./app/page.tsx:69:7
Type error: Unused '@ts-expect-error' directive.
```

## 根因分析

`@copilotkitnext@1.51.3` 精确锁定 `@ag-ui/client@0.0.42`，而项目直接依赖 `@ag-ui/client@0.0.47`。两个版本的 `AbstractAgent.messages` 类型定义不兼容（0.0.47 新增 `"reasoning"` 角色），导致：

- **版本分裂 (Split-Brain)**：同一项目中共存两套不兼容的 `@ag-ui/client` 类型定义
- 原有的 `@ts-expect-error` 指令在某些依赖解析场景下变为"未使用"而触发编译错误

## 修复方案

1. **`app/page.tsx`** — 移除已失效的 `@ts-expect-error` 注释
2. **`package.json`** — 添加 `pnpm.overrides` 将 `@ag-ui/client` 和 `@ag-ui/core` 统一强制解析为 `0.0.47`，从依赖层面根治版本分裂

## 验证

`pnpm build` 编译成功通过，TypeScript 类型检查无错误。

---
🤖 Generated with [Claude Code](https://github.com/claude)