### PR TITLE
fix(Negentropy UI): 修复首页 CopilotKitProvider 在无 Session 时因缺少必要 props 导致的崩溃

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { UseAgentUpdate, useAgent } from "@copilotkitnext/react";
 import { randomUUID } from "@ag-ui/client";
 import { EventType, Message, type BaseEvent } from "@ag-ui/core";
 
@@ -16,7 +15,7 @@ import { CHAT_CONTENT_RAIL_CLASS } from "../components/ui/chat-layout";
 import { useSessionListService } from "@/features/session/hooks/useSessionListService";
 import { useSessionService } from "@/features/session/hooks/useSessionService";
 
-import { useAgentSubscription } from "@/hooks/useAgentSubscription";
+import { useAgentSubscription, type AgentLike } from "@/hooks/useAgentSubscription";
 import { useConfirmationTool } from "@/hooks/useConfirmationTool";
 
 // 提取的工具函数
@@ -32,19 +31,42 @@ import type {
 export const AGENT_ID = "negentropy";
 export const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
+/** Agent 类型：兼容 NdjsonHttpAgent 与测试 Mock */
+export type HomeBodyAgent = AgentLike & {
+  isRunning: boolean;
+  addMessage: (message: Message) => void;
+  runAgent: (params: { runId: string }) => Promise<unknown>;
+};
+
+/**
+ * HITL 确认工具注册子组件
+ *
+ * 仅在 CopilotKitProvider 内部渲染，避免 useCopilotKit() context 缺失。
+ */
+function ConfirmationToolRegistrar({
+  onFollowup,
+}: {
+  onFollowup: (payload: { action: string; note: string }) => void;
+}) {
+  useConfirmationTool(onFollowup);
+  return null;
+}
+
 export function HomeBody({
+  agent,
   sessionId,
   userId,
   setSessionId,
+  pendingSendRef,
+  pendingForSessionRef,
 }: {
+  agent: HomeBodyAgent | null;
   sessionId: string | null;
   userId: string;
   setSessionId: (id: string | null) => void;
+  pendingSendRef: React.MutableRefObject<string | null>;
+  pendingForSessionRef: React.MutableRefObject<string | null>;
 }) {
-  const { agent } = useAgent({
-    agentId: AGENT_ID,
-    updates: [UseAgentUpdate.OnMessagesChanged, UseAgentUpdate.OnStateChanged],
-  });
   const [connection, setConnection] = useState<ConnectionState>("idle");
   const [showLeftPanel, setShowLeftPanel] = useState(true);
   const [showRightPanel, setShowRightPanel] = useState(false);
@@ -58,8 +80,6 @@ export function HomeBody({
   const updateSessionTimeRef = useRef<
     ((currentSessionId: string) => void) | undefined
   >(undefined);
-  const pendingSendRef = useRef<string | null>(null);
-  const pendingForSessionRef = useRef<string | null>(null);
   const [isCreatingSession, setIsCreatingSession] = useState(false);
 
   const addLog = useCallback(
@@ -237,8 +257,6 @@ export function HomeBody({
     ],
   );
 
-  useConfirmationTool(handleConfirmationFollowup);
-
   // Escape key to return to live view
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -411,6 +429,9 @@ export function HomeBody({
 
   return (
     <div className="h-full flex flex-col bg-zinc-50 text-zinc-900 overflow-hidden dark:bg-zinc-950 dark:text-zinc-100">
+      {agent && (
+        <ConfirmationToolRegistrar onFollowup={handleConfirmationFollowup} />
+      )}
       <div className="flex h-full overflow-hidden relative">
         {/* Left Sidebar: Session List */}
         <div

--- a/apps/negentropy-ui/app/page.tsx
+++ b/apps/negentropy-ui/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { CopilotKitProvider } from "@copilotkitnext/react";
 
@@ -13,6 +13,8 @@ import { AGENT_ID, APP_NAME, HomeBody } from "./home-body";
 export default function Home() {
   const { user, status: authStatus, login } = useAuth();
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const pendingSendRef = useRef<string | null>(null);
+  const pendingForSessionRef = useRef<string | null>(null);
 
   const agent = useMemo(() => {
     if (!user || !sessionId) {
@@ -62,18 +64,24 @@ export default function Home() {
     );
   }
 
-  const copilotAgents = agent ? { [AGENT_ID]: agent } : undefined;
+  const homeBodyProps = {
+    sessionId,
+    userId: user.userId,
+    setSessionId,
+    pendingSendRef,
+    pendingForSessionRef,
+  };
+
+  if (!agent) {
+    return <HomeBody agent={null} {...homeBodyProps} />;
+  }
 
   return (
     <CopilotKitProvider
-      agents__unsafe_dev_only={copilotAgents}
+      agents__unsafe_dev_only={{ [AGENT_ID]: agent }}
       showDevConsole="auto"
     >
-      <HomeBody
-        sessionId={sessionId}
-        userId={user.userId}
-        setSessionId={setSessionId}
-      />
+      <HomeBody agent={agent} {...homeBodyProps} />
     </CopilotKitProvider>
   );
 }

--- a/apps/negentropy-ui/tests/integration/home-flow.test.tsx
+++ b/apps/negentropy-ui/tests/integration/home-flow.test.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useRef, useState } from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EventType } from "@ag-ui/core";
@@ -73,12 +73,17 @@ vi.mock("@/components/providers/AuthProvider", () => ({
 
 function Wrapper({ sessionId }: { sessionId: string | null }) {
   const [currentSession, setCurrentSession] = useState(sessionId);
+  const pendingSendRef = useRef<string | null>(null);
+  const pendingForSessionRef = useRef<string | null>(null);
 
   return (
     <HomeBody
+      agent={mockAgent}
       sessionId={currentSession}
       userId="ui"
       setSessionId={setCurrentSession}
+      pendingSendRef={pendingSendRef}
+      pendingForSessionRef={pendingForSessionRef}
     />
   );
 }


### PR DESCRIPTION
## 问题描述

打开首页时，应用崩溃并显示"遇到错误"页面，浏览器控制台报错：

```
Error: Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'
```

## 根因分析

`CopilotKitProvider` 在 `sessionId` 为 null（初始状态）时被无条件渲染，此时 `agents__unsafe_dev_only` 为 `undefined`：

- **生产环境**：Provider 直接 `throw new Error("Missing required prop: ...")`
- **开发环境**：Provider `console.warn` 后，`useAgent` 因无已注册 Agent 而 `throw`

两种环境均被 ErrorBoundary 捕获，导致首页完全不可用。

通过阅读 `@copilotkitnext/react@1.51.3` 编译产物确认：传入空对象 `{}` 无法规避（Provider 内部已将 `undefined` 默认为 `{}`，且 `hasLocalAgents` 对空对象仍判为 `false`），必须从渲染结构上阻止。

## 修复方案

**条件渲染 CopilotKitProvider + Agent Prop 注入**：

### `page.tsx`
- `CopilotKitProvider` 仅在 `agent` 就绪时挂载
- `pendingSendRef` / `pendingForSessionRef` 上提至 `page.tsx`，防止 HomeBody remount 时丢失 pending message

### `home-body.tsx`
- `agent` 改为 prop 注入，移除 `useAgent` hook 调用
- 提取 `ConfirmationToolRegistrar` 子组件，仅在 `agent !== null` 时渲染（确保在 CopilotKitProvider 上下文内）
- 导出 `HomeBodyAgent` 类型，兼容 `NdjsonHttpAgent` 与测试 Mock

### `home-flow.test.tsx`
- 适配新增的 `agent`、`pendingSendRef`、`pendingForSessionRef` props

## 验证

- ✅ TypeScript 编译通过
- ✅ 全部 333 个测试通过（1 个预存失败与本次修改无关）
- ✅ 涉及的 9 个集成测试全部通过（含"无 Session 时发送消息自动创建会话"场景）