### PR TITLE
fix(mcp): 修复 Data Extractor 预置配置自愈逻辑;

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/b4d7e2f9a1c3_reconcile_data_extractor_preset.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/b4d7e2f9a1c3_reconcile_data_extractor_preset.py
@@ -1,0 +1,82 @@
+"""reconcile data extractor preset
+
+Revision ID: b4d7e2f9a1c3
+Revises: a9d3f7b21c4e
+Create Date: 2026-03-22 08:45:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+import negentropy.models.base
+
+# revision identifiers, used by Alembic.
+revision: str = "b4d7e2f9a1c3"
+down_revision: Union[str, None] = "a9d3f7b21c4e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Reconcile Data Extractor to the official system preset configuration."""
+
+    schema = negentropy.models.base.NEGENTROPY_SCHEMA
+    op.execute(
+        f"""
+        INSERT INTO {schema}.mcp_servers (
+            owner_id,
+            visibility,
+            name,
+            display_name,
+            description,
+            transport_type,
+            command,
+            args,
+            env,
+            url,
+            headers,
+            is_enabled,
+            auto_start,
+            config
+        )
+        VALUES (
+            'system:data-extractor-preset',
+            'PUBLIC'::{schema}.pluginvisibility,
+            'data-extractor',
+            'Data Extractor',
+            '一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。',
+            'http',
+            NULL,
+            '[]'::jsonb,
+            '{{}}'::jsonb,
+            'http://localhost:8081/mcp',
+            '{{}}'::jsonb,
+            TRUE,
+            TRUE,
+            '{{}}'::jsonb
+        )
+        ON CONFLICT (name) DO UPDATE
+        SET
+            owner_id = EXCLUDED.owner_id,
+            visibility = EXCLUDED.visibility,
+            display_name = EXCLUDED.display_name,
+            description = EXCLUDED.description,
+            transport_type = EXCLUDED.transport_type,
+            command = EXCLUDED.command,
+            args = EXCLUDED.args,
+            env = EXCLUDED.env,
+            url = EXCLUDED.url,
+            headers = EXCLUDED.headers,
+            is_enabled = EXCLUDED.is_enabled,
+            auto_start = EXCLUDED.auto_start,
+            config = EXCLUDED.config,
+            updated_at = now()
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade is a no-op because the previous migration already owns the preset row."""
+

--- a/apps/negentropy/tests/integration_tests/db/test_migrations.py
+++ b/apps/negentropy/tests/integration_tests/db/test_migrations.py
@@ -7,12 +7,21 @@ from sqlalchemy import create_engine, text
 from negentropy.config import settings
 
 
-CURRENT_HEAD = "a9d3f7b21c4e"
-PREVIOUS_HEAD = "f2c3d4e5a6b7"
+CURRENT_HEAD = "b4d7e2f9a1c3"
+PRESET_SEED_HEAD = "a9d3f7b21c4e"
 
 
 def _sync_database_url() -> str:
     return str(settings.database_url).replace("postgresql+asyncpg", "postgresql+psycopg")
+
+
+@pytest.fixture(autouse=True)
+def reset_database(alembic_config: Config):
+    """Keep migration tests isolated from the developer database."""
+
+    command.downgrade(alembic_config, "base")
+    yield
+    command.downgrade(alembic_config, "base")
 
 
 @pytest.fixture
@@ -48,7 +57,7 @@ def test_migrations_stairway(alembic_config: Config):
 
 
 def test_data_extractor_seeded_by_migration(alembic_config: Config):
-    """Ensure the Data Extractor MCP server is seeded with the expected runtime config."""
+    """Ensure the Data Extractor MCP server is present with the official preset config."""
 
     command.upgrade(alembic_config, "head")
 
@@ -85,49 +94,33 @@ def test_data_extractor_seeded_by_migration(alembic_config: Config):
     assert row["auto_start"] is True
 
 
-def test_data_extractor_seed_skips_existing_manual_record(alembic_config: Config):
-    """Ensure the seed migration does not overwrite a pre-existing data-extractor server."""
+def test_data_extractor_seed_repairs_existing_manual_record(alembic_config: Config):
+    """Ensure the latest migration reconciles a polluted manual record back to the official preset."""
 
-    command.downgrade(alembic_config, "base")
-    command.upgrade(alembic_config, PREVIOUS_HEAD)
+    command.upgrade(alembic_config, PRESET_SEED_HEAD)
 
     engine = create_engine(_sync_database_url())
     try:
         with engine.begin() as conn:
             conn.execute(
                 text("""
-                    INSERT INTO negentropy.mcp_servers (
-                        owner_id,
-                        visibility,
-                        name,
-                        display_name,
-                        description,
-                        transport_type,
-                        command,
-                        args,
-                        env,
-                        url,
-                        headers,
-                        is_enabled,
-                        auto_start,
-                        config
-                    )
-                    VALUES (
-                        'google:manual-owner',
-                        'PRIVATE'::negentropy.pluginvisibility,
-                        'data-extractor',
-                        'Manual Override',
-                        'manual record should win',
-                        'http',
-                        NULL,
-                        '[]'::jsonb,
-                        '{}'::jsonb,
-                        'http://manual.example/mcp',
-                        '{}'::jsonb,
-                        FALSE,
-                        FALSE,
-                        '{}'::jsonb
-                    )
+                    UPDATE negentropy.mcp_servers
+                    SET
+                        owner_id = 'google:manual-owner',
+                        visibility = 'PRIVATE'::negentropy.pluginvisibility,
+                        display_name = 'Manual Override',
+                        description = 'manual record should win',
+                        transport_type = 'http',
+                        command = NULL,
+                        args = '[]'::jsonb,
+                        env = '{}'::jsonb,
+                        url = 'http://manual.example/mcp',
+                        headers = '{}'::jsonb,
+                        is_enabled = FALSE,
+                        auto_start = FALSE,
+                        config = '{}'::jsonb,
+                        updated_at = now()
+                    WHERE name = 'data-extractor'
                 """)
             )
     finally:
@@ -155,10 +148,12 @@ def test_data_extractor_seed_skips_existing_manual_record(alembic_config: Config
     finally:
         engine.dispose()
 
-    assert row["owner_id"] == "google:manual-owner"
-    assert row["visibility"] == "PRIVATE"
-    assert row["display_name"] == "Manual Override"
-    assert row["description"] == "manual record should win"
-    assert row["url"] == "http://manual.example/mcp"
-    assert row["is_enabled"] is False
-    assert row["auto_start"] is False
+    assert row["owner_id"] == "system:data-extractor-preset"
+    assert row["visibility"] == "PUBLIC"
+    assert row["display_name"] == "Data Extractor"
+    assert row["description"] == (
+        "一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
+    )
+    assert row["url"] == "http://localhost:8081/mcp"
+    assert row["is_enabled"] is True
+    assert row["auto_start"] is True


### PR DESCRIPTION
## 变更内容

本 PR 在系统 MCP Hub 中引入并修复 `Data Extractor` 预置 MCP Server，包含两步连续变更：

- 新增 Alembic migration，通过原生 SQL 在 `negentropy.mcp_servers` 中预置 `data-extractor`
- 新增 follow-up reconciliation migration，在存在同名脏数据时强制将 `data-extractor` 回正为官方预置配置
- 调整迁移集成测试：
  - 更新 migration head 校验
  - 验证 `data-extractor` 预置字段正确
  - 验证同名脏记录会被修复回官方配置
  - 为迁移测试增加数据库重置逻辑，避免测试污染开发库

当前官方预置配置包括：

- `name`: `data-extractor`
- `display_name`: `Data Extractor`
- `description`: 一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。
- `transport_type`: `http`
- `url`: `http://localhost:8081/mcp`
- `visibility`: `PUBLIC`
- `is_enabled`: `true`
- `auto_start`: `true`
- `owner_id`: `system:data-extractor-preset`

## 变更原因

原始目标是通过预插 SQL 的方式，在 MCP Hub 中内置 `Data Extractor`，减少新环境初始化成本。

但在实际验证中发现，一个迁移测试场景会把本地数据库中的 `data-extractor` 改写成手工覆盖值，例如：

- `display_name = Manual Override`
- `visibility = PRIVATE`
- `is_enabled = false`
- `url = http://manual.example/mcp`

而原始预置 migration 使用 `ON CONFLICT (name) DO NOTHING`，导致系统预置在遇到同名污染记录时无法自愈，最终直接表现为 UI 上标题、状态、可见性、描述和 tools 数量异常。

因此本 PR 不仅完成初始预置，还补上了“系统预置优先”的修复逻辑，确保 `data-extractor` 作为系统预置项能够回归官方配置，并防止迁移测试继续污染开发数据库。

## 关键实现细节

### 1. 预置 migration

首条 migration 负责通过 SQL 将 `data-extractor` 写入 `negentropy.mcp_servers`，作为系统默认可用的 MCP Server。

### 2. 自愈 migration

新增 reconciliation migration，使用 `INSERT ... ON CONFLICT (name) DO UPDATE` 将 `data-extractor` 回正为官方配置。这样即使数据库中已经存在同名错误记录，也会在升级到最新 head 后恢复为正确状态。

### 3. 可见性语义修正

虽然最初需求描述里写的是 `Shared`，但当前系统权限模型中：

- `PUBLIC` 才会天然对所有用户可见
- `SHARED` 仍依赖额外授权记录

因此实际预置值采用 `PUBLIC`，以保证 Data Extractor 在现有实现下能被正常看到和使用。

### 4. 测试隔离

迁移测试增加自动 `downgrade base` 的隔离逻辑，确保测试运行前后数据库都回到干净状态，避免再次把开发环境中的 `data-extractor` 污染成 `Manual Override`。

## 验证结果

已覆盖并验证：

- migration 图保持单 head
- stairway upgrade/downgrade/upgrade 正常通过
- `data-extractor` 预置字段正确
- 同名脏记录会被修复回官方配置
