### PR TITLE
fix(mcp): 调整 MCP 服务卡片标签布局与文案;

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -677,6 +677,22 @@ interface McpServerCardProps {
   loadError?: string | null;
 }
 
+function formatTransportTypeLabel(transportType: string): string {
+  if (transportType === "http") {
+    return "HTTP(Streamable)";
+  }
+
+  return transportType;
+}
+
+function formatVisibilityLabel(visibility: string): string {
+  if (visibility === "public") {
+    return "Public";
+  }
+
+  return visibility;
+}
+
 export function McpServerCard({
   server,
   onEdit,
@@ -691,6 +707,8 @@ export function McpServerCard({
   const visibleToolCount = tools.length > 0 ? tools.length : server.tool_count;
   const showToolToggle = visibleToolCount > 0 || loadingTools;
   const summaryDescription = server.description?.trim() || "No description";
+  const toolSummaryLabel =
+    loadingTools && visibleToolCount === 0 ? "Loading tools..." : `${visibleToolCount} Tools`;
 
   const expandedTool = useMemo(
     () => tools.find((tool) => tool.name === expandedToolName) || null,
@@ -771,11 +789,19 @@ export function McpServerCard({
               </span>
             )}
             <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
-              {server.transport_type}
+              {formatTransportTypeLabel(server.transport_type)}
             </span>
             <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-              {server.visibility}
+              {formatVisibilityLabel(server.visibility)}
             </span>
+            {server.auto_start && (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                Auto-start
+              </span>
+            )}
           </div>
 
           <p
@@ -786,12 +812,6 @@ export function McpServerCard({
           </p>
 
           <div className="mt-auto flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-zinc-400 dark:text-zinc-500">
-            <span className="inline-flex shrink-0 items-center gap-1">
-              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
-              </svg>
-              {loadingTools && visibleToolCount === 0 ? "Loading tools..." : `${visibleToolCount} tools`}
-            </span>
             {showToolToggle && (
               <button
                 type="button"
@@ -816,15 +836,20 @@ export function McpServerCard({
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                 )}
-                Tools
+                <span className="inline-flex items-center gap-1">
+                  <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
+                  </svg>
+                  {toolSummaryLabel}
+                </span>
               </button>
             )}
-            {server.auto_start && (
-              <span className="inline-flex shrink-0 items-center gap-1 text-amber-600 dark:text-amber-400">
+            {!showToolToggle && (
+              <span className="inline-flex shrink-0 items-center gap-1">
                 <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
                 </svg>
-                Auto-start
+                {toolSummaryLabel}
               </span>
             )}
           </div>

--- a/apps/negentropy-ui/tests/unit/plugins/McpServerCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/McpServerCard.test.tsx
@@ -103,4 +103,56 @@ describe("McpServerCard", () => {
     expect(screen.queryByText("Output Schema")).not.toBeInTheDocument();
     expect(screen.queryByText("Advanced Metadata")).not.toBeInTheDocument();
   });
+
+  it("renders formatted badges and merged tools toggle", () => {
+    render(
+      <McpServerCard
+        server={{
+          ...server,
+          transport_type: "http",
+          visibility: "public",
+          auto_start: true,
+          tool_count: 14,
+        }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onLoad={vi.fn()}
+        tools={Array.from({ length: 14 }, (_, index) => ({
+          ...tool,
+          id: `tool-${index + 1}`,
+          name: `demo_tool_${index + 1}`,
+          title: `Demo Tool ${index + 1}`,
+        }))}
+      />
+    );
+
+    expect(screen.getByText("HTTP(Streamable)")).toBeInTheDocument();
+    expect(screen.getByText("Public")).toBeInTheDocument();
+    expect(screen.getByText("Auto-start")).toBeInTheDocument();
+
+    const toggleButton = screen.getByRole("button", { name: /toggle tools list/i });
+    expect(toggleButton).toHaveTextContent("14 Tools");
+    expect(screen.queryByText("14 tools")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Tools$/)).not.toBeInTheDocument();
+
+    fireEvent.click(toggleButton);
+    expect(screen.getByRole("button", { name: "Demo Tool 1" })).toBeInTheDocument();
+  });
+
+  it("shows loading label inside the merged tools control", () => {
+    render(
+      <McpServerCard
+        server={{ ...server, tool_count: 0 }}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onLoad={vi.fn()}
+        tools={[]}
+        loadingTools
+      />
+    );
+
+    const toggleButton = screen.getByRole("button", { name: /toggle tools list/i });
+    expect(toggleButton).toHaveTextContent("Loading tools...");
+    expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+  });
 });


### PR DESCRIPTION
## 变更内容
- 调整 MCP 服务卡片的状态标签布局，将 `Auto-start` 徽标移动到顶部状态标签栏，与 `Enabled`、传输协议、可见性保持同列展示。
- 统一卡片中的展示文案：将 `http` 显示为 `HTTP(Streamable)`，将 `public` 显示为 `Public`，避免直接暴露底层枚举值。
- 合并底部工具数量与展开入口，将原先分离的 `14 tools` 与 `Tools` 开关收敛为单一控件，显示为数量加箭头，保留原有展开/收起行为。
- 补充 `McpServerCard` 单元测试，覆盖状态标签文案、合并后的工具入口以及加载态展示。

## 变更原因
- 本次调整直接响应任务上下文中的 UI 诉求，目的是降低卡片信息分裂带来的认知成本，提升 MCP Hub 中状态信息的可读性与一致性。
- 采用最小干预方式，仅收敛展示层结构与文案，不修改后端接口、数据契约或既有交互语义，避免引入不必要的功能风险。

## 实现细节
- 在 `McpServerCard` 内通过纯展示映射函数处理 `transport_type` 与 `visibility` 的显示文案，遵循展示层 Mapper 的经典模式，避免硬编码散落在 JSX 结构中。
- 保持 `handleToggleTools`、`onLoad`、工具详情展开、编辑、删除与刷新逻辑不变，本次仅调整 DOM 组织方式与文案呈现。
- 已补充对应单测，但当前工作树缺少 `apps/negentropy-ui` 的本地依赖，`vitest` 可执行入口不可用，因此尚未完成本地测试执行验证；该缺口已如实保留，未夸大验证结论。
