### PR TITLE
fix(overlay): 统一模态框空白点击关闭语义;

### DIFF
--- a/apps/negentropy-ui/components/ui/OverlayDismissLayer.tsx
+++ b/apps/negentropy-ui/components/ui/OverlayDismissLayer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import type { ComponentPropsWithoutRef, HTMLAttributes, ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -34,30 +35,33 @@ export function OverlayDismissLayer({
 }: OverlayDismissLayerProps) {
   if (!open) return null;
 
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const { className: contentPropsClassName, onClick, ...restContentProps } =
     contentProps ?? {};
 
-  const handleBackdropClick = () => {
+  const handleWrapperClick: NonNullable<HTMLAttributes<HTMLDivElement>["onClick"]> = (
+    event,
+  ) => {
     if (!dismissible || busy) return;
+    if (contentRef.current?.contains(event.target as Node)) return;
     onClose();
   };
 
   const handleContentClick: NonNullable<HTMLAttributes<HTMLDivElement>["onClick"]> = (
     event,
   ) => {
-    event.stopPropagation();
     onClick?.(event);
   };
 
   return (
-    <div className={cn("fixed inset-0 z-50", wrapperClassName)}>
+    <div className={cn("fixed inset-0 z-50", wrapperClassName)} onClick={handleWrapperClick}>
       <div
         data-testid={backdropTestId ?? "overlay-backdrop"}
         className={cn("absolute inset-0 bg-black/50 backdrop-blur-sm", backdropClassName)}
-        onClick={handleBackdropClick}
       />
       <div className={cn("relative", containerClassName)}>
         <div
+          ref={contentRef}
           data-testid={contentTestId}
           {...restContentProps}
           className={cn(contentClassName, contentPropsClassName)}

--- a/apps/negentropy-ui/tests/unit/ui/OverlayDismissLayer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/OverlayDismissLayer.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 describe("OverlayDismissLayer", () => {
-  it("点击 backdrop 会触发关闭，点击内容区不会", async () => {
+  it("点击内容区外空白会触发关闭，点击内容区不会", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
 
@@ -11,6 +11,7 @@ describe("OverlayDismissLayer", () => {
       <OverlayDismissLayer
         open
         onClose={onClose}
+        containerClassName="flex min-h-screen items-center justify-center p-4"
         backdropTestId="overlay-backdrop"
         contentTestId="overlay-content"
       >
@@ -21,11 +22,14 @@ describe("OverlayDismissLayer", () => {
     await user.click(screen.getByTestId("overlay-content"));
     expect(onClose).not.toHaveBeenCalled();
 
-    await user.click(screen.getByTestId("overlay-backdrop"));
+    const container = screen.getByTestId("overlay-content").parentElement;
+    expect(container).not.toBeNull();
+
+    await user.click(container!);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("busy 状态下点击 backdrop 不会触发关闭", async () => {
+  it("busy 状态下点击内容区外空白不会触发关闭", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
 
@@ -34,13 +38,31 @@ describe("OverlayDismissLayer", () => {
         open
         onClose={onClose}
         busy
-        backdropTestId="overlay-backdrop"
+        containerClassName="flex min-h-screen items-center justify-center p-4"
+        contentTestId="overlay-content"
       >
         <div>Busy Content</div>
       </OverlayDismissLayer>,
     );
 
-    await user.click(screen.getByTestId("overlay-backdrop"));
+    const container = screen.getByTestId("overlay-content").parentElement;
+    expect(container).not.toBeNull();
+
+    await user.click(container!);
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("点击 backdrop 仍会触发关闭", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <OverlayDismissLayer open onClose={onClose} backdropTestId="overlay-backdrop">
+        <div>Overlay Content</div>
+      </OverlayDismissLayer>,
+    );
+
+    await user.click(screen.getByTestId("overlay-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 变更内容

本 PR 统一修复了共享模态框基础层 `OverlayDismissLayer` 的关闭语义，并补充了对应单元测试。

具体包括：

- 将“关闭判定”从仅依赖 backdrop 点击，调整为基于内容容器边界的 outside click 判定
- 在 `OverlayDismissLayer` 中通过 `contentRef.contains(event.target)` 识别点击是否发生在模态内容外
- 保持现有 `dismissible` 与 `busy` 语义不变
- 保持模态内容区内部点击不会误触发关闭
- 更新 `OverlayDismissLayer` 单测，覆盖以下场景：
  - 点击内容区外空白会关闭
  - `busy` 状态下点击内容区外空白不会关闭
  - 点击 backdrop 仍然可以关闭

## 变更原因

当前多个模态框（例如 Edit Subagent 一类表单弹窗）虽然视觉上存在“模态框外空白区域”，但由于容器层会覆盖整屏，用户点击空白时实际命中的是容器而不是 backdrop，导致只能通过 Cancel 或关闭按钮退出。

这与常见模态框交互模式不一致，也增加了用户关闭弹窗的操作成本。此次修复的目标是将“点击模态框外空白关闭”统一收敛为基础组件能力，对齐全局同类弹窗语义，同时避免逐个业务弹窗打补丁。

## 重要实现细节

- 修复点集中在共享基础组件 `OverlayDismissLayer`，而不是各业务 Dialog 分散处理，遵循 Single Source of Truth
- 采用内容边界判定而不是继续依赖事件冒泡与 backdrop 命中，避免全屏 container 布局继续吞掉 outside click
- 没有扩展修改 `Escape`、焦点管理、Portal 结构等非本次需求范围内容，控制改动半径
- 回归测试覆盖真实问题路径，确保修复不会破坏已有 `busy` 与内容区点击语义

## 验证情况

已验证：

- `pnpm exec vitest run tests/unit/ui/OverlayDismissLayer.test.tsx`
- `pnpm typecheck`

备注：仓库当前全量测试中存在与本 PR 无关的既有失败，未在本次修复中处理。
