### PR TITLE
fix(navigation): 调整一级导航与接口模块文案;

### DIFF
--- a/apps/negentropy-ui/components/ui/PluginsNav.tsx
+++ b/apps/negentropy-ui/components/ui/PluginsNav.tsx
@@ -23,7 +23,7 @@ export function PluginsNav({
   const { setNavigationInfo } = useNavigation();
 
   useEffect(() => {
-    setNavigationInfo({ moduleLabel: "Plugins", pageTitle: title });
+    setNavigationInfo({ moduleLabel: "Interface", pageTitle: title });
     return () => {
       setNavigationInfo(null);
     };

--- a/apps/negentropy-ui/config/navigation.ts
+++ b/apps/negentropy-ui/config/navigation.ts
@@ -10,7 +10,7 @@ export type MainNavItem = NavItem;
 
 export const mainNavConfig: MainNavItem[] = [
   {
-    title: "Chat",
+    title: "Home",
     href: "/",
   },
   {
@@ -22,7 +22,7 @@ export const mainNavConfig: MainNavItem[] = [
     href: "/memory",
   },
   {
-    title: "Plugins",
+    title: "Interface",
     href: "/plugins",
   },
   {

--- a/apps/negentropy-ui/tests/unit/ui/MainNav.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MainNav.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MainNav } from "@/components/layout/MainNav";
+import { mainNavConfig } from "@/config/navigation";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+vi.mock("@/components/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: {
+      roles: ["admin"],
+    },
+  }),
+}));
+
+describe("MainNav", () => {
+  it("使用更新后的一级导航文案且不改变目标路由", () => {
+    render(<MainNav items={mainNavConfig} />);
+
+    const homeLink = screen.getByRole("link", { name: "Home" });
+    const interfaceLink = screen.getByRole("link", { name: "Interface" });
+
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute("href", "/");
+    expect(homeLink.className).toContain("bg-foreground");
+
+    expect(interfaceLink).toBeInTheDocument();
+    expect(interfaceLink).toHaveAttribute("href", "/plugins");
+
+    expect(screen.queryByRole("link", { name: "Chat" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Plugins" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/PluginsNav.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/PluginsNav.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PluginsNav } from "@/components/ui/PluginsNav";
+
+const setNavigationInfo = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/plugins/skills",
+}));
+
+vi.mock("@/components/providers/NavigationProvider", () => ({
+  useNavigation: () => ({
+    setNavigationInfo,
+  }),
+}));
+
+describe("PluginsNav", () => {
+  it("写入 Interface 模块标签并保持子导航高亮逻辑", () => {
+    render(<PluginsNav title="Skills" />);
+
+    expect(setNavigationInfo).toHaveBeenCalledWith({
+      moduleLabel: "Interface",
+      pageTitle: "Skills",
+    });
+
+    const skillsLink = screen.getByRole("link", { name: "Skills" });
+    expect(skillsLink).toBeInTheDocument();
+    expect(skillsLink).toHaveAttribute("href", "/plugins/skills");
+    expect(skillsLink.className).toContain("bg-foreground");
+
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveAttribute(
+      "href",
+      "/plugins",
+    );
+  });
+});


### PR DESCRIPTION
## 变更内容
- 将一级导航中的 `Chat` 调整为 `Home`
- 将一级导航中的 `Plugins` 调整为 `Interface`
- 将插件模块页眉面包屑中的模块标签同步调整为 `Interface`
- 新增主导航与插件导航单测，覆盖文案展示与模块标签写入行为

## 变更原因
- 对齐本次任务对一级导航命名的要求
- 保持导航入口与插件模块上下文命名一致，避免出现认知分裂
- 采用最小干预方式，仅调整展示层文案，不改变现有功能行为

## 实现说明
- 保持根路由 `/` 与插件路由 `/plugins` 不变
- 保持权限过滤、一级导航高亮与插件二级导航逻辑不变
- 未改动管理端权限标签或后端语义中的 `Chat` / `Plugins` 命名，避免扩大变更半径
- 通过 `mainNavConfig` 与 `PluginsNav` 两处单一事实源完成文案同步，符合配置驱动导航与上下文注入的既有模式

## 验证情况
- 已补充主导航与插件导航相关单测，覆盖导航文案与模块标签写入行为
- 本地尝试执行 `pnpm --dir apps/negentropy-ui typecheck` 与相关 `vitest` 时，由于当前环境缺少 `apps/negentropy-ui/node_modules`，无法找到 `tsc` 与 `vitest` 可执行文件，因此未能完成运行验证
