### PR TITLE
feat(mcp): 新增 MCP Server 试用白盒执行台与执行审计链路;

### DIFF
--- a/apps/negentropy-ui/app/api/plugins/_proxy.ts
+++ b/apps/negentropy-ui/app/api/plugins/_proxy.ts
@@ -152,6 +152,44 @@ export async function proxyPost(request: Request, path: string) {
   return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
 }
 
+export async function proxyPostFormData(request: Request, path: string) {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorResponse(
+      "PLUGINS_INTERNAL_ERROR",
+      "AGUI_BASE_URL is not configured",
+      500,
+    );
+  }
+
+  const formData = await request.formData();
+  const upstreamUrl = new URL(path, baseUrl);
+  const headers = extractForwardHeaders(request);
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers,
+      body: formData,
+      cache: "no-store",
+    });
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      `Upstream connection failed: ${String(error)}`,
+      502,
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return upstreamErrorResponse(text, upstreamResponse.status);
+  }
+
+  return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+}
+
 export async function proxyPatch(request: Request, path: string) {
   const baseUrl = getBaseUrl();
   if (!baseUrl) {

--- a/apps/negentropy-ui/app/api/plugins/mcp/runs/[runId]/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/mcp/runs/[runId]/route.ts
@@ -1,0 +1,9 @@
+import { proxyGet } from "@/app/api/plugins/_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const { runId } = await params;
+  return proxyGet(request, `/plugins/mcp/runs/${runId}`);
+}

--- a/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/execute/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/execute/route.ts
@@ -1,0 +1,9 @@
+import { proxyPost } from "@/app/api/plugins/_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ serverId: string }> },
+) {
+  const { serverId } = await params;
+  return proxyPost(request, `/plugins/mcp/servers/${serverId}/tools:execute`);
+}

--- a/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/runs/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/runs/route.ts
@@ -1,0 +1,9 @@
+import { proxyGet } from "@/app/api/plugins/_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ serverId: string }> },
+) {
+  const { serverId } = await params;
+  return proxyGet(request, `/plugins/mcp/servers/${serverId}/runs`);
+}

--- a/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/trial-assets/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/mcp/servers/[serverId]/trial-assets/route.ts
@@ -1,0 +1,9 @@
+import { proxyPostFormData } from "@/app/api/plugins/_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ serverId: string }> },
+) {
+  const { serverId } = await params;
+  return proxyPostFormData(request, `/plugins/mcp/servers/${serverId}/trial-assets`);
+}

--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -669,6 +669,7 @@ interface McpTool {
 
 interface McpServerCardProps {
   server: McpServer;
+  onTry: () => void;
   onEdit: () => void;
   onDelete: () => void;
   onLoad: () => void;
@@ -695,6 +696,7 @@ function formatVisibilityLabel(visibility: string): string {
 
 export function McpServerCard({
   server,
+  onTry,
   onEdit,
   onDelete,
   onLoad,
@@ -737,6 +739,17 @@ export function McpServerCard({
               {server.display_name || server.name}
             </h3>
             <div className="flex shrink-0 items-center gap-2">
+              <button
+                onClick={onTry}
+                className="rounded-md p-2 text-zinc-400 hover:bg-emerald-50 hover:text-emerald-600 dark:hover:bg-emerald-900/20 dark:hover:text-emerald-400"
+                title="Try MCP Server"
+                aria-label={`Try ${server.display_name || server.name}`}
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-5.197-3.03A1 1 0 008 9.03v5.94a1 1 0 001.555.832l5.197-3.03a1 1 0 000-1.664z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </button>
               <button
                 onClick={onLoad}
                 disabled={loadingTools}

--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerTrialDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerTrialDialog.tsx
@@ -1,0 +1,596 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { JsonViewer } from "@/components/ui/JsonViewer";
+
+interface McpServer {
+  id: string;
+  name: string;
+  display_name: string | null;
+}
+
+interface McpTool {
+  id: string | null;
+  name: string;
+  title: string | null;
+  display_name: string | null;
+  description: string | null;
+  input_schema: Record<string, unknown>;
+  output_schema: Record<string, unknown>;
+  is_enabled: boolean;
+  call_count: number;
+}
+
+interface McpToolRunEvent {
+  id: string;
+  run_id: string;
+  sequence_num: number;
+  stage: string;
+  status: string;
+  title: string;
+  detail: string | null;
+  payload: Record<string, unknown>;
+  duration_ms: number;
+  timestamp: string | null;
+}
+
+interface McpToolRun {
+  id: string;
+  server_id: string;
+  tool_id: string | null;
+  tool_name: string;
+  origin: string;
+  status: string;
+  created_by: string | null;
+  request_payload: Record<string, unknown>;
+  normalized_request_payload: Record<string, unknown>;
+  result_payload: Record<string, unknown>;
+  error_summary: string | null;
+  duration_ms: number;
+  started_at: string | null;
+  ended_at: string | null;
+  events?: McpToolRunEvent[];
+}
+
+interface ExecuteToolResponse {
+  success: boolean;
+  run: McpToolRun;
+  error: string | null;
+}
+
+interface McpServerTrialDialogProps {
+  isOpen: boolean;
+  server: McpServer | null;
+  tools: McpTool[];
+  onClose: () => void;
+  onEnsureTools: (serverId: string) => Promise<void>;
+}
+
+type FormMode = "guided" | "raw";
+
+function classifyTool(toolName: string): string {
+  if (toolName.includes("markdown")) return "Markdown 转换";
+  if (toolName.includes("pdf")) return "PDF 转换";
+  if (toolName === "get_server_metrics" || toolName === "clear_cache") return "运维";
+  if (toolName.includes("extract") || toolName.includes("fill_")) return "抓取与抽取";
+  return "页面探测";
+}
+
+function buildInitialValues(tool: McpTool | null): Record<string, unknown> {
+  const properties = ((tool?.input_schema.properties as Record<string, Record<string, unknown>>) || {});
+  const next: Record<string, unknown> = {};
+  for (const [key, schema] of Object.entries(properties)) {
+    if (schema.default !== undefined) {
+      next[key] = schema.default;
+      continue;
+    }
+    if (schema.type === "boolean") {
+      next[key] = false;
+      continue;
+    }
+    if (schema.type === "array") {
+      next[key] = [];
+      continue;
+    }
+    next[key] = "";
+  }
+  return next;
+}
+
+function buildRawJson(tool: McpTool | null): string {
+  return JSON.stringify(buildInitialValues(tool), null, 2);
+}
+
+function formatTime(value: string | null): string {
+  if (!value) return "-";
+  return new Date(value).toLocaleString();
+}
+
+export function McpServerTrialDialog({
+  isOpen,
+  server,
+  tools,
+  onClose,
+  onEnsureTools,
+}: McpServerTrialDialogProps) {
+  const [selectedToolName, setSelectedToolName] = useState<string | null>(null);
+  const [formMode, setFormMode] = useState<FormMode>("guided");
+  const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+  const [rawJson, setRawJson] = useState("{}");
+  const [singlePdfFile, setSinglePdfFile] = useState<File | null>(null);
+  const [batchPdfFiles, setBatchPdfFiles] = useState<File[]>([]);
+  const [history, setHistory] = useState<McpToolRun[]>([]);
+  const [activeRun, setActiveRun] = useState<McpToolRun | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [executing, setExecuting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !server) return;
+    if (tools.length === 0) {
+      void onEnsureTools(server.id);
+    }
+  }, [isOpen, server, tools.length, onEnsureTools]);
+
+  const groupedTools = useMemo(() => {
+    const groups = new Map<string, McpTool[]>();
+    for (const tool of tools.filter((item) => item.is_enabled)) {
+      const group = classifyTool(tool.name);
+      const list = groups.get(group) || [];
+      list.push(tool);
+      groups.set(group, list);
+    }
+    return Array.from(groups.entries());
+  }, [tools]);
+
+  const selectedTool = useMemo(
+    () => tools.find((tool) => tool.name === selectedToolName) || null,
+    [selectedToolName, tools],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!selectedToolName && tools.length > 0) {
+      setSelectedToolName(tools[0].name);
+    }
+  }, [isOpen, selectedToolName, tools]);
+
+  useEffect(() => {
+    setFormValues(buildInitialValues(selectedTool));
+    setRawJson(buildRawJson(selectedTool));
+    setSinglePdfFile(null);
+    setBatchPdfFiles([]);
+    setError(null);
+  }, [selectedToolName, selectedTool]);
+
+  useEffect(() => {
+    if (!isOpen || !server || !selectedTool) return;
+    setHistoryLoading(true);
+    void fetch(`/api/plugins/mcp/servers/${server.id}/runs?tool_name=${selectedTool.name}`)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("Failed to load execution history");
+        }
+        return response.json();
+      })
+      .then((runs: McpToolRun[]) => {
+        setHistory(runs);
+        setActiveRun((current) => current && current.tool_name === selectedTool.name ? current : runs[0] || null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load execution history");
+      })
+      .finally(() => setHistoryLoading(false));
+  }, [isOpen, server, selectedTool]);
+
+  const loadRunDetail = async (runId: string) => {
+    const response = await fetch(`/api/plugins/mcp/runs/${runId}`);
+    if (!response.ok) {
+      throw new Error("Failed to load run detail");
+    }
+    const detail: McpToolRun = await response.json();
+    setActiveRun(detail);
+  };
+
+  const uploadTrialAsset = async (file: File) => {
+    if (!server) {
+      throw new Error("Server not selected");
+    }
+    const formData = new FormData();
+    formData.set("file", file);
+    const response = await fetch(`/api/plugins/mcp/servers/${server.id}/trial-assets`, {
+      method: "POST",
+      body: formData,
+    });
+    if (!response.ok) {
+      throw new Error("Failed to upload trial asset");
+    }
+    const result = await response.json();
+    return result.id as string;
+  };
+
+  const buildGuidedArguments = (): Record<string, unknown> => {
+    const args: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(formValues)) {
+      if (Array.isArray(value)) {
+        if (value.length > 0) args[key] = value;
+        continue;
+      }
+      if (value !== "" && value !== null && value !== undefined) {
+        args[key] = value;
+      }
+    }
+    return args;
+  };
+
+  const handleExecute = async () => {
+    if (!server || !selectedTool) return;
+    setExecuting(true);
+    setError(null);
+
+    try {
+      const argumentsPayload =
+        formMode === "raw" ? (JSON.parse(rawJson) as Record<string, unknown>) : buildGuidedArguments();
+      const assetRefs: Record<string, unknown> = {};
+
+      if (singlePdfFile) {
+        assetRefs.pdf_source = await uploadTrialAsset(singlePdfFile);
+      }
+      if (batchPdfFiles.length > 0) {
+        assetRefs.pdf_sources = await Promise.all(batchPdfFiles.map(uploadTrialAsset));
+      }
+
+      const response = await fetch(`/api/plugins/mcp/servers/${server.id}/execute`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tool_name: selectedTool.name,
+          arguments: argumentsPayload,
+          asset_refs: assetRefs,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to execute tool");
+      }
+      const result: ExecuteToolResponse = await response.json();
+      setActiveRun(result.run);
+      await loadRunDetail(result.run.id);
+      const historyResponse = await fetch(`/api/plugins/mcp/servers/${server.id}/runs?tool_name=${selectedTool.name}`);
+      if (historyResponse.ok) {
+        const runs: McpToolRun[] = await historyResponse.json();
+        setHistory(runs);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to execute tool");
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const renderGuidedField = (name: string, schema: Record<string, unknown>) => {
+    const label = schema.description ? `${name} · ${schema.description}` : name;
+    if (name === "pdf_source") {
+      return (
+        <div key={name} className="space-y-2">
+          <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-300">{label}</label>
+          <input
+            value={String(formValues[name] || "")}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, [name]: event.target.value }))}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+            placeholder="PDF URL，或改用下方文件上传"
+          />
+          <input type="file" accept="application/pdf" onChange={(event) => setSinglePdfFile(event.target.files?.[0] || null)} />
+        </div>
+      );
+    }
+    if (name === "pdf_sources") {
+      return (
+        <div key={name} className="space-y-2">
+          <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-300">{label}</label>
+          <textarea
+            value={Array.isArray(formValues[name]) ? (formValues[name] as string[]).join("\n") : ""}
+            onChange={(event) =>
+              setFormValues((prev) => ({
+                ...prev,
+                [name]: event.target.value
+                  .split("\n")
+                  .map((item) => item.trim())
+                  .filter(Boolean),
+              }))
+            }
+            rows={4}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+            placeholder="每行一个 PDF URL，或改用下方多文件上传"
+          />
+          <input
+            type="file"
+            accept="application/pdf"
+            multiple
+            onChange={(event) => setBatchPdfFiles(Array.from(event.target.files || []))}
+          />
+        </div>
+      );
+    }
+
+    const fieldType = schema.type;
+    if (fieldType === "boolean") {
+      return (
+        <label key={name} className="flex items-center gap-2 text-sm text-zinc-700 dark:text-zinc-300">
+          <input
+            type="checkbox"
+            checked={Boolean(formValues[name])}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, [name]: event.target.checked }))}
+          />
+          {label}
+        </label>
+      );
+    }
+    if (fieldType === "array") {
+      return (
+        <div key={name} className="space-y-2">
+          <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-300">{label}</label>
+          <textarea
+            value={Array.isArray(formValues[name]) ? (formValues[name] as string[]).join("\n") : ""}
+            onChange={(event) =>
+              setFormValues((prev) => ({
+                ...prev,
+                [name]: event.target.value
+                  .split("\n")
+                  .map((item) => item.trim())
+                  .filter(Boolean),
+              }))
+            }
+            rows={4}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+          />
+        </div>
+      );
+    }
+    if (fieldType === "object" || schema.additionalProperties || schema.anyOf) {
+      return (
+        <div key={name} className="space-y-2">
+          <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-300">{label}</label>
+          <textarea
+            value={
+              typeof formValues[name] === "string"
+                ? String(formValues[name])
+                : JSON.stringify(formValues[name] || {}, null, 2)
+            }
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setFormValues((prev) => {
+                try {
+                  return { ...prev, [name]: JSON.parse(nextValue) };
+                } catch {
+                  return { ...prev, [name]: nextValue };
+                }
+              });
+            }}
+            rows={6}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 font-mono text-xs dark:border-zinc-700 dark:bg-zinc-950"
+          />
+        </div>
+      );
+    }
+    return (
+      <div key={name} className="space-y-2">
+        <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-300">{label}</label>
+        <input
+          type={fieldType === "integer" || fieldType === "number" ? "number" : "text"}
+          value={String(formValues[name] ?? "")}
+          onChange={(event) =>
+            setFormValues((prev) => ({
+              ...prev,
+              [name]:
+                fieldType === "integer" || fieldType === "number"
+                  ? Number(event.target.value)
+                  : event.target.value,
+            }))
+          }
+          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-950"
+        />
+      </div>
+    );
+  };
+
+  if (!isOpen || !server) return null;
+
+  return (
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={onClose}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="flex h-[90vh] w-full max-w-[1400px] flex-col rounded-2xl bg-white p-6 shadow-xl dark:bg-zinc-900"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            试用 MCP Server: {server.display_name || server.name}
+          </h2>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">
+            白盒查看参数、执行阶段、结果与历史审计。
+          </p>
+        </div>
+        <button onClick={onClose} className="rounded-md p-2 text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800">
+          关闭
+        </button>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-12 gap-4">
+        <div className="col-span-3 min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+          <div className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">Tools</div>
+          <div className="h-full overflow-auto space-y-4">
+            {groupedTools.map(([group, items]) => (
+              <div key={group}>
+                <div className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">{group}</div>
+                <div className="space-y-1">
+                  {items.map((tool) => (
+                    <button
+                      key={tool.name}
+                      onClick={() => setSelectedToolName(tool.name)}
+                      className={`w-full rounded-lg border px-3 py-2 text-left ${
+                        selectedToolName === tool.name
+                          ? "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/30 dark:text-blue-300"
+                          : "border-zinc-200 bg-zinc-50 text-zinc-700 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-300"
+                      }`}
+                    >
+                      <div className="font-mono text-xs">{tool.display_name || tool.title || tool.name}</div>
+                      <div className="mt-1 text-[11px] text-zinc-500">{tool.call_count} calls</div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="col-span-4 min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+          <div className="mb-3 flex items-center justify-between">
+            <div>
+              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                {selectedTool?.display_name || selectedTool?.title || selectedTool?.name || "选择 Tool"}
+              </div>
+              <div className="text-xs text-zinc-500">{selectedTool?.description || "暂无描述"}</div>
+            </div>
+            <div className="flex gap-2 text-xs">
+              <button
+                className={`rounded px-2 py-1 ${formMode === "guided" ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900" : "bg-zinc-100 dark:bg-zinc-800"}`}
+                onClick={() => setFormMode("guided")}
+              >
+                表单
+              </button>
+              <button
+                className={`rounded px-2 py-1 ${formMode === "raw" ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900" : "bg-zinc-100 dark:bg-zinc-800"}`}
+                onClick={() => setFormMode("raw")}
+              >
+                Raw JSON
+              </button>
+            </div>
+          </div>
+
+          <div className="h-[calc(100%-7rem)] overflow-auto space-y-3">
+            {formMode === "raw" ? (
+              <textarea
+                value={rawJson}
+                onChange={(event) => setRawJson(event.target.value)}
+                className="h-72 w-full rounded-lg border border-zinc-200 bg-zinc-50 p-3 font-mono text-xs dark:border-zinc-700 dark:bg-zinc-950"
+              />
+            ) : (
+              Object.entries(((selectedTool?.input_schema.properties as Record<string, Record<string, unknown>>) || {})).map(
+                ([name, schema]) => renderGuidedField(name, schema),
+              )
+            )}
+
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-950">
+              <div className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">Input Schema</div>
+              <JsonViewer data={selectedTool?.input_schema || {}} />
+            </div>
+          </div>
+
+          <div className="mt-3 flex items-center justify-between">
+            <div className="text-xs text-red-500">{error}</div>
+            <button
+              onClick={handleExecute}
+              disabled={!selectedTool || executing}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {executing ? "执行中..." : "试用该 Tool"}
+            </button>
+          </div>
+        </div>
+
+        <div className="col-span-5 grid min-h-0 grid-rows-[220px_minmax(0,1fr)] gap-4">
+          <div className="min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+            <div className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">执行历史</div>
+            <div className="h-full overflow-auto space-y-2">
+              {historyLoading ? (
+                <div className="text-sm text-zinc-500">加载中...</div>
+              ) : history.length === 0 ? (
+                <div className="text-sm text-zinc-500">暂无执行历史</div>
+              ) : (
+                history.map((run) => (
+                  <button
+                    key={run.id}
+                    onClick={() => void loadRunDetail(run.id)}
+                    className={`w-full rounded-lg border px-3 py-2 text-left ${
+                      activeRun?.id === run.id
+                        ? "border-blue-200 bg-blue-50 dark:border-blue-700 dark:bg-blue-950/30"
+                        : "border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-950"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-mono text-xs">{run.tool_name}</span>
+                      <span className="text-[11px] text-zinc-500">{run.status}</span>
+                    </div>
+                    <div className="mt-1 text-[11px] text-zinc-500">
+                      {run.origin} · {run.duration_ms} ms · {formatTime(run.started_at)}
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+            <div className="mb-3 flex items-center justify-between">
+              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">白盒详情</div>
+              <div className="text-xs text-zinc-500">{activeRun ? `${activeRun.status} · ${activeRun.duration_ms} ms` : "-"}</div>
+            </div>
+            <div className="h-full overflow-auto space-y-4">
+              {!activeRun ? (
+                <div className="text-sm text-zinc-500">选择一条执行记录查看详情</div>
+              ) : (
+                <>
+                  <div className="grid grid-cols-2 gap-3 text-xs">
+                    <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-950">
+                      <div className="mb-1 font-medium text-zinc-600 dark:text-zinc-300">原始参数</div>
+                      <JsonViewer data={activeRun.request_payload} />
+                    </div>
+                    <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-950">
+                      <div className="mb-1 font-medium text-zinc-600 dark:text-zinc-300">归一化参数</div>
+                      <JsonViewer data={activeRun.normalized_request_payload} />
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-950">
+                    <div className="mb-1 text-xs font-medium text-zinc-600 dark:text-zinc-300">结果</div>
+                    <JsonViewer data={activeRun.result_payload} />
+                  </div>
+
+                  <div className="rounded-lg bg-zinc-50 p-3 dark:bg-zinc-950">
+                    <div className="mb-2 text-xs font-medium text-zinc-600 dark:text-zinc-300">阶段时间线</div>
+                    <div className="space-y-2">
+                      {(activeRun.events || []).map((event) => (
+                        <div key={event.id} className="rounded border border-zinc-200 p-2 dark:border-zinc-700">
+                          <div className="flex items-center justify-between">
+                            <div className="text-xs font-medium text-zinc-800 dark:text-zinc-100">
+                              {event.sequence_num}. {event.title}
+                            </div>
+                            <div className="text-[11px] text-zinc-500">
+                              {event.stage} · {event.status}
+                            </div>
+                          </div>
+                          {event.detail ? <div className="mt-1 text-xs text-zinc-500">{event.detail}</div> : null}
+                          {Object.keys(event.payload || {}).length > 0 ? (
+                            <div className="mt-2 rounded bg-zinc-100 p-2 dark:bg-zinc-950">
+                              <JsonViewer data={event.payload} />
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="text-xs text-zinc-500">
+                    开始时间：{formatTime(activeRun.started_at)} | 结束时间：{formatTime(activeRun.ended_at)}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/plugins/mcp/page.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/page.tsx
@@ -5,6 +5,7 @@ import { MCP_HUB_LABEL } from "@/app/plugins/copy";
 import { PluginsNav } from "@/components/ui/PluginsNav";
 import { McpServerCard } from "./_components/McpServerCard";
 import { McpServerFormDialog } from "./_components/McpServerFormDialog";
+import { McpServerTrialDialog } from "./_components/McpServerTrialDialog";
 
 interface McpTool {
   id: string | null;
@@ -62,6 +63,7 @@ export default function McpServersPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingServer, setEditingServer] = useState<McpServer | null>(null);
   const [hasAutoRequestedTools, setHasAutoRequestedTools] = useState(false);
+  const [trialServer, setTrialServer] = useState<McpServer | null>(null);
 
   const fetchServers = async () => {
     try {
@@ -149,6 +151,7 @@ export default function McpServersPage() {
             : s
         )
       );
+      return data.tools;
     } catch (err) {
       setServers((prev) =>
         prev.map((s) =>
@@ -161,6 +164,7 @@ export default function McpServersPage() {
             : s
         )
       );
+      return [];
     }
   };
 
@@ -187,6 +191,10 @@ export default function McpServersPage() {
   const handleDialogClose = () => {
     setDialogOpen(false);
     setEditingServer(null);
+  };
+
+  const handleTrialClose = () => {
+    setTrialServer(null);
   };
 
   const handleFormSubmit = async (data: Record<string, unknown>) => {
@@ -262,6 +270,7 @@ export default function McpServersPage() {
                   <div key={server.id} data-testid="mcp-grid-item">
                     <McpServerCard
                       server={server}
+                      onTry={() => setTrialServer(server)}
                       onEdit={() => handleEdit(server)}
                       onDelete={() => handleDelete(server.id)}
                       onLoad={() => handleLoadTools(server.id)}
@@ -282,6 +291,15 @@ export default function McpServersPage() {
         onClose={handleDialogClose}
         onSubmit={handleFormSubmit}
         server={editingServer}
+      />
+      <McpServerTrialDialog
+        isOpen={trialServer !== null}
+        server={trialServer}
+        tools={trialServer ? servers.find((server) => server.id === trialServer.id)?.tools || [] : []}
+        onClose={handleTrialClose}
+        onEnsureTools={async (serverId) => {
+          await handleLoadTools(serverId);
+        }}
       />
     </div>
   );

--- a/apps/negentropy-ui/tests/unit/plugins/McpLayout.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/McpLayout.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/app/plugins/mcp/_components/McpServerFormDialog", () => ({
   McpServerFormDialog: () => null,
 }));
 
+vi.mock("@/app/plugins/mcp/_components/McpServerTrialDialog", () => ({
+  McpServerTrialDialog: () => null,
+}));
+
 vi.mock("@/app/plugins/mcp/_components/McpServerCard", () => ({
   McpServerCard: ({ server }: { server: { name: string } }) => (
     <div data-testid="mcp-card">{server.name}</div>

--- a/apps/negentropy-ui/tests/unit/plugins/McpServerCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/McpServerCard.test.tsx
@@ -66,6 +66,7 @@ describe("McpServerCard", () => {
     render(
       <McpServerCard
         server={server}
+        onTry={vi.fn()}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onLoad={vi.fn()}
@@ -90,6 +91,7 @@ describe("McpServerCard", () => {
     render(
       <McpServerCard
         server={server}
+        onTry={vi.fn()}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onLoad={vi.fn()}
@@ -114,6 +116,7 @@ describe("McpServerCard", () => {
           auto_start: true,
           tool_count: 14,
         }}
+        onTry={vi.fn()}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onLoad={vi.fn()}
@@ -143,6 +146,7 @@ describe("McpServerCard", () => {
     render(
       <McpServerCard
         server={{ ...server, tool_count: 0 }}
+        onTry={vi.fn()}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onLoad={vi.fn()}
@@ -154,5 +158,20 @@ describe("McpServerCard", () => {
     const toggleButton = screen.getByRole("button", { name: /toggle tools list/i });
     expect(toggleButton).toHaveTextContent("Loading tools...");
     expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders try action button", () => {
+    render(
+      <McpServerCard
+        server={server}
+        onTry={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onLoad={vi.fn()}
+        tools={[tool]}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Try Demo Server" })).toBeInTheDocument();
   });
 });

--- a/apps/negentropy/src/negentropy/db/migrations/versions/e6f7a8b9c0d1_add_mcp_trial_runtime_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/e6f7a8b9c0d1_add_mcp_trial_runtime_tables.py
@@ -1,0 +1,139 @@
+"""add mcp trial runtime tables
+
+Revision ID: e6f7a8b9c0d1
+Revises: b4d7e2f9a1c3
+Create Date: 2026-03-22 10:30:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+import negentropy.models.base
+
+# revision identifiers, used by Alembic.
+revision: str = "e6f7a8b9c0d1"
+down_revision: Union[str, None] = "b4d7e2f9a1c3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    schema = negentropy.models.base.NEGENTROPY_SCHEMA
+
+    op.create_table(
+        "mcp_tool_runs",
+        sa.Column("server_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tool_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("tool_name", sa.String(length=255), nullable=False),
+        sa.Column("origin", sa.String(length=50), server_default="trial_ui", nullable=False),
+        sa.Column("status", sa.String(length=50), server_default="running", nullable=False),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column("request_payload", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.Column(
+            "normalized_request_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="{}",
+            nullable=False,
+        ),
+        sa.Column("result_payload", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.ForeignKeyConstraint(["server_id"], [f"{schema}.mcp_servers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tool_id"], [f"{schema}.mcp_tools.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        schema=schema,
+    )
+    op.create_index(
+        "ix_mcp_tool_runs_server_tool_started",
+        "mcp_tool_runs",
+        ["server_id", "tool_name", "started_at"],
+        unique=False,
+        schema=schema,
+    )
+    op.create_index(
+        "ix_mcp_tool_runs_origin_started",
+        "mcp_tool_runs",
+        ["origin", "started_at"],
+        unique=False,
+        schema=schema,
+    )
+
+    op.create_table(
+        "mcp_tool_run_events",
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sequence_num", sa.Integer(), nullable=False),
+        sa.Column("stage", sa.String(length=100), nullable=False),
+        sa.Column("status", sa.String(length=50), server_default="info", nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=True),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.Column("duration_ms", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("timestamp", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], [f"{schema}.mcp_tool_runs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", "sequence_num", name="mcp_tool_run_events_run_seq_unique"),
+        schema=schema,
+    )
+    op.create_index(
+        "ix_mcp_tool_run_events_run_timestamp",
+        "mcp_tool_run_events",
+        ["run_id", "timestamp"],
+        unique=False,
+        schema=schema,
+    )
+
+    op.create_table(
+        "mcp_trial_assets",
+        sa.Column("server_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_id", sa.String(length=255), nullable=False),
+        sa.Column("source_kind", sa.String(length=50), server_default="upload", nullable=False),
+        sa.Column("original_filename", sa.String(length=255), nullable=False),
+        sa.Column("content_type", sa.String(length=255), nullable=True),
+        sa.Column("size_bytes", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sha256", sa.String(length=64), nullable=False),
+        sa.Column("gcs_uri", sa.Text(), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.ForeignKeyConstraint(["server_id"], [f"{schema}.mcp_servers.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        schema=schema,
+    )
+    op.create_index(
+        "ix_mcp_trial_assets_server_created",
+        "mcp_trial_assets",
+        ["server_id", "created_at"],
+        unique=False,
+        schema=schema,
+    )
+    op.create_index(
+        "ix_mcp_trial_assets_owner_created",
+        "mcp_trial_assets",
+        ["owner_id", "created_at"],
+        unique=False,
+        schema=schema,
+    )
+
+
+def downgrade() -> None:
+    schema = negentropy.models.base.NEGENTROPY_SCHEMA
+
+    op.drop_index("ix_mcp_trial_assets_owner_created", table_name="mcp_trial_assets", schema=schema)
+    op.drop_index("ix_mcp_trial_assets_server_created", table_name="mcp_trial_assets", schema=schema)
+    op.drop_table("mcp_trial_assets", schema=schema)
+
+    op.drop_index("ix_mcp_tool_run_events_run_timestamp", table_name="mcp_tool_run_events", schema=schema)
+    op.drop_table("mcp_tool_run_events", schema=schema)
+
+    op.drop_index("ix_mcp_tool_runs_origin_started", table_name="mcp_tool_runs", schema=schema)
+    op.drop_index("ix_mcp_tool_runs_server_tool_started", table_name="mcp_tool_runs", schema=schema)
+    op.drop_table("mcp_tool_runs", schema=schema)

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -18,6 +18,7 @@ from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.plugin import McpServer, McpTool
+from negentropy.plugins.execution import McpToolExecutionService, RUN_ORIGIN_KNOWLEDGE_EXTRACTION
 from negentropy.serialization import to_json_compatible, to_json_compatible_strict
 from negentropy.storage.service import DocumentStorageService
 
@@ -1747,7 +1748,6 @@ class DataExtractorProvider:
                     target=target,
                     plan=plan,
                 )
-                await _increment_tool_call_count(server_id=target.server_id, tool_name=target.tool_name)
                 invocation_trace.append(
                     {
                         "attempt": index + 1,
@@ -1822,17 +1822,17 @@ class DataExtractorProvider:
         target: McpToolTarget,
         plan: AdaptiveToolInvocationPlan,
     ) -> Any:
-        return await self._client.call_tool(
-            transport_type=server.transport_type,
-            tool_name=target.tool_name,
-            arguments=plan.arguments,
-            command=server.command,
-            args=server.args,
-            env=server.env,
-            url=server.url,
-            headers=server.headers,
-            timeout_seconds=(target.timeout_ms / 1000.0) if target.timeout_ms else None,
-        )
+        async with AsyncSessionLocal() as db:
+            service = McpToolExecutionService(db, client=self._client)
+            execution = await service.execute_tool(
+                server=server,
+                user=None,
+                tool_name=target.tool_name,
+                arguments=plan.arguments,
+                origin=RUN_ORIGIN_KNOWLEDGE_EXTRACTION,
+                timeout_seconds=(target.timeout_ms / 1000.0) if target.timeout_ms else None,
+            )
+            return execution.call_result
 
     def _build_success_result(
         self,

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -4,7 +4,18 @@ from .internalization import ConsolidationJob, Fact, Instruction, Memory, Memory
 from .knowledge_runtime import KnowledgeGraphRun, KnowledgePipelineRun
 from .observability import Trace
 from .perception import Corpus, Knowledge
-from .plugin import McpServer, McpTool, PluginPermission, PluginPermissionType, PluginVisibility, Skill, SubAgent
+from .plugin import (
+    McpServer,
+    McpTool,
+    McpToolRun,
+    McpToolRunEvent,
+    McpTrialAsset,
+    PluginPermission,
+    PluginPermissionType,
+    PluginVisibility,
+    Skill,
+    SubAgent,
+)
 from .pulse import AppState, Event, Message, Run, Snapshot, Thread, UserState
 from .security import Credential
 
@@ -49,6 +60,9 @@ __all__ = [
     "PluginPermission",
     "McpServer",
     "McpTool",
+    "McpToolRun",
+    "McpToolRunEvent",
+    "McpTrialAsset",
     "Skill",
     "SubAgent",
 ]

--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -121,6 +121,78 @@ class McpTool(Base, UUIDMixin, TimestampMixin):
     server: Mapped["McpServer"] = relationship(back_populates="tools")
 
 
+class McpToolRun(Base, UUIDMixin):
+    """MCP Tool 执行记录。"""
+
+    __tablename__ = "mcp_tool_runs"
+
+    server_id: Mapped[UUID] = mapped_column(fk("mcp_servers", ondelete="CASCADE"), nullable=False)
+    tool_id: Mapped[Optional[UUID]] = mapped_column(fk("mcp_tools", ondelete="SET NULL"))
+    tool_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    origin: Mapped[str] = mapped_column(String(50), nullable=False, server_default="trial_ui")
+    status: Mapped[str] = mapped_column(String(50), nullable=False, server_default="running")
+    created_by: Mapped[Optional[str]] = mapped_column(String(255))
+    request_payload: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    normalized_request_payload: Mapped[Dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default="{}"
+    )
+    result_payload: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    error_summary: Mapped[Optional[str]] = mapped_column(Text)
+    duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    started_at: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
+    ended_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP)
+
+    __table_args__ = (
+        Index("ix_mcp_tool_runs_server_tool_started", "server_id", "tool_name", "started_at"),
+        Index("ix_mcp_tool_runs_origin_started", "origin", "started_at"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class McpToolRunEvent(Base, UUIDMixin):
+    """MCP Tool 执行阶段事件。"""
+
+    __tablename__ = "mcp_tool_run_events"
+
+    run_id: Mapped[UUID] = mapped_column(fk("mcp_tool_runs", ondelete="CASCADE"), nullable=False)
+    sequence_num: Mapped[int] = mapped_column(Integer, nullable=False)
+    stage: Mapped[str] = mapped_column(String(100), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, server_default="info")
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    detail: Mapped[Optional[str]] = mapped_column(Text)
+    payload: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    timestamp: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("run_id", "sequence_num", name="mcp_tool_run_events_run_seq_unique"),
+        Index("ix_mcp_tool_run_events_run_timestamp", "run_id", "timestamp"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class McpTrialAsset(Base, UUIDMixin, TimestampMixin):
+    """MCP 试用上传资产。"""
+
+    __tablename__ = "mcp_trial_assets"
+
+    server_id: Mapped[UUID] = mapped_column(fk("mcp_servers", ondelete="CASCADE"), nullable=False)
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_kind: Mapped[str] = mapped_column(String(50), nullable=False, server_default="upload")
+    original_filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    content_type: Mapped[Optional[str]] = mapped_column(String(255))
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    gcs_uri: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_: Mapped[Dict[str, Any]] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+
+    __table_args__ = (
+        Index("ix_mcp_trial_assets_server_created", "server_id", "created_at"),
+        Index("ix_mcp_trial_assets_owner_created", "owner_id", "created_at"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
 class Skill(Base, UUIDMixin, TimestampMixin):
     """技能模块定义"""
 

--- a/apps/negentropy/src/negentropy/plugins/api.py
+++ b/apps/negentropy/src/negentropy/plugins/api.py
@@ -6,12 +6,13 @@ Plugins API 模块。
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select, and_, or_
+from sqlalchemy import desc, func, select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
 
@@ -24,6 +25,9 @@ from negentropy.logging import get_logger
 from negentropy.models.plugin import (
     McpServer,
     McpTool,
+    McpToolRun,
+    McpToolRunEvent,
+    McpTrialAsset,
     PluginPermission,
     PluginPermissionType,
     PluginVisibility,
@@ -32,6 +36,7 @@ from negentropy.models.plugin import (
 )
 
 from .permissions import check_plugin_access, check_plugin_ownership, get_visible_plugin_ids
+from .execution import McpToolExecutionService
 from .subagent_presets import build_negentropy_subagent_payloads
 
 logger = get_logger("negentropy.plugins.api")
@@ -171,6 +176,65 @@ class LoadToolsResponse(BaseModel):
     server_id: UUID
     tools: List[McpToolResponse] = Field(default_factory=list)
     duration_ms: int = 0
+    error: Optional[str] = None
+
+
+class McpTrialAssetResponse(BaseModel):
+    id: UUID
+    server_id: UUID
+    owner_id: str
+    original_filename: str
+    content_type: Optional[str] = None
+    size_bytes: int
+    sha256: str
+    gcs_uri: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: Optional[str] = None
+
+
+class McpToolRunEventResponse(BaseModel):
+    id: UUID
+    run_id: UUID
+    sequence_num: int
+    stage: str
+    status: str
+    title: str
+    detail: Optional[str] = None
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    duration_ms: int = 0
+    timestamp: Optional[str] = None
+
+
+class McpToolRunSummaryResponse(BaseModel):
+    id: UUID
+    server_id: UUID
+    tool_id: Optional[UUID] = None
+    tool_name: str
+    origin: str
+    status: str
+    created_by: Optional[str] = None
+    request_payload: Dict[str, Any] = Field(default_factory=dict)
+    normalized_request_payload: Dict[str, Any] = Field(default_factory=dict)
+    result_payload: Dict[str, Any] = Field(default_factory=dict)
+    error_summary: Optional[str] = None
+    duration_ms: int = 0
+    started_at: Optional[str] = None
+    ended_at: Optional[str] = None
+
+
+class McpToolRunDetailResponse(McpToolRunSummaryResponse):
+    events: List[McpToolRunEventResponse] = Field(default_factory=list)
+
+
+class ExecuteToolRequest(BaseModel):
+    tool_name: str
+    arguments: Dict[str, Any] = Field(default_factory=dict)
+    asset_refs: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ExecuteToolResponse(BaseModel):
+    success: bool
+    run: McpToolRunDetailResponse
     error: Optional[str] = None
 
 
@@ -535,6 +599,64 @@ def _mcp_tool_to_response(tool: McpTool) -> McpToolResponse:
     )
 
 
+def _mcp_trial_asset_to_response(asset: McpTrialAsset) -> McpTrialAssetResponse:
+    return McpTrialAssetResponse(
+        id=asset.id,
+        server_id=asset.server_id,
+        owner_id=asset.owner_id,
+        original_filename=asset.original_filename,
+        content_type=asset.content_type,
+        size_bytes=asset.size_bytes,
+        sha256=asset.sha256,
+        gcs_uri=asset.gcs_uri,
+        metadata=asset.metadata_ or {},
+        created_at=asset.created_at.isoformat() if asset.created_at else None,
+    )
+
+
+def _mcp_tool_run_event_to_response(event: McpToolRunEvent) -> McpToolRunEventResponse:
+    return McpToolRunEventResponse(
+        id=event.id,
+        run_id=event.run_id,
+        sequence_num=event.sequence_num,
+        stage=event.stage,
+        status=event.status,
+        title=event.title,
+        detail=event.detail,
+        payload=event.payload or {},
+        duration_ms=event.duration_ms or 0,
+        timestamp=event.timestamp.isoformat() if event.timestamp else None,
+    )
+
+
+def _mcp_tool_run_to_response(
+    run: McpToolRun,
+    events: List[McpToolRunEvent] | None = None,
+) -> McpToolRunDetailResponse | McpToolRunSummaryResponse:
+    payload = dict(
+        id=run.id,
+        server_id=run.server_id,
+        tool_id=run.tool_id,
+        tool_name=run.tool_name,
+        origin=run.origin,
+        status=run.status,
+        created_by=run.created_by,
+        request_payload=run.request_payload or {},
+        normalized_request_payload=run.normalized_request_payload or {},
+        result_payload=run.result_payload or {},
+        error_summary=run.error_summary,
+        duration_ms=run.duration_ms or 0,
+        started_at=run.started_at.isoformat() if run.started_at else None,
+        ended_at=run.ended_at.isoformat() if run.ended_at else None,
+    )
+    if events is None:
+        return McpToolRunSummaryResponse(**payload)
+    return McpToolRunDetailResponse(
+        **payload,
+        events=[_mcp_tool_run_event_to_response(item) for item in events],
+    )
+
+
 # =============================================================================
 # MCP Tool Endpoints
 # =============================================================================
@@ -684,6 +806,127 @@ async def update_mcp_tool(
         await db.refresh(tool)
 
         return _mcp_tool_to_response(tool)
+
+
+@router.post("/mcp/servers/{server_id}/trial-assets", response_model=McpTrialAssetResponse)
+async def upload_mcp_trial_asset(
+    server_id: UUID,
+    file: UploadFile = File(...),
+    metadata: Optional[str] = Form(default=None),
+    user: AuthUser = Depends(get_current_user),
+) -> McpTrialAssetResponse:
+    """上传 MCP 试用文件到 GCS。"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "edit")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        server = await db.get(McpServer, server_id)
+        if not server:
+            raise HTTPException(status_code=404, detail="Server not found")
+
+        content = await file.read()
+        if not content:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+        extra_metadata: Dict[str, Any] = {}
+        if metadata:
+            try:
+                parsed = json.loads(metadata)
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=400, detail=f"Invalid metadata JSON: {exc}") from exc
+            if isinstance(parsed, dict):
+                extra_metadata = parsed
+
+        service = McpToolExecutionService(db)
+        asset = await service.upload_trial_asset(
+            server=server,
+            owner_id=user.user_id,
+            filename=file.filename or "upload.pdf",
+            content=content,
+            content_type=file.content_type,
+            metadata=extra_metadata,
+        )
+        return _mcp_trial_asset_to_response(asset)
+
+
+@router.post("/mcp/servers/{server_id}/tools:execute", response_model=ExecuteToolResponse)
+async def execute_mcp_tool(
+    server_id: UUID,
+    payload: ExecuteToolRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> ExecuteToolResponse:
+    """执行指定 MCP Tool 并记录白盒历史。"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "edit")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        server = await db.get(McpServer, server_id)
+        if not server:
+            raise HTTPException(status_code=404, detail="Server not found")
+
+        service = McpToolExecutionService(db)
+        execution = await service.execute_tool(
+            server=server,
+            user=user,
+            tool_name=payload.tool_name,
+            arguments=payload.arguments,
+            asset_refs=payload.asset_refs,
+        )
+        detail = _mcp_tool_run_to_response(execution.run, execution.events)
+        return ExecuteToolResponse(
+            success=execution.call_result.success,
+            run=detail,
+            error=execution.call_result.error,
+        )
+
+
+@router.get("/mcp/servers/{server_id}/runs", response_model=List[McpToolRunSummaryResponse])
+async def list_mcp_tool_runs(
+    server_id: UUID,
+    tool_name: Optional[str] = Query(default=None),
+    origin: Optional[str] = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=200),
+    user: AuthUser = Depends(get_current_user),
+) -> List[McpToolRunSummaryResponse]:
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "view")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        stmt = select(McpToolRun).where(McpToolRun.server_id == server_id)
+        if tool_name:
+            stmt = stmt.where(McpToolRun.tool_name == tool_name)
+        if origin:
+            stmt = stmt.where(McpToolRun.origin == origin)
+        stmt = stmt.order_by(desc(McpToolRun.started_at)).limit(limit)
+        result = await db.execute(stmt)
+        runs = result.scalars().all()
+        return [_mcp_tool_run_to_response(item) for item in runs]
+
+
+@router.get("/mcp/runs/{run_id}", response_model=McpToolRunDetailResponse)
+async def get_mcp_tool_run(
+    run_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> McpToolRunDetailResponse:
+    async with AsyncSessionLocal() as db:
+        run = await db.get(McpToolRun, run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail="Run not found")
+
+        has_access, error = await check_plugin_access(db, "mcp_server", run.server_id, user, "view")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        events_result = await db.execute(
+            select(McpToolRunEvent)
+            .where(McpToolRunEvent.run_id == run_id)
+            .order_by(McpToolRunEvent.sequence_num.asc())
+        )
+        events = events_result.scalars().all()
+        return _mcp_tool_run_to_response(run, list(events))
 
 
 # =============================================================================

--- a/apps/negentropy/src/negentropy/plugins/execution.py
+++ b/apps/negentropy/src/negentropy/plugins/execution.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from negentropy.auth.service import AuthUser
+from negentropy.logging import get_logger
+from negentropy.models.plugin import McpServer, McpTool, McpToolRun, McpToolRunEvent, McpTrialAsset
+from negentropy.storage.gcs_client import GCSStorageClient
+
+from .mcp_client import McpClientService, McpToolCallResult
+
+logger = get_logger("negentropy.plugins.execution")
+
+RUN_ORIGIN_TRIAL_UI = "trial_ui"
+RUN_ORIGIN_KNOWLEDGE_EXTRACTION = "knowledge_extraction"
+RUN_ORIGIN_SYSTEM = "system"
+
+
+@dataclass
+class ExecutionResult:
+    run: McpToolRun
+    events: list[McpToolRunEvent]
+    call_result: McpToolCallResult
+
+
+class McpToolExecutionService:
+    """统一的 MCP Tool 执行与审计服务。"""
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        *,
+        client: McpClientService | None = None,
+        gcs_client: GCSStorageClient | None = None,
+    ) -> None:
+        self._db = db
+        self._client = client or McpClientService()
+        self._gcs = gcs_client
+
+    async def upload_trial_asset(
+        self,
+        *,
+        server: McpServer,
+        owner_id: str,
+        filename: str,
+        content: bytes,
+        content_type: str | None,
+        metadata: dict[str, Any] | None = None,
+    ) -> McpTrialAsset:
+        safe_name = _sanitize_filename(filename)
+        sha256 = GCSStorageClient.compute_hash(content)
+        asset = McpTrialAsset(
+            server_id=server.id,
+            owner_id=owner_id,
+            original_filename=safe_name,
+            content_type=content_type,
+            size_bytes=len(content),
+            sha256=sha256,
+            gcs_uri=self._get_gcs_client().upload(
+                content=content,
+                gcs_path=f"mcp-trials/negentropy/{server.id}/{sha256[:12]}-{safe_name}",
+                content_type=content_type,
+            ),
+            metadata_=metadata or {},
+        )
+        self._db.add(asset)
+        await self._db.commit()
+        await self._db.refresh(asset)
+        return asset
+
+    async def execute_tool(
+        self,
+        *,
+        server: McpServer,
+        user: AuthUser | None,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+        asset_refs: dict[str, Any] | None = None,
+        origin: str = RUN_ORIGIN_TRIAL_UI,
+        timeout_seconds: float | None = None,
+    ) -> ExecutionResult:
+        tool = await self._db.scalar(
+            select(McpTool).where(McpTool.server_id == server.id, McpTool.name == tool_name)
+        )
+        initial_payload = _json_safe(arguments or {})
+        run = McpToolRun(
+            server_id=server.id,
+            tool_id=tool.id if tool else None,
+            tool_name=tool_name,
+            origin=origin,
+            status="running",
+            created_by=user.user_id if user else None,
+            request_payload=initial_payload,
+            normalized_request_payload={},
+            result_payload={},
+        )
+        self._db.add(run)
+        await self._db.flush()
+
+        events: list[McpToolRunEvent] = []
+        sequence_num = 0
+
+        def append_event(
+            stage: str,
+            status: str,
+            title: str,
+            *,
+            detail: str | None = None,
+            payload: dict[str, Any] | None = None,
+            duration_ms: int = 0,
+        ) -> None:
+            nonlocal sequence_num
+            sequence_num += 1
+            event = McpToolRunEvent(
+                run_id=run.id,
+                sequence_num=sequence_num,
+                stage=stage,
+                status=status,
+                title=title,
+                detail=detail,
+                payload=_json_safe(payload or {}),
+                duration_ms=duration_ms,
+            )
+            events.append(event)
+            self._db.add(event)
+
+        append_event(
+            "request_validated",
+            "completed",
+            "请求参数已校验",
+            payload={"tool_name": tool_name, "origin": origin, "arguments": initial_payload},
+        )
+
+        if tool:
+            append_event(
+                "tool_resolved",
+                "completed",
+                "已解析 Tool 定义",
+                payload={
+                    "tool_id": str(tool.id),
+                    "input_schema": tool.input_schema or {},
+                    "output_schema": tool.output_schema or {},
+                },
+            )
+
+        cleanup_paths: list[Path] = []
+        normalized_arguments = dict(arguments or {})
+        if asset_refs:
+            normalized_arguments = await self._apply_asset_refs(
+                server=server,
+                asset_refs=asset_refs,
+                arguments=normalized_arguments,
+                cleanup_paths=cleanup_paths,
+                append_event=append_event,
+            )
+
+        run.normalized_request_payload = _json_safe(normalized_arguments)
+        await self._db.flush()
+
+        stderr_lines: list[str] = []
+
+        def handle_client_event(event: dict[str, Any]) -> None:
+            append_event(
+                str(event.get("stage") or "transport"),
+                str(event.get("status") or "info"),
+                str(event.get("title") or "MCP 阶段事件"),
+                detail=_truncate_text(event.get("detail")),
+                payload=_json_safe(event.get("payload") or {}),
+                duration_ms=int(event.get("duration_ms") or 0),
+            )
+
+        def handle_stderr(message: str) -> None:
+            stderr_lines.append(message)
+            append_event(
+                "stderr",
+                "info",
+                "服务端 stderr 输出",
+                detail=_truncate_text(message, limit=2000),
+                payload={},
+            )
+
+        call_started = datetime.now(timezone.utc)
+        append_event(
+            "tool_called",
+            "running",
+            "开始调用 MCP Tool",
+            payload={"transport_type": server.transport_type},
+        )
+
+        try:
+            result = await self._client.call_tool(
+                transport_type=server.transport_type,
+                tool_name=tool_name,
+                arguments=normalized_arguments,
+                command=server.command,
+                args=server.args,
+                env=server.env,
+                url=server.url,
+                headers=server.headers,
+                timeout_seconds=timeout_seconds,
+                event_callback=handle_client_event,
+                stderr_callback=handle_stderr,
+            )
+            tool_called = True
+        except Exception as exc:  # noqa: BLE001
+            result = McpToolCallResult(success=False, error=str(exc))
+            tool_called = False
+
+        if tool_called and tool:
+            tool.call_count = (tool.call_count or 0) + 1
+
+        result_payload = {
+            "success": result.success,
+            "content": _json_safe(result.content),
+            "structured_content": _json_safe(result.structured_content),
+            "error": result.error,
+            "duration_ms": result.duration_ms,
+            "stderr": stderr_lines,
+        }
+        run.result_payload = result_payload
+        run.error_summary = result.error
+        run.duration_ms = result.duration_ms
+        run.ended_at = datetime.now(timezone.utc)
+        run.status = "completed" if result.success else "failed"
+        append_event(
+            "result_normalized",
+            "completed" if result.success else "failed",
+            "执行结果已归一化",
+            detail=_truncate_text(result.error),
+            payload=result_payload,
+            duration_ms=int((run.ended_at - call_started).total_seconds() * 1000),
+        )
+        append_event(
+            "run_persisted",
+            "completed",
+            "执行历史已持久化",
+            payload={"run_id": str(run.id), "status": run.status},
+        )
+        await self._db.commit()
+
+        for path in cleanup_paths:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("mcp_trial_temp_cleanup_failed", path=str(path))
+
+        await self._db.refresh(run)
+        return ExecutionResult(run=run, events=events, call_result=result)
+
+    async def _apply_asset_refs(
+        self,
+        *,
+        server: McpServer,
+        asset_refs: dict[str, Any],
+        arguments: dict[str, Any],
+        cleanup_paths: list[Path],
+        append_event,
+    ) -> dict[str, Any]:
+        normalized = dict(arguments)
+        for field_name, raw_ref in asset_refs.items():
+            if raw_ref is None:
+                continue
+            if isinstance(raw_ref, list):
+                normalized[field_name] = []
+                for asset_id in raw_ref:
+                    file_path = await self._materialize_asset(server=server, asset_id=UUID(str(asset_id)))
+                    cleanup_paths.append(file_path)
+                    normalized[field_name].append(str(file_path))
+                append_event(
+                    "asset_resolved",
+                    "completed",
+                    "批量试用资产已解析",
+                    payload={"field_name": field_name, "count": len(normalized[field_name])},
+                )
+                continue
+
+            file_path = await self._materialize_asset(server=server, asset_id=UUID(str(raw_ref)))
+            cleanup_paths.append(file_path)
+            normalized[field_name] = str(file_path)
+            append_event(
+                "asset_resolved",
+                "completed",
+                "试用资产已解析",
+                payload={"field_name": field_name, "asset_id": str(raw_ref), "path": str(file_path)},
+            )
+        return normalized
+
+    async def _materialize_asset(self, *, server: McpServer, asset_id: UUID) -> Path:
+        asset = await self._db.get(McpTrialAsset, asset_id)
+        if not asset or asset.server_id != server.id:
+            raise ValueError(f"Trial asset not found: {asset_id}")
+        content = self._get_gcs_client().download(asset.gcs_uri)
+        suffix = Path(asset.original_filename).suffix or ".pdf"
+        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        temp_file.write(content)
+        temp_file.flush()
+        temp_file.close()
+        return Path(temp_file.name)
+
+    def _get_gcs_client(self) -> GCSStorageClient:
+        if self._gcs is None:
+            self._gcs = GCSStorageClient.get_instance()
+        return self._gcs
+
+
+def _sanitize_filename(filename: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in filename).strip("._")
+    return cleaned[:180] or "upload.pdf"
+
+
+def _truncate_text(value: Any, *, limit: int = 1000) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}..."
+
+
+def _json_safe(value: Any) -> Any:
+    try:
+        return json.loads(json.dumps(value, default=str))
+    except TypeError:
+        return str(value)

--- a/apps/negentropy/src/negentropy/plugins/mcp_client.py
+++ b/apps/negentropy/src/negentropy/plugins/mcp_client.py
@@ -12,7 +12,7 @@ import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any
+from typing import Any, Callable
 
 import anyio
 import httpx
@@ -36,6 +36,7 @@ DEFAULT_TIMEOUT_SECONDS = 30
 async def logged_stdio_client(
     server: StdioServerParameters,
     errlog: ExternalProcessLogStream,
+    stderr_callback: Callable[[str], None] | None = None,
 ):
     """
     Spawn stdio MCP servers with stderr piped, then forward stderr lines
@@ -100,6 +101,8 @@ async def logged_stdio_client(
                 errors=server.encoding_error_handler,
             ):
                 errlog.write(chunk)
+                if stderr_callback:
+                    stderr_callback(chunk)
         except anyio.ClosedResourceError:  # pragma: no cover
             await anyio.lowlevel.checkpoint()
         finally:
@@ -204,6 +207,8 @@ class McpClientService:
         url: str | None = None,
         headers: dict[str, str] | None = None,
         timeout_seconds: float | None = None,
+        event_callback: Callable[[dict[str, Any]], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> McpToolCallResult:
         start_time = time.time()
         effective_timeout = timeout_seconds or self.timeout_seconds
@@ -219,6 +224,8 @@ class McpClientService:
                     tool_name=tool_name,
                     arguments=arguments or {},
                     timeout_seconds=effective_timeout,
+                    event_callback=event_callback,
+                    stderr_callback=stderr_callback,
                 )
             elif transport_type == "sse":
                 if not url:
@@ -229,6 +236,7 @@ class McpClientService:
                     tool_name=tool_name,
                     arguments=arguments or {},
                     timeout_seconds=effective_timeout,
+                    event_callback=event_callback,
                 )
             elif transport_type == "http":
                 if not url:
@@ -239,6 +247,7 @@ class McpClientService:
                     tool_name=tool_name,
                     arguments=arguments or {},
                     timeout_seconds=effective_timeout,
+                    event_callback=event_callback,
                 )
             else:
                 return McpToolCallResult(success=False, error=f"Unsupported transport type: {transport_type}")
@@ -446,19 +455,45 @@ class McpClientService:
         tool_name: str,
         arguments: dict[str, Any],
         timeout_seconds: float,
+        event_callback: Callable[[dict[str, Any]], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> McpToolCallResult:
         server_params = StdioServerParameters(command=command, args=args, env=env)
         async with asyncio.timeout(timeout_seconds):
-            async with logged_stdio_client(server_params, errlog=self._build_stdio_errlog(command, args)) as (
+            _emit_event(
+                event_callback,
+                stage="transport_connect",
+                status="running",
+                title="建立 STDIO 连接",
+                payload={"command": command, "args": args},
+            )
+            async with logged_stdio_client(
+                server_params,
+                errlog=self._build_stdio_errlog(command, args),
+                stderr_callback=stderr_callback,
+            ) as (
                 read,
                 write,
             ):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
+                    _emit_event(
+                        event_callback,
+                        stage="session_initialized",
+                        status="completed",
+                        title="MCP Session 已初始化",
+                    )
                     result = await session.call_tool(
                         tool_name,
                         arguments=arguments,
                         read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                    )
+                    _emit_event(
+                        event_callback,
+                        stage="tool_result",
+                        status="completed" if not bool(result.isError) else "failed",
+                        title="MCP Tool 返回结果",
+                        payload={"tool_name": tool_name},
                     )
                     return McpToolCallResult(
                         success=not bool(result.isError),
@@ -512,15 +547,36 @@ class McpClientService:
         tool_name: str,
         arguments: dict[str, Any],
         timeout_seconds: float,
+        event_callback: Callable[[dict[str, Any]], None] | None = None,
     ) -> McpToolCallResult:
         async with asyncio.timeout(timeout_seconds):
+            _emit_event(
+                event_callback,
+                stage="transport_connect",
+                status="running",
+                title="建立 SSE 连接",
+                payload={"url": url},
+            )
             async with sse_client(url, headers=headers) as (read, write):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
+                    _emit_event(
+                        event_callback,
+                        stage="session_initialized",
+                        status="completed",
+                        title="MCP Session 已初始化",
+                    )
                     result = await session.call_tool(
                         tool_name,
                         arguments=arguments,
                         read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                    )
+                    _emit_event(
+                        event_callback,
+                        stage="tool_result",
+                        status="completed" if not bool(result.isError) else "failed",
+                        title="MCP Tool 返回结果",
+                        payload={"tool_name": tool_name},
                     )
                     return McpToolCallResult(
                         success=not bool(result.isError),
@@ -567,15 +623,36 @@ class McpClientService:
         tool_name: str,
         arguments: dict[str, Any],
         timeout_seconds: float,
+        event_callback: Callable[[dict[str, Any]], None] | None = None,
     ) -> McpToolCallResult:
         async with asyncio.timeout(timeout_seconds):
+            _emit_event(
+                event_callback,
+                stage="transport_connect",
+                status="running",
+                title="建立 HTTP 连接",
+                payload={"url": url},
+            )
             async with streamablehttp_client(url, headers=headers) as (read, write, _session_id):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
+                    _emit_event(
+                        event_callback,
+                        stage="session_initialized",
+                        status="completed",
+                        title="MCP Session 已初始化",
+                    )
                     result = await session.call_tool(
                         tool_name,
                         arguments=arguments,
                         read_timeout_seconds=timedelta(seconds=timeout_seconds),
+                    )
+                    _emit_event(
+                        event_callback,
+                        stage="tool_result",
+                        status="completed" if not bool(result.isError) else "failed",
+                        title="MCP Tool 返回结果",
+                        payload={"tool_name": tool_name},
                     )
                     return McpToolCallResult(
                         success=not bool(result.isError),
@@ -594,3 +671,11 @@ def _extract_call_error(result: Any) -> str | None:
         if getattr(item, "type", None) == "text" and getattr(item, "text", None):
             parts.append(item.text)
     return "\n".join(parts).strip() or "MCP tool returned an error"
+
+
+def _emit_event(
+    callback: Callable[[dict[str, Any]], None] | None,
+    **event: Any,
+) -> None:
+    if callback:
+        callback(event)

--- a/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
+++ b/apps/negentropy/tests/unit_tests/plugins/test_mcp_client.py
@@ -15,9 +15,10 @@ async def test_discover_stdio_uses_logged_stdio_client(monkeypatch: pytest.Monke
     captured: dict[str, object] = {}
 
     @asynccontextmanager
-    async def fake_logged_stdio_client(server_params, errlog):
+    async def fake_logged_stdio_client(server_params, errlog, stderr_callback=None):
         captured["server_params"] = server_params
         captured["errlog"] = errlog
+        _ = stderr_callback
         yield object(), object()
 
     class _Tool:
@@ -92,9 +93,10 @@ async def test_call_tool_stdio_passes_structured_errlog(monkeypatch: pytest.Monk
     captured: dict[str, object] = {}
 
     @asynccontextmanager
-    async def fake_logged_stdio_client(server_params, errlog):
+    async def fake_logged_stdio_client(server_params, errlog, stderr_callback=None):
         captured["server_params"] = server_params
         captured["errlog"] = errlog
+        _ = stderr_callback
         yield object(), object()
 
     class _Result:
@@ -141,8 +143,8 @@ async def test_call_tool_stdio_passes_structured_errlog(monkeypatch: pytest.Monk
 @pytest.mark.asyncio
 async def test_call_tool_stdio_preserves_non_dict_structured_content(monkeypatch: pytest.MonkeyPatch) -> None:
     @asynccontextmanager
-    async def fake_logged_stdio_client(server_params, errlog):
-        _ = (server_params, errlog)
+    async def fake_logged_stdio_client(server_params, errlog, stderr_callback=None):
+        _ = (server_params, errlog, stderr_callback)
         yield object(), object()
 
     class _Result:
@@ -179,6 +181,63 @@ async def test_call_tool_stdio_preserves_non_dict_structured_content(monkeypatch
 
     assert result.success is True
     assert result.structured_content == [{"result": {"markdown_content": "# Title"}}]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_stdio_emits_whitebox_events_and_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    emitted_events: list[dict[str, object]] = []
+    stderr_messages: list[str] = []
+
+    @asynccontextmanager
+    async def fake_logged_stdio_client(server_params, errlog, stderr_callback=None):
+        captured["server_params"] = server_params
+        captured["errlog"] = errlog
+        if stderr_callback:
+            stderr_callback("stderr line")
+        yield object(), object()
+
+    class _Result:
+        isError = False
+        content = []
+        structuredContent = {"ok": True}
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def initialize(self) -> None:
+            captured["initialized"] = True
+
+        async def call_tool(self, tool_name, arguments, read_timeout_seconds):
+            _ = (tool_name, arguments, read_timeout_seconds)
+            return _Result()
+
+    monkeypatch.setattr("negentropy.plugins.mcp_client.logged_stdio_client", fake_logged_stdio_client)
+    monkeypatch.setattr("negentropy.plugins.mcp_client.ClientSession", lambda read, write: _Session())
+
+    service = McpClientService(timeout_seconds=5)
+    result = await service.call_tool(
+        transport_type="stdio",
+        command="uvx",
+        args=["mcp-server-fetch"],
+        env={},
+        tool_name="fetch",
+        arguments={"url": "https://example.com"},
+        event_callback=emitted_events.append,
+        stderr_callback=stderr_messages.append,
+    )
+
+    assert result.success is True
+    assert stderr_messages == ["stderr line"]
+    assert [event["stage"] for event in emitted_events] == [
+        "transport_connect",
+        "session_initialized",
+        "tool_result",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

本 PR 为 MCP Hub 增加了 MCP Server 试用能力，目标是让用户可以直接在 MCP 卡片上试用该 Server 下的 Tools，并在 UI 中白盒查看一次 MCP 调用的完整处理过程。

以预置的 Data Extractor 为核心场景，本次实现补齐了试用其 14 个 Tools 所需的前后端链路，并把试用调用与系统内真实调用统一纳入持久化审计历史。

## 改动内容

### 前端
- 在 MCP Server 卡片右上角新增“试用”操作入口。
- 新增 `McpServerTrialDialog`，支持：
  - 浏览并选择当前 MCP Server 下的 Tools
  - schema 驱动表单输入
  - raw JSON 输入模式
  - PDF 相关 Tool 的 URL / 文件上传试用
  - 查看原始参数、归一化参数、执行结果、阶段事件与执行历史
- 新增 MCP 相关前端代理路由：
  - 执行 Tool
  - 查询执行历史
  - 查询执行详情
  - 上传试用资产

### 后端
- 新增统一 MCP Tool 执行服务，负责：
  - 执行 Tool
  - 记录执行状态
  - 记录白盒阶段事件
  - 处理试用资产上传与解析
- 新增持久化运行时模型与迁移：
  - `mcp_tool_runs`
  - `mcp_tool_run_events`
  - `mcp_trial_assets`
- 在 `plugins/api` 中新增试用上传、执行、历史与详情接口。
- 扩展 `mcp_client`，增加执行阶段事件与 stderr 回调，支撑 UI 白盒可见。
- 将 Knowledge Extraction 中的 MCP 调用切换为复用统一执行服务，使试用历史与真实调用历史进入同一审计链路。

## 变更原因

这次改动对应的任务要求不是简单的“按钮 + 弹窗”，而是完整的 MCP Tool 试用工作台：

- 用户需要直接试用 MCP Server 下的全部 Tools
- Data Extractor 的 14 个 Tools 需要具备完整前后端支持
- MCP Server 处理任务的逻辑细节必须在 UI 中白盒可见
- 试用执行历史与真实调用历史都需要可追溯、可审计

因此实现上选择了：
- 前端采用 schema-first 的 Tool 试用界面
- 后端采用统一执行服务与事件化记录
- 审计层采用运行记录表 + 阶段事件表的拆分设计

## 重要实现细节

- 试用与真实调用统一使用同一套执行审计模型，避免历史分裂。
- PDF 类 Tool 支持上传试用文件，并通过资产表进行追踪。
- 执行历史不仅保存结果，还保存阶段事件，便于定位连接、初始化、调用与返回过程中的问题。
- 当前实现保持对现有 MCP Hub 与 Knowledge Extraction 能力的兼容，不改变原有业务入口语义，只统一其底层执行与审计链路。

## 验证

已完成的针对性验证包括：
- Python 单测：`tests/unit_tests/plugins/test_mcp_client.py`
- 前端插件相关单测：`McpServerCard`、`McpLayout`
- UI typecheck

备注：
- 运行 UI 全量测试时暴露了仓库中一个与本 PR 无关的既有失败：`tests/unit/config/package-scripts.test.ts` 对 `start` 脚本的断言与当前仓库现状不一致；本 PR 未修改该部分逻辑。
