### PR TITLE
fix(bootstrap): 修复循环导入导致 /auth/me 返回 404 与 ADK web 崩溃的问题

### DIFF
--- a/apps/negentropy/src/negentropy/agents/tools/perception.py
+++ b/apps/negentropy/src/negentropy/agents/tools/perception.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 from google.adk.tools import ToolContext
@@ -31,10 +31,12 @@ from negentropy.knowledge.constants import (
     DEFAULT_SEMANTIC_WEIGHT,
 )
 from negentropy.knowledge.embedding import build_batch_embedding_fn, build_embedding_fn
-from negentropy.knowledge.service import KnowledgeService
 from negentropy.knowledge.types import SearchConfig
 from negentropy.logging import get_logger
 from negentropy.models.perception import Corpus
+
+if TYPE_CHECKING:
+    from negentropy.knowledge.service import KnowledgeService
 
 logger = get_logger("negentropy.tools.perception")
 
@@ -53,6 +55,8 @@ def _get_knowledge_service() -> KnowledgeService:
     """
     global _knowledge_service
     if _knowledge_service is None:
+        from negentropy.knowledge.service import KnowledgeService
+
         _knowledge_service = KnowledgeService(
             embedding_fn=build_embedding_fn(),
             batch_embedding_fn=build_batch_embedding_fn(),

--- a/apps/negentropy/src/negentropy/plugins/api.py
+++ b/apps/negentropy/src/negentropy/plugins/api.py
@@ -37,8 +37,6 @@ from negentropy.models.plugin import (
 
 from .permissions import check_plugin_access, check_plugin_ownership, get_visible_plugin_ids
 from .execution import McpToolExecutionService
-from .subagent_presets import build_negentropy_subagent_payloads
-
 logger = get_logger("negentropy.plugins.api")
 router = APIRouter(prefix="/plugins", tags=["plugins"])
 
@@ -1236,6 +1234,8 @@ async def list_negentropy_subagent_templates(
 ) -> List[NegentropySubAgentTemplateResponse]:
     """返回 Negentropy 内置 5 个 Faculty SubAgent 模板（来自代码定义）。"""
     _ = user  # 显式依赖鉴权
+    from .subagent_presets import build_negentropy_subagent_payloads
+
     payloads = build_negentropy_subagent_payloads()
     return [
         NegentropySubAgentTemplateResponse(
@@ -1264,6 +1264,8 @@ async def sync_negentropy_subagents(
     - 已存在但归属其他用户：跳过；
     - 不存在：创建。
     """
+    from .subagent_presets import build_negentropy_subagent_payloads
+
     payloads = build_negentropy_subagent_payloads()
     created_count = 0
     updated_count = 0


### PR DESCRIPTION
## 问题背景

执行 `uv run adk web --port 6600 --reload_agents src/negentropy` 启动后端服务后，前端首页提示需要登录（实际已登录），访问登录页返回 `{"detail": "Not Found"}`。后端日志显示 `GET /auth/me` 返回 404。

**根因**：Python 循环导入导致 `services.py` 加载失败，自定义路由（`/auth/me` 等）未能注入到 FastAPI 应用中。

## 变更内容

### 修复 1：`engine/factories/runner.py` — 打断 services.py 加载阶段的循环链

- 将 `from negentropy.agents.agent import root_agent` 从顶层导入改为 `get_runner()` 函数内延迟导入
- 引入 `use_defaults` 标志修复延迟导入后的缓存逻辑

**循环链路**：`services.py → bootstrap → factories → runner.py → agents/agent → 完整 agent 树 → perception.py → cycle`

### 修复 2：`agents/tools/perception.py` — 打断路由注入阶段的循环链

- 将 `from negentropy.knowledge.service import KnowledgeService` 从顶层导入改为 `_get_knowledge_service()` 函数内延迟导入
- 使用 `TYPE_CHECKING` 守卫保留类型标注

**循环链路**：`_inject_negentropy_routes → knowledge.__init__ → knowledge.service → extraction → plugins → api → subagent_presets → agents.faculties → tools/perception → knowledge.service (cycle!)`

### 修复 3：`plugins/api.py` — 纵深防御，阻断 plugins → agents 耦合路径

- 将 `from .subagent_presets import build_negentropy_subagent_payloads` 从顶层导入移至两个端点函数内按需导入

### 清理：`engine/bootstrap.py` — 移除死代码

- 删除引用未定义变量 `patched_create_app` / `original_create_app` 的无效代码块

## 验证

- `apply_adk_patches()` 无 ImportError
- `knowledge_router`、`plugins_router`、`auth_router` 全部正常导入
- `/auth/me` 路由成功注入

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>