### PR TITLE
style(knowledge-nav): 调整 Knowledge 二级导航栏排序，将 Dashboard 移至末位

### DIFF
--- a/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
+++ b/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
@@ -6,11 +6,11 @@ import { usePathname } from "next/navigation";
 import { useNavigation } from "@/components/providers/NavigationProvider";
 
 const NAV_ITEMS = [
-  { href: "/knowledge/dashboard", label: "Dashboard" },
   { href: "/knowledge/base", label: "Knowledge Base" },
   { href: "/knowledge/graph", label: "Knowledge Graph" },
   { href: "/knowledge/documents", label: "Documents" },
   { href: "/knowledge/apis", label: "APIs" },
+  { href: "/knowledge/dashboard", label: "Dashboard" },
 ];
 
 export function KnowledgeNav({


### PR DESCRIPTION
## 变更摘要

将 Knowledge 模块二级导航栏中的 **Dashboard** 从首位移至末位（APIs 之后），优化导航信息层级，使核心功能入口（Knowledge Base、Knowledge Graph、Documents、APIs）优先展示。

## 调整后顺序

`Knowledge Base` → `Knowledge Graph` → `Documents` → `APIs` → `Dashboard`

## 改动文件

- `apps/negentropy-ui/components/ui/KnowledgeNav.tsx` — 调整 `NAV_ITEMS` 数组元素顺序

## 影响范围

- 仅调整数组元素顺序，**不涉及任何逻辑变更**
- 路由、权限、活跃状态高亮等功能均不受影响
- 所有引用 `KnowledgeNav` 的页面无需修改

## 测试计划

- [ ] 访问 Knowledge 下任意子页面，确认导航栏顺序正确
- [ ] 确认各导航项点击跳转正常，活跃状态高亮正确

🤖 Generated with [Claude Code](https://github.com/claude)