### PR TITLE
fix(knowledge-config): 修正 Corpus 创建时 Document Extraction Settings 默认配置未生效的问题

### DIFF
--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -31,11 +31,11 @@ class DefaultExtractorRoutesSettings(BaseModel):
     url: DefaultExtractorRouteSettings = Field(
         default_factory=lambda: DefaultExtractorRouteSettings(
             primary=DefaultExtractorTargetSettings(
-                server_name="Data Extractor",
+                server_name="data-extractor",
                 tool_name="convert_webpage_to_markdown",
             ),
             secondary=DefaultExtractorTargetSettings(
-                server_name="Data Extractor",
+                server_name="data-extractor",
                 tool_name="batch_convert_webpages_to_markdown",
             ),
         )
@@ -43,11 +43,11 @@ class DefaultExtractorRoutesSettings(BaseModel):
     file_pdf: DefaultExtractorRouteSettings = Field(
         default_factory=lambda: DefaultExtractorRouteSettings(
             primary=DefaultExtractorTargetSettings(
-                server_name="Data Extractor",
-                tool_name="convert_pdfs_to_markdown",
+                server_name="data-extractor",
+                tool_name="convert_pdf_to_markdown",
             ),
             secondary=DefaultExtractorTargetSettings(
-                server_name="Data Extractor",
+                server_name="data-extractor",
                 tool_name="batch_convert_pdfs_to_markdown",
             ),
         )

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py
@@ -60,21 +60,21 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
             return {
                 "url": {
                     "primary": {
-                        "server_name": "Data Extractor",
+                        "server_name": "data-extractor",
                         "tool_name": "convert_webpage_to_markdown",
                     },
                     "secondary": {
-                        "server_name": "Data Extractor",
+                        "server_name": "data-extractor",
                         "tool_name": "batch_convert_webpages_to_markdown",
                     },
                 },
                 "file_pdf": {
                     "primary": {
-                        "server_name": "Data Extractor",
-                        "tool_name": "convert_pdfs_to_markdown",
+                        "server_name": "data-extractor",
+                        "tool_name": "convert_pdf_to_markdown",
                     },
                     "secondary": {
-                        "server_name": "Data Extractor",
+                        "server_name": "data-extractor",
                         "tool_name": "batch_convert_pdfs_to_markdown",
                     },
                 },
@@ -95,11 +95,11 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
         "AsyncSessionLocal",
         lambda: FakeDefaultRouteSession(
             responses=[
-                [(server_id, "Data Extractor")],
+                [(server_id, "data-extractor")],
                 [
                     (server_id, "convert_webpage_to_markdown"),
                     (server_id, "batch_convert_webpages_to_markdown"),
-                    (server_id, "convert_pdfs_to_markdown"),
+                    (server_id, "convert_pdf_to_markdown"),
                     (server_id, "batch_convert_pdfs_to_markdown"),
                 ],
             ]
@@ -136,7 +136,7 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
             "targets": [
                 {
                     "server_id": str(server_id),
-                    "tool_name": "convert_pdfs_to_markdown",
+                    "tool_name": "convert_pdf_to_markdown",
                     "priority": 0,
                     "enabled": True,
                 },


### PR DESCRIPTION
## 问题

新建 Corpus 时，Document Extraction Settings 未被自动填充为系统预置的 Data Extractor MCP 工具（URL/PDF 提取），用户每次都需要手动配置。

## 根因分析

`config/knowledge.py` 中 `DefaultExtractorRoutesSettings` 存在两处配置值不匹配，导致 `_resolve_default_extractor_routes()` 在创建 Corpus 时查询数据库失败，默认路由始终为空：

1. **`server_name` 错误**：使用了 `"Data Extractor"`（`display_name`），但查询逻辑匹配的是 `McpServer.name` 字段，数据库实际值为 `"data-extractor"`（由 seed 迁移 `a9d3f7b21c4e` 写入）
2. **PDF 主用工具名拼写错误**：`"convert_pdfs_to_markdown"`（复数）应为 `"convert_pdf_to_markdown"`（单数），与实际注册的 MCP Tool 名称不一致

## 修复内容

**`apps/negentropy/src/negentropy/config/knowledge.py`**
- 将所有 `server_name` 从 `"Data Extractor"` 修正为 `"data-extractor"`（匹配 `McpServer.name` 唯一约束字段）
- 将 PDF 主用 `tool_name` 从 `"convert_pdfs_to_markdown"` 修正为 `"convert_pdf_to_markdown"`

**`apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py`**
- 同步修正 Mock 数据中的 `server_name` 和 `tool_name`，使测试真实反映生产行为（原测试通过伪造 `McpServer.name="Data Extractor"` 绕过了不匹配问题）

## 测试验证

- `test_api_corpus.py` 全部 4 个用例通过 ✅

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>