### PR TITLE
refactor(PipelineRunCard): 将时间起止区间从独立行迁移至元数据栏，与操作类型、触发方式、时长同行展示;

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -131,7 +131,14 @@ function PipelineRunCardContent({
             </>
           )}
         </div>
-        <span className="shrink-0">v{version}</span>
+        <div className="flex shrink-0 items-center gap-2">
+          {hasTimeline && (
+            <span className={isSelectable ? "opacity-60" : "text-zinc-400 dark:text-zinc-500"}>
+              {startLabel ?? "-"} → {endLabel ?? "-"}
+            </span>
+          )}
+          <span className="shrink-0">v{version}</span>
+        </div>
       </div>
 
       {/* 第三行：阶段进度条 */}
@@ -144,16 +151,7 @@ function PipelineRunCardContent({
         />
       )}
 
-      {/* 第四行：Timeline 时间戳 */}
-      {hasTimeline && (
-        <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-zinc-400 dark:text-zinc-500">
-          <span>{startLabel ? `开始 ${started_at}` : "开始 -"}</span>
-          <span>→</span>
-          <span>{endLabel ? `结束 ${completed_at}` : "结束 -"}</span>
-        </div>
-      )}
-
-      {/* 第五行：失败摘要（仅失败时显示） */}
+      {/* 第四行：失败摘要（仅失败时显示） */}
       {status === "failed" && (() => {
         const failedStageList = getFailedStages(stages);
         if (failedStageList.length > 0) {


### PR DESCRIPTION
## 变更概要

将 Knowledge Dashboard Pipeline Run 卡片中的时间起止区间从独立行迁移至元数据栏（第二行），与操作类型、触发方式、时长同行展示，提升卡片信息密度并减少纵向空间占用。

## 变更内容

### `PipelineRunCard.tsx`
- **删除**独立的第四行时间戳区块（原显示完整 ISO 时间戳 `开始 {ISO} → 结束 {ISO}`）
- **合并**到第二行右侧版本号左侧，使用紧凑格式 `MM-DD HH:mm:ss → MM-DD HH:mm:ss`
- 复用已有的 `formatCompactTimestamp()` 函数，无新增依赖

### 布局变化

```
前:  重建源 · API · 33s                                            v20
     ██████████ 进度条 ██████████
     开始 2026-03-22T13:43:08.350803+00:00 → 结束 2026-03-22T13:43:33...

后:  重建源 · API · 33s          03-22 21:43:08 → 21:43:33         v20
     ██████████ 进度条 ██████████
```

## 影响范围

- 仅修改 1 个文件，净减少 2 行代码
- `mode="link"` 和 `mode="selectable"` 两种模式均已适配
- Light/Dark 主题样式均已覆盖