### PR TITLE
style(dashboard): Quick Links 卡片网格调整为 3 列布局

### DIFF
--- a/apps/negentropy-ui/app/plugins/page.tsx
+++ b/apps/negentropy-ui/app/plugins/page.tsx
@@ -79,7 +79,7 @@ export default function PluginsPage() {
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
               Quick Links
             </h2>
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-3">
               <QuickLink
                 href="/plugins/mcp"
                 title="Register MCP Server"


### PR DESCRIPTION
## 概要

- Quick Links 卡片网格从 `sm:grid-cols-2` 调整为 `sm:grid-cols-3`，与上方 StatCard（MCP Hub / Skills / SubAgents）保持一致的 3 列布局
- 间距从 `gap-2` 统一为 `gap-4`，与 StatCard 区域对齐

## 测试计划

- [ ] 访问 Interface / Dashboard 页，确认 Quick Links 3 张卡片呈一行三列
- [ ] 确认与上方 MCP Hub / Skills / SubAgents 列宽对齐
- [ ] 缩小至移动端宽度，确认回退为单列

🤖 Generated with [Claude Code](https://claude.com/claude-code)