### PR TITLE
refactor(edit-chunk): 将 Edit Chunk 侧栏面板改造为模态框，与 Chunk Detail 弹窗样式保持一致

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/EditChunkDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/EditChunkDialog.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useId } from "react";
+import { X } from "lucide-react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+import type { DocumentChunkItem } from "@/features/knowledge";
+
+interface EditChunkDialogProps {
+  chunk: DocumentChunkItem | null;
+  draftContent: string;
+  draftEnabled: boolean;
+  onDraftContentChange: (value: string) => void;
+  onDraftEnabledChange: (value: boolean) => void;
+  onClose: () => void;
+  onSave: () => void;
+  onRegenerate: () => void;
+  pending: boolean;
+}
+
+export function EditChunkDialog({
+  chunk,
+  draftContent,
+  draftEnabled,
+  onDraftContentChange,
+  onDraftEnabledChange,
+  onClose,
+  onSave,
+  onRegenerate,
+  pending,
+}: EditChunkDialogProps) {
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!chunk) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !pending) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [chunk, onClose, pending]);
+
+  if (!chunk) return null;
+
+  return (
+    <OverlayDismissLayer
+      open={chunk !== null}
+      onClose={onClose}
+      busy={pending}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="flex h-[82vh] w-full max-w-3xl flex-col overflow-hidden rounded-[28px] border border-border bg-card shadow-2xl"
+      backdropTestId="edit-chunk-dialog-backdrop"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": titleId,
+      }}
+    >
+      <div className="flex items-start justify-between gap-4 px-5 py-5">
+        <div>
+          <h2 id={titleId} className="text-3xl font-semibold text-foreground">
+            Edit Chunk
+          </h2>
+          <p className="mt-1 text-sm text-muted">
+            {chunk.chunk_role === "parent" ? "Parent" : "Chunk"}-
+            {String(chunk.chunk_index).padStart(2, "0")} ·{" "}
+            {chunk.character_count} characters
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="Close edit chunk"
+          onClick={onClose}
+          disabled={pending}
+          className="rounded-full border border-border p-2 text-zinc-400 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col px-5 pb-5">
+        <div className="mb-4 flex items-center justify-between rounded-xl border border-border bg-background px-3 py-2">
+          <span className="text-sm text-muted">Enabled</span>
+          <button
+            type="button"
+            aria-pressed={draftEnabled}
+            onClick={() => onDraftEnabledChange(!draftEnabled)}
+            disabled={pending}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              draftEnabled
+                ? "bg-emerald-500 text-white"
+                : "bg-zinc-700 text-zinc-200"
+            }`}
+          >
+            {draftEnabled ? "Enabled" : "Disabled"}
+          </button>
+        </div>
+
+        <textarea
+          value={draftContent}
+          onChange={(event) => onDraftContentChange(event.target.value)}
+          disabled={pending}
+          className="min-h-0 flex-1 resize-none rounded-2xl border border-border bg-background p-4 text-sm outline-none disabled:opacity-60"
+        />
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={pending}
+            className={outlineButtonClassName("neutral", "rounded-xl px-4 py-2 text-sm")}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={onRegenerate}
+            className={outlineButtonClassName("neutral", "rounded-xl px-4 py-2 text-sm")}
+          >
+            Save & Regenerate Child Chunks
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={onSave}
+            className="rounded-xl bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -53,6 +53,7 @@ import { DeleteCorpusDialog } from "./_components/DeleteCorpusDialog";
 import { DeleteSourceDialog } from "./_components/DeleteSourceDialog";
 import { RetrievedChunkCard } from "./_components/RetrievedChunkCard";
 import { RetrievedChunkDetailDialog } from "./_components/RetrievedChunkDetailDialog";
+import { EditChunkDialog } from "./_components/EditChunkDialog";
 import { ReplaceDocumentDialog } from "./_components/ReplaceDocumentDialog";
 import { buildRetrievedChunkViewModel } from "./_components/retrieved-chunk-presenter";
 import type { RetrievedChunkViewModel } from "./_components/retrieved-chunk-presenter";
@@ -190,80 +191,6 @@ function DocumentMetadataPanel({
       <div className="mt-6 space-y-6">
         {renderFieldGroup("Document Information", docInfo)}
         {renderFieldGroup("Technical Parameters", stats)}
-      </div>
-    </section>
-  );
-}
-
-function EditChunkPanel({
-  chunk,
-  draftContent,
-  draftEnabled,
-  onDraftContentChange,
-  onDraftEnabledChange,
-  onCancel,
-  onSave,
-  onRegenerate,
-  pending,
-}: {
-  chunk: DocumentChunkItem;
-  draftContent: string;
-  draftEnabled: boolean;
-  onDraftContentChange: (value: string) => void;
-  onDraftEnabledChange: (value: boolean) => void;
-  onCancel: () => void;
-  onSave: () => void;
-  onRegenerate: () => void;
-  pending: boolean;
-}) {
-  return (
-    <section className="flex h-full flex-col rounded-2xl border border-border bg-card p-5">
-      <div className="mb-4">
-        <h3 className="text-2xl font-semibold">Edit Chunk</h3>
-        <p className="mt-1 text-sm text-muted">
-          {chunk.chunk_role === "parent" ? "Parent" : "Chunk"}-{String(chunk.chunk_index).padStart(2, "0")} · {chunk.character_count} characters
-        </p>
-      </div>
-      <div className="mb-4 flex items-center justify-between rounded-xl border border-border bg-background px-3 py-2">
-        <span className="text-sm text-muted">Enabled</span>
-        <button
-          type="button"
-          aria-pressed={draftEnabled}
-          onClick={() => onDraftEnabledChange(!draftEnabled)}
-          className={`rounded-full px-3 py-1 text-xs font-medium ${draftEnabled ? "bg-emerald-500 text-white" : "bg-zinc-700 text-zinc-200"}`}
-        >
-          {draftEnabled ? "Enabled" : "Disabled"}
-        </button>
-      </div>
-      <textarea
-        value={draftContent}
-        onChange={(event) => onDraftContentChange(event.target.value)}
-        className="min-h-0 flex-1 resize-none rounded-2xl border border-border bg-background p-4 text-sm outline-none"
-      />
-      <div className="mt-4 flex items-center justify-end gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className={outlineButtonClassName("neutral", "rounded-xl px-4 py-2 text-sm")}
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          disabled={pending}
-          onClick={onRegenerate}
-          className={outlineButtonClassName("neutral", "rounded-xl px-4 py-2 text-sm")}
-        >
-          Save & Regenerate Child Chunks
-        </button>
-        <button
-          type="button"
-          disabled={pending}
-          onClick={onSave}
-          className="rounded-xl bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
-        >
-          Save
-        </button>
       </div>
     </section>
   );
@@ -1538,25 +1465,7 @@ export default function KnowledgeBasePage() {
                   </section>
 
                   <div className="min-h-0">
-                    {selectedDocumentChunk ? (
-                      <EditChunkPanel
-                        chunk={selectedDocumentChunk}
-                        draftContent={chunkDraftContent}
-                        draftEnabled={chunkDraftEnabled}
-                        onDraftContentChange={setChunkDraftContent}
-                        onDraftEnabledChange={setChunkDraftEnabled}
-                        onCancel={() => {
-                          setSelectedDocumentChunk(null);
-                          setChunkDraftContent("");
-                          setChunkDraftEnabled(true);
-                        }}
-                        onSave={() => void handleSaveDocumentChunk()}
-                        onRegenerate={() => void handleRegenerateDocumentChunkFamily()}
-                        pending={chunkActionPending}
-                      />
-                    ) : (
-                      <DocumentMetadataPanel metadata={documentChunksMetadata} />
-                    )}
+                    <DocumentMetadataPanel metadata={documentChunksMetadata} />
                   </div>
                 </div>
               )}
@@ -1652,6 +1561,22 @@ export default function KnowledgeBasePage() {
           setDeletingDocument(null);
         }}
         onConfirm={handleConfirmDeleteDocument}
+      />
+
+      <EditChunkDialog
+        chunk={selectedDocumentChunk}
+        draftContent={chunkDraftContent}
+        draftEnabled={chunkDraftEnabled}
+        onDraftContentChange={setChunkDraftContent}
+        onDraftEnabledChange={setChunkDraftEnabled}
+        onClose={() => {
+          setSelectedDocumentChunk(null);
+          setChunkDraftContent("");
+          setChunkDraftEnabled(true);
+        }}
+        onSave={() => void handleSaveDocumentChunk()}
+        onRegenerate={() => void handleRegenerateDocumentChunkFamily()}
+        pending={chunkActionPending}
       />
     </div>
   );

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1079,7 +1079,7 @@ describe("KnowledgeBasePage", () => {
     expect(screen.getByText("Chunk-?")).toBeInTheDocument();
   });
 
-  it("document-chunks 视图点击卡片后在右栏展示 Edit Chunk", async () => {
+  it("document-chunks 视图点击卡片后以模态框展示 Edit Chunk", async () => {
     const user = userEvent.setup();
     searchParamsState.value = knowledgeBasePageSearchParams.documentChunks();
     fetchDocumentChunksMock.mockResolvedValueOnce({
@@ -1104,7 +1104,7 @@ describe("KnowledgeBasePage", () => {
     expect(screen.getByRole("button", { name: "Save & Regenerate Child Chunks" })).toBeInTheDocument();
   });
 
-  it("document-chunks 视图可展开并点击子 chunk 进入右栏编辑", async () => {
+  it("document-chunks 视图可展开并点击子 chunk 以模态框进入编辑", async () => {
     const user = userEvent.setup();
     searchParamsState.value = knowledgeBasePageSearchParams.documentChunks();
     fetchDocumentChunksMock.mockResolvedValueOnce({


### PR DESCRIPTION
## 概述

将 Corpus / Documents 页面中的「Edit Chunk」从右侧 360px 侧栏面板改造为居中模态框，与「Retrieved Chunks」中的「Chunk Detail」弹窗视觉风格保持一致，统一交互范式。

## 变更内容

### 新建 `EditChunkDialog.tsx`
- 从 `page.tsx` 提取内联 `EditChunkPanel`，重构为独立模态框组件
- 复用 `OverlayDismissLayer` 基础层，样式对齐 `RetrievedChunkDetailDialog`（`rounded-[28px]`、`shadow-2xl`、`h-[82vh]`、`max-w-3xl`）
- 支持 `busy` 状态阻止保存期间误关闭（Escape / 背景点击均被拦截）
- 完整 ARIA 无障碍属性：`role="dialog"`、`aria-modal`、`aria-labelledby`

### 修改 `page.tsx`
- 删除内联 `EditChunkPanel` 函数（减少 ~73 行）
- 右栏布局简化：始终显示 `DocumentMetadataPanel`，不再与编辑面板互斥
- 在底部 Dialog 区域统一挂载 `EditChunkDialog`

### 更新单元测试
- 测试描述从「右栏展示」改为「模态框展示」，反映新的交互方式

## 验证

- [x] 343 个单元测试全部通过
- [x] TypeScript 类型检查无错误

🤖 Generated with [Claude Code](https://claude.ai/code)