### PR TITLE
feat(chunking): Corpus 新建时 Separators 默认值简化为 \n，并引入转义编解码机制

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
@@ -7,6 +7,8 @@ import {
   ChunkingStrategy,
   createDefaultChunkingConfig,
   normalizeChunkingConfig,
+  encodeSeparatorsForDisplay,
+  decodeSeparatorsFromInput,
 } from "@/features/knowledge";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
@@ -258,15 +260,12 @@ export function CorpusFormDialog({
                       <textarea
                         className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
                         rows={4}
-                        placeholder={"\\n\\n\\n.\\n,\\n;"}
-                        value={config.separators.join("\n")}
+                        placeholder={"\\n"}
+                        value={encodeSeparatorsForDisplay(config.separators)}
                         onChange={(e) =>
                           setConfig({
                             ...config,
-                            separators: e.target.value
-                              .split("\n")
-                              .map((item) => item.trim())
-                              .filter(Boolean),
+                            separators: decodeSeparatorsFromInput(e.target.value),
                           })
                         }
                       />
@@ -415,15 +414,12 @@ export function CorpusFormDialog({
                       <textarea
                         className="w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
                         rows={4}
-                        placeholder={"\\n\\n\\n.\\n,\\n;"}
-                        value={config.separators.join("\n")}
+                        placeholder={"\\n"}
+                        value={encodeSeparatorsForDisplay(config.separators)}
                         onChange={(e) =>
                           setConfig({
                             ...config,
-                            separators: e.target.value
-                              .split("\n")
-                              .map((item) => item.trim())
-                              .filter(Boolean),
+                            separators: decodeSeparatorsFromInput(e.target.value),
                           })
                         }
                       />

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -43,6 +43,8 @@ import {
   deleteDocument,
   createDefaultChunkingConfig,
   normalizeChunkingConfig,
+  encodeSeparatorsForDisplay,
+  decodeSeparatorsFromInput,
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
@@ -413,17 +415,15 @@ function ChunkingStrategyPanel({
             <label className="text-xs md:col-span-2">
               <div className="mb-1 text-muted">Separators（每行一个）</div>
               <textarea
-                value={config.separators.join("\n")}
+                value={encodeSeparatorsForDisplay(config.separators)}
                 onChange={(e) =>
                   updateConfig({
                     ...config,
-                    separators: e.target.value
-                      .split("\n")
-                      .map((item) => item.trim())
-                      .filter(Boolean),
+                    separators: decodeSeparatorsFromInput(e.target.value),
                   })
                 }
                 rows={3}
+                placeholder={"\\n"}
                 className="w-full rounded border border-border bg-card px-2 py-2"
               />
             </label>
@@ -557,17 +557,15 @@ function ChunkingStrategyPanel({
           <label className="text-xs">
             <div className="mb-1 text-muted">Separators（每行一个）</div>
             <textarea
-              value={config.separators.join("\n")}
+              value={encodeSeparatorsForDisplay(config.separators)}
               onChange={(e) =>
                 updateConfig({
                   ...config,
-                  separators: e.target.value
-                    .split("\n")
-                    .map((item) => item.trim())
-                    .filter(Boolean),
+                  separators: decodeSeparatorsFromInput(e.target.value),
                 })
               }
               rows={3}
+              placeholder={"\\n"}
               className="w-full rounded border border-border bg-card px-2 py-2"
             />
           </label>

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -150,6 +150,8 @@ export type {
 export {
   createDefaultChunkingConfig,
   normalizeChunkingConfig,
+  encodeSeparatorsForDisplay,
+  decodeSeparatorsFromInput,
   normalizeCorpusExtractorRoutes,
   createEmptyExtractorDraftTarget,
   normalizeExtractorDraftRoutes,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -55,6 +55,73 @@ export type ChunkingConfig =
   | SemanticChunkingConfig
   | HierarchicalChunkingConfig;
 
+/**
+ * 将 separators 数组编码为 textarea 可显示的文本。
+ *
+ * 每个 separator 中的特殊字符以转义序列表示（真实 \n → 字面量 \\n），
+ * 然后以真实换行符 join 各项，实现「每行一个 separator」的体验。
+ */
+export function encodeSeparatorsForDisplay(separators: string[]): string {
+  return separators
+    .map((sep) => {
+      if (sep === "") return "<empty>";
+      return sep
+        .replace(/\\/g, "\\\\")
+        .replace(/\n/g, "\\n")
+        .replace(/\t/g, "\\t")
+        .replace(/\r/g, "\\r");
+    })
+    .join("\n");
+}
+
+/**
+ * 将 textarea 文本解码回 separators 数组。
+ *
+ * 按真实换行拆分行，每行做反转义处理。
+ * 使用逐字符扫描避免正则替换的顺序依赖问题。
+ */
+export function decodeSeparatorsFromInput(text: string): string[] {
+  return text
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      if (line === "<empty>") return "";
+      let result = "";
+      let i = 0;
+      while (i < line.length) {
+        if (line[i] === "\\" && i + 1 < line.length) {
+          const next = line[i + 1];
+          switch (next) {
+            case "n":
+              result += "\n";
+              i += 2;
+              break;
+            case "t":
+              result += "\t";
+              i += 2;
+              break;
+            case "r":
+              result += "\r";
+              i += 2;
+              break;
+            case "\\":
+              result += "\\";
+              i += 2;
+              break;
+            default:
+              result += line[i];
+              i += 1;
+              break;
+          }
+        } else {
+          result += line[i];
+          i += 1;
+        }
+      }
+      return result;
+    });
+}
+
 export function createDefaultChunkingConfig(
   strategy: ChunkingStrategy = "recursive",
 ): ChunkingConfig {
@@ -78,7 +145,7 @@ export function createDefaultChunkingConfig(
       return {
         strategy,
         preserve_newlines: true,
-        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+        separators: ["\n"],
         hierarchical_parent_chunk_size: 1024,
         hierarchical_child_chunk_size: 256,
         hierarchical_child_overlap: 51,
@@ -90,7 +157,7 @@ export function createDefaultChunkingConfig(
         chunk_size: 800,
         overlap: 100,
         preserve_newlines: true,
-        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+        separators: ["\n"],
       };
   }
 }

--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -4,6 +4,8 @@ import {
   buildExtractorRoutesFromDraft,
   createDefaultChunkingConfig,
   createEmptyExtractorDraftTarget,
+  encodeSeparatorsForDisplay,
+  decodeSeparatorsFromInput,
   normalizeChunkingConfig,
   normalizeCorpusExtractorRoutes,
   normalizeExtractorDraftRoutes,
@@ -119,6 +121,8 @@ export function primeKnowledgeFeatureMocks(
 export function createKnowledgeConfigTestExports() {
   return {
     createDefaultChunkingConfig,
+    encodeSeparatorsForDisplay,
+    decodeSeparatorsFromInput,
     normalizeChunkingConfig,
     normalizeCorpusExtractorRoutes,
     createEmptyExtractorDraftTarget,

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -493,7 +493,7 @@ describe("KnowledgeBasePage", () => {
         chunk_size: 800,
         overlap: 100,
         preserve_newlines: true,
-        separators: ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""],
+        separators: ["\n"],
       },
     });
   });

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -3,6 +3,8 @@ import {
   buildCorpusConfig,
   createEmptyExtractorDraftTarget,
   createDefaultChunkingConfig,
+  encodeSeparatorsForDisplay,
+  decodeSeparatorsFromInput,
   fetchCorpus,
   fetchDocumentChunks,
   fetchDocuments,
@@ -348,5 +350,94 @@ describe("fetchCorpus", () => {
         ],
       },
     });
+  });
+});
+
+// ============================================================================
+// Separator Textarea 编解码
+// ============================================================================
+
+describe("encodeSeparatorsForDisplay", () => {
+  it("将换行符编码为 \\n 文本", () => {
+    expect(encodeSeparatorsForDisplay(["\n"])).toBe("\\n");
+  });
+
+  it("将双换行编码为 \\n\\n 文本", () => {
+    expect(encodeSeparatorsForDisplay(["\n\n"])).toBe("\\n\\n");
+  });
+
+  it("将普通字符原样保留", () => {
+    expect(encodeSeparatorsForDisplay(["。", ". "])).toBe("。\n. ");
+  });
+
+  it("将空字符串编码为 <empty> 标记", () => {
+    expect(encodeSeparatorsForDisplay([""])).toBe("<empty>");
+  });
+
+  it("将反斜杠编码为双反斜杠", () => {
+    expect(encodeSeparatorsForDisplay(["\\"])).toBe("\\\\");
+  });
+
+  it("正确编码含反斜杠+n 的字面量", () => {
+    expect(encodeSeparatorsForDisplay(["\\n"])).toBe("\\\\n");
+  });
+
+  it("编码新默认值 [\\n] 为单行 \\n", () => {
+    const defaults = createDefaultChunkingConfig("recursive");
+    if (defaults.strategy === "recursive") {
+      expect(encodeSeparatorsForDisplay(defaults.separators)).toBe("\\n");
+    }
+  });
+});
+
+describe("decodeSeparatorsFromInput", () => {
+  it("将 \\n 文本解码为换行符", () => {
+    expect(decodeSeparatorsFromInput("\\n")).toEqual(["\n"]);
+  });
+
+  it("将 \\n\\n 文本解码为双换行", () => {
+    expect(decodeSeparatorsFromInput("\\n\\n")).toEqual(["\n\n"]);
+  });
+
+  it("将普通字符原样保留", () => {
+    expect(decodeSeparatorsFromInput("。\n. ")).toEqual(["。", ". "]);
+  });
+
+  it("将 <empty> 标记解码为空字符串", () => {
+    expect(decodeSeparatorsFromInput("<empty>")).toEqual([""]);
+  });
+
+  it("将双反斜杠解码为单反斜杠", () => {
+    expect(decodeSeparatorsFromInput("\\\\")).toEqual(["\\"]);
+  });
+
+  it("过滤意外空行", () => {
+    expect(decodeSeparatorsFromInput("\\n\n\n。")).toEqual(["\n", "。"]);
+  });
+
+  it("保留尾部空格（如 '. '）", () => {
+    expect(decodeSeparatorsFromInput(". ")).toEqual([". "]);
+  });
+});
+
+describe("separator encode/decode 往返一致性", () => {
+  it("新默认值 [\\n] 往返一致", () => {
+    const seps = ["\n"];
+    expect(decodeSeparatorsFromInput(encodeSeparatorsForDisplay(seps))).toEqual(seps);
+  });
+
+  it("旧 12 元素默认值往返一致", () => {
+    const oldDefaults = ["\n\n", "\n", "。", "！", "？", ". ", "! ", "? ", "；", ";", " ", ""];
+    expect(decodeSeparatorsFromInput(encodeSeparatorsForDisplay(oldDefaults))).toEqual(oldDefaults);
+  });
+
+  it("含字面量反斜杠的 separator 往返一致", () => {
+    const seps = ["\\n", "\\"];
+    expect(decodeSeparatorsFromInput(encodeSeparatorsForDisplay(seps))).toEqual(seps);
+  });
+
+  it("混合特殊字符往返一致", () => {
+    const seps = ["\n\n", "\t", "\r\n", "。", ""];
+    expect(decodeSeparatorsFromInput(encodeSeparatorsForDisplay(seps))).toEqual(seps);
   });
 });


### PR DESCRIPTION
## Summary

- 将 Recursive (Structure Aware) 与 Hierarchical (Parent + Child) 策略的默认 Separators 从 12 元素数组简化为 `["\n"]`，降低新用户认知负荷
- 新增 `encodeSeparatorsForDisplay` / `decodeSeparatorsFromInput` 转义函数，解决 textarea 中换行符（`\n`）与行分隔符混淆导致的显示混乱问题
- 更新 `CorpusFormDialog` 与 `page.tsx` 共 4 处 textarea 使用新编解码逻辑
- 后端默认值不变，仅影响前端新建 Corpus 时的初始值；编辑已有 Corpus 时正确回显旧配置

## Test plan

- [x] 新增 18 个 encode/decode 单元测试（往返一致性、旧默认值兼容、空字符串、反斜杠等边缘 case）
- [x] 更新 KnowledgeBasePage 测试断言，全部通过（360 passed）
- [ ] 手动验证：新建 Corpus → textarea 默认显示 `\n`
- [ ] 手动验证：编辑含旧 12 元素 separators 的 Corpus → 正确回显转义后的分隔符列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)