### PR TITLE
style(Retrieved-Chunks): 将 Retrieved Chunks 卡片与 Chunk Detail 模态框内容等比例缩小至 4/5

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx
@@ -57,19 +57,19 @@ export function RetrievedChunkCard({
         }
       }}
       className={cn(
-        "rounded-2xl border border-border bg-card text-left shadow-sm transition",
+        "rounded-xl border border-border bg-card text-left shadow-sm transition",
         "hover:border-border-muted hover:bg-card/95",
         className,
       )}
     >
-      <div className={cn("flex items-start justify-between gap-4 px-4 pt-4", isCompact && "gap-3")}>
+      <div className={cn("flex items-start justify-between gap-3 px-3 pt-3", isCompact && "gap-2.5")}>
         <div
           className={cn(
-            "flex min-w-0 flex-wrap items-center gap-2 text-sm font-medium text-zinc-500 dark:text-zinc-400",
-            isCompact && "text-xs",
+            "flex min-w-0 flex-wrap items-center gap-1.5 text-[11px] font-medium text-zinc-500 dark:text-zinc-400",
+            isCompact && "text-[10px]",
           )}
         >
-          <Grip className={cn("h-3.5 w-3.5 shrink-0", isCompact && "h-3 w-3")} />
+          <Grip className={cn("h-[11px] w-[11px] shrink-0", isCompact && "h-2.5 w-2.5")} />
           <span className="truncate text-zinc-600 dark:text-zinc-400">{chunk.title}</span>
           <span className="shrink-0 text-zinc-400 dark:text-zinc-500">·</span>
           <span className="shrink-0 text-zinc-600 dark:text-zinc-400">{chunk.characterCount} characters</span>
@@ -78,8 +78,8 @@ export function RetrievedChunkCard({
         {!hideScores && (
           <span
             className={cn(
-              "shrink-0 rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white",
-              isCompact && "px-1.5 py-0.5 text-[10px]",
+              "shrink-0 rounded bg-blue-600 px-1.5 py-[3px] text-[9px] font-semibold text-white",
+              isCompact && "px-1 py-[2px] text-[8px]",
             )}
           >
             SCORE {formatScore(chunk.score)}
@@ -87,11 +87,11 @@ export function RetrievedChunkCard({
         )}
       </div>
 
-      <div className="px-4 pb-3 pt-2">
+      <div className="px-3 pb-2.5 pt-1.5">
         <p
           className={cn(
-            "line-clamp-2 whitespace-pre-wrap text-[15px] font-medium text-foreground",
-            isCompact && "text-sm",
+            "line-clamp-2 whitespace-pre-wrap text-[12px] font-medium text-foreground",
+            isCompact && "text-[11px]",
           )}
         >
           {chunk.preview}
@@ -99,7 +99,7 @@ export function RetrievedChunkCard({
       </div>
 
       {hasChildren && (
-        <div className="px-4 pb-4">
+        <div className="px-3 pb-3">
           <button
             type="button"
             aria-expanded={isExpanded}
@@ -109,27 +109,27 @@ export function RetrievedChunkCard({
               setIsExpanded((prev) => !prev);
             }}
             className={cn(
-              "flex items-center gap-2 text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-300",
-              isCompact && "text-xs",
+              "flex items-center gap-1.5 text-[11px] font-semibold tracking-wide text-zinc-700 dark:text-zinc-300",
+              isCompact && "text-[10px]",
             )}
           >
             {isExpanded ? (
-              <ChevronDown className={cn("h-4 w-4", isCompact && "h-3.5 w-3.5")} />
+              <ChevronDown className={cn("h-3.5 w-3.5", isCompact && "h-3 w-3")} />
             ) : (
-              <ChevronRight className={cn("h-4 w-4", isCompact && "h-3.5 w-3.5")} />
+              <ChevronRight className={cn("h-3.5 w-3.5", isCompact && "h-3 w-3")} />
             )}
             <span>HIT {chunk.childHitCount} CHILD CHUNKS</span>
           </button>
 
           {isExpanded && chunk.childChunks.length > 0 && (
-            <div id={childSectionId} className="mt-3 flex flex-col gap-2">
+            <div id={childSectionId} className="mt-2.5 flex flex-col gap-1.5">
               {chunk.childChunks.map((childChunk) => {
                 const childContent = (
                   <>
                     <span
                       className={cn(
-                        "rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white",
-                        isCompact && "px-1.5 py-0.5 text-[10px]",
+                        "rounded bg-blue-600 px-1.5 py-[3px] text-[9px] font-semibold text-white",
+                        isCompact && "px-1 py-[2px] text-[8px]",
                       )}
                     >
                       {childChunk.label}
@@ -137,8 +137,8 @@ export function RetrievedChunkCard({
                     {!hideScores && (
                       <span
                         className={cn(
-                          "rounded bg-blue-600/85 px-2 py-1 text-[11px] font-semibold text-white",
-                          isCompact && "px-1.5 py-0.5 text-[10px]",
+                          "rounded bg-blue-600/85 px-1.5 py-[3px] text-[9px] font-semibold text-white",
+                          isCompact && "px-1 py-[2px] text-[8px]",
                         )}
                       >
                         SCORE {formatScore(childChunk.score)}
@@ -146,8 +146,8 @@ export function RetrievedChunkCard({
                     )}
                     <span
                       className={cn(
-                        "line-clamp-1 min-w-0 flex-1 rounded bg-blue-500/20 px-2 py-1 text-sm text-foreground",
-                        isCompact && "text-xs",
+                        "line-clamp-1 min-w-0 flex-1 rounded bg-blue-500/20 px-1.5 py-[3px] text-[11px] text-foreground",
+                        isCompact && "text-[10px]",
                       )}
                     >
                       {childChunk.content}
@@ -165,8 +165,8 @@ export function RetrievedChunkCard({
                         onChildChunkOpen(childChunk.id);
                       }}
                       className={cn(
-                        "flex w-full flex-wrap items-center gap-2 text-left text-sm text-foreground",
-                        isCompact && "text-xs",
+                        "flex w-full flex-wrap items-center gap-1.5 text-left text-[11px] text-foreground",
+                        isCompact && "text-[10px]",
                       )}
                     >
                       {childContent}
@@ -178,8 +178,8 @@ export function RetrievedChunkCard({
                   <div
                     key={childChunk.id}
                     className={cn(
-                      "flex flex-wrap items-center gap-2 text-sm text-foreground",
-                      isCompact && "text-xs",
+                      "flex flex-wrap items-center gap-1.5 text-[11px] text-foreground",
+                      isCompact && "text-[10px]",
                     )}
                   >
                     {childContent}
@@ -194,12 +194,12 @@ export function RetrievedChunkCard({
       {!hideFooter && (
         <div
           className={cn(
-            "flex items-center justify-between gap-4 border-t border-border px-4 py-3 text-sm",
-            isCompact && "text-xs",
+            "flex items-center justify-between gap-3 border-t border-border px-3 py-2.5 text-[11px]",
+            isCompact && "text-[10px]",
           )}
         >
-          <div className="flex min-w-0 items-center gap-2 text-zinc-700 dark:text-zinc-200">
-            <FileText className={cn("h-4 w-4 shrink-0 text-red-500", isCompact && "h-3.5 w-3.5")} />
+          <div className="flex min-w-0 items-center gap-1.5 text-zinc-700 dark:text-zinc-200">
+            <FileText className={cn("h-3.5 w-3.5 shrink-0 text-red-500", isCompact && "h-3 w-3")} />
             <span className="truncate" title={chunk.sourceTitle}>
               {chunk.sourceLabel}
             </span>
@@ -211,12 +211,12 @@ export function RetrievedChunkCard({
               handleOpen();
             }}
             className={cn(
-              "inline-flex items-center gap-1 text-sm font-medium uppercase tracking-wide text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100",
-              isCompact && "text-xs",
+              "inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100",
+              isCompact && "text-[10px]",
             )}
           >
             <span>Open</span>
-            <ExternalLink className={cn("h-4 w-4", isCompact && "h-3.5 w-3.5")} />
+            <ExternalLink className={cn("h-3.5 w-3.5", isCompact && "h-3 w-3")} />
           </button>
         </div>
       )}

--- a/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkDetailDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkDetailDialog.tsx
@@ -50,65 +50,65 @@ export function RetrievedChunkDetailDialog({
         "aria-labelledby": titleId,
       }}
     >
-      <div className="flex items-start justify-between gap-4 px-5 py-5">
-        <h2 id={titleId} className="text-3xl font-semibold text-foreground">
+      <div className="flex items-start justify-between gap-3 px-4 py-4">
+        <h2 id={titleId} className="text-2xl font-semibold text-foreground">
           Chunk Detail
         </h2>
         <button
           type="button"
           aria-label="Close chunk detail"
           onClick={onClose}
-          className="rounded-full border border-border p-2 text-zinc-400 hover:text-foreground"
+          className="rounded-full border border-border p-1.5 text-zinc-400 hover:text-foreground"
         >
-          <X className="h-5 w-5" />
+          <X className="h-4 w-4" />
         </button>
       </div>
 
-      <div className="min-h-0 flex-1 px-5 pb-5">
-        <div className={`grid h-full min-h-0 gap-5 ${isHierarchical ? "lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]" : "grid-cols-1"}`}>
-          <section className="min-h-0 rounded-3xl bg-card px-1">
-            <div className="mb-4 flex flex-wrap items-center gap-3 text-sm font-medium text-zinc-400">
-              <span className="inline-flex items-center gap-2">
-                <Grip className="h-3.5 w-3.5" />
+      <div className="min-h-0 flex-1 px-4 pb-4">
+        <div className={`grid h-full min-h-0 gap-4 ${isHierarchical ? "lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]" : "grid-cols-1"}`}>
+          <section className="min-h-0 rounded-2xl bg-card px-1">
+            <div className="mb-3 flex flex-wrap items-center gap-2.5 text-[11px] font-medium text-zinc-400">
+              <span className="inline-flex items-center gap-1.5">
+                <Grip className="h-[11px] w-[11px]" />
                 {chunk.title}
               </span>
-              <span className="inline-flex items-center gap-2">
-                <FileText className="h-4 w-4 text-red-500" />
+              <span className="inline-flex items-center gap-1.5">
+                <FileText className="h-3.5 w-3.5 text-red-500" />
                 <span title={chunk.sourceTitle}>{chunk.sourceLabel}</span>
               </span>
             </div>
-            <div className="mb-4 flex items-center justify-between gap-4">
-              <div className="text-sm text-zinc-500 dark:text-zinc-400">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="text-[11px] text-zinc-500 dark:text-zinc-400">
                 {chunk.characterCount} characters
               </div>
-              <span className="rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white">
+              <span className="rounded bg-blue-600 px-1.5 py-[3px] text-[9px] font-semibold text-white">
                 SCORE {formatScore(chunk.score)}
               </span>
             </div>
-            <div className="h-[calc(100%-4.5rem)] overflow-y-auto pr-2">
-              <p className="whitespace-pre-wrap text-[16px] leading-9 text-foreground">
+            <div className="h-[calc(100%-3.5rem)] overflow-y-auto pr-2">
+              <p className="whitespace-pre-wrap text-[13px] leading-7 text-foreground">
                 {chunk.fullContent}
               </p>
             </div>
           </section>
 
           {isHierarchical && (
-            <aside className="flex min-h-0 flex-col rounded-3xl border border-border bg-background/30 p-4">
-              <div className="mb-4 text-xl font-semibold text-foreground">
+            <aside className="flex min-h-0 flex-col rounded-2xl border border-border bg-background/30 p-3">
+              <div className="mb-3 text-base font-semibold text-foreground">
                 HIT {chunk.childHitCount} CHILD CHUNKS
               </div>
-              <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+              <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto pr-1">
                 {chunk.childChunks.map((childChunk) => (
-                  <div key={childChunk.id} className="space-y-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="rounded bg-blue-600 px-2 py-1 text-[11px] font-semibold text-white">
+                  <div key={childChunk.id} className="space-y-1.5">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="rounded bg-blue-600 px-1.5 py-[3px] text-[9px] font-semibold text-white">
                         {childChunk.label}
                       </span>
-                      <span className="rounded bg-blue-600/85 px-2 py-1 text-[11px] font-semibold text-white">
+                      <span className="rounded bg-blue-600/85 px-1.5 py-[3px] text-[9px] font-semibold text-white">
                         SCORE {formatScore(childChunk.score)}
                       </span>
                     </div>
-                    <p className="whitespace-pre-wrap break-words rounded bg-blue-500/20 px-3 py-2 text-sm text-foreground">
+                    <p className="whitespace-pre-wrap break-words rounded bg-blue-500/20 px-2.5 py-1.5 text-[11px] text-foreground">
                       {childChunk.content}
                     </p>
                   </div>

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1191,11 +1191,11 @@ export default function KnowledgeBasePage() {
           <div className="h-full overflow-y-auto">
             <div className="space-y-4 pb-28">
               {retrievalDocked && retrievalResults.length > 0 && (
-                <div className="rounded-2xl border border-border bg-card p-4 shadow-sm">
-                  <div className="mb-3 text-3xl font-semibold text-foreground">
+                <div className="rounded-xl border border-border bg-card p-3 shadow-sm">
+                  <div className="mb-2.5 text-2xl font-semibold text-foreground">
                     {retrievedChunkCards.length} Retrieved Chunks
                   </div>
-                  <div className="space-y-2">
+                  <div className="space-y-1.5">
                     {retrievedChunkCards.map((item) => (
                       <RetrievedChunkCard
                         key={`${item.id}-${item.raw.metadata?.corpus_id || "na"}`}

--- a/apps/negentropy-ui/tests/unit/knowledge/RetrievedChunkCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/RetrievedChunkCard.test.tsx
@@ -76,9 +76,9 @@ describe("RetrievedChunkCard", () => {
 
     render(<RetrievedChunkCard chunk={createChunk()} onOpen={onOpen} density="compact" />);
 
-    expect(screen.getByText("parent chunk preview").className).toContain("text-sm");
-    expect(screen.getByText("SCORE 0.91").className).toContain("text-[10px]");
-    expect(screen.getByText("Open").closest("button")?.className).toContain("text-xs");
+    expect(screen.getByText("parent chunk preview").className).toContain("text-[11px]");
+    expect(screen.getByText("SCORE 0.91").className).toContain("text-[8px]");
+    expect(screen.getByText("Open").closest("button")?.className).toContain("text-[10px]");
 
     await user.click(screen.getByText("Open"));
 


### PR DESCRIPTION
## 变更摘要

将 Knowledge Base 页面中 **Retrieved Chunks 卡片列表**与 **Chunk Detail 模态框**的所有内容（字号、内边距、图标尺寸、间距）等比例缩小至当前的 **4/5（80%）**，提升信息密度与视觉紧凑性。

## 变更动因

原有卡片与模态框内容偏大，在标准屏幕下单屏可视信息量有限。通过统一缩放至 80%，在保持可读性的前提下提高单屏信息承载密度。

## 实现细节

### 涉及文件

| 文件 | 变更内容 |
|------|---------|
| `apps/negentropy-ui/app/knowledge/base/page.tsx` | 容器圆角 `rounded-2xl` → `rounded-xl`，内边距 `p-4` → `p-3`，标题 `text-3xl` → `text-2xl`，卡片间距 `space-y-2` → `space-y-1.5` |
| `apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx` | 所有字号、内边距、图标尺寸、间距统一缩至 80%（default 与 compact 两种密度均已处理） |
| `apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkDetailDialog.tsx` | 模态框整体尺寸（`h-[82vh] max-w-6xl`）与分栏比例不变，内部所有内容缩至 80% |
| `apps/negentropy-ui/tests/unit/knowledge/RetrievedChunkCard.test.tsx` | 同步更新 compact 密度断言中的 CSS 类名 |

### 缩放策略

- 优先使用标准 Tailwind 类（如 `px-4` → `px-3`）
- 当 80% 值落在标准阶梯之间时使用任意值（如 `text-[11px]`、`py-[3px]`）
- Chunk Detail 模态框整体尺寸与左右分栏比例保持不变，仅缩小内部内容

## 测试验证

- RetrievedChunkCard 单元测试 4/4 通过
- KnowledgeBasePage 集成测试 33/33 通过
- 无回归

🤖 Generated with [Claude Code](https://github.com/claude)