### PR TITLE
fix(Document Chunks): 修复层级分块场景下 Child Chunks 在列表中重复显示的问题

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1977,20 +1977,33 @@ async def list_document_chunks(
         )
 
     service = _get_service()
-    items, total_count, _, _ = await service.list_knowledge(
+    # 获取该文档下全量 chunks（含 parent + child + leaf），用于 sibling 匹配
+    all_items, _, _, _ = await service.list_knowledge(
         corpus_id=corpus_id,
         app_name=resolved_app,
         source_uri=source_uri,
         include_archived=include_archived,
-        limit=limit,
-        offset=offset,
+        limit=10000,
+        offset=0,
     )
-    serialized = [_serialize_document_chunk_item(item, items) for item in items]
+
+    # 过滤顶层项：排除 child chunks（它们仅作为 parent 的嵌套子项显示）
+    top_level_items = [
+        item for item in all_items
+        if (item.metadata or {}).get("chunk_role") != "child"
+    ]
+
+    # Python 层分页
+    total_top = len(top_level_items)
+    paginated = top_level_items[offset : offset + limit]
+
+    # 序列化：传入 all_items 作为 siblings，确保 parent 能匹配到 child
+    serialized = [_serialize_document_chunk_item(item, all_items) for item in paginated]
     return DocumentChunksResponse(
-        count=total_count,
+        count=total_top,
         page=(offset // limit) + 1,
         page_size=limit,
-        document_metadata=_build_document_chunk_metadata(doc, items),
+        document_metadata=_build_document_chunk_metadata(doc, all_items),
         items=serialized,
     )
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 from io import BytesIO
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
 from fastapi import BackgroundTasks, HTTPException, UploadFile
 
 from negentropy.knowledge import api as knowledge_api
-from negentropy.knowledge.types import ChunkingStrategy
+from negentropy.knowledge.types import ChunkingStrategy, KnowledgeRecord
 
 from .conftest import FakeKnowledgeService, FakeStorageService
 
@@ -82,6 +83,73 @@ async def test_list_document_chunks_invalid_source(monkeypatch):
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail["code"] == "INVALID_DOCUMENT_SOURCE"
+
+
+@pytest.mark.asyncio
+async def test_list_document_chunks_excludes_child_from_top_level(monkeypatch):
+    """层级分块场景：child chunks 不应出现在顶层 items 中，仅嵌套在 parent 下。"""
+    corpus_id = uuid4()
+    document_id = uuid4()
+    family_id = "family-001"
+
+    parent = KnowledgeRecord(
+        id=uuid4(),
+        corpus_id=corpus_id,
+        app_name="negentropy",
+        content="parent content",
+        source_uri="https://example.com/a",
+        chunk_index=0,
+        metadata={"chunk_role": "parent", "chunk_family_id": family_id},
+        created_at=None,
+        updated_at=None,
+        embedding=None,
+    )
+    child = KnowledgeRecord(
+        id=uuid4(),
+        corpus_id=corpus_id,
+        app_name="negentropy",
+        content="child content",
+        source_uri="https://example.com/a",
+        chunk_index=1,
+        metadata={
+            "chunk_role": "child",
+            "chunk_family_id": family_id,
+            "child_chunk_index": 0,
+        },
+        created_at=None,
+        updated_at=None,
+        embedding=None,
+    )
+
+    fake_service = FakeKnowledgeService()
+    fake_service.list_knowledge = AsyncMock(return_value=([parent, child], 2, {}, []))
+
+    doc = SimpleNamespace(
+        id=document_id,
+        metadata_={"source_type": "url", "origin_url": "https://example.com/a"},
+        gcs_uri=None,
+    )
+    fake_storage = FakeStorageService(doc=doc)
+
+    monkeypatch.setattr("negentropy.storage.service.DocumentStorageService", lambda: fake_storage)
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+
+    result = await knowledge_api.list_document_chunks(
+        corpus_id=corpus_id,
+        document_id=document_id,
+        app_name="negentropy",
+        include_archived=False,
+        limit=50,
+        offset=0,
+    )
+
+    # 顶层只有 parent，不含 child
+    assert result.count == 1
+    assert len(result.items) == 1
+    assert result.items[0]["chunk_role"] == "parent"
+    # child 嵌套在 parent 的 child_chunks 中
+    assert len(result.items[0]["child_chunks"]) == 1
+    assert result.items[0]["child_chunks"][0]["chunk_role"] == "child"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

在 Corpus 的 Document Chunks 视图中，启用层级分块（Hierarchical Chunking）的文档，其 Child Chunks 同时出现在两处：
1. **正确地**嵌套在 Parent Chunk 下的"CHILD CHUNKS"折叠区域内
2. **错误地**作为独立的顶层条目再次显示（如 Chunk-01 到 Chunk-05）

导致列表中 Child Chunks 重复显示，且顶部"N Chunks"计数包含了 Child Chunks，数值偏大。

## 根因

`list_document_chunks()` 端点调用 `service.list_knowledge()` 获取所有 chunks（含 parent 和 child），然后对**每一条** item 都执行序列化并作为顶层项返回。`_serialize_document_chunk_item()` 虽然正确地将 child 嵌套到 parent 下，但 child 自身仍然作为独立顶层项出现在响应的 `items` 数组中。

## 修复方案

采用"全量获取 + Python 层过滤/分页"策略，仅修改 `api.py:list_document_chunks()`：

- 获取该文档下**全量** chunks（含 parent + child + leaf），用于 sibling 匹配
- 过滤 `chunk_role != "child"` 的 items 作为顶层显示项
- 在 Python 层对顶层项应用 `offset`/`limit` 分页
- 序列化时将全量 items 作为 siblings 传入，确保 parent 的嵌套 child 能正确匹配
- `count` 返回顶层项总数（不含 child），修正计数偏大问题

> 单文档的 chunk 数量有界（通常数百级），全量获取的内存开销可忽略。

## 涉及文件

- `apps/negentropy/src/negentropy/knowledge/api.py` — `list_document_chunks()` 端点逻辑
- `apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py` — 新增层级 chunk 列表测试

## 检索正确性验证

对 Parent-Child 策略下的检索流程进行了完整审计，确认**不受本次修改影响**：
- **索引**：仅 Child Chunks 生成 embedding（`searchable=True`）
- **检索**：仅 Child Chunks 参与近似匹配
- **提升**：`_lift_hierarchical_matches()` 将命中的 Child 提升为 Parent 返回
- 本次修复仅涉及 Document Chunks **列表展示**，不影响检索链路

## 测试计划

- [x] 单元测试通过：`uv run pytest tests/unit_tests/knowledge/test_api_documents.py -v`（13 passed）
- [ ] UI 验证：确认 Child Chunks 不再重复显示，计数仅统计顶层项

🤖 Generated with [Claude Code](https://claude.com/claude-code)