### PR TITLE
fix(McpServerTrialDialog): 修复试用模态框三栏面板内容溢出

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerTrialDialog.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerTrialDialog.tsx
@@ -418,9 +418,9 @@ export function McpServerTrialDialog({
       </div>
 
       <div className="grid min-h-0 flex-1 grid-cols-12 gap-4">
-        <div className="col-span-3 min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
-          <div className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">Tools</div>
-          <div className="h-full overflow-auto space-y-4">
+        <div className="col-span-3 flex min-h-0 flex-col rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+          <div className="shrink-0 mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">Tools</div>
+          <div className="min-h-0 flex-1 overflow-y-auto space-y-4">
             {groupedTools.map(([group, items]) => (
               <div key={group}>
                 <div className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">{group}</div>
@@ -445,15 +445,15 @@ export function McpServerTrialDialog({
           </div>
         </div>
 
-        <div className="col-span-4 min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
-          <div className="mb-3 flex items-center justify-between">
-            <div>
+        <div className="col-span-4 flex min-h-0 flex-col rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+          <div className="shrink-0 mb-3 flex items-center justify-between gap-2">
+            <div className="min-w-0">
               <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                 {selectedTool?.display_name || selectedTool?.title || selectedTool?.name || "选择 Tool"}
               </div>
-              <div className="text-xs text-zinc-500">{selectedTool?.description || "暂无描述"}</div>
+              <div className="line-clamp-3 text-xs text-zinc-500">{selectedTool?.description || "暂无描述"}</div>
             </div>
-            <div className="flex gap-2 text-xs">
+            <div className="flex shrink-0 gap-2 text-xs">
               <button
                 className={`rounded px-2 py-1 ${formMode === "guided" ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900" : "bg-zinc-100 dark:bg-zinc-800"}`}
                 onClick={() => setFormMode("guided")}
@@ -469,7 +469,7 @@ export function McpServerTrialDialog({
             </div>
           </div>
 
-          <div className="h-[calc(100%-7rem)] overflow-auto space-y-3">
+          <div className="min-h-0 flex-1 overflow-y-auto space-y-3">
             {formMode === "raw" ? (
               <textarea
                 value={rawJson}
@@ -488,7 +488,7 @@ export function McpServerTrialDialog({
             </div>
           </div>
 
-          <div className="mt-3 flex items-center justify-between">
+          <div className="shrink-0 mt-3 flex items-center justify-between">
             <div className="text-xs text-red-500">{error}</div>
             <button
               onClick={handleExecute}
@@ -501,9 +501,9 @@ export function McpServerTrialDialog({
         </div>
 
         <div className="col-span-5 grid min-h-0 grid-rows-[220px_minmax(0,1fr)] gap-4">
-          <div className="min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
-            <div className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">执行历史</div>
-            <div className="h-full overflow-auto space-y-2">
+          <div className="flex min-h-0 flex-col rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+            <div className="shrink-0 mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">执行历史</div>
+            <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
               {historyLoading ? (
                 <div className="text-sm text-zinc-500">加载中...</div>
               ) : history.length === 0 ? (
@@ -532,12 +532,12 @@ export function McpServerTrialDialog({
             </div>
           </div>
 
-          <div className="min-h-0 rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
-            <div className="mb-3 flex items-center justify-between">
+          <div className="flex min-h-0 flex-col rounded-xl border border-zinc-200 p-3 dark:border-zinc-700">
+            <div className="shrink-0 mb-3 flex items-center justify-between">
               <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">白盒详情</div>
               <div className="text-xs text-zinc-500">{activeRun ? `${activeRun.status} · ${activeRun.duration_ms} ms` : "-"}</div>
             </div>
-            <div className="h-full overflow-auto space-y-4">
+            <div className="min-h-0 flex-1 overflow-y-auto space-y-4">
               {!activeRun ? (
                 <div className="text-sm text-zinc-500">选择一条执行记录查看详情</div>
               ) : (


### PR DESCRIPTION
## 概要

修复 MCP Server 试用模态框（McpServerTrialDialog）中三栏面板内容溢出浏览器下方、滚动条无法到达所有内容的问题。

## 变更内容

- **左栏 Tools 列表**: `h-full overflow-auto` → `flex-col` + `min-h-0 flex-1 overflow-y-auto`
- **中栏参数面板** (核心修复): 移除脆弱的 `h-[calc(100%-7rem)]` 硬编码高度，改为 `flex-col` 三段式弹性布局 (Header/Content/Footer)；tool description 添加 `line-clamp-3` 截断，防止长描述推挤整个布局
- **右栏执行历史 & 白盒详情**: 同左栏模式，统一为 flexbox 弹性布局

## 根因

三栏面板均未正确使用 flexbox 弹性布局约束滚动区域高度，而是依赖 `h-full` 或 `h-[calc(100%-7rem)]` 等硬编码方式。当内容（特别是长 tool description）超出预设高度时，滚动容器边界计算失效，导致内容溢出视窗。

## 测试计划

- [ ] 选择长描述 tool（如 `convert_pdf_to_markdown`），确认 description 被截断为 3 行，表单和"试用该 Tool"按钮均在视窗内
- [ ] 选择参数较多的 tool，确认表单区域可独立滚动，footer 始终可见
- [ ] 确认左栏 tool 列表、右栏执行历史和白盒详情均可正常独立滚动
- [ ] 缩小浏览器高度至约 600px，确认布局仍然正确约束

🤖 Generated with [Claude Code](https://claude.com/claude-code)