### PR TITLE
fix(KnowledgeBase): Document Chunks 卡片移除「HIT」前缀，区别于 Retrieved Chunks 的命中语义

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/RetrievedChunkCard.tsx
@@ -18,6 +18,7 @@ interface RetrievedChunkCardProps {
   density?: "default" | "compact";
   hideFooter?: boolean;
   hideScores?: boolean;
+  showHitPrefix?: boolean;
   badges?: ReactNode;
   onChildChunkOpen?: (childChunkId: string) => void;
 }
@@ -33,6 +34,7 @@ export function RetrievedChunkCard({
   density = "default",
   hideFooter = false,
   hideScores = false,
+  showHitPrefix = true,
   badges,
   onChildChunkOpen,
 }: RetrievedChunkCardProps) {
@@ -118,7 +120,7 @@ export function RetrievedChunkCard({
             ) : (
               <ChevronRight className={cn("h-3.5 w-3.5", isCompact && "h-3 w-3")} />
             )}
-            <span>HIT {chunk.childHitCount} CHILD CHUNKS</span>
+            <span>{showHitPrefix ? "HIT " : ""}{chunk.childHitCount} CHILD CHUNKS</span>
           </button>
 
           {isExpanded && chunk.childChunks.length > 0 && (

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1385,6 +1385,7 @@ export default function KnowledgeBasePage() {
                               density="compact"
                               hideFooter
                               hideScores
+                              showHitPrefix={false}
                               onChildChunkOpen={(childChunkId) => {
                                 const childChunk = chunk.child_chunks.find((child) => child.id === childChunkId);
                                 if (childChunk) {

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -1141,7 +1141,7 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
-    await user.click(screen.getByRole("button", { name: "HIT 1 CHILD CHUNKS" }));
+    await user.click(screen.getByRole("button", { name: "1 CHILD CHUNKS" }));
     await user.click(screen.getAllByRole("button", { name: /C-03.*child chunk content/i }).at(-1)!);
 
     expect(fetchDocumentChunkDetailMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Document Chunks 页面中 Parent Chunk 卡片的「HIT X CHILD CHUNKS」字样改为「X CHILD CHUNKS」，移除「HIT」前缀
- Retrieved Chunks 页面保持原有「HIT X CHILD CHUNKS」显示不变
- 同步更新单元测试断言以匹配新的显示文本

## 背景

Knowledge Base 页面中，Document Chunks 与 Retrieved Chunks 共用 `RetrievedChunkCard` 组件。两处场景语义不同：

- **Retrieved Chunks**：「HIT」表示检索命中（命中了 N 个子 Chunk），语义准确
- **Document Chunks**：仅展示文档的分块结构，「HIT」无实际含义，需要移除以消除语义混淆

## 实现细节

- 为 `RetrievedChunkCard` 组件新增 `showHitPrefix?: boolean` 属性（默认 `true`，向后兼容）
- Document Chunks 区域传入 `showHitPrefix={false}`，Retrieved Chunks 区域保持默认行为
- 测试用例同步更新断言文本

## 改动文件

| 文件 | 变更 |
|------|------|
| `RetrievedChunkCard.tsx` | 新增 `showHitPrefix` 属性，条件渲染 HIT 前缀 |
| `page.tsx` | Document Chunks 区域传入 `showHitPrefix={false}` |
| `KnowledgeBasePage.test.tsx` | 更新测试断言匹配新的显示文本 |

## Test Plan

- [x] 前端单元测试全部通过（105/105）
- [ ] 手动验证 Document Chunks 页面显示 `5 CHILD CHUNKS`（无 HIT）
- [ ] 手动验证 Retrieved Chunks 页面显示 `HIT 5 CHILD CHUNKS`（保留 HIT）

🤖 Generated with [Claude Code](https://claude.com/claude-code)