### PR TITLE
refactor(MCP): 将「MCP Hub」更名为「MCP」

### DIFF
--- a/apps/negentropy-ui/app/plugins/copy.ts
+++ b/apps/negentropy-ui/app/plugins/copy.ts
@@ -1,1 +1,1 @@
-export const MCP_HUB_LABEL = "MCP Hub";
+export const MCP_HUB_LABEL = "MCP";

--- a/apps/negentropy-ui/tests/unit/plugins/PluginsPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/plugins/PluginsPage.test.tsx
@@ -11,7 +11,7 @@ describe("PluginsPage", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders the MCP Hub card with the existing MCP route", async () => {
+  it("renders the MCP card with the existing MCP route", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -29,7 +29,7 @@ describe("PluginsPage", () => {
 
     expect(screen.getByTestId("plugins-nav")).toHaveTextContent("Dashboard");
 
-    const mcpHubLink = screen.getByRole("link", { name: new RegExp(MCP_HUB_LABEL) });
+    const mcpHubLink = screen.getByRole("link", { name: new RegExp(`^${MCP_HUB_LABEL}`) });
     expect(mcpHubLink).toHaveAttribute("href", "/plugins/mcp");
   });
 });


### PR DESCRIPTION
## Summary

- 将 Interface / MCP 页面中的「MCP Hub」标签统一更名为「MCP」，涉及页面标题、子导航 Tab、面包屑导航及 Dashboard 统计卡片
- 仅修改 `MCP_HUB_LABEL` 常量定义（单一事实源），所有引用位置自动同步
- 同步更新单元测试描述及正则匹配，避免与 "Register MCP Server" 链接冲突

## Test Plan

- [x] 单元测试通过（PluginsPage.test.tsx、McpLayout.test.tsx）
- [ ] 验证页面标题、导航 Tab、面包屑显示为「MCP」
- [ ] 验证 Dashboard 统计卡片标题显示为「MCP」

🤖 Generated with [Claude Code](https://claude.com/claude-code)