### PR TITLE
fix(KnowledgeBase): 优化 Document Chunks 卡片显示——移除「HIT」前缀 & Parent Chunks 连续编号

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -111,8 +111,11 @@ function formatDateTime(value?: string | null): string {
 }
 
 function formatChunkLabel(chunk: DocumentChunkItem): string {
-  const prefix = chunk.chunk_role === "parent" ? "Parent" : "Chunk";
-  return `${prefix}-${String(chunk.chunk_index).padStart(2, "0")}`;
+  if (chunk.chunk_role === "parent") {
+    const index = chunk.parent_chunk_index ?? chunk.chunk_index;
+    return `Parent-${String(index).padStart(2, "0")}`;
+  }
+  return `Chunk-${String(chunk.chunk_index).padStart(2, "0")}`;
 }
 
 function toDocumentChunkCardViewModel(chunk: DocumentChunkItem): RetrievedChunkViewModel {


### PR DESCRIPTION
## Summary

- Document Chunks 页面中 Parent Chunk 卡片的「HIT X CHILD CHUNKS」字样改为「X CHILD CHUNKS」，移除「HIT」前缀，区别于 Retrieved Chunks 的检索命中语义
- Parent Chunks 标签从不连续编号（Parent-00, Parent-06, Parent-11...）改为连续编号（Parent-00, Parent-01, Parent-02...），使用已有的 `parent_chunk_index` 字段替代全局 `chunk_index`

## 背景

Knowledge Base 页面中，Document Chunks 与 Retrieved Chunks 共用 `RetrievedChunkCard` 组件：

1. **「HIT」前缀语义混淆**：Retrieved Chunks 中「HIT」表示检索命中，语义准确；Document Chunks 仅展示文档分块结构，「HIT」无实际含义
2. **编号不连续**：后端使用全局 `chunk_index` 递增计数器为所有 chunk（Parent + Child）分配编号，导致 Parent 编号被 Child 占据中间位置而不连续。后端 metadata 中已有连续的 `parent_chunk_index`（0, 1, 2, 3...），前端仅需切换数据源

## 实现细节

### 移除「HIT」前缀

- 为 `RetrievedChunkCard` 组件新增 `showHitPrefix?: boolean` 属性（默认 `true`，向后兼容）
- Document Chunks 区域传入 `showHitPrefix={false}`，Retrieved Chunks 保持默认行为

### Parent Chunks 连续编号

- 修改 `formatChunkLabel()` 函数，Parent 类型优先使用 `parent_chunk_index`（连续编号），缺失时降级为 `chunk_index`
- 非 Parent 类型（leaf/child）保持使用 `chunk_index`，无变化
- 后端无任何修改，`parent_chunk_index` 已正确存储和返回

## 改动文件

| 文件 | 变更 |
|------|------|
| `RetrievedChunkCard.tsx` | 新增 `showHitPrefix` 属性，条件渲染 HIT 前缀 |
| `page.tsx` | Document Chunks 传入 `showHitPrefix={false}`；`formatChunkLabel()` 改用 `parent_chunk_index` |
| `KnowledgeBasePage.test.tsx` | 更新测试断言匹配新的显示文本 |

## Test Plan

- [x] 前端单元测试全部通过（361/361）
- [ ] 手动验证 Document Chunks 页面 Parent Chunk 标签为连续编号（Parent-00, Parent-01, Parent-02...）
- [ ] 手动验证 Document Chunks 页面显示 `5 CHILD CHUNKS`（无 HIT）
- [ ] 手动验证 Retrieved Chunks 页面显示 `HIT 5 CHILD CHUNKS`（保留 HIT）

🤖 Generated with [Claude Code](https://claude.com/claude-code)