### PR TITLE
refactor(Knowledge-Document): 重构文档查看模态框布局，将 Metadata 整合至头部并修复 Created By 数据链路

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -85,7 +85,8 @@ function truncateHash(hash: string | null): string {
 function displayUser(createdBy: string | null): string {
   if (!createdBy) return "-";
   if (createdBy.includes("@")) {
-    return createdBy.split("@")[0];
+    const local = createdBy.split("@")[0];
+    return local || createdBy;
   }
   return createdBy.length > 20 ? `${createdBy.slice(0, 20)}...` : createdBy;
 }
@@ -203,13 +204,22 @@ export function DocumentViewDialog({
       containerClassName="flex min-h-full items-center justify-center p-4"
       contentClassName="flex h-[86vh] w-full max-w-5xl flex-col rounded-2xl bg-white p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200 dark:bg-zinc-900"
     >
-        <div className="mb-4 flex items-start justify-between">
-          <div className="flex items-center gap-3">
+        {/* Header: Title + badges + close */}
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
             {getFileIcon(viewedDoc.content_type)}
             <div className="min-w-0">
-              <h2 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100" title={viewedDoc.original_filename}>
-                {viewedDoc.original_filename}
-              </h2>
+              <div className="flex items-center gap-2">
+                <h2 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100" title={viewedDoc.original_filename}>
+                  {viewedDoc.original_filename}
+                </h2>
+                <span className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${statusBadge.bg} ${statusBadge.text}`}>
+                  {statusBadge.label}
+                </span>
+                <span className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${markdownBadge.bg} ${markdownBadge.text}`}>
+                  {markdownBadge.label}
+                </span>
+              </div>
               <p className="text-xs text-zinc-500 dark:text-zinc-400">
                 {viewedDoc.content_type || "Unknown type"}
               </p>
@@ -217,7 +227,8 @@ export function DocumentViewDialog({
           </div>
           <button
             onClick={onClose}
-            className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+            aria-label="Close document view"
+            className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
           >
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -225,93 +236,81 @@ export function DocumentViewDialog({
           </button>
         </div>
 
-        <div className="mb-4 flex flex-wrap items-center gap-2">
-          <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${statusBadge.bg} ${statusBadge.text}`}>
-            {statusBadge.label}
-          </span>
-          <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${markdownBadge.bg} ${markdownBadge.text}`}>
-            {markdownBadge.label}
-          </span>
-        </div>
-
-        <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-3">
-          <div className="min-h-0 rounded-xl border border-zinc-200 p-4 dark:border-zinc-800 lg:col-span-2">
-            <div className="mb-3 flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Markdown Content</h3>
-              <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                {detail?.markdown_extracted_at ? `Updated ${formatRelativeTime(detail.markdown_extracted_at ?? undefined)}` : ""}
-              </span>
-            </div>
-
-            <div className="h-full max-h-[52vh] overflow-auto rounded-lg bg-zinc-50 p-3 dark:bg-zinc-950">
-              {loadingDetail ? (
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">Loading markdown content...</p>
-              ) : detailError ? (
-                <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
-              ) : markdownStatus === "processing" || markdownStatus === "pending" ? (
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                  Markdown extraction is running in background. Please refresh in a moment.
-                </p>
-              ) : markdownStatus === "failed" ? (
-                <p className="text-sm text-red-600 dark:text-red-400">
-                  {detail?.markdown_extract_error || "Markdown extraction failed. You can re-ingest this source to retry."}
-                </p>
-              ) : (detail?.markdown_content || "").trim().length === 0 ? (
-                <p className="text-sm text-amber-600 dark:text-amber-400">
-                  Markdown content is empty. Click <strong>Re-Parse from GCS</strong> to regenerate from the source document.
-                </p>
-              ) : (
-                <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800 dark:text-zinc-200">
-                  {detail?.markdown_content || "No markdown content available."}
-                </pre>
-              )}
-            </div>
+        {/* Metadata strip */}
+        <div className="mb-4 grid grid-cols-2 gap-x-6 gap-y-1 rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-2.5 text-xs dark:border-zinc-800 dark:bg-zinc-950 sm:grid-cols-3">
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Size</span>
+            <span className="truncate font-medium text-zinc-900 dark:text-zinc-100">
+              {formatFileSize(viewedDoc.file_size)}
+            </span>
           </div>
-
-          <div className="min-h-0 rounded-xl border border-zinc-200 p-4 dark:border-zinc-800">
-            <h3 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">Metadata</h3>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between border-b border-zinc-100 py-2 dark:border-zinc-800">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">File Size</span>
-                <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                  {formatFileSize(viewedDoc.file_size)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between border-b border-zinc-100 py-2 dark:border-zinc-800">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">File Hash</span>
-                <span className="font-mono text-sm text-zinc-900 dark:text-zinc-100" title={viewedDoc.file_hash}>
-                  {truncateHash(viewedDoc.file_hash)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between border-b border-zinc-100 py-2 dark:border-zinc-800">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">Corpus ID</span>
-                <span className="font-mono text-sm text-zinc-900 dark:text-zinc-100" title={viewedDoc.corpus_id}>
-                  {truncateHash(viewedDoc.corpus_id)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between border-b border-zinc-100 py-2 dark:border-zinc-800">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">Storage Path</span>
-                <span className="max-w-[160px] truncate font-mono text-sm text-zinc-900 dark:text-zinc-100" title={viewedDoc.gcs_uri}>
-                  ...{viewedDoc.gcs_uri.slice(-24)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between border-b border-zinc-100 py-2 dark:border-zinc-800">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">Created By</span>
-                <span className="text-sm text-zinc-900 dark:text-zinc-100" title={viewedDoc.created_by || ""}>
-                  {displayUser(viewedDoc.created_by)}
-                </span>
-              </div>
-              <div className="flex items-center justify-between py-2">
-                <span className="text-sm text-zinc-500 dark:text-zinc-400">Created At</span>
-                <span className="text-sm text-zinc-900 dark:text-zinc-100" title={viewedDoc.created_at || ""}>
-                  {formatRelativeTime(viewedDoc.created_at ?? undefined)}
-                </span>
-              </div>
-            </div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Hash</span>
+            <span className="truncate font-mono font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.file_hash}>
+              {truncateHash(viewedDoc.file_hash)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Corpus</span>
+            <span className="truncate font-mono font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.corpus_id}>
+              {truncateHash(viewedDoc.corpus_id)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Storage</span>
+            <span className="truncate font-mono font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.gcs_uri}>
+              {viewedDoc.gcs_uri ? `...${viewedDoc.gcs_uri.slice(-24)}` : "-"}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Created By</span>
+            <span className="truncate font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.created_by || ""}>
+              {displayUser(viewedDoc.created_by)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Created</span>
+            <span className="truncate font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.created_at || ""}>
+              {formatRelativeTime(viewedDoc.created_at ?? undefined)}
+            </span>
           </div>
         </div>
 
-        <div className="mt-6 flex justify-end gap-3">
+        {/* Markdown Content - full width */}
+        <div className="flex min-h-0 flex-1 flex-col rounded-xl border border-zinc-200 p-4 dark:border-zinc-800">
+          <div className="mb-3 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Markdown Content</h3>
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">
+              {detail?.markdown_extracted_at ? `Updated ${formatRelativeTime(detail.markdown_extracted_at ?? undefined)}` : ""}
+            </span>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto rounded-lg bg-zinc-50 p-4 dark:bg-zinc-950">
+            {loadingDetail ? (
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Loading markdown content...</p>
+            ) : detailError ? (
+              <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
+            ) : markdownStatus === "processing" || markdownStatus === "pending" ? (
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                Markdown extraction is running in background. Please refresh in a moment.
+              </p>
+            ) : markdownStatus === "failed" ? (
+              <p className="text-sm text-red-600 dark:text-red-400">
+                {detail?.markdown_extract_error || "Markdown extraction failed. You can re-ingest this source to retry."}
+              </p>
+            ) : (detail?.markdown_content || "").trim().length === 0 ? (
+              <p className="text-sm text-amber-600 dark:text-amber-400">
+                Markdown content is empty. Click <strong>Re-Parse from GCS</strong> to regenerate from the source document.
+              </p>
+            ) : (
+              <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800 dark:text-zinc-200">
+                {detail?.markdown_content || "No markdown content available."}
+              </pre>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-end gap-3">
           <button
             onClick={onClose}
             className="rounded-lg px-4 py-2 text-sm text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -5,11 +5,13 @@ from io import BytesIO
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy import func, select
 
+from negentropy.auth.deps import get_optional_user
+from negentropy.auth.service import AuthUser
 from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
@@ -954,6 +956,7 @@ async def ingest_url(
     corpus_id: UUID,
     payload: IngestUrlRequest,
     background_tasks: BackgroundTasks,
+    user: Optional[AuthUser] = Depends(get_optional_user),
 ) -> AsyncPipelineResponse:
     """异步从 URL 获取内容并摄入知识库
 
@@ -1011,6 +1014,7 @@ async def ingest_url(
                 filename=raw_name,
                 content_type="text/markdown",
                 metadata={"source_type": "url", "origin_url": payload.url},
+                created_by=user.user_id if user else None,
             )
             await storage_service.save_markdown_content(
                 document_id=doc_record.id,
@@ -1222,6 +1226,7 @@ async def ingest_file(
     hierarchical_child_chunk_size: Optional[int] = Form(default=None),
     hierarchical_child_overlap: Optional[int] = Form(default=None),
     store_to_gcs: bool = Form(default=True),
+    user: Optional[AuthUser] = Depends(get_optional_user),
 ) -> AsyncPipelineResponse:
     """从上传文件导入内容到知识库
 
@@ -1325,6 +1330,7 @@ async def ingest_file(
                     filename=raw_filename,
                     content_type=file.content_type,
                     metadata={"source": "ingest_file", "source_type": "file"},
+                    created_by=user.user_id if user else None,
                 )
                 gcs_uri = doc_record.gcs_uri
 

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -94,6 +94,7 @@ class DocumentStorageService:
         filename: str,
         content_type: Optional[str] = None,
         metadata: Optional[dict] = None,
+        created_by: Optional[str] = None,
     ) -> Tuple[KnowledgeDocument, bool]:
         """Upload document to GCS and store metadata.
 
@@ -108,6 +109,7 @@ class DocumentStorageService:
             filename: Original filename
             content_type: MIME type of the file
             metadata: Optional metadata dictionary
+            created_by: Optional user identifier of the uploader
 
         Returns:
             Tuple of (document record, is_new) where is_new is False
@@ -154,6 +156,7 @@ class DocumentStorageService:
                 status="active",
                 markdown_extract_status="pending",
                 metadata_=metadata or {},
+                created_by=created_by,
             )
             db.add(doc)
 


### PR DESCRIPTION
## Summary

重构 Knowledge / Documents 页面的文档查看模态框（`DocumentViewDialog`），优化信息布局与空间利用率，并修复 Created By 字段数据链路缺失问题。

## 变更内容

### 前端 UI 重构 (`DocumentViewDialog.tsx`)
- **Metadata 整合至头部**：将原右侧 Metadata 面板（File Size、File Hash、Corpus ID、Storage Path、Created By、Created At）整合为头部紧凑信息条，采用 `grid-cols-3` 网格布局（2 行 × 3 列）
- **Badges 合并到标题行**：Status 和 Markdown Status 徽章紧跟文件名显示，消除独立行占用
- **Markdown Content 全宽**：移除原 `grid-cols-3` 分栏布局，Markdown 内容区占满模态框宽度，使用 `flex-1` 动态填充剩余高度
- **边缘 Case 修复**：`displayUser()` 处理 `@example.com` 空本地部分邮箱；`gcs_uri` 空值防护

### 后端 Created By 数据链路修复
- **`storage/service.py`**：`upload_and_store()` 方法新增 `created_by` 参数，传递至 `KnowledgeDocument` 构造函数
- **`knowledge/api.py`**：`ingest_file()` 和 `ingest_url()` 端点注入 `Depends(get_optional_user)` 依赖，将 `user.user_id` 作为 `created_by` 传入存储层

## 改动文件

| 文件 | 变更说明 |
|------|----------|
| `apps/negentropy-ui/.../DocumentViewDialog.tsx` | UI 布局重构：头部 Metadata 信息条 + 全宽 Markdown |
| `apps/negentropy/src/.../storage/service.py` | `upload_and_store()` 增加 `created_by` 参数 |
| `apps/negentropy/src/.../knowledge/api.py` | Ingest 端点注入用户身份依赖 |

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)