### PR TITLE
feat(Knowledge-Document): 实现文档 Markdown 富文本渲染与图片资产服务链路

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -372,8 +372,10 @@ export async function proxyGetBinary(
   const responseHeaders = new Headers();
   const contentDisposition = upstreamResponse.headers.get("content-disposition");
   const contentType = upstreamResponse.headers.get("content-type");
+  const cacheControl = upstreamResponse.headers.get("cache-control");
   if (contentDisposition) responseHeaders.set("content-disposition", contentDisposition);
   if (contentType) responseHeaders.set("content-type", contentType);
+  if (cacheControl) responseHeaders.set("cache-control", cacheControl);
 
   return new NextResponse(upstreamResponse.body, {
     status: upstreamResponse.status,

--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/assets/[assetName]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/assets/[assetName]/route.ts
@@ -1,0 +1,18 @@
+import { proxyGetBinary } from "../../../../../../_proxy";
+
+/**
+ * GET /api/knowledge/base/{corpusId}/documents/{documentId}/assets/{assetName}
+ * 代理文档衍生资产（图片等）
+ */
+export async function GET(
+  request: Request,
+  context: {
+    params: Promise<{ corpusId: string; documentId: string; assetName: string }>;
+  },
+) {
+  const { corpusId, documentId, assetName } = await context.params;
+  return proxyGetBinary(
+    request,
+    `/knowledge/base/${corpusId}/documents/${documentId}/assets/${encodeURIComponent(assetName)}`,
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "@/lib/utils";
+import { MermaidDiagram } from "@/components/ui/MermaidDiagram";
+
+interface DocumentMarkdownRendererProps {
+  content: string;
+  corpusId: string;
+  documentId: string;
+  appName?: string;
+}
+
+function buildAssetProxyUrl(
+  assetName: string,
+  corpusId: string,
+  documentId: string,
+  appName?: string,
+): string {
+  const params = new URLSearchParams();
+  if (appName) params.set("app_name", appName);
+  const query = params.toString();
+  const base = `/api/knowledge/base/${corpusId}/documents/${documentId}/assets/${encodeURIComponent(assetName)}`;
+  return query ? `${base}?${query}` : base;
+}
+
+function isAbsoluteUrl(src: string): boolean {
+  return (
+    src.startsWith("http://") ||
+    src.startsWith("https://") ||
+    src.startsWith("data:") ||
+    src.startsWith("blob:")
+  );
+}
+
+/**
+ * 从路径中提取文件名（取最后一段）
+ * e.g. "./images/image-1.png" → "image-1.png"
+ */
+function extractFilename(src: string): string {
+  return src.split("/").pop() || src;
+}
+
+export function DocumentMarkdownRenderer({
+  content,
+  corpusId,
+  documentId,
+  appName,
+}: DocumentMarkdownRendererProps) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden break-words whitespace-normal text-sm",
+        // 段落
+        "[&_p]:leading-7 [&_p]:my-1",
+        "[&_p+*]:mt-3",
+        // 列表
+        "[&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1 [&_ul]:my-2",
+        "[&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:space-y-1 [&_ol]:my-2",
+        "[&_li]:leading-relaxed",
+        // 标题
+        "[&_h1]:text-xl [&_h1]:font-bold [&_h1]:mb-3 [&_h1]:mt-5 [&_h1]:text-zinc-900 [&_h1]:dark:text-zinc-100",
+        "[&_h2]:text-lg [&_h2]:font-bold [&_h2]:mb-2 [&_h2]:mt-4 [&_h2]:text-zinc-900 [&_h2]:dark:text-zinc-100",
+        "[&_h3]:text-base [&_h3]:font-semibold [&_h3]:mb-2 [&_h3]:mt-3 [&_h3]:text-zinc-800 [&_h3]:dark:text-zinc-200",
+        "[&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mb-1 [&_h4]:mt-2",
+        // 代码
+        "[&_code]:font-mono [&_code]:text-[0.9em]",
+        "[&_code]:bg-zinc-100 [&_code]:dark:bg-zinc-800 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded",
+        "[&_pre]:bg-zinc-100 [&_pre]:dark:bg-zinc-800 [&_pre]:p-3 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:my-3",
+        "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
+        // 链接
+        "[&_a]:underline [&_a]:underline-offset-2 [&_a]:text-blue-600 [&_a]:dark:text-blue-400",
+        // 表格
+        "[&_table]:w-full [&_table]:border-collapse [&_table]:my-4 [&_table]:text-sm",
+        "[&_thead]:bg-zinc-100 [&_thead]:dark:bg-zinc-800/60",
+        "[&_tbody_tr:nth-child(even)]:bg-zinc-50 [&_tbody_tr:nth-child(even)]:dark:bg-zinc-900/30",
+        "[&_th]:border [&_th]:border-zinc-200 [&_th]:dark:border-zinc-700 [&_th]:px-3 [&_th]:py-2 [&_th]:font-semibold [&_th]:text-left",
+        "[&_td]:border [&_td]:border-zinc-200 [&_td]:dark:border-zinc-700 [&_td]:px-3 [&_td]:py-2",
+        // 图片
+        "[&_img]:max-w-full [&_img]:rounded-lg [&_img]:my-3",
+        // 引用块
+        "[&_blockquote]:border-l-4 [&_blockquote]:border-zinc-300 [&_blockquote]:dark:border-zinc-600 [&_blockquote]:pl-4 [&_blockquote]:my-3 [&_blockquote]:text-zinc-600 [&_blockquote]:dark:text-zinc-400",
+        // 分隔线
+        "[&_hr]:border-zinc-200 [&_hr]:dark:border-zinc-700 [&_hr]:my-4",
+      )}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          img({ src, alt, ...props }) {
+            if (!src) return null;
+
+            const resolvedSrc = isAbsoluteUrl(src)
+              ? src
+              : buildAssetProxyUrl(
+                  extractFilename(src),
+                  corpusId,
+                  documentId,
+                  appName,
+                );
+
+            return (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={resolvedSrc}
+                alt={alt || ""}
+                loading="lazy"
+                className="max-w-full rounded-lg border border-zinc-200 dark:border-zinc-700"
+                onError={(e) => {
+                  const el = e.target as HTMLImageElement;
+                  el.style.display = "none";
+                }}
+                {...props}
+              />
+            );
+          },
+          code({ className, children, ...props }) {
+            const match = /language-(\w+)/.exec(className || "");
+            const isMermaid = match && match[1] === "mermaid";
+
+            if (isMermaid) {
+              return (
+                <MermaidDiagram
+                  code={String(children).replace(/\n$/, "")}
+                />
+              );
+            }
+
+            return (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            );
+          },
+          pre({ children }) {
+            return <pre className="relative">{children}</pre>;
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -15,6 +15,7 @@ import {
   refreshDocumentMarkdown,
 } from "../utils/knowledge-api";
 import { formatRelativeTime } from "../utils/pipeline-helpers";
+import { DocumentMarkdownRenderer } from "./DocumentMarkdownRenderer";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -303,9 +304,12 @@ export function DocumentViewDialog({
                 Markdown content is empty. Click <strong>Re-Parse from GCS</strong> to regenerate from the source document.
               </p>
             ) : (
-              <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-6 text-zinc-800 dark:text-zinc-200">
-                {detail?.markdown_content || "No markdown content available."}
-              </pre>
+              <DocumentMarkdownRenderer
+                content={detail?.markdown_content || ""}
+                corpusId={document.corpus_id}
+                documentId={document.id}
+                appName={requestAppName}
+              />
             )}
           </div>
         </div>

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import mimetypes
 from io import BytesIO
 from typing import Any, Dict, Optional
 from uuid import UUID
@@ -1916,6 +1917,83 @@ async def download_document(
         media_type="text/markdown; charset=utf-8" if is_url_doc else (doc.content_type or "application/octet-stream"),
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
+        },
+    )
+
+
+@router.get("/base/{corpus_id}/documents/{document_id}/assets/{asset_name:path}")
+async def get_document_asset(
+    corpus_id: UUID,
+    document_id: UUID,
+    asset_name: str,
+    app_name: Optional[str] = Query(default=None),
+):
+    """获取文档的衍生资产文件（图片等）。
+
+    从 GCS 的 ``derived/{document_id}/assets/`` 路径下载指定资产并流式返回。
+    资产内容不可变，设置长期缓存。
+    """
+    resolved_app = _resolve_app_name(app_name)
+
+    from negentropy.storage.service import DocumentStorageService
+    from negentropy.storage.gcs_client import StorageError
+
+    storage_service = DocumentStorageService()
+
+    doc = await storage_service.get_document(
+        document_id=document_id,
+        corpus_id=corpus_id,
+        app_name=resolved_app,
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "DOCUMENT_NOT_FOUND", "message": "Document not found"},
+        )
+
+    # 取 filename 最后一段，防止路径穿越
+    safe_filename = asset_name.split("/")[-1] if "/" in asset_name else asset_name
+    if not safe_filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_ASSET_NAME", "message": "Asset name is empty"},
+        )
+
+    # 直接构造 GCS 路径并下载（避免第二次文档查询）
+    gcs_path = DocumentStorageService._build_asset_gcs_path(
+        app_name=doc.app_name,
+        corpus_id=doc.corpus_id,
+        document_id=doc.id,
+        filename=safe_filename,
+    )
+
+    try:
+        gcs_client = storage_service._get_gcs_client()
+        gcs_uri = f"gs://{gcs_client._bucket_name}/{gcs_path}"
+        content = gcs_client.download(gcs_uri)
+    except (StorageError, ValueError) as exc:
+        logger.warning(
+            "asset_download_failed",
+            doc_id=str(document_id),
+            asset_name=safe_filename,
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "ASSET_NOT_FOUND", "message": "Requested asset not found"},
+        ) from exc
+
+    content_type = mimetypes.guess_type(safe_filename)[0] or "application/octet-stream"
+    # 清洗 header 用文件名，防止注入
+    header_filename = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in safe_filename)
+
+    return StreamingResponse(
+        BytesIO(content),
+        media_type=content_type,
+        headers={
+            "Cache-Control": "public, max-age=31536000, immutable",
+            "Content-Disposition": f'inline; filename="{header_filename}"',
+            "Content-Length": str(len(content)),
         },
     )
 

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -497,6 +497,37 @@ class DocumentStorageService:
             )
             return None
 
+    async def download_extraction_asset(
+        self,
+        *,
+        document_id: UUID,
+        filename: str,
+    ) -> Optional[bytes]:
+        """从 GCS 下载 Data Extractor 生成的衍生资源。"""
+        doc = await self.get_document(document_id=document_id)
+        if not doc:
+            return None
+
+        gcs_client = self._get_gcs_client()
+        gcs_path = self._build_asset_gcs_path(
+            app_name=doc.app_name,
+            corpus_id=doc.corpus_id,
+            document_id=doc.id,
+            filename=filename,
+        )
+        gcs_uri = f"gs://{gcs_client._bucket_name}/{gcs_path}"
+
+        try:
+            return gcs_client.download(gcs_uri)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "extraction_asset_download_failed",
+                document_id=str(document_id),
+                filename=filename,
+                gcs_uri=gcs_uri,
+            )
+            return None
+
     async def get_document_content(self, document_id: UUID) -> Optional[bytes]:
         """Download document content from GCS.
 


### PR DESCRIPTION
## Summary

- **后端**：新增 `GET /base/{corpus_id}/documents/{document_id}/assets/{asset_name}` 端点，从 GCS 下载文档衍生资产（图片等）并流式返回，含路径穿越防护、Header 注入清洗及长期缓存策略
- **后端**：`DocumentStorageService` 新增 `download_extraction_asset` 方法，封装 GCS 资产下载逻辑
- **前端**：新建 `DocumentMarkdownRenderer` 组件，基于 `react-markdown` + `remark-gfm` 渲染 Markdown，自定义 `img` 组件将相对路径改写为代理 URL
- **前端**：新建 Next.js API Route 代理资产请求至后端，增强 `proxyGetBinary` 转发 `cache-control` 响应头
- **前端**：`DocumentViewDialog` 从 `<pre>` 纯文本展示切换为 Markdown 渲染，支持图片、表格、代码块、引用块、Mermaid 图表等富文本元素

## 改动文件

| 文件 | 变更 |
|------|------|
| `apps/negentropy/src/negentropy/knowledge/api.py` | 新增资产服务端点 |
| `apps/negentropy/src/negentropy/storage/service.py` | 新增资产下载方法 |
| `apps/negentropy-ui/app/api/knowledge/_proxy.ts` | 增强 cache-control 头转发 |
| `apps/negentropy-ui/.../assets/[assetName]/route.ts` | 新建资产代理路由 |
| `apps/negentropy-ui/.../DocumentMarkdownRenderer.tsx` | 新建 Markdown 渲染组件 |
| `apps/negentropy-ui/.../DocumentViewDialog.tsx` | 集成新渲染组件 |

## Test plan

- [ ] 上传含图片的 PDF 到 Knowledge，等待提取完成后在 Document View 模态框中验证图片正常显示
- [ ] 验证表格渲染有边框和条纹行样式
- [ ] 验证代码块和 Mermaid 图表正常渲染
- [ ] 检查 Network 面板：图片请求走 `/api/knowledge/.../assets/...` 代理路径，响应携带 `Cache-Control: public, max-age=31536000, immutable`
- [ ] 验证深色模式下对比度正常
- [ ] 确认 Re-Parse from GCS、Download 等现有功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)