### PR TITLE
fix(Knowledge-Document): 修复 React 19 类型定义导致的 img src 编译错误

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -90,7 +90,7 @@ export function DocumentMarkdownRenderer({
         remarkPlugins={[remarkGfm]}
         components={{
           img({ src, alt, ...props }) {
-            if (!src) return null;
+            if (!src || typeof src !== "string") return null;
 
             const resolvedSrc = isAbsoluteUrl(src)
               ? src


### PR DESCRIPTION
## 变更概要

修复 Next.js 生产构建（`pnpm build`）时 TypeScript 编译失败的问题。

## 问题原因

React 19 的 `@types/react` 将 `<img>` 元素的 `src` 属性类型从 `string` 扩展为 `string | Blob`。`DocumentMarkdownRenderer` 组件中 react-markdown 的 `img` 回调接收到的 `src` 类型为 `string | Blob`，但 `isAbsoluteUrl()` 和 `extractFilename()` 函数仅接受 `string` 参数，在 TypeScript 严格模式下编译失败。

## 修复方案

在 `DocumentMarkdownRenderer.tsx` 的 `img` 组件回调中，将原有的空值检查：

```typescript
if (!src) return null;
```

改为增加 `typeof` 类型收窄，同时排除 `Blob` 类型：

```typescript
if (!src || typeof src !== "string") return null;
```

此修改遵循 TypeScript Type Narrowing 最佳实践，将 `src` 的类型从 `string | Blob` 收窄为 `string`，使后续函数调用类型安全。

## 影响范围

- **文件**: `apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx`
- **变更量**: 1 行修改
- **功能影响**: 无。Markdown 文档中的图片 `src` 在实际场景中始终为字符串 URL，`Blob` 类型仅为 React 19 类型定义的理论扩展。

## 验证

- ✅ `pnpm build` 编译成功，无 TypeScript 错误

---

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)