### PR TITLE
style(Interface-Card): 将 MCP/SubAgent 卡片描述最大行数从 4 行缩减为 3 行

### DIFF
--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -732,7 +732,7 @@ export function McpServerCard({
 
   return (
     <div className="space-y-2">
-      <div className="flex h-[196px] flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex h-[176px] flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
             <h3 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100">
@@ -818,7 +818,7 @@ export function McpServerCard({
           </div>
 
           <p
-            className="mb-1 h-20 min-w-0 w-full overflow-hidden text-sm leading-5 text-zinc-500 line-clamp-4 dark:text-zinc-400"
+            className="mb-1 h-[60px] min-w-0 w-full overflow-hidden text-sm leading-5 text-zinc-500 line-clamp-3 dark:text-zinc-400"
             title={summaryDescription}
           >
             {summaryDescription}

--- a/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/_components/SubAgentCard.tsx
@@ -79,7 +79,7 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
           )}
         </div>
         <p
-          className="mb-1 h-20 min-w-0 w-full overflow-hidden leading-5 line-clamp-4 text-sm text-zinc-500 dark:text-zinc-400"
+          className="mb-1 h-[60px] min-w-0 w-full overflow-hidden leading-5 line-clamp-3 text-sm text-zinc-500 dark:text-zinc-400"
           title={agent.description || "No description"}
         >
           {agent.description || "No description"}

--- a/apps/negentropy-ui/app/plugins/subagents/page.tsx
+++ b/apps/negentropy-ui/app/plugins/subagents/page.tsx
@@ -212,7 +212,7 @@ export default function SubAgentsPage() {
                 className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
               >
                 {agents.map((agent) => (
-                  <div key={agent.id} className="h-[196px]" data-testid="subagent-grid-item">
+                  <div key={agent.id} className="h-[176px]" data-testid="subagent-grid-item">
                     <SubAgentCard
                       agent={agent}
                       onEdit={() => handleEdit(agent)}


### PR DESCRIPTION
## 变更摘要

- MCP Server 卡片与 SubAgent 卡片的描述区域最大显示行数从 4 行调整为 3 行
- 卡片整体高度从 196px 降低至 176px，保持布局紧凑一致

## 改动文件

- `McpServerCard.tsx` — 卡片高度 196→176px，描述 `line-clamp-4` → `line-clamp-3`，`h-20` → `h-[60px]`
- `SubAgentCard.tsx` — 描述 `line-clamp-4` → `line-clamp-3`，`h-20` → `h-[60px]`
- `subagents/page.tsx` — 网格项容器高度 196→176px

## 测试计划

- [ ] 访问 Interface → MCP 页面，确认卡片描述最多 3 行、长文本正确截断
- [ ] 访问 Interface → SubAgents 页面，确认同样效果
- [ ] 验证短文本描述无异常显示

🤖 Generated with [Claude Code](https://github.com/claude)