### PR TITLE
fix(Knowledge-Document): 修复刷新 Markdown 时图片资产未持久化到 GCS 导致的 404 错误

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1193,6 +1193,10 @@ async def _extract_and_store_document_markdown_from_gcs(
             markdown_size=len(markdown_content),
             markdown_gcs_uri=markdown_gcs_uri,
         )
+        await persist_extracted_assets(
+            document_id=document_id,
+            assets=result.assets,
+        )
     except Exception as exc:  # noqa: BLE001 - 后台任务需兜底并可观测
         logger.error(
             "document_markdown_extraction_failed",


### PR DESCRIPTION
## 问题背景

后端日志出现大量 GCS `ERROR`（`gcs_download_failed`）和 `WARNING`（`asset_download_failed`），前端渲染文档 Markdown 时请求的图片资产在 GCS 上不存在，所有图片请求均返回 404。

## 根因分析

`_extract_and_store_document_markdown_from_gcs`（`api.py:1125`）是 `refresh-markdown` 端点的后台任务。它通过 MCP Tool 提取 markdown **和图片资产**，但只存储了 markdown，**遗漏了 `persist_extracted_assets()` 调用**，导致提取的图片从未上传到 GCS。

对比其他 3 条提取路径均正确调用了 `persist_extracted_assets`：

| 路径 | 位置 | 状态 |
|------|------|------|
| URL 文档创建 | `api.py:1025` | ✅ 已调用 |
| 文档同步 | `api.py:2301` | ✅ 已调用 |
| 文件 Ingest Pipeline | `service.py:734` | ✅ 已调用 |
| **刷新 Markdown（后台任务）** | **`api.py:1125`** | ❌ **缺失** |

## 修复方案

在 `_extract_and_store_document_markdown_from_gcs` 函数中，`logger.info("document_markdown_extraction_completed", ...)` 之后补齐 `persist_extracted_assets()` 调用，与其他 3 条提取路径保持一致。

仅修改 1 个文件，插入 3 行代码。

## 验证

- 229 个单元测试全部通过，无回归
- 1 个预存失败测试（`test_ingest_file_passes_hierarchical_chunking_config_to_service`，`Depends` mock 问题）与本次修改无关

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)