### PR TITLE
feat(Memory-Activity): 新增 Activity 页，收录并持久化平台 Toast 通知为可追溯的活动日志

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/activity-toast";
 import { AsyncPipelineResult, ChunkingConfig } from "@/features/knowledge";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 

--- a/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/activity-toast";
 import { AsyncPipelineResult } from "@/features/knowledge";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -10,7 +10,7 @@ import {
   type SetStateAction,
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { toast } from "sonner";
+import { toast } from "@/lib/activity-toast";
 import {
   buildExtractorRoutesFromDraft,
   buildCorpusConfig,

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/activity-toast";
 import {
   DocumentViewDialog,
   KnowledgeDocument,

--- a/apps/negentropy-ui/app/memory/activity/page.tsx
+++ b/apps/negentropy-ui/app/memory/activity/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { MemoryNav } from "@/components/ui/MemoryNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+import { useActivityLog } from "@/features/memory";
+import type { ActivityLevel } from "@/features/memory";
+
+const LEVEL_OPTIONS: { value: ActivityLevel | null; label: string }[] = [
+  { value: null, label: "All" },
+  { value: "success", label: "Success" },
+  { value: "error", label: "Error" },
+  { value: "info", label: "Info" },
+  { value: "warning", label: "Warning" },
+];
+
+const LEVEL_DOT: Record<ActivityLevel, string> = {
+  success: "bg-emerald-500",
+  error: "bg-rose-500",
+  info: "bg-blue-500",
+  warning: "bg-amber-500",
+};
+
+const LEVEL_BADGE: Record<ActivityLevel, string> = {
+  success:
+    "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
+  error:
+    "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300",
+  info: "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-300",
+  warning:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+};
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString();
+}
+
+export default function MemoryActivityPage() {
+  const { entries, levelFilter, setLevelFilter, reload, clear, totalCount } =
+    useActivityLog();
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <MemoryNav
+        title="Activity"
+        description="平台活动日志"
+      />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+          <div className="pb-6">
+            {/* Toolbar */}
+            <div className="mb-6 flex items-center gap-3">
+              <nav className="flex items-center gap-1 rounded-full bg-muted/50 p-1">
+                {LEVEL_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.label}
+                    className={`rounded-full px-4 py-1 text-xs font-semibold transition-colors ${
+                      levelFilter === opt.value
+                        ? "bg-foreground text-background shadow-sm"
+                        : "text-muted hover:text-foreground"
+                    }`}
+                    onClick={() => setLevelFilter(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </nav>
+              <div className="flex-1" />
+              <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                {entries.length}
+                {levelFilter ? ` / ${totalCount}` : ""} entries
+              </span>
+              <button
+                className={outlineButtonClassName(
+                  "neutral",
+                  "rounded-lg px-3 py-2 text-xs font-semibold",
+                )}
+                onClick={reload}
+              >
+                Refresh
+              </button>
+              <button
+                className={outlineButtonClassName(
+                  "danger",
+                  "rounded-lg px-3 py-2 text-xs font-semibold",
+                )}
+                onClick={clear}
+              >
+                Clear All
+              </button>
+            </div>
+
+            {/* Activity Feed */}
+            {entries.length ? (
+              <div className="space-y-2">
+                {entries.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="flex items-start gap-3 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+                  >
+                    <span
+                      className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${LEVEL_DOT[entry.level]}`}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${LEVEL_BADGE[entry.level]}`}
+                        >
+                          {entry.level}
+                        </span>
+                        <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                          {formatTimestamp(entry.timestamp)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs font-medium text-zinc-900 dark:text-zinc-100">
+                        {entry.message}
+                      </p>
+                      {entry.description && (
+                        <p className="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+                          {entry.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900">
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  No activity recorded yet. Toast notifications will appear
+                  here as they occur across the platform.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/MemoryNav.tsx
+++ b/apps/negentropy-ui/components/ui/MemoryNav.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { href: "/memory/facts", label: "Facts" },
   { href: "/memory/audit", label: "Audit" },
   { href: "/memory/automation", label: "Automation" },
+  { href: "/memory/activity", label: "Activity" },
 ];
 
 export function MemoryNav({

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/activity-toast";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 

--- a/apps/negentropy-ui/features/memory/hooks/useActivityLog.ts
+++ b/apps/negentropy-ui/features/memory/hooks/useActivityLog.ts
@@ -1,0 +1,79 @@
+/**
+ * Activity Log Hook
+ *
+ * 提供平台活动日志的读取与过滤能力
+ * 数据源：localStorage（由 activity-store 管理）
+ *
+ * 遵循 AGENTS.md 原则：单一职责、复用驱动
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  readActivities,
+  clearActivities,
+  type ActivityEntry,
+  type ActivityLevel,
+} from "@/lib/activity-store";
+
+export interface UseActivityLogOptions {
+  /** 初始 level 过滤器（null = 全部） */
+  initialFilter?: ActivityLevel | null;
+}
+
+export interface UseActivityLogReturnValue {
+  /** 当前过滤后的条目（逆序：最新在前） */
+  entries: ActivityEntry[];
+  /** 当前 level 过滤器 */
+  levelFilter: ActivityLevel | null;
+  /** 设置 level 过滤器 */
+  setLevelFilter: (level: ActivityLevel | null) => void;
+  /** 从 localStorage 重新加载 */
+  reload: () => void;
+  /** 清空全部活动记录 */
+  clear: () => void;
+  /** 过滤前的总条目数 */
+  totalCount: number;
+}
+
+export function useActivityLog(
+  options: UseActivityLogOptions = {},
+): UseActivityLogReturnValue {
+  const { initialFilter = null } = options;
+  const [allEntries, setAllEntries] = useState<ActivityEntry[]>([]);
+  const [levelFilter, setLevelFilter] = useState<ActivityLevel | null>(
+    initialFilter,
+  );
+
+  const reload = useCallback(() => {
+    const raw = readActivities();
+    // 逆序：最新在前
+    setAllEntries(raw.reverse());
+  }, []);
+
+  const clear = useCallback(() => {
+    clearActivities();
+    setAllEntries([]);
+  }, []);
+
+  // 挂载时加载
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const entries = useMemo(
+    () =>
+      levelFilter
+        ? allEntries.filter((e) => e.level === levelFilter)
+        : allEntries,
+    [allEntries, levelFilter],
+  );
+
+  return {
+    entries,
+    levelFilter,
+    setLevelFilter,
+    reload,
+    clear,
+    totalCount: allEntries.length,
+  };
+}

--- a/apps/negentropy-ui/features/memory/index.ts
+++ b/apps/negentropy-ui/features/memory/index.ts
@@ -38,6 +38,12 @@ export type {
   UseMemoryAuditReturnValue,
 } from "./hooks/useMemoryAudit";
 
+export { useActivityLog } from "./hooks/useActivityLog";
+export type {
+  UseActivityLogOptions,
+  UseActivityLogReturnValue,
+} from "./hooks/useActivityLog";
+
 // ============================================================================
 // Utils (API Functions)
 // ============================================================================
@@ -56,6 +62,15 @@ export {
   triggerMemoryAutomationJobAction,
   runMemoryAutomationJob,
 } from "./utils/memory-api";
+
+// ============================================================================
+// Activity Log Types
+// ============================================================================
+
+export type {
+  ActivityEntry,
+  ActivityLevel,
+} from "@/lib/activity-store";
 
 // ============================================================================
 // Types

--- a/apps/negentropy-ui/lib/activity-store.ts
+++ b/apps/negentropy-ui/lib/activity-store.ts
@@ -1,0 +1,56 @@
+/**
+ * Activity Store
+ *
+ * 平台活动日志持久化存储（localStorage）
+ * 纯模块设计，无 React 依赖
+ *
+ * 设计模式：Append-Only Log + FIFO 淘汰
+ * - 所有 Toast 通知自动收录为 ActivityEntry
+ * - FIFO 缓冲上限 500 条，约 100KB
+ * - try/catch 包裹所有 localStorage 操作（SSR 安全 + 配额溢出兜底）
+ */
+
+const STORAGE_KEY = "negentropy:activity-log";
+const MAX_ENTRIES = 500;
+
+export type ActivityLevel = "success" | "error" | "info" | "warning";
+
+export type ActivityEntry = {
+  id: string;
+  timestamp: number;
+  level: ActivityLevel;
+  message: string;
+  description?: string;
+};
+
+/** 追加一条活动记录（FIFO，上限 500 条） */
+export function appendActivity(entry: ActivityEntry): void {
+  const entries = readActivities();
+  entries.push(entry);
+  const trimmed = entries.slice(-MAX_ENTRIES);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch {
+    // localStorage 不可用或配额溢出——静默失败，Toast 仍正常显示
+  }
+}
+
+/** 读取全部活动记录 */
+export function readActivities(): ActivityEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as ActivityEntry[];
+  } catch {
+    return [];
+  }
+}
+
+/** 清空全部活动记录 */
+export function clearActivities(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // silent
+  }
+}

--- a/apps/negentropy-ui/lib/activity-toast.ts
+++ b/apps/negentropy-ui/lib/activity-toast.ts
@@ -1,0 +1,70 @@
+/**
+ * Activity-aware Toast Facade
+ *
+ * 对 sonner toast 的薄层封装：在显示 toast 的同时
+ * 将通知内容侧写到 Activity Store (localStorage)
+ *
+ * 用法：调用方将 `import { toast } from "sonner"` 替换为
+ * `import { toast } from "@/lib/activity-toast"` 即可，零逻辑变更。
+ *
+ * 设计模式：Facade + Observer (lite)
+ * - 仅封装 success / error / info / warning 四个通知级别方法
+ * - loading / promise / custom / message / dismiss 直接透传
+ * - 仅记录 string 类型消息（React Node 不可序列化）
+ */
+
+import { toast as sonnerToast, type ExternalToast } from "sonner";
+import { appendActivity, type ActivityLevel } from "./activity-store";
+
+type ToastMessage = string | React.ReactNode;
+
+function logAndForward(
+  level: ActivityLevel,
+  message: ToastMessage,
+  data?: ExternalToast,
+) {
+  if (typeof message === "string") {
+    appendActivity({
+      id: crypto.randomUUID(),
+      timestamp: Date.now(),
+      level,
+      message,
+      description:
+        typeof data?.description === "string" ? data.description : undefined,
+    });
+  }
+}
+
+/**
+ * 封装后的 toast——API 与 sonner 完全一致，额外侧写活动日志
+ */
+export const toast = Object.assign(
+  (message: ToastMessage, data?: ExternalToast) => {
+    logAndForward("info", message, data);
+    return sonnerToast(message, data);
+  },
+  {
+    success: (message: ToastMessage, data?: ExternalToast) => {
+      logAndForward("success", message, data);
+      return sonnerToast.success(message, data);
+    },
+    error: (message: ToastMessage, data?: ExternalToast) => {
+      logAndForward("error", message, data);
+      return sonnerToast.error(message, data);
+    },
+    info: (message: ToastMessage, data?: ExternalToast) => {
+      logAndForward("info", message, data);
+      return sonnerToast.info(message, data);
+    },
+    warning: (message: ToastMessage, data?: ExternalToast) => {
+      logAndForward("warning", message, data);
+      return sonnerToast.warning(message, data);
+    },
+    // 透传：非通知级别方法不需要记录到活动日志
+    loading: sonnerToast.loading,
+    promise: sonnerToast.promise,
+    custom: sonnerToast.custom,
+    message: sonnerToast.message,
+    dismiss: sonnerToast.dismiss,
+  },
+);


### PR DESCRIPTION
## Summary

在 Memory 模块下新增 **Activity** 页，将平台所有 Toast 通知（成功、失败、信息、警告）收录为可追溯的活动日志，并通过 localStorage 持久化，解决 Toast 消息"阅后即焚"无法回溯的问题。

## 变更内容

### 新增文件（4 个）

| 文件 | 职责 |
|------|------|
| `lib/activity-store.ts` | 活动日志持久化存储（localStorage CRUD，FIFO 500 条上限） |
| `lib/activity-toast.ts` | Sonner Toast Facade——Toast 显示的同时侧写到 Activity Store |
| `features/memory/hooks/useActivityLog.ts` | React Hook：读取、Level 过滤、清空活动日志 |
| `app/memory/activity/page.tsx` | Activity 页面 UI（活动流 + Level 筛选 + Refresh / Clear All） |

### 修改文件（7 个）

| 文件 | 变更 |
|------|------|
| `components/ui/MemoryNav.tsx` | NAV_ITEMS 追加 Activity 导航项 |
| `features/memory/index.ts` | 导出 `useActivityLog` Hook 及 `ActivityEntry` / `ActivityLevel` 类型 |
| 5 处 Knowledge 组件 | `import { toast } from "sonner"` → `"@/lib/activity-toast"`（零逻辑变更） |

## 架构设计

```
  调用方 (Knowledge 等模块)
        │  import { toast } from "@/lib/activity-toast"
        ▼
  ┌──────────────────┐
  │ activity-toast.ts │ ← Facade：薄层封装 sonner toast + 侧写活动日志
  └────────┬─────────┘
           ▼
  ┌──────────────────┐
  │ activity-store.ts │ ← localStorage CRUD，FIFO 500 条上限
  └────────┬─────────┘
           ▼
  ┌──────────────────┐
  │ useActivityLog   │ ← React Hook (读取 + Level 过滤)
  └────────┬─────────┘
           ▼
  ┌──────────────────┐
  │ /memory/activity │ ← Activity 页面
  └──────────────────┘
```

## 核心决策

| 决策点 | 选择 | 理由 |
|--------|------|------|
| Toast 拦截 | Facade 封装 + 修改 5 处 import | 零逻辑变更，仅改 import 路径 |
| 持久化 | localStorage（FIFO 500 条） | ≈100KB，无需后端 API |
| 过滤 | Level 筛选 pill 组 | 最小可用 MVP (YAGNI) |

## 验证

- [x] `pnpm build` 构建通过，`/memory/activity` 路由正确注册
- [ ] 在 Knowledge 页触发 Toast → 切换到 Memory > Activity → 确认条目出现
- [ ] 刷新页面后活动条目持久保留
- [ ] Level 筛选正确过滤
- [ ] Clear All 清空全部记录

🤖 Generated with [Claude Code](https://github.com/claude)