### PR TITLE
fix(Knowledge-Document): 文档列表 Created By 列显示用户名而非用户 ID

### DIFF
--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -55,7 +55,8 @@ function truncateHash(hash: string | null): React.ReactElement {
   );
 }
 
-function displayUser(createdBy: string | null): string {
+function displayUser(createdBy: string | null, displayName?: string | null): string {
+  if (displayName) return displayName;
   if (!createdBy) return "-";
   if (createdBy.includes("@")) {
     return createdBy.split("@")[0];
@@ -223,8 +224,8 @@ export default function DocumentsPage() {
                       </div>
 
                       {/* Created By - col-span-1 */}
-                      <div className="col-span-1 text-muted truncate text-xs text-center" title={doc.created_by || ""}>
-                        {displayUser(doc.created_by)}
+                      <div className="col-span-1 text-muted truncate text-xs text-center" title={doc.created_by_name || doc.created_by || ""}>
+                        {displayUser(doc.created_by, doc.created_by_name)}
                       </div>
 
                       {/* Created At - col-span-1 */}

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -83,7 +83,8 @@ function truncateHash(hash: string | null): string {
   return `${hash.slice(0, 8)}...${hash.slice(-4)}`;
 }
 
-function displayUser(createdBy: string | null): string {
+function displayUser(createdBy: string | null, displayName?: string | null): string {
+  if (displayName) return displayName;
   if (!createdBy) return "-";
   if (createdBy.includes("@")) {
     const local = createdBy.split("@")[0];
@@ -265,8 +266,8 @@ export function DocumentViewDialog({
           </div>
           <div className="flex items-center gap-1.5 min-w-0">
             <span className="shrink-0 text-zinc-500 dark:text-zinc-400">Created By</span>
-            <span className="truncate font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.created_by || ""}>
-              {displayUser(viewedDoc.created_by)}
+            <span className="truncate font-medium text-zinc-900 dark:text-zinc-100" title={viewedDoc.created_by_name || viewedDoc.created_by || ""}>
+              {displayUser(viewedDoc.created_by, viewedDoc.created_by_name)}
             </span>
           </div>
           <div className="flex items-center gap-1.5 min-w-0">

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1083,6 +1083,7 @@ export interface KnowledgeDocument {
   status: string;
   created_at: string | null;
   created_by: string | null;
+  created_by_name?: string | null;
   markdown_extract_status?: "pending" | "processing" | "completed" | "failed" | string;
   markdown_extracted_at?: string | null;
   markdown_extract_error?: string | null;

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -18,6 +18,7 @@ from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.perception import Corpus, Knowledge
 from negentropy.models.plugin import McpServer, McpTool
+from negentropy.models.pulse import UserState
 
 from .constants import (
     DEFAULT_CHUNK_SIZE,
@@ -1477,6 +1478,7 @@ class DocumentResponse(BaseModel):
     status: str
     created_at: Optional[str] = None
     created_by: Optional[str] = None
+    created_by_name: Optional[str] = None
     markdown_extract_status: str = "pending"
     markdown_extracted_at: Optional[str] = None
     markdown_extract_error: Optional[str] = None
@@ -1609,6 +1611,50 @@ class DocumentListResponse(BaseModel):
     items: list[DocumentResponse]
 
 
+async def _resolve_user_display_names(user_ids: list[str]) -> dict[str, str]:
+    """批量解析用户 ID 到显示名称（查询 UserState.state.profile.name）。"""
+    if not user_ids:
+        return {}
+    name_map: dict[str, str] = {}
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(UserState).where(
+                UserState.app_name == settings.app_name,
+                UserState.user_id.in_(user_ids),
+            )
+        )
+        for us in result.scalars().all():
+            state = us.state or {}
+            name = state.get("profile", {}).get("name")
+            if name:
+                name_map[us.user_id] = name
+    return name_map
+
+
+def _build_document_response(doc, name_map: dict[str, str]) -> DocumentResponse:
+    """从 ORM 文档对象构建 DocumentResponse，注入用户显示名。"""
+    return DocumentResponse(
+        id=doc.id,
+        corpus_id=doc.corpus_id,
+        app_name=doc.app_name,
+        file_hash=doc.file_hash,
+        original_filename=doc.original_filename,
+        gcs_uri=doc.gcs_uri,
+        content_type=doc.content_type,
+        file_size=doc.file_size,
+        status=doc.status,
+        created_at=doc.created_at.isoformat() if doc.created_at else None,
+        created_by=doc.created_by,
+        created_by_name=name_map.get(doc.created_by) if doc.created_by else None,
+        markdown_extract_status=doc.markdown_extract_status,
+        markdown_extracted_at=(
+            doc.markdown_extracted_at.isoformat() if doc.markdown_extracted_at else None
+        ),
+        markdown_extract_error=doc.markdown_extract_error,
+        metadata=doc.metadata_ or {},
+    )
+
+
 @router.get("/base/{corpus_id}/documents", response_model=DocumentListResponse)
 async def list_documents(
     corpus_id: UUID,
@@ -1639,28 +1685,12 @@ async def list_documents(
         offset=offset,
     )
 
+    unique_user_ids = list({doc.created_by for doc in docs if doc.created_by})
+    name_map = await _resolve_user_display_names(unique_user_ids)
+
     return DocumentListResponse(
         count=total,
-        items=[
-            DocumentResponse(
-                id=doc.id,
-                corpus_id=doc.corpus_id,
-                app_name=doc.app_name,
-                file_hash=doc.file_hash,
-                original_filename=doc.original_filename,
-                gcs_uri=doc.gcs_uri,
-                content_type=doc.content_type,
-                file_size=doc.file_size,
-                status=doc.status,
-                created_at=doc.created_at.isoformat() if doc.created_at else None,
-                created_by=doc.created_by,
-                markdown_extract_status=doc.markdown_extract_status,
-                markdown_extracted_at=doc.markdown_extracted_at.isoformat() if doc.markdown_extracted_at else None,
-                markdown_extract_error=doc.markdown_extract_error,
-                metadata=doc.metadata_ or {},
-            )
-            for doc in docs
-        ],
+        items=[_build_document_response(doc, name_map) for doc in docs],
     )
 
 
@@ -1692,28 +1722,12 @@ async def list_all_documents(
         offset=offset,
     )
 
+    unique_user_ids = list({doc.created_by for doc in docs if doc.created_by})
+    name_map = await _resolve_user_display_names(unique_user_ids)
+
     return DocumentListResponse(
         count=total,
-        items=[
-            DocumentResponse(
-                id=doc.id,
-                corpus_id=doc.corpus_id,
-                app_name=doc.app_name,
-                file_hash=doc.file_hash,
-                original_filename=doc.original_filename,
-                gcs_uri=doc.gcs_uri,
-                content_type=doc.content_type,
-                file_size=doc.file_size,
-                status=doc.status,
-                created_at=doc.created_at.isoformat() if doc.created_at else None,
-                created_by=doc.created_by,
-                markdown_extract_status=doc.markdown_extract_status,
-                markdown_extracted_at=doc.markdown_extracted_at.isoformat() if doc.markdown_extracted_at else None,
-                markdown_extract_error=doc.markdown_extract_error,
-                metadata=doc.metadata_ or {},
-            )
-            for doc in docs
-        ],
+        items=[_build_document_response(doc, name_map) for doc in docs],
     )
 
 
@@ -1743,6 +1757,12 @@ async def get_document_detail(
 
     markdown_content = await storage_service.get_document_markdown(document_id)
 
+    name_map = (
+        await _resolve_user_display_names([doc.created_by])
+        if doc.created_by
+        else {}
+    )
+
     return DocumentDetailResponse(
         id=doc.id,
         corpus_id=doc.corpus_id,
@@ -1755,6 +1775,7 @@ async def get_document_detail(
         status=doc.status,
         created_at=doc.created_at.isoformat() if doc.created_at else None,
         created_by=doc.created_by,
+        created_by_name=name_map.get(doc.created_by) if doc.created_by else None,
         markdown_extract_status=doc.markdown_extract_status,
         markdown_extracted_at=doc.markdown_extracted_at.isoformat() if doc.markdown_extracted_at else None,
         markdown_extract_error=doc.markdown_extract_error,


### PR DESCRIPTION
## 问题

Knowledge / Documents 页面的 `Created By` 列直接显示原始用户 ID（如 `google:10222...`），而非人类可读的用户名。

## 方案

采用后端富化策略：在 `DocumentResponse` 中新增 `created_by_name` 字段，通过批量查询 `UserState` 表解析用户 ID 到 `state.profile.name` 显示名称。

## 变更

### 后端（`knowledge/api.py`）
- `DocumentResponse` 新增 `created_by_name: Optional[str]` 字段
- 新增 `_resolve_user_display_names()` 批量查询 UserState 获取用户显示名
- 新增 `_build_document_response()` 消除重复的 DocumentResponse 构建逻辑
- `list_documents`、`list_all_documents`、`get_document_detail` 三个端点注入用户显示名

### 前端
- `KnowledgeDocument` 接口新增 `created_by_name` 字段
- `page.tsx` 和 `DocumentViewDialog.tsx` 的 `displayUser()` 优先使用 `created_by_name`，fallback 到截断 ID

## 测试计划

- [ ] 调用 `GET /knowledge/documents` 确认响应包含 `created_by_name` 字段
- [ ] 访问 Knowledge / Documents 页面，确认 Created By 列显示用户名
- [ ] 点击文档查看详情弹窗，确认 Created By 元数据也显示用户名
- [ ] 验证 `created_by` 为空或用户不存在时的 fallback 行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)