### PR TITLE
feat(Admin-Model): 新增 Admin Models 管理页，实现 LLM/Embedding 模型配置的 DB 持久化与动态切换

### DIFF
--- a/apps/negentropy-ui/app/admin/models/page.tsx
+++ b/apps/negentropy-ui/app/admin/models/page.tsx
@@ -1,0 +1,589 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { AdminNav } from "@/components/ui/AdminNav";
+
+interface ModelConfig {
+  id: string;
+  modelType: string;
+  displayName: string;
+  vendor: string;
+  modelName: string;
+  isDefault: boolean;
+  enabled: boolean;
+  config: Record<string, unknown>;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+interface ModelFormData {
+  model_type: string;
+  display_name: string;
+  vendor: string;
+  model_name: string;
+  is_default: boolean;
+  enabled: boolean;
+  config: Record<string, unknown>;
+}
+
+const VENDORS = [
+  { value: "openai", label: "OpenAI" },
+  { value: "anthropic", label: "Anthropic" },
+  { value: "zai", label: "ZAI (智谱)" },
+  { value: "vertex_ai", label: "Vertex AI" },
+  { value: "deepseek", label: "DeepSeek" },
+  { value: "ollama", label: "Ollama" },
+];
+
+const MODEL_TYPES = [
+  { value: "llm", label: "LLM", description: "大语言模型" },
+  { value: "embedding", label: "Embedding", description: "向量嵌入模型" },
+  { value: "rerank", label: "Rerank", description: "重排序模型" },
+];
+
+const EMPTY_FORM: ModelFormData = {
+  model_type: "llm",
+  display_name: "",
+  vendor: "zai",
+  model_name: "",
+  is_default: false,
+  enabled: true,
+  config: {},
+};
+
+export default function ModelsPage() {
+  const [models, setModels] = useState<Record<string, ModelConfig[]>>({
+    llm: [],
+    embedding: [],
+    rerank: [],
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<ModelFormData>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  // LLM config fields
+  const [temperature, setTemperature] = useState(0.7);
+  const [thinkingMode, setThinkingMode] = useState(false);
+  const [thinkingBudget, setThinkingBudget] = useState(2048);
+  const [maxTokens, setMaxTokens] = useState<string>("");
+
+  // Embedding config fields
+  const [dimensions, setDimensions] = useState<string>("");
+  const [inputType, setInputType] = useState("");
+
+  const fetchModels = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await fetch("/api/auth/admin/models");
+      if (!response.ok) throw new Error("Failed to fetch models");
+      const data = await response.json();
+      setModels(data.models || { llm: [], embedding: [], rerank: [] });
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchModels();
+  }, [fetchModels]);
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+    setEditingId(null);
+    setShowForm(false);
+    setTemperature(0.7);
+    setThinkingMode(false);
+    setThinkingBudget(2048);
+    setMaxTokens("");
+    setDimensions("");
+    setInputType("");
+  };
+
+  const openCreateForm = (modelType: string) => {
+    resetForm();
+    setForm({ ...EMPTY_FORM, model_type: modelType });
+    setShowForm(true);
+  };
+
+  const openEditForm = (mc: ModelConfig) => {
+    setEditingId(mc.id);
+    setForm({
+      model_type: mc.modelType,
+      display_name: mc.displayName,
+      vendor: mc.vendor,
+      model_name: mc.modelName,
+      is_default: mc.isDefault,
+      enabled: mc.enabled,
+      config: mc.config,
+    });
+    const cfg = mc.config || {};
+    setTemperature((cfg.temperature as number) ?? 0.7);
+    setThinkingMode((cfg.thinking_mode as boolean) ?? false);
+    setThinkingBudget((cfg.thinking_budget as number) ?? 2048);
+    setMaxTokens(cfg.max_tokens != null ? String(cfg.max_tokens) : "");
+    setDimensions(cfg.dimensions != null ? String(cfg.dimensions) : "");
+    setInputType((cfg.input_type as string) ?? "");
+    setShowForm(true);
+  };
+
+  const buildConfig = (): Record<string, unknown> => {
+    const cfg: Record<string, unknown> = {};
+    if (form.model_type === "llm") {
+      cfg.temperature = temperature;
+      if (thinkingMode) {
+        cfg.thinking_mode = true;
+        cfg.thinking_budget = thinkingBudget;
+      }
+      const parsedMaxTokens = parseInt(maxTokens, 10);
+      if (maxTokens && !isNaN(parsedMaxTokens)) cfg.max_tokens = parsedMaxTokens;
+    } else if (form.model_type === "embedding") {
+      const parsedDimensions = parseInt(dimensions, 10);
+      if (dimensions && !isNaN(parsedDimensions)) cfg.dimensions = parsedDimensions;
+      if (inputType) cfg.input_type = inputType;
+    }
+    return cfg;
+  };
+
+  const handleSave = async () => {
+    if (!form.display_name || !form.model_name) return;
+    setSaving(true);
+    try {
+      const payload = { ...form, config: buildConfig() };
+      const url = editingId
+        ? `/api/auth/admin/models/${editingId}`
+        : "/api/auth/admin/models";
+      const method = editingId ? "PATCH" : "POST";
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save");
+      }
+      resetForm();
+      await fetchModels();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSetDefault = async (id: string) => {
+    setActionLoading(id);
+    try {
+      const response = await fetch(
+        `/api/auth/admin/models/${id}/set-default`,
+        { method: "POST" },
+      );
+      if (!response.ok) throw new Error("Failed to set default");
+      await fetchModels();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm("确认删除此模型配置？此操作不可撤销。")) return;
+    setActionLoading(id);
+    try {
+      const response = await fetch(`/api/auth/admin/models/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to delete");
+      }
+      await fetchModels();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleToggleEnabled = async (mc: ModelConfig) => {
+    setActionLoading(mc.id);
+    try {
+      const response = await fetch(`/api/auth/admin/models/${mc.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !mc.enabled }),
+      });
+      if (!response.ok) throw new Error("Failed to toggle");
+      await fetchModels();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Toggle failed");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <AdminNav title="Model Management" />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+          {error && (
+            <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+              {error}
+              <button
+                onClick={() => setError(null)}
+                className="ml-2 font-medium underline"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="p-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+              Loading model configurations...
+            </div>
+          ) : (
+            <>
+              {MODEL_TYPES.map((mt) => (
+                <div
+                  key={mt.value}
+                  className="mb-6 rounded-xl border border-zinc-200 bg-white overflow-hidden dark:border-zinc-700 dark:bg-zinc-900"
+                >
+                  <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800">
+                    <div>
+                      <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                        {mt.label}
+                      </h2>
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {mt.description}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => openCreateForm(mt.value)}
+                      className="px-3 py-1.5 rounded-lg text-xs font-medium bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+                    >
+                      + Add
+                    </button>
+                  </div>
+
+                  {(models[mt.value] || []).length === 0 ? (
+                    <div className="p-6 text-center text-sm text-zinc-400 dark:text-zinc-500">
+                      No {mt.label} models configured
+                    </div>
+                  ) : (
+                    <div className="divide-y divide-zinc-100 dark:divide-zinc-700">
+                      {(models[mt.value] || []).map((mc) => (
+                        <div
+                          key={mc.id}
+                          className={`flex items-center gap-4 px-4 py-3 transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800 ${!mc.enabled ? "opacity-50" : ""}`}
+                        >
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-zinc-900 dark:text-zinc-100">
+                                {mc.displayName}
+                              </span>
+                              {mc.isDefault && (
+                                <span className="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-semibold text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+                                  DEFAULT
+                                </span>
+                              )}
+                              {!mc.enabled && (
+                                <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500">
+                                  DISABLED
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+                              <span className="inline-flex items-center rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400 mr-1">
+                                {mc.vendor}
+                              </span>
+                              {mc.modelName}
+                              {mc.config &&
+                                typeof mc.config.temperature === "number" && (
+                                  <span className="ml-2 text-zinc-400">
+                                    temp={mc.config.temperature}
+                                  </span>
+                                )}
+                            </div>
+                          </div>
+
+                          <div className="flex items-center gap-1.5">
+                            {!mc.isDefault && mc.enabled && (
+                              <button
+                                onClick={() => handleSetDefault(mc.id)}
+                                disabled={actionLoading === mc.id}
+                                className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-900/20 transition-colors disabled:opacity-50"
+                              >
+                                Set Default
+                              </button>
+                            )}
+                            <button
+                              onClick={() => handleToggleEnabled(mc)}
+                              disabled={actionLoading === mc.id}
+                              className={`px-2.5 py-1 rounded-lg text-[11px] font-medium transition-colors disabled:opacity-50 ${mc.enabled ? "text-amber-600 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-900/20" : "text-emerald-600 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-900/20"}`}
+                            >
+                              {mc.enabled ? "Disable" : "Enable"}
+                            </button>
+                            <button
+                              onClick={() => openEditForm(mc)}
+                              className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800 transition-colors"
+                            >
+                              Edit
+                            </button>
+                            {!mc.isDefault && (
+                              <button
+                                onClick={() => handleDelete(mc.id)}
+                                disabled={actionLoading === mc.id}
+                                className="px-2.5 py-1 rounded-lg text-[11px] font-medium text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50"
+                              >
+                                Delete
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </>
+          )}
+
+          {/* Form Modal */}
+          {showForm && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+              <div className="w-full max-w-lg rounded-xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
+                <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+                  {editingId ? "Edit Model" : "Add Model"}
+                </h3>
+
+                <div className="space-y-3">
+                  {/* Model Type (read-only when editing) */}
+                  <div>
+                    <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+                      Type
+                    </label>
+                    <select
+                      value={form.model_type}
+                      onChange={(e) =>
+                        setForm({ ...form, model_type: e.target.value })
+                      }
+                      disabled={!!editingId}
+                      className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 disabled:opacity-60"
+                    >
+                      {MODEL_TYPES.map((mt) => (
+                        <option key={mt.value} value={mt.value}>
+                          {mt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+                      Display Name
+                    </label>
+                    <input
+                      type="text"
+                      value={form.display_name}
+                      onChange={(e) =>
+                        setForm({ ...form, display_name: e.target.value })
+                      }
+                      placeholder="e.g. GLM-5 (智谱)"
+                      className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+                        Vendor
+                      </label>
+                      <select
+                        value={form.vendor}
+                        onChange={(e) =>
+                          setForm({ ...form, vendor: e.target.value })
+                        }
+                        className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      >
+                        {VENDORS.map((v) => (
+                          <option key={v.value} value={v.value}>
+                            {v.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+                        Model Name
+                      </label>
+                      <input
+                        type="text"
+                        value={form.model_name}
+                        onChange={(e) =>
+                          setForm({ ...form, model_name: e.target.value })
+                        }
+                        placeholder="e.g. glm-5"
+                        className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      />
+                    </div>
+                  </div>
+
+                  {/* LLM-specific config */}
+                  {form.model_type === "llm" && (
+                    <div className="rounded-lg border border-zinc-100 p-3 dark:border-zinc-700 space-y-3">
+                      <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                        LLM Parameters
+                      </div>
+                      <div>
+                        <label className="flex items-center justify-between text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                          <span>Temperature</span>
+                          <span className="font-mono">{temperature}</span>
+                        </label>
+                        <input
+                          type="range"
+                          min="0"
+                          max="2"
+                          step="0.1"
+                          value={temperature}
+                          onChange={(e) =>
+                            setTemperature(parseFloat(e.target.value))
+                          }
+                          className="w-full"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                          Max Tokens (optional)
+                        </label>
+                        <input
+                          type="number"
+                          value={maxTokens}
+                          onChange={(e) => setMaxTokens(e.target.value)}
+                          placeholder="Default"
+                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                        />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          id="thinking_mode"
+                          checked={thinkingMode}
+                          onChange={(e) => setThinkingMode(e.target.checked)}
+                          className="rounded border-zinc-300 dark:border-zinc-600"
+                        />
+                        <label
+                          htmlFor="thinking_mode"
+                          className="text-xs text-zinc-600 dark:text-zinc-400"
+                        >
+                          Thinking Mode
+                        </label>
+                      </div>
+                      {thinkingMode && (
+                        <div>
+                          <label className="block text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                            Thinking Budget (tokens)
+                          </label>
+                          <input
+                            type="number"
+                            value={thinkingBudget}
+                            onChange={(e) => {
+                              const v = parseInt(e.target.value, 10);
+                              setThinkingBudget(isNaN(v) ? 0 : v);
+                            }}
+                            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Embedding-specific config */}
+                  {form.model_type === "embedding" && (
+                    <div className="rounded-lg border border-zinc-100 p-3 dark:border-zinc-700 space-y-3">
+                      <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                        Embedding Parameters
+                      </div>
+                      <div>
+                        <label className="block text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                          Dimensions (optional)
+                        </label>
+                        <input
+                          type="number"
+                          value={dimensions}
+                          onChange={(e) => setDimensions(e.target.value)}
+                          placeholder="Default"
+                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                          Input Type (optional)
+                        </label>
+                        <select
+                          value={inputType}
+                          onChange={(e) => setInputType(e.target.value)}
+                          className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                        >
+                          <option value="">None</option>
+                          <option value="search_query">search_query</option>
+                          <option value="search_document">
+                            search_document
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Enabled toggle */}
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      id="enabled"
+                      checked={form.enabled}
+                      onChange={(e) =>
+                        setForm({ ...form, enabled: e.target.checked })
+                      }
+                      className="rounded border-zinc-300 dark:border-zinc-600"
+                    />
+                    <label
+                      htmlFor="enabled"
+                      className="text-xs text-zinc-600 dark:text-zinc-400"
+                    >
+                      Enabled
+                    </label>
+                  </div>
+                </div>
+
+                <div className="mt-5 flex justify-end gap-2">
+                  <button
+                    onClick={resetForm}
+                    className="px-4 py-2 rounded-lg text-xs font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={handleSave}
+                    disabled={saving || !form.display_name || !form.model_name}
+                    className="px-4 py-2 rounded-lg text-xs font-medium bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors disabled:opacity-50"
+                  >
+                    {saving ? "Saving..." : editingId ? "Update" : "Create"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAuthBaseUrl } from "../../../../_config";
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ modelId: string }> },
+) {
+  const { modelId } = await params;
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const body = await request.text();
+  const upstreamUrl = new URL(
+    `/auth/admin/models/${encodeURIComponent(modelId)}`,
+    baseUrl,
+  );
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "PATCH",
+      headers: {
+        ...Object.fromEntries(buildAuthHeaders(request).entries()),
+        "Content-Type": "application/json",
+      },
+      body,
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: text || "Upstream returned non-OK status" },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ modelId: string }> },
+) {
+  const { modelId } = await params;
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const upstreamUrl = new URL(
+    `/auth/admin/models/${encodeURIComponent(modelId)}`,
+    baseUrl,
+  );
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "DELETE",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: text || "Upstream returned non-OK status" },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}

--- a/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/set-default/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/set-default/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAuthBaseUrl } from "../../../../../_config";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ modelId: string }> },
+) {
+  const { modelId } = await params;
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const upstreamUrl = new URL(
+    `/auth/admin/models/${encodeURIComponent(modelId)}/set-default`,
+    baseUrl,
+  );
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: text || "Upstream returned non-OK status" },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}

--- a/apps/negentropy-ui/app/api/auth/admin/models/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAuthBaseUrl } from "../../../_config";
+
+export async function GET(request: Request) {
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const upstreamUrl = new URL("/auth/admin/models", baseUrl);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "GET",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: text || "Upstream returned non-OK status" },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}
+
+export async function POST(request: Request) {
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const body = await request.text();
+  const upstreamUrl = new URL("/auth/admin/models", baseUrl);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: {
+        ...Object.fromEntries(buildAuthHeaders(request).entries()),
+        "Content-Type": "application/json",
+      },
+      body,
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: text || "Upstream returned non-OK status" },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}

--- a/apps/negentropy-ui/components/ui/AdminNav.tsx
+++ b/apps/negentropy-ui/components/ui/AdminNav.tsx
@@ -8,6 +8,7 @@ import { useNavigation } from "@/components/providers/NavigationProvider";
 const NAV_ITEMS = [
   { href: "/admin", label: "Users" },
   { href: "/admin/roles", label: "Role Management" },
+  { href: "/admin/models", label: "Models" },
 ];
 
 export function AdminNav({

--- a/apps/negentropy/src/negentropy/agents/_model.py
+++ b/apps/negentropy/src/negentropy/agents/_model.py
@@ -15,6 +15,13 @@ from negentropy.config import settings
 def create_model() -> LiteLlm:
     """创建 LiteLlm 实例。
 
-    若未来需要为模型添加 retry、fallback 或其他配置，只需修改此处。
+    优先使用缓存的 DB 配置，回退到 .env。
+    缓存由 engine/bootstrap.py 的 startup 事件预热。
     """
+    from negentropy.config.model_resolver import get_cached_llm_config
+
+    cached = get_cached_llm_config()
+    if cached:
+        name, kwargs = cached
+        return LiteLlm(name, **kwargs)
     return LiteLlm(settings.llm.full_model_name, **settings.llm.to_litellm_kwargs())

--- a/apps/negentropy/src/negentropy/auth/api.py
+++ b/apps/negentropy/src/negentropy/auth/api.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
@@ -230,3 +231,219 @@ async def list_permissions() -> dict[str, Any]:
     from .rbac import get_all_permissions
 
     return {"permissions": get_all_permissions()}
+
+
+# =============================================================================
+# Model Config Admin Endpoints
+# =============================================================================
+
+
+class ModelConfigCreate(BaseModel):
+    model_type: str = Field(..., description="llm, embedding, or rerank")
+    display_name: str
+    vendor: str
+    model_name: str
+    is_default: bool = False
+    enabled: bool = True
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ModelConfigUpdate(BaseModel):
+    display_name: Optional[str] = None
+    vendor: Optional[str] = None
+    model_name: Optional[str] = None
+    is_default: Optional[bool] = None
+    enabled: Optional[bool] = None
+    config: Optional[Dict[str, Any]] = None
+
+
+def _model_config_to_dict(mc) -> dict[str, Any]:
+    return {
+        "id": str(mc.id),
+        "modelType": mc.model_type.value,
+        "displayName": mc.display_name,
+        "vendor": mc.vendor,
+        "modelName": mc.model_name,
+        "isDefault": mc.is_default,
+        "enabled": mc.enabled,
+        "config": mc.config or {},
+        "createdAt": mc.created_at.isoformat() if mc.created_at else None,
+        "updatedAt": mc.updated_at.isoformat() if mc.updated_at else None,
+    }
+
+
+@router.get("/admin/models")
+async def list_model_configs(current_user: AuthUser = Depends(get_current_user)) -> dict[str, Any]:
+    """List all model configurations, grouped by model_type."""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    from negentropy.models.model_config import ModelConfig
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(ModelConfig).order_by(ModelConfig.model_type, ModelConfig.created_at))
+        configs = result.scalars().all()
+
+    grouped: dict[str, list] = {"llm": [], "embedding": [], "rerank": []}
+    for mc in configs:
+        key = mc.model_type.value
+        if key not in grouped:
+            grouped[key] = []
+        grouped[key].append(_model_config_to_dict(mc))
+
+    return {"models": grouped}
+
+
+@router.post("/admin/models", status_code=status.HTTP_201_CREATED)
+async def create_model_config(
+    payload: ModelConfigCreate,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Create a new model configuration."""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    from negentropy.config.model_resolver import invalidate_cache
+    from negentropy.models.model_config import ModelConfig, ModelType
+
+    try:
+        mt = ModelType(payload.model_type)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid model_type: {payload.model_type}. Must be one of: llm, embedding, rerank",
+        )
+
+    async with AsyncSessionLocal() as db:
+        # 如果 is_default=True，先取消同类型的其他默认
+        if payload.is_default:
+            await db.execute(
+                update(ModelConfig)
+                .where(ModelConfig.model_type == mt, ModelConfig.is_default.is_(True))
+                .values(is_default=False)
+            )
+
+        mc = ModelConfig(
+            model_type=mt,
+            display_name=payload.display_name,
+            vendor=payload.vendor,
+            model_name=payload.model_name,
+            is_default=payload.is_default,
+            enabled=payload.enabled,
+            config=payload.config,
+        )
+        db.add(mc)
+        await db.commit()
+        await db.refresh(mc)
+
+    invalidate_cache(payload.model_type)
+    return {"model": _model_config_to_dict(mc)}
+
+
+@router.patch("/admin/models/{model_id}")
+async def update_model_config(
+    model_id: UUID,
+    payload: ModelConfigUpdate,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Update a model configuration."""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    from negentropy.config.model_resolver import invalidate_cache
+    from negentropy.models.model_config import ModelConfig
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(ModelConfig).where(ModelConfig.id == model_id))
+        mc = result.scalar_one_or_none()
+        if not mc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="model config not found")
+
+        # 如果设为默认，先取消同类型的其他默认
+        if payload.is_default is True and not mc.is_default:
+            await db.execute(
+                update(ModelConfig)
+                .where(ModelConfig.model_type == mc.model_type, ModelConfig.is_default.is_(True))
+                .values(is_default=False)
+            )
+
+        update_data = payload.model_dump(exclude_none=True)
+        for key, value in update_data.items():
+            setattr(mc, key, value)
+
+        model_type_val = mc.model_type.value
+        await db.commit()
+        await db.refresh(mc)
+
+    invalidate_cache(model_type_val)
+    return {"model": _model_config_to_dict(mc)}
+
+
+@router.delete("/admin/models/{model_id}")
+async def delete_model_config(
+    model_id: UUID,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Delete a model configuration. Cannot delete the sole default of a type."""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    from negentropy.config.model_resolver import invalidate_cache
+    from negentropy.models.model_config import ModelConfig
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(ModelConfig).where(ModelConfig.id == model_id))
+        mc = result.scalar_one_or_none()
+        if not mc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="model config not found")
+
+        if mc.is_default:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot delete the default model. Set another model as default first.",
+            )
+
+        model_type_val = mc.model_type.value
+        await db.delete(mc)
+        await db.commit()
+
+    invalidate_cache(model_type_val)
+    return {"status": "deleted"}
+
+
+@router.post("/admin/models/{model_id}/set-default")
+async def set_default_model(
+    model_id: UUID,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """Set a model configuration as the default for its type."""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    from negentropy.config.model_resolver import invalidate_cache
+    from negentropy.models.model_config import ModelConfig
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(ModelConfig).where(ModelConfig.id == model_id))
+        mc = result.scalar_one_or_none()
+        if not mc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="model config not found")
+
+        if not mc.enabled:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot set a disabled model as default.",
+            )
+
+        # 事务: 取消同类型旧默认，设置新默认
+        await db.execute(
+            update(ModelConfig)
+            .where(ModelConfig.model_type == mc.model_type, ModelConfig.is_default.is_(True))
+            .values(is_default=False)
+        )
+        mc.is_default = True
+        await db.commit()
+        await db.refresh(mc)
+
+    invalidate_cache(mc.model_type.value)
+    return {"model": _model_config_to_dict(mc)}

--- a/apps/negentropy/src/negentropy/config/model_resolver.py
+++ b/apps/negentropy/src/negentropy/config/model_resolver.py
@@ -1,0 +1,230 @@
+"""
+Model Resolver — DB 优先、.env 回退的模型配置解析器。
+
+遵循 Single Source of Truth 原则：
+1. 首先从 DB 查询 default 配置
+2. 若 DB 无数据或不可达，回退到 settings.llm
+3. 内存缓存 + TTL 避免每次请求查 DB
+
+公开接口:
+- resolve_llm_config()        — 异步解析默认 LLM
+- resolve_embedding_config()  — 异步解析默认 Embedding
+- get_cached_llm_config()     — 同步缓存读取 (无法 await 的上下文)
+- invalidate_cache()          — 缓存失效 (Admin 写操作后调用)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple
+
+# Cache TTL in seconds
+_CACHE_TTL = 60.0
+
+# In-memory cache: { model_type: (full_model_name, kwargs, timestamp) }
+_cache: Dict[str, Tuple[str, Dict[str, Any], float]] = {}
+
+
+def invalidate_cache(model_type: Optional[str] = None) -> None:
+    """使缓存失效。Admin 写操作后调用。
+
+    Args:
+        model_type: 指定类型失效; None 表示全部失效。
+    """
+    if model_type:
+        _cache.pop(model_type, None)
+    else:
+        _cache.clear()
+
+
+def get_cached_llm_config() -> Optional[Tuple[str, Dict[str, Any]]]:
+    """同步缓存读取 — 用于 create_model() 等无法 await 的上下文。
+
+    返回 kwargs 的浅拷贝，防止调用方原地修改污染缓存。
+
+    Returns:
+        (full_model_name, litellm_kwargs) 或 None (缓存未命中/过期)。
+    """
+    entry = _cache.get("llm")
+    if entry is not None:
+        name, kwargs, ts = entry
+        if time.monotonic() - ts < _CACHE_TTL:
+            return name, kwargs.copy()
+    return None
+
+
+def get_cached_embedding_config() -> Optional[Tuple[str, Dict[str, Any]]]:
+    """同步缓存读取 — Embedding 模型。返回 kwargs 浅拷贝。"""
+    entry = _cache.get("embedding")
+    if entry is not None:
+        name, kwargs, ts = entry
+        if time.monotonic() - ts < _CACHE_TTL:
+            return name, kwargs.copy()
+    return None
+
+
+async def resolve_llm_config() -> Tuple[str, Dict[str, Any]]:
+    """异步解析默认 LLM 模型配置。
+
+    Returns:
+        (full_model_name, litellm_kwargs)
+    """
+    return await _resolve("llm")
+
+
+async def resolve_embedding_config() -> Tuple[str, Dict[str, Any]]:
+    """异步解析默认 Embedding 模型配置。
+
+    Returns:
+        (full_model_name, embedding_kwargs)
+    """
+    return await _resolve("embedding")
+
+
+async def _resolve(model_type: str) -> Tuple[str, Dict[str, Any]]:
+    """核心解析: DB → 缓存 → .env 回退。"""
+    now = time.monotonic()
+
+    # 1. 检查缓存
+    entry = _cache.get(model_type)
+    if entry is not None:
+        name, kwargs, ts = entry
+        if now - ts < _CACHE_TTL:
+            return name, kwargs.copy()
+
+    # 2. 尝试 DB
+    try:
+        result = await _resolve_from_db(model_type)
+        if result is not None:
+            name, kwargs = result
+            _cache[model_type] = (name, kwargs, now)
+            return name, kwargs.copy()
+    except Exception:
+        # Lazy import to avoid circular dependency at module level
+        from negentropy.logging import get_logger
+
+        logger = get_logger("negentropy.config.model_resolver")
+        logger.warning("model_resolver_db_fallback", model_type=model_type, exc_info=True)
+
+    # 3. 回退到 settings.llm
+    name, kwargs = _resolve_from_settings(model_type)
+    _cache[model_type] = (name, kwargs, now)
+    return name, kwargs.copy()
+
+
+async def _resolve_from_db(model_type: str) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """从 DB 查询默认模型配置。"""
+    from sqlalchemy import select
+
+    from negentropy.db.session import AsyncSessionLocal
+    from negentropy.models.model_config import ModelConfig, ModelType
+
+    mt = ModelType(model_type)
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(ModelConfig).where(
+                ModelConfig.model_type == mt,
+                ModelConfig.is_default.is_(True),
+                ModelConfig.enabled.is_(True),
+            )
+        )
+        config = result.scalar_one_or_none()
+
+    if config is None:
+        return None
+
+    full_name = _build_full_model_name(config.vendor, config.model_name)
+    cfg = config.config or {}
+
+    if model_type == "embedding":
+        kwargs = _build_embedding_kwargs(cfg)
+    else:
+        kwargs = _build_llm_kwargs(config.vendor, config.model_name, cfg)
+
+    return full_name, kwargs
+
+
+def _resolve_from_settings(model_type: str) -> Tuple[str, Dict[str, Any]]:
+    """从 settings.llm 回退解析。"""
+    from negentropy.config import settings
+
+    if model_type == "embedding":
+        return (
+            settings.llm.embedding_full_model_name,
+            settings.llm.to_litellm_embedding_kwargs(),
+        )
+    # llm / rerank 均回退到 LLM settings
+    return (
+        settings.llm.full_model_name,
+        settings.llm.to_litellm_kwargs(),
+    )
+
+
+def _build_full_model_name(vendor: str, model_name: str) -> str:
+    """构建 LiteLLM 兼容的 vendor/model_name 字符串。"""
+    from negentropy.model_names import canonicalize_model_name
+
+    raw = f"{vendor}/{model_name}" if "/" not in model_name else model_name
+    return canonicalize_model_name(raw) or raw
+
+
+def _build_llm_kwargs(vendor: str, model_name: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    """从 DB config JSONB 构建 LiteLLM kwargs。
+
+    复用 LlmSettings._apply_thinking_config 的供应商特定转译逻辑。
+    """
+    kwargs: Dict[str, Any] = {}
+
+    if "temperature" in config:
+        kwargs["temperature"] = config["temperature"]
+    if "max_tokens" in config:
+        kwargs["max_tokens"] = config["max_tokens"]
+    if "top_p" in config:
+        kwargs["top_p"] = config["top_p"]
+
+    # 供应商特定的 thinking/reasoning 适配
+    model_lower = model_name.lower()
+
+    if vendor == "zai" or "glm" in model_lower:
+        kwargs["drop_params"] = config.get("drop_params", True)
+        thinking_mode = config.get("thinking_mode", False)
+        if thinking_mode:
+            thinking_config: Dict[str, Any] = {
+                "type": "enabled",
+                "budget_tokens": config.get("thinking_budget", 2048),
+            }
+            if config.get("preserve_thinking", False):
+                thinking_config["clear_thinking"] = False
+        else:
+            thinking_config = {"type": "disabled"}
+        kwargs["extra_body"] = {"thinking": thinking_config}
+
+    elif vendor == "anthropic" or "claude" in model_lower:
+        thinking_mode = config.get("thinking_mode", False)
+        if thinking_mode:
+            kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": config.get("thinking_budget", 2048),
+            }
+        else:
+            kwargs["thinking"] = {"type": "disabled"}
+
+    elif vendor == "openai" and model_lower.startswith(("o1", "o3")):
+        thinking_mode = config.get("thinking_mode", False)
+        if thinking_mode:
+            kwargs["reasoning_effort"] = config.get("reasoning_effort", "medium")
+
+    if "drop_params" in config and "drop_params" not in kwargs:
+        kwargs["drop_params"] = config["drop_params"]
+
+    return kwargs
+
+
+def _build_embedding_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
+    """从 DB config JSONB 构建 Embedding kwargs。"""
+    kwargs: Dict[str, Any] = {}
+    if "dimensions" in config and config["dimensions"] is not None:
+        kwargs["dimensions"] = config["dimensions"]
+    if "input_type" in config and config["input_type"]:
+        kwargs["input_type"] = config["input_type"]
+    return kwargs

--- a/apps/negentropy/src/negentropy/db/migrations/versions/g1h2i3j4k5l6_add_model_configs_table.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/g1h2i3j4k5l6_add_model_configs_table.py
@@ -1,0 +1,112 @@
+"""add model_configs table
+
+Revision ID: g1h2i3j4k5l6
+Revises: e6f7a8b9c0d1
+Create Date: 2026-03-24 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+import negentropy.models.base
+
+# revision identifiers, used by Alembic.
+revision: str = "g1h2i3j4k5l6"
+down_revision: Union[str, None] = "e6f7a8b9c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    schema = negentropy.models.base.NEGENTROPY_SCHEMA
+
+    # 创建 model_type_enum 类型
+    model_type_enum = postgresql.ENUM("llm", "embedding", "rerank", name="model_type_enum", schema=schema)
+    model_type_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "model_configs",
+        sa.Column(
+            "model_type",
+            sa.Enum("llm", "embedding", "rerank", name="model_type_enum", schema=schema),
+            nullable=False,
+        ),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("vendor", sa.String(length=50), nullable=False),
+        sa.Column("model_name", sa.String(length=255), nullable=False),
+        sa.Column("is_default", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("enabled", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("vendor", "model_name", "model_type", name="model_configs_vendor_model_type_unique"),
+        schema=schema,
+    )
+
+    # 部分唯一索引: 每种 model_type 最多一个 default
+    op.create_index(
+        "ix_model_configs_default_unique",
+        "model_configs",
+        ["model_type"],
+        unique=True,
+        schema=schema,
+        postgresql_where=sa.text("is_default = true"),
+    )
+
+    # Seed 默认数据
+    model_configs = sa.table(
+        "model_configs",
+        sa.column("model_type", sa.String),
+        sa.column("display_name", sa.String),
+        sa.column("vendor", sa.String),
+        sa.column("model_name", sa.String),
+        sa.column("is_default", sa.Boolean),
+        sa.column("enabled", sa.Boolean),
+        sa.column("config", postgresql.JSONB),
+        schema=schema,
+    )
+    op.bulk_insert(
+        model_configs,
+        [
+            {
+                "model_type": "llm",
+                "display_name": "GLM-5 (智谱)",
+                "vendor": "zai",
+                "model_name": "glm-5",
+                "is_default": True,
+                "enabled": True,
+                "config": {"temperature": 0.7},
+            },
+            {
+                "model_type": "embedding",
+                "display_name": "Text Embedding 005 (Vertex AI)",
+                "vendor": "vertex_ai",
+                "model_name": "text-embedding-005",
+                "is_default": True,
+                "enabled": True,
+                "config": {},
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    schema = negentropy.models.base.NEGENTROPY_SCHEMA
+
+    op.drop_index("ix_model_configs_default_unique", table_name="model_configs", schema=schema)
+    op.drop_table("model_configs", schema=schema)
+
+    # 删除 enum 类型
+    model_type_enum = postgresql.ENUM("llm", "embedding", "rerank", name="model_type_enum", schema=schema)
+    model_type_enum.drop(op.get_bind(), checkfirst=True)

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -340,6 +340,19 @@ def apply_adk_patches():
         if not any(getattr(route, "path", "").endswith("/sessions/{session_id}/title") for route in app.router.routes):
             app.include_router(sessions_router)
             logger.info("Sessions API router mounted for title updates")
+
+        # 预热模型配置缓存，确保同步读取 (create_model) 在首次调用时有数据
+        @app.on_event("startup")
+        async def _warm_model_config_cache():
+            from negentropy.config.model_resolver import resolve_embedding_config, resolve_llm_config
+
+            try:
+                await resolve_llm_config()
+                await resolve_embedding_config()
+                logger.info("model_config_cache_warmed")
+            except Exception as exc:
+                logger.warning("model_config_cache_warm_failed", error=str(exc))
+
         return app
 
     # Patch get_fast_api_app via AdkWebServer so it applies to current call

--- a/apps/negentropy/src/negentropy/engine/summarization.py
+++ b/apps/negentropy/src/negentropy/engine/summarization.py
@@ -24,10 +24,17 @@ class SessionSummarizer:
     """Uses LLM to summarize conversation history into a short title."""
 
     def __init__(self):
-        kwargs = settings.llm.to_litellm_kwargs()
+        from negentropy.config.model_resolver import get_cached_llm_config
+
+        cached = get_cached_llm_config()
+        if cached:
+            name, kwargs = cached
+        else:
+            name = settings.llm.full_model_name
+            kwargs = settings.llm.to_litellm_kwargs()
         kwargs["max_tokens"] = 20
         logger.debug("session_summarizer_initialized")
-        self.model = LiteLlm(settings.llm.full_model_name, **kwargs)
+        self.model = LiteLlm(name, **kwargs)
 
     async def generate_title(self, history: List[types.Content]) -> Optional[str]:
         """

--- a/apps/negentropy/src/negentropy/knowledge/embedding.py
+++ b/apps/negentropy/src/negentropy/knowledge/embedding.py
@@ -126,6 +126,13 @@ async def _call_with_retry(
     raise last_exc
 
 
+async def _resolve_embedding() -> tuple[str, dict]:
+    """解析 Embedding 模型配置 (DB 优先, .env 回退)。"""
+    from negentropy.config.model_resolver import resolve_embedding_config
+
+    return await resolve_embedding_config()
+
+
 def build_embedding_fn() -> EmbeddingFn:
     """构建单条文本向量化函数
 
@@ -135,12 +142,13 @@ def build_embedding_fn() -> EmbeddingFn:
     Raises:
         EmbeddingFailed: 当向量化请求失败或响应格式异常时
     """
-    model_name = settings.llm.embedding_full_model_name
 
     async def embed(text: str) -> list[float]:
         cleaned = text.strip()
         if not cleaned:
             return []
+
+        model_name, extra_kwargs = await _resolve_embedding()
 
         try:
             import litellm
@@ -149,7 +157,7 @@ def build_embedding_fn() -> EmbeddingFn:
                 return await litellm.aembedding(
                     model=model_name,
                     input=[cleaned],
-                    **settings.llm.to_litellm_embedding_kwargs(),
+                    **extra_kwargs,
                 )
 
             response = await _call_with_retry(
@@ -197,13 +205,14 @@ def build_batch_embedding_fn() -> BatchEmbeddingFn:
     Raises:
         EmbeddingFailed: 当向量化请求失败或响应格式异常时
     """
-    model_name = settings.llm.embedding_full_model_name
 
     MAX_BATCH_SIZE = 10  # Conservative batch size to avoid token limits (20k)
 
     async def batch_embed(texts: list[str]) -> list[list[float]]:
         if not texts:
             return []
+
+        model_name, extra_kwargs = await _resolve_embedding()
 
         # Split texts into batches
         batches = [texts[i : i + MAX_BATCH_SIZE] for i in range(0, len(texts), MAX_BATCH_SIZE)]
@@ -225,7 +234,7 @@ def build_batch_embedding_fn() -> BatchEmbeddingFn:
                         return await litellm.aembedding(
                             model=model_name,
                             input=non_empty_texts,
-                            **settings.llm.to_litellm_embedding_kwargs(),
+                            **extra_kwargs,
                         )
 
                     response = await _call_with_retry(

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -1252,11 +1252,16 @@ async def _build_llm_invocation_plan(
         return None
 
     try:
+        from negentropy.config.model_resolver import resolve_llm_config
+
+        _llm_name, _llm_kwargs = await resolve_llm_config()
+        # 过滤掉与显式参数冲突的键
+        _safe_kwargs = {k: v for k, v in _llm_kwargs.items() if k not in ("model", "messages", "response_format")}
         response = await litellm.acompletion(
-            model=settings.llm.full_model_name,
+            model=_llm_name,
             messages=[{"role": "user", "content": prompt}],
             response_format={"type": "json_object"},
-            **settings.llm.to_litellm_kwargs(),
+            **_safe_kwargs,
         )
     except Exception as exc:
         logger.warning("extractor_llm_plan_failed", tool_name=tool_name, error=str(exc))

--- a/apps/negentropy/src/negentropy/knowledge/llm_extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/llm_extractors.py
@@ -138,14 +138,22 @@ Output as JSON with the following structure:
             max_retries: 最大重试次数
             fallback_to_regex: 失败时是否回退到正则提取器
         """
-        self._model = model or self._get_default_model()
+        self._model, self._model_kwargs = self._resolve_model_config(model)
         self._temperature = temperature
         self._max_retries = max_retries
         self._fallback_to_regex = fallback_to_regex
 
-    def _get_default_model(self) -> str:
-        """获取默认 LLM 模型（使用统一配置）"""
-        return settings.llm.full_model_name
+    @staticmethod
+    def _resolve_model_config(explicit_model: str | None) -> tuple[str, dict]:
+        """解析模型配置（DB 优先，.env 回退）。返回 (model_name, extra_kwargs)。"""
+        if explicit_model:
+            return explicit_model, {}
+        from negentropy.config.model_resolver import get_cached_llm_config
+
+        cached = get_cached_llm_config()
+        if cached is not None:
+            return cached[0], cached[1]
+        return settings.llm.full_model_name, settings.llm.to_litellm_kwargs()
 
     async def extract(
         self,
@@ -242,11 +250,17 @@ Output as JSON with the following structure:
         last_error = None
         for attempt in range(self._max_retries):
             try:
+                # 过滤掉与显式参数冲突的 kwargs 键
+                safe_kwargs = {
+                    k: v for k, v in self._model_kwargs.items()
+                    if k not in ("model", "messages", "temperature", "response_format")
+                }
                 response = await litellm.acompletion(
                     model=self._model,
                     messages=[{"role": "user", "content": prompt}],
                     temperature=self._temperature,
                     response_format={"type": "json_object"},
+                    **safe_kwargs,
                 )
 
                 content = response.choices[0].message.content
@@ -412,14 +426,22 @@ Output as JSON with the following structure:
             max_retries: 最大重试次数
             fallback_to_cooccurrence: 失败时是否回退到共现提取器
         """
-        self._model = model or self._get_default_model()
+        self._model, self._model_kwargs = self._resolve_model_config(model)
         self._temperature = temperature
         self._max_retries = max_retries
         self._fallback_to_cooccurrence = fallback_to_cooccurrence
 
-    def _get_default_model(self) -> str:
-        """获取默认 LLM 模型（使用统一配置）"""
-        return settings.llm.full_model_name
+    @staticmethod
+    def _resolve_model_config(explicit_model: str | None) -> tuple[str, dict]:
+        """解析模型配置（DB 优先，.env 回退）。返回 (model_name, extra_kwargs)。"""
+        if explicit_model:
+            return explicit_model, {}
+        from negentropy.config.model_resolver import get_cached_llm_config
+
+        cached = get_cached_llm_config()
+        if cached is not None:
+            return cached[0], cached[1]
+        return settings.llm.full_model_name, settings.llm.to_litellm_kwargs()
 
     async def extract(
         self,
@@ -542,11 +564,17 @@ Output as JSON with the following structure:
         last_error = None
         for attempt in range(self._max_retries):
             try:
+                # 过滤掉与显式参数冲突的 kwargs 键
+                safe_kwargs = {
+                    k: v for k, v in self._model_kwargs.items()
+                    if k not in ("model", "messages", "temperature", "response_format")
+                }
                 response = await litellm.acompletion(
                     model=self._model,
                     messages=[{"role": "user", "content": prompt}],
                     temperature=self._temperature,
                     response_format={"type": "json_object"},
+                    **safe_kwargs,
                 )
 
                 content = response.choices[0].message.content

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -16,6 +16,7 @@ from .plugin import (
     Skill,
     SubAgent,
 )
+from .model_config import ModelConfig, ModelType
 from .pulse import AppState, Event, Message, Run, Snapshot, Thread, UserState
 from .security import Credential
 
@@ -65,4 +66,7 @@ __all__ = [
     "McpTrialAsset",
     "Skill",
     "SubAgent",
+    # Model Config
+    "ModelConfig",
+    "ModelType",
 ]

--- a/apps/negentropy/src/negentropy/models/model_config.py
+++ b/apps/negentropy/src/negentropy/models/model_config.py
@@ -1,0 +1,74 @@
+"""
+Model Configuration 数据模型。
+
+存储 LLM、Embedding、Rerank 模型配置，支持管理员通过 Admin UI 动态切换。
+每种 model_type 最多一个 is_default=True 的记录（通过部分唯一索引保证）。
+"""
+
+import enum
+from typing import Any, Dict
+
+from sqlalchemy import Boolean, Enum, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin
+
+
+class ModelType(str, enum.Enum):
+    """模型类型枚举"""
+
+    LLM = "llm"
+    EMBEDDING = "embedding"
+    RERANK = "rerank"
+
+
+class ModelConfig(Base, UUIDMixin, TimestampMixin):
+    """模型配置
+
+    Attributes:
+        model_type: 模型类型 (llm / embedding / rerank)
+        display_name: 管理界面展示名称
+        vendor: 供应商标识 (如 openai, anthropic, zai, vertex_ai, deepseek, ollama)
+        model_name: 模型标识符 (如 glm-5, text-embedding-005)
+        is_default: 是否为该类型的默认模型
+        enabled: 是否启用
+        config: 供应商特定参数 (temperature, thinking_mode 等)
+    """
+
+    __tablename__ = "model_configs"
+
+    model_type: Mapped[ModelType] = mapped_column(
+        Enum(ModelType, schema=NEGENTROPY_SCHEMA, name="model_type_enum"),
+        nullable=False,
+    )
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    vendor: Mapped[str] = mapped_column(String(50), nullable=False)
+    model_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    config: Mapped[Dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default="{}"
+    )
+
+    __table_args__ = (
+        # 每种 model_type 只能有一个 default
+        Index(
+            "ix_model_configs_default_unique",
+            "model_type",
+            unique=True,
+            postgresql_where=(is_default.is_(True)),
+        ),
+        # 防止同一类型下重复的 vendor + model_name
+        UniqueConstraint(
+            "vendor",
+            "model_name",
+            "model_type",
+            name="model_configs_vendor_model_type_unique",
+        ),
+        {"schema": NEGENTROPY_SCHEMA},
+    )


### PR DESCRIPTION
## Summary

将 LLM 和 Embedding 模型配置从 `.env` 环境变量硬编码升级为 **DB 持久化 + Admin UI 动态管理**，实现 **DB 优先、.env 回退** 的双层解析策略。

### 变更内容

**后端 — 数据模型与迁移**
- 新增 `ModelConfig` SQLAlchemy 模型，支持 `llm` / `embedding` / `rerank` 三种模型类型
- 部分唯一索引 `(model_type) WHERE is_default = TRUE` 确保每种类型仅一个默认
- Alembic 迁移 Seed 默认 LLM (GLM-5) 和 Embedding (text-embedding-005)

**后端 — 模型解析器 (`model_resolver`)**
- 异步 `resolve_llm_config()` / `resolve_embedding_config()` — DB 查询 + 内存缓存 (TTL 60s)
- 同步 `get_cached_llm_config()` — 用于 Agent 构造等无法 await 的场景
- `invalidate_cache()` — Admin 写操作后即时失效
- 所有路径返回 `kwargs.copy()`，防止调用方原地修改污染全局缓存

**后端 — Admin API (5 个端点)**
- `GET /auth/admin/models` — 列出所有配置 (按 model_type 分组)
- `POST /auth/admin/models` — 新建模型配置
- `PATCH /auth/admin/models/{id}` — 更新模型配置
- `DELETE /auth/admin/models/{id}` — 删除配置 (禁删唯一默认)
- `POST /auth/admin/models/{id}/set-default` — 设为默认 (事务内切换)

**后端 — 消费端集成 (6 处)**
- `agents/_model.py` — `create_model()` 同步缓存读取
- `knowledge/embedding.py` — Embedding 函数异步解析
- `engine/summarization.py` — SessionSummarizer 同步缓存读取
- `knowledge/extraction.py` — 知识提取 LLM 调用
- `knowledge/llm_extractors.py` — 实体/关系提取器 (含 DB kwargs 传递)
- `engine/bootstrap.py` — 启动时缓存预热

**前端 — Admin Models 管理页**
- `AdminNav` 导航栏新增 Models 入口
- `/admin/models` 页面：LLM / Embedding / Rerank 三栏分组展示
- 支持 CRUD + 设默认 + 启用/禁用开关
- 新增/编辑 Modal (LLM: temperature/thinking_mode/max_tokens; Embedding: dimensions/input_type)
- Next.js API 代理路由 (3 个 route 文件)

### .env → DB 过渡策略

| 场景 | 行为 |
|------|------|
| 全新部署 | 迁移 seed 默认行，与当前 .env 默认一致 |
| 管理员通过 UI 修改 | DB 行更新 → 缓存失效 → 新配置即时生效 |
| DB 不可达 | Resolver catch 异常 → 回退 .env → 系统继续运行 |

> `.env` 中的 `NE_LLM_*` 变量保持不动，作为永久兜底。

### 关键文件

| 类型 | 文件 |
|------|------|
| 新增 | `models/model_config.py`, `config/model_resolver.py`, `migrations/g1h2i3j4k5l6_*` |
| 新增 | `app/admin/models/page.tsx`, `app/api/auth/admin/models/*` |
| 修改 | `auth/api.py`, `agents/_model.py`, `embedding.py`, `summarization.py` |
| 修改 | `extraction.py`, `llm_extractors.py`, `bootstrap.py`, `AdminNav.tsx` |

## Test Plan

- [ ] `uv run alembic upgrade head` → 确认 `model_configs` 表和 seed 数据存在
- [ ] API 端点测试: CRUD + set-default (curl / httpie)
- [ ] 启动后确认日志中 "Model config cache warmed" 出现
- [ ] 发起 Chat → 确认使用 DB 配置的 LLM
- [ ] 执行 Knowledge ingest → 确认使用 DB 配置的 Embedding
- [ ] 清空 `model_configs` 表 → 重启 → 确认回退到 .env 配置
- [ ] 前端 `/admin/models` 页面功能验证

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)