### PR TITLE
fix(Alembic): 修复 model_type_enum 重复创建导致迁移失败的问题

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/g1h2i3j4k5l6_add_model_configs_table.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/g1h2i3j4k5l6_add_model_configs_table.py
@@ -24,15 +24,20 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     schema = negentropy.models.base.NEGENTROPY_SCHEMA
 
-    # 创建 model_type_enum 类型
-    model_type_enum = postgresql.ENUM("llm", "embedding", "rerank", name="model_type_enum", schema=schema)
-    model_type_enum.create(op.get_bind(), checkfirst=True)
+    # 创建 model_type_enum 类型（幂等）
+    op.execute(f"""
+        DO $$ BEGIN
+            CREATE TYPE {schema}.model_type_enum AS ENUM ('llm', 'embedding', 'rerank');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
 
     op.create_table(
         "model_configs",
         sa.Column(
             "model_type",
-            sa.Enum("llm", "embedding", "rerank", name="model_type_enum", schema=schema),
+            postgresql.ENUM("llm", "embedding", "rerank", name="model_type_enum", schema=schema, create_type=False),
             nullable=False,
         ),
         sa.Column("display_name", sa.String(length=255), nullable=False),
@@ -65,9 +70,10 @@ def upgrade() -> None:
     )
 
     # Seed 默认数据
+    model_type_col = postgresql.ENUM("llm", "embedding", "rerank", name="model_type_enum", schema=schema, create_type=False)
     model_configs = sa.table(
         "model_configs",
-        sa.column("model_type", sa.String),
+        sa.column("model_type", model_type_col),
         sa.column("display_name", sa.String),
         sa.column("vendor", sa.String),
         sa.column("model_name", sa.String),
@@ -108,5 +114,4 @@ def downgrade() -> None:
     op.drop_table("model_configs", schema=schema)
 
     # 删除 enum 类型
-    model_type_enum = postgresql.ENUM("llm", "embedding", "rerank", name="model_type_enum", schema=schema)
-    model_type_enum.drop(op.get_bind(), checkfirst=True)
+    op.execute(f"DROP TYPE IF EXISTS {schema}.model_type_enum")


### PR DESCRIPTION
## 概述

修复 Alembic 迁移 `g1h2i3j4k5l6` 在执行 `uv run alembic upgrade head` 时因 `model_type_enum` 重复创建而抛出 `DuplicateObjectError` 的问题。

## 根因分析

迁移文件存在**双重 ENUM 创建**缺陷：

1. `postgresql.ENUM(...).create(checkfirst=True)` 手动创建枚举类型
2. `op.create_table()` 中使用 `sa.Enum(...)` 定义列（默认 `create_type=True`），Alembic 的 `before_create` 事件以 `checkfirst=False` 再次尝试创建同名枚举 → 冲突

此外，Seed 数据插入时 `sa.column("model_type", sa.String)` 导致 asyncpg 以 `VARCHAR` 类型发送数据，与 `model_type_enum` 类型不匹配。

## 修改内容

| 修改点 | 修复前 | 修复后 |
|--------|--------|--------|
| ENUM 创建 | `postgresql.ENUM().create(checkfirst=True)` | SQL `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object` 幂等模式 |
| 列定义 | `sa.Enum(...)` (默认 `create_type=True`) | `postgresql.ENUM(..., create_type=False)` |
| Seed 数据列类型 | `sa.column("model_type", sa.String)` | `sa.column("model_type", model_type_col)` |
| Downgrade | `postgresql.ENUM().drop(checkfirst=True)` | `DROP TYPE IF EXISTS` |

修改方式与项目已有最佳实践（`d1e2f3a4b5c6_add_plugins_tables.py`）保持一致。

## 验证

- [x] `uv run alembic upgrade head` 成功执行
- [x] `downgrade → upgrade` 循环验证幂等性通过