### PR TITLE
fix(Admin-Model): 修正 API 路由中 _config 模块的相对路径导入层级错误

### DIFF
--- a/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
-import { getAuthBaseUrl } from "../../../../_config";
+import { getAuthBaseUrl } from "../../../_config";
 
 export async function PATCH(
   request: Request,

--- a/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/set-default/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/[modelId]/set-default/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
-import { getAuthBaseUrl } from "../../../../../_config";
+import { getAuthBaseUrl } from "../../../../_config";
 
 export async function POST(
   request: Request,

--- a/apps/negentropy-ui/app/api/auth/admin/models/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
-import { getAuthBaseUrl } from "../../../_config";
+import { getAuthBaseUrl } from "../../_config";
 
 export async function GET(request: Request) {
   const baseUrl = getAuthBaseUrl();


### PR DESCRIPTION
## 问题背景

执行 `pnpm build` 前端服务编译时，Next.js Turbopack 构建报出 3 个 `Module not found` 错误，均指向 `_config` 模块的相对路径导入无法解析，导致生产构建失败。

## 根因分析

PR #305 新增的三个 Admin Models API 路由文件中，`_config` 的相对路径导入均**多了一级 `..`**，导致模块解析目标从正确的 `app/api/auth/_config` 偏移到了不存在的 `app/api/_config`：

| 文件 | 错误路径 | 正确路径 |
|------|---------|---------|
| `admin/models/route.ts` | `../../../_config`（3级→`app/api/`） | `../../_config`（2级→`app/api/auth/`） |
| `admin/models/[modelId]/route.ts` | `../../../../_config`（4级→`app/api/`） | `../../../_config`（3级→`app/api/auth/`） |
| `admin/models/[modelId]/set-default/route.ts` | `../../../../../_config`（5级→`app/api/`） | `../../../../_config`（4级→`app/api/auth/`） |

## 修复内容

将三个文件的 `_config` 导入路径各减少一级 `..`，与项目中其他同层级路由文件（如 `admin/roles/route.ts`、`login/route.ts`）的引用模式保持一致。

## 验证

- `pnpm build` 编译成功，58 个页面全部正常生成
- 三个修复的 API 路由（`/api/auth/admin/models`、`/api/auth/admin/models/[modelId]`、`/api/auth/admin/models/[modelId]/set-default`）均正确注册

---

🤖 Generated with [Claude Code](https://github.com/claude)