### PR TITLE
feat(Admin-Model): 新增 Ping 连通性验证按钮与 API Credentials 配置入口

### DIFF
--- a/apps/negentropy-ui/app/admin/models/page.tsx
+++ b/apps/negentropy-ui/app/admin/models/page.tsx
@@ -75,6 +75,19 @@ export default function ModelsPage() {
   const [dimensions, setDimensions] = useState<string>("");
   const [inputType, setInputType] = useState("");
 
+  // API credentials (stored in config JSONB)
+  const [apiBase, setApiBase] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [apiKeyChanged, setApiKeyChanged] = useState(false);
+
+  // Ping state
+  const [pinging, setPinging] = useState(false);
+  const [pingResult, setPingResult] = useState<{
+    status: "ok" | "error";
+    message: string;
+    latency_ms?: number;
+  } | null>(null);
+
   const fetchModels = useCallback(async () => {
     try {
       setLoading(true);
@@ -104,6 +117,10 @@ export default function ModelsPage() {
     setMaxTokens("");
     setDimensions("");
     setInputType("");
+    setApiBase("");
+    setApiKey("");
+    setApiKeyChanged(false);
+    setPingResult(null);
   };
 
   const openCreateForm = (modelType: string) => {
@@ -130,6 +147,10 @@ export default function ModelsPage() {
     setMaxTokens(cfg.max_tokens != null ? String(cfg.max_tokens) : "");
     setDimensions(cfg.dimensions != null ? String(cfg.dimensions) : "");
     setInputType((cfg.input_type as string) ?? "");
+    setApiBase((cfg.api_base as string) ?? "");
+    setApiKey((cfg.api_key as string) ?? "");
+    setApiKeyChanged(false);
+    setPingResult(null);
     setShowForm(true);
   };
 
@@ -148,6 +169,9 @@ export default function ModelsPage() {
       if (dimensions && !isNaN(parsedDimensions)) cfg.dimensions = parsedDimensions;
       if (inputType) cfg.input_type = inputType;
     }
+    // API credentials (所有 model_type 共享)
+    if (apiBase.trim()) cfg.api_base = apiBase.trim();
+    if (apiKeyChanged && apiKey.trim()) cfg.api_key = apiKey.trim();
     return cfg;
   };
 
@@ -227,6 +251,45 @@ export default function ModelsPage() {
       setError(err instanceof Error ? err.message : "Toggle failed");
     } finally {
       setActionLoading(null);
+    }
+  };
+
+  const handlePing = async () => {
+    setPinging(true);
+    setPingResult(null);
+    try {
+      const currentConfig = buildConfig();
+      const payload = {
+        model_type: form.model_type,
+        vendor: form.vendor,
+        model_name: form.model_name,
+        config: currentConfig,
+        api_base: apiBase.trim() || null,
+        api_key: apiKeyChanged ? apiKey.trim() || null : null,
+        model_id: editingId || null,
+      };
+      const response = await fetch("/api/auth/admin/models/ping", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setPingResult({
+          status: "error",
+          message: data.error || `HTTP ${response.status}`,
+        });
+        return;
+      }
+      const data = await response.json();
+      setPingResult(data);
+    } catch (err) {
+      setPingResult({
+        status: "error",
+        message: err instanceof Error ? err.message : "网络错误",
+      });
+    } finally {
+      setPinging(false);
     }
   };
 
@@ -543,6 +606,74 @@ export default function ModelsPage() {
                       </div>
                     </div>
                   )}
+
+                  {/* API Credentials */}
+                  <div className="rounded-lg border border-zinc-100 p-3 dark:border-zinc-700 space-y-3">
+                    <div className="text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+                      API Credentials
+                    </div>
+                    <div>
+                      <label className="block text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                        API Base URL (optional)
+                      </label>
+                      <input
+                        type="text"
+                        value={apiBase}
+                        onChange={(e) => setApiBase(e.target.value)}
+                        placeholder="e.g. https://open.bigmodel.cn/api/paas/v4"
+                        className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-zinc-600 dark:text-zinc-400 mb-1">
+                        API Key (optional)
+                      </label>
+                      <input
+                        type="password"
+                        value={apiKey}
+                        onChange={(e) => {
+                          setApiKey(e.target.value);
+                          setApiKeyChanged(true);
+                        }}
+                        placeholder={editingId ? "留空则保持不变" : "sk-..."}
+                        className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm font-mono dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      />
+                      {editingId && !apiKeyChanged && apiKey && (
+                        <p className="mt-1 text-[10px] text-zinc-400">
+                          当前已配置 (已脱敏显示)
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Ping */}
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={handlePing}
+                      disabled={pinging || !form.vendor || !form.model_name}
+                      className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium border border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-400 dark:hover:bg-emerald-900/20 transition-colors disabled:opacity-50"
+                    >
+                      {pinging ? "Pinging..." : "Ping"}
+                    </button>
+                    {pingResult && (
+                      <div
+                        className={`flex-1 rounded-lg px-3 py-1.5 text-xs whitespace-pre-wrap ${
+                          pingResult.status === "ok"
+                            ? "bg-emerald-50 text-emerald-700 border border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-300 dark:border-emerald-800"
+                            : "bg-red-50 text-red-700 border border-red-200 dark:bg-red-900/20 dark:text-red-300 dark:border-red-800"
+                        }`}
+                      >
+                        {pingResult.message}
+                        {pingResult.latency_ms != null &&
+                          pingResult.latency_ms > 0 && (
+                            <span className="ml-1 opacity-60">
+                              ({pingResult.latency_ms}ms)
+                            </span>
+                          )}
+                      </div>
+                    )}
+                  </div>
 
                   {/* Enabled toggle */}
                   <div className="flex items-center gap-2">

--- a/apps/negentropy-ui/app/api/auth/admin/models/ping/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/models/ping/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAuthBaseUrl } from "../../../_config";
+
+export async function POST(request: Request) {
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const body = await request.text();
+  const upstreamUrl = new URL("/auth/admin/models/ping", baseUrl);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: {
+        ...Object.fromEntries(buildAuthHeaders(request).entries()),
+        "Content-Type": "application/json",
+      },
+      body,
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: text || "Upstream returned non-OK status" },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}

--- a/apps/negentropy/src/negentropy/auth/api.py
+++ b/apps/negentropy/src/negentropy/auth/api.py
@@ -258,7 +258,39 @@ class ModelConfigUpdate(BaseModel):
     config: Optional[Dict[str, Any]] = None
 
 
+class ModelPingRequest(BaseModel):
+    """Ping 请求 — 接收表单当前数据（未保存状态亦可测试）。"""
+
+    model_type: str = Field(..., description="llm, embedding, or rerank")
+    vendor: str
+    model_name: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+    api_base: Optional[str] = None
+    api_key: Optional[str] = None
+    model_id: Optional[UUID] = None
+
+
+def _mask_api_key(key: str | None) -> str | None:
+    """将 api_key 脱敏为 ****xxxx 格式，仅保留末 4 位。"""
+    if not key:
+        return None
+    if len(key) <= 4:
+        return "****"
+    return "****" + key[-4:]
+
+
+def _sanitize_error(msg: str, max_len: int = 300) -> str:
+    """从错误信息中移除可能的 API Key / Token，防止泄露。"""
+    import re
+
+    sanitized = re.sub(r"(sk-|key-|Bearer\s+)\S+", r"\1****", msg)
+    return sanitized[:max_len]
+
+
 def _model_config_to_dict(mc) -> dict[str, Any]:
+    cfg = dict(mc.config or {})
+    if "api_key" in cfg:
+        cfg["api_key"] = _mask_api_key(cfg["api_key"])
     return {
         "id": str(mc.id),
         "modelType": mc.model_type.value,
@@ -267,7 +299,7 @@ def _model_config_to_dict(mc) -> dict[str, Any]:
         "modelName": mc.model_name,
         "isDefault": mc.is_default,
         "enabled": mc.enabled,
-        "config": mc.config or {},
+        "config": cfg,
         "createdAt": mc.created_at.isoformat() if mc.created_at else None,
         "updatedAt": mc.updated_at.isoformat() if mc.updated_at else None,
     }
@@ -359,6 +391,202 @@ async def create_model_config(
     return {"model": _model_config_to_dict(mc)}
 
 
+# --- Ping endpoint (注册在 {model_id} 路由之前，避免 FastAPI 将 "ping" 匹配为路径参数) ---
+
+
+@router.post("/admin/models/ping")
+async def ping_model(
+    payload: ModelPingRequest,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """发送轻量级请求验证模型连通性。
+
+    根据 model_type 使用不同的验证策略:
+    - LLM: litellm.acompletion (发送 "Ping, give me a pong")
+    - Embedding: litellm.aembedding (嵌入测试文本，验证向量维度)
+    - Rerank: httpx POST (匹配 APIReranker 运行时路径)
+    """
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    import asyncio
+    import time
+
+    from negentropy.config.model_resolver import build_full_model_name
+
+    full_model_name = build_full_model_name(payload.vendor, payload.model_name)
+
+    # --- 解析 api_key 优先级链: 表单 > DB > 环境变量 (litellm 默认行为) ---
+    effective_api_key = payload.api_key
+    effective_api_base = payload.api_base or payload.config.get("api_base")
+
+    if effective_api_key is None and payload.model_id:
+        from negentropy.models.model_config import ModelConfig
+
+        try:
+            async with AsyncSessionLocal() as db:
+                result = await db.execute(select(ModelConfig).where(ModelConfig.id == payload.model_id))
+                stored = result.scalar_one_or_none()
+                if stored and stored.config:
+                    effective_api_key = stored.config.get("api_key")
+                    if not effective_api_base:
+                        effective_api_base = stored.config.get("api_base")
+        except Exception:
+            from negentropy.logging import get_logger
+
+            get_logger("negentropy.auth.api").warning(
+                "ping_db_lookup_failed", model_id=str(payload.model_id), exc_info=True,
+            )
+
+    start_time = time.monotonic()
+
+    try:
+        if payload.model_type == "llm":
+            result = await _ping_llm(full_model_name, effective_api_key, effective_api_base)
+        elif payload.model_type == "embedding":
+            result = await _ping_embedding(full_model_name, effective_api_key, effective_api_base)
+        elif payload.model_type == "rerank":
+            result = await _ping_rerank(
+                payload.model_name, effective_api_key, effective_api_base,
+            )
+        else:
+            return {"status": "error", "message": f"不支持的模型类型: {payload.model_type}"}
+
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+        result["latency_ms"] = latency_ms
+        return result
+
+    except Exception as exc:
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+        error_msg = _sanitize_error(str(exc))
+        if "AuthenticationError" in error_msg or "401" in error_msg:
+            message = f"认证失败：API Key 无效或已过期。\n{error_msg}"
+        elif "404" in error_msg or "NotFoundError" in error_msg:
+            message = f"模型未找到：请检查 vendor/model_name 是否正确。\n{error_msg}"
+        elif "timeout" in error_msg.lower() or isinstance(exc, asyncio.TimeoutError):
+            message = "连接超时 (30s)，请检查网络或 API Base URL 配置。"
+        else:
+            message = f"Ping 失败：{error_msg}"
+        return {"status": "error", "message": message, "latency_ms": latency_ms}
+
+
+async def _ping_llm(
+    model: str,
+    api_key: str | None,
+    api_base: str | None,
+) -> dict[str, Any]:
+    """LLM Ping: 发送 'Ping, give me a pong' 并验证响应。"""
+    import asyncio
+
+    import litellm
+
+    kwargs: Dict[str, Any] = {"max_tokens": 20}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if api_base:
+        kwargs["api_base"] = api_base
+
+    response = await asyncio.wait_for(
+        litellm.acompletion(
+            model=model,
+            messages=[{"role": "user", "content": "Ping, give me a pong"}],
+            **kwargs,
+        ),
+        timeout=30.0,
+    )
+    content = response.choices[0].message.content or ""
+    return {"status": "ok", "message": f"Pong! {content.strip()[:100]}"}
+
+
+async def _ping_embedding(
+    model: str,
+    api_key: str | None,
+    api_base: str | None,
+) -> dict[str, Any]:
+    """Embedding Ping: 嵌入测试文本并验证向量维度。"""
+    import asyncio
+
+    import litellm
+
+    kwargs: Dict[str, Any] = {}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if api_base:
+        kwargs["api_base"] = api_base
+
+    response = await asyncio.wait_for(
+        litellm.aembedding(
+            model=model,
+            input=["Hello, world!"],
+            **kwargs,
+        ),
+        timeout=30.0,
+    )
+
+    # 兼容 dict 和对象属性两种返回格式
+    data = getattr(response, "data", None) or response.get("data", [])
+    if not data:
+        return {"status": "error", "message": "Embedding 响应为空，未返回向量数据。"}
+
+    item = data[0]
+    embedding = getattr(item, "embedding", None)
+    if embedding is None and isinstance(item, dict):
+        embedding = item.get("embedding")
+    if not embedding:
+        return {"status": "error", "message": "Embedding 响应格式异常，未找到向量数据。"}
+
+    dims = len(embedding)
+    return {"status": "ok", "message": f"Pong! Embedding 连通正常，维度: {dims}"}
+
+
+async def _ping_rerank(
+    model_name: str,
+    api_key: str | None,
+    api_base: str | None,
+) -> dict[str, Any]:
+    """Rerank Ping: 匹配 APIReranker 运行时路径 (httpx POST)。"""
+    import httpx
+
+    base_url = api_base or "https://api.cohere.ai/v1/rerank"
+
+    if not api_key:
+        import os
+
+        api_key = os.getenv("COHERE_API_KEY")
+    if not api_key:
+        return {"status": "error", "message": "缺少 API Key：请配置 Rerank 模型的 API Key。"}
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "X-Client-Name": "negentropy-ping",
+    }
+    payload = {
+        "query": "What is artificial intelligence?",
+        "documents": [
+            "AI is a branch of computer science.",
+            "The weather is sunny today.",
+        ],
+        "top_n": 2,
+        "model": model_name,
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(base_url, headers=headers, json=payload)
+        resp.raise_for_status()
+        result = resp.json()
+
+    results = result.get("results", [])
+    if not results:
+        return {"status": "error", "message": "Rerank 响应为空，未返回排序结果。"}
+
+    top_score = results[0].get("relevance_score", 0)
+    return {
+        "status": "ok",
+        "message": f"Pong! Rerank 连通正常，Top 相关性分数: {top_score:.4f}",
+    }
+
+
 @router.patch("/admin/models/{model_id}")
 async def update_model_config(
     model_id: UUID,
@@ -388,6 +616,15 @@ async def update_model_config(
                 )
 
             update_data = payload.model_dump(exclude_none=True)
+            # 服务端防御: 保护 DB 中的 api_key 不被脱敏值覆盖
+            if "config" in update_data and mc.config:
+                new_config = update_data["config"]
+                incoming_key = new_config.get("api_key")
+                if incoming_key is not None and incoming_key.startswith("****"):
+                    # 客户端回传了脱敏值，保留 DB 中的原始值
+                    new_config["api_key"] = mc.config.get("api_key")
+                elif "api_key" not in new_config and "api_key" in (mc.config or {}):
+                    new_config["api_key"] = mc.config["api_key"]
             for key, value in update_data.items():
                 setattr(mc, key, value)
 

--- a/apps/negentropy/src/negentropy/config/model_resolver.py
+++ b/apps/negentropy/src/negentropy/config/model_resolver.py
@@ -155,7 +155,7 @@ async def _resolve_from_db(model_type: str) -> Optional[Tuple[str, Dict[str, Any
     if config is None:
         return None
 
-    full_name = _build_full_model_name(config.vendor, config.model_name)
+    full_name = build_full_model_name(config.vendor, config.model_name)
     cfg = config.config or {}
 
     if model_type == "embedding":
@@ -173,7 +173,7 @@ def _resolve_defaults(model_type: str) -> Tuple[str, Dict[str, Any]]:
     return get_fallback_llm_config()
 
 
-def _build_full_model_name(vendor: str, model_name: str) -> str:
+def build_full_model_name(vendor: str, model_name: str) -> str:
     """构建 LiteLLM 兼容的 vendor/model_name 字符串。"""
     from negentropy.model_names import canonicalize_model_name
 
@@ -230,6 +230,12 @@ def _build_llm_kwargs(vendor: str, model_name: str, config: Dict[str, Any]) -> D
     if "drop_params" in config and "drop_params" not in kwargs:
         kwargs["drop_params"] = config["drop_params"]
 
+    # 透传 API 凭证 (DB 单一事实源; 未配置时 litellm 自动回退到环境变量)
+    if "api_key" in config and config["api_key"]:
+        kwargs["api_key"] = config["api_key"]
+    if "api_base" in config and config["api_base"]:
+        kwargs["api_base"] = config["api_base"]
+
     return kwargs
 
 
@@ -240,4 +246,11 @@ def _build_embedding_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
         kwargs["dimensions"] = config["dimensions"]
     if "input_type" in config and config["input_type"]:
         kwargs["input_type"] = config["input_type"]
+
+    # 透传 API 凭证 (DB 单一事实源; 未配置时 litellm 自动回退到环境变量)
+    if "api_key" in config and config["api_key"]:
+        kwargs["api_key"] = config["api_key"]
+    if "api_base" in config and config["api_base"]:
+        kwargs["api_base"] = config["api_base"]
+
     return kwargs


### PR DESCRIPTION
## 概述

在 Edit Model 模态框中新增 **Ping 按钮**和 **API Credentials 配置入口**，实现模型连通性即时验证与 API 凭证的 DB 单一事实源管理。

## 变更内容

### Ping 连通性验证
- 新增 `POST /auth/admin/models/ping` 端点，支持三种模型类型各自的验证策略：
  - **LLM**: `litellm.acompletion` 发送 "Ping, give me a pong"，验证文本生成能力
  - **Embedding**: `litellm.aembedding` 嵌入测试文本，验证向量输出并报告维度数
  - **Rerank**: `httpx.post` 匹配 `APIReranker` 运行时路径，验证相关性排序结果
- Ping 接收表单当前快照（非 DB 存储值），支持**保存前测试**修改后的配置
- 30 秒超时保护，区分认证失败 / 模型未找到 / 网络超时等错误类型

### API Credentials 配置入口
- 模型配置表单新增 **API Base URL** (文本) 和 **API Key** (密码) 字段
- 凭证存储于现有 `config` JSONB 列，**无需数据库迁移**
- `model_resolver` 透传 `api_key`/`api_base` 至 litellm kwargs，运行时自动生效
- 未配置时自动回退到环境变量，保持向后兼容

### 安全防护
- API 响应自动脱敏 `api_key`（`****xxxx` 格式，仅保留末 4 位）
- 服务端防御：拒绝 `****` 开头的脱敏值回写覆盖真实 Key
- 错误信息 sanitize，防止 API Key 通过异常消息泄露
- 前端 `apiKeyChanged` 状态追踪，仅在用户主动修改时才发送新值

## 改动文件

| 文件 | 说明 |
|------|------|
| `auth/api.py` | 新增 Ping endpoint、api_key 脱敏、config merge 防护 (+239 行) |
| `model_resolver.py` | `_build_llm_kwargs` / `_build_embedding_kwargs` 透传 api_key/api_base |
| `ping/route.ts` | 新建 Next.js Ping 代理路由 |
| `page.tsx` | 表单新增 API Credentials 区块 + Ping 按钮 + 结果展示 (+131 行) |

## 测试计划

- [ ] LLM 模型编辑 → 点击 Ping → 验证返回 Pong 文本 + 延迟
- [ ] Embedding 模型编辑 → 点击 Ping → 验证返回维度数 + 延迟
- [ ] Rerank 模型配置 → 填入 api_key → Ping → 验证返回相关性分数
- [ ] 错误场景：无效 api_key → Ping → 验证返回认证失败提示
- [ ] 凭证保存后重新打开，验证 api_base 正确显示、api_key 显示脱敏值
- [ ] GET /api/auth/admin/models 响应中 api_key 为 `****xxxx` 格式
- [ ] 未配置凭证的模型仍正常回退到环境变量

🤖 Generated with [Claude Code](https://claude.com/claude-code)