### PR TITLE
fix(Knowledge-Document): 修复 PDF 查看器中宽表格内容溢出被裁剪的问题

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -137,6 +137,13 @@ export function DocumentMarkdownRenderer({
           pre({ children }) {
             return <pre className="relative">{children}</pre>;
           },
+          table({ children }) {
+            return (
+              <div className="overflow-x-auto">
+                <table>{children}</table>
+              </div>
+            );
+          },
         }}
       >
         {content}


### PR DESCRIPTION
## 概要

- 修复 Knowledge / Documents 页面查看 PDF Markdown 时，宽表格内容被模态框左边框裁剪的问题
- 为 `DocumentMarkdownRenderer` 的 ReactMarkdown 新增 `table` 自定义组件，包裹 `overflow-x-auto` 滚动容器
- 宽表格现在支持水平滚动，窄表格无额外滚动条

## 测试计划

- [ ] 打开包含宽表格的 PDF 文档，确认表格内容完整可见且支持水平滚动
- [ ] 确认窄表格无多余滚动条
- [ ] 确认深色模式显示正常
- [ ] 确认其他 Markdown 元素（文本、图片、代码块）渲染不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)