### PR TITLE
fix(Knowledge-Document): 修复 PDF 查看器中 Markdown 内容左侧文字溢出被裁剪的问题

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -52,7 +52,7 @@ export function DocumentMarkdownRenderer({
   return (
     <div
       className={cn(
-        "overflow-hidden break-words whitespace-normal text-sm",
+        "min-w-0 overflow-x-auto break-words whitespace-normal text-sm",
         // 段落
         "[&_p]:leading-7 [&_p]:my-1",
         "[&_p+*]:mt-3",
@@ -71,7 +71,7 @@ export function DocumentMarkdownRenderer({
         "[&_pre]:bg-zinc-100 [&_pre]:dark:bg-zinc-800 [&_pre]:p-3 [&_pre]:rounded-lg [&_pre]:overflow-x-auto [&_pre]:my-3",
         "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
         // 链接
-        "[&_a]:underline [&_a]:underline-offset-2 [&_a]:text-blue-600 [&_a]:dark:text-blue-400",
+        "[&_a]:underline [&_a]:underline-offset-2 [&_a]:text-blue-600 [&_a]:dark:text-blue-400 [&_a]:break-all",
         // 表格
         "[&_table]:w-full [&_table]:border-collapse [&_table]:my-4 [&_table]:text-sm",
         "[&_thead]:bg-zinc-100 [&_thead]:dark:bg-zinc-800/60",

--- a/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentViewDialog.tsx
@@ -279,7 +279,7 @@ export function DocumentViewDialog({
         </div>
 
         {/* Markdown Content - full width */}
-        <div className="flex min-h-0 flex-1 flex-col rounded-xl border border-zinc-200 p-4 dark:border-zinc-800">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col rounded-xl border border-zinc-200 p-4 dark:border-zinc-800">
           <div className="mb-3 flex items-center justify-between">
             <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Markdown Content</h3>
             <span className="text-xs text-zinc-500 dark:text-zinc-400">
@@ -287,7 +287,7 @@ export function DocumentViewDialog({
             </span>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto rounded-lg bg-zinc-50 p-4 dark:bg-zinc-950">
+          <div className="min-h-0 min-w-0 flex-1 overflow-auto rounded-lg bg-zinc-50 p-4 dark:bg-zinc-950">
             {loadingDetail ? (
               <p className="text-sm text-zinc-500 dark:text-zinc-400">Loading markdown content...</p>
             ) : detailError ? (


### PR DESCRIPTION
## 问题背景

Knowledge / Documents 页面在查看 PDF 文档的 Markdown 格式时，模态框内的 Markdown 内容左侧文字超出可见范围，导致用户无法看到完整内容。问题在含有长 URL 的参考文献/书目内容中尤为明显。

**根因**：`DocumentMarkdownRenderer` 外层容器使用 `overflow-hidden` 会静默裁剪超出边界的内容；同时 Flex 布局链中缺少 `min-w-0`，导致子项无法正常收缩。

## 修复方案

### `DocumentMarkdownRenderer.tsx`（主要修复）
- `overflow-hidden` → `overflow-x-auto`：将内容裁剪改为水平滚动，与已有的 `<table>` 和 `<pre>` 处理方式保持一致
- 新增 `min-w-0`：标准 Flex 缩放修复，确保容器可正常收缩
- 链接元素新增 `[&_a]:break-all`：允许超长 DOI/URL 在任意字符处断行

### `DocumentViewDialog.tsx`（防御性修复）
- Markdown 内容外层 Flex 容器新增 `min-w-0`
- 可滚动内容容器新增 `min-w-0`

## 验证清单

- [ ] 打开含长 URL 参考文献的 PDF 文档，确认左侧文字完整可见
- [ ] 确认宽表格仍支持水平滚动（不影响 #310 修复）
- [ ] 确认长代码块仍支持水平滚动
- [ ] 深色模式下渲染一致
- [ ] 长文档仍可垂直滚动
- [ ] 普通短文本段落不出现多余水平滚动条