### PR TITLE
fix(Knowledge-Document): 修复 PDF 文档图片资产未上传 GCS 导致 Markdown 渲染 404 的问题

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -283,6 +283,124 @@ def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
     return assets
 
 
+# ---------------------------------------------------------------------------
+# ImageContent 提取与 Markdown 图片引用匹配
+# ---------------------------------------------------------------------------
+
+_MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)]+)\)")
+
+
+def _extract_markdown_image_refs(markdown_content: str) -> list[str]:
+    """按顺序提取 Markdown 中本地图片引用的文件名。
+
+    排除绝对 URL (http/https/data/blob)，从路径中取最后一段。
+    """
+    refs: list[str] = []
+    for match in _MARKDOWN_IMAGE_RE.finditer(markdown_content):
+        src = match.group(1).strip()
+        if src.startswith(("http://", "https://", "data:", "blob:")):
+            continue
+        filename = src.split("/")[-1].split("\\")[-1]
+        if filename:
+            refs.append(filename)
+    return refs
+
+
+def _mime_to_extension(mime_type: str) -> str:
+    """将 MIME 类型映射为文件扩展名。"""
+    mapping = {
+        "image/png": ".png",
+        "image/jpeg": ".jpg",
+        "image/gif": ".gif",
+        "image/webp": ".webp",
+        "image/svg+xml": ".svg",
+        "image/bmp": ".bmp",
+        "image/tiff": ".tiff",
+    }
+    return mapping.get(mime_type.lower(), ".png")
+
+
+def _extract_image_assets_from_content_items(
+    content_items: list[Any],
+    markdown_content: str,
+) -> list[ExtractionAsset]:
+    """从 MCP content_items 中提取 ImageContent 并转换为 ExtractionAsset。
+
+    ImageContent 无文件名字段，通过与 Markdown 中图片引用的顺序一一对应来命名。
+    """
+    image_items: list[Any] = []
+    for item in content_items:
+        if getattr(item, "type", None) == "image":
+            data = getattr(item, "data", None)
+            mime_type = getattr(item, "mimeType", None)
+            if data and mime_type:
+                image_items.append(item)
+
+    if not image_items:
+        return []
+
+    image_refs = _extract_markdown_image_refs(markdown_content)
+
+    assets: list[ExtractionAsset] = []
+    for index, img_item in enumerate(image_items):
+        data = getattr(img_item, "data", "")
+        mime_type = getattr(img_item, "mimeType", "image/png")
+
+        if index < len(image_refs):
+            name = image_refs[index]
+        else:
+            ext = _mime_to_extension(mime_type)
+            name = f"image-content-{index + 1}{ext}"
+
+        assets.append(
+            ExtractionAsset(
+                name=name,
+                content_type=mime_type,
+                data_base64=data,
+            )
+        )
+
+    return assets
+
+
+def _merge_extraction_assets(
+    structured_assets: list[ExtractionAsset],
+    content_image_assets: list[ExtractionAsset],
+) -> list[ExtractionAsset]:
+    """合并 structured_content 和 content_items 两个来源的资产。
+
+    structured_assets 优先：同名且已含数据的项不被覆盖，缺数据的项被补充。
+    """
+    if not content_image_assets:
+        return structured_assets
+    if not structured_assets:
+        return content_image_assets
+
+    existing_names: dict[str, int] = {}
+    for idx, asset in enumerate(structured_assets):
+        existing_names[asset.name] = idx
+
+    merged = list(structured_assets)
+    for img_asset in content_image_assets:
+        if img_asset.name in existing_names:
+            existing_idx = existing_names[img_asset.name]
+            existing = merged[existing_idx]
+            if not existing.data_base64 and not existing.uri and not existing.text:
+                merged[existing_idx] = ExtractionAsset(
+                    name=existing.name,
+                    content_type=img_asset.content_type or existing.content_type,
+                    uri=existing.uri,
+                    data_base64=img_asset.data_base64,
+                    text=existing.text,
+                    metadata={**existing.metadata, "source": "content_items_backfill"},
+                )
+        else:
+            merged.append(img_asset)
+            existing_names[img_asset.name] = len(merged) - 1
+
+    return merged
+
+
 def _schema_properties(schema: Any) -> dict[str, Any]:
     if not isinstance(schema, dict):
         return {}
@@ -1905,7 +2023,10 @@ class DataExtractorProvider:
                     **(payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}),
                     "adapter_name": plan.adapter_name,
                 },
-                assets=_normalize_assets(payload.get("assets")),
+                assets=_merge_extraction_assets(
+                    _normalize_assets(payload.get("assets")),
+                    _extract_image_assets_from_content_items(result.content, markdown),
+                ),
                 trace={
                     "adapter_name": plan.adapter_name,
                     "adapter_schema_summary": plan.diagnostics,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py
@@ -1,0 +1,253 @@
+"""ImageContent 提取与 assets 合并逻辑单元测试。
+
+验证 MCP 返回的 ImageContent 能正确转换为 ExtractionAsset，
+并与 Markdown 中的图片引用正确匹配。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from negentropy.knowledge.extraction import (
+    ExtractionAsset,
+    _extract_image_assets_from_content_items,
+    _extract_markdown_image_refs,
+    _merge_extraction_assets,
+    _mime_to_extension,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_markdown_image_refs
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMarkdownImageRefs:
+
+    def test_extracts_simple_refs(self):
+        md = "# Title\n![fig1](img_1.png)\ntext\n![fig2](img_2.jpg)"
+        assert _extract_markdown_image_refs(md) == ["img_1.png", "img_2.jpg"]
+
+    def test_extracts_refs_with_relative_path(self):
+        md = "![](./images/photo.png)\n![](../assets/chart.svg)"
+        assert _extract_markdown_image_refs(md) == ["photo.png", "chart.svg"]
+
+    def test_skips_absolute_urls(self):
+        md = (
+            "![](https://example.com/img.png)\n"
+            "![](data:image/png;base64,abc)\n"
+            "![](http://cdn.example.com/pic.jpg)\n"
+            "![](blob:https://localhost/uuid)\n"
+            "![](local.png)"
+        )
+        assert _extract_markdown_image_refs(md) == ["local.png"]
+
+    def test_empty_markdown(self):
+        assert _extract_markdown_image_refs("") == []
+        assert _extract_markdown_image_refs("# No images here\nJust text.") == []
+
+    def test_complex_filenames(self):
+        md = "![](img_1_36_20260324_135001.png)\n![alt text](chart-v2_final.webp)"
+        assert _extract_markdown_image_refs(md) == [
+            "img_1_36_20260324_135001.png",
+            "chart-v2_final.webp",
+        ]
+
+    def test_preserves_order(self):
+        md = "![](c.png)\n![](a.png)\n![](b.png)"
+        assert _extract_markdown_image_refs(md) == ["c.png", "a.png", "b.png"]
+
+    def test_alt_text_with_brackets(self):
+        md = "![caption [1]](figure.png)"
+        # 不匹配 —— 正则只匹配不含 ] 的 alt text
+        # 这是有意的简化，不影响实际提取工具生成的 Markdown
+        assert _extract_markdown_image_refs(md) == []
+
+
+# ---------------------------------------------------------------------------
+# _mime_to_extension
+# ---------------------------------------------------------------------------
+
+
+class TestMimeToExtension:
+
+    def test_known_types(self):
+        assert _mime_to_extension("image/png") == ".png"
+        assert _mime_to_extension("image/jpeg") == ".jpg"
+        assert _mime_to_extension("image/gif") == ".gif"
+        assert _mime_to_extension("image/webp") == ".webp"
+        assert _mime_to_extension("image/svg+xml") == ".svg"
+
+    def test_unknown_defaults_to_png(self):
+        assert _mime_to_extension("image/unknown") == ".png"
+        assert _mime_to_extension("application/octet-stream") == ".png"
+
+    def test_case_insensitive(self):
+        assert _mime_to_extension("Image/PNG") == ".png"
+        assert _mime_to_extension("IMAGE/JPEG") == ".jpg"
+
+
+# ---------------------------------------------------------------------------
+# _extract_image_assets_from_content_items
+# ---------------------------------------------------------------------------
+
+
+class TestExtractImageAssetsFromContentItems:
+
+    def test_extracts_and_matches_by_order(self):
+        content_items = [
+            SimpleNamespace(type="text", text="# Hello"),
+            SimpleNamespace(type="image", data="aGVsbG8=", mimeType="image/png"),
+            SimpleNamespace(type="text", text="world"),
+            SimpleNamespace(type="image", data="d29ybGQ=", mimeType="image/jpeg"),
+        ]
+        md = "# Hello\n![](fig1.png)\nworld\n![](fig2.jpg)"
+
+        assets = _extract_image_assets_from_content_items(content_items, md)
+
+        assert len(assets) == 2
+        assert assets[0].name == "fig1.png"
+        assert assets[0].content_type == "image/png"
+        assert assets[0].data_base64 == "aGVsbG8="
+        assert assets[1].name == "fig2.jpg"
+        assert assets[1].content_type == "image/jpeg"
+        assert assets[1].data_base64 == "d29ybGQ="
+
+    def test_fallback_naming_when_more_images_than_refs(self):
+        content_items = [
+            SimpleNamespace(type="image", data="abc", mimeType="image/png"),
+            SimpleNamespace(type="image", data="def", mimeType="image/jpeg"),
+        ]
+        md = "![](only_one.png)"
+
+        assets = _extract_image_assets_from_content_items(content_items, md)
+
+        assert len(assets) == 2
+        assert assets[0].name == "only_one.png"
+        assert assets[1].name == "image-content-2.jpg"
+
+    def test_returns_empty_when_no_images(self):
+        content_items = [SimpleNamespace(type="text", text="just text")]
+        assert _extract_image_assets_from_content_items(content_items, "text") == []
+
+    def test_returns_empty_for_empty_content_items(self):
+        assert _extract_image_assets_from_content_items([], "![](img.png)") == []
+
+    def test_skips_image_without_data(self):
+        content_items = [
+            SimpleNamespace(type="image", data=None, mimeType="image/png"),
+            SimpleNamespace(type="image", data="valid", mimeType="image/png"),
+        ]
+        md = "![](img.png)"
+        assets = _extract_image_assets_from_content_items(content_items, md)
+        assert len(assets) == 1
+        assert assets[0].data_base64 == "valid"
+        assert assets[0].name == "img.png"
+
+    def test_skips_image_without_mime_type(self):
+        content_items = [
+            SimpleNamespace(type="image", data="data123", mimeType=None),
+        ]
+        assert _extract_image_assets_from_content_items(content_items, "![](x.png)") == []
+
+    def test_fewer_images_than_refs(self):
+        content_items = [
+            SimpleNamespace(type="image", data="abc", mimeType="image/png"),
+        ]
+        md = "![](first.png)\n![](second.png)\n![](third.png)"
+
+        assets = _extract_image_assets_from_content_items(content_items, md)
+        assert len(assets) == 1
+        assert assets[0].name == "first.png"
+
+    def test_real_world_pdf_image_names(self):
+        content_items = [
+            SimpleNamespace(type="image", data="img1data", mimeType="image/png"),
+            SimpleNamespace(type="image", data="img2data", mimeType="image/png"),
+        ]
+        md = (
+            "# PDF Document\n"
+            "![](img_1_36_20260324_135001.png)\n"
+            "Some text\n"
+            "![](img_1_37_20260324_135001.png)"
+        )
+
+        assets = _extract_image_assets_from_content_items(content_items, md)
+        assert len(assets) == 2
+        assert assets[0].name == "img_1_36_20260324_135001.png"
+        assert assets[1].name == "img_1_37_20260324_135001.png"
+
+
+# ---------------------------------------------------------------------------
+# _merge_extraction_assets
+# ---------------------------------------------------------------------------
+
+
+class TestMergeExtractionAssets:
+
+    def test_content_images_only(self):
+        merged = _merge_extraction_assets(
+            [],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="abc")],
+        )
+        assert len(merged) == 1
+        assert merged[0].name == "img.png"
+        assert merged[0].data_base64 == "abc"
+
+    def test_structured_assets_only(self):
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="abc")],
+            [],
+        )
+        assert len(merged) == 1
+        assert merged[0].data_base64 == "abc"
+
+    def test_structured_wins_when_both_have_data(self):
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="structured")],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="content")],
+        )
+        assert len(merged) == 1
+        assert merged[0].data_base64 == "structured"
+
+    def test_backfill_missing_data(self):
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png")],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="backfill")],
+        )
+        assert len(merged) == 1
+        assert merged[0].data_base64 == "backfill"
+        assert merged[0].metadata.get("source") == "content_items_backfill"
+
+    def test_different_names_both_kept(self):
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="a.png", content_type="image/png", data_base64="a")],
+            [ExtractionAsset(name="b.png", content_type="image/png", data_base64="b")],
+        )
+        assert len(merged) == 2
+        names = {a.name for a in merged}
+        assert names == {"a.png", "b.png"}
+
+    def test_structured_with_uri_not_overwritten(self):
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png", uri="gs://bucket/img.png")],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="content")],
+        )
+        assert len(merged) == 1
+        assert merged[0].uri == "gs://bucket/img.png"
+        assert merged[0].data_base64 is None
+
+    def test_both_empty(self):
+        assert _merge_extraction_assets([], []) == []
+
+    def test_multiple_content_images_appended(self):
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="existing.png", content_type="image/png", data_base64="e")],
+            [
+                ExtractionAsset(name="new1.png", content_type="image/png", data_base64="n1"),
+                ExtractionAsset(name="new2.png", content_type="image/png", data_base64="n2"),
+            ],
+        )
+        assert len(merged) == 3
+        names = [a.name for a in merged]
+        assert names == ["existing.png", "new1.png", "new2.png"]

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
@@ -1137,3 +1137,192 @@ async def test_data_extractor_provider_retries_with_string_batch_contract_after_
     assert call_arguments[1] == {"pdf_sources": ["/tmp/retry.pdf"]}
     assert len(llm_calls) == 2
     assert llm_calls[1]["validation_error"].string_item_fields == ["pdf_sources.0"]
+
+
+# ---------------------------------------------------------------------------
+# _invoke_target: ImageContent in content_items merged into assets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_data_extractor_provider_merges_image_content_items_into_assets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """当 structured_content 不含 assets，但 content_items 有 ImageContent 时，
+    图片应被提取并与 Markdown 引用匹配，生成正确的 ExtractionAsset 列表。
+    """
+    server_id = uuid4()
+
+    class FakeImageContent:
+        def __init__(self, data: str, mime: str) -> None:
+            self.type = "image"
+            self.data = data
+            self.mimeType = mime
+
+    class FakeTextContent:
+        type = "text"
+        text = ""
+
+    class FakeClient:
+        async def call_tool(self, **kwargs):  # type: ignore[no-untyped-def]
+            _ = kwargs
+            return SimpleNamespace(
+                success=True,
+                structured_content={
+                    "markdown_content": (
+                        "# PDF Report\n"
+                        "![](img_1_36_20260324_135001.png)\n"
+                        "Some analysis text.\n"
+                        "![](img_1_37_20260324_135001.png)"
+                    ),
+                    "plain_text": "PDF Report\nSome analysis text.",
+                    "metadata": {"pages": 5},
+                    # NOTE: structured_content 中没有 "assets" 字段
+                },
+                content=[
+                    FakeTextContent(),
+                    FakeImageContent(data="cG5nX2RhdGFfMQ==", mime="image/png"),
+                    FakeImageContent(data="cG5nX2RhdGFfMg==", mime="image/png"),
+                ],
+                error=None,
+                duration_ms=42,
+            )
+
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction.AsyncSessionLocal",
+        lambda: FakeMcpSession(
+            server_id=server_id,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "content_base64": {"type": "string"},
+                    "filename": {"type": "string"},
+                },
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._increment_tool_call_count",
+        noop_increment_tool_call_count,
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._build_llm_invocation_plan",
+        noop_llm_plan,
+    )
+
+    provider = DataExtractorProvider()
+    provider._client = FakeClient()
+
+    result = await provider._invoke_target(
+        app_name="negentropy",
+        corpus_id=uuid4(),
+        target=SimpleNamespace(
+            server_id=server_id,
+            tool_name="convert_pdf_to_markdown",
+            timeout_ms=None,
+            tool_options={},
+        ),
+        source_kind=ROUTE_FILE_PDF,
+        url=None,
+        content=b"%PDF-1.5",
+        filename="report.pdf",
+        content_type="application/pdf",
+    )
+
+    assert result["success"] is True
+    extracted = result["result"]
+
+    # Markdown 正确提取
+    assert "# PDF Report" in extracted.markdown_content
+
+    # assets 应包含从 content_items 提取的两张图片
+    assert len(extracted.assets) == 2
+    assert extracted.assets[0].name == "img_1_36_20260324_135001.png"
+    assert extracted.assets[0].content_type == "image/png"
+    assert extracted.assets[0].data_base64 == "cG5nX2RhdGFfMQ=="
+    assert extracted.assets[1].name == "img_1_37_20260324_135001.png"
+    assert extracted.assets[1].data_base64 == "cG5nX2RhdGFfMg=="
+
+
+@pytest.mark.asyncio
+async def test_data_extractor_provider_structured_assets_take_precedence_over_content_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """当 structured_content 中已包含带 data_base64 的 assets，
+    content_items 中的同名 ImageContent 不应覆盖。
+    """
+    server_id = uuid4()
+
+    class FakeImageContent:
+        def __init__(self, data: str, mime: str) -> None:
+            self.type = "image"
+            self.data = data
+            self.mimeType = mime
+
+    class FakeClient:
+        async def call_tool(self, **kwargs):  # type: ignore[no-untyped-def]
+            _ = kwargs
+            return SimpleNamespace(
+                success=True,
+                structured_content={
+                    "markdown_content": "# Report\n![](chart.png)",
+                    "plain_text": "Report",
+                    "assets": [
+                        {
+                            "name": "chart.png",
+                            "content_type": "image/png",
+                            "data_base64": "c3RydWN0dXJlZF9kYXRh",
+                        }
+                    ],
+                },
+                content=[
+                    FakeImageContent(data="Y29udGVudF9kYXRh", mime="image/png"),
+                ],
+                error=None,
+                duration_ms=20,
+            )
+
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction.AsyncSessionLocal",
+        lambda: FakeMcpSession(
+            server_id=server_id,
+            input_schema={
+                "type": "object",
+                "properties": {"content_base64": {"type": "string"}},
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._increment_tool_call_count",
+        noop_increment_tool_call_count,
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._build_llm_invocation_plan",
+        noop_llm_plan,
+    )
+
+    provider = DataExtractorProvider()
+    provider._client = FakeClient()
+
+    result = await provider._invoke_target(
+        app_name="negentropy",
+        corpus_id=uuid4(),
+        target=SimpleNamespace(
+            server_id=server_id,
+            tool_name="convert_pdf_to_markdown",
+            timeout_ms=None,
+            tool_options={},
+        ),
+        source_kind=ROUTE_FILE_PDF,
+        url=None,
+        content=b"%PDF-1.5",
+        filename="report.pdf",
+        content_type="application/pdf",
+    )
+
+    assert result["success"] is True
+    extracted = result["result"]
+    assert len(extracted.assets) == 1
+    assert extracted.assets[0].name == "chart.png"
+    # structured_content 中的数据应优先
+    assert extracted.assets[0].data_base64 == "c3RydWN0dXJlZF9kYXRh"


### PR DESCRIPTION
## Summary

- **根因**：MCP 提取工具返回的图片数据位于 `content_items`（`ImageContent` 类型）中，但 `_build_success_result()` 仅从 `structured_content.assets` 字段提取图片资产，`_result_text_from_content_items()` 只处理 `type=="text"` 内容，完全跳过 `ImageContent`。导致 Markdown 中 `![](img_xxx.png)` 引用的图片从未上传到 GCS，前端请求返回 404。
- **修复方案**：新增 3 个纯函数从 `content_items` 中提取 `ImageContent` 图片数据，按顺序与 Markdown 中的图片引用匹配命名，并与 `structured_content.assets` 合并（structured 优先）。修改 `_build_success_result()` 一处调用点。
- **爆炸半径极小**：若 `content_items` 无 `ImageContent`，行为与修改前完全一致。

## 变更文件

| 文件 | 变更类型 | 说明 |
|------|---------|------|
| `extraction.py` | 修改 | 新增 `_extract_markdown_image_refs` / `_extract_image_assets_from_content_items` / `_merge_extraction_assets` + `_mime_to_extension` 4 个函数，修改 `_build_success_result` 1 处 |
| `test_extraction_image_assets.py` | 新建 | 26 个单元测试覆盖所有新增纯函数 |
| `test_extraction_provider.py` | 修改 | 2 个集成测试验证端到端图片资产合并逻辑 |

## Test plan

- [x] `test_extraction_image_assets.py`: 26/26 通过
- [x] `test_extraction_provider.py`: 17/17 通过（含 2 个新增）
- [x] 全量 `tests/unit_tests/knowledge/`: 257 通过，1 失败（预存在的无关用例）
- [ ] 端到端验证：上传 PDF → 查看 Document Markdown → 确认图片正常渲染

🤖 Generated with [Claude Code](https://github.com/claude)