### PR TITLE
fix(Knowledge-Document): 修复 PDF 文档图片资产因 base64 字段名不匹配和非 GCS URI 导致未上传 GCS 的问题

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -256,6 +256,24 @@ def _json_candidate_from_text(text: str) -> Any:
         return None
 
 
+# base64 数据字段名优先级序列（覆盖不同 MCP 工具实现的命名习惯）
+_BASE64_FIELD_NAMES = ("data_base64", "content_base64", "data", "base64", "image_data")
+
+
+def _extract_base64_from_asset(item: dict[str, Any]) -> str | None:
+    """从 asset dict 中按优先级提取 base64 编码数据。"""
+    for field_name in _BASE64_FIELD_NAMES:
+        value = item.get(field_name)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _is_gcs_uri(uri: str | None) -> bool:
+    """判断 URI 是否为 GCS 路径。"""
+    return bool(uri and uri.startswith("gs://"))
+
+
 def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
     if not isinstance(raw_assets, list):
         return []
@@ -266,16 +284,22 @@ def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
             continue
         name = str(item.get("name") or item.get("filename") or f"asset-{index + 1}")
         content_type = str(item.get("content_type") or item.get("mime_type") or "application/octet-stream")
+        data_base64 = _extract_base64_from_asset(item)
+        uri = item.get("uri") if isinstance(item.get("uri"), str) else None
+
+        if not data_base64 and not uri and not (isinstance(item.get("text"), str) and item.get("text")):
+            logger.warning(
+                "asset_missing_data_and_uri",
+                asset_name=name,
+                available_keys=sorted(item.keys()),
+            )
+
         assets.append(
             ExtractionAsset(
                 name=name,
                 content_type=content_type,
-                uri=item.get("uri") if isinstance(item.get("uri"), str) else None,
-                data_base64=(
-                    item.get("data_base64")
-                    if isinstance(item.get("data_base64"), str)
-                    else item.get("content_base64")
-                ),
+                uri=uri,
+                data_base64=data_base64,
                 text=item.get("text") if isinstance(item.get("text"), str) else None,
                 metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
             )
@@ -369,7 +393,8 @@ def _merge_extraction_assets(
 ) -> list[ExtractionAsset]:
     """合并 structured_content 和 content_items 两个来源的资产。
 
-    structured_assets 优先：同名且已含数据的项不被覆盖，缺数据的项被补充。
+    structured_assets 优先：同名且已含有效数据的项不被覆盖。
+    当 structured asset 无 data_base64 且 URI 非 GCS 地址时，允许 content_items 回填。
     """
     if not content_image_assets:
         return structured_assets
@@ -385,7 +410,14 @@ def _merge_extraction_assets(
         if img_asset.name in existing_names:
             existing_idx = existing_names[img_asset.name]
             existing = merged[existing_idx]
-            if not existing.data_base64 and not existing.uri and not existing.text:
+            # structured 已有 base64 数据 → 不覆盖
+            if existing.data_base64:
+                continue
+            # structured 已有 GCS URI → 不覆盖（GCS URI 可直接服务）
+            if _is_gcs_uri(existing.uri):
+                continue
+            # 其他情况（无数据、或 URI 非 GCS）→ 允许用 content_items 数据回填
+            if img_asset.data_base64:
                 merged[existing_idx] = ExtractionAsset(
                     name=existing.name,
                     content_type=img_asset.content_type or existing.content_type,
@@ -2092,7 +2124,11 @@ async def persist_extracted_assets(
     stored_assets: list[dict[str, Any]] = []
     for asset in assets:
         uri = asset.uri
-        if not uri:
+
+        # 上传决策：无 URI 或 URI 非 GCS 且有可上传数据时，需上传到 GCS
+        needs_upload = not uri or (not _is_gcs_uri(uri) and bool(asset.data_base64))
+
+        if needs_upload:
             content_bytes: bytes | None = None
             if asset.data_base64:
                 try:
@@ -2108,6 +2144,12 @@ async def persist_extracted_assets(
                     filename=asset.name,
                     content=content_bytes,
                     content_type=asset.content_type,
+                )
+            elif not _is_gcs_uri(uri):
+                logger.warning(
+                    "asset_no_uploadable_content",
+                    document_id=str(document_id),
+                    asset_name=asset.name,
                 )
 
         stored_assets.append(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py
@@ -4,16 +4,23 @@
 并与 Markdown 中的图片引用正确匹配。
 """
 
+import base64
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
 import pytest
 
 from negentropy.knowledge.extraction import (
     ExtractionAsset,
+    _extract_base64_from_asset,
     _extract_image_assets_from_content_items,
     _extract_markdown_image_refs,
+    _is_gcs_uri,
     _merge_extraction_assets,
     _mime_to_extension,
+    _normalize_assets,
+    persist_extracted_assets,
 )
 
 
@@ -251,3 +258,189 @@ class TestMergeExtractionAssets:
         assert len(merged) == 3
         names = [a.name for a in merged]
         assert names == ["existing.png", "new1.png", "new2.png"]
+
+    def test_backfill_when_structured_has_non_gcs_uri(self):
+        """非 GCS URI 时允许用 content_items 数据回填。"""
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png", uri="file:///tmp/img.png")],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="backfill_data")],
+        )
+        assert len(merged) == 1
+        assert merged[0].data_base64 == "backfill_data"
+        assert merged[0].uri == "file:///tmp/img.png"
+        assert merged[0].metadata.get("source") == "content_items_backfill"
+
+    def test_backfill_when_structured_has_http_uri(self):
+        """HTTP URI 时允许回填。"""
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png", uri="https://mcp.example.com/img.png")],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="content_data")],
+        )
+        assert len(merged) == 1
+        assert merged[0].data_base64 == "content_data"
+
+    def test_no_backfill_when_structured_has_gcs_uri(self):
+        """GCS URI 时不回填。"""
+        merged = _merge_extraction_assets(
+            [ExtractionAsset(name="img.png", content_type="image/png", uri="gs://bucket/path/img.png")],
+            [ExtractionAsset(name="img.png", content_type="image/png", data_base64="should_not_use")],
+        )
+        assert len(merged) == 1
+        assert merged[0].data_base64 is None
+        assert merged[0].uri == "gs://bucket/path/img.png"
+
+
+# ---------------------------------------------------------------------------
+# _extract_base64_from_asset & _is_gcs_uri
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBase64FromAsset:
+
+    def test_data_base64_field(self):
+        assert _extract_base64_from_asset({"data_base64": "abc"}) == "abc"
+
+    def test_content_base64_field(self):
+        assert _extract_base64_from_asset({"content_base64": "def"}) == "def"
+
+    def test_data_field(self):
+        assert _extract_base64_from_asset({"data": "ghi"}) == "ghi"
+
+    def test_base64_field(self):
+        assert _extract_base64_from_asset({"base64": "jkl"}) == "jkl"
+
+    def test_image_data_field(self):
+        assert _extract_base64_from_asset({"image_data": "mno"}) == "mno"
+
+    def test_priority_data_base64_over_data(self):
+        assert _extract_base64_from_asset({"data_base64": "winner", "data": "loser"}) == "winner"
+
+    def test_skips_empty_string(self):
+        assert _extract_base64_from_asset({"data_base64": "", "data": "fallback"}) == "fallback"
+
+    def test_skips_non_string(self):
+        assert _extract_base64_from_asset({"data_base64": 123, "data": "ok"}) == "ok"
+
+    def test_returns_none_when_empty(self):
+        assert _extract_base64_from_asset({"uri": "gs://bucket/img.png"}) is None
+
+
+class TestIsGcsUri:
+
+    def test_gcs_uri(self):
+        assert _is_gcs_uri("gs://bucket/path/file.png") is True
+
+    def test_http_uri(self):
+        assert _is_gcs_uri("https://example.com/file.png") is False
+
+    def test_file_uri(self):
+        assert _is_gcs_uri("file:///tmp/file.png") is False
+
+    def test_none(self):
+        assert _is_gcs_uri(None) is False
+
+    def test_empty_string(self):
+        assert _is_gcs_uri("") is False
+
+
+# ---------------------------------------------------------------------------
+# _normalize_assets
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAssets:
+
+    def test_extracts_data_base64_field(self):
+        assets = _normalize_assets([{"name": "img.png", "content_type": "image/png", "data_base64": "abc"}])
+        assert assets[0].data_base64 == "abc"
+
+    def test_extracts_data_field(self):
+        """MCP ImageContent 标准使用 'data' 字段。"""
+        assets = _normalize_assets([{"name": "img.png", "content_type": "image/png", "data": "ghi"}])
+        assert assets[0].data_base64 == "ghi"
+
+    def test_extracts_base64_field(self):
+        assets = _normalize_assets([{"name": "img.png", "content_type": "image/png", "base64": "jkl"}])
+        assert assets[0].data_base64 == "jkl"
+
+    def test_priority_data_base64_over_data(self):
+        assets = _normalize_assets([{"name": "img.png", "data_base64": "winner", "data": "loser"}])
+        assert assets[0].data_base64 == "winner"
+
+    def test_no_base64_returns_none(self):
+        assets = _normalize_assets([{"name": "img.png", "uri": "https://example.com/img.png"}])
+        assert assets[0].data_base64 is None
+        assert assets[0].uri == "https://example.com/img.png"
+
+    def test_empty_list(self):
+        assert _normalize_assets([]) == []
+
+    def test_non_list_returns_empty(self):
+        assert _normalize_assets(None) == []
+        assert _normalize_assets("not a list") == []
+
+
+# ---------------------------------------------------------------------------
+# persist_extracted_assets
+# ---------------------------------------------------------------------------
+
+
+class TestPersistExtractedAssets:
+
+    @pytest.mark.asyncio
+    async def test_uploads_asset_with_non_gcs_uri_and_data(self):
+        """有非 GCS URI 但有 data_base64 时，应上传到 GCS。"""
+        doc_id = uuid4()
+        asset = ExtractionAsset(
+            name="img.png",
+            content_type="image/png",
+            uri="https://mcp.example.com/temp/img.png",
+            data_base64=base64.b64encode(b"fake-png").decode(),
+        )
+
+        mock_storage = AsyncMock()
+        mock_storage.upload_extraction_asset.return_value = "gs://bucket/assets/img.png"
+
+        with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
+            result = await persist_extracted_assets(document_id=doc_id, assets=[asset])
+
+        assert len(result) == 1
+        assert result[0]["uri"] == "gs://bucket/assets/img.png"
+        mock_storage.upload_extraction_asset.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_upload_for_gcs_uri(self):
+        """已有 GCS URI 时不重复上传。"""
+        doc_id = uuid4()
+        asset = ExtractionAsset(
+            name="img.png",
+            content_type="image/png",
+            uri="gs://bucket/existing/img.png",
+        )
+
+        mock_storage = AsyncMock()
+
+        with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
+            result = await persist_extracted_assets(document_id=doc_id, assets=[asset])
+
+        assert result[0]["uri"] == "gs://bucket/existing/img.png"
+        mock_storage.upload_extraction_asset.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uploads_asset_without_uri(self):
+        """无 URI 时正常上传。"""
+        doc_id = uuid4()
+        asset = ExtractionAsset(
+            name="img.png",
+            content_type="image/png",
+            data_base64=base64.b64encode(b"fake-png").decode(),
+        )
+
+        mock_storage = AsyncMock()
+        mock_storage.upload_extraction_asset.return_value = "gs://bucket/assets/img.png"
+
+        with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
+            result = await persist_extracted_assets(document_id=doc_id, assets=[asset])
+
+        assert result[0]["uri"] == "gs://bucket/assets/img.png"
+        mock_storage.upload_extraction_asset.assert_called_once()


### PR DESCRIPTION
## 问题背景

Knowledge / Documents 页面查看文档时，PDF 文档的图片无法显示，前端仅展示文本占位符（"Extracted Images" + 尺寸信息）。服务端日志显示所有图片资产从 GCS 下载返回 404——图片在提取阶段未被成功上传到 GCS。

尽管 PR #313（commit `51d1816`）已修复了从 `content_items` 中提取 `ImageContent` 的逻辑，但仍存在三个遗漏的故障点导致部分场景下图片依旧无法上传。

## 根因分析

### 数据流链路

```
MCP Tool Response
├── structured_content.assets[]           ← _normalize_assets()
│   {name, content_type, uri?, data_base64?, data?, base64?}
├── content_items[] (ImageContent)        ← _extract_image_assets_from_content_items()
│   {type:"image", data, mimeType}
└── → _merge_extraction_assets()          ← 合并两个来源
    └── → persist_extracted_assets()      ← 上传到 GCS
        └── 前端 API 代理 → GCS 下载 → 404!
```

### 故障点 1：`_normalize_assets()` 字段名覆盖不足

当前仅识别 `data_base64` 和 `content_base64` 两个字段。MCP 工具可能使用 `data`（MCP ImageContent 标准字段）、`base64`、`image_data` 等命名，导致 base64 数据被静默丢弃。

### 故障点 2：`_merge_extraction_assets()` 回填条件过严

```python
# 原始条件：structured_content.assets 有非 GCS 的 URI 时，回填被阻断
if not existing.data_base64 and not existing.uri and not existing.text:
```

当 `structured_content.assets` 持有非 GCS URI（如 `file://` 或 MCP 工具临时 URL）时，`existing.uri` 非空导致回填条件不满足，`content_items` 的 `data_base64` 无法补入。

### 故障点 3：`persist_extracted_assets()` 跳过有 URI 的资产

即使 asset 同时持有非 GCS URI 和 `data_base64`，也会因 URI 非空而跳过上传。而前端代理只从 GCS 路径下载 → 404。

## 修复方案

### 1. 扩展 `_normalize_assets()` base64 字段识别

新增 `_extract_base64_from_asset()` 辅助函数，按优先级序列提取 base64 数据：

```python
_BASE64_FIELD_NAMES = ("data_base64", "content_base64", "data", "base64", "image_data")
```

### 2. 放宽 `_merge_extraction_assets()` 回填条件

新增 `_is_gcs_uri()` 辅助函数，将单一复合条件拆解为两个独立守卫：
- `existing.data_base64` 存在 → 不回填（已有数据）
- `_is_gcs_uri(existing.uri)` → 不回填（GCS URI 可直接服务）
- 其他情况 → 允许用 `content_items` 的 `data_base64` 回填

### 3. 修复 `persist_extracted_assets()` 上传决策

引入显式 `needs_upload` 判断：
- 无 URI → 上传
- URI 非 GCS 且有 `data_base64` → 上传（替换 URI）
- 有 GCS URI → 不重复上传

## 变更文件

| 文件 | 变更 |
|------|------|
| `apps/negentropy/src/negentropy/knowledge/extraction.py` | 新增 `_BASE64_FIELD_NAMES`、`_extract_base64_from_asset()`、`_is_gcs_uri()` 辅助函数；重写 `_normalize_assets()`、`_merge_extraction_assets()`、`persist_extracted_assets()` 核心逻辑 |
| `apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py` | 新增 `TestExtractBase64FromAsset`（9）、`TestIsGcsUri`（5）、`TestNormalizeAssets`（7）、`TestPersistExtractedAssets`（3）共 24 个单元测试 |

## 测试验证

- 图片资产测试：53 个全部通过 ✅
- Provider 集成测试：17 个全部通过 ✅
- Knowledge 全量测试：284 通过，1 个预存失败（与本次变更无关）✅