### PR TITLE
feat(knowledge): 完善 PDF 图片资产上传与复解析复用链路;

### DIFF
--- a/apps/negentropy-ui/tests/unit/knowledge/DocumentMarkdownRenderer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DocumentMarkdownRenderer.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { DocumentMarkdownRenderer } from "@/features/knowledge/components/DocumentMarkdownRenderer";
+
+describe("DocumentMarkdownRenderer", () => {
+  it("将相对图片路径代理到文档 assets 路由", () => {
+    const { container } = render(
+      <DocumentMarkdownRenderer
+        content={"# Report\n\n![](./images/figure-1.png)\n![](../assets/figure-2.png)\n![](figure-3.png)"}
+        corpusId="corpus-1"
+        documentId="document-1"
+        appName="negentropy"
+      />,
+    );
+
+    const images = Array.from(container.querySelectorAll("img"));
+    expect(images[0]).toHaveAttribute(
+      "src",
+      "/api/knowledge/base/corpus-1/documents/document-1/assets/figure-1.png?app_name=negentropy",
+    );
+    expect(images[1]).toHaveAttribute(
+      "src",
+      "/api/knowledge/base/corpus-1/documents/document-1/assets/figure-2.png?app_name=negentropy",
+    );
+    expect(images[2]).toHaveAttribute(
+      "src",
+      "/api/knowledge/base/corpus-1/documents/document-1/assets/figure-3.png?app_name=negentropy",
+    );
+  });
+
+  it("保留绝对图片地址，不走代理", () => {
+    const { container } = render(
+      <DocumentMarkdownRenderer
+        content={"![](https://example.com/image.png)"}
+        corpusId="corpus-1"
+        documentId="document-1"
+      />,
+    );
+
+    expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/image.png");
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -36,6 +36,7 @@ from .extraction import (
     merge_corpus_config,
     persist_extracted_assets,
     resolve_source_kind,
+    store_extracted_document_artifacts,
 )
 from .dao import KnowledgeRunDao
 from .exceptions import (
@@ -1179,24 +1180,15 @@ async def _extract_and_store_document_markdown_from_gcs(
         if not markdown_content:
             raise ValueError("Extractor returned empty markdown content")
 
-        markdown_gcs_uri = await storage_service.upload_markdown_derivative(
+        markdown_gcs_uri, _ = await store_extracted_document_artifacts(
             document_id=document_id,
-            markdown_content=markdown_content,
-        )
-        await storage_service.save_markdown_content(
-            document_id=document_id,
-            markdown_content=markdown_content,
-            markdown_gcs_uri=markdown_gcs_uri,
+            extracted=result,
         )
         logger.info(
             "document_markdown_extraction_completed",
             document_id=str(document_id),
             markdown_size=len(markdown_content),
             markdown_gcs_uri=markdown_gcs_uri,
-        )
-        await persist_extracted_assets(
-            document_id=document_id,
-            assets=result.assets,
         )
     except Exception as exc:  # noqa: BLE001 - 后台任务需兜底并可观测
         logger.error(
@@ -1336,7 +1328,7 @@ async def ingest_file(
                     filename=raw_filename,
                     content_type=file.content_type,
                     metadata={"source": "ingest_file", "source_type": "file"},
-                    created_by=user.user_id if user else None,
+                    created_by=getattr(user, "user_id", None),
                 )
                 gcs_uri = doc_record.gcs_uri
 
@@ -2314,18 +2306,9 @@ async def sync_document(
             detail={"code": "EMPTY_CONTENT", "message": "No content extracted from URL"},
         )
 
-    markdown_gcs_uri = await storage_service.upload_markdown_derivative(
+    _, stored_assets = await store_extracted_document_artifacts(
         document_id=document_id,
-        markdown_content=markdown_text,
-    )
-    await storage_service.save_markdown_content(
-        document_id=document_id,
-        markdown_content=markdown_text,
-        markdown_gcs_uri=markdown_gcs_uri,
-    )
-    stored_assets = await persist_extracted_assets(
-        document_id=document_id,
-        assets=extraction_result.assets,
+        extracted=extraction_result,
     )
     chunking_config = _resolve_chunking_config_from_doc_request(
         payload=payload,

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -45,6 +45,7 @@ class ExtractionAsset:
     content_type: str
     uri: str | None = None
     data_base64: str | None = None
+    local_path: str | None = None
     text: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -300,6 +301,7 @@ def _normalize_assets(raw_assets: Any) -> list[ExtractionAsset]:
                 content_type=content_type,
                 uri=uri,
                 data_base64=data_base64,
+                local_path=item.get("local_path") if isinstance(item.get("local_path"), str) else None,
                 text=item.get("text") if isinstance(item.get("text"), str) else None,
                 metadata=item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
             )
@@ -344,6 +346,22 @@ def _mime_to_extension(mime_type: str) -> str:
     return mapping.get(mime_type.lower(), ".png")
 
 
+def _guess_image_content_type(filename: str) -> str:
+    suffix = Path(filename).suffix.lower()
+    mapping = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".svg": "image/svg+xml",
+        ".bmp": "image/bmp",
+        ".tif": "image/tiff",
+        ".tiff": "image/tiff",
+    }
+    return mapping.get(suffix, "application/octet-stream")
+
+
 def _extract_image_assets_from_content_items(
     content_items: list[Any],
     markdown_content: str,
@@ -381,6 +399,7 @@ def _extract_image_assets_from_content_items(
                 name=name,
                 content_type=mime_type,
                 data_base64=data,
+                metadata={"source": "content_items"},
             )
         )
 
@@ -431,6 +450,77 @@ def _merge_extraction_assets(
             existing_names[img_asset.name] = len(merged) - 1
 
     return merged
+
+
+def _extract_enhanced_image_assets(payload: dict[str, Any]) -> list[ExtractionAsset]:
+    """从 enhanced_assets.output_directory + images.files 提取本地图片资产。"""
+    enhanced_assets = payload.get("enhanced_assets")
+    if not isinstance(enhanced_assets, dict):
+        return []
+
+    output_directory = enhanced_assets.get("output_directory")
+    images = enhanced_assets.get("images")
+    if not isinstance(output_directory, str) or not output_directory.strip():
+        return []
+    if not isinstance(images, dict):
+        return []
+
+    files = images.get("files")
+    if not isinstance(files, list):
+        return []
+
+    try:
+        base_dir = Path(output_directory).expanduser().resolve(strict=True)
+    except OSError:
+        logger.warning("enhanced_asset_output_directory_invalid", output_directory=output_directory)
+        return []
+
+    assets: list[ExtractionAsset] = []
+    for raw_name in files:
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            continue
+
+        safe_name = Path(raw_name).name
+        if safe_name != raw_name:
+            logger.warning(
+                "enhanced_asset_filename_normalized",
+                original_name=raw_name,
+                normalized_name=safe_name,
+            )
+
+        candidate = (base_dir / safe_name)
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            logger.warning(
+                "enhanced_asset_file_missing",
+                output_directory=str(base_dir),
+                asset_name=safe_name,
+            )
+            continue
+
+        try:
+            resolved.relative_to(base_dir)
+        except ValueError:
+            logger.warning(
+                "enhanced_asset_path_outside_output_directory",
+                output_directory=str(base_dir),
+                asset_path=str(resolved),
+            )
+            continue
+        if not resolved.is_file():
+            logger.warning("enhanced_asset_not_a_file", asset_path=str(resolved))
+            continue
+
+        assets.append(
+            ExtractionAsset(
+                name=safe_name,
+                content_type=_guess_image_content_type(safe_name),
+                local_path=str(resolved),
+                metadata={"source": "enhanced_output_directory"},
+            )
+        )
+    return assets
 
 
 def _schema_properties(schema: Any) -> dict[str, Any]:
@@ -2056,7 +2146,10 @@ class DataExtractorProvider:
                     "adapter_name": plan.adapter_name,
                 },
                 assets=_merge_extraction_assets(
-                    _normalize_assets(payload.get("assets")),
+                    _merge_extraction_assets(
+                        _normalize_assets(payload.get("assets")),
+                        _extract_enhanced_image_assets(payload),
+                    ),
                     _extract_image_assets_from_content_items(result.content, markdown),
                 ),
                 trace={
@@ -2114,19 +2207,30 @@ async def persist_extracted_assets(
     assets: list[ExtractionAsset],
     tracker: Any | None = None,
 ) -> list[dict[str, Any]]:
-    if not assets:
-        return []
-
     if tracker:
         await tracker.start_stage("extract_assets_store")
 
     storage_service = DocumentStorageService()
+    doc = await storage_service.get_document(document_id=document_id)
+    if not doc:
+        if tracker:
+            await tracker.complete_stage("extract_assets_store", {"asset_count": 0, "document_found": False})
+        return []
+
+    existing_assets = []
+    if isinstance(doc.metadata_, dict):
+        raw_existing_assets = doc.metadata_.get("extracted_assets")
+        if isinstance(raw_existing_assets, list):
+            existing_assets = [item for item in raw_existing_assets if isinstance(item, dict)]
+
     stored_assets: list[dict[str, Any]] = []
     for asset in assets:
         uri = asset.uri
 
         # 上传决策：无 URI 或 URI 非 GCS 且有可上传数据时，需上传到 GCS
-        needs_upload = not uri or (not _is_gcs_uri(uri) and bool(asset.data_base64))
+        needs_upload = not uri or (
+            not _is_gcs_uri(uri) and bool(asset.data_base64 or asset.local_path or asset.text is not None)
+        )
 
         if needs_upload:
             content_bytes: bytes | None = None
@@ -2135,6 +2239,17 @@ async def persist_extracted_assets(
                     content_bytes = base64.b64decode(asset.data_base64)
                 except (ValueError, TypeError):
                     logger.warning("invalid_asset_base64_skipped", document_id=str(document_id), asset_name=asset.name)
+            elif asset.local_path:
+                try:
+                    content_bytes = Path(asset.local_path).read_bytes()
+                except OSError as exc:
+                    logger.warning(
+                        "asset_local_file_read_failed",
+                        document_id=str(document_id),
+                        asset_name=asset.name,
+                        local_path=asset.local_path,
+                        error=str(exc),
+                    )
             elif asset.text is not None:
                 content_bytes = asset.text.encode("utf-8")
 
@@ -2157,13 +2272,59 @@ async def persist_extracted_assets(
                 "name": asset.name,
                 "content_type": asset.content_type,
                 "uri": uri,
-                "metadata": asset.metadata,
+                "source": str(asset.metadata.get("source") or "structured_asset"),
             }
         )
 
+    await storage_service.update_document_metadata(
+        document_id=document_id,
+        metadata_patch={"extracted_assets": stored_assets},
+    )
+    existing_uris = {
+        str(item.get("uri"))
+        for item in existing_assets
+        if isinstance(item.get("uri"), str) and _is_gcs_uri(item.get("uri"))
+    }
+    current_uris = {
+        str(item.get("uri"))
+        for item in stored_assets
+        if isinstance(item.get("uri"), str) and _is_gcs_uri(item.get("uri"))
+    }
+    stale_uris = sorted(existing_uris - current_uris)
+    for stale_uri in stale_uris:
+        await storage_service.delete_gcs_uri(gcs_uri=stale_uri)
+
     if tracker:
-        await tracker.complete_stage("extract_assets_store", {"asset_count": len(stored_assets)})
+        await tracker.complete_stage(
+            "extract_assets_store",
+            {"asset_count": len(stored_assets), "deleted_stale_asset_count": len(stale_uris)},
+        )
     return stored_assets
+
+
+async def store_extracted_document_artifacts(
+    *,
+    document_id: UUID,
+    extracted: ExtractedDocumentResult,
+    tracker: Any | None = None,
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """统一保存提取后的 Markdown 与图片资产。"""
+    storage_service = DocumentStorageService()
+    markdown_gcs_uri = await storage_service.upload_markdown_derivative(
+        document_id=document_id,
+        markdown_content=extracted.markdown_content,
+    )
+    await storage_service.save_markdown_content(
+        document_id=document_id,
+        markdown_content=extracted.markdown_content,
+        markdown_gcs_uri=markdown_gcs_uri,
+    )
+    stored_assets = await persist_extracted_assets(
+        document_id=document_id,
+        assets=extracted.assets,
+        tracker=tracker,
+    )
+    return markdown_gcs_uri, stored_assets
 
 
 def build_url_document_filename(url: str) -> str:

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -709,19 +709,13 @@ class KnowledgeService:
                 ) from exc
 
             if document_id:
-                from .extraction import persist_extracted_assets
-                from negentropy.storage.service import DocumentStorageService
+                from .extraction import store_extracted_document_artifacts
 
-                storage_service = DocumentStorageService()
                 await tracker.start_stage("markdown_store")
-                markdown_gcs_uri = await storage_service.upload_markdown_derivative(
+                markdown_gcs_uri, _ = await store_extracted_document_artifacts(
                     document_id=document_id,
-                    markdown_content=extracted.markdown_content,
-                )
-                await storage_service.save_markdown_content(
-                    document_id=document_id,
-                    markdown_content=extracted.markdown_content,
-                    markdown_gcs_uri=markdown_gcs_uri,
+                    extracted=extracted,
+                    tracker=tracker,
                 )
                 await tracker.complete_stage(
                     "markdown_store",
@@ -731,12 +725,6 @@ class KnowledgeService:
                         "markdown_length": len(extracted.markdown_content),
                     },
                 )
-                await persist_extracted_assets(
-                    document_id=document_id,
-                    assets=extracted.assets,
-                    tracker=tracker,
-                )
-
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -1014,17 +1002,13 @@ class KnowledgeService:
             await tracker.complete_stage("delete", {"deleted_count": deleted_count})
 
             if document_id:
-                from .extraction import persist_extracted_assets
+                from .extraction import store_extracted_document_artifacts
 
                 await tracker.start_stage("markdown_store")
-                markdown_gcs_uri = await storage_service.upload_markdown_derivative(
+                markdown_gcs_uri, _ = await store_extracted_document_artifacts(
                     document_id=document_id,
-                    markdown_content=extracted.markdown_content,
-                )
-                await storage_service.save_markdown_content(
-                    document_id=document_id,
-                    markdown_content=extracted.markdown_content,
-                    markdown_gcs_uri=markdown_gcs_uri,
+                    extracted=extracted,
+                    tracker=tracker,
                 )
                 await tracker.complete_stage(
                     "markdown_store",
@@ -1034,12 +1018,6 @@ class KnowledgeService:
                         "markdown_length": len(extracted.markdown_content),
                     },
                 )
-                await persist_extracted_assets(
-                    document_id=document_id,
-                    assets=extracted.assets,
-                    tracker=tracker,
-                )
-
             metadata = _normalize_source_metadata(
                 source_uri=source_uri,
                 metadata={"gcs_uri": source_uri, "rebuild": True},

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -303,6 +303,23 @@ class DocumentStorageService:
                     gcs_client.delete(doc.gcs_uri)
                     if doc.markdown_gcs_uri:
                         gcs_client.delete(doc.markdown_gcs_uri)
+                    metadata = dict(doc.metadata_ or {})
+                    extracted_assets = metadata.get("extracted_assets")
+                    if isinstance(extracted_assets, list):
+                        for asset in extracted_assets:
+                            if not isinstance(asset, dict):
+                                continue
+                            uri = asset.get("uri")
+                            if isinstance(uri, str) and uri.startswith("gs://"):
+                                try:
+                                    gcs_client.delete(uri)
+                                except StorageError as exc:
+                                    logger.warning(
+                                        "gcs_delete_asset_failed_proceeding_with_db_delete",
+                                        doc_id=str(document_id),
+                                        asset_uri=uri,
+                                        error=str(exc),
+                                    )
                 except StorageError as exc:
                     logger.warning(
                         "gcs_delete_failed_proceeding_with_db_delete",
@@ -429,6 +446,15 @@ class DocumentStorageService:
             doc.metadata_ = current
             await db.commit()
             return True
+
+    async def delete_gcs_uri(self, *, gcs_uri: str) -> bool:
+        """删除任意 GCS URI；失败时仅记录日志。"""
+        try:
+            self._get_gcs_client().delete(gcs_uri)
+            return True
+        except StorageError as exc:
+            logger.warning("gcs_uri_delete_failed", gcs_uri=gcs_uri, error=str(exc))
+            return False
 
     async def upload_markdown_derivative(
         self,

--- a/apps/negentropy/tests/unit_tests/knowledge/conftest.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/conftest.py
@@ -125,6 +125,9 @@ class FakeStorageService:
         self.saved_markdown: str | None = None
         self.saved_markdown_gcs_uri: str | None = None
         self.uploaded_markdown: str | None = None
+        self.uploaded_assets: list[dict[str, object]] = []
+        self.deleted_gcs_uris: list[str] = []
+        self.updated_metadata_patches: list[dict[str, object]] = []
         self.upload_and_store_calls: list[dict[str, object]] = []
 
     async def get_document(self, *, document_id, corpus_id=None, app_name=None):
@@ -163,8 +166,33 @@ class FakeStorageService:
                 id=uuid4(),
                 gcs_uri="gs://negentropy/knowledge/test.pdf",
                 markdown_extract_status="pending",
+                metadata_={},
             )
         return self.doc, True
+
+    async def upload_extraction_asset(self, *, document_id, filename: str, content: bytes, content_type: str):
+        _ = document_id
+        self.uploaded_assets.append(
+            {
+                "filename": filename,
+                "content": content,
+                "content_type": content_type,
+            }
+        )
+        return f"gs://derived/assets/{filename}"
+
+    async def update_document_metadata(self, *, document_id, metadata_patch: dict):
+        _ = document_id
+        self.updated_metadata_patches.append(metadata_patch)
+        if self.doc is not None:
+            current = dict(getattr(self.doc, "metadata_", {}) or {})
+            current.update(metadata_patch)
+            self.doc.metadata_ = current
+        return True
+
+    async def delete_gcs_uri(self, *, gcs_uri: str):
+        self.deleted_gcs_uris.append(gcs_uri)
+        return True
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
@@ -173,13 +173,18 @@ async def test_sync_document_success(monkeypatch):
             markdown_content="# title\n\ncontent",
         )
 
-    async def fake_persist_extracted_assets(**kwargs):
-        return []
+    async def fake_store_extracted_document_artifacts(**kwargs):
+        fake_storage.saved_markdown = kwargs["extracted"].markdown_content
+        return "gs://derived/markdown.md", []
 
     monkeypatch.setattr("negentropy.storage.service.DocumentStorageService", lambda: fake_storage)
     monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
     monkeypatch.setattr(knowledge_api, "extract_source", fake_extract_source)
-    monkeypatch.setattr(knowledge_api, "persist_extracted_assets", fake_persist_extracted_assets)
+    monkeypatch.setattr(
+        knowledge_api,
+        "store_extracted_document_artifacts",
+        fake_store_extracted_document_artifacts,
+    )
 
     result = await knowledge_api.sync_document(
         corpus_id=corpus_id,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_image_assets.py
@@ -13,9 +13,11 @@ import pytest
 
 from negentropy.knowledge.extraction import (
     ExtractionAsset,
+    _extract_enhanced_image_assets,
     _extract_base64_from_asset,
     _extract_image_assets_from_content_items,
     _extract_markdown_image_refs,
+    _guess_image_content_type,
     _is_gcs_uri,
     _merge_extraction_assets,
     _mime_to_extension,
@@ -92,6 +94,17 @@ class TestMimeToExtension:
     def test_case_insensitive(self):
         assert _mime_to_extension("Image/PNG") == ".png"
         assert _mime_to_extension("IMAGE/JPEG") == ".jpg"
+
+
+class TestGuessImageContentType:
+
+    def test_known_suffixes(self):
+        assert _guess_image_content_type("chart.png") == "image/png"
+        assert _guess_image_content_type("chart.jpeg") == "image/jpeg"
+        assert _guess_image_content_type("chart.svg") == "image/svg+xml"
+
+    def test_unknown_suffix_defaults_to_octet_stream(self):
+        assert _guess_image_content_type("chart.bin") == "application/octet-stream"
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +393,63 @@ class TestNormalizeAssets:
         assert _normalize_assets("not a list") == []
 
 
+class TestExtractEnhancedImageAssets:
+
+    def test_extracts_assets_from_output_directory(self, tmp_path):
+        output_dir = tmp_path / "enhanced"
+        output_dir.mkdir()
+        image_path = output_dir / "figure-1.png"
+        image_path.write_bytes(b"png-data")
+
+        assets = _extract_enhanced_image_assets(
+            {
+                "enhanced_assets": {
+                    "output_directory": str(output_dir),
+                    "images": {"files": ["figure-1.png"]},
+                }
+            }
+        )
+
+        assert len(assets) == 1
+        assert assets[0].name == "figure-1.png"
+        assert assets[0].local_path == str(image_path.resolve())
+        assert assets[0].content_type == "image/png"
+        assert assets[0].metadata["source"] == "enhanced_output_directory"
+
+    def test_ignores_missing_files(self, tmp_path):
+        output_dir = tmp_path / "enhanced"
+        output_dir.mkdir()
+
+        assets = _extract_enhanced_image_assets(
+            {
+                "enhanced_assets": {
+                    "output_directory": str(output_dir),
+                    "images": {"files": ["missing.png"]},
+                }
+            }
+        )
+
+        assert assets == []
+
+    def test_normalizes_nested_paths_to_basename(self, tmp_path):
+        output_dir = tmp_path / "enhanced"
+        output_dir.mkdir()
+        image_path = output_dir / "figure-2.png"
+        image_path.write_bytes(b"png-data")
+
+        assets = _extract_enhanced_image_assets(
+            {
+                "enhanced_assets": {
+                    "output_directory": str(output_dir),
+                    "images": {"files": ["nested/figure-2.png"]},
+                }
+            }
+        )
+
+        assert len(assets) == 1
+        assert assets[0].name == "figure-2.png"
+
+
 # ---------------------------------------------------------------------------
 # persist_extracted_assets
 # ---------------------------------------------------------------------------
@@ -399,6 +469,7 @@ class TestPersistExtractedAssets:
         )
 
         mock_storage = AsyncMock()
+        mock_storage.get_document.return_value = SimpleNamespace(metadata_={})
         mock_storage.upload_extraction_asset.return_value = "gs://bucket/assets/img.png"
 
         with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
@@ -419,6 +490,7 @@ class TestPersistExtractedAssets:
         )
 
         mock_storage = AsyncMock()
+        mock_storage.get_document.return_value = SimpleNamespace(metadata_={})
 
         with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
             result = await persist_extracted_assets(document_id=doc_id, assets=[asset])
@@ -437,6 +509,7 @@ class TestPersistExtractedAssets:
         )
 
         mock_storage = AsyncMock()
+        mock_storage.get_document.return_value = SimpleNamespace(metadata_={})
         mock_storage.upload_extraction_asset.return_value = "gs://bucket/assets/img.png"
 
         with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
@@ -444,3 +517,64 @@ class TestPersistExtractedAssets:
 
         assert result[0]["uri"] == "gs://bucket/assets/img.png"
         mock_storage.upload_extraction_asset.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_uploads_asset_from_local_path_and_cleans_stale_manifest(self, tmp_path):
+        doc_id = uuid4()
+        local_file = tmp_path / "img.png"
+        local_file.write_bytes(b"fake-png")
+        asset = ExtractionAsset(
+            name="img.png",
+            content_type="image/png",
+            local_path=str(local_file),
+            metadata={"source": "enhanced_output_directory"},
+        )
+
+        mock_storage = AsyncMock()
+        mock_storage.get_document.return_value = SimpleNamespace(
+            metadata_={
+                "extracted_assets": [
+                    {"name": "stale.png", "uri": "gs://bucket/assets/stale.png", "content_type": "image/png"}
+                ]
+            }
+        )
+        mock_storage.upload_extraction_asset.return_value = "gs://bucket/assets/img.png"
+
+        with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
+            result = await persist_extracted_assets(document_id=doc_id, assets=[asset])
+
+        assert result == [
+            {
+                "name": "img.png",
+                "content_type": "image/png",
+                "uri": "gs://bucket/assets/img.png",
+                "source": "enhanced_output_directory",
+            }
+        ]
+        mock_storage.update_document_metadata.assert_awaited_once_with(
+            document_id=doc_id,
+            metadata_patch={"extracted_assets": result},
+        )
+        mock_storage.delete_gcs_uri.assert_awaited_once_with(gcs_uri="gs://bucket/assets/stale.png")
+
+    @pytest.mark.asyncio
+    async def test_clears_manifest_when_assets_empty(self):
+        doc_id = uuid4()
+        mock_storage = AsyncMock()
+        mock_storage.get_document.return_value = SimpleNamespace(
+            metadata_={
+                "extracted_assets": [
+                    {"name": "stale.png", "uri": "gs://bucket/assets/stale.png", "content_type": "image/png"}
+                ]
+            }
+        )
+
+        with patch("negentropy.knowledge.extraction.DocumentStorageService", return_value=mock_storage):
+            result = await persist_extracted_assets(document_id=doc_id, assets=[])
+
+        assert result == []
+        mock_storage.update_document_metadata.assert_awaited_once_with(
+            document_id=doc_id,
+            metadata_patch={"extracted_assets": []},
+        )
+        mock_storage.delete_gcs_uri.assert_awaited_once_with(gcs_uri="gs://bucket/assets/stale.png")

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
@@ -4,6 +4,7 @@
 包括批量/单文件 schema 适配、重试机制、failover 和契约诊断。
 """
 
+from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -1326,3 +1327,80 @@ async def test_data_extractor_provider_structured_assets_take_precedence_over_co
     assert extracted.assets[0].name == "chart.png"
     # structured_content 中的数据应优先
     assert extracted.assets[0].data_base64 == "c3RydWN0dXJlZF9kYXRh"
+
+
+@pytest.mark.asyncio
+async def test_data_extractor_provider_reads_enhanced_assets_from_output_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    server_id = uuid4()
+    output_dir = tmp_path / "enhanced_assets"
+    output_dir.mkdir()
+    (output_dir / "img_1.png").write_bytes(b"png")
+
+    class FakeClient:
+        async def call_tool(self, **kwargs):  # type: ignore[no-untyped-def]
+            _ = kwargs
+            return SimpleNamespace(
+                success=True,
+                structured_content={
+                    "markdown_content": "# Report\n![](img_1.png)",
+                    "plain_text": "Report",
+                    "enhanced_assets": {
+                        "output_directory": str(output_dir),
+                        "images": {
+                            "count": 1,
+                            "files": ["img_1.png"],
+                        },
+                    },
+                },
+                content=[],
+                error=None,
+                duration_ms=20,
+            )
+
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction.AsyncSessionLocal",
+        lambda: FakeMcpSession(
+            server_id=server_id,
+            input_schema={
+                "type": "object",
+                "properties": {"content_base64": {"type": "string"}},
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._increment_tool_call_count",
+        noop_increment_tool_call_count,
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.extraction._build_llm_invocation_plan",
+        noop_llm_plan,
+    )
+
+    provider = DataExtractorProvider()
+    provider._client = FakeClient()
+
+    result = await provider._invoke_target(
+        app_name="negentropy",
+        corpus_id=uuid4(),
+        target=SimpleNamespace(
+            server_id=server_id,
+            tool_name="convert_pdf_to_markdown",
+            timeout_ms=None,
+            tool_options={},
+        ),
+        source_kind=ROUTE_FILE_PDF,
+        url=None,
+        content=b"%PDF-1.5",
+        filename="report.pdf",
+        content_type="application/pdf",
+    )
+
+    assert result["success"] is True
+    extracted = result["result"]
+    assert len(extracted.assets) == 1
+    assert extracted.assets[0].name == "img_1.png"
+    assert extracted.assets[0].local_path == str((output_dir / "img_1.png").resolve())
+    assert extracted.assets[0].metadata["source"] == "enhanced_output_directory"


### PR DESCRIPTION
## 变更概览
- 支持从 Data Extractor 的 `enhanced_assets.output_directory + images.files` 读取 PDF 提取阶段生成的本地图片文件。
- 将 PDF 图片资产统一上传到与源文档绑定的 GCS `derived/{document_id}/assets/` 路径，供 Markdown 渲染稳定复用。
- 抽取共享的 Markdown / 图片资产保存入口，统一复用在 `Ingest from File`、`Document Sync`、`Re-Parse from GCS` 链路中。
- 为文档写入 `metadata.extracted_assets` 资产清单，并在重解析或硬删除时清理失效图片资产。
- 补齐后端与前端回归测试，覆盖 enhanced assets 解析、本地文件上传、旧资产清理与 Markdown 图片代理渲染。

## 变更动机
当前 PDF -> Markdown 链路已经能处理内联 base64 或结构化 assets，但对 Data Extractor 返回的 `output_directory + images.files` 这一类“本地临时图片目录”结果缺乏消费能力。这会导致：
- PDF 转 Markdown 后图片未被完整持久化到 GCS；
- Knowledge / Document 页 Markdown View 中相对图片引用最终命中 404；
- `Ingest from File` 与 `Re-Parse from GCS` 各自维护保存逻辑，存在重复实现与行为漂移风险。

本次改动的目标是把图片资产处理补齐为文档级共享能力，在不改变现有外部接口的前提下，确保 PDF 图片在首次导入与后续重解析时都能稳定显示，并保持单一事实源。

## 关键实现细节
### 1. 提取层补齐 enhanced assets 本地文件解析
- `ExtractionAsset` 新增 `local_path`，将“待上传本地文件”提升为一等资产来源，而不是强制先转 base64。
- 在提取层新增对 `enhanced_assets.images.files` 的处理：
  - 仅接受 `files` 白名单中的文件；
  - 对文件名做 basename 归一化；
  - 校验解析后的路径仍位于 `output_directory` 下，避免路径穿越；
  - 对缺失文件或非法路径仅记录告警，不中断主链路。
- 资产合并优先级固定为：
  1. 结构化 assets；
  2. enhanced output directory 本地图片；
  3. `content_items` 中的 `ImageContent` 回填。

### 2. 抽取共享的文档级 artifacts 保存入口
- 新增共享入口统一保存：
  - Markdown 衍生文件上传；
  - Markdown 正文落库；
  - 图片资产上传与清理。
- `Ingest from File`、`Document Sync`、`Re-Parse from GCS` 统一复用同一入口，避免多条链路各自维护保存逻辑。

### 3. 文档资产 manifest 与清理策略
- 使用 `knowledge_documents.metadata.extracted_assets` 记录当前文档生效的图片集合，字段包含：
  - `name`
  - `content_type`
  - `uri`
  - `source`
- 新一轮解析完成后，会用当前 manifest 覆盖旧 manifest，并按差集删除失效的旧 GCS 图片资产。
- 文档硬删除时，也会同步清理 manifest 中记录的图片资产，避免 GCS 孤儿文件累积。

### 4. 前端展示保持兼容
- 前端继续复用现有 `/documents/{documentId}/assets/{assetName}` 代理路由加载 Markdown 图片，不引入新的接口协议。
- 补充了 `DocumentMarkdownRenderer` 单测，验证：
  - `./images/foo.png`、`../assets/foo.png`、`foo.png` 均能映射到同一 asset proxy 规则；
  - 绝对 URL 图片不会被错误代理。

## 验证
已执行：
- `uv run pytest --no-cov tests/unit_tests/knowledge/test_extraction_image_assets.py tests/unit_tests/knowledge/test_extraction_provider.py tests/unit_tests/knowledge/test_api_documents.py`
- `pnpm exec vitest run tests/unit/knowledge/DocumentMarkdownRenderer.test.tsx`

结果：
- 后端定向单测通过：`91 passed`
- 前端新增渲染用例通过：`2 passed`

补充说明：
- 为运行前端新增用例，执行过一次 `pnpm install --frozen-lockfile`。
- 通跑 `pnpm test` 时命中过一个与本次改动无关的既有失败：`tests/unit/plugins/SubAgentsLayout.test.tsx`。
