### PR TITLE
feat(Knowledge): 修复 MCP 工具调用超时并实现 Pipeline 准实时进度追踪

### DIFF
--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
-const RUNNING_POLL_INTERVAL_MS = 3000;
+const RUNNING_POLL_INTERVAL_MS = 5000;
 const BOOTSTRAP_POLL_INTERVAL_MS = 1000;
 const BOOTSTRAP_POLL_MAX_TICKS = 8;
 

--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunDetailPanel.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunDetailPanel.tsx
@@ -48,33 +48,58 @@ export function PipelineRunDetailPanel({ run }: { run: PipelineRunRecord }) {
           <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">Stages</p>
           <div className="mt-2 space-y-2">
             {getSortedStages(run.stages).map(([stageName, stage]) => (
-              <div key={stageName} className="flex min-w-0 items-center gap-2 text-[11px]">
-                <span className={`h-2 w-2 shrink-0 rounded-full ${getStageColor(stageName, stage.status)}`} />
-                <span className="min-w-0 truncate font-medium text-zinc-700 dark:text-zinc-300">
-                  {STAGE_LABELS[stageName] || stageName}
-                </span>
-                <span className="shrink-0 uppercase text-zinc-400">
-                  {stage.status || "unknown"}
-                </span>
-                <span className="shrink-0 text-zinc-400">
-                  {stage.duration_ms ? `${stage.duration_ms}ms` : "-"}
-                </span>
-                {stage.status === "skipped" && stage.reason && (
-                  <span className="truncate text-zinc-400 italic">({stage.reason})</span>
-                )}
-                {stage.error && (
-                  <span className="truncate max-w-[120px] text-rose-500">
-                    {getStageErrorSummary(stage.error)}
+              <div key={stageName}>
+                <div className="flex min-w-0 items-center gap-2 text-[11px]">
+                  <span className={`h-2 w-2 shrink-0 rounded-full ${getStageColor(stageName, stage.status)}`} />
+                  <span className="min-w-0 truncate font-medium text-zinc-700 dark:text-zinc-300">
+                    {STAGE_LABELS[stageName] || stageName}
                   </span>
-                )}
-                {stage.output && (
-                  <span className="truncate max-w-[120px] text-emerald-600 dark:text-emerald-400">
-                    {typeof stage.output === "object" && stage.output !== null && "chunk_count" in stage.output
-                      ? `${(stage.output as { chunk_count?: unknown }).chunk_count} chunks`
-                      : typeof stage.output === "object" && stage.output !== null && "record_count" in stage.output
-                        ? `${(stage.output as { record_count?: unknown }).record_count} records`
-                        : ""}
+                  <span className="shrink-0 uppercase text-zinc-400">
+                    {stage.status || "unknown"}
                   </span>
+                  <span className="shrink-0 text-zinc-400">
+                    {stage.duration_ms ? `${stage.duration_ms}ms` : "-"}
+                  </span>
+                  {stage.status === "skipped" && stage.reason && (
+                    <span className="truncate text-zinc-400 italic">({stage.reason})</span>
+                  )}
+                  {stage.error && (
+                    <span className="truncate max-w-[120px] text-rose-500">
+                      {getStageErrorSummary(stage.error)}
+                    </span>
+                  )}
+                  {stage.output && (
+                    <span className="truncate max-w-[120px] text-emerald-600 dark:text-emerald-400">
+                      {typeof stage.output === "object" && stage.output !== null && "chunk_count" in stage.output
+                        ? `${(stage.output as { chunk_count?: unknown }).chunk_count} chunks`
+                        : typeof stage.output === "object" && stage.output !== null && "record_count" in stage.output
+                          ? `${(stage.output as { record_count?: unknown }).record_count} records`
+                          : ""}
+                    </span>
+                  )}
+                </div>
+                {stage.mcp_events && stage.mcp_events.length > 0 && (
+                  <div className="ml-4 mt-1 space-y-0.5">
+                    {stage.mcp_events
+                      .filter((evt) => evt.stage !== "stderr")
+                      .map((evt, i) => (
+                        <div key={i} className="flex items-center gap-1.5 text-[10px] text-zinc-400 dark:text-zinc-500">
+                          <span
+                            className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                              evt.status === "completed"
+                                ? "bg-emerald-400"
+                                : evt.status === "running"
+                                  ? "bg-amber-400 animate-pulse"
+                                  : evt.status === "failed"
+                                    ? "bg-rose-400"
+                                    : "bg-zinc-300 dark:bg-zinc-600"
+                            }`}
+                          />
+                          <span className="truncate">{evt.title}</span>
+                          <span className="shrink-0 text-zinc-300 dark:text-zinc-600">{evt.status}</span>
+                        </div>
+                      ))}
+                  </div>
                 )}
               </div>
             ))}

--- a/apps/negentropy-ui/features/knowledge/components/PipelineStagesBar.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineStagesBar.tsx
@@ -69,6 +69,14 @@ export function PipelineStagesBar({
             {stage.status === "skipped" && stage.reason && (
               <div className="mt-0.5 italic text-zinc-400">{stage.reason}</div>
             )}
+            {stage.mcp_events && stage.mcp_events.length > 0 && (() => {
+              const lastEvent = stage.mcp_events.filter((e) => e.stage !== "stderr").at(-1);
+              return lastEvent ? (
+                <div className="mt-0.5 text-amber-300">
+                  {lastEvent.title} · {lastEvent.status}
+                </div>
+              ) : null;
+            })()}
           </div>
         </div>
       ))}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -113,6 +113,7 @@ export type {
   KnowledgePipelinesPayload,
   PipelineRunRecord,
   PipelineStageResult,
+  McpStageEvent,
   PipelineStageStatus,
   PipelineOperation,
   IngestResult,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -691,6 +691,16 @@ export interface PipelineErrorPayload extends Record<string, unknown> {
   diagnostics?: Record<string, unknown>;
 }
 
+// MCP 工具调用子事件
+export interface McpStageEvent {
+  stage: string;
+  status: string;
+  title: string;
+  timestamp: string;
+  payload?: Record<string, unknown>;
+  detail?: string;
+}
+
 // Pipeline 阶段结果
 export interface PipelineStageResult {
   status: PipelineStageStatus;
@@ -700,6 +710,7 @@ export interface PipelineStageResult {
   error?: PipelineErrorPayload;
   output?: Record<string, unknown>;
   reason?: string; // for skipped status
+  mcp_events?: McpStageEvent[];
 }
 
 // Pipeline Run 记录

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -33,10 +33,12 @@ class DefaultExtractorRoutesSettings(BaseModel):
             primary=DefaultExtractorTargetSettings(
                 server_name="data-extractor",
                 tool_name="convert_webpage_to_markdown",
+                timeout_ms=60_000,
             ),
             secondary=DefaultExtractorTargetSettings(
                 server_name="data-extractor",
                 tool_name="batch_convert_webpages_to_markdown",
+                timeout_ms=120_000,
             ),
         )
     )
@@ -45,10 +47,12 @@ class DefaultExtractorRoutesSettings(BaseModel):
             primary=DefaultExtractorTargetSettings(
                 server_name="data-extractor",
                 tool_name="convert_pdf_to_markdown",
+                timeout_ms=300_000,
             ),
             secondary=DefaultExtractorTargetSettings(
                 server_name="data-extractor",
                 tool_name="batch_convert_pdfs_to_markdown",
+                timeout_ms=600_000,
             ),
         )
     )

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -1745,6 +1745,8 @@ class DataExtractorProvider:
                 content=content,
                 filename=filename,
                 content_type=content_type,
+                tracker=tracker,
+                stage_name=stage_name,
             )
             attempts.append(attempt["attempt"])
 
@@ -1808,6 +1810,8 @@ class DataExtractorProvider:
         content: bytes | None,
         filename: str | None,
         content_type: str | None,
+        tracker: Any | None = None,
+        stage_name: str | None = None,
     ) -> dict[str, Any]:
         tool: McpTool | None = None
         discovered_tool: Any | None = None
@@ -1992,6 +1996,8 @@ class DataExtractorProvider:
                     server=server,
                     target=target,
                     plan=plan,
+                    tracker=tracker,
+                    stage_name=stage_name,
                 )
                 invocation_trace.append(
                     {
@@ -2066,7 +2072,13 @@ class DataExtractorProvider:
         server: McpServer,
         target: McpToolTarget,
         plan: AdaptiveToolInvocationPlan,
+        tracker: Any | None = None,
+        stage_name: str | None = None,
     ) -> Any:
+        event_sink = None
+        if tracker and stage_name:
+            event_sink = tracker.create_stage_event_sink(stage_name)
+
         async with AsyncSessionLocal() as db:
             service = McpToolExecutionService(db, client=self._client)
             execution = await service.execute_tool(
@@ -2076,6 +2088,7 @@ class DataExtractorProvider:
                 arguments=plan.arguments,
                 origin=RUN_ORIGIN_KNOWLEDGE_EXTRACTION,
                 timeout_seconds=(target.timeout_ms / 1000.0) if target.timeout_ms else None,
+                external_event_sink=event_sink,
             )
             return execution.call_result
 

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -185,6 +185,7 @@ class PipelineTracker:
         now = datetime.now(timezone.utc).isoformat()
         stage_data = self._stages.get(stage, {})
         started_at = stage_data.get("started_at")
+        existing_mcp_events = stage_data.get("mcp_events")
 
         self._stages[stage] = {
             "status": "completed",
@@ -193,6 +194,8 @@ class PipelineTracker:
             "duration_ms": self._calculate_duration_ms(started_at, now),
             "output": self._normalize_dict_payload(output),
         }
+        if existing_mcp_events:
+            self._stages[stage]["mcp_events"] = existing_mcp_events
         self._current_stage = None
         await self._persist()
         self._log_stage_event(
@@ -226,6 +229,7 @@ class PipelineTracker:
         if target_stage:
             stage_data = self._stages.get(target_stage, {})
             stage_started_at = stage_data.get("started_at")
+            existing_mcp_events = stage_data.get("mcp_events")
             self._stages[target_stage] = {
                 "status": "failed",
                 "started_at": stage_started_at,
@@ -233,6 +237,8 @@ class PipelineTracker:
                 "duration_ms": self._calculate_duration_ms(stage_started_at, now),
                 "error": error,
             }
+            if existing_mcp_events:
+                self._stages[target_stage]["mcp_events"] = existing_mcp_events
 
         self._status = "failed"
         self._error = error
@@ -259,6 +265,47 @@ class PipelineTracker:
                 "error": error,
             },
         )
+
+    _MAX_STDERR_EVENTS = 5
+    _PERSIST_WORTHY_STAGES = frozenset({"transport_connect", "session_initialized"})
+
+    def buffer_stage_event(self, stage: str, event: Dict[str, Any]) -> None:
+        """同步地将 MCP 子事件缓存到当前 stage 的内存数据中（不触发 DB 写入）。"""
+        stage_data = self._stages.get(stage)
+        if not stage_data:
+            return
+        if "mcp_events" not in stage_data:
+            stage_data["mcp_events"] = []
+
+        mcp_events = stage_data["mcp_events"]
+
+        if event.get("stage") == "stderr":
+            stderr_count = sum(1 for e in mcp_events if e.get("stage") == "stderr")
+            if stderr_count >= self._MAX_STDERR_EVENTS:
+                for i, e in enumerate(mcp_events):
+                    if e.get("stage") == "stderr":
+                        mcp_events.pop(i)
+                        break
+
+        mcp_events.append({
+            **event,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
+
+    def create_stage_event_sink(self, stage: str) -> Callable[[Dict[str, Any]], None]:
+        """工厂方法：创建同步事件回调，对关键事件触发非阻塞 persist。"""
+        import asyncio
+
+        def sink(event: Dict[str, Any]) -> None:
+            self.buffer_stage_event(stage, event)
+            if event.get("stage") in self._PERSIST_WORTHY_STAGES:
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(self._persist())
+                except RuntimeError:
+                    pass
+
+        return sink
 
     async def skip_stage(self, stage: str, reason: Optional[str] = None) -> None:
         """跳过阶段执行"""

--- a/apps/negentropy/src/negentropy/plugins/execution.py
+++ b/apps/negentropy/src/negentropy/plugins/execution.py
@@ -5,7 +5,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from uuid import UUID
 
 from sqlalchemy import select
@@ -87,6 +87,7 @@ class McpToolExecutionService:
         asset_refs: dict[str, Any] | None = None,
         origin: str = RUN_ORIGIN_TRIAL_UI,
         timeout_seconds: float | None = None,
+        external_event_sink: Callable[[dict[str, Any]], None] | None = None,
     ) -> ExecutionResult:
         tool = await self._db.scalar(
             select(McpTool).where(McpTool.server_id == server.id, McpTool.name == tool_name)
@@ -177,6 +178,8 @@ class McpToolExecutionService:
                 payload=_json_safe(event.get("payload") or {}),
                 duration_ms=int(event.get("duration_ms") or 0),
             )
+            if external_event_sink:
+                external_event_sink(event)
 
         def handle_stderr(message: str) -> None:
             stderr_lines.append(message)


### PR DESCRIPTION
## 问题背景

Knowledge / Base 页对 Document 执行「Rebuild」操作时，后端调用 MCP 工具 `convert_pdf_to_markdown` 进行 PDF→Markdown 转换。该操作耗时远超 30 秒，但 MCP 客户端全局默认超时为 30s（`DEFAULT_TIMEOUT_SECONDS = 30`），且 `file_pdf` 路由未配置 `timeout_ms` 覆盖值，导致 `asyncio.timeout(30)` 触发超时失败。

同时，Dashboard 虽已有 3s 轮询机制，但 Pipeline 提取阶段仅展示开始/结束两个状态——对于持续数分钟的 MCP 调用，用户在等待期间看不到任何中间进度信号。

## 变更概览

分三个 Phase 实施：

### Phase 1：超时修复（后端配置 1 文件）

- 为 `file_pdf` 路由配置默认 `timeout_ms`：primary 300s、secondary 600s
- 为 `url` 路由配置默认 `timeout_ms`：primary 60s、secondary 120s
- 仅影响新建 corpus 或未配置 `extractor_routes` 的 corpus

### Phase 2：MCP 事件桥接到 PipelineTracker（后端 3 文件）

- `PipelineTracker` 新增 `buffer_stage_event()` / `create_stage_event_sink()` 方法，将 MCP 子事件（如 `transport_connect`、`session_initialized`）同步缓存到 stage 内存数据
- `execution.py` 的 `execute_tool` 新增 `external_event_sink` 参数，转发 MCP 客户端事件
- `extraction.py` 桥接 tracker 与 event sink，使提取阶段的 MCP 事件流入 Pipeline 持久化
- 对 `complete_stage` / `fail` 方法增加 `mcp_events` 保留逻辑，防止 stage dict 替换时丢失已缓存事件
- 每个 MCP 调用最多额外 2 次 DB 写入（`transport_connect` + `session_initialized`）

### Phase 3：Dashboard 轮询 + 子事件渲染（前端 4 文件）

- 轮询间隔 3s → 5s
- 新增 `McpStageEvent` 类型定义，扩展 `PipelineStageResult`
- `PipelineRunDetailPanel` Stages 区域展示 MCP 子事件时间线（状态圆点 + 标题 + 状态）
- `PipelineStagesBar` tooltip 增加最新 MCP 事件标题展示

## 改动文件

| 文件 | 角色 |
|------|------|
| `config/knowledge.py` | 超时默认值配置 |
| `knowledge/service.py` | PipelineTracker 扩展 |
| `plugins/execution.py` | execute_tool 事件转发 |
| `knowledge/extraction.py` | 事件桥接 |
| `app/knowledge/dashboard/page.tsx` | 轮询间隔调整 |
| `features/knowledge/utils/knowledge-api.ts` | McpStageEvent 类型 |
| `features/knowledge/components/PipelineRunDetailPanel.tsx` | 子事件渲染 |
| `features/knowledge/components/PipelineStagesBar.tsx` | Tooltip 增强 |

## 验证

- 后端 307 项测试全部通过
- 超时传播链路已验证：`config → extraction → execution → mcp_client`