### PR TITLE
fix(KnowledgeBase): 消除 Rebuild 操作导致的文档列表 Loading 闪烁，新增文档状态徽章

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -45,6 +45,7 @@ import {
   normalizeChunkingConfig,
   encodeSeparatorsForDisplay,
   decodeSeparatorsFromInput,
+  PipelineStatusBadge,
 } from "@/features/knowledge";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
@@ -551,6 +552,7 @@ export default function KnowledgeBasePage() {
 
   const [documents, setDocuments] = useState<KnowledgeDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
+  const [buildingDocIds, setBuildingDocIds] = useState<Set<string>>(new Set());
 
   const [documentChunks, setDocumentChunks] = useState<DocumentChunkItem[]>([]);
   const [documentChunksMetadata, setDocumentChunksMetadata] = useState<DocumentChunksMetadata>({});
@@ -654,6 +656,15 @@ export default function KnowledgeBasePage() {
     } finally {
       setDocumentsLoading(false);
     }
+  }, [selectedCorpusId]);
+
+  /** 静默刷新：更新文档列表但不显示 Loading 状态 */
+  const silentLoadDocuments = useCallback(async () => {
+    if (!selectedCorpusId) return;
+    try {
+      const res = await fetchDocuments(selectedCorpusId, { appName: APP_NAME, limit: 100, offset: 0 });
+      setDocuments(res.items);
+    } catch { /* 静默刷新失败不阻断 */ }
   }, [selectedCorpusId]);
 
   useEffect(() => {
@@ -932,18 +943,39 @@ export default function KnowledgeBasePage() {
     doc: KnowledgeDocument,
   ) => {
     if (!selectedCorpusId) return;
+
+    // rebuild / sync: 乐观更新 + 静默刷新，避免列表闪烁
+    if (action === "rebuild" || action === "sync") {
+      setBuildingDocIds((prev) => new Set(prev).add(doc.id));
+      toast.info(`正在${action === "rebuild" ? "重建" : "同步"}「${doc.original_filename}」…`);
+      try {
+        if (action === "rebuild") {
+          await rebuildDocument(selectedCorpusId, doc.id, {
+            app_name: APP_NAME,
+            ...corpusChunkingConfig,
+          });
+        } else {
+          await syncDocument(selectedCorpusId, doc.id, {
+            app_name: APP_NAME,
+            ...corpusChunkingConfig,
+          });
+        }
+        toast.success(`${action === "rebuild" ? "重建" : "同步"}已启动「${doc.original_filename}」`);
+        await silentLoadDocuments();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : `${action} failed`);
+      } finally {
+        setBuildingDocIds((prev) => {
+          const next = new Set(prev);
+          next.delete(doc.id);
+          return next;
+        });
+      }
+      return;
+    }
+
     try {
-      if (action === "sync") {
-        await syncDocument(selectedCorpusId, doc.id, {
-          app_name: APP_NAME,
-          ...corpusChunkingConfig,
-        });
-      } else if (action === "rebuild") {
-        await rebuildDocument(selectedCorpusId, doc.id, {
-          app_name: APP_NAME,
-          ...corpusChunkingConfig,
-        });
-      } else if (action === "archive") {
+      if (action === "archive") {
         await archiveDocument(selectedCorpusId, doc.id, { app_name: APP_NAME });
       } else if (action === "unarchive") {
         await unarchiveDocument(selectedCorpusId, doc.id, { app_name: APP_NAME });
@@ -1328,7 +1360,16 @@ export default function KnowledgeBasePage() {
                                 onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id })}
                               >
                                 <p className="truncate text-sm font-medium">{doc.original_filename}</p>
-                                <p className="text-[11px] text-muted">{sourceType} · {doc.status} · {doc.file_size} bytes</p>
+                                <div className="flex items-center gap-1.5 text-[11px] text-muted">
+                                  <span>{sourceType} · {doc.file_size} bytes</span>
+                                  <PipelineStatusBadge
+                                    status={
+                                      buildingDocIds.has(doc.id)
+                                        ? "processing"
+                                        : doc.markdown_extract_status || doc.status
+                                    }
+                                  />
+                                </div>
                               </button>
                               <div className="flex flex-wrap items-center justify-end gap-1">
                                 <button onClick={() => runDocumentAction("view", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>View</button>

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -318,10 +318,13 @@ export const getPipelineStatusColor = (status?: string): string => {
       return "bg-emerald-500";
     case "running":
     case "in_progress":
+    case "processing":
       return "bg-amber-500 animate-pulse";
     case "failed":
     case "error":
       return "bg-rose-500";
+    case "pending":
+      return "bg-zinc-400 animate-pulse";
     case "skipped":
       return "bg-zinc-300 dark:bg-zinc-600";
     default:
@@ -341,10 +344,13 @@ export const getPipelineStatusTextColor = (status?: string): string => {
       return "text-emerald-600 dark:text-emerald-400";
     case "running":
     case "in_progress":
+    case "processing":
       return "text-amber-600 dark:text-amber-400";
     case "failed":
     case "error":
       return "text-rose-600 dark:text-rose-400";
+    case "pending":
+      return "text-zinc-600 dark:text-zinc-400";
     default:
       return "text-zinc-500 dark:text-zinc-400";
   }


### PR DESCRIPTION
## 问题背景

在 Knowledge Base 页面的 Corpus Documents 列表中，点击某文档的「Rebuild」按钮后，`runDocumentAction` 调用 `loadDocuments()` 会置 `documentsLoading = true`，导致整个文档列表被替换为 "Loading..." 文本，产生视觉闪烁。

## 变更内容

采用 **乐观更新 (Optimistic UI)** + **静默刷新 (Silent Refresh)** 模式，修改 2 个文件，无新文件、无新依赖。

### `pipeline-helpers.ts` — 扩展状态颜色映射

- 在 `getPipelineStatusColor` 和 `getPipelineStatusTextColor` 中新增 `processing`（amber 脉冲）和 `pending`（zinc 脉冲）分支
- 使 `PipelineStatusBadge` 能正确渲染文档的 `markdown_extract_status` 值

### `page.tsx` — 主页面改造

- **新增 `buildingDocIds` 状态**：`Set<string>` 跟踪正在构建的文档 ID
- **新增 `silentLoadDocuments`**：仅更新文档数据不切换 Loading 状态，杜绝列表闪烁
- **改造 `runDocumentAction`**：`rebuild`/`sync` 操作改为乐观更新模式——立即标记构建状态 + 弹出 Toast + 调用 API + 静默刷新
- **文档卡片新增 `PipelineStatusBadge`**：优先展示 `buildingDocIds` 乐观状态，其次取 `markdown_extract_status`，兜底取 `doc.status`

## 验证

- [x] `pnpm build` 编译通过
- [x] `vitest run` 全部 363 个测试用例通过（65 个文件）
- [ ] 手动验证：点击 Rebuild → 列表不闪烁 → Toast 弹出 → 状态徽章显示 amber 脉冲

🤖 Generated with [Claude Code](https://github.com/claude)