### PR TITLE
feat(Markdown): 为全站 Markdown 渲染添加 LaTeX 数学公式支持

### DIFF
--- a/apps/negentropy-ui/app/globals.css
+++ b/apps/negentropy-ui/app/globals.css
@@ -161,3 +161,21 @@ body {
     opacity: 1;
   }
 }
+
+/*
+ * KaTeX 暗色模式适配
+ * KaTeX 大部分元素通过 color: currentColor 自动继承文字颜色，
+ * 但部分装饰性元素（分数线、根号等）需要额外覆盖。
+ */
+.dark .katex .vlist-t2 > .vlist-r > .vlist > .vlist-s,
+.dark .katex .frac-line,
+.dark .katex .overline .overline-line,
+.dark .katex .underline .underline-line,
+.dark .katex .sqrt > .sqrt-line,
+.dark .katex .hline {
+  border-color: currentColor;
+}
+
+.dark .katex .sqrt > .root {
+  color: currentColor;
+}

--- a/apps/negentropy-ui/app/knowledge/base/_components/ReplaceDocumentDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ReplaceDocumentDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { KnowledgeDocument, fetchDocumentDetail } from "@/features/knowledge";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
@@ -149,7 +149,7 @@ export function ReplaceDocumentDialog({
             <div className="h-full min-h-0 overflow-auto rounded-lg bg-zinc-50 p-3 text-xs dark:bg-zinc-950">
               {text.trim() ? (
                 <div className="prose prose-sm max-w-none dark:prose-invert prose-pre:text-xs prose-code:text-xs">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+                  <ReactMarkdown remarkPlugins={defaultRemarkPlugins} rehypePlugins={defaultRehypePlugins}>{text}</ReactMarkdown>
                 </div>
               ) : (
                 <p className="text-zinc-500 dark:text-zinc-400">暂无可预览内容</p>

--- a/apps/negentropy-ui/app/layout.tsx
+++ b/apps/negentropy-ui/app/layout.tsx
@@ -7,6 +7,7 @@ import { NavigationProvider } from "@/components/providers/NavigationProvider";
 import { SiteHeader } from "@/components/layout/SiteHeader";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import "./globals.css";
+import "katex/dist/katex.min.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",

--- a/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/plugins/mcp/_components/McpServerCard.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { JsonViewer } from "@/components/ui/JsonViewer";
 
 const MARKDOWN_CONTENT_CLASS = [
@@ -326,7 +326,7 @@ function RichTextContent({
 
   return (
     <div className={`${MARKDOWN_CONTENT_CLASS} text-zinc-600 dark:text-zinc-300`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{parsed.value}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={defaultRemarkPlugins} rehypePlugins={defaultRehypePlugins}>{parsed.value}</ReactMarkdown>
     </div>
   );
 }

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/components/providers/AuthProvider";
 import { cn } from "@/lib/utils";
 import type { ChatMessage } from "@/types/common";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { getStreamingMarkdownSegments } from "@/utils/streaming-markdown";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { UserAvatar } from "./UserAvatar";
@@ -229,7 +229,8 @@ export function MarkdownContent({
   const segments = getStreamingMarkdownSegments(content, isStreaming);
   const renderMarkdown = (value: string) => (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={defaultRemarkPlugins}
+      rehypePlugins={defaultRehypePlugins}
       components={{
         code({ className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || "");

--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { cn } from "@/lib/utils";
 import { MermaidDiagram } from "@/components/ui/MermaidDiagram";
 
@@ -87,7 +87,8 @@ export function DocumentMarkdownRenderer({
       )}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={defaultRemarkPlugins}
+        rehypePlugins={defaultRehypePlugins}
         components={{
           img({ src, alt, ...props }) {
             if (!src || typeof src !== "string") return null;

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -24,6 +24,7 @@
     "d3-force": "^3.0.0",
     "d3-selection": "^3.0.0",
     "d3-zoom": "^3.0.0",
+    "katex": "^0.16.33",
     "lucide-react": "^0.525.0",
     "mermaid": "^11.12.2",
     "micromark": "^4.0.0",
@@ -33,7 +34,9 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "rxjs": "7.8.1",
     "sonner": "^2.0.7",
     "zod": "3.24.4"

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       d3-zoom:
         specifier: ^3.0.0
         version: 3.0.0
+      katex:
+        specifier: ^0.16.33
+        version: 0.16.33
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.2.3)
@@ -65,9 +68,15 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.3)
+      rehype-katex:
+        specifier: ^7.0.1
+        version: 7.0.1
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
       rxjs:
         specifier: 7.8.1
         version: 7.8.1

--- a/apps/negentropy-ui/tests/unit/knowledge/DocumentMarkdownRenderer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DocumentMarkdownRenderer.test.tsx
@@ -38,4 +38,43 @@ describe("DocumentMarkdownRenderer", () => {
 
     expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/image.png");
   });
+
+  it("渲染行内数学公式 $...$ 为 KaTeX 输出", () => {
+    const { container } = render(
+      <DocumentMarkdownRenderer
+        content={"质能方程 $E=mc^2$ 是物理学基础公式。"}
+        corpusId="corpus-1"
+        documentId="document-1"
+      />,
+    );
+
+    const katexElements = container.querySelectorAll(".katex");
+    expect(katexElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("渲染显示数学公式 $$...$$ 为独立 KaTeX 块", () => {
+    const { container } = render(
+      <DocumentMarkdownRenderer
+        content={"下面是公式：\n\n$$\n\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}\n$$"}
+        corpusId="corpus-1"
+        documentId="document-1"
+      />,
+    );
+
+    const katexDisplay = container.querySelectorAll(".katex-display");
+    expect(katexDisplay.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("GFM 表格中嵌入行内公式时表格和公式均正常渲染", () => {
+    const { container } = render(
+      <DocumentMarkdownRenderer
+        content={"| 公式 | 值 |\n| --- | --- |\n| $E=mc^2$ | 质能等价 |"}
+        corpusId="corpus-1"
+        documentId="document-1"
+      />,
+    );
+
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.querySelectorAll(".katex").length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
@@ -85,6 +85,31 @@ describe("MessageBubble", () => {
     expect(screen.getByText("const answer = 42;").closest("pre")).not.toBeNull();
   });
 
+  it("聊天消息中的行内数学公式被正确渲染", () => {
+    const { container } = render(
+      <MessageBubble
+        message={{ id: "a-math", role: "assistant", content: "根据 $E=mc^2$，能量与质量等价。" }}
+      />,
+    );
+
+    expect(container.querySelectorAll(".katex").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("流式消息中包含数学公式时不崩溃", () => {
+    const { container } = render(
+      <MessageBubble
+        message={{
+          id: "a-math-stream",
+          role: "assistant",
+          content: "计算结果：$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$",
+          streaming: true,
+        }}
+      />,
+    );
+
+    expect(container).toBeTruthy();
+  });
+
   it("流式回复中的未闭合表格尾部会降级为安全文本，完成后恢复为表格", () => {
     const { rerender, container } = render(
       <MessageBubble

--- a/apps/negentropy-ui/utils/markdown-plugins.ts
+++ b/apps/negentropy-ui/utils/markdown-plugins.ts
@@ -1,0 +1,15 @@
+/**
+ * react-markdown 共享插件配置
+ *
+ * 集中管理 remark/rehype 插件链，确保所有 Markdown 渲染站点
+ * 具备一致的解析能力（GFM + LaTeX 数学公式）。
+ */
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+
+/** remark 插件链：GFM 扩展 + 数学公式语法解析 */
+export const defaultRemarkPlugins = [remarkGfm, remarkMath];
+
+/** rehype 插件链：KaTeX 渲染 */
+export const defaultRehypePlugins = [rehypeKatex];


### PR DESCRIPTION
## 背景

Knowledge / Documents 页的文档预览模态框无法渲染 LaTeX 数学公式，`$$...$$` 和 `$...$` 语法以原始字符显示，未被渲染为数学公式效果。

根因：项目仅使用 `react-markdown` + `remark-gfm`，缺少数学公式解析（`remark-math`）和渲染（`rehype-katex` / KaTeX）的依赖。

## 变更内容

### 新增依赖
- `remark-math@^6.0.0` — remark 插件，解析 `$...$`（行内）和 `$$...$$`（显示）语法为 AST math 节点
- `rehype-katex@^7.0.1` — rehype 插件，将 math 节点渲染为 KaTeX HTML
- `katex@^0.16.33` — KaTeX 核心库 + CSS 样式表

### 新建共享插件配置
- `utils/markdown-plugins.ts` — 集中管理 remark/rehype 插件链，确保全站 4 处 Markdown 渲染站点具备一致的解析能力

### 全局样式
- `layout.tsx` 中全局导入 `katex/dist/katex.min.css`
- `globals.css` 中添加 KaTeX 暗色模式适配覆盖规则（分数线、根号等装饰性元素的 `border-color` 继承）

### 统一更新 4 处 ReactMarkdown 站点
1. `DocumentMarkdownRenderer.tsx` — 知识库文档预览（含图片代理、Mermaid）
2. `MessageBubble.tsx` → `MarkdownContent` — 聊天消息渲染（含流式、Mermaid、CopyButton）
3. `ReplaceDocumentDialog.tsx` — 文档替换预览
4. `McpServerCard.tsx` → `RichTextContent` — MCP 服务器描述

### 测试补充
- `DocumentMarkdownRenderer.test.tsx` — 行内公式、显示公式、GFM 表格嵌入公式 3 个用例
- `MessageBubble.test.tsx` — 聊天消息行内公式渲染、流式消息公式兼容性 2 个用例

## 验证结果

- ✅ `pnpm typecheck` 通过
- ✅ `pnpm lint` 通过（0 warnings）
- ✅ `pnpm test` 通过（65 文件 / 368 用例）
- ✅ `pnpm build` 构建成功

---

🤖 Generated with [Claude Code](https://github.com/claude)