### PR TITLE
feat(PipelineRuns): 为 Dashboard 页 Pipeline Runs 列表添加分页功能

### DIFF
--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+const PAGE_SIZE = 10;
 const RUNNING_POLL_INTERVAL_MS = 5000;
 const BOOTSTRAP_POLL_INTERVAL_MS = 1000;
 const BOOTSTRAP_POLL_MAX_TICKS = 8;
@@ -65,9 +66,12 @@ export default function KnowledgeDashboardPage() {
   const [saveStatus, setSaveStatus] = useState<string | null>(null);
   const [retryQueue, setRetryQueue] = useState<PipelineRunRecord[]>([]);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
 
   const applyPipelinesPayload = useCallback((data: KnowledgePipelinesPayload) => {
     setPipelinesPayload(data);
+    setTotal(data.count ?? data.runs?.length ?? 0);
     setError(null);
     setSelected((prev) => {
       if (!data.runs?.length) return null;
@@ -77,11 +81,15 @@ export default function KnowledgeDashboardPage() {
     });
   }, []);
 
-  const loadPipelines = useCallback(async () => {
-    const data = await fetchPipelines(APP_NAME);
+  const loadPipelines = useCallback(async (overridePage?: number) => {
+    const p = overridePage ?? page;
+    const data = await fetchPipelines(APP_NAME, {
+      limit: PAGE_SIZE,
+      offset: (p - 1) * PAGE_SIZE,
+    });
     applyPipelinesPayload(data);
     return data;
-  }, [applyPipelinesPayload]);
+  }, [applyPipelinesPayload, page]);
 
   useEffect(() => {
     let active = true;
@@ -89,7 +97,10 @@ export default function KnowledgeDashboardPage() {
       try {
         const [dashData, pipeData] = await Promise.all([
           fetchDashboard(APP_NAME),
-          fetchPipelines(APP_NAME),
+          fetchPipelines(APP_NAME, {
+            limit: PAGE_SIZE,
+            offset: (page - 1) * PAGE_SIZE,
+          }),
         ]);
         if (!active) return;
         setDashboardData(dashData);
@@ -104,10 +115,11 @@ export default function KnowledgeDashboardPage() {
     return () => {
       active = false;
     };
-  }, [applyPipelinesPayload]);
+  }, [applyPipelinesPayload, page]);
 
   useEffect(() => {
     if (!hasInitialLoad) return;
+    if (page !== 1) return;
     if (hasRunningRuns(pipelinesPayload?.runs)) return;
 
     let active = true;
@@ -117,7 +129,10 @@ export default function KnowledgeDashboardPage() {
     const intervalId = setInterval(async () => {
       tick += 1;
       try {
-        const data = await fetchPipelines(APP_NAME);
+        const data = await fetchPipelines(APP_NAME, {
+          limit: PAGE_SIZE,
+          offset: 0,
+        });
         if (!active) return;
 
         const nextSnapshot = createRunsSnapshot(data.runs);
@@ -143,13 +158,14 @@ export default function KnowledgeDashboardPage() {
       active = false;
       clearInterval(intervalId);
     };
-  }, [applyPipelinesPayload, hasInitialLoad, pipelinesPayload?.runs]);
+  }, [applyPipelinesPayload, hasInitialLoad, pipelinesPayload?.runs, page]);
 
   useEffect(() => {
+    if (page !== 1) return;
     if (!hasRunningRuns(pipelinesPayload?.runs)) return;
 
     const intervalId = setInterval(() => {
-      loadPipelines().catch((err) => {
+      loadPipelines(1).catch((err) => {
         setError(String(err));
       });
     }, RUNNING_POLL_INTERVAL_MS);
@@ -157,7 +173,7 @@ export default function KnowledgeDashboardPage() {
     return () => {
       clearInterval(intervalId);
     };
-  }, [loadPipelines, pipelinesPayload?.runs]);
+  }, [loadPipelines, pipelinesPayload?.runs, page]);
 
   const metrics = useMemo(() => {
     if (!dashboardData) return [];
@@ -277,6 +293,32 @@ export default function KnowledgeDashboardPage() {
                   </div>
                 ) : (
                   <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">暂无作业</p>
+                )}
+                {total > 0 && (
+                  <div className="mt-4 flex items-center justify-between border-t border-zinc-200 pt-3 dark:border-zinc-800">
+                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {total} run{total !== 1 ? "s" : ""}
+                    </span>
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        onClick={() => setPage((p) => Math.max(1, p - 1))}
+                        disabled={page === 1}
+                        className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                      >
+                        Previous
+                      </button>
+                      <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                        Page {page} / {Math.ceil(total / PAGE_SIZE) || 1}
+                      </span>
+                      <button
+                        onClick={() => setPage((p) => Math.min(Math.ceil(total / PAGE_SIZE), p + 1))}
+                        disabled={page >= Math.ceil(total / PAGE_SIZE)}
+                        className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
                 )}
               </div>
             </div>

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -732,6 +732,7 @@ export interface PipelineRunRecord {
 }
 
 export interface KnowledgePipelinesPayload {
+  count?: number;
   last_updated_at?: string;
   runs?: PipelineRunRecord[];
 }
@@ -2027,9 +2028,14 @@ export async function fetchGraphBuildHistory(
 
 export async function fetchPipelines(
   appName?: string,
+  options?: { limit?: number; offset?: number },
 ): Promise<KnowledgePipelinesPayload> {
-  const params = appName ? `?app_name=${encodeURIComponent(appName)}` : "";
-  const res = await fetch(`/api/knowledge/pipelines${params}`, {
+  const query = new URLSearchParams();
+  if (appName) query.set("app_name", appName);
+  if (options?.limit != null) query.set("limit", String(options.limit));
+  if (options?.offset != null) query.set("offset", String(options.offset));
+  const qs = query.toString();
+  const res = await fetch(`/api/knowledge/pipelines${qs ? `?${qs}` : ""}`, {
     cache: "no-store",
   });
   if (!res.ok) {

--- a/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
@@ -77,9 +77,10 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("在首屏无数据时，会通过兜底轮询自动显示新 Run", async () => {
     knowledgeMocks.fetchPipelinesMock
-      .mockResolvedValueOnce({ runs: [], last_updated_at: "t0" })
-      .mockResolvedValueOnce({ runs: [], last_updated_at: "t1" })
+      .mockResolvedValueOnce({ count: 0, runs: [], last_updated_at: "t0" })
+      .mockResolvedValueOnce({ count: 0, runs: [], last_updated_at: "t1" })
       .mockResolvedValueOnce({
+        count: 1,
         runs: [makeRun({ run_id: "run-new", id: "run-new-id" })],
         last_updated_at: "t2",
       });
@@ -100,6 +101,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("兜底轮询在达到 8 秒窗口后停止继续请求", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 0,
       runs: [],
       last_updated_at: "t0",
     });
@@ -124,6 +126,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("存在 running Run 时按 5 秒节奏轮询", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [makeRun({ status: "running" })],
       last_updated_at: "t0",
     });
@@ -141,6 +144,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("桌面端使用固定双栏 grid，并为长内容提供收敛样式", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -198,6 +202,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("失败的重建源 Run 会在卡片中显示开始与结束时间", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         makeRun({
           id: "run-failed-id",
@@ -222,6 +227,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("Runs 列表状态标签复用共享状态样式", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 3,
       runs: [
         makeRun({
           id: "run-running-id",
@@ -266,6 +272,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("Runs 阶段条复用共享 tooltip 内容，且不再被按钮容器裁剪", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -312,6 +319,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("详情区 Stages 使用与 Runs 一致的阶段颜色映射", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -356,6 +364,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("多 Stage 失败时，详情页 Errors 区域会同时展示所有阶段异常", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -398,6 +407,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("顶层错误与阶段错误重复时，Errors 区域不会重复展示运行级错误", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -434,6 +444,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("顶层错误与阶段错误不同步时，会同时展示运行级和阶段级错误", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -469,6 +480,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("即使缺少顶层 error，也会基于 stages 渲染 Errors 区域", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -500,6 +512,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("extract_gate 会按共享阶段语义显示，并渲染失败分类文案", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -540,6 +553,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("契约类失败会在 Errors 区展示受控诊断摘要", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -575,6 +589,7 @@ describe("KnowledgeDashboardPage polling", () => {
   });
   it("failure_category 存在时，阶段摘要与错误详情会展示归一化标签", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -610,6 +625,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("failure_category 缺失或为空时，不渲染空标签占位", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({
@@ -645,6 +661,7 @@ describe("KnowledgeDashboardPage polling", () => {
 
   it("未知契约类失败会展示诊断摘要，且空摘要不会泄漏为占位文本", async () => {
     knowledgeMocks.fetchPipelinesMock.mockResolvedValue({
+      count: 1,
       runs: [
         {
           ...makeRun({

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -2724,11 +2724,17 @@ async def upsert_graph(payload: GraphUpsertRequest) -> Dict[str, Any]:
 
 
 @router.get("/pipelines", response_model=KnowledgePipelinesResponse)
-async def get_pipelines(app_name: Optional[str] = Query(default=None)) -> KnowledgePipelinesResponse:
+async def get_pipelines(
+    app_name: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> KnowledgePipelinesResponse:
     resolved_app = _resolve_app_name(app_name)
     dao = _get_dao()
-    runs = await dao.list_pipeline_runs(resolved_app, limit=50)
+    total = await dao.count_pipeline_runs(resolved_app)
+    runs = await dao.list_pipeline_runs(resolved_app, limit=limit, offset=offset)
     return KnowledgePipelinesResponse(
+        count=total,
         runs=[
             PipelineRunRecordResponse(
                 id=str(run.id),

--- a/apps/negentropy/src/negentropy/knowledge/dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/dao.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
 from negentropy.db.session import AsyncSessionLocal
@@ -71,12 +71,23 @@ class KnowledgeRunDao:
             expected_version=expected_version,
         )
 
-    async def list_pipeline_runs(self, app_name: str, limit: int = 50) -> list[KnowledgePipelineRun]:
+    async def count_pipeline_runs(self, app_name: str) -> int:
+        async with self._session_factory() as db:
+            stmt = (
+                select(func.count())
+                .select_from(KnowledgePipelineRun)
+                .where(KnowledgePipelineRun.app_name == app_name)
+            )
+            result = await db.scalar(stmt)
+            return result or 0
+
+    async def list_pipeline_runs(self, app_name: str, limit: int = 50, offset: int = 0) -> list[KnowledgePipelineRun]:
         async with self._session_factory() as db:
             stmt = (
                 select(KnowledgePipelineRun)
                 .where(KnowledgePipelineRun.app_name == app_name)
                 .order_by(KnowledgePipelineRun.updated_at.desc())
+                .offset(offset)
                 .limit(limit)
             )
             result = await db.execute(stmt)

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -185,6 +185,7 @@ class PipelineRunRecordResponse(BaseModel):
 
 
 class KnowledgePipelinesResponse(BaseModel):
+    count: int = 0
     runs: list[PipelineRunRecordResponse] = Field(default_factory=list)
     last_updated_at: Optional[str] = None
 


### PR DESCRIPTION
## 概要

为 Knowledge Dashboard 页面的 Pipeline Runs 列表添加 offset-based 分页功能，初始加载 10 条记录，支持 Previous/Next 翻页浏览历史运行记录。

## 变更内容

- **DAO 层**：`list_pipeline_runs()` 新增 `offset` 参数；新增 `count_pipeline_runs()` 方法返回总数
- **Schema 层**：`KnowledgePipelinesResponse` 新增 `count` 字段（默认 0，向后兼容）
- **API 层**：`GET /knowledge/pipelines` 新增 `limit`/`offset` 查询参数
- **前端 API 客户端**：`fetchPipelines()` 支持传入 `{ limit, offset }` 选项
- **Dashboard 页面**：
  - 每页 10 条记录，底部显示 Previous/Next 分页控件
  - 仅在第 1 页时启用 Bootstrap 轮询与 Running 轮询，翻页后暂停轮询
  - 复用 Documents 页已有的分页样式与交互模式
- **单元测试**：所有 mock 返回值补充 `count` 字段，17 项测试全部通过

## 测试计划

- [x] `pnpm vitest run tests/unit/knowledge/DashboardPage.test.tsx` — 17/17 通过
- [ ] 手动验证：Dashboard 初始仅显示 10 条 Runs，翻页正常，第 1 页轮询正常、其余页轮询暂停

🤖 Generated with [Claude Code](https://claude.com/claude-code)