### PR TITLE
fix(CI): 修复 GitHub Actions 双 Workflow 全线失败

### DIFF
--- a/apps/negentropy-ui/tests/e2e/smoke.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/smoke.spec.ts
@@ -210,7 +210,7 @@ test("Knowledge Dashboard 状态标签视觉一致性", async ({ page }) => {
     });
   });
 
-  await page.route("**/api/knowledge/pipelines?app_name=negentropy", async (route) => {
+  await page.route(/\/api\/knowledge\/pipelines\?.*app_name=negentropy/, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/apps/negentropy/src/negentropy/db/migrations/versions/h2i3j4k5l6m7_add_lifecycle_and_kg_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/h2i3j4k5l6m7_add_lifecycle_and_kg_tables.py
@@ -338,7 +338,8 @@ def downgrade() -> None:
     # 5. 图谱增强
     op.drop_table("kg_entity_mentions", schema=schema)
     op.drop_table("kg_relations", schema=schema)
-    op.drop_index("ix_kg_entities_embedding", table_name="kg_entities", schema=schema)
+    # NOTE: ix_kg_entities_embedding 未在 upgrade() 中创建（embedding 列为 JSONB，
+    # 待 pgvector 就绪后由独立 migration 处理），故 downgrade 无需删除该索引。
     op.drop_index("ix_kg_entities_confidence", table_name="kg_entities", schema=schema)
     op.drop_index("ix_kg_entities_corpus_type", table_name="kg_entities", schema=schema)
     op.drop_table("kg_entities", schema=schema)

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -139,7 +139,7 @@ class KnowledgeDocument(Base, UUIDMixin, TimestampMixin):
 
     corpus: Mapped["Corpus"] = relationship(back_populates="documents")
     # Phase 2: 来源记录（反向关联）
-    source: Mapped["DocSource | None"] = relationship()
+    source: Mapped["DocSource | None"] = relationship(foreign_keys=[source_id])
 
 
 # =============================================================================
@@ -176,7 +176,9 @@ class DocSource(Base, UUIDMixin, TimestampMixin):
     # 原始元数据快照
     raw_metadata: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
 
-    document: Mapped["KnowledgeDocument"] = relationship(back_populates="source")
+    document: Mapped["KnowledgeDocument"] = relationship(
+        back_populates="source", foreign_keys=[document_id]
+    )
 
     __table_args__ = (
         Index("ix_doc_sources_document_id", "document_id"),


### PR DESCRIPTION
## 摘要

修复自 2026-04-06 起持续存在的 **Backend Test Suite** 与 **UI Test Suite** 双 Workflow 全线失败问题。

## 根因分析

### 问题 1: 后端集成测试全部 ERROR/FAILED [CRITICAL]

**错误信息**:
```
sqlalchemy.exc.InvalidRequestError: One or more mappers failed to initialize - 
can't proceed with initialization of other mappers. Triggering mapper: 
'Mapper[KnowledgeDocument(knowledge_documents)]'. Original exception was: 
Could not determine join condition between parent/child tables on relationship 
KnowledgeDocument.source - there are multiple foreign key paths linking the tables.
```

**根因**: `knowledge_documents` ↔ `doc_sources` 表之间存在双向外键引用：
- `KnowledgeDocument.source_id` → `doc_sources.id`
- `DocSource.document_id` → `knowledge_documents.id`

SQLAlchemy 无法自动推断 `source` 关系应使用的 FK 路径，导致 Mapper 初始化崩溃，~40+ 集成测试全部失败。

**修复**: 为 `KnowledgeDocument.source` 和 `DocSource.document` 两个 relationship 显式指定 `foreign_keys` 参数。

### 问题 2: UI E2E Playwright 测试超时失败 [CRITICAL]

**错误信息**:
```
Error: expect(locator).toHaveClass(expected) failed
Locator: getByRole('button', { name: /run-running/i })
Expected pattern: /bg-zinc-900/
Timeout: 5000ms
Error: element(s) not found
```

**根因**: PR #324 引入分页功能后，`fetchPipelines()` 签名新增 `limit/offset` query params，导致实际请求 URL 变更为：
```
/api/knowledge/pipelines?app_name=negentropy&limit=10&offset=0
```
而 E2E test 的 glob route pattern `**/api/knowledge/pipelines?app_name=negentropy` 无法匹配带额外参数的 URL，导致 Mock 未命中，Pipeline Runs 列表为空。

**修复**: 将 glob pattern 改为正则表达式 `/\/api\/knowledge\/pipelines\?.*app_name=negentropy/`，兼容任意后续 query params。

## 变更文件

| 文件 | 改动 |
|------|------|
| `apps/negentropy/src/negentropy/models/perception.py` | 2 处 relationship 添加 `foreign_keys` |
| `apps/negentropy-ui/tests/e2e/smoke.spec.ts` | 1 处 route pattern glob → regex |

## 验证

- [x] 后端 SQLAlchemy 模型导入验证通过（无 Mapper 错误）
- [ ] Backend Test Suite CI 通过
- [ ] UI Test Suite CI 通过（含 E2E smoke test）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>