### PR TITLE
fix(CI): 修复 Backend Integration Tests 全量失败（CTE 参数绑定 + KgRelation 必填字段缺失）

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/catalog_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/catalog_dao.py
@@ -12,14 +12,9 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import (
-    Integer,
-    Select,
-    Text,
     func,
-    literal_column,
     select,
     text,
-    union_all,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -171,53 +166,39 @@ class CatalogDao:
             - depth: 层级深度（根节点为 0）
             - path: 从根到当前节点的 ID 路径数组
         """
-        schema = NEGENTROPY_SCHEMA
+        table = f"{NEGENTROPY_SCHEMA}.doc_catalog_nodes"
 
-        cte = (
-            select(
-                DocCatalogNode.id,
-                DocCatalogNode.parent_id,
-                DocCatalogNode.name,
-                DocCatalogNode.slug,
-                DocCatalogNode.node_type,
-                DocCatalogNode.description,
-                DocCatalogNode.sort_order,
-                DocCatalogNode.config,
-                literal_column("0").label("depth"),
-                func.array([DocCatalogNode.id]).label("path"),
+        stmt = text(f"""
+            WITH RECURSIVE cat_tree AS (
+                SELECT
+                    id, parent_id, name, slug, node_type,
+                    description, sort_order, config,
+                    0 AS depth,
+                    ARRAY[id] AS path
+                FROM {table}
+                WHERE corpus_id = :corpus_id AND parent_id IS NULL
+
+                UNION ALL
+
+                SELECT
+                    n.id, n.parent_id, n.name, n.slug, n.node_type,
+                    n.description, n.sort_order, n.config,
+                    ct.depth + 1,
+                    ct.path || n.id
+                FROM {table} n
+                JOIN cat_tree ct ON n.parent_id = ct.id
             )
-            .where(
-                DocCatalogNode.corpus_id == corpus_id,
-                DocCatalogNode.parent_id.is_(None),
-            )
-            .cte("cat_tree", recursive=True)
-        )
+            SELECT id, parent_id, name, slug, node_type,
+                   description, sort_order, config, depth, path
+            FROM cat_tree
+            WHERE depth <= :max_depth
+            ORDER BY depth, sort_order, name
+        """)
 
-        recursive_part = select(
-            DocCatalogNode.id,
-            DocCatalogNode.parent_id,
-            DocCatalogNode.name,
-            DocCatalogNode.slug,
-            DocCatalogNode.node_type,
-            DocCatalogNode.description,
-            DocCatalogNode.sort_order,
-            DocCatalogNode.config,
-            (cte.c.depth + 1).label("depth"),
-            (cte.c.path + func.array([DocCatalogNode.id])).label("path"),
-        ).join(
-            cte,
-            DocCatalogNode.parent_id == cte.c.id,
+        result = await db.execute(
+            stmt,
+            {"corpus_id": str(corpus_id), "max_depth": max_depth},
         )
-
-        full_tree = union_all(cte.select(), recursive_part).alias("tree_result")
-        # 限制最大深度，防止超深树导致性能问题
-        query = (
-            select(full_tree)
-            .where(full_tree.c.depth <= max_depth)
-            .order_by(full_tree.c.depth, full_tree.c.sort_order, full_tree.c.name)
-        )
-
-        result = await db.execute(query)
         rows = result.all()
 
         tree_data = []
@@ -248,49 +229,39 @@ class CatalogDao:
         max_depth: int = MAX_TREE_DEPTH,
     ) -> list[dict]:
         """获取以指定节点为根的子树"""
-        schema = NEGENTROPY_SCHEMA
+        table = f"{NEGENTROPY_SCHEMA}.doc_catalog_nodes"
 
-        anchor = (
-            select(
-                DocCatalogNode.id,
-                DocCatalogNode.parent_id,
-                DocCatalogNode.name,
-                DocCatalogNode.slug,
-                DocCatalogNode.node_type,
-                DocCatalogNode.description,
-                DocCatalogNode.sort_order,
-                DocCatalogNode.config,
-                literal_column("0").label("depth"),
-                func.array([DocCatalogNode.id]).label("path"),
+        stmt = text(f"""
+            WITH RECURSIVE sub_tree AS (
+                SELECT
+                    id, parent_id, name, slug, node_type,
+                    description, sort_order, config,
+                    0 AS depth,
+                    ARRAY[id] AS path
+                FROM {table}
+                WHERE id = :node_id
+
+                UNION ALL
+
+                SELECT
+                    n.id, n.parent_id, n.name, n.slug, n.node_type,
+                    n.description, n.sort_order, n.config,
+                    st.depth + 1,
+                    st.path || n.id
+                FROM {table} n
+                JOIN sub_tree st ON n.parent_id = st.id
             )
-            .where(DocCatalogNode.id == node_id)
-            .cte("sub_tree", recursive=True)
-        )
+            SELECT id, parent_id, name, slug, node_type,
+                   description, sort_order, config, depth, path
+            FROM sub_tree
+            WHERE depth <= :max_depth
+            ORDER BY depth, sort_order
+        """)
 
-        recursive_part = select(
-            DocCatalogNode.id,
-            DocCatalogNode.parent_id,
-            DocCatalogNode.name,
-            DocCatalogNode.slug,
-            DocCatalogNode.node_type,
-            DocCatalogNode.description,
-            DocCatalogNode.sort_order,
-            DocCatalogNode.config,
-            (anchor.c.depth + 1).label("depth"),
-            (anchor.c.path + func.array([DocCatalogNode.id])).label("path"),
-        ).join(
-            anchor,
-            DocCatalogNode.parent_id == anchor.c.id,
+        result = await db.execute(
+            stmt,
+            {"node_id": str(node_id), "max_depth": max_depth},
         )
-
-        full_tree = union_all(anchor.select(), recursive_part).alias("subtree_result")
-        query = (
-            select(full_tree)
-            .where(full_tree.c.depth <= max_depth)
-            .order_by(full_tree.c.depth, full_tree.c.sort_order)
-        )
-
-        result = await db.execute(query)
         rows = result.all()
 
         return [

--- a/apps/negentropy/src/negentropy/knowledge/kg_entity_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/kg_entity_service.py
@@ -189,6 +189,7 @@ class KgEntityService:
             relation_type=relation_type,
             weight=weight,
             evidence_text=evidence_text,
+            corpus_id=corpus_id,
         )
         db.add(relation)
         await db.flush()

--- a/apps/negentropy/src/negentropy/knowledge/kg_entity_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/kg_entity_service.py
@@ -137,6 +137,7 @@ class KgEntityService:
         weight: float = 1.0,
         evidence_text: Optional[str] = None,
         corpus_id: Optional[UUID] = None,
+        app_name: str = "negentropy",
     ) -> None:
         """同步关系到 kg_relations 表
 
@@ -190,6 +191,7 @@ class KgEntityService:
             weight=weight,
             evidence_text=evidence_text,
             corpus_id=corpus_id,
+            app_name=app_name,
         )
         db.add(relation)
         await db.flush()


### PR DESCRIPTION
## 变更摘要

修复 GitHub Actions Backend Integration Tests 的 **18 个测试失败**，恢复 CI 全绿。

## 问题根因

### 问题 1：CatalogDao Recursive CTE 参数绑定失败（12 个测试）

| 项目 | 详情 |
|------|------|
| **错误** | `asyncpg.exceptions.PostgresSyntaxError: syntax error at or near "$1"` |
| **影响范围** | `TestCatalogTreeCte`（7 个）+ `TestCatalogSubtreeCte`（5 个）全部失败 |
| **根因** | SQLAlchemy 2.0 ORM 编译器构建 `WITH RECURSIVE` CTE 时，asyncpg 驱动在 `UNION ALL` 两部分的参数绑定位置存在兼容性缺陷，导致 `$1` 占位符出现在非法语法位置 |

**修复方案**：将 `get_tree()` / `get_subtree()` 从 ORM CTE 构建方式改为 `text()` 原始 SQL + 命名参数绑定（`:corpus_id`, `:node_id`, `:max_depth`），完全绕过 SQLAlchemy 编译层的 CTE 参数处理。

### 问题 2：KgRelation 缺少必填字段（6 个测试）

| 项目 | 详情 |
|------|------|
| **错误** | `NotNullViolationError: null value in column "corpus_id"/"app_name" of relation "kg_relations"` |
| **影响范围** | `TestRelationSyncIntegration`（3 个）+ `TestBatchSyncIntegration`（3 个） |
| **根因** | `sync_relation()` 创建 `KgRelation` 对象时遗漏了两个 `nullable=False` 的必填字段：`corpus_id` 和 `app_name` |

**修复方案**：在 `KgRelation()` 构造调用中补全 `corpus_id=corpus_id` 和 `app_name=app_name`，同时为 `sync_relation()` 方法签名新增 `app_name: str = "negentropy"` 参数。

## 修改文件

| 文件 | 变更说明 |
|------|----------|
| `apps/negentropy/src/negentropy/knowledge/catalog_dao.py` | `get_tree()` / `get_subtree()` CTE 查询改为 `text()` 原始 SQL |
| `apps/negentropy/src/negentropy/knowledge/kg_entity_service.py` | `sync_relation()` 补全 `corpus_id` + `app_name` 必填字段 |

## CI 验证

```
✅ Backend Unit Tests           — success
✅ Backend Integration Tests    — success（全部 26 个集成测试通过）
⏭️  Backend Performance Tests   — skipped（按预期）
```

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>