### PR TITLE
fix(Security): 使用 uv override-dependencies 强制升级 aiohttp 至 3.13.5，消除 19 个 CVE 告警;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 [English](./README.md) | [简体中文](./docs/zh-CN/README.md)
 
-<h1 align="center">🔮 Negentropy (熵减引擎)</h1>
-
+<h1 align="center">🔮 Negentropy</h1>
 
 <p align="center">
-  <strong>一个「一核五翼」(One Root, Five Wings) 架构的智能体系统，致力于对抗知识的无序趋势（熵增），实现持续自我进化的认知体系。</strong>
+  <strong>An agentic system built on a "One Root, Five Wings" architecture, dedicated to combating the entropic decay of knowledge and forging a continuously self-evolving cognitive framework.</strong>
 </p>
 
 <div align="center">
@@ -18,145 +17,158 @@
 </div>
 
 <p align="center">
-  <b>🔮 本我 · 调度核心 | 不参与原子任务执行，依据<strong>正交分解 (Orthogonal Decomposition)</strong> 原则，将意图精准委派给最合适的系部。</b> <br/> <b>👁️ 慧眼 · 感知</b> | <b>💎 本心 · 内化</b> | <b>🧠 元神 · 坐照</b> | <b>✋ 妙手 · 知行</b> | <b>🗣️ 喉舌：影响</b>
+  <b>🔮 The Self · Scheduling Core | Bypasses atomic task execution. Strictly adhering to <strong>Orthogonal Decomposition</strong>, it acts as the master conductor, assigning intents to the most capable faculties.</b> <br/> <b>👁️ The Eye · Perception</b> | <b>💎 The Soul · Internalization</b> | <b>🧠 The Mind · Contemplation</b> | <b>✋ The Hand · Action</b> | <b>🗣️ The Voice · Influence</b>
+  <br/>
 </p>
 
 ---
 
-## 🤔 为什么需要熵减引擎？
+<p align="center">
+<b><small><small><strong>Disclaimer</strong> · All tools and methodologies provided by this project are for reference only. The project team bears no direct or indirect responsibility for the outcomes of using this system. The term "cultivation/practice" herein refers purely to the self-evolution and optimization of the system, free of any religious connotations.</small></small></b>
+</p>
 
-你或许已经用过了不少智能体系统，但大概率踩过这些坑：
+---
 
-- 🌀 **信息过载** —— Agent 获取了海量信息，但信号和噪音齐飞，你只得到一堆「有用的废话」
-- 🕳️ **金鱼记忆** —— 上一轮对话的结论，下一轮就被忘得一干二净，仿佛每次都在重启人生
-- 🏄 **浅尝辄止** —— Agent 只会表面回答，从不会深挖二阶问题——「为什么」永远没人替你问
-- 💬 **纸上谈兵** —— 分析得头头是道，真正需要执行代码、操作文件时就开始「建议您手动操作」
-- 🌫️ **晦涩难懂** —— 明明是专业的洞察，输出却像天书，价值传递的损耗率直逼 80%
+## 🤔 Why Negentropy Engine?
 
-**Negentropy 的回答**：逐一对抗这些熵增形态。不在于造一个 Agent，而是构建一个**持续自我进化的认知系统**。
+You've probably test-driven your fair share of agentic systems by now, and inevitably stepped into these classic pitfalls:
+
+- 🌀 **Information Overload** —— Agents devour oceans of data, but signal and noise fly together. You're left with a pile of "truthful nonsense."
+- 🕳️ **Goldfish Memory** —— The hard-won conclusions from your last dialogue are tossed out the window by the next. It's like rebooting life every five minutes.
+- 🏄 **Surface-Level Skimming** —— Agents give you textbook answers but never dig into second-order problems. Nobody's ever asking "But _why_?" on your behalf.
+- 💬 **Armchair Strategists** —— The analysis is flawless, but the moment real work (executing code, touching files) is required, you hit the dreaded "I suggest you do this manually."
+- 🌫️ **Impenetrable Jargon** —— What should be a professional insight reads like an ancient scroll. The value degradation in transmission approaches a solid 80%.
+
+**Negentropy's Answer**: We engage these entropic forms head-on. The goal isn't just to build another Agent, but to forge a **continuously self-evolving cognitive system**.
 
 ```mermaid
 graph TB
-    Root["🔮 NegentropyEngine<br/>（本我 · 调度核心）"]
+    Root["🔮 NegentropyEngine<br/>(The Self · Scheduling Core)"]
 
-    Root -->|"transfer_to_agent"| P["👁️ 慧眼 · 感知<br/>Perception"]
-    Root -->|"transfer_to_agent"| I["💎 本心 · 内化<br/>Internalization"]
-    Root -->|"transfer_to_agent"| C["🧠 元神 · 坐照<br/>Contemplation"]
-    Root -->|"transfer_to_agent"| A["✋ 妙手 · 知行<br/>Action"]
-    Root -->|"transfer_to_agent"| Inf["🗣️ 喉舌 · 影响<br/>Influence"]
+    Root -->|"transfer_to_agent"| P["👁️ The Eye · Perception Faculty"]
+    Root -->|"transfer_to_agent"| I["💎 The Soul · Internalization Faculty"]
+    Root -->|"transfer_to_agent"| C["🧠 The Mind · Contemplation Faculty"]
+    Root -->|"transfer_to_agent"| A["✋ The Hand · Action Faculty"]
+    Root -->|"transfer_to_agent"| Inf["🗣️ The Voice · Influence Faculty"]
 
-    P -->|对抗| O["信息过载<br/>噪音淹没信号"]
-    I -->|对抗| F["遗忘<br/>知识碎片化"]
-    C -->|对抗| S["肤浅<br/>表层响应"]
-    A -->|对抗| E["虚谈<br/>认知-行动断裂"]
-    Inf -->|对抗| Obs["晦涩<br/>价值传递失真"]
+    P -->|Combats| O["Information Overload<br/>Noise Drowning Signal"]
+    I -->|Combats| F["Amnesia<br/>Knowledge Fragmentation"]
+    C -->|Combats| S["Superficiality<br/>Surface-Level Responses"]
+    A -->|Combats| E["All Talk<br/>Cognitive-Action Disconnect"]
+    Inf -->|Combats| Obs["Obscurity<br/>Value Degradation"]
 ```
 
 ---
 
-## ✨ 核心特性
+## ✨ Core Features
 
-- 🏗️ **「一核五翼」智能体编排** —— 一个编排者 + 五个正交系部的分工协作架构。根智能体负责调度决策，五大系部分别对抗信息过载、遗忘、肤浅、虚谈和晦涩
+- 🏗️ **"One Root, Five Wings" Orchestration** —— A master orchestrator teaming up with five orthogonal faculties. The root agent handles the dispatching, while the five wings systematically obliterate information overload, amnesia, superficiality, inaction, and obscurity.
 
-- 🔄 **三条标准流水线** —— 预封装的知识获取、问题解决、价值交付流水线，告别手动编排多步骤任务的繁琐，开箱即用
+- 🔄 **Three Standardized Pipelines** —— Pre-packaged pipelines for Knowledge Acquisition, Problem Solving, and Value Delivery. Say goodbye to the tedious chore of manually wiring multi-step tasks. It works out of the box.
 
-- 🧠 **动态记忆系统** —— 基于艾宾浩斯遗忘曲线的记忆衰减机制，结构化事实存储，记忆审计与治理，让 Agent 真正「记住」而不是「复读」
+- 🧠 **Dynamic Memory System** —— A memory decay mechanism modeled on the Ebbinghaus Forgetting Curve, paired with structured factual storage and memory governance. This ensures the Agent actually _remembers_ instead of merely _repeating_.
 
-- 📚 **知识管理引擎** —— 文档摄入、语义分块、向量检索、知识图谱、语义搜索，一套完整的知识生命周期管理
+- 📚 **Knowledge Management Engine** —— From document ingestion, semantic chunking, and vector retrieval to knowledge graphs and semantic search—a full-lifecycle knowledge management suite.
 
-- 🐱 **沙箱代码执行** —— MCP 协议 + MicroSandbox 双通道隔离执行，安全地让 Agent 真正「动手」而不是只动嘴
+- 🐱 **Sandboxed Code Execution** —— Dual-channel isolated execution via MCP Protocol + MicroSandbox. Safely allows the Agent to get its hands dirty, graduating from "all talk" to "taking action."
 
-- 🔧 **可插拔后端** —— Session / Memory / Artifact / Credential 全部支持 inmemory / PostgreSQL / VertexAI / GCS 切换，开发用 inmemory，生产上 postgres，平滑迁移零代码修改
+- 🔧 **Pluggable Backends** —— Sessions, Memories, Artifacts, and Credentials fully support seamless switching between in-memory / PostgreSQL / VertexAI / GCS. Use in-memory for dev, Postgres for prod. Zero-code smooth migration.
 
-- 📡 **全链路可观测** —— structlog 结构化日志 + OpenTelemetry 分布式追踪 + Langfuse Trace 分析，Agent 的每一次「思考」都有据可查
+- 📡 **Full-Stack Observability** —— Structured logging via `structlog` + Distributed tracing with OpenTelemetry + Trace analysis via Langfuse. Every "thought" the Agent has is fully documented and auditable.
 
 ---
 
-## ✨ 快速上手
+## ✨ Quick Start
 
-### 前置要求
+### Prerequisites
 
-| 依赖                             | 最低版本          | 用途          |
-| :------------------------------- | :---------------- | :------------ |
-| Python                           | 3.13+             | 后端运行时    |
-| [uv](https://docs.astral.sh/uv/) | 最新              | Python 包管理 |
-| Node.js                          | 22+               | 前端运行时    |
-| [pnpm](https://pnpm.io/)         | 最新              | 前端包管理    |
-| PostgreSQL                       | 16+ (含 pgvector) | 数据持久化    |
+<center>
 
-### 1. 克隆项目
+| Dependency                       | Minimum Version     | Purpose                  |
+| :------------------------------- | :------------------ | :----------------------- |
+| Python                           | 3.13+               | Backend Runtime          |
+| [uv](https://docs.astral.sh/uv/) | Latest              | Python Package Manager   |
+| Node.js                          | 22+                 | Frontend Runtime         |
+| [pnpm](https://pnpm.io/)         | Latest              | Frontend Package Manager |
+| PostgreSQL                       | 16+ (with pgvector) | Data Persistence         |
+
+</center>
+
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/ThreeFish-AI/negentropy.git
 cd negentropy
 ```
 
-### 2. 启动后端
+### 2. Boot the Backend
 
 ```bash
 cd apps/negentropy
-cp .env.example .env          # 复制并填写环境变量
-uv sync --dev                  # 安装全部依赖（含开发依赖）
-uv run alembic upgrade head    # 应用数据库迁移
-uv run adk web --port 8000 --reload_agents src/negentropy  # 启动引擎
+cp .env.example .env          # Copy and configure environment variables
+uv sync --dev                  # Install all dependencies (including dev)
+uv run alembic upgrade head    # Apply database migrations
+uv run adk web --port 8000 --reload_agents src/negentropy  # Start the engine
 ```
 
-### 3. 启动前端
+### 3. Boot the Frontend
 
 ```bash
 cd apps/negentropy-ui
-pnpm install                   # 安装依赖
-pnpm run dev                   # 启动开发服务器 (localhost:3333)
+pnpm install                   # Install dependencies
+pnpm run dev                   # Start development server (localhost:3333)
 ```
 
-### 4. 开始对话
+### 4. Initiate Dialogue
 
-打开浏览器访问 `http://localhost:3333`，开始与 NegentropyEngine 对话。
+Fire up your browser, head over to `http://localhost:3333`, and start conversing with the NegentropyEngine.
 
-> 完整的环境搭建指南、数据库迁移、前后端对接、故障排查详见 [docs/development.md](./docs/development.md)。
+> For comprehensive guides on environment setup, database migrations, frontend-backend integration, and troubleshooting, please refer to [docs/development.md](./docs/development.md).
 
 ---
 
-## 🏛️ 架构概览
+## 🏛️ Architecture Overview
 
-> [!TIP]
-> 
-> **设计哲学**
-> 
-> 系统的命名源自薛定谔 (Erwin Schrödinger) 在《生命是什么？》中提出的概念——生命以**负熵 (Negentropy)** 为食<sup>[[1]](#ref1)</sup>。
+<p align="center">
+  <b><strong>Design Philosophy</strong> | The system's namesake draws from Erwin Schrödinger's concept in <em>What is Life?</em>—life feeds on <strong>negative entropy (Negentropy)</strong><sup><link url=#ref1>1</link></sup>.
+</p>
 
-### 一核五翼
+### One Root, Five Wings
 
-**NegentropyEngine** 不直接执行原子任务，只做调度决策。五个系部各司其职，三条流水线封装常见的多系部协作模式。架构遵循**正交分解**原则，确保系部间职责独立、变更局部化。
+The **NegentropyEngine** refrains from executing atomic tasks directly; it exists solely for scheduling and dispatching. The five faculties operate purely in their element, while three pipelines encapsulate common multi-faculty collaboration patterns. The architecture rigidly adheres to **Orthogonal Decomposition**, ensuring decoupled responsibilities and strictly localized mutations.
 
-| 图腾  | 系部        | Agent 名称               | 对抗目标 | 核心职责                             | 专属工具                                   |
-| :---: | :---------- | :----------------------- | :------- | :----------------------------------- | :----------------------------------------- |
-|   👁️   | 慧眼 · 感知 | `PerceptionFaculty`      | 信息过载 | 广域扫描、噪音过滤、多源交叉验证     | `search_knowledge_base`, `search_web`      |
-|   💎   | 本心 · 内化 | `InternalizationFaculty` | 遗忘     | 知识结构化、长期记忆管理、一致性维护 | `save_to_memory`, `update_knowledge_graph` |
-|   🧠   | 元神 · 坐照 | `ContemplationFaculty`   | 肤浅     | 二阶思维、策略规划、错误根因分析     | `analyze_context`, `create_plan`           |
-|   ✋   | 妙手 · 知行 | `ActionFaculty`          | 虚谈     | 精准执行、代码生成、安全变更         | `execute_code`, `read_file`, `write_file`  |
-|   🗣️   | 喉舌 · 影响 | `InfluenceFaculty`       | 晦涩     | 价值传递、格式适配、说服与教育       | `publish_content`, `send_notification`     |
+<center>
 
-> 完整的架构设计方案、流水线编排机制、设计模式目录详见 [docs/framework.md](./docs/framework.md)。
+| Totem | Faculty                    | Agent Name               | Combats              | Core Responsibility                                                         | Exclusive Tools                            |
+| :---: | :------------------------- | :----------------------- | :------------------- | :-------------------------------------------------------------------------- | :----------------------------------------- |
+|   👁️   | The Eye · Perception       | `PerceptionFaculty`      | Information Overload | Wide-area scanning, noise filtering, multi-source cross-validation          | `search_knowledge_base`, `search_web`      |
+|   💎   | The Soul · Internalization | `InternalizationFaculty` | Amnesia              | Knowledge structuring, long-term memory governance, consistency maintenance | `save_to_memory`, `update_knowledge_graph` |
+|   🧠   | The Mind · Contemplation   | `ContemplationFaculty`   | Superficiality       | Second-order thinking, strategic planning, root cause analysis              | `analyze_context`, `create_plan`           |
+|   ✋   | The Hand · Action          | `ActionFaculty`          | All Talk             | Precision execution, code generation, safe mutation                         | `execute_code`, `read_file`, `write_file`  |
+|   🗣️   | The Voice · Influence      | `InfluenceFaculty`       | Obscurity            | Value delivery, format adaptation, persuasion and education                 | `publish_content`, `send_notification`     |
 
-### 三层架构
+</center>
+
+> Dive into the complete architectural blueprint, pipeline orchestration mechanics, and design pattern registry in [docs/framework.md](./docs/framework.md).
+
+### Three-Tier Architecture
 
 ```mermaid
 graph TB
-    subgraph Presentation["🖥️ 展示层"]
+    subgraph Presentation["🖥️ Presentation Layer"]
         UI["negentropy-ui<br/><i>Next.js 22 · React 19 · Tailwind</i>"]
         Wiki["negentropy-wiki<br/><i>Next.js</i>"]
     end
 
-    subgraph Engine["⚙️ 引擎层"]
-        Root["🔮 NegentropyEngine<br/>根智能体（本我）"]
-        Faculties["五大系部<br/>👁️ 感知 · 💎 内化 · 🧠 坐照 · ✋ 知行 · 🗣️ 影响"]
-        Pipelines["三条流水线<br/>知识获取 · 问题解决 · 价值交付"]
+    subgraph Engine["⚙️ Engine Layer"]
+        Root["🔮 NegentropyEngine<br/>Root Agent (The Self)"]
+        Faculties["Five Faculties<br/>👁️ Perception <br> 💎 Internalization <br> 🧠 Contemplation <br> ✋ Action <br> 🗣️ Influence"]
+        Pipelines["Three Pipelines<br/>Knowledge Acquisition <br> Problem Solving <br> Value Delivery"]
     end
 
-    subgraph Infra["🏗️ 基础设施层"]
+    subgraph Infra["🏗️ Infrastructure Layer"]
         DB[("PostgreSQL 16+<br/>pgvector")]
-        LLM["LiteLLM<br/>100+ LLM 统一接口"]
+        LLM["LiteLLM<br/>100+ LLMs Unified API"]
         OTel["OpenTelemetry · Langfuse"]
         Sandbox["MCP · MicroSandbox"]
     end
@@ -182,41 +194,41 @@ graph TB
 
 ---
 
-## 📚 文档导航
+## 📚 Document Navigator
 
-| 文档                                            | 说明                                                                 |
-| :---------------------------------------------- | :------------------------------------------------------------------- |
-| [开发指南](./docs/development.md)               | 环境搭建、日常开发工作流、数据库迁移、前后端对接、故障排查           |
-| [架构设计](./docs/framework.md)                 | 一核五翼详解、流水线编排、设计模式目录、引擎层、数据持久化、前端架构 |
-| [知识系统](./docs/knowledges.md)                | 知识管理模块的详细设计与使用                                         |
-| [记忆系统](./docs/memory.md)                    | 记忆生命周期、遗忘曲线、治理机制                                     |
-| [知识图谱](./docs/knowledge-graph.md)           | 知识图谱建模与查询                                                   |
-| [QA 流水线](./docs/qa-delivery-pipeline.md)     | 质量门禁与发布流程                                                   |
-| [SSO 集成](./docs/sso.md)                       | Google OAuth 认证配置                                                |
-| [工程变更日志](./docs/engineering-changelog.md) | 里程碑与基线变更记录                                                 |
-| [AI 协作协议](./AGENTS.md)                      | Agent 协作行为准则与工程规范                                         |
+<center>
 
----
+| Document                                                 | Description                                                                                     |
+| :------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| [Development Guide](./docs/development.md)               | Environment setup, daily workflows, db migrations, integrations, troubleshooting                |
+| [Architecture Design](./docs/framework.md)               | Deep dive into the One Root/Five Wings, pipeline choreography, design patterns, engine workings |
+| [Knowledge System](./docs/knowledges.md)                 | Detailed design and usage of the knowledge management module                                    |
+| [Memory System](./docs/memory.md)                        | Memory lifecycle, forgetting curves, and governance mechanics                                   |
+| [Knowledge Graph](./docs/knowledge-graph.md)             | Graph modeling and query implementation                                                         |
+| [QA Pipeline](./docs/qa-delivery-pipeline.md)            | Quality gates and release workflows                                                             |
+| [SSO Integration](./docs/sso.md)                         | Google OAuth authentication config                                                              |
+| [Engineering Changelog](./docs/engineering-changelog.md) | Milestones and baseline mutation records                                                        |
+| [AI Collaboration Protocol](./AGENTS.md)                 | Agent cooperation guidelines and engineering codebase                                           |
 
-## 🤝 参与贡献
-
-如果您在使用过程中遇到任何问题，请通过 [GitHub Issues](https://github.com/ThreeFish-AI/negentropy/issues) 寻求帮助。
-
-- **核心原则**：熵减、上下文驱动、循证工程。
-- **提交规范**：请确保所有变更符合 Systemic Integrity (系统完整性) 要求。
+</center>
 
 ---
 
-> [!WARNING]
-> 
-> **免责声明**
-> 
-> 本项目提供的所有工具与方法论仅供参考。用户在使用过程中产生的任何结果，项目组不承担直接或间接责任。这里的「修行」指代系统的自我演化与优化过程，不涉及任何宗教含义。
+## 🤝 Community & Contributions
 
-<a id="ref1"></a>[1] E. Schrödinger, "What is Life? The Physical Aspect of the Living Cell," *Cambridge University Press*, 1944.
+If you're holding onto an inspiration that pulls chaos back into order, or if you bump into any snags while navigating the system, please don't hesitate to share your wisdom:
+
+1. Before hitting the keyboard, kindly take a detour through the [Development Guide](./docs/development.md).
+2. Sling your game-changing ideas into our [Issues](https://github.com/ThreeFish-AI/negentropy/issues) or directly submit a [Pull Request](https://github.com/ThreeFish-AI/negentropy/pulls) packing some serious paradigm-shifting power.
+
+Please hold "Entropy Reduction," "Context-Driven," and "Evidence-Based Engineering" as your **core principles**, ensuring every mutation aligns perfectly with Systemic Integrity.
+
+---
+
+<a id="ref1"></a>[1] E. Schrödinger, "What is Life? The Physical Aspect of the Living Cell," _Cambridge University Press_, 1944.
 
 ---
 
 <p align="center">
-  <a href="LICENSE">Apache License 2.0</a>, © 2026 <a href="https://github.com/ThreeFish-AI">ThreeFish-AI</a>
+  <a href="./LICENSE">Apache License 2.0</a>, © 2026 <a href="https://github.com/ThreeFish-AI">ThreeFish-AI</a>
 </p>

--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -114,11 +114,13 @@ exclude_lines = [
 ]
 
 [tool.uv]
+override-dependencies = [
+    "aiohttp>=3.13.4",      # CVE-2025/2026 (19 个): microsandbox==0.1.8 锁死 <3.11.0, 强制覆盖升级
+]
 constraint-dependencies = [
     "authlib>=1.6.9",       # CVE-2026-27962 (critical) + CVE-2026-28490/28498/28802
     "pyasn1>=0.6.3",        # CVE-2026-30922: unbounded recursion DoS
     "pyjwt>=2.12.0",        # CVE-2026-32597: unknown crit header extensions
-    # aiohttp CVE-2025/2026 (12 个) 无法修复：microsandbox==0.1.8 严格锁死 aiohttp>=3.10.0,<3.11.0
     "cryptography>=46.0.7", # CVE-2026: buffer overflow, subgroup attack, DNS constraint
     "pygments>=2.20.0",     # CVE-2026-4539: ReDoS via GUID regex
     "requests>=2.33.0",     # CVE-2026-25645: insecure temp file reuse

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -11,6 +11,7 @@ constraints = [
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "requests", specifier = ">=2.33.0" },
 ]
+overrides = [{ name = "aiohttp", specifier = ">=3.13.4" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -23,7 +24,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.10.11"
+version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -31,25 +32,28 @@ dependencies = [
     { name = "attrs" },
     { name = "frozenlist" },
     { name = "multidict" },
+    { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/a8/8e2ba36c6e3278d62e0c88aa42bb92ddbef092ac363b390dab4421da5cf5/aiohttp-3.10.11.tar.gz", hash = "sha256:9dc2b8f3dcab2e39e0fa309c8da50c3b55e6f34ab25f1a71d3288f24924d33a7", size = 7551886, upload-time = "2024-11-13T16:40:33.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/63/654c185dfe3cf5d4a0d35b6ee49ee6ca91922c694eaa90732e1ba4b40ef1/aiohttp-3.10.11-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:703938e22434d7d14ec22f9f310559331f455018389222eed132808cd8f44127", size = 577381, upload-time = "2024-11-13T16:38:26.708Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/c4/ee9c350acb202ba2eb0c44b0f84376b05477e870444192a9f70e06844c28/aiohttp-3.10.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9bc50b63648840854e00084c2b43035a62e033cb9b06d8c22b409d56eb098413", size = 393289, upload-time = "2024-11-13T16:38:29.207Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/7c/30d161a7e3b208cef1b922eacf2bbb8578b7e5a62266a6a2245a1dd044dc/aiohttp-3.10.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f0463bf8b0754bc744e1feb61590706823795041e63edf30118a6f0bf577461", size = 388859, upload-time = "2024-11-13T16:38:31.567Z" },
-    { url = "https://files.pythonhosted.org/packages/79/10/8d050e04be447d3d39e5a4a910fa289d930120cebe1b893096bd3ee29063/aiohttp-3.10.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6c6dec398ac5a87cb3a407b068e1106b20ef001c344e34154616183fe684288", size = 1280983, upload-time = "2024-11-13T16:38:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/31/b3/977eca40afe643dcfa6b8d8bb9a93f4cba1d8ed1ead22c92056b08855c7a/aiohttp-3.10.11-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bcaf2d79104d53d4dcf934f7ce76d3d155302d07dae24dff6c9fffd217568067", size = 1317132, upload-time = "2024-11-13T16:38:35.999Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/43/b5ee8e697ed0f96a2b3d80b3058fa7590cda508e9cd256274246ba1cf37a/aiohttp-3.10.11-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25fd5470922091b5a9aeeb7e75be609e16b4fba81cdeaf12981393fb240dd10e", size = 1362630, upload-time = "2024-11-13T16:38:39.016Z" },
-    { url = "https://files.pythonhosted.org/packages/28/20/3ae8e993b2990fa722987222dea74d6bac9331e2f530d086f309b4aa8847/aiohttp-3.10.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbde2ca67230923a42161b1f408c3992ae6e0be782dca0c44cb3206bf330dee1", size = 1276865, upload-time = "2024-11-13T16:38:41.423Z" },
-    { url = "https://files.pythonhosted.org/packages/02/08/1afb0ab7dcff63333b683e998e751aa2547d1ff897b577d2244b00e6fe38/aiohttp-3.10.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:249c8ff8d26a8b41a0f12f9df804e7c685ca35a207e2410adbd3e924217b9006", size = 1230448, upload-time = "2024-11-13T16:38:43.962Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/fd/ccd0ff842c62128d164ec09e3dd810208a84d79cd402358a3038ae91f3e9/aiohttp-3.10.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:878ca6a931ee8c486a8f7b432b65431d095c522cbeb34892bee5be97b3481d0f", size = 1244626, upload-time = "2024-11-13T16:38:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/75/30e9537ab41ed7cb062338d8df7c4afb0a715b3551cd69fc4ea61cfa5a95/aiohttp-3.10.11-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8663f7777ce775f0413324be0d96d9730959b2ca73d9b7e2c2c90539139cbdd6", size = 1243608, upload-time = "2024-11-13T16:38:49.47Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e0/3e7a62d99b9080793affddc12a82b11c9bc1312916ad849700d2bddf9786/aiohttp-3.10.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6cd3f10b01f0c31481fba8d302b61603a2acb37b9d30e1d14e0f5a58b7b18a31", size = 1286158, upload-time = "2024-11-13T16:38:51.947Z" },
-    { url = "https://files.pythonhosted.org/packages/71/b8/df67886802e71e976996ed9324eb7dc379e53a7d972314e9c7fe3f6ac6bc/aiohttp-3.10.11-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4e8d8aad9402d3aa02fdc5ca2fe68bcb9fdfe1f77b40b10410a94c7f408b664d", size = 1313636, upload-time = "2024-11-13T16:38:54.424Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/3b/aea9c3e70ff4e030f46902df28b4cdf486695f4d78fd9c6698827e2bafab/aiohttp-3.10.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38e3c4f80196b4f6c3a85d134a534a56f52da9cb8d8e7af1b79a32eefee73a00", size = 1273772, upload-time = "2024-11-13T16:38:56.846Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/4b4c5705270d1c4ee146516ad288af720798d957ba46504aaf99b86e85d9/aiohttp-3.10.11-cp313-cp313-win32.whl", hash = "sha256:fc31820cfc3b2863c6e95e14fcf815dc7afe52480b4dc03393c4873bb5599f71", size = 358679, upload-time = "2024-11-13T16:38:59.787Z" },
-    { url = "https://files.pythonhosted.org/packages/28/1d/18ef37549901db94717d4389eb7be807acbfbdeab48a73ff2993fc909118/aiohttp-3.10.11-cp313-cp313-win_amd64.whl", hash = "sha256:4996ff1345704ffdd6d75fb06ed175938c133425af616142e7187f28dc75f14e", size = 378073, upload-time = "2024-11-13T16:39:02.065Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
+    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
 ]
 
 [[package]]

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,0 +1,234 @@
+[English](../../README.md) | [简体中文](./README.md)
+
+<h1 align="center">🔮 Negentropy (熵减引擎)</h1>
+
+<p align="center">
+  <strong>一个「一核五翼」架构的智能体系统，致力于对抗知识的无序趋势（熵增），实现持续自我进化的认知体系。</strong>
+</p>
+
+<div align="center">
+
+[![Python 3.13](https://img.shields.io/badge/Python-3.13-blue?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-green?style=flat-square)](../../LICENSE)
+[![uv](https://img.shields.io/badge/Package-uv-purple?style=flat-square&logo=uv&logoColor=white)](https://docs.astral.sh/uv/)
+[![Google ADK](https://img.shields.io/badge/Framework-Google%20ADK-orange?style=flat-square)](https://google.github.io/adk-docs/)
+[![Next.js 22](https://img.shields.io/badge/Frontend-Next.js%2022-black?style=flat-square&logo=next.js&logoColor=white)](https://nextjs.org/)
+
+</div>
+
+<p align="center">
+  <b>🔮 本我 · 调度核心 | 不参与原子任务执行，依据<strong>正交分解</strong> 原则，将意图精准委派给最合适的系部。</b> <br/> <b>👁️ 慧眼 · 感知</b> | <b>💎 本心 · 内化</b> | <b>🧠 元神 · 坐照</b> | <b>✋ 妙手 · 知行</b> | <b>🗣️ 喉舌：影响</b>
+  <br/>
+</p>
+
+---
+
+<p align="center">
+<b><small><small><strong>免责声明</strong> · 本项目提供的所有工具与方法论仅供参考。用户在使用过程中产生的任何结果，项目组不承担直接或间接责任。这里的「修行」指代系统的自我演化与优化过程，不涉及任何宗教含义。</small></small></b>
+</p>
+
+---
+
+## 🤔 为什么需要熵减引擎？
+
+你或许已经用过了不少智能体系统，但大概率踩过这些坑：
+
+- 🌀 **信息过载** —— Agent 获取了海量信息，但信号和噪音齐飞，你只得到一堆「有用的废话」
+- 🕳️ **金鱼记忆** —— 上一轮对话的结论，下一轮就被忘得一干二净，仿佛每次都在重启人生
+- 🏄 **浅尝辄止** —— Agent 只会表面回答，从不会深挖二阶问题——「为什么」永远没人替你问
+- 💬 **纸上谈兵** —— 分析得头头是道，真正需要执行代码、操作文件时就开始「建议您手动操作」
+- 🌫️ **晦涩难懂** —— 明明是专业的洞察，输出却像天书，价值传递的损耗率直逼 80%
+
+**Negentropy 的回答**：逐一对抗这些熵增形态。不在于造一个 Agent，而是构建一个**持续自我进化的认知系统**。
+
+```mermaid
+graph TB
+    Root["🔮 NegentropyEngine<br/>（本我 · 调度核心）"]
+
+    Root -->|"transfer_to_agent"| P["👁️ 慧眼 · 感知<br/>Perception"]
+    Root -->|"transfer_to_agent"| I["💎 本心 · 内化<br/>Internalization"]
+    Root -->|"transfer_to_agent"| C["🧠 元神 · 坐照<br/>Contemplation"]
+    Root -->|"transfer_to_agent"| A["✋ 妙手 · 知行<br/>Action"]
+    Root -->|"transfer_to_agent"| Inf["🗣️ 喉舌 · 影响<br/>Influence"]
+
+    P -->|对抗| O["信息过载<br/>噪音淹没信号"]
+    I -->|对抗| F["遗忘<br/>知识碎片化"]
+    C -->|对抗| S["肤浅<br/>表层响应"]
+    A -->|对抗| E["虚谈<br/>认知-行动断裂"]
+    Inf -->|对抗| Obs["晦涩<br/>价值传递失真"]
+```
+
+---
+
+## ✨ 核心特性
+
+- 🏗️ **「一核五翼」智能体编排** —— 一个编排者 + 五个正交系部的分工协作架构。根智能体负责调度决策，五大系部分别对抗信息过载、遗忘、肤浅、虚谈和晦涩
+
+- 🔄 **三条标准流水线** —— 预封装的知识获取、问题解决、价值交付流水线，告别手动编排多步骤任务的繁琐，开箱即用
+
+- 🧠 **动态记忆系统** —— 基于艾宾浩斯遗忘曲线的记忆衰减机制，结构化事实存储，记忆审计与治理，让 Agent 真正「记住」而不是「复读」
+
+- 📚 **知识管理引擎** —— 文档摄入、语义分块、向量检索、知识图谱、语义搜索，一套完整的知识生命周期管理
+
+- 🐱 **沙箱代码执行** —— MCP 协议 + MicroSandbox 双通道隔离执行，安全地让 Agent 真正「动手」而不是只动嘴
+
+- 🔧 **可插拔后端** —— Session / Memory / Artifact / Credential 全部支持 inmemory / PostgreSQL / VertexAI / GCS 切换，开发用 inmemory，生产上 postgres，平滑迁移零代码修改
+
+- 📡 **全链路可观测** —— structlog 结构化日志 + OpenTelemetry 分布式追踪 + Langfuse Trace 分析，Agent 的每一次「思考」都有据可查
+
+---
+
+## ✨ 快速上手
+
+### 前置要求
+
+<center>
+
+| 依赖                             | 最低版本          | 用途          |
+| :------------------------------- | :---------------- | :------------ |
+| Python                           | 3.13+             | 后端运行时    |
+| [uv](https://docs.astral.sh/uv/) | 最新              | Python 包管理 |
+| Node.js                          | 22+               | 前端运行时    |
+| [pnpm](https://pnpm.io/)         | 最新              | 前端包管理    |
+| PostgreSQL                       | 16+ (含 pgvector) | 数据持久化    |
+
+</center>
+
+### 1. 克隆项目
+
+```bash
+git clone https://github.com/ThreeFish-AI/negentropy.git
+cd negentropy
+```
+
+### 2. 启动后端
+
+```bash
+cd apps/negentropy
+cp .env.example .env          # 复制并填写环境变量
+uv sync --dev                  # 安装全部依赖（含开发依赖）
+uv run alembic upgrade head    # 应用数据库迁移
+uv run adk web --port 8000 --reload_agents src/negentropy  # 启动引擎
+```
+
+### 3. 启动前端
+
+```bash
+cd apps/negentropy-ui
+pnpm install                   # 安装依赖
+pnpm run dev                   # 启动开发服务器 (localhost:3333)
+```
+
+### 4. 开始对话
+
+打开浏览器访问 `http://localhost:3333`，开始与 NegentropyEngine 对话。
+
+> 完整的环境搭建指南、数据库迁移、前后端对接、故障排查详见 [docs/development.md](../development.md)。
+
+---
+
+## 🏛️ 架构概览
+
+<p align="center">
+  <b><strong>设计哲学</strong> | 系统的命名源自薛定谔 (Erwin Schrödinger) 在《生命是什么？》中提出的概念——生命以<strong>负熵 (Negentropy)</strong> 为食<sup><link url=#ref1>1</link></sup>。
+</p>
+
+### 一核五翼
+
+**NegentropyEngine** 不直接执行原子任务，只做调度决策。五个系部各司其职，三条流水线封装常见的多系部协作模式。架构遵循**正交分解**原则，确保系部间职责独立、变更局部化。
+
+<center>
+
+| 图腾  | 系部        | Agent 名称               | 对抗目标 | 核心职责                             | 专属工具                                   |
+| :---: | :---------- | :----------------------- | :------- | :----------------------------------- | :----------------------------------------- |
+|   👁️   | 慧眼 · 感知 | `PerceptionFaculty`      | 信息过载 | 广域扫描、噪音过滤、多源交叉验证     | `search_knowledge_base`, `search_web`      |
+|   💎   | 本心 · 内化 | `InternalizationFaculty` | 遗忘     | 知识结构化、长期记忆管理、一致性维护 | `save_to_memory`, `update_knowledge_graph` |
+|   🧠   | 元神 · 坐照 | `ContemplationFaculty`   | 肤浅     | 二阶思维、策略规划、错误根因分析     | `analyze_context`, `create_plan`           |
+|   ✋   | 妙手 · 知行 | `ActionFaculty`          | 虚谈     | 精准执行、代码生成、安全变更         | `execute_code`, `read_file`, `write_file`  |
+|   🗣️   | 喉舌 · 影响 | `InfluenceFaculty`       | 晦涩     | 价值传递、格式适配、说服与教育       | `publish_content`, `send_notification`     |
+
+</center>
+
+> 完整的架构设计方案、流水线编排机制、设计模式目录详见 [docs/framework.md](../framework.md)。
+
+### 三层架构
+
+```mermaid
+graph TB
+    subgraph Presentation["🖥️ 展示层"]
+        UI["negentropy-ui<br/><i>Next.js 22 · React 19 · Tailwind</i>"]
+        Wiki["negentropy-wiki<br/><i>Next.js</i>"]
+    end
+
+    subgraph Engine["⚙️ 引擎层"]
+        Root["🔮 NegentropyEngine<br/>本我"]
+        Faculties["五大系部<br/>👁️ 感知 · 💎 内化 · 🧠 坐照 · ✋ 知行 · 🗣️ 影响"]
+        Pipelines["三条流水线<br/>知识获取 · 问题解决 · 价值交付"]
+    end
+
+    subgraph Infra["🏗️ 基础设施层"]
+        DB[("PostgreSQL 16+<br/>pgvector")]
+        LLM["LiteLLM<br/>100+ LLM 统一接口"]
+        OTel["OpenTelemetry · Langfuse"]
+        Sandbox["MCP · MicroSandbox"]
+    end
+
+    UI -->|"AG-UI Protocol"| Root
+    Wiki -->|"HTTP/JSON"| Root
+    Root --> Faculties
+    Root --> Pipelines
+    Pipelines --> Faculties
+    Faculties --> DB
+    Faculties --> Sandbox
+    Root --> LLM
+    Root -.-> OTel
+
+    classDef pres fill:#60A5FA,stroke:#1E3A8A,color:#000
+    classDef eng fill:#F59E0B,stroke:#92400E,color:#000
+    classDef infra fill:#10B981,stroke:#065F46,color:#FFF
+
+    class UI,Wiki pres
+    class Root,Faculties,Pipelines eng
+    class DB,LLM,OTel,Sandbox infra
+```
+
+---
+
+## 📚 文档导航
+
+<center>
+
+| 文档                                        | 说明                                                                 |
+| :------------------------------------------ | :------------------------------------------------------------------- |
+| [开发指南](../development.md)               | 环境搭建、日常开发工作流、数据库迁移、前后端对接、故障排查           |
+| [架构设计](../framework.md)                 | 一核五翼详解、流水线编排、设计模式目录、引擎层、数据持久化、前端架构 |
+| [知识系统](../knowledges.md)                | 知识管理模块的详细设计与使用                                         |
+| [记忆系统](../memory.md)                    | 记忆生命周期、遗忘曲线、治理机制                                     |
+| [知识图谱](../knowledge-graph.md)           | 知识图谱建模与查询                                                   |
+| [QA 流水线](../qa-delivery-pipeline.md)     | 质量门禁与发布流程                                                   |
+| [SSO 集成](../sso.md)                       | Google OAuth 认证配置                                                |
+| [工程变更日志](../engineering-changelog.md) | 里程碑与基线变更记录                                                 |
+| [AI 协作协议](../../AGENTS.md)              | Agent 协作行为准则与工程规范                                         |
+
+</center>
+
+---
+
+## 🤝 社区与贡献
+
+如果您手中正握有将混沌拉回秩序的灵感，或在使用过程中遇到任何问题，请务必不吝赐教：
+
+1. 动键盘前，烦请顺路翻转一页 [开发指南](../development.md)
+2. 将您的重磅想法掷向 [Issue](https://github.com/ThreeFish-AI/negentropy/issues) 或直接提送带有改变战局力量的 [Pull Request](https://github.com/ThreeFish-AI/negentropy/pulls)
+
+请以「熵减」、「上下文驱动」、「循证工程」为**核心原则**，确保所有变更符合 Systemic Integrity (系统完整性) 要求。
+
+---
+
+<a id="ref1"></a>[1] E. Schrödinger, "What is Life? The Physical Aspect of the Living Cell," _Cambridge University Press_, 1944.
+
+---
+
+<p align="center">
+  <a href="../../LICENSE">Apache License 2.0</a>, © 2026 <a href="https://github.com/ThreeFish-AI">ThreeFish-AI</a>
+</p>


### PR DESCRIPTION
docs(README): 将主 README 国际化为英文，中文版迁移至 docs/zh-CN/;

fix(Security): 使用 uv override-dependencies 强制升级 aiohttp 至 3.13.5，消除 19 个 CVE 告警;

microsandbox==0.1.8 严格约束 aiohttp>=3.10.0,<3.11.0，导致 19 个 CVE-2025/2026 安全漏洞无法修复。
通过 uv override-dependencies 机制突破该约束，将 aiohttp 从 3.10.11 升级至 3.13.5，
覆盖修复全部 19 项告警（含 1 项 High、8 项 Medium、10 项 Low）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>