### PR TITLE
重命名预置 MCP Server「data-extractor」为「negentropy-perceives」

### DIFF
--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -31,13 +31,13 @@ class DefaultExtractorRoutesSettings(BaseModel):
     url: DefaultExtractorRouteSettings = Field(
         default_factory=lambda: DefaultExtractorRouteSettings(
             primary=DefaultExtractorTargetSettings(
-                server_name="data-extractor",
-                tool_name="convert_webpage_to_markdown",
+                server_name="negentropy-perceives",
+                tool_name="parse_webpage_to_markdown",
                 timeout_ms=60_000,
             ),
             secondary=DefaultExtractorTargetSettings(
-                server_name="data-extractor",
-                tool_name="batch_convert_webpages_to_markdown",
+                server_name="negentropy-perceives",
+                tool_name="parse_webpages_to_markdown",
                 timeout_ms=120_000,
             ),
         )
@@ -45,13 +45,13 @@ class DefaultExtractorRoutesSettings(BaseModel):
     file_pdf: DefaultExtractorRouteSettings = Field(
         default_factory=lambda: DefaultExtractorRouteSettings(
             primary=DefaultExtractorTargetSettings(
-                server_name="data-extractor",
-                tool_name="convert_pdf_to_markdown",
+                server_name="negentropy-perceives",
+                tool_name="parse_pdf_to_markdown",
                 timeout_ms=300_000,
             ),
             secondary=DefaultExtractorTargetSettings(
-                server_name="data-extractor",
-                tool_name="batch_convert_pdfs_to_markdown",
+                server_name="negentropy-perceives",
+                tool_name="parse_pdfs_to_markdown",
                 timeout_ms=600_000,
             ),
         )

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0001_init_schema.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0001_init_schema.py
@@ -11,7 +11,7 @@ Create Date: 2026-04-08 00:00:00.000000+00:00
   - Pulse / Internalization / Perception / State / Action
   - Observability / Security / Plugin Ecosystem / Model Config / Knowledge Runtime
   - 共 42 张表、3 个枚举、1 个序列、HNSW/GIN/部分索引、TSVECTOR 触发器
-  - 种子数据：model_configs 默认模型 × 2 + data-extractor MCP 预设
+  - 种子数据：model_configs 默认模型 × 2 + negentropy-perceives MCP 预设
 """
 from typing import Sequence, Union
 
@@ -885,7 +885,7 @@ def upgrade() -> None:
         ],
     )
 
-    # Data Extractor MCP Server 预设（幂等 upsert）
+    # Negentropy Perceives MCP Server 预设（幂等 upsert）
     op.execute(sa.text(f"""
         INSERT INTO negentropy.mcp_servers (
             owner_id, visibility, name, display_name, description,
@@ -893,10 +893,10 @@ def upgrade() -> None:
             is_enabled, auto_start, config
         )
         VALUES (
-            'system:data-extractor-preset',
+            'system:negentropy-perceives-preset',
             'PUBLIC'::negentropy.pluginvisibility,
-            'data-extractor',
-            'Data Extractor',
+            'negentropy-perceives',
+            'Negentropy Perceives',
             '一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。',
             'http',
             NULL,

--- a/apps/negentropy/src/negentropy/knowledge/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/extraction.py
@@ -2227,7 +2227,7 @@ async def extract_source(
             await tracker.start_stage("extract_resolve")
         raise ExtractorExecutionError(
             f"No extractor targets configured for source kind '{source_kind}'. "
-            "Please configure the Data Extractor MCP service and ensure the corpus "
+            "Please configure the Negentropy Perceives MCP service and ensure the corpus "
             "has valid extractor_routes in its configuration.",
             attempts=[],
         )

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -651,7 +651,7 @@ class KnowledgeService:
                 if isinstance(exc, ExtractorExecutionError) and not exc.attempts:
                     url_details["failure_category"] = "no_extractor_configured"
                     url_details["diagnostic_summary"] = (
-                        "请配置 Data Extractor MCP 服务，"
+                        "请配置 Negentropy Perceives MCP 服务，"
                         "并确保 Corpus 的 extractor_routes 配置正确。"
                     )
                 raise KnowledgeError(
@@ -760,7 +760,7 @@ class KnowledgeService:
                 if isinstance(exc, ExtractorExecutionError) and not exc.attempts:
                     details["failure_category"] = "no_extractor_configured"
                     details["diagnostic_summary"] = (
-                        "请配置 Data Extractor MCP 服务，"
+                        "请配置 Negentropy Perceives MCP 服务，"
                         "并确保 Corpus 的 extractor_routes 配置正确。"
                     )
                 raise KnowledgeError(

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -626,7 +626,7 @@ class DocumentStorageService:
         content: bytes,
         content_type: str,
     ) -> Optional[str]:
-        """上传 Data Extractor 生成的衍生资源。"""
+        """上传 Negentropy Perceives 生成的衍生资源。"""
         doc = await self.get_document(document_id=document_id)
         if not doc:
             return None
@@ -659,7 +659,7 @@ class DocumentStorageService:
         document_id: UUID,
         filename: str,
     ) -> Optional[bytes]:
-        """从 GCS 下载 Data Extractor 生成的衍生资源。"""
+        """从 GCS 下载 Negentropy Perceives 生成的衍生资源。"""
         doc = await self.get_document(document_id=document_id)
         if not doc:
             return None

--- a/apps/negentropy/tests/integration_tests/db/test_migrations.py
+++ b/apps/negentropy/tests/integration_tests/db/test_migrations.py
@@ -58,8 +58,8 @@ def test_migrations_stairway(alembic_config: Config):
     command.upgrade(alembic_config, "head")
 
 
-def test_data_extractor_seeded_by_migration(alembic_config: Config):
-    """Ensure the Data Extractor MCP server is present with the official preset config."""
+def test_negentropy_perceives_seeded_by_migration(alembic_config: Config):
+    """Ensure the Negentropy Perceives MCP server is present with the official preset config."""
 
     command.upgrade(alembic_config, "head")
 
@@ -78,15 +78,15 @@ def test_data_extractor_seeded_by_migration(alembic_config: Config):
                         is_enabled,
                         auto_start
                     FROM negentropy.mcp_servers
-                    WHERE name = 'data-extractor'
+                    WHERE name = 'negentropy-perceives'
                 """)
             ).mappings().one()
     finally:
         engine.dispose()
 
-    assert row["owner_id"] == "system:data-extractor-preset"
+    assert row["owner_id"] == "system:negentropy-perceives-preset"
     assert row["visibility"] == "PUBLIC"
-    assert row["display_name"] == "Data Extractor"
+    assert row["display_name"] == "Negentropy Perceives"
     assert row["description"] == (
         "一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
     )
@@ -96,8 +96,8 @@ def test_data_extractor_seeded_by_migration(alembic_config: Config):
     assert row["auto_start"] is True
 
 
-def test_data_extractor_seed_is_idempotent_on_re_upgrade(alembic_config: Config):
-    """Ensure the data-extractor seed survives a full downgrade → re-upgrade cycle.
+def test_negentropy_perceives_seed_is_idempotent_on_re_upgrade(alembic_config: Config):
+    """Ensure the negentropy-perceives seed survives a full downgrade → re-upgrade cycle.
 
     合并后仅有一个迁移文件，无法升级到中间版本。
     改为验证：全量升级 → 污染数据 → 全量降级 → 全量重升级后，
@@ -107,7 +107,7 @@ def test_data_extractor_seed_is_idempotent_on_re_upgrade(alembic_config: Config)
     # 1. 升级到 HEAD（创建种子数据）
     command.upgrade(alembic_config, "head")
 
-    # 2. 手动污染 data-extractor 记录
+    # 2. 手动污染 negentropy-perceives 记录
     engine = create_engine(_sync_database_url())
     try:
         with engine.begin() as conn:
@@ -129,7 +129,7 @@ def test_data_extractor_seed_is_idempotent_on_re_upgrade(alembic_config: Config)
                         auto_start = FALSE,
                         config = '{}'::jsonb,
                         updated_at = now()
-                    WHERE name = 'data-extractor'
+                    WHERE name = 'negentropy-perceives'
                 """)
             )
     finally:
@@ -156,15 +156,15 @@ def test_data_extractor_seed_is_idempotent_on_re_upgrade(alembic_config: Config)
                         is_enabled,
                         auto_start
                     FROM negentropy.mcp_servers
-                    WHERE name = 'data-extractor'
+                    WHERE name = 'negentropy-perceives'
                 """)
             ).mappings().one()
     finally:
         engine.dispose()
 
-    assert row["owner_id"] == "system:data-extractor-preset"
+    assert row["owner_id"] == "system:negentropy-perceives-preset"
     assert row["visibility"] == "PUBLIC"
-    assert row["display_name"] == "Data Extractor"
+    assert row["display_name"] == "Negentropy Perceives"
     assert row["description"] == (
         "一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
     )

--- a/apps/negentropy/tests/unit_tests/knowledge/conftest.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/conftest.py
@@ -595,7 +595,7 @@ def make_tracking_context(
     tracker_run_id: str = "run-test-001",
     corpus_id: UUID | None = None,
     app_name: str = "negentropy",
-    mcp_tool_name: str | None = "convert_pdf_to_markdown",
+    mcp_tool_name: str | None = "parse_pdf_to_markdown",
     mcp_server_id: UUID | None = None,
 ):
     """工厂函数：快速构建 TrackingContext 实例。"""

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py
@@ -60,22 +60,22 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
             return {
                 "url": {
                     "primary": {
-                        "server_name": "data-extractor",
-                        "tool_name": "convert_webpage_to_markdown",
+                        "server_name": "negentropy-perceives",
+                        "tool_name": "parse_webpage_to_markdown",
                     },
                     "secondary": {
-                        "server_name": "data-extractor",
-                        "tool_name": "batch_convert_webpages_to_markdown",
+                        "server_name": "negentropy-perceives",
+                        "tool_name": "parse_webpages_to_markdown",
                     },
                 },
                 "file_pdf": {
                     "primary": {
-                        "server_name": "data-extractor",
-                        "tool_name": "convert_pdf_to_markdown",
+                        "server_name": "negentropy-perceives",
+                        "tool_name": "parse_pdf_to_markdown",
                     },
                     "secondary": {
-                        "server_name": "data-extractor",
-                        "tool_name": "batch_convert_pdfs_to_markdown",
+                        "server_name": "negentropy-perceives",
+                        "tool_name": "parse_pdfs_to_markdown",
                     },
                 },
             }
@@ -95,12 +95,12 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
         "AsyncSessionLocal",
         lambda: FakeDefaultRouteSession(
             responses=[
-                [(server_id, "data-extractor")],
+                [(server_id, "negentropy-perceives")],
                 [
-                    (server_id, "convert_webpage_to_markdown"),
-                    (server_id, "batch_convert_webpages_to_markdown"),
-                    (server_id, "convert_pdf_to_markdown"),
-                    (server_id, "batch_convert_pdfs_to_markdown"),
+                    (server_id, "parse_webpage_to_markdown"),
+                    (server_id, "parse_webpages_to_markdown"),
+                    (server_id, "parse_pdf_to_markdown"),
+                    (server_id, "parse_pdfs_to_markdown"),
                 ],
             ]
         ),
@@ -120,13 +120,13 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
             "targets": [
                 {
                     "server_id": str(server_id),
-                    "tool_name": "convert_webpage_to_markdown",
+                    "tool_name": "parse_webpage_to_markdown",
                     "priority": 0,
                     "enabled": True,
                 },
                 {
                     "server_id": str(server_id),
-                    "tool_name": "batch_convert_webpages_to_markdown",
+                    "tool_name": "parse_webpages_to_markdown",
                     "priority": 1,
                     "enabled": True,
                 },
@@ -136,20 +136,20 @@ async def test_create_corpus_injects_backend_default_extractor_routes(monkeypatc
             "targets": [
                 {
                     "server_id": str(server_id),
-                    "tool_name": "convert_pdf_to_markdown",
+                    "tool_name": "parse_pdf_to_markdown",
                     "priority": 0,
                     "enabled": True,
                 },
                 {
                     "server_id": str(server_id),
-                    "tool_name": "batch_convert_pdfs_to_markdown",
+                    "tool_name": "parse_pdfs_to_markdown",
                     "priority": 1,
                     "enabled": True,
                 },
             ]
         },
     }
-    assert result.config["extractor_routes"]["url"]["targets"][0]["tool_name"] == "convert_webpage_to_markdown"
+    assert result.config["extractor_routes"]["url"]["targets"][0]["tool_name"] == "parse_webpage_to_markdown"
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_contracts.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_contracts.py
@@ -164,7 +164,7 @@ def test_extraction_attempt_slots_dataclass_is_json_serialized_in_trace() -> Non
     attempt = ExtractionAttempt(
         server_id="server-1",
         server_name="extractor",
-        tool_name="convert_pdf_to_markdown",
+        tool_name="parse_pdf_to_markdown",
         status="completed",
         duration_ms=12,
     )
@@ -175,7 +175,7 @@ def test_extraction_attempt_slots_dataclass_is_json_serialized_in_trace() -> Non
         {
             "server_id": "server-1",
             "server_name": "extractor",
-            "tool_name": "convert_pdf_to_markdown",
+            "tool_name": "parse_pdf_to_markdown",
             "status": "completed",
             "duration_ms": 12,
             "error": None,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_llm_plan.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_llm_plan.py
@@ -62,7 +62,7 @@ async def test_build_llm_invocation_plan_supports_slots_dataclass_request(monkey
     )
 
     plan = await _build_llm_invocation_plan(
-        tool_name="convert_pdf_to_markdown",
+        tool_name="parse_pdf_to_markdown",
         tool_description="single pdf",
         input_schema=contract.root_schema,
         contract=contract,
@@ -122,7 +122,7 @@ async def test_build_llm_invocation_plan_skips_llm_for_object_file_contract(monk
     )
 
     plan = await _build_llm_invocation_plan(
-        tool_name="batch_convert_pdfs_to_markdown",
+        tool_name="parse_pdfs_to_markdown",
         tool_description="batch pdfs",
         input_schema=contract.root_schema,
         contract=contract,
@@ -151,7 +151,7 @@ async def test_build_llm_invocation_plan_returns_none_when_serialization_fails(m
     )
 
     plan = await _build_llm_invocation_plan(
-        tool_name="convert_pdf_to_markdown",
+        tool_name="parse_pdf_to_markdown",
         tool_description="single pdf",
         input_schema=contract.root_schema,
         contract=contract,
@@ -191,7 +191,7 @@ async def test_build_llm_invocation_plan_logs_info_when_json_is_invalid(monkeypa
     )
 
     plan = await _build_llm_invocation_plan(
-        tool_name="convert_pdf_to_markdown",
+        tool_name="parse_pdf_to_markdown",
         tool_description="single pdf",
         input_schema=contract.root_schema,
         contract=contract,
@@ -204,7 +204,7 @@ async def test_build_llm_invocation_plan_logs_info_when_json_is_invalid(monkeypa
         (
             "extractor_llm_plan_invalid_json",
             {
-                "tool_name": "convert_pdf_to_markdown",
+                "tool_name": "parse_pdf_to_markdown",
                 "fallback_strategy": "schema_or_default_contract",
                 "reason": "invalid_json",
             },
@@ -245,7 +245,7 @@ async def test_build_llm_invocation_plan_skips_llm_when_prompt_payload_is_not_js
     )
 
     plan = await _build_llm_invocation_plan(
-        tool_name="convert_pdf_to_markdown",
+        tool_name="parse_pdf_to_markdown",
         tool_description="single pdf",
         input_schema=contract.root_schema,
         contract=contract,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
@@ -25,7 +25,7 @@ from .conftest import FakeMcpSession, noop_increment_tool_call_count, noop_llm_p
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_uses_pdf_batch_schema_and_normalizes_batch_result(
+async def test_negentropy_perceives_provider_uses_pdf_batch_schema_and_normalizes_batch_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -92,7 +92,7 @@ async def test_data_extractor_provider_uses_pdf_batch_schema_and_normalizes_batc
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="batch_convert_pdfs_to_markdown",
+            tool_name="parse_pdfs_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -122,7 +122,7 @@ async def test_data_extractor_provider_uses_pdf_batch_schema_and_normalizes_batc
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_normalizes_list_structured_content(
+async def test_negentropy_perceives_provider_normalizes_list_structured_content(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -168,7 +168,7 @@ async def test_data_extractor_provider_normalizes_list_structured_content(
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="batch_convert_pdfs_to_markdown",
+            tool_name="parse_pdfs_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -191,7 +191,7 @@ async def test_data_extractor_provider_normalizes_list_structured_content(
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_normalizes_json_text_content_when_structured_content_missing(
+async def test_negentropy_perceives_provider_normalizes_json_text_content_when_structured_content_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -232,7 +232,7 @@ async def test_data_extractor_provider_normalizes_json_text_content_when_structu
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -250,7 +250,7 @@ async def test_data_extractor_provider_normalizes_json_text_content_when_structu
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_rejects_failed_json_text_envelope(
+async def test_negentropy_perceives_provider_rejects_failed_json_text_envelope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -294,7 +294,7 @@ async def test_data_extractor_provider_rejects_failed_json_text_envelope(
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -310,7 +310,7 @@ async def test_data_extractor_provider_rejects_failed_json_text_envelope(
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_uses_plain_text_content_when_json_is_unavailable(
+async def test_negentropy_perceives_provider_uses_plain_text_content_when_json_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -351,7 +351,7 @@ async def test_data_extractor_provider_uses_plain_text_content_when_json_is_unav
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -374,7 +374,7 @@ async def test_data_extractor_provider_uses_plain_text_content_when_json_is_unav
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_rejects_batch_payload_without_successful_documents(
+async def test_negentropy_perceives_provider_rejects_batch_payload_without_successful_documents(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -422,7 +422,7 @@ async def test_data_extractor_provider_rejects_batch_payload_without_successful_
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="batch_convert_pdfs_to_markdown",
+            tool_name="parse_pdfs_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -443,7 +443,7 @@ async def test_data_extractor_provider_rejects_batch_payload_without_successful_
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_retries_after_validation_error_with_batch_wrapper(
+async def test_negentropy_perceives_provider_retries_after_validation_error_with_batch_wrapper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -462,7 +462,7 @@ async def test_data_extractor_provider_retries_after_validation_error_with_batch
                     structured_content=None,
                     content=[],
                     error=(
-                        "7 validation errors for call[batch_convert_pdfs_to_markdown]\n"
+                        "7 validation errors for call[parse_pdfs_to_markdown]\n"
                         "pdf_sources\n  Missing required argument\n"
                         "source_type\n  Unexpected keyword argument\n"
                         "content_base64\n  Unexpected keyword argument\n"
@@ -507,7 +507,7 @@ async def test_data_extractor_provider_retries_after_validation_error_with_batch
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="batch_convert_pdfs_to_markdown",
+            tool_name="parse_pdfs_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -541,7 +541,7 @@ async def test_data_extractor_provider_retries_after_validation_error_with_batch
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_uses_schema_string_source_for_single_pdf_without_llm(
+async def test_negentropy_perceives_provider_uses_schema_string_source_for_single_pdf_without_llm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -562,7 +562,7 @@ async def test_data_extractor_provider_uses_schema_string_source_for_single_pdf_
         "negentropy.knowledge.extraction.AsyncSessionLocal",
         lambda: FakeMcpSession(
             server_id=server_id,
-            server_name="data-extractor",
+            server_name="negentropy-perceives",
             input_schema={
                 "type": "object",
                 "properties": {
@@ -591,7 +591,7 @@ async def test_data_extractor_provider_uses_schema_string_source_for_single_pdf_
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -612,7 +612,7 @@ async def test_data_extractor_provider_uses_schema_string_source_for_single_pdf_
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_uses_llm_selected_string_source_for_single_pdf(
+async def test_negentropy_perceives_provider_uses_llm_selected_string_source_for_single_pdf(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -636,7 +636,7 @@ async def test_data_extractor_provider_uses_llm_selected_string_source_for_singl
                 error=None,
                 tools=[
                     SimpleNamespace(
-                        name="convert_pdf_to_markdown",
+                        name="parse_pdf_to_markdown",
                         description="single pdf",
                         input_schema={
                             "type": "object",
@@ -662,7 +662,7 @@ async def test_data_extractor_provider_uses_llm_selected_string_source_for_singl
         "negentropy.knowledge.extraction.AsyncSessionLocal",
         lambda: FakeMcpSession(
             server_id=server_id,
-            server_name="data-extractor",
+            server_name="negentropy-perceives",
             scalar_returns_none=True,
         ),
     )
@@ -683,7 +683,7 @@ async def test_data_extractor_provider_uses_llm_selected_string_source_for_singl
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -701,7 +701,7 @@ async def test_data_extractor_provider_uses_llm_selected_string_source_for_singl
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_keeps_string_contract_on_missing_single_source_retry(
+async def test_negentropy_perceives_provider_keeps_string_contract_on_missing_single_source_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -720,7 +720,7 @@ async def test_data_extractor_provider_keeps_string_contract_on_missing_single_s
                     structured_content=None,
                     content=[],
                     error=(
-                        "1 validation error for call[convert_pdf_to_markdown]\n"
+                        "1 validation error for call[parse_pdf_to_markdown]\n"
                         "pdf_source\n  Missing required argument\n"
                     ),
                     duration_ms=8,
@@ -764,7 +764,7 @@ async def test_data_extractor_provider_keeps_string_contract_on_missing_single_s
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -784,7 +784,7 @@ async def test_data_extractor_provider_keeps_string_contract_on_missing_single_s
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_fails_fast_when_single_string_source_has_no_candidate(
+async def test_negentropy_perceives_provider_fails_fast_when_single_string_source_has_no_candidate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -834,7 +834,7 @@ async def test_data_extractor_provider_fails_fast_when_single_string_source_has_
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -857,7 +857,7 @@ async def test_data_extractor_provider_fails_fast_when_single_string_source_has_
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_failovers_when_primary_returns_empty_payload(
+async def test_negentropy_perceives_provider_failovers_when_primary_returns_empty_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -929,7 +929,7 @@ async def test_data_extractor_provider_failovers_when_primary_returns_empty_payl
                 "file_pdf": {
                     "targets": [
                         {"server_id": str(server_id), "tool_name": "convert_pdfs_to_markdown", "priority": 0},
-                        {"server_id": str(server_id), "tool_name": "batch_convert_pdfs_to_markdown", "priority": 1},
+                        {"server_id": str(server_id), "tool_name": "parse_pdfs_to_markdown", "priority": 1},
                     ]
                 }
             }
@@ -950,7 +950,7 @@ async def test_data_extractor_provider_failovers_when_primary_returns_empty_payl
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_marks_unknown_contract_as_unsupported_for_failover(
+async def test_negentropy_perceives_provider_marks_unknown_contract_as_unsupported_for_failover(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -970,7 +970,7 @@ async def test_data_extractor_provider_marks_unknown_contract_as_unsupported_for
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -989,7 +989,7 @@ async def test_data_extractor_provider_marks_unknown_contract_as_unsupported_for
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_marks_unknown_contract_with_extra_required_fields_as_low_confidence(
+async def test_negentropy_perceives_provider_marks_unknown_contract_with_extra_required_fields_as_low_confidence(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -1016,7 +1016,7 @@ async def test_data_extractor_provider_marks_unknown_contract_with_extra_require
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -1040,7 +1040,7 @@ async def test_data_extractor_provider_marks_unknown_contract_with_extra_require
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_retries_with_string_batch_contract_after_string_type_error(
+async def test_negentropy_perceives_provider_retries_with_string_batch_contract_after_string_type_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     server_id = uuid4()
@@ -1060,7 +1060,7 @@ async def test_data_extractor_provider_retries_with_string_batch_contract_after_
                     structured_content=None,
                     content=[],
                     error=(
-                        "1 validation error for call[batch_convert_pdfs_to_markdown]\n"
+                        "1 validation error for call[parse_pdfs_to_markdown]\n"
                         "pdf_sources.0\n  Input should be a valid string\n"
                     ),
                     duration_ms=7,
@@ -1094,7 +1094,7 @@ async def test_data_extractor_provider_retries_with_string_batch_contract_after_
         "negentropy.knowledge.extraction.AsyncSessionLocal",
         lambda: FakeMcpSession(
             server_id=server_id,
-            server_name="data-extractor",
+            server_name="negentropy-perceives",
             input_schema={
                 "type": "object",
                 "properties": {
@@ -1122,7 +1122,7 @@ async def test_data_extractor_provider_retries_with_string_batch_contract_after_
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="batch_convert_pdfs_to_markdown",
+            tool_name="parse_pdfs_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -1146,7 +1146,7 @@ async def test_data_extractor_provider_retries_with_string_batch_contract_after_
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_merges_image_content_items_into_assets(
+async def test_negentropy_perceives_provider_merges_image_content_items_into_assets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """当 structured_content 不含 assets，但 content_items 有 ImageContent 时，
@@ -1219,7 +1219,7 @@ async def test_data_extractor_provider_merges_image_content_items_into_assets(
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -1246,7 +1246,7 @@ async def test_data_extractor_provider_merges_image_content_items_into_assets(
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_structured_assets_take_precedence_over_content_items(
+async def test_negentropy_perceives_provider_structured_assets_take_precedence_over_content_items(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """当 structured_content 中已包含带 data_base64 的 assets，
@@ -1310,7 +1310,7 @@ async def test_data_extractor_provider_structured_assets_take_precedence_over_co
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),
@@ -1330,7 +1330,7 @@ async def test_data_extractor_provider_structured_assets_take_precedence_over_co
 
 
 @pytest.mark.asyncio
-async def test_data_extractor_provider_reads_enhanced_assets_from_output_directory(
+async def test_negentropy_perceives_provider_reads_enhanced_assets_from_output_directory(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1387,7 +1387,7 @@ async def test_data_extractor_provider_reads_enhanced_assets_from_output_directo
         corpus_id=uuid4(),
         target=SimpleNamespace(
             server_id=server_id,
-            tool_name="convert_pdf_to_markdown",
+            tool_name="parse_pdf_to_markdown",
             timeout_ms=None,
             tool_options={},
         ),

--- a/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker.py
@@ -222,7 +222,7 @@ async def test_async_rebuild_pipeline_does_not_delete_existing_source_when_extra
         return ExtractedDocumentResult(
             plain_text="",
             markdown_content="",
-            trace={"provider": "mcp", "attempts": [{"tool_name": "convert_pdf_to_markdown", "failure_category": "empty_payload"}]},
+            trace={"provider": "mcp", "attempts": [{"tool_name": "parse_pdf_to_markdown", "failure_category": "empty_payload"}]},
         )
 
     monkeypatch.setattr(service, "_extract_file_document", fake_extract_file_document)
@@ -273,7 +273,7 @@ async def test_async_ingest_file_pipeline_marks_run_failed_when_extracted_docume
             markdown_content="",
             trace={
                 "provider": "mcp",
-                "attempts": [{"tool_name": "convert_pdf_to_markdown", "failure_category": "tool_execution_failed"}],
+                "attempts": [{"tool_name": "parse_pdf_to_markdown", "failure_category": "tool_execution_failed"}],
             },
         )
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_source_tracking.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_source_tracking.py
@@ -69,7 +69,7 @@ class TestUrlSourceTracker:
         assert meta["author"] == "John Doe"
         assert meta["extraction_duration_ms"] == 1234
         assert meta["extracted_summary"] is not None
-        assert meta["extractor_tool_name"] == "convert_pdf_to_markdown"
+        assert meta["extractor_tool_name"] == "parse_pdf_to_markdown"
 
     @pytest.mark.asyncio
     async def test_extract_metadata_title_from_metadata_priority(self) -> None:


### PR DESCRIPTION
## 概要

- 将系统预置 MCP Server 名称从 `data-extractor` 重命名为 `negentropy-perceives`
- 将 4 个工具名称从 `convert_*` / `batch_convert_*` 前缀统一为 `parse_*` 前缀
- 同步更新 Owner ID、Display Name、迁移种子数据、错误提示文案及全量测试用例

## 变更映射

| 旧值 | 新值 |
|------|------|
| `data-extractor` | `negentropy-perceives` |
| `system:data-extractor-preset` | `system:negentropy-perceives-preset` |
| `convert_pdf_to_markdown` | `parse_pdf_to_markdown` |
| `batch_convert_pdfs_to_markdown` | `parse_pdfs_to_markdown` |
| `convert_webpage_to_markdown` | `parse_webpage_to_markdown` |
| `batch_convert_webpages_to_markdown` | `parse_webpages_to_markdown` |

## 影响范围

- 配置文件（1）、迁移种子数据（1）、源码错误提示（3）、测试文件（8）
- 共 13 个文件，103 行增 / 103 行减（纯重命名替换）

## 测试计划

- [x] 全局 Grep 搜索确认旧名称零残留
- [x] 79 个单元测试全部通过

🤖 Generated with [Claude Code](https://github.com/claude)