### PR TITLE
build(pytest): 修复 CVE-2025-71176 安全漏洞，升级 pytest 至 >=9.0.3

### DIFF
--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",           # Testing framework
+    "pytest>=9.0.3",           # Testing framework (CVE-2025-71176: tmpdir handling)
     "pytest-asyncio>=1.3.0",   # Asyncio support for pytest
     "pytest-cov>=6.0.0",       # Coverage plugin for pytest
     "ruff>=0.14.14",           # Fast Python linter and formatter

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -1494,7 +1494,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.14" },
@@ -1955,7 +1955,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1964,9 +1964,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

- 修复 GitHub Dependabot 告警 #81：**CVE-2025-71176**（pytest tmpdir 不安全处理）
- 将 `pytest` 版本下限从 `>=9.0.2` 升级至 `>=9.0.3`，锁文件同步更新

## 变更范围

| 文件 | 变更说明 |
|------|---------|
| `apps/negentropy/pyproject.toml` | pytest 版本约束 `>=9.0.2` → `>=9.0.3` |
| `apps/negentropy/uv.lock` | 锁定 pytest 9.0.3（自动生成） |

## 影响分析

- **影响范围**：仅 dev 依赖，不影响生产运行时
- **风险等级**：低（patch 版本升级）
- **向后兼容**：完全兼容

## 测试计划

- [x] `uv lock` 解析成功，pytest 9.0.2 → 9.0.3
- [x] `uv run pytest` 执行通过（3 个既有 collection errors 与本次变更无关，为模块路径缺失问题）

🤖 Generated with [Claude Code](https://claude.com/claude-code)