### PR TITLE
build(security): 修复 Dependabot 安全告警，升级 pytest 并扩展 constraint-dependencies

### DIFF
--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -49,7 +49,8 @@
       "undici": ">=7.24.0",
       "dompurify": ">=3.3.2",
       "lodash-es": ">=4.18.1",
-      "picomatch": ">=4.0.4"
+      "picomatch": ">=4.0.4",
+      "follow-redirects": ">=1.16.0"
     }
   },
   "devDependencies": {

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   dompurify: '>=3.3.2'
   lodash-es: '>=4.18.1'
   picomatch: '>=4.0.4'
+  follow-redirects: '>=1.16.0'
 
 importers:
 

--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",           # Testing framework
+    "pytest>=9.0.3",           # Testing framework (CVE: vulnerable tmpdir handling)
     "pytest-asyncio>=1.3.0",   # Asyncio support for pytest
     "pytest-cov>=6.0.0",       # Coverage plugin for pytest
     "ruff>=0.14.14",           # Fast Python linter and formatter
@@ -118,10 +118,37 @@ override-dependencies = [
     "aiohttp>=3.13.4",      # CVE-2025/2026 (19 个): microsandbox==0.1.8 锁死 <3.11.0, 强制覆盖升级
 ]
 constraint-dependencies = [
+    # ── 既有约束 ──
     "authlib>=1.6.9",       # CVE-2026-27962 (critical) + CVE-2026-28490/28498/28802
     "pyasn1>=0.6.3",        # CVE-2026-30922: unbounded recursion DoS
     "pyjwt>=2.12.0",        # CVE-2026-32597: unknown crit header extensions
     "cryptography>=46.0.7", # CVE-2026: buffer overflow, subgroup attack, DNS constraint
     "pygments>=2.20.0",     # CVE-2026-4539: ReDoS via GUID regex
     "requests>=2.33.0",     # CVE-2026-25645: insecure temp file reuse
+    # ── 新增约束 (上游传递依赖防御性声明) ──
+    "pillow>=12.2.0",       # FITS GZIP decompression bomb + OOB write (high)
+    "pypdf>=6.10.0",        # 14 个 DoS/RAM 耗尽漏洞 (medium)
+    "transformers>=4.53.0", # ReDoS + Trainer 任意代码执行 (medium)
+    "tornado>=6.5.5",       # cookie injection + DoS multipart (high)
+    "ujson>=5.12.0",        # integer overflow buffer overflow + memory leak (high)
+    "fickling>=0.1.10",     # 11 个 pickle 安全检查绕过 (high)
+    "nltk>=3.9.4",          # Zip Slip + XSS (critical/medium, 另有 3 个无补丁)
+    "ecdsa>=0.19.2",        # DER 长度验证 DoS (medium, 另 #195 无补丁)
+    "h2>=4.3.0",            # HTTP Request Smuggling (medium)
+    "marshmallow>=3.26.2",  # Schema.load DoS (medium)
+    "markdown>=3.8.1",      # Uncaught Exception (medium)
+    "werkzeug>=3.1.6",      # Windows 特殊设备名路径穿越 (medium)
+    "flask>=3.1.3",         # session Vary: Cookie 缺失 (low)
+    "markdownify>=0.14.1",  # 大 headline 内存消耗 (low)
+    "unstructured>=0.18.18",# MSG 附件路径穿越任意文件写入 (critical)
+    "brotli>=1.2.0",        # decompression DoS (high)
+    "azure-core>=1.38.0",   # 不可信数据反序列化 (high)
+    "aiomysql>=0.3.0",      # 恶意 MySQL 服务器客户端文件访问 (high)
+    "pyopenssl>=26.0.0",    # DTLS cookie callback 缓冲区溢出 (high)
+    "starlette>=0.50.0",    # O(n²) Range header DoS + multipart DoS (high)
+    "protobuf>=5.29.6",     # JSON recursion depth bypass (high)
+    "urllib3>=2.6.3",       # 解压缩炸弹 + 无限链解压缩 (high)
+    "filelock>=3.20.3",     # TOCTOU symlink 竞争 (medium)
+    "orjson>=3.11.6",       # 无限递归 DoS (high)
+    "google-cloud-aiplatform>=1.133.0", # 可预测 bucket 命名 (high)
 ]

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -4,12 +4,37 @@ requires-python = "==3.13.*"
 
 [manifest]
 constraints = [
+    { name = "aiomysql", specifier = ">=0.3.0" },
     { name = "authlib", specifier = ">=1.6.9" },
+    { name = "azure-core", specifier = ">=1.38.0" },
+    { name = "brotli", specifier = ">=1.2.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "ecdsa", specifier = ">=0.19.2" },
+    { name = "fickling", specifier = ">=0.1.10" },
+    { name = "filelock", specifier = ">=3.20.3" },
+    { name = "flask", specifier = ">=3.1.3" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.133.0" },
+    { name = "h2", specifier = ">=4.3.0" },
+    { name = "markdown", specifier = ">=3.8.1" },
+    { name = "markdownify", specifier = ">=0.14.1" },
+    { name = "marshmallow", specifier = ">=3.26.2" },
+    { name = "nltk", specifier = ">=3.9.4" },
+    { name = "orjson", specifier = ">=3.11.6" },
+    { name = "pillow", specifier = ">=12.2.0" },
+    { name = "protobuf", specifier = ">=5.29.6" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pyopenssl", specifier = ">=26.0.0" },
+    { name = "pypdf", specifier = ">=6.10.0" },
     { name = "requests", specifier = ">=2.33.0" },
+    { name = "starlette", specifier = ">=0.50.0" },
+    { name = "tornado", specifier = ">=6.5.5" },
+    { name = "transformers", specifier = ">=4.53.0" },
+    { name = "ujson", specifier = ">=5.12.0" },
+    { name = "unstructured", specifier = ">=0.18.18" },
+    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "werkzeug", specifier = ">=3.1.6" },
 ]
 overrides = [{ name = "aiohttp", specifier = ">=3.13.4" }]
 
@@ -1494,7 +1519,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.14" },
@@ -1955,7 +1980,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1964,9 +1989,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

修复上游仓库 `AfterShip/data.automizelyapi.com_ai-agents` Dependabot 页面报告的安全漏洞，从 negentropy 项目侧进行依赖升级与安全约束声明。

## 变更内容

### Python 后端 (`apps/negentropy/pyproject.toml` + `uv.lock`)

- **pytest** 9.0.2 → 9.0.3：修复临时目录处理不安全漏洞 (#303)
- **新增 25 项 `constraint-dependencies`**：为上游传递依赖添加防御性安全约束，覆盖 pillow、pypdf、transformers、tornado、ujson、fickling、nltk 等高危/关键漏洞包

### 前端 (`apps/negentropy-ui/package.json` + `pnpm-lock.yaml`)

- **pnpm overrides** 添加 `follow-redirects >= 1.16.0`：修复跨域重定向认证头泄露 (#305)

### 已在 negentropy 锁文件中修补的包（~35 个告警）

aiohttp、litellm、authlib、cryptography、pyasn1、pyjwt、pygments、requests、orjson、pyopenssl、protobuf、urllib3、starlette、filelock、google-cloud-aiplatform 等 15 个包已锁定在安全版本。

### 无补丁可用的告警（6 个）

- nltk #277/#279/#280（无补丁）
- diskcache #243（无补丁）
- ecdsa #195（无补丁）
- elliptic #115（无补丁，JS）

## 测试计划

- [x] `uv lock` 成功，pytest 升级至 9.0.3
- [x] `pnpm install` 成功，follow-redirects 约束已声明
- [ ] CI 后端测试通过
- [ ] CI 前端 typecheck + lint 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)