### PR TITLE
feat(vendor-config): 引入供应商级凭证管理

### DIFF
--- a/apps/negentropy-ui/app/admin/models/page.tsx
+++ b/apps/negentropy-ui/app/admin/models/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { AdminNav } from "@/components/ui/AdminNav";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface ModelConfig {
   id: string;
@@ -33,6 +34,7 @@ const VENDORS = [
   { value: "vertex_ai", label: "Vertex AI" },
   { value: "deepseek", label: "DeepSeek" },
   { value: "ollama", label: "Ollama" },
+  { value: "gemini", label: "Gemini" },
 ];
 
 const MODEL_TYPES = [
@@ -50,6 +52,36 @@ const EMPTY_FORM: ModelFormData = {
   enabled: true,
   config: {},
 };
+
+// --- Vendor Configuration ---
+
+interface VendorConfigData {
+  vendor: string;
+  apiKey: string | null;
+  apiBase: string | null;
+  configured: boolean;
+}
+
+const VENDOR_SETUP_CONFIG = [
+  {
+    value: "openai",
+    label: "OpenAI",
+    helpUrl: "https://platform.openai.com/api-keys",
+    baseUrlPlaceholder: "https://api.openai.com/v1",
+  },
+  {
+    value: "anthropic",
+    label: "Anthropic",
+    helpUrl: "https://console.anthropic.com/settings/keys",
+    baseUrlPlaceholder: "https://api.anthropic.com",
+  },
+  {
+    value: "gemini",
+    label: "Gemini",
+    helpUrl: "https://aistudio.google.com/apikey",
+    baseUrlPlaceholder: "https://generativelanguage.googleapis.com",
+  },
+];
 
 export default function ModelsPage() {
   const [models, setModels] = useState<Record<string, ModelConfig[]>>({
@@ -88,6 +120,15 @@ export default function ModelsPage() {
     latency_ms?: number;
   } | null>(null);
 
+  // --- Vendor config state ---
+  const [vendorConfigs, setVendorConfigs] = useState<VendorConfigData[]>([]);
+  const [vendorDialogOpen, setVendorDialogOpen] = useState(false);
+  const [vendorDialogVendor, setVendorDialogVendor] = useState<string | null>(null);
+  const [vendorApiKey, setVendorApiKey] = useState("");
+  const [vendorApiBase, setVendorApiBase] = useState("");
+  const [vendorApiKeyChanged, setVendorApiKeyChanged] = useState(false);
+  const [vendorSaving, setVendorSaving] = useState(false);
+
   const fetchModels = useCallback(async () => {
     try {
       setLoading(true);
@@ -103,9 +144,21 @@ export default function ModelsPage() {
     }
   }, []);
 
+  const fetchVendorConfigs = useCallback(async () => {
+    try {
+      const response = await fetch("/api/auth/admin/vendor-configs");
+      if (!response.ok) return;
+      const data = await response.json();
+      setVendorConfigs(data.vendorConfigs || []);
+    } catch {
+      // silently fail — vendor config is non-critical for page rendering
+    }
+  }, []);
+
   useEffect(() => {
     fetchModels();
-  }, [fetchModels]);
+    fetchVendorConfigs();
+  }, [fetchModels, fetchVendorConfigs]);
 
   const resetForm = () => {
     setForm(EMPTY_FORM);
@@ -293,6 +346,81 @@ export default function ModelsPage() {
     }
   };
 
+  // --- Vendor config handlers ---
+
+  const openVendorSetup = (vendor: string) => {
+    const existing = vendorConfigs.find((vc) => vc.vendor === vendor);
+    setVendorDialogVendor(vendor);
+    setVendorApiKey(""); // 始终为空，避免脱敏值被误提交
+    setVendorApiBase(existing?.apiBase ?? "");
+    setVendorApiKeyChanged(false);
+    setVendorDialogOpen(true);
+  };
+
+  const closeVendorDialog = () => {
+    setVendorDialogOpen(false);
+    setVendorDialogVendor(null);
+    setVendorApiKey("");
+    setVendorApiBase("");
+    setVendorApiKeyChanged(false);
+  };
+
+  const handleVendorSave = async () => {
+    if (!vendorDialogVendor) return;
+    const existing = vendorConfigs.find((vc) => vc.vendor === vendorDialogVendor);
+    const isEditing = existing?.configured ?? false;
+    // 新建时必须提供 API Key；编辑时可以为空（保留原值）
+    if (!isEditing && !vendorApiKey.trim()) return;
+    setVendorSaving(true);
+    try {
+      const payload: Record<string, string | null> = {};
+      if (vendorApiKeyChanged && vendorApiKey.trim()) {
+        payload.api_key = vendorApiKey.trim();
+      } else {
+        payload.api_key = null; // 告知后端保留原值
+      }
+      if (vendorApiBase.trim()) {
+        payload.api_base = vendorApiBase.trim();
+      }
+      const response = await fetch(`/api/auth/admin/vendor-configs/${vendorDialogVendor}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save vendor config");
+      }
+      await fetchVendorConfigs();
+      closeVendorDialog();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save vendor config");
+    } finally {
+      setVendorSaving(false);
+    }
+  };
+
+  const handleVendorRemove = async () => {
+    if (!vendorDialogVendor) return;
+    if (!window.confirm(`确认移除 ${vendorDialogVendor} 的供应商配置？`)) return;
+    setVendorSaving(true);
+    try {
+      const response = await fetch(`/api/auth/admin/vendor-configs/${vendorDialogVendor}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to remove vendor config");
+      }
+      await fetchVendorConfigs();
+      closeVendorDialog();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove vendor config");
+    } finally {
+      setVendorSaving(false);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
       <AdminNav title="Model Management" />
@@ -316,6 +444,55 @@ export default function ModelsPage() {
             </div>
           ) : (
             <>
+              {/* Vendor Configuration */}
+              <div className="mb-6">
+                <div className="flex items-center justify-between mb-3">
+                  <div>
+                    <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                      Vendor Credentials
+                    </h2>
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+                      Configure API keys for model vendors. All models share vendor credentials.
+                    </p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-3 gap-4">
+                  {VENDOR_SETUP_CONFIG.map((vc) => {
+                    const config = vendorConfigs.find((c) => c.vendor === vc.value);
+                    const isConfigured = config?.configured ?? false;
+                    return (
+                      <div
+                        key={vc.value}
+                        className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                              {vc.label}
+                            </h3>
+                            {isConfigured ? (
+                              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 mt-1">
+                                Configured
+                              </span>
+                            ) : (
+                              <span className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500 mt-1">
+                                Not configured
+                              </span>
+                            )}
+                          </div>
+                          <button
+                            onClick={() => openVendorSetup(vc.value)}
+                            className="px-3 py-1.5 rounded-lg text-xs font-medium bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+                          >
+                            {isConfigured ? "Edit" : "Setup"}
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
               {MODEL_TYPES.map((mt) => (
                 <div
                   key={mt.value}
@@ -715,6 +892,102 @@ export default function ModelsPage() {
               </div>
             </div>
           )}
+
+          {/* Vendor Setup Dialog */}
+          <OverlayDismissLayer
+            open={vendorDialogOpen}
+            onClose={closeVendorDialog}
+            busy={vendorSaving}
+            containerClassName="fixed inset-0 flex items-center justify-center p-4"
+            contentClassName="w-full max-w-md rounded-xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
+            contentProps={{ role: "dialog", "aria-modal": true }}
+          >
+            {vendorDialogVendor && (() => {
+              const vcInfo = VENDOR_SETUP_CONFIG.find((v) => v.value === vendorDialogVendor);
+              const existing = vendorConfigs.find((c) => c.vendor === vendorDialogVendor);
+              const isEditing = existing?.configured ?? false;
+              return (
+                <>
+                  <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+                    Setup {vcInfo?.label ?? vendorDialogVendor}
+                  </h3>
+
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+                        API Key <span className="text-red-500">*</span>
+                      </label>
+                      <input
+                        type="password"
+                        value={vendorApiKey}
+                        onChange={(e) => {
+                          setVendorApiKey(e.target.value);
+                          setVendorApiKeyChanged(true);
+                        }}
+                        placeholder={isEditing ? "留空则保持不变" : ""}
+                        className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm font-mono dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      />
+                      {isEditing && (
+                        <p className="mt-1 text-[10px] text-zinc-400">
+                          当前已配置 API Key，留空则保持不变
+                        </p>
+                      )}
+                    </div>
+
+                    <div>
+                      <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+                        Base URL (optional)
+                      </label>
+                      <input
+                        type="text"
+                        value={vendorApiBase}
+                        onChange={(e) => setVendorApiBase(e.target.value)}
+                        placeholder={vcInfo?.baseUrlPlaceholder}
+                        className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+                      />
+                    </div>
+
+                    {vcInfo && (
+                      <a
+                        href={vcInfo.helpUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                      >
+                        Get your API Key from {vcInfo.label} &rarr;
+                      </a>
+                    )}
+                  </div>
+
+                  <div className="mt-6 flex items-center justify-end gap-2">
+                    {isEditing && (
+                      <button
+                        onClick={handleVendorRemove}
+                        disabled={vendorSaving}
+                        className="mr-auto px-4 py-2 rounded-lg text-xs font-medium bg-red-600 text-white hover:bg-red-500 dark:bg-red-600 dark:hover:bg-red-500 transition-colors disabled:opacity-50"
+                      >
+                        Remove
+                      </button>
+                    )}
+                    <button
+                      onClick={closeVendorDialog}
+                      disabled={vendorSaving}
+                      className="px-4 py-2 rounded-lg text-xs font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800 transition-colors disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleVendorSave}
+                      disabled={vendorSaving || (!isEditing && !vendorApiKey.trim())}
+                      className="px-4 py-2 rounded-lg text-xs font-medium bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors disabled:opacity-50"
+                    >
+                      {vendorSaving ? "Saving..." : "Save"}
+                    </button>
+                  </div>
+                </>
+              );
+            })()}
+          </OverlayDismissLayer>
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/app/api/auth/admin/vendor-configs/[vendor]/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/vendor-configs/[vendor]/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAuthBaseUrl } from "../../../_config";
+
+function parseUpstreamError(text: string): string {
+  try {
+    const data = JSON.parse(text);
+    return data.detail || data.error || text;
+  } catch {
+    return text || "Upstream returned non-OK status";
+  }
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ vendor: string }> },
+) {
+  const { vendor } = await params;
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const body = await request.text();
+  const upstreamUrl = new URL(
+    `/auth/admin/vendor-configs/${encodeURIComponent(vendor)}`,
+    baseUrl,
+  );
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "PUT",
+      headers: {
+        ...Object.fromEntries(buildAuthHeaders(request).entries()),
+        "Content-Type": "application/json",
+      },
+      body,
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: parseUpstreamError(text) },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ vendor: string }> },
+) {
+  const { vendor } = await params;
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const upstreamUrl = new URL(
+    `/auth/admin/vendor-configs/${encodeURIComponent(vendor)}`,
+    baseUrl,
+  );
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "DELETE",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json(
+      { error: parseUpstreamError(text) },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}

--- a/apps/negentropy-ui/app/api/auth/admin/vendor-configs/route.ts
+++ b/apps/negentropy-ui/app/api/auth/admin/vendor-configs/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAuthBaseUrl } from "../../_config";
+
+export async function GET(request: Request) {
+  const baseUrl = getAuthBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: "AUTH_BASE_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const upstreamUrl = new URL("/auth/admin/vendor-configs", baseUrl);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "GET",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: `Upstream connection failed: ${String(error)}` },
+      { status: 502 },
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    let errorMessage = "Upstream returned non-OK status";
+    try {
+      const errorData = JSON.parse(text);
+      errorMessage = errorData.detail || errorData.error || text;
+    } catch {
+      errorMessage = text || errorMessage;
+    }
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: upstreamResponse.status },
+    );
+  }
+
+  return NextResponse.json(text ? JSON.parse(text) : {}, {
+    status: upstreamResponse.status,
+  });
+}

--- a/apps/negentropy/src/negentropy/auth/api.py
+++ b/apps/negentropy/src/negentropy/auth/api.py
@@ -235,6 +235,151 @@ async def list_permissions() -> dict[str, Any]:
 
 
 # =============================================================================
+# Vendor Config Admin Endpoints
+# =============================================================================
+
+
+SUPPORTED_VENDOR_CONFIG_VENDORS = {"openai", "anthropic", "gemini"}
+
+
+class VendorConfigUpsert(BaseModel):
+    api_key: Optional[str] = Field(default=None, description="API Key (空字符串或 null 表示保留原值)")
+    api_base: Optional[str] = None
+
+
+def _vendor_config_to_dict(vc) -> dict[str, Any]:
+    return {
+        "vendor": vc.vendor,
+        "apiKey": _mask_api_key(vc.api_key),
+        "apiBase": vc.api_base,
+        "configured": True,
+    }
+
+
+@router.get("/admin/vendor-configs")
+async def list_vendor_configs(current_user: AuthUser = Depends(get_current_user)) -> dict[str, Any]:
+    """列出所有支持的供应商配置（始终返回 3 个供应商，未配置的填充 null）。"""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+
+    from negentropy.models.vendor_config import VendorConfig
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(VendorConfig))
+            stored = result.scalars().all()
+    except Exception:
+        from negentropy.logging import get_logger
+        get_logger("negentropy.auth.api").warning("list_vendor_configs_failed", exc_info=True)
+        stored = []
+
+    stored_map = {vc.vendor: vc for vc in stored}
+    configs = []
+    for vendor in sorted(SUPPORTED_VENDOR_CONFIG_VENDORS):
+        vc = stored_map.get(vendor)
+        if vc:
+            configs.append(_vendor_config_to_dict(vc))
+        else:
+            configs.append({
+                "vendor": vendor,
+                "apiKey": None,
+                "apiBase": None,
+                "configured": False,
+            })
+
+    return {"vendorConfigs": configs}
+
+
+@router.put("/admin/vendor-configs/{vendor}")
+async def upsert_vendor_config(
+    vendor: str,
+    payload: VendorConfigUpsert,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """创建或更新供应商配置（Upsert 语义）。"""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+    if vendor not in SUPPORTED_VENDOR_CONFIG_VENDORS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported vendor: {vendor}. Supported: {', '.join(sorted(SUPPORTED_VENDOR_CONFIG_VENDORS))}",
+        )
+
+    from negentropy.config.model_resolver import invalidate_cache
+    from negentropy.models.vendor_config import VendorConfig
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(VendorConfig).where(VendorConfig.vendor == vendor))
+            vc = result.scalar_one_or_none()
+
+            if vc is None:
+                # 创建新配置：api_key 必须提供
+                if not payload.api_key or not payload.api_key.strip():
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="API Key is required for new vendor configuration",
+                    )
+                vc = VendorConfig(vendor=vendor, api_key=payload.api_key, api_base=payload.api_base)
+                db.add(vc)
+            else:
+                # 更新：空 key 表示保留原值；脱敏值也保留原值
+                if not payload.api_key or payload.api_key.startswith("****"):
+                    payload.api_key = vc.api_key
+                vc.api_key = payload.api_key
+                vc.api_base = payload.api_base
+
+            await db.commit()
+            await db.refresh(vc)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=_sanitize_error(f"Failed to upsert vendor config: {exc}"),
+        )
+
+    # 供应商凭证变更影响所有模型类型，清除全部缓存
+    invalidate_cache(None)
+    return {"vendorConfig": _vendor_config_to_dict(vc)}
+
+
+@router.delete("/admin/vendor-configs/{vendor}")
+async def delete_vendor_config(
+    vendor: str,
+    current_user: AuthUser = Depends(get_current_user),
+) -> dict[str, Any]:
+    """删除供应商配置。"""
+    if "admin" not in current_user.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
+    if vendor not in SUPPORTED_VENDOR_CONFIG_VENDORS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported vendor: {vendor}. Supported: {', '.join(sorted(SUPPORTED_VENDOR_CONFIG_VENDORS))}",
+        )
+
+    from negentropy.config.model_resolver import invalidate_cache
+    from negentropy.models.vendor_config import VendorConfig
+
+    try:
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(VendorConfig).where(VendorConfig.vendor == vendor))
+            vc = result.scalar_one_or_none()
+            if not vc:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="vendor config not found")
+            await db.delete(vc)
+            await db.commit()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=_sanitize_error(f"Failed to delete vendor config: {exc}"),
+        )
+
+    invalidate_cache(None)
+    return {"status": "deleted", "vendor": vendor}
+
+
+# =============================================================================
 # Model Config Admin Endpoints
 # =============================================================================
 
@@ -416,7 +561,7 @@ async def ping_model(
 
     full_model_name = build_full_model_name(payload.vendor, payload.model_name)
 
-    # --- 解析 api_key 优先级链: 表单 > DB > 环境变量 (litellm 默认行为) ---
+    # --- 解析 api_key 优先级链: 表单 > DB 模型配置 > DB 供应商配置 > 环境变量 ---
     effective_api_key = payload.api_key
     effective_api_base = payload.api_base or payload.config.get("api_base")
 
@@ -436,6 +581,25 @@ async def ping_model(
 
             get_logger("negentropy.auth.api").warning(
                 "ping_db_lookup_failed", model_id=str(payload.model_id), exc_info=True,
+            )
+
+    # 回退到供应商级凭证
+    if effective_api_key is None:
+        from negentropy.models.vendor_config import VendorConfig
+
+        try:
+            async with AsyncSessionLocal() as db:
+                result = await db.execute(select(VendorConfig).where(VendorConfig.vendor == payload.vendor))
+                vc = result.scalar_one_or_none()
+                if vc:
+                    effective_api_key = vc.api_key
+                    if not effective_api_base:
+                        effective_api_base = vc.api_base
+        except Exception:
+            from negentropy.logging import get_logger
+
+            get_logger("negentropy.auth.api").warning(
+                "ping_vendor_lookup_failed", vendor=payload.vendor, exc_info=True,
             )
 
     start_time = time.monotonic()

--- a/apps/negentropy/src/negentropy/config/llm.py
+++ b/apps/negentropy/src/negentropy/config/llm.py
@@ -16,4 +16,5 @@ class LlmVendor(str, Enum):
     ZAI = "zai"
     VERTEX_AI = "vertex_ai"
     DEEPSEEK = "deepseek"
+    GEMINI = "gemini"
     OLLAMA = "ollama"

--- a/apps/negentropy/src/negentropy/config/model_resolver.py
+++ b/apps/negentropy/src/negentropy/config/model_resolver.py
@@ -155,13 +155,16 @@ async def _resolve_from_db(model_type: str) -> Optional[Tuple[str, Dict[str, Any
     if config is None:
         return None
 
+    # 在同一 session 中查询供应商级凭证作为回退
+    vendor_config = await _get_vendor_config(config.vendor)
+
     full_name = build_full_model_name(config.vendor, config.model_name)
     cfg = config.config or {}
 
     if model_type == "embedding":
-        kwargs = _build_embedding_kwargs(cfg)
+        kwargs = _build_embedding_kwargs(cfg, vendor_config)
     else:
-        kwargs = _build_llm_kwargs(config.vendor, config.model_name, cfg)
+        kwargs = _build_llm_kwargs(config.vendor, config.model_name, cfg, vendor_config)
 
     return full_name, kwargs
 
@@ -181,10 +184,33 @@ def build_full_model_name(vendor: str, model_name: str) -> str:
     return canonicalize_model_name(raw) or raw
 
 
-def _build_llm_kwargs(vendor: str, model_name: str, config: Dict[str, Any]) -> Dict[str, Any]:
+async def _get_vendor_config(vendor: str) -> Optional[Dict[str, str]]:
+    """从 DB 查询供应商级凭证（api_key + api_base）。查询失败时静默返回 None。"""
+    try:
+        from sqlalchemy import select
+
+        from negentropy.db.session import AsyncSessionLocal
+        from negentropy.models.vendor_config import VendorConfig
+
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(VendorConfig).where(VendorConfig.vendor == vendor)
+            )
+            vc = result.scalar_one_or_none()
+
+        if vc is None:
+            return None
+        return {"api_key": vc.api_key, "api_base": vc.api_base}
+    except Exception:
+        # vendor_configs 表可能尚未迁移，或 DB 不可达 — 静默回退
+        return None
+
+
+def _build_llm_kwargs(vendor: str, model_name: str, config: Dict[str, Any], vendor_config: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """从 DB config JSONB 构建 LiteLLM kwargs。
 
     供应商特定的 LiteLLM kwargs 构建逻辑。
+    凭证解析链: model config > vendor config > LiteLLM 环境变量回退。
     """
     kwargs: Dict[str, Any] = {}
 
@@ -230,16 +256,18 @@ def _build_llm_kwargs(vendor: str, model_name: str, config: Dict[str, Any]) -> D
     if "drop_params" in config and "drop_params" not in kwargs:
         kwargs["drop_params"] = config["drop_params"]
 
-    # 透传 API 凭证 (DB 单一事实源; 未配置时 litellm 自动回退到环境变量)
-    if "api_key" in config and config["api_key"]:
-        kwargs["api_key"] = config["api_key"]
-    if "api_base" in config and config["api_base"]:
-        kwargs["api_base"] = config["api_base"]
+    # 透传 API 凭证: model config > vendor config > LiteLLM 环境变量回退
+    effective_api_key = config.get("api_key") or (vendor_config or {}).get("api_key")
+    effective_api_base = config.get("api_base") or (vendor_config or {}).get("api_base")
+    if effective_api_key:
+        kwargs["api_key"] = effective_api_key
+    if effective_api_base:
+        kwargs["api_base"] = effective_api_base
 
     return kwargs
 
 
-def _build_embedding_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
+def _build_embedding_kwargs(config: Dict[str, Any], vendor_config: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     """从 DB config JSONB 构建 Embedding kwargs。"""
     kwargs: Dict[str, Any] = {}
     if "dimensions" in config and config["dimensions"] is not None:
@@ -247,10 +275,12 @@ def _build_embedding_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
     if "input_type" in config and config["input_type"]:
         kwargs["input_type"] = config["input_type"]
 
-    # 透传 API 凭证 (DB 单一事实源; 未配置时 litellm 自动回退到环境变量)
-    if "api_key" in config and config["api_key"]:
-        kwargs["api_key"] = config["api_key"]
-    if "api_base" in config and config["api_base"]:
-        kwargs["api_base"] = config["api_base"]
+    # 透传 API 凭证: model config > vendor config > LiteLLM 环境变量回退
+    effective_api_key = config.get("api_key") or (vendor_config or {}).get("api_key")
+    effective_api_base = config.get("api_base") or (vendor_config or {}).get("api_base")
+    if effective_api_key:
+        kwargs["api_key"] = effective_api_key
+    if effective_api_base:
+        kwargs["api_base"] = effective_api_base
 
     return kwargs

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0002_add_vendor_configs.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0002_add_vendor_configs.py
@@ -1,0 +1,38 @@
+"""添加 vendor_configs 表
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-14 00:00:00.000000+00:00
+
+新增供应商级凭证配置表，支持 OpenAI/Anthropic/Gemini 的统一 API Key 管理。
+每个供应商最多一条记录 (vendor 自然主键)。
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vendor_configs",
+        sa.Column("vendor", sa.String(50), nullable=False),
+        sa.Column("api_key", sa.Text(), nullable=False),
+        sa.Column("api_base", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("vendor", name="pk_vendor_configs"),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("vendor_configs", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -5,6 +5,7 @@ from .knowledge_runtime import KnowledgeGraphRun, KnowledgePipelineRun
 from .mcp import McpServer, McpTool
 from .mcp_runtime import McpToolRun, McpToolRunEvent, McpTrialAsset
 from .model_config import ModelConfig, ModelType
+from .vendor_config import VendorConfig
 from .observability import Trace
 from .perception import (
     Corpus,
@@ -102,4 +103,6 @@ __all__ = [
     # Model Config
     "ModelConfig",
     "ModelType",
+    # Vendor Config
+    "VendorConfig",
 ]

--- a/apps/negentropy/src/negentropy/models/vendor_config.py
+++ b/apps/negentropy/src/negentropy/models/vendor_config.py
@@ -1,0 +1,29 @@
+"""
+Vendor Configuration 数据模型。
+
+存储供应商级 API 凭证（api_key + api_base），供该供应商下所有模型共享。
+每个供应商最多一条记录（vendor 作为自然主键）。
+"""
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin
+
+
+class VendorConfig(Base, TimestampMixin):
+    """供应商级凭证配置
+
+    Attributes:
+        vendor: 供应商标识 (如 openai, anthropic, gemini)，自然主键
+        api_key: API 密钥
+        api_base: 自定义 API Base URL (可选)
+    """
+
+    __tablename__ = "vendor_configs"
+
+    vendor: Mapped[str] = mapped_column(String(50), primary_key=True)
+    api_key: Mapped[str] = mapped_column(Text, nullable=False)
+    api_base: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = ({"schema": NEGENTROPY_SCHEMA},)


### PR DESCRIPTION
## Summary

- 新增 `vendor_configs` 表，为 OpenAI、Anthropic、Gemini 三大供应商提供统一的 API Key + Base URL 管理入口
- Model Resolver 实现三级凭证回退链：`model.config` → `vendor_configs` → LiteLLM 环境变量
- Admin / Models 页面重构：顶部新增 3 列 Vendor 卡片 + Setup 对话框（使用 `OverlayDismissLayer`），配置后该供应商下所有模型自动继承凭证
- 新增后端 CRUD API（`GET/PUT/DELETE /auth/admin/vendor-configs`），含 API Key 脱敏保护
- 新增 Alembic 迁移 `0002_add_vendor_configs`

## Test plan

- [ ] 运行 `alembic upgrade head` 确认 `vendor_configs` 表创建成功
- [ ] 访问 Admin / Models 页面，确认顶部显示 3 个 Vendor 卡片（OpenAI/Anthropic/Gemini）
- [ ] 点击 Setup 弹出对话框，填入 API Key 并保存，确认卡片状态变为 Configured
- [ ] 再次打开对话框，确认 API Key 输入框为空并显示"留空则保持不变"提示
- [ ] 修改 Base URL 保存，确认更新成功
- [ ] 点击 Remove 删除配置，确认卡片恢复为 Not configured
- [ ] 创建一个 OpenAI 模型但不填 API Key，确认实际调用时使用 vendor 配置的凭证
- [ ] 现有模型管理功能（添加/编辑/删除/设为默认/Ping）不受影响

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)