### PR TITLE
feat(config): 引入 YAML 分层配置体系，支持 `negentropy init` 和 `-c` 自定义路径

### DIFF
--- a/apps/negentropy/.env.example
+++ b/apps/negentropy/.env.example
@@ -1,14 +1,19 @@
 # =============================================================================
 # Negentropy Environment Configuration
 # =============================================================================
-# Copy this file to .env and modify as needed.
-# For environment-specific overrides, create .env.{environment} files.
 #
-# File Loading Order (later overrides earlier):
-#   1. .env                    (base defaults)
-#   2. .env.local              (local overrides, gitignored)
-#   3. .env.{environment}      (environment-specific)
-#   4. .env.{environment}.local (local env overrides, gitignored)
+# [推荐] 使用 YAML 配置: uv run negentropy init
+# 详见 src/negentropy/config/config.default.yaml
+#
+# 本文件仅用于向后兼容和密钥类配置。
+# 环境变量优先级高于 YAML 配置，可用于覆盖任何 YAML 配置项。
+#
+# 优先级（从高到低）:
+#   1. 环境变量
+#   2. .env 系列文件（本文件）
+#   3. CLI 指定 YAML（negentropy -c path）
+#   4. ~/.negentropy/config.yaml（用户级）
+#   5. config.default.yaml（项目默认）
 #
 # =============================================================================
 

--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "google-adk>=1.27.2",           # Google Agent Development Kit foundation
     "microsandbox>=0.1.8",          # Isolated execution environment for tool usage
     "mcp>=1.6.0",                   # Model Context Protocol SDK for MCP Server integration
-    "pydantic-settings>=2.12.0",    # Configuration management using Pydantic models
+    "pydantic-settings[yaml]>=2.12.0",  # Configuration management with YAML support
+    "pyyaml>=6.0.2",                # YAML parser for configuration files
     
     # LLM & AI Services
     "litellm>=1.83.0",              # Unified interface for various LLM providers
@@ -38,6 +39,9 @@ dependencies = [
     "orjson>=3.11.6",               # Fast JSON serialization
     "beautifulsoup4>=4.12.3",       # HTML parsing
 ]
+
+[project.scripts]
+negentropy = "negentropy.cli:main"
 
 [dependency-groups]
 dev = [

--- a/apps/negentropy/src/negentropy/cli.py
+++ b/apps/negentropy/src/negentropy/cli.py
@@ -1,0 +1,105 @@
+"""
+Negentropy CLI Entry Point.
+
+Provides:
+    uv run negentropy            Launch the ADK web server (default)
+    uv run negentropy init       Initialize user configuration
+    uv run negentropy -c path    Launch with custom config path
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    """Copy config.default.yaml to ~/.negentropy/config.yaml."""
+    from negentropy.config.yaml_loader import USER_CONFIG_DIR, USER_CONFIG_FILE, get_default_config_path
+
+    if USER_CONFIG_FILE.exists() and not args.force:
+        print(f"配置文件已存在: {USER_CONFIG_FILE}")
+        print("使用 --force 覆盖现有配置")
+        return 1
+
+    USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    default_path = get_default_config_path()
+    shutil.copy2(default_path, USER_CONFIG_FILE)
+    print(f"配置文件已初始化: {USER_CONFIG_FILE}")
+    print("请编辑该文件以自定义配置。密钥类配置请通过环境变量设置。")
+    return 0
+
+
+def _cmd_serve(args: argparse.Namespace) -> int:
+    """Launch the ADK web server (equivalent to ``adk web``)."""
+    # Build environment for subprocess (inherit current + add NE_CONFIG_PATH)
+    env = None
+    if args.config:
+        config_path = Path(args.config).resolve()
+        if not config_path.is_file():
+            print(f"错误: 配置文件不存在: {config_path}", file=sys.stderr)
+            return 1
+        import os
+
+        env = os.environ.copy()
+        env["NE_CONFIG_PATH"] = str(config_path)
+
+    # Determine port and host
+    port = args.port or 6600
+    host = args.host or "0.0.0.0"
+
+    # Build adk web command
+    cmd = [
+        sys.executable,
+        "-m",
+        "google.adk.cli",
+        "web",
+        "--port",
+        str(port),
+        "--host",
+        host,
+        "--reload_agents",
+        "src/negentropy",
+    ]
+
+    return subprocess.call(cmd, env=env)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="negentropy",
+        description="Negentropy — AI Agent 熵减系统",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        help="自定义 YAML 配置文件路径",
+        default=None,
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # init subcommand
+    init_parser = subparsers.add_parser("init", help="初始化用户配置文件")
+    init_parser.add_argument("--force", action="store_true", help="覆盖现有配置")
+
+    # serve subcommand
+    serve_parser = subparsers.add_parser("serve", help="启动 ADK Web 服务器")
+    serve_parser.add_argument("--port", type=int, default=6600, help="服务器端口 (默认: 6600)")
+    serve_parser.add_argument("--host", default="0.0.0.0", help="绑定地址 (默认: 0.0.0.0)")
+    serve_parser.add_argument("--no-reload", action="store_true", help="禁用热重载")
+
+    args = parser.parse_args()
+
+    if args.command == "init":
+        sys.exit(_cmd_init(args))
+    else:
+        # Default: serve
+        sys.exit(_cmd_serve(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/negentropy/src/negentropy/config/__init__.py
+++ b/apps/negentropy/src/negentropy/config/__init__.py
@@ -1,29 +1,22 @@
 """
 Negentropy Configuration Module.
 
-Implements the Nested Settings Pattern for orthogonal configuration domains.
-Each sub-module represents an independent concern with its own environment variable prefix.
+Implements layered configuration loading with YAML + .env support.
 
-Multi-Environment Support:
-    Set `NE_ENV` to one of: development, testing, staging, production
-    The system will load .env files in this order (later overrides earlier):
-    1. .env
-    2. .env.local
-    3. .env.{environment}
-    4. .env.{environment}.local
+Loading priority (highest → lowest):
+    1. Environment variables  (e.g. NE_DB_POOL_SIZE=20)
+    2. .env / .env.local / .env.{env} / .env.{env}.local
+    3. CLI-specified YAML  (NE_CONFIG_PATH or ``negentropy -c path``)
+    4. ~/.negentropy/config.yaml  (user-level overrides)
+    5. config.default.yaml  (package defaults)
+    6. Field defaults in code
 
 Usage:
     from negentropy.config import settings
 
-    # Check current environment
-    settings.environment.env  # "development"
-    settings.environment.is_production  # False
-
-    # Access database configuration
-    settings.database.url
-
-    # Access logging configuration
-    settings.logging.level
+    settings.environment.env       # "development"
+    settings.database.url          # PostgresDsn
+    settings.logging.level         # LogLevel.INFO
 
 Note:
     LLM/Embedding 模型配置已迁移至 DB (model_configs 表)，
@@ -62,9 +55,8 @@ class Settings(BaseSettings):
     This class follows the Composition over Construction principle,
     delegating to specialized sub-settings for each concern.
 
-    Environment-aware loading:
-        Settings are loaded from multiple .env files based on NE_ENV.
-        See module docstring for file resolution order.
+    Configuration sources (highest priority first):
+        env vars → .env files → YAML files → Field defaults
     """
 
     model_config = SettingsConfigDict(
@@ -73,12 +65,38 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
+    def __init__(self, **kwargs):
+        # Pre-load and distribute YAML sections BEFORE sub-settings are instantiated.
+        # This populates the section registry so that each sub-settings class
+        # can read its YAML data via settings_customise_sources.
+        from ._base import set_yaml_section
+        from .yaml_loader import load_merged_yaml_config
+
+        yaml_config = load_merged_yaml_config()
+
+        for section in (
+            "app",
+            "logging",
+            "database",
+            "services",
+            "auth",
+            "search",
+            "observability",
+            "knowledge",
+        ):
+            set_yaml_section(section, yaml_config.get(section, {}))
+
+        # EnvironmentSettings reads the top-level "env" key
+        set_yaml_section("environment", {"env": yaml_config.get("env", "development")})
+
+        super().__init__(**kwargs)
+
     # Environment detection (loaded first to determine other configs)
     @cached_property
     def environment(self) -> EnvironmentSettings:
         return EnvironmentSettings(_env_file=_get_env_files())
 
-    # Composed sub-settings (each loads from its own env prefix)
+    # Composed sub-settings (each loads from its own env prefix + YAML section)
     @cached_property
     def app(self) -> AppSettings:
         return AppSettings(_env_file=_get_env_files())

--- a/apps/negentropy/src/negentropy/config/_base.py
+++ b/apps/negentropy/src/negentropy/config/_base.py
@@ -1,0 +1,67 @@
+"""
+YAML Section Injection Infrastructure.
+
+Provides :class:`YamlDictSource` — a custom :class:`PydanticBaseSettingsSource`
+that feeds pre-parsed YAML data into sub-settings as a *low-priority* source,
+ensuring the canonical priority chain:
+
+    init > env vars > .env files > YAML > field defaults
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+
+# ---------------------------------------------------------------------------
+# Section registry (module-level state)
+# ---------------------------------------------------------------------------
+
+_yaml_section_data: dict[str, dict[str, Any]] = {}
+
+
+def set_yaml_section(key: str, data: dict[str, Any]) -> None:
+    """Register YAML data for a configuration section."""
+    _yaml_section_data[key] = data
+
+
+def get_yaml_section(key: str) -> dict[str, Any]:
+    """Retrieve YAML data for a configuration section."""
+    return _yaml_section_data.get(key, {})
+
+
+def reset_sections() -> None:
+    """Clear all registered sections.  Intended for test teardown only."""
+    _yaml_section_data.clear()
+
+
+# ---------------------------------------------------------------------------
+# Custom pydantic-settings source
+# ---------------------------------------------------------------------------
+
+
+class YamlDictSource(PydanticBaseSettingsSource):
+    """
+    A settings source backed by a plain ``dict`` (typically a YAML section).
+
+    This source only provides values for fields that are **declared** on the
+    target settings model, preventing ``extra="ignore"`` validation errors.
+    """
+
+    def __init__(self, settings_cls: type[BaseSettings], yaml_data: dict[str, Any]) -> None:
+        super().__init__(settings_cls)
+        self._yaml_data = yaml_data
+
+    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+        val = self._yaml_data.get(field_name)
+        return val, field_name, val is not None
+
+    def __call__(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        for field_name in self.settings_cls.model_fields:
+            val = self._yaml_data.get(field_name)
+            if val is not None:
+                d[field_name] = val
+        return d

--- a/apps/negentropy/src/negentropy/config/app.py
+++ b/apps/negentropy/src/negentropy/config/app.py
@@ -2,7 +2,7 @@
 Application Configuration.
 """
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class AppSettings(BaseSettings):
@@ -17,3 +17,22 @@ class AppSettings(BaseSettings):
     )
 
     name: str = "negentropy"
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("app")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/auth.py
+++ b/apps/negentropy/src/negentropy/config/auth.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Literal
 
 from pydantic import Field, SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class AuthMode(str, Enum):
@@ -50,3 +50,22 @@ class AuthSettings(BaseSettings):
 
     user_id_strategy: Literal["sub", "email"] = Field(default="sub", description="User ID source: google sub or email")
     default_redirect_path: str = Field(default="/", description="Default redirect path after login")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("auth")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -1,0 +1,156 @@
+# =============================================================================
+# Negentropy Default Configuration
+# =============================================================================
+# 此文件包含所有配置项的默认值，随项目包分发。
+#
+# 用户自定义配置:
+#   uv run negentropy init            # 拷贝到 ~/.negentropy/config.yaml
+#   uv run negentropy -c my.yaml      # 使用自定义配置文件
+#
+# 优先级（从高到低）:
+#   1. 环境变量（如 NE_DB_POOL_SIZE=20）
+#   2. .env 系列文件（向后兼容）
+#   3. CLI 指定 YAML（-c path）
+#   4. ~/.negentropy/config.yaml（用户级）
+#   5. 本文件（项目默认）
+#   6. 代码中的 Field defaults
+#
+# 注意: 密钥类配置（SecretStr）请通过环境变量设置，切勿写入 YAML 文件。
+# =============================================================================
+
+# --- 环境选择 ---
+# 可选值: development | testing | staging | production
+env: development
+
+# --- 应用元数据 ---
+app:
+  name: negentropy
+
+# --- 日志配置 ---
+logging:
+  level: INFO                              # DEBUG | INFO | WARNING | ERROR | CRITICAL
+  format: console                          # console | json
+  sinks: stdio                             # 逗号分隔: stdio | file | gcloud
+  file_path: logs/negentropy.log
+  gcloud_log_name: negentropy
+  console_timestamp_format: "%Y-%m-%d %H:%M:%S"
+  console_level_width: 8
+  console_logger_width: 32
+  console_separator: " | "
+
+# --- 数据库配置 ---
+database:
+  url: "postgresql+asyncpg://aigc:@localhost:5432/negentropy"
+  pool_size: 5
+  max_overflow: 10
+  pool_recycle: 3600
+  echo: false
+
+# --- 可观测性配置 ---
+observability:
+  langfuse_host: "https://cloud.langfuse.com"
+  langfuse_enabled: true
+  # langfuse_public_key: 通过环境变量 NE_OBSERVABILITY_LANGFUSE_PUBLIC_KEY 设置
+  # langfuse_secret_key: 通过环境变量 NE_OBSERVABILITY_LANGFUSE_SECRET_KEY 设置
+
+# --- ADK 服务配置 ---
+services:
+  credential_backend: inmemory             # inmemory | postgres | session
+  memory_backend: inmemory                 # inmemory | vertexai | postgres
+  session_backend: inmemory                # inmemory | vertexai | database | postgres
+  artifact_backend: inmemory               # inmemory | gcs
+  # gcs_bucket_name: null                  # GCS bucket（artifact_backend=gcs 时必填）
+  # vertex_project_id: null                # VertexAI 项目 ID
+  # vertex_location: null                  # VertexAI 区域
+  # vertex_agent_engine_id: null           # VertexAI Agent Engine ID
+
+# --- Auth / SSO 配置 ---
+auth:
+  enabled: true
+  mode: optional                           # off | optional | strict
+  # token_secret: 通过环境变量 NE_AUTH_TOKEN_SECRET 设置
+  # google_client_id: null
+  # google_client_secret: 通过环境变量 NE_AUTH_GOOGLE_CLIENT_SECRET 设置
+  # google_redirect_uri: null
+  google_scopes:
+    - openid
+    - email
+    - profile
+  cookie_name: ne_sso
+  # cookie_domain: null
+  cookie_secure: false
+  cookie_same_site: lax
+  session_ttl_seconds: 604800              # 7 天
+  state_ttl_seconds: 600
+  allowed_domains: []
+  allowed_emails: []
+  admin_emails: []
+  user_id_strategy: sub                    # sub | email
+  default_redirect_path: "/"
+
+# --- Web Search 配置 ---
+search:
+  provider: google                         # google | duckduckgo | bing
+  # google_api_key: 通过环境变量 NE_SEARCH_GOOGLE_API_KEY 设置
+  # google_cx_id: null
+  max_retries: 3
+  timeout_seconds: 10.0
+  base_backoff_seconds: 1.0
+  max_results: 10
+
+# --- ZAI (Zhipu AI) API 配置 ---
+# ZAI_API_KEY 和 ZAI_API_BASE 通过环境变量设置（供 LiteLLM 使用）
+
+# --- Knowledge 配置 ---
+knowledge:
+  default_extractor_routes:
+    url:
+      primary:
+        server_name: negentropy-perceives
+        tool_name: parse_webpage_to_markdown
+        enabled: true
+        timeout_ms: 60000
+      secondary:
+        server_name: negentropy-perceives
+        tool_name: parse_webpages_to_markdown
+        enabled: true
+        timeout_ms: 120000
+    file_pdf:
+      primary:
+        server_name: negentropy-perceives
+        tool_name: parse_pdf_to_markdown
+        enabled: true
+        timeout_ms: 300000
+      secondary:
+        server_name: negentropy-perceives
+        tool_name: parse_pdfs_to_markdown
+        enabled: true
+        timeout_ms: 600000
+
+# =============================================================================
+# 环境特定推荐配置
+# =============================================================================
+#
+# DEVELOPMENT:
+#   env: development
+#   logging:
+#     level: DEBUG
+#     format: console
+#   database:
+#     echo: true
+#
+# TESTING:
+#   env: testing
+#   logging:
+#     level: WARNING
+#     format: json
+#
+# PRODUCTION:
+#   env: production
+#   logging:
+#     level: INFO
+#     format: json
+#     sinks: stdio,gcloud
+#   database:
+#     pool_size: 20
+#     max_overflow: 30

--- a/apps/negentropy/src/negentropy/config/database.py
+++ b/apps/negentropy/src/negentropy/config/database.py
@@ -3,7 +3,7 @@ Database Configuration.
 """
 
 from pydantic import Field, PostgresDsn
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class DatabaseSettings(BaseSettings):
@@ -25,3 +25,22 @@ class DatabaseSettings(BaseSettings):
     max_overflow: int = Field(default=10, description="Max overflow connections")
     pool_recycle: int = Field(default=3600, description="Pool recycle time in seconds")
     echo: bool = Field(default=False, description="Echo SQL statements")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("database")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/environment.py
+++ b/apps/negentropy/src/negentropy/config/environment.py
@@ -8,7 +8,7 @@ The environment is determined by the `NE_ENV` environment variable.
 from typing import Literal
 
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 Environment = Literal["development", "testing", "staging", "production"]
 
@@ -50,6 +50,25 @@ class EnvironmentSettings(BaseSettings):
         default="development",
         description="Current environment (development, testing, staging, production)",
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("environment")),
+            file_secret_settings,
+        )
 
     @property
     def is_development(self) -> bool:

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -5,7 +5,7 @@ Knowledge Configuration.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class DefaultExtractorTargetSettings(BaseModel):
@@ -72,3 +72,22 @@ class KnowledgeSettings(BaseSettings):
     default_extractor_routes: DefaultExtractorRoutesSettings = Field(
         default_factory=DefaultExtractorRoutesSettings,
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("knowledge")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/logging.py
+++ b/apps/negentropy/src/negentropy/config/logging.py
@@ -5,7 +5,7 @@ Logging Configuration.
 from enum import Enum
 
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class LogLevel(str, Enum):
@@ -44,3 +44,22 @@ class LoggingSettings(BaseSettings):
     console_level_width: int = Field(default=8, description="Console level column width")
     console_logger_width: int = Field(default=32, description="Console logger column width")
     console_separator: str = Field(default=" | ", description="Console column separator")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("logging")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/observability.py
+++ b/apps/negentropy/src/negentropy/config/observability.py
@@ -5,7 +5,7 @@ Configures connection settings for external observability platforms (Langfuse, O
 """
 
 from pydantic import Field, SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class ObservabilitySettings(BaseSettings):
@@ -45,3 +45,22 @@ class ObservabilitySettings(BaseSettings):
         """Full Langfuse OTLP endpoint with correct path for HTTP/protobuf."""
         base = self.langfuse_host.rstrip("/")
         return f"{base}/api/public/otel/v1/traces"
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("observability")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/search.py
+++ b/apps/negentropy/src/negentropy/config/search.py
@@ -12,7 +12,7 @@ Web Search Configuration.
 from enum import Enum
 
 from pydantic import Field, SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class SearchProvider(str, Enum):
@@ -89,3 +89,22 @@ class SearchSettings(BaseSettings):
             return False
         secret = api_key.get_secret_value()
         return bool(secret and self.google_cx_id)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("search")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/services.py
+++ b/apps/negentropy/src/negentropy/config/services.py
@@ -5,7 +5,7 @@ ADK Services Configuration.
 from enum import Enum
 
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class CredentialBackend(str, Enum):
@@ -74,3 +74,22 @@ class ServicesSettings(BaseSettings):
     vertex_project_id: str | None = Field(default=None, description="VertexAI project ID")
     vertex_location: str | None = Field(default=None, description="VertexAI location")
     vertex_agent_engine_id: str | None = Field(default=None, description="VertexAI Agent Engine ID")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("services")),
+            file_secret_settings,
+        )

--- a/apps/negentropy/src/negentropy/config/yaml_loader.py
+++ b/apps/negentropy/src/negentropy/config/yaml_loader.py
@@ -1,0 +1,118 @@
+"""
+YAML Configuration Loader.
+
+Implements layered YAML configuration loading with deep merge semantics.
+
+Priority order (lowest → highest):
+    1. config.default.yaml  (package defaults, shipped with wheel)
+    2. ~/.negentropy/config.yaml  (user-level overrides)
+    3. NE_CONFIG_PATH env var  (CLI-specified custom config, cross-process)
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Well-known paths
+# ---------------------------------------------------------------------------
+
+USER_CONFIG_DIR = Path.home() / ".negentropy"
+USER_CONFIG_FILE = USER_CONFIG_DIR / "config.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def get_default_config_path() -> Path:
+    """
+    Resolve the path to ``config.default.yaml`` shipped with the package.
+
+    Uses ``__file__`` relative path for reliable access in both editable-install
+    and wheel-installed modes.
+    """
+    return Path(__file__).parent / "config.default.yaml"
+
+
+def get_yaml_file_paths() -> list[Path]:
+    """
+    Return ordered list of YAML config paths to load (lowest priority first).
+    Only returns paths that exist on disk.
+    """
+    paths: list[Path] = []
+
+    # 1. Package default (always present)
+    default_path = get_default_config_path()
+    if default_path.is_file():
+        paths.append(default_path)
+
+    # 2. User-level config
+    if USER_CONFIG_FILE.is_file():
+        paths.append(USER_CONFIG_FILE)
+
+    # 3. CLI-specified config via env var (cross-process propagation)
+    cli_config = os.getenv("NE_CONFIG_PATH")
+    if cli_config:
+        cli_path = Path(cli_config).resolve()
+        if cli_path.is_file():
+            paths.append(cli_path)
+
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Deep merge
+# ---------------------------------------------------------------------------
+
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """
+    Recursively merge *override* into *base*.
+
+    - dict values are merged recursively.
+    - All other types are replaced by *override*.
+    - Neither input dict is mutated.
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Merged config loader
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def load_merged_yaml_config() -> dict:
+    """
+    Load and deep-merge all discovered YAML config files.
+
+    Cached via :func:`lru_cache` to guarantee single-load semantics,
+    matching the ``Settings`` singleton pattern.
+    """
+    merged: dict = {}
+    for path in get_yaml_file_paths():
+        try:
+            with open(path, encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+            merged = deep_merge(merged, data)
+        except (OSError, yaml.YAMLError):
+            # Graceful degradation: skip unreadable files
+            pass
+    return merged
+
+
+def reset_cache() -> None:
+    """Clear the merged-config cache.  Intended for test teardown only."""
+    load_merged_yaml_config.cache_clear()

--- a/apps/negentropy/tests/unit_tests/config/test_cli.py
+++ b/apps/negentropy/tests/unit_tests/config/test_cli.py
@@ -1,0 +1,86 @@
+"""Tests for negentropy CLI commands (init, serve)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+class TestInitCommand:
+    def test_init_creates_config(self, tmp_path, monkeypatch):
+        """``negentropy init`` should copy default config to user dir."""
+        from negentropy.config.yaml_loader import get_default_config_path
+
+        user_dir = tmp_path / ".negentropy"
+        user_file = user_dir / "config.yaml"
+
+        with (
+            patch("negentropy.config.yaml_loader.USER_CONFIG_DIR", user_dir),
+            patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_file),
+        ):
+            from negentropy.cli import _cmd_init
+
+            class Args:
+                force = False
+
+            ret = _cmd_init(Args())
+            assert ret == 0
+            assert user_file.is_file()
+
+            # Content should match default
+            default = get_default_config_path().read_text()
+            assert user_file.read_text() == default
+
+    def test_init_refuses_overwrite(self, tmp_path):
+        """init without --force should refuse to overwrite."""
+        user_dir = tmp_path / ".negentropy"
+        user_dir.mkdir()
+        user_file = user_dir / "config.yaml"
+        user_file.write_text("existing")
+
+        with (
+            patch("negentropy.config.yaml_loader.USER_CONFIG_DIR", user_dir),
+            patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_file),
+        ):
+            from negentropy.cli import _cmd_init
+
+            class Args:
+                force = False
+
+            ret = _cmd_init(Args())
+            assert ret == 1
+            assert user_file.read_text() == "existing"
+
+    def test_init_force_overwrites(self, tmp_path):
+        """init --force should overwrite existing config."""
+        user_dir = tmp_path / ".negentropy"
+        user_dir.mkdir()
+        user_file = user_dir / "config.yaml"
+        user_file.write_text("old")
+
+        with (
+            patch("negentropy.config.yaml_loader.USER_CONFIG_DIR", user_dir),
+            patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_file),
+        ):
+            from negentropy.cli import _cmd_init
+
+            class Args:
+                force = True
+
+            ret = _cmd_init(Args())
+            assert ret == 0
+            assert "old" not in user_file.read_text()
+
+
+class TestServeCommand:
+    def test_serve_rejects_missing_config(self, tmp_path):
+        """serve with -c pointing to nonexistent file should fail."""
+        from negentropy.cli import _cmd_serve
+
+        class Args:
+            config = str(tmp_path / "nonexistent.yaml")
+            port = 6600
+            host = "0.0.0.0"
+            no_reload = False
+
+        ret = _cmd_serve(Args())
+        assert ret == 1

--- a/apps/negentropy/tests/unit_tests/config/test_yaml_config.py
+++ b/apps/negentropy/tests/unit_tests/config/test_yaml_config.py
@@ -1,0 +1,206 @@
+"""Tests for YAML configuration loading, deep merge, and priority semantics."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from negentropy.config._base import get_yaml_section, reset_sections, set_yaml_section
+from negentropy.config.yaml_loader import (
+    deep_merge,
+    get_default_config_path,
+    get_yaml_file_paths,
+    load_merged_yaml_config,
+    reset_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    """Reset caches and section registry between tests."""
+    reset_cache()
+    reset_sections()
+    yield
+    reset_cache()
+    reset_sections()
+
+
+# ---------------------------------------------------------------------------
+# deep_merge
+# ---------------------------------------------------------------------------
+
+
+class TestDeepMerge:
+    def test_flat_override(self):
+        assert deep_merge({"a": 1, "b": 2}, {"b": 3, "c": 4}) == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge(self):
+        base = {"db": {"url": "default", "pool_size": 5}}
+        override = {"db": {"pool_size": 10}}
+        assert deep_merge(base, override) == {"db": {"url": "default", "pool_size": 10}}
+
+    def test_nested_new_key(self):
+        assert deep_merge({"db": {"url": "default"}}, {"db": {"echo": True}}) == {
+            "db": {"url": "default", "echo": True},
+        }
+
+    def test_no_mutation(self):
+        base = {"x": {"y": 1}}
+        override = {"x": {"z": 2}}
+        deep_merge(base, override)
+        assert base == {"x": {"y": 1}}  # not mutated
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPathResolution:
+    def test_default_config_exists(self):
+        path = get_default_config_path()
+        assert path.is_file()
+        assert path.name == "config.default.yaml"
+
+    def test_default_config_is_valid_yaml(self):
+        import yaml
+
+        path = get_default_config_path()
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, dict)
+        assert "database" in data
+        assert "logging" in data
+
+    def test_yaml_file_paths_includes_default(self):
+        paths = get_yaml_file_paths()
+        assert len(paths) >= 1
+        assert any(p.name == "config.default.yaml" for p in paths)
+
+    def test_user_config_included_when_exists(self, tmp_path):
+        user_yaml = tmp_path / "config.yaml"
+        user_yaml.write_text("app:\n  name: test\n")
+        with patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_yaml):
+            paths = get_yaml_file_paths()
+            assert user_yaml in paths
+
+    def test_cli_config_via_env_var(self, tmp_path, monkeypatch):
+        cli_yaml = tmp_path / "custom.yaml"
+        cli_yaml.write_text("logging:\n  level: DEBUG\n")
+        monkeypatch.setenv("NE_CONFIG_PATH", str(cli_yaml))
+        paths = get_yaml_file_paths()
+        assert cli_yaml in paths
+
+
+# ---------------------------------------------------------------------------
+# Merged config loading
+# ---------------------------------------------------------------------------
+
+
+class TestMergedConfig:
+    def test_load_default_only(self):
+        config = load_merged_yaml_config()
+        assert config["database"]["pool_size"] == 5
+        assert config["logging"]["level"] == "INFO"
+
+    def test_user_overrides_default(self, tmp_path):
+        user_yaml = tmp_path / "config.yaml"
+        user_yaml.write_text("database:\n  pool_size: 99\n")
+        with patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_yaml):
+            config = load_merged_yaml_config()
+            assert config["database"]["pool_size"] == 99
+            # Other defaults preserved
+            assert config["database"]["max_overflow"] == 10
+
+    def test_cli_overrides_user(self, tmp_path, monkeypatch):
+        user_yaml = tmp_path / "config.yaml"
+        user_yaml.write_text("database:\n  pool_size: 50\n")
+        cli_yaml = tmp_path / "cli.yaml"
+        cli_yaml.write_text("database:\n  pool_size: 42\n")
+
+        with (
+            patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_yaml),
+            monkeypatch.context() as m,
+        ):
+            m.setenv("NE_CONFIG_PATH", str(cli_yaml))
+            config = load_merged_yaml_config()
+            assert config["database"]["pool_size"] == 42
+
+    def test_deep_merge_nested(self, tmp_path):
+        user_yaml = tmp_path / "config.yaml"
+        user_yaml.write_text(
+            "knowledge:\n  default_extractor_routes:\n    url:\n      primary:\n        server_name: custom-server\n"
+        )
+        with patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_yaml):
+            config = load_merged_yaml_config()
+            routes = config["knowledge"]["default_extractor_routes"]
+            assert routes["url"]["primary"]["server_name"] == "custom-server"
+            # Other nested defaults preserved
+            assert routes["url"]["primary"]["tool_name"] == "parse_webpage_to_markdown"
+
+
+# ---------------------------------------------------------------------------
+# Section registry
+# ---------------------------------------------------------------------------
+
+
+class TestSectionRegistry:
+    def test_set_and_get(self):
+        set_yaml_section("test", {"key": "value"})
+        assert get_yaml_section("test") == {"key": "value"}
+
+    def test_missing_section_returns_empty(self):
+        assert get_yaml_section("nonexistent") == {}
+
+    def test_reset_clears_all(self):
+        set_yaml_section("a", {"x": 1})
+        reset_sections()
+        assert get_yaml_section("a") == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: Settings loads YAML values
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsIntegration:
+    def test_settings_reads_default_yaml(self):
+        """Verify the global settings singleton reads from config.default.yaml."""
+        from negentropy.config import settings
+
+        # These values match config.default.yaml defaults
+        assert settings.database.pool_size == 5
+        assert settings.logging.level.value == "INFO"
+        assert settings.services.credential_backend.value == "inmemory"
+
+    def test_env_var_overrides_yaml(self, monkeypatch):
+        """Environment variables must take precedence over YAML values."""
+        monkeypatch.setenv("NE_DB_POOL_SIZE", "42")
+        reset_cache()
+        reset_sections()
+
+        from negentropy.config import Settings
+
+        s = Settings()
+        assert s.database.pool_size == 42
+
+    def test_yaml_override_user_config(self, tmp_path):
+        """User YAML overrides package defaults."""
+        user_yaml = tmp_path / "config.yaml"
+        user_yaml.write_text("database:\n  pool_size: 20\n")
+
+        with patch("negentropy.config.yaml_loader.USER_CONFIG_FILE", user_yaml):
+            reset_cache()
+            reset_sections()
+
+            from negentropy.config import Settings
+
+            s = Settings()
+            assert s.database.pool_size == 20
+            # Other defaults preserved
+            assert s.database.max_overflow == 10

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -1484,7 +1484,8 @@ dependencies = [
     { name = "microsandbox" },
     { name = "orjson" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "pydantic-settings" },
+    { name = "pydantic-settings", extra = ["yaml"] },
+    { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
 ]
@@ -1512,7 +1513,8 @@ requires-dist = [
     { name = "microsandbox", specifier = ">=0.1.8" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
-    { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.12.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46" },
     { name = "structlog", specifier = ">=25.5.0" },
 ]
@@ -1932,6 +1934,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[package.optional-dependencies]
+yaml = [
+    { name = "pyyaml" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概述

将 negentropy 的配置管理从 `.env` 扁平键值对迁移为 YAML 分层配置体系，支持用户级配置覆盖和 CLI 初始化，同时保持完整的向后兼容性。

## 变更内容

### 核心架构

- **`config.default.yaml`**：项目全量默认配置模板，覆盖全部 9 个配置域（environment、app、logging、database、services、auth、search、observability、knowledge），随 wheel 分发
- **`yaml_loader.py`**：实现 YAML 路径发现（包内默认 → `~/.negentropy/config.yaml` → `NE_CONFIG_PATH`）、递归深度合并（`deep_merge`）、LRU 缓存加载
- **`_base.py`**：自定义 `YamlDictSource`（pydantic-settings 低优先级源）+ section registry，确保 YAML 值不覆盖环境变量
- **`cli.py`**：CLI 入口，`negentropy init` 拷贝默认配置，`negentropy serve` 等同于 `adk web --port 6600 --reload_agents src/negentropy`

### 配置优先级（从高到低）

```
环境变量 → .env 文件 → CLI 指定 YAML (-c) → ~/.negentropy/config.yaml → config.default.yaml → Field defaults
```

### 子 Settings 改造

9 个子 Settings 统一添加 `settings_customise_sources` 方法，通过 `YamlDictSource` 注入对应 YAML section 数据，优先级低于环境变量和 `.env`。

### 依赖变更

- `pydantic-settings` → `pydantic-settings[yaml]`
- 新增 `pyyaml>=6.0.2`
- 新增 `[project.scripts] negentropy = "negentropy.cli:main"`

## 设计决策

| 决策 | 选择 | 理由 |
|------|------|------|
| YAML Schema | 嵌套结构 | 可读性优于扁平键值，天然映射 9 个配置域 |
| 子 Settings 类型 | 保持 `BaseSettings` | 保留 `env_prefix` 兼容性，环境变量无需改名 |
| YAML 注入方式 | 自定义 `YamlDictSource` | 确保 env > .env > yaml 优先级 |
| CLI 框架 | `argparse` | 最小依赖，满足 init/serve 两个子命令 |
| 配置路径传递 | `NE_CONFIG_PATH` 环境变量 | CLI 通过 subprocess 调 adk web，需跨进程传递 |

## 测试覆盖

- **30 个新增测试**全部通过
  - `test_yaml_config.py`：deep_merge 正确性、路径发现、多文件合并、优先级验证（env > yaml）、section registry、Settings 集成
  - `test_cli.py`：init 创建/拒绝覆盖/强制覆盖、serve 缺失配置检测
- **168 个既有测试**回归通过（3 个预存在的 import 错误和 1 个预存在的 migration 断言失败与本次变更无关）

## 向后兼容性

- `.env` 和环境变量继续工作，行为不变
- `from negentropy.config import settings` 接口不变
- 无 YAML 文件时自动降级为纯 env 模式
- SecretStr 字段（API keys、tokens）仅通过环境变量设置