### PR TITLE
fix(mcp): 修正 negentropy-perceives 预置 MCP Server 迁移种子端点 8081 → 8092

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0001_init_schema.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0001_init_schema.py
@@ -1059,7 +1059,7 @@ def upgrade() -> None:
             NULL,
             '[]'::jsonb,
             '{}'::jsonb,
-            'http://localhost:8081/mcp',
+            'http://localhost:8092/mcp',
             '{}'::jsonb,
             TRUE,
             TRUE,

--- a/apps/negentropy/tests/integration_tests/db/test_migrations.py
+++ b/apps/negentropy/tests/integration_tests/db/test_migrations.py
@@ -95,7 +95,7 @@ def test_negentropy_perceives_seeded_by_migration(alembic_config: Config):
         "图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
     )
     assert row["transport_type"] == "http"
-    assert row["url"] == "http://localhost:8081/mcp"
+    assert row["url"] == "http://localhost:8092/mcp"
     assert row["is_enabled"] is True
     assert row["auto_start"] is True
 
@@ -177,6 +177,6 @@ def test_negentropy_perceives_seed_is_idempotent_on_re_upgrade(alembic_config: C
         "一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、"
         "图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
     )
-    assert row["url"] == "http://localhost:8081/mcp"
+    assert row["url"] == "http://localhost:8092/mcp"
     assert row["is_enabled"] is True
     assert row["auto_start"] is True


### PR DESCRIPTION
## 背景与动机

`negentropy-perceives` MCP Server 当前实际运行端口已从 `8081` 调整为 `8092`（完整端点：`http://localhost:8092/mcp`）。Negentropy 后端 Alembic 初始迁移中对该 MCP Server 的预置（seed）记录仍硬编码旧端口，若不同步更新，新环境部署后将写入失效端点，导致 Negentropy 侧静默无法拉起该 MCP Server。

## 变更概要

仅 1 个 SSOT + 2 处测试断言同步更新，零业务逻辑改动、零 Schema 结构调整：

| 文件 | 变更 |
| :--- | :--- |
| `apps/negentropy/src/negentropy/db/migrations/versions/0001_init_schema.py` | 预置 seed URL `http://localhost:8081/mcp` → `http://localhost:8092/mcp` |
| `apps/negentropy/tests/integration_tests/db/test_migrations.py` | 首次种子 + 幂等回归两处断言同步更新至 `8092` |

## 设计决策（循证）

**直接修改既有迁移，而非新增迁移文件。** 理由：

1. **SSOT 与项目策略一致**：现有测试注释（`test_migrations.py:106-108`）明确项目执行「单一合并迁移」策略，新增迁移会破坏该既定约束。
2. **幂等性内建**：seed 使用 `ON CONFLICT (name) DO UPDATE SET url = EXCLUDED.url`。已部署环境下次 `alembic upgrade head` 将自动把 URL 自愈为新值，无需引入新的 OP。
3. **最小干预（YAGNI）**：当前位于工作分支，未流入 `feature/1.x.x`，无历史兼容压力。新增迁移属于对「尚未发生」问题的过度防御。

## 二阶效应分析

- **新部署**：直接落地 `8092`，无影响。
- **旧部署**：`ON CONFLICT DO UPDATE` 幂等自愈，无需人工介入；`url` 为单列字段，未被其他表副本化，**无分裂风险**。
- **测试**：断言与 SSOT 同步，构成良性反馈闭环。

## 验证证据

在 `apps/negentropy/` 下执行：

```bash
uv run pytest tests/integration_tests/db/test_migrations.py -v
```

`negentropy-perceives` 相关用例全部通过：

- ✅ `test_negentropy_perceives_seeded_by_migration`（首次种子）
- ✅ `test_negentropy_perceives_seed_is_idempotent_on_re_upgrade`（污染 → 全量 downgrade → 全量 re-upgrade 幂等自愈）

> 备注：同文件中的 `test_migrations_have_single_head` 为**既有失败**（与仓库中已存在的 `0002_add_vendor_configs.py` 迁移有关），在本 PR 未应用的基线上同样复现，与本次端口变更**完全无因果关系**，不在本 PR 修复范围。

## 爆炸半径

极小。仅影响 MCP Server `negentropy-perceives` 的预置 URL 字段，幂等自愈。无 Schema、无契约、无接口签名变动。

## Next Best Action（后续建议）

若 `negentropy-perceives` 端口未来仍存在漂移可能，可考虑提取为环境变量（如 `NEGENTROPY_PERCEIVES_MCP_URL`）驱动 seed / 运行时 —— 但此属架构级演进，建议下次再发生端口变更时再行评估，遵循 YAGNI。

---

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>