### PR TITLE
test(migrations): 修复 CI Backend Integration 失败 —— Alembic head 断言改为单一计数校验

### DIFF
--- a/apps/negentropy/tests/integration_tests/db/test_migrations.py
+++ b/apps/negentropy/tests/integration_tests/db/test_migrations.py
@@ -6,9 +6,6 @@ from sqlalchemy import create_engine, text
 
 from negentropy.config import settings
 
-CURRENT_HEAD = "0001"
-PRESET_SEED_HEAD = "0001"  # 合并后种子数据在唯一迁移中
-
 
 def _sync_database_url() -> str:
     return str(settings.database_url).replace("postgresql+asyncpg", "postgresql+psycopg")
@@ -35,10 +32,11 @@ def alembic_config():
 
 
 def test_migrations_have_single_head(alembic_config: Config):
-    """Ensure the migration graph stays linear at the current head."""
+    """Ensure the migration graph stays linear — exactly one head exists."""
 
     script = ScriptDirectory.from_config(alembic_config)
-    assert script.get_heads() == [CURRENT_HEAD]
+    heads = script.get_heads()
+    assert len(heads) == 1, f"Expected single Alembic head, got: {heads}"
 
 
 def test_migrations_stairway(alembic_config: Config):


### PR DESCRIPTION
## 摘要

修复 [Run 24607088190](https://github.com/ThreeFish-AI/negentropy/actions/runs/24607088190/job/71955076428) 中 `backend-quality / Backend Integration Tests` 作业的失败：

- 失败用例：`tests/integration_tests/db/test_migrations.py::test_migrations_have_single_head`
- 断言：`AssertionError: assert ['0002'] == ['0001']`
- 结果：`1 failed, 51 passed`

## 根因

迁移目录已新增 `0002_add_vendor_configs.py`（`bc4c21b feat(vendor-config)`），Alembic head 由 `0001` 演进到 `0002`；但测试文件中仍硬编码 `CURRENT_HEAD = "0001"`，每新增一次迁移必然失败，属脆性断言。

## 变更内容

仅修改 `apps/negentropy/tests/integration_tests/db/test_migrations.py`：

- 移除硬编码常量 `CURRENT_HEAD` 与未被使用的 `PRESET_SEED_HEAD`（含过时注释「合并后种子数据在唯一迁移中」）；
- 将 `assert script.get_heads() == [CURRENT_HEAD]` 重构为 `len(heads) == 1`，与 docstring「migration graph 保持线性」语义对齐；
- `reusable-negentropy-backend-quality.yml` 中 `Verify Alembic graph has a single head` 已有等价前置守卫，本次重构与之在语义层对齐，消除双钉死脆性。

## 爆炸半径

- 仅影响 1 个测试文件中的 1 个用例；
- 不改动生产代码、迁移脚本、Schema；
- 不影响 Unit / Performance 作业。

## 验证

在线 CI [Run 24607249522](https://github.com/ThreeFish-AI/negentropy/actions/runs/24607249522) 全绿：

- ✓ Backend Unit Tests
- ✓ Backend Integration Tests
- – Backend Performance Tests（按配置仅在 workflow_dispatch / schedule 触发，此处 skipped 符合预期）

## 测试计划

- [x] 本地静态检查（pre-commit: ruff lint / ruff format）通过
- [x] 在线 `backend-quality / Backend Integration Tests` 通过
- [x] 在线 `backend-quality / Backend Unit Tests` 通过（Alembic 单 head 守卫亦通过）

## 非目标（Out of Scope）

- Node.js 20 Actions 弃用警告：纯 warning、不阻塞运行，涉及 `actions/checkout@v4`、`actions/setup-python@v5`、`actions/upload-artifact@v4`、`astral-sh/setup-uv@v5` 的 Node 24 兼容性评估，后续单独跟进。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)