### PR TITLE
fix(knowledge): 修复 Corpus Settings 分隔符多余反斜杠显示与持久化静默丢失

### DIFF
--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -171,6 +171,7 @@ export {
   normalizeChunkingConfig,
   encodeSeparatorsForDisplay,
   decodeSeparatorsFromInput,
+  decodeLiteralEscapesIfNeeded,
   normalizeCorpusExtractorRoutes,
   createEmptyExtractorDraftTarget,
   normalizeExtractorDraftRoutes,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -122,6 +122,31 @@ export function decodeSeparatorsFromInput(text: string): string[] {
     });
 }
 
+/**
+ * 防御式解码单个分隔符字符串。
+ *
+ * 用于兜底「DB 中残留字面量转义序列」的历史/导入数据：
+ *   - 输入 `"\\n\\n"`（4 字符 `\n\n`）→ 输出 `"\n\n"`（2 字符真换行）
+ *   - 输入 `"\n\n"`（已是真换行）→ 原样返回（idempotent）
+ *
+ * 复用 decodeSeparatorsFromInput 的逐字符扫描逻辑，仅当字符串包含字面量转义
+ * 序列（`\n` / `\t` / `\r` / `\\`）但不含真实控制字符时触发解码，避免对正常数据的副作用。
+ */
+export function decodeLiteralEscapesIfNeeded(value: string): string {
+  if (typeof value !== "string" || value.length === 0) return value;
+  const hasLiteralEscape = /\\[ntr\\]/.test(value);
+  const hasRealControl = /[\n\t\r]/.test(value);
+  if (!hasLiteralEscape || hasRealControl) return value;
+  // 复用 decodeSeparatorsFromInput 的核心扫描逻辑：单行解码后取首项
+  const decoded = decodeSeparatorsFromInput(value);
+  return decoded[0] ?? value;
+}
+
+function normalizeSeparatorsArray(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return fallback;
+  return (value as unknown[]).map((s) => decodeLiteralEscapesIfNeeded(String(s)));
+}
+
 export function createDefaultChunkingConfig(
   strategy: ChunkingStrategy = "recursive",
 ): ChunkingConfig {
@@ -198,9 +223,7 @@ export function normalizeChunkingConfig(
           typeof config?.preserve_newlines === "boolean"
             ? config.preserve_newlines
             : defaults.preserve_newlines,
-        separators: Array.isArray(config?.separators)
-          ? (config.separators as string[])
-          : defaults.separators,
+        separators: normalizeSeparatorsArray(config?.separators, defaults.separators),
         hierarchical_parent_chunk_size: Number(
           config?.hierarchical_parent_chunk_size ?? defaults.hierarchical_parent_chunk_size,
         ),
@@ -223,9 +246,7 @@ export function normalizeChunkingConfig(
           typeof config?.preserve_newlines === "boolean"
             ? config.preserve_newlines
             : defaults.preserve_newlines,
-        separators: Array.isArray(config?.separators)
-          ? (config.separators as string[])
-          : defaults.separators,
+        separators: normalizeSeparatorsArray(config?.separators, defaults.separators),
       };
     }
   }

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -5,6 +5,8 @@ import {
   createDefaultChunkingConfig,
   encodeSeparatorsForDisplay,
   decodeSeparatorsFromInput,
+  decodeLiteralEscapesIfNeeded,
+  normalizeChunkingConfig,
   fetchCorpus,
   fetchDocumentChunks,
   fetchDocuments,
@@ -439,5 +441,92 @@ describe("separator encode/decode 往返一致性", () => {
   it("混合特殊字符往返一致", () => {
     const seps = ["\n\n", "\t", "\r\n", "。", ""];
     expect(decodeSeparatorsFromInput(encodeSeparatorsForDisplay(seps))).toEqual(seps);
+  });
+});
+
+describe("decodeLiteralEscapesIfNeeded", () => {
+  it("将字面量 `\\n\\n`（4 字符）解码为真换行 `\\n\\n`（2 字符）", () => {
+    expect(decodeLiteralEscapesIfNeeded("\\n\\n")).toBe("\n\n");
+  });
+
+  it("将字面量 `\\n` 解码为真换行 `\\n`", () => {
+    expect(decodeLiteralEscapesIfNeeded("\\n")).toBe("\n");
+  });
+
+  it("已为真换行的输入原样返回（idempotent）", () => {
+    expect(decodeLiteralEscapesIfNeeded("\n\n")).toBe("\n\n");
+    expect(decodeLiteralEscapesIfNeeded("\n")).toBe("\n");
+  });
+
+  it("对纯文本不做任何处理", () => {
+    expect(decodeLiteralEscapesIfNeeded("。")).toBe("。");
+    expect(decodeLiteralEscapesIfNeeded(". ")).toBe(". ");
+  });
+
+  it("混合真换行与字面量时保守不解码", () => {
+    expect(decodeLiteralEscapesIfNeeded("abc\n\\n")).toBe("abc\n\\n");
+  });
+
+  it("空字符串原样返回", () => {
+    expect(decodeLiteralEscapesIfNeeded("")).toBe("");
+  });
+});
+
+describe("normalizeChunkingConfig 防御式解码", () => {
+  it("hierarchical 策略：DB 中字面量转义自动解码为真换行（修复 Bug）", () => {
+    const result = normalizeChunkingConfig({
+      strategy: "hierarchical",
+      separators: ["\\n\\n", "\\n", "。"],
+      hierarchical_parent_chunk_size: 1024,
+      hierarchical_child_chunk_size: 256,
+      hierarchical_child_overlap: 51,
+    });
+    expect(result.strategy).toBe("hierarchical");
+    if (result.strategy === "hierarchical") {
+      expect(result.separators).toEqual(["\n\n", "\n", "。"]);
+    }
+  });
+
+  it("recursive 策略：真换行原样保留", () => {
+    const result = normalizeChunkingConfig({
+      strategy: "recursive",
+      chunk_size: 800,
+      overlap: 100,
+      separators: ["\n\n", "\n", "。"],
+    });
+    expect(result.strategy).toBe("recursive");
+    if (result.strategy === "recursive") {
+      expect(result.separators).toEqual(["\n\n", "\n", "。"]);
+    }
+  });
+
+  it("hierarchical 策略：真换行原样保留（不被误解码）", () => {
+    const result = normalizeChunkingConfig({
+      strategy: "hierarchical",
+      separators: ["\n\n", "\n"],
+    });
+    expect(result.strategy).toBe("hierarchical");
+    if (result.strategy === "hierarchical") {
+      expect(result.separators).toEqual(["\n\n", "\n"]);
+    }
+  });
+
+  it("recursive 策略：字面量转义自动解码", () => {
+    const result = normalizeChunkingConfig({
+      strategy: "recursive",
+      separators: ["\\n", "。"],
+    });
+    expect(result.strategy).toBe("recursive");
+    if (result.strategy === "recursive") {
+      expect(result.separators).toEqual(["\n", "。"]);
+    }
+  });
+
+  it("separators 缺失时回退到默认值", () => {
+    const result = normalizeChunkingConfig({ strategy: "hierarchical" });
+    expect(result.strategy).toBe("hierarchical");
+    if (result.strategy === "hierarchical") {
+      expect(result.separators).toEqual(["\n"]);
+    }
   });
 });

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1091,7 +1091,7 @@ async def ingest_file(
             try:
                 raw = json.loads(separators)
                 if isinstance(raw, list):
-                    parsed_separators = [str(item) for item in raw if str(item).strip()]
+                    parsed_separators = [str(item) for item in raw if str(item) != ""]
             except json.JSONDecodeError:
                 parsed_separators = [item.strip() for item in separators.split(",") if item.strip()]
 

--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -213,9 +213,10 @@ class _ChunkingConfigWithSeparators(_ChunkingConfigBase):
     @field_validator("separators")
     @classmethod
     def validate_separators(cls, v: list[str] | tuple[str, ...]) -> tuple[str, ...]:
-        normalized = [item for item in (s.strip() for s in v) if item]
         deduped: list[str] = []
-        for item in normalized:
+        for item in v:
+            if item is None or item == "":
+                continue
             if item not in deduped:
                 deduped.append(item)
         return tuple(deduped)

--- a/apps/negentropy/tests/unit_tests/knowledge/test_types.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_types.py
@@ -140,9 +140,23 @@ class TestChunkingConfig:
         config = ChunkingConfig(chunk_size=100, overlap=50)
         assert config.overlap < config.chunk_size
 
-    def test_separators_normalized_to_hashable_tuple(self) -> None:
-        """separators 应标准化为可哈希的不可变元组"""
+    def test_separators_dedup_preserves_order_and_whitespace(self) -> None:
+        """separators 应去重并保持原值，包括纯空白与有意义的尾部空格
+
+        注：早期版本会 .strip() 并过滤空白，导致真换行 ``"\\n"`` / ``"\\n\\n"`` /
+        sentence-end ``". "`` 的尾部空格被静默销毁。修复后仅过滤空字符串与 None。
+        """
         config = ChunkingConfig(separators=["###", " ", "###", "\t", "---"])
+        assert config.separators == ("###", " ", "\t", "---")
+
+    def test_separators_preserve_real_newlines(self) -> None:
+        """真换行类分隔符（\\n / \\n\\n）必须被完整保留"""
+        config = ChunkingConfig(separators=["\n\n", "\n", "。", ". ", "! "])
+        assert config.separators == ("\n\n", "\n", "。", ". ", "! ")
+
+    def test_separators_filter_empty_string(self) -> None:
+        """空字符串无语义价值，应被过滤"""
+        config = ChunkingConfig(separators=["###", "", "---", ""])
         assert config.separators == ("###", "---")
 
     def test_serialize_chunking_config_returns_json_safe_recursive_payload(self) -> None:


### PR DESCRIPTION
## 问题背景

在 Knowledge Base 页面 → 选择 Corpus（如 Hierarchical chunking 的「Harness Engineering」）→ Settings Tab → Separators 文本框中，原本期望显示 `\n\n`（每个 `n` 前 1 条反斜杠），实际显示为 `\\n\\n`（每个 `n` 前 2 条反斜杠）。

进一步追踪发现，该症状下还潜伏着一个**保存路径上的静默数据丢失**缺陷：通过 Settings 面板任何编辑+保存动作都会**销毁所有真实换行/纯空白分隔符**，并同时**截断带有意义尾部空格的分隔符**（如 `". "` → `"."`）。

## 根因分析

### 缺陷 A — 后端 `validate_separators` 误删纯空白分隔符

`apps/negentropy/src/negentropy/knowledge/types.py` 中的 `validate_separators` 对每个分隔符调用 `.strip()` 后再过滤空字符串：

| 输入 | `.strip()` 结果 | 保留？ |
|------|----------------|--------|
| 真实 `"\n\n"` / `"\n"` / `" "` | `""` | ❌ 删除 |
| 真实 `". "` | `"."` | ⚠️ 保留但**丢失尾部空格** |
| 字面量 `"\\n\\n"`（4 字符 `\n\n`） | 原样 | ✅ 保留 |

后果：用户每次保存都静默丢失换行类分隔符；同时只有「字面量转义」形态能在 DB 中长期存活。

### 缺陷 B — 前端 `normalizeChunkingConfig` 缺少防御式解码

`apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts` 的 `normalizeChunkingConfig` 直接将 `config.separators` 透传到 state，随后 `encodeSeparatorsForDisplay` 按 `.replace(/\\/g, "\\\\")` 对每个 `\` 加倍：

- DB 存真实换行 `"\n\n"`（2 字符） → 编码后 `"\\n\\n"` → textarea 显示 `\n\n` ✅
- DB 存字面量 `"\\n\\n"`（4 字符） → 编码后 `"\\\\n\\\\n"` → textarea 显示 `\\n\\n` ❌

「Harness Engineering」语料的 `config.separators` 在 DB 中是字面量字符串形态（结合缺陷 A 的特性，可推断为早期版本 / 文档示例 / 外部数据导入路径产生），导致显示异常。

### 附加缺陷 C — `ingest_file` FormData 路径同源缺陷

`apps/negentropy/src/negentropy/knowledge/api.py` 中 `parsed_separators = [str(item) for item in raw if str(item).strip()]` 与缺陷 A 同源，需一并修复以保持语义一致性。

## 修复方案

遵循 AGENTS.md 「最小干预 / 防御式纵深 / 单一事实源 / Reuse-Driven」原则：

### 1. 后端 `validate_separators` 仅过滤 `None` 与空字符串
完整保留语义有效的真实换行与纯空白序列；保持去重与原始顺序；不再静默截断尾部空格。

### 2. 后端 `ingest_file` FormData 同步使用 `!= ""` 过滤
保持与 `validate_separators` 语义一致。

### 3. 前端新增 `decodeLiteralEscapesIfNeeded` 防御式解码并接入 normalize
- **Idempotent**：对真实换行数据无副作用；
- **保守**：仅当字符串「全字面量、无真实控制字符」时才解码，避免误伤合法的混合内容；
- **复用**：直接复用现有的 `decodeSeparatorsFromInput` 单行解码逻辑，不引入新解码实现。

## 影响面

- **DB 既有数据零变更**：不引入数据修复脚本，依靠前端 normalize 层兜底自愈；用户首次编辑保存后即「自动修正」为真换行。
- **新建 / 编辑 corpus 路径已修正**：未来通过 Settings / API 写入的 separators 不再静默丢失。
- **API 文档示例不变**：`api-specs.ts` 中 cURL/JSON 示例的 `"\\n\\n"` 是合法 JSON 转义，无需调整。
- **不修改 `model_config`**：保持 frozen 配置不变，避免对其他 Pydantic 下游模型产生意外影响。

## 验证步骤

### 单元测试

```bash
# 后端
cd apps/negentropy && uv run pytest tests/unit_tests/knowledge/ --no-cov
# → 399 passed

# 前端
cd apps/negentropy-ui && pnpm test knowledge-api
# → 44 passed (含新增 11 例)
```

### 类型检查与 Lint

```bash
cd apps/negentropy && uv run ruff check src/negentropy/knowledge   # All checks passed!
cd apps/negentropy-ui && pnpm typecheck                            # ✓
```

### 端到端手测（建议 Reviewer 在本地复现）

1. 启动 dev 环境（后端 + 前端）；
2. 浏览器打开 Knowledge Base → 选择「Harness Engineering」→ Settings Tab；
   - **修复前**：Separators 显示 `\\n\\n`（每行多余反斜杠）；
   - **修复后**：显示 `\n\n`（正常单反斜杠）；
3. 在 Settings 中修改某个分隔符并保存 → 刷新 → 验证修改持久化且文本框仍正确显示；
4. 新建 recursive corpus 使用默认分隔符 → 保存 → 重新打开验证显示正常；
5. 通过 ingest_file 上传文件并指定 `separators=["\n\n","\n"]`（FormData 路径） → 验证 chunks 切分正确。

## 关键文件变更

| 文件 | 变更 |
|------|------|
| `apps/negentropy/src/negentropy/knowledge/types.py` | 重写 `validate_separators` |
| `apps/negentropy/src/negentropy/knowledge/api.py` | `ingest_file` form parsing 同步修正 |
| `apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts` | 新增 `decodeLiteralEscapesIfNeeded` + 接入 normalize |
| `apps/negentropy-ui/features/knowledge/index.ts` | 导出新 helper |
| `apps/negentropy/tests/unit_tests/knowledge/test_types.py` | 重写 + 新增 separators 用例 |
| `apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts` | 新增 11 例覆盖 |

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)