### PR TITLE
fix(Security): 修复 5 项 Dependabot 安全告警（google-adk/authlib/Mako/python-multipart/dompurify）

### DIFF
--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -47,7 +47,7 @@
       "@ag-ui/core": "0.0.47",
       "flatted": ">=3.4.2",
       "undici": ">=7.24.0",
-      "dompurify": ">=3.3.2",
+      "dompurify": ">=3.4.0",
       "lodash-es": ">=4.18.1",
       "picomatch": ">=4.0.4",
       "follow-redirects": ">=1.16.0"

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@ag-ui/core': 0.0.47
   flatted: '>=3.4.2'
   undici: '>=7.24.0'
-  dompurify: '>=3.3.2'
+  dompurify: '>=3.4.0'
   lodash-es: '>=4.18.1'
   picomatch: '>=4.0.4'
   follow-redirects: '>=1.16.0'
@@ -2348,8 +2348,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6416,7 +6416,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7672,7 +7672,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.19
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.33
       khroma: 2.1.0
       lodash-es: 4.18.1

--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "alembic>=1.18.3",              # Database migration tool
     
     # Core Infrastructure
-    "google-adk>=1.27.2",           # Google Agent Development Kit foundation
+    "google-adk>=1.28.1",           # GHSA-rg7c-g689-fr3x: code injection + missing auth on adk web/api_server eval endpoints
     "microsandbox>=0.1.8",          # Isolated execution environment for tool usage
     "mcp>=1.6.0",                   # Model Context Protocol SDK for MCP Server integration
     "pydantic-settings[yaml]>=2.12.0",  # Configuration management with YAML support
@@ -125,7 +125,7 @@ override-dependencies = [
 ]
 constraint-dependencies = [
     # ── 既有约束 ──
-    "authlib>=1.6.9",       # CVE-2026-27962 (critical) + CVE-2026-28490/28498/28802
+    "authlib>=1.6.11",      # GHSA-jj8c-mmj3-mmgv: OAuth client cache CSRF (+ 保留历史 CVE-2026-27962 等防御)
     "pyasn1>=0.6.3",        # CVE-2026-30922: unbounded recursion DoS
     "pyjwt>=2.12.0",        # CVE-2026-32597: unknown crit header extensions
     "cryptography>=46.0.7", # CVE-2026: buffer overflow, subgroup attack, DNS constraint
@@ -157,4 +157,6 @@ constraint-dependencies = [
     "filelock>=3.20.3",     # TOCTOU symlink 竞争 (medium)
     "orjson>=3.11.6",       # 无限递归 DoS (high)
     "google-cloud-aiplatform>=1.133.0", # 可预测 bucket 命名 (high)
+    "mako>=1.3.11",         # GHSA-v92g-xgxw-vvmm: TemplateLookup 双斜杠路径穿越 (medium, alembic 传递)
+    "python-multipart>=0.0.26", # GHSA-mj87-hwqh-73pj: 大型 preamble/epilogue DoS (medium, starlette 传递)
 ]

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -5,7 +5,7 @@ requires-python = "==3.13.*"
 [manifest]
 constraints = [
     { name = "aiomysql", specifier = ">=0.3.0" },
-    { name = "authlib", specifier = ">=1.6.9" },
+    { name = "authlib", specifier = ">=1.6.11" },
     { name = "azure-core", specifier = ">=1.38.0" },
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
@@ -15,6 +15,7 @@ constraints = [
     { name = "flask", specifier = ">=3.1.3" },
     { name = "google-cloud-aiplatform", specifier = ">=1.133.0" },
     { name = "h2", specifier = ">=4.3.0" },
+    { name = "mako", specifier = ">=1.3.11" },
     { name = "markdown", specifier = ">=3.8.1" },
     { name = "markdownify", specifier = ">=0.14.1" },
     { name = "marshmallow", specifier = ">=3.26.2" },
@@ -27,6 +28,7 @@ constraints = [
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "pypdf", specifier = ">=6.10.0" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "starlette", specifier = ">=0.50.0" },
     { name = "tornado", specifier = ">=6.5.5" },
@@ -173,14 +175,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
@@ -471,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.27.2"
+version = "1.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -520,9 +523,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/8c/5f3d3fcfdabbbe509e2a488cbfbf799c6a889b25ace877d40956498d3da1/google_adk-1.27.2.tar.gz", hash = "sha256:2971793c9872cd496cc322e6dd7cf404e99512689ed2fffd43f333683d204c2a", size = 2297941, upload-time = "2026-03-17T21:14:52.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/7a/2d596bf923d9491163b1fc74f9927c538ffa8ea8fec3cadacf26749d2239/google_adk-1.31.0.tar.gz", hash = "sha256:1ebcf2f3c790bd95e8fc43c5390606a9a1019f424bdbd675fcdd4ed33e5b4c3d", size = 2407101, upload-time = "2026-04-17T00:59:03.83Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/0d/bde4735b5ec36a312774526bb75fecaf45af6ae029d9bd665c42c5fe8d15/google_adk-1.27.2-py3-none-any.whl", hash = "sha256:04b4f23e9d26d75ee2f70c8d933629b095b8f6b23ed8ffc072f4d13fd106848d", size = 2689037, upload-time = "2026-03-17T21:14:51.318Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4f/ce4a0de8a7b03431d67d7375c5e9c1becc8b9351630b7b34f0943b42fb27/google_adk-1.31.0-py3-none-any.whl", hash = "sha256:1886cfd0c9f1455fb08500348e8861be6c6810ec3eabc9dfcbfe1309ea8e3202", size = 2849240, upload-time = "2026-04-17T00:59:01.452Z" },
 ]
 
 [[package]]
@@ -565,16 +568,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
+version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
 ]
 
 [package.optional-dependencies]
@@ -600,7 +602,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.135.0"
+version = "1.148.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -616,13 +618,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/84/908cf03a1316c668766e538a210c5caaf2161ef638a7428aa47aee2a890e/google_cloud_aiplatform-1.135.0.tar.gz", hash = "sha256:1e42fc4c38147066ad05d93cb9208201514d359fb2a64663333cea2d1ec9ab42", size = 9941458, upload-time = "2026-01-28T00:25:48.179Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/f3/b2a9417014c93858a2e3266134f931eefd972c2d410b25d7b8782fc6f143/google_cloud_aiplatform-1.148.1.tar.gz", hash = "sha256:75d605fba34e68714bd08e1e482755d0a6e3ae972805f809d088e686c30879e7", size = 10278758, upload-time = "2026-04-17T23:45:26.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/66/d81fb4b81db3ee2f00f8b391f91cdb0e01d6886a2b78105f5d9b6c376104/google_cloud_aiplatform-1.135.0-py2.py3-none-any.whl", hash = "sha256:32b53ee61b3f51b14e21dc98fa9d9021c5db171cf7a407bd71abd3da46f5a6a4", size = 8200215, upload-time = "2026-01-28T00:25:45.202Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/e3515d7bbba602c2b0f6a0da5431785e897252443682e4735d0e6873dc8f/google_cloud_aiplatform-1.148.1-py2.py3-none-any.whl", hash = "sha256:035101e2d8e65c6a706cc3930b2452de7ddcbde50dd130320fcea0d8b03b0c5a", size = 8434481, upload-time = "2026-04-17T23:45:22.919Z" },
 ]
 
 [package.optional-dependencies]
 agent-engines = [
+    { name = "aiohttp" },
     { name = "cloudpickle" },
     { name = "google-cloud-iam" },
     { name = "google-cloud-logging" },
@@ -957,7 +960,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.61.0"
+version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -971,9 +974,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/38/421cd7e70952a536be87a0249409f87297d84f523754a25b08fe94b97e7f/google_genai-1.61.0.tar.gz", hash = "sha256:5773a4e8ad5b2ebcd54a633a67d8e9c4f413032fef07977ee47ffa34a6d3bbdf", size = 489672, upload-time = "2026-01-30T20:50:27.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/87/78dd70cb59f7acf3350f53c5144a7aa7bc39c6f425cd7dc1224b59fcdac3/google_genai-1.61.0-py3-none-any.whl", hash = "sha256:cb073ef8287581476c1c3f4d8e735426ee34478e500a56deef218fa93071e3ca", size = 721948, upload-time = "2026-01-30T20:50:25.551Z" },
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -1262,6 +1265,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1313,14 +1328,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
 ]
 
 [[package]]
@@ -1503,7 +1518,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.3" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
-    { name = "google-adk", specifier = ">=1.27.2" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-auth", specifier = ">=2.48.0" },
     { name = "google-cloud-logging", specifier = ">=3.13.0" },
     { name = "google-cloud-storage", specifier = ">=3.8.0" },
@@ -2050,11 +2065,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -2188,18 +2203,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
     { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

修复 GitHub Security → Dependabot 当前未修复的 5 项安全告警：1 项 critical + 4 项 medium。沿用本仓库安全修复惯例，在 `pyproject.toml` 的 `[tool.uv] constraint-dependencies`/直接 `dependencies` 与 `package.json` 的 `pnpm.overrides` 中抬升对应版本地板，并同步重生成 `uv.lock` / `pnpm-lock.yaml`。

## 变更内容

### Python 后端（`apps/negentropy/pyproject.toml` + `uv.lock`）

| # | 包 | 原版本 | 新版本 | 严重度 | GHSA | 处置点 |
|---|---|---|---|---|---|---|
| 82 | `google-adk` | 1.27.2 | **1.31.0** | **critical** | [rg7c-g689-fr3x](https://github.com/google/adk-python/security/advisories/GHSA-rg7c-g689-fr3x) | 直接依赖 `google-adk>=1.28.1` |
| 86 | `authlib` | 1.6.9 | **1.7.0** | medium | [jj8c-mmj3-mmgv](https://github.com/authlib/authlib/security/advisories/GHSA-jj8c-mmj3-mmgv) | constraint `authlib>=1.6.11` |
| 85 | `Mako` | 1.3.10 | **1.3.11** | medium | [v92g-xgxw-vvmm](https://github.com/sqlalchemy/mako/security/advisories/GHSA-v92g-xgxw-vvmm) | 新增 constraint `mako>=1.3.11`（alembic 传递） |
| 83 | `python-multipart` | 0.0.22 | **0.0.26** | medium | [mj87-hwqh-73pj](https://github.com/Kludex/python-multipart/security/advisories/GHSA-mj87-hwqh-73pj) | 新增 constraint `python-multipart>=0.0.26`（starlette 传递） |

> `google-adk` 是本项目直接依赖，`adk web` 服务默认暴露于 `0.0.0.0:6600`（见 `apps/negentropy/src/negentropy/cli.py:59`），正处于 GHSA-rg7c-g689-fr3x 的攻击面，属于**必须立即升级**的 critical 项。

### 前端（`apps/negentropy-ui/package.json` + `pnpm-lock.yaml`）

| # | 包 | 原版本 | 新版本 | 严重度 | GHSA | 处置点 |
|---|---|---|---|---|---|---|
| 84 | `dompurify` | 3.3.3 | **3.4.0** | medium | [39q2-94rc-95cp](https://github.com/cure53/DOMPurify/security/advisories/GHSA-39q2-94rc-95cp) | pnpm override `dompurify>=3.4.0`（mermaid 传递） |

### 非功能性连带升级（uv 解析器选择的最新稳定版）

- `google-auth` 2.48.0 → 2.49.2
- `google-cloud-aiplatform` 1.135.0 → 1.148.1
- `google-genai` 1.61.0 → 1.73.1
- 新增 `joserfc`（由 authlib 1.7.0 的 JOSE 后端重构引入）
- 移除 `rsa`（被 authlib/authors 替换为 `joserfc`）

## 测试计划

- [x] `uv lock` 成功解析，所有 5 个目标包版本越过补丁阈值
- [x] `pnpm install` 成功，`pnpm-lock.yaml` 中 `dompurify` 全部实例升级至 3.4.0
- [x] `uv run negentropy --help` 正常加载（ADK 1.31 CLI 兼容性验证）
- [x] 后端 Python 单元测试 119/119 通过（pre-existing 3 项模块布局报错与 master 一致，非本 PR 引入）
- [x] 前端 vitest 379/379 通过
- [x] 前端 `pnpm typecheck` + `pnpm lint` 通过
- [ ] CI `negentropy-backend-tests` 通过
- [ ] CI `negentropy-ui-tests` 通过
- [ ] CI `negentropy-dependency-review` 通过

## 风险与边界

- **google-adk 跨度较大**（1.27 → 1.31 共 4 个 minor）：15+ 处 `google.adk.agents.LlmAgent` / `google.adk.tools.ToolContext` / `google.adk.models.*` 调用已通过 `uv run negentropy --help` 与单元测试隐式验证；若 CI 暴露 API 断裂，可回退至 `>=1.28.1,<1.29`。
- **authlib 无直接使用**：项目未使用 `cache=` 参数初始化 OAuth client，实际 CSRF 风险接近零，升级属纵深防御；同时 1.7.0 内部切换至 `joserfc`，遗留 `authlib.jose` 兼容期将至 2.0.0，当前无影响。
- **Mako / python-multipart** 均为传递依赖，仅通过 constraint 声明地板，不改变解析拓扑。
- **dompurify** 本项目无 `ADD_TAGS`/`FORBID_TAGS` 直接调用，攻击面经由 mermaid 渲染；override 后 mermaid 已使用 3.4.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)