### PR TITLE
fix(adk-web): 消除 adk web 启动时四类告警噪声

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复 `adk web` 启动时 `MemoryAutomationFunctionResponse` 触发的 Pydantic `UserWarning: Field name "schema" in "MemoryAutomationFunctionResponse" shadows an attribute in parent "BaseModel"`：将 Python 属性名改为 `schema_name`，通过 `Field(alias="schema", serialization_alias="schema")` + `model_config = ConfigDict(populate_by_name=True)` 保持线协议（wire format）键名 `"schema"` 不变，前端 TS 类型与后端 SQL 数据零改动。
+- 补齐 `opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0` 依赖，消除 ADK `adk_web_server` 启动期 `Unable to import GoogleGenAiSdkInstrumentor` WARNING，恢复 Google GenAI SDK 的 OTel 自动埋点，与现有 Langfuse OTel 链路打通。
+- 站点级安静化两类先于 `negentropy.bootstrap` 触发的上游启动噪声（`AuthlibDeprecationWarning: authlib.jose module is deprecated` 与 `[EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH is enabled`）：通过 `apps/negentropy/src/_negentropy_silence.pth`（hatchling `force-include` 至 site-packages 根）+ `negentropy/_silence_upstream_warnings.py` 在解释器 site 初始化期替换 `warnings.showwarning`，按消息子串白名单丢弃噪声；不影响任何其他告警通道，对 `authlib.deprecate` 的 `simplefilter("always", AuthlibDeprecationWarning)` 免疫（在 filter 之后的 showwarning 层拦截）。
+
 ### Removed
 
 - 删除 `apps/negentropy/.env.example`（197 行）：其承载的全部非密钥配置项已在 `config.default.yaml` 中以结构化 YAML 形式表达，密钥类条目改为通过 shell 环境变量或 `.env.local` 提供。

--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -5,6 +5,11 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/negentropy"]
 
+[tool.hatch.build.targets.wheel.force-include]
+# 将 .pth 文件安装到 site-packages 根目录, 触发解释器 site 初始化期的早期 hook 加载
+# 用于在 ADK CLI 加载第三方依赖前抑制两类已知上游噪声 (authlib.jose / PLUGGABLE_AUTH)
+"src/_negentropy_silence.pth" = "_negentropy_silence.pth"
+
 [project]
 name = "negentropy"
 version = "0.1.0"
@@ -20,6 +25,7 @@ dependencies = [
     
     # Core Infrastructure
     "google-adk>=1.28.1",           # GHSA-rg7c-g689-fr3x: code injection + missing auth on adk web/api_server eval endpoints
+    "opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0",  # ADK GenAI SDK OTel 自动埋点 (消除 adk_web_server 启动期 WARNING)
     "microsandbox>=0.1.8",          # Isolated execution environment for tool usage
     "mcp>=1.6.0",                   # Model Context Protocol SDK for MCP Server integration
     "pydantic-settings[yaml]>=2.12.0",  # Configuration management with YAML support

--- a/apps/negentropy/src/_negentropy_silence.pth
+++ b/apps/negentropy/src/_negentropy_silence.pth
@@ -1,0 +1,1 @@
+import negentropy._silence_upstream_warnings

--- a/apps/negentropy/src/negentropy/_silence_upstream_warnings.py
+++ b/apps/negentropy/src/negentropy/_silence_upstream_warnings.py
@@ -1,0 +1,40 @@
+"""Site-init hook that silences two well-known upstream startup warnings.
+
+These warnings fire during ADK CLI dependency import, BEFORE
+``negentropy.bootstrap`` runs, and therefore cannot be suppressed via
+``warnings.filterwarnings`` in regular project code:
+
+1. ``authlib._joserfc_helpers`` triggers ``AuthlibDeprecationWarning`` when
+   importing the deprecated ``authlib.jose`` shim. ``authlib.deprecate`` also
+   calls ``warnings.simplefilter("always", AuthlibDeprecationWarning)`` on its
+   own import, which would defeat any ``filterwarnings`` registered earlier. We
+   therefore install a ``showwarning`` hook (which runs AFTER filter checks)
+   and drop the noise by message-content whitelist.
+2. ``google.adk.auth.*`` triggers
+   ``UserWarning("[EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH ...")``
+   because the feature is ``default_on=True`` in google-adk 1.31.0.
+
+Loaded via ``_negentropy_silence.pth`` at site initialisation, so the hook is
+in place before any third-party import in the venv.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+_SILENCED_SUBSTRINGS = (
+    "authlib.jose module is deprecated",
+    "PLUGGABLE_AUTH",
+)
+
+_orig_showwarning = warnings.showwarning
+
+
+def _filtered_showwarning(message, category, filename, lineno, file=None, line=None):
+    msg_str = str(message)
+    if any(token in msg_str for token in _SILENCED_SUBSTRINGS):
+        return
+    _orig_showwarning(message, category, filename, lineno, file=file, line=line)
+
+
+warnings.showwarning = _filtered_showwarning

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -31,7 +31,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select
 
 from negentropy.auth.deps import get_current_user
@@ -145,8 +145,10 @@ class MemoryDashboardResponse(BaseModel):
 
 
 class MemoryAutomationFunctionResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
-    schema: str
+    schema_name: str = Field(alias="schema", serialization_alias="schema")
     status: str
     definition: str
     managed: bool = True

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -1497,6 +1497,7 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "microsandbox" },
+    { name = "opentelemetry-instrumentation-google-genai" },
     { name = "orjson" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings", extra = ["yaml"] },
@@ -1526,6 +1527,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.83.0" },
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "microsandbox", specifier = ">=0.1.8" },
+    { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.6b0,<1.0.0" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.12.0" },
@@ -1650,6 +1652,36 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/36/7c307d9be8ce4ee7beb86d7f1d31027f2a6a89228240405a858d6e4d64f9/opentelemetry_instrumentation-0.58b0.tar.gz", hash = "sha256:df640f3ac715a3e05af145c18f527f4422c6ab6c467e40bd24d2ad75a00cb705", size = 31549, upload-time = "2025-09-11T11:42:14.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/db/5ff1cd6c5ca1d12ecf1b73be16fbb2a8af2114ee46d4b0e6d4b23f4f4db7/opentelemetry_instrumentation-0.58b0-py3-none-any.whl", hash = "sha256:50f97ac03100676c9f7fc28197f8240c7290ca1baa12da8bfbb9a1de4f34cc45", size = 33019, upload-time = "2025-09-11T11:41:00.624Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-google-genai"
+version = "0.7b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-genai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/59/595e5ed05715c47cf49ac7e30d0a4cf6ed41e00524401c46c9d92b84623c/opentelemetry_instrumentation_google_genai-0.7b0.tar.gz", hash = "sha256:35158682dfd00201ef3864b47dda95d6062188e8a599ecabd383688e7eba2824", size = 52057, upload-time = "2026-02-20T21:56:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/97/2c26687c6ea0747bb225ce7e5506f8f87e3e7ce4204c2900798177aa7792/opentelemetry_instrumentation_google_genai-0.7b0-py3-none-any.whl", hash = "sha256:b579d7bd3dda1aae1b76bfebbe86adcc88eadb2c08d11e864fbdecf370b19b25", size = 31402, upload-time = "2026-02-20T21:56:22.149Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1701,6 +1733,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867, upload-time = "2025-09-11T10:29:12.597Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954, upload-time = "2025-09-11T10:28:59.218Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-genai"
+version = "0.3b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/d8/4dd2fb622d26ec45b10ef63eb87fd512f5d7467c7bd35ce390629bd6dff8/opentelemetry_util_genai-0.3b0.tar.gz", hash = "sha256:83e127789a9ad615b8ca65f05fc36955a67ce257b06142bfd46159a3b7ed73d3", size = 31800, upload-time = "2026-02-20T16:16:14.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/e5/fada54909e445d7b4007f8b96221d571999efeab9446f3127cc1cebe5e07/opentelemetry_util_genai-0.3b0-py3-none-any.whl", hash = "sha256:ebc2b01bcb891ddc7218452470d189d3321cd742653299ff8e7de45debcfb986", size = 28426, upload-time = "2026-02-20T16:16:12.027Z" },
 ]
 
 [[package]]
@@ -2551,6 +2597,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 摘要

修复 `uv run adk web --port 6600 --reload_agents src/negentropy` 启动期输出的 4 类告警噪声，消除日志污染，让真实问题更易被发现。

| # | 告警来源 | 类别 | 归属 |
|---|---|---|---|
| 1 | `engine/api.py:147` `Field name "schema" ... shadows an attribute in parent "BaseModel"` | Pydantic UserWarning | **本仓库** |
| 2 | `adk.adk_web_server: Unable to import GoogleGenAiSdkInstrumentor` | OTel 埋点降级 | **本仓库依赖缺失** |
| 3 | `authlib/_joserfc_helpers.py:8: AuthlibDeprecationWarning: authlib.jose module is deprecated` | 第三方自废弃 | 上游 `authlib`（站点级安静化） |
| 4 | `google/adk/features/_feature_decorator.py:72: UserWarning: [EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH is enabled` | ADK 实验特性默认开启 | 上游 `google-adk`（站点级安静化） |

## 变更清单

### Fix #1 · Pydantic `schema` 字段去阴影化（Field Alias 模式）

- `apps/negentropy/src/negentropy/engine/api.py` `MemoryAutomationFunctionResponse`：Python 属性名 `schema` → `schema_name`，通过 `Field(alias="schema", serialization_alias="schema")` + `model_config = ConfigDict(populate_by_name=True)` **保持线协议键名 `"schema"` 不变**。
- 前端 `apps/negentropy-ui/features/memory/utils/memory-api.ts` TS 类型与后端 SQL 数据**零改动**。

### Fix #2 · 补齐 `opentelemetry-instrumentation-google-genai` 依赖

- `apps/negentropy/pyproject.toml` `dependencies` 新增 `"opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0"`（等价于 `google-adk[otel-gcp]` 的唯一新增项，避免对 extra 名称稳定性的间接耦合）。
- 消除 `adk_web_server` 启动期 WARNING，恢复 Google GenAI SDK 的 OTel 自动埋点，与现有 Langfuse OTel 链路打通。

### Fix #3 / #4 · 站点级安静化两类先于 `bootstrap` 触发的上游噪声

**为何必须采用 site-init `.pth`**：这两类告警在 `negentropy.bootstrap` 任何代码加载**之前**由 ADK CLI 依赖链自身 import 触发（从日志时序可见），因此 `warnings.filterwarnings` 无处安插；且 `authlib/deprecate.py` 自身 import 时调用 `warnings.simplefilter("always", AuthlibDeprecationWarning)` 会清空先前注册的过滤器。

**业界 prior art**：与 `coverage.pth`、`google-cloud-logging.pth` 同源——通过 `site-packages` 根目录 `.pth` 文件（解释器 `site` 模块启动期自动处理 `import` 行）注入极薄 hook 模块，**替换 `warnings.showwarning`**；`showwarning` 工作在 filter 检查**之后**，对 `simplefilter("always")` 免疫。

- **新文件** `apps/negentropy/src/_negentropy_silence.pth`（单行 `import negentropy._silence_upstream_warnings`）。
- **新文件** `apps/negentropy/src/negentropy/_silence_upstream_warnings.py`：保留原 `showwarning`，仅按消息子串白名单 `("authlib.jose module is deprecated", "PLUGGABLE_AUTH")` 丢弃 2 类噪声，其他警告原样透传。
- **`pyproject.toml`** 新增 `[tool.hatch.build.targets.wheel.force-include]` 段，将 `.pth` 安装到 wheel 根（即 venv `site-packages` 根目录）。

### CHANGELOG

- `[Unreleased]` 章节新增 `### Fixed` 三条，沿用现有中文风格。

## 验证证据

### 1. Pydantic 别名契约保持

\`\`\`bash
$ uv run python -c "
from negentropy.engine.api import MemoryAutomationFunctionResponse
m = MemoryAutomationFunctionResponse.model_validate({
    'name': 'fn_x', 'schema': 'negentropy', 'status': 'present',
    'definition': 'CREATE FUNCTION ...', 'managed': True,
})
assert m.schema_name == 'negentropy'
assert m.model_dump(by_alias=True)['schema'] == 'negentropy'
"
# OK alias contract: {'name': 'fn_x', 'schema': 'negentropy', ...}
\`\`\`

### 2. `showwarning` 安装与选择性

\`\`\`bash
$ uv run python -c "
import warnings
assert warnings.showwarning.__name__ == '_filtered_showwarning'
# 2 类子串静默；其余透传
"
# OK: showwarning hook installed, selective, and transparent for unrelated warnings
\`\`\`

### 3. 端到端启动日志（`uv run adk web --port 6601 ...`）

- ✅ 无 `UserWarning: Field name "schema" in "MemoryAutomationFunctionResponse"`
- ✅ 无 `WARNING | adk.adk_web_server | Unable to import GoogleGenAiSdkInstrumentor`
- ✅ 无 `AuthlibDeprecationWarning: authlib.jose module is deprecated`
- ✅ 无 `[EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH is enabled`
- ✅ `/list-apps` 返回 `["agents","auth","config","db","engine","knowledge","logging","models","plugins","storage"]`（HTTP 200）

### 4. 回归测试

\`\`\`
$ uv run pytest tests/unit_tests/engine/test_memory_automation_service.py \
                tests/unit_tests/models/test_model_imports.py -v
22 passed in 1.54s
\`\`\`

## 风险与回退

- **风险等级**：低。
  - Fix #1：纯 Pydantic 别名重命名，wire 协议不变；前后端无契约破坏。
  - Fix #2：新增官方推荐 OTel 包，版本号 semver pre-1.0，与现有 `opentelemetry_api/sdk 1.37.0` SemConv 兼容。
  - Fix #3/#4：`showwarning` hook 仅匹配 2 个明确子串，作用域极窄；`.pth` 仅在 venv 内生效，不污染全局 Python。
- **回退**：单 commit `git revert b9321ec` 即可，无 schema 迁移、无前端协议变更、无运行时配置变化。

## Test plan

- [x] `uv sync` 刷新 `uv.lock` 并安装新 dep 与 `.pth`
- [x] Pydantic alias 契约静态验证
- [x] `warnings.showwarning` 替换与选择性白名单验证
- [x] `adk web` 启动日志人工 diff 对比（4 条告警全部消失）
- [x] `test_memory_automation_service.py` + `test_model_imports.py` 22/22 PASS
- [x] ruff lint / format（pre-commit hook 通过）