### PR TITLE
chore(ports): 默认端口切换 6600→3292 / 3333→3192

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ uv run adk web --port 8000 --reload_agents src/negentropy  # Start the engine
 ```bash
 cd apps/negentropy-ui
 pnpm install                   # Install dependencies
-pnpm run dev                   # Start development server (localhost:3333)
+pnpm run dev                   # Start development server (localhost:3192)
 ```
 
 ### 4. Set Up Pre-commit Hooks (Recommended)
@@ -139,7 +139,7 @@ pre-commit install
 
 ### 5. Initiate Dialogue
 
-Fire up your browser, head over to `http://localhost:3333`, and start conversing with the NegentropyEngine.
+Fire up your browser, head over to `http://localhost:3192`, and start conversing with the NegentropyEngine.
 
 > For comprehensive guides on environment setup, database migrations, frontend-backend integration, and troubleshooting, please refer to [docs/development.md](./docs/development.md).
 

--- a/apps/negentropy-ui/features/knowledge/utils/api-specs.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/api-specs.ts
@@ -104,7 +104,7 @@ export interface ApiEndpoint {
   interactiveForm?: InteractiveFormConfig;
 }
 
-const BASE_URL = "http://localhost:6600";
+const BASE_URL = "http://localhost:3292";
 const DEFAULT_CHUNKING_CONFIG = createDefaultChunkingConfig("recursive");
 const DEFAULT_CHUNKING_CONFIG_DESCRIPTION =
   "canonical chunking 配置，按 strategy 判别。支持 fixed / recursive / semantic / hierarchical。";

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack -H localhost -p 3333",
+    "dev": "next dev --webpack -H localhost -p 3192",
     "build": "next build",
     "start": "node ./scripts/start-production.mjs",
     "lint": "eslint . --max-warnings=0",

--- a/apps/negentropy-ui/scripts/start-production.mjs
+++ b/apps/negentropy-ui/scripts/start-production.mjs
@@ -77,7 +77,7 @@ function prepareStandaloneRuntime(projectRoot) {
 }
 
 /* 应用默认端口与主机名（可被外部环境变量覆盖） */
-process.env.PORT ??= "3333";
+process.env.PORT ??= "3192";
 process.env.HOSTNAME ??= "localhost";
 
 const projectRoot = process.cwd();

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -17,7 +17,7 @@ import { POST as unarchiveSession } from "@/app/api/agui/sessions/[sessionId]/un
 
 // Mock 环境变量
 const mockEnv = {
-  AGUI_BASE_URL: "http://localhost:6600",
+  AGUI_BASE_URL: "http://localhost:3292",
   NEXT_PUBLIC_AGUI_APP_NAME: "negentropy",
   NEXT_PUBLIC_AGUI_USER_ID: "test-user",
 };

--- a/apps/negentropy/src/negentropy/cli.py
+++ b/apps/negentropy/src/negentropy/cli.py
@@ -48,7 +48,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         env["NE_CONFIG_PATH"] = str(config_path)
 
     # Determine port and host
-    port = args.port or 6600
+    port = args.port or 3292
     host = args.host or "0.0.0.0"
 
     # Build adk web command
@@ -88,7 +88,7 @@ def main() -> None:
 
     # serve subcommand
     serve_parser = subparsers.add_parser("serve", help="启动 ADK Web 服务器")
-    serve_parser.add_argument("--port", type=int, default=6600, help="服务器端口 (默认: 6600)")
+    serve_parser.add_argument("--port", type=int, default=3292, help="服务器端口 (默认: 3292)")
     serve_parser.add_argument("--host", default="0.0.0.0", help="绑定地址 (默认: 0.0.0.0)")
     serve_parser.add_argument("--no-reload", action="store_true", help="禁用热重载")
 

--- a/apps/negentropy/tests/unit_tests/config/test_cli.py
+++ b/apps/negentropy/tests/unit_tests/config/test_cli.py
@@ -78,7 +78,7 @@ class TestServeCommand:
 
         class Args:
             config = str(tmp_path / "nonexistent.yaml")
-            port = 6600
+            port = 3292
             host = "0.0.0.0"
             no_reload = False
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ uv run adk web --port 8000 --reload_agents src/negentropy  # ADK Web 启动
 ```bash
 cd apps/negentropy-ui
 pnpm install                           # 安装依赖
-pnpm run dev                           # 启动开发服务器 (localhost:3333)
+pnpm run dev                           # 启动开发服务器 (localhost:3192)
 ```
 
 ---
@@ -156,7 +156,7 @@ flowchart LR
     Start --> SetupFE[前端: pnpm install]
 
     SetupBE --> DevBE[后端: uv run adk web<br>--reload_agents]
-    SetupFE --> DevFE[前端: pnpm run dev<br>localhost:3333]
+    SetupFE --> DevFE[前端: pnpm run dev<br>localhost:3192]
 
     DevBE --> |热重载| DevBE
     DevFE --> |热重载| DevFE
@@ -225,7 +225,7 @@ uv run ruff format .                   # 代码格式化
 ```bash
 cd apps/negentropy-ui
 
-pnpm run dev                           # 开发启动 (localhost:3333)
+pnpm run dev                           # 开发启动 (localhost:3192)
 pnpm run build                         # 生产构建
 pnpm run start                         # 生产启动
 ```
@@ -263,7 +263,7 @@ pnpm run typecheck                     # TypeScript 类型检查
 **前置条件**：
 
 - 后端 ADK 已启动，`AGUI_BASE_URL` 可访问
-- 前端已启动：`http://localhost:3333`
+- 前端已启动：`http://localhost:3192`
 - `.env.local` 中 `NEXT_PUBLIC_AGUI_APP_NAME` 与 `NEXT_PUBLIC_AGUI_USER_ID` 已设置
 
 **验证步骤**：
@@ -436,7 +436,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3333"],
+    allow_origins=["http://localhost:3192"],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -196,7 +196,7 @@ pnpm install
 pnpm run dev
 ```
 
-> 前端启动后访问 `http://localhost:3333` 即可进入 Negentropy 主界面。
+> 前端启动后访问 `http://localhost:3192` 即可进入 Negentropy 主界面。
 
 ### 2.4 首次对话
 
@@ -206,7 +206,7 @@ sequenceDiagram
     participant UI as 🖥️ 前端界面
     participant BE as ⚙️ 后端引擎
 
-    U->>UI: 打开 localhost:3333
+    U->>UI: 打开 localhost:3192
     UI->>UI: 显示三栏布局<br/>（Session 列表 / 聊天区 / 调试面板）
     U->>UI: 在 Composer 输入框输入消息
     UI->>BE: 自动创建 Session<br/>发送用户消息
@@ -216,7 +216,7 @@ sequenceDiagram
     U->>UI: 阅读 Agent 回复<br/>查看右侧调试信息
 ```
 
-打开浏览器访问 `http://localhost:3333`，你会看到三栏布局的对话界面：
+打开浏览器访问 `http://localhost:3192`，你会看到三栏布局的对话界面：
 
 - **左侧**：Session 列表（当前为空）
 - **中间**：聊天区域 + 底部输入框（Composer）

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -120,12 +120,12 @@ uv run adk web --port 8000 --reload_agents src/negentropy  # 启动引擎
 ```bash
 cd apps/negentropy-ui
 pnpm install                   # 安装依赖
-pnpm run dev                   # 启动开发服务器 (localhost:3333)
+pnpm run dev                   # 启动开发服务器 (localhost:3192)
 ```
 
 ### 4. 开始对话
 
-打开浏览器访问 `http://localhost:3333`，开始与 NegentropyEngine 对话。
+打开浏览器访问 `http://localhost:3192`，开始与 NegentropyEngine 对话。
 
 > 完整的环境搭建指南、数据库迁移、前后端对接、故障排查详见 [docs/development.md](../development.md)。
 


### PR DESCRIPTION
## 背景

- 将 Negentropy 后端默认端口从 `6600` 切换到 `3292`
- 将 Negentropy UI 默认端口从 `3333` 切换到 `3192`
- 要求：全仓无残留，所有文档、测试 Mock、API 示例同步更新

## 改动清单（按文件分组）

### 后端 6600 → 3292（5 处）
| 文件 | 位置 | 变更 |
|---|---|---|
| `apps/negentropy/src/negentropy/cli.py` | `_cmd_serve` 默认兜底 | `args.port or 6600` → `or 3292` |
| `apps/negentropy/src/negentropy/cli.py` | `serve --port` argparse | `default=6600` + help 文案同步 |
| `apps/negentropy/tests/unit_tests/config/test_cli.py` | `TestServeCommand` Mock | `port = 6600` → `3292` |
| `apps/negentropy-ui/tests/integration/api.test.ts` | BFF 集成测试 Mock | `AGUI_BASE_URL` 同步 |
| `apps/negentropy-ui/features/knowledge/utils/api-specs.ts` | 知识库 API 示例 | `BASE_URL` 同步 |

### UI 3333 → 3192（14 处）
| 文件 | 说明 |
|---|---|
| `apps/negentropy-ui/package.json` | `dev` 脚本 `-p` 参数 |
| `apps/negentropy-ui/scripts/start-production.mjs` | 生产默认端口兜底 |
| `README.md` | 英文 README 两处 |
| `docs/zh-CN/README.md` | 中文 README 两处 |
| `docs/development.md` | 开发指南五处（含 Mermaid 节点、CORS 示例） |
| `docs/user-guide.md` | 用户手册三处（含 Mermaid 序列图） |

## 决策说明

- **单 commit 原子提交**：改动同质（端口字面替换），跨文件一致性要求同步落地，避免 bisect 中间非法状态
- **未引入集中端口常量**（YAGNI）：仅 2 个默认值、横跨 Python/TS/Markdown 三种载体，`--port` CLI 与 `PORT` 环境变量已提供覆盖路径
- **后端 CORS 代码未补**：`apps/negentropy/src/negentropy/` 原本无 `CORSMiddleware` 装配（FastAPI 由 `google.adk.cli web` 子进程接管），`docs/development.md:439` 仅为直连模式下的条件示例，改数字保持文档自洽
- **端口冲突检查**：`3092` (wiki) / `3192` (UI 新) / `3210` (Playwright) / `3292` (后端新) 两两互不冲突

## 无残留证据

``` bash
$ rg -n -w 6600 --glob '!apps/negentropy/uv.lock' --glob '!apps/negentropy-ui/playwright-report/**'
# 0 命中

$ rg -n -w 3333 --glob '!apps/negentropy-wiki/src/app/globals.css' --glob '!apps/negentropy/uv.lock' --glob '!apps/negentropy-ui/playwright-report/**'
# 0 命中
```

## 验证结果

| # | 命令 | 结果 |
|---|---|---|
| V1 | `uv run --project apps/negentropy negentropy serve --help` | `--port PORT  服务器端口 (默认: 3292)` ✅ |
| V2 | `uv run pytest apps/negentropy/tests/unit_tests/config/test_cli.py -v` | 4 passed ✅ |
| V3 | `pnpm -C apps/negentropy-ui test tests/integration/api.test.ts` | 32 passed ✅ |
| V4 | `pnpm -C apps/negentropy-ui dev` | `Local: http://localhost:3192` ✅ |
| V5 | 全仓 `rg -n -w 6600` | 0 命中 ✅ |
| V6 | 全仓 `rg -n -w 3333` | 0 命中 ✅ |

## 协作者本地迁移提示

- 若本地 `.env.local` 中有 `AGUI_BASE_URL=http://localhost:6600`，请同步改为 `3292`
- 浏览器书签若指向 `localhost:3333`，请同步改为 `3192`
- `apps/negentropy-ui/playwright-report/index.html` 的旧端口将在下次 `pnpm test:e2e` 自动覆盖

## 排除项（不改）

- `apps/negentropy-wiki/src/app/globals.css:57` — `#333333` CSS 色值
- `apps/negentropy/uv.lock` — 哈希串巧合包含 `6600`
- `apps/negentropy-ui/playwright-report/index.html` — 测试生成产物
- `apps/negentropy-ui/playwright.config.ts` — `PLAYWRIGHT_PORT` 默认 3210，与 UI 端口解耦