### PR TITLE
fix(db): 恢复被误删的 negentropy-perceives 预置 seed 以修复 integration tests;

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py
@@ -1,0 +1,77 @@
+"""Seed: negentropy-perceives 预置 MCP Server
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-19 00:00:00.000000+00:00
+
+按正交分解原则，将 DDL 与 DML 解耦：0001 仅负责 schema（纯 DDL），
+本迁移承载 negentropy-perceives 这一预置 MCP Server 的 seed（纯 DML）。
+
+SQL 模板直接复用 99eb9ff 已验证的 `INSERT ... ON CONFLICT (name) DO UPDATE`：
+- 新部署 alembic upgrade head 会首次写入预置；
+- 既有部署如被手动污染，也会在任意升级通路上被幂等自愈回归预置。
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Negentropy Perceives MCP Server 预设（幂等 upsert）
+    op.execute(
+        sa.text("""
+        INSERT INTO negentropy.mcp_servers (
+            owner_id, visibility, name, display_name, description,
+            transport_type, command, args, env, url, headers,
+            is_enabled, auto_start, config
+        )
+        VALUES (
+            'system:negentropy-perceives-preset',
+            'PUBLIC'::negentropy.pluginvisibility,
+            'negentropy-perceives',
+            'Negentropy Perceives',
+            '一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、'
+            '图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。',
+            'http',
+            NULL,
+            '[]'::jsonb,
+            '{}'::jsonb,
+            'http://localhost:8092/mcp',
+            '{}'::jsonb,
+            TRUE,
+            TRUE,
+            '{}'::jsonb
+        )
+        ON CONFLICT (name) DO UPDATE
+        SET
+            owner_id = EXCLUDED.owner_id,
+            visibility = EXCLUDED.visibility,
+            display_name = EXCLUDED.display_name,
+            description = EXCLUDED.description,
+            transport_type = EXCLUDED.transport_type,
+            command = EXCLUDED.command,
+            args = EXCLUDED.args,
+            env = EXCLUDED.env,
+            url = EXCLUDED.url,
+            headers = EXCLUDED.headers,
+            is_enabled = EXCLUDED.is_enabled,
+            auto_start = EXCLUDED.auto_start,
+            config = EXCLUDED.config,
+            updated_at = now()
+    """)
+    )
+
+
+def downgrade() -> None:
+    # 仅回收 seed，不触碰 schema
+    op.execute(sa.text("DELETE FROM negentropy.mcp_servers WHERE name = 'negentropy-perceives'"))


### PR DESCRIPTION
## 背景

GitHub Actions `backend-quality / Backend Integration Tests` 在 `feature/1.x.x` 上持续失败（[Run #24622513665](https://github.com/ThreeFish-AI/negentropy/actions/runs/24622513665)），`50 passed / 2 failed`：

```
FAILED tests/integration_tests/db/test_migrations.py::test_negentropy_perceives_seeded_by_migration
FAILED tests/integration_tests/db/test_migrations.py::test_negentropy_perceives_seed_is_idempotent_on_re_upgrade
  - sqlalchemy.exc.NoResultFound: No row was found when one was required
```

## 根因

- `43bab2c`（2026-04-19）`refactor(db): 合并初始迁移并清理孤岛 Model` 将 `0001_init_schema.py` 重写为 **纯 DDL**（文件头标注“不包含任何种子数据”），**误删了 `negentropy-perceives` MCP Server 的 seed INSERT**。
- 但业务仍依赖该预置：`config/knowledge.py`、`config/config.default.yaml`、多项集成测试均以此预置作为契约。
- `31bacef` 合入 master 的端口变更（6600→3292）触发 CI 重跑，缺失 seed 的问题被暴露。

## 方案（Orthogonal Decomposition）

按 [`AGENTS.md`](../blob/feature/1.x.x/negentropy/AGENTS.md) 的正交分解原则，将 schema (DDL) 与 seed (DML) 解耦：

- **保留** `0001_init_schema.py` 作为“纯 schema”（尊重原 refactor 意图）。
- **新增** [`apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py`](../blob/vk/ffb5-github-actions-w/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py) 承载 seed。
- SQL 直接复用 `99eb9ff` 已验证过的 `INSERT ... ON CONFLICT (name) DO UPDATE` 模板（端口 8092 与测试断言一致）。
- `downgrade()` 仅 `DELETE` seed，不触碰 schema，确保可逆。

## 循证验证

- `uv run alembic history --verbose` → `0001 → 0002` 线性单一 head，`test_migrations_have_single_head` 继续通过。
- `uv run pytest tests/integration_tests/db/test_migrations.py -v --no-cov` → **4 passed**（含此前失败的 2 项）。
- `uv run pytest tests/integration_tests/ -v --no-cov` → **52 passed**（原 50 + 恢复 2）。
- `uv run alembic downgrade base && uv run alembic upgrade head` 往返无错。
- `ruff check` / `ruff format` 均通过。

## 风险与影响

- 仅新增 1 个迁移文件，不改动既有 schema，不引入循环 FK / enum 依赖。
- seed 采用 `ON CONFLICT (name) DO UPDATE`，对存量部署幂等自愈（即使早期部署曾手工污染该记录）。
- 其余 Node.js 20 弃用告警（`actions/checkout@v4` 等）属 upstream 版本策略，不在本次修复范围内。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>