### PR TITLE
fix(auth): 修复 Google 登录跳转 :6600 并引入后端地址 SSOT 与迁移守护

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 .env*
+!.env.example
 .vercel
 *.tsbuildinfo
 next-env.d.ts

--- a/apps/negentropy-ui/.env.example
+++ b/apps/negentropy-ui/.env.example
@@ -1,0 +1,26 @@
+# Negentropy UI 本地环境变量模板
+#
+# 使用方式：复制为 .env.local 后按需覆写。
+# 服务端变量仅在 Next.js Route Handler (app/api/**) 中可见，
+# 不会被打包进客户端 bundle；带 NEXT_PUBLIC_ 前缀的变量对浏览器可见。
+#
+# 若全部留空，BFF 会自动回落到 http://localhost:3292（与后端默认端口对齐）。
+# 若检测到历史端口（如 :6600 / :6666）且 NODE_ENV !== "production"，
+# BFF 会在 server log 打印一次迁移告警，并将端口改写为 :3292。
+
+# ---------- 服务端（Route Handler 可见） ----------
+# AGUI / 通用数据面后端基址
+AGUI_BASE_URL=http://localhost:3292
+
+# 认证面：若 auth 走独立后端可单独覆盖；否则复用 AGUI_BASE_URL
+# AUTH_BASE_URL=http://localhost:3292
+
+# Knowledge 领域：支持独立部署
+# KNOWLEDGE_BASE_URL=http://localhost:3292
+
+# Memory 领域：支持独立部署
+# MEMORY_BASE_URL=http://localhost:3292
+
+# ---------- 客户端（浏览器可见） ----------
+NEXT_PUBLIC_AGUI_APP_NAME=negentropy
+NEXT_PUBLIC_AGUI_USER_ID=dev-user

--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -17,10 +17,7 @@ import {
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 import { normalizeAguiEvent, resolveEventRunAndThread } from "@/utils/agui-normalization";
-
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);
@@ -75,13 +72,7 @@ function normalizeEvent(
 }
 
 export async function POST(request: Request) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured",
-    );
-  }
+  const baseUrl = getAguiBaseUrl();
 
   let body: Record<string, unknown>;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/_request.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/_request.ts
@@ -3,17 +3,15 @@ import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
+/**
+ * 返回类型保持 `string | Response` 以维持既有路由的接入形态。
+ * 在 SSOT helper 引入默认值之后，Response 分支实际不可达，
+ * 但保留该契约作为 defense-in-depth，避免批量修改调用方。
+ */
 export function getSessionAguiBaseUrl(): string | Response {
-  const baseUrl = process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured",
-    );
-  }
-
-  return baseUrl;
+  return getAguiBaseUrl();
 }
 
 export function buildSessionUpstreamHeaders(

--- a/apps/negentropy-ui/app/api/auth/_config.ts
+++ b/apps/negentropy-ui/app/api/auth/_config.ts
@@ -1,7 +1,1 @@
-export function getAuthBaseUrl() {
-  return (
-    process.env.AUTH_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+export { getAuthBaseUrl } from "@/lib/server/backend-url";

--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getKnowledgeBaseUrl } from "@/lib/server/backend-url";
 
-function getBaseUrl() {
-  return (
-    process.env.KNOWLEDGE_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getKnowledgeBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/app/api/knowledge/stats/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/stats/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getKnowledgeBaseUrl } from "@/lib/server/backend-url";
 
 /**
  * Knowledge API 统计端点
@@ -14,31 +15,12 @@ interface ApiStatsResponse {
   avg_latency_ms: number;
 }
 
-function getBaseUrl() {
-  return (
-    process.env.KNOWLEDGE_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
-
 export async function GET(request: NextRequest) {
-  const baseUrl = getBaseUrl();
+  const baseUrl = getKnowledgeBaseUrl();
 
   // 从查询参数获取 endpoint
   const { searchParams } = request.nextUrl;
   const endpoint = searchParams.get("endpoint");
-
-  // 如果没有配置后端 URL，返回默认值
-  if (!baseUrl) {
-    const defaultStats: ApiStatsResponse = {
-      total_calls: 0,
-      success_count: 0,
-      failed_count: 0,
-      avg_latency_ms: 0,
-    };
-    return NextResponse.json(defaultStats);
-  }
 
   try {
     // 构建后端 URL，传递 endpoint 参数

--- a/apps/negentropy-ui/app/api/memory/_proxy.ts
+++ b/apps/negentropy-ui/app/api/memory/_proxy.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getMemoryBaseUrl } from "@/lib/server/backend-url";
 
-function getBaseUrl() {
-  return (
-    process.env.MEMORY_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getMemoryBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/app/api/plugins/_proxy.ts
+++ b/apps/negentropy-ui/app/api/plugins/_proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
 /**
  * Plugins API 代理工具函数
@@ -7,12 +8,7 @@ import { buildAuthHeaders } from "@/lib/sso";
  * 用于将前端的 /api/plugins/* 请求代理到后端 /plugins/* API
  */
 
-function getBaseUrl() {
-  return (
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getAguiBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/app/api/plugins/stats/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
 /**
  * Plugins Stats API 代理端点
@@ -13,12 +14,7 @@ interface PluginStatsResponse {
   subagents: { total: number; enabled: number };
 }
 
-function getBaseUrl() {
-  return (
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getAguiBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/lib/server/backend-url.ts
+++ b/apps/negentropy-ui/lib/server/backend-url.ts
@@ -1,0 +1,151 @@
+/**
+ * Negentropy BFF 后端基址单一事实源（SSOT）。
+ *
+ * 所有 Next.js Route Handler 统一通过 getAguiBaseUrl / getAuthBaseUrl /
+ * getKnowledgeBaseUrl / getMemoryBaseUrl 解析后端服务地址，避免多处文件
+ * 各自读取 process.env 造成漂移，并内置「遗留端口迁移守护」以保证端口
+ * 迁移后的向后兼容。
+ *
+ * 该模块仅应被 app/api/** 下的服务端代码 import，不应出现在任何
+ * "use client" 组件中，以免意外被打包进客户端 bundle。
+ */
+
+export const DEFAULT_BACKEND_BASE_URL = "http://localhost:3292";
+
+/** 曾经作为后端默认端口、但已在后续迁移中弃用的本地端口列表。 */
+export const LEGACY_LOCAL_PORTS: readonly string[] = ["6600", "6666"];
+
+/** 迁移守护仅对本地环回地址生效。 */
+const LOCAL_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "[::1]"];
+
+/** 当前后端默认监听端口（与 apps/negentropy/src/negentropy/cli.py 对齐）。 */
+const CURRENT_BACKEND_PORT = "3292";
+
+/** 同一 URL 只告警一次，避免每次 BFF 请求都打印导致日志噪音。 */
+const warnedUrls = new Set<string>();
+
+function isLegacyLocalhostUrl(raw: string): { host: string; port: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (!LOCAL_HOSTS.includes(parsed.hostname)) {
+    return null;
+  }
+  if (!parsed.port) {
+    return null;
+  }
+  if (!LEGACY_LOCAL_PORTS.includes(parsed.port)) {
+    return null;
+  }
+  return { host: parsed.hostname, port: parsed.port };
+}
+
+function applyLegacyPortMigration(raw: string, sourceLabel: string): string {
+  const legacy = isLegacyLocalhostUrl(raw);
+  if (!legacy) {
+    return raw;
+  }
+
+  const warnKey = `${sourceLabel}::${raw}`;
+  if (!warnedUrls.has(warnKey)) {
+    warnedUrls.add(warnKey);
+    console.warn(
+      `[backend-url] 检测到 ${sourceLabel}=${raw} 指向已弃用端口 :${legacy.port}；` +
+        `后端已迁移至 :${CURRENT_BACKEND_PORT}。请更新 apps/negentropy-ui/.env.local。`,
+    );
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    return raw;
+  }
+
+  const rewritten = new URL(raw);
+  rewritten.port = CURRENT_BACKEND_PORT;
+  return rewritten.toString().replace(/\/$/, "");
+}
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function pickFirstNonEmpty(
+  candidates: ReadonlyArray<[string, string | undefined]>,
+): { label: string; value: string } | null {
+  for (const [label, value] of candidates) {
+    if (value !== undefined) {
+      return { label, value };
+    }
+  }
+  return null;
+}
+
+function resolveFromEnvChain(envNames: readonly string[]): string {
+  const picked = pickFirstNonEmpty(envNames.map((name) => [name, readEnv(name)] as const));
+  if (!picked) {
+    return DEFAULT_BACKEND_BASE_URL;
+  }
+  return applyLegacyPortMigration(picked.value, picked.label);
+}
+
+/**
+ * AGUI / 通用数据面后端基址。
+ *
+ * 读取优先级：AGUI_BASE_URL → NEXT_PUBLIC_AGUI_BASE_URL → 默认值。
+ */
+export function getAguiBaseUrl(): string {
+  return resolveFromEnvChain(["AGUI_BASE_URL", "NEXT_PUBLIC_AGUI_BASE_URL"]);
+}
+
+/**
+ * 认证面后端基址。
+ *
+ * 若显式设置 AUTH_BASE_URL 则优先使用；否则回落到 AGUI / 通用数据面基址，
+ * 保证单体部署下的零配置体验。
+ */
+export function getAuthBaseUrl(): string {
+  return resolveFromEnvChain([
+    "AUTH_BASE_URL",
+    "AGUI_BASE_URL",
+    "NEXT_PUBLIC_AGUI_BASE_URL",
+  ]);
+}
+
+/**
+ * Knowledge 领域后端基址。
+ *
+ * 支持通过 KNOWLEDGE_BASE_URL 将知识库请求指向独立后端；否则复用 AGUI 基址。
+ */
+export function getKnowledgeBaseUrl(): string {
+  return resolveFromEnvChain([
+    "KNOWLEDGE_BASE_URL",
+    "AGUI_BASE_URL",
+    "NEXT_PUBLIC_AGUI_BASE_URL",
+  ]);
+}
+
+/**
+ * Memory 领域后端基址。
+ *
+ * 支持通过 MEMORY_BASE_URL 将记忆服务请求指向独立后端；否则复用 AGUI 基址。
+ */
+export function getMemoryBaseUrl(): string {
+  return resolveFromEnvChain([
+    "MEMORY_BASE_URL",
+    "AGUI_BASE_URL",
+    "NEXT_PUBLIC_AGUI_BASE_URL",
+  ]);
+}
+
+/**
+ * 测试专用：清空告警去重缓存。
+ * 生产代码请勿调用。
+ */
+export function __resetLegacyPortWarningsForTests(): void {
+  warnedUrls.clear();
+}

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -54,22 +54,76 @@ describe("POST /api/agui", () => {
     vi.restoreAllMocks();
   });
 
-  it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
+  it("未显式配置 AGUI_BASE_URL 时应回落到默认端口 :3292", async () => {
     delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
 
-    const request = createMockRequest("http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=test", {
-      method: "POST",
-      body: JSON.stringify({
-        messages: [{ role: "user", content: "test" }],
-      }),
-    });
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=00000000-0000-0000-0000-000000000001",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "ping" }],
+        }),
+      },
+    );
 
     const response = await POST(request);
-    const data = await response.json();
+    // 读尽 body 确保 stream 完成，避免测试运行时未处理的 pending promise
+    await response.text();
 
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
-    expect(data.error.message).toContain("AGUI_BASE_URL is not configured");
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl).toBe("http://localhost:3292/run_sse");
+  });
+
+  it("AGUI_BASE_URL 为空字符串也应回落到默认端口 :3292", async () => {
+    process.env.AGUI_BASE_URL = "";
+
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=00000000-0000-0000-0000-000000000001",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "ping" }],
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    await response.text();
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl).toBe("http://localhost:3292/run_sse");
   });
 
   it("应该返回错误当 JSON 无效", async () => {
@@ -482,16 +536,25 @@ describe("GET /api/agui/sessions/list", () => {
     vi.restoreAllMocks();
   });
 
-  it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
+  it("未显式配置 AGUI_BASE_URL 时应回落到默认端口 :3292", async () => {
     delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
 
-    const request = createMockRequest("http://localhost:3000/api/agui/sessions/list?app_name=negentropy&user_id=test");
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([]),
+    } as Response);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui/sessions/list?app_name=negentropy&user_id=test",
+    );
 
     const response = await GET(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl.startsWith("http://localhost:3292/")).toBe(true);
   });
 
   it("应该返回错误当缺少 app_name", async () => {
@@ -632,8 +695,21 @@ describe("POST /api/agui/sessions", () => {
     delete process.env.NEXT_PUBLIC_AGUI_USER_ID;
   });
 
-  it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
+  it("未显式配置 AGUI_BASE_URL 时应回落到默认端口 :3292", async () => {
     delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          id: "s-new",
+          lastUpdateTime: 1,
+          state: { metadata: {} },
+          events: [],
+        }),
+    } as Response);
 
     const request = createMockRequest("http://localhost:3000/api/agui/sessions", {
       method: "POST",
@@ -644,10 +720,10 @@ describe("POST /api/agui/sessions", () => {
     });
 
     const response = await createSession(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl.startsWith("http://localhost:3292/")).toBe(true);
   });
 
   it("应该返回错误当 JSON 无效", async () => {

--- a/apps/negentropy-ui/tests/integration/knowledge-stats-route.test.ts
+++ b/apps/negentropy-ui/tests/integration/knowledge-stats-route.test.ts
@@ -10,7 +10,34 @@ describe("GET /api/knowledge/stats", () => {
     delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
   });
 
-  it("未配置后端地址时返回全零统计", async () => {
+  it("未显式配置后端地址时应回落到默认端口 :3292", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        total_calls: 1,
+        success_count: 1,
+        failed_count: 0,
+        avg_latency_ms: 10,
+      }),
+    } as Response);
+
+    const response = await GET(new NextRequest("http://localhost:3000/api/knowledge/stats"));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(calledUrl.startsWith("http://localhost:3292/knowledge/stats")).toBe(true);
+    expect(await response.json()).toEqual({
+      total_calls: 1,
+      success_count: 1,
+      failed_count: 0,
+      avg_latency_ms: 10,
+    });
+  });
+
+  it("后端不可达时 catch 分支仍降级返回全零统计", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
     const response = await GET(new NextRequest("http://localhost:3000/api/knowledge/stats"));
 
     expect(await response.json()).toEqual({
@@ -19,6 +46,7 @@ describe("GET /api/knowledge/stats", () => {
       failed_count: 0,
       avg_latency_ms: 0,
     });
+    errorSpy.mockRestore();
   });
 
   it("会透传 endpoint 参数到后端", async () => {

--- a/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
@@ -34,15 +34,8 @@ describe("session request helpers", () => {
     expect(getSessionAguiBaseUrl()).toBe("http://public-agui");
   });
 
-  it("在 base url 缺失时返回结构化内部错误", async () => {
-    const result = getSessionAguiBaseUrl();
-
-    expect(result).toBeInstanceOf(Response);
-    const response = result as Response;
-    const data = await response.json();
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
-    expect(data.error.message).toContain("AGUI_BASE_URL is not configured");
+  it("在所有 base url env 均缺失时回落到默认端口 :3292", () => {
+    expect(getSessionAguiBaseUrl()).toBe("http://localhost:3292");
   });
 
   it("json-read header 应透传鉴权并补齐 Accept", () => {

--- a/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
+++ b/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_BACKEND_BASE_URL,
+  LEGACY_LOCAL_PORTS,
+  __resetLegacyPortWarningsForTests,
+  getAguiBaseUrl,
+  getAuthBaseUrl,
+  getKnowledgeBaseUrl,
+  getMemoryBaseUrl,
+} from "@/lib/server/backend-url";
+
+const BACKEND_URL_ENV_VARS = [
+  "AGUI_BASE_URL",
+  "NEXT_PUBLIC_AGUI_BASE_URL",
+  "AUTH_BASE_URL",
+  "KNOWLEDGE_BASE_URL",
+  "MEMORY_BASE_URL",
+];
+
+function clearBackendEnv(): void {
+  for (const name of BACKEND_URL_ENV_VARS) {
+    delete process.env[name];
+  }
+}
+
+describe("backend-url SSOT helper", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clearBackendEnv();
+    __resetLegacyPortWarningsForTests();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    clearBackendEnv();
+    process.env.NODE_ENV = originalNodeEnv;
+    __resetLegacyPortWarningsForTests();
+  });
+
+  describe("默认值", () => {
+    it("无任何 env 时应返回默认端口 :3292", () => {
+      expect(getAguiBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+      expect(getAuthBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+      expect(getKnowledgeBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+      expect(getMemoryBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+    });
+
+    it("env 仅包含空白字符时视作未配置并回落默认值", () => {
+      process.env.AGUI_BASE_URL = "   ";
+      expect(getAguiBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+    });
+
+    it("LEGACY_LOCAL_PORTS 应包含历史使用过的 6600 与 6666", () => {
+      expect(LEGACY_LOCAL_PORTS).toEqual(expect.arrayContaining(["6600", "6666"]));
+    });
+  });
+
+  describe("优先级链", () => {
+    it("AUTH_BASE_URL > AGUI_BASE_URL > NEXT_PUBLIC_AGUI_BASE_URL", () => {
+      process.env.AUTH_BASE_URL = "http://auth-internal:3292";
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://agui-public:3292";
+
+      expect(getAuthBaseUrl()).toBe("http://auth-internal:3292");
+    });
+
+    it("AGUI_BASE_URL 缺失时 auth 链应回落到 NEXT_PUBLIC_AGUI_BASE_URL", () => {
+      process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://agui-public:3292";
+      expect(getAuthBaseUrl()).toBe("http://agui-public:3292");
+    });
+
+    it("AGUI_BASE_URL 应优先于 NEXT_PUBLIC_AGUI_BASE_URL", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://agui-public:3292";
+
+      expect(getAguiBaseUrl()).toBe("http://agui-internal:3292");
+    });
+
+    it("KNOWLEDGE_BASE_URL 应覆盖 AGUI 链", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.KNOWLEDGE_BASE_URL = "http://knowledge:9001";
+
+      expect(getKnowledgeBaseUrl()).toBe("http://knowledge:9001");
+      expect(getAguiBaseUrl()).toBe("http://agui-internal:3292");
+    });
+
+    it("MEMORY_BASE_URL 应覆盖 AGUI 链", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.MEMORY_BASE_URL = "http://memory:9002";
+
+      expect(getMemoryBaseUrl()).toBe("http://memory:9002");
+      expect(getAguiBaseUrl()).toBe("http://agui-internal:3292");
+    });
+
+    it("KNOWLEDGE / MEMORY 未配置时应回落至 AGUI 链", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      expect(getKnowledgeBaseUrl()).toBe("http://agui-internal:3292");
+      expect(getMemoryBaseUrl()).toBe("http://agui-internal:3292");
+    });
+  });
+
+  describe("非 localhost URL 不受迁移守护影响", () => {
+    it("自定义 host + 旧端口不应被改写、不应告警", () => {
+      process.env.AGUI_BASE_URL = "http://backend.example.com:6600";
+      expect(getAguiBaseUrl()).toBe("http://backend.example.com:6600");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("localhost 但端口不在 LEGACY 列表时不应被改写", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:8080";
+      expect(getAguiBaseUrl()).toBe("http://localhost:8080");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("legacy port 迁移守护（开发模式）", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    it("localhost:6600 应被重写为 :3292 并打印一次迁移告警", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      const resolved = getAguiBaseUrl();
+
+      expect(resolved).toBe("http://localhost:3292");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("AGUI_BASE_URL=http://localhost:6600");
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(":6600");
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(":3292");
+    });
+
+    it("127.0.0.1:6666 也应被识别为 legacy 并重写", () => {
+      process.env.AGUI_BASE_URL = "http://127.0.0.1:6666";
+
+      expect(getAguiBaseUrl()).toBe("http://127.0.0.1:3292");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("同一 URL 重复调用只告警一次（去重）", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      getAguiBaseUrl();
+      getAguiBaseUrl();
+      getAguiBaseUrl();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("不同 source label 各自独立告警", () => {
+      process.env.AUTH_BASE_URL = "http://localhost:6600";
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      getAuthBaseUrl();
+      getAguiBaseUrl();
+
+      // AUTH_BASE_URL + AGUI_BASE_URL 两个来源 × 同一 URL => 两次告警
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("legacy port 迁移守护（生产模式）", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "production";
+    });
+
+    it("localhost:6600 在生产环境仅告警、不改写", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      const resolved = getAguiBaseUrl();
+
+      expect(resolved).toBe("http://localhost:6600");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/docs/development.md
+++ b/docs/development.md
@@ -423,7 +423,7 @@ thread_id: Mapped[UUID] = mapped_column(
 
 | 变量                        | 作用域 | 说明                                       |
 | :-------------------------- | :----- | :----------------------------------------- |
-| `AGUI_BASE_URL`             | 服务端 | ADK 后端地址（如 `http://localhost:8000`） |
+| `AGUI_BASE_URL`             | 服务端 | 后端地址（默认 `http://localhost:3292`）   |
 | `NEXT_PUBLIC_AGUI_APP_NAME` | 客户端 | 应用名称标识                               |
 | `NEXT_PUBLIC_AGUI_USER_ID`  | 客户端 | 用户标识                                   |
 
@@ -479,12 +479,14 @@ export GEMINI_API_KEY=...
 
 ```bash
 # 服务端（仅 Route Handler 可用）
-AGUI_BASE_URL=http://localhost:8000
+AGUI_BASE_URL=http://localhost:3292
 
 # 客户端（浏览器可见）
 NEXT_PUBLIC_AGUI_APP_NAME=negentropy
 NEXT_PUBLIC_AGUI_USER_ID=dev-user
 ```
+
+> **迁移守护**：若 `AGUI_BASE_URL` 指向历史本地端口（如 `:6600` / `:6666`）且 `NODE_ENV !== "production"`，BFF 会打印一次性迁移告警并将端口重写为 `:3292`；生产环境仅告警、不改写，以便运维显式修复。详见 `apps/negentropy-ui/lib/server/backend-url.ts`。
 
 ### 8.4 安全约束
 


### PR DESCRIPTION
## 背景与根因

Commit `1215a5c` 已将后端默认端口从 `:6600` 迁至 `:3292`，UI 从 `:3333` 迁至 `:3192`。但 Google 登录仍跳转到 `http://localhost:6600/auth/google/login?redirect=...`，直接导致登录失败。

- **直接原因**：Next.js BFF 登录路由 `apps/negentropy-ui/app/api/auth/login/route.ts` 通过 `getAuthBaseUrl()` 读取 `AUTH_BASE_URL → AGUI_BASE_URL → NEXT_PUBLIC_AGUI_BASE_URL` 三级环境变量，**无默认值、无迁移守护**；
- **关键触发**：开发机 `.env.local` 残留 `AGUI_BASE_URL=http://localhost:6600`，环境变量优先级高于新端口，BFF 就按旧值拼出跳转 URL；
- **次生问题**：全仓共 13 处 BFF 代理/路由文件各自内联 `process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL`，存在明显 DRY 违例，未来任意端口迁移都会重演本次事故。

## 设计要点（SSOT + 迁移守护）

严格贯彻 AGENTS.md 中「Single Source of Truth」「Evolutionary Design」「Second-Order Thinking」原则：

1. **新增 `apps/negentropy-ui/lib/server/backend-url.ts`**：单一事实源，导出 `DEFAULT_BACKEND_BASE_URL = \"http://localhost:3292\"`、`LEGACY_LOCAL_PORTS = [\"6600\", \"6666\"]`，以及 `getAguiBaseUrl` / `getAuthBaseUrl` / `getKnowledgeBaseUrl` / `getMemoryBaseUrl` 四个 getter；
2. **迁移守护 `applyLegacyPortMigration`**：若 host 为 `localhost` / `127.0.0.1` 且端口属于 `LEGACY_LOCAL_PORTS`：
   - **开发模式**（`NODE_ENV !== \"production\"`）：自动改写端口为 `3292` 并打印一次性 `console.warn`，按 `sourceLabel::url` 去重；
   - **生产模式**：**仅告警、不改写**，避免静默掩盖 prod 误配；
3. **改造 8 个 BFF 文件**消费 SSOT：`auth/_config.ts`、`agui/route.ts`、`agui/sessions/_request.ts`、`knowledge/_proxy.ts`、`knowledge/stats/route.ts`、`memory/_proxy.ts`、`plugins/_proxy.ts`、`plugins/stats/route.ts`；
4. **恢复 `apps/negentropy-ui/.env.example`**（默认 `:3292`）并在 `.gitignore` 中新增白名单 `!.env.example`，支持新环境一键 `cp`；
5. **同步文档**：`docs/development.md` §8.3 历史残留 `localhost:8000` 修正为 `localhost:3292`，并补充迁移守护说明。

### 二阶影响分析

| 场景 | 行为 |
| :--- | :--- |
| 正常配置 `AGUI_BASE_URL=http://localhost:3292` | 完全不变 |
| 指向非 localhost 的生产后端（如 `http://backend.example.com:9000`） | 完全不变，不改写、不告警 |
| 生产误配成 `:6600` | **仅告警、不静默改写**，由运维显式修复 |
| 开发机 `.env.local` 残留 `:6600` | 自动改写为 `:3292` + server log 清晰提示 → 登录直接通 |
| 未来再迁移端口 | 仅需在 `LEGACY_LOCAL_PORTS` 中追加旧端口即可 → 闭环演进 |

## 测试与门禁

本地已通过（在 `apps/negentropy-ui/` 下执行）：

- \`pnpm lint\` ✅
- \`pnpm typecheck\` ✅
- \`pnpm test\` ✅（66 test files，397 tests 全绿）

### 新增 / 调整用例

- **新增** `tests/unit/lib/server/backend-url.test.ts`（16 项单测）：默认回落、env 优先级链、非 localhost 不受影响、legacy 端口在 dev 下重写并告警、生产模式仅告警、同一 URL 去重；
- **调整** 三处原本期望「env 缺失返回 500」的集成 / 单元用例，改为断言回落到默认 `:3292` 并增加「空字符串 env 也回落」的冗余断言：
  - `tests/integration/api.test.ts`
  - `tests/integration/knowledge-stats-route.test.ts`
  - `tests/unit/api/agui-session-request.test.ts`

## 端到端验证（建议复现）

1. **场景 A**：空 `.env.local` → 点击 Google 登录 → 期望 302 至 `http://localhost:3292/...`，server log 无迁移告警；
2. **场景 B**：`AGUI_BASE_URL=http://localhost:6600`（复刻故障）→ 302 至 `http://localhost:3292/...`，server log 打印一次迁移告警；
3. **场景 C**：`AGUI_BASE_URL=http://backend.example.com:9000` → 302 至 `http://backend.example.com:9000/...`，不告警、不改写。

## 变更清单

**新增**
- \`apps/negentropy-ui/lib/server/backend-url.ts\`
- \`apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts\`
- \`apps/negentropy-ui/.env.example\`

**修改**
- \`.gitignore\`（白名单 `.env.example`）
- \`apps/negentropy-ui/app/api/auth/_config.ts\`
- \`apps/negentropy-ui/app/api/agui/route.ts\`
- \`apps/negentropy-ui/app/api/agui/sessions/_request.ts\`
- \`apps/negentropy-ui/app/api/knowledge/_proxy.ts\`
- \`apps/negentropy-ui/app/api/knowledge/stats/route.ts\`
- \`apps/negentropy-ui/app/api/memory/_proxy.ts\`
- \`apps/negentropy-ui/app/api/plugins/_proxy.ts\`
- \`apps/negentropy-ui/app/api/plugins/stats/route.ts\`
- \`apps/negentropy-ui/tests/integration/api.test.ts\`
- \`apps/negentropy-ui/tests/integration/knowledge-stats-route.test.ts\`
- \`apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts\`
- \`docs/development.md\`（§8.3）

## Test plan

- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\`（397 tests passed）
- [ ] 端到端验证场景 A / B / C（参见上文）

🤖 Generated with [Claude Code](https://claude.com/claude-code)