### PR TITLE
fix(ui-test): 用 vi.stubEnv 修复 NODE_ENV readonly 触发的 UI Type Checks 失败

### DIFF
--- a/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
+++ b/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
@@ -25,7 +25,6 @@ function clearBackendEnv(): void {
 }
 
 describe("backend-url SSOT helper", () => {
-  const originalNodeEnv = process.env.NODE_ENV;
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -37,7 +36,7 @@ describe("backend-url SSOT helper", () => {
   afterEach(() => {
     warnSpy.mockRestore();
     clearBackendEnv();
-    process.env.NODE_ENV = originalNodeEnv;
+    vi.unstubAllEnvs();
     __resetLegacyPortWarningsForTests();
   });
 
@@ -119,7 +118,7 @@ describe("backend-url SSOT helper", () => {
 
   describe("legacy port 迁移守护（开发模式）", () => {
     beforeEach(() => {
-      process.env.NODE_ENV = "development";
+      vi.stubEnv("NODE_ENV", "development");
     });
 
     it("localhost:6600 应被重写为 :3292 并打印一次迁移告警", () => {
@@ -165,7 +164,7 @@ describe("backend-url SSOT helper", () => {
 
   describe("legacy port 迁移守护（生产模式）", () => {
     beforeEach(() => {
-      process.env.NODE_ENV = "production";
+      vi.stubEnv("NODE_ENV", "production");
     });
 
     it("localhost:6600 在生产环境仅告警、不改写", () => {


### PR DESCRIPTION
## 问题概述

GitHub Actions [Run #24623901894](https://github.com/ThreeFish-AI/negentropy/actions/runs/24623901894) 的 `UI Test Suite` → `ui-quality / UI Type Checks` → **Typecheck tests** 步骤以退出码 2 失败，下游 `UI Playwright Smoke` 因 `needs` 依赖被跳过。

失败信息：

\`\`\`
tests/unit/lib/server/backend-url.test.ts(40,17): error TS2540: Cannot assign to 'NODE_ENV' because it is a read-only property.
tests/unit/lib/server/backend-url.test.ts(122,19): error TS2540: Cannot assign to 'NODE_ENV' because it is a read-only property.
tests/unit/lib/server/backend-url.test.ts(168,19): error TS2540: Cannot assign to 'NODE_ENV' because it is a read-only property.
Process completed with exit code 2.
\`\`\`

## 根因分析

| 要素 | 详情 |
| --- | --- |
| 触发 PR | #365（引入 \`lib/server/backend-url.ts\` SSOT 与单测） |
| 类型源 | \`@types/node@20.19.35\` 将 \`NodeJS.ProcessEnv[\"NODE_ENV\"]\` 标记为 readonly（与 Node.js 运行时语义对齐） |
| 测试源 | \`tests/unit/lib/server/backend-url.test.ts\` 第 40 / 122 / 168 行对 \`process.env.NODE_ENV\` 直接赋值 |
| 检测路径 | \`pnpm typecheck\` 因 \`tsconfig.json\` 已排除 \`tests/**\` 放行；仅 \`pnpm typecheck:test\`（\`tsconfig.vitest.json\`，\`strict: true\`）捕获违规 |
| 运行时 | 单测运行时通过，纯属 TypeScript 类型层回归 |

为何 PR #365 带伤合入：CI 标红但 \`UI Type Checks\` 未被配置为 required status check（属 CI 治理问题，不在本 PR 范围）。

## 解决方案

采用 Vitest 官方环境变量替身 **\`vi.stubEnv\` / \`vi.unstubAllEnvs\`** 替换直接赋值（参考 [Vitest Vi API — stubEnv](https://vitest.dev/api/vi.html#vi-stubenv)）：

- **类型安全**：\`vi.stubEnv(name: string, value: string)\` 绕过 \`ProcessEnv.NODE_ENV\` readonly 约束。
- **自动回滚**：\`vi.unstubAllEnvs()\` 统一恢复，移除手工维护的 \`originalNodeEnv\` 变量。
- **运行时等价**：Vitest 同步更新 \`process.env\` 与内部快照，业务分支判定 \`process.env.NODE_ENV === \"production\"\` 行为保持不变。
- **最小干预**：仅改动 1 个测试文件，3 行替换 + 1 行状态变量删除 + 1 行 \`unstubAllEnvs\`，不触碰业务实现与 tsconfig。

被否备选：\`process.env[\"NODE_ENV\"] = ...\` 方括号写法（跨 TS 版本不稳）、\`as any\` / \`@ts-expect-error\`（引入类型逃逸）、放宽 \`tsconfig.vitest.json\` 的 \`strict\`（爆炸半径过大）。

## 本地验证

在 \`apps/negentropy-ui\` 下全部通过：

| 命令 | 结果 |
| --- | --- |
| \`pnpm typecheck:test\` | ✅ 0 错误（此前 3 条 TS2540） |
| \`pnpm typecheck\` | ✅ |
| \`pnpm test\` | ✅ 66 test files / 397 tests 全绿 |
| \`pnpm lint\` | ✅ |

## 验收标准

合并后对应流水线预期状态：

- ✅ \`UI Type Checks / Typecheck tests\`：❌ → ✅
- ✅ \`UI Playwright Smoke\`：skipped → ✅
- ✅ \`UI Lint / Typecheck app / Unit+Integration / Build Smoke\`：保持 ✅
- ✅ \`Backend Test Suite\`：不受影响

## 额外观察（非本 PR 范围）

1. **Node.js 20 actions 弃用**：\`actions/checkout@v4\`、\`pnpm/action-setup@v4\`、\`actions/setup-node@v4\`、\`actions/upload-artifact@v4\` 在 2026-06-02 起默认切换到 Node.js 24、2026-09-16 移除 Node 20。当前仅为 warning，不是本次失败原因；遵循「最小干预」，不顺手升级，留待独立 CI 治理 PR。
2. **分支保护规则**：建议后续将 \`UI Type Checks\` 纳入 required status checks，避免类似 CI 红灯被合入的情况再次发生。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)