### PR TITLE
fix(admin/models): 统一 Ping 路径参数构造修复自定义 base_url 下 404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 .env*
+!.env.example
 .vercel
 *.tsbuildinfo
 next-env.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Fixed
 
+- 修复 Admin → Models 对 OpenAI 兼容代理 `base_url`（如 `http://llms.as-in.io/v1`）下 `gpt-5-mini` 等新一代模型 Ping 返回 `404 NotFound` 的问题，并一并收敛 Anthropic / Gemini 的同类风险：
+  - `auth.api._ping_llm` 原本手写最小 kwargs（`max_tokens=20 + api_key + api_base`），绕过业务主链路的 `_build_llm_kwargs` / `_DEFAULT_LLM_KWARGS` 合并策略，缺失 `drop_params=True`，导致 LiteLLM 无法将 `max_tokens` 自动映射为 gpt-5 / o-系要求的 `max_completion_tokens`，代理兜底以 `{'meta':{'code':404}, 'data':{}}` 返回 404；
+  - 新增 `config.model_resolver.build_ping_llm_kwargs(vendor, model_name, ...)`：内部复用 `_build_llm_kwargs` 以继承 vendor 专属适配（Anthropic `thinking={"type":"disabled"}`、OpenAI o 系列 `reasoning_effort`），并强制 `drop_params=True`，但故意不注入 `_DEFAULT_LLM_KWARGS["temperature"]`（gpt-5 仅接受 `temperature=1`，Ping 阶段不应耦合模型版本）；
+  - 新增 `config.model_resolver.normalize_api_base(...)`：防御性剥离用户误贴的 `/chat/completions`、`/v1/messages`、`/completions` 后缀及尾部多余 `/`，幂等且对合法 `https://host/v1` 配置零影响；
+  - `auth.api.ping_model` / `_ping_llm` 重构为复用上述入口，异常路径新增结构化日志（vendor / full_model_name / 归一化 api_base / latency / 脱敏 error）；
+  - 新增单元测试 `tests/unit_tests/config/test_model_resolver_ping.py`（17 用例）与端点测试 `tests/unit_tests/auth/test_admin_models_ping.py`（9 用例），覆盖三家 vendor kwargs 透传、DB vendor_configs 回退、api_base 规范化、401 / 404 / timeout 中文文案分类、非 admin 403 拦截。
 - 修复 `adk web` 启动时 `MemoryAutomationFunctionResponse` 触发的 Pydantic `UserWarning: Field name "schema" in "MemoryAutomationFunctionResponse" shadows an attribute in parent "BaseModel"`：将 Python 属性名改为 `schema_name`，通过 `Field(alias="schema", serialization_alias="schema")` + `model_config = ConfigDict(populate_by_name=True)` 保持线协议（wire format）键名 `"schema"` 不变，前端 TS 类型与后端 SQL 数据零改动。
 - 补齐 `opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0` 依赖，消除 ADK `adk_web_server` 启动期 `Unable to import GoogleGenAiSdkInstrumentor` WARNING，恢复 Google GenAI SDK 的 OTel 自动埋点，与现有 Langfuse OTel 链路打通。
 - 站点级安静化两类先于 `negentropy.bootstrap` 触发的上游启动噪声（`AuthlibDeprecationWarning: authlib.jose module is deprecated` 与 `[EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH is enabled`）：通过 `apps/negentropy/src/_negentropy_silence.pth`（hatchling `force-include` 至 site-packages 根）+ `negentropy/_silence_upstream_warnings.py` 在解释器 site 初始化期替换 `warnings.showwarning`，按消息子串白名单丢弃噪声；不影响任何其他告警通道，对 `authlib.deprecate` 的 `simplefilter("always", AuthlibDeprecationWarning)` 免疫（在 filter 之后的 showwarning 层拦截）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复 `adk web` 启动时 `MemoryAutomationFunctionResponse` 触发的 Pydantic `UserWarning: Field name "schema" in "MemoryAutomationFunctionResponse" shadows an attribute in parent "BaseModel"`：将 Python 属性名改为 `schema_name`，通过 `Field(alias="schema", serialization_alias="schema")` + `model_config = ConfigDict(populate_by_name=True)` 保持线协议（wire format）键名 `"schema"` 不变，前端 TS 类型与后端 SQL 数据零改动。
+- 补齐 `opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0` 依赖，消除 ADK `adk_web_server` 启动期 `Unable to import GoogleGenAiSdkInstrumentor` WARNING，恢复 Google GenAI SDK 的 OTel 自动埋点，与现有 Langfuse OTel 链路打通。
+- 站点级安静化两类先于 `negentropy.bootstrap` 触发的上游启动噪声（`AuthlibDeprecationWarning: authlib.jose module is deprecated` 与 `[EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH is enabled`）：通过 `apps/negentropy/src/_negentropy_silence.pth`（hatchling `force-include` 至 site-packages 根）+ `negentropy/_silence_upstream_warnings.py` 在解释器 site 初始化期替换 `warnings.showwarning`，按消息子串白名单丢弃噪声；不影响任何其他告警通道，对 `authlib.deprecate` 的 `simplefilter("always", AuthlibDeprecationWarning)` 免疫（在 filter 之后的 showwarning 层拦截）。
+
 ### Removed
 
 - 删除 `apps/negentropy/.env.example`（197 行）：其承载的全部非密钥配置项已在 `config.default.yaml` 中以结构化 YAML 形式表达，密钥类条目改为通过 shell 环境变量或 `.env.local` 提供。

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ uv run adk web --port 8000 --reload_agents src/negentropy  # Start the engine
 ```bash
 cd apps/negentropy-ui
 pnpm install                   # Install dependencies
-pnpm run dev                   # Start development server (localhost:3333)
+pnpm run dev                   # Start development server (localhost:3192)
 ```
 
 ### 4. Set Up Pre-commit Hooks (Recommended)
@@ -139,7 +139,7 @@ pre-commit install
 
 ### 5. Initiate Dialogue
 
-Fire up your browser, head over to `http://localhost:3333`, and start conversing with the NegentropyEngine.
+Fire up your browser, head over to `http://localhost:3192`, and start conversing with the NegentropyEngine.
 
 > For comprehensive guides on environment setup, database migrations, frontend-backend integration, and troubleshooting, please refer to [docs/development.md](./docs/development.md).
 

--- a/apps/negentropy-ui/.env.example
+++ b/apps/negentropy-ui/.env.example
@@ -1,0 +1,26 @@
+# Negentropy UI 本地环境变量模板
+#
+# 使用方式：复制为 .env.local 后按需覆写。
+# 服务端变量仅在 Next.js Route Handler (app/api/**) 中可见，
+# 不会被打包进客户端 bundle；带 NEXT_PUBLIC_ 前缀的变量对浏览器可见。
+#
+# 若全部留空，BFF 会自动回落到 http://localhost:3292（与后端默认端口对齐）。
+# 若检测到历史端口（如 :6600 / :6666）且 NODE_ENV !== "production"，
+# BFF 会在 server log 打印一次迁移告警，并将端口改写为 :3292。
+
+# ---------- 服务端（Route Handler 可见） ----------
+# AGUI / 通用数据面后端基址
+AGUI_BASE_URL=http://localhost:3292
+
+# 认证面：若 auth 走独立后端可单独覆盖；否则复用 AGUI_BASE_URL
+# AUTH_BASE_URL=http://localhost:3292
+
+# Knowledge 领域：支持独立部署
+# KNOWLEDGE_BASE_URL=http://localhost:3292
+
+# Memory 领域：支持独立部署
+# MEMORY_BASE_URL=http://localhost:3292
+
+# ---------- 客户端（浏览器可见） ----------
+NEXT_PUBLIC_AGUI_APP_NAME=negentropy
+NEXT_PUBLIC_AGUI_USER_ID=dev-user

--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -17,10 +17,7 @@ import {
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
 import { normalizeAguiEvent, resolveEventRunAndThread } from "@/utils/agui-normalization";
-
-function getBaseUrl() {
-  return process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-}
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);
@@ -75,13 +72,7 @@ function normalizeEvent(
 }
 
 export async function POST(request: Request) {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured",
-    );
-  }
+  const baseUrl = getAguiBaseUrl();
 
   let body: Record<string, unknown>;
   try {

--- a/apps/negentropy-ui/app/api/agui/sessions/_request.ts
+++ b/apps/negentropy-ui/app/api/agui/sessions/_request.ts
@@ -3,17 +3,15 @@ import {
   errorResponse as aguiErrorResponse,
   AGUI_ERROR_CODES,
 } from "@/lib/errors";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
+/**
+ * 返回类型保持 `string | Response` 以维持既有路由的接入形态。
+ * 在 SSOT helper 引入默认值之后，Response 分支实际不可达，
+ * 但保留该契约作为 defense-in-depth，避免批量修改调用方。
+ */
 export function getSessionAguiBaseUrl(): string | Response {
-  const baseUrl = process.env.AGUI_BASE_URL || process.env.NEXT_PUBLIC_AGUI_BASE_URL;
-  if (!baseUrl) {
-    return aguiErrorResponse(
-      AGUI_ERROR_CODES.INTERNAL_ERROR,
-      "AGUI_BASE_URL is not configured",
-    );
-  }
-
-  return baseUrl;
+  return getAguiBaseUrl();
 }
 
 export function buildSessionUpstreamHeaders(

--- a/apps/negentropy-ui/app/api/auth/_config.ts
+++ b/apps/negentropy-ui/app/api/auth/_config.ts
@@ -1,7 +1,1 @@
-export function getAuthBaseUrl() {
-  return (
-    process.env.AUTH_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+export { getAuthBaseUrl } from "@/lib/server/backend-url";

--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getKnowledgeBaseUrl } from "@/lib/server/backend-url";
 
-function getBaseUrl() {
-  return (
-    process.env.KNOWLEDGE_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getKnowledgeBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/app/api/knowledge/stats/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/stats/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getKnowledgeBaseUrl } from "@/lib/server/backend-url";
 
 /**
  * Knowledge API 统计端点
@@ -14,31 +15,12 @@ interface ApiStatsResponse {
   avg_latency_ms: number;
 }
 
-function getBaseUrl() {
-  return (
-    process.env.KNOWLEDGE_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
-
 export async function GET(request: NextRequest) {
-  const baseUrl = getBaseUrl();
+  const baseUrl = getKnowledgeBaseUrl();
 
   // 从查询参数获取 endpoint
   const { searchParams } = request.nextUrl;
   const endpoint = searchParams.get("endpoint");
-
-  // 如果没有配置后端 URL，返回默认值
-  if (!baseUrl) {
-    const defaultStats: ApiStatsResponse = {
-      total_calls: 0,
-      success_count: 0,
-      failed_count: 0,
-      avg_latency_ms: 0,
-    };
-    return NextResponse.json(defaultStats);
-  }
 
   try {
     // 构建后端 URL，传递 endpoint 参数

--- a/apps/negentropy-ui/app/api/memory/_proxy.ts
+++ b/apps/negentropy-ui/app/api/memory/_proxy.ts
@@ -1,13 +1,8 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getMemoryBaseUrl } from "@/lib/server/backend-url";
 
-function getBaseUrl() {
-  return (
-    process.env.MEMORY_BASE_URL ||
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getMemoryBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/app/api/plugins/_proxy.ts
+++ b/apps/negentropy-ui/app/api/plugins/_proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
 /**
  * Plugins API 代理工具函数
@@ -7,12 +8,7 @@ import { buildAuthHeaders } from "@/lib/sso";
  * 用于将前端的 /api/plugins/* 请求代理到后端 /plugins/* API
  */
 
-function getBaseUrl() {
-  return (
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getAguiBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/app/api/plugins/stats/route.ts
+++ b/apps/negentropy-ui/app/api/plugins/stats/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildAuthHeaders } from "@/lib/sso";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
 /**
  * Plugins Stats API 代理端点
@@ -13,12 +14,7 @@ interface PluginStatsResponse {
   subagents: { total: number; enabled: number };
 }
 
-function getBaseUrl() {
-  return (
-    process.env.AGUI_BASE_URL ||
-    process.env.NEXT_PUBLIC_AGUI_BASE_URL
-  );
-}
+const getBaseUrl = getAguiBaseUrl;
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);

--- a/apps/negentropy-ui/features/knowledge/utils/api-specs.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/api-specs.ts
@@ -104,7 +104,7 @@ export interface ApiEndpoint {
   interactiveForm?: InteractiveFormConfig;
 }
 
-const BASE_URL = "http://localhost:6600";
+const BASE_URL = "http://localhost:3292";
 const DEFAULT_CHUNKING_CONFIG = createDefaultChunkingConfig("recursive");
 const DEFAULT_CHUNKING_CONFIG_DESCRIPTION =
   "canonical chunking 配置，按 strategy 判别。支持 fixed / recursive / semantic / hierarchical。";

--- a/apps/negentropy-ui/lib/server/backend-url.ts
+++ b/apps/negentropy-ui/lib/server/backend-url.ts
@@ -1,0 +1,151 @@
+/**
+ * Negentropy BFF 后端基址单一事实源（SSOT）。
+ *
+ * 所有 Next.js Route Handler 统一通过 getAguiBaseUrl / getAuthBaseUrl /
+ * getKnowledgeBaseUrl / getMemoryBaseUrl 解析后端服务地址，避免多处文件
+ * 各自读取 process.env 造成漂移，并内置「遗留端口迁移守护」以保证端口
+ * 迁移后的向后兼容。
+ *
+ * 该模块仅应被 app/api/** 下的服务端代码 import，不应出现在任何
+ * "use client" 组件中，以免意外被打包进客户端 bundle。
+ */
+
+export const DEFAULT_BACKEND_BASE_URL = "http://localhost:3292";
+
+/** 曾经作为后端默认端口、但已在后续迁移中弃用的本地端口列表。 */
+export const LEGACY_LOCAL_PORTS: readonly string[] = ["6600", "6666"];
+
+/** 迁移守护仅对本地环回地址生效。 */
+const LOCAL_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "[::1]"];
+
+/** 当前后端默认监听端口（与 apps/negentropy/src/negentropy/cli.py 对齐）。 */
+const CURRENT_BACKEND_PORT = "3292";
+
+/** 同一 URL 只告警一次，避免每次 BFF 请求都打印导致日志噪音。 */
+const warnedUrls = new Set<string>();
+
+function isLegacyLocalhostUrl(raw: string): { host: string; port: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (!LOCAL_HOSTS.includes(parsed.hostname)) {
+    return null;
+  }
+  if (!parsed.port) {
+    return null;
+  }
+  if (!LEGACY_LOCAL_PORTS.includes(parsed.port)) {
+    return null;
+  }
+  return { host: parsed.hostname, port: parsed.port };
+}
+
+function applyLegacyPortMigration(raw: string, sourceLabel: string): string {
+  const legacy = isLegacyLocalhostUrl(raw);
+  if (!legacy) {
+    return raw;
+  }
+
+  const warnKey = `${sourceLabel}::${raw}`;
+  if (!warnedUrls.has(warnKey)) {
+    warnedUrls.add(warnKey);
+    console.warn(
+      `[backend-url] 检测到 ${sourceLabel}=${raw} 指向已弃用端口 :${legacy.port}；` +
+        `后端已迁移至 :${CURRENT_BACKEND_PORT}。请更新 apps/negentropy-ui/.env.local。`,
+    );
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    return raw;
+  }
+
+  const rewritten = new URL(raw);
+  rewritten.port = CURRENT_BACKEND_PORT;
+  return rewritten.toString().replace(/\/$/, "");
+}
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function pickFirstNonEmpty(
+  candidates: ReadonlyArray<[string, string | undefined]>,
+): { label: string; value: string } | null {
+  for (const [label, value] of candidates) {
+    if (value !== undefined) {
+      return { label, value };
+    }
+  }
+  return null;
+}
+
+function resolveFromEnvChain(envNames: readonly string[]): string {
+  const picked = pickFirstNonEmpty(envNames.map((name) => [name, readEnv(name)] as const));
+  if (!picked) {
+    return DEFAULT_BACKEND_BASE_URL;
+  }
+  return applyLegacyPortMigration(picked.value, picked.label);
+}
+
+/**
+ * AGUI / 通用数据面后端基址。
+ *
+ * 读取优先级：AGUI_BASE_URL → NEXT_PUBLIC_AGUI_BASE_URL → 默认值。
+ */
+export function getAguiBaseUrl(): string {
+  return resolveFromEnvChain(["AGUI_BASE_URL", "NEXT_PUBLIC_AGUI_BASE_URL"]);
+}
+
+/**
+ * 认证面后端基址。
+ *
+ * 若显式设置 AUTH_BASE_URL 则优先使用；否则回落到 AGUI / 通用数据面基址，
+ * 保证单体部署下的零配置体验。
+ */
+export function getAuthBaseUrl(): string {
+  return resolveFromEnvChain([
+    "AUTH_BASE_URL",
+    "AGUI_BASE_URL",
+    "NEXT_PUBLIC_AGUI_BASE_URL",
+  ]);
+}
+
+/**
+ * Knowledge 领域后端基址。
+ *
+ * 支持通过 KNOWLEDGE_BASE_URL 将知识库请求指向独立后端；否则复用 AGUI 基址。
+ */
+export function getKnowledgeBaseUrl(): string {
+  return resolveFromEnvChain([
+    "KNOWLEDGE_BASE_URL",
+    "AGUI_BASE_URL",
+    "NEXT_PUBLIC_AGUI_BASE_URL",
+  ]);
+}
+
+/**
+ * Memory 领域后端基址。
+ *
+ * 支持通过 MEMORY_BASE_URL 将记忆服务请求指向独立后端；否则复用 AGUI 基址。
+ */
+export function getMemoryBaseUrl(): string {
+  return resolveFromEnvChain([
+    "MEMORY_BASE_URL",
+    "AGUI_BASE_URL",
+    "NEXT_PUBLIC_AGUI_BASE_URL",
+  ]);
+}
+
+/**
+ * 测试专用：清空告警去重缓存。
+ * 生产代码请勿调用。
+ */
+export function __resetLegacyPortWarningsForTests(): void {
+  warnedUrls.clear();
+}

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack -H localhost -p 3333",
+    "dev": "next dev --webpack -H localhost -p 3192",
     "build": "next build",
     "start": "node ./scripts/start-production.mjs",
     "lint": "eslint . --max-warnings=0",

--- a/apps/negentropy-ui/scripts/start-production.mjs
+++ b/apps/negentropy-ui/scripts/start-production.mjs
@@ -77,7 +77,7 @@ function prepareStandaloneRuntime(projectRoot) {
 }
 
 /* 应用默认端口与主机名（可被外部环境变量覆盖） */
-process.env.PORT ??= "3333";
+process.env.PORT ??= "3192";
 process.env.HOSTNAME ??= "localhost";
 
 const projectRoot = process.cwd();

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -17,7 +17,7 @@ import { POST as unarchiveSession } from "@/app/api/agui/sessions/[sessionId]/un
 
 // Mock 环境变量
 const mockEnv = {
-  AGUI_BASE_URL: "http://localhost:6600",
+  AGUI_BASE_URL: "http://localhost:3292",
   NEXT_PUBLIC_AGUI_APP_NAME: "negentropy",
   NEXT_PUBLIC_AGUI_USER_ID: "test-user",
 };

--- a/apps/negentropy-ui/tests/integration/api.test.ts
+++ b/apps/negentropy-ui/tests/integration/api.test.ts
@@ -54,22 +54,76 @@ describe("POST /api/agui", () => {
     vi.restoreAllMocks();
   });
 
-  it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
+  it("未显式配置 AGUI_BASE_URL 时应回落到默认端口 :3292", async () => {
     delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
 
-    const request = createMockRequest("http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=test", {
-      method: "POST",
-      body: JSON.stringify({
-        messages: [{ role: "user", content: "test" }],
-      }),
-    });
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=00000000-0000-0000-0000-000000000001",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "ping" }],
+        }),
+      },
+    );
 
     const response = await POST(request);
-    const data = await response.json();
+    // 读尽 body 确保 stream 完成，避免测试运行时未处理的 pending promise
+    await response.text();
 
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
-    expect(data.error.message).toContain("AGUI_BASE_URL is not configured");
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl).toBe("http://localhost:3292/run_sse");
+  });
+
+  it("AGUI_BASE_URL 为空字符串也应回落到默认端口 :3292", async () => {
+    process.env.AGUI_BASE_URL = "";
+
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui?app_name=negentropy&user_id=test&session_id=00000000-0000-0000-0000-000000000001",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          messages: [{ role: "user", content: "ping" }],
+        }),
+      },
+    );
+
+    const response = await POST(request);
+    await response.text();
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl).toBe("http://localhost:3292/run_sse");
   });
 
   it("应该返回错误当 JSON 无效", async () => {
@@ -482,16 +536,25 @@ describe("GET /api/agui/sessions/list", () => {
     vi.restoreAllMocks();
   });
 
-  it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
+  it("未显式配置 AGUI_BASE_URL 时应回落到默认端口 :3292", async () => {
     delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
 
-    const request = createMockRequest("http://localhost:3000/api/agui/sessions/list?app_name=negentropy&user_id=test");
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify([]),
+    } as Response);
+
+    const request = createMockRequest(
+      "http://localhost:3000/api/agui/sessions/list?app_name=negentropy&user_id=test",
+    );
 
     const response = await GET(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl.startsWith("http://localhost:3292/")).toBe(true);
   });
 
   it("应该返回错误当缺少 app_name", async () => {
@@ -632,8 +695,21 @@ describe("POST /api/agui/sessions", () => {
     delete process.env.NEXT_PUBLIC_AGUI_USER_ID;
   });
 
-  it("应该返回错误当 AGUI_BASE_URL 未配置", async () => {
+  it("未显式配置 AGUI_BASE_URL 时应回落到默认端口 :3292", async () => {
     delete process.env.AGUI_BASE_URL;
+    delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          id: "s-new",
+          lastUpdateTime: 1,
+          state: { metadata: {} },
+          events: [],
+        }),
+    } as Response);
 
     const request = createMockRequest("http://localhost:3000/api/agui/sessions", {
       method: "POST",
@@ -644,10 +720,10 @@ describe("POST /api/agui/sessions", () => {
     });
 
     const response = await createSession(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0]?.[0] as URL).toString();
+    expect(calledUrl.startsWith("http://localhost:3292/")).toBe(true);
   });
 
   it("应该返回错误当 JSON 无效", async () => {

--- a/apps/negentropy-ui/tests/integration/knowledge-stats-route.test.ts
+++ b/apps/negentropy-ui/tests/integration/knowledge-stats-route.test.ts
@@ -10,7 +10,34 @@ describe("GET /api/knowledge/stats", () => {
     delete process.env.NEXT_PUBLIC_AGUI_BASE_URL;
   });
 
-  it("未配置后端地址时返回全零统计", async () => {
+  it("未显式配置后端地址时应回落到默认端口 :3292", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        total_calls: 1,
+        success_count: 1,
+        failed_count: 0,
+        avg_latency_ms: 10,
+      }),
+    } as Response);
+
+    const response = await GET(new NextRequest("http://localhost:3000/api/knowledge/stats"));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(calledUrl.startsWith("http://localhost:3292/knowledge/stats")).toBe(true);
+    expect(await response.json()).toEqual({
+      total_calls: 1,
+      success_count: 1,
+      failed_count: 0,
+      avg_latency_ms: 10,
+    });
+  });
+
+  it("后端不可达时 catch 分支仍降级返回全零统计", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
     const response = await GET(new NextRequest("http://localhost:3000/api/knowledge/stats"));
 
     expect(await response.json()).toEqual({
@@ -19,6 +46,7 @@ describe("GET /api/knowledge/stats", () => {
       failed_count: 0,
       avg_latency_ms: 0,
     });
+    errorSpy.mockRestore();
   });
 
   it("会透传 endpoint 参数到后端", async () => {

--- a/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-session-request.test.ts
@@ -34,15 +34,8 @@ describe("session request helpers", () => {
     expect(getSessionAguiBaseUrl()).toBe("http://public-agui");
   });
 
-  it("在 base url 缺失时返回结构化内部错误", async () => {
-    const result = getSessionAguiBaseUrl();
-
-    expect(result).toBeInstanceOf(Response);
-    const response = result as Response;
-    const data = await response.json();
-    expect(response.status).toBe(500);
-    expect(data.error.code).toBe("AGUI_INTERNAL_ERROR");
-    expect(data.error.message).toContain("AGUI_BASE_URL is not configured");
+  it("在所有 base url env 均缺失时回落到默认端口 :3292", () => {
+    expect(getSessionAguiBaseUrl()).toBe("http://localhost:3292");
   });
 
   it("json-read header 应透传鉴权并补齐 Accept", () => {

--- a/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
+++ b/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_BACKEND_BASE_URL,
+  LEGACY_LOCAL_PORTS,
+  __resetLegacyPortWarningsForTests,
+  getAguiBaseUrl,
+  getAuthBaseUrl,
+  getKnowledgeBaseUrl,
+  getMemoryBaseUrl,
+} from "@/lib/server/backend-url";
+
+const BACKEND_URL_ENV_VARS = [
+  "AGUI_BASE_URL",
+  "NEXT_PUBLIC_AGUI_BASE_URL",
+  "AUTH_BASE_URL",
+  "KNOWLEDGE_BASE_URL",
+  "MEMORY_BASE_URL",
+];
+
+function clearBackendEnv(): void {
+  for (const name of BACKEND_URL_ENV_VARS) {
+    delete process.env[name];
+  }
+}
+
+describe("backend-url SSOT helper", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    clearBackendEnv();
+    __resetLegacyPortWarningsForTests();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    clearBackendEnv();
+    process.env.NODE_ENV = originalNodeEnv;
+    __resetLegacyPortWarningsForTests();
+  });
+
+  describe("默认值", () => {
+    it("无任何 env 时应返回默认端口 :3292", () => {
+      expect(getAguiBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+      expect(getAuthBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+      expect(getKnowledgeBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+      expect(getMemoryBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+    });
+
+    it("env 仅包含空白字符时视作未配置并回落默认值", () => {
+      process.env.AGUI_BASE_URL = "   ";
+      expect(getAguiBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
+    });
+
+    it("LEGACY_LOCAL_PORTS 应包含历史使用过的 6600 与 6666", () => {
+      expect(LEGACY_LOCAL_PORTS).toEqual(expect.arrayContaining(["6600", "6666"]));
+    });
+  });
+
+  describe("优先级链", () => {
+    it("AUTH_BASE_URL > AGUI_BASE_URL > NEXT_PUBLIC_AGUI_BASE_URL", () => {
+      process.env.AUTH_BASE_URL = "http://auth-internal:3292";
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://agui-public:3292";
+
+      expect(getAuthBaseUrl()).toBe("http://auth-internal:3292");
+    });
+
+    it("AGUI_BASE_URL 缺失时 auth 链应回落到 NEXT_PUBLIC_AGUI_BASE_URL", () => {
+      process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://agui-public:3292";
+      expect(getAuthBaseUrl()).toBe("http://agui-public:3292");
+    });
+
+    it("AGUI_BASE_URL 应优先于 NEXT_PUBLIC_AGUI_BASE_URL", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.NEXT_PUBLIC_AGUI_BASE_URL = "http://agui-public:3292";
+
+      expect(getAguiBaseUrl()).toBe("http://agui-internal:3292");
+    });
+
+    it("KNOWLEDGE_BASE_URL 应覆盖 AGUI 链", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.KNOWLEDGE_BASE_URL = "http://knowledge:9001";
+
+      expect(getKnowledgeBaseUrl()).toBe("http://knowledge:9001");
+      expect(getAguiBaseUrl()).toBe("http://agui-internal:3292");
+    });
+
+    it("MEMORY_BASE_URL 应覆盖 AGUI 链", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      process.env.MEMORY_BASE_URL = "http://memory:9002";
+
+      expect(getMemoryBaseUrl()).toBe("http://memory:9002");
+      expect(getAguiBaseUrl()).toBe("http://agui-internal:3292");
+    });
+
+    it("KNOWLEDGE / MEMORY 未配置时应回落至 AGUI 链", () => {
+      process.env.AGUI_BASE_URL = "http://agui-internal:3292";
+      expect(getKnowledgeBaseUrl()).toBe("http://agui-internal:3292");
+      expect(getMemoryBaseUrl()).toBe("http://agui-internal:3292");
+    });
+  });
+
+  describe("非 localhost URL 不受迁移守护影响", () => {
+    it("自定义 host + 旧端口不应被改写、不应告警", () => {
+      process.env.AGUI_BASE_URL = "http://backend.example.com:6600";
+      expect(getAguiBaseUrl()).toBe("http://backend.example.com:6600");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("localhost 但端口不在 LEGACY 列表时不应被改写", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:8080";
+      expect(getAguiBaseUrl()).toBe("http://localhost:8080");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("legacy port 迁移守护（开发模式）", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    it("localhost:6600 应被重写为 :3292 并打印一次迁移告警", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      const resolved = getAguiBaseUrl();
+
+      expect(resolved).toBe("http://localhost:3292");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("AGUI_BASE_URL=http://localhost:6600");
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(":6600");
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(":3292");
+    });
+
+    it("127.0.0.1:6666 也应被识别为 legacy 并重写", () => {
+      process.env.AGUI_BASE_URL = "http://127.0.0.1:6666";
+
+      expect(getAguiBaseUrl()).toBe("http://127.0.0.1:3292");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("同一 URL 重复调用只告警一次（去重）", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      getAguiBaseUrl();
+      getAguiBaseUrl();
+      getAguiBaseUrl();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("不同 source label 各自独立告警", () => {
+      process.env.AUTH_BASE_URL = "http://localhost:6600";
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      getAuthBaseUrl();
+      getAguiBaseUrl();
+
+      // AUTH_BASE_URL + AGUI_BASE_URL 两个来源 × 同一 URL => 两次告警
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("legacy port 迁移守护（生产模式）", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "production";
+    });
+
+    it("localhost:6600 在生产环境仅告警、不改写", () => {
+      process.env.AGUI_BASE_URL = "http://localhost:6600";
+
+      const resolved = getAguiBaseUrl();
+
+      expect(resolved).toBe("http://localhost:6600");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -5,6 +5,11 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/negentropy"]
 
+[tool.hatch.build.targets.wheel.force-include]
+# 将 .pth 文件安装到 site-packages 根目录, 触发解释器 site 初始化期的早期 hook 加载
+# 用于在 ADK CLI 加载第三方依赖前抑制两类已知上游噪声 (authlib.jose / PLUGGABLE_AUTH)
+"src/_negentropy_silence.pth" = "_negentropy_silence.pth"
+
 [project]
 name = "negentropy"
 version = "0.1.0"
@@ -20,6 +25,7 @@ dependencies = [
     
     # Core Infrastructure
     "google-adk>=1.28.1",           # GHSA-rg7c-g689-fr3x: code injection + missing auth on adk web/api_server eval endpoints
+    "opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0",  # ADK GenAI SDK OTel 自动埋点 (消除 adk_web_server 启动期 WARNING)
     "microsandbox>=0.1.8",          # Isolated execution environment for tool usage
     "mcp>=1.6.0",                   # Model Context Protocol SDK for MCP Server integration
     "pydantic-settings[yaml]>=2.12.0",  # Configuration management with YAML support

--- a/apps/negentropy/src/_negentropy_silence.pth
+++ b/apps/negentropy/src/_negentropy_silence.pth
@@ -1,0 +1,1 @@
+import negentropy._silence_upstream_warnings

--- a/apps/negentropy/src/negentropy/_silence_upstream_warnings.py
+++ b/apps/negentropy/src/negentropy/_silence_upstream_warnings.py
@@ -1,0 +1,40 @@
+"""Site-init hook that silences two well-known upstream startup warnings.
+
+These warnings fire during ADK CLI dependency import, BEFORE
+``negentropy.bootstrap`` runs, and therefore cannot be suppressed via
+``warnings.filterwarnings`` in regular project code:
+
+1. ``authlib._joserfc_helpers`` triggers ``AuthlibDeprecationWarning`` when
+   importing the deprecated ``authlib.jose`` shim. ``authlib.deprecate`` also
+   calls ``warnings.simplefilter("always", AuthlibDeprecationWarning)`` on its
+   own import, which would defeat any ``filterwarnings`` registered earlier. We
+   therefore install a ``showwarning`` hook (which runs AFTER filter checks)
+   and drop the noise by message-content whitelist.
+2. ``google.adk.auth.*`` triggers
+   ``UserWarning("[EXPERIMENTAL] feature FeatureName.PLUGGABLE_AUTH ...")``
+   because the feature is ``default_on=True`` in google-adk 1.31.0.
+
+Loaded via ``_negentropy_silence.pth`` at site initialisation, so the hook is
+in place before any third-party import in the venv.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+_SILENCED_SUBSTRINGS = (
+    "authlib.jose module is deprecated",
+    "PLUGGABLE_AUTH",
+)
+
+_orig_showwarning = warnings.showwarning
+
+
+def _filtered_showwarning(message, category, filename, lineno, file=None, line=None):
+    msg_str = str(message)
+    if any(token in msg_str for token in _SILENCED_SUBSTRINGS):
+        return
+    _orig_showwarning(message, category, filename, lineno, file=file, line=line)
+
+
+warnings.showwarning = _filtered_showwarning

--- a/apps/negentropy/src/negentropy/auth/api.py
+++ b/apps/negentropy/src/negentropy/auth/api.py
@@ -419,16 +419,15 @@ async def ping_model(
     """发送 'Ping, give me a pong' 验证 LLM 模型连通性。
 
     凭证回退链: 表单 > vendor_configs (DB) > LiteLLM 环境变量。
+
+    kwargs 构造复用业务主链路的 `build_ping_llm_kwargs`（含 drop_params=True
+    与 vendor 专属适配），确保 Ping 与生产路径的参数语义一致。
     """
     if "admin" not in current_user.roles:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin role required")
 
     import asyncio
     import time
-
-    from negentropy.config.model_resolver import build_full_model_name
-
-    full_model_name = build_full_model_name(payload.vendor, payload.model_name)
 
     effective_api_key = payload.api_key
     effective_api_base = payload.api_base or payload.config.get("api_base")
@@ -456,7 +455,12 @@ async def ping_model(
     start_time = time.monotonic()
 
     try:
-        result = await _ping_llm(full_model_name, effective_api_key, effective_api_base)
+        result = await _ping_llm(
+            vendor=payload.vendor,
+            model_name=payload.model_name,
+            api_key=effective_api_key,
+            api_base=effective_api_base,
+        )
         latency_ms = int((time.monotonic() - start_time) * 1000)
         result["latency_ms"] = latency_ms
         return result
@@ -464,6 +468,19 @@ async def ping_model(
     except Exception as exc:
         latency_ms = int((time.monotonic() - start_time) * 1000)
         error_msg = _sanitize_error(str(exc))
+
+        from negentropy.config.model_resolver import build_full_model_name, normalize_api_base
+        from negentropy.logging import get_logger
+
+        get_logger("negentropy.auth.api").warning(
+            "ping_llm_failed",
+            vendor=payload.vendor,
+            model=build_full_model_name(payload.vendor, payload.model_name),
+            api_base=normalize_api_base(effective_api_base),
+            latency_ms=latency_ms,
+            error=error_msg,
+        )
+
         if "AuthenticationError" in error_msg or "401" in error_msg:
             message = f"认证失败：API Key 无效或已过期。\n{error_msg}"
         elif "404" in error_msg or "NotFoundError" in error_msg:
@@ -476,24 +493,34 @@ async def ping_model(
 
 
 async def _ping_llm(
-    model: str,
+    *,
+    vendor: str,
+    model_name: str,
     api_key: str | None,
     api_base: str | None,
 ) -> dict[str, Any]:
-    """LLM Ping: 发送 'Ping, give me a pong' 并验证响应。"""
+    """LLM Ping: 发送 'Ping, give me a pong' 并验证响应。
+
+    复用 `build_ping_llm_kwargs` 构造 kwargs（含 drop_params 与 vendor 适配），
+    与业务主链路保持单一事实源。
+    """
     import asyncio
 
     import litellm
 
-    kwargs: dict[str, Any] = {"max_tokens": 20}
-    if api_key:
-        kwargs["api_key"] = api_key
-    if api_base:
-        kwargs["api_base"] = api_base
+    from negentropy.config.model_resolver import build_full_model_name, build_ping_llm_kwargs
+
+    full_model_name = build_full_model_name(vendor, model_name)
+    kwargs = build_ping_llm_kwargs(
+        vendor,
+        model_name,
+        api_key_override=api_key,
+        api_base_override=api_base,
+    )
 
     response = await asyncio.wait_for(
         litellm.acompletion(
-            model=model,
+            model=full_model_name,
             messages=[{"role": "user", "content": "Ping, give me a pong"}],
             **kwargs,
         ),

--- a/apps/negentropy/src/negentropy/cli.py
+++ b/apps/negentropy/src/negentropy/cli.py
@@ -48,7 +48,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         env["NE_CONFIG_PATH"] = str(config_path)
 
     # Determine port and host
-    port = args.port or 6600
+    port = args.port or 3292
     host = args.host or "0.0.0.0"
 
     # Build adk web command
@@ -88,7 +88,7 @@ def main() -> None:
 
     # serve subcommand
     serve_parser = subparsers.add_parser("serve", help="启动 ADK Web 服务器")
-    serve_parser.add_argument("--port", type=int, default=6600, help="服务器端口 (默认: 6600)")
+    serve_parser.add_argument("--port", type=int, default=3292, help="服务器端口 (默认: 3292)")
     serve_parser.add_argument("--host", default="0.0.0.0", help="绑定地址 (默认: 0.0.0.0)")
     serve_parser.add_argument("--no-reload", action="store_true", help="禁用热重载")
 

--- a/apps/negentropy/src/negentropy/config/model_resolver.py
+++ b/apps/negentropy/src/negentropy/config/model_resolver.py
@@ -257,6 +257,93 @@ def _build_llm_kwargs(
     return kwargs
 
 
+# 规则依据各 vendor 的 api_base 约定（LiteLLM 会在 base 之后自动拼接端点）：
+#   - OpenAI 兼容：api_base 形如 `https://host/v1`，LiteLLM 会附加 `/chat/completions`；
+#     故用户误贴的 `/chat/completions` 应被剥离，保留 `/v1`。
+#   - Anthropic：api_base 形如 `https://api.anthropic.com`，LiteLLM 附加 `/v1/messages`；
+#     故误贴的 `/v1/messages` 应被整体剥离，不能保留 `/v1`。
+# 为避免短后缀抢先匹配（例如 `/messages` 命中 `/v1/messages` 中的尾段但留下残缺的 `/v1`），
+# 长后缀位于列表前端，依赖 break-per-iteration 的策略确保长后缀优先匹配。
+_API_BASE_REDUNDANT_SUFFIXES: tuple[str, ...] = (
+    "/v1/messages",
+    "/chat/completions",
+    "/completions",
+)
+
+
+def normalize_api_base(api_base: str | None) -> str | None:
+    """规范化 api_base — 防御性移除用户误贴的端点路径后缀。
+
+    用户在 Admin UI 配置 Base URL 时，偶有将完整端点（如
+    `http://llms.as-in.io/v1/chat/completions`）误填为 Base URL 的情况，
+    导致 LiteLLM 再次拼接 `/chat/completions` 造成 404。此函数以幂等方式
+    去除常见冗余后缀与尾部斜杠，不影响合法配置（形如 `https://host/v1`）。
+
+    剥离策略：在同一循环内交错处理「尾部斜杠」与「冗余后缀」，直至稳定，
+    以覆盖形如 `http://x/v1/chat/completions/` 这样「斜杠 + 后缀」交错出现
+    的组合情况。
+    """
+    if api_base is None:
+        return None
+    trimmed = api_base.strip()
+    if not trimmed:
+        return None
+
+    changed = True
+    while changed:
+        changed = False
+        if trimmed.endswith("/"):
+            trimmed = trimmed.rstrip("/")
+            changed = True
+            continue
+        for suffix in _API_BASE_REDUNDANT_SUFFIXES:
+            if trimmed.endswith(suffix):
+                trimmed = trimmed[: -len(suffix)]
+                changed = True
+                break
+
+    return trimmed or None
+
+
+def build_ping_llm_kwargs(
+    vendor: str,
+    model_name: str,
+    *,
+    api_key_override: str | None = None,
+    api_base_override: str | None = None,
+    vendor_config: dict[str, str] | None = None,
+    max_tokens: int | None = 20,
+) -> dict[str, Any]:
+    """构造 Admin Ping 使用的 LiteLLM kwargs，复用业务主链路的 _build_llm_kwargs。
+
+    合并顺序：
+      1) _build_llm_kwargs(vendor, model_name, config={}, vendor_config)
+         — 注入 vendor 特定适配（Anthropic thinking disabled / OpenAI o-系 reasoning）
+           以及 vendor_config 凭证；
+      2) setdefault("drop_params", True)
+         — Ping 语义的核心保护：gpt-5 / o-系等新模型对 max_tokens、temperature 有
+           严格约束；drop_params=True 允许 LiteLLM 自动剔除或映射不兼容参数；
+      3) 覆盖 api_key / api_base（若显式提供，normalize_api_base 已应用）；
+      4) 附加 max_tokens（若非 None）。
+
+    注意：故意不合并 _DEFAULT_LLM_KWARGS["temperature"]。temperature 与具体模型合法取值耦合
+    （如 gpt-5-mini 仅接受 1），Ping 阶段不应注入默认值，交由服务端缺省处理。
+    """
+    kwargs = _build_llm_kwargs(vendor, model_name, {}, vendor_config)
+    kwargs.setdefault("drop_params", True)
+
+    normalized_api_base = normalize_api_base(api_base_override)
+    if api_key_override:
+        kwargs["api_key"] = api_key_override
+    if normalized_api_base:
+        kwargs["api_base"] = normalized_api_base
+
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    return kwargs
+
+
 def _build_embedding_kwargs(config: dict[str, Any], vendor_config: dict[str, str] | None = None) -> dict[str, Any]:
     """从 DB config JSONB 构建 Embedding kwargs。"""
     kwargs: dict[str, Any] = {}

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py
@@ -1,0 +1,77 @@
+"""Seed: negentropy-perceives 预置 MCP Server
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-19 00:00:00.000000+00:00
+
+按正交分解原则，将 DDL 与 DML 解耦：0001 仅负责 schema（纯 DDL），
+本迁移承载 negentropy-perceives 这一预置 MCP Server 的 seed（纯 DML）。
+
+SQL 模板直接复用 99eb9ff 已验证的 `INSERT ... ON CONFLICT (name) DO UPDATE`：
+- 新部署 alembic upgrade head 会首次写入预置；
+- 既有部署如被手动污染，也会在任意升级通路上被幂等自愈回归预置。
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Negentropy Perceives MCP Server 预设（幂等 upsert）
+    op.execute(
+        sa.text("""
+        INSERT INTO negentropy.mcp_servers (
+            owner_id, visibility, name, display_name, description,
+            transport_type, command, args, env, url, headers,
+            is_enabled, auto_start, config
+        )
+        VALUES (
+            'system:negentropy-perceives-preset',
+            'PUBLIC'::negentropy.pluginvisibility,
+            'negentropy-perceives',
+            'Negentropy Perceives',
+            '一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、'
+            '图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。',
+            'http',
+            NULL,
+            '[]'::jsonb,
+            '{}'::jsonb,
+            'http://localhost:8092/mcp',
+            '{}'::jsonb,
+            TRUE,
+            TRUE,
+            '{}'::jsonb
+        )
+        ON CONFLICT (name) DO UPDATE
+        SET
+            owner_id = EXCLUDED.owner_id,
+            visibility = EXCLUDED.visibility,
+            display_name = EXCLUDED.display_name,
+            description = EXCLUDED.description,
+            transport_type = EXCLUDED.transport_type,
+            command = EXCLUDED.command,
+            args = EXCLUDED.args,
+            env = EXCLUDED.env,
+            url = EXCLUDED.url,
+            headers = EXCLUDED.headers,
+            is_enabled = EXCLUDED.is_enabled,
+            auto_start = EXCLUDED.auto_start,
+            config = EXCLUDED.config,
+            updated_at = now()
+    """)
+    )
+
+
+def downgrade() -> None:
+    # 仅回收 seed，不触碰 schema
+    op.execute(sa.text("DELETE FROM negentropy.mcp_servers WHERE name = 'negentropy-perceives'"))

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -31,7 +31,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select
 
 from negentropy.auth.deps import get_current_user
@@ -145,8 +145,10 @@ class MemoryDashboardResponse(BaseModel):
 
 
 class MemoryAutomationFunctionResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     name: str
-    schema: str
+    schema_name: str = Field(alias="schema", serialization_alias="schema")
     status: str
     definition: str
     managed: bool = True

--- a/apps/negentropy/tests/unit_tests/auth/test_admin_models_ping.py
+++ b/apps/negentropy/tests/unit_tests/auth/test_admin_models_ping.py
@@ -1,0 +1,351 @@
+"""`/auth/admin/models/ping` 端点行为单元测试。
+
+覆盖：
+- OpenAI / Anthropic / Gemini 三家 vendor 的 kwargs 透传（drop_params / thinking / api_base / api_key）；
+- 表单覆盖 vs vendor_configs DB 回退优先级；
+- api_base 末尾 `/chat/completions` 等冗余后缀在传入 LiteLLM 前被规范化；
+- 异常路径的中文文案分类（401 / 404 / timeout / 其他）；
+- 非 admin 角色的 403 拦截。
+
+litellm.acompletion 被 monkeypatch 为 async mock，避免真实网络出口。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from negentropy.auth.api import router as auth_router
+from negentropy.auth.deps import get_current_user
+from negentropy.auth.service import AuthUser
+
+
+def _user(roles: list[str]) -> AuthUser:
+    return AuthUser(
+        user_id="google:user",
+        email="user@example.com",
+        name="User",
+        picture=None,
+        roles=roles,
+        provider="google",
+        subject="user",
+        domain="example.com",
+    )
+
+
+def _build_app(user: AuthUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_router)
+
+    def _dep() -> AuthUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _dep
+    return app
+
+
+def _mock_response(content: str = "pong hello") -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    return response
+
+
+class _SuccessAcompletion:
+    """异步 mock：记录每次 kwargs 并返回固定 pong 响应。"""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> MagicMock:
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return _mock_response()
+
+
+class _RaisingAcompletion:
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> MagicMock:
+        raise self._exc
+
+
+def _patch_acompletion(monkeypatch: pytest.MonkeyPatch, impl: Callable[..., Any]) -> None:
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", impl)
+
+
+def _patch_no_db_vendor_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """令 DB 回退路径总是返回 None —— 用于确保当表单提供 api_key 时 DB 不被命中。
+
+    保险起见，把 AsyncSessionLocal 替换为一个会抛异常的哑对象；
+    端点内有 try/except 会静默吞掉，表现为「DB 无记录」。
+    """
+
+    class _Boom:
+        def __call__(self) -> Any:
+            raise RuntimeError("DB disabled in unit test")
+
+    monkeypatch.setattr("negentropy.auth.api.AsyncSessionLocal", _Boom())
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+class TestPingOpenAI:
+    def test_success_passes_drop_params_and_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        mock = _SuccessAcompletion()
+        _patch_acompletion(monkeypatch, mock)
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                    "api_key": "sk-test",
+                    "api_base": "http://llms.as-in.io/v1",
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert "Pong!" in body["message"]
+        assert "latency_ms" in body
+
+        assert len(mock.calls) == 1
+        kwargs = mock.calls[0]["kwargs"]
+        assert kwargs["model"] == "openai/gpt-5-mini"
+        assert kwargs["drop_params"] is True
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["api_base"] == "http://llms.as-in.io/v1"
+        assert kwargs["max_tokens"] == 20
+        assert "temperature" not in kwargs
+        assert "reasoning_effort" not in kwargs
+
+    def test_api_base_suffix_is_normalized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        mock = _SuccessAcompletion()
+        _patch_acompletion(monkeypatch, mock)
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                    "api_key": "sk",
+                    "api_base": "http://llms.as-in.io/v1/chat/completions",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert mock.calls[0]["kwargs"]["api_base"] == "http://llms.as-in.io/v1"
+
+    def test_404_maps_to_chinese_model_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        exc = RuntimeError("litellm.NotFoundError: OpenAIException - Error code: 404 - resource not found")
+        _patch_acompletion(monkeypatch, _RaisingAcompletion(exc))
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                    "api_key": "sk",
+                    "api_base": "http://x/v1",
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "error"
+        assert "模型未找到" in body["message"]
+
+    def test_401_maps_to_chinese_auth_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        exc = RuntimeError("AuthenticationError: 401 unauthorized key")
+        _patch_acompletion(monkeypatch, _RaisingAcompletion(exc))
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                    "api_key": "sk-bad",
+                },
+            )
+
+        body = resp.json()
+        assert body["status"] == "error"
+        assert "认证失败" in body["message"]
+
+    def test_timeout_maps_to_chinese_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        _patch_acompletion(monkeypatch, _RaisingAcompletion(TimeoutError()))
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                    "api_key": "sk",
+                },
+            )
+
+        body = resp.json()
+        assert body["status"] == "error"
+        assert "连接超时" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestPingAnthropic:
+    def test_thinking_disabled_passed_to_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        mock = _SuccessAcompletion()
+        _patch_acompletion(monkeypatch, mock)
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "anthropic",
+                    "model_name": "claude-sonnet-4",
+                    "api_key": "sk-ant",
+                },
+            )
+
+        assert resp.status_code == 200
+        kwargs = mock.calls[0]["kwargs"]
+        assert kwargs["model"] == "anthropic/claude-sonnet-4"
+        assert kwargs["thinking"] == {"type": "disabled"}
+        assert kwargs["drop_params"] is True
+        assert kwargs["api_key"] == "sk-ant"
+        assert "temperature" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+
+class TestPingGemini:
+    def test_drop_params_true_without_vendor_specific_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        mock = _SuccessAcompletion()
+        _patch_acompletion(monkeypatch, mock)
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "gemini",
+                    "model_name": "gemini-2.5-flash",
+                    "api_key": "g-key",
+                },
+            )
+
+        assert resp.status_code == 200
+        kwargs = mock.calls[0]["kwargs"]
+        assert kwargs["model"] == "gemini/gemini-2.5-flash"
+        assert kwargs["drop_params"] is True
+        assert kwargs["api_key"] == "g-key"
+        assert "thinking" not in kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "temperature" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Fallback & RBAC
+# ---------------------------------------------------------------------------
+
+
+class TestPingDbFallback:
+    def test_vendor_config_fallback_populates_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """当表单未提供 api_key 时，DB 中的 VendorConfig 记录应被透传。"""
+
+        class _FakeVendorConfig:
+            api_key = "sk-from-db"
+            api_base = "http://db-host/v1"
+
+        class _FakeResult:
+            def scalar_one_or_none(self) -> _FakeVendorConfig:
+                return _FakeVendorConfig()
+
+        class _FakeSession:
+            async def __aenter__(self) -> _FakeSession:
+                return self
+
+            async def __aexit__(self, *_exc: Any) -> None:
+                return None
+
+            async def execute(self, _stmt: Any) -> _FakeResult:
+                return _FakeResult()
+
+        def _fake_session_factory() -> _FakeSession:
+            return _FakeSession()
+
+        monkeypatch.setattr("negentropy.auth.api.AsyncSessionLocal", _fake_session_factory)
+
+        mock = _SuccessAcompletion()
+        _patch_acompletion(monkeypatch, mock)
+
+        app = _build_app(_user(["admin"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        kwargs = mock.calls[0]["kwargs"]
+        assert kwargs["api_key"] == "sk-from-db"
+        assert kwargs["api_base"] == "http://db-host/v1"
+
+
+class TestPingRbac:
+    def test_non_admin_role_is_forbidden(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_no_db_vendor_config(monkeypatch)
+        mock = _SuccessAcompletion()
+        _patch_acompletion(monkeypatch, mock)
+
+        app = _build_app(_user(["user"]))
+        with TestClient(app) as client:
+            resp = client.post(
+                "/auth/admin/models/ping",
+                json={
+                    "vendor": "openai",
+                    "model_name": "gpt-5-mini",
+                    "api_key": "sk",
+                },
+            )
+
+        assert resp.status_code == 403
+        assert mock.calls == []

--- a/apps/negentropy/tests/unit_tests/config/test_cli.py
+++ b/apps/negentropy/tests/unit_tests/config/test_cli.py
@@ -78,7 +78,7 @@ class TestServeCommand:
 
         class Args:
             config = str(tmp_path / "nonexistent.yaml")
-            port = 6600
+            port = 3292
             host = "0.0.0.0"
             no_reload = False
 

--- a/apps/negentropy/tests/unit_tests/config/test_model_resolver_ping.py
+++ b/apps/negentropy/tests/unit_tests/config/test_model_resolver_ping.py
@@ -1,0 +1,130 @@
+"""build_ping_llm_kwargs / normalize_api_base 单元测试。
+
+覆盖点：
+- drop_params=True 默认注入，保障 gpt-5 / o-系对不兼容参数的降级；
+- temperature 不被注入（Ping 语义故意避让模型特定约束）；
+- OpenAI / Anthropic / Gemini vendor 专属适配；
+- 表单覆盖 > vendor_config 的优先级；
+- api_base 尾部 `/chat/completions`、`/messages`、多余 `/` 的防御性规范化；
+- max_tokens=None 时完全不下传该键。
+"""
+
+from __future__ import annotations
+
+from negentropy.config.model_resolver import build_ping_llm_kwargs, normalize_api_base
+
+
+class TestNormalizeApiBase:
+    def test_returns_none_for_none(self) -> None:
+        assert normalize_api_base(None) is None
+
+    def test_returns_none_for_blank(self) -> None:
+        assert normalize_api_base("") is None
+        assert normalize_api_base("   ") is None
+
+    def test_idempotent_on_valid_base(self) -> None:
+        assert normalize_api_base("https://api.openai.com/v1") == "https://api.openai.com/v1"
+        assert normalize_api_base("http://llms.as-in.io/v1") == "http://llms.as-in.io/v1"
+
+    def test_strips_chat_completions_suffix(self) -> None:
+        assert normalize_api_base("http://llms.as-in.io/v1/chat/completions") == "http://llms.as-in.io/v1"
+
+    def test_strips_messages_suffix(self) -> None:
+        assert normalize_api_base("https://api.anthropic.com/v1/messages") == "https://api.anthropic.com"
+
+    def test_strips_trailing_slash(self) -> None:
+        assert normalize_api_base("https://api.openai.com/v1/") == "https://api.openai.com/v1"
+        assert normalize_api_base("https://api.openai.com/v1///") == "https://api.openai.com/v1"
+
+    def test_strips_composed_suffix_then_slash(self) -> None:
+        assert normalize_api_base("http://x/v1/chat/completions/") == "http://x/v1"
+
+    def test_strips_whitespace(self) -> None:
+        assert normalize_api_base("  https://api.openai.com/v1  ") == "https://api.openai.com/v1"
+
+
+class TestBuildPingLlmKwargsOpenAI:
+    def test_defaults_include_drop_params_and_max_tokens(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "openai",
+            "gpt-5-mini",
+            api_key_override="sk-test",
+            api_base_override="http://llms.as-in.io/v1",
+        )
+        assert kwargs["drop_params"] is True
+        assert kwargs["max_tokens"] == 20
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["api_base"] == "http://llms.as-in.io/v1"
+
+    def test_does_not_inject_temperature(self) -> None:
+        kwargs = build_ping_llm_kwargs("openai", "gpt-5-mini", api_key_override="sk")
+        assert "temperature" not in kwargs
+
+    def test_non_o_series_has_no_reasoning_effort(self) -> None:
+        kwargs = build_ping_llm_kwargs("openai", "gpt-5-mini", api_key_override="sk")
+        assert "reasoning_effort" not in kwargs
+
+    def test_max_tokens_none_drops_key(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "openai",
+            "gpt-5-mini",
+            api_key_override="sk",
+            max_tokens=None,
+        )
+        assert "max_tokens" not in kwargs
+
+    def test_api_base_normalization_happens(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "openai",
+            "gpt-5-mini",
+            api_key_override="sk",
+            api_base_override="http://llms.as-in.io/v1/chat/completions",
+        )
+        assert kwargs["api_base"] == "http://llms.as-in.io/v1"
+
+    def test_override_wins_over_vendor_config(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "openai",
+            "gpt-5-mini",
+            api_key_override="sk-from-form",
+            api_base_override="http://form/v1",
+            vendor_config={"api_key": "sk-from-db", "api_base": "http://db/v1"},
+        )
+        assert kwargs["api_key"] == "sk-from-form"
+        assert kwargs["api_base"] == "http://form/v1"
+
+    def test_vendor_config_used_when_no_override(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "openai",
+            "gpt-5-mini",
+            vendor_config={"api_key": "sk-db", "api_base": "http://db/v1"},
+        )
+        assert kwargs["api_key"] == "sk-db"
+        assert kwargs["api_base"] == "http://db/v1"
+
+
+class TestBuildPingLlmKwargsAnthropic:
+    def test_disables_thinking_by_default(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "anthropic",
+            "claude-sonnet-4",
+            api_key_override="sk-ant",
+        )
+        assert kwargs["thinking"] == {"type": "disabled"}
+        assert kwargs["drop_params"] is True
+        assert kwargs["max_tokens"] == 20
+        assert "temperature" not in kwargs
+
+
+class TestBuildPingLlmKwargsGemini:
+    def test_no_vendor_specific_params(self) -> None:
+        kwargs = build_ping_llm_kwargs(
+            "gemini",
+            "gemini-2.5-flash",
+            api_key_override="g-key",
+        )
+        assert kwargs["drop_params"] is True
+        assert kwargs["api_key"] == "g-key"
+        assert "thinking" not in kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "temperature" not in kwargs

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -1497,6 +1497,7 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "microsandbox" },
+    { name = "opentelemetry-instrumentation-google-genai" },
     { name = "orjson" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings", extra = ["yaml"] },
@@ -1526,6 +1527,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.83.0" },
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "microsandbox", specifier = ">=0.1.8" },
+    { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.6b0,<1.0.0" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.12.0" },
@@ -1650,6 +1652,36 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.58b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/36/7c307d9be8ce4ee7beb86d7f1d31027f2a6a89228240405a858d6e4d64f9/opentelemetry_instrumentation-0.58b0.tar.gz", hash = "sha256:df640f3ac715a3e05af145c18f527f4422c6ab6c467e40bd24d2ad75a00cb705", size = 31549, upload-time = "2025-09-11T11:42:14.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/db/5ff1cd6c5ca1d12ecf1b73be16fbb2a8af2114ee46d4b0e6d4b23f4f4db7/opentelemetry_instrumentation-0.58b0-py3-none-any.whl", hash = "sha256:50f97ac03100676c9f7fc28197f8240c7290ca1baa12da8bfbb9a1de4f34cc45", size = 33019, upload-time = "2025-09-11T11:41:00.624Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-google-genai"
+version = "0.7b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-genai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/59/595e5ed05715c47cf49ac7e30d0a4cf6ed41e00524401c46c9d92b84623c/opentelemetry_instrumentation_google_genai-0.7b0.tar.gz", hash = "sha256:35158682dfd00201ef3864b47dda95d6062188e8a599ecabd383688e7eba2824", size = 52057, upload-time = "2026-02-20T21:56:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/97/2c26687c6ea0747bb225ce7e5506f8f87e3e7ce4204c2900798177aa7792/opentelemetry_instrumentation_google_genai-0.7b0-py3-none-any.whl", hash = "sha256:b579d7bd3dda1aae1b76bfebbe86adcc88eadb2c08d11e864fbdecf370b19b25", size = 31402, upload-time = "2026-02-20T21:56:22.149Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1701,6 +1733,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867, upload-time = "2025-09-11T10:29:12.597Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954, upload-time = "2025-09-11T10:28:59.218Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-genai"
+version = "0.3b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/d8/4dd2fb622d26ec45b10ef63eb87fd512f5d7467c7bd35ce390629bd6dff8/opentelemetry_util_genai-0.3b0.tar.gz", hash = "sha256:83e127789a9ad615b8ca65f05fc36955a67ce257b06142bfd46159a3b7ed73d3", size = 31800, upload-time = "2026-02-20T16:16:14.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/e5/fada54909e445d7b4007f8b96221d571999efeab9446f3127cc1cebe5e07/opentelemetry_util_genai-0.3b0-py3-none-any.whl", hash = "sha256:ebc2b01bcb891ddc7218452470d189d3321cd742653299ff8e7de45debcfb986", size = 28426, upload-time = "2026-02-20T16:16:12.027Z" },
 ]
 
 [[package]]
@@ -2551,6 +2597,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]

--- a/docs/development.md
+++ b/docs/development.md
@@ -423,7 +423,7 @@ thread_id: Mapped[UUID] = mapped_column(
 
 | 变量                        | 作用域 | 说明                                       |
 | :-------------------------- | :----- | :----------------------------------------- |
-| `AGUI_BASE_URL`             | 服务端 | ADK 后端地址（如 `http://localhost:8000`） |
+| `AGUI_BASE_URL`             | 服务端 | 后端地址（默认 `http://localhost:3292`）   |
 | `NEXT_PUBLIC_AGUI_APP_NAME` | 客户端 | 应用名称标识                               |
 | `NEXT_PUBLIC_AGUI_USER_ID`  | 客户端 | 用户标识                                   |
 
@@ -479,12 +479,14 @@ export GEMINI_API_KEY=...
 
 ```bash
 # 服务端（仅 Route Handler 可用）
-AGUI_BASE_URL=http://localhost:8000
+AGUI_BASE_URL=http://localhost:3292
 
 # 客户端（浏览器可见）
 NEXT_PUBLIC_AGUI_APP_NAME=negentropy
 NEXT_PUBLIC_AGUI_USER_ID=dev-user
 ```
+
+> **迁移守护**：若 `AGUI_BASE_URL` 指向历史本地端口（如 `:6600` / `:6666`）且 `NODE_ENV !== "production"`，BFF 会打印一次性迁移告警并将端口重写为 `:3292`；生产环境仅告警、不改写，以便运维显式修复。详见 `apps/negentropy-ui/lib/server/backend-url.ts`。
 
 ### 8.4 安全约束
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ uv run adk web --port 8000 --reload_agents src/negentropy  # ADK Web 启动
 ```bash
 cd apps/negentropy-ui
 pnpm install                           # 安装依赖
-pnpm run dev                           # 启动开发服务器 (localhost:3333)
+pnpm run dev                           # 启动开发服务器 (localhost:3192)
 ```
 
 ---
@@ -156,7 +156,7 @@ flowchart LR
     Start --> SetupFE[前端: pnpm install]
 
     SetupBE --> DevBE[后端: uv run adk web<br>--reload_agents]
-    SetupFE --> DevFE[前端: pnpm run dev<br>localhost:3333]
+    SetupFE --> DevFE[前端: pnpm run dev<br>localhost:3192]
 
     DevBE --> |热重载| DevBE
     DevFE --> |热重载| DevFE
@@ -225,7 +225,7 @@ uv run ruff format .                   # 代码格式化
 ```bash
 cd apps/negentropy-ui
 
-pnpm run dev                           # 开发启动 (localhost:3333)
+pnpm run dev                           # 开发启动 (localhost:3192)
 pnpm run build                         # 生产构建
 pnpm run start                         # 生产启动
 ```
@@ -263,7 +263,7 @@ pnpm run typecheck                     # TypeScript 类型检查
 **前置条件**：
 
 - 后端 ADK 已启动，`AGUI_BASE_URL` 可访问
-- 前端已启动：`http://localhost:3333`
+- 前端已启动：`http://localhost:3192`
 - `.env.local` 中 `NEXT_PUBLIC_AGUI_APP_NAME` 与 `NEXT_PUBLIC_AGUI_USER_ID` 已设置
 
 **验证步骤**：
@@ -436,7 +436,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3333"],
+    allow_origins=["http://localhost:3192"],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -196,7 +196,7 @@ pnpm install
 pnpm run dev
 ```
 
-> 前端启动后访问 `http://localhost:3333` 即可进入 Negentropy 主界面。
+> 前端启动后访问 `http://localhost:3192` 即可进入 Negentropy 主界面。
 
 ### 2.4 首次对话
 
@@ -206,7 +206,7 @@ sequenceDiagram
     participant UI as 🖥️ 前端界面
     participant BE as ⚙️ 后端引擎
 
-    U->>UI: 打开 localhost:3333
+    U->>UI: 打开 localhost:3192
     UI->>UI: 显示三栏布局<br/>（Session 列表 / 聊天区 / 调试面板）
     U->>UI: 在 Composer 输入框输入消息
     UI->>BE: 自动创建 Session<br/>发送用户消息
@@ -216,7 +216,7 @@ sequenceDiagram
     U->>UI: 阅读 Agent 回复<br/>查看右侧调试信息
 ```
 
-打开浏览器访问 `http://localhost:3333`，你会看到三栏布局的对话界面：
+打开浏览器访问 `http://localhost:3192`，你会看到三栏布局的对话界面：
 
 - **左侧**：Session 列表（当前为空）
 - **中间**：聊天区域 + 底部输入框（Composer）

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -120,12 +120,12 @@ uv run adk web --port 8000 --reload_agents src/negentropy  # 启动引擎
 ```bash
 cd apps/negentropy-ui
 pnpm install                   # 安装依赖
-pnpm run dev                   # 启动开发服务器 (localhost:3333)
+pnpm run dev                   # 启动开发服务器 (localhost:3192)
 ```
 
 ### 4. 开始对话
 
-打开浏览器访问 `http://localhost:3333`，开始与 NegentropyEngine 对话。
+打开浏览器访问 `http://localhost:3192`，开始与 NegentropyEngine 对话。
 
 > 完整的环境搭建指南、数据库迁移、前后端对接、故障排查详见 [docs/development.md](../development.md)。
 


### PR DESCRIPTION
## 背景

Admin → Models 面板对 OpenAI 兼容代理（如 `http://llms.as-in.io/v1`）配置下的 `gpt-5-mini` 执行 Ping，后端返回：

```
litellm.NotFoundError: OpenAIException - Error code: 404 -
{'meta': {'code': 404, 'type': 'NotFound', 'message': 'The requested resource was not found but could be available again in the future.'},
 'data': {}}
```

同一 key + api_base + model 直接 `curl` 完全可用；Gemini / Anthropic 同类链路亦潜在存在风险。

## 根因

`auth.api._ping_llm` 过去手写最小 kwargs（`max_tokens=20 + api_key + api_base`），**绕过了业务主链路**的 `_build_llm_kwargs()` + `_DEFAULT_LLM_KWARGS` 合并策略，缺失 `drop_params=True`：

- `gpt-5-mini` 等新模型在 OpenAI 协议下仅接受 `max_completion_tokens`，不接受 `max_tokens`；`temperature` 只接受 `1`。
- 无 `drop_params=True` 时，LiteLLM 不会自动剔除/映射这些不兼容参数，硬传给 One‑API 风格的兼容代理（如 `llms.as-in.io`）后，代理在路由不到对应 channel 时兜底以 `{meta:{code:404}, data:{}}` 返回 404。
- Anthropic 走同一链路时 `thinking={"type":"disabled"}` 亦缺失；Gemini 缺失 `drop_params=True` 导致未来参数兼容风险。

本质上是违反了 AGENTS.md 的 **Single Source of Truth** 与 **Reuse-Driven** 原则 —— Ping 与业务主链路维护了两套参数构造逻辑。

## 修复方案

### 1. `config/model_resolver.py`

- 新增 `build_ping_llm_kwargs(vendor, model_name, *, api_key_override, api_base_override, vendor_config, max_tokens=20)`：
  - 内部调用既有 `_build_llm_kwargs()`，**自动继承** Anthropic `thinking={"type":"disabled"}`、OpenAI o 系列 `reasoning_effort` 等 vendor 专属适配；
  - `setdefault("drop_params", True)` 作为 Ping 语义核心保护；
  - **故意不注入** `_DEFAULT_LLM_KWARGS["temperature"]` —— 避免与模型版本约束（gpt-5 仅接受 1）耦合；
  - override 优先级：表单 > `vendor_config` (DB)。
- 新增 `normalize_api_base(api_base)`：幂等剥离用户误贴的 `/chat/completions`、`/v1/messages`、`/completions` 后缀与尾部多余 `/`，对合法 `https://host/v1` 零副作用；长后缀优先匹配避免短后缀吃掉 `/v1`。

### 2. `auth/api.py`

- `_ping_llm` 签名改为 keyword-only 并改调 `build_ping_llm_kwargs()` + `build_full_model_name()`；
- 异常路径新增结构化日志：`vendor / full_model_name / 归一化 api_base / latency_ms / 脱敏 error`；
- 401 / 404 / timeout 的中文文案分类保持不变。

### 3. 测试

- 新增 `tests/unit_tests/config/test_model_resolver_ping.py`：17 用例（`normalize_api_base` 8 个边界 + OpenAI 7 个 + Anthropic / Gemini 各 1 个）；
- 新增 `tests/unit_tests/auth/test_admin_models_ping.py`：9 用例（三家 vendor 正常路径 + api_base 规范化 + 401 / 404 / timeout 文案 + DB `vendor_configs` 回退 + 非 admin 403）。

## 验证

- `uv run pytest tests/unit_tests/config tests/unit_tests/auth` → **87 passed**;
- `uv run ruff check` 目标文件 → **0 errors**;
- pre-commit hooks（ruff lint / ruff format）全部通过。

## Test Plan

- [ ] Admin → Models → OpenAI，配置 `api_base=http://llms.as-in.io/v1` + 真实 key → Ping `gpt-5-mini` 期望 `status=ok`;
- [ ] Ping `claude-haiku-4-5-20251001`（Anthropic）→ 期望 ok;
- [ ] Ping `gemini-2.5-flash`（Gemini）→ 期望 ok;
- [ ] 故意填入 `http://llms.as-in.io/v1/chat/completions` → 规范化后仍 ok;
- [ ] 故意用错 api_key → 期望中文「认证失败」文案;
- [ ] 故意用不存在模型 → 期望中文「模型未找到」文案.

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)

Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>