### PR TITLE
fix(auth-ping): 禁用 LLM Ping 重试放大并补齐结构化日志

### DIFF
--- a/apps/negentropy/src/negentropy/auth/api.py
+++ b/apps/negentropy/src/negentropy/auth/api.py
@@ -427,11 +427,15 @@ async def ping_model(
     import time
 
     from negentropy.config.model_resolver import build_full_model_name
+    from negentropy.logging import get_logger
+
+    log = get_logger("negentropy.auth.api")
 
     full_model_name = build_full_model_name(payload.vendor, payload.model_name)
 
     effective_api_key = payload.api_key
     effective_api_base = payload.api_base or payload.config.get("api_base")
+    api_key_source = "payload" if payload.api_key else "env"
 
     if effective_api_key is None:
         from negentropy.models.vendor_config import VendorConfig
@@ -442,16 +446,25 @@ async def ping_model(
                 vc = result.scalar_one_or_none()
                 if vc:
                     effective_api_key = vc.api_key
+                    api_key_source = "db"
                     if not effective_api_base:
                         effective_api_base = vc.api_base
         except Exception:
-            from negentropy.logging import get_logger
-
-            get_logger("negentropy.auth.api").warning(
+            log.warning(
                 "ping_vendor_lookup_failed",
                 vendor=payload.vendor,
                 exc_info=True,
             )
+
+    log.info(
+        "model_ping_start",
+        vendor=payload.vendor,
+        model_name=payload.model_name,
+        full_model_name=full_model_name,
+        api_base=effective_api_base,
+        api_key_fingerprint=_mask_api_key(effective_api_key),
+        api_key_source=api_key_source,
+    )
 
     start_time = time.monotonic()
 
@@ -459,17 +472,35 @@ async def ping_model(
         result = await _ping_llm(full_model_name, effective_api_key, effective_api_base)
         latency_ms = int((time.monotonic() - start_time) * 1000)
         result["latency_ms"] = latency_ms
+        log.info(
+            "model_ping_ok",
+            vendor=payload.vendor,
+            model_name=payload.model_name,
+            latency_ms=latency_ms,
+        )
         return result
 
     except Exception as exc:
         latency_ms = int((time.monotonic() - start_time) * 1000)
         error_msg = _sanitize_error(str(exc))
+        log.warning(
+            "model_ping_failed",
+            vendor=payload.vendor,
+            model_name=payload.model_name,
+            latency_ms=latency_ms,
+            exc_type=type(exc).__name__,
+            exc_status=getattr(exc, "status_code", None),
+            exc_message=_sanitize_error(str(exc), max_len=500),
+            exc_info=True,
+        )
         if "AuthenticationError" in error_msg or "401" in error_msg:
             message = f"认证失败：API Key 无效或已过期。\n{error_msg}"
         elif "404" in error_msg or "NotFoundError" in error_msg:
             message = f"模型未找到：请检查 vendor/model_name 是否正确。\n{error_msg}"
+        elif "RateLimitError" in error_msg or "429" in error_msg:
+            message = f"请求过于频繁（429）：供应商已限流，请稍后重试。\n{error_msg}"
         elif "timeout" in error_msg.lower() or isinstance(exc, asyncio.TimeoutError):
-            message = "连接超时 (30s)，请检查网络或 API Base URL 配置。"
+            message = "连接超时 (5 min)，请检查网络或 API Base URL 配置。"
         else:
             message = f"Ping 失败：{error_msg}"
         return {"status": "error", "message": message, "latency_ms": latency_ms}
@@ -485,7 +516,14 @@ async def _ping_llm(
 
     import litellm
 
-    kwargs: dict[str, Any] = {"max_tokens": 20}
+    kwargs: dict[str, Any] = {
+        "max_tokens": 20,
+        # Ping 为健康检查，必须 fail-fast：禁用 litellm 与底层 SDK 的自动重试，
+        # 避免 1 次点击放大为 3 次请求、反向触发上游限流。
+        # num_retries=0 关闭 litellm 重试循环；max_retries=0 透传覆盖 openai SDK 默认 2。
+        "num_retries": 0,
+        "max_retries": 0,
+    }
     if api_key:
         kwargs["api_key"] = api_key
     if api_base:
@@ -497,7 +535,7 @@ async def _ping_llm(
             messages=[{"role": "user", "content": "Ping, give me a pong"}],
             **kwargs,
         ),
-        timeout=30.0,
+        timeout=300.0,  # 5 min：对齐 OpenAI SDK/LiteLLM 默认 600s，同时兼顾 UI 可用性
     )
     content = response.choices[0].message.content or ""
     return {"status": "ok", "message": f"Pong! {content.strip()[:100]}"}

--- a/apps/negentropy/src/negentropy/logging/interceptors.py
+++ b/apps/negentropy/src/negentropy/logging/interceptors.py
@@ -108,6 +108,9 @@ def intercept_third_party_loggers() -> None:
     litellm_logger.propagate = False
     litellm_logger.setLevel(logging.CRITICAL)
 
+    # Note: 故意不静默 openai._base_client / httpx loggers —
+    # 它们的 INFO 级 "Retrying request" 日志对排查 Ping 请求放大等问题至关重要。
+
     # 3. Patch Uvicorn's configuration logic to prevent it from hijacking
     # the root logger or re-adding handlers we just removed.
     try:


### PR DESCRIPTION
## 问题背景

Admin 页对 OpenAI 模型执行 Ping 连通性测试时偶发如下错误（耗时约 3181ms）：

```
Ping 失败：litellm.RateLimitError: OpenAIException - Error code: 429 - API rate limit exceeded
```

而同样的配置通过 curl 单次直接请求完全正常（约 3s 返回）。后台日志显示：

```
INFO | openai._base_client | Retrying request to /chat/completions in 1.000000 seconds
INFO | openai._base_client | Retrying request to /chat/completions in 1.000000 seconds
```

两条 `Retrying` ⇒ **1 次点击 → 3 次上游请求**（1 原始 + 2 重试），3 次并发打穿网关 RPS 阈值，形成"自循环式 429"。

## 根本原因

`_ping_llm()` 调用 `litellm.acompletion()` 时未显式设置 `num_retries` / `max_retries`，litellm 回退到底层 `openai` SDK 的默认值 `max_retries=2`。重试退避 `1s × 2 + 3 次 RTT ≈ 3.1s`，与日志耗时完全吻合。

经源码验证，Anthropic / Gemini 通过 litellm 走 `httpx.AsyncClient`（无内置重试），当前不受影响；但仍统一禁用以防御未来实现变动。

## 改动内容

### `apps/negentropy/src/negentropy/auth/api.py`

**① 禁用两层自动重试（根本修复）**

```python
kwargs: dict[str, Any] = {
    "max_tokens": 20,
    "num_retries": 0,   # 关闭 litellm 重试循环
    "max_retries": 0,   # 透传覆盖 openai SDK 默认 2
}
```

两个参数对应独立代码路径，必须同时置 0 才能彻底切断重试链。

**② 外层超时 30s → 300s（5 min）**

推理模型（o1/o3/o4-mini）单次响应可达 1–3 min，去掉 SDK 重试后需给合法慢响应留足时间预算，同时对齐 OpenAI SDK / LiteLLM 默认 600s 上限。

**③ 入口/成功/失败三处结构化日志**

复用既有 `get_logger("negentropy.auth.api")`（structlog + JSON sink），在 Ping 全链路补齐可观测字段：

- `model_ping_start`：vendor、model_name、api_base、api_key_fingerprint（脱敏末 4 位）、api_key_source
- `model_ping_ok`：latency_ms
- `model_ping_failed`：latency_ms、exc_type、exc_status、exc_message（已脱敏）、完整 traceback

**④ 补齐 429 友好错误分类 + 超时提示同步**

- 新增 `RateLimitError / 429` 分支，提示"请求过于频繁（429）：供应商已限流，请稍后重试"
- 超时提示从"连接超时 (30s)"更新为"连接超时 (5 min)"

### `apps/negentropy/src/negentropy/logging/interceptors.py`

在 `LiteLLM` logger 静默后补注释，说明故意保留 `openai._base_client` / `httpx` 的 INFO 级日志，防止未来误静默导致 Ping 放大类问题失去观测。

## 关键断言

修复后：
- 每次 Ping 点击 = 上游 1 次请求，不再出现 `openai._base_client | Retrying request` 日志
- 触发 429 时前端展示友好中文提示，后台 `model_ping_failed` 事件携带 `exc_status=429`
- Anthropic / Gemini Ping 行为不变（原本无重试放大）
- 业务路径（`knowledge/*`、`agents/*`）的 `litellm.acompletion` 调用不受影响（未全局修改 `litellm.num_retries`）

## 自建 LLM 代理转发能力（架构确认，无新增代码）

OpenAI / Anthropic / Gemini 三家的 **Base URL + API Key** 均可通过 `vendor_configs` 表独立配置，经 `model_resolver._build_llm_kwargs` / `_build_embedding_kwargs` 注入所有 litellm 调用点，实现将请求转发至用户自建 LLM 代理服务的全能力代理——本次 Ping 修复不改变此能力。