### PR TITLE
test(ci): 修复因 PR#372 新增模型配置功能导致的 CI 测试失败

### DIFF
--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -57,6 +57,7 @@ export interface KnowledgeFeatureMockSet {
   unarchiveDocumentMock: VitestMock;
   downloadDocumentMock: VitestMock;
   deleteDocumentMock: VitestMock;
+  fetchModelConfigsMock: VitestMock;
 }
 
 export interface KnowledgeFeatureTestHarness {
@@ -89,6 +90,7 @@ export function createKnowledgeFeatureMockSet(): KnowledgeFeatureMockSet {
     unarchiveDocumentMock: vi.fn(),
     downloadDocumentMock: vi.fn(),
     deleteDocumentMock: vi.fn(),
+    fetchModelConfigsMock: vi.fn().mockResolvedValue([]),
   };
 }
 
@@ -184,6 +186,7 @@ export function createKnowledgeFeatureTestHarness(
       unarchiveDocument: (...args: unknown[]) => mocks.unarchiveDocumentMock(...args),
       downloadDocument: (...args: unknown[]) => mocks.downloadDocumentMock(...args),
       deleteDocument: (...args: unknown[]) => mocks.deleteDocumentMock(...args),
+      fetchModelConfigs: (...args: unknown[]) => mocks.fetchModelConfigsMock(...args),
       ...createKnowledgeConfigTestExports(),
       ...overrides,
     },

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -175,6 +175,7 @@ describe("KnowledgeBasePage", () => {
     resetKnowledgeFeatureMocks(knowledgeMocks);
     resetKnowledgeBasePageLocalMocks(localMocks);
     primeKnowledgeBasePageLocalMocks(localMocks);
+    knowledgeMocks.fetchModelConfigsMock.mockResolvedValue([]);
     useKnowledgeBaseMock.mockImplementation(() => buildKnowledgeBaseHookState(localMocks));
   });
 

--- a/apps/negentropy/tests/integration_tests/knowledge/test_knowledge_service.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_knowledge_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -106,6 +107,10 @@ class FakeRepository:
         family_ids: Iterable[str],
     ) -> list[KnowledgeMatch]:
         return list(self.parent_results)
+
+    async def get_corpus_by_id(self, corpus_id: UUID):
+        _ = corpus_id
+        return SimpleNamespace(config={})
 
 
 async def _embedding_fn(text: str) -> list[float]:

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_corpus.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+from fastapi import BackgroundTasks
 
 from negentropy.knowledge import api as knowledge_api
 
@@ -209,6 +210,7 @@ async def test_update_corpus_serializes_chunking_strategy_to_string(monkeypatch)
                 "hierarchical_child_overlap": 150,
             }
         ),
+        background_tasks=BackgroundTasks(),
     )
 
     update_call = fake_service.update_corpus_calls[0]


### PR DESCRIPTION
## 背景

PR#372 合并后，GitHub Actions 的 Backend 和 UI 测试套件持续失败（连续 8 次）。根本原因是新增的"Corpus 级 LLM/Embedding 模型配置"功能引入了 API 签名变更和新模块导出，但相关测试代码未同步更新。

## 变更内容

### Backend 单测修复
- **`test_api_corpus.py`**: 为 `test_update_corpus_serializes_chunking_strategy_to_string` 测试补充 `update_corpus()` 新增的 `background_tasks: BackgroundTasks` 必选参数

### UI 单测修复
- **`knowledge.ts`**: 在 `KnowledgeFeatureMockSet` 接口和 `createKnowledgeFeatureTestHarness` 中补充 `fetchModelConfigs` mock 导出
- **`KnowledgeBasePage.test.tsx`**: 在 `beforeEach` 中设置 `fetchModelConfigsMock` 的默认返回值（空数组），避免 `mockReset()` 清除默认实现

### Backend 集成测试修复（预存问题）
- **`test_knowledge_service.py`**: 为 `FakeRepository` 补充 `get_corpus_by_id` 方法，与单测 `conftest.py` 中的实现保持一致。该问题此前被单测失败所遮蔽（集成测试依赖单测通过后才执行）

## 验证

- [x] Backend Unit Tests — 全部通过
- [x] Backend Integration Tests — 全部通过
- [x] UI Unit/Integration Tests — 全部通过（含 Playwright E2E）
- [x] UI Build Smoke — 通过
- [x] CI Workflow 全绿灯 ✅