### PR TITLE
feat(admin-models): Vendor 卡片已启用模型折叠披露入口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ apps/negentropy-ui/.yarn/*
 
 # Temp files
 .temp/
+.playwright-mcp/
 
 # Custom
 .claude/

--- a/apps/negentropy-ui/app/admin/models/page.tsx
+++ b/apps/negentropy-ui/app/admin/models/page.tsx
@@ -3,6 +3,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { AdminNav } from "@/components/ui/AdminNav";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { VendorModelsDisclosure } from "@/components/admin/VendorModelsDisclosure";
+import {
+  MODEL_KINDS,
+  type ModelConfigRecord,
+  type ModelKind,
+} from "@/types/admin-models";
 
 interface VendorConfigData {
   vendor: string;
@@ -48,27 +54,6 @@ interface PingResult {
   message: string;
   latency_ms?: number;
 }
-
-type ModelKind = "llm" | "embedding" | "rerank";
-
-interface ModelConfigRecord {
-  id: string;
-  model_type: ModelKind;
-  display_name: string;
-  vendor: string;
-  model_name: string;
-  is_default: boolean;
-  enabled: boolean;
-  config: Record<string, unknown>;
-  created_at?: string | null;
-  updated_at?: string | null;
-}
-
-const MODEL_KINDS: { value: ModelKind; label: string }[] = [
-  { value: "llm", label: "LLM" },
-  { value: "embedding", label: "Embedding" },
-  { value: "rerank", label: "Rerank" },
-];
 
 export default function ModelsPage() {
   const [loading, setLoading] = useState(true);
@@ -460,6 +445,11 @@ export default function ModelsPage() {
                           {isConfigured ? "Edit" : "Setup"}
                         </button>
                       </div>
+                      <VendorModelsDisclosure
+                        vendor={vc.value}
+                        vendorLabel={vc.label}
+                        models={registeredModels}
+                      />
                     </div>
                   );
                 })}

--- a/apps/negentropy-ui/components/admin/VendorModelsDisclosure.tsx
+++ b/apps/negentropy-ui/components/admin/VendorModelsDisclosure.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  MODEL_KINDS,
+  type ModelConfigRecord,
+  type ModelKind,
+} from "@/types/admin-models";
+import { cn } from "@/lib/utils";
+
+interface VendorModelsDisclosureProps {
+  vendor: string;
+  vendorLabel?: string;
+  models: ModelConfigRecord[];
+}
+
+export function VendorModelsDisclosure({
+  vendor,
+  vendorLabel,
+  models,
+}: VendorModelsDisclosureProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const grouped = useMemo(() => {
+    const map = new Map<ModelKind, ModelConfigRecord[]>();
+    for (const mk of MODEL_KINDS) {
+      map.set(mk.value, []);
+    }
+    for (const record of models) {
+      if (record.vendor !== vendor) continue;
+      if (!record.enabled) continue;
+      map.get(record.model_type)?.push(record);
+    }
+    return map;
+  }, [models, vendor]);
+
+  const total = useMemo(() => {
+    let sum = 0;
+    for (const list of grouped.values()) sum += list.length;
+    return sum;
+  }, [grouped]);
+
+  if (total === 0) return null;
+
+  const contentId = `vendor-models-${vendor}`;
+  const ariaLabel = vendorLabel
+    ? `${vendorLabel} 已启用模型`
+    : "已启用模型";
+
+  return (
+    <div className="mt-3 border-t border-zinc-200/70 pt-2 dark:border-zinc-800">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        aria-label={ariaLabel}
+        className={cn(
+          "group flex w-full items-center justify-between gap-2 rounded-md px-1.5 py-1",
+          "text-[11px] font-medium text-zinc-600 transition-colors",
+          "hover:bg-zinc-50 dark:text-zinc-400 dark:hover:bg-zinc-800/60",
+        )}
+      >
+        <span className="inline-flex items-center gap-1.5">
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "h-3.5 w-3.5 text-zinc-400 transition-transform duration-150",
+              expanded && "rotate-180",
+            )}
+          />
+          <span>{expanded ? "收起" : "查看已启用模型"}</span>
+        </span>
+        <span className="rounded-full bg-zinc-100 px-1.5 py-0.5 text-[10px] font-semibold text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+          {total}
+        </span>
+      </button>
+
+      {expanded ? (
+        <div id={contentId} className="mt-2 space-y-3">
+          {MODEL_KINDS.map((mk) => {
+            const items = grouped.get(mk.value) ?? [];
+            if (items.length === 0) return null;
+            return (
+              <section key={mk.value} className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <div className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+                    {mk.label}
+                  </div>
+                  <div className="text-[10px] text-zinc-400 dark:text-zinc-500">
+                    {items.length}
+                  </div>
+                </div>
+                <ul className="space-y-1">
+                  {items.map((mc) => (
+                    <li
+                      key={mc.id}
+                      className="flex items-center gap-2 rounded border border-zinc-100 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                    >
+                      <span className="flex-1 min-w-0 truncate font-medium text-zinc-800 dark:text-zinc-200">
+                        {mc.display_name}
+                        <span className="ml-1 font-normal text-zinc-400">
+                          {mc.model_name}
+                        </span>
+                      </span>
+                      {mk.value === "embedding" && mc.config?.dimensions != null ? (
+                        <span className="shrink-0 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                          {String(mc.config.dimensions)} dims
+                        </span>
+                      ) : null}
+                      {mc.is_default ? (
+                        <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                          Default
+                        </span>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/tests/unit/admin/VendorModelsDisclosure.test.tsx
+++ b/apps/negentropy-ui/tests/unit/admin/VendorModelsDisclosure.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { VendorModelsDisclosure } from "@/components/admin/VendorModelsDisclosure";
+import type { ModelConfigRecord } from "@/types/admin-models";
+
+function makeModel(overrides: Partial<ModelConfigRecord> = {}): ModelConfigRecord {
+  return {
+    id: overrides.id ?? "m-1",
+    model_type: overrides.model_type ?? "llm",
+    display_name: overrides.display_name ?? "GPT-4o",
+    vendor: overrides.vendor ?? "openai",
+    model_name: overrides.model_name ?? "gpt-4o",
+    is_default: overrides.is_default ?? false,
+    enabled: overrides.enabled ?? true,
+    config: overrides.config ?? {},
+  };
+}
+
+describe("VendorModelsDisclosure", () => {
+  it("该 vendor 无已启用模型时完全不渲染", () => {
+    const { container } = render(
+      <VendorModelsDisclosure
+        vendor="anthropic"
+        vendorLabel="Anthropic"
+        models={[makeModel({ vendor: "openai", model_type: "llm" })]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("存在已启用模型时默认收起并展示总数", () => {
+    render(
+      <VendorModelsDisclosure
+        vendor="openai"
+        vendorLabel="OpenAI"
+        models={[
+          makeModel({ id: "a", model_type: "llm", display_name: "GPT-4o" }),
+          makeModel({ id: "b", model_type: "embedding", display_name: "TextEmb3" }),
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /OpenAI 已启用模型/ });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("GPT-4o")).not.toBeInTheDocument();
+  });
+
+  it("点击后展开，仅渲染非空分组", async () => {
+    const user = userEvent.setup();
+    render(
+      <VendorModelsDisclosure
+        vendor="openai"
+        vendorLabel="OpenAI"
+        models={[
+          makeModel({ id: "a", model_type: "llm", display_name: "GPT-4o" }),
+          makeModel({ id: "b", model_type: "embedding", display_name: "TextEmb3" }),
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /OpenAI 已启用模型/ });
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    expect(screen.getByText("LLM")).toBeInTheDocument();
+    expect(screen.getByText("Embedding")).toBeInTheDocument();
+    expect(screen.queryByText("Rerank")).not.toBeInTheDocument();
+
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.getByText("TextEmb3")).toBeInTheDocument();
+  });
+
+  it("过滤掉 enabled=false 与其他 vendor 的条目", async () => {
+    const user = userEvent.setup();
+    render(
+      <VendorModelsDisclosure
+        vendor="openai"
+        vendorLabel="OpenAI"
+        models={[
+          makeModel({ id: "keep", model_type: "llm", display_name: "GPT-4o" }),
+          makeModel({
+            id: "disabled",
+            model_type: "llm",
+            display_name: "GPT-3.5",
+            enabled: false,
+          }),
+          makeModel({
+            id: "other-vendor",
+            vendor: "anthropic",
+            model_type: "llm",
+            display_name: "Claude-4",
+          }),
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /OpenAI 已启用模型/ });
+    await user.click(trigger);
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    expect(screen.queryByText("GPT-3.5")).not.toBeInTheDocument();
+    expect(screen.queryByText("Claude-4")).not.toBeInTheDocument();
+    expect(trigger).toHaveTextContent("1");
+  });
+
+  it("默认模型显示 Default 徽章；embedding 含 dimensions 时显示维度徽章", async () => {
+    const user = userEvent.setup();
+    render(
+      <VendorModelsDisclosure
+        vendor="openai"
+        models={[
+          makeModel({
+            id: "def",
+            model_type: "llm",
+            display_name: "GPT-4o",
+            is_default: true,
+          }),
+          makeModel({
+            id: "emb",
+            model_type: "embedding",
+            display_name: "TextEmb3",
+            config: { dimensions: 1536 },
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /已启用模型/ }));
+    expect(screen.getByText("Default")).toBeInTheDocument();
+    expect(screen.getByText("1536 dims")).toBeInTheDocument();
+  });
+
+  it("aria-controls 与展开区 id 对应", async () => {
+    const user = userEvent.setup();
+    render(
+      <VendorModelsDisclosure
+        vendor="gemini"
+        models={[makeModel({ vendor: "gemini", model_type: "llm" })]}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: /已启用模型/ });
+    expect(trigger).toHaveAttribute("aria-controls", "vendor-models-gemini");
+
+    await user.click(trigger);
+    const region = document.getElementById("vendor-models-gemini");
+    expect(region).not.toBeNull();
+  });
+});

--- a/apps/negentropy-ui/types/admin-models.ts
+++ b/apps/negentropy-ui/types/admin-models.ts
@@ -1,0 +1,20 @@
+export type ModelKind = "llm" | "embedding" | "rerank";
+
+export interface ModelConfigRecord {
+  id: string;
+  model_type: ModelKind;
+  display_name: string;
+  vendor: string;
+  model_name: string;
+  is_default: boolean;
+  enabled: boolean;
+  config: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export const MODEL_KINDS: { value: ModelKind; label: string }[] = [
+  { value: "llm", label: "LLM" },
+  { value: "embedding", label: "Embedding" },
+  { value: "rerank", label: "Rerank" },
+];


### PR DESCRIPTION
## 背景与动机

Admin / Models 页的 Vendor 凭据卡片（OpenAI / Anthropic / Gemini）当前仅显示凭据状态与 Setup/Edit 入口。管理员需打开 Setup 对话框才能确认某 vendor 下实际已启用的 LLM / Embedding / Rerank 模型，存在明显的信息检索熵。

本 PR 引入经典 **Progressive Disclosure**（渐进式披露，Nielsen Norman, 2006）范式：在每张 Vendor 卡片底部加入一个「ChevronDown + 计数徽章」的折叠入口，展开后按类型分组展示该 vendor 下 `enabled=true` 的模型列表；空分组不渲染，三类全空时折叠入口整体不渲染。

## 主要变更

- 新增组件 `components/admin/VendorModelsDisclosure.tsx`：纯展示组件，按 `vendor + enabled` 过滤 `registeredModels`，按 `MODEL_KINDS` 分组；默认收起，`aria-expanded` / `aria-controls` 支持键盘与屏幕阅读器；Default 条目显示琥珀徽章，Embedding 条目若 `config.dimensions` 存在显示维度徽章。
- 抽取类型 `types/admin-models.ts`（`ModelKind` / `ModelConfigRecord` / `MODEL_KINDS`），作为跨文件的单一事实源（SSOT）。
- `app/admin/models/page.tsx` 引用共享类型并在 Vendor 卡片内嵌入新组件；不改动任何现有网络请求、状态或交互回调。
- 新增 Vitest 单元测试 `tests/unit/admin/VendorModelsDisclosure.test.tsx`，覆盖空态 / 默认收起 / 展开分组 / enabled+vendor 过滤 / Default & dimensions 徽章 / aria-controls 映射。
- `.gitignore` 追加 `.playwright-mcp/`，屏蔽 Playwright MCP 调试产物。

## 设计要点

- **Disclosure Pattern**：独立折叠、可多卡同时展开，不走 Accordion 互斥；
- **最小干预**：复用已存在的 `registeredModels` 状态，不新增 API；
- **正交分解**：披露状态与分组渲染封装在新组件内，避免进一步膨胀 800+ 行的 `page.tsx`；
- **视觉一致**：样式对齐 Setup 对话框内「Registered Models」列表；
- **无新增依赖**：仅使用仓库既有的 `lucide-react`，不引入 Radix / shadcn / 动画库。

## 验证

- `pnpm typecheck`、`pnpm lint --max-warnings=0`、`pnpm test` 全部通过；
- Next.js dev server `✓ Ready`，无编译错误；
- 新增单测 6 个均通过，既有测试无回归。

## 非目标

- 不做删除 / 编辑操作（仍走 Setup 对话框）；不引入 i18n 框架；不改动后端 API / 数据模型。

## 参考

[1] J. Nielsen, "Progressive disclosure," _Nielsen Norman Group_, Dec. 2006. [Online]. Available: https://www.nngroup.com/articles/progressive-disclosure/