### PR TITLE
chore(mcp-negentropy-perceives): 将预置 Negentropy Perceives 端口迁移为 2992

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py
@@ -46,7 +46,7 @@ def upgrade() -> None:
             NULL,
             '[]'::jsonb,
             '{}'::jsonb,
-            'http://localhost:8092/mcp',
+            'http://localhost:2992/mcp',
             '{}'::jsonb,
             TRUE,
             TRUE,

--- a/apps/negentropy/tests/integration_tests/db/test_migrations.py
+++ b/apps/negentropy/tests/integration_tests/db/test_migrations.py
@@ -93,7 +93,7 @@ def test_negentropy_perceives_seeded_by_migration(alembic_config: Config):
         "图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
     )
     assert row["transport_type"] == "http"
-    assert row["url"] == "http://localhost:8092/mcp"
+    assert row["url"] == "http://localhost:2992/mcp"
     assert row["is_enabled"] is True
     assert row["auto_start"] is True
 
@@ -175,6 +175,6 @@ def test_negentropy_perceives_seed_is_idempotent_on_re_upgrade(alembic_config: C
         "一款商用级 MCP Server，能够从网页和 PDF 文件中精准提取包括文本、"
         "图片、表格、公式等内容，并将之转换为与源文档编排格式一致的 Markdown 文档。"
     )
-    assert row["url"] == "http://localhost:8092/mcp"
+    assert row["url"] == "http://localhost:2992/mcp"
     assert row["is_enabled"] is True
     assert row["auto_start"] is True


### PR DESCRIPTION
## 背景与动因

将通过 Alembic 预插入脚本（迁移 \`0002_seed_negentropy_perceives\`）注册的预置 MCP **Negentropy Perceives** 的端口，由旧值 \`8092\` 统一迁移为新值 \`2992\`，并要求全仓彻底替换、无字面量残留。

迁移的 seed 本身采用 \`INSERT ... ON CONFLICT (name) DO UPDATE\` 幂等契约，因此新老部署都能在一次 \`alembic upgrade head\` 内收敛到新端口，无需任何额外手动脚本。

## 变更摘要

- **迁移 seed（权威源）**：\`apps/negentropy/src/negentropy/db/migrations/versions/0002_seed_negentropy_perceives.py\` 中 \`url\` 字段改为 \`http://localhost:2992/mcp\`。
- **迁移集成测试**：\`apps/negentropy/tests/integration_tests/db/test_migrations.py\` 中 \`test_negentropy_perceives_seeded_by_migration\` 与 \`test_negentropy_perceives_seed_is_idempotent_on_re_upgrade\` 两条用例的 URL 断言同步为 \`http://localhost:2992/mcp\`。

## 改动范围（影响面盘点）

全仓 \`rg -n "8092" apps/negentropy\` 改动前唯 3 处命中：

| 路径 | 角色 |
|------|------|
| \`…/0002_seed_negentropy_perceives.py:49\` | 迁移 seed 的权威 URL |
| \`…/test_migrations.py:96\` | 迁移断言（首次 seed 场景） |
| \`…/test_migrations.py:178\` | 迁移断言（downgrade → re-upgrade 幂等场景） |

其余所有引用均经由服务名 \`negentropy-perceives\` 而非端口字面量访问，与本 PR 正交，无需修改。\`2992\` 改前在仓库其它位置未被占用，无冲突。

## 二阶影响分析

- **新部署**：首次 \`alembic upgrade head\` 即以 \`2992\` 落库；
- **既有部署**：seed 的 \`ON CONFLICT (name) DO UPDATE\` 分支会在下一次升级通路上把 \`url\` 自愈为 \`2992\`，符合迁移文件注释中 "既有部署如被手动污染，也会在任意升级通路上被幂等自愈回归预置" 的既有契约，不引入新的覆盖语义；
- **消费者侧**：知识抽取等下游通过服务名解析 URL，端口变更对上游代码透明，无 API 面变更。

## 验证

- \`rg -n "8092" apps/negentropy\` 改后无任何代码/配置命中（\`uv.lock\` 中 hash 片段的偶然匹配与端口无关）；
- \`rg -n "2992" apps/negentropy\` 命中预期 3 处；
- Python AST 语法校验通过；
- \`git diff --stat\` 显示仅 2 个文件、3 行变更。
- 集成测试需要实际 Postgres 环境，建议在具备基础设施的 CI/本地环境复跑：\`cd apps/negentropy && uv run pytest tests/integration_tests/db/test_migrations.py -v\`。

## 合规说明

遵循 AGENTS.md：最小干预、单一事实源、二阶思维。Commit 通过 \`/commit\` 规范；基于工作分支 \`vk/f96f-mcp-negentropy-p\` 创建 PR，未直接推送主干。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)