### PR TITLE
fix(models): 卡片展开时同行卡片高度不再被拉伸

### DIFF
--- a/apps/negentropy-ui/app/interface/models/page.tsx
+++ b/apps/negentropy-ui/app/interface/models/page.tsx
@@ -438,7 +438,7 @@ export default function ModelsPage() {
                   </p>
                 </div>
               </div>
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-3 items-start gap-4">
                 {VENDOR_SETUP_CONFIG.map((vc) => {
                   const config = vendorConfigs.find((c) => c.vendor === vc.value);
                   const isConfigured = config?.configured ?? false;


### PR DESCRIPTION
## Summary

- 修复 Models 页 vendor 卡片在 CSS Grid 布局中展开时，同行卡片高度被错误拉伸的问题
- 在 grid 容器上添加 `items-start`，使每个卡片仅占据自身内容所需高度

## Test plan

- [ ] 访问 Models 页面，展开任一 vendor 卡片的模型列表
- [ ] 确认同行其他卡片高度保持不变，仅展开的卡片高度增加
- [ ] 折叠后再次展开其他卡片，确认行为一致
- [ ] 确认卡片折叠状态下的样式无回归

🤖 Generated with [Claude Code](https://github.com/claude)