### PR TITLE
fix(pipeline-runs): 修复 Pipeline Runs 延迟可见性问题

### DIFF
--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -120,7 +120,6 @@ export default function KnowledgeDashboardPage() {
   useEffect(() => {
     if (!hasInitialLoad) return;
     if (page !== 1) return;
-    if (hasRunningRuns(pipelinesPayload?.runs)) return;
 
     let active = true;
     let tick = 0;

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -39,12 +39,9 @@ from .exceptions import (
     VersionConflict,
 )
 from .extraction import (
-    ROUTE_URL,
-    build_url_document_filename,
     extract_source,
     get_chunking_config_only,
     merge_corpus_config,
-    persist_extracted_assets,
     resolve_source_kind,
     store_extracted_document_artifacts,
 )
@@ -1005,55 +1002,8 @@ async def ingest_url(
             corpus_config=corpus_config,
         )
 
-        # URL 文档模式: 先落库为 Document，再异步入索引
+        # URL 文档模式: 先创建 Pipeline 记录，提取和存储全部在后台完成
         if payload.as_document:
-            from negentropy.storage.service import DocumentStorageService
-
-            extraction_result = await extract_source(
-                app_name=resolved_app,
-                corpus_id=corpus_id,
-                corpus_config=corpus_config,
-                source_kind=ROUTE_URL,
-                url=payload.url,
-            )
-            markdown_text = extraction_result.markdown_content
-            if not markdown_text:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail={"code": "EMPTY_CONTENT", "message": "No content extracted from URL"},
-                )
-
-            raw_name = build_url_document_filename(payload.url)
-            markdown_bytes = markdown_text.encode("utf-8")
-
-            storage_service = DocumentStorageService()
-            doc_record, is_new_doc = await storage_service.upload_and_store(
-                corpus_id=corpus_id,
-                app_name=resolved_app,
-                content=markdown_bytes,
-                filename=raw_name,
-                content_type="text/markdown",
-                metadata={"source_type": "url", "origin_url": payload.url},
-                created_by=user.user_id if user else None,
-            )
-            await storage_service.save_markdown_content(
-                document_id=doc_record.id,
-                markdown_content=markdown_text,
-                markdown_gcs_uri=doc_record.gcs_uri,
-            )
-            stored_assets = await persist_extracted_assets(
-                document_id=doc_record.id,
-                assets=extraction_result.assets,
-            )
-
-            meta = normalize_source_metadata(source_uri=payload.url, metadata=payload.metadata)
-            meta["source_type"] = "url"
-            meta["origin_url"] = payload.url
-            meta["document_id"] = str(doc_record.id)
-            meta["extractor_trace"] = extraction_result.trace
-            if stored_assets:
-                meta["extracted_assets"] = stored_assets
-
             run_id = await service.create_pipeline(
                 app_name=resolved_app,
                 operation="ingest_url",
@@ -1061,35 +1011,30 @@ async def ingest_url(
                     "corpus_id": str(corpus_id),
                     "url": payload.url,
                     "as_document": True,
-                    "document_id": str(doc_record.id),
-                    "duplicate_document": not is_new_doc,
                     "chunking_config": chunking_config_summary(chunking_config),
                 },
             )
 
             background_tasks.add_task(
-                service.execute_ingest_text_pipeline,
+                service.execute_ingest_url_document_pipeline,
                 run_id=run_id,
                 corpus_id=corpus_id,
                 app_name=resolved_app,
-                text=extraction_result.plain_text,
-                source_uri=payload.url,
-                metadata=meta,
+                url=payload.url,
                 chunking_config=chunking_config,
+                user_id=user.user_id if user else None,
             )
 
             logger.info(
                 "api_ingest_url_document_queued",
                 corpus_id=str(corpus_id),
                 run_id=run_id,
-                document_id=str(doc_record.id),
-                duplicate_document=not is_new_doc,
             )
 
             return AsyncPipelineResponse(
                 run_id=run_id,
                 status="running",
-                message=f"URL ingest task started (document_id={doc_record.id}). Check Pipeline page for progress.",
+                message="URL ingest task started. Check Pipeline page for progress.",
             )
 
         # 默认 URL 摄取模式: 与旧逻辑一致
@@ -2221,35 +2166,10 @@ async def sync_document(
 
     service = _get_service()
     corpus = await service.get_corpus_by_id(corpus_id)
-    extraction_result = await extract_source(
-        app_name=resolved_app,
-        corpus_id=corpus_id,
-        corpus_config=corpus.config if corpus else {},
-        source_kind=ROUTE_URL,
-        url=source_uri,
-    )
-    markdown_text = extraction_result.markdown_content
-    if not markdown_text:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"code": "EMPTY_CONTENT", "message": "No content extracted from URL"},
-        )
-
-    _, stored_assets = await store_extracted_document_artifacts(
-        document_id=document_id,
-        extracted=extraction_result,
-    )
     chunking_config = _resolve_chunking_config_from_doc_request(
         payload=payload,
         corpus_config=corpus.config if corpus else {},
     )
-    metadata = normalize_source_metadata(
-        source_uri=source_uri,
-        metadata={"source_type": "url", "origin_url": source_uri, "document_id": str(document_id)},
-    )
-    metadata["extractor_trace"] = extraction_result.trace
-    if stored_assets:
-        metadata["extracted_assets"] = stored_assets
     run_id = await service.create_pipeline(
         app_name=resolved_app,
         operation="replace_source",
@@ -2262,13 +2182,12 @@ async def sync_document(
         },
     )
     background_tasks.add_task(
-        service.execute_replace_source_pipeline,
+        service.execute_sync_document_pipeline,
         run_id=run_id,
         corpus_id=corpus_id,
         app_name=resolved_app,
-        text=extraction_result.plain_text,
+        document_id=document_id,
         source_uri=source_uri,
-        metadata=metadata,
         chunking_config=chunking_config,
     )
     return AsyncPipelineResponse(

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -694,6 +694,141 @@ class KnowledgeService:
             # 后台任务中的 re-raise 会导致 uvicorn 打印完整异常堆栈。
             return []
 
+    async def execute_ingest_url_document_pipeline(
+        self,
+        *,
+        run_id: str,
+        corpus_id: UUID,
+        app_name: str,
+        url: str,
+        chunking_config: ChunkingConfig | None = None,
+        user_id: str | None = None,
+    ) -> list[KnowledgeRecord]:
+        """执行 ingest_url (as_document=True) Pipeline（后台任务）
+
+        将 URL 提取、文档存储、分块和向量化全部在后台完成。
+        Pipeline 记录在 API 层已提前创建，此处 resume 后继续执行。
+        """
+        if not self._pipeline_dao:
+            raise ValueError("pipeline_dao is required for async pipeline operations")
+
+        tracker = PipelineTracker(
+            dao=self._pipeline_dao,
+            app_name=app_name,
+            operation="ingest_url",
+            run_id=run_id,
+        )
+        await self._resume_async_pipeline_tracker(tracker)
+
+        logger.info(
+            "pipeline_execution_started",
+            run_id=run_id,
+            corpus_id=str(corpus_id),
+            operation="ingest_url",
+            url=url,
+            as_document=True,
+        )
+
+        try:
+            # Stage 1: 提取 URL 内容
+            try:
+                text, extraction_result = await self._extract_url_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    url=url,
+                    tracker=tracker,
+                )
+            except ValueError as exc:
+                from .exceptions import KnowledgeError
+                from .extraction import ExtractorExecutionError
+
+                url_details: dict[str, Any] = {}
+                if isinstance(exc, ExtractorExecutionError) and not exc.attempts:
+                    url_details["failure_category"] = "no_extractor_configured"
+                    url_details["diagnostic_summary"] = (
+                        "请配置 Negentropy Perceives MCP 服务，并确保 Corpus 的 extractor_routes 配置正确。"
+                    )
+                raise KnowledgeError(
+                    code="CONTENT_FETCH_FAILED",
+                    message=f"Failed to fetch content from URL: {exc}",
+                    details=url_details or None,
+                ) from exc
+
+            if not text:
+                raise ValueError("No content extracted from URL")
+
+            # Stage 2: 文档存储
+            await tracker.start_stage("document_store")
+            from negentropy.storage.service import DocumentStorageService
+
+            from .extraction import build_url_document_filename, persist_extracted_assets
+
+            storage_service = DocumentStorageService()
+            raw_name = build_url_document_filename(url)
+            markdown_bytes = extraction_result.markdown_content.encode("utf-8")
+            doc_record, is_new_doc = await storage_service.upload_and_store(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                content=markdown_bytes,
+                filename=raw_name,
+                content_type="text/markdown",
+                metadata={"source_type": "url", "origin_url": url},
+                created_by=user_id,
+            )
+            await storage_service.save_markdown_content(
+                document_id=doc_record.id,
+                markdown_content=extraction_result.markdown_content,
+                markdown_gcs_uri=doc_record.gcs_uri,
+            )
+            stored_assets = await persist_extracted_assets(
+                document_id=doc_record.id,
+                assets=extraction_result.assets,
+                tracker=tracker,
+            )
+            await tracker.complete_stage(
+                "document_store",
+                {
+                    "document_id": str(doc_record.id),
+                    "duplicate_document": not is_new_doc,
+                    "stored_assets": len(stored_assets) if stored_assets else 0,
+                },
+            )
+
+            # Stage 3: 分块 + 向量化
+            meta = normalize_source_metadata(source_uri=url, metadata=None)
+            meta["source_type"] = "url"
+            meta["origin_url"] = url
+            meta["document_id"] = str(doc_record.id)
+            meta["extractor_trace"] = extraction_result.trace
+            if stored_assets:
+                meta["extracted_assets"] = stored_assets
+
+            records = await self._ingest_text_with_tracker(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                text=text,
+                source_uri=url,
+                metadata=meta,
+                chunking_config=chunking_config or self._chunking_config,
+                tracker=tracker,
+            )
+            await tracker.complete({"chunk_count": len(records), "document_id": str(doc_record.id)})
+
+            logger.info(
+                "pipeline_execution_completed",
+                run_id=run_id,
+                corpus_id=str(corpus_id),
+                record_count=len(records),
+                document_id=str(doc_record.id),
+                operation="ingest_url",
+                as_document=True,
+            )
+            return records
+
+        except Exception as exc:
+            await self._fail_pipeline_execution(tracker, exc)
+            return []
+
     async def execute_ingest_file_pipeline(
         self,
         *,
@@ -995,6 +1130,129 @@ class KnowledgeService:
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             raise
+
+    async def execute_sync_document_pipeline(
+        self,
+        *,
+        run_id: str,
+        corpus_id: UUID,
+        app_name: str,
+        document_id: UUID,
+        source_uri: str,
+        chunking_config: ChunkingConfig | None = None,
+    ) -> list[KnowledgeRecord]:
+        """执行 sync_document Pipeline（后台任务）
+
+        在后台完成 URL 重新提取、Markdown 存储和索引替换。
+        Pipeline 记录在 API 层已提前创建，此处 resume 后继续执行。
+        """
+        if not self._pipeline_dao:
+            raise ValueError("pipeline_dao is required for async pipeline operations")
+
+        tracker = PipelineTracker(
+            dao=self._pipeline_dao,
+            app_name=app_name,
+            operation="replace_source",
+            run_id=run_id,
+        )
+        await self._resume_async_pipeline_tracker(tracker)
+
+        logger.info(
+            "pipeline_execution_started",
+            run_id=run_id,
+            corpus_id=str(corpus_id),
+            operation="sync_document",
+            source_uri=source_uri,
+            document_id=str(document_id),
+        )
+
+        try:
+            # Stage 1: 从 URL 重新提取内容
+            try:
+                text, extraction_result = await self._extract_url_content(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    url=source_uri,
+                    tracker=tracker,
+                )
+            except ValueError as exc:
+                from .exceptions import KnowledgeError
+                from .extraction import ExtractorExecutionError
+
+                url_details: dict[str, Any] = {}
+                if isinstance(exc, ExtractorExecutionError) and not exc.attempts:
+                    url_details["failure_category"] = "no_extractor_configured"
+                    url_details["diagnostic_summary"] = (
+                        "请配置 Negentropy Perceives MCP 服务，并确保 Corpus 的 extractor_routes 配置正确。"
+                    )
+                raise KnowledgeError(
+                    code="CONTENT_FETCH_FAILED",
+                    message=f"Failed to fetch content from URL: {exc}",
+                    details=url_details or None,
+                ) from exc
+
+            if not text:
+                raise ValueError("No content extracted from URL during sync")
+
+            # Stage 2: 保存 Markdown 和资产
+            await tracker.start_stage("markdown_store")
+            from .extraction import store_extracted_document_artifacts
+
+            _, stored_assets = await store_extracted_document_artifacts(
+                document_id=document_id,
+                extracted=extraction_result,
+                tracker=tracker,
+            )
+            await tracker.complete_stage(
+                "markdown_store",
+                {
+                    "document_id": str(document_id),
+                    "markdown_length": len(extraction_result.markdown_content),
+                    "stored_assets": len(stored_assets) if stored_assets else 0,
+                },
+            )
+
+            # Stage 3: 删除旧知识记录
+            await tracker.start_stage("delete")
+            deleted_count = await self._repository.delete_knowledge_by_source(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                source_uri=source_uri,
+            )
+            await tracker.complete_stage("delete", {"deleted_count": deleted_count})
+
+            # Stage 4+: 分块 + 向量化
+            meta = normalize_source_metadata(
+                source_uri=source_uri,
+                metadata={"source_type": "url", "origin_url": source_uri, "document_id": str(document_id)},
+            )
+            meta["extractor_trace"] = extraction_result.trace
+            if stored_assets:
+                meta["extracted_assets"] = stored_assets
+
+            records = await self._ingest_text_with_tracker(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                text=text,
+                source_uri=source_uri,
+                metadata=meta,
+                chunking_config=chunking_config or self._chunking_config,
+                tracker=tracker,
+            )
+            await tracker.complete({"deleted_count": deleted_count, "chunk_count": len(records)})
+
+            logger.info(
+                "pipeline_execution_completed",
+                run_id=run_id,
+                corpus_id=str(corpus_id),
+                record_count=len(records),
+                operation="sync_document",
+            )
+            return records
+
+        except Exception as exc:
+            await self._fail_pipeline_execution(tracker, exc)
+            return []
 
     async def execute_rebuild_source_pipeline(
         self,


### PR DESCRIPTION
## Summary

- **根本原因**：`ingest_url`（as_document 模式）和 `sync_document` 端点在调用 `create_pipeline()` 之前执行了耗时的同步操作（URL 提取、文档存储等），导致 Pipeline Run 记录在数据库中不存在，Dashboard 轮询无法发现新任务
- **后端修复**：将 `ingest_url`（as_document）和 `sync_document` 中的耗时同步操作移至后台任务，确保 Pipeline Run 记录在 API 返回时即已创建
  - 新增 `execute_ingest_url_document_pipeline()`：在后台完成 URL 提取 → 文档存储 → Markdown 持久化 → 分块向量化
  - 新增 `execute_sync_document_pipeline()`：在后台完成 URL 重新提取 → Markdown 存储 → 删除旧记录 → 重新索引
  - 包含完整的 `ValueError → KnowledgeError` 异常包装（提供 MCP 配置诊断提示）
- **前端修复**：移除 Bootstrap Polling 中 `hasRunningRuns` 的提前返回条件，确保并发场景下新 Run 也能被快速检测
- **PDF 摄入**：经验证 `ingest_file` 已遵循正确的 pipeline 创建模式（GCS 上传是必要的同步操作，pipeline 在其之后立即创建），无需改动

## Test plan

- [ ] WebPage Ingest：创建 URL 摄入任务 → 立即切换到 Dashboard → Pipeline Run 应在 1-2 秒内出现
- [ ] Sync：对已有 URL 文档执行 Sync → 立即切换到 Dashboard → Pipeline Run 应立即可见
- [ ] PDF Ingest：上传 PDF 文件 → 切换到 Dashboard → Pipeline Run 应在 1-2 秒内出现
- [ ] 错误场景：提交一个无效 URL → Dashboard 中应显示 Pipeline Run 为 "failed" 状态
- [ ] 并发场景：启动一个 Ingest → 在其运行期间启动另一个 → 两个 Run 都应被 Bootstrap Polling 快速检测到
- [ ] 前端 Bootstrap Polling：验证有 running Run 时新增 Run 也能被快速检测

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)