### PR TITLE
refactor(backend-url): 彻底清除 6600/6666 历史端口守护与残留

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - 删除 `engine/bootstrap.py` 中 `NE_API_KEY → ZAI_API_KEY` 的环境变量映射；
   - 删除 `config/model_resolver.py` 中针对 ZAI vendor 的 thinking 处理分支；
   - `model_names.canonicalize_model_name()` 下线 GLM→zai 特化规则，退化为通用幂等 no-op（保留函数签名以维持上游调用正交性）。
+- 彻底删除 `apps/negentropy-ui/lib/server/backend-url.ts` 的「历史端口迁移守护」（`LEGACY_LOCAL_PORTS` / `applyLegacyPortMigration` / `isLegacyLocalhostUrl` / `__resetLegacyPortWarningsForTests`）及其在 `.env.example`、`docs/development.md`、`tests/unit/lib/server/backend-url.test.ts` 中的关联配对：迁移守护本意为兼容 `:6600` / `:6666` → `:3292` 过渡期，但已完成迁移后继续残留反而构成熵源（让历史端口持续在代码、文档、测试夹具中循环出现，并与运维侧 `.env` 残留互相掩盖，导致「以为 PR 引入端口回退」的误判）。`3292` 为唯一权威端口；若本地 `.env` / `.env.local` 或 Google Cloud Console OAuth 授权重定向 URI 白名单仍残留 `:6600` / `:6666`，请一次性更新至 `:3292`（运维提示已同步进 `docs/sso.md`）。
 
 ### Changed
 

--- a/apps/negentropy-ui/.env.example
+++ b/apps/negentropy-ui/.env.example
@@ -5,8 +5,6 @@
 # 不会被打包进客户端 bundle；带 NEXT_PUBLIC_ 前缀的变量对浏览器可见。
 #
 # 若全部留空，BFF 会自动回落到 http://localhost:3292（与后端默认端口对齐）。
-# 若检测到历史端口（如 :6600 / :6666）且 NODE_ENV !== "production"，
-# BFF 会在 server log 打印一次迁移告警，并将端口改写为 :3292。
 
 # ---------- 服务端（Route Handler 可见） ----------
 # AGUI / 通用数据面后端基址

--- a/apps/negentropy-ui/lib/server/backend-url.ts
+++ b/apps/negentropy-ui/lib/server/backend-url.ts
@@ -3,69 +3,13 @@
  *
  * 所有 Next.js Route Handler 统一通过 getAguiBaseUrl / getAuthBaseUrl /
  * getKnowledgeBaseUrl / getMemoryBaseUrl 解析后端服务地址，避免多处文件
- * 各自读取 process.env 造成漂移，并内置「遗留端口迁移守护」以保证端口
- * 迁移后的向后兼容。
+ * 各自读取 process.env 造成漂移。
  *
  * 该模块仅应被 app/api/** 下的服务端代码 import，不应出现在任何
  * "use client" 组件中，以免意外被打包进客户端 bundle。
  */
 
 export const DEFAULT_BACKEND_BASE_URL = "http://localhost:3292";
-
-/** 曾经作为后端默认端口、但已在后续迁移中弃用的本地端口列表。 */
-export const LEGACY_LOCAL_PORTS: readonly string[] = ["6600", "6666"];
-
-/** 迁移守护仅对本地环回地址生效。 */
-const LOCAL_HOSTS: readonly string[] = ["localhost", "127.0.0.1", "[::1]"];
-
-/** 当前后端默认监听端口（与 apps/negentropy/src/negentropy/cli.py 对齐）。 */
-const CURRENT_BACKEND_PORT = "3292";
-
-/** 同一 URL 只告警一次，避免每次 BFF 请求都打印导致日志噪音。 */
-const warnedUrls = new Set<string>();
-
-function isLegacyLocalhostUrl(raw: string): { host: string; port: string } | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    return null;
-  }
-  if (!LOCAL_HOSTS.includes(parsed.hostname)) {
-    return null;
-  }
-  if (!parsed.port) {
-    return null;
-  }
-  if (!LEGACY_LOCAL_PORTS.includes(parsed.port)) {
-    return null;
-  }
-  return { host: parsed.hostname, port: parsed.port };
-}
-
-function applyLegacyPortMigration(raw: string, sourceLabel: string): string {
-  const legacy = isLegacyLocalhostUrl(raw);
-  if (!legacy) {
-    return raw;
-  }
-
-  const warnKey = `${sourceLabel}::${raw}`;
-  if (!warnedUrls.has(warnKey)) {
-    warnedUrls.add(warnKey);
-    console.warn(
-      `[backend-url] 检测到 ${sourceLabel}=${raw} 指向已弃用端口 :${legacy.port}；` +
-        `后端已迁移至 :${CURRENT_BACKEND_PORT}。请更新 apps/negentropy-ui/.env.local。`,
-    );
-  }
-
-  if (process.env.NODE_ENV === "production") {
-    return raw;
-  }
-
-  const rewritten = new URL(raw);
-  rewritten.port = CURRENT_BACKEND_PORT;
-  return rewritten.toString().replace(/\/$/, "");
-}
 
 function readEnv(name: string): string | undefined {
   const value = process.env[name];
@@ -74,23 +18,12 @@ function readEnv(name: string): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function pickFirstNonEmpty(
-  candidates: ReadonlyArray<[string, string | undefined]>,
-): { label: string; value: string } | null {
-  for (const [label, value] of candidates) {
-    if (value !== undefined) {
-      return { label, value };
-    }
-  }
-  return null;
-}
-
 function resolveFromEnvChain(envNames: readonly string[]): string {
-  const picked = pickFirstNonEmpty(envNames.map((name) => [name, readEnv(name)] as const));
-  if (!picked) {
-    return DEFAULT_BACKEND_BASE_URL;
+  for (const name of envNames) {
+    const value = readEnv(name);
+    if (value !== undefined) return value;
   }
-  return applyLegacyPortMigration(picked.value, picked.label);
+  return DEFAULT_BACKEND_BASE_URL;
 }
 
 /**
@@ -140,12 +73,4 @@ export function getMemoryBaseUrl(): string {
     "AGUI_BASE_URL",
     "NEXT_PUBLIC_AGUI_BASE_URL",
   ]);
-}
-
-/**
- * 测试专用：清空告警去重缓存。
- * 生产代码请勿调用。
- */
-export function __resetLegacyPortWarningsForTests(): void {
-  warnedUrls.clear();
 }

--- a/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
+++ b/apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts
@@ -1,9 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   DEFAULT_BACKEND_BASE_URL,
-  LEGACY_LOCAL_PORTS,
-  __resetLegacyPortWarningsForTests,
   getAguiBaseUrl,
   getAuthBaseUrl,
   getKnowledgeBaseUrl,
@@ -25,19 +23,12 @@ function clearBackendEnv(): void {
 }
 
 describe("backend-url SSOT helper", () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
     clearBackendEnv();
-    __resetLegacyPortWarningsForTests();
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
     clearBackendEnv();
-    vi.unstubAllEnvs();
-    __resetLegacyPortWarningsForTests();
   });
 
   describe("默认值", () => {
@@ -51,10 +42,6 @@ describe("backend-url SSOT helper", () => {
     it("env 仅包含空白字符时视作未配置并回落默认值", () => {
       process.env.AGUI_BASE_URL = "   ";
       expect(getAguiBaseUrl()).toBe(DEFAULT_BACKEND_BASE_URL);
-    });
-
-    it("LEGACY_LOCAL_PORTS 应包含历史使用过的 6600 与 6666", () => {
-      expect(LEGACY_LOCAL_PORTS).toEqual(expect.arrayContaining(["6600", "6666"]));
     });
   });
 
@@ -99,81 +86,6 @@ describe("backend-url SSOT helper", () => {
       process.env.AGUI_BASE_URL = "http://agui-internal:3292";
       expect(getKnowledgeBaseUrl()).toBe("http://agui-internal:3292");
       expect(getMemoryBaseUrl()).toBe("http://agui-internal:3292");
-    });
-  });
-
-  describe("非 localhost URL 不受迁移守护影响", () => {
-    it("自定义 host + 旧端口不应被改写、不应告警", () => {
-      process.env.AGUI_BASE_URL = "http://backend.example.com:6600";
-      expect(getAguiBaseUrl()).toBe("http://backend.example.com:6600");
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-
-    it("localhost 但端口不在 LEGACY 列表时不应被改写", () => {
-      process.env.AGUI_BASE_URL = "http://localhost:8080";
-      expect(getAguiBaseUrl()).toBe("http://localhost:8080");
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("legacy port 迁移守护（开发模式）", () => {
-    beforeEach(() => {
-      vi.stubEnv("NODE_ENV", "development");
-    });
-
-    it("localhost:6600 应被重写为 :3292 并打印一次迁移告警", () => {
-      process.env.AGUI_BASE_URL = "http://localhost:6600";
-
-      const resolved = getAguiBaseUrl();
-
-      expect(resolved).toBe("http://localhost:3292");
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0]?.[0]).toContain("AGUI_BASE_URL=http://localhost:6600");
-      expect(warnSpy.mock.calls[0]?.[0]).toContain(":6600");
-      expect(warnSpy.mock.calls[0]?.[0]).toContain(":3292");
-    });
-
-    it("127.0.0.1:6666 也应被识别为 legacy 并重写", () => {
-      process.env.AGUI_BASE_URL = "http://127.0.0.1:6666";
-
-      expect(getAguiBaseUrl()).toBe("http://127.0.0.1:3292");
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it("同一 URL 重复调用只告警一次（去重）", () => {
-      process.env.AGUI_BASE_URL = "http://localhost:6600";
-
-      getAguiBaseUrl();
-      getAguiBaseUrl();
-      getAguiBaseUrl();
-
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it("不同 source label 各自独立告警", () => {
-      process.env.AUTH_BASE_URL = "http://localhost:6600";
-      process.env.AGUI_BASE_URL = "http://localhost:6600";
-
-      getAuthBaseUrl();
-      getAguiBaseUrl();
-
-      // AUTH_BASE_URL + AGUI_BASE_URL 两个来源 × 同一 URL => 两次告警
-      expect(warnSpy).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe("legacy port 迁移守护（生产模式）", () => {
-    beforeEach(() => {
-      vi.stubEnv("NODE_ENV", "production");
-    });
-
-    it("localhost:6600 在生产环境仅告警、不改写", () => {
-      process.env.AGUI_BASE_URL = "http://localhost:6600";
-
-      const resolved = getAguiBaseUrl();
-
-      expect(resolved).toBe("http://localhost:6600");
-      expect(warnSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/docs/development.md
+++ b/docs/development.md
@@ -486,8 +486,6 @@ NEXT_PUBLIC_AGUI_APP_NAME=negentropy
 NEXT_PUBLIC_AGUI_USER_ID=dev-user
 ```
 
-> **迁移守护**：若 `AGUI_BASE_URL` 指向历史本地端口（如 `:6600` / `:6666`）且 `NODE_ENV !== "production"`，BFF 会打印一次性迁移告警并将端口重写为 `:3292`；生产环境仅告警、不改写，以便运维显式修复。详见 `apps/negentropy-ui/lib/server/backend-url.ts`。
-
 ### 8.4 安全约束
 
 - 后端配置默认值由 `config.default.yaml` 承载；密钥仅通过 shell 环境变量或 `.env.local` 提供，**严禁**写入 YAML 或仓库

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -59,3 +59,22 @@
 - **同类问题影响**：所有前端 slug/id 生成点（Publication、Entry、Node、Corpus）都需对齐统一字符集。
 
 ---
+
+## ISSUE-005 废弃端口守护成为熵源
+
+- **表因**：用户反馈「Google Auth 回调仍指向 `http://localhost:6600/auth/google/callback`」，怀疑本轮 PR 把后端端口从 `:3292` 回退到 `:6600`。
+- **根因**：项目早期完成 `:6600` / `:6666` → `:3292` 迁移时，为保兼容在 `apps/negentropy-ui/lib/server/backend-url.ts` 引入 `applyLegacyPortMigration()`（localhost 自动改写 + 一次性告警），并在 `.env.example` / `docs/development.md` / `tests/unit/lib/server/backend-url.test.ts` 多处留存「历史端口会被自动迁移」的文案与白名单。迁移已完成数月，守护机制却仍让 `6600` 作为「合法白名单值」持续循环出现，与真正的配置残留（本地 `.env` / Google Cloud Console OAuth 授权重定向 URI 白名单）互相掩盖，形成典型「熵增陷阱」。经 `git log` 取证本轮 PR 的 7 个 commits 均未改动端口/回调/API_BASE 配置——用户看到的 `:6600` 实为环境侧残留，而非代码回退。
+- **处理方式**：
+  1. 彻底删除 `LEGACY_LOCAL_PORTS` / `applyLegacyPortMigration` / `isLegacyLocalhostUrl` / `__resetLegacyPortWarningsForTests` / `LOCAL_HOSTS` / `CURRENT_BACKEND_PORT` / `warnedUrls` 及配套的 `pickFirstNonEmpty` 辅助；`backend-url.ts` 精简为纯 SSOT（约 50 行）；
+  2. 对应测试从 ~180 行精简至 ~95 行，仅保留「默认值」「优先级链」两组用例；
+  3. `.env.example` 删除 2 行迁移守护注释；`docs/development.md` 删除整段「迁移守护」block quote；
+  4. `docs/sso.md` 保留一行运维提示，指引同步更新本地 `.env` 与 Google Cloud Console OAuth 授权重定向 URI 白名单；
+  5. CHANGELOG.md 在 `### Removed` 段落登记，与 Keep a Changelog 语义对齐。
+- **后续防范**：
+  1. 兼容层 / 守护层**必须**附带「退役期」——提前约定「迁移完成 N 版本后强制删除」，避免守护永久化沉淀为熵源；
+  2. 废弃值本身即为熵源，不要以「测试夹具需要断言」为由保留白名单常量；
+  3. 配置迁移完成时，CHANGELOG 须同步登记「守护退役」，而非只记录「迁移完成」；
+  4. 线上故障排查先分清「代码层残留」与「环境层残留」再下判断——前者 `git log` / `git show` 可证伪，后者需检查本地 `.env` 与第三方控制台（Google Cloud Console、Auth0、AWS Cognito 等）。
+- **同类问题影响**：所有「兼容旧值的运行时守护」（legacy API path 兼容、旧协议字段映射、deprecated flag 转译、历史 DB 列回退读取）都应按相同原则审视，不要在完成迁移后继续保留。
+
+---

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -231,6 +231,8 @@ NEXT_PUBLIC_AGUI_BASE_URL=https://<backend-host>
 NEXT_PUBLIC_AGUI_APP_NAME=negentropy
 ```
 
+> **运维提示**：若本地曾使用历史端口（如 `:6600` / `:6666`），升级到 `:3292` 后需同步更新：本地 `.env` / `.env.local` 中的 `NE_AUTH_GOOGLE_REDIRECT_URI`、Google Cloud Console OAuth 客户端的「已授权的重定向 URI」白名单。
+
 ## 9. 安全与运维要点
 
 - **State Token**：用于 OAuth 回调校验，过期时间 `NE_AUTH_STATE_TTL_SECONDS`。


### PR DESCRIPTION
## 变更背景

项目曾于早期完成 `:6600` / `:6666` → `:3292` 的后端端口迁移，当时以「向后兼容」名义在 `apps/negentropy-ui/lib/server/backend-url.ts` 引入了 `applyLegacyPortMigration()` 守护机制，并在 `.env.example`、`docs/development.md`、测试夹具中留存了大量「历史端口会被自动迁移」的文案与白名单常量。

**问题**：迁移已完成数月，守护机制却仍让 `6600` 作为「合法白名单值」在代码、文档、测试夹具中持续循环出现，与运维侧 `.env` / Google Cloud Console OAuth 授权重定向 URI 白名单残留互相掩盖，导致用户误判「PR 引入端口回退（回到 `:6600`）」。经 `git log` 与 `git show` 取证，PR #382 的 7 个 commits 均未改动端口/回调/API_BASE 配置；问题根源是「守护机制本身成为熵源」，而非代码回退。

## 变更内容

按 AGENTS.md「最小干预 + 熵减 + 单一事实源」原则，彻底删除守护机制全部残留，让 `:3292` 成为唯一、无历史包袱的权威端口。

### 代码层清除

| 文件 | 操作 | 变更量 |
|-----|-----|------|
| `apps/negentropy-ui/lib/server/backend-url.ts` | 删除 `LEGACY_LOCAL_PORTS` / `LOCAL_HOSTS` / `CURRENT_BACKEND_PORT` / `warnedUrls` / `isLegacyLocalhostUrl()` / `applyLegacyPortMigration()` / `pickFirstNonEmpty()` / `__resetLegacyPortWarningsForTests()`，保留纯 SSOT 解析逻辑 | 152 行 → 78 行 |
| `apps/negentropy-ui/tests/unit/lib/server/backend-url.test.ts` | 删除 4 个 legacy-port describe 块及相关 import，保留「默认值」「优先级链」共 8 个用例 | 180 行 → 95 行 |
| `apps/negentropy-ui/.env.example` | 删除 2 行历史端口迁移注释 | 小 |

### 文档同步

| 文件 | 操作 |
|-----|-----|
| `docs/development.md` | 删除「**迁移守护**：若 `AGUI_BASE_URL` 指向历史本地端口...」block quote |
| `docs/sso.md` | §8 环境变量表后追加 1 行运维提示，指引同步更新本地 `.env` 与 Google Cloud Console OAuth 授权重定向 URI 白名单 |
| `CHANGELOG.md` | `[Unreleased] ### Removed` 段登记守护退役条目，与 Keep a Changelog 语义对齐 |
| `docs/issue.md` | 追加 ISSUE-005，沉淀「兼容层必须附带退役期」等防范条款 |

## 验证结果

```
pnpm --filter negentropy-ui test tests/unit/lib/server/backend-url.test.ts
→ 8 passed

pnpm --filter negentropy-ui typecheck
→ 0 errors

pnpm --filter negentropy-ui lint
→ 0 warnings

rg '6600|6666|LEGACY_LOCAL_PORTS|applyLegacyPortMigration' apps/ docs/
→ 仅 CHANGELOG.md / docs/sso.md / docs/issue.md 中的历史记录段（解释「为什么删除」）
  及 uv.lock 哈希 / public/logo.svg base64 字面量（均与端口无关）
```

## 运维说明

若本地或 CI 环境仍残留历史端口配置，请手动更新以下位置：

- `.env` / `.env.local`：`AGUI_BASE_URL=http://localhost:3292`
- `NE_AUTH_GOOGLE_REDIRECT_URI=http://localhost:3292/auth/google/callback`
- Google Cloud Console → OAuth 客户端 → 已授权的重定向 URI：替换 `:6600` / `:6666` 为 `:3292`

守护移除后不再自动改写，请一次性更新至唯一权威端口 `:3292`。