### PR TITLE
fix(catalog): 修复目录节点创建时的日志保留字段冲突;

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/catalog_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/catalog_dao.py
@@ -68,7 +68,7 @@ class CatalogDao:
             extra={
                 "id": str(node.id),
                 "corpus_id": str(corpus_id),
-                "name": name,
+                "node_name": name,
                 "slug": slug,
                 "parent_id": str(parent_id) if parent_id else None,
             },

--- a/apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py
@@ -159,6 +159,30 @@ class TestCatalogNodeCrud:
     """CatalogDao 节点 CRUD 方法的单元测试"""
 
     @pytest.mark.asyncio
+    async def test_create_node_logs_with_non_reserved_extra_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """create_node 日志应避免覆写 LogRecord 保留字段。"""
+        corpus_id = uuid4()
+        session = FakeAsyncSessionForCatalog()
+        captured: dict[str, Any] = {}
+
+        def fake_info(event: str, *, extra: dict[str, Any]) -> None:
+            captured["event"] = event
+            captured["extra"] = extra
+
+        monkeypatch.setattr("negentropy.knowledge.catalog_dao.logger.info", fake_info)
+
+        await CatalogDao.create_node(
+            session,
+            corpus_id=corpus_id,
+            name="Root Category",
+            slug="root-category",
+        )
+
+        assert captured["event"] == "catalog_node_created"
+        assert captured["extra"]["node_name"] == "Root Category"
+        assert "name" not in captured["extra"]
+
+    @pytest.mark.asyncio
     async def test_create_node_adds_to_session_and_flushes(self) -> None:
         """create_node 应调用 db.add + db.flush，且节点字段正确设置"""
         corpus_id = uuid4()

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -131,3 +131,21 @@
   3. 对于**被项目代码直接调用**的安全告警（非本次形态），除锁文件升级外还需审计调用点语义是否需要补充 hardening 参数（如本 CVE 的 `follow_symlinks=False`）。
 
 ---
+
+## ISSUE-009 Catalog 创建日志覆写 `LogRecord.name` 导致 500
+
+- **表因**：用户在 `/knowledge/catalog` 创建目录节点时，接口返回 `{"error":{"code":"KNOWLEDGE_UPSTREAM_ERROR","message":"Internal Server Error"}}`，Uvicorn 堆栈落到 `CatalogDao.create_node()` 的 `logger.info("catalog_node_created", extra=...)`。
+- **根因**：`apps/negentropy/src/negentropy/knowledge/catalog_dao.py` 直接使用标准库 `logging.getLogger(...)`，其 `extra` 会写入 `logging.LogRecord`；代码把业务字段 `name` 放进 `extra`，与 `LogRecord.name` 保留属性冲突，Python 直接抛出 `KeyError: "Attempt to overwrite 'name' in LogRecord"`。业务写库本身无误，真正把链路打断的是日志副作用。
+- **处理方式**：
+  1. 保持事件名 `catalog_node_created` 不变，仅将 `extra["name"]` 重命名为 `extra["node_name"]`，避免触碰标准库保留键；
+  2. 在 `apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py` 新增回归测试，断言创建节点时日志上下文字段使用 `node_name`，且不再出现 `name`；
+  3. 维持 DAO / Service / API 其它行为不变，不扩大为整域日志改造。
+- **后续防范**：
+  1. 只要仍在使用 stdlib logging，`extra` 一律禁止使用 `name`、`msg`、`args`、`levelname`、`pathname` 等 `LogRecord` 保留键；
+  2. 结构化日志字段应优先使用业务语义前缀命名，如 `node_name`、`publication_name`、`corpus_name`，避免与 logging 框架元数据碰撞；
+  3. 新增 DAO/Repository 日志时，应配套最小回归测试，优先验证“日志不会破坏主流程”这一非功能性约束。
+- **同类问题影响**：
+  1. `apps/negentropy/src/negentropy/knowledge/wiki_dao.py` 当前也存在 `extra["name"]` 用法，虽然暂未触发用户路径故障，但属于同型风险，后续应并入日志治理专题排查；
+  2. 任何混用 `structlog` 与标准库 `logging` 的模块，都不能假设 `extra` 是“任意字典”，需明确区分框架保留键与业务键。
+
+---


### PR DESCRIPTION
## 变更概述

本 PR 修复了创建 Catalog 节点时接口返回 `KNOWLEDGE_UPSTREAM_ERROR / Internal Server Error` 的问题。

## 修改内容

- 调整 `CatalogDao.create_node()` 的创建成功日志字段命名：
  - 将 `extra["name"]` 改为 `extra["node_name"]`
  - 保持日志事件名 `catalog_node_created` 不变
- 新增 DAO 单元回归测试，验证创建节点时日志上下文字段不再使用 `name`，避免再次触发标准库 logging 保留字段冲突
- 在 `docs/issue.md` 补充 ISSUE-009，沉淀本次问题的表因、根因、处理方式与后续防范

## 修改原因

根据任务上下文，用户在创建 Catalog 时命中后端 500，堆栈定位到：

- `create_catalog_node`
- `CatalogService.create_node`
- `CatalogDao.create_node`

根因不是目录节点创建逻辑本身，而是 DAO 层成功写库后记录日志时，向标准库 `logging` 的 `extra` 传入了 `name` 字段。由于 `name` 是 `LogRecord` 保留属性，Python 会直接抛出：

- `KeyError: "Attempt to overwrite 'name' in LogRecord"`

该异常打断了主流程，最终表现为 Catalog 创建失败。

## 关键实现细节

- 采用最小干预修复，只处理当前故障点，不扩大为整域日志重构
- 不修改 API 契约、数据库 schema 或业务参数，只修正结构化日志字段命名
- 通过单元测试守住“日志不能破坏主流程”的非功能性约束
- `docs/issue.md` 中补充同类问题防范规则，便于后续排查其它使用 stdlib logging 的 DAO/Repository 模块

## 影响范围

- 无公共 API 变更
- 无数据库变更
- 仅影响 Catalog 节点创建成功后的日志字段名：`name` → `node_name`
