### PR TITLE
fix(knowledge): 修复目录文档列表与 wiki 文件名字段漂移;

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3603,7 +3603,7 @@ async def get_document_provenance(
 
     return DocumentProvenanceResponse(
         document_id=document_id,
-        filename=doc.filename or "",
+        filename=doc.original_filename or "",
         file_hash=doc.file_hash or "",
         content_type=doc.content_type,
         status=doc.status or "unknown",
@@ -3905,8 +3905,8 @@ async def get_node_documents(
         items.append(
             {
                 "id": str(doc.id),
-                "filename": doc.filename,
-                "title": (doc.metadata_ or {}).get("title") or doc.filename,
+                "filename": doc.original_filename,
+                "title": (doc.metadata_ or {}).get("title") or doc.original_filename,
                 "status": doc.status,
                 "created_at": doc.created_at.isoformat() if doc.created_at else None,
             }

--- a/apps/negentropy/src/negentropy/knowledge/kg_entity_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/kg_entity_service.py
@@ -91,7 +91,7 @@ class KgEntityService:
                 "kg_entity_updated",
                 extra={
                     "entity_id": str(existing_rec.id),
-                    "name": name,
+                    "entity_name": name,
                     "mention_count": existing_rec.mention_count,
                 },
             )
@@ -128,7 +128,7 @@ class KgEntityService:
             "kg_entity_created",
             extra={
                 "entity_id": str(new_entity.id),
-                "name": name,
+                "entity_name": name,
                 "entity_type": entity_type,
                 "corpus_id": str(corpus_id) if corpus_id else None,
             },

--- a/apps/negentropy/src/negentropy/knowledge/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_dao.py
@@ -64,7 +64,7 @@ class WikiDao:
             extra={
                 "id": str(pub.id),
                 "corpus_id": str(corpus_id),
-                "name": name,
+                "publication_name": name,
                 "slug": slug,
             },
         )
@@ -301,7 +301,7 @@ class WikiDao:
         result = await db.execute(
             select(
                 WikiPublicationEntry.document_id,
-                KnowledgeDocument.filename,
+                KnowledgeDocument.original_filename,
                 KnowledgeDocument.markdown_content,
                 KnowledgeDocument.metadata_,
             )

--- a/apps/negentropy/src/negentropy/knowledge/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_service.py
@@ -255,7 +255,7 @@ class WikiPublishingService:
                         errors.append(f"skip:{doc.id}:no_content")
                         continue
 
-                    doc_slug = self._slugify(doc.filename or f"doc-{doc.id}")
+                    doc_slug = self._slugify(doc.original_filename or f"doc-{doc.id}")
                     base_slug = f"{hierarchical_slug}/{doc_slug}" if hierarchical_slug else doc_slug
 
                     # slug 冲突兜底：追加 -2、-3...，避免违反 uq_wiki_entry_pub_slug
@@ -276,7 +276,7 @@ class WikiPublishingService:
                         publication_id=publication_id,
                         document_id=doc.id,
                         entry_slug=final_slug,
-                        entry_title=(doc.metadata_ or {}).get("title") or doc.filename,
+                        entry_title=(doc.metadata_ or {}).get("title") or doc.original_filename,
                         entry_order=entry_order,
                     )
                     synced_doc_ids.add(str(doc.id))

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
@@ -20,6 +20,34 @@ from negentropy.knowledge.types import ChunkingStrategy, KnowledgeRecord
 from .conftest import FakeKnowledgeService, FakeStorageService
 
 
+class _FakeSessionManager:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeExecuteResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeApiSession:
+    def __init__(self, values):
+        self._values = list(values)
+
+    async def execute(self, stmt):
+        _ = stmt
+        return _FakeExecuteResult(self._values.pop(0))
+
+
 @pytest.mark.asyncio
 async def test_list_document_chunks_success(monkeypatch):
     corpus_id = uuid4()
@@ -185,18 +213,21 @@ async def test_sync_document_success(monkeypatch):
         "store_extracted_document_artifacts",
         fake_store_extracted_document_artifacts,
     )
+    fake_service.execute_sync_document_pipeline = AsyncMock(return_value=None)
+
+    background_tasks = BackgroundTasks()
 
     result = await knowledge_api.sync_document(
         corpus_id=corpus_id,
         document_id=document_id,
         payload=knowledge_api.DocumentActionRequest(app_name="negentropy"),
-        background_tasks=BackgroundTasks(),
+        background_tasks=background_tasks,
     )
 
     assert result.status == "running"
     assert result.run_id == "run-test-001"
-    assert fake_storage.saved_markdown is not None
     assert fake_service.pipeline_calls[-1]["input_data"]["sync_document"] is True
+    assert len(background_tasks.tasks) == 1
 
 
 @pytest.mark.asyncio
@@ -329,6 +360,70 @@ async def test_rebuild_document_file_requires_gcs(monkeypatch):
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail["code"] == "INVALID_DOCUMENT_SOURCE"
+
+
+@pytest.mark.asyncio
+async def test_get_document_provenance_uses_original_filename(monkeypatch):
+    document_id = uuid4()
+    doc = SimpleNamespace(
+        id=document_id,
+        original_filename="architecture-overview.pdf",
+        file_hash="abc123",
+        content_type="application/pdf",
+        status="active",
+        markdown_extract_status="completed",
+    )
+    doc_source = SimpleNamespace(
+        id=uuid4(),
+        document_id=document_id,
+        source_type="file_pdf",
+        source_url=None,
+        original_url=None,
+        title=None,
+        author=None,
+        extracted_summary=None,
+        extraction_duration_ms=None,
+        extracted_at=None,
+        extractor_tool_name=None,
+        extractor_server_id=None,
+        raw_metadata={},
+        created_at=None,
+        updated_at=None,
+    )
+    fake_service = FakeKnowledgeService()
+    fake_service.source_tracker = SimpleNamespace(get_provenance=AsyncMock(return_value=doc_source))
+
+    monkeypatch.setattr(knowledge_api, "_get_service", lambda: fake_service)
+    monkeypatch.setattr(knowledge_api, "AsyncSessionLocal", lambda: _FakeSessionManager(_FakeApiSession([doc])))
+
+    result = await knowledge_api.get_document_provenance(document_id=document_id)
+
+    assert result.filename == "architecture-overview.pdf"
+    assert result.document_id == document_id
+
+
+@pytest.mark.asyncio
+async def test_get_node_documents_uses_original_filename(monkeypatch):
+    node_id = uuid4()
+    fake_doc = SimpleNamespace(
+        id=uuid4(),
+        original_filename="design-spec.md",
+        metadata_={},
+        status="active",
+        created_at=None,
+    )
+    fake_catalog_service = SimpleNamespace(
+        get_node_documents=AsyncMock(return_value=([fake_doc], 1)),
+    )
+
+    monkeypatch.setattr(knowledge_api, "_get_catalog_service", lambda: fake_catalog_service)
+    monkeypatch.setattr(knowledge_api, "AsyncSessionLocal", lambda: _FakeSessionManager(SimpleNamespace()))
+
+    result = await knowledge_api.get_node_documents(node_id=node_id)
+
+    assert result["total"] == 1
+    assert result["items"][0]["filename"] == "design-spec.md"
+    assert result["items"][0]["title"] == "design-spec.md"
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_kg_entity_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_kg_entity_service_unit.py
@@ -147,6 +147,29 @@ class TestSyncEntityFromKnowledge:
         mention = db.added[1]
         assert mention.knowledge_chunk_id is None
 
+    async def test_sync_create_logs_with_non_reserved_extra_keys(self, service, db, monkeypatch):
+        """创建实体日志不应使用 LogRecord 保留字段 name。"""
+        captured: dict[str, object] = {}
+
+        def fake_info(event: str, *, extra: dict[str, object]) -> None:
+            captured["event"] = event
+            captured["extra"] = extra
+
+        monkeypatch.setattr("negentropy.knowledge.kg_entity_service.logger.info", fake_info)
+
+        await service.sync_entity_from_knowledge(
+            db,
+            knowledge_id=_KNOWLEDGE_ID,
+            name="Alice",
+            entity_type="PERSON",
+            confidence=0.85,
+            corpus_id=_CORPUS_ID,
+        )
+
+        assert captured["event"] == "kg_entity_created"
+        assert captured["extra"]["entity_name"] == "Alice"
+        assert "name" not in captured["extra"]
+
     # -- 2. 更新已有实体 — 置信度升级 --
 
     async def test_sync_updates_existing_entity_confidence_upgrade(self, service, db):
@@ -205,6 +228,32 @@ class TestSyncEntityFromKnowledge:
             )
 
         assert existing.mention_count == 4
+
+    async def test_sync_update_logs_with_non_reserved_extra_keys(self, service, db, monkeypatch):
+        """更新实体日志不应使用 LogRecord 保留字段 name。"""
+        existing = _make_entity_ns(name="Dave", mention_count=3)
+        db.entities.append(existing)
+        captured: dict[str, object] = {}
+
+        def fake_debug(event: str, *, extra: dict[str, object]) -> None:
+            captured["event"] = event
+            captured["extra"] = extra
+
+        monkeypatch.setattr("negentropy.knowledge.kg_entity_service.logger.debug", fake_debug)
+
+        with patch.object(db, "execute", new_callable=_MockExecuteReturn, return_value=existing):
+            await service.sync_entity_from_knowledge(
+                db,
+                knowledge_id=_KNOWLEDGE_ID,
+                name="Dave",
+                entity_type="PERSON",
+                confidence=0.7,
+                corpus_id=_CORPUS_ID,
+            )
+
+        assert captured["event"] == "kg_entity_updated"
+        assert captured["extra"]["entity_name"] == "Dave"
+        assert "name" not in captured["extra"]
 
     # -- 5. 属性合并 --
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -112,6 +113,29 @@ class TestWikiCreatePublicationValidation:
         )
         assert session.flush_count >= 1
 
+    @pytest.mark.asyncio
+    async def test_create_publication_logs_with_non_reserved_extra_keys(self, monkeypatch):
+        """wiki publication 创建日志不应覆写 LogRecord 保留字段。"""
+        service = WikiPublishingService()
+        session = _FakeAsyncSession()
+        captured: dict[str, object] = {}
+
+        def fake_info(event: str, *, extra: dict[str, object]) -> None:
+            captured["event"] = event
+            captured["extra"] = extra
+
+        monkeypatch.setattr("negentropy.knowledge.wiki_dao.logger.info", fake_info)
+
+        await service.create_publication(
+            session,
+            corpus_id=uuid4(),
+            name="Architecture Wiki",
+        )
+
+        assert captured["event"] == "wiki_publication_created"
+        assert captured["extra"]["publication_name"] == "Architecture Wiki"
+        assert "name" not in captured["extra"]
+
 
 # ---------------------------------------------------------------------------
 # update_publication theme 校验
@@ -169,6 +193,60 @@ class TestWikiDelegationMethods:
         session = _FakeAsyncSession()
         result = await service.delete_publication(session, pub_id=uuid4())
         assert result is False  # FakeAsyncSession.execute 返回 None → 删除失败
+
+
+class TestWikiCatalogSync:
+    """sync_entries_from_catalog 的字段映射回归。"""
+
+    @pytest.mark.asyncio
+    async def test_sync_entries_from_catalog_uses_original_filename(self, monkeypatch):
+        service = WikiPublishingService()
+        publication_id = uuid4()
+        root_node_id = uuid4()
+        doc_id = uuid4()
+        fake_db = _FakeAsyncSession()
+        captured: dict[str, object] = {}
+
+        async def fake_get_subtree(db, node_id):
+            _ = db
+            assert node_id == root_node_id
+            return [{"id": root_node_id, "parent_id": None, "slug": "root"}]
+
+        async def fake_get_node_documents(db, catalog_node_id, limit=500):
+            _ = (db, limit)
+            assert catalog_node_id == root_node_id
+            doc = SimpleNamespace(
+                id=doc_id,
+                original_filename="System Design.pdf",
+                markdown_extract_status="completed",
+                markdown_content="# System Design",
+                metadata_={},
+            )
+            return [doc], 1
+
+        async def fake_upsert_entry(db, **kwargs):
+            _ = db
+            captured.update(kwargs)
+
+        async def fake_remove_stale_entries(db, publication_id, keep_document_ids):
+            _ = (db, publication_id, keep_document_ids)
+            return 0
+
+        monkeypatch.setattr("negentropy.knowledge.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
+        monkeypatch.setattr("negentropy.knowledge.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents)
+        monkeypatch.setattr("negentropy.knowledge.wiki_service.WikiDao.upsert_entry", fake_upsert_entry)
+        monkeypatch.setattr("negentropy.knowledge.wiki_service.WikiDao.remove_stale_entries", fake_remove_stale_entries)
+
+        result = await service.sync_entries_from_catalog(
+            fake_db,
+            publication_id=publication_id,
+            catalog_node_ids=[root_node_id],
+        )
+
+        assert result["synced_count"] == 1
+        assert captured["document_id"] == doc_id
+        assert captured["entry_slug"].endswith("system-design-pdf")
+        assert captured["entry_title"] == "System Design.pdf"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -149,3 +149,22 @@
   2. 任何混用 `structlog` 与标准库 `logging` 的模块，都不能假设 `extra` 是“任意字典”，需明确区分框架保留键与业务键。
 
 ---
+
+## ISSUE-010 KnowledgeDocument 文件名字段漂移导致 Catalog / Wiki 500
+
+- **表因**：用户在 Catalog 中执行「添加文档 -> 分配」后，拉取节点文档列表接口报 `Failed to fetch node documents: Internal Server Error`；同时 Wiki 相关同步/内容读取链路存在潜在同型崩溃。
+- **根因**：`KnowledgeDocument` 模型真实字段为 `original_filename`，但 `apps/negentropy/src/negentropy/knowledge/api.py`、`wiki_service.py`、`wiki_dao.py` 中仍残留历史字段 `doc.filename` / `KnowledgeDocument.filename`。这类字段漂移在运行时直接触发 `AttributeError`，属于典型“响应层/派生层引用已废弃属性”问题；同批扫描还发现 `wiki_dao.py`、`kg_entity_service.py` 继续使用 stdlib logging 的 `extra[\"name\"]`，存在与 ISSUE-009 同源的日志保留字段冲突风险。
+- **处理方式**：
+  1. 统一以 `KnowledgeDocument.original_filename` 作为唯一后端文件名事实源，修正 Catalog 文档列表、Document Provenance、Wiki 条目内容、Wiki 从 Catalog 同步时的 slug/title 推导；
+  2. 保持外部响应中的 `filename` 字段名不变，只修正其来源，避免破坏前端契约；
+  3. 顺手将 `wiki_dao.py` / `kg_entity_service.py` 的日志上下文字段 `name` 改为 `publication_name` / `entity_name`，闭合同型日志风险；
+  4. 补充 API / Wiki / KG 单测，确保“字段映射正确”与“日志不破坏主流程”两类回归都能在 CI 中暴露。
+- **后续防范**：
+  1. ORM 模型字段一旦重命名，所有 API 序列化层、DAO 查询投影、Service 派生逻辑必须同步走一次全局 grep 审计，不能只改写入路径；
+  2. 对外返回的 `filename` 这类展示字段应明确标注其内部来源（如 `original_filename`），避免“接口名未变、模型字段已变”造成双源认知；
+  3. stdlib logging 的 `extra` 业务键继续禁止使用 `name`，与 ISSUE-009 的防线保持一致。
+- **同类问题影响**：
+  1. Catalog / Wiki 之外，任何直接读取 `KnowledgeDocument` 属性的 provenance、export、render、sync 路径都需优先检查是否误用了 `filename`；
+  2. 这类问题具有“写路径正常、读路径崩溃”的二阶特征，UI 上常表现为操作成功后刷新列表/详情时才报错，排查时应优先检查响应序列化逻辑而非数据库写入。
+
+---


### PR DESCRIPTION
## 变更概述

本 PR 修复了 Knowledge/Catalog/Wiki 链路中的两类同源问题：

- Catalog 节点文档列表在“添加文档 -> 分配”后读取文档时触发 500
- Wiki / Knowledge 相关路径仍残留历史字段与日志键漂移，存在同型风险

## 修改内容

- 统一将 `KnowledgeDocument` 的文件名来源收敛到 `original_filename`
- 修复 Catalog 文档列表接口对已废弃 `doc.filename` 的访问
- 修复 Document Provenance、Wiki 条目内容读取、Wiki 从 Catalog 同步时对 `filename` 历史字段的误用
- 修正知识域内 stdlib logging 的 `extra["name"]` 冲突风险：
  - `wiki_dao.py` 改为 `publication_name`
  - `kg_entity_service.py` 改为 `entity_name`
- 补充 API / Wiki / KG / Catalog DAO 单元回归测试
- 在 `docs/issue.md` 新增 ISSUE-010，沉淀“字段漂移 + 日志保留字段冲突”的处理经验

## 修改原因

用户在 Catalog 中执行“添加文档 -> 分配”后，前端提示：

- `Failed to fetch node documents: Internal Server Error`

后端堆栈定位到 `knowledge/api.py::get_node_documents()`，直接原因是代码访问了不存在的 `doc.filename`，而 `KnowledgeDocument` 模型真实字段为 `original_filename`。这属于典型的模型字段演进后，API / Service / DAO 读取路径未完全同步的漂移问题。

深入排查后发现，Wiki 同步和条目内容读取链路也存在同样的 `filename` 历史字段误用；同时 `wiki_dao.py` 和 `kg_entity_service.py` 还保留了 stdlib logging 的 `extra["name"]` 用法，继续存在与 `LogRecord` 保留字段冲突的风险，因此一并闭合。

## 关键实现细节

- 不修改对外 API 字段名，不改 schema，只修正后端内部字段来源
- 对外返回中的 `filename` 继续保留，但统一由 `KnowledgeDocument.original_filename` 提供
- 采用最小干预方式处理日志问题，仅修正 `extra` 中的业务键名，不改变事件名与整体日志结构
- 通过单元测试覆盖以下回归面：
  - Catalog 文档列表使用 `original_filename`
  - Document Provenance 使用 `original_filename`
  - Wiki 从 Catalog 同步时 slug / title 推导使用 `original_filename`
  - Wiki / KG 日志不再使用 `name` 作为 stdlib logging `extra` 键

## 验证

已执行：

```bash
uv run pytest tests/unit_tests/knowledge/test_api_documents.py tests/unit_tests/knowledge/test_wiki_service_unit.py tests/unit_tests/knowledge/test_kg_entity_service_unit.py tests/unit_tests/knowledge/test_catalog_dao_unit.py -q --no-cov
```

结果：

- `72 passed`

## 影响范围

- 无数据库 schema 变更
- 无公共 API 路由变更
- 对前端返回结构保持兼容
- 影响的主要模块：
  - `knowledge/api.py`
  - `knowledge/wiki_service.py`
  - `knowledge/wiki_dao.py`
  - `knowledge/kg_entity_service.py`
