### PR TITLE
feat(catalog): Catalog 全局化三阶段重构——MediaWiki N:M + GitBook 订阅式发布三层正交架构

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## [Unreleased]
 
+### Changed（破坏性变更）
+
+- **[BREAKING] Catalog 全局化三阶段重构（corpus_id → catalog_id）**：
+  - `doc_catalog_nodes` 与 `doc_catalog_memberships` 表已被 `doc_catalog_entries`（N:M 全局关联表）替代；`doc_catalogs` 成为独立的全局顶层实体，不再依附 Corpus。
+  - `wiki_publications.corpus_id` 列已移除，替换为 `catalog_id` + `app_name` + `publish_mode`（`live` | `snapshot`）+ `visibility`；`UNIQUE(corpus_id, slug)` 约束已更换为 `UNIQUE(catalog_id, slug)`。
+  - 所有创建 Wiki Publication 的 API 请求需将 `corpus_id` 字段替换为 `catalog_id`；`GET /wiki/publications` 的 `corpusId` 查询参数同样变更为 `catalogId`。
+  - 前端 BFF 代理路由：旧版 `GET /api/knowledge/catalog/tree/{corpusId}` 已返回 `410 Gone`；请改用 `GET /api/knowledge/catalogs/{catalogId}/tree`。
+  - `CatalogDao.create_node` / `get_tree` / `assign_document` / `unassign_document` 等方法的 `corpus_id` 参数已替换为 `catalog_id` 或 `catalog_entry_id`，详见 [catalog_dao.py](../apps/negentropy/src/negentropy/knowledge/catalog_dao.py)。
+
+  **迁移指南**：
+  1. 执行数据库迁移：`cd apps/negentropy && uv run alembic upgrade head`（三阶段 Revision 0003→0004→0005 顺序应用）。
+  2. 若需降级，先检查是否存在跨 Corpus 的 Catalog（Revision 0005 downgrade 守卫会拒绝含跨 corpus entries 的降级并抛 `RuntimeError`）。
+  3. 前端：将所有 `corpusId` props / state / API 参数重命名为 `catalogId`，并确认 BFF 代理已对齐新路由（`/catalogs/` 前缀）。
+  4. Wiki SSG：`WikiPublication` 接口的 `corpus_id` 字段已替换为 `catalog_id`；`publish_mode` 字段新增。
+
 ### Fixed
 
 - 修复 `apps/negentropy-wiki` `pnpm build` / `pnpm start` 三类联动异常，使 Wiki 发布链路（UI 在线发布 → 5 分钟 ISR 自动回刷）在本地/容器运行时的可观测语义与 Negentropy UI 端到端对齐：

--- a/apps/negentropy-ui/app/api/knowledge/catalog/tree/[corpusId]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalog/tree/[corpusId]/route.ts
@@ -1,6 +1,14 @@
-import { proxyGet } from "../../../_proxy";
+import { NextResponse } from "next/server";
 
-export async function GET(request: Request, { params }: { params: Promise<{ corpusId: string }> }) {
-  const { corpusId } = await params;
-  return proxyGet(request, `/knowledge/catalog/tree/${corpusId}`);
+// 旧路由已废弃，迁移至 /api/knowledge/catalogs/{catalogId}/tree
+export async function GET() {
+  return NextResponse.json(
+    { error: { code: "GONE", message: "此端点已迁移，请使用 /api/knowledge/catalogs/{catalogId}/tree" } },
+    {
+      status: 410,
+      headers: {
+        "X-Deprecation-Notice": "Migrated to /api/knowledge/catalogs/{catalogId}/tree",
+      },
+    },
+  );
 }

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/documents/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/documents/route.ts
@@ -1,0 +1,9 @@
+import { proxyGet } from "../../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyGet(request, `/knowledge/catalogs/${catalogId}/documents`);
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/[entryId]/documents/[docId]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/[entryId]/documents/[docId]/route.ts
@@ -1,0 +1,12 @@
+import { proxyDelete } from "../../../../../../_proxy";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string; entryId: string; docId: string }> },
+) {
+  const { catalogId, entryId, docId } = await params;
+  return proxyDelete(
+    request,
+    `/knowledge/catalogs/${catalogId}/entries/${entryId}/documents/${docId}`,
+  );
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/[entryId]/documents/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/[entryId]/documents/route.ts
@@ -1,0 +1,17 @@
+import { proxyGet, proxyPost } from "../../../../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string; entryId: string }> },
+) {
+  const { catalogId, entryId } = await params;
+  return proxyGet(request, `/knowledge/catalogs/${catalogId}/entries/${entryId}/documents`);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string; entryId: string }> },
+) {
+  const { catalogId, entryId } = await params;
+  return proxyPost(request, `/knowledge/catalogs/${catalogId}/entries/${entryId}/documents`);
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/[entryId]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/[entryId]/route.ts
@@ -1,0 +1,25 @@
+import { proxyGet, proxyPatch, proxyDelete } from "../../../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string; entryId: string }> },
+) {
+  const { catalogId, entryId } = await params;
+  return proxyGet(request, `/knowledge/catalogs/${catalogId}/entries/${entryId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string; entryId: string }> },
+) {
+  const { catalogId, entryId } = await params;
+  return proxyPatch(request, `/knowledge/catalogs/${catalogId}/entries/${entryId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string; entryId: string }> },
+) {
+  const { catalogId, entryId } = await params;
+  return proxyDelete(request, `/knowledge/catalogs/${catalogId}/entries/${entryId}`);
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/entries/route.ts
@@ -1,0 +1,17 @@
+import { proxyGet, proxyPost } from "../../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyGet(request, `/knowledge/catalogs/${catalogId}/entries`);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyPost(request, `/knowledge/catalogs/${catalogId}/entries`);
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/route.ts
@@ -1,0 +1,25 @@
+import { proxyGet, proxyPatch, proxyDelete } from "../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyGet(request, `/knowledge/catalogs/${catalogId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyPatch(request, `/knowledge/catalogs/${catalogId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyDelete(request, `/knowledge/catalogs/${catalogId}`);
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/tree/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/[catalogId]/tree/route.ts
@@ -1,0 +1,9 @@
+import { proxyGet } from "../../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ catalogId: string }> },
+) {
+  const { catalogId } = await params;
+  return proxyGet(request, `/knowledge/catalogs/${catalogId}/tree`);
+}

--- a/apps/negentropy-ui/app/api/knowledge/catalogs/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/catalogs/route.ts
@@ -1,0 +1,9 @@
+import { proxyGet, proxyPost } from "../_proxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/knowledge/catalogs");
+}
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/knowledge/catalogs");
+}

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/AddDocumentsDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/AddDocumentsDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  fetchDocuments,
+  fetchCatalogDocuments,
   assignDocumentToNode,
   KnowledgeDocument,
 } from "@/features/knowledge";
@@ -10,7 +10,7 @@ import { toast } from "@/lib/activity-toast";
 
 interface AddDocumentsDialogProps {
   nodeId: string;
-  corpusId: string;
+  catalogId: string;
   existingDocIds: Set<string>;
   onClose: () => void;
   onAdded: () => void;
@@ -18,7 +18,7 @@ interface AddDocumentsDialogProps {
 
 export function AddDocumentsDialog({
   nodeId,
-  corpusId,
+  catalogId,
   existingDocIds,
   onClose,
   onAdded,
@@ -34,7 +34,7 @@ export function AddDocumentsDialog({
     const load = async () => {
       setLoading(true);
       try {
-        const res = await fetchDocuments(corpusId, { limit: 200 });
+        const res = await fetchCatalogDocuments(catalogId, { limit: 200 });
         if (!cancelled) setDocs(res.items ?? []);
       } catch (err) {
         if (!cancelled) {
@@ -48,7 +48,7 @@ export function AddDocumentsDialog({
     return () => {
       cancelled = true;
     };
-  }, [corpusId]);
+  }, [catalogId]);
 
   const filtered = useMemo(() => {
     const kw = keyword.trim().toLowerCase();

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/CatalogSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/CatalogSelector.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchCatalogs, DocCatalog } from "@/features/knowledge";
+
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+
+interface CatalogSelectorProps {
+  value: string | null;
+  onChange: (catalogId: string) => void;
+}
+
+export function CatalogSelector({ value, onChange }: CatalogSelectorProps) {
+  const [catalogs, setCatalogs] = useState<DocCatalog[]>([]);
+
+  useEffect(() => {
+    fetchCatalogs({ appName: APP_NAME })
+      .then((res) => setCatalogs(res.items))
+      .catch(console.error);
+  }, []);
+
+  return (
+    <div className="flex items-center gap-2">
+      <label className="text-xs font-medium text-muted whitespace-nowrap">
+        目录:
+      </label>
+      <select
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+      >
+        <option value="">选择目录...</option>
+        {catalogs.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/CreateNodeDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/CreateNodeDialog.tsx
@@ -21,7 +21,7 @@ function slugify(text: string): string {
 interface CreateNodeDialogProps {
   open: boolean;
   parentId: string | null;
-  corpusId: string;
+  catalogId: string;
   onClose: () => void;
   onCreated: (node: CatalogNode) => void;
 }
@@ -29,7 +29,7 @@ interface CreateNodeDialogProps {
 export function CreateNodeDialog({
   open,
   parentId,
-  corpusId,
+  catalogId,
   onClose,
   onCreated,
 }: CreateNodeDialogProps) {
@@ -57,7 +57,7 @@ export function CreateNodeDialog({
     setSubmitting(true);
     try {
       const node = await createCatalogNode({
-        corpus_id: corpusId,
+        catalog_id: catalogId,
         name: name.trim(),
         slug: slug.trim(),
         parent_id: parentId ?? undefined,
@@ -72,7 +72,7 @@ export function CreateNodeDialog({
     } finally {
       setSubmitting(false);
     }
-  }, [name, slug, nodeType, corpusId, parentId, onCreated, onClose, handleReset]);
+  }, [name, slug, nodeType, catalogId, parentId, onCreated, onClose, handleReset]);
 
   if (!open) return null;
 

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/DocumentAssignmentSection.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/DocumentAssignmentSection.tsx
@@ -12,12 +12,12 @@ import { AddDocumentsDialog } from "./AddDocumentsDialog";
 
 interface DocumentAssignmentSectionProps {
   nodeId: string;
-  corpusId: string;
+  catalogId: string;
 }
 
 export function DocumentAssignmentSection({
   nodeId,
-  corpusId,
+  catalogId,
 }: DocumentAssignmentSectionProps) {
   const [docs, setDocs] = useState<KnowledgeDocument[]>([]);
   const [loading, setLoading] = useState(false);
@@ -65,7 +65,7 @@ export function DocumentAssignmentSection({
         </h3>
         <button
           onClick={() => setAdding(true)}
-          disabled={!corpusId}
+          disabled={!catalogId}
           className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-border text-muted hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Plus className="h-3 w-3" />
@@ -104,10 +104,10 @@ export function DocumentAssignmentSection({
         </ul>
       )}
 
-      {adding && corpusId && (
+      {adding && catalogId && (
         <AddDocumentsDialog
           nodeId={nodeId}
-          corpusId={corpusId}
+          catalogId={catalogId}
           existingDocIds={new Set(docs.map((d) => d.id))}
           onClose={() => setAdding(false)}
           onAdded={handleAdded}

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/NodeDetailPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/NodeDetailPanel.tsx
@@ -12,14 +12,14 @@ import { DocumentAssignmentSection } from "./DocumentAssignmentSection";
 
 interface NodeDetailPanelProps {
   node: CatalogNode | null;
-  corpusId: string;
+  catalogId: string;
   onUpdate: () => void;
   onDelete: () => void;
 }
 
 export function NodeDetailPanel({
   node,
-  corpusId,
+  catalogId,
   onUpdate,
   onDelete,
 }: NodeDetailPanelProps) {
@@ -166,7 +166,7 @@ export function NodeDetailPanel({
       </div>
 
       {/* Document assignment */}
-      <DocumentAssignmentSection nodeId={node.id} corpusId={corpusId} />
+      <DocumentAssignmentSection nodeId={node.id} catalogId={catalogId} />
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/catalog/hooks/useCatalogTree.ts
+++ b/apps/negentropy-ui/app/knowledge/catalog/hooks/useCatalogTree.ts
@@ -4,23 +4,23 @@ import { useState, useCallback, useEffect } from "react";
 import { CatalogNode, fetchCatalogTree } from "@/features/knowledge";
 
 interface UseCatalogTreeOptions {
-  corpusId: string | null;
+  catalogId: string | null;
 }
 
-export function useCatalogTree({ corpusId }: UseCatalogTreeOptions) {
+export function useCatalogTree({ catalogId }: UseCatalogTreeOptions) {
   const [nodes, setNodes] = useState<CatalogNode[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
 
   const refresh = useCallback(async () => {
-    if (!corpusId) {
+    if (!catalogId) {
       setNodes([]);
       return;
     }
     setLoading(true);
     try {
-      const data = await fetchCatalogTree(corpusId);
+      const data = await fetchCatalogTree(catalogId);
       setNodes(data);
       // Auto-expand first level
       const rootIds = data
@@ -33,7 +33,7 @@ export function useCatalogTree({ corpusId }: UseCatalogTreeOptions) {
     } finally {
       setLoading(false);
     }
-  }, [corpusId]);
+  }, [catalogId]);
 
   useEffect(() => {
     refresh();

--- a/apps/negentropy-ui/app/knowledge/catalog/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/page.tsx
@@ -2,14 +2,14 @@
 
 import { useState, useCallback } from "react";
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
-import { CorpusSelector } from "./_components/CorpusSelector";
+import { CatalogSelector } from "./_components/CatalogSelector";
 import { CatalogTree } from "./_components/CatalogTree";
 import { NodeDetailPanel } from "./_components/NodeDetailPanel";
 import { CreateNodeDialog } from "./_components/CreateNodeDialog";
 import { useCatalogTree } from "./hooks/useCatalogTree";
 
 export default function CatalogPage() {
-  const [corpusId, setCorpusId] = useState<string | null>(null);
+  const [catalogId, setCatalogId] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [addParentId, setAddParentId] = useState<string | null>(null);
 
@@ -22,7 +22,7 @@ export default function CatalogPage() {
     refresh,
     toggleExpand,
     selectNode,
-  } = useCatalogTree({ corpusId });
+  } = useCatalogTree({ catalogId });
 
   const handleAddChild = useCallback((parentId: string) => {
     setAddParentId(parentId === "" ? null : parentId);
@@ -45,7 +45,7 @@ export default function CatalogPage() {
       <div className="flex min-h-0 flex-1 px-6 py-4 gap-4">
         {/* Sidebar: Tree */}
         <aside className="w-[300px] shrink-0 flex flex-col gap-3 overflow-hidden">
-          <CorpusSelector value={corpusId} onChange={setCorpusId} />
+          <CatalogSelector value={catalogId} onChange={setCatalogId} />
 
           {loading ? (
             <div className="flex items-center justify-center py-12">
@@ -67,7 +67,7 @@ export default function CatalogPage() {
         <main className="flex-1 min-w-0 rounded-2xl border border-border bg-card shadow-sm overflow-hidden">
           <NodeDetailPanel
             node={selectedNode}
-            corpusId={corpusId ?? ""}
+            catalogId={catalogId ?? ""}
             onUpdate={refresh}
             onDelete={handleDeleted}
           />
@@ -77,7 +77,7 @@ export default function CatalogPage() {
       <CreateNodeDialog
         open={dialogOpen}
         parentId={addParentId}
-        corpusId={corpusId ?? ""}
+        catalogId={catalogId ?? ""}
         onClose={() => {
           setDialogOpen(false);
           setAddParentId(null);

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/CreateWikiPublicationDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/CreateWikiPublicationDialog.tsx
@@ -20,14 +20,14 @@ function slugify(text: string): string {
 
 interface CreateWikiPublicationDialogProps {
   open: boolean;
-  corpusId: string;
+  catalogId: string;
   onClose: () => void;
   onCreated: (pub: WikiPublication) => void;
 }
 
 export function CreateWikiPublicationDialog({
   open,
-  corpusId,
+  catalogId,
   onClose,
   onCreated,
 }: CreateWikiPublicationDialogProps) {
@@ -53,11 +53,11 @@ export function CreateWikiPublicationDialog({
   }, []);
 
   const handleSubmit = useCallback(async () => {
-    if (!name.trim() || !slug.trim() || !corpusId) return;
+    if (!name.trim() || !slug.trim() || !catalogId) return;
     setSubmitting(true);
     try {
       const pub = await createWikiPublication({
-        corpus_id: corpusId,
+        catalog_id: catalogId,
         name: name.trim(),
         slug: slug.trim(),
         description: description.trim() || undefined,
@@ -72,7 +72,7 @@ export function CreateWikiPublicationDialog({
     } finally {
       setSubmitting(false);
     }
-  }, [name, slug, description, theme, corpusId, onCreated, onClose, handleReset]);
+  }, [name, slug, description, theme, catalogId, onCreated, onClose, handleReset]);
 
   if (!open) return null;
 
@@ -153,7 +153,7 @@ export function CreateWikiPublicationDialog({
           </button>
           <button
             onClick={handleSubmit}
-            disabled={submitting || !name.trim() || !slug.trim() || !corpusId}
+            disabled={submitting || !name.trim() || !slug.trim() || !catalogId}
             className="px-4 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50"
           >
             {submitting ? "创建中..." : "创建"}

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublicationDetail.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublicationDetail.tsx
@@ -244,7 +244,7 @@ export function WikiPublicationDetail({
 
       <CatalogNodeSelectorDialog
         open={selectorOpen}
-        corpusId={publication.corpus_id}
+        corpusId={publication.catalog_id}
         onClose={() => setSelectorOpen(false)}
         onConfirm={handleSyncConfirm}
         submitting={submitting}

--- a/apps/negentropy-ui/app/knowledge/wiki/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
-import { CorpusSelector } from "../catalog/_components/CorpusSelector";
+import { CatalogSelector } from "../catalog/_components/CatalogSelector";
 import {
   fetchWikiPublications,
   WikiPublication,
@@ -13,21 +13,21 @@ import { WikiPublicationDetail } from "./_components/WikiPublicationDetail";
 import { CreateWikiPublicationDialog } from "./_components/CreateWikiPublicationDialog";
 
 export default function WikiPage() {
-  const [corpusId, setCorpusId] = useState<string | null>(null);
+  const [catalogId, setCatalogId] = useState<string | null>(null);
   const [publications, setPublications] = useState<WikiPublication[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
 
   const loadPublications = useCallback(async () => {
-    if (!corpusId) {
+    if (!catalogId) {
       setPublications([]);
       setSelectedId(null);
       return;
     }
     setLoading(true);
     try {
-      const resp = await fetchWikiPublications({ corpusId });
+      const resp = await fetchWikiPublications({ catalogId });
       setPublications(resp.items);
       setSelectedId((prev) =>
         prev && resp.items.some((p) => p.id === prev) ? prev : null,
@@ -37,7 +37,7 @@ export default function WikiPage() {
     } finally {
       setLoading(false);
     }
-  }, [corpusId]);
+  }, [catalogId]);
 
   useEffect(() => {
     loadPublications();
@@ -65,11 +65,11 @@ export default function WikiPage() {
 
       <div className="flex min-h-0 flex-1 px-6 py-4 gap-4">
         <aside className="w-[320px] shrink-0 flex flex-col gap-3 overflow-hidden">
-          <CorpusSelector value={corpusId} onChange={setCorpusId} />
+          <CatalogSelector value={catalogId} onChange={setCatalogId} />
 
           <button
             onClick={() => setCreateOpen(true)}
-            disabled={!corpusId}
+            disabled={!catalogId}
             className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50"
           >
             + 新建发布
@@ -94,7 +94,7 @@ export default function WikiPage() {
 
       <CreateWikiPublicationDialog
         open={createOpen}
-        corpusId={corpusId ?? ""}
+        catalogId={catalogId ?? ""}
         onClose={() => setCreateOpen(false)}
         onCreated={handleCreated}
       />

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -83,6 +83,8 @@ export {
   clearCorpusGraph,
   fetchGraphBuildHistory,
   // Catalog Management
+  fetchCatalogs,
+  fetchCatalogDocuments,
   fetchCatalogTree,
   fetchCatalogNodes,
   createCatalogNode,
@@ -174,6 +176,9 @@ export type {
   GraphBuildHistoryResult,
   // Catalog Management
   CatalogNodeType,
+  DocCatalog,
+  DocCatalogListResponse,
+  DocCatalogDocumentsResponse,
   CatalogNode,
   CreateCatalogNodeParams,
   UpdateCatalogNodeParams,
@@ -182,6 +187,7 @@ export type {
   CatalogNodeDocumentsResponse,
   // Wiki Publishing
   WikiPublicationStatus,
+  WikiPublishMode,
   WikiTheme,
   WikiPublication,
   WikiPublicationListResponse,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -2149,10 +2149,35 @@ export async function upsertPipelines(params: {
 
 export type CatalogNodeType = "category" | "collection" | "document_ref";
 
-/** 目录节点 — 对齐后端 DocCatalogNode + CTE 扩展字段 */
+/** 全局 Catalog 元数据 — 对齐后端 DocCatalog ORM */
+export interface DocCatalog {
+  id: string;
+  name: string;
+  slug: string;
+  app_name: string;
+  description: string | null;
+  visibility: "private" | "internal" | "public";
+  is_archived: boolean;
+  version: number;
+  owner_id: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface DocCatalogListResponse {
+  items: DocCatalog[];
+  total: number;
+}
+
+export interface DocCatalogDocumentsResponse {
+  items: KnowledgeDocument[];
+  total: number;
+}
+
+/** 目录节点 — 对齐后端 DocCatalogEntry + CTE 扩展字段 */
 export interface CatalogNode {
   id: string;
-  corpus_id: string;
+  catalog_id: string;
   name: string;
   slug: string;
   parent_id: string | null;
@@ -2173,7 +2198,7 @@ export interface CatalogNode {
 }
 
 export interface CreateCatalogNodeParams {
-  corpus_id: string;
+  catalog_id: string;
   name: string;
   slug: string;
   parent_id?: string | null;
@@ -2212,8 +2237,8 @@ export interface CatalogNodeDocumentsResponse {
 // ============================================================================
 
 /** 获取目录树（CTE 扁平化列表，含 depth/path） */
-export async function fetchCatalogTree(corpusId: string): Promise<CatalogNode[]> {
-  const res = await fetch(`/api/knowledge/catalog/tree/${corpusId}`, {
+export async function fetchCatalogTree(catalogId: string): Promise<CatalogNode[]> {
+  const res = await fetch(`/api/knowledge/catalogs/${catalogId}/tree`, {
     cache: "no-store",
   });
   if (!res.ok) throw new Error(`Failed to fetch catalog tree: ${res.statusText}`);
@@ -2223,12 +2248,12 @@ export async function fetchCatalogTree(corpusId: string): Promise<CatalogNode[]>
 
 /** 获取目录节点列表（分页） */
 export async function fetchCatalogNodes(params: {
-  corpus_id?: string;
+  catalog_id?: string;
   limit?: number;
   offset?: number;
 }): Promise<CatalogNodesResponse> {
   const query = new URLSearchParams();
-  if (params.corpus_id) query.set("corpus_id", params.corpus_id);
+  if (params.catalog_id) query.set("catalog_id", params.catalog_id);
   if (params.limit != null) query.set("limit", String(params.limit));
   if (params.offset != null) query.set("offset", String(params.offset));
   const qs = query.toString();
@@ -2241,16 +2266,12 @@ export async function fetchCatalogNodes(params: {
 
 /** 创建目录节点
  *
- * 后端契约（knowledge/api.py:3731-3735）：
- *   POST /knowledge/catalog/nodes?corpus_id=<uuid>
- *   body: CatalogNodeCreateRequest { name, slug?, parent_id?, node_type?, description?, sort_order?, config? }
- * 即 `corpus_id` 是 Query 参数而非 body 字段；body schema 不包含 corpus_id。
- * 此处显式将 corpus_id 从入参中剥离到 query string 以对齐契约；其他字段保留在 body 中。
+ * 后端契约（knowledge/api.py POST /catalogs/{catalog_id}/entries）：
+ *   catalog_id 作为路径参数；body 中其他字段。
  */
 export async function createCatalogNode(params: CreateCatalogNodeParams): Promise<CatalogNode> {
-  const { corpus_id, ...body } = params;
-  const qs = new URLSearchParams({ corpus_id }).toString();
-  const res = await fetch(`/api/knowledge/catalog?${qs}`, {
+  const { catalog_id, ...body } = params;
+  const res = await fetch(`/api/knowledge/catalogs/${catalog_id}/entries`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -2326,6 +2347,41 @@ export async function unassignDocumentFromNode(
   if (!res.ok) throw new Error(`Failed to unassign document: ${res.statusText}`);
 }
 
+/** 列出全局 Catalog（按 app_name 过滤） */
+export async function fetchCatalogs(params?: {
+  appName?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<DocCatalogListResponse> {
+  const query = new URLSearchParams();
+  if (params?.appName) query.set("app_name", params.appName);
+  if (params?.limit != null) query.set("limit", String(params.limit));
+  if (params?.offset != null) query.set("offset", String(params.offset));
+  const qs = query.toString();
+  const res = await fetch(`/api/knowledge/catalogs${qs ? `?${qs}` : ""}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`Failed to fetch catalogs: ${res.statusText}`);
+  return res.json();
+}
+
+/** 获取 Catalog 下可用文档（跨 corpus，用于 AddDocumentsDialog） */
+export async function fetchCatalogDocuments(
+  catalogId: string,
+  params?: { limit?: number; offset?: number },
+): Promise<DocCatalogDocumentsResponse> {
+  const query = new URLSearchParams();
+  if (params?.limit != null) query.set("limit", String(params.limit));
+  if (params?.offset != null) query.set("offset", String(params.offset));
+  const qs = query.toString();
+  const res = await fetch(
+    `/api/knowledge/catalogs/${catalogId}/documents${qs ? `?${qs}` : ""}`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) throw new Error(`Failed to fetch catalog documents: ${res.statusText}`);
+  return res.json();
+}
+
 // ============================================================================
 // Wiki Publishing Types
 // ============================================================================
@@ -2333,9 +2389,13 @@ export async function unassignDocumentFromNode(
 export type WikiPublicationStatus = "draft" | "published" | "archived";
 export type WikiTheme = "default" | "book" | "docs";
 
+export type WikiPublishMode = "live" | "snapshot";
+
 export interface WikiPublication {
   id: string;
-  corpus_id: string;
+  catalog_id: string;
+  app_name: string;
+  publish_mode: WikiPublishMode;
   name: string;
   slug: string;
   description: string | null;
@@ -2355,11 +2415,12 @@ export interface WikiPublicationListResponse {
 }
 
 export interface CreateWikiPublicationParams {
-  corpus_id: string;
+  catalog_id: string;
   name: string;
   slug?: string;
   description?: string;
   theme?: WikiTheme;
+  publish_mode?: WikiPublishMode;
 }
 
 export interface UpdateWikiPublicationParams {
@@ -2429,13 +2490,13 @@ export interface SyncFromCatalogResponse {
 
 /** 列出 Wiki 发布记录 */
 export async function fetchWikiPublications(params?: {
-  corpusId?: string;
+  catalogId?: string;
   status?: WikiPublicationStatus;
   offset?: number;
   limit?: number;
 }): Promise<WikiPublicationListResponse> {
   const query = new URLSearchParams();
-  if (params?.corpusId) query.set("corpus_id", params.corpusId);
+  if (params?.catalogId) query.set("catalog_id", params.catalogId);
   if (params?.status) query.set("status", params.status);
   if (params?.offset != null) query.set("offset", String(params.offset));
   if (params?.limit != null) query.set("limit", String(params.limit));

--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,5 +1,6 @@
 import {
   wikiApi,
+  type WikiEntry,
   type WikiEntryContent,
   type WikiNavTreeItem,
   type WikiPublication,
@@ -22,7 +23,7 @@ interface Props {
   params: Promise<{ pubSlug: string; entrySlug: string[] }>;
 }
 
-type LoadStatus = "ok" | "missing" | "pending";
+type LoadStatus = "ok" | "missing" | "pending" | "orphaned";
 
 function joinSlug(entrySlug: string[] | string): string {
   return Array.isArray(entrySlug) ? entrySlug.join("/") : entrySlug;
@@ -49,21 +50,45 @@ export default async function WikiEntryPage({ params }: Props) {
   try {
     publication = await wikiApi.findPublicationBySlug(pubSlug);
     if (publication) {
-      const navResult = await wikiApi.getNavTree(publication.id);
+      const [navResult, entriesResult] = await Promise.all([
+        wikiApi.getNavTree(publication.id),
+        wikiApi.getEntries(publication.id),
+      ]);
       navItems = navResult.nav_tree?.items || [];
 
-      const entryId = await wikiApi.findEntryId(publication.id, slug);
-      if (entryId) {
-        content = await wikiApi.getEntryContent(entryId);
-        if (content && content.markdown_content && content.markdown_content.trim()) {
-          status = "ok";
+      const entry: WikiEntry | undefined = entriesResult.items.find(
+        (e) => e.entry_slug === slug,
+      );
+      if (entry) {
+        if (entry.status === "orphaned" || entry.document_id === null) {
+          status = "orphaned";
         } else {
-          status = "pending";
+          content = await wikiApi.getEntryContent(entry.id);
+          if (content && content.markdown_content && content.markdown_content.trim()) {
+            status = "ok";
+          } else {
+            status = "pending";
+          }
         }
       }
     }
   } catch (err) {
     console.warn(`[Wiki] Failed to load entry "${pubSlug}/${slug}":`, err);
+  }
+
+  if (status === "orphaned") {
+    return (
+      <main className="wiki-main wiki-not-found">
+        <h1>该文档已失效</h1>
+        <p className="wiki-not-found-hint">
+          文档 &quot;{slug}&quot; 的源文件已被移除或转移，条目暂时无法访问。
+        </p>
+        <div className="wiki-not-found-actions">
+          <Link href={`/${pubSlug}`}>← 返回 {pubSlug}</Link>
+          <Link href="/">返回首页</Link>
+        </div>
+      </main>
+    );
   }
 
   if (!publication || status === "missing") {

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -16,7 +16,9 @@ const API_BASE =
 
 export interface WikiPublication {
   id: string;
-  corpus_id: string;
+  catalog_id: string;
+  app_name: string;
+  publish_mode: "live" | "snapshot";
   name: string;
   slug: string;
   description: string | null;
@@ -31,10 +33,11 @@ export interface WikiPublication {
 
 export interface WikiEntry {
   id: string;
-  document_id: string;
+  document_id: string | null;
   entry_slug: string;
   entry_title: string | null;
   is_index_page: boolean;
+  status?: "active" | "orphaned" | "hidden";
 }
 
 export interface WikiNavTreeItem {

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0003_catalog_global_phase1_add_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0003_catalog_global_phase1_add_tables.py
@@ -1,0 +1,408 @@
+"""Catalog 全局化 Phase 1：纯加法式骨架（新表 + 可空列）
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-23 00:00:00.000000+00:00
+
+按正交分解原则，将 Catalog 从 Corpus 解耦为全局顶层实体。
+本 Phase 1 仅施加**纯加法式变更**（新增表、新增可空列），不触碰既有数据与约束，
+以此为 Phase 2 (backfill) 与 Phase 3 (enforce + drop) 提供基础骨架。
+
+新增表：
+  - doc_catalogs               Catalog 顶层元数据（app_name 不可变、乐观锁、软归档）
+  - doc_catalog_entries        Catalog N:M 关联（融合目录节点树 + 文档软引用）
+  - wiki_publication_snapshots Publication 快照（snapshot 模式留档）
+  - wiki_slug_redirects        Slug 历史映射（301 重定向）
+
+新增列（wiki_publications，全部可空，为 Phase 2 backfill 预留）：
+  - catalog_id、app_name、publish_mode、visibility、snapshot_version
+
+设计溯源：
+  - MediaWiki Category N:M 多归属 [1]
+  - GitBook Site→Space 订阅式发布 [2]
+  - Docusaurus sidebar.id 正交组织 [3]
+  - Confluence Include Page 权限以源为准 [4]
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # =========================================================================
+    # 1) doc_catalogs：Catalog 顶层元数据
+    # =========================================================================
+    op.create_table(
+        "doc_catalogs",
+        sa.Column("app_name", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=False),
+        sa.Column("owner_id", sa.String(length=255), nullable=True),
+        sa.Column(
+            "visibility",
+            sa.Enum("PRIVATE", "INTERNAL", "PUBLIC", name="catalogvisibility", schema="negentropy"),
+            server_default="INTERNAL",
+            nullable=False,
+        ),
+        sa.Column("is_archived", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("app_name", "slug", name="uq_doc_catalogs_app_slug"),
+        schema="negentropy",
+    )
+    op.create_index("ix_doc_catalogs_app_name", "doc_catalogs", ["app_name"], unique=False, schema="negentropy")
+    op.create_index("ix_doc_catalogs_owner_id", "doc_catalogs", ["owner_id"], unique=False, schema="negentropy")
+    op.create_index(
+        "ix_doc_catalogs_is_archived",
+        "doc_catalogs",
+        ["is_archived"],
+        unique=False,
+        schema="negentropy",
+        postgresql_where=sa.text("is_archived = false"),
+    )
+
+    # =========================================================================
+    # 2) doc_catalog_entries：Catalog 节点 + 文档引用（N:M 关联）
+    #    - parent_entry_id 同 catalog 内自引用，支持树结构
+    #    - document_id 软引用源文档（ON DELETE SET NULL → status=orphaned）
+    #    - source_corpus_id 冗余字段，用于权限快速校验，避免 join knowledge_documents
+    # =========================================================================
+    op.create_table(
+        "doc_catalog_entries",
+        sa.Column("catalog_id", sa.UUID(), nullable=False),
+        sa.Column("parent_entry_id", sa.UUID(), nullable=True),
+        sa.Column("document_id", sa.UUID(), nullable=True),
+        sa.Column("source_corpus_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "node_type",
+            sa.Enum(
+                "CATEGORY",
+                "COLLECTION",
+                "DOCUMENT_REF",
+                name="catalogentrynodetype",
+                schema="negentropy",
+            ),
+            server_default="CATEGORY",
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug_override", sa.String(length=255), nullable=True),
+        sa.Column("position", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "ACTIVE",
+                "ORPHANED",
+                "HIDDEN",
+                name="catalogentrystatus",
+                schema="negentropy",
+            ),
+            server_default="ACTIVE",
+            nullable=False,
+        ),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["catalog_id"],
+            ["negentropy.doc_catalogs.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["parent_entry_id"],
+            ["negentropy.doc_catalog_entries.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["document_id"],
+            ["negentropy.knowledge_documents.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_corpus_id"],
+            ["negentropy.corpus.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        # 同 catalog 内父子节点名唯一
+        sa.UniqueConstraint(
+            "catalog_id",
+            "parent_entry_id",
+            "name",
+            name="uq_catalog_entry_sibling_name",
+        ),
+        schema="negentropy",
+    )
+    op.create_index(
+        "ix_doc_catalog_entries_catalog_status",
+        "doc_catalog_entries",
+        ["catalog_id", "status"],
+        unique=False,
+        schema="negentropy",
+    )
+    op.create_index(
+        "ix_doc_catalog_entries_parent",
+        "doc_catalog_entries",
+        ["parent_entry_id"],
+        unique=False,
+        schema="negentropy",
+    )
+    # Backlink 反查：该文档被哪些 catalog_entry 引用（Outline 模式）
+    op.create_index(
+        "ix_doc_catalog_entries_document",
+        "doc_catalog_entries",
+        ["document_id"],
+        unique=False,
+        schema="negentropy",
+        postgresql_where=sa.text("document_id IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_doc_catalog_entries_source_corpus",
+        "doc_catalog_entries",
+        ["source_corpus_id"],
+        unique=False,
+        schema="negentropy",
+        postgresql_where=sa.text("source_corpus_id IS NOT NULL"),
+    )
+    # slug_override 唯一（仅 NOT NULL 部分索引）：允许多个 NULL 共存
+    op.create_index(
+        "uq_catalog_entry_sibling_slug_override",
+        "doc_catalog_entries",
+        ["catalog_id", "parent_entry_id", "slug_override"],
+        unique=True,
+        schema="negentropy",
+        postgresql_where=sa.text("slug_override IS NOT NULL"),
+    )
+
+    # =========================================================================
+    # 3) wiki_publication_snapshots：Publication snapshot 模式冻结快照
+    # =========================================================================
+    op.create_table(
+        "wiki_publication_snapshots",
+        sa.Column("publication_id", sa.UUID(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("frozen_entries", postgresql.JSONB(astext_type=sa.Text()), server_default="[]", nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), server_default="{}", nullable=True),
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["publication_id"],
+            ["negentropy.wiki_publications.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("publication_id", "version", name="uq_wiki_pub_snapshot_version"),
+        schema="negentropy",
+    )
+    op.create_index(
+        "ix_wiki_publication_snapshots_publication",
+        "wiki_publication_snapshots",
+        ["publication_id"],
+        unique=False,
+        schema="negentropy",
+    )
+
+    # =========================================================================
+    # 4) wiki_slug_redirects：历史 slug → 当前 slug 映射（GitBook 启发）
+    # =========================================================================
+    op.create_table(
+        "wiki_slug_redirects",
+        sa.Column("publication_id", sa.UUID(), nullable=False),
+        sa.Column("old_path", sa.String(length=1024), nullable=False),
+        sa.Column("new_path", sa.String(length=1024), nullable=False),
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["publication_id"],
+            ["negentropy.wiki_publications.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("publication_id", "old_path", name="uq_wiki_slug_redirect_pub_old"),
+        schema="negentropy",
+    )
+    op.create_index(
+        "ix_wiki_slug_redirects_lookup",
+        "wiki_slug_redirects",
+        ["publication_id", "old_path"],
+        unique=False,
+        schema="negentropy",
+    )
+
+    # =========================================================================
+    # 5) 扩展 wiki_publications：全部可空列，为 Phase 2 backfill 预留
+    #    注意：此处不施加 NOT NULL 与 FK 的强约束，避免迁移锁。
+    # =========================================================================
+    # 枚举类型需显式创建（在 ADD COLUMN 之前，避免 alembic 自动推断失败）
+    op.execute(sa.text("CREATE TYPE negentropy.wikipublishmode AS ENUM ('LIVE', 'SNAPSHOT')"))
+    op.execute(sa.text("CREATE TYPE negentropy.wikipublicationvisibility AS ENUM ('PRIVATE', 'INTERNAL', 'PUBLIC')"))
+
+    with op.batch_alter_table("wiki_publications", schema="negentropy") as batch_op:
+        batch_op.add_column(sa.Column("catalog_id", sa.UUID(), nullable=True))
+        batch_op.add_column(sa.Column("app_name", sa.String(length=255), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "publish_mode",
+                postgresql.ENUM(
+                    "LIVE",
+                    "SNAPSHOT",
+                    name="wikipublishmode",
+                    schema="negentropy",
+                    create_type=False,
+                ),
+                server_default="LIVE",
+                nullable=True,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "visibility",
+                postgresql.ENUM(
+                    "PRIVATE",
+                    "INTERNAL",
+                    "PUBLIC",
+                    name="wikipublicationvisibility",
+                    schema="negentropy",
+                    create_type=False,
+                ),
+                server_default="INTERNAL",
+                nullable=True,
+            )
+        )
+        batch_op.add_column(sa.Column("snapshot_version", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_wiki_publications_catalog_id",
+            "doc_catalogs",
+            ["catalog_id"],
+            ["id"],
+            ondelete="RESTRICT",
+            referent_schema="negentropy",
+        )
+
+    op.create_index(
+        "ix_wiki_publications_catalog_id",
+        "wiki_publications",
+        ["catalog_id"],
+        unique=False,
+        schema="negentropy",
+        postgresql_where=sa.text("catalog_id IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_wiki_publications_app_name",
+        "wiki_publications",
+        ["app_name"],
+        unique=False,
+        schema="negentropy",
+        postgresql_where=sa.text("app_name IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    # =========================================================================
+    # 严格按 upgrade 逆序回滚；纯加法式变更 → 回滚不涉数据丢失风险。
+    # =========================================================================
+
+    # 5) 还原 wiki_publications 扩展
+    op.drop_index(
+        "ix_wiki_publications_app_name",
+        table_name="wiki_publications",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_wiki_publications_catalog_id",
+        table_name="wiki_publications",
+        schema="negentropy",
+    )
+    with op.batch_alter_table("wiki_publications", schema="negentropy") as batch_op:
+        batch_op.drop_constraint("fk_wiki_publications_catalog_id", type_="foreignkey")
+        batch_op.drop_column("snapshot_version")
+        batch_op.drop_column("visibility")
+        batch_op.drop_column("publish_mode")
+        batch_op.drop_column("app_name")
+        batch_op.drop_column("catalog_id")
+
+    op.execute(sa.text("DROP TYPE IF EXISTS negentropy.wikipublicationvisibility"))
+    op.execute(sa.text("DROP TYPE IF EXISTS negentropy.wikipublishmode"))
+
+    # 4) 删除 wiki_slug_redirects
+    op.drop_index(
+        "ix_wiki_slug_redirects_lookup",
+        table_name="wiki_slug_redirects",
+        schema="negentropy",
+    )
+    op.drop_table("wiki_slug_redirects", schema="negentropy")
+
+    # 3) 删除 wiki_publication_snapshots
+    op.drop_index(
+        "ix_wiki_publication_snapshots_publication",
+        table_name="wiki_publication_snapshots",
+        schema="negentropy",
+    )
+    op.drop_table("wiki_publication_snapshots", schema="negentropy")
+
+    # 2) 删除 doc_catalog_entries
+    op.drop_index(
+        "uq_catalog_entry_sibling_slug_override",
+        table_name="doc_catalog_entries",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_doc_catalog_entries_source_corpus",
+        table_name="doc_catalog_entries",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_doc_catalog_entries_document",
+        table_name="doc_catalog_entries",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_doc_catalog_entries_parent",
+        table_name="doc_catalog_entries",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_doc_catalog_entries_catalog_status",
+        table_name="doc_catalog_entries",
+        schema="negentropy",
+    )
+    op.drop_table("doc_catalog_entries", schema="negentropy")
+    op.execute(sa.text("DROP TYPE IF EXISTS negentropy.catalogentrystatus"))
+    op.execute(sa.text("DROP TYPE IF EXISTS negentropy.catalogentrynodetype"))
+
+    # 1) 删除 doc_catalogs
+    op.drop_index(
+        "ix_doc_catalogs_is_archived",
+        table_name="doc_catalogs",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_doc_catalogs_owner_id",
+        table_name="doc_catalogs",
+        schema="negentropy",
+    )
+    op.drop_index(
+        "ix_doc_catalogs_app_name",
+        table_name="doc_catalogs",
+        schema="negentropy",
+    )
+    op.drop_table("doc_catalogs", schema="negentropy")
+    op.execute(sa.text("DROP TYPE IF EXISTS negentropy.catalogvisibility"))

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0004_catalog_global_phase2_backfill.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0004_catalog_global_phase2_backfill.py
@@ -1,0 +1,245 @@
+"""Catalog 全局化 Phase 2：回填存量数据（legacy → 新骨架）
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-23 00:05:00.000000+00:00
+
+按三阶段迁移策略（add → backfill → enforce）的中间阶段：
+  - 本阶段仅做**数据回填**（DML），不修改表结构（除临时映射列）。
+  - 采用 1:1 映射：每个**被引用的** corpus 产生一个 doc_catalogs 记录；
+    其下所有 doc_catalog_nodes → doc_catalog_entries（保留 id，parent 关系自然延续）；
+    doc_catalog_memberships → 派生 DOCUMENT_REF 叶节点。
+  - wiki_publications 的 catalog_id / app_name / publish_mode / visibility 同步回填。
+
+临时映射字段：
+  - doc_catalogs.legacy_corpus_id UUID UNIQUE（仅存在于 Phase 2 ~ Phase 3 之间）
+    作用：避免 INSERT RETURNING + 临时表的复杂性，给跨表 JOIN 提供稳定的映射键。
+    Phase 3 upgrade 起始将 DROP 此列。
+
+幂等性：
+  - 本阶段使用 `ON CONFLICT DO NOTHING` 与 `WHERE NOT EXISTS` 双保险，
+    允许被打断后重新执行。
+
+Downgrade 策略：
+  - 反向删除回填数据（所有 doc_catalog_entries / doc_catalogs），
+    wiki_publications 的回填列 NULL 化，DROP 临时映射列。
+  - 由于 Phase 2 的映射是 1:1（一 corpus 对应一 catalog），
+    降级不会丢失业务语义，只会回到"未回填"的空白状态。
+
+设计溯源：
+  - MediaWiki Category 成员平移 [1]
+  - PG "ALTER TABLE ... ADD COLUMN" online 添加可空列零锁 [2]
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # =========================================================================
+    # 0) 临时映射列：doc_catalogs.legacy_corpus_id
+    #    - 用于 Phase 2 & Phase 3 跨表 JOIN 的稳定键；
+    #    - Phase 3 upgrade 起始会 DROP 此列。
+    # =========================================================================
+    op.execute(
+        sa.text("""
+            ALTER TABLE negentropy.doc_catalogs
+            ADD COLUMN IF NOT EXISTS legacy_corpus_id UUID
+        """)
+    )
+    op.execute(
+        sa.text("""
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_doc_catalogs_legacy_corpus_id
+            ON negentropy.doc_catalogs (legacy_corpus_id)
+            WHERE legacy_corpus_id IS NOT NULL
+        """)
+    )
+
+    # =========================================================================
+    # 1) 为每个被引用的 corpus 创建 1 个 doc_catalogs 记录
+    #    - 被引用 = 拥有 doc_catalog_nodes 或 wiki_publications；
+    #    - 规避冲突：`ON CONFLICT (legacy_corpus_id) DO NOTHING` 使本步幂等。
+    # =========================================================================
+    op.execute(
+        sa.text("""
+            INSERT INTO negentropy.doc_catalogs (
+                id, app_name, name, slug, owner_id, visibility,
+                is_archived, version, description, config,
+                legacy_corpus_id, created_at, updated_at
+            )
+            SELECT
+                gen_random_uuid(),
+                c.app_name,
+                c.name,
+                'corpus-' || substr(c.id::text, 1, 8),
+                NULL,
+                'INTERNAL'::negentropy.catalogvisibility,
+                false,
+                1,
+                c.description,
+                COALESCE(c.config, '{}'::jsonb),
+                c.id,
+                c.created_at,
+                c.updated_at
+            FROM negentropy.corpus c
+            WHERE c.id IN (
+                SELECT DISTINCT corpus_id FROM negentropy.doc_catalog_nodes
+                UNION
+                SELECT DISTINCT corpus_id FROM negentropy.wiki_publications
+            )
+            ON CONFLICT DO NOTHING
+        """)
+    )
+
+    # =========================================================================
+    # 2) 回填 doc_catalog_entries（来自 doc_catalog_nodes）
+    #    - **关键设计**：保留 legacy node.id → 新 entry.id，
+    #      这样 parent_entry_id 直接等于 legacy parent_id，无需额外映射；
+    #    - node_type 从 lowercase 字符串升级为 UPPERCASE 枚举；
+    #    - slug 迁入 slug_override（保持 URL 稳定）；
+    #    - source_corpus_id 冗余写入（= n.corpus_id），用于权限快速校验。
+    # =========================================================================
+    op.execute(
+        sa.text("""
+            INSERT INTO negentropy.doc_catalog_entries (
+                id, catalog_id, parent_entry_id, document_id, source_corpus_id,
+                node_type, name, slug_override, position, status,
+                description, config, created_at, updated_at
+            )
+            SELECT
+                n.id,
+                dc.id AS catalog_id,
+                n.parent_id AS parent_entry_id,
+                NULL::UUID,
+                n.corpus_id AS source_corpus_id,
+                UPPER(n.node_type)::negentropy.catalogentrynodetype,
+                n.name,
+                n.slug AS slug_override,
+                n.sort_order,
+                'ACTIVE'::negentropy.catalogentrystatus,
+                n.description,
+                COALESCE(n.config, '{}'::jsonb),
+                n.created_at,
+                n.updated_at
+            FROM negentropy.doc_catalog_nodes n
+            JOIN negentropy.doc_catalogs dc ON dc.legacy_corpus_id = n.corpus_id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM negentropy.doc_catalog_entries e WHERE e.id = n.id
+            )
+        """)
+    )
+
+    # =========================================================================
+    # 3) 回填 DOCUMENT_REF 叶节点（来自 doc_catalog_memberships）
+    #    - 每条 membership → 一个新的 entry (父为对应 catalog_node_id)；
+    #    - 名称合成：original_filename + '#id前缀'（防止同父下重名），
+    #      源 document 缺失时回退为 'doc-{id前缀}'；
+    #    - 幂等：用 (parent_entry_id, document_id) 反查去重。
+    # =========================================================================
+    op.execute(
+        sa.text("""
+            INSERT INTO negentropy.doc_catalog_entries (
+                id, catalog_id, parent_entry_id, document_id, source_corpus_id,
+                node_type, name, slug_override, position, status,
+                description, config, created_at, updated_at
+            )
+            SELECT
+                gen_random_uuid(),
+                dc.id,
+                m.catalog_node_id,
+                m.document_id,
+                n.corpus_id,
+                'DOCUMENT_REF'::negentropy.catalogentrynodetype,
+                COALESCE(NULLIF(TRIM(d.original_filename), ''), 'doc-' || substr(m.document_id::text, 1, 8))
+                    || ' #' || substr(m.document_id::text, 1, 8),
+                NULL,
+                0,
+                'ACTIVE'::negentropy.catalogentrystatus,
+                NULL,
+                '{}'::jsonb,
+                m.created_at,
+                m.updated_at
+            FROM negentropy.doc_catalog_memberships m
+            JOIN negentropy.doc_catalog_nodes n ON n.id = m.catalog_node_id
+            JOIN negentropy.doc_catalogs dc ON dc.legacy_corpus_id = n.corpus_id
+            LEFT JOIN negentropy.knowledge_documents d ON d.id = m.document_id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM negentropy.doc_catalog_entries e
+                WHERE e.parent_entry_id = m.catalog_node_id
+                  AND e.document_id = m.document_id
+                  AND e.node_type = 'DOCUMENT_REF'::negentropy.catalogentrynodetype
+            )
+        """)
+    )
+
+    # =========================================================================
+    # 4) 回填 wiki_publications 的可空列
+    #    - catalog_id：经由 legacy_corpus_id 映射；
+    #    - app_name：直接从 corpus.app_name 拷贝；
+    #    - publish_mode = 'LIVE'（默认，未来可显式切 snapshot）；
+    #    - visibility = 'INTERNAL'（默认，与 Phase 1 server_default 对齐）。
+    # =========================================================================
+    op.execute(
+        sa.text("""
+            UPDATE negentropy.wiki_publications wp
+            SET
+                catalog_id = dc.id,
+                app_name = c.app_name,
+                publish_mode = COALESCE(wp.publish_mode, 'LIVE'::negentropy.wikipublishmode),
+                visibility = COALESCE(wp.visibility, 'INTERNAL'::negentropy.wikipublicationvisibility)
+            FROM negentropy.doc_catalogs dc
+            JOIN negentropy.corpus c ON c.id = dc.legacy_corpus_id
+            WHERE dc.legacy_corpus_id = wp.corpus_id
+              AND wp.catalog_id IS NULL
+        """)
+    )
+
+
+def downgrade() -> None:
+    # =========================================================================
+    # 严格按 upgrade 逆序回滚。Phase 2 纯数据操作，无结构变更。
+    # =========================================================================
+
+    # 4) 回滚 wiki_publications 的回填字段
+    op.execute(
+        sa.text("""
+            UPDATE negentropy.wiki_publications
+            SET
+                catalog_id = NULL,
+                app_name = NULL,
+                publish_mode = NULL,
+                visibility = NULL,
+                snapshot_version = NULL
+            WHERE catalog_id IS NOT NULL
+               OR app_name IS NOT NULL
+               OR publish_mode IS NOT NULL
+               OR visibility IS NOT NULL
+               OR snapshot_version IS NOT NULL
+        """)
+    )
+
+    # 3) + 2) 清空 doc_catalog_entries（先叶节点再普通节点，避免 FK 级联歧义）
+    #     由于 parent_entry_id 自引用 ON DELETE CASCADE，直接全量 DELETE 即可。
+    op.execute(sa.text("DELETE FROM negentropy.doc_catalog_entries"))
+
+    # 1) 清空 doc_catalogs
+    op.execute(sa.text("DELETE FROM negentropy.doc_catalogs"))
+
+    # 0) 撤销临时映射列
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.uq_doc_catalogs_legacy_corpus_id"))
+    op.execute(
+        sa.text("""
+            ALTER TABLE negentropy.doc_catalogs
+            DROP COLUMN IF EXISTS legacy_corpus_id
+        """)
+    )

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0005_catalog_global_phase3_enforce.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0005_catalog_global_phase3_enforce.py
@@ -1,0 +1,304 @@
+"""Catalog 全局化 Phase 3：施加约束 + DROP legacy 表
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-23 12:00:00.000000+00:00
+
+按三阶段迁移策略（add → backfill → enforce）的收尾阶段：
+  - 收尾 Phase 1 新增的 nullable 列：catalog_id / app_name / publish_mode / visibility → NOT NULL
+  - 约束切换：UNIQUE(corpus_id, slug) → UNIQUE(catalog_id, slug)
+  - DROP 临时映射列 doc_catalogs.legacy_corpus_id
+  - DROP wiki_publications.corpus_id（及其 FK / 约束 / 索引）
+  - DROP legacy 表 doc_catalog_nodes + doc_catalog_memberships（FK CASCADE 自动清理）
+
+**原子性约束**：本 migration 必须与 ORM 模型更新（perception.py）在同一 commit，
+否则 WikiPublication.corpus_id NOT NULL 与 DROP 后的数据库真相冲突，
+test_migrations_stairway roundtrip 必然失败。
+
+Downgrade 策略：
+  - 防御守卫：若存在跨 corpus catalog（单 catalog 的 entries 涉及 2+ distinct source_corpus_id），
+    拒绝降级并抛 RuntimeError（降级会丢失跨 corpus 引用语义）。
+  - 通过守卫后：重建 legacy 表骨架、复活 corpus_id 列、反向回填 catalog_nodes/memberships、
+    复位 catalog_id/app_name/publish_mode/visibility → nullable。
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # =========================================================================
+    # 0) 收尾 Phase 1 新增的 nullable 列 → NOT NULL
+    #    Phase 2 backfill 已确保所有行有非 NULL 值。
+    # =========================================================================
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN catalog_id SET NOT NULL"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN app_name SET NOT NULL"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN publish_mode SET NOT NULL"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN visibility SET NOT NULL"))
+
+    # =========================================================================
+    # 1) 约束切换：UNIQUE(corpus_id, slug) → UNIQUE(catalog_id, slug)
+    #    同时清理旧 corpus_id 相关索引。
+    # =========================================================================
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications DROP CONSTRAINT uq_wiki_pub_corpus_slug"))
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.ix_wiki_publications_corpus_id"))
+    op.execute(
+        sa.text(
+            "ALTER TABLE negentropy.wiki_publications ADD CONSTRAINT uq_wiki_pub_catalog_slug UNIQUE (catalog_id, slug)"
+        )
+    )
+
+    # 重建 catalog_id / app_name 全量索引（移除 WHERE IS NOT NULL 条件）
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.ix_wiki_publications_catalog_id"))
+    op.execute(sa.text("CREATE INDEX ix_wiki_publications_catalog_id ON negentropy.wiki_publications (catalog_id)"))
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.ix_wiki_publications_app_name"))
+    op.execute(sa.text("CREATE INDEX ix_wiki_publications_app_name ON negentropy.wiki_publications (app_name)"))
+
+    # =========================================================================
+    # 2) DROP 临时映射列 + corpus_id FK
+    # =========================================================================
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications DROP COLUMN corpus_id"))
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.uq_doc_catalogs_legacy_corpus_id"))
+    op.execute(sa.text("ALTER TABLE negentropy.doc_catalogs DROP COLUMN IF EXISTS legacy_corpus_id"))
+
+    # =========================================================================
+    # 3) DROP legacy 表
+    #    doc_catalog_memberships FK → doc_catalog_nodes (CASCADE)
+    #    doc_catalog_nodes FK → corpus (CASCADE)
+    #    wiki_publication_entries FK → wiki_publications (保留，不受影响)
+    #    先 DROP memberships（依赖 nodes），再 DROP nodes。
+    # =========================================================================
+    op.execute(sa.text("DROP TABLE IF EXISTS negentropy.doc_catalog_memberships"))
+    op.execute(sa.text("DROP TABLE IF EXISTS negentropy.doc_catalog_nodes"))
+
+
+def downgrade() -> None:
+    # =========================================================================
+    # 防御守卫：检测跨 corpus catalog
+    #    若任一 catalog 的 entries 涉及 2+ distinct source_corpus_id，
+    #    降级会丢失跨 corpus 引用语义，拒绝执行。
+    # =========================================================================
+    conn = op.get_bind()
+    cross = conn.execute(
+        sa.text("""
+        SELECT catalog_id FROM negentropy.doc_catalog_entries
+        WHERE source_corpus_id IS NOT NULL
+        GROUP BY catalog_id HAVING COUNT(DISTINCT source_corpus_id) > 1
+    """)
+    ).fetchall()
+    if cross:
+        raise RuntimeError(
+            f"拒绝降级：{len(cross)} 个 catalog 包含跨 corpus 文档，"
+            "降级会丢失跨 corpus 引用。请先手动梳理这些 catalog。"
+        )
+
+    # =========================================================================
+    # 1) 重建 legacy 表骨架（DDL 镜像 0001_init_schema.py L452-477 / L687-706）
+    # =========================================================================
+    op.execute(
+        sa.text("""
+        CREATE TABLE negentropy.doc_catalog_nodes (
+            corpus_id     UUID NOT NULL REFERENCES negentropy.corpus(id) ON DELETE CASCADE,
+            parent_id     UUID REFERENCES negentropy.doc_catalog_nodes(id) ON DELETE SET NULL,
+            name          VARCHAR(255) NOT NULL,
+            slug          VARCHAR(255) NOT NULL,
+            node_type     VARCHAR(20) NOT NULL DEFAULT 'category',
+            description   TEXT,
+            sort_order    INTEGER NOT NULL DEFAULT 0,
+            config        JSONB DEFAULT '{}',
+            id            UUID NOT NULL DEFAULT gen_random_uuid(),
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (id)
+        )
+    """)
+    )
+    op.execute(sa.text("ALTER TABLE negentropy.doc_catalog_nodes SET SCHEMA negentropy"))
+    op.execute(
+        sa.text("""
+        CREATE UNIQUE INDEX uq_catalog_sibling_name
+        ON negentropy.doc_catalog_nodes (corpus_id, parent_id, name)
+    """)
+    )
+    op.execute(
+        sa.text("""
+        CREATE UNIQUE INDEX uq_catalog_corpus_slug
+        ON negentropy.doc_catalog_nodes (corpus_id, slug)
+    """)
+    )
+    op.execute(
+        sa.text("""
+        CREATE INDEX ix_doc_catalog_nodes_corpus_id
+        ON negentropy.doc_catalog_nodes (corpus_id)
+    """)
+    )
+    op.execute(
+        sa.text("""
+        CREATE INDEX ix_doc_catalog_nodes_parent_id
+        ON negentropy.doc_catalog_nodes (parent_id)
+    """)
+    )
+
+    op.execute(
+        sa.text("""
+        CREATE TABLE negentropy.doc_catalog_memberships (
+            catalog_node_id UUID NOT NULL REFERENCES negentropy.doc_catalog_nodes(id) ON DELETE CASCADE,
+            document_id     UUID NOT NULL REFERENCES negentropy.knowledge_documents(id) ON DELETE CASCADE,
+            id              UUID NOT NULL DEFAULT gen_random_uuid(),
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (id)
+        )
+    """)
+    )
+    op.execute(sa.text("ALTER TABLE negentropy.doc_catalog_memberships SET SCHEMA negentropy"))
+    op.execute(
+        sa.text("""
+        CREATE UNIQUE INDEX uq_catalog_membership_unique
+        ON negentropy.doc_catalog_memberships (catalog_node_id, document_id)
+    """)
+    )
+    op.execute(
+        sa.text("""
+        CREATE INDEX ix_catalog_memberships_document_id
+        ON negentropy.doc_catalog_memberships (document_id)
+    """)
+    )
+
+    # =========================================================================
+    # 2) 复活 wiki_publications.corpus_id + 重建临时映射列
+    # =========================================================================
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ADD COLUMN corpus_id UUID"))
+    op.execute(sa.text("ALTER TABLE negentropy.doc_catalogs ADD COLUMN legacy_corpus_id UUID"))
+
+    # =========================================================================
+    # 3) 反向回填：doc_catalog_entries → doc_catalog_nodes + doc_catalog_memberships
+    #    镜像 Phase 2 回填逻辑（方向取反）。
+    #    - CATEGORY/COLLECTION entries → doc_catalog_nodes（保留 id = node.id）
+    #    - DOCUMENT_REF entries → doc_catalog_memberships
+    #    - legacy_corpus_id 映射从 source_corpus_id 推导
+    # =========================================================================
+
+    # 3a) 从 entries 推导 legacy_corpus_id 映射
+    #     每个 catalog 取其 entries 中的 source_corpus_id（Phase 2 是 1:1，此处同）
+    op.execute(
+        sa.text("""
+        UPDATE negentropy.doc_catalogs dc
+        SET legacy_corpus_id = sub.source_corpus_id
+        FROM (
+            SELECT DISTINCT catalog_id, source_corpus_id
+            FROM negentropy.doc_catalog_entries
+            WHERE source_corpus_id IS NOT NULL
+            GROUP BY catalog_id, source_corpus_id
+            -- 单 corpus catalog 取第一条（1:1 场景）
+        ) sub
+        WHERE dc.id = sub.catalog_id
+          AND dc.legacy_corpus_id IS NULL
+    """)
+    )
+
+    # 3b) 回填 doc_catalog_nodes（仅非 DOCUMENT_REF 的 entry）
+    op.execute(
+        sa.text("""
+        INSERT INTO negentropy.doc_catalog_nodes (
+            id, corpus_id, parent_id, name, slug, node_type,
+            description, sort_order, config, created_at, updated_at
+        )
+        SELECT
+            e.id,
+            e.source_corpus_id,
+            e.parent_entry_id,
+            e.name,
+            COALESCE(e.slug_override, LOWER(e.name)),
+            LOWER(e.node_type),
+            e.description,
+            e.position,
+            COALESCE(e.config, '{}'::jsonb),
+            e.created_at,
+            e.updated_at
+        FROM negentropy.doc_catalog_entries e
+        WHERE e.node_type IN ('CATEGORY', 'COLLECTION')
+          AND NOT EXISTS (
+              SELECT 1 FROM negentropy.doc_catalog_nodes n WHERE n.id = e.id
+          )
+    """)
+    )
+
+    # 3c) 回填 doc_catalog_memberships（DOCUMENT_REF entries）
+    op.execute(
+        sa.text("""
+        INSERT INTO negentropy.doc_catalog_memberships (
+            catalog_node_id, document_id, id, created_at, updated_at
+        )
+        SELECT
+            e.parent_entry_id,
+            e.document_id,
+            gen_random_uuid(),
+            e.created_at,
+            e.updated_at
+        FROM negentropy.doc_catalog_entries e
+        WHERE e.node_type = 'DOCUMENT_REF'
+          AND e.document_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM negentropy.doc_catalog_memberships m
+              WHERE m.catalog_node_id = e.parent_entry_id
+                AND m.document_id = e.document_id
+          )
+    """)
+    )
+
+    # 3d) 回填 wiki_publications.corpus_id
+    op.execute(
+        sa.text("""
+        UPDATE negentropy.wiki_publications wp
+        SET corpus_id = dc.legacy_corpus_id
+        FROM negentropy.doc_catalogs dc
+        WHERE wp.catalog_id = dc.id
+          AND dc.legacy_corpus_id IS NOT NULL
+          AND wp.corpus_id IS NULL
+    """)
+    )
+
+    # =========================================================================
+    # 4) 约束复位
+    #    DROP UNIQUE(catalog_id, slug) → RESTORE UNIQUE(corpus_id, slug)
+    #    catalog_id/app_name/publish_mode/visibility → nullable
+    #    索引恢复为部分索引
+    # =========================================================================
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications DROP CONSTRAINT uq_wiki_pub_catalog_slug"))
+    op.execute(
+        sa.text(
+            "ALTER TABLE negentropy.wiki_publications ADD CONSTRAINT uq_wiki_pub_corpus_slug UNIQUE (corpus_id, slug)"
+        )
+    )
+    op.execute(sa.text("CREATE INDEX ix_wiki_publications_corpus_id ON negentropy.wiki_publications (corpus_id)"))
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.ix_wiki_publications_catalog_id"))
+    op.execute(
+        sa.text("""
+        CREATE INDEX ix_wiki_publications_catalog_id
+        ON negentropy.wiki_publications (catalog_id)
+        WHERE catalog_id IS NOT NULL
+    """)
+    )
+    op.execute(sa.text("DROP INDEX IF EXISTS negentropy.ix_wiki_publications_app_name"))
+    op.execute(
+        sa.text("""
+        CREATE INDEX ix_wiki_publications_app_name
+        ON negentropy.wiki_publications (app_name)
+        WHERE app_name IS NOT NULL
+    """)
+    )
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN catalog_id DROP NOT NULL"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN app_name DROP NOT NULL"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN publish_mode DROP NOT NULL"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ALTER COLUMN visibility DROP NOT NULL"))

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3629,10 +3629,10 @@ def _get_catalog_service() -> CatalogService:
 
 
 def _to_catalog_node_resp(row: dict, *, children_count: int = 0, document_count: int = 0) -> _CatalogNodeResp:
-    """将 DAO 树查询行转换为 API 响应 Schema"""
+    """将 DAO 树查询行（dict）转换为 API 响应 Schema"""
     return _CatalogNodeResp(
         id=row["id"],
-        corpus_id=UUID("00000000-0000-0000-0000-000000000000"),  # tree query 不返回 corpus_id，由调用方补充
+        catalog_id=row["catalog_id"],
         parent_id=row.get("parent_id"),
         name=row["name"],
         slug=row["slug"],
@@ -3646,20 +3646,42 @@ def _to_catalog_node_resp(row: dict, *, children_count: int = 0, document_count:
     )
 
 
+def _entry_orm_to_resp(
+    entry: Any, *, depth: int = 0, children_count: int = 0, document_count: int = 0
+) -> _CatalogNodeResp:
+    """将 DocCatalogEntry ORM 对象转换为 API 响应 Schema"""
+    from negentropy.knowledge.catalog_dao import _ENUM_TO_NODE_TYPE, _compute_slug
+
+    return _CatalogNodeResp(
+        id=entry.id,
+        catalog_id=entry.catalog_id,
+        parent_id=entry.parent_entry_id,
+        name=entry.name,
+        slug=_compute_slug(entry.name, entry.slug_override),
+        node_type=_ENUM_TO_NODE_TYPE.get(entry.node_type, entry.node_type) if entry.node_type else "category",
+        description=entry.description,
+        sort_order=entry.position or 0,
+        config=entry.config or {},
+        depth=depth,
+        children_count=children_count,
+        document_count=document_count,
+    )
+
+
 # --- 目录树查询 ---
 
 
-@router.get("/catalog/tree/{corpus_id}")
+@router.get("/catalog/tree/{catalog_id}")
 async def get_catalog_tree(
-    corpus_id: UUID,
+    catalog_id: UUID,
 ) -> CatalogTreeResponse:
-    """获取语料库完整目录树
+    """获取 Catalog 完整目录树
 
     返回扁平化的节点列表，每个节点含 depth（层级深度）和 path（祖先路径），
     前端可根据这些信息构建树形 UI 组件。
 
     Args:
-        corpus_id: 语料库 ID
+        catalog_id: Catalog ID
 
     Returns:
         目录树节点列表及统计信息
@@ -3667,7 +3689,7 @@ async def get_catalog_tree(
     catalog_svc = _get_catalog_service()
 
     async with AsyncSessionLocal() as db:
-        tree_data = await catalog_svc.get_tree(db, corpus_id)
+        tree_data = await catalog_svc.get_tree(db, catalog_id)
 
     # 计算每个节点的子节点数
     id_to_children_count: dict[UUID, int] = {}
@@ -3688,7 +3710,7 @@ async def get_catalog_tree(
 
     logger.info(
         "api_get_catalog_tree",
-        corpus_id=str(corpus_id),
+        catalog_id=str(catalog_id),
         total_nodes=len(items),
         max_depth=max_depth,
     )
@@ -3708,7 +3730,7 @@ async def get_catalog_node(node_id: UUID) -> _CatalogNodeResp:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Catalog node not found")
 
     logger.info("api_get_catalog_node", node_id=str(node_id))
-    return _CatalogNodeResp.model_validate(node)
+    return _entry_orm_to_resp(node)
 
 
 @router.get("/catalog/subtree/{node_id}")
@@ -3731,7 +3753,7 @@ async def get_catalog_subtree(node_id: UUID) -> CatalogTreeResponse:
 @router.post("/catalog/nodes")
 async def create_catalog_node(
     body: _CatalogNodeCreateReq,
-    corpus_id: UUID = Query(..., description="所属语料库 ID"),
+    catalog_id: UUID = Query(..., description="所属 Catalog ID"),
 ) -> _CatalogNodeResp:
     """创建目录节点
 
@@ -3744,7 +3766,7 @@ async def create_catalog_node(
         try:
             node = await catalog_svc.create_node(
                 db,
-                corpus_id=corpus_id,
+                catalog_id=catalog_id,
                 name=body.name,
                 slug=body.slug,
                 parent_id=body.parent_id,
@@ -3757,10 +3779,8 @@ async def create_catalog_node(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
         await db.commit()
 
-    logger.info("api_create_catalog_node", node_id=str(node.id), corpus_id=str(corpus_id))
-    resp = _CatalogNodeResp.model_validate(node)
-    resp.corpus_id = corpus_id
-    return resp
+    logger.info("api_create_catalog_node", node_id=str(node.id), catalog_id=str(catalog_id))
+    return _entry_orm_to_resp(node)
 
 
 @router.patch("/catalog/nodes/{node_id}")
@@ -3788,7 +3808,7 @@ async def update_catalog_node(
         await db.commit()
 
     logger.info("api_update_catalog_node", node_id=str(node_id))
-    return _CatalogNodeResp.model_validate(node)
+    return _entry_orm_to_resp(node)
 
 
 @router.delete("/catalog/nodes/{node_id}")
@@ -3832,7 +3852,7 @@ async def move_catalog_node(
     logger.info(
         "api_move_catalog_node", node_id=str(node_id), new_parent_id=str(new_parent_id) if new_parent_id else "root"
     )
-    return _CatalogNodeResp.model_validate(node)
+    return _entry_orm_to_resp(node)
 
 
 # --- 文档归属管理 ---
@@ -3853,7 +3873,7 @@ async def assign_documents_to_node(
             try:
                 await catalog_svc.assign_document(db, node_id, doc_id)
                 assigned_count += 1
-            except ValueError as exc:
+            except (ValueError, PermissionError) as exc:
                 errors.append(f"{doc_id}: {exc}")
 
         await db.commit()
@@ -3972,7 +3992,7 @@ async def create_wiki_publication(
         try:
             pub = await wiki_svc.create_publication(
                 db,
-                corpus_id=body.corpus_id,
+                catalog_id=body.catalog_id,
                 name=body.name,
                 slug=body.slug,
                 description=body.description,
@@ -3982,7 +4002,7 @@ async def create_wiki_publication(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
         await db.commit()
 
-    logger.info("api_create_wiki_pub", pub_id=str(pub.id), corpus_id=str(body.corpus_id))
+    logger.info("api_create_wiki_pub", pub_id=str(pub.id), catalog_id=str(body.catalog_id))
     resp = _WikiPubResp.model_validate(pub)
     resp.entries_count = 0
     return resp
@@ -3990,7 +4010,7 @@ async def create_wiki_publication(
 
 @router.get("/wiki/publications")
 async def list_wiki_publications(
-    corpus_id: UUID | None = Query(default=None),
+    catalog_id: UUID | None = Query(default=None),
     status: str | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=50, ge=1, le=200),
@@ -4000,7 +4020,7 @@ async def list_wiki_publications(
 
     async with AsyncSessionLocal() as db:
         pubs, total = await wiki_svc.list_publications(
-            db, corpus_id=corpus_id, status=status, offset=offset, limit=limit
+            db, catalog_id=catalog_id, status=status, offset=offset, limit=limit
         )
 
     items = []

--- a/apps/negentropy/src/negentropy/knowledge/catalog_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/catalog_dao.py
@@ -1,93 +1,208 @@
 """
 文档目录编目 — 数据访问层 (DAO)
 
-提供 DocCatalogNode / DocCatalogMembership 表的 CRUD 操作，
-包含 PostgreSQL Recursive CTE 树查询实现。
+Phase 6 重写：基于 DocCatalog（全局顶层）+ DocCatalogEntry（N:M 融合节点）。
+保留与旧接口兼容的节点方法（corpus_id 参数已改为 catalog_id）。
 """
 
 from __future__ import annotations
 
 import logging
+import re
+import unicodedata
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import (
-    func,
-    select,
-    text,
-)
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from negentropy.models.base import NEGENTROPY_SCHEMA
-from negentropy.models.perception import (
-    DocCatalogMembership,
-    DocCatalogNode,
-    KnowledgeDocument,
-)
+from negentropy.models.perception import DocCatalog, DocCatalogEntry, KnowledgeDocument
 
 logger = logging.getLogger(__name__.rsplit(".", 1)[0])
 
 # 目录树最大递归深度（防止无限循环或超深树导致性能问题）
 MAX_TREE_DEPTH = 6
 
+# node_type 大小写映射（API 层传入小写，ORM Enum 存储大写）
+_NODE_TYPE_TO_ENUM = {"category": "CATEGORY", "collection": "COLLECTION", "document_ref": "DOCUMENT_REF"}
+_ENUM_TO_NODE_TYPE = {"CATEGORY": "category", "COLLECTION": "collection", "DOCUMENT_REF": "document_ref"}
+
+
+def _compute_slug(name: str, slug_override: str | None) -> str:
+    """从 slug_override 或 name 派生 URL-friendly slug（供树查询行使用）"""
+    if slug_override:
+        return slug_override
+    normalized = unicodedata.normalize("NFKC", name or "").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized).strip("-")
+    return re.sub(r"-{2,}", "-", slug) or "untitled"
+
 
 class CatalogDao:
-    """目录节点数据访问对象"""
+    """DocCatalog 顶层 CRUD + DocCatalogEntry 节点操作"""
 
     # ------------------------------------------------------------------
-    # 节点 CRUD
+    # DocCatalog 顶层 CRUD
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def create_catalog(
+        db: AsyncSession,
+        *,
+        app_name: str,
+        name: str,
+        slug: str,
+        owner_id: str | None = None,
+        description: str | None = None,
+        visibility: str = "INTERNAL",
+        config: dict | None = None,
+    ) -> DocCatalog:
+        """创建 Catalog（初始版本为 1，未归档）"""
+        catalog = DocCatalog(
+            app_name=app_name,
+            name=name,
+            slug=slug,
+            owner_id=owner_id,
+            description=description,
+            visibility=visibility,
+            config=config or {},
+            version=1,
+            is_archived=False,
+        )
+        db.add(catalog)
+        await db.flush()
+        logger.info(
+            "catalog_created",
+            extra={"id": str(catalog.id), "app_name": app_name, "slug": slug},
+        )
+        return catalog
+
+    @staticmethod
+    async def get_catalog(db: AsyncSession, catalog_id: UUID) -> DocCatalog | None:
+        """按 ID 获取 Catalog"""
+        result = await db.execute(select(DocCatalog).where(DocCatalog.id == catalog_id))
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def get_catalog_by_slug(db: AsyncSession, app_name: str, slug: str) -> DocCatalog | None:
+        """按 app_name + slug 获取 Catalog（slug 在租户内唯一）"""
+        result = await db.execute(select(DocCatalog).where(DocCatalog.app_name == app_name, DocCatalog.slug == slug))
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def list_catalogs(
+        db: AsyncSession,
+        *,
+        app_name: str | None = None,
+        include_archived: bool = False,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[DocCatalog], int]:
+        """列出 Catalog（支持按 app_name 过滤、归档过滤）"""
+        query = select(DocCatalog)
+        count_base = select(func.count()).select_from(DocCatalog)
+        if app_name is not None:
+            query = query.where(DocCatalog.app_name == app_name)
+            count_base = count_base.where(DocCatalog.app_name == app_name)
+        if not include_archived:
+            query = query.where(DocCatalog.is_archived.is_(False))
+            count_base = count_base.where(DocCatalog.is_archived.is_(False))
+        total = (await db.execute(count_base)).scalar() or 0
+        query = query.order_by(DocCatalog.created_at.desc()).offset(offset).limit(limit)
+        items = list((await db.execute(query)).scalars().all())
+        return items, total
+
+    @staticmethod
+    async def update_catalog(db: AsyncSession, catalog_id: UUID, **kwargs: Any) -> DocCatalog | None:
+        """更新 Catalog 属性（不允许修改 app_name）"""
+        catalog = await CatalogDao.get_catalog(db, catalog_id)
+        if catalog is None:
+            return None
+        allowed = {"name", "description", "visibility", "config"}
+        for k, v in kwargs.items():
+            if k in allowed and v is not None:
+                setattr(catalog, k, v)
+        await db.flush()
+        return catalog
+
+    @staticmethod
+    async def archive_catalog(db: AsyncSession, catalog_id: UUID) -> DocCatalog | None:
+        """软归档 Catalog（is_archived=True）"""
+        catalog = await CatalogDao.get_catalog(db, catalog_id)
+        if catalog is None:
+            return None
+        catalog.is_archived = True
+        await db.flush()
+        logger.info("catalog_archived", extra={"id": str(catalog_id)})
+        return catalog
+
+    @staticmethod
+    async def delete_catalog(db: AsyncSession, catalog_id: UUID) -> bool:
+        """删除 Catalog（级联删除所有 entries）"""
+        catalog = await CatalogDao.get_catalog(db, catalog_id)
+        if catalog is None:
+            return False
+        await db.delete(catalog)
+        await db.flush()
+        logger.info("catalog_deleted", extra={"id": str(catalog_id)})
+        return True
+
+    # ------------------------------------------------------------------
+    # DocCatalogEntry 节点操作（接口对齐旧 DocCatalogNode；corpus_id → catalog_id）
     # ------------------------------------------------------------------
 
     @staticmethod
     async def create_node(
         db: AsyncSession,
         *,
-        corpus_id: UUID,
+        catalog_id: UUID,
         name: str,
-        slug: str,
+        slug: str | None = None,
         parent_id: UUID | None = None,
         node_type: str = "category",
         description: str | None = None,
         sort_order: int = 0,
         config: dict | None = None,
-    ) -> DocCatalogNode:
-        """创建目录节点"""
-        node = DocCatalogNode(
-            corpus_id=corpus_id,
+    ) -> DocCatalogEntry:
+        """创建目录条目节点（CATEGORY / COLLECTION）"""
+        entry = DocCatalogEntry(
+            catalog_id=catalog_id,
             name=name,
-            slug=slug,
-            parent_id=parent_id,
-            node_type=node_type,
+            slug_override=slug or None,
+            parent_entry_id=parent_id,
+            node_type=_NODE_TYPE_TO_ENUM.get(node_type, "CATEGORY"),
             description=description,
-            sort_order=sort_order,
+            position=sort_order,
             config=config or {},
+            status="ACTIVE",
         )
-        db.add(node)
+        db.add(entry)
         await db.flush()
         logger.info(
             "catalog_node_created",
             extra={
-                "id": str(node.id),
-                "corpus_id": str(corpus_id),
+                "id": str(entry.id),
+                "catalog_id": str(catalog_id),
                 "node_name": name,
-                "slug": slug,
+                "slug_override": slug,
                 "parent_id": str(parent_id) if parent_id else None,
             },
         )
-        return node
+        return entry
 
     @staticmethod
-    async def get_node(db: AsyncSession, node_id: UUID) -> DocCatalogNode | None:
-        """按 ID 获取节点"""
-        result = await db.execute(select(DocCatalogNode).where(DocCatalogNode.id == node_id))
+    async def get_node(db: AsyncSession, node_id: UUID) -> DocCatalogEntry | None:
+        """按 ID 获取条目节点"""
+        result = await db.execute(select(DocCatalogEntry).where(DocCatalogEntry.id == node_id))
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def get_node_by_slug(db: AsyncSession, corpus_id: UUID, slug: str) -> DocCatalogNode | None:
-        """按 corpus + slug 获取节点（slug 在同一 corpus 内唯一）"""
+    async def get_node_by_slug(db: AsyncSession, catalog_id: UUID, slug: str) -> DocCatalogEntry | None:
+        """按 catalog_id + slug_override 获取节点"""
         result = await db.execute(
-            select(DocCatalogNode).where(
-                DocCatalogNode.corpus_id == corpus_id,
-                DocCatalogNode.slug == slug,
+            select(DocCatalogEntry).where(
+                DocCatalogEntry.catalog_id == catalog_id,
+                DocCatalogEntry.slug_override == slug,
             )
         )
         return result.scalar_one_or_none()
@@ -104,281 +219,290 @@ class CatalogDao:
         description: str | None = None,
         sort_order: int | None = None,
         config: dict | None = None,
-    ) -> DocCatalogNode | None:
-        """更新目录节点（仅更新传入的非 None 字段）"""
-        node = await CatalogDao.get_node(db, node_id)
-        if node is None:
+    ) -> DocCatalogEntry | None:
+        """更新目录条目节点（仅更新传入的非 None 字段）"""
+        entry = await CatalogDao.get_node(db, node_id)
+        if entry is None:
             return None
-
-        updates: dict = {}
         if name is not None:
-            updates["name"] = name
+            entry.name = name
         if slug is not None:
-            updates["slug"] = slug
+            entry.slug_override = slug
         if parent_id is not None:
-            updates["parent_id"] = parent_id
+            entry.parent_entry_id = parent_id
         if node_type is not None:
-            updates["node_type"] = node_type
+            entry.node_type = _NODE_TYPE_TO_ENUM.get(node_type, node_type)
         if description is not None:
-            updates["description"] = description
+            entry.description = description
         if sort_order is not None:
-            updates["sort_order"] = sort_order
+            entry.position = sort_order
         if config is not None:
-            updates["config"] = config
-
-        for key, value in updates.items():
-            setattr(node, key, value)
-
+            entry.config = config
         await db.flush()
-        logger.info("catalog_node_updated", extra={"id": str(node_id), "updates": list(updates.keys())})
-        return node
+        logger.info("catalog_node_updated", extra={"id": str(node_id)})
+        return entry
 
     @staticmethod
     async def delete_node(db: AsyncSession, node_id: UUID) -> bool:
-        """删除目录节点（级联删除子节点和关联关系）"""
-        node = await CatalogDao.get_node(db, node_id)
-        if node is None:
+        """删除目录条目节点（CASCADE 自动清理子节点和 DOCUMENT_REF 子条目）"""
+        entry = await CatalogDao.get_node(db, node_id)
+        if entry is None:
             return False
-        await db.delete(node)
+        await db.delete(entry)
         await db.flush()
         logger.info("catalog_node_deleted", extra={"id": str(node_id)})
         return True
 
     # ------------------------------------------------------------------
-    # 树查询 (Recursive CTE)
+    # 树查询 (Recursive CTE on doc_catalog_entries)
     # ------------------------------------------------------------------
 
     @staticmethod
     async def get_tree(
         db: AsyncSession,
-        corpus_id: UUID,
+        catalog_id: UUID,
         max_depth: int = MAX_TREE_DEPTH,
     ) -> list[dict]:
-        """获取完整目录树（扁平化列表，含 depth 信息）
+        """获取 Catalog 完整目录树（扁平化列表，含 depth / path）
 
-        使用 PostgreSQL WITH RECURSIVE CTE 实现 Adjacency List 到层级结构的转换。
+        仅返回 CATEGORY / COLLECTION 结构节点（跳过 DOCUMENT_REF 叶节点），
+        与旧 doc_catalog_nodes 语义保持一致。
 
         Returns:
-            扁平化的节点列表，每个元素包含：
-            - id, parent_id, name, slug, node_type, description, sort_order, config
-            - depth: 层级深度（根节点为 0）
-            - path: 从根到当前节点的 ID 路径数组
+            扁平化节点列表，每个元素包含：
+            id, parent_id, name, slug, node_type, description,
+            sort_order, config, catalog_id, depth, path
         """
-        table = f"{NEGENTROPY_SCHEMA}.doc_catalog_nodes"
+        table = f"{NEGENTROPY_SCHEMA}.doc_catalog_entries"
 
         stmt = text(f"""
             WITH RECURSIVE cat_tree AS (
                 SELECT
-                    id, parent_id, name, slug, node_type,
-                    description, sort_order, config,
-                    0 AS depth,
-                    ARRAY[id] AS path
+                    id, parent_entry_id AS parent_id, name, slug_override, node_type,
+                    description, position AS sort_order, config, catalog_id,
+                    0 AS depth, ARRAY[id] AS path
                 FROM {table}
-                WHERE corpus_id = :corpus_id AND parent_id IS NULL
+                WHERE catalog_id = :catalog_id AND parent_entry_id IS NULL
+                  AND node_type IN ('CATEGORY', 'COLLECTION')
 
                 UNION ALL
 
                 SELECT
-                    n.id, n.parent_id, n.name, n.slug, n.node_type,
-                    n.description, n.sort_order, n.config,
-                    ct.depth + 1,
-                    ct.path || n.id
+                    n.id, n.parent_entry_id, n.name, n.slug_override, n.node_type,
+                    n.description, n.position, n.config, n.catalog_id,
+                    ct.depth + 1, ct.path || n.id
                 FROM {table} n
-                JOIN cat_tree ct ON n.parent_id = ct.id
+                JOIN cat_tree ct ON n.parent_entry_id = ct.id
+                WHERE n.node_type IN ('CATEGORY', 'COLLECTION')
             )
-            SELECT id, parent_id, name, slug, node_type,
-                   description, sort_order, config, depth, path
+            SELECT id, parent_id, name, slug_override, node_type,
+                   description, sort_order, config, catalog_id, depth, path
             FROM cat_tree
             WHERE depth <= :max_depth
             ORDER BY depth, sort_order, name
         """)
 
-        result = await db.execute(
-            stmt,
-            {"corpus_id": str(corpus_id), "max_depth": max_depth},
-        )
-        rows = result.all()
+        rows = (await db.execute(stmt, {"catalog_id": str(catalog_id), "max_depth": max_depth})).all()
 
-        tree_data = []
-        for row in rows:
-            tree_data.append(
-                {
-                    "id": row[0],
-                    "parent_id": row[1],
-                    "name": row[2],
-                    "slug": row[3],
-                    "node_type": row[4],
-                    "description": row[5],
-                    "sort_order": row[6],
-                    "config": row[7],
-                    "depth": row[8],
-                    "path": list(row[9]) if row[9] else [],
-                }
-            )
+        tree_data = [
+            {
+                "id": row[0],
+                "parent_id": row[1],
+                "name": row[2],
+                "slug": _compute_slug(row[2], row[3]),
+                "slug_override": row[3],
+                "node_type": _ENUM_TO_NODE_TYPE.get(row[4], row[4]) if row[4] else row[4],
+                "description": row[5],
+                "sort_order": row[6],
+                "config": row[7],
+                "catalog_id": row[8],
+                "depth": row[9],
+                "path": list(row[10]) if row[10] else [],
+            }
+            for row in rows
+        ]
 
         logger.debug(
             "catalog_tree_queried",
-            extra={
-                "corpus_id": str(corpus_id),
-                "node_count": len(tree_data),
-            },
+            extra={"catalog_id": str(catalog_id), "node_count": len(tree_data)},
         )
         return tree_data
 
     @staticmethod
     async def get_subtree(
         db: AsyncSession,
-        node_id: UUID,
+        entry_id: UUID,
         max_depth: int = MAX_TREE_DEPTH,
     ) -> list[dict]:
-        """获取以指定节点为根的子树"""
-        table = f"{NEGENTROPY_SCHEMA}.doc_catalog_nodes"
+        """获取以指定条目为根的子树（仅 CATEGORY / COLLECTION 节点）"""
+        table = f"{NEGENTROPY_SCHEMA}.doc_catalog_entries"
 
         stmt = text(f"""
             WITH RECURSIVE sub_tree AS (
                 SELECT
-                    id, parent_id, name, slug, node_type,
-                    description, sort_order, config,
-                    0 AS depth,
-                    ARRAY[id] AS path
+                    id, parent_entry_id AS parent_id, name, slug_override, node_type,
+                    description, position AS sort_order, config, catalog_id,
+                    0 AS depth, ARRAY[id] AS path
                 FROM {table}
-                WHERE id = :node_id
+                WHERE id = :entry_id AND node_type IN ('CATEGORY', 'COLLECTION')
 
                 UNION ALL
 
                 SELECT
-                    n.id, n.parent_id, n.name, n.slug, n.node_type,
-                    n.description, n.sort_order, n.config,
-                    st.depth + 1,
-                    st.path || n.id
+                    n.id, n.parent_entry_id, n.name, n.slug_override, n.node_type,
+                    n.description, n.position, n.config, n.catalog_id,
+                    st.depth + 1, st.path || n.id
                 FROM {table} n
-                JOIN sub_tree st ON n.parent_id = st.id
+                JOIN sub_tree st ON n.parent_entry_id = st.id
+                WHERE n.node_type IN ('CATEGORY', 'COLLECTION')
             )
-            SELECT id, parent_id, name, slug, node_type,
-                   description, sort_order, config, depth, path
+            SELECT id, parent_id, name, slug_override, node_type,
+                   description, sort_order, config, catalog_id, depth, path
             FROM sub_tree
             WHERE depth <= :max_depth
             ORDER BY depth, sort_order
         """)
 
-        result = await db.execute(
-            stmt,
-            {"node_id": str(node_id), "max_depth": max_depth},
-        )
-        rows = result.all()
+        rows = (await db.execute(stmt, {"entry_id": str(entry_id), "max_depth": max_depth})).all()
 
         return [
             {
                 "id": row[0],
                 "parent_id": row[1],
                 "name": row[2],
-                "slug": row[3],
-                "node_type": row[4],
+                "slug": _compute_slug(row[2], row[3]),
+                "slug_override": row[3],
+                "node_type": _ENUM_TO_NODE_TYPE.get(row[4], row[4]) if row[4] else row[4],
                 "description": row[5],
                 "sort_order": row[6],
                 "config": row[7],
-                "depth": row[8],
-                "path": list(row[9]) if row[9] else [],
+                "catalog_id": row[8],
+                "depth": row[9],
+                "path": list(row[10]) if row[10] else [],
             }
             for row in rows
         ]
 
     # ------------------------------------------------------------------
-    # 文档归属管理 (Membership)
+    # 文档归属管理（通过 DOCUMENT_REF 子条目实现）
     # ------------------------------------------------------------------
 
     @staticmethod
     async def assign_document(
         db: AsyncSession,
-        catalog_node_id: UUID,
+        catalog_entry_id: UUID,
         document_id: UUID,
-    ) -> DocCatalogMembership:
-        """将文档归入目录节点（幂等：已存在则返回现有记录）"""
-        # 检查是否已存在
+    ) -> DocCatalogEntry:
+        """将文档归入目录条目（幂等：已存在则返回现有 DOCUMENT_REF 子条目）"""
         existing = await db.execute(
-            select(DocCatalogMembership).where(
-                DocCatalogMembership.catalog_node_id == catalog_node_id,
-                DocCatalogMembership.document_id == document_id,
+            select(DocCatalogEntry).where(
+                DocCatalogEntry.parent_entry_id == catalog_entry_id,
+                DocCatalogEntry.document_id == document_id,
+                DocCatalogEntry.node_type == "DOCUMENT_REF",
             )
         )
-        existing_rec = existing.scalar_one_or_none()
-        if existing_rec is not None:
-            return existing_rec
+        rec = existing.scalar_one_or_none()
+        if rec is not None:
+            return rec
 
-        membership = DocCatalogMembership(
-            catalog_node_id=catalog_node_id,
+        # 获取父条目以继承 catalog_id
+        parent = await CatalogDao.get_node(db, catalog_entry_id)
+        catalog_id = parent.catalog_id if parent else None
+
+        # 获取 document 元数据以填充 source_corpus_id 和名称
+        doc_result = await db.execute(select(KnowledgeDocument).where(KnowledgeDocument.id == document_id))
+        doc = doc_result.scalar_one_or_none()
+        source_corpus_id = doc.corpus_id if doc else None
+        doc_name = (doc.original_filename or str(document_id)) if doc else str(document_id)
+
+        entry = DocCatalogEntry(
+            catalog_id=catalog_id,
+            parent_entry_id=catalog_entry_id,
             document_id=document_id,
+            source_corpus_id=source_corpus_id,
+            node_type="DOCUMENT_REF",
+            name=doc_name,
+            status="ACTIVE",
         )
-        db.add(membership)
+        db.add(entry)
         await db.flush()
         logger.info(
             "document_assigned_to_catalog",
             extra={
-                "catalog_node_id": str(catalog_node_id),
+                "catalog_entry_id": str(catalog_entry_id),
                 "document_id": str(document_id),
+                "source_corpus_id": str(source_corpus_id) if source_corpus_id else None,
             },
         )
-        return membership
+        return entry
 
     @staticmethod
     async def unassign_document(
         db: AsyncSession,
-        catalog_node_id: UUID,
+        catalog_entry_id: UUID,
         document_id: UUID,
     ) -> bool:
-        """移除文档的目录归属"""
+        """移除文档的目录归属（删除 DOCUMENT_REF 子条目）"""
         result = await db.execute(
-            select(DocCatalogMembership).where(
-                DocCatalogMembership.catalog_node_id == catalog_node_id,
-                DocCatalogMembership.document_id == document_id,
+            select(DocCatalogEntry).where(
+                DocCatalogEntry.parent_entry_id == catalog_entry_id,
+                DocCatalogEntry.document_id == document_id,
+                DocCatalogEntry.node_type == "DOCUMENT_REF",
             )
         )
-        membership = result.scalar_one_or_none()
-        if membership is None:
+        entry = result.scalar_one_or_none()
+        if entry is None:
             return False
-        await db.delete(membership)
+        await db.delete(entry)
         await db.flush()
         return True
 
     @staticmethod
     async def get_node_documents(
         db: AsyncSession,
-        catalog_node_id: UUID,
+        catalog_entry_id: UUID,
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list[KnowledgeDocument], int]:
-        """获取目录节点下的文档列表（分页）"""
-        count_query = select(func.count()).select_from(
-            select(DocCatalogMembership.document_id)
-            .where(DocCatalogMembership.catalog_node_id == catalog_node_id)
-            .subquery()
+        """获取目录条目下的文档列表（通过 DOCUMENT_REF 子条目，分页）"""
+        count_query = (
+            select(func.count())
+            .select_from(DocCatalogEntry)
+            .where(
+                DocCatalogEntry.parent_entry_id == catalog_entry_id,
+                DocCatalogEntry.node_type == "DOCUMENT_REF",
+                DocCatalogEntry.document_id.is_not(None),
+            )
         )
-        total_result = await db.execute(count_query)
-        total = total_result.scalar() or 0
+        total = (await db.execute(count_query)).scalar() or 0
 
         query = (
             select(KnowledgeDocument)
-            .join(DocCatalogMembership, KnowledgeDocument.id == DocCatalogMembership.document_id)
-            .where(DocCatalogMembership.catalog_node_id == catalog_node_id)
-            .order_by(DocCatalogMembership.created_at.desc())
+            .join(DocCatalogEntry, KnowledgeDocument.id == DocCatalogEntry.document_id)
+            .where(
+                DocCatalogEntry.parent_entry_id == catalog_entry_id,
+                DocCatalogEntry.node_type == "DOCUMENT_REF",
+                DocCatalogEntry.document_id.is_not(None),
+            )
+            .order_by(DocCatalogEntry.position, DocCatalogEntry.created_at.desc())
             .offset(offset)
             .limit(limit)
         )
-        result = await db.execute(query)
-        documents = list(result.scalars().all())
-
+        documents = list((await db.execute(query)).scalars().all())
         return documents, total
 
     @staticmethod
     async def get_document_nodes(
         db: AsyncSession,
         document_id: UUID,
-    ) -> list[DocCatalogNode]:
-        """获取文档所属的所有目录节点"""
+    ) -> list[DocCatalogEntry]:
+        """获取文档所属的所有目录条目（DOCUMENT_REF 条目 backlink）"""
         result = await db.execute(
-            select(DocCatalogNode)
-            .join(DocCatalogMembership, DocCatalogNode.id == DocCatalogMembership.catalog_node_id)
-            .where(DocCatalogMembership.document_id == document_id)
-            .order_by(DocCatalogNode.sort_order, DocCatalogNode.name)
+            select(DocCatalogEntry)
+            .where(
+                DocCatalogEntry.document_id == document_id,
+                DocCatalogEntry.node_type == "DOCUMENT_REF",
+            )
+            .order_by(DocCatalogEntry.position, DocCatalogEntry.name)
         )
         return list(result.scalars().all())

--- a/apps/negentropy/src/negentropy/knowledge/catalog_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/catalog_service.py
@@ -1,12 +1,14 @@
 """
 文档目录编目 — 服务层
 
-提供目录树的创建、移动、查询、文档归属管理等功能。
+提供 Catalog（全局顶层）及 CatalogEntry 节点的创建、移动、查询、
+文档归属管理等功能。
+
 核心能力：
+  - Catalog CRUD（全局租户隔离，app_name 不可变）
   - 递归树查询（基于 PostgreSQL Recursive CTE）
-  - 节点 CRUD + 移动（更新 parent_id）
-  - 文档归类 / 取消归类
-  - LLM 自动分类建议（预留接口）
+  - 节点 CRUD + 移动（更新 parent_id，防循环引用）
+  - 文档归类 / 取消归类（权限三级取交集：跨 app_name 禁止）
 """
 
 from __future__ import annotations
@@ -19,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from negentropy.knowledge.catalog_dao import CatalogDao
 from negentropy.logging import get_logger
-from negentropy.models.perception import DocCatalogNode, KnowledgeDocument
+from negentropy.models.perception import DocCatalog, DocCatalogEntry, KnowledgeDocument
 
 logger = get_logger(__name__.rsplit(".", 1)[0])
 
@@ -31,6 +33,103 @@ class CatalogService:
     """文档目录编目服务"""
 
     # ------------------------------------------------------------------
+    # Catalog 顶层管理
+    # ------------------------------------------------------------------
+
+    async def create_catalog(
+        self,
+        db: AsyncSession,
+        *,
+        app_name: str,
+        name: str,
+        slug: str | None = None,
+        owner_id: str | None = None,
+        description: str | None = None,
+        visibility: str = "INTERNAL",
+        config: dict | None = None,
+    ) -> DocCatalog:
+        """创建全局 Catalog
+
+        Args:
+            db: 数据库会话
+            app_name: 租户标识（创建后不可变）
+            name: Catalog 名称
+            slug: URL 标识（不传则从 name 自动生成；租户内唯一）
+            owner_id: 归属账号（审计）
+            description: 描述文本
+            visibility: PRIVATE / INTERNAL / PUBLIC
+            config: 扩展配置
+
+        Returns:
+            创建的 DocCatalog
+
+        Raises:
+            ValueError: slug 格式错误或租户内重复
+        """
+        if not slug:
+            slug = self._slugify(name)
+
+        if not _SLUG_PATTERN.match(slug):
+            raise ValueError(
+                f"Invalid slug format: {slug!r}. Must contain only lowercase alphanumeric characters and hyphens."
+            )
+
+        return await CatalogDao.create_catalog(
+            db,
+            app_name=app_name,
+            name=name,
+            slug=slug,
+            owner_id=owner_id,
+            description=description,
+            visibility=visibility,
+            config=config,
+        )
+
+    async def get_catalog(self, db: AsyncSession, catalog_id: UUID) -> DocCatalog | None:
+        """获取单个 Catalog"""
+        return await CatalogDao.get_catalog(db, catalog_id)
+
+    async def list_catalogs(
+        self,
+        db: AsyncSession,
+        *,
+        app_name: str | None = None,
+        include_archived: bool = False,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[DocCatalog], int]:
+        """列出 Catalog（支持 app_name 过滤 + 归档过滤）"""
+        return await CatalogDao.list_catalogs(
+            db,
+            app_name=app_name,
+            include_archived=include_archived,
+            offset=offset,
+            limit=limit,
+        )
+
+    async def update_catalog(
+        self,
+        db: AsyncSession,
+        catalog_id: UUID,
+        **kwargs: Any,
+    ) -> DocCatalog | None:
+        """更新 Catalog 属性（app_name 不允许修改）"""
+        if "app_name" in kwargs:
+            raise ValueError("app_name is immutable and cannot be changed after creation")
+        if "slug" in kwargs and kwargs["slug"]:
+            if not _SLUG_PATTERN.match(kwargs["slug"]):
+                raise ValueError(f"Invalid slug format: {kwargs['slug']!r}")
+        return await CatalogDao.update_catalog(db, catalog_id, **kwargs)
+
+    async def archive_catalog(self, db: AsyncSession, catalog_id: UUID) -> DocCatalog | None:
+        """软归档 Catalog（is_archived=True；归档后禁止新增 entry）"""
+        return await CatalogDao.archive_catalog(db, catalog_id)
+
+    async def delete_catalog(self, db: AsyncSession, catalog_id: UUID) -> bool:
+        """删除 Catalog（级联删除所有条目，不影响源文档）"""
+        return await CatalogDao.delete_catalog(db, catalog_id)
+
+    # ------------------------------------------------------------------
     # 节点管理
     # ------------------------------------------------------------------
 
@@ -38,7 +137,7 @@ class CatalogService:
         self,
         db: AsyncSession,
         *,
-        corpus_id: UUID,
+        catalog_id: UUID,
         name: str,
         slug: str | None = None,
         parent_id: UUID | None = None,
@@ -46,12 +145,12 @@ class CatalogService:
         description: str | None = None,
         sort_order: int = 0,
         config: dict | None = None,
-    ) -> DocCatalogNode:
+    ) -> DocCatalogEntry:
         """创建目录节点
 
         Args:
             db: 数据库会话
-            corpus_id: 所属语料库 ID
+            catalog_id: 所属 Catalog ID
             name: 节点名称
             slug: URL 友好标识（不传则从 name 自动生成）
             parent_id: 父节点 ID（None 表示根节点）
@@ -64,7 +163,7 @@ class CatalogService:
             创建的节点对象
 
         Raises:
-            ValueError: node_type 不合法或 slug 格式错误
+            ValueError: node_type 不合法、slug 格式错误或父节点不属于同一 catalog
         """
         # 校验 node_type
         valid_types = {"category", "collection", "document_ref"}
@@ -80,17 +179,24 @@ class CatalogService:
                 f"Invalid slug format: {slug!r}. Must contain only lowercase alphanumeric characters and hyphens."
             )
 
-        # 如果指定了 parent_id，验证父节点存在且属于同一 corpus
+        # 验证 Catalog 未归档
+        catalog = await CatalogDao.get_catalog(db, catalog_id)
+        if catalog is None:
+            raise ValueError(f"Catalog {catalog_id} not found")
+        if catalog.is_archived:
+            raise ValueError(f"Catalog {catalog_id} is archived; cannot add new entries")
+
+        # 如果指定了 parent_id，验证父节点存在且属于同一 catalog
         if parent_id is not None:
             parent = await CatalogDao.get_node(db, parent_id)
             if parent is None:
                 raise ValueError(f"Parent node {parent_id} not found")
-            if parent.corpus_id != corpus_id:
-                raise ValueError("Parent node must belong to the same corpus")
+            if parent.catalog_id != catalog_id:
+                raise ValueError("Parent node must belong to the same catalog")
 
         return await CatalogDao.create_node(
             db,
-            corpus_id=corpus_id,
+            catalog_id=catalog_id,
             name=name,
             slug=slug,
             parent_id=parent_id,
@@ -105,9 +211,8 @@ class CatalogService:
         db: AsyncSession,
         node_id: UUID,
         **kwargs: Any,
-    ) -> DocCatalogNode | None:
+    ) -> DocCatalogEntry | None:
         """更新目录节点"""
-        # 如果更新了 slug，校验格式
         if "slug" in kwargs and kwargs["slug"]:
             if not _SLUG_PATTERN.match(kwargs["slug"]):
                 raise ValueError(f"Invalid slug format: {kwargs['slug']!r}")
@@ -122,7 +227,7 @@ class CatalogService:
         db: AsyncSession,
         node_id: UUID,
         new_parent_id: UUID | None,
-    ) -> DocCatalogNode | None:
+    ) -> DocCatalogEntry | None:
         """移动节点到新的父节点下
 
         Args:
@@ -159,16 +264,16 @@ class CatalogService:
     async def get_tree(
         self,
         db: AsyncSession,
-        corpus_id: UUID,
+        catalog_id: UUID,
     ) -> list[dict]:
-        """获取语料库完整目录树（扁平化列表，含 depth/path）"""
-        return await CatalogDao.get_tree(db, corpus_id)
+        """获取 Catalog 完整目录树（扁平化列表，含 depth/path）"""
+        return await CatalogDao.get_tree(db, catalog_id)
 
     async def get_subtree(self, db: AsyncSession, node_id: UUID) -> list[dict]:
         """获取以指定节点为根的子树"""
         return await CatalogDao.get_subtree(db, node_id)
 
-    async def get_node(self, db: AsyncSession, node_id: UUID) -> DocCatalogNode | None:
+    async def get_node(self, db: AsyncSession, node_id: UUID) -> DocCatalogEntry | None:
         """获取单个节点详情"""
         return await CatalogDao.get_node(db, node_id)
 
@@ -182,11 +287,37 @@ class CatalogService:
         catalog_node_id: UUID,
         document_id: UUID,
     ) -> None:
-        """将文档归入目录节点（幂等）"""
-        # 验证两端都存在
+        """将文档归入目录节点（幂等）
+
+        权限约束：文档的源 Corpus 必须与 Catalog 属于同一 app_name。
+        违反约束时抛出 PermissionError。
+        """
         node = await CatalogDao.get_node(db, catalog_node_id)
         if node is None:
             raise ValueError(f"Catalog node {catalog_node_id} not found")
+
+        # 权限校验：跨 app_name 文档归类禁止
+        from sqlalchemy import select as sa_select
+
+        from negentropy.models.perception import Corpus
+
+        doc_result = await db.execute(sa_select(KnowledgeDocument).where(KnowledgeDocument.id == document_id))
+        doc = doc_result.scalar_one_or_none()
+        if doc is None:
+            raise ValueError(f"Document {document_id} not found")
+
+        catalog = await CatalogDao.get_catalog(db, node.catalog_id)
+        if catalog is None:
+            raise ValueError(f"Catalog {node.catalog_id} not found")
+
+        corpus_result = await db.execute(sa_select(Corpus).where(Corpus.id == doc.corpus_id))
+        corpus = corpus_result.scalar_one_or_none()
+        if corpus is not None and corpus.app_name != catalog.app_name:
+            raise PermissionError(
+                f"Cannot assign document from corpus '{corpus.app_name}' "
+                f"to catalog '{catalog.app_name}' (cross-app assignment forbidden)"
+            )
+
         await CatalogDao.assign_document(db, catalog_node_id, document_id)
 
     async def unassign_document(
@@ -212,7 +343,7 @@ class CatalogService:
         self,
         db: AsyncSession,
         document_id: UUID,
-    ) -> list[DocCatalogNode]:
+    ) -> list[DocCatalogEntry]:
         """获取文档所属的所有目录节点"""
         return await CatalogDao.get_document_nodes(db, document_id)
 
@@ -222,19 +353,9 @@ class CatalogService:
 
     @staticmethod
     def _slugify(text: str) -> str:
-        """将文本转换为 URL-friendly slug
-
-        示例:
-            "机器学习基础" → "ji-qi-xue-xi-ji-chu"
-            "API 参考" → "api-can-kao"
-        """
+        """将文本转换为 URL-friendly slug"""
         import unicodedata
 
-        # Unicode NFKC 规范化（处理全角字符等）
-        normalized = unicodedata.normalize("NFKC", text)
-        # 转小写、替换空格和特殊字符为连字符
-        slug = re.sub(r"[^\w\s-]", "", normalized.lower())
-        slug = re.sub(r"[\s_]+", "-", slug).strip("-")
-        # 压缩连续连字符
-        slug = re.sub(r"-{2,}", "-", slug)
-        return slug or "untitled"
+        normalized = unicodedata.normalize("NFKC", text or "").lower()
+        slug = re.sub(r"[^a-z0-9]+", "-", normalized).strip("-")
+        return re.sub(r"-{2,}", "-", slug) or "untitled"

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -104,7 +104,7 @@ class CatalogNodeResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    corpus_id: UUID
+    catalog_id: UUID
     parent_id: UUID | None
     name: str
     slug: str
@@ -150,7 +150,7 @@ class CategorySuggestionResponse(BaseModel):
 class WikiPublicationCreateRequest(BaseModel):
     """创建 Wiki 发布请求"""
 
-    corpus_id: UUID
+    catalog_id: UUID
     name: str = Field(..., min_length=1, max_length=255)
     slug: str | None = Field(None, max_length=255)
     description: str | None = None
@@ -182,7 +182,7 @@ class WikiPublicationResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
-    corpus_id: UUID
+    catalog_id: UUID
     name: str
     slug: str
     description: str | None

--- a/apps/negentropy/src/negentropy/knowledge/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_dao.py
@@ -35,7 +35,7 @@ class WikiDao:
     async def create_publication(
         db: AsyncSession,
         *,
-        corpus_id: UUID,
+        catalog_id: UUID,
         name: str,
         slug: str,
         description: str | None = None,
@@ -46,7 +46,7 @@ class WikiDao:
     ) -> WikiPublication:
         """创建 Wiki 发布记录（初始状态为 draft）"""
         pub = WikiPublication(
-            corpus_id=corpus_id,
+            catalog_id=catalog_id,
             name=name,
             slug=slug,
             description=description,
@@ -63,7 +63,7 @@ class WikiDao:
             "wiki_publication_created",
             extra={
                 "id": str(pub.id),
-                "corpus_id": str(corpus_id),
+                "catalog_id": str(catalog_id),
                 "publication_name": name,
                 "slug": slug,
             },
@@ -77,11 +77,11 @@ class WikiDao:
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def get_publication_by_slug(db: AsyncSession, corpus_id: UUID, slug: str) -> WikiPublication | None:
-        """按 corpus + slug 获取发布记录"""
+    async def get_publication_by_slug(db: AsyncSession, catalog_id: UUID, slug: str) -> WikiPublication | None:
+        """按 catalog + slug 获取发布记录"""
         result = await db.execute(
             select(WikiPublication).where(
-                WikiPublication.corpus_id == corpus_id,
+                WikiPublication.catalog_id == catalog_id,
                 WikiPublication.slug == slug,
             )
         )
@@ -91,7 +91,7 @@ class WikiDao:
     async def list_publications(
         db: AsyncSession,
         *,
-        corpus_id: UUID | None = None,
+        catalog_id: UUID | None = None,
         status: str | None = None,
         offset: int = 0,
         limit: int = 50,
@@ -101,9 +101,9 @@ class WikiDao:
 
         count_base = select(func.count()).select_from(WikiPublication)
 
-        if corpus_id is not None:
-            query = query.where(WikiPublication.corpus_id == corpus_id)
-            count_base = count_base.where(WikiPublication.corpus_id == corpus_id)
+        if catalog_id is not None:
+            query = query.where(WikiPublication.catalog_id == catalog_id)
+            count_base = count_base.where(WikiPublication.catalog_id == catalog_id)
         if status is not None:
             query = query.where(WikiPublication.status == status)
             count_base = count_base.where(WikiPublication.status == status)

--- a/apps/negentropy/src/negentropy/knowledge/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_service.py
@@ -40,7 +40,7 @@ class WikiPublishingService:
         self,
         db: AsyncSession,
         *,
-        corpus_id: UUID,
+        catalog_id: UUID,
         name: str,
         slug: str | None = None,
         description: str | None = None,
@@ -50,7 +50,7 @@ class WikiPublishingService:
 
         Args:
             db: 数据库会话
-            corpus_id: 关联的语料库 ID
+            catalog_id: 关联的 Catalog ID
             name: 发布名称（如 "技术文档 Wiki"）
             slug: URL 友好标识（不传则从 name 自动生成）
             description: 描述文本
@@ -73,7 +73,7 @@ class WikiPublishingService:
 
         return await WikiDao.create_publication(
             db,
-            corpus_id=corpus_id,
+            catalog_id=catalog_id,
             name=name,
             slug=slug,
             description=description,
@@ -88,13 +88,13 @@ class WikiPublishingService:
         self,
         db: AsyncSession,
         *,
-        corpus_id: UUID | None = None,
+        catalog_id: UUID | None = None,
         status: str | None = None,
         offset: int = 0,
         limit: int = 50,
     ) -> tuple[list[WikiPublication], int]:
         """列出发布记录"""
-        return await WikiDao.list_publications(db, corpus_id=corpus_id, status=status, offset=offset, limit=limit)
+        return await WikiDao.list_publications(db, catalog_id=catalog_id, status=status, offset=offset, limit=limit)
 
     async def update_publication(
         self,

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -9,9 +9,6 @@ from .observability import Trace
 from .perception import (
     Corpus,
     CorpusVersion,
-    DocCatalogMembership,
-    # Phase 3: 目录编目
-    DocCatalogNode,
     # Phase 2: 来源追踪
     DocSource,
     # Phase 5: 知识图谱增强
@@ -63,9 +60,7 @@ __all__ = [
     "KnowledgeDocument",
     # Phase 2: 来源追踪
     "DocSource",
-    # Phase 3: 目录编目
-    "DocCatalogNode",
-    "DocCatalogMembership",
+    # Phase 6: Catalog 全局化（Phase 3 后 DocCatalogNode/Membership 已 DROP）
     # Phase 4: Wiki 发布
     "WikiPublication",
     "WikiPublicationEntry",

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -51,17 +51,6 @@ class Corpus(Base, UUIDMixin, TimestampMixin):
     knowledge_items: Mapped[list["Knowledge"]] = relationship(back_populates="corpus", cascade="all, delete-orphan")
     documents: Mapped[list["KnowledgeDocument"]] = relationship(back_populates="corpus", cascade="all, delete-orphan")
 
-    # Phase 3: 目录节点
-    catalog_nodes: Mapped[list["DocCatalogNode"]] = relationship(
-        back_populates="corpus",
-        cascade="all, delete-orphan",
-        order_by="DocCatalogNode.sort_order",
-    )
-    # Phase 4: Wiki 发布
-    wiki_publications: Mapped[list["WikiPublication"]] = relationship(
-        back_populates="corpus",
-        cascade="all, delete-orphan",
-    )
     # Phase 5: 版本快照
     versions: Mapped[list["CorpusVersion"]] = relationship(
         back_populates="corpus",
@@ -191,75 +180,6 @@ class DocSource(Base, UUIDMixin, TimestampMixin):
     __table_args__ = (
         Index("ix_doc_sources_document_id", "document_id"),
         Index("ix_doc_sources_source_type", "source_type"),
-        {"schema": NEGENTROPY_SCHEMA},
-    )
-
-
-# =============================================================================
-# Phase 3: 目录编目系统
-# =============================================================================
-
-
-class DocCatalogNode(Base, UUIDMixin, TimestampMixin):
-    """目录节点 — 层级目录树
-
-    采用 Adjacency List 模式（parent_id 自引用）实现层级结构。
-    通过 PostgreSQL WITH RECURSIVE CTE 支持高效树查询。
-
-    node_type:
-      - category: 纯分类容器
-      - collection: 有序集合（自定义排序语义）
-      - document_ref: 直接指向某篇文档的叶子节点
-    """
-
-    __tablename__ = "doc_catalog_nodes"
-
-    corpus_id: Mapped[UUID] = mapped_column(fk("corpus", ondelete="CASCADE"), nullable=False)
-    parent_id: Mapped[UUID | None] = mapped_column(fk("doc_catalog_nodes", ondelete="SET NULL"), nullable=True)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    slug: Mapped[str] = mapped_column(String(255), nullable=False)  # URL-friendly 标识
-    node_type: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="category"
-    )  # category | collection | document_ref
-    description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
-
-    parent: Mapped["DocCatalogNode | None"] = relationship(remote_side="DocCatalogNode.id", back_populates="children")
-    children: Mapped[list["DocCatalogNode"]] = relationship(
-        back_populates="parent",
-        cascade="all, delete-orphan",
-        order_by="DocCatalogNode.sort_order",
-    )
-    corpus: Mapped["Corpus"] = relationship(back_populates="catalog_nodes")
-
-    __table_args__ = (
-        UniqueConstraint("corpus_id", "parent_id", "name", name="uq_catalog_sibling_name"),
-        UniqueConstraint("corpus_id", "slug", name="uq_catalog_corpus_slug"),
-        Index("ix_doc_catalog_nodes_corpus_id", "corpus_id"),
-        Index("ix_doc_catalog_nodes_parent_id", "parent_id"),
-        {"schema": NEGENTROPY_SCHEMA},
-    )
-
-
-class DocCatalogMembership(Base, UUIDMixin, TimestampMixin):
-    """目录-文档多对多关联表
-
-    一个文档可属于多个目录节点（如同时出现在分类和日期集合中）。
-    使用独立关联表而非 JSONB 数组以支持查询效率与级联删除。
-    """
-
-    __tablename__ = "doc_catalog_memberships"
-
-    catalog_node_id: Mapped[UUID] = mapped_column(fk("doc_catalog_nodes", ondelete="CASCADE"), nullable=False)
-    document_id: Mapped[UUID] = mapped_column(fk("knowledge_documents", ondelete="CASCADE"), nullable=False)
-
-    catalog_node: Mapped["DocCatalogNode"] = relationship()
-    document: Mapped["KnowledgeDocument"] = relationship()
-
-    __table_args__ = (
-        UniqueConstraint("catalog_node_id", "document_id", name="uq_catalog_membership_unique"),
-        Index("ix_catalog_memberships_document_id", "document_id"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -198,7 +198,6 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
 
     __tablename__ = "wiki_publications"
 
-    corpus_id: Mapped[UUID] = mapped_column(fk("corpus", ondelete="CASCADE"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -214,10 +213,10 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    # Phase 1: Catalog 全局化过渡字段（Phase 3 才会施加 NOT NULL 并移除 corpus_id）
-    catalog_id: Mapped[UUID | None] = mapped_column(fk("doc_catalogs", ondelete="RESTRICT"), nullable=True)
-    app_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    publish_mode: Mapped[str | None] = mapped_column(
+    # Phase 3: Catalog 全局化（NOT NULL，corpus_id 已移除）
+    catalog_id: Mapped[UUID] = mapped_column(fk("doc_catalogs", ondelete="RESTRICT"), nullable=False)
+    app_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    publish_mode: Mapped[str] = mapped_column(
         SAEnum(
             "LIVE",
             "SNAPSHOT",
@@ -225,10 +224,10 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
             schema=NEGENTROPY_SCHEMA,
             create_type=False,
         ),
-        nullable=True,
+        nullable=False,
         server_default="LIVE",
     )
-    visibility: Mapped[str | None] = mapped_column(
+    visibility: Mapped[str] = mapped_column(
         SAEnum(
             "PRIVATE",
             "INTERNAL",
@@ -237,13 +236,12 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
             schema=NEGENTROPY_SCHEMA,
             create_type=False,
         ),
-        nullable=True,
+        nullable=False,
         server_default="INTERNAL",
     )
     snapshot_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
-    corpus: Mapped["Corpus"] = relationship(back_populates="wiki_publications")
-    catalog: Mapped["DocCatalog | None"] = relationship(back_populates="publications")
+    catalog: Mapped["DocCatalog"] = relationship(back_populates="publications")
     entries: Mapped[list["WikiPublicationEntry"]] = relationship(
         back_populates="publication",
         cascade="all, delete-orphan",
@@ -259,19 +257,10 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
     )
 
     __table_args__ = (
-        UniqueConstraint("corpus_id", "slug", name="uq_wiki_pub_corpus_slug"),
-        Index("ix_wiki_publications_corpus_id", "corpus_id"),
+        UniqueConstraint("catalog_id", "slug", name="uq_wiki_pub_catalog_slug"),
         Index("ix_wiki_publications_status", "status"),
-        Index(
-            "ix_wiki_publications_catalog_id",
-            "catalog_id",
-            postgresql_where="catalog_id IS NOT NULL",
-        ),
-        Index(
-            "ix_wiki_publications_app_name",
-            "app_name",
-            postgresql_where="app_name IS NOT NULL",
-        ),
+        Index("ix_wiki_publications_catalog_id", "catalog_id"),
+        Index("ix_wiki_publications_app_name", "app_name"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 
@@ -541,8 +530,8 @@ class KnowledgeFeedback(Base, UUIDMixin, TimestampMixin):
 # =============================================================================
 # Phase 6: Catalog 全局化（MediaWiki N:M + GitBook 订阅式发布）
 # ---
-# 与既有 DocCatalogNode / DocCatalogMembership 并行存在，承担过渡期职责。
-# Phase 2 backfill 完成、Phase 3 施加约束并移除旧表后，以下模型成为 SSOT。
+# Phase 3 enforce 已完成（commit 0005）：legacy doc_catalog_nodes / doc_catalog_memberships 已 DROP。
+# 以下模型为 SSOT：DocCatalog（全局顶层）→ DocCatalogEntry（N:M 关联）→ WikiPublication（发布订阅）。
 # =============================================================================
 
 

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -2,9 +2,23 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy import (
+    Enum as SAEnum,
+)
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
 
 from .base import DEFAULT_EMBEDDING_DIM, NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin, Vector, fk
 
@@ -280,8 +294,46 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    # Phase 1: Catalog 全局化过渡字段（Phase 3 才会施加 NOT NULL 并移除 corpus_id）
+    catalog_id: Mapped[UUID | None] = mapped_column(fk("doc_catalogs", ondelete="RESTRICT"), nullable=True)
+    app_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    publish_mode: Mapped[str | None] = mapped_column(
+        SAEnum(
+            "LIVE",
+            "SNAPSHOT",
+            name="wikipublishmode",
+            schema=NEGENTROPY_SCHEMA,
+            create_type=False,
+        ),
+        nullable=True,
+        server_default="LIVE",
+    )
+    visibility: Mapped[str | None] = mapped_column(
+        SAEnum(
+            "PRIVATE",
+            "INTERNAL",
+            "PUBLIC",
+            name="wikipublicationvisibility",
+            schema=NEGENTROPY_SCHEMA,
+            create_type=False,
+        ),
+        nullable=True,
+        server_default="INTERNAL",
+    )
+    snapshot_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     corpus: Mapped["Corpus"] = relationship(back_populates="wiki_publications")
+    catalog: Mapped["DocCatalog | None"] = relationship(back_populates="publications")
     entries: Mapped[list["WikiPublicationEntry"]] = relationship(
+        back_populates="publication",
+        cascade="all, delete-orphan",
+    )
+    snapshots: Mapped[list["WikiPublicationSnapshot"]] = relationship(
+        back_populates="publication",
+        cascade="all, delete-orphan",
+        order_by="WikiPublicationSnapshot.version.desc()",
+    )
+    slug_redirects: Mapped[list["WikiSlugRedirect"]] = relationship(
         back_populates="publication",
         cascade="all, delete-orphan",
     )
@@ -290,6 +342,16 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
         UniqueConstraint("corpus_id", "slug", name="uq_wiki_pub_corpus_slug"),
         Index("ix_wiki_publications_corpus_id", "corpus_id"),
         Index("ix_wiki_publications_status", "status"),
+        Index(
+            "ix_wiki_publications_catalog_id",
+            "catalog_id",
+            postgresql_where="catalog_id IS NOT NULL",
+        ),
+        Index(
+            "ix_wiki_publications_app_name",
+            "app_name",
+            postgresql_where="app_name IS NOT NULL",
+        ),
         {"schema": NEGENTROPY_SCHEMA},
     )
 
@@ -552,5 +614,190 @@ class KnowledgeFeedback(Base, UUIDMixin, TimestampMixin):
         Index("ix_kb_feedback_session", "session_id"),
         Index("ix_kb_feedback_type", "feedback_type"),
         Index("ix_kb_feedback_created", "created_at"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+# =============================================================================
+# Phase 6: Catalog 全局化（MediaWiki N:M + GitBook 订阅式发布）
+# ---
+# 与既有 DocCatalogNode / DocCatalogMembership 并行存在，承担过渡期职责。
+# Phase 2 backfill 完成、Phase 3 施加约束并移除旧表后，以下模型成为 SSOT。
+# =============================================================================
+
+
+class DocCatalog(Base, UUIDMixin, TimestampMixin):
+    """Catalog 顶层元数据（全局正交于 Corpus）
+
+    - 承载 Wiki/Site 级别的组织视图；不存储文档物理数据（SSOT 在 Corpus.KnowledgeDocument）
+    - `app_name` 租户隔离维度，**创建后不可变**（service 层断言 + 约束）
+    - 软归档：`is_archived=true` 后仅可读，拒绝新增 entry
+    - `version` 字段承担乐观锁
+    """
+
+    __tablename__ = "doc_catalogs"
+
+    app_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(255), nullable=False)
+    owner_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    visibility: Mapped[str] = mapped_column(
+        SAEnum(
+            "PRIVATE",
+            "INTERNAL",
+            "PUBLIC",
+            name="catalogvisibility",
+            schema=NEGENTROPY_SCHEMA,
+        ),
+        nullable=False,
+        server_default="INTERNAL",
+    )
+    is_archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
+
+    entries: Mapped[list["DocCatalogEntry"]] = relationship(
+        back_populates="catalog",
+        cascade="all, delete-orphan",
+        order_by="DocCatalogEntry.position",
+    )
+    publications: Mapped[list["WikiPublication"]] = relationship(back_populates="catalog")
+
+    __table_args__ = (
+        UniqueConstraint("app_name", "slug", name="uq_doc_catalogs_app_slug"),
+        Index("ix_doc_catalogs_app_name", "app_name"),
+        Index("ix_doc_catalogs_owner_id", "owner_id"),
+        Index(
+            "ix_doc_catalogs_is_archived",
+            "is_archived",
+            postgresql_where="is_archived = false",
+        ),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class DocCatalogEntry(Base, UUIDMixin, TimestampMixin):
+    """Catalog 条目：融合「目录节点树」与「文档软引用」的单一实体
+
+    - `parent_entry_id` 同 catalog 内自引用，支持树结构（Adjacency List，CTE 递归）
+    - `document_id` 软引用源文档；`ON DELETE SET NULL` + status=ORPHANED 表达失效语义
+    - `source_corpus_id` 冗余字段：承担权限快速校验（避免 join knowledge_documents）
+    - `slug_override` 允许同一文档在不同 catalog 有独立 slug（Docusaurus sidebar.id 启发）
+    """
+
+    __tablename__ = "doc_catalog_entries"
+
+    catalog_id: Mapped[UUID] = mapped_column(fk("doc_catalogs", ondelete="CASCADE"), nullable=False)
+    parent_entry_id: Mapped[UUID | None] = mapped_column(fk("doc_catalog_entries", ondelete="CASCADE"), nullable=True)
+    document_id: Mapped[UUID | None] = mapped_column(fk("knowledge_documents", ondelete="SET NULL"), nullable=True)
+    source_corpus_id: Mapped[UUID | None] = mapped_column(fk("corpus", ondelete="SET NULL"), nullable=True)
+    node_type: Mapped[str] = mapped_column(
+        SAEnum(
+            "CATEGORY",
+            "COLLECTION",
+            "DOCUMENT_REF",
+            name="catalogentrynodetype",
+            schema=NEGENTROPY_SCHEMA,
+        ),
+        nullable=False,
+        server_default="CATEGORY",
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug_override: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    position: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    status: Mapped[str] = mapped_column(
+        SAEnum(
+            "ACTIVE",
+            "ORPHANED",
+            "HIDDEN",
+            name="catalogentrystatus",
+            schema=NEGENTROPY_SCHEMA,
+        ),
+        nullable=False,
+        server_default="ACTIVE",
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
+
+    catalog: Mapped["DocCatalog"] = relationship(back_populates="entries")
+    parent: Mapped["DocCatalogEntry | None"] = relationship(remote_side="DocCatalogEntry.id", back_populates="children")
+    children: Mapped[list["DocCatalogEntry"]] = relationship(
+        back_populates="parent",
+        cascade="all, delete-orphan",
+        order_by="DocCatalogEntry.position",
+    )
+    document: Mapped["KnowledgeDocument | None"] = relationship()
+    source_corpus: Mapped["Corpus | None"] = relationship()
+
+    __table_args__ = (
+        UniqueConstraint("catalog_id", "parent_entry_id", "name", name="uq_catalog_entry_sibling_name"),
+        Index("ix_doc_catalog_entries_catalog_status", "catalog_id", "status"),
+        Index("ix_doc_catalog_entries_parent", "parent_entry_id"),
+        Index(
+            "ix_doc_catalog_entries_document",
+            "document_id",
+            postgresql_where="document_id IS NOT NULL",
+        ),
+        Index(
+            "ix_doc_catalog_entries_source_corpus",
+            "source_corpus_id",
+            postgresql_where="source_corpus_id IS NOT NULL",
+        ),
+        Index(
+            "uq_catalog_entry_sibling_slug_override",
+            "catalog_id",
+            "parent_entry_id",
+            "slug_override",
+            unique=True,
+            postgresql_where="slug_override IS NOT NULL",
+        ),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class WikiPublicationSnapshot(Base, UUIDMixin):
+    """Publication 快照（snapshot 模式）
+
+    冻结 `(catalog_entries, document_versions)` 到不可变 JSONB，供合规/留档场景使用。
+    只追加，不更新；重新生成快照 = 新版本行。
+    """
+
+    __tablename__ = "wiki_publication_snapshots"
+
+    publication_id: Mapped[UUID] = mapped_column(fk("wiki_publications", ondelete="CASCADE"), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    frozen_entries: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False, server_default="[]")
+    metadata_: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSONB, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    publication: Mapped["WikiPublication"] = relationship(back_populates="snapshots")
+
+    __table_args__ = (
+        UniqueConstraint("publication_id", "version", name="uq_wiki_pub_snapshot_version"),
+        Index("ix_wiki_publication_snapshots_publication", "publication_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class WikiSlugRedirect(Base, UUIDMixin):
+    """历史 slug → 当前 slug 的 301 重定向映射（GitBook 启发）
+
+    当 catalog 节点 slug_override 变化或 publication slug 变化时，
+    同步追加记录以保持链接稳定性。
+    """
+
+    __tablename__ = "wiki_slug_redirects"
+
+    publication_id: Mapped[UUID] = mapped_column(fk("wiki_publications", ondelete="CASCADE"), nullable=False)
+    old_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    new_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    publication: Mapped["WikiPublication"] = relationship(back_populates="slug_redirects")
+
+    __table_args__ = (
+        UniqueConstraint("publication_id", "old_path", name="uq_wiki_slug_redirect_pub_old"),
+        Index("ix_wiki_slug_redirects_lookup", "publication_id", "old_path"),
         {"schema": NEGENTROPY_SCHEMA},
     )

--- a/apps/negentropy/tests/integration_tests/knowledge/test_catalog_cross_corpus.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_catalog_cross_corpus.py
@@ -1,0 +1,413 @@
+"""
+Catalog 跨 corpus / orphaned entry 集成测试
+
+覆盖范围：
+- 跨 app_name 分配文档被 PermissionError 拒绝（catalog_service.py:315-319）
+- document 删除后 entry 置为 orphaned 状态（catalog_dao DOCUMENT_REF SET NULL 语义）
+- Catalog 隔离：不同 catalog 的树互不干扰
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture
+async def negentropy_corpus(db_engine):
+    """创建 app_name=negentropy 的测试 corpus"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import Corpus
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    corpus_id: UUID | None = None
+    async with session_factory() as session:
+        corpus = Corpus(name="cross-test-corpus-negentropy", app_name="negentropy")
+        session.add(corpus)
+        await session.flush()
+        await session.commit()
+        corpus_id = corpus.id
+
+    yield corpus_id
+
+    async with session_factory() as s:
+        obj = await s.get(Corpus, corpus_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def other_app_corpus(db_engine):
+    """创建 app_name=other-app 的测试 corpus（跨 app）"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import Corpus
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    corpus_id: UUID | None = None
+    async with session_factory() as session:
+        corpus = Corpus(name="cross-test-corpus-other", app_name="other-app")
+        session.add(corpus)
+        await session.flush()
+        await session.commit()
+        corpus_id = corpus.id
+
+    yield corpus_id
+
+    async with session_factory() as s:
+        obj = await s.get(Corpus, corpus_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def negentropy_catalog(db_engine, negentropy_corpus):
+    """创建 app_name=negentropy 的 DocCatalog"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import DocCatalog
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    catalog_id: UUID | None = None
+    async with session_factory() as session:
+        catalog = DocCatalog(
+            app_name="negentropy",
+            name="cross-test-catalog",
+            slug="cross-test-catalog",
+            visibility="INTERNAL",
+            version=1,
+            is_archived=False,
+        )
+        session.add(catalog)
+        await session.flush()
+        await session.commit()
+        catalog_id = catalog.id
+
+    yield catalog_id
+
+    async with session_factory() as s:
+        obj = await s.get(DocCatalog, catalog_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def doc_in_negentropy(db_engine, negentropy_corpus):
+    """创建属于 negentropy corpus 的 KnowledgeDocument"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import KnowledgeDocument
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    doc_id: UUID | None = None
+    async with session_factory() as session:
+        doc = KnowledgeDocument(
+            corpus_id=negentropy_corpus,
+            app_name="negentropy",
+            file_hash="abcdef1234567890" * 4,
+            original_filename="valid_doc.pdf",
+            gcs_uri="gs://test/valid_doc.pdf",
+            content_type="application/pdf",
+            file_size=2048,
+        )
+        session.add(doc)
+        await session.flush()
+        await session.commit()
+        doc_id = doc.id
+
+    yield doc_id
+
+    async with session_factory() as s:
+        obj = await s.get(KnowledgeDocument, doc_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def doc_in_other_app(db_engine, other_app_corpus):
+    """创建属于 other-app corpus 的 KnowledgeDocument（跨 app）"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import KnowledgeDocument
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    doc_id: UUID | None = None
+    async with session_factory() as session:
+        doc = KnowledgeDocument(
+            corpus_id=other_app_corpus,
+            app_name="other-app",
+            file_hash="fedcba0987654321" * 4,
+            original_filename="foreign_doc.pdf",
+            gcs_uri="gs://test/foreign_doc.pdf",
+            content_type="application/pdf",
+            file_size=1024,
+        )
+        session.add(doc)
+        await session.flush()
+        await session.commit()
+        doc_id = doc.id
+
+    yield doc_id
+
+    async with session_factory() as s:
+        obj = await s.get(KnowledgeDocument, doc_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+# ===================================================================
+# TestCrossCorpusPermission — 跨 app 分配拦截
+# ===================================================================
+
+
+class TestCrossCorpusPermission:
+    """catalog_service.assign_document 的跨 app_name 权限校验"""
+
+    @pytest.mark.asyncio
+    async def test_assign_same_app_document_succeeds(self, db_engine, negentropy_catalog, doc_in_negentropy):
+        """同 app_name 的文档归入 catalog 应成功"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+        from negentropy.knowledge.catalog_service import CatalogService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = CatalogService()
+
+        # 先创建目录节点
+        async with session_factory() as session:
+            node = await CatalogDao.create_node(
+                session,
+                catalog_id=negentropy_catalog,
+                name="Test Node",
+                slug="test-node",
+            )
+            await session.commit()
+            node_id = node.id
+
+        # 归入同 app_name 文档 → 应成功（无异常）
+        async with session_factory() as session:
+            await service.assign_document(
+                session,
+                catalog_node_id=node_id,
+                document_id=doc_in_negentropy,
+            )
+            await session.commit()
+
+    @pytest.mark.asyncio
+    async def test_assign_cross_app_document_raises_permission_error(
+        self, db_engine, negentropy_catalog, doc_in_other_app
+    ):
+        """跨 app_name 文档归入 catalog 应抛 PermissionError"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+        from negentropy.knowledge.catalog_service import CatalogService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = CatalogService()
+
+        # 先创建目录节点（属于 negentropy catalog）
+        async with session_factory() as session:
+            node = await CatalogDao.create_node(
+                session,
+                catalog_id=negentropy_catalog,
+                name="Test Node Cross",
+                slug="test-node-cross",
+            )
+            await session.commit()
+            node_id = node.id
+
+        # 归入跨 app_name 文档 → 应抛 PermissionError
+        async with session_factory() as session:
+            with pytest.raises(PermissionError, match="cross-app assignment forbidden"):
+                await service.assign_document(
+                    session,
+                    catalog_node_id=node_id,
+                    document_id=doc_in_other_app,
+                )
+
+    @pytest.mark.asyncio
+    async def test_cross_app_rejection_does_not_modify_catalog(self, db_engine, negentropy_catalog, doc_in_other_app):
+        """跨 app 拒绝后 catalog 的条目数量应保持不变"""
+        from sqlalchemy import func, select
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+        from negentropy.knowledge.catalog_service import CatalogService
+        from negentropy.models.perception import DocCatalogEntry
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = CatalogService()
+
+        async with session_factory() as session:
+            node = await CatalogDao.create_node(
+                session,
+                catalog_id=negentropy_catalog,
+                name="Clean Node",
+                slug="clean-node",
+            )
+            await session.commit()
+            node_id = node.id
+
+        # 记录初始 entry 数量
+        async with session_factory() as session:
+            count_before = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(DocCatalogEntry)
+                    .where(DocCatalogEntry.catalog_id == negentropy_catalog)
+                )
+            ).scalar()
+
+        # 尝试跨 app 分配（会失败）
+        async with session_factory() as session:
+            with pytest.raises(PermissionError):
+                await service.assign_document(
+                    session,
+                    catalog_node_id=node_id,
+                    document_id=doc_in_other_app,
+                )
+
+        # entry 数量应不变
+        async with session_factory() as session:
+            count_after = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(DocCatalogEntry)
+                    .where(DocCatalogEntry.catalog_id == negentropy_catalog)
+                )
+            ).scalar()
+
+        assert count_before == count_after
+
+
+# ===================================================================
+# TestCatalogIsolation — 不同 catalog 互不干扰
+# ===================================================================
+
+
+class TestCatalogIsolation:
+    """多个 catalog 之间的树隔离测试"""
+
+    @pytest.mark.asyncio
+    async def test_trees_of_different_catalogs_are_isolated(self, db_engine, negentropy_corpus):
+        """两个不同 catalog 的目录树互不干扰"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+        from negentropy.models.perception import DocCatalog
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        catalog_a_id: UUID
+        catalog_b_id: UUID
+
+        async with session_factory() as session:
+            cat_a = DocCatalog(
+                app_name="negentropy",
+                name="Catalog A",
+                slug="catalog-isolation-a",
+                visibility="INTERNAL",
+                version=1,
+                is_archived=False,
+            )
+            cat_b = DocCatalog(
+                app_name="negentropy",
+                name="Catalog B",
+                slug="catalog-isolation-b",
+                visibility="INTERNAL",
+                version=1,
+                is_archived=False,
+            )
+            session.add(cat_a)
+            session.add(cat_b)
+            await session.flush()
+            catalog_a_id = cat_a.id
+            catalog_b_id = cat_b.id
+            await session.commit()
+
+        # 在 catalog A 下创建节点
+        async with session_factory() as session:
+            await CatalogDao.create_node(session, catalog_id=catalog_a_id, name="Node A1", slug="node-a1")
+            await CatalogDao.create_node(session, catalog_id=catalog_a_id, name="Node A2", slug="node-a2")
+            # catalog B 只有 1 个节点
+            await CatalogDao.create_node(session, catalog_id=catalog_b_id, name="Node B1", slug="node-b1")
+            await session.commit()
+
+        async with session_factory() as session:
+            tree_a = await CatalogDao.get_tree(session, catalog_id=catalog_a_id)
+            tree_b = await CatalogDao.get_tree(session, catalog_id=catalog_b_id)
+
+        assert len(tree_a) == 2
+        assert len(tree_b) == 1
+
+        # cleanup
+        async with session_factory() as s:
+            for cid in [catalog_a_id, catalog_b_id]:
+                obj = await s.get(DocCatalog, cid)
+                if obj is not None:
+                    await s.delete(obj)
+            await s.commit()
+
+    @pytest.mark.asyncio
+    async def test_get_tree_different_catalog_does_not_return_nodes_of_other(self, db_engine, negentropy_corpus):
+        """get_tree(catalog_id=X) 不应返回属于其他 catalog 的节点"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+        from negentropy.models.perception import DocCatalog
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+
+        async with session_factory() as session:
+            cat_x = DocCatalog(
+                app_name="negentropy",
+                name="Catalog X",
+                slug="catalog-isolation-x",
+                visibility="INTERNAL",
+                version=1,
+                is_archived=False,
+            )
+            cat_y = DocCatalog(
+                app_name="negentropy",
+                name="Catalog Y",
+                slug="catalog-isolation-y",
+                visibility="INTERNAL",
+                version=1,
+                is_archived=False,
+            )
+            session.add(cat_x)
+            session.add(cat_y)
+            await session.flush()
+            x_id = cat_x.id
+            y_id = cat_y.id
+            await session.commit()
+
+        async with session_factory() as session:
+            node_x = await CatalogDao.create_node(session, catalog_id=x_id, name="X-Only Node", slug="x-only-node")
+            await session.commit()
+
+        # query catalog Y → 不应看到 catalog X 的节点
+        async with session_factory() as session:
+            tree_y = await CatalogDao.get_tree(session, catalog_id=y_id)
+
+        assert all(row["id"] != node_x.id for row in tree_y)
+
+        # cleanup
+        async with session_factory() as s:
+            for cid in [x_id, y_id]:
+                obj = await s.get(DocCatalog, cid)
+                if obj is not None:
+                    await s.delete(obj)
+            await s.commit()

--- a/apps/negentropy/tests/integration_tests/knowledge/test_catalog_dao_integration.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_catalog_dao_integration.py
@@ -20,6 +20,32 @@ import pytest
 from negentropy.knowledge.catalog_dao import CatalogDao
 
 # ===================================================================
+# 辅助工厂
+# ===================================================================
+
+
+async def _make_catalog(session_factory, *, app_name: str = "negentropy", suffix: str = "") -> UUID:
+    """创建 DocCatalog 并返回其 ID。"""
+
+    from negentropy.models.perception import DocCatalog
+
+    factory = session_factory if not callable(session_factory.__class__.__call__) else session_factory
+    async with factory() as session:
+        catalog = DocCatalog(
+            app_name=app_name,
+            name=f"test-catalog{suffix}",
+            slug=f"test-catalog{suffix}",
+            visibility="INTERNAL",
+            version=1,
+            is_archived=False,
+        )
+        session.add(catalog)
+        await session.flush()
+        await session.commit()
+        return catalog.id
+
+
+# ===================================================================
 # Fixtures — 测试数据构建
 # ===================================================================
 
@@ -52,7 +78,39 @@ async def sample_corpus(db_engine):
 
 
 @pytest.fixture
-async def catalog_tree(db_engine, sample_corpus):
+async def sample_catalog(db_engine, sample_corpus):
+    """创建与 sample_corpus 同 app_name 的全局 DocCatalog，返回其 ID。"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import DocCatalog
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    catalog_id: UUID | None = None
+    async with session_factory() as session:
+        catalog = DocCatalog(
+            app_name="negentropy",
+            name="integration-test-catalog",
+            slug="integration-test-catalog",
+            visibility="INTERNAL",
+            version=1,
+            is_archived=False,
+        )
+        session.add(catalog)
+        await session.flush()
+        await session.commit()
+        catalog_id = catalog.id
+
+    yield catalog_id
+
+    async with session_factory() as s:
+        obj = await s.get(DocCatalog, catalog_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def catalog_tree(db_engine, sample_corpus, sample_catalog):
     """构建 3 层目录树用于 CTE 测试。
 
     结构::
@@ -69,34 +127,34 @@ async def catalog_tree(db_engine, sample_corpus):
     async with session_factory() as session:
         root = await CatalogDao.create_node(
             session,
-            corpus_id=sample_corpus,
+            catalog_id=sample_catalog,
             name="Root",
             slug="root",
         )
         cat_a = await CatalogDao.create_node(
             session,
-            corpus_id=sample_corpus,
+            catalog_id=sample_catalog,
             name="Category A",
             slug="cat-a",
             parent_id=root.id,
         )
         cat_b = await CatalogDao.create_node(
             session,
-            corpus_id=sample_corpus,
+            catalog_id=sample_catalog,
             name="Category B",
             slug="cat-b",
             parent_id=root.id,
         )
         sub_a1 = await CatalogDao.create_node(
             session,
-            corpus_id=sample_corpus,
+            catalog_id=sample_catalog,
             name="SubCategory A1",
             slug="sub-a1",
             parent_id=cat_a.id,
         )
         sub_a2 = await CatalogDao.create_node(
             session,
-            corpus_id=sample_corpus,
+            catalog_id=sample_catalog,
             name="SubCategory A2",
             slug="sub-a2",
             parent_id=cat_a.id,
@@ -104,6 +162,7 @@ async def catalog_tree(db_engine, sample_corpus):
         await session.commit()
 
         return {
+            "catalog_id": sample_catalog,
             "corpus_id": sample_corpus,
             "root": root,
             "cat_a": cat_a,
@@ -162,7 +221,7 @@ class TestCatalogTreeCte:
     """get_tree() Recursive CTE 查询的集成测试"""
 
     @pytest.mark.asyncio
-    async def test_get_tree_flat_structure_single_root(self, db_engine, sample_corpus):
+    async def test_get_tree_flat_structure_single_root(self, db_engine, sample_catalog):
         """单根节点：depth=0，path=[root_id]"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -170,13 +229,13 @@ class TestCatalogTreeCte:
         async with session_factory() as session:
             root = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Solo Root",
                 slug="solo-root",
             )
             await session.commit()
 
-            tree = await CatalogDao.get_tree(session, corpus_id=sample_corpus)
+            tree = await CatalogDao.get_tree(session, catalog_id=sample_catalog)
 
         assert len(tree) == 1
         assert tree[0]["id"] == root.id
@@ -186,7 +245,7 @@ class TestCatalogTreeCte:
         assert tree[0]["path"] == [root.id]
 
     @pytest.mark.asyncio
-    async def test_get_tree_two_level_hierarchy(self, db_engine, sample_corpus):
+    async def test_get_tree_two_level_hierarchy(self, db_engine, sample_catalog):
         """两层层级结构：根 depth=0，子节点 depth=1，path 累积正确"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -194,20 +253,20 @@ class TestCatalogTreeCte:
         async with session_factory() as session:
             root = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Root",
                 slug="root-2l",
             )
             child = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Child",
                 slug="child-2l",
                 parent_id=root.id,
             )
             await session.commit()
 
-            tree = await CatalogDao.get_tree(session, corpus_id=sample_corpus)
+            tree = await CatalogDao.get_tree(session, catalog_id=sample_catalog)
 
         assert len(tree) == 2
         # 按 depth 排序：先根后子
@@ -230,7 +289,7 @@ class TestCatalogTreeCte:
 
         session_factory = catalog_tree["session"]
         async with session_factory() as session:
-            tree = await CatalogDao.get_tree(session, corpus_id=catalog_tree["corpus_id"])
+            tree = await CatalogDao.get_tree(session, catalog_id=catalog_tree["catalog_id"])
 
         # 应返回全部 5 个节点
         assert len(tree) == 5
@@ -264,7 +323,7 @@ class TestCatalogTreeCte:
         ]
 
     @pytest.mark.asyncio
-    async def test_get_tree_multiple_roots(self, db_engine, sample_corpus):
+    async def test_get_tree_multiple_roots(self, db_engine, sample_catalog):
         """多个根节点（parent_id=None）应全部出现在结果中"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -272,32 +331,32 @@ class TestCatalogTreeCte:
         async with session_factory() as session:
             r1 = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Root Alpha",
                 slug="root-alpha",
             )
             r2 = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Root Beta",
                 slug="root-beta",
             )
             await session.commit()
 
-            tree = await CatalogDao.get_tree(session, corpus_id=sample_corpus)
+            tree = await CatalogDao.get_tree(session, catalog_id=sample_catalog)
 
         assert len(tree) == 2
         root_ids = {row["id"] for row in tree if row["depth"] == 0}
         assert root_ids == {r1.id, r2.id}
 
     @pytest.mark.asyncio
-    async def test_get_tree_empty_corpus_returns_empty_list(self, db_engine, sample_corpus):
-        """空语料库（无任何节点）应返回空列表"""
+    async def test_get_tree_empty_catalog_returns_empty_list(self, db_engine, sample_catalog):
+        """空 catalog（无任何节点）应返回空列表"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
         session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
         async with session_factory() as session:
-            tree = await CatalogDao.get_tree(session, corpus_id=sample_corpus)
+            tree = await CatalogDao.get_tree(session, catalog_id=sample_catalog)
 
         assert tree == []
 
@@ -309,7 +368,7 @@ class TestCatalogTreeCte:
         async with session_factory() as session:
             tree = await CatalogDao.get_tree(
                 session,
-                corpus_id=catalog_tree["corpus_id"],
+                catalog_id=catalog_tree["catalog_id"],
                 max_depth=1,
             )
 
@@ -324,7 +383,7 @@ class TestCatalogTreeCte:
 
         session_factory = catalog_tree["session"]
         async with session_factory() as session:
-            tree = await CatalogDao.get_tree(session, corpus_id=catalog_tree["corpus_id"])
+            tree = await CatalogDao.get_tree(session, catalog_id=catalog_tree["catalog_id"])
 
         # 提取排序键用于断言
         order_keys = [(row["depth"], row["sort_order"], row["name"]) for row in tree]
@@ -407,7 +466,7 @@ class TestCatalogSubtreeCte:
         assert subtree[0]["depth"] == 0
 
     @pytest.mark.asyncio
-    async def test_get_subtree_nonexistent_node_returns_empty(self, db_engine, sample_corpus):
+    async def test_get_subtree_nonexistent_node_returns_empty(self, db_engine, sample_catalog):
         """不存在的节点 ID 应返回空列表"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -428,7 +487,7 @@ class TestCatalogCrudIntegration:
     """CatalogDao 节点 CRUD 操作的端到端集成测试"""
 
     @pytest.mark.asyncio
-    async def test_create_and_retrieve_node_roundtrip(self, db_engine, sample_corpus):
+    async def test_create_and_retrieve_node_roundtrip(self, db_engine, sample_catalog):
         """创建节点后通过 get_node 取回，字段一致"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -436,7 +495,7 @@ class TestCatalogCrudIntegration:
         async with session_factory() as session:
             created = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Roundtrip Node",
                 slug="roundtrip-node",
                 parent_id=None,
@@ -454,14 +513,14 @@ class TestCatalogCrudIntegration:
         assert fetched is not None
         assert fetched.id == created.id
         assert fetched.name == "Roundtrip Node"
-        assert fetched.slug == "roundtrip-node"
-        assert fetched.node_type == "collection"
+        assert fetched.slug_override == "roundtrip-node"
+        assert fetched.node_type == "COLLECTION"
         assert fetched.description == "Test description"
-        assert fetched.sort_order == 42
+        assert fetched.position == 42
         assert fetched.config == {"key": "value"}
 
     @pytest.mark.asyncio
-    async def test_update_node_partial_update(self, db_engine, sample_corpus):
+    async def test_update_node_partial_update(self, db_engine, sample_catalog):
         """update_node 仅修改指定字段，未指定字段保持不变"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -469,7 +528,7 @@ class TestCatalogCrudIntegration:
         async with session_factory() as session:
             node = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Original Name",
                 slug="original-slug",
                 sort_order=5,
@@ -487,12 +546,12 @@ class TestCatalogCrudIntegration:
 
         assert updated is not None
         assert updated.name == "Updated Name"
-        assert updated.sort_order == 99
+        assert updated.position == 99
         # 未更新的字段保持原值
-        assert updated.slug == "original-slug"
+        assert updated.slug_override == "original-slug"
 
     @pytest.mark.asyncio
-    async def test_delete_node_cascades_children(self, db_engine, sample_corpus):
+    async def test_delete_node_cascades_children(self, db_engine, sample_catalog):
         """删除父节点后，子节点应被级联删除"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -500,13 +559,13 @@ class TestCatalogCrudIntegration:
         async with session_factory() as session:
             parent = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Parent",
                 slug="cascade-parent",
             )
             child = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Child",
                 slug="cascade-child",
                 parent_id=parent.id,
@@ -529,7 +588,7 @@ class TestCatalogCrudIntegration:
         assert child_gone is None
 
     @pytest.mark.asyncio
-    async def test_create_node_with_parent_sets_parent_id(self, db_engine, sample_corpus):
+    async def test_create_node_with_parent_sets_parent_id(self, db_engine, sample_catalog):
         """创建带 parent_id 的节点应正确设置外键关系"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -537,30 +596,30 @@ class TestCatalogCrudIntegration:
         async with session_factory() as session:
             parent = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Parent Node",
                 slug="parent-node",
             )
             child = await CatalogDao.create_node(
                 session,
-                corpus_id=sample_corpus,
+                catalog_id=sample_catalog,
                 name="Child Node",
                 slug="child-node",
                 parent_id=parent.id,
             )
             await session.commit()
 
-        assert child.parent_id == parent.id
+        assert child.parent_entry_id == parent.id
 
         # 通过 get_node 验证关系可追溯
         async with session_factory() as session:
             fetched_child = await CatalogDao.get_node(session, child.id)
 
         assert fetched_child is not None
-        assert fetched_child.parent_id == parent.id
+        assert fetched_child.parent_entry_id == parent.id
 
     @pytest.mark.asyncio
-    async def test_delete_nonexistent_node_returns_false(self, db_engine, sample_corpus):
+    async def test_delete_nonexistent_node_returns_false(self, db_engine, sample_catalog):
         """删除不存在的节点应幂等返回 False"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -595,17 +654,17 @@ class TestCatalogMembershipIntegration:
         async with session_factory() as session:
             membership = await CatalogDao.assign_document(
                 session,
-                catalog_node_id=node_id,
+                catalog_entry_id=node_id,
                 document_id=doc_id,
             )
             await session.commit()
 
-        assert membership.catalog_node_id == node_id
+        assert membership.parent_entry_id == node_id
         assert membership.document_id == doc_id
 
         # 2. verify assignment exists via get_node_documents
         async with session_factory() as session:
-            docs, total = await CatalogDao.get_node_documents(session, catalog_node_id=node_id)
+            docs, total = await CatalogDao.get_node_documents(session, catalog_entry_id=node_id)
 
         assert total >= 1
 
@@ -613,7 +672,7 @@ class TestCatalogMembershipIntegration:
         async with session_factory() as session:
             removed = await CatalogDao.unassign_document(
                 session,
-                catalog_node_id=node_id,
+                catalog_entry_id=node_id,
                 document_id=doc_id,
             )
             await session.commit()
@@ -622,7 +681,7 @@ class TestCatalogMembershipIntegration:
 
         # 4. verify removal
         async with session_factory() as session:
-            docs_after, total_after = await CatalogDao.get_node_documents(session, catalog_node_id=node_id)
+            docs_after, total_after = await CatalogDao.get_node_documents(session, catalog_entry_id=node_id)
 
         assert total_after < total
 
@@ -638,7 +697,7 @@ class TestCatalogMembershipIntegration:
         async with session_factory() as session:
             first = await CatalogDao.assign_document(
                 session,
-                catalog_node_id=node_id,
+                catalog_entry_id=node_id,
                 document_id=doc_id,
             )
             await session.commit()
@@ -646,7 +705,7 @@ class TestCatalogMembershipIntegration:
         async with session_factory() as session:
             second = await CatalogDao.assign_document(
                 session,
-                catalog_node_id=node_id,
+                catalog_entry_id=node_id,
                 document_id=doc_id,
             )
             await session.commit()
@@ -667,20 +726,20 @@ class TestCatalogMembershipIntegration:
             for doc_id in sample_documents:
                 await CatalogDao.assign_document(
                     session,
-                    catalog_node_id=node_id,
+                    catalog_entry_id=node_id,
                     document_id=doc_id,
                 )
             await session.commit()
 
         # 分页取第 1 条
         async with session_factory() as session:
-            page1, _ = await CatalogDao.get_node_documents(session, catalog_node_id=node_id, offset=0, limit=1)
+            page1, _ = await CatalogDao.get_node_documents(session, catalog_entry_id=node_id, offset=0, limit=1)
 
         assert len(page1) == 1
 
         # 分页取第 2 条
         async with session_factory() as session:
-            page2, _ = await CatalogDao.get_node_documents(session, catalog_node_id=node_id, offset=1, limit=1)
+            page2, _ = await CatalogDao.get_node_documents(session, catalog_entry_id=node_id, offset=1, limit=1)
 
         assert len(page2) == 1
         # 两页的文档应不同
@@ -698,15 +757,15 @@ class TestCatalogMembershipIntegration:
             for doc_id in sample_documents:
                 await CatalogDao.assign_document(
                     session,
-                    catalog_node_id=node_id,
+                    catalog_entry_id=node_id,
                     document_id=doc_id,
                 )
             await session.commit()
 
         # 不同分页参数下的 total 应一致
         async with session_factory() as session:
-            _, total_full = await CatalogDao.get_node_documents(session, catalog_node_id=node_id, offset=0, limit=50)
-            _, total_paged = await CatalogDao.get_node_documents(session, catalog_node_id=node_id, offset=1, limit=1)
+            _, total_full = await CatalogDao.get_node_documents(session, catalog_entry_id=node_id, offset=0, limit=50)
+            _, total_paged = await CatalogDao.get_node_documents(session, catalog_entry_id=node_id, offset=1, limit=1)
 
         assert total_full == total_paged
         assert total_full == len(sample_documents)
@@ -724,7 +783,7 @@ class TestCatalogMembershipIntegration:
             for node_id in target_nodes:
                 await CatalogDao.assign_document(
                     session,
-                    catalog_node_id=node_id,
+                    catalog_entry_id=node_id,
                     document_id=doc_id,
                 )
             await session.commit()

--- a/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
@@ -1,0 +1,359 @@
+"""
+Wiki 发布模式集成测试
+
+覆盖范围：
+- Live 模式（默认）：Publication 创建、发布、取消发布、状态流转
+- Snapshot 概念验证：状态字段存在；未来快照功能的 fixture 准备
+- 发布版本递增语义
+- 归档（archived）状态
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture
+async def wiki_corpus(db_engine):
+    """创建测试用语料库"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import Corpus
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    corpus_id: UUID | None = None
+    async with session_factory() as session:
+        corpus = Corpus(name="wiki-publish-test-corpus", app_name="negentropy")
+        session.add(corpus)
+        await session.flush()
+        await session.commit()
+        corpus_id = corpus.id
+
+    yield corpus_id
+
+    async with session_factory() as s:
+        from negentropy.models.perception import Corpus as C
+
+        obj = await s.get(C, corpus_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def wiki_catalog(db_engine, wiki_corpus):
+    """创建测试用 DocCatalog"""
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from negentropy.models.perception import DocCatalog
+
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    catalog_id: UUID | None = None
+    async with session_factory() as session:
+        catalog = DocCatalog(
+            app_name="negentropy",
+            name="wiki-publish-test-catalog",
+            slug="wiki-publish-test-catalog",
+            visibility="INTERNAL",
+            version=1,
+            is_archived=False,
+        )
+        session.add(catalog)
+        await session.flush()
+        await session.commit()
+        catalog_id = catalog.id
+
+    yield catalog_id
+
+    async with session_factory() as s:
+        obj = await s.get(DocCatalog, catalog_id)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+# ===================================================================
+# TestWikiPublicationLifecycle — Publication 生命周期
+# ===================================================================
+
+
+class TestWikiPublicationLifecycle:
+    """WikiPublishingService 的创建、发布、取消发布生命周期测试"""
+
+    @pytest.mark.asyncio
+    async def test_create_publication_defaults_to_draft(self, db_engine, wiki_catalog):
+        """新建 Publication 默认处于 draft 状态"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            pub = await service.create_publication(
+                session,
+                catalog_id=wiki_catalog,
+                name="Test Publication",
+                slug="test-pub-draft",
+            )
+            await session.commit()
+
+        assert pub.status == "draft"
+        assert pub.version == 0
+        assert pub.catalog_id == wiki_catalog
+
+    @pytest.mark.asyncio
+    async def test_publish_changes_status_to_published(self, db_engine, wiki_catalog):
+        """publish() 使 Publication 从 draft 进入 published 状态"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            pub = await service.create_publication(
+                session,
+                catalog_id=wiki_catalog,
+                name="Test Publication Publish",
+                slug="test-pub-publish",
+            )
+            await session.commit()
+            pub_id = pub.id
+
+        async with session_factory() as session:
+            published = await service.publish(session, pub_id)
+            await session.commit()
+
+        assert published is not None
+        assert published.status == "published"
+        assert published.version >= 1
+
+    @pytest.mark.asyncio
+    async def test_publish_increments_version(self, db_engine, wiki_catalog):
+        """多次发布应递增 version"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            pub = await service.create_publication(
+                session,
+                catalog_id=wiki_catalog,
+                name="Test Pub Version",
+                slug="test-pub-version",
+            )
+            await session.commit()
+            pub_id = pub.id
+
+        # 第 1 次发布
+        async with session_factory() as session:
+            v1 = await service.publish(session, pub_id)
+            await session.commit()
+        version_1 = v1.version
+
+        # 第 2 次发布（重新发布）
+        async with session_factory() as session:
+            v2 = await service.publish(session, pub_id)
+            await session.commit()
+        version_2 = v2.version
+
+        assert version_2 > version_1
+
+    @pytest.mark.asyncio
+    async def test_unpublish_returns_to_draft(self, db_engine, wiki_catalog):
+        """unpublish() 将 published → draft"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            pub = await service.create_publication(
+                session,
+                catalog_id=wiki_catalog,
+                name="Test Pub Unpublish",
+                slug="test-pub-unpublish",
+            )
+            await session.commit()
+            pub_id = pub.id
+
+        async with session_factory() as session:
+            await service.publish(session, pub_id)
+            await session.commit()
+
+        async with session_factory() as session:
+            unpublished = await service.unpublish(session, pub_id)
+            await session.commit()
+
+        assert unpublished is not None
+        assert unpublished.status == "draft"
+
+    @pytest.mark.asyncio
+    async def test_archive_publication(self, db_engine, wiki_catalog):
+        """archive() 将 Publication 置为 archived 状态"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            pub = await service.create_publication(
+                session,
+                catalog_id=wiki_catalog,
+                name="Test Pub Archive",
+                slug="test-pub-archive",
+            )
+            await session.commit()
+            pub_id = pub.id
+
+        async with session_factory() as session:
+            archived = await service.archive(session, pub_id)
+            await session.commit()
+
+        assert archived is not None
+        assert archived.status == "archived"
+
+    @pytest.mark.asyncio
+    async def test_delete_publication_removes_record(self, db_engine, wiki_catalog):
+        """delete_publication() 后 get_publication 应返回 None"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            pub = await service.create_publication(
+                session,
+                catalog_id=wiki_catalog,
+                name="Test Pub Delete",
+                slug="test-pub-delete",
+            )
+            await session.commit()
+            pub_id = pub.id
+
+        async with session_factory() as session:
+            deleted = await service.delete_publication(session, pub_id)
+            await session.commit()
+
+        assert deleted is True
+
+        async with session_factory() as session:
+            gone = await service.get_publication(session, pub_id)
+
+        assert gone is None
+
+
+# ===================================================================
+# TestWikiPublicationCatalogBinding — catalog_id 绑定语义
+# ===================================================================
+
+
+class TestWikiPublicationCatalogBinding:
+    """Publication 与 Catalog 的绑定关系测试"""
+
+    @pytest.mark.asyncio
+    async def test_list_publications_filtered_by_catalog(self, db_engine, wiki_catalog):
+        """list_publications(catalog_id=X) 只返回该 catalog 下的发布"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+        from negentropy.models.perception import DocCatalog
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        # 创建第二个 catalog
+        async with session_factory() as session:
+            other = DocCatalog(
+                app_name="negentropy",
+                name="other-catalog-list",
+                slug="other-catalog-list",
+                visibility="INTERNAL",
+                version=1,
+                is_archived=False,
+            )
+            session.add(other)
+            await session.flush()
+            await session.commit()
+            other_catalog_id = other.id
+
+        # 在 wiki_catalog 下创建 2 个 publication
+        async with session_factory() as session:
+            await service.create_publication(session, catalog_id=wiki_catalog, name="Pub A", slug="pub-a-list")
+            await service.create_publication(session, catalog_id=wiki_catalog, name="Pub B", slug="pub-b-list")
+            # 在 other catalog 下创建 1 个
+            await service.create_publication(
+                session, catalog_id=other_catalog_id, name="Pub C Other", slug="pub-c-other-list"
+            )
+            await session.commit()
+
+        # 按 wiki_catalog 过滤
+        async with session_factory() as session:
+            pubs, total = await service.list_publications(session, catalog_id=wiki_catalog)
+
+        assert total >= 2
+        assert all(p.catalog_id == wiki_catalog for p in pubs)
+
+        # cleanup other catalog
+        async with session_factory() as s:
+            obj = await s.get(DocCatalog, other_catalog_id)
+            if obj is not None:
+                await s.delete(obj)
+            await s.commit()
+
+    @pytest.mark.asyncio
+    async def test_create_publication_slug_validation(self, db_engine, wiki_catalog):
+        """非法 slug 格式应抛 ValueError"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            with pytest.raises(ValueError, match="Invalid slug format"):
+                await service.create_publication(
+                    session,
+                    catalog_id=wiki_catalog,
+                    name="Bad Slug Pub",
+                    slug="UPPER_CASE_SLUG",
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_publication_invalid_theme_raises(self, db_engine, wiki_catalog):
+        """非法 theme 应抛 ValueError"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.knowledge.wiki_service import WikiPublishingService
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        service = WikiPublishingService()
+
+        async with session_factory() as session:
+            with pytest.raises(ValueError, match="Invalid theme"):
+                await service.create_publication(
+                    session,
+                    catalog_id=wiki_catalog,
+                    name="Bad Theme Pub",
+                    slug="bad-theme-pub",
+                    theme="unknown-theme",
+                )

--- a/apps/negentropy/tests/performance_tests/knowledge/test_catalog_tree_perf.py
+++ b/apps/negentropy/tests/performance_tests/knowledge/test_catalog_tree_perf.py
@@ -1,0 +1,165 @@
+"""
+Catalog 树查询性能基准测试
+
+固化 get_tree() Recursive CTE 的 P99 基线，防止性能回退。
+参考阈值（基于 3 层 100 节点树，本地 PG 实例）：
+  - get_tree() 平均耗时 < 50ms
+  - get_subtree() 平均耗时 < 20ms
+"""
+
+from __future__ import annotations
+
+import time
+from uuid import UUID
+
+import pytest
+
+
+class TestCatalogTreePerformance:
+    """Catalog 目录树 CTE 查询的性能基准测试"""
+
+    @pytest.fixture
+    async def perf_catalog(self, db_engine):
+        """创建性能测试用 Catalog（不依赖 corpus）"""
+        from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+        from negentropy.models.perception import DocCatalog
+
+        session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        catalog_id: UUID | None = None
+        async with session_factory() as session:
+            catalog = DocCatalog(
+                app_name="negentropy",
+                name="perf-test-catalog",
+                slug="perf-test-catalog",
+                visibility="INTERNAL",
+                version=1,
+                is_archived=False,
+            )
+            session.add(catalog)
+            await session.flush()
+            await session.commit()
+            catalog_id = catalog.id
+
+        yield catalog_id, session_factory
+
+        async with session_factory() as s:
+            obj = await s.get(DocCatalog, catalog_id)
+            if obj is not None:
+                await s.delete(obj)
+            await s.commit()
+
+    async def _build_tree(self, session_factory, catalog_id: UUID, depth: int = 3, branching: int = 4) -> int:
+        """递归构建指定深度和分支因子的目录树，返回节点总数。"""
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+
+        total = 0
+
+        async def _create_level(parent_id: UUID | None, current_depth: int, prefix: str) -> None:
+            nonlocal total
+            if current_depth > depth:
+                return
+            for i in range(branching):
+                slug = f"{prefix}-d{current_depth}-{i}"
+                async with session_factory() as session:
+                    node = await CatalogDao.create_node(
+                        session,
+                        catalog_id=catalog_id,
+                        name=slug,
+                        slug=slug,
+                        parent_id=parent_id,
+                    )
+                    await session.commit()
+                    total += 1
+                await _create_level(node.id, current_depth + 1, slug)
+
+        await _create_level(None, 1, "perf")
+        return total
+
+    @pytest.mark.asyncio
+    async def test_get_tree_100_nodes_under_50ms(self, db_engine, perf_catalog):
+        """100 节点的 3 层树，get_tree() 平均耗时应 < 50ms"""
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+
+        catalog_id, session_factory = perf_catalog
+
+        # 构建约 84 节点的树（branching=4, depth=3: 4+16+64=84）
+        total_nodes = await self._build_tree(session_factory, catalog_id, depth=3, branching=4)
+        assert total_nodes >= 4, f"tree should have nodes, got {total_nodes}"
+
+        # 预热
+        async with session_factory() as session:
+            await CatalogDao.get_tree(session, catalog_id=catalog_id)
+
+        # 实际计时（5 次取平均）
+        durations_ms = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            async with session_factory() as session:
+                tree = await CatalogDao.get_tree(session, catalog_id=catalog_id)
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            durations_ms.append(elapsed_ms)
+
+        avg_ms = sum(durations_ms) / len(durations_ms)
+        p99_ms = sorted(durations_ms)[-1]  # 5 次中最慢的即为近似 P99
+
+        assert len(tree) == total_nodes, f"expected {total_nodes} nodes, got {len(tree)}"
+        assert avg_ms < 50, f"get_tree() avg {avg_ms:.1f}ms exceeds 50ms threshold"
+        assert p99_ms < 100, f"get_tree() p99 {p99_ms:.1f}ms exceeds 100ms threshold"
+
+    @pytest.mark.asyncio
+    async def test_get_subtree_under_20ms(self, db_engine, perf_catalog):
+        """get_subtree() 对子树查询应 < 20ms"""
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+
+        catalog_id, session_factory = perf_catalog
+
+        # 构建小树（branching=3, depth=2: 3+9=12 节点）
+        await self._build_tree(session_factory, catalog_id, depth=2, branching=3)
+
+        # 获取根节点 ID 作为子树锚点
+        async with session_factory() as session:
+            tree = await CatalogDao.get_tree(session, catalog_id=catalog_id)
+
+        assert len(tree) > 0
+        root_id = [r["id"] for r in tree if r["depth"] == 0][0]
+
+        # 预热
+        async with session_factory() as session:
+            await CatalogDao.get_subtree(session, node_id=root_id)
+
+        # 实际计时（5 次取平均）
+        durations_ms = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            async with session_factory() as session:
+                subtree = await CatalogDao.get_subtree(session, node_id=root_id)
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            durations_ms.append(elapsed_ms)
+
+        avg_ms = sum(durations_ms) / len(durations_ms)
+
+        assert len(subtree) > 0
+        assert avg_ms < 20, f"get_subtree() avg {avg_ms:.1f}ms exceeds 20ms threshold"
+
+    @pytest.mark.asyncio
+    async def test_list_catalogs_under_10ms(self, db_engine, perf_catalog):
+        """list_catalogs() 应 < 10ms"""
+
+        from negentropy.knowledge.catalog_dao import CatalogDao
+
+        _, session_factory = perf_catalog
+
+        durations_ms = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            async with session_factory() as session:
+                catalogs, total = await CatalogDao.list_catalogs(session, app_name="negentropy")
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            durations_ms.append(elapsed_ms)
+
+        avg_ms = sum(durations_ms) / len(durations_ms)
+        assert avg_ms < 10, f"list_catalogs() avg {avg_ms:.1f}ms exceeds 10ms threshold"

--- a/apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py
@@ -123,28 +123,40 @@ class FakeAsyncSessionForCatalog:
 
 
 def _make_node(**overrides: Any) -> SimpleNamespace:
-    """快速构建 DocCatalogNode 的 SimpleNamespace 替身。"""
+    """快速构建 DocCatalogEntry 的 SimpleNamespace 替身。"""
     defaults: dict[str, Any] = {
         "id": uuid4(),
-        "corpus_id": uuid4(),
+        "catalog_id": uuid4(),
         "name": "Test Node",
-        "slug": "test-node",
-        "parent_id": None,
-        "node_type": "category",
+        "slug_override": "test-node",
+        "parent_entry_id": None,
+        "node_type": "CATEGORY",
         "description": None,
-        "sort_order": 0,
+        "position": 0,
         "config": {},
+        "status": "ACTIVE",
+        "document_id": None,
+        "source_corpus_id": None,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
 
 
-def _make_membership(**overrides: Any) -> SimpleNamespace:
-    """快速构建 DocCatalogMembership 的 SimpleNamespace 替身。"""
+def _make_doc_ref(**overrides: Any) -> SimpleNamespace:
+    """快速构建 DOCUMENT_REF 型 DocCatalogEntry 的 SimpleNamespace 替身。"""
     defaults: dict[str, Any] = {
         "id": uuid4(),
-        "catalog_node_id": uuid4(),
+        "catalog_id": uuid4(),
+        "name": "doc.pdf",
+        "slug_override": None,
+        "parent_entry_id": uuid4(),
+        "node_type": "DOCUMENT_REF",
+        "description": None,
+        "position": 0,
+        "config": {},
+        "status": "ACTIVE",
         "document_id": uuid4(),
+        "source_corpus_id": uuid4(),
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
@@ -161,7 +173,7 @@ class TestCatalogNodeCrud:
     @pytest.mark.asyncio
     async def test_create_node_logs_with_non_reserved_extra_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """create_node 日志应避免覆写 LogRecord 保留字段。"""
-        corpus_id = uuid4()
+        catalog_id = uuid4()
         session = FakeAsyncSessionForCatalog()
         captured: dict[str, Any] = {}
 
@@ -173,7 +185,7 @@ class TestCatalogNodeCrud:
 
         await CatalogDao.create_node(
             session,
-            corpus_id=corpus_id,
+            catalog_id=catalog_id,
             name="Root Category",
             slug="root-category",
         )
@@ -185,12 +197,12 @@ class TestCatalogNodeCrud:
     @pytest.mark.asyncio
     async def test_create_node_adds_to_session_and_flushes(self) -> None:
         """create_node 应调用 db.add + db.flush，且节点字段正确设置"""
-        corpus_id = uuid4()
+        catalog_id = uuid4()
         session = FakeAsyncSessionForCatalog()
 
         node = await CatalogDao.create_node(
             session,
-            corpus_id=corpus_id,
+            catalog_id=catalog_id,
             name="Root Category",
             slug="root-category",
             parent_id=None,
@@ -203,32 +215,32 @@ class TestCatalogNodeCrud:
         assert len(session.added) == 1
         assert session.flush_count == 1
         created = session.added[0]
-        assert created.corpus_id == corpus_id
+        assert created.catalog_id == catalog_id
         assert created.name == "Root Category"
-        assert created.slug == "root-category"
-        assert created.parent_id is None
-        assert created.node_type == "category"
+        assert created.slug_override == "root-category"
+        assert created.parent_entry_id is None
+        assert created.node_type == "CATEGORY"
         assert created.description == "Top level category"
-        assert created.sort_order == 1
+        assert created.position == 1
         assert created.config == {"theme": "dark"}
         assert node is created
 
     @pytest.mark.asyncio
     async def test_create_node_default_values(self) -> None:
-        """create_node 未传可选字段时应使用默认值：node_type=category, sort_order=0, config={}"""
-        corpus_id = uuid4()
+        """create_node 未传可选字段时应使用默认值：node_type=CATEGORY, position=0, config={}"""
+        catalog_id = uuid4()
         session = FakeAsyncSessionForCatalog()
 
         await CatalogDao.create_node(
             session,
-            corpus_id=corpus_id,
+            catalog_id=catalog_id,
             name="Default Node",
             slug="default-node",
         )
 
         created = session.added[0]
-        assert created.node_type == "category"
-        assert created.sort_order == 0
+        assert created.node_type == "CATEGORY"
+        assert created.position == 0
         assert created.config == {}
 
     @pytest.mark.asyncio
@@ -249,21 +261,21 @@ class TestCatalogNodeCrud:
 
     @pytest.mark.asyncio
     async def test_get_node_by_slug_executes_select(self) -> None:
-        """get_node_by_slug 应按 corpus_id + slug 执行 select"""
-        corpus_id = uuid4()
+        """get_node_by_slug 应按 catalog_id + slug_override 执行 select"""
+        catalog_id = uuid4()
         slug = "my-slug"
-        expected_node = _make_node(corpus_id=corpus_id, slug=slug)
+        expected_node = _make_node(catalog_id=catalog_id, slug_override=slug)
         session = FakeAsyncSessionForCatalog(
             execute_responses=[
                 _FakeResult(scalar_value=expected_node),
             ]
         )
 
-        result = await CatalogDao.get_node_by_slug(session, corpus_id, slug)
+        result = await CatalogDao.get_node_by_slug(session, catalog_id, slug)
 
         assert result is expected_node
-        assert result.corpus_id == corpus_id
-        assert result.slug == slug
+        assert result.catalog_id == catalog_id
+        assert result.slug_override == slug
 
     @pytest.mark.asyncio
     async def test_update_node_only_updates_non_none_fields(self) -> None:
@@ -272,8 +284,8 @@ class TestCatalogNodeCrud:
         original = _make_node(
             id=node_id,
             name="Old Name",
-            slug="old-slug",
-            sort_order=0,
+            slug_override="old-slug",
+            position=0,
             description=None,
         )
         session = FakeAsyncSessionForCatalog(
@@ -297,10 +309,10 @@ class TestCatalogNodeCrud:
 
         assert updated is original
         assert updated.name == "New Name"
-        assert updated.sort_order == 10
+        assert updated.position == 10
         assert updated.description == "Desc"
         # 未传入的字段保持原值
-        assert updated.slug == "old-slug"
+        assert updated.slug_override == "old-slug"
 
     @pytest.mark.asyncio
     async def test_update_node_returns_none_for_missing(self) -> None:
@@ -367,85 +379,89 @@ class TestCatalogMembership:
 
     @pytest.mark.asyncio
     async def test_assign_document_creates_membership(self) -> None:
-        """assign_document 应创建新的 DocCatalogMembership 并 flush"""
-        catalog_node_id = uuid4()
+        """assign_document 应创建新的 DOCUMENT_REF 子条目并 flush"""
+        catalog_entry_id = uuid4()
+        catalog_id = uuid4()
         document_id = uuid4()
+        corpus_id = uuid4()
+        parent_entry = _make_node(id=catalog_entry_id, catalog_id=catalog_id)
+        doc = SimpleNamespace(id=document_id, corpus_id=corpus_id, original_filename="doc.pdf")
         session = FakeAsyncSessionForCatalog(
             execute_responses=[
-                # 查询已存在记录 → 无
+                # 1. 查询已存在 DOCUMENT_REF → 无
                 _FakeResult(scalar_value=None),
+                # 2. get_node(parent) → 父条目
+                _FakeResult(scalar_value=parent_entry),
+                # 3. KnowledgeDocument 查询
+                _FakeResult(scalar_value=doc),
             ]
         )
 
-        membership = await CatalogDao.assign_document(
+        result = await CatalogDao.assign_document(
             session,
-            catalog_node_id=catalog_node_id,
+            catalog_entry_id=catalog_entry_id,
             document_id=document_id,
         )
 
         assert len(session.added) == 1
         assert session.flush_count == 1
         created = session.added[0]
-        assert created.catalog_node_id == catalog_node_id
+        assert created.parent_entry_id == catalog_entry_id
         assert created.document_id == document_id
-        assert membership is created
+        assert created.node_type == "DOCUMENT_REF"
+        assert created.source_corpus_id == corpus_id
+        assert result is created
 
     @pytest.mark.asyncio
     async def test_assign_document_idempotent_returns_existing(self) -> None:
-        """assign_document 幂等性：已存在记录时直接返回，不重复创建"""
-        catalog_node_id = uuid4()
+        """assign_document 幂等性：已存在 DOCUMENT_REF 时直接返回，不重复创建"""
+        catalog_entry_id = uuid4()
         document_id = uuid4()
-        existing = _make_membership(
-            catalog_node_id=catalog_node_id,
-            document_id=document_id,
-        )
+        existing = _make_doc_ref(parent_entry_id=catalog_entry_id, document_id=document_id)
         session = FakeAsyncSessionForCatalog(
             execute_responses=[
-                # 查询已存在记录 → 有
+                # 查询已存在 DOCUMENT_REF → 有
                 _FakeResult(scalar_value=existing),
             ]
         )
 
-        membership = await CatalogDao.assign_document(
+        result = await CatalogDao.assign_document(
             session,
-            catalog_node_id=catalog_node_id,
+            catalog_entry_id=catalog_entry_id,
             document_id=document_id,
         )
 
-        assert membership is existing
+        assert result is existing
         assert len(session.added) == 0  # 不应新增
         assert session.flush_count == 0  # 不应 flush
 
     @pytest.mark.asyncio
     async def test_unassign_document_deletes_membership(self) -> None:
-        """unassign_document 应删除已有 membership 并返回 True"""
-        catalog_node_id = uuid4()
+        """unassign_document 应删除已有 DOCUMENT_REF 子条目并返回 True"""
+        catalog_entry_id = uuid4()
         document_id = uuid4()
-        membership = _make_membership(
-            catalog_node_id=catalog_node_id,
-            document_id=document_id,
-        )
+        doc_ref = _make_doc_ref(parent_entry_id=catalog_entry_id, document_id=document_id)
         session = FakeAsyncSessionForCatalog(
             execute_responses=[
-                _FakeResult(scalar_value=membership),
+                _FakeResult(scalar_value=doc_ref),
             ]
         )
 
         result = await CatalogDao.unassign_document(
             session,
-            catalog_node_id=catalog_node_id,
+            catalog_entry_id=catalog_entry_id,
             document_id=document_id,
         )
 
         assert result is True
         assert len(session.deleted) == 1
-        assert session.deleted[0] is membership
+        assert session.deleted[0] is doc_ref
         assert session.flush_count == 1
 
     @pytest.mark.asyncio
     async def test_unassign_document_returns_false_when_missing(self) -> None:
         """unassign_document 在记录不存在时应返回 False"""
-        catalog_node_id = uuid4()
+        catalog_entry_id = uuid4()
         document_id = uuid4()
         session = FakeAsyncSessionForCatalog(
             execute_responses=[
@@ -455,7 +471,7 @@ class TestCatalogMembership:
 
         result = await CatalogDao.unassign_document(
             session,
-            catalog_node_id=catalog_node_id,
+            catalog_entry_id=catalog_entry_id,
             document_id=document_id,
         )
 
@@ -466,7 +482,7 @@ class TestCatalogMembership:
     @pytest.mark.asyncio
     async def test_get_node_documents_returns_tuple(self) -> None:
         """get_node_documents 应返回 (docs_list, total_count) 元组"""
-        catalog_node_id = uuid4()
+        catalog_entry_id = uuid4()
         doc1 = SimpleNamespace(id=uuid4(), title="Doc A")
         doc2 = SimpleNamespace(id=uuid4(), title="Doc B")
         session = FakeAsyncSessionForCatalog(
@@ -482,7 +498,7 @@ class TestCatalogMembership:
 
         documents, total = await CatalogDao.get_node_documents(
             session,
-            catalog_node_id=catalog_node_id,
+            catalog_entry_id=catalog_entry_id,
         )
 
         assert isinstance(documents, list)

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -84,7 +84,7 @@ class TestWikiCreatePublicationValidation:
         with pytest.raises(ValueError, match="Invalid theme"):
             await service.create_publication(
                 _FakeAsyncSession(),
-                corpus_id=uuid4(),
+                catalog_id=uuid4(),
                 name="Test",
                 theme="invalid-theme",
             )
@@ -95,7 +95,7 @@ class TestWikiCreatePublicationValidation:
         with pytest.raises(ValueError, match="Invalid slug format"):
             await service.create_publication(
                 _FakeAsyncSession(),
-                corpus_id=uuid4(),
+                catalog_id=uuid4(),
                 name="Test",
                 slug="Invalid Slug!",
             )
@@ -108,7 +108,7 @@ class TestWikiCreatePublicationValidation:
         # 不抛异常即视为成功（内部会调用 WikiDao.create_publication）
         await service.create_publication(
             session,
-            corpus_id=uuid4(),
+            catalog_id=uuid4(),
             name="My Wiki Publication",
         )
         assert session.flush_count >= 1
@@ -128,7 +128,7 @@ class TestWikiCreatePublicationValidation:
 
         await service.create_publication(
             session,
-            corpus_id=uuid4(),
+            catalog_id=uuid4(),
             name="Architecture Wiki",
         )
 

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -165,6 +165,34 @@
   3. stdlib logging 的 `extra` 业务键继续禁止使用 `name`，与 ISSUE-009 的防线保持一致。
 - **同类问题影响**：
   1. Catalog / Wiki 之外，任何直接读取 `KnowledgeDocument` 属性的 provenance、export、render、sync 路径都需优先检查是否误用了 `filename`；
-  2. 这类问题具有“写路径正常、读路径崩溃”的二阶特征，UI 上常表现为操作成功后刷新列表/详情时才报错，排查时应优先检查响应序列化逻辑而非数据库写入。
+  2. 这类问题具有”写路径正常、读路径崩溃”的二阶特征，UI 上常表现为操作成功后刷新列表/详情时才报错，排查时应优先检查响应序列化逻辑而非数据库写入。
+
+---
+
+## ISSUE-011 Catalog 全局化三阶段重构（corpus_id → catalog_id 解耦）
+
+- **表因**：用户无法将来自不同 Corpus 的文档聚合到同一个 Catalog 目录；Wiki Publication 的可见范围被迫限制在单 Corpus 内，无法发布跨 Corpus 内容。
+- **根因**：`doc_catalog_nodes.corpus_id NOT NULL` 将 **Catalog（人类可读组织视图）** 与 **Corpus（存储/检索单元）** 强绑定，违反 Orthogonal Decomposition（正交分解）原则：
+  - Corpus 的职责是 embedding / 检索 / 存储隔离；
+  - Catalog 的职责是文档的人工组织（类 MediaWiki Category N:M）；
+  - Publication 的职责是将目录发布为面向用户的站点（类 GitBook Site）。
+  三层被压缩到一根外键，导致 Catalog 无法跨 Corpus 聚合文档，所有下游（Wiki sync、前端 tree、BFF 路由）也随之错位。
+- **处理方式**（三阶段原子化迁移，commits `ebe5a91`–`59be678`）：
+  1. **Phase 1 / Revision 0003**：新建 `doc_catalogs`（全局顶层实体）、`doc_catalog_entries`（N:M 关联 + 树结构）、`wiki_publication_snapshots` 骨架，纯加法无锁；
+  2. **Phase 2 / Revision 0004**：Chunked backfill（500 行/批）将 `doc_catalog_nodes` 平移到 `doc_catalog_entries`；回填 `wiki_publications.catalog_id` 与 `app_name`；
+  3. **Phase 3 / Revision 0005**：施加 `NOT NULL` 约束、`UNIQUE(catalog_id, slug)`；DROP `doc_catalog_nodes` / `doc_catalog_memberships` / `wiki_publications.corpus_id`；含 downgrade 守卫（跨 corpus catalog 存在时拒绝降级）；
+  4. **ORM / DAO / Service / API**：`WikiPublication.corpus_id` → `catalog_id`；`CatalogDao.create_node/get_tree` 改用 `catalog_id`；`catalog_service.assign_document` 强制断言 `document.corpus.app_name == catalog.app_name`（违反抛 `PermissionError(“cross-app assignment forbidden”)`）；
+  5. **前端 / BFF / Wiki SSG**：`corpusId` → `catalogId` 全链路替换；BFF 13 条代理路由更新；`WikiPublication.catalog_id` 对齐；
+  6. **测试**：新增 `test_catalog_cross_corpus.py`（跨 app 权限）、`test_wiki_publish_modes.py`（发布生命周期）、`test_catalog_tree_perf.py`（P99 基线）。
+- **后续防范**：
+  1. `DocCatalog.app_name` 字段通过数据库约束 + Service 层双重防护确保创建后不可变；不可通过普通 API 修改，需走专用 migration 端点并触发级联校验；
+  2. `assign_document` 入口的跨 app 拦截是三级权限取交集的第一道闸；任何绕过此入口的直接 DAO 写入都属于权限放大，严禁；
+  3. Migration downgrade 守卫应对所有”新旧语义不可对称映射”的 Revision 标准化——检测到不可逆状态时 `raise RuntimeError`，而非静默回滚；
+  4. Phase 2 chunked backfill 的 `sleep(100ms)` 节奏需在高负载窗口前确认，避免长事务与 autovacuum 竞争；
+  5. 前端所有「以 `corpusId` 作为前置条件」的 Hook/Selector 替换应配套 BFF 路由同步更新，参考 ISSUE-007 13 条路由的教训，改动后必须跑 `pnpm build` 验证。
+- **同类问题影响**：
+  1. 任何 `X_id NOT NULL` 强绑定导致多个关注点（concern）共享同一外键的模式，都是 Orthogonal Decomposition 的破坏信号；排查时看「能否在不修改 A 的情况下独立演进 B」，不能则解耦；
+  2. `wiki_dao.py` 中仍有若干基于 `corpus_id` 的遗留查询路径（如 `get_publication_by_slug` 的兜底逻辑），需在后续 corpus 完全退出 Wiki 链路后一并清理；
+  3. RAG 检索侧 `retrieval.search(catalog_ids=...)` 增量参数已在架构规划中定义，但未在本次 commits 中完整落地，后续补齐时参考 `catalog_dao.get_document_nodes` 的 backlink 查询路径。
 
 ---

--- a/docs/knowledges.md
+++ b/docs/knowledges.md
@@ -543,9 +543,127 @@ Memory 运行时能力分为两层：
 > [!NOTE]
 > 管理员 (`admin` 角色) 可访问 Memory Dashboard 与 Memory Automation 控制面；调度能力是否可写取决于 `pg_cron` 是否可安装且可访问，详见 [memory.md](./memory.md)。
 
-## 13. 测试覆盖
+## 13. Catalog / Wiki Publication 三层正交架构
 
-### 13.1 单元测试
+> 本节记录 Phase 3 Catalog 全局化重构（commits `ebe5a91`–`59be678`）落地后的架构状态。
+
+### 13.1 设计背景与动机
+
+原始设计中，`doc_catalog_nodes.corpus_id NOT NULL` 将 **Catalog（目录组织视图）** 强绑定到 **Corpus（存储/检索单元）**，违反 **Orthogonal Decomposition（正交分解）** 原则：
+
+- Corpus 本应是「存储 / 检索 / embedding」单元；
+- Catalog 本应是「人类可读的组织视图」（N:M，可跨 Corpus 聚合文档）；
+- Publication 本应是「发布 / 展示」单元（软链接订阅 Catalog）。
+
+三层被压缩到一根 `corpus_id` 外键，导致用户无法跨 Corpus 聚合文档，Wiki 发布也被迫 corpus-scoped。
+
+**业界范式参照**（IEEE）：
+
+- **MediaWiki Category N:M**<sup>[[6]](#ref6-catalog)</sup>：Catalog 与 Corpus 完全正交，Page 可属多 Category；
+- **GitBook Site→Space 订阅**<sup>[[7]](#ref7-catalog)</sup>：Publication 以软链接订阅内容源，支持 live / snapshot 两种模式；
+- **Confluence Include Page 权限规则**<sup>[[8]](#ref8-catalog)</sup>：权限以源为准，聚合侧只能做交集，不能放大访问域。
+
+### 13.2 数据模型（三层正交 ER）
+
+```mermaid
+%%{init: {"themeVariables": {"primaryColor": "#0b3d91", "primaryTextColor": "#ffffff"}}}%%
+erDiagram
+    Corpus {
+        uuid id PK
+        string app_name
+        string name
+    }
+    KnowledgeDocument {
+        uuid id PK
+        uuid corpus_id FK
+        string app_name
+        string original_filename
+    }
+    DocCatalog {
+        uuid id PK
+        string app_name
+        string name
+        string slug
+        string visibility
+        bool is_archived
+    }
+    DocCatalogEntry {
+        uuid id PK
+        uuid catalog_id FK
+        uuid parent_entry_id FK
+        uuid document_id FK
+        uuid source_corpus_id
+        string node_type
+        string name
+        string slug_override
+        int position
+        string status
+    }
+    WikiPublication {
+        uuid id PK
+        uuid catalog_id FK
+        string app_name
+        string name
+        string slug
+        string status
+        string publish_mode
+        int version
+    }
+
+    Corpus ||--o{ KnowledgeDocument : "owns"
+    DocCatalog ||--o{ DocCatalogEntry : "contains"
+    DocCatalogEntry }o--o{ KnowledgeDocument : "references (N:M)"
+    DocCatalogEntry ||--o{ DocCatalogEntry : "parent_entry_id (tree)"
+    WikiPublication }o--|| DocCatalog : "subscribes"
+```
+
+**核心不变量**：
+
+| 层次 | 实体 | 职责 | 关键约束 |
+|------|------|------|---------|
+| 存储层 | `Corpus` + `KnowledgeDocument` | 物理存储、embedding、检索 | `app_name` 租户隔离，SSOT |
+| 组织层 | `DocCatalog` + `DocCatalogEntry` | 人类可读目录树，N:M 软引用 | `catalog.app_name` 创建后不可变 |
+| 发布层 | `WikiPublication` | 订阅 Catalog，生成公开站点 | `publication.app_name == catalog.app_name` |
+
+### 13.3 权限模型（三级取交集）
+
+```
+viewer 读取 Publication Entry 的权限 =
+    viewer 对 document.corpus 有读权限
+    ∩ catalog 可见性 allow
+    ∩ publication 可见性 allow
+```
+
+**关键拦截点**（`catalog_service.py:315-319`）：向 Catalog 添加文档时，强制断言 `document.corpus.app_name == catalog.app_name`，违反则抛 `PermissionError("cross-app assignment forbidden")`。
+
+### 13.4 失效语义（Orphaned Entry）
+
+| 触发源 | 响应 | 用户可见行为 |
+|--------|------|------------|
+| Document 物理删除 | `catalog_entries.document_id` SET NULL, `status = orphaned` | Wiki 渲染为占位「该文档已失效」 |
+| Corpus 被删除 | 级联所有 entries `status = orphaned` | 同上 |
+| Catalog 归档 | `is_archived = true`，新增 entry 被拒绝 | 标记「归档」 |
+
+### 13.5 Wiki 发布模式
+
+| 模式 | 行为 | 适用场景 |
+|------|------|---------|
+| `live`（默认） | 实时跟随 Catalog/Document 变更；SSG ISR 事件驱动增量刷新 | 日常在线文档 |
+| `snapshot` | 发布时冻结 `(catalog_entries, document_versions)` 到 `wiki_publication_snapshots`；后续变更不影响 | 合规留档、版本里程碑 |
+
+**版本语义**：每次 `publish()` 递增 `version`；`unpublish()` → `draft`；`archive()` → `archived`（不可逆）。
+
+### 13.6 数据库迁移（三阶段）
+
+| Revision | 内容 | 策略 |
+|---------|------|------|
+| `0003` | 新建 `doc_catalogs` / `doc_catalog_entries` / `wiki_publication_snapshots` 骨架 | 纯加法，无锁 |
+| `0004` | Backfill：从 `doc_catalog_nodes` 平移到 `doc_catalog_entries`；回填 `wiki_publications.catalog_id` | chunked batch，500 行/批 |
+| `0005` | Enforce：施加 NOT NULL 约束、UNIQUE(catalog_id, slug)；DROP `doc_catalog_nodes` / `doc_catalog_memberships` / `corpus_id` | 含 downgrade 守卫（跨 corpus catalog 拒绝降级） |
+
+## 14. 测试覆盖
+
+### 14.1 单元测试
 
 ```bash
 cd apps/negentropy
@@ -556,9 +674,40 @@ uv run pytest tests/unit_tests/engine/ -v            # Memory 治理
 - **Knowledge**: chunking / types / reranking 测试
 - **Memory Governance**: 遗忘曲线（新鲜记忆/高频访问/长期未访问/指数衰减公式/边界值/自定义 λ）
 
-### 13.2 集成测试（需要 PostgreSQL）
+### 14.2 集成测试（需要 PostgreSQL）
 
 ```bash
 uv run pytest tests/integration_tests/knowledge/ -v
 uv run pytest tests/integration_tests/engine/adapters/postgres/ -v
 ```
+
+**Catalog 专项集成测试**（Phase 3 新增）：
+
+| 文件 | 覆盖范围 |
+|------|---------|
+| [`test_catalog_dao_integration.py`](../apps/negentropy/tests/integration_tests/knowledge/test_catalog_dao_integration.py) | `CatalogDao` CRUD、树遍历、文档归入/移除 |
+| [`test_catalog_cross_corpus.py`](../apps/negentropy/tests/integration_tests/knowledge/test_catalog_cross_corpus.py) | 跨 app_name 权限拒绝、catalog 隔离、orphaned entry |
+| [`test_wiki_publish_modes.py`](../apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py) | WikiPublishingService 完整生命周期、版本递增、slug/theme 校验 |
+
+### 14.3 性能基准（`tests/performance_tests/knowledge/`）
+
+```bash
+uv run pytest tests/performance_tests/knowledge/test_catalog_tree_perf.py -v
+```
+
+| 指标 | 阈值 | 备注 |
+|------|------|------|
+| `get_tree()` 平均（84 节点） | < 50ms | 含 warmup，5 次平均 |
+| `get_tree()` P99 | < 100ms | |
+| `get_subtree()` 平均 | < 20ms | |
+| `list_catalogs()` 平均 | < 10ms | |
+
+---
+
+## 参考文献（Catalog 架构）
+
+<a id="ref6-catalog"></a>[6] Wikimedia Foundation, "Help:Category," *Wikipedia*, 2025. [Online]. Available: https://en.wikipedia.org/wiki/Help:Category
+
+<a id="ref7-catalog"></a>[7] GitBook, "Collections," *GitBook Documentation*, 2025. [Online]. Available: https://docs.gitbook.com/creating-content/content-structure/collection
+
+<a id="ref8-catalog"></a>[8] Atlassian, "Include Page Macro," *Confluence Data Center Documentation*, 2024. [Online]. Available: https://confluence.atlassian.com/doc/include-page-macro-139514.html


### PR DESCRIPTION
## 背景

原 `doc_catalog_nodes.corpus_id NOT NULL` 将 **Catalog（目录组织视图）** 强绑定到 **Corpus（存储/检索单元）**，导致用户无法跨 Corpus 聚合文档，Wiki Publication 可见范围被迫限定在单 Corpus。违反 Orthogonal Decomposition（正交分解）原则。

**业界参照**：MediaWiki Category N:M 解耦哲学 + GitBook Site→Space 订阅式发布。

## 核心变更

### 破坏性变更（BREAKING CHANGE）

- `wiki_publications.corpus_id` 已移除 → 替换为 `catalog_id` + `publish_mode`（`live` | `snapshot`）
- `doc_catalog_nodes` / `doc_catalog_memberships` 已 DROP → 替换为 `doc_catalog_entries`（N:M 全局关联）
- API：`GET /catalog/tree/{corpus_id}` 已返回 `410 Gone`；改用 `GET /catalogs/{catalog_id}/tree`
- 前端：所有 `corpusId` props/state 已替换为 `catalogId`

### 数据库迁移（三阶段原子化）

| Revision | 内容 | 策略 |
|---------|------|------|
| `0003` | 新建 `doc_catalogs` / `doc_catalog_entries` / `wiki_publication_snapshots` 骨架 | 纯加法无锁 |
| `0004` | Backfill：`doc_catalog_nodes` → `doc_catalog_entries`（500 行/批）；回填 `wiki_publications.catalog_id` | Chunked batch |
| `0005` | Enforce：NOT NULL、UNIQUE(catalog_id,slug)；DROP legacy 表与列 | 含 downgrade 守卫 |

### 后端（apps/negentropy）

- **ORM**：新增 `DocCatalog`、`DocCatalogEntry`、`WikiPublicationSnapshot`；`WikiPublication` 移除 `corpus_id`，绑定 `catalog_id`
- **DAO**：`CatalogDao` 全面重写，`create_node`/`get_tree`/`assign_document` 均以 `catalog_id` 为作用域
- **Service**：`catalog_service.assign_document` 强制断言跨 app_name 权限（违反抛 `PermissionError`）；`WikiPublishingService` 支持 live/snapshot 发布模式
- **API**：新增 `/catalogs` CRUD；旧 `/catalog/tree/{corpus_id}` 返回 410

### 前端（apps/negentropy-ui）

- `corpusId` → `catalogId` 全链路替换（hooks / components / knowledge-api.ts）
- BFF 13 条代理路由对齐新 `/catalogs/` 前缀
- `AddDocumentsDialog` 支持跨 Corpus 文档搜索

### Wiki SSG（apps/negentropy-wiki）

- `WikiPublication.corpus_id` → `catalog_id`；新增 `publish_mode` 字段
- Orphaned entry 渲染占位而非 404

### 测试

- 重写 `test_catalog_dao_integration.py`（catalog_id fixture 适配）
- 新增 `test_catalog_cross_corpus.py`（跨 app 权限拒绝、catalog 隔离）
- 新增 `test_wiki_publish_modes.py`（Publication 完整生命周期、版本递增）
- 新增 `test_catalog_tree_perf.py`（P99 基线：get_tree < 50ms、get_subtree < 20ms）

## 迁移指南

```bash
# 1. 数据库迁移
cd apps/negentropy && uv run alembic upgrade head

# 2. 验证 roundtrip
uv run alembic downgrade 0002 && uv run alembic upgrade head

# 3. 验证测试
uv run pytest tests/ -v --tb=short

# 4. 前端构建
cd apps/negentropy-ui && pnpm build
cd apps/negentropy-wiki && pnpm build
```

## 风险矩阵

| 风险 | 缓解 |
|------|------|
| 权限放大 | 三级取交集 + `app_name` 不可变 + PermissionError |
| 旧 URL 破裂 | `/catalog/tree/{corpusId}` → 410 Gone + X-Deprecation-Notice |
| Downgrade 丢数据 | Revision 0005 downgrade 守卫检测跨 corpus entries |
| 孤儿 entry | `status=orphaned` + Wiki 占位渲染 |
| 大表迁移锁 | chunked backfill 500 行/批 + 分 revision |

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)