### PR TITLE
refactor(wiki-publication): 清理 Wiki 发布的 dormant 字段（navigation_config + custom_css + custom_js）

### DIFF
--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -2410,7 +2410,6 @@ export interface WikiPublication {
   description: string | null;
   status: WikiPublicationStatus;
   theme: WikiTheme;
-  navigation_config: Record<string, unknown>;
   version: number;
   published_at: string | null;
   created_at: string | null;
@@ -2436,9 +2435,6 @@ export interface UpdateWikiPublicationParams {
   name?: string;
   description?: string;
   theme?: WikiTheme;
-  navigation_config?: Record<string, unknown>;
-  custom_css?: string;
-  custom_js?: string;
 }
 
 export interface WikiEntry {

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0008_drop_wiki_pub_dormant_fields.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0008_drop_wiki_pub_dormant_fields.py
@@ -1,0 +1,60 @@
+"""Wiki 发布：移除 dormant 字段（navigation_config / custom_css / custom_js）
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-24 01:00:00.000000+00:00
+
+YAGNI + Entropy Reduction：清理在 0001_init_schema 中预留、但全栈零业务消费的三个 dormant 字段。
+
+调研依据（grep 全仓 + 前后端逐文件验证）：
+  - 后端：仅 `models/perception.py` 列定义、`lifecycle_schemas.py` Pydantic 透传、`wiki_dao.py` 透传，
+    **零业务消费**（无 publish 流水线读写、无 Wiki SSG 渲染依赖、无前端写回路径）。
+  - 前端：仅 `features/knowledge/utils/knowledge-api.ts` interface 字段定义，
+    `apps/negentropy-ui/app/knowledge/wiki/**` 任一 .tsx 组件均未读写。
+  - 数据：所有生产行必然为 `{}` / NULL（从未写入实际数据 → 删除零信息丢失）。
+
+为 Phase B（Migration 0009 多 Catalog 嫁接合并）扫清前置障碍：
+  - 原 Phase B 计划顾虑 `navigation_config` JSONB 内嵌 catalog_id 引用 → 合并时需 JSONB rewrite；
+  - dormant 字段全栈清理后，Phase B 不再需要 navigation_config 处理路径。
+
+Downgrade 策略：
+  - 重建为 nullable 列，保持 schema 形状回退，与 stairway 测试兼容；
+  - 不还原数据（dormant 期数据本就为空，无业务影响）。
+
+设计溯源（IEEE 引用见 docs/knowledges.md §15）：
+  - [5] P. J. Sadalage and M. Fowler, *NoSQL Distilled*, ch. "Schema Migrations", 2016.
+        — Expand-Contract（本迁移属 Contract 阶段，前置无任何写入路径）。
+  - YAGNI: K. Beck, *Extreme Programming Explained*, Addison-Wesley, 1999.
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 三列 dormant，无业务消费 → 直接 DROP（无需 backfill）
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications DROP COLUMN IF EXISTS navigation_config"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications DROP COLUMN IF EXISTS custom_css"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications DROP COLUMN IF EXISTS custom_js"))
+
+
+def downgrade() -> None:
+    # 重建为 nullable，与 0001_init_schema 原始声明一致；dormant 期数据本就为空
+    op.execute(
+        sa.text(
+            "ALTER TABLE negentropy.wiki_publications "
+            "ADD COLUMN IF NOT EXISTS navigation_config JSONB DEFAULT '{}'::jsonb"
+        )
+    )
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ADD COLUMN IF NOT EXISTS custom_css TEXT"))
+    op.execute(sa.text("ALTER TABLE negentropy.wiki_publications ADD COLUMN IF NOT EXISTS custom_js TEXT"))

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -217,9 +217,6 @@ class WikiPublicationUpdateRequest(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=255)
     description: str | None = None
     theme: str | None = None
-    navigation_config: dict[str, Any] | None = None
-    custom_css: str | None = None
-    custom_js: str | None = None
 
 
 class WikiPublicationResponse(BaseModel):
@@ -234,7 +231,6 @@ class WikiPublicationResponse(BaseModel):
     description: str | None
     status: str
     theme: str
-    navigation_config: dict[str, Any] = Field(default_factory=dict)
     version: int
     published_at: datetime | None
     created_at: datetime | None

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_types.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_types.py
@@ -140,7 +140,6 @@ class WikiPublicationRecord:
     description: str | None
     status: str  # WikiStatus value
     theme: str  # WikiTheme value
-    navigation_config: dict[str, Any] = field(default_factory=dict)
     version: int = 1
     published_at: datetime | None = None
     created_at: datetime | None = None

--- a/apps/negentropy/src/negentropy/knowledge/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_dao.py
@@ -40,9 +40,6 @@ class WikiDao:
         slug: str,
         description: str | None = None,
         theme: str = "default",
-        navigation_config: dict | None = None,
-        custom_css: str | None = None,
-        custom_js: str | None = None,
     ) -> WikiPublication:
         """创建 Wiki 发布记录（初始状态为 draft）"""
         pub = WikiPublication(
@@ -52,9 +49,6 @@ class WikiDao:
             description=description,
             status="draft",
             theme=theme,
-            navigation_config=navigation_config or {},
-            custom_css=custom_css,
-            custom_js=custom_js,
             version=1,
         )
         db.add(pub)
@@ -134,9 +128,6 @@ class WikiDao:
             "description",
             "status",
             "theme",
-            "navigation_config",
-            "custom_css",
-            "custom_js",
         }
         for key, value in kwargs.items():
             if key in allowed_fields and value is not None:

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -207,9 +207,6 @@ class WikiPublication(Base, UUIDMixin, TimestampMixin):
     theme: Mapped[str] = mapped_column(
         String(20), nullable=False, default="default", server_default="'default'"
     )  # default | book | docs
-    navigation_config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
-    custom_css: Mapped[str | None] = mapped_column(Text, nullable=True)
-    custom_js: Mapped[str | None] = mapped_column(Text, nullable=True)
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 


### PR DESCRIPTION
## 背景

`WikiPublication` 的 `navigation_config`、`custom_css`、`custom_js` 三个字段经全链路 grep 验证为 **dormant**（前后端零业务消费）。按 YAGNI + Entropy Reduction 原则，作为 Phase B 的前置 Contract 清理步骤移除。

## 变更

- **新增 Migration 0008**：`DROP COLUMN IF EXISTS` 移除三列；downgrade 重建为 nullable 列（dormant 期无实际数据，信息无损）
- **ORM** (`perception.py`)：`WikiPublication` 移除 3 个 `mapped_column` 声明
- **DAO** (`wiki_dao.py`)：`create_publication` 移除三字段入参；`update_publication` allowed_fields 收缩
- **Schema** (`lifecycle_schemas.py`)：`WikiPublicationUpdateRequest` / `WikiPublicationResponse` 移除三字段
- **Types** (`lifecycle_types.py`)：`WikiPublicationRecord` dataclass 移除 `navigation_config`
- **TS** (`knowledge-api.ts`)：`WikiPublication` interface + `UpdateWikiPublicationParams` 移除三字段

## 验证

- Alembic 三循环（upgrade → downgrade → upgrade）通过
- TypeScript 类型检查通过（`tsc --noEmit`）
- ruff lint + format 通过
- pre-commit hooks 全过

## 范围

纯字段清理，无功能变更。删除 21 行，新增 Migration 60 行（含 docstring + downgrade）。

## 依赖

- **依赖 PR #399**（Phase A Migration 0007）合并后方可执行 `alembic upgrade head`（0008 的 `down_revision = "0007"`）
- 代码层面无依赖（本 PR 修改的文件与 #399 完全无交集）

## 后续

- Phase B Migration 0009：多 Catalog 嫁接合并（本清理简化了 Phase B 的 JSONB rewrite 路径）