### PR TITLE
feat(catalog-ui): 移除 CatalogSelector，自动绑定单实例目录（useSingletonCatalog + createCatalog API + 直接渲染工具栏/树）

### DIFF
--- a/apps/negentropy-ui/app/knowledge/catalog/hooks/useSingletonCatalog.ts
+++ b/apps/negentropy-ui/app/knowledge/catalog/hooks/useSingletonCatalog.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { fetchCatalogs, createCatalog } from "@/features/knowledge";
+
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+
+export function useSingletonCatalog() {
+  const [catalogId, setCatalogId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetchCatalogs({ appName: APP_NAME });
+        if (cancelled) return;
+
+        if (res.items.length > 0) {
+          setCatalogId(res.items[0].id);
+          return;
+        }
+
+        const catalog = await createCatalog({
+          app_name: APP_NAME,
+          name: "默认目录",
+          slug: "default",
+          visibility: "INTERNAL",
+        });
+        if (!cancelled) setCatalogId(catalog.id);
+      } catch (err) {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : "加载目录失败");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { catalogId, loading, error };
+}

--- a/apps/negentropy-ui/app/knowledge/catalog/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/page.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useCallback } from "react";
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
-import { CatalogSelector } from "./_components/CatalogSelector";
 import { CatalogTree } from "./_components/CatalogTree";
 import { CatalogTreeToolbar } from "./_components/CatalogTreeToolbar";
 import { CatalogContextMenu } from "./_components/CatalogContextMenu";
 import { NodeDetailPanel } from "./_components/NodeDetailPanel";
 import { CreateNodeDialog } from "./_components/CreateNodeDialog";
 import { useCatalogTree } from "./hooks/useCatalogTree";
+import { useSingletonCatalog } from "./hooks/useSingletonCatalog";
 import { CatalogNode, deleteCatalogNode } from "@/features/knowledge";
 import { toast } from "@/lib/activity-toast";
 
@@ -25,7 +25,7 @@ interface DragState {
 }
 
 export default function CatalogPage() {
-  const [catalogId, setCatalogId] = useState<string | null>(null);
+  const { catalogId, loading: catalogLoading, error: catalogError } = useSingletonCatalog();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [addParentId, setAddParentId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -42,7 +42,7 @@ export default function CatalogPage() {
     selectedNode,
     selectedNodeId,
     expandedIds,
-    loading,
+    loading: treeLoading,
     refresh,
     toggleExpand,
     selectNode,
@@ -66,7 +66,6 @@ export default function CatalogPage() {
     refresh();
   }, [selectNode, refresh]);
 
-  // Context menu handlers
   const handleContextMenu = useCallback(
     (_node: CatalogNode | null, e: React.MouseEvent) => {
       e.preventDefault();
@@ -122,7 +121,6 @@ export default function CatalogPage() {
     setEditingNodeId(null);
   }, []);
 
-  // Drag handlers
   const handleDragStart = useCallback((nodeId: string) => {
     setDragState({ draggedId: nodeId, targetId: null, position: null });
   }, []);
@@ -130,15 +128,11 @@ export default function CatalogPage() {
   const handleDragOver = useCallback(
     (targetId: string, e: React.DragEvent) => {
       if (!dragState.draggedId) return;
-
-      // Prevent dropping on self
       if (dragState.draggedId === targetId) return;
 
-      // Prevent dropping on descendant (cycle detection)
       const draggedNode = nodes.find((n) => n.id === dragState.draggedId);
       if (draggedNode?.path?.includes(targetId)) return;
 
-      // Calculate drop zone based on mouse position
       const rect = (e.target as HTMLElement).closest("[draggable]")?.getBoundingClientRect();
       if (!rect) return;
 
@@ -153,11 +147,7 @@ export default function CatalogPage() {
         position = "inside";
       }
 
-      setDragState((prev) => ({
-        ...prev,
-        targetId,
-        position,
-      }));
+      setDragState((prev) => ({ ...prev, targetId, position }));
     },
     [dragState.draggedId, nodes],
   );
@@ -180,7 +170,6 @@ export default function CatalogPage() {
       let newSortOrder: number;
 
       if (dragState.position === "inside") {
-        // Nest inside target
         newParentId = targetId;
         const targetChildren = nodes.filter((n) => n.parent_id === targetId);
         const maxSort = targetChildren.length
@@ -188,7 +177,6 @@ export default function CatalogPage() {
           : 0;
         newSortOrder = maxSort + 1000;
       } else {
-        // Insert before/after target (sibling)
         newParentId = targetNode.parent_id;
         const siblings = nodes
           .filter((n) => n.parent_id === targetNode.parent_id)
@@ -224,16 +212,15 @@ export default function CatalogPage() {
       <div className="flex min-h-0 flex-1 px-6 py-4 gap-4">
         {/* Sidebar: Tree */}
         <aside className="w-[300px] shrink-0 flex flex-col gap-2 overflow-hidden">
-          <CatalogSelector value={catalogId} onChange={setCatalogId} />
-
-          {!catalogId ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center rounded-lg border border-dashed border-border">
-              <p className="text-sm text-muted">请先选择目录</p>
-              <p className="text-xs text-muted/60 mt-1">
-                从上方下拉选择一个目录以管理节点
-              </p>
+          {catalogLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <p className="text-sm text-muted">加载目录...</p>
             </div>
-          ) : loading ? (
+          ) : catalogError ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center rounded-lg border border-dashed border-destructive/50">
+              <p className="text-sm text-destructive">{catalogError}</p>
+            </div>
+          ) : treeLoading ? (
             <div className="flex items-center justify-center py-12">
               <p className="text-sm text-muted">加载中...</p>
             </div>

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -84,6 +84,7 @@ export {
   fetchGraphBuildHistory,
   // Catalog Management
   fetchCatalogs,
+  createCatalog,
   fetchCatalogDocuments,
   fetchCatalogTree,
   fetchCatalogNodes,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -2374,6 +2374,22 @@ export async function fetchCatalogs(params?: {
   return res.json();
 }
 
+/** 创建全局 Catalog */
+export async function createCatalog(params: {
+  app_name: string;
+  name: string;
+  slug: string;
+  visibility?: string;
+}): Promise<DocCatalog> {
+  const res = await fetch("/api/knowledge/catalogs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) throw new Error(`Failed to create catalog: ${res.statusText}`);
+  return res.json();
+}
+
 /** 获取 Catalog 下可用文档（跨 corpus，用于 AddDocumentsDialog） */
 export async function fetchCatalogDocuments(
   catalogId: string,


### PR DESCRIPTION
## Summary

- 移除 Catalog 页面的 `CatalogSelector` 下拉选择组件，改用 `useSingletonCatalog` Hook 自动获取/创建当前 app 的唯一 Catalog
- 新增 `createCatalog` API 函数（复用已有 `POST /api/knowledge/catalogs` BFF 路由），后端无 Catalog 时自动初始化默认目录
- 工具栏（搜索、折叠全部、添加根节点）、目录树、右键上下文菜单、内联重命名、拖拽排序等维护组件**直接可见**，无需手动选择目录

## Motivation

后端已实现 Catalog 单实例约束（`uq_doc_catalogs_app_singleton`），每个 `app_name` 仅允许一个活跃 Catalog。此前前端保留了冗余的 `CatalogSelector`，用户必须先手动选择目录才能看到任何维护组件，导致所有新增的树管理功能被 `!catalogId` 条件分支隐藏。

## Implementation Details

- **`useSingletonCatalog` Hook**：页面加载时自动 `fetchCatalogs({ appName })`，若无结果则调用 `createCatalog` 自动创建默认目录，返回 `{ catalogId, loading, error }`
- **`createCatalog` API**：`POST /api/knowledge/catalogs`，BFF 路由已存在无需修改
- **`page.tsx` 渲染逻辑**：移除 `CatalogSelector` 和 `!catalogId` 占位分支，仅保留 `catalogLoading` / `catalogError` / `treeLoading` 三态处理
- **`CatalogSelector.tsx` 保留**：Wiki 页面（`/knowledge/wiki`）仍引用该组件

## Test Plan

- [ ] 打开 `/knowledge/catalog`，确认工具栏和目录树直接可见（无"请先选择目录"占位）
- [ ] 后端无 Catalog 时，确认自动创建默认目录后正确加载
- [ ] 工具栏搜索、折叠全部、添加根节点功能正常
- [ ] 右键上下文菜单操作正常（添加子节点、重命名、复制 ID、删除）
- [ ] 内联编辑（双击/F2）功能正常
- [ ] 拖拽排序视觉反馈和移动逻辑正常
- [ ] Wiki 页面（`/knowledge/wiki`）的 CatalogSelector 不受影响
- [ ] `next build` 通过

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>