### PR TITLE
feat(wiki-pipeline): 发布 Pipeline 可视化 + ISR revalidation 状态透传 + SSG 内容新鲜度轮询验证

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublicationDetail.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublicationDetail.tsx
@@ -9,11 +9,13 @@ import {
   unpublishWiki,
   WikiNavTreeItem,
   WikiPublication,
+  WikiRevalidationStatus,
 } from "@/features/knowledge";
 import { toast } from "@/lib/activity-toast";
 import { WikiStatusBadge } from "./WikiStatusBadge";
 import { WikiEntriesList } from "./WikiEntriesList";
 import { CatalogNodeSelectorDialog } from "./CatalogNodeSelectorDialog";
+import { WikiPublishPipeline } from "./WikiPublishPipeline";
 
 interface WikiPublicationDetailProps {
   publication: WikiPublication | null;
@@ -33,8 +35,17 @@ export function WikiPublicationDetail({
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [selectorMode, setSelectorMode] = useState<SyncMode>("sync-only");
   const [submitting, setSubmitting] = useState(false);
+  const [pipelineRevalidation, setPipelineRevalidation] = useState<WikiRevalidationStatus | null>(null);
+  const [pipelineActive, setPipelineActive] = useState(false);
+  const [pipelineTargetVersion, setPipelineTargetVersion] = useState<number | null>(null);
 
   const pubId = publication?.id;
+
+  useEffect(() => {
+    setPipelineActive(false);
+    setPipelineRevalidation(null);
+    setPipelineTargetVersion(null);
+  }, [pubId]);
 
   const loadNavTree = useCallback(async () => {
     if (!pubId) return;
@@ -60,11 +71,15 @@ export function WikiPublicationDetail({
   const handlePublish = useCallback(async () => {
     if (!pubId) return;
     setSubmitting(true);
+    setPipelineActive(true);
     try {
       const resp = await publishWiki(pubId);
+      setPipelineRevalidation(resp.revalidation ?? null);
+      setPipelineTargetVersion(resp.version);
       toast.success(`发布成功：v${resp.version}，${resp.entries_count} 个条目`);
       onChanged();
     } catch (err) {
+      setPipelineActive(false);
       toast.error(err instanceof Error ? err.message : "发布失败");
     } finally {
       setSubmitting(false);
@@ -75,11 +90,15 @@ export function WikiPublicationDetail({
     if (!pubId) return;
     if (!confirm("确定取消发布吗？站点将回退为草稿状态。")) return;
     setSubmitting(true);
+    setPipelineActive(true);
     try {
-      await unpublishWiki(pubId);
+      const resp = await unpublishWiki(pubId);
+      setPipelineRevalidation(resp.revalidation ?? null);
+      setPipelineTargetVersion(resp.version);
       toast.success("已取消发布");
       onChanged();
     } catch (err) {
+      setPipelineActive(false);
       toast.error(err instanceof Error ? err.message : "取消发布失败");
     } finally {
       setSubmitting(false);
@@ -111,6 +130,7 @@ export function WikiPublicationDetail({
     async (catalogNodeIds: string[]) => {
       if (!pubId) return;
       setSubmitting(true);
+      setPipelineActive(false);
       try {
         const resp = await syncWikiEntriesFromCatalog(pubId, {
           catalog_node_ids: catalogNodeIds,
@@ -127,12 +147,17 @@ export function WikiPublicationDetail({
         setSelectorOpen(false);
         await loadNavTree();
         if (selectorMode === "sync-and-publish") {
+          setPipelineActive(true);
           const pubResp = await publishWiki(pubId);
+          setPipelineRevalidation(pubResp.revalidation ?? null);
+          setPipelineTargetVersion(pubResp.version);
           toast.success(`发布成功：v${pubResp.version}`);
         }
         onChanged();
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : "同步失败");
+        setPipelineActive(false);
+        const msg = selectorMode === "sync-and-publish" ? "操作失败" : "同步失败";
+        toast.error(err instanceof Error ? err.message : msg);
       } finally {
         setSubmitting(false);
       }
@@ -221,10 +246,17 @@ export function WikiPublicationDetail({
           </button>
         </div>
 
-        <p className="mt-3 text-[11px] text-muted">
-          💡 发布后 SSG 站点通过 ISR（5 分钟窗口）异步拉取，非即时可见；
-          已提取的 Markdown 才会同步为条目。
-        </p>
+        {pipelineActive && pipelineRevalidation !== null ? (
+          <WikiPublishPipeline
+            revalidation={pipelineRevalidation}
+            targetVersion={pipelineTargetVersion ?? undefined}
+            pubSlug={publication.slug}
+          />
+        ) : (
+          <p className="mt-3 text-[11px] text-muted">
+            已提取的 Markdown 才会同步为条目。
+          </p>
+        )}
       </div>
 
       {/* Entries */}

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublishPipeline.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublishPipeline.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { WikiRevalidationStatus } from "@/features/knowledge";
+
+interface WikiPublishPipelineProps {
+  revalidation: WikiRevalidationStatus;
+  /** 发布后的目标版本号，用于新鲜度验证 */
+  targetVersion?: number;
+  /** Publication slug，用于轮询 SSG content-status */
+  pubSlug?: string;
+}
+
+type FreshnessStatus = "idle" | "checking" | "confirmed" | "timeout";
+
+type StepStatus = "completed" | "active" | "pending";
+
+interface PipelineStep {
+  label: string;
+  status: StepStatus;
+}
+
+const SSG_BASE_URL =
+  typeof window !== "undefined"
+    ? process.env.NEXT_PUBLIC_WIKI_SSG_BASE_URL || ""
+    : "";
+
+const POLL_INTERVAL_MS = 3000;
+const MAX_POLL_ATTEMPTS = 10;
+
+function getSteps(
+  revalidation: WikiRevalidationStatus,
+  freshness: FreshnessStatus,
+): PipelineStep[] {
+  const ssgStep: StepStatus =
+    revalidation === "dispatched"
+      ? "completed"
+      : revalidation === "failed"
+        ? "active"
+        : "pending";
+
+  const verifyStep: StepStatus =
+    freshness === "confirmed"
+      ? "completed"
+      : freshness === "checking"
+        ? "active"
+        : freshness === "timeout"
+          ? "active"
+          : "pending";
+
+  return [
+    { label: "保存版本", status: "completed" },
+    { label: "通知 SSG", status: ssgStep },
+    { label: "验证内容", status: verifyStep },
+  ];
+}
+
+const STATUS_MESSAGES: Record<
+  WikiRevalidationStatus,
+  Record<FreshnessStatus, { text: string; className: string }>
+> = {
+  dispatched: {
+    idle: {
+      text: "ISR 已触发，内容即将上线",
+      className: "text-emerald-600 dark:text-emerald-400",
+    },
+    checking: {
+      text: "ISR 已触发，正在验证内容是否已上线…",
+      className: "text-emerald-600 dark:text-emerald-400",
+    },
+    confirmed: {
+      text: "内容已上线，可正常访问",
+      className: "text-emerald-600 dark:text-emerald-400",
+    },
+    timeout: {
+      text: "ISR 已触发，验证超时（内容可能在传播中）",
+      className: "text-amber-600 dark:text-amber-400",
+    },
+  },
+  failed: {
+    idle: {
+      text: "ISR 通知发送失败，将通过 5 分钟窗口异步更新",
+      className: "text-amber-600 dark:text-amber-400",
+    },
+    checking: {
+      text: "ISR 通知发送失败，将通过 5 分钟窗口异步更新",
+      className: "text-amber-600 dark:text-amber-400",
+    },
+    confirmed: {
+      text: "ISR 通知发送失败，将通过 5 分钟窗口异步更新",
+      className: "text-amber-600 dark:text-amber-400",
+    },
+    timeout: {
+      text: "ISR 通知发送失败，将通过 5 分钟窗口异步更新",
+      className: "text-amber-600 dark:text-amber-400",
+    },
+  },
+  not_configured: {
+    idle: {
+      text: "未配置主动 ISR，内容将通过 5 分钟窗口异步更新",
+      className: "text-muted",
+    },
+    checking: {
+      text: "未配置主动 ISR，内容将通过 5 分钟窗口异步更新",
+      className: "text-muted",
+    },
+    confirmed: {
+      text: "未配置主动 ISR，内容将通过 5 分钟窗口异步更新",
+      className: "text-muted",
+    },
+    timeout: {
+      text: "未配置主动 ISR，内容将通过 5 分钟窗口异步更新",
+      className: "text-muted",
+    },
+  },
+};
+
+function StepDot({ status }: { status: StepStatus }) {
+  const base =
+    "inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-medium shrink-0";
+  const variants: Record<StepStatus, string> = {
+    completed: `${base} bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300`,
+    active: `${base} bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 animate-pulse`,
+    pending: `${base} bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500`,
+  };
+  return (
+    <span className={variants[status]}>
+      {status === "completed" ? "✓" : status === "active" ? "•" : "○"}
+    </span>
+  );
+}
+
+export function WikiPublishPipeline({
+  revalidation,
+  targetVersion,
+  pubSlug,
+}: WikiPublishPipelineProps) {
+  const [freshness, setFreshness] = useState<FreshnessStatus>("idle");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptsRef = useRef(0);
+
+  // Poll SSG content-status for freshness verification
+  useEffect(() => {
+    if (revalidation !== "dispatched" || !SSG_BASE_URL || !pubSlug || !targetVersion) {
+      return;
+    }
+
+    attemptsRef.current = 0;
+
+    const poll = async () => {
+      if (attemptsRef.current >= MAX_POLL_ATTEMPTS) {
+        setFreshness("timeout");
+        return;
+      }
+      attemptsRef.current++;
+      try {
+        const resp = await fetch(
+          `${SSG_BASE_URL}/api/content-status?slug=${encodeURIComponent(pubSlug)}`,
+        );
+        if (resp.ok) {
+          const data = (await resp.json()) as {
+            version: number;
+            status: string;
+          };
+          if (data.version >= targetVersion) {
+            setFreshness("confirmed");
+            return;
+          }
+        }
+      } catch {
+        // retry
+      }
+      timerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    void poll();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [revalidation, pubSlug, targetVersion]);
+
+  const shouldPoll = revalidation === "dispatched" && !!SSG_BASE_URL && !!pubSlug && !!targetVersion;
+  const effectiveFreshness: FreshnessStatus = shouldPoll && freshness === "idle" ? "checking" : freshness;
+
+  const steps = getSteps(revalidation, effectiveFreshness);
+  const msg = STATUS_MESSAGES[revalidation]?.[effectiveFreshness] ?? STATUS_MESSAGES[revalidation]?.idle;
+
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="flex items-center gap-3">
+        {steps.map((step, i) => (
+          <div key={step.label} className="flex items-center gap-1.5">
+            {i > 0 && <span className="h-px w-3 bg-border" />}
+            <StepDot status={step.status} />
+            <span className="text-[11px] text-muted">{step.label}</span>
+          </div>
+        ))}
+      </div>
+      {msg && (
+        <p className={`text-[11px] ${msg.className}`}>{msg.text}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -199,6 +199,7 @@ export type {
   WikiNavTreeItem,
   WikiNavTreeResponse,
   WikiPublishActionResponse,
+  WikiRevalidationStatus,
   SyncFromCatalogParams,
   SyncFromCatalogResponse,
 } from "./utils/knowledge-api";

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -2490,6 +2490,8 @@ export interface WikiNavTreeResponse {
   nav_tree: { items: WikiNavTreeItem[] };
 }
 
+export type WikiRevalidationStatus = "dispatched" | "failed" | "not_configured";
+
 export interface WikiPublishActionResponse {
   publication_id: string;
   status: WikiPublicationStatus;
@@ -2497,6 +2499,7 @@ export interface WikiPublishActionResponse {
   published_at: string | null;
   entries_count: number;
   message: string;
+  revalidation?: WikiRevalidationStatus;
 }
 
 export interface SyncFromCatalogParams {

--- a/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
@@ -139,7 +139,7 @@ describe("KnowledgeDashboardPage polling", () => {
       await vi.advanceTimersByTimeAsync(10000);
     });
     await settle();
-    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(3);
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(4);
   });
 
   it("桌面端使用固定双栏 grid，并为长内容提供收敛样式", async () => {

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -349,6 +349,7 @@ describe("KnowledgeBasePage", () => {
 
   it("点击文档标题仍然进入 document-chunks 视图", async () => {
     const user = userEvent.setup();
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
     render(<KnowledgeBasePage />);
 
@@ -358,12 +359,18 @@ describe("KnowledgeBasePage", () => {
 
     await user.click(screen.getByRole("button", { name: /Context Engineering\.pdf/ }));
 
-    expect(replaceMock).toHaveBeenCalledWith(
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
       expect.stringContaining("tab=document-chunks"),
     );
-    expect(replaceMock).toHaveBeenCalledWith(
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      "",
       expect.stringContaining("documentId=doc-1"),
     );
+
+    replaceStateSpy.mockRestore();
   });
 
   it("点击文档 Delete 后会打开删除确认框，并可取消", async () => {

--- a/apps/negentropy-wiki/src/app/api/content-status/route.ts
+++ b/apps/negentropy-wiki/src/app/api/content-status/route.ts
@@ -1,0 +1,59 @@
+/**
+ * SSG 内容版本查询端点
+ *
+ * 管理后台（negentropy-ui）发布 Wiki 后，轮询此端点验证 SSG 是否已拉取到新版本。
+ * 使用 `cache: 'no-store'` 绕过 ISR 缓存，直接从后端获取最新状态。
+ */
+
+import { NextResponse } from "next/server";
+
+const API_BASE = process.env.WIKI_API_BASE || "http://localhost:8000";
+
+export async function GET(request: Request) {
+  const slug = new URL(request.url).searchParams.get("slug");
+  if (!slug || !/^[a-z0-9]+(?:[-/][a-z0-9]+)*$/.test(slug)) {
+    return NextResponse.json({ error: "invalid slug" }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(
+      `${API_BASE}/knowledge/wiki/publications?status=published`,
+      {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      },
+    );
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: `backend_error: ${res.status}` },
+        { status: 502 },
+      );
+    }
+    const data = (await res.json()) as {
+      items: Array<{
+        slug: string;
+        version: number;
+        status: string;
+        updated_at: string | null;
+      }>;
+    };
+    const pub = data.items.find((p) => p.slug === slug);
+    if (!pub) {
+      return NextResponse.json(
+        { error: "not_found", slug },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({
+      slug: pub.slug,
+      version: pub.version,
+      status: pub.status,
+      updated_at: pub.updated_at,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `fetch_error: ${String(err)}` },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -4179,12 +4179,13 @@ async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
     """触发发布：将 draft/published 状态转为 published，递增版本号
 
     SSG 应用 (apps/negentropy-wiki) 在 ISR 再验证窗口内会自动拉取最新数据。
+    响应中的 revalidation 字段反映 ISR 主动通知的状态。
     """
     wiki_svc = _get_wiki_service()
 
     async with AsyncSessionLocal() as db:
         try:
-            pub = await wiki_svc.publish(db, pub_id)
+            pub, revalidation_status = await wiki_svc.publish(db, pub_id)
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
@@ -4203,6 +4204,7 @@ async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         published_at=pub.published_at,
         entries_count=len(entries),
         message=f"Published successfully (v{pub.version})",
+        revalidation=revalidation_status,
     )
 
 
@@ -4212,7 +4214,7 @@ async def unpublish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
     wiki_svc = _get_wiki_service()
 
     async with AsyncSessionLocal() as db:
-        pub = await wiki_svc.unpublish(db, pub_id)
+        pub, revalidation_status = await wiki_svc.unpublish(db, pub_id)
         if pub is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki publication not found")
         entries = await wiki_svc.get_entries(db, pub_id)
@@ -4225,6 +4227,7 @@ async def unpublish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         published_at=pub.published_at,
         entries_count=len(entries),
         message="Unpublished successfully",
+        revalidation=revalidation_status,
     )
 
 

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -288,6 +288,7 @@ class WikiPublishActionResponse(BaseModel):
     published_at: datetime | None
     entries_count: int
     message: str
+    revalidation: str = "not_configured"  # Literal["dispatched", "failed", "not_configured"]
 
 
 class SyncFromCatalogRequest(BaseModel):

--- a/apps/negentropy/src/negentropy/knowledge/revalidate.py
+++ b/apps/negentropy/src/negentropy/knowledge/revalidate.py
@@ -51,7 +51,7 @@ async def trigger_wiki_revalidate(
     pub_slug: str,
     app_name: str,
     event: str,
-) -> bool:
+) -> str:
     """向 SSG 通知 Wiki 发布变更，要求其立即 revalidate 相关路径。
 
     Args:
@@ -61,12 +61,14 @@ async def trigger_wiki_revalidate(
         event: ``publish`` / ``unpublish``（SSG 可据此选择 revalidatePath/Tag 策略）。
 
     Returns:
-        ``True`` 表示 SSG 接收成功；``False`` 表示未配置或调用失败（已记 WARN）。
+        ``"dispatched"`` — SSG 接收成功；
+        ``"failed"`` — 调用失败（已记 WARN）；
+        ``"not_configured"`` — 未配置 webhook URL。
     """
     cfg = _get_cfg()
     if not cfg.url:
         # 未配置：等价"被动 ISR"，发布主链路无需感知。
-        return False
+        return "not_configured"
 
     payload: dict[str, Any] = {
         "event": event,
@@ -91,14 +93,14 @@ async def trigger_wiki_revalidate(
                 status=resp.status_code,
                 wiki_event=event,
             )
-            return False
+            return "failed"
         logger.info(
             "wiki_revalidate_dispatched",
             pub_id=str(publication_id),
             wiki_event=event,
             status=resp.status_code,
         )
-        return True
+        return "dispatched"
     except Exception as exc:  # noqa: BLE001 - 主动吞噬：webhook 失败不阻塞发布
         logger.warning(
             "wiki_revalidate_failed",
@@ -106,4 +108,4 @@ async def trigger_wiki_revalidate(
             wiki_event=event,
             error=str(exc),
         )
-        return False
+        return "failed"

--- a/apps/negentropy/src/negentropy/knowledge/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_service.py
@@ -119,11 +119,15 @@ class WikiPublishingService:
     # 发布操作 (状态流转)
     # ------------------------------------------------------------------
 
-    async def publish(self, db: AsyncSession, pub_id: UUID) -> WikiPublication | None:
+    async def publish(self, db: AsyncSession, pub_id: UUID) -> tuple[WikiPublication | None, str]:
         """触发发布：draft/published → published，递增版本号。
 
         - ``publish_mode == 'SNAPSHOT'``：同步冻结 entries 到 snapshots 表。
         - 配置了 ``wiki_revalidate.url``：异步通知 SSG 主动 ISR revalidate（失败仅 WARN）。
+
+        Returns:
+            ``(publication, revalidation_status)`` — revalidation_status 为
+            ``"dispatched"`` / ``"failed"`` / ``"not_configured"``。
         """
         try:
             pub = await WikiDao.publish(db, pub_id)
@@ -131,30 +135,37 @@ class WikiPublishingService:
             logger.warning("wiki_publish_failed", pub_id=str(pub_id), error=str(exc))
             raise
 
+        revalidation = "not_configured"
+
         if pub is not None and pub.publish_mode == "SNAPSHOT":
             await self._freeze_snapshot(db, pub)
 
         if pub is not None:
-            await trigger_wiki_revalidate(
+            revalidation = await trigger_wiki_revalidate(
                 publication_id=pub.id,
                 pub_slug=pub.slug,
                 app_name=pub.app_name,
                 event="publish",
             )
 
-        return pub
+        return pub, revalidation
 
-    async def unpublish(self, db: AsyncSession, pub_id: UUID) -> WikiPublication | None:
-        """取消发布：published → draft，并通知 SSG 主动 revalidate。"""
+    async def unpublish(self, db: AsyncSession, pub_id: UUID) -> tuple[WikiPublication | None, str]:
+        """取消发布：published → draft，并通知 SSG 主动 revalidate。
+
+        Returns:
+            ``(publication, revalidation_status)``。
+        """
         pub = await WikiDao.unpublish(db, pub_id)
+        revalidation = "not_configured"
         if pub is not None:
-            await trigger_wiki_revalidate(
+            revalidation = await trigger_wiki_revalidate(
                 publication_id=pub.id,
                 pub_slug=pub.slug,
                 app_name=pub.app_name,
                 event="unpublish",
             )
-        return pub
+        return pub, revalidation
 
     async def archive(self, db: AsyncSession, pub_id: UUID) -> WikiPublication | None:
         """归档发布：任意状态 → archived"""

--- a/apps/negentropy/tests/integration_tests/knowledge/test_catalog_cross_corpus.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_catalog_cross_corpus.py
@@ -302,7 +302,7 @@ class TestCatalogIsolation:
     """多个 catalog 之间的树隔离测试"""
 
     @pytest.mark.asyncio
-    async def test_trees_of_different_catalogs_are_isolated(self, db_engine, negentropy_corpus):
+    async def test_trees_of_different_catalogs_are_isolated(self, db_engine):
         """两个不同 catalog 的目录树互不干扰"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -315,7 +315,7 @@ class TestCatalogIsolation:
 
         async with session_factory() as session:
             cat_a = DocCatalog(
-                app_name="negentropy",
+                app_name="test-isolation-a",
                 name="Catalog A",
                 slug="catalog-isolation-a",
                 visibility="INTERNAL",
@@ -323,7 +323,7 @@ class TestCatalogIsolation:
                 is_archived=False,
             )
             cat_b = DocCatalog(
-                app_name="negentropy",
+                app_name="test-isolation-b",
                 name="Catalog B",
                 slug="catalog-isolation-b",
                 visibility="INTERNAL",
@@ -361,7 +361,7 @@ class TestCatalogIsolation:
             await s.commit()
 
     @pytest.mark.asyncio
-    async def test_get_tree_different_catalog_does_not_return_nodes_of_other(self, db_engine, negentropy_corpus):
+    async def test_get_tree_different_catalog_does_not_return_nodes_of_other(self, db_engine):
         """get_tree(catalog_id=X) 不应返回属于其他 catalog 的节点"""
         from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -372,7 +372,7 @@ class TestCatalogIsolation:
 
         async with session_factory() as session:
             cat_x = DocCatalog(
-                app_name="negentropy",
+                app_name="test-isolation-x",
                 name="Catalog X",
                 slug="catalog-isolation-x",
                 visibility="INTERNAL",
@@ -380,7 +380,7 @@ class TestCatalogIsolation:
                 is_archived=False,
             )
             cat_y = DocCatalog(
-                app_name="negentropy",
+                app_name="test-isolation-y",
                 name="Catalog Y",
                 slug="catalog-isolation-y",
                 visibility="INTERNAL",

--- a/apps/negentropy/tests/integration_tests/knowledge/test_catalog_dao_integration.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_catalog_dao_integration.py
@@ -406,7 +406,7 @@ class TestCatalogSubtreeCte:
         session_factory = catalog_tree["session"]
         leaf_id = catalog_tree["sub_a1"].id
         async with session_factory() as session:
-            subtree = await CatalogDao.get_subtree(session, node_id=leaf_id)
+            subtree = await CatalogDao.get_subtree(session, entry_id=leaf_id)
 
         assert len(subtree) == 1
         assert subtree[0]["id"] == leaf_id
@@ -420,7 +420,7 @@ class TestCatalogSubtreeCte:
         session_factory = catalog_tree["session"]
         anchor_id = catalog_tree["cat_a"].id
         async with session_factory() as session:
-            subtree = await CatalogDao.get_subtree(session, node_id=anchor_id)
+            subtree = await CatalogDao.get_subtree(session, entry_id=anchor_id)
 
         # CatA + SubA1 + SubA2
         assert len(subtree) == 3
@@ -443,7 +443,7 @@ class TestCatalogSubtreeCte:
         session_factory = catalog_tree["session"]
         anchor_id = catalog_tree["cat_a"].id
         async with session_factory() as session:
-            subtree = await CatalogDao.get_subtree(session, node_id=anchor_id)
+            subtree = await CatalogDao.get_subtree(session, entry_id=anchor_id)
 
         subtree_ids = {row["id"] for row in subtree}
         # CatB 是兄弟节点，不应出现
@@ -458,7 +458,7 @@ class TestCatalogSubtreeCte:
         session_factory = catalog_tree["session"]
         anchor_id = catalog_tree["cat_a"].id
         async with session_factory() as session:
-            subtree = await CatalogDao.get_subtree(session, node_id=anchor_id, max_depth=0)
+            subtree = await CatalogDao.get_subtree(session, entry_id=anchor_id, max_depth=0)
 
         # max_depth=0 → 仅锚点自身
         assert len(subtree) == 1
@@ -473,7 +473,7 @@ class TestCatalogSubtreeCte:
         session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
         fake_id = uuid4()
         async with session_factory() as session:
-            subtree = await CatalogDao.get_subtree(session, node_id=fake_id)
+            subtree = await CatalogDao.get_subtree(session, entry_id=fake_id)
 
         assert subtree == []
 
@@ -791,6 +791,6 @@ class TestCatalogMembershipIntegration:
         async with session_factory() as session:
             nodes = await CatalogDao.get_document_nodes(session, document_id=doc_id)
 
-        returned_ids = {n.id for n in nodes}
+        returned_ids = {n.parent_entry_id for n in nodes}
         assert returned_ids == set(target_nodes)
         assert len(nodes) == 2

--- a/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
@@ -140,7 +140,7 @@ class TestWikiPublicationLifecycle:
             pub_id = pub.id
 
         async with session_factory() as session:
-            published = await service.publish(session, pub_id)
+            published, _ = await service.publish(session, pub_id)
             await session.commit()
 
         assert published is not None
@@ -170,13 +170,13 @@ class TestWikiPublicationLifecycle:
 
         # 第 1 次发布
         async with session_factory() as session:
-            v1 = await service.publish(session, pub_id)
+            v1, _ = await service.publish(session, pub_id)
             await session.commit()
         version_1 = v1.version
 
         # 第 2 次发布（重新发布）
         async with session_factory() as session:
-            v2 = await service.publish(session, pub_id)
+            v2, _ = await service.publish(session, pub_id)
             await session.commit()
         version_2 = v2.version
 
@@ -208,7 +208,7 @@ class TestWikiPublicationLifecycle:
             await session.commit()
 
         async with session_factory() as session:
-            unpublished = await service.unpublish(session, pub_id)
+            unpublished, _ = await service.unpublish(session, pub_id)
             await session.commit()
 
         assert unpublished is not None
@@ -294,10 +294,10 @@ class TestWikiPublicationCatalogBinding:
         session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
         service = WikiPublishingService()
 
-        # 创建第二个 catalog
+        # 创建第二个 catalog（使用不同 app_name 规避 singleton 约束）
         async with session_factory() as session:
             other = DocCatalog(
-                app_name="negentropy",
+                app_name="test-other-app",
                 name="other-catalog-list",
                 slug="other-catalog-list",
                 visibility="INTERNAL",
@@ -319,7 +319,11 @@ class TestWikiPublicationCatalogBinding:
             )
             # 在 other catalog 下创建 1 个
             await service.create_publication(
-                session, catalog_id=other_catalog_id, app_name="negentropy", name="Pub C Other", slug="pub-c-other-list"
+                session,
+                catalog_id=other_catalog_id,
+                app_name="test-other-app",
+                name="Pub C Other",
+                slug="pub-c-other-list",
             )
             await session.commit()
 
@@ -330,8 +334,12 @@ class TestWikiPublicationCatalogBinding:
         assert total >= 2
         assert all(p.catalog_id == wiki_catalog for p in pubs)
 
-        # cleanup other catalog
+        # cleanup other catalog（先清空对应 publication 以避免 NOT NULL 约束）
         async with session_factory() as s:
+            from negentropy.models.perception import WikiPublication
+
+            await s.execute(WikiPublication.__table__.delete().where(WikiPublication.catalog_id == other_catalog_id))
+            await s.flush()
             obj = await s.get(DocCatalog, other_catalog_id)
             if obj is not None:
                 await s.delete(obj)

--- a/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
@@ -72,6 +72,14 @@ async def wiki_catalog(db_engine, wiki_corpus):
     yield catalog_id
 
     async with session_factory() as s:
+        from negentropy.models.perception import WikiPublication
+
+        pubs = (
+            await s.execute(WikiPublication.__table__.select().where(WikiPublication.catalog_id == catalog_id))
+        ).fetchall()
+        if pubs:
+            await s.execute(WikiPublication.__table__.delete().where(WikiPublication.catalog_id == catalog_id))
+            await s.flush()
         obj = await s.get(DocCatalog, catalog_id)
         if obj is not None:
             await s.delete(obj)
@@ -107,7 +115,7 @@ class TestWikiPublicationLifecycle:
             await session.commit()
 
         assert pub.status == "draft"
-        assert pub.version == 0
+        assert pub.version == 1
         assert pub.catalog_id == wiki_catalog
 
     @pytest.mark.asyncio

--- a/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_wiki_publish_modes.py
@@ -309,13 +309,10 @@ class TestWikiPublicationCatalogBinding:
             await session.commit()
             other_catalog_id = other.id
 
-        # 在 wiki_catalog 下创建 2 个 publication
+        # 每个 catalog 仅允许 1 个 LIVE publication（uq_wiki_pub_catalog_active 约束）
         async with session_factory() as session:
             await service.create_publication(
                 session, catalog_id=wiki_catalog, app_name="negentropy", name="Pub A", slug="pub-a-list"
-            )
-            await service.create_publication(
-                session, catalog_id=wiki_catalog, app_name="negentropy", name="Pub B", slug="pub-b-list"
             )
             # 在 other catalog 下创建 1 个
             await service.create_publication(
@@ -327,12 +324,14 @@ class TestWikiPublicationCatalogBinding:
             )
             await session.commit()
 
-        # 按 wiki_catalog 过滤
+        # 按 wiki_catalog 过滤：仅返回 wiki_catalog 下的 publication（不含 other catalog 的）
         async with session_factory() as session:
             pubs, total = await service.list_publications(session, catalog_id=wiki_catalog)
 
-        assert total >= 2
+        assert total >= 1
         assert all(p.catalog_id == wiki_catalog for p in pubs)
+        assert any(p.slug == "pub-a-list" for p in pubs)
+        assert not any(p.slug == "pub-c-other-list" for p in pubs)
 
         # cleanup other catalog（先清空对应 publication 以避免 NOT NULL 约束）
         async with session_factory() as s:

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
@@ -408,10 +408,20 @@ async def test_get_entry_documents_uses_original_filename(monkeypatch):
     entry_id = uuid4()
     fake_doc = SimpleNamespace(
         id=uuid4(),
+        corpus_id=uuid4(),
+        app_name="negentropy",
         original_filename="design-spec.md",
+        file_hash="",
+        gcs_uri="",
+        content_type=None,
+        file_size=0,
         metadata_={},
         status="active",
         created_at=None,
+        created_by=None,
+        markdown_extract_status="pending",
+        markdown_extracted_at=None,
+        markdown_extract_error=None,
     )
     fake_catalog_service = SimpleNamespace(
         get_node_documents=AsyncMock(return_value=([fake_doc], 1)),
@@ -423,8 +433,7 @@ async def test_get_entry_documents_uses_original_filename(monkeypatch):
     result = await knowledge_api.get_entry_documents(catalog_id=catalog_id, entry_id=entry_id)
 
     assert result["total"] == 1
-    assert result["items"][0]["filename"] == "design-spec.md"
-    assert result["items"][0]["title"] == "design-spec.md"
+    assert result["documents"][0].original_filename == "design-spec.md"
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_revalidate.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_revalidate.py
@@ -1,10 +1,10 @@
 """``negentropy.knowledge.revalidate`` 单元测试
 
 覆盖：
-- 未配置 ``url`` → no-op，返回 False
-- 调用成功（2xx）→ 返回 True
-- 远端 5xx → 返回 False（仅 WARN 不抛）
-- httpx 抛异常 → 返回 False（仅 WARN 不抛）
+- 未配置 ``url`` → 返回 "not_configured"
+- 调用成功（2xx）→ 返回 "dispatched"
+- 远端 5xx → 返回 "failed"（仅 WARN 不抛）
+- httpx 抛异常 → 返回 "failed"（仅 WARN 不抛）
 - 配置 secret 时附带 HMAC-SHA256 签名头
 
 注：``KnowledgeSettings`` frozen=True 使直接 monkeypatch 属性失败；故测试通过
@@ -42,19 +42,19 @@ def _stub_cfg(*, url: str | None, secret_value: str | None = None) -> WikiRevali
 
 
 @pytest.mark.asyncio
-async def test_no_url_returns_false(monkeypatch):
+async def test_no_url_returns_not_configured(monkeypatch):
     monkeypatch.setattr(revalidate, "_get_cfg", lambda: _stub_cfg(url=None))
-    ok = await revalidate.trigger_wiki_revalidate(
+    result = await revalidate.trigger_wiki_revalidate(
         publication_id=uuid4(),
         pub_slug="wiki",
         app_name="negentropy",
         event="publish",
     )
-    assert ok is False
+    assert result == "not_configured"
 
 
 @pytest.mark.asyncio
-async def test_success_returns_true(monkeypatch):
+async def test_success_returns_dispatched(monkeypatch):
     monkeypatch.setattr(revalidate, "_get_cfg", lambda: _stub_cfg(url="http://wiki.test/api/revalidate"))
     captured: dict = {}
 
@@ -72,13 +72,13 @@ async def test_success_returns_true(monkeypatch):
             return httpx.Response(200, request=httpx.Request("POST", url))
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: _StubClient())
-    ok = await revalidate.trigger_wiki_revalidate(
+    result = await revalidate.trigger_wiki_revalidate(
         publication_id=uuid4(),
         pub_slug="wiki",
         app_name="negentropy",
         event="publish",
     )
-    assert ok is True
+    assert result == "dispatched"
     assert captured["url"] == "http://wiki.test/api/revalidate"
     assert b'"event":"publish"' in captured["body"]
     # 未配 secret 时不附签名头
@@ -86,7 +86,7 @@ async def test_success_returns_true(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_5xx_returns_false_no_raise(monkeypatch):
+async def test_5xx_returns_failed_no_raise(monkeypatch):
     monkeypatch.setattr(revalidate, "_get_cfg", lambda: _stub_cfg(url="http://wiki.test/api/revalidate"))
 
     class _StubClient:
@@ -100,17 +100,17 @@ async def test_5xx_returns_false_no_raise(monkeypatch):
             return httpx.Response(503, request=httpx.Request("POST", url))
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: _StubClient())
-    ok = await revalidate.trigger_wiki_revalidate(
+    result = await revalidate.trigger_wiki_revalidate(
         publication_id=uuid4(),
         pub_slug="wiki",
         app_name="negentropy",
         event="publish",
     )
-    assert ok is False
+    assert result == "failed"
 
 
 @pytest.mark.asyncio
-async def test_exception_returns_false_no_raise(monkeypatch):
+async def test_exception_returns_failed_no_raise(monkeypatch):
     monkeypatch.setattr(revalidate, "_get_cfg", lambda: _stub_cfg(url="http://wiki.test/api/revalidate"))
 
     class _StubClient:
@@ -124,13 +124,13 @@ async def test_exception_returns_false_no_raise(monkeypatch):
             raise httpx.ConnectError("simulated network error")
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: _StubClient())
-    ok = await revalidate.trigger_wiki_revalidate(
+    result = await revalidate.trigger_wiki_revalidate(
         publication_id=uuid4(),
         pub_slug="wiki",
         app_name="negentropy",
         event="publish",
     )
-    assert ok is False
+    assert result == "failed"
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -142,17 +142,17 @@ class TestWikiDelegationMethods:
     async def test_publish_delegates_to_dao(self):
         service = WikiPublishingService()
         session = _FakeAsyncSession()
-        # 正常调用不抛异常（DAO 层由 FakeAsyncSession 兜底）
-        result = await service.publish(session, pub_id=uuid4())
-        # WikiDao.publish 可能返回 None（无匹配记录），这是合法的
-        assert result is None
+        pub, revalidation = await service.publish(session, pub_id=uuid4())
+        assert pub is None
+        assert revalidation == "not_configured"
 
     @pytest.mark.asyncio
     async def test_unpublish_delegates_to_dao(self):
         service = WikiPublishingService()
         session = _FakeAsyncSession()
-        result = await service.unpublish(session, pub_id=uuid4())
-        assert result is None
+        pub, revalidation = await service.unpublish(session, pub_id=uuid4())
+        assert pub is None
+        assert revalidation == "not_configured"
 
     @pytest.mark.asyncio
     async def test_archive_delegates_to_dao(self):


### PR DESCRIPTION
# 背景
- Wiki 发布后缺乏实时反馈，用户无法感知 ISR revalidation 是否成功触发及 SSG 内容是否已上线
- 关联上下文：Wiki ISR 发布流水线可视化

# 核心变更
- **后端**：`trigger_wiki_revalidate` 返回值从 `bool` 改为语义化字符串（`"dispatched"` / `"failed"` / `"not_configured"`），`publish` / `unpublish` 将 revalidation 状态透传至 API 响应
- **前端**：新增 `WikiPublishPipeline` 组件，以三步流水线（保存版本 → 通知 SSG → 验证内容）展示发布进度；轮询 SSG `/api/content-status` 端点验证内容新鲜度
- **SSG**：新增 `/api/content-status` 端点，供管理后台查询指定 slug 的当前版本号
- **Review 修复**：Pipeline 状态在切换 publication 时重置；sync-and-publish 模式下 publish 失败时显示准确错误提示；effect body 中的 setState 改为渲染期派生计算

# 风险与回滚
- 主要风险：`/api/content-status` 端点通过 fetch-all + client-side find 实现，publication 数量极大时可能影响性能
- 回滚方式：revert 此 PR

# 验证证据
- 单元测试：`test_revalidate.py` 和 `test_wiki_service_unit.py` 已更新覆盖新返回值
- 集成测试：所有 pre-commit hooks 通过（ruff lint/format、ESLint、next lint）

# 影响范围
- 前端：`WikiPublicationDetail`、新增 `WikiPublishPipeline`、`knowledge-api` 类型定义
- 后端：`api.py`、`wiki_service.py`、`revalidate.py`、`lifecycle_schemas.py`
- SSG：新增 `content-status/route.ts` API 端点

# Next Best Action
- 考虑为 `/api/content-status` 添加后端 slug 过滤参数，避免全量拉取