### PR TITLE
fix(wiki-sync): Catalog 父子并选时按最小覆盖根集去重，恢复单棵树状结构

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/wiki_service.py
@@ -329,14 +329,29 @@ class WikiPublishingService:
         db: AsyncSession,
         catalog_node_ids: list[UUID],
     ) -> tuple[list[tuple[list[str], dict]], list[tuple[list[str], Any]], list[str]]:
-        """遍历每个根节点子树，摊平为容器计划 + 文档计划两类序列。
+        """遍历最小覆盖根集，摊平为容器计划 + 文档计划两类序列。
+
+        当用户在选择对话框中同时勾选祖先与后代节点时（如 ``Harness-Engineering``
+        与其子目录 ``Paper`` 并选），原本应共享同一棵树的节点会被独立当作多个
+        同步根：第二轮以 ``Paper`` 为根的 ``get_subtree`` 不含其父节点，
+        :meth:`_build_path_slugs` 沿 ``parent_id`` 回溯时在 ``node_map`` 中找不到祖先
+        而提前终止，``Paper`` 的 ``path_slugs`` 退化为 ``["paper"]``，进而通过
+        ``upsert_container_entry`` ``(publication_id, catalog_node_id)`` 唯一键覆盖
+        首轮已正确写入的 ``["harness-engineering", "paper"]``，最终被
+        ``build_nav_tree`` 视为独立顶层根（``len(path) <= 1``）。
+
+        本函数因此先做 **最小覆盖根集（minimal antichain）** 过滤：若某入选节点是
+        另一入选节点的后代，则丢弃后代，仅保留处于其外层的祖先作为遍历根，确保
+        每个 FOLDER 仅在一棵子树语境下生成 plans，``entry_path`` 与 Catalog 原生
+        父子层级保持一致。
 
         Returns:
             ``(container_plans, document_plans, errors)`` ——
               - ``container_plans``：``[(path_slugs, node_dict), ...]``，每个
                 FOLDER 节点对应一条；
               - ``document_plans``：``[(path_slugs_with_parent_segment, doc), ...]``；
-              - ``errors``：遍历期错误（环检测、空子树）。
+              - ``errors``：遍历期错误（``empty_subtree`` / ``cycle_detected`` /
+                ``descendant_of:<ancestor_id>`` 表示因祖先并选而被丢弃）。
         """
         from negentropy.knowledge.catalog_dao import CatalogDao
 
@@ -344,12 +359,37 @@ class WikiPublishingService:
         document_plans: list[tuple[list[str], Any]] = []
         errors: list[str] = []
 
+        # P1: 拉取每个候选根的子树，缓存以避免在去重阶段重复 IO。
+        # dict 键去重天然处理同一 ID 重复传入的情况。
+        subtrees_by_root: dict[str, list[dict]] = {}
         for root_node_id in catalog_node_ids:
+            rid = str(root_node_id)
+            if rid in subtrees_by_root:
+                continue
             subtree = await CatalogDao.get_subtree(db, root_node_id)
             if not subtree:
                 errors.append(f"node:{root_node_id}:empty_subtree")
                 continue
+            subtrees_by_root[rid] = subtree
 
+        # P2: 计算最小覆盖根集。若 rid 出现在另一根的后代集合中，则丢弃 rid。
+        descendants_by_root: dict[str, set[str]] = {
+            rid: {str(n["id"]) for n in subtree if str(n["id"]) != rid} for rid, subtree in subtrees_by_root.items()
+        }
+        minimal_root_ids: list[str] = []
+        for rid in subtrees_by_root:
+            ancestor = next(
+                (other for other in subtrees_by_root if other != rid and rid in descendants_by_root[other]),
+                None,
+            )
+            if ancestor is not None:
+                errors.append(f"node:{rid}:descendant_of:{ancestor}")
+                continue
+            minimal_root_ids.append(rid)
+
+        # P3: 仅对最小根集生成 plans，下游 _apply_* 接口与契约不变。
+        for root_id in minimal_root_ids:
+            subtree = subtrees_by_root[root_id]
             node_map = {str(n["id"]): n for n in subtree}
 
             for node in subtree:

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
@@ -4,9 +4,14 @@
 - 正常 root-leaf 链
 - parent_id 缺失时停止于自身
 - 环检测（self-cycle / parent-cycle）
+
+覆盖 ``WikiPublishingService._collect_subtree_plans`` 的最小覆盖根集去重：
+- 父子并选 / 三层链全选 / 无关树并选 / 同一 ID 重复
 """
 
 from __future__ import annotations
+
+import pytest
 
 from negentropy.knowledge.wiki_service import WikiPublishingService
 
@@ -51,3 +56,156 @@ class TestBuildPathSlugs:
         path, cycle = WikiPublishingService._build_path_slugs(node, {"a": node})
         assert path == ["leaf"]
         assert cycle is None
+
+
+# ---------------------------------------------------------------------------
+# _collect_subtree_plans 最小覆盖根集去重
+# ---------------------------------------------------------------------------
+
+
+def _patch_catalog_dao(
+    monkeypatch,
+    *,
+    subtrees: dict[str, list[dict]],
+    docs_by_node: dict[str, list] | None = None,
+) -> None:
+    """打桩 ``CatalogDao.get_subtree`` 与 ``get_node_documents``。
+
+    ``subtrees`` 以根节点 ID 为键，返回该子树的扁平节点列表（包含根自身及其后代）。
+    ``docs_by_node`` 以节点 ID 为键，返回该节点下文档列表；缺省为空。
+    """
+    docs_by_node = docs_by_node or {}
+
+    async def fake_get_subtree(db, node_id):
+        _ = db
+        return list(subtrees.get(str(node_id), []))
+
+    async def fake_get_node_documents(db, catalog_node_id, limit=500):
+        _ = (db, limit)
+        return list(docs_by_node.get(str(catalog_node_id), [])), len(docs_by_node.get(str(catalog_node_id), []))
+
+    monkeypatch.setattr("negentropy.knowledge.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
+    monkeypatch.setattr("negentropy.knowledge.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents)
+
+
+class TestCollectSubtreePlansMinimalRoots:
+    """父子并选时应丢弃后代根，只保留祖先作为遍历入口。"""
+
+    @pytest.mark.asyncio
+    async def test_parent_and_child_both_selected_collapse_to_parent(self, monkeypatch):
+        """图 1/图 2 复现：选中 ``Harness-Engineering`` 与子目录 ``Paper`` 时
+        Paper 应作为 Harness 的子节点同步，而非另一棵根树。
+        """
+        # Catalog 形态：harness 为根，paper 为其子
+        harness = _node("harness-id", "harness-engineering", None)
+        paper = _node("paper-id", "paper", "harness-id")
+        # get_subtree(harness) 返回完整两节点；get_subtree(paper) 仅含 paper
+        _patch_catalog_dao(
+            monkeypatch,
+            subtrees={
+                "harness-id": [harness, paper],
+                "paper-id": [paper],
+            },
+        )
+
+        service = WikiPublishingService()
+        container_plans, document_plans, errors = await service._collect_subtree_plans(
+            db=object(),
+            catalog_node_ids=["harness-id", "paper-id"],  # type: ignore[list-item]
+        )
+
+        # 容器计划应该只来自 harness 子树：harness + paper 各一条
+        plan_paths = sorted(tuple(p) for p, _ in container_plans)
+        assert plan_paths == [("harness-engineering",), ("harness-engineering", "paper")], plan_paths
+
+        # 文档计划为空（本用例未提供文档）
+        assert document_plans == []
+
+        # paper 应被作为 harness 的后代被丢弃，并打上溯源 errors
+        assert any(e == "node:paper-id:descendant_of:harness-id" for e in errors), errors
+
+    @pytest.mark.asyncio
+    async def test_three_level_chain_collapse_to_top_root(self, monkeypatch):
+        """三层链 A → A.B → A.B.C 全选 → 仅 A 作为遍历根。"""
+        a = _node("a", "a", None)
+        b = _node("b", "b", "a")
+        c = _node("c", "c", "b")
+        _patch_catalog_dao(
+            monkeypatch,
+            subtrees={
+                "a": [a, b, c],
+                "b": [b, c],
+                "c": [c],
+            },
+        )
+
+        service = WikiPublishingService()
+        container_plans, _, errors = await service._collect_subtree_plans(
+            db=object(),
+            catalog_node_ids=["a", "b", "c"],  # type: ignore[list-item]
+        )
+
+        plan_paths = sorted(tuple(p) for p, _ in container_plans)
+        assert plan_paths == [("a",), ("a", "b"), ("a", "b", "c")], plan_paths
+
+        # 应有 b、c 各自的 descendant_of 记录
+        descendant_errors = sorted(e for e in errors if ":descendant_of:" in e)
+        assert descendant_errors == [
+            "node:b:descendant_of:a",
+            "node:c:descendant_of:a",
+        ], descendant_errors
+
+    @pytest.mark.asyncio
+    async def test_two_unrelated_trees_both_kept(self, monkeypatch):
+        """两棵无关树并选互相独立，皆作为遍历根。"""
+        x = _node("x", "x", None)
+        y = _node("y", "y", None)
+        _patch_catalog_dao(
+            monkeypatch,
+            subtrees={
+                "x": [x],
+                "y": [y],
+            },
+        )
+
+        service = WikiPublishingService()
+        container_plans, _, errors = await service._collect_subtree_plans(
+            db=object(),
+            catalog_node_ids=["x", "y"],  # type: ignore[list-item]
+        )
+
+        plan_paths = sorted(tuple(p) for p, _ in container_plans)
+        assert plan_paths == [("x",), ("y",)], plan_paths
+        # 不应触发任何 descendant_of 标记
+        assert not any(":descendant_of:" in e for e in errors), errors
+
+    @pytest.mark.asyncio
+    async def test_duplicate_id_collapses_in_subtree_cache(self, monkeypatch):
+        """同一 ID 在入参中重复出现时应自然去重（dict 键收敛）。"""
+        a = _node("a", "a", None)
+        _patch_catalog_dao(monkeypatch, subtrees={"a": [a]})
+
+        service = WikiPublishingService()
+        container_plans, _, errors = await service._collect_subtree_plans(
+            db=object(),
+            catalog_node_ids=["a", "a", "a"],  # type: ignore[list-item]
+        )
+
+        # 应只产出一条容器计划，不应触发 descendant_of
+        assert [tuple(p) for p, _ in container_plans] == [("a",)]
+        assert not any(":descendant_of:" in e for e in errors), errors
+
+    @pytest.mark.asyncio
+    async def test_empty_subtree_logs_error(self, monkeypatch):
+        """``get_subtree`` 返回空时应仍记录 ``empty_subtree`` 错误，不抛异常。"""
+        _patch_catalog_dao(monkeypatch, subtrees={"a": []})
+
+        service = WikiPublishingService()
+        container_plans, document_plans, errors = await service._collect_subtree_plans(
+            db=object(),
+            catalog_node_ids=["a"],  # type: ignore[list-item]
+        )
+
+        assert container_plans == []
+        assert document_plans == []
+        assert any("empty_subtree" in e for e in errors), errors


### PR DESCRIPTION
## 背景与现象

当用户在 Wiki 详情页的「从 Catalog 同步」对话框中**同时勾选祖先节点与其后代节点**（如 `Harness-Engineering` 与其子目录 `Paper`）时，期望按 Catalog 既有树状结构同步——`Paper` 应作为 `Harness-Engineering` 的子节点；实际却被渲染成两棵互不相属的顶层树：

```
HARNESS-ENGINEERING       ← 顶层
└── harness-design-long-running-apps.md
PAPER                     ← 又一顶层（Bug）
└── 2603.05344v3.pdf
```

## 根因（已通过阅读源码确认）

\`apps/negentropy/src/negentropy/knowledge/wiki_service.py\` 中 `_collect_subtree_plans` 对 \`catalog_node_ids\` 中每项**独立**调用 `CatalogDao.get_subtree(root_node_id)`，并基于该子树构造局部 `node_map`：

1. **首轮**（root=Harness-Engineering）：子树含 H-E + Paper，`_build_path_slugs(Paper)` 正确回溯为 `["harness-engineering", "paper"]`；
2. **次轮**（root=Paper）：`get_subtree(paper_id)` 仅返回 Paper 子树，`node_map` **不含** Harness-Engineering；`_build_path_slugs` 沿 `parent_id` 回溯时 `node_map.get(harness_id)` → `None` → 提前终止 → `path_slugs` 退化为 `["paper"]`；
3. `WikiDao.upsert_container_entry` 以 `(publication_id, catalog_node_id)` 为唯一键，**第二轮 upsert 覆盖**首轮 → Paper 的 `entry_path` 最终落为 `["paper"]`；
4. `wiki_tree.build_nav_tree` 按 `len(path) <= 1` 判根 → Paper 被错判为独立顶层根。

证据：现有单测 `test_wiki_sync_helpers.py::test_missing_parent_in_map_stops_walk` 即为该退化路径的「正向用例」——表明 `_build_path_slugs` 在 parent 缺失时确实会停在自身。Bug 不在该函数，而在调用方未对祖孙重复入选去重。

## 修复方案

在 `_collect_subtree_plans` 入口插入**最小覆盖根集（minimal antichain）**过滤步骤，分三阶段：

1. **P1 子树缓存**：对 `catalog_node_ids` 逐一拉取 `get_subtree`，缓存到 `subtrees_by_root: dict[str, list[dict]]`，dict 键天然处理同一 ID 重复传入；
2. **P2 去重**：基于子树构建每根的后代 ID 集合 `descendants_by_root`；若某入选节点 `rid` 出现在另一入选节点 `other` 的后代集合中，则**丢弃** `rid`，并追加 `errors.append(f"node:{rid}:descendant_of:{other}")`，沿用既有 `node:<id>:<reason>` 错误前缀约定；
3. **P3 计划生成**：仅对最小根集执行原有的 `_build_path_slugs` + `get_node_documents` 逻辑——下游 `_apply_container_mappings` / `_apply_document_mappings` 接口与 plans 结构**完全不变**。

### 设计原则锚点（AGENTS.md）

- **Minimal Intervention**：单点改动 `_collect_subtree_plans`；`_build_path_slugs` / `_apply_*` / `build_nav_tree` / 数据模型 / 迁移 / 前端对话框零改动；
- **Reuse-Driven**：复用既有 `CatalogDao.get_subtree` 返回值（已带完整 path），不引入新 DAO 方法；
- **Boundary Management**：去重在后端入口完成（防御式），不依赖前端先行裁剪——后端是契约边界；
- **Single Source of Truth**：保持 `(publication_id, catalog_node_id)` 唯一键不变，避免 schema 改动产生迁移涟漪；
- **Second-Order Thinking**：被丢弃的后代以 `descendant_of:` 错误前缀留痕，便于运营审计与排查。

## 测试

- 在 `test_wiki_sync_helpers.py` 新增 `TestCollectSubtreePlansMinimalRoots` 测试类，覆盖：
  - 父子并选 → 仅父根遍历，子节点路径正确；
  - 三层链 A → A.B → A.B.C 全选 → 仅以 A 作为遍历根；
  - 两棵无关树并选 → 各自保留为独立根；
  - 同一 ID 重复出现 → dict 键自然去重；
  - `get_subtree` 返回空时仍记录 `empty_subtree`，不抛异常。
- `_build_path_slugs` 既有 5 个用例不受影响（未改动该函数）。

\`\`\`bash
$ uv run pytest tests/unit_tests/knowledge/test_wiki_sync_helpers.py \\
    tests/unit_tests/knowledge/test_wiki_service_unit.py \\
    tests/unit_tests/knowledge/test_wiki_tree.py --no-cov -v
======================== 37 passed, 7 warnings in 0.27s ========================
\`\`\`

## 接口契约

`POST /api/knowledge/wiki/publications/{pub_id}/sync-from-catalog` 返回值：

- `synced_count` 与「仅选父」一次的结果一致；
- `errors` 中含 `node:<paper_id>:descendant_of:<harness_id>`，便于审计「哪些选择被去重」。

## Out-of-Scope（明确不做）

- 不改前端弹窗的级联勾选 / 三态 checkbox UX（`CatalogNodeSelectorDialog` 已显示树形结构，用户可见父子关系；后端权威去重已足以矫正同步结果）；
- 不改 `WikiPublicationEntry` schema、唯一键、迁移；
- 不改 `build_nav_tree` 渲染算法。

🤖 Generated with [Claude Code](https://github.com/claude)