### PR TITLE
fix(knowledge): 修复 KB Retrieve 全屏空白（前端聚合 rejection × 后端 hybrid/rrf 降级 × 502 上游错误码 × 诊断仪器化）

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -819,6 +819,14 @@ export default function KnowledgeBasePage() {
       setRetrievalResults(res.items);
       setRetrievalDocked(true);
       setIsCorpusPanelExpanded(false);
+      if (res.errors && res.errors.length > 0) {
+        // 部分 Corpus 检索失败：展示成功项 + 顶部警示，避免静默丢失
+        const summary = res.errors
+          .map((e) => `[${e.corpusId.slice(0, 8)}] ${e.message}`)
+          .join("; ")
+          .slice(0, 200);
+        toast.warning(`部分语料检索失败：${summary}`);
+      }
     } catch (err) {
       setRetrievalError(err instanceof Error ? err.message : "Retrieve failed");
     } finally {

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -836,9 +836,15 @@ export interface AsyncPipelineResult {
   message: string;
 }
 
+export interface SearchResultError {
+  corpusId: string;
+  message: string;
+}
+
 export interface SearchResults {
   count: number;
   items: KnowledgeMatch[];
+  errors?: SearchResultError[];
 }
 
 export interface GraphUpsertResult {
@@ -1825,16 +1831,37 @@ export async function searchAcrossCorpora(
   );
 
   const mergedItems: KnowledgeMatch[] = [];
-  settled.forEach((item) => {
+  const errors: SearchResultError[] = [];
+  settled.forEach((item, idx) => {
     if (item.status === "fulfilled") {
       mergedItems.push(...item.value);
+    } else {
+      const corpusId = corpusIds[idx];
+      const reason = item.reason;
+      const message =
+        reason instanceof Error
+          ? reason.message
+          : typeof reason === "string"
+            ? reason
+            : "Unknown error";
+      errors.push({ corpusId, message });
     }
   });
+
+  // 全部失败 → 抛聚合错误，让调用方走错误路径
+  if (errors.length === corpusIds.length && corpusIds.length > 0) {
+    const merged = errors
+      .map((e) => `[${e.corpusId.slice(0, 8)}] ${e.message}`)
+      .join("; ");
+    throw new Error(merged.slice(0, 200));
+  }
+
   mergedItems.sort((a, b) => (b.combined_score ?? 0) - (a.combined_score ?? 0));
 
   return {
     count: mergedItems.length,
     items: params.limit ? mergedItems.slice(0, params.limit) : mergedItems,
+    ...(errors.length > 0 ? { errors } : {}),
   };
 }
 

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -838,6 +838,11 @@ export interface AsyncPipelineResult {
 
 export interface SearchResultError {
   corpusId: string;
+  /**
+   * 后端返回的结构化错误码（如 `EMBEDDING_FAILED`）；
+   * 仅当 rejection 为 `KnowledgeError` 时存在，便于调用方按 code 走差异化分支。
+   */
+  code?: string;
   message: string;
 }
 
@@ -1844,16 +1849,28 @@ export async function searchAcrossCorpora(
           : typeof reason === "string"
             ? reason
             : "Unknown error";
-      errors.push({ corpusId, message });
+      const code =
+        reason instanceof KnowledgeError ? reason.code : undefined;
+      errors.push(code ? { corpusId, code, message } : { corpusId, message });
     }
   });
 
-  // 全部失败 → 抛聚合错误，让调用方走错误路径
+  // 全部失败 → 抛聚合 KnowledgeError（保留 code 与逐条 errors，
+  // 让调用方既能按上游 vs 自身错误分流，又能拿到完整失败明细）。
   if (errors.length === corpusIds.length && corpusIds.length > 0) {
     const merged = errors
       .map((e) => `[${e.corpusId.slice(0, 8)}] ${e.message}`)
       .join("; ");
-    throw new Error(merged.slice(0, 200));
+    const codes = errors
+      .map((e) => e.code)
+      .filter((c): c is string => Boolean(c));
+    const allSameCode =
+      codes.length === errors.length && codes.every((c) => c === codes[0]);
+    const aggregatedCode =
+      allSameCode && codes.length > 0 ? codes[0] : "AGGREGATED_SEARCH_ERRORS";
+    throw new KnowledgeError(aggregatedCode, merged.slice(0, 200), {
+      errors,
+    });
   }
 
   mergedItems.sort((a, b) => (b.combined_score ?? 0) - (a.combined_score ?? 0));

--- a/apps/negentropy-ui/tests/unit/knowledge/searchAcrossCorpora.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/searchAcrossCorpora.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { searchAcrossCorpora } from "@/features/knowledge/utils/knowledge-api";
+import {
+  KnowledgeError,
+  searchAcrossCorpora,
+} from "@/features/knowledge/utils/knowledge-api";
 
 const buildOkResponse = (items: unknown[]) =>
   ({
@@ -95,9 +98,11 @@ describe("searchAcrossCorpora — 聚合三态", () => {
     expect(res.errors).toHaveLength(1);
     expect(res.errors?.[0].corpusId).toBe("c-2222");
     expect(res.errors?.[0].message).toContain("upstream gemini 400");
+    // 保留后端结构化 code，便于调用方按上游 vs 自身错误分流
+    expect(res.errors?.[0].code).toBe("EMBEDDING_FAILED");
   });
 
-  it("全部 rejected → 抛聚合错误（不静默丢失）", async () => {
+  it("全部 rejected 且 code 一致 → 抛 KnowledgeError 并保留原 code", async () => {
     vi.spyOn(global, "fetch")
       .mockResolvedValueOnce(
         buildErrorResponse(502, "EMBEDDING_FAILED", "upstream gemini 400"),
@@ -106,11 +111,34 @@ describe("searchAcrossCorpora — 聚合三态", () => {
         buildErrorResponse(503, "EMBEDDING_FAILED", "upstream gemini 503"),
       );
 
-    await expect(
-      searchAcrossCorpora(["c-1111", "c-2222"], {
-        query: "harness",
-        mode: "hybrid",
-      }),
-    ).rejects.toThrow(/upstream gemini/);
+    const promise = searchAcrossCorpora(["c-1111", "c-2222"], {
+      query: "harness",
+      mode: "hybrid",
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(KnowledgeError);
+    await expect(promise).rejects.toMatchObject({
+      code: "EMBEDDING_FAILED",
+      message: expect.stringMatching(/upstream gemini/),
+    });
+  });
+
+  it("全部 rejected 但 code 混合 → 聚合 code 退化为 AGGREGATED_SEARCH_ERRORS", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        buildErrorResponse(502, "EMBEDDING_FAILED", "upstream gemini 400"),
+      )
+      .mockResolvedValueOnce(
+        buildErrorResponse(500, "SEARCH_ERROR", "internal failure"),
+      );
+
+    const promise = searchAcrossCorpora(["c-1111", "c-2222"], {
+      query: "harness",
+      mode: "hybrid",
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      code: "AGGREGATED_SEARCH_ERRORS",
+    });
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/searchAcrossCorpora.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/searchAcrossCorpora.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { searchAcrossCorpora } from "@/features/knowledge/utils/knowledge-api";
+
+const buildOkResponse = (items: unknown[]) =>
+  ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: async () => ({ count: items.length, items }),
+    text: async () => JSON.stringify({ count: items.length, items }),
+    clone() {
+      return this;
+    },
+  }) as unknown as Response;
+
+const buildErrorResponse = (status: number, code: string, message: string) =>
+  ({
+    ok: false,
+    status,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: async () => ({ code, message }),
+    text: async () => JSON.stringify({ code, message }),
+    clone() {
+      return this;
+    },
+  }) as unknown as Response;
+
+describe("searchAcrossCorpora — 聚合三态", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("全部 fulfilled → 合并结果且不附 errors", async () => {
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        buildOkResponse([
+          {
+            id: "k1",
+            content: "a",
+            source_uri: "u1",
+            metadata: {},
+            combined_score: 0.9,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildOkResponse([
+          {
+            id: "k2",
+            content: "b",
+            source_uri: "u2",
+            metadata: {},
+            combined_score: 0.7,
+          },
+        ]),
+      );
+
+    const res = await searchAcrossCorpora(["c-1111", "c-2222"], {
+      query: "harness",
+      mode: "hybrid",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.count).toBe(2);
+    expect(res.items.map((i) => i.id)).toEqual(["k1", "k2"]);
+    expect(res.errors).toBeUndefined();
+  });
+
+  it("部分 rejected → 返回成功项 + errors[] 暴露失败原因", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        buildOkResponse([
+          {
+            id: "k1",
+            content: "a",
+            source_uri: "u1",
+            metadata: {},
+            combined_score: 0.9,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        buildErrorResponse(502, "EMBEDDING_FAILED", "upstream gemini 400"),
+      );
+
+    const res = await searchAcrossCorpora(["c-1111", "c-2222"], {
+      query: "harness",
+      mode: "hybrid",
+    });
+
+    expect(res.count).toBe(1);
+    expect(res.items[0].id).toBe("k1");
+    expect(res.errors).toBeDefined();
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors?.[0].corpusId).toBe("c-2222");
+    expect(res.errors?.[0].message).toContain("upstream gemini 400");
+  });
+
+  it("全部 rejected → 抛聚合错误（不静默丢失）", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        buildErrorResponse(502, "EMBEDDING_FAILED", "upstream gemini 400"),
+      )
+      .mockResolvedValueOnce(
+        buildErrorResponse(503, "EMBEDDING_FAILED", "upstream gemini 503"),
+      );
+
+    await expect(
+      searchAcrossCorpora(["c-1111", "c-2222"], {
+        query: "harness",
+        mode: "hybrid",
+      }),
+    ).rejects.toThrow(/upstream gemini/);
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -244,6 +244,7 @@ def _map_exception_to_http(exc: KnowledgeError) -> HTTPException:
     - 404: 资源不存在
     - 409: 版本冲突
     - 500: 服务器内部错误
+    - 502: 上游服务错误（vendor / Embedding 等外部依赖）
     """
     if isinstance(exc, CorpusNotFound):
         logger.warning("corpus_not_found", details=exc.details)

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -266,7 +266,16 @@ def _map_exception_to_http(exc: KnowledgeError) -> HTTPException:
             detail={"code": exc.code, "message": str(exc), "details": exc.details},
         )
 
-    if isinstance(exc, (EmbeddingFailed, SearchError)):
+    if isinstance(exc, EmbeddingFailed):
+        # 上游 Embedding 服务故障（vendor 4xx/5xx、连接异常等）：
+        # 语义上属于 Bad Gateway 而非内部错误，便于前端区分"自身可重试"与"上游修复后再试"。
+        logger.error("infrastructure_error", details=exc.details)
+        return HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={"code": exc.code, "message": str(exc), "details": exc.details},
+        )
+
+    if isinstance(exc, SearchError):
         logger.error("infrastructure_error", details=exc.details)
         return HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/apps/negentropy/src/negentropy/knowledge/embedding.py
+++ b/apps/negentropy/src/negentropy/knowledge/embedding.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import urlparse
 from uuid import UUID
 
 from negentropy.logging import get_logger
@@ -21,6 +22,33 @@ from negentropy.logging import get_logger
 from .exceptions import EmbeddingFailed
 
 logger = get_logger("negentropy.knowledge.embedding")
+
+
+def _api_base_host(api_base: Any) -> str:
+    """从 api_base 提取 host 用于日志（脱敏 path/query/credentials）。"""
+    if not isinstance(api_base, str) or not api_base:
+        return ""
+    try:
+        parsed = urlparse(api_base)
+        return parsed.netloc or parsed.path or ""
+    except Exception:
+        return ""
+
+
+def _extract_upstream_text(exc: BaseException) -> str:
+    """从 litellm 抛出的异常链中提取上游原始响应文本（已被 litellm 脱敏 URL）。"""
+    cur: BaseException | None = exc
+    seen: set[int] = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        text = getattr(cur, "text", None) or getattr(cur, "message", None)
+        if isinstance(text, str) and text:
+            return text[:500]
+        if isinstance(text, (bytes, bytearray)):
+            return text.decode("utf-8", errors="replace")[:500]
+        cur = cur.__cause__ or cur.__context__
+    return ""
+
 
 EmbeddingFn = Callable[[str], Awaitable[list[float]]]
 BatchEmbeddingFn = Callable[[list[str]], Awaitable[list[list[float]]]]
@@ -161,6 +189,15 @@ def build_embedding_fn(embedding_config_id: UUID | str | None = None) -> Embeddi
 
         model_name, extra_kwargs = await _resolve_embedding(embedding_config_id)
 
+        logger.debug(
+            "embedding_request",
+            model=model_name,
+            api_base_host=_api_base_host(extra_kwargs.get("api_base")),
+            input_count=1,
+            text_preview=cleaned[:50],
+            kwargs_keys=sorted(k for k in extra_kwargs.keys() if k != "api_key"),
+        )
+
         try:
             import litellm
 
@@ -176,7 +213,14 @@ def build_embedding_fn(embedding_config_id: UUID | str | None = None) -> Embeddi
                 context=f"embed({cleaned[:50]}...)",
             )
         except (TimeoutError, Exception) as exc:
-            logger.error("embedding_request_failed", model=model_name, exc_info=exc)
+            upstream_text = _extract_upstream_text(exc)
+            logger.error(
+                "embedding_request_failed",
+                model=model_name,
+                api_base_host=_api_base_host(extra_kwargs.get("api_base")),
+                upstream_response_text=upstream_text,
+                exc_info=exc,
+            )
             raise EmbeddingFailed(
                 text_preview=cleaned[:100],
                 model=model_name,
@@ -241,6 +285,14 @@ def build_batch_embedding_fn(embedding_config_id: UUID | str | None = None) -> B
             batch_results: list[list[float]] = [[] for _ in batch_texts]
 
             if non_empty_texts:
+                logger.debug(
+                    "batch_embedding_request",
+                    model=model_name,
+                    api_base_host=_api_base_host(extra_kwargs.get("api_base")),
+                    input_count=len(non_empty_texts),
+                    text_preview=non_empty_texts[0][:50],
+                    kwargs_keys=sorted(k for k in extra_kwargs.keys() if k != "api_key"),
+                )
                 try:
                     import litellm
 
@@ -260,9 +312,12 @@ def build_batch_embedding_fn(embedding_config_id: UUID | str | None = None) -> B
                         context=f"batch_embed({len(non_empty_texts)} texts)",
                     )
                 except (TimeoutError, Exception) as exc:
+                    upstream_text = _extract_upstream_text(exc)
                     logger.error(
                         "batch_embedding_request_failed",
                         model=model_name,
+                        api_base_host=_api_base_host(extra_kwargs.get("api_base")),
+                        upstream_response_text=upstream_text,
                         batch_size=len(non_empty_texts),
                         exc_info=exc,
                     )

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -2534,9 +2534,26 @@ class KnowledgeService:
 
         # RRF 模式: 使用专门的 RRF 检索方法
         if config.mode == "rrf":
-            if not self._embedding_fn:
-                logger.warning("rrf_search_failed_no_embedding", corpus_id=str(corpus_id))
-                # 回退到关键词检索
+            from .exceptions import EmbeddingFailed
+
+            query_embedding = None
+            if self._embedding_fn:
+                try:
+                    query_embedding = await self._embedding_fn(query)
+                except EmbeddingFailed as exc:
+                    logger.warning(
+                        "rrf_embedding_failed_falling_back_to_keyword",
+                        corpus_id=str(corpus_id),
+                        reason=exc.details.get("reason", str(exc)),
+                    )
+
+            if query_embedding is None:
+                if not self._embedding_fn:
+                    logger.warning(
+                        "rrf_search_failed_no_embedding",
+                        corpus_id=str(corpus_id),
+                    )
+                # 回退到关键词检索（embedding 不可用 / embedding 失败）
                 keyword_matches = await self._repository.keyword_search(
                     corpus_id=corpus_id,
                     app_name=app_name,
@@ -2567,7 +2584,6 @@ class KnowledgeService:
                     matches=keyword_matches,
                 )
 
-            query_embedding = await self._embedding_fn(query)
             results = await self._repository.rrf_search(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -2607,7 +2623,22 @@ class KnowledgeService:
         # 其他模式: semantic, keyword, hybrid
         query_embedding = None
         if config.mode in ("semantic", "hybrid") and self._embedding_fn:
-            query_embedding = await self._embedding_fn(query)
+            from .exceptions import EmbeddingFailed
+
+            try:
+                query_embedding = await self._embedding_fn(query)
+            except EmbeddingFailed as exc:
+                # hybrid 优雅降级：失败时仅以 keyword 检索回退；
+                # semantic 显式失败传播：纯语义模式无意义降级。
+                if config.mode == "hybrid":
+                    logger.warning(
+                        "hybrid_embedding_failed_falling_back_to_keyword",
+                        corpus_id=str(corpus_id),
+                        reason=exc.details.get("reason", str(exc)),
+                    )
+                    query_embedding = None
+                else:
+                    raise
 
         semantic_matches: list[KnowledgeMatch] = []
         keyword_matches: list[KnowledgeMatch] = []

--- a/apps/negentropy/tests/unit_tests/knowledge/test_search_resilience.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_search_resilience.py
@@ -1,0 +1,155 @@
+"""Knowledge 搜索韧性单元测试
+
+覆盖 Embedding 失败时各检索模式的降级行为：
+- ``hybrid``：embedding 失败 → 回退到 keyword-only（不抛异常）
+- ``rrf``：embedding 失败 → 回退到 keyword-only（不抛异常）
+- ``semantic``：embedding 失败 → 显式传播 ``EmbeddingFailed``
+
+以及 API 层 ``EmbeddingFailed`` 映射到 ``502 Bad Gateway`` 的契约。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.exceptions import EmbeddingFailed, SearchError
+from negentropy.knowledge.service import KnowledgeService
+from negentropy.knowledge.types import KnowledgeMatch, SearchConfig
+
+
+def _build_match(*, content: str = "k", score: float = 0.5) -> KnowledgeMatch:
+    return KnowledgeMatch(
+        id=uuid4(),
+        content=content,
+        source_uri="test://uri",
+        metadata={},
+        semantic_score=0.0,
+        keyword_score=score,
+        combined_score=score,
+    )
+
+
+class _StubRepository:
+    """最小化 KnowledgeRepository 替身，仅提供搜索方法的可断言桩。"""
+
+    def __init__(self, keyword_results: list[KnowledgeMatch] | None = None) -> None:
+        self.keyword_search = AsyncMock(return_value=keyword_results or [_build_match()])
+        self.semantic_search = AsyncMock(return_value=[])
+        self.rrf_search = AsyncMock(return_value=[])
+        self.hybrid_search = AsyncMock(return_value=[])
+
+
+@pytest.fixture
+def stub_repository() -> _StubRepository:
+    return _StubRepository()
+
+
+@pytest.fixture
+def service(stub_repository: _StubRepository) -> KnowledgeService:
+    """构造一个最小可用的 KnowledgeService，桩掉所有外部依赖。"""
+
+    async def failing_embedding(text: str) -> list[float]:
+        raise EmbeddingFailed(
+            text_preview=text[:50],
+            model="gemini/text-embedding-004",
+            reason="upstream 400 simulated",
+        )
+
+    svc = KnowledgeService(
+        repository=stub_repository,  # type: ignore[arg-type]
+        embedding_fn=failing_embedding,
+    )
+    # 桩掉与本测无关的私有 helper，避免触发 DB 调用
+    svc._hydrate_match_metadata = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    svc._lift_hierarchical_matches = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    svc._record_match_retrievals = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    return svc
+
+
+class TestSearchResilience:
+    @pytest.mark.asyncio
+    async def test_hybrid_falls_back_to_keyword_on_embedding_failure(
+        self, service: KnowledgeService, stub_repository: _StubRepository
+    ) -> None:
+        """hybrid 模式：embedding 失败 → 仅以 keyword 检索回退，不抛异常"""
+        results = await service.search(
+            corpus_id=uuid4(),
+            app_name="negentropy",
+            query="harness",
+            config=SearchConfig(mode="hybrid", limit=10),
+        )
+
+        # 关键断言：返回 keyword 结果而不抛 EmbeddingFailed
+        assert len(results) >= 1
+        # semantic_search 不应被调用（query_embedding=None 时被守卫跳过）
+        stub_repository.semantic_search.assert_not_called()
+        # keyword_search 应被调用（hybrid 分支天然要走）
+        stub_repository.keyword_search.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rrf_falls_back_to_keyword_on_embedding_failure(
+        self, service: KnowledgeService, stub_repository: _StubRepository
+    ) -> None:
+        """rrf 模式：embedding 失败 → 走与 ``not embedding_fn`` 等价的 keyword 回退路径"""
+        results = await service.search(
+            corpus_id=uuid4(),
+            app_name="negentropy",
+            query="harness",
+            config=SearchConfig(mode="rrf", limit=10),
+        )
+
+        assert len(results) >= 1
+        stub_repository.rrf_search.assert_not_called()
+        stub_repository.keyword_search.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_semantic_propagates_embedding_failure(self, service: KnowledgeService) -> None:
+        """semantic 模式：embedding 失败 → 显式传播 ``EmbeddingFailed``（无意义降级）"""
+        with pytest.raises(EmbeddingFailed):
+            await service.search(
+                corpus_id=uuid4(),
+                app_name="negentropy",
+                query="harness",
+                config=SearchConfig(mode="semantic", limit=10),
+            )
+
+
+class TestExceptionMapping:
+    def test_embedding_failed_maps_to_502(self) -> None:
+        """EmbeddingFailed → HTTP 502 Bad Gateway，保留 EMBEDDING_FAILED code"""
+        from negentropy.knowledge.api import _map_exception_to_http
+
+        exc = EmbeddingFailed(
+            text_preview="harness",
+            model="gemini/text-embedding-004",
+            reason="upstream 400",
+        )
+
+        http_exc = _map_exception_to_http(exc)
+
+        assert http_exc.status_code == 502
+        detail: Any = http_exc.detail
+        assert isinstance(detail, dict)
+        assert detail["code"] == "EMBEDDING_FAILED"
+        assert "harness" in detail["details"]["text_preview"]
+
+    def test_search_error_remains_500(self) -> None:
+        """SearchError 维持 500（与 EmbeddingFailed 区分自身错误 vs 上游错误）"""
+        from negentropy.knowledge.api import _map_exception_to_http
+
+        exc = SearchError(
+            corpus_id=str(uuid4()),
+            search_mode="hybrid",
+            reason="internal",
+        )
+
+        http_exc = _map_exception_to_http(exc)
+
+        assert http_exc.status_code == 500
+        detail: Any = http_exc.detail
+        assert isinstance(detail, dict)
+        assert detail["code"] == "SEARCH_ERROR"

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -527,3 +527,27 @@
 - **同类问题影响**：
   1. **同 endpoint 历史漏洞**：[ISSUE-016](#issue-016) 已修复 `app_name NOT NULL` 缺失导致的 500，本次修复 `uq_wiki_pub_catalog_active` 触发的 500，二者同因不同果——「endpoint 缺失结构化错误处理」是结构性问题，不是单次 bugfix。
   2. **`update_wiki_publication` / `archive` / 等同类端点**未做约束冲突防御，未来若新增约束（如 `theme` 唯一性、跨 app 互斥），会复现同型问题；建议在 service / DAO 层统一接入领域异常 + 端点层 `_map_exception_to_http` 路径（本次按最小干预原则未推进，记录为可观测的债务）。
+
+---
+
+## ISSUE-026 Knowledge Base Retrieve 全屏空白：前端聚合层静默吞噬 rejection × 后端 hybrid 缺降级路径
+
+- **表因**：用户在 `/knowledge/base` 页输入查询词、勾选 Corpus、选择 hybrid 模式，点 Retrieve 后**结果区完全空白且无任何错误提示**。后端日志可见 `POST /knowledge/base/{id}/search → 500` 与 `infrastructure_error`（litellm 调 Gemini `:batchEmbedContents` 上游返 `400 {"error":{"message":"request body doesn't contain valid prompts"}}`）。
+- **根因**（双层 Bug，缺一不可）：
+  1. **前端**（`apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts::searchAcrossCorpora` 旧实现）：`Promise.allSettled` 后只读取 `fulfilled` 分支，`rejected` 直接 `forEach` 跳过、调用方收到 `{count:0, items:[]}` —— 当**全部** Corpus 均失败（或仅勾选一个）时无错误抛出。`handleRetrieve`（`app/knowledge/base/page.tsx`）走"成功路径"，`setRetrievalResults([])` 致 UI 空白且不触发 `retrievalError` banner。
+  2. **后端**（`apps/negentropy/src/negentropy/knowledge/service.py::search` 旧实现）：hybrid / rrf 模式下 `await self._embedding_fn(query)` **未捕获 `EmbeddingFailed`**，外部 Embedding 上游故障直接传播为 500，丧失"keyword 仍可用"的优雅降级。`api.py::_map_exception_to_http` 将 `EmbeddingFailed` 与 `SearchError` 合并映射到 500，前端无法区分"自身错误（重试无意义）"与"上游错误（修复后再试）"。
+- **处理方式**（分层防御 + 诊断仪器化）：
+  1. **前端**：`searchAcrossCorpora` 改为聚合三态：全部 fulfilled → 原结果；部分 rejected → 返回 `errors[]` 字段 + 成功项；全部 rejected → 抛聚合错误（合并 reasons，限长 200 字符）。`SearchResults` 类型扩展可选 `errors?: SearchResultError[]`。`handleRetrieve` 在 `errors` 非空时通过 `toast.warning` 透出原因，避免静默丢失。
+  2. **后端 service**：hybrid 模式 `try { embedding_fn(query) } catch EmbeddingFailed` → `query_embedding=None` 走既有 keyword-only 守卫；rrf 模式失败时走与 `not embedding_fn` 等价的 keyword 回退路径；semantic 模式仍传播 `EmbeddingFailed`（纯语义无降级语义）。**复用**已有 `_repository.keyword_search` / `_hydrate_match_metadata` / `_lift_hierarchical_matches`，零新接口。
+  3. **后端 api**：拆分 `_map_exception_to_http` 中 `EmbeddingFailed` 分支映射到 `502 Bad Gateway`（保留 `code="EMBEDDING_FAILED"`）；`SearchError` 维持 500。
+  4. **诊断仪器化**：`embedding.py::embed/batch_embed` 调用 litellm 前后增加结构化日志：`api_base_host`（脱敏 path/credentials 仅留 host）、`input_count`、`text_preview`、`kwargs_keys`；失败时附加 `upstream_response_text`（从 `MaskedHTTPStatusError.text` 沿异常链 `__cause__/__context__` 提取，已被 litellm 脱敏 URL，限长 500 字节）。后续同类问题用户可一眼定位"实际请求到了哪个 host + 上游原始错误"，无需 `litellm._turn_on_debug()` 全开。
+  5. **测试锁定**：新增 `tests/unit_tests/knowledge/test_search_resilience.py`（5 例：hybrid/rrf 降级、semantic 传播、`EmbeddingFailed→502`、`SearchError→500`）+ `tests/unit/knowledge/searchAcrossCorpora.test.ts`（3 例：全 fulfilled / 部分 rejected / 全 rejected）。
+- **后续防范**：
+  1. **`Promise.allSettled` 必须聚合 rejection**：本仓库前端任何 `Promise.allSettled` 调用点都必须显式处理 `rejected` 分支（聚合抛错或 errors[] 暴露），**禁止**仅 `if (status === "fulfilled")` 的"沉默扫描"模式。建议在 `apps/negentropy-ui/features/*/utils/*-api.ts` 全文检索 `Promise.allSettled` 与 `status === "fulfilled"` 做一次性扫荡。
+  2. **外部依赖错误码语义**：调用 vendor / 上游 API 失败应映射到 `502 Bad Gateway`（不是 500），让前端能区分"我自己的 bug"与"对端坏了"。本次以 `EmbeddingFailed` 为模板，后续 `Reranker / LLMExtractor / EntityExtraction` 等同类外部依赖失败应同步对齐。
+  3. **hybrid / 多源融合检索必须保留至少一条降级路径**：任何"语义 + 关键词"融合模式当语义信号不可用时应自动退化为关键词，反之亦然。本次 `service.py::search` 已落实 hybrid 与 rrf 两种降级；新增检索模式（如未来 `cross_encoder_rerank`）需走同等"任一信号失效仍可返回结果"的契约。
+  4. **诊断信号优先于"加日志再说"**：embedding / vendor 调用类的失败日志必须包含 `api_base_host`（脱敏）+ `upstream_response_text`，否则用户拿到日志也无法定位上游归属（vendor / 自建代理 / 网关）。这次将该模式落到 `embedding.py`，可作为新增 vendor 调用模板。
+- **同类问题影响**：
+  1. **前端聚合层**：`fetchCatalogTree` / `searchGraph` / 任何 `Promise.allSettled` + 多 corpus / 多 source 聚合的端点都需复盘是否有相同"沉默丢失 rejected"反模式。
+  2. **后端外部依赖错误码**：`Reranker.rerank` / `LLMExtractor.extract` / `EntityExtractionError` / `RelationExtractionError` 等同型 `InfrastructureError` 子类目前仍走默认 500 通道，后续可统一上调到 502（与 `EmbeddingFailed` 对齐）。
+  3. **环境侧排查（独立于代码修复）**：本次错误响应 JSON `{"error":{"message":"..."}}` 缺失 Google 官方必有的 `code/status` 字段，强烈倾向是 `NATIVE_GEMINI_BASE_URL` 被覆写到了非官方代理（如 `gemini-balance` / `one-api`）的 native API 模拟，其 `:batchEmbedContents` 校验不完整。用户可执行 `echo $NATIVE_GEMINI_BASE_URL` 与 `curl -H "x-goog-api-key: $KEY" -H "Content-Type: application/json" -d '{"requests":[{"model":"models/text-embedding-004","content":{"parts":[{"text":"hi"}]}}]}' http://localhost:3392/api/gemini/v1beta/models/text-embedding-004:batchEmbedContents` 直接抓上游响应定位。本次代码修复**不消除**根因故障（仍需用户配置侧排查），但**消除**"故障 → 无声空白"链路，确保用户可见可诊断。


### PR DESCRIPTION
# 背景

- **本次变更要解决的问题**：用户在 `/knowledge/base` 输入查询、勾选 Corpus、选择 hybrid 模式后点 Retrieve，**结果区完全空白且无任何错误提示**。后端日志可见 `POST /knowledge/base/{id}/search → 500` + `infrastructure_error`（litellm 调 Gemini `:batchEmbedContents` 上游 400）。这是一个**双层 Bug 同因联动**：前端聚合层静默吞噬 rejection × 后端 hybrid 缺降级路径 × 上游故障被 500 模糊化。
- **关联上下文 / Issue / 文档**：
  - 详细复盘：[`docs/issue.md` ISSUE-026](../blob/ThreeFish-AI/fix-kb-retrieve-blank/docs/issue.md)
  - 相关组件：`KnowledgeService.search` / `_map_exception_to_http` / `searchAcrossCorpora` / `embedding.py`

# 核心变更

- **前端聚合三态化**（`features/knowledge/utils/knowledge-api.ts::searchAcrossCorpora`）：旧实现 `Promise.allSettled` 仅取 fulfilled、rejected 静默丢失，全部 Corpus 失败时返回 `{count:0, items:[]}` 走"成功路径"使 UI 空白；改为聚合三态——全成功 / 部分失败（返回 `errors[]` + 成功项）/ 全失败（抛聚合 `KnowledgeError`，**保留 `code`**：所有失败 code 一致时透传原 code，混合时退化为 `AGGREGATED_SEARCH_ERRORS`，并在 `details.errors` 携带逐条明细）。`SearchResultError` 增加可选 `code?: string` 字段，便于调用方按上游 / 自身错误分流。
- **`handleRetrieve` 透出**（`app/knowledge/base/page.tsx`）：`errors` 非空时 `toast.warning` 展示 `[corpusId前 8] message`，避免静默丢失。
- **后端 hybrid / rrf 优雅降级**（`knowledge/service.py::search`）：旧实现 hybrid / rrf 模式下 `await embedding_fn(query)` **未捕获 `EmbeddingFailed`**，外部 Embedding 故障直接 500。改为：hybrid 失败 → 仅以 keyword 检索回退；rrf 失败 → 走与 `not embedding_fn` 等价的 keyword 回退路径；semantic 仍传播 `EmbeddingFailed`（纯语义模式无意义降级）。**复用** `_repository.keyword_search` / `_hydrate_match_metadata` / `_lift_hierarchical_matches`，零新接口。
- **502 上游错误码语义**（`knowledge/api.py::_map_exception_to_http`）：拆分 `EmbeddingFailed` 分支映射到 `502 Bad Gateway`（保留 `code="EMBEDDING_FAILED"`），与 `SearchError` 自身错误的 `500` 区分；docstring 同步补 `502: 上游服务错误（vendor / Embedding 等外部依赖）`。
- **Embedding 调用诊断仪器化**（`knowledge/embedding.py`）：调 litellm 前后增加结构化日志——`api_base_host`（脱敏 path/credentials 仅留 host）+ `input_count` + `text_preview` + `kwargs_keys`；失败附 `upstream_response_text`（沿异常链 `__cause__/__context__` 提取 `MaskedHTTPStatusError.text`，已被 litellm 脱敏 URL，限长 500 字节）。后续同类问题用户可一眼定位"实际请求到了哪个 host + 上游原始错误"，无需 `litellm._turn_on_debug()` 全开。

# 风险与回滚

- **主要风险**：
  1. hybrid / rrf 模式下 Embedding 失败时**静默退化为 keyword-only**，搜索质量下降但**不再 500**——这是显式的"可用性优先"取舍，与 `not embedding_fn` 已有路径完全一致。
  2. 502 错误码替代部分原 500 响应，前端旧代码若按 `status === 500` 严匹配会漏接（已在 `searchAcrossCorpora` 透传 `code`，但其它 endpoint 暂未对齐）。
  3. embedding 日志体积增加（每次调用多 4 个字段），失败时多 ≤500 字节 `upstream_response_text`。
- **回滚方式**：直接 revert 此 PR 即可，无 schema / DB 迁移、无新增依赖、无配置项。

# 验证证据

- **单元测试**：
  - 后端 `apps/negentropy/tests/unit_tests/knowledge/test_search_resilience.py` **5 例**（hybrid / rrf 降级、semantic 传播、`EmbeddingFailed→502`、`SearchError→500`），全部通过。
  - 前端 `apps/negentropy-ui/tests/unit/knowledge/searchAcrossCorpora.test.ts` **4 例**（全 fulfilled / 部分 rejected + `code` 透传 / 全 rejected 同 code 透传 / 全 rejected 混合 code 退化），全部通过。
  - `tests/unit/knowledge/KnowledgeBasePage.test.tsx` **33 例**无回归。
- **集成测试**：暂无（涉及外部 vendor，本次以 mock 单测覆盖三态契约）。
- **E2E / Workflow**：依赖 `NATIVE_GEMINI_BASE_URL` 真实可用 Embedding 上游，本地无法稳定复现，由用户在配置侧排查（详见 ISSUE-026 附 curl 命令）。
- **静态检查**：`tsc --noEmit` 无错；pre-commit 钩子（ruff lint / ruff format / ESLint）全部 Passed。

# 影响范围

- **前端**：`apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts`（`SearchResultError` 类型扩展、`searchAcrossCorpora` 聚合三态）；`apps/negentropy-ui/app/knowledge/base/page.tsx`（`toast.warning` 透出）。
- **后端**：`apps/negentropy/src/negentropy/knowledge/service.py`（hybrid / rrf 降级）、`api.py`（502 拆分 + docstring）、`embedding.py`（诊断日志）。
- **GitHub Actions / 文档**：无 CI 变更；`docs/issue.md` 追加 ISSUE-026（含后续防范 4 条 + 同类问题影响清单 3 条）。

# Next Best Action

- **`Promise.allSettled` 沉默扫描反模式排查**：在 `apps/negentropy-ui/features/*/utils/*-api.ts` 全文检索 `Promise.allSettled` 与 `status === "fulfilled"` 做一次性扫荡，参照本次 `searchAcrossCorpora` 模板补齐 rejection 聚合（`fetchCatalogTree` / `searchGraph` 等多源端点优先）。
- **InfrastructureError 502 对齐**：`Reranker.rerank` / `LLMExtractor.extract` / `EntityExtractionError` / `RelationExtractionError` 等同型外部依赖失败目前仍走 500 通道，可统一上调到 502。
- **配置侧排查（独立于代码修复）**：用户检查 `NATIVE_GEMINI_BASE_URL` 是否被覆写到非官方代理（`gemini-balance` / `one-api` 等），`:batchEmbedContents` 校验不完整。本次代码修复**不消除**根因故障，但**消除**"故障 → 无声空白"链路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)