### PR TITLE
fix(knowledge): 查询时 honor Corpus 自配 embedding 模型，修复 query/index 模型不一致 (ISSUE-028)

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -2532,14 +2532,19 @@ class KnowledgeService:
             query_preview=query_preview,
         )
 
+        # 与 _attach_embeddings 索引侧对称：优先使用 corpus 自配的 embedding 模型，
+        # 落空再退回 service 默认 fn。修复 query/index embedding 模型不一致 (ISSUE-028)。
+        corpus_config = await self._get_corpus_config(corpus_id)
+        embedding_fn = self._resolve_embedding_fn(corpus_config)
+
         # RRF 模式: 使用专门的 RRF 检索方法
         if config.mode == "rrf":
             from .exceptions import EmbeddingFailed
 
             query_embedding = None
-            if self._embedding_fn:
+            if embedding_fn:
                 try:
-                    query_embedding = await self._embedding_fn(query)
+                    query_embedding = await embedding_fn(query)
                 except EmbeddingFailed as exc:
                     logger.warning(
                         "rrf_embedding_failed_falling_back_to_keyword",
@@ -2548,7 +2553,7 @@ class KnowledgeService:
                     )
 
             if query_embedding is None:
-                if not self._embedding_fn:
+                if not embedding_fn:
                     logger.warning(
                         "rrf_search_failed_no_embedding",
                         corpus_id=str(corpus_id),
@@ -2622,11 +2627,11 @@ class KnowledgeService:
 
         # 其他模式: semantic, keyword, hybrid
         query_embedding = None
-        if config.mode in ("semantic", "hybrid") and self._embedding_fn:
+        if config.mode in ("semantic", "hybrid") and embedding_fn:
             from .exceptions import EmbeddingFailed
 
             try:
-                query_embedding = await self._embedding_fn(query)
+                query_embedding = await embedding_fn(query)
             except EmbeddingFailed as exc:
                 # hybrid 优雅降级：失败时仅以 keyword 检索回退；
                 # semantic 显式失败传播：纯语义模式无意义降级。
@@ -2888,6 +2893,21 @@ class KnowledgeService:
         if value is None:
             return None
         return str(value)
+
+    def _resolve_embedding_fn(self, corpus_config: dict[str, Any] | None) -> EmbeddingFn | None:
+        """根据 corpus.config['models']['embedding_config_id'] 选择 embedding fn。
+
+        与 ``_attach_embeddings`` 索引侧路径对称：corpus 显式 pin → 一次性构建 corpus 专属
+        闭包（``build_embedding_fn`` 内部走 ``model_resolver._cache`` 的 60s TTL ``embedding:<uuid>``
+        键，重复 search 命中即免 DB 查询）；未 pin → 退回 ``self._embedding_fn``（service 启动时
+        锁定的全局默认 fn），保留既有"未配置 corpus 走默认"语义。
+        """
+        embedding_config_id = self._extract_embedding_config_id(corpus_config)
+        if embedding_config_id is not None:
+            from .embedding import build_embedding_fn
+
+            return build_embedding_fn(embedding_config_id)
+        return self._embedding_fn
 
     async def _attach_embeddings(
         self,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_search_corpus_embedding.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_search_corpus_embedding.py
@@ -1,0 +1,206 @@
+"""Knowledge 搜索查询时使用 corpus 自配 embedding 模型的契约测试
+
+覆盖 ISSUE-028 修复：``search()`` 必须按 ``corpus.config.models.embedding_config_id``
+解析 embedding fn，使索引侧 (``_attach_embeddings``) 与查询侧契约对称：
+
+- corpus 显式 pin → 调 corpus 专属 fn（**不**用 service 默认 fn）；
+- corpus 未 pin → 退回 service 默认 fn（``self._embedding_fn``）；
+- corpus pin 的 fn 失败 → hybrid 仍走 keyword 兜底（ISSUE-026 契约不被破坏）；
+- rrf 模式同样 honor corpus pin；
+- semantic 模式 corpus pin 失败 → ``EmbeddingFailed`` 上抛（→ api.py 映射 502）。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.exceptions import EmbeddingFailed
+from negentropy.knowledge.service import KnowledgeService
+from negentropy.knowledge.types import KnowledgeMatch, SearchConfig
+
+_PINNED_EMBEDDING_CONFIG_ID = "00000000-0000-0000-0000-000000000aaa"
+_PINNED_VECTOR = [0.11, 0.22, 0.33]
+
+
+def _build_match(*, score: float = 0.5) -> KnowledgeMatch:
+    return KnowledgeMatch(
+        id=uuid4(),
+        content="k",
+        source_uri="test://uri",
+        metadata={},
+        semantic_score=0.0,
+        keyword_score=score,
+        combined_score=score,
+    )
+
+
+class _StubRepository:
+    def __init__(self) -> None:
+        self.keyword_search = AsyncMock(return_value=[_build_match()])
+        self.semantic_search = AsyncMock(return_value=[_build_match(score=0.7)])
+        self.rrf_search = AsyncMock(return_value=[_build_match(score=0.8)])
+        self.hybrid_search = AsyncMock(return_value=[])
+        self.get_corpus_by_id = AsyncMock(return_value=None)
+
+
+def _make_service(
+    *,
+    repository: _StubRepository,
+    default_embedding_fn: AsyncMock | None = None,
+) -> KnowledgeService:
+    """构建带桩的 KnowledgeService。"""
+    svc = KnowledgeService(
+        repository=repository,  # type: ignore[arg-type]
+        embedding_fn=default_embedding_fn,
+    )
+    svc._hydrate_match_metadata = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    svc._lift_hierarchical_matches = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    svc._record_match_retrievals = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    return svc
+
+
+class TestSearchHonorsCorpusEmbeddingConfig:
+    @pytest.mark.asyncio
+    async def test_hybrid_uses_corpus_pinned_embedding_fn(self) -> None:
+        """corpus pin embedding_config_id → 走 corpus 专属 fn，service 默认 fn 不被调用。"""
+        repo = _StubRepository()
+        default_fn = AsyncMock(return_value=[0.99, 0.99, 0.99])
+        svc = _make_service(repository=repo, default_embedding_fn=default_fn)
+
+        svc._get_corpus_config = AsyncMock(  # type: ignore[method-assign]
+            return_value={"models": {"embedding_config_id": _PINNED_EMBEDDING_CONFIG_ID}}
+        )
+
+        pinned_fn = AsyncMock(return_value=_PINNED_VECTOR)
+        with patch(
+            "negentropy.knowledge.embedding.build_embedding_fn",
+            return_value=pinned_fn,
+        ) as build_fn:
+            await svc.search(
+                corpus_id=uuid4(),
+                app_name="negentropy",
+                query="harness",
+                config=SearchConfig(mode="hybrid", limit=10),
+            )
+
+        build_fn.assert_called_once_with(_PINNED_EMBEDDING_CONFIG_ID)
+        pinned_fn.assert_awaited_once_with("harness")
+        default_fn.assert_not_called()
+        repo.semantic_search.assert_awaited()
+        # 验证传入 semantic_search 的 query_embedding 是 corpus pin fn 的产物
+        called_kwargs = repo.semantic_search.await_args.kwargs
+        assert called_kwargs["query_embedding"] == _PINNED_VECTOR
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_service_embedding_fn_when_no_pin(self) -> None:
+        """corpus.config 无 embedding_config_id → 退回 service 默认 fn。"""
+        repo = _StubRepository()
+        default_fn = AsyncMock(return_value=[0.99, 0.99, 0.99])
+        svc = _make_service(repository=repo, default_embedding_fn=default_fn)
+
+        svc._get_corpus_config = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        with patch("negentropy.knowledge.embedding.build_embedding_fn") as build_fn:
+            await svc.search(
+                corpus_id=uuid4(),
+                app_name="negentropy",
+                query="harness",
+                config=SearchConfig(mode="hybrid", limit=10),
+            )
+
+        build_fn.assert_not_called()
+        default_fn.assert_awaited_once_with("harness")
+
+    @pytest.mark.asyncio
+    async def test_corpus_pinned_fn_failure_keeps_hybrid_keyword_fallback(self) -> None:
+        """corpus pin 的 fn 失败 → hybrid 仍走 keyword 兜底（ISSUE-026 契约不被破坏）。"""
+        repo = _StubRepository()
+        svc = _make_service(repository=repo, default_embedding_fn=AsyncMock())
+
+        svc._get_corpus_config = AsyncMock(  # type: ignore[method-assign]
+            return_value={"models": {"embedding_config_id": _PINNED_EMBEDDING_CONFIG_ID}}
+        )
+
+        async def failing_pinned(text: str) -> list[float]:
+            raise EmbeddingFailed(
+                text_preview=text[:50],
+                model="openai/text-embedding-3-small",
+                reason="vendor 4xx simulated",
+            )
+
+        with patch(
+            "negentropy.knowledge.embedding.build_embedding_fn",
+            return_value=failing_pinned,
+        ):
+            results = await svc.search(
+                corpus_id=uuid4(),
+                app_name="negentropy",
+                query="harness",
+                config=SearchConfig(mode="hybrid", limit=10),
+            )
+
+        assert len(results) >= 1
+        repo.semantic_search.assert_not_called()
+        repo.keyword_search.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rrf_mode_honors_corpus_pin(self) -> None:
+        """rrf 分支同样调 corpus 专属 fn。"""
+        repo = _StubRepository()
+        default_fn = AsyncMock(return_value=[0.99, 0.99, 0.99])
+        svc = _make_service(repository=repo, default_embedding_fn=default_fn)
+
+        svc._get_corpus_config = AsyncMock(  # type: ignore[method-assign]
+            return_value={"models": {"embedding_config_id": _PINNED_EMBEDDING_CONFIG_ID}}
+        )
+
+        pinned_fn = AsyncMock(return_value=_PINNED_VECTOR)
+        with patch(
+            "negentropy.knowledge.embedding.build_embedding_fn",
+            return_value=pinned_fn,
+        ):
+            svc._reranker.rerank = AsyncMock(side_effect=lambda q, m: m)  # type: ignore[method-assign]
+            await svc.search(
+                corpus_id=uuid4(),
+                app_name="negentropy",
+                query="harness",
+                config=SearchConfig(mode="rrf", limit=10),
+            )
+
+        pinned_fn.assert_awaited_once_with("harness")
+        default_fn.assert_not_called()
+        repo.rrf_search.assert_awaited()
+        called_kwargs = repo.rrf_search.await_args.kwargs
+        assert called_kwargs["query_embedding"] == _PINNED_VECTOR
+
+    @pytest.mark.asyncio
+    async def test_semantic_mode_propagates_pinned_fn_failure(self) -> None:
+        """semantic 模式 corpus pin 失败 → EmbeddingFailed 上抛（→ api.py 映射 502）。"""
+        repo = _StubRepository()
+        svc = _make_service(repository=repo, default_embedding_fn=AsyncMock())
+
+        svc._get_corpus_config = AsyncMock(  # type: ignore[method-assign]
+            return_value={"models": {"embedding_config_id": _PINNED_EMBEDDING_CONFIG_ID}}
+        )
+
+        async def failing_pinned(text: str) -> list[float]:
+            raise EmbeddingFailed(
+                text_preview=text[:50],
+                model="openai/text-embedding-3-small",
+                reason="vendor 5xx simulated",
+            )
+
+        with patch(
+            "negentropy.knowledge.embedding.build_embedding_fn",
+            return_value=failing_pinned,
+        ):
+            with pytest.raises(EmbeddingFailed):
+                await svc.search(
+                    corpus_id=uuid4(),
+                    app_name="negentropy",
+                    query="harness",
+                    config=SearchConfig(mode="semantic", limit=10),
+                )

--- a/apps/negentropy/tests/unit_tests/knowledge/test_search_resilience.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_search_resilience.py
@@ -67,6 +67,8 @@ def service(stub_repository: _StubRepository) -> KnowledgeService:
     svc._hydrate_match_metadata = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
     svc._lift_hierarchical_matches = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
     svc._record_match_retrievals = AsyncMock(side_effect=lambda **kw: kw["matches"])  # type: ignore[method-assign]
+    # search() 现按 corpus.config.embedding_config_id 选 fn；本测固定走 service 默认 fn。
+    svc._get_corpus_config = AsyncMock(return_value={})  # type: ignore[method-assign]
     return svc
 
 

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -581,3 +581,25 @@
 - **同类问题影响**：
   1. 凡通过自动化脚本生成 ICO 的入口（包括未来可能的 `apps/*/src/app/favicon.ico`、`apps/*/src/app/icon.{png,svg}`、`apps/*/src/app/apple-icon.png`）均需复核是否走 padding+多档流程；
   2. 已发布 Wiki Publication 的 OpenGraph / Twitter Card 图（如未来引入 `apps/negentropy-wiki/src/app/opengraph-image.{png,jpg}`）同样存在「非方形源图直接交付」风险，建议在引入前预设统一的资产生成脚本（`scripts/build-icons.mjs` 或 `scripts/build-icons.py`）作为单一事实源。
+
+---
+
+## ISSUE-028 Knowledge Base Retrieve 查询时未使用 Corpus 自配 Embedding 模型，导致 query/index 模型不一致
+
+- **表因**：用户在 Corpus Settings 页已显式选定 `Embedding Model = openai/text-embedding-3-small`（1536 维），执行 Retrieve（hybrid 模式）时后端仍使用全局默认 `gemini/text-embedding-004`，该模型经 `localhost:3392` 翻译代理对 Gemini `batchEmbedContents` 实现不全，返回 `400 "request body doesn't contain valid prompts"`，重试 3 次失败 → HTTP 500（ISSUE-026 的 keyword 兜底已在后续 commit 落地，但 embedding 模型选择的契约缺口仍存在）。
+- **根因**：**索引侧与查询侧 embedding fn 解析路径不对称**：
+  1. **索引侧**（`service.py::_attach_embeddings`，line 2906-2913）：读 `corpus.config['models']['embedding_config_id']`，命中则 `build_batch_embedding_fn(embedding_config_id)`，走 corpus 自身配置；
+  2. **查询侧**（`service.py::search`，line 2540-2542 / 2625-2629）：直接使用实例化时锁定的 `self._embedding_fn`（全局默认 fn），**从未读 corpus.config**。
+  后果：索引产物按 OpenAI 1536 维生成，查询走全局默认 gemini/text-embedding-004（768 维）→ 模型不一致 + 上游链路故障双重失败。
+- **处理方式**（最小干预 + 索引/查询对称化）：
+  1. 新增 `_resolve_embedding_fn(corpus_config)` 私有方法（紧邻 `_extract_embedding_config_id`），复用 `build_embedding_fn` + `_extract_embedding_config_id`，corpus pin 优先 → 退回 service 默认 fn；
+  2. `search()` 入口新增 `corpus_config = await self._get_corpus_config(corpus_id)` + `embedding_fn = self._resolve_embedding_fn(corpus_config)`；
+  3. rrf / hybrid / semantic 三分支的 `self._embedding_fn` 替换为本地变量 `embedding_fn`；
+  4. ISSUE-026 的 `EmbeddingFailed → keyword 兜底`、`502 映射`、诊断日志（`api_base_host` + `upstream_response_text`）原样保留，零回归；
+  5. 配套 5 例单元测试：corpus pin 命中 / 落空 / hybrid keyword 兜底 / rrf 走 pin / semantic 失败上抛，回归 ISSUE-026 的 5 例全部绿色。
+- **后续防范**：
+  1. **索引/查询 fn 解析必须对称**：任何新增"按 corpus 选择 fn"的场景（如 reranker fn、LLM extractor fn）需同时检查 `_attach_embeddings` 索引侧与 `search` 查询侧是否共用同一条判别逻辑。建议将 `_resolve_embedding_fn` 模式推广为通用 `_resolve_fn_for_corpus(corpus_config, fn_type)` 助手。
+  2. **corpus 级配置消费审计**：新增 corpus.config 子键（如 `models.reranker_config_id`）时，需逐路径确认 `search()`、`_attach_embeddings()`、`semantic_chunk_async()` 三处消费点均覆盖。
+- **同类问题影响**：
+  1. **chunking 阶段** `semantic_chunk_async`（service.py:2783）仍直接使用 `self._embedding_fn`，属于 index-time 另一支路；若 Hierarchical 模式需要按 corpus 配切 embedding 模型，需同法修补；
+  2. **LLM 模型对称性**：`KnowledgeQA` / `extractor` 路径中 LLM 模型的 corpus 级解析是否对称，需独立审计。


### PR DESCRIPTION
## Summary

- 修复 `search()` 查询时直接使用实例化时锁定的 `self._embedding_fn`（全局默认），未读取 `corpus.config.models.embedding_config_id` 的问题
- 新增 `_resolve_embedding_fn(corpus_config)` 私有方法，使查询侧与索引侧 `_attach_embeddings` 的 embedding fn 解析路径完全对称
- 修复后，用户在 Corpus Settings 选定 `openai/text-embedding-3-small`，Retrieve 查询自动走 OpenAI 而非全局默认 `gemini/text-embedding-004`

## Root Cause

索引侧 `_attach_embeddings` (service.py:2906-2913) 读 `corpus.config['models']['embedding_config_id']` 走 corpus 专属 fn；查询侧 `search()` (service.py:2540/2625) 直接用 `self._embedding_fn` 全局默认，**从未读 corpus.config**。两侧不对称导致索引/查询 embedding 模型不一致。

## Changes

- `service.py`：新增 `_resolve_embedding_fn(corpus_config)` 助手 + `search()` 入口加载 corpus_config 并替换三分支 `self._embedding_fn`
- `test_search_corpus_embedding.py`：新增 5 例单元测试（corpus pin 命中/落空/兜底/rrf/semantic）
- `test_search_resilience.py`：补充 `_get_corpus_config` mock 适配
- `docs/issue.md`：新增 ISSUE-028

## Test plan

- [x] `uv run pytest tests/unit_tests/knowledge/ --no-cov` — 577 passed
- [x] ISSUE-026 回归测试 `test_search_resilience.py` — 5/5 green
- [x] 新增 `test_search_corpus_embedding.py` — 5/5 green
- [ ] 接口级验证：起服务后 curl 打 `/knowledge/base/{corpus_id}/search`，确认日志 `model=openai/text-embedding-3-small`

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)