### PR TITLE
fix(bootstrap-otel): 消除 ADK Web 启动期 OTel Override Provider 双 WARNING (ISSUE-034)

### DIFF
--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -37,26 +37,41 @@ configure_logging(
 logger = get_logger("negentropy.bootstrap")
 
 
-def _install_noop_otel_logs_metrics_providers() -> None:
-    """抢注空 LoggerProvider 与 MeterProvider，阻断 ADK 自动 OTLP logs/metrics 上报。
+def _disable_adk_otel_logs_metrics_exporters() -> None:
+    """让 ADK ``_get_otel_exporters`` 只返回 traces 的 ``span_processors``。
 
-    Langfuse 仅承接 ``/v1/traces``。ADK 上游 ``_get_otel_exporters()`` 在
-    ``OTEL_EXPORTER_OTLP_ENDPOINT`` 存在时会无差别注册 ``OTLPSpanExporter``、
-    ``OTLPMetricExporter``、``OTLPLogExporter`` 三件套——后两者对 ``/v1/metrics``
-    与 ``/v1/logs`` 的上报会命中 Langfuse 404（SPA 错误页）。
+    Langfuse 仅承接 ``/v1/traces``；ADK 上游 ``_get_otel_exporters()`` 在
+    ``OTEL_EXPORTER_OTLP_ENDPOINT`` 存在时会无差别构造 ``OTLPSpanExporter``、
+    ``OTLPMetricExporter``、``OTLPLogExporter`` 三件套——后两者对 Langfuse
+    ``/v1/metrics`` 与 ``/v1/logs`` 的上报会命中 SPA 404 错误页。
 
-    OTel SDK 的 ``set_logger_provider`` / ``set_meter_provider`` 由
-    ``Once``-lock 保护：首次调用胜出。本函数抢先以「无 processor / 无 reader」
-    的 SDK provider 占位，ADK 后续 ``set_*_provider`` 会静默 no-op，从而阻断
-    logs/metrics 路径；traces 链路（TracerProvider）不动，仍由 ADK 接管。
+    本 patch 在 ``OTelHooks`` 拼装入口处把 ``metric_readers`` 与
+    ``log_record_processors`` 永久置空，使 ADK ``maybe_set_otel_providers``
+    的 ``if metric_readers:`` / ``if log_record_processors:`` 分支天然短路——
+    根源避免 ``set_logger_provider`` / ``set_meter_provider`` 被调用，从而消除
+    "Overriding of current ... is not allowed" WARNING；
+    ``span_processors``（traces 链路）不变，traces 仍正常上报到 Langfuse。
+
+    未来若启用支持 logs/metrics 的后端（SigNoz、Phoenix 等），改为返回
+    ``hooks`` 全部内容即可平滑切换。
     """
-    from opentelemetry import _logs as otel_logs_api
-    from opentelemetry import metrics as otel_metrics_api
-    from opentelemetry.sdk._logs import LoggerProvider as NoExporterLoggerProvider
-    from opentelemetry.sdk.metrics import MeterProvider as NoExporterMeterProvider
+    from google.adk.telemetry import setup as adk_otel_setup
 
-    otel_logs_api.set_logger_provider(NoExporterLoggerProvider())
-    otel_metrics_api.set_meter_provider(NoExporterMeterProvider(metric_readers=[]))
+    if getattr(adk_otel_setup._get_otel_exporters, "_negentropy_patched", False):
+        return
+
+    original = adk_otel_setup._get_otel_exporters
+
+    def _patched_get_otel_exporters():
+        hooks = original()
+        return adk_otel_setup.OTelHooks(
+            span_processors=hooks.span_processors,
+            metric_readers=[],
+            log_record_processors=[],
+        )
+
+    _patched_get_otel_exporters._negentropy_patched = True  # type: ignore[attr-defined]
+    adk_otel_setup._get_otel_exporters = _patched_get_otel_exporters
 
 
 # Configure OpenTelemetry environment variables for LiteLLM's "otel" callback
@@ -77,7 +92,7 @@ if langfuse.langfuse_enabled and langfuse.langfuse_public_key and langfuse.langf
     basic_auth = base64.b64encode(credentials.encode()).decode()
     os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {basic_auth}"
 
-    _install_noop_otel_logs_metrics_providers()
+    _disable_adk_otel_logs_metrics_exporters()
 
     logger.info(f"Configured LiteLLM OTel callback to use Langfuse: {base_endpoint}/api/public/otel")
 else:

--- a/apps/negentropy/tests/unit_tests/observability/test_otel_noop_providers.py
+++ b/apps/negentropy/tests/unit_tests/observability/test_otel_noop_providers.py
@@ -1,8 +1,12 @@
-"""验证 bootstrap._install_noop_otel_logs_metrics_providers() 抢注 NoOp Logger/Meter Provider。
+"""验证 bootstrap._disable_adk_otel_logs_metrics_exporters() 抑制 ADK 自动注册 OTLP logs/metrics。
 
-OTel SDK 的 ``set_logger_provider`` / ``set_meter_provider`` 由 ``Once`` 锁保护，
-首次调用全局胜出；后续调用仅打 warning。本组测试在子进程中运行——避免污染主测试
-进程的 OTel 全局状态、并隔离每个用例的 Once 锁。
+ADK ``google.adk.telemetry.setup.maybe_set_otel_providers`` 内部调用唯一拼装入口
+``_get_otel_exporters()``：在 ``OTEL_EXPORTER_OTLP_ENDPOINT`` 存在时无差别构造
+``OTLPSpanExporter``、``OTLPMetricExporter``、``OTLPLogExporter`` 三件套。Langfuse 仅
+承接 ``/v1/traces``，后两者上报会命中 SPA 404。
+
+本组测试在子进程中运行——避免污染主测试进程的 OTel 全局状态、并隔离每个用例的
+``Once`` 锁初始状态。
 """
 
 from __future__ import annotations
@@ -23,70 +27,87 @@ def _run_in_subprocess(script: str) -> str:
     return result.stdout
 
 
-def test_install_noop_logger_provider_yields_sdk_provider_without_processors():
-    """安装后 get_logger_provider() 返回 SDK LoggerProvider，且不挂任何 LogRecordProcessor。"""
+def test_patch_disables_metric_and_log_exporters_but_keeps_traces():
+    """patch 后 _get_otel_exporters 返回 traces span_processor，但 metric_readers / log_record_processors 为空。"""
     output = _run_in_subprocess(
         """
-        from negentropy.engine.bootstrap import _install_noop_otel_logs_metrics_providers
-        from opentelemetry import _logs
-        from opentelemetry.sdk._logs import LoggerProvider
+        import os
+        os.environ['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4318'
 
-        _install_noop_otel_logs_metrics_providers()
-        provider = _logs.get_logger_provider()
-        assert isinstance(provider, LoggerProvider), f"expected SDK LoggerProvider, got {type(provider)}"
-        # _multi_log_record_processor 是 SDK LoggerProvider 内部聚合所有 processor 的入口
-        # 此时未注册任何 processor，下属列表应为空。
-        processors = list(provider._multi_log_record_processor._log_record_processors)
-        assert processors == [], f"expected zero processors, got {processors}"
-        print("logger_ok")
+        from negentropy.engine.bootstrap import _disable_adk_otel_logs_metrics_exporters
+        from google.adk.telemetry import setup as adk_setup
+
+        _disable_adk_otel_logs_metrics_exporters()
+
+        # patch 标记必须可见（用于幂等保护与外部断言）
+        assert getattr(adk_setup._get_otel_exporters, '_negentropy_patched', False), 'missing _negentropy_patched flag'
+
+        hooks = adk_setup._get_otel_exporters()
+        # traces 链路保留：env var 存在时返回 1 个 BatchSpanProcessor(OTLPSpanExporter)
+        assert len(hooks.span_processors) == 1, f'expected 1 span processor, got {hooks.span_processors!r}'
+        # logs / metrics 永久置空——ADK maybe_set_otel_providers 的 if 分支由此短路
+        assert hooks.metric_readers == [], f'expected zero metric readers, got {hooks.metric_readers!r}'
+        assert hooks.log_record_processors == [], f'expected zero log processors, got {hooks.log_record_processors!r}'
+        print('exporters_ok')
         """
     )
-    assert "logger_ok" in output
+    assert "exporters_ok" in output
 
 
-def test_install_noop_meter_provider_yields_sdk_provider_without_readers():
-    """安装后 get_meter_provider() 返回 SDK MeterProvider，且不挂任何 MetricReader。"""
+def test_patch_is_idempotent():
+    """重复调用 patch helper 不应叠加替换、不应重复 wrap 原函数。"""
     output = _run_in_subprocess(
         """
-        from negentropy.engine.bootstrap import _install_noop_otel_logs_metrics_providers
-        from opentelemetry import metrics
-        from opentelemetry.sdk.metrics import MeterProvider
+        import os
+        os.environ['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4318'
 
-        _install_noop_otel_logs_metrics_providers()
-        provider = metrics.get_meter_provider()
-        assert isinstance(provider, MeterProvider), f"expected SDK MeterProvider, got {type(provider)}"
-        readers = list(provider._sdk_config.metric_readers)
-        assert readers == [], f"expected zero metric readers, got {readers}"
-        print("meter_ok")
+        from negentropy.engine.bootstrap import _disable_adk_otel_logs_metrics_exporters
+        from google.adk.telemetry import setup as adk_setup
+
+        _disable_adk_otel_logs_metrics_exporters()
+        first = adk_setup._get_otel_exporters
+
+        _disable_adk_otel_logs_metrics_exporters()
+        second = adk_setup._get_otel_exporters
+
+        # 第二次调用必须 no-op：函数对象保持同一引用
+        assert first is second, 'patch is not idempotent — wrapped twice'
+        print('idempotent_ok')
         """
     )
-    assert "meter_ok" in output
+    assert "idempotent_ok" in output
 
 
-def test_subsequent_set_logger_provider_is_noop_due_to_once_lock():
-    """抢注后第二次 set_logger_provider（模拟 ADK _setup_telemetry_from_env）必须无效。"""
+def test_adk_maybe_set_otel_providers_does_not_touch_logger_meter_globals():
+    """模拟 ADK 启动期调用 maybe_set_otel_providers，验证全局 LoggerProvider/MeterProvider 未被 SDK 实例覆盖。
+
+    若未应用 patch，ADK 会调用 ``set_logger_provider`` / ``set_meter_provider`` 注册 SDK
+    实例（带 OTLPLogExporter / OTLPMetricExporter），这是历史 WARNING 的根源。本用例验证
+    patch 后这两个全局调用根本不会发生——全局保持默认 ProxyProvider（NoOp）。
+    """
     output = _run_in_subprocess(
         """
-        from negentropy.engine.bootstrap import _install_noop_otel_logs_metrics_providers
-        from opentelemetry import _logs
-        from opentelemetry.sdk._logs import LoggerProvider
-        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
+        import os
+        os.environ['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4318'
 
-        _install_noop_otel_logs_metrics_providers()
-        first = _logs.get_logger_provider()
+        from negentropy.engine.bootstrap import _disable_adk_otel_logs_metrics_exporters
+        from google.adk.telemetry import setup as adk_setup
+        from opentelemetry import _logs, metrics
+        from opentelemetry.sdk._logs import LoggerProvider as SdkLoggerProvider
+        from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
 
-        # 模拟 ADK 上游的 set_logger_provider 调用——构造一个带 OTLP 风格 processor 的新 provider
-        intruder = LoggerProvider()
-        intruder.add_log_record_processor(BatchLogRecordProcessor(ConsoleLogExporter()))
-        _logs.set_logger_provider(intruder)
+        _disable_adk_otel_logs_metrics_exporters()
 
-        # Once-lock：第二次 set 静默失败，全局仍是第一个 NoOp provider
-        after = _logs.get_logger_provider()
-        assert after is first, "second set_logger_provider must NOT replace the first"
-        # 并且首个 provider 仍然没有 processor
-        processors = list(after._multi_log_record_processor._log_record_processors)
-        assert processors == [], f"NoOp provider must remain processor-less; got {processors}"
-        print("once_lock_ok")
+        # 模拟 ADK 上游调用 maybe_set_otel_providers（无额外 hooks，只走 _get_otel_exporters 路径）
+        adk_setup.maybe_set_otel_providers(otel_hooks_to_setup=None)
+
+        # 关键断言：全局 LoggerProvider / MeterProvider 必须仍是默认 ProxyProvider 而非 SDK 实例
+        # （ADK if 分支因 list 为空而短路，set_*_provider 根本未被调用）
+        assert not isinstance(_logs.get_logger_provider(), SdkLoggerProvider), \
+            f'LoggerProvider must remain default ProxyLoggerProvider, got {type(_logs.get_logger_provider())}'
+        assert not isinstance(metrics.get_meter_provider(), SdkMeterProvider), \
+            f'MeterProvider must remain default ProxyMeterProvider, got {type(metrics.get_meter_provider())}'
+        print('no_set_provider_ok')
         """
     )
-    assert "once_lock_ok" in output
+    assert "no_set_provider_ok" in output

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -707,3 +707,43 @@
   1. 任何上游框架基于 env var 自动启用次级遥测路径（如 `OTEL_RESOURCE_ATTRIBUTES`、`OTEL_PROPAGATORS`）的场景；
   2. 多 SDK 共存的 instrumentation 环境（`opentelemetry-instrumentation-*` 各自调用 `get_*_provider()`）；
   3. 升级 google-adk / google-genai-instrumentation / litellm 版本时，需复核它们对 logs/metrics 的处理是否变更（如未来 LiteLLM `enable_metrics=True` 默认开启，需同步审计）。
+
+## ISSUE-034 ADK Web 启动期两条 OTel `Overriding of current ... Provider` WARNING：抢占式 set provider 副作用 → 改为 patch ADK `_get_otel_exporters` 根因抑制
+
+- **表因**：`uv run adk web --port <p> --reload_agents src` 启动期 stderr 反复出现：
+  ```
+  WARNING |     metrics._internal | Overriding of current MeterProvider is not allowed
+  WARNING |       _logs._internal | Overriding of current LoggerProvider is not allowed
+  ```
+  污染启动日志可读性，且每次启动都触发，给排障带来噪声。
+- **根因**：ISSUE-033 的"抢占式 set provider"修复方案的天然副作用：
+  1. `apps/negentropy/src/negentropy/engine/bootstrap.py:40-59` 旧 `_install_noop_otel_logs_metrics_providers()` 在导入早期主动 `set_logger_provider(NoExporterLoggerProvider())` / `set_meter_provider(NoExporterMeterProvider(metric_readers=[]))`；
+  2. ADK Web 启动 `_setup_telemetry_from_env()` → `maybe_set_otel_providers()` → 第二次调用 `set_logger_provider` / `set_meter_provider`；
+  3. OTel SDK 的 `Once`-lock 保护使第二次调用静默失败，但**仍会通过 `_logger.warning` 打印** "Overriding of current ... is not allowed"（参见 `opentelemetry/_logs/_internal/__init__.py` 与 `opentelemetry/metrics/_internal/__init__.py` 的 `_set_*_provider` 实现）。
+- **二阶影响**：日志噪声 + 误导用户怀疑配置错误（实际 traces 链路完全正常，logs/metrics 也按 ISSUE-033 设计被阻断）。
+- **处理方式**（治本，最小干预）：把"抢占 SDK provider"替换为"patch ADK 上游 OTel 拼装入口"，ADK 根本不再调用 `set_logger_provider` / `set_meter_provider`：
+  1. `bootstrap.py` 删除 `_install_noop_otel_logs_metrics_providers()`，新增 `_disable_adk_otel_logs_metrics_exporters()`；
+  2. 该 helper monkey-patch `google.adk.telemetry.setup._get_otel_exporters`：调用原函数后强制把 `metric_readers` / `log_record_processors` 置空、保留 `span_processors`；
+  3. ADK `maybe_set_otel_providers` 内部 `if metric_readers:` / `if log_record_processors:` 分支由此短路（参见 `google/adk/telemetry/setup.py:102, 113`），`set_*_provider` 根本不被调用 → WARNING 从源头消除；
+  4. `span_processors`（traces 链路）保留原 `BatchSpanProcessor(OTLPSpanExporter())`，traces 仍正常上报到 Langfuse `/v1/traces`；
+  5. 加 `_negentropy_patched` 属性做幂等保护，与 `apply_adk_patches()` 中既有惯用法（如 `AdkWebServer.get_fast_api_app._negentropy_patched`）一致；
+  6. 测试更新 `tests/unit_tests/observability/test_otel_noop_providers.py` 3 例（子进程隔离 OTel 全局状态）：
+     - patch 后 `_get_otel_exporters()` 返回的 `metric_readers` / `log_record_processors` 为空、`span_processors` 仍为 1 个 `BatchSpanProcessor`；
+     - patch 幂等（重复调用函数对象不变）；
+     - 模拟调用 `maybe_set_otel_providers` 后全局 `LoggerProvider` / `MeterProvider` 仍是默认 ProxyProvider（**不是** SDK 实例），证明 set 调用未发生。
+- **行为对照**：
+  | 调用 | 修复前 | 修复后 |
+  |------|--------|--------|
+  | `_logs.set_logger_provider` | 项目 + ADK 各 1 次（第二次 warn） | **零次** |
+  | `metrics.set_meter_provider` | 项目 + ADK 各 1 次（第二次 warn） | **零次** |
+  | `trace.set_tracer_provider` | ADK 1 次（含 OTLP traces + ApiServerSpanExporter） | 不变 |
+  | `opentelemetry-instrumentation-google-genai` 写 GenAI events | 拿到 NoExporter SDK LoggerProvider（无 processor，丢弃） | 拿到默认 ProxyLoggerProvider（同样 NoOp 丢弃） |
+  | LiteLLM `"otel"` callback 上报 traces | → Langfuse `/v1/traces` | 不变 |
+- **后续防范**：
+  1. **OTel 抢占模式陷阱**：抢占式 `set_*_provider` 虽能利用 `Once`-lock 阻断后续注册，但**SDK 仍会输出 WARNING**——治本方案应当是阻止上游"想 set"，而非依赖"set 失败 + 静默吞错"；
+  2. **优先 patch 上游拼装入口**：当框架（ADK）在某个唯一入口（`_get_otel_exporters`）拼装多类 telemetry hooks 时，patch 该入口比 patch 各 `set_*_provider` 调用更精准；
+  3. **平滑升级到完整 OTLP 三件套**：未来若启用 SigNoz / Phoenix 等支持 logs+metrics 的 backend，把 `_disable_adk_otel_logs_metrics_exporters()` 改为有条件地透传 `metric_readers` / `log_record_processors` 即可（建议联动 `negentropy.config.observability` 加 `suppress_otlp_logs_metrics: bool` 开关）；
+  4. **ADK 升级兼容审计**：本 patch 直接替换 `_get_otel_exporters` 函数对象并依赖 `OTelHooks` dataclass 的 `span_processors` / `metric_readers` / `log_record_processors` 字段名。`google-adk` 升级时（`pyproject.toml` line 27 已锁版本范围）需 grep 该函数与 dataclass 是否变更。
+- **同类问题影响**：
+  1. 任何"抢占 OTel global provider"模式都会在上游再次 set 时触发 WARNING——但凡 SDK 依赖此类副作用的代码都应回归"上游 patch"思路；
+  2. 类似 `opentelemetry-instrumentation-*` 系列在 `OTel SDK` 之上做隐式 set 的场景（如 `langfuse.openai`、`openinference` 自动埋点），引入时需复核其是否走 `set_*_provider` 路径。


### PR DESCRIPTION
## 背景

启动 `uv run adk web --port 3292 --reload_agents src` 时，stderr 反复出现两条 OTel SDK WARNING：

\`\`\`
WARNING |     metrics._internal | Overriding of current MeterProvider is not allowed
WARNING |       _logs._internal | Overriding of current LoggerProvider is not allowed
\`\`\`

污染启动日志可读性，且每次启动都触发，给排障带来噪声。

## 根因

ISSUE-033 的「抢占式 set provider」修复方案的天然副作用：

1. \`bootstrap.py\` 旧 \`_install_noop_otel_logs_metrics_providers()\` 在导入早期主动 \`set_logger_provider(NoExporterLoggerProvider())\` / \`set_meter_provider(...)\`；
2. ADK Web 启动 \`_setup_telemetry_from_env\` → \`maybe_set_otel_providers\` → 第二次 \`set_*_provider\`；
3. OTel SDK 的 \`Once\`-lock 让第二次调用静默失败，**但仍通过 \`_logger.warning\` 打印 Override 警告**。

## 方案

把「抢占 SDK provider」替换为「patch ADK 上游 OTel 拼装入口」——ADK 根本不再调用 \`set_logger_provider\` / \`set_meter_provider\`：

- 删除 \`_install_noop_otel_logs_metrics_providers\`，新增 \`_disable_adk_otel_logs_metrics_exporters\`；
- monkey-patch \`google.adk.telemetry.setup._get_otel_exporters\`：调用原函数后强制把 \`metric_readers\` / \`log_record_processors\` 置空、保留 \`span_processors\`；
- ADK \`maybe_set_otel_providers\` 内部 \`if metric_readers:\` / \`if log_record_processors:\` 分支由此短路（\`google/adk/telemetry/setup.py:102, 113\`），\`set_*_provider\` **根本不被调用** → WARNING 从源头消除；
- \`span_processors\` 仍保留 \`BatchSpanProcessor(OTLPSpanExporter())\`，traces 链路上报到 Langfuse \`/v1/traces\` 不变；
- 加 \`_negentropy_patched\` 属性做幂等保护，与 \`apply_adk_patches()\` 中既有惯用法一致。

## 行为对照

| 调用 | 修复前 | 修复后 |
|------|--------|--------|
| \`_logs.set_logger_provider\` | 项目 + ADK 各 1 次（第二次 warn） | **零次** |
| \`metrics.set_meter_provider\` | 项目 + ADK 各 1 次（第二次 warn） | **零次** |
| \`trace.set_tracer_provider\` | ADK 1 次（含 OTLP traces + ApiServerSpanExporter） | 不变 |
| \`opentelemetry-instrumentation-google-genai\` 写 GenAI events | NoExporter SDK LoggerProvider（无 processor，丢弃） | 默认 ProxyLoggerProvider（同样 NoOp 丢弃） |
| LiteLLM \`"otel"\` callback 上报 traces | → Langfuse \`/v1/traces\` | 不变 |

## 测试

### 单测（3 例子进程隔离 OTel 全局状态）

\`tests/unit_tests/observability/test_otel_noop_providers.py\`：

1. patch 后 \`_get_otel_exporters()\` 返回的 \`metric_readers\` / \`log_record_processors\` 为空、\`span_processors\` 仍为 1 个 \`BatchSpanProcessor\`；
2. patch 幂等（重复调用函数对象不变）；
3. 模拟 \`maybe_set_otel_providers\` 调用后全局 \`LoggerProvider\` / \`MeterProvider\` 仍是默认 ProxyProvider（**不是** SDK 实例），证明 set 调用未发生。

### 全量回归

- \`uv run pytest tests/unit_tests --no-cov -q\` → 697 passed。
- \`uv run adk web --port 3293 src\` 端到端启动：两条 WARNING **完全消失**，\`Application startup complete\` / \`Uvicorn running\` 正常，所有路由（Knowledge / Memory / Interface / Auth / Sessions）正常挂载。

## 后续防范

1. **OTel 抢占模式陷阱**：抢占式 \`set_*_provider\` 虽能利用 \`Once\`-lock 阻断后续注册，但 SDK 仍会输出 WARNING——治本应阻止上游「想 set」，而非依赖「set 失败 + 静默吞错」；
2. **优先 patch 上游拼装入口**：当框架在唯一入口（\`_get_otel_exporters\`）拼装多类 telemetry hooks 时，patch 该入口比 patch 各 \`set_*_provider\` 更精准；
3. **未来引入支持 logs+metrics 的 backend**（SigNoz / Phoenix）：让 \`_disable_adk_otel_logs_metrics_exporters\` 有条件透传 \`metric_readers\` / \`log_record_processors\` 即可平滑切换（建议联动 \`negentropy.config.observability\` 加 \`suppress_otlp_logs_metrics: bool\` 开关）。

## 关联

- 演进自 ISSUE-033，详见 \`docs/issue.md\` 新增的 ISSUE-034 完整记录（表因 / 根因 / 行为对照 / 后续防范 / 同类问题影响）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)