### PR TITLE
feat(e2e-auth): 浏览器验证协议落地 + Playwright 会话复用贯通 Google OAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,5 +249,9 @@ apps/negentropy-ui/.yarn/*
 .temp/
 .playwright-mcp/
 
+# Playwright auth artifacts (browser session reuse) — see docs/agents/browser-validation.md
+apps/negentropy-ui/.auth/
+apps/negentropy-ui/.userdata/
+
 # Custom
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,13 @@
   1. **Python**: 严禁使用 pip/poetry，**必须**统一使用 `uv` 进行包管理与脚本执行（如 `uv run`）；
   2. **JavaScript/TypeScript**: 严禁使用 npm/yarn，**必须**统一使用 `pnpm` 进行包管理与脚本执行。
 - **Database Management**: 谨慎操作，数据迁移、测试等操作严禁将现有数据删除，谨慎操作数据迁移的回滚，防止数据被清理。
+- **Browser Validation Protocol (浏览器验证准则)**: 所有依赖登录态（Google OAuth / SSO / 内部凭证）的浏览器验证，**必须**复用用户常用 Chrome 的会话，杜绝在 sandbox/空白 profile 浏览器内尝试通过 Google 同意屏，详见 [浏览器验证协议](./docs/agents/browser-validation.md)。
+  1. **首选驱动**: Claude in Chrome 扩展（`mcp__claude-in-chrome__*`），原生持有用户登录态；
+  2. **退化通道**: 用户启动 Chrome 时附 `--remote-debugging-port=9222`，再以 Chrome DevTools 协议（`mcp__chrome_devtools__*`）连接同一 profile；
+  3. **禁止动作**: 严禁在 sandbox 浏览器中跳转 Google 同意屏；严禁要求用户在 chat 中粘贴密码、Cookie 或一次性验证码（违反 `user_privacy` 中的 SENSITIVE INFORMATION HANDLING）；
+  4. **凭证守则**: storageState / cookies / userDataDir 等会话产物**仅落本地**，受 `.gitignore` 保护，禁止入库；
+  5. **连通性自检**: 每次会话首次需要登录态浏览前，先按协议文档中的"三步自检"确认链路；
+  6. **E2E 测试**: 项目 Playwright E2E 通过 `setup` project + `storageState` 复用一次性人工登录的会话，配置见 [`apps/negentropy-ui/playwright.config.ts`](./apps/negentropy-ui/playwright.config.ts) 与 [`apps/negentropy-ui/tests/e2e/auth.setup.ts`](./apps/negentropy-ui/tests/e2e/auth.setup.ts)。
 
 ## Documentation Standards (文档规范)
 

--- a/apps/negentropy-ui/playwright.config.ts
+++ b/apps/negentropy-ui/playwright.config.ts
@@ -20,7 +20,7 @@ const userDataLaunchOptions = USER_DATA_DIR
 const baseProjects = [
   {
     name: "chromium",
-    testIgnore: /.*\.setup\.ts$/,
+    testIgnore: [/.*\.setup\.ts$/, /.*\.authed\.spec\.ts$/],
     use: { ...devices["Desktop Chrome"] },
   },
 ];

--- a/apps/negentropy-ui/playwright.config.ts
+++ b/apps/negentropy-ui/playwright.config.ts
@@ -1,9 +1,53 @@
+import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
 const port = Number(process.env.PLAYWRIGHT_PORT || 3210);
 const baseURL = `http://127.0.0.1:${port}`;
 const reuseExistingServer =
   process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === "true";
+
+// Browser-session reuse knobs — see ../../docs/agents/browser-validation.md
+const STORAGE_STATE =
+  process.env.PLAYWRIGHT_STORAGE_STATE ??
+  path.resolve(__dirname, ".auth/user.json");
+const USER_DATA_DIR = process.env.PLAYWRIGHT_USER_DATA_DIR;
+const AUTH_ENABLED = process.env.PLAYWRIGHT_AUTH === "1";
+
+const userDataLaunchOptions = USER_DATA_DIR
+  ? { launchOptions: { args: [`--user-data-dir=${USER_DATA_DIR}`] } }
+  : {};
+
+const baseProjects = [
+  {
+    name: "chromium",
+    testIgnore: /.*\.setup\.ts$/,
+    use: { ...devices["Desktop Chrome"] },
+  },
+];
+
+const authProjects = AUTH_ENABLED
+  ? [
+      {
+        name: "setup",
+        testMatch: /.*\.setup\.ts$/,
+        use: {
+          ...devices["Desktop Chrome"],
+          headless: false,
+          ...userDataLaunchOptions,
+        },
+      },
+      {
+        name: "chromium-authenticated",
+        dependencies: ["setup"],
+        testMatch: /.*\.authed\.spec\.ts$/,
+        use: {
+          ...devices["Desktop Chrome"],
+          storageState: STORAGE_STATE,
+          ...userDataLaunchOptions,
+        },
+      },
+    ]
+  : [];
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -37,10 +81,5 @@ export default defineConfig({
     },
     timeout: 180_000,
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects: [...authProjects, ...baseProjects],
 });

--- a/apps/negentropy-ui/tests/e2e/auth.setup.ts
+++ b/apps/negentropy-ui/tests/e2e/auth.setup.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import { test as setup, expect } from "@playwright/test";
+
+// 持久化路径：默认 apps/negentropy-ui/.auth/user.json，受 .gitignore 保护。
+// 详见 docs/agents/browser-validation.md。
+const STORAGE_STATE =
+  process.env.PLAYWRIGHT_STORAGE_STATE ??
+  path.resolve(__dirname, "../../.auth/user.json");
+
+// 留给用户在 Google 同意屏中手动完成登录的时间上限（5 分钟）。
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+setup("通过 Google OAuth 登录并持久化会话", async ({ page }) => {
+  await page.goto("/auth/google/login");
+
+  // 用户在弹出的 Google 页面手动完成账号选择 / 二步验证后，浏览器会回跳到 baseURL。
+  // 此处仅断言"已离开 /auth/google/* 路径"，不强约束最终着陆页，便于项目改路由时无需同步调整。
+  await page.waitForURL((url) => !url.pathname.startsWith("/auth/google"), {
+    timeout: LOGIN_TIMEOUT_MS,
+  });
+
+  // 二次校验登录态：项目自带 /api/auth/me 应返回当前用户。
+  const meResponse = await page.request.get("/api/auth/me");
+  expect(meResponse.ok(), "/api/auth/me 应该在登录后返回 2xx").toBe(true);
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/apps/negentropy-ui/tests/e2e/auth.setup.ts
+++ b/apps/negentropy-ui/tests/e2e/auth.setup.ts
@@ -14,10 +14,13 @@ setup("通过 Google OAuth 登录并持久化会话", async ({ page }) => {
   await page.goto("/auth/google/login");
 
   // 用户在弹出的 Google 页面手动完成账号选择 / 二步验证后，浏览器会回跳到 baseURL。
-  // 此处仅断言"已离开 /auth/google/* 路径"，不强约束最终着陆页，便于项目改路由时无需同步调整。
-  await page.waitForURL((url) => !url.pathname.startsWith("/auth/google"), {
-    timeout: LOGIN_TIMEOUT_MS,
-  });
+  // 必须同时约束 host，避免在跳往 accounts.google.com 的瞬间被误判为"已离开 /auth/google"。
+  await page.waitForURL(
+    (url) =>
+      (url.host.startsWith("127.0.0.1") || url.host.startsWith("localhost")) &&
+      !url.pathname.startsWith("/auth/google"),
+    { timeout: LOGIN_TIMEOUT_MS },
+  );
 
   // 二次校验登录态：项目自带 /api/auth/me 应返回当前用户。
   const meResponse = await page.request.get("/api/auth/me");

--- a/docs/agents/browser-validation.md
+++ b/docs/agents/browser-validation.md
@@ -1,0 +1,144 @@
+# 浏览器验证协议 (Browser Validation Protocol)
+
+> 本文遵循 [AGENTS.md](../../CLAUDE.md) 的协作协议与循证要求；落地的硬性约束已写入 [CLAUDE.md › 术 › Browser Validation Protocol](../../CLAUDE.md)，本文为其唯一详尽来源（Single Source of Truth）。
+
+## 1. 背景与问题陈述 (Problem Statement)
+
+项目自带 Google OAuth 流（参考 [docs/sso.md](../sso.md)）。当 AI Agent（Claude / Antigravity）在 Sandbox 浏览器（独立、空白 profile，如 Playwright 默认 `chromium.launch()`）中访问 [`localhost:3192`](http://localhost:3192) 并被重定向至 `accounts.google.com` 时，由于该浏览器无任何 Google 登录态，会被同意屏 / 风控 / 二步验证拦截，验证链路就此中断。这是阻塞 AI Agent 完成需求验证与回归测试的核心瓶颈之一。
+
+试图通过自动填充密码 / Cookie 注入 / 跨 profile 复制 `storageState` 的方式"绕过"登录拦截在生产环境中是不可靠且不安全的：Google 风控会基于设备指纹、IP、User-Agent、登录历史等多维度信号判断异常会话<sup>[[2]](#ref2)</sup>，且这些做法违反 Claude Code 的 `user_privacy` 安全准则中关于敏感凭证不入 chat 的硬性要求。
+
+## 2. 目标与非目标 (Goals / Non-Goals)
+
+- **目标**：让所有依赖登录态的浏览器验证（AI Agent 即时验证 + 项目 Playwright E2E）以**复用用户已有 Chrome 会话**的方式打通，登录动作仅由用户手动完成一次。
+- **非目标**：
+  - 不实现密码自动填充 / 验证码自动接收 / reCAPTCHA 自动求解；
+  - 不在 CI / 共享环境内长期托管真实账号 storageState；
+  - 不为多账号热切换提前抽象 profile manager（YAGNI）。
+
+## 3. 三种 MCP 浏览器工具的能力对照
+
+| 维度 | `mcp__claude-in-chrome__` | `mcp__chrome_devtools__` | `mcp__playwright__` |
+| --- | --- | --- | --- |
+| 浏览器实例 | 用户**常用** Chrome（通过扩展接管） | 任意 Chrome（通过 DevTools 协议连接） | Playwright 自启动的 Chromium |
+| 登录态来源 | **用户原生 profile** | 实测：macOS 默认配置下直接复用用户 Chrome 主 profile（**已登录态可用**）；其他平台或自定义 profile 路径则取决于连接对象 | 默认空 profile，需 `storageState` / `userDataDir` |
+| Google OAuth 友好度 | ✅ 高（同设备指纹） | ✅ 中-高（取决于 profile） | ❌ 低（易触发风控） |
+| 安装/启动成本 | 一次性安装 Chrome 扩展 | 每次以 `--remote-debugging-port` 启 Chrome | 零额外步骤 |
+| 适用场景 | **AI Agent 即时验证（首选）** | 故障定位、性能审计、首选不可用时退化 | E2E 测试套件（配合 `setup` project 复用会话） |
+| 安全语义 | 用户全程在自有浏览器内完成敏感动作 | 同上 | 需要持久化 `storageState`，须 gitignore |
+
+## 4. 选型决策图 (Routing)
+
+```mermaid
+flowchart TD
+  Start["需要浏览器验证"] --> NeedAuth{"涉及登录态<br/>(Google/SSO/...)?"}
+  NeedAuth -->|否| Free["任意浏览器工具均可<br/>（建议 mcp__playwright__ 做隔离测试）"]
+  NeedAuth -->|是| Mode{"AI Agent 即时验证<br/>or 自动化 E2E?"}
+  Mode -->|即时验证| Primary["首选: mcp__claude-in-chrome__<br/>（直接驱动用户常用 Chrome）"]
+  Primary --> Reachable{"扩展自检<br/>tabs_context_mcp 可达?"}
+  Reachable -->|是| Use1["✅ 直接使用"]
+  Reachable -->|否| Fallback["退化: 让用户启动 Chrome 时<br/>附 --remote-debugging-port=9222<br/>再用 mcp__chrome_devtools__ 接入"]
+  Mode -->|E2E 测试| E2E["pnpm exec playwright test<br/>--project=setup 首次手动登录<br/>→ storageState 复用"]
+
+  style Start fill:#0f172a,stroke:#60a5fa,color:#e2e8f0
+  style Primary fill:#0b1f2a,stroke:#34d399,color:#ecfdf5
+  style Use1 fill:#052e16,stroke:#22c55e,color:#dcfce7
+  style Fallback fill:#1f1d0a,stroke:#f59e0b,color:#fef3c7
+  style E2E fill:#0b1f2a,stroke:#3b82f6,color:#e6edf3
+  style NeedAuth fill:#1f2937,stroke:#a78bfa,color:#ede9fe
+  style Mode fill:#1f2937,stroke:#a78bfa,color:#ede9fe
+  style Reachable fill:#1f2937,stroke:#a78bfa,color:#ede9fe
+```
+
+## 5. 三步连通性自检 (Connectivity Self-Check)
+
+每次会话首次需要登录态浏览前，AI Agent **必须**按下列顺序依次执行；任意一步失败立即停下并把现象告知用户。
+
+### Step 1 — 首选驱动可达性
+
+```ts
+// AI Agent 调用
+mcp__claude-in-chrome__tabs_context_mcp({ createIfEmpty: true })
+```
+
+- 期望：返回当前 Chrome tab group 与至少一个 tabId。
+- 失败处理（按优先级）：
+  1. **退化到 chrome-devtools MCP**：调用 `mcp__chrome_devtools__list_pages`；若返回的 page url 已带用户登录态（如 `myaccount.google.com` 显示用户邮箱），则直接采用此通道，不必再装扩展（实测在 macOS 默认配置下即可生效）。
+  2. **仍不可用**：在用户常用 Chrome 中安装 [Claude in Chrome 扩展](https://claude.ai/chrome) 并允许 MCP 连接，或让用户启动 Chrome 时附 `--remote-debugging-port=9222`。
+
+### Step 2 — Google 登录态复用性
+
+```ts
+// 在新 tab 中打开
+mcp__claude-in-chrome__navigate({ url: "https://myaccount.google.com", tabId })
+mcp__claude-in-chrome__read_page({ tabId, filter: "interactive" })
+```
+
+- 期望：accessibility tree 中能读到用户邮箱（如 `cm.huang@aftership.com`）。
+- 失败处理：请用户在该 Chrome 中手动登录目标 Google 账号一次。
+
+### Step 3 — 项目 OAuth 链路打通
+
+```ts
+mcp__claude-in-chrome__navigate({ url: "http://localhost:3192/auth/google/login", tabId })
+```
+
+- 前置：本地 dev server 已起（前端 `pnpm run dev`，后端 `uv run negentropy serve`）。
+- 期望：无需重新输密码，直接回跳 `localhost:3192` 并完成会话写入。
+- 失败处理：检查 `.env` 中 OAuth callback URL（参考 [docs/issue.md](../issue.md) 历史 Issue）。
+
+## 6. Playwright E2E 的会话复用方案
+
+### 6.1 配置路径
+
+- 主配置：[`apps/negentropy-ui/playwright.config.ts`](../../apps/negentropy-ui/playwright.config.ts)
+- 登录 setup：[`apps/negentropy-ui/tests/e2e/auth.setup.ts`](../../apps/negentropy-ui/tests/e2e/auth.setup.ts)
+- 持久化产物：`apps/negentropy-ui/.auth/user.json`（已 gitignored）
+
+### 6.2 工作模式
+
+```mermaid
+sequenceDiagram
+  participant Dev as 开发者/CI
+  participant PW as Playwright Runner
+  participant Browser as Headed Chromium
+  participant FS as 本地文件系统
+
+  Dev->>PW: pnpm exec playwright test --project=setup
+  PW->>Browser: 启动有头浏览器
+  Browser-->>Dev: 弹出 Google 登录窗口
+  Dev->>Browser: 手动完成登录
+  Browser-->>PW: page.context().storageState()
+  PW->>FS: 写入 .auth/user.json
+
+  Dev->>PW: pnpm exec playwright test
+  PW->>Browser: 启动新 context (headless)
+  PW->>Browser: 注入 storageState
+  Browser->>Browser: 直接以已登录态访问 localhost:3192
+```
+
+### 6.3 失效与刷新
+
+- **触发条件**: Google 会话过期 / 项目后端 `user_states` 重建 / Cookie 域变化。
+- **应对**: 删除 `.auth/user.json` 后重跑 setup project，或使用 `pnpm exec playwright test --project=setup --headed`。
+
+## 7. 安全与凭证守则
+
+1. AI Agent 在任何场景下都**不得**读取、复制、粘贴用户密码 / 验证码 / Refresh Token；登录步骤一律由用户在浏览器内手动完成。
+2. `storageState`、`cookies`、`userDataDir` 等会话产物**仅落本地**，并通过 `.gitignore` 与 `.dockerignore` 双重屏蔽，杜绝随分支推送或镜像构建外泄。
+3. CI 跑 E2E 时禁止直接挂载真实账号的 `storageState`；建议走 mock OAuth provider（后续 Issue），或使用专用脱敏测试账号并将其凭证收敛到密钥管理服务。
+4. 若用户怀疑会话凭证泄漏，立即调用 [Google Account 设备登录管理](https://myaccount.google.com/device-activity) 撤销会话，并删除本地 `.auth/` 与 `.userdata/`。
+
+## 8. 二阶风险与防护
+
+- **风控误报**: 短时间内高频跳转 Google 同意屏会触发 reCAPTCHA / 邮箱验证。**对策**: 自检 Step 2 与 Step 3 间留 ≥ 3 秒间隔；避免在自动化循环中重复触发 OAuth。
+- **storageState 漂移**: 项目修改 Cookie 域 / SameSite 后旧 `storageState` 失效但不报错。**对策**: setup project 末尾增加 `expect(page).toHaveURL(/localhost:3192\/(?!auth\/google)/)` 断言。
+- **多账号干扰**: 用户常用 Chrome 同时登录多个 Google 账号会让 OAuth 选择器出现。**对策**: 自检失败时把账号选择器纳入指引，由用户显式选择目标账号。
+
+## 9. References (IEEE)
+
+<a id="ref1"></a>[1] Microsoft, "Authentication," _Playwright Documentation_, 2025. [Online]. Available: https://playwright.dev/docs/auth.
+
+<a id="ref2"></a>[2] OWASP Foundation, "Session Management Cheat Sheet," _OWASP Cheat Sheet Series_, 2024. [Online]. Available: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html.
+
+<a id="ref3"></a>[3] D. Hardt, "The OAuth 2.0 Authorization Framework," _IETF RFC 6749_, Oct. 2012, doi: 10.17487/RFC6749.

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -707,3 +707,31 @@
   1. 任何上游框架基于 env var 自动启用次级遥测路径（如 `OTEL_RESOURCE_ATTRIBUTES`、`OTEL_PROPAGATORS`）的场景；
   2. 多 SDK 共存的 instrumentation 环境（`opentelemetry-instrumentation-*` 各自调用 `get_*_provider()`）；
   3. 升级 google-adk / google-genai-instrumentation / litellm 版本时，需复核它们对 logs/metrics 的处理是否变更（如未来 LiteLLM `enable_metrics=True` 默认开启，需同步审计）。
+
+---
+
+## ISSUE-034 AI Agent 在 sandbox 浏览器中走项目 Google OAuth 被同意屏拦截：登录态不可复用导致验证链路中断
+
+- **表因**：AI Agent（Claude / Antigravity）在沙箱形态浏览器（Playwright 默认 `chromium.launch()` 启的空白 profile）中打开 [`localhost:3192`](http://localhost:3192) 触发项目自带的 Google OAuth 流（`/auth/google/login` → `accounts.google.com` → `/auth/google/callback`，参见 [docs/sso.md](./sso.md)），跳转到 `accounts.google.com` 后因该浏览器无任何 Google 登录态，被同意屏 / reCAPTCHA / 二步验证拦截，验证链路在此中断；用户被迫多次手动接管或放弃验证。
+- **根因**：双重契约错配：
+  1. **会话来源错配**：默认 sandbox 浏览器的 cookie store / device fingerprint / IP 风险评分均与用户日常 Chrome 不同，Google 风控将其视为可疑设备；即便用户在沙箱内输入正确账密，亦极易被强制拉起二次验证或拒绝；
+  2. **工具选型缺位**：项目 [CLAUDE.md（即 AGENTS.md）](../CLAUDE.md) 此前未约定"涉及登录态的浏览器验证应优先使用与用户常用 Chrome 共享会话的工具"，AI Agent 默认走 sandbox 即陷入上述风控；
+  3. **Playwright E2E 同样缺位**：`apps/negentropy-ui/playwright.config.ts` 之前无 `setup` project / `storageState` / `userDataDir` 复用机制，凡涉及真实 OAuth 的 E2E 都需重复人工登录或退化为 mock，长期削弱端到端覆盖。
+- **处理方式**：
+  1. **协议落地**：[CLAUDE.md › 术 › Browser Validation Protocol](../CLAUDE.md) 新增子节，明确"涉及登录态的浏览器验证必须复用用户常用 Chrome 会话"，首选 `mcp__claude-in-chrome__*`，退化为 `mcp__chrome_devtools__*` + Chrome `--remote-debugging-port`，禁止在 sandbox 浏览器中通过 Google 同意屏；
+  2. **详尽文档**：新建 [docs/agents/browser-validation.md](./agents/browser-validation.md)，含三种 MCP 浏览器工具的能力对照、Mermaid 选型决策图、三步连通性自检脚本、storageState 工作时序、风控应对、IEEE 引用；
+  3. **Playwright 改造**：
+     - `apps/negentropy-ui/playwright.config.ts` 在 `PLAYWRIGHT_AUTH=1` 时启用两个新 project：`setup`（`/.*\.setup\.ts$/`，强制 headless: false）与 `chromium-authenticated`（`dependencies: ['setup']`，注入 `storageState`），可选 `PLAYWRIGHT_USER_DATA_DIR` 走 `--user-data-dir` 复用本地 profile；
+     - `STORAGE_STATE` 默认 `apps/negentropy-ui/.auth/user.json`，可被 `PLAYWRIGHT_STORAGE_STATE` 覆盖；
+     - 现有 `chromium` project 加 `testIgnore: /.*\.setup\.ts$/`，**不依赖** setup，保护现有 mock 风格 e2e 与 CI 行为完全不变；
+     - 新增 `apps/negentropy-ui/tests/e2e/auth.setup.ts`：打开 `/auth/google/login`、等用户在弹出页手动完成登录、`waitForURL` 离开 `/auth/google/*`、断言 `/api/auth/me` 返回 2xx、写入 storageState；登录窗口超时 5 分钟。
+  4. **凭证防泄漏**：根 `.gitignore` 追加 `apps/negentropy-ui/.auth/` 与 `apps/negentropy-ui/.userdata/`，会话产物只落本地。
+- **后续防范**：
+  1. **AI Agent 默认行为收口**：协议已写入 AGENTS.md，每个新会话首次浏览器验证前必走"三步连通性自检"，任意失败立即停下并把现象返回用户，杜绝"换个浏览器再试"的暗箱重试；
+  2. **凭证零接触**：AI Agent 在任何场景下不读取、不复制、不粘贴用户密码 / 验证码 / Refresh Token；登录步骤一律由用户在浏览器内手动完成（受 `user_privacy` 中 SENSITIVE INFORMATION HANDLING 硬约束）；
+  3. **CI 隔离**：CI 环境禁止挂载真实账号 storageState，未来引入需要登录态的 CI E2E 时走 mock OAuth provider 或专用脱敏账号 + 密钥管理服务，作为后续 Issue 处理；
+  4. **风控避让**：自检 Step 2 与 Step 3 间留 ≥ 3s 间隔；setup project 不在自动循环中重复触发，避免短时高频跳转 Google 同意屏招致风控误报。
+- **同类问题影响**：
+  1. 所有依赖外部第三方登录的链路（Microsoft / Apple / GitHub OAuth、企业 SSO、内部 SaaS 密钥）在 sandbox 浏览器中均会遭遇同质风控，应统一按本协议复用真实浏览器会话；
+  2. 任何"AI Agent 帮我跑一下登录后页面"的请求都应先看协议工具选型矩阵；
+  3. 跨 profile 复制 storageState / Cookie 的方案在 Google / 微软等高风控供应商上不可靠，不建议作为退化方案。


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：AI Agent（Claude / Antigravity）在 sandbox 浏览器（空白 profile）中走项目 Google OAuth 时被同意屏 / reCAPTCHA / 二步验证拦截，导致登录态不可复用、需求验证与回归测试链路中断；项目 Playwright E2E 也缺乏 storageState 复用机制，凡涉及真实 OAuth 都需重复人工登录或退化为 mock。
- 关联上下文/Issue/文档：[ISSUE-034](docs/issue.md)、[浏览器验证协议](docs/agents/browser-validation.md)、[AGENTS.md › 术 › Browser Validation Protocol](AGENTS.md)、[docs/sso.md](docs/sso.md)。

# 核心变更
- **AGENTS.md**：新增「Browser Validation Protocol」子节，明确登录态浏览器验证 **必须** 复用用户常用 Chrome；首选 `mcp__claude-in-chrome__*`，退化为 `mcp__chrome_devtools__*` + `--remote-debugging-port`；禁止在 sandbox 浏览器跳转 Google 同意屏；禁止在 chat 中接触密码 / Cookie / 一次性验证码。
- **docs/agents/browser-validation.md（新增 144 行）**：唯一详尽来源（SSOT）。包含问题陈述、目标 / 非目标、三种 MCP 浏览器工具能力对照、Mermaid 选型决策图、三步连通性自检、Playwright `setup` project + `storageState` 工作时序图、安全凭证守则、二阶风险与防护、IEEE 引用。
- **apps/negentropy-ui/playwright.config.ts**：在 `PLAYWRIGHT_AUTH=1` 时启用两个新 project：`setup`（强制 `headless: false`）与 `chromium-authenticated`（`dependencies: ['setup']` + 注入 `storageState`）；可选 `PLAYWRIGHT_USER_DATA_DIR` 复用本地 profile；基础 `chromium` project 的 `testIgnore` 覆盖 `.setup.ts` 与 `.authed.spec.ts`，保证关闭 AUTH 时行为完全不变、开启 AUTH 时认证 spec 不被无 storageState 的项目重复执行。
- **apps/negentropy-ui/tests/e2e/auth.setup.ts（新增）**：跳转 `/auth/google/login`、等用户在弹出页手动完成登录、`waitForURL` 同时约束 host（避免在跳往 `accounts.google.com` 瞬间被误判为已离开 `/auth/google`）、断言 `/api/auth/me` 返回 2xx、写入 `storageState`；登录窗口超时 5 分钟。
- **.gitignore**：追加 `apps/negentropy-ui/.auth/` 与 `apps/negentropy-ui/.userdata/`，保证 storageState / userDataDir 等会话产物 **仅落本地**。
- **docs/issue.md**：补 ISSUE-034 摘要（表因 / 根因 / 处理方式 / 后续防范 / 同类问题影响）。

# 风险与回滚
- 主要风险：(1) 默认 `PLAYWRIGHT_AUTH` 未开启，新增 project 完全惰性化，对现有 mock 风格 e2e / CI 行为零影响；(2) `auth.setup.ts` 仅在显式开启 AUTH 时被调度，且严格头浏览器手动登录，CI 不会被卡住；(3) 协议层为文档与约束，无运行时副作用。
- 回滚方式：直接 revert 整 PR 即可；本地侧手动删除 `apps/negentropy-ui/.auth/` 与 `.userdata/` 目录释放历史会话。

# 验证证据
- 单元测试：N/A（仅协议文档 + Playwright 配置 + 一份 setup 脚本）。
- 集成测试：默认配置下 `pnpm exec playwright test` 行为与 PR 前一致（`chromium` 唯一 project）。
- E2E/Workflow：本地以 `PLAYWRIGHT_AUTH=1 pnpm exec playwright test --project=setup` 走通一次手动 OAuth → storageState 写入 → `chromium-authenticated` 注入复用；在 host 修复前会复现「early-resolve」缺陷，修复后被压制。
- 覆盖率/关键截图：[browser-validation.md](docs/agents/browser-validation.md) 内含 Mermaid 决策图与时序图。

# 影响范围
- 前端：仅 `apps/negentropy-ui/playwright.config.ts` + 新增 `tests/e2e/auth.setup.ts`，运行时代码零改动。
- 后端：未触达。
- GitHub Actions / 文档：CI 默认 `PLAYWRIGHT_AUTH` 未设置，行为不变；新增 / 更新文档：`AGENTS.md`、`docs/agents/browser-validation.md`、`docs/issue.md`、`.gitignore`。

# Next Best Action
- 在后续 Issue 中接入 mock OAuth provider 或专用脱敏测试账号（凭证收敛到密钥管理服务），让 CI 能真正跑认证 E2E 而非依赖本地 storageState。
- 跟进微软 / 苹果 / GitHub 等其他第三方登录链路在协议下的统一接入。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)