### PR TITLE
fix(bootstrap-otel): 消除被丢弃 PeriodicExportingMetricReader 守护线程的周期 WARNING (ISSUE-038)

### DIFF
--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -38,34 +38,39 @@ logger = get_logger("negentropy.bootstrap")
 
 
 def _disable_adk_otel_logs_metrics_exporters() -> None:
-    """让 ADK ``_get_otel_exporters`` 只返回 traces 的 ``span_processors``。
+    """让 ADK ``_get_otel_exporters`` 仅构造 traces 的 ``span_processors``。
 
     Langfuse 仅承接 ``/v1/traces``；ADK 上游 ``_get_otel_exporters()`` 在
     ``OTEL_EXPORTER_OTLP_ENDPOINT`` 存在时会无差别构造 ``OTLPSpanExporter``、
     ``OTLPMetricExporter``、``OTLPLogExporter`` 三件套——后两者对 Langfuse
     ``/v1/metrics`` 与 ``/v1/logs`` 的上报会命中 SPA 404 错误页。
 
-    本 patch 在 ``OTelHooks`` 拼装入口处把 ``metric_readers`` 与
-    ``log_record_processors`` 永久置空，使 ADK ``maybe_set_otel_providers``
-    的 ``if metric_readers:`` / ``if log_record_processors:`` 分支天然短路——
-    根源避免 ``set_logger_provider`` / ``set_meter_provider`` 被调用，从而消除
-    "Overriding of current ... is not allowed" WARNING；
-    ``span_processors``（traces 链路）不变，traces 仍正常上报到 Langfuse。
+    旧实现调用 ``original()`` 后再丢弃 ``metric_readers`` /
+    ``log_record_processors``——但 ``PeriodicExportingMetricReader`` /
+    ``BatchLogRecordProcessor`` 实例已经被构造且各自启动了守护线程，
+    导致 reader 从未注册到 MeterProvider 时仍每 60s 触发
+    ``Cannot call collect on a MetricReader ...`` WARNING。
+
+    本实现绕过 ``original()``，仅当 ``OTEL_EXPORTER_OTLP_ENDPOINT`` /
+    ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` 存在时调用上游
+    ``_get_otel_span_exporter()`` 构造 traces 通道，根源避免 OTLP metrics /
+    logs exporter 被构造（既消除 WARNING，也省掉无效 daemon 线程）。
 
     未来若启用支持 logs/metrics 的后端（SigNoz、Phoenix 等），改为返回
     ``hooks`` 全部内容即可平滑切换。
     """
+    import opentelemetry.sdk.environment_variables as otel_env
     from google.adk.telemetry import setup as adk_otel_setup
 
     if getattr(adk_otel_setup._get_otel_exporters, "_negentropy_patched", False):
         return
 
-    original = adk_otel_setup._get_otel_exporters
-
     def _patched_get_otel_exporters():
-        hooks = original()
+        span_processors = []
+        if os.getenv(otel_env.OTEL_EXPORTER_OTLP_ENDPOINT) or os.getenv(otel_env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT):
+            span_processors.append(adk_otel_setup._get_otel_span_exporter())
         return adk_otel_setup.OTelHooks(
-            span_processors=hooks.span_processors,
+            span_processors=span_processors,
             metric_readers=[],
             log_record_processors=[],
         )

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -56,8 +56,10 @@ def _disable_adk_otel_logs_metrics_exporters() -> None:
     ``_get_otel_span_exporter()`` 构造 traces 通道，根源避免 OTLP metrics /
     logs exporter 被构造（既消除 WARNING，也省掉无效 daemon 线程）。
 
-    未来若启用支持 logs/metrics 的后端（SigNoz、Phoenix 等），改为返回
-    ``hooks`` 全部内容即可平滑切换。
+    未来若启用支持 logs/metrics 的后端（SigNoz、Phoenix 等），切回 ADK 全量
+    上报的正确路径是：恢复对 ``adk_otel_setup._get_otel_exporters`` 原函数的
+    调用（保留为闭包变量），或直接构造完整 ``OTelHooks``（含 metric_readers /
+    log_record_processors）后返回。
     """
     import opentelemetry.sdk.environment_variables as otel_env
     from google.adk.telemetry import setup as adk_otel_setup

--- a/apps/negentropy/tests/unit_tests/observability/test_otel_noop_providers.py
+++ b/apps/negentropy/tests/unit_tests/observability/test_otel_noop_providers.py
@@ -111,3 +111,45 @@ def test_adk_maybe_set_otel_providers_does_not_touch_logger_meter_globals():
         """
     )
     assert "no_set_provider_ok" in output
+
+
+def test_patch_does_not_construct_orphan_metric_or_log_exporters():
+    """patch 后 _get_otel_exporters 不应触达 _get_otel_metrics_exporter / _get_otel_logs_exporter。
+
+    旧实现调用 ``original()`` 会构造 PeriodicExportingMetricReader
+    （立即启动 60s 守护线程）+ BatchLogRecordProcessor（worker 线程），
+    reader 因从未注册到 MeterProvider，每 tick 触发
+    ``Cannot call collect on a MetricReader ...`` WARNING。本用例
+    sentinel 化两个上游构造器，断言它们零调用。
+    """
+    output = _run_in_subprocess(
+        """
+        import os
+        os.environ['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4318'
+
+        from google.adk.telemetry import setup as adk_setup
+
+        called = {'metrics': 0, 'logs': 0}
+
+        def _boom_metrics():
+            called['metrics'] += 1
+            raise AssertionError('metrics exporter must not be constructed')
+
+        def _boom_logs():
+            called['logs'] += 1
+            raise AssertionError('logs exporter must not be constructed')
+
+        adk_setup._get_otel_metrics_exporter = _boom_metrics
+        adk_setup._get_otel_logs_exporter = _boom_logs
+
+        from negentropy.engine.bootstrap import _disable_adk_otel_logs_metrics_exporters
+        _disable_adk_otel_logs_metrics_exporters()
+
+        hooks = adk_setup._get_otel_exporters()
+        assert called['metrics'] == 0, called
+        assert called['logs'] == 0, called
+        assert len(hooks.span_processors) == 1
+        print('no_orphan_ok')
+        """
+    )
+    assert "no_orphan_ok" in output

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -823,3 +823,17 @@
   2. **跨设备一致性**：localStorage 仅本浏览器持久化。若用户在 A 浏览器选了模型却未 Send 就切到 B 浏览器刷新，B 浏览器读不到。修复路径是后端新增 `PATCH /sessions/{id}/state/selected_llm_model`（沿用 `sessions_api.py::update_session_title` 的 `state_delta + append_event` 模式），handleSelectedLlmModelChange 同时调用前后端双写。本期视用户反馈再决定是否上 backend；
   3. **SSR 安全**：所有 localStorage 访问都做 `typeof window === "undefined"` 守卫，避免 Next.js server build 阶段崩溃；try/catch 包裹避免 SecurityError（如 Safari 隐私模式）。
 - **同类问题影响**：所有「需要『选了即记，与 Send 解耦』」的 UI 偏好（如 thread title 草稿、Composer 草稿、左栏视图模式）都可复用本 helper 模式或抽象为通用 `useSessionPersistedState` hook；本期 YAGNI 只解决 LLM model 一项，不预先抽象。
+
+---
+
+## ISSUE-038 ADK Web 启动期 OTel `Cannot call collect on a MetricReader` 周期 WARNING：被丢弃的 PeriodicExportingMetricReader 守护线程
+
+- **表因**：`uv run adk web` 启动后每 60s 出现 `WARNING | _internal.export | Cannot call collect on a MetricReader until it is registered on a MeterProvider`，与 ISSUE-034 处理的 `Overriding of current ... Provider` 完全不同。
+- **根因**：ISSUE-034 的 `_patched_get_otel_exporters` 调用 `original()` 后再把 `metric_readers` / `log_record_processors` 置空，但上游 `_get_otel_exporters` 在 `OTEL_EXPORTER_OTLP_ENDPOINT` 存在时已无条件构造 `PeriodicExportingMetricReader(OTLPMetricExporter())`（`google/adk/telemetry/setup.py:163-166`）——`__init__` 立即启动每 60s 守护线程（`opentelemetry/sdk/metrics/_internal/export/__init__.py:494`）；reader 因未注册到 MeterProvider，`_collect` 为 None，每次 tick 触发 WARNING（同文件 line 334-336）。
+- **二阶影响**：日志噪声 + 多余 daemon 线程占用资源；与 ISSUE-034 修复后"治标"印象矛盾。
+- **处理方式**：`_patched_get_otel_exporters` 不再调用 `original()`，直接复用 `adk_otel_setup._get_otel_span_exporter()` 只构造 traces span processor（`bootstrap.py:40-88`），根源避免 OTLP metrics / logs exporter 被实例化。测试新增 `test_patch_does_not_construct_orphan_metric_or_log_exporters` 用 sentinel 化 `_get_otel_metrics_exporter` / `_get_otel_logs_exporter` 验证零调用。
+- **后续防范**：
+  1. **patch 上游工厂时优先全量重写返回值**而非"调用后裁剪"，避免副作用进入对象生命周期；
+  2. 凡 `__init__` 启动后台线程的 OTel 组件（`PeriodicExportingMetricReader`、`BatchLogRecordProcessor`、`BatchSpanProcessor`）一经实例化即等同"已激活"，不可只靠"不返回"屏蔽；
+  3. ADK 升级时审计 `_get_otel_span_exporter` / `OTelHooks` 字段。
+- **同类问题影响**：所有"调用上游工厂后再丢弃部分返回"的 patch 都需检查工厂是否在构造路径上启动后台线程。


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：`uv run adk web` 启动后每 60s 出现 `WARNING | _internal.export | Cannot call collect on a MetricReader until it is registered on a MeterProvider`。ISSUE-034 修复 `Overriding of current ... Provider` 时，`_patched_get_otel_exporters` 仍调用 `original()` 后再丢弃 `metric_readers` / `log_record_processors`——但 `PeriodicExportingMetricReader` / `BatchLogRecordProcessor` 在 `__init__` 阶段已启动守护线程，reader 未注册到 MeterProvider 仍按 60s 周期触发 collect 警告。
- 关联上下文/Issue/文档：[docs/issue.md ISSUE-038](../docs/issue.md)，承接 ISSUE-034 治标 → ISSUE-038 治本。

# 核心变更

- `_disable_adk_otel_logs_metrics_exporters` 不再调用 `original()`，改为直接复用上游 `adk_otel_setup._get_otel_span_exporter()` 仅构造 traces span processor，根源避免 OTLP metrics / logs exporter 实例化（既消除 WARNING，也省掉无效 daemon 线程）。
- 新增单测 `test_patch_does_not_construct_orphan_metric_or_log_exporters`：sentinel 化 `_get_otel_metrics_exporter` / `_get_otel_logs_exporter`，断言 patch 后两者零调用。
- `docs/issue.md` 新增 ISSUE-038 完整溯源（表因/根因/二阶影响/防范），并在 docstring 中明确未来切回 ADK 全量上报的路径。

# 风险与回滚

- 主要风险：若未来需要 metrics / logs 通道，需要按 docstring 指引恢复完整 `OTelHooks` 构造或调用 `original()`。当前 Langfuse 仅承接 `/v1/traces`，traces 链路完全保留，不影响既有上报。
- 回滚方式：直接 revert 本 PR 即可恢复至 ISSUE-034 的实现（功能回退至带 WARNING 噪声态，但不会丢失 traces）。

# 验证证据

- 单元测试：`apps/negentropy/tests/unit_tests/observability/test_otel_noop_providers.py` 4 个用例全绿，新增 sentinel 用例确保 metrics/logs exporter 构造器零调用。
- 集成测试：N/A（patch 在 import 期生效，已由子进程化单测覆盖全局状态隔离）。
- E2E/Workflow：N/A。
- 覆盖率/关键截图：本地 `uv run adk web` 启动后 60s+120s 不再复现 `Cannot call collect ...` WARNING。

# 影响范围

- 前端：无。
- 后端：仅 `apps/negentropy/src/negentropy/engine/bootstrap.py` 的 OTel patch 逻辑；ADK service factory / FastAPI 注入链路不变。
- GitHub Actions / 文档：`docs/issue.md` 增补 ISSUE-038 条目。

# Next Best Action

- 若后续接入 SigNoz / Phoenix 等支持 logs/metrics 的后端，按 docstring 恢复 `_get_otel_exporters` 原函数闭包或自行构造完整 `OTelHooks`。
- 同步审计其他 "调用上游工厂后丢弃部分返回" 的 patch（如 LiteLLM callback 链路），防范同类 daemon-thread 泄漏。