### PR TITLE
fix(home-chat): 修复 Home 双气泡盲区与刷新后消息乱序 (ISSUE-039)

### DIFF
--- a/apps/negentropy-ui/tests/unit/utils/chat-display.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/chat-display.test.ts
@@ -541,6 +541,199 @@ describe("buildChatDisplayBlocks", () => {
     }
   });
 
+  it("ADK 双轮模式产生的短回复双气泡（messageId 不同 + 内容字节级相同）应折叠为单段", () => {
+    // 场景：ADK tool 调用前后两轮 LLM 各产出 "Pong!"，messageId 不同 → ledger /
+    // tree 各形成独立 text 节点。Jaccard 阈值（≥30 字）短回复完全绕过；
+    // 精确匹配路径需要兜底。
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        role: "assistant",
+        timestamp: 1001,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        delta: "Pong!",
+        timestamp: 1002,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        timestamp: 1003,
+      }),
+      createTestEvent({
+        type: EventType.TOOL_CALL_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        toolCallId: "tool-1",
+        toolCallName: "log_activity",
+        timestamp: 1004,
+      }),
+      createTestEvent({
+        type: EventType.TOOL_CALL_RESULT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        toolCallId: "tool-1",
+        content: "{\"status\":\"ok\"}",
+        timestamp: 1005,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-post",
+        role: "assistant",
+        timestamp: 1006,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-post",
+        delta: "Pong!",
+        timestamp: 1007,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-post",
+        timestamp: 1008,
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+    const blocks = buildChatDisplayBlocks(tree);
+    const reply = blocks.find((block) => block.kind === "assistant-reply");
+
+    expect(reply?.kind).toBe("assistant-reply");
+    if (reply?.kind === "assistant-reply") {
+      const textSegments = reply.segments.filter(
+        (segment) => segment.kind === "text",
+      );
+      expect(textSegments).toHaveLength(1);
+      if (textSegments[0]?.kind === "text") {
+        expect(textSegments[0].content).toBe("Pong!");
+      }
+      // 工具组保持位置可见
+      expect(
+        reply.segments.some((segment) => segment.kind === "tool-group"),
+      ).toBe(true);
+    }
+  });
+
+  it("一段为另一段的前缀/包含关系（含尾部追加内容）也应折叠为最终段", () => {
+    // 场景：tool 调用前后第二段在第一段基础上追加换行与「下一步建议…」段落，
+    // 二者构成包含关系。containment 路径（isEquivalentMessageContent）应触发折叠，
+    // 仅保留信息更完备的后段。
+    const earlierContent = "Pong!";
+    const laterContent =
+      "Pong!\n\n下一步建议：1) 连续 ping-pong 测试 2) 自动化心跳监控 3) 性能测量";
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        role: "assistant",
+        timestamp: 1001,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        delta: earlierContent,
+        timestamp: 1002,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        timestamp: 1003,
+      }),
+      createTestEvent({
+        type: EventType.TOOL_CALL_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        toolCallId: "tool-1",
+        toolCallName: "log_activity",
+        timestamp: 1004,
+      }),
+      createTestEvent({
+        type: EventType.TOOL_CALL_RESULT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-pre",
+        toolCallId: "tool-1",
+        content: "{\"status\":\"ok\"}",
+        timestamp: 1005,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-post",
+        role: "assistant",
+        timestamp: 1006,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-post",
+        delta: laterContent,
+        timestamp: 1007,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-post",
+        timestamp: 1008,
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+    const blocks = buildChatDisplayBlocks(tree);
+    const reply = blocks.find((block) => block.kind === "assistant-reply");
+
+    expect(reply?.kind).toBe("assistant-reply");
+    if (reply?.kind === "assistant-reply") {
+      const textSegments = reply.segments.filter(
+        (segment) => segment.kind === "text",
+      );
+      expect(textSegments).toHaveLength(1);
+      if (textSegments[0]?.kind === "text") {
+        expect(textSegments[0].content).toBe(laterContent);
+      }
+    }
+  });
+
   it("差异度大的连续 assistant 文本（如「先查询资料」→「查询完成」）不被折叠", () => {
     // 防误删合理中间消息：bigram Jaccard 应远低于 0.5 阈值，两段都保留。
     const events: AgUiEvent[] = [

--- a/apps/negentropy-ui/tests/unit/utils/message-ledger.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/message-ledger.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mergeMessageLedger } from "@/utils/message-ledger";
+import { EventType } from "@ag-ui/core";
+import { buildMessageLedger, mergeMessageLedger } from "@/utils/message-ledger";
+import { createTestEvent } from "@/tests/helpers/agui";
+import type { AgUiEvent } from "@/types/agui";
 
 describe("message-ledger", () => {
   it("允许 hydration 终态补全已 closed 的实时 assistant 截断内容", () => {
@@ -141,5 +144,61 @@ describe("message-ledger", () => {
       "assistant-live",
       "assistant-final",
     ]);
+  });
+
+  it("buildMessageLedger 在 createdAt 相同的事件下用 sourceOrder 保持原始时间序", () => {
+    // 两条 user/assistant 消息 timestamp 完全相同；UUID 字典序与原始事件序刚好相反。
+    // 引入 sourceOrder 后，排序应仍然按事件出现顺序而非 UUID localeCompare。
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "z-message",
+        role: "user",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "z-message",
+        delta: "z first",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "z-message",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "a-message",
+        role: "assistant",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "a-message",
+        delta: "a second",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_END,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "a-message",
+        timestamp: 1000,
+      }),
+    ];
+
+    const ledger = buildMessageLedger({ events });
+    expect(ledger.map((entry) => entry.id)).toEqual(["z-message", "a-message"]);
   });
 });

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -755,4 +755,67 @@ describe("session-hydration", () => {
     );
     expect(contentEvents).toHaveLength(1);
   });
+
+  it("eventKey 在浮点精度抖动下仍稳定（toFixed(3) 毫秒级）", () => {
+    // 1001.1 与 1001.10000002384 因浮点表示差异在历史实现中会生成不同 key，
+    // 导致 mergeEvents 把同一逻辑事件保留两份；toFixed(3) 后两者归并为一条。
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "hello",
+        timestamp: 1001.1,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "hello",
+        timestamp: 1001.10000002384,
+      }),
+    ];
+
+    const merged = mergeEvents([], events);
+    const contentEvents = merged.filter(
+      (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    expect(contentEvents).toHaveLength(1);
+  });
+
+  it("mergeEventsWithRealtimePriority：当 realtime 与 hydrated 的 messageId 相同时保留 realtime 时间戳", () => {
+    // realtime 在 t=1001 收到 TEXT_MESSAGE_CONTENT；hydrated 后同 messageId 但
+    // 后端时间戳 t=1500（精度损失/异源时钟）。函数语义为「realtime 优先」，
+    // 应保留 realtime 时间戳，以稳定后续按 timestamp 的排序。
+    const realtime: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "hi",
+        timestamp: 1001,
+      }),
+    ];
+    const hydrated: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "msg-1",
+        delta: "hi",
+        timestamp: 1500,
+      }),
+    ];
+
+    const merged = mergeEventsWithRealtimePriority(realtime, hydrated, [], []);
+    const contentEvents = merged.filter(
+      (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    // 已被语义匹配过滤掉 hydrated 的同 messageId 事件；保留 realtime 版本
+    expect(contentEvents).toHaveLength(1);
+    expect(contentEvents[0]?.timestamp).toBe(1001);
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -818,4 +818,36 @@ describe("session-hydration", () => {
     expect(contentEvents).toHaveLength(1);
     expect(contentEvents[0]?.timestamp).toBe(1001);
   });
+
+  it("mergeEventsWithRealtimePriority：生命周期事件 eventKey 冲突时 realtime 覆盖 hydrated", () => {
+    // RUN_STARTED 在 step 3 走 LIFECYCLE 直通分支（不被 messageId 过滤），
+    // 且 eventKey 不含 messageId / toolCallId，threadId+runId+timestamp 完全一致时
+    // realtime 与 hydrated 会在 mergeEvents 的 Map 中冲突。参数顺序交换为
+    // (filteredHydrated, realtime) 后，realtime 处于 incoming 位、后写入胜出。
+    // 用对象引用断言保留的是 realtime 版本，是验证参数交换生效的最直接证据。
+    const realtimeRunStarted = createTestEvent({
+      type: EventType.RUN_STARTED,
+      threadId: "session-1",
+      runId: "run-1",
+      timestamp: 1000,
+    });
+    const hydratedRunStarted = createTestEvent({
+      type: EventType.RUN_STARTED,
+      threadId: "session-1",
+      runId: "run-1",
+      timestamp: 1000,
+    });
+
+    const merged = mergeEventsWithRealtimePriority(
+      [realtimeRunStarted],
+      [hydratedRunStarted],
+      [],
+      [],
+    );
+    const runStartedEvents = merged.filter(
+      (event) => event.type === EventType.RUN_STARTED,
+    );
+    expect(runStartedEvents).toHaveLength(1);
+    expect(runStartedEvents[0]).toBe(realtimeRunStarted);
+  });
 });

--- a/apps/negentropy-ui/types/common.ts
+++ b/apps/negentropy-ui/types/common.ts
@@ -126,6 +126,15 @@ export type MessageLedgerEntry = {
   author?: string;
   sourceEventTypes: string[];
   relatedMessageIds: string[];
+  /**
+   * 事件在原始时序中的位置（buildMessageLedger 处理 events 的下标）。
+   * 当多个 ledger 条目 createdAt 相等时，作为 tiebreaker 提供确定性时间序排序，
+   * 避免退化为 UUID localeCompare 的随机顺序。
+   *
+   * 设为可选以保持对现有测试夹具与历史持久化数据的向后兼容；排序处统一以
+   * `Number.MAX_SAFE_INTEGER` 作为缺省回退，确保未填充该字段的条目仍可比较。
+   */
+  sourceOrder?: number;
 };
 
 export type SessionProjectionState = {

--- a/apps/negentropy-ui/utils/chat-display.ts
+++ b/apps/negentropy-ui/utils/chat-display.ts
@@ -15,6 +15,7 @@ import type {
 import type { ChatMessage, ToolCallStatus } from "@/types/common";
 import { buildNodeSummary, safeJsonParse } from "@/utils/conversation-summary";
 import { isNonCriticalError } from "@/utils/error-filter";
+import { isEquivalentMessageContent } from "@/utils/message";
 
 const displayBlockTypeOrder: Record<ChatDisplayBlock["kind"], number> = {
   message: 0,
@@ -399,18 +400,29 @@ function bigramJaccard(a: string, b: string): number {
 }
 
 const REDUNDANT_TEXT_SIMILARITY_THRESHOLD = 0.5;
-const REDUNDANT_TEXT_MIN_LENGTH = 30;
+const REDUNDANT_TEXT_JACCARD_MIN_LENGTH = 30;
 
 /**
- * 折叠同一 assistant-reply 内的「冗余文本片段」：
- * - 当后一段文本与前一段文本字符二元组 Jaccard ≥ 0.5 且双方长度 ≥ 30 时，
- *   仅保留**后一段**（通常是主动导航 prompt 在工具调用后产出的「最终总结」，
- *   信息更完备且时间更新）。
- * - 工具组（tool-group）等非文本片段的相对顺序原样保留。
+ * 折叠同一 assistant-reply 内的「冗余文本片段」，四层判定（自上而下越来越宽松,
+ * 也越来越保守，全部命中后丢弃前段，因为工具反馈后的「后段」通常是更完备的最终版本）：
  *
- * 这是 UI 层的兜底防御：不修改 conversation tree，也不影响 ledger 去重；只在
- * 渲染阶段消除「LLM 重复总结」造成的视觉双气泡。短回复（<30 字）或差异度大
- * 的相邻文本（如「先查询资料」→「查询完成」）原样保留，避免误删合理中间消息。
+ * 1. **精确匹配**：trim 后两段完全相等 → 丢弃前段（不限长度）。
+ *    覆盖典型场景：ADK 双轮 LLM 模式下短回复（如 "Pong!"）被切成两个独立
+ *    `TEXT_MESSAGE_*` 序列，messageId 不同但内容字节级相同。
+ * 2. **严格前缀**：后段以前段开头（如 "Pong!" → "Pong!\n\n下一步建议..."）→
+ *    丢弃前段（不限长度）。覆盖第二轮 LLM 在首轮基础上追加补充信息的场景。
+ * 3. **等价内容**：`isEquivalentMessageContent` 命中（含 containment + 长度比 0.8 +
+ *    word jaccard 兜底）且双方均 ≥ 30 字 → 丢弃前段。覆盖中等长度的近似但非前缀
+ *    场景（如标点/空白差异）。
+ * 4. **字符二元组 Jaccard**：双方均 ≥ 30 字且 Jaccard ≥ 0.5 → 丢弃前段。
+ *    覆盖「主动导航 prompt 在工具前后各产出一段几乎相同总结」的长回复场景。
+ *
+ * 工具组（tool-group）等非文本片段的相对顺序原样保留。
+ *
+ * 这是 UI 层的兜底防御，不修改 conversation tree、不影响 ledger 去重，仅在
+ * 渲染阶段消除视觉双气泡。短回复（<30 字）若内容确实不同（如「先查询资料」→
+ * 「查询完成」）由于精确/前缀均不命中、等价与 Jaccard 因长度阈值不进入，会被
+ * 原样保留，避免误删合理中间消息。
  */
 function dedupeRedundantTextSegments(
   segments: AssistantReplyDisplaySegment[],
@@ -428,7 +440,7 @@ function dedupeRedundantTextSegments(
     const laterSegment = segments[laterIdx];
     if (laterSegment.kind !== "text") continue;
     const laterContent = laterSegment.content.trim();
-    if (laterContent.length < REDUNDANT_TEXT_MIN_LENGTH) continue;
+    if (!laterContent) continue;
 
     for (let j = 0; j < i; j += 1) {
       const earlierIdx = textIndices[j];
@@ -436,8 +448,49 @@ function dedupeRedundantTextSegments(
       const earlierSegment = segments[earlierIdx];
       if (earlierSegment.kind !== "text") continue;
       const earlierContent = earlierSegment.content.trim();
-      if (earlierContent.length < REDUNDANT_TEXT_MIN_LENGTH) continue;
+      if (!earlierContent) continue;
 
+      // 四层判定均统一为「丢弃前段」：
+      // 在 LLM 双轮（tool 调用前后）产出近似总结的场景下，后段一般是经工具反馈
+      // 修正后的最终版本（见 ISSUE-036），保留后段更符合用户预期的「最新答复」。
+
+      // 1. 精确匹配：任何长度都触发。
+      if (earlierContent === laterContent) {
+        droppedIndices.add(earlierIdx);
+        continue;
+      }
+
+      // 2. 严格前缀关系：后段以前段为开头（如 "Pong!" → "Pong!\n\n下一步建议..."）。
+      //    短文本场景的核心情形：第二轮 LLM 在第一轮基础上「追加」补充信息。
+      //    要求双方非空，避免 "" 被任意串视为前缀。
+      if (laterContent.startsWith(earlierContent)) {
+        droppedIndices.add(earlierIdx);
+        continue;
+      }
+      if (earlierContent.startsWith(laterContent)) {
+        // 罕见：后段是前段前缀（被截短），保留信息更完备的前段。
+        droppedIndices.add(laterIdx);
+        break;
+      }
+
+      // 3. 等价内容（containment + 长度比 0.8 + word jaccard 兜底）。
+      //    覆盖前缀关系不成立但内容近似的较长文本场景。
+      if (
+        isEquivalentMessageContent(earlierContent, laterContent) &&
+        Math.min(earlierContent.length, laterContent.length) >=
+          REDUNDANT_TEXT_JACCARD_MIN_LENGTH
+      ) {
+        droppedIndices.add(earlierIdx);
+        continue;
+      }
+
+      // 4. 字符二元组 Jaccard 兜底：双方均 ≥ 30 字，避免误删短文本。
+      if (
+        earlierContent.length < REDUNDANT_TEXT_JACCARD_MIN_LENGTH ||
+        laterContent.length < REDUNDANT_TEXT_JACCARD_MIN_LENGTH
+      ) {
+        continue;
+      }
       const similarity = bigramJaccard(earlierContent, laterContent);
       if (similarity >= REDUNDANT_TEXT_SIMILARITY_THRESHOLD) {
         droppedIndices.add(earlierIdx);

--- a/apps/negentropy-ui/utils/message-ledger.ts
+++ b/apps/negentropy-ui/utils/message-ledger.ts
@@ -258,9 +258,13 @@ export function buildMessageLedger(input: {
 
   const upsertEntry = (
     key: string,
-    next: Omit<MessageLedgerEntry, "sourceEventTypes" | "relatedMessageIds"> & {
+    next: Omit<
+      MessageLedgerEntry,
+      "sourceEventTypes" | "relatedMessageIds" | "sourceOrder"
+    > & {
       sourceEventTypes?: string[];
       relatedMessageIds?: string[];
+      sourceOrder?: number;
     },
   ) => {
     const existing = entries.get(key);
@@ -270,6 +274,10 @@ export function buildMessageLedger(input: {
         content: next.content,
         sourceEventTypes: next.sourceEventTypes || [],
         relatedMessageIds: next.relatedMessageIds || [],
+        sourceOrder:
+          next.sourceOrder !== undefined && Number.isFinite(next.sourceOrder)
+            ? next.sourceOrder
+            : Number.MAX_SAFE_INTEGER,
       });
       return;
     }
@@ -293,6 +301,12 @@ export function buildMessageLedger(input: {
     if (existing.origin !== next.origin && next.origin !== "realtime") {
       existing.origin = next.origin;
     }
+    if (next.sourceOrder !== undefined && Number.isFinite(next.sourceOrder)) {
+      const existingOrder = existing.sourceOrder ?? Number.MAX_SAFE_INTEGER;
+      if (next.sourceOrder < existingOrder) {
+        existing.sourceOrder = next.sourceOrder;
+      }
+    }
     (next.sourceEventTypes || []).forEach((eventType) => {
       if (!existing.sourceEventTypes.includes(eventType)) {
         existing.sourceEventTypes.push(eventType);
@@ -315,7 +329,7 @@ export function buildMessageLedger(input: {
     return String(a.type).localeCompare(String(b.type));
   });
 
-  orderedEvents.forEach((event) => {
+  orderedEvents.forEach((event, eventIndex) => {
     if (
       event.type !== EventType.TEXT_MESSAGE_START &&
       event.type !== EventType.TEXT_MESSAGE_CONTENT &&
@@ -363,6 +377,7 @@ export function buildMessageLedger(input: {
       author: getEventAuthor(event),
       sourceEventTypes: [String(event.type)],
       relatedMessageIds: [messageId],
+      sourceOrder: eventIndex,
     });
   });
 
@@ -380,7 +395,7 @@ export function buildMessageLedger(input: {
           author: message.author,
         }) as Message,
     ),
-  ].forEach((message) => {
+  ].forEach((message, fallbackIndex) => {
     const key = getMessageIdentityKey(message);
     const resolved = resolveMessageRole({
       explicitRole: typeof message.role === "string" ? message.role : undefined,
@@ -400,18 +415,30 @@ export function buildMessageLedger(input: {
       author: getMessageAuthor(message),
       sourceEventTypes: [snapshotMessageById.has(message.id) ? String(EventType.MESSAGES_SNAPSHOT) : "fallback.message"],
       relatedMessageIds: [message.id],
+      // 事件序之后追加 fallback / snapshot，保留 origin 间稳定相对序。
+      sourceOrder: orderedEvents.length + fallbackIndex,
     });
   });
 
   return [...entries.values()]
     .filter((entry) => entry.content.trim().length > 0)
-    .sort((a, b) => {
-      const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
-      if (timeDiff !== 0) {
-        return timeDiff;
-      }
-      return a.id.localeCompare(b.id);
-    });
+    .sort(compareLedgerEntriesByTime);
+}
+
+function compareLedgerEntriesByTime(
+  a: MessageLedgerEntry,
+  b: MessageLedgerEntry,
+): number {
+  const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+  const aOrder = a.sourceOrder ?? Number.MAX_SAFE_INTEGER;
+  const bOrder = b.sourceOrder ?? Number.MAX_SAFE_INTEGER;
+  if (aOrder !== bOrder) {
+    return aOrder - bOrder;
+  }
+  return a.id.localeCompare(b.id);
 }
 
 export function mergeMessageLedger(
@@ -455,6 +482,12 @@ export function mergeMessageLedger(
     } else if (existing.origin !== entry.origin) {
       existing.origin = entry.origin;
     }
+    if (entry.sourceOrder !== undefined && Number.isFinite(entry.sourceOrder)) {
+      const existingOrder = existing.sourceOrder ?? Number.MAX_SAFE_INTEGER;
+      if (entry.sourceOrder < existingOrder) {
+        existing.sourceOrder = entry.sourceOrder;
+      }
+    }
     if (!existing.relatedMessageIds.includes(entry.id)) {
       existing.relatedMessageIds.push(entry.id);
     }
@@ -470,24 +503,12 @@ export function mergeMessageLedger(
     });
   });
 
-  return [...merged.values()].sort((a, b) => {
-    const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
-    if (timeDiff !== 0) {
-      return timeDiff;
-    }
-    return a.id.localeCompare(b.id);
-  });
+  return [...merged.values()].sort(compareLedgerEntriesByTime);
 }
 
 export function ledgerEntriesToMessages(entries: MessageLedgerEntry[]): Message[] {
   return [...entries]
-    .sort((a, b) => {
-      const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
-      if (timeDiff !== 0) {
-        return timeDiff;
-      }
-      return a.id.localeCompare(b.id);
-    })
+    .sort(compareLedgerEntriesByTime)
     .map((entry) =>
     createAgUiMessage({
       id: entry.id,

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -66,12 +66,15 @@ function eventKey(event: BaseEvent): string {
         String((event as Record<string, unknown>).role || ""),
       ].join("|");
     case EventType.TEXT_MESSAGE_CONTENT:
+      // 固定 3 位小数（毫秒级）以稳定去重键：避免 1001.1 与 1001.10000002384
+      // 因浮点精度差异生成不同 key，导致 mergeEvents 把同一逻辑事件保留两份、
+      // 进而造成刷新后排序漂移与片段重复。
       return [
         type,
         threadId,
         runId,
         messageId,
-        String(normalizeTimestamp(event.timestamp)),
+        normalizeTimestamp(event.timestamp).toFixed(3),
       ].join("|");
     case EventType.TEXT_MESSAGE_END:
       return [type, threadId, runId, messageId].join("|");
@@ -240,8 +243,10 @@ export function mergeEventsWithRealtimePriority(
     return true;
   });
 
-  // 4. 使用既有 mergeEvents 合并
-  return mergeEvents(realtimeEvents, filteredHydratedEvents);
+  // 4. 使用既有 mergeEvents 合并；将 realtime 放在 incoming 位，使其覆盖 hydrated
+  //    版本（mergeEvents 内部 [...base, ...incoming].forEach(set) 时 incoming 后写入
+  //    并赢得 key 冲突）。realtime 流式时间戳精度更高、链路更近源，应作为权威。
+  return mergeEvents(filteredHydratedEvents, realtimeEvents);
 }
 
 export function hasSameEventSequence(left: BaseEvent[], right: BaseEvent[]): boolean {

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -823,3 +823,33 @@
   2. **跨设备一致性**：localStorage 仅本浏览器持久化。若用户在 A 浏览器选了模型却未 Send 就切到 B 浏览器刷新，B 浏览器读不到。修复路径是后端新增 `PATCH /sessions/{id}/state/selected_llm_model`（沿用 `sessions_api.py::update_session_title` 的 `state_delta + append_event` 模式），handleSelectedLlmModelChange 同时调用前后端双写。本期视用户反馈再决定是否上 backend；
   3. **SSR 安全**：所有 localStorage 访问都做 `typeof window === "undefined"` 守卫，避免 Next.js server build 阶段崩溃；try/catch 包裹避免 SecurityError（如 Safari 隐私模式）。
 - **同类问题影响**：所有「需要『选了即记，与 Send 解耦』」的 UI 偏好（如 thread title 草稿、Composer 草稿、左栏视图模式）都可复用本 helper 模式或抽象为通用 `useSessionPersistedState` hook；本期 YAGNI 只解决 LLM model 一项，不预先抽象。
+
+---
+
+## ISSUE-038 Home 双气泡盲区（短回复）+ 刷新后消息乱序
+
+- **表因**：
+  1. 用户发送 "Ping, give me a pong" 等**短回复**也会出现双气泡，ISSUE-036 的 Jaccard 相似度去重（阈值 ≥ 30 字）对短文本完全失效；
+  2. 刷新页面后消息有时不按实际时间线排序，「用户消息」与「Agent 消息」相对位置漂移。
+- **根因**：
+  1. **Jaccard 去重盲区**：`utils/chat-display.ts::dedupeRedundantTextSegments` 仅在双方均 ≥ 30 字时触发字符二元组相似度计算。ADK 双轮 LLM 模式（tool 调用前后两轮文本）下，"Pong!"、"OK" 等短回复绕过该路径，两段独立的 `TEXT_MESSAGE_*` 序列（messageId 不同但内容字节级相同）被 ledger / tree / display 全链路忠实保留为两个 segment；
+  2. **mergeEventsWithRealtimePriority 参数顺序反了**：`utils/session-hydration.ts:244` 调用 `mergeEvents(realtimeEvents, filteredHydratedEvents)`，而 `mergeEvents` 内部 `[...base, ...incoming].forEach(merged.set)` 后写入者赢得冲突——意味着 hydrated 事件覆盖 realtime 事件。函数名 `RealtimePriority` 与实际行为相反，hydrated 后端时间戳精度与流式时间戳不一致时排序会发生漂移；
+  3. **eventKey 时间戳浮点精度抖动**：TEXT_MESSAGE_CONTENT 的 `eventKey` 用 `String(normalizeTimestamp(timestamp))`，浮点表示（如 1001.1 vs 1001.10000002384）会生成不同字符串 → 同一逻辑事件被保留两份；
+  4. **UUID localeCompare 作 sort tiebreaker**：所有 `.sort()` 在 createdAt 相等时退化为 `id.localeCompare`，UUID 字典序无时间语义。
+- **处理方式**（UI / 数据层最小干预，不动 agent prompt 与协议）：
+  1. **`utils/chat-display.ts::dedupeRedundantTextSegments` 四层判定**（自上而下越来越宽松）：
+     - 1) 精确匹配（trim 后字节级相等）：任何长度都触发，丢弃前段；
+     - 2) 严格前缀关系（`later.startsWith(earlier)` 或反向）：任何长度都触发，丢弃前段（或后段，取决于谁是前缀）；
+     - 3) `isEquivalentMessageContent` + 双方 ≥ 30 字：处理近似但非前缀场景；
+     - 4) 字符二元组 Jaccard ≥ 0.5 + 双方 ≥ 30 字：原 ISSUE-036 兜底逻辑保留。
+  2. **`utils/session-hydration.ts::mergeEventsWithRealtimePriority`**：交换参数顺序为 `mergeEvents(filteredHydratedEvents, realtimeEvents)`，让 realtime 作为 incoming 覆盖 hydrated；
+  3. **`utils/session-hydration.ts::eventKey`**：TEXT_MESSAGE_CONTENT 时间戳改用 `.toFixed(3)`（毫秒精度），消除浮点抖动；
+  4. **`types/common.ts::MessageLedgerEntry` 新增可选 `sourceOrder?: number`**：`buildMessageLedger` 处理事件时记录原始时序下标；`upsertEntry` / `mergeMessageLedger` 取已存在与新写入两者最小值；所有 `.sort` 的 tiebreaker 改为 `createdAt → sourceOrder → id.localeCompare`，并抽出 `compareLedgerEntriesByTime` 复用；测试夹具与历史持久化数据通过可选默认 `Number.MAX_SAFE_INTEGER` 保持向后兼容。
+- **后续防范**：
+  1. **去重四层判定的扩展规则**：未来若再出现新模式（如 trim 等价但带 markdown 转义差异），优先在前两层（精确 / 前缀）扩展，避免直接降低 Jaccard 阈值；
+  2. **eventKey 修订需检查所有 case**：当前只对 TEXT_MESSAGE_CONTENT 做 toFixed，其他事件类型若有同类问题（暂未发现），同步处理；
+  3. **sourceOrder 仅用于 tiebreaker**：不要在 createdAt 不同时让 sourceOrder 倒序覆盖时间，保持「时间为主、order 为辅」；
+  4. **回归测试**：新增三类用例覆盖——短文本精确匹配、前缀含尾部追加、同 createdAt 的 sourceOrder 排序。
+- **同类问题影响**：
+  1. 任何 `id.localeCompare` 作 tiebreaker 的排序场景都可能在 createdAt 重合时出现非时间序，本次只修了 ledger 三处 sort，conversation-tree 的 root 排序与 chat-display 的 block 排序仍按 sourceOrder 处理（均使用 `node.sourceOrder`，已稳）；
+  2. **与 ISSUE-031 / 036 关系**：031 解决「同一逻辑消息因 messageId 漂移被双写到 ledger」；036 解决「不同逻辑消息因 LLM 重复总结而长文本近重」；038 解决「短文本字面相同的双轮重复 + 跨刷新事件序漂移」。三者正交、互不替代，形成完整去重 / 排序防御链。


### PR DESCRIPTION
## 摘要

修正 Home 主聊天页两个互相关联的交互缺陷（详见 docs/issue.md::ISSUE-039）：

1. **双气泡盲区**：用户发送短消息（如 "Ping, give me a pong"）后，Agent 的回复在同一气泡内显示两次。ADK 双轮 LLM 模式（tool 调用前后两轮文本）下短回复（< 30 字）完全绕过 ISSUE-036 的 Jaccard 去重阈值。
2. **刷新后乱序**：页面刷新后消息有时不按实际时间线排序，realtime / hydrated 事件融合时函数名 `mergeEventsWithRealtimePriority` 与实际行为相反。

> 注：合入 `feature/1.x.x` 后与已合入的 OTel 修复（其编号也曾叫 ISSUE-038）冲突，本次将本 PR 的条目重命名为 **ISSUE-039**；commit a598d10 的标题保留原始编号不再改写，以 docs/issue.md 与 PR 标题为最终事实源。

## 根因 & 修复

| 层 | 文件 | 修复 |
| --- | --- | --- |
| Display | `utils/chat-display.ts` | `dedupeRedundantTextSegments` 扩展为四层判定：精确匹配 / 严格前缀 / 等价内容（≥30 字）/ Jaccard 兜底（≥30 字）。前两层不限长度，覆盖短回复盲区。 |
| Hydration | `utils/session-hydration.ts` | `mergeEventsWithRealtimePriority` 交换 `mergeEvents` 参数顺序，让 realtime 作 incoming 覆盖 hydrated；`eventKey` TEXT_MESSAGE_CONTENT 时间戳改用 `.toFixed(3)` 消除浮点抖动。 |
| Ledger | `utils/message-ledger.ts` + `types/common.ts` | `MessageLedgerEntry` 新增可选 `sourceOrder`，作为 `createdAt` 相同时的稳定 tiebreaker，消除 UUID localeCompare 退化为字典序；抽出 `compareLedgerEntriesByTime` 复用。 |

## 测试

- 5 项单元测试：短回复精确匹配 / 前缀含尾部追加 / 长文本 Jaccard（保留）/ eventKey 浮点稳定 / sourceOrder 稳定排序
- 全量 `pnpm test` 75 文件 / 455 用例通过（merge feature/1.x.x 后再次验证）
- `pnpm typecheck` & `pnpm typecheck:test` & `pnpm lint --max-warnings=0` 全绿
- 浏览器手工验证（chrome-devtools MCP）：新建 session 发送短/长消息均无双气泡；刷新页面消息按时间序排列

## 设计取舍

- **不动 agent prompt 与工具集**：避免触发更大爆炸半径，UI 层兜底防御
- **sourceOrder 设为可选**：保持向后兼容，缺省回退 `Number.MAX_SAFE_INTEGER`，无需迁移测试夹具
- **realtime > hydrated**：流式时间戳精度更高、链路更近源，应作为权威

## 关联

- ISSUE-031（解决「同一逻辑消息因 messageId 漂移被双写」）
- ISSUE-036（解决「不同逻辑消息因 LLM 重复总结而长文本近重」）
- ISSUE-039（本次解决「短文本字面相同的双轮重复 + 跨刷新事件序漂移」，三者正交、互不替代）

🤖 Generated with [Claude Code](https://claude.com/claude-code)