### PR TITLE
fix(home-chat): 消除 LLM 思考独白溢出 / 推理头常驻 / 刷新乱序残留 (ISSUE-040)

### DIFF
--- a/apps/negentropy-ui/lib/adk.ts
+++ b/apps/negentropy-ui/lib/adk.ts
@@ -64,10 +64,33 @@ function getPayloadRole(payload: AdkEventPayload): NormalizedRole {
   );
 }
 
+// ADK / google-genai 透传的「推理 / 思考」Part 识别：
+// - `thought === true`：Gemini thinking、Claude extended thinking 等显式标记；
+// - `type` ∈ {thinking, thought, reasoning, reasoning_summary, reasoning_text}：
+//   各供应商在 part-level 区分推理与正文的常见 type 值。
+// 这类 part 不应进入 TEXT_MESSAGE_CONTENT 流，否则会以「LLM 思考独白」形式
+// 污染用户可见答复（参见 docs/issue.md::ISSUE-040）。
+const REASONING_PART_TYPES = new Set([
+  "thinking",
+  "thought",
+  "reasoning",
+  "reasoning_summary",
+  "reasoning_text",
+]);
+
+function isReasoningPart(part: {
+  thought?: boolean;
+  type?: string;
+}): boolean {
+  if (part.thought === true) return true;
+  if (part.type && REASONING_PART_TYPES.has(part.type)) return true;
+  return false;
+}
+
 function extractTextParts(payload: AdkEventPayload): string[] {
   if (payload.content?.parts) {
     return payload.content.parts
-      .filter((p) => !p.functionResponse && !p.functionCall)
+      .filter((p) => !p.functionResponse && !p.functionCall && !isReasoningPart(p))
       .map((p) => p.text || "")
       .filter(Boolean);
   }
@@ -78,12 +101,28 @@ function extractTextParts(payload: AdkEventPayload): string[] {
     }
     if (Array.isArray(payload.message.content)) {
       return payload.message.content
+        .filter((p) => !isReasoningPart(p))
         .map((p) => p.text || "")
         .filter(Boolean);
     }
   }
 
   return [];
+}
+
+function extractReasoningTexts(payload: AdkEventPayload): string[] {
+  const texts: string[] = [];
+  if (payload.content?.parts) {
+    payload.content.parts.forEach((p) => {
+      if (isReasoningPart(p) && p.text) texts.push(p.text);
+    });
+  }
+  if (payload.message && Array.isArray(payload.message.content)) {
+    payload.message.content.forEach((p) => {
+      if (isReasoningPart(p) && p.text) texts.push(p.text);
+    });
+  }
+  return texts;
 }
 
 function hasToolCalls(payload: AdkEventPayload): boolean {
@@ -135,6 +174,11 @@ export class AdkMessageStreamNormalizer {
   private synthStepId: string | null = null;
   private synthStepAuthor: string | null = null;
   private synthStepCounter = 0;
+  // ISSUE-040 H2: 跟踪 stepId → stepName 映射，在 STEP_FINISHED 时把同名字段
+  // 透出给 ag-ui 校验器（v0.0.47 的 `STEP_FINISHED` validator 用 `stepName` 比对，
+  // 缺失会触发 `Cannot send 'STEP_FINISHED' for step "undefined" that was not
+  // started`，导致整个 run 被中断、推理头永驻）。
+  private stepNameByStepId = new Map<string, string>();
   private lastCommon: {
     threadId: string;
     runId: string;
@@ -174,11 +218,16 @@ export class AdkMessageStreamNormalizer {
     common: { threadId: string; runId: string; timestamp: number },
   ) {
     if (!this.synthStepId) return;
+    const stepName =
+      this.stepNameByStepId.get(this.synthStepId) ||
+      this.synthStepAuthor ||
+      this.synthStepId;
     events.push(
       createStepFinishedEvent(
         { ...common, messageId: `flush:${this.synthStepId}` },
         this.synthStepId,
         null,
+        stepName,
       ),
       createCustomEvent(
         { ...common, messageId: `flush:${this.synthStepId}` },
@@ -186,6 +235,7 @@ export class AdkMessageStreamNormalizer {
         { stepId: this.synthStepId, phase: "finished" },
       ),
     );
+    this.stepNameByStepId.delete(this.synthStepId);
     this.synthStepId = null;
     this.synthStepAuthor = null;
   }
@@ -218,7 +268,29 @@ export class AdkMessageStreamNormalizer {
     const role = getPayloadRole(payload);
     const isToolResponsePart = payload.content?.parts?.some((p) => p.functionResponse);
     const hasMixedContentParts = payload.content?.parts?.some((p) => p.functionCall) &&
-      payload.content?.parts?.some((p) => !p.functionCall && !p.functionResponse && (p.text || "").trim());
+      payload.content?.parts?.some(
+        (p) =>
+          !p.functionCall &&
+          !p.functionResponse &&
+          !isReasoningPart(p) &&
+          (p.text || "").trim(),
+      );
+
+    // 推理 / 思考 Part 落到独立 ne.a2ui.thought 自定义事件作为审计痕迹，
+    // 不进入 TEXT_MESSAGE_* 流；conversation-tree 默认不渲染该自定义事件，
+    // 避免污染答复气泡，可用于后续 reasoning 面板。
+    const reasoningTexts = extractReasoningTexts(payload);
+    if (reasoningTexts.length > 0) {
+      reasoningTexts.forEach((text) => {
+        events.push(
+          createCustomEvent(
+            { ...common, messageId: payload.id },
+            "ne.a2ui.thought",
+            { text },
+          ),
+        );
+      });
+    }
 
     if (role !== "assistant" || messageShouldFlushAfterPayload(payload)) {
       this.flushAssistantMessage(events, common);
@@ -259,6 +331,9 @@ export class AdkMessageStreamNormalizer {
       parts.forEach((part) => {
         if (part.functionResponse) {
           return; // functionResponse 在下方单独处理
+        }
+        if (isReasoningPart(part)) {
+          return; // 推理内容已通过 ne.a2ui.thought 审计事件透传，不进 TEXT_MESSAGE
         }
         if (part.functionCall) {
           // 先 flush 前面积攒的文本并关闭当前消息
@@ -548,11 +623,16 @@ export class AdkMessageStreamNormalizer {
       if (author && author !== "user" && author !== this.synthStepAuthor) {
         // 关闭前一个合成 step
         if (this.synthStepId) {
+          const prevStepName =
+            this.stepNameByStepId.get(this.synthStepId) ||
+            this.synthStepAuthor ||
+            this.synthStepId;
           events.push(
             createStepFinishedEvent(
               { ...common, messageId: payload.id },
               this.synthStepId,
               null,
+              prevStepName,
             ),
             createCustomEvent(
               { ...common, messageId: payload.id },
@@ -560,10 +640,12 @@ export class AdkMessageStreamNormalizer {
               { stepId: this.synthStepId, phase: "finished" },
             ),
           );
+          this.stepNameByStepId.delete(this.synthStepId);
         }
         // 开启新的合成 step
         this.synthStepId = `synth-step:${author}:${common.runId}:${this.synthStepCounter++}`;
         this.synthStepAuthor = author;
+        this.stepNameByStepId.set(this.synthStepId, author);
         events.push(
           createStepStartedEvent(
             { ...common, messageId: payload.id },
@@ -585,6 +667,10 @@ export class AdkMessageStreamNormalizer {
     };
 
     if (payload.actions?.stepStarted) {
+      this.stepNameByStepId.set(
+        payload.actions.stepStarted.id,
+        payload.actions.stepStarted.name,
+      );
       events.push(
         createStepStartedEvent(
           {
@@ -612,16 +698,21 @@ export class AdkMessageStreamNormalizer {
     }
 
     if (payload.actions?.stepFinished) {
+      const finishedStepId = payload.actions.stepFinished.id;
+      const finishedStepName =
+        this.stepNameByStepId.get(finishedStepId) || finishedStepId;
       events.push(
         createStepFinishedEvent(
           {
             ...common,
             messageId: payload.id,
           },
-          payload.actions.stepFinished.id,
+          finishedStepId,
           payload.actions.stepFinished.result,
+          finishedStepName,
         ),
       );
+      this.stepNameByStepId.delete(finishedStepId);
       events.push(
         createCustomEvent(
           {
@@ -630,7 +721,7 @@ export class AdkMessageStreamNormalizer {
           },
           "ne.a2ui.reasoning",
           {
-            stepId: payload.actions.stepFinished.id,
+            stepId: finishedStepId,
             phase: "finished",
             result: payload.actions.stepFinished.result,
           },

--- a/apps/negentropy-ui/lib/adk/schema.ts
+++ b/apps/negentropy-ui/lib/adk/schema.ts
@@ -26,6 +26,11 @@ const adkContentPartSchema = z
     type: z.string().optional(),
     functionCall: adkFunctionCallSchema.optional(),
     functionResponse: adkFunctionResponseSchema.optional(),
+    // ADK / google-genai 透传字段：当模型（Gemini thinking、Claude extended thinking、
+    // GPT-5/o-系列 reasoning）输出推理内容时，会以 `thought=true` 的 Part 与正文 Part
+    // 并列出现。此字段历史上靠 passthrough 漏过，现显式声明以便 extractTextParts
+    // 在源头按字段过滤，避免推理内容污染 TEXT_MESSAGE_CONTENT。
+    thought: z.boolean().optional(),
   })
   .passthrough();
 

--- a/apps/negentropy-ui/lib/agui/factories.ts
+++ b/apps/negentropy-ui/lib/agui/factories.ts
@@ -168,10 +168,17 @@ export function createStepFinishedEvent(
   props: RequiredMessageEventProps,
   stepId: string,
   result: unknown,
+  // ISSUE-040 H2: ag-ui v0.0.47 validator 在 STEP_STARTED/STEP_FINISHED 配对时
+  // 用 `stepName`（而非 `stepId`）作 key 比对。若 STEP_FINISHED 不带 stepName，
+  // 校验器会把 undefined 视为「未开始过」，抛 `Cannot send 'STEP_FINISHED' for
+  // step "undefined" that was not started`，整个 run 被中断 → 推理节点状态卡在
+  // running、Home 气泡顶部「正在思考 · 推理阶段」永不切换为「思考完成」。
+  stepName?: string,
 ): StepFinishedEvent {
   return {
     type: EventType.STEP_FINISHED,
     stepId,
+    stepName,
     result,
     ...props,
   };

--- a/apps/negentropy-ui/tests/unit/adk.test.ts
+++ b/apps/negentropy-ui/tests/unit/adk.test.ts
@@ -393,4 +393,189 @@ describe("adk event mapping", () => {
       name: "Google Search",
     });
   });
+
+  // ISSUE-040 H1: 推理 / 思考 Part 不可进入 TEXT_MESSAGE_*
+  it("过滤 thought=true 的 Part，仅把正文进入 TEXT_MESSAGE_CONTENT", () => {
+    const payload = {
+      id: "evt_thought_1",
+      author: "assistant",
+      content: {
+        parts: [
+          { thought: true, text: "We need to respond ..." },
+          { text: "Pong." },
+        ],
+      },
+    };
+    const events = adkEventToAguiEvents(payload);
+    const contentEvent = events.find(
+      (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    expect(contentEvent).toBeTruthy();
+    expect("delta" in contentEvent! ? (contentEvent as unknown as { delta: string }).delta : "").toBe(
+      "Pong.",
+    );
+    // 推理内容应作为 ne.a2ui.thought 自定义事件保留作审计
+    const thoughtCustom = events.find(
+      (event) =>
+        event.type === EventType.CUSTOM &&
+        "eventType" in event &&
+        (event as unknown as { eventType: string }).eventType === "ne.a2ui.thought",
+    );
+    expect(thoughtCustom).toBeTruthy();
+  });
+
+  it("过滤 type=thinking|thought|reasoning 的 Part", () => {
+    const payload = {
+      id: "evt_thought_2",
+      author: "assistant",
+      content: {
+        parts: [
+          { type: "thinking", text: "internal plan" },
+          { type: "reasoning_summary", text: "summary" },
+          { type: "text", text: "Pong." },
+        ],
+      },
+    };
+    const events = adkEventToAguiEvents(payload);
+    const contentEvent = events.find(
+      (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    expect(
+      "delta" in contentEvent! ? (contentEvent as unknown as { delta: string }).delta : "",
+    ).toBe("Pong.");
+    const thoughtCustomEvents = events.filter(
+      (event) =>
+        event.type === EventType.CUSTOM &&
+        "eventType" in event &&
+        (event as unknown as { eventType: string }).eventType === "ne.a2ui.thought",
+    );
+    expect(thoughtCustomEvents).toHaveLength(2);
+  });
+
+  it("混合 functionCall + thought + text 时仅切割 text 段，跳过推理 Part", () => {
+    const payload = {
+      id: "evt_thought_3",
+      author: "assistant",
+      content: {
+        parts: [
+          { thought: true, text: "thinking ..." },
+          { text: "Calling tool first." },
+          {
+            functionCall: {
+              id: "call-x",
+              name: "log_activity",
+              args: { ok: 1 },
+            },
+          },
+          { text: "Pong." },
+        ],
+      },
+    };
+    const events = adkEventToAguiEvents(payload);
+    const textContents = events
+      .filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((event) =>
+        "delta" in event ? (event as unknown as { delta: string }).delta : "",
+      );
+    expect(textContents).toEqual(["Calling tool first.", "Pong."]);
+    // 推理段不应出现在 TEXT_MESSAGE_CONTENT；但 ne.a2ui.thought 应被发出
+    const thoughtCustom = events.find(
+      (event) =>
+        event.type === EventType.CUSTOM &&
+        "eventType" in event &&
+        (event as unknown as { eventType: string }).eventType === "ne.a2ui.thought",
+    );
+    expect(thoughtCustom).toBeTruthy();
+  });
+
+  // ISSUE-040 H2: STEP_FINISHED 必须携带与 STEP_STARTED 配对的 stepName，否则
+  // ag-ui v0.0.47 client 会抛 "Cannot send 'STEP_FINISHED' for step \"undefined\""
+  // 中断 run，导致推理头永驻 started 状态。
+  it("synth step 在 flushRun 时 STEP_FINISHED 携带 stepName 与 STEP_STARTED 配对", () => {
+    const normalizer = new AdkMessageStreamNormalizer();
+    const consumed = normalizer.consume({
+      id: "evt_synth_1",
+      author: "NegentropyEngine",
+      runId: "run-x",
+      threadId: "thread-x",
+      timestamp: 1000,
+      content: { parts: [{ text: "Pong." }] },
+    });
+    const flushed = normalizer.flushRun("run-x", "thread-x", 1001);
+    const stepStarted = consumed.find(
+      (event) => event.type === EventType.STEP_STARTED,
+    );
+    const stepFinished = flushed.find(
+      (event) => event.type === EventType.STEP_FINISHED,
+    );
+    expect(stepStarted).toBeTruthy();
+    expect(stepFinished).toBeTruthy();
+    const startedName =
+      stepStarted && "stepName" in stepStarted
+        ? (stepStarted as unknown as { stepName: string }).stepName
+        : undefined;
+    const finishedName =
+      stepFinished && "stepName" in stepFinished
+        ? (stepFinished as unknown as { stepName: string }).stepName
+        : undefined;
+    expect(startedName).toBe("NegentropyEngine");
+    expect(finishedName).toBe("NegentropyEngine");
+  });
+
+  it("native ADK stepFinished 无 name 字段时回退到 STEP_STARTED 缓存的 stepName", () => {
+    const normalizer = new AdkMessageStreamNormalizer();
+    const startedEvents = normalizer.consume({
+      id: "evt_step_a",
+      author: "system",
+      runId: "run-a",
+      threadId: "thread-a",
+      timestamp: 1000,
+      actions: { stepStarted: { id: "step-1", name: "PerceptionFaculty" } },
+    });
+    const finishedEvents = normalizer.consume({
+      id: "evt_step_b",
+      author: "system",
+      runId: "run-a",
+      threadId: "thread-a",
+      timestamp: 1001,
+      actions: { stepFinished: { id: "step-1", result: "ok" } },
+    });
+    const startedName = startedEvents.find(
+      (event) => event.type === EventType.STEP_STARTED,
+    );
+    const finishedName = finishedEvents.find(
+      (event) => event.type === EventType.STEP_FINISHED,
+    );
+    expect(
+      "stepName" in startedName!
+        ? (startedName as unknown as { stepName: string }).stepName
+        : undefined,
+    ).toBe("PerceptionFaculty");
+    expect(
+      "stepName" in finishedName!
+        ? (finishedName as unknown as { stepName: string }).stepName
+        : undefined,
+    ).toBe("PerceptionFaculty");
+  });
+
+  it("过滤 message.content 数组中的推理 Part", () => {
+    const payload = {
+      id: "evt_thought_4",
+      author: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", text: "plan" },
+          { type: "text", text: "Pong." },
+        ],
+      },
+    };
+    const events = adkEventToAguiEvents(payload);
+    const contentEvent = events.find(
+      (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+    );
+    expect(
+      "delta" in contentEvent! ? (contentEvent as unknown as { delta: string }).delta : "",
+    ).toBe("Pong.");
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -858,44 +858,83 @@ describe("buildConversationTree", () => {
 
   // ISSUE-040 H3：fallback 段创建的消息节点 sourceOrder 应来自 ledger（即对应
   // ledger 条目的 sourceOrder），而非每次按 events.length + fallbackIndex 重算。
-  // 这避免了同时通过 events 与 snapshot 命中同一消息时，节点 sourceOrder 与 ledger
-  // sourceOrder 不一致而触发跨链路排序漂移。
-  it("fallback 阶段重建节点的 sourceOrder 来自 ledger 而非按 events.length 重算", () => {
+  // 通过让「snapshot 数组顺序」与「ledger 时间序」错位，迫使两套公式给出不同
+  // 的 sourceOrder，从而真正回归保护 H3 修复（旧实现按 fallbackIndex 重算会与
+  // ledger 错位，跨链路排序漂移）。
+  it("fallback 阶段重建节点的 sourceOrder 来自 ledger 而非按 fallbackIndex 重算", () => {
+    // 关键：snapshot.messages 数组顺序 [msg-late, msg-early]
+    //   → message-ledger 第二轮 snapshot loop 按数组顺序赋 sourceOrder：
+    //     msg-late = orderedEvents.length + 0 = 3
+    //     msg-early = orderedEvents.length + 1 = 4
+    //   → ledger 按 createdAt 排序后回到 [msg-early, msg-late]
+    //   → conversation-tree fallback 路径 mergedFallbackMessages 顺序也是
+    //     [msg-early, msg-late]（因 effectiveMessageLedger 已按时间排序）
+    //
+    //   旧实现（按 fallbackIndex 重算）：
+    //     msg-early node = orderedEvents.length + 0 = 3
+    //     msg-late  node = orderedEvents.length + 1 = 4
+    //
+    //   新实现（复用 ledger.sourceOrder）：
+    //     msg-early node = 4（来自 snapshot 数组次位）
+    //     msg-late  node = 3（来自 snapshot 数组首位）
+    //
+    //   两个公式产出的具体数值在两条消息之间是「互换」的，可作为强差异断言。
     const events: AgUiEvent[] = [
       createTestEvent({
         type: EventType.RUN_STARTED,
         threadId: "thread-1",
         runId: "run-1",
-        timestamp: 1000,
+        timestamp: 900,
       }),
       createTestEvent({
         type: EventType.MESSAGES_SNAPSHOT,
         threadId: "thread-1",
         runId: "run-1",
         messageId: "snapshot-1",
-        timestamp: 1001,
+        timestamp: 1000,
         messages: [
           {
-            id: "msg-user",
+            id: "msg-late",
             role: "user",
-            content: "Need help",
+            content: "Late message",
             threadId: "thread-1",
             runId: "run-1",
-            createdAt: "1970-01-01T00:16:41.000Z",
+            createdAt: "2026-04-29T00:00:02.000Z",
+          },
+          {
+            id: "msg-early",
+            role: "user",
+            content: "Early message",
+            threadId: "thread-1",
+            runId: "run-1",
+            createdAt: "2026-04-29T00:00:01.000Z",
           },
         ],
+      }),
+      createTestEvent({
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1100,
       }),
     ];
 
     const tree = buildConversationTree({ events });
 
-    const userNode = tree.roots[0].children.find((n) => n.role === "user");
-    expect(userNode).toBeTruthy();
-    // events.length === 2，旧实现会把 sourceOrder 推到 ≥2 的位置（fallback 重算）。
-    // 新实现复用 ledger 中 snapshot 消息的 sourceOrder（同样为 events.length + 0 = 2，
-    // 因这是单 snapshot 单条，恰巧相等；但若 ledger 经合并已落到更小值，节点应跟随）。
-    // 这里不强测具体数值，仅确认两边同源（都来自 ledger）。
-    expect(typeof userNode!.sourceOrder).toBe("number");
-    expect(Number.isFinite(userNode!.sourceOrder)).toBe(true);
+    const allNodes = tree.roots.flatMap((turn) => turn.children);
+    const nodeLate = allNodes.find((n) => n.messageId === "msg-late");
+    const nodeEarly = allNodes.find((n) => n.messageId === "msg-early");
+    expect(nodeLate).toBeTruthy();
+    expect(nodeEarly).toBeTruthy();
+
+    // 关键断言：sourceOrder 必须与「snapshot 数组中的位置」一致（来自 ledger），
+    // 而不是「mergedFallbackMessages 中的位置」（即旧 fallbackIndex 重算结果）。
+    expect(nodeLate!.sourceOrder).toBe(3);
+    expect(nodeEarly!.sourceOrder).toBe(4);
+
+    // 反向核验：旧实现下 nodeEarly.sourceOrder == 3，nodeLate.sourceOrder == 4，
+    // 与 ledger sourceOrder 错位。当前断言可有效拦截退化。
+    expect(nodeEarly!.sourceOrder).not.toBe(3);
+    expect(nodeLate!.sourceOrder).not.toBe(4);
   });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -855,4 +855,47 @@ describe("buildConversationTree", () => {
     expect(tree.roots[0].children[0].payload.content).toBe("Need help");
     expect(tree.roots[0].children[0].role).toBe("user");
   });
+
+  // ISSUE-040 H3：fallback 段创建的消息节点 sourceOrder 应来自 ledger（即对应
+  // ledger 条目的 sourceOrder），而非每次按 events.length + fallbackIndex 重算。
+  // 这避免了同时通过 events 与 snapshot 命中同一消息时，节点 sourceOrder 与 ledger
+  // sourceOrder 不一致而触发跨链路排序漂移。
+  it("fallback 阶段重建节点的 sourceOrder 来自 ledger 而非按 events.length 重算", () => {
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "snapshot-1",
+        timestamp: 1001,
+        messages: [
+          {
+            id: "msg-user",
+            role: "user",
+            content: "Need help",
+            threadId: "thread-1",
+            runId: "run-1",
+            createdAt: "1970-01-01T00:16:41.000Z",
+          },
+        ],
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+
+    const userNode = tree.roots[0].children.find((n) => n.role === "user");
+    expect(userNode).toBeTruthy();
+    // events.length === 2，旧实现会把 sourceOrder 推到 ≥2 的位置（fallback 重算）。
+    // 新实现复用 ledger 中 snapshot 消息的 sourceOrder（同样为 events.length + 0 = 2，
+    // 因这是单 snapshot 单条，恰巧相等；但若 ledger 经合并已落到更小值，节点应跟随）。
+    // 这里不强测具体数值，仅确认两边同源（都来自 ledger）。
+    expect(typeof userNode!.sourceOrder).toBe("number");
+    expect(Number.isFinite(userNode!.sourceOrder)).toBe(true);
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -891,4 +891,60 @@ describe("session-hydration", () => {
     const merged = mergeEvents([thoughtA], [thoughtB]);
     expect(merged).toHaveLength(1);
   });
+
+  // ISSUE-040 Q3 残留乱序：sort tiebreaker 必须保留 lifecycle 推入顺序，
+  // 不能在 timestamp 相等时按 eventKey 字典序回退（CONTENT < END < START）。
+  it("hydrateSessionDetail 保留同 timestamp 下 normalizer 推入的 lifecycle 顺序", () => {
+    // 后端 ADK web events 历史回放经常一秒落库多条 (functionCall / functionResponse / 同期文本)，
+    // 三件套时间戳相等。此前 sort 用 eventKey().localeCompare 兜底会把 TEXT_MESSAGE_*
+    // 三件套打散为 CONTENT, END, START，导致前端展现层 turn 边界穿插漂移。
+    const sameTs = 1000;
+    const result = hydrateSessionDetail(
+      [
+        {
+          id: "user-1",
+          author: "user",
+          timestamp: sameTs,
+          content: { parts: [{ text: "Ping." }] },
+        },
+        {
+          id: "asst-1",
+          author: "NegentropyEngine",
+          timestamp: sameTs,
+          content: { parts: [{ text: "Pong." }] },
+        },
+      ],
+      "session-q3",
+    );
+    // 提取 TEXT_MESSAGE_* 序列，断言：每个 messageId 内 START → CONTENT → END
+    // 三件套相邻且不被另一 messageId 切断。
+    const textEvents = result.events.filter(
+      (event) =>
+        event.type === EventType.TEXT_MESSAGE_START ||
+        event.type === EventType.TEXT_MESSAGE_CONTENT ||
+        event.type === EventType.TEXT_MESSAGE_END,
+    );
+    // 用 (messageId, lifecycle) 的相对序号映射断言不再交错。
+    let lastMessageId = "";
+    let lifecycleStage = -1; // -1=before, 0=START, 1=CONTENT, 2=END
+    for (const event of textEvents) {
+      const mid = (event as unknown as { messageId: string }).messageId;
+      if (mid !== lastMessageId) {
+        // 进入新 messageId：lifecycle 重置，必须以 START 开头
+        expect(event.type).toBe(EventType.TEXT_MESSAGE_START);
+        lastMessageId = mid;
+        lifecycleStage = 0;
+        continue;
+      }
+      if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+        // CONTENT 必须跟在 START 之后（同 messageId 内）
+        expect(lifecycleStage).toBeGreaterThanOrEqual(0);
+        expect(lifecycleStage).toBeLessThanOrEqual(1);
+        lifecycleStage = 1;
+      } else if (event.type === EventType.TEXT_MESSAGE_END) {
+        expect(lifecycleStage).toBeGreaterThanOrEqual(1);
+        lifecycleStage = 2;
+      }
+    }
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/session-hydration.test.ts
@@ -850,4 +850,45 @@ describe("session-hydration", () => {
     expect(runStartedEvents).toHaveLength(1);
     expect(runStartedEvents[0]).toBe(realtimeRunStarted);
   });
+
+  // ISSUE-040 H4: eventKey 浮点抖动保护应推广到所有事件类型（不再仅 TEXT_MESSAGE_CONTENT）
+  it("eventKey 在 STEP_FINISHED 浮点抖动下仍稳定", () => {
+    const stepFinishedA = createTestEvent({
+      type: EventType.STEP_FINISHED,
+      threadId: "session-1",
+      runId: "run-1",
+      stepId: "synth-step-1",
+      timestamp: 1001.1,
+    });
+    const stepFinishedB = createTestEvent({
+      type: EventType.STEP_FINISHED,
+      threadId: "session-1",
+      runId: "run-1",
+      stepId: "synth-step-1",
+      timestamp: 1001.10000002384, // 浮点表示抖动，但 stepId 相同
+    });
+    const merged = mergeEvents([stepFinishedA], [stepFinishedB]);
+    expect(merged).toHaveLength(1);
+  });
+
+  it("eventKey 对 ne.a2ui.thought 等 CUSTOM 事件不再因浮点抖动重复保留", () => {
+    const thoughtA = createTestEvent({
+      type: EventType.CUSTOM,
+      threadId: "session-1",
+      runId: "run-1",
+      timestamp: 1001.0,
+      eventType: "ne.a2ui.thought",
+      data: { text: "thinking..." },
+    } as unknown as Parameters<typeof createTestEvent>[0]);
+    const thoughtB = createTestEvent({
+      type: EventType.CUSTOM,
+      threadId: "session-1",
+      runId: "run-1",
+      timestamp: 1001.000001, // 同毫秒级浮点抖动
+      eventType: "ne.a2ui.thought",
+      data: { text: "thinking..." },
+    } as unknown as Parameters<typeof createTestEvent>[0]);
+    const merged = mergeEvents([thoughtA], [thoughtB]);
+    expect(merged).toHaveLength(1);
+  });
 });

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -1233,6 +1233,13 @@ export function buildConversationTree(
       return;
     }
 
+    // ISSUE-040 H3: 优先复用 ledger 中已有的 sourceOrder，避免把 snapshot-only
+     // 消息（仅靠 MESSAGES_SNAPSHOT 进入 ledger、未走 TEXT_MESSAGE_START）误推
+     // 到事件流末尾，从而破坏 compareLedgerEntriesByTime 的 tiebreaker。
+    const fallbackSourceOrder =
+      typeof snapshotMessage?.sourceOrder === "number"
+        ? snapshotMessage.sourceOrder
+        : orderedEvents.length + fallbackIndex;
     let fallbackTurn =
       (runId && turns.get(runId)) || findFallbackTurnByTimestamp(turns, timestamp);
     if (runId && !fallbackTurn) {
@@ -1246,7 +1253,7 @@ export function buildConversationTree(
           timestamp,
         }),
         undefined,
-        orderedEvents.length + fallbackIndex,
+        fallbackSourceOrder,
       );
       fallbackTurn = turns.get(runId) || null;
     }
@@ -1259,7 +1266,7 @@ export function buildConversationTree(
       runId: fallbackTurn?.runId || runId,
       messageId: canonicalMessageId,
       timestamp,
-      sourceOrder: orderedEvents.length + fallbackIndex,
+      sourceOrder: fallbackSourceOrder,
       title: role === "user" ? "用户消息" : "助手消息",
       role,
       payload: {

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -145,17 +145,36 @@ function eventKey(event: BaseEvent): string {
 
 export function mergeEvents(baseEvents: BaseEvent[], incomingEvents: BaseEvent[]): BaseEvent[] {
   const merged = new Map<string, BaseEvent>();
+  // ISSUE-040 Q3 残留乱序：如果同 timestamp 时回退到 `eventKey().localeCompare`，
+  // 会把上游已正确排序的 lifecycle 序（START → CONTENT → END）按字典序打乱
+  // 为 (CONTENT < END < START)。改为以「在 [...base, ...incoming] 中的最早出现
+  // 索引」作为稳定 tiebreaker，保留调用方已建立的逻辑顺序。
+  const insertionOrder = new Map<string, number>();
+  let nextOrder = 0;
   [...baseEvents, ...incomingEvents].forEach((event) => {
-    merged.set(eventKey(event), event);
+    const key = eventKey(event);
+    if (!insertionOrder.has(key)) {
+      insertionOrder.set(key, nextOrder++);
+    }
+    merged.set(key, event);
   });
 
-  return [...merged.values()].sort((a, b) => {
-    const timeDiff = normalizeTimestamp(a.timestamp) - normalizeTimestamp(b.timestamp);
-    if (timeDiff !== 0) {
-      return timeDiff;
-    }
-    return eventKey(a).localeCompare(eventKey(b));
-  });
+  return [...merged.entries()]
+    .sort((a, b) => {
+      const [keyA, eventA] = a;
+      const [keyB, eventB] = b;
+      const timeDiff = normalizeTimestamp(eventA.timestamp) - normalizeTimestamp(eventB.timestamp);
+      if (timeDiff !== 0) {
+        return timeDiff;
+      }
+      const orderA = insertionOrder.get(keyA) ?? Number.MAX_SAFE_INTEGER;
+      const orderB = insertionOrder.get(keyB) ?? Number.MAX_SAFE_INTEGER;
+      if (orderA !== orderB) {
+        return orderA - orderB;
+      }
+      return keyA.localeCompare(keyB);
+    })
+    .map(([, event]) => event);
 }
 
 const LIFECYCLE_EVENT_TYPES = new Set([
@@ -347,15 +366,33 @@ export function hydrateSessionDetail(
   const runBuckets = new Map<string, BaseEvent[]>();
   const runNormalizers = new Map<string, AdkMessageStreamNormalizer>();
 
+  // ISSUE-040 Q3 残留乱序根因：normalizer 已按 lifecycle 顺序产出
+  // (START → CONTENT → END)，但下方的 sort 在 timestamp 相等时回退到
+  // `eventKey().localeCompare` —— 字典序下 CONTENT < END < START，会把同一
+  // 逻辑消息的 lifecycle 顺序打乱（如下方 repro 所示）；当多条消息共享同一秒
+  // 时间戳（后端 ADK 落库精度受限），跨 messageId 的 START/CONTENT/END 还会
+  // 互相穿插，造成「user1 → assistant1 → user2 → assistant2」刷新后被打散
+  // 为 「user1 → user2 → assistant1 → assistant2」这类 turn 边界漂移。
+  //
+  // 修复：用 WeakMap 给每个 normalizer 输出的事件挂一个全局递增的 emitOrder，
+  // sort tiebreaker 用 emitOrder 代替 eventKey 字典序，保持 normalizer 推入
+  // 顺序作为权威 lifecycle / turn 序。emitOrder 仅在本 hydration 调用内有效。
+  const emitOrderByEvent = new WeakMap<BaseEvent, number>();
+  let emitCounter = 0;
+
   payloads.forEach((payload) => {
     const runId = fallbackRunId(payload, sessionId);
     const threadId = fallbackThreadId(payload, sessionId);
     const normalizer =
       runNormalizers.get(runId) || new AdkMessageStreamNormalizer();
     runNormalizers.set(runId, normalizer);
-    const events = normalizer.consume(payload, { threadId, runId }).map((event) =>
-      normalizeAguiEvent(resolveEventRunAndThread(event, { threadId, runId })),
-    );
+    const events = normalizer.consume(payload, { threadId, runId }).map((event) => {
+      const normalized = normalizeAguiEvent(
+        resolveEventRunAndThread(event, { threadId, runId }),
+      );
+      emitOrderByEvent.set(normalized, emitCounter++);
+      return normalized;
+    });
     const bucket = runBuckets.get(runId) || [];
     bucket.push(...events);
     runBuckets.set(runId, bucket);
@@ -373,13 +410,16 @@ export function hydrateSessionDetail(
         }
         return getEventThreadId(event) || null;
       }, null) || sessionId;
-    events.push(
-      ...normalizer
-        .flushRun(runId, threadId, normalizeTimestamp(events[events.length - 1]?.timestamp) + 0.001)
-        .map((event) =>
-          normalizeAguiEvent(resolveEventRunAndThread(event, { threadId, runId })),
-        ),
-    );
+    const flushedEvents = normalizer
+      .flushRun(runId, threadId, normalizeTimestamp(events[events.length - 1]?.timestamp) + 0.001)
+      .map((event) => {
+        const normalized = normalizeAguiEvent(
+          resolveEventRunAndThread(event, { threadId, runId }),
+        );
+        emitOrderByEvent.set(normalized, emitCounter++);
+        return normalized;
+      });
+    events.push(...flushedEvents);
   });
 
   const normalizedEvents = [...runBuckets.entries()].flatMap(([runId, events]) => {
@@ -387,6 +427,15 @@ export function hydrateSessionDetail(
       const timeDiff = normalizeTimestamp(a.timestamp) - normalizeTimestamp(b.timestamp);
       if (timeDiff !== 0) {
         return timeDiff;
+      }
+      // emitOrder tiebreaker：保持 normalizer 推入顺序（lifecycle / turn 边界
+      // 的权威来源）。未在 emitOrderByEvent 中的事件（极罕见，理论上仅由本
+      // 函数下方合成的 RUN_STARTED / RUN_FINISHED 注入，但它们会带 ±0.001
+      // 时间漂移让 timestamp 比较先决出胜负）回退到 eventKey 字典序兜底。
+      const aOrder = emitOrderByEvent.get(a) ?? Number.MAX_SAFE_INTEGER;
+      const bOrder = emitOrderByEvent.get(b) ?? Number.MAX_SAFE_INTEGER;
+      if (aOrder !== bOrder) {
+        return aOrder - bOrder;
       }
       return eventKey(a).localeCompare(eventKey(b));
     });

--- a/apps/negentropy-ui/utils/session-hydration.ts
+++ b/apps/negentropy-ui/utils/session-hydration.ts
@@ -54,7 +54,10 @@ function eventKey(event: BaseEvent): string {
   const runId = getEventRunId(event) || "";
   const messageId = getEventMessageId(event) || "";
   const toolCallId = getEventToolCallId(event) || "";
-  const timestamp = normalizeTimestamp(event.timestamp);
+  // ISSUE-040 H4: 全部事件类型在涉及 timestamp 时统一走 toFixed(3)，避免浮点抖动
+  // 在不同 hydration 路径产出不一样的 key（如 1001.1 vs 1001.10000002384），
+  // 进而触发同一逻辑事件被保留双份、刷新后排序漂移。
+  const timestampKey = normalizeTimestamp(event.timestamp).toFixed(3);
 
   switch (event.type) {
     case EventType.TEXT_MESSAGE_START:
@@ -74,7 +77,7 @@ function eventKey(event: BaseEvent): string {
         threadId,
         runId,
         messageId,
-        normalizeTimestamp(event.timestamp).toFixed(3),
+        timestampKey,
       ].join("|");
     case EventType.TEXT_MESSAGE_END:
       return [type, threadId, runId, messageId].join("|");
@@ -116,15 +119,25 @@ function eventKey(event: BaseEvent): string {
         String(getEventErrorMessage(event) || ""),
       ].join("|");
     case EventType.CUSTOM:
+      // CUSTOM 事件附带毫秒级 timestamp 作 key，避免同一 (eventType, data) 在不同
+      // 时刻被合并为同一份；典型场景：ne.a2ui.thought / ne.a2ui.link 多次发出。
       return [
         type,
         threadId,
         runId,
         String(getCustomEventType(event) || ""),
         JSON.stringify(getCustomEventData(event) ?? null),
+        timestampKey,
       ].join("|");
+    case EventType.STEP_STARTED:
+    case EventType.STEP_FINISHED: {
+      const stepId = String(
+        (event as Record<string, unknown>).stepId || "",
+      );
+      return [type, threadId, runId, stepId].join("|");
+    }
     default:
-      return [type, threadId, runId, messageId, toolCallId, String(timestamp)].join(
+      return [type, threadId, runId, messageId, toolCallId, timestampKey].join(
         "|",
       );
   }

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -906,3 +906,23 @@
   2. 任何 ag-ui v0.0.47 之上的封装库若构造 STEP_FINISHED，**必须**显式传 `stepName`，否则整个 run 静默被中断；
   3. 任何重建节点的 fallback 路径都应优先复用 ledger 已有 sourceOrder（含未来可能的 tool-result 重建、knowledge 系列消息重建）；
   4. **与 ISSUE-031 / 036 / 039 关系**：031 解决「同一逻辑消息因 messageId 漂移被双写」；036 解决「不同逻辑消息因 LLM 重复总结而长文本近重」；039 解决「短文本字面相同的双轮重复 + eventKey 浮点抖动 + UUID localeCompare tiebreaker」；040 解决「LLM thought part 漏入正文 + STEP_FINISHED 校验缺 stepName + fallback 节点 sourceOrder 不复用 ledger + eventKey 浮点抖动盲区」。四者正交、互不替代，共同构成 Home 双气泡 / 推理头 / 排序防御链。
+
+### Q3 长尾闭环：sort tiebreaker 字典序污染 lifecycle 顺序（040 增量补丁）
+
+- **表因（首轮 040 PR 后未消除）**：「多消息→刷新」场景下，user1 → assistant1 → user2 → assistant2 在 hydration 后被打散为 user1 → user2 → assistant1 → assistant2，turn 边界跨 messageId 错位。
+- **根因（与 H3 / H4 完全独立的第五个根因 H5）**：
+  - 后端 ADK Web `/sessions/{id}` 返回的 events JSON 不含 `runId / threadId`（只有 `invocationId`，且每条事件 `invocationId` 都不同），前端 `fallbackRunId` 全部回退到 `sessionId` → 所有事件桶在同一 runBucket。
+  - 后端事件本身按 `timestamp` 已正确排序（`apps/negentropy/`：user1=1777403364 / assistant1=1777403382 / user2=1777403406 / assistant2=1777403425）。
+  - 但 `apps/negentropy-ui/utils/session-hydration.ts:386-392` 的 sort 在 `timestamp` 相等时回退到 `eventKey().localeCompare`：字典序下 `TEXT_MESSAGE_CONTENT < TEXT_MESSAGE_END < TEXT_MESSAGE_START`。
+  - `AdkMessageStreamNormalizer` 在处理一个 ADK payload（如 user1 消息）时按 `START → CONTENT → END` 顺序 push 三件套，三个事件共享 payload 的同一秒 timestamp（1777403364.145）；sort 后乱序为 `CONTENT → END → START`。
+  - 当后续 user2 / assistant 的三件套也共享同一秒，跨 messageId 的 START/CONTENT/END 互相穿插，最终 `buildConversationTree` 在 turn 内按事件顺序绑定 messageId 时就把 children 顺序错乱。
+  - 同样的字典序污染存在于 `mergeEvents` (`session-hydration.ts:146-158`)，最后一步 `mergeEvents([], normalizedEvents)` 会**再次**把刚排好的事件按字典序乱序。
+- **处理方式（最小干预）**：
+  1. **`apps/negentropy-ui/utils/session-hydration.ts::hydrateSessionDetail`**：用 `WeakMap<BaseEvent, number>` 给 normalizer 输出的每个事件挂全局递增的 `emitOrder`；sort tiebreaker 优先用 `emitOrder` 代替 `eventKey().localeCompare`，保留 normalizer 推入顺序作为权威 lifecycle / turn 序。
+  2. **`apps/negentropy-ui/utils/session-hydration.ts::mergeEvents`**：`[...base, ...incoming]` 遍历时按首次出现位置记录 `insertionOrder: Map<eventKey, number>`，sort tiebreaker 用 `insertionOrder` 代替字典序。这样调用方建立的逻辑顺序在 dedup 后仍稳定保留。
+  3. **回归测试**：`tests/unit/utils/session-hydration.test.ts` 新增「同 timestamp 下 normalizer 推入的 lifecycle 顺序」用例，断言相邻 messageId 的 START/CONTENT/END 不被穿插。临时用真实 10-event multi-round fixture 在 vitest 中走完 `hydrateSessionDetail → buildConversationTree`，确认 turn children 按 user/assistant 交替正序。
+- **后续防范**：
+  1. **任何 sort tiebreaker 不得用 `eventKey().localeCompare` 作为最终决断**：字典序与事件语义无关，看似稳定实则破坏一致性；应改为「上游推入顺序」「ledger 索引」「类型权重」之一。
+  2. **后端事件透传 `runId`** 长期看仍值得做（让 fallback runBucket 不再单桶聚集），可作为未来 ADK 协议改进的优先项；但本期已通过 `emitOrder` 在 UI 层兜底，无需后端配合即可消除乱序。
+  3. **lifecycle 完整性自检**：建议在 dev 模式下加一个轻量断言「TEXT_MESSAGE_* 三件套必须按 START→CONTENT→END 顺序、不被异 messageId 切断」，把这类排序漂移在开发期捕捉。
+- **同类问题影响**：所有「先按 timestamp 排序、再按 ID/key 字典序兜底」的合并逻辑（不限于 events，也包括 ledger / messages / display blocks）都应回头审计，确保字典序不破坏推入序。本期只修了 `hydrateSessionDetail` 与 `mergeEvents`，conversation-tree 与 chat-display 已经使用 `sourceOrder` 不受影响。

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -867,3 +867,42 @@
 - **同类问题影响**：
   1. 任何 `id.localeCompare` 作 tiebreaker 的排序场景都可能在 createdAt 重合时出现非时间序，本次只修了 ledger 三处 sort，conversation-tree 的 root 排序与 chat-display 的 block 排序仍按 sourceOrder 处理（均使用 `node.sourceOrder`，已稳）；
   2. **与 ISSUE-031 / 036 关系**：031 解决「同一逻辑消息因 messageId 漂移被双写到 ledger」；036 解决「不同逻辑消息因 LLM 重复总结而长文本近重」；039 解决「短文本字面相同的双轮重复 + 跨刷新事件序漂移」。三者正交、互不替代，形成完整去重 / 排序防御链。
+
+---
+
+## ISSUE-040 Home 三连症：思考独白溢出 / 推理头常驻 / 刷新乱序残留
+
+- **表因**：用户在 Home 多轮发送相同 `Ping, give me a pong.` 后看到三类问题共存：
+  1. **(Q1)** Agent 答复中夹带大段第三人称英文独白（如 `We need to respond to the user's latest "Ping, give me a pong." The system requires following the orchestration rules ...`），并伴随历史多轮总结的累积复述；
+  2. **(Q2)** 答复完成、工具组显示「已完成 N 个工具」之后，气泡顶部「正在思考 · 推理阶段」紫色脉冲样式仍未切换为「思考完成 · 推理阶段」；
+  3. **(Q3)** 多轮对话刷新页面后，user / assistant 消息相对位置偶发漂移（即使 commit `3fdbfd3` 已修复 ISSUE-039 的主要乱序面）。
+- **根因**（与 ISSUE-031/036/039 正交，分四组）：
+  1. **H1（Q1 主因）：reasoning/thought 部件未过滤**。默认 LLM 是 `openai/gpt-5-mini`（`apps/negentropy/src/negentropy/config/model_resolver.py:32`，reasoning 模型族），LiteLLM 响应里同时含 `content` 与 `reasoning_content`；`_build_llm_kwargs` 在 anthropic / o1 / o3 模型族下还会注入 `thinking={...}` 或 `reasoning_effort=...`（`config/model_resolver.py:641-657`）。前端 `extractTextParts`（`apps/negentropy-ui/lib/adk.ts:67-87`）与混合 parts 分支（同文件 `consume()`）**只过滤 `functionCall / functionResponse`**，从不检查 `part.thought` 或 `part.type === "thinking" | "thought" | "reasoning" | "reasoning_summary" | "reasoning_text"`。ADK schema 是 `passthrough` 但未声明 `thought`（`lib/adk/schema.ts:23-30`），所以 thought part 静默漏过，被原样拼接到 `TEXT_MESSAGE_CONTENT`。既有 `dedupeRedundantTextSegments`（`utils/chat-display.ts:427-505`）的 4 层判定无法在「字面/前缀/Jaccard」上覆盖此场景——必须在源头剔除。
+  2. **H2（Q2 主因）：`createStepFinishedEvent` 未携带 `stepName`**。`@ag-ui/client@0.0.47` 的事件校验器在 `STEP_STARTED` 时用 `t.stepName` 入栈、在 `STEP_FINISHED` 时同样用 `t.stepName` 比对（`@ag-ui/client/dist/index.mjs` 的 `M = e => t => ...` 内联），缺失即抛 `Cannot send 'STEP_FINISHED' for step "undefined" that was not started` 终止整个 run。本仓库的 `lib/agui/factories.ts::createStepFinishedEvent` 历史上只透出 `stepId / result`，导致每次 run 末的 `flushSynthStep` 都触发该错误 → 后端事件流被截断 → reasoning 节点 `status` 永远停在 `running` → UI 永驻「正在思考」。**这一项与 H1 完全独立**：即使没有 thought 溢出，也会因 STEP 校验失败而卡头部。
+  3. **H3（Q3 主因 a）：fallback 段重建消息节点的 `sourceOrder` 不复用 ledger**。`utils/conversation-tree.ts:1138-1283` 的 fallback 分支在为 snapshot-only 历史消息构造 `text` 节点时，把 `sourceOrder` 设为 `orderedEvents.length + fallbackIndex`，无视该消息在 ledger 中已有的 sourceOrder（来自 `buildMessageLedger` 的 `Math.min` 收敛）。当一条消息既走过实时 `TEXT_MESSAGE_*`（被赋小 eventIndex）又出现在 `MESSAGES_SNAPSHOT`（被赋 `events.length+fallbackIndex` 大值）时，ledger 自身借 upsertEntry 取最小值 → ledger sourceOrder 是小值；但 fallback 重建节点时用大值，与 ledger 不一致 → `compareLedgerEntriesByTime` 在 createdAt 紧邻的边界上发生跨链路漂移。
+  4. **H4（Q3 主因 b）：`eventKey` 浮点抖动保护仅覆盖 `TEXT_MESSAGE_CONTENT`**。`utils/session-hydration.ts::eventKey` 历史上只对 `TEXT_MESSAGE_CONTENT` 做 `.toFixed(3)`；其他类型（`STEP_*` / `STATE_DELTA` / `MESSAGES_SNAPSHOT` / `RAW` / `CUSTOM`）使用 `String(timestamp)` 原值，浮点表示差异（如 `1001.1` vs `1001.10000002384`）会生成不同 key，触发 `mergeEvents` 把同一逻辑事件保留双份。
+- **处理方式**（按假设逐项落地，所有改动只在 UI / 适配层）：
+  1. **H1**：
+     - **`apps/negentropy-ui/lib/adk/schema.ts`**：`adkContentPartSchema` 显式声明 `thought: z.boolean().optional()`，让透传字段不再静默丢；
+     - **`apps/negentropy-ui/lib/adk.ts`**：新增 `REASONING_PART_TYPES` 常量集合 + `isReasoningPart()` 助手；`extractTextParts` 与混合 parts 分支（`consume()` 内 `parts.forEach`）一并跳过 reasoning part；推理文本路由到 `createCustomEvent("ne.a2ui.thought", { text })` 自定义事件作审计痕迹（不进入 conversation-tree 默认渲染面）。
+     - 单元回归：`tests/unit/adk.test.ts` 新增 4 例覆盖 `thought=true` Part、`type=thinking|reasoning_summary` Part、混合 functionCall+thought+text、`message.content` 数组中的推理 Part。
+  2. **H2**：
+     - **`apps/negentropy-ui/lib/agui/factories.ts::createStepFinishedEvent`**：新增可选 `stepName` 形参；`AdkMessageStreamNormalizer` 持有 `stepNameByStepId: Map<string, string>`，在合成 step / 原生 ADK step 的 `STEP_STARTED` 路径上写入，`STEP_FINISHED` / `flushSynthStep` 路径上回查。
+     - 单元回归：新增 2 例分别覆盖「synth step 在 flushRun 时携带 author 作 stepName」「native ADK stepFinished 无 name 时回退到 STEP_STARTED 缓存的 stepName」。
+  3. **H3**：
+     - **`apps/negentropy-ui/utils/conversation-tree.ts:1138-1283`**：在 fallback 节点构造前 `lookup snapshotMessage?.sourceOrder`，命中复用、未命中再回退 `orderedEvents.length + fallbackIndex`。
+     - 测试夹具补一例确认 fallback sourceOrder 能从 ledger 继承。
+  4. **H4**：
+     - **`apps/negentropy-ui/utils/session-hydration.ts::eventKey`**：把 `normalizeTimestamp(t).toFixed(3)` 提升为通用规则，在 `default` 分支与 `CUSTOM` 分支统一使用；新增 `STEP_STARTED / STEP_FINISHED` 显式 case 用 `(threadId, runId, stepId)` 作 key。
+     - 单元回归：新增 2 例覆盖 `STEP_FINISHED` 浮点抖动 + `ne.a2ui.thought` CUSTOM 事件浮点抖动稳定去重。
+- **后续防范**：
+  1. **part 字段透传需显式声明**：未来若再有上游 SDK 引入新 Part 字段（如 `cached`、`encrypted`、`citations`），优先在 `lib/adk/schema.ts` 显式声明 + `extractTextParts` 决定语义，而不是依赖 `passthrough` 漏过；
+  2. **ag-ui / 类似事件协议升级时审计 validator key**：v0.0.47 的 STEP 校验用 `stepName` 作 key 是非直觉设计（更直觉是 `stepId`）；升级时应回归验证 STEP / TEXT_MESSAGE / TOOL_CALL 三组校验路径；
+  3. **fallback / snapshot path 的字段复用**：所有「ledger 已知值」字段（sourceOrder、createdAt、resolvedRole、relatedMessageIds）在 fallback 重建节点时一律优先复用，避免重算造成与 ledger 不一致；
+  4. **eventKey 修订需对所有事件类型扫一遍**：`.toFixed(3)` 的稳定语义最好默认开启而非按类型逐个加；
+  5. **Q3 的 Long-tail**：浏览器复测发现「多轮对话 + 刷新」场景仍有残留乱序（不同 messageId 的双气泡跨 hydration 后顺序不稳），与 ISSUE-031/036 的双气泡根因同源，需后续专项处理（建议从后端事件 runId 透传与 conversation-tree turn 边界两侧入手）。本期 ISSUE-040 已锚定问题、不再扩大爆炸半径。
+- **同类问题影响**：
+  1. 任何「上游 SDK 新增可选 Part 字段 + 前端 passthrough」组合，都可能让该字段漏入用户可见文本，需显式声明 + 语义判定；
+  2. 任何 ag-ui v0.0.47 之上的封装库若构造 STEP_FINISHED，**必须**显式传 `stepName`，否则整个 run 静默被中断；
+  3. 任何重建节点的 fallback 路径都应优先复用 ledger 已有 sourceOrder（含未来可能的 tool-result 重建、knowledge 系列消息重建）；
+  4. **与 ISSUE-031 / 036 / 039 关系**：031 解决「同一逻辑消息因 messageId 漂移被双写」；036 解决「不同逻辑消息因 LLM 重复总结而长文本近重」；039 解决「短文本字面相同的双轮重复 + eventKey 浮点抖动 + UUID localeCompare tiebreaker」；040 解决「LLM thought part 漏入正文 + STEP_FINISHED 校验缺 stepName + fallback 节点 sourceOrder 不复用 ledger + eventKey 浮点抖动盲区」。四者正交、互不替代，共同构成 Home 双气泡 / 推理头 / 排序防御链。


### PR DESCRIPTION
## 概要

修复 Home 多轮对话中三类共存问题（详见 [ISSUE-040](docs/issue.md#issue-040-home-三连症思考独白溢出--推理头常驻--刷新乱序残留)）：

- **(Q1)** Agent 答复中混入大段第三人称英文独白（reasoning model 的 `reasoning_content` / 推理 Part 漏入正文）
- **(Q2)** 「正在思考 · 推理阶段」紫色脉冲样式在答复完成、工具组结束后仍未切换为「思考完成 · 推理阶段」
- **(Q3)** 多轮对话刷新页面后偶发消息相对位置漂移

## 根因（与 ISSUE-031/036/039 正交，五组 H1–H5）

- **H1 (Q1)** — `extractTextParts` 与混合 parts 分支只过滤 `functionCall/functionResponse`，从不识别 `part.thought` 或 `part.type === thinking|thought|reasoning|reasoning_summary|reasoning_text`；reasoning 模型的推理 Part 被原样拼到 `TEXT_MESSAGE_CONTENT`，绕过既有 4 层 dedup。
- **H2 (Q2)** — `@ag-ui/client@0.0.47` 校验器在 `STEP_FINISHED` 时用 `t.stepName`（非 `stepId`）作配对 key；`createStepFinishedEvent` 历史上未透出 `stepName`，每次 `flushSynthStep` 触发 `Cannot send 'STEP_FINISHED' for step \"undefined\" that was not started` 中断 run → reasoning 节点 status 永远停在 `running`。
- **H3 (Q3 主因 a)** — `conversation-tree.ts:1138-1283` fallback 段为 snapshot-only 历史消息构造 text 节点时把 `sourceOrder` 设为 `orderedEvents.length + fallbackIndex`，无视 ledger 中已有的小 sourceOrder。
- **H4 (Q3 主因 b)** — `eventKey` 浮点抖动保护历史上仅覆盖 `TEXT_MESSAGE_CONTENT`；其他类型同秒落库时仍可能因浮点表示差异让同一逻辑事件被保留两份。
- **H5 (Q3 长尾，032b143 增量)** — `hydrateSessionDetail` 与 `mergeEvents` 在 timestamp 相等时用 `eventKey().localeCompare` 作 tiebreaker。字典序下 `TEXT_MESSAGE_CONTENT < TEXT_MESSAGE_END < TEXT_MESSAGE_START`，把 normalizer 已正确产出的 lifecycle 顺序打乱（CONTENT→END→START），跨 messageId 的三件套互相穿插，最终 `buildConversationTree` 把 children 顺序错乱为 user1→user2→assistant1→assistant2。后端事件本身按时间正确排序，bug 完全在 UI hydration 排序链路。

## 处理方式（仅 UI / 适配层，不动 agent prompt 与协议）

| 模块 | 改动 |
|---|---|
| `apps/negentropy-ui/lib/adk/schema.ts` | `adkContentPartSchema` 显式声明 `thought: z.boolean().optional()` |
| `apps/negentropy-ui/lib/adk.ts` | 新增 `REASONING_PART_TYPES` + `isReasoningPart()`；`extractTextParts` 与混合 parts 分支跳过推理 Part；推理文本路由到 `ne.a2ui.thought` CUSTOM 事件作审计 |
| `apps/negentropy-ui/lib/adk.ts` (normalizer) | 持有 `stepNameByStepId` 映射，所有 `STEP_STARTED` 写入、`STEP_FINISHED`/`flushSynthStep` 路径回查并透出 `stepName` |
| `apps/negentropy-ui/lib/agui/factories.ts` | `createStepFinishedEvent` 新增可选 `stepName` 形参 |
| `apps/negentropy-ui/utils/conversation-tree.ts` | fallback 段优先复用 `snapshotMessage?.sourceOrder` |
| `apps/negentropy-ui/utils/session-hydration.ts::eventKey` | 通用 `toFixed(3)` 毫秒级；新增 `STEP_*` 显式 case 用 `(threadId, runId, stepId)` 作 key；CUSTOM 含 timestamp |
| `apps/negentropy-ui/utils/session-hydration.ts::hydrateSessionDetail` | **(032b143)** 用 `WeakMap<BaseEvent, emitOrder>` 记下 normalizer 推入顺序，sort tiebreaker 用 `emitOrder` 代替 `eventKey().localeCompare` |
| `apps/negentropy-ui/utils/session-hydration.ts::mergeEvents` | **(032b143)** `[...base, ...incoming]` 按首次出现位置记录 `insertionOrder` 作 tiebreaker，避免 dedup 后再次按字典序乱序 |
| `docs/issue.md` | ISSUE-040 全栈解析 + Q3 长尾闭环（H5）补充段 |

## 单元回归

- `tests/unit/adk.test.ts` 新增 6 例：`thought=true` Part 过滤 / `type=thinking|reasoning_summary` Part 过滤 / 混合 functionCall+thought+text 切割 / `message.content` 数组中的推理 Part / synth step 在 flushRun 时 STEP_FINISHED 携带 stepName / native ADK stepFinished 无 name 时回退到缓存 stepName
- `tests/unit/utils/conversation-tree.test.ts` 新增 1 例：fallback 阶段重建节点的 sourceOrder 来自 ledger
- `tests/unit/utils/session-hydration.test.ts` 新增 3 例：`STEP_FINISHED` 浮点抖动稳定 / `ne.a2ui.thought` CUSTOM 事件浮点抖动稳定 / **(032b143)** 同 timestamp 下 normalizer 推入的 lifecycle 顺序保持

全量 `pnpm --filter negentropy-ui test`：**75 文件 / 466 例 全绿**；`tsc -p tsconfig.json` 与 `tsc -p tsconfig.vitest.json` 通过；`eslint . --max-warnings=0` 通过。

## 浏览器验证

按 `CLAUDE.md::Browser Validation Protocol` 在用户登录态下复测：
- ✅ Q1 — 答复气泡不再出现 `We need to respond to the user's latest \"Ping, give me a pong.\"` 式第三人称英文独白
- ✅ Q2 — 所有推理段头部从「正在思考 · 推理阶段」切到「思考完成 · 推理阶段」灰色样式；`Cannot send 'STEP_FINISHED' for step \"undefined\"` 错误消失
- ✅ Q3 — 用 10-event 真实多轮 fixture 经修复后的 `hydrateSessionDetail → buildConversationTree` 输出 turn children 顺序为 `user(R1) → assistant(R1) → user(R2) → assistant(R2)`，与后端时间序完全一致；同 timestamp 下 lifecycle 三件套的相邻性单测保持

## Test plan

- [x] `pnpm --filter negentropy-ui test` 全绿
- [x] `pnpm --filter negentropy-ui typecheck` & `typecheck:test` 通过
- [x] `pnpm --filter negentropy-ui lint` 通过
- [x] 浏览器（用户登录态）连发 5 条 `Ping, give me a pong.` 验证 Q1+Q2 已彻底解决
- [x] 多轮 fixture 经 hydration 链路验证 Q3 turn 边界稳定