### PR TITLE
feat(wiki-header): catalog 第一层提升为顶部 Header 导航 tabs

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,10 +1,12 @@
 import {
+  resolveSectionView,
   wikiApi,
   type WikiEntry,
   type WikiEntryContent,
   type WikiNavTreeItem,
   type WikiPublication,
 } from "@/lib/wiki-api";
+import { WikiHeader } from "@/components/WikiHeader";
 import { WikiNavTree } from "@/components/WikiNavTree";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import { WikiToc } from "@/components/WikiToc";
@@ -119,6 +121,7 @@ export default async function WikiEntryPage({ params }: Props) {
   const md = content?.markdown_content ?? "";
   const headings = status === "ok" ? extractHeadings(md) : [];
   const hasToc = headings.length >= 2;
+  const sectionView = resolveSectionView(navItems, slug);
 
   const sidebar = (
     <>
@@ -136,18 +139,35 @@ export default async function WikiEntryPage({ params }: Props) {
           <span className="wiki-sidebar-title">← {publication.name}</span>
         </Link>
       </div>
-      {navItems.length > 0 && (
+      {sectionView.sidebarItems.length > 0 ? (
         <nav>
-          <WikiNavTree items={navItems} pubSlug={pubSlug} activeSlug={slug} />
+          <WikiNavTree
+            items={sectionView.sidebarItems}
+            pubSlug={pubSlug}
+            activeSlug={slug}
+          />
         </nav>
+      ) : (
+        sectionView.activeItem && (
+          <p className="wiki-text-hint wiki-empty-hint">该分组暂无文档</p>
+        )
       )}
     </>
+  );
+
+  const header = sectionView.headerItems.length > 0 && (
+    <WikiHeader
+      pubSlug={pubSlug}
+      items={sectionView.headerItems}
+      activeTopSlug={sectionView.activeTopSlug}
+    />
   );
 
   return (
     <WikiLayoutShell
       sidebar={sidebar}
       hasToc={hasToc}
+      header={header || undefined}
       toc={hasToc ? <WikiToc headings={headings} /> : undefined}
     >
       {status === "pending" ? (

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -1,8 +1,10 @@
 import {
+  resolveSectionView,
   wikiApi,
   type WikiPublication,
   type WikiNavTreeItem,
 } from "@/lib/wiki-api";
+import { WikiHeader } from "@/components/WikiHeader";
 import { WikiNavTree } from "@/components/WikiNavTree";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import Link from "next/link";
@@ -77,6 +79,7 @@ export default async function WikiPublicationPage({ params }: Props) {
 
   const indexEntry = findIndexEntry(navItems);
   const entriesTotal = countLeafEntries(navItems);
+  const sectionView = resolveSectionView(navItems);
 
   const sidebar = (
     <>
@@ -102,14 +105,28 @@ export default async function WikiPublicationPage({ params }: Props) {
           🏠 首页
         </Link>
       )}
-      <nav>
-        <WikiNavTree items={navItems} pubSlug={pubSlug} />
-      </nav>
+      {sectionView.sidebarItems.length > 0 ? (
+        <nav>
+          <WikiNavTree items={sectionView.sidebarItems} pubSlug={pubSlug} />
+        </nav>
+      ) : (
+        sectionView.activeItem && (
+          <p className="wiki-text-hint wiki-empty-hint">该分组暂无文档</p>
+        )
+      )}
     </>
   );
 
+  const header = sectionView.headerItems.length > 0 && (
+    <WikiHeader
+      pubSlug={pubSlug}
+      items={sectionView.headerItems}
+      activeTopSlug={sectionView.activeTopSlug}
+    />
+  );
+
   return (
-    <WikiLayoutShell sidebar={sidebar} hasToc={false}>
+    <WikiLayoutShell sidebar={sidebar} hasToc={false} header={header || undefined}>
       <header className="wiki-doc-header">
         <h1 className="wiki-doc-title">{publication.name}</h1>
         <div className="wiki-doc-meta">

--- a/apps/negentropy-wiki/src/app/globals.css
+++ b/apps/negentropy-wiki/src/app/globals.css
@@ -184,11 +184,15 @@ hr { border: none; border-top: 1px solid var(--wiki-border); margin: 2em 0; }
   background: var(--wiki-sidebar-bg);
   border-right: 1px solid var(--wiki-border);
   position: sticky;
-  top: var(--wiki-header-height);
-  height: calc(100vh - var(--wiki-header-height));
+  top: 0;
+  height: 100vh;
   overflow-y: auto;
   padding: 1.5rem 1rem;
   min-width: 0;
+}
+.wiki-layout[data-header] .wiki-sidebar {
+  top: var(--wiki-header-height);
+  height: calc(100vh - var(--wiki-header-height));
 }
 
 .wiki-main {
@@ -201,12 +205,16 @@ hr { border: none; border-top: 1px solid var(--wiki-border); margin: 2em 0; }
 
 .wiki-toc-aside {
   position: sticky;
-  top: var(--wiki-header-height);
+  top: 0;
   align-self: start;
-  height: calc(100vh - var(--wiki-header-height));
+  height: 100vh;
   overflow-y: auto;
   border-left: 1px solid var(--wiki-border);
   background: var(--wiki-bg);
+}
+.wiki-layout[data-header] .wiki-toc-aside {
+  top: var(--wiki-header-height);
+  height: calc(100vh - var(--wiki-header-height));
 }
 
 /* ====== 顶部 Header（catalog 第一层提升为 tabs）======

--- a/apps/negentropy-wiki/src/app/globals.css
+++ b/apps/negentropy-wiki/src/app/globals.css
@@ -22,6 +22,7 @@
   --wiki-sidebar-width: 280px;
   --wiki-toc-width: 240px;
   --wiki-toc-rail-width: 40px;
+  --wiki-header-height: 56px;
   --wiki-content-max-width: 820px;
   --wiki-heading-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Noto Sans SC", sans-serif;
@@ -183,8 +184,8 @@ hr { border: none; border-top: 1px solid var(--wiki-border); margin: 2em 0; }
   background: var(--wiki-sidebar-bg);
   border-right: 1px solid var(--wiki-border);
   position: sticky;
-  top: 0;
-  height: 100vh;
+  top: var(--wiki-header-height);
+  height: calc(100vh - var(--wiki-header-height));
   overflow-y: auto;
   padding: 1.5rem 1rem;
   min-width: 0;
@@ -200,12 +201,111 @@ hr { border: none; border-top: 1px solid var(--wiki-border); margin: 2em 0; }
 
 .wiki-toc-aside {
   position: sticky;
-  top: 0;
+  top: var(--wiki-header-height);
   align-self: start;
-  height: 100vh;
+  height: calc(100vh - var(--wiki-header-height));
   overflow-y: auto;
   border-left: 1px solid var(--wiki-border);
   background: var(--wiki-bg);
+}
+
+/* ====== 顶部 Header（catalog 第一层提升为 tabs）======
+ *
+ * - Server-rendered，仅 `<Link>`，零交互状态
+ * - 渲染于 `.wiki-layout` 之外作为兄弟节点，不参与 3 列 Grid
+ * - sticky，保证滚动时常驻顶部；sidebar/toc 通过 --wiki-header-height 让位
+ */
+
+.wiki-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  height: var(--wiki-header-height);
+  background: var(--wiki-bg);
+  border-bottom: 1px solid var(--wiki-border);
+}
+
+.wiki-header-inner {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  height: 100%;
+  padding: 0 clamp(1rem, 2vw, 1.5rem);
+}
+
+.wiki-header-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-shrink: 0;
+  color: var(--wiki-text);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.98em;
+  white-space: nowrap;
+}
+.wiki-header-brand:hover {
+  color: var(--wiki-accent);
+  text-decoration: none;
+}
+
+.wiki-header-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.wiki-header-name {
+  letter-spacing: 0.01em;
+}
+
+.wiki-header-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.wiki-header-tab {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.85rem;
+  height: 100%;
+  font-size: 0.92em;
+  font-weight: 500;
+  color: var(--wiki-text-secondary);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.12s ease;
+  white-space: nowrap;
+  border-radius: 0;
+}
+.wiki-header-tab:hover {
+  color: var(--wiki-text);
+  text-decoration: none;
+  background: var(--wiki-bg-secondary);
+}
+.wiki-header-tab.active {
+  color: var(--wiki-accent);
+  border-bottom-color: var(--wiki-accent);
+  font-weight: 600;
+}
+.wiki-header-tab.disabled {
+  color: var(--wiki-text-secondary);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.wiki-header-tab.disabled:hover {
+  background: transparent;
+}
+
+.wiki-header-slot {
+  flex-shrink: 0;
 }
 
 /* ====== 侧边栏样式 ====== */

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import {
+  findFirstDocumentSlug,
+  isContainerItem,
+  type WikiNavTreeItem,
+} from "@/lib/wiki-api";
+
+/**
+ * Wiki 顶部 Header 导航 — 把 catalog 第一层提升为 tabs
+ *
+ * 设计参考：GitHub Docs / Stripe Docs / Docusaurus —— 顶部 tabs + 左侧 sidebar 子树。
+ *
+ * - Server Component（仅 `<Link>`，零客户端状态）；保持 SSG 友好。
+ * - tab 跳转目标：DOCUMENT 直链；CONTAINER → DFS 找首个后代 DOCUMENT；无文档则禁用。
+ * - `items` 为空时早返回 `null`，避免渲染空壳。
+ */
+
+interface WikiHeaderProps {
+  pubSlug: string;
+  items: WikiNavTreeItem[];
+  activeTopSlug?: string;
+}
+
+export function WikiHeader({ pubSlug, items, activeTopSlug }: WikiHeaderProps) {
+  if (!items.length) return null;
+
+  return (
+    <header className="wiki-header">
+      <div className="wiki-header-inner">
+        <Link href="/" className="wiki-header-brand" aria-label="返回 Wiki 首页">
+          {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+          <img
+            src="/logo.png"
+            alt="Negentropy"
+            className="wiki-header-logo"
+            width={28}
+            height={28}
+          />
+          <span className="wiki-header-name">Negentropy Wiki</span>
+        </Link>
+        <nav className="wiki-header-tabs" aria-label="主导航">
+          {items.map((item) => (
+            <WikiHeaderTab
+              key={`${item.entry_id ?? "c"}:${item.entry_slug}`}
+              item={item}
+              pubSlug={pubSlug}
+              isActive={item.entry_slug === activeTopSlug}
+            />
+          ))}
+        </nav>
+        <div className="wiki-header-slot" aria-hidden="true" />
+      </div>
+    </header>
+  );
+}
+
+interface WikiHeaderTabProps {
+  item: WikiNavTreeItem;
+  pubSlug: string;
+  isActive: boolean;
+}
+
+function WikiHeaderTab({ item, pubSlug, isActive }: WikiHeaderTabProps) {
+  const targetSlug = pickTabTargetSlug(item);
+  const className = `wiki-header-tab${isActive ? " active" : ""}`;
+  const label = item.entry_title || item.entry_slug;
+
+  if (!targetSlug) {
+    return (
+      <span
+        className={`${className} disabled`}
+        aria-disabled="true"
+        tabIndex={-1}
+        title="该分组暂无可用文档"
+      >
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={`/${pubSlug}/${targetSlug}`}
+      className={className}
+      aria-current={isActive ? "page" : undefined}
+    >
+      {label}
+    </Link>
+  );
+}
+
+function pickTabTargetSlug(item: WikiNavTreeItem): string | null {
+  if (!isContainerItem(item)) return item.entry_slug;
+  return findFirstDocumentSlug(item);
+}

--- a/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
+++ b/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
@@ -109,7 +109,7 @@ export function WikiLayoutShell({
   return (
     <TocContext.Provider value={ctxValue}>
       {header}
-      <div className="wiki-layout" data-toc={dataToc}>
+      <div className="wiki-layout" data-toc={dataToc} data-header={header ? "" : undefined}>
         <aside className="wiki-sidebar">{sidebar}</aside>
         <main className="wiki-main">{children}</main>
         {hasToc && <aside className="wiki-toc-aside">{toc}</aside>}

--- a/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
+++ b/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
@@ -51,6 +51,13 @@ interface WikiLayoutShellProps {
   children: ReactNode;
   toc?: ReactNode;
   hasToc?: boolean;
+  /**
+   * 顶部 Header（站点品牌 + 一级 tabs）。
+   *
+   * 渲染在 `.wiki-layout` 之外作为兄弟节点 —— 不参与 3 列 Grid，避免动 `data-toc` 三态。
+   * Sticky 偏移由 globals.css 的 `--wiki-header-height` 处理（sidebar / toc-aside 的 top）。
+   */
+  header?: ReactNode;
   /** 同站多布局共存时的命名空间隔离 */
   storageKey?: string;
 }
@@ -60,6 +67,7 @@ export function WikiLayoutShell({
   children,
   toc,
   hasToc = false,
+  header,
   storageKey = TOC_STORAGE_KEY,
 }: WikiLayoutShellProps) {
   const [collapsed, setCollapsedState] = useState(false);
@@ -100,6 +108,7 @@ export function WikiLayoutShell({
 
   return (
     <TocContext.Provider value={ctxValue}>
+      {header}
       <div className="wiki-layout" data-toc={dataToc}>
         <aside className="wiki-sidebar">{sidebar}</aside>
         <main className="wiki-main">{children}</main>

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -160,3 +160,79 @@ class WikiApiClient {
 }
 
 export const wikiApi = new WikiApiClient();
+
+// ---------------------------------------------------------------------------
+// 导航视图派生（供 Header tabs / Sidebar 子树切片复用）
+// ---------------------------------------------------------------------------
+
+/**
+ * DFS 找首个可达 DOCUMENT 节点的 entry_slug。
+ *
+ * 用于 Header CONTAINER tab 的跳转目标——把第一篇文档作为该 section 的"封面"。
+ * `null` 表示该子树整体没有任何 DOCUMENT，调用方应渲染为禁用 tab。
+ */
+export function findFirstDocumentSlug(item: WikiNavTreeItem): string | null {
+  if (!isContainerItem(item)) return item.entry_slug;
+  for (const child of item.children ?? []) {
+    const slug = findFirstDocumentSlug(child);
+    if (slug) return slug;
+  }
+  return null;
+}
+
+/**
+ * 反查包含 `currentSlug` 的第一层节点 slug。
+ *
+ * - `currentSlug` 为空（如 `/{pubSlug}` 根页）→ 返回首项 slug，落实"默认首项激活"语义；
+ * - `currentSlug` 非空但树中找不到（异常路径）→ 返回首项 slug 兜底；
+ * - 树为空 → `undefined`。
+ */
+export function findActiveTopLevelSlug(
+  items: WikiNavTreeItem[],
+  currentSlug?: string,
+): string | undefined {
+  if (!items.length) return undefined;
+  if (!currentSlug) return items[0].entry_slug;
+
+  const hits = (node: WikiNavTreeItem): boolean => {
+    if (node.entry_slug === currentSlug) return true;
+    return (node.children ?? []).some(hits);
+  };
+  for (const top of items) {
+    if (hits(top)) return top.entry_slug;
+  }
+  return items[0].entry_slug;
+}
+
+export interface WikiSectionView {
+  /** Header tabs 数据源（即原始第一层） */
+  headerItems: WikiNavTreeItem[];
+  /** 当前激活的第一层节点 slug */
+  activeTopSlug: string | undefined;
+  /** 当前激活的第一层节点对象（便于上层取 children / 渲染禁用态） */
+  activeItem: WikiNavTreeItem | undefined;
+  /** Sidebar 待渲染子树（即激活节点的 children；原第二层及以下） */
+  sidebarItems: WikiNavTreeItem[];
+}
+
+/**
+ * 单一事实源：从 navItems 与 currentSlug 派生 Header / Sidebar 视图。
+ *
+ * 用于 `/{pubSlug}` 与 `/{pubSlug}/{...entrySlug}` 两条路由共享视图切片，
+ * 杜绝两端各自重复实现 active 反查与子树切片。
+ */
+export function resolveSectionView(
+  items: WikiNavTreeItem[],
+  currentSlug?: string,
+): WikiSectionView {
+  const activeTopSlug = findActiveTopLevelSlug(items, currentSlug);
+  const activeItem = activeTopSlug
+    ? items.find((it) => it.entry_slug === activeTopSlug)
+    : undefined;
+  return {
+    headerItems: items,
+    activeTopSlug,
+    activeItem,
+    sidebarItems: activeItem?.children ?? [],
+  };
+}

--- a/apps/negentropy-wiki/tests/lib/wiki-section-view.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-section-view.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Header tabs / Sidebar 子树切片派生（catalog 第一层提升）
+ *
+ * 锁定 ``findFirstDocumentSlug`` / ``findActiveTopLevelSlug`` / ``resolveSectionView``
+ * 在以下场景的行为：
+ *   1. 空树 → 视图为空；
+ *   2. 单 DOCUMENT 一级节点 → tab 直链该 doc；
+ *   3. 多 CONTAINER 一级节点 → 找首个可达后代 DOCUMENT；
+ *   4. CONTAINER 无任何后代 DOCUMENT → tab 跳转 slug = null（禁用语义）；
+ *   5. currentSlug 为空 → activeTop = 首项；
+ *   6. currentSlug 为深层 entry → activeTop 反查命中所属第一层；
+ *   7. currentSlug 在树外 → 兜底为首项。
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  findActiveTopLevelSlug,
+  findFirstDocumentSlug,
+  resolveSectionView,
+  type WikiNavTreeItem,
+} from "@/lib/wiki-api";
+
+function doc(slug: string, overrides: Partial<WikiNavTreeItem> = {}): WikiNavTreeItem {
+  return {
+    entry_id: `entry-${slug}`,
+    entry_slug: slug,
+    entry_title: slug,
+    is_index_page: false,
+    document_id: `doc-${slug}`,
+    entry_kind: "DOCUMENT",
+    ...overrides,
+  };
+}
+
+function container(
+  slug: string,
+  children: WikiNavTreeItem[] = [],
+  overrides: Partial<WikiNavTreeItem> = {},
+): WikiNavTreeItem {
+  return {
+    entry_id: `entry-${slug}`,
+    entry_slug: slug,
+    entry_title: slug,
+    is_index_page: false,
+    document_id: null,
+    entry_kind: "CONTAINER",
+    catalog_node_id: `node-${slug}`,
+    children,
+    ...overrides,
+  };
+}
+
+describe("findFirstDocumentSlug", () => {
+  it("DOCUMENT 节点直接返回自身 slug", () => {
+    expect(findFirstDocumentSlug(doc("a"))).toBe("a");
+  });
+
+  it("CONTAINER → DFS 找到首个后代 DOCUMENT", () => {
+    const tree = container("c1", [
+      container("c1/sub", [doc("c1/sub/p1"), doc("c1/sub/p2")]),
+      doc("c1/p"),
+    ]);
+    expect(findFirstDocumentSlug(tree)).toBe("c1/sub/p1");
+  });
+
+  it("CONTAINER 无后代 DOCUMENT → 返回 null", () => {
+    const tree = container("c1", [container("c1/sub", [container("c1/sub/empty")])]);
+    expect(findFirstDocumentSlug(tree)).toBeNull();
+  });
+});
+
+describe("findActiveTopLevelSlug", () => {
+  const tree: WikiNavTreeItem[] = [
+    container("alpha", [
+      container("alpha/blog", [doc("alpha/blog/post-1")]),
+      container("alpha/paper", [doc("alpha/paper/p-2")]),
+    ]),
+    container("beta", [doc("beta/intro")]),
+  ];
+
+  it("空树 → undefined", () => {
+    expect(findActiveTopLevelSlug([], "anything")).toBeUndefined();
+  });
+
+  it("currentSlug 为空 → 默认首项", () => {
+    expect(findActiveTopLevelSlug(tree)).toBe("alpha");
+    expect(findActiveTopLevelSlug(tree, undefined)).toBe("alpha");
+  });
+
+  it("currentSlug 命中首层节点本身", () => {
+    expect(findActiveTopLevelSlug(tree, "beta")).toBe("beta");
+  });
+
+  it("currentSlug 命中深层节点 → 返回所属第一层", () => {
+    expect(findActiveTopLevelSlug(tree, "alpha/blog/post-1")).toBe("alpha");
+    expect(findActiveTopLevelSlug(tree, "beta/intro")).toBe("beta");
+  });
+
+  it("currentSlug 在树外 → 兜底首项", () => {
+    expect(findActiveTopLevelSlug(tree, "ghost/unknown")).toBe("alpha");
+  });
+});
+
+describe("resolveSectionView", () => {
+  const tree: WikiNavTreeItem[] = [
+    container("alpha", [
+      container("alpha/blog", [doc("alpha/blog/post-1")]),
+      container("alpha/paper", [doc("alpha/paper/p-2")]),
+    ]),
+    doc("beta-only"),
+  ];
+
+  it("空树 → 全空视图", () => {
+    const view = resolveSectionView([]);
+    expect(view.headerItems).toHaveLength(0);
+    expect(view.activeTopSlug).toBeUndefined();
+    expect(view.activeItem).toBeUndefined();
+    expect(view.sidebarItems).toHaveLength(0);
+  });
+
+  it("无 currentSlug → 默认首项激活，sidebarItems = 该项 children", () => {
+    const view = resolveSectionView(tree);
+    expect(view.activeTopSlug).toBe("alpha");
+    expect(view.activeItem?.entry_slug).toBe("alpha");
+    expect(view.sidebarItems.map((it) => it.entry_slug)).toEqual([
+      "alpha/blog",
+      "alpha/paper",
+    ]);
+  });
+
+  it("DOCUMENT-only 一级激活 → sidebarItems 为空", () => {
+    const view = resolveSectionView(tree, "beta-only");
+    expect(view.activeTopSlug).toBe("beta-only");
+    expect(view.activeItem?.entry_slug).toBe("beta-only");
+    expect(view.sidebarItems).toHaveLength(0);
+  });
+
+  it("深层 currentSlug → 激活其所属第一层", () => {
+    const view = resolveSectionView(tree, "alpha/paper/p-2");
+    expect(view.activeTopSlug).toBe("alpha");
+    expect(view.sidebarItems.map((it) => it.entry_slug)).toEqual([
+      "alpha/blog",
+      "alpha/paper",
+    ]);
+  });
+});


### PR DESCRIPTION
## 概述

将 wiki publication catalog 的第一层 CONTAINER 节点（如 `Harness-Engineering`）从左侧 Sidebar 迁移为顶部 Header tabs；第二层及以下保留于 Sidebar，整棵 nav 树向上提升一档。设计参考 GitHub Docs / Stripe Docs / Docusaurus 的「顶 tabs + 左 sidebar 子树」经典模式。

## 变更范围

- 路由：仅 `/{pubSlug}` 与 `/{pubSlug}/{...entrySlug}` 两条；home `/` 卡片网格不变。
- 数据：复用既有 `WikiNavTreeItem`（CONTAINER / DOCUMENT），不改后端。

## 实施要点

| 模块 | 变更 |
| --- | --- |
| `lib/wiki-api.ts` | 追加 `findFirstDocumentSlug` / `findActiveTopLevelSlug` / `resolveSectionView` 三个纯函数，作为 Header tabs 与 Sidebar 切片的**单一事实源**，被两条路由共用，杜绝重复实现 |
| `components/WikiHeader.tsx`（新增）| Server Component（仅 `<Link>`，SSG 友好）：左 brand + 中 horizontal tabs + 右预留 slot；CONTAINER tab 跳 DFS 首个后代 DOCUMENT；无文档则禁用 `<span>` + `aria-disabled` |
| `components/WikiLayoutShell.tsx` | 增加可选 `header?: ReactNode`；渲染于 `.wiki-layout` 之外作为兄弟节点，**不动**既有 3 列 CSS Grid 与 `data-toc` 三态（`expanded` / `collapsed` / `none`） |
| `app/[pubSlug]/page.tsx` | 调用 `resolveSectionView(navItems)`：pub 根页默认激活首项 + 保留 overview；sidebar 仅渲染该项的 children |
| `app/[pubSlug]/[...entrySlug]/page.tsx` | 调用 `resolveSectionView(navItems, slug)`：按当前 entry 反查所属一级；TOC / sticky 行为不退化 |
| `app/globals.css` | 引入 `--wiki-header-height: 56px`；sidebar / toc-aside 的 sticky `top` 与 `height` 改为 var 引用；新增 `.wiki-header*` 样式（GitHub Docs 风的 active 下边框） |
| `tests/lib/wiki-section-view.test.ts`（新增）| 12 用例覆盖空树 / 单 / 多 / 深路径 / DOCUMENT-only / 无后代 DOCUMENT 等边界 |

## 验证

- `pnpm test` — 47/47 全绿（含新增 12 用例）
- `pnpm lint` — 无 warning/error
- `pnpm build` — SSG 通过，路由维持 ISR `revalidate=300`
- 浏览器自检（http://localhost:3092 + 后端 :3292 真实数据）：
  - `/wiki` 顶部 Header 渲染 `Harness-Engineering` tab，默认蓝色高亮 + 下边框；Sidebar 仅显示 Blog/Paper（原第二层）；Main overview 文案保留
  - `/wiki/harness-engineering/blog/harness-design-long-running-apps-md` 文章页 active tab 反查正确；Sidebar Blog 已展开 + 当前文档高亮；TOC 正常；`← wiki` 返回链接保留
  - `/` 首页保持原 publications 卡片网格，不显示 Header
  - DevTools console 无 hydration warning / error

## 截图

- Publication 根页（默认激活首项）
- 文章详情页（active tab 反查 + sidebar 第二层提升 + TOC）
- Home `/`（保持原网格）

## 边界与回退

- nav tree 为空 → 不渲染 Header；sidebar 走原空态。
- 一级是 DOCUMENT（非 CONTAINER）→ Tab 直链；sidebarItems 空时显示「该分组暂无文档」灰字提示，不抖动布局。
- CONTAINER 一级无后代 DOCUMENT → Tab 渲染为禁用 `<span>` + `title` 提示。
- 异常 currentSlug → 兜底首项激活。
- 后端缺 `entry_kind` → 沿用 `isContainerItem` 按 `document_id` 推导。

## 不做的事

- 不动 `WikiNavTree` 内部递归逻辑（外层只是把"剥皮"后的子树传入）。
- 不引入新数据源 / 新主题变量（除 `--wiki-header-height`）。
- 不引入客户端状态 / Context（Header 全 server 渲染）。