### PR TITLE
feat(memory): Phase 2++ 增强 — ACID 巩固 + Token 预算校验 + 多因子遗忘曲线 + 搜索可观测性

### DIFF
--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/context_assembler.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/context_assembler.py
@@ -305,8 +305,20 @@ class ContextAssembler:
         final_tokens = await self._accurate_token_count(truncated_text)
 
         # Post-join 安全校验：换行符 token 化可能导致超标，逐行回退
-        while final_tokens > budget and len(truncated_lines) > 1:
-            truncated_lines.pop()
+        while final_tokens > budget and truncated_lines:
+            if len(truncated_lines) > 1:
+                truncated_lines.pop()
+            else:
+                # 单行兜底：按字符比例截断至安全长度
+                line = truncated_lines[0]
+                if len(line) > 10:
+                    safe_chars = max(0, int(len(line) * budget / max(final_tokens, 1) * 0.9))
+                    truncated_lines[0] = line[:safe_chars] + "..." if safe_chars > 0 else ""
+                else:
+                    truncated_lines = []
+                truncated_text = "\n".join(truncated_lines)
+                final_tokens = await self._accurate_token_count(truncated_text)
+                break
             truncated_text = "\n".join(truncated_lines)
             final_tokens = await self._accurate_token_count(truncated_text)
 

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/context_assembler.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/context_assembler.py
@@ -97,6 +97,25 @@ class ContextAssembler:
                 query_embedding=query_embedding,
             )
 
+            # Token Budget 硬性校验：超标时按行截断
+            budget_total = memory_tokens + history_tokens
+            actual_tokens = result.get("token_count", 0)
+            if actual_tokens > budget_total:
+                result = await self._truncate_to_budget(result, budget_total)
+                logger.warning(
+                    "context_budget_overflow",
+                    actual_tokens=actual_tokens,
+                    budget=budget_total,
+                    truncated_tokens=result["token_count"],
+                )
+
+            # 丰富 budget 元数据
+            result["budget"]["actual_tokens"] = result["token_count"]
+            result["budget"]["budget_utilization"] = (
+                result["token_count"] / self._max_tokens if self._max_tokens > 0 else 0.0
+            )
+            result["budget"]["overflow"] = actual_tokens > budget_total
+
             # 隐式反馈：记忆被注入 LLM 上下文 → mark_referenced<sup>[[33]](#ref33)</sup>
             if result.get("memory_context") and retrieval_log_id:
                 try:
@@ -246,6 +265,50 @@ class ContextAssembler:
             context_length=len(context),
         )
         return context
+
+    async def _truncate_to_budget(
+        self,
+        result: dict[str, Any],
+        budget: int,
+    ) -> dict[str, Any]:
+        """按行截断上下文至 token 预算内
+
+        优先保留先召回的高相关性内容（SQL 已按 relevance_score 排序），
+        末行按字符安全截断（chars_per_token × remaining × 0.9）。
+
+        参考 MemGPT<sup>[[7]](#ref7)</sup> Virtual Context Management 的
+        分页截断策略。
+        """
+        context_text = result.get("memory_context", "")
+        if not context_text:
+            return result
+
+        lines = context_text.split("\n")
+        truncated_lines: list[str] = []
+        current_tokens = 0
+
+        for line in lines:
+            line_tokens = await self._accurate_token_count(line)
+            if current_tokens + line_tokens <= budget:
+                truncated_lines.append(line)
+                current_tokens += line_tokens
+            else:
+                remaining = budget - current_tokens
+                if remaining > 50 and line.strip():
+                    chars_per_token = len(line) / max(line_tokens, 1)
+                    safe_chars = int(remaining * chars_per_token * 0.9)
+                    if safe_chars > 0:
+                        truncated_lines.append(line[:safe_chars] + "...")
+                break
+
+        truncated_text = "\n".join(truncated_lines)
+        final_tokens = await self._accurate_token_count(truncated_text)
+
+        return {
+            "memory_context": truncated_text,
+            "token_count": final_tokens,
+            "budget": result.get("budget", {}),
+        }
 
     async def _accurate_token_count(self, text: str) -> int:
         """使用 tiktoken BPE 编码器精确计数（替代 LENGTH/4 估算）"""

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/context_assembler.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/context_assembler.py
@@ -304,6 +304,12 @@ class ContextAssembler:
         truncated_text = "\n".join(truncated_lines)
         final_tokens = await self._accurate_token_count(truncated_text)
 
+        # Post-join 安全校验：换行符 token 化可能导致超标，逐行回退
+        while final_tokens > budget and len(truncated_lines) > 1:
+            truncated_lines.pop()
+            truncated_text = "\n".join(truncated_lines)
+            final_tokens = await self._accurate_token_count(truncated_text)
+
         return {
             "memory_context": truncated_text,
             "token_count": final_tokens,

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -96,8 +96,10 @@ class PostgresMemoryService(BaseMemoryService):
         阶段 3 — 存储（Consolidate）: 写入新记忆，附带初始 retention_score
         阶段 4 — 事实提取（Extract）: 从对话中提取结构化事实并存储
 
-        事务安全<sup>[[44]](#ref44)</sup>：整个管线在单次事务内执行，
-        使用 SAVEPOINT 隔离每段写入，advisory lock 防止同 thread 并发巩固。
+        事务安全<sup>[[44]](#ref44)</sup>：阶段 2（embedding 生成）在事务外预计算，
+        阶段 3（写入）在单次事务内执行，使用 SAVEPOINT 隔离每段写入，
+        advisory lock 防止同 thread 并发巩固。
+        阶段 4（事实提取）由 FactService 独立事务管理，不影响主事务。
 
         借鉴 Claude Code AutoDream 的 Orient→Consolidate 范式。
         """
@@ -109,25 +111,29 @@ class PostgresMemoryService(BaseMemoryService):
         segments = self._group_turns_into_segments(turns)
         thread_id = self._parse_thread_id(session.id)
 
-        # 单事务执行整个巩固管线（ACID 保障）
+        # 阶段 2（预计算）：事务外生成 embedding，避免重试休眠期间持有锁
+        seg_data: list[tuple[int, str, list[float] | None]] = []
+        for seg_idx, segment in enumerate(segments):
+            content = self._format_segment_content(segment)
+            embedding = await self._retry_embedding(content, seg_idx)
+            if embedding is None and self._embedding_fn:
+                logger.warning("consolidate_embedding_skipped", segment=seg_idx)
+                continue
+            seg_data.append((seg_idx, content, embedding))
+
+        if not seg_data:
+            logger.info("consolidate_no_segments_after_embedding", user_id=session.user_id)
+            return
+
+        # 阶段 3（写入）：单事务执行去重 + 存储
+        stored_count = 0
         async with db_session.AsyncSessionLocal() as db:
             # Advisory lock: 防止同 thread 并发巩固
             if not await self._try_acquire_advisory_lock(db, thread_id):
                 logger.info("consolidate_skipped_concurrent", thread_id=str(thread_id))
                 return
 
-            # 阶段 2+3：逐段去重后存储（SAVEPOINT 隔离）
-            stored_count = 0
-            for seg_idx, segment in enumerate(segments):
-                content = self._format_segment_content(segment)
-
-                # Orient: 生成 embedding（指数退避重试）
-                embedding = await self._retry_embedding(content, seg_idx)
-                if embedding is None and self._embedding_fn:
-                    # Embedding 失败 — 跳过该段，不存无 embedding 记忆
-                    logger.warning("consolidate_embedding_skipped", segment=seg_idx)
-                    continue
-
+            for seg_idx, content, embedding in seg_data:
                 if embedding is not None and await self._is_duplicate(
                     db=db,
                     user_id=session.user_id,
@@ -138,7 +144,6 @@ class PostgresMemoryService(BaseMemoryService):
                     logger.debug("consolidate_duplicate_skipped", segment=seg_idx)
                     continue
 
-                # Consolidate: SAVEPOINT 隔离每段写入
                 initial_score = self._calculate_initial_retention(content)
                 async with db.begin_nested():
                     memory = Memory(
@@ -154,26 +159,25 @@ class PostgresMemoryService(BaseMemoryService):
                             "event_count": len(session.events),
                             "segment_index": seg_idx,
                             "total_segments": len(segments),
-                            "turn_count": len(segment),
+                            "turn_count": len(segments[seg_idx] if seg_idx < len(segments) else []),
                         },
                     )
                     db.add(memory)
                 stored_count += 1
 
-            # 阶段 4：事实提取（同一事务内，失败仅回滚事实，不影响记忆）
-            try:
-                await self._extract_and_store_facts(
-                    db=db,
-                    turns=turns,
-                    user_id=session.user_id,
-                    app_name=session.app_name,
-                    thread_id=thread_id,
-                )
-            except Exception as exc:
-                logger.warning("fact_extraction_stage_failed", error=str(exc))
-
-            # 统一 commit — 全有或全无
+            # 统一 commit
             await db.commit()
+
+        # 阶段 4：事实提取（FactService 独立事务，失败不影响已提交的记忆）
+        try:
+            await self._extract_and_store_facts(
+                turns=turns,
+                user_id=session.user_id,
+                app_name=session.app_name,
+                thread_id=thread_id,
+            )
+        except Exception as exc:
+            logger.warning("fact_extraction_stage_failed", error=str(exc))
 
         logger.info(
             "consolidate_completed",
@@ -238,7 +242,6 @@ class PostgresMemoryService(BaseMemoryService):
     async def _extract_and_store_facts(
         self,
         *,
-        db: Any | None = None,
         turns: list[dict[str, str]],
         user_id: str,
         app_name: str,
@@ -249,8 +252,7 @@ class PostgresMemoryService(BaseMemoryService):
         使用 PatternFactExtractor 做模式匹配提取，
         通过 FactService.upsert_fact 存储（利用唯一约束做 upsert）。
 
-        Args:
-            db: 外部 session（复用事务），None 时自行创建。
+        注意：FactService 内部管理独立 session，事实写入不参与主事务。
         """
         from negentropy.engine.factories.memory import get_fact_service
 

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -17,6 +17,7 @@ PostgresMemoryService: ADK MemoryService 的 PostgreSQL 实现
 
 from __future__ import annotations
 
+import asyncio
 import re
 import uuid
 from datetime import UTC, datetime
@@ -51,6 +52,21 @@ _MAX_TURN_PAIRS_PER_SEGMENT = 5  # 每段最多包含的 user+model 对话轮次
 _DEDUP_SIMILARITY_THRESHOLD = 0.85  # cosine similarity 去重阈值（对齐 Henzinger<sup>[[40]](#ref40)</sup>）
 _DEDUP_JACCARD_THRESHOLD = 0.7  # Jaccard 词重叠二次校验阈值（对齐 Broder MinHash<sup>[[37]](#ref37)</sup>）
 _INITIAL_RETENTION_BASE = 0.8  # 新记忆初始保留分数基准
+_EMBEDDING_MAX_RETRIES = 3  # Embedding 指数退避最大重试次数<sup>[[44]](#ref44)</sup>
+
+# 记忆类型衰减率映射（ACT-R 认知架构<sup>[[45]](#ref45)</sup> + FadeMem<sup>[[46]](#ref46)</sup>）
+_MEMORY_TYPE_DECAY_RATES: dict[str, float] = {
+    "preference": 0.05,  # 用户偏好长期保持
+    "procedural": 0.06,  # 技能/流程较稳定
+    "fact": 0.08,  # 事实中等衰减
+    "episodic": 0.10,  # 对话片段衰减最快（基准）
+}
+_MEMORY_TYPE_MULTIPLIER: dict[str, float] = {
+    "preference": 1.2,
+    "procedural": 1.15,
+    "fact": 1.1,
+    "episodic": 1.0,
+}
 
 
 class PostgresMemoryService(BaseMemoryService):
@@ -84,12 +100,15 @@ class PostgresMemoryService(BaseMemoryService):
             await self._simple_consolidate(session)
 
     async def _simple_consolidate(self, session: ADKSession) -> None:
-        """四阶段记忆巩固管线
+        """四阶段记忆巩固管线（事务级联 + 并发控制）
 
         阶段 1 — 分段（Segment）: 按 speaker turn 将对话拆分为多段
         阶段 2 — 去重（Orient）: 对每段生成 embedding，与现有记忆比对跳过重复
         阶段 3 — 存储（Consolidate）: 写入新记忆，附带初始 retention_score
         阶段 4 — 事实提取（Extract）: 从对话中提取结构化事实并存储
+
+        事务安全<sup>[[44]](#ref44)</sup>：整个管线在单次事务内执行，
+        使用 SAVEPOINT 隔离每段写入，advisory lock 防止同 thread 并发巩固。
 
         借鉴 Claude Code AutoDream 的 Orient→Consolidate 范式。
         """
@@ -99,23 +118,29 @@ class PostgresMemoryService(BaseMemoryService):
             return
 
         segments = self._group_turns_into_segments(turns)
-
         thread_id = self._parse_thread_id(session.id)
 
-        # 阶段 2+3：逐段去重后存储
-        stored_count = 0
-        for seg_idx, segment in enumerate(segments):
-            content = self._format_segment_content(segment)
+        # 单事务执行整个巩固管线（ACID 保障）
+        async with db_session.AsyncSessionLocal() as db:
+            # Advisory lock: 防止同 thread 并发巩固
+            if not await self._try_acquire_advisory_lock(db, thread_id):
+                logger.info("consolidate_skipped_concurrent", thread_id=str(thread_id))
+                return
 
-            # Orient: 生成 embedding 并检测重复
-            embedding = None
-            if self._embedding_fn:
-                try:
-                    embedding = await self._embedding_fn(content)
-                except Exception as exc:
-                    logger.warning("consolidate_embedding_failed", segment=seg_idx, error=str(exc))
+            # 阶段 2+3：逐段去重后存储（SAVEPOINT 隔离）
+            stored_count = 0
+            for seg_idx, segment in enumerate(segments):
+                content = self._format_segment_content(segment)
 
-                if embedding is not None and await self._is_duplicate(
+                # Orient: 生成 embedding（指数退避重试）
+                embedding = await self._retry_embedding(content, seg_idx)
+                if embedding is None and self._embedding_fn:
+                    # Embedding 失败 — 跳过该段，不存无 embedding 记忆
+                    logger.warning("consolidate_embedding_skipped", segment=seg_idx)
+                    continue
+
+                if embedding is not None and await self._is_duplicate_in_session(
+                    db=db,
                     user_id=session.user_id,
                     app_name=session.app_name,
                     embedding=embedding,
@@ -124,39 +149,42 @@ class PostgresMemoryService(BaseMemoryService):
                     logger.debug("consolidate_duplicate_skipped", segment=seg_idx)
                     continue
 
-            # Consolidate: 存储新记忆
-            initial_score = self._calculate_initial_retention(content)
-            async with db_session.AsyncSessionLocal() as db:
-                memory = Memory(
-                    thread_id=thread_id,
-                    user_id=session.user_id,
-                    app_name=session.app_name,
-                    memory_type="episodic",
-                    content=content,
-                    embedding=embedding,
-                    retention_score=initial_score,
-                    metadata_={
-                        "source": "session",
-                        "event_count": len(session.events),
-                        "segment_index": seg_idx,
-                        "total_segments": len(segments),
-                        "turn_count": len(segment),
-                    },
-                )
-                db.add(memory)
-                await db.commit()
+                # Consolidate: SAVEPOINT 隔离每段写入
+                initial_score = self._calculate_initial_retention(content)
+                async with db.begin_nested():
+                    memory = Memory(
+                        thread_id=thread_id,
+                        user_id=session.user_id,
+                        app_name=session.app_name,
+                        memory_type="episodic",
+                        content=content,
+                        embedding=embedding,
+                        retention_score=initial_score,
+                        metadata_={
+                            "source": "session",
+                            "event_count": len(session.events),
+                            "segment_index": seg_idx,
+                            "total_segments": len(segments),
+                            "turn_count": len(segment),
+                        },
+                    )
+                    db.add(memory)
                 stored_count += 1
 
-        # 阶段 4：事实提取 — 从对话中提取结构化事实
-        try:
-            await self._extract_and_store_facts(
-                turns=turns,
-                user_id=session.user_id,
-                app_name=session.app_name,
-                thread_id=thread_id,
-            )
-        except Exception as exc:
-            logger.warning("fact_extraction_stage_failed", error=str(exc))
+            # 阶段 4：事实提取（同一事务内，失败仅回滚事实，不影响记忆）
+            try:
+                await self._extract_and_store_facts_in_session(
+                    db=db,
+                    turns=turns,
+                    user_id=session.user_id,
+                    app_name=session.app_name,
+                    thread_id=thread_id,
+                )
+            except Exception as exc:
+                logger.warning("fact_extraction_stage_failed", error=str(exc))
+
+            # 统一 commit — 全有或全无
+            await db.commit()
 
         logger.info(
             "consolidate_completed",
@@ -169,6 +197,129 @@ class PostgresMemoryService(BaseMemoryService):
     # ------------------------------------------------------------------
     # 巩固管线辅助方法
     # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _try_acquire_advisory_lock(db: Any, thread_id: uuid.UUID | None) -> bool:
+        """获取事务级 Advisory Lock 防止并发巩固
+
+        使用 pg_try_advisory_xact_lock，锁随事务结束自动释放。
+        """
+        if thread_id is None:
+            return True
+        lock_key = thread_id.int >> 64  # 取高 64 位转为 bigint
+        result = await db.execute(
+            text("SELECT pg_try_advisory_xact_lock(:lock_key)"),
+            {"lock_key": lock_key},
+        )
+        return bool(result.scalar())
+
+    async def _retry_embedding(self, content: str, segment_idx: int) -> list[float] | None:
+        """Embedding 指数退避重试（Circuit Breaker 模式<sup>[[44]](#ref44)</sup>）
+
+        最多重试 _EMBEDDING_MAX_RETRIES 次，指数等待（1s → 2s → 4s）。
+        最终失败返回 None，由调用方决定是否跳过该段。
+        """
+        if not self._embedding_fn:
+            return None
+        for attempt in range(_EMBEDDING_MAX_RETRIES):
+            try:
+                return await self._embedding_fn(content)
+            except Exception as exc:
+                wait = 2**attempt
+                logger.warning(
+                    "consolidate_embedding_retry",
+                    segment=segment_idx,
+                    attempt=attempt + 1,
+                    wait=wait,
+                    error=str(exc),
+                )
+                await asyncio.sleep(wait)
+        logger.error("consolidate_embedding_exhausted", segment=segment_idx)
+        return None
+
+    async def _is_duplicate_in_session(
+        self,
+        *,
+        db: Any,
+        user_id: str,
+        app_name: str,
+        embedding: list[float],
+        content: str = "",
+    ) -> bool:
+        """事务内去重检测（Orient 阶段）
+
+        与 _is_duplicate 逻辑相同，但复用外部 session 以在同一事务内执行。
+        """
+        distance = Memory.embedding.op("<=>")(embedding)
+        stmt = (
+            select(Memory.id, Memory.content, distance.label("dist"))
+            .where(
+                Memory.user_id == user_id,
+                Memory.app_name == app_name,
+                Memory.embedding.is_not(None),
+            )
+            .order_by(distance.asc())
+            .limit(1)
+        )
+        result = await db.execute(stmt)
+        row = result.first()
+        if row is None:
+            return False
+        similarity = 1.0 - float(row.dist)
+        if similarity >= _DEDUP_SIMILARITY_THRESHOLD:
+            return True
+        if similarity >= 0.80 and content and row.content:
+            words_new = set(content.lower().split())
+            words_old = set(row.content.lower().split())
+            if words_new and words_old:
+                jaccard = len(words_new & words_old) / len(words_new | words_old)
+                if jaccard >= _DEDUP_JACCARD_THRESHOLD:
+                    return True
+        return False
+
+    async def _extract_and_store_facts_in_session(
+        self,
+        *,
+        db: Any,
+        turns: list[dict[str, str]],
+        user_id: str,
+        app_name: str,
+        thread_id: uuid.UUID | None,
+    ) -> None:
+        """事务内事实提取与存储
+
+        与 _extract_and_store_facts 逻辑相同，但复用外部 session。
+        """
+        from negentropy.engine.factories.memory import get_fact_service
+
+        extracted = self._fact_extractor.extract(turns)
+        if not extracted:
+            return
+
+        fact_service = get_fact_service(embedding_fn=self._embedding_fn)
+        for fact in extracted:
+            try:
+                await fact_service.upsert_fact(
+                    user_id=user_id,
+                    app_name=app_name,
+                    fact_type=fact.fact_type,
+                    key=fact.key[:255],
+                    value={"text": fact.value},
+                    confidence=fact.confidence,
+                    thread_id=thread_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "fact_upsert_failed",
+                    key=fact.key[:50],
+                    error=str(exc),
+                )
+
+        logger.info(
+            "facts_extracted_and_stored",
+            user_id=user_id,
+            facts_count=len(extracted),
+        )
 
     async def _extract_and_store_facts(
         self,
@@ -322,18 +473,34 @@ class PostgresMemoryService(BaseMemoryService):
             return False
 
     @staticmethod
-    def _calculate_initial_retention(content: str) -> float:
-        """启发式计算新记忆的初始保留分数
+    def _calculate_initial_retention(
+        content: str,
+        memory_type: str = "episodic",
+        has_facts: bool = False,
+    ) -> float:
+        """多因子初始保留分数
 
-        信息密度因子：内容越长且含更多不同词，信息密度越高。
+        因子：
+        1. 信息密度（unique word ratio）
+        2. 内容长度（50 词基准）
+        3. 记忆类型乘子（偏好 > 流程 > 事实 > 情景）
+        4. 事实支撑加成（有提取事实的记忆更重要）
+
+        参考 ACT-R<sup>[[45]](#ref45)</sup> 基础激活水平与
+        FadeMem<sup>[[46]](#ref46)</sup> 多因子衰减。
         """
         words = content.split()
         if not words:
             return 0.5
-        unique_ratio = len(set(words)) / len(words) if words else 0
-        length_factor = min(1.0, len(words) / 50.0)  # 50 词为基准
+        unique_ratio = len(set(w.lower() for w in words)) / len(words)
+        length_factor = min(1.0, len(words) / 50.0)
         density_factor = 0.5 + 0.5 * unique_ratio
-        return min(1.0, _INITIAL_RETENTION_BASE * density_factor + length_factor * 0.2)
+        type_factor = _MEMORY_TYPE_MULTIPLIER.get(memory_type, 1.0)
+        fact_boost = 0.1 if has_facts else 0.0
+        raw_score = _INITIAL_RETENTION_BASE * density_factor + length_factor * 0.2
+        raw_score *= type_factor
+        raw_score += fact_boost
+        return min(1.0, raw_score)
 
     async def search_memory(
         self,
@@ -393,15 +560,12 @@ class PostgresMemoryService(BaseMemoryService):
                     offset=offset,
                 )
                 if result is not None:
-                    memories_data = result
+                    memories_data = self._tag_search_level(result, "hybrid", "combined")
                     await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
+                    self._log_search_event("hybrid", len(memories_data), user_id, app_name, query)
                     return self._build_search_response(memories_data)
             except Exception as exc:
-                logger.warning(
-                    "hybrid_search_native_failed",
-                    error=str(exc),
-                    fallback="vector_search",
-                )
+                self._log_fallback_event("hybrid", "vector", str(exc), user_id, app_name, query)
 
             # 策略 2: 回退到纯向量检索
             memories_data = await self._vector_search(
@@ -414,7 +578,12 @@ class PostgresMemoryService(BaseMemoryService):
                 date_from=date_from,
                 date_to=date_to,
             )
+            # Vector search: relevance_score = 1 - cosine_distance
+            for m in memories_data:
+                m["relevance_score"] = min(1.0, max(0.0, m.get("relevance_score", 0.0)))
+            memories_data = self._tag_search_level(memories_data, "vector", "cosine_distance")
             await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
+            self._log_search_event("vector", len(memories_data), user_id, app_name, query)
             return self._build_search_response(memories_data)
 
         # 策略 3: BM25 全文检索
@@ -427,14 +596,15 @@ class PostgresMemoryService(BaseMemoryService):
                 offset=offset,
             )
             if memories_data:
+                # BM25 ts_rank_cd 归一化到 [0, 1]
+                for m in memories_data:
+                    m["relevance_score"] = min(1.0, max(0.0, m.get("relevance_score", 0.0)))
+                memories_data = self._tag_search_level(memories_data, "keyword", "ts_rank")
                 await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
+                self._log_search_event("keyword", len(memories_data), user_id, app_name, query)
                 return self._build_search_response(memories_data)
         except Exception as exc:
-            logger.warning(
-                "keyword_search_failed",
-                error=str(exc),
-                fallback="ilike",
-            )
+            self._log_fallback_event("keyword", "ilike", str(exc), user_id, app_name, query)
 
         # 策略 4: ilike 回退
         memories_data = await self._ilike_search(
@@ -447,7 +617,9 @@ class PostgresMemoryService(BaseMemoryService):
             date_from=date_from,
             date_to=date_to,
         )
+        memories_data = self._tag_search_level(memories_data, "ilike", "retention_proxy")
         await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
+        self._log_search_event("ilike", len(memories_data), user_id, app_name, query)
         return self._build_search_response(memories_data)
 
     async def _hybrid_search_native(
@@ -652,6 +824,66 @@ class PostgresMemoryService(BaseMemoryService):
             for m in memories_orms
         ]
 
+    # ------------------------------------------------------------------
+    # 搜索可观测性辅助方法
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _tag_search_level(
+        results: list[dict[str, Any]],
+        level: str,
+        score_type: str,
+    ) -> list[dict[str, Any]]:
+        """为搜索结果标记 search_level 和 score_type 元数据
+
+        search_level: hybrid | vector | keyword | ilike
+        score_type: combined | cosine_distance | ts_rank | retention_proxy
+        raw_score: 保留原始分数用于下游比较
+        """
+        for r in results:
+            r["search_level"] = level
+            r["score_type"] = score_type
+            r["raw_score"] = r.get("relevance_score", 0.0)
+        return results
+
+    @staticmethod
+    def _log_search_event(
+        level: str,
+        result_count: int,
+        user_id: str,
+        app_name: str,
+        query: str,
+    ) -> None:
+        """搜索完成事件日志（用于检索质量可观测性）"""
+        logger.info(
+            "search_completed",
+            search_level=level,
+            result_count=result_count,
+            user_id=user_id,
+            app_name=app_name,
+            query_length=len(query),
+        )
+
+    @staticmethod
+    def _log_fallback_event(
+        from_level: str,
+        to_level: str,
+        error: str,
+        user_id: str,
+        app_name: str,
+        query: str,
+    ) -> None:
+        """搜索回退事件日志（用于监控回退频率）"""
+        logger.warning(
+            "search_fallback",
+            from_level=from_level,
+            to_level=to_level,
+            error=error[:200],
+            user_id=user_id,
+            app_name=app_name,
+            query_length=len(query),
+        )
+
     async def _record_access(
         self,
         memories_data: list[dict[str, Any]],
@@ -726,12 +958,18 @@ class PostgresMemoryService(BaseMemoryService):
             )
 
     def _build_search_response(self, memories_data: list[dict[str, Any]]) -> SearchMemoryResponse:
-        """构建 ADK SearchMemoryResponse"""
+        """构建 ADK SearchMemoryResponse（携带 search_level 元数据）"""
         memories = []
         for m in memories_data:
             content_val = {"parts": [{"text": m["content"]}]}
             created_at = m.get("created_at")
             timestamp = created_at.isoformat() if created_at else datetime.now(UTC).isoformat()
+
+            # 传播搜索质量元数据
+            metadata = dict(m.get("metadata", {}))
+            metadata["search_level"] = m.get("search_level", "unknown")
+            metadata["score_type"] = m.get("score_type", "unknown")
+            metadata["raw_score"] = m.get("raw_score", 0.0)
 
             memories.append(
                 MemoryEntry(
@@ -740,7 +978,7 @@ class PostgresMemoryService(BaseMemoryService):
                     author="system",
                     timestamp=timestamp,
                     relevance_score=m.get("relevance_score", 0.0),
-                    custom_metadata=m.get("metadata", {}),
+                    custom_metadata=metadata,
                 )
             )
 

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -200,6 +200,11 @@ class PostgresMemoryService(BaseMemoryService):
         high64 = thread_id.int >> 64
         key1 = (high64 >> 32) & 0xFFFFFFFF
         key2 = high64 & 0xFFFFFFFF
+        # int4 是有符号 32 位，需将无符号值转换为 [-2^31, 2^31-1]
+        if key1 >= 0x80000000:
+            key1 -= 0x100000000
+        if key2 >= 0x80000000:
+            key2 -= 0x100000000
         result = await db.execute(
             text("SELECT pg_try_advisory_xact_lock(:key1, :key2)"),
             {"key1": key1, "key2": key2},

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -227,15 +227,16 @@ class PostgresMemoryService(BaseMemoryService):
             try:
                 return await self._embedding_fn(content)
             except Exception as exc:
-                wait = 2**attempt
-                logger.warning(
-                    "consolidate_embedding_retry",
-                    segment=segment_idx,
-                    attempt=attempt + 1,
-                    wait=wait,
-                    error=str(exc),
-                )
-                await asyncio.sleep(wait)
+                if attempt < _EMBEDDING_MAX_RETRIES - 1:
+                    wait = 2**attempt
+                    logger.warning(
+                        "consolidate_embedding_retry",
+                        segment=segment_idx,
+                        attempt=attempt + 1,
+                        wait=wait,
+                        error=str(exc),
+                    )
+                    await asyncio.sleep(wait)
         logger.error("consolidate_embedding_exhausted", segment=segment_idx)
         return None
 
@@ -497,6 +498,8 @@ class PostgresMemoryService(BaseMemoryService):
                 )
                 if result is not None:
                     memories_data = self._tag_search_level(result, "hybrid", "combined")
+                    for m in memories_data:
+                        m["relevance_score"] = min(1.0, max(0.0, m.get("relevance_score", 0.0)))
                     await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
                     self._log_search_event("hybrid", len(memories_data), user_id, app_name, query)
                     return self._build_search_response(memories_data)

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -191,14 +191,18 @@ class PostgresMemoryService(BaseMemoryService):
     async def _try_acquire_advisory_lock(db: Any, thread_id: uuid.UUID | None) -> bool:
         """获取事务级 Advisory Lock 防止并发巩固
 
-        使用 pg_try_advisory_xact_lock，锁随事务结束自动释放。
+        使用 pg_try_advisory_xact_lock(int4, int4) 双参数形式，
+        将 UUID 高 64 位拆为两个 32 位整数，避免超出 int64 范围。
+        锁随事务结束自动释放。
         """
         if thread_id is None:
             return True
-        lock_key = thread_id.int >> 64  # 取高 64 位转为 bigint
+        high64 = thread_id.int >> 64
+        key1 = (high64 >> 32) & 0xFFFFFFFF
+        key2 = high64 & 0xFFFFFFFF
         result = await db.execute(
-            text("SELECT pg_try_advisory_xact_lock(:lock_key)"),
-            {"lock_key": lock_key},
+            text("SELECT pg_try_advisory_xact_lock(:key1, :key2)"),
+            {"key1": key1, "key2": key2},
         )
         return bool(result.scalar())
 

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -514,10 +514,10 @@ class PostgresMemoryService(BaseMemoryService):
                 date_from=date_from,
                 date_to=date_to,
             )
-            # Vector search: relevance_score = 1 - cosine_distance
+            # 先标记 raw_score（保留原始分数），再 clamp 到 [0, 1]
+            memories_data = self._tag_search_level(memories_data, "vector", "cosine_distance")
             for m in memories_data:
                 m["relevance_score"] = min(1.0, max(0.0, m.get("relevance_score", 0.0)))
-            memories_data = self._tag_search_level(memories_data, "vector", "cosine_distance")
             await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
             self._log_search_event("vector", len(memories_data), user_id, app_name, query)
             return self._build_search_response(memories_data)
@@ -532,10 +532,10 @@ class PostgresMemoryService(BaseMemoryService):
                 offset=offset,
             )
             if memories_data:
-                # BM25 ts_rank_cd 归一化到 [0, 1]
+                # 先标记 raw_score（保留原始 ts_rank），再 clamp 到 [0, 1]
+                memories_data = self._tag_search_level(memories_data, "keyword", "ts_rank")
                 for m in memories_data:
                     m["relevance_score"] = min(1.0, max(0.0, m.get("relevance_score", 0.0)))
-                memories_data = self._tag_search_level(memories_data, "keyword", "ts_rank")
                 await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
                 self._log_search_event("keyword", len(memories_data), user_id, app_name, query)
                 return self._build_search_response(memories_data)
@@ -902,7 +902,7 @@ class PostgresMemoryService(BaseMemoryService):
             timestamp = created_at.isoformat() if created_at else datetime.now(UTC).isoformat()
 
             # 传播搜索质量元数据
-            metadata = dict(m.get("metadata", {}))
+            metadata = dict(m.get("metadata") or {})
             metadata["search_level"] = m.get("search_level", "unknown")
             metadata["score_type"] = m.get("score_type", "unknown")
             metadata["raw_score"] = m.get("raw_score", 0.0)

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -36,6 +36,9 @@ from sqlalchemy import select, text, update
 # ORM 模型与会话工厂
 import negentropy.db.session as db_session
 from negentropy.engine.consolidation.llm_fact_extractor import LLMFactExtractor
+from negentropy.engine.governance.memory import (
+    _MEMORY_TYPE_MULTIPLIER,
+)
 from negentropy.logging import get_logger
 from negentropy.models.base import NEGENTROPY_SCHEMA
 from negentropy.models.internalization import Memory
@@ -53,20 +56,6 @@ _DEDUP_SIMILARITY_THRESHOLD = 0.85  # cosine similarity 去重阈值（对齐 He
 _DEDUP_JACCARD_THRESHOLD = 0.7  # Jaccard 词重叠二次校验阈值（对齐 Broder MinHash<sup>[[37]](#ref37)</sup>）
 _INITIAL_RETENTION_BASE = 0.8  # 新记忆初始保留分数基准
 _EMBEDDING_MAX_RETRIES = 3  # Embedding 指数退避最大重试次数<sup>[[44]](#ref44)</sup>
-
-# 记忆类型衰减率映射（ACT-R 认知架构<sup>[[45]](#ref45)</sup> + FadeMem<sup>[[46]](#ref46)</sup>）
-_MEMORY_TYPE_DECAY_RATES: dict[str, float] = {
-    "preference": 0.05,  # 用户偏好长期保持
-    "procedural": 0.06,  # 技能/流程较稳定
-    "fact": 0.08,  # 事实中等衰减
-    "episodic": 0.10,  # 对话片段衰减最快（基准）
-}
-_MEMORY_TYPE_MULTIPLIER: dict[str, float] = {
-    "preference": 1.2,
-    "procedural": 1.15,
-    "fact": 1.1,
-    "episodic": 1.0,
-}
 
 
 class PostgresMemoryService(BaseMemoryService):
@@ -139,7 +128,7 @@ class PostgresMemoryService(BaseMemoryService):
                     logger.warning("consolidate_embedding_skipped", segment=seg_idx)
                     continue
 
-                if embedding is not None and await self._is_duplicate_in_session(
+                if embedding is not None and await self._is_duplicate(
                     db=db,
                     user_id=session.user_id,
                     app_name=session.app_name,
@@ -173,7 +162,7 @@ class PostgresMemoryService(BaseMemoryService):
 
             # 阶段 4：事实提取（同一事务内，失败仅回滚事实，不影响记忆）
             try:
-                await self._extract_and_store_facts_in_session(
+                await self._extract_and_store_facts(
                     db=db,
                     turns=turns,
                     user_id=session.user_id,
@@ -237,58 +226,22 @@ class PostgresMemoryService(BaseMemoryService):
         logger.error("consolidate_embedding_exhausted", segment=segment_idx)
         return None
 
-    async def _is_duplicate_in_session(
+    async def _extract_and_store_facts(
         self,
         *,
-        db: Any,
-        user_id: str,
-        app_name: str,
-        embedding: list[float],
-        content: str = "",
-    ) -> bool:
-        """事务内去重检测（Orient 阶段）
-
-        与 _is_duplicate 逻辑相同，但复用外部 session 以在同一事务内执行。
-        """
-        distance = Memory.embedding.op("<=>")(embedding)
-        stmt = (
-            select(Memory.id, Memory.content, distance.label("dist"))
-            .where(
-                Memory.user_id == user_id,
-                Memory.app_name == app_name,
-                Memory.embedding.is_not(None),
-            )
-            .order_by(distance.asc())
-            .limit(1)
-        )
-        result = await db.execute(stmt)
-        row = result.first()
-        if row is None:
-            return False
-        similarity = 1.0 - float(row.dist)
-        if similarity >= _DEDUP_SIMILARITY_THRESHOLD:
-            return True
-        if similarity >= 0.80 and content and row.content:
-            words_new = set(content.lower().split())
-            words_old = set(row.content.lower().split())
-            if words_new and words_old:
-                jaccard = len(words_new & words_old) / len(words_new | words_old)
-                if jaccard >= _DEDUP_JACCARD_THRESHOLD:
-                    return True
-        return False
-
-    async def _extract_and_store_facts_in_session(
-        self,
-        *,
-        db: Any,
+        db: Any | None = None,
         turns: list[dict[str, str]],
         user_id: str,
         app_name: str,
         thread_id: uuid.UUID | None,
     ) -> None:
-        """事务内事实提取与存储
+        """从对话轮次中提取结构化事实并存储
 
-        与 _extract_and_store_facts 逻辑相同，但复用外部 session。
+        使用 PatternFactExtractor 做模式匹配提取，
+        通过 FactService.upsert_fact 存储（利用唯一约束做 upsert）。
+
+        Args:
+            db: 外部 session（复用事务），None 时自行创建。
         """
         from negentropy.engine.factories.memory import get_fact_service
 
@@ -304,50 +257,6 @@ class PostgresMemoryService(BaseMemoryService):
                     app_name=app_name,
                     fact_type=fact.fact_type,
                     key=fact.key[:255],
-                    value={"text": fact.value},
-                    confidence=fact.confidence,
-                    thread_id=thread_id,
-                )
-            except Exception as exc:
-                logger.warning(
-                    "fact_upsert_failed",
-                    key=fact.key[:50],
-                    error=str(exc),
-                )
-
-        logger.info(
-            "facts_extracted_and_stored",
-            user_id=user_id,
-            facts_count=len(extracted),
-        )
-
-    async def _extract_and_store_facts(
-        self,
-        *,
-        turns: list[dict[str, str]],
-        user_id: str,
-        app_name: str,
-        thread_id: uuid.UUID | None,
-    ) -> None:
-        """从对话轮次中提取结构化事实并存储
-
-        使用 PatternFactExtractor 做模式匹配提取，
-        通过 FactService.upsert_fact 存储（利用唯一约束做 upsert）。
-        """
-        from negentropy.engine.factories.memory import get_fact_service
-
-        extracted = self._fact_extractor.extract(turns)
-        if not extracted:
-            return
-
-        fact_service = get_fact_service(embedding_fn=self._embedding_fn)
-        for fact in extracted:
-            try:
-                await fact_service.upsert_fact(
-                    user_id=user_id,
-                    app_name=app_name,
-                    fact_type=fact.fact_type,
-                    key=fact.key[:255],  # 遵守 VARCHAR(255) 约束
                     value={"text": fact.value},
                     confidence=fact.confidence,
                     thread_id=thread_id,
@@ -432,6 +341,7 @@ class PostgresMemoryService(BaseMemoryService):
     async def _is_duplicate(
         self,
         *,
+        db: Any | None = None,
         user_id: str,
         app_name: str,
         embedding: list[float],
@@ -442,35 +352,50 @@ class PostgresMemoryService(BaseMemoryService):
         两阶段去重策略<sup>[[40]](#ref40)</sup>：
         1. Cosine similarity ≥ 0.85 → 直接判定为重复
         2. Cosine similarity ∈ [0.80, 0.85) → Jaccard 词重叠二次校验<sup>[[37]](#ref37)</sup>
+
+        Args:
+            db: 外部 session（复用事务），None 时自行创建。
         """
+        if db is not None:
+            return await self._check_duplicate(db, user_id, app_name, embedding, content)
+
         async with db_session.AsyncSessionLocal() as db:
-            distance = Memory.embedding.op("<=>")(embedding)
-            stmt = (
-                select(Memory.id, Memory.content, distance.label("dist"))
-                .where(
-                    Memory.user_id == user_id,
-                    Memory.app_name == app_name,
-                    Memory.embedding.is_not(None),
-                )
-                .order_by(distance.asc())
-                .limit(1)
+            return await self._check_duplicate(db, user_id, app_name, embedding, content)
+
+    async def _check_duplicate(
+        self,
+        db: Any,
+        user_id: str,
+        app_name: str,
+        embedding: list[float],
+        content: str,
+    ) -> bool:
+        distance = Memory.embedding.op("<=>")(embedding)
+        stmt = (
+            select(Memory.id, Memory.content, distance.label("dist"))
+            .where(
+                Memory.user_id == user_id,
+                Memory.app_name == app_name,
+                Memory.embedding.is_not(None),
             )
-            result = await db.execute(stmt)
-            row = result.first()
-            if row is None:
-                return False
-            similarity = 1.0 - float(row.dist)
-            if similarity >= _DEDUP_SIMILARITY_THRESHOLD:
-                return True
-            # 二次校验：embedding 高度相似但未达阈值时，用 Jaccard 词重叠确认
-            if similarity >= 0.80 and content and row.content:
-                words_new = set(content.lower().split())
-                words_old = set(row.content.lower().split())
-                if words_new and words_old:
-                    jaccard = len(words_new & words_old) / len(words_new | words_old)
-                    if jaccard >= _DEDUP_JACCARD_THRESHOLD:
-                        return True
+            .order_by(distance.asc())
+            .limit(1)
+        )
+        result = await db.execute(stmt)
+        row = result.first()
+        if row is None:
             return False
+        similarity = 1.0 - float(row.dist)
+        if similarity >= _DEDUP_SIMILARITY_THRESHOLD:
+            return True
+        if similarity >= 0.80 and content and row.content:
+            words_new = set(content.lower().split())
+            words_old = set(row.content.lower().split())
+            if words_new and words_old:
+                jaccard = len(words_new & words_old) / len(words_new | words_old)
+                if jaccard >= _DEDUP_JACCARD_THRESHOLD:
+                    return True
+        return False
 
     @staticmethod
     def _calculate_initial_retention(

--- a/apps/negentropy/src/negentropy/engine/governance/memory.py
+++ b/apps/negentropy/src/negentropy/engine/governance/memory.py
@@ -284,7 +284,7 @@ class MemoryGovernanceService:
         last_accessed_at: datetime,
         created_at: datetime,
         memory_type: str = "episodic",
-        related_count: int = 0,
+        related_count: int | None = None,
         lambda_: float | None = None,
     ) -> float:
         """多因子自适应保留评分
@@ -312,7 +312,7 @@ class MemoryGovernanceService:
             last_accessed_at: 最后访问时间
             created_at: 创建时间
             memory_type: 记忆类型（影响衰减率）
-            related_count: 关联记忆/事实数量（语义重要性）
+            related_count: 关联记忆/事实数量（None 时自动查询 DB）
             lambda_: 自定义衰减常数（覆盖类型默认值）
 
         Returns:
@@ -334,7 +334,10 @@ class MemoryGovernanceService:
         type_multiplier = _MEMORY_TYPE_MULTIPLIER.get(memory_type, 1.0)
 
         # Factor 4: 语义重要性（网络效应 — 关联越多越重要）
-        semantic_importance = 1.0 + min(0.5, related_count * 0.1)
+        effective_related_count = (
+            related_count if related_count is not None else await self._get_related_count(memory_id)
+        )
+        semantic_importance = 1.0 + min(0.5, effective_related_count * 0.1)
 
         # Factor 5: 时效性加成（1 年内创建的记忆获得额外加分）
         days_since_creation = max(0, (now - created_at).total_seconds() / 86400)

--- a/apps/negentropy/src/negentropy/engine/governance/memory.py
+++ b/apps/negentropy/src/negentropy/engine/governance/memory.py
@@ -33,6 +33,22 @@ from negentropy.models.internalization import Fact, Memory, MemoryAuditLog
 
 logger = get_logger("negentropy.engine.governance.memory")
 
+# 记忆类型衰减率映射（ACT-R<sup>[[45]](#ref45)</sup> + FadeMem<sup>[[46]](#ref46)</sup>）
+_MEMORY_TYPE_DECAY_RATES: dict[str, float] = {
+    "preference": 0.05,
+    "procedural": 0.06,
+    "fact": 0.08,
+    "episodic": 0.10,
+}
+_DEFAULT_DECAY_RATE = 0.10
+
+_MEMORY_TYPE_MULTIPLIER: dict[str, float] = {
+    "preference": 1.3,
+    "procedural": 1.2,
+    "fact": 1.15,
+    "episodic": 1.0,
+}
+
 
 @dataclass(frozen=True)
 class AuditRecord:
@@ -267,46 +283,65 @@ class MemoryGovernanceService:
         access_count: int,
         last_accessed_at: datetime,
         created_at: datetime,
-        lambda_: float = 0.1,
+        memory_type: str = "episodic",
+        related_count: int = 0,
+        lambda_: float | None = None,
     ) -> float:
-        """计算记忆保留分数
+        """多因子自适应保留评分
 
-        基于艾宾浩斯遗忘曲线的指数衰减模型计算记忆的保留分数。
-        分数越高表示记忆越重要，应该保留。
+        五因子公式:
+            retention = min(1.0, time_decay × frequency_boost × type_multiplier
+                            × semantic_importance / 5.0 + recency_bonus)
 
-        公式:
-            retention_score = min(1.0, time_decay × frequency_boost / 5.0)
-            time_decay = e^(-λ × days_elapsed)
-            frequency_boost = 1 + ln(1 + access_count)
-
-        其中 λ 是衰减常数（默认 0.1），days_elapsed 是距最后访问的天数。
-        频率因子使用对数增长，避免高频访问过度膨胀分数。
+        因子：
+        1. 时间衰减（Ebbinghaus 指数衰减 + 类型特定 λ）
+        2. 频率增强（对数饱和）
+        3. 类型乘子（偏好 > 流程 > 事实 > 情景）
+        4. 语义重要性（关联记忆/事实数量加成）
+        5. 时效性加成（近期创建的记忆额外加分）
 
         参考文献:
-        [1] A. Ebbinghaus, "Memory: A Contribution to Experimental Psychology,"
-            1885. (艾宾浩斯遗忘曲线)
+        [1] Ebbinghaus, "Memory," 1885.
+        [2] Anderson et al., "An Integrated Theory of the Mind,"
+            *Psychological Review*, vol. 111, no. 4, pp. 1036-1060, 2004.
+        [3] FadeMem, arXiv:2601.18642, 2026.
 
         Args:
             memory_id: 记忆 ID
             access_count: 访问次数
             last_accessed_at: 最后访问时间
             created_at: 创建时间
-            lambda_: 衰减常数 (默认 0.1，越大衰减越快)
+            memory_type: 记忆类型（影响衰减率）
+            related_count: 关联记忆/事实数量（语义重要性）
+            lambda_: 自定义衰减常数（覆盖类型默认值）
 
         Returns:
             保留分数 (0.0 - 1.0)
         """
         now = datetime.now()
+
+        # Factor 1: 时间衰减（类型特定 λ）
         days_since_access = max(0, (now - last_accessed_at).total_seconds() / 86400)
+        effective_lambda = (
+            lambda_ if lambda_ is not None else _MEMORY_TYPE_DECAY_RATES.get(memory_type, _DEFAULT_DECAY_RATE)
+        )
+        time_decay = math.exp(-effective_lambda * days_since_access)
 
-        # 指数衰减: R(t) = e^(-λ × t)
-        time_decay = math.exp(-lambda_ * days_since_access)
-
-        # 频率增强: frequency_boost = 1 + ln(1 + access_count)
+        # Factor 2: 频率增强（对数饱和）
         frequency_boost = 1.0 + math.log(1.0 + access_count)
 
-        # 综合保留分数（归一化到 [0, 1]）
-        retention_score = min(1.0, time_decay * frequency_boost / 5.0)
+        # Factor 3: 类型乘子
+        type_multiplier = _MEMORY_TYPE_MULTIPLIER.get(memory_type, 1.0)
+
+        # Factor 4: 语义重要性（网络效应 — 关联越多越重要）
+        semantic_importance = 1.0 + min(0.5, related_count * 0.1)
+
+        # Factor 5: 时效性加成（1 年内创建的记忆获得额外加分）
+        days_since_creation = max(0, (now - created_at).total_seconds() / 86400)
+        recency_bonus = max(0, 1.0 - days_since_creation / 365.0) * 0.1
+
+        # 综合评分
+        retention_score = time_decay * frequency_boost * type_multiplier * semantic_importance / 5.0 + recency_bonus
 
         logger.debug(
             "calculate_retention_score",
@@ -314,9 +349,11 @@ class MemoryGovernanceService:
             retention_score=retention_score,
             time_decay=time_decay,
             frequency_boost=frequency_boost,
-            access_count=access_count,
-            days_since_access=days_since_access,
-            lambda_=lambda_,
+            type_multiplier=type_multiplier,
+            semantic_importance=semantic_importance,
+            recency_bonus=recency_bonus,
+            memory_type=memory_type,
+            effective_lambda=effective_lambda,
         )
 
         return max(0.0, min(1.0, retention_score))
@@ -337,6 +374,33 @@ class MemoryGovernanceService:
                 raise ValueError(
                     f"Invalid decision '{decision}' for memory '{memory_id}'. Must be one of {valid_actions}"
                 )
+
+    async def _get_related_count(self, memory_id: str) -> int:
+        """查询记忆的关联数量（同 thread 的事实 + 其他记忆）
+
+        用于多因子评分的语义重要性因子。
+        """
+        async with self._session_factory() as db:
+            memory_stmt = select(Memory.thread_id).where(Memory.id == memory_id)
+            result = await db.execute(memory_stmt)
+            thread_id = result.scalar_one_or_none()
+            if thread_id is None:
+                return 0
+
+            fact_count_stmt = select(func.count()).select_from(Fact).where(Fact.thread_id == thread_id)
+            fact_count = (await db.execute(fact_count_stmt)).scalar() or 0
+
+            mem_count_stmt = (
+                select(func.count())
+                .select_from(Memory)
+                .where(
+                    Memory.thread_id == thread_id,
+                    Memory.id != memory_id,
+                )
+            )
+            mem_count = (await db.execute(mem_count_stmt)).scalar() or 0
+
+            return fact_count + mem_count
 
     async def _get_current_version(
         self,

--- a/apps/negentropy/tests/unit_tests/engine/test_memory_governance.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_memory_governance.py
@@ -13,12 +13,10 @@ import pytest
 
 
 class TestRetentionScoreCalculation:
-    """遗忘曲线公式单元测试
+    """多因子遗忘曲线公式单元测试
 
-    验证指数衰减模型:
-        retention_score = min(1.0, time_decay × frequency_boost / 5.0)
-        time_decay = e^(-λ × days_elapsed)
-        frequency_boost = 1 + ln(1 + access_count)
+    验证五因子自适应模型:
+        retention = min(1.0, time_decay × frequency_boost × type_multiplier × semantic_importance / 5.0 + recency_bonus)
     """
 
     @pytest.fixture
@@ -39,9 +37,9 @@ class TestRetentionScoreCalculation:
             last_accessed_at=now,
             created_at=now,
         )
-        # 新记忆: time_decay ≈ 1.0, frequency_boost = 1 + ln(1) = 1.0
-        # retention = min(1.0, 1.0 * 1.0 / 5.0) = 0.2
-        assert 0.15 <= score <= 0.25
+        # 新记忆: time_decay=1.0, frequency_boost=1.0, type=1.0, semantic=1.0
+        # retention = 1.0 * 1.0 * 1.0 * 1.0 / 5.0 + 0.1(recency) = 0.3
+        assert 0.25 <= score <= 0.35
 
     @pytest.mark.asyncio
     async def test_frequently_accessed_memory(self, governance_service):
@@ -54,8 +52,8 @@ class TestRetentionScoreCalculation:
             created_at=now - timedelta(days=30),
         )
         # access_count=100: frequency_boost = 1 + ln(101) ≈ 5.62
-        # time_decay ≈ 1.0 (just accessed)
-        # retention = min(1.0, 1.0 * 5.62 / 5.0) = 1.0
+        # time_decay ≈ 1.0, recency_bonus ≈ 0.092
+        # retention = min(1.0, 1.0 * 5.62 * 1.0 * 1.0 / 5.0 + 0.092) = 1.0
         assert score >= 0.9
 
     @pytest.mark.asyncio
@@ -68,14 +66,13 @@ class TestRetentionScoreCalculation:
             last_accessed_at=now - timedelta(days=30),
             created_at=now - timedelta(days=30),
         )
-        # 30 days without access: time_decay = e^(-0.1 * 30) ≈ 0.05
-        # frequency_boost = 1.0
-        # retention = min(1.0, 0.05 * 1.0 / 5.0) ≈ 0.01
-        assert score < 0.1
+        # 30 days: time_decay = e^(-0.1*30) ≈ 0.05, recency_bonus ≈ 0
+        # retention ≈ 0.05 * 1.0 / 5.0 ≈ 0.01
+        assert score < 0.15
 
     @pytest.mark.asyncio
     async def test_exponential_decay_formula(self, governance_service):
-        """验证指数衰减公式的正确性"""
+        """验证指数衰减公式的正确性（含 recency_bonus）"""
         now = datetime.now()
         lambda_ = 0.1
 
@@ -88,7 +85,8 @@ class TestRetentionScoreCalculation:
                 lambda_=lambda_,
             )
             expected_decay = math.exp(-lambda_ * days)
-            expected_score = min(1.0, expected_decay * 1.0 / 5.0)
+            recency_bonus = max(0, 1.0 - days / 365.0) * 0.1
+            expected_score = min(1.0, expected_decay * 1.0 / 5.0 + recency_bonus)
             assert abs(score - expected_score) < 0.01, f"Day {days}: expected {expected_score:.4f}, got {score:.4f}"
 
     @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/engine/test_memory_governance.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_memory_governance.py
@@ -36,6 +36,7 @@ class TestRetentionScoreCalculation:
             access_count=0,
             last_accessed_at=now,
             created_at=now,
+            related_count=0,
         )
         # 新记忆: time_decay=1.0, frequency_boost=1.0, type=1.0, semantic=1.0
         # retention = 1.0 * 1.0 * 1.0 * 1.0 / 5.0 + 0.1(recency) = 0.3
@@ -50,6 +51,7 @@ class TestRetentionScoreCalculation:
             access_count=100,
             last_accessed_at=now,
             created_at=now - timedelta(days=30),
+            related_count=0,
         )
         # access_count=100: frequency_boost = 1 + ln(101) ≈ 5.62
         # time_decay ≈ 1.0, recency_bonus ≈ 0.092
@@ -65,6 +67,7 @@ class TestRetentionScoreCalculation:
             access_count=0,
             last_accessed_at=now - timedelta(days=30),
             created_at=now - timedelta(days=30),
+            related_count=0,
         )
         # 30 days: time_decay = e^(-0.1*30) ≈ 0.05, recency_bonus ≈ 0
         # retention ≈ 0.05 * 1.0 / 5.0 ≈ 0.01
@@ -83,6 +86,7 @@ class TestRetentionScoreCalculation:
                 last_accessed_at=now - timedelta(days=days),
                 created_at=now - timedelta(days=days),
                 lambda_=lambda_,
+                related_count=0,
             )
             expected_decay = math.exp(-lambda_ * days)
             recency_bonus = max(0, 1.0 - days / 365.0) * 0.1
@@ -100,6 +104,7 @@ class TestRetentionScoreCalculation:
             access_count=0,
             last_accessed_at=now - timedelta(days=3650),
             created_at=now - timedelta(days=3650),
+            related_count=0,
         )
         assert 0.0 <= score_low <= 1.0
 
@@ -109,6 +114,7 @@ class TestRetentionScoreCalculation:
             access_count=1000000,
             last_accessed_at=now,
             created_at=now,
+            related_count=0,
         )
         assert 0.0 <= score_high <= 1.0
 
@@ -124,6 +130,7 @@ class TestRetentionScoreCalculation:
             last_accessed_at=last_access,
             created_at=last_access,
             lambda_=0.01,  # 慢衰减
+            related_count=0,
         )
 
         score_fast = await governance_service.calculate_retention_score(
@@ -132,6 +139,7 @@ class TestRetentionScoreCalculation:
             last_accessed_at=last_access,
             created_at=last_access,
             lambda_=1.0,  # 快衰减
+            related_count=0,
         )
 
         assert score_slow > score_fast

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -566,21 +566,35 @@ WHERE updated_at > NOW() - p_interval
 
 记忆不是静态存储，而是一个持续演化的动态系统<sup>[[3]](#ref3)</sup>。MAGMA 架构<sup>[[8]](#ref8)</sup>提出了双流记忆演化（延迟敏感的事件摄入 + 异步结构巩固）的理念。Negentropy 当前以艾宾浩斯遗忘曲线为核心驱动记忆演化。
 
-### 5.1 艾宾浩斯遗忘曲线模型
+### 5.1 多因子自适应遗忘曲线模型
 
-基于 Ebbinghaus 遗忘曲线<sup>[[2]](#ref2)</sup>的指数衰减模型：
+基于 Ebbinghaus 遗忘曲线<sup>[[2]](#ref2)</sup>的指数衰减，扩展为 **五因子自适应模型**（ACT-R 认知架构<sup>[[45]](#ref45)</sup> + FadeMem<sup>[[46]](#ref46)</sup>）：
 
 ```
-retention_score = min(1.0, time_decay × frequency_boost / 5.0)
+retention = min(1.0, time_decay × frequency_boost × type_multiplier × semantic_importance / 5.0 + recency_bonus)
 
 其中:
-  time_decay    = e^(-λ × days_elapsed)
-  frequency_boost = 1 + ln(1 + access_count)
+  time_decay         = e^(-λ_type × days_elapsed)
+  frequency_boost    = 1 + ln(1 + access_count)
+  type_multiplier    = 记忆类型乘子（偏好 1.3 / 流程 1.2 / 事实 1.15 / 情景 1.0）
+  semantic_importance = 1 + min(0.5, related_count × 0.1)
+  recency_bonus      = max(0, 1 - days_since_creation / 365) × 0.1
 ```
 
-- **λ（衰减常数）**：默认 `0.1`，可通过 Automation Config 自定义。值越大衰减越快
+**记忆类型衰减率映射**：
+
+| 类型 | λ | 类型乘子 | 理由 |
+| :-- | :-- | :-- | :-- |
+| preference | 0.05 | 1.3 | 用户偏好应长期保持 |
+| procedural | 0.06 | 1.2 | 技能/流程较稳定 |
+| fact | 0.08 | 1.15 | 事实中等衰减 |
+| episodic | 0.10 | 1.0 | 对话片段衰减最快（基准） |
+
+- **λ_type**：记忆类型特定的衰减常数，覆盖默认 `0.1`
 - **days_elapsed**：距最后访问的天数（`last_accessed_at`）
 - **access_count**：累计访问次数。频率因子使用**对数增长**，避免高频访问过度膨胀分数
+- **related_count**：同 thread 关联的事实和记忆数量（语义重要性）
+- **recency_bonus**：1 年内创建的记忆获得额外 [0, 0.1] 加分
 - **分数范围**：[0.0, 1.0]
 
 **典型衰减曲线**（λ=0.1, access_count=0）：
@@ -594,7 +608,8 @@ retention_score = min(1.0, time_decay × frequency_boost / 5.0)
 
 **代码实现**：
 
-- Python：`MemoryGovernanceService.calculate_retention_score()` — [`engine/governance/memory.py`](../apps/negentropy/src/negentropy/engine/governance/memory.py) L264-L323
+- Python：`MemoryGovernanceService.calculate_retention_score()` — [`engine/governance/memory.py`](../apps/negentropy/src/negentropy/engine/governance/memory.py)
+- Python：`PostgresMemoryService._calculate_initial_retention()` — [`engine/adapters/postgres/memory_service.py`](../apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py)
 - SQL：`calculate_retention_score()` plpgsql 函数 — [`schema/hippocampus_schema.sql`](./schema/hippocampus_schema.sql) §5
 
 ### 5.2 访问计数强化 (Retrieval-Enhanced Retention)
@@ -695,14 +710,19 @@ flowchart TD
     Q["search_memory(query)"] --> EMB{有 embedding_fn？}
 
     EMB -->|是| HYB["Level 1: Hybrid Search<br/>DB 原生 hybrid_search() 函数<br/>semantic_weight=0.7 + keyword_weight=0.3"]
-    HYB -->|成功| REC["记录访问 → 返回结果"]
+    HYB -->|成功| TAG["标记 search_level=hybrid<br/>score_type=combined"]
     HYB -->|失败/降级| VEC["Level 2: Vector Search<br/>embedding <=> query_embedding<br/>pgvector cosine distance"]
-    VEC --> REC
+    VEC --> TAG2["标记 search_level=vector<br/>score_type=cosine_distance"]
 
     EMB -->|否| BM25["Level 3: BM25 Keyword Search<br/>search_vector @@ plainto_tsquery<br/>ts_rank_cd 排序"]
-    BM25 -->|成功| REC
+    BM25 -->|成功| TAG3["标记 search_level=keyword<br/>score_type=ts_rank"]
     BM25 -->|失败/无 search_vector| ILK["Level 4: ilike Fallback<br/>content ILIKE '%escaped_query%'<br/>通配符转义防注入"]
-    ILK --> REC
+    ILK --> TAG4["标记 search_level=ilike<br/>score_type=retention_proxy"]
+
+    TAG --> REC["记录访问 → 返回结果"]
+    TAG2 --> REC
+    TAG3 --> REC
+    TAG4 --> REC
 
     classDef query fill:#8B5CF6,stroke:#4C1D95,color:#FFF
     classDef level1 fill:#10B981,stroke:#065F46,color:#FFF
@@ -748,6 +768,10 @@ FROM {NEGENTROPY_SCHEMA}.hybrid_search(
 | System | 20% (保留) | — | 系统指令保留空间 |
 
 **Token 估算**：采用 tiktoken BPE 编码器精确计数（Phase 1 曾使用 `LENGTH(content) / 4` 粗略估算）。Python 侧通过 [`TokenCounter`](../apps/negentropy/src/negentropy/engine/utils/token_counter.py) 工具类调用，SQL 函数 `get_context_window()` 保留 `LENGTH/4` 作为 DB 侧快速估算，Python 端后校正。参考文献 <sup>[[25]](#ref25)</sup>。
+
+**Token Budget 硬性校验**（Phase 2++ 增强）：组装完成后校验 `token_count <= budget_total`（memory_ratio + history_ratio）。超标时按行截断（优先保留先召回的高相关性内容），并输出 `context_budget_overflow` 结构化日志。参考 MemGPT<sup>[[7]](#ref7)</sup> Virtual Context Management 的分页截断策略。
+
+**搜索结果标准化**（Phase 2++ 增强）：每条搜索结果携带 `search_level` (hybrid|vector|keyword|ilike)、`score_type` (combined|cosine_distance|ts_rank|retention_proxy) 和 `raw_score` 元数据，通过 `custom_metadata` 传播至 ADK `MemoryEntry`。参考 Observability Engineering<sup>[[48]](#ref48)</sup> 的结构化可观测性理念。
 
 ### 6.4 与学术检索范式的对标
 
@@ -1664,6 +1688,18 @@ uv run pytest tests/unit_tests/engine/test_memory_automation_service.py -v
 <a id="ref27"></a>[27] J. J. Rocchio, "Relevance feedback in information retrieval," in *The SMART Retrieval System*, G. Salton, Ed. Englewood Cliffs, NJ: Prentice-Hall, 1971, pp. 313-323.
 
 <a id="ref28"></a>[28] C. J. C. Burges et al., "Learning to rank using gradient descent," *ICML*, 2005.
+
+### Phase 2++ 增强参考文献
+
+<a id="ref44"></a>[44] T. Haerder and A. Reuter, "Principles of transaction-oriented database recovery," *ACM Comput. Surveys*, vol. 15, no. 4, pp. 287–317, Dec. 1983.
+
+<a id="ref45"></a>[45] J. R. Anderson et al., "An integrated theory of the mind," *Psychological Review*, vol. 111, no. 4, pp. 1036–1060, 2004.
+
+<a id="ref46"></a>[46] FadeMem, "Biologically-inspired forgetting for agent memory," *arXiv preprint arXiv:2601.18642*, 2026.
+
+<a id="ref47"></a>[47] M. Nygard, *Release It!*, 2nd ed. Raleigh, NC: Pragmatic Bookshelf, 2018.
+
+<a id="ref48"></a>[48] C. Majors, L. Fong-Jones, and G. Miranda, *Observability Engineering*. Sebastopol, CA: O'Reilly, 2022.
 
 ---
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：记忆模块 Phase 2 在巩固管线事务安全性、上下文 Token 预算控制、遗忘曲线精度和搜索可观测性方面存在 4 个 Gap，需要补齐以支撑生产级记忆演化。
- 关联上下文/文档：[docs/memory.md](docs/memory.md) §5.1 / §6.3

# 核心变更
- **巩固管线 ACID 安全**：`_simple_consolidate` 改为单事务执行，SAVEPOINT 隔离每段写入，Advisory Lock 防止同 thread 并发巩固，Embedding 生成增加指数退避重试（Circuit Breaker 模式）
- **Token Budget 硬性校验**：`ContextAssembler` 组装完成后校验 `token_count <= budget_total`，超标时按行截断（优先保留高相关性内容），输出 `context_budget_overflow` 结构化日志
- **多因子遗忘曲线**：`calculate_retention_score` 升级为五因子自适应模型（类型衰减率 + 频率增强 + 类型乘子 + 语义重要性 + 时效性加成），对齐 ACT-R + FadeMem 学术框架
- **搜索可观测性**：每条搜索结果携带 `search_level` / `score_type` / `raw_score` 元数据，搜索回退事件输出结构化日志
- **代码审查修复**：`_MEMORY_TYPE_MULTIPLIER` 统一到 governance 层单一事实源；`_get_related_count` 接入评分使语义重要性因子生效；`_is_duplicate` / `_extract_and_store_facts` 合并消除死代码

# 风险与回滚
- 主要风险：遗忘曲线公式变更可能导致现有记忆的 retention_score 在下次审计周期重算时发生分数漂移（趋势：多数记忆分数略升，因新增 recency_bonus 和 semantic_importance 加成）
- 回滚方式：`git revert` 此 PR 即可，SQL 层 `calculate_retention_score()` 函数未变更

# 验证证据
- 单元测试：`test_memory_governance.py` 6 个用例全部通过（含五因子公式精度校验）
- 集成测试：N/A（管线变更依赖 DB 集成环境，CI 覆盖）
- E2E/Workflow：N/A
- 覆盖率/关键截图：pytest 6 passed

# 影响范围
- 前端：无
- 后端：`memory_service.py`（巩固管线 + 搜索可观测性）、`memory.py`（遗忘曲线评分）、`context_assembler.py`（Token 预算校验）、`test_memory_governance.py`（测试对齐）
- GitHub Actions / 文档：`docs/memory.md` §5.1 / §6.3 / 参考文献 [44-48] 新增

# Next Best Action
- 在 staging 环境验证巩固管线端到端流程（Advisory Lock 并发场景 + Embedding 重试降级路径）
- 观察 `context_budget_overflow` 日志频率，评估 Token 预算分配比例是否需要调整