### PR TITLE
feat(memory-ui): 自签 Dev Cookie + 浏览器实机全功能验证 + 4 大缺口 E2E 拆分

### DIFF
--- a/apps/negentropy-ui/app/api/memory/conflicts/[conflictId]/resolve/route.ts
+++ b/apps/negentropy-ui/app/api/memory/conflicts/[conflictId]/resolve/route.ts
@@ -1,0 +1,9 @@
+import { proxyPost } from "../../../_proxy";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ conflictId: string }> },
+) {
+  const { conflictId } = await params;
+  return proxyPost(request, `/memory/conflicts/${conflictId}/resolve`);
+}

--- a/apps/negentropy-ui/app/api/memory/conflicts/route.ts
+++ b/apps/negentropy-ui/app/api/memory/conflicts/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "../_proxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/memory/conflicts");
+}

--- a/apps/negentropy-ui/app/api/memory/facts/[factId]/history/route.ts
+++ b/apps/negentropy-ui/app/api/memory/facts/[factId]/history/route.ts
@@ -1,0 +1,9 @@
+import { proxyGet } from "../../../_proxy";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ factId: string }> },
+) {
+  const { factId } = await params;
+  return proxyGet(request, `/memory/facts/${factId}/history`);
+}

--- a/apps/negentropy-ui/app/api/memory/retrieval/feedback/route.ts
+++ b/apps/negentropy-ui/app/api/memory/retrieval/feedback/route.ts
@@ -1,0 +1,5 @@
+import { proxyPost } from "../../_proxy";
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/memory/retrieval/feedback");
+}

--- a/apps/negentropy-ui/app/api/memory/retrieval/metrics/route.ts
+++ b/apps/negentropy-ui/app/api/memory/retrieval/metrics/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "../../_proxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/memory/retrieval/metrics");
+}

--- a/apps/negentropy-ui/app/memory/audit/page.tsx
+++ b/apps/negentropy-ui/app/memory/audit/page.tsx
@@ -108,7 +108,7 @@ export default function MemoryAuditPage() {
         <div className="flex min-h-0 flex-1 gap-6 px-6 py-6">
           {/* D5: 统一 error banner */}
           {timelineError && (
-            <div className="absolute left-6 right-6 top-[calc(100%-2rem)] z-10 mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300 translate-y-[-100%]">
+            <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
               {timelineError.message || String(timelineError)}
             </div>
           )}

--- a/apps/negentropy-ui/app/memory/audit/page.tsx
+++ b/apps/negentropy-ui/app/memory/audit/page.tsx
@@ -105,14 +105,15 @@ export default function MemoryAuditPage() {
         description="记忆审计治理 (Retain / Delete / Anonymize)"
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-h-0 flex-1 gap-6 px-6 py-6">
-          {/* D5: 统一 error banner */}
+        <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
+          {/* D5: 统一 error banner（独立块，避免被 flex-row 兄弟挤占侧边栏空间） */}
           {timelineError && (
             <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
               {timelineError.message || String(timelineError)}
             </div>
           )}
 
+          <div className="flex min-h-0 flex-1 gap-6">
           {/* Users sidebar */}
           <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
             <div className="pb-4 pr-2">
@@ -307,6 +308,7 @@ export default function MemoryAuditPage() {
               </div>
             </div>
           </aside>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/app/memory/conflicts/page.tsx
+++ b/apps/negentropy-ui/app/memory/conflicts/page.tsx
@@ -264,7 +264,8 @@ export default function MemoryConflictsPage() {
                               {["supersede", "keep_old", "keep_new", "merge"].map((action) => (
                                 <button
                                   key={action}
-                                  className="rounded-full border border-zinc-200 px-3 py-1 text-[11px] text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+                                  className="rounded-full border border-zinc-200 px-3 py-1 text-[11px] text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-zinc-200 disabled:hover:text-zinc-600 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100 dark:disabled:hover:border-zinc-700 dark:disabled:hover:text-zinc-400"
+                                  disabled={resolveStatus === "resolving"}
                                   onClick={() => handleResolve(selected.id, action)}
                                 >
                                   {action}

--- a/apps/negentropy-ui/app/memory/conflicts/page.tsx
+++ b/apps/negentropy-ui/app/memory/conflicts/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { MemoryNav } from "@/components/ui/MemoryNav";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+import {
+  ConflictItem,
+  fetchConflicts,
+  resolveConflict,
+} from "@/features/memory";
+
+const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+
+const RESOLUTION_OPTIONS = [
+  { value: "", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "supersede", label: "Supersede" },
+  { value: "keep_old", label: "Keep Old" },
+  { value: "keep_new", label: "Keep New" },
+  { value: "merge", label: "Merge" },
+];
+
+const RESOLUTION_COLORS: Record<string, string> = {
+  pending:
+    "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-300",
+  supersede:
+    "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/50 dark:text-blue-300",
+  keep_old:
+    "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300",
+  keep_new:
+    "border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/50 dark:text-violet-300",
+  merge: "border-cyan-300 bg-cyan-50 text-cyan-700 dark:border-cyan-700 dark:bg-cyan-950/50 dark:text-cyan-300",
+};
+
+export default function MemoryConflictsPage() {
+  const [userId, setUserId] = useState("");
+  const [activeUserId, setActiveUserId] = useState<string | null>(null);
+  const [resolutionFilter, setResolutionFilter] = useState("");
+  const [conflicts, setConflicts] = useState<ConflictItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [resolveStatus, setResolveStatus] = useState<string | null>(null);
+
+  const loadConflicts = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchConflicts({
+        user_id: activeUserId || undefined,
+        app_name: APP_NAME,
+        resolution: resolutionFilter || undefined,
+        limit: 100,
+      });
+      setConflicts(data.items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [activeUserId, resolutionFilter]);
+
+  useEffect(() => {
+    loadConflicts();
+  }, [loadConflicts]);
+
+  const handleLoad = () => {
+    const trimmed = userId.trim();
+    setActiveUserId(trimmed || null);
+  };
+
+  const handleResolve = async (conflictId: string, resolution: string) => {
+    setResolveStatus("resolving");
+    try {
+      await resolveConflict(conflictId, resolution);
+      setResolveStatus("resolved");
+      await loadConflicts();
+    } catch (err) {
+      setResolveStatus(`error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const selected = conflicts.find((c) => c.id === selectedId);
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <MemoryNav title="Conflicts" description="事实冲突检视与解决" />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
+          <div className="pb-6">
+            {/* Controls */}
+            <div className="mb-6 flex items-center gap-3">
+              <input
+                className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs w-64 dark:border-zinc-700 dark:bg-zinc-800"
+                placeholder="Filter by User ID (optional)"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleLoad()}
+              />
+              <button
+                className="rounded-lg bg-zinc-900 px-4 py-2 text-xs font-semibold text-white dark:bg-zinc-800 dark:text-zinc-100"
+                onClick={handleLoad}
+              >
+                Filter
+              </button>
+              {activeUserId && (
+                <button
+                  className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                  onClick={() => {
+                    setUserId("");
+                    setActiveUserId(null);
+                  }}
+                >
+                  Clear
+                </button>
+              )}
+              <div className="h-4 w-px bg-zinc-200 mx-1 dark:bg-zinc-700" />
+              <select
+                className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                value={resolutionFilter}
+                onChange={(e) => setResolutionFilter(e.target.value)}
+              >
+                {RESOLUTION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <div className="flex-1" />
+              <button
+                className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                onClick={loadConflicts}
+                disabled={isLoading}
+              >
+                {isLoading ? "Loading..." : "Refresh"}
+              </button>
+              {activeUserId && (
+                <span className="text-xs text-muted">Filtered: {activeUserId}</span>
+              )}
+            </div>
+
+            {error && (
+              <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
+                {error}
+              </div>
+            )}
+
+            {resolveStatus && (
+              <div className="mb-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
+                {resolveStatus}
+              </div>
+            )}
+
+            {isLoading ? (
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">Loading conflicts...</p>
+            ) : conflicts.length === 0 ? (
+              <div className="rounded-2xl border border-zinc-200 bg-white p-10 text-center shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">No conflicts found.</p>
+              </div>
+            ) : (
+              <div className="flex gap-6">
+                {/* Conflict list */}
+                <div className="min-w-0 flex-[2] space-y-3">
+                  {conflicts.map((c) => (
+                    <button
+                      key={c.id}
+                      className={`w-full rounded-lg border p-3 text-left text-xs transition-colors ${
+                        selectedId === c.id
+                          ? "border-zinc-900 bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800"
+                          : "border-zinc-200 bg-white hover:border-zinc-400 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-500"
+                      }`}
+                      onClick={() => setSelectedId(c.id)}
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="space-y-1">
+                          <p className="font-medium text-zinc-900 dark:text-zinc-100">
+                            {c.conflict_type}
+                          </p>
+                          <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
+                            by {c.detected_by} · user {c.user_id.slice(0, 8)}...
+                          </p>
+                        </div>
+                        <span
+                          className={`rounded-full border px-2 py-0.5 text-[10px] ${
+                            RESOLUTION_COLORS[c.resolution] || RESOLUTION_COLORS.pending
+                          }`}
+                        >
+                          {c.resolution}
+                        </span>
+                      </div>
+                      <div className="mt-2 flex gap-3 text-[11px] text-zinc-400 dark:text-zinc-500">
+                        {c.old_fact_id && <span>Old: {c.old_fact_id.slice(0, 8)}...</span>}
+                        {c.new_fact_id && <span>New: {c.new_fact_id.slice(0, 8)}...</span>}
+                        <span>{c.created_at || "-"}</span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+
+                {/* Detail panel */}
+                <aside className="min-w-0 flex-1">
+                  <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                    <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                      Conflict Detail
+                    </h2>
+                    {selected ? (
+                      <div className="mt-4 space-y-3 text-xs">
+                        <div>
+                          <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                            Type
+                          </p>
+                          <p className="mt-1 font-medium text-zinc-900 dark:text-zinc-100">
+                            {selected.conflict_type}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                            Detected By
+                          </p>
+                          <p className="mt-1 text-zinc-900 dark:text-zinc-100">
+                            {selected.detected_by}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                            Current Resolution
+                          </p>
+                          <span
+                            className={`mt-1 inline-block rounded-full border px-2 py-0.5 text-[10px] ${
+                              RESOLUTION_COLORS[selected.resolution] || RESOLUTION_COLORS.pending
+                            }`}
+                          >
+                            {selected.resolution}
+                          </span>
+                        </div>
+                        {selected.old_fact_id && (
+                          <div>
+                            <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                              Old Fact
+                            </p>
+                            <p className="mt-1 font-mono text-[11px] text-zinc-600 dark:text-zinc-400">
+                              {selected.old_fact_id}
+                            </p>
+                          </div>
+                        )}
+                        {selected.new_fact_id && (
+                          <div>
+                            <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                              New Fact
+                            </p>
+                            <p className="mt-1 font-mono text-[11px] text-zinc-600 dark:text-zinc-400">
+                              {selected.new_fact_id}
+                            </p>
+                          </div>
+                        )}
+
+                        {selected.resolution === "pending" && (
+                          <div className="mt-4 space-y-2">
+                            <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                              Resolve
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                              {["supersede", "keep_old", "keep_new", "merge"].map((action) => (
+                                <button
+                                  key={action}
+                                  className="rounded-full border border-zinc-200 px-3 py-1 text-[11px] text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+                                  onClick={() => handleResolve(selected.id, action)}
+                                >
+                                  {action}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">
+                        Select a conflict to view details.
+                      </p>
+                    )}
+                  </div>
+                </aside>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useState } from "react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
-import { FactListPayload, fetchFacts, searchFacts } from "@/features/memory";
+import {
+  FactListPayload,
+  FactHistoryItem,
+  fetchFacts,
+  searchFacts,
+  fetchFactHistory,
+} from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -15,6 +21,12 @@ export default function MemoryFactsPage() {
   const [payload, setPayload] = useState<FactListPayload | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+
+  // Fact History modal state
+  const [historyFactId, setHistoryFactId] = useState<string | null>(null);
+  const [historyItems, setHistoryItems] = useState<FactHistoryItem[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
 
   const loadFacts = useCallback(async () => {
     if (!activeUserId) return;
@@ -71,6 +83,26 @@ export default function MemoryFactsPage() {
   const handleClearSearch = () => {
     setSearchQuery("");
     loadFacts();
+  };
+
+  const handleShowHistory = async (factId: string) => {
+    setHistoryFactId(factId);
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      const data = await fetchFactHistory(factId);
+      setHistoryItems(data.items);
+    } catch (err) {
+      setHistoryError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const handleCloseHistory = () => {
+    setHistoryFactId(null);
+    setHistoryItems([]);
+    setHistoryError(null);
   };
 
   return (
@@ -163,6 +195,14 @@ export default function MemoryFactsPage() {
                       {fact.valid_from && <span>From: {fact.valid_from}</span>}
                       {fact.valid_until && <span>Until: {fact.valid_until}</span>}
                     </div>
+                    <div className="mt-2">
+                      <button
+                        className="text-[11px] text-zinc-400 underline hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+                        onClick={() => handleShowHistory(fact.id)}
+                      >
+                        History
+                      </button>
+                    </div>
                   </div>
                 ))}
               </div>
@@ -170,6 +210,78 @@ export default function MemoryFactsPage() {
           </div>
         </div>
       </div>
+
+      {/* Fact History Modal */}
+      {historyFactId && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={handleCloseHistory}
+        >
+          <div
+            className="w-full max-w-lg rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                Fact Version History
+              </h3>
+              <button
+                className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+                onClick={handleCloseHistory}
+              >
+                Close
+              </button>
+            </div>
+            <p className="mt-1 text-[11px] font-mono text-zinc-500 dark:text-zinc-400">
+              {historyFactId}
+            </p>
+
+            {historyLoading ? (
+              <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">Loading history...</p>
+            ) : historyError ? (
+              <p className="mt-4 text-xs text-rose-600">{historyError}</p>
+            ) : historyItems.length === 0 ? (
+              <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">No history available.</p>
+            ) : (
+              <div className="mt-4 max-h-72 space-y-3 overflow-y-auto">
+                {historyItems.map((item, i) => (
+                  <div
+                    key={item.id}
+                    className={`rounded-lg border p-3 text-xs ${
+                      i === 0
+                        ? "border-zinc-900 bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800"
+                        : "border-zinc-200 dark:border-zinc-700"
+                    }`}
+                  >
+                    <div className="flex items-start justify-between">
+                      <p className="font-medium text-zinc-900 dark:text-zinc-100">{item.key}</p>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[10px] ${
+                          item.status === "active"
+                            ? "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
+                            : "border-zinc-200 bg-zinc-50 text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400"
+                        }`}
+                      >
+                        {item.status}
+                      </span>
+                    </div>
+                    <pre className="mt-2 max-h-20 overflow-auto rounded bg-zinc-50 p-2 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                      {JSON.stringify(item.value, null, 2)}
+                    </pre>
+                    <div className="mt-2 flex gap-3 text-[11px] text-zinc-400 dark:text-zinc-500">
+                      <span>Confidence: {(item.confidence * 100).toFixed(0)}%</span>
+                      {item.superseded_by && (
+                        <span>Superseded by: {item.superseded_by.slice(0, 8)}...</span>
+                      )}
+                      <span>{item.created_at || "-"}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -99,11 +99,24 @@ export default function MemoryFactsPage() {
     }
   };
 
-  const handleCloseHistory = () => {
+  const handleCloseHistory = useCallback(() => {
     setHistoryFactId(null);
     setHistoryItems([]);
     setHistoryError(null);
-  };
+  }, []);
+
+  // Esc 关闭模态：仅在打开期间监听，避免无谓全局键盘开销。
+  useEffect(() => {
+    if (!historyFactId) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleCloseHistory();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [historyFactId, handleCloseHistory]);
 
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
@@ -216,13 +229,17 @@ export default function MemoryFactsPage() {
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
           onClick={handleCloseHistory}
+          role="presentation"
         >
           <div
             className="w-full max-w-lg rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
             onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="fact-history-title"
           >
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              <h3 id="fact-history-title" className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                 Fact Version History
               </h3>
               <button

--- a/apps/negentropy-ui/app/memory/page.tsx
+++ b/apps/negentropy-ui/app/memory/page.tsx
@@ -4,7 +4,12 @@ import { useCallback, useEffect, useState } from "react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
-import { fetchMemoryDashboard, MemoryDashboard } from "@/features/memory";
+import {
+  fetchMemoryDashboard,
+  fetchRetrievalMetrics,
+  MemoryDashboard,
+  RetrievalMetrics,
+} from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -18,6 +23,12 @@ export default function MemoryDashboardPage() {
   const [activeUserId, setActiveUserId] = useState<string | undefined>(
     undefined,
   );
+
+  // Retrieval Metrics
+  const [showRetrieval, setShowRetrieval] = useState(false);
+  const [retrievalMetrics, setRetrievalMetrics] = useState<RetrievalMetrics | null>(null);
+  const [retrievalLoading, setRetrievalLoading] = useState(false);
+  const [retrievalError, setRetrievalError] = useState<string | null>(null);
 
   // D3: 可刷新的加载逻辑
   const loadDashboard = useCallback(async () => {
@@ -47,6 +58,29 @@ export default function MemoryDashboardPage() {
     setActiveUserId(undefined);
   };
 
+  const loadRetrievalMetrics = useCallback(async () => {
+    if (!activeUserId) return;
+    setRetrievalLoading(true);
+    setRetrievalError(null);
+    try {
+      const data = await fetchRetrievalMetrics({
+        user_id: activeUserId,
+        app_name: APP_NAME,
+      });
+      setRetrievalMetrics(data);
+    } catch (err) {
+      setRetrievalError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRetrievalLoading(false);
+    }
+  }, [activeUserId]);
+
+  useEffect(() => {
+    if (showRetrieval && activeUserId) {
+      loadRetrievalMetrics();
+    }
+  }, [showRetrieval, activeUserId, loadRetrievalMetrics]);
+
   const cards = dashboard
     ? [
         { label: "Users", value: dashboard.user_count },
@@ -56,7 +90,12 @@ export default function MemoryDashboardPage() {
           label: "Avg Retention",
           value: `${(dashboard.avg_retention_score * 100).toFixed(1)}%`,
         },
+        {
+          label: "Avg Importance",
+          value: `${(dashboard.avg_importance_score * 100).toFixed(1)}%`,
+        },
         { label: "Low Retention", value: dashboard.low_retention_count },
+        { label: "High Importance", value: dashboard.high_importance_count },
         { label: "Recent Audits", value: dashboard.recent_audit_count },
       ]
     : [];
@@ -111,7 +150,7 @@ export default function MemoryDashboardPage() {
               <p className="text-xs text-muted">Loading...</p>
             ) : (
               <>
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                   {cards.map((card) => (
                     <div
                       key={card.label}
@@ -143,6 +182,56 @@ export default function MemoryDashboardPage() {
                     </p>
                   </div>
                 )}
+
+                {/* Retrieval Metrics Section */}
+                <div className="mt-6">
+                  <button
+                    className="flex items-center gap-2 text-sm font-semibold text-foreground"
+                    onClick={() => setShowRetrieval(!showRetrieval)}
+                  >
+                    <span className={`transition-transform ${showRetrieval ? "rotate-90" : ""}`}>
+                      &#x25B6;
+                    </span>
+                    Retrieval Metrics
+                  </button>
+
+                  {showRetrieval && (
+                    <div className="mt-4">
+                      {!activeUserId ? (
+                        <div className="rounded-2xl border border-border bg-card p-5 text-xs text-muted">
+                          Filter by a User ID above to view retrieval quality metrics.
+                        </div>
+                      ) : retrievalLoading ? (
+                        <p className="text-xs text-muted">Loading retrieval metrics...</p>
+                      ) : retrievalError ? (
+                        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
+                          {retrievalError}
+                        </div>
+                      ) : retrievalMetrics ? (
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                          {[
+                            { label: "Total Retrievals", value: retrievalMetrics.total_retrievals },
+                            { label: "Precision@K", value: `${(retrievalMetrics.precision_at_k * 100).toFixed(1)}%` },
+                            { label: "Utilization Rate", value: `${(retrievalMetrics.utilization_rate * 100).toFixed(1)}%` },
+                            { label: "Noise Rate", value: `${(retrievalMetrics.noise_rate * 100).toFixed(1)}%` },
+                          ].map((m) => (
+                            <div
+                              key={m.label}
+                              className="rounded-xl border border-border bg-card p-4 shadow-sm"
+                            >
+                              <p className="text-[11px] uppercase tracking-wide text-muted">
+                                {m.label}
+                              </p>
+                              <p className="mt-1 text-xl font-bold text-foreground">
+                                {m.value}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  )}
+                </div>
               </>
             )}
           </div>

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -71,7 +71,7 @@ export default function MemoryTimelinePage() {
         <div className="flex min-h-0 flex-1 gap-6 px-6 py-6">
           {/* D5: 统一 error banner */}
           {error && (
-            <div className="absolute left-6 right-6 top-[calc(100%-2rem)] z-10 mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300 translate-y-[-100%]">
+            <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
               {error.message || String(error)}
             </div>
           )}

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -68,14 +68,15 @@ export default function MemoryTimelinePage() {
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
       <MemoryNav title="Timeline" description="用户记忆时间线" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-h-0 flex-1 gap-6 px-6 py-6">
-          {/* D5: 统一 error banner */}
+        <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
+          {/* D5: 统一 error banner（独立块，避免被 flex-row 兄弟挤占侧边栏空间） */}
           {error && (
             <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
               {error.message || String(error)}
             </div>
           )}
 
+          <div className="flex min-h-0 flex-1 gap-6">
           {/* Users sidebar */}
           <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
             <div className="pb-4 pr-2">
@@ -231,6 +232,7 @@ export default function MemoryTimelinePage() {
               </div>
             </div>
           </aside>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/components/ui/MemoryNav.tsx
+++ b/apps/negentropy-ui/components/ui/MemoryNav.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: "/memory/timeline", label: "Timeline" },
   { href: "/memory/facts", label: "Facts" },
   { href: "/memory/audit", label: "Audit" },
+  { href: "/memory/conflicts", label: "Conflicts" },
   { href: "/memory/automation", label: "Automation" },
   { href: "/memory/activity", label: "Activity" },
 ];

--- a/apps/negentropy-ui/features/memory/index.ts
+++ b/apps/negentropy-ui/features/memory/index.ts
@@ -61,6 +61,11 @@ export {
   updateMemoryAutomationConfig,
   triggerMemoryAutomationJobAction,
   runMemoryAutomationJob,
+  fetchConflicts,
+  resolveConflict,
+  fetchFactHistory,
+  submitRetrievalFeedback,
+  fetchRetrievalMetrics,
 } from "./utils/memory-api";
 
 // ============================================================================
@@ -93,4 +98,8 @@ export type {
   MemoryAutomationLog,
   MemoryAutomationLogsPayload,
   MemoryAutomationRunResponse,
+  ConflictItem,
+  ConflictListPayload,
+  FactHistoryItem,
+  RetrievalMetrics,
 } from "./utils/memory-api";

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -14,7 +14,9 @@ export interface MemoryDashboard {
   memory_count: number;
   fact_count: number;
   avg_retention_score: number;
+  avg_importance_score: number;
   low_retention_count: number;
+  high_importance_count: number;
   recent_audit_count: number;
 }
 
@@ -25,6 +27,7 @@ export interface MemoryItem {
   memory_type: string;
   content: string;
   retention_score: number;
+  importance_score: number;
   access_count: number;
   created_at?: string;
   last_accessed_at?: string;
@@ -171,6 +174,52 @@ export interface MemoryAutomationRunResponse {
   process_label: string;
   result?: number | null;
   snapshot: MemoryAutomationSnapshot;
+}
+
+// ============================================================================
+// Conflicts
+// ============================================================================
+
+export interface ConflictItem {
+  id: string;
+  user_id: string;
+  app_name: string;
+  old_fact_id?: string | null;
+  new_fact_id?: string | null;
+  conflict_type: string;
+  resolution: string;
+  detected_by: string;
+  created_at?: string | null;
+}
+
+export interface ConflictListPayload {
+  count: number;
+  items: ConflictItem[];
+}
+
+// ============================================================================
+// Fact History
+// ============================================================================
+
+export interface FactHistoryItem {
+  id: string;
+  key: string;
+  value: Record<string, unknown>;
+  confidence: number;
+  status: string;
+  superseded_by?: string | null;
+  created_at?: string | null;
+}
+
+// ============================================================================
+// Retrieval Metrics
+// ============================================================================
+
+export interface RetrievalMetrics {
+  total_retrievals: number;
+  precision_at_k: number;
+  utilization_rate: number;
+  noise_rate: number;
 }
 
 // ============================================================================
@@ -406,6 +455,103 @@ export async function runMemoryAutomationJob(
   });
   if (!res.ok) {
     throw new Error(`Failed to run memory automation job: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// ============================================================================
+// Conflicts
+// ============================================================================
+
+export async function fetchConflicts(params?: {
+  user_id?: string;
+  app_name?: string;
+  resolution?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<ConflictListPayload> {
+  const qs = new URLSearchParams();
+  if (params?.user_id) qs.set("user_id", params.user_id);
+  if (params?.app_name) qs.set("app_name", params.app_name);
+  if (params?.resolution) qs.set("resolution", params.resolution);
+  if (params?.limit) qs.set("limit", String(params.limit));
+  if (params?.offset) qs.set("offset", String(params.offset));
+  const search = qs.toString() ? `?${qs.toString()}` : "";
+
+  const res = await fetch(`/api/memory/conflicts${search}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch conflicts: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function resolveConflict(
+  conflictId: string,
+  resolution: string,
+): Promise<{ status: string; conflict_id: string; resolution: string }> {
+  const res = await fetch(`/api/memory/conflicts/${conflictId}/resolve`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ resolution }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to resolve conflict: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// ============================================================================
+// Fact History
+// ============================================================================
+
+export async function fetchFactHistory(
+  factId: string,
+): Promise<{ count: number; items: FactHistoryItem[] }> {
+  const res = await fetch(`/api/memory/facts/${factId}/history`, {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch fact history: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// ============================================================================
+// Retrieval Feedback
+// ============================================================================
+
+export async function submitRetrievalFeedback(
+  logId: string,
+  outcome: string,
+): Promise<{ status: string }> {
+  const res = await fetch("/api/memory/retrieval/feedback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ log_id: logId, outcome }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to submit retrieval feedback: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function fetchRetrievalMetrics(params: {
+  user_id: string;
+  app_name?: string;
+  days?: number;
+}): Promise<RetrievalMetrics> {
+  const qs = new URLSearchParams();
+  qs.set("user_id", params.user_id);
+  if (params.app_name) qs.set("app_name", params.app_name);
+  if (params.days) qs.set("days", String(params.days));
+
+  const res = await fetch(`/api/memory/retrieval/metrics?${qs.toString()}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch retrieval metrics: ${res.statusText}`);
   }
   return res.json();
 }

--- a/apps/negentropy-ui/scripts/sign-dev-cookie.mjs
+++ b/apps/negentropy-ui/scripts/sign-dev-cookie.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * sign-dev-cookie.mjs — 本地开发用：生成已签名的 ne_sso cookie 值，
+ * 兼输出 Playwright storageState JSON，用于浏览器实机回归。
+ *
+ * 用法：
+ *   NE_AUTH_TOKEN_SECRET=<hex> node apps/negentropy-ui/scripts/sign-dev-cookie.mjs
+ *     → stdout 打印 token（无尾换行噪声，方便 $(...) 抓取）
+ *
+ *   NE_AUTH_TOKEN_SECRET=<hex> node apps/negentropy-ui/scripts/sign-dev-cookie.mjs \
+ *     --storage-state apps/negentropy-ui/.auth/dev-admin.json
+ *     → 同时把 cookie 写成 Playwright storageState 文件（gitignored）
+ *
+ * 选项：
+ *   --storage-state <path>   写入 Playwright storageState JSON 到指定路径
+ *   --ttl <seconds>          覆盖默认 86400 秒
+ *   --email <email>          覆盖默认 dev-admin@example.com
+ *   --sub <sub>              覆盖默认 google:dev-admin
+ *   --name <name>            覆盖默认 Dev Admin
+ *   --roles <r1,r2>          覆盖默认 admin（逗号分隔）
+ *   --domain <domain>        cookie domain，默认 127.0.0.1
+ *   --secure                 cookie secure 标志（默认关）
+ *   --quiet                  不输出额外日志
+ *   -h, --help               显示帮助
+ *
+ * 严禁在生产环境执行；本脚本依赖的 NE_AUTH_TOKEN_SECRET 仅在本地 .env.local 下持有。
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "../../..");
+
+function parseArgs(argv) {
+  const out = {
+    storageState: null,
+    ttlSeconds: 60 * 60 * 24,
+    email: undefined,
+    sub: undefined,
+    name: undefined,
+    roles: undefined,
+    domain: undefined,
+    secure: false,
+    quiet: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "-h":
+      case "--help":
+        process.stdout.write(`用法见脚本头部注释。\n`);
+        process.exit(0);
+        break;
+      case "--storage-state":
+        out.storageState = next();
+        break;
+      case "--ttl":
+        out.ttlSeconds = Number(next());
+        if (!Number.isFinite(out.ttlSeconds) || out.ttlSeconds <= 0) {
+          process.stderr.write(`[sign-dev-cookie] --ttl 需为正整数秒\n`);
+          process.exit(1);
+        }
+        break;
+      case "--email":
+        out.email = next();
+        break;
+      case "--sub":
+        out.sub = next();
+        break;
+      case "--name":
+        out.name = next();
+        break;
+      case "--roles":
+        out.roles = next().split(",").map((s) => s.trim()).filter(Boolean);
+        break;
+      case "--domain":
+        out.domain = next();
+        break;
+      case "--secure":
+        out.secure = true;
+        break;
+      case "--quiet":
+        out.quiet = true;
+        break;
+      default:
+        process.stderr.write(`[sign-dev-cookie] 未知参数：${a}\n`);
+        process.exit(1);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const secret = process.env.NE_AUTH_TOKEN_SECRET ?? "";
+  if (!secret) {
+    process.stderr.write(
+      `[sign-dev-cookie] 环境变量 NE_AUTH_TOKEN_SECRET 必须设置；可从 ${REPO_ROOT}/apps/negentropy/.env.local 读取。\n`,
+    );
+    process.exit(2);
+  }
+
+  // 注意：Node 22+ 不直接支持 require/import .ts；改用动态 require + tsx loader 不可控。
+  // 此处复用 TS 文件 (../tests/e2e/utils/dev-cookie.ts) 的纯算法部分：
+  // 直接内联实现签名（与 dev-cookie.ts 等价；保持单一事实源）。
+  const { Buffer } = await import("node:buffer");
+  const { createHmac } = await import("node:crypto");
+
+  const b64url = (buf) => buf.toString("base64url");
+  const canonical = (v) => {
+    if (v === null || v === undefined) return "null";
+    if (typeof v === "number" || typeof v === "boolean") return JSON.stringify(v);
+    if (typeof v === "string") return JSON.stringify(v);
+    if (Array.isArray(v)) return `[${v.map(canonical).join(",")}]`;
+    if (typeof v === "object") {
+      const keys = Object.keys(v).sort();
+      return `{${keys.map((k) => `${JSON.stringify(k)}:${canonical(v[k])}`).join(",")}}`;
+    }
+    throw new TypeError(`canonical: unsupported ${typeof v}`);
+  };
+
+  const now = Math.floor(Date.now() / 1000);
+  const sub = opts.sub ?? "google:dev-admin";
+  const payload = {
+    typ: "session",
+    iat: now,
+    exp: now + opts.ttlSeconds,
+    sub,
+    email: opts.email ?? "dev-admin@example.com",
+    name: opts.name ?? "Dev Admin",
+    picture: null,
+    roles: opts.roles ?? ["admin"],
+    provider: "google",
+    subject: sub.replace(/^google:/, ""),
+    domain: null,
+  };
+
+  const encoded = b64url(Buffer.from(canonical(payload), "utf-8"));
+  const signature = b64url(createHmac("sha256", secret).update(encoded).digest());
+  const token = `${encoded}.${signature}`;
+
+  if (opts.storageState) {
+    const path = resolve(process.cwd(), opts.storageState);
+    mkdirSync(dirname(path), { recursive: true });
+    const storageState = {
+      cookies: [
+        {
+          name: "ne_sso",
+          value: token,
+          domain: opts.domain ?? "127.0.0.1",
+          path: "/",
+          expires: payload.exp,
+          httpOnly: true,
+          secure: opts.secure,
+          sameSite: "Lax",
+        },
+      ],
+      origins: [],
+    };
+    writeFileSync(path, JSON.stringify(storageState, null, 2) + "\n", "utf-8");
+    if (!opts.quiet) {
+      process.stderr.write(`[sign-dev-cookie] storageState 已写入 ${path}\n`);
+    }
+  }
+
+  // 默认 stdout 仅打印 token，方便 $(...) 抓取，不要追加额外内容
+  process.stdout.write(token);
+  if (!opts.quiet) process.stdout.write("\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`[sign-dev-cookie] 失败：${err?.stack ?? err}\n`);
+  process.exit(3);
+});

--- a/apps/negentropy-ui/tests/e2e/memory/activity.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/activity.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+
+async function mockAuthenticatedUser(page: import("@playwright/test").Page) {
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          userId: "google:test-admin",
+          email: "admin@example.com",
+          name: "Test Admin",
+          roles: ["admin"],
+        },
+      }),
+    });
+  });
+}
+
+const STORAGE_KEY = "negentropy:activity-log";
+
+const NOW = 1_777_879_000_000; // 固定基准毫秒时间戳，避免本地化差异
+
+const SAMPLE_ENTRIES = [
+  {
+    id: "a1",
+    level: "success",
+    message: "Memory saved",
+    description: "Saved successfully",
+    timestamp: NOW - 60_000,
+  },
+  {
+    id: "a2",
+    level: "error",
+    message: "Connection failed",
+    description: "fetch error",
+    timestamp: NOW - 30_000,
+  },
+  {
+    id: "a3",
+    level: "info",
+    message: "Page loaded",
+    timestamp: NOW - 10_000,
+  },
+  {
+    id: "a4",
+    level: "warning",
+    message: "Cache stale",
+    timestamp: NOW - 5_000,
+  },
+];
+
+async function seedActivityEntries(
+  page: import("@playwright/test").Page,
+  entries: unknown[],
+) {
+  // 使用 init script 让 localStorage 在页面开始执行任何脚本前就有数据，
+  // 避免与 useActivityLog 的初次读取竞态。
+  await page.addInitScript(
+    ([key, value]) => {
+      try {
+        localStorage.setItem(key as string, value as string);
+      } catch {
+        // ignore
+      }
+    },
+    [STORAGE_KEY, JSON.stringify(entries)],
+  );
+}
+
+test("Activity 空状态展示 No activity recorded yet", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  // 显式清空 localStorage（避免与之前测试串扰）
+  await seedActivityEntries(page, []);
+
+  await page.goto("/memory/activity");
+  await expect(
+    page.getByText(
+      "No activity recorded yet. Toast notifications will appear here as they occur across the platform.",
+    ),
+  ).toBeVisible();
+});
+
+test("Activity Level 筛选只展示对应级别", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await seedActivityEntries(page, SAMPLE_ENTRIES);
+
+  await page.goto("/memory/activity");
+  // 4 entries 全显示
+  await expect(page.getByText("Memory saved")).toBeVisible();
+  await expect(page.getByText("Connection failed")).toBeVisible();
+
+  // 点击 Error filter，只剩 1 条
+  await page.getByRole("button", { name: "Error" }).click();
+  await expect(page.getByText("Connection failed")).toBeVisible();
+  await expect(page.getByText("Memory saved")).not.toBeVisible();
+  await expect(page.getByText("1 / 4 entries")).toBeVisible();
+});
+
+test("Activity Clear All 清空 entries", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await seedActivityEntries(page, SAMPLE_ENTRIES);
+
+  await page.goto("/memory/activity");
+  await expect(page.getByText("Memory saved")).toBeVisible();
+
+  page.once("dialog", (dlg) => dlg.accept());
+  await page.getByRole("button", { name: "Clear All" }).click();
+  await expect(
+    page.getByText("No activity recorded yet."),
+  ).toBeVisible();
+});
+
+test("Activity 损坏 localStorage 时不白屏", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await page.addInitScript(([key]) => {
+    try {
+      localStorage.setItem(key as string, "{not valid json[[[");
+    } catch {
+      // ignore
+    }
+  }, [STORAGE_KEY]);
+
+  await page.goto("/memory/activity");
+  // 应当 fallback 到 empty state，而非崩溃
+  await expect(
+    page.getByText("No activity recorded yet.", { exact: false }),
+  ).toBeVisible();
+});

--- a/apps/negentropy-ui/tests/e2e/memory/audit.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/audit.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "@playwright/test";
+
+async function mockAuthenticatedUser(page: import("@playwright/test").Page) {
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          userId: "google:test-admin",
+          email: "admin@example.com",
+          name: "Test Admin",
+          roles: ["admin"],
+        },
+      }),
+    });
+  });
+}
+
+const TIMELINE_PAYLOAD = {
+  users: [{ id: "user-1", label: "user-1 (1)" }],
+  timeline: [
+    {
+      id: "mem-1",
+      user_id: "user-1",
+      app_name: "negentropy",
+      memory_type: "episodic",
+      content: "Standup at 10am Mon/Wed",
+      retention_score: 0.84,
+      importance_score: 0.5,
+      access_count: 0,
+      created_at: "2026-05-01T10:00:00Z",
+      metadata: {},
+    },
+  ],
+  policies: { decay_lambda: 0.1 },
+};
+
+const AUDIT_HISTORY = {
+  count: 1,
+  items: [
+    {
+      memory_id: "old-mem-1",
+      decision: "retain",
+      version: 1,
+      note: "earlier audit",
+      created_at: "2026-04-30T10:00:00Z",
+    },
+  ],
+};
+
+async function setupAuditRoutes(page: import("@playwright/test").Page) {
+  await page.route("**/api/memory*", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/memory/audit")) return route.continue();
+    if (url.includes("/api/memory/dashboard")) return route.continue();
+    if (url.includes("/api/memory/conflicts")) return route.continue();
+    if (url.includes("/api/memory/facts")) return route.continue();
+    if (url.includes("/api/memory/automation")) return route.continue();
+    if (url.includes("/api/memory/retrieval")) return route.continue();
+    if (url.includes("/api/memory/search")) return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(TIMELINE_PAYLOAD),
+    });
+  });
+  await page.route("**/api/memory/audit/history**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(AUDIT_HISTORY),
+    });
+  });
+}
+
+test("Audit 选择用户后展示 timeline + history", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await setupAuditRoutes(page);
+
+  await page.goto("/memory/audit");
+  await expect(page.getByRole("button", { name: "user-1 (1)" })).toBeVisible();
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
+
+  await expect(page.getByText("Standup at 10am Mon/Wed")).toBeVisible();
+  await expect(page.getByText("earlier audit")).toBeVisible();
+});
+
+test("Audit 选择 retain 后 Submit 计数变 1", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await setupAuditRoutes(page);
+
+  await page.goto("/memory/audit");
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
+  await expect(page.getByText("Standup at 10am Mon/Wed")).toBeVisible();
+
+  await expect(page.getByRole("button", { name: /Submit \(0\)/ })).toBeDisabled();
+  await page.getByRole("button", { name: "retain" }).click();
+  await expect(page.getByRole("button", { name: /Submit \(1\)/ })).toBeEnabled();
+});
+
+test("Audit 提交 POST /api/memory/audit 含 decisions + idempotency_key", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await setupAuditRoutes(page);
+
+  let postedBody: Record<string, unknown> | null = null;
+  await page.route("**/api/memory/audit", async (route) => {
+    if (route.request().method() === "POST") {
+      postedBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "ok",
+          audits: [
+            {
+              memory_id: "mem-1",
+              decision: "retain",
+              version: 2,
+              note: null,
+              created_at: "2026-05-01T11:00:00Z",
+            },
+          ],
+        }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/memory/audit");
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
+  await page.getByRole("button", { name: "retain" }).click();
+  await page.getByRole("button", { name: /Submit \(1\)/ }).click();
+
+  await expect.poll(() => postedBody !== null, { timeout: 5_000 }).toBeTruthy();
+  expect(postedBody).toMatchObject({
+    user_id: "user-1",
+    decisions: { "mem-1": "retain" },
+  });
+  expect(typeof (postedBody as { idempotency_key?: string })?.idempotency_key).toBe(
+    "string",
+  );
+});
+
+test("Audit 无 decision 时 Submit 禁用", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await setupAuditRoutes(page);
+
+  await page.goto("/memory/audit");
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
+  await expect(page.getByText("Standup at 10am Mon/Wed")).toBeVisible();
+
+  await expect(page.getByRole("button", { name: /Submit \(0\)/ })).toBeDisabled();
+});

--- a/apps/negentropy-ui/tests/e2e/memory/automation.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/automation.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "@playwright/test";
+
+async function mockAuthAs(
+  page: import("@playwright/test").Page,
+  roles: string[],
+) {
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          userId: "google:test-user",
+          email: "user@example.com",
+          name: "Test User",
+          roles,
+        },
+      }),
+    });
+  });
+}
+
+const SNAPSHOT_DEGRADED = {
+  capabilities: {
+    pg_cron_installed: false,
+    pg_cron_available: false,
+    management_mode: "backend-managed",
+    degraded_reasons: ["pg_cron_not_installed", "function_drifted"],
+  },
+  config: {
+    retention: {
+      decay_lambda: 0.1,
+      low_retention_threshold: 0.1,
+      min_age_days: 7,
+      auto_cleanup_enabled: false,
+      cleanup_schedule: "0 2 * * *",
+    },
+    consolidation: {
+      enabled: false,
+      schedule: "0 * * * *",
+      lookback_interval: "1 hour",
+    },
+    context_assembler: {
+      max_tokens: 4000,
+      memory_ratio: 0.3,
+      history_ratio: 0.5,
+    },
+    reweight_relevance: {
+      enabled: true,
+      schedule: "0 */6 * * *",
+    },
+  },
+  processes: [
+    {
+      key: "retention_cleanup",
+      label: "Retention Cleanup",
+      description: "基于艾宾浩斯遗忘曲线清理低价值记忆。",
+      config: {},
+      job: {
+        job_key: "cleanup_memories",
+        process_label: "Ebbinghaus Cleanup",
+        function_name: "cleanup_low_value_memories",
+        enabled: false,
+        status: "disabled",
+        job_id: null,
+        schedule: "0 2 * * *",
+        command: "SELECT negentropy.cleanup_low_value_memories(0.1, 7, 0.1)",
+        active: false,
+      },
+      functions: [],
+    },
+  ],
+  functions: [],
+  jobs: [
+    {
+      job_key: "cleanup_memories",
+      process_label: "Ebbinghaus Cleanup",
+      function_name: "cleanup_low_value_memories",
+      enabled: false,
+      status: "disabled",
+      job_id: null,
+      schedule: "0 2 * * *",
+      command: "SELECT negentropy.cleanup_low_value_memories(0.1, 7, 0.1)",
+      active: false,
+    },
+  ],
+  health: { status: "degraded" },
+};
+
+async function mockAutomationSnapshot(
+  page: import("@playwright/test").Page,
+  snapshot = SNAPSHOT_DEGRADED,
+) {
+  // 路由匹配：Playwright 后注册的 route 优先匹配，分支需主动 `route.fallback()`
+  // 才会把请求转交下一个 handler；否则请求挂起导致 UI 永远 Loading。
+  await page.route("**/api/memory/automation/logs**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ items: [] }),
+    });
+  });
+  await page.route("**/api/memory/automation**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/logs")) return route.fallback();
+    if (url.includes("/jobs/")) return route.continue();
+    if (url.includes("/config")) return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(snapshot),
+    });
+  });
+}
+
+test("Automation 非 admin 角色显示仅管理员提示", async ({ page }) => {
+  await mockAuthAs(page, []);
+  await page.goto("/memory/automation");
+  await expect(page.getByRole("heading", { name: "仅管理员可访问" })).toBeVisible();
+});
+
+test("Automation admin 视图展示 capabilities + degraded + jobs readonly", async ({ page }) => {
+  await mockAuthAs(page, ["admin"]);
+  await mockAutomationSnapshot(page);
+
+  await page.goto("/memory/automation");
+  await expect(page.getByRole("heading", { name: "系统能力" })).toBeVisible();
+  // 等到 snapshot 加载完成（management_mode 由 "-" → "backend-managed"）
+  await expect(page.getByText("backend-managed")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("missing", { exact: true })).toBeVisible();
+  await expect(page.getByText("degraded", { exact: true }).first()).toBeVisible();
+  await expect(
+    page.getByText("pg_cron_not_installed / function_drifted"),
+  ).toBeVisible();
+  await expect(
+    page.getByText("当前 `pg_cron` 不可用，调度相关操作已降级为只读；配置和函数状态仍可查看与保存。"),
+  ).toBeVisible();
+
+  // pg_cron 不可用时，cleanup job 的写按钮应禁用（启用/重建/手动触发）
+  await expect(page.getByRole("button", { name: "启用" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "重建" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "手动触发" })).toBeDisabled();
+});
+
+test("Automation 保存配置触发 POST /api/memory/automation/config", async ({ page }) => {
+  await mockAuthAs(page, ["admin"]);
+  await mockAutomationSnapshot(page);
+
+  let postCalled = false;
+  await page.route("**/api/memory/automation/config", async (route) => {
+    if (route.request().method() === "POST") {
+      postCalled = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SNAPSHOT_DEGRADED),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/memory/automation");
+  await expect(page.getByRole("button", { name: "保存并同步" })).toBeVisible();
+  await page.getByRole("button", { name: "保存并同步" }).click();
+  await expect.poll(() => postCalled, { timeout: 5_000 }).toBeTruthy();
+});

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test } from "@playwright/test";
+
+async function mockAuthenticatedUser(page: import("@playwright/test").Page) {
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          userId: "google:test-admin",
+          email: "admin@example.com",
+          name: "Test Admin",
+          roles: ["admin"],
+        },
+      }),
+    });
+  });
+}
+
+const SAMPLE_FACTS = {
+  count: 2,
+  items: [
+    {
+      id: "fact-1",
+      user_id: "user-1",
+      app_name: "negentropy",
+      fact_type: "preference",
+      key: "preferred_language",
+      value: { name: "TypeScript" },
+      confidence: 0.95,
+      importance_score: 0.5,
+      valid_from: "2026-05-01T00:00:00Z",
+      valid_until: null,
+      created_at: "2026-05-01T00:00:00Z",
+    },
+    {
+      id: "fact-2",
+      user_id: "user-1",
+      app_name: "negentropy",
+      fact_type: "knowledge",
+      key: "api_design",
+      value: { style: "REST" },
+      confidence: 0.9,
+      importance_score: 0.4,
+      valid_from: "2026-05-02T00:00:00Z",
+      valid_until: null,
+      created_at: "2026-05-02T00:00:00Z",
+    },
+  ],
+};
+
+test("Facts 初始展示 Enter a User ID 提示", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await page.goto("/memory/facts");
+  await expect(
+    page.getByText("Enter a User ID to view their semantic memory"),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Load Facts" })).toBeVisible();
+});
+
+test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await page.route("**/api/memory/facts**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SAMPLE_FACTS),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/memory/facts");
+  await page.getByPlaceholder("Enter User ID").fill("user-1");
+  await page.getByRole("button", { name: "Load Facts" }).click();
+
+  await expect(page.getByText("preferred_language")).toBeVisible();
+  await expect(page.getByText("api_design")).toBeVisible();
+  await expect(page.getByText("preference").first()).toBeVisible();
+  await expect(page.getByText("knowledge").first()).toBeVisible();
+  // Confidence percent 标签：数字与单位分两段渲染，断言 % 旁边的数字
+  await expect(page.getByText("Confidence:").first()).toBeVisible();
+});
+
+test("Facts 搜索框过滤结果", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  let searchCalled = false;
+  await page.route("**/api/memory/facts/search", async (route) => {
+    searchCalled = true;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ count: 1, items: [SAMPLE_FACTS.items[0]] }),
+    });
+  });
+  await page.route("**/api/memory/facts*", async (route) => {
+    if (route.request().url().includes("/search")) return;
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SAMPLE_FACTS),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/memory/facts");
+  await page.getByPlaceholder("Enter User ID").fill("user-1");
+  await page.getByRole("button", { name: "Load Facts" }).click();
+  await expect(page.getByText("api_design")).toBeVisible();
+
+  await page.getByPlaceholder("Search facts...").fill("language");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.getByText("preferred_language")).toBeVisible();
+  expect(searchCalled).toBe(true);
+});
+
+test("Facts History 模态展示 dialog ARIA + Esc 关闭", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await page.route("**/api/memory/facts**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/history")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          count: 1,
+          items: [
+            {
+              id: "fact-1",
+              user_id: "user-1",
+              app_name: "negentropy",
+              key: "preferred_language",
+              value: { name: "TypeScript" },
+              fact_type: "preference",
+              confidence: 0.95,
+              status: "active",
+              superseded_by: null,
+              valid_from: "2026-05-01T00:00:00Z",
+              valid_until: null,
+              created_at: "2026-05-01T00:00:00Z",
+            },
+          ],
+        }),
+      });
+      return;
+    }
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SAMPLE_FACTS),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/memory/facts");
+  await page.getByPlaceholder("Enter User ID").fill("user-1");
+  await page.getByRole("button", { name: "Load Facts" }).click();
+  await expect(page.getByText("preferred_language")).toBeVisible();
+
+  await page.getByRole("button", { name: "History" }).first().click();
+  // dialog ARIA 必须落地
+  const dialog = page.getByRole("dialog", { name: "Fact Version History" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toHaveAttribute("aria-modal", "true");
+  await expect(dialog.getByText("active")).toBeVisible();
+
+  // Esc 关闭
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible();
+});
+
+test("Facts 空结果展示 No facts found", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+  await page.route("**/api/memory/facts**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ count: 0, items: [] }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/memory/facts");
+  await page.getByPlaceholder("Enter User ID").fill("user-x");
+  await page.getByRole("button", { name: "Load Facts" }).click();
+
+  await expect(page.getByText("No facts found for this user.")).toBeVisible();
+});

--- a/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
@@ -44,17 +44,17 @@ test("Memory Dashboard 展示 8 个指标卡片", async ({ page }) => {
   await page.goto("/memory");
   await page.waitForLoadState("networkidle");
 
-  // 验证 8 个标签（用精确匹配避免 strict mode violation）
-  await expect(page.getByText("USERS", { exact: true })).toBeVisible();
-  await expect(page.getByText("MEMORIES", { exact: true })).toBeVisible();
-  await expect(page.getByText("FACTS", { exact: true })).toBeVisible();
-  await expect(page.getByText("AVG RETENTION", { exact: true })).toBeVisible();
+  // 验证 8 个标签（DOM 文本为小写，CSS `uppercase` 视觉转换；用精确匹配避免 strict mode violation）
+  await expect(page.getByText("Users", { exact: true })).toBeVisible();
+  await expect(page.getByText("Memories", { exact: true })).toBeVisible();
+  await expect(page.getByText("Facts", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Avg Retention", { exact: true })).toBeVisible();
   await expect(page.getByText("87.6%")).toBeVisible();
-  await expect(page.getByText("AVG IMPORTANCE", { exact: true })).toBeVisible();
+  await expect(page.getByText("Avg Importance", { exact: true })).toBeVisible();
   await expect(page.getByText("54.3%")).toBeVisible();
-  await expect(page.getByText("LOW RETENTION", { exact: true })).toBeVisible();
-  await expect(page.getByText("HIGH IMPORTANCE", { exact: true })).toBeVisible();
-  await expect(page.getByText("RECENT AUDITS", { exact: true })).toBeVisible();
+  await expect(page.getByText("Low Retention", { exact: true })).toBeVisible();
+  await expect(page.getByText("High Importance", { exact: true })).toBeVisible();
+  await expect(page.getByText("Recent Audits", { exact: true })).toBeVisible();
 
   // 验证卡片数值（用 locator 限定到卡片容器内的值文本）
   const cards = page.locator(".grid > div");
@@ -235,10 +235,11 @@ test("Conflicts 页面点击冲突项显示详情", async ({ page }) => {
   // 用 aside 区域限定 "consolidation" 避免与列表项冲突
   await expect(page.locator("aside").getByText("consolidation")).toBeVisible();
   await expect(page.getByText("Resolve")).toBeVisible();
-  await expect(page.getByText("supersede")).toBeVisible();
-  await expect(page.getByText("keep_old")).toBeVisible();
-  await expect(page.getByText("keep_new")).toBeVisible();
-  await expect(page.getByText("merge")).toBeVisible();
+  // 详情面板内 4 个解决按钮（避免与 select dropdown 选项冲突）
+  await expect(page.getByRole("button", { name: "supersede" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "keep_old" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "keep_new" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "merge" })).toBeVisible();
 });
 
 // ============================================================================

--- a/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
@@ -29,7 +29,7 @@ test("Memory Dashboard 展示 8 个指标卡片", async ({ page }) => {
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        user_count: 3,
+        user_count: 7,
         memory_count: 42,
         fact_count: 15,
         avg_retention_score: 0.876,
@@ -44,20 +44,25 @@ test("Memory Dashboard 展示 8 个指标卡片", async ({ page }) => {
   await page.goto("/memory");
   await page.waitForLoadState("networkidle");
 
-  await expect(page.getByText("USERS")).toBeVisible();
-  await expect(page.getByText("3")).toBeVisible();
-  await expect(page.getByText("MEMORIES")).toBeVisible();
-  await expect(page.getByText("42")).toBeVisible();
-  await expect(page.getByText("FACTS")).toBeVisible();
-  await expect(page.getByText("15")).toBeVisible();
-  await expect(page.getByText("AVG RETENTION")).toBeVisible();
+  // 验证 8 个标签（用精确匹配避免 strict mode violation）
+  await expect(page.getByText("USERS", { exact: true })).toBeVisible();
+  await expect(page.getByText("MEMORIES", { exact: true })).toBeVisible();
+  await expect(page.getByText("FACTS", { exact: true })).toBeVisible();
+  await expect(page.getByText("AVG RETENTION", { exact: true })).toBeVisible();
   await expect(page.getByText("87.6%")).toBeVisible();
-  await expect(page.getByText("AVG IMPORTANCE")).toBeVisible();
+  await expect(page.getByText("AVG IMPORTANCE", { exact: true })).toBeVisible();
   await expect(page.getByText("54.3%")).toBeVisible();
-  await expect(page.getByText("LOW RETENTION")).toBeVisible();
-  await expect(page.getByText("HIGH IMPORTANCE")).toBeVisible();
-  await expect(page.getByText("8")).toBeVisible();
-  await expect(page.getByText("RECENT AUDITS")).toBeVisible();
+  await expect(page.getByText("LOW RETENTION", { exact: true })).toBeVisible();
+  await expect(page.getByText("HIGH IMPORTANCE", { exact: true })).toBeVisible();
+  await expect(page.getByText("RECENT AUDITS", { exact: true })).toBeVisible();
+
+  // 验证卡片数值（用 locator 限定到卡片容器内的值文本）
+  const cards = page.locator(".grid > div");
+  await expect(cards).toHaveCount(8);
+  // Spot check specific values using card-scoped locators
+  await expect(cards.nth(0).locator("p").last()).toHaveText("7");
+  await expect(cards.nth(1).locator("p").last()).toHaveText("42");
+  await expect(cards.nth(2).locator("p").last()).toHaveText("15");
 });
 
 test("Memory Dashboard Retrieval Metrics 折叠面板", async ({ page }) => {
@@ -179,10 +184,13 @@ test("Conflicts 页面加载和过滤", async ({ page }) => {
   await page.goto("/memory/conflicts");
   await page.waitForLoadState("networkidle");
 
+  // 验证冲突类型文本（列表中的值）
   await expect(page.getByText("value_contradiction")).toBeVisible();
-  await expect(page.getByText("pending")).toBeVisible();
   await expect(page.getByText("temporal_overlap")).toBeVisible();
-  await expect(page.getByText("supersede")).toBeVisible();
+
+  // 验证 resolution 徽章（用 badge locator 避免 dropdown 选项冲突）
+  await expect(page.locator("button:has-text('pending')")).toBeVisible();
+  await expect(page.locator("span:has-text('supersede')").first()).toBeVisible();
 
   // 测试 resolution 过滤
   const select = page.getByRole("combobox");
@@ -219,12 +227,13 @@ test("Conflicts 页面点击冲突项显示详情", async ({ page }) => {
   await page.goto("/memory/conflicts");
   await page.waitForLoadState("networkidle");
 
-  // 点击冲突项
-  await page.getByText("value_contradiction").click();
+  // 点击冲突项（用 button 精确定位冲突卡片）
+  await page.locator("button:has-text('value_contradiction')").click();
 
   // 验证详情面板
   await expect(page.getByText("Conflict Detail")).toBeVisible();
-  await expect(page.getByText("consolidation")).toBeVisible();
+  // 用 aside 区域限定 "consolidation" 避免与列表项冲突
+  await expect(page.locator("aside").getByText("consolidation")).toBeVisible();
   await expect(page.getByText("Resolve")).toBeVisible();
   await expect(page.getByText("supersede")).toBeVisible();
   await expect(page.getByText("keep_old")).toBeVisible();

--- a/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
@@ -1,0 +1,268 @@
+import { expect, test } from "@playwright/test";
+
+async function mockAuthenticatedUser(page: import("@playwright/test").Page) {
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          userId: "google:test-admin",
+          email: "admin@example.com",
+          name: "Test Admin",
+          roles: ["admin"],
+        },
+      }),
+    });
+  });
+}
+
+// ============================================================================
+// Dashboard
+// ============================================================================
+
+test("Memory Dashboard 展示 8 个指标卡片", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+
+  await page.route("**/api/memory/dashboard**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user_count: 3,
+        memory_count: 42,
+        fact_count: 15,
+        avg_retention_score: 0.876,
+        avg_importance_score: 0.543,
+        low_retention_count: 2,
+        high_importance_count: 8,
+        recent_audit_count: 5,
+      }),
+    });
+  });
+
+  await page.goto("/memory");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByText("USERS")).toBeVisible();
+  await expect(page.getByText("3")).toBeVisible();
+  await expect(page.getByText("MEMORIES")).toBeVisible();
+  await expect(page.getByText("42")).toBeVisible();
+  await expect(page.getByText("FACTS")).toBeVisible();
+  await expect(page.getByText("15")).toBeVisible();
+  await expect(page.getByText("AVG RETENTION")).toBeVisible();
+  await expect(page.getByText("87.6%")).toBeVisible();
+  await expect(page.getByText("AVG IMPORTANCE")).toBeVisible();
+  await expect(page.getByText("54.3%")).toBeVisible();
+  await expect(page.getByText("LOW RETENTION")).toBeVisible();
+  await expect(page.getByText("HIGH IMPORTANCE")).toBeVisible();
+  await expect(page.getByText("8")).toBeVisible();
+  await expect(page.getByText("RECENT AUDITS")).toBeVisible();
+});
+
+test("Memory Dashboard Retrieval Metrics 折叠面板", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+
+  await page.route("**/api/memory/dashboard**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user_count: 1,
+        memory_count: 10,
+        fact_count: 5,
+        avg_retention_score: 0.9,
+        avg_importance_score: 0.5,
+        low_retention_count: 0,
+        high_importance_count: 3,
+        recent_audit_count: 1,
+      }),
+    });
+  });
+
+  await page.goto("/memory");
+
+  // 点击展开 Retrieval Metrics
+  await page.getByText("Retrieval Metrics").click();
+  // 未筛选用户时，显示提示
+  await expect(page.getByText("Filter by a User ID")).toBeVisible();
+});
+
+// ============================================================================
+// Timeline
+// ============================================================================
+
+test("Memory Timeline 加载用户和记忆列表", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+
+  await page.route("**/api/memory**", async (route) => {
+    if (route.request().url().includes("/api/memory/search")) return;
+    if (route.request().url().includes("/api/memory/facts")) return;
+    if (route.request().url().includes("/api/memory/dashboard")) return;
+    if (route.request().url().includes("/api/memory/audit")) return;
+    if (route.request().url().includes("/api/memory/conflicts")) return;
+    if (route.request().url().includes("/api/memory/retrieval")) return;
+    if (route.request().url().includes("/api/memory/automation")) return;
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        users: [{ id: "user-1", label: "user-1 (3)" }],
+        timeline: [
+          {
+            id: "mem-1",
+            user_id: "user-1",
+            app_name: "negentropy",
+            memory_type: "episodic",
+            content: "Test memory content",
+            retention_score: 0.85,
+            importance_score: 0.6,
+            access_count: 2,
+            created_at: "2026-05-01T10:00:00Z",
+            metadata: {},
+          },
+        ],
+        policies: { decay_lambda: 0.1 },
+      }),
+    });
+  });
+
+  await page.goto("/memory/timeline");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByText("Memory Timeline")).toBeVisible();
+  await expect(page.getByText("user-1 (3)")).toBeVisible();
+  await expect(page.getByText("Test memory content")).toBeVisible();
+  await expect(page.getByText("85%")).toBeVisible();
+});
+
+// ============================================================================
+// Conflicts (new page)
+// ============================================================================
+
+test("Conflicts 页面加载和过滤", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+
+  await page.route("**/api/memory/conflicts**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        count: 2,
+        items: [
+          {
+            id: "conflict-1",
+            user_id: "user-1",
+            app_name: "negentropy",
+            old_fact_id: "fact-old-1",
+            new_fact_id: "fact-new-1",
+            conflict_type: "value_contradiction",
+            resolution: "pending",
+            detected_by: "consolidation",
+            created_at: "2026-05-01T10:00:00Z",
+          },
+          {
+            id: "conflict-2",
+            user_id: "user-1",
+            app_name: "negentropy",
+            conflict_type: "temporal_overlap",
+            resolution: "supersede",
+            detected_by: "key_match",
+            created_at: "2026-05-02T10:00:00Z",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/memory/conflicts");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByText("value_contradiction")).toBeVisible();
+  await expect(page.getByText("pending")).toBeVisible();
+  await expect(page.getByText("temporal_overlap")).toBeVisible();
+  await expect(page.getByText("supersede")).toBeVisible();
+
+  // 测试 resolution 过滤
+  const select = page.getByRole("combobox");
+  await select.selectOption("Pending");
+  await expect(page.getByText("value_contradiction")).toBeVisible();
+});
+
+test("Conflicts 页面点击冲突项显示详情", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+
+  await page.route("**/api/memory/conflicts**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        count: 1,
+        items: [
+          {
+            id: "conflict-1",
+            user_id: "user-1",
+            app_name: "negentropy",
+            old_fact_id: "00000000-0000-0000-0000-000000000001",
+            new_fact_id: "00000000-0000-0000-0000-000000000002",
+            conflict_type: "value_contradiction",
+            resolution: "pending",
+            detected_by: "consolidation",
+            created_at: "2026-05-01T10:00:00Z",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/memory/conflicts");
+  await page.waitForLoadState("networkidle");
+
+  // 点击冲突项
+  await page.getByText("value_contradiction").click();
+
+  // 验证详情面板
+  await expect(page.getByText("Conflict Detail")).toBeVisible();
+  await expect(page.getByText("consolidation")).toBeVisible();
+  await expect(page.getByText("Resolve")).toBeVisible();
+  await expect(page.getByText("supersede")).toBeVisible();
+  await expect(page.getByText("keep_old")).toBeVisible();
+  await expect(page.getByText("keep_new")).toBeVisible();
+  await expect(page.getByText("merge")).toBeVisible();
+});
+
+// ============================================================================
+// Navigation
+// ============================================================================
+
+test("Memory 导航栏包含所有 7 个页面标签", async ({ page }) => {
+  await mockAuthenticatedUser(page);
+
+  await page.route("**/api/memory/dashboard**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user_count: 0,
+        memory_count: 0,
+        fact_count: 0,
+        avg_retention_score: 0,
+        avg_importance_score: 0,
+        low_retention_count: 0,
+        high_importance_count: 0,
+        recent_audit_count: 0,
+      }),
+    });
+  });
+
+  await page.goto("/memory");
+
+  await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Timeline" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Facts" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Audit" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Conflicts" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Automation" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Activity" })).toBeVisible();
+});

--- a/apps/negentropy-ui/tests/e2e/utils/dev-cookie.ts
+++ b/apps/negentropy-ui/tests/e2e/utils/dev-cookie.ts
@@ -1,0 +1,158 @@
+/**
+ * Dev cookie 签发工具：复刻后端 `apps/negentropy/src/negentropy/auth/tokens.py` 的 HMAC-SHA256
+ * base64url 算法，用于在不经 Google OAuth 的情况下让 Playwright Chromium 直接以指定身份访问 UI。
+ *
+ * 仅用于本地开发与浏览器实机回归。生产环境严禁使用。
+ */
+import { Buffer } from "node:buffer";
+import { createHmac, randomUUID } from "node:crypto";
+
+export interface DevSessionPayload {
+  typ: "session";
+  iat: number;
+  exp: number;
+  sub: string;
+  email: string;
+  name: string;
+  picture: string | null;
+  roles: string[];
+  provider: string;
+  subject: string;
+  domain: string | null;
+  [extra: string]: unknown;
+}
+
+export interface BuildPayloadInput {
+  email?: string;
+  sub?: string;
+  name?: string;
+  roles?: string[];
+  provider?: string;
+  subject?: string;
+  domain?: string | null;
+  picture?: string | null;
+  ttlSeconds?: number;
+  now?: number;
+}
+
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24; // 1 天，浏览器调试足够
+
+function b64urlNoPad(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+/**
+ * 与 Python `json.dumps(payload, sort_keys=True, separators=(",", ":"))` 等价。
+ * 必须递归对所有对象 key 排序，数组保持原顺序。
+ */
+export function canonicalJSONStringify(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalJSONStringify(v)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    const parts = keys.map((k) => {
+      const v = (value as Record<string, unknown>)[k];
+      return `${JSON.stringify(k)}:${canonicalJSONStringify(v)}`;
+    });
+    return `{${parts.join(",")}}`;
+  }
+  throw new TypeError(`canonicalJSONStringify: unsupported value type ${typeof value}`);
+}
+
+export function signDevSessionCookie(payload: DevSessionPayload, secret: string): string {
+  if (!secret) {
+    throw new Error("NE_AUTH_TOKEN_SECRET 不可为空");
+  }
+  const canonical = canonicalJSONStringify(payload);
+  const encoded = b64urlNoPad(Buffer.from(canonical, "utf-8"));
+  const signature = b64urlNoPad(createHmac("sha256", secret).update(encoded).digest());
+  return `${encoded}.${signature}`;
+}
+
+export function buildAdminPayload(input: BuildPayloadInput = {}): DevSessionPayload {
+  const now = input.now ?? Math.floor(Date.now() / 1000);
+  const ttl = input.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const sub = input.sub ?? "google:dev-admin";
+  return {
+    typ: "session",
+    iat: now,
+    exp: now + ttl,
+    sub,
+    email: input.email ?? "dev-admin@example.com",
+    name: input.name ?? "Dev Admin",
+    picture: input.picture ?? null,
+    roles: input.roles ?? ["admin"],
+    provider: input.provider ?? "google",
+    subject: input.subject ?? sub.replace(/^google:/, ""),
+    domain: input.domain ?? null,
+  };
+}
+
+export interface PlaywrightStorageState {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: "Lax" | "Strict" | "None";
+  }>;
+  origins: Array<{ origin: string; localStorage: Array<{ name: string; value: string }> }>;
+}
+
+export interface BuildStorageStateInput extends BuildPayloadInput {
+  secret: string;
+  cookieName?: string;
+  cookieDomain?: string;
+  cookieSecure?: boolean;
+  cookieSameSite?: "Lax" | "Strict" | "None";
+  cookiePath?: string;
+}
+
+export function buildPlaywrightStorageState(input: BuildStorageStateInput): {
+  payload: DevSessionPayload;
+  cookieValue: string;
+  storageState: PlaywrightStorageState;
+} {
+  const payload = buildAdminPayload(input);
+  const cookieValue = signDevSessionCookie(payload, input.secret);
+  const storageState: PlaywrightStorageState = {
+    cookies: [
+      {
+        name: input.cookieName ?? "ne_sso",
+        value: cookieValue,
+        domain: input.cookieDomain ?? "127.0.0.1",
+        path: input.cookiePath ?? "/",
+        expires: payload.exp,
+        httpOnly: true,
+        secure: input.cookieSecure ?? false,
+        sameSite: input.cookieSameSite ?? "Lax",
+      },
+    ],
+    origins: [],
+  };
+  return { payload, cookieValue, storageState };
+}
+
+/**
+ * 仅用于自反单测：相同 secret 二次签名应得到完全一致的 token。
+ */
+export function signatureSelfCheck(payload: DevSessionPayload, secret: string): boolean {
+  const a = signDevSessionCookie(payload, secret);
+  const b = signDevSessionCookie(payload, secret);
+  return a === b;
+}
+
+export const __testing = {
+  DEFAULT_TTL_SECONDS,
+  b64urlNoPad,
+  randomUUID, // 暴露给 spec 拼装 idempotency key
+};

--- a/apps/negentropy-ui/tests/unit/e2e/dev-cookie.test.ts
+++ b/apps/negentropy-ui/tests/unit/e2e/dev-cookie.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAdminPayload,
+  buildPlaywrightStorageState,
+  canonicalJSONStringify,
+  signDevSessionCookie,
+  signatureSelfCheck,
+} from "../../e2e/utils/dev-cookie";
+
+const SECRET = "test-secret-32bytes-fixed-for-determinism-0123456789";
+const FIXED_NOW = 1_700_000_000;
+
+describe("canonicalJSONStringify", () => {
+  it("应递归对 object key 排序，输出与 Python json.dumps(sort_keys=True,separators=(',',':')) 等价", () => {
+    const got = canonicalJSONStringify({ b: 2, a: { y: [1, 2], x: null }, c: [{ z: 1, a: 0 }] });
+    // 预期：a 内部 x 在 y 前；外层 a < b < c
+    expect(got).toBe('{"a":{"x":null,"y":[1,2]},"b":2,"c":[{"a":0,"z":1}]}');
+  });
+
+  it("应保留数组顺序，仅对对象 key 排序", () => {
+    const got = canonicalJSONStringify([3, 1, 2]);
+    expect(got).toBe("[3,1,2]");
+  });
+
+  it("应正确序列化 null / boolean / number", () => {
+    expect(canonicalJSONStringify(null)).toBe("null");
+    expect(canonicalJSONStringify(true)).toBe("true");
+    expect(canonicalJSONStringify(1.5)).toBe("1.5");
+  });
+});
+
+describe("signDevSessionCookie", () => {
+  it("应在 secret 为空时抛错", () => {
+    const payload = buildAdminPayload({ now: FIXED_NOW });
+    expect(() => signDevSessionCookie(payload, "")).toThrow(/不可为空/);
+  });
+
+  it("相同 payload + secret 应输出确定性 token（自反一致）", () => {
+    const payload = buildAdminPayload({ now: FIXED_NOW });
+    const a = signDevSessionCookie(payload, SECRET);
+    const b = signDevSessionCookie(payload, SECRET);
+    expect(a).toBe(b);
+    expect(signatureSelfCheck(payload, SECRET)).toBe(true);
+  });
+
+  it("token 形如 base64url(payload).base64url(signature)，无 padding", () => {
+    const payload = buildAdminPayload({ now: FIXED_NOW });
+    const token = signDevSessionCookie(payload, SECRET);
+    const parts = token.split(".");
+    expect(parts).toHaveLength(2);
+    for (const p of parts) {
+      expect(p).not.toContain("=");
+      expect(p).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
+    // payload 部分反解后应为 canonical JSON
+    const decoded = Buffer.from(parts[0], "base64url").toString("utf-8");
+    const canonical = canonicalJSONStringify(payload);
+    expect(decoded).toBe(canonical);
+  });
+
+  it("不同 secret 应得到不同签名", () => {
+    const payload = buildAdminPayload({ now: FIXED_NOW });
+    const a = signDevSessionCookie(payload, SECRET);
+    const b = signDevSessionCookie(payload, SECRET + "x");
+    expect(a).not.toBe(b);
+  });
+
+  it("payload 任一字段变化都应改变签名", () => {
+    const base = buildAdminPayload({ now: FIXED_NOW });
+    const tokenBase = signDevSessionCookie(base, SECRET);
+    const tokenAlt = signDevSessionCookie({ ...base, email: "other@example.com" }, SECRET);
+    expect(tokenBase).not.toBe(tokenAlt);
+  });
+});
+
+describe("buildAdminPayload", () => {
+  it("默认应为 admin role + google provider，TTL 24h", () => {
+    const p = buildAdminPayload({ now: FIXED_NOW });
+    expect(p.typ).toBe("session");
+    expect(p.iat).toBe(FIXED_NOW);
+    expect(p.exp).toBe(FIXED_NOW + 86400);
+    expect(p.sub).toBe("google:dev-admin");
+    expect(p.subject).toBe("dev-admin");
+    expect(p.roles).toEqual(["admin"]);
+    expect(p.provider).toBe("google");
+  });
+
+  it("应允许覆盖 sub / roles / TTL", () => {
+    const p = buildAdminPayload({ now: FIXED_NOW, sub: "google:viewer-1", roles: [], ttlSeconds: 60 });
+    expect(p.sub).toBe("google:viewer-1");
+    expect(p.subject).toBe("viewer-1");
+    expect(p.roles).toEqual([]);
+    expect(p.exp).toBe(FIXED_NOW + 60);
+  });
+});
+
+describe("buildPlaywrightStorageState", () => {
+  it("应输出 ne_sso cookie + 空 origins，sameSite=Lax/secure=false", () => {
+    const { storageState, cookieValue } = buildPlaywrightStorageState({ secret: SECRET, now: FIXED_NOW });
+    expect(storageState.origins).toEqual([]);
+    expect(storageState.cookies).toHaveLength(1);
+    const cookie = storageState.cookies[0];
+    expect(cookie.name).toBe("ne_sso");
+    expect(cookie.value).toBe(cookieValue);
+    expect(cookie.domain).toBe("127.0.0.1");
+    expect(cookie.sameSite).toBe("Lax");
+    expect(cookie.secure).toBe(false);
+    expect(cookie.httpOnly).toBe(true);
+  });
+});

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1022,3 +1022,30 @@
 - **处理方式**：将 sentinel 改为 `__legacy_user_config_marker__`（项目内不会重复出现的稀有字符串），断言改为该 sentinel 不应再出现在覆盖后的文件中。
 - **后续防范**：所有"已被覆盖 / 已被替换"型断言必须使用稀有 sentinel（含项目无关的双下划线 + 描述性单词组合），严禁直接用 `"old"` / `"new"` 等高频英文词。
 - **同类问题影响**：检索 `assert "<short>" not in` 模式的所有测试，确认是否也用了脆弱字符串。
+
+## 2026-05-04 Memory Facts History 模态：缺 Esc 键关闭与 ARIA 语义
+
+- **现象**：`/memory/facts` 点击「History」打开版本链模态后，按 Esc 键不关闭；模态根容器没有 `role="dialog"` 与 `aria-modal="true"`，无法被屏幕阅读器识别为模态层。
+- **根因**：`apps/negentropy-ui/app/memory/facts/page.tsx:215-284` 仅在 backdrop 与 Close 按钮上挂了 `onClick`，未实现 Escape 键监听，也未设置 ARIA 角色与 focus trap。点击外层 backdrop 关闭走 `handleCloseHistory`（line 218），点击 modal body `stopPropagation`（line 222），但键盘 Esc 没有路径触发 close。
+- **处理方式**：在 modal 容器加 `role="dialog" aria-modal="true" aria-labelledby="..."`；通过 `useEffect` 在打开时绑定 `document.addEventListener("keydown")` 监听 Escape，卸载/关闭时解绑。focus trap 不在本轮范围内（cost/benefit 不匹配，未来若有强需求再做）。
+- **后续防范**：项目内所有自定义 modal 一律走「ARIA dialog + Esc 关闭」最小可访问模式；新增 modal 时审查清单中加这两条。可在 `components/ui/` 下沉淀 `Modal` 通用组件供后续复用。
+- **同类问题影响**：复检 Memory / Knowledge / Interface 三个领域内其他自定义 modal（Audit 备注、Knowledge 实体编辑等），如无 Esc 监听同样补齐。
+
+## 2026-05-04 Memory 浏览器实机验证 dev cookie 工具与 seed 数据备查
+
+- **Dev Cookie 工具**：
+  - `apps/negentropy-ui/tests/e2e/utils/dev-cookie.ts`：HMAC-SHA256 base64url 签名核心，与后端 `apps/negentropy/src/negentropy/auth/tokens.py` 算法严格对齐（包括 canonical JSON 排序）
+  - `apps/negentropy-ui/scripts/sign-dev-cookie.mjs`：CLI 双模式（stdout token 与 storageState 文件），用于 MCP 浏览器实机回归
+  - 单测 `tests/unit/e2e/dev-cookie.test.ts` 11 例全绿；后端 Python `decode_token` 跨进程解码 JS 端 token 通过
+- **Secret 配置**：本轮新生成 `NE_AUTH_TOKEN_SECRET=bb574184c8dac66d4866d8ffe4e570c37681d09e85413283e28ae2951bca2917`，写入 `apps/negentropy/.env.local` 与 `apps/negentropy-ui/.env.local`（gitignored）。后续浏览器调试可继续复用；如需轮换，两边 secret 必须字节级一致
+- **Demo seed 数据**（来自先前轮次，本轮直接复用）：
+  - user_id：`google:dev-admin`
+  - 4 条 memory（episodic/semantic/preference 混合，metadata.source="browser_e2e_test"）
+  - 4 条 fact（key=api_design/role/editor/preferred_language）
+  - 5+ 条 audit history
+  - 0 条 conflict（巩固管线 disabled + pg_cron 不可用，本轮无法触发 fact 冲突）
+- **本轮浏览器验证局限**：
+  - Conflicts 页：仅验证 empty state + filter 控件；resolve 操作回归交给 mock E2E 覆盖
+  - Automation 页：在 pg_cron 不可用环境下验证了 degraded readonly 模式；admin API config save / job action 流程实机未触发，交给 mock E2E
+- **后续清理建议**：开发结束后 `localStorage.removeItem("negentropy:activity-log")` 清理 Activity 测试 entries；如需重置 dev seed，可手动清除上述 ID 对应的 Memory/Fact/Audit 行（**严禁** TRUNCATE）
+

--- a/docs/user-guide/memory-basics.md
+++ b/docs/user-guide/memory-basics.md
@@ -94,17 +94,19 @@ cd apps/negentropy && uv sync --extra pii-presidio
 
 ---
 
-## 3. UI 导航（4 个页面）
+## 3. UI 导航（7 个页面）
 
 | 页面 | 路径 | 核心功能 |
 |---|---|---|
-| Dashboard | `/admin/memory` | 用户数 / 记忆总数 / 平均 retention / 平均 importance |
-| Timeline | `/admin/memory?tab=timeline` | 按时间倒序的卡片，含 retention 红绿灯 + PII 锁标 |
-| Facts | `/admin/memory?tab=facts` | 结构化事实表，支持 supersede 链查看 |
-| Audit | `/admin/memory?tab=audit` | 审计历史 + retain/delete/anonymize 决策 |
-| Automation | `/admin/memory?tab=automation` | pg_cron 任务管理 + Core Block 维护 |
+| Dashboard | `/memory` | 8 项指标概览（含 Avg Importance / High Importance）+ Retrieval Metrics 折叠面板 |
+| Timeline | `/memory/timeline` | 按时间倒序的卡片，含 retention 红绿灯 + 用户筛选 + 搜索 |
+| Facts | `/memory/facts` | 结构化事实表，支持 History 版本链查看 + 搜索 |
+| Audit | `/memory/audit` | 审计历史 + retain/delete/anonymize 决策 |
+| Conflicts | `/memory/conflicts` | 事实冲突检视与手动解决（pending → supersede/keep_old/keep_new/merge）|
+| Automation | `/memory/automation` | pg_cron 任务管理（需 admin 角色）|
+| Activity | `/memory/activity` | 平台活动日志 |
 
-> Dashboard / Timeline / Facts / Audit / Automation 页面源自 `apps/negentropy-ui/`，详细操作步骤见原 `docs/user-guide.md` 第 5 章。
+> 所有页面源自 `apps/negentropy-ui/app/memory/`。
 
 ### Retention 红绿灯
 - 🟢 ≥ 50%：健康
@@ -121,6 +123,12 @@ cd apps/negentropy && uv sync --extra pii-presidio
 
 | 任务 | 入口 | 文档 |
 |---|---|---|
+| 查看系统指标 | UI Dashboard 页 | 本文档 §3 |
+| 查看检索质量 | UI Dashboard → Retrieval Metrics 面板 | 本文档 §3 |
+| 浏览用户记忆 | UI Timeline 页 | 本文档 §3 |
+| 搜索记忆 | UI Timeline / Facts 搜索框 | 本文档 §3 |
+| 查看事实版本链 | UI Facts → History 按钮 | 本文档 §3 |
+| 解决事实冲突 | UI Conflicts 页 | 本文档 §3 |
 | 程序化写入记忆 | API `/api/memory/self-edit/write` | [`memory-integration.md`](./memory-integration.md#self-edit-tools) |
 | Agent 工具调用 | `memory_search` / `memory_write` 等 5 工具 | [`memory-integration.md`](./memory-integration.md#agent-tools) |
 | 配置定时清理 | UI Automation tab | [`memory-automation.md`](./memory-automation.md) |


### PR DESCRIPTION
## 摘要

围绕 Memory 模块的浏览器实机回归，新增「自签 Dev Cookie」工具栈，以 admin 身份跳过 Google OAuth 直接验证 7 大页面真实业务流；修复 Facts History 模态可访问性缺陷；将 Facts/Audit/Automation/Activity 4 个页面的 E2E 拆分为 sibling spec 文件，便于单独 retry 与维护。

## 改动总览

### 1. Dev Cookie 工具栈（feat / 222bfaa7）
- `apps/negentropy-ui/tests/e2e/utils/dev-cookie.ts`：HMAC-SHA256 base64url 签名核心，与后端 `apps/negentropy/src/negentropy/auth/tokens.py` 算法严格对齐（含 canonical JSON 排序）
- `apps/negentropy-ui/scripts/sign-dev-cookie.mjs`：CLI 双模式（stdout token + Playwright storageState 文件）
- `apps/negentropy-ui/tests/unit/e2e/dev-cookie.test.ts`：11 例自反与序列化单测
- 后端 Python `decode_token` 跨进程解码 JS 端 token 已通过实机校验

### 2. Facts 模态可访问性修复（fix / 47e5a34c）
- 根因：模态仅挂 backdrop / Close 按钮 onClick，无 Escape 键监听，无 `role="dialog"` 与 `aria-modal="true"`
- 修复：useEffect 内挂 keydown 监听 Escape；模态根加 ARIA dialog/modal/labelledby；backdrop 加 `role="presentation"`
- 回归：`tests/e2e/memory/facts.spec.ts::Facts History 模态展示 dialog ARIA + Esc 关闭`

### 3. E2E 测试拆分（test / f9cf2a60）
新增 4 个 sibling spec（共 16 例，沿用 `mockAuthenticatedUser` 模式）：
- `facts.spec.ts`：empty 提示 / 列表渲染 / 搜索过滤 / History 模态 ARIA + Esc / 空结果（5 例）
- `audit.spec.ts`：用户选择 + history / retain 计数 / POST decisions + idempotency_key / Submit 禁用（4 例）
- `automation.spec.ts`：非 admin 仅管理员提示 / admin 视图 capabilities + degraded readonly / 保存配置触发 POST（3 例）
- `activity.spec.ts`：empty / Level 筛选 / Clear All / 损坏 localStorage 不白屏（4 例）

修缮 `memory-pages.spec.ts`：Dashboard 标签改用小写匹配（DOM textContent 实际为小写）；Conflicts 解决按钮改用 `getByRole("button")` 避免与 select option strict-mode 冲突。

### 4. 缺陷文档（docs / 442bd499）
`docs/issue.md` 追加 Facts P1 根因/修复/回归记录、dev cookie 工具与 demo seed 备查、Conflicts/Automation 在 pg_cron 不可用环境下的实机验证局限说明。

## 浏览器实机验证记录（MCP 驱动）

7 大页面在「真实后端 + 真实数据」下逐页驱动，零 console error：

| 页面 | 验证项 | 结果 |
|------|--------|------|
| Dashboard | 8 卡片真实数据 / 91.3% retention / 23.4% importance / User ID `:` encodeURIComponent / Retrieval Metrics 折叠展开 | ✅ |
| Timeline | 4 条 memory + retention 颜色三档 / Search → POST `/api/memory/search` / Retention Policy JSON | ✅ |
| Facts | 4 条 fact 卡片 / Search → POST `/api/memory/facts/search` / History 模态 → 修复后 Esc 关闭 + ARIA dialog | ✅（修复 1 个 P1） |
| Conflicts | empty state + Resolution 下拉 5 选项；resolve 流程因数据为空交给 mock E2E | ✅ |
| Audit | 4 条 timeline + 10 条 history / retain → POST `/api/memory/audit` 含 idempotency_key + decisions / version=2 | ✅ |
| Automation | pg_cron missing degraded readonly / 4 process / 3 jobs 全 disabled / 5 functions drifted SQL 可展开 | ✅ |
| Activity | 4 条注入条目 / Level filter / 损坏 localStorage 不白屏 fallback empty | ✅ |

## 质量门禁

- ✅ `pnpm typecheck` / `pnpm typecheck:test`
- ✅ `pnpm lint`（0 警告）
- ✅ `pnpm test`（76 文件 / 493 例 vitest unit）
- ✅ `pnpm exec playwright test tests/e2e/memory/`（22 例 E2E）
- ✅ MCP 浏览器逐页 0 console error

## Test plan

- [x] 单元测试 dev-cookie 11 例签名与序列化自反
- [x] 后端 Python `decode_token` 跨进程解码 JS 端 token 通过
- [x] MCP 浏览器 7 页实机回归零 error
- [x] Facts modal Esc 与 ARIA dialog 修复后再走一遍
- [x] 22 例 Playwright E2E 全绿（dev server reuse 模式）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)