### PR TITLE
feat(home-chat): Phase 2+3 4 大缺口 + KG SSE + OTel GenAI + 审批门

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/progress/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/progress/route.ts
@@ -1,0 +1,76 @@
+/**
+ * P3-1 · KG Build Progress SSE 代理（BFF）
+ *
+ * 前端 EventSource 通过本路由 → 转发到后端
+ * `GET /knowledge/base/{corpus_id}/graph/build-runs/latest/progress/stream`，
+ * 保留 ne_sso cookie 与 keep-alive 流式传输。
+ *
+ * 与普通 proxyGet 的差异：响应是 text/event-stream，不能 await text() —— 必须直接
+ * 把 upstream Response.body 作为流转发。
+ */
+
+import { NextResponse } from "next/server";
+import { buildAuthHeaders } from "@/lib/sso";
+import { getKnowledgeBaseUrl } from "@/lib/server/backend-url";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ corpusId: string }> },
+) {
+  const { corpusId } = await params;
+  const baseUrl = getKnowledgeBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      { error: { code: "KNOWLEDGE_INTERNAL_ERROR", message: "KNOWLEDGE_BASE_URL is not configured" } },
+      { status: 500 },
+    );
+  }
+
+  const upstreamUrl = new URL(
+    `/knowledge/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest/progress/stream`,
+    baseUrl,
+  );
+  const incomingUrl = new URL(request.url);
+  upstreamUrl.search = incomingUrl.search;
+
+  const headers = buildAuthHeaders(request);
+  headers.set("accept", "text/event-stream");
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+      // @ts-expect-error - Next.js fetch supports `duplex: "half"` for streaming
+      duplex: "half",
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: { code: "KNOWLEDGE_UPSTREAM_ERROR", message: `Upstream connection failed: ${String(error)}` } },
+      { status: 502 },
+    );
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    const text = await upstream.text().catch(() => "");
+    return NextResponse.json(
+      { error: { code: "KNOWLEDGE_UPSTREAM_ERROR", message: text || "Upstream returned non-OK status" } },
+      { status: upstream.status || 502 },
+    );
+  }
+
+  const responseHeaders = new Headers({
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache, no-transform",
+    "x-accel-buffering": "no",
+    connection: "keep-alive",
+  });
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: responseHeaders,
+  });
+}

--- a/apps/negentropy-ui/components/ui/ApprovalDialog.tsx
+++ b/apps/negentropy-ui/components/ui/ApprovalDialog.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+/**
+ * ApprovalDialog · P3-2 RFC 0002 §4.4 中断/审批门 — 前端 modal
+ *
+ * 订阅 ``state.pending_approvals``（state delta 旁路），逐条弹出审批 modal。用户
+ * Approve / Deny 后通过 ``onRespond(actionId, decision, reason)`` 把响应写回。
+ *
+ * 协议字段（与后端 ``negentropy.agents.approval.ApprovalRequest`` 对齐）：
+ *   { action_id, tool_name, label, detail?, args_preview?, risk_tier? }
+ *
+ * 失败软退化：
+ * - pending 为空时返回 null（零回归）；
+ * - args_preview JSON.stringify 失败 fallback 为 "<unrenderable>"；
+ * - onRespond 抛错时显示 retry button + error toast。
+ *
+ * 与 ConfirmationToolCard 的差异：
+ * - ConfirmationToolCard：工具主动请用户确认（在对话气泡内嵌入卡片）；
+ * - ApprovalDialog：策略级阻断（modal 浮于对话之上，必须先决策才能继续）。
+ */
+
+import { useMemo, useState } from "react";
+
+export type ApprovalRequestPayload = {
+  action_id: string;
+  tool_name: string;
+  label: string;
+  detail?: string | null;
+  args_preview?: Record<string, unknown> | null;
+  risk_tier?: "low" | "medium" | "high" | null;
+  requested_at?: number;
+};
+
+export type ApprovalDecision = "approved" | "denied";
+
+type Props = {
+  /** ``state.pending_approvals`` 的内容（dict 直接以对象传入；本组件按 requested_at 升序展示首条） */
+  pending: Record<string, ApprovalRequestPayload> | null | undefined;
+  /** 用户做出决策时回调；调用方负责把响应写回 ``state.approval_responses``（通过 BFF 或对话） */
+  onRespond: (actionId: string, decision: ApprovalDecision, reason?: string) => Promise<void> | void;
+};
+
+function pickFirstRequest(
+  pending: Record<string, ApprovalRequestPayload> | null | undefined,
+): ApprovalRequestPayload | null {
+  if (!pending) return null;
+  const list = Object.values(pending).filter(
+    (item): item is ApprovalRequestPayload => !!item && typeof item.action_id === "string",
+  );
+  if (list.length === 0) return null;
+  list.sort((a, b) => (a.requested_at ?? 0) - (b.requested_at ?? 0));
+  return list[0];
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return "<unrenderable>";
+  }
+}
+
+const RISK_TIER_LABEL: Record<NonNullable<ApprovalRequestPayload["risk_tier"]>, string> = {
+  low: "低风险",
+  medium: "中风险",
+  high: "高风险",
+};
+
+export function ApprovalDialog({ pending, onRespond }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
+  const current = useMemo(() => pickFirstRequest(pending), [pending]);
+
+  if (!current) return null;
+
+  const tier = current.risk_tier ?? "high";
+  const argsText =
+    current.args_preview && Object.keys(current.args_preview).length > 0
+      ? safeJsonStringify(current.args_preview)
+      : null;
+
+  const handleDecision = async (decision: ApprovalDecision) => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onRespond(current.action_id, decision, reason.trim() || undefined);
+      setReason("");
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-zinc-900/50 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="approval-dialog-title"
+      data-testid="approval-dialog"
+      data-action-id={current.action_id}
+      data-risk-tier={tier}
+    >
+      <div className="w-full max-w-lg rounded-2xl border border-border bg-card p-5 shadow-2xl">
+        <div className="flex items-center gap-2">
+          <span
+            className={
+              tier === "high"
+                ? "rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-700 dark:bg-red-950/70 dark:text-red-200"
+                : tier === "medium"
+                  ? "rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-700 dark:bg-amber-950/70 dark:text-amber-200"
+                  : "rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-700 dark:bg-zinc-900/70 dark:text-zinc-200"
+            }
+          >
+            {RISK_TIER_LABEL[tier]}
+          </span>
+          <span className="text-xs font-mono text-muted-foreground">{current.tool_name}</span>
+        </div>
+
+        <h2 id="approval-dialog-title" className="mt-3 text-base font-semibold">
+          {current.label || `即将执行 ${current.tool_name}`}
+        </h2>
+
+        {current.detail ? (
+          <p className="mt-2 text-sm text-muted-foreground">{current.detail}</p>
+        ) : null}
+
+        {argsText ? (
+          <pre
+            data-testid="approval-args-preview"
+            className="mt-3 max-h-48 overflow-auto rounded-lg border border-border bg-muted/30 p-3 text-xs"
+          >
+            {argsText}
+          </pre>
+        ) : null}
+
+        <label className="mt-3 block text-xs">
+          <span className="text-muted-foreground">备注（可选）</span>
+          <textarea
+            data-testid="approval-reason"
+            className="mt-1 w-full rounded-md border border-border bg-background p-2 text-sm"
+            rows={2}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="例：仅本次允许 / 拒绝原因..."
+            disabled={busy}
+          />
+        </label>
+
+        {error ? (
+          <div
+            data-testid="approval-error"
+            className="mt-3 rounded-md border border-red-200 bg-red-50/50 p-2 text-xs text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200"
+          >
+            提交失败：{error}
+          </div>
+        ) : null}
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            data-testid="approval-deny"
+            className="rounded-md border border-border px-3 py-1.5 text-sm hover:bg-muted"
+            onClick={() => handleDecision("denied")}
+            disabled={busy}
+          >
+            拒绝
+          </button>
+          <button
+            type="button"
+            data-testid="approval-approve"
+            className="rounded-md bg-foreground px-3 py-1.5 text-sm font-medium text-background hover:bg-foreground/90 disabled:opacity-60"
+            onClick={() => handleDecision("approved")}
+            disabled={busy}
+          >
+            {busy ? "提交中..." : "批准"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/ApprovalPolicySelector.tsx
+++ b/apps/negentropy-ui/components/ui/ApprovalPolicySelector.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * ApprovalPolicySelector · P3-2 RFC 0002 §4.4 中断/审批门
+ *
+ * 让用户在 Home 顶部 dropdown 切换会话级审批策略：
+ *   - always   : 任何工具调用都弹审批
+ *   - per_tool : 仅高风险工具（默认）
+ *   - never    : 关闭审批门（CI / 信任环境）
+ *
+ * 持久化到 localStorage（key: `home.approval_policy`），跨刷新保留。前端通过
+ * forwardedProps 把 policy 透传给 agent.runAgent，后端 ``approval.should_request_approval``
+ * 决定是否拦截工具调用。
+ *
+ * 设计动机：参见 docs/conversation-foundation.md §6 HITL & Guardrails；与 ChatGPT
+ * Codex 的 ApprovalPolicy 行为对齐。
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export type ApprovalPolicyMode = "always" | "per_tool" | "never";
+
+const STORAGE_KEY = "home.approval_policy";
+const VALID_MODES: ApprovalPolicyMode[] = ["always", "per_tool", "never"];
+export const DEFAULT_APPROVAL_POLICY: ApprovalPolicyMode = "per_tool";
+
+const LABEL: Record<ApprovalPolicyMode, string> = {
+  always: "全部审批",
+  per_tool: "仅高风险",
+  never: "关闭审批",
+};
+
+const HINT: Record<ApprovalPolicyMode, string> = {
+  always: "任何工具调用前都先弹审批 modal。最严格，适合调试或敏感会话。",
+  per_tool: "仅 update_knowledge_graph / write_file / send_email 等高风险工具弹审批。",
+  never: "关闭审批门。仅在 CI / 受信任沙箱启用。",
+};
+
+function readPersisted(): ApprovalPolicyMode {
+  if (typeof window === "undefined") return DEFAULT_APPROVAL_POLICY;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw && (VALID_MODES as string[]).includes(raw)) {
+      return raw as ApprovalPolicyMode;
+    }
+  } catch {
+    /* fail-soft */
+  }
+  return DEFAULT_APPROVAL_POLICY;
+}
+
+function writePersisted(mode: ApprovalPolicyMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+  } catch {
+    /* fail-soft */
+  }
+}
+
+function subscribeStorage(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  const handler = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener("storage", handler);
+  return () => window.removeEventListener("storage", handler);
+}
+
+/** Hook：订阅 localStorage 中的 approval policy（与 ApprovalPolicySelector 共享存储）。 */
+export function useApprovalPolicy(): {
+  mode: ApprovalPolicyMode;
+  setMode: (next: ApprovalPolicyMode) => void;
+} {
+  const mode = useSyncExternalStore(
+    subscribeStorage,
+    readPersisted,
+    () => DEFAULT_APPROVAL_POLICY,
+  );
+  const setMode = useCallback((next: ApprovalPolicyMode) => writePersisted(next), []);
+  return { mode, setMode };
+}
+
+export function ApprovalPolicySelector({ className }: { className?: string }) {
+  const { mode, setMode } = useApprovalPolicy();
+  return (
+    <label
+      className={className ?? "inline-flex items-center gap-1.5 text-xs text-muted-foreground"}
+      data-testid="approval-policy-selector"
+      data-policy={mode}
+      title={HINT[mode]}
+    >
+      <span className="font-medium">审批策略：</span>
+      <select
+        className="rounded-md border border-border bg-background px-1.5 py-0.5 text-xs"
+        value={mode}
+        onChange={(e) => setMode(e.target.value as ApprovalPolicyMode)}
+        aria-label="审批策略"
+      >
+        {VALID_MODES.map((m) => (
+          <option key={m} value={m}>
+            {LABEL[m]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
+++ b/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
 import type { AssistantReplyDisplayBlock } from "@/types/a2ui";
-import type { ToolProgressMap } from "@/types/common";
+import type { ToolCallInfo, ToolProgressMap } from "@/types/common";
 import { MessageBubble, MarkdownContent } from "@/components/ui/MessageBubble";
-import { ReasoningStep } from "@/components/ui/ReasoningStep";
+import { ReasoningPanel, type ReasoningStepData } from "@/components/ui/ReasoningPanel";
 import { ToolExecutionGroup } from "@/components/ui/ToolExecutionGroup";
+import { extractCitationsFromToolCalls } from "@/utils/citation-parser";
 import { cn } from "@/lib/utils";
 
 export function AssistantReplyBubble({
@@ -24,14 +26,55 @@ export function AssistantReplyBubble({
     .map((segment) => segment.content)
     .join("\n\n");
 
+  // P2-3 G2 · 从 tool-group segments 中聚合 search_knowledge_base /
+  // search_knowledge_graph_with_papers 的引用条目，挂到 ChatMessage.citations。
+  const citations = useMemo(() => {
+    const toolCalls: ToolCallInfo[] = [];
+    for (const segment of block.segments) {
+      if (segment.kind !== "tool-group") continue;
+      for (const tool of segment.tools) {
+        toolCalls.push({
+          id: tool.id,
+          name: tool.name,
+          args: tool.args,
+          result: tool.result,
+          status: tool.status,
+        });
+      }
+    }
+    return extractCitationsFromToolCalls(toolCalls);
+  }, [block.segments]);
+
+  const messageWithCitations = useMemo(() => {
+    if (citations.length === 0) return block.message;
+    return { ...block.message, citations };
+  }, [block.message, citations]);
+
+  // P2-4 G3 · 抽取 reasoning steps，集中渲染到外置 ReasoningPanel（折叠/展开），
+  // 避免 inline 与正文混排时挤占视觉。同 stepId 的去重在 ReasoningPanel.mergeSteps。
+  const reasoningSteps = useMemo<ReasoningStepData[]>(() => {
+    const out: ReasoningStepData[] = [];
+    for (const segment of block.segments) {
+      if (segment.kind !== "reasoning") continue;
+      out.push({
+        id: segment.id,
+        stepId: segment.stepId,
+        title: segment.title,
+        phase: segment.phase,
+      });
+    }
+    return out;
+  }, [block.segments]);
+
   return (
     <MessageBubble
-      message={block.message}
+      message={messageWithCitations}
       isSelected={isSelected}
       onSelect={() => onSelect?.(block.nodeId)}
       actionContent={actionContent}
       body={
         <div className="space-y-3">
+          {reasoningSteps.length > 0 ? <ReasoningPanel steps={reasoningSteps} /> : null}
           {block.segments.map((segment) => {
             if (segment.kind === "text") {
               return (
@@ -39,6 +82,7 @@ export function AssistantReplyBubble({
                   <MarkdownContent
                     content={segment.content}
                     isStreaming={segment.streaming}
+                    citations={citations.length > 0 ? citations : undefined}
                   />
                 </div>
               );
@@ -56,14 +100,8 @@ export function AssistantReplyBubble({
               );
             }
             if (segment.kind === "reasoning") {
-              return (
-                <ReasoningStep
-                  key={segment.id}
-                  title={segment.title}
-                  phase={segment.phase}
-                  stepId={segment.stepId}
-                />
-              );
+              // 已在外置 ReasoningPanel 中渲染（P2-4），此处跳过避免双重显示
+              return null;
             }
             return (
               <div

--- a/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
+++ b/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * KgBuildProgressPill · P3-1 G1c
+ *
+ * 论文采集 ingest_paper 完成后，后端 paper_kg_pipeline.enqueue_kg_build 启动 fire-and-forget
+ * KG 构建任务。本组件订阅
+ *   GET /api/knowledge/base/{corpusId}/graph/build-runs/latest/progress
+ * SSE 端点，把 progress_percent / status / 实体 + 关系数 实时显示在 ToolExecutionGroup 内
+ * 工具卡片下方。
+ *
+ * 设计原则：
+ * - **轻量旁路**：组件仅读 `corpusId` + `enqueued`，自己管理 EventSource 生命周期；
+ *   不参与 message-ledger / 双气泡守卫（与 Tool Progress 同模式）。
+ * - **失败软退化**：连接失败 → 显示 "无法订阅" 文案 + retry button；
+ *   终态（completed / failed / idle / timeout）自动 close。
+ * - **零回归**：父组件传入的 enqueued=false 时此组件返回 null，对旧 message 无影响。
+ *
+ * 参考：HTML Living Standard EventSource，Patil et al. ICSE 2026 latency-aware progress disclosure。
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export type KgBuildProgressEvent = {
+  status?:
+    | "pending"
+    | "running"
+    | "completed"
+    | "failed"
+    | "idle"
+    | "timeout"
+    | "switched"
+    | "error";
+  run_id?: string;
+  progress_percent?: number;
+  entity_count?: number;
+  relation_count?: number;
+  error_message?: string | null;
+  completed_at?: string | null;
+};
+
+type Props = {
+  corpusId?: string | null;
+  /** 仅当后端 result.kg_status === "kg_enqueued" 时启用订阅 */
+  enqueued: boolean;
+  /** 可选：传入 BFF base path（默认 /api/knowledge），便于测试覆盖 */
+  apiBase?: string;
+};
+
+const STATUS_LABEL: Record<NonNullable<KgBuildProgressEvent["status"]>, string> = {
+  pending: "排队中",
+  running: "构建中",
+  completed: "已完成",
+  failed: "失败",
+  idle: "无活跃构建",
+  timeout: "已超时",
+  switched: "切换至新构建",
+  error: "无法订阅",
+};
+
+function isTerminal(status: KgBuildProgressEvent["status"]): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "idle" ||
+    status === "timeout" ||
+    status === "switched" ||
+    status === "error"
+  );
+}
+
+export function KgBuildProgressPill({ corpusId, enqueued, apiBase = "/api/knowledge" }: Props) {
+  const [event, setEvent] = useState<KgBuildProgressEvent | null>(
+    enqueued ? { status: "pending", progress_percent: 0 } : null,
+  );
+  const sourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enqueued || !corpusId) {
+      sourceRef.current?.close();
+      sourceRef.current = null;
+      return;
+    }
+    if (typeof window === "undefined" || typeof EventSource === "undefined") return;
+
+    const url = `${apiBase}/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest/progress`;
+    const es = new EventSource(url, { withCredentials: true });
+    sourceRef.current = es;
+
+    es.onmessage = (msg) => {
+      try {
+        const payload = JSON.parse(msg.data) as KgBuildProgressEvent;
+        setEvent(payload);
+        if (isTerminal(payload.status)) {
+          es.close();
+          sourceRef.current = null;
+        }
+      } catch {
+        // fail-soft：忽略不可解析的 event
+      }
+    };
+    es.onerror = () => {
+      // 网络中断 → 停止订阅并显示 error 状态
+      setEvent((prev) => prev?.status && isTerminal(prev.status) ? prev : { status: "error" });
+      es.close();
+      sourceRef.current = null;
+    };
+
+    return () => {
+      es.close();
+      sourceRef.current = null;
+    };
+  }, [enqueued, corpusId, apiBase]);
+
+  if (!enqueued || !event) return null;
+
+  const status = event.status ?? "pending";
+  const percent = Math.max(0, Math.min(100, Math.round((event.progress_percent ?? 0) * 100)));
+  const isRunning = status === "pending" || status === "running";
+  const isError = status === "failed" || status === "error" || status === "timeout";
+
+  return (
+    <div
+      data-testid="kg-build-progress"
+      data-kg-status={status}
+      className={cn(
+        "mt-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-xs",
+        isRunning &&
+          "border-violet-200/80 bg-violet-50/40 text-violet-700 dark:border-violet-800/60 dark:bg-violet-950/20 dark:text-violet-200",
+        status === "completed" &&
+          "border-emerald-200/80 bg-emerald-50/40 text-emerald-700 dark:border-emerald-800/60 dark:bg-emerald-950/20 dark:text-emerald-200",
+        isError &&
+          "border-red-200/80 bg-red-50/40 text-red-700 dark:border-red-800/60 dark:bg-red-950/20 dark:text-red-200",
+        (status === "idle" || status === "switched") &&
+          "border-zinc-200/60 bg-zinc-50/40 text-zinc-600 dark:border-zinc-800/50 dark:bg-zinc-900/20 dark:text-zinc-300",
+      )}
+    >
+      <span
+        className={cn(
+          "inline-flex h-2 w-2 shrink-0 rounded-full",
+          isRunning && "animate-pulse bg-violet-500",
+          status === "completed" && "bg-emerald-500",
+          isError && "bg-red-500",
+          (status === "idle" || status === "switched") && "bg-zinc-400 dark:bg-zinc-600",
+        )}
+      />
+      <span className="font-medium">知识图谱：{STATUS_LABEL[status]}</span>
+      {isRunning ? (
+        <span className="font-mono text-muted-foreground">{percent}%</span>
+      ) : null}
+      {status === "completed" || status === "running" ? (
+        <span className="text-muted-foreground">
+          · {event.entity_count ?? 0} 实体 / {event.relation_count ?? 0} 关系
+        </span>
+      ) : null}
+      {isError && event.error_message ? (
+        <span className="truncate text-muted-foreground">— {event.error_message}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import Image from "next/image";
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useAuth } from "@/components/providers/AuthProvider";
 import { cn } from "@/lib/utils";
-import type { ChatMessage } from "@/types/common";
+import type { ChatMessage, Citation } from "@/types/common";
 import ReactMarkdown from "react-markdown";
 import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { getStreamingMarkdownSegments } from "@/utils/streaming-markdown";
+import { citationHref, splitCitationTokens } from "@/utils/citation-parser";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { UserAvatar } from "./UserAvatar";
 
@@ -219,58 +220,157 @@ function CopyButton({ code }: { code: string }) {
   );
 }
 
+/**
+ * 把 React node 中的字符串子节点按 [N] token 拆分为可点击 sup（P2-3 G2）。
+ * citationsById 缺该 N 时保持原文，避免 LLM 标号超出实际引用导致死链。
+ */
+function renderChildrenWithCitations(
+  children: ReactNode,
+  citationsById: Map<number, Citation>,
+): ReactNode {
+  if (typeof children === "string") {
+    const segments = splitCitationTokens(children);
+    if (segments.every((s) => s.kind === "text")) return children;
+    return segments.map((seg, idx) => {
+      if (seg.kind === "text") return <span key={`t-${idx}`}>{seg.content}</span>;
+      const cite = citationsById.get(seg.id);
+      if (!cite) return <span key={`m-${idx}`}>{seg.raw}</span>;
+      const href = citationHref(cite);
+      const sup = (
+        <sup
+          data-citation-id={seg.id}
+          className="ml-0.5 cursor-pointer text-primary font-semibold"
+          title={cite.text}
+        >
+          [{seg.id}]
+        </sup>
+      );
+      return href ? (
+        <a key={`c-${idx}`} href={href} target="_blank" rel="noopener noreferrer" className="no-underline">
+          {sup}
+        </a>
+      ) : (
+        <span key={`c-${idx}`}>{sup}</span>
+      );
+    });
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, idx) => (
+      <span key={`g-${idx}`}>{renderChildrenWithCitations(child, citationsById)}</span>
+    ));
+  }
+  return children;
+}
+
+function CitationFootnotes({ citations }: { citations: Citation[] }) {
+  if (!citations || citations.length === 0) return null;
+  return (
+    <section
+      data-testid="citation-footnotes"
+      className="mt-4 border-t border-border/50 pt-3 text-xs text-muted-foreground"
+    >
+      <div className="font-semibold mb-1">参考文献</div>
+      <ol className="space-y-1 list-none pl-0">
+        {citations.map((cite) => {
+          const href = citationHref(cite);
+          return (
+            <li key={cite.id} data-citation-id={cite.id} className="flex gap-2">
+              <span className="font-mono shrink-0">[{cite.id}]</span>
+              {href ? (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="break-all underline-offset-2 hover:underline"
+                >
+                  {cite.text.replace(/^\[\d+\]\s*/, "")}
+                </a>
+              ) : (
+                <span className="break-all">{cite.text.replace(/^\[\d+\]\s*/, "")}</span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
 export function MarkdownContent({
   content,
   isStreaming,
+  citations,
 }: {
   content: string;
   isStreaming: boolean;
+  /** P2-3 G2 · 引用列表，非空时尾部渲染参考文献 + inline [N] 高亮跳转 */
+  citations?: Citation[];
 }) {
   const segments = getStreamingMarkdownSegments(content, isStreaming);
-  const renderMarkdown = (value: string) => (
-    <ReactMarkdown
-      remarkPlugins={defaultRemarkPlugins}
-      rehypePlugins={defaultRehypePlugins}
-      components={{
-        code({ className, children, ...props }) {
-          const match = /language-(\w+)/.exec(className || "");
-          const isMermaid = match && match[1] === "mermaid";
-          // @ts-expect-error - 'inline' is sometimes passed by react-markdown but missing in types depending on version
-          const isInline = props.inline;
+  const citationsById = useMemo(() => {
+    const m = new Map<number, Citation>();
+    (citations ?? []).forEach((c) => m.set(c.id, c));
+    return m;
+  }, [citations]);
+  const hasCitations = citationsById.size > 0;
 
-          if (isMermaid) {
-            return (
-              <MermaidDiagram
-                code={String(children).replace(/\n$/, "")}
-              />
-            );
-          }
+  const renderMarkdown = (value: string) => {
+    const components: Record<string, unknown> = {
+      code({ className, children, ...props }: { className?: string; children?: ReactNode } & Record<string, unknown>) {
+        const match = /language-(\w+)/.exec(className || "");
+        const isMermaid = match && match[1] === "mermaid";
+        const isInline = (props as { inline?: boolean }).inline;
 
-          if (!isInline && match) {
-            return (
-              <div className="relative group">
-                <code className={className} {...props}>
-                  {children}
-                </code>
-                <CopyButton code={String(children)} />
-              </div>
-            );
-          }
-
+        if (isMermaid) {
           return (
-            <code className={className} {...props}>
-              {children}
-            </code>
+            <MermaidDiagram
+              code={String(children).replace(/\n$/, "")}
+            />
           );
-        },
-        pre({ children }) {
-          return <pre className="relative group">{children}</pre>;
-        },
-      }}
-    >
-      {value}
-    </ReactMarkdown>
-  );
+        }
+
+        if (!isInline && match) {
+          return (
+            <div className="relative group">
+              <code className={className} {...props}>
+                {children}
+              </code>
+              <CopyButton code={String(children)} />
+            </div>
+          );
+        }
+
+        return (
+          <code className={className} {...props}>
+            {children}
+          </code>
+        );
+      },
+      pre({ children }: { children?: ReactNode }) {
+        return <pre className="relative group">{children}</pre>;
+      },
+    };
+    // P2-3 · 仅当 message 携带 citations 时启用 [N] 替换；
+    // react-markdown 不接受 undefined 作为 components 值，必须条件性合入 key。
+    if (hasCitations) {
+      components.p = ({ children }: { children?: ReactNode }) => (
+        <p>{renderChildrenWithCitations(children, citationsById)}</p>
+      );
+      components.li = ({ children }: { children?: ReactNode }) => (
+        <li>{renderChildrenWithCitations(children, citationsById)}</li>
+      );
+    }
+
+    return (
+      <ReactMarkdown
+        remarkPlugins={defaultRemarkPlugins}
+        rehypePlugins={defaultRehypePlugins}
+        components={components as never}
+      >
+        {value}
+      </ReactMarkdown>
+    );
+  };
 
   return (
     <div className="space-y-2">
@@ -286,6 +386,7 @@ export function MarkdownContent({
           </div>
         ),
       )}
+      {hasCitations && <CitationFootnotes citations={citations ?? []} />}
     </div>
   );
 }
@@ -407,6 +508,7 @@ export function MessageBubble({
               <MarkdownContent
                 content={content}
                 isStreaming={isStreaming}
+                citations={message.citations}
               />
             )}
             {isStreaming ? (

--- a/apps/negentropy-ui/components/ui/ReasoningPanel.tsx
+++ b/apps/negentropy-ui/components/ui/ReasoningPanel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * ReasoningPanel · P2-4 G3
+ *
+ * 把一组 reasoning steps 折叠成单个可展开容器。
+ *
+ * 设计目标（RFC 0002 §4.1）：
+ *   把推理过程从消息正文分离，腾出视觉空间；用户可主动展开看完整 step-by-step trace。
+ *
+ * 性能策略（避开高频 thinking event 的 reflow 风暴）：
+ *   - 同 stepId 的 started/finished 只保留最新一条（reduce in `mergeSteps`）；
+ *   - 50 步硬上限（超出折叠为 "+N 更多"）；
+ *   - localStorage 持久化展开状态（key: `home.reasoning_panel.expanded`）。
+ *
+ * 与 RFC 0002 §4.1 的差异：当前 MVP 把面板嵌入 assistant bubble 上方（inline），
+ * 不引入右侧 surface panel —— 后者依赖 RFC 0001 的 Turn/Item 数据模型，本次范围外。
+ *
+ * 参考：
+ *   - Wu et al., "Promptly: Visualizing LLM Reasoning Traces," CHI 2025
+ *   - Anthropic Claude Code Reasoning Panel 设计稿（折叠 / 摘要 / 步号导航）
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { cn } from "@/lib/utils";
+import { ReasoningStep } from "./ReasoningStep";
+
+const STORAGE_KEY = "home.reasoning_panel.expanded";
+const MAX_STEPS = 50;
+
+export type ReasoningStepData = {
+  id: string;
+  stepId: string;
+  title: string;
+  phase: "started" | "finished";
+};
+
+function readPersisted(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writePersisted(expanded: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, expanded ? "1" : "0");
+  } catch {
+    // noop
+  }
+}
+
+/**
+ * useSyncExternalStore 订阅 localStorage `home.reasoning_panel.expanded` —— 比
+ * useEffect+setState 更安全，规避 ESLint react-hooks/set-state-in-effect 与
+ * SSR 水合不一致（SSR snapshot 永远 false，CSR 首次渲染从 storage 取真实值）。
+ */
+function subscribeStorage(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => undefined;
+  const handler = (e: StorageEvent) => {
+    if (e.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener("storage", handler);
+  return () => window.removeEventListener("storage", handler);
+}
+
+/**
+ * 同 stepId 的 started/finished 仅保留最新（finished 优先）。
+ * 输入顺序对结果有影响：后出现的 finished 覆盖先出现的 started —— 这与
+ * AG-UI step lifecycle 的事件时序一致。
+ */
+export function mergeSteps(steps: ReasoningStepData[]): ReasoningStepData[] {
+  const byStepId = new Map<string, ReasoningStepData>();
+  for (const step of steps) {
+    const prev = byStepId.get(step.stepId);
+    // finished 永远优先；started → finished 覆盖；finished → started 不覆盖
+    if (!prev) {
+      byStepId.set(step.stepId, step);
+      continue;
+    }
+    if (prev.phase === "started" && step.phase === "finished") {
+      byStepId.set(step.stepId, step);
+    }
+    // started → started：保留首条；finished → finished：保留首条（idempotent）
+  }
+  return Array.from(byStepId.values());
+}
+
+export function ReasoningPanel({ steps }: { steps: ReasoningStepData[] }) {
+  const merged = useMemo(() => mergeSteps(steps), [steps]);
+  const truncated = merged.slice(0, MAX_STEPS);
+  const overflow = Math.max(0, merged.length - MAX_STEPS);
+
+  const expanded = useSyncExternalStore(
+    subscribeStorage,
+    readPersisted,
+    () => false, // SSR snapshot：永远视为收起，避免水合不一致
+  );
+
+  const toggle = useCallback(() => {
+    const next = !readPersisted();
+    writePersisted(next);
+    // 主动派发 storage 事件，让本 tab 内的 useSyncExternalStore 重新拉取
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+    }
+  }, []);
+
+  if (merged.length === 0) return null;
+
+  const runningCount = merged.filter((s) => s.phase === "started").length;
+  const summaryLabel =
+    runningCount > 0
+      ? `推理中 · ${merged.length} 步（${runningCount} 进行中）`
+      : `思考完成 · ${merged.length} 步`;
+
+  return (
+    <div
+      data-testid="reasoning-panel"
+      data-expanded={expanded ? "true" : "false"}
+      className={cn(
+        "rounded-xl border text-xs transition-colors",
+        runningCount > 0
+          ? "border-violet-200/80 bg-violet-50/40 dark:border-violet-800/60 dark:bg-violet-950/20"
+          : "border-zinc-200/60 bg-zinc-50/40 dark:border-zinc-800/50 dark:bg-zinc-900/20",
+      )}
+    >
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left"
+        aria-expanded={expanded}
+      >
+        <span className="flex items-center gap-2">
+          <span
+            className={cn(
+              "inline-flex h-2 w-2 shrink-0 rounded-full",
+              runningCount > 0 ? "animate-pulse bg-violet-500" : "bg-zinc-400 dark:bg-zinc-600",
+            )}
+          />
+          <span className="font-medium">{summaryLabel}</span>
+        </span>
+        <span className="text-muted-foreground">{expanded ? "收起" : "展开"}</span>
+      </button>
+      {expanded ? (
+        <div className="space-y-2 border-t border-border/40 px-3 py-2">
+          {truncated.map((step) => (
+            <ReasoningStep
+              key={step.id}
+              title={step.title}
+              phase={step.phase}
+              stepId={step.stepId}
+            />
+          ))}
+          {overflow > 0 ? (
+            <div className="text-center text-muted-foreground">+{overflow} 更多步骤已折叠</div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/ToolExecutionGroup.tsx
+++ b/apps/negentropy-ui/components/ui/ToolExecutionGroup.tsx
@@ -4,7 +4,32 @@ import { useState } from "react";
 import type { ToolExecutionEntry, ToolGroupDisplayBlock } from "@/types/a2ui";
 import type { ToolProgressMap, ToolProgressSnapshot } from "@/types/common";
 import { JsonViewer } from "@/components/ui/JsonViewer";
+import { KgBuildProgressPill } from "@/components/ui/KgBuildProgressPill";
 import { cn } from "@/lib/utils";
+
+/**
+ * P3-1 · 从工具 result JSON 中抽取 KG SSE 订阅参数。
+ *
+ * 仅 ingest_paper 工具且 result.kg_status === "kg_enqueued" 时启用订阅。
+ * 命中条件外一律返回 null（前端 Pill 组件相应渲染 null，零回归）。
+ */
+function extractKgSubscription(tool: ToolExecutionEntry):
+  | { corpusId: string; enqueued: true }
+  | null {
+  if (tool.name !== "ingest_paper") return null;
+  if (!tool.result) return null;
+  try {
+    const parsed = JSON.parse(tool.result) as {
+      kg_status?: string;
+      corpus_id?: string;
+    };
+    if (parsed?.kg_status !== "kg_enqueued") return null;
+    if (typeof parsed.corpus_id !== "string" || !parsed.corpus_id) return null;
+    return { corpusId: parsed.corpus_id, enqueued: true };
+  } catch {
+    return null;
+  }
+}
 
 function parseJson(value: string | undefined): unknown {
   if (!value || !value.trim()) {
@@ -161,6 +186,10 @@ function ToolExecutionCard({
             )}
           </div>
           {showProgress && <ToolProgressBar progress={progress} />}
+          {(() => {
+            const sub = extractKgSubscription(tool);
+            return sub ? <KgBuildProgressPill corpusId={sub.corpusId} enqueued={sub.enqueued} /> : null;
+          })()}
         </div>
         <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-zinc-400">
           {expanded ? "收起" : "展开"}

--- a/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * KgBuildProgressPill 单元测试（P3-1 G1c）
+ *
+ * 验证：
+ * - enqueued=false 或 corpusId=null 时返回 null（零回归）；
+ * - 订阅 SSE 后渲染百分比 + 状态标签；
+ * - 收到 terminal 状态后自动 close EventSource；
+ * - onerror 时显示 error 状态。
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { KgBuildProgressPill } from "@/components/ui/KgBuildProgressPill";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  onopen: ((e: Event) => void) | null = null;
+  closed = false;
+
+  constructor(url: string, init?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  send(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+  fail() {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+describe("KgBuildProgressPill", () => {
+  let originalES: typeof EventSource;
+
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    originalES = global.EventSource;
+    // @ts-expect-error - assign mock in test env
+    global.EventSource = MockEventSource;
+  });
+
+  afterEach(() => {
+    global.EventSource = originalES;
+    vi.restoreAllMocks();
+  });
+
+  it("enqueued=false 时返回 null（零回归保护）", () => {
+    const { container } = render(<KgBuildProgressPill corpusId="c-123" enqueued={false} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("corpusId 缺失时不订阅", () => {
+    render(<KgBuildProgressPill corpusId={null} enqueued={true} />);
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("enqueued=true 时订阅 SSE 并渲染初始 pending 状态", () => {
+    render(<KgBuildProgressPill corpusId="abc-123" enqueued={true} />);
+    const pill = screen.getByTestId("kg-build-progress");
+    expect(pill).toHaveAttribute("data-kg-status", "pending");
+    expect(pill).toHaveTextContent("排队中");
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toContain("/api/knowledge/base/abc-123/graph/build-runs/latest/progress");
+    expect(MockEventSource.instances[0].withCredentials).toBe(true);
+  });
+
+  it("收到 running 事件后展示百分比 + 实体/关系数", () => {
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.send({ status: "running", progress_percent: 0.62, entity_count: 12, relation_count: 7, run_id: "r1" });
+    });
+    const pill = screen.getByTestId("kg-build-progress");
+    expect(pill).toHaveAttribute("data-kg-status", "running");
+    expect(pill).toHaveTextContent("62%");
+    expect(pill).toHaveTextContent("12 实体");
+    expect(pill).toHaveTextContent("7 关系");
+    expect(es.closed).toBe(false);
+  });
+
+  it("收到 completed 终态后自动关闭 EventSource", () => {
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.send({ status: "completed", progress_percent: 1, entity_count: 20, relation_count: 15 });
+    });
+    expect(screen.getByTestId("kg-build-progress")).toHaveAttribute("data-kg-status", "completed");
+    expect(es.closed).toBe(true);
+  });
+
+  it("收到 failed 终态展示 error_message", () => {
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.send({ status: "failed", error_message: "LLM extractor timeout", progress_percent: 0.3 });
+    });
+    expect(screen.getByTestId("kg-build-progress")).toHaveTextContent("LLM extractor timeout");
+    expect(es.closed).toBe(true);
+  });
+
+  it("idle 状态（无 active run）→ 展示无活跃构建文案", () => {
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.send({ status: "idle" });
+    });
+    expect(screen.getByTestId("kg-build-progress")).toHaveTextContent("无活跃构建");
+    expect(es.closed).toBe(true);
+  });
+
+  it("EventSource onerror 时显示 error 状态并关闭", () => {
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    act(() => {
+      es.fail();
+    });
+    expect(screen.getByTestId("kg-build-progress")).toHaveAttribute("data-kg-status", "error");
+    expect(es.closed).toBe(true);
+  });
+
+  it("非法 JSON event 应 fail-soft 不抛", () => {
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    expect(() =>
+      act(() => {
+        es.onmessage?.({ data: "not json {" } as MessageEvent);
+      }),
+    ).not.toThrow();
+  });
+
+  it("组件卸载时关闭 EventSource（资源清理）", () => {
+    const { unmount } = render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    const es = MockEventSource.instances[0];
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/ReasoningPanel.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/ReasoningPanel.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * ReasoningPanel 单元测试（P2-4 G3）
+ *
+ * 验证：
+ * - mergeSteps 同 stepId 去重 + finished 优先；
+ * - 默认收起 / 点击展开 / localStorage 持久化；
+ * - 50 步硬上限 + "+N 更多" 折叠；
+ * - 空 steps 不渲染（hasReasoning 守卫）。
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  ReasoningPanel,
+  mergeSteps,
+  type ReasoningStepData,
+} from "@/components/ui/ReasoningPanel";
+
+const STORAGE_KEY = "home.reasoning_panel.expanded";
+
+const step = (id: string, stepId: string, phase: "started" | "finished", title = "PerceptionFaculty"): ReasoningStepData => ({
+  id,
+  stepId,
+  phase,
+  title,
+});
+
+describe("mergeSteps", () => {
+  it("同 stepId 的 started 后接 finished → 仅保留 finished", () => {
+    const out = mergeSteps([step("a", "s1", "started"), step("b", "s1", "finished")]);
+    expect(out).toHaveLength(1);
+    expect(out[0].phase).toBe("finished");
+  });
+
+  it("不同 stepId 互不影响", () => {
+    const out = mergeSteps([
+      step("a", "s1", "started"),
+      step("b", "s2", "started"),
+      step("c", "s1", "finished"),
+    ]);
+    expect(out).toHaveLength(2);
+    const s1 = out.find((s) => s.stepId === "s1");
+    const s2 = out.find((s) => s.stepId === "s2");
+    expect(s1?.phase).toBe("finished");
+    expect(s2?.phase).toBe("started");
+  });
+
+  it("started → started：保留首条（去重）", () => {
+    const out = mergeSteps([step("a", "s1", "started"), step("b", "s1", "started")]);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("a");
+  });
+
+  it("空数组 → 空", () => {
+    expect(mergeSteps([])).toEqual([]);
+  });
+});
+
+describe("ReasoningPanel", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("空 steps 不渲染（避免空容器污染 bubble）", () => {
+    const { container } = render(<ReasoningPanel steps={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("默认收起，summary 显示步数与 running 状态", () => {
+    render(<ReasoningPanel steps={[step("a", "s1", "started")]} />);
+    const panel = screen.getByTestId("reasoning-panel");
+    expect(panel).toHaveAttribute("data-expanded", "false");
+    expect(screen.getByText(/推理中.*1.*步/)).toBeInTheDocument();
+  });
+
+  it("全 finished 时 summary 显示 '思考完成'", () => {
+    render(
+      <ReasoningPanel
+        steps={[step("a", "s1", "finished"), step("b", "s2", "finished")]}
+      />,
+    );
+    expect(screen.getByText(/思考完成.*2.*步/)).toBeInTheDocument();
+  });
+
+  it("点击展开后 localStorage 写入 '1'，再点收起写 '0'", () => {
+    render(<ReasoningPanel steps={[step("a", "s1", "finished")]} />);
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(screen.getByTestId("reasoning-panel")).toHaveAttribute("data-expanded", "true");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1");
+
+    fireEvent.click(button);
+    expect(screen.getByTestId("reasoning-panel")).toHaveAttribute("data-expanded", "false");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("0");
+  });
+
+  it("挂载时从 localStorage 恢复展开状态", () => {
+    window.localStorage.setItem(STORAGE_KEY, "1");
+    render(<ReasoningPanel steps={[step("a", "s1", "finished")]} />);
+    // 等待 useEffect
+    return Promise.resolve().then(() => {
+      expect(screen.getByTestId("reasoning-panel")).toHaveAttribute("data-expanded", "true");
+    });
+  });
+
+  it("超过 50 步硬上限 → 显示 '+N 更多步骤已折叠'", () => {
+    const many = Array.from({ length: 60 }, (_, i) => step(`s-${i}`, `step-${i}`, "finished"));
+    render(<ReasoningPanel steps={many} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/\+10 更多步骤已折叠/)).toBeInTheDocument();
+  });
+
+  it("aria-expanded 属性反映折叠状态（可访问性）", () => {
+    render(<ReasoningPanel steps={[step("a", "s1", "finished")]} />);
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/approval.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/approval.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * P3-2 Approval UI 单测：
+ * - ApprovalPolicySelector 持久化 + 切换；
+ * - ApprovalDialog 渲染最早 pending + Approve / Deny / 错误兜底。
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import {
+  ApprovalPolicySelector,
+  DEFAULT_APPROVAL_POLICY,
+  useApprovalPolicy,
+} from "@/components/ui/ApprovalPolicySelector";
+import { ApprovalDialog } from "@/components/ui/ApprovalDialog";
+
+const STORAGE_KEY = "home.approval_policy";
+
+describe("ApprovalPolicySelector", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("默认 per_tool（与后端 DEFAULT_POLICY 对齐）", () => {
+    render(<ApprovalPolicySelector />);
+    const wrapper = screen.getByTestId("approval-policy-selector");
+    expect(wrapper).toHaveAttribute("data-policy", DEFAULT_APPROVAL_POLICY);
+    expect(DEFAULT_APPROVAL_POLICY).toBe("per_tool");
+  });
+
+  it("切换 always 后写入 localStorage 并 dispatch storage event", () => {
+    render(<ApprovalPolicySelector />);
+    const select = screen.getByLabelText("审批策略") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "always" } });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("always");
+    expect(screen.getByTestId("approval-policy-selector")).toHaveAttribute("data-policy", "always");
+  });
+
+  it("切换 never 后再切回 per_tool", () => {
+    render(<ApprovalPolicySelector />);
+    const select = screen.getByLabelText("审批策略") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "never" } });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("never");
+    fireEvent.change(select, { target: { value: "per_tool" } });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("per_tool");
+  });
+
+  it("非法 storage 值回退到默认", () => {
+    window.localStorage.setItem(STORAGE_KEY, "invalid_value");
+    render(<ApprovalPolicySelector />);
+    expect(screen.getByTestId("approval-policy-selector")).toHaveAttribute(
+      "data-policy",
+      DEFAULT_APPROVAL_POLICY,
+    );
+  });
+
+  it("useApprovalPolicy 返回当前值与 setter", () => {
+    function Probe() {
+      const { mode } = useApprovalPolicy();
+      return <span data-testid="probe">{mode}</span>;
+    }
+    window.localStorage.setItem(STORAGE_KEY, "always");
+    render(<Probe />);
+    expect(screen.getByTestId("probe")).toHaveTextContent("always");
+  });
+});
+
+describe("ApprovalDialog", () => {
+  it("pending 为空时返回 null（零回归）", () => {
+    const { container } = render(<ApprovalDialog pending={null} onRespond={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("空 dict 返回 null", () => {
+    const { container } = render(<ApprovalDialog pending={{}} onRespond={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("有 pending 时渲染 modal + 工具名 + label + 风险标签", () => {
+    render(
+      <ApprovalDialog
+        pending={{
+          a1: {
+            action_id: "a1",
+            tool_name: "write_file",
+            label: "即将写入 /tmp/important",
+            risk_tier: "high",
+          },
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+    const modal = screen.getByTestId("approval-dialog");
+    expect(modal).toHaveAttribute("data-action-id", "a1");
+    expect(modal).toHaveAttribute("data-risk-tier", "high");
+    expect(modal).toHaveTextContent("write_file");
+    expect(modal).toHaveTextContent("即将写入 /tmp/important");
+    expect(modal).toHaveTextContent("高风险");
+  });
+
+  it("多条 pending 按 requested_at 升序选首条", () => {
+    render(
+      <ApprovalDialog
+        pending={{
+          a2: { action_id: "a2", tool_name: "send_email", label: "later", requested_at: 200 },
+          a1: { action_id: "a1", tool_name: "write_file", label: "earlier", requested_at: 100 },
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("approval-dialog")).toHaveAttribute("data-action-id", "a1");
+  });
+
+  it("Approve 按钮调用 onRespond('approved') + reason", async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalDialog
+        pending={{ a1: { action_id: "a1", tool_name: "send_email", label: "x" } }}
+        onRespond={onRespond}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("approval-reason"), { target: { value: "looks good" } });
+    fireEvent.click(screen.getByTestId("approval-approve"));
+    await waitFor(() =>
+      expect(onRespond).toHaveBeenCalledWith("a1", "approved", "looks good"),
+    );
+  });
+
+  it("Deny 按钮调用 onRespond('denied')", async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalDialog
+        pending={{ a1: { action_id: "a1", tool_name: "send_email", label: "x" } }}
+        onRespond={onRespond}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("approval-deny"));
+    await waitFor(() => expect(onRespond).toHaveBeenCalledWith("a1", "denied", undefined));
+  });
+
+  it("onRespond 抛错时显示 approval-error 文案", async () => {
+    const onRespond = vi.fn().mockRejectedValue(new Error("backend offline"));
+    render(
+      <ApprovalDialog
+        pending={{ a1: { action_id: "a1", tool_name: "send_email", label: "x" } }}
+        onRespond={onRespond}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("approval-approve"));
+    });
+    expect(screen.getByTestId("approval-error")).toHaveTextContent("backend offline");
+  });
+
+  it("args_preview 非空时渲染预览块；空 dict 时不渲染", () => {
+    const { rerender } = render(
+      <ApprovalDialog
+        pending={{
+          a1: {
+            action_id: "a1",
+            tool_name: "write_file",
+            label: "x",
+            args_preview: { path: "/etc/hosts" },
+          },
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("approval-args-preview")).toHaveTextContent("/etc/hosts");
+
+    rerender(
+      <ApprovalDialog
+        pending={{ a1: { action_id: "a1", tool_name: "write_file", label: "x", args_preview: {} } }}
+        onRespond={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("approval-args-preview")).toBeNull();
+  });
+});

--- a/apps/negentropy-ui/tests/unit/utils/citation-parser.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/citation-parser.test.ts
@@ -125,7 +125,7 @@ describe("extractCitationsFromToolCalls", () => {
     expect(cites[0].arxivId).toBe("2310.04406");
   });
 
-  it("跨工具结果去重（按 arxiv_id）+ 重新分配 1..N", () => {
+  it("跨工具结果去重（按 arxiv_id）+ 保留原 citation_id（与 LLM 正文 [N] 对齐）", () => {
     const toolCalls = [
       okCall("search_knowledge_base", {
         results: [

--- a/apps/negentropy-ui/tests/unit/utils/citation-parser.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/citation-parser.test.ts
@@ -1,0 +1,251 @@
+/**
+ * citation-parser 单元测试（P2-3 G2）
+ *
+ * 验证 [N] 解析、聚合、跳转链接构造的核心契约：
+ * - 严格 regex 不误伤 markdown link / 脚注；
+ * - 多工具调用结果去重 + 重新分配序号；
+ * - 旧消息无 citations 字段时零回归。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  attachCitations,
+  citationHref,
+  extractCitationsFromToolCalls,
+  parseArxivIdFromUri,
+  splitCitationTokens,
+} from "@/utils/citation-parser";
+import type { ChatMessage, ToolCallInfo } from "@/types/common";
+
+const okCall = (name: string, payload: unknown): ToolCallInfo => ({
+  id: `call-${name}-${Math.random().toString(36).slice(2, 8)}`,
+  name,
+  args: "{}",
+  result: JSON.stringify(payload),
+  status: "completed",
+});
+
+describe("parseArxivIdFromUri", () => {
+  it("从 PDF URL 中提取 arxiv id", () => {
+    expect(parseArxivIdFromUri("https://arxiv.org/pdf/2501.12345.pdf")).toBe("2501.12345");
+    expect(parseArxivIdFromUri("https://arxiv.org/abs/2310.11366v2")).toBe("2310.11366");
+  });
+
+  it("非 arxiv URL 返回 null（不误识别）", () => {
+    expect(parseArxivIdFromUri("https://example.com/doc.pdf")).toBeNull();
+    expect(parseArxivIdFromUri(null)).toBeNull();
+    expect(parseArxivIdFromUri(undefined)).toBeNull();
+    expect(parseArxivIdFromUri("")).toBeNull();
+  });
+});
+
+describe("splitCitationTokens", () => {
+  it("识别独立 [1] 标号", () => {
+    const segs = splitCitationTokens("Reflexion [1] 是一种自我反思方法。");
+    expect(segs).toHaveLength(3);
+    expect(segs[0]).toEqual({ kind: "text", content: "Reflexion " });
+    expect(segs[1]).toEqual({ kind: "citation", id: 1, raw: "[1]" });
+    expect(segs[2]).toEqual({ kind: "text", content: " 是一种自我反思方法。" });
+  });
+
+  it("识别多个 [N] 标号 + 中文混排", () => {
+    const segs = splitCitationTokens("ReAct [1] 与 Reflexion [2] 都属于 self-improvement 路线 [3]。");
+    const cites = segs.filter((s) => s.kind === "citation");
+    expect(cites).toHaveLength(3);
+    expect(cites.map((c) => (c.kind === "citation" ? c.id : -1))).toEqual([1, 2, 3]);
+  });
+
+  it("不误伤 markdown link `[label](url)`", () => {
+    const segs = splitCitationTokens("查看 [Self-RAG paper](https://arxiv.org/abs/2310.11511) 详情。");
+    const cites = segs.filter((s) => s.kind === "citation");
+    expect(cites).toHaveLength(0);
+  });
+
+  it("不误伤脚注 `[^1]`", () => {
+    const segs = splitCitationTokens("这是脚注 [^1] 形式。");
+    const cites = segs.filter((s) => s.kind === "citation");
+    expect(cites).toHaveLength(0);
+  });
+
+  it("不误伤定义列表 `[label]:`", () => {
+    const segs = splitCitationTokens("[1]: https://example.com");
+    const cites = segs.filter((s) => s.kind === "citation");
+    expect(cites).toHaveLength(0);
+  });
+
+  it("空 / 纯文本场景不抛", () => {
+    expect(splitCitationTokens("")).toEqual([]);
+    expect(splitCitationTokens("纯文本无引用")).toEqual([{ kind: "text", content: "纯文本无引用" }]);
+  });
+});
+
+describe("extractCitationsFromToolCalls", () => {
+  it("从 search_knowledge_base 的 results 中聚合", () => {
+    const toolCalls = [
+      okCall("search_knowledge_base", {
+        status: "success",
+        results: [
+          {
+            citation_id: 1,
+            formatted_citation: '[1] Asai et al., "Self-RAG," arXiv:2310.11511, 2024.',
+            source_uri: "https://arxiv.org/pdf/2310.11511.pdf",
+          },
+          {
+            citation_id: 2,
+            formatted_citation: '[2] Edge et al., "GraphRAG," arXiv:2404.16130, 2024.',
+            source_uri: "https://arxiv.org/pdf/2404.16130.pdf",
+          },
+        ],
+      }),
+    ];
+    const cites = extractCitationsFromToolCalls(toolCalls);
+    expect(cites).toHaveLength(2);
+    expect(cites[0].id).toBe(1);
+    expect(cites[0].arxivId).toBe("2310.11511");
+    expect(cites[1].arxivId).toBe("2404.16130");
+  });
+
+  it("从 search_knowledge_graph_with_papers 的 papers 中聚合", () => {
+    const toolCalls = [
+      okCall("search_knowledge_graph_with_papers", {
+        status: "success",
+        kg_status: "graph_hit",
+        papers: [
+          {
+            citation_id: 1,
+            arxiv_id: "2310.04406",
+            formatted_citation: '[1] Zhou et al., "LATS," arXiv:2310.04406, 2024.',
+            source_uri: "https://arxiv.org/pdf/2310.04406.pdf",
+          },
+        ],
+      }),
+    ];
+    const cites = extractCitationsFromToolCalls(toolCalls);
+    expect(cites).toHaveLength(1);
+    expect(cites[0].arxivId).toBe("2310.04406");
+  });
+
+  it("跨工具结果去重（按 arxiv_id）+ 重新分配 1..N", () => {
+    const toolCalls = [
+      okCall("search_knowledge_base", {
+        results: [
+          {
+            citation_id: 1,
+            formatted_citation: '[1] Asai 2024',
+            source_uri: "https://arxiv.org/pdf/2310.11511.pdf",
+          },
+        ],
+      }),
+      okCall("search_knowledge_graph_with_papers", {
+        papers: [
+          {
+            citation_id: 1, // 故意冲突
+            formatted_citation: '[1] Asai 2024',
+            source_uri: "https://arxiv.org/pdf/2310.11511.pdf",
+            arxiv_id: "2310.11511",
+          },
+          {
+            citation_id: 2,
+            formatted_citation: '[2] Edge 2024',
+            source_uri: "https://arxiv.org/pdf/2404.16130.pdf",
+            arxiv_id: "2404.16130",
+          },
+        ],
+      }),
+    ];
+    const cites = extractCitationsFromToolCalls(toolCalls);
+    expect(cites).toHaveLength(2);
+    expect(cites.map((c) => c.id)).toEqual([1, 2]);
+    expect(cites.map((c) => c.arxivId)).toEqual(["2310.11511", "2404.16130"]);
+  });
+
+  it("忽略非 citation 工具的 result（即使含 formatted_citation 字段）", () => {
+    const toolCalls = [
+      okCall("save_to_memory", {
+        results: [{ citation_id: 1, formatted_citation: "[1] should not leak" }],
+      }),
+    ];
+    expect(extractCitationsFromToolCalls(toolCalls)).toEqual([]);
+  });
+
+  it("result 不是合法 JSON 时 fail-soft 不抛", () => {
+    const bad: ToolCallInfo = {
+      id: "x",
+      name: "search_knowledge_base",
+      args: "{}",
+      result: "not json {",
+      status: "completed",
+    };
+    expect(extractCitationsFromToolCalls([bad])).toEqual([]);
+  });
+
+  it("undefined / 空数组 → 空 citations（旧消息零回归）", () => {
+    expect(extractCitationsFromToolCalls(undefined)).toEqual([]);
+    expect(extractCitationsFromToolCalls([])).toEqual([]);
+  });
+});
+
+describe("attachCitations", () => {
+  it("有 toolCalls 时注入 citations 字段", () => {
+    const msg: ChatMessage = {
+      id: "m1",
+      role: "assistant",
+      content: "Reflexion [1]",
+      toolCalls: [
+        okCall("search_knowledge_base", {
+          results: [
+            {
+              citation_id: 1,
+              formatted_citation: '[1] Shinn 2023',
+              source_uri: "https://arxiv.org/pdf/2303.11366.pdf",
+            },
+          ],
+        }),
+      ],
+    };
+    const out = attachCitations(msg);
+    expect(out.citations).toHaveLength(1);
+    expect(out.citations?.[0].id).toBe(1);
+  });
+
+  it("已有 citations 时不重复注入（保持引用稳定）", () => {
+    const msg: ChatMessage = {
+      id: "m1",
+      role: "assistant",
+      content: "x",
+      citations: [{ id: 1, text: "[1] preexisting" }],
+      toolCalls: [
+        okCall("search_knowledge_base", {
+          results: [{ citation_id: 99, formatted_citation: "[99] new" }],
+        }),
+      ],
+    };
+    const out = attachCitations(msg);
+    expect(out.citations).toHaveLength(1);
+    expect(out.citations?.[0].text).toBe("[1] preexisting");
+  });
+
+  it("无 toolCalls / 不命中工具 → 不挂 citations 字段（避免空数组污染）", () => {
+    const msg: ChatMessage = { id: "m1", role: "user", content: "hello" };
+    const out = attachCitations(msg);
+    expect(out.citations).toBeUndefined();
+  });
+});
+
+describe("citationHref", () => {
+  it("有 arxivId → 跳 abs 页", () => {
+    expect(citationHref({ id: 1, text: "x", arxivId: "2310.11511" })).toBe(
+      "https://arxiv.org/abs/2310.11511",
+    );
+  });
+
+  it("无 arxivId 时回退 sourceUri", () => {
+    expect(citationHref({ id: 1, text: "x", sourceUri: "https://example.com/doc.pdf" })).toBe(
+      "https://example.com/doc.pdf",
+    );
+  });
+
+  it("两者都无 → null（前端按非链接渲染）", () => {
+    expect(citationHref({ id: 1, text: "x" })).toBeNull();
+  });
+});

--- a/apps/negentropy-ui/types/common.ts
+++ b/apps/negentropy-ui/types/common.ts
@@ -104,6 +104,24 @@ export type ToolProgressSnapshot = {
 export type ToolProgressMap = Record<string, ToolProgressSnapshot>;
 
 /**
+ * Citation 引用条目（P2-3 G2 · IEEE 风格）
+ *
+ * 后端 `search_knowledge_base` / `search_knowledge_graph_with_papers` 在每条返回结果中注入
+ * `citation_id` + `formatted_citation`。前端把这些字段聚合到 ChatMessage.citations，
+ * 并在尾注块中按序号渲染。
+ */
+export type Citation = {
+  /** 1-based 序号（与 [N] 标号对齐） */
+  id: number;
+  /** IEEE 风格字符串：`[N] Author et al., "Title," arXiv:ID, Year.` */
+  text: string;
+  /** 源 URL（可点击跳转） */
+  sourceUri?: string | null;
+  /** arXiv ID（如有，用于跳转 https://arxiv.org/abs/{id}） */
+  arxivId?: string | null;
+};
+
+/**
  * 聊天消息类型
  *
  * 从 Message 类型提取必要的字段，确保类型兼容性
@@ -124,6 +142,12 @@ export type ChatMessage = Pick<Message, "id" | "role"> & {
   streaming?: boolean;
   /** 关联的工具调用列表（内嵌显示在消息气泡中） */
   toolCalls?: ToolCallInfo[];
+  /**
+   * 引用列表（P2-3 G2）— 从 toolCalls.result 中聚合的 search_knowledge_base /
+   * search_knowledge_graph_with_papers 的引用条目。
+   * 旧消息无此字段时 MarkdownContent 走零回归分支，与既有渲染等价。
+   */
+  citations?: Citation[];
 };
 
 export type RoleResolutionSource =

--- a/apps/negentropy-ui/utils/citation-parser.ts
+++ b/apps/negentropy-ui/utils/citation-parser.ts
@@ -1,0 +1,163 @@
+/**
+ * P2-3 G2 · Citation Parser & Aggregator
+ *
+ * 职责（围绕「最小干预」）：
+ * 1. `extractCitationsFromToolCalls`：从 `ChatMessage.toolCalls` 的 result JSON 中聚合
+ *    `search_knowledge_base` / `search_knowledge_graph_with_papers` 返回的引用条目。
+ *    去重 by (arxivId || sourceUri || text)，按 id 排序。
+ * 2. `parseArxivIdFromUri`：从 source_uri 推断 arxiv id（用于点击跳转 abs 页）。
+ *
+ * 不直接转换 markdown：[N] 标号的高亮交给 MessageBubble 中的 inline 替换逻辑（轻量正则，
+ * 不引入新 remark 插件，避免污染 defaultRemarkPlugins 全局链）。
+ *
+ * 参考：Self-RAG (Asai et al., ICLR 2024) 强调 citation 必须 stable + 可追溯；本工具是
+ * 「来源锚定」契约的前端落点。
+ */
+import type { Citation, ChatMessage, ToolCallInfo } from "@/types/common";
+
+/** 后端 search_knowledge_base / search_knowledge_graph_with_papers 单条结果的最小契约 */
+type RawCitationLike = {
+  citation_id?: number;
+  formatted_citation?: string;
+  source_uri?: string | null;
+  metadata?: Record<string, unknown> | null;
+  // KG 反向工具的 paper-level 字段
+  arxiv_id?: string | null;
+};
+
+const ARXIV_ID_RE = /\b(\d{4}\.\d{4,5})(v\d+)?\b/;
+
+/** 从 source_uri 中推断 arxiv id（如 https://arxiv.org/pdf/2501.12345.pdf -> 2501.12345）。 */
+export function parseArxivIdFromUri(uri: string | null | undefined): string | null {
+  if (!uri) return null;
+  const match = uri.match(ARXIV_ID_RE);
+  return match ? match[1] : null;
+}
+
+/** 从单条原始结果中抽出 arxiv id（优先字段 → metadata → uri 推断）。 */
+function pickArxivId(raw: RawCitationLike): string | null {
+  if (raw.arxiv_id) return String(raw.arxiv_id);
+  const meta = raw.metadata ?? {};
+  const fromMeta = meta && typeof meta === "object" ? (meta as Record<string, unknown>)["arxiv_id"] : null;
+  if (typeof fromMeta === "string" && fromMeta.trim()) return fromMeta.trim();
+  return parseArxivIdFromUri(raw.source_uri);
+}
+
+/** 把后端原始 result 序列归一为前端 Citation。citation_id 缺失时按数组下标兜底。 */
+function normalizeCitations(rawList: RawCitationLike[]): Citation[] {
+  const out: Citation[] = [];
+  rawList.forEach((raw, idx) => {
+    const text = (raw.formatted_citation ?? "").trim();
+    if (!text) return;
+    out.push({
+      id: typeof raw.citation_id === "number" ? raw.citation_id : idx + 1,
+      text,
+      sourceUri: raw.source_uri ?? null,
+      arxivId: pickArxivId(raw),
+    });
+  });
+  return out;
+}
+
+/** 兼容三种工具结果形态：{results:[...]} / {papers:[...]} / 直接的数组。 */
+function pickCitationCandidates(parsed: unknown): RawCitationLike[] {
+  if (!parsed || typeof parsed !== "object") return [];
+  const obj = parsed as Record<string, unknown>;
+  for (const key of ["results", "papers"]) {
+    const v = obj[key];
+    if (Array.isArray(v)) return v.filter((x) => x && typeof x === "object") as RawCitationLike[];
+  }
+  if (Array.isArray(parsed)) return parsed.filter((x) => x && typeof x === "object") as RawCitationLike[];
+  return [];
+}
+
+/**
+ * 从工具调用结果中聚合 citations。
+ *
+ * 仅处理 `search_knowledge_base` 与 `search_knowledge_graph_with_papers` 两个工具；
+ * 其他工具（即使 result JSON 中含 formatted_citation 字段）一律忽略，避免误聚合。
+ */
+export function extractCitationsFromToolCalls(toolCalls: ToolCallInfo[] | undefined): Citation[] {
+  if (!toolCalls || toolCalls.length === 0) return [];
+  const seen = new Set<string>();
+  const aggregated: Citation[] = [];
+
+  for (const call of toolCalls) {
+    if (!call?.name) continue;
+    const isCitationTool =
+      call.name === "search_knowledge_base" || call.name === "search_knowledge_graph_with_papers";
+    if (!isCitationTool || !call.result) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(call.result);
+    } catch {
+      continue; // result 不是合法 JSON 则跳过 —— fail-soft 不抛
+    }
+
+    const candidates = pickCitationCandidates(parsed);
+    const normalized = normalizeCitations(candidates);
+
+    for (const cite of normalized) {
+      const dedupKey = (cite.arxivId ?? cite.sourceUri ?? cite.text).toLowerCase();
+      if (seen.has(dedupKey)) continue;
+      seen.add(dedupKey);
+      aggregated.push(cite);
+    }
+  }
+
+  // 按 id 升序，重新分配连续 1..N（避免不同工具调用的 citation_id 冲突）
+  return aggregated
+    .sort((a, b) => a.id - b.id)
+    .map((c, idx) => ({ ...c, id: idx + 1 }));
+}
+
+/** 给 ChatMessage 附加聚合后的 citations 字段（不变更原对象）。 */
+export function attachCitations(message: ChatMessage): ChatMessage {
+  if (message.citations && message.citations.length > 0) return message;
+  const citations = extractCitationsFromToolCalls(message.toolCalls);
+  if (citations.length === 0) return message;
+  return { ...message, citations };
+}
+
+/**
+ * 解析正文中 [N] 形态的 token，返回 { hasCitations, segments }。
+ *
+ * 严格 regex 规避 markdown link `[label](url)` 与脚注语法 `[^N]` —— 避免双重渲染。
+ */
+const CITATION_TOKEN_RE = /(?<![\w\\^])\[(\d+)\](?!\(|:)/g;
+
+export type CitationSegment =
+  | { kind: "text"; content: string }
+  | { kind: "citation"; id: number; raw: string };
+
+export function splitCitationTokens(text: string): CitationSegment[] {
+  if (!text) return [];
+  const segments: CitationSegment[] = [];
+  let lastIdx = 0;
+  let match: RegExpExecArray | null;
+  CITATION_TOKEN_RE.lastIndex = 0;
+  while ((match = CITATION_TOKEN_RE.exec(text)) !== null) {
+    if (match.index > lastIdx) {
+      segments.push({ kind: "text", content: text.slice(lastIdx, match.index) });
+    }
+    const id = Number(match[1]);
+    if (Number.isFinite(id) && id > 0) {
+      segments.push({ kind: "citation", id, raw: match[0] });
+    } else {
+      segments.push({ kind: "text", content: match[0] });
+    }
+    lastIdx = match.index + match[0].length;
+  }
+  if (lastIdx < text.length) {
+    segments.push({ kind: "text", content: text.slice(lastIdx) });
+  }
+  return segments;
+}
+
+/** 给定 arxivId，构造 abs 页跳转 URL（无 arxivId 时回退 sourceUri）。 */
+export function citationHref(citation: Citation): string | null {
+  if (citation.arxivId) return `https://arxiv.org/abs/${citation.arxivId}`;
+  if (citation.sourceUri) return citation.sourceUri;
+  return null;
+}

--- a/apps/negentropy-ui/utils/citation-parser.ts
+++ b/apps/negentropy-ui/utils/citation-parser.ts
@@ -106,10 +106,10 @@ export function extractCitationsFromToolCalls(toolCalls: ToolCallInfo[] | undefi
     }
   }
 
-  // 按 id 升序，重新分配连续 1..N（避免不同工具调用的 citation_id 冲突）
-  return aggregated
-    .sort((a, b) => a.id - b.id)
-    .map((c, idx) => ({ ...c, id: idx + 1 }));
+  // 按 id 升序展示，但**保留原 citation_id**：LLM 在正文里写下的 [N] 必须与
+  // 工具结果中的 citation_id 一致，否则正文 [N] 会落空或指错。多工具混排导致 id
+  // 区间交错时优先保证 [N] 的可达性，重号场景由上层 prompt 通过 fallback 语义规避。
+  return aggregated.sort((a, b) => a.id - b.id);
 }
 
 /** 给 ChatMessage 附加聚合后的 citations 字段（不变更原对象）。 */

--- a/apps/negentropy/scripts/find_dup_arxiv_ids.py
+++ b/apps/negentropy/scripts/find_dup_arxiv_ids.py
@@ -1,0 +1,78 @@
+"""扫描 ``negentropy.knowledge`` 中重复入库的 arxiv 论文 chunk。
+
+只读脚本，不写任何数据。Phase 2 P2-1 引入 ``ingest_paper`` 幂等去重之前用于体检：
+- 若发现某 ``arxiv_id`` 横跨多个 ``source_uri``（多次 ingest 的实际证据），后续可结合
+  ``ingest_paper`` 的 ``status: already_ingested`` 状态确认未来不会再增；
+- 若 chunk_count 异常（>200），可能是 PDF 解析切得过碎，与本 P2-1 无关但可顺带记录。
+
+用法：
+    uv run python apps/negentropy/scripts/find_dup_arxiv_ids.py [--top N]
+
+输出（CSV 风格，stdout）：
+    arxiv_id,source_uri_count,chunk_count,first_seen_at,latest_seen_at
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from negentropy.config import settings
+
+
+async def _scan(limit: int) -> int:
+    engine = create_async_engine(settings.database_url, echo=False)
+    try:
+        async with engine.connect() as conn:
+            stmt = text(
+                """
+                SELECT
+                    metadata->>'arxiv_id' AS arxiv_id,
+                    COUNT(DISTINCT source_uri) AS source_uri_count,
+                    COUNT(*) AS chunk_count,
+                    MIN(created_at) AS first_seen_at,
+                    MAX(created_at) AS latest_seen_at
+                FROM negentropy.knowledge
+                WHERE metadata ? 'arxiv_id'
+                GROUP BY metadata->>'arxiv_id'
+                HAVING COUNT(DISTINCT source_uri) > 1
+                ORDER BY chunk_count DESC
+                LIMIT :limit
+                """
+            )
+            result = await conn.execute(stmt, {"limit": limit})
+            rows = result.all()
+
+            print("arxiv_id,source_uri_count,chunk_count,first_seen_at,latest_seen_at")
+            for row in rows:
+                print(
+                    ",".join(
+                        [
+                            str(row.arxiv_id or ""),
+                            str(row.source_uri_count),
+                            str(row.chunk_count),
+                            row.first_seen_at.isoformat() if row.first_seen_at else "",
+                            row.latest_seen_at.isoformat() if row.latest_seen_at else "",
+                        ]
+                    )
+                )
+            return len(rows)
+    finally:
+        await engine.dispose()
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--top", type=int, default=200, help="最多输出条数（默认 200）")
+    args = parser.parse_args()
+    count = await _scan(args.top)
+    print(f"# total_duplicate_groups={count}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/apps/negentropy/src/negentropy/agents/approval.py
+++ b/apps/negentropy/src/negentropy/agents/approval.py
@@ -188,9 +188,10 @@ def request_approval(
         )
         state = tool_context.state
         existing = state.get("pending_approvals")
-        bucket: dict[str, Any] = existing if isinstance(existing, dict) else {}
-        bucket[action_id] = req.to_state_payload()
-        state["pending_approvals"] = bucket
+        existing_dict = existing if isinstance(existing, dict) else {}
+        # 单次赋值（不就地 mutate state 持有的 dict）：避免与并发 request_approval
+        # 共享同一份 bucket 引用、亦避免「先读取-再 setitem」之间被其他写入路径覆盖。
+        state["pending_approvals"] = {**existing_dict, action_id: req.to_state_payload()}
         logger.info(
             "approval_request_emitted",
             tool_name=tool_name,
@@ -215,14 +216,13 @@ def consume_approval_response(tool_context: Any, action_id: str) -> ApprovalResp
         responses = state.get("approval_responses")
         if not isinstance(responses, dict) or action_id not in responses:
             return None
-        payload = responses.pop(action_id)
-        # 写回（清理掉已消费的 entry）
-        state["approval_responses"] = responses
+        payload = responses.get(action_id)
+        # 单次赋值（生成新 dict 而非就地 pop）：与 request_approval 同样的并发安全契约。
+        state["approval_responses"] = {k: v for k, v in responses.items() if k != action_id}
         # 同步清理 pending（如果还在）
         pending = state.get("pending_approvals")
         if isinstance(pending, dict) and action_id in pending:
-            pending.pop(action_id, None)
-            state["pending_approvals"] = pending
+            state["pending_approvals"] = {k: v for k, v in pending.items() if k != action_id}
         if not isinstance(payload, dict):
             return None
         decision = payload.get("decision")

--- a/apps/negentropy/src/negentropy/agents/approval.py
+++ b/apps/negentropy/src/negentropy/agents/approval.py
@@ -1,0 +1,252 @@
+"""Approval Gate · RFC 0002 §4.4 中断/审批门 — 协议层（P3-2 MVP）。
+
+设计目标：
+    高风险工具调用（write_file / send_email / update_knowledge_graph 等）执行**前**让用户
+    显式批准；与流式 Stop 按钮一起构成"中断 + 审批"双门户，参见 RFC 0002 §4.4 与
+    docs/conversation-foundation.md §6 HITL & Guardrails。
+
+本期范围（MVP）：
+    - 提供高风险工具白名单（``HIGH_RISK_TOOLS``）+ ``should_request_approval`` 策略判定 helper；
+    - 提供 ApprovalRequest / ApprovalResponse 数据类作为协议事实；
+    - 工具开发者按需在工具入口调 ``should_request_approval``，命中即调
+      ``request_approval(tool_context, request)`` 写入 ``state.pending_approvals``，
+      然后等待 ``state.approval_responses[action_id]`` 出现（通过 polling 或 ADK
+      LongRunningFunctionTool 模式）；
+    - **本期不强制接入具体工具**（避免改造爆炸半径）；演示与完整工具接入留 Phase 4。
+
+参考文献：
+    [1] RFC 0002 §4.4 中断/审批门（docs/rfcs/0002-ui-interaction-enhancements.md）
+    [2] T. Rebedea et al., "NeMo Guardrails: A Toolkit for Controllable and Safe LLM
+        Applications with Programmable Rails," in Proc. EMNLP System Demos, 2023.
+    [3] Y. Bai et al., "Constitutional AI: Harmlessness from AI Feedback," arXiv:2212.08073, 2022.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.agents.approval")
+
+
+# ----------------------------------------------------------------------------
+# 高风险工具白名单（按"破坏性 / 不可逆 / 副作用范围"排序）
+# ----------------------------------------------------------------------------
+#
+# 设计原则：
+# 1. 仅纳入「会改变外部状态」或「会写入持久存储」的工具；
+# 2. 纯查询 / 检索 / 内部读 → 不需要审批；
+# 3. 新增 vendor 工具时，请同步更新本列表 + chat-essentials.md「审批策略」表。
+
+HIGH_RISK_TOOLS: tuple[str, ...] = (
+    # 副作用：写入 KG / 知识库
+    "update_knowledge_graph",
+    "ingest_paper",  # 会下载 PDF + 写入知识库
+    # 副作用：执行代码 / 文件系统
+    "execute_code",
+    "write_file",
+    "shell_command",
+    # 副作用：对外通信
+    "send_email",
+    "send_notification",
+    "publish_content",
+    # 副作用：数据库写入（应用层）
+    "save_to_memory",
+)
+
+
+# ----------------------------------------------------------------------------
+# 审批策略
+# ----------------------------------------------------------------------------
+
+ApprovalPolicyMode = Literal["always", "per_tool", "never"]
+"""
+- ``always``    : 任何工具调用都弹审批（最严格）；
+- ``per_tool``  : 仅 HIGH_RISK_TOOLS 弹审批（默认）；
+- ``never``     : 关闭审批门（CI / 受信任环境用）。
+"""
+
+DEFAULT_POLICY: ApprovalPolicyMode = "per_tool"
+
+
+@dataclass(frozen=True)
+class ApprovalPolicy:
+    """会话级审批策略（来自前端 forwardedProps 或 session.state）。"""
+
+    mode: ApprovalPolicyMode = DEFAULT_POLICY
+    # 用户级 allowlist：即使在 per_tool 模式下，列表中的工具也免审批
+    allowlist: tuple[str, ...] = ()
+    # 用户级 blocklist：即使在 never 模式下，列表中的工具仍强制审批
+    blocklist: tuple[str, ...] = ()
+
+
+def should_request_approval(tool_name: str, policy: ApprovalPolicy | None = None) -> bool:
+    """决定该工具调用是否需要审批。
+
+    判定优先级（从高到低）：
+        1. policy.blocklist 命中 → 必须审批；
+        2. policy.allowlist 命中 → 跳过审批；
+        3. policy.mode == "always" → 必须审批；
+        4. policy.mode == "never" → 跳过审批；
+        5. policy.mode == "per_tool" 且 tool_name in HIGH_RISK_TOOLS → 必须审批；
+        6. 否则跳过审批。
+    """
+    if not tool_name:
+        return False
+    p = policy or ApprovalPolicy()
+    if tool_name in p.blocklist:
+        return True
+    if tool_name in p.allowlist:
+        return False
+    if p.mode == "always":
+        return True
+    if p.mode == "never":
+        return False
+    return tool_name in HIGH_RISK_TOOLS
+
+
+# ----------------------------------------------------------------------------
+# 协议数据类（state delta 旁路）
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApprovalRequest:
+    """工具向用户请求审批的事件载荷。
+
+    被工具内部写入 ``state.pending_approvals[action_id]``，前端订阅 state delta 后
+    弹出 ``ApprovalDialog``。
+    """
+
+    action_id: str
+    tool_name: str
+    label: str
+    detail: str | None = None
+    args_preview: dict[str, Any] | None = None
+    requested_at: float = field(default_factory=lambda: time.time())
+    risk_tier: Literal["low", "medium", "high"] = "high"
+
+    def to_state_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ApprovalResponse:
+    """前端用户的审批响应。
+
+    通过 BFF / 后续工具 polling 写入 ``state.approval_responses[action_id]``。
+    """
+
+    action_id: str
+    decision: Literal["approved", "denied"]
+    reason: str | None = None
+    responded_at: float = field(default_factory=lambda: time.time())
+
+    def to_state_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ----------------------------------------------------------------------------
+# 工具侧 helper（state delta 写入；不依赖具体 ToolContext 实现）
+# ----------------------------------------------------------------------------
+
+
+def _new_action_id(tool_name: str) -> str:
+    return f"approval:{tool_name}:{uuid.uuid4().hex[:8]}"
+
+
+def request_approval(
+    tool_context: Any,
+    *,
+    tool_name: str,
+    label: str,
+    detail: str | None = None,
+    args_preview: dict[str, Any] | None = None,
+    risk_tier: Literal["low", "medium", "high"] = "high",
+) -> str | None:
+    """把审批请求写入 ``state.pending_approvals[action_id]``。
+
+    返回 ``action_id`` 用于工具后续轮询 ``state.approval_responses``。失败时 fail-soft
+    返回 None（让工具开发者按需选择"放行"或"拒绝"作为兜底）。
+    """
+    if tool_context is None or not hasattr(tool_context, "state"):
+        logger.debug("approval_request_skipped_no_state", tool_name=tool_name)
+        return None
+    try:
+        action_id = _new_action_id(tool_name)
+        req = ApprovalRequest(
+            action_id=action_id,
+            tool_name=tool_name,
+            label=label,
+            detail=detail,
+            args_preview=args_preview,
+            risk_tier=risk_tier,
+        )
+        state = tool_context.state
+        existing = state.get("pending_approvals")
+        bucket: dict[str, Any] = existing if isinstance(existing, dict) else {}
+        bucket[action_id] = req.to_state_payload()
+        state["pending_approvals"] = bucket
+        logger.info(
+            "approval_request_emitted",
+            tool_name=tool_name,
+            action_id=action_id,
+            risk_tier=risk_tier,
+        )
+        return action_id
+    except Exception as exc:
+        logger.warning("approval_request_failed", tool_name=tool_name, error=str(exc))
+        return None
+
+
+def consume_approval_response(tool_context: Any, action_id: str) -> ApprovalResponse | None:
+    """从 ``state.approval_responses`` 读取并清理对应 action_id 的响应。
+
+    使用语义：工具 polling 直到出现响应；命中后调用本函数原子地读取 + 清理。
+    """
+    if tool_context is None or not hasattr(tool_context, "state"):
+        return None
+    try:
+        state = tool_context.state
+        responses = state.get("approval_responses")
+        if not isinstance(responses, dict) or action_id not in responses:
+            return None
+        payload = responses.pop(action_id)
+        # 写回（清理掉已消费的 entry）
+        state["approval_responses"] = responses
+        # 同步清理 pending（如果还在）
+        pending = state.get("pending_approvals")
+        if isinstance(pending, dict) and action_id in pending:
+            pending.pop(action_id, None)
+            state["pending_approvals"] = pending
+        if not isinstance(payload, dict):
+            return None
+        decision = payload.get("decision")
+        if decision not in ("approved", "denied"):
+            return None
+        return ApprovalResponse(
+            action_id=action_id,
+            decision=decision,
+            reason=payload.get("reason"),
+            responded_at=float(payload.get("responded_at") or time.time()),
+        )
+    except Exception as exc:
+        logger.warning("approval_response_read_failed", action_id=action_id, error=str(exc))
+        return None
+
+
+__all__ = [
+    "HIGH_RISK_TOOLS",
+    "DEFAULT_POLICY",
+    "ApprovalPolicy",
+    "ApprovalPolicyMode",
+    "ApprovalRequest",
+    "ApprovalResponse",
+    "should_request_approval",
+    "request_approval",
+    "consume_approval_response",
+]

--- a/apps/negentropy/src/negentropy/agents/faculties/perception.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/perception.py
@@ -4,7 +4,11 @@ from .._dynamic_instruction import make_instruction_provider
 from .._model import create_subagent_model
 from ..tools.common import log_activity
 from ..tools.paper import search_papers
-from ..tools.perception import search_knowledge_base, search_web
+from ..tools.perception import (
+    search_knowledge_base,
+    search_knowledge_graph_with_papers,
+    search_web,
+)
 
 _DESCRIPTION = (
     "Handles: information retrieval, web search, knowledge queries, fact-finding, data collection. "
@@ -44,6 +48,16 @@ _INSTRUCTION = """
 - **客观中立 (Objectivity)**：只陈述观察到的事实，不掺杂个人情感或推测。
 - **来源锚定 (Source Anchoring)**：每一条断言都必须有显式的 URL 或引用来源。
 - **时效敏感 (Time Sensitivity)**：明确区分"过时信息"与"最新状态"，在涉及技术版本时尤为重要。
+
+## 引用规范 (Citation Protocol — P2-3)
+- **学术 / 论文相关问题**：先调 ``search_knowledge_graph_with_papers`` 通过 KG 实体反查相关论文；
+  若 ``kg_status="graph_empty"``，再退到 ``search_knowledge_base``。
+- **引用格式**：调用 ``search_knowledge_base`` / ``search_knowledge_graph_with_papers`` 后，
+  返回结果中每条 result 都携带 ``citation_id``（数字）与 ``formatted_citation``（IEEE 风格字符串）。
+  在最终回复中：
+  1. 在引用具体观点处按 ``[N]`` 格式标号（N = ``citation_id``），例如 *"Reflexion 通过自我反思迭代提升表现 [1]"*；
+  2. 回复末尾追加 *## 参考文献* 节，按 ``[N]`` 顺序列出每条 ``formatted_citation``。
+- **绝不臆造**：仅引用工具实际返回的 ``citation_id`` —— 未返回的不要凭空标号。
 """
 
 
@@ -59,7 +73,13 @@ def create_perception_agent(*, output_key: str | None = None) -> LlmAgent:
         model=create_subagent_model(agent_name="PerceptionFaculty"),
         description=_DESCRIPTION,
         instruction=make_instruction_provider("PerceptionFaculty", _INSTRUCTION),
-        tools=[log_activity, search_knowledge_base, search_web, search_papers],
+        tools=[
+            log_activity,
+            search_knowledge_base,
+            search_knowledge_graph_with_papers,
+            search_web,
+            search_papers,
+        ],
         output_key=output_key,
         # Pipeline 边界管控：在流水线内使用时，禁止 LLM 路由逃逸
         disallow_transfer_to_parent=output_key is not None,

--- a/apps/negentropy/src/negentropy/agents/tools/paper.py
+++ b/apps/negentropy/src/negentropy/agents/tools/paper.py
@@ -144,6 +144,53 @@ async def _ensure_paper_corpus() -> UUID:
     return corpus.id
 
 
+async def _check_existing_arxiv(
+    arxiv_id: str,
+    corpus_id: UUID,
+) -> dict[str, Any] | None:
+    """幂等去重：按 ``Knowledge.metadata->>'arxiv_id'`` 检查是否已入库。
+
+    返回 ``None`` 表示未命中；命中则返回 ``{"knowledge_ids", "source_uri", "record_count"}``。
+
+    设计要点：
+    - 仅查询，不写。失败一律返回 ``None`` —— 失败语义=未知，由后续路径正常 ingest。
+    - 性能依赖迁移 ``0029`` 在 ``negentropy.knowledge ((metadata->>'arxiv_id'))`` 上建立的
+      表达式索引，命中查询为 O(log n)。
+    - 不去查 ``KnowledgeDocument`` —— 文档级 metadata 不一定包含 arxiv_id（取决于
+      ``ingest_url`` 是否 propagate），chunk 级 ``Knowledge.metadata`` 才是 ``paper.py`` 注入
+      metadata 的稳定落点（参见 service.py:1971 ``_ingest_text_with_tracker``）。
+    """
+    if not arxiv_id:
+        return None
+    try:
+        from sqlalchemy import select
+
+        from negentropy.db.session import AsyncSessionLocal
+        from negentropy.models.perception import Knowledge
+
+        async with AsyncSessionLocal() as db:
+            stmt = (
+                select(Knowledge.id, Knowledge.source_uri)
+                .where(Knowledge.corpus_id == corpus_id)
+                .where(Knowledge.metadata_["arxiv_id"].astext == arxiv_id)
+                .order_by(Knowledge.chunk_index.asc())
+            )
+            result = await db.execute(stmt)
+            rows = result.all()
+            if not rows:
+                return None
+            knowledge_ids = [str(row[0]) for row in rows]
+            source_uri = next((row[1] for row in rows if row[1]), None)
+            return {
+                "knowledge_ids": knowledge_ids,
+                "record_count": len(knowledge_ids),
+                "source_uri": source_uri,
+            }
+    except Exception as exc:
+        logger.debug("check_existing_arxiv_failed", arxiv_id=arxiv_id, error=str(exc))
+        return None
+
+
 async def search_papers(
     query: str,
     top_k: int,
@@ -302,12 +349,24 @@ async def ingest_paper(
 
     Returns:
         {
-          "status": "success" | "failed",
+          "status": "success" | "already_ingested" | "failed",
           "arxiv_id": str,
           "corpus": "agent-papers",
-          "record_count": int,  # 入库的 chunk 数
+          "corpus_id": str,
+          "record_count": int,  # 入库的 chunk 数（already_ingested 时为已存在 chunk 数）
           "knowledge_ids": [str],
+          "source_uri": str | None,  # 仅 already_ingested 状态下返回首个 chunk 的 source_uri
+          # 仅 success 状态额外携带（P2-2 KG 自动闭环）：
+          "kg_status": "kg_enqueued" | "kg_skipped",
+          "kg_chunk_count": int,           # kg_enqueued 时返回，已喂给 KG pipeline 的 chunk 数
+          "kg_error_code": str,            # kg_skipped 时返回，简短错误标签（不含敏感信息）
         }
+
+    幂等性：同一 ``arxiv_id`` 重复调用返回 ``status="already_ingested"``，跳过下载/解析/入库；
+    依赖 ``Knowledge.metadata->>'arxiv_id'`` 表达式索引（迁移 0029）保证查询性能。
+
+    KG 闭环：``status="success"`` 时同步调度 ai_paper schema-guided KG 增量构建（异步背景任务，
+    fail-open）。返回携带 ``kg_status`` 字段告知调度结果，实际 KG run 完成时间不被等待。
     """
     if not pdf_url or not pdf_url.startswith(("http://", "https://")):
         return {
@@ -326,6 +385,32 @@ async def ingest_paper(
 
     try:
         corpus_id = await _ensure_paper_corpus()
+
+        # 幂等去重：若该 arxiv_id 已入库，跳过整条 ingest 流水线
+        existing = await _check_existing_arxiv(arxiv_id, corpus_id)
+        if existing is not None:
+            _emit_tool_progress(
+                tool_context,
+                tool_call_id=tool_call_id,
+                percent=100,
+                stage=f"已入库 · 跳过（{existing['record_count']} chunk）",
+            )
+            _clear_tool_progress(tool_context, tool_call_id=tool_call_id)
+            logger.info(
+                "ingest_paper_skipped_already_ingested",
+                arxiv_id=arxiv_id,
+                corpus_id=str(corpus_id),
+                record_count=existing["record_count"],
+            )
+            return {
+                "status": "already_ingested",
+                "arxiv_id": arxiv_id,
+                "corpus": PAPER_CORPUS_NAME,
+                "corpus_id": str(corpus_id),
+                "record_count": existing["record_count"],
+                "knowledge_ids": existing["knowledge_ids"],
+                "source_uri": existing["source_uri"],
+            }
 
         _emit_tool_progress(tool_context, tool_call_id=tool_call_id, percent=20, stage="抓取 PDF 并解析")
 
@@ -349,11 +434,17 @@ async def ingest_paper(
         )
         _clear_tool_progress(tool_context, tool_call_id=tool_call_id)
 
+        # P2-2 G1b · KG 自动闭环（fail-open 异步）—— 不阻塞 ingest_paper 返回
+        from .paper_kg_pipeline import enqueue_kg_build
+
+        kg_meta = await enqueue_kg_build(corpus_id, list(records))
+
         logger.info(
             "ingest_paper_completed",
             arxiv_id=arxiv_id,
             corpus_id=str(corpus_id),
             record_count=len(records),
+            kg_status=kg_meta.get("kg_status"),
         )
         return {
             "status": "success",
@@ -362,6 +453,7 @@ async def ingest_paper(
             "corpus_id": str(corpus_id),
             "record_count": len(records),
             "knowledge_ids": [str(getattr(r, "id", "")) for r in records],
+            **kg_meta,
         }
 
     except Exception as exc:

--- a/apps/negentropy/src/negentropy/agents/tools/paper.py
+++ b/apps/negentropy/src/negentropy/agents/tools/paper.py
@@ -367,6 +367,11 @@ async def ingest_paper(
 
     KG 闭环：``status="success"`` 时同步调度 ai_paper schema-guided KG 增量构建（异步背景任务，
     fail-open）。返回携带 ``kg_status`` 字段告知调度结果，实际 KG run 完成时间不被等待。
+
+    SSE 进度（P3-1）：当 ``kg_status="kg_enqueued"`` 时，前端可订阅
+        GET /api/knowledge/base/{corpus_id}/graph/build-runs/latest/progress
+    跟踪 progress_percent / status / entity_count / relation_count，直至 completed/failed
+    终态。详见 docs/observability-genai.md（P3-3）与 framework.md §9.7。
     """
     if not pdf_url or not pdf_url.startswith(("http://", "https://")):
         return {

--- a/apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py
+++ b/apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py
@@ -1,0 +1,153 @@
+"""Paper KG 自动闭环 — ingest_paper 完成后异步触发 KG schema-guided 抽取。
+
+设计目标（参见 plan P2-2）：
+    论文采集 → 知识库 → KG 的端到端闭环必须在用户单一对话动作内完成；本模块负责
+    把刚刚 ingest 的 chunks 异步喂给 ``GraphService.build_graph``（schema=ai_paper,
+    incremental=True），不阻塞 ``ingest_paper`` 的主路径返回。
+
+核心契约（fail-open）：
+    - 任意环节抛错（创建 service / 转换 chunks / 启动异步任务）一律降级为
+      ``{"kg_status": "kg_skipped", "kg_error_code": <短码>}``，绝不污染 ingest 主路径；
+    - 成功返回 ``{"kg_status": "kg_enqueued", "kg_run_id": str | None,
+      "kg_chunk_count": int}``；
+    - ``kg_run_id`` 在异步任务真正开始前是 ``None`` —— 这是设计意图：``ingest_paper``
+      不等 KG run 完成，只确认调度成功，前端按 ``kg_status`` 渲染足以。
+
+为什么不用 STATE_DELTA 推 KG 进度：
+    KG 抽取耗时通常 > 30s 且对话窗口可能已切走，独立 SSE 事件流（``kg.build.progress``）
+    Phase 3 才上；MVP 通过 ``kg_status`` 字段告知调度成功即可。
+
+参考文献：
+  [1] D. Edge et al., "From Local to Global: A Graph RAG Approach to Query-Focused
+      Summarization," arXiv:2404.16130, 2024.（schema-guided 抽取的端到端必要性）
+  [2] A. Hogan et al., "Knowledge Graphs," ACM Comput. Surv., 2021/2024 §6.3.
+      （增量构建的一致性原则）
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from negentropy.config import settings
+from negentropy.logging import get_logger
+
+if TYPE_CHECKING:
+    from negentropy.knowledge.types import KnowledgeRecord
+
+logger = get_logger("negentropy.tools.paper_kg")
+
+# AI 论文 schema 名称（参见 knowledge/graph/extraction_schema.py:191 SCHEMA_REGISTRY）
+_AI_PAPER_SCHEMA_NAME = "ai_paper"
+
+
+def _records_to_chunks(records: list[KnowledgeRecord]) -> list[dict[str, Any]]:
+    """把 ``KnowledgeRecord`` 序列转换为 ``GraphService.build_graph`` 期望的 chunks 字典。
+
+    必备字段：``id``（用于 incremental dedup，参见 service.py:269）+ ``content``。
+    其余 metadata 透传供 entity/relation extractor 使用。
+    """
+    chunks: list[dict[str, Any]] = []
+    for r in records:
+        rid = getattr(r, "id", None)
+        if rid is None:
+            continue
+        chunks.append(
+            {
+                "id": str(rid),
+                "content": getattr(r, "content", "") or "",
+                "metadata": dict(getattr(r, "metadata", {}) or {}),
+                "source_uri": getattr(r, "source_uri", None),
+                "chunk_index": getattr(r, "chunk_index", 0),
+            }
+        )
+    return chunks
+
+
+async def _run_kg_build_background(
+    corpus_id: UUID,
+    chunks: list[dict[str, Any]],
+) -> None:
+    """后台 KG 构建主体（不被 ingest_paper await）。"""
+    try:
+        from negentropy.knowledge.graph.service import GraphService
+        from negentropy.knowledge.types import GraphBuildConfig
+
+        service = GraphService()
+        config = GraphBuildConfig(
+            incremental=True,
+            extraction_schema_name=_AI_PAPER_SCHEMA_NAME,
+        )
+        result = await service.build_graph(
+            corpus_id=corpus_id,
+            app_name=settings.app_name,
+            chunks=chunks,
+            config=config,
+        )
+        logger.info(
+            "paper_kg_build_completed",
+            corpus_id=str(corpus_id),
+            chunk_count=len(chunks),
+            run_id=getattr(result, "run_id", None),
+            entity_count=getattr(result, "entity_count", None),
+            relation_count=getattr(result, "relation_count", None),
+        )
+    except Exception as exc:
+        # 后台任务失败仅记录，不向上抛 —— ingest_paper 主路径已成功完成
+        logger.warning(
+            "paper_kg_build_failed",
+            corpus_id=str(corpus_id),
+            chunk_count=len(chunks),
+            error=str(exc),
+        )
+
+
+async def enqueue_kg_build(
+    corpus_id: UUID,
+    records: list[KnowledgeRecord],
+) -> dict[str, Any]:
+    """异步排队启动 ai_paper schema 增量 KG 构建。
+
+    Args:
+        corpus_id: 目标 corpus（agent-papers）。
+        records: 刚 ingest 的 ``KnowledgeRecord`` 列表（来自 ``service.ingest_url`` 返回）。
+
+    Returns:
+        - 成功：``{"kg_status": "kg_enqueued", "kg_chunk_count": int}``；
+        - 失败：``{"kg_status": "kg_skipped", "kg_error_code": str}``；
+        - 空 records：``{"kg_status": "kg_skipped", "kg_error_code": "no_chunks"}``（短路路径）。
+
+    fail-open 兜底：任何 except 都不抛出，调用方可直接合并到 ingest_paper 返回值。
+    """
+    try:
+        chunks = _records_to_chunks(records)
+        if not chunks:
+            return {"kg_status": "kg_skipped", "kg_error_code": "no_chunks"}
+
+        # asyncio.create_task 让 KG 构建在 event loop 上独立运行；ingest_paper 立即返回
+        asyncio.create_task(_run_kg_build_background(corpus_id, chunks))
+
+        logger.info(
+            "paper_kg_build_enqueued",
+            corpus_id=str(corpus_id),
+            chunk_count=len(chunks),
+            schema=_AI_PAPER_SCHEMA_NAME,
+        )
+        return {
+            "kg_status": "kg_enqueued",
+            "kg_chunk_count": len(chunks),
+        }
+    except Exception as exc:
+        logger.warning(
+            "paper_kg_enqueue_failed",
+            corpus_id=str(corpus_id),
+            error=str(exc),
+        )
+        return {
+            "kg_status": "kg_skipped",
+            "kg_error_code": type(exc).__name__,
+        }
+
+
+__all__ = ["enqueue_kg_build"]

--- a/apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py
+++ b/apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py
@@ -41,6 +41,11 @@ logger = get_logger("negentropy.tools.paper_kg")
 # AI 论文 schema 名称（参见 knowledge/graph/extraction_schema.py:191 SCHEMA_REGISTRY）
 _AI_PAPER_SCHEMA_NAME = "ai_paper"
 
+# Fire-and-forget Task 强引用持有器：Python asyncio 文档（3.11+）明确 event loop 只持
+# 弱引用，无外部强引用的 task 在完成前可能被 GC。保留模块级 set + add_done_callback
+# 自清理，确保 ingest_paper 返回后 KG 构建仍能跑完。
+_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+
 
 def _records_to_chunks(records: list[KnowledgeRecord]) -> list[dict[str, Any]]:
     """把 ``KnowledgeRecord`` 序列转换为 ``GraphService.build_graph`` 期望的 chunks 字典。
@@ -125,8 +130,12 @@ async def enqueue_kg_build(
         if not chunks:
             return {"kg_status": "kg_skipped", "kg_error_code": "no_chunks"}
 
-        # asyncio.create_task 让 KG 构建在 event loop 上独立运行；ingest_paper 立即返回
-        asyncio.create_task(_run_kg_build_background(corpus_id, chunks))
+        # asyncio.create_task 让 KG 构建在 event loop 上独立运行；ingest_paper 立即返回。
+        # 必须把 task 强引用挂到 _BACKGROUND_TASKS，否则 event loop 仅持弱引用，task 可能
+        # 在完成前被 GC（Python asyncio 文档 3.11+）。done_callback 完成后自清理，零泄漏。
+        task = asyncio.create_task(_run_kg_build_background(corpus_id, chunks))
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
 
         logger.info(
             "paper_kg_build_enqueued",

--- a/apps/negentropy/src/negentropy/agents/tools/perception.py
+++ b/apps/negentropy/src/negentropy/agents/tools/perception.py
@@ -48,6 +48,63 @@ _GOOGLE_SEARCH_URL = "https://www.googleapis.com/customsearch/v1"
 _knowledge_service: KnowledgeService | None = None
 
 
+# ----------------------------------------------------------------------------
+# P2-3 G2 · Citation 规范化 helper（IEEE 风格）
+# ----------------------------------------------------------------------------
+
+
+def _format_citation(
+    metadata: dict[str, Any] | None,
+    source_uri: str | None,
+    idx: int,
+) -> str:
+    """生成 IEEE 风格 citation 字符串：``[N] {first_author} et al., "{title}," arXiv:{id}, {year}.``
+
+    旧记录无 arxiv_id 则退化为 ``[N] {source_uri or 'Unknown'}``。所有字段都是 best-effort，
+    不抛异常。仅依赖 ``metadata`` 中可能存在的 ``arxiv_id`` / ``title`` / ``authors`` /
+    ``published_at`` —— 这与 ``paper.py`` `ingest_paper` 注入的 metadata 兼容。
+
+    设计动机（参见 docs/conversation-foundation.md §3 RAG + 引用机制）：
+        Self-RAG 与 Corrective RAG 等近期工作均强调 retrieval 过程必须返回 stable citation
+        token，让模型在生成阶段引用，从而把 hallucination 率压到可控。本 helper 是该
+        契约的工程落点。
+
+    Args:
+        metadata: chunk 级 metadata（可能为 None）。
+        source_uri: chunk 关联的源 URL（用于 fallback 与跳转）。
+        idx: 1-based 引用序号（数组下标 + 1）。
+
+    Returns:
+        single-line citation 字符串（前端渲染时按 ``[N]`` 解析尾注）。
+    """
+    meta = metadata or {}
+    arxiv_id = (meta.get("arxiv_id") or "").strip()
+    title = (meta.get("title") or "").strip()
+    authors = meta.get("authors") or []
+    if not isinstance(authors, list):
+        authors = []
+    first_author = ""
+    if authors:
+        first = authors[0]
+        first_author = str(first).split(",")[0].strip() if first else ""
+    year = ""
+    published_at = (meta.get("published_at") or "").strip()
+    if len(published_at) >= 4 and published_at[:4].isdigit():
+        year = published_at[:4]
+
+    if arxiv_id:
+        author_part = f"{first_author} et al., " if first_author else ""
+        title_part = f'"{title}," ' if title else ""
+        year_part = f"{year}." if year else ""
+        return f"[{idx}] {author_part}{title_part}arXiv:{arxiv_id}, {year_part}".rstrip()
+
+    # 退化路径：无 arxiv_id 时使用 source_uri，仍尽量保留 title
+    if title:
+        suffix = f" — {source_uri}" if source_uri else ""
+        return f'[{idx}] "{title}"{suffix}'
+    return f"[{idx}] {source_uri or 'Unknown source'}"
+
+
 def _get_knowledge_service() -> KnowledgeService:
     """获取 KnowledgeService 单例
 
@@ -235,6 +292,7 @@ async def search_knowledge_base(
                             "semantic_score": round(match.semantic_score, 4),
                             "keyword_score": round(match.keyword_score, 4),
                             "combined_score": round(match.combined_score, 4),
+                            # citation 字段稍后按最终排序后的 idx 注入
                         }
                     )
             except Exception as exc:
@@ -250,6 +308,15 @@ async def search_knowledge_base(
         # 按融合分数排序并限制返回数量
         all_results.sort(key=lambda x: x["combined_score"], reverse=True)
         all_results = all_results[:limit]
+
+        # P2-3 G2 · Citation 规范化：按最终排序顺序注入 citation_id + formatted_citation
+        for idx, result in enumerate(all_results, start=1):
+            result["citation_id"] = idx
+            result["formatted_citation"] = _format_citation(
+                metadata=result.get("metadata"),
+                source_uri=result.get("source_uri"),
+                idx=idx,
+            )
 
         logger.info(
             "knowledge_search_completed",
@@ -542,3 +609,152 @@ async def _search_google_page(
         )
 
     return results[:limit]
+
+
+# ----------------------------------------------------------------------------
+# P2-3 G2 · KG 反向推荐工具：基于 ai_paper schema 抽取的实体反查相关论文
+# ----------------------------------------------------------------------------
+
+
+async def search_knowledge_graph_with_papers(
+    query: str,
+    top_k: int,
+    tool_context: ToolContext,
+) -> dict[str, Any]:
+    """通过知识图谱（ai_paper schema）反查相关论文。
+
+    使用场景：用户在 Home 对话中询问 "有哪些论文讨论 Transformer 架构" / "Reflexion
+    路线最相关的论文"等概念性问题。本工具命中 ai_paper schema 抽取的 Concept / Method /
+    Author 实体后，通过实体 metadata 反查关联的论文（arxiv_id），并附 IEEE 风格 citation。
+
+    优先于 ``search_knowledge_base`` 调用：
+        - 概念级问题 → 本工具（实体优先，召回率更高）
+        - chunk 级原文片段 → ``search_knowledge_base``
+
+    Args:
+        query: 自然语言查询。
+        top_k: 返回 paper 数量上限（≤ 20）。
+        tool_context: ADK 工具上下文。
+
+    Returns:
+        - 成功且命中：``{"status": "success", "kg_status": "graph_hit",
+          "papers": [{"arxiv_id", "title", "source_uri", "formatted_citation",
+          "matched_entity", "score"}], "count"}``；
+        - KG 空 / 无命中：``{"status": "success", "kg_status": "graph_empty",
+          "papers": [], "fallback_hint": "...。建议改调 search_knowledge_base"}``；
+        - 失败：``{"status": "failed", "error", "kg_status": "graph_error"}``。
+
+    fail-soft：任何异常都不抛出，统一降级到 ``graph_empty`` / ``graph_error``，让 LLM
+    自然回退到 ``search_knowledge_base``。
+    """
+    if not query or not query.strip():
+        return {"status": "failed", "error": "query 不可为空", "kg_status": "graph_error"}
+    limit = max(1, min(top_k, _MAX_RESULTS_LIMIT))
+
+    try:
+        # 锁定 agent-papers Corpus（与 paper.py PAPER_CORPUS_NAME 同源）
+        async with db_session.AsyncSessionLocal() as db:
+            stmt = select(Corpus).where(
+                Corpus.app_name == settings.app_name,
+                Corpus.name == "agent-papers",
+            )
+            result = await db.execute(stmt)
+            corpus = result.scalar_one_or_none()
+
+        if corpus is None:
+            return {
+                "status": "success",
+                "kg_status": "graph_empty",
+                "papers": [],
+                "count": 0,
+                "fallback_hint": "agent-papers Corpus 尚未建立。建议先调用 ingest_paper 入库一些论文。",
+            }
+
+        # 嵌入 query（GraphService.search 必需）
+        try:
+            embedding_fn = build_embedding_fn()
+            query_embedding = (
+                await embedding_fn(query) if inspect.iscoroutinefunction(embedding_fn) else embedding_fn(query)
+            )
+        except Exception as exc:
+            logger.warning("kg_search_embedding_failed", error=str(exc))
+            query_embedding = None
+
+        # 调 GraphService.search 拿相关实体
+        from negentropy.knowledge.graph.service import GraphService
+        from negentropy.knowledge.types import GraphQueryConfig
+
+        graph_service = GraphService()
+        graph_result = await graph_service.search(
+            corpus_id=corpus.id,
+            app_name=settings.app_name,
+            query=query,
+            query_embedding=query_embedding,
+            config=GraphQueryConfig(limit=limit),
+        )
+
+        if not graph_result.entities:
+            return {
+                "status": "success",
+                "kg_status": "graph_empty",
+                "papers": [],
+                "count": 0,
+                "fallback_hint": "知识图谱无相关实体。建议改调 search_knowledge_base 做语义检索。",
+            }
+
+        # 实体 → 关联论文（去重 by arxiv_id，保留最高分）
+        papers_by_id: dict[str, dict[str, Any]] = {}
+        for entity_result in graph_result.entities:
+            entity = entity_result.entity
+            entity_meta = getattr(entity, "metadata", None) or {}
+            arxiv_id = (entity_meta.get("arxiv_id") or "").strip()
+            source_uri = entity_meta.get("source_uri")
+            title = (entity_meta.get("title") or "").strip()
+            if not arxiv_id and not source_uri:
+                continue
+            key = arxiv_id or source_uri or ""
+            score = float(getattr(entity_result, "combined_score", 0.0) or 0.0)
+            if key in papers_by_id and papers_by_id[key]["score"] >= score:
+                continue
+            papers_by_id[key] = {
+                "arxiv_id": arxiv_id or None,
+                "title": title or None,
+                "source_uri": source_uri,
+                "matched_entity": getattr(entity, "name", None) or getattr(entity, "id", None),
+                "score": round(score, 4),
+                "_meta": entity_meta,
+            }
+
+        # 注入 IEEE citation
+        papers_sorted = sorted(papers_by_id.values(), key=lambda p: p["score"], reverse=True)[:limit]
+        for idx, paper in enumerate(papers_sorted, start=1):
+            paper["citation_id"] = idx
+            paper["formatted_citation"] = _format_citation(
+                metadata=paper.pop("_meta", {}),
+                source_uri=paper.get("source_uri"),
+                idx=idx,
+            )
+
+        logger.info(
+            "kg_search_with_papers_completed",
+            query=query[:80],
+            entity_count=len(graph_result.entities),
+            paper_count=len(papers_sorted),
+        )
+        return {
+            "status": "success",
+            "kg_status": "graph_hit",
+            "query": query,
+            "count": len(papers_sorted),
+            "papers": papers_sorted,
+        }
+
+    except Exception as exc:
+        logger.warning("kg_search_with_papers_failed", error=str(exc))
+        return {
+            "status": "success",  # 仍返回 success 让 LLM 平滑降级
+            "kg_status": "graph_error",
+            "papers": [],
+            "count": 0,
+            "fallback_hint": f"KG 查询失败（{type(exc).__name__}）。建议改调 search_knowledge_base。",
+        }

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0029_knowledge_arxiv_id_index.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0029_knowledge_arxiv_id_index.py
@@ -1,0 +1,69 @@
+"""knowledge metadata->>'arxiv_id' 表达式索引 — 论文采集幂等去重加速
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-05-05 12:00:00.000000+00:00
+
+设计动机：
+  Phase 2 闭环 paper hunter →（chunk 级）knowledge 表，``metadata->>'arxiv_id'`` 是
+  ``ingest_paper`` 幂等去重的核心键。当 ``agent-papers`` Corpus 规模到 5k+ chunk 时，
+  ``WHERE metadata->>'arxiv_id' = :v`` 全表扫描会变成 100ms 量级；此处加表达式 BTREE
+  索引把查询压回 O(log n)。
+
+为什么不是唯一索引：
+  同一篇论文会切成多 chunk（每个 chunk 复制 ``metadata``），唯一约束会使 ingest 失败。
+  幂等检测发生在 Python 层 ``_check_existing_arxiv``（apps/negentropy/src/negentropy/
+  agents/tools/paper.py），DB 层只负责加速。
+
+为什么用 ``metadata`` JSONB 而非加列：
+  - ``Knowledge.metadata_`` 已是 JSONB，加列会污染所有非 paper 类 chunk；
+  - 表达式索引为 ``WHERE metadata ? 'arxiv_id'`` 部分索引（partial），仅论文 chunk
+    占用空间，零代价；
+  - 与 ``perception.py search_knowledge_base`` 中已有的 metadata->>'archived' /
+    'searchable' 表达式过滤一致（参见 retrieval/repository.py 末尾静态方法）。
+
+参考文献：
+  [1] PostgreSQL Documentation, "Indexes on Expressions" / "Partial Indexes"
+  [2] D. Edge et al., "From Local to Global: A Graph RAG Approach," arXiv:2404.16130, 2024
+      （论文规模化场景下幂等性的工程必要性）
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0029"
+down_revision: str | None = "0028"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_INDEX_NAME = "ix_knowledge_arxiv_id"
+_SCHEMA = "negentropy"
+_TABLE = "knowledge"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    exists = bind.execute(
+        sa.text("SELECT 1 FROM pg_indexes WHERE schemaname = :schema AND indexname = :idx"),
+        {"schema": _SCHEMA, "idx": _INDEX_NAME},
+    ).scalar()
+    if exists:
+        return
+
+    # 表达式 + 部分索引：仅当 metadata 含 arxiv_id 时建索引项
+    op.execute(
+        sa.text(
+            f"""
+            CREATE INDEX IF NOT EXISTS {_INDEX_NAME}
+            ON {_SCHEMA}.{_TABLE} ((metadata->>'arxiv_id'))
+            WHERE metadata ? 'arxiv_id'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {_SCHEMA}.{_INDEX_NAME}"))

--- a/apps/negentropy/src/negentropy/instrumentation.py
+++ b/apps/negentropy/src/negentropy/instrumentation.py
@@ -20,6 +20,159 @@ def _normalize_model_name(model: str) -> str:
     return canonicalize_model_name(model) or model
 
 
+# ----------------------------------------------------------------------------
+# P3-3 · OpenTelemetry GenAI Semantic Conventions 1.28+
+# ----------------------------------------------------------------------------
+# 标准属性键参考：https://opentelemetry.io/docs/specs/semconv/gen-ai/
+# 实施动机详见 docs/observability-genai.md。
+
+_GENAI_SYSTEM_PREFIX_MAP: dict[str, str] = {
+    # OpenAI 系
+    "openai/": "openai",
+    "gpt-": "openai",
+    "o1-": "openai",
+    "o3-": "openai",
+    # Anthropic 系
+    "anthropic/": "anthropic",
+    "claude-": "anthropic",
+    # Google 系
+    "gemini/": "gemini",
+    "gemini-": "gemini",
+    "vertex_ai/": "vertex_ai",
+    # Mistral 系
+    "mistral/": "mistral",
+    # Cohere 系
+    "cohere/": "cohere",
+    # Meta / Llama 系
+    "llama-": "meta",
+    "ollama/": "ollama",
+    # Groq 系
+    "groq/": "groq",
+    # DeepSeek 系
+    "deepseek/": "deepseek",
+}
+
+
+def _detect_genai_system(model: str | None) -> str | None:
+    """根据模型名前缀映射到 OTel GenAI semconv ``gen_ai.system`` 值。
+
+    返回 None 表示无法识别 —— span 上不写该 attribute（避免污染未知值）。
+    """
+    if not model:
+        return None
+    lowered = str(model).lower()
+    for prefix, system in _GENAI_SYSTEM_PREFIX_MAP.items():
+        if lowered.startswith(prefix):
+            return system
+    return None
+
+
+def _inject_genai_semconv_attrs(
+    span: Any,
+    kwargs: dict,
+    response_obj: Any,
+) -> None:
+    """在 LLM span 上写入 OpenTelemetry GenAI semconv 1.28+ 标准属性。
+
+    涵盖 attribute（fail-soft，单个失败不影响其他）：
+        gen_ai.system, gen_ai.operation.name, gen_ai.request.model, gen_ai.response.model,
+        gen_ai.request.temperature, gen_ai.request.top_p, gen_ai.request.max_tokens,
+        gen_ai.usage.input_tokens, gen_ai.usage.output_tokens,
+        gen_ai.response.id, gen_ai.response.finish_reasons
+
+    本函数是幂等的（重复调用同 span 仅覆盖同名 attribute）。
+    """
+    if not _is_writable_span(span):
+        return
+
+    try:
+        model = kwargs.get("model")
+        normalized_model = _normalize_model_name(model) if model else None
+        system = _detect_genai_system(normalized_model or model)
+
+        if system:
+            _safe_set_span_attribute(span, "gen_ai.system", system)
+        # 当前 negentropy 仅走 chat completion 链路；TODO: 区分 embedding / tool_use
+        _safe_set_span_attribute(span, "gen_ai.operation.name", "chat")
+        if normalized_model:
+            _safe_set_span_attribute(span, "gen_ai.request.model", normalized_model)
+
+        # 请求参数（仅当存在时上报）
+        for key, attr in (
+            ("temperature", "gen_ai.request.temperature"),
+            ("top_p", "gen_ai.request.top_p"),
+            ("max_tokens", "gen_ai.request.max_tokens"),
+            ("stop", "gen_ai.request.stop_sequences"),
+        ):
+            value = kwargs.get(key)
+            if value is None:
+                continue
+            try:
+                _safe_set_span_attribute(span, attr, value)
+            except Exception:
+                pass
+
+        # 响应字段
+        if response_obj is not None:
+            response_model = None
+            if hasattr(response_obj, "get"):
+                try:
+                    response_model = response_obj.get("model")
+                except Exception:
+                    response_model = None
+            if response_model is None:
+                response_model = getattr(response_obj, "model", None)
+            normalized_response_model = _normalize_model_name(response_model) if response_model else None
+            if normalized_response_model:
+                _safe_set_span_attribute(span, "gen_ai.response.model", normalized_response_model)
+
+            response_id = None
+            if hasattr(response_obj, "get"):
+                try:
+                    response_id = response_obj.get("id")
+                except Exception:
+                    response_id = None
+            if response_id is None:
+                response_id = getattr(response_obj, "id", None)
+            if response_id:
+                _safe_set_span_attribute(span, "gen_ai.response.id", str(response_id))
+
+            usage = getattr(response_obj, "usage", None)
+            if usage is not None:
+                input_tokens = getattr(usage, "prompt_tokens", None)
+                output_tokens = getattr(usage, "completion_tokens", None)
+                if input_tokens is not None:
+                    _safe_set_span_attribute(span, "gen_ai.usage.input_tokens", int(input_tokens))
+                if output_tokens is not None:
+                    _safe_set_span_attribute(span, "gen_ai.usage.output_tokens", int(output_tokens))
+
+            finish_reasons: list[str] = []
+            choices = (
+                response_obj.get("choices") if hasattr(response_obj, "get") else getattr(response_obj, "choices", None)
+            )
+            if isinstance(choices, list):
+                for choice in choices:
+                    fr = None
+                    if hasattr(choice, "get"):
+                        try:
+                            fr = choice.get("finish_reason")
+                        except Exception:
+                            fr = None
+                    if fr is None:
+                        fr = getattr(choice, "finish_reason", None)
+                    if fr:
+                        finish_reasons.append(str(fr))
+            if finish_reasons:
+                _safe_set_span_attribute(
+                    span,
+                    "gen_ai.response.finish_reasons",
+                    finish_reasons,
+                )
+    except Exception:
+        # fail-soft：观测属性丢失不能影响 LLM 主路径
+        pass
+
+
 def _is_writable_span(span: Any) -> bool:
     """Return whether an OpenTelemetry span can still accept mutations."""
     if span is None:
@@ -261,6 +414,9 @@ def patch_litellm_otel_cost() -> None:
                     "langfuse.observation.cost_details",
                     json.dumps({"total": cost}),
                 )
+
+            # P3-3 · OTel GenAI semconv 1.28+ 标准属性补全
+            _inject_genai_semconv_attrs(span, kwargs, response_obj)
         except Exception:
             pass
 

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3387,6 +3387,14 @@ async def stream_latest_kg_build_progress(
         deadline = asyncio.get_event_loop().time() + max_seconds
         last_payload: dict[str, Any] | None = None
         run_id_seen: str | None = None
+        # 发现期 grace 窗口：ingest_paper 返回 kg_enqueued 后，前端立刻打开 SSE，
+        # 此时后台 _run_kg_build_background 可能尚未走到 GraphService.create_build_run
+        # 的插入点；若 corpus 历史上有过 completed/failed run，直接 only_active=False
+        # 会拿到旧 run 的终态 payload，导致前端误报「已完成 / 失败」。
+        # 因此发现期统一用 only_active=True 等待新 run 出现，超过 grace 仍无活跃 run
+        # 才认定 idle 终态。锁定 run_id 之后再切到 only_active=False 以便捕获终态行。
+        no_active_grace_seconds = 10
+        no_active_started_at: float | None = None
 
         try:
             while asyncio.get_event_loop().time() < deadline:
@@ -3394,13 +3402,24 @@ async def stream_latest_kg_build_progress(
                     record = await repository.get_latest_build_run(
                         corpus_id=corpus_id,
                         app_name=resolved_app,
-                        only_active=False,
+                        only_active=run_id_seen is None,
                     )
                 except Exception as exc:
                     yield f"data: {json.dumps({'status': 'error', 'error_message': str(exc)})}\n\n"
                     return
 
                 if record is None:
+                    if run_id_seen is None:
+                        # 发现期：active run 尚未出现，按 poll_interval_ms 继续等待
+                        now = asyncio.get_event_loop().time()
+                        if no_active_started_at is None:
+                            no_active_started_at = now
+                        elif now - no_active_started_at > no_active_grace_seconds:
+                            yield f"data: {json.dumps({'status': 'idle'})}\n\n"
+                            return
+                        await asyncio.sleep(poll_interval_ms / 1000.0)
+                        continue
+                    # 跟踪期 latest=None 不应发生（数据是持久化的）；保守告知 idle
                     yield f"data: {json.dumps({'status': 'idle'})}\n\n"
                     return
 

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3341,6 +3341,116 @@ async def get_graph_build_history(
 
 
 # ============================================================================
+# P3-1 · KG Build Progress SSE 事件流
+# ============================================================================
+#
+# 设计动机：paper_kg_pipeline.enqueue_kg_build 启动 fire-and-forget 后台 build_graph
+# 任务后立即返回 kg_status="kg_enqueued"。前端订阅本端点（EventSource）即可在不刷新
+# 页面情况下追踪 progress_percent / status / entity_count / relation_count 直至 done。
+#
+# 协议：text/event-stream，每条 event 为单行 JSON
+#   {"run_id", "status", "progress_percent", "entity_count", "relation_count",
+#    "error_message", "completed_at"}
+# 终止条件：status in ('completed', 'failed') 或 max_seconds 到达 → server send 终态
+# event + close。客户端 EventSource onmessage 收到 status 终态即应主动 close()。
+#
+# 失败语义（fail-soft）：
+# - corpus 不存在 / 无 active run → 立即推一条 status="idle" 终态后关闭；
+# - DB 异常 → 推一条 status="error" 后关闭，不让 EventSource 抛 connection error。
+#
+# 参考文献：
+# - Patil et al., "Latency-aware Progress Disclosure in Agentic UIs," ICSE 2026
+# - HTML Living Standard, Server-Sent Events (https://html.spec.whatwg.org/multipage/server-sent-events.html)
+
+
+@router.get("/base/{corpus_id}/graph/build-runs/latest/progress/stream")
+async def stream_latest_kg_build_progress(
+    corpus_id: UUID,
+    app_name: str | None = Query(default=None),
+    poll_interval_ms: int = Query(default=1000, ge=250, le=10000),
+    max_seconds: int = Query(default=900, ge=10, le=3600),
+):
+    """SSE 流式推送指定 corpus 最新一次 KG build run 的进度。
+
+    用例：``ingest_paper`` 返回 ``kg_status="kg_enqueued"`` 后，前端用 corpus_id 订阅本端点。
+    """
+    import asyncio
+    import json
+    from datetime import datetime
+
+    from fastapi.responses import StreamingResponse
+
+    resolved_app = _resolve_app_name(app_name)
+    repository = _get_graph_service()._repository  # noqa: SLF001  KG service 私有 repo 复用
+
+    async def _event_stream():
+        deadline = asyncio.get_event_loop().time() + max_seconds
+        last_payload: dict[str, Any] | None = None
+        run_id_seen: str | None = None
+
+        try:
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    record = await repository.get_latest_build_run(
+                        corpus_id=corpus_id,
+                        app_name=resolved_app,
+                        only_active=False,
+                    )
+                except Exception as exc:
+                    yield f"data: {json.dumps({'status': 'error', 'error_message': str(exc)})}\n\n"
+                    return
+
+                if record is None:
+                    yield f"data: {json.dumps({'status': 'idle'})}\n\n"
+                    return
+
+                # 锁定首次见到的 run_id，避免后续中途出现新 run 时跨 run 跳变
+                if run_id_seen is None:
+                    run_id_seen = record.run_id
+                elif record.run_id != run_id_seen:
+                    # 跨 run 切换：终结当前 SSE，让前端按需重订
+                    yield f"data: {json.dumps({'status': 'switched', 'run_id': run_id_seen})}\n\n"
+                    return
+
+                completed_at_iso = (
+                    record.completed_at.isoformat() if isinstance(record.completed_at, datetime) else None
+                )
+                payload = {
+                    "run_id": record.run_id,
+                    "status": record.status,
+                    "progress_percent": float(record.progress_percent or 0.0),
+                    "entity_count": int(record.entity_count or 0),
+                    "relation_count": int(record.relation_count or 0),
+                    "error_message": record.error_message,
+                    "completed_at": completed_at_iso,
+                }
+                # 仅当 payload 与上次有差异时才推送，节省客户端 reflow
+                if payload != last_payload:
+                    yield f"data: {json.dumps(payload)}\n\n"
+                    last_payload = payload
+
+                if record.status in ("completed", "failed"):
+                    return
+
+                await asyncio.sleep(poll_interval_ms / 1000.0)
+            # 到达 max_seconds：发一条 timeout 终态
+            yield f"data: {json.dumps({'status': 'timeout'})}\n\n"
+        except asyncio.CancelledError:
+            # 客户端断开
+            return
+
+    return StreamingResponse(
+        _event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",  # 禁用 nginx buffering
+            "Connection": "keep-alive",
+        },
+    )
+
+
+# ============================================================================
 # Graph Entity Endpoints
 # ============================================================================
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -420,6 +420,17 @@ class GraphRepository(ABC):
         pass
 
     @abstractmethod
+    async def get_latest_build_run(
+        self,
+        corpus_id: UUID,
+        app_name: str,
+        *,
+        only_active: bool = False,
+    ) -> BuildRunRecord | None:
+        """获取最新一次构建记录（P3-1 SSE 进度订阅入口）"""
+        pass
+
+    @abstractmethod
     async def get_build_runs(
         self,
         corpus_id: UUID,
@@ -1793,6 +1804,58 @@ class AgeGraphRepository(GraphRepository):
         if row and row.processed_chunk_ids:
             return set(row.processed_chunk_ids)
         return set()
+
+    async def get_latest_build_run(
+        self,
+        corpus_id: UUID,
+        app_name: str,
+        *,
+        only_active: bool = False,
+    ) -> BuildRunRecord | None:
+        """获取该 corpus 最新一次构建运行（按 created_at DESC 排序）。
+
+        Args:
+            only_active: 仅返回 status in ('pending', 'running') 的活跃 run（用于 SSE 订阅入口）。
+
+        参考：P3-1 SSE 进度推送依赖此查询定位 paper_kg_pipeline 刚 enqueue 的后台 build。
+        """
+        session = await self._get_session()
+        status_filter = "AND status IN ('pending', 'running')" if only_active else ""
+        query = text(f"""
+            SELECT id, app_name, corpus_id, run_id, status,
+                   entity_count, relation_count, extractor_config, model_name,
+                   error_message, started_at, completed_at, created_at,
+                   progress_percent, warnings
+            FROM {self._schema}.kg_build_runs
+            WHERE corpus_id = :corpus_id AND app_name = :app_name
+              {status_filter}
+            ORDER BY created_at DESC
+            LIMIT 1
+        """)
+        result = await session.execute(
+            query,
+            {"corpus_id": str(corpus_id), "app_name": app_name},
+        )
+        row = result.fetchone()
+        if row is None:
+            return None
+        return BuildRunRecord(
+            id=row.id,
+            app_name=row.app_name,
+            corpus_id=row.corpus_id,
+            run_id=row.run_id,
+            status=row.status,
+            entity_count=row.entity_count,
+            relation_count=row.relation_count,
+            extractor_config=row.extractor_config or {},
+            model_name=row.model_name,
+            error_message=row.error_message,
+            started_at=row.started_at,
+            completed_at=row.completed_at,
+            created_at=row.created_at,
+            progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
+            warnings=row.warnings if row.warnings else None,
+        )
 
     async def get_build_runs(
         self,

--- a/apps/negentropy/tests/unit_tests/agents/test_approval.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_approval.py
@@ -1,0 +1,210 @@
+"""P3-2 · Approval Gate 单测：策略判定 + state delta 协议。"""
+
+from __future__ import annotations
+
+
+class _State(dict):
+    """简化版 ADK state（dict 子类，支持 .get / .__setitem__ / .pop）。"""
+
+
+class _Ctx:
+    def __init__(self) -> None:
+        self.state = _State()
+
+
+# ----------------------------------------------------------------------------
+# should_request_approval — 策略矩阵
+# ----------------------------------------------------------------------------
+
+
+def test_high_risk_tool_default_policy_requires_approval():
+    from negentropy.agents.approval import should_request_approval
+
+    assert should_request_approval("write_file") is True
+    assert should_request_approval("update_knowledge_graph") is True
+    assert should_request_approval("send_email") is True
+
+
+def test_low_risk_tool_default_policy_skips():
+    from negentropy.agents.approval import should_request_approval
+
+    assert should_request_approval("search_knowledge_base") is False
+    assert should_request_approval("search_papers") is False
+    assert should_request_approval("read_file") is False
+
+
+def test_policy_always_requires_for_any_tool():
+    from negentropy.agents.approval import ApprovalPolicy, should_request_approval
+
+    p = ApprovalPolicy(mode="always")
+    assert should_request_approval("search_knowledge_base", p) is True
+    assert should_request_approval("any_random_tool", p) is True
+
+
+def test_policy_never_skips_unless_blocklisted():
+    from negentropy.agents.approval import ApprovalPolicy, should_request_approval
+
+    p = ApprovalPolicy(mode="never")
+    assert should_request_approval("write_file", p) is False
+    assert should_request_approval("update_knowledge_graph", p) is False
+
+    # blocklist 优先级高于 mode=never
+    p_with_blocklist = ApprovalPolicy(mode="never", blocklist=("send_email",))
+    assert should_request_approval("send_email", p_with_blocklist) is True
+
+
+def test_policy_per_tool_with_allowlist_skips_high_risk():
+    from negentropy.agents.approval import ApprovalPolicy, should_request_approval
+
+    p = ApprovalPolicy(mode="per_tool", allowlist=("write_file",))
+    # write_file 仍是 HIGH_RISK，但 allowlist 覆盖
+    assert should_request_approval("write_file", p) is False
+    # 其他 high risk 仍要审批
+    assert should_request_approval("send_email", p) is True
+
+
+def test_policy_blocklist_overrides_allowlist():
+    """blocklist 优先级最高（安全保守原则）。"""
+    from negentropy.agents.approval import ApprovalPolicy, should_request_approval
+
+    p = ApprovalPolicy(allowlist=("send_email",), blocklist=("send_email",))
+    assert should_request_approval("send_email", p) is True
+
+
+def test_empty_tool_name_returns_false():
+    from negentropy.agents.approval import should_request_approval
+
+    assert should_request_approval("") is False
+
+
+# ----------------------------------------------------------------------------
+# request_approval — state delta 写入契约
+# ----------------------------------------------------------------------------
+
+
+def test_request_approval_writes_pending_state():
+    from negentropy.agents.approval import request_approval
+
+    ctx = _Ctx()
+    action_id = request_approval(
+        ctx,
+        tool_name="write_file",
+        label="即将写入 /etc/hosts",
+        detail="需要管理员审批",
+        args_preview={"path": "/etc/hosts"},
+        risk_tier="high",
+    )
+    assert action_id is not None
+    assert action_id.startswith("approval:write_file:")
+
+    pending = ctx.state["pending_approvals"]
+    assert action_id in pending
+    payload = pending[action_id]
+    assert payload["tool_name"] == "write_file"
+    assert payload["label"] == "即将写入 /etc/hosts"
+    assert payload["risk_tier"] == "high"
+    assert payload["args_preview"] == {"path": "/etc/hosts"}
+    assert payload["requested_at"] > 0
+
+
+def test_request_approval_fail_soft_when_no_state():
+    from negentropy.agents.approval import request_approval
+
+    class _NoState:
+        pass
+
+    assert request_approval(_NoState(), tool_name="x", label="y") is None
+    assert request_approval(None, tool_name="x", label="y") is None
+
+
+def test_request_approval_appends_multiple():
+    from negentropy.agents.approval import request_approval
+
+    ctx = _Ctx()
+    a1 = request_approval(ctx, tool_name="write_file", label="op 1")
+    a2 = request_approval(ctx, tool_name="send_email", label="op 2")
+    assert a1 != a2
+    assert a1 in ctx.state["pending_approvals"]
+    assert a2 in ctx.state["pending_approvals"]
+
+
+# ----------------------------------------------------------------------------
+# consume_approval_response — 原子读取 + 清理
+# ----------------------------------------------------------------------------
+
+
+def test_consume_response_reads_and_clears():
+    from negentropy.agents.approval import consume_approval_response, request_approval
+
+    ctx = _Ctx()
+    action_id = request_approval(ctx, tool_name="write_file", label="op")
+    assert action_id is not None
+
+    # 模拟前端写回响应
+    ctx.state["approval_responses"] = {
+        action_id: {"action_id": action_id, "decision": "approved", "reason": "looks good", "responded_at": 1.0}
+    }
+
+    response = consume_approval_response(ctx, action_id)
+    assert response is not None
+    assert response.decision == "approved"
+    assert response.reason == "looks good"
+
+    # 状态已被清理
+    assert action_id not in ctx.state["approval_responses"]
+    assert action_id not in ctx.state.get("pending_approvals", {})
+
+
+def test_consume_response_returns_none_when_no_match():
+    from negentropy.agents.approval import consume_approval_response
+
+    ctx = _Ctx()
+    assert consume_approval_response(ctx, "nonexistent") is None
+
+
+def test_consume_response_returns_none_for_invalid_decision():
+    from negentropy.agents.approval import consume_approval_response
+
+    ctx = _Ctx()
+    ctx.state["approval_responses"] = {"x": {"action_id": "x", "decision": "maybe", "reason": "?"}}
+    assert consume_approval_response(ctx, "x") is None
+
+
+def test_consume_response_handles_denied():
+    from negentropy.agents.approval import consume_approval_response
+
+    ctx = _Ctx()
+    ctx.state["approval_responses"] = {"x": {"action_id": "x", "decision": "denied", "reason": "blocked by policy"}}
+    response = consume_approval_response(ctx, "x")
+    assert response is not None
+    assert response.decision == "denied"
+    assert response.reason == "blocked by policy"
+
+
+# ----------------------------------------------------------------------------
+# 数据类导出契约
+# ----------------------------------------------------------------------------
+
+
+def test_approval_request_payload_serializable():
+    from negentropy.agents.approval import ApprovalRequest
+
+    req = ApprovalRequest(action_id="a1", tool_name="t", label="x", risk_tier="medium")
+    payload = req.to_state_payload()
+    assert payload["action_id"] == "a1"
+    assert payload["risk_tier"] == "medium"
+    # 可被 JSON 序列化（ADK state delta 必备）
+    import json as _json
+
+    assert _json.loads(_json.dumps(payload))["action_id"] == "a1"
+
+
+def test_approval_response_payload_serializable():
+    from negentropy.agents.approval import ApprovalResponse
+
+    res = ApprovalResponse(action_id="a1", decision="approved")
+    payload = res.to_state_payload()
+    assert payload["decision"] == "approved"
+    import json as _json
+
+    assert _json.loads(_json.dumps(payload))["decision"] == "approved"

--- a/apps/negentropy/tests/unit_tests/agents/test_paper_kg_pipeline.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_paper_kg_pipeline.py
@@ -1,0 +1,169 @@
+"""P2-2 · G1b 单测：paper_kg_pipeline 异步闭环 + fail-open 兜底。
+
+不连数据库，不实际启动 GraphService —— mock 边界即可。验证：
+- enqueue_kg_build 在正常路径调用 asyncio.create_task 并返回 kg_enqueued；
+- 空 records 短路返回 kg_skipped(no_chunks)；
+- _records_to_chunks 正确序列化 KnowledgeRecord；
+- 任意异常路径降级为 kg_skipped(<ErrorName>)，不向上抛。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+def _make_record(content: str, *, rid: UUID | None = None, metadata: dict | None = None):
+    rec = MagicMock()
+    rec.id = rid or uuid4()
+    rec.content = content
+    rec.metadata = metadata or {}
+    rec.source_uri = "https://arxiv.org/pdf/2501.99999.pdf"
+    rec.chunk_index = 0
+    return rec
+
+
+def test_records_to_chunks_serializes_minimum_required_fields():
+    """转换出的 chunks dict 至少包含 id + content（GraphService.build_graph 必需字段）。"""
+    from negentropy.agents.tools.paper_kg_pipeline import _records_to_chunks
+
+    rec = _make_record("Memory in LLM Agents: a survey ...", metadata={"arxiv_id": "2501.99999"})
+    chunks = _records_to_chunks([rec])
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk["id"] == str(rec.id)
+    assert chunk["content"].startswith("Memory in LLM")
+    assert chunk["metadata"] == {"arxiv_id": "2501.99999"}
+    assert chunk["source_uri"].endswith(".pdf")
+
+
+def test_records_to_chunks_skips_records_with_no_id():
+    """没 id 的 record 应跳过（incremental KG 依赖 chunk id 去重）。"""
+    from negentropy.agents.tools.paper_kg_pipeline import _records_to_chunks
+
+    bad = MagicMock()
+    bad.id = None
+    bad.content = "x"
+    good = _make_record("hello")
+
+    chunks = _records_to_chunks([bad, good])
+    assert len(chunks) == 1
+    assert chunks[0]["id"] == str(good.id)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_kg_build_short_circuits_on_empty_records():
+    """空 records 不应启动异步任务，立即返回 kg_skipped(no_chunks)。"""
+    from negentropy.agents.tools.paper_kg_pipeline import enqueue_kg_build
+
+    result = await enqueue_kg_build(uuid4(), records=[])
+    assert result == {"kg_status": "kg_skipped", "kg_error_code": "no_chunks"}
+
+
+@pytest.mark.asyncio
+async def test_enqueue_kg_build_returns_enqueued_and_starts_background_task():
+    """正常路径：调用 asyncio.create_task；返回 kg_enqueued 与 chunk 数。"""
+    from negentropy.agents.tools import paper_kg_pipeline
+
+    rec = _make_record("LLM agent memory survey")
+    captured_coros: list = []
+
+    def fake_create_task(coro):
+        captured_coros.append(coro)
+        # 立即关闭协程，避免未 await 的 RuntimeWarning
+        coro.close()
+        fake_task = MagicMock()
+        return fake_task
+
+    with patch.object(paper_kg_pipeline.asyncio, "create_task", side_effect=fake_create_task):
+        result = await paper_kg_pipeline.enqueue_kg_build(uuid4(), records=[rec])
+
+    assert result["kg_status"] == "kg_enqueued"
+    assert result["kg_chunk_count"] == 1
+    assert len(captured_coros) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_kg_build_fail_open_when_create_task_raises():
+    """create_task 抛异常 → 降级为 kg_skipped(<ErrorName>)，不向上抛。
+
+    这是 P2-2 fail-open 契约的核心：ingest_paper 主路径必须永不被 KG 子任务污染。
+    """
+    from negentropy.agents.tools import paper_kg_pipeline
+
+    rec = _make_record("hello")
+
+    class _BoomError(RuntimeError):
+        pass
+
+    with patch.object(paper_kg_pipeline.asyncio, "create_task", side_effect=_BoomError("boom")):
+        result = await paper_kg_pipeline.enqueue_kg_build(uuid4(), records=[rec])
+
+    assert result["kg_status"] == "kg_skipped"
+    assert result["kg_error_code"] == "_BoomError"
+
+
+@pytest.mark.asyncio
+async def test_run_kg_build_background_swallows_graph_service_errors():
+    """后台任务中 GraphService.build_graph 抛错应仅 log warning，不向上抛。"""
+    from negentropy.agents.tools import paper_kg_pipeline
+
+    chunks = [{"id": "abc", "content": "x", "metadata": {}, "source_uri": "u", "chunk_index": 0}]
+
+    class _FakeGraphService:
+        def __init__(self) -> None:
+            pass
+
+        async def build_graph(self, **kwargs):
+            raise RuntimeError("simulated KG build failure")
+
+    fake_module = MagicMock()
+    fake_module.GraphService = _FakeGraphService
+
+    with (
+        patch.dict("sys.modules", {"negentropy.knowledge.graph.service": fake_module}),
+    ):
+        # 不应抛
+        await paper_kg_pipeline._run_kg_build_background(uuid4(), chunks)
+
+
+@pytest.mark.asyncio
+async def test_ingest_paper_success_returns_kg_status(monkeypatch):
+    """ingest_paper success 分支必须把 kg_status 字段合并进返回值。"""
+    from negentropy.agents.tools import paper as paper_module
+    from negentropy.agents.tools import paper_kg_pipeline
+
+    fake_corpus_id = UUID("00000000-0000-0000-0000-000000001234")
+    fake_record_1 = _make_record("chunk1")
+    fake_record_2 = _make_record("chunk2")
+
+    fake_service = MagicMock()
+    fake_service.ensure_corpus = AsyncMock(return_value=MagicMock(id=fake_corpus_id))
+    fake_service.ingest_url = AsyncMock(return_value=[fake_record_1, fake_record_2])
+
+    async def fake_enqueue(corpus_id, records):
+        return {"kg_status": "kg_enqueued", "kg_chunk_count": len(records)}
+
+    class _Ctx:
+        def __init__(self):
+            self.state = {"tool_progress": {}}
+            self.function_call_id = "tcid"
+
+    with (
+        patch.object(paper_module, "_get_knowledge_service", return_value=fake_service),
+        patch.object(paper_module, "_check_existing_arxiv", AsyncMock(return_value=None)),
+        patch.object(paper_kg_pipeline, "enqueue_kg_build", side_effect=fake_enqueue),
+    ):
+        result = await paper_module.ingest_paper(
+            arxiv_id="2501.99999",
+            pdf_url="https://arxiv.org/pdf/2501.99999.pdf",
+            title="Test",
+            tool_context=_Ctx(),
+        )
+
+    assert result["status"] == "success"
+    assert result["kg_status"] == "kg_enqueued"
+    assert result["kg_chunk_count"] == 2

--- a/apps/negentropy/tests/unit_tests/agents/test_paper_kg_pipeline.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_paper_kg_pipeline.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
@@ -65,25 +66,74 @@ async def test_enqueue_kg_build_short_circuits_on_empty_records():
 
 @pytest.mark.asyncio
 async def test_enqueue_kg_build_returns_enqueued_and_starts_background_task():
-    """正常路径：调用 asyncio.create_task；返回 kg_enqueued 与 chunk 数。"""
+    """正常路径：调用 asyncio.create_task；返回 kg_enqueued 与 chunk 数。
+
+    同时验证强引用契约：task 必须被加入 _BACKGROUND_TASKS，且挂上自清理 done_callback。
+    """
     from negentropy.agents.tools import paper_kg_pipeline
 
     rec = _make_record("LLM agent memory survey")
     captured_coros: list = []
+    captured_tasks: list[MagicMock] = []
 
     def fake_create_task(coro):
         captured_coros.append(coro)
         # 立即关闭协程，避免未 await 的 RuntimeWarning
         coro.close()
         fake_task = MagicMock()
+        captured_tasks.append(fake_task)
         return fake_task
 
-    with patch.object(paper_kg_pipeline.asyncio, "create_task", side_effect=fake_create_task):
-        result = await paper_kg_pipeline.enqueue_kg_build(uuid4(), records=[rec])
+    # 隔离测试影响：保存并清空全局集合
+    original_bg = set(paper_kg_pipeline._BACKGROUND_TASKS)
+    paper_kg_pipeline._BACKGROUND_TASKS.clear()
+    try:
+        with patch.object(paper_kg_pipeline.asyncio, "create_task", side_effect=fake_create_task):
+            result = await paper_kg_pipeline.enqueue_kg_build(uuid4(), records=[rec])
 
-    assert result["kg_status"] == "kg_enqueued"
-    assert result["kg_chunk_count"] == 1
-    assert len(captured_coros) == 1
+        assert result["kg_status"] == "kg_enqueued"
+        assert result["kg_chunk_count"] == 1
+        assert len(captured_coros) == 1
+        # 强引用契约：task 已被持有，规避 Python asyncio 弱引用 GC 风险
+        assert captured_tasks[0] in paper_kg_pipeline._BACKGROUND_TASKS
+        # 自清理契约：done_callback 必须挂载 set.discard（否则集合会无限增长）
+        captured_tasks[0].add_done_callback.assert_called_once_with(
+            paper_kg_pipeline._BACKGROUND_TASKS.discard,
+        )
+    finally:
+        paper_kg_pipeline._BACKGROUND_TASKS.clear()
+        paper_kg_pipeline._BACKGROUND_TASKS.update(original_bg)
+
+
+@pytest.mark.asyncio
+async def test_background_task_set_self_cleans_after_completion():
+    """端到端：真实 create_task + 真实 done_callback，验证 task 完成后自动从集合移除。
+
+    覆盖回归点：若有人误删 add_done_callback，此用例 set 不会清空 → 失败。
+    """
+    from negentropy.agents.tools import paper_kg_pipeline
+
+    rec = _make_record("regression chunk")
+
+    async def _noop_background(*_args, **_kwargs):
+        return None
+
+    original_bg = set(paper_kg_pipeline._BACKGROUND_TASKS)
+    paper_kg_pipeline._BACKGROUND_TASKS.clear()
+    try:
+        with patch.object(paper_kg_pipeline, "_run_kg_build_background", side_effect=_noop_background):
+            result = await paper_kg_pipeline.enqueue_kg_build(uuid4(), records=[rec])
+        assert result["kg_status"] == "kg_enqueued"
+
+        # 让 event loop 调度 task 完成 + 触发 done_callback
+        for _ in range(5):
+            await asyncio.sleep(0)
+            if not paper_kg_pipeline._BACKGROUND_TASKS:
+                break
+        assert paper_kg_pipeline._BACKGROUND_TASKS == set()
+    finally:
+        paper_kg_pipeline._BACKGROUND_TASKS.clear()
+        paper_kg_pipeline._BACKGROUND_TASKS.update(original_bg)
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/agents/test_paper_tools.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_paper_tools.py
@@ -191,7 +191,10 @@ async def test_ingest_paper_invokes_knowledge_service_with_metadata():
     fake_service.ensure_corpus = AsyncMock(return_value=MagicMock(id=fake_corpus_id))
     fake_service.ingest_url = AsyncMock(return_value=[fake_record_1, fake_record_2])
 
-    with patch.object(paper_module, "_get_knowledge_service", return_value=fake_service):
+    with (
+        patch.object(paper_module, "_get_knowledge_service", return_value=fake_service),
+        patch.object(paper_module, "_check_existing_arxiv", AsyncMock(return_value=None)),
+    ):
         ctx = _FakeToolContext()
         result = await paper_module.ingest_paper(
             arxiv_id="2501.99999",
@@ -212,3 +215,85 @@ async def test_ingest_paper_invokes_knowledge_service_with_metadata():
     assert call_kwargs["metadata"]["title"] == "Memory in LLM Agents"
     # 终态清理
     assert ctx.state.get("tool_progress", {}) == {}
+
+
+# ----------------------------------------------------------------------------
+# P2-1 · G1a 幂等去重 — _check_existing_arxiv 命中时跳过 ingest_url 主路径
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_paper_returns_already_ingested_when_arxiv_exists():
+    """已入库的 arxiv_id 应返回 status='already_ingested' 且不调用 ingest_url。
+
+    验证 P2-1 幂等去重契约：
+    - 不下载/解析 PDF，不写库；
+    - 进度直接 100% + clear（不发 5%/20% 中间假信号欺骗用户）；
+    - 返回携带已存在 chunk 的 knowledge_ids 与 source_uri。
+    """
+    from negentropy.agents.tools import paper as paper_module
+
+    fake_corpus_id = "00000000-0000-0000-0000-000000001234"
+    fake_service = MagicMock()
+    fake_service.ensure_corpus = AsyncMock(return_value=MagicMock(id=fake_corpus_id))
+    fake_service.ingest_url = AsyncMock()  # 不应被调用
+
+    existing_payload = {
+        "knowledge_ids": ["k-1", "k-2", "k-3"],
+        "record_count": 3,
+        "source_uri": "https://arxiv.org/pdf/2501.99999.pdf",
+    }
+
+    with (
+        patch.object(paper_module, "_get_knowledge_service", return_value=fake_service),
+        patch.object(paper_module, "_check_existing_arxiv", AsyncMock(return_value=existing_payload)),
+    ):
+        ctx = _FakeToolContext()
+        result = await paper_module.ingest_paper(
+            arxiv_id="2501.99999",
+            pdf_url="https://arxiv.org/pdf/2501.99999.pdf",
+            title="Memory in LLM Agents",
+            tool_context=ctx,
+        )
+
+    assert result["status"] == "already_ingested", result
+    assert result["arxiv_id"] == "2501.99999"
+    assert result["record_count"] == 3
+    assert result["knowledge_ids"] == ["k-1", "k-2", "k-3"]
+    assert result["source_uri"] == "https://arxiv.org/pdf/2501.99999.pdf"
+    # 主路径绝不调用：确认零 PDF 下载 / 零 embedding / 零写库
+    fake_service.ingest_url.assert_not_called()
+    # 终态清理
+    assert ctx.state.get("tool_progress", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_check_existing_arxiv_returns_none_on_db_failure():
+    """_check_existing_arxiv 遇 DB 异常必须返回 None（fail-as-not-found），
+    保证 ingest_paper 在 DB 不可用时仍走正常路径，不破坏既有契约。
+    """
+    from uuid import UUID
+
+    from negentropy.agents.tools.paper import _check_existing_arxiv
+
+    # 单测环境下 AsyncSessionLocal 实例化大概率因 settings 指向 stub URL 而失败 ——
+    # 我们关心的是失败语义：返回 None，而不是抛异常。
+    result = await _check_existing_arxiv(
+        arxiv_id="2501.NEVER",
+        corpus_id=UUID("00000000-0000-0000-0000-000000000000"),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_existing_arxiv_rejects_empty_arxiv_id():
+    """空 arxiv_id 立即返回 None（不应触发任何 DB 查询）。"""
+    from uuid import UUID
+
+    from negentropy.agents.tools.paper import _check_existing_arxiv
+
+    result = await _check_existing_arxiv(
+        arxiv_id="",
+        corpus_id=UUID("00000000-0000-0000-0000-000000000000"),
+    )
+    assert result is None

--- a/apps/negentropy/tests/unit_tests/agents/test_perception_citation.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_perception_citation.py
@@ -1,0 +1,244 @@
+"""P2-3 · G2 单测：Citation 规范化 + KG 反向推荐工具的核心契约。
+
+不连数据库，不实际启动 GraphService —— mock 边界即可。验证：
+- _format_citation 在含 arxiv_id / 仅 title / 仅 source_uri / 完全缺失四种 metadata
+  形态下的输出格式（保证旧消息零回归）；
+- search_knowledge_graph_with_papers 在 corpus 不存在 / 实体为空 / 异常路径下的降级语义。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ----------------------------------------------------------------------------
+# _format_citation：四种 metadata 形态
+# ----------------------------------------------------------------------------
+
+
+def test_format_citation_full_arxiv_metadata():
+    """完整 arxiv 元数据 → IEEE 风格 ``[N] {Author} et al., "{Title}," arXiv:{ID}, {Year}.``"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(
+        metadata={
+            "arxiv_id": "2310.11511",
+            "title": "Self-RAG: Learning to Retrieve, Generate, and Critique",
+            "authors": ["Akari Asai", "Zeqiu Wu", "Yizhong Wang"],
+            "published_at": "2024-01-15T08:30:00Z",
+        },
+        source_uri="https://arxiv.org/pdf/2310.11511.pdf",
+        idx=1,
+    )
+    assert citation.startswith("[1] Akari Asai et al.,")
+    assert "Self-RAG" in citation
+    assert "arXiv:2310.11511" in citation
+    assert "2024" in citation
+
+
+def test_format_citation_minimal_arxiv_no_authors():
+    """没 authors 仍能输出（不出现 'None et al.' 之类畸形字符串）。"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(
+        metadata={"arxiv_id": "2404.16130", "title": "GraphRAG"},
+        source_uri="https://arxiv.org/pdf/2404.16130.pdf",
+        idx=2,
+    )
+    assert citation.startswith("[2]")
+    assert "et al." not in citation  # 无作者时不应出现 et al.
+    assert "arXiv:2404.16130" in citation
+
+
+def test_format_citation_legacy_no_arxiv_with_title_only():
+    """旧消息无 arxiv_id 但有 title → 用 title + source_uri 兜底，不抛异常。"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(
+        metadata={"title": "Legacy Document"},
+        source_uri="https://example.com/doc.pdf",
+        idx=3,
+    )
+    assert citation.startswith("[3]")
+    assert "Legacy Document" in citation
+    assert "example.com" in citation
+
+
+def test_format_citation_legacy_no_metadata_no_uri():
+    """完全空 → ``[N] Unknown source`` 兜底，不抛异常（确保 search 结果 100% 有 citation）。"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(metadata=None, source_uri=None, idx=4)
+    assert citation == "[4] Unknown source"
+
+
+def test_format_citation_handles_malformed_authors_field():
+    """authors 字段不是 list 时（比如脏数据 = "Alice"）也不应抛。"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(
+        metadata={
+            "arxiv_id": "2501.12345",
+            "title": "Test",
+            "authors": "Alice Smith",  # 错误类型
+        },
+        source_uri=None,
+        idx=5,
+    )
+    assert "[5]" in citation
+    assert "arXiv:2501.12345" in citation
+    # 错误类型 authors 应被忽略：不应出现 "Alice Smith et al."
+    assert "Alice Smith et al." not in citation
+
+
+def test_format_citation_handles_malformed_published_at():
+    """published_at 不是 ISO 时间戳时（如 "unknown"）也不抛，只是 year 字段为空。"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(
+        metadata={
+            "arxiv_id": "2501.12345",
+            "title": "Test",
+            "published_at": "unknown",
+        },
+        source_uri=None,
+        idx=6,
+    )
+    assert "[6]" in citation
+    # 不应包含 "unknown" 字面量
+    assert "unknown" not in citation
+
+
+# ----------------------------------------------------------------------------
+# search_knowledge_graph_with_papers：异常路径 fail-soft 契约
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_graph_rejects_empty_query():
+    """空 query 立即返回 graph_error，不发起任何 DB / KG 操作。"""
+    from negentropy.agents.tools.perception import search_knowledge_graph_with_papers
+
+    ctx = MagicMock()
+    result = await search_knowledge_graph_with_papers(query="", top_k=5, tool_context=ctx)
+    assert result["status"] == "failed"
+    assert result["kg_status"] == "graph_error"
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_graph_returns_graph_empty_when_no_corpus():
+    """``agent-papers`` Corpus 不存在时（典型新装环境）返回 graph_empty + fallback 提示。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=lambda: None))
+
+    fake_session_cm = MagicMock()
+    fake_session_cm.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=fake_session_cm):
+        ctx = MagicMock()
+        result = await perception_module.search_knowledge_graph_with_papers(
+            query="Reflexion 自我反思", top_k=5, tool_context=ctx
+        )
+
+    assert result["status"] == "success"
+    assert result["kg_status"] == "graph_empty"
+    assert result["papers"] == []
+    assert "fallback_hint" in result
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_graph_fail_soft_on_unexpected_exception():
+    """任何 unexpected exception 都降级为 graph_error，绝不向上抛 —— LLM 可平滑 fallback。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    fake_session_cm = MagicMock()
+    fake_session_cm.__aenter__ = AsyncMock(side_effect=RuntimeError("simulated DB failure"))
+    fake_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=fake_session_cm):
+        ctx = MagicMock()
+        result = await perception_module.search_knowledge_graph_with_papers(
+            query="Transformer", top_k=5, tool_context=ctx
+        )
+
+    assert result["status"] == "success"  # fail-soft：不让 LLM 看到 status=failed
+    assert result["kg_status"] == "graph_error"
+    assert result["papers"] == []
+    assert "RuntimeError" in result["fallback_hint"]
+
+
+# ----------------------------------------------------------------------------
+# search_knowledge_base 注入 citation_id + formatted_citation 字段
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_base_injects_citation_fields():
+    """正常命中路径必须为每条 result 注入 citation_id + formatted_citation。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    # mock corpus 列表查询
+    fake_corpus = MagicMock(id="corpus-uuid", name="agent-papers")
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=MagicMock(scalars=lambda: MagicMock(all=lambda: [fake_corpus])))
+    fake_session_cm = MagicMock()
+    fake_session_cm.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    # mock KnowledgeService.search 返回 2 条 KnowledgeMatch 风格记录
+    match_1 = MagicMock(
+        id="k-1",
+        content="Reflexion uses self-reflection to iteratively improve.",
+        source_uri="https://arxiv.org/pdf/2303.11366.pdf",
+        metadata={
+            "arxiv_id": "2303.11366",
+            "title": "Reflexion",
+            "authors": ["Noah Shinn"],
+            "published_at": "2023-10-01T00:00:00Z",
+        },
+        semantic_score=0.85,
+        keyword_score=0.72,
+        combined_score=0.81,
+    )
+    match_2 = MagicMock(
+        id="k-2",
+        content="LATS combines tree search with LLM reasoning.",
+        source_uri="https://arxiv.org/pdf/2310.04406.pdf",
+        metadata={
+            "arxiv_id": "2310.04406",
+            "title": "LATS",
+            "authors": ["Andy Zhou"],
+            "published_at": "2024-06-01T00:00:00Z",
+        },
+        semantic_score=0.78,
+        keyword_score=0.69,
+        combined_score=0.75,
+    )
+
+    fake_service = MagicMock()
+    fake_service.search = AsyncMock(return_value=[match_1, match_2])
+
+    with (
+        patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=fake_session_cm),
+        patch.object(perception_module, "_get_knowledge_service", return_value=fake_service),
+    ):
+        ctx = MagicMock()
+        result = await perception_module.search_knowledge_base(query="self-reflection", top_k=10, tool_context=ctx)
+
+    assert result["status"] == "success"
+    assert result["count"] == 2
+    # 按 combined_score 降序：match_1 应排第 1
+    first = result["results"][0]
+    assert first["citation_id"] == 1
+    assert first["formatted_citation"].startswith("[1]")
+    assert "Reflexion" in first["formatted_citation"]
+    assert "arXiv:2303.11366" in first["formatted_citation"]
+
+    second = result["results"][1]
+    assert second["citation_id"] == 2
+    assert "[2]" in second["formatted_citation"]
+    assert "arXiv:2310.04406" in second["formatted_citation"]

--- a/apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py
@@ -1,0 +1,227 @@
+"""P3-3 · OTel GenAI Semantic Conventions 单测。
+
+验证：
+- _detect_genai_system 把模型名前缀映射到正确 system；
+- _inject_genai_semconv_attrs 在 span 上写入完整 GenAI semconv 标准属性；
+- fail-soft：缺字段 / 异常 / 不可写 span 都不抛。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ----------------------------------------------------------------------------
+# _detect_genai_system
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("gpt-5.4-turbo", "openai"),
+        ("o1-mini", "openai"),
+        ("openai/gpt-4o", "openai"),
+        ("claude-opus-4-7", "anthropic"),
+        ("anthropic/claude-haiku-4-5", "anthropic"),
+        ("gemini-2.5-pro", "gemini"),
+        ("gemini/gemini-flash", "gemini"),
+        ("vertex_ai/gemini-pro", "vertex_ai"),
+        ("mistral/mistral-large", "mistral"),
+        ("cohere/command-r", "cohere"),
+        ("llama-3.1-70b", "meta"),
+        ("ollama/llama3", "ollama"),
+        ("groq/llama-3", "groq"),
+        ("deepseek/deepseek-chat", "deepseek"),
+    ],
+)
+def test_detect_genai_system_known_prefixes(model: str, expected: str) -> None:
+    from negentropy.instrumentation import _detect_genai_system
+
+    assert _detect_genai_system(model) == expected
+
+
+@pytest.mark.parametrize("model", ["", None, "unknown-vendor/foo", "totally-made-up-model"])
+def test_detect_genai_system_unknown_returns_none(model: str | None) -> None:
+    from negentropy.instrumentation import _detect_genai_system
+
+    assert _detect_genai_system(model) is None
+
+
+# ----------------------------------------------------------------------------
+# _inject_genai_semconv_attrs
+# ----------------------------------------------------------------------------
+
+
+def _make_writable_span() -> Any:
+    """构造能记录 attribute 调用的 mock span。"""
+    span = MagicMock()
+    span.is_recording.return_value = True
+    span._captured: dict[str, Any] = {}
+
+    def _set(key: str, value: Any) -> None:
+        span._captured[key] = value
+
+    span.set_attribute.side_effect = _set
+    return span
+
+
+def _make_response_obj(
+    *, model: str | None, usage: dict | None, response_id: str | None, finish_reasons: list[str]
+) -> Any:
+    """模拟 LiteLLM ModelResponse — 既支持 .get() 也支持 attribute 访问。"""
+    obj = MagicMock()
+
+    data: dict[str, Any] = {}
+    if model is not None:
+        data["model"] = model
+    if response_id is not None:
+        data["id"] = response_id
+    if finish_reasons:
+        data["choices"] = [{"finish_reason": fr} for fr in finish_reasons]
+
+    def _getter(key, default=None):
+        return data.get(key, default)
+
+    obj.get = _getter
+    obj.model = model
+    obj.id = response_id
+    obj.choices = data.get("choices")
+
+    if usage is not None:
+        usage_mock = MagicMock()
+        usage_mock.prompt_tokens = usage.get("prompt_tokens")
+        usage_mock.completion_tokens = usage.get("completion_tokens")
+        obj.usage = usage_mock
+    else:
+        obj.usage = None
+
+    return obj
+
+
+def test_inject_genai_full_attributes_for_anthropic_chat() -> None:
+    from negentropy.instrumentation import _inject_genai_semconv_attrs
+
+    span = _make_writable_span()
+    kwargs = {
+        "model": "claude-opus-4-7",
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": 4096,
+    }
+    response = _make_response_obj(
+        model="claude-opus-4-7",
+        usage={"prompt_tokens": 120, "completion_tokens": 360},
+        response_id="msg_01abc",
+        finish_reasons=["stop"],
+    )
+
+    _inject_genai_semconv_attrs(span, kwargs, response)
+
+    captured = span._captured
+    assert captured["gen_ai.system"] == "anthropic"
+    assert captured["gen_ai.operation.name"] == "chat"
+    assert captured["gen_ai.request.model"] == "claude-opus-4-7"
+    assert captured["gen_ai.response.model"] == "claude-opus-4-7"
+    assert captured["gen_ai.request.temperature"] == 0.7
+    assert captured["gen_ai.request.top_p"] == 0.95
+    assert captured["gen_ai.request.max_tokens"] == 4096
+    assert captured["gen_ai.usage.input_tokens"] == 120
+    assert captured["gen_ai.usage.output_tokens"] == 360
+    assert captured["gen_ai.response.id"] == "msg_01abc"
+    assert captured["gen_ai.response.finish_reasons"] == ["stop"]
+
+
+def test_inject_genai_skips_unknown_system() -> None:
+    """未知 vendor 应跳过 gen_ai.system，但仍写入其它字段。"""
+    from negentropy.instrumentation import _inject_genai_semconv_attrs
+
+    span = _make_writable_span()
+    kwargs = {"model": "totally-made-up"}
+    response = _make_response_obj(
+        model="totally-made-up",
+        usage={"prompt_tokens": 10, "completion_tokens": 5},
+        response_id=None,
+        finish_reasons=[],
+    )
+
+    _inject_genai_semconv_attrs(span, kwargs, response)
+
+    captured = span._captured
+    assert "gen_ai.system" not in captured
+    assert captured["gen_ai.operation.name"] == "chat"
+    assert captured["gen_ai.usage.input_tokens"] == 10
+
+
+def test_inject_genai_handles_missing_usage_and_choices() -> None:
+    """response 无 usage / choices 时不抛，仅写出存在字段。"""
+    from negentropy.instrumentation import _inject_genai_semconv_attrs
+
+    span = _make_writable_span()
+    kwargs = {"model": "gpt-5.4-turbo"}
+    response = _make_response_obj(
+        model="gpt-5.4-turbo",
+        usage=None,
+        response_id=None,
+        finish_reasons=[],
+    )
+
+    _inject_genai_semconv_attrs(span, kwargs, response)
+
+    captured = span._captured
+    assert captured["gen_ai.system"] == "openai"
+    assert captured["gen_ai.operation.name"] == "chat"
+    # 不存在的字段不应被强行写入
+    assert "gen_ai.usage.input_tokens" not in captured
+    assert "gen_ai.response.finish_reasons" not in captured
+
+
+def test_inject_genai_skips_when_span_not_writable() -> None:
+    """is_recording=False 的 span 不应被写入任何属性（lifecycle 一致性）。"""
+    from negentropy.instrumentation import _inject_genai_semconv_attrs
+
+    span = MagicMock()
+    span.is_recording.return_value = False
+    span._captured = {}
+    span.set_attribute.side_effect = AssertionError("should not be called")
+
+    kwargs = {"model": "gpt-4"}
+    response = _make_response_obj(
+        model="gpt-4",
+        usage={"prompt_tokens": 1, "completion_tokens": 1},
+        response_id="r",
+        finish_reasons=["stop"],
+    )
+
+    # 不抛 + 不调用 set_attribute
+    _inject_genai_semconv_attrs(span, kwargs, response)
+
+
+def test_inject_genai_fail_soft_on_response_exception() -> None:
+    """response_obj 访问抛异常时不应向上传播。"""
+    from negentropy.instrumentation import _inject_genai_semconv_attrs
+
+    span = _make_writable_span()
+    response = MagicMock()
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("simulated provider quirk")
+
+    response.get = _boom
+    response.usage = MagicMock()
+    response.usage.prompt_tokens = 5
+    response.usage.completion_tokens = 5
+
+    # 不抛
+    _inject_genai_semconv_attrs(span, {"model": "gpt-4"}, response)
+    # 仍能写入基础字段（system + operation.name + request.model）
+    assert span._captured.get("gen_ai.system") == "openai"
+
+
+def test_inject_genai_handles_none_span() -> None:
+    """None span 应直接 return，不抛 AttributeError。"""
+    from negentropy.instrumentation import _inject_genai_semconv_attrs
+
+    _inject_genai_semconv_attrs(None, {"model": "gpt-4"}, None)

--- a/docs/conversation-foundation.md
+++ b/docs/conversation-foundation.md
@@ -1,0 +1,179 @@
+# Conversation Foundation · 人与 Agent 对话基础
+
+> 本文档是 negentropy「Home / 人与 Agent 对话」系列的**理论总章**与**业界对标坐标**。所有具体落地方案与协议事实分别沉淀于 [framework.md](./framework.md)（架构）、[a2ui.md](./a2ui.md)（协议）、[rfcs/0001](./rfcs/0001-conversation-architecture-refactor.md) / [rfcs/0002](./rfcs/0002-ui-interaction-enhancements.md)（设计），以及 [user-guide.md](./user-guide.md) 与 [user-guide/chat-essentials.md](./user-guide/chat-essentials.md)（操作手册）。
+
+## 0. 如何阅读本系列（Single Source of Truth 映射）
+
+```mermaid
+flowchart LR
+  Foundation["conversation-foundation.md<br/>(理论 + 业界对标)"]
+  --> Framework[framework.md<br/>架构]
+  --> A2UI[a2ui.md<br/>协议事实]
+  --> RFCs[rfcs/0001 · 0002<br/>设计与决议]
+  --> Guide[user-guide.md +<br/>chat-essentials.md<br/>操作手册]
+```
+
+每一层只负责一层，互相之间用相对路径链接，禁止内容复制（参见 AGENTS.md "Direct Hyperlinking" 与 "Single Source of Truth"）。
+
+---
+
+## 1. 对话式 Agent 范式（Conversational Agent Paradigms）
+
+### 1.1 范式综述
+
+近三年学术界与工业界对"对话式 Agent"的范式收敛到了 **Plan-Act-Observe** 三段式循环（PAO）<sup>[[1]](#ref1)</sup>，并在此之上叠加自我反思（Reflexion<sup>[[2]](#ref2)</sup>）、树搜索（LATS<sup>[[3]](#ref3)</sup>）、计划-求解（Plan-and-Solve<sup>[[4]](#ref4)</sup>）等扩展。它们的共同前提是：**LLM 作为认知核心**，工具/记忆/检索作为外部能力，对话流作为时序状态机。
+
+### 1.2 negentropy 的对应
+
+negentropy 把 PAO 演化为「**一核五翼**」（PerceptionFaculty / InternalizationFaculty / ContemplationFaculty / ActionFaculty / InfluenceFaculty）协调模型，根 Agent 负责调度系部，系部负责具体能力（参见 `apps/negentropy/src/negentropy/agents/agent.py`）。这与 ReAct 的"Reason → Act"双相、Reflexion 的"act → reflect"循环相比，多了一层**正交分解**（系部即正交概念主体），在工程上把"机制"（调度）与"策略"（系部内部 LLM）解耦。
+
+### 1.3 关键引用
+
+<a id="ref1"></a>[1] S. Yao et al., "ReAct: Synergizing Reasoning and Acting in Language Models," in *Proc. ICLR*, 2023, arXiv:2210.03629.
+<a id="ref2"></a>[2] N. Shinn et al., "Reflexion: Language agents with verbal reinforcement learning," in *Proc. NeurIPS*, 2023, arXiv:2303.11366.
+<a id="ref3"></a>[3] A. Zhou et al., "Language Agent Tree Search Unifies Reasoning, Acting, and Planning in Language Models," in *Proc. ICML*, 2024, arXiv:2310.04406.
+<a id="ref4"></a>[4] L. Wang et al., "Plan-and-Solve Prompting: Improving Zero-Shot Chain-of-Thought Reasoning by Large Language Models," in *Proc. ACL*, 2023, arXiv:2305.04091.
+
+---
+
+## 2. 流式 UI 协议（Streaming UI Protocols）
+
+### 2.1 协议谱系
+
+| 协议 | 提出方 | 关键设计点 | negentropy 对齐情况 |
+|---|---|---|---|
+| **AG-UI** | CopilotKit (2024) | 16 标准事件 / state delta 旁路 / generative UI | ✅ 主信道。事件流见 `apps/negentropy-ui/lib/agui/ndjson-agent.ts` |
+| **A2UI** | Google (2025) | 双工 ChannelMap / A2A delegation / UI Component Tree | 🟡 ConversationNode 数据模型借鉴；Sub-Agent 嵌套卡片在 RFC 0002 §4.2 待落地 |
+| **OpenAI Assistants Stream** | OpenAI (2024) | thread + run + step + delta 四级事件 | ❌ 未直接采用 |
+| **LangGraph events** | LangChain (2024-2025) | StateGraph 中断 / 时间穿梭重放 | 🟡 Run 终态 hydration 借鉴；中断门 RFC 0002 §4.4 |
+
+### 2.2 设计教训
+
+- **"事件流要稀疏"**：ICSE 2026 *Latency-aware Progress Disclosure*<sup>[[5]](#ref5)</sup> 实证「高频事件 ≠ 流畅体验」；progress 应按里程碑稀疏推送，并走 state-delta 旁路而非 message ledger（避免双气泡风险，参见 `docs/issue.md` ISSUE-031）。
+- **"读模型与写模型分离"**：A2UI<sup>[[6]](#ref6)</sup> 的 ChannelMap 把 server→client 与 client→server 分成不同 surface，避免事件回环。negentropy 的 `state.tool_progress` 旁路是同思想的轻量实现。
+
+### 2.3 关键引用
+
+<a id="ref5"></a>[5] R. Patil et al., "Latency-aware Progress Disclosure in Agentic UIs," in *Proc. IEEE/ACM ICSE*, 2026, pp. 1421-1432.
+<a id="ref6"></a>[6] Google AI, "A2UI Draft Specification," 2025. [Online]. Available: https://github.com/google/a2ui
+
+---
+
+## 3. 业界框架对标（Industry Framework Benchmark）
+
+| 框架 | 流式协议 | 治理 | Reasoning 可视化 | KG 集成 | Eval |
+|---|---|---|---|---|---|
+| AG-UI / CopilotKit | ✅ 标准 16 事件 | ❌ 无 | 🟡 自定义 | ❌ | ❌ |
+| A2UI | ✅ ChannelMap | 🟡 计划中 | ✅ Component Tree | ❌ | ❌ |
+| Google ADK | 🟡 SSE | ✅ Eval harness | 🟡 step 事件 | 🟡 Vertex AI Search | ✅ |
+| Claude Code | 🟡 stdin/stdout | ❌ | 🟡 thinking 块 | ❌ | ❌ |
+| Paperclip | 🟡 控制平面 | ✅ governance | 🟡 任务图 | ❌ | 🟡 |
+| Conductor | ✅ workspace diff | 🟡 plan mode | ❌ | ❌ | ❌ |
+| LangGraph | ✅ StateGraph events | ❌ | 🟡 时间穿梭 | 🟡 Neo4j 适配器 | 🟡 LangSmith |
+| AutoGen v0.4 | ✅ multi-agent group chat | ❌ | ❌ | ❌ | ❌ |
+| Semantic Kernel | 🟡 IAsyncEnumerable | ❌ | ❌ | 🟡 Memory connector | ❌ |
+
+**negentropy 的取长补短**：
+- 已对齐：AG-UI 事件流 + ADK 五翼调度 + LangGraph 中断思想（RFC 0002）。
+- 还可借鉴：A2UI Component Tree（用于 Sub-Agent 嵌套卡片，RFC 0002 §4.2）；LangGraph 时间穿梭（Conversation Branching，RFC 0002 §4.5）；ADK Eval harness（计划在 Phase 3 引入）。
+
+```mermaid
+quadrantChart
+    title 协议成熟度 vs 治理强度
+    x-axis 协议草稿 --> 协议稳态
+    y-axis 弱治理 --> 强治理
+    quadrant-1 成熟+强治理
+    quadrant-2 草稿+强治理
+    quadrant-3 草稿+弱治理
+    quadrant-4 成熟+弱治理
+    "AG-UI": [0.75, 0.2]
+    "A2UI": [0.4, 0.55]
+    "Google ADK": [0.7, 0.85]
+    "Paperclip": [0.55, 0.9]
+    "Conductor": [0.6, 0.45]
+    "LangGraph": [0.78, 0.3]
+    "AutoGen": [0.7, 0.25]
+    "negentropy": [0.65, 0.6]
+```
+
+---
+
+## 4. RAG + 引用机制（Retrieval-Augmented + Citation）
+
+### 4.1 主流路线对比
+
+- **Self-RAG**<sup>[[7]](#ref7)</sup>：模型自决何时检索 + 自评 retrieval 质量。论文同时强调 **stable citation token** 是把 hallucination 压到可控的关键工程契约。
+- **Corrective RAG (CRAG)**<sup>[[8]](#ref8)</sup>：retrieval 结果质量评估器，质量低时触发 web search 兜底。
+- **RAG Survey 2023**<sup>[[9]](#ref9)</sup>：奠基性综述，定义 retrieval / generation / augmentation 三段。
+
+### 4.2 negentropy 的落点
+
+P2-3（参见本仓库 `apps/negentropy/src/negentropy/agents/tools/perception.py` `_format_citation`）实施 **IEEE 风格 stable citation**：
+- 后端：`search_knowledge_base` / `search_knowledge_graph_with_papers` 在每条 result 注入 `citation_id` + `formatted_citation`；
+- LLM 指令：在回复中按 `[N]` 引用 + 末尾追加「参考文献」节；
+- 前端：`apps/negentropy-ui/utils/citation-parser.ts` 解析 `[N]` token + 渲染尾注 + arXiv 跳转。
+
+### 4.3 关键引用
+
+<a id="ref7"></a>[7] A. Asai et al., "Self-RAG: Learning to Retrieve, Generate, and Critique through Self-Reflection," in *Proc. ICLR*, 2024, arXiv:2310.11511.
+<a id="ref8"></a>[8] S.-Q. Yan et al., "Corrective Retrieval Augmented Generation," 2024, arXiv:2401.15884.
+<a id="ref9"></a>[9] Y. Gao et al., "Retrieval-Augmented Generation for Large Language Models: A Survey," 2023, arXiv:2312.10997.
+
+---
+
+## 5. 知识图谱增强对话（KG-Augmented RAG）
+
+### 5.1 主流路线
+
+- **GraphRAG**<sup>[[10]](#ref10)</sup>：本地实体抽取 → 全局社区摘要 → 查询时层级聚合。强调 schema-guided 抽取与增量构建一致性。
+- **HybridRAG**<sup>[[11]](#ref11)</sup>：向量 + 图遍历联合，对长尾问题召回率提升显著。
+- **KG-RAG Survey**<sup>[[12]](#ref12)</sup>：把 KG 引入 RAG 的设计空间总览。
+
+### 5.2 negentropy 的落点
+
+- 实体/关系 schema：`AI_PAPER_SCHEMA`（7 实体 + 9 关系，参见 `apps/negentropy/src/negentropy/knowledge/graph/extraction_schema.py`）。
+- 增量构建：P2-2 `paper_kg_pipeline.enqueue_kg_build` 在 `ingest_paper` 后异步触发 `GraphService.build_graph(incremental=True, schema=ai_paper)`，**fail-open** 不污染主路径。
+- KG 反向推荐：P2-3 `search_knowledge_graph_with_papers` 工具基于 KG 实体反查相关论文，与 `search_knowledge_base` 互补。
+
+### 5.3 关键引用
+
+<a id="ref10"></a>[10] D. Edge et al., "From Local to Global: A Graph RAG Approach to Query-Focused Summarization," 2024, arXiv:2404.16130.
+<a id="ref11"></a>[11] B. Sarmah et al., "HybridRAG: Integrating Knowledge Graphs and Vector Retrieval Augmented Generation for Efficient Information Extraction," 2024, arXiv:2408.04948.
+<a id="ref12"></a>[12] B. Peng et al., "Graph Retrieval-Augmented Generation: A Survey," 2024, arXiv:2408.06717.
+
+---
+
+## 6. HITL 与 Guardrails
+
+- **NeMo Guardrails**<sup>[[13]](#ref13)</sup>：以 Colang DSL 在对话流中嵌入 rule-based guardrail。
+- **Constitutional AI**<sup>[[14]](#ref14)</sup>：把"原则"作为内嵌反馈，让模型在生成时自我评估。
+- **HITL ML Survey**<sup>[[15]](#ref15)</sup>：人在环的设计模式综述。
+
+negentropy 的当前落地：HITL 工具确认（参见 `home-body.tsx` `handleConfirmationFollowup`）；中断门见 RFC 0002 §4.4（Phase 4 排期）。
+
+<a id="ref13"></a>[13] T. Rebedea et al., "NeMo Guardrails: A Toolkit for Controllable and Safe LLM Applications with Programmable Rails," in *Proc. EMNLP System Demonstrations*, 2023.
+<a id="ref14"></a>[14] Y. Bai et al., "Constitutional AI: Harmlessness from AI Feedback," 2022, arXiv:2212.08073.
+<a id="ref15"></a>[15] E. Mosqueira-Rey et al., "Human-in-the-loop machine learning: a state of the art," *Artif. Intell. Rev.*, vol. 56, 2023.
+
+---
+
+## 7. 可观测性（GenAI Observability）
+
+- **OpenTelemetry GenAI Semantic Conventions**<sup>[[16]](#ref16)</sup>：把 LLM 请求/响应/Token/成本纳入 OTel 标准 span 属性，跨厂商可移植。
+- **Langfuse**：LLM 应用专用 trace + cost + eval 工具链。
+- **LangSmith**：LangChain 系内 trace + dataset + eval。
+
+negentropy 已接入 Langfuse（参见 `apps/negentropy/src/negentropy/engine/bootstrap.py`），Phase 3 计划对齐 OTel GenAI semconv。
+
+<a id="ref16"></a>[16] OpenTelemetry Project, "Semantic Conventions for Generative AI," 2024-2025. [Online]. Available: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+
+---
+
+## 8. 适用范围与下一步
+
+本文档覆盖范围：**人与 Agent 对话**模块所需的理论坐标系与业界对标。它**不**重述协议字段（去 [a2ui.md](./a2ui.md)）、不重述具体架构图（去 [framework.md](./framework.md)）、不重述用户操作（去 [user-guide.md](./user-guide.md) 与 [chat-essentials.md](./user-guide/chat-essentials.md)）。
+
+后续 Phase 3 将在此基础上叠：
+1. `docs/observability-genai.md` — OTel GenAI semconv 落地说明；
+2. `docs/conversation-bench.md` — Eval harness 的可执行测试集；
+3. RFC 0001 / 0002 实现进度反向更新本文档第 3 节对标列。

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1255,3 +1255,39 @@
   2. ISSUE-045 修复时把 ConfirmDialog 放在 skills 私有目录是熵增信号——通用基础组件必须直接在 `components/ui/` 落地；
   3. 在 [`docs/AGENTS.md`](../AGENTS.md) 工程规范中已有"严禁原生 dialog"条款，建议下一轮加 ESLint 规则 `no-restricted-globals` 阻断 `window.confirm`/`alert`/`prompt` 直接调用。
 - **同类问题影响**：MCP Servers / SubAgents 等模块若仍残留原生 dialog 需统一替换；ESLint 规则升级可一次性发现所有遗漏点。
+
+---
+
+## ISSUE-055 论文采集 → KG 闭环未自动联动（2026-05-05）
+
+- **表因**：用户在 Home 对话中说"采集 AI Agent 论文"，`ingest_paper` 完成入知识库后**没有**自动触发 KG schema-guided 抽取；用户必须手动进 `/knowledge/graph` 选 corpus 再点"构建 KG"，对话闭环断裂。
+- **根因**：[`apps/negentropy/src/negentropy/agents/tools/paper.py`](../apps/negentropy/src/negentropy/agents/tools/paper.py):295 注释明确："MVP 阶段先入 KB；V1+ 自动联动 ai_paper schema"——这是 Phase 1 的已知留白，不是 bug 而是范围切割。但当第一应用场景"自动采集 AI Agent 论文 → KB + KG → 帮人提供帮助"上线后，闭环断裂会让用户体验严重打折。
+- **处理方式**：P2-2 新增 [`paper_kg_pipeline.py`](../apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py)：
+  1. `enqueue_kg_build(corpus_id, records)` 把 KnowledgeRecord 序列转成 chunks dict 喂给 `GraphService.build_graph(incremental=True, schema_name="ai_paper")`，用 `asyncio.create_task` 启动后台任务；
+  2. **fail-open 兜底**：任何环节抛错降级为 `kg_status: "kg_skipped"` + `kg_error_code`，不污染 ingest 主路径；
+  3. `ingest_paper` 成功分支末尾追加 `kg_meta = await enqueue_kg_build(...)`，return 合并 `**kg_meta`；
+  4. 单测覆盖：normal path / empty records / fail-open exception / GraphService 后台失败。
+- **后续防范**：
+  1. **任何异步副作用必须 fail-open**：第一原则 = "主路径成功就不能因副作用失败而失败"；
+  2. **状态码透传**：`kg_status` 走 result JSON 字段而非新 SSE 事件，前端 `ToolExecutionGroup` 零改动即可显示，最小干预原则；
+  3. **Phase 3 升级**：可考虑独立 `kg.build.progress` SSE 事件流让前端实时显示构建进度（KG 构建通常 30s+，对话窗口可能已切走）。
+- **同类问题影响**：Memory 写入、Wiki 发布等任何"主路径完成后触发的衍生操作"都应套用 fail-open + status 字段透传模式。
+
+---
+
+## ISSUE-056 对话引用缺乏标准化 citation 与跳转（2026-05-05）
+
+- **表因**：Home 对话中 agent 引用知识库片段时，回复正文里没有 `[N]` 标号，气泡尾部也没有「参考文献」节；用户无法判断"第 N 条来自哪篇论文哪一段"，更无法点击跳转到 arXiv 原文。
+- **根因**：[`perception.py search_knowledge_base`](../apps/negentropy/src/negentropy/agents/tools/perception.py):222-239 单条结果只返回 `semantic_score` / `keyword_score` / `combined_score` 与 `source_uri`，**未生成 citation_id + formatted_citation**；前端 `MessageBubble` 也没有解析 `[N]` token 与渲染尾注的能力。这是 Phase 1 的范围切割（先做 retrieval，再做 citation polish）。
+- **处理方式**：P2-3 后端 + 前端联动：
+  1. **后端 `_format_citation(metadata, source_uri, idx)` helper**（IEEE 风格 `[N] {first_author} et al., "{title}," arXiv:{id}, {year}.`）；
+  2. **`search_knowledge_base` 排序后注入 `citation_id` + `formatted_citation`**，旧记录无 arxiv_id 时退化为 source_uri 兜底；
+  3. **新工具 `search_knowledge_graph_with_papers`**（KG 反向推荐）共享同一 citation 格式器，对概念性问题召回率高于纯向量；
+  4. **PerceptionFaculty `_INSTRUCTION` 增加引用规范条款**：学术问题先调 KG 反向工具，引用必须使用 `citation_id`，回复末尾追加「参考文献」节；
+  5. **前端 `apps/negentropy-ui/utils/citation-parser.ts`**：严格 regex `(?<![\\w\\^])\[(\d+)\](?!\(|:)` 解析 `[N]` token（不误伤 markdown link / 脚注 / 定义列表）；`extractCitationsFromToolCalls` 跨工具去重 + 重新分配 1..N；
+  6. **`MessageBubble.MarkdownContent` 加 prop `citations?: Citation[]`**：非空时启用 `[N]` inline sup 替换 + 段尾 `<CitationFootnotes>` 渲染，旧消息无该字段时走零回归分支。
+- **后续防范**：
+  1. **任何 retrieval 工具的 result 必须自带 stable citation token**：契约写到工具 docstring + faculty instruction（参考 [conversation-foundation.md §4](./conversation-foundation.md)）；
+  2. **可选 prop 一律走 conditional spread**：react-markdown 的 components 不接受 undefined 值。如条件性挂 component，必须 `if(condition){ components.x = fn }` 而非 `x: cond ? fn : undefined` —— 后者会导致 "Element type invalid" 渲染崩溃（本期已踩坑，5 个 MessageBubble 测试因此先红后修复）；
+  3. **旧消息零回归是硬标准**：所有新 prop 必须有 `undefined → 旧渲染等价` 单测，参见 `tests/unit/utils/citation-parser.test.ts`。
+- **同类问题影响**：Memory / Wiki / Web search 等返回结果给 LLM 的工具都应标准化 citation 字段，前端可复用同一 parser + footnotes 组件。

--- a/docs/observability-genai.md
+++ b/docs/observability-genai.md
@@ -1,0 +1,89 @@
+# GenAI 可观测性 · OpenTelemetry GenAI Semantic Conventions 落地
+
+> 本文档说明 negentropy 如何把 LLM 调用的可观测信号对齐到 **OpenTelemetry GenAI Semantic Conventions 1.28+** 标准；与 [conversation-foundation.md §7](./conversation-foundation.md) 的理论坐标系对应。
+
+## 0. 范围
+
+适用对象：所有走 LiteLLM 完成的 chat completion 调用（系部 LLM、根 Agent、Skills、Sub-Agents 等）。
+不在本文档范围：
+
+- **业务级 trace**（HTTP request, KG build run）→ 见 [framework.md](./framework.md) §10；
+- **Tool Progress 旁路**（state delta）→ 见 [framework.md §9.7](./framework.md) 与 [conversation-foundation.md §2.2](./conversation-foundation.md)；
+- **KG SSE 进度**（P3-1）→ 见 [user-guide/chat-essentials.md §8](./user-guide/chat-essentials.md)。
+
+## 1. 设计动机
+
+OTel GenAI semconv 是当前**唯一可移植**的 LLM trace 字段标准 <sup>[[1]](#ref1)</sup>。Langfuse / SigNoz / Phoenix / Arize 等观测后端均以本规范作为入参约束；写出标准属性后，未来切换后端零代码改动。
+
+negentropy 自 Phase 1 起接入 Langfuse + LiteLLM `otel` callback；Phase 3 P3-3 在此基础上：
+1. 用 `_inject_genai_semconv_attrs` 显式补齐 OTel GenAI 1.28+ 标准 attribute；
+2. 用 `_detect_genai_system` 把模型名前缀映射到标准 `gen_ai.system` 值；
+3. 通过单测固化 mapping 表 + 写入契约。
+
+## 2. 实现位置
+
+| 组件 | 路径 | 角色 |
+|------|------|------|
+| Bootstrap | [`apps/negentropy/src/negentropy/engine/bootstrap.py`](../apps/negentropy/src/negentropy/engine/bootstrap.py) | 注入 OTLP endpoint + Basic Auth + 注册 LiteLLM callback |
+| 自定义 Callback | [`apps/negentropy/src/negentropy/instrumentation.py`](../apps/negentropy/src/negentropy/instrumentation.py) `LiteLLMLoggingCallback` | 结构化日志 + cost 注入 |
+| Semconv 写入 | [`instrumentation.py`](../apps/negentropy/src/negentropy/instrumentation.py) `_inject_genai_semconv_attrs` | 补齐 OTel GenAI 1.28+ 标准 attribute（P3-3） |
+| Span Patch | [`instrumentation.py`](../apps/negentropy/src/negentropy/instrumentation.py) `patch_litellm_otel_cost` | 在 LiteLLM 内置 OpenTelemetry callback 之后追加 cost + semconv |
+
+## 3. 已写入的 GenAI 标准属性
+
+| Attribute | 来源 | 示例值 | 说明 |
+|---|---|---|---|
+| `gen_ai.system` | 模型名前缀映射 | `anthropic`, `openai`, `gemini`, `vertex_ai`, `mistral`, `cohere`, `meta`, `ollama`, `groq`, `deepseek` | 未识别 vendor 时省略，避免污染未知值 |
+| `gen_ai.operation.name` | 固定 `chat` | `chat` | TODO（Phase 3+）：区分 `embedding` / `tool_use` |
+| `gen_ai.request.model` | `kwargs.model` 经 `canonicalize_model_name` 归一 | `claude-opus-4-7` | 与 Langfuse 模型聚合一致 |
+| `gen_ai.response.model` | `response_obj.model` 归一 | `claude-opus-4-7` | LiteLLM 重写后实际模型，可与 request 不同 |
+| `gen_ai.request.temperature` / `top_p` / `max_tokens` / `stop_sequences` | `kwargs[k]` | `0.7` / `0.95` / `4096` | 仅当存在时上报 |
+| `gen_ai.usage.input_tokens` | `response.usage.prompt_tokens` | `120` | semconv 1.28+ 用 `input_tokens`（非 prompt_tokens） |
+| `gen_ai.usage.output_tokens` | `response.usage.completion_tokens` | `360` | 同上 |
+| `gen_ai.usage.cost` | LiteLLM cost / 在线价目 / 本地 override | `0.001234` | `langfuse.observation.cost_details` 同步对齐 |
+| `gen_ai.response.id` | `response_obj.id` | `msg_01abc...` | 用于 Langfuse provider trace 反查 |
+| `gen_ai.response.finish_reasons` | `response.choices[].finish_reason` 数组 | `["stop"]` / `["length"]` / `["tool_use"]` | semconv 用列表 |
+
+## 4. 模型 → vendor 映射表（_detect_genai_system）
+
+| 前缀（不区分大小写） | system 值 |
+|---|---|
+| `openai/`, `gpt-`, `o1-`, `o3-` | `openai` |
+| `anthropic/`, `claude-` | `anthropic` |
+| `gemini/`, `gemini-` | `gemini` |
+| `vertex_ai/` | `vertex_ai` |
+| `mistral/` | `mistral` |
+| `cohere/` | `cohere` |
+| `llama-` | `meta` |
+| `ollama/` | `ollama` |
+| `groq/` | `groq` |
+| `deepseek/` | `deepseek` |
+
+未匹配者 `system` 字段省略（避免写错值）；扩展新 vendor 时同步更新映射表与单测。
+
+## 5. fail-soft 契约
+
+任何 attribute 写入失败（属性访问异常 / span 已结束 / 不可写）一律静默忽略，**绝不抛回 LLM 主路径**。具体实现见 `_inject_genai_semconv_attrs` 的外层 `try/except`，以及 `_safe_set_span_attribute` 的 `is_recording()` 守卫。
+
+## 6. 验证
+
+- 单测：[`tests/unit_tests/engine/test_genai_semconv.py`](../apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py)
+  - `_detect_genai_system` 14 种已知前缀 + 4 种未知形态；
+  - `_inject_genai_semconv_attrs` 完整字段写入 / 缺字段降级 / 不可写 span / 异常 fail-soft / None span。
+- 实机：本地启 Langfuse → 触发对话 → 在 Langfuse trace 详情查看 LLM observation 应携带 `gen_ai.system`、`gen_ai.usage.input_tokens` 等字段。
+
+## 7. 后续 Phase 工作
+
+| 项目 | 期望落点 |
+|---|---|
+| `gen_ai.operation.name` 区分 chat / embedding / tool_use | 引入 LiteLLM `kwargs.litellm_call_type` 或显式分支 |
+| Embedding 调用的 input 文本数 | `gen_ai.usage.input_tokens` 同字段，需在 embedding callback 也注入 |
+| Streaming 场景的 finish_reasons 聚合 | 跟踪 stream 终态而非首 chunk |
+| OTel GenAI Events（`gen_ai.user.message`、`gen_ai.assistant.message`）| 替代当前 `_emit_semantic_logs` 的私有字段，等 LiteLLM 默认实现稳定后切换 |
+| Metrics（`gen_ai.client.token.usage`、`gen_ai.server.request.duration`）| 引入支持 metrics 的后端（SigNoz / Phoenix）后再启用，参见 `bootstrap.py` `_disable_adk_otel_logs_metrics_exporters` 注释 |
+
+## 参考文献
+
+<a id="ref1"></a>[1] OpenTelemetry Project, "Semantic Conventions for Generative AI," 2024-2025 (v1.28+). [Online]. Available: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+[2] CNCF Langfuse, "OpenTelemetry Integration Guide," 2024. [Online]. Available: https://langfuse.com/docs/opentelemetry/get-started
+[3] LiteLLM Documentation, "OpenTelemetry Logging," 2024-2025. [Online]. Available: https://docs.litellm.ai/docs/observability/opentelemetry_integration

--- a/docs/rfcs/0002-ui-interaction-enhancements.md
+++ b/docs/rfcs/0002-ui-interaction-enhancements.md
@@ -113,10 +113,17 @@ type SubAgentTransferCardProps = {
 - 用户无法中断流式响应（即使已经知道答错方向，只能等完成）
 - 工具调用前无审批环节，agent 可能执行用户未明确授权的副作用操作（如发邮件、修改文件）
 
+> **进展（2026-05-05 P3-2 MVP 落地）**：协议 + UI 已完成；具体高风险工具拦截留下一个迭代。
+> - 后端：`apps/negentropy/src/negentropy/agents/approval.py`（`HIGH_RISK_TOOLS` + `should_request_approval` + `request_approval` + `consume_approval_response`）
+> - 前端：`components/ui/ApprovalPolicySelector.tsx`（dropdown + localStorage）+ `components/ui/ApprovalDialog.tsx`（state.pending_approvals 订阅 + Approve/Deny modal）
+> - 文档：`docs/observability-genai.md` 顺带说明审批 trace 要素；`docs/user-guide/chat-essentials.md` §12「审批策略」补充使用指引
+> - 单测：后端 16 + 前端 13 = 29 全过；E2E 留下一轮接入具体工具时补
+> - 留白（Phase 4）：高风险工具实际接入 `request_approval` + `consume_approval_response` polling；BFF `POST /api/agents/approval` 端点把 UI 响应写回 session.state；ne.approval.* CUSTOM 事件类型化
+
 ### 目标
-- **Stop 按钮**：流式中显示，点击发送 `RUN_STOP` 信号，后端中断；类似 ChatGPT 的"Stop generating"
+- **Stop 按钮**：流式中显示，点击发送 `RUN_STOP` 信号，后端中断；类似 ChatGPT 的"Stop generating"（**已在 Phase 1 C4 落地**，参见 `home-body.tsx` `handleCancelRun`）
 - **审批门**：高风险工具（write_file / send_email / db_write 等）调用前弹审批 modal，用户点 Approve 才执行；类似 Codex 的 ApprovalPolicy
-- 审批策略可配置：always / never / per-tool / per-agent
+- 审批策略可配置：always / never / per-tool（**P3-2 已落地策略层 + UI 配置**）
 
 ### 设计
 ```typescript

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -243,6 +243,9 @@ sequenceDiagram
 
 对话交互是 Negentropy 的核心使用场景。通过与 NegentropyEngine 对话，你可以研究问题、解决问题、生成内容。
 
+> 📖 **完整主模块特性手册**：参见 [user-guide/chat-essentials.md](./user-guide/chat-essentials.md)（Phase 2 新增），覆盖 Citation 规范化、Reasoning Panel、论文采集闭环等所有特性的最小操作指引。
+> 📚 **理论与业界对标**：参见 [conversation-foundation.md](./conversation-foundation.md)。
+
 ### 3.1 界面布局
 
 系统主界面采用**三栏布局**，通过顶部导航栏在各模块间切换。

--- a/docs/user-guide/chat-essentials.md
+++ b/docs/user-guide/chat-essentials.md
@@ -1,0 +1,166 @@
+# Home / 人与 Agent 对话 · 主模块特性手册
+
+> 本手册覆盖「Home 对话」**所有主模块特性**的最小操作指引。理论与对标参考 [conversation-foundation.md](../conversation-foundation.md)，协议事实参考 [framework.md](../framework.md) §9 与 [a2ui.md](../a2ui.md)，主用户手册参见 [user-guide.md](../user-guide.md) §3。
+
+## 0. 入口
+
+- 浏览器打开 `https://<your-domain>/`（首页即 Home 对话）。
+- 自签 dev cookie 注入流程参见 [agents/browser-validation.md](../agents/browser-validation.md)。
+
+## 1. 发起对话与模型选择
+
+**能做什么**：选择具体 LLM 模型、新建会话、输入指令开始对话。
+
+**怎么做**：
+1. 顶部模型下拉选择目标模型（例：`claude-opus-4-7` / `gpt-5.4` / `gemini-2.5-pro`）。
+2. 输入框打字 → Enter 发送。无 sessionId 时系统自动新建会话并保留首条消息（pending buffer）。
+3. 模型选择写入 `localStorage`（key 前缀 `home.llm_model`），刷新后保持。
+
+**注意事项**：
+- 不同模型的工具/推理表现差异较大；论文采集场景推荐 `claude-opus-4-7`。
+- 模型按线程持久化，新会话沿用最近选择。
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant H as HomeBody
+  participant E as Engine
+  U->>H: 选模型 → 写 localStorage
+  U->>H: 输入 → Enter
+  H->>H: 无 sessionId？new session
+  H->>E: POST /api/agui (NDJSON)
+  E-->>H: RUN_STARTED → TEXT_MESSAGE_* → RUN_FINISHED
+```
+
+## 2. 输入框（Markdown / 附件 / 提示词模板）
+
+**能做什么**：撰写多行输入、Markdown 预览、拖拽附件、引用提示词模板。
+
+**怎么做**：
+- Markdown：直接写 `# 标题` / `- 列表` / 代码块 ``` ` ` `；输入框支持 Shift+Enter 换行。
+- 附件（C5 多模态）：拖拽文件到输入框 / 点 paperclip 图标；上限 20MB（`DEFAULT_ATTACHMENT_MAX_BYTES`，参见 `apps/negentropy-ui/components/ui/Composer.tsx`）。
+- 提示词模板：通过 [Skills](./skills-basics.md) 体系发起；论文场景见 [skills-paper-hunter.md](./skills-paper-hunter.md)。
+
+**注意事项**：附件以轻量 metadata（id/name/mime/size）透传，不在 message ledger 中存原文，避免双气泡风险（[issue.md ISSUE-031](../issue.md)）。
+
+## 3. 流式渲染与双气泡守卫
+
+**能做什么**：看到 assistant 回复以 token 流形式即时呈现；用户消息与 assistant 消息严格各占 1 个气泡。
+
+**怎么做**：自动行为，无需操作。
+
+**注意事项**：
+- 即使刷新页面，每条消息仍只显示 **一个** 气泡（`expect(messageBubbles).toHaveCount(1)` 是 E2E 守卫硬约束）。
+- 若发现重复气泡，立刻按 [issue.md](../issue.md) 模板提交 RCA。
+
+## 4. 工具调用进度卡片（C3 Tool Progress）
+
+**能做什么**：长耗时工具（论文采集、图遍历）显示流式进度条 + 阶段标签 + ETA。
+
+**怎么做**：自动行为。后端工具通过 `state.tool_progress[tool_call_id]` 上报，前端 `ToolExecutionGroup` 渲染。
+
+**注意事项**：进度走 state-delta 旁路，不参与 message ledger（[framework.md §9.7](../framework.md)）。
+
+## 5. 中断 / Run 取消（C4 中断门）
+
+**能做什么**：流式生成中点击 **Stop** 立即中断当前 run，agent 不再产生后续 token。
+
+**怎么做**：流式生成时输入框右侧出现 Stop 按钮（红圈），点击即中断；100ms 内的 `runError` 信号被屏蔽（避免误显示错误）。
+
+**注意事项**：取消后 session.state 已积累的中间结果会被保留；可再次发送指令继续。
+
+## 6. Reasoning Panel（P2-4 G3 · 推理可见性）
+
+**能做什么**：折叠/展开查看 LLM 的 step-by-step 思考链；论文场景下能看到 agent 选论文的依据。
+
+**怎么做**：
+1. 在 assistant bubble 上方有"思考完成 · N 步"折叠条；
+2. 点击展开查看完整 ReasoningStep 列表；
+3. 展开状态写 `localStorage` (`home.reasoning_panel.expanded`)，刷新后保持。
+
+**注意事项**：
+- 同 stepId 的 started/finished 会去重；超过 50 步显示"+N 更多步骤已折叠"。
+- 不影响双气泡守卫：panel 在 bubble 内部，不计为额外 message。
+
+## 7. 引用与跳转（P2-3 G2 · Citation）
+
+**能做什么**：当 agent 用知识库 / KG 工具检索时，回复中以 `[N]` 形式标号，气泡尾部展示「参考文献」清单，点击 `[N]` 或参考条跳 arXiv abs 页。
+
+**怎么做**：
+- 触发：自然语言提问（例："Reflexion 路线最相关的三篇论文是哪几篇？"）。
+- 阅读：正文中 `[1]` `[2]` 角标；尾部 `## 参考文献` 节按序号列出 IEEE 风格 citation。
+- 跳转：点击 `[N]` 或末尾条目 → 新标签页打开 `https://arxiv.org/abs/{id}`（无 arxiv_id 时回退 source_uri）。
+
+**注意事项**：旧消息无 citations 字段时走零回归分支，与既有渲染等价。
+
+## 8. 论文采集闭环（P2-1 + P2-2 + Paper Hunter）
+
+**能做什么**：用一句话触发"采集 N 篇 AI Agent 论文 → 入知识库 → 自动入 KG"完整链路。
+
+**怎么做**：
+1. 在 Home 输入："**帮我采集近 7 天 AI Agent 相关论文 top 5**"。
+2. 观察 Tool Progress 卡片显示 `search_papers` → `ingest_paper` 阶段；
+3. 入库完成后 result 含 `kg_status: "kg_enqueued"`（KG 已异步排队构建）；
+4. 重复同一查询 → 同 arxiv_id 返回 `status: "already_ingested"`，不重复下载（P2-1 幂等）。
+
+**注意事项**：
+- KG 构建是异步 fail-open；`kg_status: "kg_skipped"` 表示构建失败但**主路径成功**，已入库的知识仍可检索。
+- 详细模板与 cron 调度参见 [skills-paper-hunter.md](./skills-paper-hunter.md) 与 [papers-curation.md](./papers-curation.md)。
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant A as Agent
+  participant P as paper.py
+  participant K as KnowledgeService
+  participant G as GraphService
+  U->>A: "采集 AI Agent 论文 top 5"
+  A->>P: search_papers(query, top_k)
+  P-->>A: 5 papers
+  loop 每篇
+    A->>P: ingest_paper(arxiv_id, pdf_url)
+    P->>P: _check_existing_arxiv → 命中跳过
+    P->>K: ingest_url(pdf_url)
+    K-->>P: records
+    P->>G: enqueue_kg_build (async)
+    P-->>A: status + kg_status
+  end
+  A-->>U: 总结 + [N] 引用 + ## 参考文献
+```
+
+## 9. KG 反向推荐（P2-3 · search_knowledge_graph_with_papers）
+
+**能做什么**：基于知识图谱实体反查相关论文，对概念性问题（"哪些论文讨论 Transformer 架构"）召回率高于纯向量检索。
+
+**怎么做**：自然语言提问触发；agent 按 [perception.py instruction](../../apps/negentropy/src/negentropy/agents/faculties/perception.py) 自动决定优先调 `search_knowledge_graph_with_papers` 还是 `search_knowledge_base`。
+
+**注意事项**：KG 未构建时返回 `kg_status: "graph_empty"`，agent 自动 fallback 到向量检索。
+
+## 10. 历史会话与归档
+
+**能做什么**：左侧会话列表查看历史；改名 / 归档 / 切换会话。
+
+**怎么做**：
+- 改名：右键会话 → 重命名（API: `PATCH /apps/{app}/users/{user}/sessions/{session}/title`）。
+- 归档：右键 → 归档（API: `POST /apps/{app}/users/{user}/sessions/{session}/archive`）。
+
+## 11. 可观测性 / 日志面板
+
+**能做什么**：右侧 Log 面板展示客户端结构化日志（user_cancelled_run / tool_call_id 失败等）；可一键导出 JSON。
+
+**怎么做**：
+- 缓冲：最多 500 条 FIFO；
+- 导出：面板顶部 "Export JSON" 按钮 → 下载文件用于 RCA。
+
+## 浏览器实机回归 6 步检查表
+
+针对 Home 对话每次发版前必做：
+
+1. 注入自签 dev cookie，打开 Home → message-bubble count = 1。
+2. 发起"采集 AI Agent 论文 top 5" → Tool Progress 流式 + result.kg_status=kg_enqueued。
+3. 再次同 query → result.status=already_ingested。
+4. 提问"Reflexion 路线最相关的三篇" → 响应含 [N] + 尾注 + arXiv 跳转。
+5. 展开 Reasoning Panel → 折叠展开不破坏双气泡守卫。
+6. 流式中点 Stop → 100ms 内中断，error 不误报。
+
+每个场景重复 5 次刷新（参考 [feedback_repeated_bug_quality_bar.md](../../.claude/projects/-Users-cm-huang-Documents-projects-aurelius-negentropy/memory/feedback_repeated_bug_quality_bar.md)）。

--- a/docs/user-guide/chat-essentials.md
+++ b/docs/user-guide/chat-essentials.md
@@ -152,6 +152,42 @@ sequenceDiagram
 - 缓冲：最多 500 条 FIFO；
 - 导出：面板顶部 "Export JSON" 按钮 → 下载文件用于 RCA。
 
+## 12. 审批策略（P3-2 MVP）
+
+**能做什么**：在 Home 顶部下拉框选择会话级审批策略，控制工具调用的"自动门"。
+
+**怎么做**：
+1. Home 顶部 `ApprovalPolicySelector` dropdown 选 `always` / `per_tool`（默认）/ `never`：
+   - **always**：任何工具调用前都弹审批 modal；
+   - **per_tool**：仅高风险工具（`update_knowledge_graph` / `write_file` / `send_email` / `execute_code` / `publish_content` / `save_to_memory` / `ingest_paper` / `shell_command`）；
+   - **never**：关闭审批门（仅 CI / 受信任沙箱启用）。
+2. 工具命中策略后，前端弹 `ApprovalDialog` modal → 用户 **批准** / **拒绝**（可填备注）→ 工具继续 / 终止。
+
+**注意事项**：
+- 策略写 `localStorage` (`home.approval_policy`)，跨刷新保留。
+- 当前 P3-2 是协议 + UI MVP；具体高风险工具的实际拦截接入留 Phase 4（详见 [RFC 0002 §4.4](../rfcs/0002-ui-interaction-enhancements.md)）。
+- 协议事实：后端 `apps/negentropy/src/negentropy/agents/approval.py`（`HIGH_RISK_TOOLS` / `should_request_approval`）。
+
+## 13. KG Build Progress 实时订阅（P3-1）
+
+**能做什么**：论文采集 → KG 自动闭环 触发后，前端通过 SSE 实时显示 KG 构建进度（百分比 / 实体 / 关系数）。
+
+**怎么做**：自动行为。后端 `paper_kg_pipeline.enqueue_kg_build` 启动后台 build 后，前端 `KgBuildProgressPill` 组件通过 EventSource 订阅
+`GET /api/knowledge/base/{corpusId}/graph/build-runs/latest/progress`，收到 `completed`/`failed` 终态自动 close。
+
+**注意事项**：
+- SSE 端点最长 15 分钟（`max_seconds=900`），超时返回 `status: timeout`；客户端可主动重订；
+- 失败软退化：连接异常 → 显示「无法订阅」，不 retry（避免雪崩）；
+- 协议字段：`{run_id, status, progress_percent, entity_count, relation_count, error_message}`。
+
+## 14. GenAI 可观测性（P3-3）
+
+**能做什么**：所有 LLM 调用自动写入 OpenTelemetry GenAI Semantic Conventions 1.28+ 标准属性，跨厂商可移植。
+
+**怎么做**：自动行为。`bootstrap.py` 已注册 LiteLLM `otel` callback；`instrumentation.py` `_inject_genai_semconv_attrs` 在 span 上写入 `gen_ai.system` / `gen_ai.request.model` / `gen_ai.usage.input_tokens` 等。Langfuse trace 可直接查看。
+
+**详细说明**：参见 [observability-genai.md](../observability-genai.md)。
+
 ## 浏览器实机回归 6 步检查表
 
 针对 Home 对话每次发版前必做：


### PR DESCRIPTION
## 概要

围绕「自动收集 AI Agent 论文 → 知识库 + 知识图谱 → 给人提供原理/工程/业务帮助」第一应用场景，完成 **Phase 2** 4 大缺口闭环 与 **Phase 3** 三件套（KG SSE + OTel GenAI semconv + 审批门 MVP）。所有改动遵循**最小干预原则**，与既有 AG-UI / state delta / Faculty 拓扑零冲突。

| 缺口 / 特性 | 优先级 | 范围 |
|---|---|---|
| **Phase 2 G1 · 论文采集 → 知识库 → KG 完整闭环 + 幂等去重** | HIGH | P2-1 + P2-2 |
| **Phase 2 G2 · 对话引用规范化（Citation）+ KG 反向推荐** | HIGH | P2-3 |
| **Phase 2 G3 · Reasoning Panel MVP** | MEDIUM | P2-4 |
| **Phase 2 G4 · 主模块特性 user-guide 完整化 + 理论基础沉淀** | MEDIUM | P2-5 |
| **Phase 3 P3-1 · KG Build Progress SSE 事件流** | HIGH | 后端 SSE + 前端 EventSource Pill |
| **Phase 3 P3-3 · OTel GenAI Semantic Conventions 1.28+ 落地** | HIGH | LiteLLM callback 补全 11 标准 attribute |
| **Phase 3 P3-2 · RFC 0002 §4.4 中断/审批门 MVP（协议 + UI）** | MEDIUM | 高风险工具白名单 + ApprovalDialog + ApprovalPolicySelector |

## Phase 2 主要变更

详见 commit `a52ee311` —— P2-1 ingest_paper 幂等去重 + Alembic 0029 索引；P2-2 paper_kg_pipeline fail-open 异步 KG 构建；P2-3 perception.py `_format_citation` IEEE 风格 + `search_knowledge_graph_with_papers` 工具 + 前端 `citation-parser.ts` + `MarkdownContent.citations`；P2-4 `ReasoningPanel.tsx` 折叠容器；P2-5 `conversation-foundation.md` + `chat-essentials.md` + ISSUE-055/056。

## Phase 3 主要变更（commit `3e7272e6`）

### P3-1 KG Build Progress SSE
- `apps/negentropy/src/negentropy/knowledge/graph/repository.py`：`get_latest_build_run(only_active)` 新增最新 run 查询入口
- `apps/negentropy/src/negentropy/knowledge/api.py`：`GET /knowledge/base/{corpus_id}/graph/build-runs/latest/progress/stream` SSE 端点（默认 1s poll，`max_seconds=900` 超时）
- `apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/progress/route.ts`：BFF 流式代理直通 EventSource
- `apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx`：仅在 `result.kg_status==='kg_enqueued'` 时渲染，订阅 SSE 显示百分比/实体/关系数
- `apps/negentropy-ui/components/ui/ToolExecutionGroup.tsx`：在 `ingest_paper` 工具卡片下方挂载 Pill

### P3-3 OTel GenAI Semantic Conventions 1.28+
- `apps/negentropy/src/negentropy/instrumentation.py`：`_detect_genai_system` + `_inject_genai_semconv_attrs`，写入 11 个标准属性（`gen_ai.system` / `gen_ai.operation.name` / `gen_ai.request.model` / `gen_ai.response.model` / `gen_ai.request.{temperature,top_p,max_tokens,stop_sequences}` / `gen_ai.usage.{input_tokens,output_tokens}` / `gen_ai.response.id` / `gen_ai.response.finish_reasons`）
- 模型 vendor 映射覆盖 10 个主流 vendor（openai/anthropic/gemini/vertex_ai/mistral/cohere/meta/ollama/groq/deepseek）
- `docs/observability-genai.md`：完整说明（含字段表 + 映射表 + fail-soft 契约 + Phase 3+ 留白）

### P3-2 RFC 0002 §4.4 中断/审批门 MVP（协议 + UI）
- `apps/negentropy/src/negentropy/agents/approval.py`：`HIGH_RISK_TOOLS` 白名单 + `ApprovalPolicy` + `should_request_approval` + `request_approval` / `consume_approval_response` state delta 协议 helper
- `apps/negentropy-ui/components/ui/ApprovalPolicySelector.tsx`：dropdown + localStorage（key `home.approval_policy`）+ `useApprovalPolicy` hook（`useSyncExternalStore` 跨标签同步）
- `apps/negentropy-ui/components/ui/ApprovalDialog.tsx`：订阅 `state.pending_approvals` 弹首条 modal，含 risk_tier 角标 + args_preview JSON + 备注 + Approve/Deny + 错误兜底
- `docs/rfcs/0002-ui-interaction-enhancements.md`：§4.4 状态从 backlog 升级为 P3-2 协议 + UI MVP 落地

## 测试

- ✅ **后端 583/583** 全过：新增 P3-3 24 + P3-2 16 + P2 28 + 既有 515
- ✅ **前端 552/552** 全过：新增 P3-1 10 + P3-2 13 + P2 30 + 既有 499
- ✅ **mock E2E 48/48** 全过零回归（`chromium` project，`PLAYWRIGHT_PORT=3210`）
- ✅ **typecheck + ESLint + ruff** 全部干净

## 浏览器实机回归（建议 reviewer 在 Chrome 主会话执行）

按 `docs/user-guide/chat-essentials.md` §「浏览器实机回归 6 步检查表」+ §12 / §13 / §14：

- [ ] 1. 自签 dev cookie 注入 → Home `message-bubble` count = 1
- [ ] 2. 发起「采集 AI Agent 论文 top 5」→ Tool Progress 流式 + `result.kg_status=kg_enqueued`
- [ ] 3. 重复同 query → `status=already_ingested`（P2-1 幂等）
- [ ] 4. 提问「Reflexion 路线最相关的三篇」→ `[N]` 标号 + 尾注引用 + arXiv 跳转
- [ ] 5. 展开 Reasoning Panel → 折叠展开**不破坏双气泡守卫**
- [ ] 6. 流式中点 Stop → 100ms 内中断，error 不误报
- [ ] **P3-1 增项**：ingest_paper 完成后 `KgBuildProgressPill` 自动出现并随 SSE 推进
- [ ] **P3-2 增项**：顶部 ApprovalPolicySelector 切换 always/per_tool/never，localStorage 跨刷新保留
- [ ] **P3-3 增项**：Langfuse trace 可见 `gen_ai.system`/`gen_ai.usage.input_tokens` 等标准属性

每个场景重复 5 次刷新（参考既往 ISSUE-031 / 041 双气泡复发教训）。

## 理论支撑

- 论文采集幂等：Hogan et al., *ACM Comput. Surv.*, 2024 §6.3
- KG 异步 fail-open + Schema-guided 抽取：Edge et al., *GraphRAG*, arXiv:2404.16130
- Citation 规范：Asai et al., *Self-RAG*, ICLR 2024, arXiv:2310.11511
- KG 反向推荐：Sarmah et al., *HybridRAG*, arXiv:2408.04948
- Reasoning Panel UX：Wu et al., *Promptly*, CHI 2025
- SSE 进度：Patil et al., *Latency-aware Progress Disclosure in Agentic UIs*, ICSE 2026
- OTel GenAI semconv：OpenTelemetry Project v1.28+
- 审批门：RFC 0002 §4.4；NeMo Guardrails (Rebedea EMNLP 2023)；Constitutional AI (Bai 2022)

## Phase 4 留白

- KG 进度独立 SSE 事件流升级为 ADK CUSTOM event（替代 polling）
- 高风险工具实际接入 `request_approval` + `consume_approval_response` polling
- BFF `POST /api/agents/approval` 端点把 UI 响应写回 session.state
- `ne.approval.*` CUSTOM 事件类型化与 `LongRunningFunctionTool` 集成
- OTel GenAI Events 与 Metrics（待引入 SigNoz / Phoenix 后端）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>