### PR TITLE
fix(wiki): 构建期 backend 先行启动 + SSG/ISR 诊断日志保留

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/generate.ts
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/generate.ts
@@ -22,8 +22,8 @@ export async function generateStaticParams() {
             entrySlug: entry.entry_slug.split("/"),
           });
         }
-      } catch (err) {
-        console.warn(`Wiki: Failed to fetch entries for pub ${pub.id}`, err);
+      } catch {
+        // 单个 publication 的 entries 不可达时跳过，不阻断其余
       }
     }
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/generate.ts
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/generate.ts
@@ -22,14 +22,22 @@ export async function generateStaticParams() {
             entrySlug: entry.entry_slug.split("/"),
           });
         }
-      } catch {
-        // 单个 publication 的 entries 不可达时跳过，不阻断其余
+      } catch (err) {
+        // 单个 publication 的 entries 不可达时跳过，不阻断其余；
+        // 保留 warn 以便构建期定位"某 pub 路由有 bug" vs "该 pub 确实无 entries"。
+        console.warn(
+          `[Wiki SSG] Failed to fetch entries for publication ${pub.slug} (id=${pub.id}), skipping:`,
+          err,
+        );
       }
     }
 
     return params;
-  } catch {
-    console.warn("Wiki: Failed to fetch static params for entries, returning empty");
+  } catch (err) {
+    console.warn(
+      "[Wiki SSG] Failed to fetch static params for entries, returning empty:",
+      err,
+    );
     return [];
   }
 }

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -16,14 +16,10 @@ export default async function WikiHomePage() {
   try {
     const result = await wikiApi.listPublications();
     publications = result.items;
-  } catch (err) {
-    // 失败本次响应不写入 ISR cache，避免空列表毒化 5 分钟；
-    // 回落为 per-request SSR 一次/请求，后端恢复后下次访问即可正常重建 ISR cache。
+  } catch {
+    // 后端不可达时不写入 ISR cache，避免空列表毒化 5 分钟；
+    // 回落为 per-request SSR，后端恢复后下次访问即可正常重建 ISR cache。
     noStore();
-    console.warn(
-      "[Wiki] Failed to fetch publications（已退化为 per-request SSR，恢复后自动重建 ISR）:",
-      err,
-    );
   }
 
   return (

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -16,10 +16,15 @@ export default async function WikiHomePage() {
   try {
     const result = await wikiApi.listPublications();
     publications = result.items;
-  } catch {
+  } catch (err) {
     // 后端不可达时不写入 ISR cache，避免空列表毒化 5 分钟；
     // 回落为 per-request SSR，后端恢复后下次访问即可正常重建 ISR cache。
     noStore();
+    // 保留 warn：ISR 运行时后端间歇性不可用时，运维可从服务端日志识别退化路径。
+    console.warn(
+      "[Wiki ISR] Failed to fetch publications (degraded to per-request SSR; will rebuild ISR on next success):",
+      err,
+    );
   }
 
   return (

--- a/scripts/ctl.sh
+++ b/scripts/ctl.sh
@@ -234,13 +234,15 @@ cmd_start() {
   # Phase 4 — 前端构建
   if ! $skip_build; then
     log_phase "Phase 4/5: 前端构建"
+    # 先启动 backend，使 wiki SSG 构建时可从 API 拉取数据
+    start_service "$SVC_BACKEND" || log_warn "backend 启动失败，wiki SSG 将退化为空"
     log_info "构建 ui + wiki (并行)..."
     (cd "$REPO_ROOT/apps/negentropy-ui" && pnpm build) &
     local build_ui_pid=$!
     (cd "$REPO_ROOT/apps/negentropy-wiki" && pnpm build) &
     local build_wiki_pid=$!
     local _rc=0; wait "$build_ui_pid" || _rc=$?; wait "$build_wiki_pid" || _rc=$?
-    (( _rc )) && { log_error "前端构建失败"; exit 1; }
+    (( _rc )) && { log_error "前端构建失败"; cmd_stop; exit 1; }
     log_ok "前端构建完成"
   else
     log_phase "Phase 4/5: 前端构建 (跳过)"
@@ -305,13 +307,17 @@ cmd_logs() {
 # ── 子命令: build ────────────────────────────────────────────────────────────────
 cmd_build() {
   log_phase "仅构建（不启动）"
+  run_dir_init
+  # 先启动 backend，使 wiki SSG 构建时可从 API 拉取数据
+  start_service "$SVC_BACKEND" || log_warn "backend 启动失败，wiki SSG 将退化为空"
   log_info "构建 ui + wiki (并行)..."
   (cd "$REPO_ROOT/apps/negentropy-ui" && pnpm build) &
   local pid_ui=$!
   (cd "$REPO_ROOT/apps/negentropy-wiki" && pnpm build) &
   local pid_wiki=$!
   local _rc=0; wait "$pid_ui" || _rc=$?; wait "$pid_wiki" || _rc=$?
-  (( _rc )) && { log_error "前端构建失败"; exit 1; }
+  (( _rc )) && { log_error "前端构建失败"; stop_service "$SVC_BACKEND"; exit 1; }
+  stop_service "$SVC_BACKEND"
   log_ok "前端构建完成"
 }
 


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：Wiki SSG 在 `pnpm build` 阶段因 backend 尚未启动，触发 `ECONNREFUSED` 报错；先前以 `console.warn` 输出原始错误，构建日志中频繁出现红色噪音，引发"构建失败"误判。
- 关联上下文/Issue/文档：[`docs/issue.md`](../blob/ThreeFish-AI/fix-test-failures/docs/issue.md) — 同类 Wiki SSG/ISR 问题归档处。

# 核心变更

- `scripts/ctl.sh`：`cmd_start` Phase 4 与 `cmd_build` 在前端构建前**先行启动 backend**（首选根因修复），构建失败/结束后执行 `cmd_stop` / `stop_service "$SVC_BACKEND"` 兜底清理，避免僵尸进程。
- `apps/negentropy-wiki/src/app/page.tsx`：ISR 首页 `catch` 保留 `console.warn`，输出 "[Wiki ISR] degraded to per-request SSR" 提示并附 `err`，使运行时后端间歇性不可用时运维可从服务端日志识别 ISR 退化路径。
- `apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/generate.ts`：内层 `catch` 输出 `[Wiki SSG] Failed to fetch entries for publication ${pub.slug} (id=${pub.id})` 并附 `err`，便于构建期定位"某 publication 路由 bug" vs "该 pub 确实无 entries"；外层 `catch` 同步附回 `err` 详情。

# 风险与回滚

- 主要风险：`cmd_build` 现在会启动短生命周期 backend；若 backend 启动慢于 `wait_for_health` 上限，构建会跳过 SSG 数据并降级为空（与现状一致，已通过 `start_service` 失败时的 `log_warn` 提示），不影响构建结果。
- 回滚方式：直接 `git revert 56cbc7fd 3402d9c8` 即可还原至 `feature/1.x.x` 基线。

# 验证证据

- 单元测试：未涉及单测目录。
- 集成测试：N/A（构建脚本与日志侧改动）。
- E2E/Workflow：本地执行 `pnpm exec tsc --noEmit`（wiki 工作区）通过，未引入新类型错误；`pre-commit` 钩子 `next lint` 通过。
- 覆盖率/关键截图：N/A。

# 影响范围

- 前端：`apps/negentropy-wiki`（SSG `generateStaticParams` 与 ISR `WikiHomePage` 错误日志可观测性）。
- 后端：无代码改动；`scripts/ctl.sh` 在前端构建期临时启动 backend 进程并在 `cmd_build` 结束时停止。
- GitHub Actions / 文档：未涉及。

# Next Best Action

- 在 `docs/issue.md` 追加本条 Issue 摘要（问题/根因/处理/防范）以便同类问题跨上下文复用。
- 后续若需要进一步降噪，可考虑将 `[Wiki ISR]` warn 接入结构化日志（如 OTel logs / pino），统一与 backend 链路追踪。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>