### PR TITLE
fix(ui): 统一危险操作确认弹窗，阻断浏览器原生 dialog 回归

### DIFF
--- a/apps/negentropy-ui/app/interface/mcp/page.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/page.tsx
@@ -6,6 +6,7 @@ import { InterfaceNav } from "@/components/ui/InterfaceNav";
 import { McpServerCard } from "./_components/McpServerCard";
 import { McpServerFormDialog } from "./_components/McpServerFormDialog";
 import { McpServerTrialDialog } from "./_components/McpServerTrialDialog";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 
 interface McpTool {
   id: string | null;
@@ -72,6 +73,7 @@ interface LoadToolsResponse {
 }
 
 export default function McpServersPage() {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [servers, setServers] = useState<ServerWithTools[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -111,7 +113,13 @@ export default function McpServersPage() {
   };
 
   const handleDelete = async (serverId: string) => {
-    if (!confirm("Are you sure you want to delete this server?")) {
+    const confirmed = await confirm({
+      title: "Delete MCP Server",
+      message: "Are you sure you want to delete this server?",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!confirmed) {
       return;
     }
     try {
@@ -123,7 +131,7 @@ export default function McpServersPage() {
       }
       fetchServers();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "An error occurred");
+      setError(err instanceof Error ? err.message : "An error occurred");
     }
   };
 
@@ -320,6 +328,7 @@ export default function McpServersPage() {
           await handleLoadTools(serverId);
         }}
       />
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/models/page.tsx
+++ b/apps/negentropy-ui/app/interface/models/page.tsx
@@ -5,6 +5,7 @@ import { InterfaceNav } from "@/components/ui/InterfaceNav";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/providers/AuthProvider";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { VendorModelsDisclosure } from "@/components/interface/VendorModelsDisclosure";
 import {
   MODEL_KINDS,
@@ -60,6 +61,7 @@ interface PingResult {
 export default function ModelsPage() {
   const { user, status } = useAuth();
   const router = useRouter();
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   useEffect(() => {
     if (status === "loading") return;
@@ -191,7 +193,13 @@ export default function ModelsPage() {
 
   const handleVendorRemove = async () => {
     if (!vendorDialogVendor) return;
-    if (!window.confirm(`确认移除 ${vendorDialogVendor} 的供应商配置？`)) return;
+    const confirmed = await confirm({
+      title: "移除供应商配置",
+      message: `确认移除 ${vendorDialogVendor} 的供应商配置？`,
+      confirmLabel: "移除",
+      destructive: true,
+    });
+    if (!confirmed) return;
     setVendorSaving(true);
     try {
       const response = await fetch(`/api/interface/models/vendor-configs/${vendorDialogVendor}`, {
@@ -371,7 +379,13 @@ export default function ModelsPage() {
   };
 
   const handleModelDelete = async (mc: ModelConfigRecord) => {
-    if (!window.confirm(`确认删除 ${mc.display_name}（${mc.vendor}/${mc.model_name}）?`)) return;
+    const confirmed = await confirm({
+      title: "删除模型配置",
+      message: `确认删除 ${mc.display_name}（${mc.vendor}/${mc.model_name}）？`,
+      confirmLabel: "删除",
+      destructive: true,
+    });
+    if (!confirmed) return;
     try {
       const response = await fetch(`/api/interface/models/configs/${mc.id}`, {
         method: "DELETE",
@@ -837,6 +851,7 @@ export default function ModelsPage() {
           </OverlayDismissLayer>
         </div>
       </div>
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/subagents/_components/SubAgentFormDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { LlmModelSelect } from "@/components/ui/LlmModelSelect";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { fetchModelConfigs, type ModelConfigItem } from "@/features/knowledge/utils/knowledge-api";
 
 interface SubAgent {
@@ -47,6 +48,7 @@ export function SubAgentFormDialog({
   onSubmit,
   agent,
 }: SubAgentFormDialogProps) {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [formData, setFormData] = useState({
     name: "",
     display_name: "",
@@ -165,9 +167,13 @@ export function SubAgentFormDialog({
 
     let confirmBuiltinRename = false;
     if (agent?.is_builtin && formData.name !== agent.name) {
-      const confirmed = confirm(
-        "Renaming a Negentropy built-in SubAgent may cause future sync to create a duplicate. Continue?",
-      );
+      const confirmed = await confirm({
+        title: "Rename Built-in SubAgent",
+        message:
+          "Renaming a Negentropy built-in SubAgent may cause future sync to create a duplicate. Continue?",
+        confirmLabel: "Continue",
+        destructive: true,
+      });
       if (!confirmed) {
         return;
       }
@@ -241,7 +247,8 @@ export function SubAgentFormDialog({
   if (!open) return null;
 
   return (
-    <OverlayDismissLayer
+    <>
+      <OverlayDismissLayer
       open={open}
       onClose={onClose}
       busy={loading}
@@ -503,6 +510,8 @@ export function SubAgentFormDialog({
               </button>
             </div>
           </form>
-    </OverlayDismissLayer>
+      </OverlayDismissLayer>
+      {confirmDialog}
+    </>
   );
 }

--- a/apps/negentropy-ui/app/interface/subagents/page.tsx
+++ b/apps/negentropy-ui/app/interface/subagents/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { SubAgentCard } from "./_components/SubAgentCard";
 import { SubAgentFormDialog } from "./_components/SubAgentFormDialog";
 
@@ -34,6 +35,7 @@ interface SyncResponse {
 }
 
 export default function SubAgentsPage() {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [agents, setAgents] = useState<SubAgent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -97,7 +99,13 @@ export default function SubAgentsPage() {
   };
 
   const handleDelete = async (agentId: string) => {
-    if (!confirm("Are you sure you want to delete this subagent?")) {
+    const confirmed = await confirm({
+      title: "Delete SubAgent",
+      message: "Are you sure you want to delete this subagent?",
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!confirmed) {
       return;
     }
     try {
@@ -109,7 +117,7 @@ export default function SubAgentsPage() {
       }
       fetchAgents();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "An error occurred");
+      setError(err instanceof Error ? err.message : "An error occurred");
     }
   };
 
@@ -246,6 +254,7 @@ export default function SubAgentsPage() {
         onSubmit={handleFormSubmit}
         agent={editingAgent}
       />
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusList.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusList.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { CorpusRecord } from "@/features/knowledge";
 
 interface CorpusListProps {
@@ -18,6 +19,7 @@ export function CorpusList({
   onDelete,
   isLoading,
 }: CorpusListProps) {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -31,7 +33,7 @@ export function CorpusList({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const handleAction = (
+  const handleAction = async (
     e: React.MouseEvent,
     action: "edit" | "delete",
     corpus: CorpusRecord,
@@ -41,7 +43,13 @@ export function CorpusList({
     if (action === "edit") {
       onEdit(corpus);
     } else {
-      if (confirm(`确定要删除 "${corpus.name}" 吗？此操作无法撤销。`)) {
+      const confirmed = await confirm({
+        title: "Delete Corpus",
+        message: `确定要删除 "${corpus.name}" 吗？此操作无法撤销。`,
+        confirmLabel: "Delete",
+        destructive: true,
+      });
+      if (confirmed) {
         onDelete(corpus.id);
       }
     }
@@ -69,7 +77,8 @@ export function CorpusList({
   }
 
   return (
-    <div className="space-y-1">
+    <>
+      <div className="space-y-1">
       {corpora.map((corpus) => (
         <div
           key={corpus.id}
@@ -131,6 +140,8 @@ export function CorpusList({
           )}
         </div>
       ))}
-    </div>
+      </div>
+      {confirmDialog}
+    </>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/IngestPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/IngestPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { AsyncPipelineResult } from "@/features/knowledge";
 
 interface IngestPanelProps {
@@ -20,6 +21,7 @@ export function IngestPanel({
   onIngestUrl,
   onReplace,
 }: IngestPanelProps) {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [mode, setMode] = useState<"text" | "url">("text");
   const [sourceUri, setSourceUri] = useState("");
   const [text, setText] = useState("");
@@ -65,9 +67,12 @@ export function IngestPanel({
 
   const handleReplace = async () => {
     if (!corpusId || !sourceUri || !text.trim() || isSubmitting) return;
-    const confirmed = window.confirm(
-      `即将替换 source_uri "${sourceUri}" 下的全部内容，是否继续？`,
-    );
+    const confirmed = await confirm({
+      title: "Replace Source",
+      message: `即将替换 source_uri "${sourceUri}" 下的全部内容，是否继续？`,
+      confirmLabel: "Replace",
+      destructive: true,
+    });
     if (!confirmed) return;
     setIsSubmitting(true);
     setError(null);
@@ -82,7 +87,8 @@ export function IngestPanel({
   };
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+    <>
+      <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
       <h2 className="text-sm font-semibold text-card-foreground">
         Ingest / Replace
       </h2>
@@ -169,6 +175,8 @@ export function IngestPanel({
           </div>
         )}
       </div>
-    </div>
+      </div>
+      {confirmDialog}
+    </>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/DocumentAssignmentSection.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/DocumentAssignmentSection.tsx
@@ -6,6 +6,7 @@ import {
   unassignDocumentFromNode,
   KnowledgeDocument,
 } from "@/features/knowledge";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
 import { Plus, Trash2 } from "./icons";
 import { AddDocumentsDialog } from "./AddDocumentsDialog";
@@ -19,6 +20,7 @@ export function DocumentAssignmentSection({
   nodeId,
   catalogId,
 }: DocumentAssignmentSectionProps) {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [docs, setDocs] = useState<KnowledgeDocument[]>([]);
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
@@ -41,7 +43,13 @@ export function DocumentAssignmentSection({
 
   const handleRemove = useCallback(
     async (docId: string, filename: string) => {
-      if (!confirm(`从本节点移除「${filename}」？文档本身不会被删除。`)) return;
+      const confirmed = await confirm({
+        title: "移除归属文档",
+        message: `从本节点移除「${filename}」？文档本身不会被删除。`,
+        confirmLabel: "移除",
+        destructive: true,
+      });
+      if (!confirmed) return;
       try {
         await unassignDocumentFromNode(catalogId, nodeId, docId);
         toast.success("已移除");
@@ -50,7 +58,7 @@ export function DocumentAssignmentSection({
         toast.error(err instanceof Error ? err.message : "移除失败");
       }
     },
-    [catalogId, nodeId, refresh],
+    [catalogId, confirm, nodeId, refresh],
   );
 
   const handleAdded = useCallback(() => {
@@ -113,6 +121,7 @@ export function DocumentAssignmentSection({
           onAdded={handleAdded}
         />
       )}
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/catalog/_components/NodeDetailPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/_components/NodeDetailPanel.tsx
@@ -6,6 +6,7 @@ import {
   updateCatalogNode,
   deleteCatalogNode,
 } from "@/features/knowledge";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
 import { Pencil, Trash2 } from "./icons";
 import { DocumentAssignmentSection } from "./DocumentAssignmentSection";
@@ -23,6 +24,7 @@ export function NodeDetailPanel({
   onUpdate,
   onDelete,
 }: NodeDetailPanelProps) {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [editingDesc, setEditingDesc] = useState(false);
   const [descValue, setDescValue] = useState("");
 
@@ -46,7 +48,13 @@ export function NodeDetailPanel({
   };
 
   const handleDelete = async () => {
-    if (!confirm(`确定删除「${node.name}」？子节点将一并删除。`)) return;
+    const confirmed = await confirm({
+      title: "删除目录节点",
+      message: `确定删除「${node.name}」？子节点将一并删除。`,
+      confirmLabel: "删除",
+      destructive: true,
+    });
+    if (!confirmed) return;
     try {
       await deleteCatalogNode(catalogId, node.id);
       toast.success("节点已删除");
@@ -57,7 +65,8 @@ export function NodeDetailPanel({
   };
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto">
+    <>
+      <div className="flex flex-col h-full overflow-y-auto">
       {/* Header */}
       <div className="border-b border-border px-5 py-4">
         <div className="flex items-start justify-between">
@@ -167,6 +176,8 @@ export function NodeDetailPanel({
 
       {/* Document assignment */}
       <DocumentAssignmentSection nodeId={node.id} catalogId={catalogId} />
-    </div>
+      </div>
+      {confirmDialog}
+    </>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/catalog/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/catalog/page.tsx
@@ -10,6 +10,7 @@ import { CreateNodeDialog } from "./_components/CreateNodeDialog";
 import { useCatalogTree } from "./hooks/useCatalogTree";
 import { useSingletonCatalog } from "./hooks/useSingletonCatalog";
 import { CatalogNode, deleteCatalogNode } from "@/features/knowledge";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
 
 interface ContextMenuState {
@@ -25,6 +26,7 @@ interface DragState {
 }
 
 export default function CatalogPage() {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const { catalogId, loading: catalogLoading, error: catalogError } = useSingletonCatalog();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [addParentId, setAddParentId] = useState<string | null>(null);
@@ -97,7 +99,13 @@ export default function CatalogPage() {
   const handleContextDelete = useCallback(
     async (node: CatalogNode) => {
       if (!catalogId) return;
-      if (!confirm(`确定删除「${node.name}」？子节点将一并删除。`)) return;
+      const confirmed = await confirm({
+        title: "删除目录节点",
+        message: `确定删除「${node.name}」？子节点将一并删除。`,
+        confirmLabel: "删除",
+        destructive: true,
+      });
+      if (!confirmed) return;
       try {
         await deleteCatalogNode(catalogId, node.id);
         toast.success("节点已删除");
@@ -106,7 +114,7 @@ export default function CatalogPage() {
         toast.error(err instanceof Error ? err.message : "删除失败");
       }
     },
-    [catalogId, handleDeleted],
+    [catalogId, confirm, handleDeleted],
   );
 
   const handleRename = useCallback(
@@ -294,6 +302,7 @@ export default function CatalogPage() {
           onCollapseAll={collapseAll}
         />
       )}
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublicationDetail.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublicationDetail.tsx
@@ -11,6 +11,7 @@ import {
   WikiPublication,
   WikiRevalidationStatus,
 } from "@/features/knowledge";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
 import { WikiStatusBadge } from "./WikiStatusBadge";
 import { WikiEntriesList } from "./WikiEntriesList";
@@ -30,6 +31,7 @@ export function WikiPublicationDetail({
   onChanged,
   onDeleted,
 }: WikiPublicationDetailProps) {
+  const { confirm, confirmDialog } = useConfirmDialog();
   const [navTree, setNavTree] = useState<WikiNavTreeItem[]>([]);
   const [navLoading, setNavLoading] = useState(false);
   const [selectorOpen, setSelectorOpen] = useState(false);
@@ -88,7 +90,13 @@ export function WikiPublicationDetail({
 
   const handleUnpublish = useCallback(async () => {
     if (!pubId) return;
-    if (!confirm("确定取消发布吗？站点将回退为草稿状态。")) return;
+    const confirmed = await confirm({
+      title: "取消发布",
+      message: "确定取消发布吗？站点将回退为草稿状态。",
+      confirmLabel: "取消发布",
+      destructive: true,
+    });
+    if (!confirmed) return;
     setSubmitting(true);
     setPipelineActive(true);
     try {
@@ -103,15 +111,17 @@ export function WikiPublicationDetail({
     } finally {
       setSubmitting(false);
     }
-  }, [pubId, onChanged]);
+  }, [pubId, confirm, onChanged]);
 
   const handleDelete = useCallback(async () => {
     if (!publication) return;
-    if (
-      !confirm(
-        `确定删除发布「${publication.name}」吗？所有条目与历史版本将一并删除。`,
-      )
-    ) {
+    const confirmed = await confirm({
+      title: "删除 Wiki 发布",
+      message: `确定删除发布「${publication.name}」吗？所有条目与历史版本将一并删除。`,
+      confirmLabel: "删除",
+      destructive: true,
+    });
+    if (!confirmed) {
       return;
     }
     setSubmitting(true);
@@ -124,7 +134,7 @@ export function WikiPublicationDetail({
     } finally {
       setSubmitting(false);
     }
-  }, [publication, onDeleted]);
+  }, [publication, confirm, onDeleted]);
 
   const handleSyncConfirm = useCallback(
     async (catalogNodeIds: string[]) => {
@@ -289,6 +299,7 @@ export function WikiPublicationDetail({
             : "选择要同步的 Catalog 节点"
         }
       />
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/components/ui/ConfirmDialog.tsx
+++ b/apps/negentropy-ui/components/ui/ConfirmDialog.tsx
@@ -55,7 +55,7 @@ export function ConfirmDialog({
         >
           {title}
         </h2>
-        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{message}</p>
+        <div className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{message}</div>
       </div>
       <div className="flex justify-end gap-3 border-t border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">
         <button

--- a/apps/negentropy-ui/components/ui/ConfirmDialog.tsx
+++ b/apps/negentropy-ui/components/ui/ConfirmDialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useId, type ReactNode } from "react";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 /**
- * 项目通用 ConfirmDialog — 替代 window.confirm/alert/prompt（违反 AGENTS.md 视觉规范）。
+ * 项目通用 ConfirmDialog — 替代浏览器原生确认/告警/输入弹窗（违反 AGENTS.md 视觉规范）。
  *
  * 设计参考 ISSUE-045 Skills 模块同款实现。从 app/interface/skills/_components 升格到 components/ui，
  * 让 SessionList、Composer、Memory 等模块可复用。
@@ -11,7 +12,7 @@ import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 export interface ConfirmDialogProps {
   open: boolean;
   title: string;
-  message: string;
+  message: ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   destructive?: boolean;
@@ -31,6 +32,7 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  const titleId = useId();
   if (!open) return null;
   return (
     <OverlayDismissLayer
@@ -40,9 +42,19 @@ export function ConfirmDialog({
       backdropClassName="bg-black/55"
       containerClassName="flex min-h-full items-center justify-center p-4"
       contentClassName="w-full max-w-md rounded-2xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": titleId,
+      }}
     >
       <div className="px-5 py-4 sm:px-6" data-testid="confirm-dialog">
-        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{title}</h2>
+        <h2
+          id={titleId}
+          className="text-lg font-semibold text-zinc-900 dark:text-zinc-100"
+        >
+          {title}
+        </h2>
         <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{message}</p>
       </div>
       <div className="flex justify-end gap-3 border-t border-zinc-200 px-5 py-4 sm:px-6 dark:border-zinc-800">

--- a/apps/negentropy-ui/components/ui/SessionList.tsx
+++ b/apps/negentropy-ui/components/ui/SessionList.tsx
@@ -38,7 +38,7 @@ export function SessionList({
   const [draftTitle, setDraftTitle] = useState("");
   const ignoreBlurRef = useRef(false);
 
-  // 确认弹窗状态：归档 / 解档共用一套对话框，避免 window.confirm 的样式割裂（参考 ISSUE-045 / ISSUE-054）
+  // 确认弹窗状态：归档 / 解档共用一套对话框，避免浏览器原生弹窗的样式割裂（参考 ISSUE-045 / ISSUE-054）
   const [confirmTarget, setConfirmTarget] = useState<
     | { kind: "archive" | "unarchive"; session: SessionItem }
     | null

--- a/apps/negentropy-ui/components/ui/useConfirmDialog.tsx
+++ b/apps/negentropy-ui/components/ui/useConfirmDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+export interface ConfirmDialogRequest {
+  title: string;
+  message: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}
+
+export function useConfirmDialog() {
+  const resolverRef = useRef<((confirmed: boolean) => void) | null>(null);
+  const [request, setRequest] = useState<ConfirmDialogRequest | null>(null);
+
+  const settle = useCallback((confirmed: boolean) => {
+    resolverRef.current?.(confirmed);
+    resolverRef.current = null;
+    setRequest(null);
+  }, []);
+
+  const confirm = useCallback(
+    (nextRequest: ConfirmDialogRequest) =>
+      new Promise<boolean>((resolve) => {
+        resolverRef.current?.(false);
+        resolverRef.current = resolve;
+        setRequest(nextRequest);
+      }),
+    [],
+  );
+
+  useEffect(
+    () => () => {
+      resolverRef.current?.(false);
+      resolverRef.current = null;
+    },
+    [],
+  );
+
+  const confirmDialog = request ? (
+    <ConfirmDialog
+      open
+      title={request.title}
+      message={request.message}
+      confirmLabel={request.confirmLabel}
+      cancelLabel={request.cancelLabel}
+      destructive={request.destructive}
+      onCancel={() => settle(false)}
+      onConfirm={() => settle(true)}
+    />
+  ) : null;
+
+  return { confirm, confirmDialog };
+}

--- a/apps/negentropy-ui/tests/unit/ui/no-native-dialogs.test.ts
+++ b/apps/negentropy-ui/tests/unit/ui/no-native-dialogs.test.ts
@@ -1,0 +1,39 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const projectRoot = process.cwd();
+const scannedDirs = ["app", "components", "features", "hooks", "utils"];
+
+function collectFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const fullPath = path.join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) return collectFiles(fullPath);
+    if (!/\.(ts|tsx)$/.test(entry)) return [];
+    return [fullPath];
+  });
+}
+
+describe("native browser dialogs", () => {
+  it("are not used in app code", () => {
+    const offenders = scannedDirs
+      .flatMap((dir) => collectFiles(path.join(projectRoot, dir)))
+      .flatMap((file) => {
+        const source = readFileSync(file, "utf8");
+        return source
+          .split("\n")
+          .map((line, index) => ({ line, index }))
+          .filter(({ line }) =>
+            /window\.(confirm|alert|prompt)\s*\(|\b(alert|prompt)\s*\(/.test(line),
+          )
+          .map(({ line, index }) => ({
+            file: path.relative(projectRoot, file),
+            line: index + 1,
+            source: line.trim(),
+          }));
+      });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/useConfirmDialog.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/useConfirmDialog.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+
+function ConfirmHarness({ onResult }: { onResult: (value: boolean) => void }) {
+  const { confirm, confirmDialog } = useConfirmDialog();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={async () => {
+          onResult(
+            await confirm({
+              title: "Delete item",
+              message: "This action cannot be undone.",
+              confirmLabel: "Delete",
+              destructive: true,
+            }),
+          );
+        }}
+      >
+        Open confirm
+      </button>
+      {confirmDialog}
+    </>
+  );
+}
+
+describe("useConfirmDialog", () => {
+  it("resolves true after custom dialog confirmation", async () => {
+    const user = userEvent.setup();
+    const onResult = vi.fn();
+    render(<ConfirmHarness onResult={onResult} />);
+
+    await user.click(screen.getByRole("button", { name: "Open confirm" }));
+
+    expect(screen.getByRole("dialog", { name: "Delete item" })).toBeInTheDocument();
+    await user.click(screen.getByTestId("confirm-dialog-confirm"));
+
+    expect(onResult).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole("dialog", { name: "Delete item" })).not.toBeInTheDocument();
+  });
+
+  it("resolves false after cancellation", async () => {
+    const user = userEvent.setup();
+    const onResult = vi.fn();
+    render(<ConfirmHarness onResult={onResult} />);
+
+    await user.click(screen.getByRole("button", { name: "Open confirm" }));
+    await user.click(screen.getByTestId("confirm-dialog-cancel"));
+
+    expect(onResult).toHaveBeenCalledWith(false);
+  });
+});

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1395,3 +1395,19 @@
   2. **测试 mock 的反应式订阅**：``vi.hoisted`` + ``useSyncExternalStore`` 模式可在 jsdom 环境模拟"router.replace 后下一次 render 看到新 searchParams"；建议把这套 mock 抽出成 ``tests/helpers/next-navigation.ts``，下一轮把 Memory / Knowledge / Skills view 状态升级时复用；
   3. **integration 测试的 mock 完整性**：任何使用 ``next/navigation`` 的 hook 在 ``HomeBody`` / 其它顶层组件被引入后，integration 测试必须 mock 之，否则 ``useRouter()`` 在无 App Router 包裹下抛错。
 - **同类问题影响**：Memory timeline filter / Knowledge corpus filter / Skills create-mode flag 等一切"用户切换并希望分享的视图状态"都应套用本 hook 模式；通用 ``utils/url-state-sync.ts`` 抽象延后到第三个相同 case 出现后再做（YAGNI）。
+
+---
+
+## ISSUE-062 全站危险操作残留原生 confirm/alert（2026-05-06）
+
+- **表因**：P0 UI 全站巡检静态扫荡发现，ISSUE-054 已升格通用 [ConfirmDialog](../apps/negentropy-ui/components/ui/ConfirmDialog.tsx) 后，Interface Models / MCP / SubAgents、Knowledge Base / Catalog / Wiki 仍残留 `window.confirm`、裸 `confirm` 与 `alert`。实机会弹出浏览器原生对话框，破坏应用视觉一致性，也让 E2E 难以通过统一 `data-testid` 锚点验证。
+- **根因**：ISSUE-054 只修 SessionList 并提出“后续扫荡 MCP / SubAgents”，但缺少跨目录防回归门禁；各页面把“确认危险操作”作为局部实现，未复用通用确认原语，导致同型问题分散复发。
+- **处理方式**：
+  1. 新增 [useConfirmDialog](../apps/negentropy-ui/components/ui/useConfirmDialog.tsx)，提供 `await confirm({ title, message, confirmLabel, destructive })` 的最小封装；
+  2. 将 MCP Server 删除、SubAgent 删除与内置重命名、Models 供应商/模型删除、Knowledge Corpus/Source/节点/文档归属/Wiki 发布删除取消发布等路径统一迁移到通用 ConfirmDialog；
+  3. MCP / SubAgents 删除失败不再 `alert()`，改写入页面错误态；
+  4. 新增 `tests/unit/ui/useConfirmDialog.test.tsx` 与 `tests/unit/ui/no-native-dialogs.test.ts`，验证确认/取消语义并阻断 `window.confirm/alert/prompt` 与裸 `alert/prompt` 回归。
+- **后续防范**：
+  1. 所有危险操作必须复用 `components/ui/ConfirmDialog` 或 `useConfirmDialog`，禁止直接调用浏览器原生 dialog；
+  2. 若后续需要“输入名称二次确认”，应扩展通用组件而不是回退到 `prompt()`；
+  3. 下一步可把静态测试升级为 ESLint `no-restricted-globals` / `no-restricted-properties` 规则，覆盖裸 `confirm()` 的 AST 级识别。


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：P0 UI 全站巡检发现 Interface（Models / MCP / SubAgents）与 Knowledge（Base / Catalog / Wiki）模块在删除、取消发布、覆盖等危险操作上仍残留 `window.confirm` / 裸 `confirm` / `alert`，与 ISSUE-054 升格的通用 ConfirmDialog 视觉规范割裂，且 E2E 难以基于统一 `data-testid` 锚定。
- 关联上下文/Issue/文档：[docs/issue.md ISSUE-062](../blob/ThreeFish-AI/fix-ui-flow-bugs/docs/issue.md)、ISSUE-054（SessionList 通用 ConfirmDialog 升格）。

# 核心变更
- 新增 `components/ui/useConfirmDialog.tsx`：以 `await confirm({ title, message, confirmLabel, destructive })` 形式封装通用确认对话框，统一 Promise 时序、重入与卸载清理（pending promise 一律以 `false` 结算）。
- 升级 `components/ui/ConfirmDialog.tsx`：补齐 `role=dialog` / `aria-modal` / `aria-labelledby`（`useId` 关联标题）；将 `message` 类型由 `string` 拓宽为 `ReactNode`，并把承载容器由 `<p>` 改为 `<div>`，避免后续传入块级 JSX 触发 hydration 警告。
- 迁移 6 个面板的危险操作到通用 ConfirmDialog：MCP 服务器删除、SubAgent 删除与内置重命名、Models 供应商/模型删除、Knowledge Corpus / Source / 节点 / 文档归属移除、Wiki 发布删除与取消发布；MCP / SubAgents 的失败兜底由 `alert(...)` 改写为页面 `setError(...)` 内联展示。
- 新增双重防回归：`tests/unit/ui/useConfirmDialog.test.tsx` 验证确认/取消语义；`tests/unit/ui/no-native-dialogs.test.ts` 静态扫描 `app/components/features/hooks/utils` 阻断 `window.confirm/alert/prompt` 与裸 `alert/prompt`（裸 `confirm` 留待 ESLint AST 规则升级）。
- `docs/issue.md` 追加 ISSUE-062 全链路 RCA（表因/根因/处理方式/后续防范）。

# 风险与回滚
- 主要风险：① 多页面 JSX 结构由单根改为 Fragment 包裹 + `{confirmDialog}`，需关注 z-index / Escape 栈在嵌套对话框场景下的行为；② `ConfirmDialog` 容器由 `<p>` 改为 `<div>` 影响默认语义层级，但 `aria-labelledby` 已显式标注，screen reader 行为受控。
- 回滚方式：单 commit 粒度即可 revert 本分支 `52e3b562` + `696a8403`，或按文件回退 `useConfirmDialog.tsx` / `ConfirmDialog.tsx` 与各调用方。

# 验证证据
- 单元测试：`tests/unit/ui/useConfirmDialog.test.tsx` 覆盖 confirm / cancel 双路径；`tests/unit/ui/no-native-dialogs.test.ts` 全量静态扫描通过（0 offenders）。
- 集成测试：依赖原 SessionList 等既有用例继续通过（无破坏性接口变更）。
- E2E/Workflow：未涉及业务流变更；`data-testid="confirm-dialog"` 等锚点未变。
- 覆盖率/关键截图：pre-commit ESLint(negentropy-ui) 通过；裸 `confirm("...")` 静态搜索结果为空。

# 影响范围
- 前端：`apps/negentropy-ui` 共 13 个组件/页面 + 2 个新增测试 + 1 处通用组件升级。
- 后端：无。
- GitHub Actions / 文档：`docs/issue.md` 追加 ISSUE-062；CI 配置未变。

# Next Best Action
- 将 `no-native-dialogs.test.ts` 升级为 ESLint `no-restricted-globals` / `no-restricted-properties` 规则，覆盖裸 `confirm()` 的 AST 级识别，避免后续与 `useConfirmDialog` 暴露的同名函数产生静态扫描歧义。