### PR TITLE
fix(home-chat): 修复 Agent 答复 4 大缺陷（等待占位 / 双内容 / 推理空内容 / 刷新乱序）

### DIFF
--- a/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
+++ b/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
@@ -61,10 +61,34 @@ export function AssistantReplyBubble({
         stepId: segment.stepId,
         title: segment.title,
         phase: segment.phase,
+        content: segment.content,
+        result: segment.result,
       });
     }
     return out;
   }, [block.segments]);
+
+  // ISSUE-070：检测「等待首个 token」的场景：所有 segments 都没有可见内容时，
+  // 渲染三点脉冲动画作为占位，避免 UI 空白。
+  // 「无可见内容」=（无 text segment 或所有 text segment content 为空）且无
+  // tool-group / reasoning（reasoning 自带渲染，有 reasoning 已有反馈）。
+  const hasVisibleSegment = block.segments.some((segment) => {
+    if (segment.kind === "text") return segment.content.trim().length > 0;
+    if (segment.kind === "tool-group") return true;
+    if (segment.kind === "reasoning") return true;
+    if (segment.kind === "error") return true;
+    return false;
+  });
+  const isReplyStreaming = block.segments.some(
+    (segment) =>
+      segment.kind === "text"
+        ? segment.streaming
+        : segment.kind === "tool-group"
+          ? segment.status === "running"
+          : false,
+  );
+  const showWaitingPlaceholder =
+    !hasVisibleSegment && (isReplyStreaming || block.segments.length === 0);
 
   return (
     <MessageBubble
@@ -75,6 +99,17 @@ export function AssistantReplyBubble({
       body={
         <div className="space-y-3">
           {reasoningSteps.length > 0 ? <ReasoningPanel steps={reasoningSteps} /> : null}
+          {showWaitingPlaceholder ? (
+            <div
+              data-testid="agent-waiting-placeholder"
+              className="flex items-center gap-1.5 py-1 text-zinc-400 dark:text-zinc-500"
+              aria-label="Agent 正在思考"
+            >
+              <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+              <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+              <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
+            </div>
+          ) : null}
           {block.segments.map((segment) => {
             if (segment.kind === "text") {
               return (

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -402,7 +402,15 @@ export function MessageBubble({
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const content = normalizeContent(message.content);
-  const isStreaming = message.streaming === true && !isUser && content.trim().length > 0;
+  const hasContent = content.trim().length > 0;
+  // ISSUE-070：分离「streaming 状态」与「内容是否为空」两个维度。
+  // 旧实现要求 hasContent 才认 streaming，导致 Agent 刚开始流式回复但尚未产出
+  // 任何 token 时（streaming=true && content=""）UI 完全 blank、无任何反馈。
+  // 现：streaming + 非用户 即视为 streaming；空内容 + 无 body 时显示「等首 token」
+  // 占位（三点脉冲），由 AssistantReplyBubble 也会在 segments 全空时显示同样占位。
+  const isStreaming = message.streaming === true && !isUser;
+  const showStreamingIndicator = isStreaming && hasContent;
+  const showWaitingPlaceholder = isStreaming && !hasContent && !body;
   const avatarPositionClass = isUser
     ? "absolute right-0 top-2 translate-x-[calc(100%+0.75rem)]"
     : "absolute left-0 top-2 -translate-x-[calc(100%+0.75rem)]";
@@ -466,6 +474,7 @@ export function MessageBubble({
               ? "max-w-[85%] rounded-tr-md border border-zinc-900/90 bg-[linear-gradient(135deg,#18181b,#27272a)] text-zinc-50 shadow-[0_14px_34px_rgba(24,24,27,0.18)]"
               : "w-full max-w-full rounded-tl-md border border-zinc-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(244,244,245,0.9))] text-foreground shadow-[0_16px_40px_rgba(24,24,27,0.06)] dark:border-zinc-800 dark:bg-[linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.9))]",
             isStreaming &&
+              hasContent &&
               "ring-1 ring-amber-300/70 shadow-[0_16px_46px_rgba(245,158,11,0.12)] dark:ring-amber-700/60",
           )}
         >
@@ -504,14 +513,26 @@ export function MessageBubble({
                 "[&_th]:border-border/20 [&_th]:bg-background/10 [&_td]:border-border/20",
             )}
           >
-            {body || (
-              <MarkdownContent
-                content={content}
-                isStreaming={isStreaming}
-                citations={message.citations}
-              />
-            )}
-            {isStreaming ? (
+            {body ||
+              (hasContent ? (
+                <MarkdownContent
+                  content={content}
+                  isStreaming={isStreaming}
+                  citations={message.citations}
+                />
+              ) : null)}
+            {showWaitingPlaceholder ? (
+              <div
+                data-testid="agent-waiting-placeholder"
+                className="flex items-center gap-1.5 py-1 text-zinc-400 dark:text-zinc-500"
+                aria-label="Agent 正在思考"
+              >
+                <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+                <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+                <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
+              </div>
+            ) : null}
+            {showStreamingIndicator ? (
               <div className="mt-3 flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-amber-600 dark:text-amber-300">
                 <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-current" />
                 <span>Streaming</span>

--- a/apps/negentropy-ui/components/ui/ReasoningPanel.tsx
+++ b/apps/negentropy-ui/components/ui/ReasoningPanel.tsx
@@ -33,6 +33,15 @@ export type ReasoningStepData = {
   stepId: string;
   title: string;
   phase: "started" | "finished";
+  /**
+   * 推理过程文本内容（来自 ne.a2ui.thought / ne.a2ui.reasoning 自定义事件，
+   * 由 conversation-tree 在处理 STEP_* + thought 事件时写入 reasoning 节点
+   * payload.content）。展开面板时显示该文本，避免「展开后只有标题、看不到
+   * 实际推理」的体验缺失（ISSUE-070）。
+   */
+  content?: string;
+  /** 步骤完成时携带的结构化结果（STEP_FINISHED.result 透传），可选展示。 */
+  result?: unknown;
 };
 
 function readPersisted(): boolean {
@@ -68,25 +77,52 @@ function subscribeStorage(callback: () => void): () => void {
 }
 
 /**
- * 同 stepId 的 started/finished 仅保留最新（finished 优先）。
+ * 同 stepId 的 started/finished 仅保留最新（finished 优先），同时合并 content。
  * 输入顺序对结果有影响：后出现的 finished 覆盖先出现的 started —— 这与
  * AG-UI step lifecycle 的事件时序一致。
+ *
+ * ISSUE-070：merge 时保留**两侧的非空 content** —— started 阶段产生的 thought
+ * 文本会先出现在 started 投影里，finished 阶段如果未携带新文本，应继承
+ * started 的内容；反之 finished 携带摘要时，与 started 内容拼接（去重换行）。
  */
 export function mergeSteps(steps: ReasoningStepData[]): ReasoningStepData[] {
   const byStepId = new Map<string, ReasoningStepData>();
   for (const step of steps) {
     const prev = byStepId.get(step.stepId);
-    // finished 永远优先；started → finished 覆盖；finished → started 不覆盖
     if (!prev) {
-      byStepId.set(step.stepId, step);
+      byStepId.set(step.stepId, { ...step });
       continue;
     }
+    const mergedContent = mergeReasoningContent(prev.content, step.content);
+    const mergedResult = step.result ?? prev.result;
     if (prev.phase === "started" && step.phase === "finished") {
-      byStepId.set(step.stepId, step);
+      byStepId.set(step.stepId, {
+        ...step,
+        content: mergedContent,
+        result: mergedResult,
+      });
+    } else {
+      // 同 phase 重入：保留首条但合并 content / result
+      byStepId.set(step.stepId, {
+        ...prev,
+        content: mergedContent,
+        result: mergedResult,
+      });
     }
-    // started → started：保留首条；finished → finished：保留首条（idempotent）
   }
   return Array.from(byStepId.values());
+}
+
+function mergeReasoningContent(prev?: string, next?: string): string | undefined {
+  const a = (prev || "").trim();
+  const b = (next || "").trim();
+  if (!a && !b) return undefined;
+  if (!a) return b;
+  if (!b) return a;
+  if (a === b) return a;
+  if (a.includes(b)) return a;
+  if (b.includes(a)) return b;
+  return `${a}\n\n${b}`;
 }
 
 export function ReasoningPanel({ steps }: { steps: ReasoningStepData[] }) {
@@ -153,6 +189,8 @@ export function ReasoningPanel({ steps }: { steps: ReasoningStepData[] }) {
               title={step.title}
               phase={step.phase}
               stepId={step.stepId}
+              content={step.content}
+              result={step.result}
             />
           ))}
           {overflow > 0 ? (

--- a/apps/negentropy-ui/components/ui/ReasoningStep.tsx
+++ b/apps/negentropy-ui/components/ui/ReasoningStep.tsx
@@ -18,13 +18,28 @@ function isKnownAgent(title: string): boolean {
   return title in AGENT_DISPLAY_NAMES;
 }
 
+function stringifyResult(result: unknown): string {
+  if (result === null || result === undefined) return "";
+  if (typeof result === "string") return result.trim();
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return String(result);
+  }
+}
+
 export function ReasoningStep({
   title,
   phase,
+  content,
+  result,
 }: {
   title: string;
   phase: "started" | "finished";
   stepId: string;
+  /** ISSUE-070：推理过程文本，由 ne.a2ui.thought / ne.a2ui.reasoning 注入。 */
+  content?: string;
+  result?: unknown;
 }) {
   const isRunning = phase === "started";
   const isAgent = isKnownAgent(title);
@@ -38,24 +53,49 @@ export function ReasoningStep({
       ? `${displayName} 已完成`
       : `思考完成 · ${displayName}`;
 
+  const trimmedContent = (content || "").trim();
+  const trimmedResult = stringifyResult(result);
+  const hasDetail = trimmedContent.length > 0 || trimmedResult.length > 0;
+
   return (
     <div
+      data-testid="reasoning-step"
+      data-step-phase={phase}
+      data-has-detail={hasDetail ? "true" : "false"}
       className={cn(
-        "flex items-center gap-2 rounded-xl border px-3 py-2 text-xs",
+        "rounded-xl border px-3 py-2 text-xs",
         isRunning
           ? "border-violet-200/80 bg-violet-50/60 text-violet-700 dark:border-violet-800/60 dark:bg-violet-950/20 dark:text-violet-300"
-          : "border-zinc-200/60 bg-zinc-50/50 text-zinc-500 dark:border-zinc-800/50 dark:bg-zinc-900/30 dark:text-zinc-400",
+          : "border-zinc-200/60 bg-zinc-50/50 text-zinc-600 dark:border-zinc-800/50 dark:bg-zinc-900/30 dark:text-zinc-300",
       )}
     >
-      <span
-        className={cn(
-          "inline-flex h-2 w-2 shrink-0 rounded-full",
-          isRunning
-            ? "animate-pulse bg-violet-500"
-            : "bg-zinc-400 dark:bg-zinc-600",
-        )}
-      />
-      <span className="font-medium truncate">{label}</span>
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "inline-flex h-2 w-2 shrink-0 rounded-full",
+            isRunning
+              ? "animate-pulse bg-violet-500"
+              : "bg-zinc-400 dark:bg-zinc-600",
+          )}
+        />
+        <span className="font-medium truncate">{label}</span>
+      </div>
+      {trimmedContent ? (
+        <div
+          data-testid="reasoning-step-content"
+          className="mt-2 whitespace-pre-wrap break-words rounded-md bg-white/60 px-2 py-1.5 text-[11px] leading-relaxed text-zinc-700 dark:bg-zinc-950/40 dark:text-zinc-200"
+        >
+          {trimmedContent}
+        </div>
+      ) : null}
+      {trimmedResult ? (
+        <pre
+          data-testid="reasoning-step-result"
+          className="mt-2 max-h-48 overflow-auto rounded-md bg-zinc-100/80 px-2 py-1.5 text-[11px] leading-relaxed text-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-200"
+        >
+          {trimmedResult}
+        </pre>
+      ) : null}
     </div>
   );
 }

--- a/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
@@ -110,6 +110,55 @@ describe("MessageBubble", () => {
     expect(container).toBeTruthy();
   });
 
+  it("Agent 等首个 token 时（streaming=true 且 content=空）显示三点脉冲占位（ISSUE-070）", () => {
+    render(
+      <MessageBubble
+        message={{
+          id: "a-waiting",
+          role: "assistant",
+          content: "",
+          streaming: true,
+        }}
+      />,
+    );
+
+    const placeholder = screen.getByTestId("agent-waiting-placeholder");
+    expect(placeholder).toBeInTheDocument();
+    // 三个 bouncing dots
+    expect(placeholder.querySelectorAll("span.animate-bounce").length).toBe(3);
+    // 此时不应同时显示 streaming 标签 (streaming label 仅在有内容时出现)
+    expect(screen.queryByText("Streaming")).toBeNull();
+  });
+
+  it("用户消息 streaming=true 不会显示等待态占位（仅 assistant 适用）", () => {
+    render(
+      <MessageBubble
+        message={{
+          id: "u-stream",
+          role: "user",
+          content: "",
+          streaming: true,
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("agent-waiting-placeholder")).toBeNull();
+  });
+
+  it("Agent streaming=true 但已有内容时不显示等待占位（避免与正文重叠）", () => {
+    render(
+      <MessageBubble
+        message={{
+          id: "a-has-content",
+          role: "assistant",
+          content: "正在输出",
+          streaming: true,
+        }}
+      />,
+    );
+    expect(screen.queryByTestId("agent-waiting-placeholder")).toBeNull();
+    expect(screen.getByText("Streaming")).toBeInTheDocument();
+  });
+
   it("流式回复中的未闭合表格尾部会降级为安全文本，完成后恢复为表格", () => {
     const { rerender, container } = render(
       <MessageBubble

--- a/apps/negentropy-ui/tests/unit/ui/ReasoningPanel.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/ReasoningPanel.test.tsx
@@ -117,4 +117,52 @@ describe("ReasoningPanel", () => {
     fireEvent.click(button);
     expect(button).toHaveAttribute("aria-expanded", "true");
   });
+
+  it("ISSUE-070：展开后渲染推理 content（不再只有标题）", () => {
+    render(
+      <ReasoningPanel
+        steps={[
+          {
+            ...step("a", "s1", "finished"),
+            content: "这是一段实际的推理过程文本，从 ne.a2ui.thought 注入。",
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    const stepEl = screen.getByTestId("reasoning-step");
+    expect(stepEl.getAttribute("data-has-detail")).toBe("true");
+    expect(screen.getByTestId("reasoning-step-content")).toBeInTheDocument();
+    expect(screen.getByTestId("reasoning-step-content").textContent).toContain(
+      "这是一段实际的推理过程文本",
+    );
+  });
+
+  it("ISSUE-070：result 字段也会作为 pre 渲染", () => {
+    render(
+      <ReasoningPanel
+        steps={[
+          {
+            ...step("a", "s1", "finished"),
+            result: { final: "完成", count: 3 },
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    const resultEl = screen.getByTestId("reasoning-step-result");
+    expect(resultEl).toBeInTheDocument();
+    expect(resultEl.textContent).toContain("final");
+    expect(resultEl.textContent).toContain("完成");
+  });
+
+  it("ISSUE-070：mergeSteps 在 started→finished 时合并两侧的 content", () => {
+    const out = mergeSteps([
+      { id: "a", stepId: "s1", phase: "started", title: "X", content: "early thought" },
+      { id: "b", stepId: "s1", phase: "finished", title: "X", content: "final thought" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].phase).toBe("finished");
+    expect(out[0].content).toBe("early thought\n\nfinal thought");
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/chat-display.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/chat-display.test.ts
@@ -1027,3 +1027,159 @@ describe("isStreamingDuplicateOfAggregate (ISSUE-065 Layer 6 兜底)", () => {
     ).toBe(false);
   });
 });
+
+// =============================================================================
+// ISSUE-070 评审回归：时钟漂移容忍窗口收紧 + 仅修「漂移」不动「客观 follow-up」
+// =============================================================================
+
+describe("buildChatDisplayBlocks - 时钟漂移窗口（评审回归）", () => {
+  it("窗口内 user.timestamp 略晚于 assistant（漂移）：user 仍排到 assistant 之前", () => {
+    // 模拟原 ISSUE-070 漂移场景：user 时间戳因 client/server 时钟差比 assistant
+    // 晚 0.05s（窗口 0.2s 内），新策略仍把 user 提前。
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "asst-1",
+        role: "assistant",
+        timestamp: 1000.5, // 服务端时钟
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "asst-1",
+        delta: "你好",
+        timestamp: 1000.5,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "user-1",
+        role: "user",
+        timestamp: 1000.55, // 客户端时钟，比 assistant 晚 50ms
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "user-1",
+        delta: "提问",
+        timestamp: 1000.55,
+      }),
+    ];
+    const tree = buildConversationTree({ events });
+    const blocks = buildChatDisplayBlocks(tree);
+    const order = blocks
+      .filter(
+        (b) =>
+          (b.kind === "message" && b.message.role === "user") ||
+          b.kind === "assistant-reply",
+      )
+      .map((b) =>
+        b.kind === "message" ? `user:${b.message.id}` : `asst:${b.kind}`,
+      );
+    // user 漂在 assistant 之后但仍应排在前
+    expect(order[0]?.startsWith("user:")).toBe(true);
+    expect(order[order.length - 1]?.startsWith("asst:")).toBe(true);
+  });
+
+  it("窗口外（≥0.2s）user follow-up：保持真实时序，不被反插到 assistant 之前", () => {
+    // 关键回归：用户在 assistant 回复中（0.7s 后）紧追问 follow-up，
+    // 旧 1s 窗口会把 follow-up 排到 assistant-reply 之前。
+    // 新 0.2s 窗口下：assistant-reply 与 follow-up 时差 0.7s 超出窗口，
+    // 走真实时序排序：user → assistant-reply → user-followup。
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "user-1",
+        role: "user",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "user-1",
+        delta: "首条提问",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "asst-1",
+        role: "assistant",
+        timestamp: 1000.5,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "asst-1",
+        delta: "正在回答",
+        timestamp: 1000.5,
+      }),
+      // user 在 assistant 还在流式回复时（0.7s 后）紧追一条 follow-up
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-2",
+        timestamp: 1001.2,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-2",
+        messageId: "user-2",
+        role: "user",
+        timestamp: 1001.2,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-2",
+        messageId: "user-2",
+        delta: "紧追问",
+        timestamp: 1001.2,
+      }),
+    ];
+    const tree = buildConversationTree({ events });
+    const blocks = buildChatDisplayBlocks(tree);
+    // 抽取 user 与 assistant-reply 的相对顺序
+    const sequence = blocks
+      .filter(
+        (b) =>
+          (b.kind === "message" && b.message.role === "user") ||
+          b.kind === "assistant-reply",
+      )
+      .map((b) =>
+        b.kind === "message" ? `user:${b.message.id}` : "asst-reply",
+      );
+    // 期望：user-1, asst-reply, user-2（绝不是 user-1, user-2, asst-reply）
+    const idxFirstUser = sequence.findIndex((s) => s === "user:user-1");
+    const idxAsst = sequence.findIndex((s) => s === "asst-reply");
+    const idxFollowup = sequence.findIndex((s) => s === "user:user-2");
+    expect(idxFirstUser).toBeGreaterThanOrEqual(0);
+    expect(idxAsst).toBeGreaterThanOrEqual(0);
+    expect(idxFollowup).toBeGreaterThanOrEqual(0);
+    expect(idxFirstUser).toBeLessThan(idxAsst);
+    expect(idxAsst).toBeLessThan(idxFollowup);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/utils/message-ledger.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/message-ledger.test.ts
@@ -151,6 +151,50 @@ describe("message-ledger", () => {
     ]);
   });
 
+  it("ISSUE-070：同时间戳下 user 消息始终排在 assistant 之前（角色优先）", () => {
+    // 模拟时钟漂移：assistant 时间戳早 1ms（service clock 漂移），user 后到。
+    // 但业务正确顺序应当是 user 在前、assistant 在后；新排序按 role 优先解决。
+    const events: AgUiEvent[] = [
+      // assistant 先到（事件序 0）
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "asst-1",
+        role: "assistant",
+        timestamp: 1000.001, // 早 1ms
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "asst-1",
+        delta: "答复",
+        timestamp: 1000.001,
+      }),
+      // user 后到（事件序 2），但时间戳更晚
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "user-1",
+        role: "user",
+        timestamp: 1000.001, // 同时间戳
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "session-1",
+        runId: "run-1",
+        messageId: "user-1",
+        delta: "提问",
+        timestamp: 1000.001,
+      }),
+    ];
+    const ledger = buildMessageLedger({ events });
+    // 修复后：同时间戳下 user 必排在 assistant 之前
+    expect(ledger.map((e) => e.resolvedRole)).toEqual(["user", "assistant"]);
+  });
+
   it("buildMessageLedger 在 createdAt 相同的事件下用 sourceOrder 保持原始时间序", () => {
     // 两条 user/assistant 消息 timestamp 完全相同；UUID 字典序与原始事件序刚好相反。
     // 引入 sourceOrder 后，排序应仍然按事件出现顺序而非 UUID localeCompare。

--- a/apps/negentropy-ui/tests/unit/utils/message.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/message.test.ts
@@ -293,4 +293,15 @@ describe("longestCommonSubsequenceRatio (ISSUE-070 LCS 兜底)", () => {
     );
     expect(ratio).toBeLessThan(0.5);
   });
+
+  it("长内容（>2000 字）且高度同源时仍能 ≥ 0.65（评审：分母用截断后长度）", () => {
+    // 评审 #2：截断到首尾各 1000 后 lcsLen ≤ 2000；旧实现用「截断前长度」做
+    // 分母，对 ≥ 3077 字的同源内容上界 < 0.65，第 6 层 LCS 兜底永远不触发。
+    // 现在分母改为「实际参与 LCS 计算的较短串长度」（截断后），保持语义自洽。
+    const base = "abcdefghij".repeat(400); // 4000 chars
+    const earlier = base; // 4000
+    const later = `${base}<additional tail content for length differentiation>`;
+    const ratio = longestCommonSubsequenceRatio(earlier, later);
+    expect(ratio).toBeGreaterThanOrEqual(0.65);
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/message.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/message.test.ts
@@ -9,6 +9,7 @@ import {
   mergeAdjacentAssistant,
   mapMessagesToChat,
   buildChatMessagesFromEventsWithFallback,
+  longestCommonSubsequenceRatio,
 } from "@/utils/message";
 import type { ChatMessage } from "@/types/common";
 import {
@@ -258,5 +259,38 @@ describe("buildChatMessagesFromEventsWithFallback - sorting", () => {
     // 结果应该包含内容
     expect(result[0].id).toBe("msg1");
     expect(result[0].content).toBe("Hello");
+  });
+});
+
+describe("longestCommonSubsequenceRatio (ISSUE-070 LCS 兜底)", () => {
+  it("完全相同的字符串 → 1.0", () => {
+    expect(longestCommonSubsequenceRatio("hello world", "hello world")).toBe(1);
+  });
+
+  it("空串 → 0", () => {
+    expect(longestCommonSubsequenceRatio("", "abc")).toBe(0);
+    expect(longestCommonSubsequenceRatio("abc", "")).toBe(0);
+  });
+
+  it("一方是另一方的前缀 → 接近 1.0", () => {
+    const ratio = longestCommonSubsequenceRatio("Pong!", "Pong! Next options");
+    expect(ratio).toBeCloseTo(1, 5);
+  });
+
+  it("同源不同表面（图 1 partial 残缺版 vs final 完整版）→ ≥ 0.65", () => {
+    const partial = "Pong. Summary done- ong toPing Possible needs concrete ping";
+    const final =
+      "Pong. Summary — done: Replied Pong to your Ping. Next options Continue ping pong exchanges.";
+    const ratio = longestCommonSubsequenceRatio(partial, final);
+    // 残缺版字符在 final 中按顺序广泛出现，应当 ≥ 0.65 命中第 6 层兜底
+    expect(ratio).toBeGreaterThanOrEqual(0.65);
+  });
+
+  it("两段完全不相关的内容 → 显著低于 0.65", () => {
+    const ratio = longestCommonSubsequenceRatio(
+      "今日天气晴朗适合出行散步看看花草",
+      "我喜欢吃苹果香蕉葡萄这些水果都很甜",
+    );
+    expect(ratio).toBeLessThan(0.5);
   });
 });

--- a/apps/negentropy-ui/types/a2ui.ts
+++ b/apps/negentropy-ui/types/a2ui.ts
@@ -131,6 +131,11 @@ export interface ReplyReasoningDisplaySegment {
   title: string;
   phase: "started" | "finished";
   stepId: string;
+  /**
+   * 推理过程文本（由 ne.a2ui.thought 自定义事件累积写入对应 reasoning 节点
+   * payload.content 后透传）。展开 ReasoningPanel 时显示给用户。
+   */
+  content?: string;
   result?: unknown;
 }
 

--- a/apps/negentropy-ui/utils/chat-display.ts
+++ b/apps/negentropy-ui/utils/chat-display.ts
@@ -968,10 +968,14 @@ export function buildChatDisplayBlocks(tree: ConversationTree): ChatDisplayBlock
     blocks.push(createSummaryBlock(root));
   });
 
-  // ISSUE-070：在毫秒级时钟漂移容忍窗口（1 秒）内，把 user message 排在
-  // assistant-reply / tool-group 之前。只在差距很小时启用业务优先级，避免
-  // 把跨 turn 的真实时序颠倒。
-  const CLOCK_DRIFT_TOLERANCE_S = 1;
+  // ISSUE-070：在毫秒级时钟漂移容忍窗口内，把 user message 排在 assistant
+  // 输出（assistant-reply / tool-group）之前。窗口收紧到 0.2s 以避免误吞
+  // 「秒级 follow-up」——客户端/服务端时钟漂移在 NTP 同步下典型 < 100ms，
+  // 0.2s 既足够覆盖正常抖动，也排除「用户在 Agent 回复未完成时（≤1s）紧追
+  // 问一条 follow-up」被误判为漂移、被反向插到 assistant 之前的回归
+  // （旧 1s 窗口下 t_assistant=0.5 与 t_followup=0.7 双双落入窗口，
+  // assistant 会被排到 follow-up 之后，造成「问→追问→答」乱序）。
+  const CLOCK_DRIFT_TOLERANCE_S = 0.2;
   const isUserMessageBlock = (block: ChatDisplayBlock): boolean => {
     if (block.kind !== "message") return false;
     return block.message.role === "user";

--- a/apps/negentropy-ui/utils/chat-display.ts
+++ b/apps/negentropy-ui/utils/chat-display.ts
@@ -18,6 +18,7 @@ import { isNonCriticalError } from "@/utils/error-filter";
 import {
   bigramJaccardSimilarity,
   isEquivalentMessageContent,
+  longestCommonSubsequenceRatio,
   multisetCoverage,
 } from "@/utils/message";
 
@@ -294,6 +295,16 @@ function createReplyErrorSegment(node: ConversationNode): ReplyErrorDisplaySegme
 function createReplyReasoningSegment(
   node: ConversationNode,
 ): ReplyReasoningDisplaySegment {
+  // ISSUE-070：reasoning 节点的 payload.content 由 conversation-tree 在处理
+  // ne.a2ui.thought / ne.a2ui.reasoning 自定义事件时累积写入，需要透传到
+  // segment 供 ReasoningPanel 展开后渲染。优先级：直接 content > summary。
+  const rawContent =
+    typeof node.payload.content === "string"
+      ? String(node.payload.content)
+      : "";
+  const fallbackContent =
+    !rawContent.trim() && typeof node.summary === "string" ? node.summary : "";
+  const content = (rawContent || fallbackContent).trim() || undefined;
   return {
     id: `reply-reasoning:${node.id}`,
     kind: "reasoning",
@@ -303,6 +314,7 @@ function createReplyReasoningSegment(
     title: node.title,
     phase: node.status === "done" || node.status === "finished" ? "finished" : "started",
     stepId: String(node.payload.stepId || node.id),
+    content,
     result: node.payload.result,
   };
 }
@@ -428,12 +440,20 @@ const REDUNDANT_TEXT_JACCARD_MIN_LENGTH = 30;
  *
  * 命中后丢弃较短一方（保留更完备的最终版本）。
  */
-const STREAMING_DUPLICATE_MULTISET_RATIO = 0.8;
+// ISSUE-070：multiset 覆盖阈值从 0.8 → 0.7，长度比从 1.15 → 1.10。
+// 旧阈值漏检「partial 残缺版与 final 改写版长度差较小、字符差较大」的场景
+// （如图 1：partial=`ong toPingPossible needs concrete: ) ping (...`，final=
+// `Summary — done: Replied "Pong" to your "Ping". Next options: ...`）。
+// 配合新增的第 6 层 LCS 兜底，能稳定捕捉这类同源不同表面的残留双内容。
+const STREAMING_DUPLICATE_MULTISET_RATIO = 0.7;
 const STREAMING_DUPLICATE_MIN_LENGTH = 12;
-// 1.15 而非 1.2：实测 ISSUE-049 残缺版与 final 版长度比约 1.18（参见 chat-display.test.ts
-// 真实场景测试），1.2 阈值会漏检。multiset coverage 0.8 + min length 12 已构成主要防误删
-// 屏障，长度比仅作辅助过滤"长度持平但内容大相径庭的两段独立消息"。
-const STREAMING_DUPLICATE_LENGTH_RATIO = 1.15;
+const STREAMING_DUPLICATE_LENGTH_RATIO = 1.1;
+// 第 6 层 LCS 兜底参数：
+// - 长度门槛 50：避免误删合理短回复；
+// - LCS / 较短长度 ≥ 0.65：意味着 ≥ 65% 的较短串字符以相对顺序出现在较长
+//   串中，强烈暗示同源（即使 multiset 覆盖未达 0.7 也能命中）。
+const STREAMING_DUPLICATE_LCS_MIN_LENGTH = 50;
+const STREAMING_DUPLICATE_LCS_RATIO = 0.65;
 
 export function isStreamingDuplicateOfLater(
   earlierContent: string,
@@ -444,9 +464,17 @@ export function isStreamingDuplicateOfLater(
   if (earlierLen < STREAMING_DUPLICATE_MIN_LENGTH) return false;
   if (laterLen < STREAMING_DUPLICATE_MIN_LENGTH) return false;
   if (laterLen < earlierLen * STREAMING_DUPLICATE_LENGTH_RATIO) return false;
-  // 较短一段是否被较长一段以 ≥ 80% multiset 覆盖（流式残缺版的字符几乎都来自 final）。
   const coverage = multisetCoverage(earlierContent, laterContent);
-  return coverage >= STREAMING_DUPLICATE_MULTISET_RATIO;
+  if (coverage >= STREAMING_DUPLICATE_MULTISET_RATIO) return true;
+  // 第 6 层兜底：LCS（最长公共子序列）比例 —— 顺序+字符共同覆盖。
+  if (
+    earlierLen >= STREAMING_DUPLICATE_LCS_MIN_LENGTH &&
+    laterLen >= STREAMING_DUPLICATE_LCS_MIN_LENGTH
+  ) {
+    const lcsRatio = longestCommonSubsequenceRatio(earlierContent, laterContent);
+    if (lcsRatio >= STREAMING_DUPLICATE_LCS_RATIO) return true;
+  }
+  return false;
 }
 
 /**
@@ -841,9 +869,30 @@ export function buildChatDisplayBlocks(tree: ConversationTree): ChatDisplayBlock
     blocks.push(createSummaryBlock(root));
   });
 
+  // ISSUE-070：在毫秒级时钟漂移容忍窗口（1 秒）内，把 user message 排在
+  // assistant-reply / tool-group 之前。只在差距很小时启用业务优先级，避免
+  // 把跨 turn 的真实时序颠倒。
+  const CLOCK_DRIFT_TOLERANCE_S = 1;
+  const isUserMessageBlock = (block: ChatDisplayBlock): boolean => {
+    if (block.kind !== "message") return false;
+    return block.message.role === "user";
+  };
+  const isAssistantOutputBlock = (block: ChatDisplayBlock): boolean =>
+    block.kind === "assistant-reply" || block.kind === "tool-group";
   blocks.sort((left, right) => {
-    if (left.timestamp !== right.timestamp) {
-      return left.timestamp - right.timestamp;
+    const timeDiff = left.timestamp - right.timestamp;
+    if (Math.abs(timeDiff) > CLOCK_DRIFT_TOLERANCE_S) {
+      return timeDiff;
+    }
+    // 时钟漂移容忍窗口内：user 消息优先于 assistant 输出（时钟偏移修正）
+    if (isUserMessageBlock(left) && isAssistantOutputBlock(right)) {
+      return -1;
+    }
+    if (isAssistantOutputBlock(left) && isUserMessageBlock(right)) {
+      return 1;
+    }
+    if (timeDiff !== 0) {
+      return timeDiff;
     }
     if (left.sourceOrder !== right.sourceOrder) {
       return left.sourceOrder - right.sourceOrder;

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -32,6 +32,7 @@ import {
   accumulateTextContent,
   bigramJaccardSimilarity,
   isEquivalentMessageContent,
+  multisetCoverage,
   normalizeMessageContent,
 } from "@/utils/message";
 import { isNonCriticalError } from "@/utils/error-filter";
@@ -348,6 +349,47 @@ function getMessageTimestamp(message: Message): number {
   return createdAt instanceof Date ? createdAt.getTime() / 1000 : Date.now() / 1000;
 }
 
+/**
+ * ISSUE-070：在指定 turn 子树中找到最近的 reasoning 节点。
+ *
+ * 选择规则（自上而下）：
+ *   1. 同 runId 下最近的 reasoning 节点（按 sourceOrder 倒序，取最近一条）；
+ *   2. 同 turn 下任意 reasoning 节点（兼容 runId 漂移）；
+ *   3. 都没有则返回 null（thought 文本会被丢弃，避免污染 turn 顶层）。
+ *
+ * 不递归遍历 nodeIndex 全表（O(N)），仅遍历 turn.children → step → reasoning
+ * 这条已知层级（O(K)，K 通常 < 50）。
+ */
+function findLatestReasoningNode(
+  turns: Map<string, MutableNode>,
+  turnId: string,
+  runId: string,
+): MutableNode | null {
+  const turn = turns.get(turnId);
+  if (!turn) return null;
+  const candidates: MutableNode[] = [];
+  const visit = (node: MutableNode) => {
+    if (node.type === "reasoning" && (!runId || !node.runId || node.runId === runId)) {
+      candidates.push(node);
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(turn);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.sourceOrder - a.sourceOrder);
+  return candidates[0];
+}
+
+function appendThoughtText(existing: string, incoming: string): string {
+  const a = existing.trim();
+  const b = incoming.trim();
+  if (!a) return b;
+  if (!b) return a;
+  if (a === b || a.includes(b)) return a;
+  if (b.includes(a)) return b;
+  return `${a}\n\n${b}`;
+}
+
 function findMatchingTextNodeId(
   nodeIndex: Map<string, MutableNode>,
   input: {
@@ -371,16 +413,37 @@ function findMatchingTextNodeId(
       continue;
     }
     if (node.payload.streaming !== true) {
-      // 防御性收敛：当 hydrated TEXT_MESSAGE_* 因 messageId 不同而到达此处，
-      // 而 realtime 节点已收尾，且二者内容严格相等时，仍允许复用同一节点，
-      // 避免在已 closed 的同内容节点旁新建第二个节点。仅对 assistant 路径
-      // 放宽，user 仍要求节点处于流式态以避免误并历史用户消息。
+      // ISSUE-070 / ISSUE-058 加强：当 hydrated TEXT_MESSAGE_* 因 messageId 不同
+      // 而到达此处、而 realtime 节点已收尾时，允许如下三种次级匹配以避免在已
+      // closed 的同源节点旁新建第二个独立 text node（→ 渲染双内容）：
+      //   M1 — 内容严格相等（旧实现，最严）；
+      //   M2 — 一方是另一方的严格前缀（流式累积版 vs 完整最终版）；
+      //   M3 — multiset 覆盖率 ≥ 0.75（同源但表面字符存在重排/补齐差异）。
+      // 仅对 assistant 路径放宽；user 仍要求节点处于流式态以避免误并历史用户消息。
       const existingContent = String(node.payload.content || "").trim();
-      if (
-        input.role !== "assistant" ||
-        !existingContent ||
-        existingContent !== normalizedContent
-      ) {
+      if (input.role !== "assistant" || !existingContent) {
+        continue;
+      }
+      const equal = existingContent === normalizedContent;
+      const prefix =
+        existingContent.startsWith(normalizedContent) ||
+        normalizedContent.startsWith(existingContent);
+      let multisetMatch = false;
+      if (!equal && !prefix) {
+        const shorter =
+          existingContent.length <= normalizedContent.length
+            ? existingContent
+            : normalizedContent;
+        const longer = shorter === existingContent ? normalizedContent : existingContent;
+        if (
+          shorter.length >= 12 &&
+          longer.length >= shorter.length * 1.05 &&
+          multisetCoverage(shorter, longer) >= 0.75
+        ) {
+          multisetMatch = true;
+        }
+      }
+      if (!equal && !prefix && !multisetMatch) {
         continue;
       }
     }
@@ -521,6 +584,22 @@ function sortNodeChildren(node: MutableNode) {
     const timeDiff = a.timeRange.start - b.timeRange.start;
     if (timeDiff !== 0) {
       return timeDiff;
+    }
+    // ISSUE-070：同时间戳时，按节点 role 排序 —— text:user 必排在 text:assistant 之前，
+    // 避免刷新后用户消息漂移到 assistant 回复之后的乱序（时钟漂移导致毫秒级抖动）。
+    const roleA = a.role || "";
+    const roleB = b.role || "";
+    if (roleA !== roleB) {
+      const roleOrder: Record<string, number> = {
+        user: 0,
+        system: 1,
+        developer: 2,
+        assistant: 3,
+        tool: 4,
+      };
+      const ra = roleOrder[roleA] ?? 50;
+      const rb = roleOrder[roleB] ?? 50;
+      if (ra !== rb) return ra - rb;
     }
     const sourceOrderDiff = a.sourceOrder - b.sourceOrder;
     if (sourceOrderDiff !== 0) {
@@ -1245,6 +1324,29 @@ export function buildConversationTree(
           return;
         }
         if (eventTypeName === "ne.a2ui.reasoning") {
+          return;
+        }
+        // ISSUE-070：ne.a2ui.thought 承载 LLM 推理（thinking）的实际文本，需要把
+        // text 注入到当前 turn 内最近的 reasoning 节点 payload.content，以便
+        // ReasoningPanel 展开时显示推理过程；否则用户展开后只能看到「思考完成·
+        // 推理阶段」标签而看不到推理内容（图 3）。
+        if (eventTypeName === "ne.a2ui.thought") {
+          const data = asRecord(getCustomEventData(normalizedEvent));
+          const thoughtText =
+            data && typeof data.text === "string" ? data.text : "";
+          if (thoughtText.trim()) {
+            const target = findLatestReasoningNode(turns, turn.id, runId);
+            if (target) {
+              const existing =
+                typeof target.payload.content === "string"
+                  ? target.payload.content
+                  : "";
+              target.payload.content = appendThoughtText(existing, thoughtText);
+              if (!target.sourceEventTypes.includes(eventType)) {
+                target.sourceEventTypes.push(eventType);
+              }
+            }
+          }
           return;
         }
         const node = upsertNode(nodeIndex, roots, turns, {

--- a/apps/negentropy-ui/utils/message-ledger.ts
+++ b/apps/negentropy-ui/utils/message-ledger.ts
@@ -489,6 +489,27 @@ export function buildMessageLedger(input: {
     .sort(compareLedgerEntriesByTime);
 }
 
+// ISSUE-070：角色优先级 —— 同时间戳时 user 必排在 assistant / developer / tool
+// 之前。修复刷新后用户消息漂移到 assistant 回复之后的乱序问题。原因：
+// 1. realtime 路径 user 消息时间戳取自 send 时刻（client clock），assistant
+//    首个 TEXT_MESSAGE_START 时间戳取自服务端 RUN_STARTED（server clock），
+//    时钟漂移可能让 user 落后于 assistant 几毫秒；
+// 2. hydration 路径两类消息时间戳分别来自不同表 column（messages.created_at
+//    vs runs.started_at），毫秒级抖动同样存在。
+// 角色排序规则是「业务正确性」的唯一稳定锚点。
+const ROLE_ORDER: Record<string, number> = {
+  user: 0,
+  system: 1,
+  developer: 2,
+  assistant: 3,
+  tool: 4,
+};
+
+function roleSortKey(role: string | undefined): number {
+  if (!role) return 99;
+  return ROLE_ORDER[role] ?? 50;
+}
+
 function compareLedgerEntriesByTime(
   a: MessageLedgerEntry,
   b: MessageLedgerEntry,
@@ -496,6 +517,11 @@ function compareLedgerEntriesByTime(
   const timeDiff = a.createdAt.getTime() - b.createdAt.getTime();
   if (timeDiff !== 0) {
     return timeDiff;
+  }
+  // 同时间戳：user 优先 → developer/assistant/tool（避免刷新后 user 跑到 assistant 之后）。
+  const roleDiff = roleSortKey(a.resolvedRole) - roleSortKey(b.resolvedRole);
+  if (roleDiff !== 0) {
+    return roleDiff;
   }
   const aOrder = a.sourceOrder ?? Number.MAX_SAFE_INTEGER;
   const bOrder = b.sourceOrder ?? Number.MAX_SAFE_INTEGER;

--- a/apps/negentropy-ui/utils/message.ts
+++ b/apps/negentropy-ui/utils/message.ts
@@ -298,6 +298,10 @@ export function multisetCoverage(shorter: string, longer: string): number {
  * 复杂度 O(m*n)。为防长内容（>2000 字）退化，超长输入会先各取首尾 1000 字
  * 拼接后再比较——这种长度的 LLM 答复实际由前后段 token 主导，截断后仍能稳
  * 定区分「同源 vs 异源」。
+ *
+ * 注：分母取「实际参与 LCS 计算的较短串长度」（reduce 后），而非原串长度。
+ * 否则当较短串 > ~3077 字符时 lcsLen ≤ 2000 而分母 > 3077，ratio 上界 < 0.65，
+ * 第 6 层 LCS 兜底对长答复永远不触发——与「截断后仍稳定区分」的设计相悖。
  */
 export function longestCommonSubsequenceRatio(a: string, b: string): number {
   const trimA = a.trim();
@@ -329,8 +333,8 @@ export function longestCommonSubsequenceRatio(a: string, b: string): number {
     curr.fill(0);
   }
   const lcsLen = prev[sLen];
-  const shorterTrueLen = Math.min(trimA.length, trimB.length);
-  return shorterTrueLen === 0 ? 0 : lcsLen / shorterTrueLen;
+  const shorterReducedLen = Math.min(sA.length, sB.length);
+  return shorterReducedLen === 0 ? 0 : lcsLen / shorterReducedLen;
 }
 
 export function bigramJaccardSimilarity(a: string, b: string): number {

--- a/apps/negentropy-ui/utils/message.ts
+++ b/apps/negentropy-ui/utils/message.ts
@@ -285,6 +285,54 @@ export function multisetCoverage(shorter: string, longer: string): number {
   return matched / shorter.length;
 }
 
+/**
+ * 最长公共子序列（LCS）长度占较短串的比例。
+ *
+ * 与 ``multisetCoverage`` / ``bigramJaccardSimilarity`` 互补：
+ * - ``multisetCoverage`` 仅统计字符 *频次*，忽略顺序 → 对乱序高重复字符串易误判；
+ * - ``bigramJaccardSimilarity`` 关注字符 *相邻对*，长度差异大时偏紧；
+ * - LCS 同时关注 *字符存在* 与 *相对顺序* → 对「累积残缺版（少字符但顺序与
+ *   final 一致）」与「同源改写版（字符大致相同但局部重排）」两种主流式
+ *   双内容场景都能稳定命中，作为 ``isStreamingDuplicateOfLater`` 第 6 层兜底。
+ *
+ * 复杂度 O(m*n)。为防长内容（>2000 字）退化，超长输入会先各取首尾 1000 字
+ * 拼接后再比较——这种长度的 LLM 答复实际由前后段 token 主导，截断后仍能稳
+ * 定区分「同源 vs 异源」。
+ */
+export function longestCommonSubsequenceRatio(a: string, b: string): number {
+  const trimA = a.trim();
+  const trimB = b.trim();
+  if (!trimA || !trimB) return 0;
+  const limit = 1000;
+  const reduce = (s: string) =>
+    s.length <= limit * 2 ? s : `${s.slice(0, limit)}${s.slice(-limit)}`;
+  const sA = reduce(trimA);
+  const sB = reduce(trimB);
+  const m = sA.length;
+  const n = sB.length;
+  if (m === 0 || n === 0) return 0;
+  // 使用滚动数组优化空间到 O(min(m, n))
+  const [shorterStr, longerStr] = m <= n ? [sA, sB] : [sB, sA];
+  const sLen = shorterStr.length;
+  const lLen = longerStr.length;
+  let prev = new Array(sLen + 1).fill(0);
+  let curr = new Array(sLen + 1).fill(0);
+  for (let i = 1; i <= lLen; i += 1) {
+    for (let j = 1; j <= sLen; j += 1) {
+      if (longerStr[i - 1] === shorterStr[j - 1]) {
+        curr[j] = prev[j - 1] + 1;
+      } else {
+        curr[j] = Math.max(prev[j], curr[j - 1]);
+      }
+    }
+    [prev, curr] = [curr, prev];
+    curr.fill(0);
+  }
+  const lcsLen = prev[sLen];
+  const shorterTrueLen = Math.min(trimA.length, trimB.length);
+  return shorterTrueLen === 0 ? 0 : lcsLen / shorterTrueLen;
+}
+
 export function bigramJaccardSimilarity(a: string, b: string): number {
   const aGrams = computeCharBigrams(a);
   const bGrams = computeCharBigrams(b);

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1411,3 +1411,31 @@
   1. 所有危险操作必须复用 `components/ui/ConfirmDialog` 或 `useConfirmDialog`，禁止直接调用浏览器原生 dialog；
   2. 若后续需要“输入名称二次确认”，应扩展通用组件而不是回退到 `prompt()`；
   3. 下一步可把静态测试升级为 ESLint `no-restricted-globals` / `no-restricted-properties` 规则，覆盖裸 `confirm()` 的 AST 级识别。
+
+---
+
+## ISSUE-070 Agent 答复 4 大缺陷（等待占位 / 双内容 / 推理空内容 / 刷新乱序）（2026-05-07）
+
+- **表因**：用户截图反馈 4 处可视化缺陷：
+  1. Agent 刚开始流式答复但还未产出 token 时，气泡内**完全空白**、无任何视觉反馈；
+  2. 同一次回答内同时出现「partial 残缺版（如 "ong toPing Possible needs concrete..."）+ final 完整版（"Summary — done: Replied 'Pong'..."）」**双段内容并排渲染**；
+  3. 推理面板展开后**仅显示「思考完成 · 推理阶段」标题**，看不到实际推理文本；
+  4. 多轮发送 + **刷新页面后**，user 消息漂移到 assistant 回复**之后**，时序错乱。
+- **根因**：
+  1. [`MessageBubble.tsx`](../apps/negentropy-ui/components/ui/MessageBubble.tsx) 的 ``isStreaming`` 标志要求 ``content.trim().length > 0``；空内容时整个气泡（含 streaming indicator）都不渲染。
+  2. [`isStreamingDuplicateOfLater`](../apps/negentropy-ui/utils/chat-display.ts) 的 multiset 阈值 0.8 / 长度比 1.15 对「LLM 双轮自我修订」型残缺-改写双段漏检；[`findMatchingTextNodeId`](../apps/negentropy-ui/utils/conversation-tree.ts) 在 closed 节点时仅允许内容严格相等匹配，致同源 hydration 落到独立 text node。
+  3. [`ReasoningStepData`](../apps/negentropy-ui/components/ui/ReasoningPanel.tsx) 类型缺 ``content``/``result`` 字段；``ReasoningStep`` 仅渲染标签；``conversation-tree`` 把 ``ne.a2ui.thought`` CUSTOM 事件当作普通 custom 节点忽略，未注入对应 reasoning 节点 payload。
+  4. [`compareLedgerEntriesByTime`](../apps/negentropy-ui/utils/message-ledger.ts) 同时间戳依赖 ``sourceOrder`` + ``id.localeCompare``；realtime user message 时间戳取自 client clock、assistant 取自 server RUN_STARTED，毫秒级时钟漂移让 user 落后于 assistant 几毫秒，刷新后排序漂移。
+- **处理方式**：
+  1. **等待占位**：``MessageBubble`` 解耦 ``isStreaming`` 与 ``hasContent``，新增 ``showWaitingPlaceholder``；``AssistantReplyBubble`` 在 segments 全空 + streaming 时渲染三点 ``animate-bounce`` 占位（``data-testid="agent-waiting-placeholder"``）。
+  2. **双内容根因**：``isStreamingDuplicateOfLater`` 阈值放宽至 multiset ≥0.7 + 长度比 ≥1.10，新增第 6 层 LCS（最长公共子序列）兜底（≥0.65，长内容首尾截断 O(m·n) 防退化）；``findMatchingTextNodeId`` 在 closed 节点时放宽匹配为「严格相等 ∨ 严格前缀 ∨ multiset 覆盖 ≥0.75」。
+  3. **推理内容**：``ReasoningStepData`` / ``ReplyReasoningDisplaySegment`` 增加 ``content?``/``result?`` 字段；``ReasoningStep`` 在展开态渲染 content（``whitespace-pre-wrap``）+ result（``pre`` 限高滚动）；``conversation-tree`` 对 ``ne.a2ui.thought`` 调用 ``findLatestReasoningNode`` 把 thought.text 累积写入 reasoning 节点 ``payload.content``；``createReplyReasoningSegment`` 透传 content（fallback 至 ``node.summary``）；``mergeSteps`` 在 started→finished 时合并两侧 content。
+  4. **排序乱序**：``compareLedgerEntriesByTime`` 同时间戳新增 role 优先级（``user < system < developer < assistant < tool``）；``conversation-tree`` children 排序同步加入 role 维度；``chat-display`` blocks 排序在 1s 时钟漂移容忍窗口内让 user message 优先于 assistant-reply / tool-group。
+  5. **测试**：12 个新增用例覆盖等待占位 3 + 推理 content 渲染/合并 3 + 同时间戳 user 排序 1 + LCS 函数 5；全套 580 单测通过；浏览器实机验证刷新后 user→assistant 顺序保持正确，推理面板展开能看到具体内容，无重复气泡。
+- **后续防范**：
+  1. **两层防御**（UI 兜底 + 根因层）必须同时升级：``chat-display`` 兜底阈值放宽时，``message-ledger`` 同源合并 helper 也应同步升级；
+  2. **LCS 工具的复用**：``longestCommonSubsequenceRatio`` 已抽到 ``utils/message.ts``，下次「同源不同表面」类去重场景（KG SSE 进度合并、Tool Progress 流式更新等）建议优先复用而非新写本地实现；
+  3. **角色优先级与时钟漂移容忍窗口**：任何「按 timestamp 排序」的视图（Timeline / Activity Log / Memory）都应审视是否需要类似 role 优先 + 漂移窗口；
+  4. **空状态可见性**：所有「streaming = true」的 UI 路径都必须有等待占位（无内容时不可空白），借鉴本 issue 的 ``data-testid="agent-waiting-placeholder"`` 模式建立断言；
+  5. **CUSTOM 事件的语义价值**：``ne.a2ui.thought`` / ``ne.a2ui.reasoning`` 等自定义事件如果在前端被「无差别忽略」就失去了承载价值；新增 CUSTOM 事件时必须明确数据流路径与渲染锚点。
+- **同类问题影响**：所有「streaming + 空 content」的 UI 路径（Tool Progress 等待首条事件、KG SSE 等待首条进度）；所有「LLM 自我修订」可能产生残缺-完整双段的去重场景；所有「时钟漂移」可能导致刷新后乱序的消息列表（Memory timeline、Activity Log、Audit Log）。

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1505,3 +1505,7 @@
   4. **空状态可见性**：所有「streaming = true」的 UI 路径都必须有等待占位（无内容时不可空白），借鉴本 issue 的 ``data-testid="agent-waiting-placeholder"`` 模式建立断言；
   5. **CUSTOM 事件的语义价值**：``ne.a2ui.thought`` / ``ne.a2ui.reasoning`` 等自定义事件如果在前端被「无差别忽略」就失去了承载价值；新增 CUSTOM 事件时必须明确数据流路径与渲染锚点。
 - **同类问题影响**：所有「streaming + 空 content」的 UI 路径（Tool Progress 等待首条事件、KG SSE 等待首条进度）；所有「LLM 自我修订」可能产生残缺-完整双段的去重场景；所有「时钟漂移」可能导致刷新后乱序的消息列表（Memory timeline、Activity Log、Audit Log）。
+- **2026-05-07 评审回归（同 ISSUE-070 范畴）**：
+  1. **`chat-display` 时钟漂移窗口 1s → 0.2s**：原 1s 容忍窗口配合双向 user 优先，会把「user 提问 → assistant 回复中（≤1s 内）→ user 紧追问」的真实时序误判为漂移，把 assistant 排到 follow-up 之后，错位为「问 → 紧追问 → 答（错位）」。收紧到 0.2s（典型 NTP 时钟漂移 < 100ms 的 2x 守护带）即可保留漂移修正能力，又排除秒级 follow-up 误吞。
+  2. **`longestCommonSubsequenceRatio` 分母语义自洽**：旧实现 reduce() 把超长串截到首尾各 1000（≤2000 字符），但 ratio 分母仍取截断前的 `Math.min(trimA.length, trimB.length)`；当较短串 > ~3077 字符时 lcsLen ≤ 2000 / 分母 > 3077，ratio 上界 < 0.65，第 6 层兜底对长答复永远不触发。改为 `Math.min(sA.length, sB.length)`（与实际参与 LCS 计算的长度一致）保持语义自洽。
+  3. **回归测试覆盖**：新增 3 个用例（chat-display.test.ts × 2 覆盖窗口内漂移修正与窗口外 follow-up 真实时序保留；message.test.ts × 1 覆盖长内容 LCS 兜底仍能 ≥ 0.65）。


### PR DESCRIPTION
## Summary

ISSUE-070：用户截图反馈的 4 项聊天 UI 缺陷的根因层修复。

- **等待占位（修复 1）**：`MessageBubble` 解耦 `isStreaming` 与 `hasContent`；`AssistantReplyBubble` 在 segments 全空 + streaming 时渲染三点 `animate-bounce` 占位（`data-testid="agent-waiting-placeholder"`）。
- **双内容根因（修复 2）**：
  - `chat-display.ts::isStreamingDuplicateOfLater` 阈值放宽至 multiset ≥0.7 + 长度比 ≥1.10，新增第 6 层 LCS 兜底（≥0.65，O(m·n) DP，长内容首尾截断防退化）；
  - `conversation-tree.ts::findMatchingTextNodeId` 在 closed 节点时放宽匹配为「严格相等 ∨ 严格前缀 ∨ multiset 覆盖 ≥0.75」。
- **推理内容（修复 3）**：
  - `ReasoningStepData` / `ReplyReasoningDisplaySegment` 增加 `content?` / `result?` 字段；
  - `ReasoningStep` 展开态渲染 content（`whitespace-pre-wrap`）+ result（`pre` 限高滚动）；
  - `conversation-tree.ts` 处理 `ne.a2ui.thought` CUSTOM 事件：通过 `findLatestReasoningNode` 把 thought.text 累积写入对应 reasoning 节点 `payload.content`；
  - `mergeSteps` 在 started→finished 时合并两侧 content。
- **排序乱序（修复 4）**：
  - `message-ledger.ts::compareLedgerEntriesByTime` 同时间戳新增 role 优先级（user < system < developer < assistant < tool）；
  - `conversation-tree.ts` children 排序同步加入 role 维度；
  - `chat-display.ts` blocks 排序在 1s 时钟漂移容忍窗口内让 user message 优先于 assistant-reply / tool-group。

新增工具函数：`utils/message.ts::longestCommonSubsequenceRatio`（可复用至 KG SSE / Tool Progress 等同源去重场景）。

## Test plan

- [x] 12 个新增单测（MessageBubble 3 + ReasoningPanel 3 + ledger 1 + LCS 5）全部通过
- [x] 全套 580 个单测通过，无回归
- [x] 浏览器实机验证：刷新后 user→assistant 顺序保持正确（验证修复 4）
- [x] 浏览器实机验证：推理面板展开后能看到具体推理 content（验证修复 3）
- [x] 浏览器实机验证：单一 assistant 气泡，无重复段落（验证修复 2）
- [x] 单测验证 streaming=true && content="" 时渲染三点脉冲占位（验证修复 1）
- [x] ESLint 通过

## 关联

- `docs/issue.md` ISSUE-070 详细记录根因 / 处理方式 / 后续防范

🤖 Generated with [Claude Code](https://claude.com/claude-code)