### PR TITLE
fix(home-chat+interface-api): ISSUE-066/071 根因层合并 + ISSUE-072/073/074 文档化

### DIFF
--- a/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
+++ b/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
@@ -70,12 +70,28 @@ export function AssistantReplyBubble({
 
   // ISSUE-070：检测「等待首个 token」的场景：所有 segments 都没有可见内容时，
   // 渲染三点脉冲动画作为占位，避免 UI 空白。
-  // 「无可见内容」=（无 text segment 或所有 text segment content 为空）且无
-  // tool-group / reasoning（reasoning 自带渲染，有 reasoning 已有反馈）。
+  // ISSUE-071：原实现把 `reasoning` 视为「立即可见」——但 `ne.a2ui.reasoning`
+  // started 事件在流式开始的 100ms 内即下发空 reasoning step（仅 stepId/title），
+  // 此时 reasoning content 还未累积，整个回复气泡仍是空白；占位永远不会渲染。
+  // 重新定义「可见」：
+  // - text：trim 后有内容；
+  // - tool-group：tools 数组非空（tool_call_start 已建立条目）；
+  // - reasoning：phase=finished 或 content/result 已有累积；started 仅有标题不算可见；
+  // - error：任何错误段。
   const hasVisibleSegment = block.segments.some((segment) => {
     if (segment.kind === "text") return segment.content.trim().length > 0;
-    if (segment.kind === "tool-group") return true;
-    if (segment.kind === "reasoning") return true;
+    if (segment.kind === "tool-group") return segment.tools.length > 0;
+    if (segment.kind === "reasoning") {
+      if (segment.phase === "finished") return true;
+      const contentText = (segment.content ?? "").trim();
+      // segment.result 类型为 unknown（来自后端任意 payload）；这里仅判断
+      // 是否有「实际可见反馈」：字符串非空、非 null/undefined 的对象都算可见。
+      const hasResult =
+        segment.result !== null &&
+        segment.result !== undefined &&
+        (typeof segment.result !== "string" || segment.result.trim().length > 0);
+      return contentText.length > 0 || hasResult;
+    }
     if (segment.kind === "error") return true;
     return false;
   });

--- a/apps/negentropy-ui/tests/unit/utils/message.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/message.test.ts
@@ -10,6 +10,7 @@ import {
   mapMessagesToChat,
   buildChatMessagesFromEventsWithFallback,
   longestCommonSubsequenceRatio,
+  accumulateTextContent,
 } from "@/utils/message";
 import type { ChatMessage } from "@/types/common";
 import {
@@ -303,5 +304,46 @@ describe("longestCommonSubsequenceRatio (ISSUE-070 LCS 兜底)", () => {
     const later = `${base}<additional tail content for length differentiation>`;
     const ratio = longestCommonSubsequenceRatio(earlier, later);
     expect(ratio).toBeGreaterThanOrEqual(0.65);
+  });
+});
+
+describe("accumulateTextContent (ISSUE-071 改写覆盖检测)", () => {
+  it("追加场景：incoming 是 existing 的延续 → 拼接", () => {
+    expect(accumulateTextContent("Hello ", "Hello world")).toBe("Hello world");
+    expect(accumulateTextContent("Hello", " world")).toBe("Hello world");
+  });
+
+  it("严格前缀场景：existing 是 incoming 前缀 → 用 incoming 替换", () => {
+    expect(accumulateTextContent("Hello", "Hello world!")).toBe("Hello world!");
+  });
+
+  it("空内容：existing 空 → incoming；incoming 空 → existing", () => {
+    expect(accumulateTextContent("", "abc")).toBe("abc");
+    expect(accumulateTextContent("abc", "")).toBe("abc");
+  });
+
+  it("ISSUE-071 根因：partial 残缺中文段 + final 完整改写版 → 仅保留 final（避免 UI 双内容）", () => {
+    // 来自 verify-log-2026-05-07.md 实测复现
+    const partial =
+      "负熵（negentropy）是指系统通过输入能量或入化信息来抵抗熵增，从而降低无序度增加序性信息量的量度。\n\n完成：了一句概念定义。可能的续：举（热学/信息/生物学数学述通。建议下一：一个——A 给通化子比，B) 提供信息论/数学定义与公式或 (C)集学术资料与引用我将此相流程。采选项";
+    const final =
+      "负熵（negentropy）是指系统通过输入能量或引入结构化信息来抵抗熵增，从而降低无序度、增加有序性或信息含量的量度。\n\n已完成：提供了一句概念性定义。\n可能的后续需求：需要举例（热力学/信息论/生物学）、数学表述或通俗解释。\n建议下一步：请选择一个方向——(A) 给出通俗化例子与比喻，(B) 提供信息论/数学定义与公式，或 (C) 搜集学术资料与引用；我将据此执行相应流程。是否采纳哪个选项？";
+    const merged = accumulateTextContent(partial, final);
+    expect(merged).toBe(final);
+    expect(merged).not.toContain("入化信息");
+    expect(merged).not.toContain("采选项");
+  });
+
+  it("不误删合法的「先短简介 + 后扩展」场景：当字符 multiset 覆盖不足 0.7 时拼接保留", () => {
+    // 短介绍 + 完全不相关的扩展段，multiset coverage 应该非常低
+    const intro = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const expansion = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+    const merged = accumulateTextContent(intro, expansion);
+    expect(merged).toBe(`${intro}${expansion}`);
+  });
+
+  it("短文本（< 50 字符）跳过改写检测，走原拼接逻辑", () => {
+    // 改写检测最小长度 50，短文本不进入改写覆盖路径
+    expect(accumulateTextContent("hi", "好")).toBe("hi好");
   });
 });

--- a/apps/negentropy-ui/utils/message.ts
+++ b/apps/negentropy-ui/utils/message.ts
@@ -62,6 +62,45 @@ function findOverlapSuffixPrefix(existing: string, incoming: string): number {
   return 0;
 }
 
+/**
+ * ISSUE-071 根因层补丁：检测 LLM 流式「改写覆盖」场景。
+ *
+ * 实测在中文流式答复中（见 ISSUE-071 验证日志），LLM 会先吐出残缺
+ * 中间态（如「负熵...或入化信息...采选项」），再以一段语义等同但表面
+ * 重排的 final 完整版（「负熵...或引入结构化信息...是否采纳哪个选项？」）
+ * 重发。两者：
+ *
+ * - 互不为前缀（首句中段开始分歧）；
+ * - 末尾/开头无显著 suffix-prefix overlap；
+ *
+ * `findOverlapSuffixPrefix` 因此返回 0，原 `accumulateTextContent` 走到
+ * 兜底分支 `${existing}${incoming}` 直接拼接，UI 渲染就出现 partial+final
+ * 两段并排的可见双内容（chat-display Layer 5/6 仅在多 text segment 之间
+ * 去重，单 segment 内的内容拼接逃逸）。
+ *
+ * 这里加一层「同源改写检测」：当 incoming 长度比 existing 略长（≥ 1.05x），
+ * 且字符 multiset 高度互含（覆盖 ≥ 0.7）+ LCS 比例 ≥ 0.6（同时具备字符与
+ * 顺序相似性），视为 LLM 用 final 改写版重发，丢弃 existing partial 残段
+ * 仅保留 incoming。阈值与 chat-display 第 5/6 层兜底一致，不会误删合法
+ * 「先短后长」的追加场景（追加场景已被前面的 prefix 分支命中）。
+ */
+const REWRITE_DETECTION_MIN_LENGTH = 50;
+const REWRITE_DETECTION_LENGTH_RATIO = 1.05;
+const REWRITE_DETECTION_MULTISET_COVERAGE = 0.7;
+const REWRITE_DETECTION_LCS_RATIO = 0.6;
+
+function isRewriteCoverOfExisting(existing: string, incoming: string): boolean {
+  if (existing.length < REWRITE_DETECTION_MIN_LENGTH) return false;
+  if (incoming.length < existing.length * REWRITE_DETECTION_LENGTH_RATIO) return false;
+  if (multisetCoverage(existing, incoming) < REWRITE_DETECTION_MULTISET_COVERAGE) {
+    return false;
+  }
+  if (longestCommonSubsequenceRatio(existing, incoming) < REWRITE_DETECTION_LCS_RATIO) {
+    return false;
+  }
+  return true;
+}
+
 export function accumulateTextContent(existing: string, incoming: string): string {
   if (!incoming) {
     return existing;
@@ -82,6 +121,10 @@ export function accumulateTextContent(existing: string, incoming: string): strin
   const overlap = findOverlapSuffixPrefix(existing, incoming);
   if (overlap > 0) {
     return `${existing}${incoming.slice(overlap)}`;
+  }
+  // ISSUE-071：LLM 改写覆盖场景，丢弃残缺 existing 用 incoming 替换。
+  if (isRewriteCoverOfExisting(existing, incoming)) {
+    return incoming;
   }
   return `${existing}${incoming}`;
 }

--- a/apps/negentropy/src/negentropy/interface/models_api.py
+++ b/apps/negentropy/src/negentropy/interface/models_api.py
@@ -72,6 +72,26 @@ def _model_config_to_dict(mc) -> dict[str, Any]:
     }
 
 
+def _model_config_to_public_dict(mc) -> dict[str, Any]:
+    """ISSUE-066 / ISSUE-071：面向普通用户的精简版 model_config 字典。
+
+    剔除 ``config`` 字段（供应商特定参数，如 temperature / thinking_mode 等
+    管理员视角的可调参数）与时间戳，仅返回 Home 页 LLM 下拉渲染所需的
+    最小元数据。**永远不暴露 API key / 凭据 / endpoint / org id 等敏感信息**
+    （这些字段本身存于独立的 ``VendorConfig`` 表，与 ``model_configs`` 不同
+    出处；此函数留作公开数据的稳定边界，避免后续新增字段意外泄漏）。
+    """
+    return {
+        "id": str(mc.id),
+        "model_type": mc.model_type.value if hasattr(mc.model_type, "value") else str(mc.model_type),
+        "display_name": mc.display_name,
+        "vendor": mc.vendor,
+        "model_name": mc.model_name,
+        "is_default": mc.is_default,
+        "enabled": mc.enabled,
+    }
+
+
 def _validate_model_type(value: str):
     from negentropy.models.model_config import ModelType
 
@@ -256,8 +276,24 @@ async def list_model_configs(
     enabled: bool | None = Query(default=None),
     current_user: AuthUser = Depends(get_current_user),
 ) -> dict[str, Any]:
-    """列出 model_configs 表条目。"""
-    current_user = await _require_admin(current_user)
+    """列出 model_configs 表条目。
+
+    ISSUE-066 / ISSUE-071：``enabled=True`` 是普通用户为了在 Home 页 LLM
+    下拉中渲染「自己可用的模型列表」必走的查询路径。原实现一律 403 admin
+    role required，导致 UI 浏览器层留下 console error（``Failed to load
+    resource: 403`` 无法在 JS 静默），且让 dev mode build 出现两次原生错误
+    告警。
+
+    放宽策略：
+    - ``enabled=True`` 的只读列表对登录用户开放（**仅返回 display_name /
+      model_name / vendor / is_default 等 model 元数据，不包含任何 vendor
+      api_key / secret**）；
+    - 其他过滤组合（含 ``enabled=False`` / 不带 ``enabled`` 参数）保留 admin
+      限制（管理员能看到禁用配置和未激活的模型，普通用户不应介入）。
+    """
+    is_user_facing_listing = enabled is True
+    if not is_user_facing_listing:
+        current_user = await _require_admin(current_user)
 
     from negentropy.models.model_config import ModelConfig, ModelType
 
@@ -284,7 +320,8 @@ async def list_model_configs(
             detail=_sanitize_error(f"Failed to list model_configs: {exc}"),
         ) from exc
 
-    items = [_model_config_to_dict(mc) for mc in rows]
+    serializer = _model_config_to_dict if not is_user_facing_listing else _model_config_to_public_dict
+    items = [serializer(mc) for mc in rows]
     _ = ModelType
     return {"items": items, "count": len(items)}
 

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1509,3 +1509,64 @@
   1. **`chat-display` 时钟漂移窗口 1s → 0.2s**：原 1s 容忍窗口配合双向 user 优先，会把「user 提问 → assistant 回复中（≤1s 内）→ user 紧追问」的真实时序误判为漂移，把 assistant 排到 follow-up 之后，错位为「问 → 紧追问 → 答（错位）」。收紧到 0.2s（典型 NTP 时钟漂移 < 100ms 的 2x 守护带）即可保留漂移修正能力，又排除秒级 follow-up 误吞。
   2. **`longestCommonSubsequenceRatio` 分母语义自洽**：旧实现 reduce() 把超长串截到首尾各 1000（≤2000 字符），但 ratio 分母仍取截断前的 `Math.min(trimA.length, trimB.length)`；当较短串 > ~3077 字符时 lcsLen ≤ 2000 / 分母 > 3077，ratio 上界 < 0.65，第 6 层兜底对长答复永远不触发。改为 `Math.min(sA.length, sB.length)`（与实际参与 LCS 计算的长度一致）保持语义自洽。
   3. **回归测试覆盖**：新增 3 个用例（chat-display.test.ts × 2 覆盖窗口内漂移修正与窗口外 follow-up 真实时序保留；message.test.ts × 1 覆盖长内容 LCS 兜底仍能 ≥ 0.65）。
+
+---
+
+## ISSUE-071 LLM 改写覆盖导致流式 partial+final 双内容（中文场景；2026-05-07）
+
+- **表因**：用户在新会话发送「请用一句话回答：什么是负熵？」后，等待流式结束，assistant 气泡内**同时**渲染两段语义等同但表面不同的中文：
+  1. partial 残缺中间态：「负熵...通过输入能量或入化信息...完成：了一句概念定义...采选项」（缺字、句法不通）；
+  2. final 完整改写版：「负熵...通过输入能量或引入结构化信息...已完成：提供了一句概念性定义...是否采纳哪个选项？」。
+  双段直接拼接展示，视觉上 ≈ 双气泡。
+- **根因**：与 ISSUE-058/060/065/070 同源但层次不同——chat-display 兜底层（Layer 5/6）只在「多个 text segment 间」做去重；本场景下 LLM 把 partial 与 final 都写入**同一**`text segment`（流式 delta），由 [`accumulateTextContent`](../apps/negentropy-ui/utils/message.ts) 在节点累加。`accumulateTextContent` 旧实现仅识别：① existing.endsWith(incoming) ② incoming.startsWith(existing) ③ suffix-prefix overlap；都不命中时直接 `${existing}${incoming}` 强行拼接。中文流式改写的 partial 与 final 互不为前缀、首尾无 overlap，遂逃逸所有合并分支，UI 渲染就出现双内容。
+- **处理方式**：
+  1. **根因层**：[`accumulateTextContent`](../apps/negentropy-ui/utils/message.ts) 增加第 4 层「LLM 改写覆盖」识别。新私有函数 `isRewriteCoverOfExisting(existing, incoming)`：min length 50 + length ratio 1.05 + multiset coverage 0.7 + LCS ratio 0.6（与 chat-display 兜底层阈值对齐）。命中时丢弃 existing 仅保留 incoming，杜绝同 segment 内的双内容拼接。
+  2. **测试守卫**：`tests/unit/utils/message.test.ts` 新增 5 个 vitest 用例，包含真实复现的中文双段、合法追加场景、空内容、短文本绕过等正反用例，全部通过；全套 594 单测无回归。
+  3. **联动 ISSUE-066 修复**：本次浏览器验证暴露的 `/api/interface/models/configs?enabled=true` 普通用户 403 长期残留，UI 层「静默 return []」无法抑制浏览器 console 原生错误。后端 `apps/negentropy/src/negentropy/interface/models_api.py::list_model_configs` 改为：`enabled=True` 路径放宽给登录用户（用 `_model_config_to_public_dict` 剔除 config JSONB，仅返回 metadata，零敏感字段泄漏）；其他过滤组合保持 admin 限制。
+- **后续防范**：
+  1. **同源同节点的双内容不能依赖 chat-display segment 间去重**——`accumulateTextContent` 必须自身具备同源识别能力，否则 UI 兜底永远收不到机会；
+  2. **改写覆盖的阈值与 chat-display Layer 5/6 对齐**，避免两侧阈值漂移导致「ledger 合并 ≠ UI 去重」的不一致；
+  3. **接口权限粒度**：`enabled=True` 这类 user-facing readonly listing 不应一律 admin gate；当用户层 fetch 必走时，浏览器 console error 无法静默，是产品级回归；
+  4. **公开数据序列化用独立函数**（`_model_config_to_public_dict`）：作为公开数据的稳定边界，避免后续新增字段时意外泄漏。
+- **同类问题影响**：所有可能出现「LLM 自我修订并重发同 chunk」的中文流式场景（Memory 提取、Knowledge 摘要、Tool Progress 长 result 改写）；所有 admin-gated readonly 列表接口都应审视是否需要拆出 user-facing 子集。
+
+---
+
+## ISSUE-072 Agent 等待占位仅在「reasoning 已挂载」时不再误吞，但流式启动到首段之间仍空白（2026-05-07）
+
+- **表因**：发送消息后，user bubble 立即出现，但 assistant 侧的等待占位（三点脉冲）**全程不渲染**——即使后端 `RUN_STARTED` 已发出（左下 STATE = STREAMING），主区在 0~3s 内仍完全空白，直到首个 `TEXT_MESSAGE_CONTENT` 或 `ne.a2ui.reasoning` 抵达才开始渲染气泡，破坏「点 Send 即有反馈」的核心 UX。
+- **根因**：分两层。
+  1. **第一层（已修复）**：[`AssistantReplyBubble.tsx`](../apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx) 旧 `hasVisibleSegment` 把 `kind=reasoning` 一律视为可见。但 `ne.a2ui.reasoning` `phase=started` 在 100ms 内即下发只含 `stepId/title` 的空 reasoning step，立即把 placeholder 条件 false 化，导致占位永远不会显式渲染。本次将判据收紧为「`finished` 或 `content/result` 已累积」+ `tool-group` 增加 `tools.length > 0` 守卫。
+  2. **第二层（遗留）**：[`chat-display.ts::walkTurnNode`](../apps/negentropy-ui/utils/chat-display.ts) 第 825-827 行：`if (!replyBuilder || replyBuilder.segments.length === 0) { replyBuilder = null; return; }` —— 当 turn 已开启但还没收到任何 assistant 子节点时，**根本不会推入 `assistant-reply` block**，导致 `AssistantReplyBubble` 容器都不存在，第一层修复仅覆盖「容器已存在但被 reasoning 假阳性吞占位」的子集。
+- **处理方式**：
+  1. 第一层：本 PR 已落地（typecheck + lint + 594 单测通过 + 浏览器实测：reasoning started 不再吞占位）；
+  2. 第二层：留待后续 PR 处理——需要在 `walkTurnNode` 检测 `turn.streaming === true && children.empty` 时，合成一个仅含 placeholder kind 的 segment 推入 reply block（或在外层 `chat-display` 入口为「streaming turn without children」单独 push placeholder block）。涉及与 conversation-tree turn lifecycle、ledger merge 的对齐，需要独立设计一轮。
+- **后续防范**：
+  1. **空状态可见性**断言不能只覆盖「容器存在」分支——需要从 turn 启动开始全程兜底；
+  2. **`data-testid="agent-waiting-placeholder"` 的 e2e 守卫**应包含「Send 后 100ms ~ 1s 窗口必有占位」的最小存在断言，避免后续 reasoning/tool-group 改动再次回归。
+- **同类问题影响**：所有「streaming = true」的 UI 路径中，「turn 启动到首子节点之间的全空区间」都需类似处理（KG SSE 等待首条进度、Tool Progress 等待 args event 等）。
+
+---
+
+## ISSUE-073 Sidebar 会话切换在生产 build 下 URL 不更新（dev 模式正常）（2026-05-07）
+
+- **表因**：`pnpm -C apps/negentropy-ui build && node scripts/start-production.mjs` 启动的生产模式下，点击 sidebar 中其他会话项，URL 与 main 区都不切换；点 + New 创建新会话后 sidebar 显示新项但 URL 仍指向旧 session。dev 模式（`pnpm dev`）下完全正常。
+- **根因**：尚未确证。可疑点：
+  1. `app/page.tsx::setSessionId` `useCallback([pathname, router, queryString])`，生产 build 下 React 优化路径与 dev 不同，可能让 setter 走向 stale closure；
+  2. `agent` `useMemo([sessionId, user])` 在 sessionId 改变时新建 NdjsonHttpAgent，与 router.replace 同帧 race；
+  3. Next.js 16 turbopack vs webpack 在 prod build 下对 `useSearchParams` Suspense bailout 的处理可能与 dev 有差异。
+- **处理方式**：本 PR 仅记录复现路径，未根因修复。
+- **同类问题影响**：所有依赖 `useSearchParams` 派生 state + `router.replace` 同步的页面（Memory timeline filter、Knowledge corpus filter 等若启用）。
+- **建议下一步**：用 dev mode + `NODE_ENV=production` 的混合 build 复现，必要时把 `setSessionId` 重构为 `startTransition` 包裹，或抽出 `useUrlState` 自定义 hook 集中处理。
+
+---
+
+## ISSUE-074 ConfirmDialog 中英文混用 + MCP 模块标题/按钮重复（2026-05-07）
+
+- **表因**：`/interface/mcp` 删除 server 弹出的 ConfirmDialog 标题为「Delete MCP Server」、按钮为「Delete」（标题与按钮重复，违反 ISSUE-069 规范），全部英文；`/knowledge/catalog` 删除节点弹窗标题中文、按钮中文，但 Cancel 仍英文；`/knowledge/wiki` 取消发布标题/确认按钮中文但 Cancel 英文。
+- **根因**：ISSUE-062 升格 ConfirmDialog 时未为所有调用方建立文案规范。MCP 页面调用方未传 destructive title/confirmLabel 改写；ConfirmDialog 默认 cancelLabel "Cancel" 在中文场景下未本地化。
+- **处理方式**：本 PR 仅记录证据。后续修复方向：
+  1. ConfirmDialog 默认 `cancelLabel` 改为「取消」（中文站默认中文，多语言由 i18n 驱动）；
+  2. MCP 删除调用方传 `title="删除 MCP Server"`、`confirmLabel="删除"`；
+  3. 增 vitest 守卫：`title !== confirmLabel` + `cancelLabel.length > 0`。
+- **同类问题影响**：所有 ConfirmDialog 调用方都需复审文案；建议增加 ESLint 自定义规则在调用 `useConfirmDialog()` 时强制 destructive 时 `title!==confirmLabel`。


### PR DESCRIPTION
## 背景

基于 \`mcp__chrome_devtools__*\` 接入用户主 Chrome（cm.huang@aftership.com 真实登录态）系统化遍历 \`docs/issue.md\` 70 条 ISSUE 后，发现 5 项「声明已修复但实测仍复发或残留」的问题：

1. **ISSUE-066** — \`/api/interface/models/configs?enabled=true\` 普通用户 403，浏览器 console 长期 2 次原生错误（UI 层 silent return [] 无法抑制）
2. **ISSUE-071（新）** — 中文流式答复中 LLM 同 text segment 内 partial 残缺中间态 + final 完整改写版双现，chat-display Layer 5/6 兜底因「同 segment 内」而完全逃逸
3. **ISSUE-072（新）** — Agent 等待占位（三点脉冲）实测全程不渲染，分两层根因
4. **ISSUE-073（新）** — 生产 build（\`pnpm build && start-production.mjs\`）下 sidebar 点击切换会话 URL 不更新（dev 模式正常）
5. **ISSUE-074（新）** — ConfirmDialog 中英文混用 + MCP 模块标题/按钮重复

## 本 PR 修复范围

### A. ISSUE-071 根因层合并（apps/negentropy-ui/utils/message.ts）

\`accumulateTextContent\` 增加第 4 层「LLM 改写覆盖」识别：

- \`isRewriteCoverOfExisting\`：min length 50 + length ratio 1.05 + multiset coverage 0.7 + LCS ratio 0.6
- 命中时丢弃 existing partial 仅保留 incoming final
- 阈值与 \`chat-display\` Layer 5/6 对齐，两侧不漂移

### B. ISSUE-072 第一层修复（apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx）

\`hasVisibleSegment\` 收紧：

- \`reasoning\` segment：phase=finished 或 content/result 已累积才算可见（避免 phase=started 仅含 stepId/title 即假阳性吞占位）
- \`tool-group\`：增加 \`tools.length > 0\` 守卫
- 第二层（\`chat-display::walkTurnNode\` 在 turn 启动到首子节点之间不创建 reply block）已记录 ISSUE-072，待后续 PR

### C. ISSUE-066 后端权限放宽（apps/negentropy/src/negentropy/interface/models_api.py）

\`list_model_configs\` 重构：

- \`enabled=True\` 路径对登录用户开放（user-facing readonly listing）
- 其他过滤组合（含 \`enabled=False\` / 不带 \`enabled\`）保持 admin 限制
- 新增 \`_model_config_to_public_dict\` 剔除 config JSONB / 时间戳，作为公开数据的稳定边界，零敏感字段泄漏

### D. docs/issue.md 文档化

新增 4 条 ISSUE-071/072/073/074，记录根因、复现路径、影响域、后续防范，便于跨上下文复用。

## 回归证据

- **vitest 单测**：\`tests/unit/utils/message.test.ts\` 新增 5 个 \`accumulateTextContent (ISSUE-071 改写覆盖检测)\` 用例（包含真实复现的中文双段、合法追加、空内容、短文本绕过等正反用例），全套 594 单测通过
- **typecheck**：\`pnpm typecheck\` 0 errors
- **lint**：\`pnpm lint --max-warnings=0\` 0 errors / 0 warnings
- **浏览器实测**（dev 模式 + 真实 cm.huang@aftership.com 登录态）：
  - \`/api/interface/models/configs?model_type=llm&enabled=true\` 由 403 → 200 ✅
  - 刷新后会话历史 partial 段消失（根因层 ledger merge 早有保障，本 PR 进一步杜绝同节点拼接）
  - reasoning started 不再瞬间吞掉 placeholder 渲染条件
- **验证日志**：\`.context/verify-log-2026-05-07.md\`（gitignored，不入库）保留所有 A/B/C/D/E 用例的期望/实际/截图路径

## 影响范围

- **UI 流式答复**：所有可能 LLM 自我修订并重发同 chunk 的中文场景（Memory 提取、Knowledge 摘要、Tool Progress 长 result 改写）；占位逻辑修复影响 Home Chat 主区
- **后端权限**：仅放宽 \`list_model_configs?enabled=True\` 一条 readonly 路径，其他端点（\`POST/PUT/DELETE /configs\`、\`/vendor-configs/*\`）权限不变
- **docs/issue.md**：新增 4 条记录，无删除

## 回滚方案

PR 合入后保留 merge commit，单点回滚：

\`\`\`bash
git revert -m 1 <merge-sha>
\`\`\`

每个修复独立 commit（656b61e7 + 372a4ae6），亦可分别 \`git revert\` 单独撤销 UI 或后端改动。

## 待跟进

- ISSUE-072 第二层（\`chat-display::walkTurnNode\` 在 turn streaming 但无 children 时合成 placeholder block）
- ISSUE-073（生产 build sidebar URL 不同步）需独立设计 \`useUrlState\` hook + \`startTransition\` 包裹
- ISSUE-074 ConfirmDialog 文案统一中文化 + ESLint 守卫规则