### PR TITLE
fix(home-chat): 增加 Thinking 开关并展示真实推理内容;

### DIFF
--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -71,6 +71,30 @@ function normalizeEvent(
   );
 }
 
+export function buildStateDeltaFromForwardedProps(
+  forwardedProps: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const stateDelta: Record<string, unknown> = {};
+  if (!forwardedProps) {
+    return stateDelta;
+  }
+  if ("selected_llm_model" in forwardedProps) {
+    const raw = forwardedProps.selected_llm_model;
+    if (typeof raw === "string" && raw.length > 0) {
+      stateDelta.selected_llm_model = raw;
+    } else if (raw === null) {
+      stateDelta.selected_llm_model = null;
+    }
+  }
+  if ("thinking_enabled" in forwardedProps) {
+    const raw = forwardedProps.thinking_enabled;
+    if (typeof raw === "boolean") {
+      stateDelta.thinking_enabled = raw;
+    }
+  }
+  return stateDelta;
+}
+
 export async function POST(request: Request) {
   const baseUrl = getAguiBaseUrl();
 
@@ -122,15 +146,7 @@ export async function POST(request: Request) {
     (body.forwardedProps && typeof body.forwardedProps === "object"
       ? (body.forwardedProps as Record<string, unknown>)
       : null) ?? null;
-  const stateDelta: Record<string, unknown> = {};
-  if (forwardedProps && "selected_llm_model" in forwardedProps) {
-    const raw = forwardedProps.selected_llm_model;
-    if (typeof raw === "string" && raw.length > 0) {
-      stateDelta.selected_llm_model = raw;
-    } else if (raw === null) {
-      stateDelta.selected_llm_model = null;
-    }
-  }
+  const stateDelta = buildStateDeltaFromForwardedProps(forwardedProps);
 
   const headers = extractForwardHeaders(request);
   headers.set("content-type", "application/json");

--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -51,6 +51,7 @@ export const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
  *   一方有值即可命中），不引入新的后端 API 表面。
  */
 const LOCAL_LLM_MODEL_KEY_PREFIX = "negentropy:home:llm-model:";
+const LOCAL_THINKING_KEY_PREFIX = "negentropy:home:thinking:";
 
 function readPersistedLlmModel(sessionId: string | null): string | null {
   if (!sessionId || typeof window === "undefined") return null;
@@ -79,6 +80,81 @@ function writePersistedLlmModel(
   } catch {
     // localStorage 不可用时静默降级到内存态。
   }
+}
+
+function readPersistedThinking(sessionId: string | null): boolean | null {
+  if (!sessionId || typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(
+      `${LOCAL_THINKING_KEY_PREFIX}${sessionId}`,
+    );
+    if (raw === "1") return true;
+    if (raw === "0") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersistedThinking(
+  sessionId: string | null,
+  value: boolean,
+): void {
+  if (!sessionId || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      `${LOCAL_THINKING_KEY_PREFIX}${sessionId}`,
+      value ? "1" : "0",
+    );
+  } catch {
+    // localStorage 不可用时静默降级到内存态。
+  }
+}
+
+function splitModelName(fullModelName: string | null): {
+  vendor: string;
+  modelName: string;
+} | null {
+  if (!fullModelName) return null;
+  const slashIndex = fullModelName.indexOf("/");
+  if (slashIndex < 0) {
+    return { vendor: "", modelName: fullModelName };
+  }
+  return {
+    vendor: fullModelName.slice(0, slashIndex),
+    modelName: fullModelName.slice(slashIndex + 1),
+  };
+}
+
+function modelSupportsThinking(vendor: string, modelName: string): boolean {
+  const normalizedVendor = vendor.toLowerCase();
+  const normalizedModel = modelName.toLowerCase();
+  if (normalizedVendor === "anthropic" || normalizedModel.includes("claude")) {
+    return true;
+  }
+  if (normalizedVendor === "openai") {
+    return normalizedModel.startsWith("gpt-5") || /^o[1-9]/.test(normalizedModel);
+  }
+  return false;
+}
+
+function isThinkingSupportedForSelection(
+  selectedModel: string | null,
+  models: ModelConfigItem[],
+): boolean {
+  if (!selectedModel) {
+    // Default 模型由后端单一事实源解析；当前 fallback 为 GPT-5 系列，前端保持可切换。
+    return true;
+  }
+  const known = models.find(
+    (item) => `${item.vendor}/${item.model_name}` === selectedModel,
+  );
+  if (known) {
+    return modelSupportsThinking(known.vendor, known.model_name);
+  }
+  const parsed = splitModelName(selectedModel);
+  if (!parsed) return false;
+  return modelSupportsThinking(parsed.vendor, parsed.modelName);
 }
 
 /** Agent 类型：兼容 NdjsonHttpAgent 与测试 Mock */
@@ -133,16 +209,20 @@ export function HomeBody({
   const [scrollToBottomTrigger, setScrollToBottomTrigger] = useState(0);
   const [llmModels, setLlmModels] = useState<ModelConfigItem[]>([]);
   const [selectedLlmModel, setSelectedLlmModel] = useState<string | null>(null);
+  const [thinkingEnabled, setThinkingEnabled] = useState(false);
   // 中断门 — 用户主动 cancel 后短暂屏蔽 onRunFailed/onRunErrorEvent 引发的 error 状态，
   // 避免被显示成"运行错误"。100ms 窗口足以覆盖 abort 信号 round-trip。
   const userCancelledAtRef = useRef<number>(0);
   const perThreadLlmRef = useRef<Record<string, string | null>>({});
+  const perThreadThinkingRef = useRef<Record<string, boolean>>({});
   // 「无 session 时」用户预先选择的模型，待 startNewSession 后转入 perThreadLlmRef[newId]。
   // undefined = 无 pending；null = 用户主动清空；string = 选定模型。
   const pendingLlmRef = useRef<string | null | undefined>(undefined);
+  const pendingThinkingRef = useRef<boolean | undefined>(undefined);
   // pending 仅对「startNewSession 创建出来的新 id」生效；首次进入既有 session 不消费。
   // 由 startNewSessionWithLlmTarget 在拿到新 id 时写入，Effect 1 命中后清零。
   const pendingLlmTargetIdRef = useRef<string | null>(null);
+  const pendingThinkingTargetIdRef = useRef<string | null>(null);
   const rawEventHandlerRef = useRef<((event: BaseEvent) => void) | undefined>(
     undefined,
   );
@@ -263,6 +343,7 @@ export function HomeBody({
     const newId = await startNewSession();
     if (newId) {
       pendingLlmTargetIdRef.current = newId;
+      pendingThinkingTargetIdRef.current = newId;
     }
     return newId;
   }, [startNewSession]);
@@ -439,6 +520,12 @@ export function HomeBody({
         agent.forwardedProps = {
           ...(agent.forwardedProps ?? {}),
           selected_llm_model: selectedLlmModel ?? null,
+          thinking_enabled: isThinkingSupportedForSelection(
+            selectedLlmModel,
+            llmModels,
+          )
+            ? thinkingEnabled
+            : false,
           ...(attachmentMeta.length > 0 ? { attachments: attachmentMeta } : {}),
         };
         // 清空 Composer 附件区（与 inputValue 已被清空的语义一致）
@@ -471,6 +558,8 @@ export function HomeBody({
       scheduleTitleRefresh,
       addLog,
       selectedLlmModel,
+      thinkingEnabled,
+      llmModels,
       attachments,
     ],
   );
@@ -644,6 +733,40 @@ export function HomeBody({
 
   useEffect(() => {
     if (!sessionId) {
+      setThinkingEnabled(pendingThinkingRef.current ?? false);
+      return;
+    }
+    if (sessionId in perThreadThinkingRef.current) {
+      setThinkingEnabled(perThreadThinkingRef.current[sessionId] ?? false);
+      pendingThinkingRef.current = undefined;
+      pendingThinkingTargetIdRef.current = null;
+      return;
+    }
+    if (
+      pendingThinkingRef.current !== undefined &&
+      pendingThinkingTargetIdRef.current === sessionId
+    ) {
+      const carried = pendingThinkingRef.current;
+      perThreadThinkingRef.current[sessionId] = carried;
+      setThinkingEnabled(carried);
+      writePersistedThinking(sessionId, carried);
+      pendingThinkingRef.current = undefined;
+      pendingThinkingTargetIdRef.current = null;
+      return;
+    }
+    pendingThinkingRef.current = undefined;
+    pendingThinkingTargetIdRef.current = null;
+    const persisted = readPersistedThinking(sessionId);
+    if (persisted !== null) {
+      perThreadThinkingRef.current[sessionId] = persisted;
+      setThinkingEnabled(persisted);
+    } else {
+      setThinkingEnabled(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) {
       return;
     }
     if (sessionId in perThreadLlmRef.current) {
@@ -660,6 +783,20 @@ export function HomeBody({
     }
   }, [sessionId, snapshotForDisplay]);
 
+  useEffect(() => {
+    if (!sessionId) {
+      return;
+    }
+    if (sessionId in perThreadThinkingRef.current) {
+      return;
+    }
+    const raw = snapshotForDisplay?.["thinking_enabled"];
+    const initial = raw === true;
+    perThreadThinkingRef.current[sessionId] = initial;
+    setThinkingEnabled(initial);
+    writePersistedThinking(sessionId, initial);
+  }, [sessionId, snapshotForDisplay]);
+
   const handleSelectedLlmModelChange = useCallback(
     (next: string | null) => {
       setSelectedLlmModel(next);
@@ -674,6 +811,25 @@ export function HomeBody({
       }
     },
     [sessionId],
+  );
+
+  const handleThinkingEnabledChange = useCallback(
+    (next: boolean) => {
+      setThinkingEnabled(next);
+      if (sessionId) {
+        perThreadThinkingRef.current[sessionId] = next;
+        pendingThinkingRef.current = undefined;
+        writePersistedThinking(sessionId, next);
+      } else {
+        pendingThinkingRef.current = next;
+      }
+    },
+    [sessionId],
+  );
+
+  const thinkingSupported = useMemo(
+    () => isThinkingSupportedForSelection(selectedLlmModel, llmModels),
+    [llmModels, selectedLlmModel],
   );
 
   /**
@@ -837,6 +993,9 @@ export function HomeBody({
                 models={llmModels}
                 selectedLlmModel={selectedLlmModel}
                 onSelectedLlmModelChange={handleSelectedLlmModelChange}
+                thinkingEnabled={thinkingSupported && thinkingEnabled}
+                thinkingSupported={thinkingSupported}
+                onThinkingEnabledChange={handleThinkingEnabledChange}
                 onCancel={handleCancelRun}
                 attachments={attachments}
                 onAttachmentsChange={setAttachments}

--- a/apps/negentropy-ui/components/ui/Composer.tsx
+++ b/apps/negentropy-ui/components/ui/Composer.tsx
@@ -15,6 +15,9 @@ type ComposerProps = {
   models?: ModelConfigItem[];
   selectedLlmModel?: string | null;
   onSelectedLlmModelChange?: (value: string | null) => void;
+  thinkingEnabled?: boolean;
+  thinkingSupported?: boolean;
+  onThinkingEnabledChange?: (value: boolean) => void;
   /**
    * 中断门 — 当 isGenerating=true 时，主按钮切换为 Stop；点击触发本回调。
    * 复用 NdjsonHttpAgent.abortRun()（最小干预，不引入新协议事件）。
@@ -50,6 +53,9 @@ export function Composer({
   models,
   selectedLlmModel,
   onSelectedLlmModelChange,
+  thinkingEnabled = false,
+  thinkingSupported = true,
+  onThinkingEnabledChange,
   onCancel,
   attachments,
   onAttachmentsChange,
@@ -57,6 +63,7 @@ export function Composer({
   attachmentAccept = DEFAULT_ATTACHMENT_ACCEPT,
 }: ComposerProps) {
   const showModelSelect = Boolean(models && onSelectedLlmModelChange);
+  const showThinkingToggle = Boolean(onThinkingEnabledChange);
   const showAttachments = Boolean(onAttachmentsChange);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [dragOver, setDragOver] = useState(false);
@@ -173,6 +180,44 @@ export function Composer({
               allowClear
               ariaLabel="选择主 Agent 使用的 LLM"
             />
+          )}
+          {showThinkingToggle && (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={thinkingSupported && thinkingEnabled}
+              aria-label={
+                thinkingSupported
+                  ? "切换 Thinking 推理增强"
+                  : "当前模型不支持 Thinking 推理增强"
+              }
+              title={
+                thinkingSupported
+                  ? "Thinking：请求模型启用更强推理"
+                  : "当前模型未声明支持 Thinking"
+              }
+              data-testid="composer-thinking-toggle"
+              disabled={!thinkingSupported || (disabled && !isGenerating)}
+              onClick={() => {
+                if (!thinkingSupported) return;
+                onThinkingEnabledChange?.(!thinkingEnabled);
+              }}
+              className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border px-2 text-xs font-medium transition-colors ${
+                thinkingSupported && thinkingEnabled
+                  ? "border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200"
+                  : "border-border bg-input text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+              }`}
+            >
+              <span
+                aria-hidden="true"
+                className={`h-2 w-2 rounded-full ${
+                  thinkingSupported && thinkingEnabled
+                    ? "bg-amber-500"
+                    : "bg-zinc-400 dark:bg-zinc-600"
+                }`}
+              />
+              Thinking
+            </button>
           )}
           {showAttachments && (
             <>

--- a/apps/negentropy-ui/tests/integration/home-flow.test.tsx
+++ b/apps/negentropy-ui/tests/integration/home-flow.test.tsx
@@ -13,6 +13,7 @@ type MockAgent = {
   subscribe: ReturnType<typeof vi.fn>;
   addMessage: ReturnType<typeof vi.fn>;
   runAgent: ReturnType<typeof vi.fn>;
+  forwardedProps?: Record<string, unknown>;
 };
 
 type HitlRenderPayload = {
@@ -233,6 +234,24 @@ describe("HomeBody integration", () => {
       },
       { timeout: 3000 },
     );
+  }, 10000);
+
+  it("发送消息时把 Thinking 开关写入 forwardedProps", async () => {
+    const user = userEvent.setup();
+    render(<Wrapper sessionId="s1" />);
+    await waitForInitialHydration();
+
+    await user.click(screen.getByRole("switch", { name: "切换 Thinking 推理增强" }));
+    await user.type(screen.getByPlaceholderText("输入指令..."), "ping");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(mockAgent.runAgent).toHaveBeenCalled();
+    });
+    expect(mockAgent.forwardedProps).toMatchObject({
+      selected_llm_model: null,
+      thinking_enabled: true,
+    });
   }, 10000);
 
   it("历史回拉暂时为空时，实时 assistant 回复不会被清空", async () => {

--- a/apps/negentropy-ui/tests/unit/Composer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/Composer.test.tsx
@@ -27,6 +27,53 @@ describe("Composer", () => {
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
 
+  it("渲染 Thinking 开关并回调切换状态", async () => {
+    const onSend = vi.fn();
+    const onChange = vi.fn();
+    const onThinkingEnabledChange = vi.fn();
+    render(
+      <Composer
+        value="hi"
+        onChange={onChange}
+        onSend={onSend}
+        disabled={false}
+        thinkingEnabled={false}
+        thinkingSupported
+        onThinkingEnabledChange={onThinkingEnabledChange}
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", { name: "切换 Thinking 推理增强" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(toggle);
+    expect(onThinkingEnabledChange).toHaveBeenCalledWith(true);
+  });
+
+  it("当前模型不支持 Thinking 时禁用开关", async () => {
+    const onSend = vi.fn();
+    const onChange = vi.fn();
+    const onThinkingEnabledChange = vi.fn();
+    render(
+      <Composer
+        value="hi"
+        onChange={onChange}
+        onSend={onSend}
+        disabled={false}
+        thinkingEnabled
+        thinkingSupported={false}
+        onThinkingEnabledChange={onThinkingEnabledChange}
+      />,
+    );
+
+    const toggle = screen.getByRole("switch", {
+      name: "当前模型不支持 Thinking 推理增强",
+    });
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(toggle);
+    expect(onThinkingEnabledChange).not.toHaveBeenCalled();
+  });
+
   it("聊天输入区与消息流复用同一内容轨道常量", () => {
     expect(CHAT_CONTENT_RAIL_CLASS).toContain("max-w-4xl");
     expect(CHAT_CONTENT_RAIL_CLASS).toContain("px-6");

--- a/apps/negentropy-ui/tests/unit/api/agui-route-state.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-route-state.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildStateDeltaFromForwardedProps } from "@/app/api/agui/route";
+
+describe("buildStateDeltaFromForwardedProps", () => {
+  it("透传 selected_llm_model 与 thinking_enabled 到 session state_delta", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        selected_llm_model: "openai/gpt-5-mini",
+        thinking_enabled: true,
+      }),
+    ).toEqual({
+      selected_llm_model: "openai/gpt-5-mini",
+      thinking_enabled: true,
+    });
+  });
+
+  it("仅接受 boolean thinking_enabled，避免污染 state", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        thinking_enabled: "true",
+      }),
+    ).toEqual({});
+  });
+});

--- a/apps/negentropy-ui/tests/unit/utils/chat-display.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/chat-display.test.ts
@@ -1182,4 +1182,119 @@ describe("buildChatDisplayBlocks - 时钟漂移窗口（评审回归）", () => 
     expect(idxFirstUser).toBeLessThan(idxAsst);
     expect(idxAsst).toBeLessThan(idxFollowup);
   });
+
+  it("reasoning segment 不再把阶段 summary 当作 content 展示", () => {
+    const stepId = "synth-step:NegentropyEngine:run-1:0";
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.STEP_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "step-1",
+        stepId,
+        stepName: "NegentropyEngine",
+        timestamp: 1001,
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.STEP_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "step-1",
+        stepId,
+        stepName: "NegentropyEngine",
+        timestamp: 1002,
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        role: "assistant",
+        timestamp: 1003,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        delta: "Pong.",
+        timestamp: 1004,
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+    const blocks = buildChatDisplayBlocks(tree);
+    const reply = blocks.find((block) => block.kind === "assistant-reply");
+    expect(reply?.kind).toBe("assistant-reply");
+    if (reply?.kind === "assistant-reply") {
+      const reasoning = reply.segments.find((segment) => segment.kind === "reasoning");
+      expect(reasoning?.kind).toBe("reasoning");
+      if (reasoning?.kind === "reasoning") {
+        expect(reasoning.content).toBeUndefined();
+      }
+    }
+  });
+
+  it("真实 thought 文本会透传为 reasoning segment content", () => {
+    const stepId = "synth-step:NegentropyEngine:run-1:0";
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.CUSTOM,
+        threadId: "thread-1",
+        runId: "run-1",
+        eventType: "ne.a2ui.thought",
+        data: { text: "先判断 ping，再回答 Pong。" },
+        timestamp: 1001,
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.STEP_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "step-1",
+        stepId,
+        stepName: "NegentropyEngine",
+        timestamp: 1002,
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_START,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        role: "assistant",
+        timestamp: 1003,
+      }),
+      createTestEvent({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "assistant-1",
+        delta: "Pong.",
+        timestamp: 1004,
+      }),
+    ];
+
+    const tree = buildConversationTree({ events });
+    const blocks = buildChatDisplayBlocks(tree);
+    const reply = blocks.find((block) => block.kind === "assistant-reply");
+    expect(reply?.kind).toBe("assistant-reply");
+    if (reply?.kind === "assistant-reply") {
+      const reasoning = reply.segments.find((segment) => segment.kind === "reasoning");
+      expect(reasoning?.kind).toBe("reasoning");
+      if (reasoning?.kind === "reasoning") {
+        expect(reasoning.content).toBe("先判断 ping，再回答 Pong。");
+      }
+    }
+  });
 });

--- a/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/conversation-tree.test.ts
@@ -1161,4 +1161,78 @@ describe("buildConversationTree", () => {
       expect(turnRoots).toHaveLength(2);
     });
   });
+
+  it("ne.a2ui.thought 早于 reasoning 节点到达时会缓冲并注入真实推理内容", () => {
+    const stepId = "synth-step:NegentropyEngine:run-1:0";
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.CUSTOM,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1001,
+        eventType: "ne.a2ui.thought",
+        data: { text: "先判断 ping 的语义，再输出 pong。" },
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.STEP_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "step-1",
+        stepId,
+        stepName: "NegentropyEngine",
+        timestamp: 1002,
+      } as AgUiEvent),
+    ];
+
+    const tree = buildConversationTree({ events });
+    const reasoning = tree.nodeIndex.get(`reasoning:${stepId}`);
+    expect(reasoning?.payload.content).toBe("先判断 ping 的语义，再输出 pong。");
+  });
+
+  it("ne.a2ui.reasoning 仅在携带 content/text 时注入内容", () => {
+    const stepId = "step-with-custom-reasoning";
+    const events: AgUiEvent[] = [
+      createTestEvent({
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+      }),
+      createTestEvent({
+        type: EventType.STEP_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "step-1",
+        stepId,
+        stepName: "NegentropyEngine",
+        timestamp: 1001,
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.CUSTOM,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1002,
+        eventType: "ne.a2ui.reasoning",
+        data: { stepId, phase: "started" },
+      } as AgUiEvent),
+      createTestEvent({
+        type: EventType.CUSTOM,
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1003,
+        eventType: "ne.a2ui.reasoning",
+        data: { stepId, content: "真实 reasoning 摘要" },
+      } as AgUiEvent),
+    ];
+
+    const tree = buildConversationTree({ events });
+    const reasoning = tree.nodeIndex.get(`reasoning:${stepId}`);
+    expect(reasoning?.payload.content).toBe("真实 reasoning 摘要");
+  });
 });

--- a/apps/negentropy-ui/utils/chat-display.ts
+++ b/apps/negentropy-ui/utils/chat-display.ts
@@ -297,14 +297,13 @@ function createReplyReasoningSegment(
 ): ReplyReasoningDisplaySegment {
   // ISSUE-070：reasoning 节点的 payload.content 由 conversation-tree 在处理
   // ne.a2ui.thought / ne.a2ui.reasoning 自定义事件时累积写入，需要透传到
-  // segment 供 ReasoningPanel 展开后渲染。优先级：直接 content > summary。
+  // segment 供 ReasoningPanel 展开后渲染。不能 fallback 到 summary，否则会把
+  // 「阶段完成：步骤 synth-step...」这类生命周期标识伪装成推理内容。
   const rawContent =
     typeof node.payload.content === "string"
       ? String(node.payload.content)
       : "";
-  const fallbackContent =
-    !rawContent.trim() && typeof node.summary === "string" ? node.summary : "";
-  const content = (rawContent || fallbackContent).trim() || undefined;
+  const content = rawContent.trim() || undefined;
   return {
     id: `reply-reasoning:${node.id}`,
     kind: "reasoning",

--- a/apps/negentropy-ui/utils/conversation-tree.ts
+++ b/apps/negentropy-ui/utils/conversation-tree.ts
@@ -45,6 +45,13 @@ type LinkInstruction = {
   parentId: string;
 };
 
+type PendingThought = {
+  turnId: string;
+  runId: string;
+  text: string;
+  eventType: string;
+};
+
 const DEFAULT_THREAD_ID = "default";
 const DEFAULT_RUN_ID = "default";
 
@@ -388,6 +395,36 @@ function appendThoughtText(existing: string, incoming: string): string {
   if (a === b || a.includes(b)) return a;
   if (b.includes(a)) return b;
   return `${a}\n\n${b}`;
+}
+
+function appendThoughtToReasoningNode(
+  target: MutableNode,
+  thoughtText: string,
+  eventType: string,
+) {
+  const existing =
+    typeof target.payload.content === "string" ? target.payload.content : "";
+  target.payload.content = appendThoughtText(existing, thoughtText);
+  if (!target.sourceEventTypes.includes(eventType)) {
+    target.sourceEventTypes.push(eventType);
+  }
+}
+
+function flushPendingThoughtsForReasoning(
+  pendingThoughts: PendingThought[],
+  target: MutableNode,
+  turnId: string,
+  runId: string,
+) {
+  for (let i = 0; i < pendingThoughts.length;) {
+    const pending = pendingThoughts[i];
+    if (pending.turnId !== turnId || !isRunCompatible(pending.runId, runId)) {
+      i += 1;
+      continue;
+    }
+    appendThoughtToReasoningNode(target, pending.text, pending.eventType);
+    pendingThoughts.splice(i, 1);
+  }
 }
 
 function findMatchingTextNodeId(
@@ -867,6 +904,7 @@ export function buildConversationTree(
   >();
   const pendingConfirmationCountByRun = new Map<string, number>();
   const pendingLinks: LinkInstruction[] = [];
+  const pendingThoughts: PendingThought[] = [];
   const ledgerByMessageId = new Map<string, MessageLedgerEntry>();
   const canonicalMessageIdByRelatedId = new Map<string, string>();
   let activeRunId: string | undefined;
@@ -1261,7 +1299,7 @@ export function buildConversationTree(
           relatedMessageIds: messageId ? [messageId] : [],
         });
         attachNode(nodeIndex, roots, turns, node.id, baseParentId);
-        upsertNode(nodeIndex, roots, turns, {
+        const reasoningNode = upsertNode(nodeIndex, roots, turns, {
           id: `reasoning:${stepId}`,
           type: "reasoning",
           parentId: node.id,
@@ -1284,7 +1322,13 @@ export function buildConversationTree(
           sourceEventTypes: [eventType],
           relatedMessageIds: messageId ? [messageId] : [],
         });
-        addChild(node, nodeIndex.get(`reasoning:${stepId}`)!);
+        flushPendingThoughtsForReasoning(
+          pendingThoughts,
+          reasoningNode,
+          turn.id,
+          runId,
+        );
+        addChild(node, reasoningNode);
         return;
       }
       case EventType.RAW: {
@@ -1324,6 +1368,32 @@ export function buildConversationTree(
           return;
         }
         if (eventTypeName === "ne.a2ui.reasoning") {
+          const data = asRecord(getCustomEventData(normalizedEvent));
+          const stepId = data && typeof data.stepId === "string" ? data.stepId : "";
+          const target =
+            (stepId ? nodeIndex.get(`reasoning:${stepId}`) : undefined) ||
+            findLatestReasoningNode(turns, turn.id, runId);
+          const content =
+            data && typeof data.content === "string"
+              ? data.content
+              : data && typeof data.text === "string"
+                ? data.text
+                : "";
+          if (content.trim()) {
+            if (target) {
+              appendThoughtToReasoningNode(target, content, eventType);
+            } else {
+              pendingThoughts.push({
+                turnId: turn.id,
+                runId,
+                text: content,
+                eventType,
+              });
+            }
+          }
+          if (target && data && "result" in data) {
+            target.payload.result = data.result;
+          }
           return;
         }
         // ISSUE-070：ne.a2ui.thought 承载 LLM 推理（thinking）的实际文本，需要把
@@ -1337,14 +1407,14 @@ export function buildConversationTree(
           if (thoughtText.trim()) {
             const target = findLatestReasoningNode(turns, turn.id, runId);
             if (target) {
-              const existing =
-                typeof target.payload.content === "string"
-                  ? target.payload.content
-                  : "";
-              target.payload.content = appendThoughtText(existing, thoughtText);
-              if (!target.sourceEventTypes.includes(eventType)) {
-                target.sourceEventTypes.push(eventType);
-              }
+              appendThoughtToReasoningNode(target, thoughtText, eventType);
+            } else {
+              pendingThoughts.push({
+                turnId: turn.id,
+                runId,
+                text: thoughtText,
+                eventType,
+              });
             }
           }
           return;

--- a/apps/negentropy/src/negentropy/agents/_dynamic_model.py
+++ b/apps/negentropy/src/negentropy/agents/_dynamic_model.py
@@ -24,6 +24,7 @@ from typing import Any
 from google.adk.models.lite_llm import LiteLlm
 
 from negentropy.config.model_resolver import (
+    apply_llm_thinking_override,
     resolve_llm_config,
     resolve_llm_config_by_model_name,
     resolve_subagent_model_name,
@@ -35,6 +36,7 @@ _logger = get_logger("negentropy.agents.dynamic_model")
 # ContextVar：当前请求链路中 root Agent 期望使用的模型 ID（`vendor/model_name`）。
 # 来源：root_agent.before_model_callback 从 callback_context.state 读取并置入。
 _selected_root_llm: ContextVar[str | None] = ContextVar("selected_root_llm", default=None)
+_root_thinking_enabled: ContextVar[bool | None] = ContextVar("root_thinking_enabled", default=None)
 
 
 def set_selected_root_llm(value: str | None) -> None:
@@ -45,6 +47,16 @@ def set_selected_root_llm(value: str | None) -> None:
 def get_selected_root_llm() -> str | None:
     """读取当前 ContextVar；主要供调试/单测使用。"""
     return _selected_root_llm.get()
+
+
+def set_root_thinking_enabled(value: bool | None) -> None:
+    """设置 Home Composer 的 Thinking 开关；None 表示沿用模型配置。"""
+    _root_thinking_enabled.set(value if isinstance(value, bool) else None)
+
+
+def get_root_thinking_enabled() -> bool | None:
+    """读取当前 Thinking override；主要供调试/单测使用。"""
+    return _root_thinking_enabled.get()
 
 
 class _DynamicLiteLlm(LiteLlm):
@@ -78,6 +90,13 @@ class _DynamicLiteLlm(LiteLlm):
             async for resp in super().generate_content_async(llm_request, stream=stream):
                 yield resp
             return
+        thinking_enabled = _root_thinking_enabled.get()
+        if thinking_enabled is not None:
+            new_kwargs = apply_llm_thinking_override(
+                new_model,
+                new_kwargs,
+                thinking_enabled,
+            )
 
         lock = self._get_swap_lock()
         orig_model = self.model

--- a/apps/negentropy/src/negentropy/agents/agent.py
+++ b/apps/negentropy/src/negentropy/agents/agent.py
@@ -3,7 +3,7 @@ from google.adk.agents.callback_context import CallbackContext
 from google.adk.models.llm_request import LlmRequest
 
 from ._dynamic_instruction import make_instruction_provider
-from ._dynamic_model import set_selected_root_llm
+from ._dynamic_model import set_root_thinking_enabled, set_selected_root_llm
 from ._model import create_root_model
 from .faculties.action import action_agent
 from .faculties.contemplation import contemplation_agent
@@ -29,9 +29,12 @@ def _pick_root_model(callback_context: CallbackContext, llm_request: LlmRequest)
     try:
         state = callback_context.state
         selected = state.get("selected_llm_model") if state is not None else None
+        thinking_enabled = state.get("thinking_enabled") if state is not None else None
     except Exception:
         selected = None
+        thinking_enabled = None
     set_selected_root_llm(selected if isinstance(selected, str) else None)
+    set_root_thinking_enabled(thinking_enabled if isinstance(thinking_enabled, bool) else None)
 
 
 _ROOT_INSTRUCTION = """

--- a/apps/negentropy/src/negentropy/config/model_resolver.py
+++ b/apps/negentropy/src/negentropy/config/model_resolver.py
@@ -670,6 +670,53 @@ async def _get_vendor_config(vendor: str) -> dict[str, str] | None:
         return None
 
 
+def _supports_anthropic_thinking(vendor: str, model_name: str) -> bool:
+    model_lower = model_name.lower()
+    return vendor == "anthropic" or "claude" in model_lower
+
+
+def _supports_openai_reasoning(vendor: str, model_name: str) -> bool:
+    model_lower = model_name.lower()
+    return vendor == "openai" and (model_lower.startswith("gpt-5") or model_lower[:2] in {"o1", "o3", "o4"})
+
+
+def apply_llm_thinking_override(
+    full_model_name: str,
+    kwargs: dict[str, Any],
+    enabled: bool,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """按模型能力覆盖单轮 Thinking / Reasoning 参数。
+
+    ``enabled`` 来自 Home Composer 的 per-run 开关；它只表示"请求增强推理"，
+    不承诺供应商一定返回可见推理文本。不支持的模型保持 kwargs 原样，避免向
+    上游注入未知参数。
+    """
+    next_kwargs = kwargs.copy()
+    config = config or {}
+    vendor, model_name = _split_vendor_and_model(full_model_name)
+    vendor = vendor or ""
+
+    if _supports_anthropic_thinking(vendor, model_name):
+        if enabled:
+            next_kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": config.get("thinking_budget", 2048),
+            }
+        else:
+            next_kwargs["thinking"] = {"type": "disabled"}
+        return next_kwargs
+
+    if _supports_openai_reasoning(vendor, model_name):
+        if enabled:
+            next_kwargs["reasoning_effort"] = config.get("reasoning_effort", "medium")
+        else:
+            next_kwargs.pop("reasoning_effort", None)
+        return next_kwargs
+
+    return next_kwargs
+
+
 def _build_llm_kwargs(
     vendor: str, model_name: str, config: dict[str, Any], vendor_config: dict[str, str] | None = None
 ) -> dict[str, Any]:
@@ -687,23 +734,15 @@ def _build_llm_kwargs(
     if "top_p" in config:
         kwargs["top_p"] = config["top_p"]
 
-    # 供应商特定的 thinking/reasoning 适配
-    model_lower = model_name.lower()
-
-    if vendor == "anthropic" or "claude" in model_lower:
-        thinking_mode = config.get("thinking_mode", False)
-        if thinking_mode:
-            kwargs["thinking"] = {
-                "type": "enabled",
-                "budget_tokens": config.get("thinking_budget", 2048),
-            }
-        else:
-            kwargs["thinking"] = {"type": "disabled"}
-
-    elif vendor == "openai" and model_lower.startswith(("o1", "o3")):
-        thinking_mode = config.get("thinking_mode", False)
-        if thinking_mode:
-            kwargs["reasoning_effort"] = config.get("reasoning_effort", "medium")
+    # 供应商特定的 thinking/reasoning 适配。DB config 仍是模型配置事实源；
+    # Home 的 per-run 开关会在 DynamicLiteLlm 层覆盖本轮请求，不回写配置。
+    full_model = f"{vendor}/{model_name}" if vendor else model_name
+    kwargs = apply_llm_thinking_override(
+        full_model,
+        kwargs,
+        bool(config.get("thinking_mode", False)),
+        config,
+    )
 
     if "drop_params" in config and "drop_params" not in kwargs:
         kwargs["drop_params"] = config["drop_params"]
@@ -713,7 +752,6 @@ def _build_llm_kwargs(
     effective_api_base = config.get("api_base") or (vendor_config or {}).get("api_base")
     if effective_api_key:
         kwargs["api_key"] = effective_api_key
-    full_model = f"{vendor}/{model_name}" if vendor else model_name
     normalized_api_base = normalize_api_base_for_litellm(full_model, effective_api_base)
     if normalized_api_base:
         kwargs["api_base"] = normalized_api_base

--- a/apps/negentropy/tests/unit_tests/config/test_model_resolver_thinking.py
+++ b/apps/negentropy/tests/unit_tests/config/test_model_resolver_thinking.py
@@ -1,0 +1,59 @@
+"""Thinking / reasoning 参数映射的单元测试。"""
+
+
+def test_anthropic_thinking_override_enabled_and_disabled():
+    from negentropy.config.model_resolver import apply_llm_thinking_override
+
+    enabled = apply_llm_thinking_override(
+        "anthropic/claude-4-5-sonnet",
+        {"temperature": 0.7},
+        True,
+        {"thinking_budget": 4096},
+    )
+    assert enabled["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+
+    disabled = apply_llm_thinking_override(
+        "anthropic/claude-4-5-sonnet",
+        {"thinking": {"type": "enabled", "budget_tokens": 4096}},
+        False,
+    )
+    assert disabled["thinking"] == {"type": "disabled"}
+
+
+def test_openai_gpt5_reasoning_override_uses_reasoning_effort():
+    from negentropy.config.model_resolver import apply_llm_thinking_override
+
+    enabled = apply_llm_thinking_override(
+        "openai/gpt-5-mini",
+        {"temperature": 0.7},
+        True,
+        {"reasoning_effort": "high"},
+    )
+    assert enabled["reasoning_effort"] == "high"
+
+    disabled = apply_llm_thinking_override(
+        "openai/gpt-5-mini",
+        {"reasoning_effort": "high"},
+        False,
+    )
+    assert "reasoning_effort" not in disabled
+
+
+def test_unsupported_vendor_is_left_unchanged():
+    from negentropy.config.model_resolver import apply_llm_thinking_override
+
+    kwargs = {"temperature": 0.2}
+    out = apply_llm_thinking_override("gemini/gemini-2.5-flash", kwargs, True)
+    assert out == kwargs
+    assert out is not kwargs
+
+
+def test_build_llm_kwargs_supports_gpt5_config_thinking_mode():
+    from negentropy.config.model_resolver import _build_llm_kwargs
+
+    kwargs = _build_llm_kwargs(
+        "openai",
+        "gpt-5-mini",
+        {"thinking_mode": True, "reasoning_effort": "medium"},
+    )
+    assert kwargs["reasoning_effort"] == "medium"

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1570,3 +1570,23 @@
   2. MCP 删除调用方传 `title="删除 MCP Server"`、`confirmLabel="删除"`；
   3. 增 vitest 守卫：`title !== confirmLabel` + `cancelLabel.length > 0`。
 - **同类问题影响**：所有 ConfirmDialog 调用方都需复审文案；建议增加 ESLint 自定义规则在调用 `useConfirmDialog()` 时强制 destructive 时 `title!==confirmLabel`。
+
+---
+
+## ISSUE-075 Thinking 开关缺失 + 推理面板误展示阶段标识（2026-05-07）
+
+- **表因**：Home 对话推理面板展开后出现「阶段完成：步骤 synth-step:...」等生命周期标识，而不是模型推理过程中产生的真实内容；同时用户无法在输入区显式请求开启模型 Thinking / Reasoning 能力。
+- **根因**：
+  1. [`Composer`](../apps/negentropy-ui/components/ui/Composer.tsx) 仅提供模型选择和附件入口，没有 per-session Thinking 控制；[`app/api/agui/route.ts`](../apps/negentropy-ui/app/api/agui/route.ts) 也只把 `selected_llm_model` 写入 `state_delta`。
+  2. 后端 [`model_resolver`](../apps/negentropy/src/negentropy/config/model_resolver.py) 只对 Claude/Anthropic 与 OpenAI `o1/o3` 做 thinking/reasoning 参数映射，漏掉默认 `openai/gpt-5-mini` 这类 GPT-5 reasoning 模型。
+  3. [`chat-display`](../apps/negentropy-ui/utils/chat-display.ts) 把 reasoning 节点的 `summary` fallback 成 `content`，导致「阶段完成」这类生命周期摘要被误当作推理正文渲染。
+  4. [`conversation-tree`](../apps/negentropy-ui/utils/conversation-tree.ts) 遇到 `ne.a2ui.thought` 早于 reasoning 节点创建时会直接丢弃真实 thought 文本。
+- **处理方式**：
+  1. Composer 输入区底部新增二态 `Thinking` switch，按 session localStorage 持久化；发送时透传 `forwardedProps.thinking_enabled`，Next AG-UI route 写入 `state_delta.thinking_enabled`。
+  2. Root/SubAgent 动态 LiteLLM 在单轮请求中读取 ContextVar，并通过 `apply_llm_thinking_override()` 按模型能力覆盖参数：Claude 写 `thinking`，OpenAI GPT-5/o 系列写 `reasoning_effort`，其它模型保持 kwargs 原样。
+  3. 移除 `summary -> content` fallback；`ne.a2ui.thought` / 携带文本的 `ne.a2ui.reasoning` 若早于 reasoning 节点到达，先进入 pending buffer，节点创建后再合并进 `payload.content`。
+  4. 增加前后端单测覆盖 Thinking toggle、state_delta 透传、GPT-5 reasoning 参数映射、真实 thought 透传与阶段伪内容不渲染。
+- **后续防范**：
+  1. UI 只展示真实可观测推理文本或结构化 result，严禁把 lifecycle summary 当作推理正文；
+  2. 新增模型族时必须同步维护 Thinking 能力映射，并用单测锁定「支持时注入 / 不支持时不注入」；
+  3. CUSTOM 事件如果承载业务语义，必须具备「早到缓冲」策略，避免同 timestamp 排序或流式抖动造成信息丢失。


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Home 对话缺少显式 Thinking 开关，且推理面板会把阶段完成标识误展示为推理内容。
- 关联上下文/Issue/文档：[docs/issue.md](docs/issue.md) 中新增 ISSUE-075 记录。

# 核心变更
- 在 Composer 输入区模型选择旁新增 Thinking 开关，并在 Home 会话状态中持久化 `thinking_enabled`，发送时通过 AG-UI `forwardedProps` 与 `state_delta` 传递到后端。
- 后端动态模型解析同时读取 `selected_llm_model` 与 `thinking_enabled`，按 Claude/Anthropic 与 OpenAI GPT-5/o 系列分别映射 `thinking` 或 `reasoning_effort` 参数，不支持的供应商保持原请求不变。
- 修正 reasoning 展示语义，移除 summary 到 content 的伪内容 fallback，并为早于 reasoning 节点到达的真实 thought 事件增加 buffer 与合并逻辑。

# 风险与回滚
- 主要风险：不同供应商对推理参数支持不一致，已通过供应商白名单和 unsupported no-op 降低请求失败风险。
- 回滚方式：回滚本 PR 即可恢复原有 Composer、AG-UI 状态通道、后端模型参数与 reasoning 展示逻辑。

# 验证证据
- 单元测试：`pnpm test -- tests/unit/Composer.test.tsx tests/unit/api/agui-route-state.test.ts tests/unit/utils/conversation-tree.test.ts tests/unit/utils/chat-display.test.ts tests/unit/ui/ReasoningPanel.test.tsx tests/integration/home-flow.test.tsx` 通过，实际执行 603 个前端测试。
- 集成测试：`pnpm typecheck`、`pnpm typecheck:test`、`pnpm lint` 通过。
- E2E/Workflow：`uv run pytest tests/unit_tests/config --no-cov` 通过，76 passed。
- 覆盖率/关键截图：`uv run pytest tests/unit_tests/config` 的测试本身通过，但被全仓 coverage gate 拦截，局部 total coverage 为 7.30% 且低于 50% 门槛；Chrome DevTools 主 profile 未暴露 DevToolsActivePort，因此未做登录态浏览器验证。

# 影响范围
- 前端：Home Composer、AG-UI route、conversation tree、chat display、ReasoningPanel 相关测试。
- 后端：动态模型 ContextVar、root callback 状态读取、model resolver 推理参数映射与单测。
- GitHub Actions / 文档：未修改 CI 配置；更新 `docs/issue.md` 记录同类问题防范。

# Next Best Action
- 合并前在可连接用户 Chrome 主 profile 的环境下完成一次 UI 冒烟验证，确认 Thinking 开关位置、请求载荷与推理面板展示符合预期。
