### PR TITLE
fix(knowledge-graph): pgvector 扩展缺失导致 Knowledge Graph 全链路 500 错误

### DIFF
--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -374,6 +374,28 @@ def apply_adk_patches():
         if not any(route.path.startswith("/knowledge") for route in app.router.routes):
             app.include_router(knowledge_router)
             logger.info("Knowledge API router mounted under /knowledge")
+
+        # 全局 DBAPIError handler：pgvector 共享库缺失时返回 503 而非 500
+        from fastapi.responses import JSONResponse
+        from sqlalchemy.exc import DBAPIError
+
+        @app.exception_handler(DBAPIError)
+        async def _pgvector_missing_handler(request, exc):
+            msg = (str(exc.orig) if exc.orig else str(exc)).lower()
+            if "vector" in msg and ("could not access" in msg or "undefined file" in msg):
+                logger.error("pgvector_library_missing_on_request", path=request.url.path, error=str(exc))
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "code": "PGVECTOR_UNAVAILABLE",
+                        "message": "数据库 pgvector 扩展不可用，Knowledge Graph 功能无法使用。请安装 pgvector 后重试。",
+                        "hint": (
+                            "安装 pgvector 扩展后执行: psql -d negentropy -c 'CREATE EXTENSION IF NOT EXISTS vector;'"
+                        ),
+                    },
+                )
+            raise exc
+
         if not any(route.path.startswith("/memory") for route in app.router.routes):
             app.include_router(memory_router)
             logger.info("Memory API router mounted under /memory")
@@ -399,6 +421,36 @@ def apply_adk_patches():
                 logger.info("model_config_cache_warmed")
             except Exception as exc:
                 logger.warning("model_config_cache_warm_failed", error=str(exc))
+
+        # 检查 pgvector 扩展可用性（非阻塞：缺失不阻止启动，但明确告警）
+        @app.on_event("startup")
+        async def _check_pgvector_extension():
+            from sqlalchemy import text
+
+            from negentropy.db.session import engine as async_engine
+
+            try:
+                async with async_engine.connect() as conn:
+                    result = await conn.execute(text("SELECT extversion FROM pg_extension WHERE extname = 'vector'"))
+                    version = result.scalar_one_or_none()
+                    if version:
+                        logger.info("pgvector_extension_ok", version=version)
+                    else:
+                        logger.warning(
+                            "pgvector_extension_missing",
+                            hint="psql -d negentropy -c 'CREATE EXTENSION IF NOT EXISTS vector;'",
+                        )
+            except Exception as exc:
+                msg = str(exc).lower()
+                if "vector" in msg and ("could not access" in msg or "undefined file" in msg):
+                    logger.error(
+                        "pgvector_library_missing",
+                        error=str(exc),
+                        hint="brew install pgvector, restart PostgreSQL, then "
+                        "psql -d negentropy -c 'CREATE EXTENSION IF NOT EXISTS vector;'",
+                    )
+                else:
+                    logger.warning("pgvector_check_failed", error=str(exc))
 
         # Phase 3：启动应用层 SkillScheduler（60s tick 扫 skill_schedules 表）。
         # feature flag NEGENTROPY_SKILL_SCHEDULER_ENABLED=false 一键关闭。


### PR DESCRIPTION
## Summary

- **根因修复**：PostgreSQL 16 的 pgvector 共享库文件缺失（`$libdir/vector` 不可访问），导致所有涉及 `kg_entities` / `knowledge` 表（含 `vector(1536)` 类型 embedding 列）的查询均以 `UndefinedFileError` 失败，UI 报错 "Internal Server Error"
- **全局 DBAPIError handler**：在 FastAPI app 层添加 `@app.exception_handler(DBAPIError)`，当检测到 pgvector 共享库缺失时返回 503（含结构化错误码和安装指引），而非 500 Internal Server Error
- **启动健康检查**：添加非阻塞式 `_check_pgvector_extension` 启动事件，检测 pgvector 可用性并在缺失时输出明确的安装指引日志，不阻止 Engine 启动（Agent/Chat 等非向量功能仍可工作）
- **基础设施修复**：为 PostgreSQL 16 从源码编译安装 pgvector 0.8.2 共享库（Homebrew 仅提供 PG17/18 版本），升级数据库扩展至 0.8.2

## 影响范围

| 变更 | 文件 | 说明 |
|---|---|---|
| 全局 exception handler | `engine/bootstrap.py` | 新增 `@app.exception_handler(DBAPIError)` |
| 启动健康检查 | `engine/bootstrap.py` | 新增 `@app.on_event("startup")` |

## Test plan

- [x] 确认 pgvector 安装：`psql -d negentropy -c "SELECT extversion FROM pg_extension WHERE extname = 'vector';"` → 0.8.2
- [x] 验证之前报错的 SQL 查询恢复正常：`SELECT count(*) FROM negentropy.kg_entities WHERE is_active = true` → 4
- [x] 代码语法检查通过：ruff lint + ruff format 均 Passed
- [ ] 重启 Engine 后确认启动日志输出 `pgvector_extension_ok`
- [ ] UI 验证：Corpus → Knowledge Graph 页面正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)