### PR TITLE
fix(knowledge-graph): 修复图谱构建 LLM 凭证解析与日志可观测性

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -212,6 +212,8 @@ Output as JSON with the following structure:
         Returns:
             提取的实体节点列表
         """
+        await self._ensure_model_config()
+
         logger.debug(
             "llm_extract_entities_started",
             corpus_id=str(corpus_id),
@@ -280,8 +282,6 @@ Output as JSON with the following structure:
         Returns:
             实体提取结果列表
         """
-        await self._ensure_model_config()
-
         import litellm
 
         # 截断文本以避免 token 限制
@@ -568,6 +568,8 @@ Output as JSON with the following structure:
         Returns:
             提取的关系边列表
         """
+        await self._ensure_model_config()
+
         logger.debug(
             "llm_extract_relations_started",
             entity_count=len(entities),
@@ -653,8 +655,6 @@ Output as JSON with the following structure:
         Returns:
             关系提取结果列表
         """
-        await self._ensure_model_config()
-
         import litellm
 
         # 提取实体名称

--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -138,23 +138,63 @@ Output as JSON with the following structure:
             fallback_to_regex: 失败时是否回退到正则提取器
             schema: ExtractionSchema 实例，用于约束提取类型
         """
-        self._model, self._model_kwargs = self._resolve_model_config(model)
+        # 惰性解析模型配置（含 api_key），延迟到首次 _extract_with_llm 调用
+        # 因为 __init__ 是同步的，无法调用异步 DB 查询
+        self._explicit_model = model
+        self._model: str | None = None
+        self._model_kwargs: dict[str, Any] = {}
+        self._model_config_resolved = False
+        self._model_config_lock: asyncio.Lock | None = None
         self._temperature = temperature
         self._max_retries = max_retries
         self._fallback_to_regex = fallback_to_regex
         self._schema = schema
 
-    @staticmethod
-    def _resolve_model_config(explicit_model: str | None) -> tuple[str, dict]:
-        """解析模型配置（DB 优先，硬编码默认值回退）。返回 (model_name, extra_kwargs)。"""
-        if explicit_model:
-            return explicit_model, {}
-        from negentropy.config.model_resolver import get_cached_llm_config, get_fallback_llm_config
+    async def _ensure_model_config(self) -> None:
+        """异步解析模型配置（含 api_key）。
 
-        cached = get_cached_llm_config()
-        if cached is not None:
-            return cached[0], cached[1]
-        return get_fallback_llm_config()
+        解析链：resolve_llm_config_by_model_name → resolve_llm_config → get_fallback_llm_config。
+        使用双重检查锁保证并发安全，Lock 惰性创建避免 event loop 问题。
+        """
+        if self._model_config_resolved:
+            return
+
+        if self._model_config_lock is None:
+            self._model_config_lock = asyncio.Lock()
+
+        async with self._model_config_lock:
+            if self._model_config_resolved:
+                return
+
+            model_name: str | None = None
+            model_kwargs: dict[str, Any] = {}
+
+            try:
+                if self._explicit_model:
+                    from negentropy.config.model_resolver import resolve_llm_config_by_model_name
+
+                    resolved = await resolve_llm_config_by_model_name(self._explicit_model)
+                    if resolved is not None:
+                        model_name, model_kwargs = resolved
+                if model_name is None:
+                    from negentropy.config.model_resolver import resolve_llm_config
+
+                    model_name, model_kwargs = await resolve_llm_config()
+            except Exception:
+                logger.warning(
+                    "model_config_async_resolve_failed",
+                    explicit_model=self._explicit_model,
+                    exc_info=True,
+                )
+
+            if model_name is None:
+                from negentropy.config.model_resolver import get_fallback_llm_config
+
+                model_name, model_kwargs = get_fallback_llm_config()
+
+            self._model = model_name
+            self._model_kwargs = model_kwargs
+            self._model_config_resolved = True
 
     async def extract(
         self,
@@ -240,6 +280,8 @@ Output as JSON with the following structure:
         Returns:
             实体提取结果列表
         """
+        await self._ensure_model_config()
+
         import litellm
 
         # 截断文本以避免 token 限制
@@ -455,23 +497,62 @@ Output as JSON with the following structure:
             fallback_to_cooccurrence: 失败时是否回退到共现提取器
             schema: ExtractionSchema 实例，用于约束关系类型
         """
-        self._model, self._model_kwargs = self._resolve_model_config(model)
+        # 惰性解析模型配置（含 api_key），延迟到首次 _extract_with_llm 调用
+        self._explicit_model = model
+        self._model: str | None = None
+        self._model_kwargs: dict[str, Any] = {}
+        self._model_config_resolved = False
+        self._model_config_lock: asyncio.Lock | None = None
         self._temperature = temperature
         self._max_retries = max_retries
         self._fallback_to_cooccurrence = fallback_to_cooccurrence
         self._schema = schema
 
-    @staticmethod
-    def _resolve_model_config(explicit_model: str | None) -> tuple[str, dict]:
-        """解析模型配置（DB 优先，硬编码默认值回退）。返回 (model_name, extra_kwargs)。"""
-        if explicit_model:
-            return explicit_model, {}
-        from negentropy.config.model_resolver import get_cached_llm_config, get_fallback_llm_config
+    async def _ensure_model_config(self) -> None:
+        """异步解析模型配置（含 api_key）。
 
-        cached = get_cached_llm_config()
-        if cached is not None:
-            return cached[0], cached[1]
-        return get_fallback_llm_config()
+        解析链：resolve_llm_config_by_model_name → resolve_llm_config → get_fallback_llm_config。
+        使用双重检查锁保证并发安全，Lock 惰性创建避免 event loop 问题。
+        """
+        if self._model_config_resolved:
+            return
+
+        if self._model_config_lock is None:
+            self._model_config_lock = asyncio.Lock()
+
+        async with self._model_config_lock:
+            if self._model_config_resolved:
+                return
+
+            model_name: str | None = None
+            model_kwargs: dict[str, Any] = {}
+
+            try:
+                if self._explicit_model:
+                    from negentropy.config.model_resolver import resolve_llm_config_by_model_name
+
+                    resolved = await resolve_llm_config_by_model_name(self._explicit_model)
+                    if resolved is not None:
+                        model_name, model_kwargs = resolved
+                if model_name is None:
+                    from negentropy.config.model_resolver import resolve_llm_config
+
+                    model_name, model_kwargs = await resolve_llm_config()
+            except Exception:
+                logger.warning(
+                    "model_config_async_resolve_failed",
+                    explicit_model=self._explicit_model,
+                    exc_info=True,
+                )
+
+            if model_name is None:
+                from negentropy.config.model_resolver import get_fallback_llm_config
+
+                model_name, model_kwargs = get_fallback_llm_config()
+
+            self._model = model_name
+            self._model_kwargs = model_kwargs
+            self._model_config_resolved = True
 
     async def extract(
         self,
@@ -572,6 +653,8 @@ Output as JSON with the following structure:
         Returns:
             关系提取结果列表
         """
+        await self._ensure_model_config()
+
         import litellm
 
         # 提取实体名称

--- a/apps/negentropy/tests/unit_tests/knowledge/test_llm_extractors.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_llm_extractors.py
@@ -23,6 +23,24 @@ from negentropy.knowledge.types import GraphNode, KgEntityType, KgRelationType
 
 _CORPUS_ID = UUID("00000000-0000-0000-0000-000000000001")
 
+_MOCK_LLM_CONFIG = ("openai/gpt-5-mini", {"temperature": 0.7, "drop_params": True})
+
+
+@pytest.fixture(autouse=True)
+def _mock_model_resolver():
+    """Mock 异步 model_resolver，避免测试环境触发 DB 连接。"""
+    with (
+        patch(
+            "negentropy.config.model_resolver.resolve_llm_config",
+            new=AsyncMock(return_value=_MOCK_LLM_CONFIG),
+        ),
+        patch(
+            "negentropy.config.model_resolver.resolve_llm_config_by_model_name",
+            new=AsyncMock(return_value=_MOCK_LLM_CONFIG),
+        ),
+    ):
+        yield
+
 
 class TestEntityIDGeneration:
     """实体 ID 生成测试 - 验证确定性"""


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：图谱构建时 LLM 调用因缺少 API Key 导致 `AuthenticationError`；惰性解析后 `extract()` 入口日志始终输出 `model=None`，影响可观测性。
- 关联上下文/Issue/文档：前序 commit `1751e4e8` 修复了 pgvector 扩展缺失问题，本 PR 解决其后的 LLM 凭证解析链路问题。

# 核心变更
- 将 `LLMEntityExtractor` 和 `LLMRelationExtractor` 的模型配置解析从同步 `__init__`（无法执行异步 DB 查询）改为惰性异步解析 `_ensure_model_config()`，解析链：`resolve_llm_config_by_model_name → resolve_llm_config → get_fallback_llm_config`
- 使用双重检查锁（`asyncio.Lock`）保证并发安全，Lock 惰性创建避免 event loop 兼容问题
- 将 `_ensure_model_config()` 调用点从 `_extract_with_llm()` 内部提前至 `extract()` 入口，确保首次日志输出时 `self._model` 已完成解析
- 新增 `autouse` fixture mock 异步 `model_resolver`，避免测试环境触发 DB 连接

# 风险与回滚
- 主要风险：fallback 路径 `get_fallback_llm_config()` 返回硬编码默认值（无 API Key），依赖环境变量兜底；若 DB 与环境变量均不可用，LLM 调用仍会失败
- 回滚方式：`git revert` 即可，无 schema/数据变更

# 验证证据
- 单元测试：20 个测试用例全部通过（`test_llm_extractors.py`）
- 集成测试：N/A
- E2E/Workflow：N/A
- 覆盖率/关键截图：ruff lint + format 均通过

# 影响范围
- 前端：无
- 后端：`negentropy.knowledge.graph.extractors`（实体/关系提取器初始化与模型解析链路）
- GitHub Actions / 文档：无

# Next Best Action
- 可考虑后续将两个 Extractor 的 `_ensure_model_config` 提取为公共基类或 mixin，消除重复代码