### PR TITLE
feat(knowledge-dashboard): 将 KG 构建运行纳入 Dashboard Pipeline Runs 统一管理

### DIFF
--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -67,6 +67,7 @@ export default function KnowledgeDashboardPage() {
   const [retryQueue, setRetryQueue] = useState<UnifiedPipelineRun[]>([]);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
   const [page, setPage] = useState(1);
+  const [kbTotal, setKbTotal] = useState(0);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const bootstrapBaselineRef = useRef<RunsSnapshot | null>(null);
 
@@ -74,6 +75,7 @@ export default function KnowledgeDashboardPage() {
     (kbData: KnowledgePipelinesPayload, kgRuns: KgPipelineRun[]) => {
       const merged = mergeAndSortRuns(kbData.runs ?? [], kgRuns);
       setAllRuns(merged);
+      setKbTotal(kbData.count ?? kbData.runs?.length ?? 0);
       setLastUpdatedAt(kbData.last_updated_at ?? null);
       setError(null);
       setSelected((prev) => {
@@ -230,12 +232,8 @@ export default function KnowledgeDashboardPage() {
     ];
   }, [dashboardData]);
 
-  // 分页（基于合并后的 allRuns）
-  const pagedRuns = useMemo(() => {
-    const start = (page - 1) * PAGE_SIZE;
-    return allRuns.slice(start, start + PAGE_SIZE);
-  }, [allRuns, page]);
-  const total = allRuns.length;
+  // KB 分页总量来自服务端，KG 运行在每页始终展示
+  const total = kbTotal;
 
   const selectedKbRun =
     selected?.source === "kb" ? selected : undefined;
@@ -309,9 +307,9 @@ export default function KnowledgeDashboardPage() {
                     )}
                   </div>
                 </div>
-                {pagedRuns.length ? (
+                {allRuns.length ? (
                   <div className="mt-4 space-y-3 text-xs text-zinc-600 dark:text-zinc-400">
-                    {pagedRuns.map((run) => (
+                    {allRuns.map((run) => (
                       <PipelineRunCard
                         key={run.id}
                         run_id={run.run_id || run.id}

--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -8,27 +8,27 @@ import {
   fetchDashboard,
   fetchPipelines,
   upsertPipelines,
+  fetchCorpora,
+  fetchGraphBuildHistory,
   KnowledgeDashboard,
   KnowledgePipelinesPayload,
-  PipelineRunRecord,
   PipelineRunCard,
   PipelineRunDetailPanel,
 } from "@/features/knowledge";
+import { KgRunDetailPanel } from "@/features/knowledge/components/KgRunDetailPanel";
+import {
+  UnifiedPipelineRun,
+  KgPipelineRun,
+  adaptKgRunToUnified,
+  mergeAndSortRuns,
+  hasActiveRuns,
+} from "@/features/knowledge/utils/unified-pipeline";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 const PAGE_SIZE = 10;
 const RUNNING_POLL_INTERVAL_MS = 5000;
 const BOOTSTRAP_POLL_INTERVAL_MS = 1000;
 const BOOTSTRAP_POLL_MAX_TICKS = 8;
-
-const hasRunningRuns = (runs: PipelineRunRecord[] | undefined): boolean => {
-  return (
-    runs?.some((run) => {
-      const status = run.status?.toLowerCase();
-      return status === "running" || status === "in_progress";
-    }) ?? false
-  );
-};
 
 interface RunsSnapshot {
   count: number;
@@ -38,7 +38,7 @@ interface RunsSnapshot {
 }
 
 const createRunsSnapshot = (
-  runs: PipelineRunRecord[] | undefined,
+  runs: UnifiedPipelineRun[] | undefined,
 ): RunsSnapshot => {
   const first = runs?.[0];
   return {
@@ -60,50 +60,73 @@ const isSameRunsSnapshot = (a: RunsSnapshot, b: RunsSnapshot): boolean => {
 
 export default function KnowledgeDashboardPage() {
   const [dashboardData, setDashboardData] = useState<KnowledgeDashboard | null>(null);
-  const [pipelinesPayload, setPipelinesPayload] = useState<KnowledgePipelinesPayload | null>(null);
+  const [allRuns, setAllRuns] = useState<UnifiedPipelineRun[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<PipelineRunRecord | null>(null);
+  const [selected, setSelected] = useState<UnifiedPipelineRun | null>(null);
   const [saveStatus, setSaveStatus] = useState<string | null>(null);
-  const [retryQueue, setRetryQueue] = useState<PipelineRunRecord[]>([]);
+  const [retryQueue, setRetryQueue] = useState<UnifiedPipelineRun[]>([]);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
   const [page, setPage] = useState(1);
-  const [total, setTotal] = useState(0);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const bootstrapBaselineRef = useRef<RunsSnapshot | null>(null);
 
-  const applyPipelinesPayload = useCallback((data: KnowledgePipelinesPayload) => {
-    setPipelinesPayload(data);
-    setTotal(data.count ?? data.runs?.length ?? 0);
-    setError(null);
-    setSelected((prev) => {
-      if (!data.runs?.length) return null;
-      if (!prev) return data.runs[0];
-      const updated = data.runs.find((r) => r.id === prev.id);
-      return updated ?? data.runs[0];
-    });
-  }, []);
+  const applyRuns = useCallback(
+    (kbData: KnowledgePipelinesPayload, kgRuns: KgPipelineRun[]) => {
+      const merged = mergeAndSortRuns(kbData.runs ?? [], kgRuns);
+      setAllRuns(merged);
+      setLastUpdatedAt(kbData.last_updated_at ?? null);
+      setError(null);
+      setSelected((prev) => {
+        if (!merged.length) return null;
+        if (!prev) return merged[0];
+        const updated = merged.find((r) => r.id === prev.id);
+        return updated ?? merged[0];
+      });
+    },
+    [],
+  );
 
-  const loadPipelines = useCallback(async (overridePage?: number) => {
-    const p = overridePage ?? page;
-    const data = await fetchPipelines(APP_NAME, {
-      limit: PAGE_SIZE,
-      offset: (p - 1) * PAGE_SIZE,
-    });
-    applyPipelinesPayload(data);
-    return data;
-  }, [applyPipelinesPayload, page]);
+  const loadRuns = useCallback(
+    async (overridePage?: number) => {
+      const p = overridePage ?? page;
+      const offset = (p - 1) * PAGE_SIZE;
+
+      const [pipeData, corpora] = await Promise.all([
+        fetchPipelines(APP_NAME, { limit: PAGE_SIZE, offset }),
+        fetchCorpora(APP_NAME).catch(() => []),
+      ]);
+
+      // 仅对有知识的 corpus 查询 KG history，每个 corpus 取最近 5 条
+      const activeCorpora = corpora.filter(
+        (c) => c.knowledge_count > 0,
+      );
+      const kgHistories = await Promise.all(
+        activeCorpora.map((c) =>
+          fetchGraphBuildHistory(c.id, APP_NAME, 5).catch(() => null),
+        ),
+      );
+
+      const kgRuns: KgPipelineRun[] = kgHistories
+        .filter((h) => h !== null)
+        .flatMap((h) =>
+          (h!.runs ?? []).map((r) => adaptKgRunToUnified(r, h!.corpus_id)),
+        );
+
+      applyRuns(pipeData, kgRuns);
+      return { pipeData, kgRuns };
+    },
+    [applyRuns, page],
+  );
 
   useEffect(() => {
     let active = true;
 
     (async () => {
       try {
-        const pipeData = await fetchPipelines(APP_NAME, {
-          limit: PAGE_SIZE,
-          offset: (page - 1) * PAGE_SIZE,
-        });
+        const { pipeData, kgRuns } = await loadRuns();
         if (!active) return;
-        applyPipelinesPayload(pipeData);
-        bootstrapBaselineRef.current = createRunsSnapshot(pipeData.runs);
+        const merged = mergeAndSortRuns(pipeData.runs ?? [], kgRuns);
+        bootstrapBaselineRef.current = createRunsSnapshot(merged);
         setHasInitialLoad(true);
       } catch (err) {
         if (active) setError(String(err));
@@ -122,31 +145,31 @@ export default function KnowledgeDashboardPage() {
     return () => {
       active = false;
     };
-  }, [applyPipelinesPayload, page]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- initial load
+  }, [page]);
 
+  // Bootstrap polling
   useEffect(() => {
     if (!hasInitialLoad) return;
     if (page !== 1) return;
 
     let active = true;
     let tick = 0;
-    const baseline = bootstrapBaselineRef.current ?? createRunsSnapshot(pipelinesPayload?.runs);
+    const baseline = bootstrapBaselineRef.current ?? createRunsSnapshot(allRuns);
 
     const intervalId = setInterval(async () => {
       tick += 1;
       try {
-        const data = await fetchPipelines(APP_NAME, {
-          limit: PAGE_SIZE,
-          offset: 0,
-        });
+        const { pipeData, kgRuns } = await loadRuns();
         if (!active) return;
 
-        const nextSnapshot = createRunsSnapshot(data.runs);
+        const merged = mergeAndSortRuns(pipeData.runs ?? [], kgRuns);
+        const nextSnapshot = createRunsSnapshot(merged);
         const changed = !isSameRunsSnapshot(baseline, nextSnapshot);
-        const running = hasRunningRuns(data.runs);
+        const running = hasActiveRuns(merged);
 
         if (changed || running) {
-          applyPipelinesPayload(data);
+          applyRuns(pipeData, kgRuns);
           clearInterval(intervalId);
           return;
         }
@@ -164,15 +187,16 @@ export default function KnowledgeDashboardPage() {
       active = false;
       clearInterval(intervalId);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: pipelinesPayload?.runs removed to prevent unstable cleanup/restart cycle
-  }, [applyPipelinesPayload, hasInitialLoad, page]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasInitialLoad, page]);
 
+  // Running-state polling
   useEffect(() => {
     if (page !== 1) return;
-    if (!hasRunningRuns(pipelinesPayload?.runs)) return;
+    if (!hasActiveRuns(allRuns)) return;
 
     const intervalId = setInterval(() => {
-      loadPipelines(1).catch((err) => {
+      loadRuns(1).catch((err) => {
         setError(String(err));
       });
     }, RUNNING_POLL_INTERVAL_MS);
@@ -180,7 +204,7 @@ export default function KnowledgeDashboardPage() {
     return () => {
       clearInterval(intervalId);
     };
-  }, [loadPipelines, pipelinesPayload?.runs, page]);
+  }, [loadRuns, allRuns, page]);
 
   const metrics = useMemo(() => {
     if (!dashboardData) return [];
@@ -206,7 +230,15 @@ export default function KnowledgeDashboardPage() {
     ];
   }, [dashboardData]);
 
-  const runs = pipelinesPayload?.runs || [];
+  // 分页（基于合并后的 allRuns）
+  const pagedRuns = useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE;
+    return allRuns.slice(start, start + PAGE_SIZE);
+  }, [allRuns, page]);
+  const total = allRuns.length;
+
+  const selectedKbRun =
+    selected?.source === "kb" ? selected : undefined;
 
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
@@ -240,35 +272,35 @@ export default function KnowledgeDashboardPage() {
                     Pipeline Runs
                   </h2>
                   <div className="flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
-                    <span>{pipelinesPayload?.last_updated_at || "最近 24h"}</span>
-                    {selected && (
+                    <span>{lastUpdatedAt || "最近 24h"}</span>
+                    {selectedKbRun && (
                       <button
                         className={outlineButtonClassName("neutral", "rounded-full px-3 py-1 text-[11px]")}
                         onClick={async () => {
-                          if (!selected) return;
+                          if (!selectedKbRun) return;
                           setSaveStatus("saving");
                           try {
                             await upsertPipelines({
                               app_name: APP_NAME,
-                              run_id: selected.run_id,
-                              status: selected.status || "completed",
+                              run_id: selectedKbRun.run_id,
+                              status: selectedKbRun.status || "completed",
                               payload: {
-                                started_at: selected.started_at,
-                                completed_at: selected.completed_at,
-                                duration_ms: selected.duration_ms,
-                                duration: selected.duration,
-                                trigger: selected.trigger,
-                                input: selected.input,
-                                output: selected.output,
-                                error: selected.error,
+                                started_at: selectedKbRun.started_at,
+                                completed_at: selectedKbRun.completed_at,
+                                duration_ms: selectedKbRun.duration_ms,
+                                duration: selectedKbRun.duration,
+                                trigger: selectedKbRun.trigger,
+                                input: selectedKbRun.input,
+                                output: selectedKbRun.output,
+                                error: selectedKbRun.error,
                               },
-                              expected_version: selected.version,
+                              expected_version: selectedKbRun.version,
                               idempotency_key: crypto.randomUUID(),
                             });
                             setSaveStatus("saved");
                           } catch (err) {
                             setSaveStatus(`error:${String(err)}`);
-                            setRetryQueue((prev) => [...prev, selected]);
+                            setRetryQueue((prev) => [...prev, selectedKbRun]);
                           }
                         }}
                       >
@@ -277,24 +309,36 @@ export default function KnowledgeDashboardPage() {
                     )}
                   </div>
                 </div>
-                {runs.length ? (
+                {pagedRuns.length ? (
                   <div className="mt-4 space-y-3 text-xs text-zinc-600 dark:text-zinc-400">
-                    {runs.map((run) => (
+                    {pagedRuns.map((run) => (
                       <PipelineRunCard
                         key={run.id}
                         run_id={run.run_id || run.id}
                         status={run.status}
                         version={run.version ?? 0}
-                        operation={run.operation as PipelineRunCardOperationType}
-                        trigger={run.trigger}
+                        operation={
+                          run.source === "kb"
+                            ? (run.operation as "ingest_text" | "ingest_url" | "ingest_file" | "replace_source")
+                            : undefined
+                        }
+                        trigger={run.source === "kb" ? run.trigger : undefined}
                         duration_ms={run.duration_ms}
                         started_at={run.started_at}
                         completed_at={run.completed_at}
                         stages={run.stages}
-                        error={run.error}
+                        error={run.source === "kb" ? run.error : undefined}
                         mode="selectable"
                         selected={selected?.id === run.id}
                         onSelect={() => setSelected(run)}
+                        // KG 专属字段
+                        source={run.source}
+                        corpus_id={run.source === "kg" ? run.corpus_id : undefined}
+                        entity_count={run.source === "kg" ? run.entity_count : undefined}
+                        relation_count={run.source === "kg" ? run.relation_count : undefined}
+                        model_name={run.source === "kg" ? run.model_name : undefined}
+                        error_message={run.source === "kg" ? run.error_message : undefined}
+                        progress_percent={run.source === "kg" ? run.progress_percent : undefined}
                       />
                     ))}
                   </div>
@@ -304,7 +348,6 @@ export default function KnowledgeDashboardPage() {
                 {total > 0 && (
                   <div className="mt-4 flex items-center justify-between border-t border-zinc-200 pt-3 dark:border-zinc-800">
                     <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {/* 单字符串避免 JSX 文本节点相邻被 a11y 规范化为 "X run s" */}
                       {`${total} run${total !== 1 ? "s" : ""}`}
                     </span>
                     <div className="flex items-center gap-1.5">
@@ -355,13 +398,17 @@ export default function KnowledgeDashboardPage() {
               <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-500 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
                 {error
                   ? `加载失败：${error}`
-                  : `状态源：${pipelinesPayload ? "已加载" : "等待加载"}${saveStatus ? ` | ${saveStatus}` : ""}`}
+                  : `状态源：${allRuns.length ? "已加载" : "等待加载"}${saveStatus ? ` | ${saveStatus}` : ""}`}
               </div>
 
               {selected && (
                 <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                   <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Run Detail</h2>
-                  <PipelineRunDetailPanel run={selected} />
+                  {selected.source === "kb" ? (
+                    <PipelineRunDetailPanel run={selected} />
+                  ) : (
+                    <KgRunDetailPanel run={selected} />
+                  )}
                 </div>
               )}
 
@@ -372,7 +419,7 @@ export default function KnowledgeDashboardPage() {
                     className="mt-3 rounded bg-amber-600 px-3 py-2 text-[11px] font-semibold text-white"
                     onClick={async () => {
                       const next = retryQueue[0];
-                      if (!next) return;
+                      if (!next || next.source !== "kb") return;
                       setSaveStatus("retrying");
                       try {
                         await upsertPipelines({
@@ -410,10 +457,3 @@ export default function KnowledgeDashboardPage() {
     </div>
   );
 }
-
-type PipelineRunCardOperationType =
-  | "ingest_text"
-  | "ingest_url"
-  | "ingest_file"
-  | "replace_source"
-  | undefined;

--- a/apps/negentropy-ui/features/knowledge/components/KgRunDetailPanel.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/KgRunDetailPanel.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import type { KgPipelineRun } from "../utils/unified-pipeline";
+import {
+  formatDuration,
+  getSortedStages,
+  getStageColor,
+  STAGE_LABELS,
+  OPERATION_LABELS,
+} from "../utils/pipeline-helpers";
+
+const detailJsonClassName =
+  "mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-zinc-50 p-3 text-[11px] dark:bg-zinc-800";
+
+/**
+ * KG 构建运行详情面板
+ *
+ * 展示 KG 专属信息：模型名称、实体/关系统计、阶段进度、抽取配置、错误信息
+ */
+export function KgRunDetailPanel({ run }: { run: KgPipelineRun }) {
+  return (
+    <div className="mt-3 min-w-0 space-y-3 text-xs text-zinc-600 dark:text-zinc-400">
+      {/* 基本信息 */}
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800">
+        <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">Info</p>
+        <p className="mt-2 text-[11px] text-zinc-600 dark:text-zinc-400">
+          Operation: {OPERATION_LABELS.graph_build}
+        </p>
+        <p className="text-[11px] text-zinc-600 dark:text-zinc-400">
+          Corpus: {run.corpus_id}
+        </p>
+        <p className="text-[11px] text-zinc-600 dark:text-zinc-400">开始 {run.started_at || "-"}</p>
+        <p className="text-[11px] text-zinc-600 dark:text-zinc-400">结束 {run.completed_at || "-"}</p>
+        <p className="text-[11px] text-zinc-600 dark:text-zinc-400">
+          Duration: {formatDuration(run.duration_ms, run.started_at, run.completed_at)}
+        </p>
+        {run.model_name && (
+          <p className="text-[11px] text-zinc-600 dark:text-zinc-400">
+            Model: {run.model_name}
+          </p>
+        )}
+        {run.progress_percent != null && (
+          <p className="text-[11px] text-zinc-600 dark:text-zinc-400">
+            Progress: {Math.round(run.progress_percent * 100)}%
+          </p>
+        )}
+      </div>
+
+      {/* 实体/关系统计 */}
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800">
+        <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">Statistics</p>
+        <div className="mt-2 grid grid-cols-2 gap-3">
+          <div>
+            <p className="text-[10px] text-zinc-400">实体数</p>
+            <p className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+              {run.entity_count}
+            </p>
+          </div>
+          <div>
+            <p className="text-[10px] text-zinc-400">关系数</p>
+            <p className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+              {run.relation_count}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 阶段详情 */}
+      {run.stages && Object.keys(run.stages).length > 0 && (
+        <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800">
+          <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">Phases</p>
+          <div className="mt-2 space-y-2">
+            {getSortedStages(run.stages).map(([stageName, stage]) => (
+              <div key={stageName}>
+                <div className="flex min-w-0 items-center gap-2 text-[11px]">
+                  <span className={`h-2 w-2 shrink-0 rounded-full ${getStageColor(stageName, stage.status)}`} />
+                  <span className="min-w-0 truncate font-medium text-zinc-700 dark:text-zinc-300">
+                    {STAGE_LABELS[stageName] || stageName}
+                  </span>
+                  <span className="shrink-0 uppercase text-zinc-400">
+                    {stage.status || "unknown"}
+                  </span>
+                  {stage.status === "skipped" && stage.reason && (
+                    <span className="truncate text-zinc-400 italic">({stage.reason})</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 抽取配置 */}
+      {run.extractor_config && Object.keys(run.extractor_config).length > 0 && (
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">Extractor Config</p>
+          <pre className={detailJsonClassName}>
+            {JSON.stringify(run.extractor_config, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      {/* Warnings */}
+      {run.warnings && run.warnings.length > 0 && (() => {
+        // 过滤掉 _phase 条目，只显示实际 warning
+        const realWarnings = run.warnings.filter(
+          (w) => !("_phase" in (w as Record<string, unknown>)),
+        );
+        if (realWarnings.length === 0) return null;
+        return (
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">
+              Warnings ({realWarnings.length})
+            </p>
+            <div className="mt-2 max-h-32 space-y-1.5 overflow-auto">
+              {realWarnings.map((w, i) => (
+                <div
+                  key={i}
+                  className="rounded border border-amber-200 bg-amber-50 p-2 text-[11px] text-amber-700 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-400"
+                >
+                  {JSON.stringify(w)}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
+
+      {/* 错误信息 */}
+      {run.error_message && (
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase text-zinc-400 dark:text-zinc-500">Error</p>
+          <div className="mt-2 rounded-lg border border-rose-200 bg-rose-50 p-3 dark:border-rose-900/40 dark:bg-rose-950/20">
+            <p className="text-[11px] text-rose-700 dark:text-rose-300">
+              {run.error_message}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -158,7 +158,7 @@ function PipelineRunCardContent({
           )}
           {duration !== "-" && (
             <>
-              <span className={isSelectable ? "" : "text-zinc-400 dark:bg-zinc-500"}>·</span>
+              <span className={isSelectable ? "" : "text-zinc-400 dark:text-zinc-500"}>·</span>
               <span>{duration}</span>
             </>
           )}

--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -43,6 +43,21 @@ export interface PipelineRunCardProps {
   selected?: boolean;
   /** 点击回调（仅 mode="selectable" 有效） */
   onSelect?: () => void;
+  // ---- KG 专属字段 ----
+  /** 来源类型 */
+  source?: "kb" | "kg";
+  /** KG: corpus ID */
+  corpus_id?: string;
+  /** KG: 进度百分比 */
+  progress_percent?: number;
+  /** KG: 实体数 */
+  entity_count?: number;
+  /** KG: 关系数 */
+  relation_count?: number;
+  /** KG: 模型名称 */
+  model_name?: string;
+  /** KG: 错误信息 */
+  error_message?: string;
   /** 支持扩展字段 */
   [key: string]: unknown;
 }
@@ -79,9 +94,20 @@ function PipelineRunCardContent({
   stages,
   error,
   isSelectable,
+  source = "kb",
+  entity_count,
+  relation_count,
+  model_name,
+  error_message,
+  progress_percent,
 }: PipelineRunCardProps & { isSelectable: boolean }) {
   const duration = formatDuration(duration_ms, started_at, completed_at);
-  const operationLabel = operation ? OPERATION_LABELS[operation] || operation : null;
+  const isKg = source === "kg";
+  const operationLabel = isKg
+    ? OPERATION_LABELS.graph_build
+    : operation
+      ? OPERATION_LABELS[operation] || operation
+      : null;
   const triggerLabel = trigger ? TRIGGER_LABELS[trigger] || trigger : null;
   const hasStages = stages && Object.keys(stages).length > 0;
 
@@ -103,7 +129,7 @@ function PipelineRunCardContent({
         <PipelineStatusBadge status={status} />
       </div>
 
-      {/* 第二行：操作类型 + 触发方式 + 时长 + 版本 */}
+      {/* 第二行：操作类型 + 触发方式/KG 统计 + 时长 + 版本 */}
       <div className={`mt-1.5 flex min-w-0 items-center justify-between text-[11px] ${
         isSelectable ? "opacity-70" : "text-zinc-500 dark:text-zinc-400"
       }`}>
@@ -113,21 +139,33 @@ function PipelineRunCardContent({
               <span className={isSelectable ? "font-medium" : "font-medium text-zinc-600 dark:text-zinc-300"}>
                 {operationLabel}
               </span>
-              {triggerLabel && (
+              {isKg && entity_count != null && relation_count != null && (
+                <>
+                  <span className={isSelectable ? "" : "text-zinc-400 dark:text-zinc-500"}>·</span>
+                  <span>{entity_count} 实体 / {relation_count} 关系</span>
+                </>
+              )}
+              {!isKg && triggerLabel && (
                 <span className={isSelectable ? "" : "text-zinc-400 dark:text-zinc-500"}>·</span>
               )}
             </>
           )}
-          {triggerLabel && (
+          {!isKg && triggerLabel && (
             <span className="uppercase">{triggerLabel}</span>
           )}
-          {!operationLabel && !triggerLabel && (
+          {!operationLabel && (
             <span>{formatRelativeTime(updated_at)}</span>
           )}
           {duration !== "-" && (
             <>
-              <span className={isSelectable ? "" : "text-zinc-400 dark:text-zinc-500"}>·</span>
+              <span className={isSelectable ? "" : "text-zinc-400 dark:bg-zinc-500"}>·</span>
               <span>{duration}</span>
+            </>
+          )}
+          {isKg && model_name && (
+            <>
+              <span className={isSelectable ? "" : "text-zinc-400 dark:text-zinc-500"}>·</span>
+              <span className="truncate max-w-[100px]">{model_name}</span>
             </>
           )}
         </div>
@@ -135,6 +173,11 @@ function PipelineRunCardContent({
           {hasTimeline && (
             <span className={isSelectable ? "opacity-60" : "text-zinc-400 dark:text-zinc-500"}>
               {startLabel ?? "-"} → {endLabel ?? "-"}
+            </span>
+          )}
+          {isKg && progress_percent != null && status?.toLowerCase() === "running" && (
+            <span className="shrink-0 tabular-nums">
+              {Math.round(progress_percent * 100)}%
             </span>
           )}
           <span className="shrink-0">v{version}</span>
@@ -151,8 +194,17 @@ function PipelineRunCardContent({
         />
       )}
 
-      {/* 第四行：失败摘要（仅失败时显示） */}
+      {/* 第四行：失败摘要 */}
       {status === "failed" && (() => {
+        // KG: 直接展示 error_message
+        if (isKg && error_message) {
+          return (
+            <p className="mt-1 truncate text-[11px] text-rose-500 dark:text-rose-400">
+              {error_message}
+            </p>
+          );
+        }
+        // KB: 从 stages 或 error 中提取
         const failedStageList = getFailedStages(stages);
         if (failedStageList.length > 0) {
           const first = failedStageList[0];

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -281,6 +281,7 @@ export type {
 export { PipelineRunCard, PipelineRunList } from "./components/PipelineRunCard";
 export type { PipelineRunCardProps } from "./components/PipelineRunCard";
 export { PipelineRunDetailPanel } from "./components/PipelineRunDetailPanel";
+export { KgRunDetailPanel } from "./components/KgRunDetailPanel";
 export { PipelineStatusBadge } from "./components/PipelineStatusBadge";
 export { PipelineStagesBar } from "./components/PipelineStagesBar";
 export { DocumentViewDialog } from "./components/DocumentViewDialog";
@@ -314,3 +315,20 @@ export {
   calculateStageWidth,
   getSortedStages,
 } from "./utils/pipeline-helpers";
+
+// ============================================================================
+// Utils (Unified Pipeline)
+// ============================================================================
+
+export type {
+  UnifiedPipelineRun,
+  KgPipelineRun,
+} from "./utils/unified-pipeline";
+
+export {
+  adaptKgRunToUnified,
+  mergeAndSortRuns,
+  hasActiveRuns,
+  kgPhasesToStages,
+  KG_PHASE_KEYS,
+} from "./utils/unified-pipeline";

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -22,6 +22,7 @@ export const OPERATION_LABELS: Record<string, string> = {
   replace_source: "替换源",
   sync_source: "同步源",
   rebuild_source: "重建源",
+  graph_build: "图谱构建",
 };
 
 /**
@@ -52,6 +53,13 @@ export const STAGE_ORDER = [
   "chunk",
   "embed",
   "persist",
+  // KG 构建阶段
+  "kg_extracting",
+  "kg_resolving",
+  "kg_syncing",
+  "kg_pagerank",
+  "kg_communities",
+  "kg_summaries",
 ];
 
 /**
@@ -73,6 +81,13 @@ export const STAGE_LABELS: Record<string, string> = {
   chunk: "文本分块",
   embed: "向量化",
   persist: "持久化",
+  // KG 构建阶段
+  kg_extracting: "实体抽取",
+  kg_resolving: "实体消解",
+  kg_syncing: "一等公民同步",
+  kg_pagerank: "PageRank 计算",
+  kg_communities: "社区检测",
+  kg_summaries: "社区摘要生成",
 };
 
 /**
@@ -171,6 +186,43 @@ export const STAGE_COLORS: Record<
     completed: "bg-emerald-500",
     failed: "bg-emerald-700",
     skipped: "bg-emerald-300 dark:bg-emerald-600",
+  },
+  // KG 构建阶段颜色（violet/purple 色系区分 KB）
+  kg_extracting: {
+    running: "bg-violet-400",
+    completed: "bg-violet-500",
+    failed: "bg-violet-700",
+    skipped: "bg-violet-300 dark:bg-violet-600",
+  },
+  kg_resolving: {
+    running: "bg-purple-400",
+    completed: "bg-purple-500",
+    failed: "bg-purple-700",
+    skipped: "bg-purple-300 dark:bg-purple-600",
+  },
+  kg_syncing: {
+    running: "bg-fuchsia-400",
+    completed: "bg-fuchsia-500",
+    failed: "bg-fuchsia-700",
+    skipped: "bg-fuchsia-300 dark:bg-fuchsia-600",
+  },
+  kg_pagerank: {
+    running: "bg-indigo-400",
+    completed: "bg-indigo-500",
+    failed: "bg-indigo-700",
+    skipped: "bg-indigo-300 dark:bg-indigo-600",
+  },
+  kg_communities: {
+    running: "bg-blue-400",
+    completed: "bg-blue-500",
+    failed: "bg-blue-700",
+    skipped: "bg-blue-300 dark:bg-blue-600",
+  },
+  kg_summaries: {
+    running: "bg-cyan-400",
+    completed: "bg-cyan-500",
+    failed: "bg-cyan-700",
+    skipped: "bg-cyan-300 dark:bg-cyan-600",
   },
 };
 

--- a/apps/negentropy-ui/features/knowledge/utils/unified-pipeline.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/unified-pipeline.ts
@@ -1,0 +1,255 @@
+/**
+ * 统一管线运行类型与适配器
+ *
+ * 将 KB PipelineRunRecord 与 KG GraphBuildRunRecord 统一为 UnifiedPipelineRun，
+ * 使 Dashboard 能以单一列表展示两类运行记录。
+ *
+ * 遵循 AGENTS.md：
+ * - Reuse-Driven: KG phase 映射为 PipelineStageResult 复用 PipelineStagesBar
+ * - Orthogonal Decomposition: source 字段区分类型，组件按 source 分支渲染
+ */
+
+import type {
+  PipelineRunRecord,
+  PipelineStageResult,
+  GraphBuildRunRecord,
+} from "./knowledge-api";
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/** 统一管线运行记录（discriminated union） */
+export type UnifiedPipelineRun =
+  | ({ source: "kb" } & PipelineRunRecord)
+  | KgPipelineRun;
+
+/** KG 管线运行记录 */
+export interface KgPipelineRun {
+  source: "kg";
+  id: string;
+  run_id: string;
+  status: string;
+  started_at?: string;
+  completed_at?: string;
+  duration_ms?: number;
+  version?: number;
+  corpus_id: string;
+  progress_percent?: number;
+  entity_count: number;
+  relation_count: number;
+  model_name?: string;
+  error_message?: string;
+  extractor_config?: Record<string, unknown>;
+  warnings?: Record<string, unknown>[];
+  /** 从 KG phase 映射的合成 stages */
+  stages?: Record<string, PipelineStageResult>;
+}
+
+// ============================================================================
+// KG Phase 常量
+// ============================================================================
+
+/** KG phase key 前缀，与 pipeline-helpers.ts 中 STAGE_ORDER 的 kg_* 条目对应 */
+export const KG_PHASE_KEYS = [
+  "kg_extracting",
+  "kg_resolving",
+  "kg_syncing",
+  "kg_pagerank",
+  "kg_communities",
+  "kg_summaries",
+] as const;
+
+/** KG phase 进度区间边界（左闭右开） */
+const KG_PHASE_BOUNDARIES = [
+  { key: "kg_extracting", start: 0.0, end: 0.80 },
+  { key: "kg_resolving", start: 0.80, end: 0.85 },
+  { key: "kg_syncing", start: 0.85, end: 0.90 },
+  { key: "kg_pagerank", start: 0.90, end: 0.93 },
+  { key: "kg_communities", start: 0.93, end: 0.96 },
+  { key: "kg_summaries", start: 0.96, end: 1.00 },
+] as const;
+
+// ============================================================================
+// Phase → Stage 映射
+// ============================================================================
+
+/**
+ * 从 warnings 中提取当前 _phase 名称
+ *
+ * KG service 通过 emit_phase 将阶段元数据写入 warnings JSONB 的 _phase 条目。
+ */
+function extractCurrentPhase(
+  warnings?: Record<string, unknown>[],
+): string | null {
+  if (!warnings || !warnings.length) return null;
+
+  // 从后往前找最后一条 _phase 条目
+  for (let i = warnings.length - 1; i >= 0; i--) {
+    const entry = warnings[i];
+    if (entry && "_phase" in entry) {
+      const phase = entry._phase;
+      if (typeof phase === "object" && phase !== null && "name" in phase) {
+        return (phase as { name: string }).name;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * 根据 KG phase 名称获取对应的 stage key
+ */
+function phaseNameToKey(phaseName: string): string | null {
+  const mapping: Record<string, string | null> = {
+    extracting: "kg_extracting",
+    resolving: "kg_resolving",
+    syncing: "kg_syncing",
+    pagerank: "kg_pagerank",
+    communities: "kg_communities",
+    summaries: "kg_summaries",
+    completed: null,
+  };
+  return mapping[phaseName] ?? null;
+}
+
+/**
+ * 将 KG 的 progress_percent + warnings 映射为 PipelineStageResult 字典
+ *
+ * 映射规则：
+ * - 已完成 run → 全部 phase completed
+ * - 失败 run → 从 warnings._phase 或 progress 推断失败位置
+ * - 运行中 run → 已过 phase completed，当前 running，之后 pending
+ */
+export function kgPhasesToStages(
+  status: string,
+  progressPercent?: number,
+  warnings?: Record<string, unknown>[],
+): Record<string, PipelineStageResult> {
+  const stages: Record<string, PipelineStageResult> = {};
+  const lowerStatus = status?.toLowerCase();
+  const currentPhaseName = extractCurrentPhase(warnings);
+  const currentPhaseKey = currentPhaseName ? phaseNameToKey(currentPhaseName) : null;
+
+  // 确定 currentPhaseIndex
+  let currentIdx = -1;
+  if (currentPhaseKey) {
+    currentIdx = KG_PHASE_KEYS.indexOf(currentPhaseKey as typeof KG_PHASE_KEYS[number]);
+  }
+  // fallback: 从 progress_percent 推断
+  if (currentIdx === -1 && progressPercent != null && progressPercent > 0) {
+    for (let i = KG_PHASE_BOUNDARIES.length - 1; i >= 0; i--) {
+      if (progressPercent >= KG_PHASE_BOUNDARIES[i].start) {
+        currentIdx = i;
+        break;
+      }
+    }
+  }
+
+  for (let i = 0; i < KG_PHASE_BOUNDARIES.length; i++) {
+    const { key } = KG_PHASE_BOUNDARIES[i];
+
+    if (lowerStatus === "completed") {
+      stages[key] = { status: "completed" };
+    } else if (lowerStatus === "failed") {
+      if (currentIdx >= 0 && i < currentIdx) {
+        stages[key] = { status: "completed" };
+      } else if (i === currentIdx) {
+        stages[key] = { status: "failed" };
+      } else {
+        stages[key] = { status: "skipped", reason: "前置阶段失败" };
+      }
+    } else {
+      // running / pending / 其他
+      if (currentIdx >= 0 && i < currentIdx) {
+        stages[key] = { status: "completed" };
+      } else if (i === currentIdx) {
+        stages[key] = { status: "running" };
+      } else {
+        stages[key] = { status: "pending" };
+      }
+    }
+  }
+
+  return stages;
+}
+
+// ============================================================================
+// 适配器
+// ============================================================================
+
+function computeDurationMs(startedAt?: string, completedAt?: string): number | undefined {
+  if (!startedAt) return undefined;
+  const start = new Date(startedAt).getTime();
+  if (Number.isNaN(start)) return undefined;
+  const end = completedAt ? new Date(completedAt).getTime() : Date.now();
+  if (Number.isNaN(end)) return undefined;
+  return end - start;
+}
+
+/**
+ * 将 KG GraphBuildRunRecord 适配为 UnifiedPipelineRun
+ */
+export function adaptKgRunToUnified(
+  kgRun: GraphBuildRunRecord,
+  corpusId: string,
+): KgPipelineRun {
+  const durationMs = computeDurationMs(kgRun.started_at, kgRun.completed_at);
+
+  return {
+    source: "kg",
+    id: kgRun.id,
+    run_id: kgRun.run_id,
+    status: kgRun.status,
+    started_at: kgRun.started_at,
+    completed_at: kgRun.completed_at,
+    duration_ms: durationMs,
+    version: 0,
+    corpus_id: corpusId,
+    progress_percent: kgRun.progress_percent,
+    entity_count: kgRun.entity_count,
+    relation_count: kgRun.relation_count,
+    model_name: kgRun.model_name,
+    error_message: kgRun.error_message,
+    extractor_config: kgRun.extractor_config,
+    warnings: kgRun.warnings,
+    stages: kgPhasesToStages(kgRun.status, kgRun.progress_percent, kgRun.warnings as Record<string, unknown>[] | undefined),
+  };
+}
+
+// ============================================================================
+// 合并与排序
+// ============================================================================
+
+/**
+ * 合并 KB 与 KG 运行记录并按 started_at 降序排序
+ */
+export function mergeAndSortRuns(
+  kbRuns: PipelineRunRecord[],
+  kgRuns: KgPipelineRun[],
+): UnifiedPipelineRun[] {
+  const kbUnified: UnifiedPipelineRun[] = kbRuns.map((r) => ({
+    source: "kb" as const,
+    ...r,
+  }));
+
+  const all = [...kbUnified, ...kgRuns];
+
+  all.sort((a, b) => {
+    const ta = a.started_at ? new Date(a.started_at).getTime() : 0;
+    const tb = b.started_at ? new Date(b.started_at).getTime() : 0;
+    return tb - ta;
+  });
+
+  return all;
+}
+
+/**
+ * 检测运行中（KB 或 KG）的 run
+ */
+export function hasActiveRuns(runs: UnifiedPipelineRun[]): boolean {
+  return runs.some((run) => {
+    const status = run.status?.toLowerCase();
+    return status === "running" || status === "in_progress" || status === "pending";
+  });
+}

--- a/apps/negentropy-ui/tests/helpers/knowledge.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge.ts
@@ -30,6 +30,14 @@ import { PipelineRunCard, PipelineRunList } from "@/features/knowledge/component
 import { PipelineRunDetailPanel } from "@/features/knowledge/components/PipelineRunDetailPanel";
 import { PipelineStatusBadge } from "@/features/knowledge/components/PipelineStatusBadge";
 import { PipelineStagesBar } from "@/features/knowledge/components/PipelineStagesBar";
+import { KgRunDetailPanel } from "@/features/knowledge/components/KgRunDetailPanel";
+import {
+  adaptKgRunToUnified,
+  mergeAndSortRuns,
+  hasActiveRuns,
+  kgPhasesToStages,
+  KG_PHASE_KEYS,
+} from "@/features/knowledge/utils/unified-pipeline";
 
 type VitestMock = Mock<(...args: unknown[]) => unknown>;
 
@@ -44,6 +52,8 @@ export interface KnowledgeFeatureMockSet {
   deleteCorpusMock: VitestMock;
   fetchPipelinesMock: VitestMock;
   upsertPipelinesMock: VitestMock;
+  fetchCorporaMock: VitestMock;
+  fetchGraphBuildHistoryMock: VitestMock;
   fetchDocumentsMock: VitestMock;
   fetchDocumentChunksMock: VitestMock;
   fetchDocumentChunkDetailMock: VitestMock;
@@ -77,6 +87,8 @@ export function createKnowledgeFeatureMockSet(): KnowledgeFeatureMockSet {
     deleteCorpusMock: vi.fn(),
     fetchPipelinesMock: vi.fn(),
     upsertPipelinesMock: vi.fn(),
+    fetchCorporaMock: vi.fn(),
+    fetchGraphBuildHistoryMock: vi.fn(),
     fetchDocumentsMock: vi.fn(),
     fetchDocumentChunksMock: vi.fn(),
     fetchDocumentChunkDetailMock: vi.fn(),
@@ -152,6 +164,12 @@ export function createKnowledgeConfigTestExports() {
     PipelineRunDetailPanel,
     PipelineStatusBadge,
     PipelineStagesBar,
+    KgRunDetailPanel,
+    adaptKgRunToUnified,
+    mergeAndSortRuns,
+    hasActiveRuns,
+    kgPhasesToStages,
+    KG_PHASE_KEYS,
   };
 }
 
@@ -172,6 +190,8 @@ export function createKnowledgeFeatureTestHarness(
       deleteCorpus: (...args: unknown[]) => mocks.deleteCorpusMock(...args),
       fetchPipelines: (...args: unknown[]) => mocks.fetchPipelinesMock(...args),
       upsertPipelines: (...args: unknown[]) => mocks.upsertPipelinesMock(...args),
+      fetchCorpora: (...args: unknown[]) => mocks.fetchCorporaMock(...args),
+      fetchGraphBuildHistory: (...args: unknown[]) => mocks.fetchGraphBuildHistoryMock(...args),
       fetchDocuments: (...args: unknown[]) => mocks.fetchDocumentsMock(...args),
       fetchDocumentChunks: (...args: unknown[]) => mocks.fetchDocumentChunksMock(...args),
       fetchDocumentChunkDetail: (...args: unknown[]) => mocks.fetchDocumentChunkDetailMock(...args),

--- a/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
@@ -62,6 +62,8 @@ const makeRun = (
 /** 设置默认 mock：fetchDashboard 返回基础数据，fetchPipelines 由调用方指定 */
 function primeDashboardMock() {
   knowledgeMocks.fetchDashboardMock.mockResolvedValue(DEFAULT_DASHBOARD);
+  knowledgeMocks.fetchCorporaMock.mockResolvedValue([]);
+  knowledgeMocks.fetchGraphBuildHistoryMock.mockRejectedValue(new Error("not configured"));
 }
 
 describe("KnowledgeDashboardPage polling", () => {


### PR DESCRIPTION
## Summary

- 将 Knowledge Graph 构建运行记录纳入 Knowledge Dashboard 的 Pipeline Runs 统一管理
- 新建 `UnifiedPipelineRun` 统一类型，将 KB 和 KG 运行记录合并为单一列表按时间排序展示
- KG 的 6 个构建阶段（实体抽取→实体消解→同步→PageRank→社区检测→社区摘要）映射为 `PipelineStageResult`，复用 `PipelineStagesBar` 进度条组件
- 新建 `KgRunDetailPanel` KG 专属详情面板，展示模型名称、实体/关系统计、阶段进度、抽取配置、错误信息
- Dashboard 按来源类型条件渲染详情面板（KB → PipelineRunDetailPanel，KG → KgRunDetailPanel）

## 变更文件

| 类型 | 文件 | 说明 |
|------|------|------|
| 新建 | `unified-pipeline.ts` | UnifiedPipelineRun 类型、KG phase→Stage 映射、合并排序工具 |
| 新建 | `KgRunDetailPanel.tsx` | KG 专属详情面板 |
| 修改 | `pipeline-helpers.ts` | 追加 KG phase 常量（STAGE_ORDER/LABELS/COLORS）+ graph_build 操作标签 |
| 修改 | `PipelineRunCard.tsx` | 扩展 Props 支持 KG 字段，按 source 分支渲染 |
| 修改 | `dashboard/page.tsx` | 并行获取 corpora + KG histories，合并为统一列表 |
| 修改 | `index.ts` | 导出新模块 |

## Test plan

- [ ] 启动 dev server，进入 `/knowledge/dashboard`，验证 KB pipeline runs 正常显示（回归）
- [ ] 在 Graph 页面触发一次 KG 构建，回到 Dashboard 确认 KG run 出现在列表中
- [ ] 验证 KG run 的阶段进度条正确渲染 6 个 phase
- [ ] 选中 KG run，验证详情面板展示模型、实体/关系数、阶段详情
- [ ] 验证 running 状态下轮询正常刷新进度
- [ ] 验证失败状态的错误信息展示
- [ ] 验证分页功能正常（KB + KG 合并后的分页）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)