### PR TITLE
fix(knowledge-graph): 修复 KG 构建连接池泄漏、Session 泄漏与 Token 截断低效

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -24,7 +24,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from negentropy.engine.utils.token_counter import TokenCounter
+import tiktoken
+
 from negentropy.logging import get_logger
 
 if TYPE_CHECKING:
@@ -33,6 +34,16 @@ if TYPE_CHECKING:
 from ..types import GraphEdge, GraphNode, KgEntityType, KgRelationType
 
 logger = get_logger("negentropy.knowledge.llm_extractors")
+
+_DEFAULT_ENCODING = "cl100k_base"
+_encoding_cache: tiktoken.Encoding | None = None
+
+
+def _get_tiktoken_encoding() -> tiktoken.Encoding:
+    global _encoding_cache
+    if _encoding_cache is None:
+        _encoding_cache = tiktoken.get_encoding(_DEFAULT_ENCODING)
+    return _encoding_cache
 
 
 def _truncate_to_token_limit(text: str, max_tokens: int = 3500) -> str:
@@ -43,7 +54,7 @@ def _truncate_to_token_limit(text: str, max_tokens: int = 3500) -> str:
     - CJK ~2 chars/token → 4000 chars ≈ 2000 tokens（仍有溢出风险）
     Token 截断确保上下文利用率最优且不超限。
     """
-    encoding = TokenCounter._get_encoding()
+    encoding = _get_tiktoken_encoding()
     tokens = encoding.encode(text)
     if len(tokens) <= max_tokens:
         return text

--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from negentropy.engine.utils.token_counter import TokenCounter
 from negentropy.logging import get_logger
 
 if TYPE_CHECKING:
@@ -32,6 +33,21 @@ if TYPE_CHECKING:
 from ..types import GraphEdge, GraphNode, KgEntityType, KgRelationType
 
 logger = get_logger("negentropy.knowledge.llm_extractors")
+
+
+def _truncate_to_token_limit(text: str, max_tokens: int = 3500) -> str:
+    """基于 BPE token 计数的截断（替代字符截断 text[:4000]）。
+
+    字符截断的问题：
+    - 英文 ~4 chars/token → 4000 chars ≈ 1000 tokens（远低于模型限制）
+    - CJK ~2 chars/token → 4000 chars ≈ 2000 tokens（仍有溢出风险）
+    Token 截断确保上下文利用率最优且不超限。
+    """
+    encoding = TokenCounter._get_encoding()
+    tokens = encoding.encode(text)
+    if len(tokens) <= max_tokens:
+        return text
+    return encoding.decode(tokens[:max_tokens])
 
 
 # Backward compatibility aliases (deprecated: use KgEntityType/KgRelationType from types.py)
@@ -289,8 +305,8 @@ Output as JSON with the following structure:
         """
         import litellm
 
-        # 截断文本以避免 token 限制
-        truncated_text = text[:4000] if len(text) > 4000 else text
+        # Token 感知截断：英文 4000 chars ≈ 1000 token（浪费），CJK 4000 chars ≈ 2000 token（风险）
+        truncated_text = _truncate_to_token_limit(text, max_tokens=3500)
 
         prompt = self.EXTRACTION_PROMPT.format(text=truncated_text)
 
@@ -679,7 +695,7 @@ Output as JSON with the following structure:
         entity_names = entity_names[:50]
 
         # 截断文本
-        truncated_text = text[:4000] if len(text) > 4000 else text
+        truncated_text = _truncate_to_token_limit(text, max_tokens=3500)
 
         prompt = self.EXTRACTION_PROMPT.format(
             entity_names=json.dumps(entity_names, ensure_ascii=False),

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -607,6 +607,11 @@ class AgeGraphRepository(GraphRepository):
 
         写入 kg_relations 一等公民表（SSoT），同时保留 knowledge.metadata JSONB
         作为过渡期兼容。参见 Kleppmann §11 事务内双写模式。
+
+        ON CONFLICT DO UPDATE（而非 DO NOTHING）：唯一约束 (source_id, target_id,
+        relation_type) 命中时必须原地覆盖 evidence/weight/confidence。若使用
+        DO NOTHING，evidence 变更后 INSERT 会被静默丢弃，叠加 TemporalResolver
+        的 expire 流程会导致关系被彻底抹除（既无新行又无有效旧行）。
         """
         import json as _json
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -545,11 +545,36 @@ class AgeGraphRepository(GraphRepository):
         entities: list[GraphNode],
         corpus_id: UUID,
     ) -> list[str]:
-        """批量创建实体节点"""
+        """批量创建实体节点（单 Session 批量提交，消除逐条连接池抖动）"""
+        if not entities:
+            return []
+
+        query = text(f"""
+            UPDATE {self._schema}.knowledge
+            SET entity_type = :entity_type,
+                entity_confidence = :confidence,
+                metadata = COALESCE(metadata, '{{}}'::jsonb) || :metadata::jsonb
+            WHERE id = :entity_id
+        """)
+
         ids = []
+        params_list = []
         for entity in entities:
-            entity_id = await self.create_entity(entity, corpus_id)
-            ids.append(entity_id)
+            confidence = entity.metadata.get("confidence", 1.0)
+            params_list.append(
+                {
+                    "entity_id": entity.id.replace("entity:", ""),
+                    "entity_type": entity.node_type,
+                    "confidence": confidence,
+                    "metadata": str({"graph_label": entity.label}),
+                }
+            )
+            ids.append(entity.id)
+
+        async with self._session_scope() as session:
+            for params in params_list:
+                await session.execute(query, params)
+            await session.commit()
 
         logger.info(
             "entities_created_batch",
@@ -565,7 +590,20 @@ class AgeGraphRepository(GraphRepository):
         target_id: str,
         relation: GraphEdge,
     ) -> str:
-        """创建关系边
+        """创建单条关系边（委托给 _create_relation_with_session）"""
+        async with self._session_scope() as session:
+            rid = await self._create_relation_with_session(session, source_id, target_id, relation)
+            await session.commit()
+            return rid
+
+    async def _create_relation_with_session(
+        self,
+        session: AsyncSession,
+        source_id: str,
+        target_id: str,
+        relation: GraphEdge,
+    ) -> str:
+        """在给定 Session 上创建关系边（批量场景复用同一 Session）
 
         写入 kg_relations 一等公民表（SSoT），同时保留 knowledge.metadata JSONB
         作为过渡期兼容。参见 Kleppmann §11 事务内双写模式。
@@ -577,10 +615,6 @@ class AgeGraphRepository(GraphRepository):
         confidence = relation.metadata.get("confidence", 1.0)
         evidence = relation.metadata.get("evidence")
 
-        # 1. 写入 kg_relations 一等公民表
-        # 唯一约束 (source_id, target_id, relation_type) 命中时使用 DO UPDATE，
-        # 而非 DO NOTHING：否则 evidence 变更后 INSERT 被静默丢弃，再叠加
-        # TemporalResolver 的 expire 流程会导致关系被彻底抹除（既无新行又无有效旧行）。
         insert_query = text(f"""
             INSERT INTO {self._schema}.kg_relations
                 (source_id, target_id, corpus_id, app_name, relation_type,
@@ -613,46 +647,43 @@ class AgeGraphRepository(GraphRepository):
             WHERE id = :source_id
         """)
 
-        async with self._session_scope() as session:
-            await session.execute(
-                insert_query,
-                {
-                    "source_id": clean_source,
-                    "target_id": clean_target,
-                    "relation_type": relation.edge_type or "RELATED_TO",
-                    "weight": relation.weight or 1.0,
-                    "confidence": confidence,
-                    "evidence": evidence,
-                    "metadata": _json.dumps(relation.metadata or {}),
-                },
-            )
-
-            # 2. 过渡期：同时写入 JSONB（兼容旧读取路径）
-            relation_data = {
+        await session.execute(
+            insert_query,
+            {
+                "source_id": clean_source,
                 "target_id": clean_target,
-                "relation_type": relation.edge_type,
+                "relation_type": relation.edge_type or "RELATED_TO",
+                "weight": relation.weight or 1.0,
                 "confidence": confidence,
                 "evidence": evidence,
-            }
+                "metadata": _json.dumps(relation.metadata or {}),
+            },
+        )
 
-            result = await session.execute(select_query, {"source_id": clean_source})
-            row = result.fetchone()
+        # 过渡期：同时写入 JSONB（兼容旧读取路径）
+        relation_data = {
+            "target_id": clean_target,
+            "relation_type": relation.edge_type,
+            "confidence": confidence,
+            "evidence": evidence,
+        }
 
-            related_entities = []
-            if row and row.related:
-                related_entities = _json.loads(row.related) if isinstance(row.related, str) else row.related
+        result = await session.execute(select_query, {"source_id": clean_source})
+        row = result.fetchone()
 
-            related_entities.append(relation_data)
+        related_entities = []
+        if row and row.related:
+            related_entities = _json.loads(row.related) if isinstance(row.related, str) else row.related
 
-            await session.execute(
-                update_query,
-                {
-                    "source_id": clean_source,
-                    "related": _json.dumps(related_entities),
-                },
-            )
+        related_entities.append(relation_data)
 
-            await session.commit()
+        await session.execute(
+            update_query,
+            {
+                "source_id": clean_source,
+                "related": _json.dumps(related_entities),
+            },
+        )
 
         relation_id = f"relation:{source_id}:{target_id}:{relation.edge_type}"
 
@@ -670,15 +701,21 @@ class AgeGraphRepository(GraphRepository):
         self,
         relations: list[GraphEdge],
     ) -> list[str]:
-        """批量创建关系边"""
+        """批量创建关系边（单 Session 批量提交，消除逐条连接池抖动）"""
+        if not relations:
+            return []
+
         ids = []
-        for relation in relations:
-            relation_id = await self.create_relation(
-                relation.source,
-                relation.target,
-                relation,
-            )
-            ids.append(relation_id)
+        async with self._session_scope() as session:
+            for relation in relations:
+                rid = await self._create_relation_with_session(
+                    session,
+                    relation.source,
+                    relation.target,
+                    relation,
+                )
+                ids.append(rid)
+            await session.commit()
 
         logger.info("relations_created_batch", count=len(ids))
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -278,7 +278,7 @@ class GraphService:
             chunk_count=len(chunks),
         )
 
-        # 创建构建运行记录
+        # 创建构建运行记录（构建前元数据写入，使用默认 self._repository）
         run_uuid = await self._repository.create_build_run(
             app_name=app_name,
             corpus_id=corpus_id,
@@ -298,12 +298,23 @@ class GraphService:
         # 这两个变量也已绑定，except 不会触发 UnboundLocalError。
         build_warnings: list[dict[str, Any]] = []
         build_metrics: KgBuildMetrics | None = None
+        shared_session: AsyncSession | None = None
 
         try:
+            # 共享 Session：全构建生命周期复用单一 DB 连接，消除 ~2000 次 Session 创建/销毁抖动。
+            # Repository 的 _session_scope 注入模式（yield self._session + return）不接管生命周期，
+            # 每个 commit 仍正常提交事务，但底层 TCP 连接不被释放回连接池，直到 build_graph 结束。
+            from negentropy.db.session import AsyncSessionLocal
+
+            from .repository import AgeGraphRepository
+
+            shared_session = AsyncSessionLocal()
+            build_repo = AgeGraphRepository(session=shared_session)
+
             # 增量构建：跳过已处理的 chunk (Hogan et al., 2021 §6.3; Graphiti, 2025)
             prev_processed: set[str] = set()
             if build_config.incremental:
-                prev_processed = await self._repository.get_processed_chunk_ids(corpus_id, app_name)
+                prev_processed = await build_repo.get_processed_chunk_ids(corpus_id, app_name)
                 original_count = len(chunks)
                 chunks = [c for c in chunks if c.get("id") and str(c["id"]) not in prev_processed]
                 logger.info(
@@ -320,7 +331,7 @@ class GraphService:
                     )
             else:
                 # 全量构建：清除旧图谱数据
-                await self._repository.clear_graph(corpus_id)
+                await build_repo.clear_graph(corpus_id)
 
             # 分批处理
             all_entities: list[GraphNode] = []
@@ -365,7 +376,7 @@ class GraphService:
                     **extra,
                 )
                 try:
-                    await self._repository.update_build_run(
+                    await build_repo.update_build_run(
                         run_id=run_uuid,
                         status="running",
                         progress_percent=progress,
@@ -403,7 +414,7 @@ class GraphService:
                     progress_state["last_reported_chunks"] = chunks_processed
                     progress = min(chunks_processed / total_chunks, 1.0) * 0.80 if total_chunks > 0 else 0.80
                     try:
-                        await self._repository.update_build_run(
+                        await build_repo.update_build_run(
                             run_id=run_uuid,
                             status="running",
                             progress_percent=progress,
@@ -499,6 +510,18 @@ class GraphService:
                 # 节流上报（每 5 chunk 或 ≥10s）：避免 SSE 静默期超过 30s
                 await maybe_report_chunk_progress()
 
+            # 回收 litellm 内部 HTTP Session（aiohttp.ClientSession）
+            # litellm.acompletion 每次调用可能创建内部 Session 对象，
+            # 依赖 Python GC 延迟回收会产生 "Unclosed client session" 警告。
+            # 显式 gc.collect() 在 chunk 循环结束后及时回收。
+            import gc
+
+            gc.collect()
+            logger.info(
+                "chunk_extraction_gc_completed",
+                run_id=run_id,
+            )
+
             # 阶段 2：实体消解（多策略，Fellegi & Sunter, 1969）
             await emit_phase(
                 PHASE_RESOLVING,
@@ -519,12 +542,12 @@ class GraphService:
             )
             entities_to_save = await resolver.resolve(
                 new_entities=all_entities,
-                find_similar=self._repository.find_similar_entities,
+                find_similar=build_repo.find_similar_entities,
                 corpus_id=corpus_id,
             )
 
             # 持久化实体
-            await self._repository.create_entities(
+            await build_repo.create_entities(
                 entities_to_save,
                 corpus_id,
             )
@@ -579,14 +602,14 @@ class GraphService:
                 ]
                 temporal_results = await temporal_resolver.resolve_relations(
                     new_relations=relation_dicts_for_temporal,
-                    existing_lookup=self._repository.find_existing_relations,
+                    existing_lookup=build_repo.find_existing_relations,
                     corpus_id=corpus_id,
                 )
                 # 对 UPDATE/CONTRADICTION 的旧关系标记失效（提前到持久化之前）
                 now = datetime.now(UTC)
                 all_expire_ids = list({eid for resolved in temporal_results for eid in resolved.get("expire_ids", [])})
                 if all_expire_ids:
-                    await self._repository.expire_relations(all_expire_ids, now)
+                    await build_repo.expire_relations(all_expire_ids, now)
                 logger.info(
                     "temporal_resolution_completed",
                     relation_count=len(temporal_results),
@@ -600,7 +623,7 @@ class GraphService:
 
             # 持久化关系（依赖 create_relation 的 ON CONFLICT DO UPDATE 语义在 UPDATE 路径
             # 上原地覆盖 evidence，避免唯一约束 + DO NOTHING 造成的数据丢失）
-            await self._repository.create_relations(valid_relations)
+            await build_repo.create_relations(valid_relations)
 
             # 阶段 3：一等公民表双写同步（Kleppmann DDIA §11）
             await emit_phase(
@@ -615,8 +638,6 @@ class GraphService:
             # 双写同步使用独立事务 + 补偿重试：AGE 写入与 first-class 表写入
             # 在不同 session 中，失败时记录不一致以供后续修复
             try:
-                from negentropy.db.session import AsyncSessionLocal
-
                 from .entity_service import KgEntityService
 
                 kg_service = KgEntityService()
@@ -641,20 +662,23 @@ class GraphService:
                     }
                     for r in valid_relations
                 ]
-                async with AsyncSessionLocal() as sync_db:
-                    async with sync_db.begin():
-                        sync_result = await kg_service.batch_sync_from_graph_build(
-                            sync_db,
-                            nodes=node_dicts,
-                            edges=edge_dicts,
-                            corpus_id=corpus_id,
-                            app_name=app_name,
-                        )
+                async with shared_session.begin():
+                    sync_result = await kg_service.batch_sync_from_graph_build(
+                        shared_session,
+                        nodes=node_dicts,
+                        edges=edge_dicts,
+                        corpus_id=corpus_id,
+                        app_name=app_name,
+                    )
                     logger.info(
                         "kg_first_class_sync",
                         **sync_result,
                     )
             except Exception as sync_exc:
+                # shared_session.begin() 失败会自动 rollback，
+                # 但 session 可能处于非活动事务状态，显式清理确保后续阶段可用。
+                if shared_session.in_transaction():
+                    await shared_session.rollback()
                 build_warnings.append(
                     {
                         "phase": "first_class_sync",
@@ -673,16 +697,13 @@ class GraphService:
 
             # 计算 PageRank 实体重要性 (Brin & Page, 1998)
             try:
-                from negentropy.db.session import AsyncSessionLocal
-
                 from .graph_algorithms import compute_pagerank
 
-                async with AsyncSessionLocal() as pr_db:
-                    pr_result = await compute_pagerank(pr_db, corpus_id)
-                    logger.info(
-                        "pagerank_computed",
-                        entity_count=len(pr_result),
-                    )
+                pr_result = await compute_pagerank(shared_session, corpus_id)
+                logger.info(
+                    "pagerank_computed",
+                    entity_count=len(pr_result),
+                )
             except Exception as pr_exc:
                 build_warnings.append({"algorithm": "pagerank", "error": str(pr_exc)})
                 logger.warning(
@@ -697,20 +718,17 @@ class GraphService:
             # 优先使用 Leiden（保证社区内部连通性），降级到 Louvain
             levels_data: dict[int, dict[str, int]] = {}
             try:
-                from negentropy.db.session import AsyncSessionLocal
-
                 from .graph_algorithms import compute_communities
 
-                async with AsyncSessionLocal() as cm_db:
-                    levels_data = await compute_communities(cm_db, corpus_id)
-                    total_entities = sum(len(p) for p in levels_data.values())
-                    total_communities = sum(len(set(p.values())) for p in levels_data.values())
-                    logger.info(
-                        "communities_computed",
-                        levels=len(levels_data),
-                        entity_count=total_entities,
-                        community_count=total_communities,
-                    )
+                levels_data = await compute_communities(shared_session, corpus_id)
+                total_entities = sum(len(p) for p in levels_data.values())
+                total_communities = sum(len(set(p.values())) for p in levels_data.values())
+                logger.info(
+                    "communities_computed",
+                    levels=len(levels_data),
+                    entity_count=total_entities,
+                    community_count=total_communities,
+                )
             except Exception as cm_exc:
                 build_warnings.append({"algorithm": "community_detection", "error": str(cm_exc)})
                 logger.warning(
@@ -723,8 +741,6 @@ class GraphService:
 
             # B3: 社区摘要生成 (Edge et al., Microsoft GraphRAG, 2024)
             try:
-                from negentropy.db.session import AsyncSessionLocal
-
                 from ..ingestion.embedding import build_embedding_fn
                 from .community_summarizer import CommunitySummarizer
 
@@ -745,9 +761,9 @@ class GraphService:
                     model=normalized_llm_model,
                     embedding_fn=cs_embedding_fn,
                 )
-                async with AsyncSessionLocal() as cs_db:
+                async with shared_session.begin():
                     cs_result = await summarizer.summarize_communities(
-                        cs_db,
+                        shared_session,
                         corpus_id,
                         levels_data=levels_data if levels_data else None,
                     )
@@ -756,6 +772,8 @@ class GraphService:
                         **cs_result,
                     )
             except Exception as cs_exc:
+                if shared_session.in_transaction():
+                    await shared_session.rollback()
                 build_warnings.append({"algorithm": "community_summary", "error": str(cs_exc)})
                 logger.warning(
                     "community_summary_failed",
@@ -800,7 +818,7 @@ class GraphService:
             # 落入终态 warnings 会污染历史检视（与 _metrics 同型 sentinel 区分）。
             persisted_warnings: list[dict[str, Any]] = _strip_phase_entries(build_warnings)
             persisted_warnings.append({"_metrics": build_metrics.to_dict()})
-            await self._repository.update_build_run(
+            await build_repo.update_build_run(
                 run_id=run_uuid,
                 status="completed",
                 entity_count=len(entities_to_save),
@@ -853,13 +871,23 @@ class GraphService:
             if build_metrics is not None:
                 failure_warnings.append({"_metrics": build_metrics.to_dict()})
 
-            # 更新构建运行状态
-            await self._repository.update_build_run(
-                run_id=run_uuid,
-                status="failed",
-                error_message=error_message,
-                warnings=failure_warnings if failure_warnings else None,
-            )
+            # 更新构建运行状态（回退到独立 Session，避免共享 Session 已损坏导致二次失败）
+            try:
+                if shared_session is not None and not shared_session.is_active:
+                    raise RuntimeError("shared session inactive")
+                await build_repo.update_build_run(
+                    run_id=run_uuid,
+                    status="failed",
+                    error_message=error_message,
+                    warnings=failure_warnings if failure_warnings else None,
+                )
+            except Exception:
+                await self._repository.update_build_run(
+                    run_id=run_uuid,
+                    status="failed",
+                    error_message=error_message,
+                    warnings=failure_warnings if failure_warnings else None,
+                )
 
             return GraphBuildResult(
                 run_id=run_id,
@@ -871,6 +899,11 @@ class GraphService:
                 elapsed_seconds=elapsed,
                 error_message=error_message,
             )
+
+        finally:
+            # 确保共享 Session 被关闭（归还连接到池）
+            if shared_session is not None:
+                await shared_session.close()
 
     async def search(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -705,6 +705,8 @@ class GraphService:
                     entity_count=len(pr_result),
                 )
             except Exception as pr_exc:
+                if shared_session.in_transaction():
+                    await shared_session.rollback()
                 build_warnings.append({"algorithm": "pagerank", "error": str(pr_exc)})
                 logger.warning(
                     "pagerank_computation_failed",
@@ -730,6 +732,8 @@ class GraphService:
                     community_count=total_communities,
                 )
             except Exception as cm_exc:
+                if shared_session.in_transaction():
+                    await shared_session.rollback()
                 build_warnings.append({"algorithm": "community_detection", "error": str(cm_exc)})
                 logger.warning(
                     "community_detection_failed",

--- a/apps/negentropy/tests/unit_tests/knowledge/test_graph_repository.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_graph_repository.py
@@ -94,18 +94,20 @@ class TestAgeGraphRepository:
 
     @pytest.mark.asyncio
     async def test_create_entities_batch(self, repository, mock_session, sample_entity):
-        """create_entities 应批量创建实体"""
+        """create_entities 应批量创建实体（单 Session 批量提交）"""
         entities = [
             sample_entity,
             GraphNode(id="entity:second", label="Second", node_type="person"),
         ]
 
-        with patch.object(repository, "create_entity") as mock_create:
-            mock_create.return_value = "entity:id"
-            ids = await repository.create_entities(entities, _CORPUS_ID)
+        ids = await repository.create_entities(entities, _CORPUS_ID)
 
-            assert len(ids) == 2
-            assert mock_create.call_count == 2
+        assert len(ids) == 2
+        assert ids[0] == sample_entity.id
+        assert ids[1] == "entity:second"
+        # 批量提交：每个 entity 一次 execute，最后一次 commit
+        assert mock_session.execute.call_count == 2
+        mock_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_relation_stores_in_metadata(self, repository, mock_session, sample_edge):

--- a/apps/negentropy/tests/unit_tests/knowledge/test_graph_service.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_graph_service.py
@@ -385,16 +385,49 @@ class FakeGraphRepository:
         return []
 
 
+def _build_graph_patches(repository):
+    """为 build_graph 测试创建共享 Session mock + AgeGraphRepository mock。
+
+    build_graph 内部通过 AsyncSessionLocal() 创建共享 Session、再构造
+    AgeGraphRepository(session=shared_session) 作为 build_repo——绕过注入的 fake。
+    本 helper 将两者 mock 为使用注入的 fake repository，使单元测试无需真实 DB。
+    """
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    return (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    )
+
+
+def _patch_build_graph(repository):
+    """返回用于 with 语句的 patch 上下文管理器。"""
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    return patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session), patch(
+        "negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository
+    )
+
+
 @pytest.mark.asyncio
 async def test_build_graph_persists_canonical_model_name():
     repository = FakeGraphRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig(llm_model="openai/gpt-5-mini"))
 
-    result = await service.build_graph(
-        corpus_id=uuid4(),
-        app_name="test-app",
-        chunks=[],
-    )
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    with (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    ):
+        result = await service.build_graph(
+            corpus_id=uuid4(),
+            app_name="test-app",
+            chunks=[],
+        )
 
     assert result.status == "completed"
     assert repository.create_build_run_kwargs["model_name"] == "openai/gpt-5-mini"
@@ -461,11 +494,18 @@ async def test_build_graph_emits_phase_milestones_in_order():
     repository = PhaseTrackingFakeRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig(llm_model="openai/gpt-5-mini"))
 
-    result = await service.build_graph(
-        corpus_id=uuid4(),
-        app_name="test-app",
-        chunks=[],  # 空 chunk：跳过实体抽取与持久化阶段，但所有 emit_phase 仍应触发
-    )
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    with (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    ):
+        result = await service.build_graph(
+            corpus_id=uuid4(),
+            app_name="test-app",
+            chunks=[],  # 空 chunk：跳过实体抽取与持久化阶段，但所有 emit_phase 仍应触发
+        )
 
     assert result.status == "completed"
 
@@ -484,7 +524,14 @@ async def test_build_graph_progress_percent_monotonically_increases():
     repository = PhaseTrackingFakeRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    with (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    ):
+        await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     progresses = [
         call["progress_percent"]
@@ -506,7 +553,14 @@ async def test_build_graph_strips_phase_entries_from_terminal_warnings():
     repository = PhaseTrackingFakeRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    with (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    ):
+        await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     # 找到 status=completed 的最后一次 update 调用
     terminal_call = next(
@@ -556,7 +610,14 @@ async def test_build_graph_failure_strips_phase_and_persists_warnings_on_early_e
     repository = _FailingClearGraphRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    with (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    ):
+        result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     assert result.status == "failed"
     failed_call = next(
@@ -584,7 +645,14 @@ async def test_build_graph_failure_preserves_algorithm_warnings():
     repository = _FailingCreateRelationsRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
+    mock_session = AsyncMock()
+    mock_session.in_transaction = MagicMock(return_value=False)
+    mock_session.is_active = True
+    with (
+        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
+        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
+    ):
+        result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     assert result.status == "failed"
     failed_call = next(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_graph_service.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_graph_service.py
@@ -7,6 +7,7 @@ Graph Service 单元测试
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
@@ -385,7 +386,8 @@ class FakeGraphRepository:
         return []
 
 
-def _build_graph_patches(repository):
+@contextmanager
+def _patch_build_graph(repository):
     """为 build_graph 测试创建共享 Session mock + AgeGraphRepository mock。
 
     build_graph 内部通过 AsyncSessionLocal() 创建共享 Session、再构造
@@ -395,20 +397,11 @@ def _build_graph_patches(repository):
     mock_session = AsyncMock()
     mock_session.in_transaction = MagicMock(return_value=False)
     mock_session.is_active = True
-    return (
+    with (
         patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
         patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    )
-
-
-def _patch_build_graph(repository):
-    """返回用于 with 语句的 patch 上下文管理器。"""
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    return patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session), patch(
-        "negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository
-    )
+    ):
+        yield
 
 
 @pytest.mark.asyncio
@@ -416,13 +409,7 @@ async def test_build_graph_persists_canonical_model_name():
     repository = FakeGraphRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig(llm_model="openai/gpt-5-mini"))
 
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    with (
-        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
-        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    ):
+    with _patch_build_graph(repository):
         result = await service.build_graph(
             corpus_id=uuid4(),
             app_name="test-app",
@@ -494,13 +481,7 @@ async def test_build_graph_emits_phase_milestones_in_order():
     repository = PhaseTrackingFakeRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig(llm_model="openai/gpt-5-mini"))
 
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    with (
-        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
-        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    ):
+    with _patch_build_graph(repository):
         result = await service.build_graph(
             corpus_id=uuid4(),
             app_name="test-app",
@@ -524,13 +505,7 @@ async def test_build_graph_progress_percent_monotonically_increases():
     repository = PhaseTrackingFakeRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    with (
-        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
-        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    ):
+    with _patch_build_graph(repository):
         await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     progresses = [
@@ -553,13 +528,7 @@ async def test_build_graph_strips_phase_entries_from_terminal_warnings():
     repository = PhaseTrackingFakeRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    with (
-        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
-        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    ):
+    with _patch_build_graph(repository):
         await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     # 找到 status=completed 的最后一次 update 调用
@@ -610,13 +579,7 @@ async def test_build_graph_failure_strips_phase_and_persists_warnings_on_early_e
     repository = _FailingClearGraphRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    with (
-        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
-        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    ):
+    with _patch_build_graph(repository):
         result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     assert result.status == "failed"
@@ -645,13 +608,7 @@ async def test_build_graph_failure_preserves_algorithm_warnings():
     repository = _FailingCreateRelationsRepository()
     service = GraphService(repository=repository, config=GraphBuildConfig())
 
-    mock_session = AsyncMock()
-    mock_session.in_transaction = MagicMock(return_value=False)
-    mock_session.is_active = True
-    with (
-        patch("negentropy.db.session.AsyncSessionLocal", return_value=mock_session),
-        patch("negentropy.knowledge.graph.repository.AgeGraphRepository", return_value=repository),
-    ):
+    with _patch_build_graph(repository):
         result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=[])
 
     assert result.status == "failed"


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：KG 构建在大批量场景（849+ chunk）下，每个实体/关系的创建、PageRank、社区检测等操作各自创建独立 `AsyncSessionLocal()` 会话，导致连接池抖动、`Unclosed client session` 警告、以及连接耗尽后的构建 hang。同时字符截断 `text[:4000]` 对英文（浪费 token 空间）和 CJK（仍有溢出风险）均不友好。
- 关联上下文/Issue/文档：#477

# 核心变更
- **共享 Session 注入**：`build_graph` 全生命周期复用单一 DB 连接（`shared_session`），Repository 的 `_session_scope()` 注入模式不接管生命周期，每个操作仍独立 commit 事务，但底层 TCP 连接不被释放回连接池，消除 ~2000 次 Session 创建/销毁抖动
- **批量提交重构**：`create_entities` / `create_relations` 重构为单 Session 批量提交，`_create_relation_with_session` 支持外部传入 Session 复用
- **aiohttp Session 回收**：chunk 提取循环后显式 `gc.collect()` 回收 litellm 内部 `aiohttp.ClientSession`
- **Token 感知截断**：`_truncate_to_token_limit` 基于 tiktoken BPE 编码截断至 3500 tokens，替代字符截断 `text[:4000]`，提升英文/CJK 上下文利用率
- **事务回滚保护**：`compute_pagerank` / `compute_communities` / `first_class_sync` / `community_summarizer` 失败后显式 `shared_session.rollback()`，防止 SQLAlchemy autobegin 事务 invalidated 状态导致后续操作 `PendingRollbackError` 级联失败
- **错误回退机制**：构建失败时优先用 `build_repo`（共享 Session）更新状态，Session 已损坏则回退到 `self._repository`（独立 Session）
- **设计决策注释保留**：`_create_relation_with_session` 中 ON CONFLICT DO UPDATE 的 WHY 注释（TemporalResolver expire 会导致关系抹除）

# 风险与回滚
- 主要风险：共享 Session 在极端异常场景下的事务一致性（已通过 rollback 保护 + fallback 回退缓解）
- 回滚方式：`git revert` 即可，无数据库 schema 变更

# 验证证据
- 单元测试：ruff lint/format 通过
- 集成测试：N/A（连接池行为需实际构建验证）
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`knowledge/graph/` 模块（extractors.py / repository.py / service.py）
- GitHub Actions / 文档：无

# Next Best Action
- 在 staging 环境执行一次完整 KG 构建（大批量 chunk），验证连接池指标与构建成功率