### PR TITLE
feat(home-chat): 新增 stream 级 typing indicator 覆盖请求真空期

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -1009,6 +1009,10 @@ export function HomeBody({
               }}
               scrollToBottomTrigger={scrollToBottomTrigger}
               toolProgressMap={toolProgressMap}
+              pending={
+                effectiveConnection === "connecting" ||
+                effectiveConnection === "streaming"
+              }
             />
             <div
               className={`${CHAT_CONTENT_RAIL_CLASS} shrink-0 w-full pt-2 pb-6`}

--- a/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
+++ b/apps/negentropy-ui/components/ui/AssistantReplyBubble.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import type { AssistantReplyDisplayBlock } from "@/types/a2ui";
 import type { ToolCallInfo, ToolProgressMap } from "@/types/common";
 import { MessageBubble, MarkdownContent } from "@/components/ui/MessageBubble";
+import { ChatTypingIndicator } from "@/components/ui/ChatTypingIndicator";
 import { ReasoningPanel, type ReasoningStepData } from "@/components/ui/ReasoningPanel";
 import { ToolExecutionGroup } from "@/components/ui/ToolExecutionGroup";
 import { extractCitationsFromToolCalls } from "@/utils/citation-parser";
@@ -116,15 +117,7 @@ export function AssistantReplyBubble({
         <div className="space-y-3">
           {reasoningSteps.length > 0 ? <ReasoningPanel steps={reasoningSteps} /> : null}
           {showWaitingPlaceholder ? (
-            <div
-              data-testid="agent-waiting-placeholder"
-              className="flex items-center gap-1.5 py-1 text-zinc-400 dark:text-zinc-500"
-              aria-label="Agent 正在思考"
-            >
-              <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
-              <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
-              <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
-            </div>
+            <ChatTypingIndicator variant="inline" ariaLabel="Agent 正在思考" />
           ) : null}
           {block.segments.map((segment) => {
             if (segment.kind === "text") {

--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { AssistantReplyBubble } from "./AssistantReplyBubble";
+import { ChatTypingIndicator } from "./ChatTypingIndicator";
 import { MessageBubble } from "./MessageBubble";
 import { ToolExecutionGroup } from "./ToolExecutionGroup";
 import { CHAT_CONTENT_RAIL_CLASS } from "./chat-layout";
@@ -19,6 +20,15 @@ type ChatStreamProps = {
    * 不参与 conversationTree / message-ledger，规避 ISSUE-031 时间窗双气泡风险。
    */
   toolProgressMap?: ToolProgressMap;
+  /**
+   * Stream 级 typing indicator 触发信号 —— 通常由父级根据
+   * `effectiveConnection ∈ {'connecting','streaming'}` 派生。
+   *
+   * 隐藏规则：当末尾 displayBlock 已是 `assistant-reply` 时（无论是否已有可见内容），
+   * stream 级 indicator 让位给 AssistantReplyBubble 内置 placeholder（同款三点动画），
+   * 实现「请求真空期 → 气泡空 → 首块流入」的无缝接力，避免双 indicator 视觉重复。
+   */
+  pending?: boolean;
 };
 
 export function ChatStream({
@@ -28,6 +38,7 @@ export function ChatStream({
   contentClassName,
   scrollToBottomTrigger,
   toolProgressMap,
+  pending = false,
 }: ChatStreamProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isUserAtBottomRef = useRef(true);
@@ -73,6 +84,14 @@ export function ChatStream({
     }
   }, [scrollToBottomTrigger]);
 
+  // Stream 级 typing indicator 显示判定：
+  // - 父级声明 pending（effectiveConnection ∈ {connecting, streaming}）
+  // - 末尾 displayBlock 不是 assistant-reply（一旦 Assistant 气泡挂载，
+  //   就把展示职责让位给 AssistantReplyBubble 内置 placeholder，避免双 indicator）
+  const lastBlock = displayBlocks[displayBlocks.length - 1];
+  const showStandalonePending =
+    pending && (!lastBlock || lastBlock.kind !== "assistant-reply");
+
   return (
     <div
       ref={scrollRef}
@@ -83,9 +102,15 @@ export function ChatStream({
         className={`${CHAT_CONTENT_RAIL_CLASS} space-y-4 py-6 ${contentClassName ?? ""}`}
       >
         {displayBlocks.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">
-            发送指令开始对话。主区会按正文顺序展示消息，并把工具过程穿插在对应位置。
-          </div>
+          // 罕见路径：极慢首次会话，pending 已 true 但 hydration 尚未到达任何 block。
+          // 此时仍优先显示 indicator，避免「发送指令开始对话」误导文案在用户已发送后出现。
+          pending ? (
+            <ChatTypingIndicator variant="standalone" />
+          ) : (
+            <div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted">
+              发送指令开始对话。主区会按正文顺序展示消息，并把工具过程穿插在对应位置。
+            </div>
+          )
         ) : (
           displayBlocks.map((block) => (
             block.kind === "message" ? (
@@ -168,6 +193,9 @@ export function ChatStream({
             )
           ))
         )}
+        {showStandalonePending && displayBlocks.length > 0 ? (
+          <ChatTypingIndicator variant="standalone" />
+        ) : null}
       </div>
     </div>
   );

--- a/apps/negentropy-ui/components/ui/ChatTypingIndicator.tsx
+++ b/apps/negentropy-ui/components/ui/ChatTypingIndicator.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Chat Typing Indicator —— Agent 等待响应时的三点 bounce 动画
+ *
+ * 双层接力策略：
+ * - `inline` variant：嵌入 AssistantReplyBubble 内部，覆盖「气泡已挂载但 segments
+ *   尚无可见内容」的窗口；保留旧 testid `agent-waiting-placeholder` 兼容既有测试。
+ * - `standalone` variant：嵌入 ChatStream 列表底部，覆盖「请求已发出但 Assistant
+ *   气泡尚未挂载」的网络真空期（实测 100–500ms）。
+ *
+ * a11y：role="status" + aria-live="polite" 让屏幕阅读器以非打断方式播报；
+ * sr-only 文本提供语义兜底；motion-reduce:animate-none 响应 prefers-reduced-motion，
+ * bounce 退化为静态三点（仍可感知 indicator 存在）。
+ */
+export type ChatTypingIndicatorVariant = "inline" | "standalone";
+
+const TEST_IDS: Record<ChatTypingIndicatorVariant, string> = {
+  inline: "agent-waiting-placeholder",
+  standalone: "chat-pending-indicator",
+};
+
+export function ChatTypingIndicator({
+  variant = "inline",
+  ariaLabel = "Agent 正在响应",
+  className,
+}: {
+  variant?: ChatTypingIndicatorVariant;
+  ariaLabel?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      data-testid={TEST_IDS[variant]}
+      className={cn(
+        "flex items-center gap-1.5 py-1 text-zinc-400 dark:text-zinc-500",
+        variant === "standalone" && "px-1",
+        className,
+      )}
+    >
+      <span className="sr-only">{ariaLabel}</span>
+      <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s] motion-reduce:animate-none" />
+      <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s] motion-reduce:animate-none" />
+      <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current motion-reduce:animate-none" />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -9,6 +9,7 @@ import ReactMarkdown from "react-markdown";
 import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { getStreamingMarkdownSegments } from "@/utils/streaming-markdown";
 import { citationHref, splitCitationTokens } from "@/utils/citation-parser";
+import { ChatTypingIndicator } from "./ChatTypingIndicator";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { UserAvatar } from "./UserAvatar";
 
@@ -522,15 +523,7 @@ export function MessageBubble({
                 />
               ) : null)}
             {showWaitingPlaceholder ? (
-              <div
-                data-testid="agent-waiting-placeholder"
-                className="flex items-center gap-1.5 py-1 text-zinc-400 dark:text-zinc-500"
-                aria-label="Agent 正在思考"
-              >
-                <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
-                <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
-                <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
-              </div>
+              <ChatTypingIndicator variant="inline" ariaLabel="Agent 正在思考" />
             ) : null}
             {showStreamingIndicator ? (
               <div className="mt-3 flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-amber-600 dark:text-amber-300">

--- a/apps/negentropy-ui/tests/unit/ChatStream.pending.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ChatStream.pending.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatStream } from "../../components/ui/ChatStream";
+import type { ConversationNode } from "@/types/a2ui";
+
+vi.mock("@/components/providers/AuthProvider", () => ({
+  useAuth: () => ({ user: null }),
+}));
+
+const EMPTY_PROMPT_TEXT =
+  "发送指令开始对话。主区会按正文顺序展示消息，并把工具过程穿插在对应位置。";
+
+describe("ChatStream — stream-level pending typing indicator", () => {
+  it("空树 + pending=true：显示 standalone indicator，且不再显示「发送指令开始对话」", () => {
+    render(<ChatStream nodes={[]} pending />);
+    expect(screen.getByTestId("chat-pending-indicator")).toBeInTheDocument();
+    expect(screen.queryByText(EMPTY_PROMPT_TEXT)).toBeNull();
+  });
+
+  it("空树 + pending=false：保持原有空状态文案，不显示 indicator", () => {
+    render(<ChatStream nodes={[]} pending={false} />);
+    expect(screen.queryByTestId("chat-pending-indicator")).toBeNull();
+    expect(screen.getByText(EMPTY_PROMPT_TEXT)).toBeInTheDocument();
+  });
+
+  it("末尾非 assistant-reply（turn-status）+ pending=true：在列表底部追加 indicator", () => {
+    // 仅 RUN_STARTED 而尚无任何 assistant 子节点 → buildChatDisplayBlocks
+    // 会生成 turn-status 提示块，此时 stream 级 indicator 应可见。
+    const nodes: ConversationNode[] = [
+      {
+        id: "turn:pending",
+        type: "turn",
+        parentId: null,
+        children: [],
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1000 },
+        sourceOrder: 0,
+        title: "轮次 run-1",
+        status: "running",
+        visibility: "chat",
+        isStructural: false,
+        payload: {},
+        sourceEventTypes: ["run_started"],
+        relatedMessageIds: [],
+      },
+    ];
+    render(<ChatStream nodes={nodes} pending />);
+    expect(screen.getByTestId("chat-pending-indicator")).toBeInTheDocument();
+  });
+
+  it("末尾已是 assistant-reply：不显示 stream 级 indicator（让位给 bubble 级 placeholder）", () => {
+    // 已经有 assistant-reply 落地 → AssistantReplyBubble 内置 ChatTypingIndicator
+    // 接管展示职责，外层 ChatStream 不能再叠加一层，避免「双 indicator」。
+    const nodes: ConversationNode[] = [
+      {
+        id: "turn:1",
+        type: "turn",
+        parentId: null,
+        children: [
+          {
+            id: "message:1",
+            type: "text",
+            parentId: "turn:1",
+            children: [],
+            threadId: "thread-1",
+            runId: "run-1",
+            messageId: "msg-1",
+            timestamp: 1001,
+            timeRange: { start: 1001, end: 1001 },
+            sourceOrder: 1,
+            title: "助手消息",
+            role: "assistant",
+            visibility: "chat",
+            isStructural: false,
+            payload: { content: "你好", streaming: false },
+            sourceEventTypes: ["text_message_start", "text_message_end"],
+            relatedMessageIds: ["msg-1"],
+          },
+        ],
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1001 },
+        sourceOrder: 0,
+        title: "轮次 run-1",
+        visibility: "chat",
+        isStructural: false,
+        payload: {},
+        sourceEventTypes: ["run_started"],
+        relatedMessageIds: [],
+      },
+    ];
+    render(<ChatStream nodes={nodes} pending />);
+    expect(screen.queryByTestId("chat-pending-indicator")).toBeNull();
+  });
+
+  it("pending=false 时无论末尾是什么 block，都不显示 indicator", () => {
+    const nodes: ConversationNode[] = [
+      {
+        id: "turn:done",
+        type: "turn",
+        parentId: null,
+        children: [],
+        threadId: "thread-1",
+        runId: "run-1",
+        timestamp: 1000,
+        timeRange: { start: 1000, end: 1000 },
+        sourceOrder: 0,
+        title: "轮次 run-1",
+        status: "running",
+        visibility: "chat",
+        isStructural: false,
+        payload: {},
+        sourceEventTypes: ["run_started"],
+        relatedMessageIds: [],
+      },
+    ];
+    render(<ChatStream nodes={nodes} pending={false} />);
+    expect(screen.queryByTestId("chat-pending-indicator")).toBeNull();
+  });
+
+  it("未提供 pending prop 时默认 false（向后兼容）", () => {
+    render(<ChatStream nodes={[]} />);
+    expect(screen.queryByTestId("chat-pending-indicator")).toBeNull();
+    expect(screen.getByText(EMPTY_PROMPT_TEXT)).toBeInTheDocument();
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/ChatTypingIndicator.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/ChatTypingIndicator.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ChatTypingIndicator } from "@/components/ui/ChatTypingIndicator";
+
+describe("ChatTypingIndicator", () => {
+  it("inline variant 默认 testid 与 a11y 属性正确", () => {
+    render(<ChatTypingIndicator variant="inline" />);
+    const node = screen.getByTestId("agent-waiting-placeholder");
+    expect(node).toBeInTheDocument();
+    expect(node).toHaveAttribute("role", "status");
+    expect(node).toHaveAttribute("aria-live", "polite");
+    expect(node).toHaveAttribute("aria-label", "Agent 正在响应");
+    // 三个 bouncing dots
+    expect(node.querySelectorAll("span.animate-bounce").length).toBe(3);
+  });
+
+  it("standalone variant 使用独立 testid 并附加 px-1", () => {
+    render(<ChatTypingIndicator variant="standalone" />);
+    const node = screen.getByTestId("chat-pending-indicator");
+    expect(node).toBeInTheDocument();
+    expect(node.className).toContain("px-1");
+  });
+
+  it("自定义 ariaLabel 透传到 aria-label 与 sr-only 文本", () => {
+    render(
+      <ChatTypingIndicator variant="inline" ariaLabel="Agent 正在思考" />,
+    );
+    const node = screen.getByTestId("agent-waiting-placeholder");
+    expect(node).toHaveAttribute("aria-label", "Agent 正在思考");
+    // sr-only 文本兜底（屏幕阅读器可读，但视觉隐藏）
+    expect(node.querySelector("span.sr-only")?.textContent).toBe(
+      "Agent 正在思考",
+    );
+  });
+
+  it("默认 variant 为 inline（兼容既有 testid）", () => {
+    render(<ChatTypingIndicator />);
+    expect(screen.getByTestId("agent-waiting-placeholder")).toBeInTheDocument();
+  });
+
+  it("dots 都带有 motion-reduce:animate-none 降级修饰符（响应 prefers-reduced-motion）", () => {
+    render(<ChatTypingIndicator variant="inline" />);
+    const node = screen.getByTestId("agent-waiting-placeholder");
+    const dots = Array.from(node.querySelectorAll("span.animate-bounce"));
+    for (const dot of dots) {
+      expect(dot.className).toContain("motion-reduce:animate-none");
+    }
+  });
+
+  it("额外 className 透传到根节点", () => {
+    render(
+      <ChatTypingIndicator variant="standalone" className="extra-test-class" />,
+    );
+    expect(screen.getByTestId("chat-pending-indicator").className).toContain(
+      "extra-test-class",
+    );
+  });
+});


### PR DESCRIPTION
## 背景

用户在首页 Home Chat 发送消息后，前端在「请求已发出 → Agent 流式内容首次显示」之间存在 100–500ms（慢网或冷启动可达数秒）的等待真空期：

- 用户消息气泡已渲染、输入框切换为 Stop；
- 但 Assistant 气泡尚未挂载（要等 RUN_STARTED / 首个 TEXT_MESSAGE_CONTENT 入会话树）；
- 整个对话区视觉死寂，用户难以判断是否提交成功 / 是否已开始处理。

`AssistantReplyBubble.tsx:118-128` 早期已有三点 bounce 占位，但只覆盖「气泡已挂载但 segments 仍为空」的窗口；本 PR 在更上游的 ChatStream 层补一段 stream 级 indicator，与 bubble 级 placeholder 形成无缝接力。

## 改动总览

- 抽取共享组件 `ChatTypingIndicator`（inline / standalone 两种 variant），把 `AssistantReplyBubble` 与 `MessageBubble` 内既有的三点 bounce 占位收敛为单一事实源；保留 `data-testid=\"agent-waiting-placeholder\"` 兼容既有测试。
- `ChatStream` 新增 `pending` prop：在 `displayBlocks.map` **之外**追加 standalone 三点动画，覆盖 Assistant 气泡尚未挂载的真空期；末尾 displayBlock 已是 assistant-reply 时让位给 bubble 级 placeholder，避免双 indicator。
- `home-body` 直接以既有 `effectiveConnection ∈ {connecting, streaming}` 派生 `pending`，**不引入新 state、不动 `activeRunIdRef`**（PR #479 故意以 ref 形式保留以规避并发 race）。
- 含 a11y：`role=\"status\"` + `aria-live=\"polite\"` + sr-only 文本；动效降级：`motion-reduce:animate-none` 响应 `prefers-reduced-motion`。

## 风险评估（对 PR #479）

| 路径 | 是否触碰 |
|---|---|
| `buildChatDisplayBlocks` 去重/排序/Phase 3 折叠闸门 | ❌ indicator 在 `displayBlocks.map` 之外渲染 |
| `invocationId` 映射 | ❌ 无关联 |
| Sort tiebreaker | ❌ indicator 无 timestamp |
| `activeRunIdRef` 并发隔离 | ❌ 不读不写 |
| `conversation-tree` / `session-hydration` / `useAgentSubscription` | ❌ 完全不动 |

**回归风险：低**。

## 业界最佳实践对照

- **iMessage typing dots**：三点 bounce + 紧贴气泡上方 — 与本方案最接近；本方案多一层 stream 级覆盖「block 尚未挂载」窗口；
- **Anthropic Claude.ai / ChatGPT**：在 Assistant 气泡内显示等待 caret/spinner — 对应现有 bubble 级 placeholder；
- **Vercel AI SDK `useChat`**：暴露 `isLoading` 由调用方决定 UI — 与本方案 `effectiveConnection` 派生 `pending` 概念一致。

## 自证材料

### 测试
- 新增 12 个单元测试（`ChatTypingIndicator.test.tsx` 6 条 + `ChatStream.pending.test.tsx` 6 条），覆盖 inline/standalone 两个 variant、a11y、reduced-motion、向后兼容、stream→bubble 接力路径。
- 全量 vitest：**85 文件 / 625 测试全绿**；MessageBubble 与 ChatStream 既有测试套零回归。
- `pnpm typecheck`、`pnpm lint --max-warnings=0`：均通过。

### 浏览器实机验证（chrome_devtools 接入用户主 Chrome 真实登录态）
- React Fiber 反查确认 `<ChatStream>` 收到 `pending` prop（key 列表含 `pending`）；
- Timeline 完整捕获：发送后 standalone indicator 出现 → Assistant 气泡挂载时 indicator 消失，bubble 级 placeholder 接力；
- 暗色色彩对比正常，无 console 错误。

实机截图归档于 `.context/typing-indicator-*.png`。

## Test plan

- [x] vitest 全量绿
- [x] typecheck / lint 干净
- [x] 浏览器实机：首发场景 indicator mount/unmount 完整生命周期
- [x] PR #479 既有测试套零回归

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)