### PR TITLE
修复 Corpus chunks 计数严重偏离（Harness Engineering 849→14）— Phase 1 hotfix

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError  # noqa: F401
-from sqlalchemy import func, select
+from sqlalchemy import String, cast, exists, func, literal_column, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from negentropy.auth.deps import get_optional_user
@@ -583,6 +583,75 @@ async def _resolve_default_extractor_routes() -> dict[str, Any]:
     return resolved_routes
 
 
+# =============================================================================
+# 用户面 chunks 计数口径（Phase 1 Hotfix · 见 docs/issue.md ISSUE-026）
+# -----------------------------------------------------------------------------
+# 业界 hierarchical 切片在用户面统一以「顶层 chunks」为统计粒度（child 仅作为
+# 检索实现细节）：LangChain ParentDocumentRetriever、LlamaIndex
+# HierarchicalNodeParser、AWS Bedrock KB Hierarchical Chunking 均如此。
+# 本仓 metadata.chunk_role 字段已为该口径预留正交语义（parent/child/leaf）。
+#
+# 同时排除已被软删（status='deleted'）文档的 chunks，避免它们污染 corpus 计数
+# ——这是 「Harness Engineering chunks: 849 vs 14」问题的真正主因。
+# =============================================================================
+
+
+def _user_facing_chunk_filter_clauses() -> tuple[Any, Any]:
+    """构建用户面 chunks 计数过滤子句（chunk_role 与 active doc 两正交维度）。
+
+    返回 (not_child_clause, doc_active_or_kg_clause)，可作为 ``where(*clauses)`` 直接拼接。
+
+    语义：
+      - chunk_role='child' → 排除（hierarchical 切片实现细节）
+      - chunk_role='parent' / 'leaf' / 缺失 → 计入（用户面顶层颗粒度）
+      - source_uri 匹配某 active KnowledgeDocument → 计入
+      - source_uri 匹配的 doc 全部 status!='active' → 排除（软删 doc 的 chunks）
+      - source_uri 找不到任何 doc 但非 NULL → 排除（硬删后的孤儿）
+      - source_uri IS NULL → 计入（KG 实体类合法直连知识，无 doc 来源）
+    """
+    chunk_role_expr = func.coalesce(
+        cast(Knowledge.metadata_["chunk_role"].astext, String),
+        "leaf",
+    )
+    not_child_clause = chunk_role_expr != "child"
+
+    has_active_doc = exists(
+        select(literal_column("1"))
+        .select_from(KnowledgeDocument)
+        .where(
+            KnowledgeDocument.corpus_id == Knowledge.corpus_id,
+            KnowledgeDocument.app_name == Knowledge.app_name,
+            KnowledgeDocument.status == "active",
+            or_(
+                KnowledgeDocument.gcs_uri == Knowledge.source_uri,
+                cast(KnowledgeDocument.metadata_["origin_url"].astext, String) == Knowledge.source_uri,
+            ),
+        )
+    )
+    doc_active_or_kg_clause = or_(Knowledge.source_uri.is_(None), has_active_doc)
+
+    return (not_child_clause, doc_active_or_kg_clause)
+
+
+def _user_facing_chunk_count_subquery(corpus_id_expr: Any) -> Any:
+    """为给定 corpus 行构建标量相关子查询，返回该 corpus 的用户面 chunks 数。
+
+    ``list_corpora`` / ``get_corpus`` 的 1:N JOIN+GROUP BY 模式不易加 EXISTS 过滤，
+    改用相关子查询：每行 corpus 对应一次 ``COUNT(*) FROM knowledge WHERE ...``。
+    """
+    not_child_clause, doc_active_or_kg_clause = _user_facing_chunk_filter_clauses()
+    return (
+        select(func.count())
+        .select_from(Knowledge)
+        .where(
+            Knowledge.corpus_id == corpus_id_expr,
+            not_child_clause,
+            doc_active_or_kg_clause,
+        )
+        .scalar_subquery()
+    )
+
+
 @router.get("/dashboard", response_model=DashboardResponse)
 async def get_dashboard(app_name: str | None = Query(default=None)) -> DashboardResponse:
     resolved_app = _resolve_app_name(app_name)
@@ -594,8 +663,16 @@ async def get_dashboard(app_name: str | None = Query(default=None)) -> Dashboard
     alerts = []
     async with AsyncSessionLocal() as db:
         corpus_count = await db.scalar(select(func.count()).select_from(Corpus).where(Corpus.app_name == resolved_app))
+        # 用户面口径：排除 hierarchical child + 软删/孤儿 chunks（与 corpus list / 文档详情统一）
+        not_child_clause, doc_active_or_kg_clause = _user_facing_chunk_filter_clauses()
         knowledge_count = await db.scalar(
-            select(func.count()).select_from(Knowledge).where(Knowledge.app_name == resolved_app)
+            select(func.count())
+            .select_from(Knowledge)
+            .where(
+                Knowledge.app_name == resolved_app,
+                not_child_clause,
+                doc_active_or_kg_clause,
+            )
         )
         last_build_at = await db.scalar(
             select(func.max(Knowledge.updated_at)).where(Knowledge.app_name == resolved_app)
@@ -614,11 +691,11 @@ async def get_dashboard(app_name: str | None = Query(default=None)) -> Dashboard
 async def list_corpora(app_name: str | None = Query(default=None)) -> list[CorpusResponse]:
     resolved_app = _resolve_app_name(app_name)
     async with AsyncSessionLocal() as db:
+        # 用户面 chunks 计数：相关子查询代替 1:N JOIN+GROUP BY，便于内嵌 EXISTS 过滤软删 doc。
+        knowledge_count_subq = _user_facing_chunk_count_subquery(Corpus.id)
         stmt = (
-            select(Corpus, func.count(Knowledge.id))
-            .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
+            select(Corpus, knowledge_count_subq.label("knowledge_count"))
             .where(Corpus.app_name == resolved_app)
-            .group_by(Corpus.id)
             .order_by(Corpus.created_at.desc())
         )
         result = await db.execute(stmt)
@@ -665,11 +742,10 @@ async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
 async def get_corpus(corpus_id: UUID, app_name: str | None = Query(default=None)) -> CorpusResponse:
     resolved_app = _resolve_app_name(app_name)
     async with AsyncSessionLocal() as db:
-        stmt = (
-            select(Corpus, func.count(Knowledge.id))
-            .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
-            .where(Corpus.id == corpus_id, Corpus.app_name == resolved_app)
-            .group_by(Corpus.id)
+        # 用户面口径：相关子查询排除 child 与软删/孤儿 chunks。
+        knowledge_count_subq = _user_facing_chunk_count_subquery(Corpus.id)
+        stmt = select(Corpus, knowledge_count_subq.label("knowledge_count")).where(
+            Corpus.id == corpus_id, Corpus.app_name == resolved_app
         )
         result = await db.execute(stmt)
         row = result.first()
@@ -724,8 +800,16 @@ async def update_corpus(
         corpus = await service.update_corpus(corpus_id=corpus_id, spec=update_data)
 
         async with AsyncSessionLocal() as db:
+            # 用户面口径：与 list_corpora / get_corpus / dashboard 一致，排除 child 与软删/孤儿。
+            not_child_clause, doc_active_or_kg_clause = _user_facing_chunk_filter_clauses()
             knowledge_count = await db.scalar(
-                select(func.count()).select_from(Knowledge).where(Knowledge.corpus_id == corpus.id)
+                select(func.count())
+                .select_from(Knowledge)
+                .where(
+                    Knowledge.corpus_id == corpus.id,
+                    not_child_clause,
+                    doc_active_or_kg_clause,
+                )
             )
 
         rebuild_triggered: dict[str, Any] | None = None

--- a/apps/negentropy/tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py
@@ -1,0 +1,320 @@
+"""用户面 chunks 计数口径正交回归测试（集成测试，依赖真实 Postgres）。
+
+验证 ``list_corpora`` / ``get_corpus`` / ``get_dashboard`` 三处端点对 ``Knowledge``
+表的计数遵循统一口径：
+
+  - chunk_role='child' 的 hierarchical 子分片不计（与文档详情口径一致）
+  - 软删除（``KnowledgeDocument.status='deleted'``）文档对应的 chunks 不计
+  - source_uri 找不到任何 doc 的孤儿 chunks 不计
+  - source_uri IS NULL 的 KG 类直连知识照常计
+
+为规避现有 conftest 中 ``db_engine`` 函数级 fixture 与 asyncpg 连接池跨事件循环
+的已知边界（同文件多个 ``async def test_*`` 串跑会触发 "Future attached to a
+different loop"），本文件采用「单测试函数 + 多场景子断言」模式：每个场景独立
+``app_name`` 命名空间隔离，所有断言共享同一事件循环。
+
+参考实现：``apps/negentropy/src/negentropy/knowledge/api.py``
+``_user_facing_chunk_filter_clauses`` / ``_user_facing_chunk_count_subquery``。
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from sqlalchemy import delete
+
+from negentropy.db import session as db_session
+from negentropy.knowledge import api as knowledge_api
+from negentropy.models.perception import Corpus, Knowledge, KnowledgeDocument
+
+
+async def _create_corpus(*, app_name: str, name: str) -> UUID:
+    async with db_session.AsyncSessionLocal() as session:
+        corpus = Corpus(name=name, app_name=app_name)
+        session.add(corpus)
+        await session.flush()
+        await session.commit()
+        return corpus.id
+
+
+async def _create_document(
+    *,
+    corpus_id: UUID,
+    app_name: str,
+    gcs_uri: str,
+    status: str = "active",
+    metadata: dict | None = None,
+) -> UUID:
+    async with db_session.AsyncSessionLocal() as session:
+        doc = KnowledgeDocument(
+            corpus_id=corpus_id,
+            app_name=app_name,
+            file_hash=uuid4().hex,
+            original_filename=gcs_uri.rsplit("/", 1)[-1],
+            gcs_uri=gcs_uri,
+            content_type="text/plain",
+            file_size=100,
+            status=status,
+            metadata_=metadata or {},
+        )
+        session.add(doc)
+        await session.flush()
+        await session.commit()
+        return doc.id
+
+
+async def _insert_knowledge(
+    *,
+    corpus_id: UUID,
+    app_name: str,
+    source_uri: str | None,
+    metadata: dict,
+    count: int = 1,
+) -> None:
+    async with db_session.AsyncSessionLocal() as session:
+        for idx in range(count):
+            session.add(
+                Knowledge(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    content=f"chunk-{idx}",
+                    source_uri=source_uri,
+                    chunk_index=idx,
+                    metadata_=metadata,
+                )
+            )
+        await session.commit()
+
+
+async def _cleanup(*, app_name: str) -> None:
+    async with db_session.AsyncSessionLocal() as session:
+        await session.execute(delete(Knowledge).where(Knowledge.app_name == app_name))
+        await session.execute(delete(KnowledgeDocument).where(KnowledgeDocument.app_name == app_name))
+        await session.execute(delete(Corpus).where(Corpus.app_name == app_name))
+        await session.commit()
+
+
+async def _scenario_hierarchical_only_parents(app: str) -> None:
+    """场景 1：hierarchical 5 父 + 25 子 → 用户面 5（child 不计入）。"""
+    corpus_id = await _create_corpus(app_name=app, name="c1")
+    await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/doc1.pdf")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/doc1.pdf",
+        metadata={"chunk_role": "parent"},
+        count=5,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/doc1.pdf",
+        metadata={"chunk_role": "child"},
+        count=25,
+    )
+
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert len(listed) == 1
+    assert listed[0].knowledge_count == 5, (
+        f"[scenario 1] hierarchical parent-only should be 5, got {listed[0].knowledge_count}"
+    )
+    detail = await knowledge_api.get_corpus(corpus_id=corpus_id, app_name=app)
+    assert detail.knowledge_count == 5, "[scenario 1] get_corpus mismatch"
+    dashboard = await knowledge_api.get_dashboard(app_name=app)
+    assert dashboard.knowledge_count == 5, "[scenario 1] dashboard mismatch"
+
+
+async def _scenario_non_hierarchical_all_leaf(app: str) -> None:
+    """场景 2：非 hierarchical 10 leaf → 全部计入。"""
+    corpus_id = await _create_corpus(app_name=app, name="c2")
+    await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/doc2.pdf")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/doc2.pdf",
+        metadata={},
+        count=10,
+    )
+
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert listed[0].knowledge_count == 10, (
+        f"[scenario 2] non-hierarchical (no chunk_role) should all count, got {listed[0].knowledge_count}"
+    )
+
+
+async def _scenario_soft_deleted_doc_excluded(app: str) -> None:
+    """场景 3（关键复刻）：active 3 父 + 软删 7 父 + 软删 35 子 → 用户面 3。
+
+    完整复刻 Harness Engineering 「chunks: 849 vs 14」 真实根因。
+    """
+    corpus_id = await _create_corpus(app_name=app, name="c3")
+    await _create_document(
+        corpus_id=corpus_id,
+        app_name=app,
+        gcs_uri="gs://test/active.pdf",
+        status="active",
+    )
+    await _create_document(
+        corpus_id=corpus_id,
+        app_name=app,
+        gcs_uri="gs://test/deleted.pdf",
+        status="deleted",
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/active.pdf",
+        metadata={"chunk_role": "parent"},
+        count=3,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/deleted.pdf",
+        metadata={"chunk_role": "parent"},
+        count=7,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/deleted.pdf",
+        metadata={"chunk_role": "child"},
+        count=35,
+    )
+
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert listed[0].knowledge_count == 3, (
+        f"[scenario 3] only active doc parents should count, got {listed[0].knowledge_count}"
+    )
+    dashboard = await knowledge_api.get_dashboard(app_name=app)
+    assert dashboard.knowledge_count == 3, "[scenario 3] dashboard mismatch"
+
+
+async def _scenario_orphan_excluded(app: str) -> None:
+    """场景 4：active 2 父 + 孤儿 20 父（source_uri 找不到任何 doc）→ 用户面 2。"""
+    corpus_id = await _create_corpus(app_name=app, name="c4")
+    await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/exists.pdf")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/exists.pdf",
+        metadata={"chunk_role": "parent"},
+        count=2,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/missing.pdf",
+        metadata={"chunk_role": "parent"},
+        count=20,
+    )
+
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert listed[0].knowledge_count == 2, (
+        f"[scenario 4] orphan chunks should be excluded, got {listed[0].knowledge_count}"
+    )
+
+
+async def _scenario_kg_null_source_included(app: str) -> None:
+    """场景 5：source_uri IS NULL 的 KG 类合法直连知识照常计入。"""
+    corpus_id = await _create_corpus(app_name=app, name="c5")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri=None,
+        metadata={"chunk_role": "leaf"},
+        count=4,
+    )
+
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert listed[0].knowledge_count == 4, (
+        f"[scenario 5] KG NULL source_uri should count, got {listed[0].knowledge_count}"
+    )
+
+
+async def _scenario_combined_quadrants(app: str) -> None:
+    """场景 6：active(3 父+18 子) + 软删(5 父+25 子) + 孤儿 7 父 + KG 2 leaf
+    → 物理 60 → 用户面 5（active 父 3 + KG 2）。"""
+    corpus_id = await _create_corpus(app_name=app, name="c6")
+    await _create_document(
+        corpus_id=corpus_id,
+        app_name=app,
+        gcs_uri="gs://test/active.pdf",
+        status="active",
+    )
+    await _create_document(
+        corpus_id=corpus_id,
+        app_name=app,
+        gcs_uri="gs://test/old.pdf",
+        status="deleted",
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/active.pdf",
+        metadata={"chunk_role": "parent"},
+        count=3,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/active.pdf",
+        metadata={"chunk_role": "child"},
+        count=18,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/old.pdf",
+        metadata={"chunk_role": "parent"},
+        count=5,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/old.pdf",
+        metadata={"chunk_role": "child"},
+        count=25,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/orphan-from-hard-delete.pdf",
+        metadata={"chunk_role": "parent"},
+        count=7,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri=None,
+        metadata={"chunk_role": "leaf"},
+        count=2,
+    )
+
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert listed[0].knowledge_count == 5, (
+        f"[scenario 6] expected 3 (active parents) + 2 (KG) = 5 of 60 physical rows, got {listed[0].knowledge_count}"
+    )
+    detail = await knowledge_api.get_corpus(corpus_id=corpus_id, app_name=app)
+    assert detail.knowledge_count == 5, "[scenario 6] get_corpus mismatch"
+    dashboard = await knowledge_api.get_dashboard(app_name=app)
+    assert dashboard.knowledge_count == 5, "[scenario 6] dashboard mismatch"
+
+
+async def test_user_facing_chunk_count_filter_quadrants():
+    """串行执行 6 个场景，每个独立 app_name 命名空间，覆盖 chunks 计数全象限。"""
+    base = uuid4().hex[:8]
+    scenarios = [
+        ("hierarchical_parents_only", _scenario_hierarchical_only_parents),
+        ("non_hierarchical_leaf", _scenario_non_hierarchical_all_leaf),
+        ("soft_deleted_doc_excluded", _scenario_soft_deleted_doc_excluded),
+        ("orphan_excluded", _scenario_orphan_excluded),
+        ("kg_null_source_included", _scenario_kg_null_source_included),
+        ("combined_quadrants", _scenario_combined_quadrants),
+    ]
+    for tag, scenario in scenarios:
+        app = f"test-cnt-{base}-{tag}"
+        try:
+            await scenario(app)
+        finally:
+            await _cleanup(app_name=app)

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1650,3 +1650,59 @@
 - **评审补充修复（2026-05-09 第二轮）**：
   1. **失败终态 warnings 落库对称化**：原修复仅在成功分支通过 `_strip_phase_entries(build_warnings) + [{"_metrics": ...}]` 落 warnings，失败分支调用 `update_build_run` 未传 `warnings`，因 SQL `COALESCE(CAST(:warnings AS jsonb), warnings)` 会原样保留上一次 `emit_phase` 写入的 `_phase` 运行期标记，且丢失任何已累积的算法 warning。修复：把 `build_warnings` / `build_metrics` 提升到 try 之外初始化（防 UnboundLocalError），失败分支同样传入剥离 `_phase` 后的 warnings + 可选 `_metrics`（若已构造）。新增单测 `test_build_graph_failure_strips_phase_and_persists_warnings_on_early_exception` / `test_build_graph_failure_preserves_algorithm_warnings`。
   2. **Pill 挂载与 POST 在飞状态解耦**：原修复 `{building && corpusId && <KgBuildProgressPill .../>}` 将 Pill 挂载强绑定到 `building`，而 `handleBuild` 在 `finally` 里 `setBuilding(false)`——POST 因 BFF 15min 超时 abort 时 Pill 立即卸载、SSE 关闭，注释承诺的「SSE 仍会推送终态」实际无法被前端接收。修复：新增 `pillEnqueued` 状态（独立于 `building`）+ `pillSession` key，`KgBuildProgressPill` 新增 `onTerminal?(event)` 回调（延迟 `TERMINAL_DISPLAY_HOLD_MS = 4s` 触发，留终态展示窗口）；父组件在回调里 `setPillEnqueued(false)`，让 SSE 终态自驱卸载。新增 Pill 单测 `SSE 终态后通过 onTerminal 通知父组件` / `终态延迟回调中卸载组件不会泄漏 timer`。
+
+---
+
+## ISSUE-078 Corpus chunks 计数严重偏离（Harness Engineering 849 vs 14）：SQL 没 JOIN 文档表过滤软删 + 父子分片混算（2026-05-09）
+
+- **表因**：用户在 `/knowledge/base` 看到 `Harness Engineering` Corpus 卡片显示 `chunks: 849`，但点开唯一文档详情仅 `14 Chunks`，hierarchical 切片（parent: 3000 / child: 750）；Corpus 历史曾有 2 个 Document，删除过一个。两端口径相差近 60 倍。
+- **根因**（双因，均由 SQL 计数表达式不严谨引入）：
+  1. **主因 A：corpus chunks 计数 SQL 没有过滤软删文档**。[`apps/negentropy/src/negentropy/knowledge/api.py`](../apps/negentropy/src/negentropy/knowledge/api.py) `list_corpora` / `get_corpus` 用 `select(Corpus, func.count(Knowledge.id)).outerjoin(Knowledge ...)`，**完全没有 JOIN `knowledge_documents` 表过滤 `status='active'`**。同时 [`storage/service.py`](../apps/negentropy/src/negentropy/storage/service.py) HTTP `delete_document` 默认 `hard_delete=False` 走软删（`status='deleted'`），UI `list_documents` 用 `status == "active"` 过滤掉它，但 corpus chunks 计数没做同口径过滤，软删 doc 的全部父+子 chunks 仍计入，是 849 数字偏离的真正主因。
+  2. **次因 B：父子分片计数口径与文档详情不一致**。corpus 列表父+子全计；文档详情 `(item.metadata or {}).get("chunk_role") != "child"` 仅算父/leaf。hierarchical 切片下父:子约 1:5，14 父 + ~70 子 ≈ 84，与 849 缺口剩约 765 即来自软删 doc 的全部父+子 chunks，叠加放大用户视觉偏差。
+  3. **隐患 C：硬删未级联 chunks**。`Knowledge` 仅有 FK 到 `Corpus` (CASCADE)、与 `KnowledgeDocument` 仅靠 `source_uri` 文本软关联；`delete_document` 硬删分支只 `db.delete(doc)`，未清理 Knowledge 行。当前 849 案例不是此因，但任何走过 `hard_delete=True` 的历史路径都会留下 FK 意义的孤儿 chunks，是潜在地雷。
+  4. **隐患 D：软删 chunks 仍可被检索命中**。`is_enabled=true` + `searchable=true` + `archived` 未标 → 软删 doc 的 chunks 仍能被 RAG 检索命中。独立 bug，本次仅 ack，留待 Phase 2 处理。
+- **业界口径参考**：LangChain `ParentDocumentRetriever` / LlamaIndex `HierarchicalNodeParser` / AWS Bedrock KB Hierarchical Chunking 在用户面均以**顶层（非 child）chunks** 为统计粒度；child 是检索实现细节，不暴露到产品计数。本仓 `metadata.chunk_role` + `metadata.searchable` 已为该口径预留正交语义，无需新建字段。
+- **处理方式**（Phase 化交付，本 PR 为 Phase 1 hotfix）：
+  1. **抽取共享 helper**：[`api.py`](../apps/negentropy/src/negentropy/knowledge/api.py) 新增 `_user_facing_chunk_filter_clauses()` 返回 `(not_child_clause, doc_active_or_kg_clause)`，`_user_facing_chunk_count_subquery(corpus_id_expr)` 构建相关子查询。语义：① `coalesce(metadata->>'chunk_role','leaf') != 'child'` 排除 child；② `EXISTS (SELECT 1 FROM knowledge_documents d WHERE d.corpus_id=k.corpus_id AND d.app_name=k.app_name AND d.status='active' AND (d.gcs_uri=k.source_uri OR d.metadata->>'origin_url'=k.source_uri))` 或 `source_uri IS NULL`，前者排除软删/孤儿，后者保留 KG 类直连知识。
+  2. **统一 4 处端点**：`list_corpora` / `get_corpus` 改用相关子查询代替 1:N JOIN+GROUP BY；`update_corpus` / `get_dashboard` 直接拼 filter clauses。`delete_corpus` 的审计日志保留物理 count（删除条数审计）不变。
+  3. **集成测试**：新增 [`test_corpus_chunk_count_filter.py`](../apps/negentropy/tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py)，6 象限场景串行覆盖 hierarchical 父子 / 非 hierarchical / 软删 doc / 硬删孤儿 / KG NULL source_uri / 真实世界混合（60 物理 → 5 用户面）。受现有 `db_engine` 函数级 fixture 与 asyncpg 连接池跨事件循环边界限制，采用「单 test 函数 + 多场景子断言」模式。
+- **后续防范**：
+  1. **删除路径必须级联 chunks**：Phase 2 将在 `delete_document` 硬删分支前调用 `delete_knowledge_by_source` 清理 chunks；软删分支批量打 `metadata.archived=true` + `is_enabled=false`（防 RAG 命中）；reactivation 时直接 hard delete 旧 chunks 让重新 ingest 写一份干净的。
+  2. **任何「父子分片」产物的用户面计数默认顶层**：新增检索类功能（如未来的 multi-vector / late chunking）必须在前端面把 chunks 数收敛到顶层粒度，child / sub-chunk 仅作检索实现细节。
+  3. **Schema FK 兜底（Phase 3）**：给 `Knowledge` 加 `document_id` FK 到 `knowledge_documents(id) ON DELETE CASCADE` + 独立 CLI `cleanup_orphan_knowledge` dry-run/commit 模式清算历史脏数据；新增 `negentropy.knowledge.orphan_count{corpus_id}` metric 防止 bypass 路径再次产生孤儿。
+  4. **PR review 必查**：任何新增 `select(... func.count(Knowledge.id) ...)` 必须显式声明是「物理 count（审计）」还是「用户面 count」，前者保留原状、后者必须使用本 PR 抽出的两个 helper。
+- **同类问题影响**：
+  1. 所有 hierarchical 类切片的功能（catalog 节点、Wiki entries、KG entity 提及）均需复盘 child / sub-node 是否被错误暴露到用户面计数。
+  2. 软删 + 计数口径错配是反复出现的反模式（参考 ISSUE-058 流式双内容 / ISSUE-039 双气泡盲区）：任何「软删 + 列表过滤 + 关联表计数」三联场景都需要同步检查，确保列表与计数走同一过滤口径。
+  3. 检索路径 `is_enabled` / `archived` / `searchable` 三态独立检查，但缺少「文档维度可见性」第四态——本 issue 已识别但留待 Phase 2 解决，新增检索功能时需主动审视是否需要 doc.status 维度过滤。
+- **Phase 化交付计划**：
+  - **Phase 1（本 PR · Hotfix）**：SQL 口径修正 + 集成测试 + issue 文档；零迁移、即时生效；UI 数字立即恢复正常；单 PR revert 可回滚、零数据风险。
+  - **Phase 2（独立 PR · 应用层级联）**：硬删 chunks 级联清理 + 软删 archive chunks + reactivation 旧 chunks purge + 检索路径 archived 过滤复核 + 删除级联回归测试。
+  - **Phase 3（独立 PR · Schema FK + CLI）**：alembic 0030 加 `Knowledge.document_id` FK + ORM 同步 + 写入路径全量补丁 + 独立 CLI `cleanup_orphan_knowledge` dry-run/commit + 观测 metric。
+- **Manual 复现脚本（PR reviewer 在 staging 验证）**：
+
+  ```sql
+  -- 修复前: 含软删 doc 的 chunks
+  SELECT name, (
+    SELECT COUNT(*) FROM negentropy.knowledge k
+    WHERE k.corpus_id = c.id
+  ) AS old_count,
+  -- 修复后: 用户面口径
+  (
+    SELECT COUNT(*) FROM negentropy.knowledge k
+    WHERE k.corpus_id = c.id
+      AND COALESCE(k.metadata->>'chunk_role', 'leaf') <> 'child'
+      AND (
+        k.source_uri IS NULL
+        OR EXISTS (
+          SELECT 1 FROM negentropy.knowledge_documents d
+          WHERE d.corpus_id = k.corpus_id AND d.app_name = k.app_name
+            AND d.status = 'active'
+            AND (d.gcs_uri = k.source_uri OR d.metadata->>'origin_url' = k.source_uri)
+        )
+      )
+  ) AS new_count
+  FROM negentropy.corpus c WHERE c.name = 'Harness Engineering';
+  ```
+
+  期望：`old_count=849, new_count=14`。


### PR DESCRIPTION
## 背景与问题

「Harness Engineering」Corpus 卡片显示 `chunks: 849`，但点开唯一文档详情仅 `14 Chunks`，hierarchical 切片（parent: 3000 / child: 750），用户此前删除过一个 Document。两端口径相差近 60 倍。

## 双重根因（事件级 RCA）

经代码核对，UI 默认走**软删**（`api.py:1684` `hard_delete: bool = Query(default=False)`）；`list_documents` 用 `status == "active"` 过滤（`storage/service.py:338`），所以软删 doc 在文档列表"消失"，但 DB 行仍在（`status='deleted'`）。

### 主因 A — Corpus chunks 计数 SQL 没有 JOIN docs 过滤软删

`apps/negentropy/src/negentropy/knowledge/api.py:613-637 / 664-688`：

```python
select(Corpus, func.count(Knowledge.id))
    .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
    ...
```

**完全没有过滤 `KnowledgeDocument.status`**——软删 doc 的全部 chunks（父+子）仍记入 corpus 计数。这是 849 数字偏离的**真正主因**。

### 主因 B — 父子 chunks 计数口径与文档详情不一致

- corpus 列表：父+子全计 (`api.py:618-619`)
- 文档详情：`(item.metadata or {}).get("chunk_role") != "child"` 仅算父/leaf (`api.py:1939`)
- hierarchical 父:子 ≈ 1:5，14 父 + ~70 子 ≈ 84，与 849 缺口剩约 765 来自软删 doc 的全部父+子 chunks

### 隐患 C/D（本 PR 不解决，留待 Phase 2/3）

- **C**：硬删 (`hard_delete=True`) 未级联清理 Knowledge 行（FK 仅指向 Corpus，与 KnowledgeDocument 靠 `source_uri` 文本软关联），是潜在孤儿源头
- **D**：软删 doc 的 chunks 仍可被 RAG 检索命中（`is_enabled=true` + `searchable=true` + 无 `archived` 标记）

## 修复方案（Phase 1 hotfix · 零迁移、即时生效）

### 抽取共享 helper

`apps/negentropy/src/negentropy/knowledge/api.py` 新增：

- `_user_facing_chunk_filter_clauses()` 返回 `(not_child_clause, doc_active_or_kg_clause)`
- `_user_facing_chunk_count_subquery(corpus_id_expr)` 返回相关标量子查询

语义：

- `coalesce(metadata->>'chunk_role', 'leaf') != 'child'` 排除 child（与文档详情口径一致）
- `EXISTS(SELECT 1 FROM knowledge_documents d WHERE d.corpus_id=k.corpus_id AND d.app_name=k.app_name AND d.status='active' AND (d.gcs_uri=k.source_uri OR d.metadata->>'origin_url'=k.source_uri))` 或 `source_uri IS NULL`：前者排除软删/孤儿，后者保留 KG 类直连知识

### 4 处端点统一

| 端点 | 改动 |
|---|---|
| `list_corpora` | `outerjoin + group_by` → 相关标量子查询 |
| `get_corpus` | 同上 |
| `update_corpus` | 直接拼 filter clauses |
| `get_dashboard` | 直接拼 filter clauses |
| `delete_corpus` | **保留物理 count**（删除审计日志，不变） |

### 业界口径对齐

LangChain `ParentDocumentRetriever`<sup>[1]</sup> / LlamaIndex `HierarchicalNodeParser`<sup>[2]</sup> / AWS Bedrock KB Hierarchical Chunking<sup>[3]</sup> 均以**顶层（非 child）chunks** 为统计粒度；child 是检索实现细节，不暴露到产品计数。本仓 `metadata.chunk_role` 已为该口径预留正交语义，无需新建字段。

## 集成测试

新增 `apps/negentropy/tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py`，6 象限场景串行覆盖：

| 场景 | 物理 | 用户面 |
|---|---|---|
| hierarchical 5 父 + 25 子 | 30 | 5 |
| 非 hierarchical 10 leaf | 10 | 10 |
| **软删 doc**（关键复刻 849 vs 14）：active 3 父 + 软删 7 父 + 软删 35 子 | 45 | 3 |
| 硬删孤儿：active 2 父 + 孤儿 20 父 | 22 | 2 |
| KG NULL source_uri 4 leaf | 4 | 4 |
| **真实世界混合**：active 3 父+18 子 + 软删 5 父+25 子 + 孤儿 7 父 + KG 2 leaf | 60 | 5 |

受现有 `db_engine` 函数级 fixture 与 asyncpg 连接池跨事件循环边界限制，采用「单 test 函数 + 多场景子断言」模式，每场景独立 `app_name` 命名空间隔离。

`uv run pytest tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py` 通过。

## 影响面 & 兼容性

- `CorpusResponse` / `DashboardResponse` 的 `knowledge_count: int` 字段类型不变，UI 零改动
- `delete_corpus` 审计日志仍记录物理 count（删除条数审计语义保持）
- 既有 19 项 API 单测全数 pass
- SQL 改动均为 `Knowledge.metadata->>'chunk_role'` JSONB 表达式 + 相关子查询；单 corpus chunks ≤ 万级无需新增索引（如未来体量大可参考 `0029` 加部分表达式索引）

## Phase 化交付路线（本 PR 仅 Phase 1）

- **Phase 1（本 PR · Hotfix）**：SQL 口径修正 + 集成测试 + issue 文档；零迁移、即时生效；UI 数字立即恢复正常；单 PR revert 可回滚、零数据风险
- **Phase 2（独立 PR · 应用层级联）**：`delete_document` 硬删 chunks 级联清理 + 软删 archive chunks + reactivation 旧 chunks purge + 检索路径 archived 过滤复核
- **Phase 3（独立 PR · Schema FK + CLI）**：alembic 0030 加 `Knowledge.document_id` FK + ORM 同步 + 写入路径全量补丁 + 独立 CLI `cleanup_orphan_knowledge` dry-run/commit + 观测 metric

## Test plan

- [x] `pytest tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py` 6 象限场景全 pass
- [x] `pytest tests/unit_tests/knowledge/test_api_corpus.py tests/unit_tests/knowledge/test_api_documents.py` 19 项既有用例无回归
- [x] SQL 编译产物经 PG dialect 校验（EXISTS 子查询正确相关到外层 corpus 行）
- [x] `docs/issue.md` 追加 ISSUE-078 完整 RCA + 防范条款 + 同类问题影响
- [ ] **Reviewer staging 复现验证**（执行 PR 描述末尾的 SQL 对比脚本，期望 `Harness Engineering` `old_count=849, new_count=14`）

### Staging SQL 对比脚本

\`\`\`sql
SELECT name,
  (SELECT COUNT(*) FROM negentropy.knowledge k WHERE k.corpus_id = c.id) AS old_count,
  (
    SELECT COUNT(*) FROM negentropy.knowledge k
    WHERE k.corpus_id = c.id
      AND COALESCE(k.metadata->>'chunk_role', 'leaf') <> 'child'
      AND (
        k.source_uri IS NULL
        OR EXISTS (
          SELECT 1 FROM negentropy.knowledge_documents d
          WHERE d.corpus_id = k.corpus_id AND d.app_name = k.app_name
            AND d.status = 'active'
            AND (d.gcs_uri = k.source_uri OR d.metadata->>'origin_url' = k.source_uri)
        )
      )
  ) AS new_count
FROM negentropy.corpus c WHERE c.name = 'Harness Engineering';
\`\`\`

## 参考文献（IEEE）

[1] LangChain, "ParentDocumentRetriever," *LangChain Python Documentation*, https://python.langchain.com/docs/how_to/parent_document_retriever/, 2024.
[2] J. Liu, "HierarchicalNodeParser — Auto-Merging Retriever," *LlamaIndex Documentation*, https://docs.llamaindex.ai/en/stable/examples/retrievers/auto_merging_retriever/, 2024.
[3] Amazon Web Services, "Hierarchical chunking — Knowledge Bases for Amazon Bedrock," *AWS Documentation*, https://docs.aws.amazon.com/bedrock/latest/userguide/kb-chunking-parsing.html, 2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)