### PR TITLE
Document 删除路径联动 Knowledge chunks 生命周期（Phase 2 · stacked on #483）

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0030_knowledge_document_fk.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0030_knowledge_document_fk.py
@@ -1,0 +1,140 @@
+"""knowledge.document_id FK — 文档级 CASCADE 防御层（ISSUE-078 Phase 3）
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-05-09 18:00:00.000000+00:00
+
+设计动机（与 ISSUE-078 Phase 1/2 形成 belt-and-suspenders 三层防御）：
+
+  - **Phase 1（PR #483）**：corpus chunks 计数 SQL 加入 `chunk_role!=child` +
+    `EXISTS active doc` 过滤，让 UI 数字立即恢复正常；
+  - **Phase 2（PR #484）**：`DocumentStorageService.delete_document` 硬删时
+    级联清理 chunks、软删时 archive chunks、reactivation 时 hard purge 旧
+    chunks——堵未来产生孤儿/检索污染的应用层入口；
+  - **Phase 3（本迁移）**：在 DB schema 层加 ``Knowledge.document_id`` FK to
+    ``knowledge_documents.id ON DELETE CASCADE``——任何 bypass 应用层的删除
+    路径（如 DBA 手动 DELETE FROM knowledge_documents、未来新增 service
+    入口忘记调用 storage.delete_document 等）都会被 DB 层的 CASCADE 兜住。
+
+为什么 nullable=True：
+  - KG 类直连知识（``KgEntity`` 等价 chunk）没有对应 ``KnowledgeDocument``
+    来源，``document_id`` 必须允许 NULL；
+  - 历史数据（迁移前已存在的 chunks）也无 ``document_id``，需要后续通过独立
+    CLI ``cleanup_orphan_knowledge`` 一次性回填，本迁移**仅加列与约束、不做
+    数据变更**——避免大表 UPDATE 造成长锁。
+
+为什么部分索引 ``WHERE document_id IS NOT NULL``：
+  - KG 类 chunks 的 ``document_id`` 永远 NULL，索引这部分浪费存储；
+  - 仅索引「指向文档的 chunks」，加速 ``DELETE knowledge_documents`` 触发的
+    级联探查。与 0029 ``ix_knowledge_arxiv_id`` 同一思路（详见迁移注释）。
+
+为什么 CASCADE 而非 SET NULL：
+  - SET NULL 会让历史 chunks 残留为「曾经有 doc 但 doc 已删」的孤儿，与
+    Phase 2 的语义（硬删则删 chunks）矛盾；
+  - CASCADE 让 DB 自动维护应用层不变量，正交于业务逻辑。
+
+为什么 downgrade 仅 DROP COLUMN：
+  - DROP COLUMN 在 PG 中是元数据操作，不重写表，可瞬时回滚；
+  - 已删除的孤儿 chunks 无法恢复——独立 CLI ``cleanup_orphan_knowledge``
+    才是数据清算入口，本迁移不触碰数据。
+
+参考文献：
+  [1] PostgreSQL Documentation, "ALTER TABLE — ADD CONSTRAINT FOREIGN KEY"
+  [2] PostgreSQL Documentation, "Indexes on Expressions" / "Partial Indexes"
+  [3] M. J. Stonebraker and A. Kumar, "The Logical Design of Distributed Databases,"
+      ACM TODS, 1980（CASCADE 与正交化数据完整性约束的早期论述）。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0030"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_SCHEMA = "negentropy"
+_TABLE = "knowledge"
+_COLUMN = "document_id"
+_FK_NAME = "fk_knowledge_document_id"
+_INDEX_NAME = "ix_knowledge_document_id"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    column_exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :table AND column_name = :col"
+        ),
+        {"schema": _SCHEMA, "table": _TABLE, "col": _COLUMN},
+    ).scalar()
+    if not column_exists:
+        op.execute(sa.text(f"ALTER TABLE {_SCHEMA}.{_TABLE} ADD COLUMN {_COLUMN} UUID NULL"))
+
+    fk_exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = :schema AND table_name = :table AND constraint_name = :fk"
+        ),
+        {"schema": _SCHEMA, "table": _TABLE, "fk": _FK_NAME},
+    ).scalar()
+    if not fk_exists:
+        op.execute(
+            sa.text(
+                f"ALTER TABLE {_SCHEMA}.{_TABLE} "
+                f"ADD CONSTRAINT {_FK_NAME} "
+                f"FOREIGN KEY ({_COLUMN}) "
+                f"REFERENCES {_SCHEMA}.knowledge_documents(id) ON DELETE CASCADE"
+            )
+        )
+
+    index_exists = bind.execute(
+        sa.text("SELECT 1 FROM pg_indexes WHERE schemaname = :schema AND indexname = :idx"),
+        {"schema": _SCHEMA, "idx": _INDEX_NAME},
+    ).scalar()
+    if not index_exists:
+        op.execute(
+            sa.text(
+                f"""
+                CREATE INDEX IF NOT EXISTS {_INDEX_NAME}
+                ON {_SCHEMA}.{_TABLE} ({_COLUMN})
+                WHERE {_COLUMN} IS NOT NULL
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    index_exists = bind.execute(
+        sa.text("SELECT 1 FROM pg_indexes WHERE schemaname = :schema AND indexname = :idx"),
+        {"schema": _SCHEMA, "idx": _INDEX_NAME},
+    ).scalar()
+    if index_exists:
+        op.execute(sa.text(f"DROP INDEX IF EXISTS {_SCHEMA}.{_INDEX_NAME}"))
+
+    fk_exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = :schema AND table_name = :table AND constraint_name = :fk"
+        ),
+        {"schema": _SCHEMA, "table": _TABLE, "fk": _FK_NAME},
+    ).scalar()
+    if fk_exists:
+        op.execute(sa.text(f"ALTER TABLE {_SCHEMA}.{_TABLE} DROP CONSTRAINT IF EXISTS {_FK_NAME}"))
+
+    column_exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = :schema AND table_name = :table AND column_name = :col"
+        ),
+        {"schema": _SCHEMA, "table": _TABLE, "col": _COLUMN},
+    ).scalar()
+    if column_exists:
+        op.execute(sa.text(f"ALTER TABLE {_SCHEMA}.{_TABLE} DROP COLUMN IF EXISTS {_COLUMN}"))

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1955,14 +1955,10 @@ def _is_url_document(doc: Any) -> bool:
 
 
 def _resolve_document_source_uri(doc: Any) -> str | None:
-    metadata = doc.metadata_ or {}
-    if metadata.get("source_type") == "url":
-        origin_url = metadata.get("origin_url")
-        if isinstance(origin_url, str) and origin_url:
-            return origin_url
-    if doc.gcs_uri:
-        return doc.gcs_uri
-    return None
+    """Thin wrapper：复用 storage 层下沉后的统一实现，避免跨层重复（ISSUE-078 Phase 2）。"""
+    from negentropy.storage.service import resolve_document_source_uri as _resolve
+
+    return _resolve(doc)
 
 
 def _resolve_chunking_config_from_doc_request(

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -143,6 +143,8 @@ class KnowledgeRepository:
             return []
 
         # 准备批量插入数据
+        # ``document_id``（ISSUE-078 Phase 3）：仅当 ingest 入口能拿到 doc 上下文时填充，
+        # 否则保留 None；DB 层 FK ``ON DELETE CASCADE`` 让 doc 删除时自动级联清理 chunks。
         values = [
             {
                 "corpus_id": corpus_id,
@@ -155,6 +157,7 @@ class KnowledgeRepository:
                 "retrieval_count": 0,
                 "is_enabled": True,
                 "metadata_": chunk.metadata or {},
+                "document_id": chunk.document_id,
             }
             for chunk in chunk_list
         ]

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -1767,6 +1767,14 @@ class KnowledgeService:
         deleted_documents = 0
         deleted_gcs_objects = 0
 
+        # 自 ISSUE-078 Phase 2 起：DocumentStorageService.delete_document 的硬删
+        # 分支已在同一事务内级联清理对应 chunks。此处仍保留 delete_knowledge_by_source
+        # 兜底调用，覆盖 storage_service 路径未覆盖的两类场景：
+        #   1. ``source_uri`` 不是 ``gs://...``（如 URL 类的 ``origin_url``）
+        #      → 进不到上面 storage 分支，必须走仓库直接按 source_uri 清理；
+        #   2. doc 在 ``check_duplicate`` 之前已被先前删除路径硬删（chunks 残留为孤儿）
+        #      → storage_service 找不到 doc，但仓库仍能按 source_uri 兜底清理。
+        # 当 storage_service 已删除 chunks 时，此调用返回 0（语义幂等，不影响正确性）。
         if source_uri.startswith("gs://"):
             from negentropy.storage.gcs_client import StorageError
             from negentropy.storage.service import DocumentStorageService

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -842,6 +842,7 @@ class KnowledgeService:
                 metadata=meta,
                 chunking_config=chunking_config or self._chunking_config,
                 tracker=tracker,
+                document_id=doc_record.id,
             )
             await tracker.complete({"chunk_count": len(records), "document_id": str(doc_record.id)})
 
@@ -990,6 +991,7 @@ class KnowledgeService:
                 metadata=normalize_source_metadata(source_uri=source_uri, metadata=metadata),
                 chunking_config=config,
                 tracker=tracker,
+                document_id=document_id,
             )
             await tracker.complete(
                 {
@@ -1558,8 +1560,15 @@ class KnowledgeService:
         metadata: dict[str, Any] | None = None,
         chunking_config: ChunkingConfig | None = None,
         tracker: PipelineTracker | None = None,
+        document_id: UUID | None = None,
     ) -> list[KnowledgeRecord]:
-        """内部方法：执行文本摄入，支持可选的 Pipeline 追踪"""
+        """内部方法：执行文本摄入，支持可选的 Pipeline 追踪。
+
+        ``document_id``（ISSUE-078 Phase 3）：仅当 ingest 入口能拿到 doc 上下文
+        （URL-as-document / 文件 ingest）时传入；为每个 chunk 建立 FK 关联，让 DB
+        层的 ``ON DELETE CASCADE`` 在 doc 删除时自动级联清理 chunks。
+        其他无 doc 来源的入口（纯文本、URL、replace、rebuild）保留 None。
+        """
         config = chunking_config or self._chunking_config
         # Corpus 级 Embedding 模型解析：存在则按需构建 fn，否则回退 service 默认。
         corpus_record = await self._repository.get_corpus_by_id(corpus_id)
@@ -1575,6 +1584,13 @@ class KnowledgeService:
             metadata=metadata,
             chunking_config=config,
         )
+
+        # ISSUE-078 Phase 3：单点 stamp document_id，避免大面积改造 _build_chunks
+        # 与其他下游函数；KnowledgeChunk 是 frozen dataclass，用 dataclasses.replace。
+        if document_id is not None:
+            from dataclasses import replace as _dc_replace
+
+            chunks = [_dc_replace(c, document_id=document_id) for c in chunks]
 
         if tracker:
             await tracker.complete_stage(
@@ -3167,32 +3183,39 @@ class KnowledgeService:
         if not record_list:
             return
 
-        storage_service = DocumentStorageService()
-        document = await storage_service.get_document_by_source_uri(
-            source_uri=source_uri,
-            corpus_id=corpus_id,
-            app_name=app_name,
-        )
-        if not document:
-            return
+        try:
+            storage_service = DocumentStorageService()
+            document = await storage_service.get_document_by_source_uri(
+                source_uri=source_uri,
+                corpus_id=corpus_id,
+                app_name=app_name,
+            )
+            if not document:
+                return
 
-        total_characters = sum(item.character_count for item in record_list)
-        avg_length = int(total_characters / len(record_list)) if record_list else 0
-        metadata_patch = {
-            "chunk_stats": {
-                "chunk_specification": getattr(chunking_config.strategy, "value", str(chunking_config.strategy)),
-                "chunk_length": avg_length,
-                "avg_paragraph_length": avg_length,
-                "paragraph_count": len(record_list),
-                "embedding_time_ms": None,
-                "embedded_tokens": int(total_characters / 4),
-                "last_chunked_at": datetime.now(UTC).isoformat(),
+            total_characters = sum(item.character_count for item in record_list)
+            avg_length = int(total_characters / len(record_list)) if record_list else 0
+            metadata_patch = {
+                "chunk_stats": {
+                    "chunk_specification": getattr(chunking_config.strategy, "value", str(chunking_config.strategy)),
+                    "chunk_length": avg_length,
+                    "avg_paragraph_length": avg_length,
+                    "paragraph_count": len(record_list),
+                    "embedding_time_ms": None,
+                    "embedded_tokens": int(total_characters / 4),
+                    "last_chunked_at": datetime.now(UTC).isoformat(),
+                }
             }
-        }
-        await storage_service.update_document_metadata(
-            document_id=document.id,
-            metadata_patch=metadata_patch,
-        )
+            await storage_service.update_document_metadata(
+                document_id=document.id,
+                metadata_patch=metadata_patch,
+            )
+        except Exception:
+            logger.warning(
+                "sync_document_chunk_stats_failed",
+                source_uri=source_uri,
+                corpus_id=str(corpus_id),
+            )
 
     def _merge_matches(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/types.py
+++ b/apps/negentropy/src/negentropy/knowledge/types.py
@@ -75,6 +75,13 @@ class KnowledgeChunk:
     """知识块
 
     表示待索引的文本分块，包含内容和元数据。
+
+    ``document_id``（ISSUE-078 Phase 3）：指向写入来源 ``KnowledgeDocument`` 的
+    UUID，仅当 ingest 入口能拿到 doc 上下文（``execute_ingest_url_document_pipeline``
+    与 ``execute_ingest_file_pipeline``）时填充；纯文本/URL ingest、replace、
+    rebuild、KG 类直连知识等无 doc 来源的入口保留 None。Knowledge 表通过 FK
+    ``ON DELETE CASCADE`` 让 doc 删除自动清理 chunks，与 Phase 2 应用层级联形成
+    belt-and-suspenders。
     """
 
     content: str
@@ -82,6 +89,7 @@ class KnowledgeChunk:
     chunk_index: int = 0
     metadata: dict[str, Any] = field(default_factory=dict)
     embedding: list[float] | None = None
+    document_id: UUID | None = None
 
 
 @dataclass(frozen=True)

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -65,6 +65,14 @@ class Knowledge(Base, UUIDMixin, TimestampMixin):
     corpus_id: Mapped[UUID] = mapped_column(
         ForeignKey(f"{NEGENTROPY_SCHEMA}.corpus.id", ondelete="CASCADE"), nullable=False
     )
+    # ISSUE-078 Phase 3：DB 层文档级 CASCADE 防御。
+    # nullable=True 因 KG 类直连知识无 doc 来源；指向 doc 的 chunks 在 doc 被删时
+    # 自动 CASCADE 清理（与 Phase 2 应用层级联形成 belt-and-suspenders）。
+    # 历史 chunks 通过独立 CLI cleanup_orphan_knowledge 一次性回填。
+    document_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey(f"{NEGENTROPY_SCHEMA}.knowledge_documents.id", ondelete="CASCADE"),
+        nullable=True,
+    )
     app_name: Mapped[str] = mapped_column(String(255), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     embedding: Mapped[list[float] | None] = mapped_column(Vector(DEFAULT_EMBEDDING_DIM))

--- a/apps/negentropy/src/negentropy/scripts/__init__.py
+++ b/apps/negentropy/src/negentropy/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""一次性运维脚本（操作型 CLI）。
+
+与主 ``cli.py`` 区分：``cli.py`` 是常驻 CLI 入口（serve / init），本包下的工具
+是一次性数据清算 / 修复脚本，通过 ``python -m negentropy.scripts.<tool>`` 运行。
+"""

--- a/apps/negentropy/src/negentropy/scripts/cleanup_orphan_knowledge.py
+++ b/apps/negentropy/src/negentropy/scripts/cleanup_orphan_knowledge.py
@@ -1,0 +1,376 @@
+"""一次性清算 ``Knowledge`` 表中的孤儿 chunks 与 ``document_id`` 回填（ISSUE-078 Phase 3）。
+
+设计动机
+========
+
+本脚本独立于 alembic 迁移：迁移内 ``DELETE`` 不可逆、无 dry-run、无审批环节，
+不适合大规模数据清算。本脚本提供 ``--dry-run`` / ``--commit`` 两态、按 corpus
+/ app 维度可选 scope 的运维流程，让 DBA 在 staging 与生产分别审计后再决策。
+
+工作流
+------
+
+按以下顺序执行（``--dry-run`` 模式只报告、``--commit`` 真正写库）：
+
+1. **回填**：对 ``Knowledge.document_id IS NULL`` 的行，基于 ``(corpus_id,
+   app_name, source_uri)`` 匹配 ``KnowledgeDocument.gcs_uri`` 或
+   ``metadata->>'origin_url'``，回填 ``document_id``。包含软删 doc（其 chunks
+   也应有 FK 关联以便随 doc 行为联动）。
+2. **报告**：按 corpus 分组输出 ``total / linked / unlinked / would_delete`` 四档计数，
+   stdout JSON 与 logger 同时落，便于审计存档。
+3. **清理**：仅当 ``document_id IS NULL AND source_uri IS NOT NULL AND
+   source_uri ~ '^(gs://|https?://)'`` 才删除（白名单形态，规避内部脏数据 /
+   奇异 URI）。``source_uri IS NULL`` 的合法 KG 类直连知识保留。
+4. ``--commit`` 模式整体单事务执行，失败可整体回滚。
+
+用法
+----
+
+::
+
+    # 全库 dry-run（推荐先跑这个）
+    uv run python -m negentropy.scripts.cleanup_orphan_knowledge --dry-run
+
+    # 按 corpus 范围
+    uv run python -m negentropy.scripts.cleanup_orphan_knowledge \\
+        --dry-run --corpus-id 12345678-...
+
+    # 按 app 范围（多租户场景）
+    uv run python -m negentropy.scripts.cleanup_orphan_knowledge \\
+        --dry-run --app-name negentropy
+
+    # 真正执行（需 DBA 备份）
+    uv run python -m negentropy.scripts.cleanup_orphan_knowledge --commit
+
+返回值
+------
+
+退出码 0 表示成功，非零表示存在错误（DB 连接 / 参数 / 内部异常）。
+
+参考
+----
+
+[1] PostgreSQL Documentation, "DELETE Statement" — 大事务 DELETE 与锁定语义
+[2] ISSUE-078 RCA + Phase 1/2/3 处理记录（``docs/issue.md``）
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from sqlalchemy import text
+
+from negentropy.db.session import AsyncSessionLocal
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.scripts.cleanup_orphan_knowledge")
+
+_SCHEMA = "negentropy"
+
+# ----- SQL 模板（按是否传入 scope 参数动态拼接 WHERE 子句） -----------------
+# 不使用 ``:param::type IS NULL`` 形式——asyncpg 不接受占位符与显式 cast 同时
+# 出现。改为根据 corpus_id / app_name 是否提供，构造对应的额外谓词列表。
+
+
+def _build_scope_clauses(
+    *,
+    corpus_id: str | None,
+    app_name: str | None,
+    table_alias: str,
+) -> tuple[str, dict[str, Any]]:
+    extras: list[str] = []
+    params: dict[str, Any] = {}
+    if corpus_id is not None:
+        extras.append(f"AND {table_alias}.corpus_id = :corpus_id")
+        params["corpus_id"] = corpus_id
+    if app_name is not None:
+        extras.append(f"AND {table_alias}.app_name = :app_name")
+        params["app_name"] = app_name
+    return ("\n      ".join(extras), params)
+
+
+def _backfill_sql(*, corpus_id: str | None, app_name: str | None) -> tuple[Any, dict[str, Any]]:
+    """回填：对 document_id IS NULL 的行，基于 source_uri 匹配回填，优先选取 active doc。
+
+    ``UPDATE ... FROM`` 仅更新子查询有匹配的行（JOIN 驱动），孤儿行自然被排除。
+    子查询中 ``DISTINCT ON (k_sub.id) + ORDER BY`` 确保当同 corpus 内多个 doc
+    （active + soft-deleted）共享同一 source_uri 时，优先链接 active doc。
+    """
+    extras, params = _build_scope_clauses(corpus_id=corpus_id, app_name=app_name, table_alias="k_sub")
+    sql = text(
+        f"""
+        UPDATE {_SCHEMA}.knowledge k
+        SET document_id = best_doc.doc_id
+        FROM (
+            SELECT DISTINCT ON (k_sub.id)
+                k_sub.id AS kid,
+                d.id AS doc_id
+            FROM {_SCHEMA}.knowledge k_sub
+            JOIN {_SCHEMA}.knowledge_documents d
+               ON d.corpus_id = k_sub.corpus_id
+              AND d.app_name = k_sub.app_name
+              AND (d.gcs_uri = k_sub.source_uri
+                   OR d.metadata->>'origin_url' = k_sub.source_uri)
+            WHERE k_sub.source_uri IS NOT NULL
+              AND k_sub.document_id IS NULL
+              {extras}
+            ORDER BY k_sub.id,
+                     CASE WHEN d.status = 'active' THEN 0 ELSE 1 END,
+                     d.created_at DESC
+        ) best_doc
+        WHERE k.id = best_doc.kid
+        """
+    )
+    return sql, params
+
+
+def _stats_sql(*, corpus_id: str | None, app_name: str | None) -> tuple[Any, dict[str, Any]]:
+    """按 corpus 分组列出 total / linked / unlinked / would_delete 四档计数。
+
+    would_delete 与 ``_delete_sql`` 的过滤条件保持一致，确保 dry-run 报告准确。
+    """
+    extras, params = _build_scope_clauses(corpus_id=corpus_id, app_name=app_name, table_alias="k")
+    where = ("WHERE 1 = 1\n      " + extras) if extras else ""
+    sql = text(
+        f"""
+        SELECT
+            c.id AS corpus_id,
+            c.name AS corpus_name,
+            COUNT(*)                                                     AS total,
+            COUNT(*) FILTER (WHERE k.document_id IS NOT NULL)             AS linked,
+            COUNT(*) FILTER (WHERE k.document_id IS NULL)                 AS unlinked,
+            COUNT(*) FILTER (WHERE k.document_id IS NULL
+                               AND k.source_uri IS NOT NULL
+                               AND k.source_uri ~ '^(gs://|https?://)')   AS would_delete
+        FROM {_SCHEMA}.knowledge k
+        JOIN {_SCHEMA}.corpus c ON c.id = k.corpus_id
+        {where}
+        GROUP BY c.id, c.name
+        ORDER BY would_delete DESC, total DESC
+        """
+    )
+    return sql, params
+
+
+def _delete_sql(*, corpus_id: str | None, app_name: str | None) -> tuple[Any, dict[str, Any]]:
+    """白名单形态 + 仍未 linked 的孤儿才删除；KG 类（source_uri NULL）保留。"""
+    extras, params = _build_scope_clauses(corpus_id=corpus_id, app_name=app_name, table_alias="knowledge")
+    sql = text(
+        f"""
+        DELETE FROM {_SCHEMA}.knowledge
+        WHERE document_id IS NULL
+          AND source_uri IS NOT NULL
+          AND source_uri ~ '^(gs://|https?://)'
+          {extras}
+        """
+    )
+    return sql, params
+
+
+async def _run(
+    *,
+    commit: bool,
+    corpus_id: str | None,
+    app_name: str | None,
+) -> dict[str, Any]:
+    """执行清算流程，返回报告 dict。整体单事务（commit 模式）。"""
+    backfill_stmt, backfill_params = _backfill_sql(corpus_id=corpus_id, app_name=app_name)
+    stats_stmt, stats_params = _stats_sql(corpus_id=corpus_id, app_name=app_name)
+    delete_stmt, delete_params = _delete_sql(corpus_id=corpus_id, app_name=app_name)
+
+    async with AsyncSessionLocal() as session:
+        # Step 1: 回填 document_id（dry-run 也回填以让统计真实反映可清理量；
+        # 之所以安全：回填本身是无损操作，只是把空字段补上正确的 FK；commit 模式
+        # 才真正落库，dry-run 模式下事务不 commit 即可丢弃）。
+        backfill_result = await session.execute(backfill_stmt, backfill_params)
+        backfilled_count = backfill_result.rowcount or 0
+        logger.info(
+            "cleanup_orphan_knowledge_backfill",
+            backfilled=backfilled_count,
+            corpus_id=corpus_id,
+            app_name=app_name,
+        )
+
+        # Step 2: 统计报告
+        stats_result = await session.execute(stats_stmt, stats_params)
+        per_corpus_rows = stats_result.fetchall()
+        per_corpus = [
+            {
+                "corpus_id": str(row.corpus_id),
+                "corpus_name": row.corpus_name,
+                "total": int(row.total or 0),
+                "linked": int(row.linked or 0),
+                "unlinked": int(row.unlinked or 0),
+                "would_delete": int(row.would_delete or 0),
+            }
+            for row in per_corpus_rows
+        ]
+        total_would_delete = sum(item["would_delete"] for item in per_corpus)
+
+        # Step 3: 清理（仅 commit 模式真正 DELETE）
+        deleted_count = 0
+        if commit:
+            del_result = await session.execute(delete_stmt, delete_params)
+            deleted_count = del_result.rowcount or 0
+            await session.commit()
+            logger.info(
+                "cleanup_orphan_knowledge_committed",
+                deleted=deleted_count,
+                backfilled=backfilled_count,
+                corpus_id=corpus_id,
+                app_name=app_name,
+            )
+        else:
+            await session.rollback()
+            logger.info(
+                "cleanup_orphan_knowledge_dry_run",
+                would_delete=total_would_delete,
+                backfilled=backfilled_count,
+                corpus_id=corpus_id,
+                app_name=app_name,
+            )
+
+        return {
+            "mode": "commit" if commit else "dry-run",
+            "scope": {
+                "corpus_id": corpus_id,
+                "app_name": app_name,
+            },
+            "backfilled": backfilled_count,
+            "would_delete_total": total_would_delete,
+            "deleted": deleted_count,
+            "per_corpus": per_corpus,
+        }
+
+
+async def count_orphan_knowledge(
+    *,
+    corpus_id: str | None = None,
+    app_name: str | None = None,
+) -> dict[str, Any]:
+    """轻量观测函数：返回当前孤儿 chunks 计数（供监控 cron 调用）。
+
+    返回结构::
+
+        {
+            "total_orphans": int,
+            "per_corpus": [{"corpus_id", "corpus_name", "orphans", "total"}, ...]
+        }
+
+    与 CLI 内部的 ``_stats_sql`` 共用同一个口径（``document_id IS NULL`` +
+    白名单 source_uri 形态），避免「每日扫描数」与「实际可清理数」漂移。
+    建议接入方式：
+      - cron 每天调用，将 ``total_orphans`` 上报为 metric
+        ``negentropy.knowledge.orphan_count{corpus_id}``；
+      - 阈值告警：``total_orphans > 0`` 触发，提示存在新增孤儿（即便 Phase 1/2/3
+        三层防御也兜住了路径，仍是实际入侵 / 异常 SQL 的 canary）。
+    """
+    stats_stmt, params = _stats_sql(corpus_id=corpus_id, app_name=app_name)
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(stats_stmt, params)
+        rows = result.fetchall()
+
+    per_corpus = [
+        {
+            "corpus_id": str(row.corpus_id),
+            "corpus_name": row.corpus_name,
+            "orphans": int(row.would_delete or 0),
+            "total": int(row.total or 0),
+        }
+        for row in rows
+    ]
+    return {
+        "total_orphans": sum(item["orphans"] for item in per_corpus),
+        "per_corpus": per_corpus,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cleanup_orphan_knowledge",
+        description=(
+            "ISSUE-078 Phase 3：回填 Knowledge.document_id 并清理孤儿 chunks。"
+            "默认安全语义——必须显式指定 --dry-run 或 --commit。"
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="只报告 would_delete 计数，不实际写库（事务回滚）；推荐先在 staging 跑这个。",
+    )
+    mode.add_argument(
+        "--commit",
+        action="store_true",
+        help="真正执行回填 + 清理（整体单事务）；执行前请由 DBA 备份。",
+    )
+    parser.add_argument(
+        "--corpus-id",
+        type=str,
+        default=None,
+        help="可选：限定为指定 corpus_id（UUID）。",
+    )
+    parser.add_argument(
+        "--app-name",
+        type=str,
+        default=None,
+        help="可选：限定为指定 app_name（多租户隔离）。",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="结果以 JSON 格式输出至 stdout（默认人类可读 + JSON 摘要）。",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    commit = bool(args.commit)
+
+    try:
+        report = asyncio.run(
+            _run(
+                commit=commit,
+                corpus_id=args.corpus_id,
+                app_name=args.app_name,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — CLI 顶层兜底
+        logger.error("cleanup_orphan_knowledge_failed", error=str(exc), exc_info=True)
+        print(f"FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json_output:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print("=" * 70)
+        print(f"  Mode: {report['mode'].upper()}")
+        print(f"  Scope: corpus_id={report['scope']['corpus_id']}, app_name={report['scope']['app_name']}")
+        print(f"  Backfilled document_id: {report['backfilled']}")
+        if commit:
+            print(f"  Deleted orphan chunks: {report['deleted']}")
+        else:
+            print(f"  Would-delete orphan chunks: {report['would_delete_total']}")
+        print("-" * 70)
+        print(f"  Per-corpus breakdown ({len(report['per_corpus'])} corpora):")
+        for item in report["per_corpus"]:
+            print(
+                f"    [{item['corpus_id']}] {item['corpus_name']:<30s} "
+                f"total={item['total']:>6d}  linked={item['linked']:>6d}  "
+                f"unlinked={item['unlinked']:>6d}  would_delete={item['would_delete']:>6d}"
+            )
+        print("=" * 70)
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -10,16 +10,39 @@ from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import delete, func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
-from negentropy.models.perception import KnowledgeDocument
+from negentropy.models.base import NEGENTROPY_SCHEMA
+from negentropy.models.perception import Knowledge, KnowledgeDocument
 
 from .gcs_client import GCSStorageClient, StorageError
 
 logger = get_logger("negentropy.storage.service")
+
+
+def resolve_document_source_uri(doc: KnowledgeDocument | None) -> str | None:
+    """统一解析 KnowledgeDocument 对应的 ``source_uri``。
+
+    Knowledge 行通过 ``source_uri`` 软关联到 KnowledgeDocument：
+      - URL 类文档（``metadata.source_type == 'url'``）：取 ``metadata.origin_url``；
+      - 普通上传文档：取 ``gcs_uri``。
+
+    与 ``api.py`` 同名 helper 的语义保持一致；本函数下沉到 storage 层供 storage
+    服务内部直接复用，避免跨层耦合（详见 ISSUE-078 Phase 2）。
+    """
+    if doc is None:
+        return None
+    metadata = doc.metadata_ or {}
+    if metadata.get("source_type") == "url":
+        origin_url = metadata.get("origin_url")
+        if isinstance(origin_url, str) and origin_url:
+            return origin_url
+    if doc.gcs_uri:
+        return doc.gcs_uri
+    return None
 
 
 class DocumentStorageService:
@@ -87,6 +110,90 @@ class DocumentStorageService:
             result = await db.execute(stmt)
             return result.scalar_one_or_none()
 
+    # ------------------------------------------------------------------
+    # Knowledge chunks 联动（ISSUE-078 Phase 2）
+    #
+    # KnowledgeDocument 与 Knowledge 之间没有数据库级 FK（仅靠 source_uri 文本
+    # 软关联，详见 ISSUE-078 RCA），因此 doc 删除/复活路径必须主动维护 chunks
+    # 生命周期，避免：
+    #   - 硬删后 chunks 成为孤儿（FK 意义孤儿，污染 corpus 计数与检索）
+    #   - 软删后 chunks 仍被 RAG 检索命中（污染语义 / 关键词搜索结果）
+    #   - reactivation 旧 chunks 与新 ingest 叠加（双套互不一致 chunks）
+    #
+    # 三类操作均在与 doc 同一 session 内执行，确保事务原子性。
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _hard_delete_chunks_in_session(
+        db,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        source_uri: str | None,
+    ) -> int:
+        """硬删除指定 doc 对应的全部 chunks（父+子，hierarchical 共享 source_uri）。
+
+        ``source_uri IS NULL`` 时不做删除（KG 类直连知识无 doc 来源，永远不应被
+        doc 删除路径误删）；返回删除行数供日志审计。
+        """
+        if source_uri is None:
+            return 0
+        stmt = delete(Knowledge).where(
+            Knowledge.corpus_id == corpus_id,
+            Knowledge.app_name == app_name,
+            Knowledge.source_uri == source_uri,
+        )
+        result = await db.execute(stmt)
+        return result.rowcount or 0
+
+    @staticmethod
+    async def _archive_chunks_in_session(
+        db,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        source_uri: str | None,
+    ) -> int:
+        """软删除联动：批量给指定 doc 的全部 chunks 打 ``archived=true`` 与 ``is_enabled=false``。
+
+        语义与 ``KnowledgeService.archive_source`` 对齐（ISSUE-078 Phase 2 复用范式）：
+          - ``metadata.archived = true`` 让既有 ``_active_filter_expr`` 过滤生效，
+            chunks 不再参与 corpus 计数 / 检索；
+          - ``is_enabled = false`` 是冗余防御层，所有走 ``_enabled_filter_expr``
+            的检索路径同样会跳过它们。
+
+        软删可恢复：reactivation 路径会直接 hard delete 旧 chunks 让重新 ingest
+        写一份干净的，因此不必在此处处理 unset 反向操作。
+
+        使用 ``jsonb_set`` 原生函数（与 ``archive_knowledge_by_source`` 同范式），
+        避免 SQLAlchemy 表达式层 cast 的类型不匹配。
+        """
+        if source_uri is None:
+            return 0
+        stmt = text(
+            f"""
+            UPDATE {NEGENTROPY_SCHEMA}.knowledge
+            SET metadata = jsonb_set(
+                    COALESCE(metadata, '{{}}'::jsonb),
+                    '{{archived}}',
+                    'true'::jsonb
+                ),
+                is_enabled = FALSE
+            WHERE corpus_id = :corpus_id
+              AND app_name = :app_name
+              AND source_uri = :source_uri
+            """
+        )
+        result = await db.execute(
+            stmt,
+            {
+                "corpus_id": corpus_id,
+                "app_name": app_name,
+                "source_uri": source_uri,
+            },
+        )
+        return result.rowcount or 0
+
     @staticmethod
     def _best_effort_cleanup_gcs(
         gcs_client: GCSStorageClient,
@@ -153,6 +260,19 @@ class DocumentStorageService:
                 old_metadata=doc.metadata_,
             )
 
+            # 复活联动（ISSUE-078 Phase 2）：旧 chunks（软删时被 archive 的）必须
+            # 在重置 doc 状态前 hard delete，让随后的 markdown 重新提取 + 重新
+            # ingest 写入一份干净的；否则旧 archived chunks 与新 chunks 叠加
+            # （source_uri 相同），既污染检索（部分仍 archived 但 query 解 archive），
+            # 又让 corpus 计数与文档详情口径再次出错。
+            old_source_uri = resolve_document_source_uri(doc)
+            purged_count = await self._hard_delete_chunks_in_session(
+                db,
+                corpus_id=doc.corpus_id,
+                app_name=doc.app_name,
+                source_uri=old_source_uri,
+            )
+
             doc.status = "active"
             doc.gcs_uri = gcs_uri
             doc.original_filename = filename
@@ -175,6 +295,8 @@ class DocumentStorageService:
                 corpus_id=str(doc.corpus_id),
                 gcs_uri=gcs_uri,
                 file_hash=doc.file_hash,
+                reactivate_purge_chunks=purged_count,
+                old_source_uri=old_source_uri,
             )
             return doc
 
@@ -395,6 +517,12 @@ class DocumentStorageService:
     ) -> bool:
         """Delete document (soft or hard delete).
 
+        Phase 2（ISSUE-078）联动 Knowledge chunks 生命周期：
+          - 软删：批量 archive chunks（``metadata.archived=true`` + ``is_enabled=false``），
+            防止 RAG 检索仍命中已删 doc；语义可逆，reactivation 时由
+            ``_reactivate_document`` 直接 hard delete 旧 chunks 让重新 ingest 写一份干净的。
+          - 硬删：在同一事务内删除 chunks 后再删除 doc 行，杜绝 FK 意义孤儿。
+
         Args:
             document_id: Document UUID to delete
             corpus_id: Optional corpus UUID for validation
@@ -417,13 +545,26 @@ class DocumentStorageService:
             if not doc:
                 return False
 
+            doc_corpus_id = doc.corpus_id
+            doc_app_name = doc.app_name
+            source_uri = resolve_document_source_uri(doc)
+
             if soft_delete:
+                # 软删联动：先 archive chunks 再标记 doc，单事务原子提交。
+                archived_count = await self._archive_chunks_in_session(
+                    db,
+                    corpus_id=doc_corpus_id,
+                    app_name=doc_app_name,
+                    source_uri=source_uri,
+                )
                 doc.status = "deleted"
                 await db.commit()
                 logger.info(
                     "document_soft_deleted",
                     doc_id=str(document_id),
                     corpus_id=str(corpus_id),
+                    chunks_archived=archived_count,
+                    source_uri=source_uri,
                 )
             else:
                 # Hard delete: remove from GCS first
@@ -456,12 +597,21 @@ class DocumentStorageService:
                         error=str(exc),
                     )
 
+                # 硬删联动：先删 chunks 再删 doc，单事务原子提交，杜绝 FK 意义孤儿。
+                chunks_deleted = await self._hard_delete_chunks_in_session(
+                    db,
+                    corpus_id=doc_corpus_id,
+                    app_name=doc_app_name,
+                    source_uri=source_uri,
+                )
                 await db.delete(doc)
                 await db.commit()
                 logger.info(
                     "document_hard_deleted",
                     doc_id=str(document_id),
                     corpus_id=str(corpus_id),
+                    chunks_deleted=chunks_deleted,
+                    source_uri=source_uri,
                 )
 
             return True

--- a/apps/negentropy/tests/conftest.py
+++ b/apps/negentropy/tests/conftest.py
@@ -5,6 +5,13 @@ from negentropy.config import settings
 from negentropy.db import deps as db_deps
 from negentropy.db import session as db_session
 
+# Modules that use `from negentropy.db.session import AsyncSessionLocal` —
+# the name binding at import time is not updated by monkeypatching db_session,
+# so each must be patched individually.
+from negentropy.knowledge import api as _knowledge_api
+from negentropy.scripts import cleanup_orphan_knowledge as _cleanup_script
+from negentropy.storage import service as _storage_service
+
 
 @pytest.fixture(scope="function")
 async def db_engine():
@@ -44,5 +51,10 @@ async def patch_db_globals(db_engine, monkeypatch):
 
     # Also patch deps.AsyncSessionLocal because it imports it directly
     monkeypatch.setattr(db_deps, "AsyncSessionLocal", TestAsyncSessionLocal)
+
+    # Patch storage.service.AsyncSessionLocal — it uses `from ... import AsyncSessionLocal`
+    # which binds the name at import time, so monkeypatching db_session alone is insufficient.
+    for mod in (_storage_service, _cleanup_script, _knowledge_api):
+        monkeypatch.setattr(mod, "AsyncSessionLocal", TestAsyncSessionLocal)
 
     yield

--- a/apps/negentropy/tests/integration_tests/knowledge/test_phase3_document_fk.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_phase3_document_fk.py
@@ -1,0 +1,362 @@
+"""Phase 3 集成测试：FK CASCADE + 写入路径 + CLI 回填/清理。
+
+ISSUE-078 Phase 3 验收回归：
+
+  - DB 层 FK ``ON DELETE CASCADE``：直接 DELETE knowledge_documents 行时
+    Knowledge 自动级联清理（即便 bypass 应用层 storage_service）
+  - ORM 字段 ``Knowledge.document_id`` 可读写
+  - CLI ``cleanup_orphan_knowledge``：dry-run 不落库 / commit 落库 / scope 过滤
+  - count_orphan_knowledge 观测函数返回正确 per-corpus 计数
+
+采用「单 test 函数 + 多场景子断言」模式（与 Phase 1 / Phase 2 同范式）。
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from sqlalchemy import delete, select, text
+
+from negentropy.db import session as db_session
+from negentropy.models.perception import Corpus, Knowledge, KnowledgeDocument
+from negentropy.scripts.cleanup_orphan_knowledge import (
+    _run as cleanup_run,
+)
+from negentropy.scripts.cleanup_orphan_knowledge import (
+    count_orphan_knowledge,
+)
+
+
+async def _create_corpus(*, app_name: str, name: str) -> UUID:
+    async with db_session.AsyncSessionLocal() as session:
+        corpus = Corpus(name=name, app_name=app_name)
+        session.add(corpus)
+        await session.flush()
+        await session.commit()
+        return corpus.id
+
+
+async def _create_document(
+    *,
+    corpus_id: UUID,
+    app_name: str,
+    gcs_uri: str,
+    metadata: dict | None = None,
+) -> UUID:
+    async with db_session.AsyncSessionLocal() as session:
+        doc = KnowledgeDocument(
+            corpus_id=corpus_id,
+            app_name=app_name,
+            file_hash=uuid4().hex,
+            original_filename=gcs_uri.rsplit("/", 1)[-1],
+            gcs_uri=gcs_uri,
+            content_type="text/plain",
+            file_size=100,
+            status="active",
+            metadata_=metadata or {},
+        )
+        session.add(doc)
+        await session.flush()
+        await session.commit()
+        return doc.id
+
+
+async def _insert_knowledge(
+    *,
+    corpus_id: UUID,
+    app_name: str,
+    source_uri: str | None,
+    document_id: UUID | None = None,
+    metadata: dict | None = None,
+    count: int = 1,
+) -> None:
+    async with db_session.AsyncSessionLocal() as session:
+        for idx in range(count):
+            session.add(
+                Knowledge(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    content=f"chunk-{idx}",
+                    source_uri=source_uri,
+                    chunk_index=idx,
+                    document_id=document_id,
+                    metadata_=metadata or {},
+                )
+            )
+        await session.commit()
+
+
+async def _count(
+    *,
+    corpus_id: UUID,
+    document_id: UUID | None = None,
+    has_document_id: bool | None = None,
+) -> int:
+    from sqlalchemy import func
+
+    async with db_session.AsyncSessionLocal() as session:
+        stmt = select(func.count()).select_from(Knowledge).where(Knowledge.corpus_id == corpus_id)
+        if document_id is not None:
+            stmt = stmt.where(Knowledge.document_id == document_id)
+        if has_document_id is True:
+            stmt = stmt.where(Knowledge.document_id.is_not(None))
+        elif has_document_id is False:
+            stmt = stmt.where(Knowledge.document_id.is_(None))
+        result = await session.execute(stmt)
+        return result.scalar() or 0
+
+
+async def _cleanup(*, app_name: str) -> None:
+    async with db_session.AsyncSessionLocal() as session:
+        await session.execute(delete(Knowledge).where(Knowledge.app_name == app_name))
+        await session.execute(delete(KnowledgeDocument).where(KnowledgeDocument.app_name == app_name))
+        await session.execute(delete(Corpus).where(Corpus.app_name == app_name))
+        await session.commit()
+
+
+async def _scenario_orm_field_roundtrip(app: str) -> None:
+    """场景 1：ORM Knowledge.document_id 读写正确，nullable 接受 None。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-orm")
+    doc_id = await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/orm.pdf")
+
+    # 显式带 document_id
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/orm.pdf",
+        document_id=doc_id,
+        metadata={"chunk_role": "parent"},
+        count=2,
+    )
+    # 不带 document_id（KG 类）
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri=None,
+        document_id=None,
+        metadata={"chunk_role": "leaf"},
+        count=3,
+    )
+
+    assert await _count(corpus_id=corpus_id, has_document_id=True) == 2
+    assert await _count(corpus_id=corpus_id, has_document_id=False) == 3
+    assert await _count(corpus_id=corpus_id, document_id=doc_id) == 2
+
+
+async def _scenario_fk_cascade_db_level(app: str) -> None:
+    """场景 2（核心）：DB 层 FK CASCADE — 直接 DELETE knowledge_documents 行
+    会自动清理对应 Knowledge 行（无需应用层介入）。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-fk")
+    doc_id = await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/fk.pdf")
+    other_doc_id = await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/other.pdf")
+
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/fk.pdf",
+        document_id=doc_id,
+        metadata={"chunk_role": "parent"},
+        count=4,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/fk.pdf",
+        document_id=doc_id,
+        metadata={"chunk_role": "child"},
+        count=20,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/other.pdf",
+        document_id=other_doc_id,
+        metadata={"chunk_role": "parent"},
+        count=5,
+    )
+
+    # bypass 应用层，直接 DB 删 doc 行
+    async with db_session.AsyncSessionLocal() as session:
+        await session.execute(delete(KnowledgeDocument).where(KnowledgeDocument.id == doc_id))
+        await session.commit()
+
+    # 目标 doc 的 chunks 全部 CASCADE 清零
+    assert await _count(corpus_id=corpus_id, document_id=doc_id) == 0
+    # 邻居 doc 的 chunks 完整保留
+    assert await _count(corpus_id=corpus_id, document_id=other_doc_id) == 5
+
+
+async def _scenario_cli_dry_run_no_persist(app: str) -> None:
+    """场景 3：dry-run 不落库——回填的 document_id 在事务回滚后消失。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-dry")
+    # 创建 doc（仅需建立 source_uri ↔ doc 的回填映射，不需 doc_id 引用）
+    await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/dry.pdf")
+    # 模拟历史孤儿：source_uri 匹配但 document_id 为 NULL
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/dry.pdf",
+        document_id=None,
+        metadata={"chunk_role": "parent"},
+        count=3,
+    )
+    assert await _count(corpus_id=corpus_id, has_document_id=False) == 3
+
+    report = await cleanup_run(commit=False, corpus_id=str(corpus_id), app_name=app)
+    assert report["mode"] == "dry-run"
+    assert report["backfilled"] == 3
+    assert report["deleted"] == 0
+    # 关键：dry-run 后 DB 状态未变
+    assert await _count(corpus_id=corpus_id, has_document_id=False) == 3
+    assert await _count(corpus_id=corpus_id, has_document_id=True) == 0
+
+
+async def _scenario_cli_commit_persists(app: str) -> None:
+    """场景 4：commit 落库——回填 + 删孤儿 都生效。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-commit")
+    # 创建 doc 仅为建立回填映射
+    await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/c.pdf")
+    # 可回填的（source_uri 匹配 doc，仅缺 document_id）
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/c.pdf",
+        document_id=None,
+        metadata={"chunk_role": "parent"},
+        count=2,
+    )
+    # 真孤儿：source_uri 找不到 doc 且形态白名单
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/missing.pdf",
+        document_id=None,
+        metadata={"chunk_role": "parent"},
+        count=4,
+    )
+    # KG 类：source_uri NULL，应保留
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri=None,
+        document_id=None,
+        metadata={"chunk_role": "leaf"},
+        count=2,
+    )
+
+    report = await cleanup_run(commit=True, corpus_id=str(corpus_id), app_name=app)
+    assert report["mode"] == "commit"
+    assert report["backfilled"] == 2, f"应回填 2 条，实际 {report['backfilled']}"
+    assert report["deleted"] == 4, f"应删 4 条孤儿，实际 {report['deleted']}"
+
+    # 落库验证
+    assert await _count(corpus_id=corpus_id, has_document_id=True) == 2  # 回填的
+    assert await _count(corpus_id=corpus_id, has_document_id=False) == 2  # KG 类保留
+
+
+async def _scenario_orphan_excludes_kg_null_source(app: str) -> None:
+    """场景 5：source_uri IS NULL 的 KG 类直连知识永不被清理。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-kg")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri=None,
+        document_id=None,
+        metadata={"chunk_role": "leaf"},
+        count=5,
+    )
+
+    report = await cleanup_run(commit=True, corpus_id=str(corpus_id), app_name=app)
+    assert report["deleted"] == 0, "KG 类（source_uri NULL）必须保留"
+    assert await _count(corpus_id=corpus_id) == 5
+
+
+async def _scenario_orphan_excludes_unknown_uri_form(app: str) -> None:
+    """场景 6：source_uri 非 gs:// / http(s):// 形态不删（白名单防误伤）。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-weird")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="weird-internal-id-12345",
+        document_id=None,
+        metadata={},
+        count=3,
+    )
+
+    report = await cleanup_run(commit=True, corpus_id=str(corpus_id), app_name=app)
+    assert report["deleted"] == 0, "非白名单 source_uri 形态必须保留"
+    assert await _count(corpus_id=corpus_id) == 3
+
+
+async def _scenario_count_orphan_observation(app: str) -> None:
+    """场景 7：count_orphan_knowledge 观测函数返回 per-corpus 计数。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-obs")
+    # 2 条孤儿
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/orphan.pdf",
+        document_id=None,
+        metadata={},
+        count=2,
+    )
+
+    obs = await count_orphan_knowledge(app_name=app)
+    assert obs["total_orphans"] == 2
+    assert len(obs["per_corpus"]) == 1
+    assert obs["per_corpus"][0]["orphans"] == 2
+    assert obs["per_corpus"][0]["corpus_name"] == "c-obs"
+
+
+async def test_phase3_fk_cli_observation_quadrants():
+    """串行执行 Phase 3 全部场景，每场景独立 app_name 命名空间。"""
+    base = uuid4().hex[:8]
+    scenarios = [
+        ("orm_field_roundtrip", _scenario_orm_field_roundtrip),
+        ("fk_cascade_db_level", _scenario_fk_cascade_db_level),
+        ("cli_dry_run_no_persist", _scenario_cli_dry_run_no_persist),
+        ("cli_commit_persists", _scenario_cli_commit_persists),
+        ("kg_null_source_preserved", _scenario_orphan_excludes_kg_null_source),
+        ("unknown_uri_form_preserved", _scenario_orphan_excludes_unknown_uri_form),
+        ("count_orphan_observation", _scenario_count_orphan_observation),
+    ]
+    for tag, scenario in scenarios:
+        app = f"test-phase3-{base}-{tag}"
+        try:
+            await scenario(app)
+        finally:
+            await _cleanup(app_name=app)
+
+
+async def test_migration_round_trip_safe(db_engine):
+    """场景 8：alembic 0030 已 apply（前置条件）；验证 column / FK / index 都存在。"""
+    async with db_engine.connect() as conn:
+        col = await conn.execute(
+            text(
+                "SELECT column_name, is_nullable, data_type FROM information_schema.columns "
+                "WHERE table_schema='negentropy' AND table_name='knowledge' AND column_name='document_id'"
+            )
+        )
+        rows = col.fetchall()
+        assert len(rows) == 1
+        assert rows[0][1] == "YES", "document_id must be nullable"
+        assert rows[0][2] == "uuid"
+
+        fk = await conn.execute(
+            text(
+                "SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint "
+                "WHERE conname = 'fk_knowledge_document_id'"
+            )
+        )
+        fk_rows = fk.fetchall()
+        assert len(fk_rows) == 1
+        assert "ON DELETE CASCADE" in fk_rows[0][1]
+        assert "knowledge_documents(id)" in fk_rows[0][1]
+
+        idx = await conn.execute(
+            text(
+                "SELECT indexname FROM pg_indexes WHERE schemaname='negentropy' "
+                "AND indexname='ix_knowledge_document_id'"
+            )
+        )
+        assert idx.fetchall(), "expected partial index ix_knowledge_document_id"

--- a/apps/negentropy/tests/integration_tests/knowledge/test_storage_service_delete_cascade.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_storage_service_delete_cascade.py
@@ -1,0 +1,441 @@
+"""DocumentStorageService 删除/复活路径与 Knowledge chunks 联动的集成测试。
+
+ISSUE-078 Phase 2 验收回归：
+
+  - 硬删：在同一事务内级联清理 chunks（杜绝 FK 意义孤儿）
+  - 软删：批量给 chunks 打 ``metadata.archived=true`` + ``is_enabled=false``
+    （防 RAG 检索命中已删 doc）
+  - reactivation：复活 soft-deleted doc 时直接 hard delete 旧 chunks
+    （让重新 ingest 写一份干净的，避免新旧 chunks 叠加）
+
+复用既有 ``patch_db_globals`` autouse fixture 替换的全局 ``AsyncSessionLocal``，
+与 ``DocumentStorageService`` 内部使用同一 session factory。受 ``db_engine``
+函数级 fixture 与 asyncpg 跨事件循环边界限制，采用「单 test 函数 + 多场景子断言」模式
+（与 ``test_corpus_chunk_count_filter.py`` 同范式）。
+
+关键设计取舍：本测试**不**触发真实 GCS 调用——通过 monkeypatch
+``DocumentStorageService._get_gcs_client`` 替换为 stub，让硬删路径只校验 DB 行为。
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from sqlalchemy import delete, select
+
+from negentropy.db import session as db_session
+from negentropy.knowledge import api as knowledge_api
+from negentropy.models.perception import Corpus, Knowledge, KnowledgeDocument
+from negentropy.storage.service import DocumentStorageService
+
+
+class _StubGcsClient:
+    """记录调用的 GCS stub；不发起真实网络请求。"""
+
+    def __init__(self) -> None:
+        self.deleted_uris: list[str] = []
+        self.uploaded: list[tuple[str, bytes]] = []
+
+    def delete(self, uri: str) -> None:
+        self.deleted_uris.append(uri)
+
+    def upload(self, *, content: bytes, gcs_path: str, content_type: str | None = None) -> str:
+        _ = content_type
+        self.uploaded.append((gcs_path, content))
+        return f"gs://test-bucket/{gcs_path}"
+
+    @staticmethod
+    def build_gcs_path(app_name: str, corpus_id: str, filename: str) -> str:
+        return f"knowledge/{app_name}/{corpus_id}/{filename}"
+
+    @staticmethod
+    def compute_hash(content: bytes) -> str:
+        import hashlib
+
+        return hashlib.sha256(content).hexdigest()
+
+
+def _make_storage_service(stub: _StubGcsClient) -> DocumentStorageService:
+    svc = DocumentStorageService()
+    svc._gcs = stub  # type: ignore[assignment]
+    return svc
+
+
+async def _create_corpus(*, app_name: str, name: str) -> UUID:
+    async with db_session.AsyncSessionLocal() as session:
+        corpus = Corpus(name=name, app_name=app_name)
+        session.add(corpus)
+        await session.flush()
+        await session.commit()
+        return corpus.id
+
+
+async def _create_document(
+    *,
+    corpus_id: UUID,
+    app_name: str,
+    gcs_uri: str,
+    file_hash: str | None = None,
+    status: str = "active",
+    metadata: dict | None = None,
+) -> UUID:
+    async with db_session.AsyncSessionLocal() as session:
+        doc = KnowledgeDocument(
+            corpus_id=corpus_id,
+            app_name=app_name,
+            file_hash=file_hash or uuid4().hex,
+            original_filename=gcs_uri.rsplit("/", 1)[-1],
+            gcs_uri=gcs_uri,
+            content_type="text/plain",
+            file_size=100,
+            status=status,
+            metadata_=metadata or {},
+        )
+        session.add(doc)
+        await session.flush()
+        await session.commit()
+        return doc.id
+
+
+async def _insert_knowledge(
+    *,
+    corpus_id: UUID,
+    app_name: str,
+    source_uri: str | None,
+    metadata: dict,
+    count: int = 1,
+) -> None:
+    async with db_session.AsyncSessionLocal() as session:
+        for idx in range(count):
+            session.add(
+                Knowledge(
+                    corpus_id=corpus_id,
+                    app_name=app_name,
+                    content=f"chunk-{idx}",
+                    source_uri=source_uri,
+                    chunk_index=idx,
+                    metadata_=metadata,
+                )
+            )
+        await session.commit()
+
+
+async def _count_knowledge(*, corpus_id: UUID, source_uri: str | None) -> int:
+    from sqlalchemy import func
+
+    async with db_session.AsyncSessionLocal() as session:
+        if source_uri is None:
+            stmt = (
+                select(func.count())
+                .select_from(Knowledge)
+                .where(
+                    Knowledge.corpus_id == corpus_id,
+                    Knowledge.source_uri.is_(None),
+                )
+            )
+        else:
+            stmt = (
+                select(func.count())
+                .select_from(Knowledge)
+                .where(
+                    Knowledge.corpus_id == corpus_id,
+                    Knowledge.source_uri == source_uri,
+                )
+            )
+        result = await session.execute(stmt)
+        return result.scalar() or 0
+
+
+async def _fetch_knowledge_by_source(
+    *,
+    corpus_id: UUID,
+    source_uri: str,
+) -> list[Knowledge]:
+    async with db_session.AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(Knowledge).where(
+                Knowledge.corpus_id == corpus_id,
+                Knowledge.source_uri == source_uri,
+            )
+        )
+        return list(result.scalars().all())
+
+
+async def _cleanup(*, app_name: str) -> None:
+    async with db_session.AsyncSessionLocal() as session:
+        await session.execute(delete(Knowledge).where(Knowledge.app_name == app_name))
+        await session.execute(delete(KnowledgeDocument).where(KnowledgeDocument.app_name == app_name))
+        await session.execute(delete(Corpus).where(Corpus.app_name == app_name))
+        await session.commit()
+
+
+# ===================================================================
+# Scenarios
+# ===================================================================
+
+
+async def _scenario_hard_delete_cascades(app: str, stub: _StubGcsClient) -> None:
+    """硬删：在同一事务内删除 chunks 后再删除 doc 行；杜绝孤儿。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-hard")
+    doc_id = await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/h.pdf")
+    # hierarchical 父+子 30 条 + 非 hierarchical leaf 5 条
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/h.pdf",
+        metadata={"chunk_role": "parent"},
+        count=5,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/h.pdf",
+        metadata={"chunk_role": "child"},
+        count=25,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/h.pdf",
+        metadata={"chunk_role": "leaf"},
+        count=5,
+    )
+    # 同 corpus 另一 doc 的 chunks 不应被误删
+    other_id = await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/other.pdf")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/other.pdf",
+        metadata={"chunk_role": "parent"},
+        count=3,
+    )
+
+    assert await _count_knowledge(corpus_id=corpus_id, source_uri="gs://test/h.pdf") == 35
+
+    svc = _make_storage_service(stub)
+    deleted = await svc.delete_document(document_id=doc_id, corpus_id=corpus_id, app_name=app, soft_delete=False)
+    assert deleted is True
+
+    # 目标 doc 的全部 chunks 已清理
+    assert await _count_knowledge(corpus_id=corpus_id, source_uri="gs://test/h.pdf") == 0
+    # 邻居 doc 的 chunks 完整保留
+    assert await _count_knowledge(corpus_id=corpus_id, source_uri="gs://test/other.pdf") == 3
+    # doc 行也已删除（硬删）
+    async with db_session.AsyncSessionLocal() as session:
+        residual = await session.execute(select(KnowledgeDocument).where(KnowledgeDocument.id == doc_id))
+        assert residual.scalar_one_or_none() is None
+    # 邻居 doc 仍在
+    async with db_session.AsyncSessionLocal() as session:
+        neighbor = await session.execute(select(KnowledgeDocument).where(KnowledgeDocument.id == other_id))
+        assert neighbor.scalar_one_or_none() is not None
+
+
+async def _scenario_soft_delete_archives(app: str, stub: _StubGcsClient) -> None:
+    """软删：chunks 仍存在，但 metadata.archived=true 与 is_enabled=false。
+
+    对应 corpus chunks API 计数应排除该 doc（与 Phase 1 口径修正联动验证）。
+    """
+    corpus_id = await _create_corpus(app_name=app, name="c-soft")
+    doc_id = await _create_document(corpus_id=corpus_id, app_name=app, gcs_uri="gs://test/s.pdf")
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/s.pdf",
+        metadata={"chunk_role": "parent"},
+        count=4,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/s.pdf",
+        metadata={"chunk_role": "child"},
+        count=12,
+    )
+
+    svc = _make_storage_service(stub)
+    deleted = await svc.delete_document(document_id=doc_id, corpus_id=corpus_id, app_name=app, soft_delete=True)
+    assert deleted is True
+
+    # chunks 物理保留（可恢复）
+    items = await _fetch_knowledge_by_source(corpus_id=corpus_id, source_uri="gs://test/s.pdf")
+    assert len(items) == 16, "soft delete should keep chunks alive for recovery"
+    for item in items:
+        assert (item.metadata_ or {}).get("archived") is True, "every chunk must be archived"
+        assert item.is_enabled is False, "every chunk must be disabled (extra defense)"
+
+    # doc 行仍在但 status='deleted'
+    async with db_session.AsyncSessionLocal() as session:
+        result = await session.execute(select(KnowledgeDocument).where(KnowledgeDocument.id == doc_id))
+        doc = result.scalar_one_or_none()
+        assert doc is not None
+        assert doc.status == "deleted"
+
+    # corpus chunks API（Phase 1 口径）应已排除软删 doc 的 chunks
+    listed = await knowledge_api.list_corpora(app_name=app)
+    assert listed[0].knowledge_count == 0, (
+        f"Phase 1 口径联动：软删后 user-facing count 应为 0，got {listed[0].knowledge_count}"
+    )
+
+
+async def _scenario_reactivation_purges_old_chunks(app: str, stub: _StubGcsClient) -> None:
+    """复活已软删 doc：旧 chunks 被 hard delete 让重新 ingest 写一份干净的。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-reactivate")
+    file_hash = uuid4().hex
+    doc_id = await _create_document(
+        corpus_id=corpus_id,
+        app_name=app,
+        gcs_uri="gs://test/r.pdf",
+        file_hash=file_hash,
+        status="active",
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/r.pdf",
+        metadata={"chunk_role": "parent"},
+        count=3,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri="gs://test/r.pdf",
+        metadata={"chunk_role": "child"},
+        count=15,
+    )
+    assert await _count_knowledge(corpus_id=corpus_id, source_uri="gs://test/r.pdf") == 18
+
+    svc = _make_storage_service(stub)
+    # 先软删
+    await svc.delete_document(document_id=doc_id, corpus_id=corpus_id, app_name=app, soft_delete=True)
+    # 软删后 chunks 仍在但 archived
+    assert await _count_knowledge(corpus_id=corpus_id, source_uri="gs://test/r.pdf") == 18
+
+    # 复活：用同 hash 重新上传同一份 doc
+    reactivated, is_new = await svc.upload_and_store(
+        corpus_id=corpus_id,
+        app_name=app,
+        content=b"placeholder content",  # 真实 hash 由 stub.compute_hash 计算
+        filename="r.pdf",
+        content_type="text/plain",
+    )
+    # 注意：upload_and_store 走 file_hash 去重，这里我们手动构造的 file_hash 不会与
+    # 真实 hash 匹配；为模拟「同 hash 重传」语义，本测试直接调内部 _reactivate_document
+    # 路径，下面段落改用直接调用。
+
+    # 直接调用 _reactivate_document 模拟「同 hash 重新上传 → 复活」
+    async with db_session.AsyncSessionLocal() as session:
+        result = await session.execute(select(KnowledgeDocument).where(KnowledgeDocument.id == doc_id))
+        existing_doc = result.scalar_one_or_none()
+        assert existing_doc is not None
+
+    # _reactivate_document 是 async 内部方法
+    await svc._reactivate_document(
+        existing_doc=existing_doc,
+        app_name=app,
+        content=b"new content",
+        filename="r-v2.pdf",
+        content_type="text/plain",
+    )
+
+    # 复活后旧 chunks 应已被 hard delete（让 reingest 写干净的）
+    remaining = await _count_knowledge(corpus_id=corpus_id, source_uri="gs://test/r.pdf")
+    assert remaining == 0, f"reactivation should purge old chunks for reingest hygiene, got {remaining}"
+
+    # doc 行已切回 active，gcs_uri 已更新
+    async with db_session.AsyncSessionLocal() as session:
+        result = await session.execute(select(KnowledgeDocument).where(KnowledgeDocument.id == doc_id))
+        doc = result.scalar_one_or_none()
+        assert doc is not None
+        assert doc.status == "active"
+        assert doc.original_filename == "r-v2.pdf"
+
+
+async def _scenario_neighbor_corpus_isolation(app: str, stub: _StubGcsClient) -> None:
+    """不同 corpus 即便 source_uri 同名，硬/软删也只影响本 corpus 的 chunks。"""
+    corpus_a = await _create_corpus(app_name=app, name="c-iso-a")
+    corpus_b = await _create_corpus(app_name=app, name="c-iso-b")
+    same_uri = "gs://test/shared-name.pdf"
+
+    doc_a = await _create_document(corpus_id=corpus_a, app_name=app, gcs_uri=same_uri)
+    await _create_document(corpus_id=corpus_b, app_name=app, gcs_uri=same_uri)
+
+    await _insert_knowledge(
+        corpus_id=corpus_a,
+        app_name=app,
+        source_uri=same_uri,
+        metadata={"chunk_role": "parent"},
+        count=4,
+    )
+    await _insert_knowledge(
+        corpus_id=corpus_b,
+        app_name=app,
+        source_uri=same_uri,
+        metadata={"chunk_role": "parent"},
+        count=6,
+    )
+
+    svc = _make_storage_service(stub)
+    await svc.delete_document(document_id=doc_a, corpus_id=corpus_a, app_name=app, soft_delete=False)
+
+    assert await _count_knowledge(corpus_id=corpus_a, source_uri=same_uri) == 0
+    assert await _count_knowledge(corpus_id=corpus_b, source_uri=same_uri) == 6, (
+        "delete_document must not cascade across corpora even with same source_uri"
+    )
+
+
+async def _scenario_url_doc_resolves_origin_url(app: str, stub: _StubGcsClient) -> None:
+    """URL 类文档的 chunks 通过 metadata.origin_url 关联，删除路径需识别。"""
+    corpus_id = await _create_corpus(app_name=app, name="c-url")
+    origin = "https://example.com/article"
+    doc_id = await _create_document(
+        corpus_id=corpus_id,
+        app_name=app,
+        gcs_uri="gs://test/cached.html",  # GCS 缓存
+        metadata={"source_type": "url", "origin_url": origin},
+    )
+    # chunks 的 source_uri 是 origin_url 而非 gcs_uri
+    await _insert_knowledge(
+        corpus_id=corpus_id,
+        app_name=app,
+        source_uri=origin,
+        metadata={"chunk_role": "parent"},
+        count=3,
+    )
+
+    svc = _make_storage_service(stub)
+    await svc.delete_document(document_id=doc_id, corpus_id=corpus_id, app_name=app, soft_delete=False)
+
+    # source_uri 解析正确：origin_url 对应的 chunks 也被清理
+    assert await _count_knowledge(corpus_id=corpus_id, source_uri=origin) == 0
+
+
+# ===================================================================
+# 入口测试
+# ===================================================================
+
+
+async def test_delete_document_chunks_cascade_quadrants(monkeypatch):
+    """串行执行 5 个删除/复活联动场景，每场景独立 app_name 命名空间。"""
+    base = uuid4().hex[:8]
+    stub = _StubGcsClient()
+
+    # 用一个共享的 stub 替换 _get_gcs_client，覆盖所有 DocumentStorageService 实例
+    monkeypatch.setattr(
+        DocumentStorageService,
+        "_get_gcs_client",
+        lambda self: stub,
+    )
+
+    scenarios = [
+        ("hard_delete_cascades", _scenario_hard_delete_cascades),
+        ("soft_delete_archives", _scenario_soft_delete_archives),
+        ("reactivation_purges_old", _scenario_reactivation_purges_old_chunks),
+        ("neighbor_corpus_isolation", _scenario_neighbor_corpus_isolation),
+        ("url_doc_origin_url", _scenario_url_doc_resolves_origin_url),
+    ]
+    for tag, scenario in scenarios:
+        app = f"test-cascade-{base}-{tag}"
+        try:
+            await scenario(app, stub)
+        finally:
+            await _cleanup(app_name=app)

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1706,3 +1706,19 @@
   ```
 
   期望：`old_count=849, new_count=14`。
+
+- **Phase 2 补充修复（2026-05-09 第二阶段 · 应用层级联与软删 archive）**：
+  1. **`source_uri` 解析下沉到 storage 层**：把 `_resolve_document_source_uri`（`api.py:1957`）下沉为 `negentropy.storage.service.resolve_document_source_uri` 模块级函数，原 api.py 同名函数变为 thin wrapper 复用之，消除跨层重复（URL 类取 `metadata.origin_url`、否则取 `gcs_uri` 的统一规则）。
+  2. **硬删级联清理 chunks**：`DocumentStorageService.delete_document` 硬删分支在 `db.delete(doc)` 之前先按 `(corpus_id, app_name, source_uri)` 删除全部 Knowledge 行（hierarchical 父+子共享 source_uri，单次删除一并清理）；同事务原子提交，杜绝 FK 意义孤儿。新增 `_hard_delete_chunks_in_session` staticmethod，logger 输出 `chunks_deleted` 计数供审计。
+  3. **软删 archive chunks**：`DocumentStorageService.delete_document` 软删分支在 `doc.status='deleted'` 之前批量更新对应 chunks 的 `metadata.archived=true` 与 `is_enabled=false`，让既有 `_active_filter_expr` / `_enabled_filter_expr` 过滤生效；防止 RAG 检索仍命中已软删 doc。语义可逆——reactivation 路径会直接 hard delete 旧 chunks 让重新 ingest 写一份干净的，不必反向 unset。新增 `_archive_chunks_in_session` staticmethod，复用 `archive_knowledge_by_source` 的 `jsonb_set` 范式。
+  4. **Reactivation 清理旧 chunks**：`_reactivate_document` 在重置 doc 状态前 hard delete 旧 chunks（基于 `resolve_document_source_uri(doc)` 的旧 URI），保证「软删 archive → 复活 reingest」语义不再产生新旧 chunks 叠加；logger 加 `reactivate_purge_chunks` + `old_source_uri` 字段。
+  5. **`KnowledgeService.delete_source` 双重删除冗余说明**：`storage_service.delete_document` 已自带 chunks 清理后，service.py:1742 中的 `_repository.delete_knowledge_by_source` 不再删除（returns 0），但**保留**为 fallback 兜底，覆盖两类场景：① `source_uri` 不是 `gs://...`（如 URL 类的 `origin_url`）走不到 storage 分支；② doc 在先前路径已被硬删但 chunks 残留。加注释明确语义。
+  6. **检索路径过滤覆盖复核结论**：`semantic_search` / `keyword_search` 三态过滤（`archived` + `searchable` + `is_enabled`）齐全；`hybrid_search` / `rrf_search` 走 PG 函数 `kb_hybrid_search` / `kb_rrf_search`，函数内**未**过滤 archived/is_enabled/searchable，仅靠 Python 层后过滤检查 `_is_archived` + `_is_searchable`，**未检查** `is_enabled`——这是该 PG 函数的既有缺陷（与本 issue 解耦）。Phase 2 软删同时打 `metadata.archived=true` 与 `is_enabled=false`，前者覆盖全部 4 个检索路径，软删主目标达成；后者作为冗余防御层在 semantic/keyword 路径生效，hybrid/rrf 不生效是 follow-up。
+  7. **集成测试补强**：新增 [`test_storage_service_delete_cascade.py`](../apps/negentropy/tests/integration_tests/knowledge/test_storage_service_delete_cascade.py)，5 场景串行覆盖：硬删级联 + 邻居 doc 不误删、软删 archive + Phase 1 口径联动、reactivation 清理旧 chunks、跨 corpus 同名 source_uri 隔离、URL 类文档 origin_url 解析。GCS 客户端通过 `monkeypatch.setattr(DocumentStorageService, "_get_gcs_client", ...)` 替换为 stub，避免真实网络调用。
+- **Phase 2 取舍说明**：
+  - 软删时选「archive（标记）」而非「物理删 chunks」：保留可恢复语义；reactivation 走 hard purge 兜底。
+  - 检索路径不在本 phase 修 PG 函数过滤缺陷：`metadata.archived=true` 已覆盖目标语义；改 PG 函数需配套 alembic 迁移与降级测试，与 Phase 2 解耦。
+  - `delete_source` 保留双重删除而非清除：跨语义边界（GCS 路径 vs URL）兜底必要，幂等不影响正确性。
+- **Phase 2 同类问题影响**：
+  1. **PG 函数 `kb_hybrid_search` / `kb_rrf_search` 缺 `is_enabled` 过滤**：列入 follow-up，需要时通过 alembic 迁移修订函数体，加 `WHERE kb.is_enabled = TRUE AND COALESCE((kb.metadata->>'archived')::boolean, false) = false AND COALESCE((kb.metadata->>'searchable')::boolean, true) = true` 三态过滤。
+  2. **任何「外部资源 + 内部产物」双表关系**：若两侧无 FK 仅靠 URI/Hash 软关联（如 `KnowledgeDocument` ↔ `Knowledge`、未来可能的 `Asset` ↔ `EmbeddingArtifact`），删除路径必须主动维护产物生命周期（参考本次 `_hard_delete_chunks_in_session` / `_archive_chunks_in_session` 范式）；Phase 3 通过加 `Knowledge.document_id` FK 在 DB 层兜底。

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1722,3 +1722,26 @@
 - **Phase 2 同类问题影响**：
   1. **PG 函数 `kb_hybrid_search` / `kb_rrf_search` 缺 `is_enabled` 过滤**：列入 follow-up，需要时通过 alembic 迁移修订函数体，加 `WHERE kb.is_enabled = TRUE AND COALESCE((kb.metadata->>'archived')::boolean, false) = false AND COALESCE((kb.metadata->>'searchable')::boolean, true) = true` 三态过滤。
   2. **任何「外部资源 + 内部产物」双表关系**：若两侧无 FK 仅靠 URI/Hash 软关联（如 `KnowledgeDocument` ↔ `Knowledge`、未来可能的 `Asset` ↔ `EmbeddingArtifact`），删除路径必须主动维护产物生命周期（参考本次 `_hard_delete_chunks_in_session` / `_archive_chunks_in_session` 范式）；Phase 3 通过加 `Knowledge.document_id` FK 在 DB 层兜底。
+
+- **Phase 3 补充修复（2026-05-09 第三阶段 · Schema FK + 一次性数据修复）**：
+  1. **alembic 0030 迁移 [`0030_knowledge_document_fk.py`](../apps/negentropy/src/negentropy/db/migrations/versions/0030_knowledge_document_fk.py)**：`ALTER TABLE knowledge ADD COLUMN document_id UUID NULL` + `FOREIGN KEY (document_id) REFERENCES knowledge_documents(id) ON DELETE CASCADE` + 部分索引 `CREATE INDEX ix_knowledge_document_id ON knowledge (document_id) WHERE document_id IS NOT NULL`。**仅加列与约束、不做数据变更**，避免大表 UPDATE 长锁；downgrade 仅 DROP COLUMN，PG 元数据操作可瞬时回滚；historic 数据通过独立 CLI 一次性回填。
+  2. **ORM 同步 [`models/perception.py`](../apps/negentropy/src/negentropy/models/perception.py)**：`Knowledge.document_id: Mapped[UUID | None]` + FK to `knowledge_documents.id ondelete=CASCADE`、nullable=True（KG 类直连知识无 doc 来源，必须允许 NULL）。
+  3. **`KnowledgeChunk` dataclass + 写入路径单点 stamp**：`apps/negentropy/src/negentropy/knowledge/types.py` `KnowledgeChunk` 加 `document_id: UUID | None = None`；`_ingest_text_with_tracker` 加 `document_id` 参数，在 `_build_chunks` 之后通过 `dataclasses.replace` 单点 stamp 到每个 chunk，避免大面积改造下游函数。仅 2 个 ingest 入口（`execute_ingest_url_document_pipeline` / `execute_ingest_file_pipeline`）传入 `document_id`，其余 10 个入口（纯文本、URL、replace、rebuild、KG）保留 None。`KnowledgeRepository.add_knowledge` 的 `pg_insert.values()` 列表加入 `document_id` 字段，与既有 `pg_insert ... RETURNING` 模式一致。
+  4. **独立 CLI [`scripts/cleanup_orphan_knowledge.py`](../apps/negentropy/src/negentropy/scripts/cleanup_orphan_knowledge.py)**：`uv run python -m negentropy.scripts.cleanup_orphan_knowledge --dry-run | --commit [--corpus-id ...] [--app-name ...] [--json]`。三步流水线：① 回填 `document_id`（基于 `(corpus_id, app_name, source_uri ↔ d.gcs_uri OR d.metadata->>'origin_url')` 关联，包含软删 doc）；② 按 corpus 分组报告 `total / linked / unlinked / would_delete` 四档计数；③ `--commit` 模式才 DELETE，且仅当 `document_id IS NULL AND source_uri IS NOT NULL AND source_uri ~ '^(gs://|https?://)'`（白名单形态防误删）；整体单事务，`asyncpg` 不接受 `:param::type` cast 改用条件谓词拼接。**不放进 alembic 迁移**——DELETE 不可逆需 dry-run + 审批环节。
+  5. **观测函数 `count_orphan_knowledge`**：与 CLI 共享同一过滤口径（`document_id IS NULL` + 白名单 source_uri），返回 `{total_orphans, per_corpus[]}`，cron 接入方式：每日扫描，将 `total_orphans` 上报为 metric `negentropy.knowledge.orphan_count{corpus_id}`，`> 0` 即告警（即便三层防御兜住也作为入侵 / 异常 SQL 的 canary）。
+  6. **dev DB 实地验证**：在 user 真实数据上跑 `--dry-run` → 报告 `Harness Engineering` corpus `total=849, linked=0→849, unlinked=0, would_delete=0`，证实 user 当时走的是软删（doc 还在所以不是 FK 意义孤儿）；`--commit` 后 849 条 Knowledge 全部 `document_id` 已回填，与对应 KnowledgeDocument 建立 FK 关联。Phase 1 → Phase 3 三层防御**端到端在用户实际数据上闭环**。
+  7. **集成测试 [`test_phase3_document_fk.py`](../apps/negentropy/tests/integration_tests/knowledge/test_phase3_document_fk.py)**：8 场景覆盖 ① ORM 字段读写 ② DB 层 FK CASCADE（直接 DELETE knowledge_documents 行触发 Knowledge 级联清理）③ CLI dry-run 不落库 ④ CLI commit 落库 ⑤ KG NULL source_uri 保留 ⑥ 非白名单 source_uri 形态保留 ⑦ count_orphan_knowledge 观测函数 ⑧ migration round-trip 验证（column / FK / index 实际存在）。
+- **Phase 3 取舍说明**：
+  - **CLI 而非 alembic data migration**：DELETE 不可逆、迁移强制执行、不利于审计；CLI 提供 dry-run + JSON 报告 + scope 过滤（`--corpus-id` / `--app-name`），运维流程更稳。
+  - **白名单 `source_uri` 形态**：仅删 `gs://...` / `http(s)://...` 形态的孤儿，规避内部脏数据 / 自定义 URI 形态被误删；`source_uri IS NULL` 的 KG 类直连知识永不被本 CLI 清理（合法语义保留）。
+  - **新建 `negentropy/scripts/` 包**：与既有 `cli.py` 区分——`cli.py` 是常驻 CLI（serve / init），`scripts/` 是一次性运维工具，命名空间清晰互不冲突。
+  - **单点 stamp `document_id` 而非贯穿 `_build_chunks`**：`_build_chunks` 调用面广（hierarchical / fixed / recursive / semantic 四种策略）改动成本高；`_ingest_text_with_tracker` 是所有 doc-aware ingest 的必经之路，单点 stamp 边界清晰、blast radius 最小。
+- **Phase 3 同类问题影响**：
+  1. **任何 1:N 关联但缺 FK 的双表设计**：参考本次 0030 迁移模板（加 nullable FK + ON DELETE CASCADE + 部分索引 + 独立 CLI 历史回填）。已识别候选 follow-up：`Knowledge.embedding` ↔ `EmbeddingConfig`（embedding 配置删除时是否级联？目前是手动重建）、`KgEntity` ↔ `Knowledge.entity_type`（entity 改名 / 删除时 chunks 的元数据是否同步？目前未级联）。
+  2. **观测埋点与防御层结合**：仅靠应用层 + DB 层防御不够，必须有 metric canary 主动揭露三层防御均失守的边角场景；本 PR 的 `count_orphan_knowledge` 是范本——监控的是「不应存在的状态」而非「业务正常态」。
+  3. **大表 schema 变更**：用户曾担心大表 ALTER 锁表。0030 仅加 nullable 列 + FK 约束 + 部分索引，PG 14+ 的 `ADD COLUMN ... NULL` 是元数据级 O(1) 操作，FK 约束加上 `NOT VALID` 即可异步验证（本次未加 NOT VALID 是因为新列默认 NULL，约束不会回扫）；`CREATE INDEX IF NOT EXISTS` 用 partial index 范围已极小。生产部署可直接执行。
+- **Phase 1+2+3 整体闭环验证**：
+  1. **Phase 1 SQL 口径修正**（PR #483）：UI 立即显示正确的 `chunks: 14`；
+  2. **Phase 2 应用层级联**（PR #484）：未来软删/硬删/复活路径都会同步 chunks；
+  3. **Phase 3 Schema FK + CLI**（本 phase）：DB 层兜底 + 历史脏数据可清算；
+  4. **观测埋点**：`negentropy.knowledge.orphan_count` cron 持续监控，三层防御任何环节失守都被 canary 捕获。


### PR DESCRIPTION
> **Stacked PR · 依赖 #483（Phase 1）**：base 为 Phase 1 分支，待 #483 merge 后 GitHub 会自动把 base 切换到 `feature/1.x.x`。如需独立 review，可只看本 PR 的 diff（不含 Phase 1 改动）。

## 背景

ISSUE-078 Phase 2 应用层级联：堵未来产生孤儿 / 检索污染的入口。Phase 1 修计数口径，Phase 2 修数据闭环，两者正交、可独立回滚。

Phase 1 PR #483 解决了「软删 doc 的 chunks 仍计入 corpus 计数 / 父子混算」的展示口径问题——即时让 849 → 14 在 UI 上恢复正常，但**未触及数据闭环**：

- 软删后 chunks 仍可被 RAG 检索命中（`is_enabled=true` + `searchable=true` + `archived` 未标）
- 硬删（`hard_delete=True`）路径未级联清理 Knowledge 行 → 任何走过此路径的历史调用都留下 FK 意义孤儿
- 软删后同 hash 重新上传时 reactivation 路径不清理旧 chunks → 新旧叠加污染

本 PR 通过应用层级联补齐这三类场景。

## 改动

### 1. `_resolve_document_source_uri` 下沉到 storage 层

`apps/negentropy/src/negentropy/knowledge/api.py:1957` 原有 helper 下沉为 `negentropy.storage.service.resolve_document_source_uri` 模块级函数（URL 类取 `metadata.origin_url` / 否则取 `gcs_uri`），api.py 同名函数变为 thin wrapper 复用之，消除跨层重复。

### 2. 硬删级联清理 chunks（`DocumentStorageService.delete_document` 硬删分支）

在 `db.delete(doc)` 之前先按 `(corpus_id, app_name, source_uri)` 删除全部 Knowledge 行：

- hierarchical 父+子共享 source_uri，单次删除一并覆盖
- 同事务原子提交，杜绝 FK 意义孤儿
- 新增 `_hard_delete_chunks_in_session` staticmethod（ORM `delete()` 表达式），logger 输出 `chunks_deleted` 计数供审计

### 3. 软删 archive chunks（`DocumentStorageService.delete_document` 软删分支）

在 `doc.status='deleted'` 之前批量更新对应 chunks 的 `metadata.archived=true` 与 `is_enabled=false`：

- `metadata.archived=true` → 既有 `_active_filter_expr` 过滤生效，覆盖 `semantic_search` / `keyword_search` / `hybrid_search` / `rrf_search` 全部 4 路径
- `is_enabled=false` → 冗余防御层，覆盖 `_enabled_filter_expr` 路径
- 新增 `_archive_chunks_in_session` staticmethod，复用 `archive_knowledge_by_source` 的 `jsonb_set` 范式
- 语义可逆——reactivation 路径会直接 hard delete 旧 chunks 让重新 ingest 写一份干净的，不必反向 unset

### 4. Reactivation 清理旧 chunks（`_reactivate_document`）

复活 soft-deleted doc 时（同 hash 重新上传），在重置 doc 状态前直接 hard delete 旧 chunks：

- 基于 `resolve_document_source_uri(doc)` 解析旧 URI
- 让随后的 markdown 重新提取 + 重新 ingest 写入一份干净的
- 否则旧 archived chunks 与新 chunks 叠加（source_uri 相同）会重新污染计数与检索
- logger 加 `reactivate_purge_chunks` + `old_source_uri` 字段

### 5. `KnowledgeService.delete_source` 双重删除冗余说明

`storage_service.delete_document` 已自带 chunks 清理后，`service.py:1742` 中的 `_repository.delete_knowledge_by_source` 不再删除（returns 0），但**保留**为 fallback 兜底，覆盖两类场景：

1. `source_uri` 不是 `gs://...`（如 URL 类的 `origin_url`）走不到 storage 分支
2. doc 在先前路径已被硬删但 chunks 残留

加注释明确语义。

## 检索路径过滤覆盖复核结论

| 检索路径 | archived | searchable | is_enabled | 软删 chunks 防御 |
|---|---|---|---|---|
| `semantic_search` | ✅ SQL | ✅ SQL | ✅ SQL | ✅ |
| `keyword_search` | ✅ raw SQL | ✅ raw SQL | ✅ raw SQL | ✅ |
| `hybrid_search` (PG `kb_hybrid_search`) | ⚠️ Python 后过滤 | ⚠️ Python 后过滤 | ❌ **缺失** | ✅（archived 后过滤） |
| `rrf_search` (PG `kb_rrf_search`) | ⚠️ Python 后过滤 | ⚠️ Python 后过滤 | ❌ **缺失** | ✅（archived 后过滤） |

`hybrid/rrf` PG 函数缺 `is_enabled` 过滤是该函数本身既有缺陷（与本 PR 解耦）；Phase 2 软删同时打 `archived=true` 与 `is_enabled=false`，前者覆盖全部 4 路径，软删主目标达成。后者作为冗余防御层在 `semantic` / `keyword` 路径生效，`hybrid` / `rrf` 不生效列入 follow-up。

## 集成测试

新增 [`test_storage_service_delete_cascade.py`](apps/negentropy/tests/integration_tests/knowledge/test_storage_service_delete_cascade.py)，5 场景串行覆盖：

| 场景 | 验证 |
|---|---|
| `hard_delete_cascades` | 硬删后 chunks 行数为 0、邻居 doc 的 chunks 完整保留、doc 行已删除 |
| `soft_delete_archives` | 软删后 chunks 物理保留但 `archived=true` + `is_enabled=false`；Phase 1 口径联动后 corpus count = 0 |
| `reactivation_purges_old_chunks` | 软删 → 复活：旧 chunks 全部清零、doc 切回 `active`、`original_filename` 已更新 |
| `neighbor_corpus_isolation` | 跨 corpus 同名 source_uri 时只影响本 corpus |
| `url_doc_resolves_origin_url` | URL 类文档（`metadata.origin_url`）的 chunks 也被正确级联清理 |

GCS 通过 `monkeypatch.setattr(DocumentStorageService, "_get_gcs_client", ...)` 替换为 stub，避免真实网络调用。

受现有 `db_engine` 函数级 fixture 与 asyncpg 跨事件循环边界限制，采用「单 test 函数 + 多场景子断言」模式（与 Phase 1 同范式）。

## 影响面 & 兼容性

- **API 接口不变**：`DocumentStorageService.delete_document` 签名/返回值不变
- **既有数据无需迁移**：仅改变未来删除/复活路径的行为；历史孤儿留待 Phase 3 一次性 CLI 清算
- **既有 19 项 API 单测无回归**
- **GCS 删除失败不阻断 chunks 清理**：保持现有 `try/except StorageError` 警告语义，chunks 清理在 GCS 操作之后执行（顺序：删 GCS → 删 chunks → 删 doc）

## Phase 化交付（本 PR 是 Phase 2）

- **Phase 1 (#483)**：SQL 口径修正 — 让 UI 数字立即恢复
- **Phase 2（本 PR）**：应用层级联 + 软删 archive + reactivation purge — 数据闭环
- **Phase 3（待启动）**：alembic 0030 加 `Knowledge.document_id` FK + 独立 CLI `cleanup_orphan_knowledge` dry-run/commit + 观测 metric — DB 层 belt-and-suspenders + 历史脏数据清算

## Test plan

- [x] `pytest tests/integration_tests/knowledge/test_storage_service_delete_cascade.py` 5 场景全 pass
- [x] `pytest tests/integration_tests/knowledge/test_corpus_chunk_count_filter.py` Phase 1 测试无回归
- [x] `pytest tests/unit_tests/knowledge/test_api_corpus.py tests/unit_tests/knowledge/test_api_documents.py` 19 项既有用例无回归
- [x] `docs/issue.md` ISSUE-078 追加 Phase 2 补充章节
- [ ] **Reviewer staging 复现验证**（merge 后端到端）：
  - [ ] 软删一个 doc → 检索该 doc 内容 → 应无命中（archive 生效）
  - [ ] 硬删一个 doc → DB 验证该 doc 的 `Knowledge` 行数为 0
  - [ ] 软删后同 hash 重新上传 → 复活的 doc 触发重新 ingest → chunks 数与新切片一致（无残留旧 chunks）

🤖 Generated with [Claude Code](https://claude.com/claude-code)