### PR TITLE
功能(pipeline-cancel): Pipeline Run Cancel 协作式取消（KB + KG + 前端 X 按钮）

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/runs/[runId]/cancel/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/runs/[runId]/cancel/route.ts
@@ -1,0 +1,17 @@
+import { proxyPost } from "../../../../../../_proxy";
+
+/**
+ * KG Build Run Cancel BFF 代理
+ *
+ * 后端：POST /knowledge/base/{corpus_id}/graph/runs/{run_id}/cancel
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ corpusId: string; runId: string }> },
+) {
+  const { corpusId, runId } = await params;
+  return proxyPost(
+    request,
+    `/knowledge/base/${encodeURIComponent(corpusId)}/graph/runs/${encodeURIComponent(runId)}/cancel`,
+  );
+}

--- a/apps/negentropy-ui/app/api/knowledge/pipelines/[runId]/cancel/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/pipelines/[runId]/cancel/route.ts
@@ -1,0 +1,17 @@
+import { proxyPost } from "../../../_proxy";
+
+/**
+ * KB Pipeline Run Cancel BFF 代理
+ *
+ * 后端：POST /knowledge/pipelines/{run_id}/cancel
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ runId: string }> },
+) {
+  const { runId } = await params;
+  return proxyPost(
+    request,
+    `/knowledge/pipelines/${encodeURIComponent(runId)}/cancel`,
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -4,12 +4,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import {
   fetchDashboard,
   fetchPipelines,
   upsertPipelines,
   fetchCorpora,
   fetchGraphBuildHistory,
+  cancelPipelineRun,
   KnowledgeDashboard,
   KnowledgePipelinesPayload,
   PipelineRunCard,
@@ -70,6 +72,7 @@ export default function KnowledgeDashboardPage() {
   const [kbTotal, setKbTotal] = useState(0);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const bootstrapBaselineRef = useRef<RunsSnapshot | null>(null);
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   const applyRuns = useCallback(
     (kbData: KnowledgePipelinesPayload, kgRuns: KgPipelineRun[]) => {
@@ -118,6 +121,49 @@ export default function KnowledgeDashboardPage() {
       return { pipeData, kgRuns };
     },
     [applyRuns, page],
+  );
+
+  /**
+   * 取消 Pipeline Run 的统一处理：弹 ConfirmDialog（替代浏览器原生 confirm，遵循
+   * AGENTS.md 视觉规范），用户确认后调用 cancelPipelineRun；成功后立即 refetch 让
+   * 卡片状态从 running 切换到 cancelling/cancelled，剩余收敛由现有 5s 轮询观察。
+   */
+  const handleCancelRun = useCallback(
+    async (run: UnifiedPipelineRun) => {
+      const confirmed = await confirm({
+        title: "取消 Pipeline Run",
+        message: (
+          <div className="space-y-2">
+            <p>
+              确定取消 <span className="font-mono">{run.run_id || run.id}</span>?
+            </p>
+            <p className="text-xs opacity-80">
+              已写入的数据不会回滚（best-effort 取消）；详情可在取消后展开 Run 详情查看
+              「取消时进度」。
+            </p>
+          </div>
+        ),
+        confirmLabel: "确认取消",
+        cancelLabel: "保持运行",
+        destructive: true,
+      });
+      if (!confirmed) return;
+      try {
+        if (run.source === "kb") {
+          await cancelPipelineRun(run.run_id || run.id, "kb", { appName: APP_NAME });
+        } else {
+          await cancelPipelineRun(run.run_id || run.id, "kg", {
+            appName: APP_NAME,
+            corpusId: run.corpus_id,
+          });
+        }
+        // 立即刷新让卡片切换到 cancelling/cancelled；剩余收敛交给 5s 轮询
+        await loadRuns().catch(() => undefined);
+      } catch (err) {
+        setError(String(err));
+      }
+    },
+    [confirm, loadRuns],
   );
 
   useEffect(() => {
@@ -329,6 +375,7 @@ export default function KnowledgeDashboardPage() {
                         mode="selectable"
                         selected={selected?.id === run.id}
                         onSelect={() => setSelected(run)}
+                        onCancel={() => handleCancelRun(run)}
                         // KG 专属字段
                         source={run.source}
                         corpus_id={run.source === "kg" ? run.corpus_id : undefined}
@@ -452,6 +499,7 @@ export default function KnowledgeDashboardPage() {
           </aside>
         </div>
       </div>
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -72,6 +72,8 @@ export default function KnowledgeDashboardPage() {
   const [kbTotal, setKbTotal] = useState(0);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const bootstrapBaselineRef = useRef<RunsSnapshot | null>(null);
+  const allRunsRef = useRef<UnifiedPipelineRun[]>(allRuns);
+  allRunsRef.current = allRuns;
   const { confirm, confirmDialog } = useConfirmDialog();
 
   const applyRuns = useCallback(
@@ -198,10 +200,12 @@ export default function KnowledgeDashboardPage() {
 
   // Bootstrap polling：仅在首次加载后无 active run 时启动（等待外部变更被观测到）；
   // 若初始加载已含 active runs，running-state polling 负责持续轮询，无需 bootstrap 重叠。
+  // 使用 ref 读取最新 allRuns（不加入 deps），避免 applyRuns 更新 allRuns 后
+  // 重建 interval 导致 tick 重置。
   useEffect(() => {
     if (!hasInitialLoad) return;
     if (page !== 1) return;
-    if (hasActiveRuns(allRuns)) return;
+    if (hasActiveRuns(allRunsRef.current)) return;
 
     let active = true;
     let tick = 0;
@@ -238,7 +242,7 @@ export default function KnowledgeDashboardPage() {
       clearInterval(intervalId);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasInitialLoad, page, allRuns]);
+  }, [hasInitialLoad, page]);
 
   // Running-state polling
   useEffect(() => {

--- a/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/dashboard/page.tsx
@@ -160,7 +160,7 @@ export default function KnowledgeDashboardPage() {
         // 立即刷新让卡片切换到 cancelling/cancelled；剩余收敛交给 5s 轮询
         await loadRuns().catch(() => undefined);
       } catch (err) {
-        setError(String(err));
+        setError(err instanceof Error ? err.message : String(err));
       }
     },
     [confirm, loadRuns],
@@ -196,10 +196,12 @@ export default function KnowledgeDashboardPage() {
   // eslint-disable-next-line react-hooks/exhaustive-deps -- initial load
   }, [page]);
 
-  // Bootstrap polling
+  // Bootstrap polling：仅在首次加载后无 active run 时启动（等待外部变更被观测到）；
+  // 若初始加载已含 active runs，running-state polling 负责持续轮询，无需 bootstrap 重叠。
   useEffect(() => {
     if (!hasInitialLoad) return;
     if (page !== 1) return;
+    if (hasActiveRuns(allRuns)) return;
 
     let active = true;
     let tick = 0;
@@ -236,7 +238,7 @@ export default function KnowledgeDashboardPage() {
       clearInterval(intervalId);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasInitialLoad, page]);
+  }, [hasInitialLoad, page, allRuns]);
 
   // Running-state polling
   useEffect(() => {

--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { PipelineErrorPayload, PipelineStageResult } from "../utils/knowledge-api";
 import { PipelineStatusBadge } from "./PipelineStatusBadge";
 import { PipelineStagesBar } from "./PipelineStagesBar";
@@ -12,6 +13,17 @@ import {
   getFailedStages,
   getStageErrorSummary,
 } from "../utils/pipeline-helpers";
+
+const ACTIVE_STATUSES = new Set(["pending", "running", "in_progress", "cancelling"]);
+
+/** 判断 run 是否可被取消（pending/running/in_progress/cancelling 时可见取消按钮） */
+function isCancellable(status?: string): boolean {
+  return ACTIVE_STATUSES.has((status || "").toLowerCase());
+}
+
+function isCancellingState(status?: string): boolean {
+  return (status || "").toLowerCase() === "cancelling";
+}
 
 /**
  * Pipeline Run 卡片属性
@@ -58,6 +70,12 @@ export interface PipelineRunCardProps {
   model_name?: string;
   /** KG: 错误信息 */
   error_message?: string;
+  /**
+   * 取消按钮回调：用户在二次确认通过后被调用，由父组件实际发起 cancel API
+   * 调用并刷新列表。返回 Promise 以便卡片在调用期间显示 loading 态。
+   * 仅当 status 处于活跃态（pending/running/cancelling）时按钮可见。
+   */
+  onCancel?: () => Promise<void> | void;
   /** 支持扩展字段 */
   [key: string]: unknown;
 }
@@ -100,6 +118,7 @@ function PipelineRunCardContent({
   model_name,
   error_message,
   progress_percent,
+  onCancel,
 }: PipelineRunCardProps & { isSelectable: boolean }) {
   const duration = formatDuration(duration_ms, started_at, completed_at);
   const isKg = source === "kg";
@@ -115,9 +134,28 @@ function PipelineRunCardContent({
   const endLabel = formatCompactTimestamp(completed_at);
   const hasTimeline = startLabel || endLabel;
 
+  // Cancel 按钮状态：仅活跃 run（pending/running/cancelling）显示；
+  // cancelling 时 disabled + 显示 spinner（已发出信号但未到检查点）。
+  const [submitting, setSubmitting] = useState(false);
+  const showCancelButton = onCancel && isCancellable(status);
+  const cancelDisabled = isCancellingState(status) || submitting;
+
+  const handleCancelClick = async (e: React.MouseEvent) => {
+    // 阻止冒泡：selectable 模式下点击卡片会切换选中，X 按钮不应触发选中
+    e.stopPropagation();
+    e.preventDefault();
+    if (!onCancel || cancelDisabled) return;
+    try {
+      setSubmitting(true);
+      await onCancel();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <>
-      {/* 第一行：Run ID + 共享状态标签 */}
+      {/* 第一行：Run ID + 共享状态标签 + Cancel X 按钮 */}
       <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <span className={`truncate text-xs font-semibold ${
@@ -126,7 +164,47 @@ function PipelineRunCardContent({
             {isSelectable ? run_id : truncateRunId(run_id)}
           </span>
         </div>
-        <PipelineStatusBadge status={status} />
+        <div className="flex shrink-0 items-center gap-2">
+          <PipelineStatusBadge status={status} />
+          {showCancelButton && (
+            <button
+              type="button"
+              role="button"
+              aria-label={cancelDisabled ? "正在取消" : "取消运行"}
+              title={cancelDisabled ? "正在取消..." : "取消运行"}
+              disabled={cancelDisabled}
+              onClick={handleCancelClick}
+              className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-[11px] transition-colors ${
+                cancelDisabled
+                  ? "cursor-not-allowed opacity-60"
+                  : isSelectable
+                    ? "hover:bg-white/20"
+                    : "text-zinc-400 hover:bg-rose-50 hover:text-rose-600 dark:text-zinc-500 dark:hover:bg-rose-900/30 dark:hover:text-rose-400"
+              }`}
+            >
+              {cancelDisabled ? (
+                <svg
+                  className="h-3 w-3 animate-spin"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  aria-hidden
+                >
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" opacity="0.3" />
+                  <path d="M12 2 a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+              ) : (
+                <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" aria-hidden>
+                  <path
+                    d="M6 6 L18 18 M6 18 L18 6"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              )}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* 第二行：操作类型 + 触发方式/KG 统计 + 时长 + 版本 */}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -39,6 +39,7 @@ export type {
 
 export {
   fetchDashboard,
+  cancelPipelineRun,
   fetchCorpora,
   createCorpus,
   fetchCorpus,
@@ -132,6 +133,7 @@ export type {
   SearchConfig,
   KnowledgeErrorResponse,
   KnowledgeDashboard,
+  PipelineCancelResult,
   CorpusRecord,
   ExtractorSourceKind,
   McpExtractorTargetConfig,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1026,17 +1026,7 @@ export async function cancelPipelineRun(
       reason: opts?.reason ?? "user_cancel",
     }),
   });
-  if (res.status === 404) {
-    throw new Error("Pipeline run not found");
-  }
-  if (res.status === 409) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(`Run already in terminal state: ${body?.detail ?? res.statusText}`);
-  }
-  if (!res.ok) {
-    throw new Error(`Failed to cancel pipeline run: ${res.statusText}`);
-  }
-  return res.json();
+  return handleKnowledgeError<PipelineCancelResult>(res);
 }
 
 // ============================================================================

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -986,6 +986,60 @@ export async function fetchDashboard(
 }
 
 // ============================================================================
+// Pipeline Run Cancel
+// ============================================================================
+
+/** Cancel API 响应（KB & KG 共用）。`status` ∈ {cancelling, cancelled, noop}。 */
+export interface PipelineCancelResult {
+  status: "cancelling" | "cancelled" | "noop";
+  run_id: string;
+  in_process: boolean;
+  record: Record<string, unknown>;
+}
+
+/**
+ * 取消正在运行的 Pipeline Run（KB 或 KG）。
+ *
+ * - KB: `POST /api/knowledge/pipelines/{run_id}/cancel`
+ * - KG: `POST /api/knowledge/base/{corpus_id}/graph/runs/{run_id}/cancel`
+ *
+ * 立即返回 cancelling/cancelled/noop，task 在下个检查点退出。前端轮询观察终态。
+ */
+export async function cancelPipelineRun(
+  runId: string,
+  source: "kb" | "kg",
+  opts?: { corpusId?: string; appName?: string; reason?: string },
+): Promise<PipelineCancelResult> {
+  if (source === "kg" && !opts?.corpusId) {
+    throw new Error("cancelPipelineRun: corpusId is required for KG runs");
+  }
+  const url =
+    source === "kb"
+      ? `/api/knowledge/pipelines/${encodeURIComponent(runId)}/cancel`
+      : `/api/knowledge/base/${encodeURIComponent(opts!.corpusId!)}/graph/runs/${encodeURIComponent(runId)}/cancel`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+    body: JSON.stringify({
+      app_name: opts?.appName,
+      reason: opts?.reason ?? "user_cancel",
+    }),
+  });
+  if (res.status === 404) {
+    throw new Error("Pipeline run not found");
+  }
+  if (res.status === 409) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(`Run already in terminal state: ${body?.detail ?? res.statusText}`);
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to cancel pipeline run: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+// ============================================================================
 // Corpus (Knowledge Base)
 // ============================================================================
 

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -262,6 +262,12 @@ export const getStageColor = (stageName: string, status?: string): string => {
       return colors.failed;
     case "skipped":
       return colors.skipped;
+    case "cancelling":
+      // amber 脉动：表达"取消信号已发，等待 task 在检查点退出"的中间态
+      return "bg-amber-400 animate-pulse";
+    case "cancelled":
+      // zinc 静态：用户主动取消，区别于失败 (rose) 与跳过 (zinc-300)
+      return "bg-zinc-500";
     default:
       return colors.completed;
   }
@@ -377,6 +383,12 @@ export const getPipelineStatusColor = (status?: string): string => {
       return "bg-rose-500";
     case "pending":
       return "bg-zinc-400 animate-pulse";
+    case "cancelling":
+      // 取消进行中：amber 脉动（与 running 同色调以表达"还在运行但已收到取消信号"）
+      return "bg-amber-400 animate-pulse";
+    case "cancelled":
+      // 已取消终态：zinc 静态（区别于 failed 的 rose 与 skipped 的浅 zinc）
+      return "bg-zinc-500";
     case "skipped":
       return "bg-zinc-300 dark:bg-zinc-600";
     default:
@@ -402,6 +414,10 @@ export const getPipelineStatusTextColor = (status?: string): string => {
     case "error":
       return "text-rose-600 dark:text-rose-400";
     case "pending":
+      return "text-zinc-600 dark:text-zinc-400";
+    case "cancelling":
+      return "text-amber-700 dark:text-amber-300";
+    case "cancelled":
       return "text-zinc-600 dark:text-zinc-400";
     default:
       return "text-zinc-500 dark:text-zinc-400";

--- a/apps/negentropy-ui/features/knowledge/utils/unified-pipeline.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/unified-pipeline.ts
@@ -245,11 +245,19 @@ export function mergeAndSortRuns(
 }
 
 /**
- * 检测运行中（KB 或 KG）的 run
+ * 检测活跃 run（运行中 / 待启动 / 取消中），用于触发轮询。
+ *
+ * `cancelling` 也视为活跃，因为前端需要持续轮询观察其收敛到 `cancelled` 终态
+ * （task 在检查点退出后写终态，最长 < 一个 stage / phase 周期）。
  */
 export function hasActiveRuns(runs: UnifiedPipelineRun[]): boolean {
   return runs.some((run) => {
     const status = run.status?.toLowerCase();
-    return status === "running" || status === "in_progress" || status === "pending";
+    return (
+      status === "running" ||
+      status === "in_progress" ||
+      status === "pending" ||
+      status === "cancelling"
+    );
   });
 }

--- a/apps/negentropy-ui/tests/e2e/home-chat.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/home-chat.spec.ts
@@ -189,6 +189,7 @@ test("Home 双气泡守卫：单轮文本回复后 assistant message-bubble coun
   // 等待新 session 在左侧 SessionList 中出现（label 由 createSessionLabel 截短，前缀稳定）
   await expect(page.getByText("Session home-cha", { exact: false }).first()).toBeVisible();
   await page.getByPlaceholder("输入指令...").fill("hello");
+  await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
   await page.getByRole("button", { name: "Send" }).click();
 
   // 等待终态文本出现
@@ -281,6 +282,7 @@ test("Home 双气泡守卫：流式 Markdown + 终态 hydration 后 message-bubb
   await page.getByRole("button", { name: "+ New" }).click();
   await expect(page.getByText("Session home-cha", { exact: false }).first()).toBeVisible();
   await page.getByPlaceholder("输入指令...").fill("帮我做任务分析");
+  await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
   await page.getByRole("button", { name: "Send" }).click();
 
   await expect(page.getByRole("heading", { level: 2, name: "任务分析" })).toHaveCount(1);
@@ -501,6 +503,7 @@ test("Home 双气泡守卫：assistant 含 tool-group + 后续文本时 message-
   await page.getByRole("button", { name: "+ New" }).click();
   await expect(page.getByText("Session home-cha", { exact: false }).first()).toBeVisible();
   await page.getByPlaceholder("输入指令...").fill("找 LLM agent memory 论文");
+  await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
   await page.getByRole("button", { name: "Send" }).click();
 
   await expect(page.getByRole("heading", { level: 2, name: "检索结果" })).toBeVisible({
@@ -686,6 +689,7 @@ test("Home 流式 dedupe：双 messageId 同源不同完成度 → 仅渲染 fin
   await page.getByRole("button", { name: "+ New" }).click();
   await expect(page.getByText("Session home-cha", { exact: false }).first()).toBeVisible();
   await page.getByPlaceholder("输入指令...").fill('Reply with exactly: "Hello, test 1234"');
+  await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
   await page.getByRole("button", { name: "Send" }).click();
 
   // 等待 final 内容出现

--- a/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DashboardPage.test.tsx
@@ -141,7 +141,9 @@ describe("KnowledgeDashboardPage polling", () => {
       await vi.advanceTimersByTimeAsync(10000);
     });
     await settle();
-    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(4);
+    // Bootstrap polling 不再为 active runs 启动（避免与 running-state 重叠），
+    // 仅 running-state 5s interval 轮询：1 initial + 5s + 10s = 3 calls
+    expect(knowledgeMocks.fetchPipelinesMock).toHaveBeenCalledTimes(3);
   });
 
   it("桌面端使用固定双栏 grid，并为长内容提供收敛样式", async () => {

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelineRunCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelineRunCard.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PipelineRunCard } from "@/features/knowledge/components/PipelineRunCard";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const baseProps = {
+  run_id: "build-abc1234-1234567890",
+  version: 1,
+};
+
+describe("PipelineRunCard 取消按钮", () => {
+  it("status=running + onCancel 提供时显示 X 按钮", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="running" onCancel={onCancel} />);
+    expect(screen.getByRole("button", { name: "取消运行" })).toBeInTheDocument();
+  });
+
+  it("status=pending 时同样显示 X 按钮", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="pending" onCancel={onCancel} />);
+    expect(screen.getByRole("button", { name: "取消运行" })).toBeInTheDocument();
+  });
+
+  it("status=cancelling 时按钮 disabled 且 aria-label 为'正在取消'", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="cancelling" onCancel={onCancel} />);
+    const btn = screen.getByRole("button", { name: "正在取消" });
+    expect(btn).toBeDisabled();
+  });
+
+  it("status=completed 时不显示 X 按钮（terminal）", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="completed" onCancel={onCancel} />);
+    expect(screen.queryByRole("button", { name: /取消/ })).toBeNull();
+  });
+
+  it("status=failed 时不显示 X 按钮（terminal）", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="failed" onCancel={onCancel} />);
+    expect(screen.queryByRole("button", { name: /取消/ })).toBeNull();
+  });
+
+  it("status=cancelled 时不显示 X 按钮（terminal）", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="cancelled" onCancel={onCancel} />);
+    expect(screen.queryByRole("button", { name: /取消/ })).toBeNull();
+  });
+
+  it("不传 onCancel 时即使 running 也不显示按钮（父组件可控可见性）", () => {
+    render(<PipelineRunCard {...baseProps} status="running" />);
+    expect(screen.queryByRole("button", { name: /取消/ })).toBeNull();
+  });
+
+  it("点击 X 按钮触发 onCancel 回调", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="running" onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "取消运行" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("点击 X 按钮 stopPropagation 不会触发 selectable 模式的 onSelect", () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <PipelineRunCard
+        {...baseProps}
+        status="running"
+        mode="selectable"
+        onSelect={onSelect}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "取消运行" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("link 模式下 X 按钮也可工作", () => {
+    const onCancel = vi.fn();
+    render(<PipelineRunCard {...baseProps} status="running" mode="link" onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "取消运行" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -4,12 +4,12 @@ import json
 import mimetypes
 import re
 import urllib.parse
-from datetime import datetime
+from datetime import UTC, datetime
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError  # noqa: F401
 from sqlalchemy import func, select
@@ -155,6 +155,8 @@ from .schemas import (  # noqa: F401
     MultiHopEvidenceEdgeItem,
     MultiHopReasonRequest,
     MultiHopReasonResponse,
+    PipelineCancelRequest,
+    PipelineCancelResponse,
     PipelineRunRecordResponse,
     PipelineStageResultResponse,
     PipelinesUpsertRequest,
@@ -2917,6 +2919,71 @@ async def upsert_pipelines(payload: PipelinesUpsertRequest) -> PipelineUpsertRes
     )
 
 
+@router.post(
+    "/pipelines/{run_id}/cancel",
+    response_model=PipelineCancelResponse,
+)
+async def cancel_pipeline_run(
+    run_id: str,
+    payload: PipelineCancelRequest = Body(default_factory=PipelineCancelRequest),  # noqa: B008
+    user: AuthUser | None = Depends(get_optional_user),
+) -> PipelineCancelResponse:
+    """协作式取消正在运行的 KB Pipeline Run。
+
+    立即返回 cancelling/cancelled/noop 状态，task 在下一个 stage 边界（通常 < 5s）
+    感知信号并写终态；多 worker 场景下依赖 DB 兜底（最长一个 stage 周期）。
+    采用条件 UPDATE 规避与 `tracker._persist` 的 race（R-7 修补）。
+
+    Errors:
+        404: Run 不存在；
+        409: Run 已是 terminal 状态（completed/failed/cancelled）。
+    """
+    from .cancellation import signal_cancel
+
+    resolved_app = _resolve_app_name(payload.app_name)
+    dao = _get_dao()
+    cancellation_meta: dict[str, Any] = {
+        "requested_at": datetime.now(UTC).isoformat(),
+        "requested_by": user.email if user else None,
+        "reason": payload.reason or "user_cancel",
+    }
+    new_status, record = await dao.request_pipeline_run_cancel(
+        app_name=resolved_app,
+        run_id=run_id,
+        cancellation_meta=cancellation_meta,
+    )
+
+    if new_status == "not_found":
+        raise HTTPException(status_code=404, detail="Pipeline run not found")
+    if new_status == "terminal":
+        current = record.status if record else "unknown"
+        raise HTTPException(
+            status_code=409,
+            detail=f"Pipeline run is in terminal state: {current}",
+        )
+
+    # 进程内 fast-path 信号；False 表示 task 在其他 worker，依赖 DB 兜底
+    in_process = signal_cancel(run_id) if record else False
+
+    record_dict: dict[str, Any] = {}
+    if record is not None:
+        record_dict = {
+            "id": str(record.id),
+            "run_id": record.run_id,
+            "status": record.status,
+            "version": record.version,
+            "updated_at": record.updated_at.isoformat() if record.updated_at else None,
+            "payload": record.payload or {},
+        }
+
+    return PipelineCancelResponse(
+        status=new_status,
+        run_id=run_id,
+        in_process=in_process,
+        record=record_dict,
+    )
+
+
 # ============================================================================
 # Knowledge Graph API Endpoints (Phase 1 Enhancement)
 # ============================================================================
@@ -3015,6 +3082,76 @@ async def build_knowledge_graph(
 
     except KnowledgeError as exc:
         raise _map_exception_to_http(exc) from exc
+
+
+@router.post(
+    "/base/{corpus_id}/graph/runs/{run_id}/cancel",
+    response_model=PipelineCancelResponse,
+)
+async def cancel_kg_build_run(
+    corpus_id: UUID,
+    run_id: str,
+    payload: PipelineCancelRequest = Body(default_factory=PipelineCancelRequest),  # noqa: B008
+    user: AuthUser | None = Depends(get_optional_user),
+) -> PipelineCancelResponse:
+    """协作式取消正在运行的 KG Build Run。
+
+    路径携带 `corpus_id` 与 `run_id`：`kg_build_runs` 表按 corpus_id 索引，路径
+    携带是 RESTful 规范；run_id 用于 KG repository 内的条件 UPDATE 定位。立即
+    返回 cancelling/cancelled/noop，task 在 emit_phase 阶段边界（最长 30s）感知
+    后写终态；进程内同 worker 通过 in-memory event 秒级感知（R-9 修补）。
+
+    Errors:
+        404: KG build run 不存在；
+        409: KG build run 已 terminal（completed/failed/cancelled）。
+    """
+    from .cancellation import signal_cancel
+
+    resolved_app = _resolve_app_name(payload.app_name)
+    cancellation_meta: dict[str, Any] = {
+        "requested_at": datetime.now(UTC).isoformat(),
+        "requested_by": user.email if user else None,
+        "reason": payload.reason or "user_cancel",
+        "corpus_id": str(corpus_id),
+    }
+
+    # Reuse default GraphService 的 repository（避免新建 connection pool）
+    graph_service = _get_graph_service()
+    repository = graph_service._repository  # 内部 Repo 引用，私有但稳定（同 build_graph 共用）
+    new_status, record = await repository.request_build_run_cancel(
+        run_id=run_id,
+        app_name=resolved_app,
+        cancellation_meta=cancellation_meta,
+    )
+
+    if new_status == "not_found":
+        raise HTTPException(status_code=404, detail="KG build run not found")
+    if new_status == "terminal":
+        current = record.status if record else "unknown"
+        raise HTTPException(
+            status_code=409,
+            detail=f"KG build run is in terminal state: {current}",
+        )
+
+    in_process = signal_cancel(run_id) if record else False
+
+    record_dict: dict[str, Any] = {}
+    if record is not None:
+        record_dict = {
+            "id": str(record.id),
+            "run_id": record.run_id,
+            "status": record.status,
+            "corpus_id": str(record.corpus_id),
+            "progress_percent": record.progress_percent,
+            "warnings": record.warnings or [],
+        }
+
+    return PipelineCancelResponse(
+        status=new_status,
+        run_id=run_id,
+        in_process=in_process,
+        record=record_dict,
+    )
 
 
 @router.get("/base/{corpus_id}/graph", response_model=dict[str, Any])

--- a/apps/negentropy/src/negentropy/knowledge/cancellation.py
+++ b/apps/negentropy/src/negentropy/knowledge/cancellation.py
@@ -1,0 +1,74 @@
+"""Pipeline Run 协作式取消信号通道（Process-local Event Registry）。
+
+设计说明
+- DB（`status='cancelling'`）是权威信号源，跨 worker / 跨进程重启可见。
+- 本模块提供同 worker 进程内的 fast-path：通过 `asyncio.Event` 让 task 在
+  下一个检查点（stage 边界 / phase 边界）秒级感知取消请求，避免依赖 DB 轮询
+  的延迟。
+- 多 worker 部署场景下，cancel API 落到 worker A、task 在 worker B 时，
+  worker B 通过 stage 边界处的 DB SELECT 兜底感知 —— 见 PipelineTracker。
+
+参考
+- N. Smith, "Notes on structured concurrency, or: Go statement considered harmful,"
+  Trio Project Documentation, 2018: cancel-as-request 而非 cancel-as-kill 的
+  cooperative cancellation 设计哲学。
+- M. Kleppmann, *Designing Data-Intensive Applications*, ch. 9 §9.4: DB 作为
+  协调权威源 + 进程内 fast-path 的最终一致模式。
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+# 模块级 registry：按 run_id 索引每个活跃 pipeline 的 cancel Event。
+# - register 在 PipelineTracker.start() 时调用
+# - unregister 在 execute_*_pipeline finally 块调用，确保终态后清理，零内存泄漏
+# - asyncio dict 的写读是 event-loop 单线程操作，无需额外锁
+_CANCEL_EVENTS: dict[str, asyncio.Event] = {}
+
+
+def register_cancellable_run(run_id: str) -> asyncio.Event:
+    """注册一个可取消 run，返回该 run 的 Event。
+
+    幂等：若已注册（如 BackgroundTasks 重新调度同一 run），返回既有 Event 而非
+    覆盖；这样 cancel API 已 set 过的状态不会因二次 register 丢失。
+    """
+    existing = _CANCEL_EVENTS.get(run_id)
+    if existing is not None:
+        return existing
+    event = asyncio.Event()
+    _CANCEL_EVENTS[run_id] = event
+    return event
+
+
+def signal_cancel(run_id: str) -> bool:
+    """对 `run_id` 发出进程内取消信号。
+
+    Returns:
+        True 表示该 run 在本 worker 进程中（信号已 set，下一个检查点立即生效）；
+        False 表示本 worker 中无该 run（task 可能在其他 worker，依赖 DB 兜底）。
+    """
+    event = _CANCEL_EVENTS.get(run_id)
+    if event is None:
+        return False
+    event.set()
+    return True
+
+
+def is_cancelled(run_id: str) -> bool:
+    """同步快速检查 `run_id` 是否已被取消（不阻塞、不 await）。
+
+    chunk 级 hot loop 入口的首选检查方式：O(1) dict lookup，无 DB 压力。
+    """
+    event = _CANCEL_EVENTS.get(run_id)
+    return event is not None and event.is_set()
+
+
+def unregister_cancellable_run(run_id: str) -> None:
+    """清理 registry 条目。在 execute_*_pipeline finally 块中调用，防内存泄漏。"""
+    _CANCEL_EVENTS.pop(run_id, None)
+
+
+def _registry_size() -> int:
+    """仅用于测试：返回当前 registry 大小，验证内存泄漏防护。"""
+    return len(_CANCEL_EVENTS)

--- a/apps/negentropy/src/negentropy/knowledge/dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/dao.py
@@ -98,24 +98,33 @@ class KnowledgeRunDao:
         *,
         app_name: str | None = None,
         stale_threshold_minutes: int = 30,
-    ) -> int:
-        """将超过阈值的 running 状态 Pipeline 标记为 failed。
+        cancelling_threshold_minutes: int = 5,
+    ) -> dict[str, int]:
+        """将卡死的中间态 Pipeline 强制收敛到终态。
+
+        - `running` 超过 `stale_threshold_minutes` 分钟未更新 → 标记为 `failed`
+          （兼容既有进程崩溃 / task 卡住场景）；
+        - `cancelling` 超过 `cancelling_threshold_minutes` 分钟未更新 → 强制收敛
+          到 `cancelled`（task 已被 kill 或检查点触发前进程重启时的兜底）。
 
         Returns:
-            int: 被终结的 Pipeline 数量。
+            dict: `{"forced_failed": int, "forced_cancelled": int}`。
         """
-        cutoff = datetime.now(UTC) - timedelta(minutes=stale_threshold_minutes)
+        now = datetime.now(UTC)
+        failed_cutoff = now - timedelta(minutes=stale_threshold_minutes)
+        cancelled_cutoff = now - timedelta(minutes=cancelling_threshold_minutes)
+
         async with self._session_factory() as db:
-            conditions = [
+            # 1) running > stale_threshold → failed
+            failed_conditions = [
                 KnowledgePipelineRun.status == "running",
-                KnowledgePipelineRun.updated_at < cutoff,
+                KnowledgePipelineRun.updated_at < failed_cutoff,
             ]
             if app_name is not None:
-                conditions.append(KnowledgePipelineRun.app_name == app_name)
-
-            stmt = (
+                failed_conditions.append(KnowledgePipelineRun.app_name == app_name)
+            failed_stmt = (
                 sql_update(KnowledgePipelineRun)
-                .where(*conditions)
+                .where(*failed_conditions)
                 .values(
                     status="failed",
                     payload=KnowledgePipelineRun.payload.op("||")(
@@ -131,9 +140,104 @@ class KnowledgeRunDao:
                     ),
                 )
             )
-            result = await db.execute(stmt)
+            failed_result = await db.execute(failed_stmt)
+
+            # 2) cancelling > cancelling_threshold → cancelled
+            #    （task 在感知 cancel 信号后未及时 cancel() 落盘，例如进程重启或 kill）
+            cancelled_conditions = [
+                KnowledgePipelineRun.status == "cancelling",
+                KnowledgePipelineRun.updated_at < cancelled_cutoff,
+            ]
+            if app_name is not None:
+                cancelled_conditions.append(KnowledgePipelineRun.app_name == app_name)
+            cancelled_stmt = (
+                sql_update(KnowledgePipelineRun)
+                .where(*cancelled_conditions)
+                .values(
+                    status="cancelled",
+                    payload=KnowledgePipelineRun.payload.op("||")(
+                        {
+                            "cancellation": {
+                                "forced_by_watchdog": True,
+                                "cancelled_at": now.isoformat(),
+                                "reason": (
+                                    f"Pipeline was cancelling for over {cancelling_threshold_minutes}"
+                                    " minutes and was forcibly converged to cancelled."
+                                ),
+                            }
+                        }
+                    ),
+                )
+            )
+            cancelled_result = await db.execute(cancelled_stmt)
+
             await db.commit()
-            return result.rowcount
+            return {
+                "forced_failed": failed_result.rowcount or 0,
+                "forced_cancelled": cancelled_result.rowcount or 0,
+            }
+
+    async def request_pipeline_run_cancel(
+        self,
+        *,
+        app_name: str,
+        run_id: str,
+        cancellation_meta: dict[str, Any],
+    ) -> tuple[str, KnowledgePipelineRun | None]:
+        """对 Pipeline Run 发起取消（条件 UPDATE，规避 race B）。
+
+        规避 race B（R-7）：`tracker._persist` 在每个 stage 边界写 running 状态，与 cancel
+        API 写 cancelling 并发；若用 `upsert_pipeline_run` 会 bump version 且无条件覆盖，
+        后写者覆盖前写者；改用条件 UPDATE：
+        - `WHERE status NOT IN ('completed','failed','cancelled')` —— 只在非终态时变更，
+          避免抢占已完成 run 的状态；
+        - `pending` → `cancelled`（task 尚未启动，无需协作）；
+        - `running` → `cancelling`（信号已发，task 在下个检查点感知后调 `tracker.cancel()`）；
+        - `cancelling` → 不变（幂等命中，返回 `noop`）。
+        - 同时 `version + 1`，并把 `cancellation_meta` 合并进 `payload.cancellation`。
+
+        DB 行锁串行化 cancel 与 _persist 的并发；_persist 写入前先读 DB（R-7 第 2 步）
+        进一步保证 running 不会覆盖 cancelling。
+
+        Returns:
+            (status, record):
+            - `("not_found", None)`：run 不存在；
+            - `("terminal", record)`：已是 completed/failed/cancelled，409；
+            - `("noop", record)`：已是 cancelling，幂等命中；
+            - `("cancelled", record)`：pending → cancelled；
+            - `("cancelling", record)`：running → cancelling。
+        """
+        async with self._session_factory() as db:
+            stmt = (
+                select(KnowledgePipelineRun)
+                .where(
+                    KnowledgePipelineRun.app_name == app_name,
+                    KnowledgePipelineRun.run_id == run_id,
+                )
+                .with_for_update()
+            )
+            result = await db.execute(stmt)
+            existing = result.scalar_one_or_none()
+            if existing is None:
+                return ("not_found", None)
+
+            current_status = (existing.status or "").lower()
+            if current_status in ("completed", "failed", "cancelled"):
+                return ("terminal", existing)
+            if current_status == "cancelling":
+                return ("noop", existing)
+
+            new_status = "cancelled" if current_status == "pending" else "cancelling"
+            existing.status = new_status
+            # 合并 cancellation 元数据：保留既有 payload，叠加 cancellation 字段
+            new_payload = dict(existing.payload or {})
+            existing_cancellation = new_payload.get("cancellation") or {}
+            new_payload["cancellation"] = {**existing_cancellation, **cancellation_meta}
+            existing.payload = new_payload
+            existing.version = (existing.version or 0) + 1
+            await db.commit()
+            await db.refresh(existing)
+            return (new_status, existing)
 
     async def upsert_pipeline_run(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/exceptions.py
+++ b/apps/negentropy/src/negentropy/knowledge/exceptions.py
@@ -347,6 +347,30 @@ class RelationExtractionError(InfrastructureError):
         super().__init__(message, code="RELATION_EXTRACTION_ERROR", details=details)
 
 
+# ================================
+# Pipeline 取消异常 (Cooperative Cancellation)
+# 用于协作式取消，区别于 KnowledgeError 系列业务/基础设施失败
+# ================================
+
+
+class PipelineCancelled(Exception):
+    """Pipeline 被用户协作式取消（非系统故障）。
+
+    与 `KnowledgeError` 同层独立分支：取消是用户意图，不是失败；
+    特意不继承 `KnowledgeError` 以避免被业务层 `except KnowledgeError` 误捕获，
+    并且不复用 `asyncio.CancelledError`（BaseException 子类，会穿透 `except Exception`，
+    污染普通失败路径）。
+
+    `execute_*_pipeline` 顶层 try/except 中应优先捕获 `PipelineCancelled` 再捕获
+    `Exception`，触发 `tracker.cancel()` 终态写入。
+    """
+
+    def __init__(self, run_id: str, *, last_stage: str | None = None) -> None:
+        self.run_id = run_id
+        self.last_stage = last_stage
+        super().__init__(f"Pipeline {run_id} cancelled at stage={last_stage}")
+
+
 class GraphSearchError(SearchError):
     """图谱检索失败异常
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -2053,7 +2053,7 @@ class AgeGraphRepository(GraphRepository):
             current_status = (row.status or "").lower()
             existing_warnings = list(row.warnings or [])
 
-            def _to_record(updated_status: str, updated_warnings: list) -> BuildRunRecord:
+            def _to_record(updated_status: str, updated_warnings: list, completed_at_override=None) -> BuildRunRecord:
                 return BuildRunRecord(
                     id=row.id,
                     app_name=row.app_name,
@@ -2066,7 +2066,7 @@ class AgeGraphRepository(GraphRepository):
                     model_name=row.model_name,
                     error_message=row.error_message,
                     started_at=row.started_at,
-                    completed_at=row.completed_at,
+                    completed_at=completed_at_override if completed_at_override is not None else row.completed_at,
                     created_at=row.created_at,
                     progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
                     warnings=updated_warnings or None,
@@ -2096,7 +2096,7 @@ class AgeGraphRepository(GraphRepository):
                 },
             )
             await session.commit()
-            return (new_status, _to_record(new_status, new_warnings))
+            return (new_status, _to_record(new_status, new_warnings, completed_at_override=datetime.now(UTC)))
 
     async def finalize_stale_kg_build_runs(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -1965,6 +1965,193 @@ class AgeGraphRepository(GraphRepository):
 
         return runs
 
+    async def get_build_run_by_run_id(
+        self,
+        run_id: str,
+        app_name: str,
+    ) -> BuildRunRecord | None:
+        """按业务 `run_id`（非 UUID 主键）查找构建记录。
+
+        cancel API 收到前端的 run_id（形如 `build-xxx-timestamp`），需要根据它定位
+        kg_build_runs 行。
+        """
+        query = text(f"""
+            SELECT id, app_name, corpus_id, run_id, status,
+                   entity_count, relation_count, extractor_config, model_name,
+                   error_message, started_at, completed_at, created_at,
+                   progress_percent, warnings
+            FROM {self._schema}.kg_build_runs
+            WHERE run_id = :run_id AND app_name = :app_name
+            LIMIT 1
+        """)
+        async with self._session_scope() as session:
+            result = await session.execute(
+                query,
+                {"run_id": run_id, "app_name": app_name},
+            )
+            row = result.fetchone()
+        if row is None:
+            return None
+        return BuildRunRecord(
+            id=row.id,
+            app_name=row.app_name,
+            corpus_id=row.corpus_id,
+            run_id=row.run_id,
+            status=row.status,
+            entity_count=row.entity_count,
+            relation_count=row.relation_count,
+            extractor_config=row.extractor_config or {},
+            model_name=row.model_name,
+            error_message=row.error_message,
+            started_at=row.started_at,
+            completed_at=row.completed_at,
+            created_at=row.created_at,
+            progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
+            warnings=row.warnings if row.warnings else None,
+        )
+
+    async def request_build_run_cancel(
+        self,
+        run_id: str,
+        app_name: str,
+        *,
+        cancellation_meta: dict[str, Any],
+    ) -> tuple[str, BuildRunRecord | None]:
+        """对 KG Build Run 发起取消（条件 UPDATE，规避 race）。
+
+        与 `KnowledgeRunDao.request_pipeline_run_cancel` 同思路：
+        - WHERE status NOT IN ('completed','failed','cancelled')；
+        - pending → cancelled（task 尚未启动 / 极少出现因 KG build 是同步入口）；
+        - running → cancelling；
+        - cancelling → noop；
+        - 元数据写入 warnings JSONB 末尾的 _cancellation 条目（与 _phase / _metrics
+          同型 sentinel 模式，避免 alembic 迁移）。
+
+        Returns:
+            (status, record):
+            - `("not_found", None)`
+            - `("terminal", record)`：完成/失败/已取消
+            - `("noop", record)`：已 cancelling
+            - `("cancelled", record)`：pending → cancelled
+            - `("cancelling", record)`：running → cancelling
+        """
+        import json as _json
+
+        async with self._session_scope() as session:
+            select_stmt = text(f"""
+                SELECT id, status, warnings, app_name, corpus_id, run_id,
+                       entity_count, relation_count, extractor_config, model_name,
+                       error_message, started_at, completed_at, created_at, progress_percent
+                FROM {self._schema}.kg_build_runs
+                WHERE run_id = :run_id AND app_name = :app_name
+                FOR UPDATE
+            """)
+            row = (await session.execute(select_stmt, {"run_id": run_id, "app_name": app_name})).fetchone()
+            if row is None:
+                return ("not_found", None)
+
+            current_status = (row.status or "").lower()
+            existing_warnings = list(row.warnings or [])
+
+            def _to_record(updated_status: str, updated_warnings: list) -> BuildRunRecord:
+                return BuildRunRecord(
+                    id=row.id,
+                    app_name=row.app_name,
+                    corpus_id=row.corpus_id,
+                    run_id=row.run_id,
+                    status=updated_status,
+                    entity_count=row.entity_count,
+                    relation_count=row.relation_count,
+                    extractor_config=row.extractor_config or {},
+                    model_name=row.model_name,
+                    error_message=row.error_message,
+                    started_at=row.started_at,
+                    completed_at=row.completed_at,
+                    created_at=row.created_at,
+                    progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
+                    warnings=updated_warnings or None,
+                )
+
+            if current_status in ("completed", "failed", "cancelled"):
+                return ("terminal", _to_record(row.status, existing_warnings))
+            if current_status == "cancelling":
+                return ("noop", _to_record(row.status, existing_warnings))
+
+            new_status = "cancelled" if current_status == "pending" else "cancelling"
+            new_warnings = list(existing_warnings) + [{"_cancellation": cancellation_meta}]
+
+            update_stmt = text(f"""
+                UPDATE {self._schema}.kg_build_runs
+                SET status = :status,
+                    warnings = CAST(:warnings AS jsonb),
+                    completed_at = CASE WHEN :status = 'cancelled' THEN NOW() ELSE completed_at END
+                WHERE id = :id
+            """)
+            await session.execute(
+                update_stmt,
+                {
+                    "status": new_status,
+                    "warnings": _json.dumps(new_warnings),
+                    "id": str(row.id),
+                },
+            )
+            await session.commit()
+            return (new_status, _to_record(new_status, new_warnings))
+
+    async def finalize_stale_kg_build_runs(
+        self,
+        *,
+        app_name: str | None = None,
+        cancelling_threshold_minutes: int = 5,
+        running_threshold_minutes: int = 30,
+    ) -> dict[str, int]:
+        """KG 看门狗：把卡死的中间态 build_run 收敛到终态。
+
+        - `running` 超 `running_threshold_minutes` 分钟无更新 → 标记为 `failed`；
+        - `cancelling` 超 `cancelling_threshold_minutes` → 强制 `cancelled`。
+        """
+        async with self._session_scope() as session:
+            stale_msg = (
+                "Pipeline was running for over "
+                + str(running_threshold_minutes)
+                + " minutes and was forcibly marked as failed."
+            )
+            failed_stmt = text(f"""
+                UPDATE {self._schema}.kg_build_runs
+                SET status = 'failed',
+                    error_message = COALESCE(error_message, :stale_msg),
+                    completed_at = NOW()
+                WHERE status = 'running'
+                  AND COALESCE(completed_at, created_at) < NOW() - (:running_threshold || ' minutes')::interval
+                  {"AND app_name = :app_name" if app_name is not None else ""}
+            """)
+            cancelled_stmt = text(f"""
+                UPDATE {self._schema}.kg_build_runs
+                SET status = 'cancelled',
+                    completed_at = NOW()
+                WHERE status = 'cancelling'
+                  AND COALESCE(completed_at, created_at) < NOW() - (:cancelling_threshold || ' minutes')::interval
+                  {"AND app_name = :app_name" if app_name is not None else ""}
+            """)
+
+            params_failed: dict[str, Any] = {
+                "running_threshold": running_threshold_minutes,
+                "stale_msg": stale_msg,
+            }
+            params_cancelled: dict[str, Any] = {"cancelling_threshold": cancelling_threshold_minutes}
+            if app_name is not None:
+                params_failed["app_name"] = app_name
+                params_cancelled["app_name"] = app_name
+
+            failed_result = await session.execute(failed_stmt, params_failed)
+            cancelled_result = await session.execute(cancelled_stmt, params_cancelled)
+            await session.commit()
+
+            return {
+                "forced_failed": failed_result.rowcount or 0,
+                "forced_cancelled": cancelled_result.rowcount or 0,
+            }
+
 
 # ============================================================================
 # Factory Function

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -1803,7 +1803,7 @@ class AgeGraphRepository(GraphRepository):
                 progress_percent = COALESCE(:progress, progress_percent),
                 warnings = COALESCE(CAST(:warnings AS jsonb), warnings),
                 processed_chunk_ids = COALESCE(CAST(:chunk_ids AS jsonb), processed_chunk_ids),
-                completed_at = CASE WHEN :status IN ('completed', 'failed') THEN NOW() END
+                completed_at = CASE WHEN :status IN ('completed', 'failed', 'cancelled') THEN NOW() END
             WHERE id = :run_id
         """)
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -2084,7 +2084,7 @@ class AgeGraphRepository(GraphRepository):
                 UPDATE {self._schema}.kg_build_runs
                 SET status = :status,
                     warnings = CAST(:warnings AS jsonb),
-                    completed_at = CASE WHEN :status = 'cancelled' THEN NOW() ELSE completed_at END
+                    completed_at = CASE WHEN :status IN ('cancelled', 'cancelling') THEN NOW() ELSE completed_at END
                 WHERE id = :id
             """)
             await session.execute(

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -29,6 +29,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from negentropy.logging import get_logger
 from negentropy.model_names import canonicalize_model_name
 
+from ..cancellation import (
+    is_cancelled,
+    register_cancellable_run,
+    unregister_cancellable_run,
+)
+from ..exceptions import PipelineCancelled
 from ..types import (
     GraphBuildConfig,
     GraphEdge,
@@ -292,6 +298,11 @@ class GraphService:
             model_name=normalized_llm_model,
         )
 
+        # 注册进程内 fast-path event：cancel API 调 signal_cancel(run_id) 后，
+        # emit_phase 与 process_chunk 入口的 is_cancelled 检查会立即触发退出（R-9 修补）。
+        # 无注册等价于 cancel 仅依赖 emit_phase 边界 DB-poll 兜底，延迟最长一个 phase 周期。
+        register_cancellable_run(run_id)
+
         # 提升到 try 之外：失败分支需要剥离 _phase 后落库 warnings，避免 DB 行残留
         # 上一次 emit_phase 写入的运行期标记；同时让累积的 algorithm warning + 部分 _metrics
         # 在失败时仍然可观测。即便异常发生在 try 内的早期阶段（如 get_processed_chunk_ids）
@@ -358,7 +369,33 @@ class GraphService:
                 progress: float,
                 **extra: Any,
             ) -> None:
-                """写阶段化日志 + 更新 progress_percent + 把 _phase 元数据塞入 warnings。"""
+                """写阶段化日志 + 更新 progress_percent + 把 _phase 元数据塞入 warnings。
+
+                取消检查点（R-8 + R-9）：阶段边界检查 in-memory event（O(1) 同 worker
+                fast-path）+ DB 兜底（跨 worker / 进程重启场景）。每个大阶段 < 10 次，
+                DB SELECT 开销可承受。
+                """
+                # in-memory fast-path
+                if is_cancelled(run_id):
+                    raise PipelineCancelled(run_id, last_stage=phase)
+
+                # DB 兜底：跨 worker 场景，cancel API 落到 worker A 时本 worker 通过 DB 感知。
+                # 用 hasattr/try 兜底兼容 mock repository（无该方法时降级为仅依赖 in-memory）。
+                _get_run = getattr(self._repository, "get_build_run_by_run_id", None)
+                if _get_run is not None:
+                    try:
+                        latest_record = await _get_run(run_id, app_name)
+                    except Exception as poll_exc:
+                        logger.debug(
+                            "cancel_db_poll_failed",
+                            run_id=run_id,
+                            phase=phase,
+                            error=str(poll_exc),
+                        )
+                    else:
+                        if latest_record is not None and latest_record.status in ("cancelling", "cancelled"):
+                            raise PipelineCancelled(run_id, last_stage=phase)
+
                 nonlocal build_warnings
                 phase_meta: dict[str, Any] = {
                     "name": phase,
@@ -443,7 +480,14 @@ class GraphService:
 
                 LLM 调用使用 ``asyncio.wait_for`` 包裹 ``chunk_extract_timeout`` 秒超时，
                 避免单 chunk hang 阻塞整批 ``asyncio.gather``。重试时间窗内仍受 wait_for 约束。
+
+                取消检查点（R-8）：协程入口仅查 in-memory event（O(1) dict lookup），
+                **不查 DB**——chunk 数可能 1000+，DB SELECT 会成压力；DB 兜底由
+                emit_phase 阶段边界承担（最长 1 个 phase 周期感知）。
                 """
+                if is_cancelled(run_id):
+                    raise PipelineCancelled(run_id, last_stage="extracting")
+
                 async with semaphore:
                     text = chunk.get("content", "")
                     if not text:
@@ -854,6 +898,58 @@ class GraphService:
                 failed_chunk_count=failed_chunk_count,
             )
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，剥离运行期 _phase 标记，保留累积 warnings；
+            # best-effort 不回滚——已写入的 entities/relations 保留，前端通过详情面板看
+            # 「取消时进度」（chunks_processed / last_phase）。
+            elapsed = time.time() - start_time
+            cancellation_warnings: list[dict[str, Any]] = _strip_phase_entries(build_warnings)
+            if build_metrics is not None:
+                cancellation_warnings.append({"_metrics": build_metrics.to_dict()})
+            cancellation_warnings.append(
+                {
+                    "_cancellation": {
+                        "cancelled_at": datetime.now(UTC).isoformat(),
+                        "last_stage": cancel_exc.last_stage,
+                        "elapsed_seconds": elapsed,
+                    }
+                }
+            )
+
+            try:
+                if shared_session is not None and not shared_session.is_active:
+                    raise RuntimeError("shared session inactive")
+                await build_repo.update_build_run(
+                    run_id=run_uuid,
+                    status="cancelled",
+                    warnings=cancellation_warnings if cancellation_warnings else None,
+                )
+            except Exception:
+                await self._repository.update_build_run(
+                    run_id=run_uuid,
+                    status="cancelled",
+                    warnings=cancellation_warnings if cancellation_warnings else None,
+                )
+
+            logger.info(
+                "kg_build_cancelled",
+                corpus_id=str(corpus_id),
+                run_id=run_id,
+                last_stage=cancel_exc.last_stage,
+                elapsed_seconds=elapsed,
+            )
+
+            return GraphBuildResult(
+                run_id=run_id,
+                corpus_id=corpus_id,
+                status="cancelled",
+                entity_count=0,
+                relation_count=0,
+                chunks_processed=0,
+                elapsed_seconds=elapsed,
+                error_message=None,
+            )
+
         except Exception as exc:
             elapsed = time.time() - start_time
             error_message = str(exc)
@@ -908,6 +1004,8 @@ class GraphService:
             # 确保共享 Session 被关闭（归还连接到池）
             if shared_session is not None:
                 await shared_session.close()
+            # 清理 cancellation registry，防内存泄漏
+            unregister_cancellable_run(run_id)
 
     async def search(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -381,6 +381,9 @@ class GraphService:
 
                 # DB 兜底：跨 worker 场景，cancel API 落到 worker A 时本 worker 通过 DB 感知。
                 # 用 hasattr/try 兜底兼容 mock repository（无该方法时降级为仅依赖 in-memory）。
+                # 注意：此处通过 self._repository（而非 build_repo）查询，_repository 使用
+                # _session_scope() 开启独立 session 做 SELECT，不与 build_repo 的
+                # shared_session 事务冲突，不会触发连接池竞争。
                 _get_run = getattr(self._repository, "get_build_run_by_run_id", None)
                 if _get_run is not None:
                     try:

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -226,6 +226,35 @@ class PipelinesUpsertRequest(BaseModel):
     expected_version: int | None = None
 
 
+class PipelineCancelRequest(BaseModel):
+    """Pipeline Run 取消请求体（KB & KG 共用）。"""
+
+    app_name: str | None = None
+    reason: str | None = Field(
+        default=None,
+        description="可选取消原因，落盘到 payload.cancellation.reason；默认 'user_cancel'。",
+    )
+
+
+class PipelineCancelResponse(BaseModel):
+    """Pipeline Run 取消响应体。
+
+    `status` 语义：
+    - `cancelled`：pending → 直接转 cancelled（task 尚未启动）；
+    - `cancelling`：running → 转 cancelling（信号已发，task 在下个检查点退出）；
+    - `noop`：已是 cancelling/cancelled（幂等命中）。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    run_id: str
+    in_process: bool = Field(
+        description="True 表示进程内 fast-path 信号已送达；False 表示仅 DB 信号（依赖检查点轮询兜底）。",
+    )
+    record: dict[str, Any] = Field(default_factory=dict, description="最新 run 记录快照。")
+
+
 # ============================================================================
 # Search Schemas
 # ============================================================================

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -512,7 +512,7 @@ class PipelineTracker:
             status=self._status,
             payload=payload,
             idempotency_key=None,
-            expected_version=latest.version if latest is not None else None,
+            expected_version=getattr(latest, "version", None) if latest is not None else None,
         )
         # 乐观并发冲突：cancel API 在 pre-check 与 upsert 之间写入了 cancelling/cancelled
         if result.status == "conflict" and self._status not in ("cancelled", "completed", "failed"):

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -474,11 +474,12 @@ class PipelineTracker:
           覆盖中间态是合法的（cancel() / complete() / fail() 路径必须能落库）。
 
         锁策略说明：本方法不使用 ``SELECT ... FOR UPDATE``，而是采用
-        "读-判-写" 模式。与 cancel API 的 ``request_pipeline_run_cancel``
-        （使用 FOR UPDATE 行锁串行化并发）形成互补：cancel 持锁写 cancelling，
-        本方法先读 cancelling 再跳过写入。两者不竞争同一把锁，不会死锁。
-        ``upsert_pipeline_run`` 以 ``expected_version=None`` 调用，不检查版本——
-        版本不匹配时的覆盖是安全的，因为上面的 cancelling 守卫已拦截危险场景。
+        "读-判-写 + 乐观并发控制" 模式。
+        - 第一道防线（pre-check）：先读 DB，若已 cancelling/cancelled 且本次非终态，
+          跳过写入并接管 status。
+        - 第二道防线（OCC）：pre-check 到 upsert 之间 cancel API 可能提交（多 worker
+          部署），upsert 携带 ``expected_version`` 做版本校验；cancel API 写入后
+          version 已递增，upsert 检测到冲突后接管 DB 权威状态，不盲目覆盖取消信号。
         """
         latest = await self._dao.get_pipeline_run(self._app_name, self._run_id)
         if (
@@ -505,14 +506,20 @@ class PipelineTracker:
         if cancellation_summary:
             payload["cancellation"] = cancellation_summary
 
-        await self._dao.upsert_pipeline_run(
+        result = await self._dao.upsert_pipeline_run(
             app_name=self._app_name,
             run_id=self._run_id,
             status=self._status,
             payload=payload,
             idempotency_key=None,
-            expected_version=None,
+            expected_version=latest.version if latest is not None else None,
         )
+        # 乐观并发冲突：cancel API 在 pre-check 与 upsert 之间写入了 cancelling/cancelled
+        if result.status == "conflict" and self._status not in ("cancelled", "completed", "failed"):
+            conflict_record = result.record
+            conflict_status = conflict_record.get("status", "") if isinstance(conflict_record, dict) else ""
+            if conflict_status in ("cancelling", "cancelled"):
+                self._status = conflict_status
 
 
 class KnowledgeService:

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -472,6 +472,13 @@ class PipelineTracker:
           立即 raise PipelineCancelled。
         - 若本次写入态是终态（cancelled/completed/failed），照常写入 — 终态
           覆盖中间态是合法的（cancel() / complete() / fail() 路径必须能落库）。
+
+        锁策略说明：本方法不使用 ``SELECT ... FOR UPDATE``，而是采用
+        "读-判-写" 模式。与 cancel API 的 ``request_pipeline_run_cancel``
+        （使用 FOR UPDATE 行锁串行化并发）形成互补：cancel 持锁写 cancelling，
+        本方法先读 cancelling 再跳过写入。两者不竞争同一把锁，不会死锁。
+        ``upsert_pipeline_run`` 以 ``expected_version=None`` 调用，不检查版本——
+        版本不匹配时的覆盖是安全的，因为上面的 cancelling 守卫已拦截危险场景。
         """
         latest = await self._dao.get_pipeline_run(self._app_name, self._run_id)
         if (

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -8,6 +8,12 @@ from uuid import UUID
 
 from negentropy.logging import get_logger
 
+from .cancellation import (
+    is_cancelled,
+    register_cancellable_run,
+    unregister_cancellable_run,
+)
+from .exceptions import PipelineCancelled
 from .ingestion.chunking import chunk_text, semantic_chunk_async
 
 if TYPE_CHECKING:
@@ -78,6 +84,9 @@ class PipelineTracker:
         self._error: dict[str, Any] | None = None
         self._status = "pending"
         self._current_stage: str | None = None
+        # 取消终态附加元数据：requested_at / requested_by / reason / chunks_persisted ...
+        # 由 cancel API 在请求时写入 payload.cancellation；tracker.cancel() 时在此聚合。
+        self._cancellation_summary: dict[str, Any] | None = None
 
     def _log_context(self) -> dict[str, Any]:
         return {
@@ -152,10 +161,25 @@ class PipelineTracker:
         self._input = self._normalize_dict_payload(payload.get("input"))
         self._output = self._normalize_dict_payload(payload.get("output"))
         self._error = payload.get("error")
+        # 恢复 cancellation 元数据（cancel API 已写入 payload.cancellation 时）
+        self._cancellation_summary = payload.get("cancellation")
         self._status = record.status
 
     async def start(self, input_data: dict[str, Any]) -> None:
-        """开始 Pipeline 执行"""
+        """开始 Pipeline 执行。
+
+        R-6 race A 修补：先 `resume()` 读 DB 当前状态——若 cancel API 已抢先把
+        status 写为 cancelling/cancelled（在 BackgroundTasks 启动 task 之前用户
+        已点取消），立即 raise PipelineCancelled，**不写 running 覆盖**取消信号。
+        否则 task 启动后会盲写 running，永远跑到自然结束，cancel 信号被静默吞掉。
+        """
+        await self.resume()
+        if self._status in ("cancelling", "cancelled"):
+            raise PipelineCancelled(self._run_id, last_stage=None)
+
+        # 注册进程内 fast-path Event；幂等，重复 start 不覆盖已 set 的 Event
+        register_cancellable_run(self._run_id)
+
         self._started_at = datetime.now(UTC).isoformat()
         self._input = input_data
         self._status = "running"
@@ -166,8 +190,25 @@ class PipelineTracker:
             payload={"input": self._normalize_dict_payload(input_data)},
         )
 
+    async def _check_cancel(self) -> None:
+        """协作式取消检查点：先 in-memory event（O(1)），再 DB（跨 worker 兜底）。
+
+        DB SELECT 仅在 stage 边界触发（每个 stage <30 次/run），开销可承受。
+        若发现取消信号，raise PipelineCancelled 由 execute_*_pipeline 顶层捕获。
+        """
+        if is_cancelled(self._run_id):
+            raise PipelineCancelled(self._run_id, last_stage=self._current_stage)
+
+        # DB-poll 兜底：cancel API 落到其他 worker 时，本 worker 通过 DB 感知
+        record = await self._dao.get_pipeline_run(self._app_name, self._run_id)
+        if record is not None and record.status in ("cancelling", "cancelled"):
+            raise PipelineCancelled(self._run_id, last_stage=self._current_stage)
+
     async def start_stage(self, stage: str) -> None:
         """开始阶段执行"""
+        # 取消检查点：在 stage 边界感知用户取消请求
+        await self._check_cancel()
+
         self._current_stage = stage
         self._stages[stage] = {
             "status": "running",
@@ -340,13 +381,72 @@ class PipelineTracker:
             },
         )
 
+    async def cancel(
+        self,
+        *,
+        last_stage: str | None = None,
+        summary: dict[str, Any] | None = None,
+    ) -> None:
+        """协作式取消终态写入（区别于 fail 与 complete）。
+
+        - 幂等：已是 cancelled/completed/failed 时直接 return，避免重复写入；
+        - 把当前 stage（若有）标记为 cancelled，便于前端 stages bar 直观显示
+          取消位置；
+        - 写入 cancellation summary 到 payload 供前端展示「取消时进度」（已写入
+          chunks 数、最后完成 stage 等，配合 best-effort 不回滚语义）；
+        - 触发 `pipeline_run_cancelled` 审计日志事件，与既有 `pipeline_run_*`
+          命名风格对齐（R-11 修补）。
+        """
+        if self._status in ("cancelled", "completed", "failed"):
+            return
+        now = datetime.now(UTC).isoformat()
+        target_stage = last_stage or self._current_stage
+
+        # 当前正在执行的 stage 标记为 cancelled（不污染 failed 计数）
+        if target_stage and target_stage in self._stages:
+            stage_data = self._stages[target_stage]
+            stage_started_at = stage_data.get("started_at")
+            existing_mcp_events = stage_data.get("mcp_events")
+            self._stages[target_stage] = {
+                "status": "cancelled",
+                "started_at": stage_started_at,
+                "completed_at": now,
+                "duration_ms": self._calculate_duration_ms(stage_started_at, now),
+            }
+            if existing_mcp_events:
+                self._stages[target_stage]["mcp_events"] = existing_mcp_events
+
+        self._status = "cancelled"
+        self._completed_at = now
+        self._duration_ms = self._calculate_duration_ms(self._started_at, now)
+        self._current_stage = None
+        # cancellation summary 用 payload._cancellation_summary 字段，与 _persist 协作落库
+        self._cancellation_summary = dict(summary or {}) | {
+            "cancelled_at": now,
+            "last_stage": target_stage,
+        }
+        await self._persist()
+        self._log_stage_event(
+            "pipeline_run_cancelled",
+            status=self._status,
+            payload={
+                "duration_ms": self._duration_ms,
+                "last_stage": target_stage,
+                "summary": self._cancellation_summary,
+            },
+        )
+
     async def ensure_finalized(self, error: dict[str, Any] | None = None) -> None:
-        """安全网：若 tracker 尚未处于终态（completed/failed），强制写入 failed。
+        """安全网：若 tracker 尚未处于终态（completed/failed/cancelled），强制写入 failed。
 
         在 finally 块中调用，确保无论原始异常是否被成功处理，
-        tracker 状态都不会永远停留在 running。
+        tracker 状态都不会永远停留在 running 或 cancelling。
+
+        注意：cancelling 不被视为终态——若 task 已感知 cancel 信号但因异常未完成
+        `cancel()` 调用，应交由看门狗（`finalize_stale_pipeline_runs`）超时收敛。
+        本方法不主动把 cancelling 转 cancelled，避免吞掉真实异常上下文。
         """
-        if self._status in ("completed", "failed"):
+        if self._status in ("completed", "failed", "cancelled"):
             return
         try:
             error_payload = error or {
@@ -362,7 +462,26 @@ class PipelineTracker:
             )
 
     async def _persist(self) -> None:
-        """持久化 Pipeline 状态"""
+        """持久化 Pipeline 状态。
+
+        R-7 race B 修补：写入前先读 DB——若 cancel API 已把 status 写为
+        cancelling/cancelled，本次 running 写入会**覆盖**取消信号，导致 tracker
+        在下一个检查点之前继续盲跑。修补策略：
+        - 若 DB 已 cancelling/cancelled 且本次写入态非终态（running/pending），
+          跳过写入并接管 status（self._status = DB.status），让最近的检查点
+          立即 raise PipelineCancelled。
+        - 若本次写入态是终态（cancelled/completed/failed），照常写入 — 终态
+          覆盖中间态是合法的（cancel() / complete() / fail() 路径必须能落库）。
+        """
+        latest = await self._dao.get_pipeline_run(self._app_name, self._run_id)
+        if (
+            latest is not None
+            and latest.status in ("cancelling", "cancelled")
+            and self._status not in ("cancelled", "completed", "failed")
+        ):
+            self._status = latest.status  # 接管 DB 权威状态
+            return
+
         payload = {
             "operation": self._operation,
             "trigger": "api",
@@ -374,6 +493,10 @@ class PipelineTracker:
             "output": self._normalize_dict_payload(self._output),
             "error": self._error,
         }
+        # 取消终态 payload 增加 cancellation 字段（best-effort 不回滚语义下的可观测性）
+        cancellation_summary = getattr(self, "_cancellation_summary", None)
+        if cancellation_summary:
+            payload["cancellation"] = cancellation_summary
 
         await self._dao.upsert_pipeline_run(
             app_name=self._app_name,
@@ -421,6 +544,10 @@ class KnowledgeService:
 
     @staticmethod
     async def _fail_pipeline_execution(tracker: PipelineTracker | None, exc: Exception) -> None:
+        # 取消不是失败：让 PipelineCancelled 穿透到顶层 except，由 tracker.cancel() 落库；
+        # 否则中间层 helper 的 `except Exception: fail; raise` 会把取消错误写成 failed 终态。
+        if isinstance(exc, PipelineCancelled):
+            return
         if not tracker:
             return
         error_payload: dict[str, Any] = {
@@ -623,6 +750,10 @@ class KnowledgeService:
 
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
@@ -631,6 +762,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_ingest_url_pipeline(
         self,
@@ -714,6 +846,10 @@ class KnowledgeService:
 
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             # Pipeline 失败已由 tracker 持久化，不再重新抛出。
@@ -724,6 +860,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_ingest_url_document_pipeline(
         self,
@@ -856,6 +993,10 @@ class KnowledgeService:
             )
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
@@ -864,6 +1005,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_ingest_file_pipeline(
         self,
@@ -1007,6 +1149,10 @@ class KnowledgeService:
             )
 
             return records
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             # Pipeline 失败已由 tracker 持久化，不再重新抛出。
@@ -1017,6 +1163,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_replace_source_pipeline(
         self,
@@ -1081,6 +1228,10 @@ class KnowledgeService:
 
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
@@ -1089,6 +1240,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_sync_source_pipeline(
         self,
@@ -1173,6 +1325,10 @@ class KnowledgeService:
 
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
@@ -1181,6 +1337,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_sync_document_pipeline(
         self,
@@ -1301,6 +1458,10 @@ class KnowledgeService:
             )
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
@@ -1309,6 +1470,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def execute_rebuild_source_pipeline(
         self,
@@ -1453,6 +1615,10 @@ class KnowledgeService:
 
             return records
 
+        except PipelineCancelled as cancel_exc:
+            # 协作式取消：写入 cancelled 终态，区别于 fail；幂等（cancel() 内部保护）。
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+            return []
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
@@ -1461,6 +1627,7 @@ class KnowledgeService:
                 await tracker.ensure_finalized()
             except Exception:
                 pass
+            unregister_cancellable_run(run_id)
 
     async def ensure_corpus(self, spec: CorpusSpec) -> CorpusRecord:
         return await self._repository.get_or_create_corpus(spec)

--- a/apps/negentropy/tests/unit_tests/knowledge/test_cancel_api.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_cancel_api.py
@@ -1,0 +1,199 @@
+"""Pipeline Run Cancel API 单元测试。
+
+覆盖：
+- pending → cancelled（直接转终态）
+- running → cancelling（信号已发，task 在检查点退出）
+- 已 terminal → 409
+- 不存在的 run → 404
+- 已 cancelling → noop（幂等）
+- payload.cancellation 元数据写入正确（requested_at / requested_by / reason）
+
+不测试：进程内 fast-path event 信号（依赖 asyncio Event 真实状态，由
+test_pipeline_tracker_cancel.py 的集成测试覆盖）。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from negentropy.knowledge import api as knowledge_api
+from negentropy.knowledge.cancellation import _CANCEL_EVENTS
+from negentropy.knowledge.schemas import PipelineCancelRequest
+
+
+def _make_record(*, status: str, run_id: str = "run-1", version: int = 1):
+    """生成 KnowledgePipelineRun 同形 SimpleNamespace。"""
+    return SimpleNamespace(
+        id=uuid4(),
+        run_id=run_id,
+        status=status,
+        version=version,
+        payload={"operation": "ingest_text", "stages": {}, "input": {}},
+        updated_at=datetime.now(UTC),
+    )
+
+
+class _FakeDao:
+    def __init__(self, behavior: dict[str, object]):
+        self._behavior = behavior
+
+    async def request_pipeline_run_cancel(self, *, app_name, run_id, cancellation_meta):
+        _ = (app_name, run_id, cancellation_meta)
+        result = self._behavior["result"]
+        # 模拟 cancellation_meta 合并到 payload.cancellation
+        if isinstance(result, tuple) and result[1] is not None:
+            new_status, record = result
+            new_payload = dict(record.payload or {})
+            new_payload["cancellation"] = cancellation_meta
+            record.payload = new_payload
+            return (new_status, record)
+        return result
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_run_directly_to_cancelled(monkeypatch):
+    """pending 状态的 run 直接转 cancelled。"""
+    record = _make_record(status="cancelled")  # request_pipeline_run_cancel 已变更
+    dao = _FakeDao(behavior={"result": ("cancelled", record)})
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: dao)
+    _CANCEL_EVENTS.clear()
+
+    result = await knowledge_api.cancel_pipeline_run(
+        run_id="run-1",
+        payload=PipelineCancelRequest(app_name="negentropy", reason="user_cancel"),
+        user=None,
+    )
+
+    assert result.status == "cancelled"
+    assert result.run_id == "run-1"
+    assert result.in_process is False  # 无 task 在本进程
+    assert result.record["status"] == "cancelled"
+    assert result.record["payload"]["cancellation"]["reason"] == "user_cancel"
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_run_to_cancelling(monkeypatch):
+    """running 状态的 run 转 cancelling，task 待检查点退出。"""
+    record = _make_record(status="cancelling")
+    dao = _FakeDao(behavior={"result": ("cancelling", record)})
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: dao)
+    _CANCEL_EVENTS.clear()
+
+    result = await knowledge_api.cancel_pipeline_run(
+        run_id="run-1",
+        payload=PipelineCancelRequest(app_name="negentropy"),
+        user=None,
+    )
+
+    assert result.status == "cancelling"
+    assert result.in_process is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_terminal_run_returns_409(monkeypatch):
+    """已 completed 的 run 不能取消。"""
+    record = _make_record(status="completed")
+    dao = _FakeDao(behavior={"result": ("terminal", record)})
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: dao)
+    _CANCEL_EVENTS.clear()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await knowledge_api.cancel_pipeline_run(
+            run_id="run-1",
+            payload=PipelineCancelRequest(),
+            user=None,
+        )
+    assert exc_info.value.status_code == 409
+    assert "terminal" in str(exc_info.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_nonexistent_run_returns_404(monkeypatch):
+    """不存在的 run 返回 404。"""
+    dao = _FakeDao(behavior={"result": ("not_found", None)})
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: dao)
+    _CANCEL_EVENTS.clear()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await knowledge_api.cancel_pipeline_run(
+            run_id="nonexistent",
+            payload=PipelineCancelRequest(),
+            user=None,
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_already_cancelling_is_noop(monkeypatch):
+    """已 cancelling 的 run 二次取消幂等返回 noop。"""
+    record = _make_record(status="cancelling")
+    dao = _FakeDao(behavior={"result": ("noop", record)})
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: dao)
+    _CANCEL_EVENTS.clear()
+
+    result = await knowledge_api.cancel_pipeline_run(
+        run_id="run-1",
+        payload=PipelineCancelRequest(),
+        user=None,
+    )
+    assert result.status == "noop"
+    assert result.run_id == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_cancel_writes_payload_metadata(monkeypatch):
+    """cancellation 元数据正确写入 payload（requested_at / requested_by / reason）。"""
+    record = _make_record(status="cancelling")
+    captured_meta: dict = {}
+
+    class _CapturingDao:
+        async def request_pipeline_run_cancel(self, *, app_name, run_id, cancellation_meta):
+            captured_meta.update(cancellation_meta)
+            new_payload = dict(record.payload or {})
+            new_payload["cancellation"] = cancellation_meta
+            record.payload = new_payload
+            return ("cancelling", record)
+
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: _CapturingDao())
+    _CANCEL_EVENTS.clear()
+
+    user = SimpleNamespace(email="alice@example.com")
+    await knowledge_api.cancel_pipeline_run(
+        run_id="run-1",
+        payload=PipelineCancelRequest(reason="too slow"),
+        user=user,
+    )
+
+    assert captured_meta["reason"] == "too slow"
+    assert captured_meta["requested_by"] == "alice@example.com"
+    assert "requested_at" in captured_meta
+    # ISO-8601 时间戳格式校验
+    datetime.fromisoformat(captured_meta["requested_at"])
+
+
+@pytest.mark.asyncio
+async def test_cancel_default_reason_is_user_cancel(monkeypatch):
+    """未传 reason 时默认为 user_cancel。"""
+    record = _make_record(status="cancelling")
+    captured: dict = {}
+
+    class _CapturingDao:
+        async def request_pipeline_run_cancel(self, *, app_name, run_id, cancellation_meta):
+            captured.update(cancellation_meta)
+            return ("cancelling", record)
+
+    monkeypatch.setattr(knowledge_api, "_get_dao", lambda: _CapturingDao())
+    _CANCEL_EVENTS.clear()
+
+    await knowledge_api.cancel_pipeline_run(
+        run_id="run-1",
+        payload=PipelineCancelRequest(),
+        user=None,
+    )
+    assert captured["reason"] == "user_cancel"
+    assert captured["requested_by"] is None

--- a/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker_cancel.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker_cancel.py
@@ -2,7 +2,8 @@
 
 覆盖：
 - R-6 race A：start() 入口 resume 看到 cancelling/cancelled → raise PipelineCancelled
-- R-7 race B：_persist 写入前先读 DB，已 cancelling 则跳过 running 覆盖
+- R-7 race B 第一道防线（pre-check）：_persist 写入前先读 DB，已 cancelling 则跳过 running 覆盖
+- R-7 race B 第二道防线（OCC）：pre-check 通过但 upsert 版本不匹配时接管 cancelling
 - start_stage 入口检查点（in-memory event）→ raise PipelineCancelled
 - start_stage 入口检查点（DB 兜底）→ raise PipelineCancelled
 - cancel() 写入 cancelled 终态 + 当前 stage 同步标 cancelled + payload.cancellation
@@ -49,9 +50,14 @@ class _FakePipelineDao:
         idempotency_key: str | None,
         expected_version: int | None,
     ):
-        _ = (idempotency_key, expected_version)
-        self.persist_calls.append((app_name, run_id, status))
         existing = self.records.get((app_name, run_id))
+        # OCC version check：expected_version 不匹配时返回 conflict
+        if existing is not None and expected_version is not None and existing.version != expected_version:
+            return SimpleNamespace(
+                status="conflict",
+                record={"status": existing.status, "version": existing.version, "run_id": run_id},
+            )
+        self.persist_calls.append((app_name, run_id, status))
         version = (existing.version + 1) if existing else 1
         record = SimpleNamespace(
             id=f"id-{run_id}",
@@ -288,3 +294,53 @@ async def test_signal_cancel_returns_false_when_not_registered():
     assert signal_cancel("not-registered") is False
     register_cancellable_run("r1")
     assert signal_cancel("r1") is True
+
+
+class _StalePreCheckDao(_FakePipelineDao):
+    """DAO whose get_pipeline_run returns a stale record once, simulating
+    cancel API writing between _persist pre-check and upsert."""
+
+    def __init__(self, stale_record: SimpleNamespace) -> None:
+        super().__init__()
+        self._stale = stale_record
+        self._consumed = False
+
+    async def get_pipeline_run(self, app_name: str, run_id: str):
+        if not self._consumed:
+            self._consumed = True
+            return self._stale
+        return await super().get_pipeline_run(app_name, run_id)
+
+
+@pytest.mark.asyncio
+async def test_persist_occ_conflict_takes_over_cancelling():
+    """R-7 OCC 第二道防线：pre-check 读到 stale running（version=2），
+    但 cancel API 在间隙递增 version 至 3 并写入 cancelling；
+    upsert 检测到 version 2≠3 → conflict → tracker 接管 cancelling。"""
+    dao = _StalePreCheckDao(
+        stale_record=SimpleNamespace(
+            id="id-run-1",
+            run_id="run-1",
+            app_name="negentropy",
+            status="running",
+            version=2,
+            payload={},
+            updated_at=datetime.now(UTC),
+        )
+    )
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})  # version → 2, status=running
+
+    # 模拟 cancel API 在 pre-check 之后并发写入
+    dao.records[("negentropy", "run-1")].status = "cancelling"
+    dao.records[("negentropy", "run-1")].version = 3
+
+    tracker._status = "running"
+    persist_count_before = len(dao.persist_calls)
+    await tracker._persist()
+
+    # OCC 冲突：upsert 未执行，tracker 接管 cancelling
+    assert tracker._status == "cancelling"
+    assert len(dao.persist_calls) == persist_count_before
+    assert dao.records[("negentropy", "run-1")].status == "cancelling"

--- a/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker_cancel.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker_cancel.py
@@ -1,0 +1,290 @@
+"""PipelineTracker 取消语义单元测试。
+
+覆盖：
+- R-6 race A：start() 入口 resume 看到 cancelling/cancelled → raise PipelineCancelled
+- R-7 race B：_persist 写入前先读 DB，已 cancelling 则跳过 running 覆盖
+- start_stage 入口检查点（in-memory event）→ raise PipelineCancelled
+- start_stage 入口检查点（DB 兜底）→ raise PipelineCancelled
+- cancel() 写入 cancelled 终态 + 当前 stage 同步标 cancelled + payload.cancellation
+- cancel() 幂等：已 cancelled/completed/failed 时 noop
+- ensure_finalized 跳过 cancelled 终态
+- _fail_pipeline_execution 不把 PipelineCancelled 写成 failed
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from negentropy.knowledge.cancellation import (
+    _CANCEL_EVENTS,
+    register_cancellable_run,
+    signal_cancel,
+    unregister_cancellable_run,
+)
+from negentropy.knowledge.exceptions import PipelineCancelled
+from negentropy.knowledge.service import KnowledgeService, PipelineTracker
+
+
+class _FakePipelineDao:
+    """内存版 PipelineRun DAO，模拟 status / payload / version。"""
+
+    def __init__(self) -> None:
+        self.records: dict[tuple[str, str], SimpleNamespace] = {}
+        self.persist_calls: list[tuple[str, str, str]] = []  # (app, run, status)
+
+    async def get_pipeline_run(self, app_name: str, run_id: str):
+        return self.records.get((app_name, run_id))
+
+    async def upsert_pipeline_run(
+        self,
+        *,
+        app_name: str,
+        run_id: str,
+        status: str,
+        payload: dict[str, Any],
+        idempotency_key: str | None,
+        expected_version: int | None,
+    ):
+        _ = (idempotency_key, expected_version)
+        self.persist_calls.append((app_name, run_id, status))
+        existing = self.records.get((app_name, run_id))
+        version = (existing.version + 1) if existing else 1
+        record = SimpleNamespace(
+            id=f"id-{run_id}",
+            run_id=run_id,
+            app_name=app_name,
+            status=status,
+            payload=payload,
+            version=version,
+            updated_at=datetime.now(UTC),
+        )
+        self.records[(app_name, run_id)] = record
+        return SimpleNamespace(status="updated" if existing else "created", record={})
+
+    def seed(self, *, app_name: str, run_id: str, status: str, payload: dict | None = None):
+        self.records[(app_name, run_id)] = SimpleNamespace(
+            id=f"id-{run_id}",
+            run_id=run_id,
+            app_name=app_name,
+            status=status,
+            payload=payload or {},
+            version=1,
+            updated_at=datetime.now(UTC),
+        )
+
+
+@pytest.fixture
+def dao() -> _FakePipelineDao:
+    return _FakePipelineDao()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    _CANCEL_EVENTS.clear()
+    yield
+    _CANCEL_EVENTS.clear()
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_db_already_cancelling(dao: _FakePipelineDao):
+    """R-6 race A：cancel API 抢先把 DB 写为 cancelling 后，task 启动时立即 raise。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="cancelling")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+
+    with pytest.raises(PipelineCancelled):
+        await tracker.start({"corpus_id": "c1"})
+
+    # 关键：未写入 running 覆盖 cancelling
+    assert all(status != "running" for (_a, _r, status) in dao.persist_calls)
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_db_already_cancelled(dao: _FakePipelineDao):
+    dao.seed(app_name="negentropy", run_id="run-1", status="cancelled")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    with pytest.raises(PipelineCancelled):
+        await tracker.start({"corpus_id": "c1"})
+
+
+@pytest.mark.asyncio
+async def test_start_writes_running_when_db_pending(dao: _FakePipelineDao):
+    """正常路径：DB 未取消时 start() 写 running 状态。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+
+    assert dao.records[("negentropy", "run-1")].status == "running"
+    assert ("negentropy", "run-1", "running") in dao.persist_calls
+
+
+@pytest.mark.asyncio
+async def test_persist_skips_running_overwrite_when_db_cancelling(dao: _FakePipelineDao):
+    """R-7 race B：_persist 写 running 前发现 DB 已 cancelling，跳过覆盖并接管 status。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})  # status → running
+
+    # 模拟并发：cancel API 写 cancelling
+    dao.seed(app_name="negentropy", run_id="run-1", status="cancelling")
+    persist_count_before = len(dao.persist_calls)
+
+    # tracker._persist 在 complete_stage 等场景被调用
+    tracker._status = "running"  # tracker 自身仍在 running 视角
+    await tracker._persist()
+
+    # 关键：未把 status 写回 running 覆盖 cancelling
+    assert dao.records[("negentropy", "run-1")].status == "cancelling"
+    # 跳过本次 upsert（_persist 提前 return）
+    assert len(dao.persist_calls) == persist_count_before
+    # tracker 接管 DB 状态
+    assert tracker._status == "cancelling"
+
+
+@pytest.mark.asyncio
+async def test_persist_allows_terminal_overwrite(dao: _FakePipelineDao):
+    """终态写入合法：cancel/complete/fail 允许覆盖 cancelling。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="cancelling")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.resume()
+    tracker._status = "cancelled"
+    await tracker._persist()
+
+    assert dao.records[("negentropy", "run-1")].status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_start_stage_checks_in_memory_event(dao: _FakePipelineDao):
+    """检查点：in-memory event set 后，下个 start_stage 立即 raise。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+
+    # cancel API 在同 worker 调用 signal_cancel
+    signal_cancel("run-1")
+
+    with pytest.raises(PipelineCancelled):
+        await tracker.start_stage("chunk")
+
+
+@pytest.mark.asyncio
+async def test_start_stage_checks_db_status(dao: _FakePipelineDao):
+    """检查点：跨 worker 场景，仅 DB 写 cancelling 也能在下个 stage 边界 raise。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+
+    # 跨 worker 场景：本 worker 无 in-memory event，仅 DB 信号
+    dao.seed(app_name="negentropy", run_id="run-1", status="cancelling")
+
+    with pytest.raises(PipelineCancelled):
+        await tracker.start_stage("chunk")
+
+
+@pytest.mark.asyncio
+async def test_cancel_writes_terminal_state_and_marks_current_stage(dao: _FakePipelineDao):
+    """cancel() 写 cancelled 终态 + 当前 stage 同步标 cancelled。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+    await tracker.start_stage("chunk")
+
+    await tracker.cancel(last_stage="chunk", summary={"chunks_persisted": 42})
+
+    record = dao.records[("negentropy", "run-1")]
+    assert record.status == "cancelled"
+    assert record.payload["stages"]["chunk"]["status"] == "cancelled"
+    assert record.payload["cancellation"]["last_stage"] == "chunk"
+    assert record.payload["cancellation"]["chunks_persisted"] == 42
+    assert "cancelled_at" in record.payload["cancellation"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_is_idempotent(dao: _FakePipelineDao):
+    """已 cancelled 的 tracker 二次 cancel() 不重复写入。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+    await tracker.cancel()
+
+    persist_count_before = len(dao.persist_calls)
+    await tracker.cancel()  # 二次取消
+    assert len(dao.persist_calls) == persist_count_before
+
+
+@pytest.mark.asyncio
+async def test_cancel_does_not_overwrite_completed(dao: _FakePipelineDao):
+    """已 completed 的 tracker 调 cancel() 不覆盖（防止误终态切换）。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+    await tracker.complete({"records": 5})
+    assert dao.records[("negentropy", "run-1")].status == "completed"
+
+    await tracker.cancel()
+    assert dao.records[("negentropy", "run-1")].status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_ensure_finalized_skips_cancelled(dao: _FakePipelineDao):
+    """ensure_finalized 在 cancelled 终态下不写 failed。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+    await tracker.cancel()
+
+    persist_count_before = len(dao.persist_calls)
+    await tracker.ensure_finalized()
+    assert len(dao.persist_calls) == persist_count_before
+    assert dao.records[("negentropy", "run-1")].status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_fail_pipeline_execution_skips_pipeline_cancelled(dao: _FakePipelineDao):
+    """_fail_pipeline_execution 看到 PipelineCancelled 直接 return，避免误写 failed。"""
+    dao.seed(app_name="negentropy", run_id="run-1", status="pending")
+    tracker = PipelineTracker(dao=dao, app_name="negentropy", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": "c1"})
+
+    cancel_exc = PipelineCancelled("run-1", last_stage="chunk")
+    await KnowledgeService._fail_pipeline_execution(tracker, cancel_exc)
+
+    # 关键：未写 failed
+    assert dao.records[("negentropy", "run-1")].status == "running"
+    assert all(status != "failed" for (_a, _r, status) in dao.persist_calls)
+
+
+@pytest.mark.asyncio
+async def test_register_unregister_cancellable_run_lifecycle():
+    """registry 在 register 与 unregister 后大小匹配，验证防内存泄漏。"""
+    register_cancellable_run("r1")
+    register_cancellable_run("r2")
+    assert "r1" in _CANCEL_EVENTS and "r2" in _CANCEL_EVENTS
+
+    unregister_cancellable_run("r1")
+    assert "r1" not in _CANCEL_EVENTS
+    assert "r2" in _CANCEL_EVENTS
+
+    # 重复 unregister 幂等
+    unregister_cancellable_run("r1")
+    assert "r1" not in _CANCEL_EVENTS
+
+
+@pytest.mark.asyncio
+async def test_register_is_idempotent_returns_same_event():
+    """register 同一 run_id 多次返回同一 Event 实例（避免覆盖已 set 状态）。"""
+    e1 = register_cancellable_run("r1")
+    e1.set()
+    e2 = register_cancellable_run("r1")
+    assert e1 is e2
+    assert e2.is_set()
+
+
+@pytest.mark.asyncio
+async def test_signal_cancel_returns_false_when_not_registered():
+    assert signal_cancel("not-registered") is False
+    register_cancellable_run("r1")
+    assert signal_cancel("r1") is True


### PR DESCRIPTION
## 背景

KB / KG 两类 Pipeline Run 一旦启动只能等到自然结束（成功 / 失败 / 30 分钟看门狗超时），用户无主动中止能力 —— 长 ingest（如大文档分片 + LLM extraction）误触发后只能干等，浪费 LLM 调用成本与等待时间。本 PR 为 KB（8 个 `execute_*_pipeline`）+ KG（`build_graph`）实现协作式取消（cooperative cancellation），用户在 Pipeline 页面 Run 卡片上点击 X 图标，task 在下个 stage / phase 边界（< 30s）退出，写入 `cancelled` 终态。**无回滚**（best-effort 取消，对齐 Prefect/Airflow 行业惯例）。

## 双层信号通道

- **DB（权威源）**：跨 worker / 跨进程重启可见。`status='cancelling'` 写入 `knowledge_pipeline_runs` / `kg_build_runs`；元数据写 `payload.cancellation` / `warnings._cancellation`。
- **进程内 `asyncio.Event` registry**：同 worker fast-path（O(1) 同 worker 秒级感知）。

## 关键 Race Condition 修补

| ID | 场景 | 修补 |
|---|---|---|
| **R-6** | Cancel 在 BackgroundTask 启动前到达 | `tracker.start()` 入口先 `await self.resume()` 看 DB；已 cancelling/cancelled 立即 raise `PipelineCancelled`，不写 running 覆盖 |
| **R-7** | `tracker._persist`（每 stage 边界）与 cancel API 写并发 | 1) Cancel API 用条件 `UPDATE WHERE status NOT IN (terminal) + FOR UPDATE` 行锁；2) `_persist` 写入前先读 DB，已 cancelling 跳过本次写入并接管 status |
| **R-8** | KG `process_chunk` 检查点 DB-poll 性能 | chunk 入口仅查 in-memory event（O(1)），DB 兜底由 `emit_phase` 阶段边界承担 |
| **R-9** | KG `build_graph` 缺失 `register_cancellable_run` 注册时机 | `create_build_run` 之后立即 `register_cancellable_run(run_id)` |
| **R-10** | `PipelineStagesBar` 缺 `cancelled` 染色 | `getStageColor` / `getPipelineStatusColor` / `getPipelineStatusTextColor` 三个函数都增加 cancelling/cancelled 分支 |
| **R-11** | `tracker.cancel()` 无审计日志 | 新增 `pipeline_run_cancelled` 事件，与既有 `pipeline_run_*` 命名风格对齐 |

## API 端点

| 端点 | 用途 |
|---|---|
| `POST /knowledge/pipelines/{run_id}/cancel` | KB Pipeline Run 取消 |
| `POST /knowledge/base/{corpus_id}/graph/runs/{run_id}/cancel` | KG Build Run 取消 |

请求体：`{ reason?, app_name? }`；响应体：`{ status: cancelling\|cancelled\|noop, run_id, in_process, record }`。错误码：404 / 409。立即返回，前端 5s 轮询观察终态。

## 看门狗扩展

- **KB** `finalize_stale_pipeline_runs`：返回 `dict[forced_failed, forced_cancelled]`；新增 cancelling > 5min → cancelled 兜底（task 被 kill / 进程重启场景）。
- **KG** `finalize_stale_kg_build_runs`：同等价物（running > 30min → failed；cancelling > 5min → cancelled）。

## 前端实施

- **染色**：`pipeline-helpers.ts` 三个 status/stage 染色函数全部增加 cancelling（amber 脉动）/ cancelled（zinc 静态）；`unified-pipeline.ts:hasActiveRuns` 增加 cancelling 判定让 5s 轮询持续观察收敛。
- **API 客户端**：`cancelPipelineRun(runId, source, opts)` + `PipelineCancelResult` 类型；按 source 分发到对应 BFF。
- **BFF 代理**：`app/api/knowledge/pipelines/[runId]/cancel/route.ts` + `app/api/knowledge/base/[corpusId]/graph/runs/[runId]/cancel/route.ts`。
- **Cancel 按钮**：`PipelineRunCard.tsx` 第一行右侧 X 图标按钮，可见条件 `status ∈ {pending, running, cancelling}`；cancelling 时 disabled + spinner；`stopPropagation + preventDefault` 避免冒泡触发 selectable 卡片选中。
- **二次确认**：`app/knowledge/dashboard/page.tsx` `handleCancelRun` 使用项目通用 `useConfirmDialog`（替代浏览器 native confirm，遵循 AGENTS.md 视觉规范）；成功后立即 refetch loadRuns 让卡片状态切换，剩余收敛交 5s 轮询。

## 测试覆盖

- **后端 22 个新单测全过**：
  - `test_cancel_api.py`（7 例）：pending/running/terminal/404/noop/payload metadata/默认 reason；
  - `test_pipeline_tracker_cancel.py`（15 例）：R-6 / R-7 race 修补、in-memory + DB 检查点、cancel 终态写入、幂等、不覆盖 completed、ensure_finalized 跳过 cancelled、`_fail_pipeline_execution` 跳过 PipelineCancelled、registry 生命周期、register 幂等。
- **前端 10 个新单测全过**：`PipelineRunCard.test.tsx` —— 4 状态矩阵 + 不传 onCancel + 点击触发 + stopPropagation 隔离 + link/selectable 双模式。

## 验证

- [x] `uv run ruff check src/negentropy/knowledge/` 通过
- [x] `uv run pytest tests/unit_tests/knowledge/` 638/638 通过（含新 22 例）
- [x] `pnpm typecheck && pnpm lint` 通过
- [x] `pnpm test --run` 635/635 通过（含新 10 例）

## 测试计划

- [ ] CI 后端 + 前端单测全绿
- [ ] 手动：触发 KB ingest_url 长任务 → 卡片 X 按钮 → 二次确认 → 5-10s 内变 cancelled
- [ ] 手动：触发 KG build（>50 chunks）→ 进入 extracting 阶段 → 点 X → 30s 内变 cancelled
- [ ] 手动：已 completed 的 run 不显示 X 按钮（terminal 态）
- [ ] 手动：取消后再点同卡片 X 按钮（应已不可见）
- [ ] 手动：cancelling 状态下 X 按钮 disabled + spinner

## 设计文献（IEEE）

[1] N. Smith, "Notes on structured concurrency, or: Go statement considered harmful," *Trio Project Documentation*, 2018. — cancel-as-request 而非 cancel-as-kill 设计哲学。
[2] M. Nygard, *Release It!* 2nd ed. Pragmatic Bookshelf, 2018, ch. 5 §5.2. — best-effort cancel 与 partial-effect cleanup 的工业实践。
[3] M. Kleppmann, *Designing Data-Intensive Applications*. O'Reilly, 2017, ch. 9 §9.4. — DB 作为协调权威源 + 看门狗最终化的最终一致模式。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)