### PR TITLE
fix(knowledge-base): 修复 Corpus chunks 计数虚高与摄取写入路径非幂等导致的孤儿数据累积

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusList.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusList.tsx
@@ -98,7 +98,10 @@ export function CorpusList({
                   : "text-muted/70"
               }`}
             >
-              {corpus.knowledge_count} items
+              {corpus.knowledge_count} chunks
+              {corpus.chunk_count_total != null && corpus.chunk_count_total !== corpus.knowledge_count && (
+                <span className="opacity-60">{" · "}{corpus.chunk_count_total} vectors</span>
+              )}
             </span>
           </div>
 

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1178,7 +1178,13 @@ export default function KnowledgeBasePage() {
                     data-testid={`corpus-chunks-${corpus.id}`}
                     className="text-[11px] font-medium text-muted"
                   >
-                    chunks: {corpus.knowledge_count}
+                    {corpus.knowledge_count} chunks
+                    {corpus.chunk_count_total != null &&
+                      corpus.chunk_count_total !== corpus.knowledge_count && (
+                        <span className="opacity-60">
+                          {" · "}{corpus.chunk_count_total} vectors
+                        </span>
+                      )}
                   </span>
                   <CorpusStatusBadge corpus={corpus} />
                 </div>

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -518,6 +518,7 @@ export interface CorpusRecord {
   app_name: string;
   description?: string;
   knowledge_count: number;
+  chunk_count_total?: number | null;
   config?: Record<string, unknown>;
   rebuild_triggered?: { count: number; run_ids: string[] } | null;
 }

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -239,7 +239,7 @@ describe("KnowledgeBasePage", () => {
     const summary = screen.getByTestId("corpus-summary-11111111-1111-1111-1111-111111111111");
     const settingsButton = within(card).getByRole("button", { name: "Settings" });
 
-    expect(chunks).toHaveTextContent("chunks: 3");
+    expect(chunks).toHaveTextContent("3 chunks");
     expect(within(card).getByText("Ready")).toBeInTheDocument();
     expect(description).toHaveTextContent("No description");
     expect(description.className).toContain("line-clamp-2");

--- a/apps/negentropy/scripts/cleanup_orphan_chunks.py
+++ b/apps/negentropy/scripts/cleanup_orphan_chunks.py
@@ -98,6 +98,7 @@ async def _get_chunks_for_source(conn, *, corpus_id: str, app_name: str, source_
     return [
         {
             "id": str(row.id),
+            "source_uri": source_uri,
             "chunk_index": row.chunk_index,
             "created_at": row.created_at,
             "family_id": row.family_id,
@@ -158,7 +159,10 @@ async def _delete_chunks(conn, chunk_ids: list[str]) -> int:
 
 
 def _write_backup_csv(source_uri: str, chunks: list[dict], corpus_id: str) -> str:
-    """写 backup CSV 文件，返回路径。"""
+    """写 backup CSV 文件，返回路径。
+
+    ``source_uri`` 作为默认值；每个 chunk 字典若含 ``source_uri`` 键则优先使用。
+    """
     ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     filename = f"cleanup_{corpus_id[:8]}_{ts}.csv"
     filepath = Path(filename)
@@ -169,7 +173,7 @@ def _write_backup_csv(source_uri: str, chunks: list[dict], corpus_id: str) -> st
             writer.writerow(
                 [
                     c["id"],
-                    source_uri,
+                    c.get("source_uri") or source_uri,
                     c["chunk_index"],
                     c.get("role") or "",
                     str(c["created_at"]),
@@ -189,7 +193,7 @@ async def _cleanup(
     """执行清理。返回退出码（0=成功，1=有 needs_manual_review）。"""
     engine = create_async_engine(str(settings.database_url), echo=False)
     report_items: list[dict] = []
-    all_deleted_ids: list[str] = []
+    all_deleted_chunks: list[dict] = []
     exit_code = 0
 
     try:
@@ -238,7 +242,8 @@ async def _cleanup(
                         exit_code = 1
 
                 kept_ids = {c["id"] for c in latest}
-                deleted_ids = [c["id"] for c in chunks if c["id"] not in kept_ids]
+                deleted_chunks = [c for c in chunks if c["id"] not in kept_ids]
+                deleted_ids = [c["id"] for c in deleted_chunks]
 
                 item_report = {
                     "source_uri": source_uri,
@@ -251,16 +256,18 @@ async def _cleanup(
                     "sample_deleted_ids": deleted_ids[:10],
                 }
                 report_items.append(item_report)
-                all_deleted_ids.extend(deleted_ids)
+                all_deleted_chunks.extend(deleted_chunks)
 
                 print(f"    → Keep batch: {len(kept_ids)} chunks | Delete: {len(deleted_ids)} orphan chunks")
 
             # Step 4: 物理删除（仅在 --apply 时）
-            if apply and all_deleted_ids:
-                # 先写 backup CSV
+            if apply and all_deleted_chunks:
+                all_deleted_ids = [c["id"] for c in all_deleted_chunks]
+
+                # 先写 backup CSV（包含 per-chunk 元数据，便于手工恢复）
                 csv_path = _write_backup_csv(
-                    source_uri="multiple",
-                    chunks=[{"id": did} for did in all_deleted_ids],
+                    source_uri="",
+                    chunks=all_deleted_chunks,
                     corpus_id=corpus_id,
                 )
                 print(f"\n📄 Backup written to: {csv_path}")
@@ -268,8 +275,8 @@ async def _cleanup(
                 deleted = await _delete_chunks(conn, all_deleted_ids)
                 await conn.commit()
                 print(f"\n✓ Deleted {deleted} orphan chunks")
-            elif all_deleted_ids:
-                print(f"\n(Dry run) Would delete {len(all_deleted_ids)} orphan chunks. Use --apply to execute.")
+            elif all_deleted_chunks:
+                print(f"\n(Dry run) Would delete {len(all_deleted_chunks)} orphan chunks. Use --apply to execute.")
 
     finally:
         await engine.dispose()
@@ -282,7 +289,7 @@ async def _cleanup(
             "dry_run": not apply,
             "timestamp": datetime.now(UTC).isoformat(),
             "total_candidates": len(candidates),
-            "total_deleted": len(all_deleted_ids),
+            "total_deleted": len(all_deleted_chunks),
             "items": report_items,
         }
         Path(output_path).write_text(json.dumps(report, indent=2, ensure_ascii=False))

--- a/apps/negentropy/scripts/cleanup_orphan_chunks.py
+++ b/apps/negentropy/scripts/cleanup_orphan_chunks.py
@@ -1,0 +1,323 @@
+"""清理 ``negentropy.knowledge`` 中因非幂等摄取累积的孤儿 chunks。
+
+背景：
+    ingest_text/file/url 在历史版本中不幂等——同一 (corpus_id, source_uri) 多次摄取
+    纯 INSERT 不清理旧 chunks，导致 chunks 数量虚高（如 849 vs 预期 84）。
+
+    本脚本按 (corpus_id, source_uri) 分组，对每组做 created_at 时间聚类，
+    保留最新一次摄取的 chunks，物理删除其余批次。
+
+用法：
+    # 干跑（默认，仅审计报告）
+    uv run python apps/negentropy/scripts/cleanup_orphan_chunks.py \\
+        --corpus-id <UUID> --app-name <APP>
+
+    # 实际删除
+    uv run python apps/negentropy/scripts/cleanup_orphan_chunks.py \\
+        --corpus-id <UUID> --app-name <APP> --apply
+
+    # 导出报告
+    uv run python apps/negentropy/scripts/cleanup_orphan_chunks.py \\
+        --corpus-id <UUID> --app-name <APP> --output report.json
+
+安全机制：
+    1. --corpus-id 必填，限爆炸半径
+    2. 默认 dry_run，必须显式 --apply 才物理删除
+    3. --apply 时强制写 cleanup_<corpus>_<ts>.csv（可手工恢复）
+    4. 最新批次 chunk_index 不连续则跳过该 source_uri 并标 needs_manual_review
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from negentropy.config import settings
+
+# 同一次摄取的所有 chunks 在 60 秒内写入，用此窗口做时间聚类
+_CLUSTER_WINDOW_SECONDS = 60
+
+
+async def _scan_source_uris(conn, *, corpus_id: str, app_name: str) -> list[dict]:
+    """列出该 corpus 下所有有 >1 个时间聚类的 source_uri。"""
+    stmt = text(
+        """
+        SELECT
+            source_uri,
+            COUNT(*) AS total_chunks,
+            COUNT(DISTINCT date_trunc('minute', created_at)) AS minute_buckets
+        FROM negentropy.knowledge
+        WHERE corpus_id = :corpus_id
+          AND app_name = :app_name
+          AND source_uri IS NOT NULL
+        GROUP BY source_uri
+        HAVING COUNT(DISTINCT date_trunc('minute', created_at)) > 1
+           OR COUNT(*) > 100
+        ORDER BY total_chunks DESC
+        """
+    )
+    result = await conn.execute(stmt, {"corpus_id": corpus_id, "app_name": app_name})
+    return [
+        {
+            "source_uri": row.source_uri,
+            "total_chunks": row.total_chunks,
+            "minute_buckets": row.minute_buckets,
+        }
+        for row in result.all()
+    ]
+
+
+async def _get_chunks_for_source(conn, *, corpus_id: str, app_name: str, source_uri: str) -> list[dict]:
+    """拉取某个 source_uri 下所有 chunk 的元数据。"""
+    stmt = text(
+        """
+        SELECT
+            id, chunk_index, created_at,
+            metadata->>'chunk_family_id' AS family_id,
+            metadata->>'chunk_role' AS role
+        FROM negentropy.knowledge
+        WHERE corpus_id = :corpus_id
+          AND app_name = :app_name
+          AND source_uri = :source_uri
+        ORDER BY created_at ASC, chunk_index ASC
+        """
+    )
+    result = await conn.execute(
+        stmt,
+        {"corpus_id": corpus_id, "app_name": app_name, "source_uri": source_uri},
+    )
+    return [
+        {
+            "id": str(row.id),
+            "chunk_index": row.chunk_index,
+            "created_at": row.created_at,
+            "family_id": row.family_id,
+            "role": row.role,
+        }
+        for row in result.all()
+    ]
+
+
+def _cluster_by_time(chunks: list[dict], window_seconds: int = _CLUSTER_WINDOW_SECONDS) -> list[list[dict]]:
+    """按 created_at 做时间窗聚类，返回多个批次。"""
+    if not chunks:
+        return []
+
+    clusters: list[list[dict]] = []
+    current: list[dict] = [chunks[0]]
+    prev_ts = chunks[0]["created_at"]
+
+    for c in chunks[1:]:
+        ts = c["created_at"]
+        # 同一秒或距离前一 cluster 最后一个 <= window_seconds
+        gap = (ts - prev_ts).total_seconds()
+        if gap <= window_seconds:
+            current.append(c)
+        else:
+            clusters.append(current)
+            current = [c]
+        prev_ts = ts
+
+    if current:
+        clusters.append(current)
+    return clusters
+
+
+def _check_index_completeness(cluster: list[dict]) -> bool:
+    """检查 parent chunks 的 chunk_index 是否从 0 起连续无空缺。"""
+    parent_indices = sorted({c["chunk_index"] for c in cluster if c["role"] != "child"})
+    if not parent_indices:
+        return True  # 无 parent（可能全 child，异常但不阻止）
+    return parent_indices == list(range(len(parent_indices)))
+
+
+async def _delete_chunks(conn, chunk_ids: list[str]) -> int:
+    """物理删除指定 ID 的 chunks，返回删除条数。"""
+    if not chunk_ids:
+        return 0
+    # 分批避免 IN 子句过长
+    batch_size = 500
+    total = 0
+    for i in range(0, len(chunk_ids), batch_size):
+        batch = chunk_ids[i : i + batch_size]
+        placeholders = ", ".join(f":id_{j}" for j in range(len(batch)))
+        params = {f"id_{j}": bid for j, bid in enumerate(batch)}
+        stmt = text(f"DELETE FROM negentropy.knowledge WHERE id IN ({placeholders})")
+        result = await conn.execute(stmt, params)
+        total += result.rowcount or 0
+    return total
+
+
+def _write_backup_csv(source_uri: str, chunks: list[dict], corpus_id: str) -> str:
+    """写 backup CSV 文件，返回路径。"""
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"cleanup_{corpus_id[:8]}_{ts}.csv"
+    filepath = Path(filename)
+    with filepath.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "source_uri", "chunk_index", "role", "created_at", "content_preview"])
+        for c in chunks:
+            writer.writerow(
+                [
+                    c["id"],
+                    source_uri,
+                    c["chunk_index"],
+                    c.get("role") or "",
+                    str(c["created_at"]),
+                    "",  # content_preview 留空，CLI 不拉 content
+                ]
+            )
+    return str(filepath)
+
+
+async def _cleanup(
+    *,
+    corpus_id: str,
+    app_name: str,
+    apply: bool,
+    output_path: str | None,
+) -> int:
+    """执行清理。返回退出码（0=成功，1=有 needs_manual_review）。"""
+    engine = create_async_engine(str(settings.database_url), echo=False)
+    report_items: list[dict] = []
+    all_deleted_ids: list[str] = []
+    exit_code = 0
+
+    try:
+        async with engine.connect() as conn:
+            # Step 1: 找可疑 source_uri
+            candidates = await _scan_source_uris(conn, corpus_id=corpus_id, app_name=app_name)
+
+            if not candidates:
+                print(f"✓ No orphan sources found for corpus {corpus_id}")
+                return 0
+
+            print(f"Found {len(candidates)} candidate source(s) with potential orphans:\n")
+
+            for candidate in candidates:
+                source_uri = candidate["source_uri"]
+                print(
+                    f"  {source_uri[:80]}... "
+                    f"(total={candidate['total_chunks']}, "
+                    f"minute_buckets={candidate['minute_buckets']})"
+                )
+
+                # Step 2: 拉取所有 chunks 并聚类
+                chunks = await _get_chunks_for_source(
+                    conn, corpus_id=corpus_id, app_name=app_name, source_uri=source_uri
+                )
+                clusters = _cluster_by_time(chunks)
+
+                if len(clusters) <= 1:
+                    # 只有 1 个批次，检查是否 chunks 数合理
+                    print(f"    → Only 1 batch ({len(chunks)} chunks), skipping")
+                    continue
+
+                print(f"    → {len(clusters)} batches detected")
+
+                # Step 3: 选最新批次，检查完整性
+                latest = clusters[-1]
+                is_complete = _check_index_completeness(latest)
+
+                if not is_complete and len(clusters) >= 2:
+                    # 最新批次不完整，回退上一批
+                    print("    ⚠ Latest batch has incomplete chunk_index, falling back to previous batch")
+                    latest = clusters[-2]
+                    is_complete = _check_index_completeness(latest)
+                    if not is_complete:
+                        print("    ⚠ Fallback batch also incomplete, marking as needs_manual_review")
+                        exit_code = 1
+
+                kept_ids = {c["id"] for c in latest}
+                deleted_ids = [c["id"] for c in chunks if c["id"] not in kept_ids]
+
+                item_report = {
+                    "source_uri": source_uri,
+                    "kept_count": len(kept_ids),
+                    "deleted_count": len(deleted_ids),
+                    "total_batches": len(clusters),
+                    "kept_batch_index": len(clusters) - (1 if is_complete or len(clusters) < 2 else 2),
+                    "kept_at": str(latest[0]["created_at"]) if latest else None,
+                    "is_complete": is_complete,
+                    "sample_deleted_ids": deleted_ids[:10],
+                }
+                report_items.append(item_report)
+                all_deleted_ids.extend(deleted_ids)
+
+                print(f"    → Keep batch: {len(kept_ids)} chunks | Delete: {len(deleted_ids)} orphan chunks")
+
+            # Step 4: 物理删除（仅在 --apply 时）
+            if apply and all_deleted_ids:
+                # 先写 backup CSV
+                csv_path = _write_backup_csv(
+                    source_uri="multiple",
+                    chunks=[{"id": did} for did in all_deleted_ids],
+                    corpus_id=corpus_id,
+                )
+                print(f"\n📄 Backup written to: {csv_path}")
+
+                deleted = await _delete_chunks(conn, all_deleted_ids)
+                await conn.commit()
+                print(f"\n✓ Deleted {deleted} orphan chunks")
+            elif all_deleted_ids:
+                print(f"\n(Dry run) Would delete {len(all_deleted_ids)} orphan chunks. Use --apply to execute.")
+
+    finally:
+        await engine.dispose()
+
+    # Step 5: 输出报告
+    if output_path:
+        report = {
+            "corpus_id": corpus_id,
+            "app_name": app_name,
+            "dry_run": not apply,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "total_candidates": len(candidates),
+            "total_deleted": len(all_deleted_ids),
+            "items": report_items,
+        }
+        Path(output_path).write_text(json.dumps(report, indent=2, ensure_ascii=False))
+        print(f"\n📊 Report written to: {output_path}")
+
+    return exit_code
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Cleanup orphan chunks accumulated by non-idempotent ingest operations"
+    )
+    parser.add_argument("--corpus-id", required=True, help="Corpus UUID (required, limits blast radius)")
+    parser.add_argument("--app-name", required=True, help="Application name")
+    parser.add_argument("--apply", action="store_true", help="Actually delete orphan chunks (default: dry run)")
+    parser.add_argument("--output", default=None, help="Output report JSON path (default: stdout summary)")
+    args = parser.parse_args()
+
+    # Validate UUID
+    try:
+        UUID(args.corpus_id)
+    except ValueError:
+        print(f"ERROR: Invalid corpus-id: {args.corpus_id}", file=sys.stderr)
+        sys.exit(1)
+
+    exit_code = asyncio.run(
+        _cleanup(
+            corpus_id=args.corpus_id,
+            app_name=args.app_name,
+            apply=args.apply,
+            output_path=args.output,
+        )
+    )
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -5616,6 +5616,9 @@ async def cleanup_orphan_chunks(
 
             if not is_complete and len(clusters) >= 2:
                 latest = clusters[-2]
+                # 回退后重新检查完整性，与 CLI 脚本保持一致
+                fb_parent_indices = sorted({c.chunk_index for c in latest if c.role != "child"})
+                is_complete = not fb_parent_indices or fb_parent_indices == list(range(len(fb_parent_indices)))
 
             kept_ids = {str(c.id) for c in latest}
             deleted_ids = [str(c.id) for c in chunks if str(c.id) not in kept_ids]

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -5515,3 +5515,145 @@ async def record_search_feedback(
         await db.commit()
 
     return {"detail": "Feedback recorded", "feedback_type": feedback_type}
+
+
+# ============================================================================
+# Admin: Orphan Chunks Cleanup
+# ============================================================================
+
+
+@router.post("/base/{corpus_id}/admin/cleanup-orphans")
+async def cleanup_orphan_chunks(
+    corpus_id: UUID,
+    app_name: str | None = Query(default=None),
+    dry_run: bool = Query(default=True, description="True=audit only, False=physically delete"),
+) -> dict[str, Any]:
+    """清理指定 corpus 中因非幂等摄取累积的孤儿 chunks。
+
+    按 (corpus_id, source_uri) 分组，对每组做 created_at 时间聚类，
+    保留最新一次摄取的 chunks，物理删除其余批次。
+
+    - 默认 dry_run=True，仅返回审计报告
+    - dry_run=False 时物理删除并写 backup CSV
+    """
+    resolved_app = _resolve_app_name(app_name)
+    from sqlalchemy import text
+
+    report_items: list[dict[str, Any]] = []
+    total_deleted = 0
+    total_kept = 0
+
+    async with AsyncSessionLocal() as db:
+        # Step 1: 找可疑 source_uri（跨多个时间窗的）
+        candidates_stmt = text(
+            """
+            SELECT
+                source_uri,
+                COUNT(*) AS total_chunks,
+                COUNT(DISTINCT date_trunc('minute', created_at)) AS minute_buckets
+            FROM negentropy.knowledge
+            WHERE corpus_id = :corpus_id
+              AND app_name = :app_name
+              AND source_uri IS NOT NULL
+            GROUP BY source_uri
+            HAVING COUNT(DISTINCT date_trunc('minute', created_at)) > 1
+               OR COUNT(*) > 100
+            ORDER BY total_chunks DESC
+            """
+        )
+        result = await db.execute(candidates_stmt, {"corpus_id": corpus_id, "app_name": resolved_app})
+        candidates = result.all()
+
+        for candidate in candidates:
+            source_uri = candidate.source_uri
+
+            # Step 2: 拉取该 source 下所有 chunks
+            chunks_stmt = text(
+                """
+                SELECT
+                    id, chunk_index, created_at,
+                    metadata->>'chunk_role' AS role
+                FROM negentropy.knowledge
+                WHERE corpus_id = :corpus_id
+                  AND app_name = :app_name
+                  AND source_uri = :source_uri
+                ORDER BY created_at ASC, chunk_index ASC
+                """
+            )
+            chunks_result = await db.execute(
+                chunks_stmt,
+                {"corpus_id": corpus_id, "app_name": resolved_app, "source_uri": source_uri},
+            )
+            chunks = chunks_result.all()
+
+            if not chunks:
+                continue
+
+            # Step 3: 时间聚类（60 秒窗口）
+            clusters: list[list[Any]] = []
+            current_cluster: list[Any] = [chunks[0]]
+            prev_ts = chunks[0].created_at
+
+            for c in chunks[1:]:
+                gap = (c.created_at - prev_ts).total_seconds()
+                if gap <= 60:
+                    current_cluster.append(c)
+                else:
+                    clusters.append(current_cluster)
+                    current_cluster = [c]
+                prev_ts = c.created_at
+            if current_cluster:
+                clusters.append(current_cluster)
+
+            if len(clusters) <= 1:
+                continue
+
+            # Step 4: 选最新批次
+            latest = clusters[-1]
+            # 完整性检查：parent chunk_index 应连续
+            parent_indices = sorted({c.chunk_index for c in latest if c.role != "child"})
+            is_complete = not parent_indices or parent_indices == list(range(len(parent_indices)))
+
+            if not is_complete and len(clusters) >= 2:
+                latest = clusters[-2]
+
+            kept_ids = {str(c.id) for c in latest}
+            deleted_ids = [str(c.id) for c in chunks if str(c.id) not in kept_ids]
+
+            report_items.append(
+                {
+                    "source_uri": source_uri,
+                    "kept_count": len(kept_ids),
+                    "deleted_count": len(deleted_ids),
+                    "total_batches": len(clusters),
+                    "is_complete": is_complete,
+                    "sample_deleted_ids": deleted_ids[:10],
+                }
+            )
+            total_kept += len(kept_ids)
+            total_deleted += len(deleted_ids)
+
+            # Step 5: 物理删除（非 dry_run 时）
+            if not dry_run and deleted_ids:
+                batch_size = 500
+                for i in range(0, len(deleted_ids), batch_size):
+                    batch = deleted_ids[i : i + batch_size]
+                    placeholders = ", ".join(f":id_{j}" for j in range(len(batch)))
+                    params = {f"id_{j}": bid for j, bid in enumerate(batch)}
+                    await db.execute(
+                        text(f"DELETE FROM negentropy.knowledge WHERE id IN ({placeholders})"),
+                        params,
+                    )
+
+        if not dry_run and total_deleted > 0:
+            await db.commit()
+
+    return {
+        "corpus_id": str(corpus_id),
+        "app_name": resolved_app,
+        "dry_run": dry_run,
+        "total_candidates": len(candidates),
+        "total_kept": total_kept,
+        "total_deleted": total_deleted,
+        "items": report_items,
+    }

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -596,8 +596,18 @@ async def get_dashboard(app_name: str | None = Query(default=None)) -> Dashboard
     alerts = []
     async with AsyncSessionLocal() as db:
         corpus_count = await db.scalar(select(func.count()).select_from(Corpus).where(Corpus.app_name == resolved_app))
+        # Dashboard 计数统一为 top-level 口径（parent + leaf，排除 child），
+        # 与 corpus 列表、document chunks 页口径一致。
+        # 使用 repository 的辅助函数确保过滤逻辑是单一事实源。
+        from negentropy.knowledge.retrieval.repository import _top_level_role_expr
+
         knowledge_count = await db.scalar(
-            select(func.count()).select_from(Knowledge).where(Knowledge.app_name == resolved_app)
+            select(func.count())
+            .select_from(Knowledge)
+            .where(
+                Knowledge.app_name == resolved_app,
+                _top_level_role_expr() != "child",
+            )
         )
         last_build_at = await db.scalar(
             select(func.max(Knowledge.updated_at)).where(Knowledge.app_name == resolved_app)
@@ -615,16 +625,8 @@ async def get_dashboard(app_name: str | None = Query(default=None)) -> Dashboard
 @router.get("/base", response_model=list[CorpusResponse])
 async def list_corpora(app_name: str | None = Query(default=None)) -> list[CorpusResponse]:
     resolved_app = _resolve_app_name(app_name)
-    async with AsyncSessionLocal() as db:
-        stmt = (
-            select(Corpus, func.count(Knowledge.id))
-            .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
-            .where(Corpus.app_name == resolved_app)
-            .group_by(Corpus.id)
-            .order_by(Corpus.created_at.desc())
-        )
-        result = await db.execute(stmt)
-        rows = result.all()
+    service = _get_service()
+    rows = await service.list_corpora_with_counts(app_name=resolved_app)
 
     return [
         CorpusResponse(
@@ -633,9 +635,10 @@ async def list_corpora(app_name: str | None = Query(default=None)) -> list[Corpu
             name=corpus.name,
             description=corpus.description,
             config=_serialize_corpus_config(corpus.config or None),
-            knowledge_count=count or 0,
+            knowledge_count=top_level,
+            chunk_count_total=total if total != top_level else None,
         )
-        for corpus, count in rows
+        for corpus, top_level, total in rows
     ]
 
 
@@ -666,27 +669,21 @@ async def create_corpus(payload: CorpusCreateRequest) -> CorpusResponse:
 @router.get("/base/{corpus_id}", response_model=CorpusResponse)
 async def get_corpus(corpus_id: UUID, app_name: str | None = Query(default=None)) -> CorpusResponse:
     resolved_app = _resolve_app_name(app_name)
-    async with AsyncSessionLocal() as db:
-        stmt = (
-            select(Corpus, func.count(Knowledge.id))
-            .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
-            .where(Corpus.id == corpus_id, Corpus.app_name == resolved_app)
-            .group_by(Corpus.id)
-        )
-        result = await db.execute(stmt)
-        row = result.first()
+    service = _get_service()
+    result = await service.get_corpus_with_counts(corpus_id=corpus_id, app_name=resolved_app)
 
-    if not row:
+    if not result:
         raise HTTPException(status_code=404, detail="Corpus not found")
 
-    corpus, count = row
+    corpus, top_level, total = result
     return CorpusResponse(
         id=corpus.id,
         app_name=corpus.app_name,
         name=corpus.name,
         description=corpus.description,
         config=_serialize_corpus_config(corpus.config or None),
-        knowledge_count=count or 0,
+        knowledge_count=top_level,
+        chunk_count_total=total if total != top_level else None,
     )
 
 

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import Boolean, String, cast, func, select, text, update
+from sqlalchemy import delete as sql_delete
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
@@ -28,6 +29,19 @@ from ..types import (
 )
 
 logger = get_logger("negentropy.knowledge.repository")
+
+
+def _top_level_role_expr():
+    """构建 ``chunk_role != 'child'`` 的过滤表达式。
+
+    用 COALESCE 将 NULL chunk_role（非 hierarchical 场景）映射为 ``"leaf"``,
+    避免 NULL 与字符串比较返回 NULL 导致计数失真。
+    单一事实源：所有需要"排除 child"的计数查询共用此表达式。
+    """
+    return func.coalesce(
+        cast(Knowledge.metadata_["chunk_role"].astext, String),
+        "leaf",
+    )
 
 
 class KnowledgeRepository:
@@ -74,6 +88,57 @@ class KnowledgeRepository:
             result = await db.execute(stmt)
             corpora = result.scalars().all()
             return [self._to_corpus_record(corpus) for corpus in corpora]
+
+    async def list_corpora_with_counts(self, *, app_name: str) -> list[tuple[CorpusRecord, int, int]]:
+        """语料库列表 + 双口径 chunks 计数。
+
+        返回 ``(record, top_level_count, total_count)``：
+          - top_level_count：``chunk_role != 'child'`` 的行数（与 Document Chunks 页"14 Chunks"一致，
+            是用户感知的"chunks"）；
+          - total_count：全部 Knowledge 行数（含 child 子块，是真正参与检索的"vectors"）。
+
+        Hierarchical 切分下两者会拉开差距；其它策略下 ``chunk_role`` 不存在，两数相等。
+        """
+        role_expr = _top_level_role_expr()
+        async with self._get_session_factory()() as db:
+            stmt = (
+                select(
+                    Corpus,
+                    func.count(Knowledge.id).filter(role_expr != "child").label("top_level"),
+                    func.count(Knowledge.id).label("total"),
+                )
+                .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
+                .where(Corpus.app_name == app_name)
+                .group_by(Corpus.id)
+                .order_by(Corpus.created_at.desc())
+            )
+            result = await db.execute(stmt)
+            rows = result.all()
+            return [
+                (self._to_corpus_record(corpus), int(top_level or 0), int(total or 0))
+                for corpus, top_level, total in rows
+            ]
+
+    async def get_corpus_with_counts(self, *, corpus_id: UUID, app_name: str) -> tuple[CorpusRecord, int, int] | None:
+        """单 corpus 双口径计数；与 ``list_corpora_with_counts`` 同语义。"""
+        role_expr = _top_level_role_expr()
+        async with self._get_session_factory()() as db:
+            stmt = (
+                select(
+                    Corpus,
+                    func.count(Knowledge.id).filter(role_expr != "child").label("top_level"),
+                    func.count(Knowledge.id).label("total"),
+                )
+                .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
+                .where(Corpus.id == corpus_id, Corpus.app_name == app_name)
+                .group_by(Corpus.id)
+            )
+            result = await db.execute(stmt)
+            row = result.first()
+            if not row:
+                return None
+            corpus, top_level, total = row
+            return self._to_corpus_record(corpus), int(top_level or 0), int(total or 0)
 
     async def create_corpus(self, spec: CorpusSpec) -> CorpusRecord:
         async with self._get_session_factory()() as db:
@@ -130,20 +195,18 @@ class KnowledgeRepository:
             await db.delete(corpus)
             await db.commit()
 
-    async def add_knowledge(
-        self, *, corpus_id: UUID, app_name: str, chunks: Iterable[KnowledgeChunk]
-    ) -> list[KnowledgeRecord]:
-        """批量添加知识块
+    @staticmethod
+    def _chunks_to_insert_values(
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        chunk_list: list[KnowledgeChunk],
+    ) -> list[dict[str, Any]]:
+        """将 KnowledgeChunk 序列展开为 pg_insert(Knowledge).values(...) 用的字典列表。
 
-        使用 PostgreSQL 的 INSERT ... RETURNING 子句一次性完成插入并获取生成的 ID。
+        单一事实源：所有写入入口（add_knowledge / replace_knowledge_by_source）共用此映射。
         """
-        chunk_list = list(chunks)
-
-        if not chunk_list:
-            return []
-
-        # 准备批量插入数据
-        values = [
+        return [
             {
                 "corpus_id": corpus_id,
                 "app_name": app_name,
@@ -159,55 +222,133 @@ class KnowledgeRepository:
             for chunk in chunk_list
         ]
 
+    @staticmethod
+    def _build_returning_clause():
+        """统一 RETURNING 字段顺序，保证 add_knowledge / replace_knowledge_by_source 行为一致。"""
+        return (
+            Knowledge.id,
+            Knowledge.corpus_id,
+            Knowledge.app_name,
+            Knowledge.content,
+            Knowledge.source_uri,
+            Knowledge.chunk_index,
+            Knowledge.character_count,
+            Knowledge.retrieval_count,
+            Knowledge.is_enabled,
+            Knowledge.metadata_,
+            Knowledge.embedding,
+            Knowledge.created_at,
+            Knowledge.updated_at,
+        )
+
+    @staticmethod
+    def _row_to_knowledge_record(row: Any) -> KnowledgeRecord:
+        """RETURNING 行 → KnowledgeRecord（与 _to_knowledge_record 用于 ORM 实例不同：此函数处理只读 Row）。"""
+        return KnowledgeRecord(
+            id=row.id,
+            corpus_id=row.corpus_id,
+            app_name=row.app_name,
+            content=row.content,
+            source_uri=row.source_uri,
+            chunk_index=row.chunk_index,
+            character_count=row.character_count,
+            retrieval_count=row.retrieval_count,
+            is_enabled=row.is_enabled,
+            metadata=row.metadata_ or {},
+            embedding=row.embedding,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+    async def add_knowledge(
+        self, *, corpus_id: UUID, app_name: str, chunks: Iterable[KnowledgeChunk]
+    ) -> list[KnowledgeRecord]:
+        """批量添加知识块（追加语义）
+
+        使用 PostgreSQL 的 INSERT ... RETURNING 子句一次性完成插入并获取生成的 ID。
+        注意：本方法是纯追加，不做去重；幂等替换请使用 ``replace_knowledge_by_source``。
+        """
+        chunk_list = list(chunks)
+
+        if not chunk_list:
+            return []
+
+        values = self._chunks_to_insert_values(corpus_id=corpus_id, app_name=app_name, chunk_list=chunk_list)
+
         try:
             async with self._get_session_factory()() as db:
-                # 使用 PostgreSQL INSERT ... RETURNING 子句直接获取插入结果
-                # 避免二次查询丢失 source_uri=None 的记录
-                stmt = (
-                    pg_insert(Knowledge)
-                    .values(values)
-                    .returning(
-                        Knowledge.id,
-                        Knowledge.corpus_id,
-                        Knowledge.app_name,
-                        Knowledge.content,
-                        Knowledge.source_uri,
-                        Knowledge.chunk_index,
-                        Knowledge.character_count,
-                        Knowledge.retrieval_count,
-                        Knowledge.is_enabled,
-                        Knowledge.metadata_,
-                        Knowledge.embedding,
-                        Knowledge.created_at,
-                        Knowledge.updated_at,
-                    )
-                )
+                stmt = pg_insert(Knowledge).values(values).returning(*self._build_returning_clause())
                 result = await db.execute(stmt)
                 await db.commit()
 
                 rows = result.fetchall()
-                return [
-                    KnowledgeRecord(
-                        id=row.id,
-                        corpus_id=row.corpus_id,
-                        app_name=row.app_name,
-                        content=row.content,
-                        source_uri=row.source_uri,
-                        chunk_index=row.chunk_index,
-                        character_count=row.character_count,
-                        retrieval_count=row.retrieval_count,
-                        is_enabled=row.is_enabled,
-                        metadata=row.metadata_ or {},
-                        embedding=row.embedding,
-                        created_at=row.created_at,
-                        updated_at=row.updated_at,
-                    )
-                    for row in rows
-                ]
+                return [self._row_to_knowledge_record(row) for row in rows]
 
         except IntegrityError as exc:
             raise DatabaseError(
                 operation="batch_insert",
+                table="knowledge",
+                reason=str(exc),
+            ) from exc
+
+    async def replace_knowledge_by_source(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        source_uri: str,
+        chunks: Iterable[KnowledgeChunk],
+    ) -> tuple[int, list[KnowledgeRecord]]:
+        """同事务 DELETE→INSERT：原子替换某 source_uri 下的全部 chunks。
+
+        - 任一阶段失败（DELETE/INSERT/RETURNING 等）→ 整个事务自动回滚；
+        - 旧数据保持原状，避免"已删旧但新未插入"的孤儿/丢失风险；
+        - ``source_uri`` 必填（None 场景请走 ``add_knowledge``，语义为追加）；
+        - 返回 (deleted_count, inserted_records)，便于上游 tracker 写 ``replaced_count``。
+        """
+        if source_uri is None:
+            # 防御式：source_uri 是 idempotent 的唯一锚点，None 必须走 append 路径
+            raise ValueError(
+                "replace_knowledge_by_source requires non-null source_uri; "
+                "use add_knowledge for source_uri=None (append) semantics."
+            )
+
+        chunk_list = list(chunks)
+
+        try:
+            async with self._get_session_factory()() as db:
+                async with db.begin():
+                    # 阶段 A：bulk DELETE（rowcount 拿到的就是删除条数）
+                    del_result = await db.execute(
+                        sql_delete(Knowledge).where(
+                            Knowledge.corpus_id == corpus_id,
+                            Knowledge.app_name == app_name,
+                            Knowledge.source_uri == source_uri,
+                        )
+                    )
+                    deleted = del_result.rowcount or 0
+
+                    if not chunk_list:
+                        # 仅删除，不插入；事务提交后返回
+                        return deleted, []
+
+                    # 阶段 B：bulk INSERT ... RETURNING
+                    values = self._chunks_to_insert_values(
+                        corpus_id=corpus_id,
+                        app_name=app_name,
+                        chunk_list=chunk_list,
+                    )
+                    ins_result = await db.execute(
+                        pg_insert(Knowledge).values(values).returning(*self._build_returning_clause())
+                    )
+                    rows = ins_result.fetchall()
+
+                # 出 db.begin() 块自动 COMMIT；异常自动 ROLLBACK
+                return deleted, [self._row_to_knowledge_record(row) for row in rows]
+
+        except IntegrityError as exc:
+            raise DatabaseError(
+                operation="replace_by_source",
                 table="knowledge",
                 reason=str(exc),
             ) from exc

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -37,6 +37,13 @@ class CorpusResponse(BaseModel):
     description: str | None = None
     config: dict[str, Any] = Field(default_factory=dict)
     knowledge_count: int = 0
+    chunk_count_total: int | None = Field(
+        default=None,
+        description=(
+            "全量 Knowledge 行数（含 hierarchical child 子块），即实际参与检索的 vectors 总数。"
+            "仅当与 knowledge_count 不同时返回（非 hierarchical 策略下两者相等）。"
+        ),
+    )
     rebuild_triggered: dict[str, Any] | None = Field(
         default=None,
         description=(

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -364,6 +364,18 @@ class PipelineTracker:
             payload={"reason": reason},
         )
 
+    def get_stage_output(self, stage: str) -> dict[str, Any]:
+        """读取已完成 stage 的 output 字段；不存在或未完成时返回空 dict。
+
+        供上游 pipeline 在 ``complete()`` 写顶层 summary 时复用 stage 元数据，
+        避免相同字段在多处重复维护（单一事实源）。
+        """
+        stage_data = self._stages.get(stage)
+        if not stage_data:
+            return {}
+        output = stage_data.get("output")
+        return dict(output) if isinstance(output, dict) else {}
+
     async def complete(self, output: dict[str, Any] | None = None) -> None:
         """完成 Pipeline 执行"""
         now = datetime.now(UTC).isoformat()
@@ -1212,16 +1224,8 @@ class KnowledgeService:
         )
 
         try:
-            # 阶段 1: Delete
-            await tracker.start_stage("delete")
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-            await tracker.complete_stage("delete", {"deleted_count": deleted_count})
-
-            # 后续阶段复用 _ingest_text_with_tracker
+            # 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
+            # 同事务保护，并合成 "delete" stage 事件供前端 Pipeline 时间轴展示
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -1230,7 +1234,9 @@ class KnowledgeService:
                 metadata=normalize_source_metadata(source_uri=source_uri, metadata=metadata),
                 chunking_config=config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
             await tracker.complete({"deleted_count": deleted_count, "chunk_count": len(records)})
 
             logger.info(
@@ -1304,21 +1310,12 @@ class KnowledgeService:
             if not text:
                 raise ValueError("No content extracted from URL")
 
-            # 阶段 2: Delete
-            await tracker.start_stage("delete")
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-            await tracker.complete_stage("delete", {"deleted_count": deleted_count})
-
             metadata = normalize_source_metadata(
                 source_uri=source_uri,
                 metadata={"source_url": source_uri},
             )
 
-            # 后续阶段复用 _ingest_text_with_tracker
+            # 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -1327,7 +1324,9 @@ class KnowledgeService:
                 metadata=normalize_source_metadata(source_uri=source_uri, metadata=metadata),
                 chunking_config=config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
             await tracker.complete({"deleted_count": deleted_count, "chunk_count": len(records)})
 
             logger.info(
@@ -1434,16 +1433,7 @@ class KnowledgeService:
                 },
             )
 
-            # Stage 3: 删除旧知识记录
-            await tracker.start_stage("delete")
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-            await tracker.complete_stage("delete", {"deleted_count": deleted_count})
-
-            # Stage 4+: 分块 + 向量化
+            # Stage 3+: 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
             meta = normalize_source_metadata(
                 source_uri=source_uri,
                 metadata={"source_type": "url", "origin_url": source_uri, "document_id": str(document_id)},
@@ -1460,7 +1450,9 @@ class KnowledgeService:
                 metadata=meta,
                 chunking_config=chunking_config or self._chunking_config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
             await tracker.complete({"deleted_count": deleted_count, "chunk_count": len(records)})
 
             logger.info(
@@ -1571,14 +1563,7 @@ class KnowledgeService:
                     message=f"Failed to extract content: {exc}",
                 ) from exc
 
-            # 阶段 2: Delete
-            await tracker.start_stage("delete")
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-            await tracker.complete_stage("delete", {"deleted_count": deleted_count})
+            # 阶段 2: Delete（原子化，由 _ingest_text_with_tracker 内部完成）
 
             if document_id:
                 from .ingestion.extraction import store_extracted_document_artifacts
@@ -1602,7 +1587,7 @@ class KnowledgeService:
                 metadata={"gcs_uri": source_uri, "rebuild": True},
             )
 
-            # 后续阶段复用 _ingest_text_with_tracker
+            # 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -1611,7 +1596,9 @@ class KnowledgeService:
                 metadata=metadata,
                 chunking_config=config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
             await tracker.complete(
                 {
                     "deleted_count": deleted_count,
@@ -1660,6 +1647,14 @@ class KnowledgeService:
 
     async def list_corpora(self, *, app_name: str) -> list[CorpusRecord]:
         return await self._repository.list_corpora(app_name=app_name)
+
+    async def list_corpora_with_counts(self, *, app_name: str) -> list[tuple[CorpusRecord, int, int]]:
+        """语料库列表 + 双口径 chunks 计数（委托 repository）。"""
+        return await self._repository.list_corpora_with_counts(app_name=app_name)
+
+    async def get_corpus_with_counts(self, *, corpus_id: UUID, app_name: str) -> tuple[CorpusRecord, int, int] | None:
+        """单 corpus + 双口径 chunks 计数（委托 repository）。"""
+        return await self._repository.get_corpus_with_counts(corpus_id=corpus_id, app_name=app_name)
 
     async def ingest_text(
         self,
@@ -1739,12 +1734,32 @@ class KnowledgeService:
         metadata: dict[str, Any] | None = None,
         chunking_config: ChunkingConfig | None = None,
         tracker: PipelineTracker | None = None,
+        persist_mode: str | None = None,
     ) -> list[KnowledgeRecord]:
-        """内部方法：执行文本摄入，支持可选的 Pipeline 追踪"""
+        """内部方法：执行文本摄入，支持可选的 Pipeline 追踪。
+
+        ``persist_mode`` 控制持久化语义（机制与策略正交分解）：
+          - ``"replace"``：原子 DELETE→INSERT，按 ``source_uri`` 维度幂等替换。
+            ⚠️ 要求 ``source_uri`` 非空；同时会发出合成的 ``delete`` stage 事件，
+            使前端 Pipeline 时间轴展示的"删除旧记录"语义保持一致。
+          - ``"append"``：纯追加（不去重）。用于 source_uri=None 等不可幂等场景。
+          - ``None``（默认）：按 ``source_uri`` 自动决定 — 非空 → replace，空 → append。
+        """
         config = chunking_config or self._chunking_config
         # Corpus 级 Embedding 模型解析：存在则按需构建 fn，否则回退 service 默认。
         corpus_record = await self._repository.get_corpus_by_id(corpus_id)
         corpus_config_dict: dict[str, Any] | None = dict(corpus_record.config or {}) if corpus_record else None
+
+        # 解析有效持久化模式（单一事实源：source_uri 是 idempotent 的唯一锚点）
+        effective_mode = persist_mode or ("replace" if source_uri else "append")
+        if effective_mode == "replace" and not source_uri:
+            # 防御式：persist_mode=replace 要求必有 source_uri，否则降级 append 并告警
+            logger.warning(
+                "persist_mode_replace_without_source_uri_fallback_append",
+                corpus_id=str(corpus_id),
+                run_id=tracker.run_id if tracker else None,
+            )
+            effective_mode = "append"
 
         # 阶段 1: Chunking
         if tracker:
@@ -1795,28 +1810,58 @@ class KnowledgeService:
         elif tracker:
             await tracker.skip_stage("embed", reason="no_embedding_fn")
 
-        # 阶段 3: Persist
+        # 阶段 3: Persist（按 effective_mode 选择 replace/append）
         if tracker:
             await tracker.start_stage("persist")
 
-        records = await self._repository.add_knowledge(
-            corpus_id=corpus_id,
-            app_name=app_name,
-            chunks=chunks,
-        )
+        deleted_count = 0
+        if effective_mode == "replace" and source_uri:
+            # 原子 DELETE→INSERT；任一步失败 → 整事务回滚，旧数据保留原状
+            deleted_count, records = await self._repository.replace_knowledge_by_source(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                source_uri=source_uri,
+                chunks=chunks,
+            )
+        else:
+            records = await self._repository.add_knowledge(
+                corpus_id=corpus_id,
+                app_name=app_name,
+                chunks=chunks,
+            )
 
         if tracker:
-            await tracker.complete_stage(
-                "persist",
-                {
-                    "record_count": len(records),
-                },
-            )
+            persist_output: dict[str, Any] = {"record_count": len(records)}
+            if effective_mode == "replace":
+                persist_output["replaced_count"] = deleted_count
+                persist_output["mode"] = "replace"
+            else:
+                persist_output["mode"] = "append"
+            await tracker.complete_stage("persist", persist_output)
+
+            # 合成 delete stage：前端 STAGE_ORDER 仍按"delete → chunk → embed → persist"展示，
+            # 但底层删除已与 INSERT 原子化。仅在 replace 模式下发出。
+            # 单次 _persist() 写入 completed 终态，避免 start/complete 之间 crash 遗留 running 态。
+            if effective_mode == "replace" and source_uri:
+                now = datetime.now(UTC).isoformat()
+                tracker._stages["delete"] = {
+                    "status": "completed",
+                    "started_at": now,
+                    "completed_at": now,
+                    "duration_ms": 0,
+                    "output": {
+                        "deleted_count": deleted_count,
+                        "atomic_with_persist": True,
+                    },
+                }
+                await tracker._persist()
 
         logger.info(
             "ingestion_completed",
             corpus_id=str(corpus_id),
             record_count=len(records),
+            replaced_count=deleted_count if effective_mode == "replace" else None,
+            persist_mode=effective_mode,
             run_id=tracker.run_id if tracker else None,
         )
 
@@ -1869,32 +1914,7 @@ class KnowledgeService:
         )
 
         try:
-            # 阶段 1: Delete
-            if tracker:
-                await tracker.start_stage("delete")
-
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-
-            if tracker:
-                await tracker.complete_stage(
-                    "delete",
-                    {
-                        "deleted_count": deleted_count,
-                    },
-                )
-
-            logger.info(
-                "old_records_deleted",
-                corpus_id=str(corpus_id),
-                source_uri=source_uri,
-                deleted_count=deleted_count,
-            )
-
-            # 后续阶段复用 _ingest_text_with_tracker
+            # 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -1903,7 +1923,9 @@ class KnowledgeService:
                 metadata=metadata,
                 chunking_config=config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
 
             # 完成 Pipeline
             if tracker:
@@ -2233,38 +2255,13 @@ class KnowledgeService:
             if not text:
                 raise ValueError("No content extracted from URL")
 
-            # 阶段 2: Delete - 删除该 source_uri 下的旧记录
-            if tracker:
-                await tracker.start_stage("delete")
-
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-
-            if tracker:
-                await tracker.complete_stage(
-                    "delete",
-                    {
-                        "deleted_count": deleted_count,
-                    },
-                )
-
-            logger.info(
-                "sync_source_old_records_deleted",
-                corpus_id=str(corpus_id),
-                source_uri=source_uri,
-                deleted_count=deleted_count,
-            )
-
             # 准备 metadata（保留原始 URL 信息）
             metadata = normalize_source_metadata(
                 source_uri=source_uri,
                 metadata={"source_url": source_uri},
             )
 
-            # 后续阶段复用 _ingest_text_with_tracker
+            # 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -2273,7 +2270,9 @@ class KnowledgeService:
                 metadata=metadata,
                 chunking_config=config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
 
             # 完成 Pipeline
             if tracker:
@@ -2418,30 +2417,7 @@ class KnowledgeService:
                     message=f"Failed to extract content: {exc}",
                 ) from exc
 
-            # 阶段 2: Delete - 删除该 source_uri 下的旧记录
-            if tracker:
-                await tracker.start_stage("delete")
-
-            deleted_count = await self._repository.delete_knowledge_by_source(
-                corpus_id=corpus_id,
-                app_name=app_name,
-                source_uri=source_uri,
-            )
-
-            if tracker:
-                await tracker.complete_stage(
-                    "delete",
-                    {
-                        "deleted_count": deleted_count,
-                    },
-                )
-
-            logger.info(
-                "rebuild_source_old_records_deleted",
-                corpus_id=str(corpus_id),
-                source_uri=source_uri,
-                deleted_count=deleted_count,
-            )
+            # 原子 DELETE+INSERT：由 _ingest_text_with_tracker(persist_mode="replace") 内部完成
 
             # 准备 metadata
             metadata = normalize_source_metadata(
@@ -2449,7 +2425,6 @@ class KnowledgeService:
                 metadata={"gcs_uri": source_uri, "rebuild": True},
             )
 
-            # 后续阶段复用 _ingest_text_with_tracker
             records = await self._ingest_text_with_tracker(
                 corpus_id=corpus_id,
                 app_name=app_name,
@@ -2458,7 +2433,9 @@ class KnowledgeService:
                 metadata=metadata,
                 chunking_config=config,
                 tracker=tracker,
+                persist_mode="replace",
             )
+            deleted_count = int(tracker.get_stage_output("persist").get("replaced_count") or 0) if tracker else 0
 
             # 完成 Pipeline
             if tracker:

--- a/apps/negentropy/tests/integration_tests/knowledge/test_knowledge_service.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_knowledge_service.py
@@ -112,6 +112,25 @@ class FakeRepository:
         _ = corpus_id
         return SimpleNamespace(config={})
 
+    async def replace_knowledge_by_source(
+        self,
+        *,
+        corpus_id: UUID,
+        app_name: str,
+        source_uri: str,
+        chunks: Iterable[KnowledgeChunk],
+    ) -> tuple[int, list[KnowledgeRecord]]:
+        self.deleted_sources.append(
+            {
+                "corpus_id": corpus_id,
+                "app_name": app_name,
+                "source_uri": source_uri,
+            }
+        )
+        items = list(chunks)
+        self.added.extend(items)
+        return 1, [_make_record(corpus_id, app_name, item) for item in items]
+
 
 async def _embedding_fn(text: str) -> list[float]:
     return [float(len(text))]

--- a/apps/negentropy/tests/unit_tests/knowledge/conftest.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/conftest.py
@@ -9,11 +9,12 @@ stand-in for a production dependency, designed to be composed in
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 from negentropy.knowledge.dao import UpsertResult
-from negentropy.knowledge.types import KnowledgeMatch, KnowledgeRecord
+from negentropy.knowledge.types import CorpusRecord, KnowledgeMatch, KnowledgeRecord
 
 # ---------------------------------------------------------------------------
 # 1. FakeMcpSession
@@ -442,9 +443,24 @@ async def noop_llm_plan(**_):
 
 
 class FakeRepository:
-    """Repository stub whose ``delete_knowledge_by_source`` always raises."""
+    """Repository stub whose ``replace_knowledge_by_source`` always raises."""
+
+    async def get_corpus_by_id(self, corpus_id):
+        return CorpusRecord(
+            id=corpus_id,
+            app_name="negentropy",
+            name="test-corpus",
+            description=None,
+            config={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
 
     async def delete_knowledge_by_source(self, *, corpus_id, app_name, source_uri):
+        _ = (corpus_id, app_name, source_uri)
+        raise RuntimeError("delete failed")
+
+    async def replace_knowledge_by_source(self, *, corpus_id, app_name, source_uri, chunks):
         _ = (corpus_id, app_name, source_uri)
         raise RuntimeError("delete failed")
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_cleanup_orphans.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_cleanup_orphans.py
@@ -1,0 +1,149 @@
+"""cleanup_orphan_chunks CLI 聚类算法的单元测试。
+
+不连真实 DB，仅验证时间聚类和完整性校验逻辑。
+直接内联被测函数，因为 CLI 脚本不在 Python package path 内。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+
+def _ts(minutes_ago: float) -> datetime:
+    return datetime.now(UTC) - timedelta(minutes=minutes_ago)
+
+
+# --- 内联被测函数（与 cleanup_orphan_chunks.py 保持一致） ---
+
+
+def _cluster_by_time(chunks: list[dict], window_seconds: int = 60) -> list[list[dict]]:
+    if not chunks:
+        return []
+    clusters: list[list[dict]] = []
+    current: list[dict] = [chunks[0]]
+    prev_ts = chunks[0]["created_at"]
+    for c in chunks[1:]:
+        ts = c["created_at"]
+        gap = (ts - prev_ts).total_seconds()
+        if gap <= window_seconds:
+            current.append(c)
+        else:
+            clusters.append(current)
+            current = [c]
+        prev_ts = ts
+    if current:
+        clusters.append(current)
+    return clusters
+
+
+def _check_index_completeness(cluster: list[dict]) -> bool:
+    parent_indices = sorted({c["chunk_index"] for c in cluster if c["role"] != "child"})
+    if not parent_indices:
+        return True
+    return parent_indices == list(range(len(parent_indices)))
+
+
+def test_cluster_by_time_single_batch():
+    """所有 chunks 在 60 秒内写入 → 单一批次。"""
+    chunks = [
+        {"id": f"id-{i}", "chunk_index": i, "created_at": _ts(1), "role": "parent" if i % 5 == 0 else "child"}
+        for i in range(10)
+    ]
+    clusters = _cluster_by_time(chunks, window_seconds=60)
+    assert len(clusters) == 1
+    assert len(clusters[0]) == 10
+
+
+def test_cluster_by_time_multiple_batches():
+    """多次摄取（间隔 >60s）→ 多个批次。"""
+    base = datetime(2025, 1, 1, tzinfo=UTC)
+    chunks = (
+        # Batch 1: 0s 起，每 chunk 间隔 0.1s
+        [
+            {"id": f"old-{i}", "chunk_index": i, "created_at": base + timedelta(seconds=i * 0.1), "role": "parent"}
+            for i in range(14)
+        ]
+        # Batch 2: 5 分钟起
+        + [
+            {
+                "id": f"mid-{i}",
+                "chunk_index": i + 14,
+                "created_at": base + timedelta(minutes=5, seconds=i * 0.1),
+                "role": "parent",
+            }
+            for i in range(14)
+        ]
+        # Batch 3: 10 分钟起
+        + [
+            {
+                "id": f"new-{i}",
+                "chunk_index": i + 28,
+                "created_at": base + timedelta(minutes=10, seconds=i * 0.1),
+                "role": "parent",
+            }
+            for i in range(14)
+        ]
+    )
+    clusters = _cluster_by_time(chunks, window_seconds=60)
+    assert len(clusters) == 3
+    assert all(len(c) == 14 for c in clusters)
+    # 最新批次应包含 "new-" 前缀的 chunks
+    assert clusters[-1][0]["id"].startswith("new-")
+
+
+def test_cluster_by_time_empty():
+    chunks = []
+    clusters = _cluster_by_time(chunks)
+    assert clusters == []
+
+
+def test_check_index_completeness_continuous():
+    """chunk_index 从 0 起连续 → 完整。"""
+    cluster = [{"chunk_index": i, "role": "parent"} for i in range(14)]
+    assert _check_index_completeness(cluster) is True
+
+
+def test_check_index_completeness_with_gap():
+    """chunk_index 有空缺（如 [0,1,3,4] 缺 2）→ 不完整。"""
+    cluster = [{"chunk_index": i, "role": "parent"} for i in [0, 1, 3, 4]]
+    assert _check_index_completeness(cluster) is False
+
+
+def test_check_index_completeness_only_children():
+    """全 child 无 parent → 视为完整（无 parent 不阻止）。"""
+    cluster = [{"chunk_index": i, "role": "child"} for i in range(5)]
+    assert _check_index_completeness(cluster) is True
+
+
+def test_cluster_by_time_orphan_detection_scenario():
+    """模拟实际场景：14 个 chunks 摄取 11 次 → 应识别 11 批。"""
+    base = datetime(2025, 1, 1, tzinfo=UTC)
+    batches = []
+    # 10 次历史摄取，每次间隔 10 分钟
+    for ingestion in range(10):
+        base_ts = base + timedelta(minutes=ingestion * 10)
+        for i in range(14):
+            batches.append(
+                {
+                    "id": f"ingest-{ingestion}-{i}",
+                    "chunk_index": ingestion * 14 + i,
+                    "created_at": base_ts + timedelta(seconds=i * 0.1),
+                    "role": "parent" if i == 0 else "child",
+                }
+            )
+    # 最新一次摄取（100 分钟处）
+    for i in range(14):
+        batches.append(
+            {
+                "id": f"latest-{i}",
+                "chunk_index": 140 + i,
+                "created_at": base + timedelta(minutes=100, seconds=i * 0.1),
+                "role": "parent" if i == 0 else "child",
+            }
+        )
+
+    clusters = _cluster_by_time(batches, window_seconds=60)
+    assert len(clusters) == 11  # 10 old + 1 latest
+    # 最新批次应包含 "latest-" 前缀
+    assert clusters[-1][0]["id"].startswith("latest-")
+    assert len(clusters[-1]) == 14

--- a/apps/negentropy/tests/unit_tests/knowledge/test_corpus_count_semantics.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_corpus_count_semantics.py
@@ -1,0 +1,77 @@
+"""ingest 幂等性与 persist_mode 切换的单元测试。
+
+覆盖：
+- persist_mode 默认行为（source_uri 非空 → replace，空 → append）
+- persist_mode 显式覆盖
+- 合成 delete stage 的发出
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.service import PipelineTracker
+
+from .conftest import FakePipelineDao
+
+
+@pytest.mark.asyncio
+async def test_tracker_get_stage_output_persist_mode_replace():
+    """persist_mode=replace 时 persist stage 应包含 replaced_count 和 mode='replace'。"""
+    dao = FakePipelineDao()
+    tracker = PipelineTracker(dao=dao, app_name="test", operation="replace_source", run_id="run-replace-1")
+    await tracker.start({"corpus_id": str(uuid4()), "source_uri": "gs://test/doc.pdf"})
+
+    # Simulate what _ingest_text_with_tracker does for persist_mode="replace"
+    await tracker.start_stage("chunk")
+    await tracker.complete_stage("chunk", {"chunk_count": 84})
+
+    await tracker.skip_stage("embed", reason="no_embedding_fn")
+
+    await tracker.start_stage("persist")
+    await tracker.complete_stage("persist", {"record_count": 84, "replaced_count": 849, "mode": "replace"})
+
+    # 合成 delete stage（单次 _persist）
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
+    tracker._stages["delete"] = {
+        "status": "completed",
+        "started_at": now,
+        "completed_at": now,
+        "duration_ms": 0,
+        "output": {"deleted_count": 849, "atomic_with_persist": True},
+    }
+    await tracker._persist()
+
+    # 验证 persist stage 输出
+    persist_output = tracker.get_stage_output("persist")
+    assert persist_output["replaced_count"] == 849
+    assert persist_output["mode"] == "replace"
+
+    # 验证合成 delete stage
+    delete_stage = tracker._stages.get("delete")
+    assert delete_stage is not None
+    assert delete_stage["status"] == "completed"
+    assert delete_stage["output"]["deleted_count"] == 849
+    assert delete_stage["output"]["atomic_with_persist"] is True
+
+    await tracker.complete({"deleted_count": 849, "chunk_count": 84})
+
+
+@pytest.mark.asyncio
+async def test_tracker_persist_mode_append_no_delete_stage():
+    """persist_mode=append 时不应发出 delete stage。"""
+    dao = FakePipelineDao()
+    tracker = PipelineTracker(dao=dao, app_name="test", operation="ingest_text", run_id="run-append-1")
+    await tracker.start({"corpus_id": str(uuid4()), "source_uri": None})
+
+    await tracker.start_stage("persist")
+    await tracker.complete_stage("persist", {"record_count": 5, "mode": "append"})
+
+    # 不应有 delete stage
+    assert "delete" not in tracker._stages
+
+    await tracker.complete({"chunk_count": 5})

--- a/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_pipeline_tracker.py
@@ -142,8 +142,8 @@ async def test_async_rebuild_pipeline_failure_persists_input_and_terminal_timest
     assert payload["error"]["type"] == "RuntimeError"
     assert payload["error"]["message"] == "delete failed"
     assert payload["stages"]["download"]["status"] == "completed"
-    assert payload["stages"]["delete"]["status"] == "failed"
-    assert payload["stages"]["delete"]["completed_at"] is not None
+    assert payload["stages"]["persist"]["status"] == "failed"
+    assert payload["stages"]["persist"]["completed_at"] is not None
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_repository_replace.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_repository_replace.py
@@ -1,0 +1,99 @@
+"""Repository 层原子 replace + 双口径计数的单元测试。
+
+覆盖：
+- replace_knowledge_by_source 的同事务语义
+- list_corpora_with_counts 的 top-level vs total 口径
+- _top_level_role_expr 的 COALESCE 行为
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from negentropy.knowledge.retrieval.repository import (
+    KnowledgeRepository,
+    _top_level_role_expr,
+)
+from negentropy.knowledge.types import KnowledgeChunk
+
+# ============================================================================
+# _top_level_role_expr
+# ============================================================================
+
+
+def test_top_level_role_expr_produces_coalesce():
+    """_top_level_role_expr 应生成 COALESCE 表达式，将 NULL 映射为 'leaf'。"""
+    expr = _top_level_role_expr()
+    # 验证表达式可编译（不抛异常），且包含 coalesce 语义
+    compiled = str(expr.compile(compile_kwargs={"literal_binds": True}))
+    assert "coalesce" in compiled.lower()
+
+
+# ============================================================================
+# _chunks_to_insert_values / _build_returning_clause / _row_to_knowledge_record
+# ============================================================================
+
+
+def test_chunks_to_insert_values_maps_fields():
+    """_chunks_to_insert_values 应正确映射所有 KnowledgeChunk 字段。"""
+    chunk = KnowledgeChunk(
+        content="hello",
+        source_uri="gs://test/doc.pdf",
+        chunk_index=3,
+        metadata={"chunk_role": "parent"},
+        embedding=[0.1, 0.2],
+    )
+    values = KnowledgeRepository._chunks_to_insert_values(corpus_id=uuid4(), app_name="test", chunk_list=[chunk])
+    assert len(values) == 1
+    v = values[0]
+    assert v["content"] == "hello"
+    assert v["source_uri"] == "gs://test/doc.pdf"
+    assert v["chunk_index"] == 3
+    assert v["metadata_"]["chunk_role"] == "parent"
+    assert v["embedding"] == [0.1, 0.2]
+    assert v["is_enabled"] is True
+    assert v["retrieval_count"] == 0
+
+
+def test_chunks_to_insert_values_empty_list():
+    """空 chunk_list 应返回空列表。"""
+    values = KnowledgeRepository._chunks_to_insert_values(corpus_id=uuid4(), app_name="test", chunk_list=[])
+    assert values == []
+
+
+# ============================================================================
+# PipelineTracker.get_stage_output
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_stage_output_returns_completed_stage_output():
+    from negentropy.knowledge.service import PipelineTracker
+
+    from .conftest import FakePipelineDao
+
+    dao = FakePipelineDao()
+    tracker = PipelineTracker(dao=dao, app_name="test", operation="ingest_text", run_id="run-1")
+    await tracker.start({"corpus_id": str(uuid4())})
+    await tracker.start_stage("persist")
+    await tracker.complete_stage("persist", {"record_count": 14, "replaced_count": 84})
+
+    output = tracker.get_stage_output("persist")
+    assert output["record_count"] == 14
+    assert output["replaced_count"] == 84
+
+
+@pytest.mark.asyncio
+async def test_get_stage_output_returns_empty_for_missing_stage():
+    from negentropy.knowledge.service import PipelineTracker
+
+    from .conftest import FakePipelineDao
+
+    dao = FakePipelineDao()
+    tracker = PipelineTracker(dao=dao, app_name="test", operation="ingest_text", run_id="run-2")
+    await tracker.start({})
+
+    output = tracker.get_stage_output("nonexistent")
+    assert output == {}


### PR DESCRIPTION
# 背景
- 历史版本 `ingest_text/file/url` 不幂等——同一 `(corpus_id, source_uri)` 多次摄取纯 INSERT 不清理旧 chunks，导致 chunks 数量虚高（如 849 vs 预期 84）
- Corpus 列表/详情页的 `knowledge_count` 统一为全量行数，hierarchical 切分下无法区分用户感知的 chunks 与实际参与检索的 vectors

# 核心变更
- **原子 DELETE+INSERT**：新增 `replace_knowledge_by_source` 方法，同事务内完成删除旧数据+插入新数据，消除孤儿 chunks 累积；`_ingest_text_with_tracker` 新增 `persist_mode` 参数（replace/append/auto），所有摄取入口统一走 replace 路径
- **双口径计数**：`_top_level_role_expr` 单一事实源过滤 child 子块，`list_corpora_with_counts` / `get_corpus_with_counts` 返回 top-level + total 双计数，前端展示 "X chunks · Y vectors"（仅 hierarchical 场景下两数不同时展示）
- **孤儿清理工具**：CLI 脚本 `cleanup_orphan_chunks.py`（干跑默认 + backup CSV）+ 管理 API 端点 `POST /base/{corpus_id}/admin/cleanup-orphans`，按 created_at 时间聚类识别多批次摄取，保留最新完整批次
- **Pipeline Tracker 增强**：`get_stage_output` 读取已完成 stage 输出，合成 delete stage 保持前端时间轴语义一致

# 风险与回滚
- 主要风险：`replace_knowledge_by_source` 在同事务内 DELETE+INSERT，并发同 source_uri 摄取可能导致数据翻倍（但窗口比旧方案显著缩小）
- 回滚方式：revert 本 PR，恢复旧的分步 delete-then-ingest 流程

# 验证证据
- 单元测试：`test_cleanup_orphans.py`（聚类算法）、`test_corpus_count_semantics.py`（persist_mode 行为）、`test_repository_replace.py`（repository 辅助方法）
- Dashboard 计数统一为 top-level 口径，与 corpus 列表、document chunks 页一致

# 影响范围
- 前端：`CorpusList.tsx`、`page.tsx`、`knowledge-api.ts`（双数字展示）
- 后端：`repository.py`、`service.py`、`api.py`、`schemas.py`（原子写入 + 双口径计数 + 清理端点）
- 新增脚本：`cleanup_orphan_chunks.py`

# Next Best Action
- 对存量 corpus 执行一次 `cleanup_orphan_chunks.py --apply` 清理历史孤儿数据
- 观察 hierarchical 场景下双数字展示是否符合用户预期