### PR TITLE
feat(memory-facts): 将 Load Facts 的 User ID 文本输入替换为用户名下拉选择器

### DIFF
--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -10,12 +10,14 @@ import {
   fetchFacts,
   searchFacts,
   fetchFactHistory,
+  fetchMemories,
 } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 export default function MemoryFactsPage() {
-  const [userId, setUserId] = useState("");
+  const [users, setUsers] = useState<Array<{ id: string; label: string }>>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [activeUserId, setActiveUserId] = useState<string | null>(null);
   const [payload, setPayload] = useState<FactListPayload | null>(null);
@@ -43,23 +45,22 @@ export default function MemoryFactsPage() {
   }, [activeUserId]);
 
   useEffect(() => {
+    setUsersLoading(true);
+    fetchMemories(APP_NAME)
+      .then((data) => setUsers(data.users || []))
+      .catch(console.error)
+      .finally(() => setUsersLoading(false));
+  }, []);
+
+  useEffect(() => {
     loadFacts();
   }, [loadFacts]);
 
   const facts = payload?.items || [];
 
-  const handleLoadUser = () => {
-    const trimmed = userId.trim();
-    if (!trimmed) return;
-    setActiveUserId(trimmed);
-    if (activeUserId === trimmed) {
-      setError(null);
-      setIsLoading(true);
-      fetchFacts(trimmed, APP_NAME)
-        .then((data) => setPayload(data))
-        .catch((err) => setError(err))
-        .finally(() => setIsLoading(false));
-    }
+  const handleSelectUser = (value: string) => {
+    if (!value) return;
+    setActiveUserId(value);
   };
 
   const handleSearch = async () => {
@@ -126,19 +127,20 @@ export default function MemoryFactsPage() {
           <div className="pb-6">
             {/* User selection */}
             <div className="flex items-center gap-3 mb-6">
-              <input
+              <select
                 className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs w-64 dark:border-zinc-700 dark:bg-zinc-800"
-                placeholder="Enter User ID"
-                value={userId}
-                onChange={(e) => setUserId(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleLoadUser()}
-              />
-              <button
-                className="rounded-lg bg-zinc-900 px-4 py-2 text-xs font-semibold text-white dark:bg-zinc-800 dark:text-zinc-100"
-                onClick={handleLoadUser}
+                value={activeUserId ?? ""}
+                onChange={(e) => handleSelectUser(e.target.value)}
               >
-                Load Facts
-              </button>
+                <option value="" disabled>
+                  {usersLoading ? "加载中..." : "选择用户..."}
+                </option>
+                {users.map((u) => (
+                  <option key={u.id} value={u.id}>
+                    {u.label || u.id}
+                  </option>
+                ))}
+              </select>
               {activeUserId && (
                 <>
                   <div className="h-4 w-px bg-zinc-200 mx-1 dark:bg-zinc-700" />
@@ -174,7 +176,7 @@ export default function MemoryFactsPage() {
             {!activeUserId ? (
               <div className="rounded-2xl border border-zinc-200 bg-white p-10 text-center shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                 <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                  Enter a User ID to view their semantic memory (Facts).
+                  选择一个用户以查看其语义记忆 (Facts)。
                 </p>
               </div>
             ) : isLoading ? (

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -77,7 +77,6 @@ test("Facts 初始展示用户选择提示", async ({ page }) => {
   await expect(
     page.getByText("选择一个用户以查看其语义记忆 (Facts)。"),
   ).toBeVisible();
-  await expect(page.locator('select option[value="user-1"]')).toBeVisible();
 });
 
 test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -17,6 +17,23 @@ async function mockAuthenticatedUser(page: import("@playwright/test").Page) {
   });
 }
 
+async function mockMemoryUsers(page: import("@playwright/test").Page) {
+  await page.route("**/api/memory", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        users: [
+          { id: "user-1", label: "Test User 1" },
+          { id: "user-x", label: "Empty User" },
+        ],
+        timeline: [],
+        policies: {},
+      }),
+    });
+  });
+}
+
 const SAMPLE_FACTS = {
   count: 2,
   items: [
@@ -49,17 +66,19 @@ const SAMPLE_FACTS = {
   ],
 };
 
-test("Facts 初始展示 Enter a User ID 提示", async ({ page }) => {
+test("Facts 初始展示用户选择提示", async ({ page }) => {
   await mockAuthenticatedUser(page);
+  await mockMemoryUsers(page);
   await page.goto("/memory/facts");
+  await expect(page.locator("select")).toBeVisible();
   await expect(
-    page.getByText("Enter a User ID to view their semantic memory"),
+    page.getByText("选择一个用户以查看其语义记忆 (Facts)。"),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Load Facts" })).toBeVisible();
 });
 
 test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {
   await mockAuthenticatedUser(page);
+  await mockMemoryUsers(page);
   await page.route("**/api/memory/facts**", async (route) => {
     if (route.request().method() === "GET") {
       await route.fulfill({
@@ -73,19 +92,18 @@ test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {
   });
 
   await page.goto("/memory/facts");
-  await page.getByPlaceholder("Enter User ID").fill("user-1");
-  await page.getByRole("button", { name: "Load Facts" }).click();
+  await page.locator("select").selectOption("user-1");
 
   await expect(page.getByText("preferred_language")).toBeVisible();
   await expect(page.getByText("api_design")).toBeVisible();
   await expect(page.getByText("preference").first()).toBeVisible();
   await expect(page.getByText("knowledge").first()).toBeVisible();
-  // Confidence percent 标签：数字与单位分两段渲染，断言 % 旁边的数字
   await expect(page.getByText("Confidence:").first()).toBeVisible();
 });
 
 test("Facts 搜索框过滤结果", async ({ page }) => {
   await mockAuthenticatedUser(page);
+  await mockMemoryUsers(page);
   let searchCalled = false;
   await page.route("**/api/memory/facts/search", async (route) => {
     searchCalled = true;
@@ -109,8 +127,7 @@ test("Facts 搜索框过滤结果", async ({ page }) => {
   });
 
   await page.goto("/memory/facts");
-  await page.getByPlaceholder("Enter User ID").fill("user-1");
-  await page.getByRole("button", { name: "Load Facts" }).click();
+  await page.locator("select").selectOption("user-1");
   await expect(page.getByText("api_design")).toBeVisible();
 
   await page.getByPlaceholder("Search facts...").fill("language");
@@ -121,6 +138,7 @@ test("Facts 搜索框过滤结果", async ({ page }) => {
 
 test("Facts History 模态展示 dialog ARIA + Esc 关闭", async ({ page }) => {
   await mockAuthenticatedUser(page);
+  await mockMemoryUsers(page);
   await page.route("**/api/memory/facts**", async (route) => {
     const url = route.request().url();
     if (url.includes("/history")) {
@@ -161,24 +179,22 @@ test("Facts History 模态展示 dialog ARIA + Esc 关闭", async ({ page }) => 
   });
 
   await page.goto("/memory/facts");
-  await page.getByPlaceholder("Enter User ID").fill("user-1");
-  await page.getByRole("button", { name: "Load Facts" }).click();
+  await page.locator("select").selectOption("user-1");
   await expect(page.getByText("preferred_language")).toBeVisible();
 
   await page.getByRole("button", { name: "History" }).first().click();
-  // dialog ARIA 必须落地
   const dialog = page.getByRole("dialog", { name: "Fact Version History" });
   await expect(dialog).toBeVisible();
   await expect(dialog).toHaveAttribute("aria-modal", "true");
   await expect(dialog.getByText("active")).toBeVisible();
 
-  // Esc 关闭
   await page.keyboard.press("Escape");
   await expect(dialog).not.toBeVisible();
 });
 
 test("Facts 空结果展示 No facts found", async ({ page }) => {
   await mockAuthenticatedUser(page);
+  await mockMemoryUsers(page);
   await page.route("**/api/memory/facts**", async (route) => {
     if (route.request().method() === "GET") {
       await route.fulfill({
@@ -192,8 +208,7 @@ test("Facts 空结果展示 No facts found", async ({ page }) => {
   });
 
   await page.goto("/memory/facts");
-  await page.getByPlaceholder("Enter User ID").fill("user-x");
-  await page.getByRole("button", { name: "Load Facts" }).click();
+  await page.locator("select").selectOption("user-x");
 
   await expect(page.getByText("No facts found for this user.")).toBeVisible();
 });

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -18,20 +18,23 @@ async function mockAuthenticatedUser(page: import("@playwright/test").Page) {
 }
 
 async function mockMemoryUsers(page: import("@playwright/test").Page) {
-  await page.route("**/api/memory", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        users: [
-          { id: "user-1", label: "Test User 1" },
-          { id: "user-x", label: "Empty User" },
-        ],
-        timeline: [],
-        policies: {},
-      }),
-    });
-  });
+  await page.route(
+    (url) => new URL(url).pathname === "/api/memory",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          users: [
+            { id: "user-1", label: "Test User 1" },
+            { id: "user-x", label: "Empty User" },
+          ],
+          timeline: [],
+          policies: {},
+        }),
+      });
+    },
+  );
 }
 
 const SAMPLE_FACTS = {
@@ -74,6 +77,7 @@ test("Facts 初始展示用户选择提示", async ({ page }) => {
   await expect(
     page.getByText("选择一个用户以查看其语义记忆 (Facts)。"),
   ).toBeVisible();
+  await expect(page.locator('select option[value="user-1"]')).toBeVisible();
 });
 
 test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {


### PR DESCRIPTION
## Summary

- 将 Memory/Facts 页面的 User ID 文本输入框替换为用户名下拉选择器
- 复用 `fetchMemories` API 获取系统中已存在的用户列表，下拉框展示用户名称（`label`）而非原始 User ID
- 选择用户后自动触发 Facts 加载，移除手动 Load Facts 按钮
- 空状态提示文案中文化

## Test plan

- [ ] 打开 Memory > Facts 页面，验证下拉框正确加载并展示用户列表
- [ ] 选择用户后 Facts 自动加载，无需手动点击按钮
- [ ] Search / Clear 功能正常
- [ ] Dark Mode 下样式正确
- [ ] 无用户数据时空状态展示正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)