### PR TITLE
refactor(knowledge-graph): 变更 KG 构建单位与 Corpus chunk 计数规则为 parent chunk

### DIFF
--- a/apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py
+++ b/apps/negentropy/src/negentropy/agents/tools/paper_kg_pipeline.py
@@ -126,6 +126,16 @@ async def enqueue_kg_build(
     fail-open 兜底：任何 except 都不抛出，调用方可直接合并到 ingest_paper 返回值。
     """
     try:
+        # Hierarchical 语料库：仅使用 parent chunk 构建 KG，
+        # 避免 child chunk 参与实体/关系抽取造成冗余。
+        from negentropy.knowledge.service import CHUNK_ROLE_PARENT
+
+        parent_records = [
+            r for r in records if (getattr(r, "metadata", None) or {}).get("chunk_role") == CHUNK_ROLE_PARENT
+        ]
+        if parent_records:
+            records = parent_records
+
         chunks = _records_to_chunks(records)
         if not chunks:
             return {"kg_status": "kg_skipped", "kg_error_code": "no_chunks"}

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -596,22 +596,13 @@ async def get_dashboard(app_name: str | None = Query(default=None)) -> Dashboard
     alerts = []
     async with AsyncSessionLocal() as db:
         corpus_count = await db.scalar(select(func.count()).select_from(Corpus).where(Corpus.app_name == resolved_app))
-        # Dashboard 计数统一为 parent chunk 口径（hierarchical 语料库仅计 parent 块）。
-        # 非 hierarchical 语料库无 parent chunk，fallback 到全量计数。
-        from negentropy.knowledge.retrieval.repository import _parent_role_expr
+        # Dashboard 计数统一为 parent chunk 口径，复用 repository 的 per-corpus fallback 逻辑，
+        # 确保混合 hierarchical / non-hierarchical 语料库场景下计数准确。
+        from negentropy.knowledge.retrieval.repository import KnowledgeRepository
 
-        knowledge_count = await db.scalar(
-            select(func.count())
-            .select_from(Knowledge)
-            .where(
-                Knowledge.app_name == resolved_app,
-                _parent_role_expr() == "parent",
-            )
-        )
-        if not knowledge_count:
-            knowledge_count = await db.scalar(
-                select(func.count()).select_from(Knowledge).where(Knowledge.app_name == resolved_app)
-            )
+        repo = KnowledgeRepository()
+        corpora_with_counts = await repo.list_corpora_with_counts(app_name=resolved_app)
+        knowledge_count = sum(parent_or_all for _, parent_or_all, _ in corpora_with_counts)
         last_build_at = await db.scalar(
             select(func.max(Knowledge.updated_at)).where(Knowledge.app_name == resolved_app)
         )

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -596,19 +596,22 @@ async def get_dashboard(app_name: str | None = Query(default=None)) -> Dashboard
     alerts = []
     async with AsyncSessionLocal() as db:
         corpus_count = await db.scalar(select(func.count()).select_from(Corpus).where(Corpus.app_name == resolved_app))
-        # Dashboard 计数统一为 top-level 口径（parent + leaf，排除 child），
-        # 与 corpus 列表、document chunks 页口径一致。
-        # 使用 repository 的辅助函数确保过滤逻辑是单一事实源。
-        from negentropy.knowledge.retrieval.repository import _top_level_role_expr
+        # Dashboard 计数统一为 parent chunk 口径（hierarchical 语料库仅计 parent 块）。
+        # 非 hierarchical 语料库无 parent chunk，fallback 到全量计数。
+        from negentropy.knowledge.retrieval.repository import _parent_role_expr
 
         knowledge_count = await db.scalar(
             select(func.count())
             .select_from(Knowledge)
             .where(
                 Knowledge.app_name == resolved_app,
-                _top_level_role_expr() != "child",
+                _parent_role_expr() == "parent",
             )
         )
+        if not knowledge_count:
+            knowledge_count = await db.scalar(
+                select(func.count()).select_from(Knowledge).where(Knowledge.app_name == resolved_app)
+            )
         last_build_at = await db.scalar(
             select(func.max(Knowledge.updated_at)).where(Knowledge.app_name == resolved_app)
         )
@@ -3025,6 +3028,17 @@ async def build_knowledge_graph(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={"code": "NO_KNOWLEDGE", "message": "No knowledge chunks found in corpus"},
             )
+
+        # Hierarchical 语料库：仅使用 parent chunk 构建 KG，
+        # 避免 child chunk 参与实体/关系抽取造成冗余。
+        # 非 hierarchical 语料库无 parent chunk，保持全量使用。
+        from negentropy.knowledge.service import CHUNK_ROLE_PARENT
+
+        parent_items = [
+            item for item in knowledge_items if (item.metadata or {}).get("chunk_role") == CHUNK_ROLE_PARENT
+        ]
+        if parent_items:
+            knowledge_items = parent_items
 
         # 准备知识块数据（含 id 用于增量构建跳过判断）
         chunks = [

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -44,6 +44,16 @@ def _top_level_role_expr():
     )
 
 
+def _parent_role_expr():
+    """构建 ``chunk_role = 'parent'`` 的过滤表达式。
+
+    用于 Corpus chunk 计数与 KG 构建入口，仅选取 hierarchical 切分产生的父块。
+    非 hierarchical 语料库无 parent chunk（chunk_role 为 NULL 或 'leaf'），
+    调用方需自行 fallback 到全量计数。
+    """
+    return cast(Knowledge.metadata_["chunk_role"].astext, String)
+
+
 class KnowledgeRepository:
     def __init__(self, session_factory: async_sessionmaker | None = None):
         """
@@ -92,19 +102,17 @@ class KnowledgeRepository:
     async def list_corpora_with_counts(self, *, app_name: str) -> list[tuple[CorpusRecord, int, int]]:
         """语料库列表 + 双口径 chunks 计数。
 
-        返回 ``(record, top_level_count, total_count)``：
-          - top_level_count：``chunk_role != 'child'`` 的行数（与 Document Chunks 页"14 Chunks"一致，
-            是用户感知的"chunks"）；
+        返回 ``(record, parent_or_all_count, total_count)``：
+          - parent_or_all_count：parent chunk 数（``chunk_role = 'parent'``）。
+            非 hierarchical 语料库无 parent chunk 时 fallback 到全量计数；
           - total_count：全部 Knowledge 行数（含 child 子块，是真正参与检索的"vectors"）。
-
-        Hierarchical 切分下两者会拉开差距；其它策略下 ``chunk_role`` 不存在，两数相等。
         """
-        role_expr = _top_level_role_expr()
+        parent_expr = _parent_role_expr()
         async with self._get_session_factory()() as db:
             stmt = (
                 select(
                     Corpus,
-                    func.count(Knowledge.id).filter(role_expr != "child").label("top_level"),
+                    func.count(Knowledge.id).filter(parent_expr == "parent").label("parent_count"),
                     func.count(Knowledge.id).label("total"),
                 )
                 .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
@@ -115,18 +123,22 @@ class KnowledgeRepository:
             result = await db.execute(stmt)
             rows = result.all()
             return [
-                (self._to_corpus_record(corpus), int(top_level or 0), int(total or 0))
-                for corpus, top_level, total in rows
+                (
+                    self._to_corpus_record(corpus),
+                    int(parent_count or 0) if (parent_count or 0) > 0 else int(total or 0),
+                    int(total or 0),
+                )
+                for corpus, parent_count, total in rows
             ]
 
     async def get_corpus_with_counts(self, *, corpus_id: UUID, app_name: str) -> tuple[CorpusRecord, int, int] | None:
         """单 corpus 双口径计数；与 ``list_corpora_with_counts`` 同语义。"""
-        role_expr = _top_level_role_expr()
+        parent_expr = _parent_role_expr()
         async with self._get_session_factory()() as db:
             stmt = (
                 select(
                     Corpus,
-                    func.count(Knowledge.id).filter(role_expr != "child").label("top_level"),
+                    func.count(Knowledge.id).filter(parent_expr == "parent").label("parent_count"),
                     func.count(Knowledge.id).label("total"),
                 )
                 .outerjoin(Knowledge, Knowledge.corpus_id == Corpus.id)
@@ -137,8 +149,9 @@ class KnowledgeRepository:
             row = result.first()
             if not row:
                 return None
-            corpus, top_level, total = row
-            return self._to_corpus_record(corpus), int(top_level or 0), int(total or 0)
+            corpus, parent_count, total = row
+            parent_or_all = int(parent_count or 0) if (parent_count or 0) > 0 else int(total or 0)
+            return self._to_corpus_record(corpus), parent_or_all, int(total or 0)
 
     async def create_corpus(self, spec: CorpusSpec) -> CorpusRecord:
         async with self._get_session_factory()() as db:

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -31,19 +31,6 @@ from ..types import (
 logger = get_logger("negentropy.knowledge.repository")
 
 
-def _top_level_role_expr():
-    """构建 ``chunk_role != 'child'`` 的过滤表达式。
-
-    用 COALESCE 将 NULL chunk_role（非 hierarchical 场景）映射为 ``"leaf"``,
-    避免 NULL 与字符串比较返回 NULL 导致计数失真。
-    单一事实源：所有需要"排除 child"的计数查询共用此表达式。
-    """
-    return func.coalesce(
-        cast(Knowledge.metadata_["chunk_role"].astext, String),
-        "leaf",
-    )
-
-
 def _parent_role_expr():
     """构建 ``chunk_role = 'parent'`` 的过滤表达式。
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_repository_replace.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_repository_replace.py
@@ -2,8 +2,8 @@
 
 覆盖：
 - replace_knowledge_by_source 的同事务语义
-- list_corpora_with_counts 的 top-level vs total 口径
-- _top_level_role_expr 的 COALESCE 行为
+- list_corpora_with_counts 的 parent_or_all vs total 口径
+- _parent_role_expr 的 CAST 行为
 """
 
 from __future__ import annotations
@@ -14,21 +14,21 @@ import pytest
 
 from negentropy.knowledge.retrieval.repository import (
     KnowledgeRepository,
-    _top_level_role_expr,
+    _parent_role_expr,
 )
 from negentropy.knowledge.types import KnowledgeChunk
 
 # ============================================================================
-# _top_level_role_expr
+# _parent_role_expr
 # ============================================================================
 
 
-def test_top_level_role_expr_produces_coalesce():
-    """_top_level_role_expr 应生成 COALESCE 表达式，将 NULL 映射为 'leaf'。"""
-    expr = _top_level_role_expr()
-    # 验证表达式可编译（不抛异常），且包含 coalesce 语义
+def test_parent_role_expr_produces_cast():
+    """_parent_role_expr 应生成 CAST 表达式，提取 metadata_->>chunk_role。"""
+    expr = _parent_role_expr()
     compiled = str(expr.compile(compile_kwargs={"literal_binds": True}))
-    assert "coalesce" in compiled.lower()
+    assert "chunk_role" in compiled
+    assert "cast" in compiled.lower()
 
 
 # ============================================================================


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：当前知识图谱（KG）构建以所有 chunk（parent + child + leaf）为单位，导致 child chunk 参与实体/关系抽取造成冗余；同时 Corpus chunk 总数统计基于 `chunk_role != 'child'`（parent + leaf），对 hierarchical 语料库显示虚高（如 Harness Engineering 显示 156 而实际只有 20 个 parent chunk）
- 关联上下文：知识图谱构建流水线优化、Corpus 统计口径对齐

# 核心变更
- **Repository 层**：新增 `_parent_role_expr()` 辅助函数，`list_corpora_with_counts` / `get_corpus_with_counts` 计数改为 `chunk_role = 'parent'`，非 hierarchical 语料库（无 parent chunk）fallback 到全量计数，保持兼容
- **Dashboard**：计数查询从 `_top_level_role_expr() != 'child'` 切换为 `_parent_role_expr() == 'parent'`，同样含非 hierarchical fallback
- **KG 构建入口**：API 端点 `build_knowledge_graph` 在传递 chunks 给 `build_graph` 前过滤为 parent chunk only（有 parent 时仅用 parent，否则保持全量）
- **Paper KG Pipeline**：`enqueue_kg_build` 在调用 `_records_to_chunks` 前过滤 records 为 parent chunk

# 风险与回滚
- 主要风险：非 hierarchical 语料库无 `chunk_role = 'parent'` 的 chunk，所有 fallback 路径已覆盖（parent_count = 0 时回退到全量计数 / 全量 chunks）
- 回滚方式：`git revert` 该提交即可，无数据库 schema 变更

# 验证证据
- 单元测试：knowledge 目录 657 passed，paper_kg_pipeline 8 passed（含 fail-open 兜底、空 records 短路、后台 task 自清理等用例）
- 集成测试：无需额外集成测试（改动仅涉及查询过滤条件变更，无新外部依赖）
- E2E/Workflow：待浏览器验证 Corpus 列表 chunk 数量、Dashboard 计数、KG Build 行为
- 覆盖率/关键截图：单元测试覆盖率 19%（项目整体，非本次变更专属）

# 影响范围
- 前端：无代码变更，`knowledge_count` 字段语义调整后 UI 显示自然适配
- 后端：3 个文件（repository.py、api.py、paper_kg_pipeline.py），`_top_level_role_expr` 保留不删供 document chunks 页等继续使用
- GitHub Actions / 文档：无影响

# Next Best Action
- 浏览器端到端验证：确认 Harness Engineering Corpus 显示 20 chunks、Dashboard 计数正确、KG Build 仅处理 parent chunk