### PR TITLE
fix(knowledge-graph): 修复语料库选择器首次进入时自动选中第一个 Corpus 的问题

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
@@ -35,12 +35,14 @@ export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
         语料库
       </label>
       <select
+        key={loading ? "loading" : "loaded"}
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
+        autoComplete="off"
         disabled={loading}
         className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm text-zinc-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
       >
-        <option value="">{loading ? "加载中..." : "选择语料库..."}</option>
+        <option value="" disabled>{loading ? "加载中..." : "选择语料库..."}</option>
         {corpora.map((c) => (
           <option key={c.id} value={c.id}>
             {c.name}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge Graph 页面的语料库下拉选择器在首次进入时默认选中第一个 Corpus（如 "Harness Engineering"），而非显示占位符 "选择语料库..." 让用户自行选择
- 关联上下文/Issue/文档：用户截图反馈

# 核心变更
- 为 `<select>` 添加 `key={loading ? "loading" : "loaded"}`，在 corpora 列表加载完成后强制重新挂载 select 元素，确保 React 正确将 controlled value 绑定到 placeholder option
- 添加 `autoComplete="off"` 防止浏览器自动填充上次选择值
- 为 placeholder `<option>` 添加 `disabled` 属性，符合原生 select placeholder 的标准实践

# 风险与回滚
- 主要风险：极低，仅修改单个组件的 HTML 属性，不影响数据逻辑
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无（UI 属性变更）
- 集成测试：无
- E2E/Workflow：需手动验证——首次进入 KG 页面时下拉框应显示 "选择语料库..."
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器验证首次进入 KG 页面时下拉框显示占位符而非自动选中语料库