### PR TITLE
feat(memory-timeline): 增强 Timeline 卡片展示与用户名称显示

### DIFF
--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -29,15 +29,21 @@ interface TimelineGroup {
     : never;
 }
 
+function toLocalDateStr(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
 function groupByDate(
   items: Array<{ created_at?: string; id: string }>,
 ): TimelineGroup[] {
-  const today = new Date().toISOString().slice(0, 10);
-  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+  const now = new Date();
+  const today = toLocalDateStr(now);
+  const yesterday = toLocalDateStr(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1));
 
   const map = new Map<string, Array<{ created_at?: string; id: string }>>();
   for (const item of items) {
-    const dateStr = (item.created_at || "").slice(0, 10) || "unknown";
+    const d = item.created_at ? new Date(item.created_at) : null;
+    const dateStr = d && !isNaN(d.getTime()) ? toLocalDateStr(d) : "unknown";
     if (!map.has(dateStr)) map.set(dateStr, []);
     map.get(dateStr)!.push(item);
   }

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -3,10 +3,60 @@
 import { useMemo, useState } from "react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
+import { UserAvatar } from "@/components/ui/UserAvatar";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
-import { RetryableErrorBanner, useMemoryTimeline } from "@/features/memory";
+import {
+  RetryableErrorBanner,
+  useMemoryTimeline,
+  MemoryTimelineCard,
+} from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+
+// ---------------------------------------------------------------------------
+// Time-grouping helpers
+// ---------------------------------------------------------------------------
+
+interface TimelineGroup {
+  label: string;
+  date: string;
+  items: ReturnType<typeof useMemoryTimeline> extends {
+    payload: infer P;
+  }
+    ? P extends { timeline: infer T }
+      ? T
+      : never
+    : never;
+}
+
+function groupByDate(
+  items: Array<{ created_at?: string; id: string }>,
+): TimelineGroup[] {
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+
+  const map = new Map<string, Array<{ created_at?: string; id: string }>>();
+  for (const item of items) {
+    const dateStr = (item.created_at || "").slice(0, 10) || "unknown";
+    if (!map.has(dateStr)) map.set(dateStr, []);
+    map.get(dateStr)!.push(item);
+  }
+
+  const groups: TimelineGroup[] = [];
+  for (const [dateStr, groupItems] of map) {
+    let label: string;
+    if (dateStr === today) label = "Today";
+    else if (dateStr === yesterday) label = "Yesterday";
+    else label = dateStr;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    groups.push({ label, date: dateStr, items: groupItems as any });
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
 
 export default function MemoryTimelinePage() {
   const {
@@ -50,6 +100,7 @@ export default function MemoryTimelinePage() {
         id: item.id,
         content: item.content,
         retention_score: item.relevance_score || 0,
+        importance_score: 0,
         memory_type: "search",
         access_count: 0,
         created_at: item.timestamp,
@@ -59,178 +110,232 @@ export default function MemoryTimelinePage() {
       }))
     : filteredTimeline;
 
-  const retentionColor = (score: number) => {
-    if (score >= 0.5) return "bg-emerald-500";
-    if (score >= 0.1) return "bg-amber-500";
-    return "bg-rose-500";
-  };
+  const groupedTimeline = useMemo(() => groupByDate(displayItems), [displayItems]);
 
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
       <MemoryNav title="Timeline" description="用户记忆时间线" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
-          {/* D5: 统一 error banner（独立块，避免被 flex-row 兄弟挤占侧边栏空间） */}
-          {/* M3: 5xx 等可重试错误暴露"重试"按钮，复用 RetryableErrorBanner */}
           <RetryableErrorBanner error={error} onRetry={reload} />
 
-
           <div className="flex min-h-0 flex-1 gap-6">
-          {/* Users sidebar */}
-          <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-            <div className="pb-4 pr-2">
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Users</h2>
-                <div className="mt-3 space-y-2">
-                  {users.length ? (
-                    users.map((user) => (
-                      <button
-                        key={user.id}
-                        className={`w-full rounded-lg border px-3 py-2 text-left text-xs ${
-                          selectedUserId === user.id
-                            ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
-                            : "border-zinc-200 text-zinc-700 hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500"
-                        }`}
-                        onClick={() => {
-                          setSelectedUserId(user.id);
-                          handleClearSearch();
-                        }}
-                      >
-                        <p className="text-xs font-semibold">
-                          {user.label || user.id}
-                        </p>
-                      </button>
-                    ))
-                  ) : (
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {isLoading ? "Loading..." : "No users found"}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </div>
-          </aside>
-
-          {/* Timeline */}
-          <main className="min-h-0 min-w-0 flex-[2.2] overflow-y-auto">
-            <div className="pb-4 pr-2">
-              <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                    {searchResult ? "Search Results" : "Memory Timeline"}
-                  </h2>
-                  <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                    {selectedUserId || "all users"}
-                    {searchResult && ` · ${searchResult.count} result(s)`}
-                  </span>
-                </div>
-
-                {/* D2: 搜索框 */}
-                {selectedUserId && (
-                  <div className="mt-3 flex items-center gap-2">
-                    <input
-                      className="flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                      placeholder="Search memories..."
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-                    />
-                    <button
-                      className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
-                      onClick={handleSearch}
-                      disabled={!searchQuery.trim()}
-                    >
-                      Search
-                    </button>
-                    {searchResult && (
-                      <button
-                        className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
-                        onClick={handleClearSearch}
-                      >
-                        Clear
-                      </button>
+            {/* Users sidebar */}
+            <aside className="min-h-0 w-56 max-w-56 shrink-0 overflow-y-auto">
+              <div className="pb-4 pr-2">
+                <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Users</h2>
+                  <div className="mt-3 space-y-1.5">
+                    {users.length ? (
+                      users.map((user) => (
+                        <button
+                          key={user.id}
+                          className={`flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition ${
+                            selectedUserId === user.id
+                              ? "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                              : "border-zinc-200 text-zinc-700 hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500"
+                          }`}
+                          onClick={() => {
+                            setSelectedUserId(user.id);
+                            handleClearSearch();
+                          }}
+                        >
+                          <UserAvatar
+                            picture={user.picture}
+                            name={user.name}
+                            email={user.email}
+                            className="h-7 w-7 shrink-0"
+                            fallbackClassName="h-7 w-7 text-[10px]"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-xs font-semibold">
+                              {user.name || user.id}
+                            </p>
+                            <p className="truncate text-[10px] text-zinc-500 dark:text-zinc-400">
+                              {user.count} memories
+                            </p>
+                          </div>
+                        </button>
+                      ))
+                    ) : (
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {isLoading ? "Loading..." : "No users found"}
+                      </p>
                     )}
                   </div>
-                )}
+                </div>
+              </div>
+            </aside>
 
-                <div className="mt-4 space-y-3">
-                  {displayItems.length ? (
-                    displayItems.map((item) => (
-                      <div
-                        key={item.id}
-                        className="rounded-lg border border-zinc-200 p-3 text-xs dark:border-zinc-700"
+            {/* Timeline */}
+            <main className="min-h-0 min-w-0 flex-[2.2] overflow-y-auto">
+              <div className="pb-4 pr-2">
+                <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                      {searchResult ? "Search Results" : "Memory Timeline"}
+                    </h2>
+                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {selectedUserId
+                        ? users.find((u) => u.id === selectedUserId)?.name || selectedUserId
+                        : "all users"}
+                      {searchResult && ` · ${searchResult.count} result(s)`}
+                    </span>
+                  </div>
+
+                  {/* D2: 搜索框 */}
+                  {selectedUserId && (
+                    <div className="mt-3 flex items-center gap-2">
+                      <input
+                        className="flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                        placeholder="Search memories..."
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                      />
+                      <button
+                        className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                        onClick={handleSearch}
+                        disabled={!searchQuery.trim()}
                       >
-                        <div className="flex items-start justify-between">
-                          <p className="text-zinc-900 font-medium dark:text-zinc-100">
-                            {item.content.length > 200
-                              ? `${item.content.slice(0, 200)}...`
-                              : item.content}
-                          </p>
-                          <div className="ml-3 flex items-center gap-2 shrink-0">
-                            <span
-                              className={`h-2 w-2 rounded-full ${retentionColor(item.retention_score)}`}
-                            />
-                            <span className="text-[11px] text-zinc-500 dark:text-zinc-400">
-                              {(item.retention_score * 100).toFixed(0)}%
-                            </span>
-                          </div>
-                        </div>
-                        <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-zinc-400 dark:text-zinc-500">
-                          <span>Type: {item.memory_type}</span>
-                          {!searchResult && (
-                            <span>Access: {item.access_count}x</span>
-                          )}
-                          <span>{item.created_at || "-"}</span>
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {isLoading
-                        ? "Loading memories..."
-                        : searchResult
-                          ? "No matching memories found"
-                          : "No memories found"}
-                    </p>
+                        Search
+                      </button>
+                      {searchResult && (
+                        <button
+                          className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                          onClick={handleClearSearch}
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
                   )}
-                </div>
-              </div>
-            </div>
-          </main>
 
-          {/* Policies sidebar */}
-          <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-            <div className="space-y-4 pb-4 pr-2">
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                  Retention Policy
-                </h2>
-                <pre className="mt-3 max-h-48 overflow-auto rounded-lg bg-zinc-50 p-3 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
-                  {JSON.stringify(policies, null, 2)}
-                </pre>
-              </div>
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Legend</h2>
-                <div className="mt-3 space-y-2 text-[11px] text-zinc-600 dark:text-zinc-400">
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-emerald-500" />
-                    High retention (&ge; 50%)
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-amber-500" />
-                    Medium retention (10-50%)
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-rose-500" />
-                    Low retention (&lt; 10%)
+                  <div className="mt-4 space-y-3">
+                    {displayItems.length ? (
+                      searchResult ? (
+                        // Flat list for search results
+                        displayItems.map((item) => (
+                          <MemoryTimelineCard
+                            key={item.id}
+                            item={item}
+                            isSearchResult
+                          />
+                        ))
+                      ) : (
+                        // Time-grouped list for timeline
+                        groupedTimeline.map((group) => (
+                          <div key={group.date}>
+                            <div className="sticky top-0 z-10 bg-white pb-1 pt-2 text-[11px] font-semibold text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
+                              {group.label}
+                            </div>
+                            <div className="space-y-2">
+                              {group.items.map((item) => (
+                                <MemoryTimelineCard key={item.id} item={item} />
+                              ))}
+                            </div>
+                          </div>
+                        ))
+                      )
+                    ) : (
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {isLoading
+                          ? "Loading memories..."
+                          : searchResult
+                            ? "No matching memories found"
+                            : "No memories found"}
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-500 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-                Status: {payload ? "loaded" : "loading"}
+            </main>
+
+            {/* Policies & Legend sidebar */}
+            <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+              <div className="space-y-4 pb-4 pr-2">
+                <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                    Retention Policy
+                  </h2>
+                  <pre className="mt-3 max-h-48 overflow-auto rounded-lg bg-zinc-50 p-3 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                    {JSON.stringify(policies, null, 2)}
+                  </pre>
+                </div>
+
+                {/* Legend */}
+                <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Legend</h2>
+
+                  {/* Retention scores */}
+                  <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                    Retention
+                  </p>
+                  <div className="mt-1.5 space-y-1.5 text-[11px] text-zinc-600 dark:text-zinc-400">
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                      High retention (&ge; 50%)
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-amber-500" />
+                      Medium retention (10-50%)
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-rose-500" />
+                      Low retention (&lt; 10%)
+                    </div>
+                  </div>
+
+                  {/* Importance scores */}
+                  <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                    Importance
+                  </p>
+                  <div className="mt-1.5 space-y-1.5 text-[11px] text-zinc-600 dark:text-zinc-400">
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-blue-500" />
+                      High importance (&ge; 70%)
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-cyan-500" />
+                      Medium importance (40-70%)
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-slate-400" />
+                      Low importance (&lt; 40%)
+                    </div>
+                  </div>
+
+                  {/* Memory types */}
+                  <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                    Memory Types
+                  </p>
+                  <div className="mt-1.5 space-y-1 text-[11px] text-zinc-600 dark:text-zinc-400">
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-violet-500" /> Core
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-blue-500" /> Semantic
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-amber-500" /> Episodic
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-emerald-500" /> Procedural
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-pink-500" /> Preference
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="h-2 w-2 rounded-full bg-cyan-500" /> Fact
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-500 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
+                  Status: {payload ? "loaded" : "loading"}
+                </div>
               </div>
-            </div>
-          </aside>
+            </aside>
           </div>
         </div>
       </div>

--- a/apps/negentropy-ui/features/memory/components/MemoryTimelineCard.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemoryTimelineCard.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import {
+  BookOpen,
+  Calendar,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Eye,
+  Hash,
+  Heart,
+  Search,
+  Shield,
+  Wrench,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MemoryItem } from "../utils/memory-api";
+
+// ---------------------------------------------------------------------------
+// Memory type → icon + accent colour mapping
+// Aligned with memory-basics.md §2 decay-rate table
+// ---------------------------------------------------------------------------
+
+const MEMORY_TYPE_CONFIG: Record<
+  string,
+  { icon: typeof Shield; label: string; accent: string; bg: string }
+> = {
+  core: { icon: Shield, label: "Core", accent: "text-violet-600 dark:text-violet-400", bg: "bg-violet-100 dark:bg-violet-900/40" },
+  semantic: { icon: BookOpen, label: "Semantic", accent: "text-blue-600 dark:text-blue-400", bg: "bg-blue-100 dark:bg-blue-900/40" },
+  episodic: { icon: Clock, label: "Episodic", accent: "text-amber-600 dark:text-amber-400", bg: "bg-amber-100 dark:bg-amber-900/40" },
+  procedural: { icon: Wrench, label: "Procedural", accent: "text-emerald-600 dark:text-emerald-400", bg: "bg-emerald-100 dark:bg-emerald-900/40" },
+  preference: { icon: Heart, label: "Preference", accent: "text-pink-600 dark:text-pink-400", bg: "bg-pink-100 dark:bg-pink-900/40" },
+  fact: { icon: Hash, label: "Fact", accent: "text-cyan-600 dark:text-cyan-400", bg: "bg-cyan-100 dark:bg-cyan-900/40" },
+  search: { icon: Search, label: "Search Result", accent: "text-slate-600 dark:text-slate-400", bg: "bg-slate-100 dark:bg-slate-800/40" },
+};
+
+const DEFAULT_TYPE_CONFIG = {
+  icon: Hash,
+  label: "Unknown",
+  accent: "text-zinc-600 dark:text-zinc-400",
+  bg: "bg-zinc-100 dark:bg-zinc-800/40",
+};
+
+// ---------------------------------------------------------------------------
+// Score bar helpers
+// ---------------------------------------------------------------------------
+
+function retentionBarColor(score: number): string {
+  if (score >= 0.5) return "bg-emerald-500";
+  if (score >= 0.1) return "bg-amber-500";
+  return "bg-rose-500";
+}
+
+function importanceBarColor(score: number): string {
+  if (score >= 0.7) return "bg-blue-500";
+  if (score >= 0.4) return "bg-cyan-500";
+  return "bg-slate-400";
+}
+
+// ---------------------------------------------------------------------------
+// Relative time formatting
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(iso?: string): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return null;
+  const diff = Date.now() - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return date.toLocaleDateString();
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return "-";
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return "-";
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const CONTENT_PREVIEW_LENGTH = 150;
+
+interface MemoryTimelineCardProps {
+  item: MemoryItem;
+  isSearchResult?: boolean;
+}
+
+export function MemoryTimelineCard({ item, isSearchResult }: MemoryTimelineCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const typeConfig = MEMORY_TYPE_CONFIG[item.memory_type] ?? DEFAULT_TYPE_CONFIG;
+  const TypeIcon = typeConfig.icon;
+  const canExpand = item.content.length > CONTENT_PREVIEW_LENGTH;
+
+  return (
+    <article
+      className={cn(
+        "rounded-xl border border-zinc-200 bg-white shadow-sm transition",
+        "hover:border-zinc-300 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-600",
+      )}
+    >
+      {/* Header: type badge + score bars */}
+      <div className="flex items-start justify-between gap-3 px-3 pt-3">
+        {/* Type badge */}
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-[3px] text-[10px] font-semibold",
+            typeConfig.bg,
+            typeConfig.accent,
+          )}
+        >
+          <TypeIcon className="h-3 w-3" />
+          {typeConfig.label}
+        </span>
+
+        {/* Score indicators */}
+        <div className="flex shrink-0 items-center gap-3 text-[10px]">
+          {/* Retention */}
+          <div className="flex items-center gap-1.5">
+            <span className="text-zinc-500 dark:text-zinc-400">Ret</span>
+            <div className="h-1.5 w-12 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+              <div
+                className={cn("h-full rounded-full transition-all", retentionBarColor(item.retention_score))}
+                style={{ width: `${Math.max(item.retention_score * 100, 2)}%` }}
+              />
+            </div>
+            <span className="w-7 text-right tabular-nums text-zinc-600 dark:text-zinc-300">
+              {(item.retention_score * 100).toFixed(0)}%
+            </span>
+          </div>
+          {/* Importance */}
+          {!isSearchResult && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-zinc-500 dark:text-zinc-400">Imp</span>
+              <div className="h-1.5 w-12 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                <div
+                  className={cn("h-full rounded-full transition-all", importanceBarColor(item.importance_score))}
+                  style={{ width: `${Math.max(item.importance_score * 100, 2)}%` }}
+                />
+              </div>
+              <span className="w-7 text-right tabular-nums text-zinc-600 dark:text-zinc-300">
+                {(item.importance_score * 100).toFixed(0)}%
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="px-3 pb-2 pt-2">
+        <p className="whitespace-pre-wrap text-xs font-medium leading-relaxed text-zinc-900 dark:text-zinc-100">
+          {canExpand && !isExpanded
+            ? item.content.slice(0, CONTENT_PREVIEW_LENGTH)
+            : item.content}
+        </p>
+        {canExpand && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            className="mt-1 inline-flex items-center gap-1 text-[10px] font-semibold text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+          >
+            {isExpanded ? (
+              <>
+                <ChevronUp className="h-3 w-3" />
+                收起
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3 w-3" />
+                展开全文
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Metadata footer */}
+      <div className="flex flex-wrap items-center gap-3 border-t border-zinc-100 px-3 py-2 text-[10px] text-zinc-400 dark:border-zinc-800 dark:text-zinc-500">
+        {!isSearchResult && (
+          <span className="inline-flex items-center gap-1">
+            <Eye className="h-3 w-3" />
+            {item.access_count}x
+          </span>
+        )}
+        {item.last_accessed_at && !isSearchResult && (
+          <span className="inline-flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {formatRelativeTime(item.last_accessed_at)}
+          </span>
+        )}
+        <span className="inline-flex items-center gap-1">
+          <Calendar className="h-3 w-3" />
+          {formatDate(item.created_at)}
+        </span>
+      </div>
+    </article>
+  );
+}

--- a/apps/negentropy-ui/features/memory/components/MemoryTimelineCard.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemoryTimelineCard.tsx
@@ -159,7 +159,7 @@ export function MemoryTimelineCard({ item, isSearchResult }: MemoryTimelineCardP
       <div className="px-3 pb-2 pt-2">
         <p className="whitespace-pre-wrap text-xs font-medium leading-relaxed text-zinc-900 dark:text-zinc-100">
           {canExpand && !isExpanded
-            ? item.content.slice(0, CONTENT_PREVIEW_LENGTH)
+            ? [...item.content].slice(0, CONTENT_PREVIEW_LENGTH).join("")
             : item.content}
         </p>
         {canExpand && (

--- a/apps/negentropy-ui/features/memory/index.ts
+++ b/apps/negentropy-ui/features/memory/index.ts
@@ -52,6 +52,7 @@ export {
   RetryableErrorBanner,
   isRetryable,
 } from "./components/RetryableErrorBanner";
+export { MemoryTimelineCard } from "./components/MemoryTimelineCard";
 export type {
   RetryableError,
   RetryableErrorBannerProps,

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -35,7 +35,14 @@ export interface MemoryItem {
 }
 
 export interface MemoryListPayload {
-  users: Array<{ id: string; label: string }>;
+  users: Array<{
+    id: string;
+    label: string;
+    name?: string;
+    picture?: string;
+    email?: string;
+    count: number;
+  }>;
   timeline: MemoryItem[];
   policies: Record<string, unknown>;
 }

--- a/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
@@ -113,7 +113,7 @@ test("Memory Timeline 加载用户和记忆列表", async ({ page }) => {
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        users: [{ id: "user-1", label: "user-1 (3)" }],
+        users: [{ id: "user-1", label: "user-1 (3)", count: 3 }],
         timeline: [
           {
             id: "mem-1",
@@ -137,7 +137,7 @@ test("Memory Timeline 加载用户和记忆列表", async ({ page }) => {
   await page.waitForLoadState("networkidle");
 
   await expect(page.getByText("Memory Timeline")).toBeVisible();
-  await expect(page.getByText("user-1 (3)")).toBeVisible();
+  await expect(page.getByText("3 memories")).toBeVisible();
   await expect(page.getByText("Test memory content")).toBeVisible();
   await expect(page.getByText("85%")).toBeVisible();
 });

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -41,6 +41,7 @@ from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.internalization import Fact, Memory, MemoryAuditLog
+from negentropy.models.state import UserState
 
 from .adapters.postgres.memory_automation_service import MemoryAutomationUnavailableError
 from .factories.memory import (
@@ -77,7 +78,7 @@ class MemoryItem(BaseModel):
 
 
 class MemoryListResponse(BaseModel):
-    users: list[dict[str, str]] = Field(default_factory=list)
+    users: list[dict[str, Any]] = Field(default_factory=list)
     timeline: list[MemoryItem] = Field(default_factory=list)
     policies: dict[str, Any] = Field(default_factory=dict)
 
@@ -397,6 +398,32 @@ async def get_memory_dashboard(
     )
 
 
+async def _resolve_user_profiles(user_ids: list[str]) -> dict[str, dict[str, str | None]]:
+    """批量解析用户 ID 到显示名称和头像（查询 UserState.state.profile）。
+
+    复用 knowledge/api.py 中 _resolve_user_display_names 的模式。
+    """
+    if not user_ids:
+        return {}
+    profile_map: dict[str, dict[str, str | None]] = {}
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(UserState).where(
+                UserState.app_name == settings.app_name,
+                UserState.user_id.in_(user_ids),
+            )
+        )
+        for us in result.scalars().all():
+            state = us.state or {}
+            profile = state.get("profile", {})
+            profile_map[us.user_id] = {
+                "name": profile.get("name"),
+                "picture": profile.get("picture"),
+                "email": profile.get("email"),
+            }
+    return profile_map
+
+
 @router.get("", response_model=MemoryListResponse)
 async def list_memories(
     app_name: str | None = Query(default=None),
@@ -421,7 +448,7 @@ async def list_memories(
         user_result = await db.execute(user_stmt)
         user_rows = user_result.all()
 
-        users = [{"id": row.user_id, "label": f"{row.user_id} ({row.count})"} for row in user_rows]
+        users_placeholder = [{"id": row.user_id, "count": row.count} for row in user_rows]
 
         # 获取记忆时间线
         memory_stmt = (
@@ -432,6 +459,25 @@ async def list_memories(
 
         memory_result = await db.execute(memory_stmt)
         memories = memory_result.scalars().all()
+
+    # 解析用户名称/头像（需独立 session，避免跨 session 引用）
+    unique_user_ids = [u["id"] for u in users_placeholder]
+    profiles = await _resolve_user_profiles(unique_user_ids)
+
+    users = []
+    for entry in users_placeholder:
+        p = profiles.get(entry["id"], {})
+        display_name = p.get("name") or entry["id"]
+        users.append(
+            {
+                "id": entry["id"],
+                "label": f"{display_name} ({entry['count']})",
+                "name": p.get("name"),
+                "picture": p.get("picture"),
+                "email": p.get("email"),
+                "count": entry["count"],
+            }
+        )
 
     timeline = [
         MemoryItem(

--- a/docs/user-guide/memory-basics.md
+++ b/docs/user-guide/memory-basics.md
@@ -99,7 +99,7 @@ cd apps/negentropy && uv sync --extra pii-presidio
 | 页面 | 路径 | 核心功能 |
 |---|---|---|
 | Dashboard | `/memory` | 8 项指标概览（含 Avg Importance / High Importance）+ Retrieval Metrics 折叠面板 |
-| Timeline | `/memory/timeline` | 按时间倒序的卡片，含 retention 红绿灯 + 用户筛选 + 搜索 |
+| Timeline | `/memory/timeline` | 按时间分组的卡片，含双评分条（retention + importance）+ 记忆类型标识 + 用户筛选 + 搜索 |
 | Facts | `/memory/facts` | 结构化事实表，支持 History 版本链查看 + 搜索 |
 | Audit | `/memory/audit` | 审计历史 + retain/delete/anonymize 决策 |
 | Conflicts | `/memory/conflicts` | 事实冲突检视与手动解决（pending → supersede/keep_old/keep_new/merge）|
@@ -112,6 +112,21 @@ cd apps/negentropy && uv sync --extra pii-presidio
 - 🟢 ≥ 50%：健康
 - 🟠 ≥ 10%：将衰减
 - 🔴 < 10%：候选清理（自动化任务会处理）
+
+### Timeline 卡片视觉指南
+
+每张记忆卡片展示以下信息层次：
+
+1. **记忆类型标识**（顶部左侧）：彩色 pill badge 区分 6 种记忆类型，颜色与 §2 衰减率表格对应——Core (violet)、Semantic (blue)、Episodic (amber)、Procedural (green)、Preference (pink)、Fact (cyan)
+2. **双评分条**（顶部右侧）：
+   - **Retention**（Ret）：时间衰减指标，颜色逻辑同红绿灯（绿/琥珀/红）
+   - **Importance**（Imp）：权重指标，blue ≥70% / cyan 40-70% / slate <40%
+3. **内容区**（中部）：默认展示前 150 字符，超长内容可点击"展开全文"查看完整内容
+4. **元数据底栏**（底部）：访问次数、上次访问相对时间、创建日期
+
+时间线按日期分组（Today / Yesterday / 具体日期），便于定位特定时段的记忆。
+
+> 参考文献：Park et al. (2023) importance/recency/relevance 三维评分；Zep (2025) 时间分组与双时间戳；Hu et al. (2026) factual/experiential/working 记忆分类法。
 
 ### PII 锁标
 - 🔒 表示 metadata.pii_flags 命中（regex 级，仅提示，不阻断）


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Memory Timeline 页面卡片信息密度低，缺少记忆类型标识与 importance 评分可视化；用户侧边栏仅显示 user_id 无法辨识用户身份
- 关联上下文/文档：`memory-basics.md` §Timeline 视觉指南

# 核心变更
- **新增 `MemoryTimelineCard` 组件**：支持 7 种记忆类型的彩色 pill badge（icon + 颜色与衰减率表对应）、retention + importance 双评分进度条、内容超长折叠/展开、元数据底栏（访问次数 / 相对时间 / 创建日期）
- **时间线按日期分组**（Today / Yesterday / 具体日期），`sticky` 日期头随滚动固定
- **后端 `list_memories` API** 新增 `_resolve_user_profiles` 批量查询 UserState.profile，返回 name / picture / email / count；前端侧边栏改用 `UserAvatar` + 显示名称 + memory 计数
- **Legend 侧边栏**新增 Importance 与 Memory Types 色彩说明
- 修复 `groupByDate` 时区偏差：改用本地日期计算 Today/Yesterday，与卡片底栏 `toLocaleDateString` 一致
- 修复内容截断可能拆分 emoji surrogate pair 的问题

# 风险与回滚
- 主要风险：`_resolve_user_profiles` 新增一次独立 DB 查询，用户量大时有性能影响（当前用户量可控）
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无新增
- 集成测试：无新增
- E2E/Workflow：手动浏览器验证
- 覆盖率/关键截图：无

# 影响范围
- 前端：`page.tsx` 重构、新增 `MemoryTimelineCard` 组件、`memory-api.ts` 类型扩展
- 后端：`api.py` 用户信息扩展
- 文档：`memory-basics.md` 更新 Timeline 视觉指南

# Next Best Action
- 为 `_resolve_user_profiles` 添加缓存层，避免每次请求重复查询用户 profile
- 考虑为 Timeline 卡片添加骨架屏（Skeleton）加载态