### PR TITLE
fix(pipeline): 注册看门狗定时任务收敛卡死的 CANCELLING/RUNNING 状态

### DIFF
--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -465,6 +465,28 @@ def apply_adk_patches():
 
                 scheduler = AsyncScheduler(poll_interval=DEFAULT_TICK_SECONDS)
                 register_skill_scheduler(scheduler)
+
+                # --- watchdog: finalize stale KG/KB pipeline runs ---
+                # cancelling 超 5min 未收敛 → cancelled; running 超 30min → failed
+                async def _pipeline_watchdog_tick() -> None:
+                    from negentropy.knowledge.dao import KnowledgeRunDao
+
+                    dao = KnowledgeRunDao()
+                    result = await dao.finalize_stale_pipeline_runs()
+                    if result["forced_failed"] > 0 or result["forced_cancelled"] > 0:
+                        logger.info(
+                            "pipeline_watchdog_finalized",
+                            forced_failed=result["forced_failed"],
+                            forced_cancelled=result["forced_cancelled"],
+                        )
+
+                scheduler.register(
+                    key="pipeline_run_watchdog",
+                    callback=_pipeline_watchdog_tick,
+                    interval_seconds=300,
+                )
+                # --- end watchdog ---
+
                 scheduler.start()
                 # 把 scheduler 挂在 app.state 防止被 GC + 便于单测/shutdown 引用
                 app.state.skill_scheduler = scheduler


### PR DESCRIPTION
## Summary

- KG 构建任务卡在 `CANCELLING` 状态无法终止的根因：`finalize_stale_pipeline_runs()` 看门狗函数已存在但从未被任何定时任务调用
- 在现有 `AsyncScheduler` 中注册 `pipeline_run_watchdog` 定时任务，每 5 分钟扫描并收敛卡死的 pipeline run：
  - `cancelling` 超 5 分钟 → `cancelled`
  - `running` 超 30 分钟 → `failed`

## 根因分析

当以下场景发生时，run 会永远停留在中间态：
1. Worker 进程在取消过程中崩溃
2. Worker 重启导致 in-memory `asyncio.Event` 丢失
3. 长时间运行的 stage 阻止 DB 轮询检查
4. 取消过程中途异常导致 `cancel()` 未完成落盘

## 改动范围

仅修改 `bootstrap.py`（+22 行），复用现有 `AsyncScheduler` + `KnowledgeRunDao.finalize_stale_pipeline_runs()`，无新文件、无新依赖。

## Test plan

- [ ] 启动服务后检查日志 `skill_scheduler_started` 中包含 `pipeline_run_watchdog`
- [ ] 复现卡住场景，等待 5-10 分钟后观察 run 是否自动收敛为 `cancelled`
- [ ] 确认 `running` 状态超过 30 分钟的 run 也被标记为 `failed`

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)