### PR TITLE
fix(knowledge-graph): 修复 KG Build Run 更新时 json/jsonb 类型不匹配导致 COALESCE 报错

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -1801,8 +1801,8 @@ class AgeGraphRepository(GraphRepository):
                 relation_count = :relation_count,
                 error_message = :error_message,
                 progress_percent = COALESCE(:progress, progress_percent),
-                warnings = COALESCE(CAST(:warnings AS jsonb), warnings),
-                processed_chunk_ids = COALESCE(CAST(:chunk_ids AS jsonb), processed_chunk_ids),
+                warnings = COALESCE(CAST(:warnings AS json), warnings),
+                processed_chunk_ids = COALESCE(CAST(:chunk_ids AS json), processed_chunk_ids),
                 completed_at = CASE WHEN :status IN ('completed', 'failed', 'cancelled') THEN NOW() END
             WHERE id = :run_id
         """)
@@ -2083,7 +2083,7 @@ class AgeGraphRepository(GraphRepository):
             update_stmt = text(f"""
                 UPDATE {self._schema}.kg_build_runs
                 SET status = :status,
-                    warnings = CAST(:warnings AS jsonb),
+                    warnings = CAST(:warnings AS json),
                     completed_at = NOW()
                 WHERE id = :id
             """)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge Graph 构建流程在更新 `kg_build_runs` 表时，PostgreSQL 抛出 `CannotCoerceError: COALESCE could not convert type json to jsonb` 错误，导致构建进度无法正常更新。
- 关联上下文：数据库迁移 0016/0017 使用 `sa.JSON()` 创建 `warnings` 和 `processed_chunk_ids` 列（PostgreSQL `json` 类型），但 SQL 查询中将参数 CAST 为 `jsonb`，两者在 `COALESCE` 中无法隐式转换。

# 核心变更
- 将 `repository.py` 中 3 处 `CAST(... AS jsonb)` 改为 `CAST(... AS json)`，与数据库实际列类型对齐
- 涉及 `update_build_run` 方法的 COALESCE 语句（2 处）和取消流程的直接赋值（1 处）

# 风险与回滚
- 主要风险：无，仅修正类型声明与实际列类型的一致性
- 回滚方式：`git revert`

# 验证证据
- 单元测试：已有 pre-commit hook（ruff lint/format）通过
- 集成测试：需启动后端触发 KG 构建，确认日志无 `CannotCoerceError`，进度正常递增
- E2E/Workflow：验证构建完成、取消构建两条路径的 warnings 持久化正常

# 影响范围
- 前端：无
- 后端：`knowledge/graph/repository.py` 中 `update_build_run` 和取消构建的 SQL 语句
- GitHub Actions / 文档：无

# Next Best Action
- 在本地启动后端服务，触发一次 KG 构建验证修复效果