### PR TITLE
fix(knowledge-graph): 修复 KG Build Run 更新时 status 参数 text/varchar 类型推断冲突

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -1803,7 +1803,7 @@ class AgeGraphRepository(GraphRepository):
                 progress_percent = COALESCE(:progress, progress_percent),
                 warnings = COALESCE(CAST(:warnings AS json), warnings),
                 processed_chunk_ids = COALESCE(CAST(:chunk_ids AS json), processed_chunk_ids),
-                completed_at = CASE WHEN :status_check IN ('completed', 'failed', 'cancelled') THEN NOW() END
+                completed_at = CASE WHEN CAST(:status AS varchar) IN ('completed', 'failed', 'cancelled') THEN NOW() END
             WHERE id = :run_id
         """)
 
@@ -1813,7 +1813,6 @@ class AgeGraphRepository(GraphRepository):
                 {
                     "run_id": str(run_id),
                     "status": status,
-                    "status_check": status,
                     "entity_count": entity_count,
                     "relation_count": relation_count,
                     "error_message": error_message,

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -1803,7 +1803,7 @@ class AgeGraphRepository(GraphRepository):
                 progress_percent = COALESCE(:progress, progress_percent),
                 warnings = COALESCE(CAST(:warnings AS json), warnings),
                 processed_chunk_ids = COALESCE(CAST(:chunk_ids AS json), processed_chunk_ids),
-                completed_at = CASE WHEN :status IN ('completed', 'failed', 'cancelled') THEN NOW() END
+                completed_at = CASE WHEN :status_check IN ('completed', 'failed', 'cancelled') THEN NOW() END
             WHERE id = :run_id
         """)
 
@@ -1813,6 +1813,7 @@ class AgeGraphRepository(GraphRepository):
                 {
                     "run_id": str(run_id),
                     "status": status,
+                    "status_check": status,
                     "entity_count": entity_count,
                     "relation_count": relation_count,
                     "error_message": error_message,


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：对 Corpus 构建 Knowledge Graph 时，`update_build_run` SQL 报 `AmbiguousParameterError: inconsistent types deduced for parameter $1 — text versus character varying`，导致构建流程中断
- 关联上下文：与 commit `2393f904`（json/jsonb 类型不匹配）属同类问题——asyncpg 参数类型推断冲突

# 核心变更
- `repository.py` 的 `update_build_run` SQL 中，`:status` 参数被复用于 `SET status = :status`（推断为 VARCHAR）和 `CASE WHEN :status IN (...)`（推断为 TEXT），asyncpg 无法统一两种推断
- 修复：在 CASE WHEN 中对 `:status` 添加 `CAST(:status AS varchar)` 显式类型转换，消除歧义，与已有的 `CAST(:warnings AS json)` 模式一致

# 风险与回滚
- 主要风险：极低，仅增加显式类型转换，不改变逻辑语义
- 回滚方式：`git revert`

# 验证证据
- 单元测试：N/A（SQL 参数类型转换，无新增逻辑）
- 集成测试：重启服务后对 "Harness Engineering" Corpus 触发 KG Build，确认不再报 `AmbiguousParameterError`

# 影响范围
- 前端：无
- 后端：`knowledge/graph/repository.py` 的 `update_build_run` 方法
- GitHub Actions / 文档：无

# Next Best Action
- 在浏览器中对 "Harness Engineering" Corpus 重新触发 KG Build，验证完整构建流程成功