### PR TITLE
fix(knowledge-graph): 首次进入 Knowledge Graph 页自动选中第一个 Corpus;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CorpusRecord, fetchCorpora } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -13,12 +13,19 @@ interface CorpusSelectorProps {
 export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
   const [corpora, setCorpora] = useState<CorpusRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const autoSelected = useRef(false);
 
   useEffect(() => {
     let mounted = true;
     fetchCorpora(APP_NAME)
       .then((data) => {
-        if (mounted) setCorpora(data);
+        if (mounted) {
+          setCorpora(data);
+          if (!autoSelected.current && data.length > 0) {
+            autoSelected.current = true;
+            onChange(data[0].id);
+          }
+        }
       })
       .catch(console.error)
       .finally(() => {
@@ -27,7 +34,7 @@ export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [onChange]);
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
@@ -13,7 +13,7 @@ interface CorpusSelectorProps {
 export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
   const [corpora, setCorpora] = useState<CorpusRecord[]>([]);
   const [loading, setLoading] = useState(true);
-  const autoSelected = useRef(false);
+  const autoSelected = useRef(!!value);
 
   useEffect(() => {
     let mounted = true;


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：首次进入 Knowledge Graph 页面时，语料库下拉框为空状态，需手动选择才能开始操作，体验不够流畅。
- 关联上下文/Issue/文档：无

# 核心变更
- `CorpusSelector` 组件在加载语料库列表后，自动选中第一个 Corpus 并触发图谱加载
- 使用 `useRef` (`autoSelected`) 防止重复触发自动选中，ref 初始值基于已有 `value` 判断（`!!value`），避免覆盖已选中的值
- 将 `useEffect` 依赖从 `[]` 改为 `[onChange]`，满足 `react-hooks/exhaustive-deps` 规则；父组件传入的 `setCorpusId` 是稳定引用，effect 实际仅执行一次

# 风险与回滚
- 主要风险：无。自动选中仅在 `value` 为 `null` 时触发，已有选中值时不生效
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无
- 集成测试：无
- E2E/Workflow：无
- 覆盖率/关键截图：ESLint 通过（`react-hooks/exhaustive-deps` 无警告）

# 影响范围
- 前端：`CorpusSelector` 组件（Knowledge Graph 页面）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 可考虑为 `corpusId` 增加 URL 参数持久化（如 `?corpus=xxx`），支持刷新后恢复选中状态