### PR TITLE
fix(knowledge-graph): KG Build Progress SSE → HTTP Polling + 注册 KG Build Run 看门狗

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/route.ts
@@ -1,0 +1,12 @@
+import { proxyGet } from "../../../../../_proxy";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ corpusId: string }> },
+) {
+  const { corpusId } = await context.params;
+  return proxyGet(
+    request,
+    `/knowledge/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest`,
+  );
+}

--- a/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
+++ b/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
@@ -4,19 +4,19 @@
  * KgBuildProgressPill · P3-1 G1c
  *
  * 论文采集 ingest_paper 完成后，后端 paper_kg_pipeline.enqueue_kg_build 启动 fire-and-forget
- * KG 构建任务。本组件订阅
- *   GET /api/knowledge/base/{corpusId}/graph/build-runs/latest/progress
- * SSE 端点，把 progress_percent / status / 实体 + 关系数 实时显示在 ToolExecutionGroup 内
+ * KG 构建任务。本组件轮询
+ *   GET /api/knowledge/base/{corpusId}/graph/build-runs/latest
+ * REST 端点，把 progress_percent / status / 实体 + 关系数 实时显示在 ToolExecutionGroup 内
  * 工具卡片下方。
  *
  * 设计原则：
- * - **轻量旁路**：组件仅读 `corpusId` + `enqueued`，自己管理 EventSource 生命周期；
+ * - **轮询替代 SSE**：使用递归 setTimeout + fetch 替代 EventSource，消除长连接超时问题；
+ *   瞬态网络故障通过指数退避自动恢复，连续失败 10 次才显示 "无法订阅"。
+ * - **轻量旁路**：组件仅读 `corpusId` + `enqueued`，自己管理轮询生命周期；
  *   不参与 message-ledger / 双气泡守卫（与 Tool Progress 同模式）。
- * - **失败软退化**：连接失败 → 显示 "无法订阅" 文案 + retry button；
- *   终态（completed / failed / idle / timeout）自动 close。
+ * - **失败软退化**：连接失败 → 显示 "无法订阅" 文案；
+ *   终态（completed / failed / idle / timeout）自动停止轮询。
  * - **零回归**：父组件传入的 enqueued=false 时此组件返回 null，对旧 message 无影响。
- *
- * 参考：HTML Living Standard EventSource，Patil et al. ICSE 2026 latency-aware progress disclosure。
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -40,7 +40,7 @@ export type KgBuildProgressEvent = {
   completed_at?: string | null;
   /**
    * 子阶段标签（仅 status=running 时存在）。后端 service.emit_phase 写入 warnings JSONB
-   * 的最后一条 _phase 条目，SSE 端点透传。可选枚举：
+   * 的最后一条 _phase 条目，REST 端点透传。可选枚举：
    * extracting / resolving / syncing / pagerank / communities / summaries
    */
   phase?: string | null;
@@ -55,7 +55,7 @@ type Props = {
   /** 可选：传入 BFF base path（默认 /api/knowledge），便于测试覆盖 */
   apiBase?: string;
   /**
-   * SSE 终态回调：在 status 进入 completed/failed/timeout/idle/switched/error 时触发，
+   * 终态回调：在 status 进入 completed/failed/timeout/idle/switched/error 时触发，
    * 让父组件解除 Pill 的"在飞"标志（与 POST 在飞状态解耦）。回调延迟 ~4s 触发，
    * 留出展示终态的时间窗口；父组件需自行幂等处理重复触发。
    */
@@ -64,6 +64,18 @@ type Props = {
 
 /** 终态展示窗口（ms）：留给用户看清"已完成 / 失败"信息后再让父组件解除挂载 */
 const TERMINAL_DISPLAY_HOLD_MS = 4000;
+
+/** 正常轮询间隔 */
+const POLL_INTERVAL_MS = 3000;
+
+/** 退避基数（ms） */
+const BACKOFF_BASE_MS = 3000;
+
+/** 退避上限（ms） */
+const BACKOFF_MAX_MS = 10000;
+
+/** 连续失败上限，超过后显示错误 */
+const MAX_CONSECUTIVE_ERRORS = 10;
 
 const STATUS_LABEL: Record<NonNullable<KgBuildProgressEvent["status"]>, string> = {
   pending: "排队中",
@@ -109,7 +121,6 @@ export function KgBuildProgressPill({
   const [event, setEvent] = useState<KgBuildProgressEvent | null>(
     enqueued ? { status: "pending", progress_percent: 0 } : null,
   );
-  const sourceRef = useRef<EventSource | null>(null);
   const terminalTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // 闭包稳定化：onTerminal 由父组件每次渲染重新创建（如箭头函数），用 ref 持有最新值，
   // 避免 useEffect 依赖膨胀导致不必要的重订阅。
@@ -120,22 +131,23 @@ export function KgBuildProgressPill({
 
   useEffect(() => {
     if (!enqueued || !corpusId) {
-      sourceRef.current?.close();
-      sourceRef.current = null;
       if (terminalTimerRef.current) {
         clearTimeout(terminalTimerRef.current);
         terminalTimerRef.current = null;
       }
       return;
     }
-    if (typeof window === "undefined" || typeof EventSource === "undefined") return;
+    if (typeof window === "undefined") return;
 
-    const url = `${apiBase}/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest/progress`;
-    const es = new EventSource(url, { withCredentials: true });
-    sourceRef.current = es;
+    const url = `${apiBase}/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest`;
+    const controller = new AbortController();
+    let cancelled = false;
+    let consecutiveErrors = 0;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    // 跟踪首次见到的 run_id，过滤掉旧 run 的终态（与 SSE 端点 run_id 锁定逻辑一致）
+    let seenRunId: string | null = null;
 
     const scheduleTerminalCallback = (payload: KgBuildProgressEvent) => {
-      // 延迟通知父组件，确保用户能看到 ~4s 的终态展示后再卸载 Pill。
       if (terminalTimerRef.current) clearTimeout(terminalTimerRef.current);
       terminalTimerRef.current = setTimeout(() => {
         terminalTimerRef.current = null;
@@ -143,30 +155,81 @@ export function KgBuildProgressPill({
       }, TERMINAL_DISPLAY_HOLD_MS);
     };
 
-    es.onmessage = (msg) => {
-      try {
-        const payload = JSON.parse(msg.data) as KgBuildProgressEvent;
-        setEvent(payload);
-        if (isTerminal(payload.status)) {
-          es.close();
-          sourceRef.current = null;
-          scheduleTerminalCallback(payload);
-        }
-      } catch {
-        // fail-soft：忽略不可解析的 event
-      }
-    };
-    es.onerror = () => {
-      // 网络中断 → 停止订阅并显示 error 状态
-      setEvent((prev) => (prev?.status && isTerminal(prev.status) ? prev : { status: "error" }));
-      es.close();
-      sourceRef.current = null;
-      scheduleTerminalCallback({ status: "error" });
+    const stop = (terminalPayload: KgBuildProgressEvent) => {
+      setEvent(terminalPayload);
+      scheduleTerminalCallback(terminalPayload);
     };
 
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const res = await fetch(url, {
+          credentials: "include",
+          signal: controller.signal,
+          cache: "no-store",
+        });
+        if (cancelled) return;
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const payload = (await res.json()) as KgBuildProgressEvent;
+        consecutiveErrors = 0;
+
+        // run_id 锁定：首次记录见到的 run_id，后续若 run_id 变化且新 run 处于终态
+        // （旧 run 已完成），继续轮询等待新 run 的活跃状态
+        if (payload.run_id && seenRunId === null) {
+          seenRunId = payload.run_id;
+        }
+        if (
+          payload.run_id &&
+          seenRunId !== null &&
+          payload.run_id !== seenRunId
+        ) {
+          if (!isTerminal(payload.status)) {
+            // 切换到新 run
+            seenRunId = payload.run_id;
+          } else {
+            // 旧 run 终态是正常的，新 run 终态说明还没开始，继续轮询
+            const delay = POLL_INTERVAL_MS;
+            timeoutId = setTimeout(poll, delay);
+            return;
+          }
+        }
+
+        if (isTerminal(payload.status)) {
+          stop(payload); // 终态：写入 state + 调度延迟终态回调，停止轮询
+          return;
+        }
+        setEvent(payload);
+      } catch {
+        if (cancelled || controller.signal.aborted) return;
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+          // 持续失败，显示错误
+          setEvent((prev) =>
+            prev?.status && isTerminal(prev.status) ? prev : { status: "error" },
+          );
+          scheduleTerminalCallback({ status: "error" });
+          return;
+        }
+      }
+
+      // 调度下次轮询：正常 3s，失败时指数退避
+      const backoff =
+        consecutiveErrors > 0
+          ? Math.min(
+              BACKOFF_BASE_MS * Math.pow(1.5, consecutiveErrors - 1),
+              BACKOFF_MAX_MS,
+            )
+          : POLL_INTERVAL_MS;
+      timeoutId = setTimeout(poll, backoff);
+    };
+
+    // 首次轮询立即发起
+    poll();
+
     return () => {
-      es.close();
-      sourceRef.current = null;
+      cancelled = true;
+      controller.abort();
+      if (timeoutId) clearTimeout(timeoutId);
       if (terminalTimerRef.current) {
         clearTimeout(terminalTimerRef.current);
         terminalTimerRef.current = null;

--- a/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
+++ b/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
@@ -12,6 +12,9 @@
  * 设计原则：
  * - **轮询替代 SSE**：使用递归 setTimeout + fetch 替代 EventSource，消除长连接超时问题；
  *   瞬态网络故障通过指数退避自动恢复，连续失败 10 次才显示 "无法订阅"。
+ * - **发现期 grace**：挂载后 10s 内尚未拿到 run_id 时，使用 `?only_active=true` 让后端过滤
+ *   历史 completed/failed run；超出 grace 才接受 idle/历史终态收口。与 SSE 端点的发现期
+ *   `no_active_grace_seconds=10` 等价，规避 `enqueue_kg_build` fire-and-forget 引入的写入竞态。
  * - **轻量旁路**：组件仅读 `corpusId` + `enqueued`，自己管理轮询生命周期；
  *   不参与 message-ledger / 双气泡守卫（与 Tool Progress 同模式）。
  * - **失败软退化**：连接失败 → 显示 "无法订阅" 文案；
@@ -77,6 +80,18 @@ const BACKOFF_MAX_MS = 10000;
 /** 连续失败上限，超过后显示错误 */
 const MAX_CONSECUTIVE_ERRORS = 10;
 
+/**
+ * 发现期 grace 窗口（ms）：与 SSE 端点 `no_active_grace_seconds=10` 等价。
+ *
+ * 设计动机：`enqueue_kg_build` 是 `asyncio.create_task` fire-and-forget，
+ * `ingest_paper` 返回 `kg_enqueued` 时后台尚未走到 `GraphService.create_build_run`
+ * 的插入点。此时若直接用 `only_active=false` 轮询，会拿到该 corpus 历史上一条
+ * completed/failed run 误判为新 run 的终态。本组件在该窗口内统一使用 `only_active=true`
+ * 等待新 run 出现；超过窗口仍未见到活跃 run 才放下守护切回 `only_active=false`，
+ * 让真实终态（historic 或 idle）收口。
+ */
+const DISCOVERY_GRACE_MS = 10_000;
+
 const STATUS_LABEL: Record<NonNullable<KgBuildProgressEvent["status"]>, string> = {
   pending: "排队中",
   running: "构建中",
@@ -139,12 +154,13 @@ export function KgBuildProgressPill({
     }
     if (typeof window === "undefined") return;
 
-    const url = `${apiBase}/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest`;
+    const baseUrl = `${apiBase}/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest`;
     const controller = new AbortController();
+    const mountedAt = Date.now();
     let cancelled = false;
     let consecutiveErrors = 0;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    // 跟踪首次见到的 run_id，过滤掉旧 run 的终态（与 SSE 端点 run_id 锁定逻辑一致）
+    // 跟踪首次见到的 run_id，避免历史 run 的终态被误判（与 SSE 端点 run_id 锁定逻辑一致）。
     let seenRunId: string | null = null;
 
     const scheduleTerminalCallback = (payload: KgBuildProgressEvent) => {
@@ -160,10 +176,21 @@ export function KgBuildProgressPill({
       scheduleTerminalCallback(terminalPayload);
     };
 
+    /**
+     * 发现期：尚未锁定 run_id 且未超过 grace 窗口时，使用 only_active=true 让后端过滤掉
+     * 历史 completed/failed run。后端在该参数下无活跃 run 会返回 status=pending，让客户端
+     * 继续轮询而非误判为终态。超出 grace 后切回普通查询，由后端返回真实终态（idle 或历史 run）。
+     */
+    const buildUrl = (): string => {
+      const inDiscovery =
+        seenRunId === null && Date.now() - mountedAt < DISCOVERY_GRACE_MS;
+      return inDiscovery ? `${baseUrl}?only_active=true` : baseUrl;
+    };
+
     const poll = async () => {
       if (cancelled) return;
       try {
-        const res = await fetch(url, {
+        const res = await fetch(buildUrl(), {
           credentials: "include",
           signal: controller.signal,
           cache: "no-store",
@@ -173,25 +200,11 @@ export function KgBuildProgressPill({
         const payload = (await res.json()) as KgBuildProgressEvent;
         consecutiveErrors = 0;
 
-        // run_id 锁定：首次记录见到的 run_id，后续若 run_id 变化且新 run 处于终态
-        // （旧 run 已完成），继续轮询等待新 run 的活跃状态
-        if (payload.run_id && seenRunId === null) {
+        // run_id 锁定（或刷新到新 run）：拿到带 run_id 的 payload 即更新 seenRunId，
+        // 随后由统一的 isTerminal 收口。若新 run 已是终态（罕见的极速完成）也会被正确终结，
+        // 避免“旧锁定 + 新终态”分支死循环。
+        if (payload.run_id) {
           seenRunId = payload.run_id;
-        }
-        if (
-          payload.run_id &&
-          seenRunId !== null &&
-          payload.run_id !== seenRunId
-        ) {
-          if (!isTerminal(payload.status)) {
-            // 切换到新 run
-            seenRunId = payload.run_id;
-          } else {
-            // 旧 run 终态是正常的，新 run 终态说明还没开始，继续轮询
-            const delay = POLL_INTERVAL_MS;
-            timeoutId = setTimeout(poll, delay);
-            return;
-          }
         }
 
         if (isTerminal(payload.status)) {

--- a/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
@@ -6,14 +6,23 @@
  * - 轮询 REST 端点后渲染百分比 + 状态标签；
  * - 收到 terminal 状态后自动停止轮询；
  * - 网络瞬态故障通过指数退避自动恢复；
- * - 连续失败 10 次后显示 error 状态。
+ * - 连续失败 10 次后显示 error 状态；
+ * - 发现期使用 only_active=true 规避 enqueue 写入竞态（与 SSE 端点 grace 等价）；
+ * - 已锁定 run_id 后切到不带 only_active；超 grace 窗口后亦切换；
+ * - 已锁定 run_id 收到新 run_id 的终态时正确收口，不死循环。
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { KgBuildProgressPill } from "@/components/ui/KgBuildProgressPill";
 
-const POLL_URL_RE = /\/api\/knowledge\/base\/[^/]+\/graph\/build-runs\/latest$/;
+// 允许尾随 query string（发现期会附加 ?only_active=true）
+const POLL_URL_RE = /\/api\/knowledge\/base\/[^/]+\/graph\/build-runs\/latest(\?[^#]*)?$/;
+
+// 与组件内 POLL_INTERVAL_MS 保持一致；测试用例中使用而避免硬编码魔法数字。
+// （DISCOVERY_GRACE_MS 在测试中通过“逐轮推进 N 次 > 10s / POLL_INTERVAL”表达，
+//  不直接耦合常量值，避免组件内 grace 调整时测试失败。）
+const POLL_INTERVAL_MS_VALUE = 3000;
 
 function jsonRes(data: unknown, ok = true, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -280,6 +289,125 @@ describe("KgBuildProgressPill", () => {
       unmount();
       act(() => { vi.advanceTimersByTime(4000); });
       expect(onTerminal).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // 发现期 grace（与 SSE 端点 no_active_grace_seconds=10 等价）回归覆盖
+  // 防止 enqueue_kg_build fire-and-forget 写入 build_run 行前误读历史 run。
+  // ──────────────────────────────────────────────────────────────────
+
+  it("发现期内首轮使用 only_active=true 查询", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonRes({ status: "pending", corpus_id: "abc" }),
+    );
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    await act(async () => {});
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toMatch(/only_active=true/);
+    // 后端在 only_active=true 下回 pending 不应被当作终态
+    expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+      "data-kg-status",
+      "pending",
+    );
+  });
+
+  it("锁定 run_id 后切到不带 only_active 的查询", async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonRes({ status: "running", progress_percent: 0.2, run_id: "r1" }),
+        )
+        .mockResolvedValueOnce(
+          jsonRes({ status: "running", progress_percent: 0.5, run_id: "r1" }),
+        );
+      render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+      // 首轮：发现期 only_active=true
+      await act(async () => {});
+      expect(mockFetch.mock.calls[0][0]).toMatch(/only_active=true/);
+      // 推进 3s 触发下一轮：已锁定 run_id，不应再带 only_active
+      act(() => vi.advanceTimersByTime(POLL_INTERVAL_MS_VALUE + 50));
+      await act(async () => {});
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1][0]).not.toMatch(/only_active=true/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("超出发现期 grace 窗口后切到不带 only_active", async () => {
+    vi.useFakeTimers();
+    try {
+      // 持续返回不带 run_id 的 pending：模拟新 run 行迟迟未落库
+      mockFetch.mockResolvedValue(jsonRes({ status: "pending" }));
+      render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+      await act(async () => {});
+      expect(mockFetch.mock.calls[0][0]).toMatch(/only_active=true/);
+      // 逐轮推进：每轮 POLL_INTERVAL_MS=3s 间隔一次 fetch；
+      // 跨过 DISCOVERY_GRACE_MS=10s 至少需要 4 轮（t=3,6,9,12s），此处推进 5 轮以保险。
+      for (let i = 0; i < 5; i++) {
+        act(() => vi.advanceTimersByTime(POLL_INTERVAL_MS_VALUE + 50));
+        await act(async () => {});
+      }
+      // 最后一次 fetch 调用必然在 t≈15s+，发现期已过 → URL 不再带 only_active
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1][0];
+      expect(lastCall).not.toMatch(/only_active=true/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("已锁定 run_id 收到新 run_id 的终态时正确收口（不死循环）", async () => {
+    vi.useFakeTimers();
+    try {
+      const onTerminal = vi.fn();
+      mockFetch
+        // 首轮：锁定 run_id=A 的 running
+        .mockResolvedValueOnce(
+          jsonRes({ status: "running", progress_percent: 0.3, run_id: "A" }),
+        )
+        // 次轮：返回完全不同 run_id=B 且已是终态（极端竞态：A 结束 → B 极速失败）
+        .mockResolvedValueOnce(
+          jsonRes({
+            status: "failed",
+            error_message: "extractor crashed",
+            run_id: "B",
+          }),
+        );
+      render(
+        <KgBuildProgressPill
+          corpusId="abc"
+          enqueued={true}
+          onTerminal={onTerminal}
+        />,
+      );
+      // 首轮：锁定 A
+      await act(async () => {});
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "running",
+      );
+      // 次轮：B 终态 → 必须 stop，不能继续轮询
+      act(() => vi.advanceTimersByTime(POLL_INTERVAL_MS_VALUE + 50));
+      await act(async () => {});
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "failed",
+      );
+      expect(screen.getByTestId("kg-build-progress")).toHaveTextContent(
+        "extractor crashed",
+      );
+      // 推进 onTerminal 延迟窗口 + 远超下一轮间隔：fetch 不应被再次调用
+      act(() => vi.advanceTimersByTime(15000));
+      await act(async () => {});
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(onTerminal).toHaveBeenCalledTimes(1);
+      expect(onTerminal).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "failed", run_id: "B" }),
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
@@ -3,170 +3,255 @@
  *
  * 验证：
  * - enqueued=false 或 corpusId=null 时返回 null（零回归）；
- * - 订阅 SSE 后渲染百分比 + 状态标签；
- * - 收到 terminal 状态后自动 close EventSource；
- * - onerror 时显示 error 状态。
+ * - 轮询 REST 端点后渲染百分比 + 状态标签；
+ * - 收到 terminal 状态后自动停止轮询；
+ * - 网络瞬态故障通过指数退避自动恢复；
+ * - 连续失败 10 次后显示 error 状态。
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { KgBuildProgressPill } from "@/components/ui/KgBuildProgressPill";
 
-class MockEventSource {
-  static instances: MockEventSource[] = [];
-  url: string;
-  withCredentials: boolean;
-  onmessage: ((e: MessageEvent) => void) | null = null;
-  onerror: ((e: Event) => void) | null = null;
-  onopen: ((e: Event) => void) | null = null;
-  closed = false;
+const POLL_URL_RE = /\/api\/knowledge\/base\/[^/]+\/graph\/build-runs\/latest$/;
 
-  constructor(url: string, init?: { withCredentials?: boolean }) {
-    this.url = url;
-    this.withCredentials = init?.withCredentials ?? false;
-    MockEventSource.instances.push(this);
-  }
-
-  close() {
-    this.closed = true;
-  }
-
-  send(data: unknown) {
-    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
-  }
-  fail() {
-    this.onerror?.(new Event("error"));
-  }
+function jsonRes(data: unknown, ok = true, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: { "content-type": "application/json" },
+  });
 }
 
 describe("KgBuildProgressPill", () => {
-  let originalES: typeof EventSource;
+  let mockFetch: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    MockEventSource.instances = [];
-    originalES = global.EventSource;
-    // @ts-expect-error - assign mock in test env
-    global.EventSource = MockEventSource;
+    mockFetch = vi.fn().mockResolvedValue(jsonRes({ status: "idle" }));
+    vi.stubGlobal("fetch", mockFetch);
   });
 
   afterEach(() => {
-    global.EventSource = originalES;
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("enqueued=false 时返回 null（零回归保护）", () => {
-    const { container } = render(<KgBuildProgressPill corpusId="c-123" enqueued={false} />);
+    const { container } = render(
+      <KgBuildProgressPill corpusId="c-123" enqueued={false} />,
+    );
     expect(container).toBeEmptyDOMElement();
-    expect(MockEventSource.instances).toHaveLength(0);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("corpusId 缺失时不订阅", () => {
+  it("corpusId 缺失时不发起轮询", () => {
     render(<KgBuildProgressPill corpusId={null} enqueued={true} />);
-    expect(MockEventSource.instances).toHaveLength(0);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("enqueued=true 时订阅 SSE 并渲染初始 pending 状态", () => {
+  it("enqueued=true 时首次轮询并渲染初始 pending 状态", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonRes({ status: "pending", progress_percent: 0 }),
+    );
     render(<KgBuildProgressPill corpusId="abc-123" enqueued={true} />);
-    const pill = screen.getByTestId("kg-build-progress");
-    expect(pill).toHaveAttribute("data-kg-status", "pending");
-    expect(pill).toHaveTextContent("排队中");
-    expect(MockEventSource.instances).toHaveLength(1);
-    expect(MockEventSource.instances[0].url).toContain("/api/knowledge/base/abc-123/graph/build-runs/latest/progress");
-    expect(MockEventSource.instances[0].withCredentials).toBe(true);
+    // 初始 state 为 pending
+    expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+      "data-kg-status",
+      "pending",
+    );
+    await act(async () => {});
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toMatch(POLL_URL_RE);
   });
 
-  it("收到 running 事件后展示百分比 + 实体/关系数", () => {
+  it("收到 running 响应后展示百分比 + 实体/关系数", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonRes({
+        status: "running",
+        progress_percent: 0.62,
+        entity_count: 12,
+        relation_count: 7,
+        run_id: "r1",
+      }),
+    );
     render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
-    act(() => {
-      es.send({ status: "running", progress_percent: 0.62, entity_count: 12, relation_count: 7, run_id: "r1" });
-    });
+    await act(async () => {});
     const pill = screen.getByTestId("kg-build-progress");
     expect(pill).toHaveAttribute("data-kg-status", "running");
     expect(pill).toHaveTextContent("62%");
     expect(pill).toHaveTextContent("12 实体");
     expect(pill).toHaveTextContent("7 关系");
-    expect(es.closed).toBe(false);
   });
 
-  it("收到 completed 终态后自动关闭 EventSource", () => {
-    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
-    act(() => {
-      es.send({ status: "completed", progress_percent: 1, entity_count: 20, relation_count: 15 });
-    });
-    expect(screen.getByTestId("kg-build-progress")).toHaveAttribute("data-kg-status", "completed");
-    expect(es.closed).toBe(true);
+  it("收到 completed 终态后停止轮询", async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockResolvedValueOnce(
+        jsonRes({
+          status: "completed",
+          progress_percent: 1,
+          entity_count: 20,
+          relation_count: 15,
+        }),
+      );
+      render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+      await act(async () => { vi.advanceTimersByTime(0); });
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "completed",
+      );
+      // 推进时间，确认没有再次轮询
+      await act(async () => { vi.advanceTimersByTime(10000); });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("收到 failed 终态展示 error_message", () => {
-    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
-    act(() => {
-      es.send({ status: "failed", error_message: "LLM extractor timeout", progress_percent: 0.3 });
-    });
-    expect(screen.getByTestId("kg-build-progress")).toHaveTextContent("LLM extractor timeout");
-    expect(es.closed).toBe(true);
-  });
-
-  it("idle 状态（无 active run）→ 展示无活跃构建文案", () => {
-    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
-    act(() => {
-      es.send({ status: "idle" });
-    });
-    expect(screen.getByTestId("kg-build-progress")).toHaveTextContent("无活跃构建");
-    expect(es.closed).toBe(true);
-  });
-
-  it("EventSource onerror 时显示 error 状态并关闭", () => {
-    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
-    act(() => {
-      es.fail();
-    });
-    expect(screen.getByTestId("kg-build-progress")).toHaveAttribute("data-kg-status", "error");
-    expect(es.closed).toBe(true);
-  });
-
-  it("非法 JSON event 应 fail-soft 不抛", () => {
-    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
-    expect(() =>
-      act(() => {
-        es.onmessage?.({ data: "not json {" } as MessageEvent);
+  it("收到 failed 终态展示 error_message", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonRes({
+        status: "failed",
+        error_message: "LLM extractor timeout",
+        progress_percent: 0.3,
       }),
-    ).not.toThrow();
+    );
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    await act(async () => {});
+    expect(screen.getByTestId("kg-build-progress")).toHaveTextContent(
+      "LLM extractor timeout",
+    );
   });
 
-  it("组件卸载时关闭 EventSource（资源清理）", () => {
-    const { unmount } = render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
-    const es = MockEventSource.instances[0];
+  it("idle 状态（无 active run）→ 展示无活跃构建文案", async () => {
+    mockFetch.mockResolvedValueOnce(jsonRes({ status: "idle" }));
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    await act(async () => {});
+    expect(screen.getByTestId("kg-build-progress")).toHaveTextContent(
+      "无活跃构建",
+    );
+  });
+
+  it("瞬态网络故障后自动恢复（reject 2 次 → 成功）", async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockRejectedValueOnce(new TypeError("fetch failed"))
+        .mockResolvedValueOnce(
+          jsonRes({
+            status: "running",
+            progress_percent: 0.4,
+            run_id: "r1",
+          }),
+        );
+      render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+      // 第 1 次失败
+      await act(async () => {});
+      // 仍然 pending（初始 state），没有显示错误
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "pending",
+      );
+      // 推进到第 2 次退避（3s * 1.5^0 = 3s）
+      act(() => vi.advanceTimersByTime(4000));
+      await act(async () => {});
+      // 第 3 次：成功
+      act(() => vi.advanceTimersByTime(5000));
+      await act(async () => {});
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "running",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("连续失败 10 次后显示 error 状态并停止轮询", async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+      render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+      // 快速推进，触发 10 次失败
+      for (let i = 0; i < 10; i++) {
+        await act(async () => {});
+        act(() => vi.advanceTimersByTime(15000));
+      }
+      await act(async () => {});
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "error",
+      );
+      expect(screen.getByTestId("kg-build-progress")).toHaveTextContent(
+        "无法订阅",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("HTTP 非 200 响应计入连续失败", async () => {
+    vi.useFakeTimers();
+    try {
+      mockFetch.mockResolvedValueOnce(
+        new Response("bad gateway", { status: 502, statusText: "Bad Gateway" }),
+      );
+      render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+      await act(async () => {});
+      // 1 次非 200 不会显示错误
+      expect(screen.getByTestId("kg-build-progress")).toHaveAttribute(
+        "data-kg-status",
+        "pending",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("组件卸载时取消进行中的 fetch（资源清理）", async () => {
+    mockFetch.mockImplementationOnce(async () => {
+      // 模拟挂起
+      await new Promise(() => {});
+      return jsonRes({});
+    });
+    const { unmount } = render(
+      <KgBuildProgressPill corpusId="abc" enqueued={true} />,
+    );
+    await act(async () => {});
     unmount();
-    expect(es.closed).toBe(true);
+    // fetch 应收到 signal
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
-  it("SSE 终态后通过 onTerminal 通知父组件（解耦 POST 在飞状态）", () => {
-    // 回归保护评审 #2：旧实现 Pill 挂载与 building (POST 在飞) 强绑定，
-    // POST 因 BFF 15min 超时 abort 时 Pill 立即卸载、SSE 关闭。修复后由 SSE 终态
-    // 通过 onTerminal 回调驱动父组件解除挂载，与 POST 解耦。
+  it("终态后通过 onTerminal 通知父组件（解耦 POST 在飞状态）", async () => {
     vi.useFakeTimers();
     try {
       const onTerminal = vi.fn();
-      render(
-        <KgBuildProgressPill corpusId="abc" enqueued={true} onTerminal={onTerminal} />,
+      mockFetch.mockResolvedValueOnce(
+        jsonRes({
+          status: "completed",
+          progress_percent: 1,
+          entity_count: 5,
+          relation_count: 3,
+        }),
       );
-      const es = MockEventSource.instances[0];
-      act(() => {
-        es.send({ status: "completed", progress_percent: 1, entity_count: 5, relation_count: 3 });
-      });
-      // 终态收到后立刻关闭 SSE，但回调延迟触发以保留终态展示窗口
-      expect(es.closed).toBe(true);
+      render(
+        <KgBuildProgressPill
+          corpusId="abc"
+          enqueued={true}
+          onTerminal={onTerminal}
+        />,
+      );
+      // 让 fetch Promise resolve
+      await act(async () => {});
+      // 终态收到，但回调延迟触发
       expect(onTerminal).not.toHaveBeenCalled();
-      // 推进 4s 后回调应已触发，参数为 SSE 收到的最后一个 payload
-      act(() => {
-        vi.advanceTimersByTime(4000);
-      });
+      // 推进 4s 后回调应已触发
+      act(() => { vi.advanceTimersByTime(4000); });
       expect(onTerminal).toHaveBeenCalledTimes(1);
       expect(onTerminal).toHaveBeenCalledWith(
         expect.objectContaining({ status: "completed", entity_count: 5 }),
@@ -176,22 +261,24 @@ describe("KgBuildProgressPill", () => {
     }
   });
 
-  it("终态延迟回调中卸载组件不会泄漏 timer", () => {
+  it("终态延迟回调中卸载组件不会泄漏 timer", async () => {
     vi.useFakeTimers();
     try {
       const onTerminal = vi.fn();
-      const { unmount } = render(
-        <KgBuildProgressPill corpusId="abc" enqueued={true} onTerminal={onTerminal} />,
+      mockFetch.mockResolvedValueOnce(
+        jsonRes({ status: "completed", progress_percent: 1 }),
       );
-      const es = MockEventSource.instances[0];
-      act(() => {
-        es.send({ status: "completed", progress_percent: 1 });
-      });
+      const { unmount } = render(
+        <KgBuildProgressPill
+          corpusId="abc"
+          enqueued={true}
+          onTerminal={onTerminal}
+        />,
+      );
+      await act(async () => {});
       // 终态延迟窗口内卸载：timer 应被清理，回调不应再触发
       unmount();
-      act(() => {
-        vi.advanceTimersByTime(4000);
-      });
+      act(() => { vi.advanceTimersByTime(4000); });
       expect(onTerminal).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -485,7 +485,26 @@ def apply_adk_patches():
                     callback=_pipeline_watchdog_tick,
                     interval_seconds=300,
                 )
-                # --- end watchdog ---
+
+                # --- watchdog: finalize stale KG build runs ---
+                async def _kg_build_watchdog_tick() -> None:
+                    from negentropy.knowledge.graph.repository import get_graph_repository
+
+                    repo = get_graph_repository()
+                    result = await repo.finalize_stale_kg_build_runs()
+                    if result["forced_failed"] > 0 or result["forced_cancelled"] > 0:
+                        logger.info(
+                            "kg_build_watchdog_finalized",
+                            forced_failed=result["forced_failed"],
+                            forced_cancelled=result["forced_cancelled"],
+                        )
+
+                scheduler.register(
+                    key="kg_build_watchdog",
+                    callback=_kg_build_watchdog_tick,
+                    interval_seconds=300,
+                )
+                # --- end KG build watchdog ---
 
                 scheduler.start()
                 # 把 scheduler 挂在 app.state 防止被 GC + 便于单测/shutdown 引用

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3506,11 +3506,26 @@ async def get_graph_build_history(
 async def get_latest_kg_build_run(
     corpus_id: UUID,
     app_name: str | None = Query(default=None),
+    only_active: bool = Query(
+        default=False,
+        description=(
+            "仅返回 pending/running 的活跃 run。客户端 Pill 在锁定 run_id 前用 true 轮询，"
+            "避免拿到历史 completed/failed run 被误判为新 run 的终态（与 SSE 发现期 grace 等价）。"
+        ),
+    ),
 ) -> dict[str, Any]:
     """获取指定 corpus 最新一次 KG 构建运行的状态快照（轮询友好）。
 
     每次请求返回最新 DB 行的 JSON 快照，包含 progress_percent 与当前 phase。
-    无活跃 run 时返回 ``{"status": "idle"}``。
+
+    - ``only_active=true`` 且无活跃 run → 返回 ``{"status": "pending"}``（仍处发现期，客户端继续轮询）。
+    - ``only_active=false`` 且无任何 run → 返回 ``{"status": "idle"}``（终态）。
+
+    设计动机：``enqueue_kg_build`` 使用 ``asyncio.create_task`` fire-and-forget，
+    ``ingest_paper`` 返回 ``kg_enqueued`` 时后台尚未走到 ``GraphService.create_build_run`` 的插入点。
+    若客户端首轮就用 ``only_active=false``，会拿到该 corpus 历史上一条 completed/failed run，
+    导致 Pill 误报终态并卸载。SSE 端点（见 ``stream_latest_kg_build_progress``）通过
+    ``only_active=run_id_seen is None`` + 10s grace 显式规避，本端点通过 query 参数同等暴露。
     """
     from datetime import datetime
 
@@ -3520,11 +3535,14 @@ async def get_latest_kg_build_run(
     record = await repository.get_latest_build_run(
         corpus_id=corpus_id,
         app_name=resolved_app,
-        only_active=False,
+        only_active=only_active,
     )
 
     if record is None:
-        return {"status": "idle", "corpus_id": str(corpus_id)}
+        # only_active=True 表示客户端仍处发现期，回 "pending" 让其继续轮询；
+        # only_active=False 表示客户端已放弃发现期或允许历史 run，无 run 即真终态 "idle"。
+        status = "pending" if only_active else "idle"
+        return {"status": status, "corpus_id": str(corpus_id)}
 
     # 从 warnings JSONB 提取最后一条 _phase 条目（与 SSE 端点逻辑一致）
     phase: str | None = None

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3502,6 +3502,57 @@ async def get_graph_build_history(
 # - HTML Living Standard, Server-Sent Events (https://html.spec.whatwg.org/multipage/server-sent-events.html)
 
 
+@router.get("/base/{corpus_id}/graph/build-runs/latest")
+async def get_latest_kg_build_run(
+    corpus_id: UUID,
+    app_name: str | None = Query(default=None),
+) -> dict[str, Any]:
+    """获取指定 corpus 最新一次 KG 构建运行的状态快照（轮询友好）。
+
+    每次请求返回最新 DB 行的 JSON 快照，包含 progress_percent 与当前 phase。
+    无活跃 run 时返回 ``{"status": "idle"}``。
+    """
+    from datetime import datetime
+
+    resolved_app = _resolve_app_name(app_name)
+    repository = _get_graph_service()._repository  # noqa: SLF001
+
+    record = await repository.get_latest_build_run(
+        corpus_id=corpus_id,
+        app_name=resolved_app,
+        only_active=False,
+    )
+
+    if record is None:
+        return {"status": "idle", "corpus_id": str(corpus_id)}
+
+    # 从 warnings JSONB 提取最后一条 _phase 条目（与 SSE 端点逻辑一致）
+    phase: str | None = None
+    phase_detail: dict[str, Any] | None = None
+    if record.warnings:
+        for entry in reversed(record.warnings):
+            if isinstance(entry, dict) and "_phase" in entry:
+                meta = entry["_phase"]
+                if isinstance(meta, dict):
+                    phase = meta.get("name")
+                    phase_detail = meta
+                break
+
+    completed_at_iso = record.completed_at.isoformat() if isinstance(record.completed_at, datetime) else None
+
+    return {
+        "run_id": record.run_id,
+        "status": record.status,
+        "progress_percent": float(record.progress_percent or 0.0),
+        "entity_count": int(record.entity_count or 0),
+        "relation_count": int(record.relation_count or 0),
+        "error_message": record.error_message,
+        "completed_at": completed_at_iso,
+        "phase": phase,
+        "phase_detail": phase_detail,
+    }
+
+
 @router.get("/base/{corpus_id}/graph/build-runs/latest/progress/stream")
 async def stream_latest_kg_build_progress(
     corpus_id: UUID,

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1725,3 +1725,23 @@
   3. **已知限制**：session 切换（点击已有 session）存在同类 race condition 但不在本次修复范围——sidebar 切换的 `setSessionId` 路径未经过 `switchingSessionRef`，需独立处理
   4. **production standalone build 的 `router.replace` 失效**是预存基础设施问题，与本次修复无关
 - **同类问题影响**：ISSUE-059 / 061 / 063 / 064 均涉及前端状态机竞速。本 ISSUE 的 "ref 同步信号 + pending 自动重发" 模式可作为同类 race condition 修复的通用范式。
+
+---
+
+## ISSUE-079 KG Build Pill SSE→HTTP 轮询改造丢失发现期 grace + run_id 切换死循环（2026-05-11）
+
+- **表因**：评审 commit `bda0b75e`（KG Build Progress SSE → HTTP Polling）发现两个等价回归：
+  1. `ingest_paper` 返回 `kg_enqueued` 后，Pill 立刻挂载轮询新端点 `/build-runs/latest`，前端 `seenRunId` 锁到该 corpus 上一条 completed/failed 历史 run，触发 4s 后 onTerminal 卸载，**新 run 永不被跟踪**；
+  2. `KgBuildProgressPill.tsx` 的 run_id 切换分支：`seenRunId` 已锁到 A、下次 poll 拿到不同 run_id=B 且 B 已是终态时，代码 `setTimeout(poll, delay); return;` 既不更新 `seenRunId` 也不调用 `stop`，**死循环停在 pending 直到组件卸载**。
+- **根因**：
+  1. 新 REST 端点 `get_latest_kg_build_run` 一律 `only_active=False`，丢失了 SSE 端点 `stream_latest_kg_build_progress` 在 [`api.py:3593`](../apps/negentropy/src/negentropy/knowledge/api.py) 显式实现的“发现期 grace”—— `only_active=run_id_seen is None` + 10s 等待窗。`enqueue_kg_build` 用 `asyncio.create_task` fire-and-forget，`ingest_paper` 返回时 `_run_kg_build_background` 尚未走到 `create_build_run`；此时 `only_active=False` 拿到的是该 corpus 历史最后一条终态 run。
+  2. 客户端 run_id 切换分支注释“新 run 终态说明还没开始”与“终态=已结束”语义相反；该分支仅在“老锁定 + 新 run_id 已终态”时触发，逻辑上应当 `stop(payload)` 收口或刷新 `seenRunId` 让外层 `isTerminal` 收口，二者皆未发生。
+- **处理方式**：
+  1. **后端**：`get_latest_kg_build_run` 接受 `only_active: bool = Query(default=False)`；`only_active=True` 且 `record is None` 时返回 `{"status": "pending"}` 而非 `idle`，与 SSE 行为对齐。
+  2. **客户端**：`KgBuildProgressPill` 增加 `DISCOVERY_GRACE_MS = 10_000` + `buildUrl()`，在 `seenRunId === null && Date.now() - mountedAt < DISCOVERY_GRACE_MS` 时附加 `?only_active=true`；run_id 一致性处理简化为“拿到 run_id 就更新 `seenRunId` 让外层 `isTerminal` 收口”，消除自旋分支。
+  3. **测试**：补四条回归用例 — 发现期首轮带 `only_active=true` / 锁定后切到不带 / 超 grace 后切到不带 / 已锁定 run_id 收到新 run_id 终态正确收口。
+- **后续防范**：
+  1. 通信介质从 SSE 切换到 HTTP 轮询时，**必须**逐项审视原 SSE 在长连接内实现的状态机（发现期、run_id 锁、grace、idle 判定），不能假设“后端返回最新行”就语义等价；
+  2. 凡“先 ack 入队、后写 DB 行”的 fire-and-forget 设计，前端轮询端点必须显式区分“尚未落库（pending）”与“无任何 run（idle）”两种语义，不可合并；
+  3. 任何“拿到新 run_id 但状态异常”的客户端分支，结尾必须显式更新 lock 或调用 stop，不允许“仅 setTimeout 后 return”的自旋。
+- **同类问题影响**：项目内其他从 SSE 退化为轮询的进度上报场景（Pipeline RUNNING 看门狗、Job watcher 等）需用同一清单复核；新增「fire-and-forget + 进度查询」端点时，应将 `only_active` 类参数作为契约一部分而非可选优化。


### PR DESCRIPTION
## Summary

两个修复解决 KG 构建过程中的连接超时与状态不同步问题：

### 1. SSE → HTTP Polling（前端）

前端 `KgBuildProgressPill` 从 `EventSource` (SSE) 切换为 `fetch` 轮询 + 指数退避，消除 KG 构建期间因 SSE 长连接空闲超时导致的 `Upstream connection failed: TypeError: fetch failed` 错误。

同时修复了终态分支未调用 `scheduleTerminalCallback` 导致 `onTerminal` 回调不触发的缺陷。

### 2. KG Build Run 看门狗（后端）

`finalize_stale_kg_build_runs()` 已在 `repository.py` 中实现但未注册到调度器。现已在 `bootstrap.py` 中注册，每 300s 轮询一次：
- `running` 超 30min → 强制标记为 `failed`
- `cancelling` 超 5min → 强制标记为 `cancelled`

## 变更文件

| 文件 | 变更 |
|------|------|
| `apps/negentropy/src/negentropy/knowledge/api.py` | 新增 `GET /base/{corpus_id}/graph/build-runs/latest` REST 端点 |
| `apps/negentropy/src/negentropy/engine/bootstrap.py` | 注册 KG Build Run 看门狗定时任务 |
| `apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/route.ts` | 新增 BFF 代理路由 |
| `apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx` | EventSource → fetch 轮询重写 |
| `apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx` | 测试全量重写 |

## Test plan

- [x] `pnpm test -- --run tests/unit/ui/KgBuildProgressPill.test.tsx` — 13 用例全部通过
- [x] 638 个前端单元测试全部通过
- [ ] 浏览器实测：触发 KG 构建 → 观察进度轮询正常显示 → 构建完成后自动停止
- [ ] 确认后端启动日志中 `skill_scheduler_started` 包含 `kg_build_watchdog`
- [ ] 网络中断恢复测试：DevTools Network → Offline → 恢复 → 确认轮询自动恢复

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)