### PR TITLE
fix(knowledge-graph): 对齐 KG Toolbar 内 Toggle 组与 Build 进度 Pill 高度

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -440,6 +440,7 @@ export default function KnowledgeGraphPage() {
                       corpusId={corpusId}
                       enqueued={pillEnqueued}
                       onTerminal={handlePillTerminal}
+                      compact
                     />
                   )}
                 </div>

--- a/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
+++ b/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
@@ -63,6 +63,13 @@ type Props = {
    * 留出展示终态的时间窗口；父组件需自行幂等处理重复触发。
    */
   onTerminal?: (event: KgBuildProgressEvent) => void;
+  /**
+   * 紧凑模式：用于 Toolbar 等需与 inline 控件（按钮组）共享水平基线的场景。
+   * - 去掉 mt-2（堆叠场景才需要的间距，会让 flex items-center 行内基线下偏 ~4px）
+   * - py-2 → py-1（与项目内 text-xs 按钮 padding 对齐，消除 8px 高差）
+   * 默认 false，保留 ToolExecutionGroup 等"工具卡片下方独立状态条"既有视觉。
+   */
+  compact?: boolean;
 };
 
 /** 终态展示窗口（ms）：留给用户看清"已完成 / 失败"信息后再让父组件解除挂载 */
@@ -132,6 +139,7 @@ export function KgBuildProgressPill({
   enqueued,
   apiBase = "/api/knowledge",
   onTerminal,
+  compact = false,
 }: Props) {
   const [event, setEvent] = useState<KgBuildProgressEvent | null>(
     enqueued ? { status: "pending", progress_percent: 0 } : null,
@@ -267,7 +275,10 @@ export function KgBuildProgressPill({
       data-testid="kg-build-progress"
       data-kg-status={status}
       className={cn(
-        "mt-2 flex items-center gap-2 rounded-lg border px-3 py-2 text-xs",
+        // 通用基线：布局/形状/字号
+        "flex items-center gap-2 rounded-lg border text-xs",
+        // spacing 走互斥分支：cn 仅做字符串拼接（无 tailwind-merge），不能依赖叠加覆盖
+        compact ? "px-3 py-1" : "mt-2 px-3 py-2",
         isRunning &&
           "border-violet-200/80 bg-violet-50/40 text-violet-700 dark:border-violet-800/60 dark:bg-violet-950/20 dark:text-violet-200",
         status === "completed" &&

--- a/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx
@@ -412,4 +412,33 @@ describe("KgBuildProgressPill", () => {
       vi.useRealTimers();
     }
   });
+
+  // ----- Layout 契约：保护 compact 变体的两种 spacing 配方，禁止互相回退 -----
+  // 背景：KgBuildProgressPill 同时被 ToolExecutionGroup（块级堆叠场景，需 mt-2 py-2）
+  // 与 Knowledge Graph Toolbar（行内并排，需去 mt-2、py-1 与按钮组对齐基线）使用。
+  // 由于 lib/utils.ts 的 cn 仅做字符串拼接（无 tailwind-merge），不能依赖叠加覆盖；
+  // 组件内部以互斥分支输出 className，本组用例锁定该契约，防止后续误改回退。
+  it("默认 compact=false 时保留 mt-2 py-2（保护 ToolExecutionGroup 堆叠场景）", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonRes({ status: "running", progress_percent: 0.5 }),
+    );
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} />);
+    await act(async () => {});
+    const pill = screen.getByTestId("kg-build-progress");
+    expect(pill).toHaveClass("mt-2");
+    expect(pill).toHaveClass("py-2");
+    expect(pill).not.toHaveClass("py-1");
+  });
+
+  it("compact=true 时去除 mt-2 并用 py-1（Toolbar 内与按钮组水平对齐）", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonRes({ status: "running", progress_percent: 0.5 }),
+    );
+    render(<KgBuildProgressPill corpusId="abc" enqueued={true} compact />);
+    await act(async () => {});
+    const pill = screen.getByTestId("kg-build-progress");
+    expect(pill).not.toHaveClass("mt-2");
+    expect(pill).toHaveClass("py-1");
+    expect(pill).not.toHaveClass("py-2");
+  });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge Graph 页面 Toolbar 右侧并排展示的两组模块在视觉上错位——左侧 视图 Toggle（可视化/实体列表）与渲染器 Toggle（Cytoscape/d3-force）使用 `px-3 py-1 text-xs`，而右侧 `KgBuildProgressPill` 用 `mt-2 px-3 py-2`，高度多约 8px、行内中心再下偏约 4px。
- 关联上下文/Issue/文档：承接 #503（KG Build SSE→HTTP Polling + 看门狗）后续视觉收尾；Pill 组件位于 [`apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx`](apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx)，调用方为 [`apps/negentropy-ui/app/knowledge/graph/page.tsx`](apps/negentropy-ui/app/knowledge/graph/page.tsx) 与 [`apps/negentropy-ui/components/ui/ToolExecutionGroup.tsx`](apps/negentropy-ui/components/ui/ToolExecutionGroup.tsx)。

# 核心变更
- `KgBuildProgressPill` 新增 `compact?: boolean` prop（默认 `false`，零回归）；compact 模式去除 `mt-2`、将 `py-2` 改为 `py-1`，与 Toolbar 内 `text-xs` 按钮组共享 padding 基线。
- Knowledge Graph 页面 Toolbar 内的 Pill 调用显式传入 `compact`；`ToolExecutionGroup` 中"工具卡片下方独立状态条"保持默认堆叠形态，视觉无变化。
- 由于 [`lib/utils.ts`](apps/negentropy-ui/lib/utils.ts) 中的 `cn` 仅做字符串拼接（无 `tailwind-merge`），className 采用**互斥分支**而非叠加覆盖，避免依赖 CSS 生成顺序。
- 新增两条单元测试锁定 `compact=false`（保留 `mt-2 py-2`）与 `compact=true`（去 `mt-2`、`py-1`）的 className 契约，防止后续误改回退。

# 风险与回滚
- 主要风险：极低。仅 className 互斥分支调整 + 一个可选 prop；`ToolExecutionGroup` 既有调用未传 `compact`，行为完全不变。
- 回滚方式：`git revert 92e59996`（单 commit 改动）。

# 验证证据
- 单元测试：[`tests/unit/ui/KgBuildProgressPill.test.tsx`](apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx) 新增 2 条契约测试，正反断言 `mt-2` / `py-2` / `py-1` 是否存在。
- 集成测试：现有 `ToolExecutionGroup` 渲染路径未引用 `compact`，等价于回归保护。
- E2E/Workflow：纯视觉对齐，无 API 行为变更；Toolbar 在构建中 / 终态时 Pill 与左侧 Toggle 组水平基线一致。

# 影响范围
- 前端：`apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx`、`apps/negentropy-ui/app/knowledge/graph/page.tsx`、`apps/negentropy-ui/tests/unit/ui/KgBuildProgressPill.test.tsx`。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合入后在 Knowledge Graph 页触发一次构建，目视确认构建中 / completed / failed 三态下 Toolbar 内 Pill 与左侧 Toggle 组水平居中对齐；若未来引入 `tailwind-merge`，可将互斥分支简化为叠加覆盖并删除注释。