### PR TITLE
fix(knowledge-graph): 修复 KG 构建期 SQL 语法报错 + BFF 瞬态错误透明重试;

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -43,10 +43,73 @@ export const DEFAULT_PROXY_TIMEOUT_MS = 30_000;
  */
 export const LONG_TASK_PROXY_TIMEOUT_MS = 15 * 60 * 1_000;
 
+/**
+ * Transient 错误自动重试配置。
+ *
+ * 设计动机：Knowledge Graph 后端 fire-and-forget 构建期间，后端连接池或上游
+ * 网络偶发抖动会让 BFF fetch 抛 ``TypeError: fetch failed`` 或上游响应 502/503/504。
+ * 前端 ``KgBuildProgressPill`` 虽然已有 10 次外层指数退避，但每次失败都会让用户
+ * 短暂看到误导性错误。在 BFF 层增加一段透明 retry 把瞬态错误吸收掉，让前端
+ * 只在持续性故障时才看到错误。
+ *
+ * 触发条件（transient）：
+ *  - fetch 抛错且**非** ``DOMException(TimeoutError)``（即 fetch failed /
+ *    ECONNRESET / ECONNREFUSED / socket hang up 等连接层瞬态错误）
+ *  - upstream Response.status ∈ {502, 503, 504}
+ *
+ * 不触发（不重试）：
+ *  - TimeoutError（请求级超时，重试只会拉长用户等待）
+ *  - 4xx 客户端错误（重试无意义）
+ *  - 5xx 但非 502/503/504（应用层错误，重试无效）
+ *
+ * 启用范围：默认 ``undefined``（保留向后兼容），调用方按端点显式启用。
+ *   - 已启用：``GET /knowledge/base/:id/graph/build-runs/latest``（轮询）
+ *   - 未启用：POST（避免重复 enqueue 副作用，如 KG 构建重复触发）
+ */
+export type RetryOptions = {
+  /** 总尝试次数（首次 + 重试），如 attempts=3 即首次 + 2 次重试 */
+  attempts: number;
+  /** 每次重试前的退避毫秒数序列；长度应 ≥ attempts-1，超出 attempts-1 的项被忽略 */
+  backoffMs: number[];
+};
+
+/** 默认轮询端点的重试配置：3 次尝试，200ms / 500ms 退避 */
+export const POLLING_RETRY: RetryOptions = {
+  attempts: 3,
+  backoffMs: [200, 500],
+};
+
 type ProxyOptions = {
   /** 覆盖默认 30s 超时；长任务调用方建议传 LONG_TASK_PROXY_TIMEOUT_MS */
   timeoutMs?: number;
+  /**
+   * Transient 错误自动重试。默认不启用（兼容旧调用方）；
+   * 调用方按端点语义显式启用（仅 GET 推荐启用，POST 重试会触发副作用）。
+   */
+  retry?: RetryOptions;
 };
+
+/** 上游响应被视作 transient 的状态码集合 */
+const TRANSIENT_UPSTREAM_STATUSES = new Set([502, 503, 504]);
+
+/**
+ * 判定 fetch 抛错是否属于 transient（值得重试）。
+ *
+ * ``DOMException(TimeoutError)`` 来自 ``AbortSignal.timeout()``：请求级超时
+ * 由调用方通过 ``timeoutMs`` 显式设定，重试只会让超时累加、用户等待更久，
+ * 因此**不**视作 transient。其余 fetch 错误（fetch failed / ECONNRESET /
+ * ECONNREFUSED / socket hang up 等）均为连接层瞬态，可重试。
+ */
+function isTransientFetchError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return false;
+  }
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * 把 fetch 异常归类为 504（超时）或 502（其他连接失败），让前端能准确区分。
@@ -136,25 +199,58 @@ export async function proxyGet(request: Request, path: string, options: ProxyOpt
   upstreamUrl.search = incomingUrl.search;
   const timeoutMs = options.timeoutMs ?? DEFAULT_PROXY_TIMEOUT_MS;
 
-  let upstreamResponse: Response;
-  try {
-    upstreamResponse = await fetch(upstreamUrl, {
-      method: "GET",
-      headers: extractForwardHeaders(request),
-      cache: "no-store",
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (error) {
-    const { code, message, status } = classifyFetchError(error);
-    return errorResponse(code, message, status);
+  // Transient retry-loop：connection-layer 抛错 / 上游 502/503/504 时按退避序列
+  // 重试，吸收 fire-and-forget 后端构建期间的连接池抖动；非 transient 错误（4xx /
+  // TimeoutError / 5xx 非 502-504）立即返回。详见 ``RetryOptions`` 文档。
+  const retry = options.retry;
+  const attempts = retry?.attempts ?? 1;
+  const backoffMs = retry?.backoffMs ?? [];
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let upstreamResponse: Response;
+    try {
+      upstreamResponse = await fetch(upstreamUrl, {
+        method: "GET",
+        headers: extractForwardHeaders(request),
+        cache: "no-store",
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      // 仅 transient 且还有剩余 attempt 时退避重试
+      if (isTransientFetchError(error) && attempt < attempts) {
+        await sleep(backoffMs[attempt - 1] ?? 0);
+        continue;
+      }
+      const { code, message, status } = classifyFetchError(error);
+      return errorResponse(code, message, status);
+    }
+
+    // 上游 502/503/504 也按 transient 处理（fire-and-forget 后端瞬态不可达）
+    if (TRANSIENT_UPSTREAM_STATUSES.has(upstreamResponse.status) && attempt < attempts) {
+      // 读取并丢弃响应体，避免连接保持半开（Node fetch 不主动消费会延后 GC）
+      try {
+        await upstreamResponse.text();
+      } catch {
+        /* ignore drain errors */
+      }
+      await sleep(backoffMs[attempt - 1] ?? 0);
+      continue;
+    }
+
+    const text = await upstreamResponse.text();
+    if (!upstreamResponse.ok) {
+      return upstreamErrorResponse(text, upstreamResponse.status);
+    }
+    return NextResponse.json(JSON.parse(text));
   }
 
-  const text = await upstreamResponse.text();
-  if (!upstreamResponse.ok) {
-    return upstreamErrorResponse(text, upstreamResponse.status);
-  }
-
-  return NextResponse.json(JSON.parse(text));
+  // 理论不可达：retry-loop 内每个分支都有 return 或 continue（continue 仅在
+  // attempt<attempts 时才走），最后一次必定走到 return。兜底以满足 TS 控制流分析。
+  return errorResponse(
+    "KNOWLEDGE_UPSTREAM_ERROR",
+    "Upstream temporarily unavailable after retries",
+    502,
+  );
 }
 
 export async function proxyPost(request: Request, path: string, options: ProxyOptions = {}) {

--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build-runs/latest/route.ts
@@ -1,5 +1,13 @@
-import { proxyGet } from "../../../../../_proxy";
+import { POLLING_RETRY, proxyGet } from "../../../../../_proxy";
 
+/**
+ * KG Build Run 最新状态轮询端点（前端 ``KgBuildProgressPill`` 每 3s 调用一次）。
+ *
+ * 启用 ``POLLING_RETRY`` 让 BFF 在 fetch failed / 502 / 503 / 504 等瞬态故障时
+ * 自动重试 2 次（首次 + 2 次退避），把 KG 构建期间后端连接池抖动产生的
+ * ``Upstream connection failed: TypeError: fetch failed`` 误导性错误吸收在 BFF 层，
+ * 不再透传给前端 Pill 组件。详见 ``_proxy.ts`` ``RetryOptions`` 文档。
+ */
 export async function GET(
   request: Request,
   context: { params: Promise<{ corpusId: string }> },
@@ -8,5 +16,6 @@ export async function GET(
   return proxyGet(
     request,
     `/knowledge/base/${encodeURIComponent(corpusId)}/graph/build-runs/latest`,
+    { retry: POLLING_RETRY },
   );
 }

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -507,7 +507,16 @@ class AgeGraphRepository(GraphRepository):
         """创建实体节点
 
         将实体信息存储到 knowledge 表，并创建 Apache AGE 节点。
+
+        SQL 占位符注意事项：
+            ``:metadata::jsonb`` 这种「命名参数紧邻 PostgreSQL ``::`` cast 操作符」
+            的写法会破坏 SQLAlchemy 命名参数边界识别，导致 ``:metadata`` 未被翻译为
+            ``$N`` 而是原样发给 asyncpg，触发 ``syntax error at or near ":"``。
+            修复：改用 ``CAST(:metadata AS jsonb)`` —— CAST 函数边界清晰，与项目
+            ``update_build_run`` 等既有写法保持一致（参见 1804 行 ``CAST(:warnings AS json)``）。
         """
+        import json as _json
+
         # 更新 knowledge 表的实体字段
         confidence = entity.metadata.get("confidence", 1.0)
 
@@ -515,7 +524,7 @@ class AgeGraphRepository(GraphRepository):
             UPDATE {self._schema}.knowledge
             SET entity_type = :entity_type,
                 entity_confidence = :confidence,
-                metadata = COALESCE(metadata, '{{}}'::jsonb) || :metadata::jsonb
+                metadata = COALESCE(metadata, '{{}}'::jsonb) || CAST(:metadata AS jsonb)
             WHERE id = :entity_id
         """)
 
@@ -526,7 +535,7 @@ class AgeGraphRepository(GraphRepository):
                     "entity_id": entity.id.replace("entity:", ""),
                     "entity_type": entity.node_type,
                     "confidence": confidence,
-                    "metadata": str({"graph_label": entity.label}),
+                    "metadata": _json.dumps({"graph_label": entity.label}),
                 },
             )
             await session.commit()
@@ -545,15 +554,23 @@ class AgeGraphRepository(GraphRepository):
         entities: list[GraphNode],
         corpus_id: UUID,
     ) -> list[str]:
-        """批量创建实体节点（单 Session 批量提交，消除逐条连接池抖动）"""
+        """批量创建实体节点（单 Session 批量提交，消除逐条连接池抖动）
+
+        SQL 占位符注意事项参见 :py:meth:`create_entity` 文档：
+        ``CAST(:metadata AS jsonb)`` 取代 ``:metadata::jsonb`` 以规避 SQLAlchemy
+        命名参数边界识别异常；参数值必须用 ``json.dumps`` 序列化为合法 JSON 字符串
+        （而非 Python ``str(dict)`` 的单引号形式，否则 ``CAST`` 会再次报语法错误）。
+        """
         if not entities:
             return []
+
+        import json as _json
 
         query = text(f"""
             UPDATE {self._schema}.knowledge
             SET entity_type = :entity_type,
                 entity_confidence = :confidence,
-                metadata = COALESCE(metadata, '{{}}'::jsonb) || :metadata::jsonb
+                metadata = COALESCE(metadata, '{{}}'::jsonb) || CAST(:metadata AS jsonb)
             WHERE id = :entity_id
         """)
 
@@ -566,7 +583,7 @@ class AgeGraphRepository(GraphRepository):
                     "entity_id": entity.id.replace("entity:", ""),
                     "entity_type": entity.node_type,
                     "confidence": confidence,
-                    "metadata": str({"graph_label": entity.label}),
+                    "metadata": _json.dumps({"graph_label": entity.label}),
                 }
             )
             ids.append(entity.id)
@@ -620,12 +637,16 @@ class AgeGraphRepository(GraphRepository):
         confidence = relation.metadata.get("confidence", 1.0)
         evidence = relation.metadata.get("evidence")
 
+        # SQL 占位符注意事项：``:metadata::jsonb`` / ``:related::jsonb`` 命名参数紧邻
+        # ``::`` cast 会破坏 SQLAlchemy 命名参数边界识别（asyncpg 报 ``syntax error at or
+        # near ":"``）。统一改为 ``CAST(:name AS jsonb)``，与 ``update_build_run`` 等既有
+        # 写法保持一致。
         insert_query = text(f"""
             INSERT INTO {self._schema}.kg_relations
                 (source_id, target_id, corpus_id, app_name, relation_type,
                  weight, confidence, evidence_text, metadata, is_active)
             SELECT :source_id, :target_id, k.corpus_id, k.app_name,
-                   :relation_type, :weight, :confidence, :evidence, :metadata::jsonb, true
+                   :relation_type, :weight, :confidence, :evidence, CAST(:metadata AS jsonb), true
             FROM {self._schema}.knowledge k
             WHERE k.id = :source_id
             ON CONFLICT (source_id, target_id, relation_type) DO UPDATE SET
@@ -648,7 +669,7 @@ class AgeGraphRepository(GraphRepository):
         update_query = text(f"""
             UPDATE {self._schema}.knowledge
             SET metadata = COALESCE(metadata, '{{}}'::jsonb) ||
-                          jsonb_build_object('related_entities', :related::jsonb)
+                          jsonb_build_object('related_entities', CAST(:related AS jsonb))
             WHERE id = :source_id
         """)
 

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -786,7 +786,10 @@ class KnowledgeRepository:
         }
 
         if metadata_filter:
-            filters = " AND metadata @> :metadata_filter::jsonb"
+            # 使用 ``CAST(:name AS jsonb)`` 而非 ``:name::jsonb`` —— 后者命名参数紧邻
+            # PostgreSQL ``::`` cast 会触发 SQLAlchemy 命名参数边界识别异常，asyncpg
+            # 报 ``syntax error at or near ":"``。与 graph/repository.py 修复同口径。
+            filters = " AND metadata @> CAST(:metadata_filter AS jsonb)"
             params["metadata_filter"] = json.dumps(metadata_filter)
 
         stmt = text(


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：KG 构建期 (`create_entity` / `create_entities` / `_create_relation_with_session`) 因 SQLAlchemy `text()` 中 `:name::jsonb` 命名参数紧邻 PostgreSQL `::` cast 与同段 `'{}'::jsonb` 字面量 cast 共存，引发 `syntax error at or near ":"`，写入实体/关系阶段直接中断；同时 fire-and-forget 构建期间 BFF `proxyGet` 偶发 `TypeError: fetch failed` / 502 / 503 / 504，让 `KgBuildProgressPill` 短暂呈现误导性错误。
- 关联上下文：紧接 #503（KG Build Progress SSE → HTTP Polling + Watchdog），定位与修复轮询通路上的两类 transient/语法故障；issue 摘要维护于 [docs/issue.md](./docs/issue.md)。

# 核心变更
- **SQL 占位符同口径修复**：`knowledge/graph/repository.py` + `knowledge/retrieval/repository.py` 共 4 处 `:name::jsonb` 统一改为 `CAST(:name AS jsonb)`，与 `update_build_run` 中 `CAST(:warnings AS json)` 既有惯例对齐；`create_entity` / `create_entities` 的 metadata 参数由 `str({...})` 单引号伪 JSON 改为 `json.dumps({...})` 合法 JSON 字符串。
- **BFF transient 重试 (opt-in)**：`apps/negentropy-ui/app/api/knowledge/_proxy.ts` 为 `proxyGet` 引入 `RetryOptions` 参数与 `POLLING_RETRY = { attempts: 3, backoffMs: [200, 500] }`，仅 GET 启用、POST 不启用（避免重复 enqueue 副作用）；触发条件限定 fetch 抛错（非 `TimeoutError`）或上游 502/503/504，4xx / TimeoutError / 其他 5xx 立即返回。
- **轮询端点接入**：`/api/knowledge/base/[corpusId]/graph/build-runs/latest` 路由显式传入 `{ retry: POLLING_RETRY }`，将瞬态错误吸收在 BFF 层，不再透传 Pill 组件。

# 风险与回滚
- 主要风险：(1) SQL 改动落在写入热路径，但与既有 `CAST(... AS json)` 实践完全一致，已通过本地 KG 构建端到端验证；(2) BFF 重试默认 `undefined` 不影响现存调用方，仅 polling 端点显式启用，最坏情况单次请求总耗时上限提升至 ~90s（3 次 30s 超时 + 700ms 退避），但 TimeoutError 不会被重试故无累加。
- 回滚方式：分别 `git revert 6fba7f58`（BFF 重试）与 `git revert cac62c27`（SQL 修复）即可，两个 commit 互相独立、可各自撤回。

# 验证证据
- 单元测试：`apps/negentropy-ui/tests/unit/knowledge/proxy-empty-body.test.ts` 既有 mock-fetch 框架兼容新逻辑，未引入回归；本次未新增 retry 专项单测（已在 PR 备注中提示作为 Next Best Action 跟进）。
- 集成测试：本地 KG 全量构建验证 `create_entity` / `create_entities` / `_create_relation_with_session` 三条写入路径不再触发 `syntax error at or near ":"`，实体与关系正常落库。
- E2E：前端 Knowledge Graph 页轮询期间人工断开后端片刻，Pill 不再闪现 `Upstream connection failed: TypeError: fetch failed`，恢复后状态正确收敛。

# 影响范围
- 前端：`apps/negentropy-ui/app/api/knowledge/_proxy.ts`、`.../build-runs/latest/route.ts`。
- 后端：`apps/negentropy/src/negentropy/knowledge/graph/repository.py`、`apps/negentropy/src/negentropy/knowledge/retrieval/repository.py`。
- GitHub Actions / 文档：无。

# Next Best Action
- 为 `_proxy.ts` retry 路径补单测，锁定 “transient 退避 / TimeoutError 即返 / 4xx 不重试 / 上游 502-504 重试” 四类核心契约（可复用 `proxy-empty-body.test.ts` 的 mock-fetch 框架）。
- 观察后续 KG 构建期是否仍有透传到 Pill 的瞬态错误；若仍偶发，考虑将 `POLLING_RETRY` 推广至 `graph/stats` / `graph/timeline` 等同类轮询端点。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>