### PR TITLE
fix(knowledge-graph): 修复 KG Build Run 取消信号被状态机回写覆盖，UI 永卡 CANCELLING

### DIFF
--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -467,7 +467,10 @@ def apply_adk_patches():
                 register_skill_scheduler(scheduler)
 
                 # --- watchdog: finalize stale KG/KB pipeline runs ---
-                # cancelling 超 5min 未收敛 → cancelled; running 超 30min → failed
+                # cancelling 超 2min 未收敛 → cancelled; running 超 30min → failed
+                # 设计（ISSUE-080）：``update_build_run`` SQL 守卫修复后，watchdog 仅作
+                # backstop，主路径由 build task 异常处理写终态承担。
+                # 60s tick × 2min 阈值 ≈ 最坏 3 分钟兜底，满足用户对"取消秒~分钟级生效"的期望。
                 async def _pipeline_watchdog_tick() -> None:
                     from negentropy.knowledge.dao import KnowledgeRunDao
                     from negentropy.knowledge.graph.repository import AgeGraphRepository
@@ -499,28 +502,11 @@ def apply_adk_patches():
                 scheduler.register(
                     key="pipeline_run_watchdog",
                     callback=_pipeline_watchdog_tick,
-                    interval_seconds=300,
+                    interval_seconds=60,
                 )
-
-                # --- watchdog: finalize stale KG build runs ---
-                async def _kg_build_watchdog_tick() -> None:
-                    from negentropy.knowledge.graph.repository import get_graph_repository
-
-                    repo = get_graph_repository()
-                    result = await repo.finalize_stale_kg_build_runs()
-                    if result["forced_failed"] > 0 or result["forced_cancelled"] > 0:
-                        logger.info(
-                            "kg_build_watchdog_finalized",
-                            forced_failed=result["forced_failed"],
-                            forced_cancelled=result["forced_cancelled"],
-                        )
-
-                scheduler.register(
-                    key="kg_build_watchdog",
-                    callback=_kg_build_watchdog_tick,
-                    interval_seconds=300,
-                )
-                # --- end KG build watchdog ---
+                # 注：旧版另外注册了 ``kg_build_watchdog`` 单独 tick KG 收敛——与上方
+                # ``_pipeline_watchdog_tick`` 内调用 ``finalize_stale_kg_build_runs``
+                # 完全重复。已合并到统一 watchdog，避免双倍 DB 压力。
 
                 scheduler.start()
                 # 把 scheduler 挂在 app.state 防止被 GC + 便于单测/shutdown 引用

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -1806,7 +1806,20 @@ class AgeGraphRepository(GraphRepository):
         warnings: list[dict[str, Any]] | None = None,
         processed_chunk_ids: list[str] | None = None,
     ) -> None:
-        """更新构建运行状态
+        """更新构建运行状态。
+
+        状态机不变量（ISSUE-080）：
+        - 终态写入（``completed`` / ``failed`` / ``cancelled``）永远允许；
+        - 非终态写入（如 ``running`` 进度上报）仅当 DB 当前**不在终态/cancelling** 时
+          才生效。这避免 build task 的进度上报把取消 API 已写入的 ``cancelling``
+          状态回滚为 ``running``，导致 watchdog 命中失败、跨 worker DB 兜底失明、
+          UI 永远卡 CANCELLING 的连锁缺陷。
+        - ``completed_at`` 仅在写入终态时设为 ``NOW()``；非终态保留旧值，避免
+          被错误清零（既影响 watchdog 阈值计算，也丢失 cancel 请求时间锚）。
+
+        参考: M. Kleppmann, *Designing Data-Intensive Applications*, ch. 9 §9.4 —
+        以 DB 为权威协调源时，状态机迁移合法性必须在 SQL 层显式守护，避免
+        多写入路径（cancel API、build task heartbeat、watchdog）形成竞态覆盖。
 
         Args:
             progress_percent: 构建进度 0.0-1.0，用于前端进度条 (Nygard, 2018)
@@ -1815,6 +1828,9 @@ class AgeGraphRepository(GraphRepository):
         """
         import json as _json
 
+        # WHERE 子句守卫状态机：
+        # - 终态写入（含 cancel 异常处理路径）无条件允许；
+        # - 非终态写入要求 DB 当前不在终态/cancelling，否则零行 UPDATE 静默忽略。
         query = text(f"""
             UPDATE {self._schema}.kg_build_runs
             SET status = :status,
@@ -1824,12 +1840,19 @@ class AgeGraphRepository(GraphRepository):
                 progress_percent = COALESCE(:progress, progress_percent),
                 warnings = COALESCE(CAST(:warnings AS json), warnings),
                 processed_chunk_ids = COALESCE(CAST(:chunk_ids AS json), processed_chunk_ids),
-                completed_at = CASE WHEN CAST(:status AS varchar) IN ('completed', 'failed', 'cancelled') THEN NOW() END
+                completed_at = CASE
+                    WHEN CAST(:status AS varchar) IN ('completed', 'failed', 'cancelled') THEN NOW()
+                    ELSE completed_at
+                END
             WHERE id = :run_id
+              AND (
+                CAST(:status AS varchar) IN ('completed', 'failed', 'cancelled')
+                OR status NOT IN ('completed', 'failed', 'cancelled', 'cancelling')
+              )
         """)
 
         async with self._session_scope() as session:
-            await session.execute(
+            result = await session.execute(
                 query,
                 {
                     "run_id": str(run_id),
@@ -1843,6 +1866,17 @@ class AgeGraphRepository(GraphRepository):
                 },
             )
             await session.commit()
+            rowcount = result.rowcount or 0
+
+        if rowcount == 0:
+            # 零行 UPDATE：通常意味着 DB 已在终态/cancelling 且本次为非终态写入，
+            # 这是状态机守卫的正常拒绝路径；以 debug 级保留观测线索，便于 cancel 链路排查。
+            logger.debug(
+                "build_run_update_skipped_by_state_guard",
+                run_id=str(run_id),
+                attempted_status=status,
+            )
+            return
 
         logger.info(
             "build_run_updated",
@@ -2123,13 +2157,18 @@ class AgeGraphRepository(GraphRepository):
         self,
         *,
         app_name: str | None = None,
-        cancelling_threshold_minutes: int = 5,
+        cancelling_threshold_minutes: int = 2,
         running_threshold_minutes: int = 30,
     ) -> dict[str, int]:
         """KG 看门狗：把卡死的中间态 build_run 收敛到终态。
 
-        - `running` 超 `running_threshold_minutes` 分钟无更新 → 标记为 `failed`；
-        - `cancelling` 超 `cancelling_threshold_minutes` → 强制 `cancelled`。
+        - ``running`` 超 ``running_threshold_minutes`` 分钟无更新 → 标记为 ``failed``；
+        - ``cancelling`` 超 ``cancelling_threshold_minutes`` → 强制 ``cancelled``。
+
+        阈值（ISSUE-080）：``cancelling_threshold_minutes`` 默认从 5 → 2，配合
+        bootstrap 内 watchdog tick 间隔 60s，最坏兜底 ≤ 3 分钟。``running_threshold_minutes``
+        保持 30 分钟（保守，配合 ``update_build_run`` 修复后 ``completed_at`` 保留语义，
+        真实反映任务最后一次心跳时间而非任务启动时间）。
         """
         async with self._session_scope() as session:
             stale_msg = (

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -443,7 +443,14 @@ class GraphService:
             }
 
             async def maybe_report_chunk_progress() -> None:
-                """chunk 处理过程中按节流条件上报 progress_percent（仅更新单字段，不改 warnings）。"""
+                """chunk 处理过程中按节流条件上报 progress_percent（仅更新单字段，不改 warnings）。
+
+                取消守卫（ISSUE-080）：同 worker fast-path——cancel 信号已 set 时
+                跳过本次 update。SQL 层 ``update_build_run`` 已有状态机守卫兜底
+                （非终态写入不会回滚 cancelling），此处仅是减少日志噪音 + 早出节流。
+                """
+                if is_cancelled(run_id):
+                    return
                 async with progress_lock:
                     now = time.time()
                     delta_chunks = chunks_processed - int(progress_state["last_reported_chunks"])
@@ -521,7 +528,11 @@ class GraphService:
                         ]
 
                         return entities, relations
-                    except (TimeoutError, Exception):
+                    except (TimeoutError, Exception) as exc:
+                        # 取消信号短路（ISSUE-080）：PipelineCancelled 不参与 retry，
+                        # 避免在已取消语境下浪费 1 次 LLM 调用窗口（最多 2×60s）。
+                        if isinstance(exc, PipelineCancelled):
+                            raise
                         if _retries > 0:
                             await asyncio.sleep(1.0)
                             return await process_chunk(chunk, _retries - 1)
@@ -532,11 +543,24 @@ class GraphService:
 
             # 批量处理
             for i in range(0, len(chunks), batch_size):
+                # 批次入口取消检查点（ISSUE-080）：in-memory event O(1) 快路径，
+                # 避免在 cancel 已 set 后仍发起整批 gather 浪费调度与日志。
+                if is_cancelled(run_id):
+                    raise PipelineCancelled(run_id, last_stage=PHASE_EXTRACTING)
+
                 batch = chunks[i : i + batch_size]
                 results = await asyncio.gather(
                     *[process_chunk(chunk) for chunk in batch],
                     return_exceptions=True,
                 )
+
+                # 关键（ISSUE-080）：PipelineCancelled 优先于其它异常显式 re-raise，
+                # 防止被 ``return_exceptions=True`` 打包后误计入 failed_chunk_count
+                # 静默吞没——这是原版导致 cancel 信号在 chunk loop 内丢失、批次继续
+                # 处理直到下一个 phase 边界才被感知的根因。
+                for result in results:
+                    if isinstance(result, PipelineCancelled):
+                        raise result
 
                 for result in results:
                     if isinstance(result, Exception):

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -445,9 +445,11 @@ class GraphService:
             async def maybe_report_chunk_progress() -> None:
                 """chunk 处理过程中按节流条件上报 progress_percent（仅更新单字段，不改 warnings）。
 
-                取消守卫（ISSUE-080）：同 worker fast-path——cancel 信号已 set 时
-                跳过本次 update。SQL 层 ``update_build_run`` 已有状态机守卫兜底
-                （非终态写入不会回滚 cancelling），此处仅是减少日志噪音 + 早出节流。
+                取消守卫（ISSUE-080）：in-memory ``is_cancelled`` 仅覆盖**同 worker**
+                场景（cancel API 与 build task 在同一进程内通过 ``asyncio.Event`` 通信）；
+                跨 worker 场景下此检查不生效，正确性由 SQL 层 ``update_build_run`` 的
+                状态机 WHERE 守卫兜底（非终态写入不会回滚 cancelling）。
+                此处 fast-path 仅是同 worker 内减少日志噪音 + 早出节流的优化。
                 """
                 if is_cancelled(run_id):
                     return

--- a/apps/negentropy/tests/unit_tests/knowledge/test_graph_repository.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_graph_repository.py
@@ -390,3 +390,123 @@ class TestSessionScope:
 
         assert enter_count == 1
         assert exit_count == 1, "异常路径下 __aexit__ 仍必须触发以归还连接"
+
+
+class TestUpdateBuildRunStateMachineGuard:
+    """``update_build_run`` SQL 状态机不变量回归（ISSUE-080）。
+
+    历史 bug：原 SQL 无 WHERE 守卫，``status='running'`` 的进度上报会把 cancel API
+    已写入的 ``cancelling`` 状态回滚为 ``running``，并把 ``completed_at`` 清零，
+    导致 watchdog 永远命中不到、跨 worker DB 兜底失明、UI 永远卡 CANCELLING。
+
+    本套测试覆盖修复后的 SQL 守卫不变量：
+    1. SQL 文本必须包含状态机 WHERE 守卫（防止 SQL 重构丢失关键约束）；
+    2. SQL 文本必须包含 ``completed_at`` 的 ``ELSE completed_at`` 保留分支；
+    3. 零行 UPDATE（被守卫拒绝）走 debug 日志路径，不触发 ``build_run_updated`` 误报；
+    4. 非零行 UPDATE 触发 ``build_run_updated`` info 日志（正常路径不回归）。
+    """
+
+    @pytest.fixture
+    def captured_query(self):
+        """捕获 ``session.execute`` 传入的 SQL 文本与参数，便于断言。"""
+        return {"sql": None, "params": None, "rowcount": 1}
+
+    @pytest.fixture
+    def mock_session_factory(self, captured_query):
+        """构造 AsyncSessionLocal mock：session.execute 捕获 SQL 并返回可控 rowcount。"""
+        from contextlib import asynccontextmanager
+
+        def make(rowcount: int = 1):
+            captured_query["rowcount"] = rowcount
+
+            async def fake_execute(stmt, params=None):
+                captured_query["sql"] = str(stmt)
+                captured_query["params"] = params
+                result = MagicMock()
+                result.rowcount = captured_query["rowcount"]
+                return result
+
+            mock_session = AsyncMock(spec=AsyncSession)
+            mock_session.execute = fake_execute
+            mock_session.commit = AsyncMock()
+
+            @asynccontextmanager
+            async def fake_session_local():
+                yield mock_session
+
+            return mock_session, fake_session_local
+
+        return make
+
+    @pytest.mark.asyncio
+    async def test_sql_contains_state_machine_where_guard(self, captured_query, mock_session_factory):
+        """SQL 必须包含 WHERE 守卫：终态写入允许 OR 非终态写入要求 DB 非终态/cancelling。"""
+        _mock, factory = mock_session_factory(rowcount=1)
+        repo = AgeGraphRepository()
+        with patch(
+            "negentropy.knowledge.graph.repository.AsyncSessionLocal",
+            side_effect=lambda: factory(),
+        ):
+            await repo.update_build_run(run_id=uuid4(), status="running", progress_percent=0.3)
+
+        sql = captured_query["sql"]
+        # WHERE 守卫的两个核心子句必须存在
+        assert "status NOT IN" in sql, "缺少非终态写入守卫（DB 当前不在终态/cancelling 才允许）"
+        assert "'cancelling'" in sql, "WHERE 守卫必须显式排除 cancelling 状态"
+        assert "completed" in sql and "failed" in sql, "WHERE 守卫必须涵盖完整终态集合"
+
+    @pytest.mark.asyncio
+    async def test_sql_preserves_completed_at_on_non_terminal_writes(self, captured_query, mock_session_factory):
+        """``completed_at`` 必须含 ``ELSE completed_at`` 分支：非终态写入保留旧值，避免被 NULL 清零。"""
+        _mock, factory = mock_session_factory(rowcount=1)
+        repo = AgeGraphRepository()
+        with patch(
+            "negentropy.knowledge.graph.repository.AsyncSessionLocal",
+            side_effect=lambda: factory(),
+        ):
+            await repo.update_build_run(run_id=uuid4(), status="running")
+
+        sql = captured_query["sql"]
+        assert "ELSE completed_at" in sql, (
+            "completed_at CASE 分支必须保留旧值（ELSE completed_at），"
+            "否则非终态写入会把 cancel 请求时间锚清零，watchdog 阈值计算失真"
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_row_update_goes_to_debug_log_not_info(self, captured_query, mock_session_factory):
+        """零行 UPDATE（被状态机守卫拒绝）应走 debug 日志，不应误发 ``build_run_updated`` info 日志。"""
+        _mock, factory = mock_session_factory(rowcount=0)
+        repo = AgeGraphRepository()
+        with patch(
+            "negentropy.knowledge.graph.repository.AsyncSessionLocal",
+            side_effect=lambda: factory(),
+        ):
+            with patch("negentropy.knowledge.graph.repository.logger") as mock_logger:
+                await repo.update_build_run(run_id=uuid4(), status="running", progress_percent=0.5)
+
+        # 守卫拒绝路径：debug 记录线索 + 完全不发 build_run_updated info（避免运维误导）
+        info_event_names = [call.args[0] for call in mock_logger.info.call_args_list if call.args]
+        assert "build_run_updated" not in info_event_names, (
+            "零行 UPDATE 应走 debug 日志路径，不应触发 build_run_updated info（运维误导风险）"
+        )
+        debug_event_names = [call.args[0] for call in mock_logger.debug.call_args_list if call.args]
+        assert "build_run_update_skipped_by_state_guard" in debug_event_names, (
+            "零行 UPDATE 必须留下 debug 观测线索，便于 cancel 链路排查"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_zero_row_update_emits_info_log(self, captured_query, mock_session_factory):
+        """正常 UPDATE（rowcount > 0）必须触发 ``build_run_updated`` info 日志（happy path 回归）。"""
+        _mock, factory = mock_session_factory(rowcount=1)
+        repo = AgeGraphRepository()
+        with patch(
+            "negentropy.knowledge.graph.repository.AsyncSessionLocal",
+            side_effect=lambda: factory(),
+        ):
+            with patch("negentropy.knowledge.graph.repository.logger") as mock_logger:
+                await repo.update_build_run(run_id=uuid4(), status="completed", entity_count=10)
+
+        info_event_names = [call.args[0] for call in mock_logger.info.call_args_list if call.args]
+        assert "build_run_updated" in info_event_names, (
+            "正常 UPDATE 必须触发 build_run_updated info 日志（happy path 不可回归）"
+        )

--- a/apps/negentropy/tests/unit_tests/knowledge/test_graph_service.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_graph_service.py
@@ -621,3 +621,218 @@ async def test_build_graph_failure_preserves_algorithm_warnings():
     warnings = failed_call.get("warnings") or []
     phase_entries = [w for w in warnings if isinstance(w, dict) and "_phase" in w]
     assert phase_entries == [], "失败终态 warnings 不应残留 _phase（应被 _strip_phase_entries 剥离）"
+
+
+# ================================
+# Cancellation Propagation Tests (ISSUE-080)
+# ================================
+#
+# 背景：旧版 chunk 批处理循环 `asyncio.gather(return_exceptions=True)` 误将
+# PipelineCancelled 当作普通 chunk 失败吞没，循环继续遍历剩余 batches。叠加
+# `maybe_report_chunk_progress` 缺少 cancel 守卫 + `update_build_run` SQL 无状态机
+# 守卫，cancelling 信号被 build task 的进度上报反复回写为 running，UI 永远卡住。
+#
+# 本套测试覆盖修复后的不变量：
+# 1. chunk 内抛 PipelineCancelled 必须在 gather 返回后立即 re-raise，不能进入
+#    failed_chunk_count 路径，build_graph 终态必须为 cancelled；
+# 2. 批次入口的 in-memory cancel 检查必须在下一批 LLM 调用前生效，避免浪费整批
+#    chunks 的提取调度；
+# 3. `maybe_report_chunk_progress` 必须在 cancel 已 set 时早出，不调用 update_build_run。
+
+
+def _make_fake_extractor_class(side_effect):
+    """工厂：构造一个 stub CompositeEntityExtractor/RelationExtractor 类，
+    其 ``extract`` 调用走入注入的 side_effect（捕获 call_count + 触发 cancel + 抛异常）。
+    """
+
+    class FakeExtractor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def extract(self, *args, **kwargs):
+            return await side_effect(*args, **kwargs)
+
+    return FakeExtractor
+
+
+@pytest.mark.asyncio
+async def test_pipeline_cancelled_in_gather_propagates_to_terminal_cancelled():
+    """ISSUE-080 R1：process_chunk 中抛出的 PipelineCancelled 必须穿透 gather
+    re-raise，build_graph 终态为 cancelled，而非被静默吞没为 failed_chunk。
+
+    回归保护：旧实现 ``for result in results: if isinstance(result, Exception):
+    failed_chunk_count += 1`` 把 PipelineCancelled 也计入失败计数，循环继续遍历
+    剩余所有 batches，导致 cancel 信号在 chunk loop 内丢失、UI 永远卡 CANCELLING。
+    """
+    from negentropy.knowledge.exceptions import PipelineCancelled
+
+    call_count = {"n": 0}
+
+    async def cancelling_extract(*args, **kwargs):
+        call_count["n"] += 1
+        # 第一次调用即抛 PipelineCancelled；按 batch_size，整批 gather 收到混合异常时
+        # 需仍能让外层捕获 cancel 终态。
+        raise PipelineCancelled(run_id="test-run", last_stage="extracting")
+
+    FakeExtractorClass = _make_fake_extractor_class(cancelling_extract)
+    repository = PhaseTrackingFakeRepository()
+    service = GraphService(repository=repository, config=GraphBuildConfig())
+
+    chunks = [{"id": f"c{i}", "content": f"text-{i}"} for i in range(4)]
+
+    with (
+        _patch_build_graph(repository),
+        patch(
+            "negentropy.knowledge.graph.service.CompositeEntityExtractor",
+            FakeExtractorClass,
+        ),
+        patch(
+            "negentropy.knowledge.graph.service.CompositeRelationExtractor",
+            FakeExtractorClass,
+        ),
+    ):
+        result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=chunks)
+
+    assert result.status == "cancelled", (
+        f"build_graph 终态必须为 cancelled（PipelineCancelled 必须穿透 gather re-raise），实际={result.status}"
+    )
+    # cancel 终态写入必须发生
+    cancelled_call = next(
+        (c for c in reversed(repository.update_calls) if c.get("status") == "cancelled"),
+        None,
+    )
+    assert cancelled_call is not None, "cancel 终态 update_build_run(status='cancelled') 必须被调用"
+
+
+@pytest.mark.asyncio
+async def test_cancel_between_batches_short_circuits_next_batch():
+    """ISSUE-080 R2：批次入口的 in-memory cancel 检查必须在下一批 LLM 调用前生效。
+
+    构造：单 chunk 一批，首批正常完成后通过 signal_cancel 触发取消，第二批应被
+    批次入口 ``if is_cancelled(run_id): raise PipelineCancelled`` 短路，不再调用
+    extractor。
+    """
+    from negentropy.knowledge.cancellation import (
+        _registry_size,
+        register_cancellable_run,
+        signal_cancel,
+    )
+
+    captured_run_ids: list[str] = []
+
+    def capturing_register(run_id: str):
+        captured_run_ids.append(run_id)
+        return register_cancellable_run(run_id)
+
+    call_count = {"n": 0}
+
+    async def conditional_extract(*args, **kwargs):
+        call_count["n"] += 1
+        # 第一批的第一个 chunk 完成后立即触发 cancel；下一批不应再被调用。
+        if call_count["n"] == 1 and captured_run_ids:
+            signal_cancel(captured_run_ids[-1])
+        return []  # 返回空实体，避免触发后续 resolver/persistence 路径
+
+    FakeExtractorClass = _make_fake_extractor_class(conditional_extract)
+    repository = PhaseTrackingFakeRepository()
+    # batch_size=1 强制每个 chunk 独立一批；max_concurrency=1 避免 gather 并发干扰断言。
+    service = GraphService(
+        repository=repository,
+        config=GraphBuildConfig(batch_size=1, max_concurrency=1),
+    )
+
+    chunks = [{"id": f"c{i}", "content": f"text-{i}"} for i in range(5)]
+
+    initial_registry = _registry_size()
+    with (
+        _patch_build_graph(repository),
+        patch(
+            "negentropy.knowledge.graph.service.CompositeEntityExtractor",
+            FakeExtractorClass,
+        ),
+        patch(
+            "negentropy.knowledge.graph.service.CompositeRelationExtractor",
+            FakeExtractorClass,
+        ),
+        patch(
+            "negentropy.knowledge.graph.service.register_cancellable_run",
+            side_effect=capturing_register,
+        ),
+    ):
+        result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=chunks)
+
+    assert result.status == "cancelled", f"build_graph 必须以 cancelled 终态退出，实际={result.status}"
+    # 关键不变量：批次入口短路后，extractor 不应被剩余 chunks 调用。
+    # entity_extractor 调用 1 次（首批触发 cancel），relation_extractor 也调用 1 次（同一首批），共 ≤ 2 次。
+    # 严格断言：≤ 2 << 5（chunks 总数），证明剩余 chunks 未进入 process_chunk。
+    assert call_count["n"] <= 2, (
+        f"批次入口 in-memory cancel 检查失效——cancel 后仍调用 extractor {call_count['n']} 次（应 ≤ 2）"
+    )
+    # 注册表必须清理（finally 块的 unregister_cancellable_run 不可回归）
+    assert _registry_size() == initial_registry, "cancellation registry 必须在 build_graph 结束后清理"
+
+
+@pytest.mark.asyncio
+async def test_maybe_report_chunk_progress_skips_when_cancelled():
+    """ISSUE-080 R3：cancel 已 set 后，chunk 进度上报必须早出，不再发起
+    ``update_build_run(status='running', ...)`` 调用——否则原 SQL 守卫修复前会
+    把 cancelling 回写为 running（即便修复后 SQL 守卫拒之，多余的调用也是噪音）。
+
+    构造：batch_size=2、chunks=4（两批），首批完成后触发 cancel；统计 cancel 后
+    再发出的 ``update_build_run(status='running')`` 调用应为 0。
+    """
+    from negentropy.knowledge.cancellation import register_cancellable_run, signal_cancel
+
+    captured_run_ids: list[str] = []
+
+    def capturing_register(run_id: str):
+        captured_run_ids.append(run_id)
+        return register_cancellable_run(run_id)
+
+    cancel_triggered = {"after_call": 2}  # 第二次 extract 调用后触发（首批 2 chunks 完成）
+    call_count = {"n": 0}
+
+    async def conditional_extract(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == cancel_triggered["after_call"] and captured_run_ids:
+            signal_cancel(captured_run_ids[-1])
+        return []
+
+    FakeExtractorClass = _make_fake_extractor_class(conditional_extract)
+    repository = PhaseTrackingFakeRepository()
+    service = GraphService(
+        repository=repository,
+        config=GraphBuildConfig(batch_size=2, max_concurrency=2),
+    )
+
+    chunks = [{"id": f"c{i}", "content": f"text-{i}"} for i in range(4)]
+
+    with (
+        _patch_build_graph(repository),
+        patch(
+            "negentropy.knowledge.graph.service.CompositeEntityExtractor",
+            FakeExtractorClass,
+        ),
+        patch(
+            "negentropy.knowledge.graph.service.CompositeRelationExtractor",
+            FakeExtractorClass,
+        ),
+        patch(
+            "negentropy.knowledge.graph.service.register_cancellable_run",
+            side_effect=capturing_register,
+        ),
+    ):
+        result = await service.build_graph(corpus_id=uuid4(), app_name="test-app", chunks=chunks)
+
+    assert result.status == "cancelled"
+    # 取出 chunk 节流上报的 running 调用：维度 = (status='running' AND progress 单字段更新)。
+    # emit_phase 也会写 status='running' 但带 warnings；maybe_report_chunk_progress 只传 progress。
+    chunk_progress_running_calls = [
+        c for c in repository.update_calls if c.get("status") == "running" and "warnings" not in c
+    ]
+    # 首批完成后触发 cancel；理论上 maybe_report_chunk_progress 节流间隔 10s 也可能不触发首次上报。
+    # 关键不变量：cancel 后绝无第二次进度上报（即便有首次，count 也 ≤ 1）。
+    assert len(chunk_progress_running_calls) <= 1, (
+        f"cancel 后 maybe_report_chunk_progress 不应再发起 update_build_run，"
+        f"实际节流上报 {len(chunk_progress_running_calls)} 次"
+    )

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1743,5 +1743,33 @@
 - **后续防范**：
   1. 通信介质从 SSE 切换到 HTTP 轮询时，**必须**逐项审视原 SSE 在长连接内实现的状态机（发现期、run_id 锁、grace、idle 判定），不能假设“后端返回最新行”就语义等价；
   2. 凡“先 ack 入队、后写 DB 行”的 fire-and-forget 设计，前端轮询端点必须显式区分“尚未落库（pending）”与“无任何 run（idle）”两种语义，不可合并；
-  3. 任何“拿到新 run_id 但状态异常”的客户端分支，结尾必须显式更新 lock 或调用 stop，不允许“仅 setTimeout 后 return”的自旋。
+  3. 任何”拿到新 run_id 但状态异常”的客户端分支，结尾必须显式更新 lock 或调用 stop，不允许”仅 setTimeout 后 return”的自旋。
 - **同类问题影响**：项目内其他从 SSE 退化为轮询的进度上报场景（Pipeline RUNNING 看门狗、Job watcher 等）需用同一清单复核；新增「fire-and-forget + 进度查询」端点时，应将 `only_active` 类参数作为契约一部分而非可选优化。
+
+---
+
+## ISSUE-080 KG Build Run 取消信号被状态机回写覆盖，UI 永卡 CANCELLING（2026-05-11）
+
+- **表因**：`Knowledge → Pipelines` 点击取消 KG Build Run 后，Run 始终停留在 `CANCELLING` 状态，永不收敛到 `CANCELED`；后端处理是否真正中断也不可见。用户截图两条 runs 分别卡在 CANCELLING 2m42s 与 38m05s，远超已有 5-min watchdog 阈值，证明既非偶发也非”等一会就好”。
+- **根因**：5 处 bug 共谋形成”取消信号被自家进度上报反复回写”的竞态环：
+  1. **`update_build_run` SQL 无状态机守卫**（[`graph/repository.py`](../apps/negentropy/src/negentropy/knowledge/graph/repository.py)）：原 SQL `SET status = :status, completed_at = CASE WHEN :status IN (终态) THEN NOW() END WHERE id = :run_id`——`CASE` 无 `ELSE`，非终态写入直接把 `completed_at` 清零；且 `status` 无条件覆盖。取消 API 写入 `status='cancelling', completed_at=NOW()` 后，build task 下一次 `maybe_report_chunk_progress`（每 5 chunks / 10s）调用 `update_build_run(status='running', ...)` 直接把 `cancelling` 回滚为 `running`，watchdog 的 `WHERE status='cancelling'` 永远命中不到。
+  2. **`asyncio.gather(return_exceptions=True)` 吞 `PipelineCancelled`**（[`graph/service.py`](../apps/negentropy/src/negentropy/knowledge/graph/service.py)）：`PipelineCancelled` 继承 `Exception`（刻意避开 `BaseException`），被打包进 results 后按”chunk 失败”计入 `failed_chunk_count` 静默吞没，批处理循环继续遍历剩余所有 batches。
+  3. **`maybe_report_chunk_progress` 缺 cancel 守卫 + batches 之间缺 `is_cancelled` 检查**：与 Bug 1 联动，每 5 chunks/10s 就把 `cancelling` 改回 `running`。
+  4. **`process_chunk` 内 `except (TimeoutError, Exception)` 误吞并重试 cancel**：浪费 1 次 LLM 调用窗口（最多 2 × 60s）。
+  5. **Watchdog 间隔 300s + 阈值 5min（且重复注册）**：即便其他 bug 不存在，最坏兜底仍需 10 分钟；修复 Bug 1 后此处可缩紧。
+- **处理方式**（5 项正交修复，主修 + 顺手清理）：
+  1. **SQL 状态机守卫**：`update_build_run` SQL 加 `WHERE` 守卫——终态写入永远允许；非终态写入要求 `DB.status NOT IN (terminal, 'cancelling')`。`completed_at` CASE 加 `ELSE completed_at` 保留旧值。零行 UPDATE 走 `debug` 日志 `build_run_update_skipped_by_state_guard` 留观测线索。
+  2. **批次循环显式 re-raise PipelineCancelled**：`gather` 返回后**第一遍**遍历 results 仅识别 `PipelineCancelled` 并 re-raise，**第二遍**才走 `failed_chunk_count` 路径；批次入口加 `if is_cancelled(run_id): raise PipelineCancelled(...)` 早退。
+  3. **`process_chunk` retry 短路**：`except (TimeoutError, Exception) as exc: if isinstance(exc, PipelineCancelled): raise` 优先于 retry 判断。
+  4. **`maybe_report_chunk_progress` cancel 守卫**：函数入口 `if is_cancelled(run_id): return`。
+  5. **Watchdog 收紧 + 去重**：统一 watchdog `interval_seconds=300→60`，删除重复 `_kg_build_watchdog_tick` 注册；默认 `cancelling_threshold_minutes=5→2`。
+- **验证证据**：
+  - 单元测试 7 条（`TestUpdateBuildRunStateMachineGuard` ×4 + service 取消传播 ×3）全绿；
+  - 相关回归测试 68 条全绿（`test_graph_repository` + `test_graph_service` + `test_pipeline_tracker_cancel` + `test_cancel_api`）。
+- **后续防范**：
+  1. **状态机迁移合法性**应在 SQL 层显式守护（Kleppmann DDIA §9.4：多写入路径必须通过 SQL 约束序列化迁移合法性，而非寄望每个 call-site 正确判断）；
+  2. **协作式取消**检查点必须在所有 hot loop 入口铺设，且 `asyncio.gather(return_exceptions=True)` 后**第一遍**必须扫自定义 cancel 异常；
+  3. **任何长任务的进度心跳**必须区分”非终态写入”（保留 `completed_at` 旧值）与”终态写入”（设 `NOW()`），既保留 cancel 时间锚，也让 watchdog 阈值真实反映”最后心跳”而非”启动时间”。
+- **同类问题影响**：
+  - KB 侧 `KnowledgeRunDao` 已通过条件 UPDATE + OCC 机制规避同型 race；KG 侧本次修复使两侧语义对齐；
+  - `asyncio.gather(return_exceptions=True)` 误吞 cancel 是 Python asyncio 协作式取消的经典坑，凡使用该模式的批处理循环都需复核是否会吞掉自定义 cancel 异常。


### PR DESCRIPTION
## 概要

KG Build Run 取消操作始终无效：点击取消后 Run 卡在 `CANCELLING` 状态（截图显示 38+ 分钟），永不收敛到 `CANCELED`，后端处理也未真正中断。

**根因**：5 处 bug 共谋导致"取消信号被自家进度上报反复回写"的竞态环——核心缺陷是 `update_build_run` SQL 无状态机守卫，build task 的进度上报每 5 chunks / 10s 把 cancel API 已写入的 `cancelling` 回滚为 `running`，watchdog 的 `WHERE status='cancelling'` 永远命中不到。

## 改动

| 修复 | 文件 | 说明 |
|------|------|------|
| Fix 1: SQL 状态机守卫 | `graph/repository.py` | `update_build_run` 加 WHERE 守卫（终态写入允许、非终态要求 DB 非终态/cancelling）；`completed_at` CASE 加 `ELSE completed_at` 保留旧值 |
| Fix 2: re-raise cancel | `graph/service.py` | 批次循环 `gather` 返回后优先 re-raise `PipelineCancelled`；批次入口加 `is_cancelled` 早退 |
| Fix 3: retry 短路 + 守卫 | `graph/service.py` | `process_chunk` except 块短路 cancel（不重试）；`maybe_report_chunk_progress` 加 cancel 守卫 |
| Fix 4+5: watchdog 收紧 | `engine/bootstrap.py` + `repository.py` | interval 300→60s；threshold 5→2min；去重 `_kg_build_watchdog_tick` |

## 测试

- **7 条新增单测**（`TestUpdateBuildRunStateMachineGuard` ×4 + service cancel 传播 ×3）
- **68 条相关回归测试全绿**（`test_graph_repository` + `test_graph_service` + `test_pipeline_tracker_cancel` + `test_cancel_api`）

## 关键不变量

1. SQL 文本包含 `status NOT IN ('completed','failed','cancelled','cancelling')` 守卫
2. `completed_at` CASE 包含 `ELSE completed_at` 保留分支
3. 零行 UPDATE（被守卫拒绝）走 debug 日志，不发 info 误报
4. 批次入口短路后 extractor 调用次数 ≤ 2（远小于 chunks 总数）
5. cancel 后 `maybe_report_chunk_progress` 不再发起 `update_build_run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)