### PR TITLE
fix(knowledge-graph): 修复 KG Build Run 卡死无法收敛 + 补全 Graph 页面取消按钮

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/BuildPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/BuildPanel.tsx
@@ -16,12 +16,18 @@ function statusColor(status: string) {
       return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
     case "running":
       return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
+    case "cancelling":
+      return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400";
     case "failed":
       return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    case "cancelled":
+      return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
     default:
       return "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400";
   }
 }
+
+const CANCELLABLE_STATUSES = new Set(["pending", "running", "cancelling"]);
 
 function formatDuration(run: GraphBuildRunRecord): string {
   if (!run.started_at) return "-";
@@ -36,9 +42,11 @@ function formatDuration(run: GraphBuildRunRecord): string {
 
 interface BuildHistoryListProps {
   runs: GraphBuildRunRecord[];
+  corpusId?: string | null;
+  onCancel?: (run: GraphBuildRunRecord) => void;
 }
 
-export function BuildHistoryList({ runs }: BuildHistoryListProps) {
+export function BuildHistoryList({ runs, corpusId, onCancel }: BuildHistoryListProps) {
   if (!runs.length) {
     return (
       <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
@@ -60,9 +68,22 @@ export function BuildHistoryList({ runs }: BuildHistoryListProps) {
             >
               {run.status}
             </span>
-            <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
-              {formatDuration(run)}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+                {formatDuration(run)}
+              </span>
+              {CANCELLABLE_STATUSES.has(run.status) && onCancel && corpusId && (
+                <button
+                  type="button"
+                  className="text-[10px] text-rose-500 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
+                  onClick={() => onCancel(run)}
+                  disabled={run.status === "cancelling"}
+                  title={run.status === "cancelling" ? "正在取消..." : "取消此构建"}
+                >
+                  {run.status === "cancelling" ? "取消中" : "取消"}
+                </button>
+              )}
+            </div>
           </div>
           <div className="mt-1.5 flex gap-3 text-[11px] text-zinc-600 dark:text-zinc-400">
             <span>实体 {run.entity_count}</span>

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -4,11 +4,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { KgBuildProgressPill } from "@/components/ui/KgBuildProgressPill";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import {
   type GraphBuildRunRecord,
   type GraphSearchResultItem,
   type KnowledgeGraphPayload,
   buildKnowledgeGraph,
+  cancelPipelineRun,
   fetchCorpusGraph,
 } from "@/features/knowledge";
 
@@ -78,6 +80,7 @@ export default function KnowledgeGraphPage() {
   const simulationRef = useRef<
     import("d3-force").Simulation<GraphNodePos, undefined> | null
   >(null);
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   const loadGraph = useCallback(
     async (cid: string) => {
@@ -176,6 +179,39 @@ export default function KnowledgeGraphPage() {
       setBuilding(false);
     }
   }, [corpusId, loadGraph]);
+
+  const handleCancelBuildRun = useCallback(
+    async (run: GraphBuildRunRecord) => {
+      if (!corpusId) return;
+      const confirmed = await confirm({
+        title: "取消图谱构建",
+        message: (
+          <div className="space-y-2">
+            <p>
+              确定取消构建 <span className="font-mono">{run.run_id}</span>?
+            </p>
+            <p className="text-xs opacity-80">
+              已写入的实体和关系不会回滚（best-effort 取消）。
+            </p>
+          </div>
+        ),
+        confirmLabel: "确认取消",
+        cancelLabel: "保持运行",
+        destructive: true,
+      });
+      if (!confirmed) return;
+      try {
+        await cancelPipelineRun(run.run_id || run.id, "kg", {
+          appName: APP_NAME,
+          corpusId,
+        });
+        await loadGraph(corpusId);
+      } catch (err) {
+        console.error("cancel_build_failed", err);
+      }
+    },
+    [confirm, corpusId, loadGraph],
+  );
 
   const handlePillTerminal = useCallback(() => {
     setPillEnqueued(false);
@@ -773,7 +809,7 @@ export default function KnowledgeGraphPage() {
                 <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                   构建历史
                 </h3>
-                <BuildHistoryList runs={runs} />
+                <BuildHistoryList runs={runs} corpusId={corpusId} onCancel={handleCancelBuildRun} />
               </div>
 
               {/* Path Explorer */}
@@ -806,6 +842,7 @@ export default function KnowledgeGraphPage() {
           </aside>
         </div>
       </div>
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0030_kg_build_runs_add_updated_at.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0030_kg_build_runs_add_updated_at.py
@@ -1,0 +1,47 @@
+"""kg_build_runs 增加 updated_at 列
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-05-11 00:00:00.000000+00:00
+
+设计动机：
+  看门狗 finalize_stale_kg_build_runs 使用 COALESCE(completed_at, created_at) 判断
+  running 任务是否超时，但 running 任务 completed_at 为 NULL 且 created_at 不变，
+  导致超时判定永远不触发。添加 updated_at 列后，看门狗改用 COALESCE(updated_at, created_at)
+  即可正确检测卡死任务。
+
+  Migration 同时回填已有行的 updated_at，使当前卡死的 running 任务在下次看门狗轮询时
+  立即被收敛到 failed 终态。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0030"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("ALTER TABLE negentropy.kg_build_runs ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ"))
+    op.execute(
+        sa.text(
+            "UPDATE negentropy.kg_build_runs "
+            "SET updated_at = COALESCE(completed_at, created_at) "
+            "WHERE updated_at IS NULL"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE negentropy.kg_build_runs "
+            "ALTER COLUMN updated_at SET DEFAULT NOW(), "
+            "ALTER COLUMN updated_at SET NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("ALTER TABLE negentropy.kg_build_runs DROP COLUMN IF EXISTS updated_at"))

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -144,6 +144,7 @@ class BuildRunRecord:
     started_at: datetime | None
     completed_at: datetime | None
     created_at: datetime
+    updated_at: datetime | None = None
     progress_percent: float = 0.0
     warnings: list[dict[str, Any]] | None = None
 
@@ -1768,9 +1769,9 @@ class AgeGraphRepository(GraphRepository):
 
         query = text(f"""
             INSERT INTO {self._schema}.kg_build_runs
-                (id, app_name, corpus_id, run_id, status, extractor_config, model_name, started_at)
+                (id, app_name, corpus_id, run_id, status, extractor_config, model_name, started_at, updated_at)
             VALUES
-                (:id, :app_name, :corpus_id, :run_id, 'running', CAST(:config AS jsonb), :model, NOW())
+                (:id, :app_name, :corpus_id, :run_id, 'running', CAST(:config AS jsonb), :model, NOW(), NOW())
         """)
 
         async with self._session_scope() as session:
@@ -1824,6 +1825,7 @@ class AgeGraphRepository(GraphRepository):
                 progress_percent = COALESCE(:progress, progress_percent),
                 warnings = COALESCE(CAST(:warnings AS json), warnings),
                 processed_chunk_ids = COALESCE(CAST(:chunk_ids AS json), processed_chunk_ids),
+                updated_at = NOW(),
                 completed_at = CASE WHEN CAST(:status AS varchar) IN ('completed', 'failed', 'cancelled') THEN NOW() END
             WHERE id = :run_id
         """)
@@ -1944,7 +1946,7 @@ class AgeGraphRepository(GraphRepository):
         query = text(f"""
             SELECT id, app_name, corpus_id, run_id, status,
                    entity_count, relation_count, extractor_config, model_name,
-                   error_message, started_at, completed_at, created_at,
+                   error_message, started_at, completed_at, created_at, updated_at,
                    progress_percent, warnings
             FROM {self._schema}.kg_build_runs
             WHERE corpus_id = :corpus_id AND app_name = :app_name
@@ -1979,6 +1981,7 @@ class AgeGraphRepository(GraphRepository):
                 started_at=row.started_at,
                 completed_at=row.completed_at,
                 created_at=row.created_at,
+                updated_at=row.updated_at,
                 progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
                 warnings=row.warnings if row.warnings else None,
             )
@@ -1999,7 +2002,7 @@ class AgeGraphRepository(GraphRepository):
         query = text(f"""
             SELECT id, app_name, corpus_id, run_id, status,
                    entity_count, relation_count, extractor_config, model_name,
-                   error_message, started_at, completed_at, created_at,
+                   error_message, started_at, completed_at, created_at, updated_at,
                    progress_percent, warnings
             FROM {self._schema}.kg_build_runs
             WHERE run_id = :run_id AND app_name = :app_name
@@ -2027,6 +2030,7 @@ class AgeGraphRepository(GraphRepository):
             started_at=row.started_at,
             completed_at=row.completed_at,
             created_at=row.created_at,
+            updated_at=row.updated_at,
             progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
             warnings=row.warnings if row.warnings else None,
         )
@@ -2062,7 +2066,7 @@ class AgeGraphRepository(GraphRepository):
             select_stmt = text(f"""
                 SELECT id, status, warnings, app_name, corpus_id, run_id,
                        entity_count, relation_count, extractor_config, model_name,
-                       error_message, started_at, completed_at, created_at, progress_percent
+                       error_message, started_at, completed_at, created_at, updated_at, progress_percent
                 FROM {self._schema}.kg_build_runs
                 WHERE run_id = :run_id AND app_name = :app_name
                 FOR UPDATE
@@ -2089,6 +2093,7 @@ class AgeGraphRepository(GraphRepository):
                     started_at=row.started_at,
                     completed_at=completed_at_override if completed_at_override is not None else row.completed_at,
                     created_at=row.created_at,
+                    updated_at=row.updated_at,
                     progress_percent=float(row.progress_percent) if row.progress_percent else 0.0,
                     warnings=updated_warnings or None,
                 )
@@ -2105,7 +2110,8 @@ class AgeGraphRepository(GraphRepository):
                 UPDATE {self._schema}.kg_build_runs
                 SET status = :status,
                     warnings = CAST(:warnings AS json),
-                    completed_at = NOW()
+                    completed_at = NOW(),
+                    updated_at = NOW()
                 WHERE id = :id
             """)
             await session.execute(
@@ -2143,7 +2149,7 @@ class AgeGraphRepository(GraphRepository):
                     error_message = COALESCE(error_message, :stale_msg),
                     completed_at = NOW()
                 WHERE status = 'running'
-                  AND COALESCE(completed_at, created_at) < NOW() - (:running_threshold || ' minutes')::interval
+                  AND COALESCE(updated_at, created_at) < NOW() - (:running_threshold || ' minutes')::interval
                   {"AND app_name = :app_name" if app_name is not None else ""}
             """)
             cancelled_stmt = text(f"""
@@ -2151,7 +2157,7 @@ class AgeGraphRepository(GraphRepository):
                 SET status = 'cancelled',
                     completed_at = NOW()
                 WHERE status = 'cancelling'
-                  AND COALESCE(completed_at, created_at) < NOW() - (:cancelling_threshold || ' minutes')::interval
+                  AND COALESCE(updated_at, created_at) < NOW() - (:cancelling_threshold || ' minutes')::interval
                   {"AND app_name = :app_name" if app_name is not None else ""}
             """)
 


### PR DESCRIPTION
## Summary

- 修复看门狗 `finalize_stale_kg_build_runs` 无法收敛 running 状态卡死任务的根因：`kg_build_runs` 表缺少 `updated_at` 列，超时判定 `COALESCE(completed_at, created_at)` 对 running 任务永远退回到不变的 `created_at`
- 新增 Alembic migration 0030 添加 `updated_at` 列并回填已有行，确保当前卡死的 running 任务在下次看门狗轮询（5 分钟）即被收敛为 `failed`
- KG Graph 页面 `BuildHistoryList` 组件补全取消按钮（running/pending/cancelling 状态可见），复用已有的 `cancelPipelineRun` API + `useConfirmDialog` 确认对话框

## Test plan

- [ ] 部署后确认 migration 0030 执行成功，`kg_build_runs.updated_at` 列存在且已回填
- [ ] 确认已有 running 卡死任务被看门狗自动收敛（观察日志 `kg_build_watchdog_finalized`）
- [ ] 在 KG Graph 页面构建历史中确认取消按钮可见且可点击
- [ ] 点击取消后确认状态从 running → cancelling → cancelled 正常流转
- [ ] `pnpm typecheck` 通过

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)