### PR TITLE
refactor(knowledge-graph): KG Build API 改为 fire-and-forget 模式，后台异步执行构建

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/graph/build/route.ts
@@ -1,15 +1,15 @@
-import { LONG_TASK_PROXY_TIMEOUT_MS, proxyPost } from "../../../../_proxy";
+import { DEFAULT_PROXY_TIMEOUT_MS, proxyPost } from "../../../../_proxy";
 
 export async function POST(
   request: Request,
   context: { params: Promise<{ corpusId: string }> },
 ) {
   const { corpusId } = await context.params;
-  // KG build 是长任务（典型 1k chunk 数分钟）：默认 30s 不够；用长任务上限 15min。
-  // UI 通过 SSE 订阅 progress 端点拿到 SSoT，POST 即便超时也不影响最终态显示。
+  // 后端 fire-and-forget：_init_build_run 即刻返回 run_id，实际构建在后台 async Task 执行。
+  // 30s 足以覆盖 init 阶段（DB insert + extractor 创建）；进度通过轮询 build-runs/latest 获取。
   return proxyPost(
     request,
     `/knowledge/base/${encodeURIComponent(corpusId)}/graph/build`,
-    { timeoutMs: LONG_TASK_PROXY_TIMEOUT_MS },
+    { timeoutMs: DEFAULT_PROXY_TIMEOUT_MS },
   );
 }

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import mimetypes
 import re
@@ -190,6 +191,9 @@ if TYPE_CHECKING:
 
 logger = get_logger("negentropy.knowledge.api")
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
+
+# Fire-and-forget 后台任务强引用持有器（与 paper_kg_pipeline._BACKGROUND_TASKS 同型）
+_KG_BUILD_BG_TASKS: set[asyncio.Task[None]] = set()
 
 
 def _normalize_pipeline_stage_payloads(
@@ -3052,34 +3056,53 @@ async def build_knowledge_graph(
             extraction_schema_name=payload.extraction_schema,
         )
 
-        # 执行图谱构建
+        # Fire-and-forget：同步创建 build run 记录（<1s），立即返回 run_id，
+        # 实际构建在后台 asyncio.Task 中执行。前端通过轮询 build-runs/latest 获取进度。
         graph_service = _get_graph_service()
-        result = await graph_service.build_graph(
+        ctx = await graph_service._init_build_run(
             corpus_id=corpus_id,
             app_name=resolved_app,
             chunks=chunks,
             config=config,
         )
 
+        async def _run_build_background() -> None:
+            try:
+                result = await graph_service._execute_build(ctx)
+                logger.info(
+                    "api_graph_build_completed",
+                    corpus_id=str(corpus_id),
+                    run_id=result.run_id,
+                    entity_count=result.entity_count,
+                    relation_count=result.relation_count,
+                )
+            except Exception as exc:
+                logger.error(
+                    "api_graph_build_background_failed",
+                    corpus_id=str(corpus_id),
+                    run_id=ctx.run_id,
+                    error=str(exc),
+                )
+
+        task = asyncio.create_task(_run_build_background())
+        _KG_BUILD_BG_TASKS.add(task)
+        task.add_done_callback(_KG_BUILD_BG_TASKS.discard)
+
         logger.info(
-            "api_graph_build_completed",
+            "api_graph_build_enqueued",
             corpus_id=str(corpus_id),
-            run_id=result.run_id,
-            entity_count=result.entity_count,
-            relation_count=result.relation_count,
+            run_id=ctx.run_id,
+            chunk_count=len(chunks),
         )
 
         return GraphBuildResponse(
-            run_id=result.run_id,
-            corpus_id=result.corpus_id,
-            status=result.status,
-            entity_count=result.entity_count,
-            relation_count=result.relation_count,
-            chunks_processed=result.chunks_processed,
-            elapsed_seconds=result.elapsed_seconds,
-            error_message=result.error_message,
-            warnings=result.warnings,
-            failed_chunk_count=result.failed_chunk_count,
+            run_id=ctx.run_id,
+            corpus_id=corpus_id,
+            status="running",
+            entity_count=0,
+            relation_count=0,
+            chunks_processed=0,
+            elapsed_seconds=0.0,
         )
 
     except KnowledgeError as exc:

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -63,6 +63,22 @@ logger = get_logger("negentropy.knowledge.graph_service")
 # ============================================================================
 
 
+@dataclass
+class BuildRunContext:
+    """_init_build_run → _execute_build 的上下文传递物"""
+
+    run_id: str
+    run_uuid: UUID
+    corpus_id: UUID
+    app_name: str
+    chunks: list[dict[str, Any]]
+    config: GraphBuildConfig
+    entity_extractor: CompositeEntityExtractor
+    relation_extractor: CompositeRelationExtractor
+    start_time: float
+    normalized_llm_model: str
+
+
 @dataclass(frozen=True)
 class GraphBuildResult:
     """图谱构建结果
@@ -238,30 +254,21 @@ class GraphService:
             logger.warning("unknown_extraction_schema", schema_name=name)
         return schema
 
-    async def build_graph(
+    async def _init_build_run(
         self,
         corpus_id: UUID,
         app_name: str,
         chunks: list[dict[str, Any]],
         config: GraphBuildConfig | None = None,
-    ) -> GraphBuildResult:
-        """构建知识图谱
+    ) -> BuildRunContext:
+        """快速创建构建运行记录（<1s），返回上下文供 _execute_build 或 build_graph 使用。
 
-        从知识块中提取实体和关系，构建图谱。
-
-        Args:
-            corpus_id: 语料库 ID
-            app_name: 应用名称
-            chunks: 知识块列表，每个包含 content 和 metadata
-            config: 构建配置（可选，覆盖默认配置）
-
-        Returns:
-            构建结果统计
+        调用方可在 API 层同步 await 本方法获取 run_id 并立即返回给客户端，
+        再通过 asyncio.create_task 将实际构建推迟到后台执行。
         """
         build_config = config or self._config
         normalized_llm_model = canonicalize_model_name(build_config.llm_model)
 
-        # 按请求级 config 动态创建提取器（单例提取器无法感知 schema 变更）
         request_schema = self._resolve_schema(build_config.extraction_schema_name)
         entity_extractor = CompositeEntityExtractor(
             llm_model=build_config.llm_model,
@@ -284,7 +291,6 @@ class GraphService:
             chunk_count=len(chunks),
         )
 
-        # 创建构建运行记录（构建前元数据写入，使用默认 self._repository）
         run_uuid = await self._repository.create_build_run(
             app_name=app_name,
             corpus_id=corpus_id,
@@ -298,10 +304,51 @@ class GraphService:
             model_name=normalized_llm_model,
         )
 
-        # 注册进程内 fast-path event：cancel API 调 signal_cancel(run_id) 后，
-        # emit_phase 与 process_chunk 入口的 is_cancelled 检查会立即触发退出（R-9 修补）。
-        # 无注册等价于 cancel 仅依赖 emit_phase 边界 DB-poll 兜底，延迟最长一个 phase 周期。
         register_cancellable_run(run_id)
+
+        return BuildRunContext(
+            run_id=run_id,
+            run_uuid=run_uuid,
+            corpus_id=corpus_id,
+            app_name=app_name,
+            chunks=chunks,
+            config=build_config,
+            entity_extractor=entity_extractor,
+            relation_extractor=relation_extractor,
+            start_time=start_time,
+            normalized_llm_model=normalized_llm_model,
+        )
+
+    async def build_graph(
+        self,
+        corpus_id: UUID,
+        app_name: str,
+        chunks: list[dict[str, Any]],
+        config: GraphBuildConfig | None = None,
+    ) -> GraphBuildResult:
+        """构建知识图谱（向后兼容 wrapper：init + execute 顺序调用）。"""
+        ctx = await self._init_build_run(corpus_id, app_name, chunks, config)
+        return await self._execute_build(ctx)
+
+    async def _execute_build(
+        self,
+        ctx: BuildRunContext,
+    ) -> GraphBuildResult:
+        """执行完整 KG 构建管线。
+
+        接受 _init_build_run 创建的上下文，运行 chunk 抽取、实体消解、持久化、
+        后处理等全部阶段。成功/失败/取消均在内部写入 DB 终态。
+        """
+        build_config = ctx.config
+        entity_extractor = ctx.entity_extractor
+        relation_extractor = ctx.relation_extractor
+        run_id = ctx.run_id
+        run_uuid = ctx.run_uuid
+        corpus_id = ctx.corpus_id
+        app_name = ctx.app_name
+        chunks = ctx.chunks
+        start_time = ctx.start_time
+        normalized_llm_model = ctx.normalized_llm_model
 
         # 提升到 try 之外：失败分支需要剥离 _phase 后落库 warnings，避免 DB 行残留
         # 上一次 emit_phase 写入的运行期标记；同时让累积的 algorithm warning + 部分 _metrics
@@ -435,8 +482,10 @@ class GraphService:
             # 双触发条件：每完成 progress_report_chunk_threshold 个 chunk 或距上次上报 ≥
             # progress_report_min_interval_s 秒，取后到者。Lock 保护避免并发互相覆盖。
             progress_lock = asyncio.Lock()
-            progress_report_chunk_threshold = 5
-            progress_report_min_interval_s = 10.0
+            # 自适应节流：20 chunks → 每 1 个上报；2000 chunks → 每 10 个上报。
+            # 时间兜底从 10s 降至 5s，避免 LLM 调用 60s 超时期间前端静默过长。
+            progress_report_chunk_threshold = max(1, total_chunks // 200)
+            progress_report_min_interval_s = 5.0
             progress_state: dict[str, float | int] = {
                 "last_reported_at": time.time(),
                 "last_reported_chunks": 0,
@@ -502,8 +551,16 @@ class GraphService:
 
                 async with semaphore:
                     text = chunk.get("content", "")
+                    chunk_id = str(chunk.get("id", "?"))
                     if not text:
                         return [], []
+
+                    logger.debug(
+                        "chunk_processing_started",
+                        run_id=run_id,
+                        chunk_id=chunk_id,
+                        content_length=len(text),
+                    )
 
                     try:
                         # 提取实体（带超时）
@@ -535,6 +592,13 @@ class GraphService:
                         # 避免在已取消语境下浪费 1 次 LLM 调用窗口（最多 2×60s）。
                         if isinstance(exc, PipelineCancelled):
                             raise
+                        if isinstance(exc, TimeoutError):
+                            logger.warning(
+                                "chunk_processing_timeout",
+                                run_id=run_id,
+                                chunk_id=chunk_id,
+                                timeout_s=chunk_extract_timeout,
+                            )
                         if _retries > 0:
                             await asyncio.sleep(1.0)
                             return await process_chunk(chunk, _retries - 1)
@@ -579,8 +643,16 @@ class GraphService:
                     all_entities.extend(entities)
                     all_relations.extend(relations)
                     chunks_processed += 1
+                    logger.debug(
+                        "chunk_processing_completed",
+                        run_id=run_id,
+                        processed=chunks_processed,
+                        total=total_chunks,
+                        entity_count=len(entities),
+                        relation_count=len(relations),
+                    )
 
-                # 节流上报（每 5 chunk 或 ≥10s）：避免 SSE 静默期超过 30s
+                # 节流上报（自适应 chunk 阈值 + ≥5s 时间兜底）
                 await maybe_report_chunk_progress()
 
             # 回收 litellm 内部 HTTP Session（aiohttp.ClientSession）


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：KG Build API 原为同步阻塞模式，BFF 需 15min 长超时等待后端返回完整构建结果；前端已通过 HTTP 轮询 `build-runs/latest` 获取进度，API 同步等待造成不必要的资源占用与超时风险。
- 关联上下文：前序 PR #503（SSE→HTTP Polling）、#507（卡死收敛+取消按钮）已将前端改为轮询模式，本 PR 完成后端对应的 fire-and-forget 改造。

# 核心变更
- **service.py**：将 `GraphService.build_graph` 拆分为 `_init_build_run`（<1s 快速创建 build run 记录 + 注册取消信号）与 `_execute_build`（后台执行全量构建管线）；原 `build_graph` 保留为向后兼容 wrapper（init + execute 顺序调用）
- **api.py**：API 层同步 await `_init_build_run` 获取 run_id 后立即返回 `status="running"`；实际构建由 `asyncio.create_task` 在后台执行，通过 `_KG_BUILD_BG_TASKS` 强引用集合防止 GC 回收
- **route.ts**：BFF 代理超时从 `LONG_TASK_PROXY_TIMEOUT_MS`（15min）降至 `DEFAULT_PROXY_TIMEOUT_MS`（30s），仅需覆盖 init 阶段
- 进度上报改为自适应节流：`max(1, total_chunks // 200)` + 5s 时间兜底（原固定 5 chunks / 10s）
- 新增 chunk 级 debug 日志（`chunk_processing_started` / `chunk_processing_completed`）及 timeout warning 日志，增强可观测性

# 风险与回滚
- 主要风险：后台 Task 异常时 `_execute_build` 内部已覆盖 DB 终态写入（含双重 fallback），极端情况由看门狗（#502）兜底收敛
- 回滚方式：`git revert` 本提交即可，向后兼容 wrapper `build_graph` 不影响其他调用方

# 验证证据
- 单元测试：ruff lint/format + ESLint 通过
- 集成测试：fire-and-forget 不改变 `_execute_build` 内部逻辑，现有测试覆盖不变
- E2E/Workflow：需浏览器验证：触发 KG Build → API 即刻返回 `running` → 轮询进度正常推进至终态

# 影响范围
- 前端：无变更（前端已为轮询模式）
- 后端：`knowledge/api.py`、`knowledge/graph/service.py`
- GitHub Actions / 文档：无

# Next Best Action
- 验证：在 staging 环境触发一次完整 KG Build，确认 API 响应 < 1s 且后台构建正常完成
- 可选优化：`_init_build_run` 当前为 private 方法，可考虑提升为 public 接口以改善 API 层调用封装