### PR TITLE
fix(knowledge-graph): 对齐 KG 构建任务与 Pipelines 页面的状态展示

### DIFF
--- a/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
+++ b/apps/negentropy-ui/components/ui/KgBuildProgressPill.tsx
@@ -31,6 +31,8 @@ export type KgBuildProgressEvent = {
     | "running"
     | "completed"
     | "failed"
+    | "cancelling"
+    | "cancelled"
     | "idle"
     | "timeout"
     | "switched"
@@ -104,6 +106,8 @@ const STATUS_LABEL: Record<NonNullable<KgBuildProgressEvent["status"]>, string> 
   running: "构建中",
   completed: "已完成",
   failed: "失败",
+  cancelling: "取消中",
+  cancelled: "已取消",
   idle: "无活跃构建",
   timeout: "已超时",
   switched: "切换至新构建",
@@ -127,6 +131,7 @@ function isTerminal(status: KgBuildProgressEvent["status"]): boolean {
   return (
     status === "completed" ||
     status === "failed" ||
+    status === "cancelled" ||
     status === "idle" ||
     status === "timeout" ||
     status === "switched" ||
@@ -262,7 +267,7 @@ export function KgBuildProgressPill({
 
   const status = event.status ?? "pending";
   const percent = Math.max(0, Math.min(100, Math.round((event.progress_percent ?? 0) * 100)));
-  const isRunning = status === "pending" || status === "running";
+  const isRunning = status === "pending" || status === "running" || status === "cancelling";
   const isError = status === "failed" || status === "error" || status === "timeout";
   // 当处于 running 子阶段时优先显示 phase 中文标签，更精确反映"卡在哪一步"。
   // 命中未知阶段 / 非 running 状态时降级为顶层 STATUS_LABEL，保证兼容旧后端。
@@ -285,7 +290,7 @@ export function KgBuildProgressPill({
           "border-emerald-200/80 bg-emerald-50/40 text-emerald-700 dark:border-emerald-800/60 dark:bg-emerald-950/20 dark:text-emerald-200",
         isError &&
           "border-red-200/80 bg-red-50/40 text-red-700 dark:border-red-800/60 dark:bg-red-950/20 dark:text-red-200",
-        (status === "idle" || status === "switched") &&
+        (status === "idle" || status === "switched" || status === "cancelled") &&
           "border-zinc-200/60 bg-zinc-50/40 text-zinc-600 dark:border-zinc-800/50 dark:bg-zinc-900/20 dark:text-zinc-300",
       )}
     >
@@ -295,7 +300,7 @@ export function KgBuildProgressPill({
           isRunning && "animate-pulse bg-violet-500",
           status === "completed" && "bg-emerald-500",
           isError && "bg-red-500",
-          (status === "idle" || status === "switched") && "bg-zinc-400 dark:bg-zinc-600",
+          (status === "idle" || status === "switched" || status === "cancelled") && "bg-zinc-400 dark:bg-zinc-600",
         )}
       />
       <span className="font-medium">知识图谱：{headlineLabel}</span>

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -731,7 +731,9 @@ export type PipelineStageStatus =
   | "running"
   | "completed"
   | "failed"
-  | "skipped";
+  | "skipped"
+  | "cancelling"
+  | "cancelled";
 
 // Pipeline 操作类型
 export type PipelineOperation =

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -391,6 +391,12 @@ export const getPipelineStatusColor = (status?: string): string => {
       return "bg-zinc-500";
     case "skipped":
       return "bg-zinc-300 dark:bg-zinc-600";
+    case "idle":
+      return "bg-zinc-500";
+    case "timeout":
+      return "bg-rose-500";
+    case "switched":
+      return "bg-zinc-500";
     default:
       return "bg-zinc-400";
   }
@@ -418,6 +424,12 @@ export const getPipelineStatusTextColor = (status?: string): string => {
     case "cancelling":
       return "text-amber-700 dark:text-amber-300";
     case "cancelled":
+      return "text-zinc-600 dark:text-zinc-400";
+    case "idle":
+      return "text-zinc-600 dark:text-zinc-400";
+    case "timeout":
+      return "text-rose-600 dark:text-rose-400";
+    case "switched":
       return "text-zinc-600 dark:text-zinc-400";
     default:
       return "text-zinc-500 dark:text-zinc-400";

--- a/apps/negentropy-ui/features/knowledge/utils/unified-pipeline.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/unified-pipeline.ts
@@ -159,6 +159,14 @@ export function kgPhasesToStages(
       } else {
         stages[key] = { status: "skipped", reason: "前置阶段失败" };
       }
+    } else if (lowerStatus === "cancelled") {
+      if (currentIdx >= 0 && i < currentIdx) {
+        stages[key] = { status: "completed" };
+      } else if (i === currentIdx) {
+        stages[key] = { status: "cancelled" };
+      } else {
+        stages[key] = { status: "skipped", reason: "构建已取消" };
+      }
     } else {
       // running / pending / 其他
       if (currentIdx >= 0 && i < currentIdx) {

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -3496,6 +3496,8 @@ async def get_graph_build_history(
                 "started_at": run.started_at.isoformat() if run.started_at else None,
                 "completed_at": run.completed_at.isoformat() if run.completed_at else None,
                 "created_at": run.created_at.isoformat() if run.created_at else None,
+                "progress_percent": float(run.progress_percent) if run.progress_percent else 0.0,
+                "warnings": run.warnings,
             }
             for run in runs
         ],


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：KG 构建流水线缺少 `cancelling` / `cancelled` 状态的端到端展示，同时 `idle` / `timeout` / `switched` 状态在 Pipeline helpers 中缺少显式颜色映射（落入 default 分支）。
- 关联上下文/Issue/文档：#508 后续对齐

# 核心变更
- 前端类型定义补全 `cancelling` / `cancelled` 状态（KgBuildProgressPill 类型、标签、isTerminal/isRunning 归属）
- `pipeline-helpers` 为 `idle` / `timeout` / `switched` 补充显式背景色与文字色映射
- `unified-pipeline.ts` 新增 `cancelled` 分支，与 `failed` 分支对称：已完成阶段保持 completed，当前阶段标 cancelled，后续阶段标 skipped
- 后端 `api.py` build history 响应新增 `progress_percent` 与 `warnings` 字段

# 风险与回滚
- 主要风险：低风险，纯 UI 状态展示与 API 字段扩展（新增字段向后兼容）
- 回滚方式：revert 此 commit

# 验证证据
- 单元测试：N/A
- 集成测试：N/A
- E2E/Workflow：手动验证 cancelling → cancelled 状态流转展示正常
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：KgBuildProgressPill 组件、pipeline-helpers、unified-pipeline、knowledge-api 类型
- 后端：knowledge/api.py build history 端点
- GitHub Actions / 文档：无

# Next Best Action
- 观察 cancelling/cancelled 状态在真实构建取消场景下的端到端表现