### PR TITLE
fix(knowledge-graph): KG Build 超时韧性强化 — 断路器 + 超时降级 + 部分结果保留

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -152,10 +152,10 @@ Output as JSON with the following structure:
         self,
         model: str | None = None,
         temperature: float = 0.0,
-        max_retries: int = 3,
+        max_retries: int = 2,
         fallback_to_regex: bool = True,
         schema: Any | None = None,
-        llm_timeout: float = 60.0,
+        llm_timeout: float = 30.0,
     ) -> None:
         """初始化 LLM 实体提取器
 
@@ -165,9 +165,9 @@ Output as JSON with the following structure:
             max_retries: 最大重试次数
             fallback_to_regex: 失败时是否回退到正则提取器
             schema: ExtractionSchema 实例，用于约束提取类型
-            llm_timeout: 单次 ``litellm.acompletion`` 超时（秒）。litellm 默认无 client-level
-                超时；此值与 service.process_chunk 外层 ``asyncio.wait_for`` 形成双重防御，
-                避免单次 LLM 调用 hang 阻塞整个 build。覆盖 95P 长 chunk 后仍有冗余。
+            llm_timeout: 单次 ``litellm.acompletion`` 超时（秒）。需严格小于 service 层
+                ``chunk_extract_timeout``，确保内层重试 + fallback 在外层 wait_for 触发前完成。
+                30s × 2 retries + 1s backoff ≈ 61s < 90s outer timeout.
         """
         # 惰性解析模型配置（含 api_key），延迟到首次 _extract_with_llm 调用
         # 因为 __init__ 是同步的，无法调用异步 DB 查询
@@ -373,7 +373,7 @@ Output as JSON with the following structure:
                     error=str(exc),
                     timeout_seconds=self._llm_timeout,
                 )
-                await asyncio.sleep(2**attempt)  # 指数退避
+                await asyncio.sleep(1.0)  # 固定 1s 退避，加速失败让 fallback 接管
 
         raise RuntimeError(f"LLM entity extraction failed after {self._max_retries} retries: {last_error}")
 
@@ -520,10 +520,10 @@ Output as JSON with the following structure:
         self,
         model: str | None = None,
         temperature: float = 0.0,
-        max_retries: int = 3,
+        max_retries: int = 2,
         fallback_to_cooccurrence: bool = True,
         schema: Any | None = None,
-        llm_timeout: float = 60.0,
+        llm_timeout: float = 30.0,
     ) -> None:
         """初始化 LLM 关系提取器
 
@@ -533,8 +533,9 @@ Output as JSON with the following structure:
             max_retries: 最大重试次数
             fallback_to_cooccurrence: 失败时是否回退到共现提取器
             schema: ExtractionSchema 实例，用于约束关系类型
-            llm_timeout: 单次 ``litellm.acompletion`` 超时（秒）。同 LLMEntityExtractor
-                语义：与 service.process_chunk 外层 wait_for 形成双重防御。
+            llm_timeout: 单次 ``litellm.acompletion`` 超时（秒）。需严格小于 service 层
+                ``chunk_extract_timeout``，确保内层重试 + fallback 在外层 wait_for 触发前完成。
+                同 LLMEntityExtractor 语义。
         """
         # 惰性解析模型配置（含 api_key），延迟到首次 _extract_with_llm 调用
         self._explicit_model = model
@@ -769,7 +770,7 @@ Output as JSON with the following structure:
                     error=str(exc),
                     timeout_seconds=self._llm_timeout,
                 )
-                await asyncio.sleep(2**attempt)
+                await asyncio.sleep(1.0)  # 固定 1s 退避，加速失败让 fallback 接管
 
         raise RuntimeError(f"LLM relation extraction failed after {self._max_retries} retries: {last_error}")
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/metrics.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/metrics.py
@@ -25,6 +25,8 @@ class KgBuildMetrics:
     avg_confidence: float = 0.0
     chunks_processed: int = 0
     chunks_failed: int = 0
+    chunks_fallback: int = 0  # 使用 fallback 提取器（regex/cooccurrence）的 chunk 数
+    llm_circuit_opened: bool = False  # 断路器是否在构建期间触发
     build_duration_ms: float = 0.0
     algorithm_warnings: int = 0
     community_levels: int = 0

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -64,6 +64,38 @@ logger = get_logger("negentropy.knowledge.graph_service")
 
 
 @dataclass
+class _LLMCircuitBreaker:
+    """Simplified circuit breaker (Nygard, "Release It!", 2018) for KG build LLM calls.
+
+    Two-state model: CLOSED (normal) → OPEN (skip LLM, use fallback directly).
+    No HALF-OPEN state: KG builds are finite batches; the LLM either works or it
+    doesn't within the build window.
+
+    failure_threshold: consecutive LLM failures before opening the circuit.
+    Once open, all remaining chunks use fallback extractors (regex/cooccurrence)
+    which complete in <1s instead of 30-90s per LLM call.
+    """
+
+    consecutive_failures: int = 0
+    failure_threshold: int = 3
+    is_open: bool = False
+
+    def record_failure(self) -> None:
+        self.consecutive_failures += 1
+        if self.consecutive_failures >= self.failure_threshold and not self.is_open:
+            self.is_open = True
+
+    def record_success(self) -> None:
+        if self.consecutive_failures > 0:
+            self.consecutive_failures = 0
+        if self.is_open:
+            self.is_open = False
+
+    def should_skip_llm(self) -> bool:
+        return self.is_open
+
+
+@dataclass
 class BuildRunContext:
     """_init_build_run → _execute_build 的上下文传递物"""
 
@@ -396,6 +428,7 @@ class GraphService:
             all_relations: list[GraphEdge] = []
             chunks_processed = 0
             failed_chunk_count = 0
+            chunks_fallback = 0
             total_chunks = len(chunks)
 
             batch_size = build_config.batch_size
@@ -404,8 +437,14 @@ class GraphService:
             # 单 chunk LLM 提取超时（秒）：包裹 entity / relation extractor.extract
             # 防御场景：单条 chunk LLM 调用 hang 住会阻塞整个 batch 的 asyncio.gather，
             # 上层无心跳 → SSE 端点 progress 静默 → 前端误判"卡死"。
-            # 60s 经验值：覆盖 95P 长 chunk + 3 次指数退避（litellm 内部 1+2+4=7s）后仍有冗余。
-            chunk_extract_timeout = 60.0
+            # 90s 严格大于内层超时预算（2 retries × 30s litellm timeout + 1s backoff ≈ 61s），
+            # 确保内层重试 + fallback 在外层 wait_for 触发前完成。
+            chunk_extract_timeout = 90.0
+
+            # 断路器 (Nygard, "Release It!", 2018, Ch.5)：连续 LLM 失败达到阈值后，
+            # 跳过 LLM 直接使用 fallback 提取器（regex/cooccurrence），避免每个 chunk
+            # 白等 30-90s LLM 超时。两态模型 CLOSED→OPEN，无 HALF-OPEN（构建是有限批次）。
+            circuit_breaker = _LLMCircuitBreaker(failure_threshold=3)
 
             # 阶段化进度上报：把当前阶段元数据写入 warnings JSONB 的最后一条 _phase 条目，
             # SSE 端点透传后由前端 KgBuildProgressPill 解析渲染中文标签。
@@ -535,17 +574,23 @@ class GraphService:
 
             async def process_chunk(
                 chunk: dict[str, Any],
-                _retries: int = 1,
             ) -> tuple[list[GraphNode], list[GraphEdge]]:
-                """处理单个知识块，LLM 提取失败时重试一次 (Nygard, 2018)。
+                """处理单个知识块，LLM 提取失败时降级到 fallback 提取器。
 
-                LLM 调用使用 ``asyncio.wait_for`` 包裹 ``chunk_extract_timeout`` 秒超时，
-                避免单 chunk hang 阻塞整批 ``asyncio.gather``。重试时间窗内仍受 wait_for 约束。
+                韧性机制（三层防御）：
+                1. **断路器 fast-path**：连续 LLM 失败 ≥ threshold 后，跳过 LLM 直接
+                   使用 fallback（regex/cooccurrence），避免剩余 chunk 白等 30-90s。
+                2. **超时降级**：单个 extractor 超时后不重试整个 chunk（浪费 120s），
+                   而是直接调用 fallback 提取器获取基本实体/关系。
+                3. **部分结果保留**：实体提取成功 + 关系提取超时时，保留实体并使用
+                   cooccurrence fallback 获取关系，而非丢弃两者。
 
                 取消检查点（R-8）：协程入口仅查 in-memory event（O(1) dict lookup），
                 **不查 DB**——chunk 数可能 1000+，DB SELECT 会成压力；DB 兜底由
                 emit_phase 阶段边界承担（最长 1 个 phase 周期感知）。
                 """
+                nonlocal chunks_fallback
+
                 if is_cancelled(run_id):
                     raise PipelineCancelled(run_id, last_stage="extracting")
 
@@ -560,7 +605,20 @@ class GraphService:
                         run_id=run_id,
                         chunk_id=chunk_id,
                         content_length=len(text),
+                        circuit_open=circuit_breaker.is_open,
                     )
+
+                    # ── 断路器 fast-path：跳过 LLM，直接 fallback ──
+                    if circuit_breaker.should_skip_llm():
+                        chunks_fallback += 1
+                        return await _fallback_extract_chunk(text, chunk_id)
+
+                    # ── 正常 LLM 提取路径 ──
+                    # 实体提取与关系提取拆分为独立 try/except，实现部分结果保留：
+                    # - 实体成功 + 关系超时 → 保留实体，关系走 fallback
+                    # - 实体超时 → 整个 chunk 走 fallback
+                    entities: list[GraphNode] = []
+                    relations: list[GraphEdge] = []
 
                     try:
                         # 提取实体（带超时）
@@ -568,41 +626,111 @@ class GraphService:
                             entity_extractor.extract(text, corpus_id),
                             timeout=chunk_extract_timeout,
                         )
-
                         # 过滤低置信度实体
                         min_conf = build_config.min_entity_confidence
                         entities = [e for e in entities if e.metadata.get("confidence", 1.0) >= min_conf]
+                    except (TimeoutError, Exception) as exc:
+                        if isinstance(exc, PipelineCancelled):
+                            raise
+                        # 实体提取失败：记录失败 + 整个 chunk 走 fallback
+                        circuit_breaker.record_failure()
+                        if circuit_breaker.is_open:
+                            logger.warning(
+                                "llm_circuit_breaker_opened",
+                                run_id=run_id,
+                                consecutive_failures=circuit_breaker.consecutive_failures,
+                            )
+                        logger.warning(
+                            "chunk_entity_extraction_timeout_using_fallback",
+                            run_id=run_id,
+                            chunk_id=chunk_id,
+                            timeout_s=chunk_extract_timeout,
+                        )
+                        chunks_fallback += 1
+                        return await _fallback_extract_chunk(text, chunk_id)
 
-                        # 提取关系（带超时）
+                    # 实体提取成功 → 尝试关系提取
+                    try:
                         relations = await asyncio.wait_for(
                             relation_extractor.extract(entities, text),
                             timeout=chunk_extract_timeout,
                         )
-
                         # 过滤低置信度关系
                         relations = [
                             r
                             for r in relations
                             if r.metadata.get("confidence", 1.0) >= build_config.min_relation_confidence
                         ]
-
+                        # LLM 全部成功 → 重置断路器
+                        circuit_breaker.record_success()
                         return entities, relations
                     except (TimeoutError, Exception) as exc:
-                        # 取消信号短路（ISSUE-080）：PipelineCancelled 不参与 retry，
-                        # 避免在已取消语境下浪费 1 次 LLM 调用窗口（最多 2×60s）。
                         if isinstance(exc, PipelineCancelled):
                             raise
-                        if isinstance(exc, TimeoutError):
+                        # 关系提取失败：保留已提取的实体，关系走 cooccurrence fallback
+                        circuit_breaker.record_failure()
+                        if circuit_breaker.is_open:
                             logger.warning(
-                                "chunk_processing_timeout",
+                                "llm_circuit_breaker_opened",
+                                run_id=run_id,
+                                consecutive_failures=circuit_breaker.consecutive_failures,
+                            )
+                        logger.warning(
+                            "chunk_relation_extraction_timeout_preserving_entities",
+                            run_id=run_id,
+                            chunk_id=chunk_id,
+                            entity_count=len(entities),
+                            timeout_s=chunk_extract_timeout,
+                        )
+                        chunks_fallback += 1
+                        try:
+                            from .strategy import CooccurrenceRelationExtractor
+
+                            relations = await CooccurrenceRelationExtractor().extract(entities, text)
+                            relations = [
+                                r
+                                for r in relations
+                                if r.metadata.get("confidence", 1.0) >= build_config.min_relation_confidence
+                            ]
+                        except Exception as fallback_exc:
+                            logger.error(
+                                "cooccurrence_fallback_also_failed",
                                 run_id=run_id,
                                 chunk_id=chunk_id,
-                                timeout_s=chunk_extract_timeout,
+                                error=str(fallback_exc),
                             )
-                        if _retries > 0:
-                            await asyncio.sleep(1.0)
-                            return await process_chunk(chunk, _retries - 1)
-                        raise
+                        return entities, relations
+
+            async def _fallback_extract_chunk(
+                text: str,
+                chunk_id: str,
+            ) -> tuple[list[GraphNode], list[GraphEdge]]:
+                """使用 fallback 提取器（regex + cooccurrence）处理 chunk。
+
+                无 LLM 调用，纯本地计算，完成时间 <1s。质量低于 LLM 提取，
+                但保证每个 chunk 至少产出基本实体/关系，避免空图。
+                """
+                from .strategy import CooccurrenceRelationExtractor, RegexEntityExtractor
+
+                try:
+                    entities = await RegexEntityExtractor().extract(text, corpus_id)
+                    min_conf = build_config.min_entity_confidence
+                    entities = [e for e in entities if e.metadata.get("confidence", 1.0) >= min_conf]
+                    relations = await CooccurrenceRelationExtractor().extract(entities, text)
+                    relations = [
+                        r
+                        for r in relations
+                        if r.metadata.get("confidence", 1.0) >= build_config.min_relation_confidence
+                    ]
+                    return entities, relations
+                except Exception as exc:
+                    logger.error(
+                        "fallback_extraction_failed",
+                        run_id=run_id,
+                        chunk_id=chunk_id,
+                        error=str(exc),
+                    )
+                    raise
 
             # 阶段 1：实体/关系抽取（chunk 循环占整体进度 0.0 → 0.80）
             await emit_phase(PHASE_EXTRACTING, 0.0, processed=0, total=total_chunks)
@@ -954,6 +1082,8 @@ class GraphService:
                 avg_confidence=round(avg_conf, 4),
                 chunks_processed=chunks_processed,
                 chunks_failed=failed_chunk_count,
+                chunks_fallback=chunks_fallback,
+                llm_circuit_opened=circuit_breaker.is_open,
                 build_duration_ms=round(elapsed * 1000, 1),
                 algorithm_warnings=len(build_warnings),
                 community_levels=len(levels_data),
@@ -967,6 +1097,8 @@ class GraphService:
             # 落入终态 warnings 会污染历史检视（与 _metrics 同型 sentinel 区分）。
             persisted_warnings: list[dict[str, Any]] = _strip_phase_entries(build_warnings)
             persisted_warnings.append({"_metrics": build_metrics.to_dict()})
+            if circuit_breaker.is_open:
+                persisted_warnings.append({"_circuit_opened": True})
             await build_repo.update_build_run(
                 run_id=run_uuid,
                 status="completed",

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -80,16 +80,17 @@ class _LLMCircuitBreaker:
     failure_threshold: int = 3
     is_open: bool = False
 
-    def record_failure(self) -> None:
+    def record_failure(self) -> bool:
+        """Record a failure. Returns True on CLOSED→OPEN transition."""
         self.consecutive_failures += 1
         if self.consecutive_failures >= self.failure_threshold and not self.is_open:
             self.is_open = True
+            return True
+        return False
 
     def record_success(self) -> None:
-        if self.consecutive_failures > 0:
-            self.consecutive_failures = 0
-        if self.is_open:
-            self.is_open = False
+        self.consecutive_failures = 0
+        # Once open, stay open — two-state model is CLOSED→OPEN only.
 
     def should_skip_llm(self) -> bool:
         return self.is_open
@@ -633,8 +634,8 @@ class GraphService:
                         if isinstance(exc, PipelineCancelled):
                             raise
                         # 实体提取失败：记录失败 + 整个 chunk 走 fallback
-                        circuit_breaker.record_failure()
-                        if circuit_breaker.is_open:
+                        just_opened = circuit_breaker.record_failure()
+                        if just_opened:
                             logger.warning(
                                 "llm_circuit_breaker_opened",
                                 run_id=run_id,
@@ -668,8 +669,8 @@ class GraphService:
                         if isinstance(exc, PipelineCancelled):
                             raise
                         # 关系提取失败：保留已提取的实体，关系走 cooccurrence fallback
-                        circuit_breaker.record_failure()
-                        if circuit_breaker.is_open:
+                        just_opened = circuit_breaker.record_failure()
+                        if just_opened:
                             logger.warning(
                                 "llm_circuit_breaker_opened",
                                 run_id=run_id,


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：KG Build 在 LLM 服务不稳定时，每个 chunk 白等 30-90s 超时，导致整体构建时间过长甚至被误判为"卡死"。
- 关联上下文/Issue/文档：前序 PR #508（fire-and-forget 异步模式）后的韧性强化。

# 核心变更

### 断路器机制（`_LLMCircuitBreaker`）
参考 Nygard "Release It!" 设计，采用 **CLOSED→OPEN 两态模型**（无 HALF-OPEN，因为 KG 构建是有限批次）。连续 LLM 失败 ≥ 3 后跳过 LLM 直接走 fallback（regex/cooccurrence），后续 chunk 完成 <1s 而非 30-90s。一旦打开不再关闭，避免并发 chunk 成功导致 flapping。

### 超时预算重调
| 参数 | 原值 | 新值 | 理由 |
|------|------|------|------|
| `llm_timeout` | 60s | 30s | 单次 LLM 调用更激进超时 |
| `max_retries` | 3 | 2 | 减少无效重试次数 |
| 退避策略 | 指数退避 2^attempt | 固定 1s | 加速失败让 fallback 接管 |
| `chunk_extract_timeout` | 60s | 90s | 严格大于内层预算 2×30s+1s≈61s |

### 部分结果保留
实体/关系提取拆分为独立 try/except：
- **实体成功 + 关系超时** → 保留实体，关系走 cooccurrence fallback
- **实体超时** → 整个 chunk 走 regex + cooccurrence fallback

### 降级兜底（`_fallback_extract_chunk`）
纯本地计算（regex + cooccurrence），完成 <1s，保证每个 chunk 至少产出基本实体/关系，避免空图。

### 指标扩展
`KgBuildMetrics` 新增 `chunks_fallback` 和 `llm_circuit_opened`，持久化到 warnings JSONB 的 `_circuit_opened` 条目。

# 风险与回滚
- 主要风险：断路器过早打开导致大量 chunk 走低质量 fallback；`failure_threshold=3` 可根据实际调整。
- 回滚方式：`git revert` 即可，无数据库迁移。

# 验证证据
- 单元测试：ruff lint + format 通过
- 集成测试：依赖后续实机构建验证
- E2E/Workflow：无

# 影响范围
- 前端：无直接变更，`KgBuildProgressPill` 可通过 warnings `_circuit_opened` 字段展示断路器状态
- 后端：`service.py`（核心韧性逻辑）、`extractors.py`（超时/重试参数）、`metrics.py`（新增指标字段）
- GitHub Actions / 文档：无

# Next Best Action
- 观察 KG Build 实际运行数据，验证断路器阈值（`failure_threshold=3`）是否合理
- 考虑在前端展示 `chunks_fallback` / `llm_circuit_opened` 指标，便于用户感知构建质量