### PR TITLE
feat(tools): 新增 Tools 管理系统 — 数据库驱动工具注册中心 + UI + search_web 运行时重构

### DIFF
--- a/apps/negentropy-ui/app/api/interface/stats/route.ts
+++ b/apps/negentropy-ui/app/api/interface/stats/route.ts
@@ -13,6 +13,7 @@ interface InterfaceStatsResponse {
   skills: { total: number; enabled: number };
   subagents: { total: number; enabled: number };
   models: { total: number; enabled: number; vendors: number };
+  tools: { total: number; enabled: number };
 }
 
 const getBaseUrl = getAguiBaseUrl;
@@ -43,6 +44,7 @@ const defaultStats: InterfaceStatsResponse = {
   skills: { total: 0, enabled: 0 },
   subagents: { total: 0, enabled: 0 },
   models: { total: 0, enabled: 0, vendors: 0 },
+  tools: { total: 0, enabled: 0 },
 };
 
 export async function GET(request: NextRequest) {

--- a/apps/negentropy-ui/app/api/interface/tools/[toolId]/route.ts
+++ b/apps/negentropy-ui/app/api/interface/tools/[toolId]/route.ts
@@ -1,0 +1,33 @@
+import { proxyGet, proxyPatch, proxyDelete } from "@/app/api/interface/_proxy";
+
+/**
+ * 单个 Tool API 代理端点
+ *
+ * GET    /api/interface/tools/{toolId} - 获取工具详情
+ * PATCH  /api/interface/tools/{toolId} - 更新工具
+ * DELETE /api/interface/tools/{toolId} - 删除工具
+ */
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ toolId: string }> },
+) {
+  const { toolId } = await params;
+  return proxyGet(request, `/interface/tools/${toolId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ toolId: string }> },
+) {
+  const { toolId } = await params;
+  return proxyPatch(request, `/interface/tools/${toolId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ toolId: string }> },
+) {
+  const { toolId } = await params;
+  return proxyDelete(request, `/interface/tools/${toolId}`);
+}

--- a/apps/negentropy-ui/app/api/interface/tools/[toolId]/test/route.ts
+++ b/apps/negentropy-ui/app/api/interface/tools/[toolId]/test/route.ts
@@ -1,0 +1,15 @@
+import { proxyPost } from "@/app/api/interface/_proxy";
+
+/**
+ * Tool 测试连接 API 代理端点
+ *
+ * POST /api/interface/tools/{toolId}/test - 测试工具配置连通性
+ */
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ toolId: string }> },
+) {
+  const { toolId } = await params;
+  return proxyPost(request, `/interface/tools/${toolId}:test`);
+}

--- a/apps/negentropy-ui/app/api/interface/tools/route.ts
+++ b/apps/negentropy-ui/app/api/interface/tools/route.ts
@@ -1,0 +1,16 @@
+import { proxyGet, proxyPost } from "@/app/api/interface/_proxy";
+
+/**
+ * Tools 集合 API 代理端点
+ *
+ * GET  /api/interface/tools - 列出工具
+ * POST /api/interface/tools - 创建工具
+ */
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/interface/tools");
+}
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/interface/tools");
+}

--- a/apps/negentropy-ui/app/interface/page.tsx
+++ b/apps/negentropy-ui/app/interface/page.tsx
@@ -10,6 +10,7 @@ interface Stats {
   skills: { total: number; enabled: number };
   subagents: { total: number; enabled: number };
   models: { total: number; enabled: number; vendors: number };
+  tools: { total: number; enabled: number };
 }
 
 export default function InterfacePage() {
@@ -47,8 +48,8 @@ export default function InterfacePage() {
           </h1>
           <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-6">
             {isAdmin
-              ? "Manage Models, SubAgents, MCP servers, and Skills for your AI agents."
-              : "Manage SubAgents, MCP servers, and Skills for your AI agents."}
+              ? "Manage Models, SubAgents, MCP servers, Skills, and Tools for your AI agents."
+              : "Manage SubAgents, MCP servers, Skills, and Tools for your AI agents."}
           </p>
 
           {loading ? (
@@ -56,7 +57,7 @@ export default function InterfacePage() {
           ) : error ? (
             <div className="text-sm text-red-500">{error}</div>
           ) : (
-            <div className={`grid gap-4 ${isAdmin ? "sm:grid-cols-4" : "sm:grid-cols-3"}`}>
+            <div className={`grid gap-4 ${isAdmin ? "sm:grid-cols-5" : "sm:grid-cols-4"}`}>
               {isAdmin && (
                 <StatCard
                   title="Models"
@@ -87,6 +88,13 @@ export default function InterfacePage() {
                 href="/interface/skills"
                 description="Reusable skill modules"
               />
+              <StatCard
+                title="Tools"
+                total={stats?.tools?.total || 0}
+                enabled={stats?.tools?.enabled || 0}
+                href="/interface/tools"
+                description="Builtin tool configurations"
+              />
             </div>
           )}
 
@@ -94,7 +102,7 @@ export default function InterfacePage() {
             <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
               Quick Links
             </h2>
-            <div className={`grid gap-4 ${isAdmin ? "sm:grid-cols-4" : "sm:grid-cols-3"}`}>
+            <div className={`grid gap-4 ${isAdmin ? "sm:grid-cols-5" : "sm:grid-cols-4"}`}>
               {isAdmin && (
                 <QuickLink
                   href="/interface/models"
@@ -116,6 +124,11 @@ export default function InterfacePage() {
                 href="/interface/skills"
                 title="Create Skill"
                 description="Define reusable prompt templates"
+              />
+              <QuickLink
+                href="/interface/tools"
+                title="Configure Tool"
+                description="Manage builtin tool integrations"
               />
             </div>
           </div>

--- a/apps/negentropy-ui/app/interface/skills/_components/SkillFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/skills/_components/SkillFormDialog.tsx
@@ -61,6 +61,7 @@ export function SkillFormDialog({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{ config_schema?: string; default_config?: string }>({});
+  const [availableTools, setAvailableTools] = useState<Array<{ name: string; display_name: string | null; source: string }>>([]);
 
   useEffect(() => {
     if (skill) {
@@ -98,6 +99,27 @@ export function SkillFormDialog({
     setFieldErrors({});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skill, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let mounted = true;
+    (async () => {
+      try {
+        const response = await fetch("/api/interface/tools/available");
+        if (response.ok) {
+          const data = await response.json();
+          if (mounted) {
+            setAvailableTools(data);
+          }
+        }
+      } catch {
+        // keep silent; available tools is optional
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -327,14 +349,44 @@ export function SkillFormDialog({
                 </div>
                 <div>
                   <label className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
-                    Required Tools (one per line)
+                    Required Tools
                   </label>
+                  {availableTools.length > 0 && (
+                    <div className="mb-2 flex flex-wrap gap-1.5">
+                      {availableTools.map((t) => {
+                        const currentTools = formData.required_tools.split("\n").map((s) => s.trim()).filter(Boolean);
+                        const isSelected = currentTools.includes(t.name);
+                        return (
+                          <button
+                            key={t.name}
+                            type="button"
+                            onClick={() => {
+                              const tools = formData.required_tools.split("\n").map((s) => s.trim()).filter(Boolean);
+                              const next = isSelected
+                                ? tools.filter((n) => n !== t.name)
+                                : [...tools, t.name];
+                              setFormData({ ...formData, required_tools: next.join("\n") });
+                            }}
+                            className={
+                              "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors " +
+                              (isSelected
+                                ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+                                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700")
+                            }
+                          >
+                            <span className="text-[10px] opacity-60">{t.source === "builtin" ? "●" : "◆"}</span>
+                            {t.display_name || t.name}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
                   <textarea
                     value={formData.required_tools}
                     onChange={(e) => setFormData({ ...formData, required_tools: e.target.value })}
                     className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
-                    rows={4}
-                    placeholder="get_file&#10;write_file"
+                    rows={3}
+                    placeholder="Select from above or type tool names (one per line)"
                   />
                 </div>
               </section>

--- a/apps/negentropy-ui/app/interface/subagents/_components/SubAgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/subagents/_components/SubAgentFormDialog.tsx
@@ -68,6 +68,7 @@ export function SubAgentFormDialog({
   const [templates, setTemplates] = useState<NegentropyTemplate[]>([]);
   const [selectedTemplateName, setSelectedTemplateName] = useState("");
   const [llmModels, setLlmModels] = useState<ModelConfigItem[]>([]);
+  const [availableTools, setAvailableTools] = useState<Array<{ name: string; display_name: string | null; source: string }>>([]);
 
   const applyTemplate = (template: NegentropyTemplate) => {
     setFormData({
@@ -134,6 +135,27 @@ export function SubAgentFormDialog({
         }
       } catch {
         // keep silent; select will fall back to Default-only option
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let mounted = true;
+    (async () => {
+      try {
+        const response = await fetch("/api/interface/tools/available");
+        if (response.ok) {
+          const data = await response.json();
+          if (mounted) {
+            setAvailableTools(data);
+          }
+        }
+      } catch {
+        // keep silent; available tools is optional
       }
     })();
     return () => {
@@ -444,14 +466,44 @@ export function SubAgentFormDialog({
                   </div>
                   <div>
                     <label className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
-                      Tools (one per line)
+                      Tools
                     </label>
+                    {availableTools.length > 0 && (
+                      <div className="mb-2 flex flex-wrap gap-1.5">
+                        {availableTools.map((t) => {
+                          const currentTools = formData.tools.split("\n").map((s) => s.trim()).filter(Boolean);
+                          const isSelected = currentTools.includes(t.name);
+                          return (
+                            <button
+                              key={t.name}
+                              type="button"
+                              onClick={() => {
+                                const tools = formData.tools.split("\n").map((s) => s.trim()).filter(Boolean);
+                                const next = isSelected
+                                  ? tools.filter((n) => n !== t.name)
+                                  : [...tools, t.name];
+                                setFormData({ ...formData, tools: next.join("\n") });
+                              }}
+                              className={
+                                "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors " +
+                                (isSelected
+                                  ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+                                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700")
+                              }
+                            >
+                              <span className="text-[10px] opacity-60">{t.source === "builtin" ? "●" : "◆"}</span>
+                              {t.display_name || t.name}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
                     <textarea
                       value={formData.tools}
                       onChange={(e) => setFormData({ ...formData, tools: e.target.value })}
                       className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
-                      rows={4}
-                      placeholder="get_file&#10;write_file"
+                      rows={3}
+                      placeholder="Select from above or type tool names (one per line)"
                     />
                   </div>
                 </div>

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+interface BuiltinTool {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  tool_type: string;
+  version: string;
+  config: Record<string, unknown>;
+  credentials: Record<string, unknown>;
+  config_schema: Record<string, unknown>;
+  is_enabled: boolean;
+  is_system: boolean;
+}
+
+interface ToolCardProps {
+  tool: BuiltinTool;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleEnabled: () => void;
+  toggling?: boolean;
+}
+
+export function ToolCard({
+  tool,
+  onEdit,
+  onDelete,
+  onToggleEnabled,
+  toggling = false,
+}: ToolCardProps) {
+  const displayLabel = tool.display_name || tool.name;
+
+  const hasCredentials =
+    tool.credentials &&
+    typeof tool.credentials === "object" &&
+    Object.keys(tool.credentials).length > 0;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
+          <h3 className="truncate text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            {displayLabel}
+          </h3>
+          <div className="flex shrink-0 items-center gap-2">
+            {onToggleEnabled && (
+              <button
+                onClick={onToggleEnabled}
+                disabled={toggling}
+                title={tool.is_enabled ? "Disable tool" : "Enable tool"}
+                aria-label={`${tool.is_enabled ? "Disable" : "Enable"} ${displayLabel}`}
+                aria-pressed={tool.is_enabled}
+                className={
+                  "rounded-md p-2 disabled:opacity-50 " +
+                  (tool.is_enabled
+                    ? "text-emerald-500 hover:bg-emerald-50 hover:text-emerald-600 dark:hover:bg-emerald-900/30 dark:hover:text-emerald-300"
+                    : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300")
+                }
+              >
+                {tool.is_enabled ? (
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364a9 9 0 0 0-12.728 0M5.636 5.636a9 9 0 0 0 12.728 0m0 12.728L5.636 5.636m12.728 0L5.636 18.364" />
+                  </svg>
+                )}
+              </button>
+            )}
+            <button
+              onClick={onEdit}
+              title="Edit Tool"
+              aria-label={`Edit ${displayLabel}`}
+              className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            {!tool.is_system && (
+              <button
+                onClick={onDelete}
+                title="Delete Tool"
+                aria-label={`Delete ${displayLabel}`}
+                className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
+          {tool.is_enabled ? (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+              Enabled
+            </span>
+          ) : (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+              Disabled
+            </span>
+          )}
+          <span className="inline-flex shrink-0 items-center rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400">
+            {tool.tool_type}
+          </span>
+          {tool.is_system && (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+              System
+            </span>
+          )}
+          <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+            {tool.visibility}
+          </span>
+          {!hasCredentials && tool.is_enabled && (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-300">
+              No credentials
+            </span>
+          )}
+        </div>
+        <p
+          className="mb-1 h-20 min-w-0 w-full overflow-hidden break-words text-sm leading-5 text-zinc-500 line-clamp-4 dark:text-zinc-400"
+          title={tool.description || "No description"}
+        >
+          {tool.description || "No description"}
+        </p>
+        <div className="mt-auto flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-zinc-400 dark:text-zinc-500">
+          <span className="inline-flex shrink-0 items-center gap-1">
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+            v{tool.version}
+          </span>
+          <span className="inline-flex shrink-0 items-center gap-1">
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            {tool.name}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+
+interface BuiltinTool {
+  id: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  tool_type: string;
+  version: string;
+  config: Record<string, unknown>;
+  credentials: Record<string, unknown>;
+  config_schema: Record<string, unknown>;
+  is_enabled: boolean;
+  is_system: boolean;
+}
+
+interface ToolFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: Record<string, unknown>) => Promise<void>;
+  tool: BuiltinTool | null;
+}
+
+interface FieldSchema {
+  type: string;
+  title?: string;
+  description?: string;
+  default?: unknown;
+  required?: boolean;
+  minimum?: number;
+  maximum?: number;
+}
+
+export function ToolFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  tool,
+}: ToolFormDialogProps) {
+  const emptyForm = {
+    name: "",
+    display_name: "",
+    description: "",
+    tool_type: "search",
+    version: "1.0.0",
+    visibility: "private",
+    is_enabled: true,
+  };
+
+  const [formData, setFormData] = useState(emptyForm);
+  const [configFields, setConfigFields] = useState<Record<string, unknown>>({});
+  const [credentialFields, setCredentialFields] = useState<Record<string, unknown>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string; latency_ms?: number } | null>(null);
+
+  const configSchema = (tool?.config_schema || {}) as Record<string, Record<string, FieldSchema>>;
+  const configFieldDefs = configSchema.config || {};
+  const credentialFieldDefs = configSchema.credentials || {};
+
+  useEffect(() => {
+    if (tool) {
+      setFormData({
+        name: tool.name,
+        display_name: tool.display_name || "",
+        description: tool.description || "",
+        tool_type: tool.tool_type,
+        version: tool.version,
+        visibility: "private",
+        is_enabled: tool.is_enabled,
+      });
+      setConfigFields(tool.config || {});
+      setCredentialFields(tool.credentials || {});
+    } else {
+      setFormData({
+        name: "",
+        display_name: "",
+        description: "",
+        tool_type: "search",
+        version: "1.0.0",
+        visibility: "private",
+        is_enabled: true,
+      });
+      setConfigFields({});
+      setCredentialFields({});
+    }
+    setTestResult(null);
+  }, [tool, open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const data: Record<string, unknown> = {
+        display_name: formData.display_name || null,
+        description: formData.description || null,
+        tool_type: formData.tool_type,
+        version: formData.version,
+        is_enabled: formData.is_enabled,
+        visibility: formData.visibility,
+        config: configFields,
+        credentials: credentialFields,
+      };
+      if (!tool) {
+        data.name = formData.name;
+      }
+      await onSubmit(data);
+    } catch {
+      // onSubmit already handles toast
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleTest = async () => {
+    if (!tool) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      // 先保存当前凭证
+      const saveResponse = await fetch(`/api/interface/tools/${tool.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: configFields, credentials: credentialFields }),
+      });
+      if (!saveResponse.ok) {
+        toast.error("Failed to save before testing");
+        return;
+      }
+
+      const testResponse = await fetch(`/api/interface/tools/${tool.id}/test`, {
+        method: "POST",
+      });
+      const result = await testResponse.json();
+      setTestResult(result);
+      if (result.success) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Test failed";
+      setTestResult({ success: false, message });
+      toast.error(message);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (!open) return null;
+
+  const renderDynamicField = (
+    key: string,
+    schema: FieldSchema,
+    value: unknown,
+    onChange: (key: string, value: unknown) => void,
+    isPassword = false,
+  ) => {
+    const inputType = isPassword || schema.type === "password" ? "password" : schema.type === "number" || schema.type === "integer" ? "number" : "text";
+    const step = schema.type === "number" ? "0.1" : undefined;
+    const min = schema.minimum;
+    const max = schema.maximum;
+
+    return (
+      <div key={key}>
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+          {schema.title || key}
+          {schema.required && <span className="text-red-500 ml-1">*</span>}
+        </label>
+        {schema.description && (
+          <p className="text-xs text-zinc-500 dark:text-zinc-400 mb-1">{schema.description}</p>
+        )}
+        <input
+          type={inputType}
+          value={value === undefined || value === null ? String(schema.default ?? "") : String(value)}
+          step={step}
+          min={min}
+          max={max}
+          onChange={(e) => {
+            let val: unknown = e.target.value;
+            if (inputType === "number") {
+              val = e.target.value === "" ? "" : Number(e.target.value);
+            }
+            onChange(key, val);
+          }}
+          className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+        />
+      </div>
+    );
+  };
+
+  return (
+    <OverlayDismissLayer open={open} onClose={onClose}>
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-lg border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100 mb-4">
+            {tool ? `Edit Tool: ${tool.display_name || tool.name}` : "Add Tool"}
+          </h2>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 基本信息 */}
+            {!tool && (
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm font-mono dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                  placeholder="e.g. google_search"
+                  required
+                />
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                  Display Name
+                </label>
+                <input
+                  type="text"
+                  value={formData.display_name}
+                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                  placeholder="e.g. Google Search"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                  Tool Type
+                </label>
+                <select
+                  value={formData.tool_type}
+                  onChange={(e) => setFormData({ ...formData, tool_type: e.target.value })}
+                  className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                  disabled={!!tool}
+                >
+                  <option value="search">Search</option>
+                  <option value="retrieval">Retrieval</option>
+                  <option value="custom">Custom</option>
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+                Description
+              </label>
+              <textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100"
+                rows={2}
+                placeholder="Tool description"
+              />
+            </div>
+
+            {/* 凭证字段 */}
+            {Object.keys(credentialFieldDefs).length > 0 && (
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 mb-2">
+                  Credentials
+                </h3>
+                <div className="space-y-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-700">
+                  {Object.entries(credentialFieldDefs).map(([key, schema]) =>
+                    renderDynamicField(key, schema, credentialFields[key], (k, v) =>
+                      setCredentialFields((prev) => ({ ...prev, [k]: v })),
+                    ),
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* 配置字段 */}
+            {Object.keys(configFieldDefs).length > 0 && (
+              <div>
+                <h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 mb-2">
+                  Configuration
+                </h3>
+                <div className="space-y-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-700">
+                  {Object.entries(configFieldDefs).map(([key, schema]) =>
+                    renderDynamicField(key, schema, configFields[key], (k, v) =>
+                      setConfigFields((prev) => ({ ...prev, [k]: v })),
+                    ),
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* 测试结果 */}
+            {testResult && (
+              <div
+                className={`rounded-md p-3 text-sm ${
+                  testResult.success
+                    ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
+                    : "bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400"
+                }`}
+              >
+                {testResult.message}
+                {testResult.success && testResult.latency_ms !== undefined && (
+                  <span className="ml-2 text-xs opacity-70">({testResult.latency_ms}ms)</span>
+                )}
+              </div>
+            )}
+
+            {/* 操作按钮 */}
+            <div className="flex items-center justify-between pt-2">
+              <div>
+                {tool && (
+                  <button
+                    type="button"
+                    onClick={handleTest}
+                    disabled={testing || submitting}
+                    className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 disabled:opacity-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                  >
+                    {testing ? "Testing..." : "Test Connection"}
+                  </button>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                >
+                  {submitting ? "Saving..." : tool ? "Update" : "Create"}
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
@@ -121,19 +121,10 @@ export function ToolFormDialog({
     setTesting(true);
     setTestResult(null);
     try {
-      // 先保存当前凭证
-      const saveResponse = await fetch(`/api/interface/tools/${tool.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ config: configFields, credentials: credentialFields }),
-      });
-      if (!saveResponse.ok) {
-        toast.error("Failed to save before testing");
-        return;
-      }
-
       const testResponse = await fetch(`/api/interface/tools/${tool.id}/test`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: configFields, credentials: credentialFields }),
       });
       const result = await testResponse.json();
       setTestResult(result);

--- a/apps/negentropy-ui/app/interface/tools/page.tsx
+++ b/apps/negentropy-ui/app/interface/tools/page.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ToolCard } from "./_components/ToolCard";
+import { ToolFormDialog } from "./_components/ToolFormDialog";
+
+interface BuiltinTool {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  tool_type: string;
+  version: string;
+  config: Record<string, unknown>;
+  credentials: Record<string, unknown>;
+  config_schema: Record<string, unknown>;
+  is_enabled: boolean;
+  is_system: boolean;
+}
+
+export default function ToolsPage() {
+  const [tools, setTools] = useState<BuiltinTool[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTool, setEditingTool] = useState<BuiltinTool | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<BuiltinTool | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const fetchTools = useCallback(async () => {
+    try {
+      const response = await fetch("/api/interface/tools");
+      if (!response.ok) {
+        throw new Error("Failed to fetch tools");
+      }
+      const data = await response.json();
+      setTools(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchTools();
+  }, [fetchTools]);
+
+  const handleCreate = () => {
+    setEditingTool(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (tool: BuiltinTool) => {
+    setEditingTool(tool);
+    setDialogOpen(true);
+  };
+
+  const handleDeleteRequest = (tool: BuiltinTool) => {
+    if (tool.is_system) {
+      toast.error("System tools cannot be deleted, only disabled");
+      return;
+    }
+    setPendingDelete(tool);
+  };
+
+  const handleDeleteConfirmed = async () => {
+    if (!pendingDelete) return;
+    const target = pendingDelete;
+    setDeleting(true);
+    try {
+      const response = await fetch(`/api/interface/tools/${target.id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        let message = "Failed to delete tool";
+        try {
+          const body = await response.json();
+          message = body?.detail || body?.message || message;
+        } catch {
+          // body not JSON
+        }
+        throw new Error(message);
+      }
+      toast.success(`Deleted tool "${target.display_name || target.name}"`);
+      setPendingDelete(null);
+      void fetchTools();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleToggleEnabled = async (tool: BuiltinTool) => {
+    setTogglingId(tool.id);
+    const next = !tool.is_enabled;
+    try {
+      const response = await fetch(`/api/interface/tools/${tool.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_enabled: next }),
+      });
+      if (!response.ok) {
+        let message = "Failed to update tool";
+        try {
+          const body = await response.json();
+          message = body?.detail || body?.message || message;
+        } catch {
+          // ignore
+        }
+        throw new Error(message);
+      }
+      toast.success(`${next ? "Enabled" : "Disabled"} "${tool.display_name || tool.name}"`);
+      void fetchTools();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  const handleDialogClose = () => {
+    setDialogOpen(false);
+    setEditingTool(null);
+  };
+
+  const handleFormSubmit = async (data: Record<string, unknown>) => {
+    const url = editingTool
+      ? `/api/interface/tools/${editingTool.id}`
+      : "/api/interface/tools";
+    const method = editingTool ? "PATCH" : "POST";
+
+    const response = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      let message = "Failed to save tool";
+      try {
+        const body = await response.json();
+        message = body?.detail || body?.message || message;
+      } catch {
+        // body not JSON
+      }
+      toast.error(message);
+      throw new Error(message);
+    }
+
+    toast.success(
+      editingTool
+        ? `Updated tool "${(data.display_name as string) || (data.name as string)}"`
+        : `Created tool "${(data.display_name as string) || (data.name as string)}"`,
+    );
+    handleDialogClose();
+    void fetchTools();
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+      <InterfaceNav title="Tools" />
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 py-6">
+          <div className="w-full">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  Tools
+                </h1>
+                <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                  Configure builtin tool integrations for your AI agents.
+                </p>
+              </div>
+              <button
+                onClick={handleCreate}
+                className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-zinc-50 hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                Add Tool
+              </button>
+            </div>
+
+            {loading ? (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="h-[196px] animate-pulse rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900"
+                  >
+                    <div className="mb-3 h-5 w-1/3 rounded bg-zinc-200 dark:bg-zinc-700" />
+                    <div className="mb-2 flex gap-2">
+                      <div className="h-4 w-16 rounded-full bg-zinc-200 dark:bg-zinc-700" />
+                      <div className="h-4 w-12 rounded-full bg-zinc-200 dark:bg-zinc-700" />
+                    </div>
+                    <div className="mb-1 h-4 w-full rounded bg-zinc-200 dark:bg-zinc-700" />
+                    <div className="h-4 w-3/4 rounded bg-zinc-200 dark:bg-zinc-700" />
+                  </div>
+                ))}
+              </div>
+            ) : error ? (
+              <div role="alert" className="text-sm text-red-500">
+                {error}
+              </div>
+            ) : tools.length === 0 ? (
+              <div className="text-center py-12">
+                <div className="text-zinc-400 dark:text-zinc-500 mb-4">
+                  No tools configured yet.
+                </div>
+                <button
+                  onClick={handleCreate}
+                  className="text-sm text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200"
+                >
+                  Configure your first tool →
+                </button>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {tools.map((tool) => (
+                  <div key={tool.id} className="h-[196px]">
+                    <ToolCard
+                      tool={tool}
+                      onEdit={() => handleEdit(tool)}
+                      onDelete={() => handleDeleteRequest(tool)}
+                      onToggleEnabled={() => handleToggleEnabled(tool)}
+                      toggling={togglingId === tool.id}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ToolFormDialog
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        onSubmit={handleFormSubmit}
+        tool={editingTool}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete tool?"
+        message={
+          pendingDelete
+            ? `"${pendingDelete.display_name || pendingDelete.name}" will be permanently removed. This action cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        destructive
+        busy={deleting}
+        onCancel={() => {
+          if (!deleting) setPendingDelete(null);
+        }}
+        onConfirm={handleDeleteConfirmed}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/InterfaceNav.tsx
+++ b/apps/negentropy-ui/components/ui/InterfaceNav.tsx
@@ -15,6 +15,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/interface/subagents", label: "SubAgents" },
   { href: "/interface/mcp", label: MCP_HUB_LABEL },
   { href: "/interface/skills", label: "Skills" },
+  { href: "/interface/tools", label: "Tools" },
 ];
 
 export function InterfaceNav({

--- a/apps/negentropy-ui/tests/e2e/skills/create.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/skills/create.spec.ts
@@ -45,7 +45,7 @@ test.describe("Skills 创建流程", () => {
     await page.locator('input[placeholder="My Skill"]').fill("ArXiv Fetch");
     await page.locator('textarea[placeholder="Description of this skill"]').fill("Search and fetch arXiv papers");
     await page.locator('input[placeholder="general"]').fill("research");
-    await page.locator('textarea[placeholder*="get_file"]').fill("search_arxiv\nfetch_pdf");
+    await page.locator('textarea[placeholder*="Select from above"]').fill("search_arxiv\nfetch_pdf");
 
     await page.getByRole("button", { name: "Create", exact: true }).click();
 

--- a/apps/negentropy-ui/tests/e2e/skills/edit.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/skills/edit.spec.ts
@@ -21,7 +21,7 @@ test.describe("Skills 编辑流程", () => {
 
     await expect(page.getByRole("heading", { name: "Edit Skill" })).toBeVisible();
     await expect(page.locator('input[placeholder="my-skill"]')).toHaveValue("edit-target");
-    await expect(page.locator('textarea[placeholder*="get_file"]')).toHaveValue("a\nb");
+    await expect(page.locator('textarea[placeholder*="Select from above"]')).toHaveValue("a\nb");
     await expect(page.getByTestId("skills-form-config-schema")).toContainText('"type": "object"');
     await expect(page.getByTestId("skills-form-default-config")).toContainText('"foo": "bar"');
   });

--- a/apps/negentropy/src/negentropy/agents/tools/perception.py
+++ b/apps/negentropy/src/negentropy/agents/tools/perception.py
@@ -25,7 +25,7 @@ from sqlalchemy import select
 
 import negentropy.db.session as db_session
 from negentropy.config import settings
-from negentropy.config.search import SearchSettings
+from negentropy.config.search import SearchProvider, SearchSettings
 from negentropy.knowledge.constants import (
     DEFAULT_KEYWORD_WEIGHT,
     DEFAULT_SEMANTIC_WEIGHT,
@@ -421,6 +421,7 @@ async def search_web(
     """执行 Web 搜索获取实时信息。
 
     使用 Google Custom Search API，内置重试机制。
+    优先从 builtin_tools 注册中心读取配置，回退到环境变量/YAML。
 
     Args:
         query: 搜索查询
@@ -439,13 +440,16 @@ async def search_web(
         return {"status": "failed", "error": "max_results must be positive"}
 
     limit = min(max_results, _MAX_RESULTS_LIMIT)
-    search_config = settings.search
+
+    # 优先从 builtin_tools 注册中心读取配置
+    search_config = await _resolve_search_config()
 
     logger.info(
         "web_search_started",
         query=query[:100],
         provider=search_config.provider.value,
         limit=limit,
+        config_source="builtin_tools" if _last_config_source == "builtin_tools" else "env_vars",
     )
 
     # 检查配置
@@ -454,7 +458,8 @@ async def search_web(
         return {
             "status": "failed",
             "error": (
-                "Google Search API not configured. Please set NE_SEARCH_GOOGLE_API_KEY and NE_SEARCH_GOOGLE_CX_ID."
+                "Google Search API not configured. "
+                "Please configure it in Interface > Tools, or set NE_SEARCH_GOOGLE_API_KEY and NE_SEARCH_GOOGLE_CX_ID."
             ),
         }
 
@@ -486,6 +491,38 @@ async def search_web(
             "status": "failed",
             "error": str(exc),
         }
+
+
+# 配置来源追踪（用于日志标注）
+_last_config_source: str = "env_vars"
+
+
+async def _resolve_search_config() -> SearchSettings:
+    """解析搜索配置：优先 builtin_tools 注册中心，回退到环境变量。"""
+    global _last_config_source
+
+    try:
+        from negentropy.interface.tool_resolver import resolve_tool_config
+
+        tool_config = await resolve_tool_config("google_search")
+        if tool_config:
+            _last_config_source = "builtin_tools"
+            credentials = tool_config.get("credentials", {})
+            api_key = credentials.get("api_key")
+            return SearchSettings(
+                provider=SearchProvider.GOOGLE,
+                google_api_key=api_key,
+                google_cx_id=tool_config.get("cx_id"),
+                max_retries=tool_config.get("max_retries", 3),
+                timeout_seconds=tool_config.get("timeout_seconds", 10.0),
+                base_backoff_seconds=tool_config.get("base_backoff_seconds", 1.0),
+                max_results=tool_config.get("max_results", 10),
+            )
+    except Exception as exc:
+        logger.debug("search_config_registry_fallback", error=str(exc))
+
+    _last_config_source = "env_vars"
+    return settings.search
 
 
 async def _search_google(

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py
@@ -127,15 +127,15 @@ def upgrade() -> None:
             'system', 'public', 'google_search', 'Google Search',
             'Web search via Google Custom Search API. Provides real-time web search capabilities for agents.',
             'search', '1.0.0',
-            :config::jsonb, :credentials::jsonb, :config_schema::jsonb,
+            :config, :credentials, :config_schema,
             TRUE, TRUE
         )
         ON CONFLICT (name) DO NOTHING
     """
         ).bindparams(
-            config=config,
-            credentials=credentials,
-            config_schema=config_schema,
+            sa.bindparam("config", value=config, type_=sa.dialects.postgresql.JSONB),
+            sa.bindparam("credentials", value=credentials, type_=sa.dialects.postgresql.JSONB),
+            sa.bindparam("config_schema", value=config_schema, type_=sa.dialects.postgresql.JSONB),
         )
     )
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py
@@ -1,0 +1,144 @@
+"""创建 builtin_tools 表并种子化 google_search 工具
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-05-11 00:00:00.000000+00:00
+
+设计动机：
+  将 Google Search 等内置工具的配置从 config.default.yaml + 环境变量
+  迁移至数据库驱动，支持 UI 管理 + SubAgent/Skill 动态挂载。
+
+  种子化步骤读取环境变量 NE_SEARCH_GOOGLE_API_KEY / NE_SEARCH_GOOGLE_CX_ID，
+  自动迁移现有部署的凭证到 builtin_tools 表（ON CONFLICT DO NOTHING 保证幂等）。
+"""
+
+import json
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031"
+down_revision: str | None = "0030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+# Google Search 工具的 config_schema，供 UI 动态渲染表单
+GOOGLE_SEARCH_CONFIG_SCHEMA = {
+    "config": {
+        "cx_id": {
+            "type": "string",
+            "title": "Custom Search Engine ID",
+            "description": "Google Programmable Search Engine CX ID",
+        },
+        "max_retries": {
+            "type": "integer",
+            "title": "Max Retries",
+            "default": 3,
+            "minimum": 0,
+            "maximum": 10,
+        },
+        "timeout_seconds": {
+            "type": "number",
+            "title": "Timeout (seconds)",
+            "default": 10.0,
+            "minimum": 1.0,
+            "maximum": 60.0,
+        },
+        "base_backoff_seconds": {
+            "type": "number",
+            "title": "Base Backoff (seconds)",
+            "default": 1.0,
+            "minimum": 0.1,
+        },
+        "max_results": {
+            "type": "integer",
+            "title": "Max Results",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 100,
+        },
+    },
+    "credentials": {
+        "api_key": {
+            "type": "password",
+            "title": "Google API Key",
+            "description": "Google Cloud API Key for Custom Search API",
+            "required": True,
+        },
+    },
+}
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.builtin_tools (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_id VARCHAR(255) NOT NULL,
+            visibility VARCHAR(20) NOT NULL DEFAULT 'private',
+            name VARCHAR(255) NOT NULL,
+            display_name VARCHAR(255),
+            description TEXT,
+            tool_type VARCHAR(50) NOT NULL,
+            version VARCHAR(50) NOT NULL DEFAULT '1.0.0',
+            config JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+            credentials JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+            config_schema JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+            is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+            is_system BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT builtin_tools_name_unique UNIQUE (name)
+        )
+    """)
+    )
+
+    op.execute(sa.text(f"CREATE INDEX IF NOT EXISTS ix_builtin_tools_owner ON {SCHEMA}.builtin_tools (owner_id)"))
+    op.execute(sa.text(f"CREATE INDEX IF NOT EXISTS ix_builtin_tools_tool_type ON {SCHEMA}.builtin_tools (tool_type)"))
+
+    # 种子化 google_search：从环境变量读取凭证
+    api_key = os.environ.get("NE_SEARCH_GOOGLE_API_KEY", "")
+    cx_id = os.environ.get("NE_SEARCH_GOOGLE_CX_ID", "")
+
+    config = json.dumps(
+        {
+            "cx_id": cx_id or "d5ee76f9215be4ee9",
+            "max_retries": 3,
+            "timeout_seconds": 10.0,
+            "base_backoff_seconds": 1.0,
+            "max_results": 10,
+        }
+    )
+    credentials = json.dumps({"api_key": api_key}) if api_key else "{}"
+    config_schema = json.dumps(GOOGLE_SEARCH_CONFIG_SCHEMA)
+
+    op.execute(
+        sa.text(
+            f"""
+        INSERT INTO {SCHEMA}.builtin_tools
+            (owner_id, visibility, name, display_name, description,
+             tool_type, version, config, credentials, config_schema,
+             is_enabled, is_system)
+        VALUES (
+            'system', 'public', 'google_search', 'Google Search',
+            'Web search via Google Custom Search API. Provides real-time web search capabilities for agents.',
+            'search', '1.0.0',
+            :config::jsonb, :credentials::jsonb, :config_schema::jsonb,
+            TRUE, TRUE
+        )
+        ON CONFLICT (name) DO NOTHING
+    """
+        ).bindparams(
+            config=config,
+            credentials=credentials,
+            config_schema=config_schema,
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"DROP TABLE IF EXISTS {SCHEMA}.builtin_tools CASCADE"))

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -24,6 +24,7 @@ from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.model_config import ModelConfig
 from negentropy.models.plugin import (
+    BuiltinTool,
     McpResourceTemplate,
     McpServer,
     McpTool,
@@ -63,6 +64,7 @@ class StatsResponse(BaseModel):
     skills: dict[str, int]
     subagents: dict[str, int]
     models: dict[str, int]
+    tools: dict[str, int]
 
 
 class PermissionGrantRequest(BaseModel):
@@ -81,6 +83,100 @@ class PermissionResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+# =============================================================================
+# BuiltinTool Models
+# =============================================================================
+
+
+class BuiltinToolCreateRequest(BaseModel):
+    name: str
+    display_name: str | None = None
+    description: str | None = None
+    tool_type: str = "search"
+    version: str = "1.0.0"
+    config: dict[str, Any] = Field(default_factory=dict)
+    credentials: dict[str, Any] = Field(default_factory=dict)
+    config_schema: dict[str, Any] = Field(default_factory=dict)
+    is_enabled: bool = True
+    visibility: str = "private"
+
+
+class BuiltinToolUpdateRequest(BaseModel):
+    display_name: str | None = None
+    description: str | None = None
+    config: dict[str, Any] | None = None
+    credentials: dict[str, Any] | None = None
+    config_schema: dict[str, Any] | None = None
+    is_enabled: bool | None = None
+    visibility: str | None = None
+
+
+class BuiltinToolResponse(BaseModel):
+    id: UUID
+    owner_id: str
+    visibility: str
+    name: str
+    display_name: str | None = None
+    description: str | None = None
+    tool_type: str
+    version: str
+    config: dict[str, Any] = Field(default_factory=dict)
+    credentials: dict[str, Any] = Field(default_factory=dict)
+    config_schema: dict[str, Any] = Field(default_factory=dict)
+    is_enabled: bool
+    is_system: bool = False
+
+    class Config:
+        from_attributes = True
+
+
+class BuiltinToolAvailableResponse(BaseModel):
+    """用于 SubAgent/Skill 工具挂载选择的简要信息"""
+
+    name: str
+    display_name: str | None = None
+    tool_type: str
+    is_enabled: bool
+    source: str  # "builtin" or "mcp"
+
+
+class BuiltinToolTestResponse(BaseModel):
+    success: bool
+    message: str
+    latency_ms: float | None = None
+
+
+def _mask_credentials(credentials: dict[str, Any]) -> dict[str, Any]:
+    """脱敏凭证字段：保留首尾字符，中间用 **** 替代。"""
+    masked = {}
+    for key, value in credentials.items():
+        if isinstance(value, str) and len(value) > 8:
+            masked[key] = value[:4] + "****" + value[-4:]
+        elif isinstance(value, str) and len(value) > 0:
+            masked[key] = "****"
+        else:
+            masked[key] = value
+    return masked
+
+
+def _builtin_tool_to_response(tool: BuiltinTool) -> BuiltinToolResponse:
+    return BuiltinToolResponse(
+        id=tool.id,
+        owner_id=tool.owner_id,
+        visibility=tool.visibility.value,
+        name=tool.name,
+        display_name=tool.display_name,
+        description=tool.description,
+        tool_type=tool.tool_type,
+        version=tool.version,
+        config=tool.config or {},
+        credentials=_mask_credentials(tool.credentials or {}),
+        config_schema=tool.config_schema or {},
+        is_enabled=tool.is_enabled,
+        is_system=tool.is_system,
+    )
 
 
 # =============================================================================
@@ -521,11 +617,20 @@ async def get_stats(user: AuthUser = Depends(get_current_user)) -> StatsResponse
             model_total = 0
             model_enabled = 0
 
+        # Builtin Tools
+        visible_tool_ids = await get_visible_plugin_ids(db, "builtin_tool", user)
+        tool_total = len(visible_tool_ids)
+        tool_enabled_result = await db.scalar(
+            select(func.count()).where(and_(BuiltinTool.id.in_(visible_tool_ids), BuiltinTool.is_enabled.is_(True)))
+        )
+        tool_enabled = tool_enabled_result or 0
+
     return StatsResponse(
         mcp_servers={"total": mcp_total, "enabled": mcp_enabled},
         skills={"total": skill_total, "enabled": skill_enabled},
         subagents={"total": subagent_total, "enabled": subagent_enabled},
         models={"total": model_total, "enabled": model_enabled, "vendors": vendor_total},
+        tools={"total": tool_total, "enabled": tool_enabled},
     )
 
 
@@ -1151,6 +1256,230 @@ async def get_mcp_tool_run(
         )
         events = events_result.scalars().all()
         return _mcp_tool_run_to_response(run, list(events))
+
+
+# =============================================================================
+# BuiltinTool Endpoints
+# =============================================================================
+
+
+@router.get("/tools/available", response_model=list[BuiltinToolAvailableResponse])
+async def list_available_tools(
+    user: AuthUser = Depends(get_current_user),
+) -> list[BuiltinToolAvailableResponse]:
+    """列出所有可用工具（builtin + MCP），供 SubAgent/Skill 工具挂载选择"""
+    tools: list[BuiltinToolAvailableResponse] = []
+
+    async with AsyncSessionLocal() as db:
+        # Builtin tools
+        visible_tool_ids = await get_visible_plugin_ids(db, "builtin_tool", user)
+        if visible_tool_ids:
+            stmt = select(BuiltinTool).where(BuiltinTool.id.in_(visible_tool_ids))
+            result = await db.execute(stmt)
+            builtin_tools = result.scalars().all()
+            for t in builtin_tools:
+                tools.append(
+                    BuiltinToolAvailableResponse(
+                        name=t.name,
+                        display_name=t.display_name,
+                        tool_type=t.tool_type,
+                        is_enabled=t.is_enabled,
+                        source="builtin",
+                    )
+                )
+
+        # MCP tools
+        visible_mcp_ids = await get_visible_plugin_ids(db, "mcp_server", user)
+        if visible_mcp_ids:
+            stmt = select(McpTool).where(and_(McpTool.server_id.in_(visible_mcp_ids), McpTool.is_enabled.is_(True)))
+            result = await db.execute(stmt)
+            mcp_tools = result.scalars().all()
+            for t in mcp_tools:
+                tools.append(
+                    BuiltinToolAvailableResponse(
+                        name=t.name,
+                        display_name=getattr(t, "display_name", None) or getattr(t, "title", None),
+                        tool_type="mcp",
+                        is_enabled=t.is_enabled,
+                        source="mcp",
+                    )
+                )
+
+    return tools
+
+
+@router.get("/tools", response_model=list[BuiltinToolResponse])
+async def list_builtin_tools(
+    user: AuthUser = Depends(get_current_user),
+) -> list[BuiltinToolResponse]:
+    """列出用户可见的内置工具"""
+    async with AsyncSessionLocal() as db:
+        visible_ids = await get_visible_plugin_ids(db, "builtin_tool", user)
+        if not visible_ids:
+            return []
+
+        stmt = select(BuiltinTool).where(BuiltinTool.id.in_(visible_ids)).order_by(BuiltinTool.created_at.desc())
+        result = await db.execute(stmt)
+        tools = result.scalars().all()
+
+    return [_builtin_tool_to_response(t) for t in tools]
+
+
+@router.post("/tools", response_model=BuiltinToolResponse, status_code=status.HTTP_201_CREATED)
+async def create_builtin_tool(
+    payload: BuiltinToolCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> BuiltinToolResponse:
+    """创建自定义工具"""
+    async with AsyncSessionLocal() as db:
+        tool = BuiltinTool(
+            owner_id=user.user_id,
+            visibility=PluginVisibility(payload.visibility),
+            name=payload.name,
+            display_name=payload.display_name,
+            description=payload.description,
+            tool_type=payload.tool_type,
+            version=payload.version,
+            config=payload.config,
+            credentials=payload.credentials,
+            config_schema=payload.config_schema,
+            is_enabled=payload.is_enabled,
+            is_system=False,
+        )
+        db.add(tool)
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail=f"Tool with name '{payload.name}' already exists") from exc
+        await db.refresh(tool)
+
+    return _builtin_tool_to_response(tool)
+
+
+@router.get("/tools/{tool_id}", response_model=BuiltinToolResponse)
+async def get_builtin_tool(
+    tool_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> BuiltinToolResponse:
+    """获取工具详情"""
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "builtin_tool", tool_id, user)
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        tool = await db.get(BuiltinTool, tool_id)
+        if not tool:
+            raise HTTPException(status_code=404, detail="Tool not found")
+
+    return _builtin_tool_to_response(tool)
+
+
+@router.patch("/tools/{tool_id}", response_model=BuiltinToolResponse)
+async def update_builtin_tool(
+    tool_id: UUID,
+    payload: BuiltinToolUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> BuiltinToolResponse:
+    """更新工具配置"""
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, "builtin_tool", tool_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        tool = await db.get(BuiltinTool, tool_id)
+        if not tool:
+            raise HTTPException(status_code=404, detail="Tool not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        if "visibility" in update_data:
+            update_data["visibility"] = PluginVisibility(update_data["visibility"])
+        for field, value in update_data.items():
+            setattr(tool, field, value)
+
+        await db.commit()
+        await db.refresh(tool)
+
+    return _builtin_tool_to_response(tool)
+
+
+@router.delete("/tools/{tool_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_builtin_tool(
+    tool_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> None:
+    """删除工具（仅非系统工具可删除）"""
+    async with AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, "builtin_tool", tool_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+
+        tool = await db.get(BuiltinTool, tool_id)
+        if not tool:
+            raise HTTPException(status_code=404, detail="Tool not found")
+
+        if tool.is_system:
+            raise HTTPException(status_code=403, detail="System tools cannot be deleted, only disabled")
+
+        await db.delete(tool)
+        await db.commit()
+
+
+@router.post("/tools/{tool_id}:test", response_model=BuiltinToolTestResponse)
+async def test_builtin_tool(
+    tool_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> BuiltinToolTestResponse:
+    """测试工具配置连通性"""
+    import time
+
+    import httpx
+
+    async with AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "builtin_tool", tool_id, user)
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+
+        tool = await db.get(BuiltinTool, tool_id)
+        if not tool:
+            raise HTTPException(status_code=404, detail="Tool not found")
+
+    config = tool.config or {}
+    credentials = tool.credentials or {}
+
+    if tool.tool_type == "search" and tool.name == "google_search":
+        api_key = credentials.get("api_key", "")
+        cx_id = config.get("cx_id", "")
+        if not api_key or not cx_id:
+            return BuiltinToolTestResponse(success=False, message="API Key or CX ID is not configured")
+
+        start = time.monotonic()
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(
+                    "https://www.googleapis.com/customsearch/v1",
+                    params={"key": api_key, "cx": cx_id, "q": "test"},
+                )
+            latency = (time.monotonic() - start) * 1000
+
+            if response.status_code == 200:
+                return BuiltinToolTestResponse(
+                    success=True,
+                    message="Google Search API connection successful",
+                    latency_ms=round(latency, 1),
+                )
+            else:
+                error_body = response.json().get("error", {})
+                error_detail = error_body.get("message", response.text[:200])
+                return BuiltinToolTestResponse(
+                    success=False,
+                    message=f"API error: {error_detail}",
+                    latency_ms=round(latency, 1),
+                )
+        except Exception as exc:
+            return BuiltinToolTestResponse(success=False, message=f"Connection failed: {exc}")
+
+    return BuiltinToolTestResponse(success=False, message=f"Test not supported for tool type: {tool.tool_type}")
 
 
 # =============================================================================

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -43,6 +43,7 @@ from negentropy.models.vendor_config import VendorConfig
 
 from .execution import McpToolExecutionService
 from .permissions import check_plugin_access, check_plugin_ownership, get_visible_plugin_ids
+from .tool_resolver import invalidate_tool_cache
 
 logger = get_logger("negentropy.interface.api")
 router = APIRouter(prefix="/interface", tags=["interface"])
@@ -146,6 +147,13 @@ class BuiltinToolTestResponse(BaseModel):
     success: bool
     message: str
     latency_ms: float | None = None
+
+
+class BuiltinToolTestRequest(BaseModel):
+    """测试时可选的内联配置，避免必须先保存再测试"""
+
+    config: dict[str, Any] | None = None
+    credentials: dict[str, Any] | None = None
 
 
 def _mask_credentials(credentials: dict[str, Any]) -> dict[str, Any]:
@@ -1274,7 +1282,9 @@ async def list_available_tools(
         # Builtin tools
         visible_tool_ids = await get_visible_plugin_ids(db, "builtin_tool", user)
         if visible_tool_ids:
-            stmt = select(BuiltinTool).where(BuiltinTool.id.in_(visible_tool_ids))
+            stmt = select(BuiltinTool).where(
+                and_(BuiltinTool.id.in_(visible_tool_ids), BuiltinTool.is_enabled.is_(True))
+            )
             result = await db.execute(stmt)
             builtin_tools = result.scalars().all()
             for t in builtin_tools:
@@ -1354,6 +1364,7 @@ async def create_builtin_tool(
             raise HTTPException(status_code=409, detail=f"Tool with name '{payload.name}' already exists") from exc
         await db.refresh(tool)
 
+    invalidate_tool_cache(payload.name)
     return _builtin_tool_to_response(tool)
 
 
@@ -1400,6 +1411,7 @@ async def update_builtin_tool(
         await db.commit()
         await db.refresh(tool)
 
+    invalidate_tool_cache(tool.name)
     return _builtin_tool_to_response(tool)
 
 
@@ -1421,16 +1433,20 @@ async def delete_builtin_tool(
         if tool.is_system:
             raise HTTPException(status_code=403, detail="System tools cannot be deleted, only disabled")
 
+        tool_name = tool.name
         await db.delete(tool)
         await db.commit()
+
+    invalidate_tool_cache(tool_name)
 
 
 @router.post("/tools/{tool_id}:test", response_model=BuiltinToolTestResponse)
 async def test_builtin_tool(
     tool_id: UUID,
+    payload: BuiltinToolTestRequest | None = None,
     user: AuthUser = Depends(get_current_user),
 ) -> BuiltinToolTestResponse:
-    """测试工具配置连通性"""
+    """测试工具配置连通性。支持通过请求体内联传入 config/credentials，无需先保存即可测试。"""
     import time
 
     import httpx
@@ -1444,8 +1460,10 @@ async def test_builtin_tool(
         if not tool:
             raise HTTPException(status_code=404, detail="Tool not found")
 
-    config = tool.config or {}
-    credentials = tool.credentials or {}
+    # 请求体内联参数优先，回退到 DB 存储值
+    inline = payload or BuiltinToolTestRequest()
+    config = inline.config if inline.config is not None else (tool.config or {})
+    credentials = inline.credentials if inline.credentials is not None else (tool.credentials or {})
 
     if tool.tool_type == "search" and tool.name == "google_search":
         api_key = credentials.get("api_key", "")

--- a/apps/negentropy/src/negentropy/interface/tool_resolver.py
+++ b/apps/negentropy/src/negentropy/interface/tool_resolver.py
@@ -1,0 +1,79 @@
+"""工具配置解析器。
+
+从 builtin_tools 表读取工具配置，提供带缓存的解析能力。
+当 DB 中无对应工具时，返回 None（调用方回退到环境变量/YAML 配置）。
+"""
+
+import time
+from typing import Any
+
+from sqlalchemy import select
+
+from negentropy.db.session import AsyncSessionLocal
+from negentropy.logging import get_logger
+from negentropy.models.builtin_tool import BuiltinTool
+
+logger = get_logger("negentropy.interface.tool_resolver")
+
+# 简易内存缓存：{tool_name: (config_dict, expire_timestamp)}
+_cache: dict[str, tuple[dict[str, Any], float]] = {}
+_CACHE_TTL_SECONDS = 60.0
+
+
+async def resolve_tool_config(tool_name: str) -> dict[str, Any] | None:
+    """从 builtin_tools 表读取工具配置。
+
+    返回合并后的 config + credentials 字典；不存在或已禁用时返回 None。
+    带 60s TTL 内存缓存，避免每次工具调用都查 DB。
+
+    Args:
+        tool_name: 工具名称，如 "google_search"
+
+    Returns:
+        合并后的配置字典（含 config 和 credentials 中的所有字段），或 None
+    """
+    # 检查缓存
+    now = time.monotonic()
+    cached = _cache.get(tool_name)
+    if cached:
+        config, expire_at = cached
+        if now < expire_at:
+            return config
+
+    # 查询 DB
+    try:
+        async with AsyncSessionLocal() as db:
+            stmt = select(BuiltinTool).where(
+                BuiltinTool.name == tool_name,
+                BuiltinTool.is_enabled.is_(True),
+            )
+            result = await db.execute(stmt)
+            tool = result.scalar_one_or_none()
+
+        if tool is None:
+            return None
+
+        # 合并 config 和 credentials
+        merged: dict[str, Any] = {}
+        merged.update(tool.config or {})
+        merged["credentials"] = tool.credentials or {}
+
+        # 更新缓存
+        _cache[tool_name] = (merged, now + _CACHE_TTL_SECONDS)
+        return merged
+
+    except Exception as exc:
+        logger.warning("tool_resolver_db_error", tool_name=tool_name, error=str(exc))
+        return None
+
+
+def invalidate_tool_cache(tool_name: str | None = None) -> None:
+    """清除工具配置缓存。
+
+    Args:
+        tool_name: 清除特定工具缓存；None 则清除全部
+    """
+    if tool_name:
+        _cache.pop(tool_name, None)
+    else:
+        _cache.clear()

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -1,5 +1,6 @@
 from .action import Tool, ToolExecution
 from .base import DEFAULT_EMBEDDING_DIM, NEGENTROPY_SCHEMA, Base, TimestampMixin, Vector, fk
+from .builtin_tool import BuiltinTool
 from .internalization import Fact, Memory, MemoryAuditLog, MemoryAutomationConfig
 from .knowledge_runtime import KnowledgeGraphRun, KnowledgePipelineRun
 from .mcp import McpResourceTemplate, McpServer, McpTool
@@ -52,6 +53,8 @@ __all__ = [
     # Action
     "Tool",
     "ToolExecution",
+    # Builtin Tools
+    "BuiltinTool",
     # Observability
     "Trace",
     # Perception (知识)

--- a/apps/negentropy/src/negentropy/models/builtin_tool.py
+++ b/apps/negentropy/src/negentropy/models/builtin_tool.py
@@ -1,0 +1,59 @@
+"""内置工具配置模型。
+
+管理 Google Search 等内置工具的配置与凭证，
+替代 config.default.yaml + 环境变量的硬编码模式。
+
+设计决策：
+- 表名 builtin_tools，避免与 action.py 中已有的 tools 表（运行时执行追踪）冲突
+- credentials 与 config 分离，API 层对 credentials 做脱敏处理
+- config_schema JSONB 声明工具的配置字段定义，供 UI 动态渲染表单
+- is_system 标识系统内置工具，API 层阻止删除
+"""
+
+from typing import Any
+
+from sqlalchemy import Boolean, Enum, Index, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin
+from .plugin_common import PluginVisibility
+
+
+class BuiltinTool(Base, UUIDMixin, TimestampMixin):
+    """内置工具配置"""
+
+    __tablename__ = "builtin_tools"
+
+    # 所有权和可见性
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    visibility: Mapped[PluginVisibility] = mapped_column(
+        Enum(PluginVisibility, schema=NEGENTROPY_SCHEMA),
+        nullable=False,
+        default=PluginVisibility.PRIVATE,
+    )
+
+    # 基本信息
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(255))
+    description: Mapped[str | None] = mapped_column(Text)
+    tool_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    version: Mapped[str] = mapped_column(String(50), nullable=False, server_default="1.0.0")
+
+    # 工具配置（cx_id, max_retries, timeout 等）— JSONB
+    config: Mapped[dict[str, Any]] = mapped_column(JSONB, server_default="{}")
+    # 凭证（API Key 等敏感信息）— JSONB，API 层脱敏返回
+    credentials: Mapped[dict[str, Any]] = mapped_column(JSONB, server_default="{}")
+    # 配置 Schema（声明 config/credentials 的字段定义，供 UI 动态渲染表单）
+    config_schema: Mapped[dict[str, Any]] = mapped_column(JSONB, server_default="{}")
+
+    # 状态
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+
+    __table_args__ = (
+        UniqueConstraint("name", name="builtin_tools_name_unique"),
+        Index("ix_builtin_tools_owner", "owner_id"),
+        Index("ix_builtin_tools_tool_type", "tool_type"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )

--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -2,12 +2,14 @@
 
 实际定义已按正交职责迁移至:
 - plugin_common.py: 枚举与权限 (PluginVisibility, PluginPermissionType, PluginPermission)
+- builtin_tool.py: 内置工具配置 (BuiltinTool)
 - mcp.py: MCP Server / Tool / ResourceTemplate 定义 (McpServer, McpTool, McpResourceTemplate)
 - mcp_runtime.py: MCP 执行记录 (McpToolRun, McpToolRunEvent, McpTrialAsset)
 - skill.py: 技能定义 (Skill)
 - sub_agent.py: 子智能体配置 (SubAgent)
 """
 
+from .builtin_tool import BuiltinTool  # noqa: F401
 from .mcp import McpResourceTemplate, McpServer, McpTool  # noqa: F401
 from .mcp_runtime import McpToolRun, McpToolRunEvent, McpTrialAsset  # noqa: F401
 from .plugin_common import PluginPermission, PluginPermissionType, PluginVisibility  # noqa: F401


### PR DESCRIPTION
# 背景
- 内置工具（如 Google Search）的配置原先硬编码在 `config.default.yaml` + 环境变量中，无法通过 UI 管理，也不支持 SubAgent/Skill 动态挂载
- 关联上下文：Interface 模块扩展，支持更多内置工具的可视化配置

# 核心变更
- **BuiltinTool ORM 模型**：新建 `builtin_tools` 表（Alembic 迁移 0031），存储工具配置与凭证，credentials 与 config 分离
- **后端 CRUD API**：list/create/get/update/delete + test（支持内联传参）+ available（供工具挂载选择），凭证 API 层脱敏
- **工具配置解析器**：`tool_resolver.py`（60s TTL 缓存），CRUD 端点写入后自动失效缓存
- **search_web 运行时重构**：优先从 builtin_tools 注册中心读取配置，环境变量作为回退
- **前端 Tools 页面**：完整的工具卡片列表、创建/编辑表单、Test Connection（内联传参无需先保存）、启用/禁用开关、删除确认
- **SubAgent/Skill 工具选择器升级**：从纯文本 textarea 升级为多选标签 + 可用工具下拉，聚合 builtin + MCP 工具
- **Dashboard/导航集成**：Interface 页新增 Tools 统计卡片、Quick Link、导航栏入口

# 风险与回滚
- 主要风险：迁移 0031 创建 `builtin_tools` 表并种子化 google_search；回滚执行 `downgrade` 即 DROP TABLE
- 回滚方式：`alembic downgrade 0030`；search_web 自动回退到环境变量配置

# 验证证据
- 单元测试：ruff lint + format 通过；ESLint 通过
- 集成测试：CRUD 端点缓存失效、available 过滤 is_enabled、test 内联传参均经 Review 验证修复
- E2E/Workflow：待补充

# 影响范围
- 前端：`apps/negentropy-ui` — 新增 Tools 页面、SubAgent/Skill 表单组件、Interface 导航、API 代理路由、Stats 类型
- 后端：`apps/negentropy` — BuiltinTool 模型、interface/api.py（7 个新端点）、tool_resolver.py、perception.py（search_web 重构）、迁移 0031
- GitHub Actions / 文档：无 CI 变更

# Next Best Action
- 为新增的 Tools CRUD 端点补充自动化测试用例
- 考虑 credentials 字段加密存储（当前 JSONB 明文，API 层脱敏）