### PR TITLE
fix(dynamic-model): 增强模型选择可观测性 + 修正 OTel span user_selected_model 取值

### DIFF
--- a/apps/negentropy/src/negentropy/agents/_dynamic_model.py
+++ b/apps/negentropy/src/negentropy/agents/_dynamic_model.py
@@ -86,6 +86,11 @@ class _DynamicLiteLlm(LiteLlm):
             # 即使回退到默认模型，也记录用户意图到 OTel span。
             selected = _selected_root_llm.get()
             if selected:
+                _logger.warning(
+                    "dynamic_litellm_fallback_to_default",
+                    user_selected_model=selected,
+                    fallback_model=self.model,
+                )
                 span = trace.get_current_span()
                 if span and span.is_recording():
                     span.set_attribute("negentropy.user_selected_model", observability_model_name(selected) or selected)
@@ -126,10 +131,15 @@ class _DynamicLiteLlm(LiteLlm):
                 # 将用户意图和实际模型写入 OTel span，便于 Langfuse 排查。
                 span = trace.get_current_span()
                 if span and span.is_recording():
-                    orig_bare = observability_model_name(orig_model) or orig_model
-                    new_bare = observability_model_name(new_model) or new_model
-                    span.set_attribute("negentropy.user_selected_model", orig_bare)
-                    span.set_attribute("negentropy.effective_model", new_bare)
+                    user_intent = _selected_root_llm.get()
+                    span.set_attribute(
+                        "negentropy.user_selected_model",
+                        observability_model_name(user_intent)
+                        or user_intent
+                        or observability_model_name(new_model)
+                        or new_model,
+                    )
+                    span.set_attribute("negentropy.effective_model", observability_model_name(new_model) or new_model)
                 async for resp in super().generate_content_async(llm_request, stream=stream):
                     yield resp
             finally:

--- a/apps/negentropy/src/negentropy/agents/_dynamic_model.py
+++ b/apps/negentropy/src/negentropy/agents/_dynamic_model.py
@@ -22,6 +22,7 @@ from contextvars import ContextVar
 from typing import Any
 
 from google.adk.models.lite_llm import LiteLlm
+from opentelemetry import trace
 
 from negentropy.config.model_resolver import (
     apply_llm_thinking_override,
@@ -30,6 +31,7 @@ from negentropy.config.model_resolver import (
     resolve_subagent_model_name,
 )
 from negentropy.logging import get_logger
+from negentropy.model_names import observability_model_name
 
 _logger = get_logger("negentropy.agents.dynamic_model")
 
@@ -81,6 +83,14 @@ class _DynamicLiteLlm(LiteLlm):
             _logger.warning("dynamic_litellm_resolve_failed", exc_info=True)
 
         if override is None:
+            # 即使回退到默认模型，也记录用户意图到 OTel span。
+            selected = _selected_root_llm.get()
+            if selected:
+                span = trace.get_current_span()
+                if span and span.is_recording():
+                    span.set_attribute("negentropy.user_selected_model", observability_model_name(selected) or selected)
+                    span.set_attribute("negentropy.effective_model", observability_model_name(self.model) or self.model)
+                    span.set_attribute("negentropy.model_fallback", True)
             async for resp in super().generate_content_async(llm_request, stream=stream):
                 yield resp
             return
@@ -113,6 +123,13 @@ class _DynamicLiteLlm(LiteLlm):
                     original_model=orig_model,
                     override_model=new_model,
                 )
+                # 将用户意图和实际模型写入 OTel span，便于 Langfuse 排查。
+                span = trace.get_current_span()
+                if span and span.is_recording():
+                    orig_bare = observability_model_name(orig_model) or orig_model
+                    new_bare = observability_model_name(new_model) or new_model
+                    span.set_attribute("negentropy.user_selected_model", orig_bare)
+                    span.set_attribute("negentropy.effective_model", new_bare)
                 async for resp in super().generate_content_async(llm_request, stream=stream):
                     yield resp
             finally:
@@ -139,7 +156,13 @@ class DynamicRootLiteLlm(_DynamicLiteLlm):
         selected = _selected_root_llm.get()
         if selected:
             resolved = await resolve_llm_config_by_model_name(selected)
-            if resolved is None:
+            if resolved is not None:
+                _logger.info(
+                    "dynamic_root_llm_resolved",
+                    selected_model=selected,
+                    resolved_model=resolved[0],
+                )
+            else:
                 _logger.warning(
                     "dynamic_root_llm_unknown_model",
                     selected_model=selected,
@@ -165,6 +188,12 @@ class DynamicSubagentLiteLlm(_DynamicLiteLlm):
         if model_id:
             resolved = await resolve_llm_config_by_model_name(model_id)
             if resolved is not None:
+                _logger.info(
+                    "dynamic_subagent_llm_resolved",
+                    agent_name=agent_name,
+                    requested_model=model_id,
+                    resolved_model=resolved[0],
+                )
                 return resolved
             _logger.warning(
                 "dynamic_subagent_llm_unknown_model",


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：动态模型选择的可观测性不足，Langfuse/OTel 中缺少用户意图与实际使用模型的关联信息，排查模型切换问题困难
- 关联上下文/Issue/文档：模型选择链路 `_DynamicLiteLlm` → OTel span → Langfuse

# 核心变更
- 在 `_DynamicLiteLlm.generate_content_async` 两条路径（override 成功 / fallback）中写入 OTel span 属性：`negentropy.user_selected_model`、`negentropy.effective_model`、`negentropy.model_fallback`
- override 成功路径：`user_selected_model` 优先取 `_selected_root_llm.get()`（用户真实意图），子 Agent 场景 fallback 到 `new_model`；`effective_model` 取实际使用的模型
- fallback 路径：当用户选择了模型但解析失败回退默认时，新增 `dynamic_litellm_fallback_to_default` warning 日志，并在 span 中标记 `model_fallback = True`
- 在 `DynamicRootLiteLlm` 和 `DynamicSubagentLiteLlm` 的 `_resolve_override` 成功路径中补充 `dynamic_root_llm_resolved` / `dynamic_subagent_llm_resolved` info 日志

# 风险与回滚
- 主要风险：低风险，仅新增 OTel span 属性和日志，不影响模型调度逻辑
- 回滚方式：`git revert` 该 PR 的两个 commit

# 验证证据
- 单元测试：已有测试覆盖 `_DynamicLiteLlm` 核心路径，新增属性不改变控制流
- 集成测试：通过 pre-commit ruff lint/format 检查
- E2E/Workflow：需在 Langfuse 中验证 span 属性是否正确上报
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`apps/negentropy/src/negentropy/agents/_dynamic_model.py` — 纯可观测性增强，不改变模型选择逻辑
- GitHub Actions / 文档：无

# Next Best Action
- 合并后在 Langfuse 中验证 span 属性 `negentropy.user_selected_model` / `negentropy.effective_model` 是否正确展示
- 观察 `dynamic_litellm_fallback_to_default` 日志频率，评估是否存在频繁 fallback 的情况