### PR TITLE
fix(observability): 修复 Langfuse 模型名称口径不一致

### DIFF
--- a/apps/negentropy/src/negentropy/instrumentation.py
+++ b/apps/negentropy/src/negentropy/instrumentation.py
@@ -109,14 +109,14 @@ def _inject_genai_semconv_attrs(
     """在 LLM span 上写入 OTel GenAI semconv 1.28+ 非模型标准属性。
 
     涵盖 attribute（fail-soft，单个失败不影响其他）：
-        gen_ai.system, gen_ai.operation.name,
+        gen_ai.operation.name,
         gen_ai.request.temperature, gen_ai.request.top_p, gen_ai.request.max_tokens,
         gen_ai.usage.input_tokens, gen_ai.usage.output_tokens,
         gen_ai.response.id, gen_ai.response.finish_reasons
 
     模型属性（gen_ai.request.model / gen_ai.response.model /
-    langfuse.observation.model.name）由 ``_apply_model_normalization`` 统一写入，
-    本函数不再涉及。
+    gen_ai.system / langfuse.observation.model.name）由
+    ``_apply_model_normalization`` 统一写入，本函数不再涉及。
     """
     if not _is_writable_span(span):
         return

--- a/apps/negentropy/src/negentropy/instrumentation.py
+++ b/apps/negentropy/src/negentropy/instrumentation.py
@@ -35,36 +35,95 @@ def _normalize_model_name(model: str | None) -> str | None:
 # vendor 与裸名的单一事实源：``negentropy.model_names``。本文件仅作 OTel 注入。
 
 
+def _extract_response_model(response_obj: Any) -> str | None:
+    """从 LiteLLM response 对象中提取 model 字段，兼容 dict / object 两种形态。"""
+    if response_obj is None:
+        return None
+    if hasattr(response_obj, "get"):
+        try:
+            val = response_obj.get("model")
+            if isinstance(val, str):
+                return val
+        except Exception:
+            pass
+    val = getattr(response_obj, "model", None)
+    return val if isinstance(val, str) else None
+
+
+def _apply_model_normalization(span: Any, kwargs: dict, response_obj: Any) -> None:
+    """归一化模型名 + 注入 cost，确保 Langfuse 聚合到单一裸名行。
+
+    唯一写入 ``gen_ai.request.model``、``gen_ai.response.model`` 和
+    ``langfuse.observation.model.name`` 的入口。``_inject_genai_semconv_attrs``
+    不再写入 model 相关属性。
+    """
+    model = kwargs.get("model")
+    normalized_model = _normalize_model_name(model) if model else None
+    response_model = _extract_response_model(response_obj)
+    normalized_response_model = _normalize_model_name(response_model) if response_model else None
+
+    if not _is_writable_span(span):
+        return
+
+    # 覆盖 LiteLLM 原始写入的 request/response model（归一化裸名）
+    if normalized_model:
+        _safe_set_span_attribute(span, "gen_ai.request.model", normalized_model)
+    if normalized_response_model:
+        _safe_set_span_attribute(span, "gen_ai.response.model", normalized_response_model)
+
+    # vendor 单一事实源：原串前缀优先，否则裸名系族识别。
+    system = extract_vendor(model) or extract_vendor(response_model)
+    if system:
+        _safe_set_span_attribute(span, "gen_ai.system", system)
+
+    # Langfuse 私有强制覆盖键：最高优先级，确保 Model Costs 视图收敛到同一裸名行。
+    langfuse_model = normalized_response_model or normalized_model
+    if langfuse_model:
+        _safe_set_span_attribute(span, "langfuse.observation.model.name", langfuse_model)
+
+    # 诊断字段：保留原始调度模型名，便于排查。
+    if model:
+        _safe_set_span_attribute(span, "gen_ai.original_model", str(model))
+    if response_model and str(response_model) != str(model):
+        _safe_set_span_attribute(span, "gen_ai.original_response_model", str(response_model))
+
+    # Cost
+    cost = _extract_total_cost(kwargs, response_obj)
+    if cost is not None:
+        _safe_set_span_attribute(span, "gen_ai.usage.cost", cost)
+        _safe_set_span_attribute(
+            span,
+            "langfuse.observation.cost_details",
+            json.dumps({"total": cost}),
+        )
+
+    # 补全 OTel GenAI semconv 1.28+ 非模型属性
+    _inject_genai_semconv_attrs(span, kwargs, response_obj)
+
+
 def _inject_genai_semconv_attrs(
     span: Any,
     kwargs: dict,
     response_obj: Any,
 ) -> None:
-    """在 LLM span 上写入 OpenTelemetry GenAI semconv 1.28+ 标准属性。
+    """在 LLM span 上写入 OTel GenAI semconv 1.28+ 非模型标准属性。
 
     涵盖 attribute（fail-soft，单个失败不影响其他）：
-        gen_ai.system, gen_ai.operation.name, gen_ai.request.model, gen_ai.response.model,
+        gen_ai.system, gen_ai.operation.name,
         gen_ai.request.temperature, gen_ai.request.top_p, gen_ai.request.max_tokens,
         gen_ai.usage.input_tokens, gen_ai.usage.output_tokens,
         gen_ai.response.id, gen_ai.response.finish_reasons
 
-    本函数是幂等的（重复调用同 span 仅覆盖同名 attribute）。
+    模型属性（gen_ai.request.model / gen_ai.response.model /
+    langfuse.observation.model.name）由 ``_apply_model_normalization`` 统一写入，
+    本函数不再涉及。
     """
     if not _is_writable_span(span):
         return
 
     try:
-        model = kwargs.get("model")
-        normalized_model = _normalize_model_name(model) if model else None
-        # vendor 优先用原串前缀（最可靠），落空再用裸名系族识别。
-        system = extract_vendor(model) or extract_vendor(normalized_model)
-
-        if system:
-            _safe_set_span_attribute(span, "gen_ai.system", system)
-        # 当前 negentropy 仅走 chat completion 链路；TODO: 区分 embedding / tool_use
+        # gen_ai.system 已由 _apply_model_normalization 写入，此处不重复
         _safe_set_span_attribute(span, "gen_ai.operation.name", "chat")
-        if normalized_model:
-            _safe_set_span_attribute(span, "gen_ai.request.model", normalized_model)
 
         # 请求参数（仅当存在时上报）
         for key, attr in (
@@ -83,18 +142,6 @@ def _inject_genai_semconv_attrs(
 
         # 响应字段
         if response_obj is not None:
-            response_model = None
-            if hasattr(response_obj, "get"):
-                try:
-                    response_model = response_obj.get("model")
-                except Exception:
-                    response_model = None
-            if response_model is None:
-                response_model = getattr(response_obj, "model", None)
-            normalized_response_model = _normalize_model_name(response_model) if response_model else None
-            if normalized_response_model:
-                _safe_set_span_attribute(span, "gen_ai.response.model", normalized_response_model)
-
             response_id = None
             if hasattr(response_obj, "get"):
                 try:
@@ -138,7 +185,6 @@ def _inject_genai_semconv_attrs(
                     finish_reasons,
                 )
     except Exception:
-        # fail-soft：观测属性丢失不能影响 LLM 主路径
         pass
 
 
@@ -356,69 +402,17 @@ def patch_litellm_otel_cost() -> None:
         if not _is_writable_span(span):
             return
 
-        original_set_attributes(self, span, kwargs, response_obj)
+        # 原始方法可能因 standard_logging_object 缺失等原因内部失败，
+        # 但它已经将 gen_ai.request.model = kwargs["model"]（原始值如
+        # "openai/gpt-5-mini"）写入 span。包裹 try/except 确保后续归一化
+        # 始终执行，覆盖原始值。
         try:
-            # 模型名归一化用于 Langfuse Model Costs 视图聚合。
-            # 同 key set_attribute 是覆盖语义，无条件写以确保 alias 表生效。
-            model = kwargs.get("model")
-            normalized_model = _normalize_model_name(model) if model else None
-            response_model = None
-            if response_obj is not None and hasattr(response_obj, "get"):
-                try:
-                    response_model = response_obj.get("model")
-                except Exception:
-                    response_model = None
-            if response_model is None and response_obj is not None:
-                response_model = getattr(response_obj, "model", None)
-            normalized_response_model = _normalize_model_name(response_model) if response_model else None
+            original_set_attributes(self, span, kwargs, response_obj)
+        except Exception:
+            pass
 
-            if not _is_writable_span(span):
-                return
-
-            if normalized_model:
-                _safe_set_span_attribute(span, "gen_ai.request.model", normalized_model)
-            if normalized_response_model:
-                _safe_set_span_attribute(span, "gen_ai.response.model", normalized_response_model)
-
-            # vendor 单一事实源：原串前缀优先，否则裸名系族识别。
-            system = extract_vendor(model) or extract_vendor(response_model)
-            if system:
-                _safe_set_span_attribute(span, "gen_ai.system", system)
-
-            # Langfuse 私有强制覆盖键：胜过 ai.response.model / gen_ai.response.model，
-            # 让 Model Costs 视图收敛到同一裸名行。优先用 response.model（含具体版本，
-            # 经归一化后仍是裸名），落空再用 request.model。
-            langfuse_model = normalized_response_model or normalized_model
-            if langfuse_model:
-                _safe_set_span_attribute(span, "langfuse.observation.model.name", langfuse_model)
-
-            # 保留诊断：原始字符串挂在 span 上，便于排查「实际调用了哪个具体版本」，
-            # 与归一化后的聚合键并存不冲突。
-            # - request 侧：写 gen_ai.original_model，保留 vendor/ 前缀等调度信息；
-            # - response 侧：归一化前的 response.model 才含服务端实际版本（如
-            #   `gpt-5-mini-2025-08-07`），仅当与 request 不同（即归一化丢了信息）
-            #   才单独写一个键，避免冗余。
-            if model:
-                _safe_set_span_attribute(span, "gen_ai.original_model", str(model))
-            if response_model and str(response_model) != str(model):
-                _safe_set_span_attribute(
-                    span,
-                    "gen_ai.original_response_model",
-                    str(response_model),
-                )
-
-            # Extract and inject cost
-            cost = _extract_total_cost(kwargs, response_obj)
-            if cost is not None:
-                _safe_set_span_attribute(span, "gen_ai.usage.cost", cost)
-                _safe_set_span_attribute(
-                    span,
-                    "langfuse.observation.cost_details",
-                    json.dumps({"total": cost}),
-                )
-
-            # P3-3 · OTel GenAI semconv 1.28+ 标准属性补全
-            _inject_genai_semconv_attrs(span, kwargs, response_obj)
+        try:
+            _apply_model_normalization(span, kwargs, response_obj)
         except Exception:
             pass
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py
@@ -272,7 +272,9 @@ class CommunitySummarizer:
         """调用 LLM 生成摘要"""
         import litellm
 
-        model = self._model or "gpt-4o-mini"
+        from negentropy.config.model_resolver import get_fallback_llm_config
+
+        model = self._model or get_fallback_llm_config()[0]
         try:
             response = await litellm.acompletion(
                 model=model,

--- a/apps/negentropy/src/negentropy/knowledge/graph/global_search.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/global_search.py
@@ -386,7 +386,9 @@ class GlobalSearchService:
     async def _call_llm(self, prompt: str, max_tokens: int) -> str:
         import litellm
 
-        model = self._model or "gpt-4o-mini"
+        from negentropy.config.model_resolver import get_fallback_llm_config
+
+        model = self._model or get_fallback_llm_config()[0]
         try:
             response = await litellm.acompletion(
                 model=model,

--- a/apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py
@@ -3,7 +3,8 @@
 验证：
 - extract_vendor 把模型名前缀映射到正确 system（vendor 单一事实源已下沉到
   ``negentropy.model_names``，`instrumentation` 仅作 OTel 注入）；
-- _inject_genai_semconv_attrs 在 span 上写入完整 GenAI semconv 标准属性；
+- _apply_model_normalization 统一写入模型名归一化 + cost 属性；
+- _inject_genai_semconv_attrs 写入非模型 GenAI semconv 标准属性；
 - fail-soft：缺字段 / 异常 / 不可写 span 都不抛。
 """
 
@@ -103,7 +104,7 @@ def _make_response_obj(
 
 
 def test_inject_genai_full_attributes_for_anthropic_chat() -> None:
-    from negentropy.instrumentation import _inject_genai_semconv_attrs
+    from negentropy.instrumentation import _apply_model_normalization
 
     span = _make_writable_span()
     kwargs = {
@@ -119,7 +120,7 @@ def test_inject_genai_full_attributes_for_anthropic_chat() -> None:
         finish_reasons=["stop"],
     )
 
-    _inject_genai_semconv_attrs(span, kwargs, response)
+    _apply_model_normalization(span, kwargs, response)
 
     captured = span._captured
     assert captured["gen_ai.system"] == "anthropic"
@@ -158,7 +159,7 @@ def test_inject_genai_skips_unknown_system() -> None:
 
 def test_inject_genai_handles_missing_usage_and_choices() -> None:
     """response 无 usage / choices 时不抛，仅写出存在字段。"""
-    from negentropy.instrumentation import _inject_genai_semconv_attrs
+    from negentropy.instrumentation import _apply_model_normalization
 
     span = _make_writable_span()
     kwargs = {"model": "gpt-5.4-turbo"}
@@ -169,7 +170,7 @@ def test_inject_genai_handles_missing_usage_and_choices() -> None:
         finish_reasons=[],
     )
 
-    _inject_genai_semconv_attrs(span, kwargs, response)
+    _apply_model_normalization(span, kwargs, response)
 
     captured = span._captured
     assert captured["gen_ai.system"] == "openai"
@@ -202,7 +203,7 @@ def test_inject_genai_skips_when_span_not_writable() -> None:
 
 def test_inject_genai_fail_soft_on_response_exception() -> None:
     """response_obj 访问抛异常时不应向上传播。"""
-    from negentropy.instrumentation import _inject_genai_semconv_attrs
+    from negentropy.instrumentation import _apply_model_normalization
 
     span = _make_writable_span()
     response = MagicMock()
@@ -216,8 +217,8 @@ def test_inject_genai_fail_soft_on_response_exception() -> None:
     response.usage.completion_tokens = 5
 
     # 不抛
-    _inject_genai_semconv_attrs(span, {"model": "gpt-4"}, response)
-    # 仍能写入基础字段（system + operation.name + request.model）
+    _apply_model_normalization(span, {"model": "gpt-4"}, response)
+    # 仍能写入基础字段（system + operation.name）
     assert span._captured.get("gen_ai.system") == "openai"
 
 

--- a/apps/negentropy/tests/unit_tests/observability/test_instrumentation.py
+++ b/apps/negentropy/tests/unit_tests/observability/test_instrumentation.py
@@ -272,3 +272,68 @@ def test_log_success_event_skips_non_recording_current_span(monkeypatch):
     )
 
     assert span.attributes == {}
+
+
+def test_normalization_runs_even_if_original_set_attributes_raises(monkeypatch):
+    """original_set_attributes 抛异常时归一化仍应执行。"""
+
+    def _boom_set_attributes(self, span, kwargs, response_obj):
+        raise ValueError("simulated missing standard_logging_object")
+
+    monkeypatch.setattr(OpenTelemetry, "set_attributes", _boom_set_attributes)
+    patch_litellm_otel_cost()
+
+    span = _FakeSpan()
+    callback = _FakeOpenTelemetryCallback()
+    kwargs = {"model": "openai/gpt-5-mini", "response_cost": 0.08}
+    response_obj = {"model": "gpt-5-mini-2025-08-07"}
+
+    OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
+
+    # 归一化在 original 失败后仍然执行
+    assert span.attributes["gen_ai.request.model"] == "gpt-5-mini"
+    assert span.attributes["gen_ai.response.model"] == "gpt-5-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "gpt-5-mini"
+    assert span.attributes["gen_ai.system"] == "openai"
+
+
+def test_normalization_handles_embedding_model(monkeypatch):
+    """Embedding 模型名（gemini/text-embedding-004）也应剥离 vendor 前缀。"""
+
+    def _original_set_attributes(self, span, kwargs, response_obj):
+        self.safe_set_attribute(span, "gen_ai.request.model", kwargs.get("model"))
+
+    monkeypatch.setattr(OpenTelemetry, "set_attributes", _original_set_attributes)
+    patch_litellm_otel_cost()
+
+    span = _FakeSpan()
+    callback = _FakeOpenTelemetryCallback()
+    kwargs = {"model": "gemini/text-embedding-004"}
+    response_obj = {"model": "text-embedding-004"}
+
+    OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
+
+    assert span.attributes["gen_ai.request.model"] == "text-embedding-004"
+    assert span.attributes["gen_ai.system"] == "gemini"
+    assert span.attributes["langfuse.observation.model.name"] == "text-embedding-004"
+
+
+def test_normalization_handles_bare_model_name(monkeypatch):
+    """裸名（gpt-4o-mini）经归一化后保持不变。"""
+
+    def _original_set_attributes(self, span, kwargs, response_obj):
+        self.safe_set_attribute(span, "gen_ai.request.model", kwargs.get("model"))
+
+    monkeypatch.setattr(OpenTelemetry, "set_attributes", _original_set_attributes)
+    patch_litellm_otel_cost()
+
+    span = _FakeSpan()
+    callback = _FakeOpenTelemetryCallback()
+    kwargs = {"model": "gpt-4o-mini"}
+    response_obj = {"model": "gpt-4o-mini"}
+
+    OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
+
+    assert span.attributes["gen_ai.request.model"] == "gpt-4o-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "gpt-4o-mini"
+    assert span.attributes["gen_ai.system"] == "openai"


### PR DESCRIPTION
## Summary

- 加固 `_patched_set_attributes`：将 `original_set_attributes` 包裹 try/except，确保无论原始方法是否失败，模型名归一化始终执行
- 提取 `_apply_model_normalization` 独立函数：收敛 `gen_ai.request.model`、`gen_ai.response.model`、`langfuse.observation.model.name` 到单一写入入口
- 消除 `_inject_genai_semconv_attrs` 中重复的 model 属性写入
- 修复 `community_summarizer` / `global_search` 硬编码裸名 `"gpt-4o-mini"` fallback，改为 `model_resolver.get_fallback_llm_config()` 默认模型配置

## Test plan

- [x] `test_normalization_runs_even_if_original_set_attributes_raises` — 验证原始方法异常时归一化仍执行
- [x] `test_normalization_handles_embedding_model` — 验证 Embedding 模型名归一化
- [x] `test_normalization_handles_bare_model_name` — 验证裸名经归一化后不变
- [x] 全部 55 个相关单元测试通过
- [ ] 部署后观察 Langfuse Model Costs 视图中 `openai/gpt-5-mini` 是否消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)