### PR TITLE
fix(memory): 防止 Agent 将结构化 JSON 写入 memory content 字段

### DIFF
--- a/apps/negentropy/src/negentropy/agents/faculties/internalization.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/internalization.py
@@ -47,7 +47,9 @@ _INSTRUCTION = """
 
 ## 约束 (Constraints)
 - **严禁重复 (DRY Principle)**：不要创建副本。如果存在，请引用链接。
-- **格式严谨 (Strict Formatting)**：输出的 Markdown/JSON 必须严格符合 Schema 定义。
+- **Memory 写入约束 (Natural Language Only)**：调用 save_to_memory 时，
+  content 参数**必须**是自然语言描述句（如 "用户偏好 async-first 架构"），
+  严禁传入 JSON 对象。结构化数据请使用 update_knowledge_graph 写入 facts 表。
 - **数据主权 (Data Sovereignty)**：你是记忆的守护者，未经允许不得轻易删除核心记忆。
 """
 

--- a/apps/negentropy/src/negentropy/agents/tools/internalization.py
+++ b/apps/negentropy/src/negentropy/agents/tools/internalization.py
@@ -24,12 +24,27 @@ async def save_to_memory(content: str, tags: list[str] | None, tool_context: Too
     """将内容保存到长期记忆。
 
     Args:
-        content: 要保存的内容
+        content: 必须是自然语言描述句，禁止 JSON/结构化数据。
+            示例："用户偏好 TypeScript 前端开发"
+            错误示例：{"type":"preference","key":"lang","value":"TypeScript"}
         tags: 可选的标签列表
 
     Returns:
         保存结果
     """
+    from negentropy.engine.governance.content_validator import validate_memory_content
+
+    result = validate_memory_content(content)
+    if not result.is_natural_language:
+        return {
+            "status": "failed",
+            "error": (
+                f"save_to_memory content 必须是自然语言描述，而非 {result.detected_format}。"
+                "示例：'用户偏好 async-first 架构' 而非 JSON 对象。"
+                "结构化数据请使用 update_knowledge_graph。"
+            ),
+        }
+
     metadata = {"tags": tags or []}
     app_name = settings.app_name
     user_id = "anonymous"

--- a/apps/negentropy/src/negentropy/engine/governance/content_validator.py
+++ b/apps/negentropy/src/negentropy/engine/governance/content_validator.py
@@ -1,0 +1,46 @@
+"""Memory 内容格式校验器 — 检测非自然语言内容。
+
+防止结构化 JSON 被写入 memories.content 字段。
+设计参照同目录 pii_detector.py 的 thin-wrapper 模式：零依赖、同步、快速。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ContentCheckResult:
+    """内容格式检测结果。"""
+
+    is_natural_language: bool
+    detected_format: str  # "natural_language" | "json"
+
+
+def validate_memory_content(text: str) -> ContentCheckResult:
+    """校验 memory content 是否为自然语言。
+
+    检测逻辑：
+    1. 尝试 json.loads — 解析成功且为 dict（key ≥ 2）→ JSON
+    2. 其余情况 → 自然语言
+
+    Args:
+        text: 待校验的 content 字符串。
+
+    Returns:
+        ContentCheckResult 含 is_natural_language 和 detected_format。
+    """
+    if not text or not text.strip():
+        return ContentCheckResult(is_natural_language=True, detected_format="natural_language")
+
+    stripped = text.strip()
+
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, dict) and len(parsed) >= 2:
+            return ContentCheckResult(is_natural_language=False, detected_format="json")
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    return ContentCheckResult(is_natural_language=True, detected_format="natural_language")

--- a/apps/negentropy/tests/unit_tests/engine/test_content_validator.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_content_validator.py
@@ -1,0 +1,81 @@
+"""content_validator 单元测试。"""
+
+from __future__ import annotations
+
+from negentropy.engine.governance.content_validator import validate_memory_content
+
+
+class TestValidateMemoryContent:
+    """validate_memory_content 检测逻辑。"""
+
+    def test_natural_language_passes(self) -> None:
+        result = validate_memory_content("User prefers TypeScript and React for frontend development")
+        assert result.is_natural_language is True
+        assert result.detected_format == "natural_language"
+
+    def test_chinese_natural_language_passes(self) -> None:
+        result = validate_memory_content("用户偏好深色主题，VSCode 使用 Dracula 配色")
+        assert result.is_natural_language is True
+
+    def test_json_object_rejected(self) -> None:
+        content = '{"id": "verify-dev-fix", "type": "verification_task", "title": "test"}'
+        result = validate_memory_content(content)
+        assert result.is_natural_language is False
+        assert result.detected_format == "json"
+
+    def test_json_with_nested_object_rejected(self) -> None:
+        content = '{"id": "fix:123", "description": {"repo": "api-service", "pr": "#456"}}'
+        result = validate_memory_content(content)
+        assert result.is_natural_language is False
+        assert result.detected_format == "json"
+
+    def test_real_problematic_memory_rejected(self) -> None:
+        content = (
+            '{"id": "verify-dev-fix:20260510T082741Z",'
+            ' "type": "verification_task",'
+            ' "title": "VERIFY-DEV-FIX: api-service PR #456",'
+            ' "description": {"repo": "api-service", "pr": "#456"},'
+            ' "source": "ActionFaculty/user",'
+            ' "created_at": "2026-05-10T08:27:41Z"}'
+        )
+        result = validate_memory_content(content)
+        assert result.is_natural_language is False
+        assert result.detected_format == "json"
+
+    def test_single_key_json_passes(self) -> None:
+        """单 key JSON 视为自然语言（避免误判简单文本）。"""
+        result = validate_memory_content('{"key": "value"}')
+        assert result.is_natural_language is True
+
+    def test_json_array_passes(self) -> None:
+        """纯数组 JSON 不判为结构化（缺少 dict 的语义字段）。"""
+        result = validate_memory_content('["item1", "item2"]')
+        assert result.is_natural_language is True
+
+    def test_empty_string_passes(self) -> None:
+        result = validate_memory_content("")
+        assert result.is_natural_language is True
+
+    def test_whitespace_only_passes(self) -> None:
+        result = validate_memory_content("   ")
+        assert result.is_natural_language is True
+
+    def test_prose_with_curly_braces_passes(self) -> None:
+        """自然语言中偶现花括号不应被误判。"""
+        result = validate_memory_content("User mentioned the JSON format {key: value} in conversation")
+        assert result.is_natural_language is True
+
+    def test_dialogue_format_passes(self) -> None:
+        """原始对话格式（由其他路径处理）不被 JSON 检测拦截。"""
+        result = validate_memory_content("[User] Hello\n[Assistant] Hi there")
+        assert result.is_natural_language is True
+
+    def test_deployment_process_passes(self) -> None:
+        result = validate_memory_content(
+            "Deployment process: build with pnpm, test with vitest, deploy via GitHub Actions"
+        )
+        assert result.is_natural_language is True
+
+    def test_standup_schedule_passes(self) -> None:
+        result = validate_memory_content("Team standup is at 10am every Monday and Wednesday")
+        assert result.is_natural_language is True

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1772,4 +1772,26 @@
   3. **任何长任务的进度心跳**必须区分”非终态写入”（保留 `completed_at` 旧值）与”终态写入”（设 `NOW()`），既保留 cancel 时间锚，也让 watchdog 阈值真实反映”最后心跳”而非”启动时间”。
 - **同类问题影响**：
   - KB 侧 `KnowledgeRunDao` 已通过条件 UPDATE + OCC 机制规避同型 race；KG 侧本次修复使两侧语义对齐；
+
+---
+
+## ISSUE-020 Memory content 字段被写入结构化 JSON 而非自然语言
+
+- **表因**：Memory Timeline UI 上 Semantic 类型记忆显示为 JSON 对象（如 `{"id":"verify-dev-fix:...","type":"verification_task",...}`），用户无法从卡片中理解记忆含义。
+- **根因**：
+  1. `InternalizationFaculty` 指令中有"输出的 Markdown/JSON 必须严格符合 Schema 定义"（`faculties/internalization.py:50`），Agent 据此将 `save_to_memory` 的 content 参数填入结构化 JSON；
+  2. `save_to_memory()` 函数（`agents/tools/internalization.py:23-88`）对 content 参数无格式校验，JSON 畅通无阻地写入 `memories.content` 字段；
+  3. `save_to_memory` docstring 对 content 参数无格式约束说明，Agent LLM 看不到"必须是自然语言"的提示。
+- **处理方式**：
+  1. 新建 `engine/governance/content_validator.py` — 零依赖同步 JSON 检测工具（`validate_memory_content()`）；
+  2. `save_to_memory()` 加入 fail-fast 校验 — 检测到 JSON 时返回 `{"status": "failed", "error": "..."}` 并附带正确用法示例，引导 Agent 自我修正；
+  3. `InternalizationFaculty` 指令 — 将"格式严谨：输出的 Markdown/JSON 必须严格符合 Schema 定义"替换为"Memory 写入约束：content 必须是自然语言描述句，严禁传入 JSON 对象"；
+  4. 单元测试 13 条全绿，回归测试 34 条全绿。
+- **后续防范**：
+  1. Agent 工具的 content/docstring 应显式声明格式要求，不可留白让 LLM 自行推断；
+  2. Agent 指令中涉及"格式"的措辞需区分**工具输出格式**（JSON Schema 用于 API）和**记忆存储格式**（自然语言用于人可读）；
+  3. 记忆写入路径应建立格式守卫（至少是同步快速检测），防止非预期格式入库。
+- **同类问题影响**：
+  - `add_memory_typed()`（`memory_service.py:1450`）同样无格式校验，后续若 Agent 通过 `memory_write` 工具写入 JSON 也会出现同类问题，可考虑在此路径补充校验；
+  - `_simple_consolidate()` 路径存储的原始对话格式（`[User] text`）虽非 JSON 但也非语义记忆，可作为后续优化项。
   - `asyncio.gather(return_exceptions=True)` 误吞 cancel 是 Python asyncio 协作式取消的经典坑，凡使用该模式的批处理循环都需复核是否会吞掉自定义 cancel 异常。


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Agent 通过 `save_to_memory` 将结构化 JSON（如 `{"id":"verify-dev-fix:...","type":"verification_task",...}`）写入 `memories.content` 字段，导致 Memory Timeline UI 显示不可读的结构化数据。
- 关联上下文/Issue/文档：ISSUE-020

# 核心变更
- 新建 `content_validator.py`：零依赖同步 JSON 检测工具，参照同目录 `pii_detector.py` 的 thin-wrapper 模式
- `save_to_memory()` 入口加入 fail-fast 校验：检测到 JSON 对象（dict 且 key ≥ 2）时返回引导性错误信息，引导 Agent 自我修正
- `InternalizationFaculty` 指令修正：将"输出的 Markdown/JSON 必须严格符合 Schema 定义"替换为显式要求 content 必须为自然语言描述
- 新增 ISSUE-020 摘要至 `docs/issue.md`

# 风险与回滚
- 主要风险：`len(parsed) >= 2` 阈值可能导致单 key JSON 漏检，但这是刻意为之以降低误判率
- 回滚方式：`git revert` 本 PR 的两个 commit

# 验证证据
- 单元测试：13 条新增测试覆盖中英文自然语言、多层嵌套 JSON、空字符串、花括号散文等边界场景
- 集成测试：回归测试 34 条全绿
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`agents/tools/internalization.py`（save_to_memory 校验）、`agents/faculties/internalization.py`（指令）、`engine/governance/content_validator.py`（新建）
- GitHub Actions / 文档：`docs/issue.md` 新增 ISSUE-020 摘要

# Next Best Action
- `add_memory_typed()`（`memory_service.py`）同样无格式校验，后续若 Agent 通过 `memory_write` 工具写入 JSON 也会出现同类问题，可考虑在此路径补充校验