### PR TITLE
fix(knowledge-graph): Graph Canvas 高度自适应填满浏览器视口

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas.tsx
@@ -243,7 +243,14 @@ export function GraphCanvas({
       }
     });
 
+    // 容器尺寸变化时同步 cytoscape viewport
+    const ro = new ResizeObserver(() => {
+      cy.resize();
+    });
+    ro.observe(containerRef.current);
+
     return () => {
+      ro.disconnect();
       cy.destroy();
       cyRef.current = null;
     };
@@ -285,7 +292,7 @@ export function GraphCanvas({
   const truncated = nodes.length >= truncateThreshold;
 
   return (
-    <div className="relative h-[600px] w-full rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+    <div className="relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <div ref={containerRef} className="h-full w-full" />
       <div className="pointer-events-none absolute right-3 top-3 flex flex-col items-end gap-1 text-[10px]">
         <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -403,10 +403,10 @@ export default function KnowledgeGraphPage() {
         description="实体关系视图与构建历史"
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-h-0 flex-1 gap-6 px-6 py-4">
+        <div className="flex min-h-0 flex-1 gap-6 px-6 pt-4">
           {/* Main content area */}
-          <div className="min-h-0 min-w-0 flex-[2.2] overflow-y-auto">
-            <div className="space-y-4 pb-4 pr-2">
+          <div className="min-h-0 min-w-0 flex-[2.2] flex flex-col overflow-hidden">
+            <div className="flex min-h-0 flex-1 flex-col gap-4 pr-2">
               {/* Toolbar */}
               <div className="flex items-center justify-between">
                 <CorpusSelector value={corpusId} onChange={setCorpusId} />
@@ -521,7 +521,7 @@ export default function KnowledgeGraphPage() {
                   onSubgraphMerge={handleSubgraphMerge}
                 />
               ) : viewTab === "graph" && renderer === "cytoscape" ? (
-                <div className="flex h-[600px] items-center justify-center rounded-2xl border border-dashed border-zinc-200 bg-zinc-50 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
+                <div className="flex flex-1 min-h-0 items-center justify-center rounded-2xl border border-dashed border-zinc-200 bg-zinc-50 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
                   {!corpusId
                     ? "请选择语料库"
                     : error
@@ -529,7 +529,7 @@ export default function KnowledgeGraphPage() {
                       : "图谱为空，请先构建"}
                 </div>
               ) : viewTab === "graph" ? (
-              <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="min-h-0 flex-1 flex flex-col rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                 <div className="flex items-center justify-between">
                   <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                     Graph Canvas
@@ -541,7 +541,7 @@ export default function KnowledgeGraphPage() {
                     </div>
                   )}
                 </div>
-                <div className="mt-3 flex h-[500px] items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800">
+                <div className="mt-3 flex flex-1 min-h-0 items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800">
                   {!corpusId ? (
                     <div className="text-center">
                       <p className="text-sm text-zinc-500 dark:text-zinc-400">
@@ -658,7 +658,7 @@ export default function KnowledgeGraphPage() {
               </div>
               ) : (
               /* Entity List View */
-              <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                 <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3">
                   实体列表
                 </h2>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：知识图谱页面的 Graph Canvas 面板使用固定高度（600px/500px），无法随浏览器窗口自适应填充，导致大面积空白浪费屏幕空间。
- 关联上下文/Issue/文档：用户反馈知识图谱页 Canvas 未占满浏览器可视区域。

# 核心变更
- 将主内容区从 `overflow-y-auto` 滚动布局改为 `flex flex-col overflow-hidden` 弹性列布局，使子元素可通过 `flex-1` 增长填满可用空间
- GraphCanvas（Cytoscape）容器从 `h-[600px]` 改为 `flex-1 min-h-0`，随视口高度自适应
- 新增 `ResizeObserver` 监听容器尺寸变化并调用 `cy.resize()` 同步 Cytoscape viewport 坐标系
- 空状态占位、D3 渲染器面板同步改为弹性增长
- 实体列表视图保留独立滚动（`overflow-y-auto`），不受弹性布局影响
- 移除底部多余 padding（`py-4` → `pt-4`，移除 `pb-4`），Canvas 精确贴合视口底部

# 风险与回滚
- 主要风险：弹性布局可能影响窄屏/小窗口下的内容溢出；Cytoscape `cy.resize()` 在极端频繁触发时可能有微小性能开销
- 回滚方式：`git revert` 即可恢复固定高度布局

# 验证证据
- 单元测试：无新增（纯 UI 布局变更）
- 集成测试：TypeScript 编译通过（`pnpm exec tsc --noEmit` 零错误）
- E2E/Workflow：浏览器多尺寸实机验证（800px/1000px/1270px 三种视口高度，Canvas 底部均精确贴合视口，`fillsViewport: true`）
- 覆盖率/关键截图：Cytoscape Canvas、D3 渲染器、空状态占位、实体列表视图均逐一验证

# 影响范围
- 前端：`apps/negentropy-ui/app/knowledge/graph/page.tsx`、`_components/GraphCanvas.tsx`（2 文件，+15/-8 行）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 可考虑为超窄窗口（<768px）添加响应式断点，在小屏幕下回退为固定高度以保障可用性