### PR TITLE
style(memory): 统一 Audit 与 Timeline 页 Users 列宽度，优化三栏布局占比

### DIFF
--- a/apps/negentropy-ui/app/memory/audit/page.tsx
+++ b/apps/negentropy-ui/app/memory/audit/page.tsx
@@ -109,7 +109,7 @@ export default function MemoryAuditPage() {
 
           <div className="flex min-h-0 flex-1 gap-6">
           {/* Users sidebar */}
-          <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+          <aside className="min-h-0 w-52 shrink-0 overflow-y-auto">
             <div className="pb-4 pr-2">
               <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                 <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Users</h2>
@@ -128,7 +128,7 @@ export default function MemoryAuditPage() {
                           setAuditMap({});
                         }}
                       >
-                        <p className="text-xs font-semibold">
+                        <p className="truncate text-xs font-semibold">
                           {user.label || user.id}
                         </p>
                       </button>

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -127,9 +127,9 @@ export default function MemoryTimelinePage() {
 
           <div className="flex min-h-0 flex-1 gap-6">
             {/* Users sidebar */}
-            <aside className="min-h-0 w-56 max-w-56 shrink-0 overflow-y-auto">
+            <aside className="min-h-0 w-52 shrink-0 overflow-y-auto">
               <div className="pb-4 pr-2">
-                <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                <div className="rounded-2xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                   <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Users</h2>
                   <div className="mt-3 space-y-1.5">
                     {users.length ? (


### PR DESCRIPTION
## Summary

- Audit 页 Users 列从弹性 `flex-1` 缩窄为固定 `w-52`（208px），减少大面积空白
- Timeline 页 Users 列从 `w-56`（224px）统一为 `w-52`，与 Audit 页保持一致
- Audit 页用户名增加 `truncate` 防止长名称换行
- Timeline 页 Users 卡片内边距从 `p-4` 调整为 `p-3` 适配窄列

两个页面三栏布局（Users / 主内容 / 右侧栏）现在使用相同的宽度规则：固定 `w-52` + `flex-[2.2]` + `flex-1`，中间 Memory Audit/Timeline 模块自动获得更多空间。

## Test plan

- [ ] 启动 dev server，访问 `/memory/audit` 确认 Users 列宽度合理，长用户名被 truncate
- [ ] 访问 `/memory/timeline` 确认 Users 列宽度与 Audit 页一致，头像+名称+count 正常显示
- [ ] 缩放浏览器窗口至 1024px，确认布局无折叠或溢出

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)