### PR TITLE
fix(logging): 降级 OTLP span 导出错误为 WARNING 级别

### DIFF
--- a/apps/negentropy/src/negentropy/logging/interceptors.py
+++ b/apps/negentropy/src/negentropy/logging/interceptors.py
@@ -21,6 +21,16 @@ class RedirectStdLibHandler(logging.Handler):
             if "structlog" in record.name:
                 return
 
+            # Downgrade non-critical OTLP span export errors to WARNING
+            # (SSL timeout, connection refused, etc.) — fire-and-forget telemetry
+            if (
+                record.name == "opentelemetry.sdk._shared_internal"
+                and record.levelno >= logging.ERROR
+                and "export" in (record.getMessage() or "").lower()
+            ):
+                record.levelno = logging.WARNING
+                record.levelname = "WARNING"
+
             # Format message using stdlib's formatting (handles %s args)
             msg = self.format(record)
 


### PR DESCRIPTION
# 背景
- OTLP span 导出错误（SSL 超时、连接拒绝等）以 ERROR 级别涌入日志，产生大量噪音，干扰对真正业务错误的排查。
- 这些导出错误属于 fire-and-forget 遥测范畴，不应等同于应用级 ERROR。

# 核心变更
- 在 `RedirectStdLibHandler.emit()` 中新增过滤逻辑，将来自 `opentelemetry.sdk._shared_internal` 且消息包含 "export" 的 ERROR 及以上级别日志降级为 WARNING。

# 风险与回滚
- 主要风险：OTLP 后端完全不可用时，导出失败仅以 WARNING 呈现，可能被忽视；但不影响任何业务逻辑。
- 回滚方式：`git revert` 该提交即可。

# 验证证据
- 单元测试：ruff lint/format 通过
- 集成测试：无新增测试用例（纯日志级别调整，不影响业务逻辑）
- E2E/Workflow：不适用
- 覆盖率/关键截图：不适用

# 影响范围
- 前端：无
- 后端：`apps/negentropy/src/negentropy/logging/interceptors.py`
- GitHub Actions / 文档：无

# Next Best Action
- 观察生产环境中 OTLP 导出 WARNING 日志的频率，若仍然过于频繁可考虑进一步降级为 DEBUG 或完全静默。