### PR TITLE
fix(knowledge-graph): KG Build 进度逐 chunk 实时上报 — 消除批次级跳跃

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -768,34 +768,34 @@ class GraphService:
             # 阶段 1：实体/关系抽取（chunk 循环占整体进度 0.0 → 0.80）
             await emit_phase(PHASE_EXTRACTING, 0.0, processed=0, total=total_chunks)
 
-            # 批量处理
+            # 批量处理：as_completed 逐个完成逐个上报，避免 gather 全部完成后
+            # tally 循环微秒级跑完导致进度从 0 跳到 batch_size。
+            # semaphore 仍限制实际 LLM 并发为 max_concurrency，调用效率不变。
             for i in range(0, len(chunks), batch_size):
-                # 批次入口取消检查点（ISSUE-080）：in-memory event O(1) 快路径，
-                # 避免在 cancel 已 set 后仍发起整批 gather 浪费调度与日志。
+                # 批次入口取消检查点（ISSUE-080）
                 if is_cancelled(run_id):
                     raise PipelineCancelled(run_id, last_stage=PHASE_EXTRACTING)
 
                 batch = chunks[i : i + batch_size]
-                results = await asyncio.gather(
-                    *[process_chunk(chunk) for chunk in batch],
-                    return_exceptions=True,
-                )
+                pending = [asyncio.ensure_future(process_chunk(chunk)) for chunk in batch]
 
-                # 关键（ISSUE-080）：PipelineCancelled 优先于其它异常显式 re-raise，
-                # 防止被 ``return_exceptions=True`` 打包后误计入 failed_chunk_count
-                # 静默吞没——这是原版导致 cancel 信号在 chunk loop 内丢失、批次继续
-                # 处理直到下一个 phase 边界才被感知的根因。
-                for result in results:
-                    if isinstance(result, PipelineCancelled):
-                        raise result
-
-                for result in results:
-                    if isinstance(result, Exception):
+                for coro in asyncio.as_completed(pending):
+                    try:
+                        result = await coro
+                    except PipelineCancelled:
+                        # 取消同批剩余任务（ISSUE-080）：避免 cancel 信号
+                        # 在 chunk loop 内丢失、批次继续处理直到下一个 phase
+                        # 边界才被感知。
+                        for t in pending:
+                            if not t.done():
+                                t.cancel()
+                        raise
+                    except Exception as exc:
                         logger.warning(
                             "chunk_processing_error",
                             run_id=run_id,
-                            error=str(result),
-                            error_type=type(result).__name__,
+                            error=str(exc),
+                            error_type=type(exc).__name__,
                         )
                         failed_chunk_count += 1
                         continue
@@ -812,9 +812,8 @@ class GraphService:
                         entity_count=len(entities),
                         relation_count=len(relations),
                     )
-
-                # 节流上报（自适应 chunk 阈值 + ≥5s 时间兜底）
-                await maybe_report_chunk_progress()
+                    # 每个 chunk 完成后即上报（自适应节流仍在生效）
+                    await maybe_report_chunk_progress()
 
             # 回收 litellm 内部 HTTP Session（aiohttp.ClientSession）
             # litellm.acompletion 每次调用可能创建内部 Session 对象，


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：KG Build 在少量 chunks（如 20 个）场景下，进度从 0/20 直接跳到 10/20，而非逐个递增（1/20, 2/20, ...）。根因是 `asyncio.gather` 批量处理完成后才调用 `maybe_report_chunk_progress()`，tally 循环微秒级跑完导致进度跳跃。
- 关联上下文：自适应节流逻辑本身配置正确（`threshold = max(1, total_chunks // 200)`），但上报函数在批次级别而非 chunk 级别被调用。

# 核心变更
- 将 `asyncio.gather(return_exceptions=True)` 替换为 `asyncio.as_completed`，chunk 完成一个处理一个，而非等整批完成后 tally
- `maybe_report_chunk_progress()` 从批次级调用移至 chunk 级调用：每完成一个 chunk 即上报进度
- `PipelineCancelled` 异常处理：捕获后取消同批剩余 task 并 re-raise，语义等价于原 `return_exceptions=True` 方案
- semaphore 仍限制 LLM 并发为 `max_concurrency=3`，LLM 调用效率不受影响

# 风险与回滚
- 主要风险：`as_completed` 的异常处理路径与原 `gather` + `return_exceptions=True` 不同，需确保 `PipelineCancelled` 和普通异常的语义不变
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：25 个测试全部通过（`test_graph_service.py`）
- 集成测试：N/A
- E2E/Workflow：待手动验证进度条逐个更新效果
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无变更，数据契约不变（仍通过 polling 获取 `progress_percent`）
- 后端：`service.py` chunk 循环处理模式变更
- GitHub Actions / 文档：无

# Next Best Action
- 在本地环境触发 KG Build（20 chunks），通过 Chrome DevTools 接入浏览器验证进度条是否从 1/20 逐步递增至 20/20