### PR TITLE
feat(knowledge-graph): 统一画布外框 + 3D 标签 + 全屏 + 工具栏三段式 + 右栏抽屉

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/BuildButton.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/BuildButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * BuildButton — 工具栏紧凑型「构建图谱」按钮。
+ *
+ * 与 BuildPanel 的职责分工（AGENTS.md「正交分解」）：
+ *   - BuildPanel：完整版面，含「请先选择语料库」文案 + 错误段落，仍服务于
+ *     d3 渲染器「暂无图谱数据」空态分支。
+ *   - BuildButton：仅一个按钮 + 红点错误指示，嵌入工具栏右侧，与
+ *     CorpusSelector / 引擎选择器同基线。
+ */
+
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+
+interface BuildButtonProps {
+  building: boolean;
+  corpusId: string | null;
+  lastBuildError: string | null;
+  onBuild: () => void;
+}
+
+export function BuildButton({
+  building,
+  corpusId,
+  lastBuildError,
+  onBuild,
+}: BuildButtonProps) {
+  const title = !corpusId
+    ? "请先选择语料库"
+    : building
+      ? "构建中..."
+      : lastBuildError
+        ? `上次构建失败：${lastBuildError}`
+        : "构建图谱";
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onBuild}
+        disabled={!corpusId || building}
+        title={title}
+        aria-label="构建图谱"
+        className={outlineButtonClassName(
+          "neutral",
+          "rounded-lg px-3 py-1 text-xs font-medium",
+        )}
+      >
+        {building ? "构建中..." : "构建图谱"}
+      </button>
+      {lastBuildError && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -top-1 -right-1 h-2 w-2 rounded-full bg-red-500 ring-2 ring-white dark:ring-zinc-900"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/BuildPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/BuildPanel.tsx
@@ -53,11 +53,16 @@ interface BuildHistoryListProps {
 export function BuildHistoryList({ runs, corpusId, onCancel }: BuildHistoryListProps) {
   const [page, setPage] = useState(0);
   // 采用 React 19 推荐的「render 期间根据 props 调整 state」范式（替代 useEffect+setState
-  // 的级联渲染），当 runs.length 变化时同步重置分页索引。
+  // 的级联渲染），当底层数据刷新时同步重置分页索引。
   // 参考：https://react.dev/learn/you-might-not-need-an-effect
-  const [prevRunsLength, setPrevRunsLength] = useState(runs.length);
-  if (prevRunsLength !== runs.length) {
-    setPrevRunsLength(runs.length);
+  //
+  // 比较对象选择 `runs` 引用而非 `runs.length`：父组件的 `useMemo(() => …, [payload])`
+  // 在 payload 改变（切换语料库 / 时间穿梭 / 构建后重拉）时整体重建 `runs` 数组。
+  // 若按长度比较，两个语料库恰好拥有等长构建历史时切换不会触发重置，用户会停留在
+  // 例如「第 2 页」却看着另一个语料库的数据。引用比较覆盖一切刷新场景。
+  const [prevRuns, setPrevRuns] = useState(runs);
+  if (prevRuns !== runs) {
+    setPrevRuns(runs);
     setPage(0);
   }
 

--- a/apps/negentropy-ui/app/knowledge/graph/_components/BuildPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/BuildPanel.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { useState } from "react";
+
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import type { GraphBuildRunRecord } from "@/features/knowledge";
+
+const BUILD_HISTORY_PAGE_SIZE = 5;
 
 interface BuildPanelProps {
   building: boolean;
@@ -47,6 +51,16 @@ interface BuildHistoryListProps {
 }
 
 export function BuildHistoryList({ runs, corpusId, onCancel }: BuildHistoryListProps) {
+  const [page, setPage] = useState(0);
+  // 采用 React 19 推荐的「render 期间根据 props 调整 state」范式（替代 useEffect+setState
+  // 的级联渲染），当 runs.length 变化时同步重置分页索引。
+  // 参考：https://react.dev/learn/you-might-not-need-an-effect
+  const [prevRunsLength, setPrevRunsLength] = useState(runs.length);
+  if (prevRunsLength !== runs.length) {
+    setPrevRunsLength(runs.length);
+    setPage(0);
+  }
+
   if (!runs.length) {
     return (
       <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
@@ -55,9 +69,15 @@ export function BuildHistoryList({ runs, corpusId, onCancel }: BuildHistoryListP
     );
   }
 
+  const totalPages = Math.max(1, Math.ceil(runs.length / BUILD_HISTORY_PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages - 1);
+  const start = currentPage * BUILD_HISTORY_PAGE_SIZE;
+  const pageRuns = runs.slice(start, start + BUILD_HISTORY_PAGE_SIZE);
+  const showPager = runs.length > BUILD_HISTORY_PAGE_SIZE;
+
   return (
     <div className="mt-3 space-y-2">
-      {runs.map((run) => (
+      {pageRuns.map((run) => (
         <div
           key={run.run_id}
           className="rounded-lg border border-zinc-200 p-3 dark:border-zinc-700"
@@ -102,6 +122,29 @@ export function BuildHistoryList({ runs, corpusId, onCancel }: BuildHistoryListP
           )}
         </div>
       ))}
+      {showPager && (
+        <div className="mt-2 flex items-center justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
+          <button
+            type="button"
+            disabled={currentPage === 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            className="rounded border border-zinc-200 px-2 py-0.5 hover:bg-zinc-50 disabled:opacity-30 disabled:hover:bg-transparent dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            上一页
+          </button>
+          <span>
+            第 {currentPage + 1} / {totalPages} 页 · 共 {runs.length} 条
+          </span>
+          <button
+            type="button"
+            disabled={currentPage >= totalPages - 1}
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            className="rounded border border-zinc-200 px-2 py-0.5 hover:bg-zinc-50 disabled:opacity-30 disabled:hover:bg-transparent dark:border-zinc-700 dark:hover:bg-zinc-800"
+          >
+            下一页
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
@@ -18,6 +18,7 @@ import { useTheme } from "next-themes";
 import { fetchGraphSubgraph } from "@/features/knowledge";
 
 import { entityColor, communityColor } from "./constants";
+import { GraphCanvasFrame } from "./GraphCanvasFrame";
 import type { GraphCanvasNode, GraphCanvasEdge, GraphCanvasProps } from "./types";
 
 function nodeSize(importance?: number | null): number {
@@ -238,7 +239,23 @@ export function ForceGraphCanvas({
   );
 
   return (
-    <div className="relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+    <GraphCanvasFrame
+      stats={{ nodes: nodes.length, edges: edges.length, suffix: "Force Canvas" }}
+      badges={
+        <>
+          {truncated && (
+            <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
+              已按 importance 截断（双击节点展开邻居）
+            </span>
+          )}
+          {expanding && (
+            <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
+              加载子图…
+            </span>
+          )}
+        </>
+      }
+    >
       <div ref={containerRef} className="h-full w-full">
         {ForceGraph2D && (
           <ForceGraph2D
@@ -271,21 +288,6 @@ export function ForceGraphCanvas({
           />
         )}
       </div>
-      <div className="pointer-events-none absolute right-3 top-3 flex flex-col items-end gap-1 text-[10px]">
-        <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
-          {nodes.length} 节点 · {edges.length} 边 · Canvas
-        </span>
-        {truncated && (
-          <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
-            已按 importance 截断（双击节点展开邻居）
-          </span>
-        )}
-        {expanding && (
-          <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
-            加载子图…
-          </span>
-        )}
-      </div>
-    </div>
+    </GraphCanvasFrame>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas.tsx
@@ -25,6 +25,7 @@ import fcose from "cytoscape-fcose";
 import { fetchGraphSubgraph } from "@/features/knowledge";
 
 import { entityColor, communityColor } from "./constants";
+import { GraphCanvasFrame } from "./GraphCanvasFrame";
 import type { GraphCanvasNode, GraphCanvasEdge, GraphCanvasProps } from "./types";
 
 // fCoSE 注册一次即可（重复 register 会被 cytoscape 内部 no-op 处理）
@@ -270,23 +271,24 @@ export function GraphCanvas({
   const truncated = nodes.length >= truncateThreshold;
 
   return (
-    <div className="relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+    <GraphCanvasFrame
+      stats={{ nodes: nodes.length, edges: edges.length, suffix: "Cytoscape" }}
+      badges={
+        <>
+          {truncated && (
+            <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
+              已按 importance 截断（双击节点展开邻居）
+            </span>
+          )}
+          {expanding && (
+            <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
+              加载子图…
+            </span>
+          )}
+        </>
+      }
+    >
       <div ref={containerRef} className="h-full w-full" />
-      <div className="pointer-events-none absolute right-3 top-3 flex flex-col items-end gap-1 text-[10px]">
-        <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
-          {nodes.length} 节点 · {edges.length} 边
-        </span>
-        {truncated && (
-          <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
-            已按 importance 截断（双击节点展开邻居）
-          </span>
-        )}
-        {expanding && (
-          <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
-            加载子图…
-          </span>
-        )}
-      </div>
-    </div>
+    </GraphCanvasFrame>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
@@ -3,10 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
+import SpriteText from "three-spritetext";
 
 import { fetchGraphSubgraph } from "@/features/knowledge";
 
 import { entityColor, communityColor } from "./constants";
+import { GraphCanvasFrame } from "./GraphCanvasFrame";
 
 // ForceGraph3D 仅在客户端加载，避免 three.js SSR 问题。
 // react-force-graph-3d 导出 ClassComponent，用 any 绕过 dynamic() 的 FC 约束。
@@ -146,10 +148,49 @@ export function GraphCanvas3D({
   );
 
   const bgColor = resolvedTheme === "dark" ? "#09090b" : "#ffffff";
+  const isDark = resolvedTheme === "dark";
   const truncated = nodes.length >= truncateThreshold;
 
+  // three-spritetext 为每个节点生成持久 3D 文字（不依赖 hover tooltip），
+  // 与 2D/Sigma/Cytoscape 渲染器视觉对齐。参考 react-force-graph 官方
+  // text-nodes 范式：nodeThreeObjectExtend=true 保留原始球体（含 selected
+  // 高亮），sprite 在球体上方叠加。
+  const getNodeThreeObject = useCallback(
+    (node: { id: string | number; label?: string }) => {
+      const text = node.label ?? String(node.id).slice(0, 8);
+      const sprite = new SpriteText(text);
+      sprite.color = isDark ? "#e4e4e7" : "#27272a";
+      sprite.backgroundColor = isDark
+        ? "rgba(9,9,11,0.55)"
+        : "rgba(255,255,255,0.7)";
+      sprite.padding = 1;
+      sprite.textHeight = 3;
+      const val = nodeMeta.get(String(node.id))?.val ?? 3;
+      sprite.position.set(0, val + 2, 0);
+      return sprite;
+    },
+    [isDark, nodeMeta],
+  );
+
   return (
-    <div className="relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900 overflow-hidden">
+    <GraphCanvasFrame
+      className="overflow-hidden"
+      stats={{ nodes: nodes.length, edges: edges.length, suffix: "3D WebGL" }}
+      badges={
+        <>
+          {truncated && (
+            <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
+              已按 importance 截断（右键节点展开邻居）
+            </span>
+          )}
+          {expanding && (
+            <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
+              加载子图…
+            </span>
+          )}
+        </>
+      }
+    >
       <ForceGraph3D
         ref={fgRef}
         graphData={graphData}
@@ -157,6 +198,8 @@ export function GraphCanvas3D({
         nodeColor={getNodeColor}
         nodeVal={getNodeVal}
         nodeOpacity={0.95}
+        nodeThreeObject={getNodeThreeObject}
+        nodeThreeObjectExtend={true}
         linkColor={() => "#a1a1aa"}
         linkOpacity={0.4}
         linkWidth={0.8}
@@ -173,21 +216,6 @@ export function GraphCanvas3D({
         enableNodeDrag={true}
         showNavInfo={false}
       />
-      <div className="pointer-events-none absolute right-3 top-3 flex flex-col items-end gap-1 text-[10px]">
-        <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
-          {nodes.length} 节点 · {edges.length} 边
-        </span>
-        {truncated && (
-          <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
-            已按 importance 截断（右键节点展开邻居）
-          </span>
-        )}
-        {expanding && (
-          <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
-            加载子图…
-          </span>
-        )}
-      </div>
-    </div>
+    </GraphCanvasFrame>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx
@@ -75,13 +75,24 @@ export function GraphCanvasFrame({
     const el = frameRef.current as FullscreenCapableElement | null;
     if (!el) return;
     const current = getFullscreenElement();
-    if (current === el) {
-      const doc = document as FullscreenCapableDocument;
-      if (doc.exitFullscreen) await doc.exitFullscreen();
-      else if (doc.webkitExitFullscreen) await doc.webkitExitFullscreen();
-    } else {
-      if (el.requestFullscreen) await el.requestFullscreen();
-      else if (el.webkitRequestFullscreen) await el.webkitRequestFullscreen();
+    // requestFullscreen / exitFullscreen 返回 Promise，可能因以下原因 reject：
+    //   - 用户拒绝浏览器权限弹窗
+    //   - 页面位于无 `allow="fullscreen"` 的跨域 iframe
+    //   - 已有其它元素占据全屏（DOM 状态竞争）
+    //   - Safari `webkitRequestFullscreen` 在部分上下文返回非 Promise 或异常
+    // 不捕获就会冒泡为 unhandled promise rejection，污染控制台。
+    // 这里降级为 console.warn（保留可观测性但不打断用户交互）。
+    try {
+      if (current === el) {
+        const doc = document as FullscreenCapableDocument;
+        if (doc.exitFullscreen) await doc.exitFullscreen();
+        else if (doc.webkitExitFullscreen) await doc.webkitExitFullscreen();
+      } else {
+        if (el.requestFullscreen) await el.requestFullscreen();
+        else if (el.webkitRequestFullscreen) await el.webkitRequestFullscreen();
+      }
+    } catch (err) {
+      console.warn("graph_canvas_fullscreen_toggle_failed", err);
     }
   }, []);
 

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * GraphCanvasFrame — 五大图谱渲染器共享的画布外框。
+ *
+ * 设计意图：
+ *   - 收敛 Cytoscape / d3-force / 3D / Sigma / Force Graph 此前各自复制的
+ *     `relative min-h-0 flex-1 w-full rounded-2xl border ...` 外壳，确保
+ *     视觉契约的单一事实源（AGENTS.md「单一事实源」）。
+ *   - 统一提供右上角浮层：stats 徽标 + 调用方传入的次要徽标（truncated /
+ *     expanding 等）+ 全屏切换按钮。
+ *   - 全屏使用浏览器原生 Fullscreen API：以外框元素自身作为目标，确保
+ *     stats 与按钮在全屏期间仍可见；并通过 `data-fullscreen` 自定义属性
+ *     + Tailwind `data-[fullscreen=true]:*` 修正全屏元素默认黑底问题。
+ *   - Safari 兼容：fallback 调用 `webkitRequestFullscreen` /
+ *     `webkitExitFullscreen`。
+ */
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Maximize2, Minimize2 } from "lucide-react";
+
+interface GraphCanvasFrameStats {
+  nodes: number;
+  edges: number;
+  /** 渲染器后缀，例如 "WebGL" / "Canvas" / "SVG"，便于用户辨识当前引擎 */
+  suffix?: string;
+}
+
+export interface GraphCanvasFrameProps {
+  stats?: GraphCanvasFrameStats;
+  /** truncated / expanding 等次要徽标，渲染于 stats 与全屏按钮之间 */
+  badges?: ReactNode;
+  /** 渲染器 DOM（容器 div / ForceGraph3D / etc.） */
+  children: ReactNode;
+  /** 扩展类名（例如 GraphCanvas3D 需要 overflow-hidden） */
+  className?: string;
+}
+
+interface FullscreenCapableElement extends HTMLDivElement {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+}
+
+interface FullscreenCapableDocument extends Document {
+  webkitExitFullscreen?: () => Promise<void> | void;
+  webkitFullscreenElement?: Element | null;
+}
+
+function getFullscreenElement(): Element | null {
+  const doc = document as FullscreenCapableDocument;
+  return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
+}
+
+export function GraphCanvasFrame({
+  stats,
+  badges,
+  children,
+  className,
+}: GraphCanvasFrameProps) {
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const [isFs, setIsFs] = useState(false);
+
+  useEffect(() => {
+    const onChange = () => {
+      setIsFs(getFullscreenElement() === frameRef.current);
+    };
+    document.addEventListener("fullscreenchange", onChange);
+    document.addEventListener("webkitfullscreenchange", onChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onChange);
+      document.removeEventListener("webkitfullscreenchange", onChange);
+    };
+  }, []);
+
+  const toggleFullscreen = useCallback(async () => {
+    const el = frameRef.current as FullscreenCapableElement | null;
+    if (!el) return;
+    const current = getFullscreenElement();
+    if (current === el) {
+      const doc = document as FullscreenCapableDocument;
+      if (doc.exitFullscreen) await doc.exitFullscreen();
+      else if (doc.webkitExitFullscreen) await doc.webkitExitFullscreen();
+    } else {
+      if (el.requestFullscreen) await el.requestFullscreen();
+      else if (el.webkitRequestFullscreen) await el.webkitRequestFullscreen();
+    }
+  }, []);
+
+  const baseClass =
+    "relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 data-[fullscreen=true]:bg-white data-[fullscreen=true]:dark:bg-zinc-900";
+
+  return (
+    <div
+      ref={frameRef}
+      data-fullscreen={isFs ? "true" : "false"}
+      className={className ? `${baseClass} ${className}` : baseClass}
+    >
+      {children}
+      <div className="pointer-events-none absolute right-3 top-3 flex flex-col items-end gap-1 text-[10px]">
+        {stats && (
+          <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
+            {stats.nodes} 节点 · {stats.edges} 边
+            {stats.suffix ? ` · ${stats.suffix}` : ""}
+          </span>
+        )}
+        {badges}
+        <button
+          type="button"
+          onClick={toggleFullscreen}
+          aria-label={isFs ? "退出全屏" : "进入全屏"}
+          title={isFs ? "退出全屏" : "进入全屏"}
+          className="pointer-events-auto inline-flex h-7 w-7 items-center justify-center rounded bg-zinc-900/70 text-white hover:bg-zinc-900/90 focus:outline-none focus:ring-2 focus:ring-amber-400/60"
+        >
+          {isFs ? (
+            <Minimize2 className="h-3.5 w-3.5" />
+          ) : (
+            <Maximize2 className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/SigmaGraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/SigmaGraphCanvas.tsx
@@ -18,6 +18,7 @@ import { useTheme } from "next-themes";
 import { fetchGraphSubgraph } from "@/features/knowledge";
 
 import { entityColor, communityColor } from "./constants";
+import { GraphCanvasFrame } from "./GraphCanvasFrame";
 import type { GraphCanvasNode, GraphCanvasEdge, GraphCanvasProps } from "./types";
 
 function nodeSize(importance?: number | null): number {
@@ -273,23 +274,24 @@ export function SigmaGraphCanvas({
   const truncated = nodes.length >= truncateThreshold;
 
   return (
-    <div className="relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+    <GraphCanvasFrame
+      stats={{ nodes: nodes.length, edges: edges.length, suffix: "Sigma WebGL" }}
+      badges={
+        <>
+          {truncated && (
+            <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
+              已按 importance 截断（双击节点展开邻居）
+            </span>
+          )}
+          {expanding && (
+            <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
+              加载子图…
+            </span>
+          )}
+        </>
+      }
+    >
       <div ref={containerRef} className="h-full w-full" />
-      <div className="pointer-events-none absolute right-3 top-3 flex flex-col items-end gap-1 text-[10px]">
-        <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
-          {nodes.length} 节点 · {edges.length} 边 · WebGL
-        </span>
-        {truncated && (
-          <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
-            已按 importance 截断（双击节点展开邻居）
-          </span>
-        )}
-        {expanding && (
-          <span className="rounded bg-emerald-500/90 px-2 py-1 text-white">
-            加载子图…
-          </span>
-        )}
-      </div>
-    </div>
+    </GraphCanvasFrame>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { KgBuildProgressPill } from "@/components/ui/KgBuildProgressPill";
@@ -15,6 +16,7 @@ import {
   fetchCorpusGraph,
 } from "@/features/knowledge";
 
+import { BuildButton } from "./_components/BuildButton";
 import { BuildHistoryList, BuildPanel } from "./_components/BuildPanel";
 import { CorpusSelector } from "./_components/CorpusSelector";
 import { EntityDetailPanel } from "./_components/EntityDetailPanel";
@@ -22,12 +24,15 @@ import { EntityListPanel } from "./_components/EntityListPanel";
 import { EvidenceChainPanel } from "./_components/EvidenceChainPanel";
 import { GlobalSearchPanel } from "./_components/GlobalSearchPanel";
 import { GraphCanvas } from "./_components/GraphCanvas";
+import { GraphCanvasFrame } from "./_components/GraphCanvasFrame";
 import { GraphStatsPanel } from "./_components/GraphStatsPanel";
 import { NeighborExplorer } from "./_components/NeighborExplorer";
 import { PathExplorer } from "./_components/PathExplorer";
 import { SearchBar } from "./_components/SearchBar";
 import { TimeTravelSlider } from "./_components/TimeTravelSlider";
 import { entityColor, communityColor } from "./_components/constants";
+
+const SIDEBAR_STATE_KEY = "kg.sidebarOpen";
 
 const SigmaGraphCanvas = dynamic(
   () =>
@@ -105,6 +110,17 @@ export default function KnowledgeGraphPage() {
   const [asOf, setAsOf] = useState<string | null>(null);
   // G2: 渲染引擎切换 — Cytoscape / d3-force / Sigma.js WebGL / Force Graph 2D / 3D WebGL
   const [renderer, setRenderer] = useState<"cytoscape" | "d3" | "sigma" | "force-graph" | "3d">("cytoscape");
+  // 右侧抽屉收起状态；localStorage 持久化，SSR 安全（初值 true，挂载后读取覆盖）。
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(true);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const v = window.localStorage.getItem(SIDEBAR_STATE_KEY);
+    if (v !== null) setSidebarOpen(v === "1");
+  }, []);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SIDEBAR_STATE_KEY, sidebarOpen ? "1" : "0");
+  }, [sidebarOpen]);
   const svgRef = useRef<SVGSVGElement | null>(null);
   const simulationRef = useRef<
     import("d3-force").Simulation<GraphNodePos, undefined> | null
@@ -416,15 +432,6 @@ export default function KnowledgeGraphPage() {
   const selectedNode =
     nodes.find((n) => n.id === selectedNodeId) || null;
 
-  const entityStats = useMemo(() => {
-    const byType: Record<string, number> = {};
-    nodes.forEach((n) => {
-      const t = n.type || "other";
-      byType[t] = (byType[t] || 0) + 1;
-    });
-    return { total: nodes.length, edges: edges.length, byType };
-  }, [nodes, edges]);
-
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
       <KnowledgeNav
@@ -432,14 +439,48 @@ export default function KnowledgeGraphPage() {
         description="实体关系视图与构建历史"
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-h-0 flex-1 gap-6 px-6 pt-4">
+        <div className="flex min-h-0 flex-1 gap-2 px-6 pt-4 pb-4">
           {/* Main content area */}
           <div className="min-h-0 min-w-0 flex-[2.2] flex flex-col overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col gap-4 pr-2">
-              {/* Toolbar */}
-              <div className="flex items-center justify-between">
+              {/* Toolbar — 三段式：左 CorpusSelector / 中 SearchBar / 右 viewTab+渲染器+构建按钮+Pill */}
+              <div className="flex items-center gap-3">
+                {/* 左 */}
                 <CorpusSelector value={corpusId} onChange={setCorpusId} />
-                <div className="flex items-center gap-3">
+
+                {/* 中（仅图谱视图 + 已选语料库时显示）*/}
+                <div className="flex-1 min-w-0 flex justify-center">
+                  {viewTab === "graph" && corpusId && (
+                    <div className="relative w-full max-w-[420px]">
+                      <SearchBar
+                        corpusId={corpusId}
+                        onResults={setSearchResults}
+                        onClear={() => setSearchResults(null)}
+                      />
+                      {searchResults && searchResults.length > 0 && (
+                        <div className="absolute left-0 right-0 top-full mt-1 z-20 max-h-60 overflow-y-auto space-y-1 rounded-lg border border-zinc-200 bg-white p-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
+                          {searchResults.map((item, idx) => (
+                            <div
+                              key={idx}
+                              onClick={() => setSelectedNodeId(item.entity.id)}
+                              className="flex items-center justify-between rounded border border-zinc-100 px-2 py-1 cursor-pointer hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-800/50"
+                            >
+                              <span className="text-xs text-zinc-700 dark:text-zinc-300">
+                                {item.entity.label || item.entity.id.slice(0, 8)}
+                              </span>
+                              <span className="text-[10px] text-zinc-400">
+                                {item.combined_score.toFixed(3)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {/* 右 */}
+                <div className="flex items-center gap-3 flex-shrink-0">
                   <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700">
                     <button
                       onClick={() => setViewTab("graph")}
@@ -521,6 +562,14 @@ export default function KnowledgeGraphPage() {
                       </button>
                     </div>
                   )}
+                  {/* 构建图谱（紧凑型）— 从右侧栏迁入工具栏；保留与 viewTab 无关地展示，
+                     未选语料库时按钮自禁用并 title 提示。 */}
+                  <BuildButton
+                    building={building}
+                    corpusId={corpusId}
+                    lastBuildError={buildError}
+                    onBuild={handleBuild}
+                  />
                   {/*
                    * 复用 KgBuildProgressPill 通过 SSE（/build-runs/latest/progress）
                    * 实时展示构建阶段（phase）+ 进度百分比 + 实体/关系实时计数。
@@ -543,35 +592,6 @@ export default function KnowledgeGraphPage() {
                   )}
                 </div>
               </div>
-
-              {/* Content Area */}
-              {viewTab === "graph" && corpusId && (
-              <div className="rounded-2xl border border-zinc-200 bg-white p-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <SearchBar
-                  corpusId={corpusId}
-                  onResults={setSearchResults}
-                  onClear={() => setSearchResults(null)}
-                />
-                {searchResults && searchResults.length > 0 && (
-                  <div className="mt-2 max-h-40 overflow-y-auto space-y-1">
-                    {searchResults.map((item, idx) => (
-                      <div
-                        key={idx}
-                        onClick={() => setSelectedNodeId(item.entity.id)}
-                        className="flex items-center justify-between rounded border border-zinc-100 dark:border-zinc-800 px-2 py-1 cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
-                      >
-                        <span className="text-xs text-zinc-700 dark:text-zinc-300">
-                          {item.entity.label || item.entity.id.slice(0, 8)}
-                        </span>
-                        <span className="text-[10px] text-zinc-400">
-                          {item.combined_score.toFixed(3)}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-              )}
               {viewTab === "graph" && renderer === "3d" && corpusId && nodes.length > 0 ? (
                 <GraphCanvas3D
                   corpusId={corpusId}
@@ -644,134 +664,123 @@ export default function KnowledgeGraphPage() {
                       ? `加载失败：${error}`
                       : "图谱为空，请先构建"}
                 </div>
-              ) : viewTab === "graph" ? (
-              <div className="min-h-0 flex-1 flex flex-col rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                    Graph Canvas
-                  </h2>
-                  {entityStats.total > 0 && (
-                    <div className="flex gap-2 text-[10px] text-zinc-500 dark:text-zinc-400">
-                      <span>{entityStats.total} 实体</span>
-                      <span>{entityStats.edges} 关系</span>
-                    </div>
-                  )}
-                </div>
-                <div className="mt-3 flex flex-1 min-h-0 items-center justify-center rounded-xl border border-dashed border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800">
-                  {!corpusId ? (
-                    <div className="text-center">
-                      <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                        请选择语料库
-                      </p>
-                    </div>
-                  ) : error ? (
-                    <p className="text-xs text-red-600 dark:text-red-400">
-                      加载失败：{error}
-                    </p>
-                  ) : renderer === "d3" ? (
-                    <svg
-                      ref={svgRef}
-                      width="100%"
-                      height="100%"
-                      className="rounded-xl bg-white/60 dark:bg-zinc-800/60"
-                    >
-                      <g className="graph-layer">
-                        {!layout.length ? null : <>
-                        {edges.map((edge, index) => {
-                          const source = layout.find(
-                            (node) => node.id === edge.source,
-                          );
-                          const target = layout.find(
-                            (node) => node.id === edge.target,
-                          );
-                          if (!source || !target) return null;
-                          return (
-                            <g key={`${edge.source}-${edge.target}-${index}`}>
-                              <line
-                                x1={source.x}
-                                y1={source.y}
-                                x2={target.x}
-                                y2={target.y}
-                                stroke="#d4d4d8"
-                                strokeWidth={1}
-                                strokeOpacity={0.6}
-                              />
-                              {edge.label && (
-                                <text
-                                  x={(source.x + target.x) / 2}
-                                  y={(source.y + target.y) / 2}
-                                  fontSize={8}
-                                  fill="#a1a1aa"
-                                  textAnchor="middle"
-                                >
-                                  {edge.label}
-                                </text>
-                              )}
-                            </g>
-                          );
-                        })}
-                        {layout.map((node) => (
-                          <g
-                            key={node.id}
-                            onClick={() => setSelectedNodeId(node.id)}
-                            className="cursor-pointer"
-                          >
-                            <circle
-                              cx={node.x}
-                              cy={node.y}
-                              r={
-                                selectedNodeId === node.id
-                                  ? Math.max(
-                                      nodeRadius(node.importance) + 4,
-                                      12,
-                                    )
-                                  : nodeRadius(node.importance)
-                              }
-                              fill={
-                                node.community_id != null
-                                  ? communityColor(node.community_id)
-                                  : entityColor(node.type)
-                              }
-                              stroke={
-                                selectedNodeId === node.id
-                                  ? "#18181b"
-                                  : "none"
-                              }
-                              strokeWidth={selectedNodeId === node.id ? 2 : 0}
-                              fillOpacity={
-                                selectedNodeId === node.id ? 1 : 0.85
-                              }
-                            />
-                            <text
-                              x={node.x}
-                              y={node.y + 20}
-                              fontSize={9}
-                              textAnchor="middle"
-                              fill="#52525b"
-                              className="dark:fill-zinc-400"
+              ) : viewTab === "graph" && renderer === "d3" && corpusId && nodes.length > 0 ? (
+                <GraphCanvasFrame
+                  stats={{ nodes: nodes.length, edges: edges.length, suffix: "d3 SVG" }}
+                >
+                  <svg
+                    ref={svgRef}
+                    width="100%"
+                    height="100%"
+                    className="h-full w-full rounded-2xl"
+                  >
+                    <g className="graph-layer">
+                      {!layout.length ? null : (
+                        <>
+                          {edges.map((edge, index) => {
+                            const source = layout.find(
+                              (node) => node.id === edge.source,
+                            );
+                            const target = layout.find(
+                              (node) => node.id === edge.target,
+                            );
+                            if (!source || !target) return null;
+                            return (
+                              <g key={`${edge.source}-${edge.target}-${index}`}>
+                                <line
+                                  x1={source.x}
+                                  y1={source.y}
+                                  x2={target.x}
+                                  y2={target.y}
+                                  stroke="#d4d4d8"
+                                  strokeWidth={1}
+                                  strokeOpacity={0.6}
+                                />
+                                {edge.label && (
+                                  <text
+                                    x={(source.x + target.x) / 2}
+                                    y={(source.y + target.y) / 2}
+                                    fontSize={8}
+                                    fill="#a1a1aa"
+                                    textAnchor="middle"
+                                  >
+                                    {edge.label}
+                                  </text>
+                                )}
+                              </g>
+                            );
+                          })}
+                          {layout.map((node) => (
+                            <g
+                              key={node.id}
+                              onClick={() => setSelectedNodeId(node.id)}
+                              className="cursor-pointer"
                             >
-                              {node.label || node.id.slice(0, 8)}
-                            </text>
-                          </g>
-                        ))}
-                        </>}
-                      </g>
-                    </svg>
-                  ) : (
-                    <div className="text-center space-y-3">
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        暂无图谱数据
-                      </p>
-                      <BuildPanel
-                        building={building}
-                        corpusId={corpusId}
-                        lastBuildError={buildError}
-                        onBuild={handleBuild}
-                      />
-                    </div>
+                              <circle
+                                cx={node.x}
+                                cy={node.y}
+                                r={
+                                  selectedNodeId === node.id
+                                    ? Math.max(
+                                        nodeRadius(node.importance) + 4,
+                                        12,
+                                      )
+                                    : nodeRadius(node.importance)
+                                }
+                                fill={
+                                  node.community_id != null
+                                    ? communityColor(node.community_id)
+                                    : entityColor(node.type)
+                                }
+                                stroke={
+                                  selectedNodeId === node.id
+                                    ? "#18181b"
+                                    : "none"
+                                }
+                                strokeWidth={selectedNodeId === node.id ? 2 : 0}
+                                fillOpacity={
+                                  selectedNodeId === node.id ? 1 : 0.85
+                                }
+                              />
+                              <text
+                                x={node.x}
+                                y={node.y + 20}
+                                fontSize={9}
+                                textAnchor="middle"
+                                fill="#52525b"
+                                className="dark:fill-zinc-400"
+                              >
+                                {node.label || node.id.slice(0, 8)}
+                              </text>
+                            </g>
+                          ))}
+                        </>
+                      )}
+                    </g>
+                  </svg>
+                </GraphCanvasFrame>
+              ) : viewTab === "graph" && renderer === "d3" ? (
+                <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
+                  <p>
+                    {!corpusId
+                      ? "请选择语料库"
+                      : error
+                        ? `加载失败：${error}`
+                        : "图谱为空，请先构建"}
+                  </p>
+                  {corpusId && !error && nodes.length === 0 && (
+                    <BuildPanel
+                      building={building}
+                      corpusId={corpusId}
+                      lastBuildError={buildError}
+                      onBuild={handleBuild}
+                    />
                   )}
                 </div>
-              </div>
+              ) : viewTab === "graph" ? (
+                <div className="flex flex-1 min-h-0 items-center justify-center rounded-2xl border border-dashed border-zinc-200 bg-zinc-50 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
+                  请选择渲染器
+                </div>
               ) : (
               /* Entity List View */
               <div className="min-h-0 flex-1 overflow-y-auto rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
@@ -794,26 +803,33 @@ export default function KnowledgeGraphPage() {
             </div>
           </div>
 
-          {/* Sidebar */}
-          <aside className="min-h-0 min-w-0 w-72 flex-shrink-0 overflow-y-auto">
-            <div className="space-y-4 pb-4 pr-2">
-              {/* Build action (when graph exists) */}
-              {corpusId && (
-                <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                  <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                    构建
-                  </h3>
-                  <div className="mt-2">
-                    <BuildPanel
-                      building={building}
-                      corpusId={corpusId}
-                      lastBuildError={buildError}
-                      onBuild={handleBuild}
-                    />
-                  </div>
-                </div>
-              )}
+          {/* 抽屉 Toggle 按钮 — 始终位于 main 与 aside 之间，方便收起/展开 */}
+          <button
+            type="button"
+            onClick={() => setSidebarOpen((v) => !v)}
+            aria-label={sidebarOpen ? "收起侧边栏" : "展开侧边栏"}
+            title={sidebarOpen ? "收起侧边栏" : "展开侧边栏"}
+            className="self-start mt-2 flex h-12 w-5 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-500 shadow-sm hover:text-zinc-900 dark:bg-zinc-900 dark:border-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            {sidebarOpen ? (
+              <ChevronRight className="h-3 w-3" />
+            ) : (
+              <ChevronLeft className="h-3 w-3" />
+            )}
+          </button>
 
+          {/* Sidebar — 抽屉式收起：w-72 ↔ w-0 平滑过渡；收起时内容透明并禁用交互 */}
+          <aside
+            className={`relative min-h-0 flex-shrink-0 overflow-y-auto overflow-x-hidden transition-[width] duration-200 ease-in-out ${
+              sidebarOpen ? "w-72" : "w-0"
+            }`}
+            aria-hidden={!sidebarOpen}
+          >
+            <div
+              className={`w-72 space-y-4 pb-4 pr-2 transition-opacity duration-150 ${
+                sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+              }`}
+            >
               {/* Entity Detail */}
               <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
                 <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -111,14 +111,25 @@ export default function KnowledgeGraphPage() {
   // G2: 渲染引擎切换 — Cytoscape / d3-force / Sigma.js WebGL / Force Graph 2D / 3D WebGL
   const [renderer, setRenderer] = useState<"cytoscape" | "d3" | "sigma" | "force-graph" | "3d">("cytoscape");
   // 右侧抽屉收起状态；localStorage 持久化，SSR 安全（初值 true，挂载后读取覆盖）。
+  // 设计要点（修复挂载期闪烁 + storage 噪声）：
+  //   1) 用 hasHydratedRef 区分「初始挂载 read」与「用户交互 write」——挂载阶段
+  //      第二个 effect 不能把默认值 "1" 回写到 localStorage，否则会瞬间覆盖用户上次
+  //      持久化的 "0"，并向其他 tab 的 storage 监听者推送一段虚假的 open→close 序列。
+  //   2) 暴露 sidebarHydrated 给 JSX，用于条件性挂载 `transition-[width]` —— 让 read
+  //      effect 写入持久值之前不要播放动画，避免首屏可见的 200ms 开→收过场。
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(true);
+  const [sidebarHydrated, setSidebarHydrated] = useState(false);
+  const hasHydratedRef = useRef(false);
   useEffect(() => {
     if (typeof window === "undefined") return;
     const v = window.localStorage.getItem(SIDEBAR_STATE_KEY);
     if (v !== null) setSidebarOpen(v === "1");
+    hasHydratedRef.current = true;
+    setSidebarHydrated(true);
   }, []);
   useEffect(() => {
     if (typeof window === "undefined") return;
+    if (!hasHydratedRef.current) return; // 跳过挂载首跑，由 read effect 真实生效后再持久化用户交互
     window.localStorage.setItem(SIDEBAR_STATE_KEY, sidebarOpen ? "1" : "0");
   }, [sidebarOpen]);
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -818,17 +829,19 @@ export default function KnowledgeGraphPage() {
             )}
           </button>
 
-          {/* Sidebar — 抽屉式收起：w-72 ↔ w-0 平滑过渡；收起时内容透明并禁用交互 */}
+          {/* Sidebar — 抽屉式收起：w-72 ↔ w-0 平滑过渡；收起时内容透明并禁用交互。
+              `transition-[width]` 在 hydration 完成后才挂上，避免首屏从默认 `w-72`
+              同步切到 localStorage 持久值 `w-0` 时播放可见的 200ms 关闭动画。 */}
           <aside
-            className={`relative min-h-0 flex-shrink-0 overflow-y-auto overflow-x-hidden transition-[width] duration-200 ease-in-out ${
-              sidebarOpen ? "w-72" : "w-0"
-            }`}
+            className={`relative min-h-0 flex-shrink-0 overflow-y-auto overflow-x-hidden ${
+              sidebarHydrated ? "transition-[width] duration-200 ease-in-out" : ""
+            } ${sidebarOpen ? "w-72" : "w-0"}`}
             aria-hidden={!sidebarOpen}
           >
             <div
-              className={`w-72 space-y-4 pb-4 pr-2 transition-opacity duration-150 ${
-                sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none"
-              }`}
+              className={`w-72 space-y-4 pb-4 pr-2 ${
+                sidebarHydrated ? "transition-opacity duration-150" : ""
+              } ${sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none"}`}
             >
               {/* Entity Detail */}
               <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -46,6 +46,7 @@
     "rxjs": "7.8.1",
     "sigma": "^3.0.3",
     "sonner": "^2.0.7",
+    "three-spritetext": "^1.10.0",
     "zod": "3.24.4"
   },
   "devDependencies": {

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      three-spritetext:
+        specifier: ^1.10.0
+        version: 1.10.0(three@0.184.0)
       zod:
         specifier: 3.24.4
         version: 3.24.4
@@ -4135,6 +4138,12 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       three: '>=0.179'
+
+  three-spritetext@1.10.0:
+    resolution: {integrity: sha512-t08iP1FCU1lQh8T5MmCpdijKgas8GDHJE0LqMGBuVu3xqMMpFnEZhTlih7FlxLPQizHIGoumUSpfOlY1GO/Tgg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      three: '>=0.86.0'
 
   three@0.184.0:
     resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
@@ -9048,6 +9057,10 @@ snapshots:
       float-tooltip: 1.7.5
       kapsule: 1.16.3
       polished: 4.3.1
+      three: 0.184.0
+
+  three-spritetext@1.10.0(three@0.184.0):
+    dependencies:
       three: 0.184.0
 
   three@0.184.0: {}


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：Knowledge Graph 页面存在七项 UX/视觉缺陷——3D 渲染器节点缺持久文字标签、画布底边紧贴浏览器底沿、五大渲染器外框冗余且不一致且无全屏入口、「搜索实体」独占行浪费纵向空间、右栏「构建」卡片为单按钮过度结构化、「构建历史」无分页易淹没其他模块、右栏不可收起浪费横向空间。
- 关联上下文/Issue/文档：用户附图与本会话中确认的七项优化诉求（参考工作计划 `.claude/plans/system-instruction-you-are-working-bubbly-quill.md`）。

# 核心变更

- **新增 `GraphCanvasFrame`**（[`_components/GraphCanvasFrame.tsx`](apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx)）：五大渲染器共享外框 + Stats 右上角浮层 + 全屏按钮（Fullscreen API + Safari `webkitRequestFullscreen` 兜底；`data-fullscreen` 修正全屏黑底；lucide-react `Maximize2/Minimize2` 切换）。
- **新增 `BuildButton`**（[`_components/BuildButton.tsx`](apps/negentropy-ui/app/knowledge/graph/_components/BuildButton.tsx)）：紧凑工具栏构建按钮，未选语料库自禁用并 `title` 提示，`lastBuildError` 时右上叠加红点；与既有 `BuildPanel` 正交，后者继续服务 d3 空态分支。
- **3D 节点持久文字标签**：引入 `three-spritetext@^1.10.0`，`nodeThreeObject` 返回 `SpriteText`、`nodeThreeObjectExtend=true` 保留球体高亮，深浅模式背景/色对比度均充足。
- **工具栏三段式重排**：左 `CorpusSelector` / 中 `SearchBar`（结果浮层 `absolute z-20` 贴近输入框）/ 右 `viewTab` + 渲染器选择器 + `BuildButton` + `KgBuildProgressPill`；删除独占行的搜索栏卡片。
- **右栏抽屉式收起**：`w-72 ↔ w-0` 平滑过渡、chevron toggle 嵌入 main/aside 间隙、`localStorage` 键 `kg.sidebarOpen` 持久化、SSR 守卫；移除「构建」卡片。
- **构建历史分页**：`BuildHistoryList` 默认每页 5 条，`runs.length` 变化时采用 React 19「render 期间根据 props 调整 state」范式（替代 `useEffect+setState`，规避 `react-hooks/set-state-in-effect`）。
- **d3 SVG 接入 `GraphCanvasFrame`**：删除原「Graph Canvas 标题 + 虚线双层卡片」结构，与其他四渲染器视觉契约一致；空态分支统一为 `rounded-2xl border-dashed`。
- **底边间隙修正**：内容 flex 行追加 `pb-4`，画布与浏览器底沿留 16px 留白。

# 风险与回滚

- **主要风险**
  - d3 SVG 改造选择「就地包裹」而非组件抽离（`svgRef`/`simulationRef`/`layout` 与 page.tsx 强耦合），未触碰 d3 simulation 逻辑，理论上行为零退化；但需关注 viewport resize 时的布局节奏。
  - `three-spritetext` 为新依赖（3KB，react-force-graph 同作者维护，复用已传递引入的 `three`）；500 节点上限下显存占用约 1-2 MB，可接受。
  - 浏览器原生 Fullscreen API 在旧 Safari 需 `webkitRequestFullscreen` 兜底，已覆盖；全屏元素默认黑底由 `data-[fullscreen=true]:bg-white dark:bg-zinc-900` 显式声明。
  - `localStorage` SSR 安全已用 `typeof window !== "undefined"` 守卫，避免 Next.js hydration mismatch。
- **回滚方式**：单 commit `fe650780` 体量集中，`git revert fe650780` 即可整体回滚；新增的 `three-spritetext` 依赖未被其他模块引用，回滚后自动失活。

# 验证证据

- **单元测试**：现有 vitest 套件不涉及本次改造范围；`BuildHistoryList`/`GraphCanvas3D` 此前无单元用例，未新增。
- **集成测试**：`pnpm typecheck` ✅ + `pnpm lint` ✅ 全过；ESLint react-hooks 规则触发后已切换至 React 19 推荐范式。
- **E2E/Workflow**：Playwright E2E 未触达 Knowledge Graph 路由；本次以浏览器实机验证为主。
- **覆盖率/关键截图**：浏览器 `mcp__chrome_devtools__*` 端到端验证 10 项（见 `.context/kg-*.png`）——
  1. 底边距浏览器底沿 16px（脚本探测 `viewportHeight - rect.bottom === 16`）
  2. 五大渲染器外框圆角/边框/深浅模式背景一致，stats 后缀分别显示 `Cytoscape / d3 SVG / 3D WebGL / Sigma WebGL / Force Canvas`
  3. 全屏按钮进入/退出正常，全屏期间背景为深色不穿黑
  4. 3D SpriteText 持久标签可见（如 `Canyon Robbins / Marina Long`）
  5. 搜索栏位于工具栏中段，结果以 `absolute z-20` 浮层渲染
  6. 构建图谱按钮位于渲染器选择器右侧，KgBuildProgressPill 仍正常
  7. 构建历史 17 条 → 4 页（每页 5 条），「上一页/下一页」切换正常
  8. 抽屉收起后 main 扩展占满，localStorage `kg.sidebarOpen=0/1` 持久化
  9. 全屏期间切换渲染器、点击搜索不致崩溃，退出全屏 ResizeObserver 自动重适应
  10. 节点点击高亮、双击/右键扩展子图、时间穿梭等右栏功能行为不变

# 影响范围

- **前端**：[`apps/negentropy-ui/app/knowledge/graph/`](apps/negentropy-ui/app/knowledge/graph/) 下 `page.tsx` + 5 个渲染器组件 + `BuildPanel.tsx`，新增 `GraphCanvasFrame.tsx` 与 `BuildButton.tsx`；[`package.json`](apps/negentropy-ui/package.json) 新增 `three-spritetext@^1.10.0`。
- **后端**：无变更。
- **GitHub Actions / 文档**：无 CI 变更；后续可在 `docs/issue.md` 补充本次 UI 重构摘要（按 AGENTS.md「Issue」准则）。

# Next Best Action

- Reviewer 重点审视：① `GraphCanvasFrame` 全屏切换在 Safari 的兜底分支；② 构建历史分页是否影响实时构建中状态的可见性（默认在第 1 页，应能立即看到最新构建）；③ 工具栏在更窄屏（< 1280px）下三段式是否仍可读，必要时引入 `flex-wrap`。
- 合并后建议同步更新 `docs/issue.md`，登记本次 UI 重构条目以便跨上下文检索。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)