### PR TITLE
fix(knowledge-graph): 修复 5 种图谱引擎切换与右栏缩放的布局溢出

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
@@ -113,7 +113,7 @@ export function ForceGraphCanvas({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const graphRef = useRef<unknown>(null);
   const [expanding, setExpanding] = useState(false);
-  const [dimensions, setDimensions] = useState({ width: 700, height: 500 });
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [ForceGraph2D, setForceGraph2D] = useState<React.ComponentType<any> | null>(null);
   const { resolvedTheme } = useTheme();
@@ -257,7 +257,7 @@ export function ForceGraphCanvas({
       }
     >
       <div ref={containerRef} className="h-full w-full">
-        {ForceGraph2D && (
+        {ForceGraph2D && dimensions.width > 0 && dimensions.height > 0 && (
           <ForceGraph2D
             ref={graphRef}
             graphData={graphData}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
@@ -68,13 +68,32 @@ export function GraphCanvas3D({
   truncateThreshold = 500,
 }: GraphCanvas3DProps) {
   const fgRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [expanding, setExpanding] = useState(false);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const propsRef = useRef({ corpusId, asOf, onNodeClick, onSubgraphMerge });
   const { resolvedTheme } = useTheme();
 
   useEffect(() => {
     propsRef.current = { corpusId, asOf, onNodeClick, onSubgraphMerge };
   }, [corpusId, asOf, onNodeClick, onSubgraphMerge]);
+
+  // react-force-graph-3d 默认使用 window.innerWidth/Height，导致 Flex 布局溢出。
+  // 通过 ResizeObserver 追踪容器尺寸并传递显式 width/height 约束 Canvas。
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    const update = () => {
+      setDimensions({
+        width: el.clientWidth,
+        height: Math.max(400, el.clientHeight),
+      });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const validIds = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes]);
 
@@ -174,7 +193,6 @@ export function GraphCanvas3D({
 
   return (
     <GraphCanvasFrame
-      className="overflow-hidden"
       stats={{ nodes: nodes.length, edges: edges.length, suffix: "3D WebGL" }}
       badges={
         <>
@@ -191,31 +209,37 @@ export function GraphCanvas3D({
         </>
       }
     >
-      <ForceGraph3D
-        ref={fgRef}
-        graphData={graphData}
-        nodeLabel="label"
-        nodeColor={getNodeColor}
-        nodeVal={getNodeVal}
-        nodeOpacity={0.95}
-        nodeThreeObject={getNodeThreeObject}
-        nodeThreeObjectExtend={true}
-        linkColor={() => "#a1a1aa"}
-        linkOpacity={0.4}
-        linkWidth={0.8}
-        linkDirectionalArrowLength={3.5}
-        linkDirectionalArrowRelPos={1}
-        backgroundColor={bgColor}
-        onNodeClick={handleNodeClick}
-        onNodeRightClick={handleNodeRightClick}
-        onBackgroundClick={() => propsRef.current.onNodeClick("")}
-        cooldownTicks={150}
-        warmupTicks={20}
-        d3AlphaDecay={0.02}
-        d3VelocityDecay={0.4}
-        enableNodeDrag={true}
-        showNavInfo={false}
-      />
+      <div ref={containerRef} style={{ position: 'absolute', inset: 0 }}>
+        {dimensions.width > 0 && dimensions.height > 0 && (
+          <ForceGraph3D
+            ref={fgRef}
+            width={dimensions.width}
+            height={dimensions.height}
+            graphData={graphData}
+            nodeLabel="label"
+            nodeColor={getNodeColor}
+            nodeVal={getNodeVal}
+            nodeOpacity={0.95}
+            nodeThreeObject={getNodeThreeObject}
+            nodeThreeObjectExtend={true}
+            linkColor={() => "#a1a1aa"}
+            linkOpacity={0.4}
+            linkWidth={0.8}
+            linkDirectionalArrowLength={3.5}
+            linkDirectionalArrowRelPos={1}
+            backgroundColor={bgColor}
+            onNodeClick={handleNodeClick}
+            onNodeRightClick={handleNodeRightClick}
+            onBackgroundClick={() => propsRef.current.onNodeClick("")}
+            cooldownTicks={150}
+            warmupTicks={20}
+            d3AlphaDecay={0.02}
+            d3VelocityDecay={0.4}
+            enableNodeDrag={true}
+            showNavInfo={false}
+          />
+        )}
+      </div>
     </GraphCanvasFrame>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvasFrame.tsx
@@ -32,7 +32,7 @@ export interface GraphCanvasFrameProps {
   badges?: ReactNode;
   /** 渲染器 DOM（容器 div / ForceGraph3D / etc.） */
   children: ReactNode;
-  /** 扩展类名（例如 GraphCanvas3D 需要 overflow-hidden） */
+  /** 扩展类名（追加到基础样式） */
   className?: string;
 }
 
@@ -97,7 +97,7 @@ export function GraphCanvasFrame({
   }, []);
 
   const baseClass =
-    "relative min-h-0 flex-1 w-full rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 data-[fullscreen=true]:bg-white data-[fullscreen=true]:dark:bg-zinc-900";
+    "relative min-h-0 flex-1 w-full overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900 data-[fullscreen=true]:bg-white data-[fullscreen=true]:dark:bg-zinc-900";
 
   return (
     <div


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：Knowledge Graph 页面（`/knowledge/graph`）切换 5 种渲染引擎（Cytoscape / d3-force / 3D WebGL / Sigma / Force Graph）并收起/展开右侧抽屉时，**3D 引擎**的画布会撑爆 Flex 容器，把右栏推到浏览器视口之外；同时给其他引擎留下了潜在的初始尺寸闪烁隐患。
- 关联上下文/Issue/文档：`apps/negentropy-ui/app/knowledge/graph/page.tsx` 五引擎布局；`GraphCanvasFrame.tsx` 共享外框单一事实源。

# 核心变更

- **`GraphCanvas3D.tsx`（关键修复）**：复用 `ForceGraphCanvas` 已验证的 `containerRef + ResizeObserver` 模式，新增 `dimensions` state 并向 `ForceGraph3D` 显式传入 `width`/`height`；容器改为绝对定位（`position:absolute; inset:0`）打破「Canvas 反向撑大父容器」的循环；`dimensions=0` 时不渲染避免初始化闪烁。
- **`GraphCanvasFrame.tsx`（安全网）**：base class 追加 `overflow-hidden`，所有 5 个引擎共享溢出兜底；同步精简 `className` prop 的 JSDoc。
- **`ForceGraphCanvas.tsx`（一致性 + 防闪烁）**：`dimensions` 初值从硬编码 `700×500` 改为 `0×0` 并添加渲染守卫，与 3D 引擎保持同一范式。

# 风险与回滚

- 主要风险：`ForceGraph3D` 在 `width=0` 或 `height=0` 时被跳过渲染，依赖 ResizeObserver 在 mount 后同步回填真实尺寸；如果未来更换为不支持 ResizeObserver 的容器需重新校准。
- 回滚方式：`git revert <commit>` 即可恢复原状；变更面仅 3 个组件文件，无 schema/数据迁移。

# 验证证据

- 单元测试：无（纯布局/DOM 测量变更）。
- 集成测试：无新增。
- E2E/Workflow：在 Conductor workspace 启动 `pnpm dev` (port 3193)，使用 Chrome DevTools 量化测量 5 引擎 × sidebar 展开/收起 的完整矩阵：
  - sidebar 展开：5 引擎 frame=1482px、canvas=1480px、aside.right=1838 < viewport=1862 ✓
  - sidebar 收起：5 引擎 frame=1770px、canvas=1768px、无溢出 ✓
  - 3D 引擎下 sidebar toggle 循环：1482 ↔ 1770 平滑切换，ResizeObserver 工作正常 ✓
- 覆盖率/关键截图：测量数据见 commit message。

# 影响范围

- 前端：`apps/negentropy-ui/app/knowledge/graph/_components/{GraphCanvas3D,GraphCanvasFrame,ForceGraphCanvas}.tsx`。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action

- 在 PR 合并到 `feature/1.x.x` 后，回归验证生产构建（`pnpm build && pnpm start`）下 3D 引擎在 standalone server 模式的 ResizeObserver 表现，确保无 SSR/CSR 差异。