### PR TITLE
fix(knowledge-graph): 修复 3D 引擎节点标签带边框 + 小节点标签嵌入球体两处视觉缺陷

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
@@ -52,6 +52,12 @@ function nodeRadius3D(importance?: number | null): number {
   return 2 + 6 * clamped;
 }
 
+// react-force-graph-3d 的 nodeVal 被解释为"体积量"：实际渲染球体半径 = cbrt(val) * nodeRelSize。
+// nodeRelSize 默认 4，本文件未通过 <ForceGraph3D> props 覆盖，保持默认。
+const NODE_REL_SIZE = 4;
+// 球面与标签底边的世界单位间隙，保证最小节点也能清晰浮于球体之上。
+const LABEL_GAP = 1.5;
+
 function nodeColorFn(node: GraphCanvasNode): string {
   if (node.community_id != null) return communityColor(node.community_id);
   return entityColor(node.type);
@@ -178,20 +184,23 @@ export function GraphCanvas3D({
     (node: { id: string | number; label?: string }) => {
       const text = node.label ?? String(node.id).slice(0, 8);
       const sprite = new SpriteText(text);
-      sprite.color = isDark ? "#e4e4e7" : "#27272a";
-      sprite.backgroundColor = isDark
-        ? "rgba(9,9,11,0.55)"
-        : "rgba(255,255,255,0.7)";
-      sprite.padding = 1;
+      // 纯文字风格：去边框 + 去背景，与 2D 引擎 ForceGraphCanvas 视觉对齐。
+      sprite.color = isDark ? "#f4f4f5" : "#18181b";
+      sprite.backgroundColor = "rgba(0,0,0,0)";
+      sprite.padding = 0;
       sprite.textHeight = 3;
-      sprite.borderWidth = 0.5;
-      sprite.borderRadius = 2;
+      sprite.borderWidth = 0;
+      // 保留 dd1a6c85 引入的深度修复：标签穿透其他球体始终可见。
       sprite.material.depthWrite = false;
       sprite.renderOrder = 999;
+
       const val = nodeMeta.get(String(node.id))?.val ?? 3;
       const effectiveVal =
         String(node.id) === selectedNodeId ? val * 1.5 : val;
-      sprite.position.set(0, effectiveVal + 3, 0);
+      // 球体实际半径 = cbrt(val) * nodeRelSize（val 是体积量，非半径）。
+      // sprite 以中心为锚点，故位置 = 半径 + 半个文字高 + 视觉间隙。
+      const radius = Math.cbrt(effectiveVal) * NODE_REL_SIZE;
+      sprite.position.set(0, radius + sprite.textHeight / 2 + LABEL_GAP, 0);
       return sprite;
     },
     [isDark, nodeMeta, selectedNodeId],

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1872,3 +1872,28 @@
   - `apps/negentropy/src/negentropy/knowledge/graph/` 全部 SQL 中的 `VALUES … AS v(col type)` 已扫荡（仅 PageRank、Communities 两处，全部修复）；未来新增类似 UPDATE-FROM-VALUES 路径需复核同型缺陷；
   - 其他 `nx.community.*` 高层 API 调用入口（如未来引入 `nx.community.label_propagation_communities`、`nx.community.greedy_modularity_communities` 等）需确认是否同样依赖 dispatch backend；
   - 任何 service 层"幂等跳过"（如 `merge_entities` / `dedupe_relations` / `upsert_*`）需复核是否区分返回值 / 计数器；调用方计数若依赖"未抛异常"语义，需同步重构。
+
+---
+
+## ISSUE-083 KG 3D 引擎节点标签带边框 + 小节点标签嵌入球体（2026-05-12）
+
+- **表因**：Knowledge Graph 3D 引擎下，节点标签呈现两处视觉缺陷：(a) 每个标签外围有可见矩形边框 + 背景盒，与 2D 引擎的纯文字风格不一致；(b) 低 importance（小球）节点的标签文字嵌入球体内部，被球面遮蔽。
+- **根因**（正交分解）：
+  1. **边框/背景源自显式配置**：[`GraphCanvas3D.tsx::getNodeThreeObject`](../apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx) 第 177-198 行配置 `sprite.borderWidth = 0.5`、`sprite.borderRadius = 2` 与不透明 `backgroundColor`，是上一次"标签被球体遮挡"修复（commit `dd1a6c85`）为强化视觉边界引入的副作用，与 2D 引擎纯文字范式相悖；
+  2. **位置公式错把 volume 当作 radius**：原 `sprite.position.set(0, effectiveVal + 3, 0)` 把 `val`（即 `nodeRadius3D(importance)` 返回值 ∈ [2, 8]）直接当作球体**半径**使用 — 但 `react-force-graph-3d` 将 `nodeVal` 视为**体积量**，实际渲染半径为 `Math.cbrt(val) * nodeRelSize`（`nodeRelSize` 默认 4）。当 `val=2` 时实际半径 ≈ 5.04 而 sprite 中心 y=5，导致 sprite 整体落入球体内部。
+- **处理方式**（最小干预单文件修复）：
+  1. **去边框去背景**：[`GraphCanvas3D.tsx`](../apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx) 内 `sprite.borderWidth = 0`、`sprite.backgroundColor = "rgba(0,0,0,0)"`、`sprite.padding = 0`；文字色提升对比度（dark `#f4f4f5` zinc-100 / light `#18181b` zinc-900），与 [`ForceGraphCanvas.tsx`](../apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx) 2D 引擎对比层级对齐；
+  2. **位置公式按实际半径计算**：模块作用域新增常量 `NODE_REL_SIZE = 4`（与 `<ForceGraph3D>` 默认值同步）、`LABEL_GAP = 1.5`；位置改为 `sprite.position.set(0, Math.cbrt(effectiveVal) * NODE_REL_SIZE + sprite.textHeight / 2 + LABEL_GAP, 0)`，即「球体真实半径 + 半个文字高 + 视觉间隙」；
+  3. **保留 dd1a6c85 引入的深度修复**：`material.depthWrite = false` + `renderOrder = 999` 不动，标签穿透其他球体始终可见。
+- **验证证据**：
+  - `pnpm --filter negentropy-ui typecheck` 通过；`pnpm --filter negentropy-ui lint --max-warnings=0` 通过；
+  - 浏览器 `evaluate_script` 复刻完整公式校验：对 `importance ∈ {0, 0.5, 1.0}` × `selected ∈ {false, true}` 共 6 + 1 默认值组合，标签底边距球面恒为 1.5 单位，所有情形下**无嵌入**。最小节点（val=2）实际半径 5.04，标签 y=8.04，底边 6.54；最大选中节点（val=12）半径 9.16，y=12.16，底边 10.66；
+  - 用户生产服务器运行 standalone build 且正在构建语料库 KG，为避免破坏会话不进行强制重启 — 最终像素级视觉确认在下次 dev/build 周期完成。
+- **后续防范**：
+  1. **三方库参数语义边界**：`react-force-graph-3d` 的 `nodeVal` 是**体积量**而非半径，类似 `d3.scaleSqrt / scaleCbrt` 量纲转换；任何后续依赖球体实际几何的渲染（如标签、晕圈、ray hit area）必须经 `Math.cbrt(val) * nodeRelSize` 换算，禁止把 `val` 字面理解为半径；
+  2. **跨引擎视觉一致性约束**：5 种图谱引擎（2D Force / 3D / Sigma / Cytoscape / Cosmograph）应共享同一套「标签风格」契约 — 默认纯文字、可读对比度、必要时启用深度排序。引入背景/边框需有明确理由且全引擎同步；
+  3. **修复回归隐患**：本次修复回退 dd1a6c85 引入的 `borderWidth/borderRadius/backgroundColor` 部分但保留其深度排序部分。后续若再次需要为 3D 标签加视觉强化（如选中态高亮），应优先考虑文字加粗/放大/颜色，而非回退背景盒。
+- **同类问题影响**：
+  - 其他依赖 `nodeVal` 派生几何的代码位（如 `ForceGraphCanvas.tsx` 中 `node.x! + size` 这类基于 `size` 直接做空间计算的逻辑）已正确使用 radius 量纲，无需改动；
+  - Sigma / Cytoscape 引擎使用自有 size 体系，未受影响；
+  - 若未来引入 4D / WebGPU 引擎实现，需复核其 size 参数语义并同步修正本类公式。


### PR DESCRIPTION
## 背景

Knowledge Graph 3D 引擎下，节点标签存在两处与用户截图直接对应的视觉缺陷（参见 [docs/issue.md ISSUE-083](../blob/ThreeFish-AI/kg-3d-node-label-style/docs/issue.md)）：

1. **节点标签外围有可见矩形边框 + 背景盒**——与 2D 引擎（`ForceGraphCanvas.tsx`）的纯文字风格不一致。
2. **低 importance（小球）节点的标签嵌入球体内部**——`react-force-graph-3d` 的 `nodeVal` 是「体积量」而非半径，实际渲染半径为 `Math.cbrt(val) * nodeRelSize`，原 `y = effectiveVal + 3` 公式错把体积当半径，最小节点 `val=2` 时 sprite 中心落入球体内部。

## 主要改动

`apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx`：

- **去边框 + 去背景**：`sprite.borderWidth = 0`、`sprite.backgroundColor = "rgba(0,0,0,0)"`、`sprite.padding = 0`；文字色由 zinc-200/800 升至 zinc-100/900 以补偿对比度。
- **正确的位置公式**：模块作用域新增 `NODE_REL_SIZE = 4`（与 `<ForceGraph3D>` 默认值同步）与 `LABEL_GAP = 1.5`，标签位置改为 `radius + sprite.textHeight / 2 + LABEL_GAP`，其中 `radius = Math.cbrt(effectiveVal) * NODE_REL_SIZE`。
- **保留 [`dd1a6c85`](../commit/dd1a6c85) 的深度修复**：`material.depthWrite = false` + `renderOrder = 999` 不动，避免回归「标签被球体遮挡」原问题。

`docs/issue.md`：追加 ISSUE-083，包含表因 / 根因 / 处理方式 / 后续防范 / 同类问题影响五段式留存。

## 验证

- `pnpm --filter negentropy-ui typecheck`：通过；
- `pnpm --filter negentropy-ui lint --max-warnings=0`：通过；
- **数值正交验证**（浏览器 `evaluate_script` 复刻完整公式）：

  | importance | val | 选中态 val | 实际半径 | 标签 y | 球面以上间隙 |
  |---|---|---|---|---|---|
  | 0 | 2 | 3 | 5.04 / 5.77 | 8.04 / 8.77 | 1.5 / 1.5 |
  | 0.5 | 5 | 7.5 | 6.84 / 7.83 | 9.84 / 10.83 | 1.5 / 1.5 |
  | 1.0 | 8 | 12 | 8.00 / 9.16 | 11.00 / 12.16 | 1.5 / 1.5 |

  所有情形下标签底边距球面恒为 `LABEL_GAP=1.5` 世界单位，无嵌入。

- 用户生产服务器运行 standalone build（PID 25104）且当前正在构建语料库 KG，为避免破坏会话与正在进行的构建任务未做强制重启，最终像素级视觉确认在下次 dev/build 周期。

## 风险与回退

- 单文件单函数变更（22 行），影响面局部；其他四个引擎（2D Force / Sigma / Cytoscape / Cosmograph）未触及；
- 风险点：移除背景后复杂场景中文字与重叠球体颜色冲突的可读性 — 已通过 `depthWrite=false` + `renderOrder=999` 让标签始终位于深度最前，并提升前景色对比度兜底；
- 回退路径：`git revert 39cd479d`。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>