### PR TITLE
fix(knowledge-graph): 缩小 3D 球体至 2/3 并增大标签间隙，消除文字被球体包裹

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
@@ -53,8 +53,7 @@ function nodeRadius3D(importance?: number | null): number {
 }
 
 // react-force-graph-3d 的 nodeVal 被解释为"体积量"：实际渲染球体半径 = cbrt(val) * nodeRelSize。
-// nodeRelSize 默认 4，本文件未通过 <ForceGraph3D> props 覆盖，保持默认。
-// 将球体统一缩至默认 2/3，避免球体过大遮挡上方标签。
+// 将球体统一缩至默认 2/3（nodeRelSize 默认 4，现通过 props 覆盖），避免球体过大遮挡上方标签。
 const NODE_REL_SIZE = 2.67;
 // 球面与标签底边的世界单位间隙，保证最小节点也能清晰浮于球体之上。
 const LABEL_GAP = 3;

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas3D.tsx
@@ -54,9 +54,10 @@ function nodeRadius3D(importance?: number | null): number {
 
 // react-force-graph-3d 的 nodeVal 被解释为"体积量"：实际渲染球体半径 = cbrt(val) * nodeRelSize。
 // nodeRelSize 默认 4，本文件未通过 <ForceGraph3D> props 覆盖，保持默认。
-const NODE_REL_SIZE = 4;
+// 将球体统一缩至默认 2/3，避免球体过大遮挡上方标签。
+const NODE_REL_SIZE = 2.67;
 // 球面与标签底边的世界单位间隙，保证最小节点也能清晰浮于球体之上。
-const LABEL_GAP = 1.5;
+const LABEL_GAP = 3;
 
 function nodeColorFn(node: GraphCanvasNode): string {
   if (node.community_id != null) return communityColor(node.community_id);
@@ -234,6 +235,7 @@ export function GraphCanvas3D({
             nodeLabel="label"
             nodeColor={getNodeColor}
             nodeVal={getNodeVal}
+            nodeRelSize={NODE_REL_SIZE}
             nodeOpacity={0.95}
             nodeThreeObject={getNodeThreeObject}
             nodeThreeObjectExtend={true}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge Graph 3D 引擎中节点球体过大，sprite 文字标签从特定相机视角仍被球体遮挡/包裹，此前两次修复（dd1a6c85、6e79b9fc）后问题依旧存在。
- 关联上下文/Issue/文档：前序 PR #529、#526

# 核心变更
- `NODE_REL_SIZE` 从 4 降至 2.67，将所有球体半径统一缩至原来的 2/3（最大半径从 8 降至 ~5.34）
- `LABEL_GAP` 从 1.5 增至 3.0，保证任意相机角度下文字底部距球面至少 3 个世界单位
- 新增 `nodeRelSize={NODE_REL_SIZE}` prop 传递给 `<ForceGraph3D>`，确保库内部渲染与标签位置计算使用同一缩放值

# 风险与回滚
- 主要风险：球体变小后边的箭头视觉比例可能微调，但不影响交互逻辑
- 回滚方式：还原三个参数值即可

# 验证证据
- 单元测试：N/A（纯视觉参数调整）
- 集成测试：N/A
- E2E/Workflow：需浏览器实机验证多角度旋转
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`GraphCanvas3D.tsx` 3D 引擎节点视觉渲染
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 启动 dev server 在浏览器中切换到 Knowledge Graph 3D 引擎，多角度旋转验证文字完全可见