### PR TITLE
feat(knowledge-graph): 新增 Model Settings 面板，支持按语料库配置 LLM / Embedding 模型

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
@@ -8,9 +8,10 @@ const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 interface CorpusSelectorProps {
   value: string | null;
   onChange: (corpusId: string) => void;
+  onCorporaLoaded?: (corpora: CorpusRecord[]) => void;
 }
 
-export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
+export function CorpusSelector({ value, onChange, onCorporaLoaded }: CorpusSelectorProps) {
   const [corpora, setCorpora] = useState<CorpusRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const autoSelected = useRef(!!value);
@@ -21,6 +22,7 @@ export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
       .then((data) => {
         if (mounted) {
           setCorpora(data);
+          onCorporaLoaded?.(data);
           if (!autoSelected.current && data.length > 0) {
             autoSelected.current = true;
             onChange(data[0].id);
@@ -34,7 +36,7 @@ export function CorpusSelector({ value, onChange }: CorpusSelectorProps) {
     return () => {
       mounted = false;
     };
-  }, [onChange]);
+  }, [onChange, onCorporaLoaded]);
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  type CorpusModelsConfig,
+  type ModelConfigItem,
+  fetchModelConfigs,
+  updateCorpus,
+} from "@/features/knowledge";
+
+interface ModelConfigPanelProps {
+  corpusId: string;
+  corpusConfig: Record<string, unknown> | undefined;
+  onConfigSaved: () => void;
+}
+
+export function ModelConfigPanel({
+  corpusId,
+  corpusConfig,
+  onConfigSaved,
+}: ModelConfigPanelProps) {
+  const corpusModels = (corpusConfig?.models ?? {}) as CorpusModelsConfig;
+  const [llmConfigId, setLlmConfigId] = useState<string>(
+    corpusModels?.llm_config_id ?? "",
+  );
+  const [embeddingConfigId, setEmbeddingConfigId] = useState<string>(
+    corpusModels?.embedding_config_id ?? "",
+  );
+  const [llmModels, setLlmModels] = useState<ModelConfigItem[]>([]);
+  const [embeddingModels, setEmbeddingModels] = useState<ModelConfigItem[]>(
+    [],
+  );
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    fetchModelConfigs({ modelType: "llm", enabled: true })
+      .then(setLlmModels)
+      .catch(() => {});
+    fetchModelConfigs({ modelType: "embedding", enabled: true })
+      .then(setEmbeddingModels)
+      .catch(() => {});
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const models: CorpusModelsConfig = {
+        llm_config_id: llmConfigId || undefined,
+        embedding_config_id: embeddingConfigId || undefined,
+      };
+      const existing = corpusConfig ?? {};
+      await updateCorpus(corpusId, {
+        config: { ...existing, models },
+      });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+      onConfigSaved();
+    } catch (err) {
+      console.error("save_model_config_failed", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selectedEmbedding = embeddingModels.find(
+    (m) => m.id === embeddingConfigId,
+  );
+  const dims =
+    typeof selectedEmbedding?.config?.dimensions === "number"
+      ? selectedEmbedding.config.dimensions
+      : null;
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+      <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Model Settings
+      </h3>
+      <p className="mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
+        LLM 用于图谱实体/关系抽取与社区摘要；Embedding 用于向量化与检索
+      </p>
+
+      <div className="mt-3 space-y-3">
+        <div>
+          <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+            LLM Model
+          </label>
+          <select
+            value={llmConfigId}
+            onChange={(e) => setLlmConfigId(e.target.value)}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          >
+            <option value="">(使用全局默认)</option>
+            {llmModels.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.display_name} · {m.vendor}/{m.model_name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-zinc-600 dark:text-zinc-400 mb-1">
+            Embedding Model
+          </label>
+          <select
+            value={embeddingConfigId}
+            onChange={(e) => setEmbeddingConfigId(e.target.value)}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
+          >
+            <option value="">(使用全局默认)</option>
+            {embeddingModels.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.display_name} · {m.vendor}/{m.model_name}
+              </option>
+            ))}
+          </select>
+          {dims != null && (
+            <span className="mt-1 inline-block rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+              {dims} dims
+            </span>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={saving}
+        className="mt-3 w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+      >
+        {saving ? "保存中..." : saved ? "已保存" : "保存"}
+      </button>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
@@ -13,12 +13,14 @@ interface ModelConfigPanelProps {
   corpusId: string;
   corpusConfig: Record<string, unknown> | undefined;
   onConfigSaved: () => void;
+  llmModels?: ModelConfigItem[];
 }
 
 export function ModelConfigPanel({
   corpusId,
   corpusConfig,
   onConfigSaved,
+  llmModels: llmModelsProp,
 }: ModelConfigPanelProps) {
   const corpusModels = (corpusConfig?.models ?? {}) as CorpusModelsConfig;
   const [llmConfigId, setLlmConfigId] = useState<string>(
@@ -33,18 +35,24 @@ export function ModelConfigPanel({
   );
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchModelConfigs({ modelType: "llm", enabled: true })
-      .then(setLlmModels)
-      .catch(() => {});
+    if (llmModelsProp) {
+      setLlmModels(llmModelsProp);
+    } else {
+      fetchModelConfigs({ modelType: "llm", enabled: true })
+        .then(setLlmModels)
+        .catch(() => {});
+    }
     fetchModelConfigs({ modelType: "embedding", enabled: true })
       .then(setEmbeddingModels)
       .catch(() => {});
-  }, []);
+  }, [llmModelsProp]);
 
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       const models: CorpusModelsConfig = {
         llm_config_id: llmConfigId || undefined,
@@ -58,6 +66,7 @@ export function ModelConfigPanel({
       setTimeout(() => setSaved(false), 2000);
       onConfigSaved();
     } catch (err) {
+      setSaveError("保存失败，请重试");
       console.error("save_model_config_failed", err);
     } finally {
       setSaving(false);
@@ -132,6 +141,9 @@ export function ModelConfigPanel({
       >
         {saving ? "保存中..." : saved ? "已保存" : "保存"}
       </button>
+      {saveError && (
+        <p className="mt-1 text-[10px] text-red-600 dark:text-red-400">{saveError}</p>
+      )}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -11,9 +11,14 @@ import {
   type GraphBuildRunRecord,
   type GraphSearchResultItem,
   type KnowledgeGraphPayload,
+  type CorpusModelsConfig,
+  type CorpusRecord,
+  type ModelConfigItem,
   buildKnowledgeGraph,
   cancelPipelineRun,
   fetchCorpusGraph,
+  fetchCorpora,
+  fetchModelConfigs,
 } from "@/features/knowledge";
 
 import { BuildButton } from "./_components/BuildButton";
@@ -26,6 +31,7 @@ import { GlobalSearchPanel } from "./_components/GlobalSearchPanel";
 import { GraphCanvas } from "./_components/GraphCanvas";
 import { GraphCanvasFrame } from "./_components/GraphCanvasFrame";
 import { GraphStatsPanel } from "./_components/GraphStatsPanel";
+import { ModelConfigPanel } from "./_components/ModelConfigPanel";
 import { NeighborExplorer } from "./_components/NeighborExplorer";
 import { PathExplorer } from "./_components/PathExplorer";
 import { SearchBar } from "./_components/SearchBar";
@@ -90,6 +96,8 @@ function nodeRadius(importance?: number): number {
 
 export default function KnowledgeGraphPage() {
   const [corpusId, setCorpusId] = useState<string | null>(null);
+  const [corpora, setCorpora] = useState<CorpusRecord[]>([]);
+  const [llmModels, setLlmModels] = useState<ModelConfigItem[]>([]);
   const [payload, setPayload] = useState<KnowledgeGraphPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -137,6 +145,17 @@ export default function KnowledgeGraphPage() {
     import("d3-force").Simulation<GraphNodePos, undefined> | null
   >(null);
   const { confirm, confirmDialog } = useConfirmDialog();
+
+  const corpusRecord = useMemo(
+    () => corpora.find((c) => c.id === corpusId) ?? null,
+    [corpora, corpusId],
+  );
+
+  useEffect(() => {
+    fetchModelConfigs({ modelType: "llm", enabled: true })
+      .then(setLlmModels)
+      .catch(() => {});
+  }, []);
 
   const loadGraph = useCallback(
     async (cid: string) => {
@@ -219,8 +238,20 @@ export default function KnowledgeGraphPage() {
     setBuilding(true);
     setBuildError(null);
     try {
+      // 从 corpus config 解析 LLM 模型名
+      const modelsConfig = (corpusRecord?.config as Record<string, unknown> | undefined)?.models as CorpusModelsConfig | undefined;
+      const llmConfigId = modelsConfig?.llm_config_id;
+      let llmModelName: string | undefined;
+      if (llmConfigId) {
+        const item = llmModels.find((m) => m.id === llmConfigId);
+        if (item) {
+          llmModelName = `${item.vendor}/${item.model_name}`;
+        }
+      }
+
       const result = await buildKnowledgeGraph(corpusId, {
         enable_llm_extraction: true,
+        ...(llmModelName ? { llm_model: llmModelName } : {}),
       });
       if (result.status === "failed") {
         setBuildError(result.error_message ?? "构建失败");
@@ -234,7 +265,7 @@ export default function KnowledgeGraphPage() {
       // Pill 收到后再让父组件 setPillEnqueued(false) 自然消失。
       setBuilding(false);
     }
-  }, [corpusId, loadGraph]);
+  }, [corpusId, corpusRecord, llmModels, loadGraph]);
 
   const handleCancelBuildRun = useCallback(
     async (run: GraphBuildRunRecord) => {
@@ -457,7 +488,7 @@ export default function KnowledgeGraphPage() {
               {/* Toolbar — 三段式：左 CorpusSelector / 中 SearchBar / 右 viewTab+渲染器+构建按钮+Pill */}
               <div className="flex items-center gap-3">
                 {/* 左 */}
-                <CorpusSelector value={corpusId} onChange={setCorpusId} />
+                <CorpusSelector value={corpusId} onChange={setCorpusId} onCorporaLoaded={setCorpora} />
 
                 {/* 中（仅图谱视图 + 已选语料库时显示）*/}
                 <div className="flex-1 min-w-0 flex justify-center">
@@ -887,6 +918,18 @@ export default function KnowledgeGraphPage() {
                   </p>
                 )}
               </div>
+
+              {/* Model Settings */}
+              {corpusId && corpusRecord && (
+                <ModelConfigPanel
+                  key={corpusId}
+                  corpusId={corpusId}
+                  corpusConfig={corpusRecord.config as Record<string, unknown> | undefined}
+                  onConfigSaved={() => {
+                    fetchCorpora(APP_NAME).then(setCorpora).catch(() => {});
+                  }}
+                />
+              )}
 
               {/* G1: GraphRAG Global Search — 全局问答 */}
               {corpusId && (

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -925,6 +925,7 @@ export default function KnowledgeGraphPage() {
                   key={corpusId}
                   corpusId={corpusId}
                   corpusConfig={corpusRecord.config as Record<string, unknown> | undefined}
+                  llmModels={llmModels}
                   onConfigSaved={() => {
                     fetchCorpora(APP_NAME).then(setCorpora).catch(() => {});
                   }}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -75,6 +75,8 @@ export {
   unarchiveDocument,
   // Model Configs
   fetchModelConfigs,
+  // Corpus Update
+  updateCorpus,
   // Graph Enhanced API (Phase 1)
   buildKnowledgeGraph,
   fetchCorpusGraph,


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge Graph 页面构建图谱时无法选择 LLM / Embedding 模型，固定使用系统默认模型，缺少按语料库粒度的模型配置能力。
- 关联上下文：Interface / Model 页面已维护 LLM 和 Embedding 模型清单；Corpus 的 `config.models` 字段已支持 `llm_config_id` / `embedding_config_id` 存储，但 KG 页面未暴露配置入口。

# 核心变更
- **新建 `ModelConfigPanel` 组件**：在 KG 页面右侧边栏新增 "Model Settings" 面板，提供 LLM 与 Embedding 模型下拉选择（数据源为 Interface / Model 已启用模型），支持保存至 `corpus.config.models`，Embedding 模型额外显示维度 badge。
- **扩展 `CorpusSelector`**：新增 `onCorporaLoaded` 可选回调，将 corpora 列表提升至父组件，使 KG page 可派生 `corpusRecord` 并读取其 `config`。
- **改造 `handleBuild`**：构建图谱时从 `corpus.config.models.llm_config_id` 解析为 `vendor/model_name` 格式，传入 `buildKnowledgeGraph` API 的 `llm_model` 参数，确保使用用户指定的 LLM 模型。
- **导出 `updateCorpus`**：在 `features/knowledge/index.ts` barrel 中新增 re-export。

# 风险与回滚
- 主要风险：模型配置保存后立即生效于下次构建，不影响已有图谱数据；`fetchModelConfigs` 在非管理员权限下静默降级返回空列表。
- 回滚方式：`git revert` 本 PR 的 commit 即可完全移除该功能。

# 验证证据
- 单元测试：TypeScript 编译通过（`pnpm exec tsc --noEmit`），ESLint 零警告。
- 集成测试：无新增后端变更，复用现有 `PATCH /knowledge/base/{id}` 和 `POST /graph/build` API。
- E2E/Workflow：待浏览器实机验证 Model Settings 面板交互与构建模型生效。
- 覆盖率/关键截图：4 文件变更，+188 / -4 行。

# 影响范围
- 前端：`apps/negentropy-ui/app/knowledge/graph/` 下 3 个文件变更 + 1 个新文件；`features/knowledge/index.ts` 导出扩展。
- 后端：无变更。
- GitHub Actions / 文档：无影响。

# Next Best Action
- 浏览器实机验证：进入 KG 页面 → 选择语料库 → 确认 Model Settings 面板展示 → 切换模型并保存 → 构建图谱 → 检查后端日志确认使用了指定 LLM 模型。