### PR TITLE
fix(knowledge-graph): 修复 Force Graph 放大时节点标签消失的问题

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
@@ -214,9 +214,9 @@ export function ForceGraphCanvas({
       }
       ctx.globalAlpha = 1;
 
-      // 标签（缩放足够大时显示）
-      const fontSize = Math.max(10 / globalScale, 4);
-      if (fontSize > 4 && globalScale > 0.5) {
+      // 标签（始终显示，缩小时隐藏避免过于拥挤）
+      if (globalScale > 0.3) {
+        const fontSize = Math.max(12 / globalScale, 3.5);
         ctx.font = `${fontSize}px system-ui, sans-serif`;
         ctx.fillStyle = isDark ? "#d4d4d8" : "#27272a";
         ctx.textAlign = "center";


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Force Graph 引擎中，当图谱放大到一定程度（globalScale >= 2.5）后，节点名称文字完全消失。根因是标签渲染逻辑中 `fontSize = Math.max(10/globalScale, 4)` 在放大时被钳制为 4，无法满足 `fontSize > 4` 的条件判断。

# 核心变更
- 移除 `fontSize > 4` 硬阈值条件，改为仅保留缩放下限 `globalScale > 0.3`
- 调整字号参数：基础从 10 提至 12，下限从 4 降至 3.5，确保各缩放级别可读
- 放宽缩小隐藏阈值从 0.5 至 0.3，缩小状态下仍能显示标签

# 风险与回滚
- 主要风险：极小缩放比例下标签可能略显拥挤
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无（Canvas 渲染逻辑）
- 集成测试：无
- E2E/Workflow：需浏览器实机验证放大/缩小下标签始终可见
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`ForceGraphCanvas.tsx` 标签渲染逻辑
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证各缩放级别标签可见性