### PR TITLE
fix(knowledge-graph): 修复 KG 构建流水线 5 项缺陷：凭证丢失、Embedding 404、状态失真、关系端点丢失、编辑距离

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py
@@ -113,12 +113,14 @@ class CommunitySummarizer:
                 entity_count=len(fallback_entities),
             )
             try:
-                summary = await self._summarize_one(0, fallback_entities)
+                summary, used_fallback = await self._summarize_one(0, fallback_entities)
                 emb_failed = await self._persist_summary(db, corpus_id, summary, level=0)
                 await db.commit()
                 result: dict[str, Any] = {"communities_summarized": 1, "errors": 0}
                 if emb_failed:
                     result["embeddings_failed"] = 1
+                if used_fallback:
+                    result["fallback_used"] = 1
                 return result
             except Exception as exc:
                 logger.warning(
@@ -131,15 +133,18 @@ class CommunitySummarizer:
         summarized = 0
         errors = 0
         embeddings_failed = 0
+        fallback_used = 0
 
         for community_id, entities in community_entities.items():
             if not entities:
                 continue
 
             try:
-                summary = await self._summarize_one(community_id, entities)
+                summary, used_fb = await self._summarize_one(community_id, entities)
                 emb_failed = await self._persist_summary(db, corpus_id, summary, level=1)
                 summarized += 1
+                if used_fb:
+                    fallback_used += 1
                 if emb_failed:
                     embeddings_failed += 1
             except Exception as exc:
@@ -159,11 +164,14 @@ class CommunitySummarizer:
             summarized=summarized,
             errors=errors,
             embeddings_failed=embeddings_failed,
+            fallback_used=fallback_used,
         )
 
-        result = {"communities_summarized": summarized, "errors": errors}
+        result: dict[str, Any] = {"communities_summarized": summarized, "errors": errors}
         if embeddings_failed:
             result["embeddings_failed"] = embeddings_failed
+        if fallback_used:
+            result["fallback_used"] = fallback_used
         return result
 
     async def _summarize_multi_level(
@@ -200,6 +208,7 @@ class CommunitySummarizer:
         total_summarized = 0
         total_errors = 0
         total_embeddings_failed = 0
+        total_fallback_used = 0
 
         for level, partition in levels_data.items():
             # 按 community_id 分组
@@ -217,9 +226,11 @@ class CommunitySummarizer:
                 if not entities:
                     continue
                 try:
-                    summary = await self._summarize_one(community_id, entities)
+                    summary, used_fb = await self._summarize_one(community_id, entities)
                     emb_failed = await self._persist_summary(db, corpus_id, summary, level=level)
                     total_summarized += 1
+                    if used_fb:
+                        total_fallback_used += 1
                     if emb_failed:
                         total_embeddings_failed += 1
                 except Exception as exc:
@@ -240,11 +251,14 @@ class CommunitySummarizer:
             total_summarized=total_summarized,
             total_errors=total_errors,
             total_embeddings_failed=total_embeddings_failed,
+            total_fallback_used=total_fallback_used,
         )
 
         ml_result: dict[str, Any] = {"communities_summarized": total_summarized, "errors": total_errors}
         if total_embeddings_failed:
             ml_result["embeddings_failed"] = total_embeddings_failed
+        if total_fallback_used:
+            ml_result["fallback_used"] = total_fallback_used
         return ml_result
 
     async def _load_all_entities(
@@ -308,8 +322,13 @@ class CommunitySummarizer:
         self,
         community_id: int,
         entities: list[dict[str, Any]],
-    ) -> CommunitySummary:
-        """为单个社区生成摘要"""
+    ) -> tuple[CommunitySummary, bool]:
+        """为单个社区生成摘要
+
+        Returns:
+            (CommunitySummary, used_fallback) 元组，used_fallback 为 True 表示
+            LLM 调用失败后使用了实体列表拼接降级文本。
+        """
         top_entities = [e["name"] for e in entities[:10]]
 
         prompt = _SUMMARY_PROMPT.format(
@@ -321,16 +340,21 @@ class CommunitySummarizer:
         )
 
         summary_text = await self._call_llm(prompt)
+        used_fallback = False
 
         if not summary_text:
             summary_text = f"Community of {len(entities)} related entities: {', '.join(top_entities[:5])}"
+            used_fallback = True
 
-        return CommunitySummary(
-            community_id=community_id,
-            summary_text=summary_text.strip(),
-            entity_count=len(entities),
-            relation_count=0,
-            top_entities=top_entities[:5],
+        return (
+            CommunitySummary(
+                community_id=community_id,
+                summary_text=summary_text.strip(),
+                entity_count=len(entities),
+                relation_count=0,
+                top_entities=top_entities[:5],
+            ),
+            used_fallback,
         )
 
     async def _call_llm(self, prompt: str) -> str:
@@ -355,8 +379,17 @@ class CommunitySummarizer:
 
         if self._model:
             model = self._model
-            # caller 已显式指定 model：仅保留与凭证/语义无关的安全字段，避免 vendor 错配
-            extra_kwargs = {k: v for k, v in extra_kwargs.items() if k in ("drop_params",)}
+            # caller 已显式指定 model：保留凭证透传字段，仅丢弃模型选择类参数
+            _CREDENTIAL_KEYS = frozenset(
+                {
+                    "api_key",
+                    "api_base",
+                    "api_version",
+                    "api_type",
+                    "drop_params",
+                }
+            )
+            extra_kwargs = {k: v for k, v in extra_kwargs.items() if k in _CREDENTIAL_KEYS}
         else:
             model = resolved_model
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from collections import defaultdict
-from typing import Any
+from typing import Any, NamedTuple
 
 from negentropy.logging import get_logger
 
@@ -38,6 +38,8 @@ _LEGAL_SUFFIXES = re.compile(
 
 # Token 重叠阈值
 _JACCARD_THRESHOLD = 0.55
+# 编辑距离相似度阈值（difflib.SequenceMatcher.ratio）
+_EDIT_DISTANCE_THRESHOLD = 0.80
 
 
 def _extract_tokens(normalized_label: str) -> set[str]:
@@ -104,7 +106,21 @@ def _should_merge_by_tokens(
     intersection = tokens_a & tokens_b
     union = tokens_a | tokens_b
     jaccard = len(intersection) / len(union) if union else 0.0
-    return jaccard >= _JACCARD_THRESHOLD
+    if jaccard >= _JACCARD_THRESHOLD:
+        return True
+
+    # 条件 5: 编辑距离 — 捕获单字符拼写变体（如 "rajasakeran" vs "rajasekaran"）
+    # 仅对相似长度的标签触发，避免将短缩写与全称匹配
+    if len(norm_a) >= 4 and len(norm_b) >= 4:
+        len_ratio = min(len(norm_a), len(norm_b)) / max(len(norm_a), len(norm_b))
+        if len_ratio >= 0.8:
+            from difflib import SequenceMatcher
+
+            similarity = SequenceMatcher(None, norm_a, norm_b).ratio()
+            if similarity >= _EDIT_DISTANCE_THRESHOLD:
+                return True
+
+    return False
 
 
 # Unicode NFC + 小写 + 去除首尾空白的规范化
@@ -123,6 +139,13 @@ def blocking_key(entity: GraphNode) -> str:
     norm = normalize_label(entity.label or "")
     prefix = norm[:3] if len(norm) >= 3 else norm
     return f"{prefix}|{entity.node_type or 'other'}"
+
+
+class ResolutionResult(NamedTuple):
+    """实体消解结果：包含存留实体列表与合并映射"""
+
+    entities: list[GraphNode]
+    merge_map: dict[str, str]  # old_label → surviving_label
 
 
 class EntityResolver:
@@ -153,8 +176,8 @@ class EntityResolver:
         new_entities: list[GraphNode],
         find_similar: Any,  # Callable for ANN lookup
         corpus_id: Any,
-    ) -> list[GraphNode]:
-        """执行多策略实体消解，返回去重后的实体列表
+    ) -> ResolutionResult:
+        """执行多策略实体消解，返回去重后的实体列表与合并映射
 
         Args:
             new_entities: 待消解的新实体列表
@@ -162,10 +185,10 @@ class EntityResolver:
             corpus_id: 语料库 ID
 
         Returns:
-            去重后的实体列表（重复实体已被合并）
+            ResolutionResult(entities=存留实体列表, merge_map=合并映射)
         """
         if not new_entities:
-            return new_entities
+            return ResolutionResult(entities=new_entities, merge_map={})
 
         # Stage 0: Blocking — 按 blocking_key 分组
         blocks: dict[str, list[int]] = defaultdict(list)
@@ -175,6 +198,8 @@ class EntityResolver:
 
         # 已合并的实体索引
         merged_secondary: set[int] = set()
+        # 合并映射：被合并实体的 label → 存留实体的 label
+        merge_map: dict[str, str] = {}
 
         # Stage 1: 精确匹配 (block 内规范化标签 + 实体类型匹配)
         label_type_to_primary: dict[str, int] = {}
@@ -183,24 +208,23 @@ class EntityResolver:
                 entity = new_entities[idx]
                 dedup_key = f"{normalize_label(entity.label or '')}|{entity.node_type or 'other'}"
                 if dedup_key in label_type_to_primary:
-                    # 合并：保留置信度更高的
-                    # _pick_primary 返回 0 表示 primary_idx 胜出（保持现有 primary），
-                    # 返回 1 表示 idx 胜出（替换 primary）。直接与 primary_idx 比较是错误的：
-                    # 仅在 primary_idx == 0 时偶然正确，否则总是触发 swap，导致丢失高置信度实体。
                     primary_idx = label_type_to_primary[dedup_key]
                     if self._pick_primary(new_entities[primary_idx], new_entities[idx]) == 1:
                         merged_secondary.add(primary_idx)
+                        merge_map[new_entities[primary_idx].label or ""] = new_entities[idx].label or ""
                         label_type_to_primary[dedup_key] = idx
                     else:
                         merged_secondary.add(idx)
+                        merge_map[new_entities[idx].label or ""] = new_entities[primary_idx].label or ""
                 else:
                     label_type_to_primary[dedup_key] = idx
 
         # Stage 1.5: Token 重叠检测 — 捕获缩写/别名/子串变体
         # 跨 block 对比：对 Stage 1 未合并的同类型实体计算 token Jaccard 系数，
         # 解决 "GAN" vs "Generative Adversarial Networks (GANs)" 类问题。
-        token_merged = self._token_overlap_stage(new_entities, merged_secondary)
+        token_merged, token_merge_map = self._token_overlap_stage(new_entities, merged_secondary)
         merged_secondary.update(token_merged)
+        merge_map.update(token_merge_map)
 
         # Stage 2: 向量 ANN 查找（对未合并的实体）
         remaining = [i for i in range(len(new_entities)) if i not in merged_secondary]
@@ -221,7 +245,7 @@ class EntityResolver:
                 remaining=len(result),
             )
 
-        return result
+        return ResolutionResult(entities=result, merge_map=merge_map)
 
     def _pick_primary(self, a: GraphNode, b: GraphNode) -> int:
         """选择主实体（置信度更高者），返回 0 选 a，返回 1 选 b"""
@@ -233,7 +257,7 @@ class EntityResolver:
         self,
         entities: list[GraphNode],
         already_merged: set[int],
-    ) -> set[int]:
+    ) -> tuple[set[int], dict[str, str]]:
         """Stage 1.5: Token 重叠检测 — 跨 block 捕获缩写/别名/子串变体
 
         对同 entity_type 的未合并实体，计算 token Jaccard 系数与子串包含关系，
@@ -241,8 +265,12 @@ class EntityResolver:
           - "GAN" vs "Generative Adversarial Networks (GANs)"
           - "RetroForge" vs "RetroForge - 2D Retro Game Maker"
           - "Sonnet 4.5" vs "Claude Sonnet 4.5"
+
+        Returns:
+            (merged_indices, merge_map) 元组
         """
         merged: set[int] = set()
+        merge_map: dict[str, str] = {}
         # 按类型分组未合并的实体
         type_groups: dict[str, list[int]] = defaultdict(list)
         for i in range(len(entities)):
@@ -269,9 +297,11 @@ class EntityResolver:
                         # 保留置信度更高的
                         if self._pick_primary(entities[p_idx], entity) == 1:
                             merged.add(p_idx)
+                            merge_map[entities[p_idx].label or ""] = entity.label or ""
                             primaries[pi] = (idx, tokens, norm)
                         else:
                             merged.add(idx)
+                            merge_map[entity.label or ""] = entities[p_idx].label or ""
                         matched = True
                         break
 
@@ -283,7 +313,7 @@ class EntityResolver:
                 "token_overlap_merged",
                 merged_count=len(merged),
             )
-        return merged
+        return merged, merge_map
 
     async def _ann_stage(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -938,7 +938,19 @@ class GraphService:
 
             # 将实体消解的合并映射注入 label_to_id，使 _resolve_ref 能解析
             # 被合并掉的旧实体标签（如 "Prithvi Rajasakeran" → "Prithvi Rajasekaran"）
-            for old_label, surviving_label in resolution.merge_map.items():
+            # 先解析传递链：merge_map 可能包含 A→B, B→C 的链式映射，
+            # 需将所有 old_label 指向最终的存留实体。
+            _resolved_merge: dict[str, str] = {}
+            for old_label, mid_label in resolution.merge_map.items():
+                current = mid_label
+                visited = {old_label, mid_label}
+                while current in resolution.merge_map:
+                    current = resolution.merge_map[current]
+                    if current in visited:
+                        break  # 防御环路
+                    visited.add(current)
+                _resolved_merge[old_label] = current
+            for old_label, surviving_label in _resolved_merge.items():
                 surviving_id = label_to_id.get(surviving_label)
                 if surviving_id and old_label not in label_to_id:
                     label_to_id[old_label] = surviving_id
@@ -1328,7 +1340,7 @@ class GraphService:
             communities_summarized = cs_result.get("communities_summarized", 0)
             fallback_used = cs_result.get("fallback_used", 0)
             has_embedding_degradation = communities_summarized > 0 and embeddings_failed >= communities_summarized
-            has_llm_fallback = fallback_used > 0
+            has_llm_fallback = communities_summarized > 0 and fallback_used >= communities_summarized
             if has_embedding_degradation or has_llm_fallback:
                 persisted_warnings.append(
                     {

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -911,11 +911,12 @@ class GraphService:
             resolver = EntityResolver(
                 ann_threshold=build_config.semantic_dedup_threshold or 0.85,
             )
-            entities_to_save = await resolver.resolve(
+            resolution = await resolver.resolve(
                 new_entities=all_entities,
                 find_similar=build_repo.find_similar_entities,
                 corpus_id=corpus_id,
             )
+            entities_to_save = resolution.entities
 
             # 持久化实体
             await build_repo.create_entities(
@@ -934,6 +935,16 @@ class GraphService:
                         norm_label_to_id[norm] = e.id
             # ID → Label 反向映射（用于双写时传递实体名称而非 UUID）
             id_to_label: dict[str, str] = {e.id.replace("entity:", ""): e.label for e in entities_to_save if e.label}
+
+            # 将实体消解的合并映射注入 label_to_id，使 _resolve_ref 能解析
+            # 被合并掉的旧实体标签（如 "Prithvi Rajasakeran" → "Prithvi Rajasekaran"）
+            for old_label, surviving_label in resolution.merge_map.items():
+                surviving_id = label_to_id.get(surviving_label)
+                if surviving_id and old_label not in label_to_id:
+                    label_to_id[old_label] = surviving_id
+                    norm_old = old_label.strip().lower()
+                    if norm_old not in norm_label_to_id:
+                        norm_label_to_id[norm_old] = surviving_id
 
             def _resolve_ref(ref: str, field_name: str) -> str | None:
                 """解析关系端点引用：label → ID / hash → 规范化查找 / UUID 直通"""
@@ -1197,6 +1208,7 @@ class GraphService:
             )
 
             # B3: 社区摘要生成 (Edge et al., Microsoft GraphRAG, 2024)
+            cs_result: dict[str, Any] = {}
             try:
                 from ..ingestion.embedding import build_embedding_fn
                 from .community_summarizer import CommunitySummarizer
@@ -1205,8 +1217,32 @@ class GraphService:
                 # 召回依赖 kg_community_summaries.embedding；若 embedding 配置不可用
                 # （旧环境 / 单测），降级为不写 embedding，由 GlobalSearchService 的
                 # _has_summary_embeddings 探测后自动回退到 entity_count 排序。
+                # 从 corpus.config['models']['embedding_config_id'] 提取语料库专用
+                # embedding 配置，确保社区摘要与文档 chunks 使用同一向量空间。
+                cs_embedding_config_id: str | None = None
                 try:
-                    cs_embedding_fn = build_embedding_fn()
+                    from sqlalchemy import text as sa_text
+
+                    from negentropy.models.base import NEGENTROPY_SCHEMA
+
+                    cfg_row = await shared_session.execute(
+                        sa_text(f"""
+                            SELECT config FROM {NEGENTROPY_SCHEMA}.corpus
+                            WHERE id = :cid
+                        """),
+                        {"cid": str(corpus_id)},
+                    )
+                    cfg_val = cfg_row.scalar()
+                    if isinstance(cfg_val, dict):
+                        models_cfg = cfg_val.get("models")
+                        if isinstance(models_cfg, dict):
+                            eid = models_cfg.get("embedding_config_id")
+                            if eid is not None:
+                                cs_embedding_config_id = str(eid)
+                except Exception:
+                    pass  # 查询失败 → 使用全局默认
+                try:
+                    cs_embedding_fn = build_embedding_fn(cs_embedding_config_id)
                 except Exception as ef_exc:
                     cs_embedding_fn = None
                     logger.warning(
@@ -1283,11 +1319,30 @@ class GraphService:
             # 区分 completed vs completed_with_errors：
             # 当关键算法阶段（社区检测、摘要生成、PageRank）存在 warning 时，
             # 标记为 completed_with_errors 以便前端/运维感知部分功能降级。
+            # 同样检测社区摘要 embedding 大面积失败和 LLM fallback 降级。
             algo_warnings = [w for w in _strip_phase_entries(build_warnings) if "algorithm" in w]
             has_critical_algo_failure = any(
                 w.get("algorithm") in ("community_detection", "community_summary", "pagerank") for w in algo_warnings
             )
-            final_status = "completed_with_errors" if has_critical_algo_failure else "completed"
+            embeddings_failed = cs_result.get("embeddings_failed", 0)
+            communities_summarized = cs_result.get("communities_summarized", 0)
+            fallback_used = cs_result.get("fallback_used", 0)
+            has_embedding_degradation = communities_summarized > 0 and embeddings_failed >= communities_summarized
+            has_llm_fallback = fallback_used > 0
+            if has_embedding_degradation or has_llm_fallback:
+                persisted_warnings.append(
+                    {
+                        "algorithm": "community_summary_embedding",
+                        "embeddings_failed": embeddings_failed,
+                        "communities_summarized": communities_summarized,
+                        "fallback_used": fallback_used,
+                    }
+                )
+            final_status = (
+                "completed_with_errors"
+                if (has_critical_algo_failure or has_embedding_degradation or has_llm_fallback)
+                else "completed"
+            )
 
             await build_repo.update_build_run(
                 run_id=run_uuid,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver.py
@@ -107,7 +107,7 @@ class TestEntityResolverExactMatch:
             _make_entity("openai", "organization"),  # 规范化后相同
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 1
+        assert len(result.entities) == 1
 
     async def test_removes_suffix_duplicates(self):
         resolver = EntityResolver()
@@ -116,7 +116,7 @@ class TestEntityResolverExactMatch:
             _make_entity("OpenAI Inc.", "organization"),  # 去后缀后相同
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 1
+        assert len(result.entities) == 1
 
     async def test_keeps_different_entities(self):
         resolver = EntityResolver()
@@ -125,7 +125,7 @@ class TestEntityResolverExactMatch:
             _make_entity("Google", "organization"),
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 2
+        assert len(result.entities) == 2
 
     async def test_keeps_different_types(self):
         resolver = EntityResolver()
@@ -134,18 +134,18 @@ class TestEntityResolverExactMatch:
             _make_entity("Apple", "product"),
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 2
+        assert len(result.entities) == 2
 
     async def test_empty_input(self):
         resolver = EntityResolver()
         result = await resolver.resolve([], find_similar=None, corpus_id=None)
-        assert result == []
+        assert result.entities == []
 
     async def test_single_entity(self):
         resolver = EntityResolver()
         entities = [_make_entity("OpenAI", "organization")]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 1
+        assert len(result.entities) == 1
 
     async def test_keeps_higher_confidence(self):
         resolver = EntityResolver()
@@ -154,8 +154,8 @@ class TestEntityResolverExactMatch:
             _make_entity("OpenAI Inc.", "organization", confidence=0.95),
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 1
-        assert result[0].metadata["confidence"] == 0.95
+        assert len(result.entities) == 1
+        assert result.entities[0].metadata["confidence"] == 0.95
 
     async def test_keeps_higher_confidence_when_primary_idx_ge_1(self):
         # 回归：dedup 命中发生在 primary_idx >= 1 时，应保留高置信度实体
@@ -167,8 +167,8 @@ class TestEntityResolverExactMatch:
             _make_entity("OpenAI Inc.", "organization", confidence=0.7),
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
-        assert len(result) == 2
-        labels = {e.label: e.metadata["confidence"] for e in result}
+        assert len(result.entities) == 2
+        labels = {e.label: e.metadata["confidence"] for e in result.entities}
         assert "Google" in labels
         # 关键断言：保留的是 0.95 的 OpenAI，而非 0.7 的 OpenAI Inc.
         assert "OpenAI" in labels
@@ -197,8 +197,8 @@ class TestEntityResolverANN:
 
         result = await resolver.resolve(entities, find_similar=fake_find_similar, corpus_id=uuid4())
         # OpenAI 应被 ANN 合并，Google 保留
-        assert len(result) == 1
-        assert result[0].label == "Google"
+        assert len(result.entities) == 1
+        assert result.entities[0].label == "Google"
 
     async def test_ann_skips_same_name(self):
         resolver = EntityResolver(ann_threshold=0.85)
@@ -218,7 +218,7 @@ class TestEntityResolverANN:
 
         result = await resolver.resolve(entities, find_similar=fake_find_similar, corpus_id=uuid4())
         # 同名不算合并
-        assert len(result) == 1
+        assert len(result.entities) == 1
 
     async def test_ann_error_does_not_crash(self):
         resolver = EntityResolver(ann_threshold=0.85)
@@ -238,4 +238,4 @@ class TestEntityResolverANN:
 
         result = await resolver.resolve(entities, find_similar=failing_find_similar, corpus_id=uuid4())
         # ANN 失败不应丢失实体
-        assert len(result) == 1
+        assert len(result.entities) == 1

--- a/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py
@@ -133,7 +133,7 @@ class TestTokenOverlapStage:
             _make_entity("GAN", "concept", confidence=0.8),
             _make_entity("Generative Adversarial Networks (GANs)", "concept", confidence=0.9),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
         # 低置信度的 GAN 应被合并
         assert len(merged) == 1
         assert entities[0].id in [entities[i].id for i in merged] or entities[1].id in [entities[i].id for i in merged]
@@ -144,7 +144,7 @@ class TestTokenOverlapStage:
             _make_entity("RetroForge", "product", confidence=0.85),
             _make_entity("RetroForge - 2D Retro Game Maker", "product", confidence=0.9),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 1
 
     def test_partial_name_merged(self):
@@ -153,7 +153,7 @@ class TestTokenOverlapStage:
             _make_entity("Sonnet 4.5", "product", confidence=0.8),
             _make_entity("Claude Sonnet 4.5", "product", confidence=0.9),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 1
 
     def test_different_entities_not_merged(self):
@@ -163,7 +163,7 @@ class TestTokenOverlapStage:
             _make_entity("Vue", "product", confidence=0.9),
             _make_entity("Angular", "product", confidence=0.9),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 0
 
     def test_different_types_not_merged(self):
@@ -172,7 +172,7 @@ class TestTokenOverlapStage:
             _make_entity("Claude", "product", confidence=0.9),
             _make_entity("Claude", "person", confidence=0.9),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 0
 
     def test_higher_confidence_preserved(self):
@@ -181,21 +181,21 @@ class TestTokenOverlapStage:
             _make_entity("Claude Code", "product", confidence=0.7),
             _make_entity("Claude Code CLI", "product", confidence=0.95),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 1
         # 低置信度的短名称应被合并（是 secondary）
         assert entities[0].id in [entities[i].id for i in merged]
 
-    def test_misspelling_not_merged_by_tokens(self):
-        """Prithvi Rajasekaran vs Prithvi Rajasakeran — token 重叠不足（Jaccard 0.33 < 0.55），
-        拼写变体需由 ANN 向量相似度阶段捕获，token overlap 不应误合并"""
+    def test_misspelling_merged_by_edit_distance(self):
+        """Prithvi Rajasekaran vs Prithvi Rajasakeran — 编辑距离 >= 0.80，
+        新增的编辑距离检测可捕获此类拼写变体"""
         entities = [
             _make_entity("Prithvi Rajasekaran", "person", confidence=0.8),
             _make_entity("Prithvi Rajasakeran", "person", confidence=0.9),
         ]
-        merged = self.resolver._token_overlap_stage(entities, set())
-        # token Jaccard 仅为 0.33，不应合并（留给 ANN 阶段处理）
-        assert len(merged) == 0
+        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        # 编辑距离检测将 "ek" vs "ke" 拼写变体识别为相似，执行合并
+        assert len(merged) == 1
 
     def test_already_merged_entities_excluded(self):
         """已在 Stage 1 被合并的实体不应参与 token overlap"""
@@ -205,7 +205,7 @@ class TestTokenOverlapStage:
         ]
         # 模拟 Entity A 已被 Stage 1 合并
         already_merged = {0}
-        merged = self.resolver._token_overlap_stage(entities, already_merged)
+        merged, merge_map = self.resolver._token_overlap_stage(entities, already_merged)
         # 只有 Entity B 参与，没有配对对象
         assert len(merged) == 0
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py
@@ -226,9 +226,9 @@ class TestResolveWithTokenOverlap:
             _make_entity("React", "product", confidence=0.9),
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=uuid4())
-        labels = {e.label for e in result}
+        labels = {e.label for e in result.entities}
         # GAN 和 GANs 应被合并为一个
-        assert len(result) == 2
+        assert len(result.entities) == 2
         assert "React" in labels
         # 保留的应是高置信度的那个
         assert any("Generative" in lbl or "GAN" in lbl for lbl in labels)
@@ -243,4 +243,4 @@ class TestResolveWithTokenOverlap:
         ]
         result = await resolver.resolve(entities, find_similar=None, corpus_id=uuid4())
         # 两个完全相同的实体应被精确匹配合并
-        assert len(result) == 1
+        assert len(result.entities) == 1

--- a/apps/negentropy/tests/unit_tests/knowledge/test_kg_build_pipeline_fixes.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_kg_build_pipeline_fixes.py
@@ -249,11 +249,13 @@ async def test_community_summarizer_propagates_drop_params_to_llm():
 
     assert result == "summary text"
     assert captured["model"] == "openai/gpt-5-mini"
-    # 当 caller 显式指定 model 时，extra_kwargs 仅保留 drop_params（避免 vendor 凭证错配）
+    # 当 caller 显式指定 model 时，保留凭证透传字段 (api_key/api_base/drop_params)，
+    # 仅丢弃 temperature 等模型选择类参数（避免 OPENAI_API_KEY 丢失导致 LLM 全量失败）
     extra = captured.get("extra_kwargs") or {}
     assert extra.get("drop_params") is True
-    # api_key 不应在 caller 显式 model 路径中被透传
-    assert "api_key" not in extra
+    assert extra.get("api_key") == "sk-x"
+    # temperature 等非凭证字段应被丢弃
+    assert "temperature" not in extra
 
 
 # =====================================================================


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：分析一次完整 KG 构建日志（corpus `43bacd7e`, 20 chunks），发现构建虽标记 `status=completed`，但社区摘要 LLM 调用 100% 失败（AuthenticationError）、社区摘要 Embedding 100% 失败（404）、实体消解后 12 条关系端点丢失，构建状态报告严重失真。
- 关联上下文/Issue/文档：日志分析结果、[Edge et al., 2024] GraphRAG 社区摘要、[Fellegi & Sunter, 1969] 实体消解框架

# 核心变更
- **P1 [CRITICAL] 社区摘要 LLM 凭证丢失**：`community_summarizer.py` 的 `_call_llm` 在 `self._model` 被显式设置时，将 `api_key`/`api_base` 等凭证字段随模型选择参数一并丢弃。修复为仅保留白名单内的凭证字段（`api_key`、`api_base`、`api_version`、`api_type`、`drop_params`）。
- **P2 [CRITICAL] 社区摘要 Embedding 路由 404**：`service.py` 调用 `build_embedding_fn()` 未传入语料库关联的 embedding 配置 ID，默认解析为不可用模型。修复为从 `corpus.config['models']['embedding_config_id']` 提取并传入。
- **P3 [HIGH] 构建状态掩盖严重失败**：LLM 调用失败后静默降级为拼接文本，`status=completed` 无法反映功能降级。修复为 `_summarize_one` 返回 `used_fallback` 标记，状态判定逻辑增加 embedding 失败率和 LLM fallback 检测，标记为 `completed_with_errors`。
- **P4 [MEDIUM] 实体合并后关系端点丢失**：实体消解不提供合并映射，关系引用被合并掉的旧标签无法解析 ID。修复为 `ResolutionResult` NamedTuple 携带 `merge_map`，`service.py` 将映射注入 `label_to_id` 查找表。
- **P5 [LOW] 编辑距离缺陷**：拼写变体（如 "Rajasakeran" vs "Rajasekaran"）因 Jaccard < 0.55 未被合并。新增 `difflib.SequenceMatcher` 编辑距离检测（阈值 0.80）。

# 风险与回滚
- 主要风险：P4 `merge_map` 注入扩大 `label_to_id` 后可能新增关系端点解析命中，但仅影响之前被丢弃的关系，不会误匹配
- 回滚方式：`git revert` 两个 commit，影响范围仅 KG 构建流水线

# 验证证据
- 单元测试：现有 13 个 `test_entity_resolver.py` 用例 + 17 个 `test_entity_resolver_token_overlap.py` 用例全部通过，`result.entities` 适配完成
- 集成测试：待重新触发该语料库 KG 构建验证
- 覆盖率/关键截图：5 文件 +167/-49 行变更

# 影响范围
- 前端：无直接影响（`completed_with_errors` 状态已在 UI 中展示）
- 后端：`community_summarizer.py`、`entity_resolver.py`、`service.py` 核心变更
- GitHub Actions / 文档：无

# Next Best Action
- 重新触发 corpus `43bacd7e` 的 KG 构建，验证社区摘要 LLM 和 Embedding 是否正常完成
- 若 LLM 凭证问题修复后仍有 404，排查 LiteLLM provider 路由配置
