### PR TITLE
feat(knowledge-graph): 引入实体抽取密度上限与类型纠偏防御层

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/extraction_validator.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extraction_validator.py
@@ -37,9 +37,14 @@ KNOWN_ENTITIES_PATH: Path = Path(__file__).with_name("known_entities.yml")
 
 # AI 产品兜底规则：捕获 known_entities.yml 未覆盖的型号变体（如 "Claude 3.7 Sonnet"）。
 # 仅当 LLM 给出的类型为 person 时启用——避免误改正确的 product 类型。
+#
+# 设计：要求触发词后跟随至少一个"型号样式"后缀（数字开头或已知规格关键字），
+# 避免把真人复合名（如 "Claude Shannon" / "Claude Monet" / "Gemini Cricket"）
+# 误改为产品；裸名（"Claude" / "GPT-4" / "ChatGPT"）由 known_entities 白名单覆盖。
 AI_PRODUCT_PATTERN: re.Pattern[str] = re.compile(
-    r"^(claude|gpt[- ]?\d?|chatgpt|gemini|llama|mistral|copilot|github\s+copilot|o1)"
-    r"(?:[- ]?[\w.]+)*$",
+    r"^(?:claude|gpt|chatgpt|gemini|llama|mistral|copilot|github\s+copilot|o1)"
+    r"(?:[\s.\-]+(?:\d[\w.]*"
+    r"|opus|sonnet|haiku|pro|ultra|mini|turbo|preview|max|nano|flash|large|medium|small))+$",
     re.IGNORECASE,
 )
 

--- a/apps/negentropy/src/negentropy/knowledge/graph/extraction_validator.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extraction_validator.py
@@ -1,0 +1,185 @@
+"""KG 实体抽取后置校验（防过度抽取 + 类型纠偏）
+
+LLM 直接抽取存在两类质量缺陷：
+  1. 过度抽取：长 chunk 产出实体数远超合理水位（污染下游消解 / 摘要 / 社区检测）。
+  2. 类型误分类：典型如 AI 产品 ``Claude`` 被标为 ``person``。
+
+本模块以三层正交防御提供后置纠偏：
+  - ``apply_type_overrides``：known_entities 白名单覆盖 + AI 产品正则兜底，纠正 LLM 类型。
+  - ``enforce_density_cap``：按 chunk 字符数动态截断实体数量，保留高 confidence。
+  - ``load_known_entities``：白名单加载器（lru_cache，模块级缓存）。
+
+模块对外接口稳定；规则数据维护在同目录 ``known_entities.yml`` 中（Single Source of Truth）。
+
+参考：
+  [1] Martinez-Rodriguez et al., "Information extraction meets the Semantic Web,"
+      Semantic Web J., vol. 9, no. 6, pp. 815-840, 2018.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+import structlog
+import yaml
+
+logger = structlog.get_logger(__name__)
+
+
+# ────────────────────────── 模块常量 ──────────────────────────
+
+KNOWN_ENTITIES_PATH: Path = Path(__file__).with_name("known_entities.yml")
+
+# AI 产品兜底规则：捕获 known_entities.yml 未覆盖的型号变体（如 "Claude 3.7 Sonnet"）。
+# 仅当 LLM 给出的类型为 person 时启用——避免误改正确的 product 类型。
+AI_PRODUCT_PATTERN: re.Pattern[str] = re.compile(
+    r"^(claude|gpt[- ]?\d?|chatgpt|gemini|llama|mistral|copilot|github\s+copilot|o1)"
+    r"(?:[- ]?[\w.]+)*$",
+    re.IGNORECASE,
+)
+
+# 密度上限：每 N 个字符允许 1 个核心实体；下界 3，避免极短 chunk 被砍光。
+DENSITY_CHARS_PER_ENTITY: int = 200
+DENSITY_MIN_FLOOR: int = 3
+
+
+# ────────────────────────── 数据结构 ──────────────────────────
+
+
+class _ConfidenceCarrier(Protocol):
+    """支持 enforce_density_cap 的最小协议：拥有 confidence 字段。"""
+
+    confidence: float
+
+
+@dataclass
+class ChunkExtractionStats:
+    """单个 chunk 抽取阶段的可观测数据，由 extractor 内部写入，由 service 聚合。
+
+    设计：可变 dataclass，便于跨函数累加；构造时全零，extractor 调用 ``_parse_entity_response``
+    时填充字段；service 层每 chunk 创建一个新实例传入。
+    """
+
+    type_override_count: int = 0
+    density_truncated: bool = False
+    density_dropped_count: int = 0
+    entity_density_per_kchar: float = 0.0  # 每千字符实体数（聚合 p95 用）
+
+
+# ────────────────────────── 白名单加载 ──────────────────────────
+
+
+@functools.lru_cache(maxsize=1)
+def load_known_entities(path: Path | None = None) -> dict[str, tuple[str, str]]:
+    """加载 known_entities.yml，返回 ``{normalized_name: (canonical_name, type)}``。
+
+    Args:
+        path: 可选覆盖路径（仅测试注入用）；生产固定读取模块同目录的 ``known_entities.yml``。
+
+    Returns:
+        归一化名（小写 + strip）到 ``(canonical_name, type)`` 的字典。
+        加载失败返回空字典（容错：白名单缺失不影响主流程）。
+    """
+    target = path or KNOWN_ENTITIES_PATH
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("known_entities_load_failed", path=str(target), error=str(exc))
+        return {}
+
+    table: dict[str, tuple[str, str]] = {}
+
+    def _ingest(entries: Iterable[dict], entity_type: str) -> None:
+        for entry in entries or ():
+            if not isinstance(entry, dict):
+                continue
+            name = (entry.get("name") or "").strip()
+            if not name:
+                continue
+            table[name.lower()] = (name, entity_type)
+            for alias in entry.get("aliases", []) or ():
+                if isinstance(alias, str) and alias.strip():
+                    table[alias.strip().lower()] = (name, entity_type)
+
+    _ingest(data.get("products", []), "product")
+    _ingest(data.get("organizations", []), "organization")
+    return table
+
+
+# ────────────────────────── 类型重判 ──────────────────────────
+
+
+def apply_type_overrides(name: str, llm_type: str) -> tuple[str, str | None]:
+    """对 LLM 标注的类型应用多层重判规则。
+
+    优先级：known_entities 白名单 > AI 产品 regex 兜底（仅修正 person）> 原样。
+
+    Args:
+        name: 实体名（取 LLM 输出原文，函数内部归一化匹配）。
+        llm_type: LLM 给出的类型字符串。
+
+    Returns:
+        ``(corrected_type, override_source)``：
+          - ``override_source`` 为 ``"known_entities"`` / ``"regex_rule"`` 表示发生改判；
+          - ``None`` 表示未改判。
+    """
+    if not name:
+        return llm_type, None
+
+    normalized = name.strip().lower()
+    known = load_known_entities()
+    hit = known.get(normalized)
+    if hit is not None:
+        _, canonical_type = hit
+        if canonical_type != llm_type:
+            return canonical_type, "known_entities"
+        return llm_type, None
+
+    if llm_type == "person" and AI_PRODUCT_PATTERN.match(name.strip()):
+        return "product", "regex_rule"
+
+    return llm_type, None
+
+
+# ────────────────────────── 密度截断 ──────────────────────────
+
+
+def compute_max_entities(chunk_len: int) -> int:
+    """按 chunk 字符数计算实体数量上限：``max(DENSITY_MIN_FLOOR, chunk_len // DENSITY_CHARS_PER_ENTITY)``。"""
+    return max(DENSITY_MIN_FLOOR, chunk_len // DENSITY_CHARS_PER_ENTITY)
+
+
+def enforce_density_cap(
+    results: list[_ConfidenceCarrier],
+    chunk_len: int,
+) -> tuple[list[_ConfidenceCarrier], int]:
+    """对实体列表按 chunk 字符数施加密度上限，按 confidence 降序保留高置信度项。
+
+    Args:
+        results: 待校验的实体结果列表（要求拥有 ``confidence`` 浮点字段）。
+        chunk_len: 当前 chunk 的字符数（用于推导上限）。
+
+    Returns:
+        ``(kept, dropped_count)``：被保留的实体列表与被截断的数量。
+        截断时按 confidence 降序保留，对相同 confidence 维持原序（稳定排序）。
+    """
+    if not results:
+        return results, 0
+
+    cap = compute_max_entities(chunk_len)
+    if len(results) <= cap:
+        return results, 0
+
+    # 稳定排序：confidence 降序，原 index 升序作为 tie-breaker。
+    indexed = list(enumerate(results))
+    indexed.sort(key=lambda pair: (-float(pair[1].confidence), pair[0]))
+    kept_indices = sorted(idx for idx, _ in indexed[:cap])
+    kept = [results[i] for i in kept_indices]
+    dropped = len(results) - len(kept)
+    return kept, dropped

--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -849,7 +849,7 @@ Output as JSON with the following structure:
                     chunk_len=chunk_len,
                     kept=len(results),
                     dropped=dropped,
-                    cap=len(results) + dropped - dropped,  # 即 cap = len(results)
+                    cap=len(results),
                 )
 
         # stats 回写（供 service 层聚合到 KgBuildMetrics）

--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
     pass
 
 from ..types import GraphEdge, GraphNode, KgEntityType, KgRelationType
+from .extraction_validator import (
+    ChunkExtractionStats,
+    apply_type_overrides,
+    enforce_density_cap,
+)
 
 logger = get_logger("negentropy.knowledge.llm_extractors")
 
@@ -466,6 +471,29 @@ Important:
 - Only include entities explicitly mentioned in the text
 - Assign confidence based on how clearly the entity is identified
 
+Density guideline (precision over recall):
+- Aim for at most ~1 core entity per 200 characters of input.
+- A chunk of ~1000 characters should rarely exceed 5-6 entities.
+- Prefer fewer high-confidence entities over exhaustive listing; downstream
+  pipelines (entity resolution, community detection, summarization) suffer more
+  from false positives than from minor recall gaps.
+
+Classification guideline (resolve common confusions):
+- AI models / products → product, NOT person.
+  Examples: Claude, GPT-4, GPT-4o, Gemini, Llama, Mistral, ChatGPT, Copilot, o1.
+- AI vendors / labs → organization, NOT person.
+  Examples: Anthropic, OpenAI, Google DeepMind, Meta AI, Mistral AI.
+- Real human individuals (full names of identifiable people) → person.
+  Examples: Sam Altman, Dario Amodei, Yann LeCun.
+- Frameworks / libraries / CLI tools → product.
+  Examples: LangChain, LlamaIndex, Next.js, Playwright, Claude Code.
+
+Reasoning steps (think silently, output only JSON):
+1. List candidate mentions you see in the text.
+2. For each candidate, ask: "Is this a human individual, an organization, an AI model/product, or a generic concept?"
+3. Drop generic terms, duplicates, and noise (see CRITICAL section below).
+4. Emit at most what the density guideline allows; if you must trim, keep the highest-confidence ones.
+
 CRITICAL — Avoid noise extraction:
 - Do NOT extract generic terms or common abbreviations such as "CSS", "HTML", "JSON",
   "API", "UI", "app", "key", "spec", "config", "panel", "button", "agent", "generator",
@@ -563,6 +591,8 @@ Output as JSON with the following structure:
         self,
         text: str,
         corpus_id: UUID,
+        *,
+        stats_out: ChunkExtractionStats | None = None,
     ) -> list[GraphNode]:
         """从文本中提取实体节点
 
@@ -571,6 +601,8 @@ Output as JSON with the following structure:
         Args:
             text: 输入文本
             corpus_id: 语料库 ID
+            stats_out: 可选的 chunk 级 stats 收集器；service 层每 chunk 创建一个空实例
+                传入，调用结束后读取累计的 type_override_count / density_truncated 等字段。
 
         Returns:
             提取的实体节点列表
@@ -585,7 +617,7 @@ Output as JSON with the following structure:
         )
 
         try:
-            results = await self._extract_with_llm(text)
+            results = await self._extract_with_llm(text, stats=stats_out)
 
             entities = []
             seen = set()
@@ -598,18 +630,22 @@ Output as JSON with the following structure:
                 # 生成稳定的实体 ID（基于名称哈希）
                 entity_id = self._generate_entity_id(name, corpus_id)
 
+                metadata: dict[str, Any] = {
+                    "description": result.description,
+                    "confidence": result.confidence,
+                    "source": "llm_extraction",
+                    "source_text": result.source_text,
+                    "corpus_id": str(corpus_id),
+                    "model": self._model,
+                }
+                # 透传后置校验信号（type_override_source / original_type），便于审计回滚
+                metadata.update(result.metadata)
+
                 entity = GraphNode(
                     id=entity_id,
                     label=name,
                     node_type=result.entity_type,
-                    metadata={
-                        "description": result.description,
-                        "confidence": result.confidence,
-                        "source": "llm_extraction",
-                        "source_text": result.source_text,
-                        "corpus_id": str(corpus_id),
-                        "model": self._model,
-                    },
+                    metadata=metadata,
                 )
                 entities.append(entity)
                 seen.add(name)
@@ -636,11 +672,16 @@ Output as JSON with the following structure:
 
             raise
 
-    async def _extract_with_llm(self, text: str) -> list[EntityExtractionResult]:
+    async def _extract_with_llm(
+        self,
+        text: str,
+        stats: ChunkExtractionStats | None = None,
+    ) -> list[EntityExtractionResult]:
         """使用 LLM 提取实体
 
         Args:
             text: 输入文本
+            stats: 可选 stats 收集器，转发给 ``_parse_entity_response`` 写入。
 
         Returns:
             实体提取结果列表
@@ -649,6 +690,7 @@ Output as JSON with the following structure:
 
         # Token 感知截断：英文 4000 chars ≈ 1000 token（浪费），CJK 4000 chars ≈ 2000 token（风险）
         truncated_text = _truncate_to_token_limit(text, max_tokens=3500)
+        chunk_len = len(truncated_text)
 
         prompt = self.EXTRACTION_PROMPT.format(text=truncated_text)
 
@@ -705,7 +747,7 @@ Output as JSON with the following structure:
                 )
 
                 content = response.choices[0].message.content
-                return self._parse_entity_response(content)
+                return self._parse_entity_response(content, chunk_len=chunk_len, stats=stats)
 
             except Exception as exc:
                 last_error = exc
@@ -723,14 +765,22 @@ Output as JSON with the following structure:
 
         raise RuntimeError(f"LLM entity extraction failed after {self._max_retries} retries: {last_error}")
 
-    def _parse_entity_response(self, content: str) -> list[EntityExtractionResult]:
-        """解析 LLM 响应为实体列表
+    def _parse_entity_response(
+        self,
+        content: str,
+        chunk_len: int = 0,
+        stats: ChunkExtractionStats | None = None,
+    ) -> list[EntityExtractionResult]:
+        """解析 LLM 响应为实体列表，并应用后置校验（类型重判 + 密度截断）。
 
         Args:
             content: LLM 返回的 JSON 字符串
+            chunk_len: 当前 chunk 的字符长度，用于推导密度上限；为 0 时不做密度截断
+                （便于单元测试与 corpus 外的 ad-hoc 调用复用）。
+            stats: 可选的 stats 收集器；若提供，本函数会累加 type_override_count 等字段。
 
         Returns:
-            实体提取结果列表
+            实体提取结果列表（已应用噪声过滤、类型重判与密度截断）。
         """
         try:
             data = json.loads(content)
@@ -744,6 +794,7 @@ Output as JSON with the following structure:
 
         results = []
         filtered_count = 0
+        type_override_count = 0
         for entity_data in entities:
             if not isinstance(entity_data, dict):
                 continue
@@ -761,12 +812,23 @@ Output as JSON with the following structure:
             if entity_type not in KgEntityType.all_values():
                 entity_type = KgEntityType.OTHER.value
 
+            # 类型重判：known_entities 白名单覆盖 + AI 产品 regex 兜底
+            original_type = entity_type
+            corrected_type, override_source = apply_type_overrides(name, entity_type)
+            entity_type = corrected_type
+            metadata: dict[str, Any] = {}
+            if override_source is not None:
+                metadata["type_override_source"] = override_source
+                metadata["original_type"] = original_type
+                type_override_count += 1
+
             result = EntityExtractionResult(
                 name=name,
                 entity_type=entity_type,
                 description=entity_data.get("description"),
                 confidence=float(entity_data.get("confidence", 1.0)),
                 source_text=entity_data.get("source_text"),
+                metadata=metadata,
             )
             results.append(result)
 
@@ -776,6 +838,28 @@ Output as JSON with the following structure:
                 filtered_count=filtered_count,
                 kept_count=len(results),
             )
+
+        # 密度截断（chunk_len > 0 时启用）
+        dropped = 0
+        if chunk_len > 0 and results:
+            results, dropped = enforce_density_cap(results, chunk_len)
+            if dropped:
+                logger.warning(
+                    "entity_density_truncated",
+                    chunk_len=chunk_len,
+                    kept=len(results),
+                    dropped=dropped,
+                    cap=len(results) + dropped - dropped,  # 即 cap = len(results)
+                )
+
+        # stats 回写（供 service 层聚合到 KgBuildMetrics）
+        if stats is not None:
+            stats.type_override_count += type_override_count
+            stats.density_dropped_count += dropped
+            stats.density_truncated = stats.density_truncated or dropped > 0
+            if chunk_len > 0:
+                stats.entity_density_per_kchar = (len(results) / chunk_len) * 1000.0
+
         return results
 
     def _generate_entity_id(self, name: str, corpus_id: UUID) -> str:
@@ -869,6 +953,8 @@ Important:
 - Only create relationships between entities from the provided list
 - Use the most specific and descriptive relationship type available
 - Include the exact text evidence when possible
+- Limit total relations to at most ceil(entity_count * 1.2); skip weak or inferred links
+  to avoid combinatorial pairing. Quality beats quantity.
 
 Output as JSON with the following structure:
 {{"relations": [{{"source": "...", "target": "...", "type": "...",
@@ -1268,18 +1354,21 @@ class CompositeEntityExtractor:
         self,
         text: str,
         corpus_id: UUID,
+        *,
+        stats_out: ChunkExtractionStats | None = None,
     ) -> list[GraphNode]:
         """从文本中提取实体
 
         Args:
             text: 输入文本
             corpus_id: 语料库 ID
+            stats_out: 可选的 chunk 级 stats 收集器，仅在 LLM 抽取路径下生效。
 
         Returns:
             提取的实体节点列表
         """
         if self._enable_llm and self._llm_extractor:
-            return await self._llm_extractor.extract(text, corpus_id)
+            return await self._llm_extractor.extract(text, corpus_id, stats_out=stats_out)
 
         # 禁用 LLM 时直接使用正则
         from .strategy import RegexEntityExtractor

--- a/apps/negentropy/src/negentropy/knowledge/graph/known_entities.yml
+++ b/apps/negentropy/src/negentropy/knowledge/graph/known_entities.yml
@@ -1,0 +1,56 @@
+# Knowledge Graph 已知实体白名单（Single Source of Truth）
+#
+# 用途：当 LLM 抽取的实体命中此白名单时，使用此处声明的 canonical name 与 type，
+# 覆盖 LLM 给出的（可能错误的）分类。例如：Claude 被 LLM 标为 person → 改判 product。
+#
+# 维护原则：
+#   1. 仅收录"高频且 LLM 易误判"的实体（AI 产品、AI 机构、知名框架等）。
+#   2. 别名匹配大小写不敏感、忽略首尾空白。
+#   3. canonical name 使用最常见的书写形式（如 "GPT-4" 而非 "gpt4"）。
+#
+# 当出现新的误判 case，请在此追加一条；勿在代码中硬编码。
+
+products:
+  # Anthropic
+  - name: "Claude"
+    aliases: ["Claude 3", "Claude 3.5", "Claude 3.7", "Claude Opus", "Claude Sonnet", "Claude Haiku"]
+  - name: "Claude Code"
+
+  # OpenAI
+  - name: "GPT-4"
+    aliases: ["GPT-4o", "GPT-4 Turbo", "GPT-4.1", "GPT-4o mini"]
+  - name: "ChatGPT"
+  - name: "o1"
+    aliases: ["o1-preview", "o1-mini"]
+
+  # Google
+  - name: "Gemini"
+    aliases: ["Gemini Pro", "Gemini Ultra", "Gemini 1.5", "Gemini 2.0"]
+
+  # Meta
+  - name: "Llama"
+    aliases: ["Llama 2", "Llama 3", "Llama 3.1", "LLaMA"]
+
+  # Mistral
+  - name: "Mistral"
+    aliases: ["Mistral 7B", "Mixtral"]
+
+  # GitHub / Microsoft
+  - name: "GitHub Copilot"
+    aliases: ["Copilot"]
+
+  # 开发框架 / 工具（易被 LLM 当人名或概念）
+  - name: "LangChain"
+  - name: "LlamaIndex"
+  - name: "Next.js"
+  - name: "Playwright"
+
+organizations:
+  - name: "Anthropic"
+  - name: "OpenAI"
+  - name: "Google DeepMind"
+    aliases: ["DeepMind"]
+  - name: "Meta AI"
+  - name: "Mistral AI"
+  - name: "Microsoft"
+  - name: "GitHub"

--- a/apps/negentropy/src/negentropy/knowledge/graph/metrics.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/metrics.py
@@ -32,5 +32,10 @@ class KgBuildMetrics:
     community_levels: int = 0
     community_count_by_level: dict[int, int] = field(default_factory=dict)
 
+    # ── 抽取质量观测（来源：extraction_validator 后置校验信号） ──
+    over_extraction_chunks: int = 0  # 触发密度截断的 chunk 数
+    type_override_count: int = 0  # known_entities / regex 改判次数（按实体计）
+    entity_density_p95: float = 0.0  # 单 chunk 实体数 / chunk 字符长度 × 1000 的 P95
+
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -432,6 +432,11 @@ class GraphService:
             chunks_fallback = 0
             total_chunks = len(chunks)
 
+            # 抽取质量观测累加器（由 process_chunk 内 nonlocal 写入；聚合到 KgBuildMetrics）
+            over_extraction_chunks = 0
+            type_override_count = 0
+            density_samples: list[float] = []
+
             batch_size = build_config.batch_size
             semaphore = asyncio.Semaphore(build_config.max_concurrency)
 
@@ -635,6 +640,7 @@ class GraphService:
                 emit_phase 阶段边界承担（最长 1 个 phase 周期感知）。
                 """
                 nonlocal chunks_fallback
+                nonlocal over_extraction_chunks, type_override_count
 
                 if is_cancelled(run_id):
                     raise PipelineCancelled(run_id, last_stage="extracting")
@@ -685,11 +691,30 @@ class GraphService:
                     relations: list[GraphEdge] = []
 
                     try:
-                        # 提取实体（带超时）
+                        # 提取实体（带超时）+ 收集 chunk 级抽取质量信号（密度截断 / 类型重判）
+                        from .extraction_validator import ChunkExtractionStats
+
+                        chunk_stats = ChunkExtractionStats()
                         entities = await asyncio.wait_for(
-                            entity_extractor.extract(text, corpus_id),
+                            entity_extractor.extract(text, corpus_id, stats_out=chunk_stats),
                             timeout=chunk_extract_timeout,
                         )
+                        # 抽取质量信号累加（同协程内 await 之后立即累加，与下游 nonlocal 互不冲突）
+                        if chunk_stats.density_truncated:
+                            over_extraction_chunks += 1
+                        type_override_count += chunk_stats.type_override_count
+                        if chunk_stats.entity_density_per_kchar > 0.0:
+                            density_samples.append(chunk_stats.entity_density_per_kchar)
+                        if chunk_stats.density_truncated or chunk_stats.type_override_count:
+                            logger.warning(
+                                "chunk_extraction_quality_signal",
+                                run_id=run_id,
+                                chunk_id=chunk_id,
+                                density_truncated=chunk_stats.density_truncated,
+                                density_dropped=chunk_stats.density_dropped_count,
+                                type_overrides=chunk_stats.type_override_count,
+                                density_per_kchar=round(chunk_stats.entity_density_per_kchar, 2),
+                            )
                         # 过滤低置信度实体
                         min_conf = build_config.min_entity_confidence
                         entities = [e for e in entities if e.metadata.get("confidence", 1.0) >= min_conf]
@@ -1255,6 +1280,15 @@ class GraphService:
                 if entities_to_save
                 else 0.0
             )
+            # 抽取密度 P95（按千字符实体数）：样本不足 2 时退化为 max
+            if len(density_samples) >= 2:
+                from statistics import quantiles
+
+                # n=20 → 19 个切点，第 18 个即 P95；列表长度 < 20 时 quantiles 仍可用
+                density_p95 = quantiles(density_samples, n=20, method="inclusive")[18]
+            else:
+                density_p95 = max(density_samples) if density_samples else 0.0
+
             build_metrics = KgBuildMetrics(
                 entity_count=len(entities_to_save),
                 relation_count=len(valid_relations),
@@ -1268,6 +1302,9 @@ class GraphService:
                 algorithm_warnings=sum(1 for w in _strip_phase_entries(build_warnings) if "algorithm" in w),
                 community_levels=len(levels_data),
                 community_count_by_level={lv: len(set(p.values())) for lv, p in levels_data.items()},
+                over_extraction_chunks=over_extraction_chunks,
+                type_override_count=type_override_count,
+                entity_density_p95=round(density_p95, 2),
             )
 
             # 更新构建运行状态

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_validator.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_validator.py
@@ -106,14 +106,23 @@ class TestApplyTypeOverrides:
         assert source is None
 
     def test_ai_product_pattern_explicit_cases(self) -> None:
-        """直接验证正则覆盖范围，避免回归。"""
-        assert AI_PRODUCT_PATTERN.match("Claude")
+        """正则仅兜底带版本/规格后缀的型号变体；裸名由 known_entities 白名单覆盖。"""
+        # 带版本号或规格后缀的型号变体应命中
         assert AI_PRODUCT_PATTERN.match("GPT-4")
-        assert AI_PRODUCT_PATTERN.match("ChatGPT")
+        assert AI_PRODUCT_PATTERN.match("GPT-4o")
         assert AI_PRODUCT_PATTERN.match("Gemini Pro")
+        assert AI_PRODUCT_PATTERN.match("Gemini 1.5 Flash")
         assert AI_PRODUCT_PATTERN.match("Llama 3.1")
         assert AI_PRODUCT_PATTERN.match("o1-preview")
-        # 真人名不应命中
+        assert AI_PRODUCT_PATTERN.match("Claude 3.7 Sonnet")
+        # 裸名不再命中正则（由 known_entities 白名单接管）
+        assert not AI_PRODUCT_PATTERN.match("Claude")
+        assert not AI_PRODUCT_PATTERN.match("ChatGPT")
+        # 真人复合名（首段虽命中触发词，但尾段为非型号 token）不应命中
+        assert not AI_PRODUCT_PATTERN.match("Claude Shannon")
+        assert not AI_PRODUCT_PATTERN.match("Claude Monet")
+        assert not AI_PRODUCT_PATTERN.match("Gemini Cricket")
+        # 完全无触发词的真人名也不应命中
         assert not AI_PRODUCT_PATTERN.match("Sam Altman")
         assert not AI_PRODUCT_PATTERN.match("Yann LeCun")
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_validator.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_validator.py
@@ -1,0 +1,262 @@
+"""KG 实体抽取后置校验单元测试（extraction_validator）
+
+覆盖：
+  1. known_entities 白名单覆盖（Claude/person → product）
+  2. AI 产品 regex 兜底（型号变体 + 仅对 person 生效）
+  3. 密度截断（按 chunk 字符数动态上限 + 按 confidence 降序保留）
+  4. 边界与容错
+  5. ``_parse_entity_response`` 端到端集成（验证 metadata 透传与 stats 回写）
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from negentropy.knowledge.graph.extraction_validator import (
+    AI_PRODUCT_PATTERN,
+    ChunkExtractionStats,
+    apply_type_overrides,
+    compute_max_entities,
+    enforce_density_cap,
+    load_known_entities,
+)
+
+
+@dataclass
+class _FakeResult:
+    """符合 enforce_density_cap 协议的最小实现（带 confidence）。"""
+
+    name: str
+    confidence: float
+
+
+# ────────────────────────── known_entities 加载 ──────────────────────────
+
+
+class TestLoadKnownEntities:
+    def test_known_entities_yaml_loaded_with_aliases(self) -> None:
+        """从仓库内 known_entities.yml 加载，应至少命中 Claude / Anthropic 等典型 case。"""
+        load_known_entities.cache_clear()
+        table = load_known_entities()
+
+        assert "claude" in table
+        assert table["claude"] == ("Claude", "product")
+        # 别名同样命中
+        assert "claude 3.5" in table
+        assert table["claude 3.5"] == ("Claude", "product")
+
+        assert "anthropic" in table
+        assert table["anthropic"] == ("Anthropic", "organization")
+
+    def test_load_missing_file_returns_empty(self, tmp_path) -> None:
+        """缺失白名单文件时应静默降级为空表（不影响主流程）。"""
+        load_known_entities.cache_clear()
+        missing = tmp_path / "not_exists.yml"
+        assert load_known_entities(missing) == {}
+        load_known_entities.cache_clear()
+
+
+# ────────────────────────── apply_type_overrides ──────────────────────────
+
+
+class TestApplyTypeOverrides:
+    def setup_method(self) -> None:
+        load_known_entities.cache_clear()
+
+    def test_known_entity_override_person_to_product(self) -> None:
+        """核心场景：Claude 被 LLM 标为 person，白名单改判为 product。"""
+        corrected, source = apply_type_overrides("Claude", "person")
+        assert corrected == "product"
+        assert source == "known_entities"
+
+    def test_known_entity_alias_case_insensitive(self) -> None:
+        corrected, source = apply_type_overrides("claude 3.5", "person")
+        assert corrected == "product"
+        assert source == "known_entities"
+
+    def test_known_entity_no_change_when_already_correct(self) -> None:
+        """LLM 已给出正确类型时不动也不标 override。"""
+        corrected, source = apply_type_overrides("Claude", "product")
+        assert corrected == "product"
+        assert source is None
+
+    def test_regex_fallback_for_unseen_ai_product(self) -> None:
+        """型号变体（白名单未列）+ LLM 标 person → 正则兜底为 product。"""
+        corrected, source = apply_type_overrides("Claude 3.7 Sonnet", "person")
+        assert corrected == "product"
+        assert source == "regex_rule"
+
+    def test_regex_does_not_touch_non_person_types(self) -> None:
+        """LLM 标的不是 person 时不触发正则兜底（避免误改 concept 等）。"""
+        corrected, source = apply_type_overrides("Claude 3.7 Sonnet", "concept")
+        assert corrected == "concept"
+        assert source is None
+
+    def test_real_person_not_misclassified(self) -> None:
+        """真人名（不匹配 AI 产品 regex）保持 person 类型。"""
+        corrected, source = apply_type_overrides("Sam Altman", "person")
+        assert corrected == "person"
+        assert source is None
+
+    def test_empty_name_returns_unchanged(self) -> None:
+        corrected, source = apply_type_overrides("", "person")
+        assert corrected == "person"
+        assert source is None
+
+    def test_ai_product_pattern_explicit_cases(self) -> None:
+        """直接验证正则覆盖范围，避免回归。"""
+        assert AI_PRODUCT_PATTERN.match("Claude")
+        assert AI_PRODUCT_PATTERN.match("GPT-4")
+        assert AI_PRODUCT_PATTERN.match("ChatGPT")
+        assert AI_PRODUCT_PATTERN.match("Gemini Pro")
+        assert AI_PRODUCT_PATTERN.match("Llama 3.1")
+        assert AI_PRODUCT_PATTERN.match("o1-preview")
+        # 真人名不应命中
+        assert not AI_PRODUCT_PATTERN.match("Sam Altman")
+        assert not AI_PRODUCT_PATTERN.match("Yann LeCun")
+
+
+# ────────────────────────── 密度截断 ──────────────────────────
+
+
+class TestEnforceDensityCap:
+    def test_compute_max_entities_formula(self) -> None:
+        assert compute_max_entities(1000) == 5  # 1000 // 200
+        assert compute_max_entities(1137) == 5  # chunk 6 复现：1137 // 200 = 5
+        assert compute_max_entities(2400) == 12
+        # 下界保护
+        assert compute_max_entities(200) == 3
+        assert compute_max_entities(0) == 3
+        assert compute_max_entities(50) == 3
+
+    def test_below_cap_passes_through(self) -> None:
+        results = [_FakeResult(f"e{i}", 0.9) for i in range(3)]
+        kept, dropped = enforce_density_cap(results, chunk_len=1000)
+        assert len(kept) == 3
+        assert dropped == 0
+
+    def test_above_cap_truncates_by_confidence(self) -> None:
+        """超出上限时按 confidence 降序保留。"""
+        results = [
+            _FakeResult("low", 0.2),
+            _FakeResult("hi1", 0.95),
+            _FakeResult("mid", 0.6),
+            _FakeResult("hi2", 0.9),
+            _FakeResult("very_low", 0.1),
+        ]
+        # chunk_len=400 → cap = max(3, 2) = 3
+        kept, dropped = enforce_density_cap(results, chunk_len=400)
+        assert dropped == 2
+        assert len(kept) == 3
+        kept_names = {r.name for r in kept}
+        assert kept_names == {"hi1", "hi2", "mid"}
+
+    def test_chunk_6_reproduction(self) -> None:
+        """复现实际 issue：1137 字符 + 16 实体 → 截断到 5。"""
+        results = [_FakeResult(f"e{i}", 0.9 - i * 0.01) for i in range(16)]
+        kept, dropped = enforce_density_cap(results, chunk_len=1137)
+        assert len(kept) == 5
+        assert dropped == 11
+        # 应保留 confidence 最高的前 5 个（按 confidence 降序后）
+        assert {r.name for r in kept} == {"e0", "e1", "e2", "e3", "e4"}
+
+    def test_stable_sort_keeps_original_order_for_ties(self) -> None:
+        """相同 confidence 时保留原 index 较小者，输出按原序。"""
+        results = [_FakeResult(f"e{i}", 0.5) for i in range(5)]
+        kept, _ = enforce_density_cap(results, chunk_len=400)  # cap=3
+        assert [r.name for r in kept] == ["e0", "e1", "e2"]
+
+    def test_empty_list(self) -> None:
+        kept, dropped = enforce_density_cap([], chunk_len=1000)
+        assert kept == []
+        assert dropped == 0
+
+
+# ────────────────────────── ChunkExtractionStats ──────────────────────────
+
+
+class TestChunkExtractionStats:
+    def test_default_values(self) -> None:
+        stats = ChunkExtractionStats()
+        assert stats.type_override_count == 0
+        assert stats.density_truncated is False
+        assert stats.density_dropped_count == 0
+        assert stats.entity_density_per_kchar == 0.0
+
+    def test_fields_are_mutable(self) -> None:
+        """Stats 必须可变以便 extractor 写入累加。"""
+        stats = ChunkExtractionStats()
+        stats.type_override_count += 1
+        stats.density_truncated = True
+        assert stats.type_override_count == 1
+        assert stats.density_truncated is True
+
+
+# ────────────────────────── _parse_entity_response 集成 ──────────────────────────
+
+
+class TestParseEntityResponseIntegration:
+    """验证 validator 与 LLMEntityExtractor._parse_entity_response 的端到端衔接。"""
+
+    def setup_method(self) -> None:
+        load_known_entities.cache_clear()
+
+    def test_claude_person_corrected_in_parse(self) -> None:
+        """LLM 输出 Claude/person，解析后应改判为 product 并在 metadata 标记 override 源。"""
+        import json
+
+        from negentropy.knowledge.graph.extractors import LLMEntityExtractor
+
+        extractor = LLMEntityExtractor(fallback_to_regex=False)
+        payload = json.dumps(
+            {
+                "entities": [
+                    {"name": "Claude", "type": "person", "confidence": 0.9},
+                    {"name": "Sam Altman", "type": "person", "confidence": 0.85},
+                ]
+            }
+        )
+        stats = ChunkExtractionStats()
+        results = extractor._parse_entity_response(payload, chunk_len=500, stats=stats)
+
+        names = {r.name: r for r in results}
+        assert names["Claude"].entity_type == "product"
+        assert names["Claude"].metadata["type_override_source"] == "known_entities"
+        assert names["Claude"].metadata["original_type"] == "person"
+        # 真人名不应被改
+        assert names["Sam Altman"].entity_type == "person"
+        assert "type_override_source" not in names["Sam Altman"].metadata
+        # stats 已累加
+        assert stats.type_override_count == 1
+
+    def test_density_truncation_in_parse(self) -> None:
+        """解析阶段对超密度 chunk 应触发截断并填充 stats。"""
+        import json
+
+        from negentropy.knowledge.graph.extractors import LLMEntityExtractor
+
+        extractor = LLMEntityExtractor(fallback_to_regex=False)
+        entities = [{"name": f"Entity{i}", "type": "concept", "confidence": 0.9 - i * 0.01} for i in range(16)]
+        payload = json.dumps({"entities": entities})
+        stats = ChunkExtractionStats()
+
+        # 复现 chunk 6：1137 字符上限 5
+        results = extractor._parse_entity_response(payload, chunk_len=1137, stats=stats)
+        assert len(results) == 5
+        assert stats.density_truncated is True
+        assert stats.density_dropped_count == 11
+        assert stats.entity_density_per_kchar == pytest.approx(5 / 1137 * 1000, rel=1e-3)
+
+    def test_chunk_len_zero_disables_truncation(self) -> None:
+        """chunk_len=0（ad-hoc 调用）时不应截断。"""
+        import json
+
+        from negentropy.knowledge.graph.extractors import LLMEntityExtractor
+
+        extractor = LLMEntityExtractor(fallback_to_regex=False)
+        entities = [{"name": f"Entity{i}", "type": "concept", "confidence": 0.9} for i in range(10)]
+        payload = json.dumps({"entities": entities})
+        results = extractor._parse_entity_response(payload, chunk_len=0, stats=None)
+        assert len(results) == 10


### PR DESCRIPTION
# 背景

- **本次变更要解决的问题**：构建 Harness Engineering 语料图谱时暴露两类 LLM 抽取质量缺陷——chunk 6（1137 字符）产出 16 实体 / 15 关系（过度抽取，密度约 71 字符/实体），且 \`Claude\`（AI 产品）被分类为 \`person\`。这些假阳实体会污染下游 entity_resolver → community_summarizer → context_builder 整条链路，且现有噪声过滤与置信度阈值无法解决类型层的错误。
- **关联上下文/Issue/文档**：延续 #532（按语料库配置 LLM/Embedding 模型）后续质量调优。设计参考 Martinez-Rodriguez 等（_Semantic Web J._, 2018）的 Schema-Guided Extraction 范式，以及 Neo4j LLM-Graph-Builder 的 schema-first 默认设计。

# 核心变更

- **Prompt 工程**：实体抽取 Prompt 增加密度引导（每 200 字符约 1 个核心实体）、AI 产品/机构 vs 真人名的分类引导与正反例、Chain-of-Thought 推理步骤；关系抽取 Prompt 增加 \`⌈|E|×1.2⌉\` 上限避免组合配对爆炸。
- **后置校验防御层**（新增 [\`extraction_validator.py\`](apps/negentropy/src/negentropy/knowledge/graph/extraction_validator.py)）：white-list 覆盖 LLM 错判（\`Claude/person → product\`）、AI 产品 regex 兜底未列型号变体（\`Claude 3.7 Sonnet\` 等）、按 \`max(3, chunk_len // 200)\` 的密度截断（按 confidence 降序保留）。被纠偏的实体在 metadata 标记 \`type_override_source\` 与 \`original_type\` 以支持审计回滚。
- **数据 SSOT**（新增 [\`known_entities.yml\`](apps/negentropy/src/negentropy/knowledge/graph/known_entities.yml)）：维护 AI 产品 / 机构白名单（Claude / GPT-4 / Anthropic / OpenAI 等），代码不再硬编码；后续仅需追加 YAML 条目。
- **可观测性**：\`KgBuildMetrics\` 扩展 \`over_extraction_chunks\` / \`type_override_count\` / \`entity_density_p95\` 三个观测字段；service 层每 chunk 抽取后聚合，触发密度截断或类型改判时 WARN 日志。
- **接口契约**：\`LLMEntityExtractor.extract\` / \`CompositeEntityExtractor.extract\` 增加 keyword-only \`stats_out: ChunkExtractionStats | None\` 参数，向后兼容，仅 service 调用方主动传入。

# 风险与回滚

- **主要风险**：① 白名单不全导致漏判（缓解：保留 \`original_type\` metadata，可审计后补录）；② 密度上限对术语极密集 chunk 误伤（缓解：\`max(3, …)\` 下界 + 命中时 WARN，可按 corpus 调整 \`DENSITY_CHARS_PER_ENTITY\`）；③ Prompt 增量约 30 行 → token 成本上升 < 5%。
- **回滚方式**：单 commit \`8b0cbddb\` 完整覆盖六个文件，\`git revert\` 即可恢复；改动均为新 build 增量生效，不影响历史构建产物。

# 验证证据

- **单元测试**：新增 21 项单测覆盖白名单加载、类型重判（含 chunk 6 复现 \`16 → 5\`）、密度截断、边界与 \`_parse_entity_response\` 端到端集成。\`uv run pytest tests/unit_tests/knowledge/test_extraction_validator.py\` 全绿。
- **集成测试**：\`uv run pytest tests/unit_tests/knowledge/\` 全量 784 通过 / 0 回归（唯一失败 \`test_extraction_llm_plan.py\` 经 \`git stash\` 验证为 pre-existing，与本 PR 无关）。
- **E2E/Workflow**：待此 PR 合入后在 Harness Engineering corpus 上重新构建，对照 \`over_extraction_chunks\` / \`type_override_count\` / \`entity_density_p95\` 字段验证效果。
- **覆盖率**：\`extraction_validator.py\` 单测覆盖率 97%。

# 影响范围

- **前端**：无。
- **后端**：\`apps/negentropy/src/negentropy/knowledge/graph/\` 下 extractors / metrics / service 三处改动 + validator / known_entities 两处新增。仅作用于 LLM 抽取路径，fallback（regex / cooccurrence）路径不受影响。
- **GitHub Actions / 文档**：无配置变更；ruff lint / format pre-commit hook 全过。

# Next Best Action

- 合入后在 Harness Engineering corpus 触发一次重新构建，抽样 5-10 个 \`product\` 类型节点人工核验命名合理性；若出现新误判 case，仅需追加 \`known_entities.yml\` 即可，无需改代码。
- 后续可在 \`extraction_schema.py\` 注册 \`HARNESS_ENGINEERING_SCHEMA\` 作为独立 PR，把领域感知 schema 与本次的通用纠偏分层解耦。