### PR TITLE
fix(knowledge-graph): 修复 KG 构建管线四项级联缺陷（事务/端点流失/日志/退避）

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py
@@ -64,6 +64,14 @@ class CommunitySummarizer:
     对 Louvain 社区检测结果生成 LLM 摘要，支持全局检索模式。
     若注入 ``embedding_fn``，会在持久化时同步计算并写入 summary embedding，
     供后续 GlobalSearchService 的 Map 阶段做余弦排序。
+
+    事务边界（重要）：
+        本类仅负责 SQL 写入，**不在内部 commit**。调用方负责事务上下文：
+        典型用法是在 ``_session_scope()`` 上下文内调用 ``summarize_communities``，
+        由 session_scope 出口统一 commit / 异常路径 rollback。
+        理由：旧实现内部 ``db.commit()`` 与外层 ``async with session.begin():``
+        双重事务管理会触发 SQLAlchemy ``A transaction is already begun on this
+        Session`` 异常（参见 plan: kg-build-fix 缺陷 1）。
     """
 
     def __init__(
@@ -115,7 +123,10 @@ class CommunitySummarizer:
             try:
                 summary, used_fallback = await self._summarize_one(0, fallback_entities)
                 emb_failed = await self._persist_summary(db, corpus_id, summary, level=0)
-                await db.commit()
+                # 事务边界已上移到调用方（service.py 的 _session_scope() 出口统一 commit）：
+                # 旧实现在此处 ``await db.commit()`` 与外层 ``async with session.begin():``
+                # 双重事务管理会触发 ``A transaction is already begun on this Session``。
+                # 改由调用方持有事务上下文，本方法仅负责写入。
                 result: dict[str, Any] = {"communities_summarized": 1, "errors": 0}
                 if emb_failed:
                     result["embeddings_failed"] = 1
@@ -155,7 +166,7 @@ class CommunitySummarizer:
                     error=str(exc),
                 )
 
-        await db.commit()
+        # 事务边界由调用方持有（_session_scope 上下文出口统一 commit）。
 
         logger.info(
             "communities_summarized",
@@ -242,7 +253,7 @@ class CommunitySummarizer:
                         error=str(exc),
                     )
 
-        await db.commit()
+        # 事务边界由调用方持有（_session_scope 上下文出口统一 commit）。
 
         logger.info(
             "multi_level_communities_summarized",

--- a/apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py
@@ -123,6 +123,33 @@ def _should_merge_by_tokens(
     return False
 
 
+def _flatten_chain(chain: dict[str, str]) -> dict[str, str]:
+    """展平传递映射链：A→B, B→C, C→D ⇒ A→D, B→D, C→D。
+
+    用于 label 与 id 两条链路的统一收尾，确保下游 _resolve_ref / 关系端点重写
+    能够一步跳到最终存留节点，避免中间节点丢失导致解析失败。
+
+    Args:
+        chain: 单跳映射字典（可能包含 A→B 与 B→C 同时存在的多跳链）。
+
+    Returns:
+        展平后的字典：每个 key 直接指向链路终点；环路被防御性截断。
+    """
+    flat: dict[str, str] = {}
+    for src, dst in chain.items():
+        current = dst
+        visited = {src, dst}
+        # 沿链路前推直至终点（无后继）或检测到环（防御性截断）。
+        while current in chain:
+            nxt = chain[current]
+            if nxt in visited:
+                break
+            visited.add(nxt)
+            current = nxt
+        flat[src] = current
+    return flat
+
+
 # Unicode NFC + 小写 + 去除首尾空白的规范化
 def normalize_label(label: str) -> str:
     """规范化实体标签：NFC + 小写 + 去空白 + 去法人后缀"""
@@ -142,10 +169,25 @@ def blocking_key(entity: GraphNode) -> str:
 
 
 class ResolutionResult(NamedTuple):
-    """实体消解结果：包含存留实体列表与合并映射"""
+    """实体消解结果：包含存留实体列表与合并映射
+
+    Fields:
+        entities: 经多策略去重后的存留实体列表。
+        merge_map: 旧实体标签 → 存留实体标签的映射（传递链已展平）。
+            供 GraphRAG 双写 / 标签级关系重写使用。
+        id_merge_map: 旧实体 ID → 存留实体 ID 的映射（传递链已展平）。
+            **关系端点重写的权威映射**。覆盖三个 stage：
+              - Stage 1 (Exact): new_entity.id → primary new_entity.id
+              - Stage 1.5 (Token): new_entity.id → primary new_entity.id
+              - Stage 2 (ANN): new_entity.id → 现有 DB 实体 UUID
+                （新实体被合并到 DB 既有实体；DB UUID 不会出现在 ``entities`` 列表中
+                ——它通过 first-class 同步阶段在 ``kg_entities`` 表中独立存活）。
+            参见 plan: kg-build-fix 缺陷 2。
+    """
 
     entities: list[GraphNode]
     merge_map: dict[str, str]  # old_label → surviving_label
+    id_merge_map: dict[str, str]  # old_entity_id → surviving_entity_id
 
 
 class EntityResolver:
@@ -185,10 +227,14 @@ class EntityResolver:
             corpus_id: 语料库 ID
 
         Returns:
-            ResolutionResult(entities=存留实体列表, merge_map=合并映射)
+            ResolutionResult(entities, merge_map, id_merge_map)
+                - entities: 去重后的存留实体
+                - merge_map: 旧 label → 存留 label（传递链已展平）
+                - id_merge_map: 旧 entity_id → 存留 entity_id（传递链已展平）
+                  对 ANN 命中 DB 既有实体的场景，存留 id 为 DB 实体的 UUID。
         """
         if not new_entities:
-            return ResolutionResult(entities=new_entities, merge_map={})
+            return ResolutionResult(entities=new_entities, merge_map={}, id_merge_map={})
 
         # Stage 0: Blocking — 按 blocking_key 分组
         blocks: dict[str, list[int]] = defaultdict(list)
@@ -200,6 +246,8 @@ class EntityResolver:
         merged_secondary: set[int] = set()
         # 合并映射：被合并实体的 label → 存留实体的 label
         merge_map: dict[str, str] = {}
+        # ID 合并映射：被合并实体的 entity_id → 存留实体的 entity_id
+        id_merge_map: dict[str, str] = {}
 
         # Stage 1: 精确匹配 (block 内规范化标签 + 实体类型匹配)
         label_type_to_primary: dict[str, int] = {}
@@ -212,29 +260,38 @@ class EntityResolver:
                     if self._pick_primary(new_entities[primary_idx], new_entities[idx]) == 1:
                         merged_secondary.add(primary_idx)
                         merge_map[new_entities[primary_idx].label or ""] = new_entities[idx].label or ""
+                        id_merge_map[new_entities[primary_idx].id] = new_entities[idx].id
                         label_type_to_primary[dedup_key] = idx
                     else:
                         merged_secondary.add(idx)
                         merge_map[new_entities[idx].label or ""] = new_entities[primary_idx].label or ""
+                        id_merge_map[new_entities[idx].id] = new_entities[primary_idx].id
                 else:
                     label_type_to_primary[dedup_key] = idx
 
         # Stage 1.5: Token 重叠检测 — 捕获缩写/别名/子串变体
         # 跨 block 对比：对 Stage 1 未合并的同类型实体计算 token Jaccard 系数，
         # 解决 "GAN" vs "Generative Adversarial Networks (GANs)" 类问题。
-        token_merged, token_merge_map = self._token_overlap_stage(new_entities, merged_secondary)
+        token_merged, token_merge_map, token_id_merge_map = self._token_overlap_stage(new_entities, merged_secondary)
         merged_secondary.update(token_merged)
         merge_map.update(token_merge_map)
+        id_merge_map.update(token_id_merge_map)
 
         # Stage 2: 向量 ANN 查找（对未合并的实体）
         remaining = [i for i in range(len(new_entities)) if i not in merged_secondary]
 
         if remaining and find_similar is not None:
-            ann_merged = await self._ann_stage(new_entities, remaining, find_similar, corpus_id)
+            ann_merged, ann_id_merge_map = await self._ann_stage(new_entities, remaining, find_similar, corpus_id)
             merged_secondary.update(ann_merged)
+            id_merge_map.update(ann_id_merge_map)
 
         # 返回未被合并的实体
         result = [new_entities[i] for i in range(len(new_entities)) if i not in merged_secondary]
+
+        # 展平传递链：A→B, B→C ⇒ A→C, B→C。同样作用于 label 与 id 两条链路，
+        # 防止多跳合并使下游 _resolve_ref 因中间节点缺失而失败。
+        merge_map = _flatten_chain(merge_map)
+        id_merge_map = _flatten_chain(id_merge_map)
 
         if merged_secondary:
             logger.info(
@@ -245,7 +302,7 @@ class EntityResolver:
                 remaining=len(result),
             )
 
-        return ResolutionResult(entities=result, merge_map=merge_map)
+        return ResolutionResult(entities=result, merge_map=merge_map, id_merge_map=id_merge_map)
 
     def _pick_primary(self, a: GraphNode, b: GraphNode) -> int:
         """选择主实体（置信度更高者），返回 0 选 a，返回 1 选 b"""
@@ -257,7 +314,7 @@ class EntityResolver:
         self,
         entities: list[GraphNode],
         already_merged: set[int],
-    ) -> tuple[set[int], dict[str, str]]:
+    ) -> tuple[set[int], dict[str, str], dict[str, str]]:
         """Stage 1.5: Token 重叠检测 — 跨 block 捕获缩写/别名/子串变体
 
         对同 entity_type 的未合并实体，计算 token Jaccard 系数与子串包含关系，
@@ -267,10 +324,11 @@ class EntityResolver:
           - "Sonnet 4.5" vs "Claude Sonnet 4.5"
 
         Returns:
-            (merged_indices, merge_map) 元组
+            (merged_indices, label_merge_map, id_merge_map) 三元组
         """
         merged: set[int] = set()
         merge_map: dict[str, str] = {}
+        id_merge_map: dict[str, str] = {}
         # 按类型分组未合并的实体
         type_groups: dict[str, list[int]] = defaultdict(list)
         for i in range(len(entities)):
@@ -298,10 +356,12 @@ class EntityResolver:
                         if self._pick_primary(entities[p_idx], entity) == 1:
                             merged.add(p_idx)
                             merge_map[entities[p_idx].label or ""] = entity.label or ""
+                            id_merge_map[entities[p_idx].id] = entity.id
                             primaries[pi] = (idx, tokens, norm)
                         else:
                             merged.add(idx)
                             merge_map[entity.label or ""] = entities[p_idx].label or ""
+                            id_merge_map[entity.id] = entities[p_idx].id
                         matched = True
                         break
 
@@ -313,7 +373,7 @@ class EntityResolver:
                 "token_overlap_merged",
                 merged_count=len(merged),
             )
-        return merged, merge_map
+        return merged, merge_map, id_merge_map
 
     async def _ann_stage(
         self,
@@ -321,16 +381,25 @@ class EntityResolver:
         remaining_indices: list[int],
         find_similar: Any,
         corpus_id: Any,
-    ) -> set[int]:
-        """Stage 2: 向量 ANN 查找 + 合并"""
-        merged: list[int] = []
+    ) -> tuple[set[int], dict[str, str]]:
+        """Stage 2: 向量 ANN 查找 + 合并
 
-        # 已确认为 primary 的规范化标签集合（含类型）
-        primary_keys: set[str] = set()
+        Returns:
+            (merged_indices, id_merge_map) 元组。
+            id_merge_map 的 value 可能为 DB 既有实体的 UUID（不存在于本批 entities 中），
+            供下游关系端点重写直接跳到 DB 存留 id。
+        """
+        merged: list[int] = []
+        id_merge_map: dict[str, str] = {}
+
+        # 已确认为 primary 的规范化标签集合（含类型）→ 同时记录每个 key 对应的 entity_id，
+        # 便于本批内 ANN 命中后回填到 id_merge_map。
+        primary_keys: dict[str, str] = {}
         for i in range(len(entities)):
             if i not in remaining_indices:
                 e = entities[i]
-                primary_keys.add(f"{normalize_label(e.label or '')}|{e.node_type or 'other'}")
+                key = f"{normalize_label(e.label or '')}|{e.node_type or 'other'}"
+                primary_keys[key] = e.id
 
         for idx in remaining_indices:
             entity = entities[idx]
@@ -349,18 +418,23 @@ class EntityResolver:
             except Exception:
                 continue
 
-            for _similar_id, similar_name, score in similar:
+            for similar_id, similar_name, score in similar:
                 if similar_name == entity.label:
                     continue
                 similar_key = f"{normalize_label(similar_name)}|{entity.node_type or 'other'}"
                 if similar_key in primary_keys:
+                    # 命中本批已存在的 primary
                     merged.append(idx)
+                    id_merge_map[entity.id] = primary_keys[similar_key]
                     break
-                # 高置信度匹配直接合并：登记 DB primary 的键以便同批后续短路命中
+                # 高置信度匹配直接合并到 DB 既有实体：
+                # similar_id 是 DB UUID（非本批 entities 中的 id），关系端点重写时
+                # 需要跳到该 DB 实体。同时登记 primary_keys 以便同批后续短路命中。
                 if score >= self._ann_threshold:
                     merged.append(idx)
-                    primary_keys.add(similar_key)
+                    id_merge_map[entity.id] = str(similar_id)
+                    primary_keys[similar_key] = str(similar_id)
                     break
                 # 边界区域暂不合并（LLM 验证留给后续迭代）
 
-        return set(merged)
+        return set(merged), id_merge_map

--- a/apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py
@@ -281,9 +281,12 @@ class EntityResolver:
         remaining = [i for i in range(len(new_entities)) if i not in merged_secondary]
 
         if remaining and find_similar is not None:
-            ann_merged, ann_id_merge_map = await self._ann_stage(new_entities, remaining, find_similar, corpus_id)
+            ann_merged, ann_id_merge_map, ann_merge_map = await self._ann_stage(
+                new_entities, remaining, find_similar, corpus_id, id_merge_map
+            )
             merged_secondary.update(ann_merged)
             id_merge_map.update(ann_id_merge_map)
+            merge_map.update(ann_merge_map)
 
         # 返回未被合并的实体
         result = [new_entities[i] for i in range(len(new_entities)) if i not in merged_secondary]
@@ -381,25 +384,52 @@ class EntityResolver:
         remaining_indices: list[int],
         find_similar: Any,
         corpus_id: Any,
-    ) -> tuple[set[int], dict[str, str]]:
+        prior_id_merge_map: dict[str, str] | None = None,
+    ) -> tuple[set[int], dict[str, str], dict[str, str]]:
         """Stage 2: 向量 ANN 查找 + 合并
 
+        Args:
+            entities: 全量实体列表。
+            remaining_indices: 经 Stage 1/1.5 后存留的实体索引。
+            find_similar: 向量相似度查询回调。
+            corpus_id: 语料库 ID。
+            prior_id_merge_map: Stage 1/1.5 已建立的 id_merge_map，
+                用于将 secondary 标签命中回溯到最终存留 id。
+
         Returns:
-            (merged_indices, id_merge_map) 元组。
+            (merged_indices, id_merge_map, merge_map) 三元组。
             id_merge_map 的 value 可能为 DB 既有实体的 UUID（不存在于本批 entities 中），
             供下游关系端点重写直接跳到 DB 存留 id。
+            merge_map 同步维护被合并实体的 label → similar_name（DB 实体名称）映射，
+            确保下游 label_to_id fallback 路径能正确解析 ANN 合并的实体。
         """
         merged: list[int] = []
         id_merge_map: dict[str, str] = {}
+        merge_map: dict[str, str] = {}
+        _prior = prior_id_merge_map or {}
 
-        # 已确认为 primary 的规范化标签集合（含类型）→ 同时记录每个 key 对应的 entity_id，
-        # 便于本批内 ANN 命中后回填到 id_merge_map。
-        primary_keys: dict[str, str] = {}
+        # 存留实体的规范化标签集合（含类型）→ 存留实体 id。
+        # 从 remaining_indices 填充，确保 primary_keys 指向真正的存留实体。
+        survivor_keys: dict[str, str] = {}
+        for i in remaining_indices:
+            e = entities[i]
+            key = f"{normalize_label(e.label or '')}|{e.node_type or 'other'}"
+            survivor_keys[key] = e.id
+
+        # 被合并 secondary 的标签 → 通过 _prior 回溯到最终存留 id。
+        # 用于 ANN 返回的 similar_name 命中 secondary 标签时，仍能正确定位存留实体。
+        secondary_survivor_keys: dict[str, str] = {}
         for i in range(len(entities)):
             if i not in remaining_indices:
                 e = entities[i]
                 key = f"{normalize_label(e.label or '')}|{e.node_type or 'other'}"
-                primary_keys[key] = e.id
+                if key not in survivor_keys:
+                    # 通过 prior_id_merge_map 回溯到存留者
+                    final_id = _prior.get(e.id, e.id)
+                    secondary_survivor_keys[key] = final_id
+
+        # 合并：survivor 优先（精确匹配），secondary 作为 fallback（经回溯后的 id）
+        combined_keys: dict[str, str] = {**secondary_survivor_keys, **survivor_keys}
 
         for idx in remaining_indices:
             entity = entities[idx]
@@ -422,19 +452,27 @@ class EntityResolver:
                 if similar_name == entity.label:
                     continue
                 similar_key = f"{normalize_label(similar_name)}|{entity.node_type or 'other'}"
-                if similar_key in primary_keys:
-                    # 命中本批已存在的 primary
-                    merged.append(idx)
-                    id_merge_map[entity.id] = primary_keys[similar_key]
-                    break
+                if similar_key in combined_keys:
+                    # 命中本批其他存留实体（或经回溯的 secondary 标签）。
+                    # 排除自合并：combined_keys 中该 key 指向的 id 可能是自身
+                    # （如 "OpenAI" vs "OpenAI Inc." 经 normalize_label 后 key 相同）。
+                    target_id = combined_keys[similar_key]
+                    if target_id == entity.id:
+                        # 规范化碰撞但实际是同一实体 → 跳过，交由 DB 路径判定
+                        pass
+                    else:
+                        merged.append(idx)
+                        id_merge_map[entity.id] = target_id
+                        break
                 # 高置信度匹配直接合并到 DB 既有实体：
                 # similar_id 是 DB UUID（非本批 entities 中的 id），关系端点重写时
-                # 需要跳到该 DB 实体。同时登记 primary_keys 以便同批后续短路命中。
+                # 需要跳到该 DB 实体。同时登记 combined_keys 以便同批后续短路命中。
                 if score >= self._ann_threshold:
                     merged.append(idx)
                     id_merge_map[entity.id] = str(similar_id)
-                    primary_keys[similar_key] = str(similar_id)
+                    combined_keys[similar_key] = str(similar_id)
+                    merge_map[entity.label or ""] = similar_name
                     break
                 # 边界区域暂不合并（LLM 验证留给后续迭代）
 
-        return set(merged), id_merge_map
+        return set(merged), id_merge_map, merge_map

--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -268,18 +268,81 @@ def is_noise_entity(name: str) -> bool:
     return False
 
 
+_TRANSIENT_PROVIDER_HINTS = (
+    "502",
+    "503",
+    "429",
+    "bad gateway",
+    "service unavailable",
+    "rate limit",
+    "too many requests",
+)
+
+
+def _extract_retry_after_seconds(error_str: str) -> float | None:
+    """从错误体中提取 retry_after 数值（秒）。
+
+    支持两种来源：
+      1. JSON body 形式：``'retry_after': 60`` / ``"retry_after": "60"``。
+         Cloudflare / LiteLLM 等代理常以 JSON 错误体回传此字段。
+      2. HTTP header 形式：``Retry-After: 60``。RFC 9110 §10.2.3 规范字段。
+
+    Returns:
+        提取到的整数秒数，未匹配时返回 ``None``。
+    """
+    # JSON body：'retry_after': N 或 "retry_after": "N"
+    m = re.search(r"""['"]retry_after['"]\s*:\s*['"]?(\d+)['"]?""", error_str)
+    if m:
+        try:
+            return float(m.group(1))
+        except ValueError:
+            pass
+    # HTTP header：Retry-After: N
+    m = re.search(r"Retry-After\s*:\s*(\d+)", error_str, re.IGNORECASE)
+    if m:
+        try:
+            return float(m.group(1))
+        except ValueError:
+            pass
+    return None
+
+
 def _compute_retry_backoff(error_str: str, attempt: int) -> float:
     """计算重试退避时长（秒）。
 
-    针对网关超时（Cloudflare 524 等）采用更长的递增退避，
-    避免短间隔重试连续触发同一类超时浪费配额。
+    优先级：
+      1. **网关超时**（Cloudflare 524 / "timeout"）：30s, 60s, 90s（cap 120s）+ jitter，
+         避免短间隔重试连续触发同一类超时浪费配额。
+      2. **服务端显式 retry_after**（仅当错误指示瞬时故障：502 / 503 / 429 等）：
+         尊重服务端建议，但叠加 floor（≥ 默认指数退避）防止反向加速，cap 120s 防超长阻塞。
+         参考 RFC 9110 §10.2.3：``Retry-After`` 是服务端对客户端的速率提示，应予尊重。
+      3. **普通错误**：指数退避 1s, 2s, 4s（cap 10s）+ jitter。
+
+    参考文献：
+        [1] R. T. Fielding et al., "HTTP semantics," IETF RFC 9110, §10.2.3, 2022.
+        [2] M. T. Nygard, *Release It! Design and Deploy Production-Ready Software*,
+            2nd ed., Pragmatic Bookshelf, 2018, ch. 5 (Stability Patterns).
     """
+    # 普通错误的指数退避基线（用于 floor 计算与默认返回）
+    default_backoff = min(2.0**attempt + random.uniform(0, 1), 10.0)
+
     is_gateway_timeout = "524" in error_str or "timeout" in error_str.lower() or "timed out" in error_str.lower()
     if is_gateway_timeout:
         # 30s, 60s, 90s (cap 120s) + jitter
         return min(30.0 * (attempt + 1) + random.uniform(0, 5), 120.0)
+
+    # retry_after 仅对瞬时故障生效（避免对真正不可重试错误盲目延长）
+    lower = error_str.lower()
+    is_transient_provider_error = any(hint in lower for hint in _TRANSIENT_PROVIDER_HINTS)
+    if is_transient_provider_error:
+        retry_after = _extract_retry_after_seconds(error_str)
+        if retry_after is not None:
+            # floor: 至少不低于默认指数退避（防止 retry_after=1 反而加速）
+            # cap: 最多 120s（防止 retry_after=3600 阻塞构建）
+            return min(max(retry_after, default_backoff), 120.0) + random.uniform(0, 1)
+
     # 普通错误：指数退避 1s, 2s, 4s (cap 10s) + jitter
-    return min(2.0**attempt + random.uniform(0, 1), 10.0)
+    return default_backoff
 
 
 async def call_llm_with_retry(

--- a/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/extractors.py
@@ -323,8 +323,8 @@ def _compute_retry_backoff(error_str: str, attempt: int) -> float:
         [2] M. T. Nygard, *Release It! Design and Deploy Production-Ready Software*,
             2nd ed., Pragmatic Bookshelf, 2018, ch. 5 (Stability Patterns).
     """
-    # 普通错误的指数退避基线（用于 floor 计算与默认返回）
-    default_backoff = min(2.0**attempt + random.uniform(0, 1), 10.0)
+    # 指数退避基线（不含 jitter，用于 retry_after 的 floor 计算）
+    base_backoff = min(2.0**attempt, 10.0)
 
     is_gateway_timeout = "524" in error_str or "timeout" in error_str.lower() or "timed out" in error_str.lower()
     if is_gateway_timeout:
@@ -338,11 +338,11 @@ def _compute_retry_backoff(error_str: str, attempt: int) -> float:
         retry_after = _extract_retry_after_seconds(error_str)
         if retry_after is not None:
             # floor: 至少不低于默认指数退避（防止 retry_after=1 反而加速）
-            # cap: 最多 120s（防止 retry_after=3600 阻塞构建）
-            return min(max(retry_after, default_backoff), 120.0) + random.uniform(0, 1)
+            # cap: 最多 120s（防止 retry_after=3600 阻塞构建）+ 单层 jitter
+            return min(max(retry_after, base_backoff), 120.0) + random.uniform(0, 1)
 
     # 普通错误：指数退避 1s, 2s, 4s (cap 10s) + jitter
-    return default_backoff
+    return min(base_backoff + random.uniform(0, 1), 10.0)
 
 
 async def call_llm_with_retry(

--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -410,15 +410,17 @@ class GraphRepository(ABC):
         entity_count: int = 0,
         relation_count: int = 0,
         error_message: str | None = None,
+        human_run_id: str | None = None,
     ) -> None:
         """更新构建运行状态
 
         Args:
-            run_id: 运行记录 ID
+            run_id: 运行记录 ID（DB PK，UUID）
             status: 新状态
             entity_count: 实体数量
             relation_count: 关系数量
             error_message: 错误信息
+            human_run_id: 人类可读 run_id（``build-<hex>-<ts>``），仅用于日志补全。
         """
         pass
 
@@ -1788,8 +1790,11 @@ class AgeGraphRepository(GraphRepository):
             )
             await session.commit()
 
+        # 双字段日志：``run_uuid`` 为 DB PK，``run_id`` 为人类可读 ``build-<hex>-<ts>``。
+        # 与 ``build_run_updated`` 字段命名保持一致，便于跨日志检索。
         logger.info(
             "build_run_created",
+            run_uuid=str(run_uuid),
             run_id=run_id,
             corpus_id=str(corpus_id),
         )
@@ -1806,6 +1811,7 @@ class AgeGraphRepository(GraphRepository):
         progress_percent: float | None = None,
         warnings: list[dict[str, Any]] | None = None,
         processed_chunk_ids: list[str] | None = None,
+        human_run_id: str | None = None,
     ) -> None:
         """更新构建运行状态。
 
@@ -1826,6 +1832,11 @@ class AgeGraphRepository(GraphRepository):
             progress_percent: 构建进度 0.0-1.0，用于前端进度条 (Nygard, 2018)
             warnings: 非致命警告列表（如 PageRank 收敛失败）
             processed_chunk_ids: 增量构建已处理的 chunk ID 列表
+            human_run_id: 人类可读的 run_id（``build-<short>-<ts>``）。仅用于日志
+                字段补全；DB 写入仍以 UUID PK 为准。传入后 ``build_run_updated`` 与
+                ``build_run_update_skipped_by_state_guard`` 同时输出 ``run_uuid`` +
+                ``run_id`` 双字段，串联 service.py 层的人类可读 run_id 与 repository
+                层的 DB PK，便于跨日志与跨 worker 排障。
         """
         import json as _json
 
@@ -1877,14 +1888,18 @@ class AgeGraphRepository(GraphRepository):
             # 这是状态机守卫的正常拒绝路径；以 debug 级保留观测线索，便于 cancel 链路排查。
             logger.debug(
                 "build_run_update_skipped_by_state_guard",
-                run_id=str(run_id),
+                run_uuid=str(run_id),
+                run_id=human_run_id,
                 attempted_status=status,
             )
             return
 
+        # 双字段日志：``run_uuid`` 为 DB PK（持久化主键），``run_id`` 为人类可读
+        # ``build-<hex>-<ts>``（service 层局部变量名），便于跨日志/跨 worker 串联。
         logger.info(
             "build_run_updated",
-            run_id=str(run_id),
+            run_uuid=str(run_id),
+            run_id=human_run_id,
             status=status,
             entity_count=entity_count,
             relation_count=relation_count,

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -957,6 +957,8 @@ class GraphService:
 
             # 标签级合并映射注入 label_to_id（保留旧逻辑作为 fallback，
             # 覆盖 LLM 直接输出 label 字符串作为 source/target 的边界场景）。
+            # 同时将 DB UUID 端点（ANN Stage 2 命中 kg_entities 既有实体）注入 id_to_label，
+            # 确保下游 sync_relation 的 canonical_name 查找能命中。
             for old_label, surviving_label in (resolution.merge_map or {}).items():
                 surviving_id = label_to_id.get(surviving_label)
                 if surviving_id and old_label not in label_to_id:
@@ -964,10 +966,25 @@ class GraphService:
                     norm_old = old_label.strip().lower()
                     if norm_old not in norm_label_to_id:
                         norm_label_to_id[norm_old] = surviving_id
+                # ANN→DB UUID 场景：surviving_label 是 DB 实体名称（不在 entities_to_save 中），
+                # surviving_id 为 None；但仍需将 old_label → surviving_label 映射注入 label_to_id，
+                # 以便 _resolve_ref 的标签级 fallback 路径能正确解析到 DB 实体名称。
+                elif not surviving_id and old_label not in label_to_id:
+                    label_to_id[old_label] = surviving_label
 
             # 存留实体 id 集合（用于 UUID/hash 直通判定）
             _surviving_ids: set[str] = {e.id for e in entities_to_save}
             _surviving_clean_ids: set[str] = {e.id.replace("entity:", "") for e in entities_to_save}
+
+            # ANN→DB UUID 反向映射：DB UUID → DB 实体名称，
+            # 用于 sync_relation 的 canonical_name 查找与 _resolve_ref 的标签级 fallback。
+            # 仅当 id_merge_map 的 value 不在本批存留实体中时，才视为外部 DB UUID。
+            db_uuid_to_label: dict[str, str] = {}
+            for _old_id, _surviving_id in id_merge_map.items():
+                if _surviving_id not in _surviving_clean_ids and _surviving_id not in _surviving_ids:
+                    _label = id_to_label.get(_old_id)
+                    if _label and _label in label_to_id:
+                        db_uuid_to_label[_surviving_id] = label_to_id[_label]
 
             def _resolve_ref(ref: str, field_name: str) -> str | None:
                 """解析关系端点引用。
@@ -986,9 +1003,32 @@ class GraphService:
                 # 1. ID 级直查：被合并实体 id → 存留 id（权威映射）
                 clean = ref.replace("entity:", "")
                 if clean in id_merge_map:
-                    return id_merge_map[clean]
+                    resolved = id_merge_map[clean]
+                    # 存活检查：如果 resolved 是本批存留实体的 id（hex hash），
+                    # 直接返回；如果 resolved 是 DB UUID（kg_entities.id），
+                    # 需要转写为 label 以便下游 _create_relation_with_session（基于
+                    # knowledge.id）和 sync_relation（基于 canonical_name）能正确处理。
+                    if resolved in _surviving_clean_ids or resolved in _surviving_ids:
+                        return ref if ref.startswith("entity:") else f"entity:{clean}"
+                    # DB UUID → label → label_to_id fallback
+                    if resolved in db_uuid_to_label:
+                        return db_uuid_to_label[resolved]
+                    # resolved 是 DB UUID 但无 label 映射 → 标记 unresolved
+                    logger.warning(
+                        "relation_endpoint_db_uuid_unresolved",
+                        run_id=run_id,
+                        field=field_name,
+                        ref=ref[:64],
+                        resolved_id=resolved[:36],
+                    )
+                    return None
                 if ref in id_merge_map:
-                    return id_merge_map[ref]
+                    resolved = id_merge_map[ref]
+                    if resolved in _surviving_clean_ids or resolved in _surviving_ids:
+                        return ref
+                    if resolved in db_uuid_to_label:
+                        return db_uuid_to_label[resolved]
+                    return None
 
                 # 2. ID 已是存留实体（无需重写）
                 if clean in _surviving_clean_ids or ref in _surviving_ids:
@@ -1127,8 +1167,14 @@ class GraphService:
                 ]
                 edge_dicts = [
                     {
-                        "source": id_to_label.get(r.source.replace("entity:", ""), r.source.replace("entity:", "")),
-                        "target": id_to_label.get(r.target.replace("entity:", ""), r.target.replace("entity:", "")),
+                        "source": id_to_label.get(
+                            r.source.replace("entity:", ""),
+                            db_uuid_to_label.get(r.source.replace("entity:", ""), r.source.replace("entity:", "")),
+                        ),
+                        "target": id_to_label.get(
+                            r.target.replace("entity:", ""),
+                            db_uuid_to_label.get(r.target.replace("entity:", ""), r.target.replace("entity:", "")),
+                        ),
                         "edge_type": r.edge_type,
                         "label": r.label,
                         "weight": r.weight,

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -526,6 +526,7 @@ class GraphService:
                 try:
                     update_kwargs: dict[str, Any] = {
                         "run_id": run_uuid,
+                        "human_run_id": run_id,
                         "status": "running",
                         "progress_percent": progress,
                         "warnings": list(build_warnings),
@@ -539,7 +540,8 @@ class GraphService:
                 except Exception as exc:
                     logger.warning(
                         "update_build_run_failed",
-                        run_id=str(run_uuid),
+                        run_uuid=str(run_uuid),
+                        run_id=run_id,
                         phase=phase,
                         error=str(exc),
                     )
@@ -588,6 +590,7 @@ class GraphService:
                     try:
                         await build_repo.update_build_run(
                             run_id=run_uuid,
+                            human_run_id=run_id,
                             status="running",
                             progress_percent=progress,
                             entity_count=current_entity_count,
@@ -596,7 +599,8 @@ class GraphService:
                     except Exception as exc:
                         logger.warning(
                             "update_build_run_failed",
-                            run_id=str(run_uuid),
+                            run_uuid=str(run_uuid),
+                            run_id=run_id,
                             phase=PHASE_EXTRACTING,
                             error=str(exc),
                         )
@@ -925,6 +929,17 @@ class GraphService:
             )
 
             # 重新映射关系中的实体 ID
+            #
+            # 关系端点重写策略（缺陷 2 修复）：
+            # extractors 在抽取阶段以 SHA256 哈希填充 GraphEdge.source/target
+            # （格式 ``entity:<32-hex>``）。经多策略 resolver 后，被合并的实体
+            # 不在 ``entities_to_save`` 中，旧实现 ``id_to_label`` 仅覆盖存留实体，
+            # 导致这些哈希 ref 在 _resolve_ref 链中全程 miss，最终 unresolved。
+            #
+            # 修复：使用 resolver 暴露的 ``id_merge_map`` 作为权威映射（已展平传递链
+            # 且覆盖 Exact / Token / ANN 三阶段，含 ANN→DB UUID 跨表场景），
+            # _resolve_ref 优先以 id 直查；保留 label 链作为防御性 fallback
+            # （覆盖 LLM 误输出 label 字符串而非 id 的情况）。
             label_to_id = {e.label: e.id for e in entities_to_save}
             # 规范化标签映射（处理大小写/空格差异）
             norm_label_to_id: dict[str, str] = {}
@@ -936,21 +951,13 @@ class GraphService:
             # ID → Label 反向映射（用于双写时传递实体名称而非 UUID）
             id_to_label: dict[str, str] = {e.id.replace("entity:", ""): e.label for e in entities_to_save if e.label}
 
-            # 将实体消解的合并映射注入 label_to_id，使 _resolve_ref 能解析
-            # 被合并掉的旧实体标签（如 "Prithvi Rajasakeran" → "Prithvi Rajasekaran"）
-            # 先解析传递链：merge_map 可能包含 A→B, B→C 的链式映射，
-            # 需将所有 old_label 指向最终的存留实体。
-            _resolved_merge: dict[str, str] = {}
-            for old_label, mid_label in resolution.merge_map.items():
-                current = mid_label
-                visited = {old_label, mid_label}
-                while current in resolution.merge_map:
-                    current = resolution.merge_map[current]
-                    if current in visited:
-                        break  # 防御环路
-                    visited.add(current)
-                _resolved_merge[old_label] = current
-            for old_label, surviving_label in _resolved_merge.items():
+            # 权威 ID 映射：被合并实体 id → 存留 id（含 DB UUID 跨表场景）
+            # ``resolution.id_merge_map`` 由 EntityResolver 在三 stage 内统一维护并展平。
+            id_merge_map: dict[str, str] = dict(resolution.id_merge_map or {})
+
+            # 标签级合并映射注入 label_to_id（保留旧逻辑作为 fallback，
+            # 覆盖 LLM 直接输出 label 字符串作为 source/target 的边界场景）。
+            for old_label, surviving_label in (resolution.merge_map or {}).items():
                 surviving_id = label_to_id.get(surviving_label)
                 if surviving_id and old_label not in label_to_id:
                     label_to_id[old_label] = surviving_id
@@ -958,37 +965,50 @@ class GraphService:
                     if norm_old not in norm_label_to_id:
                         norm_label_to_id[norm_old] = surviving_id
 
+            # 存留实体 id 集合（用于 UUID/hash 直通判定）
+            _surviving_ids: set[str] = {e.id for e in entities_to_save}
+            _surviving_clean_ids: set[str] = {e.id.replace("entity:", "") for e in entities_to_save}
+
             def _resolve_ref(ref: str, field_name: str) -> str | None:
-                """解析关系端点引用：label → ID / hash → 规范化查找 / UUID 直通"""
+                """解析关系端点引用。
+
+                优先级（由权威到防御性 fallback）：
+                  1. ID 级直查：``ref`` 是 ``entity:<hash>``，先去 ``entity:`` 前缀，
+                     若在 ``id_merge_map`` 中 → 直接返回存留 id（含 DB UUID 跨表场景）。
+                  2. ID 已是存留实体 → 原值返回。
+                  3. 标签级 fallback（覆盖 LLM 误输出 label 的边界场景）：精确 →
+                     规范化 → ID 反查标签链。
+                  4. 全部失败 → 记录 warning 返回 None。
+                """
                 if not ref:
                     return None
-                # 1. 精确标签匹配
+
+                # 1. ID 级直查：被合并实体 id → 存留 id（权威映射）
+                clean = ref.replace("entity:", "")
+                if clean in id_merge_map:
+                    return id_merge_map[clean]
+                if ref in id_merge_map:
+                    return id_merge_map[ref]
+
+                # 2. ID 已是存留实体（无需重写）
+                if clean in _surviving_clean_ids or ref in _surviving_ids:
+                    # 规范化为 ``entity:<hash>`` 与下游 GraphEdge 一致
+                    return ref if ref.startswith("entity:") else f"entity:{clean}"
+
+                # 3. 标签级 fallback：精确 label
                 if ref in label_to_id:
                     return label_to_id[ref]
-                # 2. 规范化标签匹配（大小写/空格容差）
+                # 3a. 规范化 label
                 norm = ref.strip().lower()
                 if norm in norm_label_to_id:
                     return norm_label_to_id[norm]
-                # 3. ID 反向查找（hash-like 或 UUID 短格式）
-                clean = ref.replace("entity:", "")
+                # 3b. ID → label → label_to_id 间接查找（覆盖未在 id_merge_map 中的边界）
                 if clean in id_to_label:
                     resolved_label = id_to_label[clean]
                     if resolved_label in label_to_id:
                         return label_to_id[resolved_label]
-                # 4. 32 位十六进制哈希：尝试模糊匹配（取实体名哈希比较）
-                if len(ref) == 32 and all(c in "0123456789abcdef" for c in ref):
-                    logger.warning(
-                        "relation_endpoint_hash_unresolved",
-                        run_id=run_id,
-                        field=field_name,
-                        ref=ref,
-                        hint="LLM 输出了 MD5 哈希作为实体引用，无法映射到已知实体",
-                    )
-                    return None
-                # 5. 已经是 UUID 格式，直接返回
-                if ref in id_to_label or ref in {e.id for e in entities_to_save}:
-                    return ref
-                # 6. 无法解析的引用
+
+                # 4. 全部失败：unresolved
                 logger.warning(
                     "relation_endpoint_unresolved",
                     run_id=run_id,
@@ -1220,63 +1240,79 @@ class GraphService:
             )
 
             # B3: 社区摘要生成 (Edge et al., Microsoft GraphRAG, 2024)
+            #
+            # 事务边界设计（缺陷 1 修复）：
+            # 旧实现使用 ``async with shared_session.begin():`` 包裹 summarizer，
+            # 但 SQLAlchemy 2.x 中本阶段前若有 ``shared_session.execute(SELECT ...)``
+            # 直接调用会隐式 auto-begin，再 begin() 抛 ``A transaction is already
+            # begun on this Session``。同时 summarizer 内部 ``db.commit()`` 与外层
+            # begin() 形成双重事务管理，违反"事务边界单一来源"原则。
+            #
+            # 修复：剥离独立 ``AsyncSessionLocal()`` 会话（与 emit_phase 通过
+            # ``_session_scope()`` 走独立 session 的模式一致），corpus 配置查询与
+            # summarizer 全部走该独立会话，shared_session 不再涉入；summarizer
+            # 内部 commit 已移除，由本阶段末尾统一 commit / 异常 rollback。
             cs_result: dict[str, Any] = {}
             try:
+                from negentropy.db.session import AsyncSessionLocal
+
                 from ..ingestion.embedding import build_embedding_fn
                 from .community_summarizer import CommunitySummarizer
 
-                # 注入 embedding_fn — G1 GraphRAG Global Search 的 query-focused
-                # 召回依赖 kg_community_summaries.embedding；若 embedding 配置不可用
-                # （旧环境 / 单测），降级为不写 embedding，由 GlobalSearchService 的
-                # _has_summary_embeddings 探测后自动回退到 entity_count 排序。
-                # 从 corpus.config['models']['embedding_config_id'] 提取语料库专用
-                # embedding 配置，确保社区摘要与文档 chunks 使用同一向量空间。
-                cs_embedding_config_id: str | None = None
-                try:
-                    from sqlalchemy import text as sa_text
+                async with AsyncSessionLocal() as cs_session:
+                    # 1. 读取语料库 embedding 配置（与 chunk embeddings 同向量空间）
+                    cs_embedding_config_id: str | None = None
+                    try:
+                        from sqlalchemy import text as sa_text
 
-                    from negentropy.models.base import NEGENTROPY_SCHEMA
+                        from negentropy.models.base import NEGENTROPY_SCHEMA
 
-                    cfg_row = await shared_session.execute(
-                        sa_text(f"""
-                            SELECT config FROM {NEGENTROPY_SCHEMA}.corpus
-                            WHERE id = :cid
-                        """),
-                        {"cid": str(corpus_id)},
+                        cfg_row = await cs_session.execute(
+                            sa_text(f"""
+                                SELECT config FROM {NEGENTROPY_SCHEMA}.corpus
+                                WHERE id = :cid
+                            """),
+                            {"cid": str(corpus_id)},
+                        )
+                        cfg_val = cfg_row.scalar()
+                        if isinstance(cfg_val, dict):
+                            models_cfg = cfg_val.get("models")
+                            if isinstance(models_cfg, dict):
+                                eid = models_cfg.get("embedding_config_id")
+                                if eid is not None:
+                                    cs_embedding_config_id = str(eid)
+                    except Exception:
+                        pass  # 查询失败 → 使用全局默认
+
+                    # 2. 构建 embedding_fn（失败降级为 None，由 GlobalSearchService 回退到
+                    # entity_count 排序）
+                    try:
+                        cs_embedding_fn = build_embedding_fn(cs_embedding_config_id)
+                    except Exception as ef_exc:
+                        cs_embedding_fn = None
+                        logger.warning(
+                            "community_summary_embedding_fn_unavailable",
+                            error=str(ef_exc),
+                        )
+
+                    # 3. 调用 summarizer（内部不 commit，由本阶段末尾统一提交）
+                    summarizer = CommunitySummarizer(
+                        model=normalized_llm_model,
+                        embedding_fn=cs_embedding_fn,
                     )
-                    cfg_val = cfg_row.scalar()
-                    if isinstance(cfg_val, dict):
-                        models_cfg = cfg_val.get("models")
-                        if isinstance(models_cfg, dict):
-                            eid = models_cfg.get("embedding_config_id")
-                            if eid is not None:
-                                cs_embedding_config_id = str(eid)
-                except Exception:
-                    pass  # 查询失败 → 使用全局默认
-                try:
-                    cs_embedding_fn = build_embedding_fn(cs_embedding_config_id)
-                except Exception as ef_exc:
-                    cs_embedding_fn = None
-                    logger.warning(
-                        "community_summary_embedding_fn_unavailable",
-                        error=str(ef_exc),
-                    )
-
-                summarizer = CommunitySummarizer(
-                    model=normalized_llm_model,
-                    embedding_fn=cs_embedding_fn,
-                )
-                async with shared_session.begin():
                     cs_result = await summarizer.summarize_communities(
-                        shared_session,
+                        cs_session,
                         corpus_id,
                         levels_data=levels_data if levels_data else None,
                     )
+                    await cs_session.commit()
                     logger.info(
                         "community_summaries_generated",
                         **cs_result,
                     )
             except Exception as cs_exc:
+                # 独立 session 已由 ``async with`` 管理生命周期；shared_session
+                # 不再涉入本阶段。保留 shared_session 兜底以防御后续阶段误用。
                 if shared_session.in_transaction():
                     await shared_session.rollback()
                 build_warnings.append({"algorithm": "community_summary", "error": str(cs_exc)})
@@ -1358,6 +1394,7 @@ class GraphService:
 
             await build_repo.update_build_run(
                 run_id=run_uuid,
+                human_run_id=run_id,
                 status=final_status,
                 entity_count=len(entities_to_save),
                 relation_count=len(valid_relations),
@@ -1411,12 +1448,14 @@ class GraphService:
                     raise RuntimeError("shared session inactive")
                 await build_repo.update_build_run(
                     run_id=run_uuid,
+                    human_run_id=run_id,
                     status="cancelled",
                     warnings=cancellation_warnings if cancellation_warnings else None,
                 )
             except Exception:
                 await self._repository.update_build_run(
                     run_id=run_uuid,
+                    human_run_id=run_id,
                     status="cancelled",
                     warnings=cancellation_warnings if cancellation_warnings else None,
                 )
@@ -1467,6 +1506,7 @@ class GraphService:
                     raise RuntimeError("shared session inactive")
                 await build_repo.update_build_run(
                     run_id=run_uuid,
+                    human_run_id=run_id,
                     status="failed",
                     error_message=error_message,
                     warnings=failure_warnings if failure_warnings else None,
@@ -1474,6 +1514,7 @@ class GraphService:
             except Exception:
                 await self._repository.update_build_run(
                     run_id=run_uuid,
+                    human_run_id=run_id,
                     status="failed",
                     error_message=error_message,
                     warnings=failure_warnings if failure_warnings else None,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver.py
@@ -239,3 +239,139 @@ class TestEntityResolverANN:
         result = await resolver.resolve(entities, find_similar=failing_find_similar, corpus_id=uuid4())
         # ANN 失败不应丢失实体
         assert len(result.entities) == 1
+
+
+# ============================================================================
+# id_merge_map（缺陷 2 修复）：被合并实体 id → 存留 id 的权威映射
+# ============================================================================
+
+
+class TestEntityResolverIdMergeMap:
+    """验证 ResolutionResult.id_merge_map 覆盖三 stage 与传递链。"""
+
+    async def test_exact_stage_id_mapping(self):
+        """Stage 1: 精确合并应记录 id_merge_map[merged] = survivor。"""
+        resolver = EntityResolver()
+        e1 = _make_entity("OpenAI", "organization", confidence=0.95)
+        e2 = _make_entity("OpenAI Inc.", "organization", confidence=0.7)
+        result = await resolver.resolve([e1, e2], find_similar=None, corpus_id=None)
+
+        assert len(result.entities) == 1
+        survivor_id = result.entities[0].id
+        merged_id = e2.id if survivor_id == e1.id else e1.id
+        assert result.id_merge_map.get(merged_id) == survivor_id
+
+    async def test_token_overlap_stage_id_mapping(self):
+        """Stage 1.5: Token 重叠合并应记录 id_merge_map。"""
+        resolver = EntityResolver()
+        e1 = _make_entity("GAN", "concept", confidence=0.8)
+        e2 = _make_entity("Generative Adversarial Networks (GANs)", "concept", confidence=0.9)
+        result = await resolver.resolve([e1, e2], find_similar=None, corpus_id=None)
+
+        assert len(result.entities) == 1
+        # GAN（低置信）应被合并到 Generative Adversarial Networks (GANs)
+        assert result.id_merge_map.get(e1.id) == e2.id
+
+    async def test_ann_stage_id_mapping_to_db_uuid(self):
+        """Stage 2: ANN 命中 DB 既有实体时，id_merge_map 应指向 DB UUID。
+
+        关键回归：原日志中 ``entity:57cff...`` 这类被合并实体 hash 在旧实现下
+        100% 落入 unresolved；本测试覆盖 ANN→DB UUID 跨表映射场景。
+        """
+        resolver = EntityResolver(ann_threshold=0.85)
+
+        db_uuid = "58974230-38a9-44ca-b408-ee52f5a1fcb8"
+
+        async def fake_find_similar(embedding, corpus_id, entity_type, threshold, limit):
+            return [(db_uuid, "OpenAI Inc.", 0.91)]
+
+        new_entity = GraphNode(
+            id=f"entity:{'a' * 32}",
+            label="OpenAI",
+            node_type="organization",
+            metadata={"confidence": 0.9, "embedding": [0.1] * 10},
+        )
+        result = await resolver.resolve([new_entity], find_similar=fake_find_similar, corpus_id=uuid4())
+
+        # 新实体被 ANN 合并到 DB 既有实体，id_merge_map 应指向 DB UUID
+        assert len(result.entities) == 0
+        assert result.id_merge_map.get(new_entity.id) == db_uuid
+
+    async def test_transitive_chain_flattened(self):
+        """多跳合并（A→B→C）的 id_merge_map 应被展平为 A→C。
+
+        模拟：三个高度相似的实体进入合并，期望 id_merge_map 中所有被合并的 id
+        都直接指向最终存留 id。
+        """
+        resolver = EntityResolver()
+        # 三个等价命名（规范化后相同）会在 Stage 1 内逐次合并
+        e1 = _make_entity("Acme", "organization", confidence=0.7)
+        e2 = _make_entity("acme", "organization", confidence=0.8)
+        e3 = _make_entity("Acme Inc.", "organization", confidence=0.9)
+        result = await resolver.resolve([e1, e2, e3], find_similar=None, corpus_id=None)
+
+        assert len(result.entities) == 1
+        survivor_id = result.entities[0].id
+        # 所有被合并的 id 都应直接指向 survivor（链已展平，无中间跳）
+        for e in (e1, e2, e3):
+            if e.id != survivor_id:
+                assert result.id_merge_map.get(e.id) == survivor_id
+
+    async def test_empty_input_returns_empty_map(self):
+        resolver = EntityResolver()
+        result = await resolver.resolve([], find_similar=None, corpus_id=None)
+        assert result.id_merge_map == {}
+
+    async def test_no_merge_returns_empty_map(self):
+        resolver = EntityResolver()
+        entities = [
+            _make_entity("OpenAI", "organization"),
+            _make_entity("Google", "organization"),
+        ]
+        result = await resolver.resolve(entities, find_similar=None, corpus_id=None)
+        assert result.id_merge_map == {}
+
+
+# ============================================================================
+# _flatten_chain（缺陷 2 工具函数）
+# ============================================================================
+
+
+class TestFlattenChain:
+    def test_single_hop_unchanged(self):
+        from negentropy.knowledge.graph.entity_resolver import _flatten_chain
+
+        chain = {"a": "b"}
+        assert _flatten_chain(chain) == {"a": "b"}
+
+    def test_two_hop_flattened(self):
+        from negentropy.knowledge.graph.entity_resolver import _flatten_chain
+
+        chain = {"a": "b", "b": "c"}
+        flat = _flatten_chain(chain)
+        # a 直接指向 c，b 也直接指向 c
+        assert flat["a"] == "c"
+        assert flat["b"] == "c"
+
+    def test_three_hop_flattened(self):
+        from negentropy.knowledge.graph.entity_resolver import _flatten_chain
+
+        chain = {"a": "b", "b": "c", "c": "d"}
+        flat = _flatten_chain(chain)
+        assert flat["a"] == "d"
+        assert flat["b"] == "d"
+        assert flat["c"] == "d"
+
+    def test_cycle_defensively_truncated(self):
+        """环路检测：A→B, B→A 不应死循环。"""
+        from negentropy.knowledge.graph.entity_resolver import _flatten_chain
+
+        chain = {"a": "b", "b": "a"}
+        flat = _flatten_chain(chain)
+        # 防御性截断，不死循环即可
+        assert set(flat.keys()) == {"a", "b"}
+
+    def test_empty_chain(self):
+        from negentropy.knowledge.graph.entity_resolver import _flatten_chain
+
+        assert _flatten_chain({}) == {}

--- a/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py
@@ -133,7 +133,7 @@ class TestTokenOverlapStage:
             _make_entity("GAN", "concept", confidence=0.8),
             _make_entity("Generative Adversarial Networks (GANs)", "concept", confidence=0.9),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         # 低置信度的 GAN 应被合并
         assert len(merged) == 1
         assert entities[0].id in [entities[i].id for i in merged] or entities[1].id in [entities[i].id for i in merged]
@@ -144,7 +144,7 @@ class TestTokenOverlapStage:
             _make_entity("RetroForge", "product", confidence=0.85),
             _make_entity("RetroForge - 2D Retro Game Maker", "product", confidence=0.9),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 1
 
     def test_partial_name_merged(self):
@@ -153,7 +153,7 @@ class TestTokenOverlapStage:
             _make_entity("Sonnet 4.5", "product", confidence=0.8),
             _make_entity("Claude Sonnet 4.5", "product", confidence=0.9),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 1
 
     def test_different_entities_not_merged(self):
@@ -163,7 +163,7 @@ class TestTokenOverlapStage:
             _make_entity("Vue", "product", confidence=0.9),
             _make_entity("Angular", "product", confidence=0.9),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 0
 
     def test_different_types_not_merged(self):
@@ -172,7 +172,7 @@ class TestTokenOverlapStage:
             _make_entity("Claude", "product", confidence=0.9),
             _make_entity("Claude", "person", confidence=0.9),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 0
 
     def test_higher_confidence_preserved(self):
@@ -181,7 +181,7 @@ class TestTokenOverlapStage:
             _make_entity("Claude Code", "product", confidence=0.7),
             _make_entity("Claude Code CLI", "product", confidence=0.95),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         assert len(merged) == 1
         # 低置信度的短名称应被合并（是 secondary）
         assert entities[0].id in [entities[i].id for i in merged]
@@ -193,7 +193,7 @@ class TestTokenOverlapStage:
             _make_entity("Prithvi Rajasekaran", "person", confidence=0.8),
             _make_entity("Prithvi Rajasakeran", "person", confidence=0.9),
         ]
-        merged, merge_map = self.resolver._token_overlap_stage(entities, set())
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, set())
         # 编辑距离检测将 "ek" vs "ke" 拼写变体识别为相似，执行合并
         assert len(merged) == 1
 
@@ -205,7 +205,7 @@ class TestTokenOverlapStage:
         ]
         # 模拟 Entity A 已被 Stage 1 合并
         already_merged = {0}
-        merged, merge_map = self.resolver._token_overlap_stage(entities, already_merged)
+        merged, merge_map, id_merge_map = self.resolver._token_overlap_stage(entities, already_merged)
         # 只有 Entity B 参与，没有配对对象
         assert len(merged) == 0
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extractors_retry_backoff.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extractors_retry_backoff.py
@@ -83,26 +83,26 @@ class TestRetryAfterHonored:
         """关键回归：Cloudflare 502 + retry_after=60 → backoff ≥ 60s。"""
         err = "litellm.BadGatewayError: OpenAIException - Error code: 502 - {'type': 'bad gateway', 'retry_after': 60}"
         backoff = _compute_retry_backoff(err, attempt=0)
-        # floor=max(60, default_backoff≈1)=60；jitter[0,1]
-        assert 60.0 <= backoff <= 61.5
+        # floor=max(60, base_backoff=1.0)=60；单层 jitter[0,1)
+        assert 60.0 <= backoff <= 61.0
 
     def test_503_with_retry_after_15_uses_15(self):
         err = "503 Service Unavailable. Retry-After: 15"
         backoff = _compute_retry_backoff(err, attempt=0)
-        assert 15.0 <= backoff <= 16.5
+        assert 15.0 <= backoff <= 16.0
 
     def test_429_with_retry_after_capped_at_120(self):
         """超长 retry_after 被 cap 到 120s，防止构建阻塞。"""
         err = "429 Too Many Requests, retry_after: 3600"
         backoff = _compute_retry_backoff(err, attempt=0)
-        assert backoff <= 121.5  # 120 + jitter[0,1.5]
+        assert backoff <= 121.0  # 120 + 单层 jitter[0,1)
 
     def test_502_retry_after_1_does_not_accelerate(self):
         """retry_after=1 比指数退避更快时，应使用 floor（默认退避）。"""
         err = "502 Bad Gateway, retry_after: 1"
-        # attempt=3: default = min(2^3 + jitter, 10) = 8-9
+        # attempt=3: base_backoff = min(2^3, 10) = 8.0
         backoff = _compute_retry_backoff(err, attempt=3)
-        # floor=max(1, 8-9)=8-9，加 jitter[0,1] 后 8-10
+        # floor=max(1, 8.0)=8.0，加 jitter[0,1) 后 8.0-9.0
         assert backoff >= 8.0
 
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extractors_retry_backoff.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extractors_retry_backoff.py
@@ -1,0 +1,147 @@
+"""
+LLM 重试退避（``_compute_retry_backoff``）单元测试。
+
+覆盖三类故障的退避策略：
+  1. 网关超时（Cloudflare 524 / "timeout"）：30s/60s/90s 递增（cap 120s）；
+  2. 瞬时服务端错误 + ``retry_after`` 提示（502/503/429）：尊重服务端建议，
+     叠加 floor（≥ 默认指数）/ cap（≤ 120s）；
+  3. 普通错误：指数退避 1s/2s/4s（cap 10s）。
+
+参考缺陷 4（plan: kg-build-fix）：Cloudflare 502 错误返回 ``retry_after: 60``
+但旧实现按指数退避 1.1s 立刻重试，未尊重 Cloudflare 显式建议。
+"""
+
+from __future__ import annotations
+
+from negentropy.knowledge.graph.extractors import (
+    _compute_retry_backoff,
+    _extract_retry_after_seconds,
+)
+
+# ============================================================================
+# _extract_retry_after_seconds
+# ============================================================================
+
+
+class TestExtractRetryAfter:
+    def test_json_body_unquoted_int(self):
+        """JSON body 形式：'retry_after': 60。"""
+        err = "{'type': 'error', 'retry_after': 60, 'status': 502}"
+        assert _extract_retry_after_seconds(err) == 60.0
+
+    def test_json_body_double_quoted_int(self):
+        err = '{"retry_after": 30}'
+        assert _extract_retry_after_seconds(err) == 30.0
+
+    def test_json_body_quoted_string(self):
+        err = '{"retry_after": "45"}'
+        assert _extract_retry_after_seconds(err) == 45.0
+
+    def test_http_header_form(self):
+        """HTTP header 形式：Retry-After: 60。"""
+        err = "HTTP/1.1 429 Too Many Requests\nRetry-After: 90"
+        assert _extract_retry_after_seconds(err) == 90.0
+
+    def test_http_header_case_insensitive(self):
+        err = "retry-after: 15"
+        assert _extract_retry_after_seconds(err) == 15.0
+
+    def test_no_retry_after_returns_none(self):
+        err = "Generic 500 Internal Server Error"
+        assert _extract_retry_after_seconds(err) is None
+
+
+# ============================================================================
+# _compute_retry_backoff: 网关超时
+# ============================================================================
+
+
+class TestGatewayTimeoutBackoff:
+    def test_524_attempt_0_around_30s(self):
+        err = "litellm.Timeout: Cloudflare 524"
+        backoff = _compute_retry_backoff(err, attempt=0)
+        assert 30.0 <= backoff <= 35.0  # 30 + jitter[0,5]
+
+    def test_524_attempt_1_around_60s(self):
+        err = "Connection timed out"
+        backoff = _compute_retry_backoff(err, attempt=1)
+        assert 60.0 <= backoff <= 65.0
+
+    def test_524_capped_at_120s(self):
+        err = "524 timeout"
+        backoff = _compute_retry_backoff(err, attempt=10)
+        assert backoff <= 120.0
+
+
+# ============================================================================
+# _compute_retry_backoff: retry_after 解析（瞬时故障）
+# ============================================================================
+
+
+class TestRetryAfterHonored:
+    def test_502_with_retry_after_60_uses_60(self):
+        """关键回归：Cloudflare 502 + retry_after=60 → backoff ≥ 60s。"""
+        err = "litellm.BadGatewayError: OpenAIException - Error code: 502 - {'type': 'bad gateway', 'retry_after': 60}"
+        backoff = _compute_retry_backoff(err, attempt=0)
+        # floor=max(60, default_backoff≈1)=60；jitter[0,1]
+        assert 60.0 <= backoff <= 61.5
+
+    def test_503_with_retry_after_15_uses_15(self):
+        err = "503 Service Unavailable. Retry-After: 15"
+        backoff = _compute_retry_backoff(err, attempt=0)
+        assert 15.0 <= backoff <= 16.5
+
+    def test_429_with_retry_after_capped_at_120(self):
+        """超长 retry_after 被 cap 到 120s，防止构建阻塞。"""
+        err = "429 Too Many Requests, retry_after: 3600"
+        backoff = _compute_retry_backoff(err, attempt=0)
+        assert backoff <= 121.5  # 120 + jitter[0,1.5]
+
+    def test_502_retry_after_1_does_not_accelerate(self):
+        """retry_after=1 比指数退避更快时，应使用 floor（默认退避）。"""
+        err = "502 Bad Gateway, retry_after: 1"
+        # attempt=3: default = min(2^3 + jitter, 10) = 8-9
+        backoff = _compute_retry_backoff(err, attempt=3)
+        # floor=max(1, 8-9)=8-9，加 jitter[0,1] 后 8-10
+        assert backoff >= 8.0
+
+
+# ============================================================================
+# _compute_retry_backoff: 普通错误 / 非瞬时故障
+# ============================================================================
+
+
+class TestNonTransientBackoff:
+    def test_400_with_retry_after_text_uses_exponential(self):
+        """400 不是瞬时故障，即使错误体含 retry_after 也走原指数退避（不被错误延长）。"""
+        err = "400 Bad Request, retry_after: 60"
+        backoff = _compute_retry_backoff(err, attempt=0)
+        # 默认指数：min(2^0 + jitter[0,1], 10) = 1.0-2.0
+        assert 1.0 <= backoff <= 2.0
+
+    def test_unknown_error_attempt_0(self):
+        backoff = _compute_retry_backoff("ValueError: bad input", attempt=0)
+        assert 1.0 <= backoff <= 2.0
+
+    def test_unknown_error_attempt_2(self):
+        backoff = _compute_retry_backoff("RuntimeError: foo", attempt=2)
+        # min(2^2 + jitter[0,1], 10) = 4.0-5.0
+        assert 4.0 <= backoff <= 5.0
+
+    def test_unknown_error_capped_at_10s(self):
+        backoff = _compute_retry_backoff("RuntimeError: foo", attempt=10)
+        assert backoff <= 10.0
+
+
+# ============================================================================
+# _compute_retry_backoff: 网关超时优先级高于 retry_after
+# ============================================================================
+
+
+class TestGatewayTimeoutPrecedence:
+    def test_524_with_retry_after_uses_524_logic(self):
+        """524 + retry_after：524 网关超时逻辑优先（更激进的退避）。"""
+        err = "524 timeout, retry_after: 5"
+        backoff = _compute_retry_backoff(err, attempt=0)
+        # 走 524 分支：30 + jitter[0,5]
+        assert 30.0 <= backoff <= 35.0

--- a/apps/negentropy/tests/unit_tests/knowledge/test_resolve_ref.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_resolve_ref.py
@@ -1,23 +1,21 @@
 """
 _resolve_ref 多步降级解析 单元测试
 
-验证 service.py 中关系端点解析的 6 条路径：
-  1. 精确标签匹配 (label → id)
-  2. 规范化标签匹配 (大小写/空格容差)
-  3. ID 反向查找 (entity:xxx → label → id)
-  4. 32 位十六进制哈希检测 → None
-  5. UUID 直通
-  6. 无法解析 → None
+验证 service.py 中关系端点解析的路径优先级（缺陷 2 修复后）：
+  1. ID 级直查：id_merge_map[clean_ref] → 存留 id（含 DB UUID 跨表场景）
+  2. 已是存留 id → 原值返回
+  3. 标签级 fallback：精确 → 规范化 → id_to_label → label_to_id 间接链
+  4. 全部失败 → 记录 warning 返回 None
 
-注：_resolve_ref 是 build_graph 内的闭包，无法直接导入。
-本测试通过重建相同的映射表与解析逻辑来验证行为正确性，
-同时使用 inspect.getsource 验证生产代码结构回归。
+注：本测试文件中的 ``_resolve_ref`` helper 是旧逻辑的本地复现，
+用于覆盖标签 fallback 路径；缺陷 2 修复主线由 ``test_entity_resolver.py::
+TestEntityResolverIdMergeMap`` 与生产代码 inspect.getsource 结构断言覆盖。
+_resolve_ref 是 build_graph 内的闭包，无法直接导入。
 """
 
 from __future__ import annotations
 
 import inspect
-import re
 from uuid import uuid4
 
 from negentropy.knowledge.graph.service import GraphService
@@ -244,11 +242,16 @@ class TestResolveRefStructure:
         source = inspect.getsource(GraphService)
         assert "norm_label_to_id" in source
 
-    def test_has_hash_detection(self):
-        """确认存在 32 位十六进制哈希检测"""
+    def test_consumes_id_merge_map(self):
+        """缺陷 2 修复后：_resolve_ref 应优先以 id_merge_map 作为权威映射。
+
+        旧实现的 ``len(ref) == 32`` 哈希启发式已删除——现在被合并实体的
+        ``entity:<32-hex>`` 不再依赖结构特征推断，而由 resolver 暴露的
+        id_merge_map 直接重写。
+        """
         source = inspect.getsource(GraphService)
-        # 验证包含 len==32 的哈希检测逻辑
-        assert re.search(r"len\(ref\)\s*==\s*32", source) is not None
+        assert "id_merge_map" in source
+        assert "resolution.id_merge_map" in source
 
     def test_has_id_reverse_lookup(self):
         """确认存在 id_to_label 反向查找"""
@@ -260,10 +263,15 @@ class TestResolveRefStructure:
         source = inspect.getsource(GraphService)
         assert "unresolved_endpoints" in source
 
-    def test_has_hash_warning_log(self):
-        """确认哈希检测有 warning 日志"""
+    def test_no_legacy_hash_branch(self):
+        """缺陷 2 修复后：``relation_endpoint_hash_unresolved`` 日志已删除。
+
+        旧实现使用 ``len(ref) == 32 and all hex`` 启发式识别 LLM 输出的 hash，
+        但这是症状而非根因——根因是被合并实体的 id 未被纳入 id_merge_map。
+        修复后 id_merge_map 直接处理这类情形，该日志分支不再被触发，删除。
+        """
         source = inspect.getsource(GraphService)
-        assert "relation_endpoint_hash_unresolved" in source
+        assert "relation_endpoint_hash_unresolved" not in source
 
     def test_has_unresolved_warning_log(self):
         """确认无法解析的引用有 warning 日志"""

--- a/docs/issue.md
+++ b/docs/issue.md
@@ -1930,3 +1930,39 @@
   - SubAgent / MCP / Skills / Tools 等 Interface 子页面的 Setup 模态框若日后承载多维度子动作（如「Test Tool」「Test Skill 执行」），可复用本次「Test Connectivity 卡片内 grid 多子组 + 可选子组通过 placeholder 字段控制是否渲染」的范式；
   - `litellm.aembedding` 的桩化测试范式（对象响应 + dict 响应两条回退路径同测）对未来任何 embedding 相关功能（如「Test Rerank」）均可作为参考模板；
   - Anthropic 这种「缺失原生 capability」的供应商在 UI 上应统一采用「不渲染对应子组」而非「渲染但 disable」的处理，避免诱导用户填表后被告知不支持的二次挫败。
+
+---
+
+## ISSUE-085 KG 构建管线四项级联缺陷：事务冲突、关系端点 45% 流失、日志双身份、retry_after 失尊（2026-05-13）
+
+- **表因**：一次完整 KG 构建（20 chunks，6.5 分钟）日志暴露多处缺陷：① 终态被降级为 `completed_with_errors`，warning `community_summary_failed error=A transaction is already begun on this Session.`；② 75 条原始关系经 resolving 阶段后 34 条端点 unresolved（45% 流失），日志聚集出现 `entity:57cff7c895...` 等 32-hex hash ref（出现 15 次同一目标）；③ `build_run_updated` 日志 `run_id=f3c60faa-...` 与外层 `run_id=build-5ac15262-...` 双身份割裂；④ Cloudflare 502 错误返回 `retry_after: 60` 但 `_compute_retry_backoff` 仅按指数退避 1.1s 立刻重试。
+- **根因**：
+  1. **事务双管理**：[`apps/negentropy/src/negentropy/knowledge/graph/service.py`](../apps/negentropy/src/negentropy/knowledge/graph/service.py) B3 阶段在 try 块内对 `shared_session` 直接 `execute(SELECT FROM corpus)` 隐式 auto-begin 了事务；紧随的 `async with shared_session.begin():` 触发 SQLAlchemy 2.x `InvalidRequestError`。二阶问题：[`community_summarizer.py`](../apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py) 三处 `await db.commit()` 与外层 `begin()` 形成双重事务，违反"事务边界单一来源"。
+  2. **id 映射断链**：[`entity_resolver.py:ResolutionResult`](../apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py) 仅暴露 `merge_map: dict[str, str]`（label→label），无 id 维度；service.py:937 的 `id_to_label` 仅覆盖存留实体。extractors 将 `GraphEdge.source/target` 设为 SHA256 哈希 id（`entity:<32-hex>`），关系端点经 resolver 后引用被合并实体 hash 时 `_resolve_ref` 链 4 层查找均 miss。**更深的二阶缺陷**：`_ann_stage` 只返回 `set[int]`、不维护任何 merge_map，使得 ANN 命中 DB 既有实体（survivor 是 DB UUID、不在 new_entities 中）的场景 100% 落入 unresolved（修复前未爆发是因为该路径触发量低）。
+  3. **日志字段语义割裂**：`kg_build_runs` 表存在两个标识 `id`（UUID PK）+ `run_id`（VARCHAR `build-<hex>-<ts>` 人类可读），[`repository.py:1885-1891`](../apps/negentropy/src/negentropy/knowledge/graph/repository.py) 的 `build_run_updated` 日志字段名是 `run_id` 但传值是 UUID PK 字符串化，与 `build_run_created` 日志中 `run_id=人类可读字符串` 跨条目语义不一致。
+  4. **502 误退避**：[`extractors.py:_compute_retry_backoff`](../apps/negentropy/src/negentropy/knowledge/graph/extractors.py) 仅识别"网关超时（524/timeout）"与"普通错误"两类，未解析错误体中的 `retry_after` 字段（JSON body 或 HTTP header），Cloudflare 502 + 显式 60s 建议被指数退避 1.1s 覆盖。
+- **处理方式**：
+  1. **B3 事务剥离**：service.py B3 阶段使用独立 `AsyncSessionLocal()` 创建专用会话（与 emit_phase 通过 `_session_scope()` 走独立 session 同模式）：corpus 配置查询 + summarizer 调用全部走该独立会话，shared_session 不再涉入；summarizer 内部三处 `db.commit()` 全部移除，由独立 session 出口统一 commit / 异常 rollback。
+  2. **id_merge_map 上升为一等返回值**：`ResolutionResult` 新增 `id_merge_map: dict[str, str]` 字段；Stage 1 (Exact) / Stage 1.5 (Token) / Stage 2 (ANN) 三阶段同步维护，特别是 `_ann_stage` 签名变更为 `tuple[set[int], dict[str, str]]`，在命中 DB 既有实体时记录 `entity.id → str(similar_db_id)`；`resolve()` 末尾调用新增工具函数 `_flatten_chain` 展平 label / id 两条链路的传递映射（A→B→C ⇒ A→C, B→C）。service.py:927-998 重写 `_resolve_ref`：优先级 ID 直查 → 已是存留 id 原值返回 → 标签级 fallback；删除"32 位 hex hash unresolved"专属分支（已被 id_merge_map 覆盖）。
+  3. **日志双字段**：[`repository.py:update_build_run`](../apps/negentropy/src/negentropy/knowledge/graph/repository.py) 与抽象基类同步增加可选参数 `human_run_id: str | None = None`，`build_run_updated` / `build_run_update_skipped_by_state_guard` / `build_run_created` 三处日志统一输出 `run_uuid=<DB PK> + run_id=<人类可读>` 双字段；service.py 所有调用点（emit_phase、extracting progress、final update、cancel、failed）传入 `human_run_id=run_id`。
+  4. **retry_after 解析**：新增 `_extract_retry_after_seconds(error_str)` 同时支持 JSON body（`'retry_after': N`）和 HTTP header（`Retry-After: N`）；`_compute_retry_backoff` 仅在错误命中 `_TRANSIENT_PROVIDER_HINTS`（502/503/429/bad gateway/rate limit/too many requests）时启用；叠加 floor（≥ 默认指数退避防反向加速）与 cap（≤ 120s 防超长阻塞）+ jitter 防羊群。
+- **验证证据**：
+  - 单元测试：新增 [`test_extractors_retry_backoff.py`](../apps/negentropy/tests/unit_tests/knowledge/test_extractors_retry_backoff.py) 18 个用例（JSON / HTTP header 解析、502+retry_after 尊重、429 cap 至 120s、retry_after=1 不加速、400 非瞬时故障不被错误延长、524 优先级高于 retry_after）；新增 [`test_entity_resolver.py::TestEntityResolverIdMergeMap`](../apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver.py) 6 个用例（Exact / Token / ANN 三 stage 各自 id 映射 + ANN→DB UUID 跨表 + 多跳传递链展平 + 空输入 / 无合并空字典）；新增 `TestFlattenChain` 5 个用例（单跳/二跳/三跳/环路防御/空字典）；适配既有 `test_resolve_ref.py` 结构断言（`id_merge_map` 引用 + 移除 `relation_endpoint_hash_unresolved`）与 `test_entity_resolver_token_overlap.py` 3-tuple 解包；
+  - 范围覆盖：affected 7 个测试文件 158 项断言全过；KG 单元测试目录 788/788 通过（pre-existing 单个 `test_extraction_llm_plan.py::test_build_llm_invocation_plan_returns_none_when_serialization_fails` 失败与本次修复完全无关，git stash 已验证）；
+  - **修复指标对比**：
+    - `unresolved_endpoints` / `raw_count`：日志中 34/75 ≈ 45% → 预期 < 5%（id_merge_map 直查命中率）；
+    - `community_summary_failed` 警告：1 次 → 0 次；
+    - 终态 `status`：`completed_with_errors` → `completed`；
+    - `build_run_updated` 字段一致性：单字段 `run_id=UUID` → 双字段 `run_uuid` + `run_id`；
+    - **未完成项（透明披露）**：端到端浏览器回归遵循 [browser-validation 协议](../docs/agents/browser-validation.md) 需用户在自有 Chrome 主 profile 操作真实语料库 corpus，本次未在 agent 上下文执行——本修复全由单元测试与结构断言保障。
+- **后续防范**：
+  1. **事务边界单一来源**：service / repository / domain 模块层级应明确"谁开 begin / 谁负责 commit"的契约；domain service（如 summarizer）只负责写入，事务边界由 application service 持有，杜绝跨层双重事务管理；
+  2. **多策略消解的 ID 维度必维护**：任何"按 label 合并"的策略都必须同步暴露 ID 映射（new_id → surviving_id），下游不应被迫从 label 反推 id；新增 stage 时（如未来 LLM 验证）必须遵循此契约；
+  3. **传递链展平作为通用工具**：`_flatten_chain` 应作为消解管线的强制收尾步骤，防止多跳合并的中间节点丢失；
+  4. **日志字段命名规范**：DB PK（UUID）与业务可读 ID 共存时，日志字段名应分别为 `<entity>_uuid` 与 `<entity>_id`，双字段并存输出避免跨条目语义割裂；
+  5. **Provider retry hint 尊重**：RFC 9110 §10.2.3 `Retry-After` 是服务端速率提示的标准契约，所有外部调用的重试退避都应优先识别并尊重；仅在错误明确表示瞬时故障（502/503/429）时启用以避免误用。
+- **同类问题影响**：
+  - **事务双管理**：项目内任何"service 层 `async with session.begin():` + domain 模块内部 `commit()`" 的组合都需复核，PageRank / TemporalResolver / first-class sync 等阶段建议同步审视是否存在隐式 auto-begin 残留；
+  - **ID 映射断链**：未来如引入额外的"按某属性合并"策略（embedding 聚类、LLM 仲裁、规则映射等），必须强制返回 ID 映射；HippoRAG / LightRAG 等检索阶段若有类似实体规范化逻辑，需复用 `id_merge_map` + `_flatten_chain` 范式；
+  - **provider retry 策略**：所有 LiteLLM 调用点（KG 抽取、社区摘要、Test Connectivity、Wiki Publish 等）应统一走 `_compute_retry_backoff`，避免单点遗漏。
+


### PR DESCRIPTION
# 背景

- **本次变更要解决的问题**：一次完整 KG 构建（corpus `43bacd7e`，20 chunks，6.5 分钟）日志暴露出四项级联缺陷：① 社区摘要 `A transaction is already begun on this Session` 异常使终态降级为 `completed_with_errors`；② 75 条原始关系经 resolving 后 34 条端点 unresolved（45% 流失）集中指向被合并实体的 32-hex hash id（如 `entity:57cff7c895...` 出现 15 次）；③ `build_run_updated` 日志 `run_id=<UUID PK>` 与外层 `run_id=build-xxx-ts` 双身份割裂；④ Cloudflare 502 错误返回 `retry_after: 60` 但应用层只按指数退避 1.1s 立刻重试。
- **关联上下文 / Issue / 文档**：[ISSUE-085](../docs/issue.md#issue-085) / [docs/knowledge-graph.md](../docs/knowledge-graph.md)（GraphRAG + LightRAG + Fellegi-Sunter 理论沉淀）/ [docs/agents/browser-validation.md](../docs/agents/browser-validation.md)。

# 核心变更

- **缺陷 1 · 社区摘要事务冲突**：[`service.py`](../apps/negentropy/src/negentropy/knowledge/graph/service.py) B3 阶段从 `shared_session` 剥离，使用独立 `AsyncSessionLocal()` 会话承载 corpus 配置查询与 summarizer 调用；[`community_summarizer.py`](../apps/negentropy/src/negentropy/knowledge/graph/community_summarizer.py) 移除三处内部 `db.commit()`，事务边界回归调用方（"事务边界单一来源"原则）。
- **缺陷 2 · 关系端点 45% unresolved**：[`entity_resolver.py`](../apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py) `ResolutionResult` 新增 `id_merge_map: dict[str, str]`（old_entity_id → surviving_entity_id），Exact / Token / ANN 三阶段同步维护；ANN 阶段返回签名变更为 `tuple[set[int], dict[str, str]]`，命中 DB 既有实体时记录跨表 UUID 映射；新增 `_flatten_chain` 工具函数统一展平 label / id 两条链路的传递映射；[`service.py`](../apps/negentropy/src/negentropy/knowledge/graph/service.py) `_resolve_ref` 重写为"ID 直查 → 已是存留 id → 标签级 fallback"四级优先级，删除旧的 `len(ref) == 32 and all hex` 启发式分支。
- **缺陷 3 · 日志 run_id 双身份**：[`repository.py`](../apps/negentropy/src/negentropy/knowledge/graph/repository.py) `update_build_run` 新增可选 `human_run_id` 形参；`build_run_created` / `build_run_updated` / `build_run_update_skipped_by_state_guard` 三处日志统一输出 `run_uuid=<DB PK> + run_id=<人类可读>` 双字段，串联跨日志条目语义；[`service.py`](../apps/negentropy/src/negentropy/knowledge/graph/service.py) 全部 `update_build_run` 调用点传入 `human_run_id=run_id`。
- **缺陷 4 · LLM retry_after 失尊**：[`extractors.py`](../apps/negentropy/src/negentropy/knowledge/graph/extractors.py) 新增 `_extract_retry_after_seconds` 同时支持 JSON body（`'retry_after': N`）与 HTTP header（`Retry-After: N`）双源解析；`_compute_retry_backoff` 仅对 502 / 503 / 429 / bad gateway / rate limit / too many requests 等瞬时故障启用 retry_after，叠加 floor（≥ 默认指数退避防反向加速）与 cap（≤ 120s 防超长阻塞）+ jitter（防羊群），参考 RFC 9110 §10.2.3。

# 风险与回滚

- **主要风险**：
  - 缺陷 1 修复改变了 B3 阶段的 session 生命周期；若用户环境的 `AsyncSessionLocal` 配置异常（连接池耗尽 / DSN 不可达），独立 session 创建可能失败——已通过 `try/except` 包裹整个 B3 阶段并回退到 warning + 兜底 shared_session.rollback() 兜底；
  - 缺陷 2 修复使 `id_merge_map` 成为关系端点的权威映射；若 EntityResolver 三 stage 之一漏建 id 映射，会回到旧的标签级 fallback（保留原行为）但不会引入新的 unresolved；
  - 缺陷 3 仅新增可选参数与扩展日志字段，无行为变更；
  - 缺陷 4 仅对错误体含 `retry_after` 提示的 502/503/429 类错误生效，普通错误退避不变。
- **回滚方式**：`git revert 04e88d57` 单 commit 即可还原全部四项修复；ISSUE-085 详细记录每项的根因 / 修复 / 测试，便于二次审视。

# 验证证据

- **单元测试**：
  - 新增 [`test_extractors_retry_backoff.py`](../apps/negentropy/tests/unit_tests/knowledge/test_extractors_retry_backoff.py) 18 例：覆盖 JSON / HTTP header 解析、502+retry_after 尊重、429 cap 120s、retry_after=1 不加速（floor 防御）、400 非瞬时故障不被错误延长、524 优先级高于 retry_after；
  - 新增 [`test_entity_resolver.py::TestEntityResolverIdMergeMap`](../apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver.py) 6 例：Exact / Token / ANN 三 stage 各自 id 映射 + ANN→DB UUID 跨表 + 多跳传递链展平 + 空输入 / 无合并空字典；
  - 新增 `TestFlattenChain` 5 例：单跳 / 二跳 / 三跳 / 环路防御 / 空字典；
  - 适配既有 [`test_resolve_ref.py`](../apps/negentropy/tests/unit_tests/knowledge/test_resolve_ref.py) 结构断言（id_merge_map 引用 + 移除 `relation_endpoint_hash_unresolved` 断言）与 [`test_entity_resolver_token_overlap.py`](../apps/negentropy/tests/unit_tests/knowledge/test_entity_resolver_token_overlap.py) 3-tuple 解包；
  - 范围内 158 项断言全过，KG 单元测试目录 **788/788** 通过（1 个 pre-existing 失败 `test_extraction_llm_plan::test_build_llm_invocation_plan_returns_none_when_serialization_fails` 与本次修复完全无关，已通过 `git stash` 验证）。
- **集成测试**：未涉及（本次为单元级修复 + 结构断言）。
- **E2E / Workflow**：未在 agent 上下文中执行——按 [browser-validation 协议](../docs/agents/browser-validation.md) 端到端浏览器回归需用户在自有 Chrome 主 profile 触发同一 corpus 重建。
- **覆盖率 / 关键指标对比**：

| 指标 | 修复前（日志） | 修复后（目标） |
|------|------|------|
| `unresolved_endpoints / raw_count` | 34 / 75 ≈ 45% | < 5% |
| `community_summary_failed` 警告 | 1 | 0 |
| 终态 `status` | `completed_with_errors` | `completed` |
| `build_run_updated` 字段一致性 | 单字段 `run_id=UUID` | 双字段 `run_uuid` + `run_id` |

# 影响范围

- **前端**：无变更（仅日志字段调整不影响前端已订阅的 SSE / latest endpoint 数据契约）。
- **后端**：`apps/negentropy/src/negentropy/knowledge/graph/` 五个核心模块（service / entity_resolver / community_summarizer / repository / extractors）；`tests/unit_tests/knowledge/` 四个测试文件 + 一个新增；ABC `GraphRepository.update_build_run` 签名扩展（向后兼容，新增可选形参）。
- **GitHub Actions / 文档**：`docs/issue.md` 新增 ISSUE-085 完整摘要（表因 / 根因 / 处理方式 / 验证证据 / 后续防范 / 同类问题影响），符合 CLAUDE.md 工程纪律。

# Next Best Action

- **必做**：用户在自有 Chrome 主 profile 触发同一 corpus（如日志中的 `43bacd7e`）重建，对照"指标对比"表验证 `unresolved_endpoints` 占比 < 5% 与终态 `completed`；按 `gh pr review` 走 ultrareview。
- **建议（与本 PR 正交）**：① 社区检测 resolution 调优（62 节点产 28/25/25 太密，下一轮单独 PR 参数化 + 按图规模自适应）；② 前端 `/build-runs/latest` 轮询替换为 SSE / EventSource，消除构建期 ~100 次/run 的 DB 压力；③ Stage 2 (ANN) borderline LLM 验证实装（[entity_resolver.py:364](../apps/negentropy/src/negentropy/knowledge/graph/entity_resolver.py) 注释明确"留给后续迭代"）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)