### PR TITLE
fix(knowledge-graph): 修复 Cytoscape / Force Graph 右栏展开后布局溢出

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ForceGraphCanvas.tsx
@@ -256,7 +256,7 @@ export function ForceGraphCanvas({
         </>
       }
     >
-      <div ref={containerRef} className="h-full w-full">
+      <div ref={containerRef} style={{ position: "absolute", inset: 0 }}>
         {ForceGraph2D && dimensions.width > 0 && dimensions.height > 0 && (
           <ForceGraph2D
             ref={graphRef}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/GraphCanvas.tsx
@@ -288,7 +288,7 @@ export function GraphCanvas({
         </>
       }
     >
-      <div ref={containerRef} className="h-full w-full" />
+      <div ref={containerRef} style={{ position: "absolute", inset: 0 }} />
     </GraphCanvasFrame>
   );
 }


### PR DESCRIPTION
## Summary

- Cytoscape 和 Force Graph 引擎的容器 div 使用 `h-full w-full`，内部 Canvas 被引擎库赋予显式像素 CSS 宽高
- 右栏折叠后再展开时，Canvas 固有尺寸阻止 `flex-[2.2]` 容器收缩，导致右栏被挤出视窗外
- 将两个引擎的容器 div 改为 `position: absolute; inset: 0`，对齐 3D 引擎的已验证策略，使 Canvas 脱离文档流

## 变更文件

- `GraphCanvas.tsx` (Cytoscape)：容器 div 从 `h-full w-full` → `absolute inset: 0`
- `ForceGraphCanvas.tsx`：同上

## Test plan

- [ ] 切换到 Cytoscape 引擎 → 折叠右栏 → 展开右栏 → 右栏完整可见，Canvas 自动缩小
- [ ] 切换到 Force Graph 引擎 → 同上操作 → 同上预期
- [ ] 验证 d3 / Sigma / 3D 引擎不受影响
- [ ] 验证双击节点展开子图仍正常
- [ ] 验证全屏切换仍正常

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)