### PR TITLE
fix(knowledge): 取消信号穿透至 MCP 工具调用，支持运行中任务即时中断

### DIFF
--- a/apps/negentropy/src/negentropy/interface/execution.py
+++ b/apps/negentropy/src/negentropy/interface/execution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import tempfile
 from collections.abc import Callable
@@ -17,7 +18,7 @@ from negentropy.logging import get_logger
 from negentropy.models.plugin import McpServer, McpTool, McpToolRun, McpToolRunEvent, McpTrialAsset
 from negentropy.storage.gcs_client import GCSStorageClient
 
-from .mcp_client import McpClientService, McpResourceContent, McpToolCallResult
+from .mcp_client import McpCancelledError, McpClientService, McpResourceContent, McpToolCallResult
 
 logger = get_logger("negentropy.interface.execution")
 
@@ -96,6 +97,7 @@ class McpToolExecutionService:
         external_event_sink: Callable[[dict[str, Any]], None] | None = None,
         resolve_resource_links: bool = False,
         resource_concurrency: int = 4,
+        cancel_event: asyncio.Event | None = None,
     ) -> ExecutionResult:
         tool = await self._db.scalar(select(McpTool).where(McpTool.server_id == server.id, McpTool.name == tool_name))
         initial_payload = _json_safe(arguments or {})
@@ -227,6 +229,7 @@ class McpToolExecutionService:
                     resource_concurrency=resource_concurrency,
                     event_callback=handle_client_event,
                     stderr_callback=handle_stderr,
+                    cancel_event=cancel_event,
                 )
                 result = bundle.tool_result
                 resolved_resources = bundle.resources
@@ -244,8 +247,11 @@ class McpToolExecutionService:
                     timeout_seconds=timeout_seconds,
                     event_callback=handle_client_event,
                     stderr_callback=handle_stderr,
+                    cancel_event=cancel_event,
                 )
             tool_called = True
+        except McpCancelledError:
+            raise
         except Exception as exc:  # noqa: BLE001
             result = McpToolCallResult(success=False, error=str(exc))
             tool_called = False

--- a/apps/negentropy/src/negentropy/interface/mcp_client.py
+++ b/apps/negentropy/src/negentropy/interface/mcp_client.py
@@ -35,6 +35,65 @@ DEFAULT_TIMEOUT_SECONDS = 30
 DEFAULT_OPERATION_TIMEOUT_SECONDS = 120
 
 
+class McpCancelledError(Exception):
+    """MCP 工具调用被外部 pipeline 取消信号中断。
+
+    区别于 ``TimeoutError``（超时）和 ``asyncio.CancelledError``（task 取消），
+    用于标识用户主动发起的 pipeline cancel 操作穿透到 MCP 调用层。
+    """
+
+
+@asynccontextmanager
+async def _cancel_aware_timeout(
+    timeout_seconds: float,
+    cancel_event: asyncio.Event | None,
+) -> Any:
+    """异步上下文管理器：超时或 cancel_event 触发时终止 MCP 操作。
+
+    - ``cancel_event`` 为 None 时，行为与 ``asyncio.timeout`` 完全一致。
+    - ``cancel_event`` 已 set 时，立即抛出 ``McpCancelledError``。
+    - ``cancel_event`` 在操作过程中被 set 时，通过 watcher task 取消当前 task，
+      并将 ``CancelledError`` 转换为 ``McpCancelledError``。
+    - 超时先于取消触发时，抛出 ``TimeoutError``（与原有行为一致）。
+
+    参考
+    - Python asyncio cancellation 语义：``Task.cancel()`` 注入 ``CancelledError``，
+      由被取消的 task 在下一个 await 点捕获。
+    - N. Smith, "Notes on structured concurrency," §cancel scopes, 2018.
+    """
+    if cancel_event is None:
+        async with asyncio.timeout(timeout_seconds):
+            yield
+        return
+
+    if cancel_event.is_set():
+        raise McpCancelledError("Pipeline cancelled before MCP call started")
+
+    current_task = asyncio.current_task()
+
+    async def _watch_cancel() -> None:
+        await cancel_event.wait()
+        if current_task is not None and not current_task.done():
+            current_task.cancel()
+
+    watcher = asyncio.create_task(_watch_cancel())
+
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            try:
+                yield
+            except asyncio.CancelledError:
+                if cancel_event.is_set():
+                    raise McpCancelledError("Pipeline cancelled during MCP tool call") from None
+                raise
+    finally:
+        watcher.cancel()
+        try:
+            await watcher
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
 @asynccontextmanager
 async def logged_stdio_client(
     server: StdioServerParameters,
@@ -297,6 +356,7 @@ class McpClientService:
         arguments: dict[str, Any],
         timeout_seconds: float,
         event_callback: Callable[[dict[str, Any]], None] | None = None,
+        cancel_event: asyncio.Event | None = None,
         command: str | None = None,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
@@ -306,7 +366,7 @@ class McpClientService:
     ) -> McpToolCallResult:
         """统一的工具调用方法，适用于所有传输类型。"""
         transport_labels = {"stdio": "STDIO", "sse": "SSE", "http": "HTTP"}
-        async with asyncio.timeout(timeout_seconds):
+        async with _cancel_aware_timeout(timeout_seconds, cancel_event):
             _emit_event(
                 event_callback,
                 stage="transport_connect",
@@ -447,6 +507,7 @@ class McpClientService:
         timeout_seconds: float | None = None,
         event_callback: Callable[[dict[str, Any]], None] | None = None,
         stderr_callback: Callable[[str], None] | None = None,
+        cancel_event: asyncio.Event | None = None,
     ) -> McpToolCallResult:
         start_time = time.time()
         effective_timeout = timeout_seconds if timeout_seconds is not None else DEFAULT_OPERATION_TIMEOUT_SECONDS
@@ -466,6 +527,7 @@ class McpClientService:
                 arguments=arguments or {},
                 timeout_seconds=effective_timeout,
                 event_callback=event_callback,
+                cancel_event=cancel_event,
                 command=command,
                 args=args,
                 env=env,
@@ -475,6 +537,12 @@ class McpClientService:
             )
             result.duration_ms = int((time.time() - start_time) * 1000)
             return result
+        except McpCancelledError as exc:
+            return McpToolCallResult(
+                success=False,
+                error=f"MCP tool call cancelled: {exc}",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
         except TimeoutError:
             return McpToolCallResult(
                 success=False,
@@ -580,6 +648,7 @@ class McpClientService:
         timeout_seconds: float,
         resource_concurrency: int,
         event_callback: Callable[[dict[str, Any]], None] | None = None,
+        cancel_event: asyncio.Event | None = None,
         command: str | None = None,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
@@ -597,7 +666,7 @@ class McpClientService:
         不影响主 tool_result 的可用性（与计划中的 "warn + 占位" 策略对齐）。
         """
         transport_labels = {"stdio": "STDIO", "sse": "SSE", "http": "HTTP"}
-        async with asyncio.timeout(timeout_seconds):
+        async with _cancel_aware_timeout(timeout_seconds, cancel_event):
             _emit_event(
                 event_callback,
                 stage="transport_connect",
@@ -718,6 +787,7 @@ class McpClientService:
         resource_concurrency: int = 4,
         event_callback: Callable[[dict[str, Any]], None] | None = None,
         stderr_callback: Callable[[str], None] | None = None,
+        cancel_event: asyncio.Event | None = None,
     ) -> McpToolCallWithResourcesResult:
         """连接 MCP Server，调用工具并在同会话内拉取所有 ResourceLink。"""
         start_time = time.time()
@@ -744,6 +814,7 @@ class McpClientService:
                 timeout_seconds=effective_timeout,
                 resource_concurrency=resource_concurrency,
                 event_callback=event_callback,
+                cancel_event=cancel_event,
                 command=command,
                 args=args,
                 env=env,
@@ -753,6 +824,14 @@ class McpClientService:
             )
             result.tool_result.duration_ms = int((time.time() - start_time) * 1000)
             return result
+        except McpCancelledError as exc:
+            return McpToolCallWithResourcesResult(
+                tool_result=McpToolCallResult(
+                    success=False,
+                    error=f"MCP tool call cancelled: {exc}",
+                    duration_ms=int((time.time() - start_time) * 1000),
+                ),
+            )
         except TimeoutError:
             return McpToolCallWithResourcesResult(
                 tool_result=McpToolCallResult(

--- a/apps/negentropy/src/negentropy/interface/mcp_client.py
+++ b/apps/negentropy/src/negentropy/interface/mcp_client.py
@@ -537,12 +537,8 @@ class McpClientService:
             )
             result.duration_ms = int((time.time() - start_time) * 1000)
             return result
-        except McpCancelledError as exc:
-            return McpToolCallResult(
-                success=False,
-                error=f"MCP tool call cancelled: {exc}",
-                duration_ms=int((time.time() - start_time) * 1000),
-            )
+        except McpCancelledError:
+            raise
         except TimeoutError:
             return McpToolCallResult(
                 success=False,
@@ -824,14 +820,8 @@ class McpClientService:
             )
             result.tool_result.duration_ms = int((time.time() - start_time) * 1000)
             return result
-        except McpCancelledError as exc:
-            return McpToolCallWithResourcesResult(
-                tool_result=McpToolCallResult(
-                    success=False,
-                    error=f"MCP tool call cancelled: {exc}",
-                    duration_ms=int((time.time() - start_time) * 1000),
-                ),
-            )
+        except McpCancelledError:
+            raise
         except TimeoutError:
             return McpToolCallWithResourcesResult(
                 tool_result=McpToolCallResult(

--- a/apps/negentropy/src/negentropy/knowledge/cancellation.py
+++ b/apps/negentropy/src/negentropy/knowledge/cancellation.py
@@ -69,6 +69,15 @@ def unregister_cancellable_run(run_id: str) -> None:
     _CANCEL_EVENTS.pop(run_id, None)
 
 
+def get_cancel_event(run_id: str) -> asyncio.Event | None:
+    """返回 run_id 对应的 cancel Event（如已注册），否则 None。
+
+    下游消费者（如 MCP client）通过此函数获取 Event 引用，
+    在长时间操作中监听取消信号，无需耦合 registry 内部实现。
+    """
+    return _CANCEL_EVENTS.get(run_id)
+
+
 def _registry_size() -> int:
     """仅用于测试：返回当前 registry 大小，验证内存泄漏防护。"""
     return len(_CANCEL_EVENTS)

--- a/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
@@ -1804,6 +1804,7 @@ class DataExtractorProvider:
         filename: str | None = None,
         content_type: str | None = None,
         tracker: Any | None = None,
+        cancel_event: Any | None = None,
     ) -> ExtractedDocumentResult:
         targets = resolve_targets(corpus_config, source_kind)
         if not targets:
@@ -1842,6 +1843,7 @@ class DataExtractorProvider:
                 tracker=tracker,
                 stage_name=stage_name,
                 llm_config_id=llm_config_id,
+                cancel_event=cancel_event,
             )
             attempts.append(attempt["attempt"])
 
@@ -1908,6 +1910,7 @@ class DataExtractorProvider:
         tracker: Any | None = None,
         stage_name: str | None = None,
         llm_config_id: str | None = None,
+        cancel_event: Any | None = None,
     ) -> dict[str, Any]:
         # 超时兜底: 当 target 未显式配置 timeout_ms 时，按 source_kind 填充合理默认值
         if not target.timeout_ms:
@@ -2106,6 +2109,7 @@ class DataExtractorProvider:
                     plan=plan,
                     tracker=tracker,
                     stage_name=stage_name,
+                    cancel_event=cancel_event,
                 )
                 invocation_trace.append(
                     {
@@ -2189,6 +2193,7 @@ class DataExtractorProvider:
         plan: AdaptiveToolInvocationPlan,
         tracker: Any | None = None,
         stage_name: str | None = None,
+        cancel_event: Any | None = None,
     ) -> tuple[Any, dict[str, Any], dict[str, str]]:
         """调用 MCP 工具并在同会话内拉取所有 ResourceLink 动态资源。
 
@@ -2213,6 +2218,7 @@ class DataExtractorProvider:
                 timeout_seconds=(target.timeout_ms / 1000.0) if target.timeout_ms else None,
                 external_event_sink=event_sink,
                 resolve_resource_links=True,
+                cancel_event=cancel_event,
             )
             return (
                 execution.call_result,
@@ -2341,6 +2347,7 @@ async def extract_source(
     filename: str | None = None,
     content_type: str | None = None,
     tracker: Any | None = None,
+    cancel_event: Any | None = None,
 ) -> ExtractedDocumentResult:
     targets = resolve_targets(corpus_config, source_kind)
     if not targets:
@@ -2363,6 +2370,7 @@ async def extract_source(
         filename=filename,
         content_type=content_type,
         tracker=tracker,
+        cancel_event=cancel_event,
     )
 
 

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from negentropy.logging import get_logger
 
 from .cancellation import (
+    get_cancel_event,
     is_cancelled,
     register_cancellable_run,
     unregister_cancellable_run,
@@ -597,14 +598,20 @@ class KnowledgeService:
         tracker: PipelineTracker | None = None,
     ) -> tuple[str, ExtractedDocumentResult]:
         """提取 URL 内容，返回 (plain_text, 完整结果)"""
-        result = await extract_source(
-            app_name=app_name,
-            corpus_id=corpus_id,
-            corpus_config=await self._get_corpus_config(corpus_id),
-            source_kind=ROUTE_URL,
-            url=url,
-            tracker=tracker,
-        )
+        cancel_event = get_cancel_event(tracker.run_id) if tracker else None
+        try:
+            result = await extract_source(
+                app_name=app_name,
+                corpus_id=corpus_id,
+                corpus_config=await self._get_corpus_config(corpus_id),
+                source_kind=ROUTE_URL,
+                url=url,
+                tracker=tracker,
+                cancel_event=cancel_event,
+            )
+        except Exception as exc:
+            self._raise_if_mcp_cancelled(exc, tracker)
+            raise
         return result.plain_text, result
 
     async def _extract_file_content(
@@ -637,16 +644,22 @@ class KnowledgeService:
         content_type: str | None,
         tracker: PipelineTracker | None = None,
     ) -> ExtractedDocumentResult:
-        result = await extract_source(
-            app_name=app_name,
-            corpus_id=corpus_id,
-            corpus_config=await self._get_corpus_config(corpus_id),
-            source_kind=resolve_source_kind(filename=filename, content_type=content_type),
-            content=content,
-            filename=filename,
-            content_type=content_type,
-            tracker=tracker,
-        )
+        cancel_event = get_cancel_event(tracker.run_id) if tracker else None
+        try:
+            result = await extract_source(
+                app_name=app_name,
+                corpus_id=corpus_id,
+                corpus_config=await self._get_corpus_config(corpus_id),
+                source_kind=resolve_source_kind(filename=filename, content_type=content_type),
+                content=content,
+                filename=filename,
+                content_type=content_type,
+                tracker=tracker,
+                cancel_event=cancel_event,
+            )
+        except Exception as exc:
+            self._raise_if_mcp_cancelled(exc, tracker)
+            raise
         return result
 
     @staticmethod
@@ -665,6 +678,18 @@ class KnowledgeService:
             }
             raise ValueError(f"Extractor produced empty document after normalization: {diagnostics}")
         return plain_text or markdown
+
+    @staticmethod
+    def _raise_if_mcp_cancelled(exc: Exception, tracker: PipelineTracker | None) -> None:
+        """若异常为 McpCancelledError，转换为 PipelineCancelled 向上传播。
+
+        集中在 _extract_file_document / _extract_url_content 层做转换，
+        让顶层 execute_*_pipeline 的现有 ``except PipelineCancelled`` 处理逻辑无需变更。
+        """
+        from negentropy.interface.mcp_client import McpCancelledError
+
+        if isinstance(exc, McpCancelledError) and tracker:
+            raise PipelineCancelled(tracker.run_id, last_stage=tracker.current_stage) from None
 
     # =========================================================================
     # Pipeline 创建与执行（支持异步后台任务）


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：知识库构建 Runs 执行 PDF 提取时，MCP 工具调用（`parse_pdf_to_markdown`）可能长达 300s，但协作式取消仅在 stage 边界检查，无法中断进行中的 MCP 调用。用户点击取消后需等待超时才能生效。
- 关联上下文：Connection timeout after 300.0s 运行级错误；MCP 提取失败导致整个 pipeline 终止。

# 核心变更
- 新增 `McpCancelledError` 异常类型和 `_cancel_aware_timeout` 异步上下文管理器（`mcp_client.py`）：通过 watcher task 监听 `asyncio.Event` 取消信号，触发时调用 `current_task.cancel()` 注入 CancelledError 并转换为 McpCancelledError，实现即时中断 MCP HTTP 连接/stdio 子进程
- 新增 `get_cancel_event()` 函数（`cancellation.py`）：允许下游获取 cancel Event 引用
- 将 `cancel_event` 参数从 `KnowledgeService` → `extract_source` → `DataExtractorProvider` → `McpToolExecutionService` → `McpClientService` 逐层透传（5 个文件，8 个方法签名）
- 在 `_extract_file_document` / `_extract_url_content` 层将 `McpCancelledError` 转换为 `PipelineCancelled`，复用现有顶层取消处理逻辑
- 所有新增参数默认 `None`，无 cancel_event 时走原有 `asyncio.timeout` 路径，零影响现有调用者

# 风险与回滚
- 主要风险：watcher task 在极端情况下可能未正确清理；`CancelledError` 转换逻辑依赖 `cancel_event.is_set()` 检查，与 asyncio 内部取消存在理论上的竞争窗口
- 回滚方式：`git revert` 本 commit 即可，所有变更均为新增参数/方法，不影响现有 API 契约

# 验证证据
- 单元测试：23 个既有取消测试全部通过，18 个提取管线测试全部通过
- 集成测试：依赖后续端到端验证（上传大 PDF → 点击取消 → 验证进程终止）
- 覆盖率/关键截图：ruff lint/format 全部通过

# 影响范围
- 前端：无变更（UI 取消按钮和 API 已存在）
- 后端：`mcp_client.py`、`execution.py`、`cancellation.py`、`extraction.py`、`service.py`
- GitHub Actions / 文档：无变更

# Next Best Action
- 当 `negentropy-perceives` MCP Server 支持异步操作模式后（`submit_pdf_job` + `poll_job_status`），可进一步优化为真正的异步+轮询模式，完全消除长连接问题