### PR TITLE
fix(knowledge): 修复 Documents 页 Markdown 文档图片加载死锁

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -103,7 +103,6 @@ function DocumentImage({
       <img
         src={resolvedSrc}
         alt={alt || ""}
-        loading="lazy"
         className={cn(
           "max-w-full rounded-lg border border-zinc-200 dark:border-zinc-700",
           imgState === "loaded" ? "block" : "hidden",


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Documents 页中的 Markdown 文档图片永远处于 loading 状态，无法完成加载。根因是 `DocumentImage` 组件中 `loading="lazy"` 属性与 `display: none` 隐藏策略组合形成死锁——Chrome 的 lazy loading 机制将 zero-rect 元素视为"不在视口"，永远不发起网络请求；`onLoad` 永远不触发，状态永远卡在 loading。
- 关联上下文/Issue/文档：与 #540 (PDF 转 Markdown 图片提取持久化) 前端渲染增强相关

# 核心变更
- 移除 `DocumentMarkdownRenderer.tsx` 中 `<img>` 元素的 `loading="lazy"` 属性，由组件自身的三态管理（loading/loaded/error）控制图片加载流程

# 风险与回滚
- 主要风险：无 `loading="lazy"` 后文档页所有图片立即发起请求，对于图片较多的长文档可能增加初始网络负载，但实际影响极小
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无新增（已有 `DocumentMarkdownRenderer.test.tsx`）
- 集成测试：无
- E2E/Workflow：浏览器实机验证——移除 `loading="lazy"` 后 4 张图片均从 loading 状态成功加载为可见图片（`complete: true`, `display: block`）
- 覆盖率/关键截图：通过 Chrome DevTools 验证，图片 `naturalWidth` 正确，网络请求返回 200

# 影响范围
- 前端：`DocumentMarkdownRenderer.tsx` 组件
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 如后续需要对长文档做图片懒加载优化，可采用 IntersectionObserver 替代原生 `loading="lazy"`，在图片进入视口前使用 `visibility: hidden` 而非 `display: none`