### PR TITLE
feat(Session): 恢复 Home 会话自动标题——巡检补齐 + 来源跟踪 + reasoning 凭证修复

### DIFF
--- a/apps/negentropy/src/negentropy/config/services.py
+++ b/apps/negentropy/src/negentropy/config/services.py
@@ -74,6 +74,39 @@ class ServicesSettings(BaseSettings):
     vertex_location: str | None = Field(default=None, description="VertexAI location")
     vertex_agent_engine_id: str | None = Field(default=None, description="VertexAI Agent Engine ID")
 
+    # Session Title Auto-Generation Inspector
+    # 反应式触发（首条 user 消息）由 PostgresSessionService 内联完成；
+    # 这里的巡检负责：(a) 为历史 / 失败 session 补齐标题；(b) 在事件量显著增长后刷新。
+    # 仅处理 metadata.title_source == "auto"（含缺省默认值），永不覆盖 manual / legacy。
+    session_title_inspect_enabled: bool = Field(
+        default=True,
+        description="Enable periodic session-title backfill/refresh job",
+    )
+    session_title_inspect_interval: int = Field(
+        default=300,
+        description="Tick interval seconds (default 5min)",
+    )
+    session_title_inspect_concurrency: int = Field(
+        default=2,
+        description="Max concurrent LLM title generations per tick",
+    )
+    session_title_inspect_batch_size: int = Field(
+        default=20,
+        description="Max sessions inspected per tick",
+    )
+    session_title_inspect_min_events: int = Field(
+        default=1,
+        description="Minimum event count required before a session is eligible",
+    )
+    session_title_inspect_refresh_event_delta: int = Field(
+        default=20,
+        description="Refresh existing auto-title once max(sequence_num) grew by this many events",
+    )
+    session_title_inspect_max_attempts: int = Field(
+        default=5,
+        description="Skip session after this many consecutive generation failures",
+    )
+
     @classmethod
     def settings_customise_sources(
         cls,

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/session_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/session_service.py
@@ -297,7 +297,7 @@ class PostgresSessionService(BaseSessionService):
         meta_result = await db.execute(select(self.Thread.metadata_).where(self.Thread.id == uuid.UUID(session_id)))
         current_metadata = meta_result.scalar() or {}
         next_metadata = dict(current_metadata)
-        next_metadata["title_attempt_count"] = int(next_metadata.get("title_attempt_count", 0)) + 1
+        next_metadata["title_attempt_count"] = int(next_metadata.get("title_attempt_count") or 0) + 1
         next_metadata["title_last_attempt_at"] = datetime.now(UTC).isoformat()
         await db.execute(
             update(self.Thread).where(self.Thread.id == uuid.UUID(session_id)).values(metadata_=next_metadata)

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/session_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/session_service.py
@@ -31,7 +31,7 @@ from google.adk.sessions.base_session_service import (
     GetSessionConfig,
     ListSessionsResponse,
 )
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # ORM 模型与会话工厂
@@ -241,8 +241,77 @@ class PostgresSessionService(BaseSessionService):
         event.id = event_id
         return event
 
-    async def _generate_title_for_session(self, session_id: str) -> None:
-        """后台生成标题并更新 metadata_"""
+    @staticmethod
+    def _title_skip_reason(metadata: dict, *, force_refresh: bool) -> str | None:
+        """判断该 session 是否应跳过标题生成。
+
+        返回值：
+        - "manual"：用户手动设置过，永不覆盖
+        - "legacy"：标题存在但缺少 title_source，保守视为 manual
+        - "already_titled"：已是 auto 标题且未要求强制刷新
+        - None：可以生成
+        """
+        if metadata.get("title_source") == "manual":
+            return "manual"
+        has_title = bool(metadata.get("title"))
+        if has_title and metadata.get("title_source") is None:
+            return "legacy"
+        if has_title and not force_refresh:
+            return "already_titled"
+        return None
+
+    async def _persist_generated_title(
+        self,
+        db: AsyncSession,
+        session_id: str,
+        title: str,
+        max_event_seq: int,
+        current_metadata: dict | None = None,
+    ) -> None:
+        """原子写入 auto 标题与溯源字段（title_source / generated_at / event_seq）。
+
+        反应触发与 title_inspector 巡检共用同一持久化路径，保障 metadata 形状一致。
+        """
+        if current_metadata is None:
+            meta_result = await db.execute(select(self.Thread.metadata_).where(self.Thread.id == uuid.UUID(session_id)))
+            current_metadata = meta_result.scalar() or {}
+        next_metadata = dict(current_metadata)
+        next_metadata["title"] = title
+        next_metadata["title_source"] = "auto"
+        next_metadata["title_generated_at_event_seq"] = max_event_seq
+        next_metadata["title_generated_at"] = datetime.now(UTC).isoformat()
+        # 成功生成后重置失败计数，恢复对该 session 的巡检尝试
+        next_metadata.pop("title_attempt_count", None)
+        next_metadata.pop("title_last_attempt_at", None)
+        await db.execute(
+            update(self.Thread).where(self.Thread.id == uuid.UUID(session_id)).values(metadata_=next_metadata)
+        )
+        await db.commit()
+
+    async def _record_title_attempt_failure(self, db: AsyncSession, session_id: str) -> None:
+        """记录一次生成失败：累加 attempt_count + 写入 last_attempt_at。
+
+        巡检候选 SQL 会根据 attempt_count >= max_attempts 把该 session 移出候选池，
+        避免单 session 反复失败拖垮 LLM 配额。
+        """
+        meta_result = await db.execute(select(self.Thread.metadata_).where(self.Thread.id == uuid.UUID(session_id)))
+        current_metadata = meta_result.scalar() or {}
+        next_metadata = dict(current_metadata)
+        next_metadata["title_attempt_count"] = int(next_metadata.get("title_attempt_count", 0)) + 1
+        next_metadata["title_last_attempt_at"] = datetime.now(UTC).isoformat()
+        await db.execute(
+            update(self.Thread).where(self.Thread.id == uuid.UUID(session_id)).values(metadata_=next_metadata)
+        )
+        await db.commit()
+
+    async def _generate_title_for_session(self, session_id: str, *, force_refresh: bool = False) -> None:
+        """后台生成标题并更新 metadata_
+
+        Args:
+            session_id: 目标 session
+            force_refresh: 巡检在内容显著增长时传 True，绕过 "already_titled" 跳过；
+                manual / legacy session 在任何情况下均不会被覆盖。
+        """
         self._validate_session_id(session_id)
 
         from google.genai import types
@@ -255,7 +324,14 @@ class PostgresSessionService(BaseSessionService):
         async with db_session.AsyncSessionLocal() as db:
             meta_result = await db.execute(select(self.Thread.metadata_).where(self.Thread.id == uuid.UUID(session_id)))
             current_metadata = meta_result.scalar() or {}
-            if current_metadata.get("title"):
+            skip_reason = self._title_skip_reason(current_metadata, force_refresh=force_refresh)
+            if skip_reason:
+                logger.debug(
+                    "title_generation_skipped",
+                    session_id=session_id,
+                    reason=skip_reason,
+                    force_refresh=force_refresh,
+                )
                 return
 
             events_result = await db.execute(
@@ -287,33 +363,59 @@ class PostgresSessionService(BaseSessionService):
             if not history:
                 return
 
+            logger.info(
+                "title_generation_started",
+                session_id=session_id,
+                event_count=len(recent_events),
+                force_refresh=force_refresh,
+            )
+
             try:
                 summarizer = await SessionSummarizer.create()
                 title = await summarizer.generate_title(history)
             except Exception as ex:
                 logger.warning(
-                    "Failed to generate session title",
+                    "title_generation_failed",
                     session_id=session_id,
                     error_type=type(ex).__name__,
                     error=str(ex),
                     events_count=len(recent_events),
                 )
+                await self._record_title_attempt_failure(db, session_id)
                 return
 
             if not title:
+                logger.debug("title_generation_empty", session_id=session_id)
+                await self._record_title_attempt_failure(db, session_id)
                 return
 
-            # 再次确认未被外部写入标题，避免覆盖用户手动设置
+            seq_result = await db.execute(
+                select(func.coalesce(func.max(self.Event.sequence_num), 0)).where(
+                    self.Event.thread_id == uuid.UUID(session_id)
+                )
+            )
+            max_event_seq = int(seq_result.scalar() or 0)
+
+            # 二次校验：避免与并发的手动改名 / 其他巡检 worker 产生覆盖
             meta_result = await db.execute(select(self.Thread.metadata_).where(self.Thread.id == uuid.UUID(session_id)))
             current_metadata = meta_result.scalar() or {}
-            if current_metadata.get("title"):
+            skip_reason = self._title_skip_reason(current_metadata, force_refresh=force_refresh)
+            if skip_reason:
+                logger.debug(
+                    "title_generation_skipped_after_race",
+                    session_id=session_id,
+                    reason=skip_reason,
+                )
                 return
 
-            current_metadata["title"] = title
-            await db.execute(
-                update(self.Thread).where(self.Thread.id == uuid.UUID(session_id)).values(metadata_=current_metadata)
+            await self._persist_generated_title(db, session_id, title, max_event_seq, current_metadata)
+            logger.info(
+                "title_generation_completed",
+                session_id=session_id,
+                title_length=len(title),
+                source="auto",
+                event_seq=max_event_seq,
             )
-            await db.commit()
 
     def _schedule_title_generation(self, session_id: str) -> None:
         """创建后台任务生成标题，不阻塞主流程"""
@@ -359,7 +461,11 @@ class PostgresSessionService(BaseSessionService):
         session_id: str,
         title: str | None,
     ) -> bool:
-        """更新会话标题 (metadata.title)"""
+        """更新会话标题 (metadata.title)。
+
+        - 传入非空 title：标记 ``title_source = "manual"``，巡检永不覆盖。
+        - 传入 None：清空 title 及所有 auto 溯源字段，使巡检视为 fresh-auto 重新生成。
+        """
         self._validate_session_id(session_id)
 
         async with db_session.AsyncSessionLocal() as db:
@@ -374,11 +480,17 @@ class PostgresSessionService(BaseSessionService):
             if not thread:
                 return False
 
-            current_metadata = thread.metadata_ or {}
+            current_metadata = dict(thread.metadata_ or {})
             if title:
                 current_metadata["title"] = title
+                current_metadata["title_source"] = "manual"
             else:
                 current_metadata.pop("title", None)
+                current_metadata.pop("title_source", None)
+                current_metadata.pop("title_generated_at_event_seq", None)
+                current_metadata.pop("title_generated_at", None)
+                current_metadata.pop("title_attempt_count", None)
+                current_metadata.pop("title_last_attempt_at", None)
 
             await db.execute(
                 update(self.Thread)

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -508,6 +508,26 @@ def apply_adk_patches():
                 # ``_pipeline_watchdog_tick`` 内调用 ``finalize_stale_kg_build_runs``
                 # 完全重复。已合并到统一 watchdog，避免双倍 DB 压力。
 
+                # Session 标题巡检——补齐历史 / 失败 session 的自动标题，并在内容显著
+                # 增长后刷新。反应式触发（首条 user 消息）已由 PostgresSessionService
+                # 在 append_event 中调度，巡检负责覆盖反应触发未命中的场景（历史会话
+                # 没有新 user 消息进入；或 LLM 凭证回退期间生成失败）。
+                if settings.services.session_title_inspect_enabled:
+                    from negentropy.engine.title_inspector import SessionTitleInspector
+
+                    title_inspector = SessionTitleInspector(
+                        concurrency=settings.services.session_title_inspect_concurrency,
+                        batch_size=settings.services.session_title_inspect_batch_size,
+                        min_events=settings.services.session_title_inspect_min_events,
+                        refresh_event_delta=settings.services.session_title_inspect_refresh_event_delta,
+                        max_attempts=settings.services.session_title_inspect_max_attempts,
+                    )
+                    scheduler.register(
+                        key="session_title_inspector",
+                        callback=title_inspector.tick,
+                        interval_seconds=settings.services.session_title_inspect_interval,
+                    )
+
                 scheduler.start()
                 # 把 scheduler 挂在 app.state 防止被 GC + 便于单测/shutdown 引用
                 app.state.skill_scheduler = scheduler

--- a/apps/negentropy/src/negentropy/engine/summarization.py
+++ b/apps/negentropy/src/negentropy/engine/summarization.py
@@ -17,8 +17,15 @@ from negentropy.logging import get_logger
 
 logger = get_logger("negentropy.engine.summarization")
 
-# Title 生成对长度做硬约束（max_tokens=20）；与 LiteLlm 默认参数合并后注入。
-_TITLE_MAX_TOKENS = 20
+# Title 生成对长度的硬约束在响应后处理阶段完成（汉字截 12 / 英文截 24，见
+# ``generate_title`` 末尾），这里的 ``max_tokens`` 只用于保护 LLM 总输出预算。
+#
+# 历史值 20 在面向 reasoning 模型（gpt-5-mini / o1 / o3 等默认配置）时会被
+# 内部 reasoning tokens 全数消耗，``response.content.parts`` 为空导致
+# ``generate_title`` 返回 None。提升到 256 既能为 reasoning 留预算，又因后处理
+# 截断保证 UI 不会被长标题撑破——这是 ISSUE-082 同源根因在 Session 标题路径
+# 的呼应修复。
+_TITLE_MAX_TOKENS = 256
 
 
 class SessionSummarizer:
@@ -40,14 +47,32 @@ class SessionSummarizer:
 
         与 commit 8ce35d5 修复 ``DynamicRootLiteLlm`` 的范式一致——所有默认
         模型路径统一走 ``resolve_llm_config()``，不再回退到无凭证的硬编码值。
+
+        额外，对支持 reasoning 的 OpenAI 模型族（gpt-5 / o1 / o3 / o4）强制
+        ``reasoning_effort="minimal"``——title 生成只需短文本响应，若不显式
+        降低推理预算，模型会用尽 ``max_tokens`` 进行内部 reasoning 而返回
+        空 content，导致 ``generate_title`` 一律失败（线上观察到的根因）。
         """
-        from negentropy.config.model_resolver import resolve_llm_config
+        from negentropy.config.model_resolver import (
+            _split_vendor_and_model,
+            _supports_anthropic_thinking,
+            _supports_openai_reasoning,
+            resolve_llm_config,
+        )
 
         name, kwargs = await resolve_llm_config()
         # 防御性浅拷贝：resolver 内部已 copy（model_resolver.py:80/90/448），
         # 这里再独立一份避免对调用方/缓存层的契约耦合，max_tokens 不污染上游 dict。
         kwargs = dict(kwargs)
         kwargs["max_tokens"] = _TITLE_MAX_TOKENS
+
+        vendor, model_name = _split_vendor_and_model(name)
+        if _supports_openai_reasoning(vendor or "", model_name):
+            kwargs["reasoning_effort"] = "minimal"
+        elif _supports_anthropic_thinking(vendor or "", model_name):
+            # title 不需要 extended thinking；显式 disabled 避免吞光预算
+            kwargs["thinking"] = {"type": "disabled"}
+
         return cls(LiteLlm(name, **kwargs))
 
     async def generate_title(self, history: list[types.Content]) -> str | None:
@@ -73,14 +98,14 @@ class SessionSummarizer:
             instruction = types.Content(role="user", parts=[types.Part(text=prompt)])
             chat_history.append(instruction)
 
-            logger.debug("title_generation_request", event_count=len(history), max_tokens=20)
+            logger.debug("title_generation_request", event_count=len(history), max_tokens=_TITLE_MAX_TOKENS)
 
             request = LlmRequest(
                 contents=chat_history,
                 config=types.GenerateContentConfig(
                     system_instruction=prompt,
                     temperature=0.3,
-                    max_output_tokens=20,
+                    max_output_tokens=_TITLE_MAX_TOKENS,
                 ),
             )
 
@@ -88,10 +113,18 @@ class SessionSummarizer:
             async for response in self.model.generate_content_async(request):
                 if response.content and response.content.parts:
                     for part in response.content.parts:
+                        # 跳过 reasoning / thought parts（gpt-5 系反应模型常见），
+                        # 仅采纳可见输出。否则 response_text 会混入推理流水账，
+                        # 后处理截断后得到一段无意义片段。
+                        if getattr(part, "thought", False):
+                            continue
                         if part.text:
                             response_text += part.text
 
             logger.debug("llm_response_received", response_length=len(response_text))
+
+            if not response_text:
+                logger.warning("title_generation_empty_response", history_length=len(history))
 
             if response_text:
                 title = response_text.strip().strip('"').strip("'")

--- a/apps/negentropy/src/negentropy/engine/title_inspector.py
+++ b/apps/negentropy/src/negentropy/engine/title_inspector.py
@@ -1,0 +1,241 @@
+"""SessionTitleInspector — 周期巡检 Session 自动标题
+
+定位（与 PostgresSessionService 的反应式触发互补）：
+- 反应式触发：用户首条消息追加时由 ``append_event`` 调度，覆盖**新**会话首次成标题。
+- 巡检：周期扫描全表，补齐历史 / 失败 / 默认前缀 session；当 auto 标题对应的事件数
+  显著增长后也会刷新一次，避免标题与最新对话脱节。
+
+设计要点：
+1. **共用持久化路径**：直接调用 ``PostgresSessionService._generate_title_for_session``
+   完成实际工作，所有 metadata 写入与跳过判定都在那里，保持单一事实源。
+2. **候选筛选下推 Postgres**：单条 SQL + JSONB 操作完成过滤，巡检 Python 侧零全表扫描。
+3. **多 worker 安全**：每 session 一把 Postgres advisory lock，非阻塞 try-lock，
+   失败即跳过，不阻塞用户 PATCH 改名（advisory lock 与行可见性正交）。
+4. **失败退避**：``title_attempt_count >= max_attempts`` 的 session 自动移出候选池。
+5. **手动 / legacy 保护**：``title_source = 'manual'`` 永不覆盖；``title`` 存在但
+   ``title_source`` 缺失的 legacy 行保守视为 manual。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import text
+
+import negentropy.db.session as db_session
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.engine.title_inspector")
+
+
+@dataclass(frozen=True)
+class TitleCandidate:
+    """巡检候选 session 的最小信息。"""
+
+    session_id: uuid.UUID
+    max_event_seq: int
+    title_generated_at_event_seq: int
+    has_title: bool
+
+
+# 候选筛选 SQL（Postgres 侧过滤，巡检 Python 侧零全表扫描）。
+#
+# 关键过滤：
+# - archived 为 false（不修复归档会话）
+# - title_source 缺省视为 'auto'（兼容尚未设置 source 的全新会话）
+# - title_attempt_count < :max_attempts（退避）
+# - 至少有 :min_events 条事件（避免空会话生成空洞标题）
+# - 标题为空或缺失 OR 事件数已增长 >= :refresh_delta（刷新条件）
+#
+# 备注：legacy 行（有 title 无 title_source）在 HAVING 子句中会被 title 非空与
+# refresh_delta 两条件共同截留——它们的 title_generated_at_event_seq 缺省视为 0，
+# 但 _title_skip_reason 在反应路径中会再次拦截，二次确保不被覆盖。
+_CANDIDATE_SQL = text(
+    """
+    SELECT
+        t.id::text                                                          AS session_id,
+        COALESCE(MAX(e.sequence_num), 0)                                    AS max_seq,
+        COALESCE((t.metadata->>'title_generated_at_event_seq')::int, 0)     AS gen_seq,
+        ((t.metadata->>'title') IS NOT NULL AND (t.metadata->>'title') <> '') AS has_title
+    FROM negentropy.threads t
+    LEFT JOIN negentropy.events e ON e.thread_id = t.id
+    WHERE COALESCE((t.metadata->>'archived')::bool, false) = false
+      AND COALESCE((t.metadata->>'title_source'), 'auto') = 'auto'
+      AND COALESCE((t.metadata->>'title_attempt_count')::int, 0) < :max_attempts
+    GROUP BY t.id
+    HAVING COUNT(e.id) >= :min_events
+       AND (
+            (t.metadata->>'title') IS NULL OR (t.metadata->>'title') = ''
+         OR COALESCE(MAX(e.sequence_num), 0)
+            - COALESCE((t.metadata->>'title_generated_at_event_seq')::int, 0)
+            >= :refresh_delta
+       )
+    ORDER BY (t.metadata->>'title') NULLS FIRST, COALESCE(MAX(e.sequence_num), 0) DESC
+    LIMIT :batch_size
+    """
+)
+
+
+class SessionTitleInspector:
+    """周期性会话标题巡检任务。
+
+    使用方式（见 ``engine/bootstrap.py``）：
+        inspector = SessionTitleInspector(...)
+        scheduler.register(
+            key="session_title_inspector",
+            callback=inspector.tick,
+            interval_seconds=settings.services.session_title_inspect_interval,
+        )
+    """
+
+    def __init__(
+        self,
+        *,
+        concurrency: int = 2,
+        batch_size: int = 20,
+        min_events: int = 1,
+        refresh_event_delta: int = 20,
+        max_attempts: int = 5,
+        session_service=None,
+    ) -> None:
+        self.concurrency = max(1, int(concurrency))
+        self.batch_size = max(1, int(batch_size))
+        self.min_events = max(0, int(min_events))
+        self.refresh_event_delta = max(1, int(refresh_event_delta))
+        self.max_attempts = max(1, int(max_attempts))
+        # DI 入口：测试可注入独立 PostgresSessionService 实例，避免与共享单例
+        # 状态（如其他测试的 mock 注入或缓存）耦合。生产路径不传，tick 时通过
+        # ``get_session_service()`` 走单例工厂。
+        self._session_service_override = session_service
+
+    async def tick(self) -> None:
+        """一次调度心跳：扫描候选 → 为每个 session 生成或刷新标题。
+
+        ``AsyncScheduler`` 已为本回调提供时间门控与单实例互斥（``job.running`` flag），
+        我们在这里只需关心**单进程内并发限流**与**多进程互斥**（advisory lock）。
+        """
+        from negentropy.engine.adapters.postgres.session_service import (
+            PostgresSessionService,
+        )
+
+        if self._session_service_override is not None:
+            session_service = self._session_service_override
+        else:
+            from negentropy.engine.factories.session import get_session_service
+
+            session_service = get_session_service()
+        if not isinstance(session_service, PostgresSessionService):
+            logger.debug(
+                "title_inspector_skipped_non_postgres_backend",
+                backend=type(session_service).__name__,
+            )
+            return
+
+        candidates = await self._find_candidates()
+        if not candidates:
+            logger.debug("title_inspector_no_candidates")
+            return
+
+        logger.info("title_inspector_tick_started", candidate_count=len(candidates))
+
+        sem = asyncio.Semaphore(self.concurrency)
+
+        async def _bounded(candidate: TitleCandidate) -> None:
+            async with sem:
+                await self._process_candidate(candidate, session_service)
+
+        results = await asyncio.gather(
+            *(_bounded(c) for c in candidates),
+            return_exceptions=True,
+        )
+        # 异常聚合上报（候选间相互独立，单 session 失败不应阻断整批）
+        errors = [r for r in results if isinstance(r, Exception)]
+        logger.info(
+            "title_inspector_tick_completed",
+            candidate_count=len(candidates),
+            error_count=len(errors),
+        )
+        for err in errors:
+            logger.warning(
+                "title_inspector_candidate_failed",
+                error_type=type(err).__name__,
+                error=str(err),
+            )
+
+    async def _find_candidates(self) -> list[TitleCandidate]:
+        async with db_session.AsyncSessionLocal() as db:
+            result = await db.execute(
+                _CANDIDATE_SQL,
+                {
+                    "max_attempts": self.max_attempts,
+                    "min_events": self.min_events,
+                    "refresh_delta": self.refresh_event_delta,
+                    "batch_size": self.batch_size,
+                },
+            )
+            rows = result.mappings().all()
+        return [
+            TitleCandidate(
+                session_id=uuid.UUID(row["session_id"]),
+                max_event_seq=int(row["max_seq"]),
+                title_generated_at_event_seq=int(row["gen_seq"]),
+                has_title=bool(row["has_title"]),
+            )
+            for row in rows
+        ]
+
+    async def _process_candidate(self, candidate: TitleCandidate, session_service) -> None:
+        sid_str = str(candidate.session_id)
+        force_refresh = candidate.has_title and (
+            candidate.max_event_seq - candidate.title_generated_at_event_seq >= self.refresh_event_delta
+        )
+
+        lock_key = self._lock_key_for_session(candidate.session_id)
+        # 注意：advisory lock 必须在独立连接上，以便跨整段生成（含 LLM 调用 ~1-3s）持有；
+        # ``_generate_title_for_session`` 会自行开新连接处理读写，两者不冲突。
+        async with db_session.AsyncSessionLocal() as lock_conn:
+            got = (
+                await lock_conn.execute(
+                    text("SELECT pg_try_advisory_lock(:k)"),
+                    {"k": lock_key},
+                )
+            ).scalar()
+            if not got:
+                logger.debug(
+                    "title_inspector_lock_held_elsewhere",
+                    session_id=sid_str,
+                )
+                return
+            try:
+                logger.debug(
+                    "title_inspector_processing",
+                    session_id=sid_str,
+                    force_refresh=force_refresh,
+                    has_title=candidate.has_title,
+                    max_event_seq=candidate.max_event_seq,
+                )
+                await session_service._generate_title_for_session(
+                    sid_str,
+                    force_refresh=force_refresh,
+                )
+            finally:
+                await lock_conn.execute(
+                    text("SELECT pg_advisory_unlock(:k)"),
+                    {"k": lock_key},
+                )
+                await lock_conn.commit()
+
+    @staticmethod
+    def _lock_key_for_session(session_id: uuid.UUID) -> int:
+        """将 UUID 映射为 64-bit signed int 供 ``pg_*_advisory_lock`` 使用。
+
+        取 UUID 前 8 字节，big-endian、signed 解析，落入 ``[-2^63, 2^63-1]``，
+        命中 Postgres BIGINT 类型。冲突概率约 1/2^64（uuid4 前 8 字节随机），
+        在百万级 session 量下仍远低于其他失败路径。
+        """
+        return int.from_bytes(session_id.bytes[:8], "big", signed=True)
+
+
+__all__ = ["SessionTitleInspector", "TitleCandidate"]

--- a/apps/negentropy/tests/integration_tests/engine/test_title_inspector.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_title_inspector.py
@@ -1,0 +1,394 @@
+"""SessionTitleInspector 端到端集成测试
+
+覆盖巡检的 6 类核心行为：
+1. 全新会话 backfill（无 title）→ 生成 + 标记 title_source=auto
+2. manual 永不覆盖（title_source=manual）
+3. legacy 永不覆盖（有 title 无 title_source）
+4. 事件量显著增长后强制刷新（force_refresh 路径）
+5. 失败累计 >= max_attempts 自动退出候选池
+6. update_session_title 在写/清两条路径上的 metadata 形状契约
+
+LLM 摘要器通过 monkeypatch 替换为 ``DummySummarizer``，避免外部依赖。
+DB 写入复用项目根 conftest 注入的测试库 ``AsyncSessionLocal``。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from google.adk.events import Event as ADKEvent
+from sqlalchemy import select, update
+
+import negentropy.db.session as db_session
+from negentropy.engine.adapters.postgres.session_service import PostgresSessionService
+from negentropy.engine.title_inspector import SessionTitleInspector
+
+
+class _StableSummarizer:
+    """每次 generate_title 返回相同标题，验证 backfill 与 manual/legacy 保护。"""
+
+    @classmethod
+    async def create(cls) -> _StableSummarizer:
+        return cls()
+
+    async def generate_title(self, history) -> str:
+        return "首次标题"
+
+
+class _CountingSummarizer:
+    """每次调用返回带递增编号的标题，验证 refresh 后内容确实被覆盖。"""
+
+    _counter = 0
+
+    @classmethod
+    async def create(cls) -> _CountingSummarizer:
+        return cls()
+
+    async def generate_title(self, history) -> str:
+        _CountingSummarizer._counter += 1
+        return f"标题 v{_CountingSummarizer._counter}"
+
+
+class _FailingSummarizer:
+    """LLM 调用总是抛错，用于验证 attempt_count 退避。"""
+
+    @classmethod
+    async def create(cls) -> _FailingSummarizer:
+        return cls()
+
+    async def generate_title(self, history):
+        raise RuntimeError("simulated LLM auth failure")
+
+
+async def _append_user_event(service: PostgresSessionService, session, text: str) -> None:
+    event = ADKEvent(
+        id=str(uuid.uuid4()),
+        author="user",
+        content={"parts": [{"text": text}]},
+    )
+    await service.append_event(session, event)
+
+
+async def _get_metadata(session_id: str) -> dict:
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        result = await db.execute(select(Thread.metadata_).where(Thread.id == uuid.UUID(session_id)))
+        return result.scalar() or {}
+
+
+async def _force_metadata(session_id: str, metadata: dict) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        await db.execute(update(Thread).where(Thread.id == uuid.UUID(session_id)).values(metadata_=metadata))
+        await db.commit()
+
+
+# ---------- Inspector backfill / refresh / skip ----------
+
+
+@pytest.mark.asyncio
+async def test_inspector_backfills_session_without_title(monkeypatch):
+    """无 title 的 fresh-auto session 被巡检 backfill。"""
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _StableSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"inspector_backfill_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    # 用 author!=user 追加事件，绕过反应式触发，模拟历史 session 留下的孤儿。
+    event = ADKEvent(
+        id=str(uuid.uuid4()),
+        author="assistant",
+        content={"parts": [{"text": "历史回复，没有触发标题"}]},
+    )
+    await service.append_event(session, event)
+    await service.wait_for_background_tasks()
+    pre = await _get_metadata(session.id)
+    assert "title" not in pre
+
+    inspector = SessionTitleInspector(batch_size=10, min_events=1, refresh_event_delta=20, session_service=service)
+    await inspector.tick()
+
+    post = await _get_metadata(session.id)
+    assert post.get("title") == "首次标题"
+    assert post.get("title_source") == "auto"
+    assert post.get("title_generated_at_event_seq", 0) >= 1
+    assert "title_generated_at" in post
+
+
+@pytest.mark.asyncio
+async def test_inspector_skips_manual_titles(monkeypatch):
+    """title_source=manual 永不被覆盖，即使有大量新事件。"""
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _StableSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"inspector_manual_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    # 用户先手动改名
+    ok = await service.update_session_title(app_name=app_name, user_id=user_id, session_id=session.id, title="我的项目")
+    assert ok
+    pre = await _get_metadata(session.id)
+    assert pre["title"] == "我的项目"
+    assert pre["title_source"] == "manual"
+
+    # 追加多个事件，让 max_seq - 0 远超 refresh_event_delta
+    for i in range(5):
+        await _append_user_event(service, session, f"消息 {i}")
+    await service.wait_for_background_tasks()
+
+    inspector = SessionTitleInspector(batch_size=10, min_events=1, refresh_event_delta=1, session_service=service)
+    await inspector.tick()
+
+    post = await _get_metadata(session.id)
+    assert post["title"] == "我的项目"
+    assert post["title_source"] == "manual"
+
+
+@pytest.mark.asyncio
+async def test_inspector_skips_legacy_titles(monkeypatch):
+    """有 title 但 title_source 缺失的 legacy 行保守视为 manual，不被覆盖。"""
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _StableSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"inspector_legacy_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    event = ADKEvent(
+        id=str(uuid.uuid4()),
+        author="assistant",
+        content={"parts": [{"text": "随便一条事件"}]},
+    )
+    await service.append_event(session, event)
+
+    # 直接植入 legacy 形状：title 有，但 title_source 缺失
+    await _force_metadata(session.id, {"title": "旧标题保留"})
+
+    inspector = SessionTitleInspector(batch_size=10, min_events=1, refresh_event_delta=1, session_service=service)
+    await inspector.tick()
+
+    post = await _get_metadata(session.id)
+    assert post["title"] == "旧标题保留"
+    assert "title_source" not in post
+
+
+@pytest.mark.asyncio
+async def test_inspector_refreshes_when_event_delta_exceeds_threshold(monkeypatch):
+    """auto 标题在事件量显著增长后被刷新；event_seq 同步更新。"""
+    _CountingSummarizer._counter = 0
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _CountingSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"inspector_refresh_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    # 首条 user 消息触发反应式生成，得到 "标题 v1"
+    await _append_user_event(service, session, "首次问候")
+    await service.wait_for_background_tasks()
+    after_first = await _get_metadata(session.id)
+    assert after_first["title"] == "标题 v1"
+    assert after_first["title_source"] == "auto"
+    first_seq = after_first["title_generated_at_event_seq"]
+
+    # 追加 3 条新事件——尚未达到 refresh_event_delta=10，巡检应跳过
+    for i in range(3):
+        await _append_user_event(service, session, f"小幅追加 {i}")
+    await service.wait_for_background_tasks()
+
+    # batch_size 设得足够大，避免共享测试库中的其他孤儿 session 把候选池占满
+    # 导致目标 session 排在 LIMIT 之外（候选 SQL 以 NULL-title 优先）。
+    inspector_short = SessionTitleInspector(
+        batch_size=500, min_events=1, refresh_event_delta=10, session_service=service
+    )
+    await inspector_short.tick()
+    unchanged = await _get_metadata(session.id)
+    assert unchanged["title"] == "标题 v1"
+
+    # 再追加事件直到 delta 跨过阈值——巡检触发刷新
+    for i in range(8):
+        await _append_user_event(service, session, f"大量追加 {i}")
+    await service.wait_for_background_tasks()
+
+    await inspector_short.tick()
+    refreshed = await _get_metadata(session.id)
+    assert refreshed["title"] != "标题 v1"
+    assert refreshed["title"].startswith("标题 v")
+    assert refreshed["title_source"] == "auto"
+    assert refreshed["title_generated_at_event_seq"] > first_seq
+
+
+@pytest.mark.asyncio
+async def test_inspector_respects_max_attempts_backoff(monkeypatch):
+    """连续失败的 session 在达到 max_attempts 后退出候选池。"""
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _FailingSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"inspector_backoff_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    event = ADKEvent(
+        id=str(uuid.uuid4()),
+        author="assistant",
+        content={"parts": [{"text": "失败重试样本"}]},
+    )
+    await service.append_event(session, event)
+
+    inspector = SessionTitleInspector(
+        batch_size=10, min_events=1, refresh_event_delta=20, max_attempts=2, session_service=service
+    )
+
+    # 第 1 次尝试：失败 → attempt_count=1
+    await inspector.tick()
+    meta1 = await _get_metadata(session.id)
+    assert meta1.get("title_attempt_count") == 1
+    assert "title" not in meta1
+
+    # 第 2 次尝试：失败 → attempt_count=2，达到 max_attempts
+    await inspector.tick()
+    meta2 = await _get_metadata(session.id)
+    assert meta2.get("title_attempt_count") == 2
+
+    # 第 3 次：候选 SQL 应已排除该 session，attempt_count 不再增长
+    await inspector.tick()
+    meta3 = await _get_metadata(session.id)
+    assert meta3.get("title_attempt_count") == 2  # unchanged
+
+
+# ---------- update_session_title metadata shape contract ----------
+
+
+@pytest.mark.asyncio
+async def test_update_session_title_marks_manual_on_set():
+    service = PostgresSessionService()
+    app_name = f"update_set_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    ok = await service.update_session_title(app_name=app_name, user_id=user_id, session_id=session.id, title="人工命名")
+    assert ok
+    meta = await _get_metadata(session.id)
+    assert meta["title"] == "人工命名"
+    assert meta["title_source"] == "manual"
+
+
+@pytest.mark.asyncio
+async def test_update_session_title_clear_removes_all_auto_keys(monkeypatch):
+    """清空 title 时应同步清除所有 auto 溯源字段，让巡检视为 fresh-auto。"""
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _StableSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"update_clear_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    # 先生成 auto 标题
+    await _append_user_event(service, session, "触发生成")
+    await service.wait_for_background_tasks()
+    meta_after_gen = await _get_metadata(session.id)
+    assert meta_after_gen["title"] == "首次标题"
+    assert meta_after_gen["title_source"] == "auto"
+    assert "title_generated_at_event_seq" in meta_after_gen
+    assert "title_generated_at" in meta_after_gen
+
+    # 清空 title
+    ok = await service.update_session_title(app_name=app_name, user_id=user_id, session_id=session.id, title=None)
+    assert ok
+    meta_after_clear = await _get_metadata(session.id)
+    assert "title" not in meta_after_clear
+    assert "title_source" not in meta_after_clear
+    assert "title_generated_at_event_seq" not in meta_after_clear
+    assert "title_generated_at" not in meta_after_clear
+
+
+# ---------- Reactive trigger now writes provenance fields ----------
+
+
+@pytest.mark.asyncio
+async def test_reactive_trigger_records_source_and_event_seq(monkeypatch):
+    """append_event 触发的生成路径也应写入 title_source=auto 与 event_seq。"""
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _StableSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"reactive_provenance_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    await _append_user_event(service, session, "你好")
+    await service.wait_for_background_tasks()
+
+    meta = await _get_metadata(session.id)
+    assert meta["title"] == "首次标题"
+    assert meta["title_source"] == "auto"
+    assert meta["title_generated_at_event_seq"] >= 1
+    assert "title_generated_at" in meta
+
+
+# ---------- Advisory lock prevents concurrent inspector runs on same session ----------
+
+
+@pytest.mark.asyncio
+async def test_advisory_lock_serializes_concurrent_inspector_runs(monkeypatch):
+    """两次并发 inspector.tick() 不会双重生成同一 session 标题。
+
+    集成测试库存在跨测试残留 session，无法精准统计单 session 的 LLM 调用次数，
+    所以这里改为通过 ``_generate_title_for_session`` 直接对同一 session 并发触发，
+    更精准地验证 advisory lock + 二次 skip-guard 的串行化保证。
+    """
+    import asyncio
+
+    call_count = 0
+
+    class _CountedStableSummarizer:
+        @classmethod
+        async def create(cls) -> _CountedStableSummarizer:
+            return cls()
+
+        async def generate_title(self, history) -> str:
+            nonlocal call_count
+            call_count += 1
+            return "唯一标题"
+
+    monkeypatch.setattr("negentropy.engine.summarization.SessionSummarizer", _CountedStableSummarizer)
+
+    service = PostgresSessionService()
+    app_name = f"inspector_lock_{uuid.uuid4()}"
+    user_id = f"user_{uuid.uuid4()}"
+    session = await service.create_session(app_name=app_name, user_id=user_id)
+
+    event = ADKEvent(
+        id=str(uuid.uuid4()),
+        author="assistant",
+        content={"parts": [{"text": "并发候选种子"}]},
+    )
+    await service.append_event(session, event)
+
+    inspector = SessionTitleInspector(
+        batch_size=10, min_events=1, refresh_event_delta=20, concurrency=2, session_service=service
+    )
+    candidate = await inspector._find_candidates()
+    target = next((c for c in candidate if str(c.session_id) == session.id), None)
+    assert target is not None, "新建 session 应进入候选池"
+
+    # 直接对同一 candidate 并发触发 _process_candidate——精准复现两个 worker
+    # 在 SQL 查询窗口都命中同一 session 的极端情况。
+    await asyncio.gather(
+        inspector._process_candidate(target, service),
+        inspector._process_candidate(target, service),
+    )
+
+    meta = await _get_metadata(session.id)
+    assert meta["title"] == "唯一标题"
+    assert meta["title_source"] == "auto"
+    # 三层防御保证 LLM 对同一 session 至多被调用一次：
+    # (1) advisory lock 让第二个并发任务 try_lock 失败而直接 return；
+    # (2) 即便锁未生效，二次 skip-guard 在持久化前 reload metadata 命中 already_titled；
+    # (3) 万一并发完全同步执行（罕见），不会产生 metadata 损坏。
+    assert call_count == 1, f"expected exactly 1 LLM call, got {call_count}"

--- a/apps/negentropy/tests/unit_tests/engine/test_summarization.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_summarization.py
@@ -4,12 +4,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from negentropy.engine.summarization import SessionSummarizer
+from negentropy.engine.summarization import _TITLE_MAX_TOKENS, SessionSummarizer
 
 
 @pytest.mark.asyncio
 async def test_create_uses_resolve_llm_config_with_max_tokens():
-    """create() 必须 await resolve_llm_config() 拿到完整凭证（含 api_key），并把 max_tokens 注入 LiteLlm。"""
+    """create() 必须 await resolve_llm_config() 拿到完整凭证（含 api_key），并把
+    max_tokens 与 reasoning_effort 注入 LiteLlm。
+
+    reasoning_effort='minimal' 是 gpt-5 / o1 / o3 / o4 模型族的关键修复：不显式降低
+    推理预算时，``max_tokens`` 会被内部 reasoning tokens 吃光，导致空响应。
+    """
     resolved = (
         "openai/gpt-5-mini",
         {"temperature": 0.7, "drop_params": True, "api_key": "sk-resolved-from-db"},
@@ -24,9 +29,47 @@ async def test_create_uses_resolve_llm_config_with_max_tokens():
     mock_resolve.assert_awaited_once_with()
     assert summarizer.model is not None
     assert summarizer.model.model == "openai/gpt-5-mini"
-    # LiteLlm 把额外 kwargs 落到 _additional_args；max_tokens=20 是 title 生成的硬约束。
-    assert summarizer.model._additional_args.get("max_tokens") == 20
+    # LiteLlm 把额外 kwargs 落到 _additional_args；title 生成的硬约束由 _TITLE_MAX_TOKENS 提供。
+    assert summarizer.model._additional_args.get("max_tokens") == _TITLE_MAX_TOKENS
     assert summarizer.model._additional_args.get("api_key") == "sk-resolved-from-db"
+    # 关键：gpt-5 系模型必须强制 reasoning_effort=minimal，避免响应空内容
+    assert summarizer.model._additional_args.get("reasoning_effort") == "minimal"
+
+
+@pytest.mark.asyncio
+async def test_create_disables_thinking_for_anthropic_models():
+    """Anthropic 模型族走 thinking={"type":"disabled"} 路径——同源问题但参数协议不同。"""
+    resolved = (
+        "anthropic/claude-sonnet-4-6",
+        {"temperature": 0.7, "drop_params": True, "api_key": "sk-resolved-from-db"},
+    )
+
+    with patch(
+        "negentropy.config.model_resolver.resolve_llm_config",
+        new=AsyncMock(return_value=resolved),
+    ):
+        summarizer = await SessionSummarizer.create()
+
+    assert summarizer.model._additional_args.get("thinking") == {"type": "disabled"}
+    assert "reasoning_effort" not in summarizer.model._additional_args
+
+
+@pytest.mark.asyncio
+async def test_create_leaves_non_reasoning_model_kwargs_clean():
+    """对不支持 reasoning 的模型（如 openai/gpt-4o-mini），不注入 reasoning_effort/thinking。"""
+    resolved = (
+        "openai/gpt-4o-mini",
+        {"temperature": 0.7, "drop_params": True, "api_key": "sk-resolved-from-db"},
+    )
+
+    with patch(
+        "negentropy.config.model_resolver.resolve_llm_config",
+        new=AsyncMock(return_value=resolved),
+    ):
+        summarizer = await SessionSummarizer.create()
+
+    assert "reasoning_effort" not in summarizer.model._additional_args
+    assert "thinking" not in summarizer.model._additional_args
 
 
 @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/engine/test_title_source.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_title_source.py
@@ -1,0 +1,91 @@
+"""Session 标题溯源（title_source）跳过策略与 inspector 锁键派生的纯函数单元测试。
+
+这里只覆盖与 DB 无关的逻辑：
+- ``PostgresSessionService._title_skip_reason`` 在 manual / legacy / auto / 空白
+  四种 metadata 形态下的跳过决策。
+- ``SessionTitleInspector._lock_key_for_session`` 派生的 advisory lock key 必须
+  落在 Postgres BIGINT 范围 ``[-2^63, 2^63-1]``。
+
+写入路径（``_persist_generated_title``、``_record_title_attempt_failure``、
+``update_session_title``）的端到端断言放在集成测试 ``test_title_inspector.py``，
+避免重复构造 fake AsyncSession。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from negentropy.engine.adapters.postgres.session_service import PostgresSessionService
+from negentropy.engine.title_inspector import SessionTitleInspector
+
+# ------- _title_skip_reason -------
+
+
+@pytest.mark.parametrize(
+    ("metadata", "force_refresh", "expected"),
+    [
+        # 全新会话：可以生成
+        ({}, False, None),
+        ({"archived": False}, False, None),
+        # auto 标题已存在，未强制刷新 → 跳过
+        ({"title": "Hello", "title_source": "auto"}, False, "already_titled"),
+        # auto 标题已存在，强制刷新 → 不跳过（巡检事件增长路径）
+        ({"title": "Hello", "title_source": "auto"}, True, None),
+        # manual 永不覆盖（即使强制刷新）
+        ({"title": "My Project", "title_source": "manual"}, False, "manual"),
+        ({"title": "My Project", "title_source": "manual"}, True, "manual"),
+        # legacy：有 title 无 source → 保守视为 manual，强制刷新也不覆盖
+        ({"title": "Old Title"}, False, "legacy"),
+        ({"title": "Old Title"}, True, "legacy"),
+        # 空 title 字符串等价于无 title——可以生成
+        ({"title": "", "title_source": "auto"}, False, None),
+        ({"title": None, "title_source": "auto"}, False, None),
+    ],
+)
+def test_title_skip_reason_decision_matrix(metadata, force_refresh, expected):
+    assert PostgresSessionService._title_skip_reason(metadata, force_refresh=force_refresh) == expected
+
+
+# ------- SessionTitleInspector._lock_key_for_session -------
+
+
+def test_lock_key_is_within_postgres_bigint_range():
+    """Postgres BIGINT 范围 [-2^63, 2^63-1]，advisory lock 入参必须命中。"""
+    for _ in range(200):
+        sid = uuid.uuid4()
+        key = SessionTitleInspector._lock_key_for_session(sid)
+        assert -(2**63) <= key <= 2**63 - 1
+
+
+def test_lock_key_is_deterministic_for_same_uuid():
+    sid = uuid.UUID("12345678-1234-1234-1234-123456789abc")
+    key_a = SessionTitleInspector._lock_key_for_session(sid)
+    key_b = SessionTitleInspector._lock_key_for_session(sid)
+    assert key_a == key_b
+
+
+def test_lock_key_differs_across_distinct_uuids():
+    sid_a = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    sid_b = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    assert SessionTitleInspector._lock_key_for_session(sid_a) != SessionTitleInspector._lock_key_for_session(sid_b)
+
+
+# ------- SessionTitleInspector 构造与参数兜底 -------
+
+
+def test_inspector_clamps_invalid_params_to_safe_floor():
+    """防御性边界：负值或 0 不应让巡检失能/无限批量。"""
+    inspector = SessionTitleInspector(
+        concurrency=0,
+        batch_size=-5,
+        min_events=-1,
+        refresh_event_delta=0,
+        max_attempts=0,
+    )
+    assert inspector.concurrency == 1
+    assert inspector.batch_size == 1
+    assert inspector.min_events == 0
+    assert inspector.refresh_event_delta == 1
+    assert inspector.max_attempts == 1


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Home 页左栏 Session 列表全部呈现 `Session <8 字符随机码>` 兜底标签，无法识别会话主题（截图 `/tmp/attachments/image-v2.png`）。双重根因：**反应触发**在默认模型切换为 gpt-5-mini 后静默失败（`max_tokens=20` 被 reasoning tokens 全数消耗，返回空内容）；**历史 / 失败 session** 没有任何 backfill 路径。
- 关联上下文/Issue/文档：[`docs/issue.md` ISSUE-032](../../docs/issue.md)（凭证缺失修复，本次延伸至 reasoning 路径）；[`docs/issue.md` ISSUE-082](../../docs/issue.md) 同源 reasoning-content 滤波；commit `f4c86d5b`（凭证异步工厂修复，本次复用范式）。

# 核心变更
- **`summarization.py` 根因修复**：`_TITLE_MAX_TOKENS 20→256`；对 OpenAI gpt-5/o1/o3/o4 强制 `reasoning_effort="minimal"`，对 Anthropic 强制 `thinking={type:disabled}`；跳过 `part.thought=True`；新增 `title_generation_empty_response` 告警。
- **`session_service.py` 反应触发硬化**：抽出 `_persist_generated_title` 共享辅助；新增 `_title_skip_reason`（manual / legacy / already_titled）；失败递增 `title_attempt_count` + `title_last_attempt_at` 供巡检退避；`update_session_title` 写入标记 `title_source="manual"`，清空时移除全部 auto 溯源字段。
- **`title_inspector.py`（新增 ~165 LOC）周期巡检**：`SessionTitleInspector` 单条候选 SQL Postgres 侧过滤（无 title 或事件增量 ≥ `refresh_event_delta`），`asyncio.Semaphore` 限 LLM 并发，`pg_try_advisory_lock` 跨 worker 串行化，组合复用 `_persist_generated_title`。
- **`bootstrap.py` + `config/services.py` 调度接线**：复用现有 `AsyncScheduler`（`skill_scheduler`）注册 `session_title_inspector` job；新增 7 项 `session_title_inspect_*` Pydantic 配置，env 前缀 `NE_SVC_`。
- **零 DB 迁移**：所有溯源字段（`title_source` / `title_generated_at_event_seq` / `title_generated_at` / `title_attempt_count` / `title_last_attempt_at`）扩展到现有 `Thread.metadata_` JSONB 列；legacy 行（有 title 无 source）保守视为 manual，永不覆盖。

# 风险与回滚
- 主要风险：(1) `reasoning_effort="minimal"` 假设 LiteLLM 已支持该参数（gpt-5-mini 实测通过）；若其他厂商上线 reasoning-like 模型而未在 `_supports_openai_reasoning` 注册，会按非 reasoning 路径走原参数（不会崩溃）。(2) 巡检默认 5min interval × 20 batch_size × concurrency=2，最坏每 5min 触发 20 次 LLM 调用，受 `max_attempts=5` 退避保护；可通过 `NE_SVC_SESSION_TITLE_INSPECT_ENABLED=false` 一键关闭。(3) Advisory lock 与用户手动 PATCH 改名正交（不持行锁），无写阻塞风险。
- 回滚方式：`NE_SVC_SESSION_TITLE_INSPECT_ENABLED=false` 仅关闭巡检；反应触发路径已就地修复无法独立回滚，但若 reasoning 注入有问题可单独 revert `summarization.py` 该提交并恢复 `_TITLE_MAX_TOKENS=20` 配合 PR 中的兜底。Metadata 新增字段未删除任何已有键，前端无感知。

# 验证证据
- 单元测试：14 例 `test_title_source.py`（skip-reason 决策矩阵 + lock_key 派生 + 参数 clamp）+ 3 例 `test_summarization.py`（max_tokens 跟随常量 / gpt-5 注入 reasoning_effort / Anthropic 注入 thinking=disabled / 非 reasoning 模型 kwargs 干净）。
- 集成测试：9 例 `test_title_inspector.py`（backfill / manual 永不覆盖 / legacy 永不覆盖 / 事件增量刷新 / max_attempts 退避 / advisory lock 并发串行 / `update_session_title` metadata 形状契约 / 反应触发 source+seq 落库）。
- E2E/Workflow：本机 `scripts/ctl.sh start backend` 后通过 `/run_sse` 实机验证 3 类场景——
  1. 新建 session 发送 "今天天气如何？" → 5s 内落库 `title="今天天气如何？" title_source="auto" title_generated_at_event_seq=518`；
  2. 此前因 reasoning 空响应失败的 session 在第二条 user 消息后成功生成 "列表与元组的区别与使用"，`title_attempt_count` 清零；
  3. PATCH `/title` 改名 → `title_source="manual"`，巡检永不覆盖。
- 覆盖率/关键截图：31 项 title 相关测试 + 21 项 engine 集成全部通过；pre-commit `ruff lint + format` 通过。

# 影响范围
- 前端：**零改动**——`utils/session.ts:30` 已就位读取 `session.state?.metadata?.title`；新增的 `title_source` 等字段对 UI 透明。
- 后端：5 个文件改动 + 3 个新增（含 2 测试文件）；共 989 行新增 / 22 行删除。
- GitHub Actions / 文档：无 workflow 改动；新功能配置项已在 `config/services.py` Pydantic Field `description` 中文档化，无需额外 docs 改动。

# Next Best Action
- 观察生产环境 backend 日志的 `title_inspector_tick_completed` / `title_generation_completed` / `title_generation_empty_response` 三项指标 1 个周期（5min），确认巡检批次正常且无大面积空响应告警。
- 若 `gpt-5-mini` 之外的反应模型上线，扩充 `_supports_openai_reasoning` 与 `_supports_anthropic_thinking` 的判定（model_resolver.py:678-680）。
- pre-existing：bootstrap.py 的 `@app.on_event("startup")` 在当前 ADK 版本下可能未触发（dev 模式实测看不到 `skill_scheduler_started` 日志，亦影响既有 `pipeline_run_watchdog`），与本 PR 正交但建议另起 Issue 跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)