### PR TITLE
fix(interface): 治理 Dashboard/子模块系统内置可见性 + 修复 MCP Permission Denied

### DIFF
--- a/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { JsonViewer } from "@/components/ui/JsonViewer";
+import { useAuth } from "@/components/providers/AuthProvider";
 
 const MARKDOWN_CONTENT_CLASS = [
   "space-y-2 overflow-hidden break-words whitespace-normal text-sm leading-relaxed",
@@ -650,6 +651,8 @@ interface McpServer {
   config: Record<string, unknown>;
   tool_count: number;
   resource_template_count: number;
+  // 「系统内置」标识：后端从显式 is_system 列 / owner_id 前缀派生。
+  is_builtin?: boolean;
 }
 
 interface McpTool {
@@ -784,6 +787,13 @@ export function McpServerCard({
   loadingTools = false,
   loadError = null,
 }: McpServerCardProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("admin") ?? false;
+  // 后端 _mcp_server_to_response 在显式 is_system 列与 owner_id 前缀间取并；
+  // 前端做一次同步派生以兼容旧接口（is_builtin 字段缺失时回退 owner_id）。
+  const isBuiltin = server.is_builtin ?? (server.owner_id || "").startsWith("system");
+  const canEdit = isAdmin || !isBuiltin;
+
   const [showTools, setShowTools] = useState(false);
   const [showResources, setShowResources] = useState(false);
   const [expandedToolName, setExpandedToolName] = useState<string | null>(null);
@@ -874,26 +884,30 @@ export function McpServerCard({
                   </svg>
                 )}
               </button>
-              <button
-                onClick={onEdit}
-                title="Edit Server"
-                aria-label={`Edit ${server.display_name || server.name}`}
-                className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-              >
-                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
-              </button>
-              <button
-                onClick={onDelete}
-                title="Delete Server"
-                aria-label={`Delete ${server.display_name || server.name}`}
-                className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-              >
-                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-              </button>
+              {canEdit && (
+                <>
+                  <button
+                    onClick={onEdit}
+                    title="Edit Server"
+                    aria-label={`Edit ${server.display_name || server.name}`}
+                    className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                  >
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={onDelete}
+                    title="Delete Server"
+                    aria-label={`Delete ${server.display_name || server.name}`}
+                    className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                  >
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </>
+              )}
             </div>
           </div>
 
@@ -905,6 +919,14 @@ export function McpServerCard({
             ) : (
               <span className="inline-flex shrink-0 items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
                 Disabled
+              </span>
+            )}
+            {isBuiltin && (
+              <span
+                className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                title="系统内置：对全员可见，仅 admin 可编辑"
+              >
+                Built-In
               </span>
             )}
             <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">

--- a/apps/negentropy-ui/app/interface/mcp/page.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/page.tsx
@@ -54,6 +54,9 @@ interface McpServer {
   config: Record<string, unknown>;
   tool_count: number;
   resource_template_count: number;
+  // 「系统内置」标识：后端从显式 ``is_system`` 列 / owner_id 前缀派生，
+  // 前端据此渲染 Built-In 徽标 + 隐藏 Edit/Delete（非 admin）。
+  is_builtin?: boolean;
 }
 
 interface ServerWithTools extends McpServer {
@@ -194,6 +197,15 @@ export default function McpServersPage() {
     }
   };
 
+  // 仅读 DB 已有 tools 快照（GET /tools），不再对所有 enabled server 自动触发
+  // POST /tools:load（discover）。原方案存在两个问题：
+  //   1. 系统内置 server（如 negentropy-perceives）owner=system，非 admin 用户
+  //      过去触发的 POST /tools:load 会被旧版 edit 权限拦截为 "Permission denied"
+  //      并渲染到卡片上（ISSUE 主诉）。后端虽已降级为 view 权限，但仍应避免每次进
+  //      MCP 页都对所有 enabled server 发起 streamablehttp 探测，从而消除 OAuth
+  //      .well-known/oauth-protected-resource 404 噪声。
+  //   2. 工具发现属于"显式动作"语义，应由用户点击"Refresh tools"触发，与
+  //      新增/编辑 server 的写入语义对称。
   useEffect(() => {
     if (loading || error || hasAutoRequestedTools || servers.length === 0) {
       return;
@@ -210,9 +222,37 @@ export default function McpServersPage() {
 
     setHasAutoRequestedTools(true);
     enabledServerIds.forEach((serverId) => {
-      void handleLoadTools(serverId);
+      void handleListTools(serverId);
     });
   }, [loading, error, hasAutoRequestedTools, servers]);
+
+  // 仅读取 DB 中已有的 tools 快照（由 admin/owner 上次 discover 时写入），
+  // 不触发任何 MCP 客户端探测；权限要求为 view，与系统内置可见性兼容。
+  const handleListTools = async (serverId: string) => {
+    try {
+      const response = await fetch(`/api/interface/mcp/servers/${serverId}/tools`);
+      if (!response.ok) {
+        // view 拒绝时静默吞掉错误；卡片仅显示 tool_count（来自 list_mcp_servers 聚合），
+        // 不渲染红色错误条，避免用户被刷错验证的失败信息打断。
+        return;
+      }
+      const tools: McpTool[] = await response.json();
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? {
+                ...s,
+                tools,
+                tool_count: tools.length,
+                loadError: null,
+              }
+            : s
+        )
+      );
+    } catch {
+      // 网络异常静默处理，与上面同理。
+    }
+  };
 
   const handleDialogClose = () => {
     setDialogOpen(false);

--- a/apps/negentropy-ui/app/interface/skills/_components/SkillCard.tsx
+++ b/apps/negentropy-ui/app/interface/skills/_components/SkillCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useAuth } from "@/components/providers/AuthProvider";
+
 interface Skill {
   id: string;
   owner_id: string;
@@ -17,6 +19,7 @@ interface Skill {
   priority: number;
   enforcement_mode?: string;
   resources?: Array<{ type?: string; ref?: string; title?: string; lazy?: boolean }>;
+  is_builtin?: boolean;
 }
 
 interface SkillCardProps {
@@ -43,6 +46,11 @@ export function SkillCard({
   toggling = false,
   agentTools,
 }: SkillCardProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("admin") ?? false;
+  const isBuiltin = skill.is_builtin ?? (skill.owner_id || "").startsWith("system");
+  const canEdit = isAdmin || !isBuiltin;
+
   const required = skill.required_tools || [];
   const missingTools =
     Array.isArray(agentTools) && required.length > 0
@@ -124,26 +132,30 @@ export function SkillCard({
                 )}
               </button>
             )}
-            <button
-              onClick={onEdit}
-              title="Edit Skill"
-              aria-label={`Edit ${displayLabel}`}
-              className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              onClick={onDelete}
-              title="Delete Skill"
-              aria-label={`Delete ${displayLabel}`}
-              className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            {canEdit && (
+              <>
+                <button
+                  onClick={onEdit}
+                  title="Edit Skill"
+                  aria-label={`Edit ${displayLabel}`}
+                  className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                </button>
+                <button
+                  onClick={onDelete}
+                  title="Delete Skill"
+                  aria-label={`Delete ${displayLabel}`}
+                  className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                >
+                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </>
+            )}
           </div>
         </div>
         <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
@@ -154,6 +166,14 @@ export function SkillCard({
           ) : (
             <span className="inline-flex shrink-0 items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
               Disabled
+            </span>
+          )}
+          {isBuiltin && (
+            <span
+              className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+              title="系统内置：对全员可见，仅 admin 可编辑"
+            >
+              Built-In
             </span>
           )}
           <span className="inline-flex shrink-0 items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">

--- a/apps/negentropy-ui/app/interface/subagents/_components/SubAgentCard.tsx
+++ b/apps/negentropy-ui/app/interface/subagents/_components/SubAgentCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useAuth } from "@/components/providers/AuthProvider";
+
 interface SubAgent {
   id: string;
   owner_id: string;
@@ -27,6 +29,9 @@ interface SubAgentCardProps {
 }
 
 export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("admin") ?? false;
+  const canEdit = isAdmin || !agent.is_builtin;
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
       <div className="flex min-h-0 flex-1 flex-col">
@@ -35,26 +40,30 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
             {agent.display_name || agent.name}
           </h3>
           <div className="flex shrink-0 items-center gap-2">
-            <button
-              onClick={onEdit}
-              title="Edit SubAgent"
-              aria-label={`Edit ${agent.display_name || agent.name}`}
-              className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              onClick={onDelete}
-              title="Delete SubAgent"
-              aria-label={`Delete ${agent.display_name || agent.name}`}
-              className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+            {canEdit && (
+              <>
+                <button
+                  onClick={onEdit}
+                  title="Edit SubAgent"
+                  aria-label={`Edit ${agent.display_name || agent.name}`}
+                  className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                </button>
+                <button
+                  onClick={onDelete}
+                  title="Delete SubAgent"
+                  aria-label={`Delete ${agent.display_name || agent.name}`}
+                  className="rounded-md p-2 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </>
+            )}
           </div>
         </div>
         <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
@@ -82,8 +91,11 @@ export function SubAgentCard({ agent, onEdit, onDelete }: SubAgentCardProps) {
             </span>
           )}
           {agent.is_builtin && (
-            <span className="inline-flex min-w-0 items-center truncate rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-              Negentropy Built-in
+            <span
+              className="inline-flex min-w-0 items-center truncate rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+              title="系统内置：对全员可见，仅 admin 可编辑"
+            >
+              Built-In
             </span>
           )}
         </div>

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useAuth } from "@/components/providers/AuthProvider";
+
 interface BuiltinTool {
   id: string;
   owner_id: string;
@@ -31,6 +33,11 @@ export function ToolCard({
   onToggleEnabled,
   toggling = false,
 }: ToolCardProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("admin") ?? false;
+  // 系统内置工具仅 admin 可编辑（与 MCP / Skill / SubAgent 卡片语义对齐）。
+  const canEdit = isAdmin || !tool.is_system;
+
   const displayLabel = tool.display_name || tool.name;
 
   const hasCredentials =
@@ -71,16 +78,18 @@ export function ToolCard({
                 )}
               </button>
             )}
-            <button
-              onClick={onEdit}
-              title="Edit Tool"
-              aria-label={`Edit ${displayLabel}`}
-              className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
+            {canEdit && (
+              <button
+                onClick={onEdit}
+                title="Edit Tool"
+                aria-label={`Edit ${displayLabel}`}
+                className="rounded-md p-2 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              >
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              </button>
+            )}
             {!tool.is_system && (
               <button
                 onClick={onDelete}
@@ -109,8 +118,11 @@ export function ToolCard({
             {tool.tool_type}
           </span>
           {tool.is_system && (
-            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-              System
+            <span
+              className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+              title="系统内置：对全员可见，仅 admin 可编辑"
+            >
+              Built-In
             </span>
           )}
           <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">

--- a/apps/negentropy-ui/tests/unit/interface/McpServerCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/interface/McpServerCard.test.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { McpServerCard } from "@/app/interface/mcp/_components/McpServerCard";
 
+vi.mock("@/components/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { roles: ["admin"] },
+  }),
+}));
+
 const server = {
   id: "server-1",
   owner_id: "user-1",

--- a/apps/negentropy-ui/tests/unit/interface/SubAgentCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/interface/SubAgentCard.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SubAgentCard } from "@/app/interface/subagents/_components/SubAgentCard";
 
+vi.mock("@/components/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { roles: ["admin"] },
+  }),
+}));
+
 const baseAgent = {
   id: "a1",
   owner_id: "u1",

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0033_plugin_is_system.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0033_plugin_is_system.py
@@ -1,0 +1,80 @@
+"""Plugin 表统一新增 is_system 列并幂等回填系统内置 seed
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-05-16 16:30:00.000000+00:00
+
+设计动机：
+    历史上「系统内置」概念在 5 类 plugin 表中表达方式不一致：
+
+      - builtin_tools.is_system  : 显式列（迁移 0031 已建）
+      - mcp_servers              : 隐式靠 owner_id 前缀 ``"system:"``（0002 seed）
+      - sub_agents               : 隐式靠 ``config.source == "negentropy_builtin"``
+      - skills                   : 暂无 seed
+
+    Dashboard 统计与子模块列表无法对全员稳定展示系统内置项，前端也缺少统一的
+    Built-In 徽标。本迁移把单一事实源收口到显式 ``is_system`` 列：
+
+      - mcp_servers   ADD COLUMN is_system + 回填 owner_id LIKE 'system%'
+      - skills        ADD COLUMN is_system（暂无 seed，仅建列）
+      - sub_agents    ADD COLUMN is_system + 回填 config.source = 'negentropy_builtin'
+
+    伴随索引 ``ix_<table>_is_system``（与 builtin_tools 表结构风格保持对称，便于
+    permissions.get_visible_plugin_ids 中按 is_system=true 的并集子查询走索引）。
+
+    幂等性：使用 ``ADD COLUMN IF NOT EXISTS`` + 条件 UPDATE，重复执行不会破坏
+    已有数据；downgrade 仅 DROP COLUMN 不触碰 seed 行。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0033"
+down_revision: str | None = "0032"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    # 1. mcp_servers：新增列 + 索引 + 回填 ``owner_id LIKE 'system%'`` 的种子行。
+    op.execute(
+        sa.text(f"ALTER TABLE {SCHEMA}.mcp_servers ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT FALSE")
+    )
+    op.execute(sa.text(f"CREATE INDEX IF NOT EXISTS ix_mcp_servers_is_system ON {SCHEMA}.mcp_servers (is_system)"))
+    op.execute(
+        sa.text(f"UPDATE {SCHEMA}.mcp_servers SET is_system = TRUE WHERE owner_id LIKE 'system%' AND is_system = FALSE")
+    )
+
+    # 2. skills：新增列 + 索引。暂无 seed 行，回填空操作。
+    op.execute(
+        sa.text(f"ALTER TABLE {SCHEMA}.skills ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT FALSE")
+    )
+    op.execute(sa.text(f"CREATE INDEX IF NOT EXISTS ix_skills_is_system ON {SCHEMA}.skills (is_system)"))
+
+    # 3. sub_agents：新增列 + 索引 + 回填 ``config.source = 'negentropy_builtin'`` 行。
+    op.execute(
+        sa.text(f"ALTER TABLE {SCHEMA}.sub_agents ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT FALSE")
+    )
+    op.execute(sa.text(f"CREATE INDEX IF NOT EXISTS ix_sub_agents_is_system ON {SCHEMA}.sub_agents (is_system)"))
+    op.execute(
+        sa.text(
+            f"UPDATE {SCHEMA}.sub_agents SET is_system = TRUE "
+            "WHERE (config->>'source') = 'negentropy_builtin' AND is_system = FALSE"
+        )
+    )
+
+
+def downgrade() -> None:
+    # 仅回收新增的列与索引，不触碰任何 seed 行或业务数据。
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {SCHEMA}.ix_sub_agents_is_system"))
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.sub_agents DROP COLUMN IF EXISTS is_system"))
+
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {SCHEMA}.ix_skills_is_system"))
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.skills DROP COLUMN IF EXISTS is_system"))
+
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {SCHEMA}.ix_mcp_servers_is_system"))
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.mcp_servers DROP COLUMN IF EXISTS is_system"))

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -7,6 +7,8 @@ Interface API 模块。
 from __future__ import annotations
 
 import json
+import time as _mcp_time
+from asyncio import Lock as _AsyncLock
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -241,6 +243,8 @@ class McpServerResponse(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
     tool_count: int = 0
     resource_template_count: int = 0
+    # 「系统内置」统一对外字段，前端据此渲染 Built-In 徽标 + 隐藏 Edit/Delete。
+    is_builtin: bool = False
 
     class Config:
         from_attributes = True
@@ -426,6 +430,8 @@ class SkillResponse(BaseModel):
     priority: int
     enforcement_mode: str = "warning"
     resources: list[dict[str, Any]] = Field(default_factory=list)
+    # 「系统内置」统一对外字段，与 MCP/SubAgent/Tool 字段保持一致。
+    is_builtin: bool = False
 
     class Config:
         from_attributes = True
@@ -646,6 +652,49 @@ async def get_stats(user: AuthUser = Depends(get_current_user)) -> StatsResponse
 # MCP Server Endpoints
 # =============================================================================
 
+# per-server load TTL 锁：避免 N 个 view 用户在打开 MCP 页时对同一 server 重复
+# discover。键为 server_id，值为最近一次成功 load 的 monotonic 时间戳。
+# 60s 窗口在「最终一致性」与「降低 streamablehttp 探测放大」之间取折中。
+_MCP_LOAD_TTL_SECONDS = 60.0
+_mcp_load_last_success: dict[UUID, float] = {}
+_mcp_load_locks: dict[UUID, _AsyncLock] = {}
+
+
+def _mcp_load_lock_for(server_id: UUID) -> _AsyncLock:
+    lock = _mcp_load_locks.get(server_id)
+    if lock is None:
+        lock = _AsyncLock()
+        _mcp_load_locks[server_id] = lock
+    return lock
+
+
+def _record_mcp_load_success(server_id: UUID) -> None:
+    _mcp_load_last_success[server_id] = _mcp_time.monotonic()
+
+
+async def _mcp_load_throttle_or_snapshot(db, server_id: UUID) -> LoadToolsResponse | None:
+    """若 TTL 锁命中，直接返回 DB 现有 tools/templates 快照；否则返回 None 让调用方继续 discover。"""
+    last = _mcp_load_last_success.get(server_id)
+    if last is None or (_mcp_time.monotonic() - last) >= _MCP_LOAD_TTL_SECONDS:
+        return None
+
+    tools_stmt = select(McpTool).where(McpTool.server_id == server_id).order_by(McpTool.created_at.asc())
+    templates_stmt = (
+        select(McpResourceTemplate)
+        .where(McpResourceTemplate.server_id == server_id)
+        .order_by(McpResourceTemplate.created_at.asc())
+    )
+    tool_rows = (await db.execute(tools_stmt)).scalars().all()
+    template_rows = (await db.execute(templates_stmt)).scalars().all()
+
+    return LoadToolsResponse(
+        success=True,
+        server_id=server_id,
+        tools=[_mcp_tool_to_response(t) for t in tool_rows],
+        resource_templates=[_mcp_resource_template_to_response(t) for t in template_rows],
+        duration_ms=0,
+    )
+
 
 @router.get("/mcp/servers", response_model=list[McpServerResponse])
 async def list_mcp_servers(user: AuthUser = Depends(get_current_user)) -> list[McpServerResponse]:
@@ -825,6 +874,8 @@ def _mcp_server_to_response(
         config=server.config or {},
         tool_count=tool_count or 0,
         resource_template_count=resource_template_count or 0,
+        # 显式列优先；旧库未迁移到 0033 时回退 owner_id 前缀，与 permissions 模块保持一致。
+        is_builtin=bool(getattr(server, "is_system", False)) or (server.owner_id or "").startswith("system"),
     )
 
 
@@ -937,12 +988,17 @@ async def load_mcp_server_tools(
     2. 获取所有 Tools 与 Resource Templates；
     3. 同步到数据库（新增/更新；旧 server 无 resources capability 时静默兜底）；
     4. 返回完整 capability。
+
+    权限语义：``view`` 即可触发——「工具发现」对用户视角是只读操作，``mcp_tools``
+    与 ``mcp_resource_templates`` 是 server-scoped、不区分 owner 的能力快照表，
+    写入对其他用户没有副作用。这是 ISSUE: 系统内置 MCP Server（如 negentropy-perceives）
+    在普通用户的 MCP 页加载时显示 "Permission denied" 的根因修复。
     """
     from .mcp_client import McpClientService
 
     async with AsyncSessionLocal() as db:
-        # 1. 权限检查
-        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "edit")
+        # 1. 权限检查（view 即可——工具发现属于只读语义；写入由 server-scoped TTL 锁去重）。
+        has_access, error = await check_plugin_access(db, "mcp_server", server_id, user, "view")
         if not has_access:
             raise HTTPException(status_code=403, detail=error)
 
@@ -951,129 +1007,150 @@ async def load_mcp_server_tools(
         if not server:
             raise HTTPException(status_code=404, detail="Server not found")
 
-        # 3. 调用 MCP Client Service
-        client = McpClientService()
-        result = await client.discover_tools(
-            transport_type=server.transport_type,
-            command=server.command,
-            args=server.args,
-            env=server.env,
-            url=server.url,
-            headers=server.headers,
-        )
+        # 3. 快速路径：TTL 锁命中时直接返回 DB 现有快照，避免重复 streamablehttp 探测。
+        cached_response = await _mcp_load_throttle_or_snapshot(db, server_id)
+        if cached_response is not None:
+            return cached_response
 
-        if not result.success:
-            return LoadToolsResponse(
-                success=False,
-                server_id=server_id,
-                tools=[],
-                resource_templates=[],
-                duration_ms=result.duration_ms,
-                error=result.error,
+    # 4. 进入 per-server 异步互斥区：并发请求串行化，再进入 lock 后做一次双检锁，
+    #    最大并发探测降为 1/60s，与 ISSUE: streamablehttp + OAuth 404 探测放大对齐。
+    async with _mcp_load_lock_for(server_id):
+        async with AsyncSessionLocal() as db:
+            # 双检：取得锁后再判断 TTL，已被前一个并发请求刷新过则直接返回快照。
+            cached_response = await _mcp_load_throttle_or_snapshot(db, server_id)
+            if cached_response is not None:
+                return cached_response
+
+            server = await db.get(McpServer, server_id)
+            if not server:
+                raise HTTPException(status_code=404, detail="Server not found")
+
+            # 5. 调用 MCP Client Service
+            client = McpClientService()
+            result = await client.discover_tools(
+                transport_type=server.transport_type,
+                command=server.command,
+                args=server.args,
+                env=server.env,
+                url=server.url,
+                headers=server.headers,
             )
 
-        # 4. 同步 Tools 到数据库
-        existing_tools_result = await db.execute(select(McpTool).where(McpTool.server_id == server_id))
-        existing_tools = existing_tools_result.scalars().all()
-        existing_map = {t.name: t for t in existing_tools}
-
-        updated_tools: list[McpTool] = []
-        for tool_info in result.tools:
-            if tool_info.name in existing_map:
-                # 更新现有 Tool
-                existing = existing_map[tool_info.name]
-                existing.title = tool_info.title
-                existing.description = tool_info.description
-                existing.input_schema = tool_info.input_schema
-                existing.output_schema = tool_info.output_schema
-                existing.icons = tool_info.icons
-                existing.annotations = tool_info.annotations
-                existing.execution = tool_info.execution
-                existing.meta = tool_info.meta
-                updated_tools.append(existing)
-            else:
-                # 新增 Tool
-                new_tool = McpTool(
+            if not result.success:
+                return LoadToolsResponse(
+                    success=False,
                     server_id=server_id,
-                    name=tool_info.name,
-                    title=tool_info.title,
-                    description=tool_info.description,
-                    input_schema=tool_info.input_schema,
-                    output_schema=tool_info.output_schema,
-                    icons=tool_info.icons,
-                    annotations=tool_info.annotations,
-                    execution=tool_info.execution,
-                    meta=tool_info.meta,
-                    is_enabled=True,
+                    tools=[],
+                    resource_templates=[],
+                    duration_ms=result.duration_ms,
+                    error=result.error,
                 )
-                db.add(new_tool)
-                updated_tools.append(new_tool)
 
-        # 5. 同步 Resource Templates 到数据库（以 uri_template 为键）
-        existing_templates_result = await db.execute(
-            select(McpResourceTemplate).where(McpResourceTemplate.server_id == server_id)
-        )
-        existing_templates = existing_templates_result.scalars().all()
-        existing_template_map = {t.uri_template: t for t in existing_templates}
+            # 6. 同步 Tools 到数据库
+            existing_tools_result = await db.execute(select(McpTool).where(McpTool.server_id == server_id))
+            existing_tools = existing_tools_result.scalars().all()
+            existing_map = {t.name: t for t in existing_tools}
 
-        updated_templates: list[McpResourceTemplate] = []
-        seen_uri_templates: set[str] = set()
-        for template_info in result.resource_templates:
-            seen_uri_templates.add(template_info.uri_template)
-            if template_info.uri_template in existing_template_map:
-                existing_tpl = existing_template_map[template_info.uri_template]
-                existing_tpl.name = template_info.name
-                existing_tpl.title = template_info.title
-                existing_tpl.description = template_info.description
-                existing_tpl.mime_type = template_info.mime_type
-                existing_tpl.annotations = template_info.annotations
-                existing_tpl.meta = template_info.meta
-                updated_templates.append(existing_tpl)
-            else:
-                new_template = McpResourceTemplate(
-                    server_id=server_id,
-                    uri_template=template_info.uri_template,
-                    name=template_info.name,
-                    title=template_info.title,
-                    description=template_info.description,
-                    mime_type=template_info.mime_type,
-                    annotations=template_info.annotations,
-                    meta=template_info.meta,
-                    is_enabled=True,
-                )
-                db.add(new_template)
-                updated_templates.append(new_template)
+            updated_tools: list[McpTool] = []
+            for tool_info in result.tools:
+                if tool_info.name in existing_map:
+                    # 更新现有 Tool
+                    existing = existing_map[tool_info.name]
+                    existing.title = tool_info.title
+                    existing.description = tool_info.description
+                    existing.input_schema = tool_info.input_schema
+                    existing.output_schema = tool_info.output_schema
+                    existing.icons = tool_info.icons
+                    existing.annotations = tool_info.annotations
+                    existing.execution = tool_info.execution
+                    existing.meta = tool_info.meta
+                    updated_tools.append(existing)
+                else:
+                    # 新增 Tool
+                    new_tool = McpTool(
+                        server_id=server_id,
+                        name=tool_info.name,
+                        title=tool_info.title,
+                        description=tool_info.description,
+                        input_schema=tool_info.input_schema,
+                        output_schema=tool_info.output_schema,
+                        icons=tool_info.icons,
+                        annotations=tool_info.annotations,
+                        execution=tool_info.execution,
+                        meta=tool_info.meta,
+                        is_enabled=True,
+                    )
+                    db.add(new_tool)
+                    updated_tools.append(new_tool)
 
-        # 仅在 server 权威返回 templates 列表时才裁剪 stale 行：
-        # ``_discover_on_transport`` 对 ``list_resource_templates`` 的所有异常都
-        # 会静默兜底返回空列表（兼容旧 server / 瞬态错误），若此处直接 prune 会
-        # 把首次错误后的 DB 模板表清空，与 tools 同步"只增量更新、不裁剪"的语义
-        # 不对称。``resource_templates_listed`` 区分"权威空列表"与"未支持/错误"。
-        if result.resource_templates_listed:
-            for stale_uri, stale_tpl in existing_template_map.items():
-                if stale_uri not in seen_uri_templates:
-                    await db.delete(stale_tpl)
+            # 7. 同步 Resource Templates 到数据库（以 uri_template 为键）
+            existing_templates_result = await db.execute(
+                select(McpResourceTemplate).where(McpResourceTemplate.server_id == server_id)
+            )
+            existing_templates = existing_templates_result.scalars().all()
+            existing_template_map = {t.uri_template: t for t in existing_templates}
 
-        await db.commit()
+            updated_templates: list[McpResourceTemplate] = []
+            seen_uri_templates: set[str] = set()
+            for template_info in result.resource_templates:
+                seen_uri_templates.add(template_info.uri_template)
+                if template_info.uri_template in existing_template_map:
+                    existing_tpl = existing_template_map[template_info.uri_template]
+                    existing_tpl.name = template_info.name
+                    existing_tpl.title = template_info.title
+                    existing_tpl.description = template_info.description
+                    existing_tpl.mime_type = template_info.mime_type
+                    existing_tpl.annotations = template_info.annotations
+                    existing_tpl.meta = template_info.meta
+                    updated_templates.append(existing_tpl)
+                else:
+                    new_template = McpResourceTemplate(
+                        server_id=server_id,
+                        uri_template=template_info.uri_template,
+                        name=template_info.name,
+                        title=template_info.title,
+                        description=template_info.description,
+                        mime_type=template_info.mime_type,
+                        annotations=template_info.annotations,
+                        meta=template_info.meta,
+                        is_enabled=True,
+                    )
+                    db.add(new_template)
+                    updated_templates.append(new_template)
 
-        # 6. 刷新以获取 ID
-        for tool in updated_tools:
-            await db.refresh(tool)
-        for tpl in updated_templates:
-            await db.refresh(tpl)
+            # 仅在 server 权威返回 templates 列表时才裁剪 stale 行：
+            # ``_discover_on_transport`` 对 ``list_resource_templates`` 的所有异常都
+            # 会静默兜底返回空列表（兼容旧 server / 瞬态错误），若此处直接 prune 会
+            # 把首次错误后的 DB 模板表清空，与 tools 同步"只增量更新、不裁剪"的语义
+            # 不对称。``resource_templates_listed`` 区分"权威空列表"与"未支持/错误"。
+            if result.resource_templates_listed:
+                for stale_uri, stale_tpl in existing_template_map.items():
+                    if stale_uri not in seen_uri_templates:
+                        await db.delete(stale_tpl)
 
-        logger.info(
-            f"Loaded {len(updated_tools)} tools and {len(updated_templates)} resource templates "
-            f"from MCP server {server.name}"
-        )
+            await db.commit()
 
-        return LoadToolsResponse(
-            success=True,
-            server_id=server_id,
-            tools=[_mcp_tool_to_response(t) for t in updated_tools],
-            resource_templates=[_mcp_resource_template_to_response(t) for t in updated_templates],
-            duration_ms=result.duration_ms,
-        )
+            # 8. 刷新以获取 ID
+            for tool in updated_tools:
+                await db.refresh(tool)
+            for tpl in updated_templates:
+                await db.refresh(tpl)
+
+            # 9. 记录 TTL 锁时间戳，未来 60s 内的并发 / 重复请求直接走 DB 快照。
+            _record_mcp_load_success(server_id)
+
+            logger.info(
+                f"Loaded {len(updated_tools)} tools and {len(updated_templates)} resource templates "
+                f"from MCP server {server.name}"
+            )
+
+            return LoadToolsResponse(
+                success=True,
+                server_id=server_id,
+                tools=[_mcp_tool_to_response(t) for t in updated_tools],
+                resource_templates=[_mcp_resource_template_to_response(t) for t in updated_templates],
+                duration_ms=result.duration_ms,
+            )
 
 
 @router.get("/mcp/servers/{server_id}/tools", response_model=list[McpToolResponse])
@@ -2058,6 +2135,7 @@ def _skill_to_response(skill: Skill) -> SkillResponse:
         priority=skill.priority,
         enforcement_mode=getattr(skill, "enforcement_mode", "warning") or "warning",
         resources=list(skill.resources or []) if hasattr(skill, "resources") else [],
+        is_builtin=bool(getattr(skill, "is_system", False)) or (skill.owner_id or "").startswith("system"),
     )
 
 
@@ -2350,6 +2428,8 @@ async def sync_negentropy_subagents(
                 existing.tools = materialized.get("tools") or []
                 existing.is_enabled = bool(materialized.get("is_enabled", True))
                 existing.visibility = PluginVisibility(materialized.get("visibility", "private"))
+                # 与迁移 0033 的回填语义对齐：经 negentropy 内置同步的 SubAgent 都是系统内置。
+                existing.is_system = True
                 updated_count += 1
                 touched_agents.append(existing)
                 continue
@@ -2367,6 +2447,7 @@ async def sync_negentropy_subagents(
                 skills=materialized.get("skills") or [],
                 tools=materialized.get("tools") or [],
                 is_enabled=bool(materialized.get("is_enabled", True)),
+                is_system=True,
             )
             db.add(new_agent)
             created_count += 1
@@ -2575,6 +2656,10 @@ def _subagent_to_response(agent: SubAgent) -> SubAgentResponse:
     adk_config = _extract_adk_config(agent)
     raw_kind = adk_config.get("kind") if isinstance(adk_config, dict) else None
     kind = raw_kind if raw_kind in ("root", "subagent") else "subagent"
+    # is_builtin OR 合并：显式 ``is_system`` 列（迁移 0033 起）+ 历史 config.source 标记。
+    # 迁移 0033 已将 ``config.source == "negentropy_builtin"`` 行回填 is_system=TRUE，
+    # 这里保留 OR 兼容仍未跑迁移的部署，下一个 release 周期可下线 config.source 判断。
+    is_builtin = bool(getattr(agent, "is_system", False)) or source == "negentropy_builtin"
     return SubAgentResponse(
         id=agent.id,
         owner_id=agent.owner_id,
@@ -2590,7 +2675,7 @@ def _subagent_to_response(agent: SubAgent) -> SubAgentResponse:
         skills=agent.skills or [],
         tools=agent.tools or [],
         source=source,
-        is_builtin=source == "negentropy_builtin",
+        is_builtin=is_builtin,
         is_enabled=agent.is_enabled,
         kind=kind,
     )

--- a/apps/negentropy/src/negentropy/interface/permissions.py
+++ b/apps/negentropy/src/negentropy/interface/permissions.py
@@ -200,8 +200,10 @@ async def get_visible_plugin_ids(
 
     queries = [owned_query, public_query, shared_query]
 
-    # 仅当该模型显式带 ``is_system`` 列时启用系统内置可见性扩展，避免对未迁移
-    # 表执行 SELECT 时产生 UndefinedColumn 错误（向后兼容旧 schema）。
+    # 系统内置可见性扩展：is_system == TRUE 的行对全员可见。
+    # 注意：hasattr 对 SQLAlchemy mapped column 始终为 True（类级描述符），
+    # 此守卫并非用于兼容「未迁移 schema」（迁移 0033 与本代码同分支发布），
+    # 而是作为语义标记：若未来新增不带 is_system 的 plugin 类型，此处自动跳过。
     if hasattr(model, "is_system"):
         builtin_query = select(model.id).where(model.is_system.is_(True))
         queries.append(builtin_query)

--- a/apps/negentropy/src/negentropy/interface/permissions.py
+++ b/apps/negentropy/src/negentropy/interface/permissions.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from negentropy.auth.service import AuthUser
 from negentropy.models.plugin import (
+    BuiltinTool,
     McpServer,
     PluginPermission,
     PluginPermissionType,
@@ -18,6 +19,30 @@ from negentropy.models.plugin import (
     Skill,
     SubAgent,
 )
+
+# 「系统内置」单一事实源：5 类 plugin 表统一通过显式 ``is_system`` 列识别。
+# 历史种子（mcp_servers seed=0002、builtin_tools seed=0031）的 ``owner_id``
+# 使用 ``"system"`` / ``"system:..."`` 前缀仅作来源溯源，权限判断不再依赖该字符
+# 串约定 —— 字符串前缀缺索引、缺 NOT NULL 约束、易被 SSO ``sub`` 等业务字段误中。
+PLUGIN_TYPE_MODEL_MAP = {
+    "mcp_server": McpServer,
+    "skill": Skill,
+    "sub_agent": SubAgent,
+    "builtin_tool": BuiltinTool,
+}
+
+
+def _is_plugin_builtin(plugin) -> bool:
+    """统一识别「系统内置」插件。
+
+    优先读取显式 ``is_system`` 列（与 BuiltinTool / 迁移 0033 对齐）；
+    若该插件类型尚未引入该列（向后兼容期），回退到 ``owner_id`` 前缀 ``"system"``。
+    """
+    is_system = getattr(plugin, "is_system", None)
+    if is_system is not None:
+        return bool(is_system)
+    owner_id = getattr(plugin, "owner_id", None) or ""
+    return owner_id.startswith("system")
 
 
 async def check_plugin_access(
@@ -32,7 +57,7 @@ async def check_plugin_access(
 
     Args:
         db: 数据库会话
-        plugin_type: 插件类型 ("mcp_server", "skill", "sub_agent")
+        plugin_type: 插件类型 ("mcp_server", "skill", "sub_agent", "builtin_tool")
         plugin_id: 插件 UUID
         user: 当前用户
         required_permission: 需要的权限 ("view" or "edit")
@@ -53,11 +78,18 @@ async def check_plugin_access(
     if plugin.owner_id == user.user_id:
         return True, None
 
-    # 4. 检查 visibility
+    # 4. 系统内置：所有用户 view 均通过；edit 仅 admin（已在步骤 1 命中）。
+    #    与「系统内置全员可见、不可被普通用户改写」语义对齐。
+    if _is_plugin_builtin(plugin):
+        if required_permission == "view":
+            return True, None
+        return False, "System built-in plugin cannot be edited by non-admin users"
+
+    # 5. 检查 visibility
     if plugin.visibility == PluginVisibility.PUBLIC and required_permission == "view":
         return True, None
 
-    # 5. 检查授权记录
+    # 6. 检查授权记录
     if plugin.visibility in (PluginVisibility.SHARED, PluginVisibility.PUBLIC):
         permission_record = await db.scalar(
             select(PluginPermission).where(
@@ -105,6 +137,10 @@ async def check_plugin_ownership(
     if not plugin:
         return False, "Plugin not found"
 
+    # 系统内置插件：仅 admin 可视作 owner（避免误删 / 误授权 seed 行）。
+    if _is_plugin_builtin(plugin):
+        return False, "System built-in plugin can only be managed by admin users"
+
     if plugin.owner_id == user.user_id:
         return True, None
 
@@ -132,13 +168,9 @@ async def get_visible_plugin_ids(
     Returns:
         list[UUID]: 可见的插件 ID 列表
     """
-    # 根据插件类型选择模型
-    model_map = {
-        "mcp_server": McpServer,
-        "skill": Skill,
-        "sub_agent": SubAgent,
-    }
-    model = model_map.get(plugin_type)
+    # 根据插件类型选择模型（含 builtin_tool —— 修复 ISSUE: stats.tools 永远 0/0
+    # 与 list_builtin_tools 永远空的 bug，原 model_map 漏掉了 builtin_tool 键。）
+    model = PLUGIN_TYPE_MODEL_MAP.get(plugin_type)
     if not model:
         return []
 
@@ -147,12 +179,14 @@ async def get_visible_plugin_ids(
         result = await db.scalars(select(model.id))
         return list(result.all())
 
-    # 复杂查询：owner_id == user_id OR visibility == PUBLIC OR 有授权记录
-    # 使用 union 来组合这些条件
+    # 普通用户可见的并集：
+    #   1. owner_id == user_id（自有）
+    #   2. visibility == PUBLIC（公开分享）
+    #   3. 在 PluginPermission 中有授权记录（私享）
+    #   4. is_system == TRUE（系统内置 —— 对全员可见，与 BuiltinTool 模式对齐）
     owned_query = select(model.id).where(model.owner_id == user.user_id)
     public_query = select(model.id).where(model.visibility == PluginVisibility.PUBLIC)
 
-    # 获取有授权记录的插件 ID
     shared_query = (
         select(PluginPermission.plugin_id)
         .where(
@@ -164,10 +198,17 @@ async def get_visible_plugin_ids(
         .distinct()
     )
 
-    # 组合查询
+    queries = [owned_query, public_query, shared_query]
+
+    # 仅当该模型显式带 ``is_system`` 列时启用系统内置可见性扩展，避免对未迁移
+    # 表执行 SELECT 时产生 UndefinedColumn 错误（向后兼容旧 schema）。
+    if hasattr(model, "is_system"):
+        builtin_query = select(model.id).where(model.is_system.is_(True))
+        queries.append(builtin_query)
+
     from sqlalchemy import union
 
-    combined = union(owned_query, public_query, shared_query)
+    combined = union(*queries)
     result = await db.execute(combined)
     return [row[0] for row in result.fetchall()]
 
@@ -178,12 +219,7 @@ async def _get_plugin_by_type_and_id(
     plugin_id: UUID,
 ):
     """根据类型和 ID 获取插件记录。"""
-    model_map = {
-        "mcp_server": McpServer,
-        "skill": Skill,
-        "sub_agent": SubAgent,
-    }
-    model = model_map.get(plugin_type)
+    model = PLUGIN_TYPE_MODEL_MAP.get(plugin_type)
     if not model:
         return None
     return await db.get(model, plugin_id)

--- a/apps/negentropy/src/negentropy/models/mcp.py
+++ b/apps/negentropy/src/negentropy/models/mcp.py
@@ -38,12 +38,16 @@ class McpServer(Base, UUIDMixin, TimestampMixin):
     # 状态和配置
     is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
     auto_start: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    # 「系统内置」标识：与 BuiltinTool.is_system / Skill.is_system / SubAgent.is_system
+    # 对齐，作为可见性与权限判断的单一事实源（参见 permissions._is_plugin_builtin）。
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
 
     __table_args__ = (
         UniqueConstraint("name", name="mcp_servers_name_unique"),
         Index("ix_mcp_servers_owner", "owner_id"),
         Index("ix_mcp_servers_visibility", "visibility"),
+        Index("ix_mcp_servers_is_system", "is_system"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 

--- a/apps/negentropy/src/negentropy/models/skill.py
+++ b/apps/negentropy/src/negentropy/models/skill.py
@@ -38,6 +38,9 @@ class Skill(Base, UUIDMixin, TimestampMixin):
 
     # 状态
     is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    # 「系统内置」标识：与 BuiltinTool.is_system / McpServer.is_system / SubAgent.is_system
+    # 对齐，作为可见性与权限判断的单一事实源（参见 permissions._is_plugin_builtin）。
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 
     # Phase 2 — 工具白名单 fail-close 模式（warning|strict，默认 warning）
@@ -55,6 +58,7 @@ class Skill(Base, UUIDMixin, TimestampMixin):
         UniqueConstraint("name", name="skills_name_unique"),
         Index("ix_skills_owner", "owner_id"),
         Index("ix_skills_category", "category"),
+        Index("ix_skills_is_system", "is_system"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 

--- a/apps/negentropy/src/negentropy/models/sub_agent.py
+++ b/apps/negentropy/src/negentropy/models/sub_agent.py
@@ -36,9 +36,15 @@ class SubAgent(Base, UUIDMixin, TimestampMixin):
 
     # 状态
     is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    # 「系统内置」标识：与 BuiltinTool.is_system / McpServer.is_system / Skill.is_system
+    # 对齐，作为可见性与权限判断的单一事实源（参见 permissions._is_plugin_builtin）。
+    # 历史上通过 ``config.source == "negentropy_builtin"`` 标记的 SubAgent 在迁移
+    # 0033 中会被自动回填为 ``is_system=TRUE``。
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
 
     __table_args__ = (
         UniqueConstraint("name", name="sub_agents_name_unique"),
         Index("ix_sub_agents_owner", "owner_id"),
+        Index("ix_sub_agents_is_system", "is_system"),
         {"schema": NEGENTROPY_SCHEMA},
     )

--- a/apps/negentropy/tests/unit_tests/interface/test_permissions.py
+++ b/apps/negentropy/tests/unit_tests/interface/test_permissions.py
@@ -1,0 +1,84 @@
+"""单元测试：interface.permissions 模块。
+
+覆盖系统内置可见性扩展与 ``_is_plugin_builtin`` helper 的正交边界，
+对应 ISSUE: Dashboard 与子模块统计未含系统内置 / Negentropy Perceive Permission Denied。
+
+只验证纯函数语义；DB 相关路径在 integration_tests 中走真实 PG round-trip。
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from negentropy.interface.permissions import (
+    PLUGIN_TYPE_MODEL_MAP,
+    _is_plugin_builtin,
+)
+from negentropy.models.plugin import (
+    BuiltinTool,
+    McpServer,
+    Skill,
+    SubAgent,
+)
+
+
+def _stub(is_system=None, owner_id: str = "alice"):
+    """构造一个 duck-typed plugin 对象，仅暴露 _is_plugin_builtin 关心的属性。"""
+    attrs: dict[str, object] = {"owner_id": owner_id}
+    if is_system is not None:
+        attrs["is_system"] = is_system
+    return types.SimpleNamespace(**attrs)
+
+
+class TestPluginTypeModelMap:
+    """``PLUGIN_TYPE_MODEL_MAP`` 是 5 类 plugin 的单一事实源。"""
+
+    def test_includes_builtin_tool(self) -> None:
+        """ISSUE: 历史上 model_map 漏掉 builtin_tool 键，导致 stats.tools 永远 0/0。"""
+        assert PLUGIN_TYPE_MODEL_MAP["builtin_tool"] is BuiltinTool
+
+    def test_full_coverage(self) -> None:
+        assert PLUGIN_TYPE_MODEL_MAP["mcp_server"] is McpServer
+        assert PLUGIN_TYPE_MODEL_MAP["skill"] is Skill
+        assert PLUGIN_TYPE_MODEL_MAP["sub_agent"] is SubAgent
+        assert set(PLUGIN_TYPE_MODEL_MAP.keys()) == {
+            "mcp_server",
+            "skill",
+            "sub_agent",
+            "builtin_tool",
+        }
+
+
+class TestIsPluginBuiltin:
+    """显式 ``is_system`` 列优先；列缺失时回退 owner_id 前缀。"""
+
+    def test_explicit_true(self) -> None:
+        assert _is_plugin_builtin(_stub(is_system=True)) is True
+
+    def test_explicit_false_overrides_owner_prefix(self) -> None:
+        """显式列为 False 时不再回退 owner_id —— 列是权威。"""
+        plugin = _stub(is_system=False, owner_id="system:legacy")
+        assert _is_plugin_builtin(plugin) is False
+
+    def test_fallback_when_column_missing(self) -> None:
+        """旧 schema（迁移 0033 之前）回退 owner_id 前缀。"""
+        plugin = _stub(is_system=None, owner_id="system:negentropy-perceives-preset")
+        assert _is_plugin_builtin(plugin) is True
+
+    def test_fallback_regular_owner(self) -> None:
+        plugin = _stub(is_system=None, owner_id="alice@example.com")
+        assert _is_plugin_builtin(plugin) is False
+
+    def test_no_attributes_at_all(self) -> None:
+        plugin = types.SimpleNamespace()
+        assert _is_plugin_builtin(plugin) is False
+
+
+class TestModelHasIsSystem:
+    """5 类 plugin 模型都已绑定 is_system 列（迁移 0033 + builtin_tool 历史已有）。"""
+
+    @pytest.mark.parametrize("model", [McpServer, Skill, SubAgent, BuiltinTool])
+    def test_column_exists(self, model) -> None:
+        assert hasattr(model, "is_system"), f"{model.__name__} missing is_system column"


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：
  - **B1（用户主诉）**：Interface > MCP 页 `Negentropy Perceive` 卡片每次进入都显示红色 `Permission denied`。
  - **B2**：Dashboard `Tools` 统计永远 `0/0`，`/interface/tools` 列表对所有用户永远为空，即使 `google_search` 已被迁移 0031 种入。
  - **B3**：「系统内置」在 5 类 plugin 间口径分散（`BuiltinTool.is_system` 显式列 / `mcp_servers.owner_id` 前缀 / `sub_agents.config.source`），统计、权限、UI 徽标无法以单一谓词识别。
- 关联上下文：服务端日志中频繁出现的 `.well-known/oauth-protected-resource 404` 是 mcp SDK 自动 OAuth 探测，与本问题无因果关系，仅是噪声。

# 核心变更

- **后端权限统一**：`permissions.py` 补齐 `builtin_tool` model_map（修复 B2 根因），新增 `_is_plugin_builtin` helper 优先读 `is_system` 列、缺列回退 `owner_id` 前缀；`get_visible_plugin_ids` 在 owner/public/shared 之外额外 union `is_system=true`；`check_plugin_access` / `check_plugin_ownership` 对系统内置严格仅 admin 可 edit，杜绝 200→403 闪烁。
- **模型与迁移**：`McpServer`/`Skill`/`SubAgent` 新增 `is_system: bool` 列（与 `BuiltinTool` 对齐），新建幂等迁移 `0033_plugin_is_system` ADD COLUMN + 索引 + 回填 0002/SubAgent sync 历史数据，downgrade 仅回收列与索引、不触碰 seed 行。
- **B1 主诉修复**：`load_mcp_server_tools` 权限从 `edit` 降级为 `view`（工具发现是只读语义，`mcp_tools` 是 server-scoped）；引入 per-server `asyncio.Lock` + 60s TTL 双检锁，并发 view 用户对同一 server 仅触发一次 streamablehttp 探测，其余命中 DB 快照。
- **Response 统一字段**：5 类 list/get response 暴露统一 `is_builtin: bool`，SubAgent 与历史 `config.source==negentropy_builtin` 做 OR 合并；`sync_negentropy_subagents` 写入时同步置 `is_system=True`，让运行时回归显式列。
- **前端**：MCP/Skills/SubAgents/Tools 卡片统一 amber `Built-In` 徽标 + `canEdit = isAdmin || !isBuiltin` 隐藏非 admin 的 Edit/Delete；MCP 页 useEffect 由自动 `POST /tools:load` 改为 `GET /tools` 按需读 DB 快照，显式 discover 改由 Refresh tools 按钮触发，根因消除每次进页的 OAuth 404 探测放大。

# 风险与回滚

- 主要风险：
  - 迁移 0033 在已运行环境上 ADD COLUMN + 回填，使用 `IF NOT EXISTS` 与条件 UPDATE 保证幂等。
  - `load_mcp_server_tools` 权限放宽至 view 后，理论上任意 view 用户都能触发对底层 server 的 discover；通过 per-server `asyncio.Lock` + 60s TTL 双检锁限制最大并发探测为 1/60s。
  - 前端取消 useEffect 自动 load 后，从未被 admin 同步过 tools 的 server 在用户首次访问时不会自动发现工具，需点击 Refresh tools；与新增/编辑 server 的写入语义对称。
- 回滚方式：4 个原子提交可独立回滚；最坏情况下 `git revert ef2dcf64 409383a4 43ebbb19 90ab3f12`，迁移走 `alembic downgrade 0032`（仅回收列与索引，不触碰 seed）。

# 验证证据

- 单元测试：`apps/negentropy/tests/unit_tests/interface/test_permissions.py` 11 条全过；现有 `test_mcp_client.py` + `test_subagent_presets.py` 9/9 不回归。
- 集成测试：真实 PG 上 `alembic upgrade head` 应用 0033 后，确认 `mcp_servers WHERE name='negentropy-perceives'` 的 `is_system=True` 已被回填，`visibility=public`。
- E2E / Workflow：本会话内未启动完整 dev 环境的 SSO 实测；用户需按 [浏览器验证协议](docs/agents/browser-validation.md) 启动 backend + UI，使用真实 admin / 非 admin 账户分别验证 `/interface` Dashboard 5 张 StatCard 数字 > 0、`/interface/mcp` Negentropy Perceive 不再 Permission Denied、`/interface/tools` 显示 Google Search Built-In、非 admin 看到 Built-In 项时 Edit/Delete 隐藏、`/interface/models` 仍要求 admin。
- 覆盖率/关键截图：暂未附实操截图（实测在用户 dev 环境完成）；后端模型 + 权限模块单测覆盖见上。
- 静态检查：pre-commit (ruff lint + ruff format + ESLint) 全过；前端 `tsc --noEmit` 无错误。

# 影响范围

- 前端：`app/interface/mcp/page.tsx`、`app/interface/{mcp,skills,subagents,tools}/_components/*Card.tsx` 共 5 个文件；统一 Built-In 徽标 + `useAuth` 派生 `canEdit` + MCP 页移除自动 discover。
- 后端：`negentropy/interface/{permissions,api}.py`、`negentropy/models/{mcp,skill,sub_agent}.py`、新建迁移 `0033_plugin_is_system.py`、新建单测 `tests/unit_tests/interface/test_permissions.py`。
- GitHub Actions / 文档：无变更；本 PR 不引入新的 CI / 文档影响。

# Next Best Action

- 在 dev 环境跑一次完整浏览器实测（多账号 + 多页面）并把关键截图回贴到本 PR 评论，作为系统内置可见性 + Permission Denied 修复的视觉自证。
- 下一个 release 周期后下线 SubAgent 的 `config.source=="negentropy_builtin"` 旧口径，仅保留显式 `is_system` 列作为唯一事实源。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)