### PR TITLE
feat(kb-documents): 文档操作行补 Tooltip 并按归档状态互斥 Archive/Unarchive;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1393,16 +1393,67 @@ export default function KnowledgeBasePage() {
                                 </div>
                               </button>
                               <div className="flex flex-wrap items-center justify-end gap-1">
-                                <button onClick={() => runDocumentAction("view", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>View</button>
-                                <button onClick={() => runDocumentAction("download", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Download</button>
-                                <button onClick={() => runDocumentAction("replace", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Replace</button>
-                                <button onClick={() => runDocumentAction("rebuild", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Rebuild</button>
+                                <button
+                                  onClick={() => runDocumentAction("view", doc)}
+                                  title="在弹窗中预览文档解析后的 Markdown 正文"
+                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                >
+                                  View
+                                </button>
+                                <button
+                                  onClick={() => runDocumentAction("download", doc)}
+                                  title="下载原始文件到本地"
+                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                >
+                                  Download
+                                </button>
+                                <button
+                                  onClick={() => runDocumentAction("replace", doc)}
+                                  title="用新文本替换该文档并重建索引（保留文档元信息）"
+                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                >
+                                  Replace
+                                </button>
+                                <button
+                                  onClick={() => runDocumentAction("rebuild", doc)}
+                                  title="重新分块并重建向量索引（不更换原始内容）"
+                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                >
+                                  Rebuild
+                                </button>
                                 {sourceType === "url" && (
-                                  <button onClick={() => runDocumentAction("sync", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Sync</button>
+                                  <button
+                                    onClick={() => runDocumentAction("sync", doc)}
+                                    title="重新抓取该 URL 源并刷新内容（仅 URL 类型）"
+                                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                  >
+                                    Sync
+                                  </button>
                                 )}
-                                <button onClick={() => runDocumentAction("archive", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Archive</button>
-                                <button onClick={() => runDocumentAction("unarchive", doc)} className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}>Unarchive</button>
-                                <button onClick={() => runDocumentAction("delete", doc)} className={outlineButtonClassName("danger", "rounded px-2 py-1 text-[11px]")}>Delete</button>
+                                {!doc.archived ? (
+                                  <button
+                                    onClick={() => runDocumentAction("archive", doc)}
+                                    title="归档该文档，将其从默认检索中排除（可解档恢复）"
+                                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                  >
+                                    Archive
+                                  </button>
+                                ) : (
+                                  <button
+                                    onClick={() => runDocumentAction("unarchive", doc)}
+                                    title="取消归档，恢复参与检索"
+                                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-[11px]")}
+                                  >
+                                    Unarchive
+                                  </button>
+                                )}
+                                <button
+                                  onClick={() => runDocumentAction("delete", doc)}
+                                  title="删除该文档及其全部 Chunks"
+                                  className={outlineButtonClassName("danger", "rounded px-2 py-1 text-[11px]")}
+                                >
+                                  Delete
+                                </button>
                               </div>
                             </div>
                           </div>

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1249,6 +1249,7 @@ export interface KnowledgeDocument {
   markdown_extract_status?: "pending" | "processing" | "completed" | "failed" | string;
   markdown_extracted_at?: string | null;
   markdown_extract_error?: string | null;
+  archived?: boolean;
   metadata?: Record<string, unknown>;
 }
 

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -1476,8 +1476,13 @@ async def _resolve_user_display_names(user_ids: list[str]) -> dict[str, str]:
     return name_map
 
 
-def _build_document_response(doc, name_map: dict[str, str]) -> DocumentResponse:
-    """从 ORM 文档对象构建 DocumentResponse，注入用户显示名。"""
+def _build_document_response(
+    doc,
+    name_map: dict[str, str],
+    *,
+    archived: bool = False,
+) -> DocumentResponse:
+    """从 ORM 文档对象构建 DocumentResponse，注入用户显示名与归档状态。"""
     return DocumentResponse(
         id=doc.id,
         corpus_id=doc.corpus_id,
@@ -1494,8 +1499,37 @@ def _build_document_response(doc, name_map: dict[str, str]) -> DocumentResponse:
         markdown_extract_status=doc.markdown_extract_status,
         markdown_extracted_at=(doc.markdown_extracted_at.isoformat() if doc.markdown_extracted_at else None),
         markdown_extract_error=doc.markdown_extract_error,
+        archived=archived,
         metadata=doc.metadata_ or {},
     )
+
+
+async def _resolve_documents_archived_set(
+    docs: list,
+    app_name: str,
+) -> set[tuple[UUID, str]]:
+    """批量解析一批文档的归档状态，返回已归档的 ``(corpus_id, source_uri)`` 集合。
+
+    单一事实源——复用与 ``SourceSummary.archived`` 同款聚合逻辑，避免前端做映射。
+    若 ``source_uri`` 无法解析（极端老数据），该文档默认按未归档处理。
+    """
+    pairs: list[tuple[UUID, str]] = []
+    seen: set[tuple[UUID, str]] = set()
+    for doc in docs:
+        source_uri = _resolve_document_source_uri(doc)
+        if not source_uri:
+            continue
+        key = (doc.corpus_id, source_uri)
+        if key in seen:
+            continue
+        seen.add(key)
+        pairs.append(key)
+
+    if not pairs:
+        return set()
+
+    service = _get_service()
+    return await service.get_archived_source_uris(pairs=pairs, app_name=app_name)
 
 
 @router.get("/base/{corpus_id}/documents", response_model=DocumentListResponse)
@@ -1530,10 +1564,16 @@ async def list_documents(
 
     unique_user_ids = list({doc.created_by for doc in docs if doc.created_by})
     name_map = await _resolve_user_display_names(unique_user_ids)
+    archived_set = await _resolve_documents_archived_set(docs, resolved_app)
+
+    def _build(doc) -> DocumentResponse:
+        source_uri = _resolve_document_source_uri(doc)
+        archived = bool(source_uri and (doc.corpus_id, source_uri) in archived_set)
+        return _build_document_response(doc, name_map, archived=archived)
 
     return DocumentListResponse(
         count=total,
-        items=[_build_document_response(doc, name_map) for doc in docs],
+        items=[_build(doc) for doc in docs],
     )
 
 
@@ -1567,10 +1607,16 @@ async def list_all_documents(
 
     unique_user_ids = list({doc.created_by for doc in docs if doc.created_by})
     name_map = await _resolve_user_display_names(unique_user_ids)
+    archived_set = await _resolve_documents_archived_set(docs, resolved_app)
+
+    def _build(doc) -> DocumentResponse:
+        source_uri = _resolve_document_source_uri(doc)
+        archived = bool(source_uri and (doc.corpus_id, source_uri) in archived_set)
+        return _build_document_response(doc, name_map, archived=archived)
 
     return DocumentListResponse(
         count=total,
-        items=[_build_document_response(doc, name_map) for doc in docs],
+        items=[_build(doc) for doc in docs],
     )
 
 
@@ -1602,6 +1648,16 @@ async def get_document_detail(
 
     name_map = await _resolve_user_display_names([doc.created_by]) if doc.created_by else {}
 
+    source_uri = _resolve_document_source_uri(doc)
+    archived = False
+    if source_uri:
+        service = _get_service()
+        archived_set = await service.get_archived_source_uris(
+            pairs=[(doc.corpus_id, source_uri)],
+            app_name=resolved_app,
+        )
+        archived = (doc.corpus_id, source_uri) in archived_set
+
     return DocumentDetailResponse(
         id=doc.id,
         corpus_id=doc.corpus_id,
@@ -1618,6 +1674,7 @@ async def get_document_detail(
         markdown_extract_status=doc.markdown_extract_status,
         markdown_extracted_at=doc.markdown_extracted_at.isoformat() if doc.markdown_extracted_at else None,
         markdown_extract_error=doc.markdown_extract_error,
+        archived=archived,
         metadata=doc.metadata_ or {},
         markdown_content=markdown_content,
         markdown_gcs_uri=doc.markdown_gcs_uri,

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Boolean, String, cast, func, select, text, update
+from sqlalchemy import Boolean, String, cast, func, select, text, tuple_, update
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
@@ -452,6 +452,49 @@ class KnowledgeRepository:
             )
             await db.commit()
             return result.rowcount
+
+    async def get_archived_source_uris(
+        self,
+        *,
+        pairs: list[tuple[UUID, str]],
+        app_name: str,
+    ) -> set[tuple[UUID, str]]:
+        """批量判定指定 ``(corpus_id, source_uri)`` 是否处于"全量归档"状态。
+
+        判定语义与 ``SourceSummary.archived`` 完全一致：仅当某 ``source_uri``
+        对应的全部 chunk 的 ``metadata.archived`` 均为 ``true`` 时，该组合
+        才被视为已归档（任一未归档即视为未归档）。
+
+        Args:
+            pairs: ``(corpus_id, source_uri)`` 组合列表，空列表直接返回空集合。
+            app_name: 应用名称（多租户隔离）。
+
+        Returns:
+            所有 chunk 均已归档的 ``(corpus_id, source_uri)`` 集合。
+        """
+        if not pairs:
+            return set()
+
+        async with self._get_session_factory()() as db:
+            archived_expr = func.coalesce(
+                cast(Knowledge.metadata_["archived"].astext, Boolean),
+                False,
+            )
+            stmt = (
+                select(
+                    Knowledge.corpus_id,
+                    Knowledge.source_uri,
+                    func.bool_and(archived_expr).label("all_archived"),
+                )
+                .where(
+                    Knowledge.app_name == app_name,
+                    tuple_(Knowledge.corpus_id, Knowledge.source_uri).in_(pairs),
+                )
+                .group_by(Knowledge.corpus_id, Knowledge.source_uri)
+                .having(func.bool_and(archived_expr).is_(True))
+            )
+            result = await db.execute(stmt)
+            return {(row.corpus_id, row.source_uri) for row in result}
 
     async def get_knowledge_by_id(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -587,6 +587,7 @@ class DocumentResponse(BaseModel):
     markdown_extract_status: str = "pending"
     markdown_extracted_at: str | None = None
     markdown_extract_error: str | None = None
+    archived: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     class Config:

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -2091,6 +2091,23 @@ class KnowledgeService:
 
         return updated_count
 
+    async def get_archived_source_uris(
+        self,
+        *,
+        pairs: list[tuple[UUID, str]],
+        app_name: str,
+    ) -> set[tuple[UUID, str]]:
+        """批量返回所有 chunk 均已归档的 ``(corpus_id, source_uri)`` 组合。
+
+        语义与 ``SourceSummary.archived`` 完全一致——仅当某 ``source_uri``
+        对应的全部 chunk 的 ``metadata.archived`` 均为 ``true`` 时视为归档。
+        服务层薄包装，主要供 ``DocumentResponse.archived`` 字段填充使用。
+        """
+        return await self._repository.get_archived_source_uris(
+            pairs=pairs,
+            app_name=app_name,
+        )
+
     async def ingest_url(
         self,
         *,


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge Base → Corpus 详情 → Documents 列表中每行 8 个操作按钮（View / Download / Replace / Rebuild / Sync / Archive / Unarchive / Delete）存在两类 UX 缺陷——全部按钮无 tooltip，新用户难以区分 Replace / Rebuild / Sync 等语义相近的操作；Archive 与 Unarchive 同时展示，违反"互斥操作只暴露当前态可用项"的常识 UX 准则。
- 关联上下文：复用项目内 `SourceList.SourceMenu`（`apps/negentropy-ui/app/knowledge/base/_components/SourceList.tsx:234-255`）已有的 Source 级归档互斥范式，将同一模式下沉到 Document 行。

# 核心变更
- **后端 schema**：`DocumentResponse` 新增可选字段 `archived: bool = False`，`DocumentDetailResponse` 通过继承自动获得；默认值保证旧客户端反序列化无破坏。
- **后端 repository**：新增 `KnowledgeRepository.get_archived_source_uris(pairs, app_name)`，单条 SQL 按 `(corpus_id, source_uri)` 复合键分组并以 `bool_and(COALESCE((metadata->>'archived')::boolean, false))` 聚合判定全量归档，语义与 `SourceSummary.archived` 一致。
- **后端 service**：`KnowledgeService.get_archived_source_uris` 薄包装转发。
- **后端 api**：抽出 `_resolve_documents_archived_set` 辅助函数复用 `_resolve_document_source_uri`；`list_documents` / `list_all_documents` 每页一次批量聚合查询填充 `archived`，跨 Corpus 路由用复合键避免同 URI 误并；`get_document_detail` 单点聚合查询填充。
- **前端类型**：`KnowledgeDocument` 同步新增可选 `archived?: boolean`，`KnowledgeDocumentDetail` 通过 `extends` 自动获得。
- **前端 UI**（`/knowledge/base` Documents 列表）：8 个按钮全部补充中文 `title` tooltip（沿用项目原生 `title` 属性 + group-hover 模式，未引入 i18n 库或 Tooltip 组件库）；Archive 与 Unarchive 改为 `!doc.archived` / `doc.archived` 三元互斥渲染，其余按钮位置与文案保持不变。

# 风险与回滚
- 主要风险：
  - 列表态每页额外 1 次聚合 SQL（pairs ≤ limit ≤ 100）：仅 `bool_and` + `group by` 操作，已在现有 `(corpus_id, source_uri)` 检索路径范围内；若劣化可补 `(corpus_id, source_uri)` 复合索引。
  - 前后端滚动发布期前端拿不到 `archived`：字段在前端定义为可选，`!doc.archived` 退化为显示 Archive，安全默认。
  - `_resolve_document_source_uri` 返回 `None`（极端老数据）：后端默认 `archived=false`，按钮显示 Archive；点击会被后端 400 拒绝并由现有 `toast.error` 兜底。
- 回滚方式：
  - **整体回滚**：还原本次 6 个文件即可；`archived` 为新增可选字段无破坏性。
  - **仅前端回滚**：保留后端字段，UI 还原为同显两按钮 + 移除 tooltip，后端字段静默存在。
  - **仅后端回滚**：保留前端 UI；`doc.archived` 退化为 `undefined`，三元渲染始终显示 Archive，归档操作幂等无副作用；Unarchive 临时不可点（可接受降级）。

# 验证证据
- 单元测试：`uv run pytest apps/negentropy/tests/unit_tests/knowledge/` —— 816 个用例全部通过；唯一失败的 `test_extraction_llm_plan::test_build_llm_invocation_plan_returns_none_when_serialization_fails` 经 `git stash` 验证为本次改动之前既已存在的预先失败，与本 PR 无关。
- 集成测试：本次未新增集成测试；归档真值层 `archive_source` API 路径未变更，仍由原有 `archive_knowledge_by_source` repository 方法独立处理写路径。
- E2E / Workflow：UI 实机视觉验证未在本地完成（本地无可用 dev server 与 Chrome profile 协议条件），建议在 PR review 或 staging 环境覆盖以下场景：
  1. `/knowledge/base` 选中任意 Corpus 的 Documents tab，悬停 8 个按钮逐一确认中文 tooltip 文案与位置。
  2. 正常态文档只显示 Archive；点击 Archive → toast 成功 → 列表刷新后只剩 Unarchive。
  3. 点击 Unarchive → 状态回归 → 只剩 Archive。
  4. URL 类型文档 Sync 按钮存在；非 URL 不出现 Sync。
  5. 跨 Corpus 同 URI 文档分别归档互不影响。
- 覆盖率/关键截图：
  - `pnpm exec tsc --noEmit` → EXIT 0
  - `uv run ruff check` & `ruff format --check` → All checks passed
  - pre-commit hooks（ruff lint、ruff format、ESLint）全部通过
  - 关键截图：待 PR review 阶段补充浏览器实操截图

# 影响范围
- 前端：
  - `apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts`（类型扩展）
  - `apps/negentropy-ui/app/knowledge/base/page.tsx`（UI 行为，仅 `/knowledge/base` 单页；`/knowledge/documents` 全局列表页 UI 不变，仅消费同一 schema）
- 后端：
  - `apps/negentropy/src/negentropy/knowledge/schemas.py`（DocumentResponse 字段）
  - `apps/negentropy/src/negentropy/knowledge/retrieval/repository.py`（新增聚合方法）
  - `apps/negentropy/src/negentropy/knowledge/service.py`（薄包装）
  - `apps/negentropy/src/negentropy/knowledge/api.py`（3 个文档路由 + 1 个辅助函数）
- GitHub Actions / 文档：本次无变更。

# Next Best Action
- PR 合并后于 staging 完成 UI 实机回归（按"验证证据"E2E 清单 5 项），可保留截图入 `docs/agents/issue.md` 作为后续相同 UX 范式（其他列表行的 Archive/Unarchive 互斥与 tooltip 治理）的参考案例。
- 跟进 `/knowledge/documents` 全局文档列表：当前未提供 Archive/Unarchive 操作，是否需要同步治理可在后续单独提案。