### PR TITLE
fix(negentropy-ui): 修复文档 Markdown 中内嵌 HTML <img> 渲染为字面文本的问题

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx
@@ -6,8 +6,54 @@ import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plu
 import { cn } from "@/lib/utils";
 import { MermaidDiagram } from "@/components/ui/MermaidDiagram";
 import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 
 import "./highlight-theme.css";
+
+// 文档场景的 sanitize schema：在 defaultSchema 之上增量放行媒体标签与
+// width/height 属性。perceives 端为带尺寸的图片输出内嵌 HTML
+// <img …width="X" height="Y" style="…" />，启用 rehype-raw 后必须
+// 由 rehype-sanitize 兜底过滤。defaultSchema 已禁用 script/iframe/on*/style，
+// 我们只在其基础上"加白"，不削减安全约束。危险的 style 自动被剥离，
+// width/height 保留并由外层 CSS [&_img]:h-auto 驱动按比例响应式缩放。
+const documentSanitizeSchema: typeof defaultSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames ?? []),
+    "figure",
+    "figcaption",
+    "video",
+    "audio",
+    "source",
+  ],
+  attributes: {
+    ...(defaultSchema.attributes ?? {}),
+    img: [
+      ...((defaultSchema.attributes ?? {}).img ?? []),
+      "width",
+      "height",
+      "loading",
+      "decoding",
+    ],
+    video: [
+      "src",
+      "controls",
+      "poster",
+      "width",
+      "height",
+      "preload",
+      "loop",
+      "muted",
+      "autoplay",
+      "playsinline",
+    ],
+    audio: ["src", "controls", "preload", "loop", "muted", "autoplay"],
+    source: ["src", "type", "media", "srcset", "sizes"],
+    figure: [],
+    figcaption: [],
+  },
+};
 
 interface DocumentMarkdownRendererProps {
   content: string;
@@ -51,12 +97,16 @@ type ImageState = "loading" | "loaded" | "error";
 function DocumentImage({
   src,
   alt,
+  width,
+  height,
   corpusId,
   documentId,
   appName,
 }: {
   src: string;
   alt?: string;
+  width?: number | string;
+  height?: number | string;
   corpusId: string;
   documentId: string;
   appName?: string;
@@ -103,8 +153,10 @@ function DocumentImage({
       <img
         src={resolvedSrc}
         alt={alt || ""}
+        width={width}
+        height={height}
         className={cn(
-          "max-w-full rounded-lg border border-zinc-200 dark:border-zinc-700",
+          "h-auto max-w-full rounded-lg border border-zinc-200 dark:border-zinc-700",
           imgState === "loaded" ? "block" : "hidden",
         )}
         onLoad={() => setImgState("loaded")}
@@ -155,8 +207,9 @@ export function DocumentMarkdownRenderer({
         "[&_tbody_tr:nth-child(even)]:bg-zinc-50 [&_tbody_tr:nth-child(even)]:dark:bg-zinc-900/30",
         "[&_th]:border [&_th]:border-zinc-200 [&_th]:dark:border-zinc-700 [&_th]:px-3 [&_th]:py-2 [&_th]:font-semibold [&_th]:text-left",
         "[&_td]:border [&_td]:border-zinc-200 [&_td]:dark:border-zinc-700 [&_td]:px-3 [&_td]:py-2",
-        // 图片
-        "[&_img]:max-w-full [&_img]:rounded-lg [&_img]:my-3",
+        // 图片：max-w-full 限制宽度，h-auto 保证按 width/height 比例缩放
+        // （防止 perceives 输出 <img width="X" height="Y" /> 在窄屏被拉伸变形）
+        "[&_img]:max-w-full [&_img]:h-auto [&_img]:rounded-lg [&_img]:my-3",
         // 引用块
         "[&_blockquote]:border-l-4 [&_blockquote]:border-zinc-300 [&_blockquote]:dark:border-zinc-600 [&_blockquote]:pl-4 [&_blockquote]:my-3 [&_blockquote]:text-zinc-600 [&_blockquote]:dark:text-zinc-400",
         // 分隔线
@@ -165,14 +218,23 @@ export function DocumentMarkdownRenderer({
     >
       <ReactMarkdown
         remarkPlugins={defaultRemarkPlugins}
-        rehypePlugins={[...defaultRehypePlugins, rehypeHighlight]}
+        // 顺序至关重要：rehype-raw 先把内嵌 HTML 提升为节点，
+        // rehype-sanitize 紧随其后做白名单过滤，最后才是渲染插件。
+        rehypePlugins={[
+          rehypeRaw,
+          [rehypeSanitize, documentSanitizeSchema],
+          ...defaultRehypePlugins,
+          rehypeHighlight,
+        ]}
         components={{
-          img({ src, alt }) {
+          img({ src, alt, width, height }) {
             if (!src || typeof src !== "string") return null;
             return (
               <DocumentImage
                 src={src}
                 alt={alt || undefined}
+                width={width}
+                height={height}
                 corpusId={corpusId}
                 documentId={documentId}
                 appName={appName}

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -43,6 +43,8 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "rxjs": "7.8.1",

--- a/apps/negentropy-ui/pnpm-lock.yaml
+++ b/apps/negentropy-ui/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1773,6 +1779,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：perceives 端输出的文档 Markdown 中包含带尺寸的内嵌 HTML `<img width="X" height="Y" style="…" />`，被 react-markdown 当作纯文本原样展示，无法渲染为图片。
- 关联上下文/Issue/文档：与 `DocumentMarkdownRenderer` 组件的 Markdown 渲染管线相关。

# 核心变更
- 引入 `rehype-raw` 插件，使 react-markdown 能解析内嵌 HTML 标签并将其提升为 AST 节点
- 引入 `rehype-sanitize` 配合自定义 `documentSanitizeSchema`，在 defaultSchema 基础上增量放行 `figure/figcaption/video/audio/source` 标签及 `img` 的 `width/height/loading/decoding` 属性，不削减安全约束（script/iframe/on*/style 仍被剥离）
- `DocumentImage` 组件扩展支持 `width`/`height` 属性传递，外层 CSS 增加 `h-auto` 确保按 width/height 比例响应式缩放，防止窄屏拉伸变形
- rehype 插件顺序调整为：`rehype-raw → rehype-sanitize → defaultRehypePlugins → rehype-highlight`，确保安全过滤在渲染前完成

# 风险与回滚
- 主要风险：rehype-raw 开启后若 sanitize 配置不当可能引入 XSS 向量；已通过 rehype-sanitize + defaultSchema（默认禁用 script/iframe/on*/style）兜底
- 回滚方式：移除 rehype-raw/rehype-sanitize 依赖，恢复原 rehypePlugins 数组

# 验证证据
- 单元测试：N/A（渲染组件变更）
- 集成测试：N/A
- E2E/Workflow：浏览器实机验证 perceives 输出的带 `width/height` 内嵌 HTML `<img>` 正确渲染为图片，且不出现 XSS 风险标签
- 覆盖率/关键截图：CSS `h-auto` 确保响应式缩放

# 影响范围
- 前端：`DocumentMarkdownRenderer.tsx`、`package.json`、`pnpm-lock.yaml`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 可考虑为 `documentSanitizeSchema` 补充单元测试，验证危险标签（script/iframe/on*）被正确剥离