### PR TITLE
refactor(negentropy-wiki): 树遍历函数归位数据层 + 提取 WikiSidebar 组件消除侧边栏重复

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,4 +1,5 @@
 import {
+  joinEntrySlug,
   resolveSectionView,
   wikiApi,
   type WikiEntry,
@@ -7,8 +8,8 @@ import {
   type WikiPublication,
 } from "@/lib/wiki-api";
 import { WikiHeader } from "@/components/WikiHeader";
-import { WikiNavTree } from "@/components/WikiNavTree";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
+import { WikiSidebar } from "@/components/WikiSidebar";
 import { WikiToc } from "@/components/WikiToc";
 import { extractHeadings } from "@/lib/markdown-headings";
 import ReactMarkdown from "react-markdown";
@@ -37,13 +38,9 @@ interface Props {
 
 type LoadStatus = "ok" | "missing" | "pending" | "orphaned";
 
-function joinSlug(entrySlug: string[] | string): string {
-  return Array.isArray(entrySlug) ? entrySlug.join("/") : entrySlug;
-}
-
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { pubSlug, entrySlug } = await params;
-  const slug = joinSlug(entrySlug);
+  const slug = joinEntrySlug(entrySlug);
   return {
     title: `${slug} — ${pubSlug}`,
     description: `Negentropy Wiki 文档页面`,
@@ -52,7 +49,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function WikiEntryPage({ params }: Props) {
   const { pubSlug, entrySlug } = await params;
-  const slug = joinSlug(entrySlug);
+  const slug = joinEntrySlug(entrySlug);
 
   let publication: WikiPublication | null = null;
   let navItems: WikiNavTreeItem[] = [];
@@ -124,35 +121,13 @@ export default async function WikiEntryPage({ params }: Props) {
   const sectionView = resolveSectionView(navItems, slug);
 
   const sidebar = (
-    <>
-      <div className="wiki-sidebar-header">
-        <Link
-          href={`/${pubSlug}`}
-          className="wiki-sidebar-back wiki-sidebar-brand"
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
-          <img
-            src="/logo.png"
-            alt="Negentropy"
-            className="wiki-sidebar-logo"
-          />
-          <span className="wiki-sidebar-title">← {publication.name}</span>
-        </Link>
-      </div>
-      {sectionView.sidebarItems.length > 0 ? (
-        <nav>
-          <WikiNavTree
-            items={sectionView.sidebarItems}
-            pubSlug={pubSlug}
-            activeSlug={slug}
-          />
-        </nav>
-      ) : (
-        sectionView.activeItem && (
-          <p className="wiki-text-hint wiki-empty-hint">该分组暂无文档</p>
-        )
-      )}
-    </>
+    <WikiSidebar
+      pubSlug={pubSlug}
+      publication={publication}
+      sidebarItems={sectionView.sidebarItems}
+      hasActiveItem={!!sectionView.activeItem}
+      activeSlug={slug}
+    />
   );
 
   const header = sectionView.headerItems.length > 0 && (

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -1,12 +1,14 @@
 import {
+  countLeafEntries,
+  findIndexEntry,
   resolveSectionView,
   wikiApi,
   type WikiPublication,
   type WikiNavTreeItem,
 } from "@/lib/wiki-api";
 import { WikiHeader } from "@/components/WikiHeader";
-import { WikiNavTree } from "@/components/WikiNavTree";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
+import { WikiSidebar } from "@/components/WikiSidebar";
 import Link from "next/link";
 
 export const revalidate = 300;
@@ -22,28 +24,6 @@ export const revalidate = 300;
 
 interface Props {
   params: Promise<{ pubSlug: string }>;
-}
-
-function findIndexEntry(items: WikiNavTreeItem[]): WikiNavTreeItem | null {
-  for (const item of items) {
-    if (item.is_index_page && item.entry_id) return item;
-    if (item.children && item.children.length > 0) {
-      const nested = findIndexEntry(item.children);
-      if (nested) return nested;
-    }
-  }
-  return null;
-}
-
-function countLeafEntries(items: WikiNavTreeItem[]): number {
-  let total = 0;
-  for (const item of items) {
-    if (item.entry_id) total += 1;
-    if (item.children && item.children.length > 0) {
-      total += countLeafEntries(item.children);
-    }
-  }
-  return total;
 }
 
 export default async function WikiPublicationPage({ params }: Props) {
@@ -82,39 +62,13 @@ export default async function WikiPublicationPage({ params }: Props) {
   const sectionView = resolveSectionView(navItems);
 
   const sidebar = (
-    <>
-      <div className="wiki-sidebar-header">
-        <div className="wiki-sidebar-brand">
-          {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
-          <img
-            src="/logo.png"
-            alt="Negentropy"
-            className="wiki-sidebar-logo"
-          />
-          <span className="wiki-sidebar-title">{publication.name}</span>
-        </div>
-      </div>
-      {publication.description && (
-        <p className="wiki-sidebar-desc">{publication.description}</p>
-      )}
-      {indexEntry && (
-        <Link
-          href={`/${pubSlug}/${indexEntry.entry_slug}`}
-          className="wiki-nav-link active"
-        >
-          🏠 首页
-        </Link>
-      )}
-      {sectionView.sidebarItems.length > 0 ? (
-        <nav>
-          <WikiNavTree items={sectionView.sidebarItems} pubSlug={pubSlug} />
-        </nav>
-      ) : (
-        sectionView.activeItem && (
-          <p className="wiki-text-hint wiki-empty-hint">该分组暂无文档</p>
-        )
-      )}
-    </>
+    <WikiSidebar
+      pubSlug={pubSlug}
+      publication={publication}
+      sidebarItems={sectionView.sidebarItems}
+      hasActiveItem={!!sectionView.activeItem}
+      indexEntry={indexEntry}
+    />
   );
 
   const header = sectionView.headerItems.length > 0 && (

--- a/apps/negentropy-wiki/src/components/WikiSidebar.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSidebar.tsx
@@ -1,0 +1,86 @@
+import Link from "next/link";
+import { WikiNavTree } from "./WikiNavTree";
+import type { WikiNavTreeItem } from "@/lib/wiki-api";
+
+/**
+ * Wiki 侧边栏 — 统一 Publication 首页与文档详情页的左栏渲染。
+ *
+ * 根据 `activeSlug` 是否传入，自动切换两种模式：
+ *   - 未传（Publication 根页）：品牌为纯文本，显示描述与首页链接
+ *   - 已传（文档详情页）：品牌为返回链接（← 前缀），导航树高亮当前页
+ */
+
+interface WikiSidebarProps {
+  pubSlug: string;
+  publication: { name: string; description?: string | null };
+  sidebarItems: WikiNavTreeItem[];
+  hasActiveItem: boolean;
+  activeSlug?: string;
+  indexEntry?: WikiNavTreeItem | null;
+}
+
+export function WikiSidebar({
+  pubSlug,
+  publication,
+  sidebarItems,
+  hasActiveItem,
+  activeSlug,
+  indexEntry,
+}: WikiSidebarProps) {
+  const isEntryPage = activeSlug !== undefined;
+
+  return (
+    <>
+      <div className="wiki-sidebar-header">
+        {isEntryPage ? (
+          <Link
+            href={`/${pubSlug}`}
+            className="wiki-sidebar-back wiki-sidebar-brand"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+            <img
+              src="/logo.png"
+              alt="Negentropy"
+              className="wiki-sidebar-logo"
+            />
+            <span className="wiki-sidebar-title">← {publication.name}</span>
+          </Link>
+        ) : (
+          <div className="wiki-sidebar-brand">
+            {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+            <img
+              src="/logo.png"
+              alt="Negentropy"
+              className="wiki-sidebar-logo"
+            />
+            <span className="wiki-sidebar-title">{publication.name}</span>
+          </div>
+        )}
+      </div>
+      {!isEntryPage && publication.description && (
+        <p className="wiki-sidebar-desc">{publication.description}</p>
+      )}
+      {!isEntryPage && indexEntry && (
+        <Link
+          href={`/${pubSlug}/${indexEntry.entry_slug}`}
+          className="wiki-nav-link active"
+        >
+          🏠 首页
+        </Link>
+      )}
+      {sidebarItems.length > 0 ? (
+        <nav>
+          <WikiNavTree
+            items={sidebarItems}
+            pubSlug={pubSlug}
+            activeSlug={activeSlug}
+          />
+        </nav>
+      ) : (
+        hasActiveItem && (
+          <p className="wiki-text-hint wiki-empty-hint">该分组暂无文档</p>
+        )
+      )}
+    </>
+  );
+}

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -236,3 +236,49 @@ export function resolveSectionView(
     sidebarItems: activeItem?.children ?? [],
   };
 }
+
+// ---------------------------------------------------------------------------
+// 辅助遍历（DFS 查找 / 计数 / 路径合并）
+// ---------------------------------------------------------------------------
+
+/**
+ * DFS 查找导航树中标记为 `is_index_page` 的首个有效条目。
+ *
+ * 用于 Publication 首页渲染「🏠 首页」链接。
+ */
+export function findIndexEntry(items: WikiNavTreeItem[]): WikiNavTreeItem | null {
+  for (const item of items) {
+    if (item.is_index_page && item.entry_id) return item;
+    if (item.children && item.children.length > 0) {
+      const nested = findIndexEntry(item.children);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+/**
+ * 递归统计导航树中所有有效条目（`entry_id` 非空）的数量。
+ *
+ * 排除合成容器节点（`entry_id=null`），仅计可路由的叶子。
+ */
+export function countLeafEntries(items: WikiNavTreeItem[]): number {
+  let total = 0;
+  for (const item of items) {
+    if (item.entry_id) total += 1;
+    if (item.children && item.children.length > 0) {
+      total += countLeafEntries(item.children);
+    }
+  }
+  return total;
+}
+
+/**
+ * 将 catch-all 路由参数合并为完整 entry slug。
+ *
+ * entry_slug 使用 Materialized Path（可能包含 `/`），
+ * Next.js catch-all 路由将其拆为数组；此函数还原为原始 slug。
+ */
+export function joinEntrySlug(segments: string[] | string): string {
+  return Array.isArray(segments) ? segments.join("/") : segments;
+}

--- a/apps/negentropy-wiki/tests/lib/wiki-api.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-api.test.ts
@@ -5,7 +5,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // 动态导入，确保 fetch mock 在模块加载前就位
-const { wikiApi } = await import("@/lib/wiki-api");
+const { wikiApi, joinEntrySlug } = await import("@/lib/wiki-api");
 
 // ---------------------------------------------------------------------------
 // 辅助工厂
@@ -245,5 +245,25 @@ describe("WikiApiClient", () => {
 
       await expect(wikiApi.listPublications()).rejects.toThrow("Network failure");
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 辅助函数（纯函数，不需要 fetch mock）
+// ---------------------------------------------------------------------------
+
+describe("joinEntrySlug", () => {
+  it("数组参数合并为 / 分隔的字符串", () => {
+    expect(joinEntrySlug(["getting-started", "installation"])).toBe(
+      "getting-started/installation",
+    );
+  });
+
+  it("单元素数组直通", () => {
+    expect(joinEntrySlug(["intro"])).toBe("intro");
+  });
+
+  it("字符串参数原样返回", () => {
+    expect(joinEntrySlug("a/b/c")).toBe("a/b/c");
   });
 });

--- a/apps/negentropy-wiki/tests/lib/wiki-section-view.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-section-view.test.ts
@@ -14,15 +14,17 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  countLeafEntries,
   findActiveTopLevelSlug,
   findFirstDocumentSlug,
+  findIndexEntry,
   resolveSectionView,
   type WikiNavTreeItem,
 } from "@/lib/wiki-api";
 
 function doc(slug: string, overrides: Partial<WikiNavTreeItem> = {}): WikiNavTreeItem {
   return {
-    entry_id: `entry-${slug}`,
+    entry_id: overrides.entry_id ?? `entry-${slug}`,
     entry_slug: slug,
     entry_title: slug,
     is_index_page: false,
@@ -142,5 +144,95 @@ describe("resolveSectionView", () => {
       "alpha/blog",
       "alpha/paper",
     ]);
+  });
+});
+
+describe("findIndexEntry", () => {
+  it("空树 → null", () => {
+    expect(findIndexEntry([])).toBeNull();
+  });
+
+  it("找到顶层 is_index_page 条目", () => {
+    const items = [
+      doc("intro", { is_index_page: true }),
+      doc("guide"),
+    ];
+    const result = findIndexEntry(items);
+    expect(result?.entry_slug).toBe("intro");
+  });
+
+  it("递归查找深层 is_index_page 条目", () => {
+    const items = [
+      container("alpha", [
+        doc("alpha/home", { is_index_page: true }),
+        doc("alpha/guide"),
+      ]),
+      doc("beta"),
+    ];
+    const result = findIndexEntry(items);
+    expect(result?.entry_slug).toBe("alpha/home");
+  });
+
+  it("无 is_index_page 时返回 null", () => {
+    const items = [
+      doc("a"),
+      container("b", [doc("b/c")]),
+    ];
+    expect(findIndexEntry(items)).toBeNull();
+  });
+
+  it("is_index_page 但 entry_id 为 null 时跳过（合成容器）", () => {
+    const items = [
+      doc("ghost", { entry_id: null, is_index_page: true }),
+      doc("real", { is_index_page: true }),
+    ];
+    const result = findIndexEntry(items);
+    expect(result?.entry_slug).toBe("real");
+  });
+});
+
+describe("countLeafEntries", () => {
+  it("空树 → 0", () => {
+    expect(countLeafEntries([])).toBe(0);
+  });
+
+  it("纯文档列表", () => {
+    const items = [doc("a"), doc("b"), doc("c")];
+    expect(countLeafEntries(items)).toBe(3);
+  });
+
+  it("混合容器与文档（容器自身有 entry_id 也计入）", () => {
+    const items = [
+      container("cat", [doc("cat/p1"), doc("cat/p2")]),
+      doc("standalone"),
+    ];
+    // container "cat" 自身 entry_id 非空也计入（自 0011 起容器条目持久化）
+    expect(countLeafEntries(items)).toBe(4);
+  });
+
+  it("空容器有 entry_id 时也计入", () => {
+    const items = [
+      container("empty", []),
+      doc("real"),
+    ];
+    // container "empty" 自身 entry_id 非空也计入
+    expect(countLeafEntries(items)).toBe(2);
+  });
+
+  it("entry_id=null 的节点不计入（合成容器）", () => {
+    const items = [
+      doc("synthetic", { entry_id: null }),
+      doc("valid"),
+    ];
+    expect(countLeafEntries(items)).toBe(1);
+  });
+
+  it("容器 entry_id=null 时仅计子节点", () => {
+    const items = [
+      container("legacy", [doc("legacy/a")], { entry_id: null }),
+      doc("standalone"),
+    ];
+    // legacy 容器自身 entry_id=null 不计入，仅计子节点 + standalone
+    expect(countLeafEntries(items)).toBe(2);
   });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 模块页面组件中散落树遍历函数（`findIndexEntry`/`countLeafEntries`/`joinSlug`），违反与 `wiki-api.ts` 数据层的正交分解原则；两个路由页面（Publication 首页 `/:pubSlug` 与文档详情页 `/:pubSlug/*entrySlug`）存在近 30 行几乎相同的侧边栏渲染 JSX 重复。
- 关联上下文：Preening Substrate 结构性熵减任务，针对 `apps/negentropy-wiki` 模块。

# 核心变更

**1. 树遍历函数归位至数据层 `wiki-api.ts`**

将三个从页面组件中提取的纯数据变换函数移至 `wiki-api.ts` 已有的「导航视图派生」section，与 `findFirstDocumentSlug`、`findActiveTopLevelSlug`、`resolveSectionView` 同属一个概念族：

- `findIndexEntry(items)` — DFS 查找 `is_index_page` 条目（原 `[pubSlug]/page.tsx` 本地函数）
- `countLeafEntries(items)` — 递归统计有效条目数，排除 `entry_id=null` 的合成容器（原 `[pubSlug]/page.tsx` 本地函数）
- `joinEntrySlug(segments)` — 将 Next.js catch-all 路由参数还原为完整 entry slug（原 `[...entrySlug]/page.tsx` 本地 `joinSlug`，语义更精确的重命名）

**2. 提取 `WikiSidebar` Server Component**

新建 `src/components/WikiSidebar.tsx`，统一两个路由页面的侧边栏渲染。通过 `activeSlug` prop 是否传入自动切换两种模式：

| 元素 | Publication 首页 | 文档详情页 |
|---|---|---|
| 品牌 | 纯文本 `<span>` | `<Link>` 返回链接 + ← 前缀 |
| 描述 | 显示 `publication.description` | 隐藏 |
| 索引入口 | 首页链接（如有 indexEntry） | 隐藏 |
| 导航树 | 无 `activeSlug` | 传入 `activeSlug` 高亮 |

**3. 补充测试用例**

- `wiki-section-view.test.ts`：复用已有 `doc()`/`container()` 工厂，新增 `findIndexEntry` 5 用例 + `countLeafEntries` 6 用例
- `wiki-api.test.ts`：新增 `joinEntrySlug` 3 用例

# 风险与回滚
- 主要风险：无功能变更，纯结构重构；`WikiSidebar` 通过条件渲染精确还原原有两套 JSX 的全部差异（品牌样式、描述显示、索引链接、导航树高亮）
- 回滚方式：`git revert`

# 验证证据
- 单元测试：61 tests passed（从 55 增至 61，新增 14 用例覆盖所有迁移函数）
- 集成测试：`pnpm build` 成功，Next.js SSG 静态页面生成正常（7 页面，无错误）
- E2E/Workflow：待浏览器实机验证
- 覆盖率/关键截图：ESLint passed，无 lint 错误

# 影响范围
- 前端：`apps/negentropy-wiki` — 2 个页面组件简化、1 个新建组件、1 个数据层模块扩展
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证：首页 → Publication 首页 → 文档详情页的侧边栏渲染、品牌区域切换、导航树折叠/展开交互与变更前一致
