### PR TITLE
refactor(scripts): 正交分解 scripts/ 目录，提取共享模块消除三轴重复;

### DIFF
--- a/apps/negentropy/scripts/_db.py
+++ b/apps/negentropy/scripts/_db.py
@@ -1,0 +1,45 @@
+"""scripts/ 目录共享数据库工具。
+
+提供脚本级别的数据库连接管理和异步入口点，消除各脚本中的重复样板代码。
+脚本通过 ``sys.path[0]`` 自动解析同目录模块，可直接 ``from _db import ...``。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+
+from negentropy.config import settings
+
+
+@asynccontextmanager
+async def script_engine(**kwargs: Any) -> AsyncGenerator:
+    """为独立脚本创建临时引擎，退出时自动 dispose。"""
+    engine = create_async_engine(str(settings.database_url), **kwargs)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@asynccontextmanager
+async def script_connection(**engine_kwargs: Any) -> AsyncGenerator[AsyncConnection]:
+    """快捷方式：创建引擎 + 获取连接，自动清理。"""
+    async with script_engine(**engine_kwargs) as engine:
+        async with engine.connect() as conn:
+            yield conn
+
+
+def run_script(coro: Any) -> None:
+    """asyncio.run 封装 + 统一错误处理。"""
+    try:
+        exit_code = asyncio.run(coro)
+        sys.exit(exit_code if isinstance(exit_code, int) else 0)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/apps/negentropy/scripts/cleanup_orphan_chunks.py
+++ b/apps/negentropy/scripts/cleanup_orphan_chunks.py
@@ -38,124 +38,15 @@ from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID
 
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
+from _db import script_engine
 
-from negentropy.config import settings
-
-# 同一次摄取的所有 chunks 在 60 秒内写入，用此窗口做时间聚类
-_CLUSTER_WINDOW_SECONDS = 60
-
-
-async def _scan_source_uris(conn, *, corpus_id: str, app_name: str) -> list[dict]:
-    """列出该 corpus 下所有有 >1 个时间聚类的 source_uri。"""
-    stmt = text(
-        """
-        SELECT
-            source_uri,
-            COUNT(*) AS total_chunks,
-            COUNT(DISTINCT date_trunc('minute', created_at)) AS minute_buckets
-        FROM negentropy.knowledge
-        WHERE corpus_id = :corpus_id
-          AND app_name = :app_name
-          AND source_uri IS NOT NULL
-        GROUP BY source_uri
-        HAVING COUNT(DISTINCT date_trunc('minute', created_at)) > 1
-           OR COUNT(*) > 100
-        ORDER BY total_chunks DESC
-        """
-    )
-    result = await conn.execute(stmt, {"corpus_id": corpus_id, "app_name": app_name})
-    return [
-        {
-            "source_uri": row.source_uri,
-            "total_chunks": row.total_chunks,
-            "minute_buckets": row.minute_buckets,
-        }
-        for row in result.all()
-    ]
-
-
-async def _get_chunks_for_source(conn, *, corpus_id: str, app_name: str, source_uri: str) -> list[dict]:
-    """拉取某个 source_uri 下所有 chunk 的元数据。"""
-    stmt = text(
-        """
-        SELECT
-            id, chunk_index, created_at,
-            metadata->>'chunk_family_id' AS family_id,
-            metadata->>'chunk_role' AS role
-        FROM negentropy.knowledge
-        WHERE corpus_id = :corpus_id
-          AND app_name = :app_name
-          AND source_uri = :source_uri
-        ORDER BY created_at ASC, chunk_index ASC
-        """
-    )
-    result = await conn.execute(
-        stmt,
-        {"corpus_id": corpus_id, "app_name": app_name, "source_uri": source_uri},
-    )
-    return [
-        {
-            "id": str(row.id),
-            "source_uri": source_uri,
-            "chunk_index": row.chunk_index,
-            "created_at": row.created_at,
-            "family_id": row.family_id,
-            "role": row.role,
-        }
-        for row in result.all()
-    ]
-
-
-def _cluster_by_time(chunks: list[dict], window_seconds: int = _CLUSTER_WINDOW_SECONDS) -> list[list[dict]]:
-    """按 created_at 做时间窗聚类，返回多个批次。"""
-    if not chunks:
-        return []
-
-    clusters: list[list[dict]] = []
-    current: list[dict] = [chunks[0]]
-    prev_ts = chunks[0]["created_at"]
-
-    for c in chunks[1:]:
-        ts = c["created_at"]
-        # 同一秒或距离前一 cluster 最后一个 <= window_seconds
-        gap = (ts - prev_ts).total_seconds()
-        if gap <= window_seconds:
-            current.append(c)
-        else:
-            clusters.append(current)
-            current = [c]
-        prev_ts = ts
-
-    if current:
-        clusters.append(current)
-    return clusters
-
-
-def _check_index_completeness(cluster: list[dict]) -> bool:
-    """检查 parent chunks 的 chunk_index 是否从 0 起连续无空缺。"""
-    parent_indices = sorted({c["chunk_index"] for c in cluster if c["role"] != "child"})
-    if not parent_indices:
-        return True  # 无 parent（可能全 child，异常但不阻止）
-    return parent_indices == list(range(len(parent_indices)))
-
-
-async def _delete_chunks(conn, chunk_ids: list[str]) -> int:
-    """物理删除指定 ID 的 chunks，返回删除条数。"""
-    if not chunk_ids:
-        return 0
-    # 分批避免 IN 子句过长
-    batch_size = 500
-    total = 0
-    for i in range(0, len(chunk_ids), batch_size):
-        batch = chunk_ids[i : i + batch_size]
-        placeholders = ", ".join(f":id_{j}" for j in range(len(batch)))
-        params = {f"id_{j}": bid for j, bid in enumerate(batch)}
-        stmt = text(f"DELETE FROM negentropy.knowledge WHERE id IN ({placeholders})")
-        result = await conn.execute(stmt, params)
-        total += result.rowcount or 0
-    return total
+from negentropy.knowledge.cleanup import (
+    check_index_completeness,
+    cluster_by_time,
+    delete_chunks,
+    get_chunks_for_source,
+    scan_source_uris,
+)
 
 
 def _write_backup_csv(source_uri: str, chunks: list[dict], corpus_id: str) -> str:
@@ -191,15 +82,14 @@ async def _cleanup(
     output_path: str | None,
 ) -> int:
     """执行清理。返回退出码（0=成功，1=有 needs_manual_review）。"""
-    engine = create_async_engine(str(settings.database_url), echo=False)
     report_items: list[dict] = []
     all_deleted_chunks: list[dict] = []
     exit_code = 0
 
-    try:
+    async with script_engine(echo=False) as engine:
         async with engine.connect() as conn:
             # Step 1: 找可疑 source_uri
-            candidates = await _scan_source_uris(conn, corpus_id=corpus_id, app_name=app_name)
+            candidates = await scan_source_uris(conn, corpus_id=corpus_id, app_name=app_name)
 
             if not candidates:
                 print(f"✓ No orphan sources found for corpus {corpus_id}")
@@ -216,13 +106,12 @@ async def _cleanup(
                 )
 
                 # Step 2: 拉取所有 chunks 并聚类
-                chunks = await _get_chunks_for_source(
+                chunks = await get_chunks_for_source(
                     conn, corpus_id=corpus_id, app_name=app_name, source_uri=source_uri
                 )
-                clusters = _cluster_by_time(chunks)
+                clusters = cluster_by_time(chunks)
 
                 if len(clusters) <= 1:
-                    # 只有 1 个批次，检查是否 chunks 数合理
                     print(f"    → Only 1 batch ({len(chunks)} chunks), skipping")
                     continue
 
@@ -230,13 +119,12 @@ async def _cleanup(
 
                 # Step 3: 选最新批次，检查完整性
                 latest = clusters[-1]
-                is_complete = _check_index_completeness(latest)
+                is_complete = check_index_completeness(latest)
 
                 if not is_complete and len(clusters) >= 2:
-                    # 最新批次不完整，回退上一批
                     print("    ⚠ Latest batch has incomplete chunk_index, falling back to previous batch")
                     latest = clusters[-2]
-                    is_complete = _check_index_completeness(latest)
+                    is_complete = check_index_completeness(latest)
                     if not is_complete:
                         print("    ⚠ Fallback batch also incomplete, marking as needs_manual_review")
                         exit_code = 1
@@ -264,7 +152,6 @@ async def _cleanup(
             if apply and all_deleted_chunks:
                 all_deleted_ids = [c["id"] for c in all_deleted_chunks]
 
-                # 先写 backup CSV（包含 per-chunk 元数据，便于手工恢复）
                 csv_path = _write_backup_csv(
                     source_uri="",
                     chunks=all_deleted_chunks,
@@ -272,14 +159,11 @@ async def _cleanup(
                 )
                 print(f"\n📄 Backup written to: {csv_path}")
 
-                deleted = await _delete_chunks(conn, all_deleted_ids)
+                deleted = await delete_chunks(conn, all_deleted_ids)
                 await conn.commit()
                 print(f"\n✓ Deleted {deleted} orphan chunks")
             elif all_deleted_chunks:
                 print(f"\n(Dry run) Would delete {len(all_deleted_chunks)} orphan chunks. Use --apply to execute.")
-
-    finally:
-        await engine.dispose()
 
     # Step 5: 输出报告
     if output_path:
@@ -308,7 +192,6 @@ def main() -> None:
     parser.add_argument("--output", default=None, help="Output report JSON path (default: stdout summary)")
     args = parser.parse_args()
 
-    # Validate UUID
     try:
         UUID(args.corpus_id)
     except ValueError:

--- a/apps/negentropy/scripts/find_dup_arxiv_ids.py
+++ b/apps/negentropy/scripts/find_dup_arxiv_ids.py
@@ -15,54 +15,47 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import sys
 
+from _db import run_script, script_connection
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
-
-from negentropy.config import settings
 
 
 async def _scan(limit: int) -> int:
-    engine = create_async_engine(settings.database_url, echo=False)
-    try:
-        async with engine.connect() as conn:
-            stmt = text(
-                """
-                SELECT
-                    metadata->>'arxiv_id' AS arxiv_id,
-                    COUNT(DISTINCT source_uri) AS source_uri_count,
-                    COUNT(*) AS chunk_count,
-                    MIN(created_at) AS first_seen_at,
-                    MAX(created_at) AS latest_seen_at
-                FROM negentropy.knowledge
-                WHERE metadata ? 'arxiv_id'
-                GROUP BY metadata->>'arxiv_id'
-                HAVING COUNT(DISTINCT source_uri) > 1
-                ORDER BY chunk_count DESC
-                LIMIT :limit
-                """
-            )
-            result = await conn.execute(stmt, {"limit": limit})
-            rows = result.all()
+    async with script_connection(echo=False) as conn:
+        stmt = text(
+            """
+            SELECT
+                metadata->>'arxiv_id' AS arxiv_id,
+                COUNT(DISTINCT source_uri) AS source_uri_count,
+                COUNT(*) AS chunk_count,
+                MIN(created_at) AS first_seen_at,
+                MAX(created_at) AS latest_seen_at
+            FROM negentropy.knowledge
+            WHERE metadata ? 'arxiv_id'
+            GROUP BY metadata->>'arxiv_id'
+            HAVING COUNT(DISTINCT source_uri) > 1
+            ORDER BY chunk_count DESC
+            LIMIT :limit
+            """
+        )
+        result = await conn.execute(stmt, {"limit": limit})
+        rows = result.all()
 
-            print("arxiv_id,source_uri_count,chunk_count,first_seen_at,latest_seen_at")
-            for row in rows:
-                print(
-                    ",".join(
-                        [
-                            str(row.arxiv_id or ""),
-                            str(row.source_uri_count),
-                            str(row.chunk_count),
-                            row.first_seen_at.isoformat() if row.first_seen_at else "",
-                            row.latest_seen_at.isoformat() if row.latest_seen_at else "",
-                        ]
-                    )
+        print("arxiv_id,source_uri_count,chunk_count,first_seen_at,latest_seen_at")
+        for row in rows:
+            print(
+                ",".join(
+                    [
+                        str(row.arxiv_id or ""),
+                        str(row.source_uri_count),
+                        str(row.chunk_count),
+                        row.first_seen_at.isoformat() if row.first_seen_at else "",
+                        row.latest_seen_at.isoformat() if row.latest_seen_at else "",
+                    ]
                 )
-            return len(rows)
-    finally:
-        await engine.dispose()
+            )
+        return len(rows)
 
 
 async def _main() -> int:
@@ -75,4 +68,4 @@ async def _main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(asyncio.run(_main()))
+    run_script(_main())

--- a/apps/negentropy/scripts/force_reset_db.py
+++ b/apps/negentropy/scripts/force_reset_db.py
@@ -1,38 +1,22 @@
-import asyncio
-import sys
+"""强制重置数据库：DROP + CREATE public schema，并启用 vector 扩展。"""
 
+from _db import run_script, script_engine
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
-
-from negentropy.config import settings
 
 
 async def reset_db():
-    print(f"Connecting to database: {settings.database_url}")
-    # We need to connect to the 'postgres' database or the target database to drop schema?
-    # Actually, dropping public schema removes all tables in it.
-
-    engine = create_async_engine(settings.database_url, echo=True)
-
-    async with engine.begin() as conn:
-        print("Dropping schema public CASCADE...")
-        await conn.execute(text("DROP SCHEMA public CASCADE;"))
-        print("Recreating schema public...")
-        await conn.execute(text("CREATE SCHEMA public;"))
-        print("Granting usage on schema public...")
-        # Optional: ensure permissions
-        # await conn.execute(text("GRANT ALL ON SCHEMA public TO public;"))
-
-        print("Enabling vector extension...")
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+    print("Connecting to database...")
+    async with script_engine(echo=True) as engine:
+        async with engine.begin() as conn:
+            print("Dropping schema public CASCADE...")
+            await conn.execute(text("DROP SCHEMA public CASCADE;"))
+            print("Recreating schema public...")
+            await conn.execute(text("CREATE SCHEMA public;"))
+            print("Enabling vector extension...")
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
 
     print("Database schema reset successfully.")
-    await engine.dispose()
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(reset_db())
-    except Exception as e:
-        print(f"Error resetting DB: {e}")
-        sys.exit(1)
+    run_script(reset_db())

--- a/apps/negentropy/scripts/init_test_db.py
+++ b/apps/negentropy/scripts/init_test_db.py
@@ -1,25 +1,15 @@
-import asyncio
-import sys
+"""初始化测试数据库：创建 negentropy schema 和 vector 扩展。"""
 
+from _db import run_script, script_engine
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
-
-from negentropy.config import settings
 
 
 async def init_test_db() -> None:
-    engine = create_async_engine(str(settings.database_url), pool_pre_ping=True)
-    try:
+    async with script_engine(pool_pre_ping=True) as engine:
         async with engine.begin() as conn:
             await conn.execute(text("CREATE SCHEMA IF NOT EXISTS negentropy"))
             await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-    finally:
-        await engine.dispose()
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(init_test_db())
-    except Exception as exc:
-        print(f"Failed to initialize test database: {exc}", file=sys.stderr)
-        sys.exit(1)
+    run_script(init_test_db())

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -5780,7 +5780,7 @@ async def cleanup_orphan_chunks(
                 latest = clusters[-2]
                 is_complete = check_index_completeness(latest)
 
-            kept_ids = {str(c.id) for c in latest}
+            kept_ids = {c["id"] for c in latest}
             deleted_ids = [str(c.id) for c in chunks if str(c.id) not in kept_ids]
 
             report_items.append(

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -5760,36 +5760,25 @@ async def cleanup_orphan_chunks(
             if not chunks:
                 continue
 
-            # Step 3: 时间聚类（60 秒窗口）
-            clusters: list[list[Any]] = []
-            current_cluster: list[Any] = [chunks[0]]
-            prev_ts = chunks[0].created_at
+            # Step 3: 时间聚类（60 秒窗口）— 复用 cleanup 模块的纯算法
+            from negentropy.knowledge.cleanup import check_index_completeness, cluster_by_time
 
-            for c in chunks[1:]:
-                gap = (c.created_at - prev_ts).total_seconds()
-                if gap <= 60:
-                    current_cluster.append(c)
-                else:
-                    clusters.append(current_cluster)
-                    current_cluster = [c]
-                prev_ts = c.created_at
-            if current_cluster:
-                clusters.append(current_cluster)
+            chunk_dicts = [
+                {"id": str(c.id), "chunk_index": c.chunk_index, "created_at": c.created_at, "role": c.role}
+                for c in chunks
+            ]
+            clusters = cluster_by_time(chunk_dicts)
 
             if len(clusters) <= 1:
                 continue
 
             # Step 4: 选最新批次
             latest = clusters[-1]
-            # 完整性检查：parent chunk_index 应连续
-            parent_indices = sorted({c.chunk_index for c in latest if c.role != "child"})
-            is_complete = not parent_indices or parent_indices == list(range(len(parent_indices)))
+            is_complete = check_index_completeness(latest)
 
             if not is_complete and len(clusters) >= 2:
                 latest = clusters[-2]
-                # 回退后重新检查完整性，与 CLI 脚本保持一致
-                fb_parent_indices = sorted({c.chunk_index for c in latest if c.role != "child"})
-                is_complete = not fb_parent_indices or fb_parent_indices == list(range(len(fb_parent_indices)))
+                is_complete = check_index_completeness(latest)
 
             kept_ids = {str(c.id) for c in latest}
             deleted_ids = [str(c.id) for c in chunks if str(c.id) not in kept_ids]

--- a/apps/negentropy/src/negentropy/knowledge/cleanup.py
+++ b/apps/negentropy/src/negentropy/knowledge/cleanup.py
@@ -1,0 +1,133 @@
+"""Orphan chunks 清理的纯算法与数据库操作。
+
+从 CLI 脚本和 API 层中提取的公共逻辑，确保算法单一事实源。
+CLI 脚本、API 端点、单元测试均从此模块导入。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+
+# 同一次摄取的所有 chunks 在 60 秒内写入，用此窗口做时间聚类
+CLUSTER_WINDOW_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# 纯函数（无 DB 依赖）
+# ---------------------------------------------------------------------------
+
+
+def cluster_by_time(chunks: list[dict], window_seconds: int = CLUSTER_WINDOW_SECONDS) -> list[list[dict]]:
+    """按 ``created_at`` 做时间窗聚类，返回多个批次。"""
+    if not chunks:
+        return []
+
+    clusters: list[list[dict]] = []
+    current: list[dict] = [chunks[0]]
+    prev_ts = chunks[0]["created_at"]
+
+    for c in chunks[1:]:
+        ts = c["created_at"]
+        gap = (ts - prev_ts).total_seconds()
+        if gap <= window_seconds:
+            current.append(c)
+        else:
+            clusters.append(current)
+            current = [c]
+        prev_ts = ts
+
+    if current:
+        clusters.append(current)
+    return clusters
+
+
+def check_index_completeness(cluster: list[dict]) -> bool:
+    """检查 parent chunks 的 ``chunk_index`` 是否从 0 起连续无空缺。"""
+    parent_indices = sorted({c["chunk_index"] for c in cluster if c["role"] != "child"})
+    if not parent_indices:
+        return True
+    return parent_indices == list(range(len(parent_indices)))
+
+
+# ---------------------------------------------------------------------------
+# 异步数据库操作
+# ---------------------------------------------------------------------------
+
+
+async def scan_source_uris(conn: Any, *, corpus_id: str, app_name: str) -> list[dict]:
+    """列出该 corpus 下所有有 >1 个时间聚类的 ``source_uri``。"""
+    stmt = text(
+        """
+        SELECT
+            source_uri,
+            COUNT(*) AS total_chunks,
+            COUNT(DISTINCT date_trunc('minute', created_at)) AS minute_buckets
+        FROM negentropy.knowledge
+        WHERE corpus_id = :corpus_id
+          AND app_name = :app_name
+          AND source_uri IS NOT NULL
+        GROUP BY source_uri
+        HAVING COUNT(DISTINCT date_trunc('minute', created_at)) > 1
+           OR COUNT(*) > 100
+        ORDER BY total_chunks DESC
+        """
+    )
+    result = await conn.execute(stmt, {"corpus_id": corpus_id, "app_name": app_name})
+    return [
+        {
+            "source_uri": row.source_uri,
+            "total_chunks": row.total_chunks,
+            "minute_buckets": row.minute_buckets,
+        }
+        for row in result.all()
+    ]
+
+
+async def get_chunks_for_source(conn: Any, *, corpus_id: str, app_name: str, source_uri: str) -> list[dict]:
+    """拉取某个 ``source_uri`` 下所有 chunk 的元数据。"""
+    stmt = text(
+        """
+        SELECT
+            id, chunk_index, created_at,
+            metadata->>'chunk_family_id' AS family_id,
+            metadata->>'chunk_role' AS role
+        FROM negentropy.knowledge
+        WHERE corpus_id = :corpus_id
+          AND app_name = :app_name
+          AND source_uri = :source_uri
+        ORDER BY created_at ASC, chunk_index ASC
+        """
+    )
+    result = await conn.execute(
+        stmt,
+        {"corpus_id": corpus_id, "app_name": app_name, "source_uri": source_uri},
+    )
+    return [
+        {
+            "id": str(row.id),
+            "source_uri": source_uri,
+            "chunk_index": row.chunk_index,
+            "created_at": row.created_at,
+            "family_id": row.family_id,
+            "role": row.role,
+        }
+        for row in result.all()
+    ]
+
+
+async def delete_chunks(conn: Any, chunk_ids: list[str]) -> int:
+    """物理删除指定 ID 的 chunks，返回删除条数。"""
+    if not chunk_ids:
+        return 0
+    batch_size = 500
+    total = 0
+    for i in range(0, len(chunk_ids), batch_size):
+        batch = chunk_ids[i : i + batch_size]
+        placeholders = ", ".join(f":id_{j}" for j in range(len(batch)))
+        params = {f"id_{j}": bid for j, bid in enumerate(batch)}
+        stmt = text(f"DELETE FROM negentropy.knowledge WHERE id IN ({placeholders})")
+        result = await conn.execute(stmt, params)
+        total += result.rowcount or 0
+    return total

--- a/apps/negentropy/tests/unit_tests/knowledge/test_cleanup_orphans.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_cleanup_orphans.py
@@ -1,46 +1,17 @@
 """cleanup_orphan_chunks CLI 聚类算法的单元测试。
 
 不连真实 DB，仅验证时间聚类和完整性校验逻辑。
-直接内联被测函数，因为 CLI 脚本不在 Python package path 内。
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+from negentropy.knowledge.cleanup import check_index_completeness, cluster_by_time
+
 
 def _ts(minutes_ago: float) -> datetime:
     return datetime.now(UTC) - timedelta(minutes=minutes_ago)
-
-
-# --- 内联被测函数（与 cleanup_orphan_chunks.py 保持一致） ---
-
-
-def _cluster_by_time(chunks: list[dict], window_seconds: int = 60) -> list[list[dict]]:
-    if not chunks:
-        return []
-    clusters: list[list[dict]] = []
-    current: list[dict] = [chunks[0]]
-    prev_ts = chunks[0]["created_at"]
-    for c in chunks[1:]:
-        ts = c["created_at"]
-        gap = (ts - prev_ts).total_seconds()
-        if gap <= window_seconds:
-            current.append(c)
-        else:
-            clusters.append(current)
-            current = [c]
-        prev_ts = ts
-    if current:
-        clusters.append(current)
-    return clusters
-
-
-def _check_index_completeness(cluster: list[dict]) -> bool:
-    parent_indices = sorted({c["chunk_index"] for c in cluster if c["role"] != "child"})
-    if not parent_indices:
-        return True
-    return parent_indices == list(range(len(parent_indices)))
 
 
 def test_cluster_by_time_single_batch():
@@ -49,7 +20,7 @@ def test_cluster_by_time_single_batch():
         {"id": f"id-{i}", "chunk_index": i, "created_at": _ts(1), "role": "parent" if i % 5 == 0 else "child"}
         for i in range(10)
     ]
-    clusters = _cluster_by_time(chunks, window_seconds=60)
+    clusters = cluster_by_time(chunks, window_seconds=60)
     assert len(clusters) == 1
     assert len(clusters[0]) == 10
 
@@ -84,7 +55,7 @@ def test_cluster_by_time_multiple_batches():
             for i in range(14)
         ]
     )
-    clusters = _cluster_by_time(chunks, window_seconds=60)
+    clusters = cluster_by_time(chunks, window_seconds=60)
     assert len(clusters) == 3
     assert all(len(c) == 14 for c in clusters)
     # 最新批次应包含 "new-" 前缀的 chunks
@@ -93,26 +64,26 @@ def test_cluster_by_time_multiple_batches():
 
 def test_cluster_by_time_empty():
     chunks = []
-    clusters = _cluster_by_time(chunks)
+    clusters = cluster_by_time(chunks)
     assert clusters == []
 
 
 def test_check_index_completeness_continuous():
     """chunk_index 从 0 起连续 → 完整。"""
     cluster = [{"chunk_index": i, "role": "parent"} for i in range(14)]
-    assert _check_index_completeness(cluster) is True
+    assert check_index_completeness(cluster) is True
 
 
 def test_check_index_completeness_with_gap():
     """chunk_index 有空缺（如 [0,1,3,4] 缺 2）→ 不完整。"""
     cluster = [{"chunk_index": i, "role": "parent"} for i in [0, 1, 3, 4]]
-    assert _check_index_completeness(cluster) is False
+    assert check_index_completeness(cluster) is False
 
 
 def test_check_index_completeness_only_children():
     """全 child 无 parent → 视为完整（无 parent 不阻止）。"""
     cluster = [{"chunk_index": i, "role": "child"} for i in range(5)]
-    assert _check_index_completeness(cluster) is True
+    assert check_index_completeness(cluster) is True
 
 
 def test_cluster_by_time_orphan_detection_scenario():
@@ -142,7 +113,7 @@ def test_cluster_by_time_orphan_detection_scenario():
             }
         )
 
-    clusters = _cluster_by_time(batches, window_seconds=60)
+    clusters = cluster_by_time(batches, window_seconds=60)
     assert len(clusters) == 11  # 10 old + 1 latest
     # 最新批次应包含 "latest-" 前缀
     assert clusters[-1][0]["id"].startswith("latest-")


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`apps/negentropy/scripts/` 目录中 4 个脚本（471 行）存在三轴正交重复——DB 引擎生命周期（`create_async_engine` + `dispose` 在 4 个脚本中各重复一次）、异步入口点（`asyncio.run` + try/except 样板重复 4 次）、清理算法（`cluster_by_time`/`check_index_completeness` 在 CLI 脚本、API 端点、单元测试三处逐字重复）
- 关联上下文/文档：CLAUDE.md 熵减原则（正交分解、单一事实源、复用驱动）

# 核心变更
- **新建 `scripts/_db.py`**（45 行）：提取 `script_engine`（async context manager，自动 dispose）、`script_connection`（引擎+连接快捷方式）、`run_script`（asyncio.run 封装 + 统一错误处理）三个共享工具
- **新建 `src/negentropy/knowledge/cleanup.py`**（133 行）：将聚类算法（`cluster_by_time`/`check_index_completeness`）及异步 DB 操作（`scan_source_uris`/`get_chunks_for_source`/`delete_chunks`）收敛为单一事实源，CLI 脚本、API 端点、单元测试均从此模块导入
- **重构 `cleanup_orphan_chunks.py`**：从 330 行减至 195 行，删除 5 个本地函数定义，改为导入 cleanup 模块 + `_db` 工具
- **重构 `find_dup_arxiv_ids.py`**（79→55 行）、**`force_reset_db.py`**（39→22 行）、**`init_test_db.py`**（26→14 行）：使用 `_db` 共享工具消除连接样板
- **更新 `test_cleanup_orphans.py`**：删除 25 行内联函数副本，改为从 `negentropy.knowledge.cleanup` 导入
- **消除 `api.py` L5764-5792 的重复算法**：替换内联聚类循环和完整性检查为 `cluster_by_time`/`check_index_completeness` 调用

# 风险与回滚
- 主要风险：API 端点中 Row→dict 转换引入额外列表推导开销，性能影响可忽略不计
- 回滚方式：`git revert` 单次提交即可完整回滚

# 验证证据
- 单元测试：`pytest tests/unit_tests/knowledge/test_cleanup_orphans.py` — 7/7 全部通过
- 集成测试：N/A（纯重构，无新功能）
- E2E/Workflow：各脚本 `--help` 入口正常输出
- 覆盖率/关键截图：`ruff check` 全部通过，pre-commit hooks（lint + format）通过

# 影响范围
- 前端：无
- 后端：`negentropy.knowledge.api` 中 cleanup-orphans 端点的聚类逻辑改为从模块导入（外部行为不变）
- GitHub Actions / 文档：无

# Next Best Action
- 考虑为 `cleanup.py` 中的异步 DB 函数补充单元测试（当前测试仅覆盖纯函数）