### PR TITLE
feat(home-mentions): Home 对话框 @ 三类能力

### DIFF
--- a/apps/negentropy-ui/app/api/agui/_state-delta.ts
+++ b/apps/negentropy-ui/app/api/agui/_state-delta.ts
@@ -1,0 +1,97 @@
+/**
+ * AGUI 路由的 forwardedProps → state_delta 派生工具。
+ *
+ * 拆分动因：Next.js App Router 仅允许 `route.ts` 导出受限的 HTTP/配置符号，
+ * 任何额外 `export` 会被生成的路由类型校验拒绝（OmitWithTag 失败）。
+ * 因此将共享常量与纯函数下沉到本 `_state-delta.ts`（项目约定的 `_` 前缀私有模块，
+ * 与 `app/api/agui/sessions/_request.ts`、`_response.ts` 形成同构），由 `route.ts`
+ * 与对应 `tests/unit/api/agui-route-state.test.ts` 直接复用单一事实源。
+ */
+
+// 共享 UUID 校验 —— 既给路由 sessionId 用，也给 forwardedProps.{scoped,output}_corpus_ids 用。
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// 路由偏好 Agent 名长度上限（与后端 _PREFERENCE_NAME_RE 同步：标识符 1-128 字符）。
+export const PREFERRED_SUBAGENT_MAX_LEN = 128;
+// Mention 列表上限（每类 @ token 数），避免畸形 forwardedProps 撑大 state。
+export const CORPUS_IDS_MAX_LEN = 32;
+
+/**
+ * 校验 UUID 数组字段：
+ *
+ * - 非数组（含 ``undefined`` / ``null`` / 其它原始类型）→ 返回 ``null`` 表示
+ *   「字段不存在 / 类型不合法」，调用方据此决定不写 state_delta；
+ * - 数组 → 过滤非 UUID 条目、截断到 ``max``、去重保持首现顺序，返回数组
+ *   （可能为空）。空数组语义为「显式清空」，调用方需写入 state_delta 以
+ *   覆盖 ADK session.state 中可能存在的旧值。
+ *
+ * 该区分是修复「mention 跨 turn 残留」的关键 —— 前端始终显式写入派生值，
+ * BFF 据此触达「清空」状态变更，避免 session.state 被孤儿值长期污染。
+ */
+function sanitizeUuidList(raw: unknown, max: number): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  const ids = raw
+    .filter((x): x is string => typeof x === "string" && UUID_RE.test(x))
+    .slice(0, max);
+  // 去重保持首现顺序；Array.from(new Set()) 即满足该语义。
+  // 注意：``ids.length === 0`` 时仍返回 ``[]`` 而非 ``null`` —— 调用方据此写入清空。
+  return Array.from(new Set(ids));
+}
+
+export function buildStateDeltaFromForwardedProps(
+  forwardedProps: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const stateDelta: Record<string, unknown> = {};
+  if (!forwardedProps) {
+    return stateDelta;
+  }
+  if ("selected_llm_model" in forwardedProps) {
+    const raw = forwardedProps.selected_llm_model;
+    if (typeof raw === "string" && raw.length > 0) {
+      stateDelta.selected_llm_model = raw;
+    } else if (raw === null) {
+      stateDelta.selected_llm_model = null;
+    }
+  }
+  if ("thinking_enabled" in forwardedProps) {
+    const raw = forwardedProps.thinking_enabled;
+    if (typeof raw === "boolean") {
+      stateDelta.thinking_enabled = raw;
+    }
+  }
+  // Home Composer 的 @ Agent —— 用户偏好委派到指定 SubAgent（root_agent 软提示）。
+  // 合法字符串 → 写入；显式 ``null`` → 写入 ``null`` 以清空 session.state；
+  // 其它（空串 / 超长 / 非字符串）→ 不写入。
+  // 配合前端始终显式发送 ``preferred_subagent`` 字段实现跨 turn 清空语义。
+  if ("preferred_subagent" in forwardedProps) {
+    const raw = forwardedProps.preferred_subagent;
+    if (
+      typeof raw === "string" &&
+      raw.length > 0 &&
+      raw.length <= PREFERRED_SUBAGENT_MAX_LEN
+    ) {
+      stateDelta.preferred_subagent = raw;
+    } else if (raw === null) {
+      stateDelta.preferred_subagent = null;
+    }
+  }
+  // Home Composer 的 @ Corpus（检索）—— 限定本轮 RAG 检索范围；
+  // 由 ``perception.search_knowledge_base`` 消费 ``tool_context.state``。
+  // 数组（含 ``[]``）→ 写入 state_delta；非数组 → 不写入。空数组表示「显式清空」，
+  // 覆盖上一轮可能残留的 ``scoped_corpus_ids``。
+  if ("scoped_corpus_ids" in forwardedProps) {
+    const scoped = sanitizeUuidList(forwardedProps.scoped_corpus_ids, CORPUS_IDS_MAX_LEN);
+    if (scoped !== null) {
+      stateDelta.scoped_corpus_ids = scoped;
+    }
+  }
+  // Home Composer 的 @ Corpus（输出）—— 输出沉淀目标 Corpus 列表；
+  // 仅 round-trip 留痕，前端在 RUN_FINISHED 后据此调用 ingestText。
+  // 空数组同样写入以触发清空语义，避免 session.state 中残留孤儿值。
+  if ("output_corpus_ids" in forwardedProps) {
+    const output = sanitizeUuidList(forwardedProps.output_corpus_ids, CORPUS_IDS_MAX_LEN);
+    if (output !== null) {
+      stateDelta.output_corpus_ids = output;
+    }
+  }
+  return stateDelta;
+}

--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -19,6 +19,13 @@ import {
 import { normalizeAguiEvent, resolveEventRunAndThread } from "@/utils/agui-normalization";
 import { getAguiBaseUrl } from "@/lib/server/backend-url";
 
+// 共享 UUID 校验 —— 既给路由 sessionId 用，也给 forwardedProps.{scoped,output}_corpus_ids 用。
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// 路由偏好 Agent 名长度上限（与后端 _PREFERENCE_NAME_RE 同步：标识符 1-128 字符）。
+const PREFERRED_SUBAGENT_MAX_LEN = 128;
+// Mention 列表上限（每类 @ token 数），避免畸形 forwardedProps 撑大 state。
+const CORPUS_IDS_MAX_LEN = 32;
+
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);
 
@@ -71,6 +78,16 @@ function normalizeEvent(
   );
 }
 
+function sanitizeUuidList(raw: unknown, max: number): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  const ids = raw
+    .filter((x): x is string => typeof x === "string" && UUID_RE.test(x))
+    .slice(0, max);
+  if (ids.length === 0) return null;
+  // 去重保持首现顺序；Array.from(new Set()) 即满足该语义。
+  return Array.from(new Set(ids));
+}
+
 export function buildStateDeltaFromForwardedProps(
   forwardedProps: Record<string, unknown> | null,
 ): Record<string, unknown> {
@@ -91,6 +108,32 @@ export function buildStateDeltaFromForwardedProps(
     if (typeof raw === "boolean") {
       stateDelta.thinking_enabled = raw;
     }
+  }
+  // Home Composer 的 @ Agent —— 用户偏好委派到指定 SubAgent（root_agent 软提示）。
+  // 仅透传字符串；空串/超长视作未设置，避免污染 ADK session.state。
+  if ("preferred_subagent" in forwardedProps) {
+    const raw = forwardedProps.preferred_subagent;
+    if (
+      typeof raw === "string" &&
+      raw.length > 0 &&
+      raw.length <= PREFERRED_SUBAGENT_MAX_LEN
+    ) {
+      stateDelta.preferred_subagent = raw;
+    } else if (raw === null) {
+      stateDelta.preferred_subagent = null;
+    }
+  }
+  // Home Composer 的 @ Corpus（检索）—— 限定本轮 RAG 检索范围；
+  // 仅 UUID 通过，去重并截断，由 perception.search_knowledge_base 消费。
+  const scoped = sanitizeUuidList(forwardedProps.scoped_corpus_ids, CORPUS_IDS_MAX_LEN);
+  if (scoped) {
+    stateDelta.scoped_corpus_ids = scoped;
+  }
+  // Home Composer 的 @ Corpus（输出）—— 输出沉淀目标 Corpus 列表；
+  // 仅 round-trip 留痕，前端在 RUN_FINISHED 后据此调用 ingestText。
+  const output = sanitizeUuidList(forwardedProps.output_corpus_ids, CORPUS_IDS_MAX_LEN);
+  if (output) {
+    stateDelta.output_corpus_ids = output;
   }
   return stateDelta;
 }
@@ -121,7 +164,6 @@ export async function POST(request: Request) {
       "session_id is required",
     );
   }
-  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (!UUID_RE.test(sessionId)) {
     return aguiErrorResponse(
       AGUI_ERROR_CODES.BAD_REQUEST,

--- a/apps/negentropy-ui/app/api/agui/route.ts
+++ b/apps/negentropy-ui/app/api/agui/route.ts
@@ -18,13 +18,10 @@ import {
 } from "@/lib/errors";
 import { normalizeAguiEvent, resolveEventRunAndThread } from "@/utils/agui-normalization";
 import { getAguiBaseUrl } from "@/lib/server/backend-url";
-
-// 共享 UUID 校验 —— 既给路由 sessionId 用，也给 forwardedProps.{scoped,output}_corpus_ids 用。
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-// 路由偏好 Agent 名长度上限（与后端 _PREFERENCE_NAME_RE 同步：标识符 1-128 字符）。
-const PREFERRED_SUBAGENT_MAX_LEN = 128;
-// Mention 列表上限（每类 @ token 数），避免畸形 forwardedProps 撑大 state。
-const CORPUS_IDS_MAX_LEN = 32;
+// 派生 state_delta 的纯函数 + 共享 UUID 校验沉淀到 `_state-delta`：
+// Next.js App Router 限定 `route.ts` 仅可导出 HTTP handler / 配置符号，
+// 任何额外 `export`（包括纯工具函数）都会被生成路由类型校验拒绝。
+import { UUID_RE, buildStateDeltaFromForwardedProps } from "./_state-delta";
 
 function extractForwardHeaders(request: Request) {
   const headers = buildAuthHeaders(request);
@@ -76,66 +73,6 @@ function normalizeEvent(
       runId,
     }),
   );
-}
-
-function sanitizeUuidList(raw: unknown, max: number): string[] | null {
-  if (!Array.isArray(raw)) return null;
-  const ids = raw
-    .filter((x): x is string => typeof x === "string" && UUID_RE.test(x))
-    .slice(0, max);
-  if (ids.length === 0) return null;
-  // 去重保持首现顺序；Array.from(new Set()) 即满足该语义。
-  return Array.from(new Set(ids));
-}
-
-export function buildStateDeltaFromForwardedProps(
-  forwardedProps: Record<string, unknown> | null,
-): Record<string, unknown> {
-  const stateDelta: Record<string, unknown> = {};
-  if (!forwardedProps) {
-    return stateDelta;
-  }
-  if ("selected_llm_model" in forwardedProps) {
-    const raw = forwardedProps.selected_llm_model;
-    if (typeof raw === "string" && raw.length > 0) {
-      stateDelta.selected_llm_model = raw;
-    } else if (raw === null) {
-      stateDelta.selected_llm_model = null;
-    }
-  }
-  if ("thinking_enabled" in forwardedProps) {
-    const raw = forwardedProps.thinking_enabled;
-    if (typeof raw === "boolean") {
-      stateDelta.thinking_enabled = raw;
-    }
-  }
-  // Home Composer 的 @ Agent —— 用户偏好委派到指定 SubAgent（root_agent 软提示）。
-  // 仅透传字符串；空串/超长视作未设置，避免污染 ADK session.state。
-  if ("preferred_subagent" in forwardedProps) {
-    const raw = forwardedProps.preferred_subagent;
-    if (
-      typeof raw === "string" &&
-      raw.length > 0 &&
-      raw.length <= PREFERRED_SUBAGENT_MAX_LEN
-    ) {
-      stateDelta.preferred_subagent = raw;
-    } else if (raw === null) {
-      stateDelta.preferred_subagent = null;
-    }
-  }
-  // Home Composer 的 @ Corpus（检索）—— 限定本轮 RAG 检索范围；
-  // 仅 UUID 通过，去重并截断，由 perception.search_knowledge_base 消费。
-  const scoped = sanitizeUuidList(forwardedProps.scoped_corpus_ids, CORPUS_IDS_MAX_LEN);
-  if (scoped) {
-    stateDelta.scoped_corpus_ids = scoped;
-  }
-  // Home Composer 的 @ Corpus（输出）—— 输出沉淀目标 Corpus 列表；
-  // 仅 round-trip 留痕，前端在 RUN_FINISHED 后据此调用 ingestText。
-  const output = sanitizeUuidList(forwardedProps.output_corpus_ids, CORPUS_IDS_MAX_LEN);
-  if (output) {
-    stateDelta.output_corpus_ids = output;
-  }
-  return stateDelta;
 }
 
 export async function POST(request: Request) {

--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -8,6 +8,12 @@ import { EventType, Message, type BaseEvent } from "@ag-ui/core";
 import { ChatStream } from "../components/ui/ChatStream";
 import { Composer } from "../components/ui/Composer";
 import type { ComposerAttachment } from "../components/ui/AttachmentChip";
+import type { MentionCandidate, MentionToken } from "@/types/mention";
+import { deriveForwardedPropsFromMentions } from "@/utils/mention-parser";
+import { extractFinalAssistantText } from "@/utils/run-output";
+import { useSubAgentsList } from "@/hooks/useSubAgentsList";
+import { useCorporaList } from "@/app/knowledge/apis/_components/hooks/useCorporaList";
+import { ingestText } from "@/features/knowledge/utils/knowledge-api";
 import { EventTimeline } from "../components/ui/EventTimeline";
 import { LogBufferPanel } from "../components/ui/LogBufferPanel";
 import { SessionList } from "../components/ui/SessionList";
@@ -210,6 +216,45 @@ export function HomeBody({
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  // Home Composer 的 @ Mention（agent / corpus-retrieve / corpus-output）。
+  // 与 inputValue 平行存在，仅承担 ① UI 高亮 ② forwardedProps 派生。
+  const [mentions, setMentions] = useState<MentionToken[]>([]);
+  // doSend 时 snapshot 的 output_corpus_ids；RUN_FINISHED 后被 ingestText 消费。
+  // 用 Map<runId, ids[]> 支持并发 turn（虽然当前实现一次只跑一个 run，但低成本兜底）。
+  const outputCorpusIdsByRunRef = useRef<Map<string, string[]>>(new Map());
+  const userPromptByRunRef = useRef<Map<string, string>>(new Map());
+  // @ 弹层候选项数据源
+  const { subagents, loading: subagentsLoading, error: subagentsError } =
+    useSubAgentsList();
+  const { corpora, loading: corporaLoading, error: corporaError } = useCorporaList();
+  const agentCandidates = useMemo<MentionCandidate[]>(
+    () =>
+      subagents.map((a) => ({
+        kind: "agent" as const,
+        refId: a.name,
+        label: a.display_name || a.name,
+        description: a.description || undefined,
+      })),
+    [subagents],
+  );
+  const corpusCandidates = useMemo<MentionCandidate[]>(
+    () =>
+      corpora.map((c) => ({
+        kind: "corpus-retrieve" as const, // 仅占位；MentionPopover 切换 Tab 时会改写 kind
+        refId: c.id,
+        label: c.name,
+        description: c.description || undefined,
+      })),
+    [corpora],
+  );
+  const validAgentRefIds = useMemo(
+    () => new Set(subagents.map((a) => a.name)),
+    [subagents],
+  );
+  const validCorpusRefIds = useMemo(
+    () => new Set(corpora.map((c) => c.id)),
+    [corpora],
+  );
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [scrollToBottomTrigger, setScrollToBottomTrigger] = useState(0);
   const [llmModels, setLlmModels] = useState<ModelConfigItem[]>([]);
@@ -333,6 +378,13 @@ export function HomeBody({
   );
   const search = useConversationSearch(allNodes);
 
+  // 同步 conversationTree 到 ref，供 rawEventHandler 内 RUN_FINISHED 沉淀钩子读取
+  // （rawEventHandler 是 ref-based 回调，不会跟随 conversationTree 重建，需要 ref 来读最新值）。
+  const conversationTreeRef = useRef(conversationTree);
+  useEffect(() => {
+    conversationTreeRef.current = conversationTree;
+  }, [conversationTree]);
+
   // G3 审批门：从 snapshot 读取 pending_approvals；用户决策写回 BFF。
   const pendingApprovals = useMemo(
     () => (snapshotForDisplay?.pending_approvals as Record<string, unknown> | undefined) ?? null,
@@ -447,6 +499,65 @@ export function HomeBody({
               ? event.runId
               : undefined,
         });
+
+        // @ Corpus 输出沉淀 —— RUN_FINISHED 成功路径才触发；RUN_ERROR 仅清理 ref。
+        const finishedRunId =
+          "runId" in event && typeof event.runId === "string"
+            ? event.runId
+            : null;
+        if (finishedRunId) {
+          const outputIds = outputCorpusIdsByRunRef.current.get(finishedRunId);
+          const userPrompt = userPromptByRunRef.current.get(finishedRunId);
+          outputCorpusIdsByRunRef.current.delete(finishedRunId);
+          userPromptByRunRef.current.delete(finishedRunId);
+          if (
+            event.type === EventType.RUN_FINISHED &&
+            outputIds &&
+            outputIds.length > 0
+          ) {
+            // 延迟读 conversationTree —— RUN_FINISHED 触发的最后一波 state
+            // 经 useSessionService 异步合并；200ms 足以覆盖单 turn 的最终 flush。
+            setTimeout(() => {
+              const answerText = extractFinalAssistantText(
+                conversationTreeRef.current,
+                finishedRunId,
+              );
+              if (!answerText) {
+                toast.warning("沉淀失败：未获取到本轮助手回答");
+                return;
+              }
+              const sourceUri = `home:session/${sessionId}:run/${finishedRunId}`;
+              const metadata = {
+                source: "home_chat",
+                session_id: sessionId,
+                run_id: finishedRunId,
+                generated_at: new Date().toISOString(),
+                ...(userPrompt
+                  ? { user_prompt_excerpt: userPrompt.slice(0, 200) }
+                  : {}),
+              };
+              void Promise.allSettled(
+                outputIds.map((corpusId) =>
+                  ingestText(corpusId, {
+                    app_name: APP_NAME,
+                    text: answerText,
+                    source_uri: sourceUri,
+                    metadata,
+                  }),
+                ),
+              ).then((results) => {
+                const ok = results.filter((r) => r.status === "fulfilled").length;
+                const fail = results.length - ok;
+                if (ok > 0) {
+                  toast.success(`已沉淀到 ${ok} 个语料库`);
+                }
+                if (fail > 0) {
+                  toast.warning(`${fail} 个语料库沉淀失败`);
+                }
+              });
+            }, 200);
+          }
+        }
       }
     };
     updateSessionTimeRef.current = updateCurrentSessionTime;
@@ -619,10 +730,26 @@ export function HomeBody({
         size: a.size,
       }));
 
+      // @ Mention —— 从 mentions 派生本轮 turn 的偏好与 corpus 范围；
+      // 仅非空字段透传 forwardedProps（BFF 会进一步做 UUID/类型校验）。
+      const derivedMention = deriveForwardedPropsFromMentions(mentions, {
+        agents: validAgentRefIds,
+        corpora: validCorpusRefIds,
+      });
+      // snapshot output_corpus_ids，留待 RUN_FINISHED 时触发 ingest 沉淀。
+      if (derivedMention.output_corpus_ids.length > 0) {
+        outputCorpusIdsByRunRef.current.set(runId, derivedMention.output_corpus_ids);
+        userPromptByRunRef.current.set(runId, input.trim());
+      }
       try {
         setConnectionWithMetrics("connecting");
-        agent.forwardedProps = {
-          ...(agent.forwardedProps ?? {}),
+        // AbstractAgent.prepareRunAgentInput 从 runAgent 的参数读 forwardedProps，
+        // 实例属性 ``agent.forwardedProps = ...`` 不会被读取——必须把字段透传到
+        // ``runAgent({forwardedProps, runId})``。下面合并实例属性兜底以兼容历史调用方。
+        const baseForwardedProps =
+          (agent.forwardedProps as Record<string, unknown> | undefined) ?? {};
+        const forwardedProps: Record<string, unknown> = {
+          ...baseForwardedProps,
           approval_policy: { mode: approvalPolicyMode },
           selected_llm_model: selectedLlmModel ?? null,
           thinking_enabled: isThinkingSupportedForSelection(
@@ -632,11 +759,23 @@ export function HomeBody({
             ? thinkingEnabled
             : false,
           ...(attachmentMeta.length > 0 ? { attachments: attachmentMeta } : {}),
+          ...(derivedMention.preferred_subagent
+            ? { preferred_subagent: derivedMention.preferred_subagent }
+            : {}),
+          ...(derivedMention.scoped_corpus_ids.length > 0
+            ? { scoped_corpus_ids: derivedMention.scoped_corpus_ids }
+            : {}),
+          ...(derivedMention.output_corpus_ids.length > 0
+            ? { output_corpus_ids: derivedMention.output_corpus_ids }
+            : {}),
         };
-        // 清空 Composer 附件区（与 inputValue 已被清空的语义一致）
+        agent.forwardedProps = forwardedProps; // 留作 backward-compat（其他读 ref 的逻辑）
+        // 清空 Composer 附件区 + Mention 区（与 inputValue 已被清空的语义一致）
         setAttachments([]);
+        setMentions([]);
         await agent.runAgent({
           runId,
+          forwardedProps,
         });
         scheduleSessionHydration(sessionId);
         await loadSessions();
@@ -668,6 +807,9 @@ export function HomeBody({
       llmModels,
       attachments,
       approvalPolicyMode,
+      mentions,
+      validAgentRefIds,
+      validCorpusRefIds,
     ],
   );
 
@@ -1144,6 +1286,14 @@ export function HomeBody({
                 onCancel={handleCancelRun}
                 attachments={attachments}
                 onAttachmentsChange={setAttachments}
+                mentions={mentions}
+                onMentionsChange={setMentions}
+                agentCandidates={agentCandidates}
+                corpusCandidates={corpusCandidates}
+                agentsLoading={subagentsLoading}
+                agentsError={subagentsError}
+                corporaLoading={corporaLoading}
+                corporaError={corporaError}
               />
             </div>
           </div>

--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -172,7 +172,10 @@ export type HomeBodyAgent = AgentLike & {
   threadId?: string;
   isRunning: boolean;
   addMessage: (message: Message) => void;
-  runAgent: (params: { runId: string }) => Promise<unknown>;
+  runAgent: (params: {
+    runId: string;
+    forwardedProps?: Record<string, unknown>;
+  }) => Promise<unknown>;
   forwardedProps?: Record<string, unknown>;
   /**
    * NDJSON Agent 提供 abortRun()；测试 Mock 可省略。
@@ -746,6 +749,11 @@ export function HomeBody({
         // AbstractAgent.prepareRunAgentInput 从 runAgent 的参数读 forwardedProps，
         // 实例属性 ``agent.forwardedProps = ...`` 不会被读取——必须把字段透传到
         // ``runAgent({forwardedProps, runId})``。下面合并实例属性兜底以兼容历史调用方。
+        //
+        // 关键修复：``preferred_subagent`` / ``scoped_corpus_ids`` / ``output_corpus_ids``
+        // 必须始终显式写入，让本轮派生值（可能为 ``null`` / ``[]``）覆盖实例属性上残留的
+        // 上一轮值。BFF ``buildStateDeltaFromForwardedProps`` 据此把 ``null`` / ``[]``
+        // 视作清空指令，避免 ADK ``session.state`` 中孤儿值被后端继续消费。
         const baseForwardedProps =
           (agent.forwardedProps as Record<string, unknown> | undefined) ?? {};
         const forwardedProps: Record<string, unknown> = {
@@ -759,15 +767,10 @@ export function HomeBody({
             ? thinkingEnabled
             : false,
           ...(attachmentMeta.length > 0 ? { attachments: attachmentMeta } : {}),
-          ...(derivedMention.preferred_subagent
-            ? { preferred_subagent: derivedMention.preferred_subagent }
-            : {}),
-          ...(derivedMention.scoped_corpus_ids.length > 0
-            ? { scoped_corpus_ids: derivedMention.scoped_corpus_ids }
-            : {}),
-          ...(derivedMention.output_corpus_ids.length > 0
-            ? { output_corpus_ids: derivedMention.output_corpus_ids }
-            : {}),
+          // 三个 mention 字段无条件覆盖，确保跨 turn 不残留。
+          preferred_subagent: derivedMention.preferred_subagent,
+          scoped_corpus_ids: derivedMention.scoped_corpus_ids,
+          output_corpus_ids: derivedMention.output_corpus_ids,
         };
         agent.forwardedProps = forwardedProps; // 留作 backward-compat（其他读 ref 的逻辑）
         // 清空 Composer 附件区 + Mention 区（与 inputValue 已被清空的语义一致）

--- a/apps/negentropy-ui/app/knowledge/apis/_components/hooks/useCorporaList.ts
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/hooks/useCorporaList.ts
@@ -25,7 +25,8 @@ export function useCorporaList(): UseCorporaListResult {
         setError(null);
         const data = await fetchCorpora(APP_NAME);
         if (mounted) {
-          setCorpora(data);
+          // 防御：网络回退或 BFF 异常时（如未配置后端）data 可能不是数组。
+          setCorpora(Array.isArray(data) ? data : []);
         }
       } catch (err) {
         if (mounted) {

--- a/apps/negentropy-ui/components/ui/Composer.tsx
+++ b/apps/negentropy-ui/components/ui/Composer.tsx
@@ -1,9 +1,17 @@
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ModelConfigItem } from "@/features/knowledge/utils/knowledge-api";
+import type { MentionCandidate, MentionToken } from "@/types/mention";
+import {
+  applyMention,
+  detectMentionTrigger,
+  reconcileMentions,
+} from "@/utils/mention-parser";
 
 import { LlmModelSelect } from "./LlmModelSelect";
 import { AttachmentChipList, type ComposerAttachment } from "./AttachmentChip";
+import { MentionChipList } from "./MentionChipList";
+import { MentionPopover } from "./MentionPopover";
 
 type ComposerProps = {
   value: string;
@@ -38,6 +46,18 @@ type ComposerProps = {
    * 允许的 MIME 通配；undefined 表示所有 image/* + application/pdf + text/*。
    */
   attachmentAccept?: string;
+  /**
+   * @ Mention 系统 —— 全部可选，未传时 Composer 行为完全等同于改造前（向后兼容）。
+   * 接入方需同时传 ``mentions / onMentionsChange`` 及候选项数据源。
+   */
+  mentions?: MentionToken[];
+  onMentionsChange?: (next: MentionToken[]) => void;
+  agentCandidates?: MentionCandidate[];
+  corpusCandidates?: MentionCandidate[];
+  agentsLoading?: boolean;
+  agentsError?: string | null;
+  corporaLoading?: boolean;
+  corporaError?: string | null;
 };
 
 const DEFAULT_ATTACHMENT_ACCEPT = ".pdf,.txt,.md,application/pdf,image/*,text/*";
@@ -61,13 +81,121 @@ export function Composer({
   onAttachmentsChange,
   attachmentMaxBytes = DEFAULT_ATTACHMENT_MAX_BYTES,
   attachmentAccept = DEFAULT_ATTACHMENT_ACCEPT,
+  mentions,
+  onMentionsChange,
+  agentCandidates,
+  corpusCandidates,
+  agentsLoading,
+  agentsError,
+  corporaLoading,
+  corporaError,
 }: ComposerProps) {
   const showModelSelect = Boolean(models && onSelectedLlmModelChange);
   const showThinkingToggle = Boolean(onThinkingEnabledChange);
   const showAttachments = Boolean(onAttachmentsChange);
+  const showMentions = Boolean(onMentionsChange);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const isComposingRef = useRef(false);
   const [dragOver, setDragOver] = useState(false);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+
+  // --------------------------------------------------------------------
+  // @ Mention 弹层状态：trigger 由 onChange / onSelect 检测，position 锁定
+  // textarea 左下角（不依赖光标具体像素，避免 caret 测量复杂度）。
+  // --------------------------------------------------------------------
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [popoverQuery, setPopoverQuery] = useState("");
+  const triggerRangeRef = useRef<{ start: number; end: number } | null>(null);
+  const [popoverPos, setPopoverPos] = useState({ top: 0, left: 0 });
+
+  const recomputePopoverPos = useCallback(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const rect = ta.getBoundingClientRect();
+    setPopoverPos({ top: rect.bottom + 4, left: rect.left });
+  }, []);
+
+  const tryDetectTrigger = useCallback(
+    (val: string, caret: number) => {
+      if (!showMentions || isComposingRef.current) {
+        setPopoverOpen(false);
+        return;
+      }
+      const trig = detectMentionTrigger(val, caret);
+      if (!trig) {
+        setPopoverOpen(false);
+        triggerRangeRef.current = null;
+        return;
+      }
+      triggerRangeRef.current = { start: trig.start, end: trig.end };
+      setPopoverQuery(trig.queryText);
+      setPopoverOpen(true);
+      recomputePopoverPos();
+    },
+    [showMentions, recomputePopoverPos],
+  );
+
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const handle = () => recomputePopoverPos();
+    window.addEventListener("scroll", handle, true);
+    window.addEventListener("resize", handle);
+    return () => {
+      window.removeEventListener("scroll", handle, true);
+      window.removeEventListener("resize", handle);
+    };
+  }, [popoverOpen, recomputePopoverPos]);
+
+  const handleMentionPick = useCallback(
+    (candidate: MentionCandidate) => {
+      const trig = triggerRangeRef.current;
+      if (!trig || !onMentionsChange) {
+        setPopoverOpen(false);
+        return;
+      }
+      const result = applyMention(value, { ...trig, queryText: popoverQuery }, candidate);
+      onChange(result.value);
+      onMentionsChange([...(mentions ?? []), result.token]);
+      setPopoverOpen(false);
+      triggerRangeRef.current = null;
+      // 异步把光标移到 mention 插入后的位置，确保用户可继续输入
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (!ta) return;
+        ta.focus();
+        ta.setSelectionRange(result.caret, result.caret);
+      });
+    },
+    [value, popoverQuery, onChange, onMentionsChange, mentions],
+  );
+
+  const handleMentionRemove = useCallback(
+    (tokenId: string) => {
+      if (!onMentionsChange || !mentions) return;
+      const target = mentions.find((m) => m.id === tokenId);
+      if (!target) return;
+      // 移除 textarea 中对应 rawText（含尾空格）—— 找最近 anchor 出现位置
+      const haystack = value;
+      const idx = haystack.indexOf(target.rawText, Math.max(0, target.start - 16));
+      let nextValue = value;
+      if (idx >= 0) {
+        // 同时吞掉紧跟的一个空格（applyMention 写入的闭合空格）
+        const end =
+          idx + target.rawText.length < haystack.length &&
+          haystack[idx + target.rawText.length] === " "
+            ? idx + target.rawText.length + 1
+            : idx + target.rawText.length;
+        nextValue = haystack.slice(0, idx) + haystack.slice(end);
+        onChange(nextValue);
+      }
+      const survivors = reconcileMentions(value, nextValue, mentions).filter(
+        (m) => m.id !== tokenId,
+      );
+      onMentionsChange(survivors);
+    },
+    [value, mentions, onMentionsChange, onChange],
+  );
 
   const handleAddFiles = (files: FileList | File[] | null) => {
     if (!files || !onAttachmentsChange) return;
@@ -132,6 +260,7 @@ export function Composer({
       }}
     >
       <textarea
+        ref={textareaRef}
         name="prompt_content"
         autoComplete="off"
         autoCorrect="off"
@@ -145,14 +274,72 @@ export function Composer({
         }`}
         placeholder={dragOver ? "释放以添加附件..." : "输入指令..."}
         value={value}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          const next = event.target.value;
+          onChange(next);
+          if (showMentions) {
+            // 同步对齐 mention offset，防止编辑前缀导致区间漂移
+            if (mentions && onMentionsChange && mentions.length > 0) {
+              const reconciled = reconcileMentions(value, next, mentions);
+              if (reconciled !== mentions) onMentionsChange(reconciled);
+            }
+            tryDetectTrigger(next, event.target.selectionStart ?? next.length);
+          }
+        }}
+        onSelect={(event) => {
+          if (!showMentions) return;
+          const ta = event.currentTarget;
+          tryDetectTrigger(ta.value, ta.selectionStart ?? ta.value.length);
+        }}
+        onCompositionStart={() => {
+          isComposingRef.current = true;
+          setPopoverOpen(false);
+        }}
+        onCompositionEnd={(event) => {
+          isComposingRef.current = false;
+          if (showMentions) {
+            const ta = event.currentTarget;
+            tryDetectTrigger(ta.value, ta.selectionStart ?? ta.value.length);
+          }
+        }}
         onKeyDown={(event) => {
-          if (event.key === "Enter" && !event.shiftKey) {
+          // 弹层打开时，↑↓ Enter Tab Esc 由 MentionPopover 全局监听拦截，
+          // textarea 自身仅在 Enter 未被拦截（弹层关闭/无候选）时触发发送。
+          if (event.key === "Enter" && !event.shiftKey && !popoverOpen) {
             event.preventDefault();
             onSend();
           }
         }}
+        onBlur={(event) => {
+          // 仅当焦点离开 textarea + 不在 mention 弹层内部时关闭
+          // —— 点击 Popover Tab / 候选项不应关闭弹层。
+          const next = event.relatedTarget as HTMLElement | null;
+          if (next && next.closest('[data-testid="mention-popover"]')) {
+            return;
+          }
+          setTimeout(() => setPopoverOpen(false), 150);
+        }}
       />
+      {showMentions && (
+        <MentionPopover
+          open={popoverOpen}
+          position={popoverPos}
+          queryText={popoverQuery}
+          agentCandidates={agentCandidates ?? []}
+          corpusCandidates={corpusCandidates ?? []}
+          agentsLoading={agentsLoading}
+          agentsError={agentsError ?? null}
+          corporaLoading={corporaLoading}
+          corporaError={corporaError ?? null}
+          onPick={handleMentionPick}
+          onClose={() => setPopoverOpen(false)}
+        />
+      )}
+      {showMentions && mentions && mentions.length > 0 && (
+        <div className="mt-2" data-testid="composer-mentions-wrapper">
+          <MentionChipList mentions={mentions} onRemove={handleMentionRemove} />
+        </div>
+      )}
       {showAttachments && attachments && attachments.length > 0 && (
         <div className="mt-2" data-testid="composer-attachments">
           <AttachmentChipList
@@ -246,7 +433,9 @@ export function Composer({
               </button>
             </>
           )}
-          <p className="text-xs text-muted truncate">Shift+Enter 换行</p>
+          <p className="text-xs text-muted truncate">
+            Shift+Enter 换行{showMentions ? " · @ 选 Agent / 知识库" : ""}
+          </p>
         </div>
         {showStop ? (
           <button

--- a/apps/negentropy-ui/components/ui/MentionChipList.tsx
+++ b/apps/negentropy-ui/components/ui/MentionChipList.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * MentionChipList — Composer 下方的 mention 摘要 chip 列表。
+ *
+ * 等价于 ``AttachmentChipList`` 的 mention 镜像，承担"已选定的 @ 项"的可视化与
+ * 删除入口。MVP 阶段以列表 chip 替代 mirror overlay 高亮，工作量小且不破坏
+ * textarea 的 IME / Shift+Enter / 拖拽附件等既有行为。
+ *
+ * 删除 chip 时，父组件通过 ``onRemove(tokenId)`` 同步移除 textarea 中对应的
+ * ``rawText`` 片段（实际逻辑由 Composer 调用 ``reconcileMentions`` 完成）。
+ */
+import { Bot, BookOpen, Save, X } from "lucide-react";
+import type { MentionKind, MentionToken } from "@/types/mention";
+
+const _ICONS: Record<MentionKind, typeof Bot> = {
+  agent: Bot,
+  "corpus-retrieve": BookOpen,
+  "corpus-output": Save,
+};
+
+const _CHIP_CLASS: Record<MentionKind, string> = {
+  agent:
+    "border-sky-300 bg-sky-50 text-sky-900 dark:border-sky-700 dark:bg-sky-950/50 dark:text-sky-200",
+  "corpus-retrieve":
+    "border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-200",
+  "corpus-output":
+    "border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200",
+};
+
+const _KIND_TITLE: Record<MentionKind, string> = {
+  agent: "委派 SubAgent",
+  "corpus-retrieve": "限定检索范围",
+  "corpus-output": "输出沉淀目标",
+};
+
+export interface MentionChipListProps {
+  mentions: MentionToken[];
+  onRemove: (tokenId: string) => void;
+}
+
+export function MentionChipList({ mentions, onRemove }: MentionChipListProps) {
+  if (mentions.length === 0) return null;
+  return (
+    <div
+      className="flex flex-wrap gap-2"
+      data-testid="composer-mentions"
+      aria-label="已选定的 @ 项"
+    >
+      {mentions.map((m) => {
+        const Icon = _ICONS[m.kind];
+        return (
+          <span
+            key={m.id}
+            data-testid="composer-mention-chip"
+            data-mention-kind={m.kind}
+            title={`${_KIND_TITLE[m.kind]} · ${m.label}`}
+            className={`inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[11px] ${_CHIP_CLASS[m.kind]}`}
+          >
+            <Icon className="h-3 w-3" aria-hidden />
+            <span className="max-w-[160px] truncate">{m.label}</span>
+            <button
+              type="button"
+              aria-label={`移除 @${m.label}`}
+              className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-foreground/10"
+              onClick={() => onRemove(m.id)}
+            >
+              <X className="h-2.5 w-2.5" aria-hidden />
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/MentionPopover.tsx
+++ b/apps/negentropy-ui/components/ui/MentionPopover.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+/**
+ * MentionPopover — Home Composer 的 @ 弹层。
+ *
+ * 设计要点：
+ * - **Portal 绝对定位**（不复用 BaseModal —— 它是 modal 语义，会拦截背景交互）；
+ * - **3 个 Tab**（Agents / 检索 / 输出）按 kind 区分候选项；
+ * - **键盘导航**：↑↓ 切换条目、Tab 切换 Tab、Enter/Tab 选中、Esc 关闭；
+ * - **过滤**：按 queryText 子串（不区分大小写）；
+ * - **可访问性**：role=listbox + aria-activedescendant；
+ * - **空态**：显示加载 / 错误 / "暂无匹配"提示。
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Bot, BookOpen, Save, Loader2 } from "lucide-react";
+import type { MentionCandidate, MentionKind } from "@/types/mention";
+
+interface PopoverPosition {
+  top: number;
+  left: number;
+}
+
+export interface MentionPopoverProps {
+  /** 是否显示。 */
+  open: boolean;
+  /** 屏幕坐标（textarea 当前光标的视口位置）；通常由 Composer 计算后传入。 */
+  position: PopoverPosition;
+  /** 用户在 ``@`` 之后键入的过滤文本（不含 ``@``）。 */
+  queryText: string;
+  /** Agent 候选项（已按业务规则过滤，例如排除 root / 禁用项）。 */
+  agentCandidates: MentionCandidate[];
+  /** Corpus 候选项（同时用于检索 Tab 与输出 Tab，但 kind 字段不同）。 */
+  corpusCandidates: MentionCandidate[];
+  /** Agents 加载状态。 */
+  agentsLoading?: boolean;
+  agentsError?: string | null;
+  /** Corpora 加载状态。 */
+  corporaLoading?: boolean;
+  corporaError?: string | null;
+  /** 选中候选项回调。 */
+  onPick: (candidate: MentionCandidate) => void;
+  /** 关闭弹层回调（Esc / 点击外部）。 */
+  onClose: () => void;
+}
+
+const _TAB_DEFS: Array<{ kind: MentionKind; label: string; icon: typeof Bot }> = [
+  { kind: "agent", label: "Agents", icon: Bot },
+  { kind: "corpus-retrieve", label: "知识检索", icon: BookOpen },
+  { kind: "corpus-output", label: "输出沉淀", icon: Save },
+];
+
+function _filter(candidates: MentionCandidate[], q: string): MentionCandidate[] {
+  if (!q) return candidates;
+  const lower = q.toLowerCase();
+  return candidates.filter((c) => {
+    const inLabel = c.label.toLowerCase().includes(lower);
+    const inDesc = (c.description ?? "").toLowerCase().includes(lower);
+    return inLabel || inDesc;
+  });
+}
+
+export function MentionPopover({
+  open,
+  position,
+  queryText,
+  agentCandidates,
+  corpusCandidates,
+  agentsLoading,
+  agentsError,
+  corporaLoading,
+  corporaError,
+  onPick,
+  onClose,
+}: MentionPopoverProps) {
+  const [tab, _setTabRaw] = useState<MentionKind>("agent");
+  const [activeIdx, setActiveIdx] = useState(0);
+  // 切换 Tab 时同步把 activeIdx 重置到 0；避免 useEffect 内 setState 触发额外渲染。
+  const setTab = useCallback((next: MentionKind) => {
+    _setTabRaw(next);
+    setActiveIdx(0);
+  }, []);
+  const listRef = useRef<HTMLUListElement | null>(null);
+
+  const items = useMemo(() => {
+    if (!open) return [] as MentionCandidate[];
+    if (tab === "agent") return _filter(agentCandidates, queryText);
+    // retrieve / output 都基于 corpora，仅 kind 字段不同；
+    // 为简化弹层渲染，这里在拷贝里改写 kind，便于 onPick 直接透传。
+    return _filter(corpusCandidates, queryText).map((c) => ({ ...c, kind: tab }));
+  }, [open, tab, agentCandidates, corpusCandidates, queryText]);
+
+  // items.length 变化时，render 时直接 clamp activeIdx，避免 useEffect 内 setState
+  // 触发额外渲染（react-hooks/set-state-in-effect）。
+  const safeActiveIdx =
+    items.length === 0 ? 0 : Math.min(activeIdx, items.length - 1);
+
+  // 全局 keydown：弹层打开时拦截 ↑↓ Enter Esc Tab
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIdx((i) => (items.length === 0 ? 0 : (i + 1) % items.length));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIdx((i) =>
+          items.length === 0 ? 0 : (i - 1 + items.length) % items.length,
+        );
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        if (items.length === 0) {
+          // 允许 Enter 落入 textarea 的默认行为（发送）
+          if (e.key === "Tab") {
+            // Tab 时切换到下一个 Tab，避免抢走焦点
+            e.preventDefault();
+            const idx = _TAB_DEFS.findIndex((t) => t.kind === tab);
+            const next = _TAB_DEFS[(idx + 1) % _TAB_DEFS.length];
+            setTab(next.kind);
+          }
+          return;
+        }
+        e.preventDefault();
+        const picked = items[safeActiveIdx];
+        if (picked) onPick(picked);
+      }
+    };
+    window.addEventListener("keydown", handle, true);
+    return () => window.removeEventListener("keydown", handle, true);
+  }, [open, items, safeActiveIdx, onPick, onClose, tab, setTab]);
+
+  // 滚动选中项进入视野
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.querySelector<HTMLLIElement>(`[data-active="true"]`);
+    // jsdom 不实现 scrollIntoView；生产环境正常调用
+    if (item && typeof item.scrollIntoView === "function") {
+      item.scrollIntoView({ block: "nearest" });
+    }
+  }, [safeActiveIdx, tab]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  const loading = tab === "agent" ? agentsLoading : corporaLoading;
+  const error = tab === "agent" ? agentsError : corporaError;
+
+  return createPortal(
+    <div
+      data-testid="mention-popover"
+      role="dialog"
+      aria-label="Mention 候选项"
+      className="fixed z-50 w-80 rounded-xl border border-border bg-card text-foreground shadow-xl"
+      style={{ top: position.top, left: position.left }}
+      onMouseDown={(e) => {
+        // 阻止 mousedown 抢走 textarea 焦点（点击候选项时仍要保留输入态）
+        e.preventDefault();
+      }}
+    >
+      {/* Tab 切换栏 */}
+      <div className="flex items-center gap-0.5 border-b border-border p-1">
+        {_TAB_DEFS.map((t) => {
+          const Icon = t.icon;
+          const active = tab === t.kind;
+          return (
+            <button
+              key={t.kind}
+              type="button"
+              data-testid={`mention-tab-${t.kind}`}
+              aria-selected={active}
+              role="tab"
+              className={`inline-flex h-7 flex-1 items-center justify-center gap-1 rounded-md px-2 text-xs transition-colors ${
+                active
+                  ? "bg-input text-foreground"
+                  : "text-muted hover:text-foreground"
+              }`}
+              onClick={() => setTab(t.kind)}
+            >
+              <Icon className="h-3 w-3" aria-hidden />
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 候选项列表 */}
+      <ul
+        ref={listRef}
+        role="listbox"
+        aria-activedescendant={
+          items[safeActiveIdx]
+            ? `mention-item-${items[safeActiveIdx].refId}`
+            : undefined
+        }
+        className="max-h-64 overflow-y-auto py-1"
+        data-testid="mention-listbox"
+      >
+        {loading && (
+          <li className="flex items-center justify-center gap-2 px-3 py-3 text-xs text-muted">
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden /> 加载中…
+          </li>
+        )}
+        {!loading && error && (
+          <li className="px-3 py-3 text-xs text-rose-500" data-testid="mention-error">
+            加载失败：{error}
+          </li>
+        )}
+        {!loading && !error && items.length === 0 && (
+          <li
+            className="px-3 py-3 text-xs text-muted"
+            data-testid="mention-empty"
+          >
+            {tab === "agent" ? "暂无匹配的 Agent" : "暂无匹配的语料库"}
+          </li>
+        )}
+        {!loading &&
+          !error &&
+          items.map((c, idx) => {
+            const active = idx === safeActiveIdx;
+            return (
+              <li
+                key={c.refId}
+                id={`mention-item-${c.refId}`}
+                role="option"
+                aria-selected={active}
+                data-active={active ? "true" : undefined}
+                data-testid="mention-option"
+                className={`cursor-pointer px-3 py-2 ${
+                  active
+                    ? "bg-input"
+                    : "hover:bg-input/60"
+                }`}
+                onMouseEnter={() => setActiveIdx(idx)}
+                onClick={() => onPick(c)}
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="truncate text-xs font-medium">{c.label}</span>
+                </div>
+                {c.description && (
+                  <p className="mt-0.5 line-clamp-1 text-[10px] text-muted">
+                    {c.description}
+                  </p>
+                )}
+              </li>
+            );
+          })}
+      </ul>
+
+      {/* 底部提示 */}
+      <div className="border-t border-border px-3 py-1 text-[10px] text-muted">
+        ↑↓ 选择 · Enter 确认 · Tab 切换 Tab · Esc 关闭
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/negentropy-ui/hooks/useSubAgentsList.ts
+++ b/apps/negentropy-ui/hooks/useSubAgentsList.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * 与 ``apps/negentropy/src/negentropy/interface/api.py`` 的 ``SubAgentResponse`` 对齐。
@@ -29,13 +29,19 @@ interface UseSubAgentsListResult {
  * 加载当前用户可见的 SubAgent 列表（已隐藏 root + 已禁用）。
  *
  * 复用范式：与 ``app/knowledge/apis/_components/hooks/useCorporaList.ts`` 同构。
+ *
+ * 卸载安全：``mountedRef`` 提升到 hook 作用域，``useEffect`` 与 ``reload`` 共用同一份
+ * 信号；组件卸载时 cleanup 将其置为 ``false``，确保 in-flight 请求即使在卸载后完成
+ * 也不会触发 ``setSubagents`` / ``setError`` / ``setLoading``（避免 React 开发态告警
+ * 与潜在内存泄漏）。
  */
 export function useSubAgentsList(): UseSubAgentsListResult {
   const [subagents, setSubagents] = useState<SubAgentEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
 
-  const fetchOnce = async (mounted: { current: boolean }) => {
+  const fetchOnce = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -45,7 +51,7 @@ export function useSubAgentsList(): UseSubAgentsListResult {
       });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const raw = (await resp.json()) as unknown;
-      if (!mounted.current) return;
+      if (!mountedRef.current) return;
       // 防御：测试 / 异常环境下 raw 可能非数组（空对象兜底等）。
       const data: SubAgentEntry[] = Array.isArray(raw) ? (raw as SubAgentEntry[]) : [];
       // 过滤：启用的 + 非 root + 非 root kind（Home 的"直达 SubAgent"语义，
@@ -58,26 +64,23 @@ export function useSubAgentsList(): UseSubAgentsListResult {
       );
       setSubagents(filtered);
     } catch (err) {
-      if (mounted.current) {
+      if (mountedRef.current) {
         setError(err instanceof Error ? err.message : "加载 SubAgent 列表失败");
       }
     } finally {
-      if (mounted.current) setLoading(false);
+      if (mountedRef.current) setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    const mounted = { current: true };
-    void fetchOnce(mounted);
-    return () => {
-      mounted.current = false;
-    };
   }, []);
 
-  const reload = async () => {
-    const mounted = { current: true };
-    await fetchOnce(mounted);
-  };
+  useEffect(() => {
+    // Strict Mode 下 effect 会双触发（mount → cleanup → mount），需在 mount 阶段
+    // 显式置 true，防止第二次 mount 时仍读到上一次 cleanup 写入的 false。
+    mountedRef.current = true;
+    void fetchOnce();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [fetchOnce]);
 
-  return { subagents, loading, error, reload };
+  return { subagents, loading, error, reload: fetchOnce };
 }

--- a/apps/negentropy-ui/hooks/useSubAgentsList.ts
+++ b/apps/negentropy-ui/hooks/useSubAgentsList.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 与 ``apps/negentropy/src/negentropy/interface/api.py`` 的 ``SubAgentResponse`` 对齐。
+ * 仅保留 Home Composer @ Agent 弹层所需字段。
+ */
+export interface SubAgentEntry {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  is_builtin: boolean;
+  is_enabled: boolean;
+  kind?: "root" | "subagent";
+}
+
+interface UseSubAgentsListResult {
+  subagents: SubAgentEntry[];
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+}
+
+/**
+ * 加载当前用户可见的 SubAgent 列表（已隐藏 root + 已禁用）。
+ *
+ * 复用范式：与 ``app/knowledge/apis/_components/hooks/useCorporaList.ts`` 同构。
+ */
+export function useSubAgentsList(): UseSubAgentsListResult {
+  const [subagents, setSubagents] = useState<SubAgentEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchOnce = async (mounted: { current: boolean }) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const resp = await fetch("/api/interface/subagents", {
+        method: "GET",
+        cache: "no-store",
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const raw = (await resp.json()) as unknown;
+      if (!mounted.current) return;
+      // 防御：测试 / 异常环境下 raw 可能非数组（空对象兜底等）。
+      const data: SubAgentEntry[] = Array.isArray(raw) ? (raw as SubAgentEntry[]) : [];
+      // 过滤：启用的 + 非 root + 非 root kind（Home 的"直达 SubAgent"语义，
+      // root_agent 是默认目标，无需在 @ Agent 弹层中再选一次）。
+      const filtered = data.filter(
+        (a) =>
+          a.is_enabled &&
+          a.kind !== "root" &&
+          a.name !== "NegentropyEngine",
+      );
+      setSubagents(filtered);
+    } catch (err) {
+      if (mounted.current) {
+        setError(err instanceof Error ? err.message : "加载 SubAgent 列表失败");
+      }
+    } finally {
+      if (mounted.current) setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const mounted = { current: true };
+    void fetchOnce(mounted);
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const reload = async () => {
+    const mounted = { current: true };
+    await fetchOnce(mounted);
+  };
+
+  return { subagents, loading, error, reload };
+}

--- a/apps/negentropy-ui/tests/unit/api/agui-route-state.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-route-state.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { buildStateDeltaFromForwardedProps } from "@/app/api/agui/route";
 
+const UUID_A = "11111111-2222-3333-4444-555555555555";
+const UUID_B = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const UUID_C = "12345678-1234-1234-1234-123456789abc";
+
 describe("buildStateDeltaFromForwardedProps", () => {
   it("透传 selected_llm_model 与 thinking_enabled 到 session state_delta", () => {
     expect(
@@ -20,5 +24,122 @@ describe("buildStateDeltaFromForwardedProps", () => {
         thinking_enabled: "true",
       }),
     ).toEqual({});
+  });
+
+  // ----------------------------------------------------------------------
+  // @ Agent —— preferred_subagent
+  // ----------------------------------------------------------------------
+
+  it("透传非空 preferred_subagent 字符串", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({ preferred_subagent: "PerceptionFaculty" }),
+    ).toEqual({ preferred_subagent: "PerceptionFaculty" });
+  });
+
+  it("preferred_subagent 显式为 null 时透传 null（用于清空）", () => {
+    expect(buildStateDeltaFromForwardedProps({ preferred_subagent: null })).toEqual({
+      preferred_subagent: null,
+    });
+  });
+
+  it("preferred_subagent 空串 / 超长 / 非字符串一律忽略", () => {
+    expect(buildStateDeltaFromForwardedProps({ preferred_subagent: "" })).toEqual({});
+    expect(
+      buildStateDeltaFromForwardedProps({ preferred_subagent: "X".repeat(129) }),
+    ).toEqual({});
+    expect(buildStateDeltaFromForwardedProps({ preferred_subagent: 123 })).toEqual({});
+  });
+
+  // ----------------------------------------------------------------------
+  // @ Corpus 检索 —— scoped_corpus_ids
+  // ----------------------------------------------------------------------
+
+  it("透传合法 UUID 列表 scoped_corpus_ids", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        scoped_corpus_ids: [UUID_A, UUID_B],
+      }),
+    ).toEqual({ scoped_corpus_ids: [UUID_A, UUID_B] });
+  });
+
+  it("scoped_corpus_ids 中非 UUID 条目被过滤掉", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        scoped_corpus_ids: [UUID_A, "not-a-uuid", null, 42, UUID_B],
+      }),
+    ).toEqual({ scoped_corpus_ids: [UUID_A, UUID_B] });
+  });
+
+  it("scoped_corpus_ids 全部非法 → 不写入 state_delta", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        scoped_corpus_ids: ["x", null, 1],
+      }),
+    ).toEqual({});
+  });
+
+  it("scoped_corpus_ids 自动去重并保持首现顺序", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        scoped_corpus_ids: [UUID_A, UUID_B, UUID_A, UUID_C],
+      }),
+    ).toEqual({ scoped_corpus_ids: [UUID_A, UUID_B, UUID_C] });
+  });
+
+  it("scoped_corpus_ids 非数组类型整体忽略", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({ scoped_corpus_ids: UUID_A }),
+    ).toEqual({});
+    expect(
+      buildStateDeltaFromForwardedProps({ scoped_corpus_ids: { 0: UUID_A } }),
+    ).toEqual({});
+  });
+
+  // ----------------------------------------------------------------------
+  // @ Corpus 输出 —— output_corpus_ids
+  // ----------------------------------------------------------------------
+
+  it("透传合法 UUID 列表 output_corpus_ids", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({ output_corpus_ids: [UUID_A] }),
+    ).toEqual({ output_corpus_ids: [UUID_A] });
+  });
+
+  it("output_corpus_ids 与 scoped_corpus_ids 可同时存在且互不影响", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        scoped_corpus_ids: [UUID_A],
+        output_corpus_ids: [UUID_B, UUID_C],
+      }),
+    ).toEqual({
+      scoped_corpus_ids: [UUID_A],
+      output_corpus_ids: [UUID_B, UUID_C],
+    });
+  });
+
+  // ----------------------------------------------------------------------
+  // 综合：模型 + Thinking + 三类 @ 一起
+  // ----------------------------------------------------------------------
+
+  it("可同时透传所有受支持字段", () => {
+    expect(
+      buildStateDeltaFromForwardedProps({
+        selected_llm_model: "anthropic/claude-opus-4-7",
+        thinking_enabled: true,
+        preferred_subagent: "ActionFaculty",
+        scoped_corpus_ids: [UUID_A],
+        output_corpus_ids: [UUID_B],
+      }),
+    ).toEqual({
+      selected_llm_model: "anthropic/claude-opus-4-7",
+      thinking_enabled: true,
+      preferred_subagent: "ActionFaculty",
+      scoped_corpus_ids: [UUID_A],
+      output_corpus_ids: [UUID_B],
+    });
+  });
+
+  it("forwardedProps 为 null → 返回空对象", () => {
+    expect(buildStateDeltaFromForwardedProps(null)).toEqual({});
   });
 });

--- a/apps/negentropy-ui/tests/unit/api/agui-route-state.test.ts
+++ b/apps/negentropy-ui/tests/unit/api/agui-route-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildStateDeltaFromForwardedProps } from "@/app/api/agui/route";
+import { buildStateDeltaFromForwardedProps } from "@/app/api/agui/_state-delta";
 
 const UUID_A = "11111111-2222-3333-4444-555555555555";
 const UUID_B = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
@@ -70,12 +70,22 @@ describe("buildStateDeltaFromForwardedProps", () => {
     ).toEqual({ scoped_corpus_ids: [UUID_A, UUID_B] });
   });
 
-  it("scoped_corpus_ids 全部非法 → 不写入 state_delta", () => {
+  it("scoped_corpus_ids 显式空数组 → 写入空数组（清空语义）", () => {
+    // 关键回归：跨 turn 残留修复 —— 前端在用户移除 @ Corpus 后会显式发送 []，
+    // BFF 据此写入 state_delta 触发 ADK session.state 中 ``scoped_corpus_ids`` 的清空。
+    expect(
+      buildStateDeltaFromForwardedProps({ scoped_corpus_ids: [] }),
+    ).toEqual({ scoped_corpus_ids: [] });
+  });
+
+  it("scoped_corpus_ids 全部非法 → 写入空数组（清空语义）", () => {
+    // 数组类型合法但条目全部非法 → sanitize 为 [] → 视作显式清空，
+    // 与「显式空数组」走同一路径，避免脏值阻塞清空。
     expect(
       buildStateDeltaFromForwardedProps({
         scoped_corpus_ids: ["x", null, 1],
       }),
-    ).toEqual({});
+    ).toEqual({ scoped_corpus_ids: [] });
   });
 
   it("scoped_corpus_ids 自动去重并保持首现顺序", () => {
@@ -86,13 +96,27 @@ describe("buildStateDeltaFromForwardedProps", () => {
     ).toEqual({ scoped_corpus_ids: [UUID_A, UUID_B, UUID_C] });
   });
 
-  it("scoped_corpus_ids 非数组类型整体忽略", () => {
+  it("scoped_corpus_ids 非数组类型整体忽略（保留旧 session.state）", () => {
+    // 非数组（含字符串 / 对象 / undefined 等）→ 不写 state_delta；
+    // 这是「字段类型不合法」与「显式清空」的边界。
     expect(
       buildStateDeltaFromForwardedProps({ scoped_corpus_ids: UUID_A }),
     ).toEqual({});
     expect(
       buildStateDeltaFromForwardedProps({ scoped_corpus_ids: { 0: UUID_A } }),
     ).toEqual({});
+  });
+
+  it("scoped_corpus_ids 字段不存在 → 不写入 state_delta", () => {
+    // 区分「字段缺席」与「显式清空」：缺席不应清空旧值（向后兼容旧调用方）。
+    expect(buildStateDeltaFromForwardedProps({})).toEqual({});
+  });
+
+  it("output_corpus_ids 显式空数组 → 写入空数组（清空语义）", () => {
+    // 与 scoped_corpus_ids 同构 —— 防止上一轮的 output 沉淀目标遗留到下一轮。
+    expect(
+      buildStateDeltaFromForwardedProps({ output_corpus_ids: [] }),
+    ).toEqual({ output_corpus_ids: [] });
   });
 
   // ----------------------------------------------------------------------

--- a/apps/negentropy-ui/tests/unit/components/Composer.mention.test.tsx
+++ b/apps/negentropy-ui/tests/unit/components/Composer.mention.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { Composer } from "@/components/ui/Composer";
+import type { MentionCandidate, MentionToken } from "@/types/mention";
+
+const _AGENTS: MentionCandidate[] = [
+  { kind: "agent", refId: "PerceptionFaculty", label: "PerceptionFaculty" },
+  { kind: "agent", refId: "ActionFaculty", label: "ActionFaculty" },
+];
+
+const _CORPORA: MentionCandidate[] = [
+  { kind: "corpus-retrieve", refId: "uuid-a", label: "Corpus-A" },
+];
+
+/**
+ * Composer 默认无 mention 行为兼容 + 启用 mention 后的核心流程：
+ * - 键入 ``@`` 弹层出现，过滤 + 选中后插入 rawText 并新增 token；
+ * - chip 列表可点击删除，对应文本同步移除；
+ * - 弹层打开时 Enter 不触发 onSend（避免抢走选中行为）。
+ */
+function ComposerWithMention() {
+  const [value, setValue] = useState("");
+  const [mentions, setMentions] = useState<MentionToken[]>([]);
+  const onSend = vi.fn();
+  return (
+    <div>
+      <button data-testid="check-mentions" onClick={() => undefined}>
+        {JSON.stringify(mentions.map((m) => ({ kind: m.kind, refId: m.refId })))}
+      </button>
+      <button data-testid="check-value" onClick={() => undefined}>{value}</button>
+      <button data-testid="check-send" onClick={() => undefined}>
+        {onSend.mock.calls.length.toString()}
+      </button>
+      <Composer
+        value={value}
+        onChange={setValue}
+        onSend={onSend}
+        disabled={false}
+        mentions={mentions}
+        onMentionsChange={setMentions}
+        agentCandidates={_AGENTS}
+        corpusCandidates={_CORPORA}
+      />
+    </div>
+  );
+}
+
+describe("Composer @ mention 集成", () => {
+  it("无 mention prop 时不渲染弹层（向后兼容）", () => {
+    render(
+      <Composer value="@" onChange={vi.fn()} onSend={vi.fn()} disabled={false} />,
+    );
+    // 即便有 @ 字符，因 showMentions=false 也不会弹层
+    expect(screen.queryByTestId("mention-popover")).toBeNull();
+  });
+
+  it("键入 @ 触发弹层，选中 agent 后插入文本 + 新增 token", async () => {
+    const user = userEvent.setup();
+    render(<ComposerWithMention />);
+    const ta = screen.getByTestId("composer-textarea") as HTMLTextAreaElement;
+    await user.click(ta);
+    await user.type(ta, "@");
+    expect(await screen.findByTestId("mention-popover")).toBeInTheDocument();
+    // Enter 选中第一条（PerceptionFaculty）
+    fireEvent.keyDown(window, { key: "Enter" });
+    // 文本应被替换为 "@PerceptionFaculty "
+    expect((screen.getByTestId("composer-textarea") as HTMLTextAreaElement).value).toBe(
+      "@PerceptionFaculty ",
+    );
+    // mentions state 应新增一个 agent token
+    expect(screen.getByTestId("check-mentions").textContent).toContain(
+      '"kind":"agent"',
+    );
+    expect(screen.getByTestId("check-mentions").textContent).toContain(
+      '"refId":"PerceptionFaculty"',
+    );
+  });
+
+  it("弹层打开时 Enter 不触发 onSend（被弹层拦截）", async () => {
+    const onSend = vi.fn();
+    render(
+      <Composer
+        value="@"
+        onChange={() => undefined}
+        onSend={onSend}
+        disabled={false}
+        mentions={[]}
+        onMentionsChange={() => undefined}
+        agentCandidates={_AGENTS}
+        corpusCandidates={_CORPORA}
+      />,
+    );
+    const ta = screen.getByTestId("composer-textarea") as HTMLTextAreaElement;
+    ta.focus();
+    ta.setSelectionRange(1, 1);
+    fireEvent.select(ta);
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("点击 chip 删除按钮 → 同步移除文本与 token", async () => {
+    const user = userEvent.setup();
+    render(<ComposerWithMention />);
+    const ta = screen.getByTestId("composer-textarea") as HTMLTextAreaElement;
+    await user.click(ta);
+    await user.type(ta, "@");
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect((screen.getByTestId("composer-textarea") as HTMLTextAreaElement).value).toBe(
+      "@PerceptionFaculty ",
+    );
+    // 找到 chip 的删除按钮
+    const removeBtn = screen.getByRole("button", { name: /移除 @PerceptionFaculty/ });
+    await user.click(removeBtn);
+    // 文本与 token 都应被清空
+    expect((screen.getByTestId("composer-textarea") as HTMLTextAreaElement).value).toBe(
+      "",
+    );
+    expect(screen.getByTestId("check-mentions").textContent).toBe("[]");
+  });
+
+  it("IME 期间禁用弹层（compositionStart → 关闭，compositionEnd → 重新检测）", async () => {
+    const user = userEvent.setup();
+    render(<ComposerWithMention />);
+    const ta = screen.getByTestId("composer-textarea") as HTMLTextAreaElement;
+    await user.click(ta);
+    await user.type(ta, "@");
+    expect(await screen.findByTestId("mention-popover")).toBeInTheDocument();
+    // IME 开始
+    fireEvent.compositionStart(ta);
+    // 弹层关闭
+    expect(screen.queryByTestId("mention-popover")).toBeNull();
+  });
+
+  it("email 场景 user@example.com 不触发弹层", async () => {
+    const user = userEvent.setup();
+    render(<ComposerWithMention />);
+    const ta = screen.getByTestId("composer-textarea") as HTMLTextAreaElement;
+    await user.click(ta);
+    await user.type(ta, "user@");
+    expect(screen.queryByTestId("mention-popover")).toBeNull();
+  });
+});

--- a/apps/negentropy-ui/tests/unit/components/MentionPopover.test.tsx
+++ b/apps/negentropy-ui/tests/unit/components/MentionPopover.test.tsx
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MentionPopover } from "@/components/ui/MentionPopover";
+import type { MentionCandidate } from "@/types/mention";
+
+const _AGENTS: MentionCandidate[] = [
+  {
+    kind: "agent",
+    refId: "PerceptionFaculty",
+    label: "PerceptionFaculty",
+    description: "感知系部",
+  },
+  {
+    kind: "agent",
+    refId: "ActionFaculty",
+    label: "ActionFaculty",
+    description: "知行系部",
+  },
+];
+
+const _CORPORA: MentionCandidate[] = [
+  {
+    kind: "corpus-retrieve",
+    refId: "uuid-a",
+    label: "Corpus-A",
+    description: "ML papers",
+  },
+  {
+    kind: "corpus-retrieve",
+    refId: "uuid-b",
+    label: "Corpus-B",
+    description: "Cooking recipes",
+  },
+];
+
+function _renderPopover(
+  overrides: Partial<Parameters<typeof MentionPopover>[0]> = {},
+) {
+  const onPick = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <MentionPopover
+      open
+      position={{ top: 100, left: 50 }}
+      queryText=""
+      agentCandidates={_AGENTS}
+      corpusCandidates={_CORPORA}
+      onPick={onPick}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+  return { onPick, onClose };
+}
+
+describe("MentionPopover", () => {
+  it("open=false → 不渲染", () => {
+    render(
+      <MentionPopover
+        open={false}
+        position={{ top: 0, left: 0 }}
+        queryText=""
+        agentCandidates={_AGENTS}
+        corpusCandidates={_CORPORA}
+        onPick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("mention-popover")).toBeNull();
+  });
+
+  it("默认 Tab 为 Agents，展示 agent 候选项", () => {
+    _renderPopover();
+    expect(screen.getByTestId("mention-popover")).toBeInTheDocument();
+    expect(screen.getByText("PerceptionFaculty")).toBeInTheDocument();
+    expect(screen.getByText("ActionFaculty")).toBeInTheDocument();
+    // 此时不应渲染 corpus 候选
+    expect(screen.queryByText("Corpus-A")).toBeNull();
+  });
+
+  it("点击 Tab 切换显示 corpus 候选", async () => {
+    const user = userEvent.setup();
+    _renderPopover();
+    await user.click(screen.getByTestId("mention-tab-corpus-retrieve"));
+    expect(screen.getByText("Corpus-A")).toBeInTheDocument();
+    expect(screen.queryByText("PerceptionFaculty")).toBeNull();
+  });
+
+  it("queryText 过滤候选项（不区分大小写）", () => {
+    _renderPopover({ queryText: "PERC" });
+    expect(screen.getByText("PerceptionFaculty")).toBeInTheDocument();
+    expect(screen.queryByText("ActionFaculty")).toBeNull();
+  });
+
+  it("queryText 命中 description 也算匹配", () => {
+    _renderPopover({ queryText: "感知" });
+    expect(screen.getByText("PerceptionFaculty")).toBeInTheDocument();
+    expect(screen.queryByText("ActionFaculty")).toBeNull();
+  });
+
+  it("Enter 选中当前活动条目 → onPick", () => {
+    const { onPick } = _renderPopover();
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick.mock.calls[0][0]).toMatchObject({
+      kind: "agent",
+      refId: "PerceptionFaculty",
+    });
+  });
+
+  it("Esc 关闭 → onClose", () => {
+    const { onClose } = _renderPopover();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("↓ 切换下一条目后 Enter → 选中第 2 条", () => {
+    const { onPick } = _renderPopover();
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onPick.mock.calls[0][0]).toMatchObject({ refId: "ActionFaculty" });
+  });
+
+  it("空匹配 → 显示「暂无匹配」", () => {
+    _renderPopover({ queryText: "no_such_thing_xyz" });
+    expect(screen.getByTestId("mention-empty")).toBeInTheDocument();
+  });
+
+  it("agentsLoading=true → 显示加载中", () => {
+    _renderPopover({ agentsLoading: true });
+    expect(screen.getByText(/加载中/)).toBeInTheDocument();
+  });
+
+  it("agentsError → 显示错误", () => {
+    _renderPopover({ agentsError: "网络超时" });
+    expect(screen.getByTestId("mention-error")).toBeInTheDocument();
+    expect(screen.getByText(/网络超时/)).toBeInTheDocument();
+  });
+
+  it("切换到 corpus-output Tab 后选中 → onPick.kind=corpus-output", async () => {
+    const user = userEvent.setup();
+    const { onPick } = _renderPopover();
+    await user.click(screen.getByTestId("mention-tab-corpus-output"));
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onPick.mock.calls[0][0]).toMatchObject({
+      kind: "corpus-output",
+      refId: "uuid-a",
+    });
+  });
+
+  it("点击候选项 → onPick", async () => {
+    const user = userEvent.setup();
+    const { onPick } = _renderPopover();
+    await user.click(screen.getByText("ActionFaculty"));
+    expect(onPick.mock.calls[0][0]).toMatchObject({ refId: "ActionFaculty" });
+  });
+});

--- a/apps/negentropy-ui/tests/unit/utils/mention-parser.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/mention-parser.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMention,
+  deriveForwardedPropsFromMentions,
+  detectMentionTrigger,
+  reconcileMentions,
+} from "@/utils/mention-parser";
+import type { MentionToken } from "@/types/mention";
+
+// ---------------------------------------------------------------------------
+// detectMentionTrigger
+// ---------------------------------------------------------------------------
+
+describe("detectMentionTrigger", () => {
+  it("行首单独键入 @ → 触发，queryText 为空", () => {
+    const t = detectMentionTrigger("@", 1);
+    expect(t).toEqual({ start: 0, end: 1, queryText: "" });
+  });
+
+  it("@ 后键入字符 → 触发，queryText 为前缀", () => {
+    const t = detectMentionTrigger("hello @perc", 11);
+    expect(t).toEqual({ start: 6, end: 11, queryText: "perc" });
+  });
+
+  it("中文标点（如、，；）后 @ → 触发", () => {
+    // "研究、@kb" → 字符索引 0:研 1:究 2:、 3:@ 4:k 5:b（共 6 个 code unit）
+    const t = detectMentionTrigger("研究、@kb", 6);
+    expect(t).toEqual({ start: 3, end: 6, queryText: "kb" });
+  });
+
+  it("全角空格后 @ → 触发", () => {
+    const t = detectMentionTrigger("a　@b", 4);
+    expect(t).toEqual({ start: 2, end: 4, queryText: "b" });
+  });
+
+  it("email 场景（user@example.com）→ 不触发（@ 前为字母）", () => {
+    expect(detectMentionTrigger("user@example.com", 8)).toBeNull();
+  });
+
+  it("@ 后键入空格 → 不再视作 mention 上下文", () => {
+    expect(detectMentionTrigger("@perc ", 6)).toBeNull();
+  });
+
+  it("光标在 @ 之前 → 不触发", () => {
+    expect(detectMentionTrigger("@perc", 0)).toBeNull();
+  });
+
+  it("光标越界 → 不触发", () => {
+    expect(detectMentionTrigger("@perc", 99)).toBeNull();
+  });
+
+  it("@ 前为引号 → 触发（常见于 \"@xxx\"）", () => {
+    const t = detectMentionTrigger('"@kb', 4);
+    expect(t).toEqual({ start: 1, end: 4, queryText: "kb" });
+  });
+
+  it("两个 @ 紧邻 → 回扫到最近的 @", () => {
+    const t = detectMentionTrigger("@@x", 3);
+    // 最近的 @ 是 index=1，但 prev=index=0='@' 不是 leading → null
+    // 这里实际：从 i=2 向左扫，遇到 @ 但 prev 不合法 → null
+    expect(t).toBeNull();
+  });
+
+  it("queryText 含中文字符 → 触发", () => {
+    const t = detectMentionTrigger("@感知", 3);
+    expect(t).toEqual({ start: 0, end: 3, queryText: "感知" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyMention
+// ---------------------------------------------------------------------------
+
+describe("applyMention", () => {
+  it("插入 rawText 并返回 token / 新光标位置", () => {
+    const result = applyMention("hi @perc", { start: 3, end: 8, queryText: "perc" }, {
+      kind: "agent",
+      refId: "PerceptionFaculty",
+      label: "PerceptionFaculty",
+    });
+    expect(result.value).toBe("hi @PerceptionFaculty ");
+    expect(result.caret).toBe("hi @PerceptionFaculty ".length);
+    expect(result.token).toMatchObject({
+      kind: "agent",
+      refId: "PerceptionFaculty",
+      label: "PerceptionFaculty",
+      rawText: "@PerceptionFaculty",
+      start: 3,
+      end: 3 + "@PerceptionFaculty".length,
+    });
+  });
+
+  it("插入后保留 @ 之后被替换之外的尾部文本", () => {
+    const result = applyMention("@p tail", { start: 0, end: 2, queryText: "p" }, {
+      kind: "corpus-retrieve",
+      refId: "uuid-a",
+      label: "Corpus-A",
+    });
+    expect(result.value).toBe("@Corpus-A  tail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileMentions
+// ---------------------------------------------------------------------------
+
+function _mkToken(
+  rawText: string,
+  start: number,
+  overrides: Partial<MentionToken> = {},
+): MentionToken {
+  return {
+    id: `id-${rawText}`,
+    kind: "agent",
+    refId: "ref",
+    label: rawText.replace(/^@/, ""),
+    rawText,
+    start,
+    end: start + rawText.length,
+    ...overrides,
+  };
+}
+
+describe("reconcileMentions", () => {
+  it("内容未变 → 原样返回", () => {
+    const m = [_mkToken("@A", 0)];
+    expect(reconcileMentions("@A x", "@A x", m)).toBe(m);
+  });
+
+  it("mention 之前插入文本 → offset 平移", () => {
+    const m = [_mkToken("@A", 5)];
+    const r = reconcileMentions("hello @A", "hello!! @A", m);
+    expect(r).toHaveLength(1);
+    expect(r[0].start).toBe(8);
+    expect(r[0].end).toBe(10);
+  });
+
+  it("mention 之后删除文本 → offset 不变", () => {
+    const m = [_mkToken("@A", 0)];
+    const r = reconcileMentions("@A xxx", "@A x", m);
+    expect(r[0].start).toBe(0);
+  });
+
+  it("删除穿透 mention 区间 → 丢弃 token", () => {
+    const m = [_mkToken("@LongName", 5)];
+    const r = reconcileMentions("hello @LongName world", "hello @Long world", m);
+    expect(r).toHaveLength(0);
+  });
+
+  it("空 mention 列表 → 直接返回", () => {
+    expect(reconcileMentions("a", "b", [])).toEqual([]);
+  });
+
+  it("重名 mention（同 rawText 出现 2 次）→ 按距离 anchor 最近的位置匹配", () => {
+    const a = _mkToken("@X", 0);
+    const b = _mkToken("@X", 10);
+    const r = reconcileMentions("@X --- @X", "@X --- @X !", [a, b]);
+    expect(r).toHaveLength(2);
+    expect(r[0].start).toBe(0);
+    expect(r[1].start).toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveForwardedPropsFromMentions
+// ---------------------------------------------------------------------------
+
+describe("deriveForwardedPropsFromMentions", () => {
+  it("空数组 → 全部空", () => {
+    expect(deriveForwardedPropsFromMentions([])).toEqual({
+      preferred_subagent: null,
+      scoped_corpus_ids: [],
+      output_corpus_ids: [],
+    });
+  });
+
+  it("多 agent → 取最后一个", () => {
+    const r = deriveForwardedPropsFromMentions([
+      _mkToken("@A", 0, { kind: "agent", refId: "A1" }),
+      _mkToken("@B", 0, { kind: "agent", refId: "B2" }),
+    ]);
+    expect(r.preferred_subagent).toBe("B2");
+  });
+
+  it("scoped + output 各自去重", () => {
+    const r = deriveForwardedPropsFromMentions([
+      _mkToken("@x", 0, { kind: "corpus-retrieve", refId: "u1" }),
+      _mkToken("@y", 0, { kind: "corpus-retrieve", refId: "u1" }),
+      _mkToken("@z", 0, { kind: "corpus-output", refId: "o1" }),
+    ]);
+    expect(r.scoped_corpus_ids).toEqual(["u1"]);
+    expect(r.output_corpus_ids).toEqual(["o1"]);
+  });
+
+  it("validRefIds 过滤孤儿 token", () => {
+    const r = deriveForwardedPropsFromMentions(
+      [
+        _mkToken("@a", 0, { kind: "agent", refId: "Alive" }),
+        _mkToken("@b", 0, { kind: "agent", refId: "Dead" }),
+        _mkToken("@c", 0, { kind: "corpus-retrieve", refId: "stale-uuid" }),
+        _mkToken("@d", 0, { kind: "corpus-output", refId: "valid-uuid" }),
+      ],
+      {
+        agents: new Set(["Alive"]),
+        corpora: new Set(["valid-uuid"]),
+      },
+    );
+    expect(r.preferred_subagent).toBe("Alive");
+    expect(r.scoped_corpus_ids).toEqual([]);
+    expect(r.output_corpus_ids).toEqual(["valid-uuid"]);
+  });
+
+  it("agent + retrieve + output 三类共存", () => {
+    const r = deriveForwardedPropsFromMentions([
+      _mkToken("@a", 0, { kind: "agent", refId: "Pipeline-A" }),
+      _mkToken("@b", 0, { kind: "corpus-retrieve", refId: "kb-1" }),
+      _mkToken("@c", 0, { kind: "corpus-output", refId: "out-1" }),
+    ]);
+    expect(r).toEqual({
+      preferred_subagent: "Pipeline-A",
+      scoped_corpus_ids: ["kb-1"],
+      output_corpus_ids: ["out-1"],
+    });
+  });
+});

--- a/apps/negentropy-ui/tests/unit/utils/run-output.test.ts
+++ b/apps/negentropy-ui/tests/unit/utils/run-output.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { ConversationNode, ConversationTree } from "@/types/a2ui";
+import { extractFinalAssistantText } from "@/utils/run-output";
+
+function _mkNode(
+  overrides: Partial<ConversationNode> & { id: string },
+): ConversationNode {
+  return {
+    type: "text",
+    parentId: null,
+    children: [],
+    threadId: "thread-1",
+    runId: "run-A",
+    timestamp: 0,
+    timeRange: { start: 0, end: 0 },
+    sourceOrder: 0,
+    title: "",
+    visibility: "chat",
+    payload: {},
+    sourceEventTypes: [],
+    relatedMessageIds: [],
+    role: "assistant",
+    ...overrides,
+  } as ConversationNode;
+}
+
+function _mkTree(nodes: ConversationNode[]): ConversationTree {
+  const nodeIndex = new Map<string, ConversationNode>();
+  for (const n of nodes) nodeIndex.set(n.id, n);
+  return {
+    roots: nodes.filter((n) => n.parentId === null),
+    nodeIndex,
+    messageNodeIndex: new Map(),
+    toolNodeIndex: new Map(),
+  };
+}
+
+describe("extractFinalAssistantText", () => {
+  it("无 tree → 返回空串", () => {
+    expect(extractFinalAssistantText(null, "run-A")).toBe("");
+    expect(extractFinalAssistantText(undefined, "run-A")).toBe("");
+  });
+
+  it("无 runId → 返回空串", () => {
+    const tree = _mkTree([_mkNode({ id: "1", payload: { content: "hi" } })]);
+    expect(extractFinalAssistantText(tree, "")).toBe("");
+  });
+
+  it("只挑选 type=text + role=assistant + runId 匹配的节点", () => {
+    const tree = _mkTree([
+      _mkNode({ id: "1", payload: { content: "first" }, sourceOrder: 1 }),
+      _mkNode({
+        id: "2",
+        role: "user",
+        payload: { content: "ignored-user" },
+        sourceOrder: 2,
+      }),
+      _mkNode({
+        id: "3",
+        runId: "run-B",
+        payload: { content: "ignored-other-run" },
+        sourceOrder: 3,
+      }),
+      _mkNode({
+        id: "4",
+        type: "tool-call",
+        payload: { content: "ignored-tool" },
+        sourceOrder: 4,
+      }),
+      _mkNode({ id: "5", payload: { content: "second" }, sourceOrder: 5 }),
+    ]);
+    expect(extractFinalAssistantText(tree, "run-A")).toBe("first\n\nsecond");
+  });
+
+  it("按 sourceOrder 升序拼接", () => {
+    const tree = _mkTree([
+      _mkNode({ id: "1", payload: { content: "B" }, sourceOrder: 20 }),
+      _mkNode({ id: "2", payload: { content: "A" }, sourceOrder: 10 }),
+    ]);
+    expect(extractFinalAssistantText(tree, "run-A")).toBe("A\n\nB");
+  });
+
+  it("过滤空白 content", () => {
+    const tree = _mkTree([
+      _mkNode({ id: "1", payload: { content: "" }, sourceOrder: 1 }),
+      _mkNode({ id: "2", payload: { content: "  " }, sourceOrder: 2 }),
+      _mkNode({ id: "3", payload: { content: "real" }, sourceOrder: 3 }),
+    ]);
+    expect(extractFinalAssistantText(tree, "run-A")).toBe("real");
+  });
+
+  it("payload.content 非字符串 → 跳过", () => {
+    const tree = _mkTree([
+      _mkNode({ id: "1", payload: { content: 42 }, sourceOrder: 1 }),
+      _mkNode({ id: "2", payload: { content: { x: 1 } }, sourceOrder: 2 }),
+      _mkNode({ id: "3", payload: { content: "real" }, sourceOrder: 3 }),
+    ]);
+    expect(extractFinalAssistantText(tree, "run-A")).toBe("real");
+  });
+
+  it("空 tree → 返回空串", () => {
+    expect(extractFinalAssistantText(_mkTree([]), "run-A")).toBe("");
+  });
+});

--- a/apps/negentropy-ui/types/mention.ts
+++ b/apps/negentropy-ui/types/mention.ts
@@ -1,0 +1,42 @@
+/**
+ * Home Composer @ Mention 类型定义。
+ *
+ * 三类 mention 共用同一数据结构，仅以 ``kind`` 字段区分：
+ *
+ * - ``agent`` —— 用户偏好委派的 SubAgent，refId = ``sub_agents.name``；
+ * - ``corpus-retrieve`` —— 本轮 RAG 检索范围，refId = Corpus.id (UUID)；
+ * - ``corpus-output`` —— 输出沉淀目标，refId = Corpus.id (UUID)。
+ *
+ * `inputValue` 仍是 textarea 的唯一事实源（模型会读到 `@xxx` 自然文本），
+ * `MentionToken[]` 仅承担：① UI 高亮（mirror overlay）② forwardedProps 派生。
+ */
+export type MentionKind = "agent" | "corpus-retrieve" | "corpus-output";
+
+export interface MentionToken {
+  /** 前端 UUID，仅用于 React key。 */
+  id: string;
+  /** 三类 mention 之一。 */
+  kind: MentionKind;
+  /** Agent 时为 ``sub_agents.name``；Corpus 时为 UUID。 */
+  refId: string;
+  /** 显示标签（用于弹层与高亮 chip），来自 display_name || name 或 corpus.name。 */
+  label: string;
+  /** 实际插入 textarea 的文本片段，形如 ``"@PerceptionFaculty "`` 或 ``"@kb:Corpus-A "``。 */
+  rawText: string;
+  /** rawText 在 inputValue 中的起始 offset（含 ``@``）。 */
+  start: number;
+  /** rawText 在 inputValue 中的结束 offset（不含尾空格之后）。 */
+  end: number;
+}
+
+/** 候选项（弹层条目）—— Agent 与 Corpus 通用结构。 */
+export interface MentionCandidate {
+  /** Agent 时为 ``sub_agents.name``；Corpus 时为 UUID。 */
+  refId: string;
+  /** 显示标签。 */
+  label: string;
+  /** 副标 / 描述（可选）。 */
+  description?: string;
+  /** 三类之一（区分弹层 Tab）。 */
+  kind: MentionKind;
+}

--- a/apps/negentropy-ui/utils/mention-parser.ts
+++ b/apps/negentropy-ui/utils/mention-parser.ts
@@ -1,0 +1,181 @@
+/**
+ * Home Composer @ Mention 解析工具（纯函数，零副作用，单测覆盖率优先）。
+ *
+ * 职责：
+ * 1. ``detectMentionTrigger`` —— textarea onChange / onSelect 后判断当前光标是否
+ *    处于 ``@`` 触发态，返回 ``trigger.queryText`` 供弹层过滤；
+ * 2. ``applyMention`` —— 用户从弹层选中候选项后，把 ``rawText`` 写入 textarea，
+ *    返回新的 ``value`` 与下一光标位置；
+ * 3. ``reconcileMentions`` —— textarea 内容变更后，对齐 mention 区间的 offset；
+ *    若用户删除穿透了 mention 区间，则丢弃该 token（孤儿 token 清理）。
+ *
+ * 触发规则：``@`` 前必须为行首 / 空白 / 中文标点 / 引号，避免 email
+ * （``user@example.com``）等场景误触发。query 仅允许字母数字 / 中文 / ``-`` / ``_`` /
+ * ``.`` / ``:`` 等，遇到空白即截断（弹层选中后会自动追加尾空格作为闭合）。
+ */
+import type { MentionKind, MentionToken } from "@/types/mention";
+
+/** 触发态描述。 */
+export interface MentionTrigger {
+  /** ``@`` 在 inputValue 中的 offset。 */
+  start: number;
+  /** 当前光标位置（end）—— 已包含正在键入的 query 文本。 */
+  end: number;
+  /** ``@`` 之后的 query 部分（不含 ``@`` 本身）；空串表示刚键入 ``@``。 */
+  queryText: string;
+}
+
+/** ``@`` 前的合法前缀：行首、ASCII/全角空白、中文标点、英文引号等。 */
+const _LEADING_RE = /[\s 　，。；：、（）《》"'`「」『』【】]/;
+/** mention query 允许的字符集（不含空白）：英文数字、中文、常见连字、``:`` 等。 */
+const _QUERY_CHAR_RE = /[\p{L}\p{N}_\-.:]/u;
+
+export function detectMentionTrigger(
+  value: string,
+  caret: number,
+): MentionTrigger | null {
+  if (caret <= 0 || caret > value.length) return null;
+  // 向左回扫找最近的 ``@``；遇到非 query 字符（空白等）则放弃。
+  let i = caret - 1;
+  while (i >= 0) {
+    const ch = value[i];
+    if (ch === "@") {
+      // 验证 ``@`` 前为合法 leading
+      const prev = i === 0 ? "" : value[i - 1];
+      if (prev === "" || _LEADING_RE.test(prev)) {
+        return {
+          start: i,
+          end: caret,
+          queryText: value.slice(i + 1, caret),
+        };
+      }
+      return null;
+    }
+    if (!_QUERY_CHAR_RE.test(ch)) {
+      // 遇到空白或其它分隔符，不在 mention 上下文
+      return null;
+    }
+    i -= 1;
+  }
+  return null;
+}
+
+export interface ApplyMentionResult {
+  value: string;
+  caret: number;
+  token: MentionToken;
+}
+
+/**
+ * 把候选项写入 textarea：替换从 trigger.start 到 trigger.end 的 query 段，
+ * 插入 ``@label `` 闭合，返回新文本、新光标位置与生成的 MentionToken。
+ */
+export function applyMention(
+  value: string,
+  trigger: MentionTrigger,
+  candidate: { kind: MentionKind; refId: string; label: string },
+): ApplyMentionResult {
+  const rawTextNoTrail = `@${candidate.label}`;
+  const rawText = `${rawTextNoTrail} `; // 尾空格作为视觉闭合
+  const next = value.slice(0, trigger.start) + rawText + value.slice(trigger.end);
+  const token: MentionToken = {
+    id:
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    kind: candidate.kind,
+    refId: candidate.refId,
+    label: candidate.label,
+    rawText: rawTextNoTrail,
+    start: trigger.start,
+    end: trigger.start + rawTextNoTrail.length,
+  };
+  return {
+    value: next,
+    caret: trigger.start + rawText.length,
+    token,
+  };
+}
+
+/**
+ * 文本变更后对齐 mention offset：
+ *
+ * - 如果某个 mention 的 ``rawText`` 在 next 中按 offset 平移后仍能精确匹配，
+ *   则更新 start/end；否则视为被编辑/删除，丢弃。
+ * - 通过 diff 计算位移量：找首个差异位置 ``divergeAt`` 与末尾共同长度，反推平移量。
+ *
+ * 设计取舍：不做穿透分支拼接（避免引入操作转换 OT 的复杂度）；mention 区间内
+ * 被编辑即丢弃，简单可靠，符合"软偏好"语义——用户重新选即可。
+ */
+export function reconcileMentions(
+  prev: string,
+  next: string,
+  mentions: MentionToken[],
+): MentionToken[] {
+  if (mentions.length === 0) return mentions;
+  if (prev === next) return mentions;
+
+  const survivors: MentionToken[] = [];
+  for (const m of mentions) {
+    // 在 next 中按相同顺序寻找 rawText —— 单次出现优先，多次出现按距离 start 最近的匹配。
+    const idx = _nearestIndexOf(next, m.rawText, m.start);
+    if (idx < 0) continue; // 已被编辑/删除
+    survivors.push({ ...m, start: idx, end: idx + m.rawText.length });
+  }
+  return survivors;
+}
+
+function _nearestIndexOf(s: string, needle: string, anchor: number): number {
+  if (!needle) return -1;
+  // 从 anchor 附近向两侧扩散搜索，避免重名 mention 错位
+  const left = s.lastIndexOf(needle, anchor);
+  const right = s.indexOf(needle, anchor);
+  if (left < 0 && right < 0) return -1;
+  if (left < 0) return right;
+  if (right < 0) return left;
+  return anchor - left <= right - anchor ? left : right;
+}
+
+/**
+ * 从 mention 列表派生 forwardedProps 的三个字段。
+ *
+ * - ``preferred_subagent``：取最后一个 ``agent`` mention（多选时后者覆盖）；
+ * - ``scoped_corpus_ids``：所有 ``corpus-retrieve`` mention 的 refId，去重；
+ * - ``output_corpus_ids``：所有 ``corpus-output`` mention 的 refId，去重。
+ *
+ * 调用方可选地传 ``validRefIds`` 用于过滤孤儿 token（如 Corpus 已被删除）。
+ */
+export interface DerivedMentionProps {
+  preferred_subagent: string | null;
+  scoped_corpus_ids: string[];
+  output_corpus_ids: string[];
+}
+
+export function deriveForwardedPropsFromMentions(
+  mentions: MentionToken[],
+  validRefIds?: {
+    agents?: ReadonlySet<string>;
+    corpora?: ReadonlySet<string>;
+  },
+): DerivedMentionProps {
+  let preferred: string | null = null;
+  const scoped: string[] = [];
+  const output: string[] = [];
+  for (const m of mentions) {
+    if (m.kind === "agent") {
+      if (validRefIds?.agents && !validRefIds.agents.has(m.refId)) continue;
+      preferred = m.refId;
+    } else if (m.kind === "corpus-retrieve") {
+      if (validRefIds?.corpora && !validRefIds.corpora.has(m.refId)) continue;
+      scoped.push(m.refId);
+    } else if (m.kind === "corpus-output") {
+      if (validRefIds?.corpora && !validRefIds.corpora.has(m.refId)) continue;
+      output.push(m.refId);
+    }
+  }
+  return {
+    preferred_subagent: preferred,
+    scoped_corpus_ids: Array.from(new Set(scoped)),
+    output_corpus_ids: Array.from(new Set(output)),
+  };
+}

--- a/apps/negentropy-ui/utils/run-output.ts
+++ b/apps/negentropy-ui/utils/run-output.ts
@@ -1,0 +1,40 @@
+/**
+ * 从 ConversationTree 中提取某次 run 的 assistant 最终回答文本。
+ *
+ * 业务用途：Home Composer 通过 ``@Corpus`` 标记输出沉淀目标后，
+ * 在 RUN_FINISHED 事件触发时由此函数取回本轮助手回答，作为新 Document
+ * 摄入到目标 Corpus（``ingestText``）。
+ *
+ * 实现要点：
+ * - 只挑选 ``type === "text" && role === "assistant" && runId === target``；
+ * - 按 ``sourceOrder`` 升序拼接 ``payload.content``（与 ChatStream 渲染顺序一致）；
+ * - 不递归 tree.roots —— 直接遍历 ``nodeIndex`` Map 即可（已是扁平索引）。
+ */
+import type { ConversationNode, ConversationTree } from "@/types/a2ui";
+
+export function extractFinalAssistantText(
+  tree: ConversationTree | null | undefined,
+  runId: string,
+): string {
+  if (!tree || !runId) return "";
+  const nodes: ConversationNode[] = [];
+  for (const node of tree.nodeIndex.values()) {
+    if (
+      node.type === "text" &&
+      node.role === "assistant" &&
+      node.runId === runId
+    ) {
+      nodes.push(node);
+    }
+  }
+  nodes.sort((a, b) => a.sourceOrder - b.sourceOrder);
+  const parts: string[] = [];
+  for (const node of nodes) {
+    const content = node.payload?.content;
+    if (typeof content === "string" && content.trim().length > 0) {
+      parts.push(content);
+    }
+  }
+  // 多段 streaming text 之间用单空行衔接，与 Markdown 段落语义一致。
+  return parts.join("\n\n").trim();
+}

--- a/apps/negentropy/src/negentropy/agents/_dynamic_instruction.py
+++ b/apps/negentropy/src/negentropy/agents/_dynamic_instruction.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Awaitable, Callable
 
 from google.adk.agents.readonly_context import ReadonlyContext
@@ -23,8 +24,36 @@ _logger = get_logger("negentropy.agents.dynamic_instruction")
 InstructionProvider = Callable[[ReadonlyContext], Awaitable[str]]
 
 
+_PREFERENCE_KEY = "preferred_subagent"
+_PREFERENCE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\-]{0,127}$")
+
+
+_PREFERENCE_PREFIX_TEMPLATE = """## 用户偏好 (User Preference - 本轮 turn)
+用户在本轮明确指定希望由 `{name}` 处理本次请求。
+在意图允许的前提下，**优先**使用 `transfer_to_agent(agent_name="{name}", ...)` 委派。
+若你判断该 SubAgent 不适合处理本请求（如能力不匹配），仍可按「调度之道」自主选择，
+但需在最终回答中向用户**简述偏离原因**。
+
+"""
+
+
+def _render_preference_prefix(preferred: str) -> str:
+    """渲染「用户偏好」prefix；与正文之间留一个空行分隔。
+
+    用户在 Home Composer 通过 ``@Agent`` 选中某 SubAgent 后，前端将其 ``name`` 经
+    ``forwardedProps.preferred_subagent`` → BFF ``state_delta`` → ADK session.state
+    透传到根 Agent 的 ReadonlyContext。本 prefix 仅是「软偏好」—— 若 root 判断不
+    匹配仍可自主选择，但需向用户简述偏离原因，避免静默忽略用户意图。
+    """
+    return _PREFERENCE_PREFIX_TEMPLATE.format(name=preferred)
+
+
 def make_instruction_provider(agent_name: str, fallback: str) -> InstructionProvider:
     """构造 ADK InstructionProvider：DB 命中即用，未命中 / 失败回退到 ``fallback``。
+
+    扩展：当 ``ctx.state`` 含 ``preferred_subagent``（用户 @ Agent 偏好）时，
+    在 instruction 头部 prepend 「用户偏好」段落（仅本 turn 生效，state 由 ADK
+    按 turn 派发）。Agent 名仅做轻量正则校验，避免脏数据破坏 prompt。
 
     Args:
         agent_name: ``sub_agents.name``，用于 DB 查询；与 ADK Agent.name 一致。
@@ -34,7 +63,7 @@ def make_instruction_provider(agent_name: str, fallback: str) -> InstructionProv
         Async callable，签名符合 ADK 的 ``InstructionProvider`` 类型约束。
     """
 
-    async def _provider(_ctx: ReadonlyContext) -> str:
+    async def _provider(ctx: ReadonlyContext) -> str:
         try:
             text = await resolve_subagent_instruction(agent_name)
         except Exception:
@@ -43,7 +72,19 @@ def make_instruction_provider(agent_name: str, fallback: str) -> InstructionProv
                 agent_name=agent_name,
                 exc_info=True,
             )
-            return fallback
-        return text or fallback
+            text = None
+        base = text or fallback
+
+        # 仅 root_agent 消费 preferred_subagent；其它 SubAgent 共用同一 provider 也
+        # 不会被误注入，因为状态键由前端在选中 root 路由场景才设置；这里仍做防御性
+        # 校验：非法 / 空 / 异常类型一律忽略，永不阻塞主流程。
+        try:
+            state = getattr(ctx, "state", None)
+            preferred = state.get(_PREFERENCE_KEY) if state is not None else None
+        except Exception:
+            preferred = None
+        if isinstance(preferred, str) and _PREFERENCE_NAME_RE.match(preferred):
+            return _render_preference_prefix(preferred) + base
+        return base
 
     return _provider

--- a/apps/negentropy/src/negentropy/agents/_dynamic_instruction.py
+++ b/apps/negentropy/src/negentropy/agents/_dynamic_instruction.py
@@ -48,16 +48,26 @@ def _render_preference_prefix(preferred: str) -> str:
     return _PREFERENCE_PREFIX_TEMPLATE.format(name=preferred)
 
 
-def make_instruction_provider(agent_name: str, fallback: str) -> InstructionProvider:
+def make_instruction_provider(
+    agent_name: str,
+    fallback: str,
+    *,
+    is_root: bool = False,
+) -> InstructionProvider:
     """构造 ADK InstructionProvider：DB 命中即用，未命中 / 失败回退到 ``fallback``。
 
-    扩展：当 ``ctx.state`` 含 ``preferred_subagent``（用户 @ Agent 偏好）时，
-    在 instruction 头部 prepend 「用户偏好」段落（仅本 turn 生效，state 由 ADK
-    按 turn 派发）。Agent 名仅做轻量正则校验，避免脏数据破坏 prompt。
+    扩展：当 ``is_root=True`` 且 ``ctx.state`` 含 ``preferred_subagent``（用户
+    @ Agent 偏好）时，在 instruction 头部 prepend 「用户偏好」段落（仅本 turn
+    生效，state 由 ADK 按 turn 派发）。Agent 名仅做轻量正则校验，避免脏数据
+    破坏 prompt。
 
     Args:
         agent_name: ``sub_agents.name``，用于 DB 查询；与 ADK Agent.name 一致。
         fallback: 代码硬编码 instruction 文本，DB 未命中 / 异常时使用。
+        is_root: 是否为根 Agent（``NegentropyEngine``）。仅根 Agent 消费
+            ``preferred_subagent`` —— 它负责调度 SubAgent；其它 faculty 即使读到
+            同一 ``session.state`` 也不应被自指令（``transfer_to_agent(self)``）
+            或跨派系委派提示污染。
 
     Returns:
         Async callable，签名符合 ADK 的 ``InstructionProvider`` 类型约束。
@@ -75,9 +85,11 @@ def make_instruction_provider(agent_name: str, fallback: str) -> InstructionProv
             text = None
         base = text or fallback
 
-        # 仅 root_agent 消费 preferred_subagent；其它 SubAgent 共用同一 provider 也
-        # 不会被误注入，因为状态键由前端在选中 root 路由场景才设置；这里仍做防御性
-        # 校验：非法 / 空 / 异常类型一律忽略，永不阻塞主流程。
+        # 非 root 一律走原路径——避免 faculty 共用 provider 时被偏好 prefix 污染。
+        if not is_root:
+            return base
+
+        # 防御性校验：非法 / 空 / 异常类型一律忽略，永不阻塞主流程。
         try:
             state = getattr(ctx, "state", None)
             preferred = state.get(_PREFERENCE_KEY) if state is not None else None

--- a/apps/negentropy/src/negentropy/agents/agent.py
+++ b/apps/negentropy/src/negentropy/agents/agent.py
@@ -138,7 +138,8 @@ root_agent = LlmAgent(
     description="熵减系统的「本我」，通过协调五大系部的能力，持续实现自我进化。",
     # Instruction 由 sub_agents.system_prompt 经 InstructionProvider 在运行时解析；
     # DB 未命中或失败时回退到 _ROOT_INSTRUCTION 常量，永不阻塞请求。
-    instruction=make_instruction_provider("NegentropyEngine", _ROOT_INSTRUCTION),
+    # is_root=True：仅根 Agent 消费 Home Composer 的 @Agent 偏好（preferred_subagent）。
+    instruction=make_instruction_provider("NegentropyEngine", _ROOT_INSTRUCTION, is_root=True),
     tools=[log_activity],
     sub_agents=[
         perception_agent,

--- a/apps/negentropy/src/negentropy/agents/tools/perception.py
+++ b/apps/negentropy/src/negentropy/agents/tools/perception.py
@@ -238,6 +238,15 @@ async def search_knowledge_base(
         return {"status": "failed", "error": "top_k must be positive"}
     limit = min(top_k, _MAX_RESULTS_LIMIT)
 
+    # 用户 @ Corpus 检索范围（来自 Home Composer 的 forwardedProps.scoped_corpus_ids
+    # → BFF state_delta → ADK session.state → tool_context.state）。命中时仅在指定
+    # 语料库内检索；未命中则保持原"全 Corpus 聚合"行为。
+    scoped_ids: list[str] | None = None
+    if tool_context is not None and getattr(tool_context, "state", None):
+        raw_scope = tool_context.state.get("scoped_corpus_ids")
+        if isinstance(raw_scope, list) and raw_scope:
+            scoped_ids = [s for s in raw_scope if isinstance(s, str) and s]
+
     logger.info(
         "knowledge_search_started",
         query=query[:100],
@@ -245,17 +254,24 @@ async def search_knowledge_base(
         limit=limit,
         semantic_weight=semantic_weight,
         keyword_weight=keyword_weight,
+        scoped_corpus_ids=scoped_ids,
     )
 
     try:
-        # 获取所有可用的语料库
+        # 获取所有可用的语料库（按 scoped_ids 限定）
         async with db_session.AsyncSessionLocal() as db:
             stmt = select(Corpus).where(Corpus.app_name == settings.app_name)
+            if scoped_ids:
+                stmt = stmt.where(Corpus.id.in_(scoped_ids))
             result = await db.execute(stmt)
             corpora = result.scalars().all()
 
         if not corpora:
-            logger.warning("no_corpora_found", app_name=settings.app_name)
+            logger.warning(
+                "no_corpora_found",
+                app_name=settings.app_name,
+                scoped_corpus_ids=scoped_ids,
+            )
             return await _fallback_to_memory_search(query, limit, tool_context)
 
         # 使用混合检索从所有语料库中搜索

--- a/apps/negentropy/tests/unit_tests/agents/test_dynamic_instruction_preference.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_dynamic_instruction_preference.py
@@ -4,9 +4,10 @@
 ``forwardedProps.preferred_subagent`` → BFF ``state_delta`` → ADK session.state
 透传到根 Agent 的 ``ReadonlyContext``。本测试覆盖：
 
-- 命中 → instruction 头部 prepend「用户偏好」段落（Agent 名嵌入正文）；
+- ``is_root=True`` + 命中 → instruction 头部 prepend「用户偏好」段落（Agent 名嵌入正文）；
+- ``is_root=False``（默认；faculty 共用 provider）→ 永不注入，避免自指令/跨派系污染；
 - 未命中 / 非法 / 异常 → 返回原始 instruction，永不破坏 fallback；
-- DB 解析异常 → 走 fallback 仍能注入 prefix。
+- DB 解析异常 → 走 fallback 仍能注入 prefix（仅 root 路径）。
 """
 
 from __future__ import annotations
@@ -27,13 +28,13 @@ def _ctx_with_state(state: dict | None) -> MagicMock:
 
 
 # ----------------------------------------------------------------------------
-# 命中：注入 prefix
+# 命中：仅 is_root=True 时注入 prefix
 # ----------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_preferred_subagent_prepends_prefix_when_db_returns_text():
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(return_value="DB_INSTRUCTION_BODY"),
@@ -50,7 +51,7 @@ async def test_preferred_subagent_prepends_prefix_when_db_returns_text():
 @pytest.mark.asyncio
 async def test_preferred_subagent_prepends_prefix_on_fallback_path():
     """DB 解析失败 → fallback；prefix 仍然注入（用户偏好高于 instruction 来源）。"""
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(side_effect=RuntimeError("db down")),
@@ -65,7 +66,7 @@ async def test_preferred_subagent_prepends_prefix_on_fallback_path():
 @pytest.mark.asyncio
 async def test_preferred_subagent_prepends_prefix_when_db_returns_empty():
     """DB 返回空串 → 走 fallback；prefix 注入。"""
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(return_value=""),
@@ -77,13 +78,61 @@ async def test_preferred_subagent_prepends_prefix_when_db_returns_empty():
 
 
 # ----------------------------------------------------------------------------
+# 非 root：永不注入 prefix（防止 faculty 共用 provider 被污染）
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "agent_name",
+    [
+        "PerceptionFaculty",
+        "ActionFaculty",
+        "ContemplationFaculty",
+        "InternalizationFaculty",
+        "InfluenceFaculty",
+    ],
+)
+@pytest.mark.asyncio
+async def test_non_root_faculty_never_injects_prefix(agent_name):
+    """faculty 共用同一 provider 工厂；is_root 默认为 False，``preferred_subagent``
+    即使在 state 命中也不应污染 faculty instruction，避免：
+    - 自指令（faculty 自己被命中 → ``transfer_to_agent(self)`` 死循环风险）；
+    - 跨派系委派提示（其它 faculty 读到要求委派给另一 faculty 的指令）。
+    """
+    provider = make_instruction_provider(agent_name, _FALLBACK)  # is_root 默认 False
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value=f"{agent_name}_DB_BODY"),
+    ):
+        result = await provider(_ctx_with_state({"preferred_subagent": "PerceptionFaculty"}))
+
+    assert result == f"{agent_name}_DB_BODY"
+    assert "用户偏好" not in result
+
+
+@pytest.mark.asyncio
+async def test_is_root_false_explicit_skips_prefix_even_with_root_name():
+    """显式 ``is_root=False``，即便 ``agent_name`` 是 root 名也不注入。
+    确保参数语义可控（不会因 agent_name 巧合命中而隐式启用偏好）。"""
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=False)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value="ROOT_DB_BODY"),
+    ):
+        result = await provider(_ctx_with_state({"preferred_subagent": "ActionFaculty"}))
+
+    assert result == "ROOT_DB_BODY"
+    assert "用户偏好" not in result
+
+
+# ----------------------------------------------------------------------------
 # 未命中：保持原 instruction
 # ----------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_no_preferred_subagent_returns_instruction_as_is():
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(return_value="DB_BODY"),
@@ -96,7 +145,7 @@ async def test_no_preferred_subagent_returns_instruction_as_is():
 
 @pytest.mark.asyncio
 async def test_state_is_none_returns_instruction_as_is():
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(return_value=None),
@@ -131,7 +180,7 @@ async def test_state_is_none_returns_instruction_as_is():
 )
 @pytest.mark.asyncio
 async def test_invalid_preferred_subagent_ignored(preferred):
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(return_value="DB_BODY"),
@@ -150,7 +199,7 @@ async def test_state_get_raises_does_not_break_provider():
     ctx = MagicMock()
     ctx.state = bad_state
 
-    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK, is_root=True)
     with patch(
         "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
         new=AsyncMock(return_value="DB_BODY"),

--- a/apps/negentropy/tests/unit_tests/agents/test_dynamic_instruction_preference.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_dynamic_instruction_preference.py
@@ -1,0 +1,160 @@
+"""单测：``make_instruction_provider`` 注入 ``preferred_subagent`` prefix。
+
+业务背景：Home Composer 通过 ``@Agent`` 选中某 SubAgent 后，前端将其 ``name`` 经
+``forwardedProps.preferred_subagent`` → BFF ``state_delta`` → ADK session.state
+透传到根 Agent 的 ``ReadonlyContext``。本测试覆盖：
+
+- 命中 → instruction 头部 prepend「用户偏好」段落（Agent 名嵌入正文）；
+- 未命中 / 非法 / 异常 → 返回原始 instruction，永不破坏 fallback；
+- DB 解析异常 → 走 fallback 仍能注入 prefix。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from negentropy.agents._dynamic_instruction import make_instruction_provider
+
+_FALLBACK = "FALLBACK_INSTRUCTION_BODY"
+
+
+def _ctx_with_state(state: dict | None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.state = state
+    return ctx
+
+
+# ----------------------------------------------------------------------------
+# 命中：注入 prefix
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preferred_subagent_prepends_prefix_when_db_returns_text():
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value="DB_INSTRUCTION_BODY"),
+    ):
+        result = await provider(_ctx_with_state({"preferred_subagent": "PerceptionFaculty"}))
+
+    assert result.startswith("## 用户偏好")
+    assert "`PerceptionFaculty`" in result
+    assert 'agent_name="PerceptionFaculty"' in result
+    # 正文不丢
+    assert result.endswith("DB_INSTRUCTION_BODY")
+
+
+@pytest.mark.asyncio
+async def test_preferred_subagent_prepends_prefix_on_fallback_path():
+    """DB 解析失败 → fallback；prefix 仍然注入（用户偏好高于 instruction 来源）。"""
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        result = await provider(_ctx_with_state({"preferred_subagent": "ActionFaculty"}))
+
+    assert result.startswith("## 用户偏好")
+    assert "`ActionFaculty`" in result
+    assert result.endswith(_FALLBACK)
+
+
+@pytest.mark.asyncio
+async def test_preferred_subagent_prepends_prefix_when_db_returns_empty():
+    """DB 返回空串 → 走 fallback；prefix 注入。"""
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value=""),
+    ):
+        result = await provider(_ctx_with_state({"preferred_subagent": "InfluenceFaculty"}))
+
+    assert result.startswith("## 用户偏好")
+    assert result.endswith(_FALLBACK)
+
+
+# ----------------------------------------------------------------------------
+# 未命中：保持原 instruction
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_preferred_subagent_returns_instruction_as_is():
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value="DB_BODY"),
+    ):
+        result = await provider(_ctx_with_state({}))
+
+    assert result == "DB_BODY"
+    assert "用户偏好" not in result
+
+
+@pytest.mark.asyncio
+async def test_state_is_none_returns_instruction_as_is():
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await provider(_ctx_with_state(None))
+
+    assert result == _FALLBACK
+    assert "用户偏好" not in result
+
+
+# ----------------------------------------------------------------------------
+# 非法字符 / 异常类型：防御性忽略
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "preferred",
+    [
+        "",  # 空串
+        "  ",  # 仅空白
+        "PerceptionFaculty; DROP TABLE users",  # SQL 注入风格
+        "Perception Faculty",  # 含空格
+        "@PerceptionFaculty",  # 含 @
+        "../../etc/passwd",  # 路径穿越风格
+        "<script>alert(1)</script>",
+        "数据采集系部",  # 非 ASCII（当前正则只允许 ASCII 标识符；按设计拒绝）
+        "X" * 200,  # 超长（>128）
+        123,  # 非字符串
+        ["PerceptionFaculty"],  # 非字符串
+        None,  # None
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_preferred_subagent_ignored(preferred):
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value="DB_BODY"),
+    ):
+        result = await provider(_ctx_with_state({"preferred_subagent": preferred}))
+
+    assert result == "DB_BODY"
+    assert "用户偏好" not in result
+
+
+@pytest.mark.asyncio
+async def test_state_get_raises_does_not_break_provider():
+    """state.get 抛异常 → 仍能返回 instruction（fail-soft）。"""
+    bad_state = MagicMock()
+    bad_state.get = MagicMock(side_effect=RuntimeError("bad state"))
+    ctx = MagicMock()
+    ctx.state = bad_state
+
+    provider = make_instruction_provider("NegentropyEngine", _FALLBACK)
+    with patch(
+        "negentropy.agents._dynamic_instruction.resolve_subagent_instruction",
+        new=AsyncMock(return_value="DB_BODY"),
+    ):
+        result = await provider(ctx)
+
+    assert result == "DB_BODY"

--- a/apps/negentropy/tests/unit_tests/agents/test_search_knowledge_base_scope.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_search_knowledge_base_scope.py
@@ -1,0 +1,223 @@
+"""单测：``search_knowledge_base`` 按 ``tool_context.state.scoped_corpus_ids`` 限定检索范围。
+
+业务背景：Home Composer 通过 ``@Corpus`` 选中若干语料库后，前端将其 UUID 列表
+经 ``forwardedProps.scoped_corpus_ids`` → BFF ``state_delta`` → ADK session.state
+透传到 perception tool。命中时，``Corpus`` 查询追加 ``id IN (...)`` 过滤，仅在
+指定语料库内检索；未命中时保持原"全 Corpus 聚合"行为。
+
+不连真实 DB / 不实际启动 KnowledgeService —— mock 边界即可。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+def _make_corpus(corpus_id: str, name: str) -> MagicMock:
+    c = MagicMock()
+    c.id = corpus_id
+    c.name = name
+    return c
+
+
+def _make_session_cm(corpora: list[MagicMock]) -> tuple[MagicMock, MagicMock]:
+    """构造 ``AsyncSessionLocal()`` 返回的上下文管理器；返回 (cm, session) 以便断言。"""
+    fake_session = MagicMock()
+    fake_session.execute = AsyncMock(return_value=MagicMock(scalars=lambda: MagicMock(all=lambda: corpora)))
+    fake_cm = MagicMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_cm.__aexit__ = AsyncMock(return_value=False)
+    return fake_cm, fake_session
+
+
+def _make_match(corpus_id: str) -> MagicMock:
+    m = MagicMock(
+        id=f"k-{corpus_id[:4]}",
+        content="snippet",
+        source_uri=f"file://{corpus_id}",
+        metadata={"title": "T"},
+        semantic_score=0.5,
+        keyword_score=0.5,
+        combined_score=0.5,
+    )
+    return m
+
+
+# ----------------------------------------------------------------------------
+# scoped_corpus_ids 命中：仅在 IN 子集内检索
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scoped_corpus_ids_appends_in_clause_and_limits_search():
+    """state.scoped_corpus_ids = [uuid_a] → SQL 含 IN (uuid_a)，service.search 仅调用一次。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    uuid_a, uuid_b = str(uuid4()), str(uuid4())
+    # 模拟 DB 已过滤为 1 个（uuid_a），uuid_b 不在结果中
+    corpus_a = _make_corpus(uuid_a, "Corpus-A")
+    cm, session = _make_session_cm([corpus_a])
+
+    fake_service = MagicMock()
+    fake_service.search = AsyncMock(return_value=[_make_match(uuid_a)])
+
+    ctx = MagicMock()
+    ctx.state = {"scoped_corpus_ids": [uuid_a]}
+
+    with (
+        patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=cm),
+        patch.object(perception_module, "_get_knowledge_service", return_value=fake_service),
+    ):
+        result = await perception_module.search_knowledge_base(query="entropy", top_k=5, tool_context=ctx)
+
+    # SQL 含 IN 子句（避免误退化为无 scope 的全 corpus 查询）
+    stmt_str = str(session.execute.call_args.args[0]).lower()
+    assert " in (" in stmt_str
+
+    # service.search 只在过滤后的单个 corpus 上调用
+    assert fake_service.search.call_count == 1
+    called_corpus_id = fake_service.search.call_args.kwargs["corpus_id"]
+    assert called_corpus_id == uuid_a
+
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    # uuid_b 不出现在结果中
+    assert all(uuid_b not in r["source_uri"] for r in result["results"])
+
+
+# ----------------------------------------------------------------------------
+# scoped_corpus_ids 未命中：保持原"全 Corpus 聚合"行为
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_scope_falls_back_to_aggregate_search_across_all_corpora():
+    """state 不含 scoped_corpus_ids → SQL 不含 IN 子句，service.search 对每个 corpus 各调一次。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    uuid_a, uuid_b = str(uuid4()), str(uuid4())
+    corpora = [_make_corpus(uuid_a, "A"), _make_corpus(uuid_b, "B")]
+    cm, session = _make_session_cm(corpora)
+
+    fake_service = MagicMock()
+    fake_service.search = AsyncMock(side_effect=lambda **kw: [_make_match(str(kw["corpus_id"]))])
+
+    ctx = MagicMock()
+    ctx.state = {}  # 无 scoped_corpus_ids
+
+    with (
+        patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=cm),
+        patch.object(perception_module, "_get_knowledge_service", return_value=fake_service),
+    ):
+        result = await perception_module.search_knowledge_base(query="entropy", top_k=5, tool_context=ctx)
+
+    stmt_str = str(session.execute.call_args.args[0]).lower()
+    assert " in (" not in stmt_str  # 无 scope 时不追加 IN 子句
+
+    assert fake_service.search.call_count == 2
+    assert result["status"] == "success"
+    assert result["count"] == 2
+
+
+# ----------------------------------------------------------------------------
+# 非法/空 scope 防御性处理
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_list_treated_as_no_scope():
+    """state.scoped_corpus_ids = [] → 视作未指定，不追加 IN 子句。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    uuid_a = str(uuid4())
+    cm, session = _make_session_cm([_make_corpus(uuid_a, "A")])
+    fake_service = MagicMock()
+    fake_service.search = AsyncMock(return_value=[_make_match(uuid_a)])
+
+    ctx = MagicMock()
+    ctx.state = {"scoped_corpus_ids": []}
+
+    with (
+        patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=cm),
+        patch.object(perception_module, "_get_knowledge_service", return_value=fake_service),
+    ):
+        await perception_module.search_knowledge_base(query="q", top_k=3, tool_context=ctx)
+
+    stmt_str = str(session.execute.call_args.args[0]).lower()
+    assert " in (" not in stmt_str
+
+
+@pytest.mark.asyncio
+async def test_scope_with_non_string_entries_filtered_out():
+    """state.scoped_corpus_ids 含 None/int 等异类条目 → 过滤后若仍非空仍走 IN。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    uuid_a = str(uuid4())
+    cm, session = _make_session_cm([_make_corpus(uuid_a, "A")])
+    fake_service = MagicMock()
+    fake_service.search = AsyncMock(return_value=[_make_match(uuid_a)])
+
+    ctx = MagicMock()
+    ctx.state = {"scoped_corpus_ids": [uuid_a, None, 123, ""]}
+
+    with (
+        patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=cm),
+        patch.object(perception_module, "_get_knowledge_service", return_value=fake_service),
+    ):
+        await perception_module.search_knowledge_base(query="q", top_k=3, tool_context=ctx)
+
+    stmt_str = str(session.execute.call_args.args[0]).lower()
+    assert " in (" in stmt_str  # 仍有合法条目 uuid_a，应追加 IN
+
+
+@pytest.mark.asyncio
+async def test_scope_hits_nonexistent_corpus_returns_memory_fallback():
+    """scope 指向不存在的 corpus → DB 返回空 → 走 memory fallback（与 no_corpora 同路径）。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    cm, _ = _make_session_cm([])  # DB 过滤后为空
+
+    ctx = MagicMock()
+    ctx.state = {"scoped_corpus_ids": [str(uuid4())]}
+    # search_memory 缺席 → fallback 返回 count=0
+    if hasattr(ctx, "search_memory"):
+        del ctx.search_memory
+
+    with patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=cm):
+        result = await perception_module.search_knowledge_base(query="q", top_k=3, tool_context=ctx)
+
+    # 不抛异常，降级到 memory_fallback
+    assert result["status"] == "success"
+    assert result["search_mode"] == "memory_fallback"
+
+
+# ----------------------------------------------------------------------------
+# tool_context 缺失 / state 为 None：防御性兜底
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_context_without_state_does_not_raise():
+    """tool_context.state 为 None / 缺失 → 视作未指定 scope，不抛异常。"""
+    from negentropy.agents.tools import perception as perception_module
+
+    uuid_a = str(uuid4())
+    cm, session = _make_session_cm([_make_corpus(uuid_a, "A")])
+    fake_service = MagicMock()
+    fake_service.search = AsyncMock(return_value=[_make_match(uuid_a)])
+
+    ctx = MagicMock()
+    ctx.state = None
+
+    with (
+        patch.object(perception_module.db_session, "AsyncSessionLocal", return_value=cm),
+        patch.object(perception_module, "_get_knowledge_service", return_value=fake_service),
+    ):
+        result = await perception_module.search_knowledge_base(query="q", top_k=3, tool_context=ctx)
+
+    stmt_str = str(session.execute.call_args.args[0]).lower()
+    assert " in (" not in stmt_str
+    assert result["status"] == "success"


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Home 对话框仅支持发送纯文本，所有消息固定路由到 NegentropyEngine，由 root 主动委派；用户无法直接指定 SubAgent、限定本轮 RAG 检索范围，或将助手回答沉淀回指定 Corpus。
- 关联上下文/Issue/文档：plan 文件 `/Users/cm.huang/.claude/plans/system-instruction-you-are-working-steady-reddy.md`

# 核心变更
- **后端**：`perception.search_knowledge_base` 读取 `tool_context.state.scoped_corpus_ids`，命中时仅在指定语料库内检索；`_dynamic_instruction.make_instruction_provider` 在 instruction 头部注入「用户偏好 (User Preference)」prefix，让 root_agent 在 `transfer_to_agent` 时优先委派给 @Agent 指定的 SubAgent。
- **BFF**：`buildStateDeltaFromForwardedProps` 扩展 3 个新字段（preferred_subagent / scoped_corpus_ids / output_corpus_ids），含 UUID + 长度 + 去重 + 上限校验，复用现成 `forwardedProps → state_delta → tool_context.state` 通道。
- **前端**：新增 `MentionPopover`（Portal + 3 Tab + 键盘导航）+ `MentionChipList`（按 kind 着色的删除芯片）；`Composer` 新增可选 mention props（向后兼容）；`home-body.tsx` 接入 `useSubAgentsList` / `useCorporaList`，`doSend` 通过 `deriveForwardedPropsFromMentions` 派生 forwardedProps，`RUN_FINISHED` 钩子按 `output_corpus_ids` 并发调 `ingestText` 沉淀到目标 Corpus。
- **关键修正**：ag-ui 客户端 `AbstractAgent.prepareRunAgentInput` 只读 runAgent 参数中的 forwardedProps，实例属性赋值无效——必须改为 `runAgent({forwardedProps, runId})` 透传。

# 风险与回滚
- 主要风险：(1) ag-ui forwardedProps 传递方式变更可能影响其他 turn 字段（已通过保留实例属性兜底缓解）；(2) `RUN_FINISHED` 后 200ms 延迟读 conversationTree 在极端 streaming 场景可能取不到最后一段（已 toast.warning 兜底，不阻塞主流）；(3) `useCorporaList` / `useSubAgentsList` 防御性兜底改为 `Array.isArray` 后非数组响应返回 `[]`。
- 回滚方式：直接 revert 两个 commit（`f0f682a8` 后端+BFF / `7f45eaea` 前端 UI）即可；mention 字段在 BFF 层做白名单透传，未携带时 state_delta 不写入对应 key，后端 perception / instruction 自然走原路径。

# 验证证据
- **单元测试**：后端新增 24 个测试（`test_search_knowledge_base_scope.py` × 6 / `test_dynamic_instruction_preference.py` × 18），全部通过；BFF `agui-route-state.test.ts` 扩展至 14 个测试。
- **集成测试**：前端 `home-flow.test.tsx` 10 个集成测试全部通过；全套 706 项 vitest 单测零回归。
- **E2E/Workflow**：浏览器实机回归（mcp__chrome_devtools）—— 键入 `@` 触发弹层、3 Tab 切换、点击候选项写入 textarea + 派生 mention chip；拦截 `/api/agui` POST body 验证 `forwardedProps.scoped_corpus_ids` 与 `output_corpus_ids` 均为合法 UUID 数组。
- **覆盖率/关键截图**：50 个新增前端单测（24 parser + 7 run-output + 13 popover + 6 composer）+ 38 个新增后端/BFF 单测。

# 影响范围
- 前端：`apps/negentropy-ui/components/ui/{Composer,MentionPopover,MentionChipList}.tsx`、`app/home-body.tsx`、`app/api/agui/route.ts`、`hooks/useSubAgentsList.ts`、`utils/{mention-parser,run-output}.ts`、`types/mention.ts`。
- 后端：`apps/negentropy/src/negentropy/agents/{_dynamic_instruction,tools/perception}.py`；不涉及 DB 迁移、API schema 变更。
- GitHub Actions / 文档：本 PR 不涉及 CI 配置变更；implementation plan 已留档至 `.claude/plans/`。

# Next Best Action
- 待用户在真实账号下创建一两个可见 SubAgent（当前用户库中均属其他 owner 被过滤）后，按 plan 第 5 节脚本完成 `@Agent` 路由偏好的端到端验证；后续可演进至「方案 B」—— 由 InfluenceFaculty 自动沉淀输出，替代当前前端 RUN_FINISHED 钩子。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>