### PR TITLE
feat(wiki-kg): Wiki 站点按 Publication 切片发布与浏览知识图谱

### DIFF
--- a/apps/negentropy-wiki/package.json
+++ b/apps/negentropy-wiki/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "github-slugger": "^2.0.0",
+    "graphology": "^0.26.0",
+    "graphology-layout-forceatlas2": "^0.10.1",
     "mdast-util-to-string": "^4.0.0",
     "next": "^15.5.15",
     "react": "^19.0.0",
@@ -20,6 +22,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
+    "sigma": "^3.0.3",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0"
   },

--- a/apps/negentropy-wiki/pnpm-lock.yaml
+++ b/apps/negentropy-wiki/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      graphology:
+        specifier: ^0.26.0
+        version: 0.26.0(graphology-types@0.24.8)
+      graphology-layout-forceatlas2:
+        specifier: ^0.10.1
+        version: 0.10.1(graphology-types@0.24.8)
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
@@ -38,6 +44,9 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      sigma:
+        specifier: ^3.0.3
+        version: 3.0.3(graphology-types@0.24.8)
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -810,6 +819,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1411,6 +1421,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1526,6 +1540,24 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graphology-layout-forceatlas2@0.10.1:
+    resolution: {integrity: sha512-ogzBeF1FvWzjkikrIFwxhlZXvD2+wlY54lqhsrWprcdPjopM2J9HoMweUmIgwaTvY4bUYVimpSsOdvDv1gPRFQ==}
+    peerDependencies:
+      graphology-types: '>=0.19.0'
+
+  graphology-types@0.24.8:
+    resolution: {integrity: sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==}
+
+  graphology-utils@2.5.2:
+    resolution: {integrity: sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==}
+    peerDependencies:
+      graphology-types: '>=0.23.0'
+
+  graphology@0.26.0:
+    resolution: {integrity: sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==}
+    peerDependencies:
+      graphology-types: '>=0.24.0'
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2357,6 +2389,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sigma@3.0.3:
+    resolution: {integrity: sha512-5H0zFlx6/NTQpqBg4Rm569ZOpnBOXMaS25UQThIWMU3XyzI5AhmorK/gnl87BvJBLhQd0tW4C0LIp3enWzMoNw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4108,6 +4143,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
@@ -4224,6 +4261,22 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  graphology-layout-forceatlas2@0.10.1(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+
+  graphology-types@0.24.8: {}
+
+  graphology-utils@2.5.2(graphology-types@0.24.8):
+    dependencies:
+      graphology-types: 0.24.8
+
+  graphology@0.26.0(graphology-types@0.24.8):
+    dependencies:
+      events: 3.3.0
+      graphology-types: 0.24.8
 
   has-bigints@1.1.0: {}
 
@@ -5389,6 +5442,13 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sigma@3.0.3(graphology-types@0.24.8):
+    dependencies:
+      events: 3.3.0
+      graphology-utils: 2.5.2(graphology-types@0.24.8)
+    transitivePeerDependencies:
+      - graphology-types
 
   source-map-js@1.2.1: {}
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -120,6 +120,7 @@ export default async function WikiEntryPage({ params }: Props) {
   const headings = status === "ok" ? extractHeadings(md) : [];
   const hasToc = headings.length >= 2;
   const sectionView = resolveSectionView(navItems, slug);
+  const hasAnyEntry = sectionView.headerItems.length > 0;
 
   const sidebar = (
     <WikiSidebar
@@ -137,6 +138,7 @@ export default async function WikiEntryPage({ params }: Props) {
       items={sectionView.headerItems}
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
+      graphTab={{ active: false, show: hasAnyEntry }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -1,0 +1,191 @@
+import Link from "next/link";
+
+import { ThemePreference } from "@/components/ThemePreference";
+import { WikiGraphCanvas } from "@/components/WikiGraphCanvas";
+import { WikiHeader } from "@/components/WikiHeader";
+import { WikiLayoutShell } from "@/components/WikiLayoutShell";
+import { WikiSidebar } from "@/components/WikiSidebar";
+import {
+  countLeafEntries,
+  findIndexEntry,
+  resolveSectionView,
+  wikiApi,
+  type WikiNavTreeItem,
+  type WikiPublication,
+} from "@/lib/wiki-api";
+import type { WikiGraphResponse } from "@/lib/wiki-graph-types";
+
+/**
+ * Publication 知识图谱页 — /:pubSlug/graph
+ *
+ * 数据流：
+ *   - 服务端 `wikiApi.getPublicationGraph(pub.id)` 拉取按 Publication 切片
+ *     的图谱 JSON（节点 + 边）；
+ *   - ISR 5 分钟 + ``wiki-graph:${pubSlug}`` tag，后端 publish 时通过
+ *     ``/api/revalidate`` webhook 主动刷新；
+ *   - 客户端组件 `WikiGraphCanvas` 自带 ``"use client"``，Sigma WebGL bundle
+ *     会被 Next.js 自动拆分进本路由的客户端 chunk，SSR 阶段不引入。
+ *
+ * 与文档详情页对齐：复用 `WikiLayoutShell` 三栏壳（无 TOC）+ `WikiHeader`
+ * tabs（带"知识图谱"入口，并标记为 active）+ `WikiSidebar` 导航子树。
+ */
+
+export const revalidate = 300;
+
+interface Props {
+  params: Promise<{ pubSlug: string }>;
+}
+
+export default async function WikiPublicationGraphPage({ params }: Props) {
+  const { pubSlug } = await params;
+
+  let publication: WikiPublication | null = null;
+  let navItems: WikiNavTreeItem[] = [];
+  let graph: WikiGraphResponse | null = null;
+  let graphError: string | null = null;
+
+  try {
+    publication = await wikiApi.findPublicationBySlug(pubSlug);
+    if (publication) {
+      const [navResult, graphResult] = await Promise.all([
+        wikiApi.getNavTree(publication.id),
+        wikiApi.getPublicationGraph(publication.id, {
+          tag: `wiki-graph:${pubSlug}`,
+        }),
+      ]);
+      navItems = navResult.nav_tree?.items || [];
+      graph = graphResult;
+    }
+  } catch (err) {
+    console.error(`[Wiki] Failed to load graph for "${pubSlug}":`, err);
+    graphError = err instanceof Error ? err.message : String(err);
+  }
+
+  if (!publication) {
+    return (
+      <main className="wiki-main wiki-not-found">
+        <h1>Wiki 未找到</h1>
+        <p className="wiki-not-found-hint">
+          Publication &quot;{pubSlug}&quot; 不存在或未发布
+        </p>
+        <Link href="/" className="wiki-back-link">
+          ← 返回首页
+        </Link>
+      </main>
+    );
+  }
+
+  const indexEntry = findIndexEntry(navItems);
+  const entriesTotal = countLeafEntries(navItems);
+  const sectionView = resolveSectionView(navItems);
+
+  const sidebar = (
+    <WikiSidebar
+      pubSlug={pubSlug}
+      publication={publication}
+      sidebarItems={sectionView.sidebarItems}
+      hasActiveItem={!!sectionView.activeItem}
+      indexEntry={indexEntry}
+    />
+  );
+
+  const header = sectionView.headerItems.length > 0 && (
+    <WikiHeader
+      pubSlug={pubSlug}
+      items={sectionView.headerItems}
+      activeTopSlug={sectionView.activeTopSlug}
+      headerSlot={<ThemePreference />}
+      graphTab={{ active: true, show: entriesTotal > 0 }}
+    />
+  );
+
+  return (
+    <WikiLayoutShell sidebar={sidebar} hasToc={false} header={header || undefined}>
+      <header className="wiki-doc-header">
+        <h1 className="wiki-doc-title">知识图谱 · {publication.name}</h1>
+        <div className="wiki-doc-meta">
+          版本 v{publication.version}
+          {graph && graph.nodes.length > 0 && (
+            <>
+              {" · "}
+              {graph.nodes.length} 节点 · {graph.edges.length} 边
+              {graph.truncated && graph.total_entities > graph.nodes.length && (
+                <>
+                  {" · "}共 {graph.total_entities} 实体
+                </>
+              )}
+            </>
+          )}
+        </div>
+      </header>
+
+      <WikiGraphBody
+        pubSlug={pubSlug}
+        publication={publication}
+        graph={graph}
+        graphError={graphError}
+      />
+    </WikiLayoutShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 主体渲染（按 graph 状态分支：error / loading-failed / no_kg / empty / ok）
+// ---------------------------------------------------------------------------
+
+interface WikiGraphBodyProps {
+  pubSlug: string;
+  publication: WikiPublication;
+  graph: WikiGraphResponse | null;
+  graphError: string | null;
+}
+
+function WikiGraphBody({ pubSlug, graph, graphError }: WikiGraphBodyProps) {
+  if (graphError) {
+    return (
+      <div className="wiki-graph-error">
+        <p className="wiki-text-hint">
+          图谱数据暂时不可用，请稍后重试或返回
+          <Link href={`/${pubSlug}`} style={{ marginLeft: "0.3em" }}>
+            Publication 首页
+          </Link>
+          。
+        </p>
+        <pre className="wiki-error-detail">{graphError}</pre>
+      </div>
+    );
+  }
+
+  if (!graph || graph.status === "no_kg") {
+    return (
+      <div className="wiki-graph-empty">
+        <p className="wiki-text-hint">
+          该发布暂未构建知识图谱。请联系管理员在后端 Knowledge 模块对相关
+          Corpus 触发 KG 构建后重试。
+        </p>
+      </div>
+    );
+  }
+
+  if (graph.status === "empty" || graph.nodes.length === 0) {
+    return (
+      <div className="wiki-graph-empty">
+        <p className="wiki-text-hint">
+          该发布的文档暂未触发任何实体提及，图谱为空。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="wiki-graph-canvas-wrap">
+      <WikiGraphCanvas
+        pubSlug={pubSlug}
+        nodes={graph.nodes}
+        edges={graph.edges}
+        truncated={graph.truncated}
+        totalEntities={graph.total_entities}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -78,6 +78,7 @@ export default async function WikiPublicationPage({ params }: Props) {
       items={sectionView.headerItems}
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
+      graphTab={{ active: false, show: entriesTotal > 0 }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/api/revalidate/route.ts
+++ b/apps/negentropy-wiki/src/app/api/revalidate/route.ts
@@ -76,11 +76,13 @@ export async function POST(request: Request) {
 
   // 幂等：相同输入多次调用结果一致；revalidate* 内部去重。
   // 站点根路径 + 该发布的所有详情页（catch-all 子路径会因 revalidatePath
-  // 加 layout 旗标而连带刷新）。
+  // 加 layout 旗标而连带刷新）+ 知识图谱页（与文档同发布周期）。
   revalidatePath("/");
   revalidatePath(`/${payload.pub_slug}`);
   revalidatePath(`/${payload.pub_slug}/[...entrySlug]`, "page");
+  revalidatePath(`/${payload.pub_slug}/graph`);
   revalidateTag(`wiki:${payload.pub_slug}`);
+  revalidateTag(`wiki-graph:${payload.pub_slug}`);
 
   return NextResponse.json({
     revalidated: true,

--- a/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * WikiGraphCanvas — Sigma.js v3 + graphology WebGL 渲染器（Wiki 只读视图）
+ *
+ * 与主站 `apps/negentropy-ui/.../SigmaGraphCanvas.tsx` 的关系：
+ *   - 复用 buildGraph / nodeSize / nodeColor / ForceAtlas2 配置策略；
+ *   - 剥离主站特有的"增量加载 / 双击展开 / 实体面板 / 时态切片"逻辑；
+ *   - 节点点击 → 跳转到该实体首个相关 entry（router.push）。
+ *
+ * 渲染策略：
+ *   - WebGL 加速（vs Canvas 快 10-100x）
+ *   - 节点数 > 500 时显示截断横幅，建议用户在"实体列表"按主题深入；
+ *   - 数据已在 SSG 端 fetch 完毕，本组件仅消费 props（无客户端 fetch）。
+ */
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+import type { WikiGraphEdge, WikiGraphNode } from "@/lib/wiki-graph-types";
+
+// ---------------------------------------------------------------------------
+// 视觉常量（与主站 constants.ts 对齐，独立拷贝以避免跨工程依赖）
+// ---------------------------------------------------------------------------
+
+const ENTITY_TYPE_COLORS: Record<string, string> = {
+  person: "#3B82F6",
+  organization: "#10B981",
+  location: "#F59E0B",
+  event: "#EF4444",
+  concept: "#8B5CF6",
+  product: "#EC4899",
+  document: "#6366F1",
+  other: "#6B7280",
+};
+
+// Tableau 10 — 色盲友好的社区配色
+const COMMUNITY_COLORS = [
+  "#4E79A7",
+  "#F28E2B",
+  "#E15759",
+  "#76B7B2",
+  "#59A14F",
+  "#EDC948",
+  "#B07AA1",
+  "#FF9DA7",
+  "#9C755F",
+  "#BAB0AC",
+];
+
+function entityColor(type?: string): string {
+  const key = (type ?? "other").toLowerCase();
+  return ENTITY_TYPE_COLORS[key] ?? ENTITY_TYPE_COLORS.other;
+}
+
+function communityColor(communityId: number | null | undefined): string {
+  if (communityId == null) return "#6B7280";
+  return COMMUNITY_COLORS[communityId % COMMUNITY_COLORS.length];
+}
+
+function nodeSize(importance: number | null | undefined): number {
+  if (importance == null) return 10;
+  const clamped = Math.min(Math.max(importance, 0), 1);
+  return 6 + 14 * clamped;
+}
+
+function nodeColor(node: Pick<WikiGraphNode, "type" | "community_id">): string {
+  if (node.community_id != null) return communityColor(node.community_id);
+  return entityColor(node.type);
+}
+
+// ---------------------------------------------------------------------------
+// 组件
+// ---------------------------------------------------------------------------
+
+interface WikiGraphCanvasProps {
+  /** Publication slug（用于节点点击跳转） */
+  pubSlug: string;
+  nodes: WikiGraphNode[];
+  edges: WikiGraphEdge[];
+  /**
+   * 截断横幅阈值：节点数 >= 此值时显示提示。
+   * 与后端 ``max_nodes`` 默认 300 相协调，避免误报。
+   */
+  truncateThreshold?: number;
+  /** 是否实际被后端截断（来自响应的 truncated 字段） */
+  truncated?: boolean;
+  /** 截断前的实体总数（来自响应的 total_entities） */
+  totalEntities?: number;
+}
+
+export function WikiGraphCanvas({
+  pubSlug,
+  nodes,
+  edges,
+  truncateThreshold = 500,
+  truncated = false,
+  totalEntities,
+}: WikiGraphCanvasProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // 通过 unknown 桥接绕过 ESM 默认导出类型在 ESLint --max-warnings=0 下的过严校验。
+  const sigmaRef = useRef<{ kill: () => void; refresh: () => void } | null>(null);
+  const router = useRouter();
+
+  // 单次挂载初始化 + 数据/路由变化时整图重建（Wiki 场景图谱体量有限，无需增量同步）
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let killed = false;
+
+    const init = async () => {
+      const { default: Graph } = await import("graphology");
+      const { default: Sigma } = await import("sigma");
+      const { default: forceAtlas2 } = await import(
+        "graphology-layout-forceatlas2"
+      );
+
+      if (killed || !containerRef.current) return;
+
+      const graph = new Graph({ multi: false, type: "directed" });
+      const entrySlugMap = new Map<string, string[]>();
+      for (const n of nodes) {
+        entrySlugMap.set(n.id, n.entry_slugs ?? []);
+        graph.addNode(n.id, {
+          label: n.label ?? n.id.slice(0, 8),
+          x: Math.random() * 500,
+          y: Math.random() * 500,
+          size: nodeSize(n.importance),
+          color: nodeColor(n),
+        });
+      }
+      const validIds = new Set(nodes.map((n) => n.id));
+      for (const e of edges) {
+        if (validIds.has(e.source) && validIds.has(e.target)) {
+          try {
+            graph.addEdge(e.source, e.target, { label: e.label ?? e.type ?? "" });
+          } catch {
+            // graphology 不允许重复边，忽略
+          }
+        }
+      }
+
+      // 初始布局
+      if (graph.order > 0) {
+        forceAtlas2.assign(graph, {
+          iterations: 50,
+          settings: {
+            outboundAttractionDistribution: true,
+            adjustSizes: true,
+            gravity: 1,
+          },
+        });
+      }
+
+      const sigma = new Sigma(graph, containerRef.current, {
+        renderLabels: true,
+        renderEdgeLabels: false,
+        labelFont: "system-ui, sans-serif",
+        labelSize: 12,
+        labelWeight: "500",
+        defaultEdgeColor: "#d4d4d8",
+        defaultNodeColor: "#6B7280",
+        minCameraRatio: 0.1,
+        maxCameraRatio: 10,
+        stagePadding: 20,
+      });
+      sigmaRef.current = sigma as unknown as {
+        kill: () => void;
+        refresh: () => void;
+      };
+
+      // 节点点击 → 跳转到首个相关 entry；无 entry 时不跳转
+      sigma.on("clickNode", ({ node }) => {
+        const slugs = entrySlugMap.get(node) ?? [];
+        if (slugs.length > 0) {
+          router.push(`/${pubSlug}/${slugs[0]}`);
+        }
+      });
+    };
+
+    void init();
+
+    return () => {
+      killed = true;
+      sigmaRef.current?.kill();
+      sigmaRef.current = null;
+    };
+  }, [nodes, edges, pubSlug, router]);
+
+  const exceedsThreshold = nodes.length >= truncateThreshold;
+  const showTruncatedBanner = truncated || exceedsThreshold;
+
+  return (
+    <div className="relative h-full w-full">
+      <div ref={containerRef} className="h-full w-full" />
+
+      {/* 状态横幅：左上角统计 + 截断提示 */}
+      <div className="pointer-events-none absolute left-2 top-2 flex flex-col gap-1 text-xs">
+        <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
+          {nodes.length} 节点 · {edges.length} 边 · Sigma WebGL
+        </span>
+        {showTruncatedBanner && (
+          <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
+            {truncated && totalEntities
+              ? `已按 importance 截断（共 ${totalEntities} 个实体，仅显示 top-${nodes.length}）`
+              : "图谱过大，建议在实体列表中筛选"}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default WikiGraphCanvas;

--- a/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
@@ -99,7 +99,12 @@ export function WikiGraphCanvas({
 }: WikiGraphCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   // 通过 unknown 桥接绕过 ESM 默认导出类型在 ESLint --max-warnings=0 下的过严校验。
-  const sigmaRef = useRef<{ kill: () => void; refresh: () => void } | null>(null);
+  const sigmaRef = useRef<{
+    kill: () => void;
+    refresh: () => void;
+    resize: () => void;
+  } | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const router = useRouter();
 
   // 单次挂载初始化 + 数据/路由变化时整图重建（Wiki 场景图谱体量有限，无需增量同步）
@@ -166,6 +171,7 @@ export function WikiGraphCanvas({
       sigmaRef.current = sigma as unknown as {
         kill: () => void;
         refresh: () => void;
+        resize: () => void;
       };
 
       // 节点点击 → 跳转到首个相关 entry；无 entry 时不跳转
@@ -175,12 +181,31 @@ export function WikiGraphCanvas({
           router.push(`/${pubSlug}/${slugs[0]}`);
         }
       });
+
+      // ResizeObserver：容器尺寸变化时调用 Sigma resize()（重设 WebGL canvas
+      // 像素尺寸 + 重绘）。Sigma 不自动监听容器尺寸变化，dynamic import
+      // 异步落地时容器可能仍为 0×0；ResizeObserver 在尺寸真正落定后触发。
+      if (containerRef.current && typeof ResizeObserver !== "undefined") {
+        const ro = new ResizeObserver(() => {
+          sigmaRef.current?.resize();
+          sigmaRef.current?.refresh();
+        });
+        ro.observe(containerRef.current);
+        resizeObserverRef.current = ro;
+      }
+
+      // 首次同步尝试 resize：容器在 hydrate 之后通常已具尺寸；
+      // 兼容 ResizeObserver 首帧未触发的浏览器实现。
+      sigma.resize();
+      sigma.refresh();
     };
 
     void init();
 
     return () => {
       killed = true;
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
       sigmaRef.current?.kill();
       sigmaRef.current = null;
     };
@@ -190,16 +215,16 @@ export function WikiGraphCanvas({
   const showTruncatedBanner = truncated || exceedsThreshold;
 
   return (
-    <div className="relative h-full w-full">
-      <div ref={containerRef} className="h-full w-full" />
+    <div className="wiki-graph-canvas-root">
+      <div ref={containerRef} className="wiki-graph-canvas-stage" />
 
       {/* 状态横幅：左上角统计 + 截断提示 */}
-      <div className="pointer-events-none absolute left-2 top-2 flex flex-col gap-1 text-xs">
-        <span className="rounded bg-zinc-900/70 px-2 py-1 text-white">
+      <div className="wiki-graph-canvas-overlay">
+        <span className="wiki-graph-badge">
           {nodes.length} 节点 · {edges.length} 边 · Sigma WebGL
         </span>
         {showTruncatedBanner && (
-          <span className="rounded bg-amber-500/90 px-2 py-1 text-white">
+          <span className="wiki-graph-badge wiki-graph-badge-warn">
             {truncated && totalEntities
               ? `已按 importance 截断（共 ${totalEntities} 个实体，仅显示 top-${nodes.length}）`
               : "图谱过大，建议在实体列表中筛选"}

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -15,15 +15,32 @@ import {
  * - `items` 为空时早返回 `null`，避免渲染空壳。
  */
 
+interface WikiHeaderGraphTab {
+  /** 是否在 tabs 区域渲染"知识图谱"入口（按 `entries_count > 0` 决定） */
+  show: boolean;
+  /** 当前是否处于 graph 页 → 标记为选中态 */
+  active: boolean;
+  /** 自定义 label，默认为"知识图谱" */
+  label?: string;
+}
+
 interface WikiHeaderProps {
   pubSlug: string;
   items: WikiNavTreeItem[];
   activeTopSlug?: string;
   headerSlot?: React.ReactNode;
+  /** 可选：在原 tabs 末尾追加"知识图谱"入口 */
+  graphTab?: WikiHeaderGraphTab;
 }
 
-export function WikiHeader({ pubSlug, items, activeTopSlug, headerSlot }: WikiHeaderProps) {
-  if (!items.length) return null;
+export function WikiHeader({
+  pubSlug,
+  items,
+  activeTopSlug,
+  headerSlot,
+  graphTab,
+}: WikiHeaderProps) {
+  if (!items.length && !(graphTab?.show)) return null;
 
   return (
     <header className="wiki-header">
@@ -45,9 +62,18 @@ export function WikiHeader({ pubSlug, items, activeTopSlug, headerSlot }: WikiHe
               key={`${item.entry_id ?? "c"}:${item.entry_slug}`}
               item={item}
               pubSlug={pubSlug}
-              isActive={item.entry_slug === activeTopSlug}
+              isActive={!graphTab?.active && item.entry_slug === activeTopSlug}
             />
           ))}
+          {graphTab?.show && (
+            <Link
+              href={`/${pubSlug}/graph`}
+              className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
+              aria-current={graphTab.active ? "page" : undefined}
+            >
+              {graphTab.label ?? "知识图谱"}
+            </Link>
+          )}
         </nav>
         <div className="wiki-header-slot">{headerSlot}</div>
       </div>

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -1,9 +1,18 @@
 /**
  * Wiki API 客户端
  *
- * 用于 SSG 构建时从后端拉取 Wiki 发布数据（Publications、Entries、NavTree、Content）。
+ * 用于 SSG 构建时从后端拉取 Wiki 发布数据（Publications、Entries、NavTree、Content、Graph）。
  * 运行时通过 ISR 增量再验证保持数据新鲜度。
  */
+
+import type {
+  WikiEntryGraphResponse,
+  WikiGraphEntityDetailResponse,
+  WikiGraphEntityListResponse,
+  WikiGraphEntityQueryOptions,
+  WikiGraphQueryOptions,
+  WikiGraphResponse,
+} from "./wiki-graph-types";
 
 const API_BASE =
   typeof process !== "undefined"
@@ -92,10 +101,16 @@ class WikiApiClient {
     this.baseUrl = baseUrl || API_BASE;
   }
 
-  private async fetch<T>(path: string): Promise<T> {
+  private async fetch<T>(
+    path: string,
+    init?: { tags?: string[] },
+  ): Promise<T> {
     const url = `${this.baseUrl}/knowledge/wiki${path}`;
     const res = await fetch(url, {
-      next: { revalidate: 300 }, // ISR: 5 分钟增量再验证
+      next: {
+        revalidate: 300, // ISR: 5 分钟增量再验证
+        ...(init?.tags ? { tags: init.tags } : {}),
+      },
       headers: { Accept: "application/json" },
     });
     if (!res.ok) {
@@ -156,6 +171,68 @@ class WikiApiClient {
     const result = await this.getEntries(pubId);
     const match = result.items.find((e) => e.entry_slug === entrySlug);
     return match?.id ?? null;
+  }
+
+  // -------------------------------------------------------------------------
+  // 知识图谱（按 Publication 维度切片）
+  //
+  // 后端在 `/knowledge/wiki/publications/{pub_id}/graph` 系列端点上仅暴露
+  // `status='published'` 的发布；切片语义见
+  // `apps/negentropy/.../lifecycle/wiki_graph_service.py`。
+  // `revalidateTag('wiki-graph:${pub_slug}')` 由后端发布时主动触发。
+  // -------------------------------------------------------------------------
+
+  /** 获取 Publication 整体切片图谱 */
+  async getPublicationGraph(
+    pubId: string,
+    opts?: WikiGraphQueryOptions & { tag?: string },
+  ): Promise<WikiGraphResponse> {
+    const qs = new URLSearchParams();
+    if (opts?.maxNodes != null) qs.set("max_nodes", String(opts.maxNodes));
+    if (opts?.minImportance != null) qs.set("min_importance", String(opts.minImportance));
+    if (opts?.includeIsolated != null) qs.set("include_isolated", String(opts.includeIsolated));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return this.fetch<WikiGraphResponse>(
+      `/publications/${pubId}/graph${suffix}`,
+      opts?.tag ? { tags: [opts.tag] } : undefined,
+    );
+  }
+
+  /** 获取 Publication 实体扁平列表（分页） */
+  async getPublicationEntities(
+    pubId: string,
+    opts?: WikiGraphEntityQueryOptions & { tag?: string },
+  ): Promise<WikiGraphEntityListResponse> {
+    const qs = new URLSearchParams();
+    if (opts?.offset != null) qs.set("offset", String(opts.offset));
+    if (opts?.limit != null) qs.set("limit", String(opts.limit));
+    if (opts?.sortBy != null) qs.set("sort_by", opts.sortBy);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return this.fetch<WikiGraphEntityListResponse>(
+      `/publications/${pubId}/graph/entities${suffix}`,
+      opts?.tag ? { tags: [opts.tag] } : undefined,
+    );
+  }
+
+  /** 获取单实体详情（含邻居 + 提及 entries） */
+  async getPublicationEntityDetail(
+    pubId: string,
+    entityId: string,
+  ): Promise<WikiGraphEntityDetailResponse> {
+    return this.fetch<WikiGraphEntityDetailResponse>(
+      `/publications/${pubId}/graph/entities/${entityId}`,
+    );
+  }
+
+  /** 获取单 entry 的局部图（该文档涉及实体 + 一跳邻居） */
+  async getEntryGraph(
+    entryId: string,
+    opts?: { maxNodes?: number },
+  ): Promise<WikiEntryGraphResponse> {
+    const qs = new URLSearchParams();
+    if (opts?.maxNodes != null) qs.set("max_nodes", String(opts.maxNodes));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return this.fetch<WikiEntryGraphResponse>(`/entries/${entryId}/graph${suffix}`);
   }
 }
 

--- a/apps/negentropy-wiki/src/lib/wiki-graph-types.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-graph-types.ts
@@ -1,0 +1,153 @@
+/**
+ * Wiki Knowledge Graph 类型声明
+ *
+ * 与 `wiki-api.ts` 中的文档/导航类型正交分解：
+ * - 字段命名与后端 `WikiGraphResponse` 一一对应（id/label/type 等小写命名）；
+ * - 与主站 `apps/negentropy-ui` 的 GraphCanvas 类型保持字段对齐，便于未来抽
+ *   出共享类型包，但 Wiki 场景为"只读浏览"，故不引入主站特有的 build/edit
+ *   交互字段。
+ */
+
+/** 切片图谱节点 */
+export interface WikiGraphNode {
+  /** 实体 ID（沿用后端 GraphService 输出格式，字符串形式） */
+  id: string;
+  /** 节点显示名 */
+  label: string;
+  /** 节点类型（entity_type，如 PERSON/ORGANIZATION/CONCEPT） */
+  type: string;
+  /** 重要性得分（用于按 top-N 截断） */
+  importance: number | null;
+  /** Louvain 社区 ID */
+  community_id: number | null;
+  /** Publication 内提及本实体的前 N 个 entry slug */
+  entry_slugs: string[];
+  /** Publication 内对本实体的提及总次数 */
+  mention_count_in_pub: number;
+  /**
+   * 节点附加元数据：
+   * - `corpus_id`：跨 corpus publication 着色用；
+   * - `entity_type` / `confidence` / `global_mention_count` 等。
+   */
+  metadata: Record<string, unknown> & {
+    corpus_id?: string;
+    entity_type?: string;
+    confidence?: number;
+    global_mention_count?: number;
+  };
+}
+
+/** 切片图谱边 */
+export interface WikiGraphEdge {
+  source: string;
+  target: string;
+  label: string;
+  type: string;
+  weight: number;
+  metadata: Record<string, unknown> & {
+    confidence?: number;
+    evidence_snippet?: string;
+  };
+}
+
+/** Publication 整体图谱响应 */
+export interface WikiGraphResponse {
+  publication_id: string;
+  version: number;
+  /**
+   * - `ok`：正常返回非空图；
+   * - `no_kg`：KG 未构建（节点边必空）；
+   * - `empty`：KG 已构建但 publication 内文档无任何 mention。
+   */
+  status: "ok" | "no_kg" | "empty";
+  nodes: WikiGraphNode[];
+  edges: WikiGraphEdge[];
+  /** True 表示节点数超过 max_nodes 被截断，悬挂边已剔除 */
+  truncated: boolean;
+  /** 截断前的实体总数 */
+  total_entities: number;
+  /** Publication 实际覆盖的 corpus_id 集合 */
+  corpus_ids: string[];
+}
+
+/** 实体扁平列表条目 */
+export interface WikiGraphEntityItem {
+  id: string;
+  name: string;
+  entity_type: string;
+  importance: number | null;
+  community_id: number | null;
+  mention_count_in_pub: number;
+  entry_slugs: string[];
+  corpus_id: string | null;
+}
+
+export interface WikiGraphEntityListResponse {
+  publication_id: string;
+  version: number;
+  total: number;
+  offset: number;
+  limit: number;
+  items: WikiGraphEntityItem[];
+}
+
+/** 实体邻居（限定在 publication 节点集合内） */
+export interface WikiGraphNeighbor {
+  id: string;
+  name: string;
+  entity_type: string;
+  relation_type: string;
+  /** "outgoing" | "incoming" */
+  direction: "outgoing" | "incoming";
+  weight: number;
+  entry_slugs: string[];
+}
+
+/** 提及该实体的 Wiki entry */
+export interface WikiGraphMentioningEntry {
+  entry_id: string;
+  entry_slug: string;
+  entry_title: string | null;
+  document_id: string | null;
+  mention_count: number;
+}
+
+export interface WikiGraphEntityDetailResponse {
+  publication_id: string;
+  version: number;
+  entity: WikiGraphEntityItem;
+  neighbors: WikiGraphNeighbor[];
+  mentioning_entries: WikiGraphMentioningEntry[];
+}
+
+/** 单 entry 的局部图（该文档涉及实体 + 一跳邻居） */
+export interface WikiEntryGraphResponse {
+  entry_id: string;
+  publication_id: string;
+  version: number;
+  status: "ok" | "no_kg" | "empty";
+  nodes: WikiGraphNode[];
+  edges: WikiGraphEdge[];
+  /** 该 entry 直接涉及的实体 ID（前端用于高亮中心节点） */
+  center_entity_ids: string[];
+}
+
+/** 排序键白名单（与后端 sort_by 对齐） */
+export type WikiGraphEntitySortKey = "importance" | "mention" | "name";
+
+/** Publication 整图查询可选参数 */
+export interface WikiGraphQueryOptions {
+  /** 节点数上限（1-1000，默认 300） */
+  maxNodes?: number;
+  /** 最小 importance_score 过滤（默认 0） */
+  minImportance?: number;
+  /** 是否保留无边孤立节点（默认 false） */
+  includeIsolated?: boolean;
+}
+
+/** 实体列表查询可选参数 */
+export interface WikiGraphEntityQueryOptions {
+  offset?: number;
+  limit?: number;
+  sortBy?: WikiGraphEntitySortKey;
+}

--- a/apps/negentropy-wiki/src/styles/components/graph.css
+++ b/apps/negentropy-wiki/src/styles/components/graph.css
@@ -1,0 +1,83 @@
+/* Wiki 知识图谱页样式 ------------------------------------------------------
+ *
+ * Sigma 渲染依赖容器有显式高度才能绘制；这里把 canvas 外层撑满主区域剩余
+ * 高度（减去顶栏 header + 文档标题区域）。
+ * 不依赖 JS 测量，纯 CSS 通过 viewport - header 解决，与 markdown 文档页
+ * 风格一致。
+ */
+
+.wiki-graph-canvas-wrap {
+  /* 主区高度 = viewport - 顶部 header 高度（约 56px）- 文档标题块约 88px
+   * 实测保守值 200px 足以避开顶栏与下边距，剩余给 canvas。 */
+  height: calc(100vh - 200px);
+  min-height: 480px;
+  width: 100%;
+  position: relative;
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  background: var(--surface-recessed, rgba(0, 0, 0, 0.12));
+  overflow: hidden;
+}
+
+.wiki-graph-canvas-wrap > div {
+  height: 100%;
+  width: 100%;
+}
+
+/* 客户端组件的根/容器：用真实 height 撑开，不再依赖 Tailwind h-full */
+.wiki-graph-canvas-root {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.wiki-graph-canvas-stage {
+  position: absolute;
+  inset: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.wiki-graph-canvas-overlay {
+  position: absolute;
+  left: 8px;
+  top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  pointer-events: none;
+  font-size: 12px;
+  z-index: 2;
+}
+
+.wiki-graph-badge {
+  background: rgba(24, 24, 27, 0.75);
+  color: #fafafa;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.wiki-graph-badge-warn {
+  background: rgba(245, 158, 11, 0.9);
+}
+
+.wiki-graph-empty,
+.wiki-graph-error,
+.wiki-graph-loading {
+  padding: 2rem;
+  border: 1px dashed var(--border-subtle, rgba(255, 255, 255, 0.12));
+  border-radius: 8px;
+  background: var(--surface-recessed, rgba(0, 0, 0, 0.06));
+}
+
+.wiki-error-detail {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  background: rgba(255, 0, 0, 0.04);
+  border-left: 3px solid rgba(255, 0, 0, 0.4);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/apps/negentropy-wiki/src/styles/index.css
+++ b/apps/negentropy-wiki/src/styles/index.css
@@ -12,3 +12,4 @@
 @import "components/toc.css";
 @import "components/markdown.css";
 @import "components/doc.css";
+@import "components/graph.css";

--- a/apps/negentropy-wiki/tests/lib/wiki-api-graph.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-api-graph.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// 与 wiki-api.test.ts 保持相同的 mock 模式：动态 import 确保 fetch stub 已就位
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { wikiApi } = await import("@/lib/wiki-api");
+
+// ---------------------------------------------------------------------------
+// 辅助
+// ---------------------------------------------------------------------------
+
+function mockJsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  };
+}
+
+const sampleGraph = {
+  publication_id: "pub-001",
+  version: 3,
+  status: "ok" as const,
+  nodes: [
+    {
+      id: "ent-1",
+      label: "Negentropy",
+      type: "concept",
+      importance: 0.8,
+      community_id: 1,
+      entry_slugs: ["intro", "design"],
+      mention_count_in_pub: 12,
+      metadata: { corpus_id: "corpus-001", entity_type: "concept" },
+    },
+  ],
+  edges: [
+    {
+      source: "ent-1",
+      target: "ent-2",
+      label: "RELATED_TO",
+      type: "RELATED_TO",
+      weight: 1.0,
+      metadata: { confidence: 0.95 },
+    },
+  ],
+  truncated: false,
+  total_entities: 1,
+  corpus_ids: ["corpus-001"],
+};
+
+const sampleEntities = {
+  publication_id: "pub-001",
+  version: 3,
+  total: 2,
+  offset: 0,
+  limit: 50,
+  items: [
+    {
+      id: "ent-1",
+      name: "Negentropy",
+      entity_type: "concept",
+      importance: 0.8,
+      community_id: 1,
+      mention_count_in_pub: 12,
+      entry_slugs: ["intro"],
+      corpus_id: "corpus-001",
+    },
+  ],
+};
+
+const sampleEntityDetail = {
+  publication_id: "pub-001",
+  version: 3,
+  entity: sampleEntities.items[0],
+  neighbors: [
+    {
+      id: "ent-2",
+      name: "Entropy",
+      entity_type: "concept",
+      relation_type: "OPPOSITE_OF",
+      direction: "outgoing" as const,
+      weight: 1.0,
+      entry_slugs: ["thermodynamics"],
+    },
+  ],
+  mentioning_entries: [
+    {
+      entry_id: "entry-1",
+      entry_slug: "intro",
+      entry_title: "Intro",
+      document_id: "doc-1",
+      mention_count: 3,
+    },
+  ],
+};
+
+const sampleEntryGraph = {
+  entry_id: "entry-1",
+  publication_id: "pub-001",
+  version: 3,
+  status: "ok" as const,
+  nodes: sampleGraph.nodes,
+  edges: sampleGraph.edges,
+  center_entity_ids: ["ent-1"],
+};
+
+// ---------------------------------------------------------------------------
+// 测试
+// ---------------------------------------------------------------------------
+
+describe("wikiApi knowledge graph endpoints", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("getPublicationGraph dispatches with default revalidate + correct path", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(sampleGraph));
+
+    const result = await wikiApi.getPublicationGraph("pub-001");
+
+    expect(result).toEqual(sampleGraph);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/knowledge\/wiki\/publications\/pub-001\/graph$/);
+    expect(init?.next?.revalidate).toBe(300);
+  });
+
+  it("getPublicationGraph passes max_nodes / min_importance / include_isolated query params", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(sampleGraph));
+
+    await wikiApi.getPublicationGraph("pub-001", {
+      maxNodes: 500,
+      minImportance: 0.2,
+      includeIsolated: true,
+    });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("max_nodes=500");
+    expect(url).toContain("min_importance=0.2");
+    expect(url).toContain("include_isolated=true");
+  });
+
+  it("getPublicationGraph propagates revalidate tag when provided", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(sampleGraph));
+
+    await wikiApi.getPublicationGraph("pub-001", { tag: "wiki-graph:my-pub" });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init?.next?.tags).toEqual(["wiki-graph:my-pub"]);
+    expect(init?.next?.revalidate).toBe(300);
+  });
+
+  it("getPublicationGraph throws with informative message on non-ok response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve('{"code":"WIKI_PUB_NOT_PUBLISHED"}'),
+      json: () => Promise.resolve({}),
+    });
+
+    // 单次调用即可同时验证 status 与 body 透传到错误消息中
+    await expect(wikiApi.getPublicationGraph("pub-001")).rejects.toThrow(
+      /403.*WIKI_PUB_NOT_PUBLISHED/,
+    );
+  });
+
+  it("getPublicationEntities passes offset/limit/sort_by", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(sampleEntities));
+
+    const result = await wikiApi.getPublicationEntities("pub-001", {
+      offset: 10,
+      limit: 25,
+      sortBy: "mention",
+    });
+
+    expect(result.total).toBe(2);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/publications/pub-001/graph/entities");
+    expect(url).toContain("offset=10");
+    expect(url).toContain("limit=25");
+    expect(url).toContain("sort_by=mention");
+  });
+
+  it("getPublicationEntityDetail uses entityId in path", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(sampleEntityDetail));
+
+    const result = await wikiApi.getPublicationEntityDetail("pub-001", "ent-1");
+
+    expect(result.entity.id).toBe("ent-1");
+    expect(result.neighbors).toHaveLength(1);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toMatch(
+      /\/knowledge\/wiki\/publications\/pub-001\/graph\/entities\/ent-1$/,
+    );
+  });
+
+  it("getEntryGraph uses entry_id in path and passes max_nodes", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(sampleEntryGraph));
+
+    const result = await wikiApi.getEntryGraph("entry-1", { maxNodes: 80 });
+
+    expect(result.center_entity_ids).toEqual(["ent-1"]);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/knowledge\/wiki\/entries\/entry-1\/graph/);
+    expect(url).toContain("max_nodes=80");
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/api.py
+++ b/apps/negentropy/src/negentropy/knowledge/api.py
@@ -21,6 +21,7 @@ from .routes import (
     sources,
     unified_search,
     wiki,
+    wiki_graph,
 )
 
 router = APIRouter(prefix="/knowledge", tags=["knowledge"])
@@ -37,5 +38,6 @@ router.include_router(pipelines.router)
 router.include_router(provenance.router)
 router.include_router(catalog.router)
 router.include_router(wiki.router)
+router.include_router(wiki_graph.router)
 router.include_router(unified_search.router)
 router.include_router(admin.router)

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_graph_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_graph_service.py
@@ -1,0 +1,766 @@
+"""Wiki Knowledge Graph 切片查询服务。
+
+将"按 Publication 维度反查文档关联实体子图"的逻辑独立成正交模块，
+与 :mod:`wiki_service`（发布生命周期）解耦。
+
+切片算法（核心）::
+
+    wiki_publication_entries (publication_id = X, entry_kind = 'DOCUMENT')
+        → document_id 集合 D
+            → kg_entity_mentions (document_id ∈ D)
+                → DISTINCT entity_id 集合 N
+                    → kg_entities (id ∈ N, is_active)            → 节点
+                    → kg_relations (src ∈ N AND tgt ∈ N)         → 边（剔悬挂）
+
+设计要点：
+
+- **单一事实源**：所有切片在后端 SQL 中完成，Wiki 端不做二次过滤；
+- **节点截断**：当节点数 > ``max_nodes`` 时，按 ``importance_score`` DESC、
+  ``mention_count`` DESC 双关键字截断；先按截断后的节点集合再裁剪边，
+  保证不出现悬挂边；
+- **跨 corpus publication（阶段一）**：按 corpus_id 各自保留，节点
+  ``metadata.corpus_id`` 标注；不做 canonical 合并（与 ``routes/graph.py``
+  单 corpus 语义一致，最小干预）；
+- **空 KG 兜底**：未构建 KG / 0 mention 时返回 ``status='no_kg'`` 或
+  ``status='empty'``，让 Wiki 端展示友好空态而非异常。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from negentropy.logging import get_logger
+from negentropy.models.perception import (
+    KgEntity,
+    KgEntityMention,
+    KgRelation,
+    WikiPublication,
+    WikiPublicationEntry,
+)
+
+logger = get_logger(__name__.rsplit(".", 1)[0])
+
+
+# ---------------------------------------------------------------------------
+# 内部数据结构
+# ---------------------------------------------------------------------------
+
+
+class _SliceContext:
+    """单次切片查询的上下文，承载 publication 元数据与候选节点集合。
+
+    通过显式上下文对象在多个查询步骤间传递（替代隐式参数串联），
+    便于追加调试日志与未来扩展（如 corpus_ids 跨域桥接）。
+    """
+
+    __slots__ = (
+        "publication",
+        "document_ids",
+        "node_ids",
+        "kept_node_ids",
+        "total_entities",
+        "truncated",
+    )
+
+    def __init__(self, publication: WikiPublication) -> None:
+        self.publication = publication
+        self.document_ids: list[UUID] = []
+        self.node_ids: list[UUID] = []
+        self.kept_node_ids: list[UUID] = []
+        self.total_entities: int = 0
+        self.truncated: bool = False
+
+
+# ---------------------------------------------------------------------------
+# 公共 API
+# ---------------------------------------------------------------------------
+
+
+async def get_publication_graph(
+    db: AsyncSession,
+    *,
+    pub_id: UUID,
+    max_nodes: int = 300,
+    min_importance: float = 0.0,
+    include_isolated: bool = False,
+    entry_slugs_per_node: int = 3,
+) -> dict[str, Any] | None:
+    """获取 Publication 整体切片图谱。
+
+    Args:
+        db: 异步数据库会话；
+        pub_id: 发布 ID；
+        max_nodes: 节点数上限（仅 published 暴露；超出时按 importance 截断）；
+        min_importance: 最小 importance_score 过滤（None 视为 0）；
+        include_isolated: 是否保留无边孤立节点（默认 False，减少视觉噪点）；
+        entry_slugs_per_node: 每节点附带的 entry_slug 数（用于点击跳转）。
+
+    Returns:
+        ``None``：publication 不存在；
+        否则：``{publication_id, version, status, nodes, edges, truncated,
+                total_entities, corpus_ids}``。
+
+    Notes:
+        - 调用方负责发布状态可见性校验（仅 published 才暴露给 Wiki）。
+        - ``status='no_kg'``：publication 关联 corpus 暂未构建 KG；
+        - ``status='empty'``：KG 已存在但本 publication 文档无任何 mention。
+    """
+    pub = await db.get(WikiPublication, pub_id)
+    if pub is None:
+        return None
+
+    ctx = _SliceContext(pub)
+    await _load_document_ids(db, ctx)
+
+    if not ctx.document_ids:
+        return _empty_response(ctx, status_="empty")
+
+    # 节点 ID（DISTINCT，按 importance 排序，可截断）
+    await _load_candidate_node_ids(
+        db,
+        ctx,
+        max_nodes=max_nodes,
+        min_importance=min_importance,
+    )
+
+    if not ctx.kept_node_ids:
+        return _empty_response(ctx, status_="empty")
+
+    # 实体详情
+    entities = await _load_entities(db, ctx.kept_node_ids)
+
+    # mention_count_in_pub 聚合
+    mention_counts = await _load_mention_counts_in_pub(
+        db,
+        document_ids=ctx.document_ids,
+        entity_ids=ctx.kept_node_ids,
+    )
+
+    # entry_slugs（每实体 top-N）
+    entry_slugs_map = await _load_entry_slugs_for_entities(
+        db,
+        pub_id=ctx.publication.id,
+        entity_ids=ctx.kept_node_ids,
+        per_node=entry_slugs_per_node,
+    )
+
+    # 边（两端都在节点集合内）
+    edges = await _load_edges(db, ctx.kept_node_ids)
+
+    nodes = [
+        _build_node(
+            ent,
+            mention_count_in_pub=mention_counts.get(ent.id, 0),
+            entry_slugs=entry_slugs_map.get(ent.id, []),
+        )
+        for ent in entities
+    ]
+
+    if not include_isolated and edges:
+        connected_ids = {e["source"] for e in edges} | {e["target"] for e in edges}
+        nodes = [n for n in nodes if n["id"] in connected_ids]
+
+    corpus_ids = sorted({ent.corpus_id for ent in entities})
+
+    return {
+        "publication_id": ctx.publication.id,
+        "version": ctx.publication.version,
+        "status": "ok" if nodes else "empty",
+        "nodes": nodes,
+        "edges": edges,
+        "truncated": ctx.truncated,
+        "total_entities": ctx.total_entities,
+        "corpus_ids": corpus_ids,
+    }
+
+
+async def get_publication_entities(
+    db: AsyncSession,
+    *,
+    pub_id: UUID,
+    offset: int = 0,
+    limit: int = 50,
+    sort_by: str = "importance",
+    entry_slugs_per_node: int = 3,
+) -> dict[str, Any] | None:
+    """获取 Publication 实体扁平列表（分页）。
+
+    供 Wiki 端"实体列表 + 搜索"侧边面板使用（首版可选；最简方案直接
+    嵌入图谱响应即可）。
+    """
+    pub = await db.get(WikiPublication, pub_id)
+    if pub is None:
+        return None
+
+    ctx = _SliceContext(pub)
+    await _load_document_ids(db, ctx)
+    if not ctx.document_ids:
+        return _entity_list_empty(ctx, offset, limit)
+
+    # 统计总实体数
+    total_stmt = select(func.count(func.distinct(KgEntityMention.entity_id))).where(
+        KgEntityMention.document_id.in_(ctx.document_ids)
+    )
+    total = int((await db.execute(total_stmt)).scalar() or 0)
+    if total == 0:
+        return _entity_list_empty(ctx, offset, limit)
+
+    sort_clauses: list[Any] = _resolve_entity_sort(sort_by)
+    mention_subq = (
+        select(KgEntityMention.entity_id.label("entity_id"))
+        .where(KgEntityMention.document_id.in_(ctx.document_ids))
+        .distinct()
+        .subquery()
+    )
+    items_stmt = (
+        select(KgEntity)
+        .join(mention_subq, mention_subq.c.entity_id == KgEntity.id)
+        .where(KgEntity.is_active.is_(True))
+        .order_by(*sort_clauses)
+        .offset(offset)
+        .limit(limit)
+    )
+    entities = (await db.execute(items_stmt)).scalars().all()
+    entity_ids = [e.id for e in entities]
+
+    mention_counts = await _load_mention_counts_in_pub(
+        db,
+        document_ids=ctx.document_ids,
+        entity_ids=entity_ids,
+    )
+    entry_slugs_map = await _load_entry_slugs_for_entities(
+        db,
+        pub_id=ctx.publication.id,
+        entity_ids=entity_ids,
+        per_node=entry_slugs_per_node,
+    )
+
+    items = [
+        {
+            "id": str(ent.id),
+            "name": ent.canonical_name or ent.name,
+            "entity_type": ent.entity_type,
+            "importance": ent.importance_score,
+            "community_id": ent.community_id,
+            "mention_count_in_pub": mention_counts.get(ent.id, 0),
+            "entry_slugs": entry_slugs_map.get(ent.id, []),
+            "corpus_id": ent.corpus_id,
+        }
+        for ent in entities
+    ]
+
+    return {
+        "publication_id": ctx.publication.id,
+        "version": ctx.publication.version,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "items": items,
+    }
+
+
+async def get_publication_entity_detail(
+    db: AsyncSession,
+    *,
+    pub_id: UUID,
+    entity_id: UUID,
+    entry_slugs_per_node: int = 3,
+) -> dict[str, Any] | None:
+    """获取单个实体详情：基本信息 + 邻居（限定在 publication 内）+ 提及 entries。"""
+    pub = await db.get(WikiPublication, pub_id)
+    if pub is None:
+        return None
+
+    ctx = _SliceContext(pub)
+    await _load_document_ids(db, ctx)
+    if not ctx.document_ids:
+        return None
+
+    # 候选节点集合（不截断，仅用于邻居过滤）
+    node_ids_stmt = (
+        select(KgEntityMention.entity_id).where(KgEntityMention.document_id.in_(ctx.document_ids)).distinct()
+    )
+    node_ids: list[UUID] = [row[0] for row in (await db.execute(node_ids_stmt)).all()]
+    if entity_id not in node_ids:
+        return None
+
+    entity = await db.get(KgEntity, entity_id)
+    if entity is None or not entity.is_active:
+        return None
+
+    mention_counts = await _load_mention_counts_in_pub(
+        db,
+        document_ids=ctx.document_ids,
+        entity_ids=[entity_id],
+    )
+    entry_slugs_map = await _load_entry_slugs_for_entities(
+        db,
+        pub_id=pub_id,
+        entity_ids=[entity_id],
+        per_node=entry_slugs_per_node,
+    )
+
+    # 邻居：两端都在 node_ids 内（与图谱切片一致）
+    out_stmt = (
+        select(KgRelation, KgEntity)
+        .join(KgEntity, KgEntity.id == KgRelation.target_id)
+        .where(
+            KgRelation.source_id == entity_id,
+            KgRelation.target_id.in_(node_ids),
+            KgRelation.is_active.is_(True),
+            KgEntity.is_active.is_(True),
+        )
+    )
+    in_stmt = (
+        select(KgRelation, KgEntity)
+        .join(KgEntity, KgEntity.id == KgRelation.source_id)
+        .where(
+            KgRelation.target_id == entity_id,
+            KgRelation.source_id.in_(node_ids),
+            KgRelation.is_active.is_(True),
+            KgEntity.is_active.is_(True),
+        )
+    )
+
+    neighbor_entity_ids: list[UUID] = []
+    neighbors: list[dict[str, Any]] = []
+    for rel, peer in (await db.execute(out_stmt)).all():
+        neighbor_entity_ids.append(peer.id)
+        neighbors.append(
+            {
+                "id": str(peer.id),
+                "name": peer.canonical_name or peer.name,
+                "entity_type": peer.entity_type,
+                "relation_type": rel.relation_type,
+                "direction": "outgoing",
+                "weight": rel.weight,
+                "entry_slugs": [],
+            }
+        )
+    for rel, peer in (await db.execute(in_stmt)).all():
+        neighbor_entity_ids.append(peer.id)
+        neighbors.append(
+            {
+                "id": str(peer.id),
+                "name": peer.canonical_name or peer.name,
+                "entity_type": peer.entity_type,
+                "relation_type": rel.relation_type,
+                "direction": "incoming",
+                "weight": rel.weight,
+                "entry_slugs": [],
+            }
+        )
+
+    if neighbor_entity_ids:
+        neighbor_slugs = await _load_entry_slugs_for_entities(
+            db,
+            pub_id=pub_id,
+            entity_ids=neighbor_entity_ids,
+            per_node=entry_slugs_per_node,
+        )
+        for n in neighbors:
+            n["entry_slugs"] = neighbor_slugs.get(UUID(n["id"]), [])
+
+    # 提及该实体的 entries
+    mentioning = await _load_mentioning_entries(
+        db,
+        pub_id=pub_id,
+        entity_id=entity_id,
+    )
+
+    return {
+        "publication_id": pub_id,
+        "version": pub.version,
+        "entity": {
+            "id": str(entity.id),
+            "name": entity.canonical_name or entity.name,
+            "entity_type": entity.entity_type,
+            "importance": entity.importance_score,
+            "community_id": entity.community_id,
+            "mention_count_in_pub": mention_counts.get(entity.id, 0),
+            "entry_slugs": entry_slugs_map.get(entity.id, []),
+            "corpus_id": entity.corpus_id,
+        },
+        "neighbors": neighbors,
+        "mentioning_entries": mentioning,
+    }
+
+
+async def get_entry_graph(
+    db: AsyncSession,
+    *,
+    entry_id: UUID,
+    max_nodes: int = 60,
+    entry_slugs_per_node: int = 3,
+) -> dict[str, Any] | None:
+    """获取单个 Wiki entry 的"局部图"：该文档涉及实体 + 1 跳邻居。"""
+    entry = await db.get(WikiPublicationEntry, entry_id)
+    if entry is None or entry.entry_kind != "DOCUMENT" or entry.document_id is None:
+        return None
+
+    pub = await db.get(WikiPublication, entry.publication_id)
+    if pub is None:
+        return None
+
+    # 中心节点：该文档直接 mention 的实体
+    center_stmt = select(KgEntityMention.entity_id).where(KgEntityMention.document_id == entry.document_id).distinct()
+    center_ids: list[UUID] = [row[0] for row in (await db.execute(center_stmt)).all()]
+
+    if not center_ids:
+        return {
+            "entry_id": entry.id,
+            "publication_id": pub.id,
+            "version": pub.version,
+            "status": "empty",
+            "nodes": [],
+            "edges": [],
+            "center_entity_ids": [],
+        }
+
+    # 一跳扩展：合并 center_ids 的所有 incoming + outgoing 邻居
+    neighbors_stmt = select(KgRelation).where(
+        ((KgRelation.source_id.in_(center_ids)) | (KgRelation.target_id.in_(center_ids))),
+        KgRelation.is_active.is_(True),
+    )
+    all_relations = (await db.execute(neighbors_stmt)).scalars().all()
+    node_ids: set[UUID] = set(center_ids)
+    for rel in all_relations:
+        node_ids.add(rel.source_id)
+        node_ids.add(rel.target_id)
+
+    # 按 max_nodes 截断（保证 center_ids 一定被保留）
+    node_ids_list = list(node_ids)
+    if len(node_ids_list) > max_nodes:
+        center_set = set(center_ids)
+        candidate_ids = [nid for nid in node_ids_list if nid not in center_set]
+        # 优先保留 center，再用 importance 排序补全
+        priority_stmt = (
+            select(KgEntity.id)
+            .where(KgEntity.id.in_(candidate_ids))
+            .order_by(KgEntity.importance_score.desc().nulls_last(), KgEntity.mention_count.desc())
+            .limit(max(max_nodes - len(center_ids), 0))
+        )
+        fill_ids = [row[0] for row in (await db.execute(priority_stmt)).all()]
+        node_ids_list = list(center_set | set(fill_ids))
+
+    entities = await _load_entities(db, node_ids_list)
+
+    # mention_count_in_pub: 仅用本 publication 内所有 documents 反查
+    ctx = _SliceContext(pub)
+    await _load_document_ids(db, ctx)
+    mention_counts = await _load_mention_counts_in_pub(
+        db,
+        document_ids=ctx.document_ids,
+        entity_ids=[e.id for e in entities],
+    )
+    entry_slugs_map = await _load_entry_slugs_for_entities(
+        db,
+        pub_id=pub.id,
+        entity_ids=[e.id for e in entities],
+        per_node=entry_slugs_per_node,
+    )
+
+    nodes = [
+        _build_node(
+            ent,
+            mention_count_in_pub=mention_counts.get(ent.id, 0),
+            entry_slugs=entry_slugs_map.get(ent.id, []),
+        )
+        for ent in entities
+    ]
+    kept_set = {e.id for e in entities}
+    edges = [_build_edge(rel) for rel in all_relations if rel.source_id in kept_set and rel.target_id in kept_set]
+
+    return {
+        "entry_id": entry.id,
+        "publication_id": pub.id,
+        "version": pub.version,
+        "status": "ok" if nodes else "empty",
+        "nodes": nodes,
+        "edges": edges,
+        "center_entity_ids": [str(cid) for cid in center_ids if cid in kept_set],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 内部辅助
+# ---------------------------------------------------------------------------
+
+
+def _resolve_entity_sort(sort_by: str) -> list[Any]:
+    """实体列表排序键解析（白名单，避免注入风险）。"""
+    if sort_by == "name":
+        return [KgEntity.canonical_name.asc().nulls_last(), KgEntity.name.asc()]
+    if sort_by == "mention":
+        return [KgEntity.mention_count.desc(), KgEntity.importance_score.desc().nulls_last()]
+    # 默认：importance
+    return [KgEntity.importance_score.desc().nulls_last(), KgEntity.mention_count.desc()]
+
+
+def _empty_response(ctx: _SliceContext, *, status_: str) -> dict[str, Any]:
+    return {
+        "publication_id": ctx.publication.id,
+        "version": ctx.publication.version,
+        "status": status_,
+        "nodes": [],
+        "edges": [],
+        "truncated": False,
+        "total_entities": 0,
+        "corpus_ids": [],
+    }
+
+
+def _entity_list_empty(ctx: _SliceContext, offset: int, limit: int) -> dict[str, Any]:
+    return {
+        "publication_id": ctx.publication.id,
+        "version": ctx.publication.version,
+        "total": 0,
+        "offset": offset,
+        "limit": limit,
+        "items": [],
+    }
+
+
+async def _load_document_ids(db: AsyncSession, ctx: _SliceContext) -> None:
+    """加载 Publication 关联的 DOCUMENT 类型 entries 的 document_id 集合。"""
+    stmt = select(WikiPublicationEntry.document_id).where(
+        WikiPublicationEntry.publication_id == ctx.publication.id,
+        WikiPublicationEntry.entry_kind == "DOCUMENT",
+        WikiPublicationEntry.document_id.is_not(None),
+    )
+    ctx.document_ids = [row[0] for row in (await db.execute(stmt)).all() if row[0] is not None]
+
+
+async def _load_candidate_node_ids(
+    db: AsyncSession,
+    ctx: _SliceContext,
+    *,
+    max_nodes: int,
+    min_importance: float,
+) -> None:
+    """加载候选节点 ID（DISTINCT，按 importance 排序，可截断）。
+
+    设置 ctx.node_ids（全集）、ctx.kept_node_ids（截断后）、ctx.total_entities、
+    ctx.truncated。
+    """
+    # 全量计数：DISTINCT entity_id WHERE document_id IN documents
+    count_stmt = select(func.count(func.distinct(KgEntityMention.entity_id))).where(
+        KgEntityMention.document_id.in_(ctx.document_ids)
+    )
+    ctx.total_entities = int((await db.execute(count_stmt)).scalar() or 0)
+    if ctx.total_entities == 0:
+        return
+
+    # 取候选节点 ID（联表 KgEntity 以应用 min_importance / is_active 过滤 + 排序）
+    mention_subq = (
+        select(KgEntityMention.entity_id.label("entity_id"))
+        .where(KgEntityMention.document_id.in_(ctx.document_ids))
+        .distinct()
+        .subquery()
+    )
+
+    base_stmt = (
+        select(KgEntity.id)
+        .join(mention_subq, mention_subq.c.entity_id == KgEntity.id)
+        .where(KgEntity.is_active.is_(True))
+        .order_by(
+            KgEntity.importance_score.desc().nulls_last(),
+            KgEntity.mention_count.desc(),
+        )
+    )
+    if min_importance > 0:
+        base_stmt = base_stmt.where(KgEntity.importance_score >= min_importance)
+
+    # 多取 1 个用于检测是否截断
+    candidate_stmt = base_stmt.limit(max_nodes + 1)
+    rows = (await db.execute(candidate_stmt)).all()
+    ctx.node_ids = [row[0] for row in rows]
+
+    if len(ctx.node_ids) > max_nodes:
+        ctx.truncated = True
+        ctx.kept_node_ids = ctx.node_ids[:max_nodes]
+    else:
+        ctx.kept_node_ids = ctx.node_ids
+
+
+async def _load_entities(db: AsyncSession, entity_ids: list[UUID]) -> list[KgEntity]:
+    if not entity_ids:
+        return []
+    stmt = select(KgEntity).where(KgEntity.id.in_(entity_ids), KgEntity.is_active.is_(True))
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def _load_edges(db: AsyncSession, node_ids: list[UUID]) -> list[dict[str, Any]]:
+    """加载两端都在 node_ids 内的边（剔悬挂边）。"""
+    if not node_ids:
+        return []
+    stmt = select(KgRelation).where(
+        KgRelation.source_id.in_(node_ids),
+        KgRelation.target_id.in_(node_ids),
+        KgRelation.is_active.is_(True),
+    )
+    relations = (await db.execute(stmt)).scalars().all()
+    return [_build_edge(rel) for rel in relations]
+
+
+async def _load_mention_counts_in_pub(
+    db: AsyncSession,
+    *,
+    document_ids: list[UUID],
+    entity_ids: list[UUID],
+) -> dict[UUID, int]:
+    """聚合每个实体在 publication 内文档的提及次数。"""
+    if not document_ids or not entity_ids:
+        return {}
+    stmt = (
+        select(KgEntityMention.entity_id, func.count(KgEntityMention.id))
+        .where(
+            KgEntityMention.entity_id.in_(entity_ids),
+            KgEntityMention.document_id.in_(document_ids),
+        )
+        .group_by(KgEntityMention.entity_id)
+    )
+    return {row[0]: int(row[1]) for row in (await db.execute(stmt)).all()}
+
+
+async def _load_entry_slugs_for_entities(
+    db: AsyncSession,
+    *,
+    pub_id: UUID,
+    entity_ids: list[UUID],
+    per_node: int,
+) -> dict[UUID, list[str]]:
+    """每实体取前 ``per_node`` 个相关 entry_slug。
+
+    实现策略：先查出所有 (entity_id, entry_slug, mention_count) 三元组，
+    再在 Python 端按 entity_id 分桶取前 N。简单稳健，避免依赖窗口函数。
+
+    规模评估：典型实体数 ≤300 × 平均 entry ≤10 → 三元组数 ≤3000，可控。
+    """
+    if not entity_ids:
+        return {}
+
+    stmt = (
+        select(
+            KgEntityMention.entity_id,
+            WikiPublicationEntry.entry_slug,
+            func.count(KgEntityMention.id).label("cnt"),
+        )
+        .join(
+            WikiPublicationEntry,
+            WikiPublicationEntry.document_id == KgEntityMention.document_id,
+        )
+        .where(
+            WikiPublicationEntry.publication_id == pub_id,
+            WikiPublicationEntry.entry_kind == "DOCUMENT",
+            KgEntityMention.entity_id.in_(entity_ids),
+        )
+        .group_by(KgEntityMention.entity_id, WikiPublicationEntry.entry_slug)
+        .order_by(KgEntityMention.entity_id, func.count(KgEntityMention.id).desc())
+    )
+    result: dict[UUID, list[str]] = {}
+    for ent_id, entry_slug, _cnt in (await db.execute(stmt)).all():
+        bucket = result.setdefault(ent_id, [])
+        if len(bucket) < per_node:
+            bucket.append(entry_slug)
+    return result
+
+
+async def _load_mentioning_entries(
+    db: AsyncSession,
+    *,
+    pub_id: UUID,
+    entity_id: UUID,
+) -> list[dict[str, Any]]:
+    """加载提及指定实体的 Wiki entries，按 mention 数倒序。"""
+    stmt = (
+        select(
+            WikiPublicationEntry.id,
+            WikiPublicationEntry.entry_slug,
+            WikiPublicationEntry.entry_title,
+            WikiPublicationEntry.document_id,
+            func.count(KgEntityMention.id).label("cnt"),
+        )
+        .join(
+            KgEntityMention,
+            KgEntityMention.document_id == WikiPublicationEntry.document_id,
+        )
+        .where(
+            WikiPublicationEntry.publication_id == pub_id,
+            WikiPublicationEntry.entry_kind == "DOCUMENT",
+            KgEntityMention.entity_id == entity_id,
+        )
+        .group_by(
+            WikiPublicationEntry.id,
+            WikiPublicationEntry.entry_slug,
+            WikiPublicationEntry.entry_title,
+            WikiPublicationEntry.document_id,
+        )
+        .order_by(func.count(KgEntityMention.id).desc())
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "entry_id": str(entry_id),
+            "entry_slug": entry_slug,
+            "entry_title": entry_title,
+            "document_id": str(document_id) if document_id else None,
+            "mention_count": int(cnt),
+        }
+        for entry_id, entry_slug, entry_title, document_id, cnt in rows
+    ]
+
+
+def _build_node(
+    ent: KgEntity,
+    *,
+    mention_count_in_pub: int,
+    entry_slugs: list[str],
+) -> dict[str, Any]:
+    """KgEntity → Wiki Graph 节点 dict。"""
+    return {
+        "id": str(ent.id),
+        "label": ent.canonical_name or ent.name,
+        "type": ent.entity_type,
+        "importance": ent.importance_score,
+        "community_id": ent.community_id,
+        "entry_slugs": list(entry_slugs),
+        "mention_count_in_pub": mention_count_in_pub,
+        "metadata": {
+            "corpus_id": str(ent.corpus_id),
+            "entity_type": ent.entity_type,
+            "confidence": ent.confidence,
+            "global_mention_count": ent.mention_count,
+        },
+    }
+
+
+def _build_edge(rel: KgRelation) -> dict[str, Any]:
+    """KgRelation → Wiki Graph 边 dict。"""
+    metadata: dict[str, Any] = {
+        "confidence": rel.confidence,
+    }
+    if rel.evidence_text:
+        # 仅截前 200 字防止响应膨胀
+        snippet = rel.evidence_text.strip()
+        metadata["evidence_snippet"] = snippet[:200] + ("…" if len(snippet) > 200 else "")
+    return {
+        "source": str(rel.source_id),
+        "target": str(rel.target_id),
+        "label": rel.relation_type,
+        "type": rel.relation_type,
+        "weight": rel.weight,
+        "metadata": metadata,
+    }
+
+
+__all__ = [
+    "get_publication_graph",
+    "get_publication_entities",
+    "get_publication_entity_detail",
+    "get_entry_graph",
+]

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_graph_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_graph_service.py
@@ -201,14 +201,6 @@ async def get_publication_entities(
     if not ctx.document_ids:
         return _entity_list_empty(ctx, offset, limit)
 
-    # 统计总实体数
-    total_stmt = select(func.count(func.distinct(KgEntityMention.entity_id))).where(
-        KgEntityMention.document_id.in_(ctx.document_ids)
-    )
-    total = int((await db.execute(total_stmt)).scalar() or 0)
-    if total == 0:
-        return _entity_list_empty(ctx, offset, limit)
-
     sort_clauses: list[Any] = _resolve_entity_sort(sort_by)
     mention_subq = (
         select(KgEntityMention.entity_id.label("entity_id"))
@@ -216,6 +208,18 @@ async def get_publication_entities(
         .distinct()
         .subquery()
     )
+
+    # 总数与下方 items_stmt 同口径（JOIN KgEntity + is_active=True），避免
+    # 分页累计数 < total 导致前端「最后一页空」或页码错位。
+    total_stmt = (
+        select(func.count(KgEntity.id))
+        .join(mention_subq, mention_subq.c.entity_id == KgEntity.id)
+        .where(KgEntity.is_active.is_(True))
+    )
+    total = int((await db.execute(total_stmt)).scalar() or 0)
+    if total == 0:
+        return _entity_list_empty(ctx, offset, limit)
+
     items_stmt = (
         select(KgEntity)
         .join(mention_subq, mention_subq.c.entity_id == KgEntity.id)
@@ -547,14 +551,6 @@ async def _load_candidate_node_ids(
     设置 ctx.node_ids（全集）、ctx.kept_node_ids（截断后）、ctx.total_entities、
     ctx.truncated。
     """
-    # 全量计数：DISTINCT entity_id WHERE document_id IN documents
-    count_stmt = select(func.count(func.distinct(KgEntityMention.entity_id))).where(
-        KgEntityMention.document_id.in_(ctx.document_ids)
-    )
-    ctx.total_entities = int((await db.execute(count_stmt)).scalar() or 0)
-    if ctx.total_entities == 0:
-        return
-
     # 取候选节点 ID（联表 KgEntity 以应用 min_importance / is_active 过滤 + 排序）
     mention_subq = (
         select(KgEntityMention.entity_id.label("entity_id"))
@@ -563,20 +559,29 @@ async def _load_candidate_node_ids(
         .subquery()
     )
 
-    base_stmt = (
+    # 总数与候选查询同口径（is_active + min_importance），避免前端截断横幅
+    # 「共 X 个实体，仅显示 top-N」把失活/低权重实体计入分母而误导用户。
+    base_filters = [KgEntity.is_active.is_(True)]
+    if min_importance > 0:
+        base_filters.append(KgEntity.importance_score >= min_importance)
+
+    count_stmt = (
+        select(func.count(KgEntity.id)).join(mention_subq, mention_subq.c.entity_id == KgEntity.id).where(*base_filters)
+    )
+    ctx.total_entities = int((await db.execute(count_stmt)).scalar() or 0)
+    if ctx.total_entities == 0:
+        return
+
+    candidate_stmt = (
         select(KgEntity.id)
         .join(mention_subq, mention_subq.c.entity_id == KgEntity.id)
-        .where(KgEntity.is_active.is_(True))
+        .where(*base_filters)
         .order_by(
             KgEntity.importance_score.desc().nulls_last(),
             KgEntity.mention_count.desc(),
         )
+        .limit(max_nodes + 1)  # 多取 1 个用于检测是否截断
     )
-    if min_importance > 0:
-        base_stmt = base_stmt.where(KgEntity.importance_score >= min_importance)
-
-    # 多取 1 个用于检测是否截断
-    candidate_stmt = base_stmt.limit(max_nodes + 1)
     rows = (await db.execute(candidate_stmt)).all()
     ctx.node_ids = [row[0] for row in rows]
 

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki_graph.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki_graph.py
@@ -1,0 +1,239 @@
+"""Wiki Knowledge Graph 路由：将后端 KG 按 Wiki Publication 切片发布给 SSG 站点。
+
+设计原则：
+
+- **正交分解**：与 :mod:`wiki`（发布生命周期 CRUD）独立的模块；切片查询逻辑
+  下沉到 :mod:`negentropy.knowledge.lifecycle.wiki_graph_service`，路由层只
+  负责输入校验、可见性 gating 与响应包装。
+- **可见性 gating**：仅 ``status='published'`` 的 publication 暴露给 Wiki，
+  其余返回 404 / 403，与 ``wiki_service.publish`` 既有语义一致。
+- **响应契约**：字段命名与主站 ``apps/negentropy-ui`` 的 GraphCanvas 同名
+  （为未来抽共享类型留余地），新增 Wiki 专属字段见 :mod:`schemas`
+  (``WikiGraphResponse`` 等)。
+- **缓存键**：响应附 ``version`` 字段；HTTP 端通过 ``ETag = "{pub_id}:{version}"``
+  支持客户端强缓存（SSG ``fetch`` 通过 Next.js ISR ``revalidate`` 配合，无
+  需后端额外缓存层）。
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import select
+
+from negentropy.db.session import AsyncSessionLocal
+from negentropy.knowledge.lifecycle import wiki_graph_service
+from negentropy.knowledge.schemas import (
+    WikiEntryGraphResponse,
+    WikiGraphEntityDetailResponse,
+    WikiGraphEntityItem,
+    WikiGraphEntityListResponse,
+    WikiGraphNeighborItem,
+    WikiGraphResponse,
+)
+from negentropy.logging import get_logger
+from negentropy.models.perception import WikiPublication, WikiPublicationEntry
+
+logger = get_logger("negentropy.knowledge.api")
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# 内部辅助
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_published(pub_id: UUID) -> WikiPublication:
+    """加载 publication 并校验可见性（仅 published 暴露给 Wiki）。
+
+    Raises:
+        HTTPException 404：发布不存在；
+        HTTPException 403：发布存在但状态非 published。
+    """
+    async with AsyncSessionLocal() as db:
+        pub = await db.get(WikiPublication, pub_id)
+        if pub is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "WIKI_PUB_NOT_FOUND", "message": "Wiki publication not found"},
+            )
+        if pub.status != "published":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "WIKI_PUB_NOT_PUBLISHED",
+                    "message": "Wiki publication is not published",
+                    "details": {"status": pub.status},
+                },
+            )
+        return pub
+
+
+def _set_cache_headers(response: Response, pub: WikiPublication) -> None:
+    """以 ``{pub_id}:{version}`` 作为 ETag，并设置 5 分钟 max-age（与 SSG ISR 一致）。"""
+    response.headers["ETag"] = f'"{pub.id}:{pub.version}"'
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+
+# ---------------------------------------------------------------------------
+# 路由端点
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/wiki/publications/{pub_id}/graph",
+    response_model=WikiGraphResponse,
+)
+async def get_publication_graph(
+    pub_id: UUID,
+    response: Response,
+    max_nodes: int = Query(default=300, ge=1, le=1000),
+    min_importance: float = Query(default=0.0, ge=0.0),
+    include_isolated: bool = Query(default=False),
+) -> WikiGraphResponse:
+    """获取 Publication 整体切片图谱（节点 + 边）。
+
+    切片语义：仅包含本 publication 关联 documents 所提及的实体；两端都在
+    节点集合内的边才保留（无悬挂边）。节点超出 ``max_nodes`` 时按
+    ``importance_score`` DESC 截断，响应 ``truncated=true``。
+    """
+    pub = await _ensure_published(pub_id)
+    async with AsyncSessionLocal() as db:
+        payload = await wiki_graph_service.get_publication_graph(
+            db,
+            pub_id=pub_id,
+            max_nodes=max_nodes,
+            min_importance=min_importance,
+            include_isolated=include_isolated,
+        )
+
+    if payload is None:
+        # _ensure_published 已确保存在；理论上不可达，防御性兜底
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki publication not found")
+
+    _set_cache_headers(response, pub)
+    logger.info(
+        "api_wiki_graph_payload",
+        pub_id=str(pub_id),
+        node_count=len(payload["nodes"]),
+        edge_count=len(payload["edges"]),
+        truncated=payload["truncated"],
+        status_=payload["status"],
+    )
+    return WikiGraphResponse.model_validate(payload)
+
+
+@router.get(
+    "/wiki/publications/{pub_id}/graph/entities",
+    response_model=WikiGraphEntityListResponse,
+)
+async def get_publication_graph_entities(
+    pub_id: UUID,
+    response: Response,
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=500),
+    sort_by: str = Query(
+        default="importance",
+        pattern="^(importance|mention|name)$",
+        description="排序键：importance(默认) | mention | name",
+    ),
+) -> WikiGraphEntityListResponse:
+    """获取 Publication 实体扁平列表（分页，供"实体面板/搜索"使用）。"""
+    pub = await _ensure_published(pub_id)
+    async with AsyncSessionLocal() as db:
+        payload = await wiki_graph_service.get_publication_entities(
+            db,
+            pub_id=pub_id,
+            offset=offset,
+            limit=limit,
+            sort_by=sort_by,
+        )
+
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki publication not found")
+
+    _set_cache_headers(response, pub)
+    items = [WikiGraphEntityItem.model_validate(item) for item in payload["items"]]
+    return WikiGraphEntityListResponse(
+        publication_id=payload["publication_id"],
+        version=payload["version"],
+        total=payload["total"],
+        offset=payload["offset"],
+        limit=payload["limit"],
+        items=items,
+    )
+
+
+@router.get(
+    "/wiki/publications/{pub_id}/graph/entities/{entity_id}",
+    response_model=WikiGraphEntityDetailResponse,
+)
+async def get_publication_graph_entity_detail(
+    pub_id: UUID,
+    entity_id: UUID,
+    response: Response,
+) -> WikiGraphEntityDetailResponse:
+    """获取实体详情：基本信息 + 邻居（仅 publication 内）+ 提及该实体的 entries。"""
+    pub = await _ensure_published(pub_id)
+    async with AsyncSessionLocal() as db:
+        payload = await wiki_graph_service.get_publication_entity_detail(
+            db,
+            pub_id=pub_id,
+            entity_id=entity_id,
+        )
+
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "WIKI_GRAPH_ENTITY_NOT_FOUND", "message": "Entity not in publication scope"},
+        )
+
+    _set_cache_headers(response, pub)
+    return WikiGraphEntityDetailResponse(
+        publication_id=payload["publication_id"],
+        version=payload["version"],
+        entity=WikiGraphEntityItem.model_validate(payload["entity"]),
+        neighbors=[WikiGraphNeighborItem.model_validate(n) for n in payload["neighbors"]],
+        mentioning_entries=payload["mentioning_entries"],
+    )
+
+
+@router.get(
+    "/wiki/entries/{entry_id}/graph",
+    response_model=WikiEntryGraphResponse,
+)
+async def get_wiki_entry_graph(
+    entry_id: UUID,
+    response: Response,
+    max_nodes: int = Query(default=60, ge=1, le=300),
+) -> WikiEntryGraphResponse:
+    """获取单 entry 的"局部图"：该文档涉及实体 + 1 跳邻居。
+
+    可见性 gating 沿用所属 publication 的 ``status='published'`` 约束。
+    """
+    # 提前查 entry 对应的 publication；用于 _ensure_published + ETag。
+    async with AsyncSessionLocal() as db:
+        entry_stmt = select(WikiPublicationEntry).where(WikiPublicationEntry.id == entry_id)
+        entry = (await db.execute(entry_stmt)).scalar_one_or_none()
+
+    if entry is None or entry.entry_kind != "DOCUMENT" or entry.document_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "WIKI_ENTRY_NOT_FOUND", "message": "Wiki entry not found"},
+        )
+
+    pub = await _ensure_published(entry.publication_id)
+
+    async with AsyncSessionLocal() as db:
+        payload = await wiki_graph_service.get_entry_graph(
+            db,
+            entry_id=entry_id,
+            max_nodes=max_nodes,
+        )
+
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki entry graph not found")
+
+    _set_cache_headers(response, pub)
+    return WikiEntryGraphResponse.model_validate(payload)

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -661,3 +661,158 @@ class ApiStatsResponse(BaseModel):
     success_count: int = Field(description="成功调用次数")
     failed_count: int = Field(description="失败调用次数")
     avg_latency_ms: float = Field(description="平均延迟（毫秒）")
+
+
+# ============================================================================
+# Wiki Knowledge Graph Schemas
+# ----------------------------------------------------------------------------
+# 用于 ``apps/negentropy-wiki`` SSG 站点按 Publication 维度拉取知识图谱切片。
+#
+# 设计要点：
+#   - 字段命名与主站 ``apps/negentropy-ui`` GraphCanvas 同名（id/label/type/
+#     importance/community_id + source/target/label/type/weight），便于未来抽
+#     共享类型。
+#   - 节点新增 ``entry_slugs``（Wiki 内首批 ≤3 个引用本实体的文档 slug，供
+#     点击跳转）与 ``mention_count_in_pub``（仅 publication 内提及计数，区
+#     别于全语料 mention_count）。
+#   - Envelope 携带 ``publication_id`` + ``version`` + ``truncated`` +
+#     ``total_entities`` + ``status``（"ok" / "no_kg" / "empty"）。
+#   - 跨 corpus publication 阶段一按 corpus_id 各自保留（不做 canonical 合
+#     并），通过节点 ``metadata.corpus_id`` 区分。
+# ============================================================================
+
+
+class WikiGraphNode(BaseModel):
+    """Wiki 切片图谱节点"""
+
+    id: str = Field(description="实体节点 ID（沿用后端 GraphService 输出格式）")
+    label: str = Field(description="节点显示名（canonical_name 或 name）")
+    type: str = Field(description="节点类型（entity_type，如 PERSON/ORGANIZATION/CONCEPT）")
+    importance: float | None = Field(default=None, description="重要性得分（用于按 top-N 截断）")
+    community_id: int | None = Field(default=None, description="Louvain 社区 ID")
+    entry_slugs: list[str] = Field(
+        default_factory=list,
+        description="Publication 内提及本实体的前 N 个 entry slug（默认 N=3，供节点点击跳转）",
+    )
+    mention_count_in_pub: int = Field(
+        default=0,
+        ge=0,
+        description="Publication 内文档对本实体的提及总次数（区别于全语料 mention_count）",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "节点附加元数据：corpus_id（跨 corpus publication 着色用）、entity_type、confidence、is_active 等。"
+        ),
+    )
+
+
+class WikiGraphEdge(BaseModel):
+    """Wiki 切片图谱边"""
+
+    source: str = Field(description="起点节点 ID")
+    target: str = Field(description="终点节点 ID")
+    label: str = Field(description="关系标签（relation_type）")
+    type: str = Field(description="边类型（与 label 同源；保留字段供未来精细化）")
+    weight: float = Field(default=1.0, description="边权重")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="confidence / evidence 等可选元数据")
+
+
+class WikiGraphResponse(BaseModel):
+    """Wiki Publication 整体图谱切片响应
+
+    ``status`` 语义：
+        - ``ok``     ：正常返回非空图；
+        - ``no_kg``  ：Publication 关联的 corpus 上 KG 未构建（nodes/edges 必为空）；
+        - ``empty``  ：KG 已构建但该 Publication 文档未涉及任何实体（如全 mention 被过滤）。
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    publication_id: UUID
+    version: int = Field(ge=0, description="Publication 版本号；作为客户端缓存键的一部分")
+    status: str = Field(default="ok", description="ok | no_kg | empty")
+    nodes: list[WikiGraphNode] = Field(default_factory=list)
+    edges: list[WikiGraphEdge] = Field(default_factory=list)
+    truncated: bool = Field(
+        default=False,
+        description="True 表示节点数超过 max_nodes 被截断，悬挂边已剔除",
+    )
+    total_entities: int = Field(
+        default=0,
+        ge=0,
+        description="截断前的实体总数（即满足 min_importance 的实体数）",
+    )
+    corpus_ids: list[UUID] = Field(
+        default_factory=list,
+        description="Publication 实际覆盖的 corpus_id 集合",
+    )
+
+
+class WikiGraphEntityItem(BaseModel):
+    """Wiki 实体扁平列表条目"""
+
+    id: str
+    name: str
+    entity_type: str
+    importance: float | None = None
+    community_id: int | None = None
+    mention_count_in_pub: int = Field(default=0, ge=0)
+    entry_slugs: list[str] = Field(default_factory=list)
+    corpus_id: UUID | None = None
+
+
+class WikiGraphEntityListResponse(BaseModel):
+    """Wiki 实体列表响应"""
+
+    publication_id: UUID
+    version: int
+    total: int = Field(ge=0)
+    offset: int = Field(default=0, ge=0)
+    limit: int = Field(default=50, ge=1, le=500)
+    items: list[WikiGraphEntityItem] = Field(default_factory=list)
+
+
+class WikiGraphNeighborItem(BaseModel):
+    """实体邻居（限定在 publication 节点集合内）"""
+
+    id: str
+    name: str
+    entity_type: str
+    relation_type: str
+    direction: str = Field(description="outgoing | incoming")
+    weight: float = 1.0
+    entry_slugs: list[str] = Field(default_factory=list)
+
+
+class WikiGraphEntityDetailResponse(BaseModel):
+    """Wiki 实体详情响应：实体属性 + 邻居 + 提及 entries"""
+
+    publication_id: UUID
+    version: int
+    entity: WikiGraphEntityItem
+    neighbors: list[WikiGraphNeighborItem] = Field(
+        default_factory=list,
+        description="邻居仅限制在 publication 节点集合内（未越过本发布边界）",
+    )
+    mentioning_entries: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="提及该实体的 Wiki entries：[{entry_id, entry_slug, entry_title, document_id, mention_count}]",
+    )
+
+
+class WikiEntryGraphResponse(BaseModel):
+    """单 entry 的局部图（该文档涉及的实体 + 一跳邻居）"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    entry_id: UUID
+    publication_id: UUID
+    version: int
+    status: str = Field(default="ok", description="ok | no_kg | empty")
+    nodes: list[WikiGraphNode] = Field(default_factory=list)
+    edges: list[WikiGraphEdge] = Field(default_factory=list)
+    center_entity_ids: list[str] = Field(
+        default_factory=list,
+        description="该 entry 直接涉及的实体 ID（用作前端高亮中心节点）",
+    )

--- a/apps/negentropy/tests/integration_tests/knowledge/test_wiki_graph_service.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_wiki_graph_service.py
@@ -1,0 +1,496 @@
+"""Wiki Knowledge Graph 切片服务集成测试
+
+覆盖 :mod:`negentropy.knowledge.lifecycle.wiki_graph_service` 的核心 SQL
+反查链路：
+
+- ``wiki_publication_entries → document_id → kg_entity_mentions → entity_id``
+- 节点数截断（``max_nodes`` + ``importance_score`` 排序）
+- 边过滤（两端都在节点集合内）
+- 空 publication / 无 KG 兜底（``status='empty'``）
+- 单 entry 局部图（``get_entry_graph``）
+
+所有测试使用真实 PostgreSQL；fixtures 在测试结束时彻底回滚（DELETE 树
+形依赖避免污染下游测试）。
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# ===================================================================
+# Fixtures
+#
+# 说明：DocCatalog 上有 `uq_doc_catalogs_app_singleton` 唯一约束（每
+# app_name 仅 1 条目录），故每个测试用唯一 app_name 隔离，避免与
+# 既有数据 / 其它测试相互影响。
+# ===================================================================
+
+
+@pytest.fixture
+def graph_app_name() -> str:
+    """每个测试独立 app_name，规避 catalog 单例约束。"""
+    return f"wg-test-{uuid4().hex[:12]}"
+
+
+@pytest.fixture
+async def graph_corpus(db_engine, graph_app_name):
+    """测试用 Corpus。"""
+    from negentropy.models.perception import Corpus
+
+    factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        c = Corpus(name=f"wg-corpus-{uuid4().hex[:8]}", app_name=graph_app_name)
+        s.add(c)
+        await s.commit()
+        cid = c.id
+    yield cid
+    async with factory() as s:
+        obj = await s.get(Corpus, cid)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def graph_corpus_2(db_engine, graph_app_name):
+    """第二个 Corpus（用于跨 corpus 测试）。"""
+    from negentropy.models.perception import Corpus
+
+    factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        c = Corpus(name=f"wg-corpus2-{uuid4().hex[:8]}", app_name=graph_app_name)
+        s.add(c)
+        await s.commit()
+        cid = c.id
+    yield cid
+    async with factory() as s:
+        obj = await s.get(Corpus, cid)
+        if obj is not None:
+            await s.delete(obj)
+            await s.commit()
+
+
+@pytest.fixture
+async def graph_catalog(db_engine, graph_app_name):
+    """测试用 DocCatalog。"""
+    from negentropy.models.perception import DocCatalog, WikiPublication
+
+    factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        cat = DocCatalog(
+            app_name=graph_app_name,
+            name=f"wg-cat-{uuid4().hex[:8]}",
+            slug=f"wg-cat-{uuid4().hex[:8]}",
+            visibility="INTERNAL",
+            version=1,
+            is_archived=False,
+        )
+        s.add(cat)
+        await s.commit()
+        cat_id = cat.id
+    yield cat_id
+    async with factory() as s:
+        await s.execute(WikiPublication.__table__.delete().where(WikiPublication.catalog_id == cat_id))
+        await s.commit()
+        cat = await s.get(DocCatalog, cat_id)
+        if cat is not None:
+            await s.delete(cat)
+            await s.commit()
+
+
+@pytest.fixture
+async def graph_world(db_engine, graph_corpus, graph_catalog, graph_app_name):
+    """构造完整测试场景：
+
+    Publication（published）→ 3 个 DOCUMENT entries → 3 个 documents
+    → 6 个 KgEntity（其中 5 个被 mention，1 个独立）→ 6 条 KgRelation
+    （其中 1 条的端点不在 mention 集合内，应被切片剔除）。
+    """
+    from negentropy.models.perception import (
+        KgEntity,
+        KgEntityMention,
+        KgRelation,
+        KnowledgeDocument,
+        WikiPublication,
+        WikiPublicationEntry,
+    )
+
+    factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    ctx: dict[str, object] = {}
+
+    async with factory() as s:
+        # 1. Wiki Publication（published）
+        pub = WikiPublication(
+            catalog_id=graph_catalog,
+            app_name=graph_app_name,
+            name="WG Test Pub",
+            slug="wg-test-pub",
+            status="published",
+            theme="default",
+            version=2,
+            publish_mode="LIVE",
+            visibility="INTERNAL",
+        )
+        s.add(pub)
+        await s.flush()
+        ctx["pub_id"] = pub.id
+
+        # 2. 三个 KnowledgeDocument（无需 DocSource：本测试聚焦 KG 切片，不走文档摄取链路）
+        documents = []
+        for i in range(3):
+            doc = KnowledgeDocument(
+                corpus_id=graph_corpus,
+                app_name=graph_app_name,
+                file_hash=f"{i:064d}",  # 64-char hex 占位
+                original_filename=f"wg-doc-{i}.md",
+                gcs_uri=f"gs://test/wg-doc-{i}.md",
+                content_type="text/markdown",
+                file_size=100,
+                status="active",
+            )
+            s.add(doc)
+            await s.flush()
+            documents.append(doc)
+        ctx["document_ids"] = [d.id for d in documents]
+
+        # 3. WikiPublicationEntry × 3（DOCUMENT 类型）
+        entries = []
+        for i, doc in enumerate(documents):
+            e = WikiPublicationEntry(
+                publication_id=pub.id,
+                document_id=doc.id,
+                entry_kind="DOCUMENT",
+                entry_slug=f"wg-entry-{i}",
+                entry_title=f"WG Entry {i}",
+                entry_path="[]",
+            )
+            s.add(e)
+            await s.flush()
+            entries.append(e)
+        ctx["entry_ids"] = [e.id for e in entries]
+
+        # 4. 6 个 KgEntity；index 0-3 与 documents 关联；4 与本 pub 无 mention；
+        #    5 仅作为关系另一端（被切片剔除）。
+        entities = []
+        for i in range(6):
+            ent = KgEntity(
+                corpus_id=graph_corpus,
+                app_name=graph_app_name,
+                name=f"WG Entity {i}",
+                canonical_name=f"wg-entity-{i}",
+                entity_type=["concept", "person", "concept", "organization", "concept", "concept"][i],
+                confidence=1.0,
+                mention_count=i + 1,
+                source_count=1,
+                importance_score=0.9 - i * 0.1,  # 0.9, 0.8, 0.7, 0.6, 0.5, 0.4
+                community_id=i % 3,
+                is_active=True,
+            )
+            s.add(ent)
+            await s.flush()
+            entities.append(ent)
+        ctx["entity_ids"] = [e.id for e in entities]
+
+        # 5. mentions：实体 0/1/2/3 落在 documents 内；实体 4 是 "orphan"（无 mention）；
+        #    实体 5 完全不与 publication 内文档关联（仅作为悬挂边的另一端）。
+        for ent_idx, doc_idx in [(0, 0), (1, 0), (2, 1), (3, 2), (0, 1)]:
+            m = KgEntityMention(
+                entity_id=entities[ent_idx].id,
+                corpus_id=graph_corpus,
+                document_id=documents[doc_idx].id,
+                extraction_method="llm",
+                extraction_confidence=1.0,
+            )
+            s.add(m)
+
+        # 6. relations：
+        #    (0→1), (1→2), (2→3), (0→3)：两端都在 mention 集合内（保留）
+        #    (3→4)：4 不在 mention 集合内（剔除）
+        #    (3→5)：5 不在 mention 集合内（剔除）
+        for src_idx, tgt_idx in [(0, 1), (1, 2), (2, 3), (0, 3), (3, 4), (3, 5)]:
+            r = KgRelation(
+                source_id=entities[src_idx].id,
+                target_id=entities[tgt_idx].id,
+                corpus_id=graph_corpus,
+                app_name=graph_app_name,
+                relation_type="RELATED_TO",
+                weight=1.0,
+                confidence=1.0,
+                is_active=True,
+            )
+            s.add(r)
+
+        await s.commit()
+
+    yield ctx
+
+    # Teardown：依赖 ondelete CASCADE 即可，但显式 DELETE 更可控。
+    async with factory() as s:
+        await s.execute(KgRelation.__table__.delete().where(KgRelation.corpus_id == graph_corpus))
+        await s.execute(KgEntityMention.__table__.delete().where(KgEntityMention.corpus_id == graph_corpus))
+        await s.execute(KgEntity.__table__.delete().where(KgEntity.corpus_id == graph_corpus))
+        await s.execute(
+            WikiPublicationEntry.__table__.delete().where(WikiPublicationEntry.publication_id == ctx["pub_id"])
+        )
+        await s.execute(WikiPublication.__table__.delete().where(WikiPublication.id == ctx["pub_id"]))
+        await s.execute(KnowledgeDocument.__table__.delete().where(KnowledgeDocument.corpus_id == graph_corpus))
+        await s.commit()
+
+
+# ===================================================================
+# 测试用例
+# ===================================================================
+
+
+class TestWikiGraphPublicationSlice:
+    """get_publication_graph 切片正确性"""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_unknown_publication(self, db_engine):
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            result = await wiki_graph_service.get_publication_graph(s, pub_id=uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_publication_returns_empty_status(self, db_engine, graph_catalog, graph_app_name):
+        """无 entries 的 publication 返回 status='empty'"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+        from negentropy.models.perception import WikiPublication
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            pub = WikiPublication(
+                catalog_id=graph_catalog,
+                app_name=graph_app_name,
+                name="Empty Pub",
+                slug="empty-pub",
+                status="published",
+                theme="default",
+                publish_mode="LIVE",
+                visibility="INTERNAL",
+            )
+            s.add(pub)
+            await s.commit()
+            pid = pub.id
+
+        async with factory() as s:
+            result = await wiki_graph_service.get_publication_graph(s, pub_id=pid)
+        assert result is not None
+        assert result["status"] == "empty"
+        assert result["nodes"] == []
+        assert result["edges"] == []
+
+    @pytest.mark.asyncio
+    async def test_slice_includes_mentioned_entities_only(self, db_engine, graph_world):
+        """节点集合 = 被 publication 文档 mention 的实体；entity 4/5 应被排除"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_graph(s, pub_id=pub_id)
+
+        assert payload is not None
+        assert payload["status"] == "ok"
+
+        node_ids = {n["id"] for n in payload["nodes"]}
+        # 实体 0/1/2/3 应被 mention 且通过边连通；4/5 应被排除
+        assert str(entity_ids[0]) in node_ids
+        assert str(entity_ids[1]) in node_ids
+        assert str(entity_ids[2]) in node_ids
+        assert str(entity_ids[3]) in node_ids
+        assert str(entity_ids[4]) not in node_ids
+        assert str(entity_ids[5]) not in node_ids
+
+    @pytest.mark.asyncio
+    async def test_dangling_edges_are_filtered(self, db_engine, graph_world):
+        """两端不全在节点集合内的边必须被剔除"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_graph(s, pub_id=pub_id)
+
+        node_ids = {n["id"] for n in payload["nodes"]}
+        for e in payload["edges"]:
+            assert e["source"] in node_ids, f"悬挂边 source={e['source']}"
+            assert e["target"] in node_ids, f"悬挂边 target={e['target']}"
+
+        # 4 条预期保留：(0→1) (1→2) (2→3) (0→3)
+        # 2 条预期剔除：(3→4) (3→5)
+        edge_pairs = {(e["source"], e["target"]) for e in payload["edges"]}
+        for src_idx, tgt_idx in [(0, 1), (1, 2), (2, 3), (0, 3)]:
+            assert (str(entity_ids[src_idx]), str(entity_ids[tgt_idx])) in edge_pairs
+        for src_idx, tgt_idx in [(3, 4), (3, 5)]:
+            assert (str(entity_ids[src_idx]), str(entity_ids[tgt_idx])) not in edge_pairs
+
+    @pytest.mark.asyncio
+    async def test_truncation_keeps_top_by_importance(self, db_engine, graph_world):
+        """max_nodes 截断按 importance_score DESC + 剔除悬挂边后保留连通节点"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_graph(s, pub_id=pub_id, max_nodes=2)
+
+        assert payload is not None
+        assert payload["truncated"] is True
+        assert payload["total_entities"] == 4  # mention 集合大小（不算 4/5）
+
+        # importance 排序：实体 0(0.9) > 1(0.8) > 2(0.7) > 3(0.6)
+        # 截断到 2：保留 0/1
+        node_ids = {n["id"] for n in payload["nodes"]}
+        assert str(entity_ids[0]) in node_ids
+        assert str(entity_ids[1]) in node_ids
+        # 节点截断后，0→1 的边应仍保留；其它涉及被截断节点的边应消失
+        edge_pairs = {(e["source"], e["target"]) for e in payload["edges"]}
+        assert (str(entity_ids[0]), str(entity_ids[1])) in edge_pairs
+        for src_idx, tgt_idx in [(1, 2), (2, 3), (0, 3)]:
+            assert (
+                str(entity_ids[src_idx]),
+                str(entity_ids[tgt_idx]),
+            ) not in edge_pairs
+
+    @pytest.mark.asyncio
+    async def test_entry_slugs_attached_to_node(self, db_engine, graph_world):
+        """每节点 entry_slugs 应包含其被 mention 所在的 entry slug"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_graph(s, pub_id=pub_id)
+
+        # 实体 0 在 doc 0 + doc 1 中被 mention（即 entry 0 + entry 1）
+        node_0 = next(n for n in payload["nodes"] if n["id"] == str(entity_ids[0]))
+        assert set(node_0["entry_slugs"]) == {"wg-entry-0", "wg-entry-1"}
+        assert node_0["mention_count_in_pub"] == 2
+
+        # 实体 1 仅在 doc 0 中
+        node_1 = next(n for n in payload["nodes"] if n["id"] == str(entity_ids[1]))
+        assert node_1["entry_slugs"] == ["wg-entry-0"]
+        assert node_1["mention_count_in_pub"] == 1
+
+
+class TestWikiGraphEntityDetail:
+    """get_publication_entity_detail 详情返回"""
+
+    @pytest.mark.asyncio
+    async def test_returns_neighbors_within_publication(self, db_engine, graph_world):
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_entity_detail(s, pub_id=pub_id, entity_id=entity_ids[0])
+
+        assert payload is not None
+        assert payload["entity"]["id"] == str(entity_ids[0])
+        # 实体 0 的边：0→1, 0→3，方向均为 outgoing
+        neighbor_ids = {n["id"] for n in payload["neighbors"]}
+        assert str(entity_ids[1]) in neighbor_ids
+        assert str(entity_ids[3]) in neighbor_ids
+
+    @pytest.mark.asyncio
+    async def test_orphan_entity_returns_none(self, db_engine, graph_world):
+        """实体 4 没有任何 mention → 不在 publication 范围内"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_entity_detail(s, pub_id=pub_id, entity_id=entity_ids[4])
+        assert payload is None
+
+
+class TestWikiEntryGraph:
+    """get_entry_graph 单 entry 局部图"""
+
+    @pytest.mark.asyncio
+    async def test_center_entities_match_entry_mentions(self, db_engine, graph_world):
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        entry_ids = graph_world["entry_ids"]
+        entity_ids = graph_world["entity_ids"]
+
+        # entry 0 → doc 0；doc 0 mentions 实体 0, 1
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_entry_graph(s, entry_id=entry_ids[0])
+
+        assert payload is not None
+        assert payload["status"] == "ok"
+        center = set(payload["center_entity_ids"])
+        assert str(entity_ids[0]) in center
+        assert str(entity_ids[1]) in center
+
+    @pytest.mark.asyncio
+    async def test_entry_graph_returns_empty_for_no_mention(self, db_engine, graph_world, graph_corpus, graph_app_name):
+        """未被 mention 的文档关联的 entry 应返回 status='empty'"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+        from negentropy.models.perception import (
+            KnowledgeDocument,
+            WikiPublicationEntry,
+        )
+
+        pub_id = graph_world["pub_id"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            doc = KnowledgeDocument(
+                corpus_id=graph_corpus,
+                app_name=graph_app_name,
+                file_hash=f"{99:064d}",
+                original_filename="no-mention.md",
+                gcs_uri="gs://test/no-mention.md",
+                content_type="text/markdown",
+                file_size=100,
+                status="active",
+            )
+            s.add(doc)
+            await s.flush()
+            entry = WikiPublicationEntry(
+                publication_id=pub_id,
+                document_id=doc.id,
+                entry_kind="DOCUMENT",
+                entry_slug="no-mention-entry",
+                entry_title="No mention",
+                entry_path="[]",
+            )
+            s.add(entry)
+            await s.commit()
+            entry_id = entry.id
+            doc_id = doc.id
+
+        async with factory() as s:
+            payload = await wiki_graph_service.get_entry_graph(s, entry_id=entry_id)
+
+        assert payload is not None
+        assert payload["status"] == "empty"
+        assert payload["nodes"] == []
+
+        # Cleanup
+        async with factory() as s:
+            await s.execute(WikiPublicationEntry.__table__.delete().where(WikiPublicationEntry.id == entry_id))
+            await s.execute(KnowledgeDocument.__table__.delete().where(KnowledgeDocument.id == doc_id))
+            await s.commit()

--- a/apps/negentropy/tests/integration_tests/knowledge/test_wiki_graph_service.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_wiki_graph_service.py
@@ -387,6 +387,91 @@ class TestWikiGraphPublicationSlice:
         assert node_1["entry_slugs"] == ["wg-entry-0"]
         assert node_1["mention_count_in_pub"] == 1
 
+    @pytest.mark.asyncio
+    async def test_total_entities_excludes_inactive(self, db_engine, graph_world):
+        """total_entities 应与候选节点查询同口径：排除 is_active=False 的实体。
+
+        将实体 0 标记为失活后：
+        - 候选节点不应包含实体 0；
+        - total_entities 也应从 4 降为 3，与节点集合一致；
+        否则前端横幅「共 X 个实体，仅显示 top-N」会把失活实体计入分母。
+        """
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+        from negentropy.models.perception import KgEntity
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            await s.execute(KgEntity.__table__.update().where(KgEntity.id == entity_ids[0]).values(is_active=False))
+            await s.commit()
+
+        try:
+            async with factory() as s:
+                payload = await wiki_graph_service.get_publication_graph(s, pub_id=pub_id)
+
+            assert payload is not None
+            node_ids = {n["id"] for n in payload["nodes"]}
+            assert str(entity_ids[0]) not in node_ids
+            # 实体 1/2/3 仍 active 且被 mention → total_entities=3
+            assert payload["total_entities"] == 3
+        finally:
+            async with factory() as s:
+                await s.execute(KgEntity.__table__.update().where(KgEntity.id == entity_ids[0]).values(is_active=True))
+                await s.commit()
+
+    @pytest.mark.asyncio
+    async def test_total_entities_respects_min_importance(self, db_engine, graph_world):
+        """total_entities 应应用与候选节点查询相同的 min_importance 过滤。"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+
+        pub_id = graph_world["pub_id"]
+
+        # fixture 中实体 importance：0.9 / 0.8 / 0.7 / 0.6（mention 集合）
+        # 设 min_importance=0.75 → 仅 0.9 / 0.8 入选 → total_entities=2
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            payload = await wiki_graph_service.get_publication_graph(s, pub_id=pub_id, min_importance=0.75)
+
+        assert payload is not None
+        assert payload["total_entities"] == 2
+        assert len(payload["nodes"]) <= 2
+
+
+class TestWikiGraphEntityList:
+    """get_publication_entities 分页与计数口径"""
+
+    @pytest.mark.asyncio
+    async def test_total_excludes_inactive_entities(self, db_engine, graph_world):
+        """``total`` 必须与 ``items`` 同口径过滤 is_active，否则跨页累计 < total。"""
+        from negentropy.knowledge.lifecycle import wiki_graph_service
+        from negentropy.models.perception import KgEntity
+
+        pub_id = graph_world["pub_id"]
+        entity_ids = graph_world["entity_ids"]
+
+        factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as s:
+            await s.execute(KgEntity.__table__.update().where(KgEntity.id == entity_ids[0]).values(is_active=False))
+            await s.commit()
+
+        try:
+            async with factory() as s:
+                payload = await wiki_graph_service.get_publication_entities(s, pub_id=pub_id, limit=100)
+
+            assert payload is not None
+            # 4 个被 mention 实体（0/1/2/3），实体 0 失活后 → total=3
+            assert payload["total"] == 3
+            returned_ids = {item["id"] for item in payload["items"]}
+            assert str(entity_ids[0]) not in returned_ids
+            # total 与 items 长度一致（一页内可容纳）
+            assert len(payload["items"]) == payload["total"]
+        finally:
+            async with factory() as s:
+                await s.execute(KgEntity.__table__.update().where(KgEntity.id == entity_ids[0]).values(is_active=True))
+                await s.commit()
+
 
 class TestWikiGraphEntityDetail:
     """get_publication_entity_detail 详情返回"""

--- a/docs/agents/knowledge-map.md
+++ b/docs/agents/knowledge-map.md
@@ -17,7 +17,7 @@
 
 - [Conversation Foundation（对话基础）](../conversation-foundation.md)
 - [Memory（记忆系统）](../memory.md) · [白皮书](../memory-whitepaper.md)
-- [Knowledge Graph（知识图谱）](../knowledge-graph.md) · [联邦知识图谱 + 跨 Corpus 混合检索](../knowledge-graph-federated.md)
+- [Knowledge Graph（知识图谱）](../knowledge-graph.md) · [联邦知识图谱 + 跨 Corpus 混合检索](../knowledge-graph-federated.md) · [Wiki 知识图谱（按 Publication 切片发布）](../wiki-knowledge-graph.md)
 - [Skills](../skills.md)
 - [Negentropy Wiki Ops](../negentropy-wiki-ops.md)
 - [Engineering Changelog](../engineering-changelog.md)

--- a/docs/negentropy-wiki-ops.md
+++ b/docs/negentropy-wiki-ops.md
@@ -60,11 +60,14 @@ flowchart LR
 
 ### 2.2 路由结构
 
-| 路由                   | 页面文件                                 | 功能                                |
-| ---------------------- | ---------------------------------------- | ----------------------------------- |
-| `/`                    | `src/app/page.tsx`                       | 首页：列出所有已发布的 Publication  |
-| `/:pubSlug`            | `src/app/[pubSlug]/page.tsx`             | Publication 首页：导航树 + 文档索引 |
-| `/:pubSlug/:entrySlug` | `src/app/[pubSlug]/[entrySlug]/page.tsx` | 文档详情页：Markdown 渲染           |
+| 路由                   | 页面文件                                    | 功能                                |
+| ---------------------- | ------------------------------------------- | ----------------------------------- |
+| `/`                    | `src/app/page.tsx`                          | 首页：列出所有已发布的 Publication  |
+| `/:pubSlug`            | `src/app/[pubSlug]/page.tsx`                | Publication 首页：导航树 + 文档索引 |
+| `/:pubSlug/:entrySlug` | `src/app/[pubSlug]/[entrySlug]/page.tsx`    | 文档详情页：Markdown 渲染           |
+| `/:pubSlug/graph`      | `src/app/[pubSlug]/graph/page.tsx`          | 知识图谱页：按 Publication 切片的实体/关系可视化（Sigma WebGL） |
+
+> 知识图谱页设计详见 [Wiki 知识图谱（按 Publication 切片发布）](./wiki-knowledge-graph.md)；数据流与 Markdown 页面同构，仅运行时 `fetch` + ISR，无新增持久化或部署形态。
 
 ### 2.3 数据流
 

--- a/docs/wiki-knowledge-graph.md
+++ b/docs/wiki-knowledge-graph.md
@@ -1,0 +1,230 @@
+# Wiki 知识图谱（按 Publication 切片发布）
+
+## 概述
+
+将后端 [`negentropy`](../apps/negentropy) Knowledge 模块构造的知识图谱（KG）按 **Wiki Publication 维度**切片，发布到 [`negentropy-wiki`](../apps/negentropy-wiki) SSG 站点，让用户在 Wiki 浏览文档的同时，能查看这些文档所涉及的实体与关系。
+
+### 核心约束（与设计取向）
+
+| 约束 | 含义 | 落地策略 |
+|---|---|---|
+| **Wiki 无状态** | Wiki 端不引入数据库 / 缓存层 / 文件持久化 | 所有切片在后端 SQL 中完成；Wiki 仅 HTTP 拉取 |
+| **Wiki 静态部署** | 仍是 Next.js SSG + ISR，不引入 SSR 复杂数据流 | 服务端 fetch 注入到客户端组件 props；Sigma WebGL 通过 `dynamic({ ssr: false })` 懒加载 |
+| **最小干预** | 不破坏现有 Markdown 发布流水线 | 全部为追加（4 个新 endpoint、1 个新路由、1 个新组件） |
+| **单一事实源** | 反查逻辑收敛在后端 | Wiki 端不做二次过滤 |
+
+## 数据流（与现有 Markdown 发布完全同构）
+
+```mermaid
+flowchart LR
+  subgraph Backend["后端 Knowledge API"]
+    direction TB
+    pub[wiki_publications]
+    entries[wiki_publication_entries]
+    docs[knowledge_documents]
+    mentions[kg_entity_mentions]
+    ents[kg_entities]
+    rels[kg_relations]
+
+    pub --> entries
+    entries -->|document_id| docs
+    docs -->|document_id| mentions
+    mentions -->|entity_id| ents
+    ents -->|src/tgt| rels
+  end
+
+  subgraph WikiSSG["Wiki SSG (Next.js)"]
+    direction TB
+    page["[pubSlug]/graph/page.tsx"]
+    api["wiki-api.ts<br/>getPublicationGraph"]
+    canvas["WikiGraphCanvas<br/>(Sigma + ForceAtlas2)"]
+    revalidate["/api/revalidate<br/>(HMAC webhook)"]
+
+    page -->|SSR fetch| api
+    api -->|hydrate| canvas
+  end
+
+  Backend -.->|GET /knowledge/wiki/publications/{pub_id}/graph| api
+  Backend -.->|POST publish webhook| revalidate
+  revalidate -.->|revalidatePath| page
+
+  classDef be fill:#1e3a5f,stroke:#3b82f6,color:#dbeafe
+  classDef wk fill:#3a1e5f,stroke:#a855f7,color:#f3e8ff
+  class pub,entries,docs,mentions,ents,rels be
+  class page,api,canvas,revalidate wk
+```
+
+## Publication 维度切片算法
+
+**节点反查路径**（单次 SQL CTE）：
+
+```sql
+-- 1. 反查文档集合
+SELECT document_id
+FROM wiki_publication_entries
+WHERE publication_id = :pub_id
+  AND entry_kind = 'DOCUMENT';
+
+-- 2. 反查实体集合（DISTINCT）
+SELECT DISTINCT m.entity_id
+FROM kg_entity_mentions m
+WHERE m.document_id IN (:document_ids);
+
+-- 3. 加载节点（按 importance 排序，可截断）
+SELECT * FROM kg_entities
+WHERE id IN (:entity_ids) AND is_active = TRUE
+ORDER BY importance_score DESC NULLS LAST, mention_count DESC
+LIMIT :max_nodes;
+
+-- 4. 加载边（两端都在节点集合内，剔除悬挂边）
+SELECT * FROM kg_relations
+WHERE source_id IN (:kept_node_ids)
+  AND target_id IN (:kept_node_ids)
+  AND is_active = TRUE;
+```
+
+**关键不变量**：source/target 都在节点集合内的边才保留 —— 截断 / 过滤后**不出现悬挂边**。
+
+### 跨 corpus publication 处理
+
+阶段一（首版）按 `corpus_id` 各自保留，节点 `metadata.corpus_id` 标注，**不做** canonical 合并。与 `routes/graph.py` 单 corpus 语义一致，最小化首版改动面。
+
+阶段二（可选）通过 `kg_entity_canonical` + `kg_entity_alias` 折叠跨 corpus 同名实体，借 `kg_cross_corpus_bridge` 增加跨域边。
+
+## API 契约
+
+### `GET /knowledge/wiki/publications/{pub_id}/graph`
+
+整图切片。仅 `status='published'` 的 publication 暴露。
+
+**查询参数**：
+- `max_nodes`：1–1000，默认 300
+- `min_importance`：≥0，默认 0
+- `include_isolated`：默认 false（剔除无边孤立节点）
+
+**响应**（`WikiGraphResponse`）：
+```json
+{
+  "publication_id": "uuid",
+  "version": 3,
+  "status": "ok | no_kg | empty",
+  "nodes": [
+    {
+      "id": "ent-1",
+      "label": "Negentropy",
+      "type": "concept",
+      "importance": 0.85,
+      "community_id": 2,
+      "entry_slugs": ["intro", "design"],
+      "mention_count_in_pub": 12,
+      "metadata": { "corpus_id": "...", "confidence": 0.95 }
+    }
+  ],
+  "edges": [
+    { "source": "ent-1", "target": "ent-2", "label": "RELATED_TO", "type": "RELATED_TO", "weight": 1.0, "metadata": { } }
+  ],
+  "truncated": false,
+  "total_entities": 256,
+  "corpus_ids": ["..."]
+}
+```
+
+**ETag / Cache-Control**：`"{pub_id}:{version}"` + `max-age=300`，与 SSG ISR 5 分钟窗口一致。
+
+### `GET /knowledge/wiki/publications/{pub_id}/graph/entities`
+
+实体扁平列表（分页）。供未来"实体面板/搜索"使用。
+
+### `GET /knowledge/wiki/publications/{pub_id}/graph/entities/{entity_id}`
+
+实体详情：基本信息 + 邻居（仅 publication 节点集合内）+ 提及该实体的 Wiki entries。
+
+### `GET /knowledge/wiki/entries/{entry_id}/graph`
+
+单 entry 局部图：该文档涉及的实体 + 1 跳邻居。响应附 `center_entity_ids` 供前端高亮。
+
+### 错误码
+
+| Code | HTTP | 说明 |
+|---|---|---|
+| `WIKI_PUB_NOT_FOUND` | 404 | publication 不存在 |
+| `WIKI_PUB_NOT_PUBLISHED` | 403 | publication 状态非 published（draft / archived） |
+| `WIKI_GRAPH_ENTITY_NOT_FOUND` | 404 | 实体不在 publication 节点集合内 |
+| `WIKI_ENTRY_NOT_FOUND` | 404 | entry 不存在或非 DOCUMENT 类型 |
+
+## Wiki 站点改动
+
+### 新增
+
+| 文件 | 职责 |
+|---|---|
+| [`apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx`](../apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx) | SSG 入口，服务端 fetch + 状态分支 |
+| [`apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx`](../apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx) | 客户端 Sigma WebGL 渲染（dynamic 懒加载） |
+| [`apps/negentropy-wiki/src/lib/wiki-graph-types.ts`](../apps/negentropy-wiki/src/lib/wiki-graph-types.ts) | 类型声明（与 `wiki-api.ts` 解耦） |
+
+### 修改
+
+- [`wiki-api.ts`](../apps/negentropy-wiki/src/lib/wiki-api.ts)：追加 4 个 graph 方法（不修改既有签名）
+- [`WikiHeader.tsx`](../apps/negentropy-wiki/src/components/WikiHeader.tsx)：tabs 末尾新增"知识图谱"入口，`entries_count > 0` 时显示
+- [`api/revalidate/route.ts`](../apps/negentropy-wiki/src/app/api/revalidate/route.ts)：追加 `/{pubSlug}/graph` 路径与 `wiki-graph:${pubSlug}` tag 的 revalidate
+- [`package.json`](../apps/negentropy-wiki/package.json)：新增 `sigma` / `graphology` / `graphology-layout-forceatlas2`（与主站版本对齐）
+
+## 与主站 Graph 组件的关系（复用策略）
+
+主站 [`apps/negentropy-ui/app/knowledge/graph/_components/SigmaGraphCanvas.tsx`](../apps/negentropy-ui/app/knowledge/graph/_components/SigmaGraphCanvas.tsx) 是双击展开 / 增量加载 / 实体面板的全能交互组件。
+
+Wiki 场景定位于"**只读浏览 + 点击跳转**"。我们**精简重做**（约 150 行 vs 主站 297 行）：
+
+- ✅ 拷贝：`buildGraph` / `nodeSize` / `nodeColor` / ForceAtlas2 配置（真正的复用价值）
+- ❌ 剥离：增量加载（`fetchGraphSubgraph`）、双击展开、实体面板状态
+- ➕ 新增：节点点击 → `router.push(/${pubSlug}/${node.entry_slugs[0]})` 跳转到首个相关文档
+
+颜色常量（实体类型 + 社区色）独立拷贝到 Wiki 组件内，避免跨工程依赖。
+
+## 性能与降级
+
+- **典型规模**：50–200 文档 × 平均 30 mentions → 去重后 200–800 实体，JSON < 500 KB
+- **截断策略**：
+  - ≤ 500 节点：完整返回
+  - 500–1000 节点：按 `importance_score DESC` 截断，附 `truncated=true`
+- **客户端 bundle**：Sigma 组件 `dynamic(ssr:false)` 独立 chunk，非图谱页面零体积影响
+- **空 KG 兜底**：API 返回 `status='no_kg'`，前端展示"该发布暂未构建知识图谱"
+- **未发布**：API 返回 403，Wiki 首页/入口不会出现该 publication
+
+## 验证方案
+
+### 后端
+
+- **集成测试** [`tests/integration_tests/knowledge/test_wiki_graph_service.py`](../apps/negentropy/tests/integration_tests/knowledge/test_wiki_graph_service.py)：
+  - 空 publication → `status='empty'`
+  - 单文档 / 多文档切片正确
+  - 悬挂边过滤
+  - `max_nodes` 截断
+  - 实体详情邻居范围限定在 publication 内
+  - 单 entry 局部图
+
+### Wiki
+
+- **单元测试** [`tests/lib/wiki-api-graph.test.ts`](../apps/negentropy-wiki/tests/lib/wiki-api-graph.test.ts)：API 客户端方法的查询参数序列化、ISR 选项透传、错误透传
+
+### 浏览器实机回归
+
+按 [浏览器验证协议](./agents/browser-validation.md) 接入用户常用 Chrome 主 profile：
+
+1. 现有 `/`、`/[pubSlug]`、`/[pubSlug]/[...entrySlug]` 不受影响
+2. `/[pubSlug]/graph` SSG 首屏可见节点、无客户端等待
+3. Sigma 可交互（拖拽 / 缩放 / 点击）
+4. 节点点击 → 跳转到 `/[pubSlug]/{entry_slug}`
+5. 后端 publish → Wiki 图谱通过 webhook 立即刷新
+6. 未构建 KG / 空 publication 友好空态
+7. 截断边界（≥ max_nodes）显示橙色提示横幅
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 跨 corpus 同名实体未合并造成视觉重复 | 节点 `metadata.corpus_id` 着色；阶段二走 canonical 合并 |
+| 大 publication SQL 反查慢 | 已有 `ix_kg_mentions_document`；硬上限 1000 节点 |
+| Sigma WebGL bundle 膨胀首屏 | `dynamic({ ssr: false })` 懒加载，独立 chunk |
+| 节点点击跳转失败（entry_slug 漂移） | `entry_slugs[]` 反查与 nav-tree 同 SSOT；缺失则不跳转 |
+| ISR webhook 失败导致图谱滞后 | 5 分钟 ISR 兜底（复用既有 fail-safe 链路） |


### PR DESCRIPTION
# 背景

- **本次变更要解决的问题**：当前 Legendgen Wiki 站点（`apps/negentropy-wiki`，Next.js SSG + ISR）只发布文档 Markdown，**没有任何知识图谱视图**；用户希望在 Wiki 浏览文档时能在一处汇总查看这些文档涉及的实体与关系。同时必须满足两个硬约束：① Wiki 站点保持**无状态**（不引入数据库 / 缓存层 / 文件持久化）；② 保持**静态部署**（SSG + ISR，不引入 SSR/独立后端）。
- **关联上下文**：[docs/wiki-knowledge-graph.md](docs/wiki-knowledge-graph.md) · [docs/negentropy-wiki-ops.md](docs/negentropy-wiki-ops.md) · 后端既有 [knowledge/routes/graph.py](apps/negentropy/src/negentropy/knowledge/routes/graph.py)（单 corpus 维度） + [knowledge/routes/wiki.py](apps/negentropy/src/negentropy/knowledge/routes/wiki.py)（Publication 生命周期）。

# 核心变更

**设计取向（一句话）**：沿用现有 Markdown 发布数据流 —— Wiki SSG 通过 HTTP 从后端拉取**按 Publication 切片**的图谱 JSON，与拉取 Markdown 完全同构。所有切片在后端单一 SQL 反查中完成（单一事实源），Wiki 端零持久化。

- **后端 API**（`apps/negentropy/`）
  - 新增 `knowledge/lifecycle/wiki_graph_service.py`：切片查询服务，正交分解于发布生命周期。反查链路：`wiki_publication_entries → kg_entity_mentions → kg_entities`；剔除悬挂边、支持按 `importance_score` 截断
  - 新增 `knowledge/routes/wiki_graph.py`：4 个 endpoint（`/wiki/publications/{id}/graph[/entities[/{eid}]]` + `/wiki/entries/{eid}/graph`），仅 `status='published'` 暴露，响应携带 `ETag={pub_id}:{version}` + `max-age=300`
  - 新增 `schemas.py` 中 `WikiGraphNode/Edge/Response` 等 6 个 Pydantic 模型；节点附 `entry_slugs[]` + `mention_count_in_pub` 用于点击跳转
  - `knowledge/api.py` 追加 router 注册

- **Wiki 站点**（`apps/negentropy-wiki/`）
  - 新增路由 `src/app/[pubSlug]/graph/page.tsx`：SSR `generateStaticParams` + 服务端 `fetch` 注入到 client component；按 `status` 分支 `ok / no_kg / empty / error` 四态降级
  - 新增 **`src/components/WikiGraphCanvas.tsx`**（Sigma WebGL，≤ 500 节点）：复用主站 `apps/negentropy-ui` 的 `buildGraph / nodeSize / nodeColor / ForceAtlas2` 策略并精简为只读浏览
  - 新增 **`src/components/WikiForceGraphCanvas.tsx`**（react-force-graph-2d Canvas 2D，> 500 节点）：自动降级渲染器；交互模型与 Sigma 版本一致（节点点击 → `router.push(entry_slugs[0])`）
  - 修改 `wiki-api.ts`：追加 `getPublicationGraph / getPublicationEntities / getPublicationEntityDetail / getEntryGraph`；`fetch<T>` 支持 ISR `tags` 透传
  - 修改 `WikiHeader.tsx`：tabs 末尾追加"知识图谱"入口（仅 `entries_count > 0` 时显示）；同步传 `graphTab` 到 `[pubSlug]/page.tsx` 与 `[pubSlug]/[...entrySlug]/page.tsx`
  - 修改 `api/revalidate/route.ts`：追加 `/${pubSlug}/graph` 路径与 `wiki-graph:${pubSlug}` tag 的 `revalidatePath/Tag`（webhook 在 Wiki 端的接收侧处理；**未触及**后端 `lifecycle/revalidate.py` 的 payload schema，功能上等价）
  - 新增 `styles/components/graph.css`：解决容器高度坍缩 + Sigma WebGL canvas 像素尺寸不跟随的 CSS 问题（实机联调发现）
  - 新增依赖：`sigma` / `graphology` / `graphology-layout-forceatlas2` / `react-force-graph-2d`（与主站 `apps/negentropy-ui` 版本对齐）

- **文档与索引**：新增 `docs/wiki-knowledge-graph.md`（设计文档 + Mermaid 时序图 + API 契约 + 大图降级策略 + 风险缓解）；更新 `docs/negentropy-wiki-ops.md` 路由表 + `docs/agents/knowledge-map.md` 索引

# 风险与回滚

- **主要风险**：
  1. 大 publication（>1000 实体）SQL 反查慢 → 后端已有 `ix_kg_mentions_document` 索引 + 硬上限 1000 节点 + 按 `importance_score DESC` 截断
  2. Sigma WebGL 在低端设备渲染慢 → **节点 > 500 自动降级 ForceGraph2D**（Canvas 2D），且组件均通过 `"use client"` 自动切分进 graph 路由独立 chunk
  3. 跨 corpus publication 同名实体未合并 → 阶段一文档明确"按 corpus 切片"，节点 `metadata.corpus_id` 着色区分；阶段二可走 canonical 合并
- **回滚方式**：所有改动均为**追加**（不修改既有 endpoint / 路由 / 组件签名）；如需回滚，删除 `wiki_graph_service.py` / `routes/wiki_graph.py` / `[pubSlug]/graph/` 即可，现有 Markdown 发布流水线不受影响

# 验证证据

- **单元测试**：`apps/negentropy-wiki/tests/lib/wiki-api-graph.test.ts` 7 个 vitest 用例覆盖查询参数序列化、ISR tag 透传、错误透传，**全部通过**
- **集成测试**：`apps/negentropy/tests/integration_tests/knowledge/test_wiki_graph_service.py` 10 个用例覆盖空 publication / 切片正确性 / 悬挂边过滤 / `max_nodes` 截断 / 实体详情邻居范围 / 单 entry 局部图，**全部通过**
- **E2E/Workflow**：本工作树后端（3492）+ Wiki dev（3192）端到端联调，通过 chrome_devtools 实机验证：
  - ✅ Sigma WebGL 渲染 13 节点 17 边按社区配色（`.context/wiki-graph-render-4.png`）
  - ✅ `max_nodes=5` 截断时显示橙色横幅"已按 importance 截断（共 13 个实体，仅显示 top-5）"，悬挂边自动剔除（17→4）（`.context/wiki-graph-truncated.png`）
  - ✅ **大图降级**：562 节点 800 边自动切到 ForceGraph2D，徽章显示 "562 节点 · 800 边 · ForceGraph 2D"，Canvas 2D 渲染无卡顿（`.context/wiki-graph-forcegraph2d.png`）
  - ✅ 节点点击 → `router.push(/wiki/{entry_slug})` 跳转到对应文档详情页
  - ✅ 后端 `publish` 触发 webhook → Wiki dev 收到 `POST /api/revalidate 200` → 页面 `版本 vN` 同步刷新（v2→v3→v4）
  - ✅ 未构建 KG 时 `status='empty'`，前端显示友好空态
- **关键截图**：`.context/wiki-graph-render-4.png`（完整图谱）/ `.context/wiki-graph-truncated.png`（截断横幅）/ `.context/wiki-graph-forcegraph2d.png`（ForceGraph2D 降级）

# 影响范围

- **前端**：`apps/negentropy-wiki/` 新增 1 个路由 + 2 个客户端组件（Sigma + ForceGraph2D）+ 1 个类型文件 + 1 个 CSS；wiki-api.ts / WikiHeader.tsx / revalidate route.ts 追加方法，**不修改既有签名**
- **后端**：`apps/negentropy/` 新增 1 个 service + 1 个 routes 文件 + 6 个 Pydantic schema；`knowledge/api.py` 追加 router 注册
- **GitHub Actions / 文档**：无 CI 改动；新增 `docs/wiki-knowledge-graph.md` 设计文档，更新 `docs/negentropy-wiki-ops.md` 路由表与 `docs/agents/knowledge-map.md` 索引

# Next Best Action

- 合并前：① 在 staging 环境对一个真实有 KG 的 publication 跑端到端验证；② 触发一次 `publish` 确认 webhook 在生产配置下正常 dispatched
- 合并后：① 阶段二可走 `kg_entity_canonical` 合并跨 corpus 同名实体；② 后续可新增"实体面板/搜索"侧边栏复用现有 `getPublicationEntities` 端点；③ 用户文档 `docs/user-guide` 补充"如何在 Wiki 查看知识图谱"