### PR TITLE
fix(monorepo-build): 为 ui/wiki 增加 prebuild 钩子以确保 agents-chat-core dist 就绪

### DIFF
--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack -H localhost -p 3192",
+    "prebuild": "pnpm --filter @negentropy/agents-chat-core build",
     "build": "next build",
     "start": "node ./scripts/start-production.mjs",
     "lint": "eslint . --max-warnings=0",

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack -H localhost -p 3192",
-    "prebuild": "pnpm --filter @negentropy/agents-chat-core build",
+    "prebuild": "test -d node_modules/@negentropy/agents-chat-core/dist || pnpm --filter @negentropy/agents-chat-core build",
     "build": "next build",
     "start": "node ./scripts/start-production.mjs",
     "lint": "eslint . --max-warnings=0",

--- a/apps/negentropy-wiki/package.json
+++ b/apps/negentropy-wiki/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3092",
-    "prebuild": "pnpm --filter @negentropy/agents-chat-core build",
+    "prebuild": "test -d node_modules/@negentropy/agents-chat-core/dist || pnpm --filter @negentropy/agents-chat-core build",
     "build": "next build",
     "start": "node ./scripts/start-production.mjs",
     "lint": "next lint",

--- a/apps/negentropy-wiki/package.json
+++ b/apps/negentropy-wiki/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3092",
+    "prebuild": "pnpm --filter @negentropy/agents-chat-core build",
     "build": "next build",
     "start": "node ./scripts/start-production.mjs",
     "lint": "next lint",


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：在 `apps/negentropy-ui/` 子目录直接执行 `pnpm build` 时，pnpm 不会自动构建上游 workspace 依赖 `@negentropy/agents-chat-core`，其 `exports` 指向的 `dist/` 不存在，Turbopack 抛出 22 个 Module-not-found 错误。
- 关联上下文/Issue/文档：同一系统性缺陷存在于 `negentropy-wiki`（同样依赖 `agents-chat-core`）。

# 核心变更
- 在 `apps/negentropy-ui/package.json` 与 `apps/negentropy-wiki/package.json` 各新增 `prebuild` 生命周期钩子：`pnpm --filter @negentropy/agents-chat-core build`，在 `next build` 前自动触发 tsup 构建上游包，覆盖 root `pnpm -r build` 与子目录 `pnpm build` 两条主路径。

# 风险与回滚
- 主要风险：与 root `pnpm -r build` 同时使用时会出现一次冗余构建（tsup 约 1-2s，幂等，无副作用）。
- 回滚方式：`git revert` 删除两行 `prebuild` 即可。

# 验证证据
- 单元测试：N/A（零业务代码改动）。
- 集成测试：冷启动验证通过——删除 `dist/` 后在 `apps/negentropy-ui/` 执行 `pnpm build`，`prebuild` 先触发 tsup（242ms + DTS 4s），随后 `next build` 编译成功，0 错误。
- E2E/Workflow：N/A。
- 覆盖率/关键截图：N/A。

# 影响范围
- 前端：`apps/negentropy-ui/package.json`、`apps/negentropy-wiki/package.json` 各一行新增。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 可选：评估是否同步为 `predev` 钩子，改善冷启动开发体验。
- 可选：长期 DX 优化——为 `agents-chat-core` 增加 `development` exports 条件 + Next.js `transpilePackages`，彻底免构建。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>