### PR TITLE
fix(builtin-tools): visibility 列从 VARCHAR 修正为 pluginvisibility 枚举（修复 /interface/tools 与 /stats 500）

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0036_builtin_tools_visibility_enum.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0036_builtin_tools_visibility_enum.py
@@ -1,0 +1,122 @@
+"""builtin_tools.visibility VARCHAR(20) → negentropy.pluginvisibility 枚举
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-05-18 09:40:00.000000+00:00
+
+设计动机：
+    迁移 0031 创建 ``builtin_tools`` 表时把 ``visibility`` 列声明为 ``VARCHAR(20)``
+    并以小写 ``'private'`` / ``'public'`` 作为字面量与种子值，而 ORM 模型
+    ``BuiltinTool.visibility`` 使用 ``Enum(PluginVisibility, schema="negentropy")``。
+
+    SQLAlchemy 序列化 ``PluginVisibility.PUBLIC`` 时以成员 NAME（大写 ``'PUBLIC'``）
+    作为绑定参数，并生成 ``WHERE ... = $N::negentropy.pluginvisibility`` 的显式
+    cast。PG 无 ``character varying = pluginvisibility`` 操作符，导致
+
+        asyncpg.exceptions.UndefinedFunctionError: operator does not exist:
+          character varying = negentropy.pluginvisibility
+
+    在 ``permissions.get_visible_plugin_ids(plugin_type='builtin_tool')`` 上稳定
+    复现，``GET /interface/tools`` 与 ``GET /interface/stats`` 500。
+
+    同源 ``mcp_servers`` / ``skills`` / ``sub_agents`` 在迁移 0001 已用 PG 枚举建表
+    （0001_init_schema.py:196/306/334），仅 ``builtin_tools`` 偏离了模板。
+
+    与 ISSUE-012（pg 枚举列上的 text-only 操作必须显式 cast）同源——本次以
+    「ORM Enum 与迁移 VARCHAR 漂移」的形态再次出现。
+
+幂等与不可逆性：
+    采用 forward-only 修复，不回改迁移 0031（既会破坏 stairway，又会让已经
+    运行旧 0031 的部署陷入 schema 漂移）。本迁移 ``upgrade`` 在数据规范化、
+    类型转换前后均显式做防御性断言；``downgrade`` 走 ``USING visibility::text``
+    回到 VARCHAR(20)（规避 ISSUE-012 的直接 enum→varchar cast 陷阱）。
+
+锁与性能：
+    ``ALTER COLUMN ... TYPE`` 取 ACCESS EXCLUSIVE 锁并重写表数据。本表生产
+    部署量级极小（仅 system seed），可接受。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0036"
+down_revision: str | None = "0035"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+ENUM_TYPE = f"{SCHEMA}.pluginvisibility"  # 0001 已建，无需 CREATE TYPE
+
+
+def upgrade() -> None:
+    # 1) 规范化遗留数据：把 0031 种子的 'public' 等小写字面量映射到枚举成员名（大写）。
+    #    使用 LOWER(...) 做兜底（防御性覆盖大小写混杂的人工写入）。
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.builtin_tools
+               SET visibility = CASE LOWER(visibility::text)
+                   WHEN 'private' THEN 'PRIVATE'
+                   WHEN 'shared'  THEN 'SHARED'
+                   WHEN 'public'  THEN 'PUBLIC'
+                   ELSE visibility
+               END
+            """
+        )
+    )
+
+    # 2) 防御性断言：若仍存在非法值，立刻抛出；避免 ALTER TYPE 报含糊的 cast 错误。
+    op.execute(
+        sa.text(
+            f"""
+            DO $$
+            DECLARE bad_count int;
+            BEGIN
+              SELECT count(*) INTO bad_count FROM {SCHEMA}.builtin_tools
+               WHERE visibility NOT IN ('PRIVATE','SHARED','PUBLIC');
+              IF bad_count > 0 THEN
+                RAISE EXCEPTION 'unexpected visibility values in builtin_tools: % rows', bad_count;
+              END IF;
+            END $$;
+            """
+        )
+    )
+
+    # 3) 转换列类型：DROP DEFAULT → ALTER TYPE USING → SET DEFAULT
+    #    表上无视图 / 触发器 / visibility 索引依赖（0031 仅建了 owner / tool_type 索引）。
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.builtin_tools ALTER COLUMN visibility DROP DEFAULT"))
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {SCHEMA}.builtin_tools
+            ALTER COLUMN visibility TYPE {ENUM_TYPE}
+            USING visibility::{ENUM_TYPE}
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {SCHEMA}.builtin_tools
+            ALTER COLUMN visibility SET DEFAULT 'PRIVATE'::{ENUM_TYPE}
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # 反向：先 DROP DEFAULT，再走 ::text 中转回到 VARCHAR(20)，最后恢复 0031 的小写默认值。
+    # 必须经 ``::text``，避免「enum 直接 ::varchar」复现 ISSUE-012 类陷阱。
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.builtin_tools ALTER COLUMN visibility DROP DEFAULT"))
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {SCHEMA}.builtin_tools
+            ALTER COLUMN visibility TYPE VARCHAR(20)
+            USING visibility::text
+            """
+        )
+    )
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.builtin_tools ALTER COLUMN visibility SET DEFAULT 'private'"))

--- a/apps/negentropy/tests/integration_tests/interface/test_get_visible_plugin_ids.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_get_visible_plugin_ids.py
@@ -1,0 +1,220 @@
+"""Integration 测试：``permissions.get_visible_plugin_ids`` 在真实 PG 上的并集语义。
+
+动机：
+    迁移 0031 将 ``builtin_tools.visibility`` 误建为 ``VARCHAR(20)``，而 ORM 把
+    该字段映射为 ``Enum(PluginVisibility, schema="negentropy")``，导致 SQLAlchemy
+    生成的 ``WHERE visibility = $N::negentropy.pluginvisibility`` 在 VARCHAR 列上
+    报 ``UndefinedFunctionError``，``GET /interface/tools`` / ``GET /interface/stats``
+    500（见 docs/agents/issue.md ISSUE-089，与 ISSUE-012 同源）。
+
+本测试用真实 PG round-trip 守护：
+    1. 4 类 plugin（builtin_tool / mcp_server / skill / sub_agent）的 visibility
+       列类型与 ORM 声明一致，``= PluginVisibility.PUBLIC`` 查询不报错；
+    2. 并集语义：own + PUBLIC + 授权（PluginPermission） + is_system 全部纳入；
+       其他用户的 PRIVATE 行不可见。
+
+下次任何 plugin 表的 visibility 漂移（ORM Enum vs 迁移 VARCHAR）会被本测试立即捕获。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete
+
+import negentropy.db.session as db_session
+from negentropy.auth.service import AuthUser
+from negentropy.interface.permissions import get_visible_plugin_ids
+from negentropy.models.plugin import (
+    BuiltinTool,
+    McpServer,
+    PluginPermission,
+    PluginPermissionType,
+    PluginVisibility,
+    Skill,
+    SubAgent,
+)
+
+
+def _make_user(user_id: str, *, admin: bool = False) -> AuthUser:
+    return AuthUser(
+        user_id=user_id,
+        email=None,
+        name=None,
+        picture=None,
+        roles=["admin"] if admin else ["user"],
+        provider="test",
+        subject=user_id,
+        domain=None,
+    )
+
+
+@dataclass(frozen=True)
+class _PluginCase:
+    """4 类 plugin 的最小可插入工厂 + 表 unique name 命名空间。"""
+
+    plugin_type: str
+    model: type
+    factory: Callable[..., object]
+
+
+def _builtin_tool_factory(
+    *, owner_id: str, visibility: PluginVisibility, name: str, is_system: bool = False
+) -> BuiltinTool:
+    return BuiltinTool(
+        owner_id=owner_id,
+        visibility=visibility,
+        name=name,
+        tool_type="search",
+        is_system=is_system,
+    )
+
+
+def _mcp_server_factory(
+    *, owner_id: str, visibility: PluginVisibility, name: str, is_system: bool = False
+) -> McpServer:
+    return McpServer(
+        owner_id=owner_id,
+        visibility=visibility,
+        name=name,
+        transport_type="stdio",
+        is_system=is_system,
+    )
+
+
+def _skill_factory(*, owner_id: str, visibility: PluginVisibility, name: str, is_system: bool = False) -> Skill:
+    return Skill(
+        owner_id=owner_id,
+        visibility=visibility,
+        name=name,
+        is_system=is_system,
+    )
+
+
+def _sub_agent_factory(*, owner_id: str, visibility: PluginVisibility, name: str, is_system: bool = False) -> SubAgent:
+    return SubAgent(
+        owner_id=owner_id,
+        visibility=visibility,
+        name=name,
+        agent_type="llm_agent",
+        is_system=is_system,
+    )
+
+
+PLUGIN_CASES: list[_PluginCase] = [
+    _PluginCase("builtin_tool", BuiltinTool, _builtin_tool_factory),
+    _PluginCase("mcp_server", McpServer, _mcp_server_factory),
+    _PluginCase("skill", Skill, _skill_factory),
+    _PluginCase("sub_agent", SubAgent, _sub_agent_factory),
+]
+
+
+@pytest.fixture
+def alice() -> AuthUser:
+    return _make_user(f"test-alice-{uuid4().hex[:8]}")
+
+
+@pytest.fixture
+def bob() -> AuthUser:
+    return _make_user(f"test-bob-{uuid4().hex[:8]}")
+
+
+@pytest.mark.parametrize("case", PLUGIN_CASES, ids=lambda c: c.plugin_type)
+@pytest.mark.asyncio
+async def test_get_visible_plugin_ids_union_semantics(
+    case: _PluginCase,
+    alice: AuthUser,
+    bob: AuthUser,
+) -> None:
+    """4 类 plugin 的可见性并集语义在真实 PG 上一致：own + PUBLIC + 授权 + is_system。
+
+    本测试覆盖的核心回归路径：
+        - ``WHERE visibility = $N::negentropy.pluginvisibility`` 必须能在真实 PG
+          上 round-trip（防止再次出现 VARCHAR vs ENUM 漂移）；
+        - PUBLIC / SHARED / PRIVATE 与 ``is_system`` / ``PluginPermission`` 的并集
+          行为符合 ``permissions.get_visible_plugin_ids`` 文档约定。
+    """
+    ns = uuid4().hex[:8]  # 用 name 唯一前缀避开同表 UNIQUE(name)
+
+    own_private = case.factory(
+        owner_id=alice.user_id, visibility=PluginVisibility.PRIVATE, name=f"{case.plugin_type}-own-private-{ns}"
+    )
+    own_public = case.factory(
+        owner_id=alice.user_id, visibility=PluginVisibility.PUBLIC, name=f"{case.plugin_type}-own-public-{ns}"
+    )
+    other_private = case.factory(
+        owner_id=bob.user_id, visibility=PluginVisibility.PRIVATE, name=f"{case.plugin_type}-other-private-{ns}"
+    )
+    other_public = case.factory(
+        owner_id=bob.user_id, visibility=PluginVisibility.PUBLIC, name=f"{case.plugin_type}-other-public-{ns}"
+    )
+    other_shared_with_alice = case.factory(
+        owner_id=bob.user_id, visibility=PluginVisibility.SHARED, name=f"{case.plugin_type}-other-shared-{ns}"
+    )
+    system_row = case.factory(
+        owner_id="system",
+        # 与 is_system 维度正交：即便 PRIVATE，is_system=True 也对全员可见。
+        visibility=PluginVisibility.PRIVATE,
+        name=f"{case.plugin_type}-system-{ns}",
+        is_system=True,
+    )
+
+    rows: list[object] = [own_private, own_public, other_private, other_public, other_shared_with_alice, system_row]
+    row_ids: list = []
+    perm_id = None
+
+    try:
+        async with db_session.AsyncSessionLocal() as db:
+            db.add_all(rows)
+            await db.commit()
+            for r in rows:
+                await db.refresh(r)
+            row_ids = [r.id for r in rows]  # type: ignore[attr-defined]
+
+        async with db_session.AsyncSessionLocal() as db:
+            perm = PluginPermission(
+                plugin_type=case.plugin_type,
+                plugin_id=other_shared_with_alice.id,  # type: ignore[attr-defined]
+                user_id=alice.user_id,
+                permission=PluginPermissionType.VIEW,
+            )
+            db.add(perm)
+            await db.commit()
+            await db.refresh(perm)
+            perm_id = perm.id
+
+        async with db_session.AsyncSessionLocal() as db:
+            visible = await get_visible_plugin_ids(db, case.plugin_type, alice)
+
+        visible_set = set(visible)
+        assert own_private.id in visible_set, "owner_id 自有 PRIVATE 应可见"  # type: ignore[attr-defined]
+        assert own_public.id in visible_set, "owner_id 自有 PUBLIC 应可见"  # type: ignore[attr-defined]
+        assert other_public.id in visible_set, "他人 PUBLIC 应可见"  # type: ignore[attr-defined]
+        assert other_shared_with_alice.id in visible_set, "他人 SHARED + PluginPermission 授权应可见"  # type: ignore[attr-defined]
+        assert system_row.id in visible_set, "is_system=True 对全员可见"  # type: ignore[attr-defined]
+        assert other_private.id not in visible_set, "他人 PRIVATE 不应可见"  # type: ignore[attr-defined]
+
+    finally:
+        async with db_session.AsyncSessionLocal() as db:
+            if perm_id is not None:
+                await db.execute(delete(PluginPermission).where(PluginPermission.id == perm_id))
+            if row_ids:
+                await db.execute(delete(case.model).where(case.model.id.in_(row_ids)))
+            await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_visible_plugin_ids_builtin_tool_public_query_does_not_raise() -> None:
+    """ISSUE-089 直接回归测试：``builtin_tool`` 的 PUBLIC 子查询不再触发
+    ``UndefinedFunctionError: operator does not exist: character varying = negentropy.pluginvisibility``。
+
+    只要 0036 迁移已应用、ORM 与 DB 列类型一致，本调用即可顺利完成 round-trip
+    （即便无任何匹配行也不应抛 ProgrammingError）。
+    """
+    alice = _make_user(f"test-alice-{uuid4().hex[:8]}")
+    async with db_session.AsyncSessionLocal() as db:
+        ids = await get_visible_plugin_ids(db, "builtin_tool", alice)
+    assert isinstance(ids, list)

--- a/docs/agents/issue.md
+++ b/docs/agents/issue.md
@@ -2063,3 +2063,37 @@
   - 本仓库其余 `router.replace` / `router.push` 调用（`app/admin/layout.tsx`、`app/interface/layout.tsx`、`app/interface/task-models/page.tsx`、`app/interface/models/page.tsx`、`app/knowledge/documents/page.tsx`）均为 pathname 级跳转，不在 bug 影响面，保持不变。
   - 未来若在 Knowledge / Memory / Interface 页加入"仅 query 切换 tab/filter"的入口（如 `?tab=...` / `?filter=...`），需直接采用 `window.history.replaceState` 模式而非 `router.replace`。
   - 与 [ISSUE-061](#issue-061) / [ISSUE-062](#issue-062) / [ISSUE-066](#issue-066) 一起构成 Next.js App Router URL 单源派生模式下的四件套：URL 派生（061 v2-D）、稳定 deps（062）、router.replace 异步延迟下的 pending auto-send（066）、router.replace 同 pathname no-op 绕道（本期 088）。后续接入新 URL-派生场景时，应同步审视这四件套是否完整。
+
+---
+
+## ISSUE-089 `builtin_tools.visibility` ORM Enum 与迁移 VARCHAR 漂移致 `/interface/tools` 与 `/interface/stats` 500（2026-05-18）
+
+- **表因**：服务端日志（开发本机与开发环境同步复现）`uvicorn.error` 反复抛出 `Exception in ASGI application`，根因是 SQLAlchemy 抛 `ProgrammingError`：
+  ```
+  asyncpg.exceptions.UndefinedFunctionError: operator does not exist:
+    character varying = negentropy.pluginvisibility
+  HINT: No operator matches the given name and argument types.
+  [parameters: ('google:106729725448726600925', 'PUBLIC', 'builtin_tool', 'google:...')]
+  SQL: ... WHERE negentropy.builtin_tools.visibility = $2::negentropy.pluginvisibility ...
+  ```
+  两个端点 500：`GET /interface/tools`（[`api.list_builtin_tools`](../../apps/negentropy/src/negentropy/interface/api.py)）与 `GET /interface/stats`（[`api.get_stats`](../../apps/negentropy/src/negentropy/interface/api.py)），同一链路都经过 [`permissions.get_visible_plugin_ids`](../../apps/negentropy/src/negentropy/interface/permissions.py) 的 `model.visibility == PluginVisibility.PUBLIC` 子查询。
+- **根因**：
+  1. PG 枚举 `negentropy.pluginvisibility` 在 [`0001_init_schema.py:196`](../../apps/negentropy/src/negentropy/db/migrations/versions/0001_init_schema.py) 创建，成员 NAME 为大写 `PRIVATE/SHARED/PUBLIC`。`mcp_servers/skills/sub_agents` 三类 plugin 均沿此模板建表。
+  2. [`0031_builtin_tools.py:82`](../../apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py) 偏离模板，把 `builtin_tools.visibility` 建为 `VARCHAR(20) NOT NULL DEFAULT 'private'`，并以小写字面量 `'public'` 种子化 `google_search` 行（line 127）。
+  3. ORM 模型 [`builtin_tool.py:30-34`](../../apps/negentropy/src/negentropy/models/builtin_tool.py) 沿用 `Enum(PluginVisibility, schema=NEGENTROPY_SCHEMA)`，SQLAlchemy 据此生成 `WHERE visibility = $N::negentropy.pluginvisibility` 的显式 cast，绑定值用枚举成员 NAME（大写 `'PUBLIC'`）。
+  4. PG 无 `varchar = pluginvisibility` 操作符，对 VARCHAR 列做 enum cast 直接报 `UndefinedFunctionError`。
+- **处理方式**：
+  1. 新增前向迁移 [`0036_builtin_tools_visibility_enum.py`](../../apps/negentropy/src/negentropy/db/migrations/versions/0036_builtin_tools_visibility_enum.py) 三步走：
+     1. `UPDATE` 把 `LOWER(visibility::text) ∈ {'private','shared','public'}` 的行规范化为 enum 成员名（大写）；
+     2. `DO $$ ... RAISE EXCEPTION ... $$` 防御性断言：若仍有非法值，明确抛错而非让 `ALTER TYPE` 报含糊的 cast 错误；
+     3. `DROP DEFAULT` → `ALTER COLUMN visibility TYPE negentropy.pluginvisibility USING visibility::negentropy.pluginvisibility` → `SET DEFAULT 'PRIVATE'::negentropy.pluginvisibility`。
+  2. **不修改 0031**：违反 forward-only 约定会破坏既有部署的 stairway 测试，且 0036 已在数据规范化阶段覆盖 0031 的小写遗留。
+  3. `downgrade()` 同样三步反向，`USING visibility::text` 中转回 `VARCHAR(20)`、恢复 `DEFAULT 'private'`，与 [ISSUE-012](#issue-012)「枚举列上 text-only 操作必须经 `::text` cast」对齐。
+  4. 新增 integration 测试 [`tests/integration_tests/interface/test_get_visible_plugin_ids.py`](../../apps/negentropy/tests/integration_tests/interface/test_get_visible_plugin_ids.py) 守护真实 PG round-trip：参数化覆盖 4 类 plugin（`builtin_tool/mcp_server/skill/sub_agent`），断言 own + PUBLIC + SHARED（PluginPermission 授权） + is_system 的并集语义全部生效，他人 PRIVATE 不可见；并补一个直接的「`builtin_tool` PUBLIC 子查询不抛 ProgrammingError」回归点位。
+- **后续防范**：
+  1. **新增 plugin 表的强制模板**：任何新表若有 `visibility` 列，必须复用 `Enum(PluginVisibility, schema=NEGENTROPY_SCHEMA)`（ORM）+ `sa.Enum("PRIVATE", "SHARED", "PUBLIC", name="pluginvisibility", schema="negentropy")`（迁移），与 0001 的 `mcp_servers/skills/sub_agents` 三处保持对称；review 时若发现 `visibility VARCHAR` 直接打回。
+  2. **ORM ↔ 迁移漂移的代价是「类型层 SQL 错误」**：与字段名漂移（[ISSUE-010](#issue-010)）、属性懒加载漂移（[ISSUE-016](#issue-016) 三阶）同属「写入侧契约与读取侧契约错位」家族。Review 红线：所有 `mapped_column(Enum(...))` 的 PR 必须对照同表 `CREATE TABLE` / 后续 `ALTER COLUMN` 迁移是否落地为对应 PG enum 类型。
+  3. **真实 PG round-trip 测试是底线**：单元测试只能验证纯函数语义，类似 `get_visible_plugin_ids` 这种「ORM 表达式 → PG 执行」路径必须有 integration 用例覆盖；本期补的参数化用例可作为下次新增 plugin 表时的「填空」模板。
+- **同类问题影响**：
+  - 与 [ISSUE-012](#issue-012)（枚举列上 `LOWER`/`UPPER` 必须 `::text` cast）同源——本期是「读侧 cast 失败」，012 是「迁移侧 cast 失败」，两者共同提示「PG 枚举列与 text 之间的所有交互都需要显式 cast，且 ORM 侧声明类型必须与 DB 真实列类型严格一致」。
+  - 已确认本仓库其他 plugin 表（`mcp_servers/skills/sub_agents`）的 `visibility` 列与 ORM 声明一致，无同型漂移。任何未来新增 plugin 类型（如假想中的 `prompt_template`/`workflow`）必须按上文「新增 plugin 表的强制模板」实施。


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：服务端日志反复抛出 `asyncpg.exceptions.UndefinedFunctionError: operator does not exist: character varying = negentropy.pluginvisibility`，导致 `GET /interface/tools`（`api.list_builtin_tools`）与 `GET /interface/stats`（`api.get_stats`）500，Tools 列表与 Dashboard 统计全链路不可用。
- 关联上下文/Issue/文档：[ISSUE-089](docs/agents/issue.md#issue-089-builtin_toolsvisibility-orm-enum-与迁移-varchar-漂移致-interfacetools-与-interfacestats-5002026-05-18)（本期新增）；与 [ISSUE-012](docs/agents/issue.md#issue-012-alembic-0005-downgrade-在-pg-枚举列上直接调用-lower-及回填-document_ref-时未守护父节点存在性) 同源——「PG 枚举列与 text 之间的所有交互必须显式 cast，且 ORM 声明类型必须与 DB 真实列类型严格一致」。

# 核心变更
- **新增前向不可逆迁移 [`0036_builtin_tools_visibility_enum.py`](apps/negentropy/src/negentropy/db/migrations/versions/0036_builtin_tools_visibility_enum.py)**：① `UPDATE` 把 0031 种子的 `'public'` 等小写值规范化为枚举成员名（大写 `PRIVATE/SHARED/PUBLIC`），并兜底其它大小写变体；② `DO $$ RAISE EXCEPTION $$` 防御性断言非法值；③ `DROP DEFAULT` → `ALTER COLUMN visibility TYPE negentropy.pluginvisibility USING visibility::negentropy.pluginvisibility` → `SET DEFAULT 'PRIVATE'::negentropy.pluginvisibility`。对称 `downgrade()` 经 `USING visibility::text` 中转回 `VARCHAR(20)` + 恢复 `'private'` 默认值，规避 [ISSUE-012](docs/agents/issue.md#issue-012) 类直接 enum→varchar cast 陷阱。
- **不修改 0031**：前向不可逆约定（修 0031 会破坏既有部署的 stairway 与已运行旧 0031 的环境）；0036 已在数据规范化阶段覆盖 0031 的小写遗留。
- **新增集成测试 [`tests/integration_tests/interface/test_get_visible_plugin_ids.py`](apps/negentropy/tests/integration_tests/interface/test_get_visible_plugin_ids.py)**：参数化覆盖 4 类 plugin（`builtin_tool/mcp_server/skill/sub_agent`）的可见性并集语义（own + PUBLIC + SHARED via PluginPermission + is_system），真实 PG round-trip 守护；并补一个针对 `builtin_tool` PUBLIC 子查询「不再抛 ProgrammingError」的直接回归点位。下次任何 plugin 表「ORM Enum vs 迁移 VARCHAR」漂移会被立即捕获。
- **沉淀 [ISSUE-089](docs/agents/issue.md#issue-089)** 到 `docs/agents/issue.md`：记录表因 / 根因 / 处理 / 后续防范（新表强制模板、Review 红线、真实 PG round-trip 为底线）/ 同类问题影响，与 ISSUE-012 合并审视。
- **未触代码层**：`BuiltinTool` ORM 模型、`permissions.get_visible_plugin_ids` 查询、`interface/api.py` 端点均无需调整——bug 仅在 DB schema 漂移层。

# 风险与回滚
- **主要风险**：① `ALTER COLUMN ... TYPE` 取 ACCESS EXCLUSIVE 锁并重写表数据，但 `builtin_tools` 当前部署仅 system seed 量级（生产 1 行），锁窗口可忽略；② 若运维侧手工写入了 `{private,shared,public}` 之外的 visibility 值，将被防御性断言显式抛错，避免 `ALTER TYPE` 后给出含糊的 cast 失败信息（这是设计意图，而非风险）。
- **回滚方式**：`uv run alembic downgrade 0035` 即回到 VARCHAR(20) 与 `'private'` 默认值；本次同时验证了 `0035→0036→0035→0036` 反复 stairway 行为正确。

# 验证证据
- **单元测试**：`uv run pytest tests/unit_tests/interface/test_permissions.py -v` —— **11/11 passed**（未引入回归）。
- **集成测试**：`uv run pytest tests/integration_tests/interface/test_get_visible_plugin_ids.py -v` —— **5/5 passed**（4 plugin 类型参数化 + 1 builtin_tool 直接回归点位）。
- **迁移 stairway**：`alembic upgrade head`（0035→0036） + `alembic downgrade 0035` + 再 `upgrade head` 均成功；schema 复核显示 `visibility` 列从 `varchar(20)` 切换到 `negentropy.pluginvisibility`、默认值从 `'private'`→`'PRIVATE'::negentropy.pluginvisibility`、`google_search` seed 行从 `'public'`→`'PUBLIC'`。
- **预先存在的 `tests/integration_tests/db/test_migrations.py` 失败**（`wiki_publication_entries.document_id NOT NULL` vs 旧 NULL 行）已通过 `git stash` 复核确认与本次改动无关。
- **E2E/Workflow**：本仓库 dev server（端口 3292）触达确认端点已可达（401 unauth 网关为预期表现，非 500）；用户主 Chrome 实机 UI 回归留待用户本机执行（当前 MCP chrome_devtools 被锁在 sandbox profile 上，与 [feedback_browser_validation.md](docs/agents/browser-validation.md) 约定的主 profile 不一致，需先解锁后再做最后一公里 UI 验证）。

# 影响范围
- **前端**：无改动；`/interface/tools` 与 Dashboard 统计在用户侧应立刻恢复（前端代码未调整）。
- **后端**：仅迁移 + 集成测试 + 文档；`BuiltinTool` ORM 与 `permissions.get_visible_plugin_ids` 查询保持原样。
- **GitHub Actions / 文档**：`docs/agents/issue.md` 新增 ISSUE-089；CI 配置无变更。

# Next Best Action
- 合并后在 PR 关联环境上线时，执行 `cd apps/negentropy && uv run alembic upgrade head` 让 0036 落地；同时人工在用户主 Chrome 上访问 `/` Dashboard 与 Tools 页确认无 500、Tools 列表至少含 `google_search` 一行。
- 后续若有新增 plugin 类型（如 `prompt_template` / `workflow`），按 [ISSUE-089 防范条款 1](docs/agents/issue.md#issue-089) 复用 `Enum(PluginVisibility, schema=NEGENTROPY_SCHEMA)` + 0001 风格的迁移模板，并在本 PR 引入的 `test_get_visible_plugin_ids.py` 中追加对应 `_PluginCase`。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)