### PR TITLE
fix(KnowledgeNav): 统一二级导航靠右对齐以匹配其他模块视觉

### DIFF
--- a/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
+++ b/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
@@ -37,7 +37,8 @@ export function KnowledgeNav({
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
-      <div className="flex flex-wrap items-center justify-between gap-4">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        {modeToggle}
         <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => {
             const active = isActive(item.href, item.aliases);
@@ -56,7 +57,6 @@ export function KnowledgeNav({
             );
           })}
         </nav>
-        {modeToggle}
       </div>
     </div>
   );

--- a/apps/negentropy-ui/tests/unit/ui/KnowledgeNav.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/KnowledgeNav.test.tsx
@@ -25,4 +25,27 @@ describe("KnowledgeNav", () => {
     expect(pipelinesLink.className).toContain("bg-foreground");
     expect(baseLink).toHaveAttribute("href", "/knowledge/base");
   });
+
+  // 视觉不变量：与 HomeNav/MemoryNav/InterfaceNav/AdminNav 保持二级导航靠右对齐
+  it("二级导航容器使用 justify-end，整体右对齐", () => {
+    const { container } = render(<KnowledgeNav title="Pipelines" />);
+    const nav = container.querySelector("nav") as HTMLElement;
+    const flexRow = nav.parentElement as HTMLElement;
+
+    expect(flexRow.className).toContain("justify-end");
+    expect(flexRow.className).not.toContain("justify-between");
+  });
+
+  it("传入 modeToggle 时，渲染顺序为 modeToggle 在 nav 之前（确保 nav 始终贴最右边缘）", () => {
+    const { container } = render(
+      <KnowledgeNav title="Wiki" modeToggle={<div data-testid="mt">toggle</div>} />,
+    );
+    const nav = container.querySelector("nav") as HTMLElement;
+    const toggle = container.querySelector("[data-testid='mt']") as HTMLElement;
+    const flexRow = nav.parentElement as HTMLElement;
+
+    expect(toggle.parentElement).toBe(flexRow);
+    // DOCUMENT_POSITION_FOLLOWING (4) 表示 nav 出现在 toggle 之后
+    expect(toggle.compareDocumentPosition(nav) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge 模块（`/knowledge/*`）二级导航栏在多数子页面显示为靠左，与 Home / Memory / Interface / Admin 一律靠右的视觉规范不一致，产生视觉熵增。
- 关联上下文/Issue/文档：根因为 `KnowledgeNav` 容器使用 `justify-between` 以支持 Wiki 子页面传入 `modeToggle`，其余 5 个子页面（Base / Graph / Documents / APIs / Pipelines）不传 `modeToggle`，单元素 flex 容器在 `justify-between` 下塌缩为 flex-start，因此 nav 看似靠左。

# 核心变更
- `apps/negentropy-ui/components/ui/KnowledgeNav.tsx:40-59`：容器对齐由 `justify-between` 改为 `justify-end`；JSX 顺序调整为 `{modeToggle}` 在 `<nav>` 之前，确保 Wiki 子页面下 nav 也始终贴最右边缘，与 HomeNav / MemoryNav / InterfaceNav / AdminNav 视觉一致。
- `apps/negentropy-ui/tests/unit/ui/KnowledgeNav.test.tsx`：新增两条单测锁定视觉不变量——断言容器 className 含 `justify-end` 不含 `justify-between`；断言传入 `modeToggle` 时其 DOM 顺序在 `<nav>` 之前。

# 风险与回滚
- 主要风险：极低。改动仅涉及 Tailwind 对齐 class 与 children 渲染顺序，无运行时副作用；`KnowledgeNav` props 形状未变，7 处调用方零改动。
- 回滚方式：`git revert <commit>` 即可还原。

# 验证证据
- 单元测试：`pnpm --filter negentropy-ui test` 92 files / 722 tests 全过；`KnowledgeNav.test.tsx` 3/3 通过。
- 集成测试：N/A（纯样式与 DOM 顺序改动）。
- E2E/Workflow：N/A。
- 覆盖率/关键截图：dev server 编译产物 `.next/dev/server/app/knowledge/base/page.js` 中 KnowledgeNav 容器实际渲染为 `flex flex-wrap items-center justify-end gap-4`，与其他模块完全一致；`pnpm lint` / `pnpm typecheck` 通过。

# 影响范围
- 前端：仅 `negentropy-ui` 的 `KnowledgeNav` 组件及其单测；其它模块导航无改动。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后顺手浏览 `/knowledge/{base,graph,wiki,documents,apis,pipelines}` 与 `/memory`、`/interface` 任意子页面，确认视觉一致；新增的 2 条视觉不变量单测将持续防止此类对齐回归。