### PR TITLE
style(secondary-nav): 二级导航统一改为水平居中，主导航保持靠右不变

### DIFF
--- a/apps/negentropy-ui/components/ui/AdminNav.tsx
+++ b/apps/negentropy-ui/components/ui/AdminNav.tsx
@@ -31,7 +31,7 @@ export function AdminNav({
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
-      <div className="flex flex-wrap items-center justify-end gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-4">
         <nav className="flex flex-wrap items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => (
             <Link

--- a/apps/negentropy-ui/components/ui/HomeNav.tsx
+++ b/apps/negentropy-ui/components/ui/HomeNav.tsx
@@ -38,7 +38,7 @@ export function HomeNav({ title }: { title: string }) {
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
-      <div className="flex flex-wrap items-center justify-end gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-4">
         <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => {
             const href = item.key === "studio" ? studioHref : item.href;

--- a/apps/negentropy-ui/components/ui/InterfaceNav.tsx
+++ b/apps/negentropy-ui/components/ui/InterfaceNav.tsx
@@ -44,7 +44,7 @@ export function InterfaceNav({
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
-      <div className="flex flex-wrap items-center justify-end gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-4">
         <nav className="flex flex-wrap items-center gap-1 bg-muted/50 p-1 rounded-full">
           {visibleItems.map((item) => (
             <Link

--- a/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
+++ b/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
@@ -37,7 +37,7 @@ export function KnowledgeNav({
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
-      <div className="flex flex-wrap items-center justify-end gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-4">
         {modeToggle}
         <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => {

--- a/apps/negentropy-ui/components/ui/MemoryNav.tsx
+++ b/apps/negentropy-ui/components/ui/MemoryNav.tsx
@@ -36,7 +36,7 @@ export function MemoryNav({
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
-      <div className="flex flex-wrap items-center justify-end gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-4">
         <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => (
             <Link

--- a/apps/negentropy-ui/tests/unit/ui/KnowledgeNav.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/KnowledgeNav.test.tsx
@@ -26,17 +26,18 @@ describe("KnowledgeNav", () => {
     expect(baseLink).toHaveAttribute("href", "/knowledge/base");
   });
 
-  // 视觉不变量：与 HomeNav/MemoryNav/InterfaceNav/AdminNav 保持二级导航靠右对齐
-  it("二级导航容器使用 justify-end，整体右对齐", () => {
+  // 视觉不变量：与 HomeNav/MemoryNav/InterfaceNav/AdminNav 保持二级导航水平居中
+  it("二级导航容器使用 justify-center，整体水平居中", () => {
     const { container } = render(<KnowledgeNav title="Pipelines" />);
     const nav = container.querySelector("nav") as HTMLElement;
     const flexRow = nav.parentElement as HTMLElement;
 
-    expect(flexRow.className).toContain("justify-end");
+    expect(flexRow.className).toContain("justify-center");
+    expect(flexRow.className).not.toContain("justify-end");
     expect(flexRow.className).not.toContain("justify-between");
   });
 
-  it("传入 modeToggle 时，渲染顺序为 modeToggle 在 nav 之前（确保 nav 始终贴最右边缘）", () => {
+  it("传入 modeToggle 时，渲染顺序为 modeToggle 在 nav 之前（确保 modeToggle 与 nav 顺序稳定）", () => {
     const { container } = render(
       <KnowledgeNav title="Wiki" modeToggle={<div data-testid="mt">toggle</div>} />,
     );


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：上一次 [#565 (246902d3)](https://github.com/ThreeFish-AI/negentropy/pull/565) 将所有二级导航统一为 `justify-end`（靠右）。现产品视觉决策调整为**水平居中**，使胶囊样导航在页面横向居中、与靠右的主导航形成层级对比。
- 关联上下文：与 [#565](https://github.com/ThreeFish-AI/negentropy/pull/565) 形成对照——主导航 `MainNav`（SiteHeader 内）继续通过 `justify-between` 保持靠右，**完全不动**。

# 核心变更

- 5 个模块二级导航（`KnowledgeNav` / `InterfaceNav` / `MemoryNav` / `HomeNav` / `AdminNav`）的外层 flex 容器：`justify-end` → `justify-center`，单 className 替换，其余样式保持不动。
- KnowledgeNav 视觉不变量单测同步更新：断言 `className.toContain("justify-center")`，并新增 `not.toContain("justify-end")` 双重防线，避免误回退。
- 用例名与注释同步从"靠右对齐"修正为"水平居中"，保留 `not.toContain("justify-between")` 守护历史修复。

# 风险与回滚

- 主要风险：5 个模块通用 className 调整，覆盖 30+ 业务页面。`modeToggle`（仅 KnowledgeNav 暴露，被 Wiki 模块 `LibraryShell.tsx` 使用）居中后与 nav 作为一组水平居中显示，gap-4 间距保持，无功能影响。
- 回滚方式：单 commit `e87f79f6`，`git revert e87f79f6` 即可恢复至 `justify-end`。

# 验证证据

- 单元测试：`pnpm --filter negentropy-ui test`，**724/724 通过**，KnowledgeNav 3 个用例（含 `justify-center` 视觉不变量）全绿。
- typecheck：`pnpm --filter negentropy-ui typecheck` 与 `typecheck:test` 双通道通过。
- E2E：本次为纯样式 className 调整，未触及交互/路由/数据流，无需新增 E2E。
- 关键截图：本地 dev 模式未登录态主导航截图证实顶部 `Home / Knowledge / Memory / Interface` 仍靠右；二级导航需登录后渲染，按 [browser-validation](docs/agents/browser-validation.md) 协议不代办 OAuth，建议合并前由维护者在已登录 Chrome 主 profile 内目视确认。
- pre-commit：ESLint 钩子通过。

# 影响范围

- 前端：`apps/negentropy-ui/components/ui/{Admin,Home,Interface,Knowledge,Memory}Nav.tsx` + 同模块测试。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action

- 维护者登录 dev 环境（`pnpm --filter negentropy-ui dev`，3192 端口）后访问 `/`、`/knowledge/base`、`/knowledge/wiki`、`/memory`、`/interface`、`/admin` 目视确认二级导航胶囊整体水平居中、主导航保持靠右。
- 后续若产品方再次调整对齐策略，建议把 `justify-center` 的视觉不变量补齐到 `HomeNav` / `MemoryNav` / `InterfaceNav` / `AdminNav` 的单测中，让 5 个模块均显式锁定。