### PR TITLE
fix(kg-watchdog): 修复 pipeline_watchdog KG 子流程 asyncpg int→interval 类型错误

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/graph/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/repository.py
@@ -2205,7 +2205,7 @@ class AgeGraphRepository(GraphRepository):
                     error_message = COALESCE(error_message, :stale_msg),
                     completed_at = NOW()
                 WHERE status = 'running'
-                  AND COALESCE(updated_at, created_at) < NOW() - (:running_threshold || ' minutes')::interval
+                  AND COALESCE(updated_at, created_at) < NOW() - make_interval(mins => :running_threshold)
                   {"AND app_name = :app_name" if app_name is not None else ""}
             """)
             cancelled_stmt = text(f"""
@@ -2213,7 +2213,7 @@ class AgeGraphRepository(GraphRepository):
                 SET status = 'cancelled',
                     completed_at = NOW()
                 WHERE status = 'cancelling'
-                  AND COALESCE(updated_at, created_at) < NOW() - (:cancelling_threshold || ' minutes')::interval
+                  AND COALESCE(updated_at, created_at) < NOW() - make_interval(mins => :cancelling_threshold)
                   {"AND app_name = :app_name" if app_name is not None else ""}
             """)
 

--- a/apps/negentropy/tests/integration_tests/knowledge/test_finalize_stale_kg_build_runs_integration.py
+++ b/apps/negentropy/tests/integration_tests/knowledge/test_finalize_stale_kg_build_runs_integration.py
@@ -1,0 +1,176 @@
+"""``AgeGraphRepository.finalize_stale_kg_build_runs`` 集成测试。
+
+回归目标（root cause）:
+    旧 SQL ``(:running_threshold || ' minutes')::interval`` 中 ``||`` 是 PostgreSQL 字符串拼接，
+    要求两侧为 text；而 ``finalize_stale_kg_build_runs`` 入参 ``running_threshold_minutes``
+    与 ``cancelling_threshold_minutes`` 默认为 ``int(30)`` / ``int(2)``。asyncpg 在
+    prepared-statement 编码阶段严格校验类型，直接抛 ``TypeError: expected str, got int``，
+    被 SQLAlchemy 翻译为 ``asyncpg.exceptions.DataError``，导致 ``pipeline_watchdog`` 调度
+    每个 tick 失败（详见 ``engine/schedulers/handlers/pipeline_watchdog.py``）。
+
+修复方案：raw SQL 改用 ``make_interval(mins => :p)``，原生接收 ``int4``，与本仓库既有范式
+``engine/adapters/postgres/memory_automation_service.py`` 中 ``make_interval(days => p_min_age_days)``
+保持一致。
+
+为何必须用集成测试：bug 触发点在 asyncpg native type encoder（C 扩展层），单元测试（mock /
+SQLite）无法复现；必须连接真 PostgreSQL 才能验证。
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from negentropy.knowledge.graph.repository import AgeGraphRepository
+from negentropy.models.base import NEGENTROPY_SCHEMA
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def stale_kg_runs(db_engine):
+    """插入 1 条 stale ``running`` 与 1 条 stale ``cancelling`` 用例数据。
+
+    使用唯一 ``app_name`` 隔离作用域，避免污染共享开发 DB 中无关 run；
+    teardown 阶段按 ``app_name`` 清理，保证测试可重复。
+    """
+    app_name = f"watchdog-test-{uuid4().hex[:8]}"
+    running_id = uuid4()
+    cancelling_id = uuid4()
+    sf = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with sf() as s:
+        await s.execute(
+            text(f"""
+                INSERT INTO {NEGENTROPY_SCHEMA}.kg_build_runs
+                    (id, app_name, status, created_at, updated_at)
+                VALUES
+                    (:rid, :app, 'running',    NOW() - INTERVAL '2 hours', NOW() - INTERVAL '2 hours'),
+                    (:cid, :app, 'cancelling', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '2 hours')
+            """),
+            {"rid": running_id, "cid": cancelling_id, "app": app_name},
+        )
+        await s.commit()
+
+    yield app_name, running_id, cancelling_id
+
+    async with sf() as s:
+        await s.execute(
+            text(f"DELETE FROM {NEGENTROPY_SCHEMA}.kg_build_runs WHERE app_name = :app"),
+            {"app": app_name},
+        )
+        await s.commit()
+
+
+@pytest.fixture
+async def db_session(db_engine):
+    """绑定到测试 engine 的独立 AsyncSession，供 ``AgeGraphRepository`` 注入。"""
+    sf = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+    async with sf() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeStaleKgBuildRunsIntegration:
+    """``finalize_stale_kg_build_runs`` 行为级回归测试。"""
+
+    async def test_running_and_cancelling_converge_without_dataerror(self, db_engine, db_session, stale_kg_runs):
+        """主路径：running → failed、cancelling → cancelled，且不抛 asyncpg DataError。"""
+        app_name, running_id, cancelling_id = stale_kg_runs
+
+        # 注入 session 让 repository 走测试 engine；该调用是 pre-fix 必然抛
+        # ``asyncpg.exceptions.DataError: invalid input for query argument $2: 30
+        # (expected str, got int)`` 的入口。
+        repo = AgeGraphRepository(session=db_session)
+        result = await repo.finalize_stale_kg_build_runs(app_name=app_name)
+
+        assert result == {"forced_failed": 1, "forced_cancelled": 1}
+
+        # 用独立连接 verify 实际持久化结果（绕开 ORM 缓存，确保读到 DB 真值）。
+        sf = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with sf() as verify_session:
+            rows = (
+                (
+                    await verify_session.execute(
+                        text(f"""
+                        SELECT id, status, completed_at, error_message
+                          FROM {NEGENTROPY_SCHEMA}.kg_build_runs
+                         WHERE app_name = :app
+                    """),
+                        {"app": app_name},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        by_id = {r["id"]: r for r in rows}
+        assert by_id[running_id]["status"] == "failed"
+        assert by_id[running_id]["completed_at"] is not None
+        assert "forcibly marked as failed" in (by_id[running_id]["error_message"] or "")
+        assert by_id[cancelling_id]["status"] == "cancelled"
+        assert by_id[cancelling_id]["completed_at"] is not None
+
+    async def test_default_int_thresholds_pass_asyncpg_encoding(self, db_session, stale_kg_runs):
+        """回归锁死：默认阈值为 int(30, 2)，pre-fix 直接抛 asyncpg DataError。"""
+        app_name, *_ = stale_kg_runs
+
+        # 不显式传 threshold，走 30 / 2 默认值——正是 production 触发 bug 的入参形态。
+        repo = AgeGraphRepository(session=db_session)
+        result = await repo.finalize_stale_kg_build_runs(app_name=app_name)
+
+        assert isinstance(result, dict)
+        assert result["forced_failed"] >= 0
+        assert result["forced_cancelled"] >= 0
+
+    async def test_fresh_run_not_affected(self, db_engine, db_session):
+        """边界用例：新鲜 ``running`` 行（updated_at = NOW()）不应被收敛为 failed。"""
+        app_name = f"watchdog-fresh-{uuid4().hex[:8]}"
+        fresh_id = uuid4()
+
+        sf = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+        async with sf() as s:
+            await s.execute(
+                text(f"""
+                    INSERT INTO {NEGENTROPY_SCHEMA}.kg_build_runs
+                        (id, app_name, status, created_at, updated_at)
+                    VALUES (:rid, :app, 'running', NOW(), NOW())
+                """),
+                {"rid": fresh_id, "app": app_name},
+            )
+            await s.commit()
+
+        try:
+            repo = AgeGraphRepository(session=db_session)
+            result = await repo.finalize_stale_kg_build_runs(app_name=app_name)
+            assert result == {"forced_failed": 0, "forced_cancelled": 0}
+
+            async with sf() as verify_session:
+                row = (
+                    (
+                        await verify_session.execute(
+                            text(f"""
+                            SELECT status FROM {NEGENTROPY_SCHEMA}.kg_build_runs WHERE id = :rid
+                        """),
+                            {"rid": fresh_id},
+                        )
+                    )
+                    .mappings()
+                    .one()
+                )
+            assert row["status"] == "running"
+        finally:
+            async with sf() as s:
+                await s.execute(
+                    text(f"DELETE FROM {NEGENTROPY_SCHEMA}.kg_build_runs WHERE app_name = :app"),
+                    {"app": app_name},
+                )
+                await s.commit()


### PR DESCRIPTION
# 背景

- **本次变更要解决的问题**：后端调度任务 `pipeline_watchdog` 每个 tick（约 60s）抛出 `pipeline_watchdog_kg_failed`，错误链顶为 `asyncpg.exceptions.DataError: invalid input for query argument $2: 30 (expected str, got int)`，导致 KG 长尾 `running` / `cancelling` build run 无法被看门狗收敛，`HandlerResult.metrics.kg_ok` 长期为 `False`，影响 Dashboard 与退避策略。
- **关联上下文**：错误日志样本见 `.context/attachments/pasted_text_2026-05-18_14-44-22.txt`；KB 子流程走 ORM + Python `datetime` 算术不受影响，bug 仅存在于 KG 的 raw SQL 路径。

# 核心变更

- `apps/negentropy/src/negentropy/knowledge/graph/repository.py:2208/2216`：将 `(:p || ' minutes')::interval` 改为 `make_interval(mins => :p)`。
  - **根因**：`||` 是 PostgreSQL 字符串拼接，要求两侧 text，但 Python 直传 `int(30)` / `int(2)`；asyncpg 在 prepared-statement 编码阶段严格校验类型，直接拒绝。
  - **范式对齐**：`make_interval()` 原生接收 `int4`，与仓库现有最佳实践 `engine/adapters/postgres/memory_automation_service.py:108`（`make_interval(days => p_min_age_days)`）保持一致——类型安全 + 一致性 + 可读性。
  - 函数签名、参数 dict、调用方均零改动；唯一调用方 `engine/schedulers/handlers/pipeline_watchdog.py:43`。
- **新增**：`apps/negentropy/tests/integration_tests/knowledge/test_finalize_stale_kg_build_runs_integration.py`：集成回归测试 3 用例（必须真 PG，因 bug 在 asyncpg C 扩展类型编码层）。

# 风险与回滚

- **主要风险**：极低。`make_interval` 自 PostgreSQL 9.4 起为标准内置函数；语义与原 SQL 完全等价（仅替换 interval 构造方式，未改 WHERE 条件、未改事务边界）；事务序、参数 dict、调用方零改动。
- **回滚方式**：`git revert b364857e` 即恢复旧 SQL（不推荐——会复现 bug）。

# 验证证据

- **集成测试**：新增 3 用例全 PASS（`uv run pytest tests/integration_tests/knowledge/test_finalize_stale_kg_build_runs_integration.py`）：
  - `test_running_and_cancelling_converge_without_dataerror`：主路径 running→failed、cancelling→cancelled，断言 `{forced_failed: 1, forced_cancelled: 1}`。
  - `test_default_int_thresholds_pass_asyncpg_encoding`：默认 int 阈值（30/2）路径——这就是 production 触发 bug 的入参形态，pre-fix 必然抛 `DataError`。
  - `test_fresh_run_not_affected`：边界用例，新鲜 `running`（updated_at = NOW()）不被错收为 failed。
- **单元测试回归**：`tests/unit_tests/engine/test_scheduler_handlers.py` 18/18 PASS，无回归。
- **运行时验证（部署后）**：scheduler 日志中 `pipeline_watchdog_kg_failed` 应消失；有长尾 run 时 `pipeline_watchdog_finalized` 打印且 `forced_failed`/`forced_cancelled` 非 0；`HandlerResult.metrics.kg_ok` 回到 `True`。

# 影响范围

- **前端**：无。
- **后端**：仅 `AgeGraphRepository.finalize_stale_kg_build_runs` 内两行 raw SQL；唯一调用方 `pipeline_watchdog` handler，签名/返回值不变。
- **GitHub Actions / 文档**：无。
- **数据库**：无 schema 变更、无迁移、无数据写入语义变化（同表同列同事务）。

# Next Best Action

- 部署后观察 1–2 个 `pipeline_watchdog` tick 周期，确认 `pipeline_watchdog_kg_failed` 不再出现、`metrics.kg_ok=True`。
- 若需主动收敛积压长尾，可执行只读探针 `SELECT id, status, updated_at FROM negentropy.kg_build_runs WHERE status IN ('running','cancelling') AND COALESCE(updated_at, created_at) < NOW() - make_interval(mins => 30);` 评估清理量级。