### PR TITLE
fix(builtin-tool): 修复 Interface/Tools 页 JSONB 双编码导致 500 错误

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0031_builtin_tools.py
@@ -12,7 +12,6 @@ Create Date: 2026-05-11 00:00:00.000000+00:00
   自动迁移现有部署的凭证到 builtin_tools 表（ON CONFLICT DO NOTHING 保证幂等）。
 """
 
-import json
 import os
 from collections.abc import Sequence
 
@@ -104,17 +103,15 @@ def upgrade() -> None:
     api_key = os.environ.get("NE_SEARCH_GOOGLE_API_KEY", "")
     cx_id = os.environ.get("NE_SEARCH_GOOGLE_CX_ID", "")
 
-    config = json.dumps(
-        {
-            "cx_id": cx_id or "d5ee76f9215be4ee9",
-            "max_retries": 3,
-            "timeout_seconds": 10.0,
-            "base_backoff_seconds": 1.0,
-            "max_results": 10,
-        }
-    )
-    credentials = json.dumps({"api_key": api_key}) if api_key else "{}"
-    config_schema = json.dumps(GOOGLE_SEARCH_CONFIG_SCHEMA)
+    config = {
+        "cx_id": cx_id or "d5ee76f9215be4ee9",
+        "max_retries": 3,
+        "timeout_seconds": 10.0,
+        "base_backoff_seconds": 1.0,
+        "max_results": 10,
+    }
+    credentials = {"api_key": api_key} if api_key else {}
+    config_schema = GOOGLE_SEARCH_CONFIG_SCHEMA
 
     op.execute(
         sa.text(

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0038_fix_jsonb_encoding.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0038_fix_jsonb_encoding.py
@@ -1,0 +1,49 @@
+"""Fix double-encoded JSONB in builtin_tools.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-05-19
+
+Root cause:
+    Migration 0031 used json.dumps() to pre-serialize Python dicts to strings,
+    then passed them through sa.bindparam(..., type_=JSONB). SQLAlchemy's
+    JSONB processor double-encoded them, storing e.g. '"{\\"api_key\\": ...}"'
+    instead of '{"api_key": ...}'.
+
+    jsonb_typeof() returns 'string' for double-encoded values vs 'object'
+    for correct ones.
+
+Fix:
+    UPDATE rows where jsonb_typeof(col) = 'string' to parse the string
+    back into proper jsonb objects. Idempotent: correct rows are untouched.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0038"
+down_revision: str | None = "0037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+_COLUMNS = ("config", "credentials", "config_schema")
+
+
+def upgrade() -> None:
+    for col in _COLUMNS:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {SCHEMA}.builtin_tools
+                   SET {col} = ({col}::text)::jsonb
+                 WHERE jsonb_typeof({col}) = 'string'
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -40,6 +40,7 @@ from negentropy.models.plugin import (
     SkillSchedule,
     SkillVersion,
     SubAgent,
+    ensure_dict,
 )
 from negentropy.models.vendor_config import VendorConfig
 
@@ -181,9 +182,9 @@ def _builtin_tool_to_response(tool: BuiltinTool) -> BuiltinToolResponse:
         description=tool.description,
         tool_type=tool.tool_type,
         version=tool.version,
-        config=tool.config or {},
-        credentials=_mask_credentials(tool.credentials or {}),
-        config_schema=tool.config_schema or {},
+        config=ensure_dict(tool.config),
+        credentials=_mask_credentials(ensure_dict(tool.credentials)),
+        config_schema=ensure_dict(tool.config_schema),
         is_enabled=tool.is_enabled,
         is_system=tool.is_system,
     )
@@ -1546,8 +1547,8 @@ async def test_builtin_tool(
 
     # 请求体内联参数优先，回退到 DB 存储值
     inline = payload or BuiltinToolTestRequest()
-    config = inline.config if inline.config is not None else (tool.config or {})
-    credentials = inline.credentials if inline.credentials is not None else (tool.credentials or {})
+    config = inline.config if inline.config is not None else ensure_dict(tool.config)
+    credentials = inline.credentials if inline.credentials is not None else ensure_dict(tool.credentials)
 
     if tool.tool_type == "search" and tool.name == "google_search":
         api_key = credentials.get("api_key", "")

--- a/apps/negentropy/src/negentropy/interface/tool_resolver.py
+++ b/apps/negentropy/src/negentropy/interface/tool_resolver.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
-from negentropy.models.builtin_tool import BuiltinTool
+from negentropy.models.builtin_tool import BuiltinTool, ensure_dict
 
 logger = get_logger("negentropy.interface.tool_resolver")
 
@@ -55,8 +55,8 @@ async def resolve_tool_config(tool_name: str) -> dict[str, Any] | None:
 
         # 合并 config 和 credentials
         merged: dict[str, Any] = {}
-        merged.update(tool.config or {})
-        merged["credentials"] = tool.credentials or {}
+        merged.update(ensure_dict(tool.config))
+        merged["credentials"] = ensure_dict(tool.credentials)
 
         # 更新缓存
         _cache[tool_name] = (merged, now + _CACHE_TTL_SECONDS)

--- a/apps/negentropy/src/negentropy/models/builtin_tool.py
+++ b/apps/negentropy/src/negentropy/models/builtin_tool.py
@@ -10,6 +10,7 @@
 - is_system 标识系统内置工具，API 层阻止删除
 """
 
+import json as _json
 from typing import Any
 
 from sqlalchemy import Boolean, Enum, Index, String, Text, UniqueConstraint
@@ -18,6 +19,25 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin
 from .plugin_common import PluginVisibility
+
+
+def ensure_dict(value: Any) -> dict[str, Any]:
+    """将 JSONB 列值安全转为 dict。
+
+    防御 migration 0031 中 json.dumps() + JSONB bindparam 双编码
+    导致读取时返回 str 而非 dict 的问题。
+    """
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = _json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except (ValueError, TypeError):
+            return {}
+    return {}
 
 
 class BuiltinTool(Base, UUIDMixin, TimestampMixin):

--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -9,7 +9,7 @@
 - sub_agent.py: 子智能体配置 (SubAgent)
 """
 
-from .builtin_tool import BuiltinTool  # noqa: F401
+from .builtin_tool import BuiltinTool, ensure_dict  # noqa: F401
 from .mcp import McpResourceTemplate, McpServer, McpTool  # noqa: F401
 from .mcp_runtime import McpToolRun, McpToolRunEvent, McpTrialAsset  # noqa: F401
 from .plugin_common import PluginPermission, PluginPermissionType, PluginVisibility  # noqa: F401


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`GET /interface/tools` 返回 500，页面显示 "Failed to fetch tools"
- 根因：migration 0031 使用 `json.dumps()` 预序列化 Python dict 后传入 `sa.bindparam(..., type_=JSONB)`，SQLAlchemy JSONB 处理器二次编码，导致数据库存储 JSON 字符串而非 JSON 对象。读取时 `tool.credentials` 返回 `str`，`_mask_credentials()` 调用 `.items()` 触发 `AttributeError`

# 核心变更
- 新增 `ensure_dict()` 防御性 helper（`models/builtin_tool.py`），安全处理 JSONB 列读取时 str/dict/None 类型不一致问题
- `api.py` 与 `tool_resolver.py` 所有 JSONB 列（config、credentials、config_schema）读取点均用 `ensure_dict()` 包裹
- 新增 migration 0038 幂等修复已存储的双编码数据（`WHERE jsonb_typeof(col) = 'string'` → `SET col = (col::text)::jsonb`）
- 修复 migration 0031 移除 `json.dumps()`，直接传递 Python dict 给 `bindparam`，避免全新部署复现

# 风险与回滚
- 主要风险：migration 0038 对 builtin_tools 表执行 UPDATE，但该表数据量极小（个位数行），且使用 `jsonb_typeof()` 条件过滤，幂等安全
- 回滚方式：revert 此 PR 即可；0038 downgrade 为 no-op，数据修复后无需逆向

# 验证证据
- 单元测试：ruff lint + ruff format pre-commit hooks 全部通过
- 集成测试：migration 0038 幂等性由 `WHERE jsonb_typeof(col) = 'string'` 条件保证，正确行不会被修改
- E2E/Workflow：需部署后浏览器验证 `/interface/tools` 页面正常加载

# 影响范围
- 前端：无代码变更，Tools 页面将恢复正常显示
- 后端：`api.py`（list/detail/test 工具端点）、`tool_resolver.py`（工具配置解析）、两个 migration 文件
- GitHub Actions / 文档：无

# Next Best Action
- 部署后执行 `SELECT name, jsonb_typeof(config), jsonb_typeof(credentials), jsonb_typeof(config_schema) FROM negentropy.builtin_tools;` 验证三列均返回 `object`
- 浏览器访问 `/interface/tools` 页面确认不再报 500