### PR TITLE
fix(scheduler): 修复 Dashboard Owner/Agent 维度统计标签显示 unknown 或原始 ID;

### DIFF
--- a/apps/negentropy/src/negentropy/interface/scheduler_api.py
+++ b/apps/negentropy/src/negentropy/interface/scheduler_api.py
@@ -30,9 +30,12 @@ from pydantic import BaseModel
 from sqlalchemy import and_, case, func, select, update
 from sqlalchemy.exc import SQLAlchemyError
 
+from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.scheduled_task import ScheduledTask, TaskExecution
+from negentropy.models.state import UserState
+from negentropy.models.sub_agent import SubAgent
 
 logger = get_logger("negentropy.interface.scheduler_api")
 
@@ -413,16 +416,56 @@ async def get_stats(
             )
             rows = (await db.execute(stmt)).all()
 
+            # --- Label resolution: owner / agent 维度需将 ID 映射为可读名称 ---
+            label_map: dict[str, str] = {}
+            none_label = "unknown"
+
+            if group_by == "owner":
+                owner_ids = [str(r.bucket_key) for r in rows if r.bucket_key is not None]
+                if owner_ids:
+                    user_rows = (
+                        await db.execute(
+                            select(UserState.user_id, UserState.state).where(
+                                UserState.user_id.in_(owner_ids),
+                                UserState.app_name == settings.app_name,
+                            )
+                        )
+                    ).all()
+                    for uid, state in user_rows:
+                        profile = (state or {}).get("profile", {})
+                        label_map[uid] = profile.get("name") or profile.get("email") or uid
+                none_label = "System"
+
+            elif group_by == "agent":
+                agent_ids = [r.bucket_key for r in rows if r.bucket_key is not None]
+                if agent_ids:
+                    agent_rows = (
+                        await db.execute(
+                            select(SubAgent.id, SubAgent.display_name, SubAgent.name).where(
+                                SubAgent.id.in_(agent_ids),
+                            )
+                        )
+                    ).all()
+                    for aid, dname, name in agent_rows:
+                        label_map[str(aid)] = dname or name or str(aid)
+                none_label = "Unassigned"
+
             buckets = []
             for r in rows:
-                bucket_key = str(r.bucket_key) if r.bucket_key is not None else "unknown"
+                raw_key = str(r.bucket_key) if r.bucket_key is not None else None
+                if raw_key is None:
+                    bucket_key = none_label
+                    label = none_label
+                else:
+                    bucket_key = raw_key
+                    label = label_map.get(raw_key, raw_key)
                 runs = int(r.runs or 0)
                 success = int(r.success or 0)
                 failed = int(r.failed or 0)
                 buckets.append(
                     {
                         "key": bucket_key,
-                        "label": bucket_key,
+                        "label": label,
                         "runs": runs,
                         "success": success,
                         "failed": failed,


### PR DESCRIPTION
# 背景
- Dashboard 首页「Owner × Runs」环形图全部显示 "unknown"，因为后端 `GET /scheduler/stats?group_by=owner` 对 NULL `owner_id` 统一标记为 "unknown"，非 NULL 的 `owner_id`（UUID）也未解析为可读名称。Agent 维度存在同样问题。

# 核心变更
- 在 `scheduler_api.py::get_stats()` 的 `_compute()` 中，SQL 聚合完成后根据 `group_by` 类型批量查询关联表解析 label：
  - **Owner 维度**：查询 `UserState` 表，按 `state.profile.name → email → raw_id` 回退链解析，NULL 归为 `"System"`
  - **Agent 维度**：查询 `SubAgent` 表，按 `display_name → name → raw_id` 回退链解析，NULL 归为 `"Unassigned"`
- `StatsBucket.key` 保持原始 ID 用于前端筛选契约，`label` 字段返回可读名称

# 风险与回滚
- 新增的查询复用已有 `AsyncSession`，仅在 owner/agent 维度触发，使用 `IN` 批量查询，性能影响可控
- 回滚方式：`git revert`

# 验证证据
- Ruff lint + format 全部通过
- 需浏览器实机确认 Dashboard 页面图表显示正确

# 影响范围
- 前端：无需改动（已使用 `b.label` 渲染）
- 后端：`scheduler_api.py` 新增 3 个 import + ~40 行 label 解析逻辑

# Next Best Action
- 浏览器实机验证 Dashboard Owner × Runs 图表是否正确显示用户名