### PR TITLE
fix(home-nav): 修复 Home 子页面面包屑标签统一显示 Workspace 而非 Studio/Dashboard

### DIFF
--- a/apps/negentropy-ui/app/(home)/layout.tsx
+++ b/apps/negentropy-ui/app/(home)/layout.tsx
@@ -21,7 +21,7 @@ export default function HomeLayout({ children }: { children: ReactNode }) {
           </div>
         }
       >
-        <HomeNav title="Workspace" />
+        <HomeNav />
       </Suspense>
       <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
     </div>

--- a/apps/negentropy-ui/components/ui/HomeNav.tsx
+++ b/apps/negentropy-ui/components/ui/HomeNav.tsx
@@ -19,18 +19,20 @@ const NAV_ITEMS = [
  *   反向（Dashboard → Studio）也不主动恢复 sessionId，避免历史串扰；
  *   Studio 内部仍由 useSearchParams 自然派生 ?sessionId=。
  */
-export function HomeNav({ title }: { title: string }) {
+export function HomeNav() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { setNavigationInfo } = useNavigation();
 
-  useEffect(() => {
-    setNavigationInfo({ moduleLabel: "Home", pageTitle: title });
-    return () => setNavigationInfo(null);
-  }, [title, setNavigationInfo]);
-
   const isActive = (href: string) =>
     href === "/studio" ? pathname.startsWith("/studio") : pathname.startsWith(href);
+
+  const activeLabel = NAV_ITEMS.find((item) => isActive(item.href))?.label ?? "Studio";
+
+  useEffect(() => {
+    setNavigationInfo({ moduleLabel: "Home", pageTitle: activeLabel });
+    return () => setNavigationInfo(null);
+  }, [activeLabel, setNavigationInfo]);
 
   // Studio Tab 保留 sessionId（用户在 Dashboard <-> Studio 切换时不丢失会话）
   const sessionId = searchParams?.get("sessionId");


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Home 路由组下 Studio 和 Dashboard 子页面的面包屑导航标签均硬编码显示为 "Home / Workspace"，无法区分当前所在页面。
- 关联上下文/Issue/文档：用户截图反馈

# 核心变更
- **`HomeNav` 组件**：移除外部传入的 `title` prop，改为根据当前路由路径（`usePathname()`）动态匹配 `NAV_ITEMS` 的 `label`，使面包屑正确显示 "Home / Studio" 或 "Home / Dashboard"
- **`layout.tsx`**：移除硬编码的 `title="Workspace"` prop 传递

# 风险与回滚
- 主要风险：低风险，仅影响 Home 路由组的面包屑文字显示，不涉及业务逻辑
- 回滚方式：`git revert` 该 commit

# 验证证据
- 单元测试：无（纯 UI 展示逻辑）
- 集成测试：无
- E2E/Workflow：需浏览器实机验证 `/studio` 和 `/dashboard` 面包屑标签正确切换
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`apps/negentropy-ui/components/ui/HomeNav.tsx`、`apps/negentropy-ui/app/(home)/layout.tsx`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证 `/studio` → 面包屑 "Home / Studio"，`/dashboard` → 面包屑 "Home / Dashboard"，切换时实时更新