### PR TITLE
fix(cli): 重命名 ctl.sh 为 cli.sh 并修复 start 命令多处问题

### DIFF
--- a/apps/negentropy-ui/playwright.config.ts
+++ b/apps/negentropy-ui/playwright.config.ts
@@ -53,7 +53,7 @@ const setupHeadless = AUTH_MODE === "dev-cookie";
 
 // chromium-devcookie：authed spec 专用 project，**不依赖 OAuth setup**，与上面的
 // authProjects 正交。spec 通过 utils/dev-cookie.ts 现签 ne_sso 并 addCookies 到上下文，
-// 直接 hit ctl.sh 启动的真实 backend + UI（默认 http://localhost:3192）。
+// 直接 hit cli.sh 启动的真实 backend + UI（默认 http://localhost:3192）。
 //
 // **CI 默认禁用**：authed spec 需要外部 backend + PostgreSQL；CI smoke job 仅启
 // Playwright webServer (pnpm build && pnpm start)，没有 backend，因此默认跳过。

--- a/apps/negentropy-ui/tests/e2e/skills/_authed-helpers.ts
+++ b/apps/negentropy-ui/tests/e2e/skills/_authed-helpers.ts
@@ -12,7 +12,7 @@
  * 设计：
  * - 不依赖 .auth/* storageState 文件，每次 fresh 签发，secret 漂移即时暴露；
  * - 复用现有 utils/dev-cookie.ts 的 HMAC-SHA256 签名实现；
- * - 默认 cookie 域 ``localhost``，与 ctl.sh 启动的 UI（http://localhost:3192）匹配。
+ * - 默认 cookie 域 ``localhost``，与 cli.sh 启动的 UI（http://localhost:3192）匹配。
  */
 import type { BrowserContext } from "@playwright/test";
 import { buildPlaywrightStorageState } from "../utils/dev-cookie";

--- a/docs/core/design/skills.md
+++ b/docs/core/design/skills.md
@@ -108,7 +108,7 @@ flowchart LR
   - `agents/tools/paper_hunter.py:fetch_papers(query, top_n, days_back, categories)`：arXiv API（≥3s 间隔，topN 上限 20）。
 - **9 个 authed E2E spec**：
   - `list/create/edit/delete/rbac/invoke/enforcement/resources/integration/paper-hunter.authed.spec.ts`，**全部连真实 backend + 真实 PostgreSQL**，通过 `applyDevCookie` 即时签 ne_sso 注入；
-  - 浏览器 baseURL 从 ctl.sh 启动的 UI（`http://localhost:3192`）取，跳过 webServer 重新构建；
+  - 浏览器 baseURL 从 cli.sh 启动的 UI（`http://localhost:3192`）取，跳过 webServer 重新构建；
   - 现有 17 个 mocked case 全部不退化，加上 27 个 authed case = **44 case 全绿**。
 - **浏览器实机回归**：通过 `mcp__chrome_devtools__` + dev cookie 注入完整走 「From Template → Install Paper Hunter → Preview Render」三步链路（截图存档 `.temp/skills-phase2-preview-real.png`）。
 

--- a/docs/core/user-guide/skills-advanced.md
+++ b/docs/core/user-guide/skills-advanced.md
@@ -136,7 +136,7 @@ LLM 解码 `<available_skills>` 后，调用工具完成端到端流程；最终
 
 当前 Phase 1 的触发是 **被动**（用户 prompt 进入）。如需「每天 9 点自动跑」：
 
-- 短期：用 ctl.sh / cron 定时调 `/api/v1/agents/...` 的会话端点（接口待定）；
+- 短期：用 cli.sh / cron 定时调 `/api/v1/agents/...` 的会话端点（接口待定）；
 - 长期：Phase 2 在 SubAgent 上加 `schedule` 字段 + 调度服务（PostgreSQL `pg_cron` 已可用）。
 
 ---

--- a/docs/core/user-guide/skills-troubleshooting.md
+++ b/docs/core/user-guide/skills-troubleshooting.md
@@ -18,7 +18,7 @@
    ```
    然后在 DevTools Console 中执行 `document.cookie = "ne_sso=" + TOKEN + "; path=/; SameSite=Lax";` 后刷新；
 3. **后端 `NE_AUTH_TOKEN_SECRET` 与 dev cookie 不一致**：核对 `apps/negentropy/.env.local` 与 `apps/negentropy-ui/.env.local` 中的值是否字节一致，且与 `~/.negentropy/config.yaml` 中 `auth.token_secret` 一致；
-4. **后端进程未重启**：UI 重启不会重新读取 backend secret；后端配置改动需 `./scripts/ctl.sh restart backend`。
+4. **后端进程未重启**：UI 重启不会重新读取 backend secret；后端配置改动需 `./scripts/cli.sh restart backend`。
 
 ## B. 403 Forbidden 在创建 / 删除 / 启停时
 

--- a/docs/knowledge/user-guide/papers-curation.md
+++ b/docs/knowledge/user-guide/papers-curation.md
@@ -46,7 +46,7 @@ sequenceDiagram
 ### 步骤 1：确保后端服务在跑
 
 ```bash
-./scripts/ctl.sh start backend ui
+./scripts/cli.sh start backend ui
 # 后端 :3185, 前端 :3192（默认）
 ```
 

--- a/docs/knowledge/user-guide/skills-paper-hunter.md
+++ b/docs/knowledge/user-guide/skills-paper-hunter.md
@@ -20,7 +20,7 @@ Skill 落库（required_tools=[fetch_papers, save_to_memory, update_knowledge_gr
 
 ```bash
 # 1) 启动服务（已启则跳过）
-./scripts/ctl.sh start backend ui
+./scripts/cli.sh start backend ui
 
 # 2) 三步自检：dev cookie + skills 端点
 TOKEN=$(NE_AUTH_TOKEN_SECRET=<hex> node apps/negentropy-ui/scripts/sign-dev-cookie.mjs --quiet)

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -122,6 +122,8 @@ start_service() {
   else
     log_error "${name} 健康检查失败，最近日志："
     tail -20 "$(log_file "$name")" 2>/dev/null
+    # 清理失败的孤儿进程与陈旧 PID 文件，避免 is_running 误判导致后续重试被静默跳过
+    stop_service "$name" >/dev/null 2>&1 || true
     return 1
   fi
 }

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# ctl.sh — Negentropy 全套服务控制脚本
-# Usage: ./scripts/ctl.sh <command> [options]
+# cli.sh — Negentropy 全套服务控制脚本
+# Usage: ./scripts/cli.sh <command> [options]
 # Commands: start | stop | restart | status | logs | build
 set -euo pipefail
 
@@ -23,7 +23,7 @@ log_info()  { echo "${BLUE}[$(_ts)]${RESET} $*"; }
 log_ok()    { echo "${GREEN}[$(_ts)]${RESET} $*"; }
 log_warn()  { echo "${YELLOW}[$(_ts)]${RESET} $*"; }
 log_error() { echo "${RED}[$(_ts)]${RESET} $*" >&2; }
-log_phase() { echo "\n${BOLD}${BLUE}[$(_ts)] ── $* ──${RESET}"; }
+log_phase() { printf '\n%s[%s] ── %s ──%s\n' "${BOLD}${BLUE}" "$(_ts)" "$*" "${RESET}"; }
 
 # ── 服务注册表 ───────────────────────────────────────────────────────────────────
 # 每个服务: name dir port start_cmd
@@ -59,7 +59,8 @@ svc_start_cmd() {
   esac
 }
 
-ALL_SERVICES=("$SVC_BACKEND" "$SVC_UI" "$SVC_WIKI" "$SVC_PERCEIVES")
+# 启动顺序遵循依赖链：perceives（MCP）→ backend（依赖 perceives）→ ui/wiki（依赖 backend）
+ALL_SERVICES=("$SVC_PERCEIVES" "$SVC_BACKEND" "$SVC_UI" "$SVC_WIKI")
 
 # ── 进程管理工具 ─────────────────────────────────────────────────────────────────
 run_dir_init() { mkdir -p "$RUN_DIR"; }
@@ -80,9 +81,12 @@ port_in_use() {
 }
 
 wait_for_health() {
+  # 端口绑定 = 服务存活：去掉 `-f` 让任意 HTTP 响应（含 404/405/406）都视为就绪，
+  # 兼容 FastMCP 等仅在 /mcp 子路径暴露端点、根路径 404 的服务；
+  # 进程级活性仍由 `is_running` 兜底，崩溃可立即检出。
   local name="$1" port="$2" attempts=60 i=1
   while (( i <= attempts )); do
-    if curl -sfLo /dev/null "http://localhost:${port}/" 2>/dev/null; then
+    if curl -sLo /dev/null "http://localhost:${port}/" 2>/dev/null; then
       return 0
     fi
     is_running "$name" || return 1
@@ -157,8 +161,11 @@ stop_service() {
 # ── 子命令: stop ─────────────────────────────────────────────────────────────────
 cmd_stop() {
   log_phase "停止所有服务"
-  for svc in "${ALL_SERVICES[@]}"; do
-    stop_service "$svc"
+  # 倒序停止：先停下游（ui/wiki），再停 backend，最后停 perceives，
+  # 避免下游在依赖被回收期间发起新请求。
+  local idx
+  for (( idx=${#ALL_SERVICES[@]}-1; idx>=0; idx-- )); do
+    stop_service "${ALL_SERVICES[idx]}"
   done
   log_ok "所有服务已停止"
 }
@@ -243,7 +250,9 @@ cmd_start() {
   # Phase 4 — 前端构建
   if ! $skip_build; then
     log_phase "Phase 4/5: 前端构建"
-    # 先启动 backend，使 wiki SSG 构建时可从 API 拉取数据
+    # 依赖链：perceives（MCP 前置）→ backend（wiki SSG 数据源）
+    # backend 在 MCP 工具调用链上依赖 perceives，必须先就绪。
+    start_service "$SVC_PERCEIVES" || log_warn "perceives 启动失败，backend 与 wiki SSG 可能降级"
     start_service "$SVC_BACKEND" || log_warn "backend 启动失败，wiki SSG 将退化为空"
     log_info "构建 ui + wiki (并行)..."
     (cd "$REPO_ROOT/apps/negentropy-ui" && pnpm build) &
@@ -276,7 +285,7 @@ cmd_start() {
   printf "  %-10s %s\n" "wiki"      "http://localhost:3092"
   printf "  %-10s %s\n" "perceives" "http://localhost:2992"
   echo ""
-  log_info "查看日志: ./scripts/ctl.sh logs [backend|ui|wiki|perceives]"
+  log_info "查看日志: ./scripts/cli.sh logs [backend|ui|wiki|perceives]"
 }
 
 # ── 子命令: restart ──────────────────────────────────────────────────────────────
@@ -318,7 +327,8 @@ cmd_logs() {
 cmd_build() {
   log_phase "仅构建（不启动）"
   run_dir_init
-  # 先启动 backend，使 wiki SSG 构建时可从 API 拉取数据
+  # 依赖链：perceives（MCP 前置）→ backend（wiki SSG 数据源）
+  start_service "$SVC_PERCEIVES" || log_warn "perceives 启动失败，backend 与 wiki SSG 可能降级"
   start_service "$SVC_BACKEND" || log_warn "backend 启动失败，wiki SSG 将退化为空"
   log_info "构建 ui + wiki (并行)..."
   (cd "$REPO_ROOT/apps/negentropy-ui" && pnpm build) &
@@ -326,8 +336,15 @@ cmd_build() {
   (cd "$REPO_ROOT/apps/negentropy-wiki" && pnpm build) &
   local pid_wiki=$!
   local _rc=0; wait "$pid_ui" || _rc=$?; wait "$pid_wiki" || _rc=$?
-  (( _rc )) && { log_error "前端构建失败"; stop_service "$SVC_BACKEND"; exit 1; }
+  # 倒序回收，先停 backend 再停 perceives
+  if (( _rc )); then
+    log_error "前端构建失败"
+    stop_service "$SVC_BACKEND"
+    stop_service "$SVC_PERCEIVES"
+    exit 1
+  fi
   stop_service "$SVC_BACKEND"
+  stop_service "$SVC_PERCEIVES"
   log_ok "前端构建完成"
 }
 
@@ -337,7 +354,7 @@ cmd_help() {
 ${BOLD}Negentropy 服务控制脚本${RESET}
 
 ${BOLD}用法:${RESET}
-  ./scripts/ctl.sh <command> [options]
+  ./scripts/cli.sh <command> [options]
 
 ${BOLD}命令:${RESET}
   start [--no-pull] [--skip-build]   全生命周期启动所有服务
@@ -352,9 +369,9 @@ ${BOLD}选项:${RESET}
   --skip-build   跳过前端构建
 
 ${BOLD}示例:${RESET}
-  ./scripts/ctl.sh start              # 完整启动
-  ./scripts/ctl.sh restart --no-pull  # 不拉代码，直接重启
-  ./scripts/ctl.sh logs backend       # 查看后端日志
+  ./scripts/cli.sh start              # 完整启动
+  ./scripts/cli.sh restart --no-pull  # 不拉代码，直接重启
+  ./scripts/cli.sh logs backend       # 查看后端日志
 EOF
 }
 


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：`scripts/ctl.sh start` 暴露多个问题 —— 阶段标题前打印字面量 `\n`、perceives 健康检查 404 误判失败导致全员连锁停服、perceives（MCP 前置依赖）启动顺序错置在最后。同时 `ctl.sh` 命名语义偏窄（control），改名为 `cli.sh` 与项目其他子工程命名规范对齐。
- 关联上下文/Issue/文档：见 `.context/attachments/.../pasted_text_2026-05-20_17-13-11.txt` 中复现日志。

# 核心变更

- **重命名**：`scripts/ctl.sh` → `scripts/cli.sh`（`git mv` 保留历史，相似度 86%），同步更新 7 处外部引用（5 个 docs + Playwright 配置 + e2e helper）与脚本内 Usage / 帮助文本。
- **日志格式**：`log_phase()` 改用 `printf` 替代 `echo`，规避 BSD `echo` 不解释转义导致的字面量 `\n` 输出。
- **依赖顺序**：`ALL_SERVICES` 调整为 `perceives → backend → ui → wiki`；Phase 4（前端构建）与 `cmd_build` 在 `backend` 之前先启动 `perceives`，保证 wiki SSG 与 MCP 工具链可用。
- **健康检查**：`wait_for_health` 去掉 `curl -f` 标志 —— 4xx 响应（如 FastMCP `/mcp` 子路径暴露下根路径返回 404）也视为"端口已绑定、框架已起来"，进程级活性仍由现有 `is_running` 兜底。
- **优雅停止**：`cmd_stop` 改倒序遍历（ui → wiki → backend → perceives），避免下游在依赖被回收期间发起新请求。

# 风险与回滚

- 主要风险：（1）外部脚本 / CI / 文档若仍引用旧的 `scripts/ctl.sh` 路径会失效（已全仓 grep 确认 0 命中）；（2）`curl -f` 去除后，若某服务真的彻底宕机但有反向代理在前回 502/503，仍会判定为"存活"，但循环内 `is_running "$name"` 进程级兜底可立即检出。
- 回滚方式：`git revert <commit>` 即可恢复到 `ctl.sh` 与原 `wait_for_health` 行为。

# 验证证据

- 单元测试：N/A（脚本级改动）。
- 集成测试：`bash -n scripts/cli.sh` 静态校验通过；构造 404 HTTP server 对比 `curl -sfLo`（rc=22）与 `curl -sLo`（rc=0），确认健康检查修复行为。
- E2E/Workflow：`printf` vs `echo` 字节级对比（`od -c`）确认旧版输出字面量 `\` + `n`、新版输出真正的 LF。完整 `./scripts/cli.sh start` 实机验证待用户在主环境跑（涉及 PostgreSQL/pull/前端构建/4 服务编排）。
- 覆盖率/关键截图：见 commit `5a5db6ef` 的 diff stat。

# 影响范围

- 前端：仅 `apps/negentropy-ui/playwright.config.ts` 与 `tests/e2e/skills/_authed-helpers.ts` 注释引用更新，零运行时行为变化。
- 后端：无 Python/服务代码改动。
- GitHub Actions / 文档：5 个用户手册引用更新；未涉及任何 workflow 文件。

# Next Best Action

- 在主环境执行 `./scripts/cli.sh stop && ./scripts/cli.sh start`，确认 4 个服务全部 RUNNING 且不再自动停止；如有 CI 流水线显式调用 `ctl.sh`，同步迁移到 `cli.sh`。