### PR TITLE
refactor(observability): 统一 Langfuse 模型上报口径为 vendor/model

### DIFF
--- a/apps/negentropy/src/negentropy/instrumentation.py
+++ b/apps/negentropy/src/negentropy/instrumentation.py
@@ -12,19 +12,25 @@ from opentelemetry import trace
 
 from negentropy.config.pricing import get_effective_model_pricing_usd, get_last_online_catalog_error
 from negentropy.logging import get_logger
-from negentropy.model_names import extract_vendor, observability_model_name
+from negentropy.model_names import extract_vendor, observability_model_name, pricing_lookup_model_name
 
 
-def _normalize_model_name(model: str | None) -> str | None:
-    """规范化模型名用于 Langfuse 上报（裸名 + 剥日期 + 别名）。
+def _normalize_model_name(model: str | None, *, vendor_hint: str | None = None) -> str | None:
+    """规范化模型名用于 Langfuse 上报（``vendor/model`` 全名 + 剥日期 + 别名）。
 
     与调度路径的 ``canonicalize_model_name`` 正交：调度需要保留 ``vendor/``
-    前缀以驱动 LiteLLM 选择真实 API；观测需要裸名以让 Langfuse 把同一模型
-    聚合到单一 cost 行。两套口径分别落在 ``model_names`` 模块。
+    前缀以驱动 LiteLLM 选择真实 API；观测同样以 ``vendor/model`` 形态上报，让
+    Langfuse Model Costs 视图把同一模型聚合到单一 cost 行（避免裸名 vs 带前缀
+    被拆成多行）。两套口径都落在 ``model_names`` 模块，但语义独立维护。
+
+    ``vendor_hint`` 用于跨字段一致性：当 response.model 是裸名（如 Gemini Embedding
+    的 ``text-embedding-004``）时，请求侧的 ``gemini/`` 前缀作为权威来源透传给
+    ``observability_model_name``，避免 ``_VENDOR_FAMILY_PREFIXES`` 误把它识别成
+    OpenAI 模型。
     """
     if model is None:
         return None
-    normalized = observability_model_name(model)
+    normalized = observability_model_name(model, vendor_hint=vendor_hint)
     return normalized if normalized else model
 
 
@@ -51,32 +57,38 @@ def _extract_response_model(response_obj: Any) -> str | None:
 
 
 def _apply_model_normalization(span: Any, kwargs: dict, response_obj: Any) -> None:
-    """归一化模型名 + 注入 cost，确保 Langfuse 聚合到单一裸名行。
+    """归一化模型名 + 注入 cost，确保 Langfuse 聚合到单一 ``vendor/model`` 行。
 
     唯一写入 ``gen_ai.request.model``、``gen_ai.response.model`` 和
     ``langfuse.observation.model.name`` 的入口。``_inject_genai_semconv_attrs``
     不再写入 model 相关属性。
+
+    跨字段 vendor 一致性：request 与 response 共用同一 ``vendor_hint``，避免
+    ``gemini/text-embedding-004`` request 与 ``text-embedding-004`` response 被
+    家族前缀表分别识别成 ``gemini`` 与 ``openai``，造成 Langfuse 拆两行。
     """
     model = kwargs.get("model")
-    normalized_model = _normalize_model_name(model) if model else None
     response_model = _extract_response_model(response_obj)
-    normalized_response_model = _normalize_model_name(response_model) if response_model else None
+
+    # vendor 单一事实源：原串前缀优先（LiteLLM 调度必带 ``vendor/``），其次响应裸名系族识别。
+    system = extract_vendor(model) or extract_vendor(response_model)
+
+    normalized_model = _normalize_model_name(model, vendor_hint=system) if model else None
+    normalized_response_model = _normalize_model_name(response_model, vendor_hint=system) if response_model else None
 
     if not _is_writable_span(span):
         return
 
-    # 覆盖 LiteLLM 原始写入的 request/response model（归一化裸名）
+    # 覆盖 LiteLLM 原始写入的 request/response model（归一化为 ``vendor/model`` 全名）
     if normalized_model:
         _safe_set_span_attribute(span, "gen_ai.request.model", normalized_model)
     if normalized_response_model:
         _safe_set_span_attribute(span, "gen_ai.response.model", normalized_response_model)
 
-    # vendor 单一事实源：原串前缀优先，否则裸名系族识别。
-    system = extract_vendor(model) or extract_vendor(response_model)
     if system:
         _safe_set_span_attribute(span, "gen_ai.system", system)
 
-    # Langfuse 私有强制覆盖键：最高优先级，确保 Model Costs 视图收敛到同一裸名行。
+    # Langfuse 私有强制覆盖键：最高优先级，确保 Model Costs 视图收敛到同一 ``vendor/model`` 行。
     langfuse_model = normalized_response_model or normalized_model
     if langfuse_model:
         _safe_set_span_attribute(span, "langfuse.observation.model.name", langfuse_model)
@@ -245,7 +257,8 @@ class LiteLLMLoggingCallback:
         """Log successful LLM interaction."""
         self._ensure_tracing()
         try:
-            model = _normalize_model_name(kwargs.get("model", "unknown"))
+            raw_model = kwargs.get("model", "unknown")
+            model = _normalize_model_name(raw_model, vendor_hint=extract_vendor(raw_model))
             input_tokens = 0
             output_tokens = 0
 
@@ -300,7 +313,8 @@ class LiteLLMLoggingCallback:
     def log_failure_event(self, kwargs: dict, response_obj: Any, start_time: Any, end_time: Any) -> None:
         """Log failed LLM interaction."""
         try:
-            model = _normalize_model_name(kwargs.get("model", "unknown"))
+            raw_model = kwargs.get("model", "unknown")
+            model = _normalize_model_name(raw_model, vendor_hint=extract_vendor(raw_model))
             exception = kwargs.get("exception", "unknown error")
 
             latency_ms = (end_time - start_time).total_seconds() * 1000
@@ -329,8 +343,12 @@ def _resolve_total_cost(kwargs: dict, response_obj: Any) -> tuple[float | None, 
     3. LiteLLM's completion_cost function
     4. LiteLLM 官方在线价目表
     5. 本地 override 配置
+
+    使用 ``pricing_lookup_model_name`` 而非 ``_normalize_model_name``：定价路径需要
+    裸名作为 LiteLLM catalog 查表键（``observability_model_name`` 在 2026-05-21 反转
+    口径后输出 ``vendor/model`` 全名，与定价查表语义已不再耦合）。
     """
-    model = _normalize_model_name(kwargs.get("model"))
+    model = pricing_lookup_model_name(kwargs.get("model"))
     cost = kwargs.get("response_cost")
     if cost is None:
         standard_logging = kwargs.get("standard_logging_object")

--- a/apps/negentropy/src/negentropy/model_names.py
+++ b/apps/negentropy/src/negentropy/model_names.py
@@ -4,29 +4,40 @@ LLM 模型名规范化工具。
 提供全局唯一的模型名规范化与查表键转换逻辑，避免观测、日志、
 持久化和定价等链路各自维护不同的命名规则。
 
-# 正交分解：调度路径 vs 观测路径
+# 正交分解：调度路径 vs 观测路径 vs 定价路径
 
-调度链路（LiteLLM `acompletion` / `aembedding`、`build_full_model_name`、定价查表）
+调度链路（LiteLLM `acompletion` / `aembedding`、`build_full_model_name`）
 **必须保留 `vendor/model_name` 前缀**——LiteLLM 依赖它选择真实 API（`openai/`、
 `gemini/` 等），所以本模块对调度链路只做轻量幂等处理：
 
 - ``canonicalize_model_name()`` —— 仅 ``strip()``，保留 vendor 前缀；
+
+定价链路（LiteLLM 在线/本地价目表查表）需要**裸名**作为查表键：
+
 - ``pricing_lookup_model_name()`` —— 在 canonicalize 之后剥前缀拿裸名查定价表。
 
-观测链路（OTel span 上报到 Langfuse）则**需要裸名**——Langfuse Model Costs 视图按
-模型字段聚合，若同一模型以 ``openai/gpt-5-mini`` / ``gpt-5-mini`` /
-``gpt-5-mini-2025-08-07`` 三种写法上报会被拆成三行统计，违反 Single Source of Truth。
-观测路径专用：
+观测链路（OTel span 上报到 Langfuse）需要**带 vendor 前缀的全名**——Langfuse
+Model Costs 视图按模型字段聚合，若同一模型以 ``openai/gpt-5-mini`` /
+``gpt-5-mini`` / ``gpt-5-mini-2025-08-07`` 三种写法上报会被拆成三行统计，
+违反 Single Source of Truth。观测路径专用：
 
-- ``observability_model_name()`` —— 剥 vendor 前缀 + 剥日期/版本后缀 + 别名映射，幂等；
+- ``observability_model_name()`` —— 补齐/保留 vendor 前缀 + 剥日期/版本后缀 +
+  别名映射，幂等；
 - ``extract_vendor()`` —— 从原串或裸名识别供应商，写到 OTel ``gen_ai.system``。
 
 **仅 ``negentropy.instrumentation`` 应当调用观测路径函数**。其它代码路径继续走
 ``canonicalize_model_name()`` / ``pricing_lookup_model_name()``。
 
-历史上 GLM 系列曾在此被强制规范为 `zai/<model>`；该专属链路已随
-ZAI/LiteLLM 整合下线。上游调用点（观测、定价、日志）保持接口不变以
-维持正交性，若未来需要引入新的供应商规范化规则，可在此处扩展。
+# 历史决策记录
+
+- 2026 初期：曾在 GLM 系列上做 `zai/<model>` 强制规范化；ZAI/LiteLLM 整合后下线。
+- 2026-05：观测路径口径**首次设计为「裸名」**（剥 vendor 前缀），目的是把
+  ``openai/gpt-5-mini`` 与裸名 ``gpt-5-mini`` 聚合到同一行。
+- 2026-05-21：**反转**为「vendor/model」全名。原因：LiteLLM 原生 OTel callback
+  在我们的 monkey-patch 之前会先写 ``gen_ai.request.model = "openai/gpt-5-mini"``
+  到 span，而 Langfuse 的 Model Costs 视图仍把带前缀的串与裸名拆成不同行。
+  与其在多入口竞速覆盖裸名，不如**承认 vendor/model 才是 LiteLLM 调度路径
+  唯一权威形态**，把所有上报收敛到这个形态，并显式补齐裸名调用方。
 """
 
 from __future__ import annotations
@@ -68,9 +79,9 @@ def pricing_lookup_model_name(model_name: str | None) -> str | None:
 # 观测链路：仅供 negentropy.instrumentation 使用
 # ---------------------------------------------------------------------------
 
-# LiteLLM 风格的 vendor 前缀白名单（小写匹配）。命中后剥外层一次。
+# LiteLLM 风格的 vendor 前缀白名单（小写匹配）。命中后保留作为权威 vendor。
 # 双层前缀场景（如 `bedrock/anthropic.claude-3-5-sonnet`）只剥 `bedrock/`，剩余
-# `anthropic.claude-3-5-sonnet` 与 LiteLLM catalog 裸名格式一致，便于定价查表对齐。
+# `anthropic.claude-3-5-sonnet` 作为 bare model；最终输出仍以 `bedrock/` 拼回。
 _VENDOR_PREFIXES: tuple[str, ...] = (
     "openai/",
     "anthropic/",
@@ -98,6 +109,8 @@ _DATE_SUFFIX_REGEXES: tuple[re.Pattern[str], ...] = (
 
 # 显式别名映射（`alias → canonical`）。起步只放最确定的一两条；新增映射
 # **必须**同步补 `tests/unit_tests/config/test_model_names.py` 单测。
+# 注意：别名作用于「裸名」阶段（剥前缀剥日期之后、拼回 vendor 之前），所以
+# 别名键也应当是裸名形态。
 _MODEL_ALIASES: dict[str, str] = {
     # 空起步：保持最小风险面；后续如发现明确同模型不同名再加。
 }
@@ -110,7 +123,7 @@ _VENDOR_FAMILY_PREFIXES: tuple[tuple[str, str], ...] = (
     ("o1-", "openai"),
     ("o3-", "openai"),
     ("o4-", "openai"),
-    ("text-embedding-", "openai"),  # OpenAI text-embedding-3-*；Gemini 同名必须走前缀
+    ("text-embedding-", "openai"),  # OpenAI text-embedding-3-*；Gemini 同名必须走前缀或 vendor_hint
     ("claude-", "anthropic"),
     ("gemini-", "gemini"),
     ("llama-", "meta"),
@@ -122,13 +135,27 @@ _VENDOR_FAMILY_PREFIXES: tuple[tuple[str, str], ...] = (
 )
 
 
-def _strip_vendor_prefix(name: str) -> str:
-    """剥外层 vendor 前缀（仅一次），大小写不敏感。未命中则返回原串。"""
+def _split_vendor_and_bare(name: str) -> tuple[str | None, str]:
+    """把 `vendor/bare` 形态拆成 ``(vendor_lowercased, bare)``；未命中返回 ``(None, name)``。
+
+    仅识别 ``_VENDOR_PREFIXES`` 白名单，避免把模型名里偶发的 ``/`` 误判为 vendor 分隔符。
+    大小写不敏感；返回的 vendor 一律 lowercase，便于在 Langfuse 聚合时收敛到同一聚合键。
+    """
     lowered = name.lower()
     for prefix in _VENDOR_PREFIXES:
         if lowered.startswith(prefix):
-            return name[len(prefix) :]
-    return name
+            return prefix.rstrip("/"), name[len(prefix) :]
+    return None, name
+
+
+def _strip_vendor_prefix(name: str) -> str:
+    """剥外层 vendor 前缀（仅一次），大小写不敏感。未命中则返回原串。
+
+    保留供 ``pricing_lookup_model_name`` 之外的潜在调用方；新代码优先使用
+    ``_split_vendor_and_bare`` 拿到 vendor + bare 一次完成。
+    """
+    _, bare = _split_vendor_and_bare(name)
+    return bare
 
 
 def _strip_date_suffix(name: str) -> str:
@@ -139,17 +166,33 @@ def _strip_date_suffix(name: str) -> str:
     return name
 
 
-def observability_model_name(model_name: str | None) -> str | None:
-    """返回**仅供观测上报**的裸模型名（剥 vendor 前缀 + 剥日期后缀 + 别名映射）。
+def observability_model_name(model_name: str | None, *, vendor_hint: str | None = None) -> str | None:
+    """返回**仅供观测上报**的全名（``vendor/model`` 形态，剥日期 + 别名 + 幂等）。
 
-    四步幂等管线：
+    五步幂等管线：
+
     1. ``strip()`` 空白；空 / None 透传。
-    2. 剥 ``vendor/`` 前缀（最外层一次，大小写不敏感）。
-    3. 剥日期/版本后缀（白名单正则，避免误伤 ``gpt-4o-mini``）。
-    4. 显式别名映射兜底。
+    2. 拆分 vendor 与裸名：若原串带 ``_VENDOR_PREFIXES`` 中的显式前缀，取该前缀（lowercase）
+       作为权威 vendor；否则 vendor 落空，bare 为整串。
+    3. 剥日期/版本后缀（白名单正则，避免误伤 ``gpt-4o-mini`` / ``text-embedding-3-large``）。
+       作用于 bare。
+    4. 别名映射兜底（``_MODEL_ALIASES``，作用于 bare）。
+    5. 决定最终 vendor 并组合输出：
+       - 显式前缀命中 → 用之；
+       - 否则使用 ``vendor_hint`` 兜底（调用方通过该参数注入 request 侧权威 vendor，
+         消除 ``gemini/text-embedding-004`` request 与 ``text-embedding-004`` response
+         在家族前缀表中被识别成不同 vendor 的歧义）；
+       - 都落空再用 ``extract_vendor(bare)`` 兜底；
+       - 最终 vendor 仍为 None 时返回裸名（保持「未知模型保持原样」契约）。
 
-    幂等保证：步骤 2 之后无 ``/``、步骤 3 之后无匹配尾、步骤 4 字典查表 fixpoint，
-    重复调用结果不变。**禁止**在 LiteLLM 调度路径使用本函数（会破坏供应商路由）。
+    幂等保证：
+    - 步骤 2 之后若再调用一次，新输入已是 ``vendor/bare`` 形态，会再次拆出同一 vendor；
+    - 步骤 3 的正则锚到 ``$``，剥完不再匹配；
+    - 步骤 4 字典查表 fixpoint；
+    - 步骤 5 组合输出后再次进入本函数，会被步骤 2 识别为 ``vendor/bare`` 形态并取同一 vendor。
+
+    **禁止**在 LiteLLM 调度路径使用本函数（语义虽然兼容，但调度路径应走
+    ``canonicalize_model_name`` 表达「不修改」的契约）。
     """
     if not model_name:
         return model_name
@@ -158,10 +201,17 @@ def observability_model_name(model_name: str | None) -> str | None:
     if not normalized:
         return model_name
 
-    normalized = _strip_vendor_prefix(normalized)
-    normalized = _strip_date_suffix(normalized)
-    normalized = _MODEL_ALIASES.get(normalized, normalized)
-    return normalized
+    explicit_vendor, bare = _split_vendor_and_bare(normalized)
+    bare = _strip_date_suffix(bare)
+    bare = _MODEL_ALIASES.get(bare, bare)
+
+    vendor = explicit_vendor or (vendor_hint.strip().lower() if vendor_hint else None)
+    if not vendor:
+        vendor = extract_vendor(bare)
+
+    if vendor:
+        return f"{vendor}/{bare}"
+    return bare
 
 
 def extract_vendor(model_name: str | None) -> str | None:
@@ -179,17 +229,15 @@ def extract_vendor(model_name: str | None) -> str | None:
     if not normalized:
         return None
 
-    lowered = normalized.lower()
-
     # 1. 显式 vendor/ 前缀
-    for prefix in _VENDOR_PREFIXES:
-        if lowered.startswith(prefix):
-            return prefix.rstrip("/")
+    explicit_vendor, _ = _split_vendor_and_bare(normalized)
+    if explicit_vendor:
+        return explicit_vendor
 
     # 2. 系族前缀回退（用裸名形式判断，避免一次错误 strip 影响后续）
-    bare = _strip_vendor_prefix(normalized).lower()
+    bare_lower = normalized.lower()
     for family_prefix, vendor in _VENDOR_FAMILY_PREFIXES:
-        if bare.startswith(family_prefix):
+        if bare_lower.startswith(family_prefix):
             return vendor
 
     return None

--- a/apps/negentropy/tests/unit_tests/config/test_model_names.py
+++ b/apps/negentropy/tests/unit_tests/config/test_model_names.py
@@ -67,49 +67,87 @@ def test_observability_model_name_handles_empty_input():
     assert observability_model_name("   ") == "   "
 
 
-def test_observability_model_name_strips_vendor_prefix():
-    assert observability_model_name("openai/gpt-5-mini") == "gpt-5-mini"
-    assert observability_model_name("anthropic/claude-3-5-sonnet") == "claude-3-5-sonnet"
-    assert observability_model_name("gemini/text-embedding-004") == "text-embedding-004"
-    assert observability_model_name("vertex_ai/gemini-1.5-pro") == "gemini-1.5-pro"
-    assert observability_model_name("deepseek/deepseek-chat") == "deepseek-chat"
-    assert observability_model_name("ollama/llama-3-8b") == "llama-3-8b"
+def test_observability_model_name_preserves_vendor_prefix():
+    # 已带显式 vendor 前缀：保持不变（这是 Langfuse 聚合的目标形态）。
+    assert observability_model_name("openai/gpt-5-mini") == "openai/gpt-5-mini"
+    assert observability_model_name("anthropic/claude-3-5-sonnet") == "anthropic/claude-3-5-sonnet"
+    assert observability_model_name("gemini/text-embedding-004") == "gemini/text-embedding-004"
+    assert observability_model_name("vertex_ai/gemini-1.5-pro") == "vertex_ai/gemini-1.5-pro"
+    assert observability_model_name("deepseek/deepseek-chat") == "deepseek/deepseek-chat"
+    assert observability_model_name("ollama/llama-3-8b") == "ollama/llama-3-8b"
 
 
-def test_observability_model_name_vendor_prefix_case_insensitive():
-    # 大小写不敏感（实际 LiteLLM 内部统一小写，但保险起见兼容）。
-    assert observability_model_name("Azure/gpt-4") == "gpt-4"
-    assert observability_model_name("OpenAI/gpt-5-mini") == "gpt-5-mini"
+def test_observability_model_name_adds_vendor_prefix_to_bare_name():
+    # 裸名通过家族前缀识别 vendor 并补齐前缀，让 Langfuse 与带前缀的调用收敛到同一聚合键。
+    assert observability_model_name("gpt-5-mini") == "openai/gpt-5-mini"
+    assert observability_model_name("gpt-5-nano") == "openai/gpt-5-nano"
+    assert observability_model_name("gpt-4o-mini") == "openai/gpt-4o-mini"
+    assert observability_model_name("claude-3-5-sonnet") == "anthropic/claude-3-5-sonnet"
+    assert observability_model_name("gemini-1.5-pro") == "gemini/gemini-1.5-pro"
+    assert observability_model_name("llama-3-8b") == "meta/llama-3-8b"
+    assert observability_model_name("deepseek-chat") == "deepseek/deepseek-chat"
+
+
+def test_observability_model_name_vendor_prefix_lowercased():
+    # 显式前缀大小写不敏感识别，输出统一小写以收敛聚合键。
+    assert observability_model_name("Azure/gpt-4") == "azure/gpt-4"
+    assert observability_model_name("OpenAI/gpt-5-mini") == "openai/gpt-5-mini"
 
 
 def test_observability_model_name_strips_date_suffix():
-    # OpenAI 风格：YYYY-MM-DD 后缀
-    assert observability_model_name("gpt-5-mini-2025-08-07") == "gpt-5-mini"
-    assert observability_model_name("gpt-4o-2024-08-06") == "gpt-4o"
+    # OpenAI 风格：YYYY-MM-DD 后缀；裸名经家族前缀识别为 openai 补齐前缀。
+    assert observability_model_name("gpt-5-mini-2025-08-07") == "openai/gpt-5-mini"
+    assert observability_model_name("gpt-4o-2024-08-06") == "openai/gpt-4o"
     # Anthropic 风格：YYYYMMDD 后缀
-    assert observability_model_name("claude-3-5-sonnet-20241022") == "claude-3-5-sonnet"
-    assert observability_model_name("claude-3-opus-20240229") == "claude-3-opus"
+    assert observability_model_name("claude-3-5-sonnet-20241022") == "anthropic/claude-3-5-sonnet"
+    assert observability_model_name("claude-3-opus-20240229") == "anthropic/claude-3-opus"
 
 
 def test_observability_model_name_combines_prefix_and_date_strip():
     # 前缀 + 日期联动：response.model 经常是 vendor 拼接 + 服务端版本号。
-    assert observability_model_name("openai/gpt-5-mini-2025-08-07") == "gpt-5-mini"
-    assert observability_model_name("anthropic/claude-3-5-sonnet-20241022") == "claude-3-5-sonnet"
+    assert observability_model_name("openai/gpt-5-mini-2025-08-07") == "openai/gpt-5-mini"
+    assert observability_model_name("anthropic/claude-3-5-sonnet-20241022") == "anthropic/claude-3-5-sonnet"
 
 
 def test_observability_model_name_does_not_strip_non_date_digits():
-    # 不误伤本身带数字的模型名（关键不变量）。
-    assert observability_model_name("gpt-4o-mini") == "gpt-4o-mini"
-    assert observability_model_name("text-embedding-3-large") == "text-embedding-3-large"
-    assert observability_model_name("o1-preview") == "o1-preview"
-    assert observability_model_name("claude-3-5-sonnet") == "claude-3-5-sonnet"
+    # 不误伤本身带数字的模型名（关键不变量），同时仍补齐 vendor 前缀。
+    assert observability_model_name("gpt-4o-mini") == "openai/gpt-4o-mini"
+    assert observability_model_name("text-embedding-3-large") == "openai/text-embedding-3-large"
+    assert observability_model_name("o1-preview") == "openai/o1-preview"
+    assert observability_model_name("claude-3-5-sonnet") == "anthropic/claude-3-5-sonnet"
     # 三/四位数字尾默认不剥（如 Gemini 1.5 Pro 002，未来如确需可加 alias map）。
-    assert observability_model_name("gemini-1.5-pro-002") == "gemini-1.5-pro-002"
+    assert observability_model_name("gemini-1.5-pro-002") == "gemini/gemini-1.5-pro-002"
 
 
-def test_observability_model_name_bedrock_double_prefix_strips_outer_only():
-    # 双层前缀只剥外层；剩余 `anthropic.claude-3-5-sonnet` 与 LiteLLM catalog 对齐。
-    assert observability_model_name("bedrock/anthropic.claude-3-5-sonnet") == "anthropic.claude-3-5-sonnet"
+def test_observability_model_name_bedrock_double_prefix_keeps_outer_vendor():
+    # 双层前缀：外层 ``bedrock/`` 作为权威 vendor 保留，内层供应商记号留在 bare 中。
+    assert observability_model_name("bedrock/anthropic.claude-3-5-sonnet") == "bedrock/anthropic.claude-3-5-sonnet"
+
+
+def test_observability_model_name_unknown_model_stays_bare():
+    # vendor 既无显式前缀也无法系族识别 → 返回裸名（避免污染 Langfuse 聚合键）。
+    assert observability_model_name("some-unknown-model") == "some-unknown-model"
+
+
+def test_observability_model_name_vendor_hint_bridges_bare_response():
+    # 跨字段一致性：request ``gemini/text-embedding-004`` 提供 ``gemini`` hint，
+    # response ``text-embedding-004`` 借此补 ``gemini/`` 而非家族前缀的 ``openai/``。
+    assert observability_model_name("text-embedding-004", vendor_hint="gemini") == "gemini/text-embedding-004"
+    # hint 同样应用于已带其它无关字符串的输入，hint 大小写规范化为小写。
+    assert observability_model_name("text-embedding-004", vendor_hint="GEMINI") == "gemini/text-embedding-004"
+
+
+def test_observability_model_name_explicit_prefix_overrides_vendor_hint():
+    # 显式前缀比 hint 权威：若原串本身带 ``anthropic/``，传 ``openai`` hint 也不应改写。
+    assert (
+        observability_model_name("anthropic/claude-3-5-sonnet", vendor_hint="openai") == "anthropic/claude-3-5-sonnet"
+    )
+
+
+def test_observability_model_name_vendor_hint_empty_or_blank_ignored():
+    # 空字符串 / 全空白 hint 视为未提供，回退到家族前缀识别。
+    assert observability_model_name("gpt-5-mini", vendor_hint="") == "openai/gpt-5-mini"
+    assert observability_model_name("gpt-5-mini", vendor_hint="   ") == "openai/gpt-5-mini"
 
 
 def test_observability_model_name_is_idempotent():
@@ -122,6 +160,7 @@ def test_observability_model_name_is_idempotent():
         "gpt-4o-mini",
         "text-embedding-3-large",
         "bedrock/anthropic.claude-3-5-sonnet",
+        "some-unknown-model",
     ]
     for sample in samples:
         first = observability_model_name(sample)
@@ -130,7 +169,7 @@ def test_observability_model_name_is_idempotent():
 
 
 def test_observability_model_name_strips_whitespace_first():
-    assert observability_model_name("  openai/gpt-5-mini-2025-08-07  ") == "gpt-5-mini"
+    assert observability_model_name("  openai/gpt-5-mini-2025-08-07  ") == "openai/gpt-5-mini"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_genai_semconv.py
@@ -125,8 +125,8 @@ def test_inject_genai_full_attributes_for_anthropic_chat() -> None:
     captured = span._captured
     assert captured["gen_ai.system"] == "anthropic"
     assert captured["gen_ai.operation.name"] == "chat"
-    assert captured["gen_ai.request.model"] == "claude-opus-4-7"
-    assert captured["gen_ai.response.model"] == "claude-opus-4-7"
+    assert captured["gen_ai.request.model"] == "anthropic/claude-opus-4-7"
+    assert captured["gen_ai.response.model"] == "anthropic/claude-opus-4-7"
     assert captured["gen_ai.request.temperature"] == 0.7
     assert captured["gen_ai.request.top_p"] == 0.95
     assert captured["gen_ai.request.max_tokens"] == 4096

--- a/apps/negentropy/tests/unit_tests/observability/test_instrumentation.py
+++ b/apps/negentropy/tests/unit_tests/observability/test_instrumentation.py
@@ -82,12 +82,12 @@ def test_patch_litellm_otel_cost_injects_cost_attributes(monkeypatch):
 
     OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
 
-    # 归一化后裸名上报，让 Langfuse Model Costs 视图聚合。
-    assert span.attributes["gen_ai.request.model"] == "gpt-5-mini"
-    assert span.attributes["gen_ai.response.model"] == "gpt-5-mini"
+    # 归一化为 vendor/model 全名上报，让 Langfuse Model Costs 视图收敛到单一聚合键。
+    assert span.attributes["gen_ai.request.model"] == "openai/gpt-5-mini"
+    assert span.attributes["gen_ai.response.model"] == "openai/gpt-5-mini"
     assert span.attributes["gen_ai.system"] == "openai"
     # Langfuse 私有强制覆盖键。
-    assert span.attributes["langfuse.observation.model.name"] == "gpt-5-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "openai/gpt-5-mini"
     # 诊断字段保留原始字符串（用于 trace 详情排查）。
     assert span.attributes["gen_ai.original_model"] == "openai/gpt-5-mini"
     # request == response 时不重复写 original_response_model，避免冗余。
@@ -112,11 +112,11 @@ def test_patch_normalizes_dated_response_model(monkeypatch):
 
     OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
 
-    assert span.attributes["gen_ai.request.model"] == "gpt-5-mini"
-    assert span.attributes["gen_ai.response.model"] == "gpt-5-mini"
+    assert span.attributes["gen_ai.request.model"] == "openai/gpt-5-mini"
+    assert span.attributes["gen_ai.response.model"] == "openai/gpt-5-mini"
     assert span.attributes["gen_ai.system"] == "openai"
     # response.model 优先用作 Langfuse 强制覆盖键（更接近实际计费模型）。
-    assert span.attributes["langfuse.observation.model.name"] == "gpt-5-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "openai/gpt-5-mini"
     assert span.attributes["gen_ai.original_model"] == "openai/gpt-5-mini"
     # response.model 含具体版本日期，归一化丢失的信息单独保留到 original_response_model。
     assert span.attributes["gen_ai.original_response_model"] == "gpt-5-mini-2025-08-07"
@@ -139,11 +139,11 @@ def test_patch_emits_vendor_for_bare_model(monkeypatch):
 
     OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
 
-    assert span.attributes["gen_ai.request.model"] == "gpt-4o-mini"
-    # 日期后缀剥离后归一为 gpt-4o-mini。
-    assert span.attributes["gen_ai.response.model"] == "gpt-4o-mini"
+    assert span.attributes["gen_ai.request.model"] == "openai/gpt-4o-mini"
+    # 日期后缀剥离 + 系族前缀识别后补齐为 openai/gpt-4o-mini。
+    assert span.attributes["gen_ai.response.model"] == "openai/gpt-4o-mini"
     assert span.attributes["gen_ai.system"] == "openai"
-    assert span.attributes["langfuse.observation.model.name"] == "gpt-4o-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "openai/gpt-4o-mini"
     assert span.attributes["gen_ai.original_model"] == "gpt-4o-mini"
     # 裸名 request 与带日期的 response 不同，需各自保留诊断字符串。
     assert span.attributes["gen_ai.original_response_model"] == "gpt-4o-mini-2024-07-18"
@@ -217,8 +217,8 @@ def test_patch_litellm_handle_success_preserves_recording_parent_span(monkeypatc
     )
 
     assert set_attributes_calls["count"] == 1
-    # 经归一化后写入裸名（与 Langfuse Model Costs 视图聚合口径一致）。
-    assert parent_span.attributes["gen_ai.request.model"] == "gpt-5-mini"
+    # 经归一化后写入 vendor/model 全名（与 Langfuse Model Costs 视图聚合口径一致）。
+    assert parent_span.attributes["gen_ai.request.model"] == "openai/gpt-5-mini"
     assert parent_span.attributes["gen_ai.usage.cost"] == 0.12
     assert len(parent_span.statuses) == 1
 
@@ -290,15 +290,20 @@ def test_normalization_runs_even_if_original_set_attributes_raises(monkeypatch):
 
     OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
 
-    # 归一化在 original 失败后仍然执行
-    assert span.attributes["gen_ai.request.model"] == "gpt-5-mini"
-    assert span.attributes["gen_ai.response.model"] == "gpt-5-mini"
-    assert span.attributes["langfuse.observation.model.name"] == "gpt-5-mini"
+    # 归一化在 original 失败后仍然执行（vendor 前缀以 request 侧权威推断）
+    assert span.attributes["gen_ai.request.model"] == "openai/gpt-5-mini"
+    assert span.attributes["gen_ai.response.model"] == "openai/gpt-5-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "openai/gpt-5-mini"
     assert span.attributes["gen_ai.system"] == "openai"
 
 
 def test_normalization_handles_embedding_model(monkeypatch):
-    """Embedding 模型名（gemini/text-embedding-004）也应剥离 vendor 前缀。"""
+    """Embedding 模型名（gemini/text-embedding-004）请求与响应跨字段保持 vendor 一致。
+
+    response.model 是裸名 ``text-embedding-004``，家族前缀表会把它识别为 OpenAI；
+    request 侧 ``gemini/`` 前缀必须作为权威 vendor_hint 桥接，让 Langfuse 聚合到
+    ``gemini/text-embedding-004``，避免被 Embedding 的 OpenAI 同名模型污染。
+    """
 
     def _original_set_attributes(self, span, kwargs, response_obj):
         self.safe_set_attribute(span, "gen_ai.request.model", kwargs.get("model"))
@@ -313,13 +318,14 @@ def test_normalization_handles_embedding_model(monkeypatch):
 
     OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
 
-    assert span.attributes["gen_ai.request.model"] == "text-embedding-004"
+    assert span.attributes["gen_ai.request.model"] == "gemini/text-embedding-004"
+    assert span.attributes["gen_ai.response.model"] == "gemini/text-embedding-004"
     assert span.attributes["gen_ai.system"] == "gemini"
-    assert span.attributes["langfuse.observation.model.name"] == "text-embedding-004"
+    assert span.attributes["langfuse.observation.model.name"] == "gemini/text-embedding-004"
 
 
 def test_normalization_handles_bare_model_name(monkeypatch):
-    """裸名（gpt-4o-mini）经归一化后保持不变。"""
+    """裸名（gpt-4o-mini）经归一化后补齐 ``openai/`` 前缀，与带前缀调用聚合到同一行。"""
 
     def _original_set_attributes(self, span, kwargs, response_obj):
         self.safe_set_attribute(span, "gen_ai.request.model", kwargs.get("model"))
@@ -334,6 +340,6 @@ def test_normalization_handles_bare_model_name(monkeypatch):
 
     OpenTelemetry.set_attributes(callback, span, kwargs, response_obj)
 
-    assert span.attributes["gen_ai.request.model"] == "gpt-4o-mini"
-    assert span.attributes["langfuse.observation.model.name"] == "gpt-4o-mini"
+    assert span.attributes["gen_ai.request.model"] == "openai/gpt-4o-mini"
+    assert span.attributes["langfuse.observation.model.name"] == "openai/gpt-4o-mini"
     assert span.attributes["gen_ai.system"] == "openai"

--- a/docs/agents/issue.md
+++ b/docs/agents/issue.md
@@ -1684,6 +1684,13 @@
   - <a id="ref78-1"></a>[1] OpenTelemetry Authors, *Semantic Conventions for Generative AI*, v1.28+, "gen_ai.system / gen_ai.request.model / gen_ai.response.model," 2025. [Online]. Available: https://opentelemetry.io/docs/specs/semconv/gen-ai/
   - <a id="ref78-2"></a>[2] Langfuse, *OpenTelemetry Integration — Attribute Mapping*, "Model attribute precedence: ai.response.model > gen_ai.response.model > gen_ai.request.model; langfuse.observation.* override namespace," 2026. [Online]. Available: https://langfuse.com/integrations/native/opentelemetry
   - <a id="ref78-3"></a>[3] LiteLLM, *Langfuse OTEL Integration*, "litellm.success_callback = ['otel'] forwards via OTLP," 2026. [Online]. Available: https://docs.litellm.ai/docs/observability/langfuse_otel_integration
+- **决策反转补丁（2026-05-21）**：
+  1. **现象**：上述方案落地后，Langfuse Model Costs 视图仍同时出现 `gpt-5-mini`（裸名）与 `openai/gpt-5-mini`（带前缀）两行；`gpt-5-nano` 也以裸名独立成行。即 monkey-patch 之外仍有路径绕过归一化（或被 LiteLLM 原始 OTel callback 先行写入了带前缀的 `gen_ai.request.model`）。
+  2. **新口径**：把观测路径输出形态由「裸名」**反转为 `vendor/model` 全名**（`openai/gpt-5-mini`、`anthropic/claude-3-5-sonnet`、`gemini/text-embedding-004` …）。核心论据：LiteLLM 调度路径必须收到 `vendor/` 前缀才能选择真实 API，因此带前缀的形态本就是系统中**唯一已知的全局权威形态**；把所有观测点都收敛到这个形态，比与 LiteLLM 原始 callback 在裸名形态上竞速覆盖更稳健。日期/版本后缀仍剥（`gpt-5-mini-2025-08-07` → `openai/gpt-5-mini`）。
+  3. **算法变更**：`observability_model_name(name, *, vendor_hint=None)` 改为「拆 vendor + 裸名 → 剥日期 → 别名 → 拼回 vendor/bare」。`vendor_hint` 解决跨字段一致性：当 request `gemini/text-embedding-004` 与 response 裸名 `text-embedding-004` 共存时，把 request 侧 vendor 注入 response 归一化，避免家族前缀表把 `text-embedding-` 误识别成 `openai`。提取内部小工具 `_split_vendor_and_bare()` 统一拆分逻辑。
+  4. **定价路径解耦**：`instrumentation._resolve_total_cost` 显式切到 `pricing_lookup_model_name(...)`（裸名查表），不再借观测函数；阅读时一眼能看出「定价 vs 观测」走两套不同的契约。
+  5. **测试反转**：`test_model_names.py` / `test_instrumentation.py` / `test_genai_semconv.py` 中所有 `observability_model_name` / `gen_ai.{request,response}.model` / `langfuse.observation.model.name` 断言由裸名反转为 `vendor/model`；新增 `vendor_hint` 用例 + 「请求带前缀、响应裸名」跨字段一致性用例。
+  6. **教训沉淀**：「把所有形态收敛到裸名」与「把所有形态收敛到 vendor/model」都满足 Single Source of Truth；选哪个要看**系统内已有的权威形态是什么**。在 LiteLLM 体系下，`vendor/model` 才是调度路径的硬约束，反向（剥前缀）需要主动改写多入口，更脆弱。
 
 ---
 


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：Langfuse 的 Model Costs 视图同一物理模型被拆成多行（同时出现 `gpt-5-mini` 与 `openai/gpt-5-mini`，以及裸名 `gpt-5-nano`），账单观测失真、违反 Single Source of Truth。
- 关联上下文/Issue/文档：`docs/agents/issue.md` 中 2026-05 的原决策（剥 vendor 前缀输出裸名）落地后仍出现裸名 vs 带前缀混报；本次为该决策的反转补丁（追加在 1665-1672 段之后）。

# 核心变更

- `apps/negentropy/src/negentropy/model_names.py`：`observability_model_name()` 由「剥 vendor 前缀输出裸名」反转为「补齐/保留 vendor 前缀输出 `vendor/model` 全名」；新增 `vendor_hint` 可选参数；提取内部小工具 `_split_vendor_and_bare()` 统一拆分逻辑；保持幂等与「未知模型保持原样」契约。
- `apps/negentropy/src/negentropy/instrumentation.py`：`_apply_model_normalization()` 用 request 侧 vendor 作为跨字段 `vendor_hint`，解决 `gemini/text-embedding-004` request 与裸名 response 被家族前缀表分别识别成 `gemini` / `openai` 的歧义；`_resolve_total_cost` 显式切到 `pricing_lookup_model_name(...)`，使「定价路径走裸名」与「观测路径走 vendor/model」两套契约视觉上正交。
- 单元测试（`test_model_names` / `test_instrumentation` / `test_genai_semconv`）：所有断言由裸名反转为 `vendor/model`；新增 `vendor_hint` 覆盖、embedding 跨字段一致性、unknown model passthrough 用例。
- `docs/agents/issue.md`：追加 2026-05-21 决策反转补丁说明，记录「SoT 形态选 vendor/model 还是裸名」的工程教训——LiteLLM 体系下 `vendor/model` 才是调度路径硬约束，反向（剥前缀）需主动改写多入口、更脆弱。

# 风险与回滚

- 主要风险：Langfuse 历史聚合行（旧裸名行）在过渡期会与新 `vendor/model` 行并存，待旧 trace 自然滚出窗口后收敛；定价查表路径已显式切到 `pricing_lookup_model_name`，与本次反转解耦。
- 回滚方式：`git revert` 本 PR 即可恢复旧的「裸名口径」；`observability_model_name` 接口签名向后兼容（`vendor_hint` 为可选关键字），下游 `agents/_dynamic_model.py` 无需改动。

# 验证证据

- 单元测试：`tests/unit_tests/config/test_model_names.py`（25 PASS）、`tests/unit_tests/observability/test_instrumentation.py`（11 PASS）、`tests/unit_tests/engine/test_genai_semconv.py`（24 PASS）、`tests/unit_tests/config/test_pricing_catalog.py`（3 PASS）；广义回归 `tests/unit_tests/{observability,config,engine,agents}` 共 834 PASS。
- 集成测试：N/A（本次仅触达 OTel 注入与归一化函数，不涉及 DB/HTTP 集成路径）。
- E2E/Workflow：人工验收方案见 `.claude/plans/system-instruction-you-are-working-virtual-flurry.md` 中「集成层」步骤：本地启动 negentropy backend + Langfuse 后，分别触发 OpenAI / Anthropic / Gemini Embedding 三类请求，核验 Model Costs 视图同一模型只出现一行且形态为 `vendor/model`。
- 覆盖率/关键截图：Issue 触发截图见 `.context/attachments/2i3rVN/image.png`（PR 描述外引用）。

# 影响范围

- 前端：无。
- 后端：`negentropy` 服务的 OTel/Langfuse 上报路径（`gen_ai.request.model` / `gen_ai.response.model` / `langfuse.observation.model.name` / `negentropy.{user_selected_model,effective_model}`）；structlog `negentropy.llm.usage` / `negentropy.llm.error` 字段。
- GitHub Actions / 文档：`docs/agents/issue.md` 增补决策反转补丁段；CI 配置无变更。

# Next Best Action

- 提交后 1 周内在 Langfuse Model Costs 视图回归核验：旧的裸名行随旧 trace 自然滚出，不应出现新增的 `vendor/model-YYYY-MM-DD` 形态行。
- 后续如需统一 `cognizes` 子项目走 langfuse-py SDK 直连路径（如 `apps/cognizes/tests/integration/engine/mind/test_langfuse_real.py:72` 仍写裸名 `gemini-2.0-flash`），单独 PR 处理：在 cognizes 引入等价归一化模块即可，与本次 negentropy 改动正交。