### PR TITLE
feat(KnowledgeGraph): Sigma 升为默认渲染引擎并重排视图引擎切换组

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -122,8 +122,8 @@ export default function KnowledgeGraphPage() {
   const [buildError, setBuildError] = useState<string | null>(null);
   // G3: as_of 状态 — null 表示当前时刻，提供时穿梭至历史快照
   const [asOf, setAsOf] = useState<string | null>(null);
-  // G2: 渲染引擎切换 — Cytoscape / d3-force / Sigma.js WebGL / Force Graph 2D / 3D WebGL
-  const [renderer, setRenderer] = useState<"cytoscape" | "d3" | "sigma" | "force-graph" | "3d">("cytoscape");
+  // G2: 渲染引擎切换（默认 Sigma WebGL）— Sigma / 3D / d3-force / Force Graph / Cytoscape
+  const [renderer, setRenderer] = useState<"cytoscape" | "d3" | "sigma" | "force-graph" | "3d">("sigma");
   // 右侧抽屉收起状态；localStorage 持久化，SSR 安全（初值 true，挂载后读取覆盖）。
   // 设计要点（修复挂载期闪烁 + storage 噪声）：
   //   1) 用 hasHydratedRef 区分「初始挂载 read」与「用户交互 write」——挂载阶段
@@ -554,26 +554,15 @@ export default function KnowledgeGraphPage() {
                   {viewTab === "graph" && (
                     <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 text-[10px]">
                       <button
-                        onClick={() => setRenderer("cytoscape")}
-                        title="Cytoscape.js + fCoSE 布局（Phase 4 默认）"
+                        onClick={() => setRenderer("sigma")}
+                        title="Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）"
                         className={`px-2 py-1 font-medium ${
-                          renderer === "cytoscape"
+                          renderer === "sigma"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
                         } rounded-l-lg`}
                       >
-                        Cytoscape
-                      </button>
-                      <button
-                        onClick={() => setRenderer("d3")}
-                        title="d3-force（Phase 1 兼容回退）"
-                        className={`px-2 py-1 font-medium border-x border-zinc-200 dark:border-zinc-700 ${
-                          renderer === "d3"
-                            ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
-                            : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
-                        }`}
-                      >
-                        d3-force
+                        Sigma
                       </button>
                       <button
                         onClick={() => setRenderer("3d")}
@@ -587,26 +576,37 @@ export default function KnowledgeGraphPage() {
                         3D
                       </button>
                       <button
-                        onClick={() => setRenderer("sigma")}
-                        title="Sigma.js v3 WebGL 渲染（高性能，适合大图）"
-                        className={`px-2 py-1 font-medium ${
-                          renderer === "sigma"
+                        onClick={() => setRenderer("d3")}
+                        title="d3-force（Phase 1 兼容回退）"
+                        className={`px-2 py-1 font-medium border-x border-zinc-200 dark:border-zinc-700 ${
+                          renderer === "d3"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
                         }`}
                       >
-                        Sigma
+                        d3-force
                       </button>
                       <button
                         onClick={() => setRenderer("force-graph")}
                         title="react-force-graph-2d（粒子流动效果，视觉表现力强）"
-                        className={`px-2 py-1 font-medium ${
+                        className={`px-2 py-1 font-medium border-x border-zinc-200 dark:border-zinc-700 ${
                           renderer === "force-graph"
+                            ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
+                            : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
+                        }`}
+                      >
+                        Force Graph
+                      </button>
+                      <button
+                        onClick={() => setRenderer("cytoscape")}
+                        title="Cytoscape.js + fCoSE 布局（Phase 4 默认）"
+                        className={`px-2 py-1 font-medium ${
+                          renderer === "cytoscape"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
                         } rounded-r-lg`}
                       >
-                        Force Graph
+                        Cytoscape
                       </button>
                     </div>
                   )}

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -599,7 +599,7 @@ export default function KnowledgeGraphPage() {
                       </button>
                       <button
                         onClick={() => setRenderer("cytoscape")}
-                        title="Cytoscape.js + fCoSE 布局（Phase 4 默认）"
+                        title="Cytoscape.js + fCoSE 布局（Phase 4 历史默认）"
                         className={`px-2 py-1 font-medium ${
                           renderer === "cytoscape"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：知识图谱页面（`/knowledge/graph`）顶部视图引擎切换组顺序与默认引擎不符合使用习惯——基于 Canvas/SVG 的 Cytoscape 占据首位且为默认引擎，在中大规模图谱下首屏渲染压力较大。
- 关联上下文：基于截图标注调整为 `Sigma | 3D | d3-force | Force Graph | Cytoscape`，默认引擎切至 Sigma.js v3（WebGL），让首屏对真实工作负载（高节点数 / 高连通度）更友好。

# 核心变更

- `apps/negentropy-ui/app/knowledge/graph/page.tsx`
  - `useState` 默认值由 `cytoscape` 切换为 `sigma`，并同步更新顶部注释（line 125-126）。
  - 顶部胶囊组按钮按 Sigma → 3D → d3-force → Force Graph → Cytoscape 顺序重排（line 555-611）。
  - 同步更新 `rounded-l-lg` / `rounded-r-lg` 至新的首末按钮，并将中间三枚按钮统一应用 `border-x`，顺手补齐原 Sigma 与 Force Graph 之间缺失的分隔线，胶囊组视觉一致。
  - Sigma 按钮 `title` 追加“默认引擎”提示，便于鼠标悬停识别。

# 风险与回滚

- 主要风险：默认引擎切换为 Sigma 后，Sigma 渲染分支（`SigmaGraphCanvas` 动态 import + WebGL 上下文）成为新用户首次访问的关键路径；如目标设备 WebGL 不可用，会回退到既有 `nodes.length > 0` 条件分支的空态占位。视觉层面仅胶囊组顺序与默认高亮位置变化，无新交互引入。
- 回滚方式：单文件、单 commit 改动，直接 `git revert <commit>` 即可完整还原默认引擎与按钮顺序。

# 验证证据

- 单元测试：`apps/negentropy-ui/tests` 未覆盖渲染引擎切换；本次为 UI 顺序与默认值调整，未触达既有测试断言。
- 集成测试：N/A。
- E2E/Workflow：N/A。
- 覆盖率/关键截图：`pnpm typecheck` 通过；pre-commit ESLint 通过（`ESLint (negentropy-ui)` Passed）。建议合并前在登录态 Chrome 实操确认默认高亮在 Sigma、按钮顺序符合截图。

# 影响范围

- 前端：仅 `apps/negentropy-ui` 知识图谱页面顶部工具栏；条件渲染分支（lines 643-810）按 `renderer` 字符串路由，与按钮顺序无耦合，未触达。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action

- 评估为 `renderer` 增加 `localStorage` 持久化，让用户切换偏好跨会话保留（本次范围外，可作为独立小型增强跟进）。
- 评估清理 Cytoscape `title` 中“Phase 4 默认”的历史表述，避免与新默认引擎产生认知歧义。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)