### PR TITLE
feat(ClaudeCode): 将 Claude Code CLI 作为 BuiltinTool 接入 ADK Agent 工具链

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -237,13 +237,21 @@ export function HomeBody({
     useSubAgentsList();
   const { corpora, loading: corporaLoading, error: corporaError } = useCorporaList();
   const agentCandidates = useMemo<MentionCandidate[]>(
-    () =>
-      subagents.map((a) => ({
+    () => [
+      ...subagents.map((a) => ({
         kind: "agent" as const,
         refId: a.name,
         label: a.display_name || a.name,
         description: a.description || undefined,
       })),
+      {
+        kind: "agent" as const,
+        refId: "claude_code",
+        label: "Claude Code",
+        description:
+          "提示 ADK Agent 使用 Claude Code 工具来完成代码分析、修改、测试等复杂任务",
+      },
+    ],
     [subagents],
   );
   const corpusCandidates = useMemo<MentionCandidate[]>(
@@ -257,7 +265,7 @@ export function HomeBody({
     [corpora],
   );
   const validAgentRefIds = useMemo(
-    () => new Set(subagents.map((a) => a.name)),
+    () => new Set([...subagents.map((a) => a.name), "claude_code"]),
     [subagents],
   );
   const validCorpusRefIds = useMemo(

--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -237,21 +237,25 @@ export function HomeBody({
     useSubAgentsList();
   const { corpora, loading: corporaLoading, error: corporaError } = useCorporaList();
   const agentCandidates = useMemo<MentionCandidate[]>(
-    () => [
-      ...subagents.map((a) => ({
+    () => {
+      const mapped = subagents.map((a) => ({
         kind: "agent" as const,
         refId: a.name,
         label: a.display_name || a.name,
         description: a.description || undefined,
-      })),
-      {
-        kind: "agent" as const,
-        refId: "claude_code",
-        label: "Claude Code",
-        description:
-          "提示 ADK Agent 使用 Claude Code 工具来完成代码分析、修改、测试等复杂任务",
-      },
-    ],
+      }));
+      const hasBuiltinClaudeCode = subagents.some((a) => a.name === "claude_code");
+      if (!hasBuiltinClaudeCode) {
+        mapped.push({
+          kind: "agent" as const,
+          refId: "claude_code",
+          label: "Claude Code",
+          description:
+            "提示 ADK Agent 使用 Claude Code 工具来完成代码分析、修改、测试等复杂任务",
+        });
+      }
+      return mapped;
+    },
     [subagents],
   );
   const corpusCandidates = useMemo<MentionCandidate[]>(

--- a/apps/negentropy/src/negentropy/agents/faculties/action.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/action.py
@@ -3,6 +3,7 @@ from google.adk.agents import LlmAgent
 from .._dynamic_instruction import make_instruction_provider
 from .._model import create_subagent_model
 from ..tools.action import execute_code, read_file, write_file
+from ..tools.claude_code import invoke_claude_code
 from ..tools.common import log_activity
 
 _DESCRIPTION = (
@@ -61,7 +62,7 @@ def create_action_agent(*, output_key: str | None = None) -> LlmAgent:
         model=create_subagent_model(agent_name="ActionFaculty"),
         description=_DESCRIPTION,
         instruction=make_instruction_provider("ActionFaculty", _INSTRUCTION),
-        tools=[log_activity, execute_code, read_file, write_file],
+        tools=[log_activity, execute_code, read_file, write_file, invoke_claude_code],
         output_key=output_key,
         # Pipeline 边界管控：在流水线内使用时，禁止 LLM 路由逃逸
         disallow_transfer_to_parent=output_key is not None,

--- a/apps/negentropy/src/negentropy/agents/tools/claude_code.py
+++ b/apps/negentropy/src/negentropy/agents/tools/claude_code.py
@@ -1,0 +1,82 @@
+"""invoke_claude_code — 让 ADK Agent 调用 Claude Code 的 FunctionTool。
+
+Claude Code 拥有完整的文件读写、Bash 执行、代码搜索能力，
+可以自主完成多文件编辑、测试运行、Git 操作等复杂任务链。
+是 ADK Agent 工具箱中的"超级工具"。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.tools import ToolContext
+
+from negentropy.engine.claude_code.models import ClaudeCodeConfig
+from negentropy.engine.claude_code.service import ClaudeCodeService
+
+
+async def invoke_claude_code(
+    task: str,
+    tool_context: ToolContext,
+    working_directory: str | None = None,
+    allowed_tools: str | None = None,
+    max_turns: int = 20,
+    system_prompt: str | None = None,
+) -> dict[str, Any]:
+    """调用 Claude Code 执行复杂的代码分析与修改任务。
+
+    Claude Code 拥有完整的文件读写、Bash 执行、代码搜索能力，
+    可以自主完成多文件编辑、测试运行、Git 操作等复杂任务链。
+    适用于需要跨文件理解、多步骤修改、测试验证的复杂代码任务。
+
+    Args:
+        task: 描述 Claude Code 需要完成的任务
+        tool_context: ADK 注入的上下文
+        working_directory: 目标项目的工作目录（默认使用系统配置）
+        allowed_tools: 允许使用的工具，逗号分隔
+            （默认: "Bash,Read,Write,Edit,Glob,Grep"）
+        max_turns: 最大自主迭代轮数（默认 20）
+        system_prompt: 自定义系统指令
+    """
+    # 1. 从 session state 读取全局配置（由 BuiltinTool 系统注入）
+    cc_defaults: dict = tool_context.state.get("claude_code_config", {})
+
+    # 2. tool call 参数覆盖默认值
+    config = ClaudeCodeConfig(
+        cli_path=cc_defaults.get("cli_path", "claude"),
+        model=cc_defaults.get("model"),
+        cwd=working_directory or cc_defaults.get("cwd") or cc_defaults.get("default_cwd"),
+        max_turns=max_turns,
+        system_prompt=system_prompt or cc_defaults.get("system_prompt"),
+        permission_mode=cc_defaults.get("permission_mode", "auto"),
+        timeout_seconds=float(cc_defaults.get("timeout_seconds", 300.0)),
+        mcp_config=cc_defaults.get("mcp_config"),
+    )
+
+    # 3. 解析 allowed_tools
+    if allowed_tools:
+        config.allowed_tools = [t.strip() for t in allowed_tools.split(",")]
+    elif cc_defaults.get("allowed_tools"):
+        raw = cc_defaults["allowed_tools"]
+        config.allowed_tools = raw if isinstance(raw, list) else [t.strip() for t in raw.split(",")]
+
+    # 4. 会话续接（从 state 取上次 session_id）
+    last_session: str | None = tool_context.state.get("claude_code_session_id")
+    if last_session:
+        config.resume_session_id = last_session
+
+    # 5. 执行
+    result = await ClaudeCodeService.invoke(task, config)
+
+    # 6. 存储新 session_id 供后续续接
+    if result.session_id:
+        tool_context.state["claude_code_session_id"] = result.session_id
+
+    return {
+        "status": result.status,
+        "summary": result.summary,
+        "session_id": result.session_id,
+        "cost_usd": result.cost_usd,
+        "turn_count": result.turn_count,
+        "error": result.error,
+    }

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0039_seed_claude_code_builtin_tool.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0039_seed_claude_code_builtin_tool.py
@@ -1,0 +1,162 @@
+"""种子化 claude_code 内置工具（系统级、全员可见可用）
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-05-22 00:00:00.000000+00:00
+
+设计动机：
+    `038-claude-code-integration` 设计文档将 Claude Code CLI 作为 ADK Agent 的
+    BuiltinTool 接入。前端 Interface / Tools 页通过 ``BuiltinTool`` 行渲染卡片，
+    后端 ADK FunctionTool ``invoke_claude_code`` 与 Scheduler handler ``claude_code``
+    都在运行时从 ``builtin_tools`` 表读取全局默认配置（cli_path / max_turns /
+    timeout_seconds / permission_mode / allowed_tools 等）。
+
+    因此需要一条幂等 seed 迁移，将 ``claude_code`` 行写入 ``builtin_tools`` 表，
+    属性约束：
+      - ``owner_id = 'system'`` —— 与 0031 的 ``google_search`` 同源，进入
+        ``permissions.get_visible_plugin_ids`` 的 system-union 路径
+      - ``visibility = 'PUBLIC'`` —— 0036 将列类型从 VARCHAR 升级为
+        ``negentropy.pluginvisibility`` 枚举（成员名大写）
+      - ``is_system = TRUE`` —— ToolCard 渲染 "Built-In" 徽章并阻止删除
+      - ``is_enabled = TRUE`` —— 默认开启，ADK Agent / Scheduler handler 立即可用
+      - 不写入 ``credentials`` —— ANTHROPIC_API_KEY 由 VendorConfig 注入子进程
+        环境变量，不在此处持久化明文凭据
+
+JSONB 编码：
+    沿用 0031 的写法（``sa.bindparam(..., type_=JSONB)`` + Python dict），
+    经 0038 验证读取侧正确；不再走 ``json.dumps()`` 字符串预序列化以避免
+    双编码问题。
+
+幂等性：
+    ``ON CONFLICT (name) DO NOTHING`` 保证重复执行不覆盖运维已调整的配置；
+    若需变更默认值，应单独走 data-fix 脚本而非反复 seed。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0039"
+down_revision: str | None = "0038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+# Claude Code 默认允许的 ADK Tool 子集（沿用 038 文档约定）。
+# Bash / Read / Write / Edit / Glob / Grep 覆盖典型 agentic coding 场景；
+# WebFetch / WebSearch / Task 等高权限工具默认禁用，避免长时间脱缰。
+_DEFAULT_ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+# UI ToolFormDialog 根据 config_schema 动态渲染表单字段。
+# 与 ``ClaudeCodeConfig`` 字段保持一一对应（参见
+# ``engine/claude_code/models.py``），便于运维直接在 Interface / Tools 页调参。
+CLAUDE_CODE_CONFIG_SCHEMA = {
+    "config": {
+        "cli_path": {
+            "type": "string",
+            "title": "CLI Path",
+            "description": "Claude Code CLI 可执行文件路径（默认沿用系统 PATH 中的 `claude`）",
+            "default": "claude",
+        },
+        "model": {
+            "type": "string",
+            "title": "Model Override",
+            "description": "覆盖 Claude Code 默认模型（留空则使用 SDK / CLI 自身的默认值）",
+        },
+        "system_prompt": {
+            "type": "string",
+            "title": "System Prompt",
+            "description": "自定义系统指令，会拼接到 Claude Code 默认 system prompt 之后",
+        },
+        "default_cwd": {
+            "type": "string",
+            "title": "Default Working Directory",
+            "description": "未在 tool call 中显式指定 working_directory 时使用的默认工作目录",
+        },
+        "max_turns": {
+            "type": "integer",
+            "title": "Max Turns",
+            "description": "Claude Code 在单次调用中允许的最大自主迭代轮数",
+            "default": 20,
+            "minimum": 1,
+            "maximum": 200,
+        },
+        "timeout_seconds": {
+            "type": "number",
+            "title": "Timeout (seconds)",
+            "description": "单次 Claude Code 调用的超时上限，超时返回 status=timeout",
+            "default": 300.0,
+            "minimum": 10.0,
+            "maximum": 3600.0,
+        },
+        "permission_mode": {
+            "type": "string",
+            "title": "Permission Mode",
+            "description": "Claude Code 工具权限模式：auto 默认放行 / ask 逐项询问 / plan 仅规划不执行",
+            "enum": ["auto", "ask", "plan"],
+            "default": "auto",
+        },
+        "allowed_tools": {
+            "type": "array",
+            "title": "Allowed Tools",
+            "description": (
+                "Claude Code 内置工具白名单"
+                "（Bash / Read / Write / Edit / Glob / Grep / WebFetch / WebSearch / Task ...）"
+            ),
+            "items": {"type": "string"},
+            "default": _DEFAULT_ALLOWED_TOOLS,
+        },
+    },
+    "credentials": {
+        # ANTHROPIC_API_KEY 由 VendorConfig 统一管理，不在 builtin_tools 表中存储明文。
+        # 此处保留空字典占位，便于未来扩展 per-tool 凭据时无需再次 schema 迁移。
+    },
+}
+
+CLAUDE_CODE_CONFIG_DEFAULT = {
+    "cli_path": "claude",
+    "model": None,
+    "system_prompt": None,
+    "default_cwd": None,
+    "max_turns": 20,
+    "timeout_seconds": 300.0,
+    "permission_mode": "auto",
+    "allowed_tools": _DEFAULT_ALLOWED_TOOLS,
+}
+
+CLAUDE_CODE_DESCRIPTION = (
+    "调用本地 Claude Code CLI 完成多文件代码分析、跨文件重构、自主测试修复等复杂 agentic coding 任务。"
+    "ADK Agent 通过 invoke_claude_code FunctionTool 触发；Scheduler 可周期性调度 claude_code handler。"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            INSERT INTO {SCHEMA}.builtin_tools
+                (owner_id, visibility, name, display_name, description,
+                 tool_type, version, config, credentials, config_schema,
+                 is_enabled, is_system)
+            VALUES (
+                'system', 'PUBLIC', 'claude_code', 'Claude Code',
+                :description,
+                'claude_code', '1.0.0',
+                :config, :credentials, :config_schema,
+                TRUE, TRUE
+            )
+            ON CONFLICT (name) DO NOTHING
+            """
+        ).bindparams(
+            sa.bindparam("description", value=CLAUDE_CODE_DESCRIPTION, type_=sa.Text),
+            sa.bindparam("config", value=CLAUDE_CODE_CONFIG_DEFAULT, type_=sa.dialects.postgresql.JSONB),
+            sa.bindparam("credentials", value={}, type_=sa.dialects.postgresql.JSONB),
+            sa.bindparam("config_schema", value=CLAUDE_CODE_CONFIG_SCHEMA, type_=sa.dialects.postgresql.JSONB),
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"DELETE FROM {SCHEMA}.builtin_tools WHERE name = 'claude_code' AND owner_id = 'system'"))

--- a/apps/negentropy/src/negentropy/engine/claude_code/__init__.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/__init__.py
@@ -1,0 +1,6 @@
+"""Claude Code 集成模块 — 封装 Claude Code CLI/SDK 调用能力。"""
+
+from .models import ClaudeCodeConfig, ClaudeCodeResult
+from .service import ClaudeCodeService
+
+__all__ = ["ClaudeCodeConfig", "ClaudeCodeResult", "ClaudeCodeService"]

--- a/apps/negentropy/src/negentropy/engine/claude_code/models.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/models.py
@@ -1,0 +1,48 @@
+"""Claude Code 数据模型。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ClaudeCodeConfig:
+    """Claude Code 调用配置。
+
+    来源：BuiltinTool.config（全局默认）+ ADK tool call 参数（单次覆盖）。
+    """
+
+    cli_path: str = "claude"
+    model: str | None = None
+    system_prompt: str | None = None
+    allowed_tools: list[str] | None = None
+    disallowed_tools: list[str] | None = None
+    cwd: str | None = None
+    max_turns: int = 20
+    timeout_seconds: float = 300.0
+    permission_mode: str = "auto"  # auto | ask | plan
+    mcp_config: dict[str, Any] | None = None
+    resume_session_id: str | None = None
+
+    # 默认允许的工具集
+    _DEFAULT_TOOLS: list[str] = field(
+        default_factory=lambda: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"],
+        repr=False,
+        compare=False,
+    )
+
+    def get_effective_allowed_tools(self) -> list[str]:
+        return self.allowed_tools or self._DEFAULT_TOOLS
+
+
+@dataclass
+class ClaudeCodeResult:
+    """Claude Code 执行结果。"""
+
+    status: str  # "success" | "error" | "timeout"
+    summary: str  # 最终文本结果（截断到 2000 字符）
+    session_id: str | None = None  # Claude Code 返回的 session_id（可续接）
+    cost_usd: float = 0.0
+    turn_count: int = 0
+    error: str | None = None

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -1,0 +1,274 @@
+"""ClaudeCodeService — 封装 Claude Code CLI / SDK 调用。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import time
+from typing import Any
+
+from negentropy.logging import get_logger
+
+from .models import ClaudeCodeConfig, ClaudeCodeResult
+
+logger = get_logger("negentropy.engine.claude_code.service")
+
+# stream-json 事件类型常量
+_EVT_ASSISTANT = "assistant"
+_EVT_TOOL_USE = "tool_use"
+_EVT_TOOL_RESULT = "tool_result"
+_EVT_RESULT = "result"
+_EVT_SYSTEM = "system"
+
+_SUMMARY_MAX_LEN = 2000
+
+
+class ClaudeCodeService:
+    """封装 Claude Code CLI 调用。优先 claude-code-sdk，降级 CLI 子进程。"""
+
+    _sdk_available: bool | None = None  # 延迟探测，模块级缓存
+
+    @classmethod
+    def _check_sdk(cls) -> bool:
+        if cls._sdk_available is None:
+            try:
+                import claude_code_sdk  # noqa: F401
+
+                cls._sdk_available = True
+            except ImportError:
+                cls._sdk_available = False
+        return cls._sdk_available
+
+    @staticmethod
+    async def invoke(
+        prompt: str,
+        config: ClaudeCodeConfig,
+        abort_event: asyncio.Event | None = None,
+    ) -> ClaudeCodeResult:
+        """调用 Claude Code 并等待完整结果。
+
+        用于 ADK Tool（tool call 内等待）和 Scheduler Handler。
+        """
+        t0 = time.monotonic()
+        try:
+            if ClaudeCodeService._check_sdk():
+                result = await ClaudeCodeService._invoke_sdk(prompt, config, abort_event)
+            else:
+                result = await ClaudeCodeService._invoke_cli(prompt, config, abort_event)
+            elapsed = time.monotonic() - t0
+            logger.info(
+                "claude_code_invoke_done",
+                status=result.status,
+                elapsed_s=round(elapsed, 2),
+                turns=result.turn_count,
+                cost=result.cost_usd,
+                sdk=ClaudeCodeService._sdk_available,
+            )
+            return result
+        except asyncio.CancelledError:
+            return ClaudeCodeResult(status="error", summary="", error="cancelled")
+        except Exception as exc:
+            logger.warning("claude_code_invoke_failed", error=str(exc))
+            return ClaudeCodeResult(status="error", summary="", error=str(exc))
+
+    # ------------------------------------------------------------------
+    # SDK 路径
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _invoke_sdk(
+        prompt: str,
+        config: ClaudeCodeConfig,
+        abort_event: asyncio.Event | None,
+    ) -> ClaudeCodeResult:
+        import claude_code_sdk
+
+        options = claude_code_sdk.ClaudeCodeOptions(
+            system_prompt=config.system_prompt,
+            allowed_tools=config.get_effective_allowed_tools(),
+            max_turns=config.max_turns,
+            permission_mode=config.permission_mode,
+            cwd=config.cwd,
+        )
+        if config.resume_session_id:
+            options.resume = config.resume_session_id
+        if config.model:
+            options.model = config.model
+
+        result_text = ""
+        session_id = None
+        cost = 0.0
+        turns = 0
+
+        async for msg in claude_code_sdk.query(prompt=prompt, options=options):
+            # ResultMessage
+            if hasattr(msg, "result") and msg.result:
+                result_text = msg.result
+            if hasattr(msg, "session_id") and msg.session_id:
+                session_id = msg.session_id
+            if hasattr(msg, "cost_usd") and msg.cost_usd:
+                cost = msg.cost_usd
+            if hasattr(msg, "num_turns") and msg.num_turns:
+                turns = msg.num_turns
+
+            if abort_event and abort_event.is_set():
+                break
+
+        return ClaudeCodeResult(
+            status="success",
+            summary=result_text[:_SUMMARY_MAX_LEN],
+            session_id=session_id,
+            cost_usd=cost,
+            turn_count=turns,
+        )
+
+    # ------------------------------------------------------------------
+    # CLI 子进程路径（降级）
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _invoke_cli(
+        prompt: str,
+        config: ClaudeCodeConfig,
+        abort_event: asyncio.Event | None,
+    ) -> ClaudeCodeResult:
+        args = ClaudeCodeService._build_cli_args(prompt, config)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=config.cwd,
+            )
+        except FileNotFoundError:
+            return ClaudeCodeResult(
+                status="error",
+                summary="",
+                error=f"claude CLI not found at '{config.cli_path}'",
+            )
+
+        result_text = ""
+        session_id = None
+        cost = 0.0
+        turns = 0
+
+        try:
+            async for line in proc.stdout:
+                if abort_event and abort_event.is_set():
+                    proc.terminate()
+                    break
+                decoded = line.decode("utf-8", errors="replace").strip()
+                if not decoded:
+                    continue
+                try:
+                    event = json.loads(decoded)
+                except json.JSONDecodeError:
+                    continue
+
+                evt_type = event.get("type")
+                if evt_type == _EVT_RESULT:
+                    result_text = event.get("result", "")
+                    session_id = event.get("session_id")
+                    cost = event.get("cost_usd", 0.0)
+                    turns = event.get("num_turns", 0)
+                elif evt_type == _EVT_ASSISTANT:
+                    content = event.get("content", "")
+                    if content and not result_text:
+                        result_text = content
+        except asyncio.CancelledError:
+            proc.terminate()
+            await proc.wait()
+            raise
+        finally:
+            if proc.returncode is None:
+                proc.terminate()
+                await proc.wait()
+
+        status = "success" if proc.returncode == 0 else "error"
+        return ClaudeCodeResult(
+            status=status,
+            summary=result_text[:_SUMMARY_MAX_LEN],
+            session_id=session_id,
+            cost_usd=cost,
+            turn_count=turns,
+        )
+
+    @staticmethod
+    def _build_cli_args(prompt: str, config: ClaudeCodeConfig) -> list[str]:
+        args = [
+            config.cli_path,
+            "-p",
+            prompt,
+            "--output-format",
+            "stream-json",
+            "--max-turns",
+            str(config.max_turns),
+            "--permission-mode",
+            config.permission_mode,
+        ]
+        if config.resume_session_id:
+            args += ["--resume", config.resume_session_id]
+        if config.model:
+            args += ["--model", config.model]
+        if config.system_prompt:
+            args += ["--system-prompt", config.system_prompt]
+        if config.cwd:
+            args += ["--cwd", config.cwd]
+        if config.allowed_tools:
+            args += ["--allowed-tools", ",".join(config.allowed_tools)]
+        return args
+
+    # ------------------------------------------------------------------
+    # 连通性测试
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def test_connection(config: ClaudeCodeConfig) -> dict[str, Any]:
+        """执行 claude --version + 简单 prompt 验证连通性。"""
+        cli = config.cli_path or "claude"
+
+        if not shutil.which(cli):
+            return {
+                "success": False,
+                "message": f"claude CLI not found in PATH (tried '{cli}')",
+            }
+
+        # 1. 获取版本
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                cli,
+                "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await asyncio.wait_for(proc.wait(), timeout=10.0)
+            version_out = (await proc.stdout.read()).decode().strip()
+        except Exception as exc:
+            return {"success": False, "message": f"claude --version failed: {exc}"}
+
+        # 2. 简单 prompt 测试
+        t0 = time.monotonic()
+        test_result = await ClaudeCodeService.invoke(
+            "respond with exactly: OK",
+            ClaudeCodeConfig(
+                cli_path=cli,
+                max_turns=1,
+                timeout_seconds=15.0,
+            ),
+        )
+        latency = round((time.monotonic() - t0) * 1000)
+
+        if test_result.status == "success":
+            return {
+                "success": True,
+                "message": f"Claude Code connected (version: {version_out})",
+                "version": version_out,
+                "latency_ms": latency,
+            }
+        return {
+            "success": False,
+            "message": f"Claude Code prompt test failed: {test_result.error}",
+            "version": version_out,
+        }

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -53,9 +53,10 @@ class ClaudeCodeService:
         t0 = time.monotonic()
         try:
             if ClaudeCodeService._check_sdk():
-                result = await ClaudeCodeService._invoke_sdk(prompt, config, abort_event)
+                coro = ClaudeCodeService._invoke_sdk(prompt, config, abort_event)
             else:
-                result = await ClaudeCodeService._invoke_cli(prompt, config, abort_event)
+                coro = ClaudeCodeService._invoke_cli(prompt, config, abort_event)
+            result = await asyncio.wait_for(coro, timeout=config.timeout_seconds)
             elapsed = time.monotonic() - t0
             logger.info(
                 "claude_code_invoke_done",
@@ -68,6 +69,9 @@ class ClaudeCodeService:
             return result
         except asyncio.CancelledError:
             return ClaudeCodeResult(status="error", summary="", error="cancelled")
+        except TimeoutError:
+            logger.warning("claude_code_invoke_timeout", timeout=config.timeout_seconds)
+            return ClaudeCodeResult(status="timeout", summary="", error=f"exceeded timeout ({config.timeout_seconds}s)")
         except Exception as exc:
             logger.warning("claude_code_invoke_failed", error=str(exc))
             return ClaudeCodeResult(status="error", summary="", error=str(exc))
@@ -100,6 +104,7 @@ class ClaudeCodeService:
         session_id = None
         cost = 0.0
         turns = 0
+        error_text = None
 
         async for msg in claude_code_sdk.query(prompt=prompt, options=options):
             # ResultMessage
@@ -111,12 +116,16 @@ class ClaudeCodeService:
                 cost = msg.cost_usd
             if hasattr(msg, "num_turns") and msg.num_turns:
                 turns = msg.num_turns
+            if hasattr(msg, "is_error") and msg.is_error:
+                error_text = result_text or "SDK returned error"
 
             if abort_event and abort_event.is_set():
                 break
 
+        status = "error" if error_text else "success"
         return ClaudeCodeResult(
-            status="success",
+            status=status,
+            error=error_text,
             summary=result_text[:_SUMMARY_MAX_LEN],
             session_id=session_id,
             cost_usd=cost,
@@ -139,7 +148,7 @@ class ClaudeCodeService:
             proc = await asyncio.create_subprocess_exec(
                 *args,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
                 cwd=config.cwd,
             )
         except FileNotFoundError:

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/__init__.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/__init__.py
@@ -82,6 +82,7 @@ def _bootstrap_default_handlers() -> None:
         "cache_warm",
         "pgvector_check",
         "agent_inspection",
+        "claude_code",
     ):
         try:
             __import__(f"negentropy.engine.schedulers.handlers.{module_name}")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
@@ -43,9 +43,11 @@ async def claude_code_handler(task) -> HandlerResult:
 
         # 会话续接（从 task execution 历史中找最近 session_id）
         if payload.get("resume"):
-            last_session_id = await _find_last_session_id(task.id)
-            if last_session_id:
-                config.resume_session_id = last_session_id
+            logger.info(
+                "claude_code_resume_requested",
+                task_id=task.id,
+                note="resume not yet implemented, starting fresh session",
+            )
 
         result = await ClaudeCodeService.invoke(prompt, config)
 
@@ -98,31 +100,3 @@ async def _load_claude_code_defaults():
             mcp_config=cfg.get("mcp_config"),
         )
     return ClaudeCodeConfig()
-
-
-async def _find_last_session_id(task_id) -> str | None:
-    """从最近一次 task_execution 的 metrics 中提取 session_id。"""
-
-    from sqlalchemy import select
-
-    from negentropy.db.session import AsyncSessionLocal
-    from negentropy.models.scheduled_task import TaskExecution
-
-    async with AsyncSessionLocal() as db:
-        stmt = (
-            select(TaskExecution)
-            .where(
-                TaskExecution.task_id == task_id,
-                TaskExecution.status == "ok",
-            )
-            .order_by(TaskExecution.started_at.desc())
-            .limit(1)
-        )
-        result = await db.execute(stmt)
-        execution = result.scalar_one_or_none()
-
-    if execution and execution.output_summary:
-        # session_id 存储在 output_summary 或 metrics 中
-        # 暂时返回 None，待 Phase 3 完善会话续接模型后启用
-        return None
-    return None

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
@@ -1,0 +1,128 @@
+"""``claude_code`` handler — 通过 Scheduler 周期性调度 Claude Code 执行。
+
+行为约定：
+- ``task.payload`` 中应包含 ``prompt``（Claude Code 的任务描述）；
+- 可选 ``cwd`` / ``max_turns`` / ``resume`` 字段覆盖全局配置；
+- 实际执行复用 ``ClaudeCodeService.invoke`` 保持单一事实源；
+- 配置来源于 ``builtin_tools`` 表中 ``tool_type="claude_code"`` 的全局配置。
+"""
+
+from __future__ import annotations
+
+from negentropy.logging import get_logger
+
+from . import HandlerResult, register_handler
+
+logger = get_logger("negentropy.engine.schedulers.handlers.claude_code")
+
+
+@register_handler("claude_code")
+async def claude_code_handler(task) -> HandlerResult:
+    """Scheduler 调度 Claude Code 执行。
+
+    task.payload:
+    - prompt: str — 任务描述（必填）
+    - cwd: str | None — 工作目录（覆盖全局配置）
+    - max_turns: int | None — 最大迭代轮数（覆盖全局配置）
+    - resume: bool — 是否续接上次会话（默认 False）
+    """
+    payload = task.payload or {}
+    prompt = payload.get("prompt", "")
+    if not prompt:
+        return HandlerResult(status="failed", error="missing payload.prompt")
+
+    try:
+        from negentropy.engine.claude_code.service import ClaudeCodeService
+
+        # 加载全局配置
+        config = await _load_claude_code_defaults()
+        if payload.get("cwd"):
+            config.cwd = payload["cwd"]
+        if payload.get("max_turns"):
+            config.max_turns = int(payload["max_turns"])
+
+        # 会话续接（从 task execution 历史中找最近 session_id）
+        if payload.get("resume"):
+            last_session_id = await _find_last_session_id(task.id)
+            if last_session_id:
+                config.resume_session_id = last_session_id
+
+        result = await ClaudeCodeService.invoke(prompt, config)
+
+        return HandlerResult(
+            status="ok" if result.status == "success" else "failed",
+            output_summary=result.summary,
+            error=result.error,
+            metrics={
+                "cost_usd": result.cost_usd,
+                "session_id": result.session_id,
+                "turn_count": result.turn_count,
+            },
+        )
+    except Exception as exc:
+        logger.warning("claude_code_handler_failed", error=str(exc))
+        return HandlerResult(status="failed", error=str(exc))
+
+
+async def _load_claude_code_defaults():
+    """从 builtin_tools 表读取 claude_code 全局配置。"""
+    from sqlalchemy import select
+
+    from negentropy.db.session import AsyncSessionLocal
+    from negentropy.engine.claude_code.models import ClaudeCodeConfig
+    from negentropy.models.builtin_tool import BuiltinTool
+
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(BuiltinTool)
+            .where(
+                BuiltinTool.tool_type == "claude_code",
+                BuiltinTool.is_enabled.is_(True),
+            )
+            .limit(1)
+        )
+        result = await db.execute(stmt)
+        tool = result.scalar_one_or_none()
+
+    if tool:
+        cfg = tool.config or {}
+        return ClaudeCodeConfig(
+            cli_path=cfg.get("cli_path", "claude"),
+            model=cfg.get("model"),
+            system_prompt=cfg.get("system_prompt"),
+            allowed_tools=cfg.get("allowed_tools"),
+            cwd=cfg.get("cwd") or cfg.get("default_cwd"),
+            max_turns=cfg.get("max_turns", 20),
+            timeout_seconds=float(cfg.get("timeout_seconds", 300.0)),
+            permission_mode=cfg.get("permission_mode", "auto"),
+            mcp_config=cfg.get("mcp_config"),
+        )
+    return ClaudeCodeConfig()
+
+
+async def _find_last_session_id(task_id) -> str | None:
+    """从最近一次 task_execution 的 metrics 中提取 session_id。"""
+
+    from sqlalchemy import select
+
+    from negentropy.db.session import AsyncSessionLocal
+    from negentropy.models.scheduled_task import TaskExecution
+
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(TaskExecution)
+            .where(
+                TaskExecution.task_id == task_id,
+                TaskExecution.status == "ok",
+            )
+            .order_by(TaskExecution.started_at.desc())
+            .limit(1)
+        )
+        result = await db.execute(stmt)
+        execution = result.scalar_one_or_none()
+
+    if execution and execution.output_summary:
+        # session_id 存储在 output_summary 或 metrics 中
+        # 暂时返回 None，待 Phase 3 完善会话续接模型后启用
+        return None
+    return None

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -1582,6 +1582,23 @@ async def test_builtin_tool(
         except Exception as exc:
             return BuiltinToolTestResponse(success=False, message=f"Connection failed: {exc}")
 
+    if tool.tool_type == "claude_code":
+        from negentropy.engine.claude_code.models import ClaudeCodeConfig
+        from negentropy.engine.claude_code.service import ClaudeCodeService
+
+        cc_config = ClaudeCodeConfig(
+            cli_path=config.get("cli_path", "claude"),
+            model=config.get("model"),
+            timeout_seconds=15.0,
+        )
+        result = await ClaudeCodeService.test_connection(cc_config)
+        latency = result.get("latency_ms")
+        return BuiltinToolTestResponse(
+            success=result["success"],
+            message=result["message"],
+            latency_ms=latency,
+        )
+
     return BuiltinToolTestResponse(success=False, message=f"Test not supported for tool type: {tool.tool_type}")
 
 

--- a/docs/agents/knowledge-map.md
+++ b/docs/agents/knowledge-map.md
@@ -28,6 +28,7 @@
 - [Memory（记忆系统）](../concepts/025-the-memory-system.md) · [白皮书](../concepts/026-memory-whitepaper.md)
 - [Knowledge Base（知识库设计）](../concepts/035-the-knowledge-base.md)
 - [Knowledge Graph（知识图谱）](../concepts/036-the-knowledge-graph.md) · [联邦知识图谱 + 跨 Corpus 混合检索](../concepts/037-federated-kg.md)
+- [Claude Code 集成（BuiltinTool）](../concepts/038-claude-code-integration.md) — Claude Code CLI 作为 ADK Agent 工具的接入方案
 - [Skills](../concepts/design/skills.md)
 - [Negentropy Wiki Ops](../reference/wiki/ops.md)
 - [Wiki 知识图谱（按 Publication 切片发布）](../reference/wiki/design/knowledge-graph.md)

--- a/docs/concepts/038-claude-code-integration.md
+++ b/docs/concepts/038-claude-code-integration.md
@@ -1,0 +1,164 @@
+# Claude Code 集成设计：作为 BuiltinTool 接入 ADK Agent
+
+> 将本地 Claude Code CLI 作为 **BuiltinTool** 接入 Negentropy 系统，使 ADK Agent（一核五翼）获得调用 Claude Code 的能力。
+>
+> - 架构总览：[Framework](./framework.md)
+> - Agent 工具体系：[Framework §5](./framework.md#5-设计模式目录)
+> - Interface / Tools 页：[Framework §9](./framework.md#9-前端应用架构-negentropy-ui)
+
+---
+
+## 1. 设计动机
+
+ADK Agent 拥有 `execute_code` / `read_file` / `write_file` 等基础工具，但缺乏 Claude Code CLI 的完整能力——多文件上下文理解、自主迭代修复、跨文件重构等。
+
+**Claude Code** 是 Anthropic 官方的 agentic coding 工具，具备完整的文件读写、Bash 执行、代码搜索、MCP 扩展能力。将其作为 ADK Agent 的一个 **FunctionTool**，可使 Agent 在需要时自主委托复杂代码任务。
+
+**核心原则**：Claude Code 永远作为 Tool 被调用，入口始终是 ADK Agent。
+
+## 2. 架构设计
+
+### 2.1 调用路径
+
+```
+用户请求 → ADK Agent（Root / Faculty）
+           → tool call: invoke_claude_code(task, cwd, max_turns)
+             → ClaudeCodeService
+               → claude-code-sdk Python 包（优先）
+               → CLI 子进程（降级）
+             → 返回结果给 ADK Agent
+           → ADK Agent 拿到结果，继续流程或回复用户
+```
+
+### 2.2 组件关系
+
+```
+┌───────────────────────────────────────────────────────┐
+│  ADK Agent 层 (一核五翼)                               │
+│                                                       │
+│  ActionFaculty ── tool_call ──┐                       │
+│  ContemplationFaculty         │                       │
+│  ...                          ↓                       │
+│  ┌──────── Tool Layer ────────────────────────┐      │
+│  │ ADK 内置 │ MCP Tools │ invoke_claude_code ✨│      │
+│  └────────────────────────────────────────────┘       │
+│           │                                            │
+│           ↓                                            │
+│  ┌──── ClaudeCodeService ─────────────────────┐      │
+│  │  claude-code-sdk / CLI subprocess          │      │
+│  │  invoke(prompt, config) → ClaudeCodeResult │      │
+│  └────────────────────────────────────────────┘      │
+└───────────────────────────────────────────────────────┘
+```
+
+### 2.3 配置体系
+
+Claude Code 配置存储在 **BuiltinTool** 表中（`tool_type = "claude_code"`），由 Alembic 迁移 `0039_seed_claude_code_builtin_tool.py` 以 `owner_id='system'` / `visibility='PUBLIC'` / `is_system=true` 种子化，登录用户在 Interface / Tools 页即可看到"Claude Code"卡片并直接调参；ANTHROPIC_API_KEY 由 VendorConfig 注入子进程环境，不在 builtin_tools 表中保存明文凭据。
+
+| 配置项 | 说明 | 默认值 |
+|-------|------|--------|
+| `cli_path` | Claude Code CLI 路径 | `claude` |
+| `model` | 覆盖模型（留空用默认） | `null` |
+| `default_cwd` | 默认工作目录 | `null` |
+| `max_turns` | 最大自主迭代轮数 | `20` |
+| `timeout_seconds` | 超时时间（秒） | `300` |
+| `permission_mode` | 权限模式 | `auto` |
+| `allowed_tools` | 允许的工具列表 | `Bash,Read,Write,Edit,Glob,Grep` |
+
+ADK Tool call 参数（`working_directory`, `max_turns` 等）可覆盖全局配置。
+
+### 2.4 Studio @claude-code 提示
+
+在 Studio 对话框 @mention 候选列表中注入 `Claude Code` 条目。当用户选择 @claude-code 时，消息中包含 `@Claude Code` 提示文本，发送给 ADK Agent。Agent 自主决定是否调用 `invoke_claude_code` tool。
+
+不引入新的 MentionKind——`claude_code` 作为一种特殊的 agent mention 存在。
+
+### 2.5 Scheduler 周期性调度
+
+通过 `claude_code` handler 实现 Scheduler 周期性调用：
+
+```
+Cron 触发 → claude_code handler
+  → 从 BuiltinTool 读取全局配置
+  → 调用 ClaudeCodeService.invoke(prompt, config)
+  → 返回 HandlerResult（含 cost_usd, session_id）
+```
+
+未来可扩展 `resume` 参数实现跨调度会话续接。
+
+## 3. 文件结构
+
+```
+apps/negentropy/src/negentropy/
+├── agents/tools/
+│   └── claude_code.py              # invoke_claude_code ADK FunctionTool
+├── agents/faculties/
+│   └── action.py                   # 注册 invoke_claude_code 到 tools 列表
+├── engine/claude_code/
+│   ├── __init__.py                 # 包导出
+│   ├── models.py                   # ClaudeCodeConfig, ClaudeCodeResult
+│   └── service.py                  # ClaudeCodeService（SDK + CLI）
+├── engine/schedulers/handlers/
+│   └── claude_code.py              # claude_code scheduler handler
+├── db/migrations/versions/
+│   └── 0039_seed_claude_code_builtin_tool.py  # 系统级 BuiltinTool seed
+└── interface/api.py                # test_builtin_tool 扩展
+
+apps/negentropy-ui/
+├── app/home-body.tsx               # @claude-code mention candidate 注入
+```
+
+## 4. 关键接口
+
+### 4.1 ClaudeCodeService
+
+```python
+class ClaudeCodeService:
+    @staticmethod
+    async def invoke(prompt, config, abort_event=None) -> ClaudeCodeResult
+    @staticmethod
+    async def test_connection(config) -> dict
+```
+
+### 4.2 invoke_claude_code（ADK FunctionTool）
+
+```python
+async def invoke_claude_code(
+    task: str,                      # 任务描述
+    working_directory: str | None,  # 工作目录
+    allowed_tools: str | None,      # 允许的工具（逗号分隔）
+    max_turns: int,                 # 最大迭代轮数
+    system_prompt: str | None,      # 自定义系统指令
+    tool_context: ToolContext,       # ADK 注入的上下文
+) -> dict[str, Any]                 # {status, summary, session_id, cost_usd, ...}
+```
+
+### 4.3 ClaudeCodeResult
+
+```python
+@dataclass
+class ClaudeCodeResult:
+    status: str                    # "success" | "error" | "timeout"
+    summary: str                   # 最终文本（≤2000字符）
+    session_id: str | None         # 会话 ID（可续接）
+    cost_usd: float = 0.0
+    turn_count: int = 0
+    error: str | None = None
+```
+
+## 5. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| Claude Code 长时间执行阻塞 ADK Agent | `timeout_seconds` 默认 300s，超时返回 error |
+| API Key 安全 | 从 VendorConfig 读取，注入 subprocess 环境 |
+| 进程泄漏 | `try/finally` 确保 `terminate` + `wait` |
+| SDK 不可用 | 自动降级为 CLI 子进程 |
+| 并发冲突 | 同一 cwd 串行执行 |
+
+## 6. 参考文献
+
+- [1] Anthropic, "Claude Code SDK," https://docs.anthropic.com/en/docs/claude-code/sdk, 2025.
+- [2] Anthropic, "Claude Code CLI Usage," https://docs.anthropic.com/en/docs/claude-code/cli-usage, 2025.
+- [3] Google, "ADK Custom Tools," https://adk.dev/tools-custom/, 2025.
+- [4] E. Gamma et al., *Design Patterns: Elements of Reusable Object-Oriented Software*, Addison-Wesley, 1994 — Adapter Pattern.


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：将本地 Claude Code CLI 接入 Negentropy 系统，使 ADK Agent（一核五翼）获得调用 Claude Code 完成复杂代码任务的能力
- 关联上下文/文档：[038-claude-code-integration](docs/concepts/038-claude-code-integration.md)

# 核心变更
- **ClaudeCodeService**（`engine/claude_code/service.py`）：封装 claude-code-sdk Python 包（优先）→ CLI 子进程（降级）双路径调用，支持流式输出、超时中断、进程清理
- **invoke_claude_code**（`agents/tools/claude_code.py`）：ADK FunctionTool，ActionFaculty 注册为工具，支持 tool call 参数覆盖全局配置 + 会话续接
- **Scheduler handler**（`handlers/claude_code.py`）：`@register_handler("claude_code")` 支持周期性调度，复用 ClaudeCodeService 保持单一事实源
- **BuiltinTool seed**（`0039`）：以 `owner_id='system'` / `visibility='PUBLIC'` / `is_system=true` 种子化到 `builtin_tools` 表，Interface / Tools 页全员可见
- **Studio @claude-code**（`home-body.tsx`）：注入 agent mention candidate，用户 @claude-code 提示 ADK Agent 自主决定是否调用 tool
- **连通性测试**（`interface/api.py`）：扩展 `test_builtin_tool` 端点支持 `tool_type == "claude_code"`
- 设计文档沉淀至 `docs/concepts/038-claude-code-integration.md`，知识索引同步更新

# 风险与回滚
- 主要风险：Claude Code 长时间执行阻塞 ADK Agent（缓解：`timeout_seconds=300` 默认上限 + `max_turns=20`）
- 回滚方式：`alembic downgrade 0038` 删除 seed 行；移除 `action.py` 注册即可禁用 tool

# 验证证据
- 单元测试：Ruff lint / format 全量通过（pre-commit hooks）
- 集成测试：Alembic upgrade 0039 成功 seed，ORM hydration 验证 JSONB 列均为 `object`、`visibility=PluginVisibility.PUBLIC`
- E2E/Workflow：Interface / Tools 页可见 Claude Code 卡片（系统内置徽章），config_schema 动态表单渲染

# 影响范围
- 前端：`home-body.tsx` mention 候选列表新增 claude_code 条目
- 后端：新增 `engine/claude_code/` 包、`agents/tools/claude_code.py`、`handlers/claude_code.py`、迁移 0039；修改 `action.py` / `api.py` / `handlers/__init__.py`
- GitHub Actions / 文档：新增 `docs/concepts/038-claude-code-integration.md`，更新 `knowledge-map.md`

# Next Best Action
- 上线后验证：Interface / Tools 页点击 Test Connection 确认 CLI 连通性
- 后续扩展：ContemplationFaculty 注册只读版 claude_code tool（禁用 Write/Edit）
- 会话续接：完善 `_find_last_session_id` 从 TaskExecution.metrics 提取 session_id