### PR TITLE
docs(README): 校真补缺 — 校准版本号失真与文档链接断裂

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-green?style=flat-square)](./LICENSE)
 [![uv](https://img.shields.io/badge/Package-uv-purple?style=flat-square&logo=uv&logoColor=white)](https://docs.astral.sh/uv/)
 [![Google ADK](https://img.shields.io/badge/Framework-Google%20ADK-orange?style=flat-square)](https://google.github.io/adk-docs/)
-[![Next.js 22](https://img.shields.io/badge/Frontend-Next.js%2022-black?style=flat-square&logo=next.js&logoColor=white)](https://nextjs.org/)
+[![Next.js 16](https://img.shields.io/badge/Frontend-Next.js%2016-black?style=flat-square&logo=next.js&logoColor=white)](https://nextjs.org/)
 
 </div>
 
@@ -88,7 +88,7 @@ graph TB
 | :------------------------------- | :------------------ | :----------------------- |
 | Python                           | 3.13+               | Backend Runtime          |
 | [uv](https://docs.astral.sh/uv/) | Latest              | Python Package Manager   |
-| Node.js                          | 22+                 | Frontend Runtime         |
+| Node.js                          | 20+                 | Frontend Runtime         |
 | [pnpm](https://pnpm.io/)         | Latest              | Frontend Package Manager |
 | PostgreSQL                       | 16+ (with pgvector) | Data Persistence         |
 
@@ -174,7 +174,7 @@ The **NegentropyEngine** refrains from executing atomic tasks directly; it exist
 ```mermaid
 graph TB
     subgraph Presentation["🖥️ Presentation Layer"]
-        UI["negentropy-ui<br/><i>Next.js 22 · React 19 · Tailwind</i>"]
+        UI["negentropy-ui<br/><i>Next.js 16 · React 19 · Tailwind</i>"]
         Wiki["negentropy-wiki<br/><i>Next.js</i>"]
     end
 
@@ -224,9 +224,9 @@ graph TB
 | [Knowledge System](docs/concepts/035-the-knowledge-base.md) | Detailed design and usage of the knowledge management module                                    |
 | [Memory System](docs/concepts/025-the-memory-system.md)     | Memory lifecycle, forgetting curves, and governance mechanics                                   |
 | [Knowledge Graph](docs/concepts/036-the-knowledge-graph.md) | Graph modeling and query implementation                                                         |
-| [QA Pipeline](./docs/qa-delivery-pipeline.md)               | Quality gates and release workflows                                                             |
-| [SSO Integration](./docs/sso.md)                            | Google OAuth authentication config                                                              |
-| [Engineering Changelog](./docs/engineering-changelog.md)    | Milestones and baseline mutation records                                                        |
+| [QA Pipeline](./docs/concepts/design/qa-delivery-pipeline.md)               | Quality gates and release workflows                                                             |
+| [SSO Integration](./docs/concepts/design/sso.md)                            | Google OAuth authentication config                                                              |
+| [Engineering Changelog](./docs/concepts/engineering-changelog.md)    | Milestones and baseline mutation records                                                        |
 | [AI Collaboration Protocol](./AGENTS.md)                    | Agent cooperation guidelines and engineering codebase                                           |
 
 </center>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：README.md 作为项目门面文档，经校真补缺流程核验 22 项陈述后，发现 5 处失真（校准率 22.7%），包括版本号标注与 `package.json` 实际依赖不一致、3 条文档导航链接路径偏移导致 404。

# 核心变更
- Next.js 版本 badge 及架构图从 "22" 校准为 "16"，与 `apps/negentropy-ui/package.json`（`next: "16.2.6"`）一致
- Node.js 最低版本从 "22+" 校准为 "20+"，与根 `package.json` `engines.node`（`">=20"`）对齐
- 修正 3 条文档导航链接：`qa-delivery-pipeline.md` → `docs/concepts/design/`、`sso.md` → `docs/concepts/design/`、`engineering-changelog.md` → `docs/concepts/`

# 风险与回滚
- 主要风险：纯文档变更，零运行时风险
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：不适用（纯文档）
- 集成测试：不适用
- E2E/Workflow：逐一 `ls` 验证修正后的 3 条路径均存在；`grep -n` 确认版本号全局一致
- 覆盖率/关键截图：核验 22 项，其余 17 项均与工程现状一致

# 影响范围
- 前端：无
- 后端：无
- GitHub Actions / 文档：README.md 版本徽章与导航链接

# Next Best Action
- 建议同步检查 `docs/i18n/zh-CN/README.md` 中文版本是否存在同类失真