### PR TITLE
fix(ADK): 修复 ADK 2.0 ApiServer 作用域 bug 导致启动失败

### DIFF
--- a/apps/negentropy/src/negentropy/cli.py
+++ b/apps/negentropy/src/negentropy/cli.py
@@ -32,6 +32,7 @@ import argparse
 import os
 import shutil
 import sys
+import traceback
 from pathlib import Path
 
 
@@ -170,6 +171,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             pass
         # 真实异常（导入失败、配置错误等）才打印
         print(f"错误: ADK 启动失败: {exc}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         return 1
 
 

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -301,10 +301,8 @@ def apply_adk_patches():
     # is called INSIDE get_fast_api_app (via services.py import by ADK agent loader),
     # meaning the current call already bypasses the wrapper. We must set sys.modules
     # eagerly here so the conditional import at lines 519-535 sees the None entry.
-    _saved_dev_server = sys.modules.get("google.adk.cli.dev_server")
-    if _saved_dev_server is not None:
-        sys.modules["google.adk.cli.dev_server"] = None  # type: ignore[assignment]
-        logger.debug("Set sys.modules['google.adk.cli.dev_server'] = None to force ApiServer fallback")
+    sys.modules["google.adk.cli.dev_server"] = None  # type: ignore[assignment]
+    logger.debug("Set sys.modules['google.adk.cli.dev_server'] = None to force ApiServer fallback")
 
     patched_items = []
 

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -292,6 +292,20 @@ def apply_adk_patches():
 
     logger.info("Monkey-patching ADK service factories to use negentropy configuration...")
 
+    # ADK 2.0 workaround (eager): fast_api.get_fast_api_app() has a scoping bug where
+    # ApiServer is conditionally imported inside `if web:` branches. When web=True
+    # and DevServer import succeeds, ApiServer is never assigned as a local variable,
+    # but setup_observer() references it as a type annotation, causing UnboundLocalError.
+    #
+    # The wrapper-based fix below (Patch #2) is insufficient because apply_adk_patches()
+    # is called INSIDE get_fast_api_app (via services.py import by ADK agent loader),
+    # meaning the current call already bypasses the wrapper. We must set sys.modules
+    # eagerly here so the conditional import at lines 519-535 sees the None entry.
+    _saved_dev_server = sys.modules.get("google.adk.cli.dev_server")
+    if _saved_dev_server is not None:
+        sys.modules["google.adk.cli.dev_server"] = None  # type: ignore[assignment]
+        logger.debug("Set sys.modules['google.adk.cli.dev_server'] = None to force ApiServer fallback")
+
     patched_items = []
 
     # Helper to clean factory names for display
@@ -578,13 +592,10 @@ def apply_adk_patches():
             if hasattr(mod, "create_artifact_service_from_options"):
                 mod.create_artifact_service_from_options = patched_create_artifact_service_from_options
 
-    # ADK 2.0 workaround: fast_api.get_fast_api_app() has a scoping bug where
-    # ApiServer is conditionally imported inside `if web:` branches. When web=True
-    # and DevServer import succeeds, the `from .api_server import ApiServer` in the
-    # except block is skipped. But nested function setup_observer() references
-    # ApiServer as a type annotation, causing UnboundLocalError.
-    # Fix: wrap get_fast_api_app to ensure DevServer import fails, forcing the
-    # ApiServer fallback path which always imports ApiServer as a local variable.
+    # ADK 2.0 workaround (wrapper): safety net for subsequent calls to get_fast_api_app.
+    # The primary fix is the eager sys.modules override above. This wrapper protects
+    # any future calls that might bypass the eager fix (e.g., if services.py is imported
+    # before get_fast_api_app is first called).
     try:
         from google.adk.cli import fast_api as _fast_api_mod
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：升级 google-adk 至 2.0.0 GA 后，`scripts/cli.sh start` 启动 backend 失败，报错 `cannot access local variable 'ApiServer' where it is not associated with a value`
- 关联上下文：ADK 2.0 的 `fast_api.get_fast_api_app()` 函数体内，`ApiServer` 仅在 `if web:` 的条件分支中作为局部变量导入，但 `setup_observer()` 的类型注解在函数定义时求值引用了 `ApiServer`，当 `DevServer` 导入成功时 `ApiServer` 从未被赋值，触发 `UnboundLocalError`

# 核心变更
- **`bootstrap.py`**：将 `sys.modules["google.adk.cli.dev_server"] = None` 从 wrapper 函数（Patch #2）提升到 `apply_adk_patches()` 开头直接执行。根因是 `apply_adk_patches()` 通过 `services.py` 在 `get_fast_api_app()` 函数体内部被触发（ADK agent loader 阶段），此时 wrapper 从未被调用，sys.modules trick 不生效。现有 wrapper 保留作为后续调用的安全网
- **`cli.py`**：在 `_cmd_serve` 异常处理中增加 `traceback.print_exc()` 输出，便于未来快速定位类似启动失败问题

# 风险与回滚
- 主要风险：`dev_server` 模块被全局屏蔽后，ADK 的 DevServer（开发调试端点）不可用，回退到 ApiServer（仅生产端点）。对本地开发体验无实质影响，因 ADK Web UI 端点由 ApiServer 提供
- 回滚方式：`git revert`

# 验证证据
- 单元测试：N/A（monkey-patch 层面变更，由运行时行为验证）
- 集成测试：`scripts/cli.sh start` 完整启动流水线
- E2E/Workflow：本地 `scripts/cli.sh start` 验证 backend 健康检查通过
- 覆盖率/关键截图：pre-commit hooks（ruff lint + ruff format）全部通过

# 影响范围
- 前端：无影响
- 后端：`negentropy/engine/bootstrap.py`、`negentropy/cli.py`
- GitHub Actions / 文档：无影响

# Next Best Action
- 建议在 ADK 上游仓库提 Issue 报告 `fast_api.py` 的 `ApiServer` 变量作用域 bug，推动官方修复（将类型注解改为字符串形式 `"ApiServer"`）