### PR TITLE
feat(dashboard): Execution Timeline 卡片新增分页、状态筛选与搜索功能

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/ExecutionTimeline.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/ExecutionTimeline.tsx
@@ -1,8 +1,21 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { TaskExecutionDTO } from "../_lib/types";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+
+import type { ExecutionStatus, TaskExecutionDTO } from "../_lib/types";
+
+const PAGE_SIZE = 8;
+
+const STATUS_OPTIONS: Array<{ value: ExecutionStatus | "all"; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "ok", label: "OK" },
+  { value: "failed", label: "Failed" },
+  { value: "running", label: "Running" },
+  { value: "cancelled", label: "Cancelled" },
+  { value: "timeout", label: "Timeout" },
+];
 
 interface ExecutionTimelineProps {
   executions: TaskExecutionDTO[];
@@ -45,12 +58,44 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
   const listRef = useRef<HTMLDivElement | null>(null);
   const firstIdRef = useRef<string | null>(null);
 
-  // 高亮新插入的头部条目 800ms
+  const [statusFilter, setStatusFilter] = useState<ExecutionStatus | "all">("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // --- Client-side filter pipeline ---
+  const filtered = useMemo(() => {
+    let result = executions;
+    if (statusFilter !== "all") {
+      result = result.filter((e) => e.status === statusFilter);
+    }
+    const q = searchQuery.trim().toLowerCase();
+    if (q) {
+      result = result.filter((e) => {
+        const fields = [e.task_key, e.output_summary, e.handler_kind].filter(Boolean);
+        return fields.some((f) => f!.toLowerCase().includes(q));
+      });
+    }
+    return result;
+  }, [executions, statusFilter, searchQuery]);
+
+  const totalCount = executions.length;
+  const filteredCount = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(filteredCount / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paged = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  // --- SSE: auto-jump to page 1 when new execution arrives ---
   useEffect(() => {
     if (!executions.length) return;
     const newest = executions[0];
     if (firstIdRef.current === newest.id) return;
     firstIdRef.current = newest.id;
+    setCurrentPage(1);
+  }, [executions]);
+
+  // --- Flash highlight on the first item of page 1 ---
+  useEffect(() => {
+    if (safePage !== 1 || !paged.length) return;
     const node = listRef.current?.firstElementChild as HTMLElement | undefined;
     if (!node) return;
     node.classList.add("ring-2", "ring-indigo-400");
@@ -58,25 +103,69 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
       node.classList.remove("ring-2", "ring-indigo-400");
     }, 800);
     return () => window.clearTimeout(id);
-  }, [executions]);
+  }, [safePage, paged]);
 
   return (
     <div className="rounded-lg border border-border bg-card shadow-sm">
-      <div className="border-b border-border px-3 py-2 text-[11px] uppercase tracking-wider text-muted">
-        Execution Timeline
+      {/* Header */}
+      <div className="border-b border-border px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span className="shrink-0 text-[11px] uppercase tracking-wider text-muted">
+            Execution Timeline
+          </span>
+          {/* Status filter pills */}
+          <div className="flex items-center gap-0.5 overflow-x-auto rounded-full bg-muted/50 px-1 py-0.5">
+            {STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => { setStatusFilter(opt.value); setCurrentPage(1); }}
+                className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold transition-colors ${
+                  statusFilter === opt.value
+                    ? "bg-foreground text-background"
+                    : "text-muted hover:text-foreground"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          {/* Search input */}
+          <div className="relative ml-auto min-w-0 max-w-[140px] flex-1">
+            <Search className="pointer-events-none absolute left-1.5 top-1/2 h-3 w-3 -translate-y-1/2 text-muted" />
+            <input
+              value={searchQuery}
+              onChange={(e) => { setSearchQuery(e.target.value); setCurrentPage(1); }}
+              placeholder="Search..."
+              className="w-full rounded-md border border-border bg-background py-0.5 pl-6 pr-2 text-[11px] text-foreground placeholder:text-muted/50 focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+          {/* Count */}
+          <span className="shrink-0 text-[10px] tabular-nums text-muted">
+            {filteredCount === totalCount ? `${totalCount}` : `${filteredCount}/${totalCount}`}
+          </span>
+        </div>
       </div>
-      <div ref={listRef} className="max-h-[480px] overflow-auto">
-        {executions.length === 0 ? (
-          <div className="px-3 py-6 text-center text-xs text-muted">No executions yet.</div>
+
+      {/* List */}
+      <div ref={listRef}>
+        {paged.length === 0 ? (
+          <div className="px-3 py-6 text-center text-xs text-muted">
+            {filteredCount === 0 && totalCount > 0
+              ? "No executions match current filters."
+              : "No executions yet."}
+          </div>
         ) : (
           <ul className="divide-y divide-border">
-            {executions.map((e) => (
+            {paged.map((e) => (
               <li key={e.id} className="px-3 py-2 transition-shadow">
                 <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
                     <span className="font-mono text-[11px] text-muted">{formatTime(e.started_at)}</span>
                     <StatusBadge status={e.status} />
-                    <span className="truncate text-xs font-medium text-foreground">{e.task_key ?? e.task_id}</span>
+                    <span className="truncate text-xs font-medium text-foreground">
+                      {e.task_key ?? e.task_id}
+                    </span>
                   </div>
                   <div className="flex items-center gap-2 text-[11px] text-muted">
                     {e.duration_ms !== null ? <span>{e.duration_ms}ms</span> : null}
@@ -86,12 +175,41 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
                 {e.output_summary ? (
                   <div className="mt-1 truncate text-[11px] text-muted">{e.output_summary}</div>
                 ) : null}
-                {e.error ? <div className="mt-1 text-[11px] text-red-600 dark:text-red-400">{e.error}</div> : null}
+                {e.error ? (
+                  <div className="mt-1 text-[11px] text-red-600 dark:text-red-400">{e.error}</div>
+                ) : null}
               </li>
             ))}
           </ul>
         )}
       </div>
+
+      {/* Pagination */}
+      {filteredCount > PAGE_SIZE && (
+        <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
+          <button
+            type="button"
+            disabled={safePage <= 1}
+            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            aria-label="上一页"
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </button>
+          <span className="text-[10px] font-medium text-muted">
+            {safePage} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={safePage >= totalPages}
+            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+            aria-label="下一页"
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/ExecutionTimeline.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/ExecutionTimeline.tsx
@@ -94,8 +94,10 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
   }, [executions]);
 
   // --- Flash highlight on the first item of page 1 ---
+  const pagedLen = paged.length;
+  const firstPagedId = paged[0]?.id;
   useEffect(() => {
-    if (safePage !== 1 || !paged.length) return;
+    if (safePage !== 1 || !pagedLen) return;
     const node = listRef.current?.firstElementChild as HTMLElement | undefined;
     if (!node) return;
     node.classList.add("ring-2", "ring-indigo-400");
@@ -103,7 +105,7 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
       node.classList.remove("ring-2", "ring-indigo-400");
     }, 800);
     return () => window.clearTimeout(id);
-  }, [safePage, paged]);
+  }, [safePage, pagedLen, firstPagedId]);
 
   return (
     <div className="rounded-lg border border-border bg-card shadow-sm">
@@ -190,7 +192,7 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
           <button
             type="button"
             disabled={safePage <= 1}
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            onClick={() => setCurrentPage(Math.max(1, safePage - 1))}
             aria-label="上一页"
             className="inline-flex h-5 w-5 items-center justify-center rounded text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
           >
@@ -202,7 +204,7 @@ export function ExecutionTimeline({ executions }: ExecutionTimelineProps) {
           <button
             type="button"
             disabled={safePage >= totalPages}
-            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+            onClick={() => setCurrentPage(Math.min(totalPages, safePage + 1))}
             aria-label="下一页"
             className="inline-flex h-5 w-5 items-center justify-center rounded text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
           >


### PR DESCRIPTION
# 背景
- Dashboard Execution Timeline 卡片将所有 execution 条目（最多 200 条）以滚动列表展示，缺少分页浏览、分类筛选和搜索能力，条目多时信息密度过高、难以定位目标记录
- 关联上下文/Issue/文档：Dashboard 页面交互优化需求

# 核心变更
- 仅修改 `ExecutionTimeline.tsx`（+131/-13），所有新逻辑封装在组件内部，不改父级数据 hook、API client 或后端
- **分页**：客户端分页 `PAGE_SIZE=8`，底部 prev/next 导航 + 页码指示器，参考 `SessionList.tsx` 的分页模式
- **状态筛选**：标题栏新增药丸按钮组（All/OK/Failed/Running/Cancelled/Timeout），选中态 `bg-foreground text-background`
- **搜索**：标题栏新增紧凑搜索框（max-w 140px），对 `task_key`、`output_summary`、`handler_kind` 做大小写不敏感子串匹配
- **SSE 兼容**：新 execution 推送时自动跳回第 1 页并保留闪烁高亮；状态原地更新（running→ok）不触发跳页
- 筛选/搜索变更时在事件处理器中直接重置分页（避免 ESLint `react-hooks/set-state-in-effect` 告警）

# 风险与回滚
- 主要风险：无。变更限于单个前端组件，组件接口（`executions` prop）不变，不影响 SSE 数据流和 Dashboard 其他模块
- 回滚方式：`git revert` 该 commit

# 验证证据
- 单元测试：无新增（纯 UI 交互变更）
- 集成测试：N/A
- E2E/Workflow：ESLint（`pnpm --filter negentropy-ui lint`）零错误零警告通过；TypeScript 类型检查通过
- 覆盖率/关键截图：待 dev server 启动后浏览器实机验证

# 影响范围
- 前端：`ExecutionTimeline.tsx` 组件（Dashboard 页面右侧 5/12 列卡片）
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action
- 启动 dev server 在浏览器中实机验证分页、筛选、搜索的交互体验