### PR TITLE
feat(dashboard): Activity 面板重构为右栏抽屉式 UI，新增分页与触发按钮

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityBadgeButton.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityBadgeButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Activity } from "lucide-react";
+
+interface ActivityBadgeButtonProps {
+  count: number;
+  onClick: () => void;
+}
+
+export function ActivityBadgeButton({ count, onClick }: ActivityBadgeButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative inline-flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-background transition-colors hover:bg-muted/50"
+      aria-label={`Activity log (${count} entries)`}
+    >
+      <Activity className="h-4 w-4 text-muted" />
+      {count > 0 ? (
+        <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-foreground px-1 text-[9px] font-bold text-background">
+          {count > 99 ? "99+" : count}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityDrawer.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityDrawer.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+
+import { useActivityLog } from "@/hooks/useActivityLog";
+import { outlineButtonClassName } from "@/components/ui/button-styles";
+
+import {
+  LEVEL_OPTIONS,
+  LEVEL_DOT,
+  LEVEL_BADGE,
+  formatTimestamp,
+} from "./ActivityLogPanel";
+
+const PAGE_SIZE = 12;
+
+interface ActivityDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ActivityDrawer({ open, onClose }: ActivityDrawerProps) {
+  const { entries, levelFilter, setLevelFilter, reload, clear, totalCount } =
+    useActivityLog();
+
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const handleLevelChange = useCallback(
+    (level: typeof levelFilter) => {
+      setLevelFilter(level);
+      setCurrentPage(1);
+    },
+    [setLevelFilter],
+  );
+
+  const handleClose = useCallback(() => {
+    setCurrentPage(1);
+    onClose();
+  }, [onClose]);
+
+  if (!open) return null;
+
+  const totalPages = Math.max(1, Math.ceil(entries.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const pagedEntries = entries.slice(
+    (safePage - 1) * PAGE_SIZE,
+    safePage * PAGE_SIZE,
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end"
+      role="dialog"
+      aria-modal="true"
+    >
+      <button
+        type="button"
+        onClick={handleClose}
+        aria-label="Close drawer"
+        className="absolute inset-0 bg-black/30 backdrop-blur-[2px]"
+      />
+      <aside className="relative z-10 flex h-full w-full max-w-[480px] flex-col border-l border-border bg-card shadow-xl">
+        {/* Header */}
+        <header className="border-b border-border px-4 py-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-foreground">
+                Activity
+              </span>
+              <span className="rounded-full bg-muted/50 px-2 py-0.5 text-[10px] font-semibold text-muted">
+                {totalCount}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted transition-colors hover:bg-muted/50 hover:text-foreground"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          {/* Level filter pills */}
+          <nav className="mt-2 flex items-center gap-1 rounded-full bg-muted/50 p-0.5">
+            {LEVEL_OPTIONS.map((opt) => (
+              <button
+                key={opt.label}
+                className={`rounded-full px-2.5 py-0.5 text-[11px] font-semibold transition-colors ${
+                  levelFilter === opt.value
+                    ? "bg-foreground text-background shadow-sm"
+                    : "text-muted hover:text-foreground"
+                }`}
+                onClick={() => handleLevelChange(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </nav>
+
+          {/* Actions */}
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <span className="text-[11px] text-muted">
+              {entries.length}
+              {levelFilter ? ` / ${totalCount}` : ""} entries
+            </span>
+            <button
+              className={outlineButtonClassName(
+                "neutral",
+                "rounded-md px-2 py-1 text-[11px] font-semibold",
+              )}
+              onClick={reload}
+            >
+              Refresh
+            </button>
+            <button
+              className={outlineButtonClassName(
+                "danger",
+                "rounded-md px-2 py-1 text-[11px] font-semibold",
+              )}
+              onClick={clear}
+            >
+              Clear All
+            </button>
+          </div>
+        </header>
+
+        {/* Body */}
+        <div className="flex-1 overflow-auto px-4 py-3">
+          {pagedEntries.length ? (
+            <ul className="space-y-2">
+              {pagedEntries.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="flex items-start gap-3 rounded-lg border border-border bg-background p-3 shadow-sm"
+                >
+                  <span
+                    className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${LEVEL_DOT[entry.level]}`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${LEVEL_BADGE[entry.level]}`}
+                      >
+                        {entry.level}
+                      </span>
+                      <span className="text-[11px] text-muted">
+                        {formatTimestamp(entry.timestamp)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs font-medium text-foreground">
+                      {entry.message}
+                    </p>
+                    {entry.description ? (
+                      <p className="mt-0.5 text-[11px] text-muted">
+                        {entry.description}
+                      </p>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="px-3 py-6 text-center text-xs text-muted">
+              No activity recorded yet. Toast notifications will appear here as
+              they occur across the platform.
+            </div>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {entries.length > PAGE_SIZE ? (
+          <div className="flex items-center justify-between border-t border-border px-4 py-1.5">
+            <button
+              type="button"
+              disabled={safePage <= 1}
+              onClick={() =>
+                setCurrentPage(Math.max(1, safePage - 1))
+              }
+              aria-label="Previous page"
+              className="inline-flex h-5 w-5 items-center justify-center rounded text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </button>
+            <span className="text-[10px] font-medium text-muted">
+              {safePage} / {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={safePage >= totalPages}
+              onClick={() =>
+                setCurrentPage(Math.min(totalPages, safePage + 1))
+              }
+              aria-label="Next page"
+              className="inline-flex h-5 w-5 items-center justify-center rounded text-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ) : null}
+      </aside>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityLogPanel.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityLogPanel.tsx
@@ -1,9 +1,13 @@
-"use client";
+/**
+ * Activity Log 共享 UI 常量与工具函数。
+ *
+ * 原 ActivityLogPanel 内联面板已重构为右侧抽屉（ActivityDrawer），
+ * 本文件仅保留共享常量供 ActivityDrawer 及其他消费方复用。
+ */
 
-import { useActivityLog, type ActivityLevel } from "@/hooks/useActivityLog";
-import { outlineButtonClassName } from "@/components/ui/button-styles";
+import type { ActivityLevel } from "@/hooks/useActivityLog";
 
-const LEVEL_OPTIONS: { value: ActivityLevel | null; label: string }[] = [
+export const LEVEL_OPTIONS: { value: ActivityLevel | null; label: string }[] = [
   { value: null, label: "All" },
   { value: "success", label: "Success" },
   { value: "error", label: "Error" },
@@ -11,14 +15,14 @@ const LEVEL_OPTIONS: { value: ActivityLevel | null; label: string }[] = [
   { value: "warning", label: "Warning" },
 ];
 
-const LEVEL_DOT: Record<ActivityLevel, string> = {
+export const LEVEL_DOT: Record<ActivityLevel, string> = {
   success: "bg-emerald-500",
   error: "bg-rose-500",
   info: "bg-blue-500",
   warning: "bg-amber-500",
 };
 
-const LEVEL_BADGE: Record<ActivityLevel, string> = {
+export const LEVEL_BADGE: Record<ActivityLevel, string> = {
   success:
     "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
   error:
@@ -28,104 +32,6 @@ const LEVEL_BADGE: Record<ActivityLevel, string> = {
     "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
 };
 
-function formatTimestamp(ts: number): string {
+export function formatTimestamp(ts: number): string {
   return new Date(ts).toLocaleString();
-}
-
-export function ActivityLogPanel() {
-  const { entries, levelFilter, setLevelFilter, reload, clear, totalCount } =
-    useActivityLog();
-
-  return (
-    <div
-      data-testid="activity-log-panel"
-      className="rounded-lg border border-border bg-card shadow-sm"
-    >
-      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
-        <div className="text-[11px] uppercase tracking-wider text-muted">
-          Activity
-        </div>
-        <nav className="ml-2 flex items-center gap-1 rounded-full bg-muted/50 p-0.5">
-          {LEVEL_OPTIONS.map((opt) => (
-            <button
-              key={opt.label}
-              className={`rounded-full px-2.5 py-0.5 text-[11px] font-semibold transition-colors ${
-                levelFilter === opt.value
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-muted hover:text-foreground"
-              }`}
-              onClick={() => setLevelFilter(opt.value)}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </nav>
-        <div className="ml-auto flex items-center gap-2">
-          <span className="text-[11px] text-muted">
-            {entries.length}
-            {levelFilter ? ` / ${totalCount}` : ""} entries
-          </span>
-          <button
-            className={outlineButtonClassName(
-              "neutral",
-              "rounded-md px-2 py-1 text-[11px] font-semibold",
-            )}
-            onClick={reload}
-          >
-            Refresh
-          </button>
-          <button
-            className={outlineButtonClassName(
-              "danger",
-              "rounded-md px-2 py-1 text-[11px] font-semibold",
-            )}
-            onClick={clear}
-          >
-            Clear All
-          </button>
-        </div>
-      </div>
-      <div className="max-h-[480px] overflow-auto p-3">
-        {entries.length ? (
-          <ul className="space-y-2">
-            {entries.map((entry) => (
-              <li
-                key={entry.id}
-                className="flex items-start gap-3 rounded-lg border border-border bg-background p-3 shadow-sm"
-              >
-                <span
-                  className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${LEVEL_DOT[entry.level]}`}
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${LEVEL_BADGE[entry.level]}`}
-                    >
-                      {entry.level}
-                    </span>
-                    <span className="text-[11px] text-muted">
-                      {formatTimestamp(entry.timestamp)}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-xs font-medium text-foreground">
-                    {entry.message}
-                  </p>
-                  {entry.description ? (
-                    <p className="mt-0.5 text-[11px] text-muted">
-                      {entry.description}
-                    </p>
-                  ) : null}
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div className="px-3 py-6 text-center text-xs text-muted">
-            No activity recorded yet. Toast notifications will appear here as
-            they occur across the platform.
-          </div>
-        )}
-      </div>
-    </div>
-  );
 }

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/DashboardHeaderStrip.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/DashboardHeaderStrip.tsx
@@ -3,6 +3,7 @@
 import { MCP_HUB_LABEL } from "@/app/interface/copy";
 import type { MemoryDashboard } from "@/features/memory";
 
+import { ActivityBadgeButton } from "./ActivityBadgeButton";
 import { MetricCell } from "./MetricCell";
 import type { KpiResponse } from "../_lib/types";
 
@@ -37,6 +38,8 @@ interface DashboardHeaderStripProps {
   interfaceStats: Stats | null;
   interfaceLoading: boolean;
   isAdmin: boolean;
+  activityCount: number;
+  onOpenActivity: () => void;
 }
 
 /* ---------- Group wrapper ---------- */
@@ -62,6 +65,8 @@ export function DashboardHeaderStrip({
   interfaceStats,
   interfaceLoading,
   isAdmin,
+  activityCount,
+  onOpenActivity,
 }: DashboardHeaderStripProps) {
   const hasAlerts =
     memoryDashboard &&
@@ -227,6 +232,11 @@ export function DashboardHeaderStrip({
             href="/interface/tools"
           />
         </CellGroup>
+
+        {/* Activity trigger */}
+        <div className="flex shrink-0 items-center md:ml-2">
+          <ActivityBadgeButton count={activityCount} onClick={onOpenActivity} />
+        </div>
       </div>
     </div>
   );

--- a/apps/negentropy-ui/app/(home)/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/page.tsx
@@ -10,8 +10,9 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useAuth } from "@/components/providers/AuthProvider";
 import { fetchMemoryDashboard, type MemoryDashboard } from "@/features/memory";
+import { useActivityLog } from "@/hooks/useActivityLog";
 
-import { ActivityLogPanel } from "./_components/ActivityLogPanel";
+import { ActivityDrawer } from "./_components/ActivityDrawer";
 import { DashboardHeaderStrip } from "./_components/DashboardHeaderStrip";
 import { DimensionCharts } from "./_components/DimensionCharts";
 import { ExecutionTimeline } from "./_components/ExecutionTimeline";
@@ -58,6 +59,8 @@ interface InterfaceStats {
 export default function DashboardPage() {
   const [filters, setFilters] = useState<DashboardFilters>(INITIAL_FILTERS);
   const [selectedTask, setSelectedTask] = useState<ScheduledTaskDTO | null>(null);
+  const [activityOpen, setActivityOpen] = useState(false);
+  const { totalCount: activityCount } = useActivityLog();
 
   const {
     kpis,
@@ -153,6 +156,8 @@ export default function DashboardPage() {
         interfaceStats={interfaceStats}
         interfaceLoading={interfaceLoading}
         isAdmin={isAdmin}
+        activityCount={activityCount}
+        onOpenActivity={() => setActivityOpen(true)}
       />
 
       {/* Expandable Memory detail panel */}
@@ -188,10 +193,8 @@ export default function DashboardPage() {
           <ExecutionTimeline executions={executions} />
         </div>
       </div>
-      <div className="mt-3">
-        <ActivityLogPanel />
-      </div>
       <TaskDetailDrawer task={selectedTask} onClose={handleClose} onTaskChanged={refresh} />
+      <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Dashboard 页面底部的 Activity 面板以内联卡片形式展示，占用页面纵向空间且不支持分页，需要改造为右侧抽屉式 UI
- 关联上下文/Issue/文档：Dashboard 交互优化

# 核心变更
- 将底部内联 `ActivityLogPanel` 重构为右侧抽屉组件 `ActivityDrawer`（z-50，复用 TaskDetailDrawer 模式）
- 新建 `ActivityBadgeButton` 触发按钮组件（Activity 图标 + 计数 badge），嵌入 `DashboardHeaderStrip` 右上角
- 抽屉内支持 Level 过滤（All/Success/Error/Info/Warning）、12 条/页分页、Refresh/Clear 操作
- 原 `ActivityLogPanel.tsx` 保留为共享常量模块（LEVEL_OPTIONS/LEVEL_DOT/LEVEL_BADGE/formatTimestamp）

# 风险与回滚
- 主要风险：两个独立 `useActivityLog` 实例（页面 badge + 抽屉列表）均从 localStorage 读取，天然一致
- 回滚方式：`git revert` 单个 commit

# 验证证据
- 单元测试：无新增（UI 组件改动）
- 集成测试：TypeScript 类型检查通过，ESLint 所有规则通过（含 react-hooks/set-state-in-effect）
- E2E/Workflow：待浏览器实机验证
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`negentropy-ui` Dashboard 页面 5 个文件（2 新建 + 3 修改）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证抽屉交互（打开/关闭、Level 过滤、分页、深色模式）