### PR TITLE
fix(knowledge-graph): 修复可视化选项卡选中时文字重影问题

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -532,7 +532,7 @@ export default function KnowledgeGraphPage() {
                   <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700">
                     <button
                       onClick={() => setViewTab("graph")}
-                      className={`px-3 py-1 text-xs font-medium ${
+                      className={`px-3 py-1 text-xs font-medium outline-hidden transition-colors ${
                         viewTab === "graph"
                           ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                           : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
@@ -542,7 +542,7 @@ export default function KnowledgeGraphPage() {
                     </button>
                     <button
                       onClick={() => setViewTab("entities")}
-                      className={`px-3 py-1 text-xs font-medium ${
+                      className={`px-3 py-1 text-xs font-medium outline-hidden transition-colors ${
                         viewTab === "entities"
                           ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                           : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
@@ -556,7 +556,7 @@ export default function KnowledgeGraphPage() {
                       <button
                         onClick={() => setRenderer("sigma")}
                         title="Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）"
-                        className={`px-2 py-1 font-medium ${
+                        className={`px-2 py-1 font-medium outline-hidden transition-colors ${
                           renderer === "sigma"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
@@ -567,7 +567,7 @@ export default function KnowledgeGraphPage() {
                       <button
                         onClick={() => setRenderer("3d")}
                         title="3D WebGL（three.js + d3-force-3d，支持三维旋转）"
-                        className={`px-2 py-1 font-medium border-x border-zinc-200 dark:border-zinc-700 ${
+                        className={`px-2 py-1 font-medium outline-hidden transition-colors border-x border-zinc-200 dark:border-zinc-700 ${
                           renderer === "3d"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
@@ -578,7 +578,7 @@ export default function KnowledgeGraphPage() {
                       <button
                         onClick={() => setRenderer("d3")}
                         title="d3-force（Phase 1 兼容回退）"
-                        className={`px-2 py-1 font-medium border-x border-zinc-200 dark:border-zinc-700 ${
+                        className={`px-2 py-1 font-medium outline-hidden transition-colors border-x border-zinc-200 dark:border-zinc-700 ${
                           renderer === "d3"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
@@ -589,7 +589,7 @@ export default function KnowledgeGraphPage() {
                       <button
                         onClick={() => setRenderer("force-graph")}
                         title="react-force-graph-2d（粒子流动效果，视觉表现力强）"
-                        className={`px-2 py-1 font-medium border-x border-zinc-200 dark:border-zinc-700 ${
+                        className={`px-2 py-1 font-medium outline-hidden transition-colors border-x border-zinc-200 dark:border-zinc-700 ${
                           renderer === "force-graph"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"
@@ -600,7 +600,7 @@ export default function KnowledgeGraphPage() {
                       <button
                         onClick={() => setRenderer("cytoscape")}
                         title="Cytoscape.js + fCoSE 布局（Phase 4 历史默认）"
-                        className={`px-2 py-1 font-medium ${
+                        className={`px-2 py-1 font-medium outline-hidden transition-colors ${
                           renderer === "cytoscape"
                             ? "bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900"
                             : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700"


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：知识图谱页面可视化选项卡在点击选中时，浏览器默认 focus outline 导致文字出现重影/双影视觉效果。
- 关联上下文/Issue/文档：Knowledge Graph 可视化工具栏交互体验优化。

# 核心变更
- 为工具栏全部 7 个选项卡按钮（可视化/实体列表切换 + Sigma/3D/d3-force/Force Graph/Cytoscape 渲染器切换）统一添加 `outline-hidden` 消除浏览器默认 outline 引起的重影，并添加 `transition-colors` 使选中态切换更平滑。

# 风险与回滚
- 主要风险：`outline-hidden` 移除了默认 focus outline，键盘用户失去视觉焦点指示。但项目中共有 48 处同类用法（36 个文件），属既定模式，不构成新风险。
- 回滚方式：`git revert` 单个 commit 即可。

# 验证证据
- 单元测试：无（纯 CSS 类变更）
- 集成测试：无
- E2E/Workflow：浏览器实机验证，选中选项卡时文字重影消失，切换过渡平滑
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：`apps/negentropy-ui/app/knowledge/graph/page.tsx`（1 文件，7 处按钮样式变更）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 考虑为所有使用 `outline-hidden` 的交互元素统一补充 `focus-visible:ring-2` 样式，系统性解决键盘无障碍焦点指示问题。