### PR TITLE
fix(knowledge): URL 文档名称显示为页面标题而非 URL slug

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -991,7 +991,11 @@ class KnowledgeService:
                 content=markdown_bytes,
                 filename=raw_name,
                 content_type="text/markdown",
-                metadata={"source_type": "url", "origin_url": url},
+                metadata={
+                    "source_type": "url",
+                    "origin_url": url,
+                    "title": extraction_result.metadata.get("title"),
+                },
                 created_by=user_id,
             )
             await storage_service.save_markdown_content(
@@ -1449,6 +1453,17 @@ class KnowledgeService:
                 extracted=extraction_result,
                 tracker=tracker,
             )
+
+            # 回填页面标题到文档 metadata（首次同步或历史数据补齐）
+            extraction_title = extraction_result.metadata.get("title")
+            if extraction_title:
+                from negentropy.storage.service import DocumentStorageService
+
+                await DocumentStorageService().update_document_metadata(
+                    document_id=document_id,
+                    metadata_patch={"title": extraction_title},
+                )
+
             await tracker.complete_stage(
                 "markdown_store",
                 {

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -1457,12 +1457,15 @@ class KnowledgeService:
             # 回填页面标题到文档 metadata（首次同步或历史数据补齐）
             extraction_title = extraction_result.metadata.get("title")
             if extraction_title:
-                from negentropy.storage.service import DocumentStorageService
+                try:
+                    from negentropy.storage.service import DocumentStorageService
 
-                await DocumentStorageService().update_document_metadata(
-                    document_id=document_id,
-                    metadata_patch={"title": extraction_title},
-                )
+                    await DocumentStorageService().update_document_metadata(
+                        document_id=document_id,
+                        metadata_patch={"title": extraction_title},
+                    )
+                except Exception:
+                    logger.warning("Failed to backfill title for document %s", document_id, exc_info=True)
 
             await tracker.complete_stage(
                 "markdown_store",


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：通过 `parse_webpage_to_markdown` 转换得到的 URL 文档，在 Knowledge / Documents 页面及 Wiki 中显示名称为 URL slug（如 `effective-harnesses-for-long-running-agents.md`），而非网页原始标题（如 "Effective harnesses for long-running agents"）
- 根因：Perceives 转换器已正确提取 `metadata["title"]`，但 Service 层创建文档记录时硬编码 `metadata={"source_type": "url", "origin_url": url}`，丢弃了提取结果中的 title，导致 Wiki 同步降级使用 `original_filename`（URL slug）

# 核心变更
- `execute_ingest_url_document_pipeline`（~L994）：新建 URL 文档时，将 `extraction_result.metadata.get("title")` 写入文档 metadata
- `execute_sync_document_pipeline`（~L1453）：同步刷新已有文档时，通过 `update_document_metadata` 回填 title，覆盖历史数据

# 风险与回滚
- 主要风险：`metadata.get("title")` 可能为 `None`（如纯 API 响应无标题），此时 wiki_service 已有降级逻辑回退到 `original_filename`，行为不变
- 回滚方式：还原 service.py 的两处改动即可

# 验证证据
- 单元测试：已有 wiki_service 的 entry_title 降级逻辑覆盖
- 集成测试：新增 URL 文档后检查 `knowledge_documents.metadata_` 包含 `"title"` 键；同步已有 URL 文档后 title 被回填
- E2E/Workflow：Wiki 同步后 `entry_title` 显示为页面标题而非 slug

# 影响范围
- 前端：无代码变更，Wiki 导航树和文档列表自动显示正确标题
- 后端：`service.py` 两处改动，影响 URL 文档创建与同步两个流程
- GitHub Actions / 文档：无

# Next Best Action
- 对已有 URL 文档执行「同步文档」操作以补齐 title，然后触发 Wiki 重同步即可修正显示

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)