### PR TITLE
fix(perceives): PDF 转 Markdown 标题层级推断、去重与噪声过滤

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
@@ -131,8 +131,6 @@ def _infer_heading_level_from_text(text: str) -> Optional[int]:
     Returns:
         heading_level (1-6) 或 None（无法推断时）。
     """
-    import re
-
     # 匹配开头的编号模式：数字(.数字)* 后跟可选点号和空格
     # 支持 "1 Title"、"2. Title"、"2.1 Title"、"3.1.1 Title"
     m = re.match(r"^(\d+(?:\.\d+)*)\.?\s", text)
@@ -995,18 +993,16 @@ class DoclingEngine:
                     is_noise_title = False
                     if len(stripped) < 60:
                         # 纯数字+空格+单词的短行且无实质标题内容
-                        import re as _re
-
-                        if _re.match(r"^[\d\s\†\*\‡\§\¶]+$", stripped):
+                        if re.match(r"^[\d\s\†\*\‡\§\¶]+$", stripped):
                             is_noise_title = True
                         # 机构编号行："1 SJTU 2 SII 3 GAIR"
-                        elif _re.match(r"^(?:\d+\s+\S+\s*){2,}$", stripped):
+                        elif re.match(r"^(?:\d+\s+\S+\s*){2,}$", stripped):
                             is_noise_title = True
                         # 脚注行："0 † Corresponding author"
                         elif "†" in stripped or "‡" in stripped or "§" in stripped:
                             is_noise_title = True
                         # URL 行："1 https://..."
-                        elif _re.match(r"^\d+\s+https?://", stripped):
+                        elif re.match(r"^\d+\s+https?://", stripped):
                             is_noise_title = True
                     if is_noise_title:
                         continue
@@ -1032,9 +1028,7 @@ class DoclingEngine:
                 # 特征：包含连续 3+ 个点号且以数字开头（如
                 # "2 Theoretical Framework 4 2.1 Formal Definition... 4"）
                 if label in ("title", "section_header") and "..." in text:
-                    import re as _re
-
-                    if _re.search(r"\.{3,}", text) and _re.search(r"\d", text):
+                    if re.search(r"\.{3,}", text) and re.search(r"\d", text):
                         continue
 
                 # 标题去重：同一文本在整个文档中只保留首次出现

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
@@ -118,6 +118,38 @@ class DoclingConversionResult:
     page_count: int = 0
 
 
+def _infer_heading_level_from_text(text: str) -> Optional[int]:
+    """从文本编号模式推断标题层级。
+
+    学术论文/技术文档的常见编号模式：
+        "1 Introduction"        → H2（顶级章节）
+        "2. Theoretical Frame"  → H2（顶级章节，带尾随点号）
+        "2.1 Formal Definition" → H3（子节）
+        "3.1.1 Tech Landscape"  → H4（子子节）
+        "Abstract"              → None（无编号，不推断）
+
+    Returns:
+        heading_level (1-6) 或 None（无法推断时）。
+    """
+    import re
+
+    # 匹配开头的编号模式：数字(.数字)* 后跟可选点号和空格
+    # 支持 "1 Title"、"2. Title"、"2.1 Title"、"3.1.1 Title"
+    m = re.match(r"^(\d+(?:\.\d+)*)\.?\s", text)
+    if not m:
+        return None
+
+    numbering = m.group(1)
+    parts = numbering.split(".")
+
+    if len(parts) == 1:
+        return 2  # "N Title" → H2（顶级章节）
+    elif len(parts) == 2:
+        return 3  # "N.N Title" → H3（子节）
+    else:
+        return 4  # "N.N.N+ Title" → H4
+
+
 # ---------------------------------------------------------------------------
 # Docling 引擎
 # ---------------------------------------------------------------------------
@@ -916,6 +948,12 @@ class DoclingEngine:
             page_figures.setdefault(region.page_no, []).append(region)
 
         try:
+            # 标题去重：跟踪已输出的标题文本，跳过跨页重复。
+            # 学术论文的 "References" 在每页会被 Docling 重新检测为 title/section_header，
+            # 导致最终 Markdown 出现多个 # References。使用文本指纹去重，
+            # 同一标题文本在文档中只保留首次出现。
+            seen_heading_texts: set[str] = set()
+
             for item, _level in doc.iterate_items():
                 label = str(getattr(item, "label", "")).lower()
                 if label not in self._TEXT_LABELS:
@@ -949,14 +987,62 @@ class DoclingEngine:
 
                 heading_level: Optional[int] = None
                 if label == "title":
+                    # 过滤学术论文首页的噪声标题：
+                    # - 作者机构/编号行（如 "1 SJTU 2 SII 3 GAIR"）
+                    # - 脚注标记（如 "0 † Corresponding author"）
+                    # - URL（如 "1 https://github.com/..."）
+                    stripped = text.strip()
+                    is_noise_title = False
+                    if len(stripped) < 60:
+                        # 纯数字+空格+单词的短行且无实质标题内容
+                        import re as _re
+
+                        if _re.match(r"^[\d\s\†\*\‡\§\¶]+$", stripped):
+                            is_noise_title = True
+                        # 机构编号行："1 SJTU 2 SII 3 GAIR"
+                        elif _re.match(r"^(?:\d+\s+\S+\s*){2,}$", stripped):
+                            is_noise_title = True
+                        # 脚注行："0 † Corresponding author"
+                        elif "†" in stripped or "‡" in stripped or "§" in stripped:
+                            is_noise_title = True
+                        # URL 行："1 https://..."
+                        elif _re.match(r"^\d+\s+https?://", stripped):
+                            is_noise_title = True
+                    if is_noise_title:
+                        continue
                     heading_level = 1
                 elif label == "section_header":
-                    raw_level = getattr(item, "level", None)
-                    try:
-                        heading_level = int(raw_level) if raw_level else 2
-                    except (TypeError, ValueError):
-                        heading_level = 2
+                    # 优先从文本编号推断层级：学术论文标题编号模式
+                    # "1 Introduction" → H2, "2.1 Formal Definition" → H3,
+                    # "3.1.1 Technological Landscape" → H4
+                    heading_level = _infer_heading_level_from_text(text.strip())
+                    if heading_level is None:
+                        # 降级：使用 Docling 的 _level（通常全为 1，不可靠）
+                        if isinstance(_level, int) and _level >= 1:
+                            heading_level = min(1 + _level, 6)
+                        else:
+                            raw_level = getattr(item, "level", None)
+                            try:
+                                heading_level = int(raw_level) if raw_level else 2
+                            except (TypeError, ValueError):
+                                heading_level = 2
                     heading_level = max(1, min(6, heading_level))
+
+                # 目录行过滤：跳过 PDF 目录页中带点号引导线的条目。
+                # 特征：包含连续 3+ 个点号且以数字开头（如
+                # "2 Theoretical Framework 4 2.1 Formal Definition... 4"）
+                if label in ("title", "section_header") and "..." in text:
+                    import re as _re
+
+                    if _re.search(r"\.{3,}", text) and _re.search(r"\d", text):
+                        continue
+
+                # 标题去重：同一文本在整个文档中只保留首次出现
+                if label in ("title", "section_header"):
+                    heading_key = text.strip().lower()
+                    if heading_key in seen_heading_texts:
+                        continue
+                    seen_heading_texts.add(heading_key)
 
                 blocks.append(
                     DoclingTextBlock(

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Dict, List, Optional, Tuple
 
 from ...base import Stage, StageResult
@@ -71,9 +72,7 @@ class BuiltinAssembler(PDFToolBase):
                             text_table_fingerprints.add(first_data_row)
                     # 公式指纹：LaTeX 核心内容（去除空白）
                     if "$$" in text:
-                        for m in __import__("re").finditer(
-                            r"\$\$(.*?)\$\$", text, __import__("re").DOTALL
-                        ):
+                        for m in re.finditer(r"\$\$(.*?)\$\$", text, re.DOTALL):
                             core = m.group(1).strip().replace(" ", "")
                             if len(core) > 10:
                                 text_formula_fingerprints.add(core)

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -58,6 +58,26 @@ class BuiltinAssembler(PDFToolBase):
             # 1. 收集所有内容元素
             elements: List[_ContentElement] = []
 
+            # 1a. 预扫描：收集文本块中的表格与公式指纹，用于跨 Stage 去重
+            text_table_fingerprints: set[str] = set()
+            text_formula_fingerprints: set[str] = set()
+            if input_data.text and input_data.text.blocks:
+                for block in input_data.text.blocks:
+                    text = block.text.strip()
+                    # 表格指纹：首行非空单元格的拼接（跳过 separator 行）
+                    if text.startswith("|"):
+                        first_data_row = _extract_table_fingerprint(text)
+                        if first_data_row:
+                            text_table_fingerprints.add(first_data_row)
+                    # 公式指纹：LaTeX 核心内容（去除空白）
+                    if "$$" in text:
+                        for m in __import__("re").finditer(
+                            r"\$\$(.*?)\$\$", text, __import__("re").DOTALL
+                        ):
+                            core = m.group(1).strip().replace(" ", "")
+                            if len(core) > 10:
+                                text_formula_fingerprints.add(core)
+
             # 文本块
             if input_data.text and input_data.text.blocks:
                 for block in input_data.text.blocks:
@@ -71,9 +91,13 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 表格
+            # 表格（去重：跳过文本块中已存在的表格）
             if input_data.tables:
                 for table in input_data.tables.tables:
+                    md = table.markdown.strip() if table.markdown else ""
+                    fp = _extract_table_fingerprint(md) if md.startswith("|") else ""
+                    if fp and fp in text_table_fingerprints:
+                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=table.reading_order,
@@ -84,9 +108,14 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 公式
+            # 公式（去重：跳过文本块中已存在的公式）
             if input_data.formulas:
                 for formula in input_data.formulas.formulas:
+                    latex_core = (
+                        formula.latex.strip().replace(" ", "") if formula.latex else ""
+                    )
+                    if len(latex_core) > 10 and latex_core in text_formula_fingerprints:
+                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=formula.reading_order,
@@ -129,6 +158,9 @@ class BuiltinAssembler(PDFToolBase):
             #    - y0：bbox 顶部纵坐标（TopLeft 坐标系），缺失时退化到 reading_order * 100
             #    - x0：bbox 左侧横坐标，作为多列布局列序兜底（先左列后右列）
             #    - reading_order：稳定序兜底，保证同坐标元素遵循 Stage 内部序
+            #
+            #    无 bbox 的孤立元素（如公式提取缺少坐标）排在同页定位内容之后，
+            #    避免错误地排到页首。
             def _sort_key(
                 elem: _ContentElement,
             ) -> Tuple[int, float, float, int]:
@@ -149,7 +181,8 @@ class BuiltinAssembler(PDFToolBase):
                     y_pos = float(bbox[1])
                     x_pos = float(bbox[0])
                 else:
-                    y_pos = elem.reading_order * 100.0
+                    # 孤立元素排在同页定位内容之后（1e6 远大于任何合理的 y0）
+                    y_pos = 1_000_000.0 + elem.reading_order
                     x_pos = 0.0
                 return (page, y_pos, x_pos, elem.reading_order)
 
@@ -269,6 +302,27 @@ class _ContentElement:
 # ---------------------------------------------------------------------------
 # Markdown 转换辅助函数
 # ---------------------------------------------------------------------------
+
+
+def _extract_table_fingerprint(table_text: str) -> str:
+    """提取 Markdown 表格的首行数据单元格指纹（用于去重比较）。
+
+    跳过 separator 行（如 ``|---|---|``），取第一个含实际数据的行，
+    去除管道符和空白后作为指纹。
+    """
+    for line in table_text.split("\n"):
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        # 跳过 separator 行
+        if set(line.replace("|", "").replace("-", "").replace(":", "").strip()) <= {
+            " ",
+        }:
+            continue
+        cells = [c.strip() for c in line.split("|") if c.strip()]
+        if cells:
+            return "|".join(cells)
+    return ""
 
 
 def _text_block_to_markdown(block: TextBlock) -> str:


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：学术论文/技术文档 PDF 转 Markdown 时，标题层级不准确（Docling 的 `_level` 全为 1）、跨页重复标题未去重（如 References 在每页重复出现）、首页噪声标题（作者机构、脚注标记）混入输出、以及跨 Stage 表格/公式重复。
- 关联上下文：PDF 转 Markdown 管线（perceives 模块）

# 核心变更
- **标题层级推断** (`docling.py`): 新增 `_infer_heading_level_from_text()` 函数，从文本编号模式推断层级（`1 Title` → H2，`2.1 Sub` → H3，`3.1.1 SubSub` → H4），优先于 Docling 不可靠的 `_level`
- **噪声标题过滤** (`docling.py`): 过滤学术论文首页的机构编号行、脚注标记（†‡§）、URL 行等噪声 title 元素
- **目录行过滤** (`docling.py`): 跳过 PDF 目录页中带 `...` 引导线的条目
- **标题去重** (`docling.py`): 使用 `seen_heading_texts` 集合，同一标题文本在整个文档中只保留首次出现
- **跨 Stage 去重** (`assembly.py`): 预扫描文本块中的表格/公式指纹，在组装阶段跳过已存在的重复表格和公式
- **孤立元素排序修复** (`assembly.py`): 无 bbox 的元素（如缺少坐标的公式）排在同页定位内容之后，避免错误排到页首

# 风险与回滚
- 主要风险：标题层级推断基于正则模式匹配，非标准编号格式的文档可能推断不准（有降级逻辑兜底）
- 回滚方式：`git revert` 单个 commit

# 验证证据
- 单元测试：标题层级推断函数覆盖了主要编号模式
- 集成测试：通过实际学术论文 PDF 转换验证去重和层级效果
- E2E/Workflow：手动验证多篇学术论文 PDF 的 Markdown 输出质量

# 影响范围
- 前端：无
- 后端：`perceives` 模块的 PDF 转换管线（docling 引擎 + assembly 组装阶段）
- GitHub Actions / 文档：无

# Next Best Action
- 收集更多类型文档（法律文书、技术规范）的边缘 Case，扩展噪声过滤和层级推断规则