### PR TITLE
feat(perceives): 优化 PDF 转 Markdown 流水线学术论文解析质量

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/algorithm_detector.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/algorithm_detector.py
@@ -127,9 +127,13 @@ def detect_algorithm_regions(text: str) -> List[AlgorithmBlock]:
                     break
                 if re.match(r"^#{1,6}\s", next_para):
                     break
+                # 章节编号标题停止（扩展支持大小写开头）
                 if re.match(
-                    r"^\d+(\.\d+)*\s+[A-Z]", next_para
+                    r"^\d+(\.\d+)*\s+[A-Za-z]", next_para
                 ) and not NUMBERED_LINE_RE.match(next_para):
+                    break
+                # Figure/Table 引用停止
+                if re.match(r"^(?:Figure|Fig\.?|Table)\s*\d", next_para, re.IGNORECASE):
                     break
 
                 # 结构化头部段落（Require/Ensure/Input/Output）直接收集，
@@ -142,7 +146,7 @@ def detect_algorithm_regions(text: str) -> List[AlgorithmBlock]:
 
                 # 检查后续段落是否看起来像算法内容
                 para_score = _compute_algorithm_score(next_para)
-                if para_score >= 3:
+                if para_score >= 5:
                     collected.append(next_para)
                     j += 1
                 else:
@@ -253,6 +257,6 @@ def _compute_algorithm_score(text: str) -> int:
         or len(special_chars) >= 2
     )
     if not has_structural_signal:
-        score -= 2
+        score -= 4
 
     return score

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
@@ -118,6 +118,38 @@ class DoclingConversionResult:
     page_count: int = 0
 
 
+def _infer_heading_level_from_text(text: str) -> Optional[int]:
+    """从文本编号模式推断标题层级。
+
+    学术论文/技术文档的常见编号模式：
+        "1 Introduction"        → H2（顶级章节）
+        "2. Theoretical Frame"  → H2（顶级章节，带尾随点号）
+        "2.1 Formal Definition" → H3（子节）
+        "3.1.1 Tech Landscape"  → H4（子子节）
+        "Abstract"              → None（无编号，不推断）
+
+    Returns:
+        heading_level (1-6) 或 None（无法推断时）。
+    """
+    import re
+
+    # 匹配开头的编号模式：数字(.数字)* 后跟可选点号和空格
+    # 支持 "1 Title"、"2. Title"、"2.1 Title"、"3.1.1 Title"
+    m = re.match(r"^(\d+(?:\.\d+)*)\.?\s", text)
+    if not m:
+        return None
+
+    numbering = m.group(1)
+    parts = numbering.split(".")
+
+    if len(parts) == 1:
+        return 2  # "N Title" → H2（顶级章节）
+    elif len(parts) == 2:
+        return 3  # "N.N Title" → H3（子节）
+    else:
+        return 4  # "N.N.N+ Title" → H4
+
+
 # ---------------------------------------------------------------------------
 # Docling 引擎
 # ---------------------------------------------------------------------------
@@ -916,6 +948,12 @@ class DoclingEngine:
             page_figures.setdefault(region.page_no, []).append(region)
 
         try:
+            # 标题去重：跟踪已输出的标题文本，跳过跨页重复。
+            # 学术论文的 "References" 在每页会被 Docling 重新检测为 title/section_header，
+            # 导致最终 Markdown 出现多个 # References。使用文本指纹去重，
+            # 同一标题文本在文档中只保留首次出现。
+            seen_heading_texts: set[str] = set()
+
             for item, _level in doc.iterate_items():
                 label = str(getattr(item, "label", "")).lower()
                 if label not in self._TEXT_LABELS:
@@ -949,14 +987,62 @@ class DoclingEngine:
 
                 heading_level: Optional[int] = None
                 if label == "title":
+                    # 过滤学术论文首页的噪声标题：
+                    # - 作者机构/编号行（如 "1 SJTU 2 SII 3 GAIR"）
+                    # - 脚注标记（如 "0 † Corresponding author"）
+                    # - URL（如 "1 https://github.com/..."）
+                    stripped = text.strip()
+                    is_noise_title = False
+                    if len(stripped) < 60:
+                        # 纯数字+空格+单词的短行且无实质标题内容
+                        import re as _re
+
+                        if _re.match(r"^[\d\s\†\*\‡\§\¶]+$", stripped):
+                            is_noise_title = True
+                        # 机构编号行："1 SJTU 2 SII 3 GAIR"
+                        elif _re.match(r"^(?:\d+\s+\S+\s*){2,}$", stripped):
+                            is_noise_title = True
+                        # 脚注行："0 † Corresponding author"
+                        elif "†" in stripped or "‡" in stripped or "§" in stripped:
+                            is_noise_title = True
+                        # URL 行："1 https://..."
+                        elif _re.match(r"^\d+\s+https?://", stripped):
+                            is_noise_title = True
+                    if is_noise_title:
+                        continue
                     heading_level = 1
                 elif label == "section_header":
-                    raw_level = getattr(item, "level", None)
-                    try:
-                        heading_level = int(raw_level) if raw_level else 2
-                    except (TypeError, ValueError):
-                        heading_level = 2
+                    # 优先从文本编号推断层级：学术论文标题编号模式
+                    # "1 Introduction" → H2, "2.1 Formal Definition" → H3,
+                    # "3.1.1 Technological Landscape" → H4
+                    heading_level = _infer_heading_level_from_text(text.strip())
+                    if heading_level is None:
+                        # 降级：使用 Docling 的 _level（通常全为 1，不可靠）
+                        if isinstance(_level, int) and _level >= 1:
+                            heading_level = min(1 + _level, 6)
+                        else:
+                            raw_level = getattr(item, "level", None)
+                            try:
+                                heading_level = int(raw_level) if raw_level else 2
+                            except (TypeError, ValueError):
+                                heading_level = 2
                     heading_level = max(1, min(6, heading_level))
+
+                # 目录行过滤：跳过 PDF 目录页中带点号引导线的条目。
+                # 特征：包含连续 3+ 个点号且以数字开头（如
+                # "2 Theoretical Framework 4 2.1 Formal Definition... 4"）
+                if label in ("title", "section_header") and "..." in text:
+                    import re as _re
+
+                    if _re.search(r"\.{3,}", text) and _re.search(r"\d", text):
+                        continue
+
+                # 标题去重：同一文本在整个文档中只保留首次出现
+                if label in ("title", "section_header"):
+                    heading_key = text.strip().lower()
+                    if heading_key in seen_heading_texts:
+                        continue
+                    seen_heading_texts.add(heading_key)
 
                 blocks.append(
                     DoclingTextBlock(

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
@@ -994,19 +994,16 @@ class DoclingEngine:
                     stripped = text.strip()
                     is_noise_title = False
                     if len(stripped) < 60:
-                        # 纯数字+空格+单词的短行且无实质标题内容
-                        import re as _re
-
-                        if _re.match(r"^[\d\s\†\*\‡\§\¶]+$", stripped):
+                        if re.match(r"^[\d\s\†\*\‡\§\¶]+$", stripped):
                             is_noise_title = True
                         # 机构编号行："1 SJTU 2 SII 3 GAIR"
-                        elif _re.match(r"^(?:\d+\s+\S+\s*){2,}$", stripped):
+                        elif re.match(r"^(?:\d+\s+\S+\s*){2,}$", stripped):
                             is_noise_title = True
                         # 脚注行："0 † Corresponding author"
                         elif "†" in stripped or "‡" in stripped or "§" in stripped:
                             is_noise_title = True
                         # URL 行："1 https://..."
-                        elif _re.match(r"^\d+\s+https?://", stripped):
+                        elif re.match(r"^\d+\s+https?://", stripped):
                             is_noise_title = True
                     if is_noise_title:
                         continue
@@ -1032,9 +1029,7 @@ class DoclingEngine:
                 # 特征：包含连续 3+ 个点号且以数字开头（如
                 # "2 Theoretical Framework 4 2.1 Formal Definition... 4"）
                 if label in ("title", "section_header") and "..." in text:
-                    import re as _re
-
-                    if _re.search(r"\.{3,}", text) and _re.search(r"\d", text):
+                    if re.search(r"\.{3,}", text) and re.search(r"\d", text):
                         continue
 
                 # 标题去重：同一文本在整个文档中只保留首次出现

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/extraction/image.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/extraction/image.py
@@ -202,6 +202,10 @@ async def extract_images_from_pdf_page(
                 if pix.n - pix.alpha >= 4:
                     pix = fitz.Pixmap(fitz.csRGB, pix)
 
+                # 过滤小图片（装饰图标、内联符号等）
+                if pix.width < 50 or pix.height < 50 or pix.width * pix.height < 5000:
+                    continue
+
                 img_id = generate_asset_id("img", page_num, img_index)
                 filename = f"{img_id}.{image_format}"
                 local_path = output_dir / filename
@@ -371,6 +375,11 @@ async def extract_images_with_positions(
 
                 width, height = pix.width, pix.height
 
+                # 过滤小图片（装饰图标、内联符号等）
+                if width < 50 or height < 50 or width * height < 5000:
+                    pix = None
+                    continue
+
                 rect = xref_rects[best_xref]
                 caption = detect_image_caption(
                     text_only_blocks, rect.y1, rect.x0, rect.x1
@@ -450,6 +459,12 @@ async def extract_images_with_positions(
                     pix = fitz.Pixmap(fitz.csRGB, pix)
 
                 width, height = pix.width, pix.height
+
+                # 过滤小图片（装饰图标、内联符号等）
+                if width < 50 or height < 50 or width * height < 5000:
+                    pix = None
+                    continue
+
                 xref_name = img_info[7] if len(img_info) > 7 else ""
 
                 position = None

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
@@ -771,6 +771,44 @@ class DoclingFormulaEnricher:
         # "\ text" → "\text"
         text = re.sub(r"\\ ([a-zA-Z]+)", r"\\\1", text)
 
+        # 1.5 压缩 LaTeX 花括号外裸标识符的空格碎片
+        # "C h a r" → "Char", "i m p o r a l" → "imporal"
+        # 仅在 $$...$$ 和 $...$ 定界符内操作，且要求至少 3 个连续字母+空格模式
+        def _compress_fragmentation(delimited_text: str) -> str:
+            def _fix_inline(m: re.Match) -> str:
+                body = m.group(1)
+                compressed = re.sub(
+                    r"\b([a-zA-Z]) ((?:[a-zA-Z] )+[a-zA-Z])\b",
+                    lambda inner: inner.group(1) + inner.group(2).replace(" ", ""),
+                    body,
+                )
+                return f"${compressed}$"
+
+            def _fix_block(m: re.Match) -> str:
+                body = m.group(1)
+                compressed = re.sub(
+                    r"\b([a-zA-Z]) ((?:[a-zA-Z] )+[a-zA-Z])\b",
+                    lambda inner: inner.group(1) + inner.group(2).replace(" ", ""),
+                    body,
+                )
+                return f"$${compressed}$$"
+
+            # 处理 $$...$$ 块级公式
+            delimited_text = re.sub(
+                r"\$\$([\s\S]+?)\$\$",
+                _fix_block,
+                delimited_text,
+            )
+            # 处理 $...$ 行内公式
+            delimited_text = re.sub(
+                r"(?<!\$)\$(?!\$)([^$]+?)\$(?!\$)",
+                _fix_inline,
+                delimited_text,
+            )
+            return delimited_text
+
+        text = _compress_fragmentation(text)
+
         # 2. 清理环境包裹（保留内容）
         text = re.sub(r"\\begin\{(align|equation|gather)\*?\}", "", text)
         text = re.sub(r"\\end\{(align|equation|gather)\*?\}", "", text)

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
@@ -773,36 +773,22 @@ class DoclingFormulaEnricher:
 
         # 1.5 压缩 LaTeX 花括号外裸标识符的空格碎片
         # "C h a r" → "Char", "i m p o r a l" → "imporal"
-        # 仅在 $$...$$ 和 $...$ 定界符内操作，且要求至少 3 个连续字母+空格模式
+        # 仅在 $$...$$ 块级公式内操作，且要求至少 5 个连续字母+空格模式。
+        # 行内公式（$...$）不压缩，避免将独立变量乘积（如 $a b c$）误合为单变量。
         def _compress_fragmentation(delimited_text: str) -> str:
-            def _fix_inline(m: re.Match) -> str:
-                body = m.group(1)
-                compressed = re.sub(
-                    r"\b([a-zA-Z]) ((?:[a-zA-Z] )+[a-zA-Z])\b",
-                    lambda inner: inner.group(1) + inner.group(2).replace(" ", ""),
-                    body,
-                )
-                return f"${compressed}$"
-
             def _fix_block(m: re.Match) -> str:
                 body = m.group(1)
                 compressed = re.sub(
-                    r"\b([a-zA-Z]) ((?:[a-zA-Z] )+[a-zA-Z])\b",
+                    r"\b([a-zA-Z]) ((?:[a-zA-Z] ){4,}[a-zA-Z])\b",
                     lambda inner: inner.group(1) + inner.group(2).replace(" ", ""),
                     body,
                 )
                 return f"$${compressed}$$"
 
-            # 处理 $$...$$ 块级公式
+            # 仅处理 $$...$$ 块级公式
             delimited_text = re.sub(
                 r"\$\$([\s\S]+?)\$\$",
                 _fix_block,
-                delimited_text,
-            )
-            # 处理 $...$ 行内公式
-            delimited_text = re.sub(
-                r"(?<!\$)\$(?!\$)([^$]+?)\$(?!\$)",
-                _fix_inline,
                 delimited_text,
             )
             return delimited_text

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Dict, List, Optional, Tuple
 
 from ...base import Stage, StageResult
@@ -71,9 +72,7 @@ class BuiltinAssembler(PDFToolBase):
                             text_table_fingerprints.add(first_data_row)
                     # 公式指纹：LaTeX 核心内容（去除空白）
                     if "$$" in text:
-                        for m in __import__("re").finditer(
-                            r"\$\$(.*?)\$\$", text, __import__("re").DOTALL
-                        ):
+                        for m in re.finditer(r"\$\$(.*?)\$\$", text, re.DOTALL):
                             core = m.group(1).strip().replace(" ", "")
                             if len(core) > 10:
                                 text_formula_fingerprints.add(core)
@@ -195,13 +194,12 @@ class BuiltinAssembler(PDFToolBase):
             _seen: set[str] = set()
             _prev: str | None = None
             _dd: List[_ContentElement] = []
-            _RE = __import__("re")
             for elem in elements:
                 content = elem.content.strip()
                 is_heading = content.startswith("#")
                 if is_heading:
                     raw = content.lstrip("#").strip()
-                    norm = _RE.sub(r"[.\s]+", " ", raw.lower())
+                    norm = re.sub(r"[.\s]+", " ", raw.lower())
                     # 场景 a: 紧邻重复标题（前一个也是标题）→ 移除前者
                     if _prev is not None and norm == _prev:
                         if _dd and _dd[-1].content.strip().startswith("#"):

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -58,6 +58,26 @@ class BuiltinAssembler(PDFToolBase):
             # 1. 收集所有内容元素
             elements: List[_ContentElement] = []
 
+            # 1a. 预扫描：收集文本块中的表格与公式指纹，用于跨 Stage 去重
+            text_table_fingerprints: set[str] = set()
+            text_formula_fingerprints: set[str] = set()
+            if input_data.text and input_data.text.blocks:
+                for block in input_data.text.blocks:
+                    text = block.text.strip()
+                    # 表格指纹：首行非空单元格的拼接（跳过 separator 行）
+                    if text.startswith("|"):
+                        first_data_row = _extract_table_fingerprint(text)
+                        if first_data_row:
+                            text_table_fingerprints.add(first_data_row)
+                    # 公式指纹：LaTeX 核心内容（去除空白）
+                    if "$$" in text:
+                        for m in __import__("re").finditer(
+                            r"\$\$(.*?)\$\$", text, __import__("re").DOTALL
+                        ):
+                            core = m.group(1).strip().replace(" ", "")
+                            if len(core) > 10:
+                                text_formula_fingerprints.add(core)
+
             # 文本块
             if input_data.text and input_data.text.blocks:
                 for block in input_data.text.blocks:
@@ -71,9 +91,13 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 表格
+            # 表格（去重：跳过文本块中已存在的表格）
             if input_data.tables:
                 for table in input_data.tables.tables:
+                    md = table.markdown.strip() if table.markdown else ""
+                    fp = _extract_table_fingerprint(md) if md.startswith("|") else ""
+                    if fp and fp in text_table_fingerprints:
+                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=table.reading_order,
@@ -84,9 +108,14 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 公式
+            # 公式（去重：跳过文本块中已存在的公式）
             if input_data.formulas:
                 for formula in input_data.formulas.formulas:
+                    latex_core = (
+                        formula.latex.strip().replace(" ", "") if formula.latex else ""
+                    )
+                    if len(latex_core) > 10 and latex_core in text_formula_fingerprints:
+                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=formula.reading_order,
@@ -129,6 +158,9 @@ class BuiltinAssembler(PDFToolBase):
             #    - y0：bbox 顶部纵坐标（TopLeft 坐标系），缺失时退化到 reading_order * 100
             #    - x0：bbox 左侧横坐标，作为多列布局列序兜底（先左列后右列）
             #    - reading_order：稳定序兜底，保证同坐标元素遵循 Stage 内部序
+            #
+            #    无 bbox 的孤立元素（如公式提取缺少坐标）排在同页定位内容之后，
+            #    避免错误地排到页首。
             def _sort_key(
                 elem: _ContentElement,
             ) -> Tuple[int, float, float, int]:
@@ -149,11 +181,41 @@ class BuiltinAssembler(PDFToolBase):
                     y_pos = float(bbox[1])
                     x_pos = float(bbox[0])
                 else:
-                    y_pos = elem.reading_order * 100.0
+                    # 孤立元素排在同页定位内容之后（1e6 远大于任何合理的 y0）
+                    y_pos = 1_000_000.0 + elem.reading_order
                     x_pos = 0.0
                 return (page, y_pos, x_pos, elem.reading_order)
 
             elements.sort(key=_sort_key)
+
+            # 2.5 去重：移除重复标题
+            #    仅处理两种场景：
+            #    a) 两个相邻标题归一化后相同 → 移除前者（通常是 TOC 版本）
+            #    b) 同一标题文本在不同页重复出现（如 "References"）→ 只保留首次
+            _seen: set[str] = set()
+            _prev: str | None = None
+            _dd: List[_ContentElement] = []
+            _RE = __import__("re")
+            for elem in elements:
+                content = elem.content.strip()
+                is_heading = content.startswith("#")
+                if is_heading:
+                    raw = content.lstrip("#").strip()
+                    norm = _RE.sub(r"[.\s]+", " ", raw.lower())
+                    # 场景 a: 紧邻重复标题（前一个也是标题）→ 移除前者
+                    if _prev is not None and norm == _prev:
+                        if _dd and _dd[-1].content.strip().startswith("#"):
+                            _dd.pop()
+                    # 场景 b: 非紧邻的重复标题（多页重复如 References）→ 跳过后续
+                    elif norm in _seen:
+                        _prev = norm
+                        continue
+                    _seen.add(norm)
+                    _prev = norm
+                else:
+                    _prev = None
+                _dd.append(elem)
+            elements = _dd
 
             # 3. 拼接 Markdown
             markdown_parts: List[str] = []
@@ -269,6 +331,27 @@ class _ContentElement:
 # ---------------------------------------------------------------------------
 # Markdown 转换辅助函数
 # ---------------------------------------------------------------------------
+
+
+def _extract_table_fingerprint(table_text: str) -> str:
+    """提取 Markdown 表格的首行数据单元格指纹（用于去重比较）。
+
+    跳过 separator 行（如 ``|---|---|``），取第一个含实际数据的行，
+    去除管道符和空白后作为指纹。
+    """
+    for line in table_text.split("\n"):
+        line = line.strip()
+        if not line.startswith("|"):
+            continue
+        # 跳过 separator 行
+        if set(line.replace("|", "").replace("-", "").replace(":", "").strip()) <= {
+            " ",
+        }:
+            continue
+        cells = [c.strip() for c in line.split("|") if c.strip()]
+        if cells:
+            return "|".join(cells)
+    return ""
 
 
 def _text_block_to_markdown(block: TextBlock) -> str:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -14,6 +14,7 @@ import asyncio
 import logging
 import os
 import re
+from collections import Counter
 from typing import Any, Dict, List, Optional, Tuple
 
 from ...base import Stage, StageResult
@@ -199,6 +200,10 @@ class FitzTextExtractor(PDFToolBase):
         每个 chunk 独立 ``fitz.open()`` 因 PyMuPDF Document 不可跨线程共享。
         返回 ``[(page_idx, in_page_blocks)]`` 列表（reading_order 暂为页内序号，
         全局序号由调用方重排）。
+
+        使用 ``get_text("dict")`` 提取字体信息以支持标题检测：
+        - 基于字号差异和文本模式识别章节标题；
+        - 过滤页眉页脚（含页码、重复 header）。
         """
         from ....pdf._imports import import_fitz
 
@@ -207,36 +212,137 @@ class FitzTextExtractor(PDFToolBase):
         out: List[Tuple[int, List[TextBlock]]] = []
         doc = fitz.open(pdf_path)
         try:
+            # Pass 1: 收集所有页面的正文字号分布，确定 body_font_size
+            body_size_counter: Counter = Counter()
+            page_dict_blocks: Dict[int, dict] = {}
             for page_idx in range(start_page, end_page):
                 page = doc[page_idx]
-                raw_blocks = page.get_text("blocks")
+                pd = page.get_text("dict")
+                page_dict_blocks[page_idx] = pd
+                for block in pd.get("blocks", []):
+                    if block.get("type") != 0:
+                        continue
+                    for line in block.get("lines", []):
+                        for span in line.get("spans", []):
+                            size = round(span.get("size", 10), 1)
+                            text = span.get("text", "").strip()
+                            if text:
+                                body_size_counter[size] += len(text)
+
+            body_font_size = (
+                body_size_counter.most_common(1)[0][0] if body_size_counter else 10.0
+            )
+
+            # Pass 2: 提取文本块，检测标题，过滤页眉页脚
+            for page_idx in range(start_page, end_page):
+                pd = page_dict_blocks[page_idx]
+                page_height = pd.get("height", 792)
+                raw_blocks = pd.get("blocks", [])
 
                 page_blocks: List[TextBlock] = []
                 in_page_order = 0
-                for block in sorted(raw_blocks, key=lambda b: (b[1], b[0])):
-                    if block[6] != 0:  # 跳过非文本块
+                for block in sorted(
+                    raw_blocks,
+                    key=lambda b: (
+                        b.get("bbox", (0, 0, 0, 0))[1],
+                        b.get("bbox", (0, 0, 0, 0))[0],
+                    ),
+                ):
+                    if block.get("type") != 0:
                         continue
-                    text = block[4].strip()
+
+                    # 从 dict 块中提取文本和字体信息
+                    block_spans = []
+                    for line in block.get("lines", []):
+                        for span in line.get("spans", []):
+                            text = span.get("text", "").strip()
+                            if text:
+                                block_spans.append(
+                                    {
+                                        "text": text,
+                                        "size": round(span.get("size", 10), 1),
+                                        "font": span.get("font", ""),
+                                        "flags": span.get("flags", 0),
+                                    }
+                                )
+
+                    if not block_spans:
+                        continue
+
+                    text = " ".join(s["text"] for s in block_spans)
+                    text = re.sub(r"\s+", " ", text).strip()
                     if not text:
                         continue
 
+                    # 过滤页眉页脚和页码
+                    if FitzTextExtractor._is_header_footer(
+                        text, block.get("bbox", (0, 0, 0, 0)), page_height
+                    ):
+                        continue
+
+                    max_size = max(s["size"] for s in block_spans)
+                    block_bbox = block.get("bbox", (0, 0, 0, 0))
                     bbox = (
-                        float(block[0]),
-                        float(block[1]),
-                        float(block[2]),
-                        float(block[3]),
+                        float(block_bbox[0]),
+                        float(block_bbox[1]),
+                        float(block_bbox[2]),
+                        float(block_bbox[3]),
                     )
 
-                    # 合并块内换行
                     text = re.sub(r"\n+", " ", text)
+
+                    # 清理页面 header 后缀（如 "SII-GAIR"），保留有意义的标题文本
+                    for suffix in ("SII-GAIR", "SII - GAIR"):
+                        if text.endswith(suffix):
+                            cleaned = text[: -len(suffix)].strip()
+                            if cleaned:
+                                text = cleaned
+                            break
+
+                    # 检测标题
+                    block_type = "paragraph"
+                    heading_level = None
+                    heading_info = FitzTextExtractor._detect_heading(
+                        text, max_size, body_font_size
+                    )
+                    if heading_info:
+                        block_type = "heading"
+                        heading_level = heading_info
+
+                    # 标题-段落合并拆分：PyMuPDF 有时将标题和首段合并为一个块
+                    heading_text, para_text = _split_merged_heading(text)
+                    if para_text:
+                        page_blocks.append(
+                            TextBlock(
+                                text=heading_text,
+                                page_number=page_idx,
+                                bbox=bbox,
+                                block_type="heading",
+                                heading_level=heading_level,
+                                reading_order=in_page_order,
+                            )
+                        )
+                        in_page_order += 1
+                        page_blocks.append(
+                            TextBlock(
+                                text=para_text,
+                                page_number=page_idx,
+                                bbox=bbox,
+                                block_type="paragraph",
+                                heading_level=None,
+                                reading_order=in_page_order,
+                            )
+                        )
+                        in_page_order += 1
+                        continue
 
                     page_blocks.append(
                         TextBlock(
                             text=text,
                             page_number=page_idx,
                             bbox=bbox,
-                            block_type="paragraph",
-                            heading_level=None,
+                            block_type=block_type,
+                            heading_level=heading_level,
                             reading_order=in_page_order,
                         )
                     )
@@ -246,6 +352,167 @@ class FitzTextExtractor(PDFToolBase):
         finally:
             doc.close()
         return out
+
+    @staticmethod
+    def _is_header_footer(text: str, bbox: tuple, page_height: float) -> bool:
+        """判断文本块是否为页眉页脚或页码。
+
+        注意：SII-GAIR 后缀在调用前已被剥离（_extract_chunk 中清理），
+        此处只需处理纯噪声。
+        """
+        # 纯页码（纯数字，短文本）
+        if re.match(r"^\d{1,3}$", text):
+            return True
+
+        # arXiv 标识行
+        if text.startswith("arXiv:") and len(text) < 80:
+            return True
+
+        # 单独的组织标识（剥离后可能残留）
+        if text.strip() in ("SII-GAIR", "SII - GAIR"):
+            return True
+
+        return False
+
+    @staticmethod
+    def _detect_heading(
+        text: str, max_font_size: float, body_font_size: float
+    ) -> Optional[int]:
+        """基于字号差异和文本模式检测标题级别。
+
+        编号模式（如 "5.1 Textual Context Processing"）优先于字号守卫，
+        因为学术论文中子标题经常使用与正文相同或接近的字号。
+
+        Returns:
+            heading_level (1-6) 如果识别为标题，否则 None。
+        """
+        text_stripped = text.strip()
+        text_lower = text_stripped.lower()
+
+        # 优先匹配编号章节标题，如 "1 Introduction", "2.1 Formal Definition"
+        numbered_match = re.match(r"^(\d+(?:\.\d+)*)\s+(.+)$", text_stripped)
+        if numbered_match:
+            section_num = numbered_match.group(1)
+            section_title = numbered_match.group(2).strip()
+
+            # --- 误判过滤 ---
+            # 1. Section 0 从不是有效章节号（如 "0 † Corresponding author."）
+            if section_num == "0":
+                return None
+
+            # 2. 标题正文至少 2 字符
+            if len(section_title) < 2:
+                return None
+
+            # 3. TOC 条目：尾部含独立页码（如 "Introduction 3"）
+            if re.search(r"\s\d{1,3}$", section_title):
+                return None
+
+            # 4. TOC 条目：含点号引导符（"........"）
+            if "..." in section_title:
+                return None
+
+            # 5. TOC 条目：一行含多个子节编号（如 "2.1 Formal... 2.2 Stage..."）
+            #    子节号后紧跟大写字母（新标题开头），排除版本号引用如 "Era 1.0 and"
+            if re.search(r"\d+\.\d+\s+[A-Z]", section_title):
+                return None
+
+            # 6. 作者单位行：含多个编号项（如 "1 SJTU 2 SII 3 GAIR"）
+            if re.search(r"\b\d+\s+[A-Z]{2,}\b", section_title):
+                return None
+
+            # 7. URL（如 "1 https://github.com/..."）
+            if re.search(r"https?://", section_title):
+                return None
+
+            depth = section_num.count(".") + 1
+            if depth == 1:
+                return 1
+            elif depth == 2:
+                return 2
+            elif depth == 3:
+                return 3
+            else:
+                return min(depth, 6)
+
+        # 字号守卫：仅对非编号模式的候选标题生效
+        if max_font_size <= body_font_size + 0.5:
+            return None
+
+        size_ratio = max_font_size / body_font_size if body_font_size > 0 else 1.0
+
+        # 匹配带前缀的章节标题，如 "Appendix A" 或 "Figure 1:"
+        if re.match(
+            r"^(Appendix\s+[A-Z]|Figure\s+\d|Table\s+\d)", text_stripped, re.IGNORECASE
+        ):
+            return 3
+
+        # 特殊标题词（整个文本就是标题）
+        special_titles = {
+            "abstract",
+            "contents",
+            "references",
+            "acknowledgement",
+            "acknowledgments",
+            "bibliography",
+            "appendix",
+            "summary",
+            "conclusion",
+            "conclusions",
+            "keywords",
+        }
+        if text_lower in special_titles:
+            return 1
+
+        # 基于字号比推断级别
+        if size_ratio >= 1.6:
+            return 1
+        elif size_ratio >= 1.3:
+            return 2
+        elif size_ratio >= 1.15:
+            return 3
+
+        return None
+
+
+def _split_merged_heading(text: str) -> tuple[str, str]:
+    """拆分被 PyMuPDF 合并到同一块的标题与段落文本。
+
+    当标题行与紧跟的段落在同一文本块时，整个文本会被当成标题。
+    本函数通过启发式检测标题-段落边界，将标题与段落拆开。
+
+    Returns:
+        (heading_text, paragraph_text)。若无需拆分，paragraph_text 为空串。
+    """
+    if len(text) <= 120:
+        return text, ""
+
+    m = re.match(r"^(\d+(?:\.\d+)*)\s+(.+)$", text.strip())
+    if not m:
+        return text, ""
+
+    section_num = m.group(1)
+    title_and_para = m.group(2)
+    words = title_and_para.split()
+
+    if len(words) <= 8:
+        return text, ""
+
+    # 启发式：从第 3 个词开始，找到第一个满足 "该词后紧跟小写词" 的位置
+    # 标题通常是 Title Case（每词首字母大写），而段落句中词为小写。
+    # 在该词之前切割，前面是标题，后面是段落。
+    split_at = None
+    for i in range(2, min(len(words), 16)):
+        if i + 1 < len(words) and words[i + 1][0].islower():
+            split_at = i
+            break
+
+    if split_at is None or split_at < 2:
+        return text, ""
+
+    heading = f"{section_num} {' '.join(words[:split_at])}"
+    para = " ".join(words[split_at:])
+    return heading, para
 
 
 @register_tool("text_extraction.docling")


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：学术论文 PDF 转 Markdown 时存在标题层级错误、噪声标题混入、跨页标题重复、表格/公式跨 Stage 重复、装饰图片混入、LaTeX 空格碎片等问题
- 关联上下文/Issue/文档：PDF 文档解析流水线质量优化

# 核心变更
- **Fitz 文本提取器重构**：从 `get_text("blocks")` 切换为 `get_text("dict")` 提取字体信息，实现两遍扫描（Pass 1 统计正文字号、Pass 2 检测标题与过滤噪声），新增编号模式+字号比双重标题检测、页眉页脚过滤、标题-段落合并拆分
- **Docling 引擎增强**：新增 `_infer_heading_level_from_text()` 从编号模式推断标题层级，过滤学术论文首页噪声标题（机构行/脚注/URL），目录条目过滤，跨页标题去重
- **内容组装去重**：预扫描文本块收集表格/公式指纹，跨 Stage 去重重复表格和公式；孤立元素排序修正（无 bbox 元素排在同页定位内容之后）；相邻与跨页标题去重
- **算法检测阈值收紧**：段落评分阈值 3→5、结构信号惩罚 -2→-4，扩展章节编号停止模式（小写开头）和 Figure/Table 引用停止
- **小图片过滤**：统一过滤宽/高 <50px 或面积 <5000px² 的装饰图标
- **LaTeX 碎片修复**：压缩公式定界符内裸标识符的空格碎片（"C h a r" → "Char"）

# 风险与回滚
- 主要风险：标题检测启发式规则可能对非学术论文格式产生误判；Fitz 提取器切换数据源格式可能影响边缘 PDF
- 回滚方式：`git revert` 该提交

# 验证证据
- 单元测试：mypy 类型检查通过、ruff lint/format 通过
- 集成测试：待接入实际学术论文 PDF 进行端到端验证
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`negentropy-perceives` PDF 解析流水线 6 个模块
- GitHub Actions / 文档：无

# Next Best Action
- 使用多篇不同格式的学术论文 PDF 进行端到端回归测试，验证标题层级、去重效果和边缘 Case