### PR TITLE
feat(perceives): PDF Markdown 组装公式-文本去重与标题层级规范化

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
@@ -770,16 +770,18 @@ class DoclingFormulaEnricher:
         )
         # "\ text" → "\text"
         text = re.sub(r"\\ ([a-zA-Z]+)", r"\\\1", text)
+        # "\mathcal {E}" → "\mathcal{E}" — LaTeX 命令与花括号间异常空格
+        text = re.sub(r"(\\[a-zA-Z]+) \{", r"\1{", text)
 
         # 1.5 压缩 LaTeX 花括号外裸标识符的空格碎片
         # "C h a r" → "Char", "i m p o r a l" → "imporal"
-        # 仅在 $$...$$ 块级公式内操作，且要求至少 5 个连续字母+空格模式。
-        # 行内公式（$...$）不压缩，避免将独立变量乘积（如 $a b c$）误合为单变量。
+        # 仅在 $$...$$ 块级公式内操作，且要求至少 3 个连续字母+空格模式（即 4+
+        # 字母标识符）。行内公式（$...$）不压缩，避免将独立变量乘积误合为单变量。
         def _compress_fragmentation(delimited_text: str) -> str:
             def _fix_block(m: re.Match) -> str:
                 body = m.group(1)
                 compressed = re.sub(
-                    r"\b([a-zA-Z]) ((?:[a-zA-Z] ){4,}[a-zA-Z])\b",
+                    r"\b([a-zA-Z]) ((?:[a-zA-Z] ){2,}[a-zA-Z])\b",
                     lambda inner: inner.group(1) + inner.group(2).replace(" ", ""),
                     body,
                 )
@@ -802,6 +804,8 @@ class DoclingFormulaEnricher:
 
         # 3. 规范化等式编号
         text = re.sub(r"\s*\\tag\{(\d+)\}", r" \\qquad (\1)", text)
+        # 3.1 清理对齐标记混入的公式编号: "& ( N )" → "\\qquad (N)"
+        text = re.sub(r"&\s*\(\s*(\d+)\s*\)", r"\\qquad (\1)", text)
 
         return text.strip()
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -368,6 +368,37 @@ class BuiltinAssembler(PDFToolBase):
                             _used_formula_indices.add(fi)
                             break
 
+            # 2.4 公式-文本去重：已被公式 Stage 或孤儿匹配覆盖的文本块需移除。
+            #    比较策略：提取公式元素中的等式编号（如 "(5)"、"( 5 )"），
+            #    如果文本元素含相同编号且包含数学符号，视为重复并移除。
+            _formula_eq_nums: set[str] = set()
+            for elem in elements:
+                if elem.element_type == "formula" and elem.content.strip().startswith(
+                    "$$"
+                ):
+                    # 匹配 LaTeX 中的编号: (N) 或 ( N )
+                    for m in re.finditer(r"\(\s*(\d+)\s*\)", elem.content):
+                        _formula_eq_nums.add(m.group(1))
+            if _formula_eq_nums:
+                _math_chars = set("∈∀∃∑∏∫→←↔≤≥≠≈θφψωαβγδ∧∨")
+                elements = [
+                    elem
+                    for elem in elements
+                    if not (
+                        elem.element_type == "text"
+                        and elem.block is not None
+                        and re.search(
+                            r"\(\s*("
+                            + "|".join(re.escape(n) for n in _formula_eq_nums)
+                            + r")\s*\)",
+                            elem.content,
+                        )
+                        and any(c in elem.content for c in _math_chars)
+                        and len(elem.content.strip()) < 200
+                        and not elem.content.strip().startswith("#")
+                    )
+                ]
+
             # 2.5 去重：移除重复标题与重复 Figure/Table 注释
             #    标题去重：
             #    a) 两个相邻标题归一化后相同 → 移除前者（通常是 TOC 版本）

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -58,6 +58,7 @@ class BuiltinAssembler(PDFToolBase):
 
             # 1. 收集所有内容元素
             elements: List[_ContentElement] = []
+            _orphan_block_formulas: List[ExtractedFormula] = []
 
             # 1a. 构建专用 Stage 的空间占用索引（page → bbox 列表），
             #     用于在添加文本块时进行反向去重：当文本块落入公式/表格/图片
@@ -127,27 +128,33 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 公式（正向去重：跳过文本块中已存在的公式；
-            #   无 bbox 的公式因无法确定位置而排在错误位置，
-            #   且 S3 文本提取已捕获其文本，故直接跳过）
+            # 公式（有 bbox 的正常插入；无 bbox 的通过文本匹配升级为 LaTeX）
             if input_data.formulas:
                 for formula in input_data.formulas.formulas:
-                    if not formula.bbox:
-                        continue
-                    latex_core = (
-                        formula.latex.strip().replace(" ", "") if formula.latex else ""
-                    )
-                    if len(latex_core) > 10 and latex_core in text_formula_fingerprints:
-                        continue
-                    elements.append(
-                        _ContentElement(
-                            reading_order=formula.reading_order,
-                            page_number=formula.page_number,
-                            element_type="formula",
-                            content=_formula_to_markdown(formula),
-                            formula=formula,
+                    if formula.bbox:
+                        latex_core = (
+                            formula.latex.strip().replace(" ", "")
+                            if formula.latex
+                            else ""
                         )
-                    )
+                        if (
+                            len(latex_core) > 10
+                            and latex_core in text_formula_fingerprints
+                        ):
+                            continue
+                        elements.append(
+                            _ContentElement(
+                                reading_order=formula.reading_order,
+                                page_number=formula.page_number,
+                                element_type="formula",
+                                content=_formula_to_markdown(formula),
+                                formula=formula,
+                            )
+                        )
+                    elif formula.latex and formula.formula_type == "block":
+                        # 无 bbox 的块级公式：尝试在文本块中定位并标记替换
+                        # 收集到临时列表，排序后通过文本匹配定位
+                        _orphan_block_formulas.append(formula)
 
             # 代码块
             if input_data.code:
@@ -276,6 +283,90 @@ class BuiltinAssembler(PDFToolBase):
                 return (page, y_pos, x_pos, elem.reading_order)
 
             elements.sort(key=_sort_key)
+
+            # 2.1 标题层级规范化：学术论文中首个 H1 为论文标题，
+            #     后续标题应整体下移一级（H1→H2, H2→H3, H3→H4），
+            #     避免所有 section 与标题同级。
+            _first_h1_seen = False
+            for elem in elements:
+                content = elem.content.strip()
+                if not content.startswith("#"):
+                    continue
+                level = len(content) - len(content.lstrip("#"))
+                if level == 1 and not _first_h1_seen:
+                    _first_h1_seen = True
+                    continue  # 论文标题保持 H1
+                if _first_h1_seen and level >= 1:
+                    # 下移一级，最大到 H5
+                    new_level = min(level + 1, 5)
+                    new_content = "#" * new_level + content[level:]
+                    elem.content = new_content
+
+            # 2.2 无 bbox 块级公式：通过公式编号或数学符号在文本块中定位并替换
+            #    策略 1：通过公式编号（如 LaTeX 末尾的 \quad (N)）匹配
+            #    策略 2：通过数学符号 + 公式特征匹配
+            if _orphan_block_formulas:
+                _used_formula_indices: set[int] = set()
+                for elem in elements:
+                    if elem.element_type != "text" or not elem.block:
+                        continue
+                    text = elem.block.text.strip()
+                    if not text or text.startswith("#") or len(text) < 10:
+                        continue
+                    for fi, formula in enumerate(_orphan_block_formulas):
+                        if fi in _used_formula_indices or not formula.latex:
+                            continue
+                        matched = False
+                        # 策略 1：公式编号匹配（最可靠）
+                        eq_num = re.search(r"\\quad\s*\(\s*(\d+)\s*\)", formula.latex)
+                        if eq_num:
+                            num_str = f"({eq_num.group(1)})"
+                            if num_str in text:
+                                matched = True
+                        # 策略 2：数学符号 + LaTeX 关键词匹配
+                        if not matched:
+                            _math_symbols = [
+                                "→",
+                                "∑",
+                                "∈",
+                                "∪",
+                                "⊆",
+                                "θ",
+                                "φ",
+                                "≥",
+                                "≤",
+                                "∧",
+                                "…",
+                            ]
+                            _has_math = any(s in text for s in _math_symbols)
+                            latex_ids = re.findall(r"\\[a-zA-Z]+", formula.latex)
+                            _latex_names = [
+                                n.replace("\\", "")
+                                for n in latex_ids
+                                if n
+                                not in (
+                                    "\\quad",
+                                    "\\colon",
+                                    "\\to",
+                                    "\\left",
+                                    "\\right",
+                                    "\\dots",
+                                    "\\text",
+                                )
+                            ]
+                            _name_match = any(
+                                n.lower() in text.lower() for n in _latex_names
+                            )
+                            if _has_math and _name_match:
+                                matched = True
+                        if matched:
+                            formula_md = _formula_to_markdown(formula)
+                            elem.content = formula_md
+                            elem.element_type = "formula"
+                            elem.formula = formula
+                            elem.block = None
+                            _used_formula_indices.add(fi)
+                            break
 
             # 2.5 去重：移除重复标题与重复 Figure/Table 注释
             #    标题去重：


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：PDF 转 Markdown 流水线在学术论文解析场景下，存在无 bbox 块级公式丢失、标题层级不规范（所有 section 与论文标题同级）、公式与文本内容重复、以及 LaTeX 后处理空格碎片压缩不足等问题。
- 关联上下文：PDF Markdown 组装质量持续优化系列。

# 核心变更
- **无 bbox 块级公式文本匹配**（`assembly.py`）：不再直接跳过无 bbox 的块级公式，而是通过公式编号（策略 1）或数学符号 + LaTeX 关键词（策略 2）在文本块中定位并替换为 LaTeX 公式，显著提升公式覆盖率。
- **标题层级规范化**（`assembly.py`）：识别学术论文中首个 H1 为论文标题，后续标题整体下移一级（H1→H2, H2→H3），避免 section 与标题同级。
- **公式-文本去重**（`assembly.py`）：已被公式 Stage 或孤儿匹配覆盖的文本块，通过等式编号交叉比对进行去重，消除重复渲染。
- **LaTeX 公式后处理增强**（`math_formula.py`）：空格碎片压缩阈值从 5+ 连续降至 3+（即 4+ 字母标识符）；新增 `\mathcal {E}` 类 LaTeX 命令与花括号间异常空格修复；对齐标记混入的公式编号清理。

# 风险与回滚
- 主要风险：标题层级下移规则假设首个 H1 为论文标题，对非学术论文格式（如技术报告以 H2 开头）可能过度降级；孤儿公式匹配策略 2（符号+关键词）在极端情况下可能误匹配。
- 回滚方式：`git revert` 本 PR 的 3 个 commit。

# 验证证据
- 单元测试：LaTeX 后处理空格碎片压缩与编号规范化。
- 集成测试：PDF Markdown 组装流水线端到端验证。
- E2E/Workflow：学术论文 PDF 样本解析质量对比验证。
- 覆盖率/关键截图：公式覆盖率与标题层级正确性已通过实机验证。

# 影响范围
- 前端：无直接影响。
- 后端：`negentropy-perceives` PDF 转换流水线（`assembly.py`、`math_formula.py`）。
- GitHub Actions / 文档：无。

# Next Best Action
- 针对非学术论文格式（如技术报告、教科书）验证标题层级规范化规则的适用性，必要时引入文档类型检测进行差异化处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)