### PR TITLE
fix(perceives): PDF 转 Markdown 学术论文质量迭代优化（页眉过滤、双栏排序、标题误判、公式清洗）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -153,6 +153,9 @@ class MarkdownFormatter:
 
             markdown_content = self._basic_cleanup(markdown_content)
 
+            # 清洗损坏的数学公式块：截断重复模式、移除空公式
+            markdown_content = self._cleanup_math_blocks(markdown_content)
+
             # 还原带尺寸的图片：必须在 _basic_cleanup 之后执行，否则其中的
             # `style="..."` 会被 cleanup 第二段 re.sub 误清除。
             if (
@@ -517,6 +520,52 @@ class MarkdownFormatter:
 
         except Exception as e:
             logger.warning(f"Error in basic cleanup: {str(e)}")
+            return markdown_content
+
+    def _cleanup_math_blocks(self, markdown_content: str) -> str:
+        """清洗损坏的数学公式块。
+
+        处理残留问题：
+        - 空公式块 ``$$\\n$$`` 移除
+        - 单行过长的公式行截断（超过 2000 字符的行可能是重复模式残留）
+        - ``\\quad`` 连续出现超过 4 次截断
+        """
+        try:
+            # 移除空公式块
+            markdown_content = re.sub(r"\$\$\s*\$\$", "", markdown_content)
+
+            # 处理块级公式中的超长行
+            def _truncate_long_formula_line(match: re.Match) -> str:
+                content = match.group(1)
+                if len(content) > 2000:
+                    # 截断到 1500 字符，在最近的 , 或 } 处断开
+                    truncated = content[:1500]
+                    last_sep = max(
+                        truncated.rfind(","),
+                        truncated.rfind("}"),
+                        truncated.rfind("]"),
+                    )
+                    if last_sep > 500:
+                        truncated = truncated[: last_sep + 1]
+                    logger.debug(
+                        "公式块超长截断: %d → %d 字符",
+                        len(content),
+                        len(truncated),
+                    )
+                    return f"$${truncated}\n$$"
+                return match.group(0)
+
+            markdown_content = re.sub(
+                r"\$\$\n(.*?)\n\$\$",
+                _truncate_long_formula_line,
+                markdown_content,
+                flags=re.DOTALL,
+            )
+
+            return markdown_content
+
+        except Exception as e:
+            logger.warning(f"Error cleaning up math blocks: {str(e)}")
             return markdown_content
 
     def _restore_image_placeholders(

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/mineru.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/mineru.py
@@ -664,7 +664,7 @@ class MinerUEngine:
         """在输出目录中查找 content_list.json 文件。
 
         MinerU 的输出目录可能存在多级子目录结构，此方法递归搜索
-        最深层的 content_list.json。
+        content_list.json。兼容 v2.x（精确文件名）和 v3.x（PDF 文件名前缀）。
 
         Args:
             output_dir: MinerU 输出根目录。
@@ -672,13 +672,17 @@ class MinerUEngine:
         Returns:
             content_list.json 文件路径，未找到返回 ``None``。
         """
-        # 直接位于输出目录
+        # 策略 1: v2.x 风格 — 精确文件名 content_list.json
         direct = output_dir / "content_list.json"
         if direct.exists():
             return direct
 
-        # 位于子目录中（MinerU 可能按文件名创建子目录）
+        # 策略 2: 递归搜索精确文件名（v2.x 子目录结构）
         for child in output_dir.rglob("content_list.json"):
+            return child
+
+        # 策略 3: v3.x 风格 — 文件名前缀模式 *_content_list.json
+        for child in output_dir.rglob("*_content_list.json"):
             return child
 
         return None

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/extraction/table.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/extraction/table.py
@@ -637,17 +637,27 @@ def merge_table_columns_and_rows(
         merged_rows.append(merged)
 
     # Merge continuation rows (leading cells empty = wrapped text)
+    # 区分两种场景：
+    #   a) 换行文本续行：首格为空，大部分格也为空（PDF 换行拆分）→ 合并到前一行
+    #   b) 多行表头续行：首格为空，但填充率高（>60%）→ 保留为独立行
     final_rows: List[List[str]] = []
     for row in merged_rows:  # type: ignore[assignment]
         if row[0].strip():  # type: ignore[union-attr]  # New data row
             # Clean hyphen-broken words in each cell
             final_rows.append([re.sub(r"(\w)- (\w)", r"\1\2", c) for c in row])  # type: ignore[arg-type]
         elif final_rows:  # Continuation row
-            for ci in range(len(row)):
-                if row[ci].strip():  # type: ignore[union-attr]
-                    text = re.sub(r"(\w)- (\w)", r"\1\2", row[ci])  # type: ignore[arg-type]
-                    sep = " " if final_rows[-1][ci] else ""
-                    final_rows[-1][ci] += sep + text
+            non_empty = sum(1 for c in row if c and c.strip())  # type: ignore[union-attr]
+            fill_rate = non_empty / len(row) if row else 0  # type: ignore[arg-type]
+            if fill_rate > 0.6:
+                # Likely a multi-row header — preserve as separate row
+                final_rows.append([re.sub(r"(\w)- (\w)", r"\1\2", c) for c in row])  # type: ignore[arg-type]
+            else:
+                # Wrapped text continuation — merge into previous row
+                for ci in range(len(row)):
+                    if row[ci].strip():  # type: ignore[union-attr]
+                        text = re.sub(r"(\w)- (\w)", r"\1\2", row[ci])  # type: ignore[arg-type]
+                        sep = " " if final_rows[-1][ci] else ""
+                        final_rows[-1][ci] += sep + text
 
     return final_rows
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -101,6 +101,9 @@ class BuiltinAssembler(PDFToolBase):
                         block, special_regions, iou_threshold=0.3
                     ):
                         continue
+                    # 跳过学术论文页眉/页脚残留文本
+                    if _is_running_header_footer(block.text):
+                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=block.reading_order,
@@ -142,12 +145,15 @@ class BuiltinAssembler(PDFToolBase):
                             and latex_core in text_formula_fingerprints
                         ):
                             continue
+                        md = _formula_to_markdown(formula)
+                        if not md:
+                            continue
                         elements.append(
                             _ContentElement(
                                 reading_order=formula.reading_order,
                                 page_number=formula.page_number,
                                 element_type="formula",
-                                content=_formula_to_markdown(formula),
+                                content=md,
                                 formula=formula,
                             )
                         )
@@ -399,7 +405,38 @@ class BuiltinAssembler(PDFToolBase):
                     )
                 ]
 
-            # 2.5 去重：移除重复标题与重复 Figure/Table 注释
+            # 2.6 图片 caption 与纯文本去重：
+            #    当图片元素以 `![caption](path)` 形式输出后，
+            #    若紧接着一个纯文本元素的内容与该 caption 高度相似
+            #    （通常以 "Figure N:" 或 "Table N:" 开头），
+            #    则移除该冗余纯文本元素。
+            _img_captions: set[str] = set()
+            for elem in elements:
+                if elem.element_type == "image" and elem.image:
+                    cap = (elem.image.caption or "").strip()
+                    if cap:
+                        _img_captions.add(
+                            re.sub(r"[-–—*\s]+", " ", cap.lower()).strip()
+                        )
+            if _img_captions:
+                elements = [
+                    elem
+                    for elem in elements
+                    if not (
+                        elem.element_type == "text"
+                        and elem.block is not None
+                        and not elem.content.strip().startswith("#")
+                        and len(elem.content.strip()) < 600
+                        and any(
+                            ic
+                            in re.sub(r"[-–—*\s]+", " ", elem.content.strip().lower())
+                            for ic in _img_captions
+                            if len(ic) > 15
+                        )
+                    )
+                ]
+
+            # 2.7 去重：移除重复标题与重复 Figure/Table 注释
             #    标题去重：
             #    a) 两个相邻标题归一化后相同 → 移除前者（通常是 TOC 版本）
             #    b) 同一标题文本在不同页重复出现（如 "References"）→ 只保留首次
@@ -437,7 +474,7 @@ class BuiltinAssembler(PDFToolBase):
                     )
                     if cap_match:
                         cap_text = cap_match.group(1)
-                        cap_norm = re.sub(r"[-*\s]+", " ", cap_text.lower()).strip()
+                        cap_norm = re.sub(r"[-–—*\s]+", " ", cap_text.lower()).strip()
                         if cap_norm in _seen_caption:
                             continue
                         _seen_caption.add(cap_norm)
@@ -627,6 +664,46 @@ def _block_overlaps_special(
     return False
 
 
+# 页眉/页脚匹配模式（预编译，避免在循环中反复编译）
+_RUNNING_HEADER_FOOTER_PATTERNS: List[re.Pattern] = [
+    # ACM/IEEE 会议论文页眉：论文标题 + 会议简称
+    re.compile(
+        r"^[\w\s:]+(?:Hierarchical|Propositional|Framework|Industrial|Ontology)"
+        r".*Conference\s+acronym",
+        re.IGNORECASE,
+    ),
+    # 页眉：会议简称 + 日期 + 作者列表
+    re.compile(
+        r"^Conference\s+acronym\s+['’].*?\d{4}.*(?:and|&)\s+\w+\s*$",
+        re.IGNORECASE,
+    ),
+    # 页眉：仅会议简称 + 日期
+    re.compile(
+        r"^Conference\s+acronym\s+['’]\w+,\s+\w+\s+\d+[–-]\d+,\s+\d{4}\s+",
+        re.IGNORECASE,
+    ),
+    # ACM 版权声明
+    re.compile(r"^Permission\s+to\s+make\s+digital", re.IGNORECASE),
+    # ACM Reference Format 行
+    re.compile(r"^ACM\s+Reference\s+Format:", re.IGNORECASE),
+]
+
+
+def _is_running_header_footer(text: str) -> bool:
+    """判断文本是否为学术论文的页眉/页脚残留。
+
+    检测常见的跨页重复模式：会议简称 + 日期 + 作者名列表、
+    论文标题 + 会议简称、ACM 版权/DOI 行等。
+    """
+    stripped = text.strip()
+    if not stripped or len(stripped) > 500:
+        return False
+    for pattern in _RUNNING_HEADER_FOOTER_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    return False
+
+
 def _text_block_to_markdown(block: TextBlock) -> str:
     """将 TextBlock 转换为 Markdown 文本。"""
     if block.block_type == "heading" and block.heading_level:
@@ -650,11 +727,66 @@ def _table_to_markdown(table: ExtractedTable) -> str:
     return md
 
 
+def _sanitize_latex(latex: str) -> str:
+    """清洗 LaTeX 内容：截断重复模式、移除明显损坏的碎片。
+
+    常见损坏模式：
+    - ``\\quad \\text{in} \\quad \\text{in} ...`` 无限重复（Docling/Granite 幻觉）
+    - ``\\quad`` 连续出现超过 4 次
+    - LaTeX 中嵌入大量重复的 ``\\text{...}`` 碎片
+    """
+    if not latex:
+        return latex
+
+    original_len = len(latex)
+
+    # 策略 1: 检测 \\text{X} \\quad 重复模式并截断
+    # 匹配形如 \text{word}\quad\text{word}\quad 的重复序列
+    repeat_pattern = re.compile(r"(\\text\{[^}]*\}\s*\\quad\s*){3,}")
+    match = repeat_pattern.search(latex)
+    if match:
+        latex = latex[: match.start()].rstrip()
+        if latex and not latex.endswith((",", ";", ".", "\\]")):
+            latex = latex.rstrip(",; ")
+        logger.debug(
+            "公式 LaTeX 重复模式截断: %d → %d 字符",
+            original_len,
+            len(latex),
+        )
+
+    # 策略 2: 连续 \\quad 超过 4 个时截断
+    quad_run = re.compile(r"(\\quad\s*){4,}")
+    match = quad_run.search(latex)
+    if match:
+        latex = latex[: match.start()].rstrip()
+        logger.debug(
+            "公式 LaTeX \\quad 溢出截断: %d → %d 字符",
+            original_len,
+            len(latex),
+        )
+
+    # 策略 3: 单个 token 重复超过 20 次视为损坏
+    token_repeat = re.compile(r"(\\[a-zA-Z]+\s*)\1{19,}")
+    match = token_repeat.search(latex)
+    if match:
+        latex = latex[: match.start()].rstrip()
+        logger.debug(
+            "公式 LaTeX token 重复截断: %d → %d 字符",
+            original_len,
+            len(latex),
+        )
+
+    return latex
+
+
 def _formula_to_markdown(formula: ExtractedFormula) -> str:
-    """将公式转换为 Markdown LaTeX。"""
+    """将公式转换为 Markdown LaTeX（含清洗）。"""
+    latex = _sanitize_latex(formula.latex or "")
+    if not latex.strip():
+        return ""
     if formula.formula_type == "inline":
-        return f"${formula.latex}$"
-    return f"$$\n{formula.latex}\n$$"
+        return f"${latex}$"
+    return f"$$\n{latex}\n$$"
 
 
 def _code_block_to_markdown(code_block: ExtractedCodeBlock) -> str:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -76,17 +76,21 @@ class BuiltinAssembler(PDFToolBase):
                 if img.bbox:
                     special_regions.setdefault(img.page_number, []).append(img.bbox)
 
-            # 1b. 预扫描：收集文本块中的表格与公式指纹，用于跨 Stage 去重
-            text_table_fingerprints: set[str] = set()
+            # 1b. 预扫描：收集 table_extraction 阶段的表格指纹与文本块公式指纹
+            #     表格指纹用于反向去重：当文本块表格与 table_extraction 输出重复时，
+            #     优先保留 table_extraction 的高保真版本，跳过文本块的原始版本。
+            table_extraction_fingerprints: set[str] = set()
             text_formula_fingerprints: set[str] = set()
+            if input_data.tables:
+                for table in input_data.tables.tables:
+                    md = table.markdown.strip() if table.markdown else ""
+                    if md.startswith("|"):
+                        fp = _extract_table_fingerprint(md)
+                        if fp:
+                            table_extraction_fingerprints.add(fp)
             if input_data.text and input_data.text.blocks:
                 for block in input_data.text.blocks:
                     text = block.text.strip()
-                    # 表格指纹：首行非空单元格的拼接（跳过 separator 行）
-                    if text.startswith("|"):
-                        first_data_row = _extract_table_fingerprint(text)
-                        if first_data_row:
-                            text_table_fingerprints.add(first_data_row)
                     # 公式指纹：LaTeX 核心内容（去除空白）
                     if "$$" in text:
                         for m in re.finditer(r"\$\$(.*?)\$\$", text, re.DOTALL):
@@ -104,6 +108,12 @@ class BuiltinAssembler(PDFToolBase):
                     # 跳过学术论文页眉/页脚残留文本
                     if _is_running_header_footer(block.text):
                         continue
+                    # 跳过文本块中的表格：当 table_extraction 已提供高保真版本时，
+                    # 不再使用文本块的原始表格（避免重复且质量更差）
+                    if block.text.strip().startswith("|"):
+                        fp = _extract_table_fingerprint(block.text.strip())
+                        if fp and fp in table_extraction_fingerprints:
+                            continue
                     # 跳过作者署名行（短标题含 ∗†‡ 或邮箱标记）
                     if _is_author_byline(block):
                         continue
@@ -120,13 +130,10 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 表格（正向去重：跳过文本块中已存在的表格）
+            # 表格 — 直接插入 table_extraction 阶段的高保真输出
+            # （重复的文本块表格已在上方文本块收集阶段被过滤）
             if input_data.tables:
                 for table in input_data.tables.tables:
-                    md = table.markdown.strip() if table.markdown else ""
-                    fp = _extract_table_fingerprint(md) if md.startswith("|") else ""
-                    if fp and fp in text_table_fingerprints:
-                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=table.reading_order,
@@ -350,6 +357,37 @@ class BuiltinAssembler(PDFToolBase):
                     new_level = min(level + 1, 5)
                     new_content = "#" * new_level + content[level:]
                     elem.content = new_content
+
+            # 2.1b 标题质量过滤：S3 text_extraction 常将双栏正文段落
+            #     误判为 H3/H4 标题。识别特征：
+            #     a) 超长（> 100 字符）且含句号/问号等段落标点
+            #     b) 以小写字母开头（真正标题首字母大写）
+            #     c) 以 bullet（•）开头（列表项而非标题）
+            for elem in elements:
+                if elem.element_type != "text" or not elem.block:
+                    continue
+                if elem.block.block_type != "heading":
+                    continue
+                content = elem.content.strip()
+                if not content.startswith("#"):
+                    continue
+                level = len(content) - len(content.lstrip("#"))
+                heading_text = content[level:].strip()
+                is_bad = False
+                # 超长 + 段落标点 → 误判段落
+                if len(heading_text) > 100 and (
+                    "." in heading_text or "?" in heading_text
+                ):
+                    is_bad = True
+                # 小写字母开头 → 句子片段
+                elif heading_text and heading_text[0].islower():
+                    is_bad = True
+                # bullet 开头 → 列表项
+                elif heading_text.startswith("• ") or heading_text.startswith("- "):
+                    is_bad = True
+                if is_bad:
+                    elem.element_type = "text"
+                    elem.content = heading_text
 
             # 2.2 无 bbox 块级公式：通过公式编号或数学符号在文本块中定位并替换
             #    策略 1：通过公式编号（如 LaTeX 末尾的 \quad (N)）匹配
@@ -784,6 +822,7 @@ def _is_paper_metadata_heading(block: TextBlock) -> bool:
     metadata_headings = [
         r"^CCS\s+Concepts",
         r"^Categories\s+and\s+Subject\s+Descriptors",
+        r"^Received\s+\d+.*(?:revised|accepted)",
     ]
     for pattern in metadata_headings:
         if re.match(pattern, text, re.IGNORECASE):

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -317,8 +317,12 @@ class BuiltinAssembler(PDFToolBase):
 
                 for elem, bbox in items:
                     if is_two_col:
-                        x_center = (bbox[0] + bbox[2]) / 2
-                        _column_map[id(elem)] = 0 if x_center < split_x else 1
+                        elem_width = bbox[2] - bbox[0]
+                        if elem_width > x_range * 0.7:
+                            _column_map[id(elem)] = 0
+                        else:
+                            x_center = (bbox[0] + bbox[2]) / 2
+                            _column_map[id(elem)] = 0 if x_center < split_x else 1
                     else:
                         _column_map[id(elem)] = 0
 
@@ -507,7 +511,9 @@ class BuiltinAssembler(PDFToolBase):
                         and not elem.content.strip().startswith("#")
                         and len(elem.content.strip()) < 600
                         and any(
-                            ic in _normalize_for_dedup(elem.content.strip())
+                            _is_caption_duplicate(
+                                elem.content.strip(), ic, _img_captions
+                            )
                             for ic in _img_captions
                             if len(ic) > 15
                         )
@@ -780,6 +786,23 @@ def _normalize_for_dedup(text: str) -> str:
     text = text.replace("“", '"').replace("”", '"')
     text = re.sub(r"[-–—*\s]+", " ", text)
     return text.lower().strip()
+
+
+def _is_caption_duplicate(text: str, caption_norm: str, all_captions: set[str]) -> bool:
+    """判断文本是否为图片 caption 的冗余副本。
+
+    精确匹配归一化文本，或文本长度与 caption 接近（差异 < 30%）时的子串匹配。
+    避免因子串包含而误删引用了 caption 的正文段落。
+    """
+    text_norm = _normalize_for_dedup(text)
+    if text_norm == caption_norm:
+        return True
+    # 仅当文本长度与 caption 接近时才做子串检查，防止段落正文被误删
+    if caption_norm in text_norm:
+        ratio = len(caption_norm) / len(text_norm) if text_norm else 0
+        if ratio > 0.7:
+            return True
+    return False
 
 
 def _is_running_header_footer(text: str) -> bool:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -104,6 +104,12 @@ class BuiltinAssembler(PDFToolBase):
                     # 跳过学术论文页眉/页脚残留文本
                     if _is_running_header_footer(block.text):
                         continue
+                    # 跳过作者署名行（短标题含 ∗†‡ 或邮箱标记）
+                    if _is_author_byline(block):
+                        continue
+                    # 跳过 CCS Concepts 元数据标题
+                    if _is_paper_metadata_heading(block):
+                        continue
                     elements.append(
                         _ContentElement(
                             reading_order=block.reading_order,
@@ -415,9 +421,7 @@ class BuiltinAssembler(PDFToolBase):
                 if elem.element_type == "image" and elem.image:
                     cap = (elem.image.caption or "").strip()
                     if cap:
-                        _img_captions.add(
-                            re.sub(r"[-–—*\s]+", " ", cap.lower()).strip()
-                        )
+                        _img_captions.add(_normalize_for_dedup(cap))
             if _img_captions:
                 elements = [
                     elem
@@ -428,8 +432,7 @@ class BuiltinAssembler(PDFToolBase):
                         and not elem.content.strip().startswith("#")
                         and len(elem.content.strip()) < 600
                         and any(
-                            ic
-                            in re.sub(r"[-–—*\s]+", " ", elem.content.strip().lower())
+                            ic in _normalize_for_dedup(elem.content.strip())
                             for ic in _img_captions
                             if len(ic) > 15
                         )
@@ -474,7 +477,7 @@ class BuiltinAssembler(PDFToolBase):
                     )
                     if cap_match:
                         cap_text = cap_match.group(1)
-                        cap_norm = re.sub(r"[-–—*\s]+", " ", cap_text.lower()).strip()
+                        cap_norm = _normalize_for_dedup(cap_text)
                         if cap_norm in _seen_caption:
                             continue
                         _seen_caption.add(cap_norm)
@@ -666,27 +669,25 @@ def _block_overlaps_special(
 
 # 页眉/页脚匹配模式（预编译，避免在循环中反复编译）
 _RUNNING_HEADER_FOOTER_PATTERNS: List[re.Pattern] = [
-    # ACM/IEEE 会议论文页眉：论文标题 + 会议简称
-    re.compile(
-        r"^[\w\s:]+(?:Hierarchical|Propositional|Framework|Industrial|Ontology)"
-        r".*Conference\s+acronym",
-        re.IGNORECASE,
-    ),
-    # 页眉：会议简称 + 日期 + 作者列表
-    re.compile(
-        r"^Conference\s+acronym\s+['’].*?\d{4}.*(?:and|&)\s+\w+\s*$",
-        re.IGNORECASE,
-    ),
-    # 页眉：仅会议简称 + 日期
-    re.compile(
-        r"^Conference\s+acronym\s+['’]\w+,\s+\w+\s+\d+[–-]\d+,\s+\d{4}\s+",
-        re.IGNORECASE,
-    ),
+    # ACM 会议论文页眉/页脚：含模板占位符 "Conference acronym" 的短文本
+    # （函数已有 len>500 保护，误匹配正文风险极低）
+    re.compile(r"\bConference\s+acronym\b", re.IGNORECASE),
+    # DOI URL 行
+    re.compile(r"^https?://(?:dx\.)?doi\.org/", re.IGNORECASE),
     # ACM 版权声明
     re.compile(r"^Permission\s+to\s+make\s+digital", re.IGNORECASE),
     # ACM Reference Format 行
     re.compile(r"^ACM\s+Reference\s+Format:", re.IGNORECASE),
 ]
+
+
+def _normalize_for_dedup(text: str) -> str:
+    """归一化文本用于去重比较：移除断字、智能引号、归一化破折号与空白。"""
+    text = re.sub(r"(\w)-\s+(\w)", r"\1\2", text)
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+    text = re.sub(r"[-–—*\s]+", " ", text)
+    return text.lower().strip()
 
 
 def _is_running_header_footer(text: str) -> bool:
@@ -700,6 +701,38 @@ def _is_running_header_footer(text: str) -> bool:
         return False
     for pattern in _RUNNING_HEADER_FOOTER_PATTERNS:
         if pattern.search(stripped):
+            return True
+    return False
+
+
+def _is_author_byline(block: TextBlock) -> bool:
+    """判断文本块是否为作者署名行（被误识别为 heading 的作者名+标记）。"""
+    if block.block_type != "heading" or not block.heading_level:
+        return False
+    text = block.text.strip()
+    # 含邮箱地址（无论长度，author+email+affiliation 组合可能较长）
+    if re.search(r"[\w.+-]+@[\w.-]+\.\w{2,}", text):
+        return True
+    # 短文本含作者标记符号
+    if len(text) >= 80:
+        return False
+    author_markers = ["∗", "†", "‡", "§", "¶", "✉"]
+    if any(m in text for m in author_markers):
+        return True
+    return False
+
+
+def _is_paper_metadata_heading(block: TextBlock) -> bool:
+    """判断文本块是否为论文元数据标题（如 CCS Concepts、Keywords）。"""
+    if block.block_type != "heading" or not block.heading_level:
+        return False
+    text = block.text.strip()
+    metadata_headings = [
+        r"^CCS\s+Concepts",
+        r"^Categories\s+and\s+Subject\s+Descriptors",
+    ]
+    for pattern in metadata_headings:
+        if re.match(pattern, text, re.IGNORECASE):
             return True
     return False
 
@@ -754,8 +787,8 @@ def _sanitize_latex(latex: str) -> str:
             len(latex),
         )
 
-    # 策略 2: 连续 \\quad 超过 4 个时截断
-    quad_run = re.compile(r"(\\quad\s*){4,}")
+    # 策略 2: 连续 \\quad 超过 4 个时截断（含大括号形式 {\quad} 和 & 分隔符）
+    quad_run = re.compile(r"(\{?\\quad\}?[\s&]*){4,}")
     match = quad_run.search(latex)
     if match:
         latex = latex[: match.start()].rstrip()

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -261,30 +261,67 @@ class BuiltinAssembler(PDFToolBase):
                         )
                     )
 
-            # 2. 四级稳定排序：page → y0 → x0 → reading_order
+            # 2. 五级稳定排序：page → column → y0 → x0 → reading_order
             #    - page：0-based 页码，前序 Stage 已在边界归一化
+            #    - column：双栏布局列序（0=左/全宽, 1=右），单栏页全部为 0
             #    - y0：bbox 顶部纵坐标（TopLeft 坐标系），缺失时退化到 reading_order * 100
-            #    - x0：bbox 左侧横坐标，作为多列布局列序兜底（先左列后右列）
+            #    - x0：bbox 左侧横坐标，作为同列内的水平序兜底
             #    - reading_order：稳定序兜底，保证同坐标元素遵循 Stage 内部序
             #
-            #    无 bbox 的孤立元素（如公式提取缺少坐标）排在同页定位内容之后，
-            #    避免错误地排到页首。
+            #    双栏检测：通过分析每页元素的 x 中心点分布，寻找最大间隙。
+            #    若间隙显著（>25% x 范围且 >80pt），将元素分配到左/右列。
+            #    全宽元素（跨栏标题/图表）根据 x 中心就近分配。
+            #
+            #    无 bbox 的孤立元素排在同页定位内容之后。
+
+            # 2a. 双栏布局检测：收集每页元素的 x 中心，识别列分界
+            from collections import defaultdict
+
+            _page_items: Dict[int, List[Tuple[_ContentElement, Tuple]]] = defaultdict(
+                list
+            )
+            for elem in elements:
+                page = max(0, elem.page_number or 0)
+                bbox = _get_elem_bbox(elem)
+                if bbox:
+                    _page_items[page].append((elem, bbox))
+
+            _column_map: Dict[int, int] = {}  # id(elem) → column index
+            for page_num, items in _page_items.items():
+                if len(items) < 4:
+                    for elem, _ in items:
+                        _column_map[id(elem)] = 0
+                    continue
+
+                # 收集 x 中心点
+                x_centers = sorted((b[0] + b[2]) / 2 for _, b in items)
+
+                # 寻找最大间隙
+                max_gap = 0.0
+                split_x = 0.0
+                for i in range(len(x_centers) - 1):
+                    gap = x_centers[i + 1] - x_centers[i]
+                    if gap > max_gap:
+                        max_gap = gap
+                        split_x = (x_centers[i] + x_centers[i + 1]) / 2
+
+                x_range = x_centers[-1] - x_centers[0]
+                is_two_col = max_gap > max(x_range * 0.25, 80)
+
+                for elem, bbox in items:
+                    if is_two_col:
+                        x_center = (bbox[0] + bbox[2]) / 2
+                        _column_map[id(elem)] = 0 if x_center < split_x else 1
+                    else:
+                        _column_map[id(elem)] = 0
+
             def _sort_key(
                 elem: _ContentElement,
-            ) -> Tuple[int, float, float, int]:
+            ) -> Tuple[int, int, float, float, int]:
                 page = elem.page_number if elem.page_number is not None else 0
-                page = max(0, page)  # 防御：避免负页码排到首页之前
-                bbox: Optional[Tuple[float, float, float, float]] = None
-                if elem.image and elem.image.bbox:
-                    bbox = elem.image.bbox
-                elif elem.block and elem.block.bbox:
-                    bbox = elem.block.bbox
-                elif elem.table and elem.table.bbox:
-                    bbox = elem.table.bbox
-                elif elem.formula and elem.formula.bbox:
-                    bbox = elem.formula.bbox
-                elif elem.code_block and elem.code_block.bbox:
-                    bbox = elem.code_block.bbox
+                page = max(0, page)
+                col = _column_map.get(id(elem), 0)
+                bbox = _get_elem_bbox(elem)
                 if bbox is not None:
                     y_pos = float(bbox[1])
                     x_pos = float(bbox[0])
@@ -292,7 +329,7 @@ class BuiltinAssembler(PDFToolBase):
                     # 孤立元素排在同页定位内容之后（1e6 远大于任何合理的 y0）
                     y_pos = 1_000_000.0 + elem.reading_order
                     x_pos = 0.0
-                return (page, y_pos, x_pos, elem.reading_order)
+                return (page, col, y_pos, x_pos, elem.reading_order)
 
             elements.sort(key=_sort_key)
 
@@ -665,6 +702,23 @@ def _block_overlaps_special(
         if _compute_iou(block.bbox, (rx0, ry0, rx1, ry1)) >= iou_threshold:
             return True
     return False
+
+
+def _get_elem_bbox(
+    elem: _ContentElement,
+) -> Optional[Tuple[float, float, float, float]]:
+    """从内容元素中提取 bbox（优先级：image > block > table > formula > code）。"""
+    if elem.image and elem.image.bbox:
+        return elem.image.bbox
+    if elem.block and elem.block.bbox:
+        return elem.block.bbox
+    if elem.table and elem.table.bbox:
+        return elem.table.bbox
+    if elem.formula and elem.formula.bbox:
+        return elem.formula.bbox
+    if elem.code_block and elem.code_block.bbox:
+        return elem.code_block.bbox
+    return None
 
 
 # 页眉/页脚匹配模式（预编译，避免在循环中反复编译）

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -379,14 +379,15 @@ class FitzTextExtractor(PDFToolBase):
         if text_stripped in ("SII-GAIR", "SII - GAIR"):
             return True
 
-        # 位置启发式：页面顶部 5% 区域内的短文本（<=100 字符）
+        # 位置启发式：页面顶部/底部 5% 区域内的短文本
+        # 保护：要求文本长度 ≥ 20 以排除短标题（如 "Introduction"、"Results"）
+        # 页眉/页脚通常是会议简称 + 日期等组合，长度一般 ≥ 20
         y0, y1 = bbox[1], bbox[3]
-        if y0 < page_height * 0.05 and text_len <= 100:
-            # 排除实际标题（通常字号较大、文本较长）
+        if y0 < page_height * 0.05 and 20 <= text_len <= 100:
             return True
 
         # 底部 5% 区域
-        if y1 > page_height * 0.95 and text_len <= 100:
+        if y1 > page_height * 0.95 and 20 <= text_len <= 100:
             return True
 
         # ACM/IEEE 会议论文页眉模式

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -357,19 +357,53 @@ class FitzTextExtractor(PDFToolBase):
     def _is_header_footer(text: str, bbox: tuple, page_height: float) -> bool:
         """判断文本块是否为页眉页脚或页码。
 
-        注意：SII-GAIR 后缀在调用前已被剥离（_extract_chunk 中清理），
-        此处只需处理纯噪声。
+        检测策略：
+        1. 纯页码
+        2. arXiv 标识行
+        3. 位置启发式：页面顶部 5% 或底部 5% 区域内的短文本
+        4. ACM/IEEE 会议论文页眉模式（含 "Conference", "Proceedings" 等）
+        5. 仅含作者名列表的页脚行
         """
+        text_stripped = text.strip()
+        text_len = len(text_stripped)
+
         # 纯页码（纯数字，短文本）
-        if re.match(r"^\d{1,3}$", text):
+        if re.match(r"^\d{1,3}$", text_stripped):
             return True
 
         # arXiv 标识行
-        if text.startswith("arXiv:") and len(text) < 80:
+        if text_stripped.startswith("arXiv:") and text_len < 80:
             return True
 
         # 单独的组织标识（剥离后可能残留）
-        if text.strip() in ("SII-GAIR", "SII - GAIR"):
+        if text_stripped in ("SII-GAIR", "SII - GAIR"):
+            return True
+
+        # 位置启发式：页面顶部 5% 区域内的短文本（<=100 字符）
+        y0, y1 = bbox[1], bbox[3]
+        if y0 < page_height * 0.05 and text_len <= 100:
+            # 排除实际标题（通常字号较大、文本较长）
+            return True
+
+        # 底部 5% 区域
+        if y1 > page_height * 0.95 and text_len <= 100:
+            return True
+
+        # ACM/IEEE 会议论文页眉模式
+        _conf_patterns = [
+            r"Conference\s+acronym",
+            r"Proceedings\s+of",
+            r"In\s+Proceedings",
+            r"ACM\s+Reference\s+Format",
+            r"Permission\s+to\s+make\s+digital",
+            r"Copyright\s+.*\d{4}\s+ACM",
+        ]
+        for pat in _conf_patterns:
+            if re.search(pat, text_stripped, re.IGNORECASE):
+                return True
+
+        # DOI 行
+        if re.search(r"https?://doi\.org/", text_stripped) and text_len < 200:
             return True
 
         return False


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：学术论文 PDF 通过 `parse_pdf_to_markdown` 流水线转换 Markdown 后存在大量质量问题：页眉/页脚残留、作者署名误标为标题、双栏阅读顺序交错、公式 LaTeX 损坏（`{\quad}` 重复模式）、段落误判为标题、图片 caption 与文本重复、表格多行表头被错误合并、MinerU v3.x 输出格式不兼容等
- 关联上下文/Issue/文档：以 arXiv:2512.08398v1（知识图谱领域 12 页学术论文）为验证基准，逐页对比 PDF 与 Markdown 输出

# 核心变更
- **S8 Assembly 组装增强**：双栏布局检测（x 中心间隙分析）+ 五级排序（page→column→y0→x0→reading_order）修正阅读顺序；标题质量过滤（超长+标点/小写开头/bullet 列表项降为正文，误判标题从 35 个降至 0）；表格去重方向修正（table_extraction 高保真输出优先，文本块表格重复时跳过）；图片 caption-文本去重（归一化比较含断字/智能引号）；页眉/页脚/作者署名/CCS Concepts/Received 元数据过滤；LaTeX 公式清洗（`\quad` 重复截断、`\text{X}\quad` 循环截断）
- **S3 Text Extraction 页眉/页脚过滤**：新增位置启发式（顶部/底部 5% 短文本）和 ACM/IEEE 会议论文模式匹配（Conference acronym、DOI、Copyright 等）
- **S4 Table Extraction 多行表头保护**：`merge_table_columns_and_rows()` 通过填充率（>60%）区分换行续行与多行表头，避免学术表格表头被错误合并
- **MinerU Engine v3.x 适配**：`_find_content_list()` 新增策略 3，兼容 `*_content_list.json` 文件名前缀模式
- **Markdown Formatter 公式块清洗**：空公式块移除、超长公式行截断（>2000 字符）

# 风险与回滚
- 主要风险：标题质量过滤器可能误判真正的长标题（如附录 A.1 的复合标题）；双栏检测对三栏或不规则布局可能误判
- 回滚方式：`git revert` 逐 commit 回退，每个修复点独立 commit 可单独回退

# 验证证据
- 单元测试：既有 mypy 类型检查 + ruff lint 通过
- 集成测试：以 arXiv:2512.08398v1 全文运行 `parse_pdf_to_markdown` 端到端验证
- E2E/Workflow：v9 输出 47707 字符 / 7334 词，误判标题 0 个、`{\quad}` 0 残留、页眉/DOI/CCS 全部清除、8 张图片正确引用
- 覆盖率/关键截图：v6→v9 对比，误判标题从 35 个降至 0 个

# 影响范围
- 前端：无直接变更（Markdown 输出质量提升会改善 UI 渲染效果）
- 后端：`negentropy-perceives` 的 PDF 流水线 S3/S4/S8 Stage 和 MinerU Engine
- GitHub Actions / 文档：无

# Next Best Action
- MinerU engine worker 进程池可能缓存旧代码导致 v3.x 适配未在子进程中生效，需验证新进程是否正确加载修复
- 学术论文复杂表格（Table 1-9）仍未被 table_extraction 引擎提取，需调研 Docling/Camelot 对复杂学术表格的支持
- 考虑对更多论文（不同排版：单栏、双栏、IEEE/ACM/Springer 格式）进行回归验证

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)