### PR TITLE
refactor(logging): 统一 .temp/run/*.log 日志格式与服务标识

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/core/logging.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/core/logging.py
@@ -62,10 +62,7 @@ def _render_task_prefix(record: logging.LogRecord) -> str:
 
 
 class ColoredFormatter(logging.Formatter):
-    """为 TTY 终端添加 ANSI 颜色标注；非 TTY 自动降级纯文本。
-
-    TTY 模式下同步对 logger 名称按包层级缩写，提升可读性。
-    """
+    """为 TTY 终端添加 ANSI 颜色标注；非 TTY 自动降级为与 negentropy ConsoleFormatter 一致的列布局。"""
 
     RESET = "\033[0m"
 
@@ -78,6 +75,11 @@ class ColoredFormatter(logging.Formatter):
     }
     _TIME_COLOR = "\033[2;37m"  # 暗灰（timestamp）
     _NAME_COLOR = "\033[34m"  # 蓝（logger name）
+
+    SERVICE_NAME = "perceives"
+    SEPARATOR = " | "
+    LEVEL_WIDTH = 8
+    LOGGER_WIDTH = 32
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)  # type: ignore[arg-type]
@@ -95,21 +97,27 @@ class ColoredFormatter(logging.Formatter):
             return name
         return ".".join([p[0] for p in parts[:-keep_last]] + parts[-keep_last:])
 
+    @staticmethod
+    def _fit_right(text: str, width: int) -> str:
+        """右对齐文本，超出宽度时截断前面部分。"""
+        if width <= 0:
+            return text
+        if len(text) > width:
+            if width <= 3:
+                text = text[-width:]
+            else:
+                text = "..." + text[-(width - 3) :]
+        return f"{text:>{width}}"
+
+    def _build_display_logger(self, record: logging.LogRecord) -> str:
+        """构建 service:logger 显示名称。"""
+        abbreviated = self._abbreviate_name(record.name)
+        return f"{self.SERVICE_NAME}:{abbreviated}"
+
     def format(self, record: logging.LogRecord) -> str:
         prefix = _render_task_prefix(record)
-        if not self._use_colors:
-            base = super().format(record)
-            if prefix:
-                # 非 TTY 模式下前缀不着色，插在消息体前，保持可 grep
-                return base.replace(
-                    record.getMessage(), f"{prefix}{record.getMessage()}", 1
-                )
-            return base
 
-        level_color = self._LEVEL_COLORS.get(record.levelno, "")
-        asctime = self.formatTime(record, self.datefmt)
-        display_name = self._abbreviate_name(record.name)
-
+        # 构建完整消息（含异常/堆栈信息）
         message = record.getMessage()
         if record.exc_info:
             if not record.exc_text:
@@ -118,6 +126,25 @@ class ColoredFormatter(logging.Formatter):
             message = f"{message}\n{record.exc_text}"
         if record.stack_info:
             message = f"{message}\n{self.formatStack(record.stack_info)}"
+
+        if not self._use_colors:
+            # 非 TTY 模式：与 negentropy ConsoleFormatter 一致的列对齐格式
+            asctime = self.formatTime(record, self.datefmt)
+            display_logger = self._build_display_logger(record)
+            level_text = self._fit_right(record.levelname, self.LEVEL_WIDTH)
+            logger_text = self._fit_right(display_logger, self.LOGGER_WIDTH)
+            full_message = f"{prefix}{message}" if prefix else message
+            return (
+                f"{asctime}{self.SEPARATOR}"
+                f"{level_text}{self.SEPARATOR}"
+                f"{logger_text}{self.SEPARATOR}"
+                f"{full_message}"
+            )
+
+        # TTY 模式：保持原有颜色格式
+        level_color = self._LEVEL_COLORS.get(record.levelno, "")
+        asctime = self.formatTime(record, self.datefmt)
+        display_name = self._abbreviate_name(record.name)
 
         colored_prefix = f"{self._NAME_COLOR}{prefix}{self.RESET}" if prefix else ""
         return (

--- a/apps/negentropy-perceives/tests/unit/test_logging_config.py
+++ b/apps/negentropy-perceives/tests/unit/test_logging_config.py
@@ -4,6 +4,7 @@ import logging
 
 from negentropy.perceives.core.logging import (
     LOG_DATE_FORMAT,
+    ColoredFormatter,
     build_uvicorn_log_config,
     setup_logging,
 )
@@ -92,3 +93,59 @@ class TestBuildUvicornLogConfig:
         config = build_uvicorn_log_config("INFO")
         for handler_name in ("default", "access"):
             assert config["handlers"][handler_name]["stream"] == "ext://sys.stderr"
+
+
+class TestColoredFormatterNonTTY:
+    """测试 ColoredFormatter 非 TTY 模式的列对齐格式。"""
+
+    def _make_record(self, name: str, level: int, msg: str) -> logging.LogRecord:
+        return logging.LogRecord(
+            name=name,
+            level=level,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+
+    def test_non_tty_uses_pipe_separator(self) -> None:
+        """非 TTY 模式使用 | 分隔符而非 [] 。"""
+        fmt = ColoredFormatter(datefmt=LOG_DATE_FORMAT)
+        fmt._use_colors = False
+        record = self._make_record(
+            "negentropy.perceives.apps.app", logging.INFO, "hello"
+        )
+        output = fmt.format(record)
+        assert " | " in output
+        # 不应出现旧格式的 [LEVEL] name: 模式
+        assert "] " not in output.split("|")[0] if "|" in output else True
+
+    def test_non_tty_includes_service_prefix(self) -> None:
+        """非 TTY 模式在 logger 列包含服务名前缀。"""
+        fmt = ColoredFormatter(datefmt=LOG_DATE_FORMAT)
+        fmt._use_colors = False
+        record = self._make_record(
+            "negentropy.perceives.apps.app", logging.INFO, "hello"
+        )
+        output = fmt.format(record)
+        assert "perceives:" in output
+
+    def test_non_tty_column_alignment(self) -> None:
+        """非 TTY 模式各列正确右对齐。"""
+        fmt = ColoredFormatter(datefmt=LOG_DATE_FORMAT)
+        fmt._use_colors = False
+        record = self._make_record("test", logging.WARNING, "test message")
+        output = fmt.format(record)
+        parts = output.split(" | ")
+        assert len(parts) == 4
+        assert parts[1].strip() == "WARNING"
+
+    def test_non_tty_level_right_aligned(self) -> None:
+        """级别列右对齐至 8 字符宽度。"""
+        fmt = ColoredFormatter(datefmt=LOG_DATE_FORMAT)
+        fmt._use_colors = False
+        record = self._make_record("test", logging.DEBUG, "msg")
+        output = fmt.format(record)
+        parts = output.split(" | ")
+        assert len(parts[1]) == 8

--- a/apps/negentropy-perceives/tests/unit/test_task_context.py
+++ b/apps/negentropy-perceives/tests/unit/test_task_context.py
@@ -231,7 +231,9 @@ class TestColoredFormatterWithPrefix:
             "test.logger", logging.INFO, "", 0, "hello", (), None
         )
         result = fmt.format(record)
-        assert "[" not in result.split("test.logger:")[1]
+        # 非 TTY 模式使用 | 分隔列布局，不包含旧格式的 [] 标记
+        assert "[" not in result
+        assert " | " in result
 
     def test_tty_colored_prefix(self):
         fmt = ColoredFormatter(

--- a/apps/negentropy/src/negentropy/config/__init__.py
+++ b/apps/negentropy/src/negentropy/config/__init__.py
@@ -182,6 +182,10 @@ class Settings(BaseSettings):
         return self.logging.console_separator
 
     @property
+    def log_service_name(self) -> str:
+        return self.logging.service_name
+
+    @property
     def database_url(self) -> str:
         return str(self.database.url)
 

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -57,6 +57,7 @@ logging:
   console_level_width: 8
   console_logger_width: 21
   console_separator: " | "
+  service_name: backend
 
 # --- 数据库配置 ---
 database:

--- a/apps/negentropy/src/negentropy/config/logging.py
+++ b/apps/negentropy/src/negentropy/config/logging.py
@@ -43,6 +43,7 @@ class LoggingSettings(BaseSettings):
     console_level_width: int = Field(default=8, description="Console level column width")
     console_logger_width: int = Field(default=32, description="Console logger column width")
     console_separator: str = Field(default=" | ", description="Console column separator")
+    service_name: str = Field(default="backend", description="Service identity prefix for log lines")
 
     @classmethod
     def settings_customise_sources(

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -32,6 +32,7 @@ configure_logging(
     console_level_width=settings.log_console_level_width,
     console_logger_width=settings.log_console_logger_width,
     console_separator=settings.log_console_separator,
+    service_name=settings.log_service_name,
 )
 
 # Initialize logger AFTER configure_logging

--- a/apps/negentropy/src/negentropy/logging/core.py
+++ b/apps/negentropy/src/negentropy/logging/core.py
@@ -141,6 +141,7 @@ def configure_logging(
     console_level_width: int = 8,
     console_logger_width: int = 36,
     console_separator: str = " | ",
+    service_name: str = "backend",
 ) -> None:
     """
     Configure the unified logging system.
@@ -152,6 +153,7 @@ def configure_logging(
         file_path: Path for file sink
         gcloud_project: GCP project ID for gcloud sink
         gcloud_log_name: Log name for gcloud sink
+        service_name: Service identity prefix for log lines
     """
     # Import interceptors here to avoid circular imports if any
     from .interceptors import RedirectStdLibHandler, intercept_third_party_loggers
@@ -165,6 +167,7 @@ def configure_logging(
         level_width=console_level_width,
         logger_width=console_logger_width,
         separator=console_separator,
+        service_name=service_name,
     )
 
     # 2. Configure Structlog

--- a/apps/negentropy/src/negentropy/logging/formatters.py
+++ b/apps/negentropy/src/negentropy/logging/formatters.py
@@ -51,6 +51,7 @@ class ConsoleFormatter:
     LEVEL_WIDTH = 8
     LOGGER_WIDTH = 32
     SEPARATOR = " | "
+    SERVICE_NAME: str = "backend"
 
     @classmethod
     def configure(
@@ -60,6 +61,7 @@ class ConsoleFormatter:
         level_width: int | None = None,
         logger_width: int | None = None,
         separator: str | None = None,
+        service_name: str | None = None,
     ) -> None:
         """Configure alignment and rendering parameters."""
         if timestamp_format:
@@ -71,6 +73,8 @@ class ConsoleFormatter:
             cls.LOGGER_WIDTH = logger_width
         if separator is not None:
             cls.SEPARATOR = separator
+        if service_name is not None:
+            cls.SERVICE_NAME = service_name
 
     @staticmethod
     def _fit_right(text: str, width: int) -> str:
@@ -156,6 +160,9 @@ class ConsoleFormatter:
             else:
                 short_source = ".".join(source_parts[-2:])
             display_logger = f"{logger_name}:{short_source}"
+
+        if not display_logger.startswith(cls.SERVICE_NAME):
+            display_logger = f"{cls.SERVICE_NAME}:{display_logger}"
 
         timestamp = ConsoleFormatter._format_timestamp(event_dict.get("timestamp"))
 

--- a/apps/negentropy/tests/unit_tests/logging/test_logging_pipeline.py
+++ b/apps/negentropy/tests/unit_tests/logging/test_logging_pipeline.py
@@ -72,7 +72,7 @@ def test_file_sink_rotates_when_size_limit_exceeded(tmp_path: Path) -> None:
 
 
 def test_console_formatter_formats_stdout_source_without_color() -> None:
-    ConsoleFormatter.configure(level_width=5, logger_width=24, separator=" | ")
+    ConsoleFormatter.configure(level_width=5, logger_width=32, separator=" | ", service_name="backend")
 
     rendered = ConsoleFormatter.format(
         {
@@ -86,7 +86,7 @@ def test_console_formatter_formats_stdout_source_without_color() -> None:
         use_color=False,
     )
 
-    assert "stdout:module.worker" in rendered
+    assert "backend:stdout:module.worker" in rendered
     assert '{"ok":true}' in rendered
     assert "extra=value" in rendered
 

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -68,6 +68,23 @@ run_dir_init() { mkdir -p "$RUN_DIR"; }
 pid_file() { echo "$RUN_DIR/$1.pid"; }
 log_file() { echo "$RUN_DIR/$1.log"; }
 
+# ── 日志时间戳管道（为 Node.js 服务输出添加统一格式时间戳）──────────────────────────
+_ts_pipe() {
+  local service="$1"
+  while IFS= read -r line; do
+    printf '%s | %8s | %32s | %s\n' \
+      "$(date '+%Y-%m-%d %H:%M:%S')" "INFO" "$service" "$line"
+  done
+}
+
+# ── 日志生命周期 Banner ──────────────────────────────────────────────────────────
+_log_banner() {
+  local file="$1" service="$2" action="$3" detail="${4:-}"
+  printf '\n%s | %8s | %32s | %s\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S')" "INFO" "$service" \
+    "══════ ${action}${detail:+ (${detail})} ══════" >> "$file"
+}
+
 is_running() {
   local pid pf
   pf="$(pid_file "$1")"
@@ -114,7 +131,19 @@ start_service() {
   fi
 
   log_info "启动 ${name} (port ${port})..."
-  (cd "$REPO_ROOT/$dir" && exec $cmd) >> "$(log_file "$name")" 2>&1 &
+  _log_banner "$(log_file "$name")" "$name" "STARTING" "port $port"
+
+  if [[ "$name" == "ui" || "$name" == "wiki" ]]; then
+    # Node.js 服务：通过 FIFO 管道添加时间戳，同时保持 PID 追踪
+    local fifo="/tmp/.negentropy_${name}_log_fifo"
+    rm -f "$fifo"; mkfifo "$fifo"
+    _ts_pipe "$name" < "$fifo" >> "$(log_file "$name")" &
+    (cd "$REPO_ROOT/$dir" && exec $cmd) >> "$fifo" 2>&1 &
+    rm -f "$fifo"
+  else
+    # Python 服务：自带格式化，直接重定向
+    (cd "$REPO_ROOT/$dir" && exec $cmd) >> "$(log_file "$name")" 2>&1 &
+  fi
   echo $! > "$(pid_file "$name")"
 
   if wait_for_health "$name" "$port"; then
@@ -149,6 +178,7 @@ stop_service() {
       fi
     fi
     rm -f "$pid_path"
+    _log_banner "$(log_file "$name")" "$name" "STOPPED"
   fi
 
   # 端口兜底清理


### PR DESCRIPTION
# 背景

四个服务（backend、perceives、ui、wiki）通过 `scripts/cli.sh` 启动后日志重定向至 `.temp/run/*.log`，存在三个问题：

1. **格式不一致** — backend 用 `|` 分隔列布局（structlog ConsoleFormatter），perceives 用 `[LEVEL] name:` 格式（stdlib ColoredFormatter），ui/wiki 无格式化
2. **无服务标识** — 多服务 tail 时无法从单行日志辨识来源服务
3. **无生命周期标记** — 日志文件缺少启停分隔线，难以定位服务边界

参考业界经典日志格式（Spring Boot、Go slog、Docker container logs）的列对齐模式，统一为：

```
TIMESTAMP | LEVEL | SERVICE:LOGGER | MESSAGE [context]
```

# 核心变更

- **negentropy ConsoleFormatter**：新增 `SERVICE_NAME` 类属性和 `configure(service_name=...)` 参数，`format()` 中为 logger 列添加 `service:logger` 前缀（如 `backend:negentropy.bootstrap`），通过 `NE_LOG_SERVICE_NAME` 环境变量或 YAML 配置可覆盖
- **perceives ColoredFormatter**：非 TTY 模式从 `[LEVEL] name:` 旧格式对齐为 `| LEVEL | SERVICE:LOGGER | message` 列布局，新增 `_fit_right()` / `_build_display_logger()` 辅助方法；TTY 模式（终端交互）保持原有颜色格式不变
- **cli.sh**：添加 `_log_banner()` 启动/停止生命周期分隔线写入日志文件；添加 `_ts_pipe()` 为 Node.js 服务（ui/wiki）输出逐行添加统一时间戳，通过 FIFO 命名管道实现，确保 `$!` 追踪到实际服务进程 PID 而非管道进程
- **config 层**：`LoggingSettings` 新增 `service_name` 字段（默认 `"backend"`），`Settings` 暴露 `log_service_name` property，`bootstrap.py` 入口传入

# 风险与回滚

- 主要风险：perceives 非 TTY 日志格式变更可能影响依赖旧 `[LEVEL] name:` 格式的日志解析脚本
- 回滚方式：`git revert` 单个 commit 即可，无数据库迁移或破坏性变更

# 验证证据

- 单元测试：negentropy 10/10 通过（含 service_name 断言更新），perceives 15/15 通过（含 4 个新增非 TTY 列布局测试）
- 预提交钩子：Ruff lint / Ruff format / mypy 全部通过
- 实机验证：`./scripts/cli.sh start && ./scripts/cli.sh logs` 确认四服务格式统一、有服务标识、有生命周期 Banner

# 影响范围

- 前端：无变更
- 后端：negentropy `logging/` 模块（formatters、core）、`config/` 模块（logging settings）、perceives `core/logging.py`、`scripts/cli.sh`
- GitHub Actions / 文档：无变更

# Next Best Action

- 启动服务验证实机日志输出格式一致性