### PR TITLE
fix(MainNav): 修复一级导航选中状态与二级子页面联级丢失

### DIFF
--- a/apps/negentropy-ui/components/layout/MainNav.tsx
+++ b/apps/negentropy-ui/components/layout/MainNav.tsx
@@ -3,11 +3,11 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { NavItem } from "@/config/navigation";
+import { type MainNavItem } from "@/config/navigation";
 import { useAuth } from "@/components/providers/AuthProvider";
 
 interface MainNavProps {
-  items?: NavItem[];
+  items?: MainNavItem[];
 }
 
 export function MainNav({ items }: MainNavProps) {
@@ -25,13 +25,10 @@ export function MainNav({ items }: MainNavProps) {
       {visibleItems?.length ? (
         <nav className="flex items-center gap-1 bg-zinc-100/50 p-1 rounded-full dark:bg-zinc-800/50">
           {visibleItems.map((item, index) => {
-            // Logic to determine active state.
-            // For "/", it matches exactly or if strictly root.
-            // For others, startsWith.
-            const isActive =
-              item.href === "/"
-                ? pathname === "/"
-                : pathname?.startsWith(item.href);
+            const matchPaths = item.activePaths ?? [item.href];
+            const isActive = matchPaths.some(
+              (p) => (p === "/" ? pathname === "/" : pathname?.startsWith(p))
+            );
 
             return (
               <Link

--- a/apps/negentropy-ui/config/navigation.ts
+++ b/apps/negentropy-ui/config/navigation.ts
@@ -6,12 +6,16 @@ export type NavItem = {
   roles?: string[];
 };
 
-export type MainNavItem = NavItem;
+export type MainNavItem = NavItem & {
+  /** Active 状态匹配路径前缀列表。未设置时默认为 [href] */
+  activePaths?: string[];
+};
 
 export const mainNavConfig: MainNavItem[] = [
   {
     title: "Home",
     href: "/",
+    activePaths: ["/", "/studio", "/dashboard"],
   },
   {
     title: "Knowledge",
@@ -20,10 +24,12 @@ export const mainNavConfig: MainNavItem[] = [
   {
     title: "Memory",
     href: "/memory/timeline",
+    activePaths: ["/memory"],
   },
   {
     title: "Interface",
     href: "/interface/subagents",
+    activePaths: ["/interface"],
   },
   {
     title: "Admin",


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：一级导航（MainNav）的选中状态判断逻辑存在缺陷，当用户在部分二级子页面时，对应的一级导航项未正确高亮。例如 `/studio` 页面下，二级导航 "Studio" 正确高亮，但一级导航 "Home" 未高亮。
- 根因：Home 使用 `pathname === "/"` 精确匹配，遗漏 `/studio`、`/dashboard`；Memory 的 `startsWith("/memory/timeline")` 遗漏 `/memory/facts` 等子页面；Interface 的 `startsWith("/interface/subagents")` 遗漏 `/interface/mcp` 等子页面。

# 核心变更
- 在 `MainNavItem` 类型中新增可选字段 `activePaths: string[]`，显式声明每个一级模块覆盖的路径前缀列表
- 为 Home 配置 `["/", "/studio", "/dashboard"]`，Memory 配置 `["/memory"]`，Interface 配置 `["/interface"]`，未配置时回退到 `[href]`
- `MainNav.tsx` 的 `isActive` 逻辑从隐式 `href` 派生匹配改为基于 `activePaths` 声明式匹配，`"/"` 路径精确匹配，其他前缀匹配

# 风险与回滚
- 主要风险：`activePaths` 配置缺失时回退到 `[href]`，行为与修改前一致，无破坏性变更
- 回滚方式：`git revert` 该 commit

# 验证证据
- 单元测试：无（UI 选中状态变更）
- 集成测试：无
- E2E/Workflow：浏览器实机验证全部 5 个模块（Home/Studio、Home/Dashboard、Knowledge/Base、Memory/Facts、Interface/MCP、Admin/Roles），一级导航选中状态均正确联级
- 覆盖率/关键截图：![Home/Studio 一级导航选中](https://maas-log-prod.cn-wlcb.ufileos.com/anthropic/c206b851-1437-47d6-8b44-a5ff25af971d/nav-home-studio-active.png?UCloudPublicKey=TOKEN_e15ba47a-d098-4fbd-9afc-a0dcf0e4e621&Expires=1779681857&Signature=GiAi4h20DLoQ5npiSw+ZZikaI8A=)

# 影响范围
- 前端：`apps/negentropy-ui/config/navigation.ts`（类型扩展 + 配置更新）、`apps/negentropy-ui/components/layout/MainNav.tsx`（选中逻辑修复）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 后续若新增 Home 模块子页面（如 `/settings`），需同步更新 `mainNavConfig` 中 Home 的 `activePaths` 列表

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>