### PR TITLE
fix(cli): 降级 start_service 已在运行日志为 info 级别

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -120,7 +120,7 @@ start_service() {
   cmd="$(svc_start_cmd "$name")"
 
   if is_running "$name"; then
-    log_warn "${name} 已在运行 (PID $(cat "$(pid_file "$name")"))"
+    log_info "${name} 已在运行 (PID $(cat "$(pid_file "$name")"))"
     return 0
   fi
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`scripts/cli.sh start` 的 Phase 4 为 wiki SSG 构建提前启动 `perceives` 和 `backend`，Phase 5 再次遍历 `ALL_SERVICES` 时这两个服务命中 `is_running` 检查，输出 `log_warn`（黄色警告）。但这是**预期行为**而非异常，warning 级别语义不当，给用户造成不必要的视觉噪音与"出问题了"的错觉。
- 关联上下文/Issue/文档：无

# 核心变更
- `scripts/cli.sh:start_service()` 中 `is_running` 命中时的日志级别从 `log_warn`（黄色）降级为 `log_info`（蓝色）

# 风险与回滚
- 主要风险：无。仅变更日志输出级别，不影响任何启动/停止/健康检查逻辑
- 回滚方式：`git revert`

# 验证证据
- 单元测试：N/A（Shell 脚本无单测覆盖）
- 集成测试：N/A
- E2E/Workflow：手动验证 `./scripts/cli.sh start` 全流程，Phase 5 已启动服务输出蓝色 info 而非黄色 warn
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：无（仅 `scripts/cli.sh` 开发工具链脚本）
- GitHub Actions / 文档：无

# Next Best Action
- 无需后续操作