### PR TITLE
feat(wiki-ui): 首页 Hero 条幅改造为液态流动渐变动画背景;

### DIFF
--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -61,17 +61,20 @@ export default async function WikiHomePage() {
       footer={<WikiFooter />}
     >
       <section className="home-hero">
-        <p className="home-hero-text">
-          关注人工智能与互联网技术的前沿动态，工作学习提升、生活日常记录、兴趣知识分享
-        </p>
-        <p className="home-hero-subtext">
-          你我的知识，绝非一场零和的游戏！
-        </p>
-        {firstPubSlug && (
-          <a href={firstPubSlug} className="home-hero-cta">
-            深度学习 | 引介 → 5min
-          </a>
-        )}
+        <div className="home-hero-bg" aria-hidden="true" />
+        <div className="home-hero-content">
+          <p className="home-hero-text">
+            关注人工智能与互联网技术的前沿动态，工作学习提升、生活日常记录、兴趣知识分享
+          </p>
+          <p className="home-hero-subtext">
+            你我的知识，绝非一场零和的游戏！
+          </p>
+          {firstPubSlug && (
+            <a href={firstPubSlug} className="home-hero-cta">
+              深度学习 | 引介 → 5min
+            </a>
+          )}
+        </div>
       </section>
 
       <section className="home-cards-section">

--- a/apps/negentropy-wiki/src/styles/components/home-hero.css
+++ b/apps/negentropy-wiki/src/styles/components/home-hero.css
@@ -1,9 +1,49 @@
-/* 首页 Hero Banner */
+/* 首页 Hero Banner — 液态流动渐变动画 */
+
+/* ── 外层容器 ── */
 .home-hero {
-  background: var(--wiki-home-accent);
+  position: relative;
+  overflow: hidden;
+  background: var(--wiki-hero-base);
   color: #ffffff;
   text-align: center;
   padding: 4rem 2rem 3.5rem;
+}
+
+/* ── 背景层：多层 radial-gradient 斑点 + blur 有机柔化 ── */
+.home-hero-bg {
+  position: absolute;
+  inset: -50%;
+  z-index: 0;
+  filter: blur(60px);
+  opacity: 0.85;
+  background:
+    radial-gradient(circle at 30% 40%, var(--wiki-hero-blob-1) 0%, transparent 70%),
+    radial-gradient(circle at 70% 60%, var(--wiki-hero-blob-2) 0%, transparent 70%);
+  animation: hero-drift-1 14s ease-in-out infinite alternate;
+}
+
+.home-hero-bg::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 80%, var(--wiki-hero-blob-3) 0%, transparent 70%);
+  animation: hero-drift-2 18s ease-in-out infinite alternate;
+}
+
+.home-hero-bg::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, #34D399 0%, transparent 60%);
+  opacity: 0.5;
+  animation: hero-drift-3 22s ease-in-out infinite alternate;
+}
+
+/* ── 内容层 ── */
+.home-hero-content {
+  position: relative;
+  z-index: 1;
 }
 
 .home-hero-text {
@@ -36,12 +76,47 @@
   color: var(--wiki-home-accent);
 }
 
+/* ── @keyframes：三组不同周期的对角线漂移 ── */
+@keyframes hero-drift-1 {
+  0%   { transform: translate(-20%, -15%) scale(1.1); }
+  33%  { transform: translate(10%, 25%) scale(0.95); }
+  66%  { transform: translate(25%, -10%) scale(1.05); }
+  100% { transform: translate(-10%, 20%) scale(1); }
+}
+
+@keyframes hero-drift-2 {
+  0%   { transform: translate(15%, 20%) scale(0.95); }
+  33%  { transform: translate(-25%, -5%) scale(1.1); }
+  66%  { transform: translate(5%, -20%) scale(1); }
+  100% { transform: translate(-15%, 15%) scale(1.05); }
+}
+
+@keyframes hero-drift-3 {
+  0%   { transform: translate(-10%, 10%) scale(1.05); }
+  50%  { transform: translate(20%, -25%) scale(0.9); }
+  100% { transform: translate(10%, 15%) scale(1.1); }
+}
+
+/* ── 无障碍：尊重 prefers-reduced-motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .home-hero-bg,
+  .home-hero-bg::before,
+  .home-hero-bg::after {
+    animation: none;
+  }
+}
+
+/* ── 移动端适配 ── */
 @media (max-width: 768px) {
   .home-hero {
     padding: 3rem 1.25rem 2.5rem;
   }
   .home-hero-text {
     font-size: 1em;
+  }
+  .home-hero-bg {
+    filter: blur(40px);
+    inset: -30%;
   }
 }
 

--- a/apps/negentropy-wiki/src/styles/components/home-hero.css
+++ b/apps/negentropy-wiki/src/styles/components/home-hero.css
@@ -35,7 +35,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% 20%, #34D399 0%, transparent 60%);
+  background: radial-gradient(circle at 20% 20%, var(--wiki-hero-blob-4) 0%, transparent 60%);
   opacity: 0.5;
   animation: hero-drift-3 22s ease-in-out infinite alternate;
 }

--- a/apps/negentropy-wiki/src/styles/tokens.css
+++ b/apps/negentropy-wiki/src/styles/tokens.css
@@ -34,4 +34,10 @@
 
   /* 首页品牌强调色 */
   --wiki-home-accent: #20B2AA;
+
+  /* 首页 Hero 液态渐变色彩 */
+  --wiki-hero-base: #0A7B71;
+  --wiki-hero-blob-1: #20B2AA;
+  --wiki-hero-blob-2: #2DD4BF;
+  --wiki-hero-blob-3: #0D9488;
 }

--- a/apps/negentropy-wiki/src/styles/tokens.css
+++ b/apps/negentropy-wiki/src/styles/tokens.css
@@ -40,4 +40,5 @@
   --wiki-hero-blob-1: #20B2AA;
   --wiki-hero-blob-2: #2DD4BF;
   --wiki-hero-blob-3: #0D9488;
+  --wiki-hero-blob-4: #34D399;
 }


### PR DESCRIPTION
# 背景
- Wiki 首页 Hero 条幅使用静态纯色背景（`#20B2AA`），视觉表现力不足，缺乏品牌辨识度与动态吸引力
- 参考 [reactbits.dev Aurora](https://reactbits.dev/backgrounds/aurora) 三色流动渐变模式，将扁平背景改造为液态流动动画

# 核心变更

参考 reactbits.dev **Aurora** 组件（ogl + GLSL simplex noise 驱动三色流动渐变）的核心美学，以纯 CSS 实现零依赖方案：

- **分层架构**：新增 `home-hero-bg`（背景层，`aria-hidden="true"`）+ `home-hero-content`（内容层），文本与动画解耦
- **液态渐变**：三层 `radial-gradient` 斑点 + `filter: blur(60px)` 有机柔化，复现 Aurora 的色彩流动效果
- **动画系统**：三组 `@keyframes`（14s / 18s / 22s 不同周期）驱动对角线漂移 + 缩放变化，避免可感知的循环
- **色彩体系**：基于 `--wiki-home-accent: #20B2AA` 衍生三色渐变（`#20B2AA` / `#2DD4BF` / `#0D9488`）+ 翡翠绿 `#34D399` 点缀
- **无障碍**：`prefers-reduced-motion` 媒体查询冻结动画为静态渐变
- **移动端**：`blur(60px)` → `blur(40px)`，`inset: -50%` → `-30%`，降低 GPU 合成负载
- **零依赖**：不引入任何 npm 包，纯 CSS + HTML div，完美兼容 Server Component

# 风险与回滚
- **主要风险**：低性能设备上 `filter: blur()` 可能产生 GPU 合成层开销（已通过移动端 blur 降级缓解）
- **回滚方式**：`git revert` 即可恢复为静态纯色背景，无数据/依赖副作用

# 验证证据
- **Lint**：`next lint` ✅ passed
- **Build**：`pnpm build` ✅ 生产构建零错误
- **浏览器实机验证**：
  - 三层动画正确运行（computed styles 确认 `animation: hero-drift-1/2/3`、`filter: blur(60px)`、`position: absolute` 全部生效）
  - 深色模式兼容正常
  - `prefers-reduced-motion` CSS 规则注入确认

# 影响范围
- **前端**：`apps/negentropy-wiki` 首页 Hero 条幅（3 files, +97 −13 lines）
- **后端**：无
- **CI / 文档**：无

# Next Best Action
- 可考虑后续增加鼠标交互响应（如 reactbits LiquidChrome 的鼠标涟漪效果），但需权衡 WebGL 依赖（`ogl` ~23KB）引入的包体积增长