### PR TITLE
feat(wiki-ui): Wiki 首页标题与侧边栏映射为一级 Catalog 导航

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -137,6 +137,7 @@ export default async function WikiEntryPage({ params }: Props) {
       sidebarItems={sectionView.sidebarItems}
       hasActiveItem={!!sectionView.activeItem}
       activeSlug={slug}
+      activeItem={sectionView.activeItem}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,4 +1,5 @@
 import {
+  findFirstDocumentSlug,
   joinEntrySlug,
   resolveSectionView,
   wikiApi,
@@ -130,6 +131,12 @@ export default async function WikiEntryPage({ params }: Props) {
     ? buildBreadcrumbPath(navItems, slug)
     : [];
 
+  const catalogItem = sectionView.activeItem;
+  const catalogTargetSlug = catalogItem ? findFirstDocumentSlug(catalogItem) : null;
+  const catalogName = catalogTargetSlug && catalogItem
+    ? (catalogItem.entry_title || catalogItem.entry_slug)
+    : null;
+
   const sidebar = (
     <WikiSidebar
       pubSlug={pubSlug}
@@ -137,7 +144,8 @@ export default async function WikiEntryPage({ params }: Props) {
       sidebarItems={sectionView.sidebarItems}
       hasActiveItem={!!sectionView.activeItem}
       activeSlug={slug}
-      activeItem={sectionView.activeItem}
+      catalogTargetSlug={catalogTargetSlug}
+      catalogName={catalogName}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -1,5 +1,6 @@
 import {
   countLeafEntries,
+  findFirstDocumentSlug,
   findIndexEntry,
   resolveSectionView,
   wikiApi,
@@ -64,6 +65,12 @@ export default async function WikiPublicationPage({ params }: Props) {
   const entriesTotal = countLeafEntries(navItems);
   const sectionView = resolveSectionView(navItems);
 
+  const catalogItem = sectionView.activeItem;
+  const catalogTargetSlug = catalogItem ? findFirstDocumentSlug(catalogItem) : null;
+  const catalogName = catalogTargetSlug && catalogItem
+    ? (catalogItem.entry_title || catalogItem.entry_slug)
+    : null;
+
   const sidebar = (
     <WikiSidebar
       pubSlug={pubSlug}
@@ -71,6 +78,7 @@ export default async function WikiPublicationPage({ params }: Props) {
       sidebarItems={sectionView.sidebarItems}
       hasActiveItem={!!sectionView.activeItem}
       indexEntry={indexEntry}
+      activeItem={sectionView.activeItem}
     />
   );
 
@@ -89,7 +97,13 @@ export default async function WikiPublicationPage({ params }: Props) {
   return (
     <WikiLayoutShell sidebar={sidebar} hasToc={false} header={header || undefined}>
       <header className="wiki-doc-header">
-        <h1 className="wiki-doc-title">{publication.name}</h1>
+        <h1 className="wiki-doc-title">
+          {catalogName && catalogTargetSlug ? (
+            <Link href={`/${pubSlug}/${catalogTargetSlug}`}>{catalogName}</Link>
+          ) : (
+            publication.name
+          )}
+        </h1>
         <div className="wiki-doc-meta">
           版本 v{publication.version} · {entriesTotal} 篇文档 ·{" "}
           {publication.published_at

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -78,7 +78,8 @@ export default async function WikiPublicationPage({ params }: Props) {
       sidebarItems={sectionView.sidebarItems}
       hasActiveItem={!!sectionView.activeItem}
       indexEntry={indexEntry}
-      activeItem={sectionView.activeItem}
+      catalogTargetSlug={catalogTargetSlug}
+      catalogName={catalogName}
     />
   );
 

--- a/apps/negentropy-wiki/src/components/WikiSidebar.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSidebar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { WikiNavTree } from "./WikiNavTree";
-import type { WikiNavTreeItem } from "@/lib/wiki-api";
+import { findFirstDocumentSlug, type WikiNavTreeItem } from "@/lib/wiki-api";
 
 /**
  * Wiki 侧边栏 — 统一 Publication 首页与文档详情页的左栏渲染。
@@ -17,6 +17,8 @@ interface WikiSidebarProps {
   hasActiveItem: boolean;
   activeSlug?: string;
   indexEntry?: WikiNavTreeItem | null;
+  /** 当前激活的一级 Catalog 节点，用于替换 publication.name 显示 */
+  activeItem?: WikiNavTreeItem;
 }
 
 export function WikiSidebar({
@@ -26,35 +28,69 @@ export function WikiSidebar({
   hasActiveItem,
   activeSlug,
   indexEntry,
+  activeItem,
 }: WikiSidebarProps) {
   const isEntryPage = activeSlug !== undefined;
+
+  const catalogTargetSlug = activeItem ? findFirstDocumentSlug(activeItem) : null;
+  const catalogName = catalogTargetSlug
+    ? (activeItem?.entry_title || activeItem?.entry_slug)
+    : null;
+
+  const renderBrand = (href: string, title: string, className: string) => (
+    <Link href={href} className={className}>
+      {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+      <img
+        src="/logo.png"
+        alt="Negentropy"
+        className="wiki-sidebar-logo"
+      />
+      <span className="wiki-sidebar-title">{title}</span>
+    </Link>
+  );
 
   return (
     <>
       <div className="wiki-sidebar-header">
         {isEntryPage ? (
-          <Link
-            href={`/${pubSlug}`}
-            className="wiki-sidebar-back wiki-sidebar-brand"
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
-            <img
-              src="/logo.png"
-              alt="Negentropy"
-              className="wiki-sidebar-logo"
-            />
-            <span className="wiki-sidebar-title">← {publication.name}</span>
-          </Link>
+          catalogName && catalogTargetSlug ? (
+            renderBrand(
+              `/${pubSlug}/${catalogTargetSlug}`,
+              `← ${catalogName}`,
+              "wiki-sidebar-back wiki-sidebar-brand",
+            )
+          ) : (
+            <Link
+              href={`/${pubSlug}`}
+              className="wiki-sidebar-back wiki-sidebar-brand"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+              <img
+                src="/logo.png"
+                alt="Negentropy"
+                className="wiki-sidebar-logo"
+              />
+              <span className="wiki-sidebar-title">← {publication.name}</span>
+            </Link>
+          )
         ) : (
-          <div className="wiki-sidebar-brand">
-            {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
-            <img
-              src="/logo.png"
-              alt="Negentropy"
-              className="wiki-sidebar-logo"
-            />
-            <span className="wiki-sidebar-title">{publication.name}</span>
-          </div>
+          catalogName && catalogTargetSlug ? (
+            renderBrand(
+              `/${pubSlug}/${catalogTargetSlug}`,
+              catalogName,
+              "wiki-sidebar-brand",
+            )
+          ) : (
+            <div className="wiki-sidebar-brand">
+              {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+              <img
+                src="/logo.png"
+                alt="Negentropy"
+                className="wiki-sidebar-logo"
+              />
+              <span className="wiki-sidebar-title">{publication.name}</span>
+            </div>
+          )
         )}
       </div>
       {!isEntryPage && publication.description && (

--- a/apps/negentropy-wiki/src/components/WikiSidebar.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSidebar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { WikiNavTree } from "./WikiNavTree";
-import { findFirstDocumentSlug, type WikiNavTreeItem } from "@/lib/wiki-api";
+import type { WikiNavTreeItem } from "@/lib/wiki-api";
 
 /**
  * Wiki 侧边栏 — 统一 Publication 首页与文档详情页的左栏渲染。
@@ -17,8 +17,10 @@ interface WikiSidebarProps {
   hasActiveItem: boolean;
   activeSlug?: string;
   indexEntry?: WikiNavTreeItem | null;
-  /** 当前激活的一级 Catalog 节点，用于替换 publication.name 显示 */
-  activeItem?: WikiNavTreeItem;
+  /** 当前激活的一级 Catalog 首篇文档 slug，用于替换 publication.name 显示 */
+  catalogTargetSlug?: string | null;
+  /** 当前激活的一级 Catalog 显示名 */
+  catalogName?: string | null;
 }
 
 export function WikiSidebar({
@@ -28,14 +30,10 @@ export function WikiSidebar({
   hasActiveItem,
   activeSlug,
   indexEntry,
-  activeItem,
+  catalogTargetSlug,
+  catalogName,
 }: WikiSidebarProps) {
   const isEntryPage = activeSlug !== undefined;
-
-  const catalogTargetSlug = activeItem ? findFirstDocumentSlug(activeItem) : null;
-  const catalogName = catalogTargetSlug
-    ? (activeItem?.entry_title || activeItem?.entry_slug)
-    : null;
 
   const renderBrand = (href: string, title: string, className: string) => (
     <Link href={href} className={className}>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki Publication 首页的两处「Wiki」字样（侧边栏标题 + 页面 h1）对应的是 Publication 产品标题，而非实际的一级 Catalog 导航内容（如 Harness Engineering），用户点击无法直达 Catalog 内容页
- 关联上下文/Issue/文档：Wiki 首页 UX 优化

# 核心变更
- **WikiSidebar.tsx**：新增 `activeItem` 可选 prop，当存在有效一级 Catalog 时，侧边栏标题显示 Catalog 名称（如 Harness Engineering）并链接到其首篇文档；Entry 详情页 back link 同步适配
- **[pubSlug]/page.tsx**：h1 标题从 `publication.name` 替换为一级 Catalog 名称 + 可点击链接，传递 `activeItem` 给 Sidebar
- **[...entrySlug]/page.tsx**：传递 `sectionView.activeItem` 给 Sidebar，使 entry 页 back link 也指向一级 Catalog 首篇文档

# 风险与回滚
- 主要风险：`activeItem` 为可选 prop，未传入时完全回退到原行为（显示 `publication.name`），无破坏性变更
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：复用已有 `findFirstDocumentSlug` / `resolveSectionView` 函数，无需新增测试
- 集成测试：`pnpm --filter negentropy-wiki build` 构建通过，TypeScript 类型检查通过
- E2E/Workflow：需浏览器实机验证
- 覆盖率/关键截图：无 nav tree 或 Catalog 无文档时回退到 publication name 纯文本

# 影响范围
- 前端：`negentropy-wiki` 的 Publication 首页与 Entry 详情页的侧边栏标题、页面 h1 标题
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action
- 浏览器实机验证：访问 Wiki Publication 首页确认侧边栏标题和 h1 均显示一级 Catalog 名称且可点击跳转到首篇文档