### PR TITLE
fix(auth): OAuth 重登录不再覆盖 DB 管理的角色

### DIFF
--- a/apps/negentropy/src/negentropy/auth/service.py
+++ b/apps/negentropy/src/negentropy/auth/service.py
@@ -74,7 +74,7 @@ class AuthService:
         token_payload = await self._exchange_code(code)
         claims = await self._verify_id_token(token_payload.get("id_token"))
         user = self._build_user(claims)
-        await self._upsert_user_state(user, claims)
+        user = await self._upsert_user_state(user, claims)
         session_token = self._build_session_token(user)
         return AuthResult(user=user, token=session_token, redirect=redirect)
 
@@ -165,7 +165,8 @@ class AuthService:
             domain=domain,
         )
 
-    async def _upsert_user_state(self, user: AuthUser, claims: dict[str, Any]) -> None:
+    async def _upsert_user_state(self, user: AuthUser, claims: dict[str, Any]) -> AuthUser:
+        effective_roles: list[str] = user.roles
         async with AsyncSessionLocal() as db:
             result = await db.execute(
                 select(UserState).where(
@@ -174,6 +175,12 @@ class AuthService:
                 )
             )
             user_state = result.scalar_one_or_none()
+
+            if user_state:
+                db_roles = (user_state.state or {}).get("roles", user.roles)
+                if isinstance(db_roles, list):
+                    effective_roles = db_roles
+
             next_state = {
                 "profile": {
                     "email": user.email,
@@ -190,7 +197,7 @@ class AuthService:
                     "domain": user.domain,
                     "last_login_at": int(time.time()),
                 },
-                "roles": user.roles,
+                "roles": effective_roles,
             }
 
             if user_state:
@@ -204,6 +211,19 @@ class AuthService:
                     )
                 )
             await db.commit()
+
+        if effective_roles == user.roles:
+            return user
+        return AuthUser(
+            user_id=user.user_id,
+            email=user.email,
+            name=user.name,
+            picture=user.picture,
+            roles=effective_roles,
+            provider=user.provider,
+            subject=user.subject,
+            domain=user.domain,
+        )
 
     def _build_session_token(self, user: AuthUser) -> str:
         now = int(time.time())

--- a/apps/negentropy/tests/unit_tests/auth/test_service.py
+++ b/apps/negentropy/tests/unit_tests/auth/test_service.py
@@ -1,0 +1,170 @@
+"""ISSUE-065: OAuth 重登录不再覆盖 DB 管理的角色。
+
+角色权威源规则：
+- 首次登录：使用 ``admin_emails`` 配置派生角色
+- 后续登录：保留 DB ``user_states.state.roles``（管理面板 PATCH 设置的权威源）
+"""
+
+from typing import Any
+
+import pytest
+
+from negentropy.auth.service import AuthService, AuthUser
+from negentropy.config import settings
+from negentropy.config.auth import AuthSettings
+
+
+def _make_user(
+    *, user_id: str = "google:alice", email: str = "alice@example.com", roles: list[str] | None = None
+) -> AuthUser:
+    return AuthUser(
+        user_id=user_id,
+        email=email,
+        name="Alice",
+        picture=None,
+        roles=roles or ["user"],
+        provider="google",
+        subject="sub-alice",
+        domain="example.com",
+    )
+
+
+class _FakeUserState:
+    def __init__(self, user_id: str, state: dict[str, Any]) -> None:
+        self.user_id = user_id
+        self.state = state
+
+
+class _FakeResult:
+    def __init__(self, value: object | None) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object | None:
+        return self._value
+
+
+class _FakeSession:
+    def __init__(self, value: object | None) -> None:
+        self._value = value
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def execute(self, *_args: object, **_kwargs: object) -> _FakeResult:
+        return _FakeResult(self._value)
+
+    def add(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+def _patch_db(monkeypatch: pytest.MonkeyPatch, user_state: object | None) -> None:
+    """替换 service 模块中已导入的 AsyncSessionLocal。"""
+    monkeypatch.setattr(
+        "negentropy.auth.service.AsyncSessionLocal",
+        lambda: _FakeSession(user_state),
+    )
+
+
+def _claims(email: str = "alice@example.com") -> dict[str, Any]:
+    return {"sub": "sub-alice", "email": email, "name": "Alice", "email_verified": True}
+
+
+# ============================================================================
+# 首次登录：config 派生角色
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_new_user_gets_admin_role_from_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """首次登录且 email 在 admin_emails 中 → 角色为 ["admin"]。"""
+    _patch_db(monkeypatch, None)
+    monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=["admin@example.com"]))
+
+    service = AuthService()
+    user = _make_user(email="admin@example.com", roles=["admin"])
+    result = await service._upsert_user_state(user, _claims("admin@example.com"))
+
+    assert result.roles == ["admin"]
+
+
+@pytest.mark.asyncio
+async def test_new_user_gets_user_role_when_not_in_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """首次登录且 email 不在 admin_emails 中 → 角色为 ["user"]。"""
+    _patch_db(monkeypatch, None)
+    monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=["admin@example.com"]))
+
+    service = AuthService()
+    user = _make_user(email="alice@example.com", roles=["user"])
+    result = await service._upsert_user_state(user, _claims("alice@example.com"))
+
+    assert result.roles == ["user"]
+
+
+# ============================================================================
+# 已有用户重登录：保留 DB 角色（核心回归防护）
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_existing_user_preserves_admin_role_on_relogin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB 中已设为 admin 的用户重登录 → 保留 admin 角色，不被 config 覆盖。"""
+    db_state = _FakeUserState("google:alice", {"roles": ["admin"], "profile": {}, "auth": {}})
+    _patch_db(monkeypatch, db_state)
+    monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=[]))
+
+    service = AuthService()
+    user = _make_user(roles=["user"])
+    result = await service._upsert_user_state(user, _claims())
+
+    assert result.roles == ["admin"]
+
+
+@pytest.mark.asyncio
+async def test_existing_user_preserves_user_role_despite_config_promotion(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB 中角色为 user、config 中为 admin → 保留 DB 的 user 角色（DB 是权威源）。"""
+    db_state = _FakeUserState("google:alice", {"roles": ["user"], "profile": {}, "auth": {}})
+    _patch_db(monkeypatch, db_state)
+    monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=["alice@example.com"]))
+
+    service = AuthService()
+    user = _make_user(roles=["admin"])
+    result = await service._upsert_user_state(user, _claims())
+
+    assert result.roles == ["user"]
+
+
+# ============================================================================
+# 边缘 Case
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_corrupted_db_roles_falls_back_to_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB state.roles 为非列表（损坏数据）→ 回退到 config 派生角色。"""
+    db_state = _FakeUserState("google:alice", {"roles": "admin", "profile": {}, "auth": {}})
+    _patch_db(monkeypatch, db_state)
+
+    service = AuthService()
+    user = _make_user(roles=["user"])
+    result = await service._upsert_user_state(user, _claims())
+
+    assert result.roles == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_same_roles_returns_same_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """config 派生角色与 DB 角色一致 → 返回同一 AuthUser 实例。"""
+    db_state = _FakeUserState("google:alice", {"roles": ["user"], "profile": {}, "auth": {}})
+    _patch_db(monkeypatch, db_state)
+
+    service = AuthService()
+    user = _make_user(roles=["user"])
+    result = await service._upsert_user_state(user, _claims())
+
+    assert result is user


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：管理员通过 Admin 面板将用户提升为 Admin 后，该用户下次 OAuth 登录时角色被静默回滚为 `["user"]`
- 关联上下文/Issue/文档：ISSUE-065

# 核心变更
- `service.py` `_upsert_user_state` 对已有用户保留 DB 中的 `state.roles`（权威源），不再用 `admin_emails` 配置派生值无条件覆盖
- `_upsert_user_state` 返回 `AuthUser` 携带 DB 权威角色，`handle_callback` 使用返回值使 JWT session token 立即反映正确角色
- 新用户首次登录仍使用 `admin_emails` 配置派生角色（行为不变）

# 风险与回滚
- 主要风险：无。已有用户重登录时 profile/auth 元数据仍正常刷新，仅 roles 字段不再被覆盖
- 回滚方式：`git revert`

# 验证证据
- 单元测试：新增 6 个测试（`test_service.py`），覆盖新用户赋权、已有用户角色保留、config 提升不覆盖 DB、损坏数据回退、实例复用
- 集成测试：全部 38 个 auth 模块测试通过
- E2E/Workflow：手动验证 — Admin 面板设角色 → 登出 → 重新登录 → 角色保持
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`apps/negentropy/src/negentropy/auth/service.py`（23 行新增，3 行删除）
- GitHub Actions / 文档：无

# Next Best Action
- 用现有 Admin 账号通过 Admin 面板 `PATCH /auth/users/{user_id}/roles` 将目标用户提升为 Admin，验证重登录后角色不再回滚