### PR TITLE
feat(wiki): 支持归属文档显示名编辑以修正源名称传播瑕疵

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
@@ -6,20 +6,26 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   fetchCatalogNodeDocuments,
   unassignDocumentFromNode,
+  updateDocument,
   KnowledgeDocument,
 } from "@/features/knowledge";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
-import { Plus, Trash2 } from "./icons";
+import { Plus, Trash2, Pencil, Check, X } from "./icons";
 import { AddDocumentsDialog } from "./AddDocumentsDialog";
 
 interface DocumentAssignmentSectionProps {
   nodeId: string;
   catalogId: string;
+}
+
+/** 决定 Wiki 站点上显示的标题（优先级与后端 _resolve_doc_display_title 一致）。 */
+function effectiveDisplayName(doc: KnowledgeDocument): string {
+  return (doc.display_name || "").trim() || doc.original_filename;
 }
 
 export function DocumentAssignmentSection({
@@ -30,6 +36,11 @@ export function DocumentAssignmentSection({
   const [docs, setDocs] = useState<KnowledgeDocument[]>([]);
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
+  // 行内编辑态：正在编辑的文档 id
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const editInputRef = useRef<HTMLInputElement>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -46,6 +57,14 @@ export function DocumentAssignmentSection({
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // 编辑态挂载后自动聚焦
+  useEffect(() => {
+    if (editingId) {
+      editInputRef.current?.focus();
+      editInputRef.current?.select();
+    }
+  }, [editingId]);
 
   const handleRemove = useCallback(
     async (docId: string, filename: string) => {
@@ -71,6 +90,52 @@ export function DocumentAssignmentSection({
     void refresh();
   }, [refresh]);
 
+  const startEdit = useCallback((doc: KnowledgeDocument) => {
+    setEditingId(doc.id);
+    setEditDraft(doc.display_name ?? "");
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingId(null);
+    setEditDraft("");
+  }, []);
+
+  const commitEdit = useCallback(
+    async (doc: KnowledgeDocument) => {
+      const trimmed = editDraft.trim() || null;
+      // 无变化时静默退出
+      if (trimmed === (doc.display_name ?? null)) {
+        cancelEdit();
+        return;
+      }
+      setSaving(true);
+      try {
+        await updateDocument(doc.corpus_id, doc.id, { display_name: trimmed });
+        toast.success("保存成功，下次发布生效");
+        setEditingId(null);
+        setEditDraft("");
+        await refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "保存失败");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [cancelEdit, editDraft, refresh],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, doc: KnowledgeDocument) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void commitEdit(doc);
+      } else if (e.key === "Escape") {
+        cancelEdit();
+      }
+    },
+    [cancelEdit, commitEdit],
+  );
+
   return (
     <div className="px-5 py-4 border-t border-border">
       <div className="flex items-center justify-between mb-3">
@@ -93,28 +158,86 @@ export function DocumentAssignmentSection({
         <p className="text-xs text-muted/60 italic">暂无归属文档</p>
       ) : (
         <ul className="space-y-1 max-h-[280px] overflow-y-auto">
-          {docs.map((doc) => (
-            <li
-              key={doc.id}
-              className="group flex items-center justify-between gap-2 px-2 py-1.5 rounded-md hover:bg-muted/30 text-xs"
-            >
-              <div className="flex-1 min-w-0">
-                <p className="truncate font-medium text-foreground">
-                  {doc.original_filename}
-                </p>
-                <p className="text-[10px] text-muted/70 font-mono">
-                  {doc.markdown_extract_status ?? "—"} · {doc.id.slice(0, 8)}…
-                </p>
-              </div>
-              <button
-                onClick={() => handleRemove(doc.id, doc.original_filename)}
-                title="从节点移除"
-                className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 rounded text-muted hover:text-red-600 hover:bg-red-50 transition-opacity"
+          {docs.map((doc) => {
+            const isEditing = editingId === doc.id;
+            const effectiveName = effectiveDisplayName(doc);
+
+            return (
+              <li
+                key={doc.id}
+                className="group flex items-center justify-between gap-2 px-2 py-1.5 rounded-md hover:bg-muted/30 text-xs"
               >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </li>
-          ))}
+                <div className="flex-1 min-w-0">
+                  {/* 主行：Wiki 站点显示名 或 编辑态 input */}
+                  {isEditing ? (
+                    <div className="flex items-center gap-1">
+                      <input
+                        ref={editInputRef}
+                        type="text"
+                        value={editDraft}
+                        onChange={(e) => setEditDraft(e.target.value)}
+                        onKeyDown={(e) => handleKeyDown(e, doc)}
+                        placeholder="留空则使用源名称"
+                        maxLength={255}
+                        disabled={saving}
+                        aria-label="编辑 Wiki 显示名称"
+                        className="flex-1 min-w-0 h-6 px-1.5 text-xs rounded border border-primary/50 bg-transparent focus:outline-none focus:ring-1 focus:ring-primary"
+                      />
+                      <button
+                        onClick={() => void commitEdit(doc)}
+                        disabled={saving}
+                        title="保存"
+                        className="p-0.5 rounded text-muted hover:text-green-600 disabled:opacity-50"
+                      >
+                        <Check className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        onClick={cancelEdit}
+                        disabled={saving}
+                        title="取消"
+                        className="p-0.5 rounded text-muted hover:text-red-500 disabled:opacity-50"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ) : (
+                    <p className="truncate font-medium text-foreground">
+                      {effectiveName}
+                    </p>
+                  )}
+
+                  {/* 副行：源名称 · 状态 · ID */}
+                  <p className="text-[10px] text-muted/70 font-mono">
+                    源名称：{doc.original_filename}
+                    <span className="mx-1">·</span>
+                    {doc.markdown_extract_status ?? "—"}
+                    <span className="mx-1">·</span>
+                    {doc.id.slice(0, 8)}…
+                  </p>
+                </div>
+
+                {/* 操作按钮 */}
+                {!isEditing && (
+                  <div className="flex items-center gap-0.5 shrink-0">
+                    <button
+                      onClick={() => startEdit(doc)}
+                      title="编辑 Wiki 显示名称"
+                      className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 rounded text-muted hover:text-blue-600 hover:bg-blue-50 transition-opacity"
+                    >
+                      <Pencil className="h-3 w-3" />
+                    </button>
+                    <button
+                      onClick={() => handleRemove(doc.id, doc.original_filename)}
+                      title="从节点移除"
+                      className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 rounded text-muted hover:text-red-600 hover:bg-red-50 transition-opacity"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
@@ -23,9 +23,14 @@ interface DocumentAssignmentSectionProps {
   catalogId: string;
 }
 
-/** 决定 Wiki 站点上显示的标题（优先级与后端 _resolve_doc_display_title 一致）。 */
+/** 决定 Wiki 站点上显示的标题（优先级与后端 _resolve_doc_display_title 一致）。
+ *  display_name（用户手填）→ metadata.title（PDF/抓取自动抽取）→ original_filename（兜底）。 */
 function effectiveDisplayName(doc: KnowledgeDocument): string {
-  return (doc.display_name || "").trim() || doc.original_filename;
+  const displayName = (doc.display_name || "").trim();
+  if (displayName) return displayName;
+  const metaTitle = typeof doc.metadata?.title === "string" ? doc.metadata.title.trim() : "";
+  if (metaTitle) return metaTitle;
+  return doc.original_filename;
 }
 
 export function DocumentAssignmentSection({

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/icons.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/icons.tsx
@@ -82,3 +82,19 @@ export function Pencil({ className = "h-4 w-4" }: { className?: string }) {
     </svg>
   );
 }
+
+export function Check({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+export function X({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -63,6 +63,7 @@ export {
   fetchDocumentDetail,
   fetchDocumentChunks,
   fetchDocumentChunkDetail,
+  updateDocument,
   updateDocumentChunk,
   regenerateDocumentChunkFamily,
   refreshDocumentMarkdown,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1239,6 +1239,11 @@ export interface KnowledgeDocument {
   app_name: string;
   file_hash: string;
   original_filename: string;
+  /**
+   * Wiki 站点上显示的名称（用户手填覆盖）。
+   * 为空 / null 时，Wiki 站点回退到 `metadata.title -> original_filename`。
+   */
+  display_name?: string | null;
   gcs_uri: string;
   content_type: string | null;
   file_size: number;
@@ -1415,6 +1420,30 @@ export async function fetchDocumentDetail(
     `/api/knowledge/base/${corpusId}/documents/${documentId}?${query.toString()}`,
     { cache: "no-store" },
   );
+  return handleKnowledgeError(res);
+}
+
+/**
+ * 更新文档元信息（目前仅支持 `display_name`）。
+ *
+ * - 传入 `null` 或仅空白字符串 → 清除覆盖；Wiki 站点回退到
+ *   `metadata.title -> original_filename`。
+ * - 长度上限 255；超过由后端返回 422。
+ */
+export async function updateDocument(
+  corpusId: string,
+  documentId: string,
+  patch: { display_name?: string | null },
+  params?: { appName?: string },
+): Promise<KnowledgeDocument> {
+  const body: Record<string, unknown> = { ...patch };
+  if (params?.appName) body.app_name = params.appName;
+
+  const res = await fetch(`/api/knowledge/base/${corpusId}/documents/${documentId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
   return handleKnowledgeError(res);
 }
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0040_add_knowledge_document_display_name.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0040_add_knowledge_document_display_name.py
@@ -1,0 +1,42 @@
+"""knowledge_documents 新增 display_name 列以支持 Wiki 显示名编辑
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-05-26 00:00:00.000000+00:00
+
+设计动机：
+    源文件名 (``original_filename``) 在抓取 / OCR 过程中常带有传播瑕疵
+    （截断、前缀冗余、空格被下划线替代等）；用作 Wiki 站点页面标题会
+    损害可读性。新增一列 ``display_name`` 作为「Wiki 站点上显示的名称」
+    的用户手填值，既保留源文件名的可追溯性，又支持就地修正。
+
+    Wiki 同步管线 (``wiki_service.sync_publication``) 将按
+    ``display_name -> metadata_.title -> original_filename`` 的优先级
+    决定 ``WikiPublicationEntry.entry_title``，编辑后由用户主动触发
+    「从 Catalog 同步」/「同步并发布」生效，不在写入时产生隐式发布。
+
+幂等性：
+    使用 ``ADD COLUMN IF NOT EXISTS`` 保证重复执行安全；downgrade 仅
+    ``DROP COLUMN`` 该新增列，不触碰其它业务数据。既有行的 ``display_name``
+    为 ``NULL``，运行时优先级链回退到现有行为。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0040"
+down_revision: str | None = "0039"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.knowledge_documents ADD COLUMN IF NOT EXISTS display_name VARCHAR(255)"))
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.knowledge_documents DROP COLUMN IF EXISTS display_name"))

--- a/apps/negentropy/src/negentropy/knowledge/_shared.py
+++ b/apps/negentropy/src/negentropy/knowledge/_shared.py
@@ -674,6 +674,7 @@ def _build_document_response(
         app_name=doc.app_name,
         file_hash=doc.file_hash,
         original_filename=doc.original_filename,
+        display_name=getattr(doc, "display_name", None),
         gcs_uri=doc.gcs_uri,
         content_type=doc.content_type,
         file_size=doc.file_size,

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -374,6 +374,7 @@ class WikiDao:
             select(
                 WikiPublicationEntry.document_id,
                 KnowledgeDocument.original_filename,
+                KnowledgeDocument.display_name,
                 KnowledgeDocument.markdown_content,
                 KnowledgeDocument.metadata_,
             )
@@ -384,12 +385,22 @@ class WikiDao:
         if row is None:
             return None
 
-        doc_id, filename, markdown_content, metadata = row
+        doc_id, filename, display_name, markdown_content, metadata = row
+        # 与 wiki_service._resolve_doc_display_title 保持同源优先级：
+        # display_name (用户覆盖) -> metadata_.title -> original_filename。
+        resolved_title = (display_name or "").strip()
+        if not resolved_title:
+            meta_title = (metadata or {}).get("title")
+            if isinstance(meta_title, str) and meta_title.strip():
+                resolved_title = meta_title.strip()
+        if not resolved_title:
+            resolved_title = filename or "Untitled"
         return {
             "document_id": doc_id,
             "filename": filename,
+            "display_name": display_name,
             "markdown_content": markdown_content or "",
-            "title": (metadata or {}).get("title") or filename or "Untitled",
+            "title": resolved_title,
             "metadata": metadata or {},
         }
 

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -31,6 +31,25 @@ VALID_THEMES = {"default", "book", "docs"}
 VALID_STATUSES = {"draft", "published", "archived"}
 
 
+def _resolve_doc_display_title(doc: Any) -> str:
+    """决定文档在 Wiki 站点上的展示标题（单一事实源）。
+
+    优先级：``display_name``（用户手填覆盖）→ ``metadata_.title``
+    （PDF / 抓取自动抽取）→ ``original_filename``（兜底）。
+
+    用于 :meth:`WikiPublishingService.sync_publication` 与
+    ``routes.wiki.get_entry_content``，保证后端 entry_title 与前端
+    SSG 展示一致。
+    """
+    display_name = (getattr(doc, "display_name", None) or "").strip()
+    if display_name:
+        return display_name
+    meta_title = (doc.metadata_ or {}).get("title") if getattr(doc, "metadata_", None) else None
+    if isinstance(meta_title, str) and meta_title.strip():
+        return meta_title.strip()
+    return doc.original_filename
+
+
 class WikiPublishingService:
     """Wiki 发布服务"""
 
@@ -541,7 +560,7 @@ class WikiPublishingService:
                 publication_id=publication_id,
                 document_id=doc.id,
                 entry_slug=final_slug,
-                entry_title=(doc.metadata_ or {}).get("title") or doc.original_filename,
+                entry_title=_resolve_doc_display_title(doc),
                 entry_path=entry_path,
             )
             synced_doc_ids.add(str(doc.id))

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -27,6 +27,7 @@ from negentropy.knowledge.schemas import (
     DocumentMarkdownRefreshRequest,
     DocumentMarkdownRefreshResponse,
     DocumentResponse,
+    DocumentUpdateRequest,
 )
 from negentropy.logging import get_logger
 
@@ -180,6 +181,7 @@ async def get_document_detail(
         app_name=doc.app_name,
         file_hash=doc.file_hash,
         original_filename=doc.original_filename,
+        display_name=doc.display_name,
         gcs_uri=doc.gcs_uri,
         content_type=doc.content_type,
         file_size=doc.file_size,
@@ -195,6 +197,62 @@ async def get_document_detail(
         markdown_content=markdown_content,
         markdown_gcs_uri=doc.markdown_gcs_uri,
     )
+
+
+@router.patch("/base/{corpus_id}/documents/{document_id}", response_model=DocumentResponse)
+async def update_document(
+    corpus_id: UUID,
+    document_id: UUID,
+    payload: DocumentUpdateRequest,
+) -> DocumentResponse:
+    """更新文档元信息（当前仅支持 ``display_name``）。
+
+    - ``display_name`` 为 ``None`` / 空白时清除覆盖，展示侧回退到
+      ``metadata_.title -> original_filename``；
+    - 与 :func:`get_document_detail` 一致的 ``corpus_id`` / ``app_name`` 权限校验。
+    """
+    resolved_app = _resolve_app_name(payload.app_name)
+
+    from negentropy.storage.service import DocumentStorageService
+
+    storage_service = DocumentStorageService()
+
+    try:
+        doc = await storage_service.update_document_display_name(
+            document_id=document_id,
+            display_name=payload.display_name,
+            corpus_id=corpus_id,
+            app_name=resolved_app,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "DOCUMENT_UPDATE_INVALID", "message": str(exc)},
+        ) from exc
+
+    if not doc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "DOCUMENT_NOT_FOUND", "message": "Document not found"},
+        )
+
+    name_map = await _resolve_user_display_names([doc.created_by]) if doc.created_by else {}
+    source_uri = _resolve_document_source_uri(doc)
+    archived = False
+    if source_uri:
+        service = _get_service()
+        archived_set = await service.get_archived_source_uris(
+            pairs=[(doc.corpus_id, source_uri)],
+            app_name=resolved_app,
+        )
+        archived = (doc.corpus_id, source_uri) in archived_set
+
+    logger.info(
+        "api_update_document",
+        document_id=str(document_id),
+        cleared=doc.display_name is None,
+    )
+    return _build_document_response(doc, name_map, archived=archived)
 
 
 @router.post(

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -577,6 +577,7 @@ class DocumentResponse(BaseModel):
     app_name: str
     file_hash: str
     original_filename: str
+    display_name: str | None = None
     gcs_uri: str
     content_type: str | None = None
     file_size: int
@@ -592,6 +593,13 @@ class DocumentResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class DocumentUpdateRequest(BaseModel):
+    """文档元信息更新请求（目前仅支持 ``display_name``）。"""
+
+    display_name: str | None = Field(default=None, max_length=255)
+    app_name: str | None = None
 
 
 class DocumentDetailResponse(DocumentResponse):

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -98,6 +98,9 @@ class KnowledgeDocument(Base, UUIDMixin, TimestampMixin):
     # 文件标识
     file_hash: Mapped[str] = mapped_column(String(64), nullable=False)  # SHA-256
     original_filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Wiki 站点上显示的名称。``None`` 时由展示侧按
+    # ``metadata_.title -> original_filename`` 回退；详见 0040 迁移设计动机。
+    display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # 存储信息
     gcs_uri: Mapped[str] = mapped_column(Text, nullable=False)

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -576,6 +576,65 @@ class DocumentStorageService:
             await db.commit()
             return True
 
+    async def update_document_display_name(
+        self,
+        *,
+        document_id: UUID,
+        display_name: str | None,
+        corpus_id: UUID | None = None,
+        app_name: str | None = None,
+    ) -> KnowledgeDocument | None:
+        """更新文档的 Wiki 显示名称。
+
+        - 空白字符串 / 仅空白字符 归一化为 ``None``（与未填等价，由
+          展示侧回退到 ``metadata_.title -> original_filename``）。
+        - 长度上限 255；超过抛 ``ValueError``。
+        - 与 :meth:`get_document` 一致的 ``corpus_id`` / ``app_name`` 权限校验。
+
+        Args:
+            document_id: 文档 UUID
+            display_name: 新的显示名（``None`` / 空白 表示清除覆盖）
+            corpus_id: 可选 corpus 校验
+            app_name: 可选 app 校验
+
+        Returns:
+            更新后的 ``KnowledgeDocument``；若文档不存在或权限不匹配返回 ``None``
+        """
+        normalized: str | None
+        if display_name is None:
+            normalized = None
+        else:
+            stripped = display_name.strip()
+            if not stripped:
+                normalized = None
+            elif len(stripped) > 255:
+                raise ValueError("display_name 长度不能超过 255 字符")
+            else:
+                normalized = stripped
+
+        async with AsyncSessionLocal() as db:
+            conditions = [KnowledgeDocument.id == document_id]
+            if corpus_id:
+                conditions.append(KnowledgeDocument.corpus_id == corpus_id)
+            if app_name:
+                conditions.append(KnowledgeDocument.app_name == app_name)
+
+            stmt = select(KnowledgeDocument).where(*conditions)
+            result = await db.execute(stmt)
+            doc = result.scalar_one_or_none()
+            if not doc:
+                return None
+
+            doc.display_name = normalized
+            await db.commit()
+            await db.refresh(doc)
+            logger.info(
+                "document_display_name_updated",
+                doc_id=str(document_id),
+                cleared=normalized is None,
+            )
+            return doc
+
     async def delete_gcs_uri(self, *, gcs_uri: str) -> bool:
         """删除任意 GCS URI；失败时仅记录日志。"""
         try:


### PR DESCRIPTION
# 背景
- 源文件名（`original_filename`）在抓取 / OCR 过程中常带有传播瑕疵（截断如 `50714_Agent_Harness_Engineerin.pdf`、前缀冗余、空格被下划线替代等），直接作为 Wiki 站点页面标题损害可读性与专业感。
- 需要保留源文件名的可追溯性（hash、归档比对依赖），同时允许用户就地修正 Wiki 站点上的显示名称，将编辑成本从「重命名源文件 + 重新解析」降为「就地一次编辑」。

# 核心变更

### 数据层
- **迁移 0040**：`knowledge_documents` 表新增 `display_name VARCHAR(255) NULL`，幂等 `ADD COLUMN IF NOT EXISTS`，downgrade 为 `DROP COLUMN`，对既有行无影响
- **ORM**：`KnowledgeDocument.display_name: Mapped[str | None]`，紧邻 `original_filename` 字段

### 后端服务
- **`DocumentStorageService.update_document_display_name()`**：空白字符串归一化为 `None`（与未填等价）、长度上限 255、与 `get_document` 一致的 corpus/app_name 权限校验
- **PATCH 端点**：`PATCH /base/{corpus_id}/documents/{document_id}` 接收 `{ display_name, app_name }`，返回完整 `DocumentResponse`
- **序列化全覆盖**：`DocumentResponse` schema、`_build_document_response`、`DocumentDetailResponse`、`get_document_detail` 内联构建、`get_entry_documents`（Catalog 列表）均携带 `display_name` 字段

### Wiki 发布管线
- **统一优先级链**：`wiki_service._resolve_doc_display_title()` + `wiki_dao.get_entry_content()` 均按 `display_name → metadata_.title → original_filename` 解析标题，保证后端 entry_title 与 SSG 展示一致
- **不自动触发发布**：用户编辑 display_name 后需手动「从 Catalog 同步」/「同步并发布」才在 Wiki 站点生效

### 前端
- **类型**：`KnowledgeDocument.display_name?: string | null`；新增 `updateDocument()` API 客户端
- **归属文档 UI**：主行显示 `display_name || original_filename`，副行展示 `源名称：original_filename · status · id前8`；hover 显示 ✏️ 编辑按钮，行内 input 编辑 + Enter 提交 / Esc 取消 + 保存成功 toast「保存成功，下次发布生效」
- **图标**：新增 `Check` / `X` 组件用于编辑态操作按钮

# 风险与回滚
- 主要风险：用户编辑后未立即重发布，公网 Wiki 仍为旧标题（toast 已明确提示）
- 回滚方式：`alembic downgrade -1` 删除列；前端类型为可选字段，缺失视为 `null` 不影响现有功能；PATCH 端点移除后前端走 404 降级

# 验证证据
- 单元测试：`_resolve_doc_display_title` 6 组优先级链验证（display_name 仅设置 / metadata.title 回退 / 空白回退 / 无 attr 回退兼容）
- 运行时验证：ORM 模型加载确认 `display_name` 列存在；Schema 序列化验证字段正确
- TypeScript 编译：零新增错误（既有 `@negentropy/agents-chat-core` 预存错误不变）
- Ruff lint/format：全部通过；Pre-commit hooks（trim、ruff、ESLint）全部通过

# 影响范围
- 前端：`DocumentAssignmentSection.tsx`、`icons.tsx`、`knowledge-api.ts`、`features/knowledge/index.ts`
- 后端：迁移 0040、`perception.py`、`service.py`、`schemas.py`、`_shared.py`、`documents.py`、`wiki_service.py`、`wiki_dao.py`
- GitHub Actions / 文档：无 CI 配置变更

# Next Best Action
- 在真实环境中执行 `alembic upgrade head` 并进行端到端实机验证（编辑 → 保存 → 刷新 → 同步 → Wiki 站点确认标题更新、副信息仍展示 original_filename）
- 如未来需按 Wiki 节点差异化显示名，可在 `DocCatalogEntry.config` JSONB 中增加 per-assignment override，不破坏当前 schema

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)