### PR TITLE
fix(ui): 修复 LLM/Embedding Model 下拉框选项冗余显示 vendor/model 信息

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusSettingsPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusSettingsPanel.tsx
@@ -156,7 +156,7 @@ function CorpusSettingsPanel({
               <option value="">(使用全局默认)</option>
               {embeddingModels.map((m) => (
                 <option key={m.id} value={m.id}>
-                  {m.display_name} · {m.vendor}/{m.model_name}
+                  {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
                 </option>
               ))}
             </select>
@@ -183,7 +183,7 @@ function CorpusSettingsPanel({
               <option value="">(使用全局默认)</option>
               {llmModels.map((m) => (
                 <option key={m.id} value={m.id}>
-                  {m.display_name} · {m.vendor}/{m.model_name}
+                  {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
                 </option>
               ))}
             </select>

--- a/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
@@ -227,7 +227,7 @@ export function ModelConfigPanel({
             <option value="">(使用全局默认)</option>
             {llmModels.map((m) => (
               <option key={m.id} value={m.id}>
-                {m.display_name} · {m.vendor}/{m.model_name}
+                {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
               </option>
             ))}
           </select>
@@ -245,7 +245,7 @@ export function ModelConfigPanel({
             <option value="">(使用全局默认)</option>
             {embeddingModels.map((m) => (
               <option key={m.id} value={m.id}>
-                {m.display_name} · {m.vendor}/{m.model_name}
+                {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
               </option>
             ))}
           </select>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：知识库设置（CorpusSettingsPanel）和知识图谱模型配置（ModelConfigPanel）中的 LLM / Embedding Model 下拉框选项显示冗余，格式为 `display_name · vendor/model_name`（如 "GPT-4o Mini · openai/gpt-4o-mini"），vendor/model 信息重复出现两次
- 关联上下文/Issue/文档：与 `LlmModelSelect.tsx`、`TaskModelSelect.tsx` 中已有的正确模式对齐

# 核心变更
- 将 `CorpusSettingsPanel.tsx`（Embedding Model + LLM Model）和 `ModelConfigPanel.tsx`（LLM Model + Embedding Model）共 4 处下拉框选项标签从 `{m.display_name} · {m.vendor}/{m.model_name}` 统一改为 `{m.display_name?.trim() || \`${m.vendor}/${m.model_name}\`}`
- 复用项目内 `LlmModelSelect` 和 `TaskModelSelect` 已验证的标准 fallback 模式：优先展示 display_name，无值时回退到 vendor/model_name

# 风险与回滚
- 主要风险：低风险纯 UI 文本变更，不涉及数据流、状态管理或 API 调用
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：无（纯 JSX 文本渲染变更）
- 集成测试：Pre-commit hooks（ESLint）全部通过
- E2E/Workflow：需人工在知识库设置页和知识图谱配置页检查下拉框显示
- 覆盖率/关键截图：下拉框选项应仅显示一次 vendor/model（如 "openai/gpt-4o-mini"），无冗余重复

# 影响范围
- 前端：`CorpusSettingsPanel.tsx`（知识库设置页）、`ModelConfigPanel.tsx`（知识图谱配置页）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 在 dev 环境中实机验证知识库设置和知识图谱模型配置两个页面的下拉框显示效果