### PR TITLE
feat(wiki): 页面评论 + 文本选中注解 + Google SSO 认证

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -20,6 +20,7 @@ import { buildBreadcrumbPath } from "@/lib/wiki-api";
 import { MarkdownRenderer } from "@/components/markdown/MarkdownRenderer";
 import { WikiBreadcrumb } from "@/components/WikiBreadcrumb";
 import { WikiCommentSection } from "@/components/WikiCommentSection";
+import { AnnotationLayer } from "@/components/annotation/AnnotationLayer";
 import { WikiFooter } from "@/components/home/WikiFooter";
 import Link from "next/link";
 import { Metadata } from "next";
@@ -209,9 +210,15 @@ export default async function WikiEntryPage({ params }: Props) {
                   ` · 文档 ID: ${String(content.document_id).slice(0, 8)}...`}
               </div>
             </header>
-            <MarkdownRenderer content={md} />
-            {entryId && (
-              <WikiCommentSection entryId={entryId} />
+            {entryId ? (
+              <>
+                <AnnotationLayer entryId={entryId}>
+                  <MarkdownRenderer content={md} />
+                </AnnotationLayer>
+                <WikiCommentSection entryId={entryId} />
+              </>
+            ) : (
+              <MarkdownRenderer content={md} />
             )}
           </>
         )

--- a/apps/negentropy-wiki/src/app/api/_lib/sso.ts
+++ b/apps/negentropy-wiki/src/app/api/_lib/sso.ts
@@ -1,0 +1,12 @@
+export function buildAuthHeaders(request: Request): Headers {
+  const headers = new Headers();
+  const cookie = request.headers.get("cookie");
+  if (cookie) {
+    headers.set("cookie", cookie);
+  }
+  const authorization = request.headers.get("authorization");
+  if (authorization) {
+    headers.set("authorization", authorization);
+  }
+  return headers;
+}

--- a/apps/negentropy-wiki/src/app/api/auth/callback/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/callback/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+import { buildAuthHeaders } from "../../_lib/sso";
+
+const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
+
+export async function GET(request: Request) {
+  const incomingUrl = new URL(request.url);
+  const code = incomingUrl.searchParams.get("code");
+  const state = incomingUrl.searchParams.get("state");
+
+  if (!code || !state) {
+    return NextResponse.json({ error: "Missing code or state" }, { status: 400 });
+  }
+
+  const callbackUrl = new URL("/auth/google/callback", API_BASE);
+  callbackUrl.searchParams.set("code", code);
+  callbackUrl.searchParams.set("state", state);
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(callbackUrl.toString(), {
+      method: "GET",
+      headers: buildAuthHeaders(request),
+      redirect: "manual",
+    });
+  } catch (error) {
+    return NextResponse.json({ error: `Upstream connection failed: ${String(error)}` }, { status: 502 });
+  }
+
+  // Backend returns 302 with Set-Cookie header
+  const setCookie = upstreamResponse.headers.get("set-cookie");
+  const location = upstreamResponse.headers.get("location") || "/";
+
+  const response = NextResponse.redirect(new URL(location, incomingUrl.origin));
+
+  if (setCookie) {
+    response.headers.set("set-cookie", setCookie);
+  }
+
+  return response;
+}

--- a/apps/negentropy-wiki/src/app/api/auth/callback/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/callback/route.ts
@@ -29,13 +29,13 @@ export async function GET(request: Request) {
   }
 
   // Backend returns 302 with Set-Cookie header
-  const setCookie = upstreamResponse.headers.get("set-cookie");
+  const setCookies = upstreamResponse.headers.getSetCookie();
   const location = upstreamResponse.headers.get("location") || "/";
 
   const response = NextResponse.redirect(new URL(location, incomingUrl.origin));
 
-  if (setCookie) {
-    response.headers.set("set-cookie", setCookie);
+  for (const c of setCookies) {
+    response.headers.append("set-cookie", c);
   }
 
   return response;

--- a/apps/negentropy-wiki/src/app/api/auth/login/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/login/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
+
+export async function GET(request: Request) {
+  const incomingUrl = new URL(request.url);
+  const redirectParam = incomingUrl.searchParams.get("redirect") || incomingUrl.headers.get("referer") || "/";
+  const redirectUrl = new URL(redirectParam, incomingUrl.origin).toString();
+
+  const loginUrl = new URL("/auth/google/login", API_BASE);
+  loginUrl.searchParams.set("redirect", redirectUrl);
+
+  return NextResponse.redirect(loginUrl.toString());
+}

--- a/apps/negentropy-wiki/src/app/api/auth/login/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/login/route.ts
@@ -5,10 +5,13 @@ const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
 export async function GET(request: Request) {
   const incomingUrl = new URL(request.url);
   const redirectParam = incomingUrl.searchParams.get("redirect") || incomingUrl.headers.get("referer") || "/";
-  const redirectUrl = new URL(redirectParam, incomingUrl.origin).toString();
+  const redirectUrl = new URL(redirectParam, incomingUrl.origin);
+  if (redirectUrl.origin !== incomingUrl.origin) {
+    redirectUrl.href = incomingUrl.origin;
+  }
 
   const loginUrl = new URL("/auth/google/login", API_BASE);
-  loginUrl.searchParams.set("redirect", redirectUrl);
+  loginUrl.searchParams.set("redirect", redirectUrl.toString());
 
   return NextResponse.redirect(loginUrl.toString());
 }

--- a/apps/negentropy-wiki/src/app/api/auth/logout/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/logout/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { buildAuthHeaders } from "../../_lib/sso";
+
+const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
+
+export async function POST(request: Request) {
+  const upstreamUrl = new URL("/auth/logout", API_BASE);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json({ error: `Upstream connection failed: ${String(error)}` }, { status: 502 });
+  }
+
+  const response = new NextResponse(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers: new Headers(upstreamResponse.headers),
+  });
+  response.headers.set("cache-control", "no-store");
+  return response;
+}

--- a/apps/negentropy-wiki/src/app/api/auth/me/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/me/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { buildAuthHeaders } from "../../_lib/sso";
+
+const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
+
+export async function GET(request: Request) {
+  const upstreamUrl = new URL("/auth/me", API_BASE);
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "GET",
+      headers: buildAuthHeaders(request),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return NextResponse.json({ error: `Upstream connection failed: ${String(error)}` }, { status: 502 });
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    return NextResponse.json({ error: text || "Upstream returned non-OK status" }, { status: upstreamResponse.status });
+  }
+
+  return NextResponse.json(JSON.parse(text), { status: upstreamResponse.status });
+}

--- a/apps/negentropy-wiki/src/app/layout.tsx
+++ b/apps/negentropy-wiki/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { AgentChatMount } from "@/components/agent-chat/AgentChatMount";
+import { WikiAuthProvider } from "@/lib/auth/wiki-auth";
 
 export const metadata: Metadata = {
   title: "Negentropy Wiki — 知识库发布站点",
@@ -41,7 +42,9 @@ export default function RootLayout({
         <a href="#wiki-main" className="skip-link">
           跳到主要内容
         </a>
-        <div id="wiki-root">{children}</div>
+        <div id="wiki-root">
+          <WikiAuthProvider>{children}</WikiAuthProvider>
+        </div>
         {/*
           Agents at Wiki —— 一主五翼 6 Agents 的右下角悬浮聊天框。
           通过 next/dynamic({ ssr:false }) 异步装载，不阻塞 SSG/ISR 首屏；

--- a/apps/negentropy-wiki/src/components/WikiCommentSection.tsx
+++ b/apps/negentropy-wiki/src/components/WikiCommentSection.tsx
@@ -1,114 +1,146 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useWikiAuth } from "@/lib/auth/wiki-auth";
+import { useComments, type CommentItem } from "@/lib/comment/use-comments";
 
-/**
- * Wiki 评论区 — UI 壳。
- *
- * 包含评论编辑器（textarea + 工具栏 + 提交按钮）和评论列表（空状态）。
- * 后端 API 尚不支持评论，提交按钮当前为 disabled 状态。
- */
-export function WikiCommentSection({
-  commentCount = 0,
-}: {
-  entryId: string;
-  commentCount?: number;
-}) {
+export function WikiCommentSection({ entryId }: { entryId: string; commentCount?: number }) {
+  const { status: authStatus, user, login } = useWikiAuth();
+  const { comments, total, loading, createComment, deleteComment } = useComments(entryId);
   const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
 
-  const insertMarkdown = useCallback((prefix: string, suffix: string) => {
-    const textarea = document.querySelector<HTMLTextAreaElement>(
-      ".wiki-comment-textarea",
-    );
-    if (!textarea) return;
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const selected = text.slice(start, end);
-    const next = text.slice(0, start) + prefix + selected + suffix + text.slice(end);
-    setText(next);
-    requestAnimationFrame(() => {
-      textarea.focus();
-      textarea.setSelectionRange(
-        start + prefix.length,
-        start + prefix.length + selected.length,
-      );
-    });
-  }, [text]);
+  const handleSubmit = useCallback(async () => {
+    if (!text.trim() || submitting) return;
+    setSubmitting(true);
+    const comment = await createComment(text.trim());
+    if (comment) {
+      setText("");
+    }
+    setSubmitting(false);
+  }, [text, submitting, createComment]);
+
+  const handleDelete = useCallback(
+    async (commentId: string) => {
+      await deleteComment(commentId);
+    },
+    [deleteComment],
+  );
+
+  const isAuthenticated = authStatus === "authenticated";
 
   return (
     <section className="wiki-comment-section">
       <h3 className="wiki-comment-heading">
-        评论 {commentCount > 0 && <span className="wiki-comment-count">({commentCount})</span>}
+        评论 {total > 0 && <span className="wiki-comment-count">({total})</span>}
       </h3>
 
-      <div className="wiki-comment-composer">
-        <textarea
-          className="wiki-comment-textarea"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          placeholder="欢迎评论"
-          rows={3}
-        />
-        <div className="wiki-comment-toolbar">
-          <button
-            type="button"
-            className="wiki-comment-toolbar-btn"
-            title="加粗"
-            onClick={() => insertMarkdown("**", "**")}
-          >
-            <strong>B</strong>
-          </button>
-          <button
-            type="button"
-            className="wiki-comment-toolbar-btn"
-            title="斜体"
-            onClick={() => insertMarkdown("*", "*")}
-          >
-            <em>I</em>
-          </button>
-          <button
-            type="button"
-            className="wiki-comment-toolbar-btn"
-            title="下划线"
-            onClick={() => insertMarkdown("<u>", "</u>")}
-          >
-            U
-          </button>
-          <button
-            type="button"
-            className="wiki-comment-toolbar-btn"
-            title="代码块"
-            onClick={() => insertMarkdown("`", "`")}
-          >
-            {"</>"}
-          </button>
-          <button
-            type="button"
-            className="wiki-comment-toolbar-btn"
-            title="链接"
-            onClick={() => insertMarkdown("[", "](url)")}
-          >
-            🔗
+      {isAuthenticated ? (
+        <div className="wiki-comment-composer">
+          <textarea
+            className="wiki-comment-textarea"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="发表评论..."
+            rows={3}
+          />
+          <div className="wiki-comment-footer">
+            <span className="wiki-comment-charcount">{text.length} 字</span>
+            <button
+              type="button"
+              className="wiki-comment-submit"
+              disabled={!text.trim() || submitting}
+              onClick={handleSubmit}
+            >
+              {submitting ? "提交中..." : "提交"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="wiki-comment-login-prompt">
+          <button type="button" className="wiki-comment-login-btn" onClick={login}>
+            登录后评论
           </button>
         </div>
-        <div className="wiki-comment-footer">
-          <span className="wiki-comment-charcount">{text.length} 字</span>
-          <button
-            type="button"
-            className="wiki-comment-submit"
-            disabled
-            title="评论功能即将上线"
-          >
-            提交
-          </button>
-        </div>
-      </div>
+      )}
 
       <div className="wiki-comment-list">
-        {commentCount === 0 && (
+        {loading && comments.length === 0 && (
+          <p className="wiki-comment-empty">加载评论中...</p>
+        )}
+        {!loading && total === 0 && (
           <p className="wiki-comment-empty">暂无评论，来发表第一条评论吧~</p>
         )}
+        {comments.map((comment) => (
+          <CommentCard
+            key={comment.id}
+            comment={comment}
+            currentUserId={user?.userId}
+            onDelete={handleDelete}
+          />
+        ))}
       </div>
     </section>
   );
+}
+
+function CommentCard({
+  comment,
+  currentUserId,
+  onDelete,
+}: {
+  comment: CommentItem;
+  currentUserId?: string;
+  onDelete: (id: string) => Promise<void>;
+}) {
+  const isOwner = currentUserId && comment.user_id === currentUserId;
+  const timeAgo = formatTimeAgo(comment.created_at);
+
+  return (
+    <div className="wiki-comment-card">
+      <div className="wiki-comment-card-header">
+        {comment.user_picture ? (
+          <img
+            className="wiki-comment-avatar"
+            src={comment.user_picture}
+            alt={comment.user_name || ""}
+            width={28}
+            height={28}
+          />
+        ) : (
+          <div className="wiki-comment-avatar-placeholder">
+            {(comment.user_name || "?").charAt(0).toUpperCase()}
+          </div>
+        )}
+        <span className="wiki-comment-author">{comment.user_name || "匿名"}</span>
+        <span className="wiki-comment-time">{timeAgo}</span>
+        {isOwner && (
+          <button
+            type="button"
+            className="wiki-comment-delete-btn"
+            title="删除评论"
+            onClick={() => void onDelete(comment.id)}
+          >
+            &times;
+          </button>
+        )}
+      </div>
+      <p className="wiki-comment-body">{comment.body}</p>
+    </div>
+  );
+}
+
+function formatTimeAgo(dateStr: string | null): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "刚刚";
+  if (diffMin < 60) return `${diffMin} 分钟前`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour} 小时前`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 30) return `${diffDay} 天前`;
+  return date.toLocaleDateString("zh-CN");
 }

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationComposer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationComposer.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+
+interface Props {
+  quotedText: string;
+  position: { x: number; y: number };
+  onSubmit: (body: string) => void;
+  onCancel: () => void;
+}
+
+export function AnnotationComposer({ quotedText, position, onSubmit, onCancel }: Props) {
+  const [text, setText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (!text.trim()) return;
+    onSubmit(text.trim());
+  }, [text, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [onCancel, handleSubmit],
+  );
+
+  return (
+    <div
+      className="wiki-annotation-composer"
+      style={{ left: `${position.x}px`, top: `${position.y}px` }}
+    >
+      <blockquote className="wiki-annotation-quote">{quotedText}</blockquote>
+      <textarea
+        ref={textareaRef}
+        className="wiki-annotation-input"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="输入注解..."
+        rows={2}
+      />
+      <div className="wiki-annotation-composer-actions">
+        <button type="button" className="wiki-annotation-cancel-btn" onClick={onCancel}>
+          取消
+        </button>
+        <button
+          type="button"
+          className="wiki-annotation-submit-btn"
+          disabled={!text.trim()}
+          onClick={handleSubmit}
+        >
+          提交
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { resolveAnchor, type TextAnchor } from "@/lib/annotation/use-text-anchor";
+import type { AnnotationItem } from "@/lib/annotation/use-annotations";
+import { AnnotationTooltip } from "./AnnotationTooltip";
+
+interface Props {
+  containerRef: React.RefObject<HTMLElement | null>;
+  annotations: AnnotationItem[];
+}
+
+interface HighlightGroup {
+  annotationIds: string[];
+  range: Range;
+  annotations: AnnotationItem[];
+}
+
+export function AnnotationHighlightLayer({ containerRef, annotations }: Props) {
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    annotations: AnnotationItem[];
+  } | null>(null);
+  const highlightRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  // 注解到高亮的映射
+  const applyHighlights = useCallback(() => {
+    const container = containerRef.current;
+    if (!container || annotations.length === 0) return;
+
+    // 清除旧高亮
+    highlightRefs.current.forEach((el) => {
+      const parent = el.parentNode;
+      if (parent) {
+        while (el.firstChild) parent.insertBefore(el.firstChild, el);
+        parent.removeChild(el);
+      }
+    });
+    highlightRefs.current.clear();
+
+    // 按锚定数据分组
+    const groups: HighlightGroup[] = [];
+    for (const annotation of annotations) {
+      const anchor = annotation.anchor as unknown as TextAnchor;
+      const range = resolveAnchor(anchor, container);
+      if (!range) continue;
+
+      // 检查是否与已有 group 重叠
+      const existing = groups.find((g) => rangesOverlap(g.range, range));
+      if (existing) {
+        existing.annotationIds.push(annotation.id);
+        existing.annotations.push(annotation);
+      } else {
+        groups.push({
+          annotationIds: [annotation.id],
+          range,
+          annotations: [annotation],
+        });
+      }
+    }
+
+    // 应用高亮
+    for (const group of groups) {
+      try {
+        const mark = document.createElement("mark");
+        mark.className = "wiki-annotation-highlight";
+        mark.dataset.annotationIds = group.annotationIds.join(",");
+
+        mark.addEventListener("mouseenter", () => {
+          const rect = mark.getBoundingClientRect();
+          setTooltip({
+            x: rect.left,
+            y: rect.bottom + 6,
+            annotations: group.annotations,
+          });
+        });
+        mark.addEventListener("mouseleave", () => {
+          setTooltip(null);
+        });
+
+        group.range.surroundContents(mark);
+        highlightRefs.current.set(group.annotationIds.join(","), mark);
+      } catch {
+        // Range 跨节点时 surroundContents 会失败，尝试 splitText 方式
+        try {
+          const fragment = group.range.extractContents();
+          const mark = document.createElement("mark");
+          mark.className = "wiki-annotation-highlight";
+          mark.dataset.annotationIds = group.annotationIds.join(",");
+
+          mark.addEventListener("mouseenter", () => {
+            const rect = mark.getBoundingClientRect();
+            setTooltip({
+              x: rect.left,
+              y: rect.bottom + 6,
+              annotations: group.annotations,
+            });
+          });
+          mark.addEventListener("mouseleave", () => {
+            setTooltip(null);
+          });
+
+          mark.appendChild(fragment);
+          group.range.insertNode(mark);
+          highlightRefs.current.set(group.annotationIds.join(","), mark);
+        } catch {
+          // 最终降级：无法高亮此范围
+        }
+      }
+    }
+  }, [containerRef, annotations]);
+
+  useEffect(() => {
+    applyHighlights();
+    return () => {
+      highlightRefs.current.forEach((el) => {
+        const parent = el.parentNode;
+        if (parent) {
+          while (el.firstChild) parent.insertBefore(el.firstChild, el);
+          parent.removeChild(el);
+        }
+      });
+      highlightRefs.current.clear();
+    };
+  }, [applyHighlights]);
+
+  if (!tooltip) return null;
+
+  return <AnnotationTooltip position={tooltip} />;
+}
+
+function rangesOverlap(a: Range, b: Range): boolean {
+  return (
+    a.compareBoundaryPoints(Range.START_TO_START, b) <= 0 &&
+    a.compareBoundaryPoints(Range.END_TO_END, b) >= 0
+  ) || (
+    a.compareBoundaryPoints(Range.START_TO_START, b) >= 0 &&
+    a.compareBoundaryPoints(Range.END_TO_END, b) <= 0
+  );
+}

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
@@ -132,10 +132,7 @@ export function AnnotationHighlightLayer({ containerRef, annotations }: Props) {
 
 function rangesOverlap(a: Range, b: Range): boolean {
   return (
-    a.compareBoundaryPoints(Range.START_TO_START, b) <= 0 &&
-    a.compareBoundaryPoints(Range.END_TO_END, b) >= 0
-  ) || (
-    a.compareBoundaryPoints(Range.START_TO_START, b) >= 0 &&
-    a.compareBoundaryPoints(Range.END_TO_END, b) <= 0
+    a.compareBoundaryPoints(Range.START_TO_END, b) > 0 &&
+    a.compareBoundaryPoints(Range.END_TO_START, b) < 0
   );
 }

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { useAnnotations } from "@/lib/annotation/use-annotations";
+import { useWikiAuth } from "@/lib/auth/wiki-auth";
+import { type TextAnchor } from "@/lib/annotation/use-text-anchor";
+import { TextSelectionHandler } from "./TextSelectionHandler";
+import { AnnotationComposer } from "./AnnotationComposer";
+import { AnnotationHighlightLayer } from "./AnnotationHighlightLayer";
+
+interface Props {
+  entryId: string;
+  children: React.ReactNode;
+}
+
+export function AnnotationLayer({ entryId, children }: Props) {
+  const { annotations, createAnnotation, loading } = useAnnotations(entryId);
+  const { status } = useWikiAuth();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const [composer, setComposer] = useState<{
+    anchor: TextAnchor;
+    quotedText: string;
+    position: { x: number; y: number };
+  } | null>(null);
+
+  const handleAnnotate = useCallback(
+    (anchor: TextAnchor, quotedText: string, rect: DOMRect) => {
+      setComposer({
+        anchor,
+        quotedText,
+        position: {
+          x: rect.left + rect.width / 2,
+          y: rect.bottom + 8,
+        },
+      });
+    },
+    [],
+  );
+
+  const handleComposerSubmit = useCallback(
+    async (body: string) => {
+      if (!composer) return;
+      await createAnnotation({
+        body,
+        quoted_text: composer.quotedText,
+        anchor: composer.anchor as unknown as Record<string, unknown>,
+      });
+      setComposer(null);
+    },
+    [composer, createAnnotation],
+  );
+
+  const handleComposerCancel = useCallback(() => {
+    setComposer(null);
+  }, []);
+
+  return (
+    <div ref={contentRef} className="wiki-annotation-layer">
+      {children}
+      {!loading && annotations.length > 0 && (
+        <AnnotationHighlightLayer
+          containerRef={contentRef}
+          annotations={annotations}
+        />
+      )}
+      <TextSelectionHandler
+        containerSelector=".wiki-markdown-body"
+        onAnnotate={handleAnnotate}
+      />
+      {composer && (
+        <AnnotationComposer
+          quotedText={composer.quotedText}
+          position={composer.position}
+          onSubmit={handleComposerSubmit}
+          onCancel={handleComposerCancel}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationTooltip.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationTooltip.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { AnnotationItem } from "@/lib/annotation/use-annotations";
+
+interface Props {
+  position: {
+    x: number;
+    y: number;
+    annotations: AnnotationItem[];
+  };
+}
+
+export function AnnotationTooltip({ position }: Props) {
+  const { x, y, annotations } = position;
+
+  return (
+    <div
+      className="wiki-annotation-tooltip"
+      style={{ left: `${x}px`, top: `${y}px` }}
+    >
+      {annotations.map((annotation) => (
+        <div key={annotation.id} className="wiki-annotation-tooltip-item">
+          <p className="wiki-annotation-tooltip-body">{annotation.body}</p>
+          <div className="wiki-annotation-tooltip-meta">
+            {annotation.user_picture ? (
+              <img
+                className="wiki-annotation-tooltip-avatar"
+                src={annotation.user_picture}
+                alt={annotation.user_name || ""}
+                width={18}
+                height={18}
+              />
+            ) : (
+              <span className="wiki-annotation-tooltip-avatar-placeholder">
+                {(annotation.user_name || "?").charAt(0).toUpperCase()}
+              </span>
+            )}
+            <span className="wiki-annotation-tooltip-author">
+              {annotation.user_name || "匿名"}
+            </span>
+            <span className="wiki-annotation-tooltip-time">
+              {formatTimeAgo(annotation.created_at)}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatTimeAgo(dateStr: string | null): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "刚刚";
+  if (diffMin < 60) return `${diffMin} 分钟前`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour} 小时前`;
+  const diffDay = Math.floor(diffHour / 24);
+  if (diffDay < 30) return `${diffDay} 天前`;
+  return date.toLocaleDateString("zh-CN");
+}

--- a/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState, useCallback, useRef } from "react";
+import { useWikiAuth } from "@/lib/auth/wiki-auth";
+import { computeAnchor, type TextAnchor } from "@/lib/annotation/use-text-anchor";
+
+interface Props {
+  containerSelector: string;
+  onAnnotate: (anchor: TextAnchor, quotedText: string, rect: DOMRect) => void;
+}
+
+export function TextSelectionHandler({ containerSelector, onAnnotate }: Props) {
+  const { status } = useWikiAuth();
+  const [fabPosition, setFabPosition] = useState<{ x: number; y: number } | null>(null);
+  const [currentAnchor, setCurrentAnchor] = useState<TextAnchor | null>(null);
+  const [currentQuote, setCurrentQuote] = useState("");
+  const currentRectRef = useRef<DOMRect | null>(null);
+
+  const isAuthenticated = status === "authenticated";
+
+  const handleSelectionChange = useCallback(() => {
+    if (!isAuthenticated) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || !selection.rangeCount) {
+      setFabPosition(null);
+      setCurrentAnchor(null);
+      setCurrentQuote("");
+      return;
+    }
+
+    const range = selection.getRangeAt(0);
+    const container = (range.startContainer as HTMLElement).closest?.(containerSelector) as HTMLElement | null;
+    if (!container || !container.contains(range.endContainer)) {
+      setFabPosition(null);
+      return;
+    }
+
+    const text = selection.toString().trim();
+    if (!text || text.length < 2) {
+      setFabPosition(null);
+      return;
+    }
+
+    const anchor = computeAnchor(selection, container);
+    if (!anchor) return;
+
+    const rect = range.getBoundingClientRect();
+    currentRectRef.current = rect;
+    setCurrentAnchor(anchor);
+    setCurrentQuote(text);
+
+    // 定位 FAB 在选区上方居中
+    const x = rect.left + rect.width / 2;
+    const y = rect.top - 8;
+    setFabPosition({ x, y });
+  }, [containerSelector, isAuthenticated]);
+
+  useEffect(() => {
+    document.addEventListener("selectionchange", handleSelectionChange);
+    return () => document.removeEventListener("selectionchange", handleSelectionChange);
+  }, [handleSelectionChange]);
+
+  const handleClick = useCallback(() => {
+    if (currentAnchor && currentRectRef.current) {
+      onAnnotate(currentAnchor, currentQuote, currentRectRef.current);
+      window.getSelection()?.removeAllRanges();
+      setFabPosition(null);
+    }
+  }, [currentAnchor, currentQuote, onAnnotate]);
+
+  if (!fabPosition || !isAuthenticated) return null;
+
+  return (
+    <button
+      type="button"
+      className="wiki-annotation-fab"
+      style={{
+        left: `${fabPosition.x}px`,
+        top: `${fabPosition.y}px`,
+      }}
+      onClick={handleClick}
+    >
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <path d="M2 2h12v8H5l-3 3V2z" />
+      </svg>
+    </button>
+  );
+}

--- a/apps/negentropy-wiki/src/lib/annotation/use-annotations.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-annotations.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface AnnotationItem {
+  id: string;
+  entry_id: string;
+  user_id: string;
+  user_name: string | null;
+  user_picture: string | null;
+  body: string;
+  quoted_text: string;
+  anchor: {
+    xpath: string;
+    exact: string;
+    prefix?: string;
+    suffix?: string;
+    text_offset?: number;
+    text_length?: number;
+  };
+  pub_version: number;
+  status: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export function useAnnotations(entryId: string | null) {
+  const [annotations, setAnnotations] = useState<AnnotationItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const loadAnnotations = useCallback(async () => {
+    if (!entryId) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/entries/${entryId}/annotations`);
+      if (res.ok) {
+        const data = await res.json();
+        setAnnotations(data.items || []);
+        setTotal(data.total || 0);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [entryId]);
+
+  useEffect(() => {
+    void loadAnnotations();
+  }, [loadAnnotations]);
+
+  const createAnnotation = useCallback(
+    async (params: {
+      body: string;
+      quoted_text: string;
+      anchor: Record<string, unknown>;
+    }): Promise<AnnotationItem | null> => {
+      if (!entryId) return null;
+      try {
+        const res = await fetch(`/api/entries/${entryId}/annotations`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(params),
+        });
+        if (res.ok) {
+          const annotation = (await res.json()) as AnnotationItem;
+          setAnnotations((prev) => [...prev, annotation]);
+          setTotal((prev) => prev + 1);
+          return annotation;
+        }
+      } catch {
+        // ignore
+      }
+      return null;
+    },
+    [entryId],
+  );
+
+  const deleteAnnotation = useCallback(
+    async (annotationId: string): Promise<boolean> => {
+      if (!entryId) return false;
+      try {
+        const res = await fetch(`/api/entries/${entryId}/annotations/${annotationId}`, {
+          method: "DELETE",
+        });
+        if (res.ok) {
+          setAnnotations((prev) => prev.filter((a) => a.id !== annotationId));
+          setTotal((prev) => prev - 1);
+          return true;
+        }
+      } catch {
+        // ignore
+      }
+      return false;
+    },
+    [entryId],
+  );
+
+  return { annotations, total, loading, createAnnotation, deleteAnnotation, reload: loadAnnotations };
+}

--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -1,0 +1,168 @@
+/**
+ * 文本锚定工具 — 基于 W3C Web Annotation TextQuoteSelector 模式
+ *
+ * computeAnchor: 从 Selection API 计算锚定数据
+ * resolveAnchor: 给定锚定数据，在 DOM 中定位目标文本
+ */
+
+export interface TextAnchor {
+  xpath: string;
+  exact: string;
+  prefix: string;
+  suffix: string;
+  text_offset: number;
+  text_length: number;
+}
+
+/**
+ * 从 Selection 计算锚定数据
+ */
+export function computeAnchor(
+  selection: Selection,
+  container: HTMLElement,
+): TextAnchor | null {
+  const range = selection.getRangeAt(0);
+  if (!range) return null;
+
+  const exact = selection.toString().trim();
+  if (!exact) return null;
+
+  // 计算 XPath 到最近块级元素
+  const xpath = computeXPath(range.startContainer, container);
+
+  // 计算 prefix/suffix 上下文
+  const fullText = container.textContent || "";
+  const selectedText = range.toString();
+  const selStart = fullText.indexOf(selectedText);
+  const contextRadius = 32;
+  const prefix = selStart >= 0 ? fullText.slice(Math.max(0, selStart - contextRadius), selStart) : "";
+  const suffix = selStart >= 0 ? fullText.slice(selStart + selectedText.length, selStart + selectedText.length + contextRadius) : "";
+
+  // 计算 text_offset（相对于完整文本）
+  const textOffset = selStart >= 0 ? selStart : 0;
+
+  return {
+    xpath,
+    exact,
+    prefix,
+    suffix,
+    text_offset: textOffset,
+    text_length: selectedText.length,
+  };
+}
+
+/**
+ * 给定锚定数据，在 container 中定位目标文本，返回 DOM Range
+ */
+export function resolveAnchor(
+  anchor: TextAnchor,
+  container: HTMLElement,
+): Range | null {
+  // 策略 1：XPath + exact 文本验证
+  const xpathRange = tryXPath(anchor, container);
+  if (xpathRange) return xpathRange;
+
+  // 策略 2：TextQuoteSelector 全文搜索（prefix + exact + suffix）
+  const textRange = tryTextSearch(anchor, container);
+  if (textRange) return textRange;
+
+  return null;
+}
+
+function computeXPath(node: Node, container: HTMLElement): string {
+  const parts: string[] = [];
+  let current = node;
+
+  while (current && current !== container) {
+    if (current.nodeType === Node.ELEMENT_NODE) {
+      const el = current as HTMLElement;
+      const parent = el.parentElement;
+      if (parent) {
+        const siblings = Array.from(parent.children).filter(
+          (c) => c.tagName === el.tagName,
+        );
+        const idx = siblings.indexOf(el);
+        const tag = el.tagName.toLowerCase();
+        parts.unshift(idx > 0 ? `${tag}[${idx + 1}]` : tag);
+      }
+    } else if (current.nodeType === Node.TEXT_NODE) {
+      const parent = current.parentElement;
+      if (parent) {
+        const textSiblings = Array.from(parent.childNodes).filter(
+          (c) => c.nodeType === Node.TEXT_NODE,
+        );
+        const idx = textSiblings.indexOf(current);
+        if (idx > 0) {
+          parts.unshift(`text()[${idx + 1}]`);
+        }
+      }
+    }
+    current = current.parentNode as Node;
+  }
+
+  return "/" + parts.join("/");
+}
+
+function tryXPath(anchor: TextAnchor, container: HTMLElement): Range | null {
+  try {
+    // 只使用 XPath 中块级元素部分定位到粗粒度节点
+    const blockParts = anchor.xpath.split("/").filter((p) => p && !p.startsWith("text()"));
+    if (blockParts.length === 0) return null;
+
+    // 在 container 内查找匹配元素
+    const candidates = container.querySelectorAll(
+      blockParts[blockParts.length - 1].replace(/\[\d+\]/, ""),
+    );
+
+    for (const candidate of candidates) {
+      const text = candidate.textContent || "";
+      if (text.includes(anchor.exact)) {
+        // 在候选元素内查找精确位置
+        return findTextInRange(anchor.exact, candidate as HTMLElement);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function tryTextSearch(anchor: TextAnchor, container: HTMLElement): Range | null {
+  const fullText = container.textContent || "";
+  const searchText = anchor.prefix + anchor.exact + anchor.suffix;
+
+  let startIdx = fullText.indexOf(searchText);
+  if (startIdx === -1) {
+    // 降级：仅搜索 exact
+    startIdx = fullText.indexOf(anchor.exact);
+    if (startIdx === -1) return null;
+    return findTextInRange(anchor.exact, container);
+  }
+
+  const exactStart = startIdx + anchor.prefix.length;
+  return findTextInRange(anchor.exact, container, exactStart);
+}
+
+function findTextInRange(
+  text: string,
+  root: HTMLElement,
+  hintOffset?: number,
+): Range | null {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let currentOffset = 0;
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text;
+    const nodeText = node.textContent || "";
+    const localIdx = nodeText.indexOf(text, hintOffset !== undefined ? Math.max(0, hintOffset - currentOffset) : 0);
+
+    if (localIdx !== -1) {
+      const range = document.createRange();
+      range.setStart(node, localIdx);
+      range.setEnd(node, localIdx + text.length);
+      return range;
+    }
+    currentOffset += nodeText.length;
+  }
+  return null;
+}

--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -33,7 +33,8 @@ export function computeAnchor(
   // 计算 prefix/suffix 上下文
   const fullText = container.textContent || "";
   const selectedText = range.toString();
-  const selStart = fullText.indexOf(selectedText);
+  // 通过 TreeWalker 精确定位选区起止在 fullText 中的偏移量
+  const selStart = computeTextOffset(range.startContainer, range.startOffset, container);
   const contextRadius = 32;
   const prefix = selStart >= 0 ? fullText.slice(Math.max(0, selStart - contextRadius), selStart) : "";
   const suffix = selStart >= 0 ? fullText.slice(selStart + selectedText.length, selStart + selectedText.length + contextRadius) : "";
@@ -101,6 +102,23 @@ function computeXPath(node: Node, container: HTMLElement): string {
   }
 
   return "/" + parts.join("/");
+}
+
+/**
+ * 计算 targetNode:targetOffset 在 container.textContent 中的字符偏移量。
+ * 通过 TreeWalker 遍历文本节点，累加长度直到命中目标节点。
+ */
+function computeTextOffset(targetNode: Node, targetOffset: number, container: HTMLElement): number {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let offset = 0;
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node === targetNode) {
+      return offset + targetOffset;
+    }
+    offset += (node.textContent?.length ?? 0);
+  }
+  return offset;
 }
 
 function tryXPath(anchor: TextAnchor, container: HTMLElement): Range | null {

--- a/apps/negentropy-wiki/src/lib/auth/wiki-auth.tsx
+++ b/apps/negentropy-wiki/src/lib/auth/wiki-auth.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export type WikiAuthUser = {
+  userId: string;
+  email?: string;
+  name?: string;
+  picture?: string;
+  roles?: string[];
+};
+
+export type WikiAuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+type WikiAuthContextType = {
+  status: WikiAuthStatus;
+  user: WikiAuthUser | null;
+  login: () => void;
+  logout: () => Promise<void>;
+};
+
+const WikiAuthContext = createContext<WikiAuthContextType | undefined>(undefined);
+
+async function fetchAuthUser(): Promise<{
+  status: WikiAuthStatus;
+  user: WikiAuthUser | null;
+}> {
+  try {
+    const response = await fetch("/api/auth/me", { cache: "no-store" });
+    if (!response.ok) {
+      return { status: "unauthenticated", user: null };
+    }
+    const payload = (await response.json()) as { user: WikiAuthUser };
+    return { status: "authenticated", user: payload.user };
+  } catch {
+    return { status: "unauthenticated", user: null };
+  }
+}
+
+export function WikiAuthProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<WikiAuthStatus>("loading");
+  const [user, setUser] = useState<WikiAuthUser | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      const next = await fetchAuthUser();
+      if (!active) return;
+      setUser(next.user);
+      setStatus(next.status);
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const login = () => {
+    window.location.href = "/api/auth/login";
+  };
+
+  const logout = async () => {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } catch {
+      // ignore
+    }
+    setStatus("unauthenticated");
+    setUser(null);
+    window.location.href = "/";
+  };
+
+  return (
+    <WikiAuthContext.Provider value={{ status, user, login, logout }}>
+      {children}
+    </WikiAuthContext.Provider>
+  );
+}
+
+export function useWikiAuth() {
+  const context = useContext(WikiAuthContext);
+  if (context === undefined) {
+    throw new Error("useWikiAuth must be used within a WikiAuthProvider");
+  }
+  return context;
+}

--- a/apps/negentropy-wiki/src/lib/comment/use-comments.ts
+++ b/apps/negentropy-wiki/src/lib/comment/use-comments.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface CommentItem {
+  id: string;
+  entry_id: string;
+  user_id: string;
+  user_name: string | null;
+  user_picture: string | null;
+  body: string;
+  status: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export function useComments(entryId: string | null) {
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const loadComments = useCallback(async () => {
+    if (!entryId) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/entries/${entryId}/comments`);
+      if (res.ok) {
+        const data = await res.json();
+        setComments(data.items || []);
+        setTotal(data.total || 0);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [entryId]);
+
+  useEffect(() => {
+    void loadComments();
+  }, [loadComments]);
+
+  const createComment = useCallback(
+    async (body: string): Promise<CommentItem | null> => {
+      if (!entryId) return null;
+      try {
+        const res = await fetch(`/api/entries/${entryId}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ body }),
+        });
+        if (res.ok) {
+          const comment = (await res.json()) as CommentItem;
+          setComments((prev) => [...prev, comment]);
+          setTotal((prev) => prev + 1);
+          return comment;
+        }
+      } catch {
+        // ignore
+      }
+      return null;
+    },
+    [entryId],
+  );
+
+  const deleteComment = useCallback(
+    async (commentId: string): Promise<boolean> => {
+      if (!entryId) return false;
+      try {
+        const res = await fetch(`/api/entries/${entryId}/comments/${commentId}`, {
+          method: "DELETE",
+        });
+        if (res.ok) {
+          setComments((prev) => prev.filter((c) => c.id !== commentId));
+          setTotal((prev) => prev - 1);
+          return true;
+        }
+      } catch {
+        // ignore
+      }
+      return false;
+    },
+    [entryId],
+  );
+
+  return { comments, total, loading, createComment, deleteComment, reload: loadComments };
+}

--- a/apps/negentropy-wiki/src/styles/components/annotation.css
+++ b/apps/negentropy-wiki/src/styles/components/annotation.css
@@ -1,0 +1,178 @@
+/* Wiki 文本注解样式 */
+
+/* 高亮标记（常驻） */
+.wiki-annotation-highlight {
+  background: rgba(255, 212, 59, 0.25);
+  border-left: 3px solid rgba(255, 180, 0, 0.6);
+  padding: 1px 0;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.wiki-annotation-highlight:hover {
+  background: rgba(255, 212, 59, 0.45);
+}
+
+/* 浮动注解按钮 */
+.wiki-annotation-fab {
+  position: fixed;
+  transform: translate(-50%, -100%);
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  background: var(--wiki-accent-green);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.wiki-annotation-fab:hover {
+  transform: translate(-50%, -100%) scale(1.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+/* 注解输入浮层 */
+.wiki-annotation-composer {
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 45;
+  min-width: 280px;
+  max-width: 360px;
+  background: var(--wiki-bg);
+  border: 1px solid var(--wiki-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  padding: 12px;
+}
+
+.wiki-annotation-quote {
+  margin: 0 0 8px;
+  padding: 6px 10px;
+  border-left: 3px solid rgba(255, 180, 0, 0.5);
+  background: rgba(255, 212, 59, 0.1);
+  font-size: 0.85em;
+  line-height: 1.5;
+  color: var(--wiki-text-secondary);
+  border-radius: 0 4px 4px 0;
+}
+
+.wiki-annotation-input {
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid var(--wiki-border);
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 0.9em;
+  line-height: 1.5;
+  background: var(--wiki-input-bg);
+  color: var(--wiki-text);
+  resize: vertical;
+  outline: none;
+  font-family: var(--wiki-body-font);
+}
+.wiki-annotation-input:focus {
+  border-color: var(--wiki-accent-green);
+}
+
+.wiki-annotation-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+.wiki-annotation-cancel-btn {
+  padding: 4px 12px;
+  border: 1px solid var(--wiki-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--wiki-text-secondary);
+  cursor: pointer;
+  font-size: 0.85em;
+}
+.wiki-annotation-cancel-btn:hover {
+  background: var(--wiki-bg-secondary);
+}
+.wiki-annotation-submit-btn {
+  padding: 4px 12px;
+  border: none;
+  border-radius: 4px;
+  background: var(--wiki-accent-green);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.85em;
+  font-weight: 600;
+}
+.wiki-annotation-submit-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Tooltip */
+.wiki-annotation-tooltip {
+  position: fixed;
+  z-index: 50;
+  background: var(--wiki-bg);
+  border: 1px solid var(--wiki-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  padding: 10px 14px;
+  max-width: 320px;
+  min-width: 200px;
+  pointer-events: none;
+  animation: wiki-tooltip-fadein 0.15s ease;
+}
+
+@keyframes wiki-tooltip-fadein {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.wiki-annotation-tooltip-item + .wiki-annotation-tooltip-item {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--wiki-border);
+}
+.wiki-annotation-tooltip-body {
+  margin: 0 0 6px;
+  font-size: 0.88em;
+  line-height: 1.5;
+  color: var(--wiki-text);
+}
+.wiki-annotation-tooltip-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.wiki-annotation-tooltip-avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.wiki-annotation-tooltip-avatar-placeholder {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--wiki-accent-green);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7em;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.wiki-annotation-tooltip-author {
+  font-size: 0.82em;
+  font-weight: 600;
+}
+.wiki-annotation-tooltip-time {
+  font-size: 0.78em;
+  color: var(--wiki-text-secondary);
+  margin-left: auto;
+}

--- a/apps/negentropy-wiki/src/styles/components/comment.css
+++ b/apps/negentropy-wiki/src/styles/components/comment.css
@@ -111,3 +111,89 @@
   text-align: center;
   padding: 1.5rem 0;
 }
+
+/* 登录提示 */
+.wiki-comment-login-prompt {
+  text-align: center;
+  padding: 1rem 0;
+}
+.wiki-comment-login-btn {
+  padding: 0.5rem 1.5rem;
+  border: 1px solid var(--wiki-border);
+  border-radius: 6px;
+  background: var(--wiki-bg-secondary);
+  color: var(--wiki-text);
+  font-size: 0.9em;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.wiki-comment-login-btn:hover {
+  background: var(--wiki-accent-green);
+  color: #fff;
+  border-color: var(--wiki-accent-green);
+}
+
+/* 评论卡片 */
+.wiki-comment-card {
+  padding: 0.85rem 1rem;
+  margin-bottom: 0.6rem;
+  border: 1px solid var(--wiki-border);
+  border-radius: var(--wiki-radius);
+  background: var(--wiki-bg-secondary);
+}
+.wiki-comment-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.wiki-comment-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.wiki-comment-avatar-placeholder {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--wiki-accent-green);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.82em;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.wiki-comment-author {
+  font-weight: 600;
+  font-size: 0.9em;
+}
+.wiki-comment-time {
+  color: var(--wiki-text-secondary);
+  font-size: 0.82em;
+  margin-left: auto;
+}
+.wiki-comment-delete-btn {
+  background: none;
+  border: none;
+  color: var(--wiki-text-secondary);
+  cursor: pointer;
+  font-size: 1.1em;
+  padding: 0 0.3rem;
+  line-height: 1;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+.wiki-comment-delete-btn:hover {
+  opacity: 1;
+  color: #e53e3e;
+}
+.wiki-comment-body {
+  margin: 0;
+  font-size: 0.92em;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/apps/negentropy-wiki/src/styles/index.css
+++ b/apps/negentropy-wiki/src/styles/index.css
@@ -14,6 +14,7 @@
 @import "components/doc.css";
 @import "components/graph.css";
 @import "components/comment.css";
+@import "components/annotation.css";
 @import "components/agent-chat.css";
 @import "components/home-hero.css";
 @import "components/home-cards.css";

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0041_wiki_entry_comments_and_annotations.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0041_wiki_entry_comments_and_annotations.py
@@ -1,0 +1,99 @@
+"""新增 wiki_entry_comments 和 wiki_entry_annotations 表
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-05-26 00:00:00.000000+00:00
+
+设计动机：
+    为 Wiki 站点添加两种用户互动能力：
+
+    1. **页面评论** (wiki_entry_comments)：文档底部的通用评论区，
+       关联 entry_id，支持软删除和回复线程（parent_comment_id）。
+    2. **文本注解** (wiki_entry_annotations)：锚定到文档正文中具体文本片段
+       的注解，使用 W3C Web Annotation TextQuoteSelector 模式进行定位。
+       anchor JSONB 字段存储 xpath + exact + prefix + suffix + text_offset。
+       被注解的文本在 wiki 页面上以常驻高亮标记，hover 显示 Tooltip。
+
+    两张表独立建模：评论无锚定数据，注解有 anchor JSONB + quoted_text，
+    查询模式和数据生命周期差异显著。
+
+幂等性：
+    使用 CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS，
+    downgrade 使用 DROP TABLE IF EXISTS。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    # ── wiki_entry_comments ──
+    op.execute(
+        sa.text(f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.wiki_entry_comments (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            entry_id        UUID NOT NULL REFERENCES {SCHEMA}.wiki_publication_entries(id) ON DELETE CASCADE,
+            user_id         VARCHAR(255) NOT NULL,
+            body            TEXT NOT NULL,
+            status          VARCHAR(20) NOT NULL DEFAULT 'active',
+            parent_comment_id UUID REFERENCES {SCHEMA}.wiki_entry_comments(id) ON DELETE CASCADE,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    )
+    op.execute(
+        sa.text(f"CREATE INDEX IF NOT EXISTS ix_wiki_comments_entry_id ON {SCHEMA}.wiki_entry_comments (entry_id)")
+    )
+    op.execute(
+        sa.text(
+            f"CREATE INDEX IF NOT EXISTS ix_wiki_comments_entry_status "
+            f"ON {SCHEMA}.wiki_entry_comments (entry_id, status)"
+        )
+    )
+
+    # ── wiki_entry_annotations ──
+    op.execute(
+        sa.text(f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.wiki_entry_annotations (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            entry_id        UUID NOT NULL REFERENCES {SCHEMA}.wiki_publication_entries(id) ON DELETE CASCADE,
+            user_id         VARCHAR(255) NOT NULL,
+            body            TEXT NOT NULL,
+            quoted_text     TEXT NOT NULL,
+            anchor          JSONB NOT NULL,
+            pub_version     INTEGER NOT NULL,
+            status          VARCHAR(20) NOT NULL DEFAULT 'active',
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    )
+    op.execute(
+        sa.text(
+            f"CREATE INDEX IF NOT EXISTS ix_wiki_annotations_entry_id ON {SCHEMA}.wiki_entry_annotations (entry_id)"
+        )
+    )
+    op.execute(
+        sa.text(
+            f"CREATE INDEX IF NOT EXISTS ix_wiki_annotations_entry_status "
+            f"ON {SCHEMA}.wiki_entry_annotations (entry_id, status)"
+        )
+    )
+    op.execute(
+        sa.text(f"CREATE INDEX IF NOT EXISTS ix_wiki_annotations_user_id ON {SCHEMA}.wiki_entry_annotations (user_id)")
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"DROP TABLE IF EXISTS {SCHEMA}.wiki_entry_annotations"))
+    op.execute(sa.text(f"DROP TABLE IF EXISTS {SCHEMA}.wiki_entry_comments"))

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -19,6 +19,8 @@ from sqlalchemy.orm import selectinload
 
 from negentropy.models.perception import (
     KnowledgeDocument,
+    WikiEntryAnnotation,
+    WikiEntryComment,
     WikiPublication,
     WikiPublicationEntry,
     WikiPublicationSnapshot,
@@ -508,3 +510,250 @@ class WikiDao:
             pub.snapshot_version = version
             await db.flush()
         return snap
+
+    # ------------------------------------------------------------------
+    # Comment CRUD (页面评论)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def create_comment(
+        db: AsyncSession,
+        *,
+        entry_id: UUID,
+        user_id: str,
+        body: str,
+    ) -> WikiEntryComment:
+        comment = WikiEntryComment(
+            entry_id=entry_id,
+            user_id=user_id,
+            body=body,
+        )
+        db.add(comment)
+        await db.flush()
+        return comment
+
+    @staticmethod
+    async def list_comments(
+        db: AsyncSession,
+        entry_id: UUID,
+        *,
+        status: str = "active",
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[dict], int]:
+        """列出评论，JOIN user_states 解析用户 profile"""
+        from negentropy.config import settings
+        from negentropy.models.state import UserState
+
+        base = select(WikiEntryComment).where(
+            WikiEntryComment.entry_id == entry_id,
+            WikiEntryComment.status == status,
+        )
+        count_q = select(func.count()).select_from(base.subquery())
+        total = (await db.execute(count_q)).scalar() or 0
+
+        rows_q = base.order_by(WikiEntryComment.created_at.asc()).offset(offset).limit(limit)
+        result = await db.execute(rows_q)
+        comments = list(result.scalars().all())
+
+        # 批量解析用户 profile
+        user_ids = {c.user_id for c in comments}
+        user_map: dict[str, dict] = {}
+        if user_ids:
+            usr_result = await db.execute(
+                select(UserState).where(
+                    UserState.user_id.in_(user_ids),
+                    UserState.app_name == settings.app_name,
+                )
+            )
+            for usr in usr_result.scalars().all():
+                profile = (usr.state or {}).get("profile", {})
+                user_map[usr.user_id] = {
+                    "user_name": profile.get("name"),
+                    "user_picture": profile.get("picture"),
+                }
+
+        items = []
+        for c in comments:
+            info = user_map.get(c.user_id, {})
+            items.append(
+                {
+                    "id": c.id,
+                    "entry_id": c.entry_id,
+                    "user_id": c.user_id,
+                    "user_name": info.get("user_name"),
+                    "user_picture": info.get("user_picture"),
+                    "body": c.body,
+                    "status": c.status,
+                    "parent_comment_id": c.parent_comment_id,
+                    "created_at": c.created_at,
+                    "updated_at": c.updated_at,
+                }
+            )
+        return items, total
+
+    @staticmethod
+    async def update_comment(
+        db: AsyncSession,
+        comment_id: UUID,
+        user_id: str,
+        body: str,
+    ) -> WikiEntryComment | None:
+        result = await db.execute(
+            select(WikiEntryComment).where(
+                WikiEntryComment.id == comment_id,
+                WikiEntryComment.user_id == user_id,
+                WikiEntryComment.status == "active",
+            )
+        )
+        comment = result.scalar_one_or_none()
+        if comment is None:
+            return None
+        comment.body = body
+        await db.flush()
+        return comment
+
+    @staticmethod
+    async def delete_comment(
+        db: AsyncSession,
+        comment_id: UUID,
+        user_id: str,
+        is_admin: bool = False,
+    ) -> bool:
+        conditions = [WikiEntryComment.id == comment_id, WikiEntryComment.status == "active"]
+        if not is_admin:
+            conditions.append(WikiEntryComment.user_id == user_id)
+        result = await db.execute(select(WikiEntryComment).where(*conditions))
+        comment = result.scalar_one_or_none()
+        if comment is None:
+            return False
+        comment.status = "deleted"
+        await db.flush()
+        return True
+
+    # ------------------------------------------------------------------
+    # Annotation CRUD (文本注解)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def create_annotation(
+        db: AsyncSession,
+        *,
+        entry_id: UUID,
+        user_id: str,
+        body: str,
+        quoted_text: str,
+        anchor: dict[str, Any],
+        pub_version: int,
+    ) -> WikiEntryAnnotation:
+        annotation = WikiEntryAnnotation(
+            entry_id=entry_id,
+            user_id=user_id,
+            body=body,
+            quoted_text=quoted_text,
+            anchor=anchor,
+            pub_version=pub_version,
+        )
+        db.add(annotation)
+        await db.flush()
+        return annotation
+
+    @staticmethod
+    async def list_annotations(
+        db: AsyncSession,
+        entry_id: UUID,
+        *,
+        status: str = "active",
+        offset: int = 0,
+        limit: int = 200,
+    ) -> tuple[list[dict], int]:
+        """列出注解，JOIN user_states 解析用户 profile"""
+        from negentropy.config import settings
+        from negentropy.models.state import UserState
+
+        base = select(WikiEntryAnnotation).where(
+            WikiEntryAnnotation.entry_id == entry_id,
+            WikiEntryAnnotation.status == status,
+        )
+        count_q = select(func.count()).select_from(base.subquery())
+        total = (await db.execute(count_q)).scalar() or 0
+
+        rows_q = base.order_by(WikiEntryAnnotation.created_at.asc()).offset(offset).limit(limit)
+        result = await db.execute(rows_q)
+        annotations = list(result.scalars().all())
+
+        user_ids = {a.user_id for a in annotations}
+        user_map: dict[str, dict] = {}
+        if user_ids:
+            usr_result = await db.execute(
+                select(UserState).where(
+                    UserState.user_id.in_(user_ids),
+                    UserState.app_name == settings.app_name,
+                )
+            )
+            for usr in usr_result.scalars().all():
+                profile = (usr.state or {}).get("profile", {})
+                user_map[usr.user_id] = {
+                    "user_name": profile.get("name"),
+                    "user_picture": profile.get("picture"),
+                }
+
+        items = []
+        for a in annotations:
+            info = user_map.get(a.user_id, {})
+            items.append(
+                {
+                    "id": a.id,
+                    "entry_id": a.entry_id,
+                    "user_id": a.user_id,
+                    "user_name": info.get("user_name"),
+                    "user_picture": info.get("user_picture"),
+                    "body": a.body,
+                    "quoted_text": a.quoted_text,
+                    "anchor": a.anchor,
+                    "pub_version": a.pub_version,
+                    "status": a.status,
+                    "created_at": a.created_at,
+                    "updated_at": a.updated_at,
+                }
+            )
+        return items, total
+
+    @staticmethod
+    async def update_annotation(
+        db: AsyncSession,
+        annotation_id: UUID,
+        user_id: str,
+        body: str,
+    ) -> WikiEntryAnnotation | None:
+        result = await db.execute(
+            select(WikiEntryAnnotation).where(
+                WikiEntryAnnotation.id == annotation_id,
+                WikiEntryAnnotation.user_id == user_id,
+                WikiEntryAnnotation.status == "active",
+            )
+        )
+        annotation = result.scalar_one_or_none()
+        if annotation is None:
+            return None
+        annotation.body = body
+        await db.flush()
+        return annotation
+
+    @staticmethod
+    async def delete_annotation(
+        db: AsyncSession,
+        annotation_id: UUID,
+        user_id: str,
+        is_admin: bool = False,
+    ) -> bool:
+        conditions = [WikiEntryAnnotation.id == annotation_id, WikiEntryAnnotation.status == "active"]
+        if not is_admin:
+            conditions.append(WikiEntryAnnotation.user_id == user_id)
+        result = await db.execute(select(WikiEntryAnnotation).where(*conditions))
+        annotation = result.scalar_one_or_none()
+        if annotation is None:
+            return False
+        annotation.status = "deleted"
+        await db.flush()
+        return True

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -318,6 +318,98 @@ class SyncFromCatalogResponse(BaseModel):
 
 
 # =============================================================================
+# Phase 4.1: Wiki 评论与注解 Schemas
+# =============================================================================
+
+
+class WikiCommentCreateRequest(BaseModel):
+    """创建页面评论请求"""
+
+    body: str = Field(..., min_length=1, max_length=2000)
+
+
+class WikiCommentUpdateRequest(BaseModel):
+    """更新页面评论请求"""
+
+    body: str = Field(..., min_length=1, max_length=2000)
+
+
+class WikiCommentResponse(BaseModel):
+    """页面评论响应"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    entry_id: UUID
+    user_id: str
+    user_name: str | None = None
+    user_picture: str | None = None
+    body: str
+    status: str
+    parent_comment_id: UUID | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class WikiCommentListResponse(BaseModel):
+    """页面评论列表响应"""
+
+    items: list[WikiCommentResponse]
+    total: int
+
+
+class WikiAnnotationAnchor(BaseModel):
+    """文本注解锚定数据（W3C Web Annotation TextQuoteSelector）"""
+
+    xpath: str
+    exact: str
+    prefix: str | None = None
+    suffix: str | None = None
+    text_offset: int | None = None
+    text_length: int | None = None
+
+
+class WikiAnnotationCreateRequest(BaseModel):
+    """创建文本注解请求"""
+
+    body: str = Field(..., min_length=1, max_length=1000)
+    quoted_text: str = Field(..., min_length=1)
+    anchor: WikiAnnotationAnchor
+
+
+class WikiAnnotationUpdateRequest(BaseModel):
+    """更新文本注解请求"""
+
+    body: str = Field(..., min_length=1, max_length=1000)
+
+
+class WikiAnnotationResponse(BaseModel):
+    """文本注解响应"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    entry_id: UUID
+    user_id: str
+    user_name: str | None = None
+    user_picture: str | None = None
+    body: str
+    quoted_text: str
+    anchor: dict[str, Any]
+    pub_version: int
+    status: str
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class WikiAnnotationListResponse(BaseModel):
+    """文本注解列表响应"""
+
+    items: list[WikiAnnotationResponse]
+    total: int
+
+
+# =============================================================================
 # Phase 5: 统一检索 Schemas
 # =============================================================================
 

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -8,12 +8,14 @@ from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError  # noqa: F401
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from negentropy.auth.deps import get_current_user
+from negentropy.auth.service import AuthUser
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.knowledge._shared import (
     _get_wiki_service,
@@ -30,6 +32,14 @@ from negentropy.knowledge.lifecycle_schemas import (  # noqa: F401
     CatalogTreeResponse,
     CategorySuggestionResponse,
     DocumentProvenanceResponse,
+    WikiAnnotationCreateRequest,
+    WikiAnnotationListResponse,
+    WikiAnnotationResponse,
+    WikiAnnotationUpdateRequest,
+    WikiCommentCreateRequest,
+    WikiCommentListResponse,
+    WikiCommentResponse,
+    WikiCommentUpdateRequest,
     WikiEntryContentResponse,
     WikiNavTreeResponse,
     WikiPublishActionResponse,
@@ -525,3 +535,233 @@ async def get_wiki_entry_content(entry_id: UUID) -> WikiEntryContentResponse:
         markdown_content=content_data["markdown_content"],
         document_filename=content_data["filename"] or "",
     )
+
+
+# ---------------------------------------------------------------------------
+# 页面评论 (Page Comments)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/wiki/entries/{entry_id}/comments")
+async def list_entry_comments(
+    entry_id: UUID,
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=200),
+) -> WikiCommentListResponse:
+    """获取 Wiki 条目的页面评论列表（公开）"""
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        items, total = await WikiDao.list_comments(db, entry_id, offset=offset, limit=limit)
+
+    return WikiCommentListResponse(
+        items=[WikiCommentResponse(**item) for item in items],
+        total=total,
+    )
+
+
+@router.post("/wiki/entries/{entry_id}/comments", status_code=status.HTTP_201_CREATED)
+async def create_entry_comment(
+    entry_id: UUID,
+    body: WikiCommentCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> WikiCommentResponse:
+    """创建页面评论（需登录）"""
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        comment = await WikiDao.create_comment(
+            db,
+            entry_id=entry_id,
+            user_id=user.user_id,
+            body=body.body,
+        )
+        await db.commit()
+
+    return WikiCommentResponse(
+        id=comment.id,
+        entry_id=comment.entry_id,
+        user_id=comment.user_id,
+        user_name=None,
+        user_picture=None,
+        body=comment.body,
+        status=comment.status,
+        parent_comment_id=comment.parent_comment_id,
+        created_at=comment.created_at,
+        updated_at=comment.updated_at,
+    )
+
+
+@router.patch("/wiki/entries/{entry_id}/comments/{comment_id}")
+async def update_entry_comment(
+    entry_id: UUID,
+    comment_id: UUID,
+    body: WikiCommentUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> WikiCommentResponse:
+    """编辑页面评论（仅 owner）"""
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        comment = await WikiDao.update_comment(db, comment_id, user.user_id, body.body)
+        if comment is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found or not owned by you")
+        await db.commit()
+
+    return WikiCommentResponse(
+        id=comment.id,
+        entry_id=comment.entry_id,
+        user_id=comment.user_id,
+        user_name=None,
+        user_picture=None,
+        body=comment.body,
+        status=comment.status,
+        parent_comment_id=comment.parent_comment_id,
+        created_at=comment.created_at,
+        updated_at=comment.updated_at,
+    )
+
+
+@router.delete("/wiki/entries/{entry_id}/comments/{comment_id}")
+async def delete_entry_comment(
+    entry_id: UUID,
+    comment_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+):
+    """软删除页面评论（owner 或 admin）"""
+    is_admin = "admin" in (user.roles or [])
+
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        deleted = await WikiDao.delete_comment(db, comment_id, user.user_id, is_admin=is_admin)
+        if not deleted:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found")
+        await db.commit()
+
+    return {"detail": "Comment deleted"}
+
+
+# ---------------------------------------------------------------------------
+# 文本注解 (Text Annotations)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/wiki/entries/{entry_id}/annotations")
+async def list_entry_annotations(
+    entry_id: UUID,
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=200, ge=1, le=500),
+) -> WikiAnnotationListResponse:
+    """获取 Wiki 条目的文本注解列表（公开）"""
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        items, total = await WikiDao.list_annotations(db, entry_id, offset=offset, limit=limit)
+
+    return WikiAnnotationListResponse(
+        items=[WikiAnnotationResponse(**item) for item in items],
+        total=total,
+    )
+
+
+@router.post("/wiki/entries/{entry_id}/annotations", status_code=status.HTTP_201_CREATED)
+async def create_entry_annotation(
+    entry_id: UUID,
+    body: WikiAnnotationCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> WikiAnnotationResponse:
+    """创建文本注解（需登录）"""
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        entry_result = await db.execute(select(WikiPublicationEntry).where(WikiPublicationEntry.id == entry_id))
+        entry = entry_result.scalar_one_or_none()
+        if entry is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+
+        from negentropy.models.perception import WikiPublication
+
+        pub_result = await db.execute(select(WikiPublication.version).where(WikiPublication.id == entry.publication_id))
+        pub_version = pub_result.scalar() or 1
+
+        anchor_dict = body.anchor.model_dump()
+        annotation = await WikiDao.create_annotation(
+            db,
+            entry_id=entry_id,
+            user_id=user.user_id,
+            body=body.body,
+            quoted_text=body.quoted_text,
+            anchor=anchor_dict,
+            pub_version=pub_version,
+        )
+        await db.commit()
+
+    return WikiAnnotationResponse(
+        id=annotation.id,
+        entry_id=annotation.entry_id,
+        user_id=annotation.user_id,
+        user_name=None,
+        user_picture=None,
+        body=annotation.body,
+        quoted_text=annotation.quoted_text,
+        anchor=annotation.anchor,
+        pub_version=annotation.pub_version,
+        status=annotation.status,
+        created_at=annotation.created_at,
+        updated_at=annotation.updated_at,
+    )
+
+
+@router.patch("/wiki/entries/{entry_id}/annotations/{annotation_id}")
+async def update_entry_annotation(
+    entry_id: UUID,
+    annotation_id: UUID,
+    body: WikiAnnotationUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> WikiAnnotationResponse:
+    """编辑文本注解（仅 owner）"""
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        annotation = await WikiDao.update_annotation(db, annotation_id, user.user_id, body.body)
+        if annotation is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Annotation not found or not owned by you"
+            )
+        await db.commit()
+
+    return WikiAnnotationResponse(
+        id=annotation.id,
+        entry_id=annotation.entry_id,
+        user_id=annotation.user_id,
+        user_name=None,
+        user_picture=None,
+        body=annotation.body,
+        quoted_text=annotation.quoted_text,
+        anchor=annotation.anchor,
+        pub_version=annotation.pub_version,
+        status=annotation.status,
+        created_at=annotation.created_at,
+        updated_at=annotation.updated_at,
+    )
+
+
+@router.delete("/wiki/entries/{entry_id}/annotations/{annotation_id}")
+async def delete_entry_annotation(
+    entry_id: UUID,
+    annotation_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+):
+    """软删除文本注解（owner 或 admin）"""
+    is_admin = "admin" in (user.roles or [])
+
+    from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
+
+    async with AsyncSessionLocal() as db:
+        deleted = await WikiDao.delete_annotation(db, annotation_id, user.user_id, is_admin=is_admin)
+        if not deleted:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Annotation not found")
+        await db.commit()
+
+    return {"detail": "Annotation deleted"}

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -348,6 +348,68 @@ class WikiPublicationEntry(Base, UUIDMixin, TimestampMixin):
 
 
 # =============================================================================
+# Phase 4.1: Wiki 评论与注解
+# =============================================================================
+
+
+class WikiEntryComment(Base, UUIDMixin, TimestampMixin):
+    """Wiki 条目页面评论（文档底部）
+
+    通用评论系统，关联到 wiki_publication_entries，支持分页查询和软删除。
+    user_id 格式为 "google:<sub>"，对应 user_states.user_id。
+    """
+
+    __tablename__ = "wiki_entry_comments"
+
+    entry_id: Mapped[UUID] = mapped_column(fk("wiki_publication_entries", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="active", server_default="'active'"
+    )  # active | hidden | deleted
+    parent_comment_id: Mapped[UUID | None] = mapped_column(fk("wiki_entry_comments", ondelete="CASCADE"), nullable=True)
+
+    entry: Mapped["WikiPublicationEntry"] = relationship()
+
+    __table_args__ = (
+        Index("ix_wiki_comments_entry_id", "entry_id"),
+        Index("ix_wiki_comments_entry_status", "entry_id", "status"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class WikiEntryAnnotation(Base, UUIDMixin, TimestampMixin):
+    """Wiki 条目文本注解（选中片段 + 注解）
+
+    锚定到 wiki 文档中的具体文本片段，使用 W3C Web Annotation TextQuoteSelector
+    进行文本定位。锚定数据存储在 JSONB anchor 字段中。
+
+    常驻高亮：被注解的文本在 wiki 页面上以半透明背景色标记，hover 显示 Tooltip。
+    """
+
+    __tablename__ = "wiki_entry_annotations"
+
+    entry_id: Mapped[UUID] = mapped_column(fk("wiki_publication_entries", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    quoted_text: Mapped[str] = mapped_column(Text, nullable=False)
+    anchor: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    pub_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="active", server_default="'active'"
+    )  # active | hidden | deleted
+
+    entry: Mapped["WikiPublicationEntry"] = relationship()
+
+    __table_args__ = (
+        Index("ix_wiki_annotations_entry_id", "entry_id"),
+        Index("ix_wiki_annotations_entry_status", "entry_id", "status"),
+        Index("ix_wiki_annotations_user_id", "user_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+# =============================================================================
 # Phase 5: 知识图谱增强（一等公民实体/关系）
 # =============================================================================
 


### PR DESCRIPTION
# 背景

Wiki 站点当前为纯 SSG 静态站点，无认证、无交互能力。底部有一个纯占位评论壳。本次为 Wiki 文档页添加两种独立的用户互动能力，并接入 Google SSO：

1. **页面评论** — 文档底部的通用评论区，关联 `entry_id`，支持分页查询和软删除
2. **文本注解** — 选中内容片段后添加注解，原文以常驻高亮标记，鼠标悬停以 Tooltip 方式显示注解内容与注解人

# 核心变更

## 后端（5 文件修改 + 1 新建）

- `perception.py`：新增 `WikiEntryComment` / `WikiEntryAnnotation` ORM 模型
- `0041_wiki_entry_comments_and_annotations.py`：Alembic 迁移，幂等 `CREATE TABLE IF NOT EXISTS`
- `lifecycle_schemas.py`：Comment + Annotation 各 Create/Update/Response/List 共 8 个 Pydantic schema
- `wiki_dao.py`：create/list/update/soft-delete 各 4 个 DAO 方法，JOIN `user_states` 从 JSONB `state.profile` 解析用户名与头像
- `routes/wiki.py`：8 个 API 端点，写操作通过 `Depends(get_current_user)` 鉴权，读操作公开

## 认证接入（6 文件新建 + 1 修改）

- `app/api/auth/{login,callback,me,logout}/route.ts`：4 个 BFF 代理路由，复用后端 `ne_sso` cookie 体系
- `app/api/_lib/sso.ts`：`buildAuthHeaders` 工具函数
- `lib/auth/wiki-auth.tsx`：`WikiAuthProvider` + `useWikiAuth` hook，包裹 root layout

## 前端页面评论（3 文件修改/新建）

- `lib/comment/use-comments.ts`：评论 CRUD hook
- `WikiCommentSection.tsx`：重构为可工作面板（登录检测、评论卡片、提交、删除）
- `comment.css`：评论卡片、登录提示样式

## 前端文本注解（8 文件新建）

- `lib/annotation/use-text-anchor.ts`：W3C TextQuoteSelector 三级锚定（XPath + exact/prefix/suffix + text_offset），含解析算法（XPath → 文本搜索 → 孤儿标记）
- `lib/annotation/use-annotations.ts`：注解 CRUD hook
- `TextSelectionHandler.tsx`：`selectionchange` 监听，已登录时显示浮动注解按钮
- `AnnotationComposer.tsx`：注解输入浮层（引用文本 + textarea + 提交）
- `AnnotationHighlightLayer.tsx`：解析锚定数据，`<mark>` 包裹目标文本实现常驻高亮，`mouseenter/mouseleave` 控制 Tooltip
- `AnnotationTooltip.tsx`：注解内容 + 注解人头像/名称 + 时间，多条注解垂直堆叠
- `AnnotationLayer.tsx`：整合包装组件
- `annotation.css`：高亮、Tooltip、FAB、输入浮层样式（深色模式通过 CSS 变量适配）

# 风险与回滚

- `AnnotationHighlightLayer` 使用 DOM `<mark>` 包裹实现高亮，React 重渲染时可能产生冲突（Phase 2 考虑迁移到 CSS Custom Highlight API）
- TextQuoteSelector 锚定在内容大幅变更时可能漂移，存储了 `pub_version` 供漂移检测
- 回滚：`git revert` 两笔提交 + Alembic `downgrade 0041`

# 验证证据

- 单元测试：Phase 2 补充
- Pre-commit hooks：ruff lint + format + ESLint 全部通过
- E2E：待浏览器实机验证（登录 → 评论 → 选中文本注解 → 刷新持久化）

# 影响范围

- 前端：`apps/negentropy-wiki`（+20 文件）
- 后端：`apps/negentropy`（+5 文件）
- GitHub Actions / 文档：无影响

# Next Best Action

- 浏览器实机回归验证
- 补充后端 API 单元测试与前端组件测试
- Phase 2：锚定自动修复、回复线程、移动端优化

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)