### PR TITLE
fix(wiki): 修复 CLI start 两处构建失败

### DIFF
--- a/apps/negentropy-wiki/src/app/api/auth/login/route.ts
+++ b/apps/negentropy-wiki/src/app/api/auth/login/route.ts
@@ -4,7 +4,7 @@ const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
 
 export async function GET(request: Request) {
   const incomingUrl = new URL(request.url);
-  const redirectParam = incomingUrl.searchParams.get("redirect") || incomingUrl.headers.get("referer") || "/";
+  const redirectParam = incomingUrl.searchParams.get("redirect") || request.headers.get("referer") || "/";
   const redirectUrl = new URL(redirectParam, incomingUrl.origin);
   if (redirectUrl.origin !== incomingUrl.origin) {
     redirectUrl.href = incomingUrl.origin;

--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -92,7 +92,7 @@ function computeXPath(node: Node, container: HTMLElement): string {
         const textSiblings = Array.from(parent.childNodes).filter(
           (c) => c.nodeType === Node.TEXT_NODE,
         );
-        const idx = textSiblings.indexOf(current);
+        const idx = textSiblings.indexOf(current as ChildNode);
         if (idx > 0) {
           parts.unshift(`text()[${idx + 1}]`);
         }


### PR DESCRIPTION
## Summary

- 修复 `login/route.ts` 中 `URL` 对象误用 `.headers` 属性，应为 `request.headers`（`URL` 对象无 `headers` 属性，运行时必然 `TypeError`）
- 修复 `use-text-anchor.ts` 中 `Node` 类型与 `ChildNode[]` 的 `indexOf` 参数不匹配，导致 Next.js TypeScript 检查失败

## Test plan

- [ ] `scripts/cli.sh start` 可正常完成前端构建
- [ ] Wiki 登录跳转 redirect 链路正常（referer 回退生效）
- [ ] 文本注解 XPath 计算在多文本兄弟节点场景下定位正确

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)