### PR TITLE
fix(auth): 配置级 Admin 角色不可被 DB 状态自动降级

### DIFF
--- a/apps/negentropy/src/negentropy/auth/service.py
+++ b/apps/negentropy/src/negentropy/auth/service.py
@@ -181,6 +181,11 @@ class AuthService:
                 if isinstance(db_roles, list):
                     effective_roles = db_roles
 
+            # Config-level admin is non-negotiable: DB state cannot demote users
+            # who are explicitly listed in admin_emails.
+            if "admin" in user.roles and "admin" not in effective_roles:
+                effective_roles = ["admin"]
+
             next_state = {
                 "profile": {
                     "email": user.email,

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -106,7 +106,7 @@ auth:
   state_ttl_seconds: 600
   allowed_domains: []
   allowed_emails: []
-  admin_emails: ["threefish.ai@gmail.com", "cm.huang@aftership"]
+  admin_emails: ["threefish.ai@gmail.com", "cm.huang@aftership.com"]
   user_id_strategy: sub                    # sub | email
   default_redirect_path: "/"
 

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -106,7 +106,7 @@ auth:
   state_ttl_seconds: 600
   allowed_domains: []
   allowed_emails: []
-  admin_emails: ["threefish.ai@gmail.com"]
+  admin_emails: ["threefish.ai@gmail.com", "cm.huang@aftership"]
   user_id_strategy: sub                    # sub | email
   default_redirect_path: "/"
 

--- a/apps/negentropy/tests/unit_tests/auth/test_service.py
+++ b/apps/negentropy/tests/unit_tests/auth/test_service.py
@@ -126,8 +126,8 @@ async def test_existing_user_preserves_admin_role_on_relogin(monkeypatch: pytest
 
 
 @pytest.mark.asyncio
-async def test_existing_user_preserves_user_role_despite_config_promotion(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DB 中角色为 user、config 中为 admin → 保留 DB 的 user 角色（DB 是权威源）。"""
+async def test_config_admin_is_non_negotiable_over_db_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB 中角色为 user、config 中为 admin → config 级 admin 不可被 DB 降级。"""
     db_state = _FakeUserState("google:alice", {"roles": ["user"], "profile": {}, "auth": {}})
     _patch_db(monkeypatch, db_state)
     monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=["alice@example.com"]))
@@ -136,7 +136,7 @@ async def test_existing_user_preserves_user_role_despite_config_promotion(monkey
     user = _make_user(roles=["admin"])
     result = await service._upsert_user_state(user, _claims())
 
-    assert result.roles == ["user"]
+    assert result.roles == ["admin"]
 
 
 # ============================================================================
@@ -168,3 +168,35 @@ async def test_same_roles_returns_same_instance(monkeypatch: pytest.MonkeyPatch)
     result = await service._upsert_user_state(user, _claims())
 
     assert result is user
+
+
+# ============================================================================
+# Config 级 Admin 不可降级保护
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_config_admin_protects_new_user_with_lost_db_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB 记录丢失 + config admin → 新用户仍获得 admin（根因回归）。"""
+    _patch_db(monkeypatch, None)
+    monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=["admin@example.com"]))
+
+    service = AuthService()
+    user = _make_user(email="admin@example.com", roles=["admin"])
+    result = await service._upsert_user_state(user, _claims("admin@example.com"))
+
+    assert result.roles == ["admin"]
+
+
+@pytest.mark.asyncio
+async def test_config_admin_protects_against_corrupted_db_roles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DB roles 损坏（非列表）+ config admin → config 级 admin 仍生效。"""
+    db_state = _FakeUserState("google:alice", {"roles": "corrupted", "profile": {}, "auth": {}})
+    _patch_db(monkeypatch, db_state)
+    monkeypatch.setattr(settings, "auth", AuthSettings(admin_emails=["alice@example.com"]))
+
+    service = AuthService()
+    user = _make_user(roles=["admin"])
+    result = await service._upsert_user_state(user, _claims())
+
+    assert result.roles == ["admin"]


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`cm.huang@aftership.com` 重新登录后自动从 Admin 降级为 User。根因是 `_upsert_user_state()` 查不到已有 DB 记录时（可能因之前的 DB 操作导致记录丢失），`_build_user()` 按 `admin_emails` 配置派发角色，而该邮箱不在配置列表中，导致被分配 `["user"]`。
- 关联上下文：ISSUE-065（OAuth 重登录不再覆盖 DB 管理的角色）

# 核心变更
- `config.default.yaml`：`admin_emails` 加入 `cm.huang@aftership.com`，确保配置级始终授予 Admin
- `auth/service.py`：`_upsert_user_state()` 增加 Admin 保护断言——`admin_emails` 中列出的用户，其 Admin 身份是硬性的、不可被任何 DB 状态（记录丢失、角色损坏、降级写入）覆盖
- `test_service.py`：补充 3 个防御性测试用例（DB 降级保护、记录丢失保护、角色损坏保护）

# 风险与回滚
- 主要风险：`admin_emails` 中列出的用户无法通过 Admin API 降级（这是设计意图——配置级 Admin 应为硬性身份）
- 回滚方式：`git revert`

# 验证证据
- 单元测试：8 passed（含 3 个新增防御性用例）
- Pre-commit hooks：全部通过（ruff lint、ruff format、trim whitespace 等）

# 影响范围
- 前端：无
- 后端：`auth/service.py`（角色分配逻辑）、`config.default.yaml`（默认配置）
- GitHub Actions / 文档：无

# Next Best Action
- 部署后通过 `PATCH /auth/users/{user_id}/roles` 或 SQL 恢复该用户的 Admin 角色