### PR TITLE
fix(knowledge): 补全文档 PATCH 代理路由，修复 Wiki 页面修改文档名称报 405 Method Not Allowed

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/route.ts
@@ -1,4 +1,4 @@
-import { proxyDelete, proxyGet } from "../../../../_proxy";
+import { proxyDelete, proxyGet, proxyPatch } from "../../../../_proxy";
 
 /**
  * GET /api/knowledge/base/{corpusId}/documents/{documentId}
@@ -10,6 +10,21 @@ export async function GET(
 ) {
   const { corpusId, documentId } = await context.params;
   return proxyGet(request, `/knowledge/base/${corpusId}/documents/${documentId}`);
+}
+
+/**
+ * PATCH /api/knowledge/base/{corpusId}/documents/{documentId}
+ * Update document metadata (e.g. display_name)
+ */
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ corpusId: string; documentId: string }> },
+) {
+  const { corpusId, documentId } = await context.params;
+  return proxyPatch(
+    request,
+    `/knowledge/base/${corpusId}/documents/${documentId}`,
+  );
 }
 
 /**


### PR DESCRIPTION
## 问题

Wiki 页面 → Paper 节点 → 归属文档列表中，点击编辑图标修改文档的显示名称（display_name）时，前端发送 `PATCH /api/knowledge/base/{corpusId}/documents/{documentId}` 请求，但 Next.js BFF 代理路由文件仅导出了 `GET` 和 `DELETE`，缺少 `PATCH` handler，导致 Next.js 返回 **405 Method Not Allowed**。

## 根因分析

调用链：

1. `DocumentAssignmentSection.tsx` 的 `commitEdit` → 调用 `updateDocument()`
2. `knowledge-api.ts` 的 `updateDocument()` → 发送 `PATCH` 请求
3. Next.js 路由 `route.ts` 只有 `GET` + `DELETE`，**缺少 `PATCH`** → 返回 405
4. 后端 FastAPI `documents.py:202` 的 `@router.patch(...)` 处理器**已存在且功能正常**

## 修复内容

在 `apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/route.ts` 中：

- 导入 `proxyPatch`（与同目录下 `chunks/[chunkId]/route.ts` 的 PATCH 实现模式一致）
- 新增 `PATCH` export，将请求代理到后端 `/knowledge/base/{corpusId}/documents/{documentId}`

## 实机验证

通过 Chrome DevTools 在 Wiki 页面完成重命名操作，PATCH 请求返回 **200 OK**，页面即时刷新显示新名称，无任何错误提示。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>