### PR TITLE
fix(wiki): 隐藏头部导航栏 tabs 区域的水平滚动条;

### DIFF
--- a/apps/negentropy-wiki/src/styles/components/header.css
+++ b/apps/negentropy-wiki/src/styles/components/header.css
@@ -50,7 +50,10 @@
   min-width: 0;
   height: 100%;
   overflow-x: auto;
-  scrollbar-width: thin;
+  scrollbar-width: none;
+}
+.wiki-header-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .wiki-header-tab {


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 站点头部导航栏（`.wiki-header-tabs`）在 tab 数量较多或视口较窄时，底部会出现一条可见的水平滚动条，影响视觉整洁度
- 关联上下文/Issue/文档：无

# 核心变更
- 将 `.wiki-header-tabs` 的 `scrollbar-width: thin` 改为 `scrollbar-width: none`，在 Firefox 中隐藏滚动条
- 新增 `.wiki-header-tabs::-webkit-scrollbar { display: none; }` 规则，在 Chrome/Safari/Edge 中隐藏滚动条
- 保留 `overflow-x: auto`，横向滚动能力不受影响

# 风险与回滚
- 主要风险：极低风险，纯 CSS 视觉调整，不影响交互功能
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：不适用（纯 CSS 变更）
- 集成测试：不适用
- E2E/Workflow：通过浏览器目视确认
- 覆盖率/关键截图：用户已提供问题截图

# 影响范围
- 前端：`apps/negentropy-wiki/src/styles/components/header.css`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 在多浏览器（Chrome、Firefox、Safari）中验证滚动条隐藏效果与横向滚动功能正常