### PR TITLE
feat(pipeline): Pipeline Run ID 使用文档名称替代 UUID 后缀

### DIFF
--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -460,14 +460,16 @@ export const formatRelativeTime = (dateStr?: string): string => {
 };
 
 /**
- * 截断 Run ID 显示
- * @param runId - 完整的 Run ID
- * @param length - 保留的字符长度，默认 8
- * @returns 截断后的 Run ID
+ * 截断 Run ID 显示。
+ * 新格式 run_id 为 `{operation}-{label}-{4hex}`，优先保留 operation + label 部分，
+ * 省略末尾 short-uuid 后缀；旧格式（纯 8 位 hex）按固定长度截断。
  */
-export const truncateRunId = (runId: string, length = 8): string => {
+export const truncateRunId = (runId: string, length = 24): string => {
   if (!runId) return "-";
-  return runId.length > length ? `${runId.slice(0, length)}...` : runId;
+  // 尝试去掉末尾的 short-uuid 后缀 (4 hex chars + '-')
+  const withoutSuffix = runId.replace(/-[0-9a-f]{4}$/, "");
+  if (withoutSuffix.length <= length) return withoutSuffix;
+  return `${withoutSuffix.slice(0, length)}...`;
 };
 
 export interface FailedStageDetail {

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 import uuid
 from collections.abc import Awaitable, Callable, Iterable
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote, urlparse
 from uuid import UUID
 
 from negentropy.logging import get_logger
@@ -50,6 +53,68 @@ CHUNK_ROLE_LEAF = "leaf"
 
 EmbeddingFn = Callable[[str], Awaitable[list[float]]]
 BatchEmbeddingFn = Callable[[list[str]], Awaitable[list[list[float]]]]
+
+# ---------------------------------------------------------------------------
+# Run ID 语义化：从 input_data 提取人类可读的源标签
+# ---------------------------------------------------------------------------
+
+_LABEL_MAX_LENGTH = 50
+
+
+def _sanitize_label(name: str, *, max_length: int = _LABEL_MAX_LENGTH) -> str:
+    """清理标签：非字母数字替换为 `_`，合并连续下划线，截断过长名称。"""
+    sanitized = re.sub(r"[^\w\-.]", "_", name)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    return sanitized[:max_length]
+
+
+def _extract_source_label(input_data: dict[str, Any]) -> str:
+    """从 input_data 中提取人类可读的源标识。
+
+    优先级：filename > url > source_uri。
+    """
+    # 1. filename → 去掉扩展名
+    if filename := input_data.get("filename"):
+        name = Path(filename).stem
+        if label := _sanitize_label(name):
+            return label
+
+    # 2. url → 取最后路径段
+    if url := input_data.get("url"):
+        parsed = urlparse(url)
+        path = unquote(parsed.path).rstrip("/")
+        if path:
+            segment = path.split("/")[-1]
+            if label := _sanitize_label(segment):
+                return label
+        # URL 无路径时使用 domain
+        if label := _sanitize_label(parsed.netloc):
+            return label
+
+    # 3. source_uri → 区分 GCS / HTTP / 通用
+    if source_uri := input_data.get("source_uri"):
+        if source_uri.startswith("gs://"):
+            name = source_uri.split("/")[-1]
+            if "." in name:
+                name = Path(name).stem
+            if label := _sanitize_label(name):
+                return label
+        if source_uri.startswith(("http://", "https://")):
+            parsed = urlparse(source_uri)
+            path = unquote(parsed.path).rstrip("/")
+            if path:
+                segment = path.split("/")[-1]
+                if label := _sanitize_label(segment):
+                    return label
+            if label := _sanitize_label(parsed.netloc):
+                return label
+        # 通用回退：取最后路径段
+        name = source_uri.split("/")[-1]
+        if label := _sanitize_label(name):
+            return label
+
+    return ""
+
 
 # Pipeline 操作类型
 PipelineOperation = str  # "ingest_text" | "ingest_url" | "replace_source" | "sync_source" | "rebuild_source"
@@ -718,10 +783,14 @@ class KnowledgeService:
         if not self._pipeline_dao:
             raise ValueError("pipeline_dao is required for async pipeline operations")
 
+        label = _extract_source_label(input_data)
+        run_id = f"{operation}-{label}-{uuid.uuid4().hex[:4]}" if label else f"{operation}-{uuid.uuid4().hex[:8]}"
+
         tracker = PipelineTracker(
             dao=self._pipeline_dao,
             app_name=app_name,
             operation=operation,
+            run_id=run_id,
         )
         await tracker.start(input_data)
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_run_id_label.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_run_id_label.py
@@ -1,0 +1,122 @@
+"""测试 run_id 语义化辅助函数：_extract_source_label / _sanitize_label"""
+
+from __future__ import annotations
+
+from negentropy.knowledge.service import _extract_source_label, _sanitize_label
+
+# ---------------------------------------------------------------------------
+# _sanitize_label
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeLabel:
+    def test_simple_name(self) -> None:
+        assert _sanitize_label("report.pdf") == "report.pdf"
+
+    def test_spaces_replaced(self) -> None:
+        assert _sanitize_label("my report name") == "my_report_name"
+
+    def test_special_chars_replaced(self) -> None:
+        assert _sanitize_label("hello@world#123") == "hello_world_123"
+
+    def test_consecutive_underscores_collapsed(self) -> None:
+        assert _sanitize_label("a   b") == "a_b"
+
+    def test_leading_trailing_stripped(self) -> None:
+        assert _sanitize_label("__hello__") == "hello"
+
+    def test_truncation(self) -> None:
+        long_name = "a" * 100
+        assert len(_sanitize_label(long_name)) == 50
+
+    def test_unicode_preserved(self) -> None:
+        assert _sanitize_label("中文文档") == "中文文档"
+
+    def test_empty_string(self) -> None:
+        assert _sanitize_label("") == ""
+
+    def test_only_special_chars(self) -> None:
+        assert _sanitize_label("@#$%") == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_source_label — filename 优先级
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromFilename:
+    def test_pdf_filename(self) -> None:
+        assert _extract_source_label({"filename": "report.pdf"}) == "report"
+
+    def test_docx_filename(self) -> None:
+        assert _extract_source_label({"filename": "meeting notes.docx"}) == "meeting_notes"
+
+    def test_filename_with_path(self) -> None:
+        assert _extract_source_label({"filename": "/uploads/my paper.pdf"}) == "my_paper"
+
+    def test_filename_without_extension(self) -> None:
+        assert _extract_source_label({"filename": "README"}) == "README"
+
+
+# ---------------------------------------------------------------------------
+# _extract_source_label — URL 优先级
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromUrl:
+    def test_url_with_path(self) -> None:
+        assert _extract_source_label({"url": "https://blog.com/post/guide"}) == "guide"
+
+    def test_url_with_trailing_slash(self) -> None:
+        assert _extract_source_label({"url": "https://blog.com/post/guide/"}) == "guide"
+
+    def test_url_encoded_path(self) -> None:
+        assert _extract_source_label({"url": "https://blog.com/post/my%20article"}) == "my_article"
+
+    def test_url_root_uses_domain(self) -> None:
+        assert _extract_source_label({"url": "https://example.com/"}) == "example.com"
+
+    def test_url_no_path_uses_domain(self) -> None:
+        assert _extract_source_label({"url": "https://example.com"}) == "example.com"
+
+
+# ---------------------------------------------------------------------------
+# _extract_source_label — source_uri 优先级
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromSourceUri:
+    def test_gcs_uri_with_filename(self) -> None:
+        assert _extract_source_label({"source_uri": "gs://bucket/app/corpus/report.pdf"}) == "report"
+
+    def test_gcs_uri_without_extension(self) -> None:
+        assert _extract_source_label({"source_uri": "gs://bucket/app/corpus/data"}) == "data"
+
+    def test_http_source_uri(self) -> None:
+        assert _extract_source_label({"source_uri": "https://docs.com/guide/install"}) == "install"
+
+    def test_generic_uri_last_segment(self) -> None:
+        assert _extract_source_label({"source_uri": "memory://some/path/doc_name"}) == "doc_name"
+
+
+# ---------------------------------------------------------------------------
+# _extract_source_label — 优先级 & 回退
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPriority:
+    def test_filename_over_url(self) -> None:
+        """filename 优先级高于 url"""
+        result = _extract_source_label({"filename": "file.pdf", "url": "https://x.com/article"})
+        assert result == "file"
+
+    def test_url_over_source_uri(self) -> None:
+        """url 优先级高于 source_uri"""
+        result = _extract_source_label({"url": "https://x.com/article", "source_uri": "gs://b/doc.pdf"})
+        assert result == "article"
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert _extract_source_label({}) == ""
+
+    def test_all_empty_fields_returns_empty(self) -> None:
+        assert _extract_source_label({"filename": "", "url": "", "source_uri": ""}) == ""


### PR DESCRIPTION
## Summary

- **后端**：新增 `_extract_source_label` / `_sanitize_label` 辅助函数，按优先级从 `filename > url > source_uri` 提取人类可读的源标签，用于生成语义化 run_id
- **后端**：修改 `create_pipeline()` 生成语义化 run_id（如 `ingest_file-report-abcd`），保留 4 位 hex 后缀保障唯一性；无标签时回退原格式
- **前端**：调整 `truncateRunId` 智能截断逻辑，优先展示 `operation + label` 部分，省略末尾 UUID 后缀
- **测试**：新增 26 个单元测试覆盖各输入模式、优先级与边缘场景

### 变更前后对比

| 变更前 | 变更后 |
|--------|--------|
| `ingest_file-a1b2c3d4` | `ingest_file-my_paper-abcd` |
| `rebuild_source-e5f6a7b8` | `rebuild_source-research_report-ef01` |
| `ingest_url-1234cdef` | `ingest_url-blog_guide-2345` |

## Test plan

- [x] 单元测试：26 个新测试用例覆盖 `_extract_source_label` / `_sanitize_label` 各路径
- [x] 既有测试：`test_pipeline_tracker` / `test_pipeline_tracker_cancel` 全部通过，无回归
- [x] Pre-commit hooks：ruff lint / format / ESLint 全部通过
- [ ] 集成验证：上传文件后检查返回 run_id 包含文件名
- [ ] UI 验证：Knowledge/Pipelines 页面确认新 Run 显示文档名称

🤖 Generated with [Claude Code](https://github.com/anthropic.com), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)