### PR TITLE
fix(wiki): 修复发布下拉框默认选中及文档条目数统计逻辑;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_hooks/useWikiPublications.ts
+++ b/apps/negentropy-ui/app/knowledge/wiki/_hooks/useWikiPublications.ts
@@ -30,7 +30,7 @@ export function useWikiPublications({ catalogId }: UseWikiPublicationsOptions) {
       const resp = await fetchWikiPublications({ catalogId });
       setPublications(resp.items);
       setSelectedId((prev) =>
-        prev && resp.items.some((p) => p.id === prev) ? prev : null,
+        prev && resp.items.some((p) => p.id === prev) ? prev : (resp.items[0]?.id ?? null),
       );
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "加载发布列表失败");

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -348,6 +348,19 @@ class WikiDao:
         return list(result.scalars().all())
 
     @staticmethod
+    async def count_document_entries(db: AsyncSession, publication_id: UUID) -> int:
+        """计算发布中 DOCUMENT 类型条目数量（排除 CONTAINER 文件夹节点）。"""
+        result = await db.execute(
+            select(func.count())
+            .select_from(WikiPublicationEntry)
+            .where(
+                WikiPublicationEntry.publication_id == publication_id,
+                WikiPublicationEntry.entry_kind == "DOCUMENT",
+            )
+        )
+        return result.scalar() or 0
+
+    @staticmethod
     async def get_entry_by_slug(
         db: AsyncSession,
         publication_id: UUID,

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -260,6 +260,10 @@ class WikiPublishingService:
         """获取发布的所有条目"""
         return await WikiDao.get_entries(db, publication_id)
 
+    async def count_document_entries(self, db: AsyncSession, publication_id: UUID) -> int:
+        """计算发布中 DOCUMENT 类型条目数量。"""
+        return await WikiDao.count_document_entries(db, publication_id)
+
     async def get_entry_content(
         self,
         db: AsyncSession,

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -223,7 +223,7 @@ async def list_wiki_publications(
         items = []
         for pub in pubs:
             resp = _WikiPubResp.model_validate(pub)
-            resp.entries_count = len(pub.entries) if pub.entries else 0
+            resp.entries_count = sum(1 for e in (pub.entries or []) if e.entry_kind == "DOCUMENT")
             items.append(resp)
 
     return _WikiPubListResp(items=items, total=total)
@@ -304,7 +304,7 @@ async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         if pub is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki publication not found")
 
-        entries = await wiki_svc.get_entries(db, pub_id)
+        doc_count = await wiki_svc.count_document_entries(db, pub_id)
         await db.commit()
 
     logger.info("api_publish_wiki", pub_id=str(pub_id), version=pub.version)
@@ -314,7 +314,7 @@ async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         status=pub.status,
         version=pub.version,
         published_at=pub.published_at,
-        entries_count=len(entries),
+        entries_count=doc_count,
         message=f"Published successfully (v{pub.version})",
         revalidation=revalidation_status,
     )
@@ -329,7 +329,7 @@ async def unpublish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         pub, revalidation_status = await wiki_svc.unpublish(db, pub_id)
         if pub is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki publication not found")
-        entries = await wiki_svc.get_entries(db, pub_id)
+        doc_count = await wiki_svc.count_document_entries(db, pub_id)
         await db.commit()
 
     return WikiPublishActionResponse(
@@ -337,7 +337,7 @@ async def unpublish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         status=pub.status,
         version=pub.version,
         published_at=pub.published_at,
-        entries_count=len(entries),
+        entries_count=doc_count,
         message="Unpublished successfully",
         revalidation=revalidation_status,
     )

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -241,7 +241,7 @@ async def get_wiki_publication(pub_id: UUID) -> _WikiPubResp:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wiki publication not found")
 
         resp = _WikiPubResp.model_validate(pub)
-        resp.entries_count = len(pub.entries) if pub.entries else 0
+        resp.entries_count = sum(1 for e in (pub.entries or []) if e.entry_kind == "DOCUMENT")
 
     return resp
 


### PR DESCRIPTION
# 背景
- Wiki 发布页面加载后下拉框显示"— 请选择—"占位符，需手动选择才能操作，体验不佳；同时文档条目数将 CONTAINER（文件夹）和 DOCUMENT（实际文档）全部计入，如 5 篇文档 + 3 个文件夹错误显示为 8 个条目。

# 核心变更
- **前端**：`useWikiPublications` hook 加载发布列表后自动选中第一个 publication，不再回退为 `null`
- **后端**：新增 `WikiDao.count_document_entries` 方法，通过 SQL COUNT 仅统计 `entry_kind == "DOCUMENT"` 的条目
- **后端**：`wiki.py` routes 层 4 处 `entries_count` 计算全部改为只统计 DOCUMENT 类型（list/get 用 Python 过滤已 eager-load 数据，publish/unpublish 用专用 count 方法替代全量加载）

# 风险与回滚
- `entry_kind` 字段已有 CHECK 约束保证取值仅为 CONTAINER/DOCUMENT，查询安全
- 回滚方式：`git revert` 单个 commit

# 验证证据
- Pre-commit hooks（ruff lint / ruff format / ESLint）全部通过
- 需浏览器实机验证：下拉框默认选中 + 条目数仅显示文档篇数

# 影响范围
- 前端：`useWikiPublications.ts`（1 行）
- 后端：`wiki_dao.py`、`wiki_service.py`、`wiki.py`（4 文件）

# Next Best Action
- 浏览器访问 `/knowledge/wiki` 确认下拉框自动选中与条目数正确

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)