### PR TITLE
feat(wiki): 启用 Google 登录功能

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
@@ -104,6 +104,7 @@ function WikiUserMenu({
   logout: () => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
+  const [imgError, setImgError] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -116,8 +117,15 @@ function WikiUserMenu({
         setOpen(false);
       }
     };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
     document.addEventListener("pointerdown", handlePointerDown);
-    return () => document.removeEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   }, [open]);
 
   return (
@@ -128,14 +136,17 @@ function WikiUserMenu({
         onClick={() => setOpen(!open)}
         title={user.name || "User"}
         aria-label="用户菜单"
+        aria-expanded={open}
+        aria-haspopup="true"
       >
-        {user.picture ? (
+        {user.picture && !imgError ? (
           <img
             src={user.picture}
             alt=""
             width={22}
             height={22}
             style={{ borderRadius: "50%" }}
+            onError={() => setImgError(true)}
           />
         ) : (
           <span className="wiki-user-avatar-initial">

--- a/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
@@ -1,33 +1,56 @@
-/**
- * Wiki Header 右侧操作区 — 用户登录 / GitHub / 设置图标组。
- *
- * Server Component，纯静态链接和图标，无客户端状态。
- */
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useWikiAuth, type WikiAuthUser } from "@/lib/auth/wiki-auth";
+
 export function WikiHeaderActions() {
+  const { status, user, login, logout } = useWikiAuth();
+
   return (
     <div className="wiki-header-actions">
-      {/* 登录/注册 */}
-      <button
-        type="button"
-        className="wiki-header-action-btn"
-        disabled
-        title="登录功能即将上线"
-        aria-label="登录"
-      >
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+      {/* Auth zone */}
+      {status === "loading" ? (
+        <span className="wiki-header-action-btn" aria-label="Loading" style={{ opacity: 0.5 }}>
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ animation: "wiki-auth-pulse 1.2s ease-in-out infinite" }}
+          >
+            <circle cx="12" cy="7" r="4" />
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+          </svg>
+        </span>
+      ) : status === "unauthenticated" ? (
+        <button
+          type="button"
+          className="wiki-header-action-btn"
+          onClick={login}
+          title="登录"
+          aria-label="登录"
         >
-          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-          <circle cx="12" cy="7" r="4" />
-        </svg>
-      </button>
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+        </button>
+      ) : user ? (
+        <WikiUserMenu user={user} logout={logout} />
+      ) : null}
 
       {/* GitHub */}
       <a
@@ -69,6 +92,95 @@ export function WikiHeaderActions() {
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
         </svg>
       </span>
+    </div>
+  );
+}
+
+function WikiUserMenu({
+  user,
+  logout,
+}: {
+  user: WikiAuthUser;
+  logout: () => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      <button
+        type="button"
+        className="wiki-header-action-btn"
+        onClick={() => setOpen(!open)}
+        title={user.name || "User"}
+        aria-label="用户菜单"
+      >
+        {user.picture ? (
+          <img
+            src={user.picture}
+            alt=""
+            width={22}
+            height={22}
+            style={{ borderRadius: "50%" }}
+          />
+        ) : (
+          <span className="wiki-user-avatar-initial">
+            {(user.name || "?").charAt(0).toUpperCase()}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="wiki-user-dropdown">
+          <div className="wiki-user-dropdown-header">
+            <p className="wiki-user-dropdown-name">
+              {user.name || "User"}
+            </p>
+            {user.email && (
+              <p className="wiki-user-dropdown-email">{user.email}</p>
+            )}
+          </div>
+          <div className="wiki-user-dropdown-divider" />
+          <button
+            type="button"
+            className="wiki-user-dropdown-logout"
+            onClick={() => {
+              void logout();
+              setOpen(false);
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+              <polyline points="16 17 21 12 16 7" />
+              <line x1="21" y1="12" x2="9" y2="12" />
+            </svg>
+            退出登录
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/negentropy-wiki/src/styles/components/header.css
+++ b/apps/negentropy-wiki/src/styles/components/header.css
@@ -239,6 +239,89 @@
   color: var(--wiki-text);
 }
 
+/* Auth: user avatar initial fallback */
+.wiki-user-avatar-initial {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--wiki-accent);
+  color: #fff;
+  font-size: 0.72em;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* Auth: user dropdown panel */
+.wiki-user-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  min-width: 200px;
+  background: var(--wiki-bg);
+  border: 1px solid var(--wiki-border);
+  border-radius: var(--wiki-radius);
+  box-shadow: var(--wiki-shadow), 0 4px 16px rgba(0, 0, 0, 0.08);
+  padding: 0.5rem 0;
+  z-index: 50;
+}
+
+.wiki-user-dropdown-header {
+  padding: 0.4rem 0.75rem;
+}
+
+.wiki-user-dropdown-name {
+  font-size: 0.88em;
+  font-weight: 600;
+  color: var(--wiki-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wiki-user-dropdown-email {
+  font-size: 0.78em;
+  color: var(--wiki-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wiki-user-dropdown-divider {
+  height: 1px;
+  background: var(--wiki-border);
+  margin: 0.35rem 0;
+}
+
+.wiki-user-dropdown-logout {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.82em;
+  border: 0;
+  background: transparent;
+  color: var(--wiki-text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.wiki-user-dropdown-logout:hover {
+  background: var(--wiki-bg-secondary);
+  color: var(--wiki-accent);
+}
+
+/* Auth: loading pulse animation */
+@keyframes wiki-auth-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
 @media (max-width: 768px) {
   .wiki-search-box {
     display: none;


### PR DESCRIPTION
## Summary

- 将 WikiHeaderActions 从 Server Component 转为 Client Component，接入 `useWikiAuth()` hook，实现三态认证 UI（loading / 未登录 / 已登录）
- 未登录时显示可点击的登录按钮，点击后触发完整的 Google OAuth 2.0 登录流程
- 已登录时显示用户头像 + 下拉菜单（用户名、邮箱、退出登录按钮）
- 新增用户下拉菜单 CSS 样式（`wiki-user-dropdown` 系列），全部复用 Wiki CSS 变量确保深色模式自动适配

## Test plan

- [x] 构建通过（`pnpm --filter negentropy-wiki build`）
- [x] 通过浏览器验证未登录状态：登录按钮可点击，跳转 Google OAuth
- [x] 通过浏览器验证 Google 登录流程：选择账号 → 授权 → 回调 → 页面显示已登录
- [x] 通过浏览器验证已登录状态：用户头像 + 下拉菜单（用户名/邮箱/退出登录）
- [x] 通过浏览器验证退出登录：点击退出 → 回到未登录状态 → 可重新登录
- [x] Pre-commit hooks 通过（next lint）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)