### PR TITLE
fix(wiki): 修复文档内容页文本注解功能无法触发的问题

### DIFF
--- a/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
@@ -30,7 +30,10 @@ export function TextSelectionHandler({ containerSelector, onAnnotate }: Props) {
     }
 
     const range = selection.getRangeAt(0);
-    const container = (range.startContainer as HTMLElement).closest?.(containerSelector) as HTMLElement | null;
+    const startElement = range.startContainer.nodeType === Node.ELEMENT_NODE
+      ? (range.startContainer as HTMLElement)
+      : range.startContainer.parentElement;
+    const container = startElement?.closest?.(containerSelector) as HTMLElement | null;
     if (!container || !container.contains(range.endContainer)) {
       setFabPosition(null);
       return;

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -697,12 +697,30 @@ async def create_entry_annotation(
         )
         await db.commit()
 
+        # 解析用户 profile（复用 wiki_dao 的 UserState 查询模式）
+        from negentropy.config import settings
+        from negentropy.models.state import UserState
+
+        user_name = None
+        user_picture = None
+        usr_result = await db.execute(
+            select(UserState).where(
+                UserState.user_id == user.user_id,
+                UserState.app_name == settings.app_name,
+            )
+        )
+        usr = usr_result.scalar_one_or_none()
+        if usr:
+            profile = (usr.state or {}).get("profile", {})
+            user_name = profile.get("name")
+            user_picture = profile.get("picture")
+
     return WikiAnnotationResponse(
         id=annotation.id,
         entry_id=annotation.entry_id,
         user_id=annotation.user_id,
-        user_name=None,
-        user_picture=None,
+        user_name=user_name,
+        user_picture=user_picture,
         body=annotation.body,
         quoted_text=annotation.quoted_text,
         anchor=annotation.anchor,

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -749,12 +749,29 @@ async def update_entry_annotation(
             )
         await db.commit()
 
+        from negentropy.config import settings
+        from negentropy.models.state import UserState
+
+        user_name = None
+        user_picture = None
+        usr_result = await db.execute(
+            select(UserState).where(
+                UserState.user_id == user.user_id,
+                UserState.app_name == settings.app_name,
+            )
+        )
+        usr = usr_result.scalar_one_or_none()
+        if usr:
+            profile = (usr.state or {}).get("profile", {})
+            user_name = profile.get("name")
+            user_picture = profile.get("picture")
+
     return WikiAnnotationResponse(
         id=annotation.id,
         entry_id=annotation.entry_id,
         user_id=annotation.user_id,
-        user_name=None,
-        user_picture=None,
+        user_name=user_name,
+        user_picture=user_picture,
         body=annotation.body,
         quoted_text=annotation.quoted_text,
         anchor=annotation.anchor,


### PR DESCRIPTION
## Summary

- **核心修复**：`TextSelectionHandler.tsx` 中 `range.startContainer` 在用户选中文本时返回 `Text` 节点，而 `Text` 节点没有 `closest()` 方法，导致 `.wiki-markdown-body` 容器查找始终失败，FAB 注解按钮永远不渲染。通过 `parentElement` 上溯到元素节点后再调用 `closest()` 修复此问题
- **次要修复**：后端 `create_entry_annotation` 路由在创建注解后查询 `UserState` 填充 `user_name` 和 `user_picture`，使新创建的注解在 Tooltip 中立即显示作者信息

## 根因分析

```tsx
// 修复前：Text 节点没有 closest() 方法，可选链静默返回 undefined
const container = (range.startContainer as HTMLElement).closest?.(containerSelector);

// 修复后：Text 节点通过 parentElement 上溯到元素节点
const startElement = range.startContainer.nodeType === Node.ELEMENT_NODE
  ? (range.startContainer as HTMLElement)
  : range.startContainer.parentElement;
const container = startElement?.closest?.(containerSelector);
```

## Test plan

- [x] 浏览器端到端验证：选中文字 → FAB 按钮出现 → 点击 FAB → 注解浮层弹出 → 提交注解 → 高亮显示 → hover Tooltip 显示内容与作者

🤖 Generated with [Claude Code](https://claude.com/claude-code)