### PR TITLE
fix(auth): 添加启动时 admin_emails 诊断日志，防止配置层覆盖导致 Admin 角色丢失 (#674)

### DIFF
--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -631,3 +631,9 @@ def apply_adk_patches():
 
     logger.info(f"ADK service factories patched successfully: {', '.join(patched_items)}")
     logger.info(f"Using configured credential backend: {settings.credential_service_backend}")
+    logger.info(
+        "Auth config resolved: enabled=%s, mode=%s, admin_emails=%s",
+        settings.auth.enabled,
+        settings.auth.mode.value,
+        settings.auth.admin_emails,
+    )


### PR DESCRIPTION
## 问题

cm.huang@aftership.com 始终无法获得 Admin 角色，此前已修复两次（#667、#660）但均未生效。

**根因**：`~/.negentropy/config.yaml`（用户级配置）中 `admin_emails` 仅包含 `threefish.ai@gmail.com`，缺失 `cm.huang@aftership.com`。由于用户级配置优先级高于 `config.default.yaml`，且 `deep_merge` 对列表执行整体替换而非合并，导致包默认配置中的正确值被覆盖丢失。

## 变更

在 `bootstrap.py` 的 `apply_adk_patches()` 启动流程末尾添加诊断日志，输出解析后的 `enabled`、`mode`、`admin_emails` 三个 Auth 关键配置字段，便于运维在服务启动时一眼发现配置层覆盖导致的管理员角色丢失问题。

## 关联

- #667 配置级 Admin 角色不可被 DB 状态自动降级
- #660 OAuth 重登录不再覆盖 DB 管理的角色

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)