### PR TITLE
fix(perceives): 修复 webpage pipeline 实现 1:1 还原 Anthropic 博客等 Next.js 站点

### DIFF
--- a/apps/negentropy-perceives/pyproject.toml
+++ b/apps/negentropy-perceives/pyproject.toml
@@ -37,6 +37,12 @@ dependencies = [
     "beautifulsoup4>=4.14.0",
     "fake-useragent>=2.2.0",
     "requests>=2.33.1",
+    # --- 网页主内容提取（S4 三引擎竞争） ---
+    "trafilatura>=2.0.0",        # 主流博客/学术文章正文定位最优（rank=1）
+    "readability-lxml>=0.8.1",   # Mozilla Readability 算法 Python 实现（rank=2 fallback）
+    "lxml-html-clean>=0.4.0",    # lxml>=5 拆分子模块；justext/readability 依赖此清洗器
+    # --- HTML → Markdown 转换（S10 二引擎竞争） ---
+    "html2text>=2025.4.15",      # markitdown 的 fallback 引擎
     # --- 浏览器自动化 ---
     "playwright>=1.58.0",
     "selenium>=4.43.0",

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -208,6 +208,12 @@ class MarkdownFormatter:
             Enhanced and cleaned up Markdown content
         """
         try:
+            # Code block language detection and structural fixes must run
+            # BEFORE protection, because they operate on actual ``` fence
+            # markers.  After protection all fences become %%CODEBLOCK_…%%
+            # placeholders and none of the regex patterns can match.
+            markdown_content = self._format_code_blocks(markdown_content)
+
             # 保护代码块内容不被格式化 pass 修改
             markdown_content, protected = self._protect_code_blocks(markdown_content)
             # 保护块级数学公式 ``$$..$$`` 不被任何排版 / 段落 / 去重 pass 修改。
@@ -232,8 +238,6 @@ class MarkdownFormatter:
             if self.options.get("format_headings", True):
                 markdown_content = self._format_headings(markdown_content)
 
-            # Code block and quote formatting always applied
-            markdown_content = self._format_code_blocks(markdown_content)
             markdown_content = self._format_quotes(markdown_content)
 
             if self.options.get("apply_typography", True):
@@ -497,7 +501,15 @@ class MarkdownFormatter:
             return markdown_content
 
     def _format_code_blocks(self, markdown_content: str) -> str:
-        """Enhance code block formatting with language detection."""
+        """Enhance code block formatting with language detection.
+
+        IMPORTANT: Must be called BEFORE ``_protect_code_blocks`` in the
+        ``format()`` pipeline.  All operations (consecutive-fence fix,
+        FORTRAN label correction, language detection, blank-line padding)
+        require actual ````` fence markers to be present in the text.
+        After protection all fences become ``%%CODEBLOCK_…%%`` placeholders
+        and none of the regex patterns here can match.
+        """
         try:
             # 修复连续的代码围栏标记：```LANG\n``` filename → ```\n filename
             markdown_content = re.sub(

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -279,10 +279,16 @@ class MarkdownFormatter:
             return markdown_content
 
     def _protect_code_blocks(self, markdown_content: str) -> Tuple[str, Dict[str, str]]:
-        """提取已标注语言的代码块并替换为占位符，防止格式化管线修改其内容。
+        """提取所有 fenced 代码块并替换为占位符，防止格式化管线修改其内容。
 
-        仅保护已有语言标签的代码块（如 ```python, ```algorithm），
-        未标注语言的代码块留给 _format_code_blocks 进行语言检测。
+        包括两类：
+        1. 带语言标签的代码块（```python, ```algorithm）— 保留原始 fence
+        2. 未标注语言的纯 fence 代码块（``` ... ```）— 同样保护其内容，
+           避免 ``_apply_typography_fixes`` 把 ``--`` 误改为 em-dash、
+           智能引号替换等典型 typography 操作破坏代码语义。
+
+        ``_format_code_blocks`` 自身处理"未标注语言的语言检测"工作，但保护
+        机制要确保在 typography 之前所有 fenced block 都成为占位符。
         """
         protected: Dict[str, str] = {}
 
@@ -291,9 +297,10 @@ class MarkdownFormatter:
             protected[placeholder] = match.group(0)
             return placeholder
 
-        # 仅匹配带语言标签的代码块（```后紧跟字母）
+        # 匹配所有 fenced 代码块：```<可选语言>\n...\n```
+        # 已标注语言 (```python) 与未标注 (```\n) 都纳入保护
         result = re.sub(
-            r"^```[a-zA-Z][^\n]*\n.*?^```\s*$",
+            r"^```[^\n]*\n.*?^```\s*$",
             _replacer,
             markdown_content,
             flags=re.MULTILINE | re.DOTALL,
@@ -414,10 +421,64 @@ class MarkdownFormatter:
             # Add proper spacing around images
             markdown_content = re.sub(r"(!\[.*?\]\(.*?\))", r"\n\1\n", markdown_content)
 
+            # Caption 去重：当 ``![alt](url)`` 紧跟一个内容与 alt 文本相同的
+            # 段落（HTML <figcaption> 经 MarkItDown 输出为独立段落），
+            # 删除该重复段落避免 UI 渲染时 figcaption 与正文段同时出现。
+            markdown_content = self._dedupe_image_caption(markdown_content)
+
             return markdown_content
         except Exception as e:
             logger.warning(f"Error formatting images: {str(e)}")
             return markdown_content
+
+    @staticmethod
+    def _dedupe_image_caption(markdown_content: str) -> str:
+        """删除紧跟在 ``![alt](url)`` 后内容与 alt 完全相同的段落。
+
+        匹配模式（按行）：
+            ![<alt>](<url>)\n\n<text>\n
+        当 ``<text>`` 去前后空格后与 ``<alt>`` 去前后空格后相同，则删除
+        ``<text>`` 行（保留图片行与其后空行）。UI 渲染时 ``DocumentImage``
+        会用 alt 作为 figcaption；若 markdown 里又写一遍同样的段落，
+        figcaption 会重复出现。
+
+        注意：仅匹配紧邻图片行的下一非空段落，并要求严格相等（去空格 +
+        casefold），避免误删与 alt 局部相似的正文段。
+        """
+        lines = markdown_content.split("\n")
+        img_re = re.compile(r"^\s*!\[(.*?)\]\(.*?\)\s*$")
+        result: List[str] = []
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            m = img_re.match(line)
+            if not m:
+                result.append(line)
+                i += 1
+                continue
+            alt = m.group(1).strip()
+            result.append(line)
+            i += 1
+            # 跳过紧随其后的空行
+            blanks_start = i
+            while i < len(lines) and lines[i].strip() == "":
+                i += 1
+            if i < len(lines) and alt:
+                next_text = lines[i].strip()
+                if next_text and next_text.casefold() == alt.casefold():
+                    # 跳过该重复段（不写入 result），同时把前置空行也只保留一个
+                    if blanks_start < len(lines):
+                        # 保留单个空行作为段落分隔
+                        result.append("")
+                    i += 1
+                    # 跳过段落后的空行（保留一个）
+                    while i < len(lines) and lines[i].strip() == "":
+                        i += 1
+                    continue
+            # 普通情况：把空行原样追加
+            for k in range(blanks_start, i):
+                result.append(lines[k])
+        return "\n".join(result)
 
     def _format_links(self, markdown_content: str) -> str:
         """Optimize link formatting."""

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/anti_detection.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/anti_detection.py
@@ -6,6 +6,9 @@
 工具降级链：
 1. ``playwright_stealth`` — Playwright 隐身模式
 2. ``undetected_chromedriver`` — undetected-chromedriver + Selenium
+
+短路语义：若 S2 已成功填充 ``ctx.raw_html``（非空），则 S3 直接 short-circuit
+返回 success(skip)，避免无谓地启动浏览器并因驱动错误终止整条管线。
 """
 
 from __future__ import annotations
@@ -19,6 +22,17 @@ from ...registry import register_tool
 from .._base import WebToolBase
 
 logger = logging.getLogger(__name__)
+
+
+# raw_html 长度低于此阈值时视为 S2 未实际拿到内容，仍需走反检测降级。
+# 主流博客最小 HTML 也在 4KB+，1KB 设为保守阈值。
+_MIN_RAW_HTML_FOR_SKIP = 1024
+
+
+def _should_skip_anti_detection(ctx: StageContext) -> bool:
+    """S2 已成功获取 raw_html 时，S3 反检测应被短路跳过。"""
+    raw_html = getattr(ctx, "raw_html", None) or ""
+    return len(raw_html) >= _MIN_RAW_HTML_FOR_SKIP
 
 
 @register_tool("playwright_stealth")
@@ -39,7 +53,22 @@ class PlaywrightStealthTool(WebToolBase):
             return False
 
     async def _run(self, ctx: StageContext) -> StageResult[StageContext]:
-        """使用 Playwright 隐身模式获取网页 HTML。"""
+        """使用 Playwright 隐身模式获取网页 HTML。
+
+        若 S2 已成功填充 raw_html，则直接 short-circuit 返回 success。
+        """
+        if _should_skip_anti_detection(ctx):
+            logger.info(
+                "S3 anti_detection 短路跳过 (S2 已获取 raw_html len=%d)",
+                len(ctx.raw_html),
+            )
+            return StageResult(
+                success=True,
+                output=ctx,
+                engine_used=f"{self.tool_name}:skipped_s2_ok",
+                metadata={"skipped": True, "reason": "s2_already_succeeded"},
+            )
+
         from ....scraping.anti_detection import AntiDetectionScraper
 
         url = ctx.url
@@ -101,7 +130,22 @@ class UndetectedChromeDriverTool(WebToolBase):
             return False
 
     async def _run(self, ctx: StageContext) -> StageResult[StageContext]:
-        """使用 undetected-chromedriver 获取网页 HTML。"""
+        """使用 undetected-chromedriver 获取网页 HTML。
+
+        若 S2 已成功填充 raw_html，则直接 short-circuit 返回 success。
+        """
+        if _should_skip_anti_detection(ctx):
+            logger.info(
+                "S3 anti_detection 短路跳过 (S2 已获取 raw_html len=%d)",
+                len(ctx.raw_html),
+            )
+            return StageResult(
+                success=True,
+                output=ctx,
+                engine_used=f"{self.tool_name}:skipped_s2_ok",
+                metadata={"skipped": True, "reason": "s2_already_succeeded"},
+            )
+
         from ....scraping.anti_detection import AntiDetectionScraper
 
         url = ctx.url

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
+from html import escape as html_escape
 from typing import Dict, Optional
 
 from ...base import StageResult
@@ -41,8 +42,7 @@ def _ensure_h1_title(html: str, title: str) -> str:
         return html
     if _H1_TAG_RE.search(html):
         return html
-    # 简单转义防止 title 含尖括号
-    safe = title.replace("<", "&lt;").replace(">", "&gt;")
+    safe = html_escape(title)
     h1_html = f"<h1>{safe}</h1>"
 
     # 优先注入到 <body> 开头

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Dict
+from typing import Dict, Optional
 
 from ...base import StageResult
 from ...models import StageContext
@@ -23,10 +23,173 @@ logger = logging.getLogger(__name__)
 
 
 _IMG_TAG_RE = re.compile(r"<img\b", re.IGNORECASE)
+_H1_TAG_RE = re.compile(r"<h1\b", re.IGNORECASE)
+_H2_TAG_RE = re.compile(r"<h2\b", re.IGNORECASE)
+_H3_TAG_RE = re.compile(r"<h3\b", re.IGNORECASE)
+
+
+def _ensure_h1_title(html: str, title: str) -> str:
+    """若 main_html 缺失 H1，则将 page title 注入为 H1 置顶。
+
+    readability 等正文提取器常把 H1（页面主标题）抽走作为 title，
+    返回的 summary 中不含 H1，这导致 Markdown 输出失去主标题。
+
+    注入位置必须在 ``<body>`` 内（若存在）；放到 ``<html>`` 之前会让
+    MarkItDown 等 HTML→MD 转换器把 H1 视为文档之外的噪声并丢弃。
+    """
+    if not html or not title:
+        return html
+    if _H1_TAG_RE.search(html):
+        return html
+    # 简单转义防止 title 含尖括号
+    safe = title.replace("<", "&lt;").replace(">", "&gt;")
+    h1_html = f"<h1>{safe}</h1>"
+
+    # 优先注入到 <body> 开头
+    body_match = re.search(r"<body\b[^>]*>", html, re.IGNORECASE)
+    if body_match:
+        idx = body_match.end()
+        return html[:idx] + "\n" + h1_html + html[idx:]
+
+    # 没有 <body> 时注入到 <html> 内的开头
+    html_match = re.search(r"<html\b[^>]*>", html, re.IGNORECASE)
+    if html_match:
+        idx = html_match.end()
+        return html[:idx] + "\n" + h1_html + html[idx:]
+
+    # 都没有：作为纯片段，放在最前面（后续会被 markitdown 包到 body 内）
+    return f"{h1_html}\n{html}"
+
 
 # 触发“图片丢失”兜底的阈值：原始 HTML 至少有这么多 <img>，
 # 但主内容区的 <img> 为 0 时，视为 trafilatura 提取失败。
-_MIN_RAW_IMAGES_FOR_LOSS_GUARD = 3
+# 调低到 1：哪怕原文仅有 1 张正文图片，trafilatura 丢失也应触发兜底
+# （Anthropic 等 Next.js Image 代理站点上 trafilatura 常完全丢弃 <img>）。
+_MIN_RAW_IMAGES_FOR_LOSS_GUARD = 1
+
+# 触发“结构退化”兜底的阈值：原始 HTML 含足够多的 H2/H3，但 trafilatura
+# 输出的 H2+H3 总数 ≤ 1 时，视为正文结构被严重压平。
+# trafilatura 对部分静态生成站点（Next.js 等）会丢失多数 heading；
+# 让 readability/bs_heuristic 兜底通常输出质量更好。
+_MIN_RAW_HEADINGS_FOR_LOSS_GUARD = 3
+_MAX_MAIN_HEADINGS_FOR_LOSS_GUARD = 1
+
+
+def _inject_after_h1(html: str, fragment: str) -> str:
+    """把 ``fragment`` 注入到 ``html`` 中第一个 ``</h1>`` 之后。
+
+    若 ``html`` 中找不到 H1，则注入到 ``<body>`` 开头；都没有时直接前置。
+    """
+    if not html or not fragment:
+        return html
+    h1_close = re.search(r"</h1>", html, re.IGNORECASE)
+    if h1_close:
+        idx = h1_close.end()
+        return html[:idx] + "\n" + fragment + html[idx:]
+    body_match = re.search(r"<body\b[^>]*>", html, re.IGNORECASE)
+    if body_match:
+        idx = body_match.end()
+        return html[:idx] + "\n" + fragment + html[idx:]
+    return f"{fragment}\n{html}"
+
+
+def _extract_hero_metadata(raw_html: str) -> Optional[str]:
+    """从原始 HTML 中提取 hero/header 区域的元数据段（lead + 发布日期）。
+
+    现代 blog/news 站点（Anthropic / Next.js 站点）常把文章 lead 段与
+    发布日期放在 ``<section>`` / ``hero`` / ``metadata`` 容器中，
+    与正文 body 分离。readability/trafilatura 把这些视为 page chrome
+    并排除掉，导致 Markdown 输出失去文章简介与发布日期。
+
+    本函数用启发式规则识别这类 hero 容器：
+      1. 优先匹配 class/data-attr 含 ``hero``/``metadata``/``summary``
+         /``lead``/``date``/``published`` 关键字的容器；
+      2. 提取容器内的 ``<p>`` 段落（保留发布日期 + lead）；
+      3. 限制片段长度防误抓整页。
+
+    返回带 ``<p>`` 包裹的 HTML 片段，或 None。
+    """
+    if not raw_html:
+        return None
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(raw_html, "html.parser")
+        # 启发式：找出 class/data 含相关关键字的容器
+        hero_keywords = re.compile(
+            r"hero|metadata|summary|lead|published|article-(?:header|meta)",
+            re.IGNORECASE,
+        )
+
+        def _is_hero_container(tag) -> bool:
+            if tag.name not in ("section", "header", "div"):
+                return False
+            class_attr = " ".join(tag.get("class", []) or [])
+            data_component = tag.get("data-component", "") or ""
+            id_attr = tag.get("id", "") or ""
+            return bool(
+                hero_keywords.search(class_attr)
+                or hero_keywords.search(data_component)
+                or hero_keywords.search(id_attr)
+            )
+
+        candidates = soup.find_all(_is_hero_container)
+        if not candidates:
+            return None
+
+        # 选择含 <p> 且文本长度合理（避免大容器误抓正文）的最浅候选
+        for c in candidates:
+            ps = c.find_all("p", recursive=True)
+            if not ps:
+                continue
+            total_text = "\n".join(
+                p.get_text(strip=True) for p in ps if p.get_text(strip=True)
+            )
+            if not total_text or len(total_text) > 1500:
+                # 太长说明抓到了整篇正文，跳过
+                continue
+            # 把 <p> 序列拼成 HTML 片段
+            fragments = []
+            for p in ps:
+                txt = p.get_text(strip=True)
+                if txt:
+                    # 用 inner_html 保留 inline 元素（链接、强调等）
+                    fragments.append(f"<p>{p.decode_contents()}</p>")
+            if fragments:
+                return "\n".join(fragments)
+        return None
+    except Exception:
+        logger.debug("hero metadata 提取失败", exc_info=True)
+        return None
+
+
+def _normalize_redirect_urls(html: str) -> str:
+    """规范化形如 ``<host>/redirect/<tracking-id>`` 的 anchor href。
+
+    某些站点（如 Anthropic 自家 blog）把外链经过自己的 redirect 服务
+    包装为形如 ``http(s)://<domain>/redirect/<tracking-id>`` 的 URL，
+    导致 anchor href 失去真实目标可读性，且 anchor 文本与 href 域名
+    语义错位。本函数：当 anchor 文本看起来像一个域名时，把 href 替换
+    为 ``https://<anchor-text>/``。其余 anchor 原样保留。"""
+    if not html or "/redirect/" not in html:
+        return html
+
+    anchor_re = re.compile(
+        r'<a(?P<attrs1>[^>]*)\shref="(?P<href>https?://[^"/]+/redirect/[^"]*)"(?P<attrs2>[^>]*)>(?P<text>[^<]*?)</a>',
+        re.IGNORECASE,
+    )
+
+    def _sub(m: re.Match) -> str:
+        text = m.group("text").strip()
+        if re.fullmatch(r"[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}", text):
+            return f'<a{m.group("attrs1")} href="https://{text}/"{m.group("attrs2")}>{m.group("text")}</a>'
+        return m.group(0)
+
+    try:
+        return anchor_re.sub(_sub, html)
+    except Exception:
+        logger.debug("redirect URL 规范化失败", exc_info=True)
+        return html
 
 
 def _rehydrate_trafilatura_graphics(html: str) -> str:
@@ -109,7 +272,7 @@ class TrafilaturaTool(WebToolBase):
             # 在此还原为标准 <img>，让下游 S5/S9/S10 能正常识别图片。
             main_html = _rehydrate_trafilatura_graphics(main_html)
 
-            # 图片丢失兜底：若原始 HTML 中存在多张图片但 trafilatura
+            # 图片丢失兜底：若原始 HTML 中存在图片但 trafilatura
             # 输出为 0，说明本页结构使 trafilatura 整体丢弃了图片
             # （常见于 Next.js 图像代理 / 复杂 figure 嵌套）。此时主动
             # 标记失败，交由 S4 竞争模式降级到 readability 或启发式兜底。
@@ -128,6 +291,41 @@ class TrafilaturaTool(WebToolBase):
                     ),
                     engine_used=self.tool_name,
                 )
+
+            # 结构退化兜底：若原始 HTML 含足够多的 H2/H3 但 trafilatura
+            # 输出的 H2+H3 ≤ 1，说明正文结构被严重压平。此时主动失败，
+            # 让 readability / bs_heuristic 接管以保留章节层级。
+            raw_heading_count = len(_H2_TAG_RE.findall(raw_html)) + len(
+                _H3_TAG_RE.findall(raw_html)
+            )
+            main_heading_count = len(_H2_TAG_RE.findall(main_html)) + len(
+                _H3_TAG_RE.findall(main_html)
+            )
+            if (
+                raw_heading_count >= _MIN_RAW_HEADINGS_FOR_LOSS_GUARD
+                and main_heading_count <= _MAX_MAIN_HEADINGS_FOR_LOSS_GUARD
+            ):
+                logger.warning(
+                    "trafilatura 压平了文档结构 (raw_h2+h3=%d, main_h2+h3=%d)，触发结构退化兜底",
+                    raw_heading_count,
+                    main_heading_count,
+                )
+                return StageResult(
+                    success=False,
+                    error=(
+                        f"trafilatura 压平了文档结构 (raw_html 含 {raw_heading_count} "
+                        f"个 H2/H3，但输出仅剩 {main_heading_count} 个)，触发兜底"
+                    ),
+                    engine_used=self.tool_name,
+                )
+
+            # H1 注入：trafilatura 通常会把 H1 当 title 抽走，
+            # main_html 内不含 H1。把 ctx.title 注入为 H1 置顶，
+            # 让下游 Markdown 输出保留主标题。
+            main_html = _ensure_h1_title(main_html, ctx.title or "")
+
+            # 规范化站内跟踪 redirect URL
+            main_html = _normalize_redirect_urls(main_html)
 
             ctx.metadata["main_content_html"] = main_html
 
@@ -199,10 +397,25 @@ class ReadabilityTool(WebToolBase):
                     engine_used=self.tool_name,
                 )
 
-            ctx.metadata["main_content_html"] = main_html
             # readability 的标题提取通常更精确
             if short_title and not ctx.title:
                 ctx.title = short_title
+
+            # H1 注入：readability 把 H1 当 title 抽走，
+            # summary 内不含 H1。把 ctx.title 注入为 H1 置顶。
+            main_html = _ensure_h1_title(main_html, ctx.title or short_title or "")
+
+            # Hero 元数据注入：readability 把 lead 段 / 发布日期
+            # 视为 page chrome 排除掉。从 raw_html 启发式提取并
+            # 紧随 H1 注入到 body 开头，避免文章简介与日期丢失。
+            hero_html = _extract_hero_metadata(raw_html)
+            if hero_html:
+                main_html = _inject_after_h1(main_html, hero_html)
+
+            # 规范化站内跟踪 redirect URL（anchor 文本是域名时）
+            main_html = _normalize_redirect_urls(main_html)
+
+            ctx.metadata["main_content_html"] = main_html
 
             return StageResult(
                 success=True,
@@ -257,6 +470,14 @@ class BeautifulSoupHeuristicTool(WebToolBase):
                     error="BeautifulSoup 启发式未提取到有效主内容",
                     engine_used=self.tool_name,
                 )
+
+            # H1 注入：bs_heuristic 通常会保留 H1，但某些主题把标题
+            # 渲染为带特殊 class 的 div / 多 H2 并列结构，导致 H1 缺失。
+            # 兜底注入避免下游 Markdown 失去主标题。
+            main_html = _ensure_h1_title(main_html, ctx.title or "")
+
+            # 规范化站内跟踪 redirect URL
+            main_html = _normalize_redirect_urls(main_html)
 
             ctx.metadata["main_content_html"] = main_html
 

--- a/apps/negentropy-perceives/uv.lock
+++ b/apps/negentropy-perceives/uv.lock
@@ -238,6 +238,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +515,20 @@ wheels = [
 ]
 
 [[package]]
+name = "courlan"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/54/6d6ceeff4bed42e7a10d6064d35ee43a810e7b3e8beb4abeae8cff4713ae/courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190", size = 206382, upload-time = "2024-10-29T16:40:20.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/ca/6a667ccbe649856dcd3458bab80b016681b274399d6211187c6ab969fc50/courlan-1.3.2-py3-none-any.whl", hash = "sha256:d0dab52cf5b5b1000ee2839fbc2837e93b2514d3cb5bb61ae158a55b7a04c6be", size = 33848, upload-time = "2024-10-29T16:40:18.325Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.13.5"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +607,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/2e/cdfd8b01c37cbf4f9482eefd455853a3cf9c995029a46acd31dfaa9c1dd6/cssselect-1.4.0.tar.gz", hash = "sha256:fdaf0a1425e17dfe8c5cf66191d211b357cf7872ae8afc4c6762ddd8ac47fc92", size = 40589, upload-time = "2026-01-29T07:00:26.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/0c/7bb51e3acfafd16c48875bf3db03607674df16f5b6ef8d056586af7e2b8b/cssselect-1.4.0-py3-none-any.whl", hash = "sha256:c0ec5c0191c8ee39fcc8afc1540331d8b55b0183478c50e9c8a79d44dbceb1d8", size = 18540, upload-time = "2026-01-29T07:00:24.994Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -657,6 +689,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/34/14cd8e76f907f7d4dca2334cfeec9f81d30fd15c25a015f99aaea694eaed/datasets-4.8.5.tar.gz", hash = "sha256:0f0c1c3d56ffff2c93b2f4c63c95bac94f3d7e8621aea2a2a576275233bba772", size = 605649, upload-time = "2026-04-27T15:43:57.384Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/99/00f3196036501b53032c4b1ab8337a0b978dee832ed276dae3815df4e8b5/datasets-4.8.5-py3-none-any.whl", hash = "sha256:5079900781719c0e063a8efdd2cd95a31ad0c63209178669cd23cf1b926149ff", size = 528973, upload-time = "2026-04-27T15:43:53.702Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -1218,6 +1265,31 @@ wheels = [
 ]
 
 [[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/10/ead9dabc999f353c3aa5d0dc0835b1e355215a5ecb489a7f4ef2ddad5e33/htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0", size = 44690, upload-time = "2025-11-04T17:46:44.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/adfcdaaad5805c0c5156aeefd64c1e868c05e9c1cd6fd21751f168cd88c7/htmldate-1.9.4-py3-none-any.whl", hash = "sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c", size = 31558, upload-time = "2025-11-04T17:46:43.258Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1531,6 +1603,18 @@ wheels = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
 name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1661,6 +1745,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
     { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
     { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/bd/6e2b76a6c5dee10397db9c929f0c5066766ec1036046f0335b7ca7ca08b8/lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746", size = 14573, upload-time = "2026-05-20T12:17:52.215Z" },
 ]
 
 [[package]]
@@ -2160,7 +2256,9 @@ dependencies = [
     { name = "docling" },
     { name = "fake-useragent" },
     { name = "fastmcp" },
+    { name = "html2text" },
     { name = "litellm" },
+    { name = "lxml-html-clean" },
     { name = "marker-pdf" },
     { name = "markitdown" },
     { name = "mineru" },
@@ -2173,10 +2271,12 @@ dependencies = [
     { name = "pymupdf" },
     { name = "pypdf" },
     { name = "pyyaml" },
+    { name = "readability-lxml" },
     { name = "requests" },
     { name = "rich" },
     { name = "selenium" },
     { name = "setuptools" },
+    { name = "trafilatura" },
     { name = "typer" },
     { name = "undetected-chromedriver" },
 ]
@@ -2210,7 +2310,9 @@ requires-dist = [
     { name = "docling", specifier = ">=2.89.0" },
     { name = "fake-useragent", specifier = ">=2.2.0" },
     { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "html2text", specifier = ">=2025.4.15" },
     { name = "litellm", specifier = ">=1.83.7" },
+    { name = "lxml-html-clean", specifier = ">=0.4.0" },
     { name = "marker-pdf", specifier = ">=1.10.2" },
     { name = "markitdown", specifier = ">=0.1.5" },
     { name = "mineru", specifier = ">=3.0.9" },
@@ -2223,10 +2325,12 @@ requires-dist = [
     { name = "pymupdf", specifier = ">=1.27.2" },
     { name = "pypdf", specifier = ">=6.10.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "readability-lxml", specifier = ">=0.8.1" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "selenium", specifier = ">=4.43.0" },
     { name = "setuptools", specifier = ">=82.0.1" },
+    { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.21.2" },
     { name = "undetected-chromedriver", specifier = ">=3.5.5" },
 ]
@@ -3573,6 +3677,20 @@ wheels = [
 ]
 
 [[package]]
+name = "readability-lxml"
+version = "0.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "cssselect" },
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/3e/dc87d97532ddad58af786ec89c7036182e352574c1cba37bf2bf783d2b15/readability_lxml-0.8.4.1.tar.gz", hash = "sha256:9d2924f5942dd7f37fb4da353263b22a3e877ccf922d0e45e348e4177b035a53", size = 22874, upload-time = "2025-05-03T21:11:45.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/75/2cc58965097e351415af420be81c4665cf80da52a17ef43c01ffbe2caf91/readability_lxml-0.8.4.1-py3-none-any.whl", hash = "sha256:874c0cea22c3bf2b78c7f8df831bfaad3c0a89b7301d45a188db581652b4b465", size = 19912, upload-time = "2025-05-03T21:11:43.993Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4212,6 +4330,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4338,6 +4465,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/b6/097367f180b6383a3581ca1b86fcae284e52075fa941d1232df35293363c/trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d", size = 132557, upload-time = "2024-12-03T15:23:21.41Z" },
 ]
 
 [[package]]
@@ -4542,6 +4687,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：用 `parse_webpage_to_markdown` 还原 Anthropic Engineering blog 等 Next.js 静态生成站点时，输出 Markdown 严重失真——段落被压平、heading 全部丢失、图片/表格/代码块缺失、纳入了导航/页脚噪声等。
- 关联上下文：基线案例 https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents ，沉淀范式与 [pdf-to-markdown 12 维质量矩阵](https://github.com/ThreeFish-AI/) 一致。

# 核心变更

- **build(perceives)**：补全 webpage pipeline 必要依赖
  - 新增 `trafilatura`、`readability-lxml`、`html2text`、`lxml-html-clean`。S4 三引擎竞争与 S10 二引擎竞争所需依赖此前缺失，运行时强制降级，正文质量退化。
- **fix(S3) anti_detection 短路**
  - 配置注释说"仅在 S2 失败时触发"，但 orchestrator 实际无条件按顺序执行 sequential stage，S2 成功后 S3 仍尝试启动 playwright_stealth / undetected_chromedriver，遇驱动错误直接终止整条管线。`ctx.raw_html` 已存在（≥1KB）时短路返回 success(skip)。
- **fix(S4) main_content_extraction 多处加固**
  - `_ensure_h1_title`：readability/trafilatura 把 H1 当 title 抽走，summary 不含 H1；注入 `<h1>` 时必须放在 `<body>` 内，否则 MarkItDown 把 `<html>` 之外的内容视为噪声丢弃。
  - `_extract_hero_metadata`：从 raw_html 启发式识别含 `hero`/`metadata`/`summary`/`lead`/`published` 关键字的容器，提取 `<p>` 序列（发布日期 + lead 简介）注入到 H1 之后。
  - `_normalize_redirect_urls`：把形如 `<host>/redirect/<tracking-id>` 且 anchor 文本是域名的链接规范化为 `https://<anchor-text>/`。
  - trafilatura 兜底阈值收紧：图片丢失阈值 3→1；新增"结构退化"兜底——原文 H2+H3 ≥ 3 但 trafilatura 输出 ≤ 1 时主动失败让位。
- **fix(S11) markdown_formatting 两处修复**
  - `_protect_code_blocks` 扩展：将未标注语言的纯 fence 也纳入保护，避免 typography pass 把代码内 `--oneline` 类参数误转为 em-dash。
  - `_dedupe_image_caption`：`![alt](url)` 紧跟内容与 alt 完全相同的段落（HTML `<figcaption>` 经 MarkItDown 输出为独立段落）时去重，避免 UI 渲染 figcaption 与正文段同时出现。

# 风险与回滚

- 主要风险：
  - trafilatura 兜底阈值变严可能在某些以前刚好通过的页面上让位给 readability/bs_heuristic。两个 fallback 引擎在多数主流博客/新闻页输出质量并不更差，回归测试也无退化，风险可控。
  - hero metadata 启发式匹配 5 个关键字，极少数页面的非主文段可能被误抓。已加 `total_text > 1500` 长度上限避免抓到整页。
- 回滚方式：单 commit revert `cd0792b2`（代码修复）与 `990a8757`（依赖补全）即可全量回滚。

# 验证证据

- 单元测试：`apps/negentropy-perceives` 内 webpage / main_content / formatter / anti_detection 相关 112 个单元测试全部通过，无既有用例退化。
- E2E：基线 URL 端到端跑完整 12-stage pipeline，Knowledge Base Ingest URL → Documents 页 Markdown 渲染逐项核对 12 维质量矩阵：H1/H2/H3/段落顺序/段间距/代码块/表格 5×3/高清原图 1920×1080/figcaption 单实例/13 个链接/0 redirect URL/发布日期 + lead 全部 ✅。

# 影响范围

- 前端：无变更（既有 `DocumentMarkdownRenderer` 渲染逻辑可直接复用）。
- 后端：`negentropy-perceives` 内 S3/S4/S11 三处 stage 实现 + pyproject 依赖；不影响 `negentropy` engine。
- GitHub Actions / 文档：无。

# Next Best Action

- 跑一遍主流博客/新闻站点的 unseen sample（如 Stripe blog、Vercel blog）验证 hero metadata 提取与 trafilatura 兜底阈值在不同站点结构下的鲁棒性，沉淀更多边界案例到 webpage pipeline 集成测试集。

🤖 Generated with [Claude Code](https://claude.com/claude-code)