### PR TITLE
fix(wiki): 修复 Agent 对话框 user_id mismatch 及 session 未创建问题

### DIFF
--- a/apps/negentropy-wiki/src/app/layout.tsx
+++ b/apps/negentropy-wiki/src/app/layout.tsx
@@ -43,14 +43,16 @@ export default function RootLayout({
           跳到主要内容
         </a>
         <div id="wiki-root">
-          <WikiAuthProvider>{children}</WikiAuthProvider>
+          <WikiAuthProvider>
+            {children}
+            {/*
+              Agents at Wiki —— 一主五翼 6 Agents 的右下角悬浮聊天框。
+              通过 next/dynamic({ ssr:false }) 异步装载，不阻塞 SSG/ISR 首屏；
+              必须置于 WikiAuthProvider 内部，以便 ChatDrawer 读取 userId。
+            */}
+            <AgentChatMount />
+          </WikiAuthProvider>
         </div>
-        {/*
-          Agents at Wiki —— 一主五翼 6 Agents 的右下角悬浮聊天框。
-          通过 next/dynamic({ ssr:false }) 异步装载，不阻塞 SSG/ISR 首屏；
-          完整设计见 .claude/plans/system-instruction-you-are-working-hidden-knuth.md
-        */}
-        <AgentChatMount />
       </body>
     </html>
   );

--- a/apps/negentropy-wiki/src/components/agent-chat/ChatDrawer.tsx
+++ b/apps/negentropy-wiki/src/components/agent-chat/ChatDrawer.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { useChatAgent } from "@/lib/agent-chat/use-chat-agent";
 import { useSubAgents } from "@/lib/agent-chat/use-subagents";
 import { useWikiPageContext } from "@/lib/agent-chat/page-context";
+import { useWikiAuth } from "@/lib/auth/wiki-auth";
 import { ChatComposer } from "./ChatComposer";
 import { ChatMessageView } from "./ChatMessage";
 
@@ -21,6 +22,7 @@ interface ChatDrawerProps {
 export function ChatDrawer({ open, onClose }: ChatDrawerProps) {
   const pageContext = useWikiPageContext();
   const { rootAgent, faculties, error: subAgentError } = useSubAgents();
+  const { user } = useWikiAuth();
   const [preferredAgentName, setPreferredAgentName] = useState<string | null>(
     null,
   );
@@ -28,6 +30,7 @@ export function ChatDrawer({ open, onClose }: ChatDrawerProps) {
     defaultAgentName: rootAgent?.name ?? null,
     preferredAgentName,
     pageContext,
+    userId: user?.userId ?? null,
   });
 
   const dialogRef = useRef<HTMLDivElement | null>(null);

--- a/apps/negentropy-wiki/src/lib/agent-chat/use-chat-agent.ts
+++ b/apps/negentropy-wiki/src/lib/agent-chat/use-chat-agent.ts
@@ -43,6 +43,8 @@ export interface UseChatAgentOptions {
   preferredAgentName: string | null;
   /** 当前 wiki 页面上下文，注入到 forwardedProps.wiki_context。 */
   pageContext: WikiPageContext;
+  /** 当前认证用户的 user_id，透传给 BFF 避免 user_id mismatch。 */
+  userId: string | null;
 }
 
 function safeUuid(): string {
@@ -68,6 +70,44 @@ function loadThreadId(): string {
     // ignore
   }
   return next;
+}
+
+const SESSION_CREATED_KEY = "wiki:agent-chat:session-created";
+
+/** 调用 BFF 创建后端 ADK session，返回后端分配的 session ID。 */
+async function ensureBackendSession(
+  userId: string,
+  clientThreadId: string,
+): Promise<string> {
+  // 同一 threadId 只创建一次，避免刷新后重复创建
+  try {
+    const created = window.sessionStorage.getItem(SESSION_CREATED_KEY);
+    if (created === clientThreadId) return clientThreadId;
+  } catch {
+    // ignore
+  }
+
+  const res = await fetch("/api/agui/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      app_name: "negentropy",
+      user_id: userId,
+      session_id: clientThreadId,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text().catch(() => "unknown");
+    throw new Error(`Failed to create session: ${err}`);
+  }
+
+  try {
+    window.sessionStorage.setItem(SESSION_CREATED_KEY, clientThreadId);
+  } catch {
+    // ignore
+  }
+  return clientThreadId;
 }
 
 export interface UseChatAgentResult {
@@ -145,29 +185,25 @@ export function useChatAgent(options: UseChatAgentOptions): UseChatAgentResult {
         "wiki:agent-chat:thread-id",
         threadIdRef.current,
       );
+      window.sessionStorage.removeItem(SESSION_CREATED_KEY);
     } catch {
       // ignore
     }
   }, [abort]);
 
-  // ---- 发送 ----
-  const send = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed) return;
-      setError(null);
-
+  // ---- 实际发送逻辑（由 send 调用） ----
+  const doSend = useCallback(
+    (text: string, threadId: string, userId: string | null) => {
       const userMsgId = safeUuid();
       const assistantMsgId = safeUuid();
       const runId = safeUuid();
-      const threadId = threadIdRef.current;
       const effectiveAgent =
         options.preferredAgentName ?? options.defaultAgentName ?? null;
 
       const userMsg: ChatMessage = {
         id: userMsgId,
         role: "user",
-        content: trimmed,
+        content: text,
         streaming: false,
         createdAt: Date.now(),
       };
@@ -191,7 +227,7 @@ export function useChatAgent(options: UseChatAgentOptions): UseChatAgentResult {
       setMessages((prev) => [...prev, userMsg, assistantMsg]);
       setStatus("streaming");
 
-      const url = `/api/agui?session_id=${encodeURIComponent(threadId)}`;
+      const url = `/api/agui?session_id=${encodeURIComponent(threadId)}${userId ? `&user_id=${encodeURIComponent(userId)}` : ""}`;
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
 
@@ -266,6 +302,37 @@ export function useChatAgent(options: UseChatAgentOptions): UseChatAgentResult {
         });
     },
     [messages, options.defaultAgentName, options.preferredAgentName, options.pageContext, flushPending],
+  );
+
+  // ---- 发送（先确保后端 session 已创建） ----
+  const send = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      setError(null);
+
+      const userId = options.userId;
+      const threadId = threadIdRef.current;
+
+      // 异步创建后端 session（首次），成功后再发送消息
+      const ensureAndSend = async () => {
+        try {
+          if (userId) {
+            await ensureBackendSession(userId, threadId);
+          }
+        } catch (err) {
+          setError(
+            err instanceof Error ? err.message : String(err),
+          );
+          setStatus("error");
+          return;
+        }
+        doSend(trimmed, threadId, userId);
+      };
+
+      void ensureAndSend();
+    },
+    [options.userId, doSend],
   );
 
   /** 单事件分发到 messages 状态。 */


### PR DESCRIPTION
## Summary

- **根因**：Wiki Agent 对话框输入 "Hi" 后返回 `{"error":{"code":"AGUI_UPSTREAM_ERROR","message":"{\"error\":\"user_id mismatch\"}"}}`
- Wiki 的 `useChatAgent` 未传递 `user_id`，BFF 默认为 `"ui"`，Python auth middleware 比对真实用户 ID 不匹配返回 403
- 同时发现 Wiki 缺少后端 ADK session 创建步骤，导致 `Session not found` 错误

## Changes

- **`ChatDrawer.tsx`**：从 `useWikiAuth()` 获取 `userId` 并透传至 `useChatAgent`
- **`layout.tsx`**：将 `AgentChatMount` 移入 `WikiAuthProvider` 内部，确保 ChatDrawer 能访问认证上下文
- **`use-chat-agent.ts`**：
  - `UseChatAgentOptions` 新增 `userId` 字段，构造 URL 时携带 `user_id` 参数
  - 新增 `ensureBackendSession()` 在首次发送前调用 `POST /api/agui/sessions` 创建 ADK session
  - session 创建结果缓存至 `sessionStorage`，避免刷新后重复创建

## Test plan

- [x] 浏览器实机验证：已登录状态下输入 "Hi"，Agent 正常流式回复
- [x] 连续对话验证：第二条消息同样获得完整回复
- [x] 页面刷新后对话上下文保持（sessionStorage 持久化）
- [x] pre-commit hooks 通过（ESLint / next lint）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)