### PR TITLE
fix(knowledge-graph): 修复 Wiki 知识图谱同步失败，补齐 Mention document_id 关联; 全宽布局与深色主题适配;

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -5,10 +5,8 @@ import { WikiForceGraphCanvas } from "@/components/WikiForceGraphCanvas";
 import { WikiGraphCanvas } from "@/components/WikiGraphCanvas";
 import { WikiHeader } from "@/components/WikiHeader";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
-import { WikiSidebar } from "@/components/WikiSidebar";
 import {
   countLeafEntries,
-  findIndexEntry,
   resolveSectionView,
   wikiApi,
   type WikiNavTreeItem,
@@ -27,8 +25,8 @@ import type { WikiGraphResponse } from "@/lib/wiki-graph-types";
  *   - 客户端组件 `WikiGraphCanvas` 自带 ``"use client"``，Sigma WebGL bundle
  *     会被 Next.js 自动拆分进本路由的客户端 chunk，SSR 阶段不引入。
  *
- * 与文档详情页对齐：复用 `WikiLayoutShell` 三栏壳（无 TOC）+ `WikiHeader`
- * tabs（带"知识图谱"入口，并标记为 active）+ `WikiSidebar` 导航子树。
+ * 图谱页使用全宽布局（variant="home"），无 sidebar / TOC，canvas 占满
+ * viewport 宽度以最大化图谱可视化空间。
  */
 
 export const revalidate = 300;
@@ -76,19 +74,8 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
     );
   }
 
-  const indexEntry = findIndexEntry(navItems);
   const entriesTotal = countLeafEntries(navItems);
   const sectionView = resolveSectionView(navItems);
-
-  const sidebar = (
-    <WikiSidebar
-      pubSlug={pubSlug}
-      publication={publication}
-      sidebarItems={sectionView.sidebarItems}
-      hasActiveItem={!!sectionView.activeItem}
-      indexEntry={indexEntry}
-    />
-  );
 
   const header = sectionView.headerItems.length > 0 && (
     <WikiHeader
@@ -101,31 +88,38 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
   );
 
   return (
-    <WikiLayoutShell sidebar={sidebar} hasToc={false} header={header || undefined}>
-      <header className="wiki-doc-header">
-        <h1 className="wiki-doc-title">知识图谱 · {publication.name}</h1>
-        <div className="wiki-doc-meta">
-          版本 v{publication.version}
-          {graph && graph.nodes.length > 0 && (
-            <>
-              {" · "}
-              {graph.nodes.length} 节点 · {graph.edges.length} 边
-              {graph.truncated && graph.total_entities > graph.nodes.length && (
-                <>
-                  {" · "}共 {graph.total_entities} 实体
-                </>
-              )}
-            </>
-          )}
-        </div>
-      </header>
+    <WikiLayoutShell
+      sidebar={<></>}
+      hasToc={false}
+      header={header || undefined}
+      variant="home"
+    >
+      <div className="wiki-graph-page">
+        <header className="wiki-graph-page-header">
+          <h1 className="wiki-doc-title">知识图谱 · {publication.name}</h1>
+          <div className="wiki-doc-meta">
+            版本 v{publication.version}
+            {graph && graph.nodes.length > 0 && (
+              <>
+                {" · "}
+                {graph.nodes.length} 节点 · {graph.edges.length} 边
+                {graph.truncated && graph.total_entities > graph.nodes.length && (
+                  <>
+                    {" · "}共 {graph.total_entities} 实体
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        </header>
 
-      <WikiGraphBody
-        pubSlug={pubSlug}
-        publication={publication}
-        graph={graph}
-        graphError={graphError}
-      />
+        <WikiGraphBody
+          pubSlug={pubSlug}
+          publication={publication}
+          graph={graph}
+          graphError={graphError}
+        />
+      </div>
     </WikiLayoutShell>
   );
 }

--- a/apps/negentropy-wiki/src/components/WikiForceGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiForceGraphCanvas.tsx
@@ -96,6 +96,7 @@ interface FGLink {
 function toForceGraphData(
   nodes: WikiGraphNode[],
   edges: WikiGraphEdge[],
+  isDark: boolean,
 ): { nodes: FGNode[]; links: FGLink[] } {
   const validIds = new Set(nodes.map((n) => n.id));
   return {
@@ -113,7 +114,7 @@ function toForceGraphData(
         source: e.source,
         target: e.target,
         label: e.label ?? e.type ?? "",
-        color: "#52525b",
+        color: isDark ? "rgba(255,255,255,0.12)" : "#52525b",
       })),
   };
 }
@@ -193,7 +194,18 @@ export function WikiForceGraphCanvas({
     [entrySlugMap, pubSlug, router],
   );
 
-  const graphData = useMemo(() => toForceGraphData(nodes, edges), [nodes, edges]);
+  const isDark = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    const rootEl = document.documentElement;
+    const colorScheme = rootEl.getAttribute("data-color-scheme");
+    return (
+      colorScheme === "dark" ||
+      (!colorScheme &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches)
+    );
+  }, []);
+
+  const graphData = useMemo(() => toForceGraphData(nodes, edges, isDark), [nodes, edges, isDark]);
 
   // 自定义节点渲染：圆形 + 标签（缩小时隐藏）
   const nodeCanvasObject = useCallback(
@@ -209,12 +221,12 @@ export function WikiForceGraphCanvas({
       if (globalScale > 0.3) {
         const fontSize = Math.max(12 / globalScale, 3.5);
         ctx.font = `${fontSize}px system-ui, sans-serif`;
-        ctx.fillStyle = "#d4d4d8";
+        ctx.fillStyle = isDark ? "#e3e3e3" : "#1c1e21";
         ctx.textAlign = "center";
         ctx.fillText(node.name, node.x!, node.y! + size + fontSize + 1);
       }
     },
-    [],
+    [isDark],
   );
 
   const nodePointerAreaPaint = useCallback(
@@ -248,7 +260,7 @@ export function WikiForceGraphCanvas({
             linkWidth={1}
             linkDirectionalArrowLength={4}
             linkDirectionalArrowRelPos={0.8}
-            linkDirectionalArrowColor="#71717a"
+            linkDirectionalArrowColor={isDark ? "rgba(255,255,255,0.25)" : "#71717a"}
             onNodeClick={handleNodeClick}
             enableNodeDrag={true}
             cooldownTicks={200}

--- a/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
@@ -121,6 +121,18 @@ export function WikiGraphCanvas({
 
       if (killed || !containerRef.current) return;
 
+      // Detect dark mode for label/edge color adaptation
+      const rootEl = document.documentElement;
+      const colorScheme = rootEl.getAttribute("data-color-scheme");
+      const prefersDark =
+        colorScheme === "dark" ||
+        (!colorScheme &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches);
+      const labelColor = prefersDark ? "#e3e3e3" : "#1c1e21";
+      const edgeColor = prefersDark
+        ? "rgba(255, 255, 255, 0.12)"
+        : "#d4d4d8";
+
       const graph = new Graph({ multi: false, type: "directed" });
       const entrySlugMap = new Map<string, string[]>();
       for (const n of nodes) {
@@ -162,7 +174,8 @@ export function WikiGraphCanvas({
         labelFont: "system-ui, sans-serif",
         labelSize: 12,
         labelWeight: "500",
-        defaultEdgeColor: "#d4d4d8",
+        labelColor: { color: labelColor },
+        defaultEdgeColor: edgeColor,
         defaultNodeColor: "#6B7280",
         minCameraRatio: 0.1,
         maxCameraRatio: 10,

--- a/apps/negentropy-wiki/src/styles/components/graph.css
+++ b/apps/negentropy-wiki/src/styles/components/graph.css
@@ -1,21 +1,26 @@
 /* Wiki 知识图谱页样式 ------------------------------------------------------
  *
- * Sigma 渲染依赖容器有显式高度才能绘制；这里把 canvas 外层撑满主区域剩余
- * 高度（减去顶栏 header + 文档标题区域）。
- * 不依赖 JS 测量，纯 CSS 通过 viewport - header 解决，与 markdown 文档页
- * 风格一致。
+ * 图谱页使用全宽布局（variant="home"），canvas 占满 viewport 宽度。
+ * Sigma 渲染依赖容器有显式高度才能绘制；高度通过 viewport - header 解决。
  */
 
+.wiki-graph-page {
+  width: 100%;
+  max-width: 100%;
+}
+
+.wiki-graph-page-header {
+  padding: 1.5rem clamp(1.25rem, 4vw, 3rem) 0.5rem;
+}
+
 .wiki-graph-canvas-wrap {
-  /* 主区高度 = viewport - 顶部 header 高度（约 56px）- 文档标题块约 88px
-   * 实测保守值 200px 足以避开顶栏与下边距，剩余给 canvas。 */
   height: calc(100vh - 200px);
   min-height: 480px;
   width: 100%;
   position: relative;
-  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border: 1px solid var(--wiki-border);
   border-radius: 8px;
-  background: var(--surface-recessed, rgba(0, 0, 0, 0.12));
+  background: var(--wiki-bg-secondary);
   overflow: hidden;
 }
 
@@ -65,9 +70,9 @@
 .wiki-graph-error,
 .wiki-graph-loading {
   padding: 2rem;
-  border: 1px dashed var(--border-subtle, rgba(255, 255, 255, 0.12));
+  border: 1px dashed var(--wiki-border);
   border-radius: 8px;
-  background: var(--surface-recessed, rgba(0, 0, 0, 0.06));
+  background: var(--wiki-bg-secondary);
 }
 
 .wiki-error-detail {

--- a/apps/negentropy/src/negentropy/knowledge/graph/entity_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/entity_service.py
@@ -47,6 +47,7 @@ class KgEntityService:
         metadata: dict | None = None,
         corpus_id: UUID | None = None,
         app_name: str = "negentropy",
+        document_id: UUID | None = None,
     ) -> bool:
         """从 knowledge 记录同步实体到 kg_entities 表（双写）
 
@@ -69,7 +70,7 @@ class KgEntityService:
             调用方据此区分 ``created`` / ``updated``，避免误把幂等更新当新增计入指标
             （参 issue.md ISSUE-032）。
         """
-        from negentropy.models.perception import KgEntity
+        from negentropy.models.perception import KgEntity, KgEntityMention
 
         # 检查是否已存在（幂等），仅使用 (corpus_id, canonical_name) 匹配
         # 与 UNIQUE 约束 uq_kg_entity_corpus_name 对齐，避免同名称不同 entity_type 时
@@ -107,6 +108,25 @@ class KgEntityService:
                 merged = {**(existing_rec.properties or {}), **metadata}
                 existing_rec.properties = merged
             existing_rec.mention_count += 1
+            # 为当前 document 创建 mention（幂等：已存在则跳过）
+            if document_id is not None:
+                existing_mention = await db.execute(
+                    sa.select(KgEntityMention)
+                    .where(
+                        KgEntityMention.entity_id == existing_rec.id,
+                        KgEntityMention.document_id == document_id,
+                    )
+                    .limit(1)
+                )
+                if existing_mention.scalar_one_or_none() is None:
+                    extra_mention = KgEntityMention(
+                        entity_id=existing_rec.id,
+                        corpus_id=corpus_id,
+                        document_id=document_id,
+                        context_snippet=f"Entity '{name}' mentioned in document",
+                    )
+                    db.add(extra_mention)
+                    await db.flush()
             logger.debug(
                 "kg_entity_updated",
                 extra={
@@ -135,11 +155,11 @@ class KgEntityService:
         # 创建 mention 记录（此时 new_entity.id 已生成）
         # 注意：knowledge_chunk_id 不在此设置，因为 knowledge_id 在批量同步场景中
         # 可能指向不存在的 Knowledge 记录，会导致 FK 约束违规
-        from negentropy.models.perception import KgEntityMention
 
         mention = KgEntityMention(
             entity_id=new_entity.id,
             corpus_id=corpus_id,
+            document_id=document_id,
             context_snippet=f"Entity '{name}' extracted from chunk",
         )
         db.add(mention)
@@ -293,6 +313,9 @@ class KgEntityService:
 
         for node in nodes:
             try:
+                node_doc_ids = node.get("document_ids") or []
+                primary_doc_id = UUID(node_doc_ids[0]) if node_doc_ids else None
+
                 async with db.begin_nested():  # SAVEPOINT: 单条失败仅回滚此 savepoint
                     created = await self.sync_entity_from_knowledge(
                         db,
@@ -303,11 +326,20 @@ class KgEntityService:
                         metadata=node.get("metadata"),
                         corpus_id=corpus_id,
                         app_name=app_name,
+                        document_id=primary_doc_id,
                     )
                 if created:
                     entities_created += 1
                 else:
                     entities_updated += 1
+                # 为额外的 document 创建 mention（幂等）
+                if len(node_doc_ids) > 1:
+                    await self._ensure_extra_document_mentions(
+                        db,
+                        node=node,
+                        extra_doc_ids=node_doc_ids[1:],
+                        corpus_id=corpus_id,
+                    )
             except Exception as exc:
                 entities_failed += 1
                 logger.warning(
@@ -371,6 +403,62 @@ class KgEntityService:
             "relations_skipped": relations_skipped,
             "relations_failed": relations_failed,
         }
+
+    async def _ensure_extra_document_mentions(
+        self,
+        db: AsyncSession,
+        *,
+        node: dict,
+        extra_doc_ids: list[str],
+        corpus_id: UUID | None,
+    ) -> None:
+        """为多 document 实体的额外 document 创建 mention（幂等）。
+
+        当一个实体从多个 document 的 chunk 中被提取时，主 document 已在
+        sync_entity_from_knowledge 中创建 mention，此方法为剩余 document 补建。
+        """
+        from negentropy.models.perception import KgEntity, KgEntityMention
+
+        name = node.get("label") or node.get("id", "unknown")
+        canonical = name.strip().lower()
+        _corpus_filters = [KgEntity.corpus_id == corpus_id] if corpus_id else []
+
+        entity_result = await db.execute(
+            sa.select(KgEntity).where(KgEntity.canonical_name == canonical, *_corpus_filters).limit(1)
+        )
+        entity_rec = entity_result.scalar_one_or_none()
+        if entity_rec is None:
+            return
+
+        for doc_id_str in extra_doc_ids:
+            try:
+                doc_uuid = UUID(doc_id_str)
+                existing = await db.execute(
+                    sa.select(KgEntityMention)
+                    .where(
+                        KgEntityMention.entity_id == entity_rec.id,
+                        KgEntityMention.document_id == doc_uuid,
+                    )
+                    .limit(1)
+                )
+                if existing.scalar_one_or_none() is None:
+                    mention = KgEntityMention(
+                        entity_id=entity_rec.id,
+                        corpus_id=corpus_id,
+                        document_id=doc_uuid,
+                        context_snippet=f"Entity '{name}' extracted from document",
+                    )
+                    db.add(mention)
+                    await db.flush()
+            except Exception as exc:
+                logger.warning(
+                    "extra_document_mention_failed",
+                    extra={
+                        "entity": name,
+                        "document_id": doc_id_str,
+                        "error": str(exc),
+                    },
+                )
 
     async def get_top_entities(
         self,

--- a/apps/negentropy/src/negentropy/knowledge/graph/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/graph/service.py
@@ -427,6 +427,8 @@ class GraphService:
             # 分批处理
             all_entities: list[GraphNode] = []
             all_relations: list[GraphEdge] = []
+            # entity canonical_label → set of document_ids（用于 mention 创建时关联 document）
+            entity_to_documents: dict[str, set[str]] = {}
             chunks_processed = 0
             failed_chunk_count = 0
             chunks_fallback = 0
@@ -623,7 +625,7 @@ class GraphService:
             async def process_chunk(
                 chunk: dict[str, Any],
                 chunk_index: int,
-            ) -> tuple[list[GraphNode], list[GraphEdge]]:
+            ) -> tuple[list[GraphNode], list[GraphEdge], str | None]:
                 """处理单个知识块，LLM 提取失败时降级到 fallback 提取器。
 
                 Args:
@@ -668,7 +670,7 @@ class GraphService:
                     text = chunk.get("content", "")
                     if not text:
                         _log_chunk_done([], [], mode="empty")
-                        return [], []
+                        return [], [], None
 
                     logger.info(
                         "chunk_processing_started",
@@ -685,7 +687,7 @@ class GraphService:
                         chunks_fallback += 1
                         fb_entities, fb_relations = await _fallback_extract_chunk(text, chunk_id)
                         _log_chunk_done(fb_entities, fb_relations, mode="fallback_fast_path")
-                        return fb_entities, fb_relations
+                        return fb_entities, fb_relations, chunk.get("document_id")
 
                     # ── 正常 LLM 提取路径 ──
                     # 实体提取与关系提取拆分为独立 try/except，实现部分结果保留：
@@ -743,7 +745,7 @@ class GraphService:
                         chunks_fallback += 1
                         fb_entities, fb_relations = await _fallback_extract_chunk(text, chunk_id)
                         _log_chunk_done(fb_entities, fb_relations, mode="fallback_entity_timeout")
-                        return fb_entities, fb_relations
+                        return fb_entities, fb_relations, chunk.get("document_id")
 
                     # 实体提取成功 → 检查断路器再尝试关系提取
                     if llm_cancel.is_set():
@@ -767,7 +769,7 @@ class GraphService:
                                 error=str(fallback_exc),
                             )
                         _log_chunk_done(entities, relations, mode="entity_llm_relation_cooccurrence")
-                        return entities, relations
+                        return entities, relations, chunk.get("document_id")
 
                     try:
                         relations = await asyncio.wait_for(
@@ -783,7 +785,7 @@ class GraphService:
                         # LLM 全部成功 → 重置断路器
                         circuit_breaker.record_success()
                         _log_chunk_done(entities, relations, mode="llm_full")
-                        return entities, relations
+                        return entities, relations, chunk.get("document_id")
                     except (TimeoutError, Exception) as exc:
                         if isinstance(exc, PipelineCancelled):
                             raise
@@ -821,7 +823,7 @@ class GraphService:
                                 error=str(fallback_exc),
                             )
                         _log_chunk_done(entities, relations, mode="entity_llm_relation_fallback")
-                        return entities, relations
+                        return entities, relations, chunk.get("document_id")
 
             async def _fallback_extract_chunk(
                 text: str,
@@ -895,9 +897,15 @@ class GraphService:
                         failed_chunk_count += 1
                         continue
 
-                    entities, relations = result
+                    entities, relations, doc_id = result
                     all_entities.extend(entities)
                     all_relations.extend(relations)
+                    # 累积 entity → documents 映射（用于 mention 创建时关联 document）
+                    if doc_id:
+                        for e in entities:
+                            key = (e.label or "").strip().lower()
+                            if key:
+                                entity_to_documents.setdefault(key, set()).add(doc_id)
                     chunks_processed += 1
                     logger.info(
                         "chunk_processing_completed",
@@ -1180,16 +1188,21 @@ class GraphService:
                 from .entity_service import KgEntityService
 
                 kg_service = KgEntityService()
-                node_dicts = [
-                    {
+                node_dicts = []
+                for e in entities_to_save:
+                    nd = {
                         "id": e.id.replace("entity:", ""),
                         "label": e.label,
                         "node_type": e.node_type,
                         "confidence": e.metadata.get("confidence", 1.0),
                         "metadata": e.metadata,
                     }
-                    for e in entities_to_save
-                ]
+                    # 附上该实体被提及的 document_ids（用于 KgEntityMention.document_id 填充）
+                    canonical = (e.label or "").strip().lower()
+                    doc_ids = entity_to_documents.get(canonical)
+                    if doc_ids:
+                        nd["document_ids"] = list(doc_ids)
+                    node_dicts.append(nd)
                 edge_dicts = [
                     {
                         "source": id_to_label.get(

--- a/apps/negentropy/src/negentropy/knowledge/routes/graph.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/graph.py
@@ -168,12 +168,13 @@ async def build_knowledge_graph(
         if parent_items:
             knowledge_items = parent_items
 
-        # 准备知识块数据（含 id 用于增量构建跳过判断）
+        # 准备知识块数据（含 id 用于增量构建跳过判断、document_id 用于 mention 关联）
         chunks = [
             {
                 "id": str(item.id),
                 "content": item.content,
                 "metadata": item.metadata or {},
+                "document_id": item.metadata.get("document_id") if item.metadata else None,
             }
             for item in knowledge_items
         ]


### PR DESCRIPTION
# 背景
- Wiki 站点知识图谱页面始终显示"图谱为空"，无法展示主站 KG 数据；图谱页布局存在左右空白浪费空间，深色主题下标签文字不可见
- 关联上下文：Wiki Publication 图谱切片查询依赖 `kg_entity_mentions.document_id`，该字段从未被 KG Build Pipeline 填充

# 核心变更

**后端 — document_id 链路补齐（commit f78b4e5e）**
- `routes/graph.py`: 从 chunk metadata 提取 `document_id` 到顶层字段
- `service.py`: `process_chunk` 返回值扩展为 3 元组（含 `document_id`），构建 `entity→documents` 映射，同步阶段传递给 node_dicts
- `entity_service.py`: `sync_entity_from_knowledge` 新增 `document_id` 参数，mention 创建时填充该字段；已存在实体路径中为每个 document 幂等创建 mention；新增 `_ensure_extra_document_mentions` 处理多 document 实体

**前端 — 全宽布局 + 深浅色主题适配（commit f7796aab）**
- `page.tsx`: 图谱页改用 `variant="home"` 全宽布局，移除 sidebar，canvas 占满 viewport 宽度
- `WikiGraphCanvas.tsx`: Sigma 初始化时检测 `data-color-scheme`/`prefers-color-scheme`，动态设置 `labelColor` 和 `defaultEdgeColor`
- `WikiForceGraphCanvas.tsx`: ForceGraph2D 降级渲染器同步适配标签、边、箭头颜色
- `graph.css`: canvas 背景和边框改用 `--wiki-border`/`--wiki-bg-secondary` CSS 变量，深浅色自动适配

# 风险与回滚
- 主要风险：已存在实体路径新增 mention 幂等查询，大规模图谱构建时可能增加 DB 写入
- 回滚方式：`git revert` 两个 commit 即可，无数据迁移依赖

# 验证证据
- 单元测试：无新增（KG Build Pipeline 测试覆盖已有逻辑）
- E2E/Workflow：通过浏览器验证 Wiki 图谱页 `http://localhost:3092/wiki/graph` 正常显示 268 节点 / 367 边 / 399 实体
- 覆盖率/关键截图：
  - API 验证：`GET /knowledge/wiki/publications/{pub_id}/graph` 返回完整图谱数据
  - 布局验证：`main` 元素 `width=1865px, x=0, no sidebar, maxWidth=100%`
  - 深色主题验证：标题色 `#e3e3e3`、背景 `#242526`、边框 `#444952`

# 影响范围
- 前端：`apps/negentropy-wiki` 图谱页布局和渲染器
- 后端：`apps/negentropy` KG Build Pipeline 的 entity_service / graph service / routes
- GitHub Actions / 文档：无影响

# Next Best Action
- 观察全量 KG Build 后 `kg_entity_mentions` 表中 `document_id IS NOT NULL` 记录比例，确认数据完整性
- 考虑为 ThemePreference 组件的 SVG 图标解决 hydration mismatch 问题（当前已知非阻塞）