### PR TITLE
fix(perceives): 修复 webpage pipeline Hero 区域元数据丢失

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
@@ -141,16 +141,21 @@ def _apply_common_post_processing(
 
     # 5. 去重后注入 hero 片段
     if hero_html:
-        # 简单去重：检查 main_html 是否已包含 hero 中的纯文本段落
         try:
             from bs4 import BeautifulSoup
 
+            main_soup = BeautifulSoup(main_html, "html.parser")
+            existing_texts = {
+                p.get_text(strip=True)
+                for p in main_soup.find_all("p")
+                if p.get_text(strip=True)
+            }
             hero_soup = BeautifulSoup(hero_html, "html.parser")
             deduped_parts = []
             for child in hero_soup.children:
                 if hasattr(child, "name") and child.name == "p":
                     text = child.get_text(strip=True)
-                    if text and text in main_html:
+                    if text and text in existing_texts:
                         continue
                 deduped_parts.append(str(child))
             hero_html = "\n".join(deduped_parts) if deduped_parts else None
@@ -327,7 +332,11 @@ def _clean_title(raw_title: str, og_title: Optional[str] = None) -> str:
     for sep in (" | ", " — ", " – ", " - ", " ‣ ", " • ", " :: "):
         if sep in raw_title:
             parts = [p.strip() for p in raw_title.split(sep)]
-            # 取最长的段作为标题（站点名通常较短）
+            if len(parts) == 2:
+                # 两段式：长度相近时优先取第一段（CMS 通常 Title | Site 格式）
+                shorter, longer = sorted(parts, key=len)
+                if len(shorter) * 2 >= len(longer):
+                    return parts[0]
             return max(parts, key=len)
     return raw_title
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
@@ -93,8 +93,77 @@ def _inject_after_h1(html: str, fragment: str) -> str:
     return f"{fragment}\n{html}"
 
 
+def _apply_common_post_processing(
+    main_html: str,
+    raw_html: str,
+    title: str,
+) -> str:
+    """对所有主内容提取引擎统一的后续处理：标题注入 + hero 元数据注入。
+
+    统一封装 H1 标题注入、hero 元数据（lead 段落、发布日期、品牌图片）
+    提取与注入、OG 元数据后备、标题清洗等步骤，确保无论哪个引擎胜出
+    都能获得一致的元数据保真度。
+
+    去重保护：如果 ``main_html`` 已包含 hero 段落的文本内容，
+    则跳过该段的注入，避免重复。
+    """
+    # 1. 标题清洗
+    og_meta = _extract_og_metadata(raw_html)
+    og_title = og_meta.get("title") if og_meta else None
+    clean_title = _clean_title(title, og_title)
+
+    # 2. H1 注入
+    main_html = _ensure_h1_title(main_html, clean_title)
+
+    # 3. Hero 元数据提取
+    hero_html = _extract_hero_metadata(raw_html)
+
+    # 4. OG 后备：当 hero 启发式未匹配时，从 meta 标签构建 hero 片段
+    if not hero_html and og_meta:
+        parts = []
+        if og_meta.get("image"):
+            parts.append(f'<img src="{html_escape(og_meta["image"])}" alt="">')
+        if og_meta.get("description"):
+            parts.append(f"<p>{html_escape(og_meta['description'])}</p>")
+        if og_meta.get("published_time"):
+            from datetime import datetime
+
+            try:
+                dt = datetime.fromisoformat(
+                    og_meta["published_time"].replace("Z", "+00:00")
+                )
+                formatted = dt.strftime("%b %d, %Y")
+            except (ValueError, TypeError):
+                formatted = og_meta["published_time"]
+            parts.append(f"<p>Published {html_escape(formatted)}</p>")
+        if parts:
+            hero_html = "\n".join(parts)
+
+    # 5. 去重后注入 hero 片段
+    if hero_html:
+        # 简单去重：检查 main_html 是否已包含 hero 中的纯文本段落
+        try:
+            from bs4 import BeautifulSoup
+
+            hero_soup = BeautifulSoup(hero_html, "html.parser")
+            deduped_parts = []
+            for child in hero_soup.children:
+                if hasattr(child, "name") and child.name == "p":
+                    text = child.get_text(strip=True)
+                    if text and text in main_html:
+                        continue
+                deduped_parts.append(str(child))
+            hero_html = "\n".join(deduped_parts) if deduped_parts else None
+        except Exception:
+            pass
+        if hero_html:
+            main_html = _inject_after_h1(main_html, hero_html)
+
+    return main_html
+
+
 def _extract_hero_metadata(raw_html: str) -> Optional[str]:
-    """从原始 HTML 中提取 hero/header 区域的元数据段（lead + 发布日期）。
+    """从原始 HTML 中提取 hero/header 区域的元数据段（lead + 发布日期 + 图片）。
 
     现代 blog/news 站点（Anthropic / Next.js 站点）常把文章 lead 段与
     发布日期放在 ``<section>`` / ``hero`` / ``metadata`` 容器中，
@@ -103,30 +172,35 @@ def _extract_hero_metadata(raw_html: str) -> Optional[str]:
 
     本函数用启发式规则识别这类 hero 容器：
       1. 优先匹配 class/data-attr 含 ``hero``/``metadata``/``summary``
-         /``lead``/``date``/``published`` 关键字的容器；
-      2. 提取容器内的 ``<p>`` 段落（保留发布日期 + lead）；
-      3. 限制片段长度防误抓整页。
+         /``lead``/``date``/``published``/``byline``/``intro``/``dek`` 关键字的容器；
+      2. 提取容器内的 ``<p>``、``<img>``、``<time>`` 元素（按文档顺序）；
+      3. 限制文本长度防误抓整页（仅计算 ``<p>`` 文本，图片不计入）。
 
-    返回带 ``<p>`` 包裹的 HTML 片段，或 None。
+    返回 HTML 片段（含 ``<p>``、``<img>``、``<p><time>``），或 None。
     """
     if not raw_html:
         return None
     try:
-        from bs4 import BeautifulSoup
+        from bs4 import BeautifulSoup, Tag
 
         soup = BeautifulSoup(raw_html, "html.parser")
-        # 启发式：找出 class/data 含相关关键字的容器
         hero_keywords = re.compile(
-            r"hero|metadata|summary|lead|published|article-(?:header|meta)",
+            r"hero|metadata|summary|lead|published|article-(?:header|meta)"
+            r"|byline|intro|dek|abstract",
             re.IGNORECASE,
         )
 
         def _is_hero_container(tag) -> bool:
-            if tag.name not in ("section", "header", "div"):
+            if not isinstance(tag, Tag) or tag.name not in ("section", "header", "div"):
                 return False
-            class_attr = " ".join(tag.get("class", []) or [])
-            data_component = tag.get("data-component", "") or ""
-            id_attr = tag.get("id", "") or ""
+            raw_class = tag.get("class") or [""]
+            class_attr = (
+                " ".join(raw_class) if isinstance(raw_class, list) else str(raw_class)
+            )
+            raw_dc = tag.get("data-component", "") or ""
+            data_component = str(raw_dc)
+            raw_id = tag.get("id", "") or ""
+            id_attr = str(raw_id)
             return bool(
                 hero_keywords.search(class_attr)
                 or hero_keywords.search(data_component)
@@ -137,30 +211,125 @@ def _extract_hero_metadata(raw_html: str) -> Optional[str]:
         if not candidates:
             return None
 
-        # 选择含 <p> 且文本长度合理（避免大容器误抓正文）的最浅候选
         for c in candidates:
             ps = c.find_all("p", recursive=True)
             if not ps:
                 continue
+            # 仅 <p> 文本计入长度限制
             total_text = "\n".join(
                 p.get_text(strip=True) for p in ps if p.get_text(strip=True)
             )
             if not total_text or len(total_text) > 1500:
-                # 太长说明抓到了整篇正文，跳过
                 continue
-            # 把 <p> 序列拼成 HTML 片段
+            # 收集所有感兴趣元素并按文档顺序排列
+            elements = []
+            for child in c.descendants:
+                if not isinstance(child, Tag):
+                    continue
+                if child.name == "img":
+                    elements.append(("img", child))
+                elif child.name == "time":
+                    elements.append(("time", child))
+                elif child.name == "p":
+                    elements.append(("p", child))
+            # 去重：一个 <p> 内的子 <img> 不应同时作为 <img> 和 <p> 出现
+            seen_ids: set = set()
+            unique_elements = []
+            for kind, el in elements:
+                el_id = id(el)
+                if el_id in seen_ids:
+                    continue
+                # 跳过已被其他 <p> 包含的 <img>（避免重复）
+                if kind == "img":
+                    parent = el.parent
+                    while parent:
+                        if parent.name == "p" and id(parent) in seen_ids:
+                            break
+                        parent = parent.parent
+                    else:
+                        seen_ids.add(el_id)
+                        unique_elements.append((kind, el))
+                    continue
+                seen_ids.add(el_id)
+                unique_elements.append((kind, el))
+            # 构建 HTML 片段
             fragments = []
-            for p in ps:
-                txt = p.get_text(strip=True)
-                if txt:
-                    # 用 inner_html 保留 inline 元素（链接、强调等）
-                    fragments.append(f"<p>{p.decode_contents()}</p>")
+            for kind, el in unique_elements:
+                if kind == "p":
+                    txt = el.get_text(strip=True)
+                    if txt:
+                        fragments.append(f"<p>{el.decode_contents()}</p>")
+                elif kind == "img":
+                    src = el.get("src", "")
+                    if src:
+                        fragments.append(str(el))
+                elif kind == "time":
+                    txt = el.get_text(strip=True)
+                    if txt:
+                        time_str = str(el)
+                        fragments.append(f"<p>{time_str}</p>")
             if fragments:
                 return "\n".join(fragments)
         return None
     except Exception:
         logger.debug("hero metadata 提取失败", exc_info=True)
         return None
+
+
+def _extract_og_metadata(raw_html: str) -> Optional[Dict[str, str]]:
+    """从 ``<meta>`` 标签提取 Open Graph / Article 结构化元数据。
+
+    当 :func:`_extract_hero_metadata` 启发式匹配失败时（例如站点使用
+    非标准 class 命名），此函数从 ``og:*`` 和 ``article:*`` meta 标签
+    中提取标题、描述、图片和发布时间作为后备数据源。
+
+    返回含已找到字段的 dict，或 None（未找到任何有用字段时）。
+    """
+    if not raw_html:
+        return None
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(raw_html[:50000], "html.parser")
+        result: Dict[str, str] = {}
+        og_fields = {
+            "og:title": "title",
+            "og:description": "description",
+            "og:image": "image",
+            "article:published_time": "published_time",
+        }
+        for prop, key in og_fields.items():
+            tag = soup.find("meta", attrs={"property": prop}) or soup.find(
+                "meta", attrs={"name": prop}
+            )
+            if tag:
+                content = tag.get("content", "")
+                if content and isinstance(content, str):
+                    result[key] = content.strip()
+        return result if result else None
+    except Exception:
+        logger.debug("OG metadata 提取失败", exc_info=True)
+        return None
+
+
+def _clean_title(raw_title: str, og_title: Optional[str] = None) -> str:
+    """清洗 ``<title>`` 标签中可能附带的站点名。
+
+    许多站点的 ``<title>`` 格式为 ``"文章标题 | 站点名"`` 或
+    ``"站点名 — 文章标题"``，导致 H1 注入时带入多余文本。
+    优先使用 OG title（通常更干净），否则按常见分隔符拆分取最长段。
+    """
+    if og_title and og_title.strip():
+        return og_title.strip()
+    if not raw_title:
+        return raw_title
+    # 按优先级尝试常见分隔符
+    for sep in (" | ", " — ", " – ", " - ", " ‣ ", " • ", " :: "):
+        if sep in raw_title:
+            parts = [p.strip() for p in raw_title.split(sep)]
+            # 取最长的段作为标题（站点名通常较短）
+            return max(parts, key=len)
+    return raw_title
 
 
 def _normalize_redirect_urls(html: str) -> str:
@@ -319,10 +488,10 @@ class TrafilaturaTool(WebToolBase):
                     engine_used=self.tool_name,
                 )
 
-            # H1 注入：trafilatura 通常会把 H1 当 title 抽走，
-            # main_html 内不含 H1。把 ctx.title 注入为 H1 置顶，
-            # 让下游 Markdown 输出保留主标题。
-            main_html = _ensure_h1_title(main_html, ctx.title or "")
+            # 统一后续处理：标题清洗 + H1 注入 + hero 元数据注入
+            main_html = _apply_common_post_processing(
+                main_html, raw_html, ctx.title or ""
+            )
 
             # 规范化站内跟踪 redirect URL
             main_html = _normalize_redirect_urls(main_html)
@@ -401,16 +570,10 @@ class ReadabilityTool(WebToolBase):
             if short_title and not ctx.title:
                 ctx.title = short_title
 
-            # H1 注入：readability 把 H1 当 title 抽走，
-            # summary 内不含 H1。把 ctx.title 注入为 H1 置顶。
-            main_html = _ensure_h1_title(main_html, ctx.title or short_title or "")
-
-            # Hero 元数据注入：readability 把 lead 段 / 发布日期
-            # 视为 page chrome 排除掉。从 raw_html 启发式提取并
-            # 紧随 H1 注入到 body 开头，避免文章简介与日期丢失。
-            hero_html = _extract_hero_metadata(raw_html)
-            if hero_html:
-                main_html = _inject_after_h1(main_html, hero_html)
+            # 统一后续处理：标题清洗 + H1 注入 + hero 元数据注入
+            main_html = _apply_common_post_processing(
+                main_html, raw_html, ctx.title or short_title or ""
+            )
 
             # 规范化站内跟踪 redirect URL（anchor 文本是域名时）
             main_html = _normalize_redirect_urls(main_html)
@@ -471,10 +634,10 @@ class BeautifulSoupHeuristicTool(WebToolBase):
                     engine_used=self.tool_name,
                 )
 
-            # H1 注入：bs_heuristic 通常会保留 H1，但某些主题把标题
-            # 渲染为带特殊 class 的 div / 多 H2 并列结构，导致 H1 缺失。
-            # 兜底注入避免下游 Markdown 失去主标题。
-            main_html = _ensure_h1_title(main_html, ctx.title or "")
+            # 统一后续处理：标题清洗 + H1 注入 + hero 元数据注入
+            main_html = _apply_common_post_processing(
+                main_html, raw_html, ctx.title or ""
+            )
 
             # 规范化站内跟踪 redirect URL
             main_html = _normalize_redirect_urls(main_html)

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/webpage/main_content_extraction.py
@@ -160,7 +160,9 @@ def _apply_common_post_processing(
                 deduped_parts.append(str(child))
             hero_html = "\n".join(deduped_parts) if deduped_parts else None
         except Exception:
-            pass
+            logger.debug(
+                "Hero deduplication failed, keeping original hero_html", exc_info=True
+            )
         if hero_html:
             main_html = _inject_after_h1(main_html, hero_html)
 


### PR DESCRIPTION
## Summary

- 修复 `parse_webpage_to_markdown` pipeline 处理 Anthropic 等博客时，页面头部的文章标题、发布日期、引述段落和品牌图片丢失的问题
- 根因：S4 主内容提取阶段仅 readability 引擎调用 hero 元数据注入，trafilatura（rank=1）成功时 hero 提取函数不执行
- 新增 `_extract_og_metadata()` 从 Open Graph meta 标签提取后备元数据；新增 `_clean_title()` 清洗标题中的站点名后缀
- 所有 3 个引擎（trafilatura、readability、bs_heuristic）统一通过 `_apply_common_post_processing()` 调用共享后处理

## 验证

- 1485 个单元测试全部通过（1485 passed, 11 skipped），无回归
- 浏览器端到端验证：对 Anthropic 博客重新 Ingest 后，标题 ✅ / 发布日期 ✅ / 引述段落 ✅ / 品牌图片 ✅ 全部正确渲染

## Test plan

- [x] 运行 `uv run pytest tests/unit/ -x` 确认无回归
- [x] 通过 Knowledge Base Ingest From URL 重新导入目标 WebPage
- [x] 在 Documents 页面 View 确认 4 个缺失项已恢复
- [ ] 与 Anthropic 原页面逐段对比内容一致性

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)