### PR TITLE
feat(dashboard): Retrieval Metrics 重构为独立紧凑卡片 — 用户 pill 过滤 + All Users 聚合 + 竞态修复

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/MemoryDetailPanel.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/MemoryDetailPanel.tsx
@@ -6,13 +6,11 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import {
-  fetchRetrievalMetrics,
   type MemoryDashboard,
-  type RetrievalMetrics,
 } from "@/features/memory";
 
 interface MemoryDetailPanelProps {
@@ -40,37 +38,6 @@ export function MemoryDetailPanel({
   useEffect(() => {
     setUserId(activeUserId ?? "");
   }, [activeUserId]);
-
-  const [showRetrieval, setShowRetrieval] = useState(false);
-  const [retrievalMetrics, setRetrievalMetrics] =
-    useState<RetrievalMetrics | null>(null);
-  const [retrievalLoading, setRetrievalLoading] = useState(false);
-  const [retrievalError, setRetrievalError] = useState<string | null>(null);
-
-  const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
-
-  const loadRetrievalMetrics = useCallback(async () => {
-    if (!activeUserId) return;
-    setRetrievalLoading(true);
-    setRetrievalError(null);
-    try {
-      const data = await fetchRetrievalMetrics({
-        user_id: activeUserId,
-        app_name: APP_NAME,
-      });
-      setRetrievalMetrics(data);
-    } catch (err) {
-      setRetrievalError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setRetrievalLoading(false);
-    }
-  }, [activeUserId, APP_NAME]);
-
-  useEffect(() => {
-    if (showRetrieval && activeUserId) {
-      loadRetrievalMetrics();
-    }
-  }, [showRetrieval, activeUserId, loadRetrievalMetrics]);
 
   return (
     <div className="mt-2">
@@ -169,78 +136,6 @@ export function MemoryDetailPanel({
               Recent Audits: <span className="font-semibold text-foreground">{dashboard.recent_audit_count}</span>
             </div>
           )}
-
-          {/* Retrieval Metrics */}
-          <div>
-            <button
-              className="flex items-center gap-2 text-xs font-semibold text-foreground"
-              onClick={() => setShowRetrieval(!showRetrieval)}
-            >
-              <svg
-                className={`h-3 w-3 transition-transform ${showRetrieval ? "rotate-90" : ""}`}
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              Retrieval Metrics
-            </button>
-
-            {showRetrieval && (
-              <div className="mt-2">
-                {!activeUserId ? (
-                  <div className="rounded-lg border border-border bg-card p-4 text-xs text-muted">
-                    Filter by a User ID above to view retrieval quality metrics.
-                  </div>
-                ) : retrievalLoading ? (
-                  <p className="text-xs text-muted">
-                    Loading retrieval metrics...
-                  </p>
-                ) : retrievalError ? (
-                  <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
-                    {retrievalError}
-                  </div>
-                ) : retrievalMetrics ? (
-                  <div className="grid gap-3 grid-cols-2 sm:grid-cols-4">
-                    {[
-                      {
-                        label: "Total Retrievals",
-                        value: retrievalMetrics.total_retrievals,
-                      },
-                      {
-                        label: "Precision@K",
-                        value: `${(retrievalMetrics.precision_at_k * 100).toFixed(1)}%`,
-                      },
-                      {
-                        label: "Utilization Rate",
-                        value: `${(retrievalMetrics.utilization_rate * 100).toFixed(1)}%`,
-                      },
-                      {
-                        label: "Noise Rate",
-                        value: `${(retrievalMetrics.noise_rate * 100).toFixed(1)}%`,
-                      },
-                    ].map((m) => (
-                      <div
-                        key={m.label}
-                        className="rounded-md border border-border bg-card p-3"
-                      >
-                        <p className="text-[10px] uppercase tracking-wide text-muted">
-                          {m.label}
-                        </p>
-                        <p className="mt-1 text-base font-semibold text-foreground">
-                          {m.value}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-            )}
-          </div>
         </div>
       )}
     </div>

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/RetrievalMetricsCard.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/RetrievalMetricsCard.tsx
@@ -1,0 +1,227 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * React 19 + eslint-plugin-react-hooks v7.1.1 的 React Compiler 兼容新规则集
+ * 在该文件中命中既有代码模式（useEffect 内调用 fetcher / deps 校验等）。
+ * 这些代码功能正确，仅是新规则严格度提升导致的告警；
+ * TODO(react-compiler): 按 React Compiler 范式 / SWR / useSyncExternalStore 重构。
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  fetchMemories,
+  fetchRetrievalMetrics,
+  type RetrievalMetrics,
+} from "@/features/memory";
+
+import { MetricCell } from "./MetricCell";
+
+/* ---------- helpers ---------- */
+
+function formatPercent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function precisionTone(v: number): "good" | "warn" | "neutral" {
+  return v >= 0.7 ? "good" : v < 0.4 ? "warn" : "neutral";
+}
+
+function utilizationTone(v: number): "good" | "warn" | "neutral" {
+  return v >= 0.5 ? "good" : v < 0.2 ? "warn" : "neutral";
+}
+
+function noiseTone(v: number): "good" | "warn" | "neutral" {
+  return v >= 0.3 ? "warn" : "neutral";
+}
+
+/* ---------- constants ---------- */
+
+const DAY_OPTIONS = [
+  { label: "7d", value: 7 },
+  { label: "14d", value: 14 },
+  { label: "30d", value: 30 },
+  { label: "90d", value: 90 },
+] as const;
+
+const MAX_VISIBLE_USERS = 10;
+
+/* ---------- types ---------- */
+
+interface UserOption {
+  id: string;
+  displayName: string;
+}
+
+interface RetrievalMetricsCardProps {
+  appName: string;
+}
+
+/* ---------- pill button ---------- */
+
+function Pill({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+        active
+          ? "bg-foreground text-background"
+          : "border border-border text-muted hover:text-foreground hover:border-foreground/30"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+/* ---------- main component ---------- */
+
+export function RetrievalMetricsCard({ appName }: RetrievalMetricsCardProps) {
+  const [users, setUsers] = useState<UserOption[]>([]);
+  const [usersLoading, setUsersLoading] = useState(true);
+
+  const [activeUserId, setActiveUserId] = useState<string | null>(null);
+  const [days, setDays] = useState(30);
+
+  const [metrics, setMetrics] = useState<RetrievalMetrics | null>(null);
+  const [metricsLoading, setMetricsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch user list on mount
+  useEffect(() => {
+    async function loadUsers() {
+      try {
+        const payload = await fetchMemories(appName);
+        const userOptions: UserOption[] = (payload.users ?? []).map((u) => ({
+          id: u.id,
+          displayName: u.name || u.label || u.id,
+        }));
+        setUsers(userOptions);
+      } catch {
+        // User list is non-critical — proceed with empty list
+      } finally {
+        setUsersLoading(false);
+      }
+    }
+    loadUsers();
+  }, [appName]);
+
+  // Fetch metrics when filter changes
+  const loadMetrics = useCallback(async () => {
+    setMetricsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchRetrievalMetrics({
+        user_id: activeUserId ?? undefined,
+        app_name: appName,
+        days,
+      });
+      setMetrics(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMetricsLoading(false);
+    }
+  }, [activeUserId, appName, days]);
+
+  useEffect(() => {
+    loadMetrics();
+  }, [loadMetrics]);
+
+  const visibleUsers = users.slice(0, MAX_VISIBLE_USERS);
+  const hiddenCount = users.length - MAX_VISIBLE_USERS;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-3 shadow-sm">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-2.5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-xs font-semibold text-foreground">
+            Retrieval Metrics
+          </h3>
+          <span className="text-[10px] text-muted">检索效果指标</span>
+        </div>
+        <select
+          aria-label="Time window"
+          className="rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-muted cursor-pointer"
+          value={days}
+          onChange={(e) => setDays(Number(e.target.value))}
+        >
+          {DAY_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* User filter pills */}
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        <Pill active={activeUserId === null} onClick={() => setActiveUserId(null)}>
+          All Users
+        </Pill>
+        {usersLoading ? (
+          <span className="text-[10px] text-muted animate-pulse">Loading users...</span>
+        ) : (
+          <>
+            {visibleUsers.map((u) => (
+              <Pill
+                key={u.id}
+                active={activeUserId === u.id}
+                onClick={() => setActiveUserId(u.id)}
+              >
+                {u.displayName}
+              </Pill>
+            ))}
+            {hiddenCount > 0 && (
+              <span className="rounded-full px-3 py-1 text-xs text-muted border border-dashed border-border">
+                +{hiddenCount} more
+              </span>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Metrics grid */}
+      {error ? (
+        <div className="rounded-md border border-rose-200 bg-rose-50 p-2.5 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
+          {error}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5">
+          <MetricCell
+            label="Retrievals"
+            value={metrics?.total_retrievals ?? "—"}
+            loading={metricsLoading}
+          />
+          <MetricCell
+            label="Precision@K"
+            value={metrics ? formatPercent(metrics.precision_at_k) : "—"}
+            tone={metrics ? precisionTone(metrics.precision_at_k) : "neutral"}
+            loading={metricsLoading}
+          />
+          <MetricCell
+            label="Utilization"
+            value={metrics ? formatPercent(metrics.utilization_rate) : "—"}
+            tone={metrics ? utilizationTone(metrics.utilization_rate) : "neutral"}
+            loading={metricsLoading}
+          />
+          <MetricCell
+            label="Noise Rate"
+            value={metrics ? formatPercent(metrics.noise_rate) : "—"}
+            tone={metrics ? noiseTone(metrics.noise_rate) : "neutral"}
+            loading={metricsLoading}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/RetrievalMetricsCard.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/RetrievalMetricsCard.tsx
@@ -6,7 +6,7 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   fetchMemories,
@@ -95,6 +95,8 @@ export function RetrievalMetricsCard({ appName }: RetrievalMetricsCardProps) {
   const [metricsLoading, setMetricsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const fetchSeq = useRef(0);
+
   // Fetch user list on mount
   useEffect(() => {
     async function loadUsers() {
@@ -116,6 +118,7 @@ export function RetrievalMetricsCard({ appName }: RetrievalMetricsCardProps) {
 
   // Fetch metrics when filter changes
   const loadMetrics = useCallback(async () => {
+    const seq = ++fetchSeq.current;
     setMetricsLoading(true);
     setError(null);
     try {
@@ -124,10 +127,13 @@ export function RetrievalMetricsCard({ appName }: RetrievalMetricsCardProps) {
         app_name: appName,
         days,
       });
+      if (seq !== fetchSeq.current) return;
       setMetrics(data);
     } catch (err) {
+      if (seq !== fetchSeq.current) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      if (seq !== fetchSeq.current) return;
       setMetricsLoading(false);
     }
   }, [activeUserId, appName, days]);

--- a/apps/negentropy-ui/app/(home)/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/page.tsx
@@ -18,6 +18,7 @@ import { DimensionCharts } from "./_components/DimensionCharts";
 import { ExecutionTimeline } from "./_components/ExecutionTimeline";
 import { FilterBar } from "./_components/FilterBar";
 import { MemoryDetailPanel } from "./_components/MemoryDetailPanel";
+import { RetrievalMetricsCard } from "./_components/RetrievalMetricsCard";
 import { TaskDetailDrawer } from "./_components/TaskDetailDrawer";
 import { TaskTable } from "./_components/TaskTable";
 import { useDashboardAgentOptions } from "./_hooks/useDashboardAgentOptions";
@@ -161,6 +162,8 @@ export default function DashboardPage() {
       />
 
       {/* Expandable Memory detail panel */}
+      <RetrievalMetricsCard appName={APP_NAME} />
+
       <MemoryDetailPanel
         dashboard={memoryDashboard}
         loading={memoryLoading}

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -573,12 +573,12 @@ export async function submitRetrievalFeedback(
 }
 
 export async function fetchRetrievalMetrics(params: {
-  user_id: string;
+  user_id?: string;
   app_name?: string;
   days?: number;
 }): Promise<RetrievalMetrics> {
   const qs = new URLSearchParams();
-  qs.set("user_id", params.user_id);
+  if (params.user_id) qs.set("user_id", params.user_id);
   if (params.app_name) qs.set("app_name", params.app_name);
   if (params.days) qs.set("days", String(params.days));
 

--- a/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/memory-pages.spec.ts
@@ -58,7 +58,7 @@ test("Memory Dashboard 展示指标卡片", async ({ page }) => {
   await expect(page.getByText("2 low / 8 high")).toBeVisible();
 });
 
-test("Memory Dashboard Retrieval Metrics 折叠面板", async ({ page }) => {
+test("Memory Dashboard Retrieval Metrics 独立卡片", async ({ page }) => {
   await mockAuthenticatedUser(page);
 
   await page.route("**/api/memory/dashboard**", async (route) => {
@@ -78,18 +78,58 @@ test("Memory Dashboard Retrieval Metrics 折叠面板", async ({ page }) => {
     });
   });
 
+  // Mock user list + retrieval metrics
+  await page.route("**/api/memory**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/api/memory/dashboard")) return;
+    if (url.includes("/api/memory/retrieval/metrics")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          total_retrievals: 128,
+          precision_at_k: 0.72,
+          utilization_rate: 0.55,
+          noise_rate: 0.18,
+        }),
+      });
+      return;
+    }
+    // Default: user list for pill buttons
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        users: [
+          { id: "user-1", label: "Alice", count: 5 },
+          { id: "user-2", label: "Bob", count: 3 },
+        ],
+        timeline: [],
+        policies: {},
+      }),
+    });
+  });
+
   await page.goto("/dashboard");
 
   // Memory CellGroup label 应可见
   await expect(page.getByText("Memory", { exact: true }).first()).toBeVisible();
 
-  // 展开 Memory 详情面板
-  await page.getByText("Memory 详情").click();
+  // Retrieval Metrics 卡片标题始终可见
+  await expect(
+    page.getByRole("heading", { name: "Retrieval Metrics" }),
+  ).toBeVisible();
 
-  // 点击展开 Retrieval Metrics
-  await page.getByText("Retrieval Metrics").click();
-  // 未筛选用户时，显示提示
-  await expect(page.getByText("Filter by a User ID")).toBeVisible();
+  // "All Users" pill 默认选中
+  await expect(
+    page.getByRole("button", { name: "All Users" }),
+  ).toBeVisible();
+
+  // 指标网格加载后应显示
+  await expect(page.getByText("128")).toBeVisible();
+  await expect(page.getByText("72.0%")).toBeVisible();
+  await expect(page.getByText("55.0%")).toBeVisible();
+  await expect(page.getByText("18.0%")).toBeVisible();
 });
 
 // ============================================================================

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/retrieval_tracker.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/retrieval_tracker.py
@@ -161,7 +161,7 @@ class RetrievalTracker:
     async def get_effectiveness_metrics(
         self,
         *,
-        user_id: str,
+        user_id: str | None,
         app_name: str,
         days: int = 30,
     ) -> dict[str, float | int]:
@@ -179,9 +179,9 @@ class RetrievalTracker:
                     "with_feedback"
                 ),
             ).where(
-                MemoryRetrievalLog.user_id == user_id,
                 MemoryRetrievalLog.app_name == app_name,
                 MemoryRetrievalLog.created_at >= since,
+                *([MemoryRetrievalLog.user_id == user_id] if user_id else []),
             )
             result = await db.execute(stmt)
             row = result.one()

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -873,7 +873,7 @@ async def submit_retrieval_feedback(
 
 @router.get("/retrieval/metrics", response_model=RetrievalMetricsResponse)
 async def get_retrieval_metrics(
-    user_id: str = Query(..., description="用户 ID"),
+    user_id: str | None = Query(default=None, description="用户 ID（null=聚合全部用户）"),
     app_name: str | None = Query(default=None, description="应用名称"),
     days: int = Query(default=30, ge=1, le=365, description="统计时间窗口（天）"),
     user: AuthUser = Depends(get_current_user),


### PR DESCRIPTION
# 背景
- 原 Retrieval Metrics 嵌套在 MemoryDetailPanel 可折叠区域内，需要先选中用户才能查看，无法一眼看到全局聚合指标，交互路径过深。
- 关联上下文：Dashboard 检索效果指标可视化优化。

# 核心变更
- **提取独立组件**：将 Retrieval Metrics 从 `MemoryDetailPanel` 中抽离为独立紧凑卡片 `RetrievalMetricsCard`，直接内嵌在 Dashboard 主面板中，无需展开即可查看。
- **用户 Pill 过滤**：新增用户列表 Pill 按钮，支持按单用户过滤，默认"All Users"聚合展示全部用户指标。
- **时间窗口选择器**：新增 7d / 14d / 30d / 90d 时间窗口下拉选择器。
- **后端聚合支持**：`user_id` 参数改为可选（`str | None`），后端 `retrieval_tracker` 条件过滤，前端 `fetchRetrievalMetrics` 同步适配。
- **竞态条件修复**：添加 `fetchSeq` ref 计数器，筛选条件快速切换时丢弃过期 API 响应，防止旧数据覆盖新数据。

# 风险与回滚
- 主要风险：后端 `user_id` 从必填改为可选，需确认无其他调用方依赖其必填语义。
- 回滚方式：`git revert` 两个 commit 即可。

# 验证证据
- 单元测试：N/A（UI 组件变更）
- 集成测试：N/A
- E2E/Workflow：ESLint / Pre-commit hooks 通过
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：`MemoryDetailPanel`（删除 Retrieval Metrics 相关代码）、新增 `RetrievalMetricsCard` 组件、`page.tsx` 集成、`memory-api.ts` 参数调整
- 后端：`api.py`（`get_retrieval_metrics` 端点 `user_id` 改为可选）、`retrieval_tracker.py`（条件过滤）
- GitHub Actions / 文档：无

# Next Best Action
- 验证其他调用方是否依赖 `user_id` 必填语义，必要时补充集成测试覆盖 All Users 聚合场景。