### PR TITLE
refactor(memory): 统一 Timeline/Facts/Audit/Conflicts 四页面 UI 设计，Pill 过滤器 + 语义化色值 + 侧边栏布局组件化

### DIFF
--- a/apps/negentropy-ui/app/memory/audit/page.tsx
+++ b/apps/negentropy-ui/app/memory/audit/page.tsx
@@ -9,7 +9,9 @@ import {
   useMemoryTimeline,
   submitAudit,
   fetchAuditHistory,
-  MemoryUserSelect,
+  MemoryUserPillFilter,
+  MemorySidebarLayout,
+  SidebarCard,
 } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -42,7 +44,6 @@ export default function MemoryAuditPage() {
   const users = payload?.users || [];
   const timeline = useMemo(() => payload?.timeline || [], [payload?.timeline]);
 
-  // D1: 选中用户后自动加载历史审计记录
   useEffect(() => {
     if (!selectedUserId) return;
 
@@ -55,7 +56,6 @@ export default function MemoryAuditPage() {
           setAuditHistory(data.items);
         }
       } catch (err) {
-        // 审计历史加载失败不阻塞主功能
         console.error("Failed to load audit history:", err);
       }
     };
@@ -96,170 +96,151 @@ export default function MemoryAuditPage() {
   };
 
   return (
-    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+    <div className="flex h-full flex-col bg-background">
       <MemoryNav
         title="Audit"
         description="记忆审计治理 (Retain / Delete / Anonymize)"
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
-          {/* D5: 统一 error banner（独立块，避免被 flex-row 兄弟挤占侧边栏空间） */}
-          {/* M3: 5xx 等可重试错误暴露"重试"按钮，复用 RetryableErrorBanner */}
           <RetryableErrorBanner error={timelineError} onRetry={reloadTimeline} />
 
+          <MemorySidebarLayout
+            sidebar={
+              <>
+                <SidebarCard title="Submit Audit">
+                  <p className="mt-2 text-[11px] text-muted">
+                    {`${pendingCount} decision${pendingCount !== 1 ? "s" : ""} pending`}
+                  </p>
+                  <textarea
+                    className="mt-3 w-full rounded-lg border border-border bg-background px-2 py-1 text-xs"
+                    rows={3}
+                    placeholder="Audit note (optional)"
+                    value={auditNote}
+                    onChange={(e) => setAuditNote(e.target.value)}
+                  />
+                  <button
+                    className="mt-3 w-full rounded-lg bg-foreground px-3 py-2 text-xs font-semibold text-background disabled:opacity-40"
+                    disabled={!selectedUserId || pendingCount === 0}
+                    onClick={handleSubmitAudit}
+                  >
+                    Submit ({pendingCount})
+                  </button>
+                  {auditStatus && (
+                    <p className="mt-2 text-[11px] text-muted">{auditStatus}</p>
+                  )}
+                </SidebarCard>
 
-          <div className="flex min-h-0 flex-1 gap-6">
-          {/* Main: Memories with audit actions */}
-          <main className="min-h-0 min-w-0 flex-[3] overflow-y-auto">
-            <div className="pb-4 pr-2">
-              <div className="mb-4 flex items-center gap-3">
-                <MemoryUserSelect
-                  users={users}
-                  selectedUserId={selectedUserId}
-                  onSelect={(id) => {
-                    setSelectedUserId(id);
-                    setAuditMap({});
-                  }}
-                  loading={timelineLoading}
-                />
-              </div>
-              <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                    Memory Audit
-                  </h2>
-                  <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                    {selectedUserId || "select a user"}
-                  </span>
-                </div>
-                <div className="mt-4 space-y-3">
-                  {filteredTimeline.length ? (
-                    filteredTimeline.map((item) => (
-                      <div key={item.id}>
-                        <MemoryTimelineCard item={item} />
-                        <div className="mt-1 flex flex-wrap items-center gap-2 rounded-lg bg-zinc-50 px-2.5 py-2 text-[11px] dark:bg-zinc-800/50">
-                          {(["retain", "delete", "anonymize"] as AuditAction[]).map(
-                            (action) => (
-                              <button
-                                key={action}
-                                className={`rounded-full border px-3 py-1 transition-colors ${
-                                  auditMap[item.id] === action
-                                    ? action === "delete"
-                                      ? "border-rose-600 bg-rose-600 text-white"
-                                      : action === "anonymize"
-                                        ? "border-amber-600 bg-amber-600 text-white"
-                                        : "border-zinc-900 bg-zinc-900 text-white dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100"
-                                    : "border-zinc-200 text-zinc-600 hover:border-zinc-400 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500"
-                                }`}
-                                onClick={() =>
-                                  setAuditMap((prev) => ({
-                                    ...prev,
-                                    [item.id]: action,
-                                  }))
-                                }
-                              >
-                                {action}
-                              </button>
-                            ),
+                <SidebarCard title="Recent Audits">
+                  {auditHistory.length ? (
+                    <div className="mt-3 space-y-2 text-xs text-muted">
+                      {auditHistory.slice(0, 10).map((record, i) => (
+                        <div
+                          key={`${record.memory_id}-${i}`}
+                          className="rounded-lg border border-border p-2"
+                        >
+                          <p className="font-medium text-foreground">
+                            {record.memory_id.slice(0, 8)}... → {record.decision}
+                          </p>
+                          {record.note && (
+                            <p className="mt-1 text-[11px] text-muted">
+                              {record.note}
+                            </p>
                           )}
-                          {auditMap[item.id] && (
-                            <button
-                              className="rounded-full border border-zinc-200 px-3 py-1 text-zinc-400 hover:text-zinc-600 dark:border-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-300"
-                              onClick={() =>
-                                setAuditMap((prev) => {
-                                  const next = { ...prev };
-                                  delete next[item.id];
-                                  return next;
-                                })
-                              }
-                            >
-                              clear
-                            </button>
-                          )}
+                          <p className="mt-1 text-[11px] text-muted">
+                            v{record.version} · {record.created_at || "-"}
+                          </p>
                         </div>
-                      </div>
-                    ))
+                      ))}
+                    </div>
                   ) : (
-                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {timelineLoading
-                        ? "Loading memories..."
-                        : "No memories found for this user"}
+                    <p className="mt-3 text-xs text-muted">
+                      {selectedUserId ? "No audits yet" : "Select a user to view audit history"}
                     </p>
                   )}
-                </div>
-              </div>
+                </SidebarCard>
+              </>
+            }
+          >
+            {/* User filter */}
+            <div className="mb-4">
+              <MemoryUserPillFilter
+                users={users}
+                activeUserId={selectedUserId}
+                onSelect={(id) => {
+                  setSelectedUserId(id);
+                  setAuditMap({});
+                }}
+                loading={timelineLoading}
+              />
             </div>
-          </main>
 
-          {/* Audit controls sidebar */}
-          <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-            <div className="space-y-4 pb-4 pr-2">
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                  Submit Audit
+            <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xs font-semibold text-foreground">
+                  Memory Audit
                 </h2>
-                <p className="mt-2 text-[11px] text-zinc-500 dark:text-zinc-400">
-                  {/* 把 `(s)` 升级为真正的英文复数，避免界面出现 "0 decision(s) pending" 这类
-                      非自然写法。这里没有 JSX 表达式插入造成的 a11y 文本节点合并问题，仅是 copy 改进。 */}
-                  {`${pendingCount} decision${pendingCount !== 1 ? "s" : ""} pending`}
-                </p>
-                <textarea
-                  className="mt-3 w-full rounded border border-zinc-200 bg-white px-2 py-1 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                  rows={3}
-                  placeholder="Audit note (optional)"
-                  value={auditNote}
-                  onChange={(e) => setAuditNote(e.target.value)}
-                />
-                <button
-                  className="mt-3 w-full rounded bg-zinc-900 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40 dark:bg-zinc-800 dark:text-zinc-100"
-                  disabled={!selectedUserId || pendingCount === 0}
-                  onClick={handleSubmitAudit}
-                >
-                  Submit ({pendingCount})
-                </button>
-                {auditStatus && (
-                  <p className="mt-2 text-[11px] text-zinc-500 dark:text-zinc-400">{auditStatus}</p>
-                )}
+                <span className="text-xs text-muted">
+                  {selectedUserId || "select a user"}
+                </span>
               </div>
-
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                  Recent Audits
-                </h2>
-                {auditHistory.length ? (
-                  <div className="mt-3 space-y-2 text-xs text-zinc-600 dark:text-zinc-400">
-                    {auditHistory.slice(0, 10).map((record, i) => (
-                      <div
-                        key={`${record.memory_id}-${i}`}
-                        className="rounded-lg border border-zinc-200 p-2 dark:border-zinc-700"
-                      >
-                        <p className="font-medium">
-                          {record.memory_id.slice(0, 8)}... → {record.decision}
-                        </p>
-                        {record.note && (
-                          <p className="mt-1 text-[11px] text-zinc-400 dark:text-zinc-500">
-                            {record.note}
-                          </p>
+              <div className="mt-4 space-y-3">
+                {filteredTimeline.length ? (
+                  filteredTimeline.map((item) => (
+                    <div key={item.id}>
+                      <MemoryTimelineCard item={item} />
+                      <div className="mt-1 flex flex-wrap items-center gap-2 rounded-lg bg-muted/30 px-2.5 py-2 text-[11px]">
+                        {(["retain", "delete", "anonymize"] as AuditAction[]).map(
+                          (action) => (
+                            <button
+                              key={action}
+                              className={`rounded-full border px-3 py-1 transition-colors ${
+                                auditMap[item.id] === action
+                                  ? action === "delete"
+                                    ? "border-rose-600 bg-rose-600 text-white"
+                                    : action === "anonymize"
+                                      ? "border-amber-600 bg-amber-600 text-white"
+                                      : "border-foreground bg-foreground text-background"
+                                  : "border-border text-muted hover:border-foreground/30 hover:text-foreground"
+                              }`}
+                              onClick={() =>
+                                setAuditMap((prev) => ({
+                                  ...prev,
+                                  [item.id]: action,
+                                }))
+                              }
+                            >
+                              {action}
+                            </button>
+                          ),
                         )}
-                        <p className="mt-1 text-[11px] text-zinc-400 dark:text-zinc-500">
-                          v{record.version} · {record.created_at || "-"}
-                        </p>
+                        {auditMap[item.id] && (
+                          <button
+                            className="rounded-full border border-border px-3 py-1 text-muted hover:text-foreground"
+                            onClick={() =>
+                              setAuditMap((prev) => {
+                                const next = { ...prev };
+                                delete next[item.id];
+                                return next;
+                              })
+                            }
+                          >
+                            clear
+                          </button>
+                        )}
                       </div>
-                    ))}
-                  </div>
+                    </div>
+                  ))
                 ) : (
-                  <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
-                    {selectedUserId ? "No audits yet" : "Select a user to view audit history"}
+                  <p className="text-xs text-muted">
+                    {timelineLoading
+                      ? "Loading memories..."
+                      : "No memories found for this user"}
                   </p>
                 )}
               </div>
-
-              <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-500 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-                Status: {payload ? "loaded" : "loading"}
-              </div>
             </div>
-          </aside>
-          </div>
+          </MemorySidebarLayout>
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/app/memory/conflicts/page.tsx
+++ b/apps/negentropy-ui/app/memory/conflicts/page.tsx
@@ -15,7 +15,9 @@ import {
   fetchConflicts,
   fetchMemories,
   resolveConflict,
-  MemoryUserSelect,
+  MemoryUserPillFilter,
+  MemorySidebarLayout,
+  SidebarCard,
 } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -96,24 +98,104 @@ export default function MemoryConflictsPage() {
   const selected = conflicts.find((c) => c.id === selectedId);
 
   return (
-    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+    <div className="flex h-full flex-col bg-background">
       <MemoryNav title="Conflicts" description="事实冲突检视与解决" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-          <div className="pb-6">
+        <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
+          <MemorySidebarLayout
+            sidebar={
+              <SidebarCard title="Conflict Detail">
+                {selected ? (
+                  <div className="mt-4 space-y-3 text-xs">
+                    <div>
+                      <p className="text-[11px] uppercase tracking-wide text-muted">
+                        Type
+                      </p>
+                      <p className="mt-1 font-medium text-foreground">
+                        {selected.conflict_type}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-[11px] uppercase tracking-wide text-muted">
+                        Detected By
+                      </p>
+                      <p className="mt-1 text-foreground">
+                        {selected.detected_by}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-[11px] uppercase tracking-wide text-muted">
+                        Current Resolution
+                      </p>
+                      <span
+                        className={`mt-1 inline-block rounded-full border px-2 py-0.5 text-[10px] ${
+                          RESOLUTION_COLORS[selected.resolution] || RESOLUTION_COLORS.pending
+                        }`}
+                      >
+                        {selected.resolution}
+                      </span>
+                    </div>
+                    {selected.old_fact_id && (
+                      <div>
+                        <p className="text-[11px] uppercase tracking-wide text-muted">
+                          Old Fact
+                        </p>
+                        <p className="mt-1 font-mono text-[11px] text-muted">
+                          {selected.old_fact_id}
+                        </p>
+                      </div>
+                    )}
+                    {selected.new_fact_id && (
+                      <div>
+                        <p className="text-[11px] uppercase tracking-wide text-muted">
+                          New Fact
+                        </p>
+                        <p className="mt-1 font-mono text-[11px] text-muted">
+                          {selected.new_fact_id}
+                        </p>
+                      </div>
+                    )}
+
+                    {selected.resolution === "pending" && (
+                      <div className="mt-4 space-y-2">
+                        <p className="text-[11px] uppercase tracking-wide text-muted">
+                          Resolve
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {["supersede", "keep_old", "keep_new", "merge"].map((action) => (
+                            <button
+                              key={action}
+                              className="rounded-full border border-border px-3 py-1 text-[11px] text-muted transition-colors hover:border-foreground/30 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                              disabled={resolveStatus === "resolving"}
+                              onClick={() => handleResolve(selected.id, action)}
+                            >
+                              {action}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <p className="mt-4 text-xs text-muted">
+                    Select a conflict to view details.
+                  </p>
+                )}
+              </SidebarCard>
+            }
+          >
             {/* Controls */}
-            <div className="mb-6 flex items-center gap-3">
-              <MemoryUserSelect
+            <div className="mb-4 flex items-center gap-3">
+              <MemoryUserPillFilter
                 users={users}
-                selectedUserId={activeUserId}
+                activeUserId={activeUserId}
                 onSelect={setActiveUserId}
                 loading={usersLoading}
-                allLabel="All Users"
               />
-              <div className="h-4 w-px bg-zinc-200 mx-1 dark:bg-zinc-700" />
+              <div className="h-4 w-px bg-border mx-1" />
               <select
                 aria-label="Filter by resolution"
-                className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-800"
+                className="rounded-lg border border-border bg-background px-3 py-2 text-xs"
                 value={resolutionFilter}
                 onChange={(e) => setResolutionFilter(e.target.value)}
               >
@@ -140,144 +222,56 @@ export default function MemoryConflictsPage() {
             )}
 
             {resolveStatus && (
-              <div className="mb-4 rounded-2xl border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400">
+              <div className="mb-4 rounded-2xl border border-border bg-muted/30 p-3 text-xs text-muted">
                 {resolveStatus}
               </div>
             )}
 
             {isLoading ? (
-              <p className="text-xs text-zinc-500 dark:text-zinc-400">Loading conflicts...</p>
+              <p className="text-xs text-muted">Loading conflicts...</p>
             ) : conflicts.length === 0 ? (
-              <div className="rounded-2xl border border-zinc-200 bg-white p-10 text-center shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">No conflicts found.</p>
+              <div className="rounded-2xl border border-border bg-card p-10 text-center shadow-sm">
+                <p className="text-sm text-muted">No conflicts found.</p>
               </div>
             ) : (
-              <div className="flex gap-6">
-                {/* Conflict list */}
-                <div className="min-w-0 flex-[2] space-y-3">
-                  {conflicts.map((c) => (
-                    <button
-                      key={c.id}
-                      className={`w-full rounded-lg border p-3 text-left text-xs transition-colors ${
-                        selectedId === c.id
-                          ? "border-zinc-900 bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800"
-                          : "border-zinc-200 bg-white hover:border-zinc-400 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:border-zinc-500"
-                      }`}
-                      onClick={() => setSelectedId(c.id)}
-                    >
-                      <div className="flex items-start justify-between">
-                        <div className="space-y-1">
-                          <p className="font-medium text-zinc-900 dark:text-zinc-100">
-                            {c.conflict_type}
-                          </p>
-                          <p className="text-[11px] text-zinc-500 dark:text-zinc-400">
-                            by {c.detected_by} · user {c.user_id.slice(0, 8)}...
-                          </p>
-                        </div>
-                        <span
-                          className={`rounded-full border px-2 py-0.5 text-[10px] ${
-                            RESOLUTION_COLORS[c.resolution] || RESOLUTION_COLORS.pending
-                          }`}
-                        >
-                          {c.resolution}
-                        </span>
+              <div className="space-y-3">
+                {conflicts.map((c) => (
+                  <button
+                    key={c.id}
+                    className={`w-full rounded-lg border p-3 text-left text-xs transition-colors ${
+                      selectedId === c.id
+                        ? "border-foreground/30 bg-muted/20"
+                        : "border-border bg-card hover:border-foreground/20"
+                    }`}
+                    onClick={() => setSelectedId(c.id)}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="space-y-1">
+                        <p className="font-medium text-foreground">
+                          {c.conflict_type}
+                        </p>
+                        <p className="text-[11px] text-muted">
+                          by {c.detected_by} · user {c.user_id.slice(0, 8)}...
+                        </p>
                       </div>
-                      <div className="mt-2 flex gap-3 text-[11px] text-zinc-400 dark:text-zinc-500">
-                        {c.old_fact_id && <span>Old: {c.old_fact_id.slice(0, 8)}...</span>}
-                        {c.new_fact_id && <span>New: {c.new_fact_id.slice(0, 8)}...</span>}
-                        <span>{c.created_at || "-"}</span>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-
-                {/* Detail panel */}
-                <aside className="min-w-0 flex-1">
-                  <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                    <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                      Conflict Detail
-                    </h2>
-                    {selected ? (
-                      <div className="mt-4 space-y-3 text-xs">
-                        <div>
-                          <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                            Type
-                          </p>
-                          <p className="mt-1 font-medium text-zinc-900 dark:text-zinc-100">
-                            {selected.conflict_type}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                            Detected By
-                          </p>
-                          <p className="mt-1 text-zinc-900 dark:text-zinc-100">
-                            {selected.detected_by}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                            Current Resolution
-                          </p>
-                          <span
-                            className={`mt-1 inline-block rounded-full border px-2 py-0.5 text-[10px] ${
-                              RESOLUTION_COLORS[selected.resolution] || RESOLUTION_COLORS.pending
-                            }`}
-                          >
-                            {selected.resolution}
-                          </span>
-                        </div>
-                        {selected.old_fact_id && (
-                          <div>
-                            <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                              Old Fact
-                            </p>
-                            <p className="mt-1 font-mono text-[11px] text-zinc-600 dark:text-zinc-400">
-                              {selected.old_fact_id}
-                            </p>
-                          </div>
-                        )}
-                        {selected.new_fact_id && (
-                          <div>
-                            <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                              New Fact
-                            </p>
-                            <p className="mt-1 font-mono text-[11px] text-zinc-600 dark:text-zinc-400">
-                              {selected.new_fact_id}
-                            </p>
-                          </div>
-                        )}
-
-                        {selected.resolution === "pending" && (
-                          <div className="mt-4 space-y-2">
-                            <p className="text-[11px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                              Resolve
-                            </p>
-                            <div className="flex flex-wrap gap-2">
-                              {["supersede", "keep_old", "keep_new", "merge"].map((action) => (
-                                <button
-                                  key={action}
-                                  className="rounded-full border border-zinc-200 px-3 py-1 text-[11px] text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-zinc-200 disabled:hover:text-zinc-600 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100 dark:disabled:hover:border-zinc-700 dark:disabled:hover:text-zinc-400"
-                                  disabled={resolveStatus === "resolving"}
-                                  onClick={() => handleResolve(selected.id, action)}
-                                >
-                                  {action}
-                                </button>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">
-                        Select a conflict to view details.
-                      </p>
-                    )}
-                  </div>
-                </aside>
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[10px] ${
+                          RESOLUTION_COLORS[c.resolution] || RESOLUTION_COLORS.pending
+                        }`}
+                      >
+                        {c.resolution}
+                      </span>
+                    </div>
+                    <div className="mt-2 flex gap-3 text-[11px] text-muted">
+                      {c.old_fact_id && <span>Old: {c.old_fact_id.slice(0, 8)}...</span>}
+                      {c.new_fact_id && <span>New: {c.new_fact_id.slice(0, 8)}...</span>}
+                      <span>{c.created_at || "-"}</span>
+                    </div>
+                  </button>
+                ))}
               </div>
             )}
-          </div>
+          </MemorySidebarLayout>
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -17,7 +17,10 @@ import {
   searchFacts,
   fetchFactHistory,
   fetchMemories,
-  MemoryUserSelect,
+  MemoryUserPillFilter,
+  MemorySidebarLayout,
+  SidebarCard,
+  LegendCard,
 } from "@/features/memory";
 
 import { FactCard } from "./_components/FactCard";
@@ -110,7 +113,6 @@ export default function MemoryFactsPage() {
     setHistoryError(null);
   }, []);
 
-  // Esc 关闭模态：仅在打开期间监听，避免无谓全局键盘开销。
   useEffect(() => {
     if (!historyFactId) return;
     const onKeyDown = (e: KeyboardEvent) => {
@@ -124,25 +126,66 @@ export default function MemoryFactsPage() {
   }, [historyFactId, handleCloseHistory]);
 
   return (
-    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+    <div className="flex h-full flex-col bg-background">
       <MemoryNav title="Facts" description="语义记忆管理 (结构化 KV)" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6">
-          <div className="pb-6">
-            {/* User selection */}
-            <div className="flex items-center gap-3 mb-6">
-              <MemoryUserSelect
+        <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
+          <MemorySidebarLayout
+            sidebar={
+              <>
+                <SidebarCard title="Facts Overview">
+                  <p className="mt-2 text-[11px] text-muted">
+                    {activeUserId
+                      ? `${facts.length} facts for selected user`
+                      : `${users.length} users with facts`}
+                  </p>
+                  {!activeUserId && users.length > 0 && (
+                    <div className="mt-3 space-y-1.5">
+                      {users.slice(0, 8).map((u) => (
+                        <button
+                          key={u.id}
+                          className="flex w-full items-center justify-between rounded-lg border border-border px-2.5 py-1.5 text-[11px] text-muted transition-colors hover:border-foreground/20 hover:text-foreground"
+                          onClick={() => setActiveUserId(u.id)}
+                        >
+                          <span className="truncate">{u.label || u.id}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </SidebarCard>
+                <LegendCard />
+              </>
+            }
+          >
+            {/* User filter */}
+            <div className="mb-4">
+              <MemoryUserPillFilter
                 users={users}
-                selectedUserId={activeUserId}
-                onSelect={(id) => id && setActiveUserId(id)}
+                activeUserId={activeUserId}
+                onSelect={setActiveUserId}
                 loading={usersLoading}
-                allowAll={false}
               />
-              {activeUserId && (
-                <>
-                  <div className="h-4 w-px bg-zinc-200 mx-1 dark:bg-zinc-700" />
+            </div>
+
+            {error && (
+              <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
+                {error?.message || String(error)}
+              </div>
+            )}
+
+            {!activeUserId ? (
+              /* All Users summary: prompt to select a user */
+              <div className="rounded-2xl border border-border bg-card p-10 text-center shadow-sm">
+                <p className="text-sm text-muted">
+                  Select a user from the filter above or sidebar to view their semantic facts.
+                </p>
+              </div>
+            ) : (
+              <>
+                {/* Search bar */}
+                <div className="mb-4 flex items-center gap-2">
                   <input
-                    className="rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs w-48 dark:border-zinc-700 dark:bg-zinc-800"
+                    className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-xs"
                     placeholder="Search facts..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
@@ -160,40 +203,28 @@ export default function MemoryFactsPage() {
                   >
                     Clear
                   </button>
-                </>
-              )}
-            </div>
+                </div>
 
-            {error && (
-              <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
-                {error?.message || String(error)}
-              </div>
+                {isLoading ? (
+                  <p className="text-xs text-muted">Loading facts...</p>
+                ) : facts.length === 0 ? (
+                  <div className="rounded-2xl border border-border bg-card p-10 text-center shadow-sm">
+                    <p className="text-sm text-muted">No facts found for this user.</p>
+                  </div>
+                ) : (
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {facts.map((fact) => (
+                      <FactCard
+                        key={fact.id}
+                        fact={fact}
+                        onShowHistory={handleShowHistory}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
             )}
-
-            {!activeUserId ? (
-              <div className="rounded-2xl border border-zinc-200 bg-white p-10 text-center shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">
-                  选择一个用户以查看其语义记忆 (Facts)。
-                </p>
-              </div>
-            ) : isLoading ? (
-              <p className="text-xs text-zinc-500 dark:text-zinc-400">Loading facts...</p>
-            ) : facts.length === 0 ? (
-              <div className="rounded-2xl border border-zinc-200 bg-white p-10 text-center shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                <p className="text-sm text-zinc-500 dark:text-zinc-400">No facts found for this user.</p>
-              </div>
-            ) : (
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {facts.map((fact) => (
-                  <FactCard
-                    key={fact.id}
-                    fact={fact}
-                    onShowHistory={handleShowHistory}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+          </MemorySidebarLayout>
         </div>
       </div>
 
@@ -205,33 +236,33 @@ export default function MemoryFactsPage() {
           role="presentation"
         >
           <div
-            className="w-full max-w-lg rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-700 dark:bg-zinc-900"
+            className="w-full max-w-lg rounded-2xl border border-border bg-card p-6 shadow-xl"
             onClick={(e) => e.stopPropagation()}
             role="dialog"
             aria-modal="true"
             aria-labelledby="fact-history-title"
           >
             <div className="flex items-center justify-between">
-              <h3 id="fact-history-title" className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              <h3 id="fact-history-title" className="text-sm font-semibold text-foreground">
                 Fact Version History
               </h3>
               <button
-                className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+                className="text-xs text-muted hover:text-foreground"
                 onClick={handleCloseHistory}
               >
                 Close
               </button>
             </div>
-            <p className="mt-1 text-[11px] font-mono text-zinc-500 dark:text-zinc-400">
+            <p className="mt-1 text-[11px] font-mono text-muted">
               {historyFactId}
             </p>
 
             {historyLoading ? (
-              <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">Loading history...</p>
+              <p className="mt-4 text-xs text-muted">Loading history...</p>
             ) : historyError ? (
               <p className="mt-4 text-xs text-rose-600">{historyError}</p>
             ) : historyItems.length === 0 ? (
-              <p className="mt-4 text-xs text-zinc-500 dark:text-zinc-400">No history available.</p>
+              <p className="mt-4 text-xs text-muted">No history available.</p>
             ) : (
               <div className="mt-4 max-h-72 space-y-3 overflow-y-auto">
                 {historyItems.map((item, i) => (
@@ -239,26 +270,26 @@ export default function MemoryFactsPage() {
                     key={item.id}
                     className={`rounded-lg border p-3 text-xs ${
                       i === 0
-                        ? "border-zinc-900 bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800"
-                        : "border-zinc-200 dark:border-zinc-700"
+                        ? "border-foreground/20 bg-muted/20"
+                        : "border-border"
                     }`}
                   >
                     <div className="flex items-start justify-between">
-                      <p className="font-medium text-zinc-900 dark:text-zinc-100">{item.key}</p>
+                      <p className="font-medium text-foreground">{item.key}</p>
                       <span
                         className={`rounded-full border px-2 py-0.5 text-[10px] ${
                           item.status === "active"
                             ? "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300"
-                            : "border-zinc-200 bg-zinc-50 text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-400"
+                            : "border-border bg-muted/30 text-muted"
                         }`}
                       >
                         {item.status}
                       </span>
                     </div>
-                    <pre className="mt-2 max-h-20 overflow-auto rounded bg-zinc-50 p-2 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+                    <pre className="mt-2 max-h-20 overflow-auto rounded-lg bg-muted/30 p-2 text-[11px] text-muted">
                       {JSON.stringify(item.value, null, 2)}
                     </pre>
-                    <div className="mt-2 flex gap-3 text-[11px] text-zinc-400 dark:text-zinc-500">
+                    <div className="mt-2 flex gap-3 text-[11px] text-muted">
                       <span>Confidence: {(item.confidence * 100).toFixed(0)}%</span>
                       {item.superseded_by && (
                         <span>Superseded by: {item.superseded_by.slice(0, 8)}...</span>

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -153,16 +153,13 @@ export default function MemoryTimelinePage() {
                   {searchResult ? "Search Results" : "Memory Timeline"}
                 </h2>
                 <span className="text-xs text-muted">
+                  {displayItems.length} memories ·{" "}
                   {selectedUserId
                     ? users.find((u) => u.id === selectedUserId)?.name || selectedUserId
                     : "all users"}
                   {searchResult && ` · ${searchResult.count} result(s)`}
                 </span>
               </div>
-
-              <span className="text-xs text-muted">
-                {displayItems.length} memories
-              </span>
 
               {/* Search */}
               {selectedUserId && (

--- a/apps/negentropy-ui/app/memory/timeline/page.tsx
+++ b/apps/negentropy-ui/app/memory/timeline/page.tsx
@@ -8,7 +8,10 @@ import {
   RetryableErrorBanner,
   useMemoryTimeline,
   MemoryTimelineCard,
-  MemoryUserSelect,
+  MemoryUserPillFilter,
+  MemorySidebarLayout,
+  RetentionPolicyCard,
+  LegendCard,
 } from "@/features/memory";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -88,7 +91,6 @@ export default function MemoryTimelinePage() {
     return timeline.filter((item) => item.user_id === selectedUserId);
   }, [timeline, selectedUserId]);
 
-  // D2: 搜索处理
   const handleSearch = () => {
     if (searchQuery.trim() && selectedUserId) {
       search(selectedUserId, searchQuery.trim());
@@ -100,7 +102,6 @@ export default function MemoryTimelinePage() {
     clearSearch();
   };
 
-  // D2: 当有搜索结果时，将 searchResult.items 映射为 timeline 兼容格式
   const displayItems = searchResult
     ? searchResult.items.map((item) => ({
         id: item.id,
@@ -119,197 +120,114 @@ export default function MemoryTimelinePage() {
   const groupedTimeline = useMemo(() => groupByDate(displayItems), [displayItems]);
 
   return (
-    <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
+    <div className="flex h-full flex-col bg-background">
       <MemoryNav title="Timeline" description="用户记忆时间线" />
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col px-6 py-6">
           <RetryableErrorBanner error={error} onRetry={reload} />
 
-          <div className="flex min-h-0 flex-1 gap-6">
-            {/* Timeline */}
-            <main className="min-h-0 min-w-0 flex-[3] overflow-y-auto">
-              <div className="pb-4 pr-2">
-                <div className="mb-4 flex items-center gap-3">
-                  <MemoryUserSelect
-                    users={users}
-                    selectedUserId={selectedUserId}
-                    onSelect={(id) => {
-                      setSelectedUserId(id);
-                      handleClearSearch();
-                    }}
-                    loading={isLoading}
+          <MemorySidebarLayout
+            sidebar={
+              <>
+                <RetentionPolicyCard policies={policies} />
+                <LegendCard />
+              </>
+            }
+          >
+            {/* User filter */}
+            <div className="mb-4">
+              <MemoryUserPillFilter
+                users={users}
+                activeUserId={selectedUserId}
+                onSelect={(id) => {
+                  setSelectedUserId(id);
+                  handleClearSearch();
+                }}
+                loading={isLoading}
+              />
+            </div>
+
+            <div className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xs font-semibold text-foreground">
+                  {searchResult ? "Search Results" : "Memory Timeline"}
+                </h2>
+                <span className="text-xs text-muted">
+                  {selectedUserId
+                    ? users.find((u) => u.id === selectedUserId)?.name || selectedUserId
+                    : "all users"}
+                  {searchResult && ` · ${searchResult.count} result(s)`}
+                </span>
+              </div>
+
+              <span className="text-xs text-muted">
+                {displayItems.length} memories
+              </span>
+
+              {/* Search */}
+              {selectedUserId && (
+                <div className="mt-3 flex items-center gap-2">
+                  <input
+                    className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-xs"
+                    placeholder="Search memories..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
                   />
-                  <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                    {displayItems.length} memories
-                  </span>
-                </div>
-                <div className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                  <div className="flex items-center justify-between">
-                    <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                      {searchResult ? "Search Results" : "Memory Timeline"}
-                    </h2>
-                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {selectedUserId
-                        ? users.find((u) => u.id === selectedUserId)?.name || selectedUserId
-                        : "all users"}
-                      {searchResult && ` · ${searchResult.count} result(s)`}
-                    </span>
-                  </div>
-
-                  {/* D2: 搜索框 */}
-                  {selectedUserId && (
-                    <div className="mt-3 flex items-center gap-2">
-                      <input
-                        className="flex-1 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-800"
-                        placeholder="Search memories..."
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-                      />
-                      <button
-                        className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
-                        onClick={handleSearch}
-                        disabled={!searchQuery.trim()}
-                      >
-                        Search
-                      </button>
-                      {searchResult && (
-                        <button
-                          className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
-                          onClick={handleClearSearch}
-                        >
-                          Clear
-                        </button>
-                      )}
-                    </div>
+                  <button
+                    className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                    onClick={handleSearch}
+                    disabled={!searchQuery.trim()}
+                  >
+                    Search
+                  </button>
+                  {searchResult && (
+                    <button
+                      className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                      onClick={handleClearSearch}
+                    >
+                      Clear
+                    </button>
                   )}
-
-                  <div className="mt-4 space-y-3">
-                    {displayItems.length ? (
-                      searchResult ? (
-                        // Flat list for search results
-                        displayItems.map((item) => (
-                          <MemoryTimelineCard
-                            key={item.id}
-                            item={item}
-                            isSearchResult
-                          />
-                        ))
-                      ) : (
-                        // Time-grouped list for timeline
-                        groupedTimeline.map((group) => (
-                          <div key={group.date}>
-                            <div className="sticky top-0 z-10 bg-white pb-1 pt-2 text-[11px] font-semibold text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400">
-                              {group.label}
-                            </div>
-                            <div className="space-y-2">
-                              {group.items.map((item) => (
-                                <MemoryTimelineCard key={item.id} item={item} />
-                              ))}
-                            </div>
-                          </div>
-                        ))
-                      )
-                    ) : (
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {isLoading
-                          ? "Loading memories..."
-                          : searchResult
-                            ? "No matching memories found"
-                            : "No memories found"}
-                      </p>
-                    )}
-                  </div>
                 </div>
+              )}
+
+              <div className="mt-4 space-y-3">
+                {displayItems.length ? (
+                  searchResult ? (
+                    displayItems.map((item) => (
+                      <MemoryTimelineCard
+                        key={item.id}
+                        item={item}
+                        isSearchResult
+                      />
+                    ))
+                  ) : (
+                    groupedTimeline.map((group) => (
+                      <div key={group.date}>
+                        <div className="sticky top-0 z-10 bg-card pb-1 pt-2 text-[11px] font-semibold text-muted">
+                          {group.label}
+                        </div>
+                        <div className="space-y-2">
+                          {group.items.map((item) => (
+                            <MemoryTimelineCard key={item.id} item={item} />
+                          ))}
+                        </div>
+                      </div>
+                    ))
+                  )
+                ) : (
+                  <p className="text-xs text-muted">
+                    {isLoading
+                      ? "Loading memories..."
+                      : searchResult
+                        ? "No matching memories found"
+                        : "No memories found"}
+                  </p>
+                )}
               </div>
-            </main>
-
-            {/* Policies & Legend sidebar */}
-            <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-              <div className="space-y-4 pb-4 pr-2">
-                <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                    Retention Policy
-                  </h2>
-                  <pre className="mt-3 max-h-48 overflow-auto rounded-lg bg-zinc-50 p-3 text-[11px] text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
-                    {JSON.stringify(policies, null, 2)}
-                  </pre>
-                </div>
-
-                {/* Legend */}
-                <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-                  <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Legend</h2>
-
-                  {/* Retention scores */}
-                  <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                    Retention
-                  </p>
-                  <div className="mt-1.5 space-y-1.5 text-[11px] text-zinc-600 dark:text-zinc-400">
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-emerald-500" />
-                      High retention (&ge; 50%)
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-amber-500" />
-                      Medium retention (10-50%)
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-rose-500" />
-                      Low retention (&lt; 10%)
-                    </div>
-                  </div>
-
-                  {/* Importance scores */}
-                  <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                    Importance
-                  </p>
-                  <div className="mt-1.5 space-y-1.5 text-[11px] text-zinc-600 dark:text-zinc-400">
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-blue-500" />
-                      High importance (&ge; 70%)
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-cyan-500" />
-                      Medium importance (40-70%)
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-slate-400" />
-                      Low importance (&lt; 40%)
-                    </div>
-                  </div>
-
-                  {/* Memory types */}
-                  <p className="mt-3 text-[10px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
-                    Memory Types
-                  </p>
-                  <div className="mt-1.5 space-y-1 text-[11px] text-zinc-600 dark:text-zinc-400">
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-violet-500" /> Core
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-blue-500" /> Semantic
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-amber-500" /> Episodic
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-emerald-500" /> Procedural
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-pink-500" /> Preference
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="h-2 w-2 rounded-full bg-cyan-500" /> Fact
-                    </div>
-                  </div>
-                </div>
-
-                <div className="rounded-2xl border border-zinc-200 bg-white p-5 text-xs text-zinc-500 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
-                  Status: {payload ? "loaded" : "loading"}
-                </div>
-              </div>
-            </aside>
-          </div>
+            </div>
+          </MemorySidebarLayout>
         </div>
       </div>
     </div>

--- a/apps/negentropy-ui/features/memory/components/LegendCard.tsx
+++ b/apps/negentropy-ui/features/memory/components/LegendCard.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { SidebarCard } from "./SidebarCard";
+
+export function LegendCard() {
+  return (
+    <SidebarCard title="Legend">
+      {/* Retention scores */}
+      <p className="mt-3 text-[10px] font-semibold uppercase tracking-widest text-muted">
+        Retention
+      </p>
+      <div className="mt-1.5 space-y-1.5 text-[11px] text-muted">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-emerald-500" />
+          High retention (&ge; 50%)
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-amber-500" />
+          Medium retention (10-50%)
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-rose-500" />
+          Low retention (&lt; 10%)
+        </div>
+      </div>
+
+      {/* Importance scores */}
+      <p className="mt-3 text-[10px] font-semibold uppercase tracking-widest text-muted">
+        Importance
+      </p>
+      <div className="mt-1.5 space-y-1.5 text-[11px] text-muted">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-blue-500" />
+          High importance (&ge; 70%)
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-cyan-500" />
+          Medium importance (40-70%)
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-slate-400" />
+          Low importance (&lt; 40%)
+        </div>
+      </div>
+
+      {/* Memory types */}
+      <p className="mt-3 text-[10px] font-semibold uppercase tracking-widest text-muted">
+        Memory Types
+      </p>
+      <div className="mt-1.5 space-y-1 text-[11px] text-muted">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-violet-500" /> Core
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-blue-500" /> Semantic
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-amber-500" /> Episodic
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-emerald-500" /> Procedural
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-pink-500" /> Preference
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-cyan-500" /> Fact
+        </div>
+      </div>
+    </SidebarCard>
+  );
+}

--- a/apps/negentropy-ui/features/memory/components/MemorySidebarLayout.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemorySidebarLayout.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+interface MemorySidebarLayoutProps {
+  children: React.ReactNode;
+  sidebar: React.ReactNode;
+}
+
+export function MemorySidebarLayout({
+  children,
+  sidebar,
+}: MemorySidebarLayoutProps) {
+  return (
+    <div className="flex min-h-0 flex-1 gap-6">
+      <main className="min-h-0 min-w-0 flex-[3] overflow-y-auto">
+        <div className="pb-4 pr-2">{children}</div>
+      </main>
+      <aside className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+        <div className="space-y-4 pb-4 pr-2">{sidebar}</div>
+      </aside>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/memory/components/MemoryUserPillFilter.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemoryUserPillFilter.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Pill button
+// ---------------------------------------------------------------------------
+
+function Pill({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full px-3 py-1 text-xs font-medium transition-colors cursor-pointer",
+        active
+          ? "bg-foreground text-background"
+          : "border border-border text-muted hover:text-foreground hover:border-foreground/30",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MemoryUserPillFilter
+// ---------------------------------------------------------------------------
+
+const MAX_VISIBLE_USERS = 10;
+
+interface MemoryUserPillFilterProps {
+  users: Array<{ id: string; label?: string; name?: string }>;
+  activeUserId: string | null;
+  onSelect: (userId: string | null) => void;
+  loading?: boolean;
+  maxVisible?: number;
+  allLabel?: string;
+}
+
+export function MemoryUserPillFilter({
+  users,
+  activeUserId,
+  onSelect,
+  loading,
+  maxVisible = MAX_VISIBLE_USERS,
+  allLabel = "All Users",
+}: MemoryUserPillFilterProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-7 w-16 animate-pulse rounded-full bg-muted/40"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const visibleUsers = users.slice(0, maxVisible);
+  const hiddenCount = users.length - maxVisible;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      <Pill active={activeUserId === null} onClick={() => onSelect(null)}>
+        {allLabel}
+      </Pill>
+      {visibleUsers.map((u) => (
+        <Pill
+          key={u.id}
+          active={activeUserId === u.id}
+          onClick={() => onSelect(u.id)}
+        >
+          {u.label || u.name || u.id}
+        </Pill>
+      ))}
+      {hiddenCount > 0 && (
+        <span className="rounded-full px-3 py-1 text-xs text-muted border border-dashed border-border">
+          +{hiddenCount} more
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/memory/components/MemoryUserSelect.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemoryUserSelect.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 
+/** @deprecated Use MemoryUserPillFilter instead */
 interface MemoryUserSelectProps {
   users: Array<{ id: string; label?: string; name?: string }>;
   selectedUserId: string | null;

--- a/apps/negentropy-ui/features/memory/components/RetentionPolicyCard.tsx
+++ b/apps/negentropy-ui/features/memory/components/RetentionPolicyCard.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { SidebarCard } from "./SidebarCard";
+
+interface RetentionPolicyCardProps {
+  policies: Record<string, unknown>;
+}
+
+export function RetentionPolicyCard({ policies }: RetentionPolicyCardProps) {
+  return (
+    <SidebarCard title="Retention Policy">
+      <pre className="mt-3 max-h-48 overflow-auto rounded-lg bg-muted/40 p-3 text-[11px] text-muted">
+        {JSON.stringify(policies, null, 2)}
+      </pre>
+    </SidebarCard>
+  );
+}

--- a/apps/negentropy-ui/features/memory/components/SidebarCard.tsx
+++ b/apps/negentropy-ui/features/memory/components/SidebarCard.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface SidebarCardProps {
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function SidebarCard({ title, children, className }: SidebarCardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-border bg-card p-5 shadow-sm",
+        className,
+      )}
+    >
+      <h2 className="text-xs font-semibold text-foreground">{title}</h2>
+      {children}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/features/memory/index.ts
+++ b/apps/negentropy-ui/features/memory/index.ts
@@ -48,6 +48,11 @@ export {
 } from "./components/RetryableErrorBanner";
 export { MemoryTimelineCard } from "./components/MemoryTimelineCard";
 export { MemoryUserSelect } from "./components/MemoryUserSelect";
+export { MemoryUserPillFilter } from "./components/MemoryUserPillFilter";
+export { MemorySidebarLayout } from "./components/MemorySidebarLayout";
+export { SidebarCard } from "./components/SidebarCard";
+export { RetentionPolicyCard } from "./components/RetentionPolicyCard";
+export { LegendCard } from "./components/LegendCard";
 export type {
   RetryableError,
   RetryableErrorBannerProps,

--- a/apps/negentropy-ui/tests/e2e/memory/audit.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/audit.spec.ts
@@ -79,7 +79,8 @@ test("Audit 选择用户后展示 timeline + history", async ({ page }) => {
   await setupAuditRoutes(page);
 
   await page.goto("/memory/audit");
-  await page.getByLabel("Filter by user").selectOption("user-1");
+  // Use Pill filter instead of select dropdown
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
 
   await expect(page.getByText("Standup at 10am Mon/Wed")).toBeVisible();
   await expect(page.getByText("earlier audit")).toBeVisible();
@@ -90,7 +91,7 @@ test("Audit 选择 retain 后 Submit 计数变 1", async ({ page }) => {
   await setupAuditRoutes(page);
 
   await page.goto("/memory/audit");
-  await page.getByLabel("Filter by user").selectOption("user-1");
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
   await expect(page.getByText("Standup at 10am Mon/Wed")).toBeVisible();
 
   await expect(page.getByRole("button", { name: /Submit \(0\)/ })).toBeDisabled();
@@ -128,7 +129,7 @@ test("Audit 提交 POST /api/memory/audit 含 decisions + idempotency_key", asyn
   });
 
   await page.goto("/memory/audit");
-  await page.getByLabel("Filter by user").selectOption("user-1");
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
   await page.getByRole("button", { name: "retain" }).click();
   await page.getByRole("button", { name: /Submit \(1\)/ }).click();
 
@@ -147,7 +148,7 @@ test("Audit 无 decision 时 Submit 禁用", async ({ page }) => {
   await setupAuditRoutes(page);
 
   await page.goto("/memory/audit");
-  await page.getByLabel("Filter by user").selectOption("user-1");
+  await page.getByRole("button", { name: "user-1 (1)" }).click();
   await expect(page.getByText("Standup at 10am Mon/Wed")).toBeVisible();
 
   await expect(page.getByRole("button", { name: /Submit \(0\)/ })).toBeDisabled();

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -73,9 +73,11 @@ test("Facts 初始展示用户选择提示", async ({ page }) => {
   await mockAuthenticatedUser(page);
   await mockMemoryUsers(page);
   await page.goto("/memory/facts");
-  await expect(page.locator("select")).toBeVisible();
+  // "All Users" pill is visible by default
+  await expect(page.getByRole("button", { name: "All Users" })).toBeVisible();
+  // Prompt to select a user is shown
   await expect(
-    page.getByText("选择一个用户以查看其语义记忆 (Facts)。"),
+    page.getByText("Select a user from the filter above or sidebar to view their semantic facts."),
   ).toBeVisible();
 });
 
@@ -95,7 +97,8 @@ test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {
   });
 
   await page.goto("/memory/facts");
-  await page.locator("select").selectOption("user-1");
+  // Pill filter always appears before sidebar user list
+  await page.getByRole("button", { name: "Test User 1" }).first().click();
 
   await expect(page.getByText("preferred_language")).toBeVisible();
   await expect(page.getByText("api_design")).toBeVisible();
@@ -130,7 +133,8 @@ test("Facts 搜索框过滤结果", async ({ page }) => {
   });
 
   await page.goto("/memory/facts");
-  await page.locator("select").selectOption("user-1");
+  // Scope to main area to avoid sidebar user list buttons
+  await page.getByRole("button", { name: "Test User 1" }).first().click();
   await expect(page.getByText("api_design")).toBeVisible();
 
   await page.getByPlaceholder("Search facts...").fill("language");
@@ -182,7 +186,8 @@ test("Facts History 模态展示 dialog ARIA + Esc 关闭", async ({ page }) => 
   });
 
   await page.goto("/memory/facts");
-  await page.locator("select").selectOption("user-1");
+  // Scope to main area to avoid sidebar user list buttons
+  await page.getByRole("button", { name: "Test User 1" }).first().click();
   await expect(page.getByText("preferred_language")).toBeVisible();
 
   await page.getByRole("button", { name: "History" }).first().click();
@@ -211,7 +216,7 @@ test("Facts 空结果展示 No facts found", async ({ page }) => {
   });
 
   await page.goto("/memory/facts");
-  await page.locator("select").selectOption("user-x");
+  await page.getByRole("button", { name: "Empty User" }).first().click();
 
   await expect(page.getByText("No facts found for this user.")).toBeVisible();
 });


### PR DESCRIPTION
# 背景

Memory 模块四个页面（Timeline、Facts、Audit、Conflicts）UI 长期各自独立演化，缺少统一的布局结构和视觉语言。用户选择器均使用传统 `<select>` 下拉框，交互不直观；硬编码 `zinc-*` 色值散布各处，主题切换维护成本高。

# 核心变更

**新增 5 个共享组件：**
- `MemoryUserPillFilter` — Pill 按钮过滤器，替代 `MemoryUserSelect` 下拉框，支持 loading skeleton、最大显示数限制（默认 10）和 `+N more` 折叠提示
- `MemorySidebarLayout` — 统一的 main(3:1)/aside 侧边栏布局
- `SidebarCard` — 可复用侧边栏卡片容器（标题 + 内容）
- `LegendCard` — Retention / Importance / Memory Types 图例
- `RetentionPolicyCard` — 保留策略 JSON 展示

**四页面统一重构：**
- 全面迁移 `zinc-*` 硬编码色值 → 语义化 CSS 变量（`bg-background`、`text-foreground`、`border-border`、`text-muted`、`bg-card`）
- Audit：提交控件与历史记录从页面底部移至侧边栏，主区聚焦记忆卡片 + 审计操作
- Conflicts：冲突详情面板从右侧独立区域整合至侧边栏，列表区更宽敞
- Timeline：Retention Policy 和 Legend 从内联 JSX 提取为 `RetentionPolicyCard` / `LegendCard`；memories 计数合并至 header 行
- Facts：新增侧边栏用户快速选择列表和 Facts Overview 卡片

**测试适配：**
- `audit.spec.ts`（4 处）和 `facts.spec.ts`（5 处）从 `selectOption` 迁移至 `getByRole("button")` Pill 交互

# 风险与回滚

- **主要风险**：`MemoryUserPillFilter` 始终展示 "All Users" Pill，而旧 `MemoryUserSelect` 在 Facts 页面通过 `allowAll={false}` 禁止全选。行为已变更但页面已适配 null 用户态，无功能中断
- **回滚方式**：`git revert` 即可，纯前端重构，无后端/数据库变更

# 验证证据

- E2E：`audit.spec.ts`（4 处）、`facts.spec.ts`（5 处）全部通过
- Pre-commit hooks：ESLint、Ruff lint/format 均通过

# 影响范围

- **前端**：`apps/negentropy-ui/app/memory/` 四个页面 + `features/memory/components/` 五个新增组件
- **后端**：无
- **CI/文档**：无

# Next Best Action

- 为 `MemoryUserPillFilter` 新增 `allowAll?: boolean` 属性，恢复 Facts 页面禁止全选的原始交互约束