### PR TITLE
fix(perceives): PDF→Markdown 1:1 还原 R10 — Agentic AI Survey 13 维新失真治理（D13-D25）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -702,6 +702,30 @@ class MarkdownFormatter:
                 # \uff08\u524d\u5bfc M \u5927\u5199\uff09\u3001 ``30-50`` \u6570\u5b57\uff08\u524d\u5bfc\u975e lowercase\uff09\u5747\u4e92\u65a5\u3002
                 text = re.sub(r"(?<=[a-z])-\s+(?=[a-z]{2})", "-", text)
 
+                # R10-D22\uff1aLatin-1 \u91cd\u97f3\u5b57\u7b26\u7684 UTF-8 \u2192 CP1252 \u53cc\u7f16\u7801 mojibake \u8fd8\u539f\u3002
+                # \u539f ``\u00ed`` UTF-8 ``\\xc3\\xad`` \u88ab CP1252 \u89e3\u4e3a ``\u00c3 + U+00AD``\uff0c
+                # \u518d\u4ee5 UTF-8 \u7f16\u7801\u4e3a 4 \u5b57\u8282\u5e8f\u5217\uff1b\u7c7b\u4f3c\u8986\u76d6 \u00e1/\u00e9/\u00f3/\u00fa/\u00f1/\u00fc/\u00f6/\u00e4/\u00e7 \u7b49
+                # \u897f\u3001\u8461\u3001\u6cd5\u3001\u5fb7\u8bed\u91cd\u97f3\u5b57\u7b26\u3002\u5fc5\u987b\u5728\u4e0b\u65b9 D13 U+00AD \u5904\u7406**\u4e4b\u524d**
+                # \u5b8c\u6210\u8bc6\u522b \u2014\u2014 D13 \u4f1a\u628a ``\u00c3 + \u00ad + guez`` \u7684 U+00AD \u4e0e\u540e\u7a7a\u767d\u4e00\u5e76
+                # \u5265\u79bb\uff08``\u00ad`` \u540e\u662f\u5c0f\u5199 ``g`` \u89e6\u53d1\uff09\uff0c\u5bfc\u81f4 ``Rodr\u00c3guez`` \u5b64\u7acb \u00c3 \u6b8b\u7559\u3002
+                _latin1_mojibake_map = (
+                    (
+                        "\u00c3\u00ad",
+                        "\u00ed",
+                    ),  # \u00c3 + U+00AD \u2192 \u00ed (Rodr\u00edguez)
+                    ("\u00c3\u00a9", "\u00e9"),  # \u2192 \u00e9 (P\u00e9rez)
+                    ("\u00c3\u00a1", "\u00e1"),  # \u2192 \u00e1 (S\u00e1nchez)
+                    ("\u00c3\u00b3", "\u00f3"),  # \u2192 \u00f3
+                    ("\u00c3\u00ba", "\u00fa"),  # \u2192 \u00fa
+                    ("\u00c3\u00b1", "\u00f1"),  # \u2192 \u00f1 (Mu\u00f1oz)
+                    ("\u00c3\u00bc", "\u00fc"),  # \u2192 \u00fc
+                    ("\u00c3\u00b6", "\u00f6"),  # \u2192 \u00f6
+                    ("\u00c3\u00a4", "\u00e4"),  # \u2192 \u00e4
+                    ("\u00c3\u00a7", "\u00e7"),  # \u2192 \u00e7
+                )
+                for moji, fixed in _latin1_mojibake_map:
+                    text = text.replace(moji, fixed)
+
                 # R10-D13\uff1a\u8f6f\u8fde\u5b57\u7b26 U+00AD \u8de8\u884c\u65ad\u5b57\u5408\u5e76\u3002PyMuPDF \u5728\u6392\u7248\u65ad\u5b57\u5904
                 # \u4fdd\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u95f4\u63d0\u793a\u7b26\uff09\uff0cspan \u62fc\u63a5\u540e\u5f62\u6210
                 # ``advance\u00ad ment``\uff08U+00AD + \u53ef\u9009\u7a7a\u767d + \u540e\u7eed\u5c0f\u5199\u8bcd\uff09\u3002
@@ -751,6 +775,13 @@ class MarkdownFormatter:
                 )
                 for moji, fixed in _mojibake_map:
                     text = text.replace(moji, fixed)
+
+                # R10-D23：闭括号前空格归一 ``(2025 )`` → ``(2025)``。
+                # PyMuPDF 抽取 ``(2025\n)`` 后 ``\n`` 折叠为空格形成 ``(2025 )``，
+                # Agentic AI Survey 表格 / References / 正文累计 112 处。仅去除
+                # ``)`` 紧前的单空格，且要求 ``)`` 紧前是非空白字符（避免 ``(  )``
+                # 空括号被破坏 —— 这类极少见且本身就是噪声）。
+                text = re.sub(r"(\S) \)", r"\1)", text)
 
                 lines = text.split("\n")
                 fixed_lines = []

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -687,7 +687,20 @@ class MarkdownFormatter:
                 # \u628a `\n` \u6298\u53e0\u4e3a\u7a7a\u683c\u540e\u53d8\u6210 `word- word`\u3002\u4ec5\u5339\u914d\u4e24\u4fa7\u5747\u4e3a ASCII \u5c0f\u5199
                 # \u5b57\u6bcd + \u4e2d\u95f4\u7a7a\u683c\u7684\u5f62\u6001\uff0c\u907f\u5f00\u590d\u5408\u8bcd (state-of-the-art \u65e0\u7a7a\u683c)\u3001
                 # \u6570\u5b57\u8303\u56f4 (20- 30)\u3001\u4e13\u6709\u7f29\u5199\u8fb9\u754c (X- Ray \u5927\u5199) \u7b49\u3002
-                text = re.sub(r"([a-z])- ([a-z])", r"\1\2", text)
+                #
+                # R10-D21 \u590d\u5408\u94fe\u5b88\u62a4\uff1a``Reasoning-acting-\ninteracting`` \u7c7b\u590d\u5408\u94fe
+                # \u5728 PyMuPDF \u884c\u6298\u53e0\u540e\u53d8\u6210 ``Reasoning-acting- interacting``\uff0c
+                # \u82e5\u76f4\u63a5\u547d\u4e2d ``g- i`` \u5408\u5e76\u89c4\u5219\u4f1a\u5f97\u5230 ``actinginteracting`` \u89c6\u89c9\u7834\u574f\u3002
+                # \u901a\u8fc7 ``(?<![a-zA-Z]-)`` \u5b88\u62a4\uff1a\u5339\u914d\u524d\u7f00 ``[a-z]+`` \u8d77\u59cb\u4f4d\u7f6e\u7684\u524d
+                # 2 \u5b57\u7b26\u82e5\u5df2\u662f ``<letter>-``\uff08\u5373\u4f4d\u4e8e\u65e2\u6709 hyphen \u94fe\u4e2d\uff09\uff0c\u8df3\u8fc7\u5408\u5e76\uff1b
+                # \u4ec5\u5bf9\u72ec\u7acb\u5355\u8bcd\u7684 wrap-hyphen \u5b9e\u65bd\u5408\u5e76\u3002
+                text = re.sub(r"\b(?<![a-zA-Z]-)([a-z]+)- ([a-z]+)\b", r"\1\2", text)
+                # R10-D21 \u7eed\uff1a\u590d\u5408\u94fe wrap \u7a7a\u683c\u6536\u5c3e\u3002\u547d\u4e2d\u5b88\u62a4\u540e\u4fdd\u7559\u7684 ``acting- interacting``
+                # \u4ecd\u542b\u4e00\u4e2a\u591a\u4f59\u7a7a\u683c\uff0c\u9700\u628a ``<lowercase>-<space>+<lowercase>`` \u4e2d\u7684\u7a7a\u683c
+                # \u6536\u7d27\u4e3a\u96f6\uff0c\u628a ``acting- interacting`` \u53d8\u6210 ``acting-interacting``\u3002
+                # \u4e0e\u5355\u5b57\u6bcd ``a - b``\uff08\u524d\u5bfc\u7a7a\u683c\u975e lowercase\uff09\u3001 ``LLM-based`` \u5927\u5199\u8fb9\u754c
+                # \uff08\u524d\u5bfc M \u5927\u5199\uff09\u3001 ``30-50`` \u6570\u5b57\uff08\u524d\u5bfc\u975e lowercase\uff09\u5747\u4e92\u65a5\u3002
+                text = re.sub(r"(?<=[a-z])-\s+(?=[a-z]{2})", "-", text)
 
                 # R10-D13\uff1a\u8f6f\u8fde\u5b57\u7b26 U+00AD \u8de8\u884c\u65ad\u5b57\u5408\u5e76\u3002PyMuPDF \u5728\u6392\u7248\u65ad\u5b57\u5904
                 # \u4fdd\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u95f4\u63d0\u793a\u7b26\uff09\uff0cspan \u62fc\u63a5\u540e\u5f62\u6210

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -708,6 +708,29 @@ class MarkdownFormatter:
                 # \u9632\u5fa1\u515c\u5e95\uff1a\u6e05\u9664\u4efb\u4f55\u6b8b\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u7b26\u4e0d\u5e94\u8fdb\u5165 markdown\uff09
                 text = text.replace("\u00ad", "")
 
+                # R10-D17\uff1a\u96f6\u5bbd\u7a7a\u683c U+200B \u6e05\u9664\u3002Springer Nature \u7b49\u671f\u520a\u5728\u5f15\u7528 URL
+                # \u6bcf\u5b57\u7b26\u4e4b\u95f4\u6ce8\u5165 U+200B \u4f5c\u4e3a\u8f6f\u6362\u884c hint\uff0c\u7834\u574f\u6587\u672c\u62f7\u8d1d / \u5168\u6587\u68c0\u7d22 /
+                # URL \u53ef\u70b9\u51fb\u6027\u3002U+200B \u5728 markdown \u4e2d\u65e0\u610f\u4e49\u4e14\u4e0d\u53ef\u89c1\uff0c\u5168\u5c40\u6e05\u9664\u3002
+                # \u4ec5\u6e05\u9664 U+200B \u5355\u4e00\u5b57\u7b26\uff1b\u4fdd\u7559 U+200D ZWJ\uff08emoji / \u5370\u5ea6\u8bed\u8fde\u5199\uff09\u3002
+                text = text.replace("\u200b", "")
+
+                # R10-D18\uff1aUTF-8 \u2192 CP1252 \u53cc\u7f16\u7801 mojibake \u8fd8\u539f\u3002PDF \u4e2d em-dash
+                # ``\u2014`` (U+2014, UTF-8 ``E2 80 94``) \u5728\u67d0\u4e9b PyMuPDF \u62bd\u53d6\u8def\u5f84\u4e0a
+                # \u4f1a\u88ab CP1252 \u89e3\u7801\u4e3a ``\u00e2 \u20ac "`` (U+00E2 U+20AC U+201D) \u4e09\u5b57\u7b26\u5e8f\u5217
+                # \u518d\u4ee5 UTF-8 \u91cd\u65b0\u7f16\u7801\uff0c\u6700\u7ec8\u5728 markdown \u4e2d\u663e\u793a\u4e3a ``\u00e2\u20ac"``\u3002\u540c\u7c7b
+                # \u5931\u771f\u8986\u76d6 en-dash / \u5355 / \u53cc\u5f15\u53f7 / \u7701\u7565\u53f7\u3002\u56fa\u5b9a 6 \u6a21\u5f0f\u66ff\u6362\uff0c
+                # \u4e0d\u4f9d\u8d56\u5916\u90e8\u5e93\uff08ftfy \u5f53\u524d\u4ec5\u4e3a docling \u4f20\u9012\u4f9d\u8d56\uff0c\u907f\u514d\u786c\u7ed1\u5b9a\uff09\u3002
+                _mojibake_map = (
+                    ("\u00e2\u20ac\u201d", "\u2014"),  # \u2014 em-dash
+                    ("\u00e2\u20ac\u201c", "\u2013"),  # \u2013 en-dash
+                    ("\u00e2\u20ac\u2122", "\u2019"),  # \u2019 right single quote
+                    ("\u00e2\u20ac\u0153", "\u201c"),  # \u201c left double quote
+                    ("\u00e2\u20ac\u009d", "\u201d"),  # \u201d right double quote
+                    ("\u00e2\u20ac\u00a6", "\u2026"),  # \u2026 ellipsis
+                )
+                for moji, fixed in _mojibake_map:
+                    text = text.replace(moji, fixed)
+
                 lines = text.split("\n")
                 fixed_lines = []
                 for line in lines:

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -705,6 +705,14 @@ class MarkdownFormatter:
                 # \u4e0e em-dash \u98ce\u683c ``A - B``\uff08\u4e24\u4fa7\u5747\u7a7a\u683c\uff09\u3001\u590d\u5408\u8bcd ``X-Y`` \u4e92\u65a5\u3002
                 text = re.sub(r"(?<=[a-zA-Z]) -(?=[a-z])", "", text)
 
+                # R10-D19\uff1a\u4e24\u4fa7\u5747\u7a7a\u683c\u7684\u65ad\u5b57 ``per - formance`` \u2014\u2014 \u8868\u683c cell \u5185
+                # \u62bd\u53d6\u8def\u5f84\u7684\u6700\u5e38\u89c1 hyphenation \u6b8b\u7559\u3002\u4e24\u4fa7\u5747\u8981\u6c42 2+ \u5b57\u6bcd\uff08\u907f\u514d
+                # \u8bef\u541e\u6570\u5b66 ``a - b`` \u5355\u5b57\u6bcd\uff09\uff0c\u53f3\u4fa7\u8981\u6c42\u5c0f\u5199\u8d77\u9996\uff08\u907f\u514d\u8bef\u541e em-dash
+                # \u98ce\u683c ``Section A - Section B``\uff09\u3002Springer \u671f\u520a References /
+                # Table cells \u9ad8\u9891\u51fa\u73b0 ``Scalabil - ity`` / ``gov - ernance`` /
+                # ``sym - bolic`` / ``Mo - zolevskyi`` \u7b49\u6a21\u5f0f\u3002
+                text = re.sub(r"(?<=[a-zA-Z]{2}) - (?=[a-z]{2})", "", text)
+
                 # \u9632\u5fa1\u515c\u5e95\uff1a\u6e05\u9664\u4efb\u4f55\u6b8b\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u7b26\u4e0d\u5e94\u8fdb\u5165 markdown\uff09
                 text = text.replace("\u00ad", "")
 
@@ -856,11 +864,29 @@ class MarkdownFormatter:
         kept: List[str] = []
         seen_fingerprints: List[set[str]] = []
 
+        # R10-D20：caption 行（``Table N ...`` / ``Figure N ...`` / ``Fig. N ...``
+        # / ``Algorithm N ...``）的精确相邻去重。PyMuPDF 把 caption 抽为正文段、
+        # table_extraction 又把同样 caption 内嵌为表头部，二者经 assembly 写入
+        # markdown 后形成「caption / caption / table」三段结构。caption 通常少于
+        # 15 词，会被下方主体 Jaccard 去重的长度守卫绕过，故在主流程前插入紧邻
+        # 重复 caption 检查 —— 仅对相邻位置（kept 末尾即上一保留段）做精确相等比对，
+        # 不影响跨段落非相邻的合法重复（如 ``Table 5 (continued)``）。
+        _caption_re = re.compile(
+            r"^(?:Table|Figure|Fig\.|Tab\.|Algorithm|Algo\.)\s+\d+\b",
+            re.IGNORECASE,
+        )
+
+        def _is_caption(text: str) -> bool:
+            return bool(_caption_re.match(text.strip()))
+
         for para in paragraphs:
             # 块级公式段落始终保留，不参与 Jaccard 相似度比较，
             # 也不污染后续段落的对比基线。
             if _is_math_block(para):
                 kept.append(para)
+                continue
+            # caption 精确相邻去重：仅当上一保留段为相同 caption 时跳过
+            if _is_caption(para) and kept and kept[-1].strip() == para.strip():
                 continue
             fp = _fingerprint(para)
             if len(fp) < 15:

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -783,6 +783,12 @@ class MarkdownFormatter:
                 # 空括号被破坏 —— 这类极少见且本身就是噪声）。
                 text = re.sub(r"(\S) \)", r"\1)", text)
 
+                # R10-D24：开括号后空格归一 ``( 2008)`` → ``(2008)``。
+                # 与 D23 对称的镜像 case：``Harden (\n2008)`` 折叠后形成
+                # ``Harden ( 2008)``，Agentic AI Survey 累计 3 处。要求 ``(``
+                # 紧后是非空白，避免破坏空括号噪声。
+                text = re.sub(r"\( (\S)", r"(\1", text)
+
                 lines = text.split("\n")
                 fixed_lines = []
                 for line in lines:

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -689,6 +689,25 @@ class MarkdownFormatter:
                 # \u6570\u5b57\u8303\u56f4 (20- 30)\u3001\u4e13\u6709\u7f29\u5199\u8fb9\u754c (X- Ray \u5927\u5199) \u7b49\u3002
                 text = re.sub(r"([a-z])- ([a-z])", r"\1\2", text)
 
+                # R10-D13\uff1a\u8f6f\u8fde\u5b57\u7b26 U+00AD \u8de8\u884c\u65ad\u5b57\u5408\u5e76\u3002PyMuPDF \u5728\u6392\u7248\u65ad\u5b57\u5904
+                # \u4fdd\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u95f4\u63d0\u793a\u7b26\uff09\uff0cspan \u62fc\u63a5\u540e\u5f62\u6210
+                # ``advance\u00ad ment``\uff08U+00AD + \u53ef\u9009\u7a7a\u767d + \u540e\u7eed\u5c0f\u5199\u8bcd\uff09\u3002
+                # \u8be5\u6a21\u5f0f\u5728 PDF \u89c6\u89c9\u5c42\u5e76\u975e\u771f\u5b9e\u8fde\u5b57\u7b26\uff0c\u9700\u5c06 U+00AD \u4e0e\u5176\u540e\u7a7a\u767d
+                # \u4e00\u5e76\u5220\u9664\uff0c\u6062\u590d\u5b8c\u6574\u8bcd\uff1b\u540c\u6837\u9650\u5b9a\u540e\u7eed\u4e3a ASCII \u5c0f\u5199\u4ee5\u907f\u514d\u8bef\u541e
+                # \u5927\u5199\u4e13\u6709\u540d\u8bcd\u8fb9\u754c\u4e0e\u6570\u5b57\u3002
+                text = re.sub(r"\u00ad[ \t]*(?=[a-z])", "", text)
+
+                # R10-D14\uff1a\u53cd\u5411 ``word -word`` \u6a21\u5f0f\uff08\u524d\u7a7a\u683c + ASCII \u8fde\u5b57\u7b26 + \u5c0f\u5199\uff09\u3002
+                # \u8be5\u6a21\u5f0f\u51fa\u73b0\u5728 figure caption / \u8868\u683c\u6807\u9898\u7b49\u62bd\u53d6\u8def\u5f84\u4e0a \u2014\u2014 \u90e8\u5206
+                # caption \u6536\u96c6\u5668\u628a U+00AD \u5f52\u4e00\u5316\u4e3a ASCII ``-`` \u4f46\u672a\u540c\u65f6\u5408\u5e76\u65ad\u5b57\uff0c
+                # \u5f62\u6210 ``retrofit -ting`` / ``or -chestration``\u3002\u5224\u5b9a\u6761\u4ef6\u4e0e\u524d
+                # \u4e00\u89c4\u5219\u540c\u6e90\uff08\u8981\u6c42\u524d ASCII \u5b57\u6bcd + \u5355\u7a7a\u683c + \u5355 ``-`` + ASCII \u5c0f\u5199\uff09\uff0c
+                # \u4e0e em-dash \u98ce\u683c ``A - B``\uff08\u4e24\u4fa7\u5747\u7a7a\u683c\uff09\u3001\u590d\u5408\u8bcd ``X-Y`` \u4e92\u65a5\u3002
+                text = re.sub(r"(?<=[a-zA-Z]) -(?=[a-z])", "", text)
+
+                # \u9632\u5fa1\u515c\u5e95\uff1a\u6e05\u9664\u4efb\u4f55\u6b8b\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u7b26\u4e0d\u5e94\u8fdb\u5165 markdown\uff09
+                text = text.replace("\u00ad", "")
+
                 lines = text.split("\n")
                 fixed_lines = []
                 for line in lines:

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -58,6 +58,130 @@ _HOMOGENEOUS_PAIRS = frozenset(
 )
 
 
+# R10-D19 守护词表：em-dash 风格 ``word - connector ...`` 中的常见 RHS 连接词。
+# Why: D19 的 ``word - word`` 合并对学术 PDF 表格 cell / Reference 内的跨行断字
+# （``Scalabil - ity`` → ``Scalability``）有效，但对正文中的 em-dash 风格
+# （``data - or what was left - was deleted``）会误吞分隔符。RHS 词若命中此表，
+# 视为 em-dash 连接词，保留 ``  - `` 原貌；否则按断字处理合并。
+# 涵盖：连词 / 冠词 / 关系代词 / be-have-do 助动词 / 情态动词 / 介词 / 人称代词 /
+# 物主代词 / 常见副词 / 从属连词 / 否定词 / 转折词 / 拉丁缩写 (i.e. / e.g.)。
+_EM_DASH_RHS_CONNECTORS = frozenset(
+    {
+        # 连词
+        "or",
+        "and",
+        "but",
+        "so",
+        "if",
+        "as",
+        "yet",
+        "nor",
+        # 冠词
+        "a",
+        "an",
+        "the",
+        # 关系代词 / 疑问词
+        "that",
+        "which",
+        "who",
+        "whom",
+        "whose",
+        "where",
+        "when",
+        "why",
+        "how",
+        # be / have / do
+        "is",
+        "was",
+        "are",
+        "were",
+        "be",
+        "been",
+        "being",
+        "has",
+        "have",
+        "had",
+        "having",
+        "do",
+        "does",
+        "did",
+        "doing",
+        # 情态动词
+        "will",
+        "would",
+        "shall",
+        "should",
+        "can",
+        "could",
+        "may",
+        "might",
+        "must",
+        # 介词
+        "to",
+        "in",
+        "on",
+        "at",
+        "by",
+        "of",
+        "for",
+        "with",
+        "from",
+        "into",
+        "onto",
+        "about",
+        "after",
+        "before",
+        "between",
+        "through",
+        # 人称代词 / 物主代词
+        "i",
+        "it",
+        "he",
+        "she",
+        "we",
+        "they",
+        "you",
+        "its",
+        "his",
+        "her",
+        "our",
+        "their",
+        "your",
+        # 副词
+        "just",
+        "only",
+        "even",
+        "also",
+        "still",
+        "rather",
+        "perhaps",
+        # 从属连词 / 转折
+        "like",
+        "than",
+        "then",
+        "since",
+        "while",
+        "until",
+        "unless",
+        "though",
+        "because",
+        "although",
+        "despite",
+        "except",
+        "namely",
+        "however",
+        "moreover",
+        "furthermore",
+        "instead",
+        # 否定
+        "not",
+        "no",
+    }
+)
+# 拉丁缩写需带尾点匹配，单独保存
+_EM_DASH_RHS_LATIN_ABBR = frozenset({"i.e.", "e.g.", "cf.", "viz."})
+
+
 def _classify_line(line: str) -> _LineType:
     """将 Markdown 行分类为对应的块级元素类型。"""
     for pattern, line_type in _LINE_PATTERNS:
@@ -700,7 +824,11 @@ class MarkdownFormatter:
                 # \u6536\u7d27\u4e3a\u96f6\uff0c\u628a ``acting- interacting`` \u53d8\u6210 ``acting-interacting``\u3002
                 # \u4e0e\u5355\u5b57\u6bcd ``a - b``\uff08\u524d\u5bfc\u7a7a\u683c\u975e lowercase\uff09\u3001 ``LLM-based`` \u5927\u5199\u8fb9\u754c
                 # \uff08\u524d\u5bfc M \u5927\u5199\uff09\u3001 ``30-50`` \u6570\u5b57\uff08\u524d\u5bfc\u975e lowercase\uff09\u5747\u4e92\u65a5\u3002
-                text = re.sub(r"(?<=[a-z])-\s+(?=[a-z]{2})", "-", text)
+                #
+                # \u6536\u7a84\u7a7a\u767d\u96c6\u4e3a ``[ \t]+``\uff1a\u907f\u514d ``\s+`` \u547d\u4e2d ``\n`` \u4ece\u800c\u628a\u884c/\u6bb5\u843d
+                # \u8fb9\u754c\u541e\u6389\uff08\u5982\u6bb5\u5c3e ``word-`` + \u6bb5\u9996 lowercase \u8de8\u6bb5\u5408\u5e76\uff09\uff0c\u7834\u574f
+                # markdown \u6bb5\u843d\u7ed3\u6784\u3002
+                text = re.sub(r"(?<=[a-z])-[ \t]+(?=[a-z]{2})", "-", text)
 
                 # R10-D22\uff1aLatin-1 \u91cd\u97f3\u5b57\u7b26\u7684 UTF-8 \u2192 CP1252 \u53cc\u7f16\u7801 mojibake \u8fd8\u539f\u3002
                 # \u539f ``\u00ed`` UTF-8 ``\\xc3\\xad`` \u88ab CP1252 \u89e3\u4e3a ``\u00c3 + U+00AD``\uff0c
@@ -748,7 +876,25 @@ class MarkdownFormatter:
                 # \u98ce\u683c ``Section A - Section B``\uff09\u3002Springer \u671f\u520a References /
                 # Table cells \u9ad8\u9891\u51fa\u73b0 ``Scalabil - ity`` / ``gov - ernance`` /
                 # ``sym - bolic`` / ``Mo - zolevskyi`` \u7b49\u6a21\u5f0f\u3002
-                text = re.sub(r"(?<=[a-zA-Z]{2}) - (?=[a-z]{2})", "", text)
+                #
+                # \u5b88\u62a4\uff1a\u53f3\u4fa7\u82e5\u662f\u5e38\u89c1 em-dash \u8fde\u63a5\u8bcd\uff08``or`` / ``and`` / ``the`` /
+                # ``which`` / ``i.e.`` \u7b49\uff0c\u8be6\u89c1 ``_EM_DASH_RHS_CONNECTORS`` \u4e0e
+                # ``_EM_DASH_RHS_LATIN_ABBR``\uff09\uff0c\u4fdd\u7559 ` - ` \u539f\u8c8c\u4ee5\u907f\u514d\u8bef\u541e\u6b63\u6587
+                # em-dash\uff08``data - or what was left - was deleted``\uff09\u3002
+                def _collapse_bothside_wrap(match: re.Match) -> str:
+                    rhs = match.group(1).lower()
+                    if rhs in _EM_DASH_RHS_CONNECTORS or rhs in _EM_DASH_RHS_LATIN_ABBR:
+                        return match.group(0)
+                    return match.group(1)
+
+                # 拉丁缩写以 ``.`` 结尾且后续常跟 ``,`` / ``;``，``\b`` 无法在
+                # 双非字符位置成立，故拉丁缩写分支不带 ``\b``；普通词分支带 ``\b``
+                # 以严格限定单词边界。
+                text = re.sub(
+                    r"(?<=[a-zA-Z]{2}) - ((?:i\.e|e\.g|cf|viz)\.|[a-z]+\b)",
+                    _collapse_bothside_wrap,
+                    text,
+                )
 
                 # \u9632\u5fa1\u515c\u5e95\uff1a\u6e05\u9664\u4efb\u4f55\u6b8b\u7559 U+00AD\uff08\u4e0d\u53ef\u89c1\u5b57\u7b26\u4e0d\u5e94\u8fdb\u5165 markdown\uff09
                 text = text.replace("\u00ad", "")

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -421,6 +421,30 @@ class FitzTextExtractor(PDFToolBase):
         if text_stripped in ("SII-GAIR", "SII - GAIR"):
             return True
 
+        # R10-D15：期刊运行头 / 页脚的常见模式 —— 位置无关，仅靠文本特征即可判定，
+        # 因为 PyMuPDF 抽取时这些块的 bbox 可能因双栏 / 旋转文本被记到正文区。
+        #
+        # 1. Springer Nature 期刊页脚：``11 Page 2 of 37`` / ``Page 3 of 37 11``
+        #    （issue number + "Page X of Y" 或反向）
+        if re.match(r"^\d{1,4}\s+Page\s+\d+\s+of\s+\d+\s*$", text_stripped):
+            return True
+        if re.match(r"^Page\s+\d+\s+of\s+\d+\s+\d{1,4}\s*$", text_stripped):
+            return True
+        # 2. 双数字运行页码（双栏期刊常见，如 ``1 3``）—— 仅短文本且两段都是 1-4 位
+        if re.match(r"^\d{1,4}\s+\d{1,4}\s*$", text_stripped):
+            return True
+        # 3. 作者运行头：``First Initial. Surname et al.`` / ``Surname and Surname et al.``
+        if re.match(
+            r"^[A-Z]\.\s+[A-Za-z'\-]+(?:\s+[A-Za-z'\-]+)?\s+et\s+al\.?\s*$",
+            text_stripped,
+        ):
+            return True
+        if re.match(
+            r"^[A-Z][A-Za-z'\-]+\s+and\s+[A-Z][A-Za-z'\-]+\s+et\s+al\.?\s*$",
+            text_stripped,
+        ):
+            return True
+
         # 位置启发式：页面顶部/底部 5% 区域内的短文本
         # 保护：要求文本长度 ≥ 20 以排除短标题（如 "Introduction"、"Results"）
         # 页眉/页脚通常是会议简称 + 日期等组合，长度一般 ≥ 20
@@ -512,6 +536,20 @@ class FitzTextExtractor(PDFToolBase):
             if re.search(r"(?:^|\s)\d+\.\s+[A-Z]", section_title):
                 return None
 
+            # R10-D16：编号开头但内含完整句子（学术 PDF 列表项常被 PyMuPDF
+            # 抽为单段，再因 ``^\d+\.`` 前缀被升级为 heading，破坏文档大纲）。
+            # 句子型正文的强信号：① 作者代词 ``We / I / Our`` 接动词；② 不定式
+            # 列表 ``To <verb>``（连续逗号分隔项）；③ 显著主谓 + 多逗号子句。
+            # 10. 含作者代词 + 后续小写（动词起首）的句子结构
+            if re.search(r"\b(We|I|Our)\s+[a-z]", section_title):
+                return None
+            # 11. 不定式列表起首（``To identify, classify, and ...``）
+            if re.match(r"^To\s+[a-z]+,\s+\w+,", section_title):
+                return None
+            # 12. 多逗号子句（≥ 2 个 ``, ``）且长度 > 60 —— 句子型正文
+            if section_title.count(", ") >= 2 and len(section_title) > 60:
+                return None
+
             depth = section_num.count(".") + 1
             if depth == 1:
                 return 1
@@ -540,6 +578,14 @@ class FitzTextExtractor(PDFToolBase):
 
         # 排除 footnote 标记行（如 "† Corresponding author"）
         if re.match(r"^[†‡*§¶]\s", text_stripped) and len(text_stripped) < 100:
+            return None
+
+        # R10-D16 续：非编号路径下也过滤句子型正文（章节 lead-in 句被字号守卫
+        # 误升级）。强信号：作者代词 ``We / I / Our`` + 后续 2 个以上小写词，
+        # 仅当文本长度 > 50 时启用，避免误删合法短标题如 ``Our Method``。
+        if len(text_stripped) > 50 and re.search(
+            r"\b(We|I|Our)\s+[a-z]+\s+[a-z]", text_stripped
+        ):
             return None
 
         # 特殊标题词（整个文本就是标题）

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -550,6 +550,21 @@ class FitzTextExtractor(PDFToolBase):
             if section_title.count(", ") >= 2 and len(section_title) > 60:
                 return None
 
+            # R10-D25：list-item label + 句子型 body 折叠到同一文本块的剩余信号。
+            # 典型产物 ``Paradigm specialization by domain High-stakes, regulated``
+            # 中包含 ``[a-z]+\s+[A-Z][\w-]+,`` —— 小写词 + 空格 + Capital 起首词
+            # （可含 hyphen）+ 逗号；学术 heading 内 Capital 词后接逗号几乎不出现
+            # （合法 heading 的 Capital 复合词 ``Reinforcement Learning`` 后无逗号），
+            # 该组合是 PyMuPDF 折叠 PDF list-item ``\d+. **Label** Body sentence,...``
+            # 的特征指纹。守护：长度 > 50 + 不含 ``:``（合法 heading subtitle 分隔符
+            # 后续可能触发同样模式，但语义合法，需放行）。
+            if (
+                len(section_title) > 50
+                and ":" not in section_title
+                and re.search(r"\b[a-z]+\s+[A-Z][\w-]+,", section_title)
+            ):
+                return None
+
             depth = section_num.count(".") + 1
             if depth == 1:
                 return 1

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -538,10 +538,22 @@ class FitzTextExtractor(PDFToolBase):
 
             # R10-D16：编号开头但内含完整句子（学术 PDF 列表项常被 PyMuPDF
             # 抽为单段，再因 ``^\d+\.`` 前缀被升级为 heading，破坏文档大纲）。
-            # 句子型正文的强信号：① 作者代词 ``We / I / Our`` 接动词；② 不定式
-            # 列表 ``To <verb>``（连续逗号分隔项）；③ 显著主谓 + 多逗号子句。
-            # 10. 含作者代词 + 后续小写（动词起首）的句子结构
-            if re.search(r"\b(We|I|Our)\s+[a-z]", section_title):
+            # 句子型正文的强信号：① 作者代词 ``We / Our`` 接小写动词；
+            # ② 不定式列表 ``To <verb>``（连续逗号分隔项）；③ 显著主谓 + 多逗号
+            # 子句；④ 第一人称 ``I`` 接学术叙述动词（``I propose / introduce / ...``）。
+            # 10a. ``We`` / ``Our`` + 后续小写（动词起首）的句子结构
+            if re.search(r"\b(We|Our)\s+[a-z]", section_title):
+                return None
+            # 10b. 单字母 ``I`` 单独识别 —— 避免误伤 ``Phase I improvements`` /
+            # ``Type I errors`` 这类含罗马数字 I 的合法 heading。仅当 I 后紧跟
+            # 常见学术叙述动词时才视为句子型正文。
+            if re.search(
+                r"\bI\s+(?:propose|introduce|present|argue|show|find|study|"
+                r"explore|describe|analyze|investigate|examine|believe|think|"
+                r"claim|note|observe|demonstrate|prove|assume|hypothesize|"
+                r"conclude|discuss|review|survey|provide|develop|design)\b",
+                section_title,
+            ):
                 return None
             # 11. 不定式列表起首（``To identify, classify, and ...``）
             if re.match(r"^To\s+[a-z]+,\s+\w+,", section_title):
@@ -596,10 +608,20 @@ class FitzTextExtractor(PDFToolBase):
             return None
 
         # R10-D16 续：非编号路径下也过滤句子型正文（章节 lead-in 句被字号守卫
-        # 误升级）。强信号：作者代词 ``We / I / Our`` + 后续 2 个以上小写词，
+        # 误升级）。强信号：作者代词 ``We / Our`` + 后续 2 个以上小写词，
         # 仅当文本长度 > 50 时启用，避免误删合法短标题如 ``Our Method``。
+        # ``I`` 单字母不在通用守护范围（罗马数字 I 与代词 I 难以区分），
+        # 仅当 I 后紧跟学术叙述动词时才视为句子型正文。
         if len(text_stripped) > 50 and re.search(
-            r"\b(We|I|Our)\s+[a-z]+\s+[a-z]", text_stripped
+            r"\b(We|Our)\s+[a-z]+\s+[a-z]", text_stripped
+        ):
+            return None
+        if len(text_stripped) > 50 and re.search(
+            r"\bI\s+(?:propose|introduce|present|argue|show|find|study|"
+            r"explore|describe|analyze|investigate|examine|believe|think|"
+            r"claim|note|observe|demonstrate|prove|assume|hypothesize|"
+            r"conclude|discuss|review|survey|provide|develop|design)\b",
+            text_stripped,
         ):
             return None
 

--- a/apps/negentropy-perceives/tests/unit/test_formatter_dedupe_table_caption.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_dedupe_table_caption.py
@@ -1,0 +1,56 @@
+"""``MarkdownFormatter`` 表格 caption 重复去重单元测试。
+
+R10-D20 沉淀：Agentic AI Survey 中 ``Table N ...`` caption 在 markdown 中
+连续重复 2 次（PyMuPDF 把 caption 抽为正文段、table_extraction 又把 caption
+内嵌为表格头部，二者均经 assembly 写入 markdown），形成视觉上的 ``Table 1 ...
+\\n\\nTable 1 ...\\n\\n| ... |`` 结构。共 5 处（Table 1/2/3/5/8）。
+"""
+
+from __future__ import annotations
+
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+
+
+class TestTableCaptionDedupe:
+    """``MarkdownFormatter`` 应去除紧邻重复的 ``Table N ...`` caption。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_adjacent_duplicate_table_caption_deduped(self) -> None:
+        """连续两行相同的 ``Table 1 Summary ...`` caption 应仅保留一份。"""
+        md = (
+            "Table 1 Summary of prior surveys on Agentic AI\n\n"
+            "Table 1 Summary of prior surveys on Agentic AI\n\n"
+            "| References | Focus |\n"
+            "| ---------- | ----- |\n"
+            "| Plaat | Agentic LLMs |\n"
+        )
+        result = self.formatter.format(md)
+        assert result.count("Table 1 Summary of prior surveys on Agentic AI") == 1
+
+    def test_different_table_captions_preserved(self) -> None:
+        """不同表格的不同 caption 应各保留一份。"""
+        md = (
+            "Table 1 Summary of prior surveys\n\n"
+            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n"
+            "Table 2 Mapping human functions\n\n"
+            "| c | d |\n| --- | --- |\n| 3 | 4 |\n"
+        )
+        result = self.formatter.format(md)
+        assert "Table 1 Summary of prior surveys" in result
+        assert "Table 2 Mapping human functions" in result
+
+    def test_non_adjacent_duplicate_table_caption_preserved(self) -> None:
+        """跨段落非相邻重复的 caption 不强制去重（``Table 5 (continued)`` 等
+        延续性 caption 合法地出现在不同位置）。
+        """
+        md = (
+            "Table 5 (continued)\n\n"
+            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n"
+            "Some other paragraph here that is sufficiently long.\n\n"
+            "Table 5 (continued)\n\n"
+            "| c | d |\n| --- | --- |\n| 3 | 4 |\n"
+        )
+        result = self.formatter.format(md)
+        assert result.count("Table 5 (continued)") == 2

--- a/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
@@ -118,3 +118,36 @@ class TestFormatterHyphenation:
         result = self.formatter._apply_typography_fixes(md)
         assert "neuro-symbolic" in result
         assert "state-of-the-art" in result
+
+    # ---- R10-D19: word - word（两侧均空格）模式合并 ----
+
+    def test_bothside_space_hyphen_merged(self) -> None:
+        """表格 / 长正文中两侧均空格的断字 ``per - formance`` 应合并为
+        ``performance``。该模式在 Springer 期刊表格内尤其常见。
+        """
+        md = "| feature | No per - formance metrics |\n| feature | Scalabil - ity not addressed |"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "performance" in result
+        assert "Scalability" in result
+        assert "per - formance" not in result
+        assert "Scalabil - ity" not in result
+
+    def test_bothside_space_proper_noun_merged(self) -> None:
+        """专有名词跨行断字 ``Mo - zolevskyi`` 也应合并。"""
+        md = "(2025), Mo - zolevskyi and AlShikh (2024)"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Mozolevskyi" in result
+
+    def test_bothside_space_em_dash_with_capital_preserved(self) -> None:
+        """两侧均空格但右侧大写起首（em-dash 风格 ``A - B``）不应合并。"""
+        md = "Section A - Section B contains the analysis."
+        result = self.formatter._apply_typography_fixes(md)
+        # Section B 不应被并入 Section
+        assert "SectionB" not in result
+        # 形如 "A - Section" 至少 A 后保留断行
+
+    def test_bothside_space_single_letter_preserved(self) -> None:
+        """单字母两侧（``a - b``）不应合并 —— 多为数学 / 公式 / 列表项。"""
+        md = "Compute a - b as the simple difference."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "ab" not in result.replace("a - b", "").replace("simple", "")

--- a/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
@@ -151,3 +151,26 @@ class TestFormatterHyphenation:
         md = "Compute a - b as the simple difference."
         result = self.formatter._apply_typography_fixes(md)
         assert "ab" not in result.replace("a - b", "").replace("simple", "")
+
+    # ---- R10-D21: 复合链断字（``X-Y-\nZ`` → ``X-Y- Z``）保留所有 hyphen ----
+
+    def test_compound_chain_wrapped_preserves_hyphen(self) -> None:
+        """复合词链 ``Reasoning-acting-`` 跨行断到 ``interacting``，应保留所有 hyphen
+        而非把后半并入 ``acting`` —— 避免 ``actinginteracting`` 这类视觉破坏。
+        """
+        md = "Reasoning-acting- interacting taxonomy"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Reasoning-acting-interacting" in result
+        assert "actinginteracting" not in result
+
+    def test_compound_chain_three_segments(self) -> None:
+        """三段复合 / 多次断字混合保留 hyphen 链，不影响已有 hyphen 串。"""
+        md = "the perceive-plan-act-reflect (PPAR) and the read- write- merge loop"
+        result = self.formatter._apply_typography_fixes(md)
+        # 已有 hyphen 链 perceive-plan-act-reflect 必须保留
+        assert "perceive-plan-act-reflect" in result
+        # 两次断字合并：第一次 read- write 合并（无前置 hyphen），第二次 write- merge
+        # 进入复合链 wrap 收尾逻辑，可得 readwrite-merge / read-write-merge / readwritemerge
+        # 三种都是可接受还原 —— 关键是不能出现裸残 "- " 或视觉破坏。
+        assert "- " not in result.replace("(PPAR) and the", "")
+        assert "merge" in result and "write" in result

--- a/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
@@ -64,3 +64,57 @@ class TestFormatterHyphenation:
         assert "survey" in result
         assert "harness" in result
         assert "engineering" in result
+
+    # ---- R10-D13/D14: 软连字符 U+00AD 与反向 `word -word` 模式合并 ----
+
+    def test_soft_hyphen_with_space_merged(self) -> None:
+        """PyMuPDF 在跨行断字处保留 U+00AD，``\" \".join(spans)`` 后形成
+        ``advance\\xad ment``。需识别该模式并合并为完整词。
+        """
+        md = "Its rapid advance­ ment has led to a frame­ work."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "advancement" in result
+        assert "framework" in result
+        assert "­" not in result
+
+    def test_isolated_soft_hyphen_stripped(self) -> None:
+        """单独残留 U+00AD（无 trailing 空格 / 无 follow-up 小写）也应清除。"""
+        md = "fragment­ ends here­."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "­" not in result
+
+    def test_reverse_pattern_space_hyphen_merged(self) -> None:
+        """反向模式 ``word -word``（即 ``-`` 前空格、后无空格）也是跨行断字
+        的产物，应合并。常见于 image caption / 表格标题（一种 caption 抽取路径
+        把 U+00AD 转为 ASCII 连字符）。
+        """
+        md = (
+            "Conceptual framework resolves conceptual retrofit -ting by distinguishing "
+            "the prompt-driven or -chestration of funda -mentally incompatible systems."
+        )
+        result = self.formatter._apply_typography_fixes(md)
+        assert "retrofitting" in result
+        assert "orchestration" in result
+        assert "fundamentally" in result
+        assert "retrofit -ting" not in result
+
+    def test_reverse_pattern_uppercase_preserved(self) -> None:
+        """``word -Word``（连字符后为大写）不应合并 — 多见于专有名词或缩写边界。"""
+        md = "Smith -John (2024) discussed X -Ray imaging."
+        result = self.formatter._apply_typography_fixes(md)
+        # 不应合并为 SmithJohn / XRay
+        assert "SmithJohn" not in result
+        assert "XRay" not in result
+
+    def test_reverse_pattern_em_dash_preserved(self) -> None:
+        """两侧都有空格（``a - b``）是 em-dash 风格，不应合并。"""
+        md = "Section A - Section B contains the analysis."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Section A - Section B" in result or "A — Section" in result
+
+    def test_reverse_pattern_compound_no_space_preserved(self) -> None:
+        """正常复合词（无空格）保持不变。"""
+        md = "neuro-symbolic systems combine state-of-the-art models."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "neuro-symbolic" in result
+        assert "state-of-the-art" in result

--- a/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py
@@ -174,3 +174,68 @@ class TestFormatterHyphenation:
         # 三种都是可接受还原 —— 关键是不能出现裸残 "- " 或视觉破坏。
         assert "- " not in result.replace("(PPAR) and the", "")
         assert "merge" in result and "write" in result
+
+    # ---- R10-D19 守护：em-dash 风格连接词不应被误吞 ----
+
+    def test_em_dash_with_lowercase_connector_or_preserved(self) -> None:
+        """``data - or what was left - was deleted`` 这类含 lowercase 连接词的
+        em-dash 风格句不应被合并 —— 右侧 ``or`` 在 connector denylist 内，
+        保留 ` - ` 分隔符。
+        """
+        md = "data - or what was left of it - was deleted by the cleanup script."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "dataor" not in result
+        assert "data - or" in result
+
+    def test_em_dash_with_lowercase_connector_and_preserved(self) -> None:
+        """``X - and indeed Y`` em-dash 风格应保留分隔符。"""
+        md = "the model - and indeed all its variants - achieves high accuracy."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "modeland" not in result
+        assert "model - and" in result
+
+    def test_em_dash_with_lowercase_connector_which_preserved(self) -> None:
+        """``X - which is Y`` 关系代词 em-dash 风格应保留。"""
+        md = "the framework - which is general purpose - covers the use cases."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "frameworkwhich" not in result
+        assert "framework - which" in result
+
+    def test_em_dash_with_latin_abbr_ie_preserved(self) -> None:
+        """``X - i.e., Y`` 拉丁缩写 em-dash 风格应保留。"""
+        md = "the approach - i.e., the gradient method - converges quickly."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "approachi.e." not in result
+        assert "approach - i.e." in result
+
+    def test_em_dash_with_pronoun_it_preserved(self) -> None:
+        """``X - it Y`` 人称代词 em-dash 风格应保留。"""
+        md = "the system - it was tested extensively - performed well."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "systemit" not in result
+        assert "system - it" in result
+
+    def test_hyphenation_with_short_suffix_still_merged(self) -> None:
+        """守护清单仅含完整连接词，syllable 后缀（``ity`` / ``ing``）应继续合并。
+
+        ``it`` 与 ``in`` 虽在 denylist 中，但 ``it`` 在 ``Scalabil - ity`` 里
+        是 ``ity`` 的前缀，不满足 ``\\b`` 词边界，故不命中守护，正常合并。
+        """
+        md = "table cell shows Scalabil - ity and gov - ernance metrics"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Scalability" in result
+        assert "governance" in result
+
+    # ---- R10-D21 守护：` - ` wrap 收尾不可跨段落 ----
+
+    def test_d21_wrap_does_not_cross_paragraph_break(self) -> None:
+        """段尾 ``word-`` + 段首 lowercase 不应跨段合并 —— ``\\s+`` 收窄为
+        ``[ \\t]+`` 后，``\\n\\n`` 不参与 wrap 收尾。
+        """
+        md = "The author Mary-\n\nsometimes she was called Maria.\n"
+        result = self.formatter._apply_typography_fixes(md)
+        # 段落分隔符必须保留
+        assert "\n\n" in result
+        # 不应跨段合并为单段
+        assert "Marysometimes" not in result
+        assert "Mary-sometimes" not in result

--- a/apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py
@@ -1,0 +1,84 @@
+"""``MarkdownFormatter`` Unicode 残留过滤（U+200B 零宽空格 + UTF-8 双编码 mojibake）。
+
+R10-D17/D18 沉淀：Agentic AI Survey (Springer Nature 期刊) PDF 包含两类
+此前样本未触发的 Unicode 失真：
+
+- D17 零宽空格 U+200B 注入：Springer 期刊在引用 URL 中每个 ASCII 字符之间插入
+  U+200B 作为软换行 hint，Agentic AI Survey 37 页 References 累计注入 1304 处，
+  渲染时不可见但破坏文本拷贝 / 全文检索 / URL 可点击性。
+
+- D18 UTF-8 → CP1252 双编码 mojibake：PDF 中 em-dash ``—`` (U+2014, UTF-8
+  ``E2 80 94``) 在 PyMuPDF 抽取路径上一些情况会被 CP1252 解码为
+  ``â € "`` (U+00E2 U+20AC U+201D) 三字符序列再以 UTF-8 重新编码，最终在
+  Markdown 中显示为 ``â€"``。同类失真也覆盖 en-dash / 引号 / 省略号。
+"""
+
+from __future__ import annotations
+
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+
+
+class TestZeroWidthSpaceStrip:
+    """U+200B 零宽空格应被无条件清除（不可见字符不应进入 markdown）。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_zwsp_in_url_stripped(self) -> None:
+        """Springer 期刊在 URL 每字符间注入的 ZWSP 应被剥离。"""
+        md = "See reference: ​h​t​t​p​s​:​/​/​d​o​i​.​o​r​g​/​1​0​.​1​/​abc"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "​" not in result
+        assert "https://doi.org/10.1/abc" in result
+
+    def test_zwsp_in_body_text_stripped(self) -> None:
+        """正文中的零宽空格（如分词 hint）应被剥离。"""
+        md = "Hello​world and good​bye."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "​" not in result
+        assert "Helloworld" in result
+
+    def test_zwj_preserved(self) -> None:
+        """零宽连接符 U+200D（用于 emoji / 印度系文字连写）不应被剥离。"""
+        md = "Family emoji 👨‍👩‍👧 should stay."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "‍" in result
+
+
+class TestMojibakeFix:
+    """UTF-8 → CP1252 → UTF-8 双编码 mojibake 应被还原。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_em_dash_mojibake_restored(self) -> None:
+        """em-dash ``—`` 的三字符 mojibake ``â€"`` 应被还原。"""
+        md = "Agentic AI: complex goalsâ€”A comprehensive survey of architectures"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "goals—A" in result
+        assert "â€" not in result
+
+    def test_en_dash_mojibake_restored(self) -> None:
+        """en-dash ``–`` 的 mojibake ``â€"`` 应被还原。"""
+        md = "Pages 2018â€“2025 of the analysis"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "2018–2025" in result
+
+    def test_right_single_quote_mojibake_restored(self) -> None:
+        """right single quote ``'`` 的 mojibake ``â€™`` 应被还原。"""
+        md = "Agentic AIâ€™s dual lineages"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Agentic AI’s" in result
+
+    def test_legitimate_em_dash_preserved(self) -> None:
+        """合法 em-dash 不应被改动。"""
+        md = "This is a sentence — with an em-dash."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "—" in result
+
+    def test_text_without_mojibake_unchanged(self) -> None:
+        """普通文本（无任何 mojibake / ZWSP）经过此规则应无变化。"""
+        md = "Plain ASCII text without artifacts."
+        result = self.formatter._apply_typography_fixes(md)
+        # 末尾可能因其他规则影响，但 mojibake / ZWSP 维度应无变化
+        assert "Plain ASCII text without artifacts." in result

--- a/apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py
@@ -152,3 +152,19 @@ class TestSpaceBeforeCloseParen:
         md = 'The article "(quoted text)" is unchanged.'
         result = self.formatter._apply_typography_fixes(md)
         assert '"(quoted text)"' in result
+
+    def test_open_paren_space_normalized(self) -> None:
+        """``( 2008)`` → ``(2008)``。学术 PDF 中 ``(\\n2008)`` 经 PyMuPDF 折叠
+        形成 ``( 2008)``，与 D23 闭括号空格对称。
+        """
+        md = "Adopted by Thomas and Harden ( 2008), per Kaelbling et al. ( 1998)."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "(2008)" in result
+        assert "(1998)" in result
+        assert "( 2008)" not in result
+
+    def test_open_paren_no_space_preserved(self) -> None:
+        """正常 ``(2008)`` 不变。"""
+        md = "Reference (2008) is normal."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "(2008)" in result

--- a/apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py
@@ -82,3 +82,73 @@ class TestMojibakeFix:
         result = self.formatter._apply_typography_fixes(md)
         # 末尾可能因其他规则影响，但 mojibake / ZWSP 维度应无变化
         assert "Plain ASCII text without artifacts." in result
+
+
+class TestLatin1MojibakeFix:
+    """Latin-1 重音字符（á / é / í / ó / ú / ñ / ü 等）的 UTF-8 → CP1252 双编码
+    mojibake 还原。原 ``í`` UTF-8 ``\\xc3\\xad`` 被 CP1252 解为 ``Ã`` + ``­``，
+    再以 UTF-8 编码成 4 字节序列；当下游 U+00AD 兜底剥离生效后，残留为 ``RodrÃguez``
+    （丢失 ``í`` 的尾字节信息）。需在 ZWSP / U+00AD 兜底**之前**识别完整 mojibake
+    序列并还原。
+    """
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_i_acute_mojibake_restored(self) -> None:
+        """``í`` 的 mojibake ``Ã­`` (Ã + U+00AD soft hyphen) 应还原为 ``í``。"""
+        md = "Author RodrÃ­guez A. (2024) and MartÃ­nez B."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Rodríguez" in result
+        assert "Martínez" in result
+        assert "Ã" not in result
+
+    def test_n_tilde_mojibake_restored(self) -> None:
+        """``ñ`` 的 mojibake ``Ã±`` 应还原。"""
+        md = "MuÃ±oz et al. and PerÃ±ez (2024)"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Muñoz" in result
+        assert "Perñez" in result
+
+    def test_e_acute_mojibake_restored(self) -> None:
+        """``é`` 的 mojibake ``Ã©`` 应还原。"""
+        md = "PÃ©rez and SÃ¡nchez (2024)"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "Pérez" in result
+        assert "Sánchez" in result
+
+
+class TestSpaceBeforeCloseParen:
+    """学术 PDF 经常在年份 / 引用编号后留 ``(2025 )`` 形式的空格，应正规化为
+    ``(2025)``。Springer Nature 期刊在 References / Table cells 中尤其多。
+    """
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_year_close_paren_normalized(self) -> None:
+        """``(2025 )`` → ``(2025)``。"""
+        md = "See Plaat et al. (2025 ) and Schneider (2025 ) for details."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "(2025)" in result
+        assert "(2025 )" not in result
+
+    def test_word_close_paren_normalized(self) -> None:
+        """``(single-agent system )`` → ``(single-agent system)``。"""
+        md = "An AI Agent (or a single-agent system ) is a unit."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "(or a single-agent system)" in result
+        assert "system )" not in result
+
+    def test_balanced_paren_preserved(self) -> None:
+        """``(content)`` 形式无空格应不变。"""
+        md = "Reference (2025) and (single system) preserved."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "(2025)" in result
+        assert "(single system)" in result
+
+    def test_paren_inside_quotes_not_broken(self) -> None:
+        """带括号的引用如 ``"AI"`` 不应受影响。"""
+        md = 'The article "(quoted text)" is unchanged.'
+        result = self.formatter._apply_typography_fixes(md)
+        assert '"(quoted text)"' in result

--- a/apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py
+++ b/apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py
@@ -133,3 +133,54 @@ class TestHeadingClassification:
             # 短的 pronoun 起首 noun phrase 应被字号守卫接受为 heading
             # （非编号路径，依赖 size_ratio 推断级别）
             assert r is not None, f"short pronoun heading {short!r} dropped"
+
+    # ---- R10-D25：编号 list-item label + 句子型 body 边界 ----
+
+    def test_label_body_with_capital_hyphen_comma_not_heading(self) -> None:
+        """编号 list-item label + 句子型 body 折叠到同一文本块的产物
+        ``1. Paradigm specialization by domain High-stakes, regulated domains``
+        包含 ``[a-z]+\\s+[A-Z][\\w-]+,`` 信号（lowercase + Capital-hyphen + 逗号），
+        在学术 heading 中几乎不出现，应识别为列表项而非 heading。
+        """
+        text = (
+            "1. Paradigm specialization by domain High-stakes, regulated domains "
+            "like Healthcare"
+        )
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result is None, f"label+body list-item misclassified as h{result}"
+
+    def test_legitimate_heading_with_capital_compound_preserved(self) -> None:
+        """合法 heading 含 Capital 复合词但无逗号（``Deep Learning Models for
+        Reinforcement Learning Applications``）应保留为 heading。"""
+        text = "5 Deep Learning Models for Reinforcement Learning Applications"
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result == 1, f"legitimate heading dropped: got {result!r}"
+
+    def test_legitimate_heading_with_colon_subtitle_preserved(self) -> None:
+        """合法 heading 含 colon subtitle（D25 length/colon 守卫）应保留。"""
+        text = "4 Findings: a paradigm-aware analysis of the Agentic AI landscape"
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result == 1
+
+    def test_short_numbered_heading_with_one_capital_preserved(self) -> None:
+        """长度 < 50 的短编号 heading 即使含 Capital 词也不应触发 D25。"""
+        text = "2 Theoretical framework for Agentic AI"
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result == 1
+
+    def test_legitimate_compound_no_comma_preserved(self) -> None:
+        """含 hyphen 的 Capital 复合词但无逗号（``Cross-functional analysis``）
+        应保留为合法 heading。"""
+        text = "3 Cross-functional analysis of LLM systems and frameworks"
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result == 1

--- a/apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py
+++ b/apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py
@@ -184,3 +184,58 @@ class TestHeadingClassification:
             text, self.HEADING_FONT, self.BODY_FONT
         )
         assert result == 1
+
+    # ---- R10-D16 守护：罗马数字 I 与代词 I 区分 ----
+
+    @pytest.mark.parametrize(
+        "text,expected_level",
+        [
+            # 罗马数字 I 后跟 lowercase 词的合法 heading（``Phase I improvements`` /
+            # ``Type I errors`` / ``Class I features``）。旧版 ``\\b(We|I|Our)\\s+[a-z]``
+            # 会误吞这些，需走 verb-anchored 守护避开。
+            ("1 Phase I improvements over baseline systems", 1),
+            ("2 Type I errors in evaluation methodology", 1),
+            ("3 Class I features of the proposed model", 1),
+            ("4 Period I results from the analysis", 1),
+        ],
+    )
+    def test_roman_numeral_I_heading_preserved(
+        self, text: str, expected_level: int
+    ) -> None:
+        """编号 heading 含罗马数字 I + lowercase 词不应被句子型过滤命中。"""
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result == expected_level, (
+            f"expected h{expected_level} for {text!r}, got {result}"
+        )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # 学术第一人称 ``I`` + 叙述动词：应识别为句子型正文。
+            "1. I propose a novel framework for agent coordination",
+            "2. I introduce a new taxonomy spanning agentic paradigms",
+            "3. I argue that existing approaches fail to address scalability",
+            "4. I demonstrate the effectiveness of the proposed model",
+        ],
+    )
+    def test_first_person_I_with_academic_verb_filtered(self, text: str) -> None:
+        """``I`` 后紧跟学术叙述动词（propose / introduce / argue / demonstrate
+        等）的句子型正文应过滤。"""
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result is None, f"first-person sentence misclassified as h{result}"
+
+    def test_roman_numeral_I_non_numbered_preserved(self) -> None:
+        """非编号路径下，``Phase I introduction`` 这类长 heading 含罗马数字 I 不应被
+        过滤（``introduction`` 是名词非叙述动词，且 ``I`` 后接它构不成学术第一人称句）。
+        长度 > 50 触发字号守卫但 verb-anchored 守护不命中。
+        """
+        text = "Phase I introduction of new reasoning capabilities for agents"
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        # 字号守卫接受为 heading（size_ratio 决定级别）
+        assert result is not None, f"Roman-numeral I heading dropped: got {result!r}"

--- a/apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py
+++ b/apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py
@@ -1,0 +1,135 @@
+"""``FitzTextExtractor`` 结构识别（页眉页脚过滤 + heading 分级）单元测试。
+
+R10-D15/D16 沉淀：Agentic AI Survey (Springer Nature 期刊) PDF 包含两类
+此前样本未触发的结构性失真：
+
+- D15 页眉页脚泄漏：Springer 期刊页脚 ``11 Page 2 of 37`` / 反向 ``Page 3 of 37 11`` /
+  作者运行头 ``M. Abou Ali et al.`` / 双数字页码 ``1 3`` 等模式被 PyMuPDF
+  抽取为正文短段落，``_is_header_footer`` 的位置启发式因 ``20 <= text_len``
+  下界过滤掉了所有 < 20 字符的运行头，导致泄漏。
+- D16 误判 heading：列表项 ``1. A novel dual-paradigm taxonomy We introduce
+  and employ a new framework (Fig. 2 )`` 被 ``_detect_heading`` 提升为 ``##``，
+  破坏 TOC 与文档大纲；句子型正文被错升的根因是 ``len > 100`` 的长度阈值
+  对学术句子型号召过于宽松。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from negentropy.perceives.pipeline.stages.pdf.text_extraction import (
+    FitzTextExtractor,
+)
+
+
+class TestHeaderFooterFilter:
+    """``_is_header_footer`` 应正确识别期刊页眉页脚而不误伤短标题。"""
+
+    # bbox 与 page_height 的占位值（页脚区域）— 这些模式应通过纯文本即可判定，
+    # 不依赖位置。
+    BBOX_BODY = (50.0, 300.0, 400.0, 320.0)  # 正文居中
+    PAGE_H = 800.0
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "11 Page 2 of 37",  # Springer 期刊页脚（issue + page of total）
+            "Page 3 of 37 11",  # 反向变体
+            "1 3",  # 双数字运行页码（双栏期刊常见）
+            "M. Abou Ali et al.",  # 作者运行头（First Author surname + et al.）
+            "Smith and Jones et al.",  # 多作者运行头变体
+        ],
+    )
+    def test_journal_running_headers_filtered(self, text: str) -> None:
+        """期刊运行头 / 页脚不论位置都应过滤。"""
+        assert FitzTextExtractor._is_header_footer(text, self.BBOX_BODY, self.PAGE_H)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Introduction",  # 短标题应保留
+            "Conclusion",
+            "Methods",
+            "1 Background",  # 编号短标题
+            "2.1 Symbolic AI",  # 子节标题
+            "Body paragraph starting with normal text.",  # 短正文段
+        ],
+    )
+    def test_legitimate_short_text_not_filtered(self, text: str) -> None:
+        """合法短标题 / 短段落不应被误判为页眉页脚。"""
+        assert not FitzTextExtractor._is_header_footer(
+            text, self.BBOX_BODY, self.PAGE_H
+        )
+
+
+class TestHeadingClassification:
+    """``_detect_heading`` 不应把句子型正文升级为 heading。"""
+
+    # 学术论文典型字号：body 10pt，h2/h3 11-13pt
+    BODY_FONT = 10.0
+    HEADING_FONT = 12.0
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # R10-D16：编号开头但内含完整句子（含 "We" 作者代词 + 动词 "introduce"），
+            # 应被识别为列表项 / 正文，而非 heading
+            "1. A novel dual-paradigm taxonomy We introduce and employ a new framework",
+            # 编号开头 + 不定式列表项（"To identify, classify, and synthesize ..."）
+            "1. To identify, classify, and synthesize literature based on the dual paradigm",
+            # 编号开头 + 含图表引用 + 显著主谓结构
+            "2. We provide a comprehensive analysis of the agentic landscape (Fig. 2)",
+        ],
+    )
+    def test_sentence_like_numbered_not_heading(self, text: str) -> None:
+        """编号开头但句子结构明显的文本不应被升级为 heading。"""
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result is None, f"unexpected heading level {result} for: {text!r}"
+
+    @pytest.mark.parametrize(
+        "text,expected_level",
+        [
+            # 真正的 numbered headings：短、名词性短语、无主谓结构
+            ("1 Introduction", 1),
+            ("2 Theoretical framework: a dual-paradigm taxonomy for Agentic AI", 1),
+            ("2.1 Core principles of autonomy and agency", 2),
+            ("2.2.1 Markov decision processes (MDPs)", 3),
+            ("3 Methodology", 1),
+            ("4 Findings: a paradigm-aware analysis of the Agentic AI landscape", 1),
+        ],
+    )
+    def test_legitimate_numbered_headings_classified(
+        self, text: str, expected_level: int
+    ) -> None:
+        """合法 numbered headings 应正确分级。"""
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result == expected_level, (
+            f"expected h{expected_level} for {text!r}, got {result}"
+        )
+
+    def test_sentence_like_non_numbered_not_heading(self) -> None:
+        """非编号路径下，含作者代词 + 多词正文的句子（``Our analysis of the
+        complete corpus reveals three significant patterns:``）即使字号较大
+        也不应被升级为 heading —— 常见于章节小节的 lead-in 句。
+        """
+        text = "Our analysis of the complete corpus reveals three significant patterns:"
+        result = FitzTextExtractor._detect_heading(
+            text, self.HEADING_FONT, self.BODY_FONT
+        )
+        assert result is None, f"sentence lead-in misclassified as heading h{result}"
+
+    def test_legitimate_short_pronoun_heading_preserved(self) -> None:
+        """合法的"我方"风格短标题（如 ``Our methodology`` / ``Our approach``）
+        应保留 —— 仅句子结构（pronoun + 多词正文）才被过滤。
+        """
+        for short in ("Our Method", "Our Approach", "Our Framework"):
+            r = FitzTextExtractor._detect_heading(
+                short, self.HEADING_FONT, self.BODY_FONT
+            )
+            # 短的 pronoun 起首 noun phrase 应被字号守卫接受为 heading
+            # （非编号路径，依赖 size_ratio 推断级别）
+            assert r is not None, f"short pronoun heading {short!r} dropped"


### PR DESCRIPTION
## 背景

[ISSUE-094 PDF→Markdown 还原工程](docs/.agents/issue.md) 第十轮迭代。本轮以 **Agentic AI Survey 37 页 Springer Nature 期刊** 作为 unseen sample 端到端测试 negentropy-perceives 的 `parse_pdf_to_markdown` 管线（11 stages：preprocessing → quick_scan → layout_analysis → text_extraction → table_extraction → formula_extraction → image_extraction → code_detection → assembly → asset_bundling）；逐页对照 PDF 原文档与 Markdown 渲染（Knowledge Base 的 Harness Engineering corpus），按 12 维质量矩阵深度扫描，**累计定位并修复 13 个此前 sample 未触发的根因维度**。

主要影响：学术 PDF 在 Markdown 渲染时残留大量「不可见破坏」—— 软连字符 / 零宽空格 / UTF-8 双编码 mojibake / 期刊运行头 / 括号空格 / 句子型 heading 误判 / list-item label+body 折叠等。这些残留破坏文本拷贝、全文检索、URL 可点击性、TOC 大纲、视觉一致性。

## 修复维度（R10 新增 D13-D25 共 13 维）

| 维度 | 失真 | 修复点 | sample 实例 |
|---|---|---|---|
| **D13** | 软连字符 U+00AD 渗漏 | `MarkdownFormatter._apply_typography_fixes`：`­[ \\t]*(?=[a-z])` 合并 + 兜底 strip | 138 → 0 |
| **D14** | 反向 `word -word`（图注路径） | `(?<=[a-zA-Z]) -(?=[a-z])` 强制合并 | 11 → 0 |
| **D15** | 期刊运行头 / 页脚泄漏 | `FitzTextExtractor._is_header_footer` 补 Springer / 双数字 / `Surname et al.` 4 类模式 | 58 → 0 |
| **D16** | 列表项 lead-in 句被误升 heading | `_detect_heading` 编号路径 + 非编号路径补「作者代词 + 多词正文」过滤 | 3 → 0（h2 15→12, h4 13→12） |
| **D17** | 零宽空格 U+200B（URL 注入） | 全局 `text.replace("​", "")`，保留 U+200D ZWJ | **1304 → 0** |
| **D18** | UTF-8 / CP1252 双编码 mojibake（em / en dash / 引号 / 省略号） | 固定 6 模式映射 `â€" → —` 等 | 1 → 0 |
| **D19** | 两侧空格 `word - word`（表格 cell 内） | `(?<=[a-zA-Z]{2}) - (?=[a-z]{2})` 强制合并 | 80 → 0 |
| **D20** | Table caption 紧邻重复 | `_deduplicate_approximate_paragraphs` 起首插入 caption 精确去重 | 5 → 0 |
| **D21** | 复合 hyphen 链 wrap 误吞（`Reasoning-acting- interacting`） | `(?<![a-zA-Z]-)` 守护 + `(?<=[a-z])-\\s+(?=[a-z]{2})` 收尾 | `actinginteracting` 1 → 0 |
| **D22** | Latin-1 重音字符 mojibake（`Ã­` → `í`） | D13 之前 10 类 Latin-1 mojibake 映射 | `RodrÃguez` 1 → 0 |
| **D23** | 闭括号前空格（`(2025 )`） | `(\\S) \\)` → `\\1)` | 112 → 0 |
| **D24** | 开括号后空格（`( 2008)`，D23 镜像） | `\\( (\\S)` → `(\\1` | 3 → 0 |
| **D25** | list-item label + 句子型 body 误升 heading | `_detect_heading` 编号路径补 `[a-z]+\\s+[A-Z][\\w-]+,` 信号 + length>50 + no colon 守护 | h2 12 → 10（含意外修复一处误升的作者机构 `IKERBASQUE`） |

## 改动文件

- `apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py` —— 9 条新增排版归一化规则 + 1 处 caption 去重补强
- `apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py` —— `_is_header_footer` + `_detect_heading` 增 8 条结构识别规则（含 D25）
- `apps/negentropy-perceives/tests/unit/test_formatter_hyphenation.py` —— 新增 11 条断字 / 复合链测试
- `apps/negentropy-perceives/tests/unit/test_formatter_unicode_artifacts.py` —— 新建文件，17 条 ZWSP / mojibake / 括号空格测试
- `apps/negentropy-perceives/tests/unit/test_formatter_dedupe_table_caption.py` —— 新建文件，3 条 caption 去重测试
- `apps/negentropy-perceives/tests/unit/test_text_extraction_structure.py` —— 新建文件，27 条运行头 / heading 分级测试（含 D25 5 条）

## 9 commits（按维度顺序）

- `1689bd43` R1 D13/D14
- `60143ae0` R2+R3 D15/D16
- `af1559ed` R4 D17/D18
- `70ebc549` R5 D19/D20
- `2474f80a` R6 D21
- `17a1c647` R7 D22/D23
- `a7fd5980` R8 D24
- `dcb76932` R9 D25

## 测试 & 实机验证

- ✅ **Unit 全量回归 1625 passed 0 regression**（含本轮新增 58 测试，5 条为 D25）
- ✅ **签名跨轮稳定**：图 9 / table 87 行 / 13 表头 / inline_math 0 / block_math 0 / code_block 0 维度不变；md_chars 116508 → 113319（-2.7%，全部为噪声清理）；h2/h4 误判修正（h2: 15→10 / h4: 13→12）
- ✅ **Chrome 实机双 tab 对照**（用户常用 Chrome 主 profile）：PDF 原文 vs Documents 渲染逐页扫描，封面 / 摘要 / TOC / 章节 / Table 1 / Figures 2-8 / 4.1 list / References 全维度通过
- ✅ **重抽取链路验证**：通过 backend `POST /knowledge/base/{corpus_id}/documents/{document_id}/refresh_markdown` 触发 9 轮端到端重新解析，DB `markdown_extract_status` 轮询 + GCS asset 上传双确认

## 已知限制 / 后续候选（非阻塞）

- **D26 候选**：4.1 节列表的第 2、3 项 (`2. The governance divide ...`、`3. Temporal paradigm shift ...`) 仍被吸入紧跟段落正文中（不影响 heading 大纲，但语义结构未完整恢复）。这需要 assembly 层的「numbered prefix mid-paragraph splitting」改动，跨度较大，留待后续单独工作项。

## Test plan

- [x] Unit tests `apps/negentropy-perceives/tests/unit/` 全量绿（1625 passed）
- [x] 量化签名（heading 数 / 图数 / 表行数 / 公式数 / hyphen residue 等）跨 r0 → r9 diff 全部为 0 新增问题
- [x] Chrome 实机双 tab 视觉对照（首页 / TOC 页 / 含图页 / 含表页 / 含 4.1 list 页 / 末页）
- [x] 13 维质量矩阵逐维核对清单
- [ ] reviewer: 用其他 unseen 学术 PDF（如 NeurIPS / IEEE 期刊）抽样验证以确认 R10 治理无回归

## 相关

- 13 维质量矩阵 + R10 经验沉淀已同步至 `pdf-to-markdown-12d-quality-matrix` memory
- 端到端验证范式见 `pdf-to-markdown-e2e-verification` memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)