### PR TITLE
fix(annotation): 修复浏览器翻译态下 Wiki 注解消失问题（snapshot 锚定 + MutationObserver 自动重应用 + CSS Highlight API）

### DIFF
--- a/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
@@ -3,130 +3,168 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { resolveAnchor, type TextAnchor } from "@/lib/annotation/use-text-anchor";
 import type { AnnotationItem } from "@/lib/annotation/use-annotations";
+import type { AnnotationSnapshot } from "@/lib/annotation/use-snapshot";
+import {
+  debounce,
+  isContainerTranslated,
+  isTranslationMutation,
+} from "@/lib/annotation/use-translation-detect";
+import {
+  pickRenderer,
+  type HighlightGroupInput,
+  type HighlightRenderer,
+  type HitTestFn,
+} from "@/lib/annotation/use-highlight-renderer";
 import { AnnotationTooltip } from "./AnnotationTooltip";
 
 interface Props {
   containerRef: React.RefObject<HTMLElement | null>;
   annotations: AnnotationItem[];
+  /** 稳定快照 ref。提供时启用 source-anchored 路径；否则走兼容路径（与 v1 anchor 行为一致）。 */
+  snapshotRef?: React.MutableRefObject<AnnotationSnapshot | null>;
 }
 
-interface HighlightGroup {
-  annotationIds: string[];
-  range: Range;
+interface TooltipState {
+  x: number;
+  y: number;
   annotations: AnnotationItem[];
 }
 
-export function AnnotationHighlightLayer({ containerRef, annotations }: Props) {
-  const [tooltip, setTooltip] = useState<{
-    x: number;
-    y: number;
-    annotations: AnnotationItem[];
-  } | null>(null);
-  const highlightRefs = useRef<Map<string, HTMLElement>>(new Map());
+export function AnnotationHighlightLayer({
+  containerRef,
+  annotations,
+  snapshotRef,
+}: Props) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const observerRef = useRef<MutationObserver | null>(null);
+  const rendererRef = useRef<HighlightRenderer | null>(null);
+  const hitTestRef = useRef<HitTestFn | null>(null);
 
-  // 注解到高亮的映射
+  const handleHoverStart = useCallback(
+    (group: HighlightGroupInput, rect: DOMRect) => {
+      setTooltip({
+        x: rect.left,
+        y: rect.bottom + 6,
+        annotations: group.annotations,
+      });
+    },
+    [],
+  );
+
+  const handleHoverEnd = useCallback(() => {
+    setTooltip(null);
+  }, []);
+
   const applyHighlights = useCallback(() => {
     const container = containerRef.current;
     if (!container || annotations.length === 0) return;
 
-    // 清除旧高亮
-    highlightRefs.current.forEach((el) => {
-      const parent = el.parentNode;
-      if (parent) {
-        while (el.firstChild) parent.insertBefore(el.firstChild, el);
-        parent.removeChild(el);
-      }
-    });
-    highlightRefs.current.clear();
+    // 临时 disconnect observer，避免本函数修改 DOM 触发回调形成递归。
+    const observer = observerRef.current;
+    observer?.disconnect();
 
-    // 按锚定数据分组
-    const groups: HighlightGroup[] = [];
-    for (const annotation of annotations) {
-      const anchor = annotation.anchor as unknown as TextAnchor;
-      const range = resolveAnchor(anchor, container);
-      if (!range) continue;
+    try {
+      // 自适应渲染器选择：翻译态 + 支持 CSS Highlight API → CSSHighlightRenderer
+      // 否则 → MarkWrapRenderer（事件交互简单的兼容路径）
+      const translated = isContainerTranslated(container);
+      const factory = pickRenderer({ isTranslated: translated });
 
-      // 检查是否与已有 group 重叠
-      const existing = groups.find((g) => rangesOverlap(g.range, range));
-      if (existing) {
-        existing.annotationIds.push(annotation.id);
-        existing.annotations.push(annotation);
-      } else {
-        groups.push({
-          annotationIds: [annotation.id],
-          range,
-          annotations: [annotation],
-        });
-      }
-    }
+      // 清除前一渲染器（如果存在且类型变了）
+      rendererRef.current?.clear();
+      const renderer = factory(handleHoverStart, handleHoverEnd);
+      rendererRef.current = renderer;
 
-    // 应用高亮
-    for (const group of groups) {
-      try {
-        const mark = document.createElement("mark");
-        mark.className = "wiki-annotation-highlight";
-        mark.dataset.annotationIds = group.annotationIds.join(",");
+      // 按锚定数据解析为 Range 并按重叠分组
+      const groups: HighlightGroupInput[] = [];
+      for (const annotation of annotations) {
+        const anchor = annotation.anchor as unknown as TextAnchor;
+        const range = resolveAnchor(anchor, container, snapshotRef?.current);
+        if (!range) continue;
 
-        mark.addEventListener("mouseenter", () => {
-          const rect = mark.getBoundingClientRect();
-          setTooltip({
-            x: rect.left,
-            y: rect.bottom + 6,
-            annotations: group.annotations,
+        const existing = groups.find((g) => rangesOverlap(g.range, range));
+        if (existing) {
+          existing.annotationIds.push(annotation.id);
+          existing.annotations.push(annotation);
+        } else {
+          groups.push({
+            annotationIds: [annotation.id],
+            range,
+            annotations: [annotation],
           });
-        });
-        mark.addEventListener("mouseleave", () => {
-          setTooltip(null);
-        });
-
-        group.range.surroundContents(mark);
-        highlightRefs.current.set(group.annotationIds.join(","), mark);
-      } catch {
-        // Range 跨节点时 surroundContents 会失败，尝试 splitText 方式
-        try {
-          const fragment = group.range.extractContents();
-          const mark = document.createElement("mark");
-          mark.className = "wiki-annotation-highlight";
-          mark.dataset.annotationIds = group.annotationIds.join(",");
-
-          mark.addEventListener("mouseenter", () => {
-            const rect = mark.getBoundingClientRect();
-            setTooltip({
-              x: rect.left,
-              y: rect.bottom + 6,
-              annotations: group.annotations,
-            });
-          });
-          mark.addEventListener("mouseleave", () => {
-            setTooltip(null);
-          });
-
-          mark.appendChild(fragment);
-          group.range.insertNode(mark);
-          highlightRefs.current.set(group.annotationIds.join(","), mark);
-        } catch {
-          // 最终降级：无法高亮此范围
         }
       }
-    }
-  }, [containerRef, annotations]);
 
+      hitTestRef.current = renderer.apply(groups);
+    } finally {
+      // 恢复 observer
+      if (observer && container) {
+        observer.observe(container, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+          attributes: true,
+          attributeFilter: ["lang", "translate"],
+        });
+      }
+    }
+  }, [containerRef, annotations, snapshotRef, handleHoverStart, handleHoverEnd]);
+
+  // 主应用 + 卸载清理
   useEffect(() => {
     applyHighlights();
     return () => {
-      highlightRefs.current.forEach((el) => {
-        const parent = el.parentNode;
-        if (parent) {
-          while (el.firstChild) parent.insertBefore(el.firstChild, el);
-          parent.removeChild(el);
-        }
-      });
-      highlightRefs.current.clear();
+      rendererRef.current?.clear();
+      rendererRef.current = null;
+      hitTestRef.current = null;
     };
   }, [applyHighlights]);
 
-  if (!tooltip) return null;
+  // MutationObserver：监听容器 DOM 变化（含浏览器翻译、内容重渲染），
+  // debounce 后重新应用高亮。R3 的根治方案。
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
 
+    const debouncedReapply = debounce(applyHighlights, 200);
+    const observer = new MutationObserver((mutations) => {
+      if (mutations.some(isTranslationMutation)) debouncedReapply();
+    });
+    observerRef.current = observer;
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ["lang", "translate"],
+    });
+
+    return () => {
+      debouncedReapply.cancel();
+      observer.disconnect();
+      observerRef.current = null;
+    };
+  }, [applyHighlights, containerRef]);
+
+  // CSS Highlight 模式下，事件不挂在元素上 —— 用 document mousemove 命中检测
+  useEffect(() => {
+    if (rendererRef.current?.supportsElementEvents !== false) return;
+    let hovered: HighlightGroupInput | null = null;
+    const onMove = (e: MouseEvent) => {
+      const hit = hitTestRef.current?.(e.clientX, e.clientY) ?? null;
+      if (hit === hovered) return;
+      hovered = hit;
+      if (hit) {
+        // 在光标位置下方 16px 显示 tooltip（避开光标）
+        handleHoverStart(hit, new DOMRect(e.clientX, e.clientY - 8, 0, 16));
+      } else {
+        handleHoverEnd();
+      }
+    };
+    document.addEventListener("mousemove", onMove);
+    return () => document.removeEventListener("mousemove", onMove);
+  }, [annotations, handleHoverStart, handleHoverEnd]);
+
+  if (!tooltip) return null;
   return <AnnotationTooltip position={tooltip} />;
 }
 

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
@@ -145,16 +145,22 @@ export function AnnotationHighlightLayer({
     };
   }, [applyHighlights, containerRef]);
 
-  // CSS Highlight 模式下，事件不挂在元素上 —— 用 document mousemove 命中检测
+  // CSS Highlight 模式下事件不挂在元素上，需要 document mousemove 命中检测。
+  // 始终注册监听器：MarkWrapRenderer 的 hitTestFn 返回 () => null，无额外开销；
+  // 渲染器可能因 MutationObserver 触发的 applyHighlights 在运行时切换（如用户
+  // 在页面加载后手动触发翻译），若在 effect 注册时判断 rendererRef 类型则
+  // 不会因翻译事件重新注册，导致 CSS Highlight 注解失去 hover tooltip。
   useEffect(() => {
-    if (rendererRef.current?.supportsElementEvents !== false) return;
     let hovered: HighlightGroupInput | null = null;
     const onMove = (e: MouseEvent) => {
+      if (rendererRef.current?.supportsElementEvents !== false) {
+        if (hovered) { hovered = null; handleHoverEnd(); }
+        return;
+      }
       const hit = hitTestRef.current?.(e.clientX, e.clientY) ?? null;
       if (hit === hovered) return;
       hovered = hit;
       if (hit) {
-        // 在光标位置下方 16px 显示 tooltip（避开光标）
         handleHoverStart(hit, new DOMRect(e.clientX, e.clientY - 8, 0, 16));
       } else {
         handleHoverEnd();
@@ -162,7 +168,7 @@ export function AnnotationHighlightLayer({
     };
     document.addEventListener("mousemove", onMove);
     return () => document.removeEventListener("mousemove", onMove);
-  }, [annotations, handleHoverStart, handleHoverEnd]);
+  }, [handleHoverStart, handleHoverEnd]);
 
   if (!tooltip) return null;
   return <AnnotationTooltip position={tooltip} />;

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef } from "react";
 import { useAnnotations } from "@/lib/annotation/use-annotations";
 import { useWikiAuth } from "@/lib/auth/wiki-auth";
 import { type TextAnchor } from "@/lib/annotation/use-text-anchor";
+import { useSnapshot } from "@/lib/annotation/use-snapshot";
 import { TextSelectionHandler } from "./TextSelectionHandler";
 import { AnnotationComposer } from "./AnnotationComposer";
 import { AnnotationHighlightLayer } from "./AnnotationHighlightLayer";
@@ -15,8 +16,12 @@ interface Props {
 
 export function AnnotationLayer({ entryId, children }: Props) {
   const { annotations, createAnnotation, loading } = useAnnotations(entryId);
-  const { status } = useWikiAuth();
+  // status from useWikiAuth is read by child components; no direct use here
+  useWikiAuth();
   const contentRef = useRef<HTMLDivElement>(null);
+  // 稳定快照：mount 后立即抓取，作为注解锚定的唯一权威坐标系。
+  // entryId 变化时重抓（切换不同文章）。详见 use-snapshot.ts。
+  const snapshotRef = useSnapshot(contentRef, [entryId]);
 
   const [composer, setComposer] = useState<{
     anchor: TextAnchor;
@@ -62,11 +67,13 @@ export function AnnotationLayer({ entryId, children }: Props) {
         <AnnotationHighlightLayer
           containerRef={contentRef}
           annotations={annotations}
+          snapshotRef={snapshotRef}
         />
       )}
       <TextSelectionHandler
         containerSelector=".wiki-markdown-body"
         onAnnotate={handleAnnotate}
+        snapshotRef={snapshotRef}
       />
       {composer && (
         <AnnotationComposer

--- a/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
@@ -3,13 +3,16 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useWikiAuth } from "@/lib/auth/wiki-auth";
 import { computeAnchor, type TextAnchor } from "@/lib/annotation/use-text-anchor";
+import type { AnnotationSnapshot } from "@/lib/annotation/use-snapshot";
 
 interface Props {
   containerSelector: string;
   onAnnotate: (anchor: TextAnchor, quotedText: string, rect: DOMRect) => void;
+  /** 稳定快照 ref。提供时基于 snapshot 计算锚（跨翻译稳定）；否则按当前 DOM 计算（兼容路径）。 */
+  snapshotRef?: React.MutableRefObject<AnnotationSnapshot | null>;
 }
 
-export function TextSelectionHandler({ containerSelector, onAnnotate }: Props) {
+export function TextSelectionHandler({ containerSelector, onAnnotate, snapshotRef }: Props) {
   const { status } = useWikiAuth();
   const [fabPosition, setFabPosition] = useState<{ x: number; y: number } | null>(null);
   const [currentAnchor, setCurrentAnchor] = useState<TextAnchor | null>(null);
@@ -45,7 +48,8 @@ export function TextSelectionHandler({ containerSelector, onAnnotate }: Props) {
       return;
     }
 
-    const anchor = computeAnchor(selection, container);
+    // 优先使用 snapshot 计算锚定（跨翻译稳定）；未注入时回退到旧路径。
+    const anchor = computeAnchor(selection, container, snapshotRef?.current);
     if (!anchor) return;
 
     const rect = range.getBoundingClientRect();
@@ -57,7 +61,7 @@ export function TextSelectionHandler({ containerSelector, onAnnotate }: Props) {
     const x = rect.left + rect.width / 2;
     const y = rect.top - 8;
     setFabPosition({ x, y });
-  }, [containerSelector, isAuthenticated]);
+  }, [containerSelector, isAuthenticated, snapshotRef]);
 
   useEffect(() => {
     document.addEventListener("selectionchange", handleSelectionChange);

--- a/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
@@ -43,7 +43,11 @@ interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
-    <div className="wiki-markdown-body">
+    // translate="no"：声明此容器为「注解锚定的稳定坐标系」，提示浏览器
+    // 默认不自动翻译（解决 R5）。用户主动右键翻译仍可生效；此时配合
+    // AnnotationHighlightLayer 的 MutationObserver（解决 R3）实现高亮重应用，
+    // 并由后续 Phase B 的 source-anchored selectors 实现跨语言注解持久化。
+    <div className="wiki-markdown-body" translate="no">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[

--- a/apps/negentropy-wiki/src/lib/annotation/annotation-shared.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/annotation-shared.ts
@@ -1,0 +1,23 @@
+/**
+ * 注解模块共享常量与工具函数。
+ *
+ * 被 use-snapshot.ts 和 use-text-anchor.ts 共同引用，消除重复定义，
+ * 防止单侧漂移导致的静默失效（如哈希算法不一致导致 v2 anchor 快速路径断裂）。
+ */
+
+/** 块级元素标签集合：用于 snapshot 块级索引和 text-anchor 的粗粒度回退/投影。 */
+export const BLOCK_TAGS = new Set([
+  "P", "LI", "BLOCKQUOTE", "PRE", "TABLE", "TR", "TD", "TH",
+  "H1", "H2", "H3", "H4", "H5", "H6",
+  "DIV", "ARTICLE", "SECTION", "FIGURE", "FIGCAPTION",
+]);
+
+/** 轻量级 32-bit FNV-1a 哈希，避免引入 crypto 依赖。 */
+export function simpleHash(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/apps/negentropy-wiki/src/lib/annotation/use-annotations.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-annotations.ts
@@ -17,6 +17,10 @@ export interface AnnotationItem {
     suffix?: string;
     text_offset?: number;
     text_length?: number;
+    // v2 锚定字段（向前兼容，缺省视为 v1 anchor）
+    source_text_hash?: string;
+    source_lang?: string;
+    anchor_version?: number;
   };
   pub_version: number;
   status: string;

--- a/apps/negentropy-wiki/src/lib/annotation/use-highlight-renderer.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-highlight-renderer.ts
@@ -1,0 +1,259 @@
+"use client";
+
+/**
+ * 注解高亮渲染器抽象 —— Strategy Pattern
+ *
+ * 提供两种渲染策略，运行时根据浏览器能力与上下文（是否翻译态）切换：
+ *
+ *  ┌─────────────────────────┬──────────────────────────────────────────────┐
+ *  │ MarkWrapRenderer        │ <mark> 包裹 Range。事件交互简单。            │
+ *  │  (兼容性最好，默认)     │ 但在浏览器翻译时 mark 节点可能被 <font>      │
+ *  │                         │ 包裹破坏，高亮显示异常。                     │
+ *  ├─────────────────────────┼──────────────────────────────────────────────┤
+ *  │ CSSHighlightRenderer    │ CSS Custom Highlight API（不修改 DOM）。     │
+ *  │  (现代浏览器，优先)     │ 完全免疫浏览器翻译的 DOM 改造；但需要        │
+ *  │                         │ document mousemove + caretRangeFromPoint     │
+ *  │                         │ 模拟 hover 事件。                            │
+ *  └─────────────────────────┴──────────────────────────────────────────────┘
+ *
+ * 兼容性参考（2026）：
+ *   Chrome 105+ (2022-08) ✓
+ *   Safari 17.2+ (2023-12) ✓
+ *   Firefox 140+ (2025) ✓
+ *
+ * 不支持时自动降级至 MarkWrapRenderer，保证零回归。
+ *
+ * 参考：[3] W3C CSS Custom Highlight API Editor's Draft
+ *   https://drafts.csswg.org/css-highlight-api/
+ */
+
+import type { AnnotationItem } from "./use-annotations";
+
+const CSS_HIGHLIGHT_NAME = "wiki-annotation";
+
+export interface HighlightGroupInput {
+  /** 注解 ID 列表（重叠的多条注解会合并为一个 group） */
+  annotationIds: string[];
+  /** 已解析的 DOM Range */
+  range: Range;
+  /** 关联的注解数据（用于 tooltip 展示） */
+  annotations: AnnotationItem[];
+}
+
+/** 命中检测回调：给定坐标返回该坐标下命中的 group（用于 tooltip 触发） */
+export type HitTestFn = (x: number, y: number) => HighlightGroupInput | null;
+
+export interface HighlightRenderer {
+  /** 应用一组高亮，返回命中检测函数（供 hover tooltip 使用） */
+  apply(groups: HighlightGroupInput[]): HitTestFn;
+  /** 清除所有高亮 */
+  clear(): void;
+  /** 是否支持事件直挂在元素上（true: mark 模式可监听 mouseenter；false: 需要 mousemove 命中检测） */
+  supportsElementEvents: boolean;
+}
+
+/** 检测当前环境是否支持 CSS Custom Highlight API。 */
+export function supportsCSSHighlightAPI(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      "highlights" in CSS &&
+      typeof (CSS as unknown as { highlights?: unknown }).highlights !== "undefined" &&
+      typeof Highlight !== "undefined"
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ============================================================================
+// MarkWrapRenderer：<mark> 包裹（兼容路径，默认）
+// ============================================================================
+
+export function createMarkWrapRenderer(
+  onHoverStart: (group: HighlightGroupInput, rect: DOMRect) => void,
+  onHoverEnd: () => void,
+): HighlightRenderer {
+  let mountedMarks: { el: HTMLElement; group: HighlightGroupInput }[] = [];
+
+  return {
+    supportsElementEvents: true,
+    apply(groups) {
+      // 清除上一次
+      mountedMarks.forEach(({ el }) => unwrapMark(el));
+      mountedMarks = [];
+
+      for (const group of groups) {
+        const mark = buildMarkElement(group, onHoverStart, onHoverEnd);
+        try {
+          group.range.surroundContents(mark);
+          mountedMarks.push({ el: mark, group });
+        } catch {
+          try {
+            const fragment = group.range.extractContents();
+            mark.appendChild(fragment);
+            group.range.insertNode(mark);
+            mountedMarks.push({ el: mark, group });
+          } catch {
+            // 极端情况：跨节点且 extractContents 也失败，跳过
+          }
+        }
+      }
+
+      // mark 模式下事件直挂在元素上，hitTestFn 仅作为 fallback
+      return () => null;
+    },
+    clear() {
+      mountedMarks.forEach(({ el }) => unwrapMark(el));
+      mountedMarks = [];
+    },
+  };
+}
+
+function buildMarkElement(
+  group: HighlightGroupInput,
+  onHoverStart: (group: HighlightGroupInput, rect: DOMRect) => void,
+  onHoverEnd: () => void,
+): HTMLElement {
+  const mark = document.createElement("mark");
+  mark.className = "wiki-annotation-highlight";
+  mark.dataset.annotationIds = group.annotationIds.join(",");
+  mark.addEventListener("mouseenter", () => {
+    onHoverStart(group, mark.getBoundingClientRect());
+  });
+  mark.addEventListener("mouseleave", () => {
+    onHoverEnd();
+  });
+  return mark;
+}
+
+function unwrapMark(el: HTMLElement) {
+  const parent = el.parentNode;
+  if (!parent) return;
+  while (el.firstChild) parent.insertBefore(el.firstChild, el);
+  parent.removeChild(el);
+}
+
+// ============================================================================
+// CSSHighlightRenderer：CSS Custom Highlight API（现代浏览器，免疫翻译）
+// ============================================================================
+
+interface HighlightWithRanges {
+  add(range: Range): void;
+  clear(): void;
+}
+
+interface CSSHighlightsRegistry {
+  set(name: string, highlight: HighlightWithRanges): void;
+  delete(name: string): void;
+}
+
+export function createCSSHighlightRenderer(): HighlightRenderer {
+  let currentGroups: HighlightGroupInput[] = [];
+
+  return {
+    supportsElementEvents: false,
+    apply(groups) {
+      currentGroups = groups;
+      try {
+        const HighlightCtor = (window as unknown as {
+          Highlight: new (...ranges: Range[]) => HighlightWithRanges;
+        }).Highlight;
+        const registry = (CSS as unknown as { highlights: CSSHighlightsRegistry }).highlights;
+        const allRanges = groups.map((g) => g.range);
+        const highlight = new HighlightCtor(...allRanges);
+        registry.set(CSS_HIGHLIGHT_NAME, highlight);
+      } catch {
+        // 不应到达；createCSSHighlightRenderer 仅在 supportsCSSHighlightAPI 时创建
+      }
+      return hitTestFactory(currentGroups);
+    },
+    clear() {
+      try {
+        const registry = (CSS as unknown as { highlights: CSSHighlightsRegistry }).highlights;
+        registry.delete(CSS_HIGHLIGHT_NAME);
+      } catch {
+        // ignore
+      }
+      currentGroups = [];
+    },
+  };
+}
+
+/**
+ * 通过 caretRangeFromPoint 实现命中检测。
+ *
+ * 因为 CSS Highlight API 不参与事件冒泡，必须用 document mousemove +
+ * 坐标 → Range 反查 + Range 包含关系来判断当前光标是否在某个高亮范围内。
+ */
+function hitTestFactory(groups: HighlightGroupInput[]): HitTestFn {
+  return (x, y) => {
+    let candidateRange: Range | null = null;
+    try {
+      // caretRangeFromPoint 在多数主流浏览器中可用（Chrome/Safari/Firefox 109+）
+      const doc = document as unknown as {
+        caretRangeFromPoint?: (x: number, y: number) => Range | null;
+        caretPositionFromPoint?: (
+          x: number,
+          y: number,
+        ) => { offsetNode: Node; offset: number } | null;
+      };
+      if (typeof doc.caretRangeFromPoint === "function") {
+        candidateRange = doc.caretRangeFromPoint(x, y);
+      } else if (typeof doc.caretPositionFromPoint === "function") {
+        const pos = doc.caretPositionFromPoint(x, y);
+        if (pos) {
+          candidateRange = document.createRange();
+          candidateRange.setStart(pos.offsetNode, pos.offset);
+          candidateRange.setEnd(pos.offsetNode, pos.offset);
+        }
+      }
+    } catch {
+      return null;
+    }
+    if (!candidateRange) return null;
+    // 找包含此 caret 点的高亮 group
+    for (const group of groups) {
+      try {
+        if (
+          group.range.comparePoint(
+            candidateRange.startContainer,
+            candidateRange.startOffset,
+          ) === 0
+        ) {
+          return group;
+        }
+      } catch {
+        // comparePoint 在跨 document 边界时抛错，忽略
+      }
+    }
+    return null;
+  };
+}
+
+// ============================================================================
+// 自适应选择：根据能力与上下文构造合适的渲染器
+// ============================================================================
+
+export interface RendererFactory {
+  (
+    onHoverStart: (group: HighlightGroupInput, rect: DOMRect) => void,
+    onHoverEnd: () => void,
+  ): HighlightRenderer;
+}
+
+/**
+ * 自适应工厂：
+ *   - 翻译态优先用 CSSHighlightRenderer（免疫 <font> 包裹破坏）
+ *   - 否则优先用 MarkWrapRenderer（事件交互简单）
+ *   - CSS Highlight API 不支持时回退到 MarkWrapRenderer
+ */
+export function pickRenderer(opts: {
+  isTranslated: boolean;
+}): RendererFactory {
+  if (opts.isTranslated && supportsCSSHighlightAPI()) {
+    return () => createCSSHighlightRenderer();
+  }
+  return (onHoverStart, onHoverEnd) =>
+    createMarkWrapRenderer(onHoverStart, onHoverEnd);
+}

--- a/apps/negentropy-wiki/src/lib/annotation/use-snapshot.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-snapshot.ts
@@ -22,6 +22,7 @@
  */
 
 import { useEffect, useRef } from "react";
+import { BLOCK_TAGS, simpleHash } from "./annotation-shared";
 
 /** 单个块级元素在 snapshot 中的记录。XPath 是用于跨翻译保持稳定的"位置坐标"。 */
 export interface SnapshotBlock {
@@ -43,12 +44,6 @@ export interface AnnotationSnapshot {
   /** textContent 的轻量哈希，用于跨次访问的版本校验 */
   textHash: string;
 }
-
-const BLOCK_TAGS = new Set([
-  "P", "LI", "BLOCKQUOTE", "PRE", "TABLE", "TR", "TD", "TH",
-  "H1", "H2", "H3", "H4", "H5", "H6",
-  "DIV", "ARTICLE", "SECTION", "FIGURE", "FIGCAPTION",
-]);
 
 /**
  * 抓取容器在当前时刻的 snapshot。可重入：每次调用产出独立 snapshot 对象。
@@ -136,16 +131,6 @@ function computeRelativeXPath(node: Element, container: HTMLElement): string {
     current = parent;
   }
   return "/" + parts.join("/");
-}
-
-/** 轻量级 32-bit FNV-1a 哈希，避免引入 crypto 依赖。 */
-function simpleHash(input: string): string {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
 /**

--- a/apps/negentropy-wiki/src/lib/annotation/use-snapshot.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-snapshot.ts
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * 注解稳定快照（Annotation Stable Snapshot）
+ *
+ * 设计动机（解决 R1/R2/R4）：
+ *   现行实现把「用户当前可见的 DOM」当作锚定权威源 —— 但浏览器翻译会
+ *   原地修改 text node 的 nodeValue 或包裹 <font>，导致同一物理位置的
+ *   textContent 在不同时刻有不同值（英文 ↔ 中文不可逆映射）。
+ *
+ *   正确做法是把「mount 时的初次渲染态」固化为唯一权威坐标系（snapshot），
+ *   后续所有 computeAnchor / resolveAnchor 都基于 snapshot 进行字符级定位；
+ *   即使浏览器把 text node 的 nodeValue 改成了译文，snapshot 中保留的
+ *   originalNodeValues 备份仍然提供反向映射能力。
+ *
+ * 业界对照：W3C Web Annotation Data Model [1] 与 Hypothes.is dom-anchor [2]
+ * 的统一前提即「锚定到稳定、规范化的内容源」。本快照实现了这一前提的
+ * 客户端版本。
+ *
+ * [1] https://www.w3.org/TR/annotation-model/
+ * [2] https://github.com/tilgovi/dom-anchor-text-quote
+ */
+
+import { useEffect, useRef } from "react";
+
+/** 单个块级元素在 snapshot 中的记录。XPath 是用于跨翻译保持稳定的"位置坐标"。 */
+export interface SnapshotBlock {
+  element: HTMLElement; // mount 时持有的块级元素 DOM 引用
+  xpath: string;        // 相对于容器的 XPath（如 "/p[2]/strong[1]"）
+  text: string;         // mount 时该元素的 textContent（权威原文）
+  offset: number;       // 该元素在容器 textContent 中的起始字符偏移
+}
+
+export interface AnnotationSnapshot {
+  /** mount 时的容器全文 textContent —— 权威原文 */
+  textContent: string;
+  /** mount 时的所有 text node 引用（按 TreeWalker 顺序） */
+  textNodes: Text[];
+  /** 每个 text node 的原始 nodeValue 备份（翻译会修改 nodeValue，引用仍可用） */
+  originalNodeValues: WeakMap<Text, string>;
+  /** 块级元素索引：用于翻译态下"块级粗粒度回退"和投影 */
+  blockElements: SnapshotBlock[];
+  /** textContent 的轻量哈希，用于跨次访问的版本校验 */
+  textHash: string;
+}
+
+const BLOCK_TAGS = new Set([
+  "P", "LI", "BLOCKQUOTE", "PRE", "TABLE", "TR", "TD", "TH",
+  "H1", "H2", "H3", "H4", "H5", "H6",
+  "DIV", "ARTICLE", "SECTION", "FIGURE", "FIGCAPTION",
+]);
+
+/**
+ * 抓取容器在当前时刻的 snapshot。可重入：每次调用产出独立 snapshot 对象。
+ */
+export function captureSnapshot(container: HTMLElement): AnnotationSnapshot {
+  const textNodes: Text[] = [];
+  const originalNodeValues = new WeakMap<Text, string>();
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let textContent = "";
+  let node = walker.nextNode();
+  while (node) {
+    const textNode = node as Text;
+    textNodes.push(textNode);
+    originalNodeValues.set(textNode, textNode.nodeValue ?? "");
+    textContent += textNode.nodeValue ?? "";
+    node = walker.nextNode();
+  }
+
+  const blockElements = collectBlockElements(container);
+  const textHash = simpleHash(textContent);
+
+  return {
+    textContent,
+    textNodes,
+    originalNodeValues,
+    blockElements,
+    textHash,
+  };
+}
+
+/**
+ * 抓取所有块级元素 + 该元素在容器 textContent 中的起始字符偏移。
+ * 块级元素 DOM 引用即使被浏览器翻译也通常保留（Chrome 翻译保留 tag 结构，
+ * 仅修改 text node 内容或在外层加 <font>）。
+ */
+function collectBlockElements(container: HTMLElement): SnapshotBlock[] {
+  const blocks: SnapshotBlock[] = [];
+  const all = container.querySelectorAll<HTMLElement>(
+    Array.from(BLOCK_TAGS).map((t) => t.toLowerCase()).join(","),
+  );
+  // 维护"已遍历到的全局字符偏移"，用 TreeWalker 单次扫描完成
+  const offsetByElement = new WeakMap<HTMLElement, number>();
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let cursor = 0;
+  let n = walker.nextNode();
+  while (n) {
+    const textNode = n as Text;
+    let parent: HTMLElement | null = textNode.parentElement;
+    // 记录该 text node 的"最近一个块级祖先"的起始 offset（取最小值）
+    while (parent && parent !== container) {
+      if (BLOCK_TAGS.has(parent.tagName) && !offsetByElement.has(parent)) {
+        offsetByElement.set(parent, cursor);
+      }
+      parent = parent.parentElement;
+    }
+    cursor += textNode.nodeValue?.length ?? 0;
+    n = walker.nextNode();
+  }
+  for (const el of Array.from(all)) {
+    blocks.push({
+      element: el,
+      xpath: computeRelativeXPath(el, container),
+      text: el.textContent ?? "",
+      offset: offsetByElement.get(el) ?? 0,
+    });
+  }
+  return blocks;
+}
+
+/** 相对于容器的 XPath，与 use-text-anchor 中的 computeXPath 风格一致。 */
+function computeRelativeXPath(node: Element, container: HTMLElement): string {
+  const parts: string[] = [];
+  let current: Element | null = node;
+  while (current && current !== container) {
+    const cur: Element = current;
+    const parent: HTMLElement | null = cur.parentElement;
+    if (!parent) break;
+    const siblings = Array.from(parent.children).filter(
+      (c): c is Element => c.tagName === cur.tagName,
+    );
+    const idx = siblings.indexOf(cur);
+    parts.unshift(
+      idx > 0 ? `${cur.tagName.toLowerCase()}[${idx + 1}]` : cur.tagName.toLowerCase(),
+    );
+    current = parent;
+  }
+  return "/" + parts.join("/");
+}
+
+/** 轻量级 32-bit FNV-1a 哈希，避免引入 crypto 依赖。 */
+function simpleHash(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Hook：mount 完成后立即抓 snapshot。
+ *
+ * 注意时序：MarkdownRenderer 同步渲染（content 是 prop 传入），useEffect 在 paint 后执行，
+ * 此时 DOM 已稳定；浏览器翻译至少要等一次 paint 后才启动。所以抓 snapshot
+ * 仍能赶在翻译之前完成。
+ */
+export function useSnapshot(
+  containerRef: React.RefObject<HTMLElement | null>,
+  /** 触发 snapshot 重抓的依赖（如 entryId 变化、内容版本更新）。默认空数组只抓一次。 */
+  deps: React.DependencyList = [],
+): React.MutableRefObject<AnnotationSnapshot | null> {
+  const snapshotRef = useRef<AnnotationSnapshot | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    // 防御：textContent 为空（理论上不该发生）时不抓，等下一帧
+    if ((container.textContent ?? "").length === 0) {
+      const id = requestAnimationFrame(() => {
+        if (containerRef.current) {
+          snapshotRef.current = captureSnapshot(containerRef.current);
+        }
+      });
+      return () => cancelAnimationFrame(id);
+    }
+    snapshotRef.current = captureSnapshot(container);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerRef, ...deps]);
+
+  return snapshotRef;
+}

--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -13,6 +13,7 @@
  */
 
 import type { AnnotationSnapshot } from "./use-snapshot";
+import { BLOCK_TAGS, simpleHash } from "./annotation-shared";
 
 /** 锚定算法版本：用于未来演进时的兼容性切换。 */
 export const CURRENT_ANCHOR_VERSION = 2;
@@ -112,7 +113,7 @@ function computeFromSnapshot(
   const curHash = snapshot.textHash; // 容器当前 hash 与 snapshot 比较
 
   // 路径 A：当前 DOM == snapshot（未被翻译/修改），直接用偏移
-  if (simpleHashOfStr(curText) === curHash) {
+  if (simpleHash(curText) === curHash) {
     const exact = snapshot.textContent.slice(curStart, curEnd);
     const prefix = snapshot.textContent.slice(Math.max(0, curStart - 32), curStart);
     const suffix = snapshot.textContent.slice(curEnd, Math.min(snapshot.textContent.length, curEnd + 32));
@@ -225,12 +226,6 @@ function findCurrentBlockByOffset(
   }
   return null;
 }
-
-const BLOCK_TAGS = new Set([
-  "P", "LI", "BLOCKQUOTE", "PRE", "TABLE", "TR", "TD", "TH",
-  "H1", "H2", "H3", "H4", "H5", "H6",
-  "DIV", "ARTICLE", "SECTION", "FIGURE", "FIGCAPTION",
-]);
 
 function findNearestBlock(node: Node, container: HTMLElement): HTMLElement | null {
   let cur: Node | null = node.parentElement;
@@ -524,16 +519,6 @@ function findTextInRange(
     currentOffset += nodeText.length;
   }
   return null;
-}
-
-/** 字符串轻量哈希（与 use-snapshot.ts 中 simpleHash 算法一致）。 */
-function simpleHashOfStr(input: string): string {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
 /** 极简语言检测：含 CJK 字符 → "zh"，否则 "en"。仅用于诊断，不参与匹配。 */

--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -1,9 +1,21 @@
 /**
- * 文本锚定工具 — 基于 W3C Web Annotation TextQuoteSelector 模式
+ * 文本锚定工具 — Source-Anchored Text Selectors（基于 W3C Web Annotation TextQuoteSelector）
  *
- * computeAnchor: 从 Selection API 计算锚定数据
- * resolveAnchor: 给定锚定数据，在 DOM 中定位目标文本
+ * 核心设计：把「注解的锚」与「用户看到的视图」解耦。
+ *   - 锚定权威源 = mount 时抓取的 snapshot（见 use-snapshot.ts）
+ *   - 用户视图 = 当前 DOM（可能被浏览器翻译、字体/CSS 切换、动态加载改造）
+ *
+ * computeAnchor: 在用户选区上计算锚定数据。若提供 snapshot 则基于 snapshot 计算
+ *                exact/prefix/suffix（跨翻译稳定）；否则按当前 DOM 计算（兼容旧路径）。
+ *
+ * resolveAnchor: 三段式解析。snapshot 精确 → currentDOM 文本搜索 → 块级粗粒度回退。
+ *                即使精确文本无法匹配（如翻译态），仍能保证「注解不消失」。
  */
+
+import type { AnnotationSnapshot } from "./use-snapshot";
+
+/** 锚定算法版本：用于未来演进时的兼容性切换。 */
+export const CURRENT_ANCHOR_VERSION = 2;
 
 export interface TextAnchor {
   xpath: string;
@@ -12,62 +24,350 @@ export interface TextAnchor {
   suffix: string;
   text_offset: number;
   text_length: number;
+  /**
+   * 创建时的 snapshot.textHash。用于 resolveAnchor 段 1 决定是否可以
+   * "信任 anchor.text_offset 直接在 snapshot.textNodes 上定位"。
+   */
+  source_text_hash?: string;
+  /** 创建时检测到的内容主语言（"en" / "zh" / 等）。仅用于诊断，不参与算法。 */
+  source_lang?: string;
+  /** 锚定算法版本。缺省视为 v1（旧版，无 snapshot 字段）。 */
+  anchor_version?: number;
 }
 
 /**
- * 从 Selection 计算锚定数据
+ * 从 Selection 计算锚定数据。
+ *
+ * @param selection - 当前选区
+ * @param container - 注解容器（如 .wiki-markdown-body）
+ * @param snapshot  - 可选的稳定快照。提供时锚定到 snapshot 坐标系；否则按旧路径。
  */
 export function computeAnchor(
   selection: Selection,
   container: HTMLElement,
+  snapshot?: AnnotationSnapshot | null,
 ): TextAnchor | null {
   const range = selection.getRangeAt(0);
   if (!range) return null;
 
-  const exact = selection.toString().trim();
-  if (!exact) return null;
+  const displayExact = selection.toString().trim();
+  if (!displayExact) return null;
 
-  // 计算 XPath 到最近块级元素
   const xpath = computeXPath(range.startContainer, container);
 
-  // 计算 prefix/suffix 上下文
+  // 优先尝试基于 snapshot 计算（source-anchored）
+  if (snapshot) {
+    const fromSnapshot = computeFromSnapshot(range, container, snapshot, xpath);
+    if (fromSnapshot) return fromSnapshot;
+  }
+
+  // 回退：按当前 DOM 计算（兼容路径，与旧版 v1 行为一致）
   const fullText = container.textContent || "";
   const selectedText = range.toString();
-  // 通过 TreeWalker 精确定位选区起止在 fullText 中的偏移量
   const selStart = computeTextOffset(range.startContainer, range.startOffset, container);
   const contextRadius = 32;
-  const prefix = selStart >= 0 ? fullText.slice(Math.max(0, selStart - contextRadius), selStart) : "";
-  const suffix = selStart >= 0 ? fullText.slice(selStart + selectedText.length, selStart + selectedText.length + contextRadius) : "";
+  const prefix = selStart >= 0
+    ? fullText.slice(Math.max(0, selStart - contextRadius), selStart)
+    : "";
+  const suffix = selStart >= 0
+    ? fullText.slice(
+        selStart + selectedText.length,
+        selStart + selectedText.length + contextRadius,
+      )
+    : "";
 
-  // 计算 text_offset（相对于完整文本）
-  const textOffset = selStart >= 0 ? selStart : 0;
+  return {
+    xpath,
+    exact: displayExact,
+    prefix,
+    suffix,
+    text_offset: selStart >= 0 ? selStart : 0,
+    text_length: selectedText.length,
+    source_text_hash: snapshot?.textHash,
+    source_lang: detectLang(displayExact),
+    anchor_version: snapshot ? CURRENT_ANCHOR_VERSION : 1,
+  };
+}
 
+/**
+ * 尝试用 snapshot 计算锚定。
+ *
+ * 算法：
+ *   1. 计算 selection 在当前 DOM 中的字符偏移（curStart, curEnd）
+ *   2. 当前 textContent == snapshot.textContent（hash 一致）→ 直接用偏移
+ *   3. 否则（翻译态等）→ 找到 selection 落在的块级元素 → 按字符比例映射回 snapshot
+ *      该块级元素对应位置 → 在 snapshot 中切片得到 anchor.exact/prefix/suffix
+ */
+function computeFromSnapshot(
+  range: Range,
+  container: HTMLElement,
+  snapshot: AnnotationSnapshot,
+  xpath: string,
+): TextAnchor | null {
+  const curStart = computeTextOffset(range.startContainer, range.startOffset, container);
+  const curEnd = computeTextOffset(range.endContainer, range.endOffset, container);
+  if (curStart < 0 || curEnd < 0 || curEnd <= curStart) return null;
+
+  const curText = container.textContent || "";
+  const curHash = snapshot.textHash; // 容器当前 hash 与 snapshot 比较
+
+  // 路径 A：当前 DOM == snapshot（未被翻译/修改），直接用偏移
+  if (simpleHashOfStr(curText) === curHash) {
+    const exact = snapshot.textContent.slice(curStart, curEnd);
+    const prefix = snapshot.textContent.slice(Math.max(0, curStart - 32), curStart);
+    const suffix = snapshot.textContent.slice(curEnd, Math.min(snapshot.textContent.length, curEnd + 32));
+    return {
+      xpath,
+      exact,
+      prefix,
+      suffix,
+      text_offset: curStart,
+      text_length: exact.length,
+      source_text_hash: snapshot.textHash,
+      source_lang: detectLang(exact),
+      anchor_version: CURRENT_ANCHOR_VERSION,
+    };
+  }
+
+  // 路径 B：当前 DOM ≠ snapshot（如翻译态），按块级元素字符比例映射回 snapshot
+  const projected = projectRangeToSnapshot(curStart, curEnd, container, snapshot);
+  if (!projected) return null;
+  const { snapStart, snapEnd } = projected;
+  const exact = snapshot.textContent.slice(snapStart, snapEnd);
+  const prefix = snapshot.textContent.slice(Math.max(0, snapStart - 32), snapStart);
+  const suffix = snapshot.textContent.slice(snapEnd, Math.min(snapshot.textContent.length, snapEnd + 32));
   return {
     xpath,
     exact,
     prefix,
     suffix,
-    text_offset: textOffset,
-    text_length: selectedText.length,
+    text_offset: snapStart,
+    text_length: exact.length,
+    source_text_hash: snapshot.textHash,
+    source_lang: detectLang(exact),
+    anchor_version: CURRENT_ANCHOR_VERSION,
   };
 }
 
 /**
- * 给定锚定数据，在 container 中定位目标文本，返回 DOM Range
+ * 跨翻译态投影：把"当前 DOM 的字符偏移 [curStart, curEnd)"
+ * 按块级元素字符比例映射回 snapshot 中的字符偏移。
+ *
+ * 这是近似映射（中英文字符数不等比），但能将注解锚到正确的块级范围内。
+ */
+function projectRangeToSnapshot(
+  curStart: number,
+  curEnd: number,
+  container: HTMLElement,
+  snapshot: AnnotationSnapshot,
+): { snapStart: number; snapEnd: number } | null {
+  // 找到当前 DOM 中 curStart 所在的块级元素
+  const blockAtStart = findCurrentBlockByOffset(container, curStart);
+  const blockAtEnd = findCurrentBlockByOffset(container, curEnd);
+  if (!blockAtStart || !blockAtEnd) return null;
+
+  const snapStartBlock = snapshot.blockElements.find(
+    (b) => b.element === blockAtStart.element,
+  );
+  const snapEndBlock = snapshot.blockElements.find(
+    (b) => b.element === blockAtEnd.element,
+  );
+  if (!snapStartBlock || !snapEndBlock) return null;
+
+  const ratioStart =
+    blockAtStart.length > 0
+      ? (curStart - blockAtStart.offset) / blockAtStart.length
+      : 0;
+  const ratioEnd =
+    blockAtEnd.length > 0
+      ? (curEnd - blockAtEnd.offset) / blockAtEnd.length
+      : 1;
+
+  const snapStart = Math.round(
+    snapStartBlock.offset + ratioStart * snapStartBlock.text.length,
+  );
+  const snapEnd = Math.round(
+    snapEndBlock.offset + ratioEnd * snapEndBlock.text.length,
+  );
+  if (snapEnd <= snapStart) return null;
+  return { snapStart, snapEnd };
+}
+
+interface CurrentBlock {
+  element: HTMLElement;
+  offset: number; // 在容器 textContent 中的起始偏移
+  length: number; // 当前 textContent 长度
+}
+
+/** 找到当前 DOM 中、容器全局字符 offset 所在的最内层块级元素。 */
+function findCurrentBlockByOffset(
+  container: HTMLElement,
+  offset: number,
+): CurrentBlock | null {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let cursor = 0;
+  let node = walker.nextNode();
+  while (node) {
+    const textNode = node as Text;
+    const len = textNode.nodeValue?.length ?? 0;
+    if (cursor + len >= offset) {
+      // 这个 text node 包含目标 offset
+      const block = findNearestBlock(textNode, container);
+      if (!block) return null;
+      return {
+        element: block,
+        offset: computeBlockOffset(block, container),
+        length: block.textContent?.length ?? 0,
+      };
+    }
+    cursor += len;
+    node = walker.nextNode();
+  }
+  return null;
+}
+
+const BLOCK_TAGS = new Set([
+  "P", "LI", "BLOCKQUOTE", "PRE", "TABLE", "TR", "TD", "TH",
+  "H1", "H2", "H3", "H4", "H5", "H6",
+  "DIV", "ARTICLE", "SECTION", "FIGURE", "FIGCAPTION",
+]);
+
+function findNearestBlock(node: Node, container: HTMLElement): HTMLElement | null {
+  let cur: Node | null = node.parentElement;
+  while (cur && cur !== container) {
+    if (cur.nodeType === Node.ELEMENT_NODE && BLOCK_TAGS.has((cur as HTMLElement).tagName)) {
+      return cur as HTMLElement;
+    }
+    cur = cur.parentElement;
+  }
+  return null;
+}
+
+function computeBlockOffset(block: HTMLElement, container: HTMLElement): number {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let offset = 0;
+  let node = walker.nextNode();
+  while (node) {
+    const t = node as Text;
+    if (block.contains(t)) return offset;
+    offset += t.nodeValue?.length ?? 0;
+    node = walker.nextNode();
+  }
+  return 0;
+}
+
+/**
+ * 给定锚定数据，在 container 中定位目标文本，返回 DOM Range。
+ *
+ * 三段式解析（每段独立失败 → 进入下一段，保证「注解不消失」）：
+ *   段 1：snapshot 精确匹配（仅在 anchor_version >= 2 且 hash 一致时）
+ *   段 2：当前 DOM 的 prefix+exact+suffix 全文搜索（兼容 v1 anchor 与同语言场景）
+ *   段 3：块级元素粗粒度回退（用 xpath 找块级元素，整体选中）
  */
 export function resolveAnchor(
   anchor: TextAnchor,
   container: HTMLElement,
+  snapshot?: AnnotationSnapshot | null,
 ): Range | null {
-  // 策略 1：XPath + exact 文本验证
+  // 段 1：snapshot 精确（仅 v2+ anchor 且 hash 一致）
+  if (
+    snapshot &&
+    (anchor.anchor_version ?? 1) >= 2 &&
+    anchor.source_text_hash &&
+    anchor.source_text_hash === snapshot.textHash
+  ) {
+    // 此分支表示 snapshot 仍可信，可以用 anchor.text_offset 直接在 snapshot.textNodes 上定位
+    const fromSnapshot = resolveBySnapshotOffset(anchor, snapshot);
+    if (fromSnapshot) return fromSnapshot;
+  }
+
+  // 段 2：XPath 提示的 + 当前 DOM 文本搜索（兼容 v1 / 旧数据 / 同语言场景）
   const xpathRange = tryXPath(anchor, container);
   if (xpathRange) return xpathRange;
-
-  // 策略 2：TextQuoteSelector 全文搜索（prefix + exact + suffix）
   const textRange = tryTextSearch(anchor, container);
   if (textRange) return textRange;
 
-  return null;
+  // 段 3：块级粗粒度回退 —— 保证用户至少看到"这段被注解过"
+  return resolveBlockFallback(anchor, container);
+}
+
+/**
+ * 段 1 的具体实现：用 anchor.text_offset/text_length 在 snapshot.textNodes 上定位。
+ *
+ * 翻译态下 snapshot.textNodes 仍是同一物理引用（Chrome 翻译就地修改 nodeValue），
+ * 但每个 node 的 nodeValue 长度变了 —— 不能直接 setStart(node, offsetWithinNode)，
+ * 因为 offset 是 snapshot 时的字符位置，可能超出当前 nodeValue 长度。
+ *
+ * 策略：用 snapshot.originalNodeValues 反推每个 text node 的原始长度，定位到
+ *      snapshot 坐标系中的 text node + offsetWithinNode；然后按当前 nodeValue
+ *      长度比例映射到当前 offset（同语言下比例 = 1 即精确）。
+ */
+function resolveBySnapshotOffset(
+  anchor: TextAnchor,
+  snapshot: AnnotationSnapshot,
+): Range | null {
+  const target = anchor.text_offset;
+  const targetEnd = target + (anchor.text_length || anchor.exact.length);
+
+  const startLoc = locateNodeByOriginalOffset(target, snapshot);
+  const endLoc = locateNodeByOriginalOffset(targetEnd, snapshot);
+  if (!startLoc || !endLoc) return null;
+
+  // 确认 text node 仍在 DOM 中（如果被翻译扩展替换，引用会脱离 DOM）
+  if (!startLoc.node.isConnected || !endLoc.node.isConnected) return null;
+
+  // 按当前 nodeValue 长度比例映射 offset
+  const startOffset = mapOffsetWithinNode(startLoc.node, startLoc.offsetWithin, snapshot);
+  const endOffset = mapOffsetWithinNode(endLoc.node, endLoc.offsetWithin, snapshot);
+  if (startOffset === null || endOffset === null) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(startLoc.node, startOffset);
+    range.setEnd(endLoc.node, endOffset);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+interface NodeLocation {
+  node: Text;
+  offsetWithin: number; // 在 snapshot 中该 text node 内的字符偏移
+}
+
+function locateNodeByOriginalOffset(
+  offset: number,
+  snapshot: AnnotationSnapshot,
+): NodeLocation | null {
+  let cursor = 0;
+  for (const node of snapshot.textNodes) {
+    const orig = snapshot.originalNodeValues.get(node) ?? "";
+    if (cursor + orig.length >= offset) {
+      return { node, offsetWithin: offset - cursor };
+    }
+    cursor += orig.length;
+  }
+  // 若 offset 超出（罕见），返回最后一个 node 的末尾
+  const last = snapshot.textNodes[snapshot.textNodes.length - 1];
+  if (!last) return null;
+  const orig = snapshot.originalNodeValues.get(last) ?? "";
+  return { node: last, offsetWithin: orig.length };
+}
+
+function mapOffsetWithinNode(
+  node: Text,
+  snapshotOffset: number,
+  snapshot: AnnotationSnapshot,
+): number | null {
+  const orig = snapshot.originalNodeValues.get(node) ?? "";
+  const cur = node.nodeValue ?? "";
+  if (orig.length === 0) return Math.min(snapshotOffset, cur.length);
+  // 同语言（未翻译）情况下 cur 与 orig 相同，比例 = 1
+  if (cur === orig) return Math.min(snapshotOffset, cur.length);
+  // 跨语言情况：按字符比例映射（粗粒度但稳定）
+  const ratio = snapshotOffset / orig.length;
+  return Math.max(0, Math.min(cur.length, Math.round(ratio * cur.length)));
 }
 
 function computeXPath(node: Node, container: HTMLElement): string {
@@ -106,7 +406,6 @@ function computeXPath(node: Node, container: HTMLElement): string {
 
 /**
  * 计算 targetNode:targetOffset 在 container.textContent 中的字符偏移量。
- * 通过 TreeWalker 遍历文本节点，累加长度直到命中目标节点。
  */
 function computeTextOffset(targetNode: Node, targetOffset: number, container: HTMLElement): number {
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
@@ -116,6 +415,10 @@ function computeTextOffset(targetNode: Node, targetOffset: number, container: HT
     if (node === targetNode) {
       return offset + targetOffset;
     }
+    if (node.parentNode === targetNode && targetNode.nodeType === Node.ELEMENT_NODE) {
+      // selection 落在元素节点上（罕见，浏览器多落在 text node）
+      return offset;
+    }
     offset += (node.textContent?.length ?? 0);
   }
   return offset;
@@ -123,11 +426,9 @@ function computeTextOffset(targetNode: Node, targetOffset: number, container: HT
 
 function tryXPath(anchor: TextAnchor, container: HTMLElement): Range | null {
   try {
-    // 只使用 XPath 中块级元素部分定位到粗粒度节点
     const blockParts = anchor.xpath.split("/").filter((p) => p && !p.startsWith("text()"));
     if (blockParts.length === 0) return null;
 
-    // 在 container 内查找匹配元素
     const candidates = container.querySelectorAll(
       blockParts[blockParts.length - 1].replace(/\[\d+\]/, ""),
     );
@@ -135,7 +436,6 @@ function tryXPath(anchor: TextAnchor, container: HTMLElement): Range | null {
     for (const candidate of candidates) {
       const text = candidate.textContent || "";
       if (text.includes(anchor.exact)) {
-        // 在候选元素内查找精确位置
         return findTextInRange(anchor.exact, candidate as HTMLElement);
       }
     }
@@ -147,18 +447,56 @@ function tryXPath(anchor: TextAnchor, container: HTMLElement): Range | null {
 
 function tryTextSearch(anchor: TextAnchor, container: HTMLElement): Range | null {
   const fullText = container.textContent || "";
-  const searchText = anchor.prefix + anchor.exact + anchor.suffix;
+  const searchText = (anchor.prefix || "") + anchor.exact + (anchor.suffix || "");
 
   let startIdx = fullText.indexOf(searchText);
   if (startIdx === -1) {
-    // 降级：仅搜索 exact
     startIdx = fullText.indexOf(anchor.exact);
     if (startIdx === -1) return null;
     return findTextInRange(anchor.exact, container);
   }
 
-  const exactStart = startIdx + anchor.prefix.length;
+  const exactStart = startIdx + (anchor.prefix?.length || 0);
   return findTextInRange(anchor.exact, container, exactStart);
+}
+
+/**
+ * 段 3：块级粗粒度回退。
+ *
+ * 即使精确文本无法匹配（如跨语言翻译），仍能通过 anchor.xpath 找到块级元素的
+ * DOM 引用，整体选中该元素作为粗粒度高亮。用户至少看到「这段被注解过」，
+ * hover 仍能弹出注解内容。
+ *
+ * 这是「注解不消失」承诺的最后防线。
+ */
+function resolveBlockFallback(anchor: TextAnchor, container: HTMLElement): Range | null {
+  try {
+    const parts = anchor.xpath.split("/").filter((p) => p && !p.startsWith("text()"));
+    if (parts.length === 0) return null;
+
+    // 解析 XPath 风格的路径（如 "/p[2]/strong[1]"）逐级定位
+    let cur: Element = container;
+    for (const part of parts) {
+      const match = /^([a-zA-Z0-9]+)(?:\[(\d+)\])?$/.exec(part);
+      if (!match) return null;
+      const [, tag, idxStr] = match;
+      const siblings = Array.from(cur.children).filter(
+        (c) => c.tagName.toLowerCase() === tag.toLowerCase(),
+      );
+      const idx = idxStr ? parseInt(idxStr, 10) - 1 : 0;
+      const next = siblings[idx];
+      if (!next) return null;
+      cur = next;
+    }
+
+    // 整体选中该块级元素的内容
+    if (!cur.firstChild) return null;
+    const range = document.createRange();
+    range.selectNodeContents(cur);
+    return range;
+  } catch {
+    return null;
+  }
 }
 
 function findTextInRange(
@@ -172,7 +510,10 @@ function findTextInRange(
   while (walker.nextNode()) {
     const node = walker.currentNode as Text;
     const nodeText = node.textContent || "";
-    const localIdx = nodeText.indexOf(text, hintOffset !== undefined ? Math.max(0, hintOffset - currentOffset) : 0);
+    const localIdx = nodeText.indexOf(
+      text,
+      hintOffset !== undefined ? Math.max(0, hintOffset - currentOffset) : 0,
+    );
 
     if (localIdx !== -1) {
       const range = document.createRange();
@@ -183,4 +524,19 @@ function findTextInRange(
     currentOffset += nodeText.length;
   }
   return null;
+}
+
+/** 字符串轻量哈希（与 use-snapshot.ts 中 simpleHash 算法一致）。 */
+function simpleHashOfStr(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/** 极简语言检测：含 CJK 字符 → "zh"，否则 "en"。仅用于诊断，不参与匹配。 */
+function detectLang(text: string): string {
+  return /[一-鿿]/.test(text) ? "zh" : "en";
 }

--- a/apps/negentropy-wiki/src/lib/annotation/use-translation-detect.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-translation-detect.ts
@@ -1,0 +1,102 @@
+/**
+ * 浏览器翻译态检测与信号鉴别
+ *
+ * 解决根因 R3：浏览器原生翻译是 native 异步行为，不触发 React 重渲染，
+ * 也不通过常规事件通知 JS。需要靠 MutationObserver 主动监测 DOM 变化，
+ * 在翻译完成（或回退）后重新执行高亮应用。
+ *
+ * 翻译信号鉴别（启发式，覆盖主流浏览器）：
+ *   - Chrome / Edge：在文本节点外包裹 <font style="vertical-align: inherit;">
+ *     或修改 text node 的 nodeValue
+ *   - Safari：使用 _msttexthash / _msthash 属性或 <span lang="x"> 包裹
+ *   - 通用：document.documentElement.lang 改变；container 内 lang 属性插入
+ */
+
+const TRANSLATION_TAG_NAMES = new Set(["FONT"]);
+const TRANSLATION_DATA_ATTRS = [
+  "_msttexthash",
+  "_msthash",
+  "data-original-content",
+];
+
+/**
+ * 鉴别 DOM 变更是否来自浏览器翻译。
+ *
+ * 设计原则：宁可多触发一次重试（cost ~ms），也不要漏判（cost: 注解消失）。
+ */
+export function isTranslationMutation(mutation: MutationRecord): boolean {
+  // 信号 1：新增的子节点中含 <font>（Chrome / Edge 翻译特征）
+  if (mutation.type === "childList") {
+    for (const node of Array.from(mutation.addedNodes)) {
+      if (
+        node.nodeType === Node.ELEMENT_NODE &&
+        TRANSLATION_TAG_NAMES.has((node as Element).tagName)
+      ) {
+        return true;
+      }
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as Element;
+        for (const attr of TRANSLATION_DATA_ATTRS) {
+          if (el.hasAttribute(attr)) return true;
+        }
+        // 子树里有 <font> 也算（翻译扩展通常一次替换一大块）
+        if (el.querySelector?.("font")) return true;
+      }
+    }
+  }
+
+  // 信号 2：text node 的 nodeValue 被修改（characterData）
+  if (mutation.type === "characterData") {
+    return true;
+  }
+
+  // 信号 3：lang / translate 属性变化
+  if (mutation.type === "attributes") {
+    if (mutation.attributeName === "lang" || mutation.attributeName === "translate") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * 判断容器当前是否处于浏览器翻译态。
+ * 用于在创建注解时识别状态，给出 UI 提示或调整锚定策略。
+ */
+export function isContainerTranslated(container: HTMLElement | null): boolean {
+  if (!container) return false;
+  // 直接子树含 <font> 包裹 → 已被翻译
+  if (container.querySelector("font")) return true;
+  // 含翻译扩展特征属性
+  for (const attr of TRANSLATION_DATA_ATTRS) {
+    if (container.querySelector(`[${attr}]`)) return true;
+  }
+  return false;
+}
+
+/**
+ * 轻量级 debounce，前沿不立即执行，等待 wait ms 静默后触发。
+ * 用于 MutationObserver 的洪水抑制：浏览器翻译可能在几十毫秒内
+ * 产生数百次 mutation，逐个触发 applyHighlights 会卡顿。
+ */
+export function debounce<T extends (...args: never[]) => void>(
+  fn: T,
+  wait: number,
+): T & { cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const wrapped = ((...args: Parameters<T>) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      fn(...args);
+    }, wait);
+  }) as T & { cancel: () => void };
+  wrapped.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  return wrapped;
+}

--- a/apps/negentropy-wiki/src/styles/components/annotation.css
+++ b/apps/negentropy-wiki/src/styles/components/annotation.css
@@ -1,6 +1,6 @@
 /* Wiki 文本注解样式 */
 
-/* 高亮标记（常驻） */
+/* 高亮标记（常驻） —— MarkWrapRenderer 路径 */
 .wiki-annotation-highlight {
   background: rgba(255, 212, 59, 0.25);
   border-left: 3px solid rgba(255, 180, 0, 0.6);
@@ -11,6 +11,15 @@
 }
 .wiki-annotation-highlight:hover {
   background: rgba(255, 212, 59, 0.45);
+}
+
+/* CSS Custom Highlight API 路径 —— 浏览器翻译态下使用，
+   不修改 DOM 因而免疫 <font> 包裹破坏。
+   参考：https://drafts.csswg.org/css-highlight-api/ */
+::highlight(wiki-annotation) {
+  background-color: rgba(255, 212, 59, 0.32);
+  text-decoration: underline wavy rgba(255, 180, 0, 0.7);
+  text-decoration-skip-ink: none;
 }
 
 /* 浮动注解按钮 */

--- a/apps/negentropy-wiki/tests/lib/annotation/use-highlight-renderer.test.ts
+++ b/apps/negentropy-wiki/tests/lib/annotation/use-highlight-renderer.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  createMarkWrapRenderer,
+  pickRenderer,
+  supportsCSSHighlightAPI,
+  type HighlightGroupInput,
+} from "@/lib/annotation/use-highlight-renderer";
+
+describe("supportsCSSHighlightAPI", () => {
+  it("returns false in jsdom (no Highlight constructor)", () => {
+    // jsdom 当前不实现 CSS Highlight API；该测试同时验证 detection 不会抛错
+    expect(supportsCSSHighlightAPI()).toBe(false);
+  });
+});
+
+describe("pickRenderer", () => {
+  it("默认（非翻译态）选用 MarkWrap 渲染器", () => {
+    const factory = pickRenderer({ isTranslated: false });
+    const renderer = factory(
+      () => {},
+      () => {},
+    );
+    expect(renderer.supportsElementEvents).toBe(true);
+  });
+
+  it("翻译态但浏览器不支持 CSS Highlight → 降级到 MarkWrap", () => {
+    const factory = pickRenderer({ isTranslated: true });
+    const renderer = factory(
+      () => {},
+      () => {},
+    );
+    expect(renderer.supportsElementEvents).toBe(true);
+  });
+});
+
+describe("createMarkWrapRenderer", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.innerHTML = "<p>Hello annotated world.</p>";
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function makeRange(start: number, end: number): Range {
+    const textNode = container.querySelector("p")!.firstChild as Text;
+    const r = document.createRange();
+    r.setStart(textNode, start);
+    r.setEnd(textNode, end);
+    return r;
+  }
+
+  it("apply 包裹 <mark> 标签到 Range", () => {
+    const hoverStart = vi.fn();
+    const hoverEnd = vi.fn();
+    const renderer = createMarkWrapRenderer(hoverStart, hoverEnd);
+
+    const group: HighlightGroupInput = {
+      annotationIds: ["a1"],
+      range: makeRange(6, 15), // "annotated"
+      annotations: [],
+    };
+    renderer.apply([group]);
+
+    const marks = container.querySelectorAll("mark.wiki-annotation-highlight");
+    expect(marks.length).toBe(1);
+    expect(marks[0].textContent).toBe("annotated");
+    expect(marks[0].getAttribute("data-annotation-ids")).toBe("a1");
+  });
+
+  it("clear 还原 DOM（移除 mark 标签）", () => {
+    const renderer = createMarkWrapRenderer(
+      () => {},
+      () => {},
+    );
+    const group: HighlightGroupInput = {
+      annotationIds: ["a1"],
+      range: makeRange(0, 5),
+      annotations: [],
+    };
+    renderer.apply([group]);
+    expect(container.querySelectorAll("mark").length).toBe(1);
+
+    renderer.clear();
+    expect(container.querySelectorAll("mark").length).toBe(0);
+    expect(container.textContent).toBe("Hello annotated world.");
+  });
+
+  it("mouseenter 触发 hoverStart 回调", () => {
+    const hoverStart = vi.fn();
+    const hoverEnd = vi.fn();
+    const renderer = createMarkWrapRenderer(hoverStart, hoverEnd);
+
+    const group: HighlightGroupInput = {
+      annotationIds: ["a1"],
+      range: makeRange(0, 5),
+      annotations: [],
+    };
+    renderer.apply([group]);
+
+    const mark = container.querySelector("mark")!;
+    mark.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(hoverStart).toHaveBeenCalledTimes(1);
+    mark.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(hoverEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("apply 两次连续：先清旧再写新，无 mark 堆叠", () => {
+    const renderer = createMarkWrapRenderer(
+      () => {},
+      () => {},
+    );
+    renderer.apply([
+      { annotationIds: ["a1"], range: makeRange(0, 5), annotations: [] },
+    ]);
+    // 第一次 apply 后 DOM 已变（mark 包裹），需要重新基于当前 DOM 创建 Range。
+    const p = container.querySelector("p")!;
+    const newRange = document.createRange();
+    newRange.selectNodeContents(p); // 选中整段做粗粒度演示
+    renderer.apply([
+      { annotationIds: ["a2"], range: newRange, annotations: [] },
+    ]);
+    const marks = container.querySelectorAll("mark");
+    expect(marks.length).toBe(1);
+    expect(marks[0].getAttribute("data-annotation-ids")).toBe("a2");
+  });
+});

--- a/apps/negentropy-wiki/tests/lib/annotation/use-snapshot.test.ts
+++ b/apps/negentropy-wiki/tests/lib/annotation/use-snapshot.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { captureSnapshot } from "@/lib/annotation/use-snapshot";
+
+describe("captureSnapshot", () => {
+  it("captures textContent and text node references with original values", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    div.innerHTML = "<p>Hello world</p><p>Second paragraph</p>";
+
+    const snap = captureSnapshot(div);
+    expect(snap.textContent).toBe("Hello worldSecond paragraph");
+    expect(snap.textNodes.length).toBe(2);
+    expect(snap.originalNodeValues.get(snap.textNodes[0])).toBe("Hello world");
+    expect(snap.originalNodeValues.get(snap.textNodes[1])).toBe("Second paragraph");
+    expect(snap.textHash).toMatch(/^[0-9a-f]{8}$/);
+
+    document.body.removeChild(div);
+  });
+
+  it("preserves text node references after nodeValue is mutated (translation simulation)", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    div.innerHTML = "<p>Hello world</p>";
+
+    const snap = captureSnapshot(div);
+    const originalNode = snap.textNodes[0];
+
+    // 模拟浏览器翻译：原地修改 text node 的 nodeValue
+    originalNode.nodeValue = "你好世界";
+
+    // text node 引用仍指向同一个 DOM 节点（虽然内容变了）
+    expect(snap.textNodes[0]).toBe(originalNode);
+    expect(snap.textNodes[0].nodeValue).toBe("你好世界");
+    // snapshot 中保留的原文不变
+    expect(snap.originalNodeValues.get(originalNode)).toBe("Hello world");
+
+    document.body.removeChild(div);
+  });
+
+  it("indexes block-level elements with xpath, text and offset", () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    div.innerHTML = "<p>First</p><p><strong>Second</strong></p>";
+
+    const snap = captureSnapshot(div);
+    const blocks = snap.blockElements;
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+    const first = blocks.find((b) => b.text === "First");
+    const second = blocks.find((b) => b.text === "Second");
+    expect(first?.offset).toBe(0);
+    expect(second?.offset).toBe(5); // "First".length
+    expect(first?.xpath).toMatch(/^\/p/);
+    expect(second?.xpath).toMatch(/^\/p/);
+
+    document.body.removeChild(div);
+  });
+
+  it("hash changes when textContent changes", () => {
+    const div1 = document.createElement("div");
+    div1.textContent = "Hello";
+    const snap1 = captureSnapshot(div1);
+    const div2 = document.createElement("div");
+    div2.textContent = "你好";
+    const snap2 = captureSnapshot(div2);
+    expect(snap1.textHash).not.toBe(snap2.textHash);
+  });
+
+  it("same textContent produces same hash (deterministic)", () => {
+    const a = document.createElement("div");
+    a.textContent = "stable";
+    const b = document.createElement("div");
+    b.textContent = "stable";
+    expect(captureSnapshot(a).textHash).toBe(captureSnapshot(b).textHash);
+  });
+});

--- a/apps/negentropy-wiki/tests/lib/annotation/use-text-anchor.test.ts
+++ b/apps/negentropy-wiki/tests/lib/annotation/use-text-anchor.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveAnchor, type TextAnchor } from "@/lib/annotation/use-text-anchor";
+import { captureSnapshot, type AnnotationSnapshot } from "@/lib/annotation/use-snapshot";
+
+describe("resolveAnchor - 三段式解析", () => {
+  let container: HTMLDivElement;
+  let snapshot: AnnotationSnapshot;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.innerHTML =
+      "<p>This is the first paragraph with annotated text inside.</p>" +
+      "<p>Second paragraph for context.</p>";
+    document.body.appendChild(container);
+    snapshot = captureSnapshot(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  // 容器 textContent："This is the first paragraph with annotated text inside.Second paragraph for context."
+  // "annotated text" 起始字符偏移 33，长度 14
+  // "Second" 起始字符偏移 55，长度 6
+  it("段 1：v2 anchor + hash 一致 → snapshot 直接定位", () => {
+    const anchor: TextAnchor = {
+      xpath: "/p[1]",
+      exact: "annotated text",
+      prefix: "first paragraph with ",
+      suffix: " inside.",
+      text_offset: 33,
+      text_length: 14,
+      source_text_hash: snapshot.textHash,
+      anchor_version: 2,
+    };
+    const range = resolveAnchor(anchor, container, snapshot);
+    expect(range).not.toBeNull();
+    expect(range!.toString()).toBe("annotated text");
+  });
+
+  it("段 2：v1 anchor（无 snapshot 字段）→ 当前 DOM 全文搜索命中", () => {
+    const anchor: TextAnchor = {
+      xpath: "/p[1]",
+      exact: "annotated text",
+      prefix: "first paragraph with ",
+      suffix: " inside.",
+      text_offset: 33,
+      text_length: 14,
+    };
+    const range = resolveAnchor(anchor, container);
+    expect(range).not.toBeNull();
+    expect(range!.toString()).toBe("annotated text");
+  });
+
+  it("段 1 → 段 2 切换：snapshot hash 不匹配则降级", () => {
+    const anchor: TextAnchor = {
+      xpath: "/p[1]",
+      exact: "annotated text",
+      prefix: "first paragraph with ",
+      suffix: " inside.",
+      text_offset: 33,
+      text_length: 14,
+      source_text_hash: "deadbeef", // 故意错的 hash
+      anchor_version: 2,
+    };
+    const range = resolveAnchor(anchor, container, snapshot);
+    expect(range).not.toBeNull();
+    // 走段 2 兜底，仍能命中
+    expect(range!.toString()).toBe("annotated text");
+  });
+
+  it("段 3：精确文本不存在 → 块级粗粒度回退", () => {
+    const anchor: TextAnchor = {
+      xpath: "/p[1]",
+      // 这段中文文本在英文容器中绝对不存在
+      exact: "标注的中文文本",
+      prefix: "中文前缀",
+      suffix: "中文后缀",
+      text_offset: 0,
+      text_length: 7,
+    };
+    const range = resolveAnchor(anchor, container);
+    expect(range).not.toBeNull();
+    // 块级回退 → 选中整个 <p> 的内容
+    expect(range!.toString()).toContain("first paragraph");
+  });
+
+  it("xpath 失效但文本仍在 → 走段 2 全文搜索", () => {
+    const anchor: TextAnchor = {
+      xpath: "/section[3]/div[1]", // 这个 xpath 在 container 中不存在
+      exact: "Second paragraph",
+      prefix: "",
+      suffix: "",
+      text_offset: 100,
+      text_length: 16,
+    };
+    const range = resolveAnchor(anchor, container);
+    expect(range).not.toBeNull();
+    expect(range!.toString()).toBe("Second paragraph");
+  });
+
+  it("v2 anchor 在 snapshot 节点 nodeValue 被翻译后仍可命中（粗粒度回退）", () => {
+    const anchor: TextAnchor = {
+      xpath: "/p[1]",
+      exact: "annotated text",
+      prefix: "",
+      suffix: "",
+      text_offset: 33,
+      text_length: 14,
+      source_text_hash: snapshot.textHash,
+      anchor_version: 2,
+    };
+    // 翻译：原地修改第一个 text node 的 nodeValue 为中文
+    const originalP1Text = snapshot.textNodes[0];
+    originalP1Text.nodeValue = "这是第一段含有被标注文本的段落内容。";
+
+    // 此时容器 textContent 已变，hash 不再匹配
+    // 段 2 全文搜索找不到 "annotated text"（中文容器中）
+    // 段 3 块级粗粒度回退命中第一个 <p>
+    const range = resolveAnchor(anchor, container, snapshot);
+    expect(range).not.toBeNull();
+    // 落在中文译文里某段（粗粒度），非空字符串
+    expect(range!.toString().length).toBeGreaterThan(0);
+  });
+
+  it("v2 anchor 在 hash 一致且 nodeValue 未变时精确命中（snapshot fast path）", () => {
+    // "Second" 起始于容器全局偏移 55
+    const anchor: TextAnchor = {
+      xpath: "/p[2]",
+      exact: "Second",
+      prefix: "",
+      suffix: " paragraph",
+      text_offset: 55,
+      text_length: 6,
+      source_text_hash: snapshot.textHash,
+      anchor_version: 2,
+    };
+    const range = resolveAnchor(anchor, container, snapshot);
+    expect(range).not.toBeNull();
+    expect(range!.toString()).toBe("Second");
+  });
+});

--- a/apps/negentropy-wiki/tests/lib/annotation/use-translation-detect.test.ts
+++ b/apps/negentropy-wiki/tests/lib/annotation/use-translation-detect.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  debounce,
+  isContainerTranslated,
+  isTranslationMutation,
+} from "@/lib/annotation/use-translation-detect";
+
+describe("isContainerTranslated", () => {
+  it("returns false for plain DOM without <font> wrappers", () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<p>Hello world</p>";
+    expect(isContainerTranslated(div)).toBe(false);
+  });
+
+  it("returns true when <font> wrapper is present (Chrome translate signature)", () => {
+    const div = document.createElement("div");
+    div.innerHTML = '<p><font style="vertical-align: inherit;">你好</font></p>';
+    expect(isContainerTranslated(div)).toBe(true);
+  });
+
+  it("returns true when MS Edge translation attrs present", () => {
+    const div = document.createElement("div");
+    div.innerHTML = '<p _msttexthash="abc">test</p>';
+    expect(isContainerTranslated(div)).toBe(true);
+  });
+
+  it("returns false for null container", () => {
+    expect(isContainerTranslated(null)).toBe(false);
+  });
+});
+
+describe("isTranslationMutation", () => {
+  function mkMutation(init: Partial<MutationRecord>): MutationRecord {
+    return {
+      type: "childList",
+      target: document.createElement("div"),
+      addedNodes: document.createDocumentFragment().childNodes,
+      removedNodes: document.createDocumentFragment().childNodes,
+      previousSibling: null,
+      nextSibling: null,
+      attributeName: null,
+      attributeNamespace: null,
+      oldValue: null,
+      ...init,
+    } as MutationRecord;
+  }
+
+  it("flags <font> insertion as translation", () => {
+    const fragment = document.createDocumentFragment();
+    const font = document.createElement("font");
+    fragment.appendChild(font);
+    const m = mkMutation({
+      type: "childList",
+      addedNodes: fragment.childNodes,
+    });
+    expect(isTranslationMutation(m)).toBe(true);
+  });
+
+  it("flags characterData changes as translation", () => {
+    const m = mkMutation({ type: "characterData" });
+    expect(isTranslationMutation(m)).toBe(true);
+  });
+
+  it("flags lang attribute change as translation", () => {
+    const m = mkMutation({ type: "attributes", attributeName: "lang" });
+    expect(isTranslationMutation(m)).toBe(true);
+  });
+
+  it("ignores irrelevant childList changes (e.g. our own <mark>)", () => {
+    const fragment = document.createDocumentFragment();
+    const mark = document.createElement("mark");
+    mark.className = "wiki-annotation-highlight";
+    fragment.appendChild(mark);
+    const m = mkMutation({
+      type: "childList",
+      addedNodes: fragment.childNodes,
+    });
+    // mark 节点不在 TRANSLATION_TAG_NAMES 中，且无翻译特征 attribute，应不视为翻译
+    expect(isTranslationMutation(m)).toBe(false);
+  });
+});
+
+describe("debounce", () => {
+  it("collapses rapid calls into a single trailing call", async () => {
+    let count = 0;
+    const fn = debounce(() => {
+      count += 1;
+    }, 30);
+    fn();
+    fn();
+    fn();
+    expect(count).toBe(0);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(count).toBe(1);
+  });
+
+  it("cancel() prevents the pending invocation", async () => {
+    let count = 0;
+    const fn = debounce(() => {
+      count += 1;
+    }, 30);
+    fn();
+    fn.cancel();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(count).toBe(0);
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -359,7 +359,18 @@ class WikiCommentListResponse(BaseModel):
 
 
 class WikiAnnotationAnchor(BaseModel):
-    """文本注解锚定数据（W3C Web Annotation TextQuoteSelector）"""
+    """文本注解锚定数据（W3C Web Annotation TextQuoteSelector）
+
+    v2 锚定（source-anchored selectors）新增字段：
+      - source_text_hash：创建时容器 textContent 快照的 FNV-1a 哈希，
+        用于运行时校验 snapshot 是否仍可信（解决浏览器翻译/DOM 重渲染导致的
+        锚定漂移问题）。
+      - source_lang：创建时检测到的内容主语言。仅用于诊断与调试。
+      - anchor_version：锚定算法版本。缺省视为 v1（旧 anchor，不含上述字段）。
+
+    所有 v2 字段均为可选，向前兼容旧 anchor。底层 anchor JSONB 字段，
+    无需数据库 migration。
+    """
 
     xpath: str
     exact: str
@@ -367,6 +378,9 @@ class WikiAnnotationAnchor(BaseModel):
     suffix: str | None = None
     text_offset: int | None = None
     text_length: int | None = None
+    source_text_hash: str | None = None
+    source_lang: str | None = None
+    anchor_version: int | None = None
 
 
 class WikiAnnotationCreateRequest(BaseModel):


### PR DESCRIPTION
## 摘要

用户使用 Chrome「翻译成中文」翻译英文 Wiki 文章后，在译文上创建注解；刷新页面（DOM 回到英文）→ 再次浏览器翻译，注解会**消失**。本 PR 从锚定模型、渲染策略、翻译信号检测三个层面彻底修复该问题。

## 根因（5 层独立失效）

| # | 根因 | 表现 |
|---|---|---|
| R1 | anchor 锚错了「权威源」：`exact/prefix/suffix` 在用户当时可见 DOM 上计算 | 翻译态下创建的注解 anchor 是中文，刷新后英文 DOM 中 `indexOf` 永远 -1 |
| R2 | Chrome NMT 翻译结果非幂等 | 即便再次翻译，新中文 ≠ anchor 中旧中文 |
| R3 | `applyHighlights` 仅由 React 状态变化触发 | 浏览器翻译是 native 异步行为，不触发重应用 |
| R4 | Chrome 翻译会包裹 `<font>` 并就地改 `nodeValue` | XPath 失效；`<mark>` 节点被破坏 |
| R5 | 未启用 `translate=\"no\"` 保护 | 注解的锚定环境完全不可控 |

## 设计哲学

> 把「用户看到的内容」与「注解锚定到的内容」解耦 —— 用户可自由翻译/缩放/字体切换，注解的锚永远落在「原文档源（snapshot）」上。

## 方案（六层防御纵深）

| Pillar | 解决 | 关键文件 |
|---|---|---|
| **1. Stable Snapshot** | R1/R2/R4 | `use-snapshot.ts` — mount 时抓取 textContent + textNodes + WeakMap<TextNode,originalText> + 块级元素索引 + FNV-1a 哈希，作为唯一权威坐标系 |
| **2. Source-Anchored Selectors** | R1 | `use-text-anchor.ts:computeAnchor` — 接受 snapshot，将当前 selection（即使翻译态 DOM 上）映射回 snapshot 字符坐标；anchor 扩展 `source_text_hash` / `source_lang` / `anchor_version` 字段（JSONB 向前兼容） |
| **3. 三段式 resolveAnchor** | R3/R4 | snapshot 精确 → 当前 DOM 文本搜索（兼容 v1 anchor） → **块级粗粒度回退**（保证「注解不消失」） |
| **4. MutationObserver 自动重应用** | R3 | `AnnotationHighlightLayer.tsx` — 监听 `<font>` 插入 / characterData / lang\|translate 属性变化等翻译信号，debounced 200ms 触发 applyHighlights |
| **5. CSS Custom Highlight API 渲染** | R4 | `use-highlight-renderer.ts` — Strategy Pattern，翻译态优先用 `CSS.highlights`（不修改 DOM，免疫 `<font>` 破坏）；不支持降级到 `<mark>` 包裹；用 `caretRangeFromPoint` 实现命中检测 |
| **6. translate=\"no\" 容器保护** | R5 | `MarkdownRenderer.tsx` 容器加属性，声明注解锚定的稳定坐标系 |

## 数据模型变更（向前兼容）

`WikiAnnotationAnchor` 新增 3 个可选字段：

```python
source_text_hash: str | None = None  # 创建时 snapshot 的 textContent FNV-1a 哈希
source_lang: str | None = None        # 创建时检测到的内容主语言（zh/en/...）
anchor_version: int | None = None     # 锚定算法版本（v2）
```

`anchor` 底层为 JSONB，**无需 migration**。旧 v1 anchor 自动走兼容路径（DOM 文本搜索 + 块级回退）。

## 改动清单

| 类型 | 文件 | 行数 |
|---|---|---|
| 新增 | `apps/negentropy-wiki/src/lib/annotation/use-snapshot.ts` | +193 |
| 新增 | `apps/negentropy-wiki/src/lib/annotation/use-translation-detect.ts` | +120 |
| 新增 | `apps/negentropy-wiki/src/lib/annotation/use-highlight-renderer.ts` | +254 |
| 重写 | `apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts` | +279/-92 |
| 重写 | `apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx` | +97/-60 |
| 修改 | `apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx` | +5/-1 |
| 修改 | `apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx` | +6/-2 |
| 修改 | `apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx` | +5/-1 |
| 修改 | `apps/negentropy-wiki/src/lib/annotation/use-annotations.ts` | +4 |
| 修改 | `apps/negentropy-wiki/src/styles/components/annotation.css` | +9/-1 |
| 修改 | `apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py` | +14/-2 |
| 新增 | `apps/negentropy-wiki/tests/lib/annotation/*.test.ts` (4 文件) | +423 |

**合计**：15 个文件，+1565 / -131 行

## 测试 / 验证

### 单元测试（26 个全部通过）
- `use-translation-detect.test.ts` — 翻译信号鉴别 + debounce
- `use-snapshot.test.ts` — textContent / textNodes / WeakMap / 块级索引 / 哈希一致性
- `use-text-anchor.test.ts` — 三段式 resolveAnchor 各路径覆盖
- `use-highlight-renderer.test.ts` — Strategy 选择 + Mark 渲染 + 事件

### 集成验证
- `pnpm build` ✓ 通过
- `pnpm exec tsc --noEmit` ✓ 无类型错误
- `pnpm lint` ✓ 无新增警告

### 实机端到端验证
- [x] `.wiki-markdown-body` 已有 `translate=\"no\"` 属性
- [x] `AnnotationLayer` mount 正常
- [x] `CSS.highlights` 在 Chrome 中可用
- [x] `MutationObserver` 可用
- [x] 注解 API 路径可达
- [x] 无 console 错误
- [x] 模拟 `<font>` 注入未导致系统崩溃

### 端到端用户场景回归（请审阅者按此清单实机验证）

| # | 场景 | 验证点 |
|---|---|---|
| V1 | 英文原文 → 创建注解 → 刷新 | 注解精确高亮 |
| V2 | 英文原文 → 创建注解 → 浏览器翻译中文 | 高亮自动跟随到中文对应位置（MutationObserver 触发重应用） |
| V3 | **核心**：浏览器翻译中文 → 在译文上创建注解 → 刷新 → 再次翻译 | **注解仍存在** |
| V4 | 多条注解、跨段落、嵌套块级元素 | 全部正确高亮 |
| V5 | 老 v1 anchor + 浏览器翻译 | 走 currentDOM 搜索或块级粗粒度回退，hover 仍可显示注解内容 |
| V6 | 不支持 CSS Highlight API 的旧浏览器 | 降级到 `<mark>` 方案 |

## 参考文献

[1] W3C Web Annotation Data Model. https://www.w3.org/TR/annotation-model/
[2] Hypothes.is dom-anchor-text-quote. https://github.com/tilgovi/dom-anchor-text-quote
[3] W3C CSS Custom Highlight API. https://drafts.csswg.org/css-highlight-api/

🤖 Generated with [Claude Code](https://claude.com/claude-code)