### PR TITLE
fix(scheduler): 修复 Maintenance Consolidation SQL 参数边界识别异常

### DIFF
--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_automation_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_automation_service.py
@@ -351,7 +351,8 @@ class MemoryAutomationService:
             result_data = row[0] if row else None
         elif job_key == "trigger_consolidation":
             consolidation = config["consolidation"]
-            sql = text(f"SELECT {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(:lookback::interval)")
+            # CAST(:lookback AS interval) —— 避免 :lookback::interval 命名参数边界识别异常
+            sql = text(f"SELECT {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(CAST(:lookback AS interval))")
             async with AsyncSessionLocal() as db:
                 result = await db.execute(sql, {"lookback": consolidation["lookback_interval"]})
                 row = result.first()
@@ -455,7 +456,7 @@ class MemoryAutomationService:
                 await db.execute(
                     text(
                         "UPDATE scheduled_tasks SET enabled = :enabled, "
-                        "cron_expr = :cron_expr, payload = :payload ::jsonb "
+                        "cron_expr = :cron_expr, payload = CAST(:payload AS jsonb) "
                         "WHERE key = :task_key"
                     ),
                     {

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
@@ -74,7 +74,10 @@ async def _run_consolidation(task: ScheduledTask) -> HandlerResult:
     payload = task.payload or {}
     lookback_interval = payload.get("lookback_interval", "1 hour")
 
-    sql = text(f"SELECT {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(:lookback::interval)")
+    # CAST(:lookback AS interval) 而非 :lookback::interval —— 命名参数紧邻 PostgreSQL ::
+    # cast 会破坏 SQLAlchemy 参数边界识别，asyncpg 报 syntax error。同口径修复参见
+    # knowledge/graph/repository.py:515-519、knowledge/retrieval/repository.py:832-834。
+    sql = text(f"SELECT {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(CAST(:lookback AS interval))")
     try:
         async with AsyncSessionLocal() as db:
             result = await db.execute(sql, {"lookback": lookback_interval})

--- a/apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_memory_automation_service.py
@@ -109,6 +109,9 @@ def test_build_function_definitions_includes_reweight():
     assert "outcome_feedback IS NOT NULL" in sql
 
 
+# ---- Reweight relevance tests ----
+
+
 @pytest.mark.asyncio
 async def test_run_reweight_relevance_dispatches(service: MemoryAutomationService):
     """Verify _run_reweight_relevance queries users with feedback and calls reweight_memories."""
@@ -197,3 +200,130 @@ async def test_run_reweight_relevance_partial_failure(service: MemoryAutomationS
     assert result["users_processed"] == 2
     assert result["failed_users"] == 1
     assert mock_rw_module.reweight_memories.call_count == 3
+
+
+# ---- Consolidation SQL parameter boundary tests ----
+
+
+def test_consolidation_handler_sql_uses_cast_not_double_colon():
+    """Handler 层 _run_consolidation SQL 构造行必须使用 CAST 而非 :: 直接 cast。"""
+    import inspect
+
+    from negentropy.engine.schedulers.handlers.memory_automation import _run_consolidation
+
+    source = inspect.getsource(_run_consolidation)
+    sql_lines = [line for line in source.splitlines() if "sql = text(" in line]
+    assert len(sql_lines) == 1, f"预期恰好 1 行 sql = text(...)，实际 {len(sql_lines)} 行"
+    assert "CAST(:lookback AS interval)" in sql_lines[0], (
+        f"sql 构造行应使用 CAST(:lookback AS interval)，实际: {sql_lines[0]}"
+    )
+
+
+def test_consolidation_service_run_job_sql_uses_cast_not_double_colon():
+    """Service 层 run_job(trigger_consolidation) SQL 构造行必须使用 CAST。"""
+    import inspect
+
+    from negentropy.engine.adapters.postgres.memory_automation_service import MemoryAutomationService
+
+    source = inspect.getsource(MemoryAutomationService.run_job)
+    # 筛选 trigger_consolidation 分支内的 sql = text(...) 行
+    in_consolidation_branch = False
+    sql_lines = []
+    for line in source.splitlines():
+        if '"trigger_consolidation"' in line:
+            in_consolidation_branch = True
+        elif in_consolidation_branch and ("elif " in line or "else:" in line):
+            in_consolidation_branch = False
+        if in_consolidation_branch and "sql = text(" in line:
+            sql_lines.append(line)
+    assert len(sql_lines) == 1, f"预期 1 行 sql = text(...)，实际 {len(sql_lines)} 行"
+    assert "CAST(:lookback AS interval)" in sql_lines[0], (
+        f"sql 构造行应使用 CAST(:lookback AS interval)，实际: {sql_lines[0]}"
+    )
+
+
+def test_sync_config_payload_uses_cast_not_double_colon():
+    """_sync_config_to_scheduled_tasks 中 payload 赋值应使用 CAST 规范。"""
+    import inspect
+
+    from negentropy.engine.adapters.postgres.memory_automation_service import MemoryAutomationService
+
+    source = inspect.getsource(MemoryAutomationService._sync_config_to_scheduled_tasks)
+    assert "CAST(:payload AS jsonb)" in source, (
+        "_sync_config_to_scheduled_tasks 应使用 CAST(:payload AS jsonb) 而非 :payload ::jsonb"
+    )
+    assert ":payload ::jsonb" not in source, (
+        "_sync_config_to_scheduled_tasks 不应使用 :payload ::jsonb —— 脆弱写法，应统一为 CAST 规范"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_run_consolidation_success():
+    """Handler _run_consolidation 成功路径：返回 ok + count。"""
+    from negentropy.models.scheduled_task import ScheduledTask
+
+    mock_result = MagicMock()
+    mock_result.first.return_value = (3,)
+
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = mock_result
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+
+    task = MagicMock(spec=ScheduledTask)
+    task.payload = {"job_type": "trigger_consolidation", "lookback_interval": "2 hours"}
+
+    with patch(
+        "negentropy.engine.schedulers.handlers.memory_automation.AsyncSessionLocal",
+        return_value=mock_db,
+    ):
+        from negentropy.engine.schedulers.handlers.memory_automation import _run_consolidation
+
+        result = await _run_consolidation(task)
+
+    assert result.status == "ok"
+    assert result.metrics["consolidated"] == 3
+
+    # 验证 SQL 使用 CAST 而非 ::
+    call_args = mock_db.execute.call_args
+    sql_text = str(call_args[0][0])
+    assert "CAST(:lookback AS interval)" in sql_text
+    assert ":lookback::interval" not in sql_text
+
+
+@pytest.mark.asyncio
+async def test_service_run_job_consolidation_success():
+    """Service run_job(trigger_consolidation) 成功路径：验证 SQL 使用 CAST。"""
+    from negentropy.engine.adapters.postgres.memory_automation_service import MemoryAutomationService
+
+    mock_select_result = MagicMock()
+    mock_select_result.first.return_value = (5,)
+
+    mock_db = AsyncMock()
+    # _reconcile_functions 创建 5 个 function → 5 次 DDL execute
+    # + consolidation SELECT → 1 次 execute = 6 次
+    mock_db.execute.side_effect = [MagicMock()] * 5 + [mock_select_result]
+    mock_db.commit = AsyncMock()
+    mock_db.__aenter__ = AsyncMock(return_value=mock_db)
+    mock_db.__aexit__ = AsyncMock(return_value=False)
+
+    mock_get_config = AsyncMock(return_value=DEFAULT_AUTOMATION_CONFIG)
+    mock_get_snapshot = AsyncMock(return_value={})
+
+    service = MemoryAutomationService()
+    with (
+        patch(
+            "negentropy.engine.adapters.postgres.memory_automation_service.AsyncSessionLocal",
+            return_value=mock_db,
+        ),
+        patch.object(service, "get_effective_config", mock_get_config),
+        patch.object(service, "get_snapshot", mock_get_snapshot),
+    ):
+        result = await service.run_job(app_name="test", job_key="trigger_consolidation")
+
+    assert result["result"] == 5
+
+    # 最后一个 execute 调用是 consolidation SQL
+    consolidation_call = mock_db.execute.call_args_list[-1]
+    sql_text = str(consolidation_call[0][0])
+    assert "CAST(:lookback AS interval)" in sql_text, f"SQL 应包含 CAST，实际: {sql_text}"


### PR DESCRIPTION
# 背景
- SQLAlchemy `text()` 中 PostgreSQL `::` 类型转换语法紧邻命名参数时，asyncpg 驱动无法正确解析参数边界，导致 `trigger_consolidation` 运行时报 syntax error。
- 同类问题在 `knowledge/graph/repository.py` 和 `knowledge/retrieval/repository.py` 中已有先例修复。

# 核心变更
- 将 `:lookback::interval` 替换为 `CAST(:lookback AS interval)`（Service 层 + Handler 层共 2 处）
- 将 `:payload ::jsonb` 替换为 `CAST(:payload AS jsonb)`（`_sync_config_to_scheduled_tasks` 1 处）
- 新增 5 个单元测试：源码断言型回归保护 + Mock 路径执行验证，覆盖 Handler 和 Service 双层

# 风险与回滚
- 主要风险：`CAST()` 与 `::` 在 PostgreSQL 中语义完全等价，无行为差异风险
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：5 个新增测试覆盖 CAST 规范断言 + 成功路径 SQL 验证
- 集成测试：N/A
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`memory_automation_service.py`（Service 层）、`memory_automation.py`（Handler 层）
- GitHub Actions / 文档：无

# Next Best Action
- 考虑全量扫描 `text()` 调用中是否存在其他 `::` cast + 命名参数的同类隐患

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>