### PR TITLE
fix(builtin-tool): 修复 Google Search 凭证脱敏回传导致 Test Connection 失败

### DIFF
--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -1515,7 +1515,7 @@ async def update_builtin_tool(
         if "visibility" in update_data:
             update_data["visibility"] = PluginVisibility(update_data["visibility"])
         # 前端可能回传 GET 响应中的脱敏凭证，替换为 DB 真实值后再写入
-        if "credentials" in update_data:
+        if "credentials" in update_data and update_data["credentials"] is not None:
             update_data["credentials"] = _merge_masked_credentials(
                 update_data["credentials"], ensure_dict(tool.credentials)
             )

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -172,6 +172,27 @@ def _mask_credentials(credentials: dict[str, Any]) -> dict[str, Any]:
     return masked
 
 
+def _is_masked_value(value: Any) -> bool:
+    """判断值是否为 _mask_credentials 产生的脱敏占位值。"""
+    return isinstance(value, str) and "****" in value
+
+
+def _merge_masked_credentials(incoming: dict[str, Any], stored: dict[str, Any]) -> dict[str, Any]:
+    """将 incoming 中的脱敏占位值替换为 stored 中的真实值。
+
+    前端回传 GET 响应中的脱敏值时，用 DB 真实凭证替换：
+    - incoming 中未被脱敏的字段（用户新输入）保持不变
+    - incoming 中被脱敏且 stored 中无对应值时保留原值（下游校验拦截）
+    """
+    merged = {}
+    for key, value in incoming.items():
+        if _is_masked_value(value) and key in stored:
+            merged[key] = stored[key]
+        else:
+            merged[key] = value
+    return merged
+
+
 def _builtin_tool_to_response(tool: BuiltinTool) -> BuiltinToolResponse:
     return BuiltinToolResponse(
         id=tool.id,
@@ -1493,6 +1514,11 @@ async def update_builtin_tool(
         update_data = payload.model_dump(exclude_unset=True)
         if "visibility" in update_data:
             update_data["visibility"] = PluginVisibility(update_data["visibility"])
+        # 前端可能回传 GET 响应中的脱敏凭证，替换为 DB 真实值后再写入
+        if "credentials" in update_data:
+            update_data["credentials"] = _merge_masked_credentials(
+                update_data["credentials"], ensure_dict(tool.credentials)
+            )
         for field, value in update_data.items():
             setattr(tool, field, value)
 
@@ -1555,6 +1581,8 @@ async def test_builtin_tool(
     inline = payload or BuiltinToolTestRequest()
     config = inline.config if inline.config is not None else ensure_dict(tool.config)
     credentials = inline.credentials if inline.credentials is not None else ensure_dict(tool.credentials)
+    # 前端可能回传 GET 响应中的脱敏凭证（含 ****），替换为 DB 真实值
+    credentials = _merge_masked_credentials(credentials, ensure_dict(tool.credentials))
 
     if tool.tool_type == "search" and tool.name == "google_search":
         api_key = credentials.get("api_key", "")

--- a/apps/negentropy/tests/unit_tests/interface/test_builtin_tool_api.py
+++ b/apps/negentropy/tests/unit_tests/interface/test_builtin_tool_api.py
@@ -426,3 +426,161 @@ class TestTestBuiltinToolGeneric:
                 await interface_api.test_builtin_tool(tool_id=tool_id, payload=None, user=_user)
 
         assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 5) 凭证脱敏回传：_merge_masked_credentials 辅助函数 + 端点集成
+# ---------------------------------------------------------------------------
+
+
+class TestIsMaskedValue:
+    """_is_masked_value 脱敏占位检测。"""
+
+    def test_masked_long_value(self) -> None:
+        assert interface_api._is_masked_value("AIza****1234") is True
+
+    def test_masked_short_value(self) -> None:
+        assert interface_api._is_masked_value("****") is True
+
+    def test_normal_string_not_masked(self) -> None:
+        assert interface_api._is_masked_value("AIzaSyB-abc123") is False
+
+    def test_empty_string_not_masked(self) -> None:
+        assert interface_api._is_masked_value("") is False
+
+    def test_non_string_not_masked(self) -> None:
+        assert interface_api._is_masked_value(42) is False
+        assert interface_api._is_masked_value(None) is False
+        assert interface_api._is_masked_value({}) is False
+
+    def test_single_star_not_masked(self) -> None:
+        assert interface_api._is_masked_value("AIza*1234") is False
+
+    def test_three_stars_not_masked(self) -> None:
+        assert interface_api._is_masked_value("AIza***1234") is False
+
+
+class TestMergeMaskedCredentials:
+    """_merge_masked_credentials 脱敏值替换为 DB 真实值。"""
+
+    def test_masked_replaced_with_stored(self) -> None:
+        result = interface_api._merge_masked_credentials(
+            {"api_key": "AIza****1234"},
+            {"api_key": "AIzaSyB-real-key"},
+        )
+        assert result == {"api_key": "AIzaSyB-real-key"}
+
+    def test_new_value_preserved(self) -> None:
+        result = interface_api._merge_masked_credentials(
+            {"api_key": "brand-new-key"},
+            {"api_key": "old-key"},
+        )
+        assert result == {"api_key": "brand-new-key"}
+
+    def test_mixed_masked_and_new(self) -> None:
+        result = interface_api._merge_masked_credentials(
+            {"api_key": "AIza****1234", "secret": "new-secret"},
+            {"api_key": "real-key", "secret": "old-secret"},
+        )
+        assert result == {"api_key": "real-key", "secret": "new-secret"}
+
+    def test_masked_without_stored_kept_as_is(self) -> None:
+        result = interface_api._merge_masked_credentials(
+            {"api_key": "****"},
+            {},
+        )
+        assert result == {"api_key": "****"}
+
+    def test_empty_incoming_returns_empty(self) -> None:
+        result = interface_api._merge_masked_credentials({}, {"api_key": "real"})
+        assert result == {}
+
+    def test_empty_stored_masked_preserved(self) -> None:
+        result = interface_api._merge_masked_credentials({"k": "****"}, {})
+        assert result == {"k": "****"}
+
+
+class TestTestBuiltinToolMaskedCredentials:
+    """前端回传脱敏凭证时，test 端点用 DB 真实值调用 Google API。"""
+
+    @pytest.mark.asyncio
+    async def test_masked_api_key_replaced_with_stored(self, _user) -> None:
+        """前端回传脱敏 api_key，test 端点用 DB 真实 key 调 Google API。"""
+        tool_id = uuid4()
+        tool = _make_tool(
+            tool_id=tool_id,
+            config={"cx_id": "real-cx"},
+            credentials={"api_key": "AIzaSyB-real-api-key-12345"},
+        )
+
+        fake_db = MagicMock()
+        fake_db.get = AsyncMock(return_value=tool)
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_client = MagicMock()
+        fake_client.get = AsyncMock(return_value=fake_response)
+        fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+        fake_client.__aexit__ = AsyncMock(return_value=False)
+
+        # 模拟前端：cx_id 未脱敏，api_key 是 GET 返回的脱敏值
+        payload = interface_api.BuiltinToolTestRequest(
+            config={"cx_id": "real-cx"},
+            credentials={"api_key": "AIza****2345"},
+        )
+
+        with (
+            patch.object(interface_api, "AsyncSessionLocal", _mock_async_session(fake_db)),
+            patch.object(
+                interface_api,
+                "check_plugin_access",
+                new=AsyncMock(return_value=(True, None)),
+            ),
+            patch("httpx.AsyncClient", return_value=fake_client),
+        ):
+            resp = await interface_api.test_builtin_tool(tool_id=tool_id, payload=payload, user=_user)
+
+        assert resp.success is True
+        call_kwargs = fake_client.get.await_args.kwargs
+        assert call_kwargs["params"]["key"] == "AIzaSyB-real-api-key-12345"
+        assert call_kwargs["params"]["cx"] == "real-cx"
+
+    @pytest.mark.asyncio
+    async def test_new_api_key_not_replaced(self, _user) -> None:
+        """用户输入全新 API Key（非脱敏），test 端点使用新值。"""
+        tool_id = uuid4()
+        tool = _make_tool(
+            tool_id=tool_id,
+            config={"cx_id": "my-cx"},
+            credentials={"api_key": "old-key"},
+        )
+
+        fake_db = MagicMock()
+        fake_db.get = AsyncMock(return_value=tool)
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_client = MagicMock()
+        fake_client.get = AsyncMock(return_value=fake_response)
+        fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+        fake_client.__aexit__ = AsyncMock(return_value=False)
+
+        payload = interface_api.BuiltinToolTestRequest(
+            config={"cx_id": "my-cx"},
+            credentials={"api_key": "brand-new-key"},
+        )
+
+        with (
+            patch.object(interface_api, "AsyncSessionLocal", _mock_async_session(fake_db)),
+            patch.object(
+                interface_api,
+                "check_plugin_access",
+                new=AsyncMock(return_value=(True, None)),
+            ),
+            patch("httpx.AsyncClient", return_value=fake_client),
+        ):
+            resp = await interface_api.test_builtin_tool(tool_id=tool_id, payload=payload, user=_user)
+
+        assert resp.success is True
+        call_kwargs = fake_client.get.await_args.kwargs
+        assert call_kwargs["params"]["key"] == "brand-new-key"


### PR DESCRIPTION
# 背景
- 前端 GET Builtin Tool 详情时，API 返回脱敏凭证（如 `AIza****1234`）。前端直接将该脱敏值回传至 Test Connection 端点时，Google API 因无效凭证拒绝连接，导致 Test Connection 始终失败。同理，PATCH 更新端点若回传脱敏值会将脱敏占位写入 DB。

# 核心变更
- 新增 `_is_masked_value()` 检测脱敏占位值（含 `****` 的字符串），新增 `_merge_masked_credentials()` 将 incoming 中的脱敏值替换为 DB 真实凭证
- `test_builtin_tool` 端点：在发起 Google API 请求前，将前端回传的脱敏凭证替换为 DB 真实值
- `update_builtin_tool` 端点：在写入 DB 前，将前端回传的脱敏凭证替换为 DB 真实值；补充 `is not None` 守卫防止 `credentials: null` 触发 500
- 补充 3 组单元测试覆盖：`_is_masked_value`（7 例）、`_merge_masked_credentials`（6 例）、`test_builtin_tool` 脱敏凭证集成（2 例）

# 风险与回滚
- 主要风险：`_is_masked_value` 以 `****` 子串为检测标记，理论上合法凭证若含 4 连续星号会被误判为脱敏值（实际 API Key 格式不含星号，概率极低）
- 回滚方式：`git revert` 该 PR 即可

# 验证证据
- 单元测试：`TestIsMaskedValue`（7 例）、`TestMergeMaskedCredentials`（6 例）、`TestTestBuiltinToolMaskedCredentials`（2 例），覆盖脱敏检测、值替换、端点集成三个层面
- Pre-commit hooks：Ruff lint + format 全部通过

# 影响范围
- 前端：无变更，前端回传逻辑不变
- 后端：`interface/api.py` 的 `test_builtin_tool` 和 `update_builtin_tool` 两个端点
- GitHub Actions / 文档：无变更

# Next Best Action
- 合并后可验证 Google Search 工具的 Test Connection 在前端正常工作