### PR TITLE
fix(wiki-home): 解耦 catalogName 与 catalogTargetSlug，修复首页显示 publication.name 而非 Catalog 一级菜单名

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -135,7 +135,7 @@ export default async function WikiEntryPage({ params }: Props) {
 
   const catalogItem = sectionView.activeItem;
   const catalogTargetSlug = catalogItem ? findFirstDocumentSlug(catalogItem) : null;
-  const catalogName = catalogTargetSlug && catalogItem
+  const catalogName = catalogItem
     ? (catalogItem.entry_title || catalogItem.entry_slug)
     : null;
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -68,7 +68,7 @@ export default async function WikiPublicationPage({ params }: Props) {
 
   const catalogItem = sectionView.activeItem;
   const catalogTargetSlug = catalogItem ? findFirstDocumentSlug(catalogItem) : null;
-  const catalogName = catalogTargetSlug && catalogItem
+  const catalogName = catalogItem
     ? (catalogItem.entry_title || catalogItem.entry_slug)
     : null;
 
@@ -100,8 +100,12 @@ export default async function WikiPublicationPage({ params }: Props) {
     <WikiLayoutShell sidebar={sidebar} hasToc={false} header={header || undefined} footer={<WikiFooter />}>
       <header className="wiki-doc-header">
         <h1 className="wiki-doc-title">
-          {catalogName && catalogTargetSlug ? (
-            <Link href={`/${pubSlug}/${catalogTargetSlug}`}>{catalogName}</Link>
+          {catalogName ? (
+            catalogTargetSlug ? (
+              <Link href={`/${pubSlug}/${catalogTargetSlug}`}>{catalogName}</Link>
+            ) : (
+              catalogName
+            )
           ) : (
             publication.name
           )}

--- a/apps/negentropy-wiki/src/components/WikiSidebar.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSidebar.tsx
@@ -51,11 +51,26 @@ export function WikiSidebar({
     <>
       <div className="wiki-sidebar-header">
         {isEntryPage ? (
-          catalogName && catalogTargetSlug ? (
-            renderBrand(
-              `/${pubSlug}/${catalogTargetSlug}`,
-              `← ${catalogName}`,
-              "wiki-sidebar-back wiki-sidebar-brand",
+          catalogName ? (
+            catalogTargetSlug ? (
+              renderBrand(
+                `/${pubSlug}/${catalogTargetSlug}`,
+                `← ${catalogName}`,
+                "wiki-sidebar-back wiki-sidebar-brand",
+              )
+            ) : (
+              <Link
+                href={`/${pubSlug}`}
+                className="wiki-sidebar-back wiki-sidebar-brand"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+                <img
+                  src="/logo.png"
+                  alt="Negentropy"
+                  className="wiki-sidebar-logo"
+                />
+                <span className="wiki-sidebar-title">← {catalogName}</span>
+              </Link>
             )
           ) : (
             <Link
@@ -72,11 +87,23 @@ export function WikiSidebar({
             </Link>
           )
         ) : (
-          catalogName && catalogTargetSlug ? (
-            renderBrand(
-              `/${pubSlug}/${catalogTargetSlug}`,
-              catalogName,
-              "wiki-sidebar-brand",
+          catalogName ? (
+            catalogTargetSlug ? (
+              renderBrand(
+                `/${pubSlug}/${catalogTargetSlug}`,
+                catalogName,
+                "wiki-sidebar-brand",
+              )
+            ) : (
+              <div className="wiki-sidebar-brand">
+                {/* eslint-disable-next-line @next/next/no-img-element -- next.config.ts 已设 images.unoptimized，next/image 在此无优化收益 */}
+                <img
+                  src="/logo.png"
+                  alt="Negentropy"
+                  className="wiki-sidebar-logo"
+                />
+                <span className="wiki-sidebar-title">{catalogName}</span>
+              </div>
             )
           ) : (
             <div className="wiki-sidebar-brand">


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：当 Catalog 一级菜单项存在但无可导航的子文档时（`findFirstDocumentSlug` 返回 null），`catalogName` 因与 `catalogTargetSlug` 耦合而被置为 null，导致 Wiki 首页标题和 Sidebar 回退显示 `publication.name` 而非 Catalog 菜单名。

# 核心变更
- 解耦 `catalogName` 与 `catalogTargetSlug` 的赋值逻辑：`catalogName` 仅依赖 `catalogItem` 是否存在，不再要求 `catalogTargetSlug` 非空
- `page.tsx`（首页）：标题渲染增加 `catalogName && !catalogTargetSlug` 分支，直接展示 catalogName 纯文本
- `WikiSidebar.tsx`：entry page 分支在无 target slug 时回退链接至 publication 首页并显示 catalogName；非 entry page 分支使用不可交互 `<div>` 展示 catalogName
- `[...entrySlug]/page.tsx`：同步解耦 catalogName 赋值，下游仅作为 prop 传递至 WikiSidebar，无需额外改动

# 风险与回滚
- 主要风险：无功能性风险，变更仅在 `catalogTargetSlug === null` 的边缘场景下生效，正常路径行为不变
- 回滚方式：`git revert` 本 commit 即可

# 验证证据
- 单元测试：无新增（纯 UI 条件渲染调整）
- 集成测试：无
- E2E/Workflow：需在浏览器中验证 Catalog 一级菜单项无子文档时首页标题和 Sidebar 显示正确
- 覆盖率/关键截图：无

# 影响范围
- 前端：`negentropy-wiki` — 首页标题渲染 + Sidebar header 渲染
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证：构造一个无子文档的 Catalog 一级菜单项，确认首页标题显示 Catalog 名称而非 publication.name