### PR TITLE
fix(memory): 修复 All Users 缺失仅有 Facts 用户及用户名数量后缀问题

### DIFF
--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select, text, union
 
 from negentropy.auth.deps import get_current_user, resolve_user_with_db_roles
 from negentropy.auth.service import AuthUser
@@ -355,11 +355,18 @@ async def list_memories(
     resolved_app = _resolve_app_name(app_name)
 
     async with AsyncSessionLocal() as db:
-        # 获取用户列表
+        # 获取用户列表（UNION memories + facts，确保仅有 Facts 的用户也出现）
+        mem_user_ids = select(Memory.user_id).where(Memory.app_name == resolved_app)
+        fact_user_ids = select(Fact.user_id).where(Fact.app_name == resolved_app)
+        all_user_ids = union(mem_user_ids, fact_user_ids).subquery()
+
         user_stmt = (
-            select(Memory.user_id, func.count(Memory.id).label("count"))
-            .where(Memory.app_name == resolved_app)
-            .group_by(Memory.user_id)
+            select(all_user_ids.c.user_id, func.count(Memory.id).label("count"))
+            .outerjoin(
+                Memory,
+                (Memory.user_id == all_user_ids.c.user_id) & (Memory.app_name == resolved_app),
+            )
+            .group_by(all_user_ids.c.user_id)
             .order_by(func.count(Memory.id).desc())
         )
         user_result = await db.execute(user_stmt)
@@ -388,7 +395,7 @@ async def list_memories(
         users.append(
             {
                 "id": entry["id"],
-                "label": f"{display_name} ({entry['count']})",
+                "label": display_name,
                 "name": p.get("name"),
                 "picture": p.get("picture"),
                 "email": p.get("email"),


### PR DESCRIPTION
## Summary

- 修复 Memory/Facts 页面 "All Users" 列表缺失仅有 Facts 而无 Memory 记录的用户（如 Chao Ming Huang, Aurelius）
- 移除 Memory 模块所有页面用户名后的 Memory 数量后缀（如 "User Name (5)" → "User Name"）

## Changes

- **后端 `engine/api.py`**：将 `list_memories` 端点的用户列表查询从仅查 `memories` 表改为 UNION `memories` + `facts` 两张表的 `user_id`，再 LEFT JOIN `memories` 统计 count，确保所有用户（有 Memory 或有 Facts）均可见
- 移除 `label` 字段中的 `(count)` 后缀，改为纯 `display_name`

## Test plan

- [ ] 调用 `GET /memory` 接口，验证返回 users 列表包含仅有 Facts 记录的用户
- [ ] 浏览器打开 Facts 页面，确认 "Chao Ming Huang, Aurelius" 出现在用户列表
- [ ] 浏览器打开 Timeline / Audit / Conflicts 页面，确认用户名显示干净无数量后缀

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>