### PR TITLE
fix(observability): 补齐 OTLP HTTP Exporter 依赖 + 修复 TracingManager 控制流，恢复 Langfuse 全链路可观测性

### DIFF
--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -23,8 +23,9 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.46",  # SQL Toolkit and ORM
     "alembic>=1.18.3",              # Database migration tool
     # Core Infrastructure
-    "google-adk>=2.0.0",            # ADK 2.0 GA: Workflow Runtime, Collaborative Agents, Task API
+    "google-adk>=2.1.0",            # ADK 2.1: Workflow Runtime + native OTel agentic metrics + event compaction tracing
     "opentelemetry-instrumentation-google-genai>=0.6b0,<1.0.0",  # ADK GenAI SDK OTel 自动埋点 (消除 adk_web_server 启动期 WARNING)
+    "opentelemetry-exporter-otlp-proto-http>=1.37.0,<2.0.0",  # OTLP HTTP/protobuf span exporter — TracingManager / LiteLLM otel callback / ADK _get_otel_span_exporter 均依赖此包
     "microsandbox>=0.1.8",          # Isolated execution environment for tool usage
     "mcp>=1.6.0",                   # Model Context Protocol SDK for MCP Server integration
     "pydantic-settings[yaml]>=2.12.0",  # Configuration management with YAML support

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/tracing.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/tracing.py
@@ -235,59 +235,60 @@ class TracingManager:
             processors.append(BatchSpanProcessor(PostgresSpanExporter()))
 
             # OTLP: 实时可视化 (Langfuse)
+            langfuse = settings.observability
+
             if self.otlp_exporter:
                 # 优先使用注入的 Exporter (测试用)
                 processors.append(BatchSpanProcessor(self.otlp_exporter))
             else:
-                # 优先使用 ObservabilitySettings 配置
-                langfuse = settings.observability
+                # 使用传入的 endpoint 或配置中的 Langfuse OTLP 端点
+                endpoint = self.otlp_endpoint or langfuse.langfuse_otlp_endpoint
 
-            # 使用传入的 endpoint 或配置中的 Langfuse OTLP 端点
-            endpoint = self.otlp_endpoint or langfuse.langfuse_otlp_endpoint
+                should_enable_otlp = (
+                    # 显式传入了 endpoint
+                    self.otlp_endpoint is not None
+                    # 或者配置了 Langfuse 且启用了 export
+                    or (langfuse.langfuse_enabled and langfuse.langfuse_public_key and langfuse.langfuse_secret_key)
+                )
 
-            should_enable_otlp = (
-                # 显式传入了 endpoint
-                self.otlp_endpoint is not None
-                # 或者配置了 Langfuse 且启用了 export
-                or (langfuse.langfuse_enabled and langfuse.langfuse_public_key and langfuse.langfuse_secret_key)
-            )
+                if should_enable_otlp:
+                    if OTLPSpanExporter:
+                        logger.info(f"OTLP Export enabled: endpoint={endpoint}")
+                        headers = {}
+                        # 如果有 Langfuse 凭证，添加 Basic Auth Header
+                        if langfuse.langfuse_public_key and langfuse.langfuse_secret_key:
+                            import base64
 
-            if should_enable_otlp:
-                if OTLPSpanExporter:
-                    logger.info(f"OTLP Export enabled: endpoint={endpoint}")
-                    headers = {}
-                    # 如果有 Langfuse 凭证，添加 Basic Auth Header
-                    if langfuse.langfuse_public_key and langfuse.langfuse_secret_key:
-                        import base64
+                            # Langfuse 使用 Basic Auth (User=Public Key, Pass=Secret Key)
+                            credentials = (
+                                f"{langfuse.langfuse_public_key}:{langfuse.langfuse_secret_key.get_secret_value()}"
+                            )
+                            basic_auth = base64.b64encode(credentials.encode()).decode()
+                            headers["Authorization"] = f"Basic {basic_auth}"
+                            # Log masked credentials for debugging
+                            pk_preview = (
+                                langfuse.langfuse_public_key[:8] + "..."
+                                if len(langfuse.langfuse_public_key) > 8
+                                else "***"
+                            )
+                            logger.info(f"Using Langfuse credentials: {pk_preview}")
 
-                        # Langfuse 使用 Basic Auth (User=Public Key, Pass=Secret Key)
-                        credentials = (
-                            f"{langfuse.langfuse_public_key}:{langfuse.langfuse_secret_key.get_secret_value()}"
-                        )
-                        basic_auth = base64.b64encode(credentials.encode()).decode()
-                        headers["Authorization"] = f"Basic {basic_auth}"
-                        # Log masked credentials for debugging
-                        pk_preview = (
-                            langfuse.langfuse_public_key[:8] + "..." if len(langfuse.langfuse_public_key) > 8 else "***"
-                        )
-                        logger.info(f"Using Langfuse credentials: {pk_preview}")
-
-                    try:
-                        otlp_exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
-                        processors.append(BatchSpanProcessor(otlp_exporter))
-                        logger.info(f"OTLP Exporter created and added: {type(otlp_exporter).__name__}")
-                    except Exception as e:
-                        logger.error(f"Failed to create OTLP Exporter: {e}")
+                        try:
+                            otlp_exporter = OTLPSpanExporter(endpoint=endpoint, headers=headers)
+                            processors.append(BatchSpanProcessor(otlp_exporter))
+                            logger.info(f"OTLP Exporter created and added: {type(otlp_exporter).__name__}")
+                        except Exception as e:
+                            logger.error(f"Failed to create OTLP Exporter: {e}")
+                    else:
+                        logger.warning("OTLP Exporter requested but opentelemetry-exporter-otlp not installed.")
                 else:
-                    logger.warning("OTLP Exporter requested but opentelemetry-exporter-otlp not installed.")
-            else:
-                # OTLP not enabled - log diagnostic information
-                logger.warning("OTLP Export NOT enabled - checking conditions...")
-                logger.warning(f"  otlp_endpoint: {self.otlp_endpoint}")
-                logger.warning(f"  langfuse_enabled: {langfuse.langfuse_enabled}")
-                logger.warning(f"  langfuse_public_key: {bool(langfuse.langfuse_public_key)}")
-                logger.warning(f"  langfuse_secret_key: {bool(langfuse.langfuse_secret_key)}")
-                logger.warning(f"  OTLPSpanExporter available: {OTLPSpanExporter is not None}")
+                    # OTLP not enabled - log diagnostic information
+                    logger.warning("OTLP Export NOT enabled - checking conditions...")
+                    logger.warning(f"  otlp_endpoint: {self.otlp_endpoint}")
+                    logger.warning(f"  langfuse_enabled: {langfuse.langfuse_enabled}")
+                    logger.warning(f"  langfuse_public_key: {bool(langfuse.langfuse_public_key)}")
+                    logger.warning(f"  langfuse_secret_key: {bool(langfuse.langfuse_secret_key)}")
+                    logger.warning(f"  OTLPSpanExporter available: {OTLPSpanExporter is not None}")
 
         if self.console_export:
             processors.append(BatchSpanProcessor(ConsoleSpanExporter()))

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -75,7 +75,7 @@ def _disable_adk_otel_logs_metrics_exporters() -> None:
             try:
                 span_processors.append(adk_otel_setup._get_otel_span_exporter())
             except (ImportError, ModuleNotFoundError):
-                pass  # ADK 2.0: OTLP HTTP exporter not installed; skip trace export
+                pass  # Defensive fallback — should not trigger after adding opentelemetry-exporter-otlp-proto-http dep
         return adk_otel_setup.OTelHooks(
             span_processors=span_processors,
             metric_readers=[],

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -563,7 +563,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -580,6 +580,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "starlette" },
@@ -590,9 +591,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/08/e9af9ab3b0df422f9c9c07251840f8be876694852d3ac06dbe4e15ce01a7/google_adk-2.0.0.tar.gz", hash = "sha256:2f53c70b5de8409d427f0955bc89f1ba30a8397dec5aefa0ac7c3ecd1b4018d4", size = 3337944, upload-time = "2026-05-19T16:17:10.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/d2/58823ea0d5ac32143773d377b014123191ce420480c003190e1f86a9667c/google_adk-2.1.0.tar.gz", hash = "sha256:fd1709bf5e70e5aaa7d148c7b788d2cd00bb659ee10505a731bb2ad609d28968", size = 3340742, upload-time = "2026-05-23T00:13:56.793Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/f5/596e879aacad5214945ede50a4c8e4a0811979ecff83c91e0df11ef13961/google_adk-2.0.0-py3-none-any.whl", hash = "sha256:6d06d8e3b9119ccd7721505356f8c0a5253dcfdc426dd9a72e0fef1cf9ed4703", size = 3846211, upload-time = "2026-05-19T16:17:08.081Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5b/56a9992b6f9447437f29e3691a487b16dfdea42aedec16ceced9de88b9f8/google_adk-2.1.0-py3-none-any.whl", hash = "sha256:4ec8a0ccdf8af90f9fa505c740cae921b47590aee3d61bca14f7bfa8bc886e4e", size = 3852259, upload-time = "2026-05-23T00:13:59.611Z" },
 ]
 
 [[package]]
@@ -1308,6 +1309,7 @@ dependencies = [
     { name = "microsandbox" },
     { name = "networkx" },
     { name = "numpy" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-google-genai" },
     { name = "orjson" },
     { name = "packaging" },
@@ -1342,7 +1344,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "croniter", specifier = ">=2.0" },
-    { name = "google-adk", specifier = ">=2.0.0" },
+    { name = "google-adk", specifier = ">=2.1.0" },
     { name = "google-auth", specifier = ">=2.48.0" },
     { name = "google-cloud-logging", specifier = ">=3.13.0" },
     { name = "google-cloud-storage", specifier = ">=3.8.0" },
@@ -1355,6 +1357,7 @@ requires-dist = [
     { name = "microsandbox", specifier = ">=0.1.8" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0,<2.0.0" },
     { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.6b0,<1.0.0" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "packaging", specifier = ">=24.0" },
@@ -1438,20 +1441,50 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/04/05040d7ce33a907a2a02257e601992f0cdf11c73b33f13c4492bf6c3d6d5/opentelemetry_api-1.37.0.tar.gz", hash = "sha256:540735b120355bd5112738ea53621f8d5edb35ebcd6fe21ada3ab1c61d1cd9a7", size = 64923, upload-time = "2025-09-11T10:29:01.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/48/28ed9e55dcf2f453128df738210a980e09f4e468a456fa3c763dbc8be70a/opentelemetry_api-1.37.0-py3-none-any.whl", hash = "sha256:accf2024d3e89faec14302213bc39550ec0f4095d1cf5ca688e1bfb1c8612f47", size = 65732, upload-time = "2025-09-11T10:28:41.826Z" },
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.58b0"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1459,9 +1492,9 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/36/7c307d9be8ce4ee7beb86d7f1d31027f2a6a89228240405a858d6e4d64f9/opentelemetry_instrumentation-0.58b0.tar.gz", hash = "sha256:df640f3ac715a3e05af145c18f527f4422c6ab6c467e40bd24d2ad75a00cb705", size = 31549, upload-time = "2025-09-11T11:42:14.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/db/5ff1cd6c5ca1d12ecf1b73be16fbb2a8af2114ee46d4b0e6d4b23f4f4db7/opentelemetry_instrumentation-0.58b0-py3-none-any.whl", hash = "sha256:50f97ac03100676c9f7fc28197f8240c7290ca1baa12da8bfbb9a1de4f34cc45", size = 33019, upload-time = "2025-09-11T11:41:00.624Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
 ]
 
 [[package]]
@@ -1480,30 +1513,42 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
+]
+
+[[package]]
 name = "opentelemetry-sdk"
-version = "1.37.0"
+version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/62/2e0ca80d7fe94f0b193135375da92c640d15fe81f636658d2acf373086bc/opentelemetry_sdk-1.37.0.tar.gz", hash = "sha256:cc8e089c10953ded765b5ab5669b198bbe0af1b3f89f1007d19acd32dc46dda5", size = 170404, upload-time = "2025-09-11T10:29:11.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/62/9f4ad6a54126fb00f7ed4bb5034964c6e4f00fcd5a905e115bd22707e20d/opentelemetry_sdk-1.37.0-py3-none-any.whl", hash = "sha256:8f3c3c22063e52475c5dbced7209495c2c16723d016d39287dfc215d1771257c", size = 131941, upload-time = "2025-09-11T10:28:57.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.58b0"
+version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/1b/90701d91e6300d9f2fb352153fb1721ed99ed1f6ea14fa992c756016e63a/opentelemetry_semantic_conventions-0.58b0.tar.gz", hash = "sha256:6bd46f51264279c433755767bb44ad00f1c9e2367e1b42af563372c5a6fa0c25", size = 129867, upload-time = "2025-09-11T10:29:12.597Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/90/68152b7465f50285d3ce2481b3aec2f82822e3f52e5152eeeaf516bab841/opentelemetry_semantic_conventions-0.58b0-py3-none-any.whl", hash = "sha256:5564905ab1458b96684db1340232729fce3b5375a06e140e8904c78e4f815b28", size = 207954, upload-time = "2025-09-11T10:28:59.218Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# 背景
- Langfuse OTLP 全链路可观测性失效：`TracingManager` 中 OTLP 初始化代码位于 `else` 块外部，导致两个结构性 bug：
  1. 当 `self.otlp_exporter` 被注入（测试模式）时，`langfuse = settings.observability` 仅在 `else` 分支赋值，其后的 OTLP 代码引用 `langfuse` 触发 `NameError`
  2. 即使注入了测试 Exporter，OTLP 初始化仍会无条件执行，可能创建重复的 Span Processor
- `opentelemetry-exporter-otlp-proto-http` 未声明为显式依赖，导致运行时 import 失败（`OTLPSpanExporter = None`）

# 核心变更
- **`tracing.py`**：将 `langfuse` 赋值提前至 `if/else` 之前，OTLP 初始化逻辑整体移入 `else` 分支，消除 NameError 风险与重复 Exporter 创建
- **`pyproject.toml`**：新增 `opentelemetry-exporter-otlp-proto-http>=1.37.0,<2.0.0` 显式依赖；ADK 版本提升至 `>=2.1.0`
- **`bootstrap.py`**：更新 fallback 注释，反映依赖补齐后的预期行为

# 风险与回滚
- 主要风险：ADK `>=2.0.0` → `>=2.1.0` 可能引入不兼容变更（已验证 `opentelemetry-instrumentation-google-genai` 兼容）
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：TracingManager 的 `otlp_exporter` 注入路径不再触发 OTLP 侧初始化
- 集成测试：Langfuse OTLP Exporter 在配置完整时正确创建并注册
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：无
- 后端：`TracingManager` OTLP 初始化控制流、ADK 依赖版本、OTLP HTTP Exporter 依赖声明
- GitHub Actions / 文档：`uv.lock` 自动更新

# Next Best Action
- 部署后在 Langfuse Dashboard 验证 Span 是否正常上报
- 确认 ADK 2.1.0 的 agentic metrics 和 event compaction tracing 功能正常工作