### PR TITLE
fix(wiki-annotation): 将 ::highlight() 样式从静态 CSS 迁移至 JS 运行时注入

### DIFF
--- a/apps/negentropy-wiki/src/lib/annotation/use-highlight-renderer.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-highlight-renderer.ts
@@ -31,6 +31,20 @@ import type { AnnotationItem } from "./use-annotations";
 
 const CSS_HIGHLIGHT_NAME = "wiki-annotation";
 
+/** 运行时注入 ::highlight() 样式（绕过 LightningCSS 不识别该伪元素的构建限制） */
+const HIGHLIGHT_STYLE_ID = "wiki-annotation-highlight-style";
+function injectHighlightStyle(): void {
+  if (document.getElementById(HIGHLIGHT_STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = HIGHLIGHT_STYLE_ID;
+  style.textContent = `::highlight(${CSS_HIGHLIGHT_NAME}) {
+  background-color: rgba(255, 212, 59, 0.32);
+  text-decoration: underline wavy rgba(255, 180, 0, 0.7);
+  text-decoration-skip-ink: none;
+}`;
+  document.head.appendChild(style);
+}
+
 export interface HighlightGroupInput {
   /** 注解 ID 列表（重叠的多条注解会合并为一个 group） */
   annotationIds: string[];
@@ -156,6 +170,7 @@ export function createCSSHighlightRenderer(): HighlightRenderer {
     apply(groups) {
       currentGroups = groups;
       try {
+        injectHighlightStyle();
         const HighlightCtor = (window as unknown as {
           Highlight: new (...ranges: Range[]) => HighlightWithRanges;
         }).Highlight;

--- a/apps/negentropy-wiki/src/styles/components/annotation.css
+++ b/apps/negentropy-wiki/src/styles/components/annotation.css
@@ -13,14 +13,8 @@
   background: rgba(255, 212, 59, 0.45);
 }
 
-/* CSS Custom Highlight API 路径 —— 浏览器翻译态下使用，
-   不修改 DOM 因而免疫 <font> 包裹破坏。
-   参考：https://drafts.csswg.org/css-highlight-api/ */
-::highlight(wiki-annotation) {
-  background-color: rgba(255, 212, 59, 0.32);
-  text-decoration: underline wavy rgba(255, 180, 0, 0.7);
-  text-decoration-skip-ink: none;
-}
+/* CSS Custom Highlight API 路径的样式通过 JS 运行时注入（use-highlight-renderer.ts），
+   绕过 LightningCSS 不识别 ::highlight() 伪元素的构建限制 */
 
 /* 浮动注解按钮 */
 .wiki-annotation-fab {


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：LightningCSS 不识别 `::highlight()` 伪元素，导致构建时产生警告
- 关联上下文/文档：[CSS Custom Highlight API](https://drafts.csswg.org/css-highlight-api/)

# 核心变更
- 将 `annotation.css` 中的 `::highlight(wiki-annotation)` 静态规则迁移至 `use-highlight-renderer.ts` 的 `injectHighlightStyle()` 函数，在 `apply()` 首次调用时通过 `<style>` 标签动态注入，绕过 LightningCSS 的解析限制

# 风险与回滚
- 主要风险：样式属性值与原静态规则完全一致，仅变更注入方式，风险极低
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无新增（纯样式迁移，逻辑不变）
- 集成测试：无
- E2E/Workflow：需验证注解高亮在浏览器中正常渲染
- 覆盖率/关键截图：无

# 影响范围
- 前端：`negentropy-wiki` 注解高亮模块
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 验证构建警告是否消除，以及注解高亮功能在浏览器中表现正常