### PR TITLE
fix(scheduler): 修复 Maintenance Consolidation asyncpg interval 编码失败并统一异常处理

### DIFF
--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import text
@@ -25,6 +26,25 @@ if TYPE_CHECKING:
     from negentropy.models.scheduled_task import ScheduledTask
 
 logger = get_logger("negentropy.engine.schedulers.handlers.memory_automation")
+
+_INTERVAL_UNIT_MAP = {
+    "second": "seconds",
+    "minute": "minutes",
+    "hour": "hours",
+    "day": "days",
+}
+
+
+def _parse_interval(s: str) -> timedelta:
+    """将 'N unit' 格式的 interval 字符串解析为 timedelta（如 '1 hour' → timedelta(hours=1)）。"""
+    parts = s.strip().split()
+    if len(parts) != 2:
+        raise ValueError(f"Unsupported interval format: {s!r}")
+    value = int(parts[0])
+    unit = parts[1].lower().rstrip("s")
+    if unit not in _INTERVAL_UNIT_MAP:
+        raise ValueError(f"Unsupported interval unit: {unit!r}")
+    return timedelta(**{_INTERVAL_UNIT_MAP[unit]: value})
 
 
 @register_handler("memory_automation")
@@ -74,13 +94,16 @@ async def _run_consolidation(task: ScheduledTask) -> HandlerResult:
     payload = task.payload or {}
     lookback_interval = payload.get("lookback_interval", "1 hour")
 
+    # asyncpg 原生支持 timedelta → PostgreSQL interval 编解码，必须传 timedelta 而非 str。
+    lookback_td = _parse_interval(lookback_interval)
+
     # CAST(:lookback AS interval) 而非 :lookback::interval —— 命名参数紧邻 PostgreSQL ::
     # cast 会破坏 SQLAlchemy 参数边界识别，asyncpg 报 syntax error。同口径修复参见
     # knowledge/graph/repository.py:515-519、knowledge/retrieval/repository.py:832-834。
     sql = text(f"SELECT {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(CAST(:lookback AS interval))")
     try:
         async with AsyncSessionLocal() as db:
-            result = await db.execute(sql, {"lookback": lookback_interval})
+            result = await db.execute(sql, {"lookback": lookback_td})
             row = result.first()
             await db.commit()
         count = row[0] if row else None

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
@@ -94,14 +94,13 @@ async def _run_consolidation(task: ScheduledTask) -> HandlerResult:
     payload = task.payload or {}
     lookback_interval = payload.get("lookback_interval", "1 hour")
 
-    # asyncpg 原生支持 timedelta → PostgreSQL interval 编解码，必须传 timedelta 而非 str。
-    lookback_td = _parse_interval(lookback_interval)
-
     # CAST(:lookback AS interval) 而非 :lookback::interval —— 命名参数紧邻 PostgreSQL ::
     # cast 会破坏 SQLAlchemy 参数边界识别，asyncpg 报 syntax error。同口径修复参见
     # knowledge/graph/repository.py:515-519、knowledge/retrieval/repository.py:832-834。
     sql = text(f"SELECT {NEGENTROPY_SCHEMA}.trigger_maintenance_consolidation(CAST(:lookback AS interval))")
     try:
+        # asyncpg 原生支持 timedelta → PostgreSQL interval 编解码，必须传 timedelta 而非 str。
+        lookback_td = _parse_interval(lookback_interval)
         async with AsyncSessionLocal() as db:
             result = await db.execute(sql, {"lookback": lookback_td})
             row = result.first()

--- a/apps/negentropy/tests/unit_tests/engine/test_scheduler_handlers.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_scheduler_handlers.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
@@ -30,6 +31,7 @@ from negentropy.engine.schedulers.handlers.agent_inspection import (
     _compute_backoff_seconds,
     _scheduled_tasks_summary,
 )
+from negentropy.engine.schedulers.handlers.memory_automation import _parse_interval
 
 
 @pytest.fixture(autouse=True)
@@ -405,3 +407,82 @@ class TestSkillInvokeHandler:
         result = await handler(task)
         assert result.status == "failed"
         assert "invalid skill_schedule_id" in (result.error or "")
+
+
+class TestParseInterval:
+    def test_single_hour(self):
+        assert _parse_interval("1 hour") == timedelta(hours=1)
+
+    def test_plural_hours(self):
+        assert _parse_interval("5 hours") == timedelta(hours=5)
+
+    def test_minutes(self):
+        assert _parse_interval("30 minutes") == timedelta(minutes=30)
+
+    def test_seconds(self):
+        assert _parse_interval("1 second") == timedelta(seconds=1)
+
+    def test_days(self):
+        assert _parse_interval("7 days") == timedelta(days=7)
+
+    def test_whitespace_tolerant(self):
+        assert _parse_interval("  2  hours  ") == timedelta(hours=2)
+
+    def test_unsupported_format_raises(self):
+        with pytest.raises(ValueError, match="Unsupported interval format"):
+            _parse_interval("1hour")
+
+    def test_unsupported_unit_raises(self):
+        with pytest.raises(ValueError, match="Unsupported interval unit"):
+            _parse_interval("1 week")
+
+    def test_non_numeric_value_raises(self):
+        with pytest.raises(ValueError):
+            _parse_interval("abc hours")
+
+
+class TestConsolidationHandler:
+    """覆盖 _run_consolidation：验证 timedelta 被正确传递给 SQL 执行。"""
+
+    @pytest.mark.asyncio
+    async def test_consolidation_passes_timedelta(self, monkeypatch):
+        """_run_consolidation 应将 payload 中的 interval 字符串转为 timedelta 后传给 SQL。"""
+        from negentropy.engine.schedulers.handlers.memory_automation import _run_consolidation
+
+        captured_params: dict = {}
+
+        class _Row:
+            def __getitem__(self, idx):
+                return 0
+
+        class _Result:
+            def first(self):
+                return _Row()
+
+        class _SpySession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def execute(self, stmt, params=None):
+                captured_params.update(params or {})
+                return _Result()
+
+            async def commit(self):
+                pass
+
+        monkeypatch.setattr(
+            "negentropy.engine.schedulers.handlers.memory_automation.AsyncSessionLocal",
+            lambda: _SpySession(),
+        )
+
+        task = _make_task(
+            "memory_automation", payload={"job_type": "trigger_consolidation", "lookback_interval": "1 hour"}
+        )
+        result = await _run_consolidation(task)
+
+        assert result.status == "ok"
+        assert isinstance(captured_params["lookback"], timedelta)
+        assert captured_params["lookback"] == timedelta(hours=1)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`_run_consolidation` 将 `lookback_interval` 以字符串形式传递给 asyncpg 参数绑定，asyncpg 无法将 `str` 编码为 PostgreSQL `interval` 类型，导致任务执行时报类型编码错误。
- 关联上下文：同口径修复参见 `knowledge/graph/repository.py`、`knowledge/retrieval/repository.py` 中的 `CAST` 替换模式。

# 核心变更
- 新增 `_parse_interval(s)` 工具函数，将 `"N unit"` 格式字符串（如 `"1 hour"`、`"30 minutes"`）解析为 `datetime.timedelta`，利用 asyncpg 原生 `timedelta` ↔ PostgreSQL `interval` 编解码能力
- `_run_consolidation` 中将 `lookback_interval` 参数从 `str` 改为 `timedelta` 传入 SQL 执行，消除类型编码失败
- 将 `_parse_interval` 调用置于 `try` 块内，确保格式非法时的 `ValueError` 与 SQL 异常走统一 fail-soft 路径（`HandlerResult(status="failed")`）
- 新增 9 个 `_parse_interval` 单元测试 + 1 个 `_run_consolidation` 集成测试，覆盖正常解析、边界格式、非法输入及 timedelta 透传验证

# 风险与回滚
- 主要风险：`_parse_interval` 仅支持 `{second, minute, hour, day}` 四种单位，若 payload 中传入 `"1 week"` 等格式会返回 `failed` 状态（此前是直接异常，行为更安全）
- 回滚方式：`git revert` 对应 commit 即可

# 验证证据
- 单元测试：`TestParseInterval`（9 用例，覆盖单复数单位、空白容忍、非法格式/单位/数值）
- 集成测试：`TestConsolidationHandler.test_consolidation_passes_timedelta`（通过 monkeypatch 验证 `timedelta` 被正确传递给 SQL 参数）
- E2E/Workflow：N/A（需调度器实际触发验证）
- 覆盖率/关键截图：Pre-commit hooks（ruff lint + format）全部通过

# 影响范围
- 前端：无
- 后端：`memory_automation` handler 的 `trigger_consolidation` 分支
- GitHub Actions / 文档：无

# Next Best Action
- 观察 `memory_automation` handler 在生产调度器中的执行日志，确认 `trigger_consolidation` 任务正常完成