### PR TITLE
fix(claude-code-tool): 修复 Test Connection 失败 + 工具类型显示为 Agent

### DIFF
--- a/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
@@ -26,6 +26,28 @@ interface ToolCardProps {
   toggling?: boolean;
 }
 
+const TOOL_TYPE_DISPLAY: Record<string, { label: string; className: string }> = {
+  claude_code: {
+    label: "Agent",
+    className: "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400",
+  },
+  search: {
+    label: "Search",
+    className: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
+  },
+  retrieval: {
+    label: "Retrieval",
+    className: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
+  },
+  custom: {
+    label: "Custom",
+    className: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
+  },
+};
+
+const DEFAULT_TOOL_TYPE_STYLE =
+  "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400";
+
 export function ToolCard({
   tool,
   onEdit,
@@ -114,9 +136,16 @@ export function ToolCard({
               Disabled
             </span>
           )}
-          <span className="inline-flex shrink-0 items-center rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400">
-            {tool.tool_type}
-          </span>
+          {(() => {
+            const display = TOOL_TYPE_DISPLAY[tool.tool_type];
+            return (
+              <span
+                className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ${display ? display.className : DEFAULT_TOOL_TYPE_STYLE}`}
+              >
+                {display ? display.label : tool.tool_type}
+              </span>
+            );
+          })()}
           {tool.is_system && (
             <span
               className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
@@ -242,6 +242,7 @@ export function ToolFormDialog({
                   <option value="search">Search</option>
                   <option value="retrieval">Retrieval</option>
                   <option value="custom">Custom</option>
+                  <option value="claude_code">Agent</option>
                 </select>
               </div>
             </div>

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -148,7 +148,7 @@ class ClaudeCodeService:
             proc = await asyncio.create_subprocess_exec(
                 *args,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
                 cwd=config.cwd,
             )
         except FileNotFoundError:
@@ -195,13 +195,29 @@ class ClaudeCodeService:
                 proc.terminate()
                 await proc.wait()
 
+        # 进程已退出，读取 stderr
+        stderr_text = ""
+        if proc.stderr:
+            stderr_bytes = await proc.stderr.read()
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace").strip()
+
         status = "success" if proc.returncode == 0 else "error"
+        error_msg = None
+        if proc.returncode != 0:
+            parts = [f"CLI exited with code {proc.returncode}"]
+            if stderr_text:
+                parts.append(f"stderr: {stderr_text[:500]}")
+            if not result_text and not stderr_text:
+                parts.append("no output captured")
+            error_msg = "; ".join(parts)
+
         return ClaudeCodeResult(
             status=status,
             summary=result_text[:_SUMMARY_MAX_LEN],
             session_id=session_id,
             cost_usd=cost,
             turn_count=turns,
+            error=error_msg,
         )
 
     @staticmethod
@@ -212,6 +228,7 @@ class ClaudeCodeService:
             prompt,
             "--output-format",
             "stream-json",
+            "--verbose",
             "--max-turns",
             str(config.max_turns),
             "--permission-mode",
@@ -276,8 +293,9 @@ class ClaudeCodeService:
                 "version": version_out,
                 "latency_ms": latency,
             }
+        error_detail = test_result.error or "unknown error (no error output captured)"
         return {
             "success": False,
-            "message": f"Claude Code prompt test failed: {test_result.error}",
+            "message": f"Claude Code prompt test failed: {error_detail}",
             "version": version_out,
         }


### PR DESCRIPTION
## Summary

- **Test Connection 修复**：`_invoke_cli` 原先丢弃 stderr 且非零退出码时未设置 `error` 字段，导致报错 `"Claude Code prompt test failed: None"`。改为捕获 stderr 并构造有意义的错误消息
- **CLI 参数修复**：`_build_cli_args` 补充 `--verbose` 参数，解决 Claude CLI 报错 `"When using --print, --output-format=stream-json requires --verbose"`
- **工具类型显示**：ToolCard 新增 `claude_code → Agent` 映射（violet 配色），ToolFormDialog 下拉框新增 Agent 选项

## 改动文件

| 文件 | 变更 |
|------|------|
| `engine/claude_code/service.py` | `_invoke_cli` 捕获 stderr + 设置 error 字段；`_build_cli_args` 补充 `--verbose`；`test_connection` 防御性 fallback |
| `ToolCard.tsx` | 新增 `TOOL_TYPE_DISPLAY` 映射常量，`claude_code` 显示为 "Agent" |
| `ToolFormDialog.tsx` | 下拉框新增 `<option value="claude_code">Agent</option>` |

## 测试验证

- 28 个单元测试全部通过
- 浏览器实机验证：Interface / Tools → Claude Code → Test Connection → ✅ **Claude Code connected (version: 2.1.144)**

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)