### PR TITLE
fix(wiki-annotation): 修复浏览器翻译后注解不可见并增加删除功能

### DIFF
--- a/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
@@ -22,6 +22,10 @@ interface Props {
   annotations: AnnotationItem[];
   /** 稳定快照 ref。提供时启用 source-anchored 路径；否则走兼容路径（与 v1 anchor 行为一致）。 */
   snapshotRef?: React.MutableRefObject<AnnotationSnapshot | null>;
+  /** 删除注解回调 */
+  onDeleteAnnotation?: (annotationId: string) => Promise<boolean>;
+  /** 当前用户 ID，用于判断注解所有权 */
+  currentUserId?: string;
 }
 
 interface TooltipState {
@@ -34,14 +38,22 @@ export function AnnotationHighlightLayer({
   containerRef,
   annotations,
   snapshotRef,
+  onDeleteAnnotation,
+  currentUserId,
 }: Props) {
   const [tooltip, setTooltip] = useState<TooltipState | null>(null);
   const observerRef = useRef<MutationObserver | null>(null);
   const rendererRef = useRef<HighlightRenderer | null>(null);
   const hitTestRef = useRef<HitTestFn | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleHoverStart = useCallback(
     (group: HighlightGroupInput, rect: DOMRect) => {
+      // 取消待执行的隐藏延时
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
       setTooltip({
         x: rect.left,
         y: rect.bottom + 6,
@@ -52,8 +64,33 @@ export function AnnotationHighlightLayer({
   );
 
   const handleHoverEnd = useCallback(() => {
+    // 延时隐藏：给用户留出将鼠标移到 Tooltip 上（点击删除按钮等）的时间
+    hideTimerRef.current = setTimeout(() => {
+      hideTimerRef.current = null;
+      setTooltip(null);
+    }, 200);
+  }, []);
+
+  const handleTooltipEnter = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const handleTooltipLeave = useCallback(() => {
     setTooltip(null);
   }, []);
+
+  const handleDeleteAnnotation = useCallback(
+    async (annotationId: string) => {
+      if (!onDeleteAnnotation) return;
+      if (!window.confirm("确定删除此注解？")) return;
+      await onDeleteAnnotation(annotationId);
+      setTooltip(null);
+    },
+    [onDeleteAnnotation],
+  );
 
   const applyHighlights = useCallback(() => {
     const container = containerRef.current;
@@ -78,7 +115,7 @@ export function AnnotationHighlightLayer({
       const groups: HighlightGroupInput[] = [];
       for (const annotation of annotations) {
         const anchor = annotation.anchor as unknown as TextAnchor;
-        const range = resolveAnchor(anchor, container, snapshotRef?.current);
+        const range = resolveAnchor(anchor, container, snapshotRef?.current, annotation.quoted_text);
         if (!range) continue;
 
         const existing = groups.find((g) => rangesOverlap(g.range, range));
@@ -171,7 +208,15 @@ export function AnnotationHighlightLayer({
   }, [handleHoverStart, handleHoverEnd]);
 
   if (!tooltip) return null;
-  return <AnnotationTooltip position={tooltip} />;
+  return (
+    <AnnotationTooltip
+      position={tooltip}
+      currentUserId={currentUserId}
+      onDelete={onDeleteAnnotation ? handleDeleteAnnotation : undefined}
+      onMouseEnter={handleTooltipEnter}
+      onMouseLeave={handleTooltipLeave}
+    />
+  );
 }
 
 function rangesOverlap(a: Range, b: Range): boolean {

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationHighlightLayer.tsx
@@ -86,8 +86,8 @@ export function AnnotationHighlightLayer({
     async (annotationId: string) => {
       if (!onDeleteAnnotation) return;
       if (!window.confirm("确定删除此注解？")) return;
-      await onDeleteAnnotation(annotationId);
-      setTooltip(null);
+      const ok = await onDeleteAnnotation(annotationId);
+      if (ok) setTooltip(null);
     },
     [onDeleteAnnotation],
   );

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationLayer.tsx
@@ -15,9 +15,8 @@ interface Props {
 }
 
 export function AnnotationLayer({ entryId, children }: Props) {
-  const { annotations, createAnnotation, loading } = useAnnotations(entryId);
-  // status from useWikiAuth is read by child components; no direct use here
-  useWikiAuth();
+  const { annotations, createAnnotation, deleteAnnotation, loading } = useAnnotations(entryId);
+  const { user } = useWikiAuth();
   const contentRef = useRef<HTMLDivElement>(null);
   // 稳定快照：mount 后立即抓取，作为注解锚定的唯一权威坐标系。
   // entryId 变化时重抓（切换不同文章）。详见 use-snapshot.ts。
@@ -68,6 +67,8 @@ export function AnnotationLayer({ entryId, children }: Props) {
           containerRef={contentRef}
           annotations={annotations}
           snapshotRef={snapshotRef}
+          onDeleteAnnotation={deleteAnnotation}
+          currentUserId={user?.userId}
         />
       )}
       <TextSelectionHandler

--- a/apps/negentropy-wiki/src/components/annotation/AnnotationTooltip.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/AnnotationTooltip.tsx
@@ -8,18 +8,43 @@ interface Props {
     y: number;
     annotations: AnnotationItem[];
   };
+  currentUserId?: string;
+  onDelete?: (annotationId: string) => Promise<void>;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 }
 
-export function AnnotationTooltip({ position }: Props) {
+export function AnnotationTooltip({
+  position,
+  currentUserId,
+  onDelete,
+  onMouseEnter,
+  onMouseLeave,
+}: Props) {
   const { x, y, annotations } = position;
 
   return (
     <div
       className="wiki-annotation-tooltip"
       style={{ left: `${x}px`, top: `${y}px` }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       {annotations.map((annotation) => (
         <div key={annotation.id} className="wiki-annotation-tooltip-item">
+          {onDelete && currentUserId && annotation.user_id === currentUserId && (
+            <button
+              type="button"
+              className="wiki-annotation-tooltip-delete"
+              title="删除注解"
+              onClick={(e) => {
+                e.stopPropagation();
+                void onDelete(annotation.id);
+              }}
+            >
+              ×
+            </button>
+          )}
           <p className="wiki-annotation-tooltip-body">{annotation.body}</p>
           <div className="wiki-annotation-tooltip-meta">
             {annotation.user_picture ? (

--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -254,15 +254,17 @@ function computeBlockOffset(block: HTMLElement, container: HTMLElement): number 
 /**
  * 给定锚定数据，在 container 中定位目标文本，返回 DOM Range。
  *
- * 三段式解析（每段独立失败 → 进入下一段，保证「注解不消失」）：
+ * 四段式解析（每段独立失败 → 进入下一段，保证「注解不消失」）：
  *   段 1：snapshot 精确匹配（仅在 anchor_version >= 2 且 hash 一致时）
  *   段 2：当前 DOM 的 prefix+exact+suffix 全文搜索（兼容 v1 anchor 与同语言场景）
+ *   段 2.5：用 quoted_text（创建时用户看到的显示文本）搜索当前 DOM（跨语言匹配）
  *   段 3：块级元素粗粒度回退（用 xpath 找块级元素，整体选中）
  */
 export function resolveAnchor(
   anchor: TextAnchor,
   container: HTMLElement,
   snapshot?: AnnotationSnapshot | null,
+  quotedText?: string,
 ): Range | null {
   // 段 1：snapshot 精确（仅 v2+ anchor 且 hash 一致）
   if (
@@ -281,6 +283,13 @@ export function resolveAnchor(
   if (xpathRange) return xpathRange;
   const textRange = tryTextSearch(anchor, container);
   if (textRange) return textRange;
+
+  // 段 2.5：quoted_text 跨语言匹配。用注解创建时的显示文本在当前 DOM 中搜索，
+  // 解决 anchor.exact（原文）与翻译后 DOM 不匹配的问题。
+  if (quotedText && quotedText !== anchor.exact) {
+    const quotedRange = findTextInRange(quotedText, container);
+    if (quotedRange) return quotedRange;
+  }
 
   // 段 3：块级粗粒度回退 —— 保证用户至少看到"这段被注解过"
   return resolveBlockFallback(anchor, container);
@@ -372,6 +381,11 @@ function computeXPath(node: Node, container: HTMLElement): string {
   while (current && current !== container) {
     if (current.nodeType === Node.ELEMENT_NODE) {
       const el = current as HTMLElement;
+      // 跳过浏览器翻译产物（如 <font>），确保 XPath 跨翻译态一致
+      if (TRANSLATION_SKIP_TAGS.has(el.tagName)) {
+        current = current.parentNode as Node;
+        continue;
+      }
       const parent = el.parentElement;
       if (parent) {
         const siblings = Array.from(parent.children).filter(
@@ -466,7 +480,14 @@ function tryTextSearch(anchor: TextAnchor, container: HTMLElement): Range | null
  */
 function resolveBlockFallback(anchor: TextAnchor, container: HTMLElement): Range | null {
   try {
-    const parts = anchor.xpath.split("/").filter((p) => p && !p.startsWith("text()"));
+    // 过滤 text() 和翻译产物元素（如 font），确保 XPath 跨翻译态一致
+    const parts = anchor.xpath
+      .split("/")
+      .filter((p) => p && !p.startsWith("text()"))
+      .filter((p) => {
+        const match = /^([a-zA-Z0-9]+)/.exec(p);
+        return match && !TRANSLATION_SKIP_TAGS.has(match[1].toUpperCase());
+      });
     if (parts.length === 0) return null;
 
     // 解析 XPath 风格的路径（如 "/p[2]/strong[1]"）逐级定位
@@ -525,3 +546,6 @@ function findTextInRange(
 function detectLang(text: string): string {
   return /[一-鿿]/.test(text) ? "zh" : "en";
 }
+
+/** 浏览器翻译产物元素 —— computeXPath / resolveBlockFallback 跳过此类标签，确保 XPath 跨翻译态一致。 */
+const TRANSLATION_SKIP_TAGS = new Set(["FONT"]);

--- a/apps/negentropy-wiki/src/styles/components/annotation.css
+++ b/apps/negentropy-wiki/src/styles/components/annotation.css
@@ -126,7 +126,7 @@
   padding: 10px 14px;
   max-width: 320px;
   min-width: 200px;
-  pointer-events: none;
+  pointer-events: auto;
   animation: wiki-tooltip-fadein 0.15s ease;
 }
 
@@ -139,6 +139,9 @@
   margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--wiki-border);
+}
+.wiki-annotation-tooltip-item {
+  position: relative;
 }
 .wiki-annotation-tooltip-body {
   margin: 0 0 6px;
@@ -178,4 +181,28 @@
   font-size: 0.78em;
   color: var(--wiki-text-secondary);
   margin-left: auto;
+}
+
+/* 注解 Tooltip 删除按钮 */
+.wiki-annotation-tooltip-delete {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  border: none;
+  background: transparent;
+  color: var(--wiki-text-secondary);
+  cursor: pointer;
+  font-size: 1.1em;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 3px;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+.wiki-annotation-tooltip-item:hover .wiki-annotation-tooltip-delete {
+  opacity: 1;
+}
+.wiki-annotation-tooltip-delete:hover {
+  color: #e53e3e;
+  background: rgba(229, 62, 62, 0.08);
 }


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：浏览器翻译页面后，注解高亮因 DOM 结构变化而无法正确匹配原文，导致注解不可见；同时缺少注解删除功能。
- 关联上下文/Issue/文档：无

# 核心变更
- **跨语言锚定匹配（段 2.5）**：`resolveAnchor` 新增 `quotedText` 参数，当 `anchor.exact`（原文）在翻译后 DOM 中匹配失败时，用创建时的显示文本（`quoted_text`）作为 fallback 搜索当前 DOM
- **XPath 翻译产物过滤**：`computeXPath` 和 `resolveBlockFallback` 跳过浏览器翻译注入的 `<font>` 元素，确保 XPath 在翻译态/非翻译态间一致
- **注解删除功能**：Tooltip 支持删除按钮（仅注解作者可见），hover 延时 200ms 隐藏以支持鼠标移入 Tooltip 操作
- **删除失败容错**：检查 `deleteAnnotation` 返回值，API 失败时保持 Tooltip 显示，避免用户误判

# 风险与回滚
- 主要风险：段 2.5 的 `quotedText` 匹配为纯文本搜索，若多篇内容含相同文本可能匹配到错误位置（概率极低，因注解锚定在特定容器内）
- 回滚方式：`git revert` 即可

# 验证证据
- 单元测试：无新增（锚定逻辑为 DOM 操作，需浏览器环境）
- 集成测试：无
- E2E/Workflow：需浏览器实机验证翻译态下注解可见性 + 删除功能
- 覆盖率/关键截图：无

# 影响范围
- 前端：`negentropy-wiki` 注解模块（AnnotationHighlightLayer / AnnotationTooltip / use-text-anchor / annotation.css）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证：开启 Chrome 翻译后确认已有注解高亮正常显示、新建注解在翻译态下可正确创建与删除