### PR TITLE
style(wiki-nav): 移除侧栏导航中的圆点图标和向右箭头

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiNavTree.tsx
+++ b/apps/negentropy-wiki/src/components/WikiNavTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { isContainerItem, type WikiNavTreeItem } from "@/lib/wiki-api";
 
 /**
@@ -104,30 +104,9 @@ function WikiNavNode({
     }
   }, [isActive]);
 
-  const handleToggleKey = (event: KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onToggle(item.entry_slug);
-    }
-  };
-
   return (
     <li className="wiki-nav-item" role="treeitem">
       <div className="wiki-nav-row">
-        {hasChildren ? (
-          <button
-            type="button"
-            className={`wiki-nav-toggle${isOpen ? " open" : ""}`}
-            aria-label={isOpen ? "折叠" : "展开"}
-            aria-expanded={isOpen}
-            onClick={() => onToggle(item.entry_slug)}
-            onKeyDown={handleToggleKey}
-          >
-            <ChevronIcon />
-          </button>
-        ) : (
-          <span className="wiki-nav-leaf-dot" aria-hidden="true" />
-        )}
         {isContainer ? (
           <button
             type="button"
@@ -166,23 +145,5 @@ function WikiNavNode({
         </div>
       )}
     </li>
-  );
-}
-
-function ChevronIcon() {
-  return (
-    <svg
-      viewBox="0 0 16 16"
-      width="12"
-      height="12"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <polyline points="5 3 11 8 5 13" />
-    </svg>
   );
 }

--- a/apps/negentropy-wiki/src/styles/components/nav-tree.css
+++ b/apps/negentropy-wiki/src/styles/components/nav-tree.css
@@ -11,59 +11,7 @@
 .wiki-nav-row {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
   min-width: 0;
-}
-
-/* ---- Toggle chevron ---- */
-.wiki-nav-toggle {
-  flex-shrink: 0;
-  width: 18px;
-  height: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  background: transparent;
-  color: var(--wiki-text-secondary);
-  cursor: pointer;
-  padding: 0;
-  border-radius: 4px;
-  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1),
-              background 0.12s ease,
-              color 0.12s ease;
-}
-.wiki-nav-toggle:hover {
-  background: var(--wiki-bg-secondary);
-  color: var(--wiki-text);
-}
-.wiki-nav-toggle.open {
-  transform: rotate(90deg);
-}
-
-/* ---- Leaf dot indicator ---- */
-.wiki-nav-leaf-dot {
-  flex-shrink: 0;
-  width: 18px;
-  height: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.wiki-nav-leaf-dot::after {
-  content: "";
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--wiki-border);
-  transition: background 0.12s ease, transform 0.12s ease;
-}
-.wiki-nav-item:hover > .wiki-nav-row > .wiki-nav-leaf-dot::after {
-  background: var(--wiki-text-secondary);
-}
-.wiki-nav-item:has(.wiki-nav-link.active) > .wiki-nav-row > .wiki-nav-leaf-dot::after {
-  background: var(--wiki-accent);
-  transform: scale(1.25);
 }
 
 /* ---- Document link (leaf item) ---- */
@@ -145,9 +93,6 @@
 /* ---- Reduced motion ---- */
 @media (prefers-reduced-motion: reduce) {
   .wiki-nav-children {
-    transition: none;
-  }
-  .wiki-nav-toggle {
     transition: none;
   }
   .wiki-nav-link {


### PR DESCRIPTION
## Summary

- 彻底移除 `WikiNavTree` 中的 `ChevronIcon`（向右箭头 `>`）和 `wiki-nav-leaf-dot`（小圆点）视觉指示器
- 上一次修复（#707）仅移除了 Header 用户头像，但反向地将叶子节点 spacer 改为可见圆点，问题未解决
- 本次修复保留组标题按钮（`BLOG`/`PAPER` 等）的展开/折叠交互能力

## 变更文件

- `apps/negentropy-wiki/src/components/WikiNavTree.tsx` — 删除 `ChevronIcon`、`wiki-nav-toggle` 按钮、`wiki-nav-leaf-dot` span 及 `handleToggleKey` 函数
- `apps/negentropy-wiki/src/styles/components/nav-tree.css` — 删除 `.wiki-nav-toggle`、`.wiki-nav-leaf-dot` 相关样式（共 -95 行）

## Test plan

- [x] 浏览器实机验证：侧栏导航项无圆点/图标
- [x] 浏览器实机验证：容器节点无向右箭头
- [x] 点击 BLOG/PAPER 组标题可正常展开/折叠子列表
- [x] 活跃项高亮（左侧蓝色竖条）正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)