### PR TITLE
fix(wiki-count): 修正 countLeafEntries 排除 CONTAINER 节点以对齐主站点文档计数

### DIFF
--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -335,14 +335,14 @@ export function findIndexEntry(items: WikiNavTreeItem[]): WikiNavTreeItem | null
 }
 
 /**
- * 递归统计导航树中所有有效条目（`entry_id` 非空）的数量。
+ * 递归统计导航树中 DOCUMENT 类型条目的数量。
  *
- * 排除合成容器节点（`entry_id=null`），仅计可路由的叶子。
+ * 通过 `isContainerItem()` 排除 CONTAINER 节点，仅计实际文档。
  */
 export function countLeafEntries(items: WikiNavTreeItem[]): number {
   let total = 0;
   for (const item of items) {
-    if (item.entry_id) total += 1;
+    if (!isContainerItem(item) && item.entry_id) total += 1;
     if (item.children && item.children.length > 0) {
       total += countLeafEntries(item.children);
     }

--- a/apps/negentropy-wiki/tests/lib/wiki-section-view.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-section-view.test.ts
@@ -201,22 +201,20 @@ describe("countLeafEntries", () => {
     expect(countLeafEntries(items)).toBe(3);
   });
 
-  it("混合容器与文档（容器自身有 entry_id 也计入）", () => {
+  it("混合容器与文档（容器不计入）", () => {
     const items = [
       container("cat", [doc("cat/p1"), doc("cat/p2")]),
       doc("standalone"),
     ];
-    // container "cat" 自身 entry_id 非空也计入（自 0011 起容器条目持久化）
-    expect(countLeafEntries(items)).toBe(4);
+    expect(countLeafEntries(items)).toBe(3);
   });
 
-  it("空容器有 entry_id 时也计入", () => {
+  it("空容器不计入", () => {
     const items = [
       container("empty", []),
       doc("real"),
     ];
-    // container "empty" 自身 entry_id 非空也计入
-    expect(countLeafEntries(items)).toBe(2);
+    expect(countLeafEntries(items)).toBe(1);
   });
 
   it("entry_id=null 的节点不计入（合成容器）", () => {


### PR DESCRIPTION
# 背景
- Wiki 侧栏文档总数与主站点不一致：`countLeafEntries` 仅凭 `entry_id` 是否为空判定，会将持有持久化 `entry_id` 的 CONTAINER 节点一并计入，导致文档计数虚高。
- 关联上下文：容器条目自 v0.0.11 起持久化，`entry_kind='CONTAINER'` 且 `entry_id` 非空，旧逻辑无法区分容器与实际文档。

# 核心变更
- `countLeafEntries` 新增 `!isContainerItem(item)` 前置判定，复用已有的 `isContainerItem()`（优先检查 `entry_kind`，兜底检查 `document_id`）排除 CONTAINER 节点，仅计 DOCUMENT 类型条目。
- 同步更新相关单元测试期望值（混合容器 4→3、空容器 2→1）。

# 风险与回滚
- 主要风险：`countLeafEntries` 在 `page.tsx` 和 `graph/page.tsx` 两处调用，修改后返回值将减小（不再含容器），需确认下游消费端（如分页、进度展示）已兼容该语义变更。
- 回滚方式：`git revert` 该 commit 即可恢复旧计数逻辑。

# 验证证据
- 单元测试：23 个 `wiki-section-view` 测试全部通过，覆盖纯文档、混合容器、空容器、合成容器、容器 entry_id=null 等场景。
- 集成测试：不涉及。
- E2E/Workflow：不涉及。
- 覆盖率/关键截图：`countLeafEntries` 相关 6 个用例全覆盖。

# 影响范围
- 前端：`apps/negentropy-wiki` — 导航树文档计数显示。
- 后端：无变更。
- GitHub Actions / 文档：无变更。

# Next Best Action
- 合并后在浏览器端验证 Wiki 侧栏文档总数与主站点一致。