### PR TITLE
fix(wiki-annotation): 修复浏览器翻译后跨 <font> 节点注解不可见

### DIFF
--- a/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
+++ b/apps/negentropy-wiki/src/lib/annotation/use-text-anchor.ts
@@ -84,9 +84,10 @@ export function computeAnchor(
     suffix,
     text_offset: selStart >= 0 ? selStart : 0,
     text_length: selectedText.length,
-    source_text_hash: snapshot?.textHash,
+    // snapshot-based 计算失败，偏移量在当前 DOM 空间，不应声称 v2 元数据
+    source_text_hash: undefined,
     source_lang: detectLang(displayExact),
-    anchor_version: snapshot ? CURRENT_ANCHOR_VERSION : 1,
+    anchor_version: 1,
   };
 }
 
@@ -287,7 +288,7 @@ export function resolveAnchor(
   // 段 2.5：quoted_text 跨语言匹配。用注解创建时的显示文本在当前 DOM 中搜索，
   // 解决 anchor.exact（原文）与翻译后 DOM 不匹配的问题。
   if (quotedText && quotedText !== anchor.exact) {
-    const quotedRange = findTextInRange(quotedText, container);
+    const quotedRange = findTextAcrossNodes(quotedText, container);
     if (quotedRange) return quotedRange;
   }
 
@@ -445,7 +446,7 @@ function tryXPath(anchor: TextAnchor, container: HTMLElement): Range | null {
     for (const candidate of candidates) {
       const text = candidate.textContent || "";
       if (text.includes(anchor.exact)) {
-        return findTextInRange(anchor.exact, candidate as HTMLElement);
+        return findTextAcrossNodes(anchor.exact, candidate as HTMLElement);
       }
     }
   } catch {
@@ -462,11 +463,11 @@ function tryTextSearch(anchor: TextAnchor, container: HTMLElement): Range | null
   if (startIdx === -1) {
     startIdx = fullText.indexOf(anchor.exact);
     if (startIdx === -1) return null;
-    return findTextInRange(anchor.exact, container);
+    return findTextAcrossNodes(anchor.exact, container);
   }
 
   const exactStart = startIdx + (anchor.prefix?.length || 0);
-  return findTextInRange(anchor.exact, container, exactStart);
+  return findTextAcrossNodes(anchor.exact, container, exactStart);
 }
 
 /**
@@ -515,29 +516,84 @@ function resolveBlockFallback(anchor: TextAnchor, container: HTMLElement): Range
   }
 }
 
-function findTextInRange(
+interface TextSegment {
+  node: Text;
+  /** 该节点文本在拼接字符串中的起始位置。 */
+  start: number;
+  /** 该节点文本在拼接字符串中的结束位置（不含）。 */
+  end: number;
+}
+
+/**
+ * 跨节点文本搜索：在 root 下所有 Text 节点的拼接内容中查找 text，
+ * 返回可能跨越多个文本节点的 DOM Range。
+ *
+ * Chrome 翻译会将文本拆分到多个 <font> 元素内（各自含独立 Text 节点），
+ * 导致旧版 findTextInRange（单节点 indexOf）无法命中跨节点文本。
+ * 此函数通过拼接全部文本节点内容后统一搜索解决该问题。
+ */
+function findTextAcrossNodes(
   text: string,
   root: HTMLElement,
   hintOffset?: number,
 ): Range | null {
+  if (!text) return null;
+
+  // Phase 1：遍历所有 Text 节点，构建拼接内容 + 段映射
+  const segments: TextSegment[] = [];
+  let concatenated = "";
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-  let currentOffset = 0;
+  let n: Node | null;
+  while ((n = walker.nextNode())) {
+    const textNode = n as Text;
+    const value = textNode.nodeValue ?? "";
+    if (value.length === 0) continue;
+    const start = concatenated.length;
+    concatenated += value;
+    segments.push({ node: textNode, start, end: concatenated.length });
+  }
 
-  while (walker.nextNode()) {
-    const node = walker.currentNode as Text;
-    const nodeText = node.textContent || "";
-    const localIdx = nodeText.indexOf(
-      text,
-      hintOffset !== undefined ? Math.max(0, hintOffset - currentOffset) : 0,
-    );
+  if (segments.length === 0 || concatenated.length < text.length) return null;
 
-    if (localIdx !== -1) {
-      const range = document.createRange();
-      range.setStart(node, localIdx);
-      range.setEnd(node, localIdx + text.length);
-      return range;
+  // Phase 2：在拼接字符串中搜索目标文本
+  const searchStart = hintOffset !== undefined ? Math.max(0, hintOffset) : 0;
+  const matchIndex = concatenated.indexOf(text, searchStart);
+  if (matchIndex === -1) return null;
+
+  // Phase 3：将匹配边界映射回 Text 节点 + 偏移
+  const matchEnd = matchIndex + text.length;
+  const startLoc = locateSegment(segments, matchIndex);
+  const endLoc = locateSegment(segments, matchEnd - 1);
+
+  if (!startLoc || !endLoc) return null;
+
+  try {
+    const range = document.createRange();
+    range.setStart(startLoc.node, matchIndex - startLoc.start);
+    range.setEnd(endLoc.node, matchEnd - endLoc.start);
+    return range;
+  } catch {
+    return null;
+  }
+}
+
+/** 二分查找包含指定字符位置的段。position 必须在 [seg.start, seg.end) 范围内。 */
+function locateSegment(
+  segments: TextSegment[],
+  position: number,
+): TextSegment | null {
+  let lo = 0;
+  let hi = segments.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const seg = segments[mid];
+    if (position < seg.start) {
+      hi = mid - 1;
+    } else if (position >= seg.end) {
+      lo = mid + 1;
+    } else {
+      return seg;
     }
-    currentOffset += nodeText.length;
   }
   return null;
 }

--- a/apps/negentropy-wiki/tests/lib/annotation/use-text-anchor.test.ts
+++ b/apps/negentropy-wiki/tests/lib/annotation/use-text-anchor.test.ts
@@ -139,4 +139,75 @@ describe("resolveAnchor - 三段式解析", () => {
     expect(range).not.toBeNull();
     expect(range!.toString()).toBe("Second");
   });
+
+  describe("跨节点文本搜索（Chrome 翻译 <font> 拆分场景）", () => {
+    it("Stage 2.5：quotedText 跨 <font> 节点时仍可命中", () => {
+      // 模拟 Chrome 翻译后的 DOM：<p><font>你好</font><font>世界</font></p>
+      container.innerHTML = "<p><font>你好</font><font>世界</font></p>";
+
+      // anchor.exact 是原文（英文），quotedText 是中文显示文本
+      const anchor: TextAnchor = {
+        xpath: "/p[1]",
+        exact: "Hello world",
+        prefix: "",
+        suffix: "",
+        text_offset: 0,
+        text_length: 11,
+      };
+      const quotedText = "你好世界";
+      // Stage 2 找不到英文 → Stage 2.5 用中文搜索
+      const range = resolveAnchor(anchor, container, null, quotedText);
+      expect(range).not.toBeNull();
+      expect(range!.toString()).toBe("你好世界");
+    });
+
+    it("单节点匹配仍正常工作", () => {
+      container.innerHTML = "<p>单节点文本</p>";
+      const anchor: TextAnchor = {
+        xpath: "/p[1]",
+        exact: "单节点文本",
+        prefix: "",
+        suffix: "",
+        text_offset: 0,
+        text_length: 5,
+      };
+      const range = resolveAnchor(anchor, container);
+      expect(range).not.toBeNull();
+      expect(range!.toString()).toBe("单节点文本");
+    });
+
+    it("跨 <font> 节点的多段落匹配", () => {
+      container.innerHTML =
+        "<p><font>第一段</font><font>内容</font></p>" +
+        "<p><font>第二段</font><font>内容</font></p>";
+      const anchor: TextAnchor = {
+        xpath: "/p[2]",
+        exact: "第二段内容",
+        prefix: "",
+        suffix: "",
+        text_offset: 8,
+        text_length: 5,
+      };
+      const range = resolveAnchor(anchor, container);
+      expect(range).not.toBeNull();
+      expect(range!.toString()).toBe("第二段内容");
+    });
+
+    it("Stage 2.5：quotedText 不存在时降级到 Stage 3 块级回退", () => {
+      container.innerHTML = "<p><font>你好</font><font>世界</font></p>";
+      const anchor: TextAnchor = {
+        xpath: "/p[1]",
+        exact: "nonexistent",
+        prefix: "",
+        suffix: "",
+        text_offset: 0,
+        text_length: 11,
+      };
+      const quotedText = "不存在的文本";
+      const range = resolveAnchor(anchor, container, null, quotedText);
+      // Stage 2 + 2.5 全部失败 → Stage 3 块级回退选中整个 <p>
+      expect(range).not.toBeNull();
+      expect(range!.toString()).toBe("你好世界");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- 修复 Chrome 翻译将文本拆分到多个 `<font>` 元素后，注解在翻译态页面上不可见的问题
- 将 `findTextInRange`（单节点搜索）替换为 `findTextAcrossNodes`（跨节点搜索），通过拼接所有 Text 节点内容后统一搜索，支持创建跨节点 DOM Range
- 修复 `computeAnchor` fallback 路径错误声明 v2 元数据（`source_text_hash` / `anchor_version`）的缺陷，防止 Stage 1 使用错误的中文 DOM 偏移进入 snapshot 解析

## Root Cause
Chrome 翻译将 `<p>Hello world</p>` 转化为 `<p><font>你好</font><font>世界</font></p>`，连续文本被拆分到独立 Text 节点。`resolveAnchor` Stage 2.5 跨语言匹配使用 `findTextInRange`（`indexOf` 仅在单个节点内搜索），无法找到跨 `<font>` 的中文文本，导致注解定位失败。

## Test plan
- [x] 单元测试：33/33 通过（含 4 个新增跨节点搜索测试）
- [x] 浏览器 DOM 验证：跨 `<font>` 节点中文文本搜索 + Range 创建成功
- [x] 翻译检测验证：`<font>` 元素识别 → CSS Highlight API 激活正常
- [ ] 用户手动验证：浏览器"翻译成中文" → 选中中文文本 → 添加注解 → 确认注解高亮可见

🤖 Generated with [Claude Code](https://claude.com/claude-code)