### PR TITLE
fix(wiki-home): 首页导航项与卡片从 Catalog 一级目录动态获取并修复图标/描述/兜底逻辑

### DIFF
--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -1,6 +1,12 @@
 import { unstable_noStore as noStore } from "next/cache";
+import type { ComponentType } from "react";
 
-import { wikiApi, type WikiPublication } from "@/lib/wiki-api";
+import {
+  findFirstDocumentSlug,
+  wikiApi,
+  type WikiNavTreeItem,
+  type WikiPublication,
+} from "@/lib/wiki-api";
 import { WikiHeader } from "@/components/WikiHeader";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import { ThemePreference } from "@/components/ThemePreference";
@@ -12,6 +18,12 @@ import { getPublicationIcon } from "@/components/home/CardIcons";
 
 // ISR: 5 分钟增量再验证
 export const revalidate = 300;
+
+/** 从 nav tree 一级节点构建跳转 href */
+function buildEntryHref(pubSlug: string, item: WikiNavTreeItem): string {
+  const target = findFirstDocumentSlug(item);
+  return target ? `/${pubSlug}/${target}` : `/${pubSlug}`;
+}
 
 export default async function WikiHomePage() {
   let publications: WikiPublication[] = [];
@@ -27,12 +39,51 @@ export default async function WikiHomePage() {
     );
   }
 
-  const homeLinks = publications.map((p) => ({
-    label: p.name,
-    href: `/${p.slug}`,
-  }));
+  // 并行获取每个 publication 的 nav tree，从中提取一级目录节点
+  const navTrees = await Promise.all(
+    publications.map(async (pub) => {
+      try {
+        const navResult = await wikiApi.getNavTree(pub.id);
+        return { pub, items: navResult.nav_tree?.items || [] };
+      } catch {
+        return { pub, items: [] as WikiNavTreeItem[] };
+      }
+    }),
+  );
 
-  const firstPubSlug = publications.length > 0 ? `/${publications[0].slug}` : undefined;
+  // 从 nav tree 一级节点构建 header 导航项
+  const homeLinks: { label: string; href: string }[] = [];
+  // 从 nav tree 一级节点构建卡片数据（存储 Icon 组件引用，在 JSX 中渲染）
+  const homeCards: { title: string; href: string; description: string; Icon: ComponentType }[] = [];
+
+  for (const { pub, items } of navTrees) {
+    for (const item of items) {
+      const title = item.entry_title || item.entry_slug;
+      const href = buildEntryHref(pub.slug, item);
+      homeLinks.push({ label: title, href });
+      homeCards.push({
+        title,
+        href,
+        description: "暂无描述",
+        Icon: getPublicationIcon(title),
+      });
+    }
+  }
+
+  // fallback: 如果 nav tree 没有一级节点，用 publication 自身作为兜底
+  if (homeLinks.length === 0) {
+    for (const pub of publications) {
+      homeLinks.push({ label: pub.name, href: `/${pub.slug}` });
+      homeCards.push({
+        title: pub.name,
+        href: `/${pub.slug}`,
+        description: pub.description || "暂无描述",
+        Icon: getPublicationIcon(pub.name),
+      });
+    }
+  }
+
+  const firstHref = homeCards.length > 0 ? homeCards[0].href : undefined;
 
   const header = (
     <WikiHeader
@@ -45,9 +96,9 @@ export default async function WikiHomePage() {
 
   const sidebar = (
     <div className="home-mobile-sidebar">
-      {publications.map((p) => (
-        <a key={p.slug} href={`/${p.slug}`} className="home-mobile-sidebar-link">
-          {p.name}
+      {homeLinks.map((link) => (
+        <a key={link.href} href={link.href} className="home-mobile-sidebar-link">
+          {link.label}
         </a>
       ))}
     </div>
@@ -69,8 +120,8 @@ export default async function WikiHomePage() {
           <p className="home-hero-subtext">
             你我的相识绝非一场零和游戏！
           </p>
-          {firstPubSlug && (
-            <a href={firstPubSlug} className="home-hero-cta">
+          {firstHref && (
+            <a href={firstHref} className="home-hero-cta">
               Harness Engineering → 5min
             </a>
           )}
@@ -79,16 +130,15 @@ export default async function WikiHomePage() {
 
       <section className="home-cards-section">
         <div className="home-cards-grid">
-          {publications.map((pub) => {
-            const Icon = getPublicationIcon(pub.name);
-            return (
-              <HomeCard
-                key={pub.id}
-                publication={pub}
-                icon={<Icon />}
-              />
-            );
-          })}
+          {homeCards.map((card, idx) => (
+            <HomeCard
+              key={`${card.href}:${idx}`}
+              title={card.title}
+              href={card.href}
+              description={card.description}
+              icon={<card.Icon />}
+            />
+          ))}
         </div>
       </section>
     </WikiLayoutShell>

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -57,22 +57,21 @@ export default async function WikiHomePage() {
   const homeCards: { title: string; href: string; description: string; Icon: ComponentType }[] = [];
 
   for (const { pub, items } of navTrees) {
-    for (const item of items) {
-      const title = item.entry_title || item.entry_slug;
-      const href = buildEntryHref(pub.slug, item);
-      homeLinks.push({ label: title, href });
-      homeCards.push({
-        title,
-        href,
-        description: "暂无描述",
-        Icon: getPublicationIcon(title),
-      });
-    }
-  }
-
-  // fallback: 如果 nav tree 没有一级节点，用 publication 自身作为兜底
-  if (homeLinks.length === 0) {
-    for (const pub of publications) {
+    if (items.length > 0) {
+      // 有 nav tree 一级节点时，从中构建导航项
+      for (const item of items) {
+        const title = item.entry_title || item.entry_slug;
+        const href = buildEntryHref(pub.slug, item);
+        homeLinks.push({ label: title, href });
+        homeCards.push({
+          title,
+          href,
+          description: pub.description || "暂无描述",
+          Icon: getPublicationIcon(pub.name),
+        });
+      }
+    } else {
+      // nav tree 为空或 API 失败时，用 publication 自身作为兜底
       homeLinks.push({ label: pub.name, href: `/${pub.slug}` });
       homeCards.push({
         title: pub.name,

--- a/apps/negentropy-wiki/src/components/home/HomeCard.tsx
+++ b/apps/negentropy-wiki/src/components/home/HomeCard.tsx
@@ -1,18 +1,15 @@
-import type { WikiPublication } from "@/lib/wiki-api";
-
 interface HomeCardProps {
-  publication: WikiPublication;
+  title: string;
+  href: string;
+  description: string;
   icon: React.ReactNode;
 }
 
-export function HomeCard({ publication, icon }: HomeCardProps) {
-  const href = `/${publication.slug}`;
-  const description = publication.description || "暂无描述";
-
+export function HomeCard({ title, href, description, icon }: HomeCardProps) {
   return (
     <a href={href} className="home-card">
       <div className="home-card-icon">{icon}</div>
-      <h3 className="home-card-title">{publication.name}</h3>
+      <h3 className="home-card-title">{title}</h3>
       <p className="home-card-desc">{description}</p>
     </a>
   );


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 首页的 Header 导航项和卡片原先直接基于 Publication 列表渲染，无法反映 Catalog 层级的实际目录结构
- 关联上下文/Issue/文档：bd1de15a 初始实现 + e793db0b Code Review 修复

# 核心变更
- 首页 `page.tsx` 在 ISR 阶段并行获取每个 Publication 的 nav tree，从一级目录节点（`WikiNavTreeItem`）动态构建导航项和卡片数据
- 新增 `buildEntryHref` 辅助函数：递归查找容器节点的第一个文档 slug，构建精确跳转路径 `/{pubSlug}/{firstDocSlug}`
- `HomeCard` 组件解耦 `WikiPublication` 依赖，改为接收 `title`/`href`/`description`/`icon` 纯属性，提升复用性
- 逐个 Publication 粒度 fallback：nav tree 为空或 API 失败时，该 Publication 仍以自身信息展示，不会静默消失
- 图标映射使用 `pub.name` 确保 `ICON_MAP` 命中，描述回退至 `pub.description`

# 风险与回滚
- 主要风险：ISR 阶段新增 N 次 nav tree API 调用（`Promise.all` 并行），增加了首页渲染延迟；单个 API 失败已被 `try/catch` 兜底
- 回滚方式：`git revert` 即可恢复为基于 Publication 列表的静态渲染

# 验证证据
- 单元测试：无（ISR 服务端组件，依赖集成验证）
- 集成测试：无
- E2E/Workflow：需浏览器验证首页导航项与卡片是否正确反映 Catalog 结构
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`negentropy-wiki` 首页（`page.tsx`）及 `HomeCard` 组件
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证首页在正常/部分 API 失败/全空三种场景下的表现