### PR TITLE
fix(memory-facts): 修复 All Users 筛选器下 Facts 不显示的问题

### DIFF
--- a/apps/negentropy-ui/app/memory/facts/_components/FactCard.tsx
+++ b/apps/negentropy-ui/app/memory/facts/_components/FactCard.tsx
@@ -99,10 +99,11 @@ function TemporalBadge({ fact }: { fact: FactItem }) {
 
 interface FactCardProps {
   fact: FactItem;
+  userLabel?: string;
   onShowHistory: (factId: string) => void;
 }
 
-export function FactCard({ fact, onShowHistory }: FactCardProps) {
+export function FactCard({ fact, userLabel, onShowHistory }: FactCardProps) {
   return (
     <article className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
       <ConfidenceBar confidence={fact.confidence} />
@@ -123,6 +124,11 @@ export function FactCard({ fact, onShowHistory }: FactCardProps) {
           <TemporalBadge fact={fact} />
           {fact.created_at && (
             <span>{formatShortDate(fact.created_at)}</span>
+          )}
+          {userLabel && (
+            <span className="truncate rounded-full border border-border px-1.5 py-px text-[10px]">
+              {userLabel}
+            </span>
           )}
         </div>
         <button

--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -43,11 +43,10 @@ export default function MemoryFactsPage() {
   const [historyError, setHistoryError] = useState<string | null>(null);
 
   const loadFacts = useCallback(async () => {
-    if (!activeUserId) return;
     setIsLoading(true);
     setError(null);
     try {
-      const data = await fetchFacts(activeUserId, APP_NAME);
+      const data = await fetchFacts(activeUserId ?? undefined, APP_NAME);
       setPayload(data);
     } catch (err) {
       setError(err as Error);
@@ -69,6 +68,7 @@ export default function MemoryFactsPage() {
   }, [loadFacts]);
 
   const facts = payload?.items || [];
+  const userLabelMap = new Map(users.map((u) => [u.id, u.label || u.id]));
 
   const handleSearch = async () => {
     if (!searchQuery.trim() || !activeUserId) return;
@@ -137,7 +137,7 @@ export default function MemoryFactsPage() {
                   <p className="mt-2 text-[11px] text-muted">
                     {activeUserId
                       ? `${facts.length} facts for selected user`
-                      : `${users.length} users with facts`}
+                      : `${facts.length} facts across ${users.length} users`}
                   </p>
                   {!activeUserId && users.length > 0 && (
                     <div className="mt-3 space-y-1.5">
@@ -173,56 +173,51 @@ export default function MemoryFactsPage() {
               </div>
             )}
 
-            {!activeUserId ? (
-              /* All Users summary: prompt to select a user */
+            {/* Search bar -- only when a specific user is selected */}
+            {activeUserId && (
+              <div className="mb-4 flex items-center gap-2">
+                <input
+                  className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-xs"
+                  placeholder="Search facts..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                />
+                <button
+                  className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                  onClick={handleSearch}
+                >
+                  Search
+                </button>
+                <button
+                  className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
+                  onClick={handleClearSearch}
+                >
+                  Clear
+                </button>
+              </div>
+            )}
+
+            {/* Facts grid -- always shown */}
+            {isLoading ? (
+              <p className="text-xs text-muted">Loading facts...</p>
+            ) : facts.length === 0 ? (
               <div className="rounded-2xl border border-border bg-card p-10 text-center shadow-sm">
                 <p className="text-sm text-muted">
-                  Select a user from the filter above or sidebar to view their semantic facts.
+                  {activeUserId ? "No facts found for this user." : "No facts found."}
                 </p>
               </div>
             ) : (
-              <>
-                {/* Search bar */}
-                <div className="mb-4 flex items-center gap-2">
-                  <input
-                    className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-xs"
-                    placeholder="Search facts..."
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {facts.map((fact) => (
+                  <FactCard
+                    key={fact.id}
+                    fact={fact}
+                    userLabel={activeUserId ? undefined : userLabelMap.get(fact.user_id)}
+                    onShowHistory={handleShowHistory}
                   />
-                  <button
-                    className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
-                    onClick={handleSearch}
-                  >
-                    Search
-                  </button>
-                  <button
-                    className={outlineButtonClassName("neutral", "rounded-lg px-3 py-2 text-xs")}
-                    onClick={handleClearSearch}
-                  >
-                    Clear
-                  </button>
-                </div>
-
-                {isLoading ? (
-                  <p className="text-xs text-muted">Loading facts...</p>
-                ) : facts.length === 0 ? (
-                  <div className="rounded-2xl border border-border bg-card p-10 text-center shadow-sm">
-                    <p className="text-sm text-muted">No facts found for this user.</p>
-                  </div>
-                ) : (
-                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                    {facts.map((fact) => (
-                      <FactCard
-                        key={fact.id}
-                        fact={fact}
-                        onShowHistory={handleShowHistory}
-                      />
-                    ))}
-                  </div>
-                )}
-              </>
+                ))}
+              </div>
             )}
           </MemorySidebarLayout>
         </div>

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -235,18 +235,19 @@ function buildMemoryRetryableError(
 // ============================================================================
 
 export async function fetchFacts(
-  userId: string,
+  userId?: string,
   appName?: string,
   factType?: string,
   limit?: number,
 ): Promise<FactListPayload> {
   const params = new URLSearchParams();
-  params.set("user_id", userId);
+  if (userId) params.set("user_id", userId);
   if (appName) params.set("app_name", appName);
   if (factType) params.set("fact_type", factType);
   if (limit) params.set("limit", String(limit));
+  const qs = params.toString() ? `?${params.toString()}` : "";
 
-  const res = await fetch(`/api/memory/facts?${params.toString()}`, {
+  const res = await fetch(`/api/memory/facts${qs}`, {
     cache: "no-store",
   });
   if (!res.ok) {

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -69,16 +69,27 @@ const SAMPLE_FACTS = {
   ],
 };
 
-test("Facts 初始展示用户选择提示", async ({ page }) => {
+test("Facts 初始展示 All Users 视图直接加载事实", async ({ page }) => {
   await mockAuthenticatedUser(page);
   await mockMemoryUsers(page);
+  await page.route("**/api/memory/facts**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SAMPLE_FACTS),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
   await page.goto("/memory/facts");
   // "All Users" pill is visible by default
   await expect(page.getByRole("button", { name: "All Users" })).toBeVisible();
-  // Prompt to select a user is shown
-  await expect(
-    page.getByText("Select a user from the filter above or sidebar to view their semantic facts."),
-  ).toBeVisible();
+  // Facts grid is shown with user labels
+  await expect(page.getByText("preferred_language")).toBeVisible();
+  await expect(page.getByText("Test User 1")).toBeVisible();
 });
 
 test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {

--- a/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/memory/facts.spec.ts
@@ -87,9 +87,10 @@ test("Facts 初始展示 All Users 视图直接加载事实", async ({ page }) =
   await page.goto("/memory/facts");
   // "All Users" pill is visible by default
   await expect(page.getByRole("button", { name: "All Users" })).toBeVisible();
-  // Facts grid is shown with user labels
+  // Facts grid is shown with user labels on cards
   await expect(page.getByText("preferred_language")).toBeVisible();
-  await expect(page.getByText("Test User 1")).toBeVisible();
+  // User label badge appears on FactCard (scoped to article to avoid filter/sidebar matches)
+  await expect(page.locator("article").getByText("Test User 1").first()).toBeVisible();
 });
 
 test("Facts 加载列表展示 Key/Type/Confidence", async ({ page }) => {

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/fact_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/fact_service.py
@@ -331,15 +331,15 @@ class FactService:
     async def list_facts(
         self,
         *,
-        user_id: str,
+        user_id: str | None = None,
         app_name: str,
         fact_type: str | None = None,
         limit: int = 100,
     ) -> list[Fact]:
-        """列出用户的所有有效 Fact
+        """列出有效 Fact
 
         Args:
-            user_id: 用户 ID
+            user_id: 用户 ID，为 None 时返回所有用户的 Facts
             app_name: 应用名称
             fact_type: 可选的事实类型过滤
             limit: 返回数量限制
@@ -350,12 +350,15 @@ class FactService:
         now = datetime.now(UTC)
 
         async with db_session.AsyncSessionLocal() as db:
-            stmt = select(Fact).where(
-                Fact.user_id == user_id,
+            conditions = [
                 Fact.app_name == app_name,
                 Fact.status == "active",
                 (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
-            )
+            ]
+            if user_id is not None:
+                conditions.append(Fact.user_id == user_id)
+
+            stmt = select(Fact).where(*conditions)
 
             if fact_type:
                 stmt = stmt.where(Fact.fact_type == fact_type)

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -500,7 +500,7 @@ async def search_memories(payload: MemorySearchRequest) -> MemorySearchResponse:
 @router.get("/facts", response_model=FactListResponse)
 async def list_facts(
     app_name: str | None = Query(default=None),
-    user_id: str = Query(...),
+    user_id: str | None = Query(default=None),
     fact_type: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=1000),
 ) -> FactListResponse:


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：当 Memory Facts 页面筛选器选择 "All Users" 时，由于前端 `loadFacts` 存在 `!activeUserId` 的 early return 且后端 `user_id` 为必填参数，导致该筛选器下无任何 Facts 数据返回与展示。
- 关联上下文/Issue/文档：N/A

# 核心变更
- **后端** `fact_service.list_facts`：`user_id` 参数改为 `str | None`，为 `None` 时跳过用户过滤，返回所有用户的活跃 Facts
- **API 层** `/facts` 端点：`user_id` 查询参数从 `Query(...)` 改为 `Query(default=None)`
- **前端 API** `fetchFacts`：`userId` 改为可选参数，省略时不拼接 `user_id` 查询参数；修正空参数时 URL 末尾多余 `?` 的问题
- **前端页面** `page.tsx`：移除 `loadFacts` 中 `!activeUserId` 的 early return，使 All Users 视图正常拉取数据；重构渲染逻辑，All Users 下展示 Facts 网格并显示用户标签
- **组件** `FactCard`：新增可选 `userLabel` prop，在 All Users 视图中标注每条 Fact 的所属用户

# 风险与回滚
- 主要风险：All Users 查询无用户过滤，数据量由 `limit`（默认 100）兜底，大规模用户场景下可能需分页支持
- 回滚方式：`git revert` 该 commit 即可

# 验证证据
- 单元测试：N/A（本次为 Bug 修复，未新增测试）
- 集成测试：N/A
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：`negentropy-ui` — Facts 页面、FactCard 组件、memory API 工具函数
- 后端：`negentropy` — fact_service、engine API 路由
- GitHub Actions / 文档：无影响

# Next Best Action
- 若 Facts 数据量增长较快，可考虑为 All Users 视图增加分页或虚拟滚动支持