### PR TITLE
feat(wiki-home): 首页 Hero 区域替换为 Galaxy WebGL 星空粒子背景

### DIFF
--- a/apps/negentropy-wiki/package.json
+++ b/apps/negentropy-wiki/package.json
@@ -27,6 +27,7 @@
     "mdast-util-to-string": "^4.0.0",
     "mermaid": "^11.15.0",
     "next": "16.2.6",
+    "ogl": "^1.0.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-force-graph-2d": "^1.29.1",

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -13,6 +13,7 @@ import { ThemePreference } from "@/components/ThemePreference";
 import { WikiSearchBox } from "@/components/WikiSearchBox";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { HomeCard } from "@/components/home/HomeCard";
+import { GalaxyHeroMount } from "@/components/home/GalaxyHeroMount";
 import { WikiFooter } from "@/components/home/WikiFooter";
 import { getPublicationIcon } from "@/components/home/CardIcons";
 
@@ -111,7 +112,7 @@ export default async function WikiHomePage() {
       footer={<WikiFooter />}
     >
       <section className="home-hero">
-        <div className="home-hero-bg" aria-hidden="true" />
+        <GalaxyHeroMount />
         <div className="home-hero-content">
           <p className="home-hero-text">
             关注 AI Infra、Agent 工程化、信息论等领域前沿动态

--- a/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
+++ b/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { Renderer, Program, Mesh, Color, Triangle } from "ogl";
+import { useEffect, useRef } from "react";
+
+/* ── GLSL Vertex Shader ── */
+const vertexShader = /* glsl */ `
+attribute vec2 uv;
+attribute vec2 position;
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position, 0, 1);
+}
+`;
+
+/* ── GLSL Fragment Shader ── */
+const fragmentShader = /* glsl */ `
+precision highp float;
+uniform float uTime;
+uniform vec3 uResolution;
+uniform vec2 uFocal;
+uniform vec2 uRotation;
+uniform float uStarSpeed;
+uniform float uDensity;
+uniform float uHueShift;
+uniform float uSpeed;
+uniform vec2 uMouse;
+uniform float uGlowIntensity;
+uniform float uSaturation;
+uniform bool uMouseRepulsion;
+uniform float uTwinkleIntensity;
+uniform float uRotationSpeed;
+uniform float uRepulsionStrength;
+uniform float uMouseActiveFactor;
+uniform float uAutoCenterRepulsion;
+uniform bool uTransparent;
+varying vec2 vUv;
+
+#define NUM_LAYER 4.0
+#define STAR_COLOR_CUTOFF 0.2
+#define MAT45 mat2(0.7071, -0.7071, 0.7071, 0.7071)
+#define PERIOD 3.0
+
+float Hash21(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+
+float tri(float x) {
+  return abs(fract(x) * 2.0 - 1.0);
+}
+
+float tris(float x) {
+  float t = fract(x);
+  return 1.0 - smoothstep(0.0, 1.0, abs(2.0 * t - 1.0));
+}
+
+float trisn(float x) {
+  float t = fract(x);
+  return 2.0 * (1.0 - smoothstep(0.0, 1.0, abs(2.0 * t - 1.0))) - 1.0;
+}
+
+vec3 hsv2rgb(vec3 c) {
+  vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+  vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+  return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+float Star(vec2 uv, float flare) {
+  float d = length(uv);
+  float m = (0.05 * uGlowIntensity) / d;
+  float rays = smoothstep(0.0, 1.0, 1.0 - abs(uv.x * uv.y * 1000.0));
+  m += rays * flare * uGlowIntensity;
+  uv *= MAT45;
+  rays = smoothstep(0.0, 1.0, 1.0 - abs(uv.x * uv.y * 1000.0));
+  m += rays * 0.3 * flare * uGlowIntensity;
+  m *= smoothstep(1.0, 0.2, d);
+  return m;
+}
+
+vec3 StarLayer(vec2 uv) {
+  vec3 col = vec3(0.0);
+  vec2 gv = fract(uv) - 0.5;
+  vec2 id = floor(uv);
+  for (int y = -1; y <= 1; y++) {
+    for (int x = -1; x <= 1; x++) {
+      vec2 offset = vec2(float(x), float(y));
+      vec2 si = id + vec2(float(x), float(y));
+      float seed = Hash21(si);
+      float size = fract(seed * 345.32);
+      float glossLocal = tri(uStarSpeed / (PERIOD * seed + 1.0));
+      float flareSize = smoothstep(0.9, 1.0, size) * glossLocal;
+      float red = smoothstep(STAR_COLOR_CUTOFF, 1.0, Hash21(si + 1.0)) + STAR_COLOR_CUTOFF;
+      float blu = smoothstep(STAR_COLOR_CUTOFF, 1.0, Hash21(si + 3.0)) + STAR_COLOR_CUTOFF;
+      float grn = min(red, blu) * seed;
+      vec3 base = vec3(red, grn, blu);
+      float hue = atan(base.g - base.r, base.b - base.r) / (2.0 * 3.14159) + 0.5;
+      hue = fract(hue + uHueShift / 360.0);
+      float sat = length(base - vec3(dot(base, vec3(0.299, 0.587, 0.114)))) * uSaturation;
+      float val = max(max(base.r, base.g), base.b);
+      base = hsv2rgb(vec3(hue, sat, val));
+      vec2 pad = vec2(tris(seed * 34.0 + uTime * uSpeed / 10.0), tris(seed * 38.0 + uTime * uSpeed / 30.0)) - 0.5;
+      float star = Star(gv - offset - pad, flareSize);
+      vec3 color = base;
+      float twinkle = trisn(uTime * uSpeed + seed * 6.2831) * 0.5 + 1.0;
+      twinkle = mix(1.0, twinkle, uTwinkleIntensity);
+      star *= twinkle;
+      col += star * size * color;
+    }
+  }
+  return col;
+}
+
+void main() {
+  vec2 focalPx = uFocal * uResolution.xy;
+  vec2 uv = (vUv * uResolution.xy - focalPx) / uResolution.y;
+  vec2 mouseNorm = uMouse - vec2(0.5);
+  if (uAutoCenterRepulsion > 0.0) {
+    vec2 centerUV = vec2(0.0, 0.0);
+    float centerDist = length(uv - centerUV);
+    vec2 repulsion = normalize(uv - centerUV) * (uAutoCenterRepulsion / (centerDist + 0.1));
+    uv += repulsion * 0.05;
+  } else if (uMouseRepulsion) {
+    vec2 mousePosUV = (uMouse * uResolution.xy - focalPx) / uResolution.y;
+    float mouseDist = length(uv - mousePosUV);
+    vec2 repulsion = normalize(uv - mousePosUV) * (uRepulsionStrength / (mouseDist + 0.1));
+    uv += repulsion * 0.05 * uMouseActiveFactor;
+  } else {
+    vec2 mouseOffset = mouseNorm * 0.1 * uMouseActiveFactor;
+    uv += mouseOffset;
+  }
+  float autoRotAngle = uTime * uRotationSpeed;
+  mat2 autoRot = mat2(cos(autoRotAngle), -sin(autoRotAngle), sin(autoRotAngle), cos(autoRotAngle));
+  uv = autoRot * uv;
+  uv = mat2(uRotation.x, -uRotation.y, uRotation.y, uRotation.x) * uv;
+  vec3 col = vec3(0.0);
+  for (float i = 0.0; i < 1.0; i += 1.0 / NUM_LAYER) {
+    float depth = fract(i + uStarSpeed * uSpeed);
+    float scale = mix(20.0 * uDensity, 0.5 * uDensity, depth);
+    float fade = depth * smoothstep(1.0, 0.9, depth);
+    col += StarLayer(uv * scale + i * 453.32) * fade;
+  }
+  if (uTransparent) {
+    float alpha = length(col);
+    alpha = smoothstep(0.0, 0.3, alpha);
+    alpha = min(alpha, 1.0);
+    gl_FragColor = vec4(col, alpha);
+  } else {
+    gl_FragColor = vec4(col, 1.0);
+  }
+}
+`;
+
+interface GalaxyBackgroundProps {
+  className?: string;
+}
+
+export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
+  const ctnDom = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ctnDom.current) return;
+    const ctn = ctnDom.current;
+
+    // 主题检测
+    const rootEl = document.documentElement;
+    const colorScheme = rootEl.getAttribute("data-color-scheme");
+    const prefersDark =
+      colorScheme === "dark" ||
+      (!colorScheme && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+    // 无障碍：减弱动画
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    // 主题预设 — 对齐 reactbits Galaxy Preview 效果
+    const transparent = false;
+    const glowIntensity = 0.5;
+    const hueShift = 140;
+    const saturation = 0.5;
+    const disableAnimation = prefersReducedMotion;
+    const starSpeed = 0.5;
+    const density = 1.2;
+    const speed = 1.0;
+    const mouseRepulsion = true;
+    const repulsionStrength = 2;
+    const twinkleIntensity = 0.4;
+    const rotationSpeed = 0.1;
+
+    const targetMousePos = { x: 0.5, y: 0.5 };
+    const smoothMousePos = { x: 0.5, y: 0.5 };
+    const targetMouseActive = { value: 0.0 };
+    const smoothMouseActive = { value: 0.0 };
+
+    const renderer = new Renderer({ alpha: transparent, premultipliedAlpha: false });
+    const gl = renderer.gl;
+
+    if (transparent) {
+      gl.enable(gl.BLEND);
+      gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      gl.clearColor(0, 0, 0, 0);
+    } else {
+      gl.clearColor(0, 0, 0, 1);
+    }
+
+    let program: Program;
+
+    function resize() {
+      renderer.setSize(ctn.offsetWidth, ctn.offsetHeight);
+      if (program) {
+        program.uniforms.uResolution.value = new Color(
+          gl.canvas.width,
+          gl.canvas.height,
+          gl.canvas.width / gl.canvas.height,
+        );
+      }
+    }
+    window.addEventListener("resize", resize, false);
+    resize();
+
+    const geometry = new Triangle(gl);
+    program = new Program(gl, {
+      vertex: vertexShader,
+      fragment: fragmentShader,
+      uniforms: {
+        uTime: { value: 0 },
+        uResolution: {
+          value: new Color(gl.canvas.width, gl.canvas.height, gl.canvas.width / gl.canvas.height),
+        },
+        uFocal: { value: new Float32Array([0.5, 0.5]) },
+        uRotation: { value: new Float32Array([1.0, 0.0]) },
+        uStarSpeed: { value: starSpeed },
+        uDensity: { value: density },
+        uHueShift: { value: hueShift },
+        uSpeed: { value: speed },
+        uMouse: { value: new Float32Array([smoothMousePos.x, smoothMousePos.y]) },
+        uGlowIntensity: { value: glowIntensity },
+        uSaturation: { value: saturation },
+        uMouseRepulsion: { value: mouseRepulsion },
+        uTwinkleIntensity: { value: twinkleIntensity },
+        uRotationSpeed: { value: rotationSpeed },
+        uRepulsionStrength: { value: repulsionStrength },
+        uMouseActiveFactor: { value: 0.0 },
+        uAutoCenterRepulsion: { value: 0 },
+        uTransparent: { value: transparent },
+      },
+    });
+
+    const mesh = new Mesh(gl, { geometry, program });
+    let animateId: number;
+
+    function update(t: number) {
+      animateId = requestAnimationFrame(update);
+      if (!disableAnimation) {
+        program.uniforms.uTime.value = t * 0.001;
+        program.uniforms.uStarSpeed.value = (t * 0.001 * starSpeed) / 10.0;
+      }
+      const lerpFactor = 0.05;
+      smoothMousePos.x += (targetMousePos.x - smoothMousePos.x) * lerpFactor;
+      smoothMousePos.y += (targetMousePos.y - smoothMousePos.y) * lerpFactor;
+      smoothMouseActive.value += (targetMouseActive.value - smoothMouseActive.value) * lerpFactor;
+      program.uniforms.uMouse.value[0] = smoothMousePos.x;
+      program.uniforms.uMouse.value[1] = smoothMousePos.y;
+      program.uniforms.uMouseActiveFactor.value = smoothMouseActive.value;
+      renderer.render({ scene: mesh });
+    }
+    animateId = requestAnimationFrame(update);
+    ctn.appendChild(gl.canvas);
+
+    function handleMouseMove(e: MouseEvent) {
+      const rect = ctn.getBoundingClientRect();
+      const x = (e.clientX - rect.left) / rect.width;
+      const y = 1.0 - (e.clientY - rect.top) / rect.height;
+      targetMousePos.x = x;
+      targetMousePos.y = y;
+      targetMouseActive.value = 1.0;
+    }
+    function handleMouseLeave() {
+      targetMouseActive.value = 0.0;
+    }
+    function handleTouchMove(e: TouchEvent) {
+      const touch = e.touches[0];
+      const rect = ctn.getBoundingClientRect();
+      const x = (touch.clientX - rect.left) / rect.width;
+      const y = 1.0 - (touch.clientY - rect.top) / rect.height;
+      targetMousePos.x = x;
+      targetMousePos.y = y;
+      targetMouseActive.value = 1.0;
+    }
+
+    ctn.addEventListener("mousemove", handleMouseMove);
+    ctn.addEventListener("mouseleave", handleMouseLeave);
+    ctn.addEventListener("touchmove", handleTouchMove, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(animateId);
+      window.removeEventListener("resize", resize);
+      ctn.removeEventListener("mousemove", handleMouseMove);
+      ctn.removeEventListener("mouseleave", handleMouseLeave);
+      ctn.removeEventListener("touchmove", handleTouchMove);
+      if (ctn.contains(gl.canvas)) {
+        ctn.removeChild(gl.canvas);
+      }
+      gl.getExtension("WEBGL_lose_context")?.loseContext();
+    };
+  }, []);
+
+  return <div ref={ctnDom} className={className} aria-hidden="true" />;
+}

--- a/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
+++ b/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
@@ -164,13 +164,6 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
     if (!ctnDom.current) return;
     const ctn = ctnDom.current;
 
-    // 主题检测
-    const rootEl = document.documentElement;
-    const colorScheme = rootEl.getAttribute("data-color-scheme");
-    const prefersDark =
-      colorScheme === "dark" ||
-      (!colorScheme && window.matchMedia("(prefers-color-scheme: dark)").matches);
-
     // 无障碍：减弱动画
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
@@ -195,7 +188,11 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
     const targetMouseActive = { value: 0.0 };
     const smoothMouseActive = { value: 0.0 };
 
-    const renderer = new Renderer({ alpha: transparent, premultipliedAlpha: false });
+    const renderer = new Renderer({
+      alpha: transparent,
+      premultipliedAlpha: false,
+      dpr: Math.min(window.devicePixelRatio, 2),
+    });
     const gl = renderer.gl;
 
     if (transparent) {
@@ -294,6 +291,11 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
     ctn.addEventListener("mousemove", handleMouseMove);
     ctn.addEventListener("mouseleave", handleMouseLeave);
     ctn.addEventListener("touchmove", handleTouchMove, { passive: true });
+    function handleTouchEnd() {
+      targetMouseActive.value = 0.0;
+    }
+    ctn.addEventListener("touchend", handleTouchEnd);
+    ctn.addEventListener("touchcancel", handleTouchEnd);
 
     return () => {
       cancelAnimationFrame(animateId);
@@ -301,6 +303,8 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
       ctn.removeEventListener("mousemove", handleMouseMove);
       ctn.removeEventListener("mouseleave", handleMouseLeave);
       ctn.removeEventListener("touchmove", handleTouchMove);
+      ctn.removeEventListener("touchend", handleTouchEnd);
+      ctn.removeEventListener("touchcancel", handleTouchEnd);
       if (ctn.contains(gl.canvas)) {
         ctn.removeChild(gl.canvas);
       }

--- a/apps/negentropy-wiki/src/components/home/GalaxyHeroMount.tsx
+++ b/apps/negentropy-wiki/src/components/home/GalaxyHeroMount.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const GalaxyBackground = dynamic(
+  () => import("./GalaxyBackground").then((mod) => mod.GalaxyBackground),
+  { ssr: false, loading: () => null },
+);
+
+export function GalaxyHeroMount() {
+  return <GalaxyBackground className="home-hero-galaxy" />;
+}

--- a/apps/negentropy-wiki/src/styles/components/home-hero.css
+++ b/apps/negentropy-wiki/src/styles/components/home-hero.css
@@ -1,4 +1,4 @@
-/* 首页 Hero Banner — 液态流动渐变动画 */
+/* 首页 Hero Banner — Galaxy 星空背景 */
 .home-hero {
   position: relative;
   overflow: hidden;
@@ -8,31 +8,17 @@
   padding: 5rem 2rem 4rem;
 }
 
-.home-hero-bg {
+/* Galaxy WebGL 容器 */
+.home-hero-galaxy {
   position: absolute;
-  inset: -50%;
+  inset: 0;
   z-index: 0;
-  filter: blur(60px);
-  opacity: 0.85;
-  background:
-    radial-gradient(circle at 30% 40%, var(--wiki-hero-blob-1) 0%, transparent 70%),
-    radial-gradient(circle at 70% 60%, var(--wiki-hero-blob-2) 0%, transparent 70%);
-  animation: hero-drift-1 14s ease-in-out infinite alternate;
+  pointer-events: auto;
 }
-.home-hero-bg::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 80%, var(--wiki-hero-blob-3) 0%, transparent 70%);
-  animation: hero-drift-2 18s ease-in-out infinite alternate;
-}
-.home-hero-bg::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, var(--wiki-hero-blob-4) 0%, transparent 60%);
-  opacity: 0.5;
-  animation: hero-drift-3 22s ease-in-out infinite alternate;
+.home-hero-galaxy canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .home-hero-content {
@@ -73,29 +59,10 @@
   color: var(--wiki-home-accent);
 }
 
-@keyframes hero-drift-1 {
-  0%   { transform: translate(-20%, -15%) scale(1.1); }
-  33%  { transform: translate(10%, 25%) scale(0.95); }
-  66%  { transform: translate(25%, -10%) scale(1.05); }
-  100% { transform: translate(-10%, 20%) scale(1); }
-}
-@keyframes hero-drift-2 {
-  0%   { transform: translate(15%, 20%) scale(0.95); }
-  33%  { transform: translate(-25%, -5%) scale(1.1); }
-  66%  { transform: translate(5%, -20%) scale(1); }
-  100% { transform: translate(-15%, 15%) scale(1.05); }
-}
-@keyframes hero-drift-3 {
-  0%   { transform: translate(-10%, 10%) scale(1.05); }
-  50%  { transform: translate(20%, -25%) scale(0.9); }
-  100% { transform: translate(10%, 15%) scale(1.1); }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .home-hero-bg,
-  .home-hero-bg::before,
-  .home-hero-bg::after {
-    animation: none;
+  /* Galaxy 组件内部读取 prefers-reduced-motion 设置 disableAnimation */
+  .home-hero-galaxy {
+    pointer-events: none;
   }
 }
 
@@ -105,10 +72,6 @@
   }
   .home-hero-text {
     font-size: 1.25em;
-  }
-  .home-hero-bg {
-    filter: blur(40px);
-    inset: -30%;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,10 +174,10 @@ importers:
     dependencies:
       '@copilotkit/react-core':
         specifier: ^1.51.1
-        version: 1.57.4(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+        version: 1.57.4(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       '@copilotkit/react-ui':
         specifier: ^1.51.1
-        version: 1.57.4(@ag-ui/core@0.0.47)(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+        version: 1.57.4(@ag-ui/core@0.0.47)(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       '@copilotkit/runtime':
         specifier: ^1.51.1
         version: 1.57.4(@cfworker/json-schema@4.1.1)(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(ws@8.20.1))(@langchain/langgraph-sdk@1.9.5(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(ws@8.20.1))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@opentelemetry/api@1.9.1)(langchain@1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(ws@8.20.1))(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.4.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod-to-json-schema@3.25.2(zod@4.4.3))
@@ -220,7 +220,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.6(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -413,7 +413,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.6(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^28.0.0
         version: 28.1.0
@@ -465,6 +465,9 @@ importers:
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ogl:
+        specifier: ^1.0.11
+        version: 1.0.11
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -5882,6 +5885,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ogl@1.0.11:
+    resolution: {integrity: sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -7940,7 +7946,7 @@ snapshots:
 
   '@copilotkit/license-verifier@0.4.0': {}
 
-  '@copilotkit/react-core@1.57.4(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)':
+  '@copilotkit/react-core@1.57.4(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)':
     dependencies:
       '@ag-ui/client': 0.0.47
       '@ag-ui/core': 0.0.47
@@ -7981,9 +7987,9 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@copilotkit/react-ui@1.57.4(@ag-ui/core@0.0.47)(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)':
+  '@copilotkit/react-ui@1.57.4(@ag-ui/core@0.0.47)(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)':
     dependencies:
-      '@copilotkit/react-core': 1.57.4(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+      '@copilotkit/react-core': 1.57.4(@types/mdast@4.0.4)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(graphql@16.14.0)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       '@copilotkit/runtime-client-gql': 1.57.4(@ag-ui/core@0.0.47)(graphql@16.14.0)(react@19.2.3)
       '@copilotkit/shared': 1.57.4(@ag-ui/core@0.0.47)
       '@headlessui/react': 2.2.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -10222,7 +10228,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.41)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11383,26 +11389,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.6
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
-      globals: 16.4.0
-      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
@@ -11435,6 +11421,26 @@ snapshots:
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
       globals: 16.4.0
       typescript-eslint: 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-config-next@16.2.6(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.6
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
+      globals: 16.4.0
+      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11477,18 +11483,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -11511,35 +11506,6 @@ snapshots:
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
-      hasown: 2.0.3
-      is-core-module: 2.16.2
-      is-glob: 4.0.3
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
       - supports-color
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
@@ -11583,6 +11549,33 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      hasown: 2.0.3
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -13920,6 +13913,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obug@2.1.1: {}
+
+  ogl@1.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
 


### PR DESCRIPTION
## Summary

- 将 wiki 首页 Hero 区域的 CSS 液态渐变动画背景替换为基于 [reactbits.dev Galaxy](https://reactbits.dev/backgrounds/galaxy) 的 WebGL 星空粒子背景
- 使用 OGL（零依赖轻量 WebGL 库）+ GLSL Fragment Shader 实现 4 层视差深度星场渲染
- 支持鼠标排斥交互、触摸事件、色彩闪烁和缓慢自动旋转

## 变更内容

| 文件 | 变更 |
|------|------|
| `GalaxyBackground.tsx` | 新建 — WebGL 星空客户端组件（GLSL 着色器 + OGL 渲染） |
| `GalaxyHeroMount.tsx` | 新建 — `next/dynamic({ ssr: false })` 延迟装载器 |
| `page.tsx` | 修改 — 导入 GalaxyHeroMount，替换 hero-bg div |
| `home-hero.css` | 修改 — 移除旧渐变动画，替换为 Galaxy 容器样式 |
| `package.json` | 修改 — 添加 `ogl` 依赖 |

## 技术细节

- **SSR 兼容**：通过 `next/dynamic({ ssr: false })` 避免 Node.js 端执行 WebGL 代码
- **无障碍**：检测 `prefers-reduced-motion` 并冻结动画
- **移动端**：增加 `touchmove` 事件支持触摸交互
- **性能**：OGL 约 22KB gzip，通过动态导入实现代码分割

## Test plan

- [x] 浏览器打开 `localhost:3092` 验证星空渲染效果
- [x] 与 https://reactbits.dev/backgrounds/galaxy Preview 效果对比，视觉一致
- [x] 鼠标交互排斥效果正常
- [x] 文本（标题、副标题、CTA）在星空背景上清晰可读
- [x] 卡片区域、Header、Footer 功能不受影响
- [ ] 深色/浅色模式切换后效果正常
- [ ] 移动端响应式布局验证

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)