### PR TITLE
build(deps): 升级 mako/python-multipart 修复 2 个 HIGH 严重性 Dependabot 告警

### DIFF
--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -185,6 +185,6 @@ constraint-dependencies = [
     "filelock>=3.20.3",     # TOCTOU symlink 竞争 (medium)
     "orjson>=3.11.6",       # 无限递归 DoS (high)
     "google-cloud-aiplatform>=1.133.0", # 可预测 bucket 命名 (high)
-    "mako>=1.3.11",         # GHSA-v92g-xgxw-vvmm: TemplateLookup 双斜杠路径穿越 (medium, alembic 传递)
-    "python-multipart>=0.0.26", # GHSA-mj87-hwqh-73pj: 大型 preamble/epilogue DoS (medium, starlette 传递)
+    "mako>=1.3.12",         # GHSA-2h4p-vjrc-8xpq / CVE-2026-44307: Windows 反斜杠 URI TemplateLookup 路径穿越 (high, alembic 传递; 兼容 GHSA-v92g-xgxw-vvmm)
+    "python-multipart>=0.0.27", # GHSA-pp6c-gr5w-3c5g / CVE-2026-42561: MultipartParser 无界 part headers DoS (high, mcp/starlette 传递; 兼容 GHSA-mj87-hwqh-73pj)
 ]

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -16,7 +16,7 @@ constraints = [
     { name = "google-cloud-aiplatform", specifier = ">=1.133.0" },
     { name = "h2", specifier = ">=4.3.0" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "mako", specifier = ">=1.3.11" },
+    { name = "mako", specifier = ">=1.3.12" },
     { name = "markdown", specifier = ">=3.8.1" },
     { name = "markdownify", specifier = ">=0.14.1" },
     { name = "marshmallow", specifier = ">=3.26.2" },
@@ -29,7 +29,7 @@ constraints = [
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "pypdf", specifier = ">=6.10.0" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "starlette", specifier = ">=0.50.0" },
     { name = "tornado", specifier = ">=6.5.5" },
@@ -1117,14 +1117,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1952,11 +1952,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

GitHub Security 的 Dependabot 当前存在 **2 个 HIGH 严重性 (state=open) 漏洞告警**（[#94](https://github.com/ThreeFish-AI/negentropy/security/dependabot/94)、[#95](https://github.com/ThreeFish-AI/negentropy/security/dependabot/95)），均落在 `apps/negentropy/uv.lock` 内的**传递依赖**上。本 PR 通过最小化的 constraint-dependencies 调整，使 `uv lock` 重新求解时拉取已修复版本，关闭 2 个 HIGH 告警，同时不引入新问题。

## 漏洞清单

| Alert | CVE | 包 | 现版本 | 修复版本 | 引入路径 | 严重性 |
|-------|-----|-----|---------|----------|---------|---------|
| #94 | CVE-2026-44307 / GHSA-2h4p-vjrc-8xpq | `Mako` | 1.3.11 | **1.3.12** | `alembic → mako` | HIGH (CVSS 8.7) Windows 反斜杠路径穿越 |
| #95 | CVE-2026-42561 / GHSA-pp6c-gr5w-3c5g | `python-multipart` | 0.0.26 | **0.0.27** | `mcp/starlette → python-multipart` | HIGH (CVSS 7.5) multipart 头部解析 DoS |

## 变更内容

仅修改 `apps/negentropy/pyproject.toml` 的 `[tool.uv].constraint-dependencies` 两行，并由 `uv lock` 同步刷新 `apps/negentropy/uv.lock`：

```diff
-    "mako>=1.3.11",         # GHSA-v92g-xgxw-vvmm: TemplateLookup 双斜杠路径穿越 (medium, alembic 传递)
-    "python-multipart>=0.0.26", # GHSA-mj87-hwqh-73pj: 大型 preamble/epilogue DoS (medium, starlette 传递)
+    "mako>=1.3.12",         # GHSA-2h4p-vjrc-8xpq / CVE-2026-44307: Windows 反斜杠 URI TemplateLookup 路径穿越 (high, alembic 传递; 兼容 GHSA-v92g-xgxw-vvmm)
+    "python-multipart>=0.0.27", # GHSA-pp6c-gr5w-3c5g / CVE-2026-42561: MultipartParser 无界 part headers DoS (high, mcp/starlette 传递; 兼容 GHSA-mj87-hwqh-73pj)
```

`uv lock` 求解结果：
- `mako`: 1.3.11 → **1.3.12**
- `python-multipart`: 0.0.26 → **0.0.29**（uv 自动跃迁到符合约束的最新稳定版）

## 复用与不引入新问题的论证

- **复用现有机制**：复用 `[tool.uv].constraint-dependencies` 这一已经在项目中规范化的"传递依赖安全防御"机制（同一列表已经成功管控了 `urllib3` / `idna` / `pillow` / `starlette` / `protobuf` 等 30+ 个传递依赖），不引入新概念、新文件、新约束源。
- **变更爆炸半径最小**：仅 2 行 constraint 升级（patch 级），无 API、no behavior change；其他 30+ 条约束保持原状。
- **本地代码无入侵**：项目 `apps/negentropy/src/` 内**未直接 import mako 或 python-multipart**，仅由 alembic / mcp / starlette 间接使用，patch 版升级对调用方完全透明。
- **兄弟工作空间已验证**：`apps/cognizes` (0.0.29) 与 `apps/negentropy-perceives` (0.0.27) 早已运行在修复版本，无任何已知问题，可作为版本兼容性的旁证。
- **不影响其他 uv.lock**：`apps/cognizes/uv.lock`、`apps/negentropy-perceives/uv.lock` 均未在 Dependabot 告警列表中，本次不触碰。

## 测试计划 (Test Plan)

- [x] **依赖解析验证**：`uv lock` → `mako 1.3.12` / `python-multipart 0.0.29`
- [x] **Lockfile 一致性**：`uv sync --frozen` 通过，依赖与 lockfile 完全一致
- [x] **运行时 import 冒烟**：`mako` / `alembic` / `python-multipart` / `mcp.server.fastmcp` 全部 import 成功
- [x] **Lint 回归**：`uv run ruff check src/ tests/` → All checks passed
- [x] **Format 回归**：`uv run ruff format --check src/ tests/` → 512 files already formatted
- [x] **单元测试回归**：`uv run pytest tests/unit_tests/` → **1895/1898 passed**（3 个失败已确认为预先存在的环境/批量污染问题，stash 状态下同样复现，与本次升级无关）
- [ ] PR 合并后 Dependabot 在 24h 内自动 resolve Alert #94、#95