### PR TITLE
fix(wiki-header): 首页添加 Knowledge Graph 固定导航、统一标签命名并移除首页搜索组件

### DIFF
--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -10,7 +10,6 @@ import {
 import { WikiHeader } from "@/components/WikiHeader";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import { ThemePreference } from "@/components/ThemePreference";
-import { WikiSearchBox } from "@/components/WikiSearchBox";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { HomeCard } from "@/components/home/HomeCard";
 import { GalaxyHeroMount } from "@/components/home/GalaxyHeroMount";
@@ -85,12 +84,19 @@ export default async function WikiHomePage() {
 
   const firstHref = homeCards.length > 0 ? homeCards[0].href : undefined;
 
+  const firstPubSlug = publications.length > 0 ? publications[0].slug : undefined;
+
   const header = (
     <WikiHeader
       homeLinks={homeLinks}
       headerSlot={<ThemePreference />}
-      searchBox={<WikiSearchBox />}
       actions={<WikiHeaderActions />}
+      pubSlug={firstPubSlug}
+      graphTab={
+        firstPubSlug
+          ? { show: true, active: false, label: "Knowledge Graph" }
+          : undefined
+      }
     />
   );
 

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -83,7 +83,7 @@ export function WikiHeader({
               className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
               aria-current={graphTab.active ? "page" : undefined}
             >
-              {graphTab.label ?? "知识图谱"}
+              {graphTab.label ?? "Knowledge Graph"}
             </Link>
           )}
         </nav>


### PR DESCRIPTION
# 背景
- Wiki 首页 Header 缺少 Knowledge Graph 入口，用户需进入具体 Publication 后才能访问图谱功能；同时首页搜索组件定位与其他入口重叠，造成信息冗余
- 关联上下文：commit 6f97be42

# 核心变更
- **首页添加 Knowledge Graph 固定导航**：在 `page.tsx` 中从 `publications[0].slug` 提取 `firstPubSlug`，并作为 `graphTab` 传入 `WikiHeader`，条件守卫确保仅在存在 Publication 时渲染
- **统一标签命名**：将 `WikiHeader` 组件中 `graphTab.label` 的 fallback 从 `"知识图谱"` 改为 `"Knowledge Graph"`，与调用方显式传入的 label 保持一致
- **移除首页搜索组件**：从首页移除 `WikiSearchBox`，该组件仍保留在 Publication 详情页（`[pubSlug]/page.tsx`、`[...entrySlug]/page.tsx`）中正常使用

# 风险与回滚
- 主要风险：无已知功能回归，`graphTab` 与 `pubSlug` 的条件守卫保证空 Publication 场景下不会产生无效链接
- 回滚方式：`git revert 6f97be42`

# 验证证据
- 单元测试：无新增（UI 调整，Server Component 无逻辑变更）
- 集成测试：N/A
- E2E/Workflow：Code Review 已确认 props 传递、条件守卫、早返回逻辑均正确
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：`apps/negentropy-wiki/src/app/page.tsx`、`apps/negentropy-wiki/src/components/WikiHeader.tsx`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 可考虑为 Knowledge Graph tab 添加图标以增强视觉辨识度