### PR TITLE
fix(wiki-toc): 修复右栏 TOC 折叠按钮箭头方向错误

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiToc.tsx
+++ b/apps/negentropy-wiki/src/components/WikiToc.tsx
@@ -165,7 +165,7 @@ function CollapseIcon() {
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <polyline points="11 3 5 8 11 13" />
+      <polyline points="5 3 11 8 5 13" />
     </svg>
   );
 }


### PR DESCRIPTION
# 背景

- **问题**：Wiki 右栏 TOC（目录）面板展开态的折叠按钮箭头指向左侧 ❮，与右侧面板的折叠语义（向右边缘收缩）不一致
- **关联**：commit `da8e059a`

# 核心变更

- 修正 `CollapseIcon` SVG `<polyline>` 坐标：`11 3 5 8 11 13`（左向 ❮）→ `5 3 11 8 5 13`（右向 ❯）
- TOC 位于三栏布局（`sidebar | content | TOC`）的第三列，折叠操作应使用右向箭头 ❯，符合"向右收缩"的 UI 约定

# 风险与回滚

- **主要风险**：无，纯视觉图标方向修正，不涉及任何逻辑变更
- **回滚方式**：`git revert` 单一提交即可

# 验证证据

- **单元测试**：不涉及
- **集成测试**：不涉及
- **E2E/Workflow**：浏览器实机目视验证
- **覆盖截图**：右向箭头与右侧面板折叠语义一致

# 影响范围

- **前端**：`WikiToc.tsx` → `CollapseIcon` 组件
- **后端**：无
- **CI / 文档**：无

# Next Best Action

- 合并后在浏览器中验证折叠/展开交互体验的视觉一致性