### PR TITLE
fix(consolidation): 补建 consolidation_jobs 表并消除 autogenerate 索引漂移，修复 Maintenance Consolidation 持续失败

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/env.py
+++ b/apps/negentropy/src/negentropy/db/migrations/env.py
@@ -83,6 +83,9 @@ _IGNORED_INDEXES = frozenset(
         "ix_negentropy_knowledge_search_vector",  # GIN 索引 (TSVECTOR)
         "ix_knowledge_documents_file_hash",  # 命名与 ORM 自动生成的不一致
         "ix_kg_entities_embedding",  # HNSW 索引 (需 ALTER COLUMN 后手动创建)
+        "idx_consolidation_jobs_status",  # consolidation_jobs 索引由迁移 0044 持有
+        "idx_consolidation_jobs_thread",  # 同上
+        "idx_consolidation_jobs_pending",  # 部分索引 (WHERE status = 'pending')，同上
     }
 )
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0044_create_consolidation_jobs.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0044_create_consolidation_jobs.py
@@ -1,0 +1,108 @@
+"""创建 negentropy.consolidation_jobs 表 — 补齐 0043 函数缺失的依赖表
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-05-29 00:00:00.000000+00:00
+
+设计动机：
+    迁移 0043 将 SQL 函数 ``trigger_maintenance_consolidation`` 静态化进 negentropy
+    schema，其函数体 ``INSERT INTO negentropy.consolidation_jobs ...``，但建表语句
+    从未随之迁入——该表的权威定义只存在于 cognizes 应用的 hippocampus_schema.sql
+    （无 schema 前缀）。导致 Scheduler「Maintenance Consolidation」任务每次触发即报
+    ``UndefinedTableError: relation "negentropy.consolidation_jobs" does not exist``，
+    已连续失败 25 次。
+
+    本迁移在 negentropy schema 内补建 ``consolidation_jobs`` 表，列定义 1:1 对齐
+    cognizes 权威定义，使 0043 的函数得以正常入队。表结构由配套 ORM 模型
+    ``models.internalization.ConsolidationJob`` 镜像，避免 autogenerate 漂移。
+
+幂等性：
+    建表前以 information_schema 探测存在性（仿 0035），便于半失败重试。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0044"
+down_revision: str | None = "0043"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            f"WHERE table_schema = '{SCHEMA}' AND table_name = 'consolidation_jobs'"
+        )
+    ).scalar()
+    if exists:
+        return
+
+    op.create_table(
+        "consolidation_jobs",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "thread_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(f"{SCHEMA}.threads.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("job_type", sa.String(length=50), nullable=False),
+        sa.Column("result", postgresql.JSONB(), nullable=True, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_consolidation_jobs_status",
+        "consolidation_jobs",
+        ["status"],
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_consolidation_jobs_thread",
+        "consolidation_jobs",
+        ["thread_id"],
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_consolidation_jobs_pending",
+        "consolidation_jobs",
+        ["created_at"],
+        schema=SCHEMA,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    exists = bind.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            f"WHERE table_schema = '{SCHEMA}' AND table_name = 'consolidation_jobs'"
+        )
+    ).scalar()
+    if not exists:
+        return
+
+    op.drop_index("idx_consolidation_jobs_pending", table_name="consolidation_jobs", schema=SCHEMA)
+    op.drop_index("idx_consolidation_jobs_thread", table_name="consolidation_jobs", schema=SCHEMA)
+    op.drop_index("idx_consolidation_jobs_status", table_name="consolidation_jobs", schema=SCHEMA)
+    op.drop_table("consolidation_jobs", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -1,7 +1,7 @@
 from .action import Tool, ToolExecution
 from .base import DEFAULT_EMBEDDING_DIM, NEGENTROPY_SCHEMA, Base, TimestampMixin, Vector, fk
 from .builtin_tool import BuiltinTool
-from .internalization import Fact, Memory, MemoryAuditLog, MemoryAutomationConfig
+from .internalization import ConsolidationJob, Fact, Memory, MemoryAuditLog, MemoryAutomationConfig
 from .knowledge_runtime import KnowledgeGraphRun, KnowledgePipelineRun
 from .mcp import McpResourceTemplate, McpServer, McpTool
 from .mcp_runtime import McpToolRun, McpToolRunEvent, McpTrialAsset
@@ -52,6 +52,7 @@ __all__ = [
     "Fact",
     "MemoryAuditLog",
     "MemoryAutomationConfig",
+    "ConsolidationJob",
     # Action
     "Tool",
     "ToolExecution",

--- a/apps/negentropy/src/negentropy/models/internalization.py
+++ b/apps/negentropy/src/negentropy/models/internalization.py
@@ -283,7 +283,9 @@ class ConsolidationJob(Base, UUIDMixin):
     ``full_consolidation`` 待处理任务；消费侧负责取出 ``pending`` 任务执行巩固。
 
     模型与迁移 0044 的 ``negentropy.consolidation_jobs`` 建表语句逐列对齐，
-    作为该表的单一事实源，避免 autogenerate 将其视为孤儿表而误删。索引由迁移持有。
+    作为该表的单一事实源，避免 autogenerate 将其视为孤儿表而误删。索引由迁移 0044
+    持有（含 ``idx_consolidation_jobs_pending`` 部分索引），并已在 ``migrations/env.py``
+    的 ``_IGNORED_INDEXES`` 登记，以免 autogenerate 反向发出 ``drop_index``。
 
     参考文献:
     [1] S. J. Sara, "Reconsolidation and the stability of memory traces,"

--- a/apps/negentropy/src/negentropy/models/internalization.py
+++ b/apps/negentropy/src/negentropy/models/internalization.py
@@ -274,3 +274,33 @@ class MemoryCoreBlock(Base, UUIDMixin):
         ),
         {"schema": NEGENTROPY_SCHEMA},
     )
+
+
+class ConsolidationJob(Base, UUIDMixin):
+    """会话巩固任务队列（Consolidation Job Queue）
+
+    SQL 函数 ``trigger_maintenance_consolidation`` 按时间窗口为活跃 thread 入队
+    ``full_consolidation`` 待处理任务；消费侧负责取出 ``pending`` 任务执行巩固。
+
+    模型与迁移 0044 的 ``negentropy.consolidation_jobs`` 建表语句逐列对齐，
+    作为该表的单一事实源，避免 autogenerate 将其视为孤儿表而误删。索引由迁移持有。
+
+    参考文献:
+    [1] S. J. Sara, "Reconsolidation and the stability of memory traces,"
+        Current Opinion in Neurobiology, vol. 35, pp. 110-115, 2015.
+    """
+
+    __tablename__ = "consolidation_jobs"
+
+    thread_id: Mapped[UUID] = mapped_column(
+        ForeignKey(f"{NEGENTROPY_SCHEMA}.threads.id", ondelete="CASCADE"), nullable=False
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending", server_default="'pending'")
+    job_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    result: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
+    error: Mapped[str | None] = mapped_column(Text)
+    started_at: Mapped[datetime | None] = mapped_column(TIMESTAMP, nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+    __table_args__ = ({"schema": NEGENTROPY_SCHEMA},)

--- a/apps/negentropy/tests/integration_tests/db/test_consolidation_jobs.py
+++ b/apps/negentropy/tests/integration_tests/db/test_consolidation_jobs.py
@@ -1,0 +1,71 @@
+"""回归测试：consolidation_jobs 表存在性 + trigger_maintenance_consolidation 可执行。
+
+复现并证伪 Scheduler「Maintenance Consolidation」连续失败的根因——迁移 0043 引入的
+函数 ``negentropy.trigger_maintenance_consolidation`` 在函数体内引用
+``negentropy.consolidation_jobs``，而该表此前从未被任何迁移创建，触发即报
+``UndefinedTableError``。迁移 0044 补建该表后，本测试断言：
+
+1. ``negentropy.consolidation_jobs`` 表存在；
+2. handler 实际下发的报错 SQL 可正常执行并返回整数（不再抛 UndefinedTableError）。
+"""
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from negentropy.config import settings
+
+
+def _sync_database_url() -> str:
+    return str(settings.database_url).replace("postgresql+asyncpg", "postgresql+psycopg")
+
+
+@pytest.fixture
+def alembic_config() -> Config:
+    """Returns an Alembic configuration object."""
+    return Config("alembic.ini")
+
+
+def test_consolidation_jobs_table_exists_after_upgrade(alembic_config: Config):
+    """迁移到 head 后，negentropy.consolidation_jobs 表应存在。"""
+    command.upgrade(alembic_config, "head")
+
+    engine = create_engine(_sync_database_url())
+    try:
+        with engine.begin() as conn:
+            exists = conn.execute(
+                text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = 'negentropy' AND table_name = 'consolidation_jobs'"
+                )
+            ).scalar()
+    finally:
+        engine.dispose()
+
+    assert exists, "negentropy.consolidation_jobs 表应由迁移 0044 创建"
+
+
+def test_trigger_maintenance_consolidation_executes(alembic_config: Config):
+    """复现 handler 下发的报错 SQL：应成功执行并返回入队计数（非负整数）。
+
+    使用事务回滚，避免向集成库写入测试巩固任务。
+    """
+    command.upgrade(alembic_config, "head")
+
+    engine = create_engine(_sync_database_url())
+    try:
+        with engine.connect() as conn:
+            trans = conn.begin()
+            try:
+                count = conn.execute(
+                    text("SELECT negentropy.trigger_maintenance_consolidation(CAST(:lookback AS interval))"),
+                    {"lookback": "1 hour"},
+                ).scalar()
+            finally:
+                trans.rollback()
+    finally:
+        engine.dispose()
+
+    assert isinstance(count, int)
+    assert count >= 0


### PR DESCRIPTION
## 背景

Interface / Scheduler 下的 **Maintenance Consolidation** 任务（`key=memory_consolidation`，cron `0 * * * *`）持续异常，已连续失败 **25 次**，每小时触发即报：

```
asyncpg.exceptions.UndefinedTableError: relation "negentropy.consolidation_jobs" does not exist
[SQL: SELECT negentropy.trigger_maintenance_consolidation(CAST($1 AS interval))]
[parameters: (datetime.timedelta(seconds=3600),)]
```

## 根因

调用链 `Scheduler → handler "memory_automation" → _run_consolidation() → SQL trigger_maintenance_consolidation()` 完整且正确，唯独**缺一张表**：

- 迁移 **0043** 将 `trigger_maintenance_consolidation` 函数静态化进 `negentropy` schema，函数体执行 `INSERT INTO negentropy.consolidation_jobs ...`；
- 但**没有任何迁移创建 `negentropy.consolidation_jobs` 表**——该表的权威定义只存在于 `apps/cognizes/.../hippocampus_schema.sql`（无 schema 前缀，属 cognizes 应用，且配套有消费 worker）；
- 即 0043 从 cognizes 的 hippocampus 设计中**只搬运了函数、漏搬了它依赖的表**（典型迁移完整性缺陷 / split-brain）。`negentropy.threads` 表及 `id(UUID)`/`updated_at` 列均已存在，函数其余引用成立，唯一缺口就是这张表。

## 修复方案（最小且符合 SSOT）

1. **新增迁移 `0044`**：在 `negentropy` schema 补建 `consolidation_jobs` 表及 3 个索引，列定义 1:1 对齐权威定义；建表前以 `information_schema` 探测存在性（仿 0035 幂等风格），`downgrade()` 可逆。
2. **新增 ORM 模型 `ConsolidationJob`**（`models/internalization.py`）并在 `models/__init__.py` 导出，作为该表的单一事实源，避免日后 `alembic autogenerate` 将其当作孤儿表误删（split-brain 防护）。
3. **新增回归集成测试** `tests/integration_tests/db/test_consolidation_jobs.py`：迁移到 head 后断言表存在，并复现 handler 实际下发的报错 SQL 可成功执行。
4. **消除 autogenerate 索引漂移（代码评审追加）**：0044 创建的 3 个索引（`idx_consolidation_jobs_status` / `_thread` / `_pending`）此前既未在模型声明、也未登记到 `migrations/env.py` 的 `_IGNORED_INDEXES`，经实测 `alembic revision --autogenerate` 会反向对其发出 `op.drop_index`（表本身因有 ORM 模型而不会被误删，符合预期）。其中 `_pending` 为**部分索引**，PostgreSQL 会将谓词归一化为 `((status)::text = 'pending'::text)`，模型侧 `postgresql_where` 无法字符串匹配（与既有 `idx_kb_entity_type` 同类），故按既定范式将 3 个索引名补登进 `_IGNORED_INDEXES`，并在 `ConsolidationJob` docstring 标注其登记位置，使「索引由迁移持有」的设计意图自解释。

## 验证

- `ruff check` / `ruff format`、pre-commit hooks：通过；
- `test_scheduler_handlers.py` 34 项单测：通过（含 `TestConsolidationHandler`）；
- ORM 元数据自检：表/列/PK/FK(CASCADE)/NOT NULL/默认值均正确；Alembic 单一线性 head = `0044`；
- 迁移已应用至本地库（`0043 → 0044`），`consolidation_jobs` 表及 3 索引创建成功；
- 以 `timedelta(seconds=3600)` 精确复现原报错语句，返回 `0`，**不再抛 UndefinedTableError**；
- 新增 2 项集成回归测试 `test_consolidation_jobs.py` 对实库通过；
- handler 全链路 `memory_automation_handler` 返回 `status=ok`；
- **索引漂移修复实测**：补登 `_IGNORED_INDEXES` 后，`alembic revision --autogenerate` 对 `consolidation_jobs` **零漂移**（修复前会发出 3 条 `op.drop_index`），不再向自动生成产物注入噪声。

部署后该任务将在下次触发（或「Run Now」）恢复正常，`consecutive_failures` 归 0。

## 二阶影响说明（非本 bug 范畴）

negentropy 应用内目前**没有消费者**处理这些 `pending` job（消费 worker 仅存在于 cognizes）。建表后任务恢复其「按时间窗口批量入队」的既定职责，入队 job 在 negentropy 侧暂以小体量累积（函数自带 1h 去重窗口，增量有界）。是否补 negentropy 侧消费者属独立功能演进，不在本次范围。
