### PR TITLE
refactor(KnowledgeNav): Wiki 二级导航项迁移并移除冗余 catalog 别名;

### DIFF
--- a/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
+++ b/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
@@ -30,15 +30,14 @@ export function KnowledgeNav({
     };
   }, [title, setNavigationInfo]);
 
-  const isActive = (href: string, aliases?: string[]) =>
-    pathname.startsWith(href) || (aliases?.some((a) => pathname.startsWith(a)) ?? false);
+  const isActive = (href: string) => pathname.startsWith(href);
 
   return (
     <div className="border-b border-border bg-card px-6 py-1">
       <div className="flex flex-wrap items-center justify-center gap-4">
         <nav className="flex items-center gap-1 bg-muted/50 p-1 rounded-full">
           {NAV_ITEMS.map((item) => {
-            const active = isActive(item.href, item.aliases);
+            const active = isActive(item.href);
             return (
               <Link
                 key={item.href}

--- a/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
+++ b/apps/negentropy-ui/components/ui/KnowledgeNav.tsx
@@ -8,9 +8,9 @@ import { useNavigation } from "@/components/providers/NavigationProvider";
 const NAV_ITEMS = [
   { href: "/knowledge/base", label: "Knowledge Base" },
   { href: "/knowledge/graph", label: "Knowledge Graph" },
-  { href: "/knowledge/wiki", label: "Wiki", aliases: ["/knowledge/catalog"] },
   { href: "/knowledge/documents", label: "Documents" },
   { href: "/knowledge/apis", label: "APIs" },
+  { href: "/knowledge/wiki", label: "Wiki" },
   { href: "/knowledge/pipelines", label: "Pipelines" },
 ];
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge 模块二级导航中 Wiki 项位置不合理，且其携带的 `aliases: ["/knowledge/catalog"]` 属永不命中的死代码，需调整顺序并清理冗余。
- 关联上下文/Issue/文档：续接 `e6bcf9dd`（SubAgents→Agents 更名与二级导航顺序调整）的导航整理工作。

# 核心变更
- 将 `NAV_ITEMS` 中 Wiki 项从 Knowledge Graph 之后下移至 APIs 与 Pipelines 之间，顺序调整为 Knowledge Base → Knowledge Graph → Documents → APIs → Wiki → Pipelines。
- 移除 Wiki 项的 `aliases: ["/knowledge/catalog"]`：`/knowledge/catalog` 为服务端 `redirect` 路由（`app/knowledge/catalog/page.tsx`），渲染前即跳转至 `/knowledge/wiki`，该别名从不命中高亮逻辑；catalog 重定向路由本身保持不变。
- 同步清理 `isActive` 已失效的 `aliases` 形参、别名匹配逻辑及调用处实参——删除全部 `aliases` 后 TS 将元素类型收窄为 `{ href; label }`，残留的 `item.aliases` 引用会触发 TS2339，阻断 `next build` 与 CI 类型检查，故一并消除。

# 风险与回滚
- 主要风险：极低；单文件 UI 导航改动，不涉及路由/数据/接口，catalog 重定向链路未触碰。
- 回滚方式：`git revert fe5930cb 5c29a318`，或直接还原 `KnowledgeNav.tsx`。

# 验证证据
- 单元测试：`tests/unit/ui/KnowledgeNav.test.tsx` 2/2 通过（Pipelines 高亮、容器 `justify-center` 不变量）。
- 集成测试：不涉及。
- E2E/Workflow：不涉及。
- 覆盖率/关键截图：`pnpm exec tsc --noEmit` 对该文件类型错误归零；pre-commit（ESLint negentropy-ui）全绿。

# 影响范围
- 前端：仅 `apps/negentropy-ui/components/ui/KnowledgeNav.tsx`（Knowledge 二级导航渲染）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后实机回归一次 `/knowledge/catalog` → `/knowledge/wiki` 重定向与各二级导航高亮，确认视觉顺序符合预期。
