### PR TITLE
feat(scheduler-executions): Executions 时间倒序分页（每页 10 条）+ 历史浏览冻结防抖;

### DIFF
--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
@@ -72,6 +72,9 @@ export function SchedulerExecutionPanel({
 }: SchedulerExecutionPanelProps) {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
+  // 历史浏览快照：用户翻到第 2 页及以后时锁定当前数据集，使 SSE 实时插入 / 轮询刷新
+  // 不再重排行序、造成翻页抖动；停留或返回第 1 页时为 null，始终呈现最新数据。
+  const [frozen, setFrozen] = useState<TaskExecutionDTO[] | null>(null);
 
   // 按状态过滤 + 防御性时间倒序（后端已倒序，此处确保契约稳健；null 视为最旧排末位）
   const filtered = useMemo(() => {
@@ -86,17 +89,31 @@ export function SchedulerExecutionPanel({
     });
   }, [executions, statusFilter]);
 
+  // 有效视图：冻结态渲染历史快照，否则跟随最新过滤结果。计数 / 分页 / 空态统一以此为准。
+  const view = frozen ?? filtered;
+
   // 客户端切片分页（默认每页 10 条）
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(view.length / PAGE_SIZE));
   const safePage = Math.min(currentPage, totalPages);
-  const paged = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+  const paged = view.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  // 翻页：离开第 1 页时冻结当前快照，回到第 1 页时解冻并重新同步实时数据。
+  const goToPage = (target: number) => {
+    const next = Math.min(totalPages, Math.max(1, target));
+    if (next === 1) {
+      setFrozen(null);
+    } else if (safePage === 1) {
+      setFrozen(filtered);
+    }
+    setCurrentPage(next);
+  };
 
   return (
     <div className="rounded-xl border border-border bg-card shadow-sm">
       {/* Status filter pills */}
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
-          Executions ({filtered.length})
+          Executions ({view.length})
         </span>
         <div className="flex items-center bg-muted/50 p-0.5 rounded-full">
           {STATUS_FILTERS.map((sf) => (
@@ -105,6 +122,7 @@ export function SchedulerExecutionPanel({
               onClick={() => {
                 setStatusFilter(sf.key);
                 setCurrentPage(1);
+                setFrozen(null);
               }}
               className={`px-3 py-0.5 rounded-full text-[10px] font-medium transition-colors ${
                 statusFilter === sf.key
@@ -133,7 +151,7 @@ export function SchedulerExecutionPanel({
           <tbody>
             {loading && executions.length === 0 ? (
               Array.from({ length: 10 }).map((_, i) => <SkeletonRow key={i} />)
-            ) : filtered.length === 0 ? (
+            ) : view.length === 0 ? (
               <tr>
                 <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
                   No executions match the current filter.
@@ -177,13 +195,13 @@ export function SchedulerExecutionPanel({
       </div>
 
       {/* Pagination */}
-      {filtered.length > PAGE_SIZE && (
+      {view.length > PAGE_SIZE && (
         <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
           <button
             type="button"
             disabled={safePage <= 1}
-            onClick={() => setCurrentPage(Math.max(1, safePage - 1))}
-            aria-label="上一页"
+            onClick={() => goToPage(safePage - 1)}
+            aria-label="Previous page"
             className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
           >
             <ChevronLeft className="h-3.5 w-3.5" />
@@ -194,8 +212,8 @@ export function SchedulerExecutionPanel({
           <button
             type="button"
             disabled={safePage >= totalPages}
-            onClick={() => setCurrentPage(Math.min(totalPages, safePage + 1))}
-            aria-label="下一页"
+            onClick={() => goToPage(safePage + 1)}
+            aria-label="Next page"
             className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
           >
             <ChevronRight className="h-3.5 w-3.5" />

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
 import type { ExecutionStatus, TaskExecutionDTO } from "@/features/scheduler";
 
 interface SchedulerExecutionPanelProps {
@@ -10,6 +12,8 @@ interface SchedulerExecutionPanelProps {
 }
 
 type StatusFilter = "all" | ExecutionStatus;
+
+const PAGE_SIZE = 10;
 
 const STATUS_FILTERS: { key: StatusFilter; label: string }[] = [
   { key: "all", label: "All" },
@@ -67,11 +71,25 @@ export function SchedulerExecutionPanel({
   loading,
 }: SchedulerExecutionPanelProps) {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [currentPage, setCurrentPage] = useState(1);
 
+  // 按状态过滤 + 防御性时间倒序（后端已倒序，此处确保契约稳健；null 视为最旧排末位）
   const filtered = useMemo(() => {
-    if (statusFilter === "all") return executions;
-    return executions.filter((e) => e.status === statusFilter);
+    const base =
+      statusFilter === "all"
+        ? executions
+        : executions.filter((e) => e.status === statusFilter);
+    return [...base].sort((a, b) => {
+      const ta = a.started_at ? Date.parse(a.started_at) : -Infinity;
+      const tb = b.started_at ? Date.parse(b.started_at) : -Infinity;
+      return tb - ta;
+    });
   }, [executions, statusFilter]);
+
+  // 客户端切片分页（默认每页 10 条）
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paged = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
 
   return (
     <div className="rounded-xl border border-border bg-card shadow-sm">
@@ -84,7 +102,10 @@ export function SchedulerExecutionPanel({
           {STATUS_FILTERS.map((sf) => (
             <button
               key={sf.key}
-              onClick={() => setStatusFilter(sf.key)}
+              onClick={() => {
+                setStatusFilter(sf.key);
+                setCurrentPage(1);
+              }}
               className={`px-3 py-0.5 rounded-full text-[10px] font-medium transition-colors ${
                 statusFilter === sf.key
                   ? "bg-foreground text-background shadow-sm ring-1 ring-border"
@@ -119,7 +140,7 @@ export function SchedulerExecutionPanel({
                 </td>
               </tr>
             ) : (
-              filtered.map((e) => (
+              paged.map((e) => (
                 <tr
                   key={e.id}
                   className="border-b border-border last:border-b-0 hover:bg-muted/30 transition-colors"
@@ -154,6 +175,33 @@ export function SchedulerExecutionPanel({
           </tbody>
         </table>
       </div>
+
+      {/* Pagination */}
+      {filtered.length > PAGE_SIZE && (
+        <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
+          <button
+            type="button"
+            disabled={safePage <= 1}
+            onClick={() => setCurrentPage(Math.max(1, safePage - 1))}
+            aria-label="上一页"
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </button>
+          <span className="text-[10px] font-medium text-muted-foreground">
+            {safePage} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={safePage >= totalPages}
+            onClick={() => setCurrentPage(Math.min(totalPages, safePage + 1))}
+            aria-label="下一页"
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Scheduler 的 Executions 列表此前一次性渲染全部记录、无分页，且顺序完全依赖后端契约；记录增多后可读性与可控性下降。在引入分页后，还需消除实时数据流（SSE 插入 + 30s 轮询刷新）在「浏览历史」时造成的行错位抖动。
- 关联上下文/Issue/文档：基于本工作区代码评审的两项非阻断观察（翻页抖动、文案一致性）落地修复。

# 核心变更
- **时间倒序分页**：Executions 按 `started_at` 客户端切片分页，默认每页 10 条；防御性排序使后端契约波动下顺序仍稳健（`null` 视为最旧、排末位）。
- **历史浏览冻结防抖**：用户翻到第 2 页及以后即冻结当前数据快照，SSE/轮询刷新不再重排行序；第 1 页恒为实时，返回首页或切换状态过滤时自动解冻并重新同步最新数据。
- **派生一致性 + 文案统一**：计数 / 分页 / 空态统一以有效视图 `view` 为准，避免 live 与 frozen 混用导致的页码与计数错位；分页 `aria-label` 统一为英文（Previous/Next page）。

# 风险与回滚
- 主要风险：冻结是「刻意且有界」的陈旧——浏览历史期间不反映新插入（第 1 页始终实时，返回即同步）；纯前端叶子组件改动，不触碰数据 hook，无后端/契约影响。
- 回滚方式：`git revert eb2d1217 1e686a09` 即可完全恢复原行为，无数据迁移。

# 验证证据
- 单元测试：本次未新增（纯展示层交互逻辑）。
- 集成测试：N/A。
- E2E/Workflow：未跑实机；已对翻页/冻结/解冻/过滤切换/数据增减等 9 个场景逐条推演，无空白页与计数错位。
- 覆盖率/关键截图：`pnpm typecheck` Exit 0、`eslint` Exit 0、pre-commit hooks 全 Passed。

# 影响范围
- 前端：`apps/negentropy-ui` Scheduler Executions 面板（`SchedulerExecutionPanel.tsx`，单文件 +72/−6）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 可选实机回归：alt-port dev server 复用真实登录态，验证「第 2 页停留 + 新执行流入 → 行不抖动、回首页见最新」。
- 如需，可补充 Executions 面板轻量交互单测（分页边界 + 冻结/解冻）。