### PR TITLE
fix(wiki-home): 首页卡片区域高度随内容自适应，消除页脚白条;

### DIFF
--- a/apps/negentropy-wiki/src/styles/layout.css
+++ b/apps/negentropy-wiki/src/styles/layout.css
@@ -142,10 +142,27 @@
 }
 
 /* Home variant: full-width single column（Hero 需全幅出血，不受容器约束） */
+/*
+ * 首页最底层背景填深色（与页脚同色）—— 仅当页面含首页布局时命中（`:has()` 作用域隔离，
+ * 内容页不受影响）。配合下方移除 `.wiki-layout--home` 的 min-height：高视口短内容时，
+ * 页脚下方的余白不再露出 body 的浅色背景，而是与深色页脚无缝衔接，避免「白条」回归。
+ */
+#wiki-root:has(.wiki-layout--home) {
+  min-height: 100vh;
+  background: var(--wiki-footer-bg);
+}
+
+/*
+ * 不再强制撑满视口：显式 `min-height: 0` 覆写基类 `.wiki-layout` 的 `min-height: 100vh`
+ *（首页元素同时持有 `wiki-layout wiki-layout--home` 两个类）。高度回归内容自适应——
+ * 卡片区上下间隙由 `.home-cards-section` 的对称 padding 决定（各 48px），页脚紧随其后。
+ * 显式声明 body 同色背景，避免被上方 `#wiki-root` 的深色底透出（浅色模式卡片区应为白）。
+ */
 .wiki-layout--home {
   display: block;
   max-width: 100%;
-  min-height: calc(100vh - var(--wiki-header-height));
+  min-height: 0;
+  background: var(--wiki-bg);
 }
 .wiki-main--home {
   max-width: 100%;


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：首页卡片区域被 `min-height: calc(100vh - var(--wiki-header-height))` 强制撑满视口，导致内容不足时页脚与视口底部之间出现「白条」间隙。
- 关联上下文/文档：基于 commit 49b84b21 的延续优化。

# 核心变更
- 移除 `.wiki-layout--home` 的 `min-height: calc(100vh - var(--wiki-header-height))`，改为 `min-height: 0`，高度回归内容自适应；
- 新增 `#wiki-root:has(.wiki-layout--home)` 规则，在首页作用域内为根容器填充与页脚同色的深色背景（`var(--wiki-footer-bg)`），短内容时页脚下余白不再露出浅色「白条」；
- 为 `.wiki-layout--home` 显式声明 `background: var(--wiki-bg)`，防止 `#wiki-root` 深色背景透出到卡片区；
- 利用 `:has()` 伪类实现作用域隔离，内容页完全不受影响。

# 风险与回滚
- 主要风险：`:has()` 伪类需 Chrome 105+、Firefox 121+、Safari 15.4+ 支持，极低版本浏览器不生效（降级为旧行为，不报错）。
- 回滚方式：`git revert` 本 commit 即可恢复。

# 验证证据
- 单元测试：N/A（纯 CSS 变更）
- 集成测试：N/A
- E2E/Workflow：已通过浏览器实机验证（短内容/长内容/明暗模式均无白条回归）。

# 影响范围
- 前端：`apps/negentropy-wiki/src/styles/layout.css`（仅首页布局）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 可视情况在 wiki 首页补充响应式断点下的 padding 微调（当前 480px 以下已降为 2rem）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)