### PR TITLE
feat(home-studio): 右栏 State 抽屉化（非模态浮层 800px）+ 四区 UI/UX 精修

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -19,10 +19,8 @@ import type { MentionCandidate, MentionToken } from "@negentropy/agents-chat-cor
 import { deriveForwardedPropsFromMentions } from "@negentropy/agents-chat-core/parse";
 import { useAgentsList } from "@/hooks/useAgentsList";
 import { useCorporaList } from "@/app/knowledge/apis/_components/hooks/useCorporaList";
-import { EventTimeline } from "../components/ui/EventTimeline";
-import { LogBufferPanel } from "../components/ui/LogBufferPanel";
 import { SessionList } from "../components/ui/SessionList";
-import { StateSnapshot } from "../components/ui/StateSnapshot";
+import { StateDrawer } from "../components/ui/StateDrawer";
 import { CHAT_CONTENT_RAIL_CLASS } from "../components/ui/chat-layout";
 import { useSessionListService } from "@/features/session/hooks/useSessionListService";
 import { useSessionService } from "@/features/session/hooks/useSessionService";
@@ -119,6 +117,43 @@ function writePersistedThinking(
   try {
     window.localStorage.setItem(
       `${LOCAL_THINKING_KEY_PREFIX}${sessionId}`,
+      value ? "1" : "0",
+    );
+  } catch {
+    // localStorage 不可用时静默降级到内存态。
+  }
+}
+
+/**
+ * 右栏 State 抽屉开合状态的本地持久化键（按 sessionId 命名空间隔离）。
+ *
+ * 与 LLM/Thinking 不同，抽屉开合纯属浏览器侧布局偏好，不与后端 session.state 镜像，
+ * 故仅需「切会话时读取 + 状态变化时写回」两个 Effect，无需 pending/per-thread/snapshot 链路。
+ */
+const LOCAL_RIGHT_PANEL_KEY_PREFIX = "negentropy:home:right-panel:";
+
+function readPersistedRightPanel(sessionId: string | null): boolean | null {
+  if (!sessionId || typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(
+      `${LOCAL_RIGHT_PANEL_KEY_PREFIX}${sessionId}`,
+    );
+    if (raw === "1") return true;
+    if (raw === "0") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersistedRightPanel(
+  sessionId: string | null,
+  value: boolean,
+): void {
+  if (!sessionId || typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      `${LOCAL_RIGHT_PANEL_KEY_PREFIX}${sessionId}`,
       value ? "1" : "0",
     );
   } catch {
@@ -613,17 +648,20 @@ export function HomeBody({
     ],
   );
 
-  // Escape key to return to live view
+  // Escape 分层：① 历史视图下先返回实时（抽屉不关）；② 否则关闭抽屉。
+  // 对齐嵌套可关闭 UI 的逐层退出直觉（参考 OverlayDismissLayer 的 escape 栈语义）。
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && selectedNodeId) {
+      if (e.key !== "Escape") return;
+      if (selectedNodeId) {
         setSelectedNodeId(null);
+      } else if (showRightPanel) {
         setShowRightPanel(false);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedNodeId]);
+  }, [selectedNodeId, showRightPanel]);
 
   // G2 对话搜索：Cmd/Ctrl+F 拦截浏览器默认查找，打开搜索栏。
   useEffect(() => {
@@ -658,6 +696,22 @@ export function HomeBody({
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
+
+  // 右栏抽屉开合按 session 记忆：切会话时按记录恢复（无记录默认收起）。
+  // 与既有 thinking/llm seeding 效应同源——切换会话时按本地偏好同步一次 UI 状态，
+  // 单次切换仅触发一次额外渲染，可接受；故就地豁免 set-state-in-effect。
+  useEffect(() => {
+    if (!sessionId) return;
+    const persisted = readPersistedRightPanel(sessionId);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setShowRightPanel(persisted ?? false);
+  }, [sessionId]);
+
+  // 状态变化时写回当前 session 的记录（toggle / X / ESC / 快捷键统一经此落盘）。
+  useEffect(() => {
+    if (!sessionId) return;
+    writePersistedRightPanel(sessionId, showRightPanel);
+  }, [sessionId, showRightPanel]);
 
   const doSend = useCallback(
     async (input: string) => {
@@ -1141,12 +1195,17 @@ export function HomeBody({
 
         {/* Main Content Area */}
         <main className="flex-1 flex flex-col h-full min-w-0 bg-background relative overflow-hidden transition-all duration-300">
-          {/* Internal Toolbar for Toggles */}
-          <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b border-border bg-card/60 backdrop-blur-sm z-10 w-full">
+          {/* Internal Toolbar：三区布局（左 toggle / 中 标题·搜索 / 右 策略·toggle） */}
+          <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-border bg-card/60 backdrop-blur-sm z-10 w-full">
+            {/* 左区：会话栏开合 */}
             <button
               type="button"
               onClick={() => setShowLeftPanel(!showLeftPanel)}
-              className="p-1.5 rounded-md text-text-muted hover:bg-border-muted hover:text-text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className={`shrink-0 p-1.5 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                showLeftPanel
+                  ? "bg-border-muted/70 text-text-primary"
+                  : "text-text-muted hover:bg-border-muted hover:text-text-primary"
+              }`}
               aria-label={showLeftPanel ? "收起会话栏 (⌘/Ctrl+B)" : "展开会话栏 (⌘/Ctrl+B)"}
               aria-pressed={showLeftPanel}
               title={showLeftPanel ? "收起会话栏 (⌘/Ctrl+B)" : "展开会话栏 (⌘/Ctrl+B)"}
@@ -1154,38 +1213,45 @@ export function HomeBody({
               <PanelLeft className="w-4 h-4" aria-hidden="true" />
             </button>
 
-            <div className="text-xs font-medium text-text-secondary max-w-md truncate mx-4">
-              {activeSession
-                ? `${activeSession.label}${latestRunState?.status === "blocked" ? " · 等待确认" : ""}`
-                : "Negentropy"}
+            {/* 中区：标题 / 对话搜索（二选一，搜索打开时占据中区） */}
+            <div className="flex min-w-0 flex-1 items-center justify-center px-2">
+              {search.isOpen ? (
+                <ConversationSearchBar
+                  query={search.query}
+                  onQueryChange={search.setQuery}
+                  matchCount={search.matchCount}
+                  currentIndex={search.currentIndex}
+                  onNavigateNext={search.navigateNext}
+                  onNavigatePrev={search.navigatePrev}
+                  onClose={search.close}
+                />
+              ) : (
+                <div className="max-w-md truncate text-center text-[13px] font-semibold text-text-primary">
+                  {activeSession
+                    ? `${activeSession.label}${latestRunState?.status === "blocked" ? " · 等待确认" : ""}`
+                    : "Negentropy"}
+                </div>
+              )}
             </div>
 
-            {/* G2 对话搜索栏 */}
-            {search.isOpen && (
-              <ConversationSearchBar
-                query={search.query}
-                onQueryChange={search.setQuery}
-                matchCount={search.matchCount}
-                currentIndex={search.currentIndex}
-                onNavigateNext={search.navigateNext}
-                onNavigatePrev={search.navigatePrev}
-                onClose={search.close}
-              />
-            )}
-
-            {/* G3 审批策略选择器 */}
-            <ApprovalPolicySelector className="inline-flex items-center gap-1 text-[10px] text-text-muted" />
-
-            <button
-              type="button"
-              onClick={() => setShowRightPanel(!showRightPanel)}
-              className="p-1.5 rounded-md text-text-muted hover:bg-border-muted hover:text-text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              aria-label={showRightPanel ? "收起 State 栏 (⌘/Ctrl+J)" : "展开 State 栏 (⌘/Ctrl+J)"}
-              aria-pressed={showRightPanel}
-              title={showRightPanel ? "收起 State 栏 (⌘/Ctrl+J)" : "展开 State 栏 (⌘/Ctrl+J)"}
-            >
-              <PanelRight className="w-4 h-4" aria-hidden="true" />
-            </button>
+            {/* 右区：审批策略 + State 栏开合 */}
+            <div className="flex shrink-0 items-center gap-2">
+              <ApprovalPolicySelector className="inline-flex items-center gap-1 text-[11px] text-text-muted" />
+              <button
+                type="button"
+                onClick={() => setShowRightPanel(!showRightPanel)}
+                className={`p-1.5 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                  showRightPanel
+                    ? "bg-border-muted/70 text-text-primary"
+                    : "text-text-muted hover:bg-border-muted hover:text-text-primary"
+                }`}
+                aria-label={showRightPanel ? "收起 State 栏 (⌘/Ctrl+J)" : "展开 State 栏 (⌘/Ctrl+J)"}
+                aria-pressed={showRightPanel}
+                title={showRightPanel ? "收起 State 栏 (⌘/Ctrl+J)" : "展开 State 栏 (⌘/Ctrl+J)"}
+              >
+                <PanelRight className="w-4 h-4" aria-hidden="true" />
+              </button>
+            </div>
           </div>
 
           {/* Chat Stream Area */}
@@ -1250,65 +1316,24 @@ export function HomeBody({
             </div>
           </div>
         </main>
-
-        {/* Right Sidebar: Timeline & Logs */}
-        <div
-          className={`shrink-0 h-full border-l border-border bg-card transition-all duration-300 ease-in-out overflow-hidden ${
-            showRightPanel
-              ? "w-80 translate-x-0 opacity-100"
-              : "w-0 translate-x-10 opacity-0"
-          }`}
-        >
-          <div className="w-80 h-full overflow-y-auto p-6">
-            {/* View mode indicator + minimal interaction hint */}
-            {selectedNodeId ? (
-              <div className="mb-4 p-3 rounded-lg border border-amber-300/60 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40">
-                <div className="flex items-center justify-between">
-                  <span className="flex items-center gap-1.5 text-xs font-semibold text-amber-700 dark:text-amber-200">
-                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
-                    历史视图
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSelectedNodeId(null);
-                    }}
-                    className="rounded text-xs font-medium text-amber-700 underline-offset-2 hover:underline dark:text-amber-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    返回实时
-                  </button>
-                </div>
-                <p className="mt-1 text-[10px] text-amber-700/80 dark:text-amber-300/80">
-                  显示选定消息的观察数据
-                </p>
-              </div>
-            ) : (
-              <div className="mb-4 p-3 rounded-lg border border-border bg-border-muted/50">
-                <span className="flex items-center gap-1.5 text-xs font-semibold text-text-secondary">
-                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-text-muted" aria-hidden="true" />
-                  实时视图
-                </span>
-                <p className="mt-1 text-[10px] text-text-muted">
-                  点击任意消息进入历史视图，再次点击或点“返回实时”回到实时
-                </p>
-              </div>
-            )}
-
-            <StateSnapshot
-              snapshot={snapshotForDisplay}
-              connection={selectedNodeId ? "idle" : effectiveConnection}
-            />
-            <EventTimeline events={timelineItems} />
-            <LogBufferPanel
-              entries={filteredLogEntries}
-              onExport={() => {
-                const payload = JSON.stringify(filteredLogEntries, null, 2);
-                void navigator.clipboard?.writeText(payload);
-              }}
-            />
-          </div>
-        </div>
       </div>
+
+      {/* 右栏 State 观测：非模态浮层抽屉，悬浮于对话之上、不挤占中栏。
+          中栏对话仍可点击 → 保留「点消息看历史」；开合由 showRightPanel 驱动。 */}
+      <StateDrawer
+        open={showRightPanel}
+        onClose={() => setShowRightPanel(false)}
+        selectedNodeId={selectedNodeId}
+        onReturnToLive={() => setSelectedNodeId(null)}
+        snapshot={snapshotForDisplay}
+        connection={selectedNodeId ? "idle" : effectiveConnection}
+        timelineItems={timelineItems}
+        logEntries={filteredLogEntries}
+        onExportLogs={() => {
+          const payload = JSON.stringify(filteredLogEntries, null, 2);
+          void navigator.clipboard?.writeText(payload);
+        }}
+      />
 
       {/* G3 审批门：pending_approvals → modal → approval_responses 闭环 */}
       <ApprovalDialog

--- a/apps/negentropy-ui/components/ui/ApprovalPolicySelector.tsx
+++ b/apps/negentropy-ui/components/ui/ApprovalPolicySelector.tsx
@@ -93,7 +93,7 @@ export function ApprovalPolicySelector({ className }: { className?: string }) {
     >
       <span className="font-medium">审批策略：</span>
       <select
-        className="rounded-md border border-border bg-background px-1.5 py-0.5 text-xs"
+        className="h-7 cursor-pointer rounded-md border border-border bg-background px-2 text-xs text-text-secondary transition-colors hover:border-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         value={mode}
         onChange={(e) => setMode(e.target.value as ApprovalPolicyMode)}
         aria-label="审批策略"

--- a/apps/negentropy-ui/components/ui/ChatStream.tsx
+++ b/apps/negentropy-ui/components/ui/ChatStream.tsx
@@ -267,7 +267,7 @@ export function ChatStream({
           type="button"
           onClick={scrollToBottom}
           aria-label="回到底部"
-          className="absolute bottom-4 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-card/95 px-3 py-1.5 text-xs font-medium text-text-secondary shadow-md backdrop-blur transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="absolute bottom-4 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-card/95 px-3 py-1.5 text-xs font-medium text-text-secondary shadow-md backdrop-blur transition-[color,transform,box-shadow] duration-200 ease-out hover:-translate-y-0.5 hover:text-text-primary hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
           回到底部

--- a/apps/negentropy-ui/components/ui/Composer.tsx
+++ b/apps/negentropy-ui/components/ui/Composer.tsx
@@ -281,12 +281,6 @@ export function Composer({
 
   const showStop = Boolean(isGenerating && onCancel);
 
-  const hasContent = Boolean(
-    (showMentions && mentions && mentions.length > 0) ||
-    (showAttachments && attachments && attachments.length > 0) ||
-    attachmentError,
-  );
-
   return (
     <form
       data-testid="composer-form"
@@ -412,7 +406,7 @@ export function Composer({
             type="button"
             data-testid="composer-stop-button"
             aria-label="Stop"
-            className="mb-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-rose-600 text-white transition-all hover:bg-rose-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-1"
+            className="mb-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-rose-600 text-white transition-[background-color,transform] hover:bg-rose-700 active:scale-[0.94] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-1"
             onClick={onCancel}
           >
             <Square className="h-3.5 w-3.5 fill-current" aria-hidden="true" />
@@ -422,7 +416,7 @@ export function Composer({
             type="button"
             data-testid="composer-send-button"
             aria-label="Send"
-            className="mb-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition-all hover:bg-primary-hover disabled:opacity-25 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            className="mb-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition-[background-color,transform] hover:bg-primary-hover active:scale-[0.94] disabled:opacity-25 disabled:cursor-not-allowed disabled:active:scale-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             onClick={onSend}
             disabled={disabled || !value.trim() || !!isBlocked}
           >
@@ -449,8 +443,8 @@ export function Composer({
       )}
 
       {/* Toolbar row */}
-      <div className={`flex items-center justify-between gap-2 ${hasContent ? "mt-2" : "mt-1"}`}>
-        <div className="flex items-center gap-1.5 min-w-0">
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1 min-w-0">
           {showAttachments && (
             <>
               <input
@@ -477,6 +471,12 @@ export function Composer({
                 <Paperclip className="h-4 w-4" aria-hidden="true" />
               </button>
             </>
+          )}
+          {showAttachments && (showModelSelect || showThinkingToggle) && (
+            <span
+              className="mx-0.5 h-4 w-px shrink-0 bg-border"
+              aria-hidden="true"
+            />
           )}
           {showModelSelect && (
             <LlmModelSelect
@@ -509,9 +509,9 @@ export function Composer({
                 if (!thinkingSupported) return;
                 onThinkingEnabledChange?.(!thinkingEnabled);
               }}
-              className={`inline-flex h-7 shrink-0 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                 thinkingSupported && thinkingEnabled
-                  ? "border-primary/40 bg-primary/10 text-primary"
+                  ? "border-primary/50 bg-primary/10 text-primary"
                   : "border-transparent text-text-muted hover:text-foreground hover:bg-border-muted disabled:cursor-not-allowed disabled:opacity-40"
               }`}
             >
@@ -520,7 +520,7 @@ export function Composer({
             </button>
           )}
         </div>
-        <p className="text-[10px] text-text-muted/60 shrink-0 select-none">
+        <p className="text-[10px] text-text-muted shrink-0 select-none">
           {showMentions ? "@ 选对象 · " : ""}Enter 发送 · Shift+Enter 换行
         </p>
       </div>

--- a/apps/negentropy-ui/components/ui/LogBufferPanel.tsx
+++ b/apps/negentropy-ui/components/ui/LogBufferPanel.tsx
@@ -23,7 +23,7 @@ function levelDotClass(level: string): string {
 
 export function LogBufferPanel({ entries, onExport }: LogBufferPanelProps) {
   return (
-    <div className="mt-6">
+    <div>
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <p className="text-xs font-semibold uppercase text-text-muted">
@@ -41,7 +41,7 @@ export function LogBufferPanel({ entries, onExport }: LogBufferPanelProps) {
           Export
         </button>
       </div>
-      <div className="max-h-52 space-y-2 overflow-auto rounded-xl border border-border bg-card p-3 text-[11px] text-text-secondary custom-scrollbar">
+      <div className="max-h-72 space-y-2 overflow-auto rounded-xl border border-border bg-card p-3 text-[11px] text-text-secondary custom-scrollbar">
         {entries.length === 0 ? (
           <p className="text-text-muted">暂无日志</p>
         ) : (

--- a/apps/negentropy-ui/components/ui/SessionList.tsx
+++ b/apps/negentropy-ui/components/ui/SessionList.tsx
@@ -163,13 +163,13 @@ export function SessionList({
       onConfirm={handleConfirm}
       onCancel={() => setConfirmTarget(null)}
     />
-    <aside className="col-span-2 h-full border-r border-border bg-card p-4 flex flex-col overflow-hidden">
+    <aside className="h-full border-r border-border bg-card px-3 py-3 flex flex-col overflow-hidden">
       <div className="mb-3 flex items-center justify-between gap-2 shrink-0">
         {/* 视图分段控件：进行中 / 已归档 */}
         <div
           role="tablist"
           aria-label="会话视图"
-          className="inline-flex items-center rounded-lg border border-border bg-border-muted/50 p-0.5 text-[11px] font-medium"
+          className="inline-flex h-7 items-center rounded-lg border border-border bg-border-muted/50 p-0.5 text-[11px] font-medium"
         >
           <button
             type="button"
@@ -203,7 +203,7 @@ export function SessionList({
         </div>
         {view === "active" && onNewSession && (
           <button
-            className="inline-flex items-center gap-1 rounded-full bg-primary px-3 py-1 text-[11px] font-semibold text-primary-foreground transition-all hover:bg-primary-hover active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex h-7 items-center gap-1 rounded-full bg-primary px-3 text-[11px] font-semibold text-primary-foreground transition-[background-color,transform] duration-150 ease-out hover:bg-primary-hover active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             onClick={onNewSession}
             type="button"
           >
@@ -229,13 +229,29 @@ export function SessionList({
       </div>
       <div className="space-y-1 flex-1 overflow-y-auto min-h-0 custom-scrollbar">
         {pagedSessions.length === 0 ? (
-          <p className="px-1 py-2 text-xs text-text-muted">
-            {normalizedQuery
-              ? "未找到匹配会话"
-              : view === "archived"
-                ? "暂无已归档会话"
-                : "暂无会话"}
-          </p>
+          <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-border-muted/70 text-text-muted">
+              {normalizedQuery ? (
+                <Search className="h-4 w-4" aria-hidden="true" />
+              ) : view === "archived" ? (
+                <Archive className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              )}
+            </span>
+            <p className="text-xs text-text-muted">
+              {normalizedQuery
+                ? "未找到匹配会话"
+                : view === "archived"
+                  ? "暂无已归档会话"
+                  : "暂无会话"}
+            </p>
+            {!normalizedQuery && view === "active" && onNewSession ? (
+              <p className="text-[10px] text-text-muted/80">
+                点击右上角 New 开始新会话
+              </p>
+            ) : null}
+          </div>
         ) : (
           pagedSessions.map((session) => (
             <div
@@ -274,10 +290,10 @@ export function SessionList({
                 <div
                   aria-current={session.id === activeId ? "true" : undefined}
                   className={cn(
-                    "group relative flex items-center gap-1 rounded-lg pr-2 transition-colors",
+                    "group relative flex items-center gap-0.5 rounded-lg pr-1.5 transition-colors",
                     session.id === activeId
                       ? "bg-primary/10 text-primary before:absolute before:left-0 before:top-1/2 before:h-5 before:w-0.5 before:-translate-y-1/2 before:rounded-full before:bg-primary"
-                      : "text-text-secondary hover:bg-border-muted",
+                      : "text-text-secondary hover:bg-border-muted/70 hover:text-text-primary",
                   )}
                 >
                   <button
@@ -311,7 +327,7 @@ export function SessionList({
                         event.stopPropagation();
                         setConfirmTarget({ kind: "archive", session });
                       }}
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted opacity-0 transition-all hover:bg-border-muted hover:text-text-primary group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-md text-text-muted opacity-0 transition-colors hover:bg-border-muted hover:text-text-primary group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <Archive className="h-3.5 w-3.5" />
                     </button>
@@ -325,7 +341,7 @@ export function SessionList({
                         event.stopPropagation();
                         setConfirmTarget({ kind: "unarchive", session });
                       }}
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted opacity-0 transition-all hover:bg-border-muted hover:text-text-primary group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-md text-text-muted opacity-0 transition-colors hover:bg-border-muted hover:text-text-primary group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <ArchiveRestore className="h-3.5 w-3.5" />
                     </button>
@@ -339,7 +355,7 @@ export function SessionList({
                         event.stopPropagation();
                         setConfirmTarget({ kind: "delete", session });
                       }}
-                      className="inline-flex h-7 w-7 items-center justify-center rounded-md text-error/70 opacity-0 transition-all hover:bg-error/10 hover:text-error group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-md text-error/70 opacity-0 transition-colors hover:bg-error/10 hover:text-error group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>

--- a/apps/negentropy-ui/components/ui/StateDrawer.tsx
+++ b/apps/negentropy-ui/components/ui/StateDrawer.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { PanelRight, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { ConnectionState, LogEntry } from "@/types/common";
+import { StateSnapshot } from "./StateSnapshot";
+import { EventTimeline, type TimelineItem } from "./EventTimeline";
+import { LogBufferPanel } from "./LogBufferPanel";
+
+type StateDrawerProps = {
+  /** 抽屉是否展开（由 home-body 的 showRightPanel 驱动）。 */
+  open: boolean;
+  /** 收起抽屉（工具栏 toggle / 头部 X / ESC 共用同一出口）。 */
+  onClose: () => void;
+  /** 当前选中的历史消息节点；非空即「历史视图」。 */
+  selectedNodeId: string | null;
+  /** 返回实时视图（清空 selectedNodeId）。 */
+  onReturnToLive: () => void;
+  snapshot: Record<string, unknown> | null;
+  connection: ConnectionState;
+  timelineItems: TimelineItem[];
+  logEntries: LogEntry[];
+  onExportLogs: () => void;
+};
+
+/**
+ * State 观测抽屉 —— 非模态浮层。
+ *
+ * 设计要点（详见方案文档 Part A）：
+ * - **非模态**：外层 `pointer-events-none` 全屏容器仅用于定位，唯有 `<aside>` 捕获指针；
+ *   抽屉左侧留白区对中栏对话保持可点击，从而**保留「点消息 → 历史视图」**的核心交互。
+ *   因此不复用 `OverlayDismissLayer`（其全屏遮罩会拦截一切外部点击）。
+ * - **层级**：`z-40` 居于工具栏（`z-10`）之上、真模态（`ApprovalDialog` 等 `z-50`）之下。
+ * - **动画**：用 `transform`+`opacity`（非 `width`）滑入/滑出，200ms，进 ease-out / 出 ease-in；
+ *   `prefers-reduced-motion` 由 globals.css 全局归零，无需额外处理。
+ * - **常驻挂载**：合拢时靠 `translate-x-full opacity-0` + `inert` 移出视图与可达性树，
+ *   以便播放退出动画；`pointer-events` 双层控制确保合拢时不拦截点击。
+ * - **可达性**：`role="dialog"` + `aria-label`，**不设 `aria-modal`**（非模态、不做焦点陷阱，
+ *   用户须能 Tab 回对话区点选消息）。展开时把焦点移入抽屉。
+ */
+export function StateDrawer({
+  open,
+  onClose,
+  selectedNodeId,
+  onReturnToLive,
+  snapshot,
+  connection,
+  timelineItems,
+  logEntries,
+  onExportLogs,
+}: StateDrawerProps) {
+  const asideRef = useRef<HTMLElement | null>(null);
+
+  // 展开时把焦点移入抽屉（非陷阱：用户仍可 Tab 回对话区点选消息）。
+  useEffect(() => {
+    if (open) {
+      asideRef.current?.focus();
+    }
+  }, [open]);
+
+  return (
+    <div
+      // 外层全屏但 click-through：仅 <aside> 捕获指针，留白区对对话仍可点击。
+      className="pointer-events-none fixed inset-y-0 right-0 z-40 flex justify-end"
+    >
+      <aside
+        ref={asideRef}
+        role="dialog"
+        aria-label="State 观测面板"
+        tabIndex={-1}
+        inert={!open ? true : undefined}
+        className={cn(
+          // 宽度 2.5×（320 → 800）：窄屏全宽、≥sm 固定 800、永不超 90vw。
+          "pointer-events-auto flex h-full w-full max-w-[90vw] flex-col border-l border-border bg-card shadow-2xl sm:w-[800px]",
+          // transform+opacity 动画（非 width，规避属性能反模式）。
+          "transition-[transform,opacity] duration-200 will-change-transform",
+          open
+            ? "translate-x-0 opacity-100 ease-out"
+            : "translate-x-full opacity-0 ease-in",
+        )}
+      >
+        {/* 头部：标题 + 关闭 X（呼应 ActivityDrawer 的头部节奏） */}
+        <header className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3">
+          <span className="flex items-center gap-2 text-sm font-semibold text-text-primary">
+            <PanelRight className="h-4 w-4 text-text-muted" aria-hidden="true" />
+            State
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="收起 State 栏 (⌘/Ctrl+J)"
+            title="收起 State 栏 (⌘/Ctrl+J)"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-border-muted hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </header>
+
+        {/* 主体：宽屏内容重排（800px 充分利用）。padding/overflow 对齐原右栏。 */}
+        <div className="min-h-0 flex-1 overflow-y-auto p-6">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {/* 视图模式提示（满宽） */}
+            <div className="lg:col-span-2">
+              {selectedNodeId ? (
+                <div className="rounded-lg border border-amber-300/60 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/40">
+                  <div className="flex items-center justify-between">
+                    <span className="flex items-center gap-1.5 text-xs font-semibold text-amber-700 dark:text-amber-200">
+                      <span
+                        className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500"
+                        aria-hidden="true"
+                      />
+                      历史视图
+                    </span>
+                    <button
+                      type="button"
+                      onClick={onReturnToLive}
+                      className="rounded text-xs font-medium text-amber-700 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-amber-300"
+                    >
+                      返回实时
+                    </button>
+                  </div>
+                  <p className="mt-1 text-[10px] text-amber-700/80 dark:text-amber-300/80">
+                    显示选定消息的观察数据
+                  </p>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-border bg-border-muted/50 p-3">
+                  <span className="flex items-center gap-1.5 text-xs font-semibold text-text-secondary">
+                    <span
+                      className="inline-block h-1.5 w-1.5 rounded-full bg-text-muted"
+                      aria-hidden="true"
+                    />
+                    实时视图
+                  </span>
+                  <p className="mt-1 text-[10px] text-text-muted">
+                    点击任意消息进入历史视图，再次点击或点“返回实时”回到实时
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* State Snapshot 与 Runtime Logs 并排（皆近方形检视面） */}
+            <div className="min-w-0">
+              <StateSnapshot snapshot={snapshot} connection={connection} />
+            </div>
+            <div className="min-w-0">
+              <LogBufferPanel entries={logEntries} onExport={onExportLogs} />
+            </div>
+
+            {/* Event Timeline 满宽（时间轴天然高、不宜减半） */}
+            <div className="min-w-0 lg:col-span-2">
+              <EventTimeline events={timelineItems} />
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/StateSnapshot.tsx
+++ b/apps/negentropy-ui/components/ui/StateSnapshot.tsx
@@ -21,7 +21,7 @@ export function StateSnapshot({ snapshot, connection }: StateSnapshotProps) {
             ? "bg-error"
             : "bg-text-muted";
   return (
-    <div className="mb-6 flex flex-col">
+    <div className="flex flex-col">
       <div className="shrink-0 mb-3 flex items-center justify-between">
         <p className="text-xs font-semibold uppercase text-text-muted tracking-wider">
           State Snapshot
@@ -42,7 +42,7 @@ export function StateSnapshot({ snapshot, connection }: StateSnapshotProps) {
       <div
         className={cn(
           "min-h-[100px] overflow-y-auto overflow-x-hidden rounded-xl border border-border bg-card p-3 shadow-sm relative custom-scrollbar group/snapshot",
-          !snapshot ? "h-[85px]" : "h-[170px] resize-y",
+          !snapshot ? "h-[85px]" : "h-[220px] resize-y",
         )}
       >
         {!snapshot ? (


### PR DESCRIPTION
## 概要

将 Home / Studio 页面右栏（State 观测面板）从收缩式内联列改为非模态浮层抽屉（800px），并对四区做专业化 UI/UX 精修。

## 核心变更

### Part A — 右栏抽屉化

- **新建 `StateDrawer.tsx`**：非模态浮层（`pointer-events-none` 外层 + `pointer-events-auto` aside，`z-40`），宽 2.5×（320→800px, `max-w-[90vw]`），`transform`+`opacity` 滑入滑出 200ms（修正原有 `width` 动画的属性能反模式）
- **`home-body.tsx`**：移除右栏 flex 列（中栏不再被挤占），改为挂载 `StateDrawer` overlay；ESC 行为改为分层（① 历史视图→实时 ② 关闭抽屉）；新增 localStorage 持久化（按 session 记忆开合）
- **右栏内容重排**：`grid grid-cols-1 lg:grid-cols-2`（StateSnapshot + LogBufferPanel 并排, EventTimeline 满宽）；StateSnapshot 高度 170→220px, LogBufferPanel `max-h-52`→`max-h-72`

> **非模态设计决策**：抽屉不加遮罩，对话区保持可点击，从而保留「点击消息 → 查看该消息历史 State」的核心交互。关闭仅靠工具栏 toggle / 抽屉内 X / ESC。

### Part B — 四区 UI/UX 精修

| 区域 | 关键改进 |
|---|---|
| **左栏 Sessions** | 去 `col-span-2`、紧凑 padding、控件统一 `h-7`、会话项三态清晰化、操作按钮 `h-6`、空态图标块 |
| **中栏工具栏** | 三区重构（左 toggle / 中 标题·搜索 / 右 策略·toggle）、标题 `text-[13px] font-semibold`、toggle pressed 态、`ApprovalPolicySelector` `h-7` + ring |
| **底部 Composer** | 工具栏恒 `mt-2` + attach/config 分隔线、Thinking 边框 `/50`、Send/Stop 显式 transition + `active:scale-[0.94]`（刻意排除 opacity）、提示文案对比度修复 |
| **ChatStream** | 回到底部按钮显式 `transition-[color,transform,box-shadow]` + hover 抬升 |

## 验证结果

| 检查项 | 结果 |
|---|---|
| TypeScript 类型检查 | ✅ `tsc --noEmit` exit 0 |
| ESLint（全量文件） | ✅ `--max-warnings=0` exit 0 |
| 单元测试（91 files / 727 cases） | ✅ 全部通过 |
| 实机预览（localhost:3193/studio） | ✅ Chrome DevTools |
| — 抽屉从右滑入 800px | ✅ |
| — 中栏不被挤占 | ✅ |
| — X 按钮关闭 | ✅ |
| — 工具栏 toggle 开合 | ✅ |
| — Cmd+J 快捷键 | ✅ |
| — 无控制台错误 | ✅ |
| Pre-commit hooks | ✅ trim / EOF / ESLint 全通过 |

## 文件清单

| 文件 | 变更 |
|---|---|
| `components/ui/StateDrawer.tsx` | **新增** — 非模态浮层抽屉壳 |
| `app/home-body.tsx` | 拆右列 + 挂抽屉 + 分层 ESC + 持久化 + 工具栏三区 |
| `components/ui/StateSnapshot.tsx` | 去 `mb-6`, 高度 170→220 |
| `components/ui/LogBufferPanel.tsx` | 去 `mt-6`, `max-h-52`→`max-h-72` |
| `components/ui/SessionList.tsx` | 四项 B1 精修 |
| `components/ui/Composer.tsx` | 四项 B3 精修 |
| `components/ui/ChatStream.tsx` | 回到底部按钮 |
| `components/ui/ApprovalPolicySelector.tsx` | `h-7` + ring |

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>