### PR TITLE
fix(home-studio): 左栏 Session 每页 10 个消除纵向滚动条，内收头像悬挑并收缩侧栏根治中栏横向滚动条

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -1119,11 +1119,11 @@ export function HomeBody({
         <div
           className={`shrink-0 h-full border-r border-border bg-card transition-all duration-300 ease-in-out overflow-hidden ${
             showLeftPanel
-              ? "w-64 translate-x-0 opacity-100"
+              ? "w-56 translate-x-0 opacity-100"
               : "w-0 -translate-x-10 opacity-0"
           }`}
         >
-          <div className="w-64 h-full overflow-hidden flex flex-col">
+          <div className="w-56 h-full overflow-hidden flex flex-col">
             <SessionList
               sessions={sessions}
               activeId={sessionId}
@@ -1255,11 +1255,11 @@ export function HomeBody({
         <div
           className={`shrink-0 h-full border-l border-border bg-card transition-all duration-300 ease-in-out overflow-hidden ${
             showRightPanel
-              ? "w-80 translate-x-0 opacity-100"
+              ? "w-72 translate-x-0 opacity-100"
               : "w-0 translate-x-10 opacity-0"
           }`}
         >
-          <div className="w-80 h-full overflow-y-auto p-6">
+          <div className="w-72 h-full overflow-y-auto p-6">
             {/* View mode indicator + minimal interaction hint */}
             {selectedNodeId ? (
               <div className="mb-4 p-3 rounded-lg border border-amber-300/60 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/40">

--- a/apps/negentropy-ui/components/ui/MessageBubble.tsx
+++ b/apps/negentropy-ui/components/ui/MessageBubble.tsx
@@ -412,9 +412,13 @@ export function MessageBubble({
   const isStreaming = message.streaming === true && !isUser;
   const showStreamingIndicator = isStreaming && hasContent;
   const showWaitingPlaceholder = isStreaming && !hasContent && !body;
+  // 头像悬挑落点：横向位移收敛到 calc(100% - 0.5rem)（自身 32px − 8px = 24px 悬挑），
+  // 使头像外缘始终落在对话轨道的左右留白内（px-6=24px / sm:px-8=32px 均不溢出），
+  // 从根因消除中栏横向滚动条（轨道滚动容器 overflow-y-auto 按 CSS 规范连带 overflow-x:auto）；
+  // 8px 角部交叠落在气泡 2rem 圆角空白处，不遮挡正文（气泡 px-5 内边距留有余量）。
   const avatarPositionClass = isUser
-    ? "absolute right-0 top-2 translate-x-[calc(100%+0.75rem)]"
-    : "absolute left-0 top-2 -translate-x-[calc(100%+0.75rem)]";
+    ? "absolute right-0 top-2 translate-x-[calc(100%-0.5rem)]"
+    : "absolute left-0 top-2 -translate-x-[calc(100%-0.5rem)]";
 
   if (isSystem) {
     return (

--- a/apps/negentropy-ui/components/ui/SessionList.tsx
+++ b/apps/negentropy-ui/components/ui/SessionList.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import type { SessionListView } from "@/utils/session";
 
-const PAGE_SIZE = 12;
+const PAGE_SIZE = 10;
 
 type SessionItem = {
   id: string;

--- a/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/MessageBubble.test.tsx
@@ -28,7 +28,7 @@ describe("MessageBubble", () => {
     const avatarRail = avatar.parentElement?.parentElement;
     expect(avatarRail?.className).toContain("absolute");
     expect(avatarRail?.className).toContain("right-0");
-    expect(avatarRail?.className).toContain("translate-x-[calc(100%+0.75rem)]");
+    expect(avatarRail?.className).toContain("translate-x-[calc(100%-0.5rem)]");
   });
 
   it("智能体头像去掉边框与 ring 并定位在消息外侧", () => {
@@ -47,7 +47,7 @@ describe("MessageBubble", () => {
     const avatarRail = avatar?.parentElement;
     expect(avatarRail?.className).toContain("absolute");
     expect(avatarRail?.className).toContain("left-0");
-    expect(avatarRail?.className).toContain("-translate-x-[calc(100%+0.75rem)]");
+    expect(avatarRail?.className).toContain("-translate-x-[calc(100%-0.5rem)]");
   });
 
   it("流式回复在结束前按 Markdown 语义渲染并显示状态", () => {

--- a/apps/negentropy-ui/tests/unit/ui/SessionList.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/SessionList.test.tsx
@@ -160,7 +160,7 @@ describe("SessionList", () => {
 });
 
 describe("SessionList 分页", () => {
-  it("超过 12 个 session 时仅显示 12 个，分页栏显示正确页码", () => {
+  it("超过 10 个 session 时仅显示 10 个，分页栏显示正确页码", () => {
     const sessions = makeSessions(15);
     render(
       <SessionList
@@ -171,9 +171,9 @@ describe("SessionList 分页", () => {
       />,
     );
 
-    // 应该恰好渲染 12 个 session（第 1 页）
+    // 应该恰好渲染 10 个 session（第 1 页）
     const sessionItems = document.querySelectorAll("[data-session-id]");
-    expect(sessionItems).toHaveLength(12);
+    expect(sessionItems).toHaveLength(10);
 
     // 分页栏应显示 "1 / 2"
     expect(screen.getByText("1 / 2")).toBeInTheDocument();
@@ -193,9 +193,9 @@ describe("SessionList 分页", () => {
 
     await user.click(screen.getByRole("button", { name: "下一页" }));
 
-    // 第 2 页应显示 3 个 session（13-15）
+    // 第 2 页应显示 5 个 session（11-15）
     const sessionItems = document.querySelectorAll("[data-session-id]");
-    expect(sessionItems).toHaveLength(3);
+    expect(sessionItems).toHaveLength(5);
     expect(screen.getByText("2 / 2")).toBeInTheDocument();
   });
 
@@ -222,8 +222,8 @@ describe("SessionList 分页", () => {
     expect(screen.getByRole("button", { name: "下一页" })).toBeDisabled();
   });
 
-  it("12 个或更少 session 时不显示分页栏", () => {
-    const sessions = makeSessions(12);
+  it("10 个或更少 session 时不显示分页栏", () => {
+    const sessions = makeSessions(10);
     render(
       <SessionList
         {...defaultProps}
@@ -249,7 +249,7 @@ describe("SessionList 分页", () => {
     );
 
     // 模拟删除后 sessions 减少
-    const reduced = makeSessions(11);
+    const reduced = makeSessions(10);
     rerender(
       <SessionList
         {...defaultProps}
@@ -259,7 +259,7 @@ describe("SessionList 分页", () => {
       />,
     );
 
-    // 分页栏应消失（11 <= 12）
+    // 分页栏应消失（10 <= 10）
     expect(screen.queryByRole("button", { name: "上一页" })).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Home/Studio 页面中栏因消息头像溢出出现横向滚动条，左栏 Session 列表每页 12 条导致纵向滚动条
- 关联上下文/Issue/文档：基于 #725 Home/Studio UI 精修的后续修复

# 核心变更
- **SessionList 分页阈值**：`PAGE_SIZE` 从 12 降为 10，使首屏 session 列表无需纵向滚动
- **头像悬挑收敛**：`MessageBubble` 头像 `translate` 从 `calc(100%+0.75rem)` 改为 `calc(100%-0.5rem)`，悬挑量从 44px 降至 24px，精确落在对话轨道 `px-6`/`sm:px-8` 留白内，从 CSS 溢出层面根除横向滚动条
- **侧栏收缩**：左栏 `w-64`→`w-56`（256→224px），右栏 `w-80`→`w-72`（320→288px），为消息轨道腾出横向空间

# 风险与回滚
- 主要风险：头像 8px 角部交叠落在气泡 2rem 圆角空白处，极端窄屏可能视觉上略紧凑；侧栏收窄 32px 对长 session 名截断行为无影响（原有截断逻辑不变）
- 回滚方式：`git revert` 单 commit 即可回滚

# 验证证据
- 单元测试：`SessionList.test.tsx` 分页边界用例全部同步更新（10/15→1页10+2页5），`MessageBubble.test.tsx` 头像位移断言同步新 calc 值
- 集成测试：无新增
- E2E/Workflow：无
- 覆盖率/关键截图：无

# 影响范围
- 前端：`home-body.tsx`（侧栏宽度）、`MessageBubble.tsx`（头像定位）、`SessionList.tsx`（分页阈值）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证 Home/Studio 页面在标准屏（1440px）与窄屏（1280px）下横向/纵向滚动条是否彻底消除