### PR TITLE
fix(wiki-graph): 图谱文字配色随主题切换实时自适应

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ThemePreference } from "@/components/ThemePreference";
 import { WikiGraphRenderer } from "@/components/WikiGraphRenderer";
 import { WikiHeader } from "@/components/WikiHeader";
+import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import {
   countLeafEntries,
@@ -82,6 +83,7 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
       items={sectionView.headerItems}
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
+      actions={<WikiHeaderActions />}
       graphTab={{ active: true, show: entriesTotal > 0 }}
     />
   );

--- a/apps/negentropy-wiki/src/components/ThemePreference.tsx
+++ b/apps/negentropy-wiki/src/components/ThemePreference.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 
-type ColorScheme = "light" | "dark" | "system";
+import { COLOR_SCHEME_KEY } from "@/lib/wiki-color-scheme";
 
-const COLOR_SCHEME_KEY = "wiki:color-scheme";
+type ColorScheme = "light" | "dark" | "system";
 
 function getStoredValue(key: string, fallback: string): string {
   if (typeof window === "undefined") return fallback;

--- a/apps/negentropy-wiki/src/components/WikiCytoscapeCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiCytoscapeCanvas.tsx
@@ -17,6 +17,7 @@ import { useRouter } from "next/navigation";
 import type { Core, ElementDefinition, LayoutOptions } from "cytoscape";
 
 import type { WikiGraphEdge, WikiGraphNode } from "@/lib/wiki-graph-types";
+import { useIsDark } from "@/lib/wiki-color-scheme";
 import { detectDark, nodeColor } from "@/lib/wiki-graph-visual";
 
 // nodeSize 系数随渲染器而异（Cytoscape 节点宽高量纲偏大），保留本地定义。
@@ -24,6 +25,19 @@ function nodeSize(importance: number | null | undefined): number {
   if (importance == null) return 18;
   const clamped = Math.min(Math.max(importance, 0), 1);
   return 14 + 22 * clamped;
+}
+
+// 暗色态 → 标签 / 描边 / 边配色（init 样式表与主题同步 effect 共用，单一来源）。
+function schemeColors(isDark: boolean): {
+  labelColor: string;
+  outlineColor: string;
+  edgeColor: string;
+} {
+  return {
+    labelColor: isDark ? "#e3e3e3" : "#27272a",
+    outlineColor: isDark ? "#18181b" : "#ffffff",
+    edgeColor: isDark ? "rgba(255,255,255,0.18)" : "#a1a1aa",
+  };
 }
 
 function toElements(
@@ -88,6 +102,8 @@ export function WikiCytoscapeCanvas({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const cyRef = useRef<Core | null>(null);
   const router = useRouter();
+  // 响应式暗色态：驱动下方「主题同步」effect 在切换时就地重设节点 / 边配色。
+  const isDark = useIsDark();
 
   // 节点 id → entry_slugs 映射，供点击跳转兜底反查
   const entrySlugMap = useMemo(() => {
@@ -110,10 +126,8 @@ export function WikiCytoscapeCanvas({
 
       if (killed || !containerRef.current) return;
 
-      const isDark = detectDark();
-      const labelColor = isDark ? "#e3e3e3" : "#27272a";
-      const outlineColor = isDark ? "#18181b" : "#ffffff";
-      const edgeColor = isDark ? "rgba(255,255,255,0.18)" : "#a1a1aa";
+      // 首屏按当前主题着色；后续主题切换由下方同步 effect 就地重设。
+      const { labelColor, outlineColor, edgeColor } = schemeColors(detectDark());
 
       const cy = cytoscape({
         container: containerRef.current,
@@ -182,6 +196,23 @@ export function WikiCytoscapeCanvas({
       cyRef.current = null;
     };
   }, [elements, entrySlugMap, pubSlug, router]);
+
+  // 主题同步：切换 light/dark 时对现有节点 / 边下发 style bypass 就地重设配色
+  // （高于样式表优先级，立即重绘；不重建实例、不重排）。
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+    const { labelColor, outlineColor, edgeColor } = schemeColors(isDark);
+    cy.nodes().style({
+      color: labelColor,
+      "border-color": outlineColor,
+      "text-outline-color": outlineColor,
+    });
+    cy.edges().style({
+      "line-color": edgeColor,
+      "target-arrow-color": edgeColor,
+    });
+  }, [isDark]);
 
   return (
     <div className="wiki-graph-canvas-root">

--- a/apps/negentropy-wiki/src/components/WikiD3ForceCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiD3ForceCanvas.tsx
@@ -17,7 +17,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import type { WikiGraphEdge, WikiGraphNode } from "@/lib/wiki-graph-types";
-import { detectDark, nodeColor } from "@/lib/wiki-graph-visual";
+import { useIsDark } from "@/lib/wiki-color-scheme";
+import { nodeColor } from "@/lib/wiki-graph-visual";
 
 // 模拟节点：在 WikiGraphNode 字段子集上叠加 d3 物理引擎所需的位置 / 速度。
 type D3Node = {
@@ -69,8 +70,8 @@ export function WikiD3ForceCanvas({
   const [layout, setLayout] = useState<D3Node[]>([]);
   const router = useRouter();
 
-  // isDark 仅作用于客户端 layout 落定后渲染的元素，无 SSR 着色不一致风险。
-  const isDark = useMemo(() => detectDark(), []);
+  // 响应式暗色态：主题切换时随 React 重渲染，SVG 文字 / 边 fill 即时更新（零重排）。
+  const isDark = useIsDark();
   const labelColor = isDark ? "#e3e3e3" : "#52525b";
   const edgeColor = isDark ? "rgba(255,255,255,0.15)" : "#d4d4d8";
   const edgeLabelColor = isDark ? "rgba(255,255,255,0.45)" : "#a1a1aa";

--- a/apps/negentropy-wiki/src/components/WikiForceGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiForceGraphCanvas.tsx
@@ -21,7 +21,16 @@ import type { ComponentType } from "react";
 import { useRouter } from "next/navigation";
 
 import type { WikiGraphEdge, WikiGraphNode } from "@/lib/wiki-graph-types";
-import { detectDark, nodeColor } from "@/lib/wiki-graph-visual";
+import { useIsDark } from "@/lib/wiki-color-scheme";
+import { nodeColor } from "@/lib/wiki-graph-visual";
+
+// 边 / 箭头配色（随响应式 isDark 实时取值，经函数式 prop 下传，避免重建 graphData）。
+function edgeColor(isDark: boolean): string {
+  return isDark ? "rgba(255,255,255,0.12)" : "#52525b";
+}
+function arrowColor(isDark: boolean): string {
+  return isDark ? "rgba(255,255,255,0.25)" : "#71717a";
+}
 
 // ---------------------------------------------------------------------------
 // 视觉常量：配色 / 取色逻辑见 `@/lib/wiki-graph-visual`（跨渲染器单一事实源）。
@@ -53,13 +62,13 @@ interface FGLink {
   source: string;
   target: string;
   label: string;
-  color: string;
 }
 
+// 注：link 颜色不再固化进数据（否则主题切换需重建 graphData → 触发整图重排），
+// 改由 ForceGraph2D 的 linkColor 函数式 prop 实时读取响应式 isDark。
 function toForceGraphData(
   nodes: WikiGraphNode[],
   edges: WikiGraphEdge[],
-  isDark: boolean,
 ): { nodes: FGNode[]; links: FGLink[] } {
   const validIds = new Set(nodes.map((n) => n.id));
   return {
@@ -77,7 +86,6 @@ function toForceGraphData(
         source: e.source,
         target: e.target,
         label: e.label ?? e.type ?? "",
-        color: isDark ? "rgba(255,255,255,0.12)" : "#52525b",
       })),
   };
 }
@@ -157,9 +165,10 @@ export function WikiForceGraphCanvas({
     [entrySlugMap, pubSlug, router],
   );
 
-  const isDark = useMemo(() => detectDark(), []);
+  // 响应式暗色态：仅驱动标签 / 边 / 箭头取色，不参与 graphData（保持布局稳定）。
+  const isDark = useIsDark();
 
-  const graphData = useMemo(() => toForceGraphData(nodes, edges, isDark), [nodes, edges, isDark]);
+  const graphData = useMemo(() => toForceGraphData(nodes, edges), [nodes, edges]);
 
   // 自定义节点渲染：圆形 + 标签（缩小时隐藏）
   const nodeCanvasObject = useCallback(
@@ -210,11 +219,11 @@ export function WikiForceGraphCanvas({
             nodeCanvasObject={nodeCanvasObject}
             nodeCanvasObjectMode={() => "replace"}
             nodePointerAreaPaint={nodePointerAreaPaint}
-            linkColor="color"
+            linkColor={() => edgeColor(isDark)}
             linkWidth={1}
             linkDirectionalArrowLength={4}
             linkDirectionalArrowRelPos={0.8}
-            linkDirectionalArrowColor={isDark ? "rgba(255,255,255,0.25)" : "#71717a"}
+            linkDirectionalArrowColor={() => arrowColor(isDark)}
             onNodeClick={handleNodeClick}
             enableNodeDrag={true}
             cooldownTicks={200}

--- a/apps/negentropy-wiki/src/components/WikiGraph3DCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraph3DCanvas.tsx
@@ -14,19 +14,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import SpriteText from "three-spritetext";
 
 import type { WikiGraphEdge, WikiGraphNode } from "@/lib/wiki-graph-types";
-import { detectDark, nodeColor } from "@/lib/wiki-graph-visual";
-
-// react-force-graph-3d 导出 ClassComponent，用 any 绕过 dynamic() 的 FC 约束。
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ForceGraph3D: any = dynamic(
-  () => import("react-force-graph-3d").then((m) => m.default),
-  { ssr: false },
-);
+import { useIsDark } from "@/lib/wiki-color-scheme";
+import { nodeColor } from "@/lib/wiki-graph-visual";
 
 // react-force-graph-3d 的 nodeVal 解释为"体积量"：渲染半径 = cbrt(val) * nodeRelSize。
 const NODE_REL_SIZE = 2.67;
@@ -59,8 +52,32 @@ export function WikiGraph3DCanvas({
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const router = useRouter();
 
-  const isDark = useMemo(() => detectDark(), []);
+  // react-force-graph-3d 为 ClassComponent：改用 useState + 动态 import 直接渲染
+  // （而非 next/dynamic 包裹），使 ref 直达实例 —— 主题切换时调用 refresh() 就地
+  // 重建标签 / 连线配色（位置由力模拟保留，不重排）。code-split 行为与 2D 同源。
+  // 实例 / 组件均以 any 承载（库默认导出为无精确类型的 ClassComponent）。
+  const [ForceGraph3D, setForceGraph3D] = useState<any>(null);
+  const fgRef = useRef<any>(null);
+
+  // 响应式暗色态：驱动标签 / 连线 / 背景取色与下方 refresh 同步。
+  const isDark = useIsDark();
   const bgColor = isDark ? "#0a0a0a" : "#ffffff";
+
+  useEffect(() => {
+    let cancelled = false;
+    import("react-force-graph-3d").then((mod) => {
+      if (!cancelled) setForceGraph3D(() => mod.default);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // 主题同步：light/dark 切换后让实例重绘（重跑 nodeThreeObject 生成新色 SpriteText、
+  // 重设 linkColor），不重建实例、不重排。
+  useEffect(() => {
+    fgRef.current?.refresh?.();
+  }, [isDark]);
 
   // 节点 id → entry_slugs 映射，供点击跳转
   const entrySlugMap = useMemo(() => {
@@ -151,8 +168,9 @@ export function WikiGraph3DCanvas({
   return (
     <div className="wiki-graph-canvas-root">
       <div ref={containerRef} className="wiki-graph-canvas-stage">
-        {dimensions.width > 0 && dimensions.height > 0 && (
+        {ForceGraph3D && dimensions.width > 0 && dimensions.height > 0 && (
           <ForceGraph3D
+            ref={fgRef}
             width={dimensions.width}
             height={dimensions.height}
             graphData={graphData}

--- a/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
@@ -18,6 +18,7 @@ import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 
 import type { WikiGraphEdge, WikiGraphNode } from "@/lib/wiki-graph-types";
+import { useIsDark } from "@/lib/wiki-color-scheme";
 import { detectDark, nodeColor } from "@/lib/wiki-graph-visual";
 
 // ---------------------------------------------------------------------------
@@ -29,6 +30,14 @@ function nodeSize(importance: number | null | undefined): number {
   if (importance == null) return 10;
   const clamped = Math.min(Math.max(importance, 0), 1);
   return 6 + 14 * clamped;
+}
+
+// 暗色态 → 标签 / 边配色（init 与主题同步 effect 共用，单一来源）。
+function schemeColors(isDark: boolean): { labelColor: string; edgeColor: string } {
+  return {
+    labelColor: isDark ? "#e3e3e3" : "#1c1e21",
+    edgeColor: isDark ? "rgba(255, 255, 255, 0.12)" : "#d4d4d8",
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -65,9 +74,12 @@ export function WikiGraphCanvas({
     kill: () => void;
     refresh: () => void;
     resize: () => void;
+    setSetting: (key: string, value: unknown) => void;
   } | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const router = useRouter();
+  // 响应式暗色态：驱动下方「主题同步」effect 在切换时就地重设 Sigma 配色。
+  const isDark = useIsDark();
 
   // 单次挂载初始化 + 数据/路由变化时整图重建（Wiki 场景图谱体量有限，无需增量同步）
   useEffect(() => {
@@ -83,12 +95,8 @@ export function WikiGraphCanvas({
 
       if (killed || !containerRef.current) return;
 
-      // Detect dark mode for label/edge color adaptation
-      const prefersDark = detectDark();
-      const labelColor = prefersDark ? "#e3e3e3" : "#1c1e21";
-      const edgeColor = prefersDark
-        ? "rgba(255, 255, 255, 0.12)"
-        : "#d4d4d8";
+      // 首屏按当前主题着色（避免闪烁）；后续主题切换由下方同步 effect 接管。
+      const { labelColor, edgeColor } = schemeColors(detectDark());
 
       const graph = new Graph({ multi: false, type: "directed" });
       const entrySlugMap = new Map<string, string[]>();
@@ -142,6 +150,7 @@ export function WikiGraphCanvas({
         kill: () => void;
         refresh: () => void;
         resize: () => void;
+        setSetting: (key: string, value: unknown) => void;
       };
 
       // 节点点击 → 跳转到首个相关 entry；无 entry 时不跳转
@@ -180,6 +189,16 @@ export function WikiGraphCanvas({
       sigmaRef.current = null;
     };
   }, [nodes, edges, pubSlug, router]);
+
+  // 主题同步：切换 light/dark 时就地重设标签 / 边色并 refresh（不重建实例、不重排）。
+  useEffect(() => {
+    const sigma = sigmaRef.current;
+    if (!sigma) return;
+    const { labelColor, edgeColor } = schemeColors(isDark);
+    sigma.setSetting("labelColor", { color: labelColor });
+    sigma.setSetting("defaultEdgeColor", edgeColor);
+    sigma.refresh();
+  }, [isDark]);
 
   const exceedsThreshold = nodes.length >= truncateThreshold;
   const showTruncatedBanner = truncated || exceedsThreshold;

--- a/apps/negentropy-wiki/src/lib/wiki-color-scheme.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-color-scheme.ts
@@ -1,0 +1,58 @@
+/**
+ * Wiki 颜色方案（明 / 暗）响应式订阅模块 —— 主题响应式的单一事实源。
+ *
+ * 背景：`ThemePreference` 组件在用户切换主题时执行三件事（见该组件 handleToggle）：
+ *   1. 写入 `localStorage[COLOR_SCHEME_KEY]`；
+ *   2. 翻转 `<html data-color-scheme>` 属性（`detectDark()` 的读取源）；
+ *   3. `window.dispatchEvent(new StorageEvent("storage", { key: COLOR_SCHEME_KEY }))`
+ *      —— 这一同窗派发的 storage 事件，是「主题已变更」在 React 侧的广播信号。
+ *
+ * 五个知识图谱渲染器此前都在挂载时一次性读取 `detectDark()` 后缓存，无人订阅上述
+ * 信号，故主题切换不会重绘（只有切换引擎触发 remount 才被动刷新）。本模块把
+ * 「订阅同一信号 → 派生响应式 isDark」收敛为唯一来源，供渲染器复用。
+ *
+ * 设计契约与 `ThemePreference` 完全一致：同一 `COLOR_SCHEME_KEY`、同一 `matchMedia`
+ * （覆盖 system 模式下系统主题变化）。
+ */
+
+import { useSyncExternalStore } from "react";
+
+import { detectDark } from "./wiki-graph-visual";
+
+/** 主题偏好在 localStorage 中的键名（与 ThemePreference、layout.tsx 内联脚本一致） */
+export const COLOR_SCHEME_KEY = "wiki:color-scheme";
+
+/**
+ * 订阅主题变更：同窗 storage 事件（ThemePreference 切换时派发）+ 系统主题偏好变化
+ * （覆盖 system 模式）。返回清理函数。SSR 环境下为 no-op。
+ */
+function subscribeColorScheme(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === COLOR_SCHEME_KEY) onChange();
+  };
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+
+  window.addEventListener("storage", onStorage);
+  mq.addEventListener("change", onChange);
+
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    mq.removeEventListener("change", onChange);
+  };
+}
+
+/**
+ * 响应式暗色态：主题切换时同步更新，供图谱渲染器就地适配文字 / 边配色。
+ *
+ * 以 `detectDark()` 作为客户端快照（返回稳定 boolean，无 tearing / 重渲染循环风险）；
+ * 服务端快照恒为 `false`（渲染器均 `ssr:false`，此处仅为 useSyncExternalStore 契约兜底）。
+ */
+export function useIsDark(): boolean {
+  return useSyncExternalStore(
+    subscribeColorScheme,
+    () => detectDark(),
+    () => false,
+  );
+}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：五个知识图谱渲染器（Sigma WebGL、ForceGraph 2D、D3 Force、Cytoscape、3D WebGL）在挂载时一次性读取 `detectDark()` 后缓存，主题切换不会重绘，只有切换引擎触发 remount 才被动刷新配色
- 关联上下文/文档：`wiki-color-scheme.ts` 模块注释

# 核心变更
- 新增 `wiki-color-scheme.ts` 响应式订阅模块：基于 `useSyncExternalStore` 封装 `useIsDark()` hook，订阅同窗 storage 事件 + 系统 matchMedia 变化，作为主题响应式的单一事实源
- 五个渲染器统一接入 `useIsDark()`，各自实现就地配色更新策略（不重建实例、不重排布局）：Sigma 调用 `setSetting` + `refresh`；Cytoscape 下发 style bypass；ForceGraph 2D/D3 Force 经函数式 prop 实时取色；3D 改用 `useState` + 动态 import 替代 `next/dynamic`，使 ref 直达实例以调用 `refresh()`
- `COLOR_SCHEME_KEY` 常量从 `ThemePreference` 迁移至 `wiki-color-scheme.ts` 并反向导入，消除魔术字符串
- 知识图谱页右上角补齐 GitHub 跳转图标（`WikiHeaderActions`）

# 风险与回滚
- 主要风险：`useSyncExternalStore` 在 React 18 strict mode 下 subscribe/unsubscribe 双调用，已验证清理函数正确移除所有 listener
- 回滚方式：`git revert` 该分支全部提交

# 验证证据
- 单元测试：无（纯 UI 响应式逻辑，无自动化测试覆盖）
- 集成测试：浏览器实机验证 light/dark 切换后五类渲染器文字与边配色即时更新
- E2E/Workflow：N/A
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：`apps/negentropy-wiki` 下 5 个 Canvas 渲染器 + `ThemePreference` + `wiki-color-scheme.ts` + `page.tsx`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 可考虑将各渲染器中散落的 `schemeColors()` / `edgeColor()` / `arrowColor()` 配色函数收敛至 `wiki-color-scheme.ts` 或 `wiki-graph-visual.ts`，进一步消除跨渲染器配色重复
