### PR TITLE
fix(wiki): 导航下拉箭头按需显示 & FAB 图标 SVG 化

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -106,7 +106,11 @@ interface WikiHeaderTabProps {
 function WikiHeaderTab({ item, pubSlug, isActive }: WikiHeaderTabProps) {
   const targetSlug = pickTabTargetSlug(item);
   const label = item.entry_title || item.entry_slug;
-  const hasChildren = isContainerItem(item) && item.children && item.children.length > 0;
+  const hasChildren =
+    isContainerItem(item) &&
+    item.children &&
+    item.children.length > 0 &&
+    item.children.some((child) => pickTabTargetSlug(child) !== null);
 
   if (!targetSlug) {
     return (

--- a/apps/negentropy-wiki/src/components/agent-chat/AgentChatFab.tsx
+++ b/apps/negentropy-wiki/src/components/agent-chat/AgentChatFab.tsx
@@ -9,6 +9,44 @@
 import { useState } from "react";
 import { ChatDrawer } from "./ChatDrawer";
 
+/** 极简对话气泡 — 圆角矩形 + 三条消息横线 */
+function ChatIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      <line x1="8" y1="9" x2="16" y2="9" opacity="0.7" />
+      <line x1="8" y1="13" x2="13" y2="13" opacity="0.5" />
+    </svg>
+  );
+}
+
+/** 极简关闭 X */
+function CloseIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <line x1="6" y1="6" x2="18" y2="18" />
+      <line x1="18" y1="6" x2="6" y2="18" />
+    </svg>
+  );
+}
+
 export default function AgentChatFab() {
   const [open, setOpen] = useState(false);
 
@@ -23,7 +61,7 @@ export default function AgentChatFab() {
         title="Agents at Wiki"
       >
         <span className="wiki-agent-chat-fab__icon" aria-hidden>
-          {open ? "✕" : "💬"}
+          {open ? <CloseIcon /> : <ChatIcon />}
         </span>
       </button>
       <ChatDrawer open={open} onClose={() => setOpen(false)} />

--- a/apps/negentropy-wiki/src/styles/components/agent-chat.css
+++ b/apps/negentropy-wiki/src/styles/components/agent-chat.css
@@ -16,8 +16,6 @@
   border: 1px solid var(--wiki-border);
   background: var(--wiki-accent);
   color: #fff;
-  font-size: 24px;
-  line-height: 1;
   cursor: pointer;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
   transition: transform 120ms ease, background 120ms ease;
@@ -35,7 +33,9 @@
 }
 
 .wiki-agent-chat-fab__icon {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* ---------- Drawer ---------- */


### PR DESCRIPTION
# 背景
- Wiki 顶部导航的 CONTAINER 类型项在所有子页均不可渲染时仍展示下拉箭头，点击后弹出空面板，用户体验异常；FAB 聊天按钮使用 emoji（💬 / ✕）作为图标，在不同 OS/浏览器下渲染不一致。
- 关联 commit：`06d6a1cd`、`2be8f15b`

# 核心变更
- **WikiHeader.tsx**：`hasChildren` 条件新增 `item.children.some((child) => pickTabTargetSlug(child) !== null)` 过滤，仅当存在至少一个可渲染子页时才展示下拉箭头，避免空下拉面板。
- **AgentChatFab.tsx**：新增 `ChatIcon`（Lucide message-square 变体）与 `CloseIcon` 两个纯 SVG 组件，替换原 emoji 渲染；图标使用 `stroke="currentColor"` 继承父级配色，无障碍性无退化（`aria-hidden` 已在父级 span 标注）。
- **agent-chat.css**：移除 emoji 专用 `font-size: 24px` / `line-height: 1`；`__icon` 容器改为 `display: flex` + 居中对齐，适配 SVG 渲染。

# 风险与回滚
- 主要风险：极低。两处变更均为 UI 表现层，不涉及数据流或状态逻辑。
- 回滚方式：`git revert` 对应 commit 即可。

# 验证证据
- 单元测试：无新增（纯 UI 展示变更，逻辑为已有 `pickTabTargetSlug` 的组合调用）。
- 集成测试：无。
- E2E/Workflow：浏览器实机验证通过。
- 覆盖率/关键截图：无。

# 影响范围
- 前端：Wiki 顶部导航栏下拉箭头、右下角 Agent 聊天 FAB 按钮。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 若后续导航树结构进一步复杂化（如多级嵌套容器），可考虑将 `hasChildren` 计算提取为独立 selector 函数并补充单元测试。