### PR TITLE
fix(wiki-header): 导航栏下拉箭头仅在直接子项为 DOCUMENT 时显示

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -106,11 +106,12 @@ interface WikiHeaderTabProps {
 function WikiHeaderTab({ item, pubSlug, isActive }: WikiHeaderTabProps) {
   const targetSlug = pickTabTargetSlug(item);
   const label = item.entry_title || item.entry_slug;
+  /* 仅当直接子项中存在 DOCUMENT（非纯 CONTAINER 分组）时渲染下拉；
+     纯 CONTAINER 子项是侧边栏层级结构，不应出现在头部下拉菜单 */
   const hasChildren =
     isContainerItem(item) &&
     item.children &&
-    item.children.length > 0 &&
-    item.children.some((child) => pickTabTargetSlug(child) !== null);
+    item.children.some((child) => !isContainerItem(child));
 
   if (!targetSlug) {
     return (


### PR DESCRIPTION
## 问题

Wiki 站点头部导航栏中，"Harness Engineering" 等导航项的所有直接子项均为 CONTAINER（纯分组节点），不应触发下拉箭头，但实际仍显示了 `▼` 箭头。

### 根因

导航树数据结构：
```
Harness Engineering (CONTAINER)
  ├── Blog (CONTAINER) ← 纯分组节点
  │     └── 文档子项...
  └── Paper (CONTAINER) ← 纯分组节点
        └── 文档子项...
```

旧逻辑使用 `pickTabTargetSlug(child)` 做过滤，但该函数对 CONTAINER 子项会 DFS 深搜到后代 DOCUMENT，导致 Blog/Paper 虽是纯分组节点却通过了检查。

## 修复

将 `hasChildren` 判定从 DFS 深搜改为**直接子项类型检查**：

```tsx
// Before: DFS 深搜后代文档
item.children.some((child) => pickTabTargetSlug(child) !== null)

// After: 仅看直接子项是否为 DOCUMENT
item.children.some((child) => !isContainerItem(child))
```

纯 CONTAINER 子项属于侧边栏层级结构，不应出现在头部下拉菜单中。

## 改动文件

| 文件 | 变更 |
|------|------|
| `apps/negentropy-wiki/src/components/WikiHeader.tsx` | `hasChildren` 条件改为检查直接子项类型 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)