### PR TITLE
style(wiki-annotation): 注解 FAB 药丸化紫罗兰重塑 + 翻译态禁用

### DIFF
--- a/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
+++ b/apps/negentropy-wiki/src/components/annotation/TextSelectionHandler.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useWikiAuth } from "@/lib/auth/wiki-auth";
 import { computeAnchor, type TextAnchor } from "@/lib/annotation/use-text-anchor";
+import { isContainerTranslated } from "@/lib/annotation/use-translation-detect";
 import type { AnnotationSnapshot } from "@/lib/annotation/use-snapshot";
 
 interface Props {
@@ -38,6 +39,12 @@ export function TextSelectionHandler({ containerSelector, onAnnotate, snapshotRe
       : range.startContainer.parentElement;
     const container = startElement?.closest?.(containerSelector) as HTMLElement | null;
     if (!container || !container.contains(range.endContainer)) {
+      setFabPosition(null);
+      return;
+    }
+
+    // 浏览器翻译态下禁用新建注解，避免锚定错乱
+    if (isContainerTranslated(container)) {
       setFabPosition(null);
       return;
     }
@@ -82,15 +89,18 @@ export function TextSelectionHandler({ containerSelector, onAnnotate, snapshotRe
     <button
       type="button"
       className="wiki-annotation-fab"
+      aria-label="添加注解"
       style={{
         left: `${fabPosition.x}px`,
         top: `${fabPosition.y}px`,
       }}
       onClick={handleClick}
     >
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
-        <path d="M2 2h12v8H5l-3 3V2z" />
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M11.5 2.5l2 2L6 12H4v-2z" />
+        <path d="M10 4l2 2" opacity="0.5" />
       </svg>
+      <span>注解</span>
     </button>
   );
 }

--- a/apps/negentropy-wiki/src/styles/components/annotation.css
+++ b/apps/negentropy-wiki/src/styles/components/annotation.css
@@ -16,7 +16,7 @@
 /* CSS Custom Highlight API 路径的样式通过 JS 运行时注入（use-highlight-renderer.ts），
    绕过 LightningCSS 不识别 ::highlight() 伪元素的构建限制 */
 
-/* 浮动注解按钮 */
+/* 浮动注解按钮 —— 药丸状紫罗兰 + 铅笔图标 + 文本标签 */
 .wiki-annotation-fab {
   position: fixed;
   transform: translate(-50%, -100%);
@@ -24,19 +24,47 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
+  gap: 5px;
   height: 32px;
+  padding: 0 12px;
   border: none;
-  border-radius: 6px;
-  background: var(--wiki-accent-green);
+  border-radius: var(--wiki-radius);
+  background: var(--wiki-accent);
   color: #fff;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  white-space: nowrap;
+  font-size: 0.8em;
+  font-weight: 600;
+  font-family: var(--wiki-body-font);
+  line-height: 1;
+  box-shadow: 0 2px 8px rgba(124, 58, 237, 0.18);
+  animation: wiki-annotation-fab-in 0.15s ease-out;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
 }
 .wiki-annotation-fab:hover {
-  transform: translate(-50%, -100%) scale(1.1);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  background: var(--wiki-accent-hover);
+  transform: translate(-50%, -100%) translateY(-2px);
+  box-shadow: 0 4px 12px rgba(124, 58, 237, 0.25);
+}
+.wiki-annotation-fab:active {
+  transform: translate(-50%, -100%) scale(0.96);
+}
+.wiki-annotation-fab:focus-visible {
+  outline: 2px solid var(--wiki-accent);
+  outline-offset: 2px;
+}
+
+@keyframes wiki-annotation-fab-in {
+  from { opacity: 0; transform: translate(-50%, -100%) scale(0.85); }
+  to   { opacity: 1; transform: translate(-50%, -100%) scale(1); }
+}
+
+/* 深色模式 FAB 阴影适配 */
+[data-color-scheme="dark"] .wiki-annotation-fab {
+  box-shadow: 0 2px 8px rgba(210, 168, 255, 0.12);
+}
+[data-color-scheme="dark"] .wiki-annotation-fab:hover {
+  box-shadow: 0 4px 12px rgba(210, 168, 255, 0.18);
 }
 
 /* 注解输入浮层 */
@@ -79,7 +107,7 @@
   font-family: var(--wiki-body-font);
 }
 .wiki-annotation-input:focus {
-  border-color: var(--wiki-accent-green);
+  border-color: var(--wiki-accent);
 }
 
 .wiki-annotation-composer-actions {
@@ -104,11 +132,15 @@
   padding: 4px 12px;
   border: none;
   border-radius: 4px;
-  background: var(--wiki-accent-green);
+  background: var(--wiki-accent);
   color: #fff;
   cursor: pointer;
   font-size: 0.85em;
   font-weight: 600;
+  transition: background 0.12s ease;
+}
+.wiki-annotation-submit-btn:hover:not(:disabled) {
+  background: var(--wiki-accent-hover);
 }
 .wiki-annotation-submit-btn:disabled {
   opacity: 0.4;
@@ -164,7 +196,7 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: var(--wiki-accent-green);
+  background: var(--wiki-accent);
   color: #fff;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 背景

注解 FAB 此前为 32px 绿色方块，与 wiki 整体紫罗兰设计语言不一致；同时浏览器翻译态下新建注解会导致锚定错乱。本次变更在 [FAB 图标 SVG 化](https://github.com/ThreeFish-AI/negentropy/pull/738) 的基础上，完成视觉重塑与翻译态防护。

## 核心变更

- **翻译态守卫** — `TextSelectionHandler` 新增 `isContainerTranslated` 检查，浏览器翻译态下隐藏 FAB、禁止新建注解，避免锚定错乱
- **FAB 药丸化重塑** — 从 32px 绿色方块改为药丸形紫罗兰按钮（铅笔 SVG 图标 + "注解"文本标签），含入场动画 `scale(0.85→1)`、hover 上浮 `translateY(-2px)`、active 缩放 `scale(0.96)`、`focus-visible` 轮廓
- **颜色统一** — 注解输入框聚焦边框、提交按钮、高亮标记全部从 `--wiki-accent-green` 切换至 `--wiki-accent`，与全局紫罗兰主题一致
- **深色模式适配** — FAB 阴影在 `[data-color-scheme="dark"]` 下切换为浅紫色调（`rgba(210,168,255,...)`），确保明暗主题下均具辨识度
- **无障碍** — 添加 `aria-label="添加注解"` 与 `:focus-visible` 键盘焦点轮廓

## 风险与回滚

- **主要风险**：4 处阴影 rgba 与 accent 色强绑定，未来调整 accent 色时需同步更新
- **回滚方式**：`git revert`

## 验证证据

| 类型 | 状态 |
|------|------|
| 单元测试 | `use-translation-detect.test.ts` 已覆盖 `isContainerTranslated` |
| 浏览器实机 | 选区 FAB 出现/消失、翻译态禁用、明暗主题切换均验证通过 |

## 影响范围

- **前端**：`wiki-annotation` 模块（`TextSelectionHandler.tsx` + `annotation.css`）
- **后端**：无
- **CI/文档**：无

## Next Best Action

将 4 处硬编码阴影 rgba 抽取为 CSS 变量（如 `--wiki-accent-shadow` / `--wiki-accent-shadow-dark`），消除 accent 色变更时的手动同步负担。
