### PR TITLE
feat(scheduler): Handler Manifest 驱动动态表单 + 任务 CRUD 全栈实现;

### DIFF
--- a/apps/negentropy-ui/app/api/interface/_proxy.ts
+++ b/apps/negentropy-ui/app/api/interface/_proxy.ts
@@ -260,6 +260,67 @@ export async function proxyPatch(request: Request, path: string) {
   return NextResponse.json(JSON.parse(text));
 }
 
+export async function proxyPut(request: Request, path: string) {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorResponse(
+      "PLUGINS_INTERNAL_ERROR",
+      "AGUI_BASE_URL is not configured",
+      500,
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_BAD_REQUEST",
+      `Invalid JSON body: ${String(error)}`,
+      400,
+    );
+  }
+
+  const upstreamUrl = new URL(path, baseUrl);
+  const incomingUrl = new URL(request.url);
+  upstreamUrl.search = incomingUrl.search;
+  const headers = extractForwardHeaders(request);
+  headers.set("content-type", "application/json");
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: "PUT",
+      headers,
+      body: JSON.stringify(body),
+      cache: "no-store",
+    });
+  } catch (error) {
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      `Upstream connection failed: ${String(error)}`,
+      502,
+    );
+  }
+
+  const text = await upstreamResponse.text();
+  if (!upstreamResponse.ok) {
+    try {
+      const errorJson = JSON.parse(text);
+      return NextResponse.json(errorJson, { status: upstreamResponse.status });
+    } catch {
+      // Fallback if not JSON
+    }
+    return errorResponse(
+      "PLUGINS_UPSTREAM_ERROR",
+      text || "Upstream returned non-OK status",
+      upstreamResponse.status,
+    );
+  }
+
+  return NextResponse.json(JSON.parse(text));
+}
+
 export async function proxyDelete(request: Request, path: string) {
   const baseUrl = getBaseUrl();
   if (!baseUrl) {

--- a/apps/negentropy-ui/app/api/scheduler/[...path]/route.ts
+++ b/apps/negentropy-ui/app/api/scheduler/[...path]/route.ts
@@ -1,4 +1,4 @@
-import { proxyGet, proxyPost } from "@/app/api/interface/_proxy";
+import { proxyDelete, proxyGet, proxyPost, proxyPut } from "@/app/api/interface/_proxy";
 
 /**
  * /api/scheduler/* → 后端 /scheduler/* 反向代理
@@ -8,13 +8,17 @@ import { proxyGet, proxyPost } from "@/app/api/interface/_proxy";
  * 不走通用代理（避免 .text() 把流读完）。
  *
  * 路由结构：
- *   GET  /api/scheduler/kpis              → /scheduler/kpis
- *   GET  /api/scheduler/tasks             → /scheduler/tasks
- *   GET  /api/scheduler/tasks/{id}        → /scheduler/tasks/{id}
- *   GET  /api/scheduler/executions        → /scheduler/executions
- *   GET  /api/scheduler/stats             → /scheduler/stats
- *   POST /api/scheduler/tasks/{id}/run    → /scheduler/tasks/{id}/run
- *   POST /api/scheduler/tasks/{id}/toggle → /scheduler/tasks/{id}/toggle
+ *   GET    /api/scheduler/kpis              → /scheduler/kpis
+ *   GET    /api/scheduler/tasks             → /scheduler/tasks
+ *   POST   /api/scheduler/tasks             → /scheduler/tasks（新建）
+ *   GET    /api/scheduler/tasks/{id}        → /scheduler/tasks/{id}
+ *   PUT    /api/scheduler/tasks/{id}        → /scheduler/tasks/{id}（编辑）
+ *   DELETE /api/scheduler/tasks/{id}        → /scheduler/tasks/{id}（删除）
+ *   GET    /api/scheduler/executions        → /scheduler/executions
+ *   GET    /api/scheduler/stats             → /scheduler/stats
+ *   GET    /api/scheduler/handlers          → /scheduler/handlers（manifest）
+ *   POST   /api/scheduler/tasks/{id}/run    → /scheduler/tasks/{id}/run
+ *   POST   /api/scheduler/tasks/{id}/toggle → /scheduler/tasks/{id}/toggle
  */
 
 type Ctx = { params: Promise<{ path: string[] }> };
@@ -31,4 +35,14 @@ export async function GET(request: Request, ctx: Ctx) {
 export async function POST(request: Request, ctx: Ctx) {
   const { path } = await ctx.params;
   return proxyPost(request, buildBackendPath(path));
+}
+
+export async function PUT(request: Request, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxyPut(request, buildBackendPath(path));
+}
+
+export async function DELETE(request: Request, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxyDelete(request, buildBackendPath(path));
 }

--- a/apps/negentropy-ui/app/interface/scheduler/_components/ManifestField.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/ManifestField.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import type { PayloadFieldSchema } from "@/features/scheduler";
+
+interface ManifestFieldProps {
+  field: PayloadFieldSchema;
+  value: unknown;
+  onChange: (name: string, value: unknown) => void;
+  disabled?: boolean;
+}
+
+/**
+ * 单个 Manifest payload 字段渲染器。
+ * 按 PayloadFieldSchema.type 映射到对应的表单控件。
+ */
+export function ManifestField({ field, value, onChange, disabled }: ManifestFieldProps) {
+  const inputCls =
+    "w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:border-zinc-500 dark:focus:ring-zinc-500";
+  const labelCls = "mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300";
+
+  const handleChange = (v: unknown) => onChange(field.name, v);
+
+  if (field.type === "boolean") {
+    return (
+      <label className="flex items-center gap-2 py-1">
+        <input
+          type="checkbox"
+          checked={!!value}
+          onChange={(e) => handleChange(e.target.checked)}
+          disabled={disabled}
+          className="h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-400 dark:border-zinc-600"
+        />
+        <span className={labelCls}>
+          {field.label}
+          {field.required && <span className="ml-0.5 text-red-500">*</span>}
+        </span>
+      </label>
+    );
+  }
+
+  if (field.type === "enum" && field.enum_options) {
+    return (
+      <div>
+        <label className={labelCls}>
+          {field.label}
+          {field.required && <span className="ml-0.5 text-red-500">*</span>}
+        </label>
+        <select
+          value={String(value ?? "")}
+          onChange={(e) => handleChange(e.target.value)}
+          disabled={disabled}
+          className={inputCls}
+        >
+          <option value="">—</option>
+          {field.enum_options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+        {field.help_text && (
+          <p className="mt-0.5 text-[10px] text-zinc-500 dark:text-zinc-400">{field.help_text}</p>
+        )}
+      </div>
+    );
+  }
+
+  if (field.type === "integer") {
+    return (
+      <div>
+        <label className={labelCls}>
+          {field.label}
+          {field.required && <span className="ml-0.5 text-red-500">*</span>}
+        </label>
+        <input
+          type="number"
+          step={1}
+          value={value != null ? String(value) : ""}
+          onChange={(e) => handleChange(e.target.value === "" ? null : parseInt(e.target.value, 10))}
+          disabled={disabled}
+          placeholder={field.help_text}
+          className={inputCls}
+        />
+      </div>
+    );
+  }
+
+  if (field.type === "number") {
+    return (
+      <div>
+        <label className={labelCls}>
+          {field.label}
+          {field.required && <span className="ml-0.5 text-red-500">*</span>}
+        </label>
+        <input
+          type="number"
+          step="any"
+          value={value != null ? String(value) : ""}
+          onChange={(e) => handleChange(e.target.value === "" ? null : parseFloat(e.target.value))}
+          disabled={disabled}
+          placeholder={field.help_text}
+          className={inputCls}
+        />
+      </div>
+    );
+  }
+
+  // default: string
+  return (
+    <div>
+      <label className={labelCls}>
+        {field.label}
+        {field.required && <span className="ml-0.5 text-red-500">*</span>}
+      </label>
+      <input
+        type="text"
+        value={String(value ?? "")}
+        onChange={(e) => handleChange(e.target.value)}
+        disabled={disabled}
+        placeholder={field.help_text}
+        className={inputCls}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerHeader.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerHeader.tsx
@@ -6,6 +6,7 @@ interface SchedulerHeaderProps {
   onTabChange: (tab: "tasks" | "executions" | "stats") => void;
   onRefresh: () => void;
   loading: boolean;
+  onCreateTask?: () => void;
 }
 
 const TABS: { key: "tasks" | "executions" | "stats"; label: string }[] = [
@@ -20,6 +21,7 @@ export function SchedulerHeader({
   onTabChange,
   onRefresh,
   loading,
+  onCreateTask,
 }: SchedulerHeaderProps) {
   return (
     <div className="flex items-center justify-between">
@@ -33,6 +35,18 @@ export function SchedulerHeader({
       </div>
 
       <div className="flex items-center gap-3">
+        {/* New Task button */}
+        {onCreateTask && (
+          <button
+            onClick={onCreateTask}
+            className="inline-flex items-center rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+          >
+            <svg className="mr-1.5 h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+            New Task
+          </button>
+        )}
         {/* Tab pills */}
         <div className="flex items-center bg-muted/50 p-1 rounded-full">
           {TABS.map((tab) => (

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
@@ -9,6 +9,8 @@ interface SchedulerTaskDetailDrawerProps {
   onClose: () => void;
   onRun: (id: string) => void;
   onToggle: (id: string, enabled: boolean) => void;
+  onEdit: (task: ScheduledTaskDTO) => void;
+  onDelete: (task: ScheduledTaskDTO) => void;
 }
 
 function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
@@ -45,6 +47,8 @@ export function SchedulerTaskDetailDrawer({
   onClose,
   onRun,
   onToggle,
+  onEdit,
+  onDelete,
 }: SchedulerTaskDetailDrawerProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -91,12 +95,17 @@ export function SchedulerTaskDetailDrawer({
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
-          <div>
+          <div className="flex items-center gap-2">
             <h2 className="text-sm font-bold text-foreground">
               {task.display_name || task.key}
             </h2>
-            <p className="text-[10px] text-muted-foreground mt-0.5">{task.key}</p>
+            {task.is_system && (
+              <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-0.5 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
+                System
+              </span>
+            )}
           </div>
+          <p className="text-[10px] text-muted-foreground mt-0.5">{task.key}</p>
           <button
             onClick={onClose}
             className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
@@ -210,6 +219,25 @@ export function SchedulerTaskDetailDrawer({
             }`}
           >
             {task.enabled ? "Disable" : "Enable"}
+          </button>
+          <div className="flex-1" />
+          <button
+            onClick={() => onDelete(task)}
+            disabled={task.is_system}
+            title={task.is_system ? "System tasks cannot be deleted" : undefined}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium border transition-colors ${
+              task.is_system
+                ? "text-muted-foreground/40 border-muted/30 cursor-not-allowed"
+                : "text-red-600 dark:text-red-400 border-red-200 dark:border-red-800 hover:bg-red-500/10"
+            }`}
+          >
+            Delete
+          </button>
+          <button
+            onClick={() => onEdit(task)}
+            className="rounded-md px-3 py-1.5 text-xs font-medium bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+          >
+            Edit
           </button>
         </div>
       </div>

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
@@ -95,17 +95,19 @@ export function SchedulerTaskDetailDrawer({
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
-          <div className="flex items-center gap-2">
-            <h2 className="text-sm font-bold text-foreground">
-              {task.display_name || task.key}
-            </h2>
-            {task.is_system && (
-              <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-0.5 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
-                System
-              </span>
-            )}
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-bold text-foreground">
+                {task.display_name || task.key}
+              </h2>
+              {task.is_system && (
+                <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2 py-0.5 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
+                  System
+                </span>
+              )}
+            </div>
+            <p className="text-[10px] text-muted-foreground mt-0.5">{task.key}</p>
           </div>
-          <p className="text-[10px] text-muted-foreground mt-0.5">{task.key}</p>
           <button
             onClick={onClose}
             className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskFormDialog.tsx
@@ -1,0 +1,626 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import type {
+  ScheduledTaskDTO,
+  HandlerDescriptor,
+  TaskWritePayload,
+  TriggerType,
+} from "@/features/scheduler";
+import { fetchHandlers } from "@/features/scheduler";
+import { ManifestField } from "./ManifestField";
+
+interface SchedulerTaskFormDialogProps {
+  open: boolean;
+  task: ScheduledTaskDTO | null; // null = create, object = edit
+  onClose: () => void;
+  onSubmit: (mode: "create" | "edit", id: string | null, body: TaskWritePayload) => Promise<void>;
+}
+
+type FormState = {
+  key: string;
+  handler_kind: string;
+  trigger_type: TriggerType;
+  interval_seconds: string;
+  cron_expr: string;
+  enabled: boolean;
+  display_name: string;
+  description: string;
+  role: string;
+  scenario: string;
+  category: string;
+  max_concurrency: string;
+  token_budget: string;
+};
+
+const EMPTY_FORM: FormState = {
+  key: "",
+  handler_kind: "",
+  trigger_type: "interval",
+  interval_seconds: "60",
+  cron_expr: "",
+  enabled: true,
+  display_name: "",
+  description: "",
+  role: "",
+  scenario: "",
+  category: "",
+  max_concurrency: "1",
+  token_budget: "",
+};
+
+export function SchedulerTaskFormDialog({
+  open,
+  task,
+  onClose,
+  onSubmit,
+}: SchedulerTaskFormDialogProps) {
+  const isEdit = task !== null;
+  const [formData, setFormData] = useState<FormState>(EMPTY_FORM);
+  const [payloadValues, setPayloadValues] = useState<Record<string, unknown>>({});
+  const [payloadJsonText, setPayloadJsonText] = useState("{}");
+  const [payloadMode, setPayloadMode] = useState<"form" | "json">("form");
+  const [handlers, setHandlers] = useState<HandlerDescriptor[]>([]);
+  const [loadingHandlers, setLoadingHandlers] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Fetch handler manifest on open
+  useEffect(() => {
+    if (!open) return;
+    let mounted = true;
+    (async () => {
+      setLoadingHandlers(true);
+      try {
+        const res = await fetchHandlers();
+        if (mounted) setHandlers(res.items);
+      } catch {
+        // fallback: empty handlers → JSON mode only
+        if (mounted) setHandlers([]);
+      } finally {
+        if (mounted) setLoadingHandlers(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [open]);
+
+  // Reset/populate form on task change
+  useEffect(() => {
+    if (!open) return;
+
+    const resetState = task
+      ? {
+          key: task.key,
+          handler_kind: task.handler_kind,
+          trigger_type: task.trigger_type,
+          interval_seconds: task.interval_seconds != null ? String(task.interval_seconds) : "",
+          cron_expr: task.cron_expr || "",
+          enabled: task.enabled,
+          display_name: task.display_name || "",
+          description: task.description || "",
+          role: task.role || "",
+          scenario: task.scenario || "",
+          category: task.category || "",
+          max_concurrency: String(task.max_concurrency),
+          token_budget: task.token_budget != null ? String(task.token_budget) : "",
+        }
+      : EMPTY_FORM;
+    const resetPayload = task ? (task.payload || {}) : {};
+    const resetJson = task ? JSON.stringify(task.payload || {}, null, 2) : "{}";
+
+    queueMicrotask(() => {
+      setError(null);
+      setFieldErrors({});
+      setFormData(resetState);
+      setPayloadValues(resetPayload);
+      setPayloadJsonText(resetJson);
+      setPayloadMode("form");
+    });
+  }, [task, open]);
+
+  // Get current handler descriptor
+  const currentDescriptor = handlers.find((h) => h.handler_kind === formData.handler_kind);
+
+  // When handler changes, reset payload
+  useEffect(() => {
+    if (!open || !handlers.length) return;
+    const desc = handlers.find((h) => h.handler_kind === formData.handler_kind);
+    if (!desc) return;
+
+    // Set defaults from schema
+    const defaults: Record<string, unknown> = {};
+    for (const f of desc.payload_fields) {
+      if (f.default !== undefined && f.default !== null) {
+        defaults[f.name] = f.default;
+      }
+    }
+    // Merge with existing only if creating or handler matches task's handler
+    if (!task || task.handler_kind !== formData.handler_kind) {
+      // Use microtask to avoid synchronous setState in effect
+      queueMicrotask(() => {
+        setPayloadValues(defaults);
+        setPayloadJsonText(JSON.stringify(defaults, null, 2));
+      });
+    }
+
+    // Adjust trigger_type if not supported
+    if (desc.trigger_types.length > 0 && !desc.trigger_types.includes(formData.trigger_type)) {
+      const fallback = (desc.default_trigger_type && desc.trigger_types.includes(desc.default_trigger_type as TriggerType))
+        ? (desc.default_trigger_type as TriggerType)
+        : desc.trigger_types[0];
+      queueMicrotask(() => {
+        setFormData((prev) => ({
+          ...prev,
+          trigger_type: fallback,
+        }));
+      });
+    }
+  }, [formData.handler_kind, formData.trigger_type, handlers, open, task]);
+
+  const updateField = useCallback((key: keyof FormState, value: string | boolean) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  // Get visible payload fields based on discriminator
+  const visibleFields = currentDescriptor
+    ? currentDescriptor.payload_fields.filter((f) => {
+        if (!f.applies_when || !currentDescriptor.discriminator_field) return true;
+        const discValue = payloadValues[currentDescriptor.discriminator_field];
+        return discValue != null && f.applies_when.includes(String(discValue));
+      })
+    : [];
+
+  // All payload field names (including non-visible) for known-set check
+  const allFieldNames = new Set((currentDescriptor?.payload_fields || []).map((f) => f.name));
+
+  const handlePayloadChange = useCallback((name: string, value: unknown) => {
+    setPayloadValues((prev) => {
+      const next = { ...prev, [name]: value };
+      setPayloadJsonText(JSON.stringify(next, null, 2));
+      return next;
+    });
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setFieldErrors({});
+
+    const errors: Record<string, string> = {};
+
+    // Validate key (create only)
+    if (!isEdit && !formData.key.trim()) {
+      errors.key = "Key is required";
+    }
+    if (!formData.handler_kind) {
+      errors.handler_kind = "Handler is required";
+    }
+    // Trigger consistency
+    if (formData.trigger_type === "interval") {
+      const val = parseFloat(formData.interval_seconds);
+      if (!val || val <= 0) errors.interval_seconds = "Must be > 0";
+    }
+    if (formData.trigger_type === "cron") {
+      if (!formData.cron_expr.trim()) errors.cron_expr = "Cron expression is required";
+    }
+    // Max concurrency
+    if (formData.max_concurrency && parseInt(formData.max_concurrency, 10) < 1) {
+      errors.max_concurrency = "Must be ≥ 1";
+    }
+    // Token budget
+    if (formData.token_budget && parseInt(formData.token_budget, 10) < 0) {
+      errors.token_budget = "Must be ≥ 0";
+    }
+    // Payload validation
+    let finalPayload: Record<string, unknown>;
+    if (payloadMode === "json") {
+      try {
+        finalPayload = JSON.parse(payloadJsonText) as Record<string, unknown>;
+      } catch (err) {
+        errors.payloadJson = err instanceof Error ? err.message : "Invalid JSON";
+        finalPayload = {};
+      }
+    } else {
+      // Form mode: validate required visible fields
+      for (const f of visibleFields) {
+        if (f.required && (payloadValues[f.name] === undefined || payloadValues[f.name] === "" || payloadValues[f.name] === null)) {
+          errors[`payload_${f.name}`] = `${f.label} is required`;
+        }
+      }
+      // Trim: only send visible + known fields
+      finalPayload = {};
+      for (const [k, v] of Object.entries(payloadValues)) {
+        if (allFieldNames.has(k) || !currentDescriptor) {
+          finalPayload[k] = v;
+        }
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      setError("Fix the highlighted fields before saving.");
+      setLoading(false);
+      return;
+    }
+
+    const body: TaskWritePayload = {
+      handler_kind: formData.handler_kind,
+      trigger_type: formData.trigger_type,
+      interval_seconds: formData.trigger_type === "interval" ? parseFloat(formData.interval_seconds) || null : null,
+      cron_expr: formData.trigger_type === "cron" ? formData.cron_expr || null : null,
+      enabled: formData.enabled,
+      display_name: formData.display_name || null,
+      description: formData.description || null,
+      role: formData.role || null,
+      scenario: formData.scenario || null,
+      category: formData.category || null,
+      payload: finalPayload,
+      max_concurrency: parseInt(formData.max_concurrency, 10) || 1,
+      token_budget: formData.token_budget ? parseInt(formData.token_budget, 10) : null,
+    };
+    if (!isEdit) {
+      body.key = formData.key.trim();
+    }
+
+    try {
+      await onSubmit(isEdit ? "edit" : "create", isEdit ? task.id : null, body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  const inputCls =
+    "w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-1 focus:ring-zinc-400 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100 dark:focus:border-zinc-500 dark:focus:ring-zinc-500";
+  const labelCls = "mb-1 block text-xs font-medium text-zinc-700 dark:text-zinc-300";
+  const sectionTitleCls = "text-[10px] uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-2";
+
+  return (
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={loading}
+      backdropClassName="bg-black/55"
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-xl flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-2xl sm:max-h-[calc(100vh-2rem)] dark:border-zinc-700 dark:bg-zinc-900"
+    >
+      {/* Header */}
+      <div className="border-b border-zinc-200 px-5 py-4 dark:border-zinc-800">
+        <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          {isEdit ? "Edit Task" : "New Task"}
+        </h2>
+        <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+          {isEdit ? `Editing "${task.display_name || task.key}"` : "Create a new scheduled task definition"}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-5">
+          {/* Error banner */}
+          {error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          {/* Basic Info */}
+          <section>
+            <h3 className={sectionTitleCls}>Basic</h3>
+            <div className="space-y-3">
+              {isEdit ? (
+                <div>
+                  <label className={labelCls}>Key</label>
+                  <input type="text" value={formData.key} disabled className={inputCls} />
+                  <p className="mt-0.5 text-[10px] text-zinc-400">Key cannot be changed after creation</p>
+                </div>
+              ) : (
+                <div>
+                  <label className={labelCls}>
+                    Key <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.key}
+                    onChange={(e) => updateField("key", e.target.value)}
+                    placeholder="unique_task_key"
+                    className={`${inputCls} ${fieldErrors.key ? "border-red-400" : ""}`}
+                  />
+                  {fieldErrors.key && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>}
+                </div>
+              )}
+
+              <div>
+                <label className={labelCls}>
+                  Handler <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={formData.handler_kind}
+                  onChange={(e) => updateField("handler_kind", e.target.value)}
+                  disabled={isEdit || loadingHandlers}
+                  className={`${inputCls} ${fieldErrors.handler_kind ? "border-red-400" : ""}`}
+                >
+                  <option value="">— Select handler —</option>
+                  {handlers.map((h) => (
+                    <option key={h.handler_kind} value={h.handler_kind}>
+                      {h.label}
+                    </option>
+                  ))}
+                </select>
+                {fieldErrors.handler_kind && (
+                  <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.handler_kind}</p>
+                )}
+              </div>
+
+              <div>
+                <label className={labelCls}>Display Name</label>
+                <input
+                  type="text"
+                  value={formData.display_name}
+                  onChange={(e) => updateField("display_name", e.target.value)}
+                  placeholder="Human-readable name"
+                  className={inputCls}
+                />
+              </div>
+
+              <div>
+                <label className={labelCls}>Description</label>
+                <textarea
+                  value={formData.description}
+                  onChange={(e) => updateField("description", e.target.value)}
+                  placeholder="What this task does"
+                  rows={2}
+                  className={inputCls}
+                />
+              </div>
+
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={formData.enabled}
+                  onChange={(e) => updateField("enabled", e.target.checked)}
+                  className="h-4 w-4 rounded border-zinc-300 dark:border-zinc-600"
+                />
+                <span className={labelCls}>Enabled</span>
+              </label>
+            </div>
+          </section>
+
+          {/* Schedule */}
+          <section>
+            <h3 className={sectionTitleCls}>Schedule</h3>
+            <div className="space-y-3">
+              <div>
+                <label className={labelCls}>Trigger Type</label>
+                <select
+                  value={formData.trigger_type}
+                  onChange={(e) => updateField("trigger_type", e.target.value)}
+                  className={inputCls}
+                >
+                  {(currentDescriptor?.trigger_types || ["interval", "cron", "oneshot"]).map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {formData.trigger_type === "interval" && (
+                <div>
+                  <label className={labelCls}>
+                    Interval (seconds) <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="number"
+                    step="1"
+                    min="1"
+                    value={formData.interval_seconds}
+                    onChange={(e) => updateField("interval_seconds", e.target.value)}
+                    placeholder="60"
+                    className={`${inputCls} ${fieldErrors.interval_seconds ? "border-red-400" : ""}`}
+                  />
+                  {fieldErrors.interval_seconds && (
+                    <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.interval_seconds}</p>
+                  )}
+                </div>
+              )}
+              {formData.trigger_type === "cron" && (
+                <div>
+                  <label className={labelCls}>
+                    Cron Expression <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.cron_expr}
+                    onChange={(e) => updateField("cron_expr", e.target.value)}
+                    placeholder="0 * * * *"
+                    className={`${inputCls} font-mono ${fieldErrors.cron_expr ? "border-red-400" : ""}`}
+                  />
+                  {fieldErrors.cron_expr && (
+                    <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.cron_expr}</p>
+                  )}
+                  <p className="mt-0.5 text-[10px] text-zinc-400">
+                    5-field POSIX cron: min hour day month weekday
+                  </p>
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* Metadata */}
+          <section>
+            <h3 className={sectionTitleCls}>Metadata</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelCls}>Role</label>
+                <input
+                  type="text"
+                  value={formData.role}
+                  onChange={(e) => updateField("role", e.target.value)}
+                  placeholder="e.g. sentinel"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Scenario</label>
+                <input
+                  type="text"
+                  value={formData.scenario}
+                  onChange={(e) => updateField("scenario", e.target.value)}
+                  placeholder="e.g. maintenance"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Category</label>
+                <input
+                  type="text"
+                  value={formData.category}
+                  onChange={(e) => updateField("category", e.target.value)}
+                  placeholder="e.g. maintenance"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Max Concurrency</label>
+                <input
+                  type="number"
+                  step="1"
+                  min="1"
+                  value={formData.max_concurrency}
+                  onChange={(e) => updateField("max_concurrency", e.target.value)}
+                  className={`${inputCls} ${fieldErrors.max_concurrency ? "border-red-400" : ""}`}
+                />
+              </div>
+              {currentDescriptor?.supports_token_budget && (
+                <div>
+                  <label className={labelCls}>Token Budget</label>
+                  <input
+                    type="number"
+                    step="1"
+                    min="0"
+                    value={formData.token_budget}
+                    onChange={(e) => updateField("token_budget", e.target.value)}
+                    placeholder="e.g. 100000"
+                    className={inputCls}
+                  />
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* Payload */}
+          {currentDescriptor && currentDescriptor.payload_fields.length > 0 && (
+            <section>
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className={sectionTitleCls}>Payload</h3>
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    onClick={() => setPayloadMode("form")}
+                    className={`rounded px-2 py-0.5 text-[10px] font-medium ${
+                      payloadMode === "form"
+                        ? "bg-zinc-200 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-100"
+                        : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400"
+                    }`}
+                  >
+                    Form
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setPayloadMode("json")}
+                    className={`rounded px-2 py-0.5 text-[10px] font-medium ${
+                      payloadMode === "json"
+                        ? "bg-zinc-200 text-zinc-900 dark:bg-zinc-700 dark:text-zinc-100"
+                        : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400"
+                    }`}
+                  >
+                    JSON
+                  </button>
+                </div>
+              </div>
+
+              {payloadMode === "form" ? (
+                <div className="space-y-3">
+                  {currentDescriptor.payload_fields.map((f) => {
+                    // Check visibility via discriminator
+                    if (f.applies_when && currentDescriptor.discriminator_field) {
+                      const discValue = payloadValues[currentDescriptor.discriminator_field];
+                      if (discValue == null || !f.applies_when.includes(String(discValue))) return null;
+                    }
+                    return (
+                      <div key={f.name}>
+                        <ManifestField
+                          field={f}
+                          value={payloadValues[f.name]}
+                          onChange={handlePayloadChange}
+                        />
+                        {fieldErrors[`payload_${f.name}`] && (
+                          <p className="mt-0.5 text-[10px] text-red-500">
+                            {fieldErrors[`payload_${f.name}`]}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div>
+                  <textarea
+                    value={payloadJsonText}
+                    onChange={(e) => setPayloadJsonText(e.target.value)}
+                    rows={6}
+                    className={`${inputCls} font-mono text-xs ${
+                      fieldErrors.payloadJson ? "border-red-400" : ""
+                    }`}
+                  />
+                  {fieldErrors.payloadJson && (
+                    <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.payloadJson}</p>
+                  )}
+                </div>
+              )}
+            </section>
+          )}
+
+          {/* Fallback JSON for handlers without manifest */}
+          {(!currentDescriptor || currentDescriptor.payload_fields.length === 0) && !loadingHandlers && formData.handler_kind && (
+            <section>
+              <h3 className={sectionTitleCls}>Payload (JSON)</h3>
+              <textarea
+                value={payloadJsonText}
+                onChange={(e) => setPayloadJsonText(e.target.value)}
+                rows={4}
+                className={`${inputCls} font-mono text-xs`}
+                placeholder="{}"
+              />
+            </section>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-zinc-200 px-5 py-3 dark:border-zinc-800">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-3 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={loading || loadingHandlers}
+            className="rounded-md bg-zinc-900 px-4 py-1.5 text-xs font-medium text-white hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          >
+            {loading ? "Saving…" : isEdit ? "Save Changes" : "Create Task"}
+          </button>
+        </div>
+      </form>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/interface/scheduler/page.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/page.tsx
@@ -3,9 +3,10 @@
 import { useState } from "react";
 import { toast } from "sonner";
 
-import type { DashboardFilters, ScheduledTaskDTO } from "@/features/scheduler";
-import { runTaskNow, toggleTaskEnabled } from "@/features/scheduler/api";
+import type { DashboardFilters, ScheduledTaskDTO, TaskWritePayload } from "@/features/scheduler";
+import { runTaskNow, toggleTaskEnabled, createTask, updateTask, deleteTask } from "@/features/scheduler/api";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 
 import { useSchedulerData } from "@/app/(home)/dashboard/_hooks/useSchedulerData";
 import { useSchedulerStream } from "@/app/(home)/dashboard/_hooks/useSchedulerStream";
@@ -17,6 +18,7 @@ import { SchedulerTaskTable } from "./_components/SchedulerTaskTable";
 import { SchedulerExecutionPanel } from "./_components/SchedulerExecutionPanel";
 import { SchedulerStatsPanel } from "./_components/SchedulerStatsPanel";
 import { SchedulerTaskDetailDrawer } from "./_components/SchedulerTaskDetailDrawer";
+import { SchedulerTaskFormDialog } from "./_components/SchedulerTaskFormDialog";
 
 const DEFAULT_FILTERS: DashboardFilters = {
   role: null,
@@ -32,6 +34,13 @@ export default function SchedulerPage() {
   const [filters, setFilters] = useState<DashboardFilters>(DEFAULT_FILTERS);
   const [selectedTask, setSelectedTask] = useState<ScheduledTaskDTO | null>(null);
 
+  // Form dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<ScheduledTaskDTO | null>(null);
+
+  // Delete confirmation
+  const { confirm, confirmDialog } = useConfirmDialog();
+
   const {
     kpis,
     tasks,
@@ -46,6 +55,8 @@ export default function SchedulerPage() {
   } = useSchedulerData(filters);
 
   const { connected } = useSchedulerStream({ onExecution: pushExecution });
+
+  // ---- Existing handlers ----
 
   const handleRun = async (id: string) => {
     try {
@@ -75,6 +86,63 @@ export default function SchedulerPage() {
     }
   };
 
+  // ---- CRUD handlers ----
+
+  const handleCreate = () => {
+    setEditingTask(null);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (task: ScheduledTaskDTO) => {
+    setEditingTask(task);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async (task: ScheduledTaskDTO) => {
+    const confirmed = await confirm({
+      title: "Delete Task",
+      message: (
+        <>
+          Are you sure you want to delete{" "}
+          <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs font-mono dark:bg-zinc-800">
+            {task.display_name || task.key}
+          </code>
+          ? This action cannot be undone. All execution history will be permanently removed.
+        </>
+      ),
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!confirmed) return;
+
+    try {
+      await deleteTask(task.id);
+      toast.success("Task deleted");
+      setSelectedTask(null);
+      refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete task");
+    }
+  };
+
+  const handleFormSubmit = async (mode: "create" | "edit", id: string | null, body: TaskWritePayload) => {
+    if (mode === "create") {
+      const created = await createTask(body);
+      toast.success("Task created");
+      setFormOpen(false);
+      refresh();
+      // Auto-select the new task
+      setSelectedTask(created);
+    } else if (mode === "edit" && id) {
+      const updated = await updateTask(id, body);
+      toast.success("Task updated");
+      setFormOpen(false);
+      refresh();
+      // Update selected task in drawer
+      setSelectedTask(updated);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col bg-zinc-50 dark:bg-zinc-950">
       <InterfaceNav title="Scheduler" />
@@ -86,6 +154,7 @@ export default function SchedulerPage() {
             onTabChange={setActiveTab}
             onRefresh={refresh}
             loading={loading}
+            onCreateTask={handleCreate}
           />
 
           {error && (
@@ -126,10 +195,23 @@ export default function SchedulerPage() {
               onClose={() => setSelectedTask(null)}
               onRun={handleRun}
               onToggle={handleToggle}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
             />
           )}
         </div>
       </div>
+
+      {/* Task Create/Edit Dialog */}
+      <SchedulerTaskFormDialog
+        open={formOpen}
+        task={editingTask}
+        onClose={() => setFormOpen(false)}
+        onSubmit={handleFormSubmit}
+      />
+
+      {/* Delete Confirmation Dialog */}
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/features/scheduler/api.ts
+++ b/apps/negentropy-ui/features/scheduler/api.ts
@@ -7,12 +7,15 @@
 import type {
   DashboardFilters,
   ExecutionListResponse,
+  HandlerListResponse,
   KpiResponse,
+  ScheduledTaskDTO,
   StatsGroupBy,
   StatsResponse,
   StatsWindow,
   TaskDetailResponse,
   TaskListResponse,
+  TaskWritePayload,
 } from "./types";
 
 const API_ROOT = "/api/scheduler";
@@ -95,5 +98,37 @@ export async function toggleTaskEnabled(
   return jsonFetch(`/tasks/${encodeURIComponent(taskId)}/toggle`, {
     method: "POST",
     body: JSON.stringify({ enabled }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Handler Manifest
+// ---------------------------------------------------------------------------
+
+export async function fetchHandlers(): Promise<HandlerListResponse> {
+  return jsonFetch("/handlers");
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export async function createTask(body: TaskWritePayload): Promise<ScheduledTaskDTO> {
+  return jsonFetch("/tasks", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function updateTask(taskId: string, body: Partial<TaskWritePayload>): Promise<ScheduledTaskDTO> {
+  return jsonFetch(`/tasks/${encodeURIComponent(taskId)}`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteTask(taskId: string): Promise<{ ok: boolean; deleted_task_id: string }> {
+  return jsonFetch(`/tasks/${encodeURIComponent(taskId)}`, {
+    method: "DELETE",
   });
 }

--- a/apps/negentropy-ui/features/scheduler/index.ts
+++ b/apps/negentropy-ui/features/scheduler/index.ts
@@ -11,6 +11,7 @@ export type {
   FireReason,
   StatsGroupBy,
   StatsWindow,
+  PayloadFieldType,
 } from "./types";
 export type {
   ScheduledTaskDTO,
@@ -22,6 +23,10 @@ export type {
   ExecutionListResponse,
   TaskDetailResponse,
   DashboardFilters,
+  PayloadFieldSchema,
+  HandlerDescriptor,
+  HandlerListResponse,
+  TaskWritePayload,
 } from "./types";
 
 // API
@@ -33,6 +38,10 @@ export {
   fetchStats,
   runTaskNow,
   toggleTaskEnabled,
+  fetchHandlers,
+  createTask,
+  updateTask,
+  deleteTask,
 } from "./api";
 
 // Filter type

--- a/apps/negentropy-ui/features/scheduler/types.ts
+++ b/apps/negentropy-ui/features/scheduler/types.ts
@@ -44,6 +44,7 @@ export interface ScheduledTaskDTO {
   updated_at: string | null;
   payload: Record<string, unknown>;
   recent: string[];
+  is_system: boolean;
 }
 
 export interface TaskExecutionDTO {
@@ -118,4 +119,60 @@ export interface DashboardFilters {
   owner: string | null;
   category: string | null;
   window: StatsWindow;
+}
+
+// ---------------------------------------------------------------------------
+// Handler Manifest — 统一定义协议
+// ---------------------------------------------------------------------------
+
+export type PayloadFieldType = "string" | "number" | "integer" | "boolean" | "enum";
+
+export interface PayloadFieldSchema {
+  name: string;
+  label: string;
+  type: PayloadFieldType;
+  required?: boolean;
+  default?: unknown;
+  enum_options?: string[];
+  help_text?: string;
+  applies_when?: string[];
+}
+
+export interface HandlerDescriptor {
+  handler_kind: string;
+  label: string;
+  description: string;
+  trigger_types: TriggerType[];
+  payload_fields: PayloadFieldSchema[];
+  discriminator_field: string | null;
+  default_trigger_type: string | null;
+  supports_token_budget: boolean;
+}
+
+export interface HandlerListResponse {
+  items: HandlerDescriptor[];
+}
+
+// ---------------------------------------------------------------------------
+// CRUD 请求载荷
+// ---------------------------------------------------------------------------
+
+export interface TaskWritePayload {
+  key?: string; // 仅 create 时必填
+  handler_kind: string;
+  trigger_type: TriggerType;
+  interval_seconds: number | null;
+  cron_expr: string | null;
+  enabled?: boolean;
+  owner_id?: string | null;
+  participant_id?: string | null;
+  agent_id?: string | null;
+  role?: string | null;
+  scenario?: string | null;
+  category?: string | null;
+  display_name?: string | null;
+  description?: string | null;
+  payload?: Record<string, unknown>;
+  max_concurrency?: number;
+  token_budget?: number | null;
 }

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0046_seed_default_scheduled_tasks.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0046_seed_default_scheduled_tasks.py
@@ -224,7 +224,6 @@ def upgrade() -> None:
             sa.bindparam("token_budget", value=spec.get("token_budget")),
             sa.bindparam("enabled", value=True),
             sa.bindparam("is_system", value=True),
-            sa.bindparam("next_fire_at", value=sa.text("NOW()")),
         ]
         op.execute(
             sa.text(
@@ -236,7 +235,7 @@ def upgrade() -> None:
                 VALUES
                     (:key, :handler_kind, :trigger_type, :interval_seconds, :cron_expr,
                      :role, :scenario, :category, :display_name, :description,
-                     :payload, :max_concurrency, :token_budget, :enabled, :is_system, :next_fire_at)
+                     :payload, :max_concurrency, :token_budget, :enabled, :is_system, NOW())
                 ON CONFLICT (key) DO NOTHING
                 """
             ).bindparams(*bindparams)

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0046_seed_default_scheduled_tasks.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0046_seed_default_scheduled_tasks.py
@@ -1,0 +1,250 @@
+"""Scheduler 任务定义迁移化种子 + is_system 列。
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-05-29 00:00:00.000000+00:00
+
+设计动机：
+    将 ``registry.ensure_defaults()`` 中硬编码的 9 条系统种子任务迁入 Alembic
+    data migration，实现 DB 驱动、UI 可配置的单一事实源闭环：
+
+      1. 新增 ``scheduled_tasks.is_system`` 列（BOOLEAN NOT NULL DEFAULT false），
+         标识系统种子任务，CRUD DELETE 时拒绝删除（409），引导用户改用 toggle 禁用；
+         与 ``builtin_tools.is_system`` / ``agents.is_system`` 范式对齐。
+      2. 9 条种子 INSERT ... ON CONFLICT (key) DO NOTHING 幂等写入：
+         - 现有 DB（已通过 ensure_defaults 跑出 9 行）：key 冲突 → 全跳过，不覆盖用户编辑 ✅
+         - 全新 DB：迁移负责 bootstrap 这 9 行 ✅
+
+    此后 ``ensure_defaults()`` 的 defaults 列表可安全清空（保留空壳函数作为
+    未来 runtime self-heal 挂载点），DB 成为任务实例的唯一事实源。
+    Handler Manifest（能力定义）仍合法留在代码中。
+
+JSONB 编码：
+    沿用 0039 的 ``sa.bindparam(..., type_=JSONB)`` + Python dict 范式。
+
+参考文献：
+[1] 0039_seed_claude_code_builtin_tool.py — 幂等 JSONB seed 范式。
+[2] 0033_plugin_is_system.py — is_system 列范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0046"
+down_revision: str | None = "0045"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+TABLE = f"{SCHEMA}.scheduled_tasks"
+
+# 系统 seed 任务的 key 集合，供 DELETE 保护校验使用。
+SEED_KEYS = frozenset(
+    {
+        "pipeline_watchdog",
+        "session_title_inspect",
+        "cache_warm",
+        "pgvector_check",
+        "agent_inspection_demo",
+        "scheduled_tasks_summary_demo",
+        "memory_cleanup",
+        "memory_consolidation",
+        "memory_reweight",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# 种子定义：与 ensure_defaults() 的 defaults 列表平移，payload 用 Python dict
+# ---------------------------------------------------------------------------
+
+_SEEDS = [
+    {
+        "key": "pipeline_watchdog",
+        "handler_kind": "pipeline_watchdog",
+        "trigger_type": "interval",
+        "interval_seconds": 60.0,
+        "cron_expr": None,
+        "role": "sentinel",
+        "scenario": "kg_kb_maintenance",
+        "category": "maintenance",
+        "display_name": "KB/KG Pipeline Watchdog",
+        "description": "收敛 cancelling/running 长尾状态的 KB/KG runs",
+        "payload": {},
+    },
+    {
+        "key": "session_title_inspect",
+        "handler_kind": "session_title_inspect",
+        "trigger_type": "interval",
+        "interval_seconds": 300.0,
+        "cron_expr": None,
+        "role": "sentinel",
+        "scenario": "session_quality",
+        "category": "maintenance",
+        "display_name": "Session Title Inspector",
+        "description": "周期巡检 Session 标题，补齐与刷新",
+        "payload": {},
+    },
+    {
+        "key": "cache_warm",
+        "handler_kind": "cache_warm",
+        "trigger_type": "oneshot",
+        "interval_seconds": None,
+        "cron_expr": None,
+        "role": "system",
+        "scenario": "bootstrap",
+        "category": "maintenance",
+        "display_name": "Model Config Cache Warm",
+        "description": "启动时预热 LLM/Embedding 配置缓存",
+        "payload": {},
+    },
+    {
+        "key": "pgvector_check",
+        "handler_kind": "pgvector_check",
+        "trigger_type": "oneshot",
+        "interval_seconds": None,
+        "cron_expr": None,
+        "role": "system",
+        "scenario": "bootstrap",
+        "category": "maintenance",
+        "display_name": "pgvector Extension Check",
+        "description": "启动时检查 pgvector 扩展可用性",
+        "payload": {},
+    },
+    {
+        "key": "agent_inspection_demo",
+        "handler_kind": "agent_inspection",
+        "trigger_type": "interval",
+        "interval_seconds": 300.0,
+        "cron_expr": None,
+        "role": "supervisor",
+        "scenario": "agent_health",
+        "category": "cognitive",
+        "display_name": "Faculty Health Inspector",
+        "description": "每 5min 检查 Faculties 五系部模块可用性",
+        "payload": {"inspection_type": "faculty_health"},
+        "token_budget": 100_000,
+    },
+    {
+        "key": "scheduled_tasks_summary_demo",
+        "handler_kind": "agent_inspection",
+        "trigger_type": "interval",
+        "interval_seconds": 600.0,
+        "cron_expr": None,
+        "role": "supervisor",
+        "scenario": "scheduler_health",
+        "category": "cognitive",
+        "display_name": "Scheduled Tasks Summary",
+        "description": "每 10min 巡检调度框架自身 last_status 分布（系统级告警）",
+        "payload": {"inspection_type": "scheduled_tasks_summary"},
+        "token_budget": 10_000,
+    },
+    {
+        "key": "memory_cleanup",
+        "handler_kind": "memory_automation",
+        "trigger_type": "cron",
+        "interval_seconds": None,
+        "cron_expr": "0 2 * * *",
+        "role": "sentinel",
+        "scenario": "memory_retention",
+        "category": "maintenance",
+        "display_name": "Ebbinghaus Cleanup",
+        "description": "基于艾宾浩斯遗忘曲线清理低价值记忆",
+        "payload": {
+            "job_type": "cleanup_memories",
+            "threshold": 0.1,
+            "min_age_days": 7,
+            "decay_lambda": 0.1,
+        },
+    },
+    {
+        "key": "memory_consolidation",
+        "handler_kind": "memory_automation",
+        "trigger_type": "cron",
+        "interval_seconds": None,
+        "cron_expr": "0 * * * *",
+        "role": "sentinel",
+        "scenario": "memory_consolidation",
+        "category": "maintenance",
+        "display_name": "Maintenance Consolidation",
+        "description": "按时间窗口批量触发会话巩固任务",
+        "payload": {
+            "job_type": "trigger_consolidation",
+            "lookback_interval": "1 hour",
+        },
+    },
+    {
+        "key": "memory_reweight",
+        "handler_kind": "memory_automation",
+        "trigger_type": "cron",
+        "interval_seconds": None,
+        "cron_expr": "0 */6 * * *",
+        "role": "sentinel",
+        "scenario": "memory_relevance",
+        "category": "maintenance",
+        "display_name": "Rocchio Reweight",
+        "description": "定期聚合用户反馈，调整记忆检索权重",
+        "payload": {
+            "job_type": "reweight_relevance",
+        },
+    },
+]
+
+
+def upgrade() -> None:
+    # 1. 新增 is_system 列
+    op.add_column(
+        "scheduled_tasks",
+        sa.Column(
+            "is_system",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+            comment="系统种子任务标记：由迁移种子写入，不可通过 UI 删除",
+        ),
+        schema=SCHEMA,
+    )
+
+    # 2. 幂等 seed 9 条默认任务
+    for spec in _SEEDS:
+        bindparams = [
+            sa.bindparam("key", value=spec["key"]),
+            sa.bindparam("handler_kind", value=spec["handler_kind"]),
+            sa.bindparam("trigger_type", value=spec["trigger_type"]),
+            sa.bindparam("interval_seconds", value=spec.get("interval_seconds")),
+            sa.bindparam("cron_expr", value=spec.get("cron_expr")),
+            sa.bindparam("role", value=spec.get("role")),
+            sa.bindparam("scenario", value=spec.get("scenario")),
+            sa.bindparam("category", value=spec.get("category")),
+            sa.bindparam("display_name", value=spec.get("display_name")),
+            sa.bindparam("description", value=spec.get("description")),
+            sa.bindparam("payload", value=spec.get("payload", {}), type_=sa.dialects.postgresql.JSONB),
+            sa.bindparam("max_concurrency", value=1),
+            sa.bindparam("token_budget", value=spec.get("token_budget")),
+            sa.bindparam("enabled", value=True),
+            sa.bindparam("is_system", value=True),
+            sa.bindparam("next_fire_at", value=sa.text("NOW()")),
+        ]
+        op.execute(
+            sa.text(
+                f"""
+                INSERT INTO {TABLE}
+                    (key, handler_kind, trigger_type, interval_seconds, cron_expr,
+                     role, scenario, category, display_name, description,
+                     payload, max_concurrency, token_budget, enabled, is_system, next_fire_at)
+                VALUES
+                    (:key, :handler_kind, :trigger_type, :interval_seconds, :cron_expr,
+                     :role, :scenario, :category, :display_name, :description,
+                     :payload, :max_concurrency, :token_budget, :enabled, :is_system, :next_fire_at)
+                ON CONFLICT (key) DO NOTHING
+                """
+            ).bindparams(*bindparams)
+        )
+
+
+def downgrade() -> None:
+    # 遵循 AGENTS.md「谨慎数据迁移回滚」原则：downgrade 仅删列，
+    # 不删除种子数据（避免误删运维已调整的配置）。
+    # 若需完全清除，请走运维 data-fix 脚本。
+    op.drop_column("scheduled_tasks", "is_system", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/__init__.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/__init__.py
@@ -1,25 +1,38 @@
 """Handler 注册中心 — 把 ``handler_kind`` 字符串路由到具体的执行函数。
 
-Phase 4 内置 6 个 handler：
-- ``skill_invoke``        — 替代旧 ``register_skill_scheduler`` tick
-- ``pipeline_watchdog``   — 替代 ``bootstrap.py`` 中的 inline ``_pipeline_watchdog_tick``
+Phase 4 内置 handler 清单：
+- ``skill_invoke``          — 替代旧 ``register_skill_scheduler`` tick
+- ``pipeline_watchdog``     — 替代 ``bootstrap.py`` 中的 inline ``_pipeline_watchdog_tick``
 - ``session_title_inspect`` — 替代旧 ``SessionTitleInspector.start()`` 自启
-- ``cache_warm``          — startup 一次性 → oneshot 任务
-- ``pgvector_check``      — startup 一次性 → oneshot 任务
-- ``agent_inspection``    — 24/7 自驱 Agent 巡检最小骨架
+- ``cache_warm``            — startup 一次性 → oneshot 任务
+- ``pgvector_check``        — startup 一次性 → oneshot 任务
+- ``agent_inspection``      — 24/7 自驱 Agent 巡检最小骨架
+- ``memory_automation``     — 仿生记忆自动化三作业统一入口
+- ``claude_code``           — Claude Code 任务执行
 
-每个 handler 是 ``async def fn(task, ctx) -> HandlerResult``，由
+每个 handler 是 ``async def fn(task) -> HandlerResult``，由
 ``ScheduledTaskRegistry.dispatch`` 调用。
+
+Handler Manifest（统一定义协议）：
+每个 handler 通过 ``register_descriptor`` 声明其 ``HandlerDescriptor``，
+包含支持触发类型、payload 字段 schema、判别式字段等信息。
+Manifest 作为「能力定义」（SSOT）与 handler 实现共置，
+供 UI 动态表单渲染消费。
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from negentropy.models.scheduled_task import ScheduledTask
+
+
+# ---------------------------------------------------------------------------
+# Handler 执行结果
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -39,6 +52,11 @@ class HandlerResult:
 
 
 HandlerFn = Callable[["ScheduledTask"], Awaitable[HandlerResult]]
+
+
+# ---------------------------------------------------------------------------
+# Handler 注册表
+# ---------------------------------------------------------------------------
 
 
 HANDLER_REGISTRY: dict[str, HandlerFn] = {}
@@ -62,14 +80,76 @@ def list_handlers() -> list[str]:
     return list(HANDLER_REGISTRY.keys())
 
 
-# Phase 4：导入子模块触发 register_handler 装饰器；显式列出以便静态扫描。
-# 任一 handler import 失败不应让 scheduler bootstrap 整个崩掉——
-# fail-soft 在 Registry 启动路径里处理。
-def _bootstrap_default_handlers() -> None:
-    """显式按需 import 默认 handler 模块，触发装饰器副作用注册。
+# ---------------------------------------------------------------------------
+# Handler Manifest — 统一定义协议
+# ---------------------------------------------------------------------------
 
-    Plan 第 5.1 节列出的 6 个 handler 必须在 ``ScheduledTaskRegistry.start()``
-    之前完成导入。本函数由 Registry 启动时调用一次。
+PayloadFieldType = Literal["string", "number", "integer", "boolean", "enum"]
+
+
+@dataclass(frozen=True)
+class PayloadField:
+    """Handler payload 单个字段的 schema 描述。
+
+    ``applies_when`` 用于判别式 handler：仅当 discriminator 字段取
+    ``applies_when`` 中的值时，该字段才在 UI 表单中显示并参与校验。
+    """
+
+    name: str
+    label: str
+    type: PayloadFieldType
+    required: bool = False
+    default: Any | None = None
+    enum_options: tuple[str, ...] | None = None  # type == "enum" 时必填
+    help_text: str | None = None
+    applies_when: tuple[str, ...] | None = None  # 判别式依赖值
+
+
+@dataclass(frozen=True)
+class HandlerDescriptor:
+    """Handler 能力描述器，驱动 UI 动态表单渲染。
+
+    与 handler 实现共置（SSOT）：payload 字段 schema 紧邻消费它的
+    handler 代码，改 handler 时同步改 descriptor，杜绝 split-brain。
+    """
+
+    handler_kind: str
+    label: str
+    description: str
+    supported_trigger_types: tuple[str, ...]  # 子集 of ("interval", "cron", "oneshot")
+    payload_fields: tuple[PayloadField, ...] = ()
+    discriminator_field: str | None = None  # 判别式 handler 的枚举字段名
+    default_trigger_type: str | None = None
+    supports_token_budget: bool = False
+
+
+HANDLER_DESCRIPTORS: dict[str, HandlerDescriptor] = {}
+
+
+def register_descriptor(d: HandlerDescriptor) -> HandlerDescriptor:
+    """注册 handler 描述器到全局 ``HANDLER_DESCRIPTORS`` 表。"""
+    HANDLER_DESCRIPTORS[d.handler_kind] = d
+    return d
+
+
+def get_descriptor(kind: str) -> HandlerDescriptor | None:
+    return HANDLER_DESCRIPTORS.get(kind)
+
+
+def list_descriptors() -> list[HandlerDescriptor]:
+    return list(HANDLER_DESCRIPTORS.values())
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_default_handlers() -> None:
+    """显式按需 import 默认 handler 模块，触发装饰器 + 描述器注册副作用。
+
+    本函数由 Registry 启动时 / API ``GET /scheduler/handlers`` 调用。
+    幂等：Python import cache 保证重复调用零开销。
     """
     from negentropy.logging import get_logger
 
@@ -92,11 +172,18 @@ def _bootstrap_default_handlers() -> None:
 
 
 __all__ = [
+    "HANDLER_DESCRIPTORS",
     "HANDLER_REGISTRY",
+    "HandlerDescriptor",
     "HandlerFn",
     "HandlerResult",
+    "PayloadField",
+    "PayloadFieldType",
     "_bootstrap_default_handlers",
+    "get_descriptor",
     "get_handler",
+    "list_descriptors",
     "list_handlers",
+    "register_descriptor",
     "register_handler",
 ]

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/agent_inspection.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/agent_inspection.py
@@ -44,9 +44,34 @@ from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.scheduled_task import ScheduledTask, TaskExecution
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, PayloadField, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.agent_inspection")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="agent_inspection",
+        label="Agent Inspection",
+        description="自驱 Agent 巡检：探活、健康检查、调度框架自检",
+        supported_trigger_types=("interval", "cron"),
+        default_trigger_type="interval",
+        discriminator_field="inspection_type",
+        payload_fields=(
+            PayloadField(
+                name="inspection_type",
+                label="Inspection Type",
+                type="enum",
+                required=True,
+                enum_options=("self_check", "faculty_health", "faculty_deep_check", "scheduled_tasks_summary"),
+                help_text=(
+                    "巡检类型：self_check=回声; faculty_health=探活;"
+                    " faculty_deep_check=深度检查; scheduled_tasks_summary=调度自检"
+                ),
+            ),
+        ),
+        supports_token_budget=True,
+    ),
+)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/cache_warm.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/cache_warm.py
@@ -7,9 +7,19 @@ from __future__ import annotations
 
 from negentropy.logging import get_logger
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.cache_warm")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="cache_warm",
+        label="Model Config Cache Warm",
+        description="启动时预热 LLM/Embedding 配置缓存",
+        supported_trigger_types=("oneshot",),
+        default_trigger_type="oneshot",
+    ),
+)
 
 
 @register_handler("cache_warm")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
@@ -11,9 +11,29 @@ from __future__ import annotations
 
 from negentropy.logging import get_logger
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, PayloadField, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.claude_code")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="claude_code",
+        label="Claude Code",
+        description="通过 Scheduler 调度 Claude Code 执行任务",
+        supported_trigger_types=("cron", "interval"),
+        default_trigger_type="cron",
+        payload_fields=(
+            PayloadField(
+                name="prompt", label="Prompt", type="string", required=True, help_text="Claude Code 的任务描述"
+            ),
+            PayloadField(name="cwd", label="Working Directory", type="string", help_text="工作目录（覆盖全局配置）"),
+            PayloadField(name="max_turns", label="Max Turns", type="integer", help_text="最大迭代轮数（覆盖全局配置）"),
+            PayloadField(
+                name="resume", label="Resume Session", type="boolean", default=False, help_text="是否续接上次会话"
+            ),
+        ),
+    ),
+)
 
 
 @register_handler("claude_code")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/memory_automation.py
@@ -20,12 +20,68 @@ from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.base import NEGENTROPY_SCHEMA
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, PayloadField, register_descriptor, register_handler
 
 if TYPE_CHECKING:
     from negentropy.models.scheduled_task import ScheduledTask
 
 logger = get_logger("negentropy.engine.schedulers.handlers.memory_automation")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="memory_automation",
+        label="Memory Automation",
+        description="仿生记忆自动化：遗忘清理、会话巩固、相关性重加权",
+        supported_trigger_types=("cron", "interval"),
+        default_trigger_type="cron",
+        discriminator_field="job_type",
+        payload_fields=(
+            PayloadField(
+                name="job_type",
+                label="Job Type",
+                type="enum",
+                required=True,
+                enum_options=("cleanup_memories", "trigger_consolidation", "reweight_relevance"),
+                help_text=(
+                    "作业类型：cleanup_memories=遗忘清理;"
+                    " trigger_consolidation=会话巩固; reweight_relevance=相关性重加权"
+                ),
+            ),
+            PayloadField(
+                name="threshold",
+                label="Threshold",
+                type="number",
+                default=0.1,
+                help_text="低价值记忆阈值（仅 cleanup_memories）",
+                applies_when=("cleanup_memories",),
+            ),
+            PayloadField(
+                name="min_age_days",
+                label="Min Age (days)",
+                type="integer",
+                default=7,
+                help_text="最小记忆天数（仅 cleanup_memories）",
+                applies_when=("cleanup_memories",),
+            ),
+            PayloadField(
+                name="decay_lambda",
+                label="Decay Lambda",
+                type="number",
+                default=0.1,
+                help_text="艾宾浩斯衰减系数（仅 cleanup_memories）",
+                applies_when=("cleanup_memories",),
+            ),
+            PayloadField(
+                name="lookback_interval",
+                label="Lookback Interval",
+                type="string",
+                default="1 hour",
+                help_text="回溯时间窗口，如 '1 hour'（仅 trigger_consolidation）",
+                applies_when=("trigger_consolidation",),
+            ),
+        ),
+    ),
+)
 
 _INTERVAL_UNIT_MAP = {
     "second": "seconds",

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pgvector_check.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pgvector_check.py
@@ -7,9 +7,19 @@ from __future__ import annotations
 
 from negentropy.logging import get_logger
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.pgvector_check")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="pgvector_check",
+        label="pgvector Extension Check",
+        description="启动时检查 pgvector 扩展可用性",
+        supported_trigger_types=("oneshot",),
+        default_trigger_type="oneshot",
+    ),
+)
 
 
 @register_handler("pgvector_check")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pipeline_watchdog.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pipeline_watchdog.py
@@ -8,9 +8,19 @@ from __future__ import annotations
 
 from negentropy.logging import get_logger
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.pipeline_watchdog")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="pipeline_watchdog",
+        label="Pipeline Watchdog",
+        description="收敛 KB/KG Pipeline 长尾状态的定时巡检",
+        supported_trigger_types=("interval",),
+        default_trigger_type="interval",
+    ),
+)
 
 
 @register_handler("pipeline_watchdog")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/session_title_inspect.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/session_title_inspect.py
@@ -8,9 +8,28 @@ from __future__ import annotations
 
 from negentropy.logging import get_logger
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, PayloadField, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.session_title_inspect")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="session_title_inspect",
+        label="Session Title Inspector",
+        description="周期巡检 Session 标题，补齐与刷新",
+        supported_trigger_types=("interval",),
+        default_trigger_type="interval",
+        payload_fields=(
+            PayloadField(name="concurrency", label="Concurrency", type="integer", help_text="并行巡检数"),
+            PayloadField(name="batch_size", label="Batch Size", type="integer", help_text="每批处理 session 数"),
+            PayloadField(name="min_events", label="Min Events", type="integer", help_text="最小事件数阈值"),
+            PayloadField(
+                name="refresh_event_delta", label="Refresh Event Delta", type="integer", help_text="刷新事件增量阈值"
+            ),
+            PayloadField(name="max_attempts", label="Max Attempts", type="integer", help_text="最大尝试次数"),
+        ),
+    ),
+)
 
 
 @register_handler("session_title_inspect")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/skill_invoke.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/skill_invoke.py
@@ -12,9 +12,28 @@ from uuid import UUID
 
 from negentropy.logging import get_logger
 
-from . import HandlerResult, register_handler
+from . import HandlerDescriptor, HandlerResult, PayloadField, register_descriptor, register_handler
 
 logger = get_logger("negentropy.engine.schedulers.handlers.skill_invoke")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="skill_invoke",
+        label="Skill Invoke",
+        description="根据 skill_schedule_id 触发一次 Skill 执行",
+        supported_trigger_types=("cron", "interval"),
+        default_trigger_type="cron",
+        payload_fields=(
+            PayloadField(
+                name="skill_schedule_id",
+                label="Skill Schedule ID",
+                type="string",
+                required=True,
+                help_text="关联的 skill_schedule 行 UUID",
+            ),
+        ),
+    ),
+)
 
 
 @register_handler("skill_invoke")

--- a/apps/negentropy/src/negentropy/engine/schedulers/registry.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/registry.py
@@ -235,135 +235,15 @@ class ScheduledTaskRegistry:
             logger.info("unified_scheduler_stopped")
 
     # ------------------------------------------------------------------
-    # 默认任务幂等注入
+    # 默认任务幂等注入（已迁入 0046 migration）
     # ------------------------------------------------------------------
 
     async def ensure_defaults(self) -> None:
-        """把 Plan 第 5.1 节列出的 5 个非 skill 默认任务幂等插入 DB。
+        """系统种子任务已迁入 Alembic 迁移 0046 幂等 seed（DB 驱动）。
 
-        skill_invoke 任务已通过 0034 migration 从 skill_schedules 回填；
-        本函数只关心非 skill 任务的首次注入。
+        保留空壳函数作为 ``start()`` 调用链的挂载点，未来可用于
+        runtime self-heal（如检测到 0 个系统任务时告警）。
         """
-        defaults: list[dict[str, Any]] = [
-            dict(
-                key="pipeline_watchdog",
-                handler_kind="pipeline_watchdog",
-                trigger_type="interval",
-                interval_seconds=60.0,
-                role="sentinel",
-                scenario="kg_kb_maintenance",
-                category="maintenance",
-                display_name="KB/KG Pipeline Watchdog",
-                description="收敛 cancelling/running 长尾状态的 KB/KG runs",
-            ),
-            dict(
-                key="session_title_inspect",
-                handler_kind="session_title_inspect",
-                trigger_type="interval",
-                interval_seconds=300.0,
-                role="sentinel",
-                scenario="session_quality",
-                category="maintenance",
-                display_name="Session Title Inspector",
-                description="周期巡检 Session 标题，补齐与刷新",
-            ),
-            dict(
-                key="cache_warm",
-                handler_kind="cache_warm",
-                trigger_type="oneshot",
-                role="system",
-                scenario="bootstrap",
-                category="maintenance",
-                display_name="Model Config Cache Warm",
-                description="启动时预热 LLM/Embedding 配置缓存",
-            ),
-            dict(
-                key="pgvector_check",
-                handler_kind="pgvector_check",
-                trigger_type="oneshot",
-                role="system",
-                scenario="bootstrap",
-                category="maintenance",
-                display_name="pgvector Extension Check",
-                description="启动时检查 pgvector 扩展可用性",
-            ),
-            dict(
-                key="agent_inspection_demo",
-                handler_kind="agent_inspection",
-                trigger_type="interval",
-                interval_seconds=300.0,
-                role="supervisor",
-                scenario="agent_health",
-                category="cognitive",
-                display_name="Faculty Health Inspector",
-                description="每 5min 检查 Faculties 五系部模块可用性",
-                payload={"inspection_type": "faculty_health"},
-                token_budget=100_000,
-            ),
-            dict(
-                key="scheduled_tasks_summary_demo",
-                handler_kind="agent_inspection",
-                trigger_type="interval",
-                interval_seconds=600.0,
-                role="supervisor",
-                scenario="scheduler_health",
-                category="cognitive",
-                display_name="Scheduled Tasks Summary",
-                description="每 10min 巡检调度框架自身 last_status 分布（系统级告警）",
-                payload={"inspection_type": "scheduled_tasks_summary"},
-                token_budget=10_000,
-            ),
-            dict(
-                key="memory_cleanup",
-                handler_kind="memory_automation",
-                trigger_type="cron",
-                cron_expr="0 2 * * *",
-                role="sentinel",
-                scenario="memory_retention",
-                category="maintenance",
-                display_name="Ebbinghaus Cleanup",
-                description="基于艾宾浩斯遗忘曲线清理低价值记忆",
-                payload={
-                    "job_type": "cleanup_memories",
-                    "threshold": 0.1,
-                    "min_age_days": 7,
-                    "decay_lambda": 0.1,
-                },
-            ),
-            dict(
-                key="memory_consolidation",
-                handler_kind="memory_automation",
-                trigger_type="cron",
-                cron_expr="0 * * * *",
-                role="sentinel",
-                scenario="memory_consolidation",
-                category="maintenance",
-                display_name="Maintenance Consolidation",
-                description="按时间窗口批量触发会话巩固任务",
-                payload={
-                    "job_type": "trigger_consolidation",
-                    "lookback_interval": "1 hour",
-                },
-            ),
-            dict(
-                key="memory_reweight",
-                handler_kind="memory_automation",
-                trigger_type="cron",
-                cron_expr="0 */6 * * *",
-                role="sentinel",
-                scenario="memory_relevance",
-                category="maintenance",
-                display_name="Rocchio Reweight",
-                description="定期聚合用户反馈，调整记忆检索权重",
-                payload={
-                    "job_type": "reweight_relevance",
-                },
-            ),
-        ]
-        async with AsyncSessionLocal() as db:
-            for spec in defaults:
-                await _upsert_default_task(db, spec, lease_seconds=self._lease_seconds)
-            await db.commit()
 
     # ------------------------------------------------------------------
     # 心跳 tick：扫表 → 派发

--- a/apps/negentropy/src/negentropy/interface/scheduler_api.py
+++ b/apps/negentropy/src/negentropy/interface/scheduler_api.py
@@ -1,14 +1,18 @@
 """/scheduler/* 聚合 API — Phase 4 Dashboard 后端契约。
 
-端点清单（Plan 第 7 节）：
-- GET  /scheduler/kpis          KPI 卡片数据
-- GET  /scheduler/tasks         任务清单（多维筛选）
-- GET  /scheduler/tasks/{id}    单任务详情 + 最近执行
-- GET  /scheduler/executions    执行历史（分页 + 多维筛选）
-- GET  /scheduler/stats         分组聚合（角色/场景/Agent/Owner/Handler）
-- POST /scheduler/tasks/{id}/run     手动触发
-- POST /scheduler/tasks/{id}/toggle  启停
-- GET  /scheduler/stream        SSE 实时执行事件
+端点清单：
+- GET  /scheduler/kpis                KPI 卡片数据
+- GET  /scheduler/tasks               任务清单（多维筛选）
+- GET  /scheduler/tasks/{id}          单任务详情 + 最近执行
+- GET  /scheduler/executions          执行历史（分页 + 多维筛选）
+- GET  /scheduler/stats               分组聚合（角色/场景/Agent/Owner/Handler）
+- GET  /scheduler/handlers            Handler manifest（统一定义协议）
+- POST /scheduler/tasks               创建任务
+- PUT  /scheduler/tasks/{id}          更新任务
+- DELETE /scheduler/tasks/{id}        删除任务
+- POST /scheduler/tasks/{id}/run      手动触发
+- POST /scheduler/tasks/{id}/toggle   启停
+- GET  /scheduler/stream              SSE 实时执行事件
 
 参考文献：
 [1] FastAPI Docs, *Server-Sent Events with StreamingResponse*. SSE 实现模式。
@@ -26,9 +30,9 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import and_, case, func, select, update
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
@@ -127,6 +131,7 @@ def _serialize_task(t: ScheduledTask, recent: list[str] | None = None) -> dict[s
         "updated_at": t.updated_at.isoformat() if t.updated_at else None,
         "payload": t.payload or {},
         "recent": recent or [],
+        "is_system": t.is_system,
     }
 
 
@@ -526,6 +531,380 @@ async def toggle_task(task_id: UUID, body: ToggleBody) -> dict[str, Any]:
             raise HTTPException(status_code=500, detail=f"toggle failed: {exc}") from exc
     _STATS_CACHE.invalidate()
     return {"ok": True, "enabled": body.enabled}
+
+
+# ---------------------------------------------------------------------------
+# GET /scheduler/stream (SSE)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Handler Manifest — 统一定义协议
+# ---------------------------------------------------------------------------
+
+
+def _serialize_descriptor(d: HandlerDescriptor) -> dict[str, Any]:  # noqa: F821
+    """将 HandlerDescriptor dataclass 序列化为 API 响应 dict。"""
+    from negentropy.engine.schedulers.handlers import PayloadField
+
+    def _field(f: PayloadField) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "name": f.name,
+            "label": f.label,
+            "type": f.type,
+            "required": f.required,
+        }
+        if f.default is not None:
+            result["default"] = f.default
+        if f.enum_options:
+            result["enum_options"] = list(f.enum_options)
+        if f.help_text:
+            result["help_text"] = f.help_text
+        if f.applies_when:
+            result["applies_when"] = list(f.applies_when)
+        return result
+
+    return {
+        "handler_kind": d.handler_kind,
+        "label": d.label,
+        "description": d.description,
+        "trigger_types": list(d.supported_trigger_types),
+        "payload_fields": [_field(f) for f in d.payload_fields],
+        "discriminator_field": d.discriminator_field,
+        "default_trigger_type": d.default_trigger_type,
+        "supports_token_budget": d.supports_token_budget,
+    }
+
+
+@router.get("/handlers")
+async def list_handler_descriptors() -> dict[str, Any]:
+    """返回所有已注册 Handler 的能力描述（驱动 UI 动态表单）。"""
+    from negentropy.engine.schedulers.handlers import _bootstrap_default_handlers, list_descriptors
+
+    _bootstrap_default_handlers()  # 幂等：确保 handler 模块已 import → 描述器已注册
+    return {"items": [_serialize_descriptor(d) for d in list_descriptors()]}
+
+
+# ---------------------------------------------------------------------------
+# CRUD — Pydantic 请求模型
+# ---------------------------------------------------------------------------
+
+
+class TaskCreateRequest(BaseModel):
+    key: str = Field(..., min_length=1, max_length=192, description="任务唯一标识，创建后不可变")
+    handler_kind: str = Field(..., min_length=1, max_length=64)
+    trigger_type: Literal["interval", "cron", "oneshot"]
+    interval_seconds: float | None = None
+    cron_expr: str | None = None
+    enabled: bool = True
+    owner_id: str | None = None
+    participant_id: str | None = None
+    agent_id: UUID | None = None
+    role: str | None = None
+    scenario: str | None = None
+    category: str | None = None
+    display_name: str | None = None
+    description: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    max_concurrency: int = Field(default=1, ge=1)
+    token_budget: int | None = Field(default=None, ge=0)
+
+
+class TaskUpdateRequest(BaseModel):
+    handler_kind: str | None = None
+    trigger_type: Literal["interval", "cron", "oneshot"] | None = None
+    interval_seconds: float | None = None
+    cron_expr: str | None = None
+    enabled: bool | None = None
+    owner_id: str | None = None
+    participant_id: str | None = None
+    agent_id: UUID | None = None
+    role: str | None = None
+    scenario: str | None = None
+    category: str | None = None
+    display_name: str | None = None
+    description: str | None = None
+    payload: dict[str, Any] | None = None
+    max_concurrency: int | None = Field(default=None, ge=1)
+    token_budget: int | None = Field(default=None, ge=0)
+
+
+# ---------------------------------------------------------------------------
+# CRUD — 共享校验
+# ---------------------------------------------------------------------------
+
+
+def _validate_task_spec(
+    handler_kind: str,
+    trigger_type: str,
+    interval_seconds: float | None,
+    cron_expr: str | None,
+    payload: dict[str, Any],
+) -> None:
+    """纯函数校验任务定义一致性。失败抛 HTTPException(400)。"""
+    from negentropy.engine.schedulers.handlers import (
+        HANDLER_REGISTRY,
+        _bootstrap_default_handlers,
+        get_descriptor,
+    )
+
+    _bootstrap_default_handlers()
+
+    # 1. handler_kind 合法性
+    if handler_kind not in HANDLER_REGISTRY:
+        raise HTTPException(status_code=400, detail=f"unknown handler_kind: {handler_kind}")
+
+    # 2. trigger 一致性
+    if trigger_type == "interval":
+        if not interval_seconds or interval_seconds <= 0:
+            raise HTTPException(status_code=400, detail="interval trigger requires interval_seconds > 0")
+        if cron_expr:
+            raise HTTPException(status_code=400, detail="interval trigger must not have cron_expr")
+    elif trigger_type == "cron":
+        if not cron_expr:
+            raise HTTPException(status_code=400, detail="cron trigger requires cron_expr")
+        if interval_seconds:
+            raise HTTPException(status_code=400, detail="cron trigger must not have interval_seconds")
+        # croniter 校验
+        try:
+            from croniter import croniter
+
+            croniter(cron_expr, _utcnow())
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"invalid cron expression: {exc}") from exc
+    elif trigger_type == "oneshot":
+        if interval_seconds or cron_expr:
+            raise HTTPException(status_code=400, detail="oneshot trigger must not have interval_seconds or cron_expr")
+    else:
+        raise HTTPException(status_code=400, detail=f"invalid trigger_type: {trigger_type}")
+
+    # 3. trigger_type ∈ descriptor.supported_trigger_types
+    descriptor = get_descriptor(handler_kind)
+    if descriptor and descriptor.supported_trigger_types and trigger_type not in descriptor.supported_trigger_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"handler {handler_kind} does not support trigger_type {trigger_type}, "
+            f"supported: {list(descriptor.supported_trigger_types)}",
+        )
+
+    # 4. payload 校验 against manifest
+    if descriptor and descriptor.payload_fields:
+        _validate_payload_against_manifest(payload, descriptor)
+
+
+def _validate_payload_against_manifest(
+    payload: dict[str, Any],
+    descriptor: HandlerDescriptor,  # noqa: F821
+) -> None:
+    """校验 payload 字段与 manifest 一致性。"""
+
+    # 判别式字段值
+    discriminator_value: str | None = None
+    if descriptor.discriminator_field:
+        discriminator_value = payload.get(descriptor.discriminator_field)
+        if discriminator_value is None:
+            # 判别式字段缺失 → 宽松放行（edit 可能只改了 trigger 等非 payload 字段）
+            return
+
+    known_names: set[str] = set()
+    for pf in descriptor.payload_fields:
+        known_names.add(pf.name)
+        # 判别式依赖过滤
+        if pf.applies_when and discriminator_value and discriminator_value not in pf.applies_when:
+            continue
+        # enum 校验
+        if pf.type == "enum" and pf.enum_options:
+            val = payload.get(pf.name)
+            if val is not None and val not in pf.enum_options:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"payload.{pf.name} invalid enum value '{val}', options: {list(pf.enum_options)}",
+                )
+        # required 校验（仅对可见字段）
+        if pf.required and pf.name not in payload:
+            raise HTTPException(status_code=400, detail=f"payload.{pf.name} is required")
+
+
+def _compute_next_fire_for_spec(
+    trigger_type: str, interval_seconds: float | None, cron_expr: str | None
+) -> datetime | None:
+    """根据 trigger 配置计算 next_fire_at（与 registry._compute_next_fire 对齐）。"""
+    now = _utcnow()
+    if trigger_type == "interval" and interval_seconds:
+        return now + timedelta(seconds=float(interval_seconds))
+    if trigger_type == "cron" and cron_expr:
+        try:
+            from croniter import croniter
+
+            return croniter(cron_expr, now).get_next(datetime)
+        except Exception:
+            return now + timedelta(minutes=5)
+    # oneshot: 首次设 now 让它立即被 claim
+    if trigger_type == "oneshot":
+        return now
+    return now
+
+
+# ---------------------------------------------------------------------------
+# CRUD — POST /scheduler/tasks
+# ---------------------------------------------------------------------------
+
+
+@router.post("/tasks", status_code=201)
+async def create_task(body: TaskCreateRequest) -> dict[str, Any]:
+    """创建新的调度任务。"""
+    _validate_task_spec(body.handler_kind, body.trigger_type, body.interval_seconds, body.cron_expr, body.payload)
+
+    async with AsyncSessionLocal() as db:
+        # key 唯一性
+        existing = (await db.execute(select(ScheduledTask).where(ScheduledTask.key == body.key))).scalar_one_or_none()
+        if existing:
+            raise HTTPException(status_code=409, detail=f"task key '{body.key}' already exists")
+
+        next_fire = _compute_next_fire_for_spec(body.trigger_type, body.interval_seconds, body.cron_expr)
+        task = ScheduledTask(
+            key=body.key,
+            handler_kind=body.handler_kind,
+            trigger_type=body.trigger_type,
+            interval_seconds=body.interval_seconds,
+            cron_expr=body.cron_expr,
+            enabled=body.enabled,
+            owner_id=body.owner_id,
+            participant_id=body.participant_id,
+            agent_id=body.agent_id,
+            role=body.role,
+            scenario=body.scenario,
+            category=body.category,
+            display_name=body.display_name,
+            description=body.description,
+            payload=body.payload,
+            max_concurrency=body.max_concurrency,
+            token_budget=body.token_budget,
+            next_fire_at=next_fire,
+        )
+        db.add(task)
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail=f"conflict: {exc}") from exc
+        except SQLAlchemyError as exc:
+            await db.rollback()
+            logger.warning("create_task_failed", key=body.key, error=str(exc))
+            raise HTTPException(status_code=500, detail=f"create failed: {exc}") from exc
+        await db.refresh(task)
+
+    _STATS_CACHE.invalidate()
+    return _serialize_task(task)
+
+
+# ---------------------------------------------------------------------------
+# CRUD — PUT /scheduler/tasks/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.put("/tasks/{task_id}")
+async def update_task(task_id: UUID, body: TaskUpdateRequest) -> dict[str, Any]:
+    """更新调度任务定义（key 不可变）。"""
+    async with AsyncSessionLocal() as db:
+        task = await db.get(ScheduledTask, task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="task not found")
+        if task.is_system:
+            raise HTTPException(
+                status_code=409,
+                detail="system task cannot be modified; disable it instead",
+            )
+
+        # 收集 exclude_unset 字段（区分"未传"与"显式传 null"）
+        # 收集 exclude_unset 字段（区分"未传"与"显式传 null"）
+        update_data = body.model_dump(exclude_unset=True)
+        if not update_data:
+            return _serialize_task(task)
+
+        # 合并现有值 + 新值，形成完整视图用于校验
+        merged_handler = update_data.get("handler_kind", task.handler_kind)
+        merged_trigger = update_data.get("trigger_type", task.trigger_type)
+        merged_interval = update_data.get("interval_seconds", task.interval_seconds)
+        merged_cron = update_data.get("cron_expr", task.cron_expr)
+        merged_payload = update_data.get("payload", task.payload or {})
+
+        # trigger 切换时清空旧字段
+        if "trigger_type" in update_data:
+            new_tt = update_data["trigger_type"]
+            if new_tt == "oneshot":
+                merged_interval = None
+                merged_cron = None
+                if "interval_seconds" not in update_data:
+                    update_data["interval_seconds"] = None
+                if "cron_expr" not in update_data:
+                    update_data["cron_expr"] = None
+            elif new_tt == "interval":
+                merged_cron = None
+                if "cron_expr" not in update_data:
+                    update_data["cron_expr"] = None
+            elif new_tt == "cron":
+                merged_interval = None
+                if "interval_seconds" not in update_data:
+                    update_data["interval_seconds"] = None
+
+        _validate_task_spec(merged_handler, merged_trigger, merged_interval, merged_cron, merged_payload)
+
+        # 检测 schedule 变更 → 重算 next_fire_at
+        schedule_changed = any(k in update_data for k in ("trigger_type", "interval_seconds", "cron_expr"))
+
+        # 应用更新
+        for field_name, value in update_data.items():
+            if field_name == "agent_id" and value is not None:
+                value = UUID(str(value))
+            setattr(task, field_name, value)
+
+        if schedule_changed:
+            task.next_fire_at = _compute_next_fire_for_spec(
+                task.trigger_type,
+                task.interval_seconds,
+                task.cron_expr,
+            )
+
+        try:
+            await db.commit()
+        except SQLAlchemyError as exc:
+            await db.rollback()
+            logger.warning("update_task_failed", task_id=str(task_id), error=str(exc))
+            raise HTTPException(status_code=500, detail=f"update failed: {exc}") from exc
+        await db.refresh(task)
+
+    _STATS_CACHE.invalidate()
+    return _serialize_task(task)
+
+
+# ---------------------------------------------------------------------------
+# CRUD — DELETE /scheduler/tasks/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/tasks/{task_id}")
+async def delete_task(task_id: UUID) -> dict[str, Any]:
+    """删除调度任务（系统种子任务不可删除）。"""
+    async with AsyncSessionLocal() as db:
+        task = await db.get(ScheduledTask, task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="task not found")
+        if task.is_system:
+            raise HTTPException(
+                status_code=409,
+                detail=f"system task '{task.key}' cannot be deleted; use toggle to disable instead",
+            )
+        try:
+            await db.delete(task)
+            await db.commit()
+        except SQLAlchemyError as exc:
+            await db.rollback()
+            logger.warning("delete_task_failed", task_id=str(task_id), error=str(exc))
+            raise HTTPException(status_code=500, detail=f"delete failed: {exc}") from exc
+
+    _STATS_CACHE.invalidate()
+    return {"ok": True, "deleted_task_id": str(task_id)}
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/src/negentropy/interface/scheduler_api.py
+++ b/apps/negentropy/src/negentropy/interface/scheduler_api.py
@@ -817,7 +817,6 @@ async def update_task(task_id: UUID, body: TaskUpdateRequest) -> dict[str, Any]:
             )
 
         # 收集 exclude_unset 字段（区分"未传"与"显式传 null"）
-        # 收集 exclude_unset 字段（区分"未传"与"显式传 null"）
         update_data = body.model_dump(exclude_unset=True)
         if not update_data:
             return _serialize_task(task)

--- a/apps/negentropy/src/negentropy/models/scheduled_task.py
+++ b/apps/negentropy/src/negentropy/models/scheduled_task.py
@@ -68,6 +68,14 @@ class ScheduledTask(Base, UUIDMixin, TimestampMixin):
     token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
     backoff_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    is_system: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+        comment="系统种子任务标记：由迁移种子写入，不可通过 UI 删除",
+    )
+
     executions: Mapped[list[TaskExecution]] = relationship(
         back_populates="task",
         cascade="all, delete-orphan",

--- a/apps/negentropy/tests/unit_tests/engine/test_scheduler_handlers.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_scheduler_handlers.py
@@ -19,6 +19,7 @@ from negentropy.engine.schedulers.handlers import (
     HANDLER_REGISTRY,
     HandlerResult,
     _bootstrap_default_handlers,
+    get_descriptor,
     get_handler,
     list_handlers,
 )
@@ -67,7 +68,7 @@ def _make_task(
 
 
 class TestRegistry:
-    def test_all_six_handlers_registered(self):
+    def test_all_eight_handlers_registered(self):
         expected = {
             "skill_invoke",
             "pipeline_watchdog",
@@ -75,6 +76,8 @@ class TestRegistry:
             "cache_warm",
             "pgvector_check",
             "agent_inspection",
+            "memory_automation",
+            "claude_code",
         }
         assert expected <= set(HANDLER_REGISTRY.keys())
 
@@ -84,6 +87,44 @@ class TestRegistry:
 
     def test_get_handler_missing_returns_none(self):
         assert get_handler("nonexistent_kind") is None
+
+
+class TestDescriptorRegistry:
+    """验证每个 handler 都有对应的 descriptor，且判别式 handler 结构正确。"""
+
+    def test_every_handler_has_descriptor(self):
+        for kind in HANDLER_REGISTRY:
+            desc = get_descriptor(kind)
+            assert desc is not None, f"handler '{kind}' has no descriptor"
+            assert desc.handler_kind == kind
+            assert desc.label  # label 非空
+            assert desc.supported_trigger_types  # 至少支持一种触发类型
+
+    def test_agent_inspection_descriptor(self):
+        desc = get_descriptor("agent_inspection")
+        assert desc is not None
+        assert desc.discriminator_field == "inspection_type"
+        assert desc.supports_token_budget is True
+        # 枚举字段存在
+        enum_fields = [f for f in desc.payload_fields if f.type == "enum"]
+        assert len(enum_fields) == 1
+        assert enum_fields[0].name == "inspection_type"
+        assert "faculty_health" in (enum_fields[0].enum_options or ())
+
+    def test_memory_automation_descriptor(self):
+        desc = get_descriptor("memory_automation")
+        assert desc is not None
+        assert desc.discriminator_field == "job_type"
+        # 从属字段带 applies_when
+        threshold = next(f for f in desc.payload_fields if f.name == "threshold")
+        assert threshold.applies_when == ("cleanup_memories",)
+        lookback = next(f for f in desc.payload_fields if f.name == "lookback_interval")
+        assert lookback.applies_when == ("trigger_consolidation",)
+
+    def test_oneshot_handlers_only_support_oneshot(self):
+        for kind in ("cache_warm", "pgvector_check"):
+            desc = get_descriptor(kind)
+            assert desc.supported_trigger_types == ("oneshot",)
 
 
 @pytest.fixture

--- a/apps/negentropy/tests/unit_tests/interface/test_scheduler_api.py
+++ b/apps/negentropy/tests/unit_tests/interface/test_scheduler_api.py
@@ -1,6 +1,7 @@
 """/scheduler/* API 端点级单测
 
-聚焦工具函数（_window_to_delta、_serialize_task）与路由 metadata，
+聚焦工具函数（_window_to_delta、_serialize_task、_validate_task_spec）
+与路由 metadata、handler descriptor 序列化，
 DB 相关分支留给 integration_tests 在真实 Postgres 上覆盖。
 """
 
@@ -26,7 +27,7 @@ def test_window_to_delta_unknown_falls_back_to_24h():
     assert _window_to_delta("xyz") == timedelta(hours=24)
 
 
-def test_router_exposes_eight_endpoints():
+def test_router_exposes_all_endpoints():
     from negentropy.interface.scheduler_api import router
 
     paths = {r.path for r in router.routes}
@@ -39,11 +40,12 @@ def test_router_exposes_eight_endpoints():
         "/scheduler/tasks/{task_id}/run",
         "/scheduler/tasks/{task_id}/toggle",
         "/scheduler/stream",
+        "/scheduler/handlers",
     }
     assert expected <= paths
 
 
-def test_serialize_task_minimal():
+def test_serialize_task_includes_is_system():
     from negentropy.interface.scheduler_api import _serialize_task
 
     class _Fake:
@@ -78,12 +80,97 @@ def test_serialize_task_minimal():
     t.created_at = now
     t.updated_at = now
     t.payload = {"inspection_type": "self_check"}
+    t.is_system = False
 
     data = _serialize_task(t, recent=["ok", "ok"])
     assert data["key"] == "demo"
     assert data["handler_kind"] == "agent_inspection"
     assert data["recent"] == ["ok", "ok"]
     assert data["payload"]["inspection_type"] == "self_check"
+    assert data["is_system"] is False
+
+
+def test_serialize_descriptor():
+    from negentropy.engine.schedulers.handlers import (
+        _bootstrap_default_handlers,
+        get_descriptor,
+    )
+    from negentropy.interface.scheduler_api import _serialize_descriptor
+
+    _bootstrap_default_handlers()
+    desc = get_descriptor("memory_automation")
+    assert desc is not None
+
+    data = _serialize_descriptor(desc)
+    assert data["handler_kind"] == "memory_automation"
+    assert data["discriminator_field"] == "job_type"
+    assert len(data["payload_fields"]) == 5
+    # 验证 applies_when 正确序列化
+    threshold_field = next(f for f in data["payload_fields"] if f["name"] == "threshold")
+    assert threshold_field["applies_when"] == ["cleanup_memories"]
+
+
+class TestValidateTaskSpec:
+    """覆盖 _validate_task_spec 的各分支。"""
+
+    def _validate(self, **overrides):
+        from negentropy.interface.scheduler_api import _validate_task_spec
+
+        spec = {
+            "handler_kind": "pipeline_watchdog",
+            "trigger_type": "interval",
+            "interval_seconds": 60.0,
+            "cron_expr": None,
+            "payload": {},
+        }
+        spec.update(overrides)
+        _validate_task_spec(
+            spec["handler_kind"],
+            spec["trigger_type"],
+            spec["interval_seconds"],
+            spec["cron_expr"],
+            spec["payload"],
+        )
+
+    def test_valid_interval_task(self):
+        self._validate()  # 不抛异常即通过
+
+    def test_unknown_handler_rejected(self):
+        with pytest.raises(Exception, match="unknown handler_kind"):
+            self._validate(handler_kind="nonexistent_handler")
+
+    def test_interval_without_seconds_rejected(self):
+        with pytest.raises(Exception, match="interval_seconds > 0"):
+            self._validate(interval_seconds=None)
+
+    def test_interval_with_cron_rejected(self):
+        with pytest.raises(Exception, match="must not have cron_expr"):
+            self._validate(cron_expr="0 * * * *")
+
+    def test_cron_without_expr_rejected(self):
+        with pytest.raises(Exception, match="cron trigger requires cron_expr"):
+            self._validate(trigger_type="cron", interval_seconds=None, cron_expr=None)
+
+    def test_invalid_cron_rejected(self):
+        with pytest.raises(Exception, match="invalid cron"):
+            self._validate(trigger_type="cron", interval_seconds=None, cron_expr="not-valid-cron")
+
+    def test_oneshot_with_interval_rejected(self):
+        with pytest.raises(Exception, match="must not have interval_seconds"):
+            self._validate(trigger_type="oneshot", interval_seconds=60.0, cron_expr=None)
+
+    def test_unsupported_trigger_type_for_handler(self):
+        with pytest.raises(Exception, match="does not support trigger_type"):
+            self._validate(handler_kind="cache_warm", trigger_type="interval", interval_seconds=60.0)
+
+    def test_valid_cron_task(self):
+        self._validate(
+            handler_kind="memory_automation",
+            trigger_type="cron",
+            interval_seconds=None,
+            cron_expr="0 * * * *",
+            payload={"job_type": "cleanup_memories"},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：将 Scheduler 任务管理从只读展示升级为完整的可配置化 CRUD 闭环，使运维人员可通过 UI 自主创建、编辑、删除调度任务，无需改代码重新部署
- 关联上下文/文档：Handler Manifest 统一定义协议，每个 handler 声明其 payload schema、支持触发类型、判别式字段等能力描述，作为 UI 动态表单渲染的 SSOT

# 核心变更
- **Handler Manifest 协议**：新增 `HandlerDescriptor` / `PayloadField` dataclass，8 个 handler 各自共置 descriptor 注册，包含 payload 字段 schema、判别式字段（如 `memory_automation` 的 `job_type`）、`applies_when` 条件可见性
- **后端 CRUD 端点**：`POST /scheduler/tasks`（创建）、`PUT /scheduler/tasks/{id}`（编辑）、`DELETE /scheduler/tasks/{id}`（删除），含完整的 trigger 一致性校验、handler 能力校验、payload manifest 校验
- **`GET /scheduler/handlers` 端点**：返回全部 handler descriptor，驱动前端动态表单渲染
- **前端 Form Dialog**：`SchedulerTaskFormDialog` 组件，支持 Form / JSON 双模式编辑 payload，自动根据 descriptor 渲染字段、处理判别式可见性、校验必填项
- **ManifestField 组件**：按 `PayloadFieldType`（string / number / integer / boolean / enum）映射到对应表单控件
- **系统任务保护**：新增 `is_system` 列 + migration 0046 种子迁移，系统任务不可删除/修改（409），引导用户改用 toggle 禁用
- **代理层补齐**：`_proxy.ts` 新增 `proxyPut` / `proxyDelete`，路由层新增 `PUT` / `DELETE` export
- **种子任务迁移化**：`registry.ensure_defaults()` 中 9 条硬编码种子迁入 Alembic 0046 data migration，DB 成为任务实例唯一事实源
- **Drawer 增强**：Detail Drawer 新增 Edit / Delete 操作按钮 + System badge 展示

# 风险与回滚
- 主要风险：migration 0046 新增 `is_system` 列（`BOOLEAN NOT NULL DEFAULT false`），`downgrade` 仅删列不删种子数据，遵循「谨慎数据迁移回滚」原则
- 回滚方式：`alembic downgrade 0045` 回退列；前端为纯增量 UI，回退无副作用

# 验证证据
- 单元测试：`test_scheduler_handlers.py` 新增 `TestDescriptorRegistry` 4 条用例（descriptor 完整性、判别式字段、applies_when、oneshot 约束）；`test_scheduler_api.py` 新增 `TestValidateTaskSpec` 9 条用例覆盖各校验分支 + `_serialize_descriptor` 序列化验证
- 集成测试：CRUD 端点 DB 交互留给 integration_tests
- E2E/Workflow：待浏览器实机验证
- 覆盖率/关键截图：Handler Manifest API → UI Form 动态渲染链路

# 影响范围
- 前端：`negentropy-ui` 新增 3 个组件（`SchedulerTaskFormDialog` / `ManifestField` / SchedulerHeader 改造）、`features/scheduler` 模块扩展（types / api / index）
- 后端：`scheduler_api.py` 新增 ~400 行（3 个 CRUD 端点 + handler manifest + 校验函数）；`handlers/__init__.py` 新增 Manifest 协议；8 个 handler 文件各增加 descriptor 注册；`scheduled_task.py` 新增 `is_system` 列
- GitHub Actions / 文档：新增 migration 0046

# Next Best Action
- 浏览器实机验证 Create / Edit / Delete 全链路（含 system task 保护、payload 动态表单、判别式字段联动）
- 考虑为 `proxyPut` / `proxyPost` / `proxyPatch` 抽取共享 helper 以消除 `_proxy.ts` 中的重复代码