### PR TITLE
feat(cli-log): .temp/run 服务日志按 3MB 自动滚动，根除单文件无限增长;

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 
 # ── 路径 ────────────────────────────────────────────────────────────────────────
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# 使用 ${BASH_SOURCE[0]} 而非 $0 解析自身路径：被执行时二者等价，被 source（测试）
+# 时 $0 为调用方 shell，唯有 BASH_SOURCE[0] 始终指向 cli.sh，保证 REPO_ROOT 正确。
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 RUN_DIR="$REPO_ROOT/.temp/run"
 
 # ── 颜色 ────────────────────────────────────────────────────────────────────────
@@ -68,13 +70,58 @@ run_dir_init() { mkdir -p "$RUN_DIR"; }
 pid_file() { echo "$RUN_DIR/$1.pid"; }
 log_file() { echo "$RUN_DIR/$1.log"; }
 
-# ── 日志时间戳管道（为 Node.js 服务输出添加统一格式时间戳）──────────────────────────
-_ts_pipe() {
-  local service="$1"
-  while IFS= read -r line; do
-    printf '%s | %8s | %32s | %s\n' \
-      "$(date '+%Y-%m-%d %H:%M:%S')" "INFO" "$service" "$line"
+# ── 日志滚动配置 ─────────────────────────────────────────────────────────────────
+# 单个日志达到阈值即滚动（重命名为 .1/.2…，新建空 .log 续写），避免无限增长导致无法打开。
+# 可经环境变量覆盖：NEGENTROPY_LOG_MAX_BYTES（默认 3MB）、NEGENTROPY_LOG_BACKUPS（默认 5）。
+LOG_MAX_BYTES="${NEGENTROPY_LOG_MAX_BYTES:-$((3 * 1024 * 1024))}"
+LOG_BACKUPS="${NEGENTROPY_LOG_BACKUPS:-5}"
+
+# 跨平台文件字节大小：BSD(stat -f%z) → GNU(stat -c%s) → POSIX(wc -c) 三级兜底，缺文件返回 0。
+_file_size() {
+  [ -f "$1" ] || { echo 0; return; }
+  stat -f%z "$1" 2>/dev/null || stat -c%s "$1" 2>/dev/null || wc -c < "$1" 2>/dev/null || echo 0
+}
+
+# 滚动 <logf>：删最旧 .N → 依次 .k→.k+1 右移 → .log→.1（logrotate 风格命名）。
+# 末行 `|| true` 保证函数恒返回 0，避免在 set -e 下误杀调用方（_log_sink 长驻循环）。
+_rotate_log() {
+  local base="$1" i
+  rm -f "${base}.${LOG_BACKUPS}" 2>/dev/null || true
+  i=$(( LOG_BACKUPS - 1 ))
+  while [ "$i" -ge 1 ]; do
+    [ -f "${base}.${i}" ] && mv -f "${base}.${i}" "${base}.$(( i + 1 ))"
+    i=$(( i - 1 ))
   done
+  [ -f "$base" ] && mv -f "$base" "${base}.1" || true
+}
+
+# ── 日志滚动写入管道（统一承接所有服务的 stdout/stderr）──────────────────────────────
+# 从 stdin 逐行读取，按行 `>>` 追加写入 <name>.log，累计字节达 LOG_MAX_BYTES 即滚动。
+# 逐行 `>>`（每行按文件名重开）使滚动后下一行自动写入新建的 <name>.log，无需重启服务。
+# add_ts=1：为 Node(ui/wiki) 注入与原 _ts_pipe 完全一致的时间戳列；add_ts=0：原样透传
+# （Python 服务自带时间戳）。函数体置于子 shell：set +e 隔离 errexit，避免单行写入抖动
+# 中断长驻日志泵；export LC_ALL=C 使 ${#out} 按字节计长（中文日志阈值判断准确），均不外泄。
+_log_sink() {
+  local name="$1" add_ts="${2:-0}" logf
+  logf="$(log_file "$name")"
+  (
+    set +e
+    export LC_ALL=C
+    size="$(_file_size "$logf")"
+    while IFS= read -r line || [ -n "$line" ]; do
+      if [ "$add_ts" = "1" ]; then
+        out="$(printf '%s | %8s | %32s | %s' "$(date '+%Y-%m-%d %H:%M:%S')" "INFO" "$name" "$line")"
+      else
+        out="$line"
+      fi
+      printf '%s\n' "$out" >> "$logf"
+      size=$(( size + ${#out} + 1 ))
+      if [ "$size" -ge "$LOG_MAX_BYTES" ]; then
+        _rotate_log "$logf"
+        size=0
+      fi
+    done
+  )
 }
 
 # ── 日志生命周期 Banner ──────────────────────────────────────────────────────────
@@ -133,18 +180,17 @@ start_service() {
   log_info "启动 ${name} (port ${port})..."
   _log_banner "$(log_file "$name")" "$name" "STARTING" "port $port"
 
-  if [[ "$name" == "ui" || "$name" == "wiki" ]]; then
-    # Node.js 服务：通过 FIFO 管道添加时间戳，同时保持 PID 追踪
-    local fifo="/tmp/.negentropy_${name}_log_fifo"
-    rm -f "$fifo"; mkfifo "$fifo"
-    _ts_pipe "$name" < "$fifo" >> "$(log_file "$name")" &
-    (cd "$REPO_ROOT/$dir" && exec $cmd) >> "$fifo" 2>&1 &
-    rm -f "$fifo"
-  else
-    # Python 服务：自带格式化，直接重定向
-    (cd "$REPO_ROOT/$dir" && exec $cmd) >> "$(log_file "$name")" 2>&1 &
-  fi
-  echo $! > "$(pid_file "$name")"
+  # 所有服务统一经 FIFO → _log_sink 落盘，由 sink 负责 3MB 滚动：
+  #   Node(ui/wiki) 注入时间戳前缀(add_ts=1)；Python(backend/perceives) 自带时间戳原样透传(add_ts=0)。
+  # 服务被杀 → FIFO 写端关闭 → sink 读到 EOF 自然退出（无新增孤儿）。
+  local add_ts=0
+  case "$name" in ui|wiki) add_ts=1 ;; esac
+  local fifo="/tmp/.negentropy_${name}_log_fifo"
+  rm -f "$fifo"; mkfifo "$fifo"
+  _log_sink "$name" "$add_ts" < "$fifo" &
+  (cd "$REPO_ROOT/$dir" && exec $cmd) >> "$fifo" 2>&1 &
+  echo $! > "$(pid_file "$name")"   # $! = 服务进程（紧跟服务启动捕获），PID/停止语义不变
+  rm -f "$fifo"
 
   if wait_for_health "$name" "$port"; then
     log_ok "${name} 已就绪 (PID $(cat "$(pid_file "$name")"))"
@@ -351,14 +397,15 @@ cmd_logs() {
       exit 1
     fi
   fi
+  # tail -F（大写）按文件名跟随：日志滚动/截断后自动重开新建的 <name>.log，跨滚动不中断。
   if [[ "$target" == "all" ]]; then
-    tail -f "$(log_file backend)" "$(log_file ui)" "$(log_file wiki)" "$(log_file perceives)" 2>/dev/null \
+    tail -F "$(log_file backend)" "$(log_file ui)" "$(log_file wiki)" "$(log_file perceives)" 2>/dev/null \
       || log_error "无日志文件，请先启动服务"
   else
     local lf
     lf="$(log_file "$target")"
     if [[ -f "$lf" ]]; then
-      tail -f "$lf"
+      tail -F "$lf"
     else
       log_error "无 ${target} 日志文件，请先启动服务"
       exit 1
@@ -419,12 +466,15 @@ EOF
 }
 
 # ── 主入口 ────────────────────────────────────────────────────────────────────────
-case "${1:-help}" in
-  start)   shift; cmd_start "$@" ;;
-  stop)    cmd_stop ;;
-  restart) shift; cmd_restart "$@" ;;
-  status)  cmd_status ;;
-  logs)    shift; cmd_logs "${1:-all}" ;;
-  build)   cmd_build ;;
-  help|*)  cmd_help ;;
-esac
+# 仅在「直接执行」时分发命令；被 source（如测试调用内部函数）时跳过，避免副作用。
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+  case "${1:-help}" in
+    start)   shift; cmd_start "$@" ;;
+    stop)    cmd_stop ;;
+    restart) shift; cmd_restart "$@" ;;
+    status)  cmd_status ;;
+    logs)    shift; cmd_logs "${1:-all}" ;;
+    build)   cmd_build ;;
+    help|*)  cmd_help ;;
+  esac
+fi

--- a/scripts/tests/test_log_rotation.sh
+++ b/scripts/tests/test_log_rotation.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# test_log_rotation.sh — cli.sh 日志滚动功能的函数级回归测试
+#
+# 通过 source cli.sh（依赖其 BASH_SOURCE 守卫不触发命令分发）直接调用生产同款函数
+# _log_sink / _rotate_log / _file_size，覆盖两条真实落盘路径：
+#   用例 1：直接管道写入（验证滚动、保留数上限、内容完整性）；
+#   用例 2：FIFO 实链路（验证后台 sink 生命周期、EOF 自然退出、Node 时间戳列注入）。
+# 无需启动真实服务，秒级完成。
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI="$SCRIPT_DIR/../cli.sh"
+
+# shellcheck source=/dev/null
+source "$CLI"
+set +e +u   # 关闭 errexit/nounset，由断言逻辑自行控制流程
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+check() { if eval "$2"; then ok "$1"; else bad "$1 — 条件不成立: $2"; fi; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# 隔离运行目录 + 小阈值，便于快速触发多次滚动
+RUN_DIR="$TMP"
+LOG_MAX_BYTES=$((64 * 1024))   # 64KB
+LOG_BACKUPS=3
+
+echo "== 用例 1：直接管道 _log_sink，验证滚动 / 保留数上限 / 内容完整性 =="
+# 6000 行 × 47B ≈ 282KB，阈值 64KB → 4 次滚动（> LOG_BACKUPS，触发最旧文件淘汰）
+{ for ((i = 1; i <= 6000; i++)); do
+    printf 'line-%05d-pad-pad-pad-pad-pad-pad-pad-pad-pad\n' "$i"
+  done; } | _log_sink svc 0
+
+LOGF="$(log_file svc)"
+active_size="$(_file_size "$LOGF")"
+rotated_count=$(ls -1 "${LOGF}".[0-9]* 2>/dev/null | wc -l | tr -d ' ')
+
+check "活动日志存在"                    "[ -f '$LOGF' ]"
+check "活动日志 ≤ 阈值+单行余量"         "[ $active_size -le $((LOG_MAX_BYTES + 256)) ]"
+check "发生滚动（存在 svc.log.1）"        "[ -f '${LOGF}.1' ]"
+check "历史文件数严格收敛到 LOG_BACKUPS"  "[ $rotated_count -eq $LOG_BACKUPS ]"
+check "最后一行落在活动日志（无损坏）"     "grep -q 'line-06000-' '$LOGF'"
+
+echo "== 用例 2：FIFO 实链路（后台 sink ← fifo），验证 EOF 退出 + 时间戳列注入 =="
+FIFO="$TMP/.fifo_w"
+rm -f "$FIFO"
+mkfifo "$FIFO"
+_log_sink wiki 1 < "$FIFO" &      # add_ts=1：Node(ui/wiki) 路径
+SINK_PID=$!
+# 3000 行 × ~108B（含时间戳列）≈ 324KB → 4 次滚动；写端在块结束时关闭 → sink 收 EOF
+{ for ((i = 1; i <= 3000; i++)); do
+    printf 'wiki-line-%05d-pad-pad-pad-pad-pad-pad\n' "$i"
+  done; } > "$FIFO"
+wait "$SINK_PID" 2>/dev/null
+sink_alive=1
+kill -0 "$SINK_PID" 2>/dev/null && sink_alive=0   # 0 = 仍存活（异常）
+
+WLOG="$(log_file wiki)"
+check "wiki 活动日志存在"                 "[ -f '$WLOG' ]"
+check "wiki 发生滚动（存在 wiki.log.1）"   "[ -f '${WLOG}.1' ]"
+check "EOF 后 sink 已自然退出"            "[ $sink_alive -eq 1 ]"
+check "时间戳列已注入（行首为 ts + |）"     "grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \\| ' '$WLOG'"
+check "wiki 内容完整（末行存活）"          "grep -q 'wiki-line-03000-' '$WLOG'"
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  printf '\033[32m== 全部通过：PASS=%d FAIL=%d ==\033[0m\n' "$PASS" "$FAIL"
+  exit 0
+else
+  printf '\033[31m== 存在失败：PASS=%d FAIL=%d ==\033[0m\n' "$PASS" "$FAIL"
+  exit 1
+fi


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`.temp/run` 下各服务（backend/ui/wiki/perceives）日志为单文件无上限追加，长时间运行后体积无限增长，难以打开/检索，缺乏任何容量保护。
- 关联上下文/Issue/文档：本地全套服务控制脚本 [scripts/cli.sh](scripts/cli.sh)（start / stop / restart / status / logs / build）。

# 核心变更
- **日志自动滚动**：单文件达 **3MB**（`NEGENTROPY_LOG_MAX_BYTES` 可覆盖）即按 logrotate 风格滚动（`.log`→`.1`→…→`.N`），默认保留 5 份（`NEGENTROPY_LOG_BACKUPS`），从根本上消除单文件无限增长。
- **统一落盘管道**：以 `_log_sink` 取代旧 `_ts_pipe`，所有服务统一经 FIFO 汇聚——Node(ui/wiki) 注入与原格式一致的时间戳列，Python(backend/perceives) 原样透传其自带时间戳；逐行 `>>` 重开使滚动后下一行自动续写新文件，无需重启服务。
- **配套能力**：新增 `_file_size`（BSD `stat -f%z` → GNU `stat -c%s` → POSIX `wc -c` 三级跨平台兜底）；`cmd_logs` 由 `tail -f` 改为 `tail -F` 以跨滚动不中断续读；新增 `BASH_SOURCE` 守卫，使脚本可被测试 `source` 调用内部函数而不触发命令分发。
- **回归测试**：新增 [scripts/tests/test_log_rotation.sh](scripts/tests/test_log_rotation.sh)，函数级覆盖直接管道与 FIFO 实链路两条路径（10 条断言）。

# 风险与回滚
- 主要风险：Python 服务由「直接重定向」改为经 FIFO + sink 落盘，新增对 `/tmp` 可写与 sink 子进程存活的依赖（本地开发环境风险极低）；逐行重开 `>>` 较单 fd 写入略增系统调用（应用级日志量下可忽略）。
- 回滚方式：本特性集中于单提交 `d767a26d`，`git revert d767a26d` 即可完全回退；无数据迁移、无 schema 变更、无外部依赖改动。

# 验证证据
- 单元测试：`bash scripts/tests/test_log_rotation.sh` → **10/10 PASS**（滚动触发、保留数严格收敛、内容完整性、FIFO EOF 自然退出、时间戳列注入）。
- 集成测试：补测「sink 在近阈值的既有日志上续写」（跨重启 `>>` 累积）路径——初始大小经 `_file_size` 正确计入、阈值处准确滚动、活动日志续写且末行无损。
- E2E/Workflow：不涉及（纯本地服务控制脚本，无业务链路）。
- 覆盖率/关键截图：`bash -n` 对 `cli.sh` 与测试脚本语法检查均通过。

# 影响范围
- 前端：无源码改动（仅 ui/wiki 运行日志的写入路径变化，对应用透明）。
- 后端：无源码改动（仅 backend/perceives 运行日志的写入路径变化）。
- GitHub Actions / 文档：无。改动仅限 `scripts/cli.sh` 与新增 `scripts/tests/test_log_rotation.sh`。

# Next Best Action
- 如需将该 shell 测试纳入常态回归，可把 `bash scripts/tests/*.sh` 挂入 pre-commit 钩子或某个 `make test` 入口，避免其随 `cli.sh` 演进而腐化、失去回归价值。
