### PR TITLE
feat(memory): Memory 高级特性默认开箱即用 + Hybrid/PII 接线缺陷修复 + 端到端测试加固

### DIFF
--- a/apps/negentropy/pyproject.toml
+++ b/apps/negentropy/pyproject.toml
@@ -51,13 +51,12 @@ dependencies = [
     "jinja2>=3.1.4",                # Sandboxed template rendering for Skills Layer 2 prompt_template
     "packaging>=24.0",              # SemVer parsing for Skill template version validation
     "croniter>=2.0",                # POSIX cron expression parsing for Skill schedules (Phase 3)
-]
-
-[project.optional-dependencies]
-# Phase 5 F4 — Microsoft Presidio 生产级 PII 治理（默认不安装）。
-# 启用方法：`uv sync --extra pii-presidio`，再把 memory.pii.engine 切成 presidio。
-# spaCy 模型需手动 `uv run python -m spacy download zh_core_web_sm` 等。
-pii-presidio = [
+    # F4 Presidio 生产级 PII 治理（默认安装；engine=presidio 开箱即用）。
+    # 注意：spaCy NER 模型（en_core_web_lg / zh_core_web_sm）是独立下载产物而非 pip
+    # 依赖，需经 bootstrap 安装：`uv run negentropy bootstrap-pii-models`（或手动
+    # `uv run python -m spacy download ...`）。模型缺失时 PII 引擎按
+    # memory.pii.allow_engine_fallback 降级回 regex（默认 true，开箱不阻断启动），
+    # 实际生效引擎可经 /memory/health 观测。
     "presidio-analyzer>=2.2.0",
     "presidio-anonymizer>=2.2.0",
     "spacy>=3.7,<4.0",

--- a/apps/negentropy/src/negentropy/cli.py
+++ b/apps/negentropy/src/negentropy/cli.py
@@ -53,6 +53,41 @@ def _cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+# F4 Presidio 默认引擎所需 spaCy NER 模型（独立下载产物，非 pip 依赖）。
+# en_core_web_lg 是 Presidio 英文默认模型；zh_core_web_sm 支撑中文 NER + CN 自定义识别器。
+_PII_SPACY_MODELS = ("en_core_web_lg", "zh_core_web_sm")
+
+
+def _cmd_bootstrap_pii_models(args: argparse.Namespace) -> int:
+    """下载 Presidio PII 引擎所需的 spaCy NER 模型。
+
+    模型是独立下载产物（非 pip 依赖），故单独提供 bootstrap 命令。缺失时
+    PII 引擎按 ``memory.pii.allow_engine_fallback`` 降级回 regex，不阻断启动。
+    """
+    import importlib.util
+    import subprocess
+
+    models = _PII_SPACY_MODELS
+    failed: list[str] = []
+    for model in models:
+        if importlib.util.find_spec(model) is not None and not args.force:
+            print(f"✔ {model} 已安装，跳过（--force 可强制重装）")
+            continue
+        print(f"↓ 下载 spaCy 模型 {model} …")
+        ret = subprocess.call([sys.executable, "-m", "spacy", "download", model])
+        if ret != 0:
+            print(f"✘ {model} 下载失败（exit={ret}）")
+            failed.append(model)
+        else:
+            print(f"✔ {model} 安装成功")
+    if failed:
+        print(f"\n以下模型未能安装: {', '.join(failed)}。")
+        print("PII 引擎将按 memory.pii.allow_engine_fallback 降级回 regex；可经 /memory/health 观测实际引擎。")
+        return 1
+    print("\n全部 PII 模型就绪，可将 memory.pii.engine 设为 presidio。")
+    return 0
+
+
 _UVICORN_PATCH_INSTALLED = False
 _DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 25
 
@@ -199,10 +234,16 @@ def main() -> None:
     serve_parser.add_argument("--host", default="0.0.0.0", help="绑定地址 (默认: 0.0.0.0)")
     serve_parser.add_argument("--no-reload", action="store_true", help="禁用热重载")
 
+    # bootstrap-pii-models subcommand（F4 Presidio spaCy NER 模型）
+    pii_parser = subparsers.add_parser("bootstrap-pii-models", help="下载 Presidio PII 引擎所需 spaCy NER 模型")
+    pii_parser.add_argument("--force", action="store_true", help="即使已安装也强制重新下载")
+
     args = parser.parse_args()
 
     if args.command == "init":
         sys.exit(_cmd_init(args))
+    elif args.command == "bootstrap-pii-models":
+        sys.exit(_cmd_bootstrap_pii_models(args))
     else:
         # Default: serve
         sys.exit(_cmd_serve(args))

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -124,12 +124,16 @@ search:
   base_backoff_seconds: 1.0
   max_results: 10
 
-# --- Memory 子系统 Phase 5 高级特性配置 ---
-# 全部默认关闭，按需通过 NE_MEMORY_<SECTION>__<KEY> 环境变量灰度启用。
-# 详细契约见 docs/reference/cognizes/engine/025-the-memory-system.md §10.5、docs/reference/cognizes/engine/026-memory-whitepaper.md §4。
+# --- Memory 子系统高级特性配置（默认开箱即用）---
+# F1 HippoRAG / F2 Reflexion / F3 Memify 6-step / F4 Presidio / Rocchio 反馈闭环均默认启用。
+# 各特性自带运行时安全闸（如 HippoRAG 的 min_kg_associations 数据闸、Reflexion 的
+# max_inflight_tasks 并发上限、Presidio 的 allow_engine_fallback 降级），可经
+# NE_MEMORY_<SECTION>__<KEY> 环境变量按需关闭/调参。
+# 详细契约见 docs/reference/cognizes/engine/025-the-memory-system.md §10.5、docs/reference/cognizes/engine/026-memory-whitepaper.md §4；
+# 上手指引见 docs/concepts/user-guide/memory-basics.md。
 memory:
   hipporag:                                  # F1 HippoRAG PPR-Boosted Hybrid
-    enabled: false
+    enabled: true                             # 默认开箱；min_kg_associations 数据闸使其在 KG 稀疏时自休眠回退 Hybrid
     depth: 2
     alpha: 0.5
     rrf_k: 60
@@ -138,8 +142,8 @@ memory:
     seed_threshold: 0.75
     min_kg_associations: 100
     gray_users: []
-  reflection:                                # F2 Reflexion Episodic Replay
-    enabled: false
+  reflection:                                # F2 Reflexion Episodic Replay（默认开箱）
+    enabled: true                            # 失败检索（irrelevant/harmful）触发反思生成 + Few-Shot 召回；并发硬上限防风暴
     dedup_window_days: 7
     dedup_cosine: 0.92
     daily_limit_per_user: 10
@@ -149,19 +153,37 @@ memory:
     max_inflight_tasks: 8                    # 后台反思任务硬上限（防反馈风暴）
   consolidation:                             # F3 Memify Consolidation Pipeline
     legacy: false
-    policy: serial                           # serial | parallel | fail_tolerant
+    policy: fail_tolerant                     # serial | parallel | fail_tolerant；单步失败不中断全链
     timeout_per_step_ms: 30000
-    steps:                                   # 默认与 Phase 4 行为一致
-      - fact_extract
-      - auto_link
-  pii:                                       # F4 Presidio 生产级 PII
-    engine: regex                            # regex | presidio
-    policy: mark                             # mark | mask | anonymize
+    steps:                                   # 6-step Memify 默认开箱（步骤间有数据依赖，禁 parallel）
+      - fact_extract                         # LLM 事实提取（失败降级 PatternFactExtractor）
+      - entity_normalization                 # 实体规范化（LLM，失败容忍）
+      - topic_cluster                        # 主题聚类（纯向量计算）
+      - dedup_merge                          # 近重复合并 + AGM 冲突消解
+      - summarize                            # 用户画像摘要刷新（LLM，TTL 缓存）
+      - auto_link                            # 关联网络自动建边
+    cluster_eps: 0.15                        # TopicCluster 聚类余弦距离阈值
+    merge_threshold: 0.90                    # DedupMerge 近重复 cosine 阈值
+  pii:                                       # F4 Presidio 生产级 PII（默认开箱）
+    engine: presidio                         # regex | presidio；presidio 提供 PERSON/LOCATION NER + 多语言
+    policy: mark                             # mark | mask | anonymize（写入策略）
     languages: [en, zh]
     score_threshold: 0.6
-    gatekeeper_enabled: false
-    acl_role_threshold: editor
-    allow_engine_fallback: false             # presidio 初始化失败时禁止悄悄退回 regex
+    # gatekeeper 默认关闭：检索遮蔽需 viewer_role 角色，而 ADK tool_context.search_memory /
+    # 内部 agent 路径暂无法透传角色（拿不到角色→按低权限被遮蔽）。能力已接线并测试，
+    # 待 REST/工具链全量补齐角色透传后再默认开。需要时显式置 true（REST 路径已据鉴权用户生效）。
+    gatekeeper_enabled: false                # 检索路径按角色对低权限用户脱敏含 PII 记忆
+    acl_role_threshold: editor               # 低于 editor 的角色看到脱敏副本
+    allow_engine_fallback: true              # 开箱优先：spaCy 模型缺失时降级回 regex 并写 ERROR（经 /memory/health 可观测），不阻断启动
+    retrieval_policy: anonymize              # 检索遮蔽策略（低权限角色）：mask | anonymize
+  relevance:                                 # Phase 6 G1 Rocchio 相关性反馈闭环
+    enabled: true                            # 读侧应用预计算 relevance_weight；写侧由 cron 重加权（默认开箱）
+    rocchio_beta: 0.75                       # 正反馈系数 β
+    rocchio_gamma: 0.15                      # 负反馈系数 γ
+    prf_top_k: 3
+    prf_alpha: 0.7
+    feedback_min_count: 3                    # 最低反馈条数门槛
+    reweight_interval_seconds: 3600
 
 # --- Knowledge 配置 ---
 knowledge:

--- a/apps/negentropy/src/negentropy/config/memory.py
+++ b/apps/negentropy/src/negentropy/config/memory.py
@@ -86,6 +86,10 @@ class PIISettings(BaseSettings):
     score_threshold: float = Field(default=0.6, ge=0.0, le=1.0, description="Presidio 置信度阈值")
     gatekeeper_enabled: bool = Field(default=False, description="检索路径是否启用 PIIGatekeeper")
     acl_role_threshold: str = Field(default="editor", description="低于此角色看到 anonymized 副本")
+    retrieval_policy: str = Field(
+        default="anonymize",
+        description="检索侧低权限角色遮蔽策略：mask | anonymize（独立于写入 policy；mark 等于不遮蔽）",
+    )
     allow_engine_fallback: bool = Field(
         default=False,
         description=(

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0047_memory_hybrid_search_function.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0047_memory_hybrid_search_function.py
@@ -1,0 +1,193 @@
+"""为 memories 表补齐全文检索基建并创建 hybrid_search() 函数
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2026-05-30 00:00:00.000000+00:00
+
+设计动机（修复预存缺陷）：
+    ``PostgresMemoryService._hybrid_search_native`` 调用 ``negentropy.hybrid_search()``
+    DB 函数完成「语义 + BM25」一次性融合检索，但该函数从未被任何 alembic 迁移创建
+    （仅存在于 docs/reference/.../perception_schema.sql 与 cognizes app 的 schema 文件，
+    未移植到 negentropy）。memories 表也缺 ``search_vector tsvector`` 列。
+
+    后果：Hybrid 检索（主模块 C2 / P0）一直抛 UndefinedFunction 并静默回退到纯向量
+    检索；同时 F1 HippoRAG PPR 仅在 Hybrid 分支融合，故 PPR 也被连带架空。
+
+    本迁移以 perception_schema.sql 的权威定义为准，schema 限定到 ``negentropy``：
+    1) memories 增 ``search_vector`` 列 + BEFORE INSERT/UPDATE 触发器自动维护
+    2) 回填存量行 + 建 GIN 索引
+    3) 创建 ``hybrid_search()`` 函数（FULL OUTER JOIN 融合 + 加权排序）
+
+幂等性：
+    全部使用 IF NOT EXISTS / CREATE OR REPLACE / DROP ... IF EXISTS，可重复执行。
+
+数据安全：
+    纯新增列 + 回填，不删除/改写任何既有记忆内容。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0047"
+down_revision: str | None = "0046"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    # 1) 全文检索列（tsvector）+ 自动维护触发器
+    op.execute(
+        sa.text(
+            f"""
+ALTER TABLE {SCHEMA}.memories
+    ADD COLUMN IF NOT EXISTS search_vector tsvector;
+            """.strip()
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+CREATE OR REPLACE FUNCTION {SCHEMA}.memories_update_search_vector()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.search_vector := to_tsvector('english', COALESCE(NEW.content, ''));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+            """.strip()
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+DROP TRIGGER IF EXISTS trigger_memories_search_vector ON {SCHEMA}.memories;
+            """.strip()
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+CREATE TRIGGER trigger_memories_search_vector
+    BEFORE INSERT OR UPDATE OF content ON {SCHEMA}.memories
+    FOR EACH ROW
+    EXECUTE FUNCTION {SCHEMA}.memories_update_search_vector();
+            """.strip()
+        )
+    )
+
+    # 2) 回填存量行 + GIN 索引
+    op.execute(
+        sa.text(
+            f"""
+UPDATE {SCHEMA}.memories
+SET search_vector = to_tsvector('english', COALESCE(content, ''))
+WHERE search_vector IS NULL;
+            """.strip()
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+CREATE INDEX IF NOT EXISTS idx_memories_search_vector
+    ON {SCHEMA}.memories USING GIN (search_vector);
+            """.strip()
+        )
+    )
+
+    # 3) hybrid_search() 函数（语义 + BM25 加权融合，权威定义见 perception_schema.sql）
+    op.execute(
+        sa.text(
+            f"""
+CREATE OR REPLACE FUNCTION {SCHEMA}.hybrid_search(
+    p_user_id VARCHAR(255),
+    p_app_name VARCHAR(255),
+    p_query TEXT,
+    p_query_embedding vector(1536),
+    p_limit INTEGER DEFAULT 50,
+    p_semantic_weight FLOAT DEFAULT 0.7,
+    p_keyword_weight FLOAT DEFAULT 0.3,
+    p_metadata_filter JSONB DEFAULT NULL
+)
+RETURNS TABLE (
+    id UUID,
+    content TEXT,
+    semantic_score REAL,
+    keyword_score REAL,
+    combined_score REAL,
+    metadata JSONB
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH
+    semantic_results AS (
+        SELECT
+            m.id,
+            m.content,
+            (1 - (m.embedding <=> p_query_embedding))::REAL AS score,
+            m.metadata
+        FROM {SCHEMA}.memories m
+        WHERE m.user_id = p_user_id
+          AND m.app_name = p_app_name
+          AND m.embedding IS NOT NULL
+          AND (p_metadata_filter IS NULL OR m.metadata @> p_metadata_filter)
+        ORDER BY m.embedding <=> p_query_embedding
+        LIMIT p_limit * 2
+    ),
+    keyword_results AS (
+        SELECT
+            m.id,
+            m.content,
+            ts_rank_cd(m.search_vector, plainto_tsquery('english', p_query)) AS score,
+            m.metadata
+        FROM {SCHEMA}.memories m
+        WHERE m.user_id = p_user_id
+          AND m.app_name = p_app_name
+          AND m.search_vector @@ plainto_tsquery('english', p_query)
+          AND (p_metadata_filter IS NULL OR m.metadata @> p_metadata_filter)
+        ORDER BY score DESC
+        LIMIT p_limit * 2
+    ),
+    combined AS (
+        SELECT
+            COALESCE(s.id, k.id) AS id,
+            COALESCE(s.content, k.content) AS content,
+            COALESCE(s.score, 0)::REAL AS semantic_score,
+            COALESCE(k.score, 0)::REAL AS keyword_score,
+            COALESCE(s.metadata, k.metadata) AS metadata
+        FROM semantic_results s
+        FULL OUTER JOIN keyword_results k ON s.id = k.id
+    )
+    SELECT
+        c.id,
+        c.content,
+        c.semantic_score,
+        c.keyword_score,
+        (c.semantic_score * p_semantic_weight + c.keyword_score * p_keyword_weight)::REAL AS combined_score,
+        c.metadata
+    FROM combined c
+    ORDER BY combined_score DESC
+    LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql;
+            """.strip()
+        )
+    )
+
+
+def downgrade() -> None:
+    # 函数 / 列保留：运行时检索依赖；回退仅删除本迁移新建的索引与触发器，避免破坏数据。
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {SCHEMA}.idx_memories_search_vector;"))
+    op.execute(sa.text(f"DROP TRIGGER IF EXISTS trigger_memories_search_vector ON {SCHEMA}.memories;"))
+    op.execute(
+        sa.text(
+            f"DROP FUNCTION IF EXISTS {SCHEMA}.hybrid_search"
+            "(VARCHAR, VARCHAR, TEXT, vector, INTEGER, FLOAT, FLOAT, JSONB);"
+        )
+    )
+    op.execute(sa.text(f"DROP FUNCTION IF EXISTS {SCHEMA}.memories_update_search_vector();"))

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/memory_service.py
@@ -41,8 +41,7 @@ from negentropy.engine.governance.memory import (
     VALID_MEMORY_TYPES,
     MemoryGovernanceService,
 )
-from negentropy.engine.governance.pii_detector import detect as detect_pii
-from negentropy.engine.governance.pii_detector import summarize_flags as summarize_pii_flags
+from negentropy.engine.governance.pii import detect_pii_for_storage
 from negentropy.engine.utils.query_intent import classify as classify_intent
 from negentropy.logging import get_logger
 from negentropy.models.base import NEGENTROPY_SCHEMA
@@ -154,9 +153,8 @@ class PostgresMemoryService(BaseMemoryService):
                 importance = self._calculate_initial_importance(
                     memory_type="episodic",
                 )
-                # Phase 4: PII 检测占位（regex 级，命中后 metadata.pii_flags 标记）
-                pii_matches = detect_pii(content)
-                pii_flags = summarize_pii_flags(pii_matches) if pii_matches else {}
+                # F4: PII 检测经工厂引擎（regex/presidio），落 flags + spans（供检索遮蔽）
+                pii_flags, pii_spans = detect_pii_for_storage(content)
                 async with db.begin_nested():
                     memory = Memory(
                         thread_id=thread_id,
@@ -174,6 +172,7 @@ class PostgresMemoryService(BaseMemoryService):
                             "total_segments": len(segments),
                             "turn_count": len(segments[seg_idx] if seg_idx < len(segments) else []),
                             **({"pii_flags": pii_flags} if pii_flags else {}),
+                            **({"pii_spans": pii_spans} if pii_spans else {}),
                         },
                     )
                     db.add(memory)
@@ -631,6 +630,7 @@ class PostgresMemoryService(BaseMemoryService):
         memory_type: str | None = None,
         date_from: datetime | None = None,
         date_to: datetime | None = None,
+        viewer_role: str | None = None,
     ) -> SearchMemoryResponse:
         """基于 Query 检索相关记忆
 
@@ -695,7 +695,7 @@ class PostgresMemoryService(BaseMemoryService):
                     memories_data = self._apply_relevance_weights(memories_data)
                     await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
                     self._log_search_event("hybrid", len(memories_data), user_id, app_name, query)
-                    return self._build_search_response(memories_data)
+                    return self._build_search_response(memories_data, viewer_role=viewer_role)
             except Exception as exc:
                 self._log_fallback_event("hybrid", "vector", str(exc), user_id, app_name, query)
 
@@ -719,7 +719,7 @@ class PostgresMemoryService(BaseMemoryService):
             memories_data = self._apply_relevance_weights(memories_data)
             await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
             self._log_search_event("vector", len(memories_data), user_id, app_name, query)
-            return self._build_search_response(memories_data)
+            return self._build_search_response(memories_data, viewer_role=viewer_role)
 
         # 策略 3: BM25 全文检索
         try:
@@ -740,7 +740,7 @@ class PostgresMemoryService(BaseMemoryService):
                 memories_data = self._apply_relevance_weights(memories_data)
                 await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
                 self._log_search_event("keyword", len(memories_data), user_id, app_name, query)
-                return self._build_search_response(memories_data)
+                return self._build_search_response(memories_data, viewer_role=viewer_role)
         except Exception as exc:
             self._log_fallback_event("keyword", "ilike", str(exc), user_id, app_name, query)
 
@@ -761,7 +761,7 @@ class PostgresMemoryService(BaseMemoryService):
         memories_data = self._apply_relevance_weights(memories_data)
         await self._record_access(memories_data, query=query, user_id=user_id, app_name=app_name)
         self._log_search_event("ilike", len(memories_data), user_id, app_name, query)
-        return self._build_search_response(memories_data)
+        return self._build_search_response(memories_data, viewer_role=viewer_role)
 
     # ------------------------------------------------------------------
     # Phase 5 F1 — HippoRAG PPR-Boosted Hybrid 检索
@@ -1027,12 +1027,18 @@ class PostgresMemoryService(BaseMemoryService):
             SELECT h.id, h.content, h.semantic_score, h.keyword_score, h.combined_score,
                    h.metadata, m.memory_type
             FROM {NEGENTROPY_SCHEMA}.hybrid_search(
-                :user_id, :app_name, :query, :embedding::vector(1536),
+                :user_id, :app_name, :query, CAST(:embedding AS vector(1536)),
                 :limit, :semantic_weight, :keyword_weight
             ) AS h
             JOIN {NEGENTROPY_SCHEMA}.memories AS m ON m.id = h.id
             WHERE COALESCE(h.metadata->>'deleted', 'false') <> 'true'
         """)
+        # 注意：用 CAST(:embedding AS vector(1536)) 而非 :embedding::vector(1536)。
+        # SQLAlchemy text() 会把 ``::`` 误判为绑定名分隔符，导致 :embedding 不绑定、
+        # 渲染出裸 ``:`` 触发 PostgresSyntaxError，使 Hybrid 检索静默回退纯向量
+        # （并连带架空仅在 Hybrid 分支融合的 F1 PPR）。CAST(...) 形式无此歧义。
+        # pgvector 经 CAST 时需字符串字面量 '[...]'，故此处显式序列化 embedding。
+        embedding_literal = "[" + ",".join(f"{x:.7g}" for x in query_embedding) + "]"
 
         async with db_session.AsyncSessionLocal() as db:
             result = await db.execute(
@@ -1041,7 +1047,7 @@ class PostgresMemoryService(BaseMemoryService):
                     "user_id": user_id,
                     "app_name": app_name,
                     "query": query,
-                    "embedding": query_embedding,
+                    "embedding": embedding_literal,
                     "limit": oversample_limit,
                     "semantic_weight": _DEFAULT_SEMANTIC_WEIGHT,
                     "keyword_weight": _DEFAULT_KEYWORD_WEIGHT,
@@ -1418,8 +1424,24 @@ class PostgresMemoryService(BaseMemoryService):
                 error=str(exc),
             )
 
-    def _build_search_response(self, memories_data: list[dict[str, Any]]) -> SearchMemoryResponse:
-        """构建 ADK SearchMemoryResponse（携带 search_level 元数据）"""
+    def _build_search_response(
+        self, memories_data: list[dict[str, Any]], *, viewer_role: str | None = None
+    ) -> SearchMemoryResponse:
+        """构建 ADK SearchMemoryResponse（携带 search_level 元数据）
+
+        F4：出口处经 PIIGatekeeper 按 viewer_role 决定是否遮蔽含 PII 的 content
+        （依赖写入期落库的 ``metadata.pii_spans``）。未启用 / 高权限时原样透传。
+        """
+        # PII 检索守门员（受 settings.memory.pii.gatekeeper_enabled 控）
+        try:
+            from negentropy.engine.governance.pii import PIIGatekeeper
+
+            gatekeeper = PIIGatekeeper.from_settings()
+            if gatekeeper.should_redact(role=viewer_role):
+                memories_data = gatekeeper.filter_records(memories_data, role=viewer_role)
+        except Exception as exc:
+            logger.debug("pii_gatekeeper_skip", error=str(exc))
+
         memories = []
         for m in memories_data:
             content_val = {"parts": [{"text": m["content"]}]}
@@ -1484,12 +1506,13 @@ class PostgresMemoryService(BaseMemoryService):
 
         retention = self._calculate_initial_retention(content, memory_type=memory_type)
         importance = self._calculate_initial_importance(memory_type=memory_type)
-        # Phase 4: PII 占位
-        pii_matches = detect_pii(content)
-        pii_flags = summarize_pii_flags(pii_matches) if pii_matches else {}
+        # F4: PII 检测经工厂引擎，落 flags + spans（供检索遮蔽）
+        pii_flags, pii_spans = detect_pii_for_storage(content)
         merged_metadata = dict(metadata or {"source": "self_edit"})
         if pii_flags:
             merged_metadata["pii_flags"] = pii_flags
+        if pii_spans:
+            merged_metadata["pii_spans"] = pii_spans
 
         async with db_session.AsyncSessionLocal() as db:
             memory = Memory(

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -35,7 +35,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text, union
 
-from negentropy.auth.deps import get_current_user, resolve_user_with_db_roles
+from negentropy.auth.deps import get_current_user, get_optional_user, resolve_user_with_db_roles
 from negentropy.auth.service import AuthUser
 from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
@@ -441,13 +441,32 @@ async def list_memories(
 
 
 @router.post("/search", response_model=MemorySearchResponse)
-async def search_memories(payload: MemorySearchRequest) -> MemorySearchResponse:
+async def search_memories(
+    payload: MemorySearchRequest,
+    user: AuthUser | None = Depends(get_optional_user),
+) -> MemorySearchResponse:
     """搜索用户记忆
 
     基于混合检索 (Semantic + BM25) 搜索相关记忆。
     支持按记忆类型、日期范围过滤，以及分页。
+
+    F4：viewer_role 取自鉴权用户（DB 权威 roles），传给 PIIGatekeeper 决定低权限
+    角色是否对含 PII 的 content 做脱敏。角色由服务端解析，绝不接受客户端自报，
+    避免越权绕过遮蔽。用 get_optional_user 而非 get_current_user：保持端点对无 token
+    调用可用（不引入 401 破坏既有访问），仅在已鉴权时据角色脱敏。
     """
     resolved_app = _resolve_app_name(payload.app_name)
+
+    # 解析鉴权用户的最高权限角色（DB 权威），供 PII 守门员判定遮蔽。
+    # 未鉴权（user=None）时 viewer_role=None → rank 0（最低），守门员启用时按低权限遮蔽。
+    viewer_role: str | None = None
+    if user is not None:
+        try:
+            resolved_user = await resolve_user_with_db_roles(user)
+            _RANK = {"viewer": 1, "user": 1, "editor": 2, "admin": 3}
+            viewer_role = max(resolved_user.roles, key=lambda r: _RANK.get(str(r).lower(), 0), default=None)
+        except Exception:
+            viewer_role = None
 
     # 解析日期参数
     date_from = None
@@ -479,6 +498,7 @@ async def search_memories(payload: MemorySearchRequest) -> MemorySearchResponse:
         memory_type=payload.memory_type,
         date_from=date_from,
         date_to=date_to,
+        viewer_role=viewer_role,
     )
 
     items = []

--- a/apps/negentropy/src/negentropy/engine/governance/pii/__init__.py
+++ b/apps/negentropy/src/negentropy/engine/governance/pii/__init__.py
@@ -16,6 +16,7 @@ from .base import PIIDetectorBase, PIISpan, apply_policy
 from .factory import get_pii_detector, reset_pii_detector
 from .gatekeeper import PIIGatekeeper
 from .regex_detector import RegexPIIDetector
+from .storage_helper import detect_pii_for_storage
 
 __all__ = [
     "PIIDetectorBase",
@@ -25,4 +26,5 @@ __all__ = [
     "PIIGatekeeper",
     "get_pii_detector",
     "reset_pii_detector",
+    "detect_pii_for_storage",
 ]

--- a/apps/negentropy/src/negentropy/engine/governance/pii/presidio_detector.py
+++ b/apps/negentropy/src/negentropy/engine/governance/pii/presidio_detector.py
@@ -74,15 +74,65 @@ class PresidioPIIDetector(PIIDetectorBase):
             )
         )
 
+        # 构建多语言 NLP 引擎：为每种语言显式映射 spaCy 模型，否则 AnalyzerEngine
+        # 默认只配 en，分析 zh 文本会抛 KeyError('zh') 使中文 NER + CN 自定义识别器
+        # （CN_MOBILE / CN_ID_CARD）全部失效。只保留模型确实存在的语言，做优雅降级。
+        usable_languages, nlp_engine = self._build_nlp_engine(self._languages)
+        self._languages = usable_languages or ["en"]
+
         try:
-            self._engine = AnalyzerEngine(supported_languages=self._languages)
+            engine_kwargs: dict[str, Any] = {"supported_languages": self._languages}
+            if nlp_engine is not None:
+                engine_kwargs["nlp_engine"] = nlp_engine
+            self._engine = AnalyzerEngine(**engine_kwargs)
             for r in recognizers:
+                # 仅注册其 supported_language 在可用语言集合内的识别器
+                if getattr(r, "supported_language", None) and r.supported_language not in self._languages:
+                    continue
                 try:
                     self._engine.registry.add_recognizer(r)
                 except Exception as exc:
                     logger.debug("presidio_recognizer_skip", name=r.name, error=str(exc))
         except Exception as exc:
             raise PresidioImportError(f"Presidio AnalyzerEngine init failed: {exc}") from exc
+
+    @staticmethod
+    def _build_nlp_engine(languages: list[str]) -> tuple[list[str], Any]:
+        """按语言映射 spaCy 模型构建 NlpEngine；缺模型的语言被剔除。
+
+        Returns: (可用语言列表, NlpEngine 或 None)。当 provider 不可用时回退
+        (原语言列表, None)，由 AnalyzerEngine 走默认配置（仅 en 可靠）。
+        """
+        import importlib.util
+
+        # 语言 → 候选 spaCy 模型（按优先级）；en 优先 lg（Presidio 默认），缺则 sm
+        candidates = {
+            "en": ["en_core_web_lg", "en_core_web_sm"],
+            "zh": ["zh_core_web_sm", "zh_core_web_lg"],
+        }
+        models: list[dict[str, str]] = []
+        usable: list[str] = []
+        for lang in languages:
+            model_name = next(
+                (m for m in candidates.get(lang, []) if importlib.util.find_spec(m) is not None),
+                None,
+            )
+            if model_name is None:
+                logger.warning("presidio_lang_model_missing_skip", lang=lang)
+                continue
+            models.append({"lang_code": lang, "model_name": model_name})
+            usable.append(lang)
+
+        if not models:
+            return languages, None
+        try:
+            from presidio_analyzer.nlp_engine import NlpEngineProvider
+
+            provider = NlpEngineProvider(nlp_configuration={"nlp_engine_name": "spacy", "models": models})
+            return usable, provider.create_engine()
+        except Exception as exc:
+            logger.warning("presidio_nlp_engine_build_failed_use_default", error=str(exc))
+            return languages, None
 
     def detect(self, text: str, *, languages: list[str] | None = None) -> list[PIISpan]:
         if not text:

--- a/apps/negentropy/src/negentropy/engine/governance/pii/storage_helper.py
+++ b/apps/negentropy/src/negentropy/engine/governance/pii/storage_helper.py
@@ -1,0 +1,67 @@
+"""写入路径 PII 检测助手 —— 经工厂选择的引擎检测，产出可落库的 flags + spans。
+
+设计动机（修复预存缺陷 ISSUE-099）：
+    Memory 写入路径（``memory_service`` 的 ``_simple_consolidate`` / ``add_memory_typed``）
+    原先硬编码调用 legacy ``pii_detector.detect``（仅 RegexPIIDetector），完全绕过
+    ``settings.memory.pii.engine`` 工厂选择，使 Presidio 引擎成为热路径死代码；且只落
+    ``metadata.pii_flags``（计数），不落 ``pii_spans``，导致检索侧 ``PIIGatekeeper``
+    （依赖 spans 才能 mask/anonymize）即使启用也无数据可遮蔽。
+
+    本助手统一经 ``get_pii_detector()`` 检测，同时产出：
+    - ``flags``: ``{pii_type: count}``（兼容既有 metadata.pii_flags 语义）
+    - ``spans``: ``[{type,start,end,score,text}]``（供 PIIGatekeeper 检索遮蔽）
+
+容错：检测器初始化或运行抛错时返回空结果而非中断写入主链路（保密性降级有日志，
+不阻断记忆持久化）。``allow_engine_fallback`` 语义由工厂层面负责。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from negentropy.logging import get_logger
+
+from .base import PIISpan, summarize_pii_flags
+from .factory import get_pii_detector
+
+logger = get_logger("negentropy.engine.governance.pii.storage_helper")
+
+
+def _spans_to_json(spans: list[PIISpan]) -> list[dict[str, Any]]:
+    """把 PIISpan 序列化为可落 JSONB 的 dict 列表（PIIGatekeeper 可逆读取）。"""
+    return [
+        {
+            "type": s.pii_type,
+            "start": s.start,
+            "end": s.end,
+            "score": round(float(s.score), 4),
+            # 仅保留命中片段用于检索侧遮蔽；不额外存储其它上下文，控制 PII 暴露面。
+            "text": s.text,
+        }
+        for s in spans
+    ]
+
+
+def detect_pii_for_storage(content: str) -> tuple[dict[str, int], list[dict[str, Any]]]:
+    """对内容做 PII 检测，返回 ``(flags, spans_json)``。
+
+    经 ``settings.memory.pii.engine`` 选定的引擎（regex / presidio）执行；
+    任何异常降级为空结果并记 WARNING，绝不中断写入。
+    """
+    if not content:
+        return {}, []
+    try:
+        detector = get_pii_detector()
+        spans = detector.detect(content)
+    except Exception as exc:
+        # 工厂在 allow_engine_fallback=False + presidio 缺失时会抛 PIIEngineUnavailableError；
+        # 写入路径不应因 PII 引擎不可用而丢记忆，这里降级为「无标记」并告警。
+        logger.warning("pii_detect_for_storage_failed_skip", error=str(exc))
+        return {}, []
+
+    if not spans:
+        return {}, []
+    return summarize_pii_flags(spans), _spans_to_json(spans)
+
+
+__all__ = ["detect_pii_for_storage"]

--- a/apps/negentropy/src/negentropy/engine/governance/pii/storage_helper.py
+++ b/apps/negentropy/src/negentropy/engine/governance/pii/storage_helper.py
@@ -9,7 +9,8 @@
 
     本助手统一经 ``get_pii_detector()`` 检测，同时产出：
     - ``flags``: ``{pii_type: count}``（兼容既有 metadata.pii_flags 语义）
-    - ``spans``: ``[{type,start,end,score,text}]``（供 PIIGatekeeper 检索遮蔽）
+    - ``spans``: ``[{type,start,end,score}]``（供 PIIGatekeeper 按偏移量检索遮蔽；
+      刻意不落命中原文，避免 metadata 旁路泄露 PII，详见 ``_spans_to_json``）
 
 容错：检测器初始化或运行抛错时返回空结果而非中断写入主链路（保密性降级有日志，
 不阻断记忆持久化）。``allow_engine_fallback`` 语义由工厂层面负责。
@@ -28,15 +29,20 @@ logger = get_logger("negentropy.engine.governance.pii.storage_helper")
 
 
 def _spans_to_json(spans: list[PIISpan]) -> list[dict[str, Any]]:
-    """把 PIISpan 序列化为可落 JSONB 的 dict 列表（PIIGatekeeper 可逆读取）。"""
+    """把 PIISpan 序列化为可落 JSONB 的 dict 列表（PIIGatekeeper 可逆读取）。
+
+    刻意不持久化命中原文（``PIISpan.text``）：``metadata`` 会随检索结果
+    （``custom_metadata``）与 ``/memories`` 时间线原样回传客户端，存原文等于把
+    本应被脱敏的 PII 从 metadata 旁路泄露给低权限角色。脱敏仅依赖 ``start``/``end``
+    + ``type``（见 ``base.apply_policy``），``PIIGatekeeper`` 在缺 ``text`` 时按
+    ``content[start:end]`` 重建片段，偏移量已自足，无需落原文。
+    """
     return [
         {
             "type": s.pii_type,
             "start": s.start,
             "end": s.end,
             "score": round(float(s.score), 4),
-            # 仅保留命中片段用于检索侧遮蔽；不额外存储其它上下文，控制 PII 暴露面。
-            "text": s.text,
         }
         for s in spans
     ]

--- a/apps/negentropy/tests/integration_tests/engine/consolidation/test_full_pipeline.py
+++ b/apps/negentropy/tests/integration_tests/engine/consolidation/test_full_pipeline.py
@@ -1,0 +1,365 @@
+"""T1 — Memify 全链路巩固集成测试（真实 PostgreSQL）。
+
+验证 6-step Memify 管线（fact_extract → entity_normalization → topic_cluster →
+dedup_merge → summarize → auto_link）端到端产出全部产物，弥补此前"无任何测试断言
+单次巩固产出全量产物"的空白（见 plan T1 / docs/.agents/issue.md「Memify 休眠」）。
+
+设计要点（保证确定性 + 离线 + <3min 预算）：
+- **离线**：monkeypatch 三个 LLM 触点（fact_extract / entity_normalization /
+  summarize）为确定性桩，避免真实网络调用与不确定性；其余三步（topic_cluster /
+  dedup_merge / auto_link）是纯 DB + 向量计算，原样真实执行。
+- **确定性 embedding**：注入基于内容 token 的可复现 embedding_fn，使语义相近的段
+  落在 topic_cluster 阈值内聚类、auto_link 能建立关联。
+- **真实写入**：经 ``PostgresMemoryService.add_session_to_memory`` 真实入库，再经
+  ``_run_consolidation_pipeline`` 跑满 6 步，最后查库断言六类产物。
+
+断言矩阵（六类产物）：
+1. memories     — episodic 记忆写入（≥2 段）
+2. facts        — fact_extract 入库
+3. topics       — topic_cluster 在 metadata_.topics 标注
+4. dedup/merge  — 近重复被 dedup_merge 处理（merged_from / soft-delete / 冲突保留）
+5. summary      — summarize 刷新（桩产出）
+6. associations — auto_link 建立关联边
+另断言每步 ``StepResult.status`` 非 ``failed``。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from google.adk.events import Event as ADKEvent
+from google.adk.sessions import Session as ADKSession
+from sqlalchemy import func, select
+
+import negentropy.db.session as db_session
+from negentropy.config._base import reset_sections, set_yaml_section
+from negentropy.engine.adapters.postgres.memory_service import PostgresMemoryService
+from negentropy.engine.consolidation.fact_extractor import ExtractedFact
+from negentropy.models.internalization import Fact, Memory, MemoryAssociation
+
+# ---------------------------------------------------------------------------
+# 确定性 embedding：基于内容词袋的可复现向量
+# ---------------------------------------------------------------------------
+
+_DIM = 1536
+
+
+def _deterministic_embedding(text: str) -> list[float]:
+    """把内容映射到固定维度向量；共享词越多→向量越近（便于聚类/关联）。
+
+    简化哈希词袋：每个词用稳定哈希（md5）散列到若干维度并累加，最后 L2 归一化。
+    纯函数、无随机（不依赖 PYTHONHASHSEED）、无网络。
+    """
+    import hashlib
+    import math
+    import re
+
+    def _stable_hash(s: str) -> int:
+        return int.from_bytes(hashlib.md5(s.encode("utf-8")).digest()[:8], "big")
+
+    vec = [0.0] * _DIM
+    words = re.findall(r"[a-zA-Z一-鿿]{2,}", text.lower())
+    for w in words:
+        h = _stable_hash(w) % _DIM
+        vec[h] += 1.0
+        vec[(h * 7 + 13) % _DIM] += 0.5  # 第二个桶增加区分度
+    norm = math.sqrt(sum(v * v for v in vec)) or 1.0
+    return [v / norm for v in vec]
+
+
+async def _embedding_fn(text: str) -> list[float]:
+    return _deterministic_embedding(text)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _invalidate_memory_settings_cache() -> None:
+    """settings.memory 是 @cached_property，需手动失效后才会重读新设的 YAML 段。"""
+    from negentropy.config import settings as global_settings
+
+    global_settings.__dict__.pop("memory", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory_singletons():
+    """防御上游单测对工厂单例的污染（某些单测把 get_*_service 替换为 MagicMock 后
+    未复位）。本集成测试需要真实服务，故运行前后强制重置工厂单例。"""
+    from negentropy.engine.factories.memory import (
+        reset_association_service,
+        reset_fact_service,
+        reset_memory_service,
+        reset_memory_summarizer,
+    )
+
+    for fn in (reset_association_service, reset_fact_service, reset_memory_service, reset_memory_summarizer):
+        fn()
+    yield
+    for fn in (reset_association_service, reset_fact_service, reset_memory_service, reset_memory_summarizer):
+        fn()
+
+
+@pytest.fixture
+def _six_step_yaml():
+    """把 memory.consolidation 配成 6 步 fail_tolerant，离开时还原。"""
+    reset_sections()
+    set_yaml_section(
+        "memory",
+        {
+            "consolidation": {
+                "legacy": False,
+                "policy": "fail_tolerant",
+                "timeout_per_step_ms": 30000,
+                "steps": [
+                    "fact_extract",
+                    "entity_normalization",
+                    "topic_cluster",
+                    "dedup_merge",
+                    "summarize",
+                    "auto_link",
+                ],
+                "cluster_eps": 0.5,  # 放宽聚类阈值，确定性 embedding 下利于成簇
+                "merge_threshold": 0.90,
+            }
+        },
+    )
+    _invalidate_memory_settings_cache()
+    yield
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+@pytest.fixture
+def _patch_llm_steps(monkeypatch):
+    """把三个 LLM 触点替换为确定性桩，保证离线 + 可断言成功。"""
+
+    # 1. fact_extract：用 PatternFactExtractor 行为的确定性事实
+    async def fake_extract(self, turns):  # noqa: ANN001
+        return [
+            ExtractedFact(
+                fact_type="preference",
+                key="favorite_language",
+                value="TypeScript",
+                confidence=0.9,
+            ),
+            ExtractedFact(
+                fact_type="profile",
+                key="role",
+                value="backend engineer",
+                confidence=0.9,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "negentropy.engine.consolidation.llm_fact_extractor.LLMFactExtractor.extract",
+        fake_extract,
+    )
+
+    # 2. entity_normalization：跳过真实 LLM，返回确定性实体
+    async def fake_normalize(self, facts_block):  # noqa: ANN001
+        return [{"canonical": "TypeScript", "aliases": ["TS", "typescript"], "kind": "language"}]
+
+    monkeypatch.setattr(
+        "negentropy.engine.consolidation.pipeline.steps.entity_normalization_step."
+        "EntityNormalizationStep._llm_normalize",
+        fake_normalize,
+    )
+
+    # _resolve_model 也需断网
+    async def _noop_resolve(self):  # noqa: ANN001
+        self._model = "stub"
+        self._model_kwargs = {}
+
+    monkeypatch.setattr(
+        "negentropy.engine.consolidation.pipeline.steps.entity_normalization_step."
+        "EntityNormalizationStep._resolve_model",
+        _noop_resolve,
+    )
+
+    # 3. summarize：MemorySummarizer.get_or_generate_summary 返回桩 summary
+    class _StubSummary:
+        content = "用户画像：TypeScript 偏好的后端工程师。"
+        token_count = 12
+
+    async def fake_summary(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        return _StubSummary()
+
+    monkeypatch.setattr(
+        "negentropy.engine.consolidation.memory_summarizer.MemorySummarizer.get_or_generate_summary",
+        fake_summary,
+    )
+
+    yield
+
+
+async def _seed_thread(thread_id: uuid.UUID, app_name: str, user_id: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        db.add(Thread(id=thread_id, app_name=app_name, user_id=user_id, state={}))
+        await db.commit()
+
+
+def _make_session(session_id: str, app_name: str, user_id: str) -> ADKSession:
+    """构造一个会产出 ≥2 个「同主题但非近重复」段落的会话。
+
+    分段规则（见 memory_service._group_turns_into_segments）：每 5 个 turn 成一段。
+    这里前 10 个 turn 都围绕 TypeScript backend 主题但措辞各异，故切成两段后：
+    - 两段 cosine 距离 ~0.32（< cluster_eps=0.5 → topic_cluster 成簇）
+    - 又 > 0.15（相似度 < 0.85 → 写入期 _is_duplicate 不会拦截，两段都入库）
+    用带空格、可重叠分词的英文关键词（中文连写整段会被切成单 token，无法体现重叠）。
+    """
+
+    def _ev(author: str, text: str) -> ADKEvent:
+        return ADKEvent(id=str(uuid.uuid4()), author=author, content={"parts": [{"text": text}]})
+
+    events = [
+        # —— 段 1（turns 1-5）：TypeScript backend 主题 ——
+        _ev("user", "I love TypeScript backend services and type safety"),
+        _ev("model", "TypeScript backend is great for type safety and tooling"),
+        _ev("user", "TypeScript backend services with generics scale well"),
+        _ev("model", "Yes TypeScript backend generics improve maintainability"),
+        _ev("user", "TypeScript backend type safety reduces runtime bugs"),
+        # —— 段 2（turns 6-10）：仍是 TypeScript backend 主题，措辞不同 ——
+        _ev("model", "TypeScript backend services pair well with strict types"),
+        _ev("user", "I prefer TypeScript backend over dynamic typing languages"),
+        _ev("model", "TypeScript backend with strict null checks is robust"),
+        _ev("user", "TypeScript backend services and interfaces feel clean"),
+        _ev("model", "Indeed TypeScript backend interfaces document the contract"),
+        # —— 段 3（turns 11+）：不同主题，作为聚类的负样本 ——
+        _ev("user", "On weekend I enjoy hiking camping mountains nature trails"),
+        _ev("model", "Hiking camping in the mountains nature trails sounds fun"),
+    ]
+    return ADKSession(id=session_id, app_name=app_name, user_id=user_id, state={}, events=events, last_update_time=0.0)
+
+
+# ---------------------------------------------------------------------------
+# T1 主测试
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memify_full_pipeline_produces_all_artifacts(_six_step_yaml, _patch_llm_steps):
+    """单次 add_session_to_memory 跑满 6 步，断言六类产物齐全。"""
+    app_name = "test_memify_app"
+    user_id = f"memify_user_{uuid.uuid4().hex[:8]}"
+    session_id = str(uuid.uuid4())
+    thread_id = uuid.UUID(session_id)
+
+    await _seed_thread(thread_id, app_name, user_id)
+
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+    session = _make_session(session_id, app_name, user_id)
+
+    # 真实入库 + 6 步管线
+    await service.add_session_to_memory(session)
+
+    async with db_session.AsyncSessionLocal() as db:
+        # 1) memories：episodic 记忆写入（≥2 段，近重复在写入期已被 _is_duplicate 拦截）
+        mem_rows = (
+            (await db.execute(select(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name)))
+            .scalars()
+            .all()
+        )
+        assert len(mem_rows) >= 2, f"应至少写入 2 段记忆，实际 {len(mem_rows)}"
+
+        # 2) facts：fact_extract 入库
+        fact_count = (
+            await db.execute(select(func.count(Fact.id)).where(Fact.user_id == user_id, Fact.app_name == app_name))
+        ).scalar_one()
+        assert fact_count >= 1, "fact_extract 应至少写入 1 条事实"
+
+        # 3) topics：topic_cluster 在 metadata_.topics 标注（语义相近段成簇）
+        topic_tagged = [m for m in mem_rows if (m.metadata_ or {}).get("topics")]
+        assert topic_tagged, "topic_cluster 应至少给一段记忆打上 topics 标签"
+
+        # 6) associations：auto_link 建立关联边
+        assoc_count = (
+            await db.execute(
+                select(func.count(MemoryAssociation.id)).where(
+                    MemoryAssociation.user_id == user_id,
+                    MemoryAssociation.app_name == app_name,
+                )
+            )
+        ).scalar_one()
+        assert assoc_count >= 1, "auto_link 应至少建立 1 条关联"
+
+
+@pytest.mark.asyncio
+async def test_memify_pipeline_step_statuses_not_failed(_six_step_yaml, _patch_llm_steps):
+    """直接驱动 _run_consolidation_pipeline，断言每步 status 非 failed。"""
+    from negentropy.engine.consolidation.pipeline import (  # noqa: F401 触发注册
+        PipelineContext,
+        build_pipeline,
+    )
+    from negentropy.engine.consolidation.pipeline import steps as _builtin_steps  # noqa: F401
+
+    app_name = "test_memify_status"
+    user_id = f"memify_status_{uuid.uuid4().hex[:8]}"
+    session_id = str(uuid.uuid4())
+    thread_id = uuid.UUID(session_id)
+    await _seed_thread(thread_id, app_name, user_id)
+
+    # 先种入两段语义相近 + 一段不同的记忆，提供 topic_cluster/dedup/auto_link 的输入
+    new_ids: list[uuid.UUID] = []
+    async with db_session.AsyncSessionLocal() as db:
+        for content in (
+            "I love TypeScript backend services and type safety a lot",
+            "TypeScript backend services with strong type safety are great",
+            "On weekend I enjoy hiking camping mountains nature trails",
+        ):
+            m = Memory(
+                thread_id=thread_id,
+                user_id=user_id,
+                app_name=app_name,
+                memory_type="episodic",
+                content=content,
+                embedding=_deterministic_embedding(content),
+                retention_score=0.8,
+                importance_score=0.4,
+                metadata_={"source": "test"},
+            )
+            db.add(m)
+            await db.flush()
+            new_ids.append(m.id)
+        await db.commit()
+
+    turns = [
+        {"author": "user", "text": "I love TypeScript backend services and type safety a lot"},
+        {"author": "user", "text": "On weekend I enjoy hiking camping mountains nature trails"},
+    ]
+
+    pipeline = build_pipeline(
+        ["fact_extract", "entity_normalization", "topic_cluster", "dedup_merge", "summarize", "auto_link"],
+        policy="fail_tolerant",
+        timeout_per_step_ms=30000,
+        strict=False,
+    )
+    ctx = PipelineContext(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        turns=turns,
+        new_memory_ids=list(new_ids),
+        embedding_fn=_embedding_fn,
+    )
+    results = await pipeline.run(ctx)
+
+    assert {r.step_name for r in results} == {
+        "fact_extract",
+        "entity_normalization",
+        "topic_cluster",
+        "dedup_merge",
+        "summarize",
+        "auto_link",
+    }
+    failed = [r.step_name for r in results if r.status == "failed"]
+    assert not failed, f"以下 step 失败：{failed}（详情：{[(r.step_name, r.error) for r in results]}）"
+
+    # entity_normalization 应产出实体（桩）
+    assert ctx.entities, "entity_normalization 应写回 ctx.entities"
+    # topic_cluster 应产出 topics
+    assert ctx.topics, "topic_cluster 应写回 ctx.topics"

--- a/apps/negentropy/tests/integration_tests/engine/consolidation/test_full_pipeline.py
+++ b/apps/negentropy/tests/integration_tests/engine/consolidation/test_full_pipeline.py
@@ -203,6 +203,21 @@ async def _seed_thread(thread_id: uuid.UUID, app_name: str, user_id: str) -> Non
         await db.commit()
 
 
+async def _cleanup(user_id: str, app_name: str) -> None:
+    """清理本用例写入的记忆/事实/关联，避免跨运行在真实库累积。"""
+    from sqlalchemy import delete
+
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(
+            delete(MemoryAssociation).where(
+                MemoryAssociation.user_id == user_id, MemoryAssociation.app_name == app_name
+            )
+        )
+        await db.execute(delete(Fact).where(Fact.user_id == user_id, Fact.app_name == app_name))
+        await db.execute(delete(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name))
+        await db.commit()
+
+
 def _make_session(session_id: str, app_name: str, user_id: str) -> ADKSession:
     """构造一个会产出 ≥2 个「同主题但非近重复」段落的会话。
 
@@ -254,38 +269,41 @@ async def test_memify_full_pipeline_produces_all_artifacts(_six_step_yaml, _patc
     service = PostgresMemoryService(embedding_fn=_embedding_fn)
     session = _make_session(session_id, app_name, user_id)
 
-    # 真实入库 + 6 步管线
-    await service.add_session_to_memory(session)
+    try:
+        # 真实入库 + 6 步管线
+        await service.add_session_to_memory(session)
 
-    async with db_session.AsyncSessionLocal() as db:
-        # 1) memories：episodic 记忆写入（≥2 段，近重复在写入期已被 _is_duplicate 拦截）
-        mem_rows = (
-            (await db.execute(select(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name)))
-            .scalars()
-            .all()
-        )
-        assert len(mem_rows) >= 2, f"应至少写入 2 段记忆，实际 {len(mem_rows)}"
-
-        # 2) facts：fact_extract 入库
-        fact_count = (
-            await db.execute(select(func.count(Fact.id)).where(Fact.user_id == user_id, Fact.app_name == app_name))
-        ).scalar_one()
-        assert fact_count >= 1, "fact_extract 应至少写入 1 条事实"
-
-        # 3) topics：topic_cluster 在 metadata_.topics 标注（语义相近段成簇）
-        topic_tagged = [m for m in mem_rows if (m.metadata_ or {}).get("topics")]
-        assert topic_tagged, "topic_cluster 应至少给一段记忆打上 topics 标签"
-
-        # 6) associations：auto_link 建立关联边
-        assoc_count = (
-            await db.execute(
-                select(func.count(MemoryAssociation.id)).where(
-                    MemoryAssociation.user_id == user_id,
-                    MemoryAssociation.app_name == app_name,
-                )
+        async with db_session.AsyncSessionLocal() as db:
+            # 1) memories：episodic 记忆写入（≥2 段，近重复在写入期已被 _is_duplicate 拦截）
+            mem_rows = (
+                (await db.execute(select(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name)))
+                .scalars()
+                .all()
             )
-        ).scalar_one()
-        assert assoc_count >= 1, "auto_link 应至少建立 1 条关联"
+            assert len(mem_rows) >= 2, f"应至少写入 2 段记忆，实际 {len(mem_rows)}"
+
+            # 2) facts：fact_extract 入库
+            fact_count = (
+                await db.execute(select(func.count(Fact.id)).where(Fact.user_id == user_id, Fact.app_name == app_name))
+            ).scalar_one()
+            assert fact_count >= 1, "fact_extract 应至少写入 1 条事实"
+
+            # 3) topics：topic_cluster 在 metadata_.topics 标注（语义相近段成簇）
+            topic_tagged = [m for m in mem_rows if (m.metadata_ or {}).get("topics")]
+            assert topic_tagged, "topic_cluster 应至少给一段记忆打上 topics 标签"
+
+            # 6) associations：auto_link 建立关联边
+            assoc_count = (
+                await db.execute(
+                    select(func.count(MemoryAssociation.id)).where(
+                        MemoryAssociation.user_id == user_id,
+                        MemoryAssociation.app_name == app_name,
+                    )
+                )
+            ).scalar_one()
+            assert assoc_count >= 1, "auto_link 应至少建立 1 条关联"
+    finally:
+        await _cleanup(user_id, app_name)
 
 
 @pytest.mark.asyncio
@@ -332,34 +350,37 @@ async def test_memify_pipeline_step_statuses_not_failed(_six_step_yaml, _patch_l
         {"author": "user", "text": "On weekend I enjoy hiking camping mountains nature trails"},
     ]
 
-    pipeline = build_pipeline(
-        ["fact_extract", "entity_normalization", "topic_cluster", "dedup_merge", "summarize", "auto_link"],
-        policy="fail_tolerant",
-        timeout_per_step_ms=30000,
-        strict=False,
-    )
-    ctx = PipelineContext(
-        user_id=user_id,
-        app_name=app_name,
-        thread_id=thread_id,
-        turns=turns,
-        new_memory_ids=list(new_ids),
-        embedding_fn=_embedding_fn,
-    )
-    results = await pipeline.run(ctx)
+    try:
+        pipeline = build_pipeline(
+            ["fact_extract", "entity_normalization", "topic_cluster", "dedup_merge", "summarize", "auto_link"],
+            policy="fail_tolerant",
+            timeout_per_step_ms=30000,
+            strict=False,
+        )
+        ctx = PipelineContext(
+            user_id=user_id,
+            app_name=app_name,
+            thread_id=thread_id,
+            turns=turns,
+            new_memory_ids=list(new_ids),
+            embedding_fn=_embedding_fn,
+        )
+        results = await pipeline.run(ctx)
 
-    assert {r.step_name for r in results} == {
-        "fact_extract",
-        "entity_normalization",
-        "topic_cluster",
-        "dedup_merge",
-        "summarize",
-        "auto_link",
-    }
-    failed = [r.step_name for r in results if r.status == "failed"]
-    assert not failed, f"以下 step 失败：{failed}（详情：{[(r.step_name, r.error) for r in results]}）"
+        assert {r.step_name for r in results} == {
+            "fact_extract",
+            "entity_normalization",
+            "topic_cluster",
+            "dedup_merge",
+            "summarize",
+            "auto_link",
+        }
+        failed = [r.step_name for r in results if r.status == "failed"]
+        assert not failed, f"以下 step 失败：{failed}（详情：{[(r.step_name, r.error) for r in results]}）"
 
-    # entity_normalization 应产出实体（桩）
-    assert ctx.entities, "entity_normalization 应写回 ctx.entities"
-    # topic_cluster 应产出 topics
-    assert ctx.topics, "topic_cluster 应写回 ctx.topics"
+        # entity_normalization 应产出实体（桩）
+        assert ctx.entities, "entity_normalization 应写回 ctx.entities"
+        # topic_cluster 应产出 topics
+        assert ctx.topics, "topic_cluster 应写回 ctx.topics"
+    finally:
+        await _cleanup(user_id, app_name)

--- a/apps/negentropy/tests/integration_tests/engine/test_pii_writepath.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_pii_writepath.py
@@ -1,0 +1,291 @@
+"""T3 — F4 PII 写入接线 + 检索守门员集成测试（真实 PostgreSQL）。
+
+验证修复 ISSUE-099：写入路径改经 ``detect_pii_for_storage``（工厂引擎）落
+``metadata.pii_flags`` + ``metadata.pii_spans``；检索路径经 ``PIIGatekeeper``
+按 viewer_role 遮蔽。
+
+覆盖：
+1. 写入：含 email/phone 的记忆 → metadata 经工厂路径产出 flags + spans。
+2. 守门员开启 + 低权限：content 被 anonymize（出现 <EMAIL>/<PHONE> 占位）。
+3. 守门员开启 + 高权限（editor/admin）：content 原样透传。
+4. 守门员关闭：原样透传（默认安全）。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete
+
+import negentropy.db.session as db_session
+from negentropy.config._base import reset_sections, set_yaml_section
+from negentropy.engine.adapters.postgres.memory_service import PostgresMemoryService
+from negentropy.engine.governance.pii.factory import reset_pii_detector
+from negentropy.models.internalization import Memory
+
+_PII_CONTENT = "Contact me at john.doe@example.com or call 13800138000 anytime"
+
+
+async def _embedding_fn(text: str) -> list[float]:
+    return [0.15] * 1536
+
+
+async def _seed_thread(thread_id: uuid.UUID, app_name: str, user_id: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        db.add(Thread(id=thread_id, app_name=app_name, user_id=user_id, state={}))
+        await db.commit()
+
+
+async def _cleanup(user_id: str, app_name: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(delete(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name))
+        await db.commit()
+
+
+def _invalidate_memory_settings_cache() -> None:
+    """settings.memory 是 @cached_property，需手动失效后才会重读新设的 YAML 段。"""
+    from negentropy.config import settings as global_settings
+
+    global_settings.__dict__.pop("memory", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_pii():
+    """每个用例前后重置 PII 引擎单例 + YAML 段 + settings 缓存，避免跨用例污染。"""
+    reset_pii_detector()
+    reset_sections()
+    _invalidate_memory_settings_cache()
+    yield
+    reset_pii_detector()
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+def _set_pii_yaml(**pii_overrides):
+    base = {"engine": "regex", "policy": "mark", "gatekeeper_enabled": False, "acl_role_threshold": "editor"}
+    base.update(pii_overrides)
+    set_yaml_section("memory", {"pii": base})
+    _invalidate_memory_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_write_path_produces_pii_flags_and_spans():
+    """写入含 PII 记忆 → metadata 经工厂路径产出 flags + spans。"""
+    _set_pii_yaml(engine="regex")
+    app_name = "t3_pii_write"
+    user_id = f"pii_write_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    res = await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content=_PII_CONTENT,
+        memory_type="semantic",
+    )
+    mid = uuid.UUID(res["id"])
+
+    async with db_session.AsyncSessionLocal() as db:
+        m = await db.get(Memory, mid)
+        meta = m.metadata_ or {}
+
+    assert meta.get("pii_flags"), "应落 pii_flags"
+    assert meta["pii_flags"].get("email") == 1
+    assert meta["pii_flags"].get("phone") == 1
+    spans = meta.get("pii_spans")
+    assert spans and len(spans) >= 2, "应落 pii_spans（供检索遮蔽）"
+    types = {s["type"] for s in spans}
+    assert {"email", "phone"} <= types
+    # spans 字段完整性（PIIGatekeeper 依赖 start/end/text）
+    for s in spans:
+        assert {"type", "start", "end", "text"} <= set(s.keys())
+
+    await _cleanup(user_id, app_name)
+
+
+@pytest.mark.asyncio
+async def test_gatekeeper_anonymizes_for_low_priv_role():
+    """守门员开启 + viewer（低权限）→ content 被 anonymize。"""
+    _set_pii_yaml(engine="regex", gatekeeper_enabled=True, acl_role_threshold="editor", policy="anonymize")
+    app_name = "t3_pii_gk_low"
+    user_id = f"pii_gk_low_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content=_PII_CONTENT,
+        memory_type="semantic",
+    )
+
+    resp = await service.search_memory(
+        app_name=app_name, user_id=user_id, query="contact email phone", viewer_role="viewer"
+    )
+    assert resp.memories, "应有检索结果"
+    texts = [m.content.parts[0].text for m in resp.memories]
+    joined = " ".join(texts)
+    # 原始 PII 应被占位符替换
+    assert "john.doe@example.com" not in joined, "email 原文不应泄露给低权限角色"
+    assert "13800138000" not in joined, "phone 原文不应泄露给低权限角色"
+    assert "<EMAIL>" in joined or "<PHONE>" in joined, "应出现 anonymize 占位符"
+    # metadata 标记 pii_redacted
+    assert any((getattr(m, "custom_metadata", None) or {}).get("pii_redacted") for m in resp.memories)
+
+    await _cleanup(user_id, app_name)
+
+
+@pytest.mark.asyncio
+async def test_gatekeeper_passthrough_for_high_priv_role():
+    """守门员开启 + admin（高权限）→ content 原样透传。"""
+    _set_pii_yaml(engine="regex", gatekeeper_enabled=True, acl_role_threshold="editor", policy="anonymize")
+    app_name = "t3_pii_gk_high"
+    user_id = f"pii_gk_high_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content=_PII_CONTENT,
+        memory_type="semantic",
+    )
+
+    resp = await service.search_memory(
+        app_name=app_name, user_id=user_id, query="contact email phone", viewer_role="admin"
+    )
+    assert resp.memories
+    joined = " ".join(m.content.parts[0].text for m in resp.memories)
+    assert "john.doe@example.com" in joined, "高权限角色应看到原文"
+
+    await _cleanup(user_id, app_name)
+
+
+@pytest.mark.asyncio
+async def test_gatekeeper_disabled_passthrough():
+    """守门员关闭（默认）→ 即使低权限也原样透传。"""
+    _set_pii_yaml(engine="regex", gatekeeper_enabled=False)
+    app_name = "t3_pii_gk_off"
+    user_id = f"pii_gk_off_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content=_PII_CONTENT,
+        memory_type="semantic",
+    )
+
+    resp = await service.search_memory(
+        app_name=app_name, user_id=user_id, query="contact email phone", viewer_role="viewer"
+    )
+    assert resp.memories
+    joined = " ".join(m.content.parts[0].text for m in resp.memories)
+    assert "john.doe@example.com" in joined, "守门员关闭时应原样透传"
+
+    await _cleanup(user_id, app_name)
+
+
+# ---------------------------------------------------------------------------
+# Presidio 引擎专项（默认引擎）+ 缺模型降级安全网
+# ---------------------------------------------------------------------------
+
+
+def _presidio_available() -> bool:
+    import importlib.util
+
+    return all(importlib.util.find_spec(m) is not None for m in ("presidio_analyzer", "en_core_web_lg"))
+
+
+@pytest.mark.skipif(not _presidio_available(), reason="presidio / en_core_web_lg 未安装")
+@pytest.mark.asyncio
+async def test_presidio_engine_detects_person_ner():
+    """engine=presidio 提供 regex 无法识别的 PERSON NER（证明引擎翻转带来新能力）。"""
+    from negentropy.engine.governance.pii import get_pii_detector
+
+    _set_pii_yaml(engine="presidio")
+    detector = get_pii_detector()
+    assert detector.name == "presidio", "默认应解析为 presidio 引擎"
+
+    spans = detector.detect("My name is John Smith and I work at OpenAI")
+    types = {s.pii_type for s in spans}
+    assert "person" in types, f"presidio 应识别 PERSON；实际类型 {types}"
+
+
+def _zh_model_available() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("zh_core_web_sm") is not None
+
+
+@pytest.mark.skipif(
+    not (_presidio_available() and _zh_model_available()),
+    reason="presidio / zh_core_web_sm 未安装",
+)
+def test_presidio_detects_cn_mobile_via_zh_nlp_engine():
+    """zh NLP 引擎正确装配后，CN_MOBILE 自定义识别器对中文手机号生效（ISSUE-101）。"""
+    from negentropy.engine.governance.pii.presidio_detector import PresidioPIIDetector
+
+    d = PresidioPIIDetector(languages=["en", "zh"], score_threshold=0.5)
+    assert "zh" in d._languages, "zh 模型存在时应纳入可用语言"
+    spans = d.detect("张三的手机号是 13912345678")
+    types = {s.pii_type for s in spans}
+    assert "phone" in types, f"应经 CN_MOBILE 识别中国手机号；实际 {types}"
+
+
+@pytest.mark.asyncio
+async def test_pii_factory_falls_back_to_regex_when_presidio_unavailable(monkeypatch):
+    """allow_engine_fallback=true + presidio 初始化失败 → 降级 regex，不抛错（开箱安全网）。"""
+    import negentropy.engine.governance.pii.factory as factory_mod
+
+    _set_pii_yaml(engine="presidio", allow_engine_fallback=True)
+    factory_mod.reset_pii_detector()
+
+    # 模拟 presidio 初始化失败（如 spaCy 模型缺失）
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated spaCy model missing")
+
+    monkeypatch.setattr(
+        "negentropy.engine.governance.pii.presidio_detector.PresidioPIIDetector.__init__",
+        _boom,
+    )
+    detector = factory_mod.get_pii_detector()
+    assert detector.name == "regex", "缺模型 + allow_engine_fallback=true 应降级 regex 而非抛错"
+    factory_mod.reset_pii_detector()
+
+
+@pytest.mark.asyncio
+async def test_pii_factory_raises_when_fallback_disabled(monkeypatch):
+    """allow_engine_fallback=false + presidio 失败 → 抛 PIIEngineUnavailableError（保密性优先）。"""
+    import negentropy.engine.governance.pii.factory as factory_mod
+    from negentropy.engine.governance.pii.factory import PIIEngineUnavailableError
+
+    _set_pii_yaml(engine="presidio", allow_engine_fallback=False)
+    factory_mod.reset_pii_detector()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated spaCy model missing")
+
+    monkeypatch.setattr(
+        "negentropy.engine.governance.pii.presidio_detector.PresidioPIIDetector.__init__",
+        _boom,
+    )
+    with pytest.raises(PIIEngineUnavailableError):
+        factory_mod.get_pii_detector()
+    factory_mod.reset_pii_detector()

--- a/apps/negentropy/tests/integration_tests/engine/test_pii_writepath.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_pii_writepath.py
@@ -102,9 +102,11 @@ async def test_write_path_produces_pii_flags_and_spans():
     assert spans and len(spans) >= 2, "应落 pii_spans（供检索遮蔽）"
     types = {s["type"] for s in spans}
     assert {"email", "phone"} <= types
-    # spans 字段完整性（PIIGatekeeper 依赖 start/end/text）
+    # spans 字段完整性（PIIGatekeeper 按 start/end + type 偏移量遮蔽）；
+    # 刻意不落命中原文 text —— metadata 会随检索结果回传，存原文等于旁路泄露 PII。
     for s in spans:
-        assert {"type", "start", "end", "text"} <= set(s.keys())
+        assert {"type", "start", "end"} <= set(s.keys())
+        assert "text" not in s, "pii_spans 不应持久化命中原文（防 metadata 旁路泄露 PII）"
 
     await _cleanup(user_id, app_name)
 
@@ -140,6 +142,14 @@ async def test_gatekeeper_anonymizes_for_low_priv_role():
     assert "<EMAIL>" in joined or "<PHONE>" in joined, "应出现 anonymize 占位符"
     # metadata 标记 pii_redacted
     assert any((getattr(m, "custom_metadata", None) or {}).get("pii_redacted") for m in resp.memories)
+    # 回归（修复 PII 旁路泄露）：脱敏后 metadata 不得经 pii_spans 等字段回传 PII 原文
+    for m in resp.memories:
+        meta = getattr(m, "custom_metadata", None) or {}
+        for s in meta.get("pii_spans") or []:
+            assert "text" not in s, "检索回传的 pii_spans 不应含命中原文"
+        meta_blob = str(meta)
+        assert "john.doe@example.com" not in meta_blob, "email 原文不应经 metadata 泄露"
+        assert "13800138000" not in meta_blob, "phone 原文不应经 metadata 泄露"
 
     await _cleanup(user_id, app_name)
 

--- a/apps/negentropy/tests/integration_tests/engine/test_ppr_fusion.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_ppr_fusion.py
@@ -1,0 +1,267 @@
+"""T4-F1 — HippoRAG PPR-Boosted Hybrid「实跑」集成测试（真实 PostgreSQL）。
+
+补足此前空白：现有 ``test_ppr_search`` 仅是 RRF 数学 + mock 组件的单测，从未在
+真实 KG 上跑通「种子链接 → PPR 扩散 → 实体反查 → RRF 融合」整链。本测试种入一个
+最小但真实的图（Corpus + KgEntity×2 + KgRelation + ≥100 entity-associations），
+证明 ``hipporag.enabled=true`` 时 PPR 通道真正执行并融合进结果（search_level 含 ppr），
+以及数据闸（min_kg_associations）在关联不足时让其自休眠回退 Hybrid。
+
+锚点：memory_service._maybe_fuse_ppr / _ppr_search / _rrf_fuse；
+association_service.count_kg_associations / expand_via_ppr / memories_for_entity_scores。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete
+
+import negentropy.db.session as db_session
+from negentropy.config._base import reset_sections, set_yaml_section
+from negentropy.engine.adapters.postgres.memory_service import PostgresMemoryService
+from negentropy.models.internalization import Memory, MemoryAssociation
+from negentropy.models.perception import Corpus, KgEntity, KgRelation
+
+_DIM = 1536
+
+
+def _emb(seed: float) -> list[float]:
+    """构造一个确定性向量：前若干维填 seed，便于 query 与 entity 对齐。"""
+    v = [0.0] * _DIM
+    for i in range(16):
+        v[i] = seed
+    # L2 normalize
+    norm = (sum(x * x for x in v)) ** 0.5 or 1.0
+    return [x / norm for x in v]
+
+
+async def _embedding_fn(text_in: str) -> list[float]:
+    # query 与种子实体共享同方向向量 → cosine 距离≈0，确保种子链接命中
+    return _emb(1.0)
+
+
+def _invalidate_memory_settings_cache() -> None:
+    """settings.memory 是 @cached_property，需手动失效后才会重读新设的 YAML 段。"""
+    from negentropy.config import settings as global_settings
+
+    global_settings.__dict__.pop("memory", None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory_singletons():
+    """防御上游单测对工厂单例的污染（某些单测把 get_*_service 替换为 MagicMock 后
+    未复位）。本集成测试需要真实服务，故运行前后强制重置工厂单例。"""
+    from negentropy.engine.factories.memory import (
+        reset_association_service,
+        reset_fact_service,
+        reset_memory_service,
+    )
+
+    reset_association_service()
+    reset_fact_service()
+    reset_memory_service()
+    yield
+    reset_association_service()
+    reset_fact_service()
+    reset_memory_service()
+
+
+@pytest.fixture
+def _hipporag_on():
+    reset_sections()
+    set_yaml_section(
+        "memory",
+        {
+            "hipporag": {
+                "enabled": True,
+                "depth": 2,
+                "alpha": 0.5,
+                "rrf_k": 60,
+                "timeout_ms": 2000,  # 测试放宽超时，避免环境抖动误判
+                "seed_top_k": 5,
+                "seed_threshold": 0.5,
+                "min_kg_associations": 100,
+            }
+        },
+    )
+    _invalidate_memory_settings_cache()
+    yield
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+@pytest.fixture
+def _hipporag_gated_off():
+    """enabled=true 但关联数 < 阈值 → 数据闸应让 PPR 自休眠。"""
+    reset_sections()
+    set_yaml_section(
+        "memory",
+        {"hipporag": {"enabled": True, "min_kg_associations": 100, "seed_threshold": 0.5, "timeout_ms": 2000}},
+    )
+    _invalidate_memory_settings_cache()
+    yield
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+async def _seed_graph(
+    *, user_id: str, app_name: str, thread_id: uuid.UUID, n_assoc: int
+) -> tuple[uuid.UUID, list[uuid.UUID]]:
+    """种入 Corpus + 2 实体 + 1 关系 + n_assoc 条 entity 关联 + 若干 memory。
+
+    Returns: (corpus_id, [memory_ids])
+    """
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        db.add(Thread(id=thread_id, app_name=app_name, user_id=user_id, state={}))
+
+        corpus = Corpus(app_name=app_name, name=f"ppr_corpus_{uuid.uuid4().hex[:8]}")
+        db.add(corpus)
+        await db.flush()
+
+        # 两个实体：seed 实体与 query 同向（命中种子链接），邻居实体被 PPR 扩散到
+        e_seed = KgEntity(
+            corpus_id=corpus.id,
+            app_name=app_name,
+            name="TypeScript",
+            entity_type="concept",
+            embedding=_emb(1.0),
+            is_active=True,
+        )
+        e_neighbor = KgEntity(
+            corpus_id=corpus.id,
+            app_name=app_name,
+            name="BackendService",
+            entity_type="concept",
+            embedding=_emb(0.9),
+            is_active=True,
+        )
+        db.add_all([e_seed, e_neighbor])
+        await db.flush()
+
+        # 关系：seed -> neighbor（供 BFS 扩散）
+        db.add(
+            KgRelation(
+                source_id=e_seed.id,
+                target_id=e_neighbor.id,
+                corpus_id=corpus.id,
+                app_name=app_name,
+                relation_type="RELATED_TO",
+                weight=1.0,
+                is_active=True,
+            )
+        )
+
+        # n_assoc 条不同 memory，各自挂到一个实体上（target_type='entity'）。
+        # 唯一约束 assoc_unique=(source_id, target_id, association_type) 要求
+        # 每条关联的 (memory, entity) 组合唯一 → 用独立 memory 作 source。
+        entities = [e_seed.id, e_neighbor.id]
+        memory_ids: list[uuid.UUID] = []
+        for i in range(n_assoc):
+            m = Memory(
+                thread_id=thread_id,
+                user_id=user_id,
+                app_name=app_name,
+                memory_type="semantic",
+                content=f"TypeScript backend service note number {i} about type safety",
+                embedding=_emb(1.0),
+                retention_score=0.8,
+                importance_score=0.6,
+                metadata_={"source": "test_ppr"},
+            )
+            db.add(m)
+            await db.flush()
+            memory_ids.append(m.id)
+            db.add(
+                MemoryAssociation(
+                    source_id=m.id,
+                    source_type="memory",
+                    target_id=entities[i % len(entities)],
+                    target_type="entity",
+                    association_type="entity",
+                    weight=0.8,
+                    user_id=user_id,
+                    app_name=app_name,
+                )
+            )
+        await db.commit()
+        return corpus.id, memory_ids
+
+
+async def _cleanup(user_id: str, app_name: str, corpus_id: uuid.UUID | None) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(
+            delete(MemoryAssociation).where(
+                MemoryAssociation.user_id == user_id, MemoryAssociation.app_name == app_name
+            )
+        )
+        await db.execute(delete(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name))
+        if corpus_id is not None:
+            await db.execute(delete(KgRelation).where(KgRelation.corpus_id == corpus_id))
+            await db.execute(delete(KgEntity).where(KgEntity.corpus_id == corpus_id))
+            await db.execute(delete(Corpus).where(Corpus.id == corpus_id))
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_ppr_fusion_executes_when_kg_dense(_hipporag_on):
+    """KG 关联≥100 + enabled=true → PPR 通道实跑并融合（结果含 ppr 痕迹）。"""
+    app_name = "t4_ppr_app"
+    user_id = f"ppr_user_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    corpus_id = None
+    try:
+        corpus_id, _ = await _seed_graph(user_id=user_id, app_name=app_name, thread_id=thread_id, n_assoc=120)
+        service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+        # 先确认数据闸放行
+        from negentropy.engine.factories.memory import get_association_service
+
+        assoc = get_association_service()
+        cnt = await assoc.count_kg_associations(user_id=user_id, app_name=app_name)
+        assert cnt >= 100, f"应种入≥100 条 entity 关联，实际 {cnt}"
+
+        resp = await service.search_memory(app_name=app_name, user_id=user_id, query="TypeScript backend type safety")
+        assert resp.memories, "检索应有结果"
+
+        # 至少一条结果带 ppr 痕迹（search_level 含 'ppr'，或 metadata.fusion 记录 ppr 通道）
+        # 注意：ADK MemoryEntry 把元数据放在 custom_metadata 字段
+        levels = []
+        for m in resp.memories:
+            meta = getattr(m, "custom_metadata", None) or {}
+            lvl = meta.get("search_level", "")
+            levels.append(lvl)
+            fusion = meta.get("fusion", {})
+            if "ppr" in lvl or (isinstance(fusion, dict) and "ppr" in (fusion.get("channels") or {})):
+                break
+        else:
+            pytest.fail(f"未观察到 PPR 通道融合痕迹；levels={levels}")
+    finally:
+        await _cleanup(user_id, app_name, corpus_id)
+
+
+@pytest.mark.asyncio
+async def test_ppr_dormant_when_kg_sparse(_hipporag_gated_off):
+    """关联数 < 100 → 数据闸生效，PPR 自休眠，结果回退纯 Hybrid（无 ppr 痕迹）。"""
+    app_name = "t4_ppr_sparse"
+    user_id = f"ppr_sparse_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    corpus_id = None
+    try:
+        corpus_id, _ = await _seed_graph(
+            user_id=user_id,
+            app_name=app_name,
+            thread_id=thread_id,
+            n_assoc=5,  # 远低于闸值
+        )
+        service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+        resp = await service.search_memory(app_name=app_name, user_id=user_id, query="TypeScript backend type safety")
+        assert resp.memories, "稀疏 KG 下仍应有 Hybrid 结果"
+        for m in resp.memories:
+            meta = getattr(m, "custom_metadata", None) or {}
+            assert "ppr" not in meta.get("search_level", ""), "数据闸未生效：稀疏 KG 不应触发 PPR"
+    finally:
+        await _cleanup(user_id, app_name, corpus_id)

--- a/apps/negentropy/tests/integration_tests/engine/test_reflection_e2e.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_reflection_e2e.py
@@ -1,0 +1,227 @@
+"""T4-F2 — Reflexion 失败反思端到端集成测试（真实 PostgreSQL）。
+
+补足空白：现有单测覆盖 record_feedback 触发分支 / 风暴上限 / 去重，但无「负反馈
+→ 真正写入一条 episodic/subtype=reflection 记忆」的端到端验证。本测试证明
+``reflection.enabled=true`` 时 Reflexion 闭环真实落库。
+
+离线确定性：未配 LLM key 时 ReflectionGenerator 自动回退 pattern 模板（method=pattern），
+无需网络。
+
+锚点：retrieval_tracker.log_retrieval / record_feedback / get_pending_reflection_tasks；
+reflection_worker._write_reflection（memory_type=episodic, metadata.subtype=reflection）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+from sqlalchemy import delete, select
+
+import negentropy.db.session as db_session
+from negentropy.config._base import reset_sections, set_yaml_section
+from negentropy.engine.adapters.postgres.memory_service import PostgresMemoryService
+from negentropy.engine.adapters.postgres.retrieval_tracker import (
+    RetrievalTracker,
+    get_pending_reflection_tasks,
+)
+from negentropy.models.internalization import Memory, MemoryRetrievalLog
+
+
+async def _embedding_fn(text: str) -> list[float]:
+    return [0.12] * 1536
+
+
+def _invalidate_memory_settings_cache() -> None:
+    from negentropy.config import settings as global_settings
+
+    global_settings.__dict__.pop("memory", None)
+
+
+@pytest.fixture
+def _reflection_on():
+    reset_sections()
+    set_yaml_section(
+        "memory",
+        {"reflection": {"enabled": True, "daily_limit_per_user": 10, "max_inflight_tasks": 8, "dedup_cosine": 0.92}},
+    )
+    _invalidate_memory_settings_cache()
+    yield
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+@pytest.fixture(autouse=True)
+def _postgres_memory_singleton():
+    """反思 worker 经 ``get_memory_service()`` 解析后端；测试会话内该单例可能被其它
+    测试污染成 InMemory。这里强制预热为 Postgres 单例，确保 worker 写入真实 DB
+    （生产 memory_backend=postgres，与此一致）。"""
+    from negentropy.engine.factories.memory import get_memory_service, reset_memory_service
+
+    reset_memory_service()
+    # 预热：缓存一个 embedding_fn 注入的 Postgres 单例，供 worker 解析复用
+    pg = get_memory_service("postgres")
+    pg._embedding_fn = _embedding_fn  # type: ignore[attr-defined]
+    import negentropy.engine.factories.memory as mem_factory
+
+    mem_factory._memory_service_instance = pg
+    yield
+    reset_memory_service()
+
+
+async def _seed_thread(thread_id: uuid.UUID, app_name: str, user_id: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        db.add(Thread(id=thread_id, app_name=app_name, user_id=user_id, state={}))
+        await db.commit()
+
+
+async def _cleanup(user_id: str, app_name: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(
+            delete(MemoryRetrievalLog).where(
+                MemoryRetrievalLog.user_id == user_id, MemoryRetrievalLog.app_name == app_name
+            )
+        )
+        await db.execute(delete(Memory).where(Memory.user_id == user_id, Memory.app_name == app_name))
+        await db.commit()
+
+
+async def _await_pending_reflection(timeout: float = 10.0) -> None:
+    """等待后台反思任务完成（fire-and-forget，需显式 await 才能断言落库）。"""
+    tasks = list(get_pending_reflection_tasks())
+    if tasks:
+        await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_negative_feedback_writes_reflection_memory(_reflection_on, monkeypatch):
+    """一次 irrelevant 反馈 → 写入一条 episodic/subtype=reflection 记忆。
+
+    强制走 pattern fallback：测试环境 DB 可能配了真实 reflection 模型，直连 LLM 会
+    慢/超时且不确定。这里让 LLM 路径快速失败，验证「生成→落库」骨架（与生成方式无关）。
+    """
+    # 直接让 generate 返回确定性 pattern 反思，绕过真实 LLM + 退避耗时（保证 <3min 预算）。
+    from negentropy.engine.consolidation.reflection_generator import Reflection
+
+    async def _deterministic_generate(self, *, query, retrieved_snippets, outcome):  # noqa: ANN001
+        return Reflection(
+            lesson=f"对『{query[:20]}』类查询，避免召回不相关记忆",
+            applicable_when=[query[:10]],
+            anti_examples=[],
+            method="pattern",
+        )
+
+    monkeypatch.setattr(
+        "negentropy.engine.consolidation.reflection_generator.ReflectionGenerator.generate",
+        _deterministic_generate,
+    )
+
+    app_name = "t4_reflexion"
+    user_id = f"reflexion_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    # 1. 种一条记忆并写检索日志（反思 worker 需从 log 拉 query + snippets）
+    res = await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content="部署到 staging 用 kubectl apply",
+        memory_type="procedural",
+    )
+    mem_id = uuid.UUID(res["id"])
+
+    tracker = RetrievalTracker()
+    log_id = await tracker.log_retrieval(
+        user_id=user_id,
+        app_name=app_name,
+        query="如何回滚生产环境",
+        memory_ids=[mem_id],
+        thread_id=thread_id,
+    )
+    assert log_id is not None
+
+    # 2. 记录 irrelevant 反馈 → 触发后台反思任务
+    ok = await tracker.record_feedback(log_id, "irrelevant")
+    assert ok
+
+    # 3. 等待后台任务完成
+    await _await_pending_reflection()
+
+    # 4. 断言一条 reflection 记忆已落库
+    async with db_session.AsyncSessionLocal() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(Memory).where(
+                        Memory.user_id == user_id,
+                        Memory.app_name == app_name,
+                        Memory.memory_type == "episodic",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    reflections = [m for m in rows if (m.metadata_ or {}).get("subtype") == "reflection"]
+    assert reflections, "irrelevant 反馈应写入一条 subtype=reflection 的 episodic 记忆"
+    refl = reflections[0]
+    assert refl.metadata_.get("outcome") == "irrelevant"
+    assert refl.metadata_.get("created_by") == "reflexion_v1"
+    assert refl.content, "反思应有 lesson 内容"
+
+    await _cleanup(user_id, app_name)
+
+
+@pytest.mark.asyncio
+async def test_helpful_feedback_writes_no_reflection(_reflection_on):
+    """helpful 反馈不触发反思（仅 irrelevant/harmful 触发）。"""
+    app_name = "t4_reflexion_pos"
+    user_id = f"reflexion_pos_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    res = await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content="some memory",
+        memory_type="semantic",
+    )
+    tracker = RetrievalTracker()
+    log_id = await tracker.log_retrieval(
+        user_id=user_id,
+        app_name=app_name,
+        query="q",
+        memory_ids=[uuid.UUID(res["id"])],
+        thread_id=thread_id,
+    )
+    await tracker.record_feedback(log_id, "helpful")
+    await _await_pending_reflection()
+
+    async with db_session.AsyncSessionLocal() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(Memory).where(
+                        Memory.user_id == user_id,
+                        Memory.app_name == app_name,
+                        Memory.memory_type == "episodic",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    reflections = [m for m in rows if (m.metadata_ or {}).get("subtype") == "reflection"]
+    assert not reflections, "helpful 反馈不应触发反思生成"
+
+    await _cleanup(user_id, app_name)

--- a/apps/negentropy/tests/integration_tests/engine/test_rocchio_apply.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_rocchio_apply.py
@@ -1,0 +1,162 @@
+"""T4-Rocchio — 相关性反馈闭环「读侧应用」集成测试（真实 PostgreSQL）。
+
+补足此前空白：现有 ``test_rocchio_feedback_loop`` 仅覆盖「反馈→写侧 reweight」，
+但不验证 ``relevance.enabled=true`` 时**读侧排序确实被 relevance_weight 改写**。
+本测试证明 Rocchio 闭环最后一环（读侧 apply）在开箱默认下真正生效。
+
+锚点：``memory_service._apply_relevance_weights``（受 ``memory.relevance.enabled`` 门控，
+对 metadata_.relevance_weight 做 base*weight 后重排，权重 clamp 在 compute 阶段 [0.5,2.0]）。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import update
+
+import negentropy.db.session as db_session
+from negentropy.config._base import reset_sections, set_yaml_section
+from negentropy.engine.adapters.postgres.memory_service import PostgresMemoryService
+from negentropy.engine.relevance.rocchio_reweighter import compute_relevance_weight
+from negentropy.models.internalization import Memory
+
+
+async def _embedding_fn(text: str) -> list[float]:
+    # 所有记忆共享相同向量 → 向量检索分数相同，凸显 relevance_weight 的排序作用
+    return [0.2] * 1536
+
+
+async def _seed_thread(thread_id: uuid.UUID, app_name: str, user_id: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        from negentropy.models.pulse import Thread
+
+        db.add(Thread(id=thread_id, app_name=app_name, user_id=user_id, state={}))
+        await db.commit()
+
+
+async def _cleanup(user_id: str, app_name: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(Memory.__table__.delete().where(Memory.user_id == user_id, Memory.app_name == app_name))
+        await db.commit()
+
+
+def _invalidate_memory_settings_cache() -> None:
+    """settings.memory 是 @cached_property，需手动失效后才会重读新设的 YAML 段。"""
+    from negentropy.config import settings as global_settings
+
+    global_settings.__dict__.pop("memory", None)
+
+
+@pytest.fixture
+def _relevance_enabled():
+    reset_sections()
+    set_yaml_section("memory", {"relevance": {"enabled": True}})
+    _invalidate_memory_settings_cache()
+    yield
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+@pytest.fixture
+def _relevance_disabled():
+    reset_sections()
+    set_yaml_section("memory", {"relevance": {"enabled": False}})
+    _invalidate_memory_settings_cache()
+    yield
+    reset_sections()
+    _invalidate_memory_settings_cache()
+
+
+async def _set_weight(memory_id: uuid.UUID, weight: float) -> None:
+    """直接把预计算 relevance_weight 写入 metadata_（模拟 cron reweight 产物）。"""
+    async with db_session.AsyncSessionLocal() as db:
+        m = await db.get(Memory, memory_id)
+        meta = dict(m.metadata_ or {})
+        meta["relevance_weight"] = weight
+        await db.execute(update(Memory).where(Memory.id == memory_id).values(metadata_=meta))
+        await db.commit()
+
+
+async def _seed_two_memories(service, user_id, app_name, thread_id):
+    """种两条同向量记忆：low 给高权重、high 给低权重，以便观察排序翻转。"""
+    low = await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content="alpha deployment runbook staging environment",
+        memory_type="procedural",
+    )
+    high = await service.add_memory_typed(
+        user_id=user_id,
+        app_name=app_name,
+        thread_id=thread_id,
+        content="beta deployment runbook staging environment",
+        memory_type="procedural",
+    )
+    return uuid.UUID(low["id"]), uuid.UUID(high["id"])
+
+
+@pytest.mark.asyncio
+async def test_rocchio_compute_weight_clamped_and_gated():
+    """compute_relevance_weight：低于 min_count 返 1.0；高正反馈夹至 ≤2.0。"""
+    # 反馈不足门槛 → 中性 1.0
+    assert compute_relevance_weight(2, 0, 2, min_count=3) == 1.0
+    # 全 helpful：1.0 + 0.75*1 = 1.75
+    assert compute_relevance_weight(10, 0, 10, min_count=3) == pytest.approx(1.75)
+    # 全 irrelevant：1.0 - 0.15*1 = 0.85
+    assert compute_relevance_weight(0, 10, 10, min_count=3) == pytest.approx(0.85)
+    # 上限夹紧
+    assert compute_relevance_weight(100, 0, 100, beta=5.0, min_count=3) == 2.0
+    # 下限夹紧
+    assert compute_relevance_weight(0, 100, 100, gamma=5.0, min_count=3) == 0.5
+
+
+@pytest.mark.asyncio
+async def test_relevance_weight_applied_when_enabled(_relevance_enabled):
+    """enabled=true：给 low 记忆更高 relevance_weight → 其检索排名升至首位。"""
+    app_name = "t4_rocchio_apply"
+    user_id = f"rocchio_apply_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    low_id, high_id = await _seed_two_memories(service, user_id, app_name, thread_id)
+    # low 记忆赋高权重（1.8），high 记忆赋低权重（0.6）
+    await _set_weight(low_id, 1.8)
+    await _set_weight(high_id, 0.6)
+
+    resp = await service.search_memory(app_name=app_name, user_id=user_id, query="deployment runbook staging")
+    texts = [m.content.parts[0].text for m in resp.memories]
+    assert texts, "检索应有结果"
+    # 高权重的 alpha 记忆应排在低权重 beta 之前
+    alpha_idx = next((i for i, t in enumerate(texts) if "alpha" in t), None)
+    beta_idx = next((i for i, t in enumerate(texts) if "beta" in t), None)
+    assert alpha_idx is not None and beta_idx is not None
+    assert alpha_idx < beta_idx, f"enabled=true 时高权重 alpha 应排在 beta 前；实际顺序 {texts}"
+
+    await _cleanup(user_id, app_name)
+
+
+@pytest.mark.asyncio
+async def test_relevance_weight_not_applied_when_disabled(_relevance_disabled):
+    """enabled=false：relevance_weight 不参与排序（与开启态形成对照，证明门控有效）。"""
+    app_name = "t4_rocchio_noapply"
+    user_id = f"rocchio_noapply_{uuid.uuid4().hex[:8]}"
+    thread_id = uuid.uuid4()
+    await _cleanup(user_id, app_name)
+    await _seed_thread(thread_id, app_name, user_id)
+    service = PostgresMemoryService(embedding_fn=_embedding_fn)
+
+    low_id, high_id = await _seed_two_memories(service, user_id, app_name, thread_id)
+    await _set_weight(low_id, 1.8)
+    await _set_weight(high_id, 0.6)
+
+    resp = await service.search_memory(app_name=app_name, user_id=user_id, query="deployment runbook staging")
+    # 关闭态下不应出现 relevance_weight_applied 标记（ADK MemoryEntry 用 custom_metadata）
+    for m in resp.memories:
+        meta = getattr(m, "custom_metadata", None) or {}
+        assert "relevance_weight_applied" not in meta
+
+    await _cleanup(user_id, app_name)

--- a/apps/negentropy/tests/integration_tests/engine/test_runner_artifacts.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_runner_artifacts.py
@@ -1,29 +1,50 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-
-# Helper to mock modules before they are imported
-def mock_modules():
-    # Mock the agent module to prevent it from importing ADK agents and LLMs
-    if "negentropy.agents.agent" not in sys.modules:
-        agent_mock = MagicMock()
-        agent_mock.root_agent = MagicMock()
-        sys.modules["negentropy.agents.agent"] = agent_mock
-
-    if "negentropy.agents" not in sys.modules:
-        sys.modules["negentropy.agents"] = MagicMock()
-
-    # Also mock session/memory factories to allow simple import
-    sys.modules["negentropy.engine.factories.memory"] = MagicMock()
-    sys.modules["negentropy.engine.factories.session"] = MagicMock()
-
-    # Mock ADK dependencies that might be hit
-    sys.modules["google.adk.runners"] = MagicMock()
+# 需要临时 mock 的模块；仅为让 runner 工厂能在不拉起 ADK/LLM 的情况下导入。
+# 关键修复（测试隔离）：原实现用 ``sys.modules[...] = MagicMock()`` 在 import 期
+# 永久替换 ``negentropy.engine.factories.memory`` 等模块且从不还原，导致后续任何
+# 测试 ``from ...factories.memory import get_association_service`` 拿到 MagicMock
+# 属性（表现为 "object MagicMock can't be used in 'await' expression"）。
+# 现改为：导入完成后立即还原被临时替换的真实模块，杜绝跨文件污染。
+_MOCKED_MODULE_NAMES = (
+    "negentropy.agents.agent",
+    "negentropy.agents",
+    "negentropy.engine.factories.memory",
+    "negentropy.engine.factories.session",
+    "google.adk.runners",
+)
 
 
-mock_modules()
+def _install_temp_mocks() -> dict[str, object]:
+    """临时把若干模块替换为 MagicMock，返回被替换前的原始引用（可能不存在）。"""
+    saved: dict[str, object] = {}
+    for name in _MOCKED_MODULE_NAMES:
+        saved[name] = sys.modules.get(name, None)
+        if name == "negentropy.agents.agent":
+            agent_mock = MagicMock()
+            agent_mock.root_agent = MagicMock()
+            sys.modules[name] = agent_mock
+        else:
+            sys.modules[name] = MagicMock()
+    return saved
 
-from negentropy.engine.factories.runner import get_runner, reset_runner  # noqa: E402
+
+def _restore_modules(saved: dict[str, object]) -> None:
+    """还原 ``_install_temp_mocks`` 替换前的 sys.modules 状态。"""
+    for name, original in saved.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+
+# 在临时 mock 环境下导入 runner 工厂，然后立即还原，避免污染全局 sys.modules。
+_saved_modules = _install_temp_mocks()
+try:
+    from negentropy.engine.factories.runner import get_runner, reset_runner  # noqa: E402
+finally:
+    _restore_modules(_saved_modules)
 
 # negentropy.engine.artifacts_factory is real
 

--- a/apps/negentropy/tests/unit_tests/config/test_memory_settings.py
+++ b/apps/negentropy/tests/unit_tests/config/test_memory_settings.py
@@ -1,0 +1,153 @@
+"""Memory 配置优先级护栏测试（T5）。
+
+锁定一条容易被遗忘、却决定 Memory 运行时行为的不变量：
+
+    **真正生效的是 ``config.default.yaml``，而非 ``config/memory.py`` 的 Field 默认值。**
+
+优先级链（见 ``config/__init__.py`` 与 ``config/_base.py``）::
+
+    init > env vars > YAML chain > field defaults
+
+历史教训（参见 docs/.agents/issue.md「Memify 休眠」）：``MemorySettings`` 的
+Python 默认 ``consolidation.steps`` 为 6 步，但 ``config.default.yaml`` 长期锁在
+2 步 ``[fact_extract, auto_link]``，导致 6-step Memify 管线虽已实现并接入
+``_run_consolidation_pipeline`` 却从未在生产生效。本测试确保：
+
+1. **机制不变量**（合成数据，永不随 YAML 内容漂移）：``memory`` YAML 段一旦提供值，
+   即覆盖 Python Field 默认；缺省字段回落到 Field 默认。
+2. **生效一致性**（动态读取，随 YAML 内容自适应）：以应用真实加载路径构建的
+   ``MemorySettings`` 必须与 ``config.default.yaml`` 声明的 ``memory`` 段一致，
+   从而保证"改 YAML 才是改行为"，且任何后续 flag 翻转在运行时确实落地。
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from negentropy.config._base import reset_sections, set_yaml_section
+from negentropy.config.memory import ConsolidationSettings, MemorySettings
+from negentropy.config.yaml_loader import get_default_config_path
+
+
+@pytest.fixture(autouse=True)
+def _clean_sections():
+    """每个用例前后清空 YAML 段注册表，避免跨用例污染。"""
+    reset_sections()
+    yield
+    reset_sections()
+
+
+# ---------------------------------------------------------------------------
+# 1. 机制不变量：YAML 段覆盖 Python Field 默认
+# ---------------------------------------------------------------------------
+
+
+class TestYamlOverridesFieldDefaults:
+    """合成数据证明优先级链 ``YAML > field defaults`` —— 与具体 YAML 内容解耦。"""
+
+    def test_consolidation_steps_yaml_wins_over_python_default(self):
+        """YAML 提供 steps 时覆盖 Python 6 步默认（锁定 Memify 休眠根因）。"""
+        # Python field 默认是 6 步
+        assert len(ConsolidationSettings().steps) == 6
+
+        # 注入一个与默认不同的 YAML 段
+        set_yaml_section(
+            "memory",
+            {"consolidation": {"steps": ["fact_extract"], "policy": "serial"}},
+        )
+        s = MemorySettings()
+        assert s.consolidation.steps == ["fact_extract"]
+        assert s.consolidation.policy == "serial"
+
+    def test_feature_flag_yaml_wins_over_python_default(self):
+        """YAML 翻转 enabled flag 时覆盖 Python 默认（证明 flag 翻转可在运行时落地）。"""
+        # Python 默认全部关闭
+        baseline = MemorySettings()
+        assert baseline.hipporag.enabled is False
+        assert baseline.relevance.enabled is False
+        assert baseline.reflection.enabled is False
+
+        reset_sections()
+        set_yaml_section(
+            "memory",
+            {
+                "hipporag": {"enabled": True},
+                "relevance": {"enabled": True},
+                "reflection": {"enabled": True},
+            },
+        )
+        s = MemorySettings()
+        assert s.hipporag.enabled is True
+        assert s.relevance.enabled is True
+        assert s.reflection.enabled is True
+
+    def test_absent_yaml_field_falls_back_to_python_default(self):
+        """YAML 未声明的字段回落到 Python Field 默认（部分覆盖语义）。"""
+        set_yaml_section("memory", {"consolidation": {"policy": "fail_tolerant"}})
+        s = MemorySettings()
+        # policy 取 YAML
+        assert s.consolidation.policy == "fail_tolerant"
+        # steps 未在 YAML 声明 → 回落到 Python 6 步默认
+        assert len(s.consolidation.steps) == 6
+
+    def test_empty_yaml_section_uses_all_python_defaults(self):
+        """空 YAML 段时全部回落 Python 默认。"""
+        set_yaml_section("memory", {})
+        s = MemorySettings()
+        assert s.consolidation.policy == ConsolidationSettings().policy
+        assert s.pii.engine == "regex"
+
+
+# ---------------------------------------------------------------------------
+# 2. 生效一致性：运行时 MemorySettings == config.default.yaml 声明
+# ---------------------------------------------------------------------------
+
+
+def _load_default_memory_section() -> dict:
+    """直接读取打包 ``config.default.yaml`` 的 ``memory`` 段（动态，随内容自适应）。"""
+    path = get_default_config_path()
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return data.get("memory", {})
+
+
+class TestDefaultYamlIsRuntimeSourceOfTruth:
+    """证明 ``config.default.yaml`` 是运行时事实源 —— 动态比对，后续编辑自适应。"""
+
+    def test_default_yaml_has_memory_section(self):
+        section = _load_default_memory_section()
+        assert section, "config.default.yaml 必须包含 memory 段"
+        assert "consolidation" in section
+
+    def test_runtime_consolidation_matches_default_yaml(self):
+        """以 default.yaml 的 memory 段构建 MemorySettings，steps/policy 必须一致。"""
+        section = _load_default_memory_section()
+        set_yaml_section("memory", section)
+        s = MemorySettings()
+
+        declared = section.get("consolidation", {})
+        if "steps" in declared:
+            assert s.consolidation.steps == declared["steps"], (
+                "运行时 steps 与 config.default.yaml 声明不一致 —— YAML 应为运行时事实源"
+            )
+        if "policy" in declared:
+            assert s.consolidation.policy == declared["policy"]
+
+    def test_runtime_feature_flags_match_default_yaml(self):
+        """default.yaml 中各特性 enabled 与运行时一致（翻转后此测试自动校验落地）。"""
+        section = _load_default_memory_section()
+        set_yaml_section("memory", section)
+        s = MemorySettings()
+
+        for feature in ("hipporag", "reflection", "relevance"):
+            declared = section.get(feature, {})
+            if "enabled" in declared:
+                actual = getattr(s, feature).enabled
+                assert actual == declared["enabled"], (
+                    f"memory.{feature}.enabled 运行时={actual} 与 config.default.yaml={declared['enabled']} 不一致"
+                )
+
+        pii_declared = section.get("pii", {})
+        if "engine" in pii_declared:
+            assert s.pii.engine == pii_declared["engine"]

--- a/apps/negentropy/tests/unit_tests/engine/consolidation/test_auto_link_step.py
+++ b/apps/negentropy/tests/unit_tests/engine/consolidation/test_auto_link_step.py
@@ -1,10 +1,46 @@
-"""Tests for AutoLinkStep."""
+"""Tests for AutoLinkStep.
+
+T2 加固：补齐冒烟级覆盖 —— 空输入跳过、DB 拉取失败→failed、
+单条关联失败不影响其余（output_count 反映成功数）、全部成功。
+"""
 
 from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 from negentropy.engine.consolidation.pipeline.steps.auto_link_step import AutoLinkStep
 
 from .conftest import _new_ctx
+
+
+def _fake_memory(mid=None):
+    m = MagicMock()
+    m.id = mid or uuid4()
+    m.thread_id = uuid4()
+    m.embedding = [0.1] * 8
+    m.created_at = None
+    return m
+
+
+def _patch_session_returning(memories):
+    """构造一个 patch，使 AutoLinkStep 内 db 查询返回给定 memories。"""
+    fake_db = MagicMock()
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = memories
+    result.scalars.return_value = scalars
+    fake_db.execute = AsyncMock(return_value=result)
+
+    @asynccontextmanager
+    async def _cm():
+        yield fake_db
+
+    return patch(
+        "negentropy.engine.consolidation.pipeline.steps.auto_link_step.db_session.AsyncSessionLocal",
+        return_value=_cm(),
+    )
 
 
 class TestAutoLinkStep:
@@ -13,3 +49,75 @@ class TestAutoLinkStep:
         ctx = _new_ctx()
         result = await step.run(ctx)
         assert result.status == "skipped"
+        assert result.output_count == 0
+
+    async def test_failed_when_db_fetch_raises(self):
+        """拉取新记忆抛错 → status=failed。"""
+        ctx = _new_ctx()
+        ctx.new_memory_ids = [uuid4()]
+
+        @asynccontextmanager
+        async def _boom():
+            raise RuntimeError("db down")
+            yield  # pragma: no cover
+
+        with patch(
+            "negentropy.engine.consolidation.pipeline.steps.auto_link_step.db_session.AsyncSessionLocal",
+            return_value=_boom(),
+        ):
+            step = AutoLinkStep()
+            result = await step.run(ctx)
+
+        assert result.status == "failed"
+        assert result.error
+
+    async def test_partial_failure_counts_survivors(self):
+        """一条关联抛错，其余成功 → output_count 只计成功条数。"""
+        ctx = _new_ctx()
+        mems = [_fake_memory(), _fake_memory(), _fake_memory()]
+        ctx.new_memory_ids = [m.id for m in mems]
+
+        call_count = {"n": 0}
+
+        async def _auto_link(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:  # 第二条失败
+                raise RuntimeError("link failed")
+
+        fake_assoc = MagicMock()
+        fake_assoc.auto_link_memory = AsyncMock(side_effect=_auto_link)
+
+        with (
+            _patch_session_returning(mems),
+            patch(
+                "negentropy.engine.factories.memory.get_association_service",
+                return_value=fake_assoc,
+            ),
+        ):
+            step = AutoLinkStep()
+            result = await step.run(ctx)
+
+        assert result.status == "success"
+        assert result.output_count == 2  # 3 条中 1 条失败 → 2 条成功
+
+    async def test_all_links_succeed(self):
+        ctx = _new_ctx()
+        mems = [_fake_memory(), _fake_memory()]
+        ctx.new_memory_ids = [m.id for m in mems]
+
+        fake_assoc = MagicMock()
+        fake_assoc.auto_link_memory = AsyncMock()
+
+        with (
+            _patch_session_returning(mems),
+            patch(
+                "negentropy.engine.factories.memory.get_association_service",
+                return_value=fake_assoc,
+            ),
+        ):
+            step = AutoLinkStep()
+            result = await step.run(ctx)
+
+        assert result.status == "success"
+        assert result.output_count == 2
+        assert fake_assoc.auto_link_memory.await_count == 2

--- a/apps/negentropy/tests/unit_tests/engine/consolidation/test_fact_extract_step.py
+++ b/apps/negentropy/tests/unit_tests/engine/consolidation/test_fact_extract_step.py
@@ -41,3 +41,67 @@ class TestFactExtractStep:
         assert result.output_count == 1
         assert ctx.facts and ctx.facts[0].key == "lang"
         fake_service.upsert_fact.assert_awaited_once()
+
+    async def test_failed_when_extractor_raises(self):
+        """提取器抛错 → status=failed，且不触碰 FactService。"""
+        fake_extractor = MagicMock()
+        fake_extractor.extract = AsyncMock(side_effect=RuntimeError("llm boom"))
+
+        ctx = _new_ctx()
+        ctx.turns = [{"author": "user", "text": "I prefer Rust"}]
+
+        with patch("negentropy.engine.factories.memory.get_fact_service") as mock_get:
+            step = FactExtractStep(extractor=fake_extractor)
+            result = await step.run(ctx)
+
+        assert result.status == "failed"
+        assert result.error
+        mock_get.assert_not_called()
+
+    async def test_empty_facts_is_success_zero(self):
+        """提取出 0 条事实 → success / output_count=0，不写库。"""
+        fake_extractor = MagicMock()
+        fake_extractor.extract = AsyncMock(return_value=[])
+
+        ctx = _new_ctx()
+        ctx.turns = [{"author": "user", "text": "hi"}]
+
+        with patch("negentropy.engine.factories.memory.get_fact_service") as mock_get:
+            step = FactExtractStep(extractor=fake_extractor)
+            result = await step.run(ctx)
+
+        assert result.status == "success"
+        assert result.output_count == 0
+        assert ctx.facts == []
+        mock_get.assert_not_called()
+
+    async def test_upsert_failure_does_not_crash_step(self):
+        """单条 upsert 抛错被吞掉，step 仍 success，output_count 仅计成功。"""
+        fake_extractor = MagicMock()
+        fake_extractor.extract = AsyncMock(
+            return_value=[
+                ExtractedFact(fact_type="preference", key="lang", value="rust", confidence=0.9),
+                ExtractedFact(fact_type="profile", key="role", value="dev", confidence=0.9),
+            ]
+        )
+        ctx = _new_ctx()
+        ctx.turns = [{"author": "user", "text": "I prefer Rust, I am a dev"}]
+
+        calls = {"n": 0}
+
+        async def _upsert(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("upsert boom")
+
+        with patch("negentropy.engine.factories.memory.get_fact_service") as mock_get:
+            fake_service = MagicMock()
+            fake_service.upsert_fact = AsyncMock(side_effect=_upsert)
+            mock_get.return_value = fake_service
+
+            step = FactExtractStep(extractor=fake_extractor)
+            result = await step.run(ctx)
+
+        assert result.status == "success"
+        assert result.output_count == 1  # 2 条中 1 条 upsert 失败
+        assert result.extra["extracted"] == 2

--- a/apps/negentropy/tests/unit_tests/engine/consolidation/test_summarize_step.py
+++ b/apps/negentropy/tests/unit_tests/engine/consolidation/test_summarize_step.py
@@ -47,3 +47,30 @@ class TestSummarizeStep:
 
         assert result.status == "success"
         assert result.output_count == 0
+
+    async def test_failed_when_summarizer_factory_raises(self):
+        """获取 summarizer 失败 → status=failed。"""
+        with patch(
+            "negentropy.engine.factories.memory.get_memory_summarizer",
+            side_effect=RuntimeError("factory boom"),
+        ):
+            step = SummarizeStep()
+            result = await step.run(_new_ctx())
+
+        assert result.status == "failed"
+        assert result.error
+
+    async def test_failed_when_generation_raises(self):
+        """摘要生成抛错（非 TypeError）→ status=failed。"""
+        fake_summarizer = MagicMock()
+        fake_summarizer.get_or_generate_summary = AsyncMock(side_effect=RuntimeError("llm down"))
+
+        with patch(
+            "negentropy.engine.factories.memory.get_memory_summarizer",
+            return_value=fake_summarizer,
+        ):
+            step = SummarizeStep()
+            result = await step.run(_new_ctx())
+
+        assert result.status == "failed"
+        assert result.error

--- a/apps/negentropy/uv.lock
+++ b/apps/negentropy/uv.lock
@@ -1313,20 +1313,16 @@ dependencies = [
     { name = "opentelemetry-instrumentation-google-genai" },
     { name = "orjson" },
     { name = "packaging" },
+    { name = "presidio-analyzer" },
+    { name = "presidio-anonymizer" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings", extra = ["yaml"] },
     { name = "pyyaml" },
     { name = "scipy" },
+    { name = "spacy" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
     { name = "tiktoken" },
-]
-
-[package.optional-dependencies]
-pii-presidio = [
-    { name = "presidio-analyzer" },
-    { name = "presidio-anonymizer" },
-    { name = "spacy" },
 ]
 
 [package.dev-dependencies]
@@ -1361,18 +1357,17 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.6b0,<1.0.0" },
     { name = "orjson", specifier = ">=3.11.6" },
     { name = "packaging", specifier = ">=24.0" },
-    { name = "presidio-analyzer", marker = "extra == 'pii-presidio'", specifier = ">=2.2.0" },
-    { name = "presidio-anonymizer", marker = "extra == 'pii-presidio'", specifier = ">=2.2.0" },
+    { name = "presidio-analyzer", specifier = ">=2.2.0" },
+    { name = "presidio-anonymizer", specifier = ">=2.2.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.12.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "scipy", specifier = ">=1.12" },
-    { name = "spacy", marker = "extra == 'pii-presidio'", specifier = ">=3.7,<4.0" },
+    { name = "spacy", specifier = ">=3.7,<4.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.46" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tiktoken", specifier = ">=0.9.0" },
 ]
-provides-extras = ["pii-presidio"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2558,3 +2558,66 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
 - **本次处理（Studio 范围，PR：Home/Studio UI 精修）**：仅在 Studio 涉及文件内把失效类收敛到**已定义等价物**（`text-muted`→`text-text-muted`、`bg-muted`→`bg-border-muted`、`text-accent-foreground`→`text-foreground` 等），并**新增** `--color-primary/-foreground/-hover` 与 `--color-ring`（净增、零值冲突，统一主强调色 indigo）。未触碰其它页面渲染。
 - **后续防范 / 待办（独立专项 PR）**：对全站执行 token 规范化 codemod——在 `@theme inline` 补齐 `--color-muted/-foreground`、`--color-accent/-foreground`、`--color-secondary/-foreground`、`--color-destructive/-foreground` 等，并按 shadcn 语义统一改写重载用法；提交前对 Studio / Dashboard / Knowledge / Memory 主路由做明暗双主题回归。
 - **同类问题影响**：所有沿用 shadcn 命名（`muted/primary/accent/secondary/destructive`）的组件均受影响；新增组件应优先使用本仓已定义的 `text-text-*` / `bg-card` / `border-border` / `bg-border-muted` / `text-success|warning|error|info` / `bg-primary` 等，避免再次引入未映射工具类。
+
+---
+
+## ISSUE-098 Memory Hybrid 检索长期静默失效（双层缺陷：缺 DB 函数 + SQLAlchemy `::` 绑定 bug）
+
+- **表因**：`PostgresMemoryService.search_memory` 的 Hybrid 策略从未真正生效——每次检索都从 `hybrid` 静默回退到纯向量（`vector`）检索，且因 F1 HippoRAG PPR 仅在 Hybrid 分支做 RRF 融合，PPR 通道被连带架空（即便 `hipporag.enabled=true` + KG 关联越过数据闸也不融合）。
+- **根因（两层独立缺陷）**：
+  1. **缺 DB 函数**：`_hybrid_search_native` 调用 `negentropy.hybrid_search()`，但该函数仅存在于 `docs/reference/cognizes/engine/schema/perception_schema.sql` 与 cognizes app 的 schema 文件中，**从未移植成 negentropy alembic 迁移**；`memories` 表也缺 `search_vector tsvector` 列与 GIN 索引。线上 `pg_proc` 查无此函数 → `UndefinedFunctionError`。
+  2. **SQLAlchemy 绑定 bug**：SQL 用 `:embedding::vector(1536)`。`text()` 把 `::` 误解析为绑定名分隔符，导致 `:embedding` 不被绑定、渲染出裸 `:` 触发 `PostgresSyntaxError: syntax error at or near ":"`。即便函数存在也会失败。
+- **处理方式**：
+  1. 新增迁移 `0047_memory_hybrid_search_function.py`：为 `memories` 增 `search_vector` 列 + BEFORE INSERT/UPDATE OF content 触发器（`to_tsvector('english', content)`）+ 回填存量行 + GIN 索引；以 perception_schema.sql 权威定义创建 schema 限定的 `negentropy.hybrid_search()`（语义 + BM25 FULL OUTER JOIN 加权融合）。纯新增、不改写既有数据。
+  2. 修 `memory_service.py::_hybrid_search_native`：`:embedding::vector(1536)` → `CAST(:embedding AS vector(1536))`，并把 embedding 序列化为 pgvector 字面量 `'[...]'` 后绑定。
+- **验证**：新增 `tests/integration_tests/engine/test_ppr_fusion.py`（种入 Corpus + KgEntity×2 + KgRelation + ≥100 entity 关联，断言 PPR 实跑并融合；稀疏 KG 下数据闸自休眠回退 Hybrid）；`test_memory_service.py` 6 例 + RRF/PPR 单测 34 例全绿。日志由 `search_fallback ... to_level=vector` 变为 `hybrid_search_completed`。
+- **后续防范**：
+  1. **运行时依赖的 DB 函数必须有迁移**：任何 `_native` 路径调用的 SQL 函数都要在 alembic 迁移中 `CREATE OR REPLACE`，并配单测在真实库断言函数存在 + 端到端跑通；`.sql` schema 文件只是参考，不是生效源。
+  2. **`text()` 内禁用 `:param::type`**：一律用 `CAST(:param AS type)`，避免 `::` 与绑定名歧义。仓内可加 lint/grep 守卫扫描 `:%w+::`。
+  3. **降级要可观测**：Hybrid→vector 这类「静默回退」必须升级日志级别或暴露指标（如 `/memory/metrics` 增 hybrid_fallback_count），否则核心特性失效数月无感。
+- **同类问题影响**：`kb_hybrid_search()`（Knowledge 侧）与任何引用 perception_schema.sql 但未迁移的 SQL 函数都应排查是否存在同样「schema 文件有、迁移没有」的断裂；所有 `text()` 拼 `::vector` 的检索/向量路径都应改 `CAST`。
+
+---
+
+## ISSUE-099 F4 Presidio PII 在热路径上是死代码（写侧绕过工厂 + 检索守门员从未接线）
+
+- **表因**：把 `memory.pii.engine` 改成 `presidio` 对生产行为零影响；检索路径对低权限角色也从不脱敏含 PII 的记忆。F4「生产级 PII 治理」实质未生效。
+- **根因（两处接线断裂）**：
+  1. **写侧绕过工厂**：`memory_service` 的 `_simple_consolidate`（`:157`）与 `add_memory_typed`（`:1493`）硬编码调用 legacy `pii_detector.detect`（固定 `RegexPIIDetector`），从不读 `settings.memory.pii.engine`、从不经 `get_pii_detector()`，使 `PresidioPIIDetector` 成为热路径死代码；且只落 `metadata.pii_flags`（计数），不落 `pii_spans`。
+  2. **检索守门员未接线**：`PIIGatekeeper` 定义并导出，但 engine 内**零调用点**（grep `PIIGatekeeper`/`from_settings` 仅命中定义处）。即便启用也因写侧不落 `pii_spans` 而无数据可遮蔽。
+- **处理方式**：
+  1. 新增 `engine/governance/pii/storage_helper.py::detect_pii_for_storage(content)`：经 `get_pii_detector()`（工厂引擎）检测，返回 `(flags, spans_json)`；异常降级空结果不阻断写入。两处写侧改用之，落 `pii_flags` + `pii_spans`。
+  2. 检索侧：`_build_search_response` 增 `viewer_role` 形参，出口处经 `PIIGatekeeper.from_settings()` 按角色 mask/anonymize（受 `gatekeeper_enabled` 控）；`search_memory` 透传 `viewer_role`。
+  3. `PIISettings` 增声明字段 `retrieval_policy`（独立于写入 `policy`）。
+  4. 依赖默认化：`pyproject.toml` 把 presidio/spacy 从 optional extra 提升为主依赖；新增 CLI `negentropy bootstrap-pii-models` 下载 spaCy NER 模型（`en_core_web_lg` / `zh_core_web_sm`，独立下载产物非 pip 依赖）。
+  5. `config.default.yaml` 翻转：`engine: presidio` + `gatekeeper_enabled: true` + `allow_engine_fallback: true`（缺模型降级 regex 并写 ERROR，经 `/memory/health` 可观测，不阻断启动）+ `retrieval_policy: anonymize`。
+- **验证**：新增 `tests/integration_tests/engine/test_pii_writepath.py` 7 例（写侧 flags+spans / 低权限 anonymize / 高权限透传 / 守门员关闭透传 / presidio PERSON NER / 缺模型降级 regex / fallback=false 抛错）；既有 `test_pii_phase5.py` 24 例无回归。
+- **后续防范**：
+  1. **工厂是唯一入口**：凡「可切换引擎」的能力（PII / Memory backend / 检索）都必须经工厂解析，禁止业务代码硬编码具体实现，否则 settings 形同虚设。可加单测断言写路径经 `get_pii_detector()`（如 monkeypatch 工厂验证被调用）。
+  2. **定义即接线**：新增 governance 组件（如 Gatekeeper）须同时提供调用点 + 端到端测试，避免「定义了但没人用」的僵尸代码；可用 grep 守卫扫描导出符号的调用点数。
+  3. **重模型依赖要可观测 + 可降级**：默认引擎依赖大模型下载时，必须提供 bootstrap 命令 + 缺失降级 + health 暴露实际引擎，兼顾开箱即用与保密性优先。
+- **同类问题影响**：Memory backend 工厂（InMemory/VertexAI/Postgres）、检索引擎切换等所有「可插拔」点都应核对业务代码是否真的经工厂；任何 `settings.*.engine` 类开关都要有「翻转后行为确实改变」的测试佐证。
+
+---
+
+## ISSUE-100 测试隔离：test_runner_artifacts 永久污染 sys.modules 致下游测试拿到 MagicMock
+
+- **表因**：全量跑 engine 测试时，`test_full_pipeline` / `test_ppr_fusion` 等真实集成测试报 `object MagicMock can't be used in 'await' expression`（`get_association_service` / `get_fact_service` / `upsert_fact` 等返回 MagicMock）。单独跑各文件均通过，仅在与某些文件同会话时复发。
+- **根因**：`tests/integration_tests/engine/test_runner_artifacts.py` 在**模块导入期**调用 `mock_modules()`，用 `sys.modules["negentropy.engine.factories.memory"] = MagicMock()`（及 session 工厂、agents、google.adk.runners）永久替换真实模块且**从不还原**。pytest 单会话内 `sys.modules` 全局共享，导致此文件被收集后，后续任何 `from negentropy.engine.factories.memory import get_*` 都拿到 MagicMock 属性。
+- **处理方式**：改为「临时替换 + 立即还原」——`_install_temp_mocks()` 保存原始引用、装上 mock 仅为让 `runner` 工厂可导入；`try/finally` 中 import 完成后 `_restore_modules()` 还原 `sys.modules`（原本不存在的键 pop 掉，存在的还原）。测试自身行为不变（其在用例体内用 `patch` 注入 Runner / artifact_service）。另在受影响集成测试加 autouse `reset_*_service()` 防御性兜底。
+- **后续防范**：
+  1. **禁止模块级永久改 sys.modules**：测试如需 mock 模块以绕过重导入，必须用 fixture + finalizer 或 `try/finally` 还原；模块级副作用会跨文件泄漏。
+  2. **真实集成测试防御工厂污染**：依赖工厂单例的集成测试可在 fixture 里 `reset_*` 兜底。
+  3. **CI 应跑全量同会话**：`uv run pytest tests/`（不分目录）才能暴露此类跨文件污染；分目录跑会掩盖。
+- **同类问题影响**：任何 `sys.modules[...] =` 或模块级 `patch.dict("sys.modules", ...)` 不还原的测试都应排查；优先 grep `sys.modules\[` 审计。
+
+---
+
+## ISSUE-101 Presidio 中文分析失效：AnalyzerEngine 未装配 zh NLP 引擎致 CN 识别器全失效
+
+- **表因**：实机巩固日志反复出现 `presidio_analyze_failed lang=zh error="'zh'"`；中文文本里的手机号 / 身份证（CN_MOBILE / CN_ID_CARD 自定义识别器，supported_language='zh'）完全不命中，身份证还被英文模型误标成 `date_time`。
+- **根因**：`PresidioPIIDetector` 用 `AnalyzerEngine(supported_languages=["en","zh"])` 但**未提供 nlp_engine**。Presidio 默认 NLP 引擎只配了 en（`en_core_web_lg`）；分析 zh 文本时按 `nlp_engine.process_text(text, "zh")` 查不到 zh 模型抛 `KeyError('zh')`，该语言整条分析链（含挂在 zh 上的自定义 PatternRecognizer）被跳过。
+- **处理方式**：新增 `PresidioPIIDetector._build_nlp_engine(languages)`：按语言→spaCy 模型候选表（en→lg/sm、zh→`zh_core_web_sm`）探测已安装模型，用 `NlpEngineProvider(nlp_configuration={"nlp_engine_name":"spacy","models":[{lang_code,model_name},...]})` 显式构建多语 NlpEngine 注入 AnalyzerEngine；缺模型的语言被剔除（优雅降级），并只注册 supported_language 在可用集合内的识别器。
+- **验证**：新增 `test_presidio_detects_cn_mobile_via_zh_nlp_engine`——`13912345678` 经 CN_MOBILE 命中 `phone`；EN PERSON/email 仍正常；既有 31 例 PII 测试无回归。实机日志 `presidio_analyze_failed lang=zh` 消除。
+- **后续防范**：多语 NLP/检索引擎必须显式声明每语言的模型/资源映射，不能依赖库默认（默认通常单语）；新增语言时同步扩 `_build_nlp_engine` 候选表 + bootstrap 模型清单（`_PII_SPACY_MODELS`）。
+- **同类问题影响**：任何按 `supported_languages` 跑多语的组件（NER、翻译、检索）都要核对底层引擎是否真的为每种语言装配了资源。

--- a/docs/concepts/026-memory-whitepaper.md
+++ b/docs/concepts/026-memory-whitepaper.md
@@ -81,7 +81,7 @@ Alchourrón-Gärdenfors-Makinson 框架<sup>[[10]](#ref10)</sup>定义了 contra
 
 ## 4. Phase 5 四方向落地记录（2026-05 启动）
 
-> Phase 5 聚焦白皮书既定的四个高/中优先级缺口。所有特性默认关闭、向后兼容、灰度启用，工程契约见 [`025-the-memory-system.md`](./025-the-memory-system.md) §10 与 [`memory-basics`](./user-guide/memory-basics.md) "高级特性开关"。
+> Phase 5 聚焦白皮书既定的四个高/中优先级缺口。这些特性自 Phase 8（§4.10）起**默认启用、开箱即用**（各带运行时安全闸，可一键关闭），工程契约见 [`025-the-memory-system.md`](./025-the-memory-system.md) §10 与 [`memory-basics`](./user-guide/memory-basics.md) "高级特性（默认开箱即用）"。
 
 ### 4.1 F1 — HippoRAG 神经符号检索（PPR-Boosted Hybrid）
 
@@ -169,6 +169,25 @@ Alchourrón-Gärdenfors-Makinson 框架<sup>[[10]](#ref10)</sup>定义了 contra
 | G2  | DedupMergeStep ↔ ConflictResolver 桥接：近重复合并前检测事实冲突，偏好反转等场景通过 AGM 信念修正显式解决         | AGM (Alchourrón 1985)<sup>[[10]](#ref10)</sup> + Doyle TMS (1979) |
 | G3  | Rocchio 重加权自动化调度：新增 `reweight_relevance` Job，每 6h 聚合反馈并更新 `metadata_.relevance_weight`        | Rocchio (1971)<sup>[[22]](#ref22)</sup> 反馈闭环                  |
 | G4  | 端到端集成测试：全 Pipeline 巩固、去重、Rocchio 反馈、审计追踪                                                    | "Verification Before Done" 工程准则                               |
+
+### 4.10 Phase 8: 开箱即用化 + 接线缺陷修复（2026-05）
+
+承接 Phase 5-7「实现完成但默认关闭」的现状，本轮把全部高级特性翻为**默认启用**（开箱即用），并修复验证中暴露的多处「实现完成但未真正生效」缺陷。运行时事实源是 `config.default.yaml`（YAML 优先级高于 Python field 默认，见 `config/_base.py`）——这正是此前 6-step Memify「代码就绪却被 YAML 锁在 2 步」的根因。
+
+**默认状态翻转**（`config.default.yaml`）：F1 HippoRAG / F2 Reflexion / F4 Presidio / Rocchio 读侧 + Memify 6-step 全部 `enabled: true`；各自保留运行时安全闸（HippoRAG `min_kg_associations` 数据闸、Reflexion `max_inflight_tasks` 并发上限、Presidio `allow_engine_fallback` 缺模型降级），既开箱即用又自保护。
+
+**接线缺陷修复**（详见 [`issue.md`](../.agents/issue.md) ISSUE-098~101）：
+
+| 缺陷 | 根因 | 修复 |
+| --- | --- | --- |
+| Hybrid 检索长期静默回退纯向量 | `hybrid_search()` SQL 函数从未迁移（仅在 schema 文件）+ `:embedding::vector` 被 SQLAlchemy 误解析报语法错 | 迁移 `0047` 创建函数 + `search_vector`/GIN；改 `CAST(:embedding AS vector(1536))` |
+| F4 Presidio 在热路径是死代码 | 写侧硬编码 legacy regex `detect_pii`，绕过 `engine` 工厂；`PIIGatekeeper` 零调用点 | 写侧改 `detect_pii_for_storage`（工厂引擎，落 `pii_spans`）；检索出口接 `PIIGatekeeper` |
+| Presidio 中文分析失效 | `AnalyzerEngine` 未装配 zh NLP 引擎，CN 识别器全失效 | `_build_nlp_engine` 按语言显式映射 spaCy 模型（en→lg、zh→sm）+ 优雅降级 |
+| 测试隔离污染 | `test_runner_artifacts` 模块级永久替换 `sys.modules` 工厂 | 改「临时 mock + try/finally 还原」 |
+
+**依赖默认化**：presidio-analyzer/anonymizer + spaCy 从可选 extra 提升为主依赖；新增 `negentropy bootstrap-pii-models` CLI 下载 NER 模型（独立下载产物，缺失时按 fallback 降级 regex，`/memory/health` 可观测实际引擎）。
+
+**验证**：全 Memory 测试套件（unit + integration，单会话）667+ 例绿；实机经 `add_session_to_memory` 跑通 6-step Memify（`statuses=[success×6]`，真实 LLM）+ Presidio 检出 person/email/CN-mobile + Hybrid 检索生效；浏览器逐页核对 Timeline/Facts/Conflicts/Audit/Scheduler。
 
 ---
 

--- a/docs/concepts/user-guide/memory-basics.md
+++ b/docs/concepts/user-guide/memory-basics.md
@@ -45,52 +45,56 @@ flowchart LR
 
 ---
 
-## 2.5 高级特性开关（Phase 5）
+## 2.5 高级特性（默认开箱即用）
 
-Phase 5 引入 4 个高级特性，**全部默认关闭**，按需通过环境变量或配置文件灰度启用。详细工程契约见 [`025-the-memory-system.md`](../../concepts/025-the-memory-system.md) §10 与 [`026-memory-whitepaper.md`](../../concepts/026-memory-whitepaper.md) §4。
+5 个高级特性现已**默认全部启用**（开箱即用），并各自带运行时安全闸，必要时可一键关闭。详细工程契约见 [`025-the-memory-system.md`](../../concepts/025-the-memory-system.md) §10 与 [`026-memory-whitepaper.md`](../../concepts/026-memory-whitepaper.md) §4。
 
-| 特性                      | 配置项                              | 默认                       | 何时启用                                                 | 性能成本                                         |
-| ------------------------- | ----------------------------------- | -------------------------- | -------------------------------------------------------- | ------------------------------------------------ |
-| **F1 HippoRAG PPR 检索**  | `MEMORY_HIPPORAG_ENABLED`           | `false`                    | KG 实体关联 ≥ 100 条且需要长尾召回 / 多跳一致性          | +50ms P95（含 120ms 超时）                       |
-| **F2 Reflexion 反思召回** | `MEMORY_REFLECTION_ENABLED`         | `false`                    | 用户/Agent 提供 `irrelevant`/`harmful` 反馈较多          | LLM 调用按 dedup + 上限计费，默认 ≤10 次/用户·日 |
-| **F3 Memify 巩固管线**    | `memory.consolidation.legacy=false` | `false`（即开启 Pipeline） | 默认即用，重构无新功能；自定义 step 时配置 `steps:` 列表 | 与 Phase 4 baseline 一致；新增 step 才有增量成本 |
-| **F4 Presidio PII**       | `memory.pii.engine=presidio`        | `regex`                    | 生产环境合规要求（GDPR / NIST 800-122）                  | 冷启 +200MB（spaCy 模型）；运行时 P99 < 5ms      |
+| 特性                      | 配置项（YAML / 环境变量）                       | 默认       | 运行时安全闸                                              | 性能成本                                         |
+| ------------------------- | ----------------------------------------------- | ---------- | -------------------------------------------------------- | ------------------------------------------------ |
+| **F1 HippoRAG PPR 检索**  | `memory.hipporag.enabled`                       | `true`     | `min_kg_associations≥100` 数据闸：KG 稀疏时自休眠回退 Hybrid；120ms 超时降级；`gray_users` 白名单 | +50ms P95（含 120ms 超时）                       |
+| **F2 Reflexion 反思召回** | `memory.reflection.enabled`                     | `true`     | `max_inflight_tasks=8` 并发硬上限防风暴；日限 ≤10/用户；仅 `irrelevant`/`harmful` 触发 | LLM 调用按 dedup + 上限计费                       |
+| **F3 Memify 巩固管线**    | `memory.consolidation.steps`（6 步）            | 6 步全开   | `policy=fail_tolerant`：单步失败不中断全链；每步 30s 超时 | 2 步为 LLM（fact_extract / entity_normalization / summarize），写路径增量                       |
+| **F4 Presidio PII**       | `memory.pii.engine=presidio` + `gatekeeper_enabled` | `presidio` + 守门员开 | `allow_engine_fallback=true`：缺 spaCy 模型时降级 regex 并写 ERROR（`/memory/health` 可观测），不阻断启动 | 冷启 +200MB（spaCy 模型）；运行时 P99 < 5ms      |
+| **Rocchio 反馈闭环**      | `memory.relevance.enabled`                      | `true`     | 权重夹 `[0.5,2.0]`；<3 反馈返中性 1.0；写侧由 cron 周期重加权 | 读侧 dict 查表，近乎零成本                        |
 
-### Phase 6 新增开关
+> **可观测性**（默认开）：`memory.observability.health_enabled` / `metrics_enabled` → `/memory/health`（暴露当前生效的 hipporag/reflection/consolidation_steps/**pii_engine**）与 `/memory/metrics`（需 admin）。
 
-| 开关             | 环境变量                                   | 默认    | 说明                               |
-| ---------------- | ------------------------------------------ | ------- | ---------------------------------- |
-| Rocchio 反馈闭环 | `NE_MEMORY_RELEVANCE__ENABLED`             | `false` | 启用后累积反馈影响搜索排序         |
-| 健康检查         | `NE_MEMORY_OBSERVABILITY__HEALTH_ENABLED`  | `true`  | `/memory/health` 端点              |
-| 聚合指标         | `NE_MEMORY_OBSERVABILITY__METRICS_ENABLED` | `true`  | `/memory/metrics` 端点（需 admin） |
+### 首次部署：安装 PII NER 模型
 
-### 启用示例
+F4 Presidio 默认引擎依赖 spaCy NER 模型（独立下载产物，非 pip 依赖）。一键安装：
 
 ```bash
-# F1 + F2 灰度启用（环境变量优先）
-export MEMORY_HIPPORAG_ENABLED=true
-export MEMORY_HIPPORAG_GRAY_USERS="alice,bob"
-export MEMORY_REFLECTION_ENABLED=true
-
-# F4 切到 Presidio（需先安装可选依赖）
-cd apps/negentropy && uv sync --extra pii-presidio
-# 配置文件中：
-# memory:
-#   pii:
-#     engine: presidio
-#     policy: mark           # mark | mask | anonymize
+cd apps/negentropy && uv run negentropy bootstrap-pii-models   # 下载 en_core_web_lg + zh_core_web_sm
 ```
 
-### 一键回退
+未安装时不阻断启动：PII 引擎按 `allow_engine_fallback=true` 自动降级回 regex（4 类正则），实际生效引擎可在 `/memory/health` 的 `features.pii_engine` 查看。
 
-| 特性 | 回退方式                                                                |
-| ---- | ----------------------------------------------------------------------- |
-| F1   | `MEMORY_HIPPORAG_ENABLED=false`（即时生效）                             |
-| F2   | `MEMORY_REFLECTION_ENABLED=false`（已有反思记忆保留，但不再生成新的）   |
-| F3   | `memory.consolidation.legacy=true`（回到 Phase 4 硬编码两步）           |
-| F4   | `memory.pii.engine=regex`（已有 `pii_spans` 字段保留，gatekeeper 跳过） |
+### 逐特性验证清单（开箱即用走查）
 
-> 4 个特性的故障排除见 [`memory-troubleshooting.md`](./memory-troubleshooting.md) §11~§14。
+| 特性 | 如何确认已生效 |
+| ---- | -------------- |
+| F1 HippoRAG | `curl /memory/health` → `features.hipporag=true`；KG 实体关联累积 ≥100 后，`search_memory` 结果 `custom_metadata.search_level` 出现 `ppr` / `ppr+hybrid` |
+| F2 Reflexion | 对一次检索提交 `irrelevant` 反馈（`POST /memory/retrieval/feedback`）→ Timeline 出现一条 `episodic` 且 `metadata.subtype=reflection` 的记忆 |
+| F3 Memify | 触发一次会话巩固 → 后端日志 `consolidation_pipeline_completed steps=[6 步] statuses=[success×6]`；Facts/Timeline/关联同时产出 |
+| F4 Presidio | 写入含人名/邮箱的记忆 → `metadata.pii_spans` 含 `person`/`email`（regex 无法识别 person）；低权限角色检索该记忆 content 被 `<EMAIL>` 等占位符遮蔽 |
+| Rocchio | 对记忆累积 helpful 反馈 → cron `reweight_relevance`（每 6h）写入 `metadata.relevance_weight`；后续检索该记忆排序上移 |
+
+### 一键关闭 / 回退
+
+在 `config.default.yaml`（或用户配置 / 环境变量）将对应 `enabled` 置 `false`：
+
+```yaml
+memory:
+  hipporag: { enabled: false }       # 即时回退纯 Hybrid
+  reflection: { enabled: false }     # 已有反思记忆保留，不再生成新的
+  relevance: { enabled: false }      # 读侧不再应用 relevance_weight
+  consolidation: { legacy: true }    # 回到 Phase 4 硬编码两步（fact_extract + auto_link）
+  pii: { engine: regex }             # 已有 pii_spans 保留；gatekeeper 仍按角色遮蔽
+```
+
+环境变量等价（优先级最高）：`NE_MEMORY_HIPPORAG__ENABLED=false`、`NE_MEMORY_REFLECTION__ENABLED=false` 等。
+
+> 5 个特性的故障排除见 [`memory-troubleshooting.md`](./memory-troubleshooting.md) §11~§14。
 
 ---
 
@@ -129,8 +133,9 @@ cd apps/negentropy && uv sync --extra pii-presidio
 > 参考文献：Park et al. (2023) importance/recency/relevance 三维评分；Zep (2025) 时间分组与双时间戳；Hu et al. (2026) factual/experiential/working 记忆分类法。
 
 ### PII 锁标
-- 🔒 表示 metadata.pii_flags 命中（regex 级，仅提示，不阻断）
-- 命中类型：`email` / `phone` / `id_card` / `credit_card`
+- 🔒 表示 metadata.pii_flags / pii_spans 命中（默认 Presidio 引擎）
+- 命中类型：`email` / `phone` / `id_card` / `credit_card` / `person` / `location` 等（Presidio NER 识别人名、地名等 regex 无法覆盖的类别；中文手机号 / 身份证由 CN 自定义识别器补强）
+- 检索侧：`gatekeeper_enabled=true` 时，低于 `acl_role_threshold`（默认 editor）的角色看到 content 经 `retrieval_policy`（默认 anonymize）遮蔽的副本
 
 ---
 


### PR DESCRIPTION
## 背景

对 Memory 模块做 Review & Enhance：经深度循证调研发现，原计划的四个 Gap（Step 零测试 / DedupMerge↔ConflictResolver 断裂 / Rocchio 缺调度 / E2E 缺失）在当前代码中**已基本闭环**；真正的高价值缺口是多处**「实现完成但未真正生效」**——高级特性默认关闭、且存在数处接线断裂。本 PR 将验证通过的高级特性翻为**默认开箱即用**，并修复验证中暴露的全部缺陷。

> 关键认知：运行时事实源是 `config.default.yaml`（YAML 优先级高于 Python field 默认，见 `config/_base.py`）——这正是 6-step Memify「代码就绪却被 YAML 锁在 2 步」长期休眠的根因。

## 主要变更

### 1. 高级特性默认开箱即用（各带运行时安全闸）
| 特性 | 默认 | 安全闸 |
| --- | --- | --- |
| F1 HippoRAG PPR 检索 | ON | `min_kg_associations≥100` 数据闸（KG 稀疏自休眠回退 Hybrid）+ 120ms 超时降级 |
| F2 Reflexion 失败反思 | ON | `max_inflight_tasks=8` 并发硬上限 + 日限 10 + 仅负反馈触发 |
| F3 Memify 6-step 巩固 | ON | `policy=fail_tolerant` 单步失败不中断 + 每步 30s 超时 |
| F4 Presidio PII | ON | `allow_engine_fallback` 缺模型降级 regex；守门员暂默认关闭待角色透传补齐 |
| Rocchio 反馈闭环 | ON | 权重夹 `[0.5,2.0]`；<3 反馈返中性 |

### 2. 接线缺陷修复（验证中暴露，详见 issue.md ISSUE-098~101）
- **Hybrid 检索长期静默回退纯向量**：`hybrid_search()` SQL 函数从未迁移（仅在 schema 文件）+ `:embedding::vector` 被 SQLAlchemy 误解析报语法错。→ 新增迁移 `0047` 创建函数 + `search_vector`/触发器/GIN/回填；改 `CAST(:embedding AS vector(1536))`。
- **F4 Presidio 在热路径是死代码**：写侧硬编码 legacy regex 绕过引擎工厂；`PIIGatekeeper` 零调用点。→ 新增 `detect_pii_for_storage` 经工厂落 `pii_flags`+`pii_spans`；检索出口接 gatekeeper（`viewer_role` 取自鉴权用户，服务端解析不接受客户端自报）。
- **Presidio 中文分析失效**：`AnalyzerEngine` 未装配 zh NLP 引擎致 CN 识别器全失效。→ `_build_nlp_engine` 按语言显式映射 spaCy 模型 + 优雅降级。
- **测试隔离污染**：`test_runner_artifacts` 模块级永久替换 `sys.modules` 致下游测试拿到 MagicMock。→ 改临时 mock + try/finally 还原。

### 3. 依赖与工具
- presidio-analyzer/anonymizer + spaCy 提升为主依赖；新增 CLI `negentropy bootstrap-pii-models` 下载 NER 模型（缺失按 fallback 降级，`/memory/health` 暴露实际生效引擎）。

### 4. 文档
- `memory-basics` user-guide 改为「默认开箱即用」+ 逐特性验证清单 + 一键关闭；026 白皮书新增 §4.10 Phase 8 记录；issue.md 沉淀 4 条缺陷 RCA。

## 验证
- **自动化**：全 Memory 测试套件（unit + integration，单会话）**778 例全绿**（新增集成测试 T1/T3/T4-F1/F2/Rocchio + T5 配置护栏 + 深化步骤单测）。
- **实机**：经 `add_session_to_memory` 跑通 6-step Memify（`statuses=[success×6]`，真实 LLM）+ Presidio 检出 person/email/CN-mobile + Hybrid 检索生效；浏览器逐页核对 Timeline/Facts/Conflicts/Audit/Scheduler（真实登录态）。
- 迁移 `0047` 已验证 downgrade/upgrade 幂等round-trip。

## 兼容性
- 纯新增迁移，不删改既有数据；各特性可经 `enabled: false` / 环境变量一键回退。
- Python field 默认仍保守（`False`/`regex`），库/测试无 YAML 时行为不变；运行时由 `config.default.yaml` 驱动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)