### PR TITLE
feat(routine): 引入长周期自主任务子系统（Evaluator-Optimizer + Reflexion 闭环）

### DIFF
--- a/apps/negentropy-ui/app/api/routine/[...path]/route.ts
+++ b/apps/negentropy-ui/app/api/routine/[...path]/route.ts
@@ -1,0 +1,45 @@
+import { proxyDelete, proxyGet, proxyPost, proxyPut } from "@/app/api/interface/_proxy";
+
+/**
+ * /api/routine/* → 后端 /routines/* 反向代理
+ *
+ * 复用 ``_proxy.ts`` 的鉴权 / Session 透传逻辑。SSE 流式端点 ``/api/routine/stream``
+ * 由相邻路由独立处理，不走通用代理（避免 .text() 把流读完）。
+ *
+ * 路由结构：
+ *   GET    /api/routine/kpis                         → /routines/kpis
+ *   GET    /api/routine                              → /routines
+ *   POST   /api/routine                              → /routines（新建）
+ *   GET    /api/routine/{id}                         → /routines/{id}
+ *   PUT    /api/routine/{id}                         → /routines/{id}（编辑）
+ *   DELETE /api/routine/{id}                         → /routines/{id}（删除）
+ *   GET    /api/routine/{id}/iterations              → /routines/{id}/iterations
+ *   POST   /api/routine/{id}/{start|pause|resume|cancel}
+ *   POST   /api/routine/{id}/iterations/{iid}/{approve|reject}
+ */
+
+type Ctx = { params: Promise<{ path: string[] }> };
+
+function buildBackendPath(segments: string[]): string {
+  return "/routines/" + segments.map((s) => encodeURIComponent(s)).join("/");
+}
+
+export async function GET(request: Request, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxyGet(request, buildBackendPath(path));
+}
+
+export async function POST(request: Request, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxyPost(request, buildBackendPath(path));
+}
+
+export async function PUT(request: Request, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxyPut(request, buildBackendPath(path));
+}
+
+export async function DELETE(request: Request, ctx: Ctx) {
+  const { path } = await ctx.params;
+  return proxyDelete(request, buildBackendPath(path));
+}

--- a/apps/negentropy-ui/app/api/routine/stream/route.ts
+++ b/apps/negentropy-ui/app/api/routine/stream/route.ts
@@ -1,0 +1,58 @@
+import { buildAuthHeaders } from "@/lib/sso";
+import { getAguiBaseUrl } from "@/lib/server/backend-url";
+
+/**
+ * /api/routine/stream — SSE 流式代理（独立路由，避开通用 proxy 的 .text() 缓冲）。
+ *
+ * 直通转发后端 ``/routines/stream`` 的 ``routine`` / ``iteration`` 事件与心跳。
+ * 鉴权 header 复用 buildAuthHeaders + X-Session-ID / X-User-ID 透传。
+ */
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  const baseUrl = getAguiBaseUrl();
+  if (!baseUrl) {
+    return new Response("AGUI_BASE_URL is not configured", { status: 500 });
+  }
+
+  const headers = buildAuthHeaders(request);
+  const sessionId = request.headers.get("x-session-id");
+  if (sessionId) headers.set("x-session-id", sessionId);
+  const userId = request.headers.get("x-user-id");
+  if (userId) headers.set("x-user-id", userId);
+  headers.set("accept", "text/event-stream");
+
+  const upstreamUrl = new URL("/routines/stream", baseUrl);
+  const incomingUrl = new URL(request.url);
+  upstreamUrl.search = incomingUrl.search;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+      // @ts-expect-error Next.js 流式 fetch — duplex 在 Node fetch 中合法
+      duplex: "half",
+    });
+  } catch (error) {
+    return new Response(`Upstream connection failed: ${String(error)}`, { status: 502 });
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    const text = await upstream.text();
+    return new Response(text || "Upstream returned non-OK status", { status: upstream.status });
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineDetailDrawer.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { Button } from "@/components/ui/Button";
+import type { RoutineDTO, RoutineStatus } from "@/features/routine";
+
+import { RoutineIterationTimeline } from "./RoutineIterationTimeline";
+import { RoutineScoreSparkline } from "./RoutineScoreSparkline";
+import { routineStatusClass, scoreColorClass } from "./status-style";
+
+type ControlAction = "start" | "pause" | "resume" | "cancel";
+
+interface RoutineDetailDrawerProps {
+  routine: RoutineDTO;
+  onClose: () => void;
+  onControl: (action: ControlAction) => void;
+  onEdit: (r: RoutineDTO) => void;
+  onDelete: (r: RoutineDTO) => void;
+  onApproveIteration: (iterationId: string) => void;
+  onRejectIteration: (iterationId: string) => void;
+  busy?: boolean;
+}
+
+function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between py-1.5 text-xs">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className="ml-4 break-all text-right text-foreground">{children}</span>
+    </div>
+  );
+}
+
+/** 依状态计算可用控制动作。 */
+function controlsFor(status: RoutineStatus): ControlAction[] {
+  switch (status) {
+    case "pending":
+      return ["start"];
+    case "running":
+      return ["pause", "cancel"];
+    case "paused":
+      return ["resume", "cancel"];
+    default:
+      return [];
+  }
+}
+
+export function RoutineDetailDrawer({
+  routine,
+  onClose,
+  onControl,
+  onEdit,
+  onDelete,
+  onApproveIteration,
+  onRejectIteration,
+  busy,
+}: RoutineDetailDrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  useEffect(() => {
+    const el = panelRef.current;
+    if (!el) return;
+    el.style.transform = "translateX(100%)";
+    requestAnimationFrame(() => {
+      el.style.transition = "transform 200ms ease-out";
+      el.style.transform = "translateX(0)";
+    });
+  }, []);
+
+  const iterations = routine.iterations ?? [];
+  const ascending = [...iterations].sort((a, b) => a.seq - b.seq);
+  const scores = ascending.map((it) => it.score);
+  const controls = controlsFor(routine.status);
+  const isTerminal = ["succeeded", "failed", "cancelled"].includes(routine.status);
+
+  const controlLabel: Record<ControlAction, string> = {
+    start: "Start",
+    pause: "Pause",
+    resume: "Resume",
+    cancel: "Cancel",
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40 bg-overlay" onClick={onClose} />
+      <div
+        ref={panelRef}
+        className="fixed inset-y-0 right-0 z-50 flex w-[460px] max-w-[92vw] flex-col border-l border-border bg-card shadow-xl"
+        style={{ transform: "translateX(100%)" }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-bold text-foreground">{routine.display_name || routine.title}</h2>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(routine.status)}`}
+              >
+                {routine.status}
+              </span>
+            </div>
+            <p className="mt-0.5 text-[10px] text-muted-foreground">{routine.key}</p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close routine details"
+            className="cursor-pointer rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 space-y-5 overflow-auto px-5 py-4">
+          {/* Goal */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Goal</h3>
+            <p className="whitespace-pre-wrap break-words rounded-lg border border-border p-3 text-xs text-foreground">
+              {routine.goal}
+            </p>
+          </section>
+
+          {/* Acceptance criteria */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Acceptance Criteria</h3>
+            <p className="whitespace-pre-wrap break-words rounded-lg border border-border p-3 text-xs text-text-secondary">
+              {routine.acceptance_criteria}
+            </p>
+          </section>
+
+          {/* Progress + budgets */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Progress</h3>
+            <div className="rounded-lg border border-border p-3">
+              <div className="mb-2">
+                <RoutineScoreSparkline scores={scores} threshold={routine.success_score_threshold} />
+              </div>
+              <DetailField label="Iterations">
+                {routine.iteration_count}
+                {routine.max_iterations ? ` / ${routine.max_iterations}` : ""}
+              </DetailField>
+              <DetailField label="Best Score">
+                <span className={scoreColorClass(routine.best_score)}>{routine.best_score ?? "—"}</span>
+              </DetailField>
+              <DetailField label="Last Score">
+                <span className={scoreColorClass(routine.last_score)}>{routine.last_score ?? "—"}</span>
+              </DetailField>
+              <DetailField label="Success Threshold">{routine.success_score_threshold}</DetailField>
+              <DetailField label="Total Cost">
+                ${routine.total_cost_usd.toFixed(4)}
+                {routine.max_cost_usd ? ` / $${routine.max_cost_usd}` : ""}
+              </DetailField>
+              {routine.termination_reason && (
+                <DetailField label="Termination">{routine.termination_reason}</DetailField>
+              )}
+            </div>
+          </section>
+
+          {/* Config */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Config</h3>
+            <div className="rounded-lg border border-border p-3">
+              <DetailField label="Approval Mode">{routine.approval_mode}</DetailField>
+              {routine.cwd && <DetailField label="Working Dir">{routine.cwd}</DetailField>}
+              {routine.verification_command && (
+                <DetailField label="Verify Cmd">
+                  <code className="text-[10px]">{routine.verification_command}</code>
+                </DetailField>
+              )}
+              {routine.claude_session_id && (
+                <DetailField label="Session">
+                  <code className="text-[10px]">{routine.claude_session_id.slice(0, 16)}…</code>
+                </DetailField>
+              )}
+            </div>
+          </section>
+
+          {/* Iteration timeline */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+              Iterations ({iterations.length})
+            </h3>
+            <RoutineIterationTimeline
+              iterations={iterations}
+              onApprove={onApproveIteration}
+              onReject={onRejectIteration}
+              busy={busy}
+            />
+          </section>
+        </div>
+
+        {/* Footer controls */}
+        <div className="flex items-center gap-2 border-t border-border px-5 py-3">
+          {controls.map((action) => (
+            <Button
+              key={action}
+              variant={action === "cancel" ? "outline" : "neutral"}
+              size="sm"
+              disabled={busy}
+              onClick={() => onControl(action)}
+            >
+              {controlLabel[action]}
+            </Button>
+          ))}
+          <div className="flex-1" />
+          {!["running"].includes(routine.status) && (
+            <Button variant="neutral" size="sm" disabled={busy} onClick={() => onEdit(routine)}>
+              Edit
+            </Button>
+          )}
+          {isTerminal && (
+            <button
+              onClick={() => onDelete(routine)}
+              disabled={busy}
+              className="cursor-pointer rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-500/10 disabled:opacity-50 dark:border-red-800 dark:text-red-400"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFilterBar.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFilterBar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { RoutineFilters, RoutineStatus } from "@/features/routine";
+
+interface RoutineFilterBarProps {
+  filters: Partial<RoutineFilters>;
+  onChange: (filters: Partial<RoutineFilters>) => void;
+}
+
+const STATUS_OPTIONS: { value: RoutineStatus | ""; label: string }[] = [
+  { value: "", label: "All Statuses" },
+  { value: "pending", label: "Pending" },
+  { value: "running", label: "Running" },
+  { value: "paused", label: "Paused" },
+  { value: "succeeded", label: "Succeeded" },
+  { value: "failed", label: "Failed" },
+  { value: "cancelled", label: "Cancelled" },
+];
+
+export function RoutineFilterBar({ filters, onChange }: RoutineFilterBarProps) {
+  const inputCls =
+    "rounded-md border border-border bg-input px-3 py-1.5 text-xs text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <select
+        value={filters.status ?? ""}
+        onChange={(e) => onChange({ ...filters, status: (e.target.value || null) as RoutineStatus | null })}
+        className={inputCls}
+      >
+        {STATUS_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <input
+        type="text"
+        value={filters.q ?? ""}
+        placeholder="Search key / title..."
+        onChange={(e) => onChange({ ...filters, q: e.target.value })}
+        className={`${inputCls} min-w-[200px] flex-1`}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { ErrorBanner } from "@/components/ui/ErrorState";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import type { ApprovalMode, RoutineCreatePayload, RoutineDTO, RoutineUpdatePayload } from "@/features/routine";
+
+interface RoutineFormDialogProps {
+  open: boolean;
+  routine: RoutineDTO | null; // null = create
+  onClose: () => void;
+  onSubmit: (mode: "create" | "edit", id: string | null, body: RoutineCreatePayload | RoutineUpdatePayload) => Promise<void>;
+}
+
+interface FormState {
+  key: string;
+  title: string;
+  goal: string;
+  acceptance_criteria: string;
+  cwd: string;
+  verification_command: string;
+  max_iterations: string;
+  max_cost_usd: string;
+  success_score_threshold: string;
+  no_progress_patience: string;
+  approval_mode: ApprovalMode;
+  // Claude Code config 覆盖
+  model: string;
+  max_turns: string;
+  permission_mode: string;
+  allowed_tools: string;
+  display_name: string;
+  description: string;
+}
+
+const EMPTY: FormState = {
+  key: "",
+  title: "",
+  goal: "",
+  acceptance_criteria: "",
+  cwd: "",
+  verification_command: "",
+  max_iterations: "20",
+  max_cost_usd: "5",
+  success_score_threshold: "85",
+  no_progress_patience: "3",
+  approval_mode: "auto",
+  model: "",
+  max_turns: "",
+  permission_mode: "",
+  allowed_tools: "",
+  display_name: "",
+  description: "",
+};
+
+const APPROVAL_HELP: Record<ApprovalMode, string> = {
+  auto: "全自动：创建后无人干预，直到完成或终止",
+  first: "首次审批：第 1 次执行前需人工确认，之后自动迭代",
+  every: "每轮审批：每次迭代执行前都需人工确认",
+};
+
+export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineFormDialogProps) {
+  const isEdit = routine !== null;
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!open) return;
+    const cfg = (routine?.config ?? {}) as Record<string, unknown>;
+    const next: FormState = routine
+      ? {
+          key: routine.key,
+          title: routine.title,
+          goal: routine.goal,
+          acceptance_criteria: routine.acceptance_criteria,
+          cwd: routine.cwd ?? "",
+          verification_command: routine.verification_command ?? "",
+          max_iterations: routine.max_iterations != null ? String(routine.max_iterations) : "",
+          max_cost_usd: routine.max_cost_usd != null ? String(routine.max_cost_usd) : "",
+          success_score_threshold: String(routine.success_score_threshold),
+          no_progress_patience: String(routine.no_progress_patience),
+          approval_mode: routine.approval_mode,
+          model: (cfg.model as string) ?? "",
+          max_turns: cfg.max_turns != null ? String(cfg.max_turns) : "",
+          permission_mode: (cfg.permission_mode as string) ?? "",
+          allowed_tools: Array.isArray(cfg.allowed_tools) ? (cfg.allowed_tools as string[]).join(", ") : "",
+          display_name: routine.display_name ?? "",
+          description: routine.description ?? "",
+        }
+      : EMPTY;
+    // 用 microtask 推迟，避免在 effect 体内同步 setState（对齐 SchedulerTaskFormDialog）
+    queueMicrotask(() => {
+      setForm(next);
+      setError(null);
+      setFieldErrors({});
+    });
+  }, [open, routine]);
+
+  const update = <K extends keyof FormState>(k: K, v: FormState[K]) => setForm((f) => ({ ...f, [k]: v }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const errs: Record<string, string> = {};
+    if (!isEdit && !form.key.trim()) errs.key = "Key is required";
+    if (!form.title.trim()) errs.title = "Title is required";
+    if (!form.goal.trim()) errs.goal = "Goal is required";
+    if (!form.acceptance_criteria.trim()) errs.acceptance_criteria = "Acceptance criteria is required";
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      setError("Fix the highlighted fields before saving.");
+      setLoading(false);
+      return;
+    }
+
+    // 组装 Claude Code config 覆盖（仅非空字段）
+    const config: Record<string, unknown> = {};
+    if (form.model.trim()) config.model = form.model.trim();
+    if (form.max_turns.trim()) config.max_turns = parseInt(form.max_turns, 10);
+    if (form.permission_mode.trim()) config.permission_mode = form.permission_mode.trim();
+    if (form.allowed_tools.trim())
+      config.allowed_tools = form.allowed_tools.split(",").map((s) => s.trim()).filter(Boolean);
+
+    const base = {
+      title: form.title.trim(),
+      goal: form.goal.trim(),
+      acceptance_criteria: form.acceptance_criteria.trim(),
+      cwd: form.cwd.trim() || null,
+      verification_command: form.verification_command.trim() || null,
+      max_iterations: form.max_iterations.trim() ? parseInt(form.max_iterations, 10) : null,
+      max_cost_usd: form.max_cost_usd.trim() ? parseFloat(form.max_cost_usd) : null,
+      success_score_threshold: parseInt(form.success_score_threshold, 10) || 85,
+      no_progress_patience: parseInt(form.no_progress_patience, 10) || 3,
+      approval_mode: form.approval_mode,
+      config,
+      display_name: form.display_name.trim() || null,
+      description: form.description.trim() || null,
+    };
+
+    try {
+      if (isEdit) {
+        await onSubmit("edit", routine.id, base as RoutineUpdatePayload);
+      } else {
+        await onSubmit("create", null, { ...base, key: form.key.trim() } as RoutineCreatePayload);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  const inputCls =
+    "w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+  const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
+  const sectionTitleCls = "text-[10px] uppercase tracking-wider text-text-muted mb-2";
+
+  return (
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={loading}
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-xl flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl sm:max-h-[calc(100vh-2rem)]"
+    >
+      <div className="border-b border-border px-5 py-4">
+        <h2 className="text-lg font-semibold text-foreground">{isEdit ? "Edit Routine" : "New Routine"}</h2>
+        <p className="mt-1 text-sm text-text-muted">
+          {isEdit ? `Editing "${routine.display_name || routine.title}"` : "Define a long-horizon autonomous task"}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-5">
+          {error && <ErrorBanner message={error} />}
+
+          {/* Basic */}
+          <section>
+            <h3 className={sectionTitleCls}>Basic</h3>
+            <div className="space-y-3">
+              {isEdit ? (
+                <div>
+                  <label className={labelCls}>Key</label>
+                  <input type="text" value={form.key} disabled className={inputCls} />
+                </div>
+              ) : (
+                <div>
+                  <label className={labelCls}>
+                    Key <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={form.key}
+                    onChange={(e) => update("key", e.target.value)}
+                    placeholder="unique_routine_key"
+                    className={`${inputCls} ${fieldErrors.key ? "border-red-400" : ""}`}
+                  />
+                  {fieldErrors.key && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>}
+                </div>
+              )}
+              <div>
+                <label className={labelCls}>
+                  Title <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={form.title}
+                  onChange={(e) => update("title", e.target.value)}
+                  className={`${inputCls} ${fieldErrors.title ? "border-red-400" : ""}`}
+                />
+                {fieldErrors.title && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>}
+              </div>
+              <div>
+                <label className={labelCls}>Description</label>
+                <textarea
+                  value={form.description}
+                  onChange={(e) => update("description", e.target.value)}
+                  rows={2}
+                  className={inputCls}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Goal */}
+          <section>
+            <h3 className={sectionTitleCls}>Goal &amp; Criteria</h3>
+            <div className="space-y-3">
+              <div>
+                <label className={labelCls}>
+                  Goal <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={form.goal}
+                  onChange={(e) => update("goal", e.target.value)}
+                  rows={4}
+                  placeholder="The long-horizon objective for Claude Code to accomplish"
+                  className={`${inputCls} ${fieldErrors.goal ? "border-red-400" : ""}`}
+                />
+                {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}
+              </div>
+              <div>
+                <label className={labelCls}>
+                  Acceptance Criteria <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={form.acceptance_criteria}
+                  onChange={(e) => update("acceptance_criteria", e.target.value)}
+                  rows={3}
+                  placeholder="How the Evaluator judges success (the rubric)"
+                  className={`${inputCls} ${fieldErrors.acceptance_criteria ? "border-red-400" : ""}`}
+                />
+                {fieldErrors.acceptance_criteria && (
+                  <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.acceptance_criteria}</p>
+                )}
+              </div>
+            </div>
+          </section>
+
+          {/* Budgets */}
+          <section>
+            <h3 className={sectionTitleCls}>Budgets &amp; Guardrails</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelCls}>Max Iterations</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={form.max_iterations}
+                  onChange={(e) => update("max_iterations", e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Max Cost (USD)</label>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.5"
+                  value={form.max_cost_usd}
+                  onChange={(e) => update("max_cost_usd", e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Success Threshold (0-100)</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={form.success_score_threshold}
+                  onChange={(e) => update("success_score_threshold", e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>No-Progress Patience</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={form.no_progress_patience}
+                  onChange={(e) => update("no_progress_patience", e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Execution */}
+          <section>
+            <h3 className={sectionTitleCls}>Execution (Claude Code)</h3>
+            <div className="space-y-3">
+              <div>
+                <label className={labelCls}>Working Directory</label>
+                <input
+                  type="text"
+                  value={form.cwd}
+                  onChange={(e) => update("cwd", e.target.value)}
+                  placeholder="/path/to/project"
+                  className={inputCls}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelCls}>Max Turns / Iteration</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={form.max_turns}
+                    onChange={(e) => update("max_turns", e.target.value)}
+                    placeholder="default"
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label className={labelCls}>Permission Mode</label>
+                  <select
+                    value={form.permission_mode}
+                    onChange={(e) => update("permission_mode", e.target.value)}
+                    className={inputCls}
+                  >
+                    <option value="">default</option>
+                    <option value="auto">auto</option>
+                    <option value="ask">ask</option>
+                    <option value="plan">plan</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className={labelCls}>Allowed Tools (comma-separated)</label>
+                <input
+                  type="text"
+                  value={form.allowed_tools}
+                  onChange={(e) => update("allowed_tools", e.target.value)}
+                  placeholder="Bash, Read, Write, Edit, Glob, Grep"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className={labelCls}>Model (optional)</label>
+                <input
+                  type="text"
+                  value={form.model}
+                  onChange={(e) => update("model", e.target.value)}
+                  placeholder="inherit global config"
+                  className={inputCls}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Evaluation */}
+          <section>
+            <h3 className={sectionTitleCls}>Evaluation</h3>
+            <div>
+              <label className={labelCls}>Verification Command (optional gate)</label>
+              <input
+                type="text"
+                value={form.verification_command}
+                onChange={(e) => update("verification_command", e.target.value)}
+                placeholder="e.g. uv run pytest -q"
+                className={inputCls}
+              />
+              <p className="mt-0.5 text-[10px] text-text-muted">
+                测试驱动门控：退出码非 0 时评分封顶，作为客观锚点缓解 LLM 评审偏差
+              </p>
+            </div>
+          </section>
+
+          {/* Approval */}
+          <section>
+            <h3 className={sectionTitleCls}>Human-in-the-Loop</h3>
+            <div>
+              <label className={labelCls}>Approval Mode</label>
+              <select
+                value={form.approval_mode}
+                onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
+                className={inputCls}
+              >
+                <option value="auto">Auto (fully autonomous)</option>
+                <option value="first">First iteration approval</option>
+                <option value="every">Every iteration approval</option>
+              </select>
+              <p className="mt-0.5 text-[10px] text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+            </div>
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={loading}
+            className="cursor-pointer rounded-md border border-border px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="cursor-pointer rounded-md bg-foreground px-4 py-1.5 text-sm font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {loading ? "Saving…" : isEdit ? "Save" : "Create"}
+          </button>
+        </div>
+      </form>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
@@ -118,13 +118,18 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
       return;
     }
 
-    // 组装 Claude Code config 覆盖（仅非空字段）
-    const config: Record<string, unknown> = {};
+    // 组装 Claude Code config 覆盖：从既有 config 起步，仅增删本表单管理的 4 个键，
+    // 保留 system_prompt / timeout_seconds 等表单未暴露但引擎消费的键（编辑时不被整体覆盖丢弃）。
+    const config: Record<string, unknown> = { ...((routine?.config as Record<string, unknown>) ?? {}) };
     if (form.model.trim()) config.model = form.model.trim();
+    else delete config.model;
     if (form.max_turns.trim()) config.max_turns = parseInt(form.max_turns, 10);
+    else delete config.max_turns;
     if (form.permission_mode.trim()) config.permission_mode = form.permission_mode.trim();
+    else delete config.permission_mode;
     if (form.allowed_tools.trim())
       config.allowed_tools = form.allowed_tools.split(",").map((s) => s.trim()).filter(Boolean);
+    else delete config.allowed_tools;
 
     const base = {
       title: form.title.trim(),

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineHeader.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineHeader.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+
+interface RoutineHeaderProps {
+  connected: boolean;
+  onRefresh: () => void;
+  loading: boolean;
+  onCreate: () => void;
+}
+
+export function RoutineHeader({ connected, onRefresh, loading, onCreate }: RoutineHeaderProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Routine</h1>
+        <p className="text-sm text-text-muted">
+          Long-horizon autonomous task execution — Engine orchestrates, Claude Code executes
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button
+          variant="neutral"
+          size="sm"
+          onClick={onCreate}
+          leftIcon={
+            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+            </svg>
+          }
+        >
+          New Routine
+        </Button>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span
+            className={`inline-block h-2 w-2 rounded-full ${
+              connected ? "bg-emerald-500" : "bg-text-muted animate-pulse"
+            }`}
+          />
+          {connected ? "Live" : "Reconnecting..."}
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRefresh}
+          disabled={loading}
+          leftIcon={
+            <svg
+              className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+          }
+        >
+          Refresh
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+
+import type { RoutineIterationDTO } from "@/features/routine";
+
+import { iterationDotClass, scoreColorClass, verdictClass } from "./status-style";
+
+interface RoutineIterationTimelineProps {
+  iterations: RoutineIterationDTO[];
+  onApprove: (iterationId: string) => void;
+  onReject: (iterationId: string) => void;
+  busy?: boolean;
+}
+
+export function RoutineIterationTimeline({
+  iterations,
+  onApprove,
+  onReject,
+  busy,
+}: RoutineIterationTimelineProps) {
+  if (iterations.length === 0) {
+    return <p className="text-[11px] text-text-muted">No iterations yet.</p>;
+  }
+
+  return (
+    <ol className="space-y-2">
+      {iterations.map((it) => (
+        <IterationCard key={it.id} it={it} onApprove={onApprove} onReject={onReject} busy={busy} />
+      ))}
+    </ol>
+  );
+}
+
+function IterationCard({
+  it,
+  onApprove,
+  onReject,
+  busy,
+}: {
+  it: RoutineIterationDTO;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  busy?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isPendingApproval = it.status === "pending_approval";
+
+  return (
+    <li className="rounded-lg border border-border p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className={`inline-block h-2 w-2 rounded-full ${iterationDotClass(it.status)}`} />
+          <span className="text-xs font-semibold text-foreground">#{it.seq}</span>
+          <span className="text-[10px] text-text-muted">{it.status}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {it.verdict && (
+            <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${verdictClass(it.verdict)}`}>
+              {it.verdict}
+            </span>
+          )}
+          {it.score != null && (
+            <span className={`text-sm font-bold tabular-nums ${scoreColorClass(it.score)}`}>{it.score}</span>
+          )}
+        </div>
+      </div>
+
+      {/* 执行摘要 */}
+      {it.summary && (
+        <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-text-secondary">
+          {expanded || it.summary.length <= 280 ? it.summary : `${it.summary.slice(0, 280)}…`}
+          {it.summary.length > 280 && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="ml-1 cursor-pointer text-sky-600 hover:underline dark:text-sky-400"
+            >
+              {expanded ? "收起" : "展开"}
+            </button>
+          )}
+        </p>
+      )}
+
+      {/* 执行失败信息 */}
+      {it.exec_error && (
+        <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-500/5 p-2 text-[10px] text-red-600 dark:text-red-400">
+          {it.exec_error}
+        </pre>
+      )}
+
+      {/* 评估反思 */}
+      {it.reflection && (
+        <p className="mt-2 rounded bg-muted/40 p-2 text-[11px] italic text-text-secondary">
+          💡 {it.reflection}
+        </p>
+      )}
+
+      {/* 指标行 */}
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-text-muted">
+        {it.exec_status && <span>exec: {it.exec_status}</span>}
+        <span>turns: {it.turn_count}</span>
+        <span>cost: ${it.cost_usd.toFixed(4)}</span>
+        {it.gate_exit_code != null && <span>gate exit: {it.gate_exit_code}</span>}
+        {it.started_at && <span>{new Date(it.started_at).toLocaleTimeString()}</span>}
+      </div>
+
+      {/* 审批门控操作 */}
+      {isPendingApproval && (
+        <div className="mt-2 flex items-center gap-2 rounded-md bg-amber-500/5 p-2">
+          <span className="text-[10px] text-amber-700 dark:text-amber-300">等待审批后执行</span>
+          <div className="flex-1" />
+          <button
+            onClick={() => onApprove(it.id)}
+            disabled={busy}
+            className="cursor-pointer rounded-md border border-emerald-200 px-2.5 py-1 text-[11px] font-medium text-emerald-600 hover:bg-emerald-500/10 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-400"
+          >
+            Approve
+          </button>
+          <button
+            onClick={() => onReject(it.id)}
+            disabled={busy}
+            className="cursor-pointer rounded-md border border-red-200 px-2.5 py-1 text-[11px] font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50 dark:border-red-800 dark:text-red-400"
+          >
+            Reject
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineKpiStrip.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineKpiStrip.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/Skeleton";
+import type { RoutineKpis } from "@/features/routine";
+
+interface RoutineKpiStripProps {
+  kpis: RoutineKpis | null;
+  loading: boolean;
+}
+
+function MetricCell({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-3 flex-1 min-w-0">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{label}</div>
+      <div className={`text-lg font-bold tabular-nums ${color ?? "text-foreground"}`}>{value}</div>
+      {sub && <div className="text-[10px] text-muted-foreground mt-0.5">{sub}</div>}
+    </div>
+  );
+}
+
+function SkeletonCell() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-3 flex-1 min-w-0">
+      <Skeleton className="h-3 w-12 mb-2" />
+      <Skeleton className="h-5 w-16" />
+    </div>
+  );
+}
+
+export function RoutineKpiStrip({ kpis, loading }: RoutineKpiStripProps) {
+  if (loading && !kpis) {
+    return (
+      <div className="flex gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonCell key={i} />
+        ))}
+      </div>
+    );
+  }
+  if (!kpis) return null;
+
+  return (
+    <div className="flex gap-3">
+      <MetricCell label="Total" value={String(kpis.total)} sub={`${kpis.pending} pending`} />
+      <MetricCell label="Running" value={String(kpis.running)} color="text-sky-600 dark:text-sky-400" />
+      <MetricCell label="Paused" value={String(kpis.paused)} color="text-amber-600 dark:text-amber-400" />
+      <MetricCell label="Succeeded" value={String(kpis.succeeded)} color="text-emerald-600 dark:text-emerald-400" />
+      <MetricCell label="Failed" value={String(kpis.failed)} color="text-red-600 dark:text-red-400" />
+      <MetricCell label="Total Cost" value={`$${kpis.total_cost_usd.toFixed(2)}`} sub={`avg ${kpis.avg_iterations} iters`} />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineScoreSparkline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineScoreSparkline.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+interface RoutineScoreSparklineProps {
+  /** 按 seq 升序的评分序列（null 表示尚未评估，跳过）。 */
+  scores: (number | null)[];
+  threshold?: number;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * 评分趋势 SVG 折线图。X 轴 = 迭代序号，Y 轴 = 0-100。虚线标注成功阈值。
+ */
+export function RoutineScoreSparkline({
+  scores,
+  threshold = 85,
+  width = 220,
+  height = 48,
+}: RoutineScoreSparklineProps) {
+  const pts = scores
+    .map((s, i) => ({ s, i }))
+    .filter((p): p is { s: number; i: number } => p.s != null);
+
+  if (pts.length === 0) {
+    return <div className="text-[10px] text-text-muted">尚无评分数据</div>;
+  }
+
+  const pad = 4;
+  const n = scores.length;
+  const xOf = (i: number) => (n <= 1 ? width / 2 : pad + (i * (width - 2 * pad)) / (n - 1));
+  const yOf = (s: number) => height - pad - (s / 100) * (height - 2 * pad);
+
+  const path = pts.map((p, idx) => `${idx === 0 ? "M" : "L"}${xOf(p.i).toFixed(1)},${yOf(p.s).toFixed(1)}`).join(" ");
+  const thresholdY = yOf(threshold);
+
+  return (
+    <svg width={width} height={height} className="overflow-visible" role="img" aria-label="score trajectory">
+      {/* 阈值线 */}
+      <line
+        x1={pad}
+        y1={thresholdY}
+        x2={width - pad}
+        y2={thresholdY}
+        className="stroke-emerald-500/40"
+        strokeWidth={1}
+        strokeDasharray="3 3"
+      />
+      {/* 折线 */}
+      <path d={path} fill="none" className="stroke-sky-500" strokeWidth={1.5} strokeLinejoin="round" />
+      {/* 数据点 */}
+      {pts.map((p) => (
+        <circle
+          key={p.i}
+          cx={xOf(p.i)}
+          cy={yOf(p.s)}
+          r={2}
+          className={p.s >= threshold ? "fill-emerald-500" : "fill-sky-500"}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/Skeleton";
+import type { RoutineDTO } from "@/features/routine";
+
+import { routineStatusClass, scoreColorClass } from "./status-style";
+
+interface RoutineTableProps {
+  routines: RoutineDTO[];
+  loading: boolean;
+  onSelect: (r: RoutineDTO) => void;
+}
+
+export function RoutineTable({ routines, loading, onSelect }: RoutineTableProps) {
+  if (loading && routines.length === 0) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (routines.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border bg-card py-12 text-center">
+        <p className="text-sm text-text-muted">No routines yet. Create your first autonomous task.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+            <th className="px-4 py-2.5 font-medium">Name</th>
+            <th className="px-4 py-2.5 font-medium">Status</th>
+            <th className="px-4 py-2.5 font-medium">Progress</th>
+            <th className="px-4 py-2.5 font-medium">Best Score</th>
+            <th className="px-4 py-2.5 font-medium">Cost</th>
+            <th className="px-4 py-2.5 font-medium">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {routines.map((r) => (
+            <tr
+              key={r.id}
+              onClick={() => onSelect(r)}
+              className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
+            >
+              <td className="px-4 py-3">
+                <div className="font-medium text-foreground">{r.display_name || r.title}</div>
+                <div className="text-[10px] text-text-muted">{r.key}</div>
+              </td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(r.status)}`}
+                >
+                  {r.status}
+                </span>
+                {r.termination_reason && (
+                  <div className="mt-0.5 text-[10px] text-text-muted">{r.termination_reason}</div>
+                )}
+              </td>
+              <td className="px-4 py-3 tabular-nums text-text-secondary">
+                {r.iteration_count}
+                {r.max_iterations ? ` / ${r.max_iterations}` : ""}
+              </td>
+              <td className={`px-4 py-3 font-semibold tabular-nums ${scoreColorClass(r.best_score)}`}>
+                {r.best_score ?? "—"}
+              </td>
+              <td className="px-4 py-3 tabular-nums text-text-secondary">
+                ${r.total_cost_usd.toFixed(3)}
+                {r.max_cost_usd ? <span className="text-text-muted"> / ${r.max_cost_usd}</span> : null}
+              </td>
+              <td className="px-4 py-3 text-[11px] text-text-muted">
+                {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -1,0 +1,66 @@
+import type { IterationStatus, RoutineStatus, Verdict } from "@/features/routine";
+
+/** Routine 状态 → 徽章配色。 */
+export function routineStatusClass(status: RoutineStatus): string {
+  switch (status) {
+    case "running":
+      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+    case "paused":
+      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "succeeded":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "failed":
+      return "bg-red-500/10 text-red-700 dark:text-red-300";
+    case "cancelled":
+      return "bg-muted text-text-secondary line-through";
+    default: // pending
+      return "bg-muted/60 text-foreground";
+  }
+}
+
+/** 迭代状态 → 状态点配色。 */
+export function iterationDotClass(status: IterationStatus): string {
+  switch (status) {
+    case "in_flight":
+      return "bg-sky-500 animate-pulse";
+    case "dispatched":
+      return "bg-sky-400";
+    case "pending_approval":
+      return "bg-amber-500 animate-pulse";
+    case "executed":
+      return "bg-violet-500";
+    case "evaluated":
+      return "bg-emerald-500";
+    case "reaped":
+    case "aborted":
+      return "bg-text-muted";
+    default:
+      return "bg-text-muted";
+  }
+}
+
+/** 评分 → 文字配色（≥85 绿，≥50 琥珀，<50 红）。 */
+export function scoreColorClass(score: number | null | undefined): string {
+  if (score == null) return "text-text-muted";
+  if (score >= 85) return "text-emerald-600 dark:text-emerald-400";
+  if (score >= 50) return "text-amber-600 dark:text-amber-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+/** verdict → 徽章配色。 */
+export function verdictClass(verdict: Verdict | null | undefined): string {
+  switch (verdict) {
+    case "pass":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "progressing":
+      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+    case "stalled":
+      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "regressed":
+      return "bg-orange-500/10 text-orange-700 dark:text-orange-300";
+    case "unrecoverable":
+      return "bg-red-500/10 text-red-700 dark:text-red-300";
+    default:
+      return "bg-muted/60 text-text-secondary";
+  }
+}

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -76,7 +76,7 @@ export default function RoutinePage() {
     setActionBusy(true);
     try {
       const updated = await controlRoutine(selected.id, action);
-      toast.success(`Routine ${action}ed`);
+      toast.success(`Routine ${{ start: "started", pause: "paused", resume: "resumed", cancel: "cancelled" }[action]}`);
       await refreshSelected(updated.id);
       refresh();
     } catch (err) {

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { ErrorBanner } from "@/components/ui/ErrorState";
+import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+import {
+  approveIteration,
+  controlRoutine,
+  createRoutine,
+  deleteRoutine,
+  fetchRoutineDetail,
+  rejectIteration,
+  updateRoutine,
+  useRoutineData,
+  useRoutineStream,
+} from "@/features/routine";
+import type {
+  RoutineCreatePayload,
+  RoutineDTO,
+  RoutineFilters,
+  RoutineUpdatePayload,
+} from "@/features/routine";
+
+import { RoutineDetailDrawer } from "./_components/RoutineDetailDrawer";
+import { RoutineFilterBar } from "./_components/RoutineFilterBar";
+import { RoutineFormDialog } from "./_components/RoutineFormDialog";
+import { RoutineHeader } from "./_components/RoutineHeader";
+import { RoutineKpiStrip } from "./_components/RoutineKpiStrip";
+import { RoutineTable } from "./_components/RoutineTable";
+
+const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "" };
+
+export default function RoutinePage() {
+  const [filters, setFilters] = useState<Partial<RoutineFilters>>(DEFAULT_FILTERS);
+  const [selected, setSelected] = useState<RoutineDTO | null>(null);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<RoutineDTO | null>(null);
+  const [actionBusy, setActionBusy] = useState(false);
+
+  const { confirm, confirmDialog } = useConfirmDialog();
+  const { routines, kpis, loading, error, refresh } = useRoutineData(filters);
+
+  // 刷新当前选中详情（含迭代）
+  const refreshSelected = useCallback(async (id: string) => {
+    try {
+      const detail = await fetchRoutineDetail(id);
+      setSelected(detail);
+    } catch {
+      // ignore — drawer 可能已关闭
+    }
+  }, []);
+
+  // SSE：路由 / 迭代事件到达时刷新列表与详情
+  const { connected } = useRoutineStream({
+    onRoutineEvent: () => {
+      void refresh();
+      if (selected) void refreshSelected(selected.id);
+    },
+    onIterationEvent: (ev) => {
+      if (selected && (ev.routine_id === selected.id || ev.id === selected.id)) {
+        void refreshSelected(selected.id);
+      }
+    },
+  });
+
+  const openDetail = async (r: RoutineDTO) => {
+    setSelected(r);
+    void refreshSelected(r.id);
+  };
+
+  const handleControl = async (action: "start" | "pause" | "resume" | "cancel") => {
+    if (!selected) return;
+    setActionBusy(true);
+    try {
+      const updated = await controlRoutine(selected.id, action);
+      toast.success(`Routine ${action}ed`);
+      await refreshSelected(updated.id);
+      refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : `Failed to ${action}`);
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const handleApprove = async (iterationId: string) => {
+    if (!selected) return;
+    setActionBusy(true);
+    try {
+      await approveIteration(selected.id, iterationId);
+      toast.success("Iteration approved");
+      await refreshSelected(selected.id);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to approve");
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const handleReject = async (iterationId: string) => {
+    if (!selected) return;
+    setActionBusy(true);
+    try {
+      await rejectIteration(selected.id, iterationId);
+      toast.success("Iteration rejected");
+      await refreshSelected(selected.id);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to reject");
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const handleCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (r: RoutineDTO) => {
+    setEditing(r);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async (r: RoutineDTO) => {
+    const ok = await confirm({
+      title: "Delete Routine",
+      message: (
+        <>
+          Delete{" "}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">{r.display_name || r.key}</code>? This
+          permanently removes all its iterations and cannot be undone.
+        </>
+      ),
+      confirmLabel: "Delete",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await deleteRoutine(r.id);
+      toast.success("Routine deleted");
+      setSelected(null);
+      refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete");
+    }
+  };
+
+  const handleFormSubmit = async (
+    mode: "create" | "edit",
+    id: string | null,
+    body: RoutineCreatePayload | RoutineUpdatePayload,
+  ) => {
+    if (mode === "create") {
+      const created = await createRoutine(body as RoutineCreatePayload);
+      toast.success("Routine created");
+      setFormOpen(false);
+      refresh();
+      void openDetail(created);
+    } else if (mode === "edit" && id) {
+      const updated = await updateRoutine(id, body as RoutineUpdatePayload);
+      toast.success("Routine updated");
+      setFormOpen(false);
+      refresh();
+      await refreshSelected(updated.id);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-muted">
+      <InterfaceNav title="Routine" />
+      <div className="flex-1 overflow-auto">
+        <div className="space-y-5 px-6 py-6">
+          <RoutineHeader connected={connected} onRefresh={refresh} loading={loading} onCreate={handleCreate} />
+
+          {error && <ErrorBanner message={error} />}
+
+          <RoutineKpiStrip kpis={kpis} loading={loading} />
+          <RoutineFilterBar filters={filters} onChange={setFilters} />
+          <RoutineTable routines={routines} loading={loading} onSelect={openDetail} />
+
+          {selected && (
+            <RoutineDetailDrawer
+              routine={selected}
+              onClose={() => setSelected(null)}
+              onControl={handleControl}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onApproveIteration={handleApprove}
+              onRejectIteration={handleReject}
+              busy={actionBusy}
+            />
+          )}
+        </div>
+      </div>
+
+      <RoutineFormDialog open={formOpen} routine={editing} onClose={() => setFormOpen(false)} onSubmit={handleFormSubmit} />
+
+      {confirmDialog}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/components/ui/InterfaceNav.tsx
+++ b/apps/negentropy-ui/components/ui/InterfaceNav.tsx
@@ -20,6 +20,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/interface/skills", label: "Skills" },
   { href: "/interface/tools", label: "Tools" },
   { href: "/interface/scheduler", label: "Scheduler" },
+  { href: "/interface/routine", label: "Routine" },
 ];
 
 export function InterfaceNav({

--- a/apps/negentropy-ui/features/routine/api.ts
+++ b/apps/negentropy-ui/features/routine/api.ts
@@ -1,0 +1,118 @@
+/**
+ * Routine API 客户端。
+ *
+ * 所有请求经 ``/api/routine/*`` 反向代理走到后端 ``/routines/*``。
+ */
+
+import type {
+  IterationListResponse,
+  RoutineCreatePayload,
+  RoutineDTO,
+  RoutineFilters,
+  RoutineKpis,
+  RoutineListResponse,
+  RoutineIterationDTO,
+  RoutineUpdatePayload,
+} from "./types";
+
+const API_ROOT = "/api/routine";
+
+async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_ROOT}${path}`, {
+    cache: "no-store",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const j = await res.json();
+      detail = typeof j === "object" && j ? JSON.stringify(j) : String(j);
+    } catch {
+      detail = await res.text().catch(() => "");
+    }
+    throw new Error(`routine API ${path} → ${res.status}: ${detail || res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchKpis(): Promise<RoutineKpis> {
+  return jsonFetch("/kpis");
+}
+
+export async function fetchRoutines(filters: Partial<RoutineFilters> = {}): Promise<RoutineListResponse> {
+  const sp = new URLSearchParams();
+  if (filters.status) sp.set("status", filters.status);
+  if (filters.q) sp.set("q", filters.q);
+  const q = sp.toString();
+  return jsonFetch(`${q ? `?${q}` : ""}`);
+}
+
+export async function fetchRoutineDetail(routineId: string, recent = 20): Promise<RoutineDTO> {
+  return jsonFetch(`/${encodeURIComponent(routineId)}?recent=${recent}`);
+}
+
+export async function fetchIterations(
+  routineId: string,
+  opts: { limit?: number; before_seq?: number } = {},
+): Promise<IterationListResponse> {
+  const sp = new URLSearchParams();
+  if (opts.limit) sp.set("limit", String(opts.limit));
+  if (opts.before_seq != null) sp.set("before_seq", String(opts.before_seq));
+  const q = sp.toString();
+  return jsonFetch(`/${encodeURIComponent(routineId)}/iterations${q ? `?${q}` : ""}`);
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export async function createRoutine(body: RoutineCreatePayload): Promise<RoutineDTO> {
+  return jsonFetch("", { method: "POST", body: JSON.stringify(body) });
+}
+
+export async function updateRoutine(routineId: string, body: RoutineUpdatePayload): Promise<RoutineDTO> {
+  return jsonFetch(`/${encodeURIComponent(routineId)}`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteRoutine(
+  routineId: string,
+): Promise<{ ok: boolean; deleted_routine_id: string }> {
+  return jsonFetch(`/${encodeURIComponent(routineId)}`, { method: "DELETE" });
+}
+
+// ---------------------------------------------------------------------------
+// 控制动作
+// ---------------------------------------------------------------------------
+
+type ControlAction = "start" | "pause" | "resume" | "cancel";
+
+export async function controlRoutine(routineId: string, action: ControlAction): Promise<RoutineDTO> {
+  return jsonFetch(`/${encodeURIComponent(routineId)}/${action}`, { method: "POST" });
+}
+
+export async function approveIteration(
+  routineId: string,
+  iterationId: string,
+): Promise<RoutineIterationDTO> {
+  return jsonFetch(
+    `/${encodeURIComponent(routineId)}/iterations/${encodeURIComponent(iterationId)}/approve`,
+    { method: "POST" },
+  );
+}
+
+export async function rejectIteration(
+  routineId: string,
+  iterationId: string,
+): Promise<RoutineIterationDTO> {
+  return jsonFetch(
+    `/${encodeURIComponent(routineId)}/iterations/${encodeURIComponent(iterationId)}/reject`,
+    { method: "POST" },
+  );
+}

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineData.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineData.ts
@@ -1,0 +1,53 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * React 19 + eslint-plugin-react-hooks v7 的 React Compiler 兼容规则集命中
+ * 「useEffect 内调用 fetcher 间接 setState」的既有数据加载模式（对齐 useSchedulerData）。
+ * 功能正确，仅严格度提升导致告警；TODO(react-compiler): 后续按 SWR / useSyncExternalStore 重构。
+ */
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchKpis, fetchRoutines } from "../api";
+import type { RoutineDTO, RoutineFilters, RoutineKpis } from "../types";
+
+/**
+ * Routine 列表 + KPI 数据 hook。
+ *
+ * - 依据 filters 拉取列表与 KPI；
+ * - 暴露 ``refresh()`` 供控制动作 / SSE 事件后手动刷新；
+ * - ``bump`` 计数器允许外部（SSE）触发去抖刷新。
+ */
+export function useRoutineData(filters: Partial<RoutineFilters>) {
+  const [routines, setRoutines] = useState<RoutineDTO[]>([]);
+  const [kpis, setKpis] = useState<RoutineKpis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 序列化 filters 以稳定 effect 依赖
+  const filterKey = JSON.stringify({ status: filters.status ?? null, q: filters.q ?? "" });
+  const reqIdRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const reqId = ++reqIdRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const [listRes, kpiRes] = await Promise.all([fetchRoutines(filters), fetchKpis()]);
+      if (reqId !== reqIdRef.current) return; // 过期请求丢弃
+      setRoutines(listRes.items);
+      setKpis(kpiRes);
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return;
+      setError(err instanceof Error ? err.message : "Failed to load routines");
+    } finally {
+      if (reqId === reqIdRef.current) setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterKey]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { routines, kpis, loading, error, refresh: load };
+}

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineStream.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineStream.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { RoutineStreamEvent } from "../types";
+
+/**
+ * SSE 实时事件订阅（与 ``/api/routine/stream`` 配对）。
+ *
+ * 监听 ``routine`` 与 ``iteration`` 两类事件；自动重连（exponential backoff，最大 30s）。
+ * 可选 ``routineId`` 过滤（服务端已过滤，客户端再防御一次）。
+ */
+export function useRoutineStream(opts?: {
+  routineId?: string;
+  onRoutineEvent?: (e: RoutineStreamEvent) => void;
+  onIterationEvent?: (e: RoutineStreamEvent) => void;
+}) {
+  const { routineId, onRoutineEvent, onIterationEvent } = opts ?? {};
+  const [connected, setConnected] = useState(false);
+
+  const routineCbRef = useRef(onRoutineEvent);
+  const iterationCbRef = useRef(onIterationEvent);
+  useEffect(() => {
+    routineCbRef.current = onRoutineEvent;
+    iterationCbRef.current = onIterationEvent;
+  }, [onRoutineEvent, onIterationEvent]);
+
+  useEffect(() => {
+    let es: EventSource | null = null;
+    let reconnectTimer: number | null = null;
+    let attempt = 0;
+    let disposed = false;
+
+    const parse = (ev: Event): RoutineStreamEvent | null => {
+      try {
+        return JSON.parse((ev as MessageEvent).data) as RoutineStreamEvent;
+      } catch {
+        return null;
+      }
+    };
+
+    const open = () => {
+      if (disposed) return;
+      const url = routineId
+        ? `/api/routine/stream?routine_id=${encodeURIComponent(routineId)}`
+        : "/api/routine/stream";
+      es = new EventSource(url, { withCredentials: true });
+
+      es.onopen = () => {
+        if (disposed) return;
+        setConnected(true);
+        attempt = 0;
+      };
+
+      es.addEventListener("routine", (ev) => {
+        if (disposed) return;
+        const data = parse(ev);
+        if (data) routineCbRef.current?.(data);
+      });
+
+      es.addEventListener("iteration", (ev) => {
+        if (disposed) return;
+        const data = parse(ev);
+        if (data) iterationCbRef.current?.(data);
+      });
+
+      es.onerror = () => {
+        if (disposed) return;
+        setConnected(false);
+        es?.close();
+        attempt += 1;
+        const delay = Math.min(30000, 500 * 2 ** Math.min(attempt, 6)) + Math.random() * 500;
+        reconnectTimer = window.setTimeout(open, delay);
+      };
+    };
+
+    open();
+
+    return () => {
+      disposed = true;
+      if (reconnectTimer) window.clearTimeout(reconnectTimer);
+      es?.close();
+    };
+  }, [routineId]);
+
+  return { connected };
+}

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Routine 共享模块 — 统一导出类型、API 客户端和 hooks。
+ */
+
+export type {
+  RoutineStatus,
+  ApprovalMode,
+  IterationStatus,
+  Verdict,
+  ExecStatus,
+  RoutineDTO,
+  RoutineIterationDTO,
+  RoutineKpis,
+  RoutineListResponse,
+  IterationListResponse,
+  RoutineFilters,
+  RoutineCreatePayload,
+  RoutineUpdatePayload,
+  RoutineStreamEvent,
+} from "./types";
+
+export {
+  fetchKpis,
+  fetchRoutines,
+  fetchRoutineDetail,
+  fetchIterations,
+  createRoutine,
+  updateRoutine,
+  deleteRoutine,
+  controlRoutine,
+  approveIteration,
+  rejectIteration,
+} from "./api";
+
+export { useRoutineData } from "./hooks/useRoutineData";
+export { useRoutineStream } from "./hooks/useRoutineStream";

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -1,0 +1,141 @@
+/**
+ * Routine 共享类型 — 与后端 ``routine_api.py`` 的序列化契约对齐。
+ */
+
+export type RoutineStatus =
+  | "pending"
+  | "running"
+  | "paused"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export type ApprovalMode = "auto" | "first" | "every";
+
+export type IterationStatus =
+  | "pending_approval"
+  | "dispatched"
+  | "in_flight"
+  | "executed"
+  | "evaluated"
+  | "reaped"
+  | "aborted";
+
+export type Verdict = "pass" | "progressing" | "stalled" | "regressed" | "unrecoverable";
+
+export type ExecStatus = "success" | "error" | "timeout";
+
+export interface RoutineDTO {
+  id: string;
+  key: string;
+  title: string;
+  display_name: string | null;
+  description: string | null;
+  goal: string;
+  acceptance_criteria: string;
+  cwd: string | null;
+  verification_command: string | null;
+  status: RoutineStatus;
+  termination_reason: string | null;
+  max_iterations: number | null;
+  max_cost_usd: number | null;
+  deadline_at: string | null;
+  success_score_threshold: number;
+  no_progress_patience: number;
+  approval_mode: ApprovalMode;
+  iteration_count: number;
+  total_cost_usd: number;
+  best_score: number | null;
+  last_score: number | null;
+  claude_session_id: string | null;
+  reflections: string[];
+  config: Record<string, unknown>;
+  owner_id: string | null;
+  agent_id: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  // 仅 detail 端点返回
+  iterations?: RoutineIterationDTO[];
+}
+
+export interface RoutineIterationDTO {
+  id: string;
+  routine_id: string;
+  seq: number;
+  status: IterationStatus;
+  prompt: string | null;
+  resume_session_id: string | null;
+  exec_status: ExecStatus | null;
+  summary: string | null;
+  claude_session_id: string | null;
+  cost_usd: number;
+  turn_count: number;
+  exec_error: string | null;
+  score: number | null;
+  verdict: Verdict | null;
+  reflection: string | null;
+  eval_error: string | null;
+  gate_exit_code: number | null;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+export interface RoutineKpis {
+  total: number;
+  running: number;
+  paused: number;
+  succeeded: number;
+  failed: number;
+  cancelled: number;
+  pending: number;
+  total_cost_usd: number;
+  avg_iterations: number;
+}
+
+export interface RoutineListResponse {
+  items: RoutineDTO[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export interface IterationListResponse {
+  items: RoutineIterationDTO[];
+  has_more: boolean;
+  next_before_seq: number | null;
+}
+
+export interface RoutineFilters {
+  status: RoutineStatus | null;
+  q: string;
+}
+
+/** 创建请求体 */
+export interface RoutineCreatePayload {
+  key: string;
+  title: string;
+  goal: string;
+  acceptance_criteria: string;
+  cwd?: string | null;
+  verification_command?: string | null;
+  max_iterations?: number | null;
+  max_cost_usd?: number | null;
+  deadline_at?: string | null;
+  success_score_threshold?: number;
+  no_progress_patience?: number;
+  approval_mode?: ApprovalMode;
+  config?: Record<string, unknown>;
+  display_name?: string | null;
+  description?: string | null;
+}
+
+/** 更新请求体（全部可选） */
+export type RoutineUpdatePayload = Partial<Omit<RoutineCreatePayload, "key">>;
+
+/** SSE 事件 */
+export interface RoutineStreamEvent {
+  type: "routine" | "iteration";
+  id: string;
+  routine_id?: string;
+  status?: string;
+  [key: string]: unknown;
+}

--- a/apps/negentropy/src/negentropy/config/__init__.py
+++ b/apps/negentropy/src/negentropy/config/__init__.py
@@ -35,6 +35,7 @@ from .knowledge import KnowledgeSettings
 from .logging import LoggingSettings
 from .memory import MemorySettings
 from .observability import ObservabilitySettings
+from .routine import RoutineSettings
 from .search import SearchSettings
 from .services import ServicesSettings
 
@@ -74,6 +75,7 @@ class Settings(BaseSettings):
             "observability",
             "knowledge",
             "memory",
+            "routine",
         ):
             set_yaml_section(section, yaml_config.get(section, {}))
 
@@ -133,6 +135,11 @@ class Settings(BaseSettings):
     def memory(self) -> MemorySettings:
         """Memory Phase 5 高级特性配置（HippoRAG / Reflexion / Memify / PII）。"""
         return MemorySettings()
+
+    @cached_property
+    def routine(self) -> RoutineSettings:
+        """Routine 长周期自主任务编排配置（Evaluator-Optimizer + Reflexion）。"""
+        return RoutineSettings()
 
     # =========================================================================
     # Legacy Compatibility Layer
@@ -249,6 +256,7 @@ __all__ = [
     "KnowledgeSettings",
     "LoggingSettings",
     "MemorySettings",
+    "RoutineSettings",
     "ObservabilitySettings",
     "DatabaseSettings",
     "ServicesSettings",

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -185,6 +185,19 @@ memory:
     feedback_min_count: 3                    # 最低反馈条数门槛
     reweight_interval_seconds: 3600
 
+# --- Routine 配置（长周期自主任务迭代执行：Evaluator-Optimizer + Reflexion）---
+routine:
+  enabled: false                             # 灰度开关：关闭时 routine_inspector 心跳 no-op，不影响调度引擎
+  inspector_interval_seconds: 25             # 心跳 tick 间隔；与种子 routine_inspector ScheduledTask 一致
+  max_concurrent_executions: 2               # 全局并发 Claude Code 执行上限（进程内信号量）
+  lease_slack_seconds: 60                    # Runner lease 宽裕量；崩溃恢复 reaper 据此判定孤儿迭代
+  gate_timeout_seconds: 120                  # verification_command 命令门控执行超时
+  max_reflections_injected: 5                # 注入下一迭代 prompt 的最近反思条数（Reflexion 窗口）
+  eval_failure_patience: 3                   # 评估器连续失败容忍次数，超过终止为 unrecoverable_error
+  default_max_iterations: 20                 # 创建 routine 默认迭代硬上限
+  default_max_cost_usd: 5.0                  # 创建 routine 默认成本熔断（USD）
+  evaluator_model: null                      # LLM-as-Judge 模型覆盖；null 走 task_registry 的 routine.evaluate
+
 # --- Knowledge 配置 ---
 knowledge:
   # Wiki SSG ISR 主动 revalidate webhook：publish/unpublish 完成后向 SSG 通知立即重渲染。

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -1,0 +1,85 @@
+"""Routine 子系统配置 — 长周期自主任务迭代执行。
+
+承载 Routine 编排循环（Evaluator-Optimizer + Reflexion）的配置开关与默认预算。
+特性默认关闭（``enabled=False``），灰度开启后由 ``routine_inspector`` 心跳驱动。
+
+env 前缀 ``NE_ROUTINE_``；YAML 节点 ``routine:``。
+
+参考文献：
+[1] Anthropic, *Building Effective AI Agents*, 2024. Evaluator-Optimizer 工作流。
+[2] N. Shinn et al., "Reflexion: Language Agents with Verbal Reinforcement Learning,"
+    in *Proc. NeurIPS*, 2023. arXiv:2303.11366. 跨迭代自反思记忆。
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+
+class RoutineSettings(BaseSettings):
+    """Routine 编排循环配置。
+
+    Inspector 心跳间隔、并发上限、崩溃恢复 lease、评估器重试、默认预算等。
+    所有运行期硬约束（守卫）均在代码层强制，配置仅提供默认值与调优旋钮。
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="NE_ROUTINE_",
+        env_nested_delimiter="__",
+        extra="ignore",
+        frozen=True,
+    )
+
+    enabled: bool = Field(
+        default=False,
+        description="是否启用 Routine 编排循环（默认关闭，灰度开启）。关闭时 inspector handler 直接 no-op。",
+    )
+    inspector_interval_seconds: int = Field(
+        default=25, ge=5, le=600, description="routine_inspector 心跳 tick 间隔（秒）"
+    )
+    max_concurrent_executions: int = Field(
+        default=2, ge=1, le=32, description="全局并发 Claude Code 执行上限（进程内信号量）"
+    )
+    lease_slack_seconds: int = Field(
+        default=60, ge=10, description="Runner lease 宽裕量：lease = 执行超时 + 此值，用于崩溃恢复 reaper 判定"
+    )
+    gate_timeout_seconds: int = Field(default=120, ge=10, description="verification_command 命令门控执行超时（秒）")
+    max_reflections_injected: int = Field(
+        default=5, ge=1, le=50, description="注入下一次迭代 prompt 的最近反思条数（Reflexion 窗口）"
+    )
+    eval_failure_patience: int = Field(
+        default=3, ge=1, description="评估器连续失败容忍次数，超过则终止 routine 为 unrecoverable_error"
+    )
+    default_max_iterations: int = Field(
+        default=20, ge=1, description="创建 routine 时 max_iterations 的默认值（硬上限守卫）"
+    )
+    default_max_cost_usd: float = Field(
+        default=5.0, ge=0.0, description="创建 routine 时 max_cost_usd 的默认值（成本熔断守卫）"
+    )
+    evaluator_model: str | None = Field(
+        default=None,
+        description="评估器 LLM-as-Judge 模型覆盖；为空时走 task_registry 的 routine.evaluate 解析",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        from ._base import YamlDictSource, get_yaml_section
+
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            YamlDictSource(settings_cls, get_yaml_section("routine")),
+            file_secret_settings,
+        )
+
+
+__all__ = ["RoutineSettings"]

--- a/apps/negentropy/src/negentropy/config/task_registry.py
+++ b/apps/negentropy/src/negentropy/config/task_registry.py
@@ -100,6 +100,15 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         category="Session",
         description="为新会话生成简短的标题。",
     ),
+    # --- Routine (global) ---
+    TaskSlot(
+        task_key="routine.evaluate",
+        model_type="llm",
+        scope="global",
+        label="Routine 结果评估",
+        category="Routine",
+        description="LLM-as-Judge 按验收标准为 Routine 迭代结果评分并生成反思反馈。",
+    ),
     # --- Knowledge Graph (corpus) ---
     TaskSlot(
         task_key="knowledge.kg.extraction.entity",

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0048_routine_tables.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0048_routine_tables.py
@@ -1,0 +1,228 @@
+"""创建 Routine 长周期自主任务表 + 种子 routine_inspector 心跳任务。
+
+Revision ID: 0048
+Revises: 0047
+Create Date: 2026-05-30 00:00:00.000000+00:00
+
+设计动机：
+    落地「持续自迭代自主决策任务执行」能力（Evaluator-Optimizer + Reflexion 闭环）。
+
+      1. ``routines``：长周期自主任务注册源（goal / acceptance_criteria / 预算守卫 /
+         生命周期状态机 / Reflexion 反思记忆）。表结构由 ORM 模型 ``models.routine.Routine``
+         镜像，避免 autogenerate 漂移。
+      2. ``routine_iterations``：单次 Execute→Evaluate→Decide 周期事实表，含执行结果
+         （Claude Code summary/session_id/cost）与评估结果（score/verdict/reflection）。
+      3. 种子 1 条 ``routine_inspector`` ScheduledTask（interval=25s）作为编排心跳，
+         由统一调度引擎 tick 驱动 ``RoutineOrchestrator.inspect_once()``。
+         INSERT ... ON CONFLICT (key) DO NOTHING 幂等。
+
+幂等性：
+    建表前以 information_schema 探测存在性（仿 0044），便于半失败重试。
+
+参考文献：
+[1] 0044_create_consolidation_jobs.py — information_schema 幂等建表范式。
+[2] 0046_seed_default_scheduled_tasks.py — ScheduledTask 幂等 seed 范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0048"
+down_revision: str | None = "0047"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+SCHEDULED_TASKS = f"{SCHEMA}.scheduled_tasks"
+
+# 种子 inspector 心跳任务的 key，供 DELETE 保护与 downgrade 使用。
+INSPECTOR_KEY = "routine_inspector"
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(f"SELECT 1 FROM information_schema.tables WHERE table_schema = '{SCHEMA}' AND table_name = :t"),
+            {"t": table_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # --- 1. routines ---
+    if not _table_exists(bind, "routines"):
+        op.create_table(
+            "routines",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column("key", sa.String(length=192), nullable=False, unique=True),
+            sa.Column("owner_id", sa.String(length=255), nullable=True),
+            sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+            sa.Column("title", sa.String(length=255), nullable=False),
+            sa.Column("display_name", sa.String(length=255), nullable=True),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("goal", sa.Text(), nullable=False),
+            sa.Column("acceptance_criteria", sa.Text(), nullable=False),
+            sa.Column("cwd", sa.Text(), nullable=True),
+            sa.Column("verification_command", sa.Text(), nullable=True),
+            sa.Column(
+                "status",
+                sa.String(length=24),
+                nullable=False,
+                server_default=sa.text("'pending'"),
+                comment="pending|running|paused|succeeded|failed|cancelled",
+            ),
+            sa.Column(
+                "termination_reason",
+                sa.String(length=48),
+                nullable=True,
+                comment="success|max_iterations|max_cost|deadline|no_progress|oscillation|unrecoverable_error|user_cancelled",
+            ),
+            sa.Column("max_iterations", sa.Integer(), nullable=True),
+            sa.Column("max_cost_usd", sa.Float(), nullable=True),
+            sa.Column("deadline_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("success_score_threshold", sa.Integer(), nullable=False, server_default=sa.text("85")),
+            sa.Column("no_progress_patience", sa.Integer(), nullable=False, server_default=sa.text("3")),
+            sa.Column(
+                "approval_mode",
+                sa.String(length=16),
+                nullable=False,
+                server_default=sa.text("'auto'"),
+                comment="auto|first|every — 迭代执行前的人工审批级别",
+            ),
+            sa.Column("iteration_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("total_cost_usd", sa.Float(), nullable=False, server_default=sa.text("0")),
+            sa.Column("best_score", sa.Integer(), nullable=True),
+            sa.Column("last_score", sa.Integer(), nullable=True),
+            sa.Column("claude_session_id", sa.String(length=128), nullable=True),
+            sa.Column("reflections", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("config", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            schema=SCHEMA,
+        )
+        op.create_index("ix_routines_status", "routines", ["status"], schema=SCHEMA)
+        op.create_index("ix_routines_owner", "routines", ["owner_id"], schema=SCHEMA)
+
+    # --- 2. routine_iterations ---
+    if not _table_exists(bind, "routine_iterations"):
+        op.create_table(
+            "routine_iterations",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "routine_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey(f"{SCHEMA}.routines.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("seq", sa.Integer(), nullable=False),
+            sa.Column(
+                "status",
+                sa.String(length=24),
+                nullable=False,
+                server_default=sa.text("'dispatched'"),
+                comment="pending_approval|dispatched|in_flight|executed|evaluated|reaped|aborted",
+            ),
+            sa.Column("prompt", sa.Text(), nullable=True),
+            sa.Column("resume_session_id", sa.String(length=128), nullable=True),
+            sa.Column("exec_status", sa.String(length=16), nullable=True),
+            sa.Column("summary", sa.Text(), nullable=True),
+            sa.Column("claude_session_id", sa.String(length=128), nullable=True),
+            sa.Column("cost_usd", sa.Float(), nullable=False, server_default=sa.text("0")),
+            sa.Column("turn_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column("exec_error", sa.Text(), nullable=True),
+            sa.Column("score", sa.Integer(), nullable=True),
+            sa.Column(
+                "verdict",
+                sa.String(length=24),
+                nullable=True,
+                comment="pass|progressing|stalled|regressed|unrecoverable",
+            ),
+            sa.Column("reflection", sa.Text(), nullable=True),
+            sa.Column("eval_error", sa.Text(), nullable=True),
+            sa.Column("gate_exit_code", sa.Integer(), nullable=True),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("metrics", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.UniqueConstraint("routine_id", "seq", name="uq_routine_iterations_seq"),
+            schema=SCHEMA,
+        )
+        op.create_index(
+            "ix_routine_iterations_routine_seq",
+            "routine_iterations",
+            ["routine_id", "seq"],
+            schema=SCHEMA,
+        )
+        op.create_index(
+            "ix_routine_iterations_lease",
+            "routine_iterations",
+            ["status", "lease_expires_at"],
+            schema=SCHEMA,
+        )
+
+    # --- 3. 种子 routine_inspector 心跳任务（幂等）---
+    op.execute(
+        sa.text(
+            f"""
+            INSERT INTO {SCHEDULED_TASKS}
+                (key, handler_kind, trigger_type, interval_seconds, cron_expr,
+                 role, scenario, category, display_name, description,
+                 payload, max_concurrency, token_budget, enabled, is_system, next_fire_at)
+            VALUES
+                (:key, :handler_kind, :trigger_type, :interval_seconds, :cron_expr,
+                 :role, :scenario, :category, :display_name, :description,
+                 :payload, :max_concurrency, :token_budget, :enabled, :is_system, NOW())
+            ON CONFLICT (key) DO NOTHING
+            """
+        ).bindparams(
+            sa.bindparam("key", value=INSPECTOR_KEY),
+            sa.bindparam("handler_kind", value="routine_inspector"),
+            sa.bindparam("trigger_type", value="interval"),
+            sa.bindparam("interval_seconds", value=25.0),
+            sa.bindparam("cron_expr", value=None),
+            sa.bindparam("role", value="supervisor"),
+            sa.bindparam("scenario", value="routine_orchestration"),
+            sa.bindparam("category", value="cognitive"),
+            sa.bindparam("display_name", value="Routine Inspector"),
+            sa.bindparam("description", value="巡检活跃 Routine，驱动评估-决策-调度闭环"),
+            sa.bindparam("payload", value={}, type_=postgresql.JSONB),
+            sa.bindparam("max_concurrency", value=1),
+            sa.bindparam("token_budget", value=None),
+            sa.bindparam("enabled", value=True),
+            sa.bindparam("is_system", value=True),
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    # 删除种子 inspector 任务（系统种子，downgrade 时清理）。
+    op.execute(
+        sa.text(f"DELETE FROM {SCHEDULED_TASKS} WHERE key = :key").bindparams(sa.bindparam("key", value=INSPECTOR_KEY))
+    )
+
+    if _table_exists(bind, "routine_iterations"):
+        op.drop_index("ix_routine_iterations_lease", table_name="routine_iterations", schema=SCHEMA)
+        op.drop_index("ix_routine_iterations_routine_seq", table_name="routine_iterations", schema=SCHEMA)
+        op.drop_table("routine_iterations", schema=SCHEMA)
+
+    if _table_exists(bind, "routines"):
+        op.drop_index("ix_routines_owner", table_name="routines", schema=SCHEMA)
+        op.drop_index("ix_routines_status", table_name="routines", schema=SCHEMA)
+        op.drop_table("routines", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -274,6 +274,15 @@ async def _negentropy_lifespan(app):
                 logger.info("unified_scheduler_stopped_via_lifespan")
             except Exception as exc:
                 logger.warning("unified_scheduler_stop_failed", error=str(exc))
+        # Routine 编排：中止在途 Claude Code 执行并收敛后台 Runner（仅启用时存在单例）
+        try:
+            from negentropy.engine.routine.orchestrator import _GLOBAL_ORCHESTRATOR
+
+            if _GLOBAL_ORCHESTRATOR is not None:
+                await _GLOBAL_ORCHESTRATOR.aclose(timeout=_NEGENTROPY_LIFESPAN_TIMEOUT_REGISTRY)
+                logger.info("routine_orchestrator_stopped_via_lifespan")
+        except Exception as exc:
+            logger.warning("routine_orchestrator_stop_failed", error=str(exc))
         try:
             from negentropy.engine.lifecycle import dispose_all
 
@@ -408,6 +417,7 @@ def apply_adk_patches():
         from negentropy.engine.sessions_api import router as sessions_router
         from negentropy.interface.api import router as interface_router
         from negentropy.interface.models_api import router as interface_models_router
+        from negentropy.interface.routine_api import router as interface_routine_router
         from negentropy.interface.scheduler_api import router as interface_scheduler_router
         from negentropy.interface.task_models_api import corpus_router as interface_task_models_corpus_router
         from negentropy.interface.task_models_api import router as interface_task_models_router
@@ -551,6 +561,9 @@ def apply_adk_patches():
         if not any(route.path.startswith("/scheduler") for route in app.router.routes):
             app.include_router(interface_scheduler_router)
             logger.info("Scheduler API router mounted under /scheduler")
+        if not any(route.path.startswith("/routines") for route in app.router.routes):
+            app.include_router(interface_routine_router)
+            logger.info("Routine API router mounted under /routines")
         # Corpus 级 task-models 路由独立挂载（prefix=/knowledge/corpus/...），
         # 不与 /interface 共享 prefix，需判定挂载唯一性。
         if not any(

--- a/apps/negentropy/src/negentropy/engine/routine/__init__.py
+++ b/apps/negentropy/src/negentropy/engine/routine/__init__.py
@@ -1,0 +1,18 @@
+"""Routine 编排引擎 — 长周期自主任务的 Evaluator-Optimizer 闭环。
+
+模块职责（正交分解）：
+- ``decision``：纯函数守卫与决策逻辑（无 IO，可单元测试）。
+- ``prompt_builder``：构建含目标 + 验收标准 + 累积反思的执行 prompt（Reflexion 注入）。
+- ``runner``：进程内后台执行器注册表 + 全局并发信号量；非阻塞调用 ClaudeCodeService。
+- ``evaluator``：LLM-as-Judge + 可选命令门控，产出 score / verdict / reflection。
+- ``bus``：RoutineBus，SSE 事件 fan-out（复用 ExecutionBus 范式）。
+- ``orchestrator``：RoutineOrchestrator.inspect_once() 主控制循环（reap → eval → dispatch）。
+
+设计取舍见 ``docs/concepts/039-the-routine-system.md``。
+"""
+
+from __future__ import annotations
+
+from .orchestrator import RoutineOrchestrator, get_orchestrator
+
+__all__ = ["RoutineOrchestrator", "get_orchestrator"]

--- a/apps/negentropy/src/negentropy/engine/routine/bus.py
+++ b/apps/negentropy/src/negentropy/engine/routine/bus.py
@@ -1,0 +1,79 @@
+"""RoutineBus — 进程内事件 fan-out，供 ``/routines/stream`` SSE 端点消费。
+
+复用 ``ScheduledTaskRegistry.ExecutionBus`` 的 asyncio.Queue 广播范式：每个 SSE 连接
+``subscribe()`` 获得独立队列，``publish()`` 同时压入所有队列；队列满则丢弃最旧事件。
+
+事件形态：``{"type": "routine"|"iteration", ...payload}``。
+- ``routine``：routine 状态变更（status / best_score / total_cost_usd 等）。
+- ``iteration``：迭代生命周期（dispatched / in_flight / executed / evaluated）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Any
+
+
+class RoutineBus:
+    """asyncio.Queue fan-out 总线（进程内单例，懒创建于运行 loop）。"""
+
+    def __init__(self, max_buffer_per_subscriber: int = 64) -> None:
+        self._subs: list[asyncio.Queue[dict[str, Any]]] = []
+        self._max = max_buffer_per_subscriber
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
+        async with self._lock:
+            q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=self._max)
+            self._subs.append(q)
+            return q
+
+    async def unsubscribe(self, q: asyncio.Queue[dict[str, Any]]) -> None:
+        async with self._lock:
+            with suppress(ValueError):
+                self._subs.remove(q)
+
+    async def publish(self, event: dict[str, Any]) -> None:
+        for q in list(self._subs):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                with suppress(asyncio.QueueEmpty):
+                    q.get_nowait()
+                with suppress(asyncio.QueueFull):
+                    q.put_nowait(event)
+
+    def publish_nowait(self, event: dict[str, Any]) -> None:
+        """同步 fire-and-forget publish（供非 async 上下文 / 不便 await 时使用）。"""
+        for q in list(self._subs):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                with suppress(asyncio.QueueEmpty):
+                    q.get_nowait()
+                with suppress(asyncio.QueueFull):
+                    q.put_nowait(event)
+
+    async def close_all_subscribers(self) -> None:
+        """向所有订阅者投递关停哨兵 + 清空订阅表（SSE 端点据此收尾）。"""
+        async with self._lock:
+            for q in list(self._subs):
+                with suppress(asyncio.QueueFull):
+                    q.put_nowait({"__shutdown__": True})
+            self._subs.clear()
+
+
+# 进程内单例
+_GLOBAL_BUS: RoutineBus | None = None
+
+
+def get_bus() -> RoutineBus:
+    """获取进程内 RoutineBus 单例（懒创建）。"""
+    global _GLOBAL_BUS
+    if _GLOBAL_BUS is None:
+        _GLOBAL_BUS = RoutineBus()
+    return _GLOBAL_BUS
+
+
+__all__ = ["RoutineBus", "get_bus"]

--- a/apps/negentropy/src/negentropy/engine/routine/decision.py
+++ b/apps/negentropy/src/negentropy/engine/routine/decision.py
@@ -152,9 +152,10 @@ def _consecutive_exec_failures(history: list[_IterationLike]) -> int:
 
 
 def _is_no_progress(routine: _RoutineLike, history: list[_IterationLike]) -> bool:
-    """最近 ``no_progress_patience`` 次评分均 ≤ 历史最优分则视为停滞。
+    """最近 ``no_progress_patience`` 次评分无一超过「窗口之前」的历史最优则视为停滞。
 
-    需至少累积 patience 次有效评分；不足时不触发（给探索留出空间）。
+    基线取最近窗口之前的迭代最优分（``routine.best_score`` 含窗口自身，直接比较会恒真）；
+    需窗口之前另有评分历史方可能触发，不足时不判停滞（给探索留出空间）。
     """
     patience = routine.no_progress_patience
     if patience <= 0:
@@ -162,12 +163,12 @@ def _is_no_progress(routine: _RoutineLike, history: list[_IterationLike]) -> boo
     scored = [it for it in history if it.score is not None]
     if len(scored) < patience:
         return False
-    best = routine.best_score
+    # 基线 = 最近窗口之前的迭代最优分；窗口内若创出新高即视为有进展。
+    best = max((it.score for it in scored[:-patience]), default=None)
     if best is None:
-        return False
+        return False  # 窗口前无评分历史 → 不判停滞
     recent = scored[-patience:]
-    # 最近 patience 次没有任何一次严格超过历史最优 → 停滞
-    return all(it.score < best or it.score == best for it in recent) and all(it.score <= best for it in recent)
+    return all(it.score <= best for it in recent)
 
 
 def _is_oscillating(history: list[_IterationLike]) -> bool:

--- a/apps/negentropy/src/negentropy/engine/routine/decision.py
+++ b/apps/negentropy/src/negentropy/engine/routine/decision.py
@@ -1,0 +1,203 @@
+"""Routine 决策守卫 — 纯函数，无 IO，可独立单元测试。
+
+将「何时终止 / 何时继续」的全部判定逻辑收敛于此，与编排副作用（DB / Claude Code 调用）
+正交解耦。守卫均为硬编码上限（非模型自律），对齐业界对自主循环失控的防护共识
+（OpenHands MAX_ITERATIONS；Claude Code --max-turns/--max-budget-usd；$47k agent loop 教训）。
+
+参考文献：
+[1] Anthropic, *Building Effective AI Agents*, 2024. "include stopping conditions
+    (such as a maximum number of iterations) to maintain control."
+[2] N. Shinn et al., "Reflexion," NeurIPS, 2023. 进度停滞 / 振荡的反思驱动终止。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+
+class _RoutineLike(Protocol):
+    """决策所需的 Routine 只读视图（避免与 ORM 强耦合，便于测试注入）。"""
+
+    status: str
+    max_iterations: int | None
+    max_cost_usd: float | None
+    deadline_at: datetime | None
+    success_score_threshold: int
+    no_progress_patience: int
+    iteration_count: int
+    total_cost_usd: float
+    best_score: int | None
+
+
+class _IterationLike(Protocol):
+    """决策所需的迭代只读视图。"""
+
+    seq: int
+    exec_status: str | None
+    score: int | None
+    verdict: str | None
+    gate_exit_code: int | None
+
+
+# 终止原因常量（与 Routine.termination_reason 列约定一致）
+REASON_SUCCESS = "success"
+REASON_MAX_ITERATIONS = "max_iterations"
+REASON_MAX_COST = "max_cost"
+REASON_DEADLINE = "deadline"
+REASON_NO_PROGRESS = "no_progress"
+REASON_OSCILLATION = "oscillation"
+REASON_UNRECOVERABLE = "unrecoverable_error"
+
+# 连续执行/评估失败达到此次数判定为不可恢复
+_CONSECUTIVE_FAILURE_LIMIT = 3
+
+
+@dataclass(frozen=True, slots=True)
+class Decision:
+    """决策结果。``action ∈ {continue, terminate}``；terminate 时携带 reason。"""
+
+    action: str  # "continue" | "terminate"
+    reason: str | None = None
+
+    @property
+    def is_terminate(self) -> bool:
+        return self.action == "terminate"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def pre_dispatch_check(routine: _RoutineLike, *, now: datetime | None = None) -> Decision:
+    """派发新迭代前的预算守卫。
+
+    在创建下一个迭代之前调用：若任一硬上限已触达，返回 terminate 阻止继续派发。
+    """
+    now = now or _utcnow()
+
+    if routine.max_iterations is not None and routine.iteration_count >= routine.max_iterations:
+        return Decision("terminate", REASON_MAX_ITERATIONS)
+
+    if routine.max_cost_usd is not None and routine.total_cost_usd >= routine.max_cost_usd:
+        return Decision("terminate", REASON_MAX_COST)
+
+    if routine.deadline_at is not None:
+        deadline = routine.deadline_at
+        if deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=UTC)
+        if now >= deadline:
+            return Decision("terminate", REASON_DEADLINE)
+
+    return Decision("continue")
+
+
+def decide(
+    routine: _RoutineLike,
+    latest: _IterationLike,
+    history: list[_IterationLike],
+    *,
+    now: datetime | None = None,
+) -> Decision:
+    """评估后的核心决策：成功 / 终止 / 继续。
+
+    Args:
+        routine: 路由只读视图（已含本轮反规范化的 iteration_count / total_cost / best_score）。
+        latest: 刚完成评估的最新迭代。
+        history: 全部已评估迭代（按 seq 升序），用于停滞 / 振荡 / 连续失败判定。
+        now: 注入当前时间（测试用）。
+
+    Returns:
+        Decision。优先级：成功 > 不可恢复 > 预算/截止 > 停滞 > 振荡 > 继续。
+    """
+    now = now or _utcnow()
+
+    # 1) 成功：评分达标 AND（无门控 或 门控通过）
+    if latest.score is not None and latest.score >= routine.success_score_threshold:
+        if latest.gate_exit_code in (None, 0):
+            return Decision("terminate", REASON_SUCCESS)
+
+    # 2) 不可恢复：judge 显式判定 / 连续执行失败 / 连续评估失败
+    if latest.verdict == "unrecoverable":
+        return Decision("terminate", REASON_UNRECOVERABLE)
+    if _consecutive_exec_failures(history) >= _CONSECUTIVE_FAILURE_LIMIT:
+        return Decision("terminate", REASON_UNRECOVERABLE)
+
+    # 3) 预算 / 截止（评估后再查一次，确保本轮成本计入后即时熔断）
+    budget = pre_dispatch_check(routine, now=now)
+    if budget.is_terminate:
+        return budget
+
+    # 4) 进度停滞：最近 N 次评分均未超过历史最优
+    if _is_no_progress(routine, history):
+        return Decision("terminate", REASON_NO_PROGRESS)
+
+    # 5) 振荡：verdict 在 progressing/regressed 间反复横跳且分数无上升趋势
+    if _is_oscillating(history):
+        return Decision("terminate", REASON_OSCILLATION)
+
+    return Decision("continue")
+
+
+def _consecutive_exec_failures(history: list[_IterationLike]) -> int:
+    """从尾部起连续 ``exec_status ∈ {error, timeout}`` 的迭代数。"""
+    count = 0
+    for it in reversed(history):
+        if it.exec_status in ("error", "timeout"):
+            count += 1
+        else:
+            break
+    return count
+
+
+def _is_no_progress(routine: _RoutineLike, history: list[_IterationLike]) -> bool:
+    """最近 ``no_progress_patience`` 次评分均 ≤ 历史最优分则视为停滞。
+
+    需至少累积 patience 次有效评分；不足时不触发（给探索留出空间）。
+    """
+    patience = routine.no_progress_patience
+    if patience <= 0:
+        return False
+    scored = [it for it in history if it.score is not None]
+    if len(scored) < patience:
+        return False
+    best = routine.best_score
+    if best is None:
+        return False
+    recent = scored[-patience:]
+    # 最近 patience 次没有任何一次严格超过历史最优 → 停滞
+    return all(it.score < best or it.score == best for it in recent) and all(it.score <= best for it in recent)
+
+
+def _is_oscillating(history: list[_IterationLike]) -> bool:
+    """振荡判定：最近至少 4 次评分无净增长，且 verdict 在改善/退步间交替。"""
+    scored = [it for it in history if it.score is not None]
+    if len(scored) < 4:
+        return False
+    recent = scored[-4:]
+    scores = [it.score for it in recent]
+    # 净增长（末 - 首）非正，说明整体未推进
+    net_gain = scores[-1] - scores[0]
+    if net_gain > 0:
+        return False
+    verdicts = [it.verdict for it in recent if it.verdict in ("progressing", "regressed")]
+    if len(verdicts) < 3:
+        return False
+    # 存在方向反转（progressing↔regressed）
+    flips = sum(1 for a, b in zip(verdicts, verdicts[1:], strict=False) if a != b)
+    return flips >= 2
+
+
+__all__ = [
+    "Decision",
+    "pre_dispatch_check",
+    "decide",
+    "REASON_SUCCESS",
+    "REASON_MAX_ITERATIONS",
+    "REASON_MAX_COST",
+    "REASON_DEADLINE",
+    "REASON_NO_PROGRESS",
+    "REASON_OSCILLATION",
+    "REASON_UNRECOVERABLE",
+]

--- a/apps/negentropy/src/negentropy/engine/routine/evaluator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/evaluator.py
@@ -1,0 +1,244 @@
+"""Routine 评估器 — LLM-as-Judge + 可选命令门控（混合方案）。
+
+闭环中 Engine 担任 Evaluator：对 Claude Code 的阶段性产出，依据验收标准评分（0-100）、
+给出 verdict 与自然语言反思（reflection）。混合方案以客观命令门控
+（``verification_command`` 的退出码）锚定 LLM 评分，缓解 LLM-as-Judge 的已知偏差。
+
+LLM 调用路径复用 ``LLMFactExtractor`` 范式：``resolve_model_config_async`` 解析模型
++ ``litellm.acompletion`` 结构化 JSON 输出 + 指数退避重试。
+
+参考文献：
+[1] J. Gu et al., "A Survey on LLM-as-a-Judge," arXiv:2411.15594, 2024. 偏差与缓解。
+[2] OpenAI, *Codex: long-horizon tasks*, 2025. 测试驱动的自我校验（Plan→Edit→Test→Repair）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import litellm
+
+from negentropy.engine.utils.model_config import resolve_model_config_async
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.engine.routine.evaluator")
+
+_TASK_KEY = "routine.evaluate"
+_VALID_VERDICTS = {"pass", "progressing", "stalled", "regressed", "unrecoverable"}
+_SUMMARY_MAX_CHARS = 4000
+
+_JUDGE_PROMPT = """你是一名严格、客观的任务评审员。请根据「目标」与「验收标准」，评估执行者本轮产出的质量。
+
+# 目标
+{goal}
+
+# 验收标准
+{acceptance_criteria}
+
+# 执行者本轮产出摘要
+{summary}
+
+# 客观验证结果
+{gate_section}
+
+评审要求：
+1. score：0-100 的整数。验收标准全部满足≈90-100；主体完成有瑕疵≈70-89；部分推进≈40-69；几乎无进展≈0-39。
+2. 若「客观验证结果」显示命令失败（退出码非 0），score 不得高于 60。
+3. verdict 取值（仅一项）：
+   - pass：达到验收标准，可终止；
+   - progressing：较上轮有实质推进，应继续；
+   - stalled：基本无推进；
+   - regressed：较上轮退步；
+   - unrecoverable：存在无法通过继续迭代解决的根本障碍（如目标自相矛盾、缺失必要前提）。
+4. reflection：给执行者的具体、可操作改进建议（指出尚未满足的验收项与下一步动作），中文，≤200字。
+
+仅输出 JSON：
+{{"score": <int 0-100>, "verdict": "<pass|progressing|stalled|regressed|unrecoverable>", "reflection": "<改进建议>"}}"""
+
+
+class _RoutineLike(Protocol):
+    goal: str
+    acceptance_criteria: str
+    cwd: str | None
+    verification_command: str | None
+
+
+class _IterationLike(Protocol):
+    exec_status: str | None
+    summary: str | None
+    exec_error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationResult:
+    """评估产出。``ok=False`` 时表示评估自身失败（LLM 不可用等），上层据此重试/容忍。"""
+
+    ok: bool
+    score: int | None = None
+    verdict: str | None = None
+    reflection: str | None = None
+    gate_exit_code: int | None = None
+    error: str | None = None
+
+
+class RoutineEvaluator:
+    """Routine 迭代评估器：命令门控 + LLM-as-Judge。"""
+
+    def __init__(
+        self,
+        *,
+        explicit_model: str | None = None,
+        temperature: float = 0.0,
+        max_retries: int = 3,
+        gate_timeout_seconds: int = 120,
+    ) -> None:
+        self._explicit_model = explicit_model
+        self._temperature = temperature
+        self._max_retries = max_retries
+        self._gate_timeout_seconds = gate_timeout_seconds
+
+    async def evaluate(self, routine: _RoutineLike, iteration: _IterationLike) -> EvaluationResult:
+        """评估一次迭代产出，返回 score / verdict / reflection / gate_exit_code。
+
+        流程：先跑命令门控（若配置）→ 再调用 LLM Judge（门控结果作为锚点输入）。
+        LLM 失败重试耗尽 → 返回 ``ok=False``，由 orchestrator 据 eval_failure_patience 处理。
+        """
+        # 1) 命令门控（可选）
+        gate_exit_code: int | None = None
+        gate_output = ""
+        if routine.verification_command:
+            gate_exit_code, gate_output = await self._run_gate(routine.verification_command, routine.cwd)
+
+        # 2) LLM Judge
+        summary = (iteration.summary or "").strip()
+        if iteration.exec_status in ("error", "timeout"):
+            # 执行失败也要评估：把错误信息交给 judge，通常判 regressed/stalled
+            summary = (f"[执行 {iteration.exec_status}] {iteration.exec_error or ''}\n\n{summary}").strip()
+        summary = summary[:_SUMMARY_MAX_CHARS] or "(执行者未产出任何摘要)"
+
+        gate_section = self._format_gate(routine.verification_command, gate_exit_code, gate_output)
+
+        try:
+            score, verdict, reflection = await self._judge(
+                routine.goal, routine.acceptance_criteria, summary, gate_section
+            )
+        except Exception as exc:
+            logger.warning("routine_evaluate_judge_failed", error=str(exc))
+            return EvaluationResult(ok=False, gate_exit_code=gate_exit_code, error=str(exc))
+
+        return EvaluationResult(
+            ok=True,
+            score=score,
+            verdict=verdict,
+            reflection=reflection,
+            gate_exit_code=gate_exit_code,
+        )
+
+    async def _run_gate(self, command: str, cwd: str | None) -> tuple[int | None, str]:
+        """在 ``cwd`` 执行验证命令，返回 (exit_code, 截断输出)。超时/异常 → exit_code=None。
+
+        以 ``start_new_session=True`` 起独立进程组，超时时整组 SIGKILL，避免 pytest 等
+        fork 出的子进程在 shell 被杀后变成孤儿泄漏。
+        """
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                cwd=cwd or None,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=self._gate_timeout_seconds)
+            except TimeoutError:
+                self._kill_process_group(proc)
+                with suppress(Exception):
+                    await proc.communicate()
+                logger.warning("routine_gate_timeout", command=command[:120])
+                return None, f"(命令执行超时 {self._gate_timeout_seconds}s)"
+            output = (stdout or b"").decode("utf-8", errors="replace")[-2000:]
+            return proc.returncode, output
+        except Exception as exc:
+            logger.warning("routine_gate_failed", command=command[:120], error=str(exc))
+            return None, f"(命令执行异常: {exc})"
+
+    @staticmethod
+    def _kill_process_group(proc) -> None:
+        """杀掉子进程所在进程组；失败则降级单进程 kill。"""
+        import os
+        import signal
+
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            with suppress(Exception):
+                proc.kill()
+
+    @staticmethod
+    def _format_gate(command: str | None, exit_code: int | None, output: str) -> str:
+        if not command:
+            return "（本任务未配置客观验证命令）"
+        status = "通过 (exit 0)" if exit_code == 0 else f"失败 (exit {exit_code})"
+        tail = output.strip()[-1000:]
+        return f"命令 `{command}` 执行结果：{status}\n输出尾部：\n{tail}"
+
+    async def _judge(
+        self, goal: str, acceptance_criteria: str, summary: str, gate_section: str
+    ) -> tuple[int, str, str]:
+        """调用 LLM 评审，解析结构化 JSON；含指数退避重试。"""
+        model, model_kwargs = await resolve_model_config_async(_TASK_KEY, explicit_model=self._explicit_model)
+        prompt = _JUDGE_PROMPT.format(
+            goal=goal,
+            acceptance_criteria=acceptance_criteria,
+            summary=summary,
+            gate_section=gate_section,
+        )
+        safe_kwargs = {
+            k: v for k, v in model_kwargs.items() if k not in ("model", "messages", "temperature", "response_format")
+        }
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                response = await litellm.acompletion(
+                    model=model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=self._temperature,
+                    response_format={"type": "json_object"},
+                    **safe_kwargs,
+                )
+                content = response.choices[0].message.content
+                return self._parse(content)
+            except Exception as exc:
+                last_error = exc
+                logger.warning("routine_judge_retry", attempt=attempt + 1, error=str(exc))
+                await asyncio.sleep(2**attempt)
+
+        raise RuntimeError(f"LLM judge failed after {self._max_retries} retries: {last_error}")
+
+    @staticmethod
+    def _parse(content: str | None) -> tuple[int, str, str]:
+        """解析 judge JSON，做边界裁剪与字段校验。"""
+        data: dict[str, Any] = json.loads(content or "{}")
+
+        raw_score = data.get("score", 0)
+        try:
+            score = int(round(float(raw_score)))
+        except (TypeError, ValueError):
+            score = 0
+        score = max(0, min(100, score))
+
+        verdict = str(data.get("verdict", "")).strip().lower()
+        if verdict not in _VALID_VERDICTS:
+            # 依据分数兜底推断 verdict，保证决策层有合法输入
+            verdict = "progressing" if score >= 40 else "stalled"
+
+        reflection = str(data.get("reflection", "")).strip()
+        return score, verdict, reflection
+
+
+__all__ = ["RoutineEvaluator", "EvaluationResult"]

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -1,0 +1,484 @@
+"""RoutineOrchestrator — 长周期自主任务的主控制循环（Orchestrator + Evaluator）。
+
+``inspect_once()`` 由 ``routine_inspector`` Scheduler 心跳每 tick 调用一次，执行三阶段：
+
+  (a) REAP   — 清理崩溃遗留的孤儿在途迭代（lease 过期 + 本进程不再持有）。
+  (b) EVAL   — 对已执行完毕的迭代评估 + 决策（成功/终止/继续）。
+  (c) DISPATCH — 为运行中且预算未耗尽的 routine 派发下一迭代（后台 Runner 异步执行）。
+
+设计要点：
+- tick 轻量：阶段 (c) 仅创建迭代行 + 调用 ``runner.launch``（非阻塞），绝不内联等待
+  Claude Code，确保心跳 handler 远低于其 60s 超时。
+- 并发幂等：``FOR UPDATE SKIP LOCKED`` 抢占 routine 行 + 每 routine 单在途 +
+  ``uq_routine_iterations_seq`` 唯一约束三重兜底。
+- Human-in-the-Loop：``approval_mode`` 决定新迭代以 dispatched（自动）还是
+  pending_approval（待审批）创建；后者不会被 launch，等待 API approve。
+
+参考文献：
+[1] Anthropic, *Building Effective AI Agents*, 2024. Evaluator-Optimizer / Orchestrator-Workers。
+[2] PostgreSQL Docs, *FOR UPDATE SKIP LOCKED*. 并发 tick 幂等。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import negentropy.db.session as db_session
+from negentropy.config import settings
+from negentropy.logging import get_logger
+from negentropy.models.routine import Routine, RoutineIteration
+
+from . import decision as decision_mod
+from .bus import get_bus
+from .evaluator import RoutineEvaluator
+from .prompt_builder import append_reflection, build_prompt
+from .runner import get_runner
+
+logger = get_logger("negentropy.engine.routine.orchestrator")
+
+# 非终态迭代状态（一个 routine 同时至多存在一个）
+_NON_TERMINAL_ITER = ("pending_approval", "dispatched", "in_flight", "executed")
+# 每 tick 评估/派发的 routine 批量上限，避免单 tick 过载
+_BATCH_LIMIT = 10
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _lease_extension() -> timedelta:
+    """本进程仍在执行时的 lease 顺延量（= inspector 间隔 + slack）。"""
+    return timedelta(seconds=settings.routine.inspector_interval_seconds + settings.routine.lease_slack_seconds)
+
+
+class RoutineOrchestrator:
+    """Routine 编排器（进程内单例）。"""
+
+    def __init__(self) -> None:
+        self._evaluator = RoutineEvaluator(
+            explicit_model=settings.routine.evaluator_model,
+            gate_timeout_seconds=settings.routine.gate_timeout_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # 主入口
+    # ------------------------------------------------------------------
+    async def inspect_once(self) -> dict[str, int]:
+        """单次巡检：reap → evaluate → dispatch。返回各阶段计数（供 handler 汇报）。"""
+        reaped = await self._reap_orphans()
+        evaluated = await self._evaluate_and_decide()
+        launched = await self._dispatch_due()
+        return {"reaped": reaped, "evaluated": evaluated, "launched": launched}
+
+    # ------------------------------------------------------------------
+    # (a) REAP
+    # ------------------------------------------------------------------
+    async def _reap_orphans(self) -> int:
+        """回收孤儿在途迭代：lease 过期且本进程 Runner 不再持有 → 标记 reaped。"""
+        runner = get_runner()
+        now = _utcnow()
+        reaped = 0
+        async with db_session.AsyncSessionLocal() as db:
+            rows = (
+                (
+                    await db.execute(
+                        select(RoutineIteration)
+                        .where(
+                            RoutineIteration.status == "in_flight",
+                            RoutineIteration.lease_expires_at.is_not(None),
+                            RoutineIteration.lease_expires_at < now,
+                        )
+                        .limit(_BATCH_LIMIT)
+                        .with_for_update(skip_locked=True)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for it in rows:
+                if runner.is_running(it.id):
+                    # 本进程仍在执行（lease 偏短）→ 顺延 lease，不回收
+                    it.lease_expires_at = now + _lease_extension()
+                    continue
+                it.status = "reaped"
+                it.finished_at = now
+                it.lease_expires_at = None
+                it.exec_error = it.exec_error or "reaped: lease expired (process restart or hang)"
+                reaped += 1
+            await db.commit()
+        if reaped:
+            logger.info("routine_reaped_orphans", count=reaped)
+        return reaped
+
+    # ------------------------------------------------------------------
+    # (b) EVALUATE + DECIDE
+    # ------------------------------------------------------------------
+    async def _evaluate_and_decide(self) -> int:
+        """对最新迭代处于 executed 的 routine 评估 + 决策。"""
+        async with db_session.AsyncSessionLocal() as db:
+            routine_ids = await self._find_routines_pending_eval(db)
+
+        evaluated = 0
+        for routine_id in routine_ids[:_BATCH_LIMIT]:
+            try:
+                if await self._evaluate_one(routine_id):
+                    evaluated += 1
+            except Exception as exc:  # 单 routine 失败不阻断整体巡检
+                logger.warning("routine_evaluate_one_failed", routine_id=str(routine_id), error=str(exc))
+        return evaluated
+
+    async def _find_routines_pending_eval(self, db: AsyncSession) -> list[UUID]:
+        """找出「最新迭代为 executed」的运行中 routine。"""
+        # 取每个 running routine 的最大 seq 迭代，过滤 status='executed'
+        subq = (
+            select(
+                RoutineIteration.routine_id,
+                RoutineIteration.status,
+                RoutineIteration.seq,
+            )
+            .order_by(RoutineIteration.routine_id, RoutineIteration.seq.desc())
+            .distinct(RoutineIteration.routine_id)
+        ).subquery()
+        rows = (
+            await db.execute(
+                select(subq.c.routine_id)
+                .join(Routine, Routine.id == subq.c.routine_id)
+                .where(Routine.status == "running", subq.c.status == "executed")
+            )
+        ).all()
+        return [r[0] for r in rows]
+
+    async def _evaluate_one(self, routine_id: UUID) -> bool:
+        """评估单个 routine 的最新 executed 迭代并据决策推进状态机。"""
+        async with db_session.AsyncSessionLocal() as db:
+            routine = await db.get(Routine, routine_id, with_for_update=True)
+            if routine is None or routine.status != "running":
+                return False
+            latest = await self._latest_iteration(db, routine_id)
+            if latest is None or latest.status != "executed":
+                return False
+
+            result = await self._evaluator.evaluate(routine, latest)
+
+            if not result.ok:
+                # 评估失败：记录 + 计数；超过容忍阈值终止
+                attempts = int((latest.metrics or {}).get("eval_attempts", 0)) + 1
+                latest.eval_error = result.error
+                latest.metrics = {**(latest.metrics or {}), "eval_attempts": attempts}
+                if attempts >= settings.routine.eval_failure_patience:
+                    self._terminate(routine, decision_mod.REASON_UNRECOVERABLE)
+                    latest.status = "evaluated"
+                    latest.verdict = "unrecoverable"
+                await db.commit()
+                await self._publish_routine(routine)
+                return False
+
+            # 写入评估结果
+            latest.score = result.score
+            latest.verdict = result.verdict
+            latest.reflection = result.reflection
+            latest.gate_exit_code = result.gate_exit_code
+            latest.status = "evaluated"
+
+            # 更新 routine 反规范化评分 + 追加反思
+            routine.last_score = result.score
+            if result.score is not None:
+                routine.best_score = (
+                    result.score if routine.best_score is None else max(routine.best_score, result.score)
+                )
+            if result.reflection:
+                routine.reflections = append_reflection(routine.reflections, result.reflection)
+
+            # 决策
+            history = await self._evaluated_history(db, routine_id)
+            verdict = decision_mod.decide(routine, latest, history)
+            if verdict.is_terminate:
+                self._terminate(routine, verdict.reason or decision_mod.REASON_SUCCESS)
+
+            await db.commit()
+            await self._publish_routine(routine)
+            await get_bus().publish(
+                {
+                    "type": "iteration",
+                    "id": str(latest.id),
+                    "routine_id": str(routine_id),
+                    "status": "evaluated",
+                    "score": result.score,
+                    "verdict": result.verdict,
+                }
+            )
+            return True
+
+    # ------------------------------------------------------------------
+    # (c) DISPATCH
+    # ------------------------------------------------------------------
+    async def _dispatch_due(self) -> int:
+        """为运行中、无在途迭代、预算未耗尽的 routine 派发下一迭代。
+
+        同时承担「派发用户已 approve 的待执行迭代」（approval_mode 门控）。
+        """
+        runner = get_runner()
+        launched = 0
+
+        # 先处理已 approve 待 launch 的迭代（dispatched 但 runner 未持有）
+        launched += await self._launch_approved(runner)
+
+        if not runner.has_capacity():
+            return launched
+
+        # 先在事务内创建迭代行并提交，再 launch（commit-before-launch）：
+        # 避免「runner 已启动但 commit 回滚」导致后台任务对不存在的迭代行 UPDATE 0 行、
+        # 却仍消耗一次 Claude Code 执行并累加成本的 phantom-row 问题。
+        launch_specs: list[tuple] = []
+        async with db_session.AsyncSessionLocal() as db:
+            routines = (
+                (
+                    await db.execute(
+                        select(Routine)
+                        .where(Routine.status == "running")
+                        .order_by(Routine.updated_at.asc())
+                        .limit(_BATCH_LIMIT)
+                        .with_for_update(skip_locked=True)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            slots = runner.available_slots()
+            for routine in routines:
+                if slots <= 0:
+                    break
+                # 已有非终态迭代 → 跳过（每 routine 单在途）
+                if await self._has_active_iteration(db, routine.id):
+                    continue
+                # 预算预检
+                budget = decision_mod.pre_dispatch_check(routine)
+                if budget.is_terminate:
+                    self._terminate(routine, budget.reason or decision_mod.REASON_MAX_ITERATIONS)
+                    await self._publish_routine(routine)
+                    continue
+
+                # seq 从实际最大值派生（非 iteration_count），避免 aborted/reaped 迭代
+                # 占用的 seq 与新迭代冲突触发 uq_routine_iterations_seq。
+                seq = await self._next_seq(db, routine.id)
+                prompt = build_prompt(routine, max_reflections=settings.routine.max_reflections_injected)
+                needs_approval = self._needs_approval(routine.approval_mode, seq)
+                iteration = RoutineIteration(
+                    routine_id=routine.id,
+                    seq=seq,
+                    status="pending_approval" if needs_approval else "dispatched",
+                    prompt=prompt,
+                    resume_session_id=routine.claude_session_id,
+                )
+                db.add(iteration)
+                await db.flush()  # 取 iteration.id
+
+                await self._publish_iteration_created(routine.id, iteration)
+
+                if not needs_approval:
+                    config = await self._build_config(routine)
+                    launch_specs.append((iteration.id, routine.id, prompt, config))
+                    slots -= 1
+
+            await db.commit()
+
+        # commit 成功后再 launch 后台执行
+        for iteration_id, routine_id, prompt, config in launch_specs:
+            runner.launch(iteration_id=iteration_id, routine_id=routine_id, prompt=prompt, config=config)
+            launched += 1
+        return launched
+
+    async def _launch_approved(self, runner) -> int:
+        """启动用户已 approve（dispatched 且本进程未持有）的迭代。"""
+        launch_specs: list[tuple] = []
+        async with db_session.AsyncSessionLocal() as db:
+            rows = (
+                (
+                    await db.execute(
+                        select(RoutineIteration)
+                        .join(Routine, Routine.id == RoutineIteration.routine_id)
+                        .where(
+                            RoutineIteration.status == "dispatched",
+                            RoutineIteration.started_at.is_(None),
+                            Routine.status == "running",
+                        )
+                        .limit(_BATCH_LIMIT)
+                        .with_for_update(skip_locked=True)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            slots = runner.available_slots()
+            for it in rows:
+                if slots <= 0:
+                    break
+                if runner.is_running(it.id):
+                    continue
+                routine = await db.get(Routine, it.routine_id)
+                if routine is None:
+                    continue
+                config = await self._build_config(routine)
+                prompt = it.prompt or build_prompt(routine)
+                launch_specs.append((it.id, routine.id, prompt, config))
+                slots -= 1
+
+        for iteration_id, routine_id, prompt, config in launch_specs:
+            runner.launch(iteration_id=iteration_id, routine_id=routine_id, prompt=prompt, config=config)
+        return len(launch_specs)
+
+    # ------------------------------------------------------------------
+    # 辅助
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _needs_approval(approval_mode: str, seq: int) -> bool:
+        if approval_mode == "every":
+            return True
+        if approval_mode == "first":
+            return seq == 1
+        return False  # auto
+
+    @staticmethod
+    def _terminate(routine: Routine, reason: str) -> None:
+        routine.status = "succeeded" if reason == decision_mod.REASON_SUCCESS else "failed"
+        routine.termination_reason = reason
+
+    async def _build_config(self, routine: Routine):
+        """构建本次执行的 ClaudeCodeConfig：全局默认 + routine 覆盖 + session 续接。"""
+        from negentropy.engine.schedulers.handlers.claude_code import _load_claude_code_defaults
+
+        config = await _load_claude_code_defaults()
+        overrides = routine.config or {}
+        if routine.cwd:
+            config.cwd = routine.cwd
+        if overrides.get("max_turns"):
+            config.max_turns = int(overrides["max_turns"])
+        if overrides.get("model"):
+            config.model = overrides["model"]
+        if overrides.get("system_prompt"):
+            config.system_prompt = overrides["system_prompt"]
+        if overrides.get("allowed_tools"):
+            config.allowed_tools = overrides["allowed_tools"]
+        if overrides.get("permission_mode"):
+            config.permission_mode = overrides["permission_mode"]
+        if overrides.get("timeout_seconds"):
+            config.timeout_seconds = float(overrides["timeout_seconds"])
+        config.resume_session_id = routine.claude_session_id
+        return config
+
+    @staticmethod
+    async def _next_seq(db: AsyncSession, routine_id: UUID) -> int:
+        """下一个迭代 seq = 当前最大 seq + 1（含所有终态迭代，避免 seq 复用冲突）。"""
+        max_seq = (
+            await db.execute(
+                select(func.coalesce(func.max(RoutineIteration.seq), 0)).where(
+                    RoutineIteration.routine_id == routine_id
+                )
+            )
+        ).scalar_one()
+        return int(max_seq) + 1
+
+    @staticmethod
+    async def _latest_iteration(db: AsyncSession, routine_id: UUID) -> RoutineIteration | None:
+        return (
+            await db.execute(
+                select(RoutineIteration)
+                .where(RoutineIteration.routine_id == routine_id)
+                .order_by(RoutineIteration.seq.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+    @staticmethod
+    async def _evaluated_history(db: AsyncSession, routine_id: UUID) -> list[RoutineIteration]:
+        return list(
+            (
+                await db.execute(
+                    select(RoutineIteration)
+                    .where(
+                        RoutineIteration.routine_id == routine_id,
+                        RoutineIteration.status == "evaluated",
+                    )
+                    .order_by(RoutineIteration.seq.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    @staticmethod
+    async def _has_active_iteration(db: AsyncSession, routine_id: UUID) -> bool:
+        row = (
+            await db.execute(
+                select(RoutineIteration.id)
+                .where(
+                    RoutineIteration.routine_id == routine_id,
+                    RoutineIteration.status.in_(_NON_TERMINAL_ITER),
+                )
+                .limit(1)
+            )
+        ).first()
+        return row is not None
+
+    @staticmethod
+    async def _publish_routine(routine: Routine) -> None:
+        await get_bus().publish(
+            {
+                "type": "routine",
+                "id": str(routine.id),
+                "status": routine.status,
+                "termination_reason": routine.termination_reason,
+                "best_score": routine.best_score,
+                "last_score": routine.last_score,
+                "iteration_count": routine.iteration_count,
+                "total_cost_usd": routine.total_cost_usd,
+            }
+        )
+
+    @staticmethod
+    async def _publish_iteration_created(routine_id: UUID, iteration: RoutineIteration) -> None:
+        await get_bus().publish(
+            {
+                "type": "iteration",
+                "id": str(iteration.id),
+                "routine_id": str(routine_id),
+                "status": iteration.status,
+                "seq": iteration.seq,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # 关停
+    # ------------------------------------------------------------------
+    async def aclose(self, *, timeout: float = 15.0) -> None:
+        """关停：中止全部在途迭代并等待后台任务收尾。"""
+        runner = get_runner()
+        for iteration_id in list(runner._runners.keys()):  # noqa: SLF001
+            runner.request_abort(iteration_id)
+        tasks = list(runner._runners.values())  # noqa: SLF001
+        if tasks:
+            with suppress(Exception):
+                await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout)
+        await get_bus().close_all_subscribers()
+
+
+# 进程内单例
+_GLOBAL_ORCHESTRATOR: RoutineOrchestrator | None = None
+
+
+def get_orchestrator() -> RoutineOrchestrator:
+    """获取进程内 RoutineOrchestrator 单例（懒创建）。"""
+    global _GLOBAL_ORCHESTRATOR
+    if _GLOBAL_ORCHESTRATOR is None:
+        _GLOBAL_ORCHESTRATOR = RoutineOrchestrator()
+    return _GLOBAL_ORCHESTRATOR
+
+
+__all__ = ["RoutineOrchestrator", "get_orchestrator"]

--- a/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
+++ b/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
@@ -1,0 +1,76 @@
+"""Routine prompt 构建 — 目标 + 验收标准 + 累积反思（Reflexion 注入）。
+
+闭环中 Executor（Claude Code）通过 ``resume_session_id`` 保有自身工作上下文；
+本模块注入的是 Evaluator 产出的「外部反馈」——历次迭代的反思，使下一次执行
+针对性地修正已知缺陷。这正是 Reflexion 的 episodic replay 机制。
+
+参考文献：
+[1] N. Shinn et al., "Reflexion: Language Agents with Verbal Reinforcement Learning,"
+    NeurIPS, 2023. arXiv:2303.11366.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class _RoutineLike(Protocol):
+    goal: str
+    acceptance_criteria: str
+    reflections: dict[str, Any]
+    claude_session_id: str | None
+
+
+def build_prompt(routine: _RoutineLike, *, max_reflections: int = 5) -> str:
+    """构建发送给 Claude Code 的迭代 prompt。
+
+    首次执行（无 session）注入目标 + 验收标准；续接执行额外注入最近 N 条反思
+    与「继续推进」指令。反思来自 ``routine.reflections["items"]``（追加顺序）。
+    """
+    is_resume = bool(routine.claude_session_id)
+
+    parts: list[str] = [
+        f"# 目标 (Goal)\n{routine.goal.strip()}",
+        f"# 验收标准 (Acceptance Criteria)\n{routine.acceptance_criteria.strip()}",
+    ]
+
+    reflections = _recent_reflections(routine, max_reflections)
+    if reflections:
+        bullet = "\n".join(f"- {r}" for r in reflections)
+        parts.append(
+            "# 既往迭代的反馈 (Feedback from previous attempts)\n"
+            "以下是对你此前尝试的评估反馈，请逐条针对性改进：\n" + bullet
+        )
+
+    if is_resume:
+        parts.append("# 继续 (Continue)\n请在既有会话上下文基础上继续推进，聚焦上述反馈中尚未满足的验收标准项。")
+    else:
+        parts.append("# 开始 (Start)\n请着手完成上述目标，确保产出可被验收标准客观检验。")
+
+    return "\n\n".join(parts)
+
+
+def _recent_reflections(routine: _RoutineLike, limit: int) -> list[str]:
+    """取最近 ``limit`` 条反思文本（顺序保持，旧→新）。"""
+    raw = (routine.reflections or {}).get("items", [])
+    if not isinstance(raw, list):
+        return []
+    items = [str(x).strip() for x in raw if str(x).strip()]
+    if limit > 0:
+        items = items[-limit:]
+    return items
+
+
+def append_reflection(reflections: dict[str, Any] | None, reflection: str) -> dict[str, Any]:
+    """向反思记忆追加一条；返回新 dict（不原地修改，便于 ORM 变更检测）。
+
+    JSONB 列原地 mutate 不会被 SQLAlchemy 标脏，故必须整体重赋值。
+    """
+    text = (reflection or "").strip()
+    existing = list((reflections or {}).get("items", []))
+    if text:
+        existing.append(text)
+    return {"items": existing}
+
+
+__all__ = ["build_prompt", "append_reflection"]

--- a/apps/negentropy/src/negentropy/engine/routine/runner.py
+++ b/apps/negentropy/src/negentropy/engine/routine/runner.py
@@ -1,0 +1,234 @@
+"""Routine 后台执行器 — 进程内 asyncio.Task 注册表 + 全局并发信号量。
+
+职责：把「长耗时的 Claude Code 调用」从 Inspector 心跳 tick 中剥离，作为后台任务运行，
+使心跳 tick 始终轻量快速。每个迭代一个 asyncio.Task，受全局信号量限流；任务完成时
+把执行结果原子写回 ``routine_iterations`` 并更新父 ``routines`` 的反规范化累计。
+
+崩溃恢复：迭代携带 ``lease_expires_at``（= 执行超时 + slack）。进程崩溃后本注册表清空，
+Orchestrator reaper 据 lease 过期 + 本注册表不再持有，将孤儿迭代标记 reaped 并重新派发。
+
+单一所有者假设（重要）：进程内 ``_runners`` dict 与信号量仅在本进程可见，故 Routine
+编排要求**单 engine 进程**持有（与 Scheduler Registry 同进程同 loop）。多进程部署下，
+B 进程的 reaper 可能误判 A 进程仍在执行的迭代为孤儿——``is_running`` 仅反映本进程。
+单进程内的并发安全由以下三重兜底保证：① Scheduler 心跳的 ``job.running`` 标志 + DB lease
+使 ``inspect_once`` 不自重入；② 每 routine 单在途迭代检查；③ ``_do_write_back`` 仅在迭代
+仍为 ``in_flight`` 时翻转并计数（条件 UPDATE），防止 reaped/aborted 迭代被复活或双计。
+``uq_routine_iterations_seq`` + seq 取实际 MAX 为 seq 唯一性兜底。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import update
+
+import negentropy.db.session as db_session
+from negentropy.engine.claude_code.models import ClaudeCodeConfig
+from negentropy.engine.claude_code.service import ClaudeCodeService
+from negentropy.logging import get_logger
+from negentropy.models.routine import Routine, RoutineIteration
+
+from .bus import get_bus
+
+logger = get_logger("negentropy.engine.routine.runner")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class RoutineRunner:
+    """进程内后台执行器注册表（单例，懒创建于运行 loop）。"""
+
+    def __init__(self, *, max_concurrent: int = 2) -> None:
+        self._max_concurrent = max_concurrent
+        self._semaphore: asyncio.Semaphore | None = None
+        self._runners: dict[UUID, asyncio.Task] = {}
+        self._aborts: dict[UUID, asyncio.Event] = {}
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self._max_concurrent)
+        return self._semaphore
+
+    @property
+    def active_count(self) -> int:
+        return len(self._runners)
+
+    @property
+    def max_concurrent(self) -> int:
+        return self._max_concurrent
+
+    def has_capacity(self) -> bool:
+        return len(self._runners) < self._max_concurrent
+
+    def available_slots(self) -> int:
+        """剩余可启动名额（全局并发上限 - 当前在途）。"""
+        return max(0, self._max_concurrent - len(self._runners))
+
+    def is_running(self, iteration_id: UUID) -> bool:
+        return iteration_id in self._runners
+
+    def launch(
+        self,
+        *,
+        iteration_id: UUID,
+        routine_id: UUID,
+        prompt: str,
+        config: ClaudeCodeConfig,
+    ) -> None:
+        """非阻塞启动一次后台执行。立即返回；结果在任务完成时写回 DB。"""
+        if iteration_id in self._runners:
+            logger.debug("routine_runner_already_running", iteration_id=str(iteration_id))
+            return
+
+        abort = asyncio.Event()
+        self._aborts[iteration_id] = abort
+        task = asyncio.create_task(
+            self._run(iteration_id, routine_id, prompt, config, abort),
+            name=f"routine-iter-{iteration_id}",
+        )
+        self._runners[iteration_id] = task
+
+        def _cleanup(_t: asyncio.Task, _iid: UUID = iteration_id) -> None:
+            self._runners.pop(_iid, None)
+            self._aborts.pop(_iid, None)
+
+        task.add_done_callback(_cleanup)
+
+    def request_abort(self, iteration_id: UUID) -> bool:
+        """请求中止某个在途迭代（用户 pause/cancel）。返回是否命中本进程任务。"""
+        abort = self._aborts.get(iteration_id)
+        if abort is not None:
+            abort.set()
+            return True
+        return False
+
+    async def _run(
+        self,
+        iteration_id: UUID,
+        routine_id: UUID,
+        prompt: str,
+        config: ClaudeCodeConfig,
+        abort: asyncio.Event,
+    ) -> None:
+        async with self._get_semaphore():
+            if abort.is_set():
+                await self._mark_aborted(iteration_id)
+                return
+            # 1) 翻转 in_flight + 设置 lease
+            lease = _utcnow() + timedelta(seconds=config.timeout_seconds + 60)
+            await self._mark_in_flight(iteration_id, lease)
+            await get_bus().publish(
+                {"type": "iteration", "id": str(iteration_id), "routine_id": str(routine_id), "status": "in_flight"}
+            )
+
+            # 2) 执行 Claude Code（长耗时，受 config.timeout_seconds 约束）
+            result = await ClaudeCodeService.invoke(prompt, config, abort_event=abort)
+
+            # 3) 写回结果（abort 命中则标记 aborted，否则 executed）
+            if abort.is_set():
+                await self._mark_aborted(iteration_id)
+                await get_bus().publish(
+                    {"type": "iteration", "id": str(iteration_id), "routine_id": str(routine_id), "status": "aborted"}
+                )
+                return
+
+            await self._write_back(iteration_id, routine_id, result)
+            await get_bus().publish(
+                {
+                    "type": "iteration",
+                    "id": str(iteration_id),
+                    "routine_id": str(routine_id),
+                    "status": "executed",
+                    "exec_status": result.status,
+                    "cost_usd": result.cost_usd,
+                    "turn_count": result.turn_count,
+                }
+            )
+
+    async def _mark_in_flight(self, iteration_id: UUID, lease: datetime) -> None:
+        async with db_session.AsyncSessionLocal() as db:
+            await db.execute(
+                update(RoutineIteration)
+                .where(RoutineIteration.id == iteration_id)
+                .values(status="in_flight", started_at=_utcnow(), lease_expires_at=lease)
+            )
+            await db.commit()
+
+    async def _mark_aborted(self, iteration_id: UUID) -> None:
+        async with db_session.AsyncSessionLocal() as db:
+            await db.execute(
+                update(RoutineIteration)
+                .where(RoutineIteration.id == iteration_id)
+                .values(status="aborted", finished_at=_utcnow(), lease_expires_at=None)
+            )
+            await db.commit()
+
+    async def _write_back(self, iteration_id: UUID, routine_id: UUID, result) -> None:
+        """原子写回执行结果 + 更新父 routine 反规范化累计。
+
+        用 ``asyncio.shield`` 包裹，避免关停取消时丢失已完成的 Claude Code 结果。
+        """
+        await asyncio.shield(self._do_write_back(iteration_id, routine_id, result))
+
+    async def _do_write_back(self, iteration_id: UUID, routine_id: UUID, result) -> None:
+        exec_status = "success" if result.status == "success" else result.status  # success|error|timeout
+        async with db_session.AsyncSessionLocal() as db:
+            # 仅当迭代仍处于 in_flight 时才翻转为 executed：若期间已被 reaper 标记 reaped
+            # 或被用户 abort，rowcount=0，则不再覆盖终态、也不重复累加计数/成本（防双计）。
+            res = await db.execute(
+                update(RoutineIteration)
+                .where(RoutineIteration.id == iteration_id, RoutineIteration.status == "in_flight")
+                .values(
+                    status="executed",
+                    exec_status=exec_status,
+                    summary=result.summary or None,
+                    claude_session_id=result.session_id,
+                    cost_usd=result.cost_usd or 0.0,
+                    turn_count=result.turn_count or 0,
+                    exec_error=result.error,
+                    finished_at=_utcnow(),
+                    lease_expires_at=None,
+                )
+            )
+            if res.rowcount == 1:
+                # 父 routine 累计：成本累加、迭代计数 +1、会话续接（仅成功转换时）
+                routine = await db.get(Routine, routine_id)
+                if routine is not None:
+                    routine.total_cost_usd = (routine.total_cost_usd or 0.0) + (result.cost_usd or 0.0)
+                    routine.iteration_count = (routine.iteration_count or 0) + 1
+                    if result.session_id:
+                        routine.claude_session_id = result.session_id
+            await db.commit()
+
+
+# 进程内单例
+_GLOBAL_RUNNER: RoutineRunner | None = None
+
+
+def get_runner(*, max_concurrent: int | None = None) -> RoutineRunner:
+    """获取进程内 RoutineRunner 单例（懒创建）。
+
+    首次创建时的并发上限优先级：显式入参 > ``settings.routine.max_concurrent_executions``。
+    后续调用沿用既有实例（并发上限不可热改）。
+    """
+    global _GLOBAL_RUNNER
+    if _GLOBAL_RUNNER is None:
+        if max_concurrent is None:
+            from negentropy.config import settings
+
+            max_concurrent = settings.routine.max_concurrent_executions
+        _GLOBAL_RUNNER = RoutineRunner(max_concurrent=max_concurrent)
+    return _GLOBAL_RUNNER
+
+
+def reset_runner() -> None:
+    """测试辅助：清空单例。"""
+    global _GLOBAL_RUNNER
+    _GLOBAL_RUNNER = None
+
+
+__all__ = ["RoutineRunner", "get_runner", "reset_runner"]

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/__init__.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/__init__.py
@@ -164,6 +164,7 @@ def _bootstrap_default_handlers() -> None:
         "agent_inspection",
         "memory_automation",
         "claude_code",
+        "routine_inspector",
     ):
         try:
             __import__(f"negentropy.engine.schedulers.handlers.{module_name}")

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/routine_inspector.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/routine_inspector.py
@@ -1,0 +1,47 @@
+"""``routine_inspector`` handler — Routine 编排循环的心跳驱动。
+
+由统一调度引擎按 ``interval`` 周期 tick，每次调用 ``RoutineOrchestrator.inspect_once()``
+执行 reap → evaluate → dispatch 三阶段。本 handler 自身轻量快速（仅 DB 读写 + 后台任务
+调度），真正的 Claude Code 长耗时执行交由进程内后台 Runner 异步完成，不阻塞心跳。
+
+灰度：``settings.routine.enabled=False`` 时直接 no-op，使本心跳对调度引擎零副作用。
+"""
+
+from __future__ import annotations
+
+from negentropy.config import settings
+from negentropy.logging import get_logger
+
+from . import HandlerDescriptor, HandlerResult, register_descriptor, register_handler
+
+logger = get_logger("negentropy.engine.schedulers.handlers.routine_inspector")
+
+register_descriptor(
+    HandlerDescriptor(
+        handler_kind="routine_inspector",
+        label="Routine Inspector",
+        description="巡检活跃 Routine，驱动评估-决策-调度闭环（长周期自主任务）",
+        supported_trigger_types=("interval",),
+        default_trigger_type="interval",
+    ),
+)
+
+
+@register_handler("routine_inspector")
+async def routine_inspector_handler(task) -> HandlerResult:
+    """单次巡检 tick。返回各阶段计数摘要，写入 task_executions 供 Dashboard 观测。"""
+    if not settings.routine.enabled:
+        return HandlerResult(status="ok", output_summary="routine disabled")
+
+    try:
+        from negentropy.engine.routine import get_orchestrator
+
+        result = await get_orchestrator().inspect_once()
+        return HandlerResult(
+            status="ok",
+            output_summary=(f"reaped={result['reaped']} evaluated={result['evaluated']} launched={result['launched']}"),
+            metrics=result,
+        )
+    except Exception as exc:
+        logger.warning("routine_inspector_failed", error=str(exc))
+        return HandlerResult(status="failed", error=str(exc))

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -1,0 +1,658 @@
+"""/routines/* 聚合 API — Routine 长周期自主任务的后端契约。
+
+端点清单：
+- GET    /routines                          路由清单（status/owner/q 筛选 + 游标分页）
+- GET    /routines/kpis                      KPI 卡片数据
+- GET    /routines/{id}                      单路由详情 + 最近迭代
+- GET    /routines/{id}/iterations           迭代历史（分页）
+- POST   /routines                           创建路由（status=pending）
+- PUT    /routines/{id}                      更新路由（非运行态）
+- DELETE /routines/{id}                      删除路由（非运行态）
+- POST   /routines/{id}/start                启动（pending/paused → running）
+- POST   /routines/{id}/pause                暂停（running → paused，中止在途迭代）
+- POST   /routines/{id}/resume               恢复（paused → running）
+- POST   /routines/{id}/cancel               取消（→ cancelled）
+- POST   /routines/{id}/iterations/{iid}/approve   审批通过待执行迭代
+- POST   /routines/{id}/iterations/{iid}/reject    驳回待执行迭代
+- GET    /routines/stream                    SSE 实时事件（routine + iteration）
+
+鉴权由 ``AuthMiddleware`` 在中间件层统一处理，端点不显式 Depends（对齐 scheduler_api）。
+
+参考文献：
+[1] FastAPI Docs, *Server-Sent Events with StreamingResponse*. SSE 实现模式。
+[2] Anthropic, *Building Effective AI Agents*, 2024. Evaluator-Optimizer 控制接口。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time as _time
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+import negentropy.db.session as db_session
+from negentropy.config import settings
+from negentropy.logging import get_logger
+from negentropy.models.routine import Routine, RoutineIteration
+
+logger = get_logger("negentropy.interface.routine_api")
+
+router = APIRouter(prefix="/routines", tags=["routines"])
+
+# 终态：不可再启动 / 编辑调度
+_TERMINAL = ("succeeded", "failed", "cancelled")
+_ACTIVE = ("running", "paused")
+_NON_TERMINAL_ITER = ("pending_approval", "dispatched", "in_flight", "executed")
+_DEFAULT_RECENT_ITERATIONS = 20
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# 10s TTL 缓存（KPI 高频请求降压）
+# ---------------------------------------------------------------------------
+
+
+class _TTLCache:
+    def __init__(self, ttl_seconds: float = 10.0) -> None:
+        self._ttl = ttl_seconds
+        self._store: dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any | None:
+        item = self._store.get(key)
+        if item is None:
+            return None
+        ts, value = item
+        if _time.monotonic() - ts > self._ttl:
+            self._store.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = (_time.monotonic(), value)
+
+    def invalidate(self) -> None:
+        self._store.clear()
+
+
+_KPI_CACHE = _TTLCache(ttl_seconds=10.0)
+
+
+# ---------------------------------------------------------------------------
+# DTO
+# ---------------------------------------------------------------------------
+
+
+class RoutineCreateRequest(BaseModel):
+    key: str = Field(..., min_length=1, max_length=192)
+    title: str = Field(..., min_length=1, max_length=255)
+    goal: str = Field(..., min_length=1)
+    acceptance_criteria: str = Field(..., min_length=1)
+    cwd: str | None = None
+    verification_command: str | None = None
+    max_iterations: int | None = Field(default=None, ge=1, le=1000)
+    max_cost_usd: float | None = Field(default=None, ge=0)
+    deadline_at: datetime | None = None
+    success_score_threshold: int = Field(default=85, ge=0, le=100)
+    no_progress_patience: int = Field(default=3, ge=1, le=50)
+    approval_mode: Literal["auto", "first", "every"] = "auto"
+    config: dict[str, Any] = Field(default_factory=dict)
+    owner_id: str | None = None
+    agent_id: UUID | None = None
+    display_name: str | None = None
+    description: str | None = None
+
+
+class RoutineUpdateRequest(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    goal: str | None = None
+    acceptance_criteria: str | None = None
+    cwd: str | None = None
+    verification_command: str | None = None
+    max_iterations: int | None = Field(default=None, ge=1, le=1000)
+    max_cost_usd: float | None = Field(default=None, ge=0)
+    deadline_at: datetime | None = None
+    success_score_threshold: int | None = Field(default=None, ge=0, le=100)
+    no_progress_patience: int | None = Field(default=None, ge=1, le=50)
+    approval_mode: Literal["auto", "first", "every"] | None = None
+    config: dict[str, Any] | None = None
+    display_name: str | None = None
+    description: str | None = None
+
+
+class ControlBody(BaseModel):
+    reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# 序列化
+# ---------------------------------------------------------------------------
+
+
+def _serialize_routine(r: Routine, *, iterations: list[RoutineIteration] | None = None) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "id": str(r.id),
+        "key": r.key,
+        "title": r.title,
+        "display_name": r.display_name,
+        "description": r.description,
+        "goal": r.goal,
+        "acceptance_criteria": r.acceptance_criteria,
+        "cwd": r.cwd,
+        "verification_command": r.verification_command,
+        "status": r.status,
+        "termination_reason": r.termination_reason,
+        "max_iterations": r.max_iterations,
+        "max_cost_usd": r.max_cost_usd,
+        "deadline_at": r.deadline_at.isoformat() if r.deadline_at else None,
+        "success_score_threshold": r.success_score_threshold,
+        "no_progress_patience": r.no_progress_patience,
+        "approval_mode": r.approval_mode,
+        "iteration_count": r.iteration_count,
+        "total_cost_usd": r.total_cost_usd,
+        "best_score": r.best_score,
+        "last_score": r.last_score,
+        "claude_session_id": r.claude_session_id,
+        "reflections": (r.reflections or {}).get("items", []),
+        "config": r.config or {},
+        "owner_id": r.owner_id,
+        "agent_id": str(r.agent_id) if r.agent_id else None,
+        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+    }
+    if iterations is not None:
+        data["iterations"] = [_serialize_iteration(it) for it in iterations]
+    return data
+
+
+def _serialize_iteration(it: RoutineIteration) -> dict[str, Any]:
+    return {
+        "id": str(it.id),
+        "routine_id": str(it.routine_id),
+        "seq": it.seq,
+        "status": it.status,
+        "prompt": it.prompt,
+        "resume_session_id": it.resume_session_id,
+        "exec_status": it.exec_status,
+        "summary": it.summary,
+        "claude_session_id": it.claude_session_id,
+        "cost_usd": it.cost_usd,
+        "turn_count": it.turn_count,
+        "exec_error": it.exec_error,
+        "score": it.score,
+        "verdict": it.verdict,
+        "reflection": it.reflection,
+        "eval_error": it.eval_error,
+        "gate_exit_code": it.gate_exit_code,
+        "started_at": it.started_at.isoformat() if it.started_at else None,
+        "finished_at": it.finished_at.isoformat() if it.finished_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /routines/kpis
+# ---------------------------------------------------------------------------
+
+
+@router.get("/kpis")
+async def get_kpis() -> dict[str, Any]:
+    """KPI 卡片：总数 / 运行中 / 已成功 / 已失败 / 累计成本 / 平均迭代数。"""
+    cached = _KPI_CACHE.get("kpis")
+    if cached is not None:
+        return cached
+
+    async with db_session.AsyncSessionLocal() as db:
+        status_counts_rows = (await db.execute(select(Routine.status, func.count()).group_by(Routine.status))).all()
+        status_counts = {row[0]: row[1] for row in status_counts_rows}
+        total = sum(status_counts.values())
+        total_cost = (await db.execute(select(func.coalesce(func.sum(Routine.total_cost_usd), 0.0)))).scalar() or 0.0
+        avg_iter = (await db.execute(select(func.coalesce(func.avg(Routine.iteration_count), 0.0)))).scalar() or 0.0
+
+    result = {
+        "total": total,
+        "running": status_counts.get("running", 0),
+        "paused": status_counts.get("paused", 0),
+        "succeeded": status_counts.get("succeeded", 0),
+        "failed": status_counts.get("failed", 0),
+        "cancelled": status_counts.get("cancelled", 0),
+        "pending": status_counts.get("pending", 0),
+        "total_cost_usd": round(float(total_cost), 4),
+        "avg_iterations": round(float(avg_iter), 2),
+    }
+    _KPI_CACHE.set("kpis", result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# GET /routines/stream (SSE)
+# 声明在 /{routine_id} 之前，确保字面路径 /stream 优先于路径参数匹配。
+# ---------------------------------------------------------------------------
+
+
+@router.get("/stream")
+async def routine_stream(request: Request, routine_id: UUID | None = Query(None)) -> StreamingResponse:
+    """SSE 实时推送 routine / iteration 事件 + 5s 心跳保活。
+
+    事件形如：
+        event: routine
+        data: {"id":"...","status":"running",...}
+        event: iteration
+        data: {"id":"...","routine_id":"...","status":"executed",...}
+    """
+    from negentropy.engine.routine.bus import get_bus
+
+    bus = get_bus()
+
+    async def _gen():
+        queue = await bus.subscribe()
+        try:
+            yield b": connected\n\n"
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=5.0)
+                except TimeoutError:
+                    yield b": ping\n\n"
+                    continue
+                if event.get("__shutdown__"):
+                    yield b": shutdown\n\n"
+                    break
+                if routine_id is not None:
+                    rid = str(routine_id)
+                    ev_rid = event.get("routine_id") or event.get("id")
+                    if ev_rid != rid:
+                        continue
+                ev_type = event.get("type", "routine")
+                payload = json.dumps(event, ensure_ascii=False)
+                yield f"event: {ev_type}\ndata: {payload}\n\n".encode()
+        finally:
+            await bus.unsubscribe(queue)
+
+    return StreamingResponse(
+        _gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /routines
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+async def list_routines(
+    status: str | None = Query(None),
+    owner_id: str | None = Query(None),
+    q: str | None = Query(None, description="按 key / title 模糊搜索"),
+    limit: int = Query(50, ge=1, le=200),
+    cursor: str | None = Query(None, description="上一页末尾 updated_at ISO 串"),
+) -> dict[str, Any]:
+    """路由清单：多维筛选 + 基于 updated_at 的游标分页。"""
+    async with db_session.AsyncSessionLocal() as db:
+        stmt = select(Routine)
+        if status:
+            stmt = stmt.where(Routine.status == status)
+        if owner_id:
+            stmt = stmt.where(Routine.owner_id == owner_id)
+        if q:
+            like = f"%{q}%"
+            stmt = stmt.where((Routine.key.ilike(like)) | (Routine.title.ilike(like)))
+        if cursor:
+            try:
+                cursor_dt = datetime.fromisoformat(cursor)
+                stmt = stmt.where(Routine.updated_at < cursor_dt)
+            except ValueError:
+                raise HTTPException(status_code=400, detail="invalid cursor") from None
+        stmt = stmt.order_by(Routine.updated_at.desc()).limit(limit + 1)
+        rows = (await db.execute(stmt)).scalars().all()
+
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    next_cursor = rows[-1].updated_at.isoformat() if has_more and rows else None
+    return {
+        "items": [_serialize_routine(r) for r in rows],
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /routines/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{routine_id}")
+async def get_routine(
+    routine_id: UUID,
+    recent: int = Query(_DEFAULT_RECENT_ITERATIONS, ge=1, le=200),
+) -> dict[str, Any]:
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        iterations = (
+            (
+                await db.execute(
+                    select(RoutineIteration)
+                    .where(RoutineIteration.routine_id == routine_id)
+                    .order_by(RoutineIteration.seq.desc())
+                    .limit(recent)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return _serialize_routine(r, iterations=list(iterations))
+
+
+# ---------------------------------------------------------------------------
+# GET /routines/{id}/iterations
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{routine_id}/iterations")
+async def list_iterations(
+    routine_id: UUID,
+    limit: int = Query(50, ge=1, le=200),
+    before_seq: int | None = Query(None, description="分页：返回 seq 小于此值的迭代"),
+) -> dict[str, Any]:
+    async with db_session.AsyncSessionLocal() as db:
+        if await db.get(Routine, routine_id) is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        stmt = select(RoutineIteration).where(RoutineIteration.routine_id == routine_id)
+        if before_seq is not None:
+            stmt = stmt.where(RoutineIteration.seq < before_seq)
+        stmt = stmt.order_by(RoutineIteration.seq.desc()).limit(limit + 1)
+        rows = (await db.execute(stmt)).scalars().all()
+
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    return {
+        "items": [_serialize_iteration(it) for it in rows],
+        "has_more": has_more,
+        "next_before_seq": rows[-1].seq if has_more and rows else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /routines
+# ---------------------------------------------------------------------------
+
+
+@router.post("")
+async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
+    async with db_session.AsyncSessionLocal() as db:
+        routine = Routine(
+            key=body.key,
+            title=body.title,
+            goal=body.goal,
+            acceptance_criteria=body.acceptance_criteria,
+            cwd=body.cwd,
+            verification_command=body.verification_command,
+            status="pending",
+            max_iterations=body.max_iterations
+            if body.max_iterations is not None
+            else settings.routine.default_max_iterations,
+            max_cost_usd=body.max_cost_usd if body.max_cost_usd is not None else settings.routine.default_max_cost_usd,
+            deadline_at=body.deadline_at,
+            success_score_threshold=body.success_score_threshold,
+            no_progress_patience=body.no_progress_patience,
+            approval_mode=body.approval_mode,
+            config=body.config or {},
+            reflections={},
+            owner_id=body.owner_id,
+            agent_id=body.agent_id,
+            display_name=body.display_name,
+            description=body.description,
+        )
+        db.add(routine)
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            raise HTTPException(status_code=409, detail=f"routine key '{body.key}' already exists") from exc
+        except SQLAlchemyError as exc:
+            await db.rollback()
+            logger.warning("create_routine_failed", error=str(exc))
+            raise HTTPException(status_code=500, detail=f"create failed: {exc}") from exc
+        await db.refresh(routine)
+
+    _KPI_CACHE.invalidate()
+    return _serialize_routine(routine)
+
+
+# ---------------------------------------------------------------------------
+# PUT /routines/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{routine_id}")
+async def update_routine(routine_id: UUID, body: RoutineUpdateRequest) -> dict[str, Any]:
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status == "running":
+            raise HTTPException(status_code=409, detail="cannot edit a running routine; pause it first")
+
+        update_data = body.model_dump(exclude_unset=True)
+        for field_name, value in update_data.items():
+            setattr(r, field_name, value)
+
+        try:
+            await db.commit()
+        except SQLAlchemyError as exc:
+            await db.rollback()
+            logger.warning("update_routine_failed", routine_id=str(routine_id), error=str(exc))
+            raise HTTPException(status_code=500, detail=f"update failed: {exc}") from exc
+        await db.refresh(r)
+
+    _KPI_CACHE.invalidate()
+    return _serialize_routine(r)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /routines/{id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/{routine_id}")
+async def delete_routine(routine_id: UUID) -> dict[str, Any]:
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status in _ACTIVE:
+            raise HTTPException(status_code=409, detail=f"cannot delete a {r.status} routine; cancel it first")
+        try:
+            await db.delete(r)
+            await db.commit()
+        except SQLAlchemyError as exc:
+            await db.rollback()
+            logger.warning("delete_routine_failed", routine_id=str(routine_id), error=str(exc))
+            raise HTTPException(status_code=500, detail=f"delete failed: {exc}") from exc
+
+    _KPI_CACHE.invalidate()
+    return {"ok": True, "deleted_routine_id": str(routine_id)}
+
+
+# ---------------------------------------------------------------------------
+# 控制动作：start / pause / resume / cancel
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{routine_id}/start")
+async def start_routine(routine_id: UUID, body: ControlBody | None = None) -> dict[str, Any]:
+    """启动：pending/paused → running。"""
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status not in ("pending", "paused"):
+            raise HTTPException(status_code=409, detail=f"cannot start from status '{r.status}'")
+        r.status = "running"
+        r.termination_reason = None
+        await db.commit()
+        await db.refresh(r)
+    _KPI_CACHE.invalidate()
+    await _publish_routine(r)
+    return _serialize_routine(r)
+
+
+@router.post("/{routine_id}/pause")
+async def pause_routine(routine_id: UUID, body: ControlBody | None = None) -> dict[str, Any]:
+    """暂停：running → paused，并中止当前在途迭代。"""
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status != "running":
+            raise HTTPException(status_code=409, detail=f"cannot pause from status '{r.status}'")
+        r.status = "paused"
+        await db.commit()
+        await db.refresh(r)
+        await _abort_active_iterations(db, routine_id)
+    _KPI_CACHE.invalidate()
+    await _publish_routine(r)
+    return _serialize_routine(r)
+
+
+@router.post("/{routine_id}/resume")
+async def resume_routine(routine_id: UUID, body: ControlBody | None = None) -> dict[str, Any]:
+    """恢复：paused → running。"""
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status != "paused":
+            raise HTTPException(status_code=409, detail=f"cannot resume from status '{r.status}'")
+        r.status = "running"
+        await db.commit()
+        await db.refresh(r)
+    _KPI_CACHE.invalidate()
+    await _publish_routine(r)
+    return _serialize_routine(r)
+
+
+@router.post("/{routine_id}/cancel")
+async def cancel_routine(routine_id: UUID, body: ControlBody | None = None) -> dict[str, Any]:
+    """取消：任意活跃态 → cancelled，中止在途迭代。"""
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status in _TERMINAL:
+            raise HTTPException(status_code=409, detail=f"routine already terminal: '{r.status}'")
+        r.status = "cancelled"
+        r.termination_reason = "user_cancelled"
+        await db.commit()
+        await db.refresh(r)
+        await _abort_active_iterations(db, routine_id)
+    _KPI_CACHE.invalidate()
+    await _publish_routine(r)
+    return _serialize_routine(r)
+
+
+# ---------------------------------------------------------------------------
+# 审批门控：approve / reject
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{routine_id}/iterations/{iteration_id}/approve")
+async def approve_iteration(routine_id: UUID, iteration_id: UUID) -> dict[str, Any]:
+    """审批通过：pending_approval → dispatched（下一 tick 由 Inspector 派发执行）。"""
+    async with db_session.AsyncSessionLocal() as db:
+        it = await db.get(RoutineIteration, iteration_id)
+        if it is None or it.routine_id != routine_id:
+            raise HTTPException(status_code=404, detail="iteration not found")
+        if it.status != "pending_approval":
+            raise HTTPException(status_code=409, detail=f"iteration not pending_approval: '{it.status}'")
+        it.status = "dispatched"
+        await db.commit()
+        await db.refresh(it)
+    return _serialize_iteration(it)
+
+
+@router.post("/{routine_id}/iterations/{iteration_id}/reject")
+async def reject_iteration(routine_id: UUID, iteration_id: UUID) -> dict[str, Any]:
+    """驳回：pending_approval → aborted。"""
+    async with db_session.AsyncSessionLocal() as db:
+        it = await db.get(RoutineIteration, iteration_id)
+        if it is None or it.routine_id != routine_id:
+            raise HTTPException(status_code=404, detail="iteration not found")
+        if it.status != "pending_approval":
+            raise HTTPException(status_code=409, detail=f"iteration not pending_approval: '{it.status}'")
+        it.status = "aborted"
+        it.finished_at = _utcnow()
+        await db.commit()
+        await db.refresh(it)
+    return _serialize_iteration(it)
+
+
+# ---------------------------------------------------------------------------
+# 辅助
+# ---------------------------------------------------------------------------
+
+
+async def _abort_active_iterations(db, routine_id: UUID) -> None:
+    """中止该 routine 当前在途/待执行迭代：请求 runner abort + 标记 aborted。"""
+    from negentropy.engine.routine.runner import get_runner
+
+    runner = get_runner()
+    rows = (
+        (
+            await db.execute(
+                select(RoutineIteration).where(
+                    RoutineIteration.routine_id == routine_id,
+                    RoutineIteration.status.in_(_NON_TERMINAL_ITER),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    now = _utcnow()
+    for it in rows:
+        runner.request_abort(it.id)
+        # executed 等待评估的不强行中止（结果已产出）；其余标记 aborted
+        if it.status in ("pending_approval", "dispatched", "in_flight"):
+            it.status = "aborted"
+            it.finished_at = now
+            it.lease_expires_at = None
+    await db.commit()
+
+
+async def _publish_routine(r: Routine) -> None:
+    from negentropy.engine.routine.bus import get_bus
+
+    await get_bus().publish(
+        {
+            "type": "routine",
+            "id": str(r.id),
+            "status": r.status,
+            "termination_reason": r.termination_reason,
+            "best_score": r.best_score,
+            "last_score": r.last_score,
+            "iteration_count": r.iteration_count,
+            "total_cost_usd": r.total_cost_usd,
+        }
+    )
+
+
+__all__ = ["router"]

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -26,6 +26,7 @@ from .perception import (
 )
 from .plugin_common import PluginPermission, PluginPermissionType, PluginVisibility
 from .pulse import Event, Thread
+from .routine import Routine, RoutineIteration
 from .scheduled_task import ScheduledTask, TaskExecution
 from .security import Credential
 from .skill import Skill
@@ -99,6 +100,9 @@ __all__ = [
     # Scheduled Task (统一心跳调度)
     "ScheduledTask",
     "TaskExecution",
+    # Routine (长周期自主任务迭代)
+    "Routine",
+    "RoutineIteration",
     # Model Config
     "ModelConfig",
     "ModelType",

--- a/apps/negentropy/src/negentropy/models/routine.py
+++ b/apps/negentropy/src/negentropy/models/routine.py
@@ -1,0 +1,209 @@
+"""Routine 长周期自主任务模型 — Evaluator-Optimizer 闭环的事实源。
+
+定位：
+- ``routines``：长周期自主任务的注册源。每个 Routine 携带目标（goal）、验收标准
+  （acceptance_criteria）、预算守卫（max_iterations / max_cost_usd / deadline）与生命周期
+  状态机。由 Negentropy Engine 担任 Orchestrator + Evaluator。
+- ``routine_iterations``：单次 Execute→Evaluate→Decide 周期的 append-mostly 事实表。
+  记录发送给 Claude Code 的 prompt、执行结果（summary / session_id / cost）、评估结果
+  （score / verdict / reflection）。
+
+闭环：Engine 派发 goal → Claude Code（Executor，可 resume session）执行 → Engine 用
+LLM-as-Judge + 可选命令门控评估 → 决策继续迭代（注入累积反思）或终止（成功/失败/预算耗尽）。
+
+参考文献：
+[1] Anthropic, *Building Effective AI Agents*, 2024. Evaluator-Optimizer 工作流：
+    一个 LLM 生成、另一个评估并反馈，迭代至验收标准满足。
+[2] N. Shinn et al., "Reflexion: Language Agents with Verbal Reinforcement Learning,"
+    in *Proc. NeurIPS*, 2023. arXiv:2303.11366. 自然语言反思持久化为 episodic memory，
+    注入下次迭代。
+[3] PostgreSQL Docs, *FOR UPDATE SKIP LOCKED*. 并发巡检 tick 的行级幂等保证。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import (
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin
+
+
+class Routine(Base, UUIDMixin, TimestampMixin):
+    """长周期自主任务 — Engine 编排 Claude Code 迭代执行直至验收或终止。
+
+    生命周期状态机（``status``）::
+
+        pending ──start──→ running ──score≥threshold──→ succeeded (终态)
+          │                 │
+          │                 ├── pause ──→ paused ──resume──→ running
+          │                 ├── cancel ──→ cancelled (终态)
+          │                 └── guardrail/deadline ──→ failed (终态)
+          └── cancel ──→ cancelled (终态)
+
+    Human-in-the-Loop（``approval_mode``）：``auto`` 全自动；``first`` 仅首次迭代前需审批；
+    ``every`` 每轮迭代前需审批。审批门控在迭代创建时决定初始状态（dispatched vs
+    pending_approval）。
+    """
+
+    __tablename__ = "routines"
+
+    # --- 标识与归属 ---
+    key: Mapped[str] = mapped_column(String(192), unique=True, nullable=False)
+    owner_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    agent_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
+
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # --- 任务定义 ---
+    goal: Mapped[str] = mapped_column(Text, nullable=False)
+    acceptance_criteria: Mapped[str] = mapped_column(Text, nullable=False)
+    cwd: Mapped[str | None] = mapped_column(Text, nullable=True)
+    verification_command: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # --- 生命周期 ---
+    status: Mapped[str] = mapped_column(
+        String(24),
+        nullable=False,
+        default="pending",
+        server_default="pending",
+        comment="pending|running|paused|succeeded|failed|cancelled",
+    )
+    termination_reason: Mapped[str | None] = mapped_column(
+        String(48),
+        nullable=True,
+        comment="success|max_iterations|max_cost|deadline|no_progress|oscillation|unrecoverable_error|user_cancelled",
+    )
+
+    # --- 预算守卫（硬上限，代码层强制）---
+    max_iterations: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_cost_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
+    deadline_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    success_score_threshold: Mapped[int] = mapped_column(Integer, nullable=False, default=85, server_default="85")
+    no_progress_patience: Mapped[int] = mapped_column(Integer, nullable=False, default=3, server_default="3")
+
+    # --- Human-in-the-Loop ---
+    approval_mode: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default="auto",
+        server_default="auto",
+        comment="auto|first|every — 迭代执行前的人工审批级别",
+    )
+
+    # --- 运行期状态（反规范化，加速守卫判定）---
+    iteration_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    total_cost_usd: Mapped[float] = mapped_column(Float, nullable=False, default=0.0, server_default="0")
+    best_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    claude_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    # --- Reflexion 反思记忆 + Claude Code 配置覆盖 ---
+    reflections: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+    config: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+
+    iterations: Mapped[list[RoutineIteration]] = relationship(
+        back_populates="routine",
+        cascade="all, delete-orphan",
+        order_by="RoutineIteration.seq.desc()",
+    )
+
+    __table_args__ = (
+        Index("ix_routines_status", "status"),
+        Index("ix_routines_owner", "owner_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+class RoutineIteration(Base, UUIDMixin):
+    """单次迭代周期 — Execute（Claude Code）→ Evaluate（Judge）→ Decide。
+
+    设计取舍：
+    - 不写 ``updated_at``：迭代是 append-mostly 事件流，状态翻转有限
+      （dispatched → in_flight → executed → evaluated）。
+    - ``lease_expires_at``：进程内后台 Runner 的崩溃恢复 lease；超时未完成由 Inspector
+      reaper 标记为 ``reaped`` 并重新派发。
+    - ``status`` 状态机::
+
+        [approval≠auto] pending_approval ──approve──→ dispatched
+                                          └─reject──→ aborted
+        dispatched ──runner pickup──→ in_flight ──result──→ executed ──judge──→ evaluated
+                                          │                    │
+                                          ├─lease expired─→ reaped
+                                          └─user cancel──→ aborted
+    """
+
+    __tablename__ = "routine_iterations"
+
+    routine_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey(f"{NEGENTROPY_SCHEMA}.routines.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    status: Mapped[str] = mapped_column(
+        String(24),
+        nullable=False,
+        default="dispatched",
+        server_default="dispatched",
+        comment="pending_approval|dispatched|in_flight|executed|evaluated|reaped|aborted",
+    )
+
+    # --- 执行输入 ---
+    prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resume_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    # --- Claude Code 执行结果 ---
+    exec_status: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    claude_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    cost_usd: Mapped[float] = mapped_column(Float, nullable=False, default=0.0, server_default="0")
+    turn_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    exec_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # --- 评估结果 ---
+    score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    verdict: Mapped[str | None] = mapped_column(
+        String(24),
+        nullable=True,
+        comment="pass|progressing|stalled|regressed|unrecoverable",
+    )
+    reflection: Mapped[str | None] = mapped_column(Text, nullable=True)
+    eval_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    gate_exit_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # --- 时序与租约 ---
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    metrics: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
+
+    routine: Mapped[Routine] = relationship(back_populates="iterations")
+
+    __table_args__ = (
+        UniqueConstraint("routine_id", "seq", name="uq_routine_iterations_seq"),
+        Index("ix_routine_iterations_routine_seq", "routine_id", "seq"),
+        Index("ix_routine_iterations_lease", "status", "lease_expires_at"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+__all__ = ["Routine", "RoutineIteration"]

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -1,0 +1,239 @@
+"""RoutineOrchestrator 全链路集成测试 — 真实 Postgres。
+
+覆盖范围：
+- inspect_once 的 evaluate+decide：高分 → succeeded；progressing → 继续
+- inspect_once 的 dispatch：auto 模式创建并执行迭代；first 模式首迭代 pending_approval
+- 预算守卫：max_iterations 触达 → failed/max_iterations
+- 反思追加：评估反思写入 routine.reflections
+
+注意：
+- ClaudeCodeService.invoke 与 RoutineEvaluator.evaluate 被 mock，避免真实 LLM / CLI 调用；
+- routine key 使用 UUID 后缀隔离，try/finally 清理测试数据。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import delete, select
+
+import negentropy.db.session as db_session
+from negentropy.engine.claude_code.models import ClaudeCodeResult
+from negentropy.engine.routine.evaluator import EvaluationResult
+from negentropy.engine.routine.orchestrator import RoutineOrchestrator
+from negentropy.models.routine import Routine, RoutineIteration
+
+pytestmark = pytest.mark.asyncio
+
+
+def _key(prefix: str = "itest_routine") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+async def _make_routine(**overrides) -> uuid.UUID:
+    defaults = dict(
+        key=_key(),
+        title="Integration Test",
+        goal="实现功能",
+        acceptance_criteria="通过验收",
+        status="running",
+        max_iterations=5,
+        success_score_threshold=85,
+        no_progress_patience=3,
+        approval_mode="auto",
+        iteration_count=0,
+        reflections={},
+        config={},
+    )
+    defaults.update(overrides)
+    async with db_session.AsyncSessionLocal() as db:
+        r = Routine(**defaults)
+        db.add(r)
+        await db.commit()
+        return r.id
+
+
+async def _cleanup(routine_id: uuid.UUID) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(delete(Routine).where(Routine.id == routine_id))
+        await db.commit()
+
+
+async def _add_iteration(routine_id: uuid.UUID, **overrides) -> uuid.UUID:
+    defaults = dict(routine_id=routine_id, seq=1, status="executed", exec_status="success", summary="done")
+    defaults.update(overrides)
+    async with db_session.AsyncSessionLocal() as db:
+        it = RoutineIteration(**defaults)
+        db.add(it)
+        await db.commit()
+        return it.id
+
+
+async def test_evaluate_high_score_terminates_succeeded():
+    rid = await _make_routine(iteration_count=1)
+    await _add_iteration(rid, seq=1)
+    try:
+        orch = RoutineOrchestrator()
+        with patch.object(
+            orch._evaluator,
+            "evaluate",
+            new=AsyncMock(
+                return_value=EvaluationResult(ok=True, score=92, verdict="pass", reflection="很好", gate_exit_code=None)
+            ),
+        ):
+            count = await orch._evaluate_and_decide()
+        assert count == 1
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "succeeded"
+            assert r.termination_reason == "success"
+            assert r.best_score == 92
+            assert r.reflections.get("items") == ["很好"]
+    finally:
+        await _cleanup(rid)
+
+
+async def test_evaluate_progressing_continues():
+    rid = await _make_routine(iteration_count=1)
+    await _add_iteration(rid, seq=1)
+    try:
+        orch = RoutineOrchestrator()
+        with patch.object(
+            orch._evaluator,
+            "evaluate",
+            new=AsyncMock(
+                return_value=EvaluationResult(ok=True, score=55, verdict="progressing", reflection="继续改进")
+            ),
+        ):
+            await orch._evaluate_and_decide()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "running"  # 未终止
+            assert r.last_score == 55
+    finally:
+        await _cleanup(rid)
+
+
+async def test_dispatch_auto_launches_and_writes_back():
+    rid = await _make_routine(approval_mode="auto", iteration_count=0)
+    try:
+        orch = RoutineOrchestrator()
+        fake = ClaudeCodeResult(status="success", summary="ok", session_id="s1", cost_usd=0.05, turn_count=2)
+        with patch(
+            "negentropy.engine.claude_code.service.ClaudeCodeService.invoke",
+            new=AsyncMock(return_value=fake),
+        ):
+            launched = await orch._dispatch_due()
+            assert launched == 1
+            await asyncio.sleep(1.2)  # 等待后台 runner 写回
+        async with db_session.AsyncSessionLocal() as db:
+            its = (await db.execute(select(RoutineIteration).where(RoutineIteration.routine_id == rid))).scalars().all()
+            assert len(its) == 1
+            assert its[0].status == "executed"
+            assert its[0].exec_status == "success"
+            r = await db.get(Routine, rid)
+            assert r.iteration_count == 1
+            assert r.claude_session_id == "s1"
+            assert r.total_cost_usd == pytest.approx(0.05)
+    finally:
+        await _cleanup(rid)
+
+
+async def test_dispatch_first_approval_creates_pending():
+    rid = await _make_routine(approval_mode="first", iteration_count=0)
+    try:
+        orch = RoutineOrchestrator()
+        with patch(
+            "negentropy.engine.claude_code.service.ClaudeCodeService.invoke",
+            new=AsyncMock(),
+        ) as mock_invoke:
+            launched = await orch._dispatch_due()
+            # first 模式首迭代待审批，不应 launch
+            assert launched == 0
+            mock_invoke.assert_not_called()
+        async with db_session.AsyncSessionLocal() as db:
+            its = (await db.execute(select(RoutineIteration).where(RoutineIteration.routine_id == rid))).scalars().all()
+            assert len(its) == 1
+            assert its[0].status == "pending_approval"
+            assert its[0].seq == 1
+    finally:
+        await _cleanup(rid)
+
+
+async def test_dispatch_pre_budget_terminates_at_max_iterations():
+    rid = await _make_routine(max_iterations=3, iteration_count=3)
+    try:
+        orch = RoutineOrchestrator()
+        with patch(
+            "negentropy.engine.claude_code.service.ClaudeCodeService.invoke",
+            new=AsyncMock(),
+        ):
+            await orch._dispatch_due()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "failed"
+            assert r.termination_reason == "max_iterations"
+    finally:
+        await _cleanup(rid)
+
+
+async def test_redispatch_after_aborted_iteration_uses_next_seq():
+    """回归（code review #1）：存在 aborted 迭代时再派发须用 seq=MAX+1，不复用 seq 触发唯一约束冲突。
+
+    复现 pause→resume 流：iteration_count=0，seq=1 迭代被 abort（计数未增），
+    旧逻辑 seq=iteration_count+1=1 会与已存在的 seq=1 行冲突 → IntegrityError。
+    """
+    rid = await _make_routine(approval_mode="auto", iteration_count=0)
+    # 造一个已 aborted 的 seq=1 迭代（模拟 pause 中止）
+    await _add_iteration(rid, seq=1, status="aborted", exec_status=None, summary=None)
+    try:
+        orch = RoutineOrchestrator()
+        fake = ClaudeCodeResult(status="success", summary="ok", session_id="s2", cost_usd=0.01, turn_count=1)
+        with patch(
+            "negentropy.engine.claude_code.service.ClaudeCodeService.invoke",
+            new=AsyncMock(return_value=fake),
+        ):
+            launched = await orch._dispatch_due()  # 不应抛 IntegrityError
+            assert launched == 1
+            await asyncio.sleep(1.2)
+        async with db_session.AsyncSessionLocal() as db:
+            its = (await db.execute(select(RoutineIteration).where(RoutineIteration.routine_id == rid))).scalars().all()
+            seqs = sorted(it.seq for it in its)
+            assert seqs == [1, 2], f"expected seqs [1,2], got {seqs}"
+            new_it = next(it for it in its if it.seq == 2)
+            assert new_it.status == "executed"
+    finally:
+        await _cleanup(rid)
+
+
+async def test_write_back_no_double_count_when_reaped_midflight():
+    """回归（code review #5）：迭代在执行中被 reaper 标记 reaped 后，
+    runner 的 write-back 不应把它复活为 executed、也不应重复累加 iteration_count/cost。"""
+    rid = await _make_routine(approval_mode="auto", iteration_count=0)
+    iid = await _add_iteration(rid, seq=1, status="in_flight", exec_status=None, summary=None)
+    try:
+        from negentropy.engine.routine.runner import get_runner
+
+        runner = get_runner()
+        fake = ClaudeCodeResult(status="success", summary="late", session_id="s3", cost_usd=0.99, turn_count=5)
+
+        # 模拟：write-back 发生前，reaper 已把该迭代置为 reaped
+        async with db_session.AsyncSessionLocal() as db:
+            it = await db.get(RoutineIteration, iid)
+            it.status = "reaped"
+            await db.commit()
+
+        # 直接调用内部 write-back（绕过 launch，确定性复现竞态）
+        await runner._do_write_back(iid, rid, fake)  # noqa: SLF001
+
+        async with db_session.AsyncSessionLocal() as db:
+            it = await db.get(RoutineIteration, iid)
+            assert it.status == "reaped"  # 未被复活
+            r = await db.get(Routine, rid)
+            assert r.iteration_count == 0  # 未被累加
+            assert r.total_cost_usd == pytest.approx(0.0)  # 成本未被累加
+    finally:
+        await _cleanup(rid)

--- a/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
@@ -1,0 +1,159 @@
+"""Routine API 全链路集成测试 — 真实 Postgres + ASGI。
+
+覆盖范围：
+- CRUD：create / 重复 key 409 / detail / list 过滤 / update / delete
+- 控制状态机：start / pause / resume / cancel + 非法转换 409
+- 编辑运行中 routine 被拒（409）
+- 审批门控：approve / reject 迭代
+- 路由顺序：/stream 字面路径优先于 /{routine_id}
+- KPIs 聚合
+
+注意：SSE /stream 端点不在此测试（ASGITransport 下 is_disconnected 永不返回，会阻塞）；
+其路由优先级通过 router.routes 声明顺序断言。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from sqlalchemy import delete
+
+import negentropy.db.session as db_session
+from negentropy.interface.routine_api import router
+from negentropy.models.routine import Routine, RoutineIteration
+
+pytestmark = pytest.mark.asyncio
+
+
+def _key() -> str:
+    return f"itest_api_{uuid.uuid4().hex[:8]}"
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def _cleanup(key_prefix: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(delete(Routine).where(Routine.key.like(f"{key_prefix}%")))
+        await db.commit()
+
+
+async def test_stream_route_declared_before_id():
+    """/routines/stream 必须在 /routines/{routine_id} 之前声明，否则被路径参数吞掉。"""
+    paths = [r.path for r in router.routes]
+    assert paths.index("/routines/stream") < paths.index("/routines/{routine_id}")
+
+
+async def test_full_crud_and_control_lifecycle():
+    app = _app()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            # CREATE
+            r = await c.post(
+                "/routines",
+                json={
+                    "key": key,
+                    "title": "API Test",
+                    "goal": "实现功能 X",
+                    "acceptance_criteria": "测试通过",
+                    "max_iterations": 5,
+                    "approval_mode": "first",
+                    "verification_command": "echo ok",
+                },
+            )
+            assert r.status_code == 200, r.text
+            rid = r.json()["id"]
+            assert r.json()["status"] == "pending"
+            assert r.json()["approval_mode"] == "first"
+
+            # 重复 key → 409
+            dup = await c.post(
+                "/routines",
+                json={"key": key, "title": "x", "goal": "g", "acceptance_criteria": "a"},
+            )
+            assert dup.status_code == 409
+
+            # detail 带 iterations
+            detail = await c.get(f"/routines/{rid}")
+            assert detail.status_code == 200 and "iterations" in detail.json()
+
+            # list 过滤
+            lst = await c.get("/routines", params={"q": "API Test"})
+            assert lst.status_code == 200 and any(x["id"] == rid for x in lst.json()["items"])
+
+            # KPIs
+            kpi = await c.get("/routines/kpis")
+            assert kpi.status_code == 200 and kpi.json()["total"] >= 1
+
+            # update（pending 可改）
+            upd = await c.put(f"/routines/{rid}", json={"max_iterations": 10})
+            assert upd.status_code == 200 and upd.json()["max_iterations"] == 10
+
+            # start → running
+            st = await c.post(f"/routines/{rid}/start")
+            assert st.status_code == 200 and st.json()["status"] == "running"
+
+            # 运行中不可编辑 → 409
+            assert (await c.put(f"/routines/{rid}", json={"goal": "x"})).status_code == 409
+
+            # pause → resume
+            assert (await c.post(f"/routines/{rid}/pause")).json()["status"] == "paused"
+            assert (await c.post(f"/routines/{rid}/resume")).json()["status"] == "running"
+
+            # cancel → cancelled
+            cancel = await c.post(f"/routines/{rid}/cancel")
+            assert cancel.json()["status"] == "cancelled"
+            assert cancel.json()["termination_reason"] == "user_cancelled"
+
+            # 重复 cancel（已终态）→ 409
+            assert (await c.post(f"/routines/{rid}/cancel")).status_code == 409
+
+            # delete（终态可删）
+            assert (await c.delete(f"/routines/{rid}")).status_code == 200
+            # 删后 404
+            assert (await c.get(f"/routines/{rid}")).status_code == 404
+    finally:
+        await _cleanup("itest_api_")
+
+
+async def test_iteration_approve_reject():
+    app = _app()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            r = await c.post(
+                "/routines",
+                json={"key": key, "title": "Approve Test", "goal": "g", "acceptance_criteria": "a"},
+            )
+            rid = r.json()["id"]
+
+        # 直接在 DB 造两个 pending_approval 迭代
+        async with db_session.AsyncSessionLocal() as db:
+            it1 = RoutineIteration(routine_id=uuid.UUID(rid), seq=1, status="pending_approval", prompt="p1")
+            it2 = RoutineIteration(routine_id=uuid.UUID(rid), seq=2, status="pending_approval", prompt="p2")
+            db.add_all([it1, it2])
+            await db.commit()
+            iid1, iid2 = str(it1.id), str(it2.id)
+
+        async with _client(app) as c:
+            # approve → dispatched
+            ap = await c.post(f"/routines/{rid}/iterations/{iid1}/approve")
+            assert ap.status_code == 200 and ap.json()["status"] == "dispatched"
+            # 重复 approve（非 pending）→ 409
+            assert (await c.post(f"/routines/{rid}/iterations/{iid1}/approve")).status_code == 409
+            # reject → aborted
+            rj = await c.post(f"/routines/{rid}/iterations/{iid2}/reject")
+            assert rj.status_code == 200 and rj.json()["status"] == "aborted"
+    finally:
+        await _cleanup("itest_api_")

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
@@ -122,6 +122,21 @@ def test_decide_no_progress_plateau():
     assert res.is_terminate and res.reason == d.REASON_NO_PROGRESS
 
 
+def test_decide_no_progress_ignores_in_window_climb():
+    """回归（code review #1）：窗口内创出新高（超过「窗口之前」最优）应继续推进，
+    不应因 best_score 含窗口自身导致 _is_no_progress 恒真而误判停滞终止。
+
+    success_score_threshold=95 高于全部评分，确保不走「成功」分支、隔离 no_progress 判定。"""
+    r = FakeRoutine(best_score=90, no_progress_patience=3, success_score_threshold=95)
+    hist = [
+        FakeIter(seq=1, score=40, verdict="progressing"),  # 窗口之前最优 = 40
+        FakeIter(seq=2, score=60, verdict="progressing"),
+        FakeIter(seq=3, score=75, verdict="progressing"),
+        FakeIter(seq=4, score=90, verdict="progressing"),
+    ]
+    assert d.decide(r, hist[-1], hist).action == "continue"
+
+
 def test_decide_oscillation():
     r = FakeRoutine(best_score=60, no_progress_patience=10)  # patience 大以排除 no_progress 抢先
     hist = [

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
@@ -1,0 +1,243 @@
+"""Routine 决策守卫 + prompt 构建 + handler 注册 单元测试。
+
+覆盖：
+- decision.pre_dispatch_check：max_iterations / max_cost / deadline 预算守卫
+- decision.decide：成功 / 不可恢复 / 停滞 / 振荡 / 继续 全分支
+- prompt_builder.build_prompt / append_reflection：Reflexion 注入与追加语义
+- routine_inspector handler + descriptor 注册
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from negentropy.engine.routine import decision as d
+from negentropy.engine.routine.prompt_builder import append_reflection, build_prompt
+
+# ---------------------------------------------------------------------------
+# 轻量只读视图（避免依赖 ORM / DB）
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeRoutine:
+    status: str = "running"
+    max_iterations: int | None = None
+    max_cost_usd: float | None = None
+    deadline_at: datetime | None = None
+    success_score_threshold: int = 85
+    no_progress_patience: int = 3
+    iteration_count: int = 0
+    total_cost_usd: float = 0.0
+    best_score: int | None = None
+    goal: str = "实现功能 X"
+    acceptance_criteria: str = "通过全部验收项"
+    reflections: dict = field(default_factory=dict)
+    claude_session_id: str | None = None
+
+
+@dataclass
+class FakeIter:
+    seq: int = 1
+    exec_status: str | None = "success"
+    score: int | None = None
+    verdict: str | None = None
+    gate_exit_code: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# pre_dispatch_check
+# ---------------------------------------------------------------------------
+
+
+def test_pre_dispatch_allows_when_under_budget():
+    assert d.pre_dispatch_check(FakeRoutine(max_iterations=5, iteration_count=2)).action == "continue"
+
+
+def test_pre_dispatch_max_iterations():
+    res = d.pre_dispatch_check(FakeRoutine(max_iterations=3, iteration_count=3))
+    assert res.is_terminate and res.reason == d.REASON_MAX_ITERATIONS
+
+
+def test_pre_dispatch_max_cost():
+    res = d.pre_dispatch_check(FakeRoutine(max_cost_usd=5.0, total_cost_usd=5.5))
+    assert res.is_terminate and res.reason == d.REASON_MAX_COST
+
+
+def test_pre_dispatch_deadline():
+    res = d.pre_dispatch_check(FakeRoutine(deadline_at=datetime.now(UTC) - timedelta(hours=1)))
+    assert res.is_terminate and res.reason == d.REASON_DEADLINE
+
+
+def test_pre_dispatch_naive_deadline_treated_as_utc():
+    # naive datetime 不应抛错（被视为 UTC）
+    res = d.pre_dispatch_check(FakeRoutine(deadline_at=datetime(2000, 1, 1)))
+    assert res.is_terminate and res.reason == d.REASON_DEADLINE
+
+
+# ---------------------------------------------------------------------------
+# decide
+# ---------------------------------------------------------------------------
+
+
+def test_decide_success_when_score_meets_threshold_and_gate_ok():
+    r = FakeRoutine(best_score=92)
+    it = FakeIter(score=92, verdict="pass", gate_exit_code=0)
+    res = d.decide(r, it, [it])
+    assert res.is_terminate and res.reason == d.REASON_SUCCESS
+
+
+def test_decide_success_blocked_by_failing_gate():
+    r = FakeRoutine(best_score=92)
+    it = FakeIter(score=92, verdict="pass", gate_exit_code=1)
+    assert d.decide(r, it, [it]).action == "continue"
+
+
+def test_decide_unrecoverable_verdict():
+    r = FakeRoutine(best_score=40)
+    it = FakeIter(score=40, verdict="unrecoverable")
+    res = d.decide(r, it, [it])
+    assert res.is_terminate and res.reason == d.REASON_UNRECOVERABLE
+
+
+def test_decide_unrecoverable_on_consecutive_exec_failures():
+    r = FakeRoutine(best_score=50)
+    hist = [FakeIter(seq=i, exec_status="error", score=None) for i in range(1, 4)]
+    res = d.decide(r, hist[-1], hist)
+    assert res.is_terminate and res.reason == d.REASON_UNRECOVERABLE
+
+
+def test_decide_no_progress_plateau():
+    r = FakeRoutine(best_score=70, no_progress_patience=3)
+    hist = [
+        FakeIter(seq=1, score=70, verdict="stalled"),
+        FakeIter(seq=2, score=65, verdict="stalled"),
+        FakeIter(seq=3, score=68, verdict="stalled"),
+        FakeIter(seq=4, score=70, verdict="stalled"),
+    ]
+    res = d.decide(r, hist[-1], hist)
+    assert res.is_terminate and res.reason == d.REASON_NO_PROGRESS
+
+
+def test_decide_oscillation():
+    r = FakeRoutine(best_score=60, no_progress_patience=10)  # patience 大以排除 no_progress 抢先
+    hist = [
+        FakeIter(seq=1, score=50, verdict="progressing"),
+        FakeIter(seq=2, score=40, verdict="regressed"),
+        FakeIter(seq=3, score=52, verdict="progressing"),
+        FakeIter(seq=4, score=45, verdict="regressed"),
+    ]
+    res = d.decide(r, hist[-1], hist)
+    assert res.is_terminate and res.reason == d.REASON_OSCILLATION
+
+
+def test_decide_continue_when_progressing_with_headroom():
+    r = FakeRoutine(best_score=60, no_progress_patience=3)
+    hist = [
+        FakeIter(seq=1, score=40, verdict="progressing"),
+        FakeIter(seq=2, score=60, verdict="progressing"),
+    ]
+    assert d.decide(r, hist[-1], hist).action == "continue"
+
+
+def test_decide_budget_checked_after_eval():
+    # 评估后即时熔断：成本已超即使分数未达标也终止
+    r = FakeRoutine(best_score=50, max_cost_usd=5.0, total_cost_usd=6.0)
+    it = FakeIter(score=50, verdict="progressing")
+    res = d.decide(r, it, [it])
+    assert res.is_terminate and res.reason == d.REASON_MAX_COST
+
+
+# ---------------------------------------------------------------------------
+# prompt_builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_prompt_first_run_has_goal_and_criteria():
+    r = FakeRoutine()
+    prompt = build_prompt(r)
+    assert "实现功能 X" in prompt
+    assert "通过全部验收项" in prompt
+    assert "开始" in prompt  # 首次执行段
+    assert "既往迭代的反馈" not in prompt  # 无反思
+
+
+def test_build_prompt_resume_injects_reflections():
+    r = FakeRoutine(
+        claude_session_id="sess-1",
+        reflections={"items": ["补充单元测试", "修复边界条件"]},
+    )
+    prompt = build_prompt(r)
+    assert "既往迭代的反馈" in prompt
+    assert "补充单元测试" in prompt
+    assert "修复边界条件" in prompt
+    assert "继续" in prompt  # resume 段
+
+
+def test_build_prompt_caps_reflections_window():
+    r = FakeRoutine(
+        claude_session_id="s",
+        reflections={"items": [f"r{i}" for i in range(10)]},
+    )
+    prompt = build_prompt(r, max_reflections=3)
+    # 仅最近 3 条
+    assert "r9" in prompt and "r8" in prompt and "r7" in prompt
+    assert "r0" not in prompt and "r6" not in prompt
+
+
+def test_append_reflection_returns_new_dict():
+    before = {"items": ["a"]}
+    after = append_reflection(before, "b")
+    assert after == {"items": ["a", "b"]}
+    assert before == {"items": ["a"]}  # 原 dict 不被原地修改
+
+
+def test_append_reflection_ignores_empty():
+    assert append_reflection({"items": ["a"]}, "   ") == {"items": ["a"]}
+
+
+def test_append_reflection_handles_none():
+    assert append_reflection(None, "first") == {"items": ["first"]}
+
+
+# ---------------------------------------------------------------------------
+# handler 注册
+# ---------------------------------------------------------------------------
+
+
+def test_routine_inspector_handler_registered():
+    from negentropy.engine.schedulers.handlers import (
+        _bootstrap_default_handlers,
+        get_descriptor,
+        get_handler,
+    )
+
+    _bootstrap_default_handlers()
+    assert get_handler("routine_inspector") is not None
+    desc = get_descriptor("routine_inspector")
+    assert desc is not None
+    assert desc.supported_trigger_types == ("interval",)
+
+
+@pytest.mark.asyncio
+async def test_routine_inspector_noop_when_disabled(monkeypatch):
+    """enabled=False 时 handler 直接 no-op，不触发编排。"""
+    from negentropy.config import settings
+    from negentropy.config.routine import RoutineSettings
+    from negentropy.engine.schedulers.handlers.routine_inspector import routine_inspector_handler
+
+    # settings.routine 是 cached_property；构造一个 disabled 实例覆盖缓存值。
+    # RoutineSettings frozen，但 enabled 默认即 False，直接用默认实例。
+    disabled = RoutineSettings()
+    assert disabled.enabled is False
+    monkeypatch.setattr(type(settings), "routine", property(lambda self: disabled))
+
+    class _Task:
+        payload: dict = {}
+
+    result = await routine_inspector_handler(_Task())
+    assert result.status == "ok"
+    assert "disabled" in (result.output_summary or "")

--- a/docs/.agents/knowledge-map.md
+++ b/docs/.agents/knowledge-map.md
@@ -30,6 +30,7 @@
 - [Knowledge Base（知识库设计）](../concepts/035-the-knowledge-base.md)
 - [Knowledge Graph（知识图谱）](../concepts/036-the-knowledge-graph.md) · [联邦知识图谱 + 跨 Corpus 混合检索](../concepts/037-federated-kg.md)
 - [Claude Code 集成（BuiltinTool）](../concepts/038-claude-code-integration.md) — Claude Code CLI 作为 ADK Agent 工具的接入方案
+- [Routine（长周期自主任务）](../concepts/039-the-routine-system.md) — Engine 编排 + Claude Code 执行的 Evaluator-Optimizer 自迭代闭环（含 Reflexion 反思记忆、LLM-as-Judge 评估、审批门控、停止护栏）
 - [Skills](../concepts/design/skills.md)
 - [Negentropy Wiki Ops](../reference/wiki/ops.md)
 - [Wiki 知识图谱（按 Publication 切片发布）](../reference/wiki/design/knowledge-graph.md)
@@ -53,6 +54,7 @@
 
 - [Research（研究文献索引）](../research/) — 认知增强、上下文工程、Agent runtime、向量检索、知识图谱、Agent Sandbox 等领域基线调研
 - [ADK 2.0 升级调研](../research/020b-adk-2.0-upgrade.md) — Google ADK 2.0 核心新特性、Breaking Changes、本项目影响评估与渐进式升级路径
+- [Routine Agent 迭代模式调研](../research/110-routine-agent-iteration.md) — ReAct/Reflexion/Self-Refine/LATS/Voyager + LLM-as-Judge + Claude Code/Codex/Gemini/OpenHands 工程实践与停止护栏（长周期自主任务理论基础）
 
 ## 用户文档与运维
 

--- a/docs/concepts/039-the-routine-system.md
+++ b/docs/concepts/039-the-routine-system.md
@@ -1,0 +1,305 @@
+# The Routine System：长周期自主任务架构设计
+
+> 「持续自迭代自主决策任务执行」的全生命周期支持。Negentropy Engine 担任 **Orchestrator + Evaluator**，Claude Code 担任 **Executor**，构成 Evaluator-Optimizer 闭环（结合 Reflexion 跨迭代反思记忆）。
+>
+> - 理论与工程调研：[Routine Agent 迭代模式调研](../research/110-routine-agent-iteration.md)
+> - Claude Code 接入：[Claude Code 集成设计](./038-claude-code-integration.md)
+> - 心跳调度引擎：[Framework](./framework.md)
+
+---
+
+## 1. 设计动机
+
+单次 Agent 调用在长周期任务上存在结构性缺陷：无法根据中间产出自我纠偏、缺乏跨轮次的失败记忆、没有客观的完成度判定与预算护栏。Routine 把这一空白补齐为一个**闭环控制系统**：
+
+1. 用户提交一个长任务（目标 + 验收标准 + 预算）；
+2. Engine 将目标派发给 Claude Code 执行，记录阶段性结果（摘要 / session_id / 成本 / 轮数）；
+3. Engine 用 **LLM-as-Judge + 可选命令门控** 评估结果，产出评分（0-100）、verdict 与自然语言反思；
+4. Engine **自主决策**：继续迭代（再次调度 Claude Code，复用其 session 并注入累积反思）或终止（成功 / 不可恢复 / 预算耗尽）；
+5. 如此反复，直至取得满意结果或触发终止信号。
+
+**核心原则**：编排与执行职责分离——Engine 决策「做什么 / 是否继续」，Claude Code 决策「怎么做」；所有护栏在 Engine 代码层硬编码强制，不依赖模型自律。
+
+## 2. 架构总览
+
+```mermaid
+flowchart TB
+    subgraph UI["前端 negentropy-ui · Interface / Routine"]
+        PAGE["RoutinePage<br/>列表 / 详情抽屉 / 创建表单"]
+        SSE_C["useRoutineStream<br/>SSE 订阅"]
+    end
+
+    subgraph API["接口层 interface/routine_api.py"]
+        REST["REST: CRUD + start/pause/resume/cancel<br/>+ approve/reject"]
+        STREAM["GET /routines/stream (SSE)"]
+    end
+
+    subgraph SCHED["调度引擎 schedulers/registry.py"]
+        TICK["routine_inspector ScheduledTask<br/>interval=25s 心跳"]
+    end
+
+    subgraph ENGINE["编排引擎 engine/routine/"]
+        ORCH["RoutineOrchestrator.inspect_once()<br/>reap → evaluate → dispatch"]
+        EVAL["RoutineEvaluator<br/>命令门控 + LLM-as-Judge"]
+        DEC["decision.py<br/>纯函数守卫"]
+        RUN["RoutineRunner<br/>后台 asyncio.Task + 信号量"]
+        BUS["RoutineBus<br/>SSE 事件 fan-out"]
+    end
+
+    subgraph EXEC["执行层"]
+        CC["ClaudeCodeService.invoke()<br/>SDK / CLI + resume_session_id"]
+    end
+
+    subgraph DB["PostgreSQL"]
+        T1[("routines")]
+        T2[("routine_iterations")]
+    end
+
+    PAGE -->|fetch| REST
+    SSE_C -.->|EventSource| STREAM
+    REST --> T1
+    REST --> T2
+    TICK --> ORCH
+    ORCH --> DEC
+    ORCH --> EVAL
+    ORCH --> RUN
+    RUN --> CC
+    ORCH --> BUS
+    RUN --> BUS
+    BUS -.-> STREAM
+    ORCH --> T1
+    ORCH --> T2
+    RUN --> T2
+
+    classDef ui fill:#1e3a5f,stroke:#4a9eff,color:#e0f0ff
+    classDef api fill:#3d2f5c,stroke:#a87fff,color:#f0e8ff
+    classDef sched fill:#5c4a1e,stroke:#ffc857,color:#fff5e0
+    classDef engine fill:#1e4d3a,stroke:#4ade80,color:#e0ffe8
+    classDef exec fill:#5c1e2e,stroke:#ff6b81,color:#ffe0e8
+    classDef db fill:#2d2d3d,stroke:#8888aa,color:#e0e0f0
+    class PAGE,SSE_C ui
+    class REST,STREAM api
+    class TICK sched
+    class ORCH,EVAL,DEC,RUN,BUS engine
+    class CC exec
+    class T1,T2 db
+```
+
+**关键架构决策：心跳 Inspector + 后台 Runner**。Routine 不为每个任务起一个独立调度任务，而是用**单个** `routine_inspector` 心跳任务（复用统一调度引擎）周期性调用 `inspect_once()`；`inspect_once()` 只做轻量决策（DB 读写 + 后台任务调度），真正长耗时的 Claude Code 执行交由进程内 `asyncio.Task` 后台 Runner 异步完成。这样心跳 tick 始终远低于其超时阈值，且评估—决策—执行三阶段得以解耦。
+
+> **否决方案**：「每 Routine 一个 backing ScheduledTask」。原因：① 调度引擎默认 lease（120s）短于 Claude Code 执行时长（可达 300s+），会导致重复派发；② Execute+Evaluate+Decide 三阶段无法优雅塞入单次 handler；③ Routine 是事件驱动（评估完立即再派发），非 wall-clock 定时。
+
+## 3. 数据模型
+
+```mermaid
+erDiagram
+    routines ||--o{ routine_iterations : "1:N (CASCADE)"
+
+    routines {
+        uuid id PK
+        string key UK
+        string title
+        text goal
+        text acceptance_criteria
+        text cwd
+        text verification_command
+        string status "pending|running|paused|succeeded|failed|cancelled"
+        string termination_reason
+        int max_iterations
+        float max_cost_usd
+        timestamptz deadline_at
+        int success_score_threshold
+        int no_progress_patience
+        string approval_mode "auto|first|every"
+        int iteration_count "反规范化"
+        float total_cost_usd "反规范化"
+        int best_score
+        int last_score
+        string claude_session_id "session 续接"
+        jsonb reflections "Reflexion 记忆 {items:[]}"
+        jsonb config "Claude Code 配置覆盖"
+    }
+
+    routine_iterations {
+        uuid id PK
+        uuid routine_id FK
+        int seq "UNIQUE(routine_id,seq)"
+        string status "dispatched|in_flight|executed|evaluated|..."
+        text prompt
+        string resume_session_id
+        string exec_status "success|error|timeout"
+        text summary
+        string claude_session_id
+        float cost_usd
+        int turn_count
+        int score "0-100"
+        string verdict "pass|progressing|stalled|regressed|unrecoverable"
+        text reflection "评估器反馈"
+        int gate_exit_code "命令门控退出码"
+        timestamptz lease_expires_at "崩溃恢复租约"
+        jsonb metrics
+    }
+```
+
+- **`routines`**：长周期任务注册源。`reflections` JSONB 存累积反思（Reflexion episodic memory）；`config` 存 Claude Code 配置覆盖（model / max_turns / allowed_tools 等）；`iteration_count` / `total_cost_usd` / `best_score` 反规范化以加速守卫判定。
+- **`routine_iterations`**：单次 Execute→Evaluate→Decide 周期的 append-mostly 事实表。`lease_expires_at` 为后台 Runner 的崩溃恢复租约；`UNIQUE(routine_id, seq)` 为并发派发的硬幂等兜底。
+
+模型定义：[`models/routine.py`](../../apps/negentropy/src/negentropy/models/routine.py)；建表与种子迁移：[`0048_routine_tables.py`](../../apps/negentropy/src/negentropy/db/migrations/versions/0048_routine_tables.py)。
+
+## 4. 生命周期状态机
+
+### 4.1 Routine 状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: 创建
+    pending --> running: start()
+    pending --> cancelled: cancel()
+    running --> paused: pause() + 中止在途迭代
+    paused --> running: resume()
+    paused --> cancelled: cancel()
+    running --> succeeded: 评分≥阈值且门控通过
+    running --> failed: 守卫触发(预算/停滞/振荡/不可恢复)
+    running --> cancelled: cancel()
+    succeeded --> [*]
+    failed --> [*]
+    cancelled --> [*]
+```
+
+### 4.2 迭代状态机（含审批门控）
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending_approval: approval_mode≠auto
+    [*] --> dispatched: approval_mode=auto
+    pending_approval --> dispatched: 用户 approve
+    pending_approval --> aborted: 用户 reject
+    dispatched --> in_flight: Runner 拾取
+    in_flight --> executed: Claude Code 返回
+    in_flight --> reaped: lease 过期(崩溃)
+    in_flight --> aborted: 用户 cancel
+    executed --> evaluated: 评估器评分
+    evaluated --> [*]
+    reaped --> [*]
+    aborted --> [*]
+```
+
+**Human-in-the-Loop**：`approval_mode` 决定迭代初始状态——`auto` 全自动（直接 `dispatched`）；`first` 仅首迭代需审批；`every` 每迭代需审批。`pending_approval` 的迭代不会被 Runner 拾取，等待 API `approve` 转 `dispatched` 后才执行。
+
+## 5. 编排循环 `inspect_once()`
+
+每次心跳 tick 执行三阶段（顺序：先回收、再评估、后派发）：
+
+```mermaid
+sequenceDiagram
+    participant Tick as routine_inspector 心跳
+    participant Orch as RoutineOrchestrator
+    participant Eval as RoutineEvaluator
+    participant Dec as decision.py
+    participant Run as RoutineRunner
+    participant CC as ClaudeCodeService
+    participant DB as PostgreSQL
+
+    Tick->>Orch: inspect_once()
+
+    Note over Orch,DB: (a) REAP 回收孤儿
+    Orch->>DB: 查 in_flight 且 lease 过期
+    Orch->>DB: 本进程不持有 → 标记 reaped
+
+    Note over Orch,Dec: (b) EVALUATE + DECIDE
+    Orch->>DB: 查最新迭代=executed 的 routine
+    Orch->>Eval: evaluate(routine, iteration)
+    Eval->>Eval: 命令门控(可选) + LLM-as-Judge
+    Eval-->>Orch: score / verdict / reflection
+    Orch->>DB: 写评估结果 + 追加反思
+    Orch->>Dec: decide(routine, latest, history)
+    Dec-->>Orch: continue | terminate(reason)
+    alt terminate
+        Orch->>DB: 置终态 + termination_reason
+    end
+
+    Note over Orch,CC: (c) DISPATCH 派发下一迭代
+    Orch->>DB: 查 running 且无在途迭代(FOR UPDATE SKIP LOCKED)
+    Orch->>Dec: pre_dispatch_check(预算/截止)
+    Orch->>DB: 创建迭代(dispatched 或 pending_approval)
+    Orch->>Run: launch(非阻塞)
+    Run->>CC: invoke(prompt, config, abort_event)
+    CC-->>Run: ClaudeCodeResult
+    Run->>DB: 写回结果 + 更新 routine 累计
+```
+
+模块布局（[`engine/routine/`](../../apps/negentropy/src/negentropy/engine/routine/)）：
+
+| 模块 | 职责 |
+|------|------|
+| `orchestrator.py` | `inspect_once()` 主控制循环（reap / evaluate / dispatch） |
+| `runner.py` | 进程内后台执行器注册表 + 全局并发信号量；非阻塞调用 ClaudeCodeService |
+| `evaluator.py` | LLM-as-Judge + 命令门控，产出 score / verdict / reflection |
+| `decision.py` | 纯函数守卫与决策（可单元测试，无 IO） |
+| `prompt_builder.py` | 构建含目标 + 验收标准 + 累积反思的 prompt（Reflexion 注入） |
+| `bus.py` | RoutineBus，SSE 事件 fan-out |
+
+## 6. 评估管线：混合方案
+
+评估采用 **LLM-as-Judge + 可选命令门控** 的混合方案：
+
+1. **命令门控**（若配置 `verification_command`）：在 routine 工作目录执行测试命令，退出码喂给 Judge prompt 并作为成功的硬约束——门控失败时评分封顶，成功的判定要求 `gate_exit_code == 0`。这是 Codex 式「测试驱动自校验」的客观锚点。
+2. **LLM-as-Judge**：复用 `LLMFactExtractor` 的 LLM 调用范式（`resolve_model_config_async("routine.evaluate")` + `litellm.acompletion` 结构化 JSON 输出 + 指数退避重试），`temperature=0` 保证确定性，输出 `{score, verdict, reflection}`。
+
+**偏差治理**：客观门控锚定评分以缓解 LLM 评审的 verbosity / self-preference 偏差；score 与 verdict 解耦，使停滞检测在绝对分数漂移时仍可依趋势判定。详见[调研 §3](../research/110-routine-agent-iteration.md)。
+
+## 7. 停止准则与护栏
+
+全部在 `decision.py` 中以**纯函数**实现，硬编码强制（非模型自律）：
+
+| 守卫 | 触发条件 | termination_reason |
+|------|---------|--------------------|
+| 成功 | `score ≥ success_score_threshold` 且门控通过 | `success` |
+| 迭代上限 | `iteration_count ≥ max_iterations` | `max_iterations` |
+| 成本熔断 | `total_cost_usd ≥ max_cost_usd` | `max_cost` |
+| 截止时间 | `now ≥ deadline_at` | `deadline` |
+| 进度停滞 | 最近 N 次评分均未超历史最优 | `no_progress` |
+| 振荡 | 评分无净增长且 verdict 反复横跳 | `oscillation` |
+| 不可恢复 | judge 判 unrecoverable / 连续执行失败 / 连续评估失败 | `unrecoverable_error` |
+
+**崩溃恢复**：进程内 Runner 非崩溃安全，由 Reaper 兜底——迭代携带 `lease_expires_at`（= 执行超时 + slack），进程重启后孤儿在途迭代被标记 `reaped`，下一 tick 重新派发并复用 `claude_session_id` 续接。
+
+## 8. 配置
+
+配置源：[`config/routine.py`](../../apps/negentropy/src/negentropy/config/routine.py)（`RoutineSettings`，env 前缀 `NE_ROUTINE_`，YAML 节点 `routine:`，默认值见 `config.default.yaml`）。
+
+| 配置项 | 默认 | 说明 |
+|--------|------|------|
+| `enabled` | `false` | 灰度开关；关闭时心跳 no-op |
+| `inspector_interval_seconds` | `25` | 心跳 tick 间隔 |
+| `max_concurrent_executions` | `2` | 全局并发 Claude Code 执行上限 |
+| `lease_slack_seconds` | `60` | Runner 租约宽裕量 |
+| `gate_timeout_seconds` | `120` | 命令门控执行超时 |
+| `max_reflections_injected` | `5` | 注入 prompt 的最近反思条数 |
+| `eval_failure_patience` | `3` | 评估连续失败容忍次数 |
+| `default_max_iterations` | `20` | 创建默认迭代上限 |
+| `default_max_cost_usd` | `5.0` | 创建默认成本熔断 |
+| `evaluator_model` | `null` | 评估器模型覆盖（走 `routine.evaluate` task slot 解析） |
+
+评估器模型可在 Interface / Task Models 页为 `routine.evaluate` 槽位单独绑定。
+
+## 9. API 与前端
+
+REST 端点（[`interface/routine_api.py`](../../apps/negentropy/src/negentropy/interface/routine_api.py)，prefix `/routines`）：
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/routines` · `/routines/{id}` · `/routines/{id}/iterations` · `/routines/kpis` | 查询 |
+| POST | `/routines` · PUT/DELETE `/routines/{id}` | CRUD |
+| POST | `/routines/{id}/{start\|pause\|resume\|cancel}` | 控制 |
+| POST | `/routines/{id}/iterations/{iid}/{approve\|reject}` | 审批门控 |
+| GET | `/routines/stream` | SSE 实时事件（routine + iteration） |
+
+前端位于 [`app/interface/routine/`](../../apps/negentropy-ui/app/interface/routine/)：列表 + KPI + 过滤 + 创建/编辑表单 + 详情抽屉（迭代时间线 + 评分趋势 + 控制按钮 + 审批操作）。导航在 `InterfaceNav.tsx` 的 Scheduler 之后新增 Routine 二级菜单。SSE 实时更新经 `useRoutineStream` 订阅 `/api/routine/stream`。
+
+## 10. 涟漪效应与边界
+
+- **对调度引擎**：仅新增一个种子 ScheduledTask（`routine_inspector`），复用既有心跳与 SSE 范式，零侵入。
+- **对 Claude Code**：仅作为 `ClaudeCodeService.invoke()` 的调用方，复用既有 SDK/CLI 双路径与 `resume_session_id` 能力。
+- **单进程假设**：进程内 Runner 注册表要求单 engine 进程持有 Routine 编排（与调度引擎同进程同 loop）。DB 层 `FOR UPDATE SKIP LOCKED` + 每 routine 单在途 + 唯一约束为多并发 tick 的硬幂等兜底。
+- **灰度**：`routine.enabled=false` 默认关闭，对现有功能零影响。

--- a/docs/research/110-routine-agent-iteration.md
+++ b/docs/research/110-routine-agent-iteration.md
@@ -1,0 +1,156 @@
+# Routine：长周期自主任务的 Agent 迭代模式调研
+
+> **摘要 / 导言**：单次（single-shot）的智能体调用在长周期（long-horizon）任务上系统性失效——模型一旦交付便丧失对"结果是否达标"的判断与纠错能力，错误沿轨迹复利累积，且缺乏跨轮次的经验承继。Negentropy 的 **Routine** 特性主张以一个**闭环**应对这一困境：由 Engine 担任 Orchestrator + Evaluator，向 Claude Code（Executor）下发目标；Engine 对暂存（staged）产物进行评估——LLM-as-Judge 给出 0–100 分、verdict 与 reflection，并叠加可选的命令/测试客观门禁（objective gate）；据此决策**迭代**（恢复 Claude Code 会话并注入累积反思）或**终止**（成功 / 不可恢复 / 预算耗尽）。本报告综合迭代式智能体的学术基础、LLM-as-a-Judge 的偏差治理、业界编码智能体的长程执行工程，以及停止准则与失控防护，最终将这些证据映射到 Routine 的具体设计决策上。
+
+---
+
+## 1. 问题背景与设计命题
+
+长周期任务（跨越数十至数百步、可能持续数小时的编码、重构、调研类工作）对智能体提出了三重挑战，而这三者恰是单次调用范式无法回应的。
+
+其一，**误差复利（compounding error）**。Anthropic 在《Building Effective AI Agents》中明确指出，赋予智能体自主性会同时放大成本与"复合错误"（compounding errors）的风险，因此每一步都应从环境获取"ground truth"（如工具执行结果）以评估进展<sup>[[1]](#ref1)</sup>。单次调用恰恰缺失这一反馈通道：模型在内部"自信"地生成全部输出，却无任何外部信号校准其轨迹。
+
+其二，**判停缺位**。模型自身难以可靠地判断"任务是否真正完成"。当评估与生成由同一前向过程承担时，模型倾向于在语言层面宣告成功而非在事实层面验证成功。将"生成"与"评判"正交解耦（Orthogonal Decomposition），使评估成为独立的、可锚定客观证据的环节，是恢复判停能力的前提。
+
+其三，**经验不可承继**。朴素的"失败即重试"会丢弃上一轮的全部教训，使智能体在同一陷阱上反复跌倒。长周期任务需要一种跨轮次的**情节记忆（episodic memory）**，把失败转化为可被下一轮利用的约束。
+
+由此引出 Routine 的核心设计命题——**闭环生成–评估–决策（generator → evaluator → decide loop）**：以独立评估器锚定客观信号对抗误差复利，以显式终止准则恢复判停，以反思注入实现经验承继。下文逐层论证其学术与工程基础。
+
+```mermaid
+flowchart LR
+    G["Generator<br/>Claude Code<br/>(Executor)"] -->|"staged result"| E["Evaluator<br/>LLM-as-Judge<br/>+ Objective Gate"]
+    E -->|"score / verdict / reflection"| D{"Decide"}
+    D -->|"iterate:<br/>resume + inject reflections"| G
+    D -->|"terminate:<br/>success / unrecoverable / budget"| T(["Done"])
+
+    style G fill:#1f3a5f,stroke:#5b9bd5,stroke-width:2px,color:#e8f0fe
+    style E fill:#3d2c52,stroke:#a07cc5,stroke-width:2px,color:#f3e9fb
+    style D fill:#5a3d1f,stroke:#d59b5b,stroke-width:2px,color:#fdf3e8
+    style T fill:#1f4d2e,stroke:#5bbd7c,stroke-width:2px,color:#e8fbef
+```
+
+---
+
+## 2. 学术基础：迭代式智能体模式
+
+闭环迭代并非新构想，过去数年的多项工作从不同侧面奠定了其方法论。以下逐一阐述其机制，并指明对 Routine 闭环的映射。
+
+**ReAct（推理–行动交织）**。Yao 等人提出将"推理轨迹（reasoning trace）"与"行动（action）"在同一序列中交替生成：推理用于规划与追踪状态，行动用于与外部环境交互并取回观测，二者协同减少幻觉、提升可解释性<sup>[[2]](#ref2)</sup>。ReAct 确立了"思考→行动→观测"的基本节律，是 Executor 单次会话内部循环的原型；Routine 在其之上叠加了**跨会话**的外层循环。
+
+**Reflexion（口头化自我反思持久为情节记忆）**。Shinn 等人提出 Reflexion 框架：智能体在一轮失败后，将环境反馈转译为**自然语言形式的"口头强化（verbal reinforcement）"反思**，并将其写入情节记忆缓冲，供后续轮次的决策检索利用——无需更新模型权重即可实现跨试验的策略改进<sup>[[3]](#ref3)</sup>。这正是 Routine **反思注入（reflection injection）**机制的理论内核：每轮评估产出的 reflection 被持久化并在下一轮恢复会话时回注，使智能体"记住"为何失败、如何规避。Reflexion 由此成为本报告最直接的设计依据。
+
+**Self-Refine（自反馈迭代精修）**。Madaan 等人证明，同一个 LLM 可在无额外训练的前提下，对自身输出生成反馈并据此迭代改写，从而提升质量<sup>[[4]](#ref4)</sup>。它印证了"生成–反馈–精修"循环的有效性；Routine 的差异在于将反馈职责交由**独立**的评估器并锚定客观门禁，以缓解"自我评判"的乐观偏置（见 §3）。
+
+**LATS（语言智能体树搜索）**。Zhou 等人将蒙特卡洛树搜索（MCTS）引入语言智能体，统一推理、行动与规划：通过对多条候选轨迹进行扩展、评估与回溯（backtracking），在解空间中进行有引导的探索<sup>[[5]](#ref5)</sup>。LATS 代表迭代的"分支搜索"形态。Routine 当前采用**线性恢复式迭代**（resume-and-retry）而非树搜索，以换取实现简洁与会话连续性；但 LATS 的"评估驱动回溯"思想为 Routine 未来引入分支/检查点回退预留了演进方向。
+
+**Voyager（自动课程 + 技能库 + 自验证）**。Wang 等人在 Minecraft 中构建终身学习智能体 Voyager，其三大组件为：自动课程（automatic curriculum）渐进式提出目标、可复用技能库（skill library）沉淀可执行代码、以及**自验证（self-verification）**机制校验任务完成度并在失败时驱动重试<sup>[[6]](#ref6)</sup>。Voyager 的自验证回路与 Routine 的"评估器判停"同构；其技能库沉淀思想则与 Negentropy 的知识结晶（Knowledge Crystallization）理念相呼应——失败教训与成功范式都应被持久化为系统资产。
+
+---
+
+## 3. 评估机制：LLM-as-a-Judge 及其偏差治理
+
+将 LLM 用作评估器（LLM-as-a-Judge）是 Routine 评估环节的技术选型，但该范式存在系统性偏差，必须以工程手段治理。Gu 等人的系统综述梳理了这一领域的主要偏差类型<sup>[[7]](#ref7)</sup>：
+
+- **位置偏差（position bias）**：评判结果受候选呈现顺序影响；
+- **冗长偏差（verbosity bias）**：倾向给更长的回答打高分，而非更正确的；
+- **自我偏好（self-preference）**：评估模型偏好与自身风格相近或自身生成的内容；
+- **评分区间偏差（scoring-range / scale bias）**：分数在区间内分布失衡、缺乏区分度。
+
+针对上述偏差，Routine 采用三项相互正交的缓解策略：
+
+1. **确定性评判（temperature = 0）**：将评估调用的温度置零，消除随机抖动，使同一产物在重复评估下给出稳定结论，便于"无进展/震荡"检测（见 §5）依赖可复现的分数轨迹。
+2. **客观门禁锚定（objective gate anchoring）**：在主观分数之外引入可选的命令/测试门禁（如编译、单测、lint）。客观门禁提供不可被语言风格"游说"的硬信号，从根本上抑制冗长偏差与自我偏好对最终决策的污染——评估器再"健谈"，也无法让一个未通过测试的产物被判为成功。
+3. **分数与裁定解耦（score + verdict decoupling）**：将连续分数（0–100，用于趋势与阈值判断）与离散裁定（verdict，如 pass/fail/continue）分离产出，并要求评估器附带 reflection 说明理由。解耦避免了"用单一标量承载过多语义"的脆弱性，也使 reflection 成为可注入下一轮的结构化经验。
+
+此外，长上下文场景下的"**Lost in the Middle**"效应不容忽视。Liu 等人发现，当关键信息位于长上下文的中段时，模型的利用率显著低于其位于首尾时——性能随相关信息位置呈现 U 形曲线<sup>[[8]](#ref8)</sup>。这对 Routine 有两点直接含义：其一，注入评估器的累积反思应**置于提示的显著位置**（首部或尾部），而非淹没于冗长的历史中段；其二，反思需经提炼压缩而非无限堆叠，以免关键约束因落入"中间盲区"而被忽视。
+
+---
+
+## 4. 工程实践：业界编码智能体的长程执行
+
+学术模式之外，主流编码智能体的工程实现为 Routine 提供了可直接借鉴的落地范式。
+
+**Anthropic —《Building Effective AI Agents》**。该文（2024-12-19）系统归纳了若干可组合的工作流与智能体模式，其中两者与 Routine 高度契合<sup>[[1]](#ref1)</sup>：
+
+- **Evaluator-Optimizer（评估器–优化器）**：一个 LLM 生成响应，另一个 LLM 评估并给出反馈，在循环中迭代。适用场景的判据是"存在清晰的评估标准，且迭代精修能带来可测量的提升"。这正是 Routine 闭环的工程命名对应物。
+- **Orchestrator-Workers（编排者–工作者）**：中央 LLM 动态拆解任务、分派子任务、再汇总结果；适用于"无法预先预测子任务"的复杂任务（如跨多文件的代码变更）。Routine 中 Engine 即扮演 Orchestrator 角色，Claude Code 则是承接具体执行的 Worker。
+
+尤为关键的是其关于停止准则的指引：文中建议为自主智能体设置停止条件"**例如最大迭代次数（maximum number of iterations）**"以保持可控，并强调因自主性抬升成本与复合错误风险，须在沙盒环境中充分测试并辅以"适当的护栏（appropriate guardrails）"<sup>[[1]](#ref1)</sup>。这为 §5 的硬性护栏提供了权威背书。
+
+**Claude Code Headless / Agent SDK**。Claude Code 的无头模式是 Routine 将其作为 Executor 编排的技术基础<sup>[[9]](#ref9)</sup>。关键能力包括：以 `claude -p`（`--print`）非交互运行；`--output-format stream-json` 以 NDJSON 逐行输出事件，适配长任务的实时监控；通过捕获 JSON 输出中的 `session_id` 并以 `--resume $session_id` **恢复既有会话**，从而在多次独立调用间承继完整对话历史；以及以 `--max-turns` 约束单次调用的内部迭代上限（无头模式默认上限为 10 轮），作为成本与安全控制（部分版本另提供 `--max-budget-usd` 等预算开关，需以实际 CLI/SDK 版本为准）。其中，**会话跨调用连续性**是有状态迭代的命门——它使 Engine 能够"暂停—评估—带着反思恢复"，而非每轮从零重启，丢失上下文。
+
+**OpenAI Codex（2025）**。Codex 体现了"Plan → Edit → Test → Observe → Repair"的测试驱动自纠循环：以持久化的规约/计划/状态文件（spec / plan / status）作为长任务的锚点，使智能体在长时间运行中维持目标一致性（业界曾报道其在约 25 小时的连续自主实验中的表现）<sup>[[10]](#ref10)</sup>。其启示是：**持久化的外部状态文件**能显著抑制长程任务的目标漂移，而测试反馈是自纠的客观信号源——二者分别对应 Routine 的持久化状态表与客观门禁。
+
+**Google Gemini CLI**。Gemini CLI 以 ReAct 循环为执行内核，配合 `GEMINI.md` 提供项目级上下文约定，并支持非交互（non-interactive）模式以嵌入自动化管线<sup>[[11]](#ref11)</sup>。它印证了"ReAct 内核 + 项目记忆文件 + 无头执行"已成为编码智能体的事实标准组合，与 Claude Code 的形态高度一致。
+
+**OpenHands（原 OpenDevin）**。Wang 等人将智能体抽象为"**从事件历史到下一事件的函数，在循环中运行**"（agent = function from event history to next event, run in a loop），并内置 `MAX_ITERATIONS` 与成本（cost）截断作为护栏<sup>[[12]](#ref12)</sup>。这一极简而深刻的抽象，恰是 Routine "事件驱动 + 硬护栏"架构的直接思想来源：迭代循环本身是纯粹的状态转移，而护栏是循环之外的强制约束。
+
+---
+
+## 5. 停止准则与失控防护
+
+闭环若无可靠的出口，便从"自主"退化为"失控"。Routine 的护栏设计遵循一条总原则——**护栏在 Engine 代码中硬编码强制（enforce, don't just alert），而非依赖模型自我约束**。模型自我约束在对抗性或退化场景下不可信；唯有执行层的确定性逻辑才能保证终止。
+
+**硬性上限（hard caps）**。三类必备上限：最大迭代次数（`max_iterations`）、最大累计成本（`max_cost`）、绝对截止时间（`deadline`）。任一触顶即无条件终止并标记 `budget_exhausted`。这与 OpenHands 的 `MAX_ITERATIONS` + cost 截断<sup>[[12]](#ref12)</sup>、Anthropic 的"最大迭代次数"指引<sup>[[1]](#ref1)</sup> 一脉相承。
+
+**无进展 / 停滞检测（no-progress / plateau detection）**。当连续 N 轮的评估分数不再提升（或提升幅度低于阈值），判定为陷入平台期，提前终止以止损——这依赖 §3 的确定性评判保证分数轨迹可比。
+
+**震荡检测（oscillation detection）**。当产物或分数在若干状态间往复跳变（A→B→A→B）而无净收敛，判定为震荡并终止，避免在循环中空耗预算。
+
+需要警惕的核心失败模式包括：
+
+- **奖励作弊 / 评估器游说（reward hacking / evaluator gaming）**：Executor 学会"取悦"评估器而非真正达标（例如以冗长辞令利用 verbosity bias）。**对策即客观门禁锚定**——硬信号不可被游说。
+- **震荡（oscillation）**：见上，由震荡检测兜底。
+- **上下文漂移（context drift）**：长程迭代中目标逐渐偏离初衷。**对策为持久化目标/状态文件**（借鉴 Codex<sup>[[10]](#ref10)</sup>）与显著位置的目标重述（对抗 Lost in the Middle<sup>[[8]](#ref8)</sup>）。
+- **成本失控（cost blowup）**：业界已有真实教训——某自主智能体循环因执行层未强制预算约束，最终累积高达数万美元的开销。其关键教益正是"**enforce, don't just alert**"：仅设置告警而不在执行层硬性切断，等同于没有护栏。Routine 据此将预算切断置于决策代码的确定性路径中，使任何单轮调用都无法越过预算红线。
+
+---
+
+## 6. 对 Routine 系统的设计映射
+
+下表将前述每一项模式/证据收敛为 Routine 的具体设计决策，构成"理论—实现"的可追溯映射。系统的完整架构详见 [Routine 系统架构设计](../concepts/039-the-routine-system.md)。
+
+| 学术 / 工程模式 | 关键机制 | Routine 设计决策 |
+| :--- | :--- | :--- |
+| Reflexion<sup>[[3]](#ref3)</sup> | 口头化反思持久为情节记忆，跨轮回注 | **反思注入** + `reflections` JSONB 字段持久化累积反思 |
+| Self-Refine<sup>[[4]](#ref4)</sup> | 生成–反馈–精修循环 | 闭环精修；但反馈职责外移至独立评估器 |
+| ReAct<sup>[[2]](#ref2)</sup> | 思考–行动–观测交织 | Executor 会话内部循环节律 |
+| Evaluator-Optimizer<sup>[[1]](#ref1)</sup> | 生成器 + 独立评估器在环 | `inspect_once`：单轮 evaluate + decide |
+| Orchestrator-Workers<sup>[[1]](#ref1)</sup> | 中央编排 + 工作者执行 | Engine 为 Orchestrator，Claude Code 为 Worker |
+| LLM-as-a-Judge<sup>[[7]](#ref7)</sup> | 主观评分 + 偏差治理 | `RoutineEvaluator`：temperature=0 + 客观门禁锚定 + score/verdict 解耦 |
+| Lost in the Middle<sup>[[8]](#ref8)</sup> | 长上下文中段利用率低 | 反思置于提示显著位置 + 提炼压缩 |
+| Claude Code Headless<sup>[[9]](#ref9)</sup> | `--resume` 会话连续性 | `claude_session_id` 跨调用恢复有状态迭代 |
+| Codex<sup>[[10]](#ref10)</sup> | 持久化 spec/plan/status + 测试自纠 | 持久化状态表锚定目标 + 测试型客观门禁 |
+| OpenHands<sup>[[12]](#ref12)</sup> | 事件历史→下一事件 + 硬护栏 | 护栏硬编码于 `decision.py` 纯函数 |
+| 硬性护栏<sup>[[1]](#ref1)</sup><sup>[[12]](#ref12)</sup> | max_iterations / cost / deadline | `decision.py` 确定性切断（enforce, not alert）|
+| 持久化状态 | 可审计的迭代轨迹 | `Routine` / `RoutineIteration` 数据表 |
+
+综上，Routine 并非对单一论文的复刻，而是将 Reflexion 的反思承继、Evaluator-Optimizer 的双角色解耦、LLM-as-Judge 的偏差治理、Claude Code 的会话连续性，以及 OpenHands/Anthropic 的硬护栏五条证据线，正交地组装为一个可审计、可止损、可自我承继经验的长周期自主执行闭环。
+
+---
+
+## 参考文献
+
+<a id="ref1"></a>[1] Anthropic, "Building effective AI agents," *Anthropic Engineering Blog*, Dec. 19, 2024. [Online]. Available: https://www.anthropic.com/research/building-effective-agents
+
+<a id="ref2"></a>[2] S. Yao, J. Zhao, D. Yu, N. Du, I. Shafran, K. Narasimhan, and Y. Cao, "ReAct: Synergizing reasoning and acting in language models," in *Proc. Int. Conf. Learn. Representations (ICLR)*, 2023, arXiv:2210.03629.
+
+<a id="ref3"></a>[3] N. Shinn, F. Cassano, E. Berman, A. Gopinath, K. Narasimhan, and S. Yao, "Reflexion: Language agents with verbal reinforcement learning," in *Adv. Neural Inf. Process. Syst. (NeurIPS)*, vol. 36, 2023, arXiv:2303.11366.
+
+<a id="ref4"></a>[4] A. Madaan, N. Tandon, P. Gupta, S. Hallinan, L. Gao, S. Wiegreffe, U. Alon, N. Dziri, S. Prabhumoye, Y. Yang, S. Gupta, B. P. Majumder, K. Hermann, S. Welleck, A. Yazdanbakhsh, and P. Clark, "Self-Refine: Iterative refinement with self-feedback," in *Adv. Neural Inf. Process. Syst. (NeurIPS)*, vol. 36, 2023, arXiv:2303.17651.
+
+<a id="ref5"></a>[5] A. Zhou, K. Yan, M. Shlapentokh-Rothman, H. Wang, and Y.-X. Wang, "Language agent tree search unifies reasoning, acting, and planning in language models," in *Proc. Int. Conf. Mach. Learn. (ICML)*, 2024, arXiv:2310.04406.
+
+<a id="ref6"></a>[6] G. Wang, Y. Xie, Y. Jiang, A. Mandlekar, C. Xiao, Y. Zhu, L. Fan, and A. Anandkumar, "Voyager: An open-ended embodied agent with large language models," *Trans. Mach. Learn. Res. (TMLR)*, 2023, arXiv:2305.16291.
+
+<a id="ref7"></a>[7] J. Gu, X. Jiang, Z. Shi, H. Tan, X. Zhai, C. Xu, W. Li, Y. Shen, S. Ma, H. Liu, S. Wang, K. Zhang, Y. Wang, W. Gao, L. Ni, and J. Guo, "A survey on LLM-as-a-judge," 2024, arXiv:2411.15594.
+
+<a id="ref8"></a>[8] N. F. Liu, K. Lin, J. Hewitt, A. Paranjape, M. Bevilacqua, F. Petroni, and P. Liang, "Lost in the middle: How language models use long contexts," *Trans. Assoc. Comput. Linguist. (TACL)*, vol. 12, pp. 157–173, 2024, arXiv:2307.03172.
+
+<a id="ref9"></a>[9] Anthropic, "Run Claude Code programmatically (headless mode)," *Claude Code Documentation*, 2025. [Online]. Available: https://code.claude.com/docs/en/headless
+
+<a id="ref10"></a>[10] OpenAI, "Introducing Codex," *OpenAI Blog*, 2025. [Online]. Available: https://openai.com/index/introducing-codex/
+
+<a id="ref11"></a>[11] Google, "Gemini CLI," *Google Cloud / GitHub Documentation*, 2025. [Online]. Available: https://github.com/google-gemini/gemini-cli
+
+<a id="ref12"></a>[12] X. Wang, B. Li, Y. Song, F. F. Xu, X. Tang, M. Zhuge, J. Pan, Y. Song, B. Li, J. Singh, H. H. Tran, F. Li, R. Ma, M. Zheng, B. Qian, Y. Shao, N. Muennighoff, Y. Zhang, B. Hui, J. Lin, R. Brennan, H. Peng, H. Ji, and G. Neubig, "OpenHands: An open platform for AI software developers as generalist agents," in *Proc. Int. Conf. Learn. Representations (ICLR)*, 2025, arXiv:2407.16741.


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：补齐「长周期自主任务」能力——由 Negentropy Engine 担任 Orchestrator + Evaluator，编排 Claude Code（Executor）依据目标 / 验收标准持续自迭代，直至达标或触达硬上限守卫，构成 Evaluator-Optimizer + Reflexion 自迭代闭环。
- 关联上下文/Issue/文档：[docs/concepts/039-the-routine-system.md](docs/concepts/039-the-routine-system.md)（架构设计）、[docs/research/110-routine-agent-iteration.md](docs/research/110-routine-agent-iteration.md)（Agent 迭代模式调研）。本分支已就代码评审意见在三处完成修复并补回归用例。

# 核心变更
- **后端编排**：新增 `engine/routine/`——orchestrator（`inspect_once` 心跳：reap 孤儿 → evaluate+decide → dispatch 三阶段，commit-before-launch / seq=MAX+1 / FOR UPDATE SKIP LOCKED 三重幂等）、decision（纯函数守卫与决策）、evaluator（LLM-as-Judge + 可选命令门控）、runner（进程内后台执行 + 并发信号量 + 崩溃恢复 lease + 条件化 write-back 防双计）、prompt_builder（Reflexion 反思注入）、bus（SSE fan-out）。
- **数据与配置**：新增 `models/routine.py`（`routines` / `routine_iterations`）、迁移 `0048`（幂等建表 + seed `routine_inspector` 心跳任务）、`config/routine.py` 与 YAML 默认（灰度开关 `enabled=false`）、task_registry 注册 `routine.evaluate` 槽位。
- **API**：`interface/routine_api.py` 提供 CRUD、控制（start/pause/resume/cancel）、审批门控（approve/reject）、KPI、SSE `/routines/stream`；bootstrap 挂载路由并在 lifespan 关停时收敛在途执行。
- **前端**：新增 `/interface/routine` 二级菜单与管理界面（列表 / KPI / 筛选 / 详情抽屉 / 迭代时间线 / 评分 sparkline / 表单 / SSE 实时刷新）及 `/api/routine/*` 反向代理。
- **评审修复**：① no_progress 守卫基线改为「最近窗口之前」最优分，修复 `best_score` 含窗口致比较恒真、健康 routine 在 patience 次评分后被误判停滞终止；② 编辑表单 config 改为合并增删，保留 `system_prompt`/`timeout_seconds` 等表单未暴露但引擎消费的键；③ 控制操作 Toast 文案改用过去式映射，修正 "pauseed"/"resumeed"。

# 风险与回滚
- 主要风险：自主循环失控（成本/迭代膨胀）。已由 decision 硬上限守卫（max_iterations / max_cost / deadline / no_progress / oscillation / 连续失败）+ `approval_mode` 人工门控 + 单进程单在途 + lease 回收三重兜底控制；特性默认关闭（`routine.enabled=false`），inspector 心跳直接 no-op，对现有统一调度引擎零副作用。
- 回滚方式：保持 `routine.enabled=false`（无运行期影响）；或回退本分支提交；迁移 `0048` 提供 downgrade（删表 + 清理 seed 任务，不触碰其他数据）。

# 验证证据
- 单元测试：`test_routine_decision.py` **22 项通过**（含新增「窗口内创新高应继续」回归用例——旧逻辑失败、修复后通过，覆盖原测试盲区）。
- 集成测试：`test_routine_orchestrator.py`（真实 Postgres：evaluate/dispatch、max_iterations 预算守卫、seq=MAX+1、write-back 防双计）、`test_routine_api.py`。
- E2E/Workflow：特性默认关闭，暂不引入 E2E；前端经 `tsc --noEmit`（全局 0 error）与 ESLint（改动文件 0 告警）校验。
- 覆盖率/关键截图：pre-commit（Ruff lint/format + ESLint）全通过。

# 影响范围
- 前端：新增 `app/interface/routine/*`、`features/routine/*`、`app/api/routine/*`；`InterfaceNav` 新增 Routine 菜单项。
- 后端：新增 `engine/routine/*`、`interface/routine_api.py`、`models/routine.py`、`config/routine.py`、迁移 `0048`、`routine_inspector` handler；`bootstrap` 挂载路由与关停收敛。
- GitHub Actions / 文档：无 CI 变更；新增设计文档与调研报告，更新知识索引。

# Next Best Action
- 在隔离环境置 `routine.enabled=true`，跑通一条真实 routine 的端到端闭环（含 `verification_command` 门控与审批流），观测 SSE 推送与 KPI，再评估灰度放量与默认开启策略。
