### PR TITLE
fix(claude-code): 移除 CLI 降级路径中不支持的 --cwd 参数

### DIFF
--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -240,8 +240,8 @@ class ClaudeCodeService:
             args += ["--model", config.model]
         if config.system_prompt:
             args += ["--system-prompt", config.system_prompt]
-        if config.cwd:
-            args += ["--cwd", config.cwd]
+        # NOTE: cwd 通过 create_subprocess_exec(..., cwd=) 设置，不传 CLI 参数
+        # （claude CLI 不支持 --cwd 选项，传了会报 unknown option 错误）
         if config.allowed_tools:
             args += ["--allowed-tools", ",".join(config.allowed_tools)]
         return args


### PR DESCRIPTION
## 背景

Claude Code CLI v2.x 不支持 `--cwd` 选项，`_build_cli_args` 将其作为 CLI 参数传递会导致 exit code 1 错误，影响 Routine Runner 及所有 CLI 降级路径的 Claude Code 调用。

## 核心变更

- **移除冗余 CLI 参数**：删除 `_build_cli_args` 中 `--cwd config.cwd` 的拼接逻辑（`service.py` L241-244）
- **添加说明注释**：明确 cwd 已通过 `create_subprocess_exec(..., cwd=config.cwd)` 在进程级正确设置，CLI 参数既多余又冲突

## 实现细节

`config.cwd` 的工作目录设置本身从未缺失——它在 `service.py:152` 的 `create_subprocess_exec` 调用中通过 `cwd=` 关键字参数传入，由操作系统在进程创建时直接设定子进程工作目录。CLI 参数是后来误加的冗余路径，而 Claude CLI v2.x 不识别该选项会直接报错退出。

## 风险与回滚

- **风险**：无。本次仅移除冗余且错误的 CLI 参数，不改变实际工作目录的设置方式
- **回滚**：`git revert`

## 影响范围

- **后端**：`negentropy/engine/claude_code/service.py` — CLI 参数构建逻辑
- **前端 / CI / 文档**：无影响

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>