### PR TITLE
fix(routine-api): 修复 Routine 页 404；BFF catch-all 路由改为 optional

### DIFF
--- a/apps/negentropy-ui/app/api/routine/[[...path]]/route.ts
+++ b/apps/negentropy-ui/app/api/routine/[[...path]]/route.ts
@@ -18,9 +18,10 @@ import { proxyDelete, proxyGet, proxyPost, proxyPut } from "@/app/api/interface/
  *   POST   /api/routine/{id}/iterations/{iid}/{approve|reject}
  */
 
-type Ctx = { params: Promise<{ path: string[] }> };
+type Ctx = { params: Promise<{ path?: string[] }> };
 
-function buildBackendPath(segments: string[]): string {
+function buildBackendPath(segments: string[] | undefined): string {
+  if (!segments || segments.length === 0) return "/routines";
   return "/routines/" + segments.map((s) => encodeURIComponent(s)).join("/");
 }
 


### PR DESCRIPTION
## 问题

Routine 页面（`/interface/routine`）加载时报 `routine API → 404: Not Found`。

## 根因

Next.js BFF 代理路由使用了 `[...path]`（required catch-all），无法匹配零路径段的请求。

前端 `fetchRoutines()` 调用 `GET /api/routine`（无额外路径段），`createRoutine()` 调用 `POST /api/routine`。这些请求在 Next.js App Router 中无法被 `[...path]` 匹配——因为 `[...path]` **要求至少一个路径段**，而 `/api/routine` 没有任何段，Next.js 直接返回 404。

## 修复

| 变更 | 说明 |
|------|------|
| 目录重命名 `[...path]` → `[[...path]]` | required catch-all → optional catch-all |
| `buildBackendPath` 适配空段 | `[[...path]]` 匹配零段时 `params.path` 为 `undefined`，需处理此情况 |

## 验证

1. 重启 Next.js dev server
2. 打开 `/interface/routine` 页面
3. 确认页面正常加载，KPI 卡片、routine 列表、SSE stream 均正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)