### PR TITLE
feat(knowledge): 扩展 Ingest From File 支持 PDF + Markdown 双类型文档摄入

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/IngestFileDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/IngestFileDialog.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toast } from "@/lib/activity-toast";
+import { AsyncPipelineResult, ChunkingConfig } from "@/features/knowledge";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { FileText, FileType, UploadCloud, X } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// 常量
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+type FileTab = "pdf" | "markdown";
+
+interface TabConfig {
+  accept: string;
+  extensions: string[];
+  Icon: typeof FileText;
+  description: string;
+  label: string;
+  supportedFormats: string;
+}
+
+const TAB_CONFIG: Record<FileTab, TabConfig> = {
+  pdf: {
+    accept: ".pdf",
+    extensions: [".pdf"],
+    Icon: FileText,
+    description: "PDF 文档将通过 AI 提取转换为 Markdown",
+    label: "PDF",
+    supportedFormats: "支持 .pdf（最大 50 MB）",
+  },
+  markdown: {
+    accept: ".txt,.md,.markdown",
+    extensions: [".txt", ".md", ".markdown"],
+    Icon: FileType,
+    description: "Markdown 与纯文本文件直接摄入，无需格式转换",
+    label: "Markdown",
+    supportedFormats: "支持 .md, .markdown, .txt（最大 50 MB）",
+  },
+};
+
+/** 所有 tab 的扩展名合集，用于自动检测 */
+const ALL_EXTENSIONS = Object.values(TAB_CONFIG).flatMap((c) => c.extensions);
+
+// ---------------------------------------------------------------------------
+// 工具函数
+// ---------------------------------------------------------------------------
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getFileExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  return dot >= 0 ? filename.slice(dot).toLowerCase() : "";
+}
+
+function detectTab(filename: string): FileTab | null {
+  const ext = getFileExtension(filename);
+  if (TAB_CONFIG.pdf.extensions.includes(ext)) return "pdf";
+  if (TAB_CONFIG.markdown.extensions.includes(ext)) return "markdown";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface IngestFileDialogProps {
+  isOpen: boolean;
+  corpusId: string | null;
+  onClose: () => void;
+  onIngestFile: (params: {
+    file: File;
+    source_uri?: string;
+    chunkingConfig?: ChunkingConfig;
+  }) => Promise<AsyncPipelineResult>;
+  chunkingConfig?: ChunkingConfig;
+  onSuccess?: () => void;
+  title?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function IngestFileDialog({
+  isOpen,
+  corpusId,
+  onClose,
+  onIngestFile,
+  chunkingConfig,
+  onSuccess,
+  title = "Ingest From File",
+}: IngestFileDialogProps) {
+  const [tab, setTab] = useState<FileTab>("pdf");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const config = TAB_CONFIG[tab];
+
+  // ---- 文件处理 ----
+
+  const handleFileSelect = (file: File) => {
+    const ext = getFileExtension(file.name);
+
+    // 自动检测：若扩展名不属于当前 tab 但匹配另一 tab，自动切换
+    if (!config.extensions.includes(ext)) {
+      const detected = detectTab(file.name);
+      if (detected && detected !== tab) {
+        setTab(detected);
+        // 切换后重新用目标 tab 的配置验证
+        const targetConfig = TAB_CONFIG[detected];
+        if (!targetConfig.extensions.includes(ext)) {
+          setError(`不支持的文件类型: ${ext}。支持的格式: ${targetConfig.extensions.join(", ")}`);
+          return;
+        }
+      } else if (!ALL_EXTENSIONS.includes(ext)) {
+        setError(`不支持的文件类型: ${ext}。支持的格式: ${ALL_EXTENSIONS.join(", ")}`);
+        return;
+      }
+    }
+
+    // 文件大小验证
+    if (file.size > MAX_FILE_SIZE) {
+      setError(`文件大小超过限制（最大 ${formatFileSize(MAX_FILE_SIZE)}）`);
+      return;
+    }
+
+    setSelectedFile(file);
+    setError(null);
+  };
+
+  // ---- 拖拽 ----
+
+  const handleDrag = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setDragActive(true);
+    } else if (e.type === "dragleave") {
+      setDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    if (e.dataTransfer.files?.[0]) {
+      handleFileSelect(e.dataTransfer.files[0]);
+    }
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files?.[0]) {
+      handleFileSelect(e.target.files[0]);
+    }
+  };
+
+  // ---- 操作 ----
+
+  const clearFile = () => {
+    setSelectedFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleTabChange = (newTab: FileTab) => {
+    setTab(newTab);
+    setSelectedFile(null);
+    setError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleIngest = () => {
+    if (!corpusId || !selectedFile) return;
+
+    const currentFile = selectedFile;
+
+    // 立即关闭并重置
+    resetForm();
+    onSuccess?.();
+
+    toast.success("已开始从文件摄入知识源", {
+      description: "可在 Pipeline 页面查看构建进度",
+    });
+
+    // Fire-and-forget
+    onIngestFile({ file: currentFile, source_uri: currentFile.name, chunkingConfig }).catch(
+      (err) => {
+        toast.error("摄入失败", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      },
+    );
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
+
+  const resetForm = () => {
+    setTab("pdf");
+    setSelectedFile(null);
+    setError(null);
+    setDragActive(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  if (!isOpen) return null;
+
+  const TabIcon = config.Icon;
+
+  return (
+    <OverlayDismissLayer
+      open={isOpen}
+      onClose={handleClose}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-2xl bg-card p-6 shadow-xl animate-in fade-in zoom-in-95 duration-200"
+      contentProps={{
+        role: "dialog",
+        "aria-modal": true,
+        "aria-labelledby": "ingest-file-dialog-title",
+      }}
+      backdropTestId="overlay-backdrop"
+      contentTestId="overlay-content"
+    >
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <h2
+          id="ingest-file-dialog-title"
+          className="text-lg font-semibold text-foreground"
+        >
+          {title}
+        </h2>
+        <button
+          onClick={handleClose}
+          className="text-text-muted hover:text-foreground"
+          aria-label="关闭"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* Tab Switcher */}
+      <div className="mb-4 flex gap-4 text-xs">
+        {(Object.keys(TAB_CONFIG) as FileTab[]).map((key) => (
+          <button
+            key={key}
+            onClick={() => handleTabChange(key)}
+            className={`flex items-center gap-1.5 pb-1 font-medium ${
+              tab === key
+                ? "border-b-2 border-foreground text-foreground"
+                : "text-text-muted hover:text-foreground"
+            }`}
+          >
+            {TAB_CONFIG[key].label}
+          </button>
+        ))}
+      </div>
+
+      {/* Upload Zone */}
+      <div
+        className={`
+          border-2 rounded-lg text-center transition-colors cursor-pointer
+          ${
+            selectedFile
+              ? "border-solid border-foreground/20 p-4"
+              : dragActive
+                ? "border-dashed border-blue-500 bg-blue-50 p-8 dark:bg-blue-900/20"
+                : "border-dashed border-border p-8 hover:border-foreground/30"
+          }
+        `}
+        onDragEnter={handleDrag}
+        onDragLeave={handleDrag}
+        onDragOver={handleDrag}
+        onDrop={handleDrop}
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={config.accept}
+          onChange={handleFileInput}
+          className="hidden"
+        />
+
+        {selectedFile ? (
+          <div className="flex items-center gap-3 text-left">
+            <TabIcon className="h-5 w-5 shrink-0 text-text-muted" />
+            <div className="min-w-0">
+              <p className="max-w-[240px] truncate text-sm font-medium text-foreground">
+                {selectedFile.name}
+              </p>
+              <p className="text-xs text-text-muted">
+                {formatFileSize(selectedFile.size)}
+              </p>
+            </div>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                clearFile();
+              }}
+              className="ml-auto shrink-0 text-text-muted hover:text-red-500"
+              aria-label="清除文件"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ) : (
+          <div>
+            <UploadCloud className="mx-auto mb-3 h-10 w-10 text-text-muted" />
+            <p className="text-sm text-text-secondary">
+              拖拽文件到此处，或{" "}
+              <span className="text-blue-500">点击选择</span>
+            </p>
+            <p className="mt-1.5 text-xs text-text-muted">
+              {config.supportedFormats}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Tab Description */}
+      <p className="mt-2 px-1 text-xs text-text-muted">
+        {config.description}
+      </p>
+
+      {/* Error */}
+      {error && (
+        <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="mt-6 flex justify-end gap-3">
+        <button
+          onClick={handleClose}
+          className="rounded-lg px-4 py-2 text-sm text-text-secondary hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleIngest}
+          className="rounded-lg bg-foreground px-4 py-2 text-sm font-semibold text-background shadow-sm hover:opacity-90 disabled:opacity-50"
+          disabled={!corpusId || !selectedFile}
+        >
+          Ingest
+        </button>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/base/_components/IngestFileDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/IngestFileDialog.tsx
@@ -116,12 +116,6 @@ export function IngestFileDialog({
       const detected = detectTab(file.name);
       if (detected && detected !== tab) {
         setTab(detected);
-        // 切换后重新用目标 tab 的配置验证
-        const targetConfig = TAB_CONFIG[detected];
-        if (!targetConfig.extensions.includes(ext)) {
-          setError(`不支持的文件类型: ${ext}。支持的格式: ${targetConfig.extensions.join(", ")}`);
-          return;
-        }
       } else if (!ALL_EXTENSIONS.includes(ext)) {
         setError(`不支持的文件类型: ${ext}。支持的格式: ${ALL_EXTENSIONS.join(", ")}`);
         return;

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -10,7 +10,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -47,6 +46,7 @@ import { Button } from "@/components/ui/Button";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { navPillClassName, navRailContainerClassName } from "@/components/ui/nav-styles";
 import { AddSourceDialog } from "./_components/AddSourceDialog";
+import { IngestFileDialog } from "./_components/IngestFileDialog";
 import { CorpusFormDialog } from "./_components/CorpusFormDialog";
 import { CorpusSettingsPanel } from "./_components/CorpusSettingsPanel";
 import { CorpusStatusBadge } from "./_components/CorpusStatusBadge";
@@ -117,6 +117,7 @@ export default function KnowledgeBasePage() {
   const [editingCorpus, setEditingCorpus] = useState<CorpusRecord | undefined>(undefined);
   const [isDeleteCorpusDialogOpen, setIsDeleteCorpusDialogOpen] = useState(false);
   const [isIngestUrlDialogOpen, setIsIngestUrlDialogOpen] = useState(false);
+  const [isIngestFileDialogOpen, setIsIngestFileDialogOpen] = useState(false);
   const [deletingCorpus, setDeletingCorpus] = useState<CorpusRecord | null>(null);
   const [isDeletingCorpus, setIsDeletingCorpus] = useState(false);
   const [isDeleteDocumentDialogOpen, setIsDeleteDocumentDialogOpen] = useState(false);
@@ -125,8 +126,6 @@ export default function KnowledgeBasePage() {
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] = useState(false);
   const [replacingDocument, setReplacingDocument] = useState<KnowledgeDocument | null>(null);
   const [viewingDoc, setViewingDoc] = useState<KnowledgeDocument | null>(null);
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const selectedCorpus = useMemo(
     () => corpora.find((item) => item.id === selectedCorpusId) || null,
@@ -467,36 +466,6 @@ export default function KnowledgeBasePage() {
     });
   };
 
-  const handleIngestFile = ({
-    file,
-    source_uri,
-    chunkingConfig,
-  }: {
-    file: File;
-    source_uri?: string;
-    chunkingConfig?: ChunkingConfig;
-  }) => {
-    if (!selectedCorpusId) {
-      toast.error("请先选择 Corpus");
-      return;
-    }
-
-    // 立即显示 Toast 提示
-    toast.success("已开始从文件摄入知识源", {
-      description: "可在 Pipeline 页面查看构建进度",
-    });
-
-    // Fire-and-forget: 不等待 API 完成
-    ingestFile({
-      file,
-      source_uri: source_uri || file.name,
-      chunkingConfig: chunkingConfig ?? corpusChunkingConfig,
-    })
-      .then(() => loadDocuments())
-      .catch((err) => {
-        toast.error(err instanceof Error ? err.message : "文件摄入失败");
-      });
-  };
 
   const runDocumentAction = async (
     action: "sync" | "rebuild" | "replace" | "archive" | "unarchive" | "download" | "view" | "delete",
@@ -888,23 +857,11 @@ export default function KnowledgeBasePage() {
                         Ingest From URL
                       </button>
                       <button
-                        onClick={() => fileInputRef.current?.click()}
+                        onClick={() => setIsIngestFileDialogOpen(true)}
                         className={outlineButtonClassName("neutral", "rounded px-3 py-1.5 text-xs")}
                       >
                         Ingest From File
                       </button>
-                      <input
-                        ref={fileInputRef}
-                        type="file"
-                        className="hidden"
-                        onChange={(e) => {
-                          const file = e.target.files?.[0];
-                          if (file) {
-                            void handleIngestFile({ file, source_uri: file.name });
-                            e.currentTarget.value = "";
-                          }
-                        }}
-                      />
                     </div>
                   </div>
 
@@ -1167,6 +1124,21 @@ export default function KnowledgeBasePage() {
         initialMode="url"
         allowedModes={["url"]}
         title="Ingest From URL"
+      />
+
+      <IngestFileDialog
+        isOpen={isIngestFileDialogOpen}
+        corpusId={selectedCorpusId}
+        onClose={() => setIsIngestFileDialogOpen(false)}
+        onIngestFile={(params) =>
+          ingestFile(params).then((result) => {
+            void loadDocuments();
+            return result;
+          })
+        }
+        chunkingConfig={corpusChunkingConfig}
+        onSuccess={() => setIsIngestFileDialogOpen(false)}
+        title="Ingest From File"
       />
 
       <CorpusFormDialog

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -523,7 +523,7 @@ export interface CorpusRecord {
   rebuild_triggered?: { count: number; run_ids: string[] } | null;
 }
 
-export type ExtractorSourceKind = "url" | "file_pdf";
+export type ExtractorSourceKind = "url" | "file_pdf" | "file_md";
 
 export interface McpExtractorTargetConfig {
   server_id: string;
@@ -538,7 +538,7 @@ export interface CorpusExtractorRouteConfig {
   targets: McpExtractorTargetConfig[];
 }
 
-export type CorpusExtractorRouteKey = "url" | "file_pdf";
+export type CorpusExtractorRouteKey = "url" | "file_pdf" | "file_md";
 export type CorpusExtractorTargets = McpExtractorTargetConfig[];
 export type ExtractorDraftTarget = McpExtractorTargetConfig;
 export type ExtractorDraftRoute = [ExtractorDraftTarget, ExtractorDraftTarget];
@@ -563,6 +563,7 @@ export interface CorpusModelsConfig {
 export interface CorpusExtractorRoutes {
   url?: CorpusExtractorRouteConfig;
   file_pdf?: CorpusExtractorRouteConfig;
+  file_md?: CorpusExtractorRouteConfig;
 }
 
 export type NormalizedCorpusExtractorRoutes = Record<
@@ -642,6 +643,7 @@ export function normalizeCorpusExtractorRoutes(
   return {
     url: normalizeRoute(raw.url),
     file_pdf: normalizeRoute(raw.file_pdf),
+    file_md: normalizeRoute(raw.file_md),
   };
 }
 
@@ -652,14 +654,15 @@ export function normalizeExtractorDraftRoutes(
   return {
     url: createExtractorDraftRoute(normalized.url.targets),
     file_pdf: createExtractorDraftRoute(normalized.file_pdf.targets),
+    file_md: createExtractorDraftRoute(normalized.file_md?.targets || []),
   };
 }
 
 export function buildExtractorRoutesFromDraft(
   draft: ExtractorDraftRoutes,
 ): NormalizedCorpusExtractorRoutes {
-  const buildTargets = (targets: ExtractorDraftRoute) =>
-    targets
+  const buildTargets = (targets: ExtractorDraftRoute | undefined) =>
+    (targets || [])
       .filter((item) => item.server_id && item.tool_name)
       .map((item, priority) => ({
         ...item,
@@ -670,6 +673,7 @@ export function buildExtractorRoutesFromDraft(
   return {
     url: { targets: buildTargets(draft.url) },
     file_pdf: { targets: buildTargets(draft.file_pdf) },
+    file_md: { targets: buildTargets(draft.file_md) },
   };
 }
 
@@ -683,6 +687,7 @@ export function buildCorpusConfig(
     extractor_routes: {
       url: { targets: extractorRoutes?.url?.targets || [] },
       file_pdf: { targets: extractorRoutes?.file_pdf?.targets || [] },
+      file_md: { targets: extractorRoutes?.file_md?.targets || [] },
     },
   };
   if (models) {

--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -92,6 +92,7 @@ export function createKnowledgeApiExtractorRoutes(
     extractor_routes: {
       url: { targets: urlTargets },
       file_pdf: { targets: filePdfTargets },
+      file_md: { targets: [] },
     },
   };
 }

--- a/apps/negentropy-ui/tests/helpers/knowledge-api.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-api.ts
@@ -87,12 +87,13 @@ export function createKnowledgeApiExtractorRouteTarget(
 export function createKnowledgeApiExtractorRoutes(
   urlTargets: McpExtractorTargetConfig[] = [],
   filePdfTargets: McpExtractorTargetConfig[] = [],
+  fileMdTargets: McpExtractorTargetConfig[] = [],
 ): { extractor_routes: CorpusExtractorRoutes } {
   return {
     extractor_routes: {
       url: { targets: urlTargets },
       file_pdf: { targets: filePdfTargets },
-      file_md: { targets: [] },
+      file_md: { targets: fileMdTargets },
     },
   };
 }
@@ -125,6 +126,15 @@ export const knowledgeApiExtractorRouteFixtures = {
     priority: 1,
     timeout_ms: 25000,
     tool_options: { ocr: true },
+  }),
+  defaultMdTarget: createKnowledgeApiExtractorRouteTarget({
+    server_id: "server-md",
+    tool_name: "parse_markdown",
+  }),
+  dualMdPrimaryTarget: createKnowledgeApiExtractorRouteTarget({
+    server_id: "server-md-primary",
+    tool_name: "parse_md",
+    timeout_ms: 10000,
   }),
 } as const;
 

--- a/apps/negentropy-ui/tests/helpers/knowledge-base-page.ts
+++ b/apps/negentropy-ui/tests/helpers/knowledge-base-page.ts
@@ -184,6 +184,7 @@ export function createKnowledgeBaseExtractorRoutes(
       targets: urlTargets,
     },
     file_pdf: { targets: [] },
+    file_md: { targets: [] },
   };
 }
 

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -261,6 +261,7 @@ describe("fetchCorpus", () => {
         }),
         createEmptyExtractorDraftTarget(1),
       ],
+      file_md: [createEmptyExtractorDraftTarget(0), createEmptyExtractorDraftTarget(1)],
     });
 
     expect(routes).toEqual({
@@ -284,6 +285,7 @@ describe("fetchCorpus", () => {
           }),
         ],
       },
+      file_md: { targets: [] },
     });
   });
 
@@ -317,6 +319,7 @@ describe("fetchCorpus", () => {
         knowledgeApiExtractorRouteFixtures.dualPdfPrimaryTarget,
         knowledgeApiExtractorRouteFixtures.dualPdfBackupTarget,
       ],
+      file_md: [createEmptyExtractorDraftTarget(0), createEmptyExtractorDraftTarget(1)],
     });
 
     expect(routes).toEqual({
@@ -352,6 +355,7 @@ describe("fetchCorpus", () => {
           }),
         ],
       },
+      file_md: { targets: [] },
     });
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -172,7 +172,11 @@ describe("fetchCorpus", () => {
 
   it("normalizeCorpusExtractorRoutes 与 buildCorpusConfig 会稳定保留 extractor routes 结构", () => {
     const normalized = normalizeCorpusExtractorRoutes(
-      createKnowledgeApiExtractorRoutes([knowledgeApiExtractorRouteFixtures.defaultUrlTarget]),
+      createKnowledgeApiExtractorRoutes(
+        [knowledgeApiExtractorRouteFixtures.defaultUrlTarget],
+        [],
+        [knowledgeApiExtractorRouteFixtures.defaultMdTarget],
+      ),
     );
 
     expect(normalized.url.targets).toEqual([
@@ -184,6 +188,14 @@ describe("fetchCorpus", () => {
       }),
     ]);
     expect(normalized.file_pdf.targets).toEqual([]);
+    expect(normalized.file_md.targets).toEqual([
+      expect.objectContaining({
+        server_id: "server-md",
+        tool_name: "parse_markdown",
+        priority: 0,
+        enabled: true,
+      }),
+    ]);
 
     expect(
       buildCorpusConfig(createDefaultChunkingConfig(), normalized),
@@ -198,13 +210,25 @@ describe("fetchCorpus", () => {
           ],
         },
         file_pdf: { targets: [] },
+        file_md: {
+          targets: [
+            expect.objectContaining({
+              server_id: "server-md",
+              tool_name: "parse_markdown",
+            }),
+          ],
+        },
       },
     });
   });
 
   it("normalizeExtractorDraftRoutes 会为每个 route 生成固定双槽位 draft", () => {
     const draft = normalizeExtractorDraftRoutes(
-      createKnowledgeApiExtractorRoutes([knowledgeApiExtractorRouteFixtures.defaultUrlTarget]),
+      createKnowledgeApiExtractorRoutes(
+        [knowledgeApiExtractorRouteFixtures.defaultUrlTarget],
+        [],
+        [knowledgeApiExtractorRouteFixtures.defaultMdTarget],
+      ),
     );
 
     expect(draft.url).toEqual([
@@ -225,6 +249,20 @@ describe("fetchCorpus", () => {
       expect.objectContaining({
         server_id: "",
         tool_name: "",
+        priority: 0,
+        enabled: true,
+      }),
+      expect.objectContaining({
+        server_id: "",
+        tool_name: "",
+        priority: 1,
+        enabled: true,
+      }),
+    ]);
+    expect(draft.file_md).toEqual([
+      expect.objectContaining({
+        server_id: "server-md",
+        tool_name: "parse_markdown",
         priority: 0,
         enabled: true,
       }),
@@ -261,7 +299,13 @@ describe("fetchCorpus", () => {
         }),
         createEmptyExtractorDraftTarget(1),
       ],
-      file_md: [createEmptyExtractorDraftTarget(0), createEmptyExtractorDraftTarget(1)],
+      file_md: [
+        createKnowledgeApiExtractorRouteTarget({
+          server_id: "server-md-1",
+          tool_name: "parse_markdown",
+        }),
+        createEmptyExtractorDraftTarget(1),
+      ],
     });
 
     expect(routes).toEqual({
@@ -285,7 +329,16 @@ describe("fetchCorpus", () => {
           }),
         ],
       },
-      file_md: { targets: [] },
+      file_md: {
+        targets: [
+          expect.objectContaining({
+            server_id: "server-md-1",
+            tool_name: "parse_markdown",
+            priority: 0,
+            enabled: true,
+          }),
+        ],
+      },
     });
   });
 

--- a/apps/negentropy-ui/tests/unit/ui/Card.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/Card.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import { Card } from "@/components/ui/Card";
+
+describe("Card", () => {
+  it("默认渲染为带 sm 阴影的卡片容器", () => {
+    const { container } = render(<Card>content</Card>);
+
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.tagName).toBe("DIV");
+    expect(el.textContent).toBe("content");
+    expect(el.className).toContain("rounded-card");
+    expect(el.className).toContain("shadow-sm");
+    expect(el.className).not.toContain("cursor-pointer");
+  });
+
+  it("flat elevation 不含阴影，interactive 启用 hover 过渡", () => {
+    const { container } = render(
+      <Card elevation="flat" interactive>
+        click me
+      </Card>,
+    );
+
+    const el = container.firstElementChild as HTMLElement;
+    // flat: 无静态阴影类（shadow-sm / shadow-md），仅 hover 时叠加
+    expect(el.className).not.toMatch(/(?<!hover:)shadow-(sm|md)\b/);
+    expect(el.className).toContain("cursor-pointer");
+    expect(el.className).toContain("hover:shadow-md");
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
@@ -167,7 +167,7 @@ class ExtractorExecutionError(ValueError):
         self.attempts = attempts
 
 
-_MD_EXTENSIONS = {".md", ".markdown"}
+_MD_EXTENSIONS = {".md", ".markdown", ".txt"}
 
 
 def resolve_source_kind(
@@ -190,7 +190,7 @@ def resolve_source_kind(
         dot = lower_filename.rfind(".")
         if dot >= 0:
             ext = lower_filename[dot:]
-    if ext in _MD_EXTENSIONS or "text/markdown" in lower_content_type:
+    if ext in _MD_EXTENSIONS or lower_content_type in {"text/markdown", "text/plain"}:
         return ROUTE_FILE_MD
 
     return ROUTE_FILE_GENERIC

--- a/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
@@ -28,11 +28,12 @@ from .content import (
 
 logger = get_logger("negentropy.knowledge.extraction")
 
-SourceKind = Literal["url", "file_pdf", "file_generic"]
+SourceKind = Literal["url", "file_pdf", "file_md", "file_generic"]
 
 EXTRACTOR_ROUTES_KEY = "extractor_routes"
 ROUTE_URL = "url"
 ROUTE_FILE_PDF = "file_pdf"
+ROUTE_FILE_MD = "file_md"
 ROUTE_FILE_GENERIC = "file_generic"
 MAX_LLM_PLANNING_PAYLOAD_CHARS = 16_000
 MAX_LLM_VALIDATION_ERROR_CHARS = 1_500
@@ -166,6 +167,9 @@ class ExtractorExecutionError(ValueError):
         self.attempts = attempts
 
 
+_MD_EXTENSIONS = {".md", ".markdown"}
+
+
 def resolve_source_kind(
     *,
     source_uri: str | None = None,
@@ -179,6 +183,15 @@ def resolve_source_kind(
     lower_content_type = (content_type or "").lower()
     if lower_filename.endswith(".pdf") or "application/pdf" in lower_content_type:
         return ROUTE_FILE_PDF
+
+    # Markdown 文件：按扩展名或 MIME type 检测，优先于 file_generic 回退
+    ext = ""
+    if lower_filename:
+        dot = lower_filename.rfind(".")
+        if dot >= 0:
+            ext = lower_filename[dot:]
+    if ext in _MD_EXTENSIONS or "text/markdown" in lower_content_type:
+        return ROUTE_FILE_MD
 
     return ROUTE_FILE_GENERIC
 
@@ -255,6 +268,7 @@ def resolve_targets(raw: dict[str, Any] | None, source_kind: SourceKind) -> list
 _DEFAULT_EXTRACTION_TIMEOUT_MS: dict[str, int] = {
     ROUTE_URL: 60_000,  # 1 分钟
     ROUTE_FILE_PDF: 300_000,  # 5 分钟
+    ROUTE_FILE_MD: 30_000,  # 30 秒（本地读取，无需 MCP）
     ROUTE_FILE_GENERIC: 120_000,  # 2 分钟
 }
 _FALLBACK_EXTRACTION_TIMEOUT_MS = 120_000

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_types.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_types.py
@@ -23,6 +23,7 @@ class SourceKind(Enum):
 
     URL = "url"
     FILE_PDF = "file_pdf"
+    FILE_MD = "file_md"
     FILE_GENERIC = "file_generic"
     TEXT_INPUT = "text_input"
 

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -23,7 +23,7 @@ from .ingestion.chunking import chunk_text, semantic_chunk_async
 if TYPE_CHECKING:
     from .dao import KnowledgeRunDao
 from .constants import TEXT_PREVIEW_MAX_LENGTH
-from .ingestion.extraction import ROUTE_URL, ExtractedDocumentResult, extract_source, resolve_source_kind
+from .ingestion.extraction import ROUTE_FILE_MD, ROUTE_URL, ExtractedDocumentResult, extract_source, resolve_source_kind
 from .ingestion.source_tracking import SourceTrackingService, TrackingContext
 from .retrieval.repository import KnowledgeRepository
 from .retrieval.reranking import NoopReranker, Reranker
@@ -709,13 +709,30 @@ class KnowledgeService:
         content_type: str | None,
         tracker: PipelineTracker | None = None,
     ) -> ExtractedDocumentResult:
+        source_kind = resolve_source_kind(filename=filename, content_type=content_type)
+
+        # Markdown 文件：跳过 MCP 提取，直接读取文件内容
+        if source_kind == ROUTE_FILE_MD:
+            from .ingestion.content import optimize_markdown_content
+
+            raw_text = content.decode("utf-8", errors="replace")
+            markdown = optimize_markdown_content(raw_text)
+            return ExtractedDocumentResult(
+                plain_text=raw_text,
+                markdown_content=markdown,
+                metadata={"source_kind": source_kind, "extraction_method": "passthrough"},
+                assets=[],
+                trace={"provider": "passthrough", "source_kind": source_kind},
+            )
+
+        # 非 Markdown 文件：通过 MCP 提取
         cancel_event = get_cancel_event(tracker.run_id) if tracker else None
         try:
             result = await extract_source(
                 app_name=app_name,
                 corpus_id=corpus_id,
                 corpus_config=await self._get_corpus_config(corpus_id),
-                source_kind=resolve_source_kind(filename=filename, content_type=content_type),
+                source_kind=source_kind,
                 content=content,
                 filename=filename,
                 content_type=content_type,


### PR DESCRIPTION
## 概述

扩展 Knowledge Base Corpus 的「Ingest From File」功能，从仅支持 PDF 扩展为同时支持 **PDF** 和 **Markdown** 两种文档类型。

### 核心差异

| 文件类型 | 提取流程 |
|---------|---------|
| **PDF** | 通过 MCP 工具（negentropy-perceives）执行 10 阶段 Pipeline 转换为 Markdown |
| **Markdown** | 跳过 MCP 提取，直接读取文件内容 |

其余流程（GCS 存储、Documents 展示、分块嵌入、PG/PGVector 存储、Pipeline 跟踪）完全一致。

## 变更内容

### 后端（3 文件）

- **`extraction.py`**：新增 `ROUTE_FILE_MD` 常量 + `file_md` SourceKind；`resolve_source_kind()` 检测 `.md`/`.markdown` 扩展名与 `text/markdown` MIME type
- **`lifecycle_types.py`**：`SourceKind` 枚举新增 `FILE_MD = "file_md"`
- **`service.py`**：`_extract_file_document()` 对 Markdown 文件跳过 MCP 提取，直接 `decode + optimize_markdown_content()` 构造结果

### 前端（5 文件 + 1 新建 + 3 测试）

- **`IngestFileDialog.tsx`**（新建）：专业文件摄入对话框，PDF/Markdown 双 Tab + 拖拽上传 + 文件类型自动检测
- **`page.tsx`**：替换隐藏文件输入为 `IngestFileDialog`，移除废弃的 `fileInputRef` 和 `handleIngestFile`
- **`knowledge-api.ts`**：`ExtractorSourceKind`、`CorpusExtractorRouteKey` 等类型扩展支持 `file_md`
- **测试文件**：适配新增 `file_md` 路由键

### 不需要变更

GCS 存储、KnowledgeDocument 模型、知识图谱构建、Pipeline Runs 跟踪 — 均已通用化

## 测试验证

- ✅ 后端 `resolve_source_kind()` 单元断言全部通过
- ✅ 后端 extraction contract 测试 7/7 通过
- ✅ 前端 TypeScript 类型检查零新增错误
- ✅ 前端 knowledge 测试套件 23 文件 181 测试全部通过
- ✅ Pre-commit hooks（Ruff lint/format + ESLint）全部通过

## 界面效果

![image.png](.context/attachments/9l1v1a/image.png)

替换「Ingest From File」隐藏文件输入为弹出对话框，支持 PDF/Markdown 切换和拖拽上传。

🤖 Generated with [Claude Code](https://claude.com/claude-code)