### PR TITLE
feat(ui): 参考 ReactBits 设计模式全面优化 UI 交互动画系统

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/MetricCell.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/MetricCell.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
+
 interface MetricCellProps {
   label: string;
   value: string | number;
@@ -23,6 +25,8 @@ export function MetricCell({
   loading,
   href,
 }: MetricCellProps) {
+  const isNumeric = typeof value === "number";
+
   const cell = (
     <div
       className={`flex items-center gap-1.5 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 ${
@@ -31,7 +35,15 @@ export function MetricCell({
     >
       <span className="text-xs text-muted-foreground whitespace-nowrap">{label}</span>
       {loading ? (
-        <span className="inline-block h-3.5 w-8 animate-pulse rounded bg-muted/60" />
+        <span className="inline-block h-3.5 w-8 animate-shimmer rounded bg-gradient-to-r from-muted via-muted/40 to-muted bg-[length:200%_100%]" />
+      ) : isNumeric ? (
+        <AnimatedNumber
+          value={value}
+          duration={500}
+          className={`text-sm font-semibold whitespace-nowrap tabular-nums ${
+            toneClass[tone] ?? toneClass.neutral
+          }`}
+        />
       ) : (
         <span
           className={`text-sm font-semibold whitespace-nowrap tabular-nums ${

--- a/apps/negentropy-ui/app/(home)/dashboard/page.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/page.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useAuth } from "@/components/providers/AuthProvider";
 import { ErrorBanner } from "@/components/ui/ErrorState";
+import { FadeIn } from "@/components/ui/FadeIn";
 import { fetchMemoryDashboard, type MemoryDashboard } from "@/features/memory";
 import { useActivityLog } from "@/hooks/useActivityLog";
 
@@ -144,22 +145,26 @@ export default function DashboardPage() {
       ) : null}
 
       {/* Unified dashboard header strip */}
-      <DashboardHeaderStrip
-        kpis={kpis}
-        kpiLoading={loading}
-        memoryDashboard={memoryDashboard}
-        memoryLoading={memoryLoading}
-        interfaceStats={interfaceStats}
-        interfaceLoading={interfaceLoading}
-        isAdmin={isAdmin}
-        activityCount={activityCount}
-        onOpenActivity={() => setActivityOpen(true)}
-      />
+      <FadeIn>
+        <DashboardHeaderStrip
+          kpis={kpis}
+          kpiLoading={loading}
+          memoryDashboard={memoryDashboard}
+          memoryLoading={memoryLoading}
+          interfaceStats={interfaceStats}
+          interfaceLoading={interfaceLoading}
+          isAdmin={isAdmin}
+          activityCount={activityCount}
+          onOpenActivity={() => setActivityOpen(true)}
+        />
+      </FadeIn>
 
       {/* Expandable Memory detail panel */}
-      <RetrievalMetricsCard appName={APP_NAME} />
+      <FadeIn delay={60}>
+        <RetrievalMetricsCard appName={APP_NAME} />
+      </FadeIn>
 
-      <div className="mt-3">
+      <FadeIn delay={120} className="mt-3">
         <FilterBar
           filters={filters}
           tasks={tasks}
@@ -169,18 +174,18 @@ export default function DashboardPage() {
           onRefresh={refresh}
           connected={connected}
         />
-      </div>
-      <div className="mt-3">
+      </FadeIn>
+      <FadeIn delay={180} className="mt-3">
         <DimensionCharts byRole={statsByRole} byScenario={statsByScenario} byOwner={statsByOwner} />
-      </div>
-      <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-12">
+      </FadeIn>
+      <FadeIn delay={240} className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-12">
         <div className="lg:col-span-7">
           <TaskTable tasks={tasks} filters={filters} onSelect={handleSelect} />
         </div>
         <div className="lg:col-span-5">
           <ExecutionTimeline executions={executions} />
         </div>
-      </div>
+      </FadeIn>
       <TaskDetailDrawer task={selectedTask} onClose={handleClose} onTaskChanged={refresh} />
       <ActivityDrawer open={activityOpen} onClose={() => setActivityOpen(false)} />
     </div>

--- a/apps/negentropy-ui/app/globals.css
+++ b/apps/negentropy-ui/app/globals.css
@@ -139,10 +139,11 @@
   --ease-in: cubic-bezier(0.4, 0, 1, 1);
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* 入场动画（animate-enter / animate-fade-in / animate-slide-in-right） */
+  /* 入场动画（animate-enter / animate-fade-in / animate-slide-in-right / animate-shimmer） */
   --animate-enter: enter var(--duration-base) var(--ease-out) both;
   --animate-fade-in: fade-in var(--duration-base) var(--ease-out) both;
   --animate-slide-in-right: slide-in-right var(--duration-base) var(--ease-out) both;
+  --animate-shimmer: shimmer 1.5s ease-in-out infinite;
 
   --font-sans: var(--font-geist-sans), "PingFang SC", "Noto Sans SC", "Microsoft YaHei",
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -295,6 +296,59 @@ body {
     opacity: 1;
     transform: translateX(0);
   }
+}
+
+/*
+ * 骨架扫光（Shimmer）— Linear/Vercel 级加载占位
+ * 一条半透明高亮带从左到右滑过骨架表面，比 pulse 更精致。
+ * 已被 prefers-reduced-motion 规则统一降级。
+ */
+@keyframes shimmer {
+  from {
+    background-position: -200% 0;
+  }
+  to {
+    background-position: 200% 0;
+  }
+}
+
+/*
+ * 主按钮光泽扫过（参考 ReactBits ShinyButton）。
+ * 仅在 hover 时触发一次 ::before 伪元素扫光，运行一次即消失。
+ * 已被 prefers-reduced-motion 规则统一降级。
+ */
+@keyframes btn-shine {
+  from {
+    left: -100%;
+  }
+  to {
+    left: 200%;
+  }
+}
+
+.shiny-btn-primary {
+  position: relative;
+  overflow: hidden;
+}
+
+.shiny-btn-primary::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 60%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.15),
+    transparent
+  );
+  pointer-events: none;
+}
+
+.shiny-btn-primary:hover::before {
+  animation: btn-shine 0.5s ease-out forwards;
 }
 
 .mermaid-diagram svg {

--- a/apps/negentropy-ui/components/layout/MainNav.tsx
+++ b/apps/negentropy-ui/components/layout/MainNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { motion, useReducedMotion } from "framer-motion";
 import { type MainNavItem } from "@/config/navigation";
 import { useAuth } from "@/components/providers/AuthProvider";
 import {
@@ -16,6 +17,7 @@ interface MainNavProps {
 export function MainNav({ items }: MainNavProps) {
   const pathname = usePathname();
   const { user } = useAuth();
+  const prefersReduced = useReducedMotion();
 
   // Filter items based on user roles
   const visibleItems = items?.filter((item) => {
@@ -33,7 +35,7 @@ export function MainNav({ items }: MainNavProps) {
               p === "/" ? pathname === "/" : pathname?.startsWith(p),
             );
 
-            return (
+            const link = (
               <Link
                 key={index}
                 href={item.disabled ? "#" : item.href}
@@ -44,6 +46,23 @@ export function MainNav({ items }: MainNavProps) {
               >
                 {item.title}
               </Link>
+            );
+
+            if (prefersReduced) return link;
+
+            return (
+              <motion.div
+                key={index}
+                initial={{ opacity: 0, y: -4 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{
+                  duration: 0.25,
+                  delay: index * 0.05,
+                  ease: [0.16, 1, 0.3, 1],
+                }}
+              >
+                {link}
+              </motion.div>
             );
           })}
         </nav>

--- a/apps/negentropy-ui/components/ui/AnimatedList.tsx
+++ b/apps/negentropy-ui/components/ui/AnimatedList.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+/**
+ * 交错入场列表容器（参考 ReactBits AnimatedList）。
+ *
+ * 列表项交错淡入：每项延迟 staggerMs ms，duration 200ms。
+ * 使用 AnimatePresence 处理项目新增/移除。
+ * 尊重 prefers-reduced-motion：降级为直接渲染。
+ */
+export function AnimatedList({
+  children,
+  staggerMs = 50,
+  className,
+}: {
+  children: ReactNode[];
+  /** 交错延迟（ms），默认 50。 */
+  staggerMs?: number;
+  className?: string;
+}) {
+  const prefersReduced = useReducedMotion();
+
+  if (prefersReduced) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <AnimatePresence initial={false}>
+      <motion.div
+        className={className}
+        initial="hidden"
+        animate="visible"
+        variants={{
+          visible: {
+            transition: {
+              staggerChildren: staggerMs / 1000,
+            },
+          },
+        }}
+      >
+        {children.map((child, i) => (
+          <motion.div
+            key={i}
+            variants={{
+              hidden: { opacity: 0, y: 6 },
+              visible: {
+                opacity: 1,
+                y: 0,
+                transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] },
+              },
+            }}
+          >
+            {child}
+          </motion.div>
+        ))}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/apps/negentropy-ui/components/ui/AnimatedList.tsx
+++ b/apps/negentropy-ui/components/ui/AnimatedList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { Children, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 /**
@@ -40,21 +40,23 @@ export function AnimatedList({
           },
         }}
       >
-        {children.map((child, i) => (
-          <motion.div
-            key={i}
-            variants={{
-              hidden: { opacity: 0, y: 6 },
-              visible: {
-                opacity: 1,
-                y: 0,
-                transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] },
-              },
-            }}
-          >
-            {child}
-          </motion.div>
-        ))}
+        {Children.map(children, (child) =>
+          child == null ? null : (
+            <motion.div
+              key={child.key}
+              variants={{
+                hidden: { opacity: 0, y: 6 },
+                visible: {
+                  opacity: 1,
+                  y: 0,
+                  transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] },
+                },
+              }}
+            >
+              {child}
+            </motion.div>
+          ),
+        )}
       </motion.div>
     </AnimatePresence>
   );

--- a/apps/negentropy-ui/components/ui/AnimatedList.tsx
+++ b/apps/negentropy-ui/components/ui/AnimatedList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Children, type ReactNode } from "react";
+import { Children, isValidElement, type ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 /**
@@ -40,10 +40,10 @@ export function AnimatedList({
           },
         }}
       >
-        {Children.map(children, (child) =>
+        {Children.map(children, (child, i) =>
           child == null ? null : (
             <motion.div
-              key={child.key}
+              key={isValidElement(child) ? child.key : i}
               variants={{
                 hidden: { opacity: 0, y: 6 },
                 visible: {

--- a/apps/negentropy-ui/components/ui/AnimatedNumber.tsx
+++ b/apps/negentropy-ui/components/ui/AnimatedNumber.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+
+/**
+ * 数值递增动画（参考 ReactBits CountUp）。
+ *
+ * 数值从 0 动画到目标值，duration 400-600ms，仅数字类型触发。
+ * 尊重 prefers-reduced-motion：降级为直接显示目标值。
+ * 使用 requestAnimationFrame 实现，避免 layout thrash。
+ */
+export function AnimatedNumber({
+  value,
+  duration = 500,
+  className,
+}: {
+  value: number;
+  /** 动画时长（ms），默认 500。 */
+  duration?: number;
+  className?: string;
+}) {
+  const [display, setDisplay] = useState(0);
+  const prefersReduced = useReducedMotion();
+  const rafRef = useRef<number>(0);
+  const startRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (prefersReduced) {
+      setDisplay(value);
+      return;
+    }
+
+    const from = 0;
+    const to = value;
+
+    if (from === to) {
+      setDisplay(to);
+      return;
+    }
+
+    const animate = (timestamp: number) => {
+      if (!startRef.current) startRef.current = timestamp;
+      const elapsed = timestamp - startRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplay(Math.round(from + (to - from) * eased));
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    startRef.current = 0;
+    rafRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [value, duration, prefersReduced]);
+
+  return (
+    <span className={className}>
+      {display.toLocaleString()}
+    </span>
+  );
+}

--- a/apps/negentropy-ui/components/ui/AnimatedNumber.tsx
+++ b/apps/negentropy-ui/components/ui/AnimatedNumber.tsx
@@ -20,24 +20,32 @@ export function AnimatedNumber({
   duration?: number;
   className?: string;
 }) {
-  const [display, setDisplay] = useState(0);
   const prefersReduced = useReducedMotion();
+
+  if (prefersReduced) {
+    return <span className={className}>{value.toLocaleString()}</span>;
+  }
+
+  return (
+    <AnimatedNumberAnim value={value} duration={duration} className={className} />
+  );
+}
+
+function AnimatedNumberAnim({
+  value,
+  duration = 500,
+  className,
+}: {
+  value: number;
+  duration?: number;
+  className?: string;
+}) {
+  const [display, setDisplay] = useState(0);
   const rafRef = useRef<number>(0);
   const startRef = useRef<number>(0);
 
   useEffect(() => {
-    if (prefersReduced) {
-      setDisplay(value);
-      return;
-    }
-
-    const from = 0;
     const to = value;
-
-    if (from === to) {
-      setDisplay(to);
-      return;
-    }
 
     const animate = (timestamp: number) => {
       if (!startRef.current) startRef.current = timestamp;
@@ -46,7 +54,7 @@ export function AnimatedNumber({
 
       // ease-out cubic
       const eased = 1 - Math.pow(1 - progress, 3);
-      setDisplay(Math.round(from + (to - from) * eased));
+      setDisplay(Math.round(to * eased));
 
       if (progress < 1) {
         rafRef.current = requestAnimationFrame(animate);
@@ -59,7 +67,7 @@ export function AnimatedNumber({
     return () => {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
-  }, [value, duration, prefersReduced]);
+  }, [value, duration]);
 
   return (
     <span className={className}>

--- a/apps/negentropy-ui/components/ui/BaseDrawer.tsx
+++ b/apps/negentropy-ui/components/ui/BaseDrawer.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 /**
- * 通用侧边抽屉基类（遮罩 + 滑入面板 + Escape/遮罩关闭 + 焦点管理）。
+ * 通用侧边抽屉基类（遮罩 + 弹性滑入面板 + Escape/遮罩关闭 + 焦点管理）。
  *
  * 设计动机（Reuse-Driven / Orthogonal Decomposition）：
  * 收敛 StateDrawer、TaskDetailDrawer、ActivityDrawer、Scheduler 详情抽屉等
  * 多处重复的「固定定位 + 遮罩 + 右滑面板」实现。BaseDrawer 承担壳层 + 关闭交互 +
  * 焦点陷阱 + 入场滑动，业务专注面板内容。z-[45] 介于 Header(z-30) 与 Modal(z-50) 之间。
+ *
+ * 升级：使用 framer-motion spring 物理动画替代 CSS 动画，实现更自然的滑入/滑出。
  */
 
 import { ReactNode, useEffect, useId, useRef } from "react";
 import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useFocusTrap } from "@/lib/useFocusTrap";
@@ -32,6 +35,8 @@ export interface BaseDrawerProps {
   /** 是否渲染标题栏内置关闭按钮。默认 true。 */
   showClose?: boolean;
 }
+
+const SPRING_TRANSITION = { type: "spring" as const, damping: 30, stiffness: 300 };
 
 export function BaseDrawer({
   open,
@@ -60,66 +65,78 @@ export function BaseDrawer({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, closeOnEscape, onClose]);
 
-  if (!open || typeof document === "undefined") return null;
+  if (typeof document === "undefined") return null;
 
   return createPortal(
-    <div
-      className={cn(
-        "fixed inset-0 z-[45] flex",
-        side === "right" ? "justify-end" : "justify-start",
-      )}
-    >
-      <div
-        className="absolute inset-0 bg-overlay backdrop-blur-sm animate-fade-in"
-        onClick={closeOnBackdrop ? onClose : undefined}
-        aria-hidden
-      />
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={title ? titleId : undefined}
-        tabIndex={-1}
-        className={cn(
-          "relative flex h-full w-full flex-col bg-card shadow-xl outline-none",
-          side === "right"
-            ? "border-l border-border animate-slide-in-right"
-            : "border-r border-border animate-fade-in",
-          widthClassName,
-        )}
-      >
-        {(title || showClose) && (
-          <div className="flex items-start justify-between gap-3 border-b border-border px-5 py-4">
-            <div className="min-w-0 space-y-1">
-              {title ? (
-                <h3 id={titleId} className="text-h4 font-semibold tracking-heading text-foreground">
-                  {title}
-                </h3>
-              ) : null}
-              {subtitle ? (
-                <p className="text-sm leading-caption text-text-muted">{subtitle}</p>
-              ) : null}
-            </div>
-            {showClose ? (
-              <Button
-                iconOnly
-                size="sm"
-                variant="ghost"
-                onClick={onClose}
-                aria-label="关闭"
-                className="-mr-1 shrink-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
+    <AnimatePresence>
+      {open && (
+        <div
+          className={cn(
+            "fixed inset-0 z-[45] flex",
+            side === "right" ? "justify-end" : "justify-start",
+          )}
+        >
+          <motion.div
+            className="absolute inset-0 bg-overlay backdrop-blur-sm"
+            onClick={closeOnBackdrop ? onClose : undefined}
+            aria-hidden
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          />
+          <motion.div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={title ? titleId : undefined}
+            tabIndex={-1}
+            className={cn(
+              "relative flex h-full w-full flex-col bg-card shadow-xl outline-none",
+              side === "right"
+                ? "border-l border-border"
+                : "border-r border-border",
+              widthClassName,
+            )}
+            initial={{ x: side === "right" ? "100%" : "-100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: side === "right" ? "100%" : "-100%" }}
+            transition={SPRING_TRANSITION}
+          >
+            {(title || showClose) && (
+              <div className="flex items-start justify-between gap-3 border-b border-border px-5 py-4">
+                <div className="min-w-0 space-y-1">
+                  {title ? (
+                    <h3 id={titleId} className="text-h4 font-semibold tracking-heading text-foreground">
+                      {title}
+                    </h3>
+                  ) : null}
+                  {subtitle ? (
+                    <p className="text-sm leading-caption text-text-muted">{subtitle}</p>
+                  ) : null}
+                </div>
+                {showClose ? (
+                  <Button
+                    iconOnly
+                    size="sm"
+                    variant="ghost"
+                    onClick={onClose}
+                    aria-label="关闭"
+                    className="-mr-1 shrink-0"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                ) : null}
+              </div>
+            )}
+            <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+            {footer ? (
+              <div className="border-t border-border px-5 py-4">{footer}</div>
             ) : null}
-          </div>
-        )}
-        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
-        {footer ? (
-          <div className="border-t border-border px-5 py-4">{footer}</div>
-        ) : null}
-      </div>
-    </div>,
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>,
     document.body,
   );
 }

--- a/apps/negentropy-ui/components/ui/BaseModal.tsx
+++ b/apps/negentropy-ui/components/ui/BaseModal.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 /**
- * 通用模态对话框基类（背景遮罩 + 居中卡片 + Escape 关闭 + click-outside 关闭）。
+ * 通用模态对话框基类（背景遮罩 + 弹性缩放居中卡片 + Escape 关闭 + click-outside 关闭）。
  *
  * 设计动机（Reuse-Driven / Orthogonal Decomposition）：
  * 收敛 Wiki Publication 创建对话框、Catalog 节点选择对话框等多处重复实现的
  * 模态壳。BaseModal 仅承担"壳层 + 关闭交互 + 焦点管理"，业务对话框关注于自身
  * 字段、提交按钮等差异化部分；规避空 prop 默认值导致 useEffect 重跑等同型陷阱。
  *
- * 精致升级：令牌化遮罩（bg-overlay + backdrop-blur）、入场动画（fade + scale）、
+ * 精致升级：令牌化遮罩（bg-overlay + backdrop-blur）、弹性物理缩放入场（framer-motion spring）、
  * 焦点陷阱与焦点回归（useFocusTrap）、aria-labelledby 关联标题，rounded-modal 圆角。
  */
 
 import { ReactNode, useEffect, useId, useRef } from "react";
 import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
@@ -53,6 +54,8 @@ const SIZE_CLASS: Record<NonNullable<BaseModalProps["size"]>, string> = {
   lg: "max-w-lg",
 };
 
+const SPRING_TRANSITION = { type: "spring" as const, damping: 28, stiffness: 320 };
+
 export function BaseModal({
   open,
   title,
@@ -80,43 +83,55 @@ export function BaseModal({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, closeOnEscape, onClose]);
 
-  if (!open || typeof document === "undefined") return null;
+  if (typeof document === "undefined") return null;
 
   const sizeClass = SIZE_CLASS[size];
 
   return createPortal(
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4 backdrop-blur-sm animate-fade-in"
-      onClick={closeOnBackdrop ? onClose : undefined}
-    >
-      <div
-        ref={cardRef}
-        tabIndex={-1}
-        className={cn(
-          "flex max-h-[80vh] w-full flex-col rounded-modal border border-border bg-card p-6 shadow-xl outline-none animate-enter",
-          sizeClass,
-        )}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="mb-3">
-          <h3 id={titleId} className="text-h4 font-semibold tracking-heading">
-            {title}
-          </h3>
-          {subtitle ? (
-            <div className="mt-1 text-sm text-muted-foreground">
-              {subtitle}
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-overlay p-4 backdrop-blur-sm"
+          onClick={closeOnBackdrop ? onClose : undefined}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          <motion.div
+            ref={cardRef}
+            tabIndex={-1}
+            className={cn(
+              "flex max-h-[80vh] w-full flex-col rounded-modal border border-border bg-card p-6 shadow-xl outline-none",
+              sizeClass,
+            )}
+            onClick={(e) => e.stopPropagation()}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={SPRING_TRANSITION}
+          >
+            <div className="mb-3">
+              <h3 id={titleId} className="text-h4 font-semibold tracking-heading">
+                {title}
+              </h3>
+              {subtitle ? (
+                <div className="mt-1 text-sm text-muted-foreground">
+                  {subtitle}
+                </div>
+              ) : null}
             </div>
-          ) : null}
-        </div>
-        <div className="flex-1 overflow-y-auto">{children}</div>
-        {footer ? (
-          <div className="mt-4 flex items-center justify-end gap-2">{footer}</div>
-        ) : null}
-      </div>
-    </div>,
+            <div className="flex-1 overflow-y-auto">{children}</div>
+            {footer ? (
+              <div className="mt-4 flex items-center justify-end gap-2">{footer}</div>
+            ) : null}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
     document.body,
   );
 }

--- a/apps/negentropy-ui/components/ui/Button.tsx
+++ b/apps/negentropy-ui/components/ui/Button.tsx
@@ -38,7 +38,7 @@ const BASE =
   "disabled:pointer-events-none disabled:opacity-50 disabled:active:scale-100";
 
 const VARIANTS: Record<ButtonVariant, string> = {
-  primary: "bg-primary text-primary-foreground shadow-xs hover:bg-primary-hover",
+  primary: "bg-primary text-primary-foreground shadow-xs hover:bg-primary-hover hover:shadow-md hover:ring-1 hover:ring-primary/15 shiny-btn-primary",
   neutral: "bg-foreground text-background shadow-xs hover:opacity-90",
   secondary: "bg-muted text-foreground hover:bg-border/60 dark:hover:bg-border",
   outline:

--- a/apps/negentropy-ui/components/ui/EmptyState.tsx
+++ b/apps/negentropy-ui/components/ui/EmptyState.tsx
@@ -41,7 +41,7 @@ export function EmptyState({
       {Icon ? (
         <div
           className={cn(
-            "flex items-center justify-center rounded-2xl",
+            "flex items-center justify-center rounded-2xl animate-fade-in",
             tone === "accent"
               ? "bg-primary/10 text-primary"
               : "bg-muted text-text-muted",
@@ -51,7 +51,7 @@ export function EmptyState({
           <Icon className={size === "md" ? "h-6 w-6" : "h-5 w-5"} aria-hidden />
         </div>
       ) : null}
-      <div className="space-y-1">
+      <div className="space-y-1 animate-fade-in" style={{ animationDelay: "60ms" }}>
         <p className="text-body-lg font-semibold tracking-default text-foreground">{title}</p>
         {description ? (
           <p className="mx-auto max-w-sm text-sm leading-caption text-text-muted">

--- a/apps/negentropy-ui/components/ui/FadeIn.tsx
+++ b/apps/negentropy-ui/components/ui/FadeIn.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+/**
+ * 视口入场淡入包装器（参考 ReactBits FadeContent / AnimatedContent）。
+ *
+ * 子元素进入视口时执行 opacity + translateY 淡入动画，仅触发一次。
+ * 尊重 prefers-reduced-motion：降级为直接渲染子元素。
+ *
+ * ⚠ 严禁用于高频渲染区域（如 ChatStream 消息流）。
+ */
+export function FadeIn({
+  children,
+  delay = 0,
+  className,
+  as = "div",
+}: {
+  children: ReactNode;
+  /** 交错延迟（ms），默认 0。 */
+  delay?: number;
+  className?: string;
+  /** 容器元素，默认 div。 */
+  as?: "div" | "section" | "span";
+}) {
+  const prefersReduced = useReducedMotion();
+
+  if (prefersReduced) {
+    const Tag = as;
+    return <Tag className={className}>{children}</Tag>;
+  }
+
+  const Tag = motion.create(as);
+
+  return (
+    <Tag
+      className={cn(className)}
+      initial={{ opacity: 0, y: 8 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-40px" }}
+      transition={{
+        duration: 0.3,
+        delay: delay / 1000,
+        ease: [0.16, 1, 0.3, 1], // expo-out
+      }}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/apps/negentropy-ui/components/ui/FadeIn.tsx
+++ b/apps/negentropy-ui/components/ui/FadeIn.tsx
@@ -4,6 +4,15 @@ import { type ReactNode } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
+/** 模块级预创建 motion 元素，避免渲染期间调用 motion.create() 创建新组件。 */
+const motionElements = {
+  div: motion.div,
+  section: motion.section,
+  span: motion.span,
+} as const;
+
+type ElementType = "div" | "section" | "span";
+
 /**
  * 视口入场淡入包装器（参考 ReactBits FadeContent / AnimatedContent）。
  *
@@ -23,7 +32,7 @@ export function FadeIn({
   delay?: number;
   className?: string;
   /** 容器元素，默认 div。 */
-  as?: "div" | "section" | "span";
+  as?: ElementType;
 }) {
   const prefersReduced = useReducedMotion();
 
@@ -32,7 +41,7 @@ export function FadeIn({
     return <Tag className={className}>{children}</Tag>;
   }
 
-  const Tag = motion.create(as);
+  const Tag = motionElements[as];
 
   return (
     <Tag

--- a/apps/negentropy-ui/components/ui/Skeleton.tsx
+++ b/apps/negentropy-ui/components/ui/Skeleton.tsx
@@ -4,9 +4,9 @@ import { cn } from "@/lib/utils";
 /**
  * 骨架占位（Reuse-Driven）。
  *
- * 收敛全站「正在加载…」文本与零散 shimmer，统一为令牌驱动的脉冲占位块，
- * 用于 >300ms 的异步加载（符合 MD/HIG 加载反馈准则）。脉冲动画已被全局
- * `prefers-reduced-motion` 规则降级。预留尺寸以避免布局抖动（CLS）。
+ * 收敛全站「正在加载…」文本与零散 shimmer，统一为令牌驱动的扫光占位块，
+ * 用于 >300ms 的异步加载（符合 MD/HIG 加载反馈准则）。
+ * 扫光动画已被全局 `prefers-reduced-motion` 规则降级。预留尺寸以避免布局抖动（CLS）。
  */
 export type SkeletonProps = HTMLAttributes<HTMLDivElement>;
 
@@ -14,7 +14,11 @@ export function Skeleton({ className, ...props }: SkeletonProps) {
   return (
     <div
       aria-hidden
-      className={cn("animate-pulse rounded-control bg-muted", className)}
+      className={cn(
+        "animate-shimmer rounded-control",
+        "bg-gradient-to-r from-muted via-muted/40 to-muted bg-[length:200%_100%]",
+        className,
+      )}
       {...props}
     />
   );

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -37,6 +37,7 @@
     "d3-force": "^3.0.0",
     "d3-selection": "^3.0.0",
     "d3-zoom": "^3.0.0",
+    "framer-motion": "^12.40.0",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",
     "highlight.js": "^11.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextjs-toploader:
         specifier: ^3.7.15
-        version: 3.9.17(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 3.9.17(next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.0
         version: 19.2.3
@@ -141,7 +141,7 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        version: 16.2.6(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       identity-obj-proxy:
         specifier: ^3.0.0
         version: 3.0.0
@@ -208,6 +208,9 @@ importers:
       d3-zoom:
         specifier: ^3.0.0
         version: 3.0.0
+      framer-motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       graphology:
         specifier: ^0.26.0
         version: 0.26.0(graphology-types@0.24.8)
@@ -349,7 +352,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^28.0.0
         version: 28.1.0
@@ -3669,6 +3672,20 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  framer-motion@12.40.0:
+    resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4608,6 +4625,12 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  motion-dom@12.40.0:
+    resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8012,7 +8035,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(jsdom@27.4.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0))
+      vitest: 4.1.6(@types/node@20.19.41)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -8917,18 +8940,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8957,6 +8980,26 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-next@16.2.6(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.6
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      globals: 16.4.0
+      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
@@ -8976,7 +9019,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -8991,18 +9034,18 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@1.21.7)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9017,7 +9060,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9026,9 +9079,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9040,7 +9093,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9070,6 +9123,33 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      hasown: 2.0.3
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9423,6 +9503,15 @@ snapshots:
   format@0.2.2: {}
 
   fraction.js@5.3.4: {}
+
+  framer-motion@12.40.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 12.40.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   fsevents@2.3.2:
     optional: true
@@ -10661,6 +10750,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  motion-dom@12.40.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
   ms@2.1.3: {}
 
   msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3):
@@ -10759,7 +10854,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-toploader@3.9.17(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  nextjs-toploader@3.9.17(next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       next: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nprogress: 0.2.0


### PR DESCRIPTION
## 概述

参考 [ReactBits.dev](https://reactbits.dev) 的 Text Animations、Components 等模块设计模式，以「简约、专业、美观」为原则，全面优化 negentropy-ui 主站的 UI 交互动画系统。

## 变更内容

### Phase 1：CSS 层面打磨（零新依赖）
- **Skeleton 微光扫光**：`animate-pulse` 替换为 Linear/Vercel 风格的 shimmer 扫光渐变
- **EmptyState 入场**：图标与标题添加 `animate-fade-in` 交错入场
- **Button 辉光**：primary 变体新增 hover 阴影辉光 + ShinyButton 光泽扫过

### Phase 2：引入 framer-motion + 高影响力组件
- **AnimatedNumber**：Dashboard 指标数值递增动画（参考 ReactBits CountUp）
- **FadeIn**：视口入场淡入包装器，应用于 Dashboard 各区块（参考 ReactBits FadeContent）
- **AnimatedList**：交错入场列表容器（参考 ReactBits AnimatedList）
- **BaseDrawer**：CSS 动画 → framer-motion spring 物理弹性滑入/滑出
- **BaseModal**：CSS 动画 → framer-motion spring 弹性缩放入场/退场

### Phase 3：交互微反馈增强
- **MainNav**：主导航项首次加载交错淡入动画
- **ShinyButton**：主按钮 hover 时光泽扫过（CSS-only）

## 设计决策

| 决策 | 理由 |
|------|------|
| 仅 framer-motion 引入 negentropy-ui | wiki 保持现有 CSS 动画体系 |
| 排除 WebGL 背景 | 仪表盘不适合 WebGL，已有 indigo 环境光 |
| 排除 SplitText/DecryptedText | 营销站效果，仪表盘需克制 |
| 排除 TiltCard/SpotlightCard | 高频 GPU 合成影响性能 |
| 所有动画 ≤ 400ms | 工具应用，不是展示站 |
| 全部尊重 prefers-reduced-motion | framer-motion useReducedMotion + CSS 降级 |

## 文件清单

| 文件 | 变更 |
|------|------|
| `globals.css` | shimmer/shiny keyframes + 动画令牌 |
| `Skeleton.tsx` | shimmer 扫光替换 pulse |
| `EmptyState.tsx` | fade-in 入场 |
| `Button.tsx` | hover 辉光 + 光泽 |
| `BaseDrawer.tsx` | spring 弹性滑入 |
| `BaseModal.tsx` | spring 弹性缩放 |
| `MainNav.tsx` | 交错入场 |
| `AnimatedNumber.tsx` | 新建 - 数值递增 |
| `FadeIn.tsx` | 新建 - 视口淡入 |
| `AnimatedList.tsx` | 新建 - 交错列表 |
| `MetricCell.tsx` | AnimatedNumber 应用 |
| `dashboard/page.tsx` | FadeIn 区块包裹 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)