### PR TITLE
refactor(routine-ui): 重设计 New Routine 模态框 — 宽面板双列布局 + 高级设置折叠 + Footer 组件化

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
 
+import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { cn } from "@/lib/utils";
 import type { ApprovalMode, RoutineCreatePayload, RoutineDTO, RoutineUpdatePayload } from "@/features/routine";
 
 interface RoutineFormDialogProps {
@@ -66,6 +69,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -91,13 +95,22 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
           description: routine.description ?? "",
         }
       : EMPTY;
+    // 编辑模式下，若高级字段有非空值则自动展开
+    const hasAdvanced =
+      !!(routine?.cwd) ||
+      !!(cfg.model) ||
+      cfg.max_turns != null ||
+      !!(cfg.permission_mode) ||
+      (Array.isArray(cfg.allowed_tools) && (cfg.allowed_tools as string[]).length > 0) ||
+      !!(routine?.verification_command);
     // 用 microtask 推迟，避免在 effect 体内同步 setState（对齐 SchedulerTaskFormDialog）
     queueMicrotask(() => {
       setForm(next);
       setError(null);
       setFieldErrors({});
+      setShowAdvanced(isEdit && hasAdvanced);
     });
-  }, [open, routine]);
+  }, [open, routine, isEdit]);
 
   const update = <K extends keyof FormState>(k: K, v: FormState[K]) => setForm((f) => ({ ...f, [k]: v }));
 
@@ -163,9 +176,8 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
   if (!open) return null;
 
   const inputCls =
-    "w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
   const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
-  const sectionTitleCls = "text-[10px] uppercase tracking-wider text-text-muted mb-2";
 
   return (
     <OverlayDismissLayer
@@ -173,23 +185,23 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
       onClose={onClose}
       busy={loading}
       containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
-      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-xl flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl sm:max-h-[calc(100vh-2rem)]"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-2xl flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl sm:max-h-[calc(100vh-2rem)]"
     >
+      {/* Header */}
       <div className="border-b border-border px-5 py-4">
         <h2 className="text-lg font-semibold text-foreground">{isEdit ? "Edit Routine" : "New Routine"}</h2>
         <p className="mt-1 text-sm text-text-muted">
-          {isEdit ? `Editing "${routine.display_name || routine.title}"` : "Define a long-horizon autonomous task"}
+          {isEdit ? `Editing "${routine.display_name || routine.title}"` : "定义一个长周期自主任务"}
         </p>
       </div>
 
       <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
-        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-5">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
           {error && <ErrorBanner message={error} />}
 
-          {/* Basic */}
+          {/* Key + Title (双列) + Description */}
           <section>
-            <h3 className={sectionTitleCls}>Basic</h3>
-            <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
               {isEdit ? (
                 <div>
                   <label className={labelCls}>Key</label>
@@ -205,7 +217,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                     value={form.key}
                     onChange={(e) => update("key", e.target.value)}
                     placeholder="unique_routine_key"
-                    className={`${inputCls} ${fieldErrors.key ? "border-red-400" : ""}`}
+                    className={cn(inputCls, fieldErrors.key && "border-red-400")}
                   />
                   {fieldErrors.key && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>}
                 </div>
@@ -218,63 +230,59 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                   type="text"
                   value={form.title}
                   onChange={(e) => update("title", e.target.value)}
-                  className={`${inputCls} ${fieldErrors.title ? "border-red-400" : ""}`}
+                  className={cn(inputCls, fieldErrors.title && "border-red-400")}
                 />
                 {fieldErrors.title && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>}
               </div>
-              <div>
-                <label className={labelCls}>Description</label>
-                <textarea
-                  value={form.description}
-                  onChange={(e) => update("description", e.target.value)}
-                  rows={2}
-                  className={inputCls}
-                />
-              </div>
+            </div>
+            <div className="mt-3">
+              <label className={labelCls}>Description</label>
+              <textarea
+                value={form.description}
+                onChange={(e) => update("description", e.target.value)}
+                rows={2}
+                className={inputCls}
+              />
             </div>
           </section>
 
-          {/* Goal */}
-          <section>
-            <h3 className={sectionTitleCls}>Goal &amp; Criteria</h3>
-            <div className="space-y-3">
-              <div>
-                <label className={labelCls}>
-                  Goal <span className="text-red-500">*</span>
-                </label>
-                <textarea
-                  value={form.goal}
-                  onChange={(e) => update("goal", e.target.value)}
-                  rows={4}
-                  placeholder="The long-horizon objective for Claude Code to accomplish"
-                  className={`${inputCls} ${fieldErrors.goal ? "border-red-400" : ""}`}
-                />
-                {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}
-              </div>
-              <div>
-                <label className={labelCls}>
-                  Acceptance Criteria <span className="text-red-500">*</span>
-                </label>
-                <textarea
-                  value={form.acceptance_criteria}
-                  onChange={(e) => update("acceptance_criteria", e.target.value)}
-                  rows={3}
-                  placeholder="How the Evaluator judges success (the rubric)"
-                  className={`${inputCls} ${fieldErrors.acceptance_criteria ? "border-red-400" : ""}`}
-                />
-                {fieldErrors.acceptance_criteria && (
-                  <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.acceptance_criteria}</p>
-                )}
-              </div>
+          {/* Goal & Criteria */}
+          <section className="space-y-3">
+            <div>
+              <label className={labelCls}>
+                Goal <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                value={form.goal}
+                onChange={(e) => update("goal", e.target.value)}
+                rows={3}
+                placeholder="The long-horizon objective for Claude Code to accomplish"
+                className={cn(inputCls, fieldErrors.goal && "border-red-400")}
+              />
+              {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}
+            </div>
+            <div>
+              <label className={labelCls}>
+                Acceptance Criteria <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                value={form.acceptance_criteria}
+                onChange={(e) => update("acceptance_criteria", e.target.value)}
+                rows={2}
+                placeholder="How the Evaluator judges success (the rubric)"
+                className={cn(inputCls, fieldErrors.acceptance_criteria && "border-red-400")}
+              />
+              {fieldErrors.acceptance_criteria && (
+                <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.acceptance_criteria}</p>
+              )}
             </div>
           </section>
 
-          {/* Budgets */}
-          <section>
-            <h3 className={sectionTitleCls}>Budgets &amp; Guardrails</h3>
-            <div className="grid grid-cols-2 gap-3">
+          {/* Budgets & Approval (子卡片) */}
+          <section className="rounded-card border border-border bg-muted/30 p-4">
+            <div className="grid grid-cols-4 gap-3">
               <div>
-                <label className={labelCls}>Max Iterations</label>
+                <label className={labelCls}>Max Iter.</label>
                 <input
                   type="number"
                   min={1}
@@ -284,7 +292,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                 />
               </div>
               <div>
-                <label className={labelCls}>Max Cost (USD)</label>
+                <label className={labelCls}>Max Cost</label>
                 <input
                   type="number"
                   min={0}
@@ -295,7 +303,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                 />
               </div>
               <div>
-                <label className={labelCls}>Success Threshold (0-100)</label>
+                <label className={labelCls}>Threshold</label>
                 <input
                   type="number"
                   min={0}
@@ -306,7 +314,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                 />
               </div>
               <div>
-                <label className={labelCls}>No-Progress Patience</label>
+                <label className={labelCls}>Patience</label>
                 <input
                   type="number"
                   min={1}
@@ -316,93 +324,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                 />
               </div>
             </div>
-          </section>
-
-          {/* Execution */}
-          <section>
-            <h3 className={sectionTitleCls}>Execution (Claude Code)</h3>
-            <div className="space-y-3">
-              <div>
-                <label className={labelCls}>Working Directory</label>
-                <input
-                  type="text"
-                  value={form.cwd}
-                  onChange={(e) => update("cwd", e.target.value)}
-                  placeholder="/path/to/project"
-                  className={inputCls}
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className={labelCls}>Max Turns / Iteration</label>
-                  <input
-                    type="number"
-                    min={1}
-                    value={form.max_turns}
-                    onChange={(e) => update("max_turns", e.target.value)}
-                    placeholder="default"
-                    className={inputCls}
-                  />
-                </div>
-                <div>
-                  <label className={labelCls}>Permission Mode</label>
-                  <select
-                    value={form.permission_mode}
-                    onChange={(e) => update("permission_mode", e.target.value)}
-                    className={inputCls}
-                  >
-                    <option value="">default</option>
-                    <option value="auto">auto</option>
-                    <option value="ask">ask</option>
-                    <option value="plan">plan</option>
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label className={labelCls}>Allowed Tools (comma-separated)</label>
-                <input
-                  type="text"
-                  value={form.allowed_tools}
-                  onChange={(e) => update("allowed_tools", e.target.value)}
-                  placeholder="Bash, Read, Write, Edit, Glob, Grep"
-                  className={inputCls}
-                />
-              </div>
-              <div>
-                <label className={labelCls}>Model (optional)</label>
-                <input
-                  type="text"
-                  value={form.model}
-                  onChange={(e) => update("model", e.target.value)}
-                  placeholder="inherit global config"
-                  className={inputCls}
-                />
-              </div>
-            </div>
-          </section>
-
-          {/* Evaluation */}
-          <section>
-            <h3 className={sectionTitleCls}>Evaluation</h3>
-            <div>
-              <label className={labelCls}>Verification Command (optional gate)</label>
-              <input
-                type="text"
-                value={form.verification_command}
-                onChange={(e) => update("verification_command", e.target.value)}
-                placeholder="e.g. uv run pytest -q"
-                className={inputCls}
-              />
-              <p className="mt-0.5 text-[10px] text-text-muted">
-                测试驱动门控：退出码非 0 时评分封顶，作为客观锚点缓解 LLM 评审偏差
-              </p>
-            </div>
-          </section>
-
-          {/* Approval */}
-          <section>
-            <h3 className={sectionTitleCls}>Human-in-the-Loop</h3>
-            <div>
+            <div className="mt-3">
               <label className={labelCls}>Approval Mode</label>
               <select
                 value={form.approval_mode}
@@ -413,28 +335,112 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                 <option value="first">First iteration approval</option>
                 <option value="every">Every iteration approval</option>
               </select>
-              <p className="mt-0.5 text-[10px] text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+              <p className="mt-1 text-caption text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
             </div>
+          </section>
+
+          {/* Advanced Settings (折叠) */}
+          <section>
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((prev) => !prev)}
+              className="group flex w-full items-center gap-2 rounded-control px-1.5 py-1.5 text-caption font-medium text-text-secondary transition-colors hover:bg-muted"
+              aria-expanded={showAdvanced}
+            >
+              <ChevronDown
+                aria-hidden="true"
+                className={cn(
+                  "h-3.5 w-3.5 text-text-muted transition-transform duration-150",
+                  showAdvanced && "rotate-180",
+                )}
+              />
+              <span>{showAdvanced ? "收起高级设置" : "高级设置 (Working Directory, Model, Tools...)"}</span>
+            </button>
+
+            {showAdvanced && (
+              <div className="mt-3 space-y-3 rounded-card border border-border bg-muted/30 p-4">
+                <div>
+                  <label className={labelCls}>Working Directory</label>
+                  <input
+                    type="text"
+                    value={form.cwd}
+                    onChange={(e) => update("cwd", e.target.value)}
+                    placeholder="/path/to/project"
+                    className={inputCls}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className={labelCls}>Max Turns / Iteration</label>
+                    <input
+                      type="number"
+                      min={1}
+                      value={form.max_turns}
+                      onChange={(e) => update("max_turns", e.target.value)}
+                      placeholder="default"
+                      className={inputCls}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelCls}>Permission Mode</label>
+                    <select
+                      value={form.permission_mode}
+                      onChange={(e) => update("permission_mode", e.target.value)}
+                      className={inputCls}
+                    >
+                      <option value="">default</option>
+                      <option value="auto">auto</option>
+                      <option value="ask">ask</option>
+                      <option value="plan">plan</option>
+                    </select>
+                  </div>
+                </div>
+                <div>
+                  <label className={labelCls}>Allowed Tools (comma-separated)</label>
+                  <input
+                    type="text"
+                    value={form.allowed_tools}
+                    onChange={(e) => update("allowed_tools", e.target.value)}
+                    placeholder="Bash, Read, Write, Edit, Glob, Grep"
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label className={labelCls}>Model (optional)</label>
+                  <input
+                    type="text"
+                    value={form.model}
+                    onChange={(e) => update("model", e.target.value)}
+                    placeholder="inherit global config"
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label className={labelCls}>Verification Command (optional gate)</label>
+                  <input
+                    type="text"
+                    value={form.verification_command}
+                    onChange={(e) => update("verification_command", e.target.value)}
+                    placeholder="e.g. uv run pytest -q"
+                    className={inputCls}
+                  />
+                  <p className="mt-1 text-caption text-text-muted">
+                    测试驱动门控：退出码非 0 时评分封顶，作为客观锚点缓解 LLM 评审偏差
+                  </p>
+                </div>
+              </div>
+            )}
           </section>
         </div>
 
         {/* Footer */}
         <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={loading}
-            className="cursor-pointer rounded-md border border-border px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/50 disabled:opacity-50"
-          >
+          <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={loading}>
             Cancel
-          </button>
-          <button
-            type="submit"
-            disabled={loading}
-            className="cursor-pointer rounded-md bg-foreground px-4 py-1.5 text-sm font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
-          >
-            {loading ? "Saving…" : isEdit ? "Save" : "Create"}
-          </button>
+          </Button>
+          <Button type="submit" variant="primary" size="sm" loading={loading}>
+            {isEdit ? "Save" : "Create Routine"}
+          </Button>
         </div>
       </form>
     </OverlayDismissLayer>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
@@ -244,28 +244,23 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                 {fieldErrors.title && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>}
               </div>
             </div>
-            <div className="mt-3">
-              <label className={vLabelCls}>Description</label>
-              <textarea
-                value={form.description}
-                onChange={(e) => update("description", e.target.value)}
-                rows={2}
-                className={inputCls}
-              />
-            </div>
+            <textarea
+              className={cn(inputCls, "mt-3")}
+              value={form.description}
+              onChange={(e) => update("description", e.target.value)}
+              rows={2}
+              placeholder="Description"
+            />
           </section>
 
           {/* ── Goal & Criteria (textarea → 垂直布局) ── */}
           <section className="space-y-3">
             <div>
-              <label className={vLabelCls}>
-                Goal <span className="text-red-500">*</span>
-              </label>
               <textarea
                 value={form.goal}
                 onChange={(e) => update("goal", e.target.value)}
                 rows={3}
-                placeholder="The long-horizon objective for Claude Code to accomplish"
+                placeholder="Goal: The long-horizon objective for Claude Code to accomplish"
                 className={cn(inputCls, fieldErrors.goal && "border-red-400")}
               />
               {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFormDialog.tsx
@@ -175,9 +175,14 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
 
   if (!open) return null;
 
+  /* ── 样式常量 ── */
+  // 通用 input 基础样式；水平布局时叠加 min-w-0 flex-1 覆盖 w-full
   const inputCls =
     "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
-  const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
+  // 水平 Label（shrink-0 不收缩，whitespace-nowrap 不换行）
+  const labelCls = "shrink-0 whitespace-nowrap text-xs font-medium text-text-secondary";
+  // 垂直 Label（用于 textarea 上方的 label）
+  const vLabelCls = "mb-1 block text-xs font-medium text-text-secondary";
 
   return (
     <OverlayDismissLayer
@@ -199,44 +204,48 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
           {error && <ErrorBanner message={error} />}
 
-          {/* Key + Title (双列) + Description */}
+          {/* ── Key + Title (双列水平) + Description (垂直) ── */}
           <section>
             <div className="grid grid-cols-2 gap-3">
               {isEdit ? (
-                <div>
+                <div className="flex items-center gap-2">
                   <label className={labelCls}>Key</label>
-                  <input type="text" value={form.key} disabled className={inputCls} />
+                  <input type="text" value={form.key} disabled className={cn(inputCls, "min-w-0 flex-1")} />
                 </div>
               ) : (
                 <div>
-                  <label className={labelCls}>
-                    Key <span className="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={form.key}
-                    onChange={(e) => update("key", e.target.value)}
-                    placeholder="unique_routine_key"
-                    className={cn(inputCls, fieldErrors.key && "border-red-400")}
-                  />
+                  <div className="flex items-center gap-2">
+                    <label className={labelCls}>
+                      Key <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={form.key}
+                      onChange={(e) => update("key", e.target.value)}
+                      placeholder="unique_routine_key"
+                      className={cn(inputCls, "min-w-0 flex-1", fieldErrors.key && "border-red-400")}
+                    />
+                  </div>
                   {fieldErrors.key && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>}
                 </div>
               )}
               <div>
-                <label className={labelCls}>
-                  Title <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={form.title}
-                  onChange={(e) => update("title", e.target.value)}
-                  className={cn(inputCls, fieldErrors.title && "border-red-400")}
-                />
+                <div className="flex items-center gap-2">
+                  <label className={labelCls}>
+                    Title <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={form.title}
+                    onChange={(e) => update("title", e.target.value)}
+                    className={cn(inputCls, "min-w-0 flex-1", fieldErrors.title && "border-red-400")}
+                  />
+                </div>
                 {fieldErrors.title && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>}
               </div>
             </div>
             <div className="mt-3">
-              <label className={labelCls}>Description</label>
+              <label className={vLabelCls}>Description</label>
               <textarea
                 value={form.description}
                 onChange={(e) => update("description", e.target.value)}
@@ -246,10 +255,10 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
             </div>
           </section>
 
-          {/* Goal & Criteria */}
+          {/* ── Goal & Criteria (textarea → 垂直布局) ── */}
           <section className="space-y-3">
             <div>
-              <label className={labelCls}>
+              <label className={vLabelCls}>
                 Goal <span className="text-red-500">*</span>
               </label>
               <textarea
@@ -262,7 +271,7 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
               {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}
             </div>
             <div>
-              <label className={labelCls}>
+              <label className={vLabelCls}>
                 Acceptance Criteria <span className="text-red-500">*</span>
               </label>
               <textarea
@@ -278,68 +287,70 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
             </div>
           </section>
 
-          {/* Budgets & Approval (子卡片) */}
+          {/* ── Budgets & Approval (子卡片，2 列水平) ── */}
           <section className="rounded-card border border-border bg-muted/30 p-4">
-            <div className="grid grid-cols-4 gap-3">
-              <div>
-                <label className={labelCls}>Max Iter.</label>
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Max Iterations</label>
                 <input
                   type="number"
                   min={1}
                   value={form.max_iterations}
                   onChange={(e) => update("max_iterations", e.target.value)}
-                  className={inputCls}
+                  className={cn(inputCls, "min-w-0 flex-1")}
                 />
               </div>
-              <div>
-                <label className={labelCls}>Max Cost</label>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Max Cost (USD)</label>
                 <input
                   type="number"
                   min={0}
                   step="0.5"
                   value={form.max_cost_usd}
                   onChange={(e) => update("max_cost_usd", e.target.value)}
-                  className={inputCls}
+                  className={cn(inputCls, "min-w-0 flex-1")}
                 />
               </div>
-              <div>
-                <label className={labelCls}>Threshold</label>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Score Threshold</label>
                 <input
                   type="number"
                   min={0}
                   max={100}
                   value={form.success_score_threshold}
                   onChange={(e) => update("success_score_threshold", e.target.value)}
-                  className={inputCls}
+                  className={cn(inputCls, "min-w-0 flex-1")}
                 />
               </div>
-              <div>
-                <label className={labelCls}>Patience</label>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>No-Progress Limit</label>
                 <input
                   type="number"
                   min={1}
                   value={form.no_progress_patience}
                   onChange={(e) => update("no_progress_patience", e.target.value)}
-                  className={inputCls}
+                  className={cn(inputCls, "min-w-0 flex-1")}
                 />
               </div>
             </div>
-            <div className="mt-3">
-              <label className={labelCls}>Approval Mode</label>
-              <select
-                value={form.approval_mode}
-                onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
-                className={inputCls}
-              >
-                <option value="auto">Auto (fully autonomous)</option>
-                <option value="first">First iteration approval</option>
-                <option value="every">Every iteration approval</option>
-              </select>
-              <p className="mt-1 text-caption text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+            <div className="mt-3 flex items-start gap-2">
+              <label className={cn(labelCls, "pt-2")}>Approval Mode</label>
+              <div className="min-w-0 flex-1">
+                <select
+                  value={form.approval_mode}
+                  onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
+                  className={inputCls}
+                >
+                  <option value="auto">Auto (fully autonomous)</option>
+                  <option value="first">First iteration approval</option>
+                  <option value="every">Every iteration approval</option>
+                </select>
+                <p className="mt-1 text-caption text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+              </div>
             </div>
           </section>
 
-          {/* Advanced Settings (折叠) */}
+          {/* ── Advanced Settings (折叠，全部水平) ── */}
           <section>
             <button
               type="button"
@@ -358,35 +369,35 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
             </button>
 
             {showAdvanced && (
-              <div className="mt-3 space-y-3 rounded-card border border-border bg-muted/30 p-4">
-                <div>
+              <div className="mt-3 space-y-2 rounded-card border border-border bg-muted/30 p-4">
+                <div className="flex items-center gap-2">
                   <label className={labelCls}>Working Directory</label>
                   <input
                     type="text"
                     value={form.cwd}
                     onChange={(e) => update("cwd", e.target.value)}
                     placeholder="/path/to/project"
-                    className={inputCls}
+                    className={cn(inputCls, "min-w-0 flex-1")}
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className={labelCls}>Max Turns / Iteration</label>
+                  <div className="flex items-center gap-2">
+                    <label className={labelCls}>Max Turns / Iter.</label>
                     <input
                       type="number"
                       min={1}
                       value={form.max_turns}
                       onChange={(e) => update("max_turns", e.target.value)}
                       placeholder="default"
-                      className={inputCls}
+                      className={cn(inputCls, "min-w-0 flex-1")}
                     />
                   </div>
-                  <div>
+                  <div className="flex items-center gap-2">
                     <label className={labelCls}>Permission Mode</label>
                     <select
                       value={form.permission_mode}
                       onChange={(e) => update("permission_mode", e.target.value)}
-                      className={inputCls}
+                      className={cn(inputCls, "min-w-0 flex-1")}
                     >
                       <option value="">default</option>
                       <option value="auto">auto</option>
@@ -395,35 +406,37 @@ export function RoutineFormDialog({ open, routine, onClose, onSubmit }: RoutineF
                     </select>
                   </div>
                 </div>
-                <div>
-                  <label className={labelCls}>Allowed Tools (comma-separated)</label>
+                <div className="flex items-center gap-2">
+                  <label className={labelCls}>Allowed Tools</label>
                   <input
                     type="text"
                     value={form.allowed_tools}
                     onChange={(e) => update("allowed_tools", e.target.value)}
                     placeholder="Bash, Read, Write, Edit, Glob, Grep"
-                    className={inputCls}
+                    className={cn(inputCls, "min-w-0 flex-1")}
                   />
                 </div>
-                <div>
-                  <label className={labelCls}>Model (optional)</label>
+                <div className="flex items-center gap-2">
+                  <label className={labelCls}>Model</label>
                   <input
                     type="text"
                     value={form.model}
                     onChange={(e) => update("model", e.target.value)}
                     placeholder="inherit global config"
-                    className={inputCls}
+                    className={cn(inputCls, "min-w-0 flex-1")}
                   />
                 </div>
                 <div>
-                  <label className={labelCls}>Verification Command (optional gate)</label>
-                  <input
-                    type="text"
-                    value={form.verification_command}
-                    onChange={(e) => update("verification_command", e.target.value)}
-                    placeholder="e.g. uv run pytest -q"
-                    className={inputCls}
-                  />
+                  <div className="flex items-center gap-2">
+                    <label className={labelCls}>Verification Command</label>
+                    <input
+                      type="text"
+                      value={form.verification_command}
+                      onChange={(e) => update("verification_command", e.target.value)}
+                      placeholder="e.g. uv run pytest -q"
+                      className={cn(inputCls, "min-w-0 flex-1")}
+                    />
+                  </div>
                   <p className="mt-1 text-caption text-text-muted">
                     测试驱动门控：退出码非 0 时评分封顶，作为客观锚点缓解 LLM 评审偏差
                   </p>

--- a/apps/negentropy-ui/tests/unit/features/routine/routine-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/routine/routine-api.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  approveIteration,
+  controlRoutine,
+  createRoutine,
+  deleteRoutine,
+  fetchIterations,
+  fetchKpis,
+  fetchRoutineDetail,
+  fetchRoutines,
+  rejectIteration,
+  updateRoutine,
+} from "@/features/routine";
+import type { RoutineCreatePayload, RoutineUpdatePayload } from "@/features/routine";
+
+/**
+ * Routine API 客户端单测。
+ *
+ * 验证三件事：① 请求 URL（含查询串编码 / 路径段转义）；② HTTP 方法与
+ * Content-Type / body 序列化；③ 解析返回值与错误分支（非 2xx 抛错且携带后端 detail）。
+ */
+
+const ok = (payload: unknown) =>
+  new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("routine api client", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetchKpis 命中 /kpis 并解析返回体", async () => {
+    const kpis = { total: 3, running: 1 };
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok(kpis));
+
+    await expect(fetchKpis()).resolves.toMatchObject(kpis);
+    expect(spy).toHaveBeenCalledWith(
+      "/api/routine/kpis",
+      expect.objectContaining({ cache: "no-store", headers: expect.objectContaining({ "Content-Type": "application/json" }) }),
+    );
+  });
+
+  it("fetchRoutines 无 filter 时不附加查询串", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ items: [], next_cursor: null, has_more: false }));
+
+    await fetchRoutines();
+    expect(spy).toHaveBeenCalledWith("/api/routine", expect.any(Object));
+  });
+
+  it("fetchRoutines 序列化 status 与 q 查询参数", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ items: [], next_cursor: null, has_more: false }));
+
+    await fetchRoutines({ status: "running", q: "deep work" });
+    const url = spy.mock.calls[0]?.[0] as string;
+    expect(url.startsWith("/api/routine?")).toBe(true);
+    expect(url).toContain("status=running");
+    // 空格按 application/x-www-form-urlencoded 编码为 +
+    expect(url).toContain("q=deep+work");
+  });
+
+  it("fetchRoutineDetail 转义路径段并带 recent 参数", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "a/b" }));
+
+    await fetchRoutineDetail("a/b", 5);
+    expect(spy).toHaveBeenCalledWith("/api/routine/a%2Fb?recent=5", expect.any(Object));
+  });
+
+  it("fetchRoutineDetail recent 默认 20", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "r1" }));
+
+    await fetchRoutineDetail("r1");
+    expect(spy).toHaveBeenCalledWith("/api/routine/r1?recent=20", expect.any(Object));
+  });
+
+  it("fetchIterations 无选项时不附加查询串", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ items: [], has_more: false, next_before_seq: null }));
+
+    await fetchIterations("r1");
+    expect(spy).toHaveBeenCalledWith("/api/routine/r1/iterations", expect.any(Object));
+  });
+
+  it("fetchIterations 透传 limit 与 before_seq（含 0）", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ items: [], has_more: false, next_before_seq: null }));
+
+    await fetchIterations("r1", { limit: 10, before_seq: 0 });
+    const url = spy.mock.calls[0]?.[0] as string;
+    expect(url).toContain("limit=10");
+    // before_seq=0 不应被当作 falsy 而丢弃
+    expect(url).toContain("before_seq=0");
+  });
+
+  it("createRoutine 以 POST 发送 JSON body", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "new" }));
+    const body: RoutineCreatePayload = {
+      key: "k1",
+      title: "T",
+      goal: "G",
+      acceptance_criteria: "AC",
+    };
+
+    await expect(createRoutine(body)).resolves.toMatchObject({ id: "new" });
+    expect(spy).toHaveBeenCalledWith(
+      "/api/routine",
+      expect.objectContaining({ method: "POST", body: JSON.stringify(body) }),
+    );
+  });
+
+  it("updateRoutine 以 PUT 发送 JSON body 并转义 id", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "r 1" }));
+    const body: RoutineUpdatePayload = { title: "T2" };
+
+    await updateRoutine("r 1", body);
+    expect(spy).toHaveBeenCalledWith(
+      "/api/routine/r%201",
+      expect.objectContaining({ method: "PUT", body: JSON.stringify(body) }),
+    );
+  });
+
+  it("deleteRoutine 以 DELETE 命中资源路径", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ ok: true, deleted_routine_id: "r1" }));
+
+    await expect(deleteRoutine("r1")).resolves.toEqual({ ok: true, deleted_routine_id: "r1" });
+    expect(spy).toHaveBeenCalledWith("/api/routine/r1", expect.objectContaining({ method: "DELETE" }));
+  });
+
+  it.each(["start", "pause", "resume", "cancel"] as const)(
+    "controlRoutine 拼接 %s 动作并 POST",
+    async (action) => {
+      const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "r1" }));
+
+      await controlRoutine("r1", action);
+      expect(spy).toHaveBeenCalledWith(`/api/routine/r1/${action}`, expect.objectContaining({ method: "POST" }));
+    },
+  );
+
+  it("approveIteration 命中 approve 子路径并转义两段 id", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "it1" }));
+
+    await approveIteration("r/1", "it 1");
+    expect(spy).toHaveBeenCalledWith(
+      "/api/routine/r%2F1/iterations/it%201/approve",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("rejectIteration 命中 reject 子路径", async () => {
+    const spy = vi.spyOn(global, "fetch").mockResolvedValue(ok({ id: "it1" }));
+
+    await rejectIteration("r1", "it1");
+    expect(spy).toHaveBeenCalledWith(
+      "/api/routine/r1/iterations/it1/reject",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("非 2xx 响应抛错并携带后端结构化 detail", async () => {
+    // 用 mockImplementation 每次返回新 Response：Response body 仅可读一次，
+    // 否则二次断言会拿到已被消费的空 body。
+    vi.spyOn(global, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ detail: "boom" }), {
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(fetchKpis()).rejects.toThrow(/500/);
+    await expect(fetchKpis()).rejects.toThrow(/boom/);
+  });
+
+  it("非 2xx 且 body 非 JSON 时回退到文本 / statusText", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("plain text error", { status: 404, statusText: "Not Found" }),
+    );
+
+    await expect(fetchRoutines()).rejects.toThrow(/404/);
+  });
+});

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRoutineData } from "@/features/routine/hooks/useRoutineData";
+import * as api from "@/features/routine/api";
+import type { RoutineDTO, RoutineKpis } from "@/features/routine";
+
+/**
+ * useRoutineData hook 单测。
+ *
+ * 覆盖：① 挂载后并发拉取 list + kpis 并落地 state；② filters 变化触发重拉；
+ * ③ 失败分支写入 error；④ refresh() 手动刷新。
+ */
+
+const KPIS: RoutineKpis = {
+  total: 2,
+  running: 1,
+  paused: 0,
+  succeeded: 1,
+  failed: 0,
+  cancelled: 0,
+  pending: 0,
+  total_cost_usd: 1.5,
+  avg_iterations: 3,
+};
+
+function makeRoutine(id: string): RoutineDTO {
+  return {
+    id,
+    key: id,
+    title: id,
+    display_name: null,
+    description: null,
+    goal: "g",
+    acceptance_criteria: "ac",
+    cwd: null,
+    verification_command: null,
+    status: "running",
+    termination_reason: null,
+    max_iterations: 20,
+    max_cost_usd: 5,
+    deadline_at: null,
+    success_score_threshold: 85,
+    no_progress_patience: 3,
+    approval_mode: "auto",
+    iteration_count: 0,
+    total_cost_usd: 0,
+    best_score: null,
+    last_score: null,
+    claude_session_id: null,
+    reflections: [],
+    config: {},
+    owner_id: null,
+    agent_id: null,
+    created_at: null,
+    updated_at: null,
+  };
+}
+
+describe("useRoutineData", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("挂载后并发拉取列表与 KPI 并落地 state", async () => {
+    const listSpy = vi
+      .spyOn(api, "fetchRoutines")
+      .mockResolvedValue({ items: [makeRoutine("r1")], next_cursor: null, has_more: false });
+    const kpiSpy = vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
+
+    const { result } = renderHook(() => useRoutineData({ status: "running" }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.routines).toHaveLength(1);
+    expect(result.current.routines[0].id).toBe("r1");
+    expect(result.current.kpis).toMatchObject({ total: 2 });
+    expect(result.current.error).toBeNull();
+    expect(listSpy).toHaveBeenCalledWith({ status: "running" });
+    expect(kpiSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters 变化时重新拉取", async () => {
+    const listSpy = vi
+      .spyOn(api, "fetchRoutines")
+      .mockResolvedValue({ items: [], next_cursor: null, has_more: false });
+    vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
+
+    const { result, rerender } = renderHook((props: { q: string }) => useRoutineData(props), {
+      initialProps: { q: "a" },
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listSpy).toHaveBeenCalledTimes(1);
+
+    rerender({ q: "b" });
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+    expect(listSpy).toHaveBeenLastCalledWith({ q: "b" });
+  });
+
+  it("拉取失败时写入 error 并停止 loading", async () => {
+    vi.spyOn(api, "fetchRoutines").mockRejectedValue(new Error("network down"));
+    vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
+
+    const { result } = renderHook(() => useRoutineData({}));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("network down");
+    expect(result.current.routines).toHaveLength(0);
+  });
+
+  it("refresh() 触发再次拉取", async () => {
+    const listSpy = vi
+      .spyOn(api, "fetchRoutines")
+      .mockResolvedValue({ items: [], next_cursor: null, has_more: false });
+    vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
+
+    const { result } = renderHook(() => useRoutineData({}));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listSpy).toHaveBeenCalledTimes(1);
+
+    await result.current.refresh();
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+  });
+});


### PR DESCRIPTION
## 背景

原 New Routine 模态框采用垂直堆叠 + 分区标题布局，表单项过多导致模态框高度偏大，标签与输入框各占一行空间利用率低，低频配置项与核心字段平铺增加认知负担。

## 核心变更

- **宽面板 + 双列水平布局**：模态框从 `max-w-xl` → `max-w-2xl`，Key/Title 双列并排，Budgets 四项 2×2 水平排列（Label 与 Input 同行 `flex`），显著压降模态框高度
- **高级设置折叠**：Working Directory、Model、Permission Mode、Allowed Tools、Verification Command 合并为可折叠区域（`ChevronDown` + `aria-expanded`），编辑模式下自动检测高级字段是否有值并展开
- **标签语义精简**：Description 与 Goal 移除独立 Label 行改用 placeholder 承载提示；Label 从垂直改为水平（`shrink-0 whitespace-nowrap`）；Budgets 区域用子卡片视觉分组替代文字标题
- **Footer 组件化**：底部按钮从手写 `<button>` 替换为 `<Button>` 组件，复用设计系统 `loading` 状态
- **条件样式统一**：模板字符串拼接条件 className 全部改用 `cn()` 工具函数
- **圆角令牌对齐**：`rounded-md` → `rounded-control` / `rounded-card` / `rounded-modal`

## 风险与回滚

- 主要风险：Goal 字段移除独立 Label 后 `*` 必填标记消失，与其他必填字段视觉提示不一致（已记录为后续优化项）
- 回滚方式：`git revert` 本 PR

## 验证证据

- 浏览器实机验证模态框打开 / 编辑 / 创建流程正常

## 影响范围

- 前端：`RoutineFormDialog.tsx` 单文件重构（+202 / -188）
- 后端 / CI / 文档：无

## Next Best Action

- 为 Goal textarea 补充 `aria-label` 或 `sr-only` label，保持必填字段 `*` 指示符一致性