### PR TITLE
feat(scheduler-ui): Scheduler 任务列表新增 Description 列与详情抽屉描述段落

### DIFF
--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
@@ -122,6 +122,18 @@ export function SchedulerTaskDetailDrawer({
 
         {/* Body */}
         <div className="flex-1 overflow-auto px-5 py-4 space-y-5">
+          {/* Description */}
+          {task.description && (
+            <section>
+              <h3 className="text-micro uppercase tracking-overline text-muted-foreground mb-2">
+                Description
+              </h3>
+              <p className="text-xs text-foreground leading-relaxed whitespace-pre-wrap break-words">
+                {task.description}
+              </p>
+            </section>
+          )}
+
           {/* Status */}
           <section>
             <h3 className="text-micro uppercase tracking-overline text-muted-foreground mb-2">Status</h3>

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskTable.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskTable.tsx
@@ -55,7 +55,7 @@ function StatusDots({ statuses }: { statuses: string[] }) {
 function SkeletonRow() {
   return (
     <tr className="border-b border-border last:border-b-0">
-      {Array.from({ length: 8 }).map((_, i) => (
+      {Array.from({ length: 9 }).map((_, i) => (
         <td key={i} className="px-3 py-2">
           <Skeleton className="h-4" style={{ width: `${50 + (i * 13) % 40}%` }} />
         </td>
@@ -81,6 +81,7 @@ export function SchedulerTaskTable({
           <thead className="sticky top-0 bg-card text-muted-foreground z-10">
             <tr className="border-b border-border">
               <th className="px-3 py-2 text-left font-medium">Task</th>
+              <th className="px-3 py-2 text-left font-medium">Description</th>
               <th className="px-3 py-2 text-left font-medium">Handler</th>
               <th className="px-3 py-2 text-left font-medium">Trigger</th>
               <th className="px-3 py-2 text-left font-medium">Last</th>
@@ -95,7 +96,7 @@ export function SchedulerTaskTable({
               Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} />)
             ) : tasks.length === 0 ? (
               <tr>
-                <td colSpan={8} className="px-3 py-6 text-center text-muted-foreground">
+                <td colSpan={9} className="px-3 py-6 text-center text-muted-foreground">
                   No tasks match current filters.
                 </td>
               </tr>
@@ -111,6 +112,15 @@ export function SchedulerTaskTable({
                       {t.display_name || t.key}
                     </div>
                     <div className="text-micro text-muted-foreground">{t.key}</div>
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {t.description ? (
+                      <div className="max-w-[240px] truncate" title={t.description}>
+                        {t.description}
+                      </div>
+                    ) : (
+                      "—"
+                    )}
                   </td>
                   <td className="px-3 py-2 text-muted-foreground">{t.handler_kind}</td>
                   <td className="px-3 py-2 text-muted-foreground">

--- a/apps/negentropy-ui/tests/e2e/interface/scheduler.spec.ts
+++ b/apps/negentropy-ui/tests/e2e/interface/scheduler.spec.ts
@@ -327,6 +327,7 @@ test.describe("Interface / Scheduler 页面", () => {
 
     // Table header
     await expect(page.getByText("Task").first()).toBeVisible();
+    await expect(page.getByText("Description").first()).toBeVisible();
     await expect(page.getByText("Handler").first()).toBeVisible();
     await expect(page.getByText("Trigger").first()).toBeVisible();
     await expect(page.getByText("Actions").first()).toBeVisible();
@@ -334,6 +335,11 @@ test.describe("Interface / Scheduler 页面", () => {
     // Task rows
     await expect(page.getByText("KB/KG Pipeline Watchdog")).toBeVisible();
     await expect(page.getByText("Ebbinghaus Cleanup")).toBeVisible();
+
+    // Description column value
+    await expect(
+      page.getByText("收敛 cancelling/running 长尾状态的 KB/KG runs").first(),
+    ).toBeVisible();
 
     // Trigger type display: interval → "60s", cron → "0 2 * * *"
     await expect(page.getByText("60s").first()).toBeVisible();


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Scheduler 任务的 `description` 字段早已可在 New/Edit Task 表单中录入（`SchedulerTaskFormDialog`），并已存在于 `ScheduledTaskDTO` 与种子数据（迁移 `0046`）中，但任务列表与详情抽屉均未展示，用户无法直观区分同类任务的用途。本次补齐 description 的「展示侧」闭环。
- 关联上下文/Issue/文档：承接 New Routine 模态框重设计（#761）与 Demo 预设系统（#760），完善 Scheduler 交互界面的信息呈现。

# 核心变更
- **任务列表** `SchedulerTaskTable.tsx`：在 Task 与 Handler 之间新增 Description 列——超长文本 `max-w-[240px] truncate` + 原生 `title` 悬浮提示，空值回退 `—`；同步将表头、数据行、骨架行单元格数与空态 `colSpan` 由 8 统一调整为 9，保持列数一致。
- **详情抽屉** `SchedulerTaskDetailDrawer.tsx`：在 Body 顶部新增条件渲染的 Description 段落（`task.description` 为空时不渲染），`whitespace-pre-wrap break-words` 兼容多行与长串。
- **E2E** `scheduler.spec.ts`：复用现有 Playwright mock fixture，补充 Description 列表头与列值两条可见性断言。

# 风险与回滚
- 主要风险：低。纯前端展示增量，无 API 契约、数据结构或迁移变更；新增列使表格变宽，已由容器 `overflow-auto` 与单元格截断兜底，对 `null`/空串均有 `—` 兜底。
- 回滚方式：`git revert fbacc3e5` 即可完全回退，无数据副作用。

# 验证证据
- 单元测试：N/A（纯 UI 展示变更）。
- 集成测试：N/A。
- E2E/Workflow：`scheduler.spec.ts` 新增 Description 表头与列值断言，断言取值来自测试内 mock fixture（非依赖真实后端），且与种子迁移 `0046` 文案一致。
- 覆盖率/关键截图：`tsc -p tsconfig.json --noEmit` 退出码 0，无类型回归；列数一致性（表头 / 数据行 / 骨架行 / `colSpan` 均为 9）逐项核验通过。

# 影响范围
- 前端：`apps/negentropy-ui` Scheduler 任务列表与详情抽屉；scheduler 仅此一处任务渲染，无移动端/卡片视图需同步。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 可选增强：补一条「`description` 为 `null` 时表格渲染 `—`」的负向 E2E 用例（当前 mock 两条数据均含描述，尚未覆盖空态分支）。
