### PR TITLE
feat(routine-viz): Routine 运行全过程可视化（Fleet 实时视图 + Run 深链页）+ 成本解析修复;

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -16,34 +16,11 @@ import {
   rejectIteration,
   useRoutineDetailLive,
 } from "@/features/routine";
-import type { RoutineStatus } from "@/features/routine";
 
 import { ClockProvider } from "../_components/ClockProvider";
 import { RoutineRunView } from "../_components/RoutineRunView";
+import { CONTROL_LABEL, controlsFor, type ControlAction } from "../_components/routine-controls";
 import { routineStatusClass } from "../_components/status-style";
-
-type ControlAction = "start" | "pause" | "resume" | "cancel";
-
-const CONTROL_LABEL: Record<ControlAction, string> = {
-  start: "Start",
-  pause: "Pause",
-  resume: "Resume",
-  cancel: "Cancel",
-};
-
-/** 依状态计算可用控制动作（与抽屉一致）。 */
-function controlsFor(status: RoutineStatus): ControlAction[] {
-  switch (status) {
-    case "pending":
-      return ["start"];
-    case "running":
-      return ["pause", "cancel"];
-    case "paused":
-      return ["resume", "cancel"];
-    default:
-      return [];
-  }
-}
 
 export default function RoutineRunPage() {
   const params = useParams<{ id: string }>();

--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/Button";
+import { ErrorBanner } from "@/components/ui/ErrorState";
+import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { Spinner } from "@/components/ui/Spinner";
+import {
+  approveIteration,
+  controlRoutine,
+  rejectIteration,
+  useRoutineDetailLive,
+} from "@/features/routine";
+import type { RoutineStatus } from "@/features/routine";
+
+import { ClockProvider } from "../_components/ClockProvider";
+import { RoutineRunView } from "../_components/RoutineRunView";
+import { routineStatusClass } from "../_components/status-style";
+
+type ControlAction = "start" | "pause" | "resume" | "cancel";
+
+const CONTROL_LABEL: Record<ControlAction, string> = {
+  start: "Start",
+  pause: "Pause",
+  resume: "Resume",
+  cancel: "Cancel",
+};
+
+/** 依状态计算可用控制动作（与抽屉一致）。 */
+function controlsFor(status: RoutineStatus): ControlAction[] {
+  switch (status) {
+    case "pending":
+      return ["start"];
+    case "running":
+      return ["pause", "cancel"];
+    case "paused":
+      return ["resume", "cancel"];
+    default:
+      return [];
+  }
+}
+
+export default function RoutineRunPage() {
+  const params = useParams<{ id: string }>();
+  const id = typeof params?.id === "string" ? params.id : null;
+  const { routine, loading, error, reload, connected } = useRoutineDetailLive(id);
+  const [busy, setBusy] = useState(false);
+
+  const handleControl = useCallback(
+    async (action: ControlAction) => {
+      if (!id) return;
+      setBusy(true);
+      try {
+        await controlRoutine(id, action);
+        toast.success(
+          `Routine ${{ start: "started", pause: "paused", resume: "resumed", cancel: "cancelled" }[action]}`,
+        );
+        await reload();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : `Failed to ${action}`);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [id, reload],
+  );
+
+  const handleApprove = useCallback(
+    async (iterationId: string) => {
+      if (!id) return;
+      setBusy(true);
+      try {
+        await approveIteration(id, iterationId);
+        toast.success("Iteration approved");
+        await reload();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to approve");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [id, reload],
+  );
+
+  const handleReject = useCallback(
+    async (iterationId: string) => {
+      if (!id) return;
+      setBusy(true);
+      try {
+        await rejectIteration(id, iterationId);
+        toast.success("Iteration rejected");
+        await reload();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to reject");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [id, reload],
+  );
+
+  const clockActive = routine?.status === "running";
+  const controls = routine ? controlsFor(routine.status) : [];
+
+  return (
+    <div className="flex h-full flex-col bg-muted">
+      <InterfaceNav title="Routine" />
+      <div className="flex-1 overflow-auto">
+        <ClockProvider active={!!clockActive}>
+          <div className="space-y-4 px-6 py-6">
+            {/* 头部：返回 + 标题 + 状态 + 控制 */}
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <Link
+                  href="/interface/routine"
+                  aria-label="返回 Routine 列表"
+                  className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </Link>
+                <div className="min-w-0">
+                  <h1 className="truncate text-xl font-bold text-foreground">
+                    {routine?.display_name || routine?.title || "Routine"}
+                  </h1>
+                  {routine?.key && <p className="truncate text-[11px] text-text-muted">{routine.key}</p>}
+                </div>
+                {routine && (
+                  <span
+                    className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(routine.status)}`}
+                  >
+                    {routine.status}
+                  </span>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${connected ? "bg-emerald-500" : "animate-pulse bg-text-muted"}`}
+                  />
+                  {connected ? "Live" : "Reconnecting..."}
+                </span>
+                {controls.map((action) => (
+                  <Button
+                    key={action}
+                    variant={action === "cancel" ? "outline" : "neutral"}
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => handleControl(action)}
+                  >
+                    {CONTROL_LABEL[action]}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            {error && <ErrorBanner message={error} onRetry={reload} />}
+
+            {routine ? (
+              <RoutineRunView
+                routine={routine}
+                onApproveIteration={handleApprove}
+                onRejectIteration={handleReject}
+                busy={busy}
+              />
+            ) : loading ? (
+              <div className="flex justify-center py-16">
+                <Spinner size="lg" label="加载中" />
+              </div>
+            ) : (
+              !error && (
+                <div className="rounded-card border border-dashed border-border bg-card py-12 text-center text-sm text-text-muted">
+                  未找到该 Routine。
+                </div>
+              )
+            )}
+          </div>
+        </ClockProvider>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/ClockProvider.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/ClockProvider.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+/**
+ * 单一时钟 —— 整视图共享一个 1Hz 心跳，供在途迭代渲染实时耗时。
+ *
+ * 设计动机（杜绝「重复定时器 / 重渲染风暴」失败模式）：
+ * - **唯一 interval**：N 个在途卡片共用一个 ``setInterval``，而非各自持有。
+ * - **可见性暂停**：``document.hidden`` 时停摆，回前台立即补一拍（对齐 [[useHeartbeatPoll]]）。
+ * - **空转保护**：``active=false``（无任何在途）时根本不起定时器。
+ *
+ * 叶子组件用 [[ElapsedClock]] 订阅 ``now``，本地算 ``now - startedAt``；
+ * 仅这些极小叶子随 tick 重渲，父层不读 ``now``。
+ */
+
+const ClockContext = createContext<number | null>(null);
+
+export function ClockProvider({ active, children }: { active: boolean; children: ReactNode }) {
+  // 无在途时回退到一次性快照（足够渲染静态时长），避免无谓 state。
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!active) return;
+
+    let timerId: number | null = null;
+    const tick = () => setNow(Date.now());
+
+    const start = () => {
+      if (timerId !== null) return;
+      timerId = window.setInterval(tick, 1000);
+    };
+    const stop = () => {
+      if (timerId !== null) {
+        window.clearInterval(timerId);
+        timerId = null;
+      }
+    };
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        tick(); // 回前台立即补一拍
+        start();
+      }
+    };
+
+    tick();
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [active]);
+
+  return <ClockContext.Provider value={now}>{children}</ClockContext.Provider>;
+}
+
+/**
+ * 读取共享时钟。无 Provider 时回退为挂载时刻（静态），保证组件不崩。
+ * 注意：回退值不会自动 tick —— 实时计时必须置于 ClockProvider 内。
+ */
+export function useClock(): number {
+  const ctx = useContext(ClockContext);
+  const [fallback] = useState(() => Date.now()); // 无条件调用，满足 rules-of-hooks
+  return ctx ?? fallback;
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/ElapsedClock.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/ElapsedClock.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { memo } from "react";
+
+import { useClock } from "./ClockProvider";
+import { formatDuration, spanMs } from "./routine-format";
+
+/**
+ * 实时耗时 —— 订阅共享时钟，按秒刷新 ``now - startedAt``。
+ * 仅用于在途（未完成）迭代；置于 [[ClockProvider]] 内才会 tick。
+ */
+export const LiveElapsed = memo(function LiveElapsed({
+  startedAt,
+  prefix,
+  className,
+}: {
+  startedAt: string | null;
+  prefix?: string;
+  className?: string;
+}) {
+  const now = useClock();
+  const ms = spanMs(startedAt, now);
+  if (ms === null) return null;
+  return (
+    <span className={`tabular-nums ${className ?? ""}`}>
+      {prefix}
+      {formatDuration(ms)}
+    </span>
+  );
+});
+
+/**
+ * 静态时长 —— 已完成迭代 ``finishedAt - startedAt``，不订阅时钟（不随 tick 重渲）。
+ */
+export const StaticDuration = memo(function StaticDuration({
+  startedAt,
+  finishedAt,
+  prefix,
+  className,
+}: {
+  startedAt: string | null;
+  finishedAt: string | null;
+  prefix?: string;
+  className?: string;
+}) {
+  if (!startedAt || !finishedAt) return null;
+  const start = Date.parse(startedAt);
+  const end = Date.parse(finishedAt);
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return (
+    <span className={`tabular-nums ${className ?? ""}`}>
+      {prefix}
+      {formatDuration(Math.max(0, end - start))}
+    </span>
+  );
+});

--- a/apps/negentropy-ui/app/interface/routine/_components/ReflectionFlow.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/ReflectionFlow.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useMemo } from "react";
+import { CornerDownRight } from "lucide-react";
+
+import type { RoutineIterationDTO } from "@/features/routine";
+
+import { verdictClass } from "./status-style";
+
+function head(text: string | null, n = 140): string {
+  if (!text) return "";
+  const t = text.trim();
+  return t.length <= n ? t : `${t.slice(0, n)}…`;
+}
+
+/**
+ * Reflexion 记忆流 —— 把「迭代 N 的 reflection 注入迭代 N+1 的 prompt」这条反馈边显式化，
+ * 是闭环之所以「自迭代」的关键。仅展示最近若干条以保持精炼。
+ */
+export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO[] }) {
+  const asc = useMemo(() => [...iterations].sort((a, b) => a.seq - b.seq), [iterations]);
+  const items = useMemo(() => {
+    const out: { it: RoutineIterationDTO; next: RoutineIterationDTO | undefined }[] = [];
+    for (let i = 0; i < asc.length; i++) {
+      if (asc[i].reflection) out.push({ it: asc[i], next: asc[i + 1] });
+    }
+    return out.slice(-6);
+  }, [asc]);
+
+  if (items.length === 0) {
+    return (
+      <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+        <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+          反思记忆流 · Reflexion
+        </h3>
+        <p className="py-4 text-center text-[11px] text-text-muted">暂无反思记录</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+      <h3 className="mb-3 text-[10px] uppercase tracking-wider text-muted-foreground">
+        反思记忆流 · Reflexion（reflection → 下轮 prompt）
+      </h3>
+      <ol className="space-y-3">
+        {items.map(({ it, next }) => (
+          <li key={it.id} className="rounded-lg border border-border p-2.5">
+            <div className="flex items-center gap-2 text-[11px]">
+              <span className="font-semibold text-foreground">#{it.seq}</span>
+              {it.verdict && (
+                <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${verdictClass(it.verdict)}`}>
+                  {it.verdict}
+                </span>
+              )}
+            </div>
+            <p className="mt-1 text-[11px] italic text-text-secondary">💡 {it.reflection}</p>
+            {next?.prompt && (
+              <div className="mt-2 flex items-start gap-1.5 rounded bg-muted/40 p-2 text-[10px] text-text-muted">
+                <CornerDownRight className="mt-0.5 h-3 w-3 shrink-0 text-primary" aria-hidden />
+                <span className="min-w-0">
+                  注入 <span className="font-medium text-text-secondary">#{next.seq}</span> 提示：{head(next.prompt)}
+                </span>
+              </div>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import type { RoutineIterationDTO, Verdict } from "@/features/routine";
+
+import { NULL_HEX, VERDICT_HEX } from "./chart-colors";
+
+interface Row {
+  seq: number;
+  score: number | null;
+  verdict: Verdict | null;
+  cost: number;
+}
+
+interface TooltipPayloadItem {
+  payload?: Row;
+}
+
+function ConvergenceTooltip({ active, payload }: { active?: boolean; payload?: TooltipPayloadItem[] }) {
+  if (!active || !payload || payload.length === 0) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+  return (
+    <div className="rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] shadow-md">
+      <div className="font-semibold text-foreground">迭代 #{row.seq}</div>
+      <div className="text-text-secondary">score: {row.score ?? "—"}</div>
+      {row.verdict && <div className="text-text-secondary">verdict: {row.verdict}</div>}
+      <div className="text-text-muted">cost: ${row.cost.toFixed(4)}</div>
+    </div>
+  );
+}
+
+/**
+ * 评分收敛趋势图 —— X=迭代序号，Y=评分(0-100)。
+ * 阈值线 + 最佳分参考线；数据点按 verdict 着色，融合「是否改进」与「为何」。
+ */
+export function RoutineConvergenceChart({
+  iterations,
+  threshold,
+  bestScore,
+}: {
+  iterations: RoutineIterationDTO[];
+  threshold: number;
+  bestScore: number | null;
+}) {
+  const data: Row[] = iterations.map((it) => ({
+    seq: it.seq,
+    score: it.score,
+    verdict: it.verdict,
+    cost: it.cost_usd,
+  }));
+  const hasScores = data.some((d) => d.score != null);
+
+  return (
+    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+      <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        评分收敛趋势 · Convergence
+      </h3>
+      {!hasScores ? (
+        <p className="py-8 text-center text-[11px] text-text-muted">尚无评分数据</p>
+      ) : (
+        <div className="h-56 min-h-[14rem] w-full" style={{ minWidth: 1 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: -8 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#3f3f46" strokeOpacity={0.2} />
+              <XAxis
+                dataKey="seq"
+                type="number"
+                domain={["dataMin", "dataMax"]}
+                allowDecimals={false}
+                stroke="currentColor"
+                fontSize={11}
+                tickFormatter={(v) => `#${v}`}
+              />
+              <YAxis domain={[0, 100]} ticks={[0, 25, 50, 75, 100]} stroke="currentColor" fontSize={11} />
+              <Tooltip content={<ConvergenceTooltip />} />
+              <ReferenceLine
+                y={threshold}
+                stroke="#10b981"
+                strokeDasharray="4 4"
+                strokeOpacity={0.7}
+                label={{ value: `阈值 ${threshold}`, position: "right", fontSize: 10, fill: "#10b981" }}
+              />
+              {bestScore != null && (
+                <ReferenceLine y={bestScore} stroke="#6366f1" strokeDasharray="2 4" strokeOpacity={0.6} />
+              )}
+              <Line
+                type="monotone"
+                dataKey="score"
+                stroke="#0ea5e9"
+                strokeWidth={1.5}
+                dot={false}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+              <Scatter dataKey="score" isAnimationActive={false}>
+                {data.map((d, i) => (
+                  <Cell key={i} fill={d.verdict ? VERDICT_HEX[d.verdict] : NULL_HEX} />
+                ))}
+              </Scatter>
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineDetailDrawer.tsx
@@ -14,6 +14,8 @@ type ControlAction = "start" | "pause" | "resume" | "cancel";
 interface RoutineDetailDrawerProps {
   routine: RoutineDTO;
   onClose: () => void;
+  /** 打开全屏 Run 全过程页（深链路由）。 */
+  onOpenFull?: () => void;
   onControl: (action: ControlAction) => void;
   onEdit: (r: RoutineDTO) => void;
   onDelete: (r: RoutineDTO) => void;
@@ -48,6 +50,7 @@ function controlsFor(status: RoutineStatus): ControlAction[] {
 export function RoutineDetailDrawer({
   routine,
   onClose,
+  onOpenFull,
   onControl,
   onEdit,
   onDelete,
@@ -109,15 +112,25 @@ export function RoutineDetailDrawer({
             </div>
             <p className="mt-0.5 text-[10px] text-muted-foreground">{routine.key}</p>
           </div>
-          <button
-            onClick={onClose}
-            aria-label="Close routine details"
+          <div className="flex items-center gap-1">
+            {onOpenFull && (
+              <button
+                onClick={onOpenFull}
+                className="cursor-pointer rounded-md px-2 py-1 text-[11px] font-medium text-primary underline-offset-4 transition-colors hover:bg-muted/50 hover:underline"
+              >
+                全过程 →
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              aria-label="Close routine details"
             className="cursor-pointer rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
           >
-            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         {/* Body */}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineDetailDrawer.tsx
@@ -3,13 +3,12 @@
 import { useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui/Button";
-import type { RoutineDTO, RoutineStatus } from "@/features/routine";
+import type { RoutineDTO } from "@/features/routine";
 
 import { RoutineIterationTimeline } from "./RoutineIterationTimeline";
 import { RoutineScoreSparkline } from "./RoutineScoreSparkline";
+import { CONTROL_LABEL, controlsFor, type ControlAction } from "./routine-controls";
 import { routineStatusClass, scoreColorClass } from "./status-style";
-
-type ControlAction = "start" | "pause" | "resume" | "cancel";
 
 interface RoutineDetailDrawerProps {
   routine: RoutineDTO;
@@ -31,20 +30,6 @@ function DetailField({ label, children }: { label: string; children: React.React
       <span className="ml-4 break-all text-right text-foreground">{children}</span>
     </div>
   );
-}
-
-/** 依状态计算可用控制动作。 */
-function controlsFor(status: RoutineStatus): ControlAction[] {
-  switch (status) {
-    case "pending":
-      return ["start"];
-    case "running":
-      return ["pause", "cancel"];
-    case "paused":
-      return ["resume", "cancel"];
-    default:
-      return [];
-  }
 }
 
 export function RoutineDetailDrawer({
@@ -83,13 +68,6 @@ export function RoutineDetailDrawer({
   const scores = ascending.map((it) => it.score);
   const controls = controlsFor(routine.status);
   const isTerminal = ["succeeded", "failed", "cancelled"].includes(routine.status);
-
-  const controlLabel: Record<ControlAction, string> = {
-    start: "Start",
-    pause: "Pause",
-    resume: "Resume",
-    cancel: "Cancel",
-  };
 
   return (
     <>
@@ -222,7 +200,7 @@ export function RoutineDetailDrawer({
               disabled={busy}
               onClick={() => onControl(action)}
             >
-              {controlLabel[action]}
+              {CONTROL_LABEL[action]}
             </Button>
           ))}
           <div className="flex-1" />

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFleetCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFleetCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { memo } from "react";
+
+import { Card } from "@/components/ui/Card";
+import type { RoutineDTO, RoutineIterationLite } from "@/features/routine";
+
+import { LiveElapsed } from "./ElapsedClock";
+import { RoutineLoopBar } from "./RoutineLoopBar";
+import { RoutineMeter } from "./RoutineMeter";
+import { LOOP_STAGE_META, loopStageOf } from "./routine-loop";
+import { limitFillClass, routineStatusClass, scoreColorClass, scoreFillClass } from "./status-style";
+
+interface RoutineFleetCardProps {
+  routine: RoutineDTO;
+  latest: RoutineIterationLite | undefined;
+  /** 快速预览（右侧抽屉）。 */
+  onOpenDetail: (r: RoutineDTO) => void;
+  /** 打开全屏 Run 全过程页（深链路由）。 */
+  onOpenFull: (r: RoutineDTO) => void;
+}
+
+const ACTIVE_TIMING: ReadonlySet<string> = new Set(["dispatched", "in_flight", "executed"]);
+
+export const RoutineFleetCard = memo(function RoutineFleetCard({
+  routine,
+  latest,
+  onOpenDetail,
+  onOpenFull,
+}: RoutineFleetCardProps) {
+  const snapshot = loopStageOf(latest, routine);
+  const needsApproval = latest?.status === "pending_approval";
+  const timing = !!latest && ACTIVE_TIMING.has(latest.status) && !!latest.started_at;
+
+  const iterRatio = routine.max_iterations
+    ? routine.iteration_count / routine.max_iterations
+    : null;
+  const costRatio = routine.max_cost_usd ? routine.total_cost_usd / routine.max_cost_usd : null;
+
+  return (
+    <Card
+      interactive
+      onClick={() => onOpenDetail(routine)}
+      className="flex flex-col gap-3 p-4"
+    >
+      {/* 标题 + 状态 */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold text-foreground">
+            {routine.display_name || routine.title}
+          </div>
+          <div className="truncate text-[10px] text-text-muted">{routine.key}</div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {needsApproval && (
+            <span className="inline-flex animate-pulse items-center rounded-full bg-amber-500/15 px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+              待审批
+            </span>
+          )}
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(routine.status)}`}
+          >
+            {routine.status}
+          </span>
+        </div>
+      </div>
+
+      {/* 闭环阶段条 */}
+      <RoutineLoopBar snapshot={snapshot} size="sm" />
+
+      {/* 实时/终态信息行 */}
+      <div className="flex min-h-4 items-center gap-2 text-[11px] text-text-secondary">
+        {timing ? (
+          <>
+            <span className="font-medium text-foreground">
+              {snapshot.activeStage ? LOOP_STAGE_META[snapshot.activeStage].label : "运行中"}
+            </span>
+            <LiveElapsed startedAt={latest?.started_at ?? null} className="text-text-secondary" />
+            {latest?.turn_count != null && (
+              <span className="text-text-muted">· {latest.turn_count} turns</span>
+            )}
+          </>
+        ) : snapshot.mode === "done" ? (
+          <span className="text-text-muted">
+            {snapshot.terminationReason ? `终止：${snapshot.terminationReason}` : "已结束"}
+          </span>
+        ) : snapshot.mode === "paused" ? (
+          <span className="text-amber-600 dark:text-amber-400">已暂停</span>
+        ) : snapshot.mode === "waiting-approval" ? (
+          <span className="text-amber-600 dark:text-amber-400">等待审批后派发</span>
+        ) : (
+          <span className="text-text-muted">空闲</span>
+        )}
+      </div>
+
+      {/* 指标条 */}
+      <div className="space-y-2">
+        <RoutineMeter
+          label="Iterations"
+          valueText={
+            routine.max_iterations
+              ? `${routine.iteration_count} / ${routine.max_iterations}`
+              : `${routine.iteration_count}`
+          }
+          ratio={iterRatio}
+          fillClass={iterRatio == null ? "bg-sky-500/60" : limitFillClass(iterRatio)}
+        />
+        <RoutineMeter
+          label="Best Score"
+          valueText={`best ${routine.best_score ?? "—"} · last ${routine.last_score ?? "—"}`}
+          ratio={routine.best_score != null ? routine.best_score / 100 : null}
+          fillClass={scoreFillClass(routine.best_score, routine.success_score_threshold)}
+          notchPct={routine.success_score_threshold}
+        />
+        <RoutineMeter
+          label="Cost"
+          valueText={
+            routine.max_cost_usd
+              ? `$${routine.total_cost_usd.toFixed(3)} / $${routine.max_cost_usd}`
+              : `$${routine.total_cost_usd.toFixed(3)}`
+          }
+          ratio={costRatio}
+          fillClass={costRatio == null ? "bg-sky-500/60" : limitFillClass(costRatio)}
+        />
+      </div>
+
+      {/* 页脚：打开全屏 */}
+      <div className="flex items-center justify-between pt-0.5">
+        <span className={`text-[10px] tabular-nums ${scoreColorClass(routine.last_score)}`}>
+          {routine.last_score != null ? `score ${routine.last_score}` : ""}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpenFull(routine);
+          }}
+          className="cursor-pointer rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          全过程 →
+        </button>
+      </div>
+    </Card>
+  );
+});

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFleetCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFleetCard.tsx
@@ -8,7 +8,7 @@ import type { RoutineDTO, RoutineIterationLite } from "@/features/routine";
 import { LiveElapsed } from "./ElapsedClock";
 import { RoutineLoopBar } from "./RoutineLoopBar";
 import { RoutineMeter } from "./RoutineMeter";
-import { LOOP_STAGE_META, loopStageOf } from "./routine-loop";
+import { ACTIVE_TIMING, LOOP_STAGE_META, loopStageOf } from "./routine-loop";
 import { limitFillClass, routineStatusClass, scoreColorClass, scoreFillClass } from "./status-style";
 
 interface RoutineFleetCardProps {
@@ -20,8 +20,6 @@ interface RoutineFleetCardProps {
   onOpenFull: (r: RoutineDTO) => void;
 }
 
-const ACTIVE_TIMING: ReadonlySet<string> = new Set(["dispatched", "in_flight", "executed"]);
-
 export const RoutineFleetCard = memo(function RoutineFleetCard({
   routine,
   latest,
@@ -30,7 +28,8 @@ export const RoutineFleetCard = memo(function RoutineFleetCard({
 }: RoutineFleetCardProps) {
   const snapshot = loopStageOf(latest, routine);
   const needsApproval = latest?.status === "pending_approval";
-  const timing = !!latest && ACTIVE_TIMING.has(latest.status) && !!latest.started_at;
+  const timing =
+    snapshot.mode === "looping" && !!latest && ACTIVE_TIMING.has(latest.status) && !!latest.started_at;
 
   const iterRatio = routine.max_iterations
     ? routine.iteration_count / routine.max_iterations

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineFleetView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineFleetView.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo } from "react";
+import { Activity } from "lucide-react";
+
+import { EmptyState } from "@/components/ui/EmptyState";
+import { FadeIn } from "@/components/ui/FadeIn";
+import { Skeleton } from "@/components/ui/Skeleton";
+import type { RoutineDTO, RoutineIterationLite } from "@/features/routine";
+import { useFleetSeed } from "@/features/routine";
+
+import { RoutineFleetCard } from "./RoutineFleetCard";
+
+interface RoutineFleetViewProps {
+  routines: RoutineDTO[];
+  latestByRoutine: Record<string, RoutineIterationLite>;
+  loading: boolean;
+  seedLatest: (routineId: string, lite: RoutineIterationLite) => void;
+  onOpenDetail: (r: RoutineDTO) => void;
+  onOpenFull: (r: RoutineDTO) => void;
+}
+
+/** 排序权重：待审批 < 运行中 < 暂停。 */
+function rank(r: RoutineDTO, lite: RoutineIterationLite | undefined): number {
+  if (lite?.status === "pending_approval") return 0;
+  if (r.status === "running") return 1;
+  return 2; // paused
+}
+
+export function RoutineFleetView({
+  routines,
+  latestByRoutine,
+  loading,
+  seedLatest,
+  onOpenDetail,
+  onOpenFull,
+}: RoutineFleetViewProps) {
+  // Fleet 聚焦「运行中 / 暂停」的活跃任务（其余在 Table 视图查看）。
+  const active = useMemo(
+    () =>
+      routines
+        .filter((r) => r.status === "running" || r.status === "paused")
+        .sort((a, b) => {
+          const ra = rank(a, latestByRoutine[a.id]);
+          const rb = rank(b, latestByRoutine[b.id]);
+          if (ra !== rb) return ra - rb;
+          return (b.updated_at ?? "").localeCompare(a.updated_at ?? "");
+        }),
+    [routines, latestByRoutine],
+  );
+
+  // 进入 Live 视图时一次性回填 authoritative started_at（有界探测）。
+  useFleetSeed(true, active, latestByRoutine, seedLatest);
+
+  if (loading && routines.length === 0) {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-52 w-full rounded-card" />
+        ))}
+      </div>
+    );
+  }
+
+  if (active.length === 0) {
+    return (
+      <div className="rounded-card border border-dashed border-border bg-card">
+        <EmptyState
+          icon={Activity}
+          title="暂无运行中的任务"
+          description="当前没有运行或暂停的 Routine。切换到 Table 视图查看全部任务，或新建一个自主任务。"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      {active.map((r, i) => (
+        <FadeIn key={r.id} delay={Math.min(i * 30, 240)}>
+          <RoutineFleetCard
+            routine={r}
+            latest={latestByRoutine[r.id]}
+            onOpenDetail={onOpenDetail}
+            onOpenFull={onOpenFull}
+          />
+        </FadeIn>
+      ))}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { RoutineDTO, RoutineIterationDTO } from "@/features/routine";
+
+import { useClock } from "./ClockProvider";
+import { RoutineMeter } from "./RoutineMeter";
+import { formatDuration, remainingMs } from "./routine-format";
+import { limitFillClass, scoreFillClass } from "./status-style";
+
+const TERMINAL: ReadonlySet<string> = new Set(["succeeded", "failed", "cancelled"]);
+
+/**
+ * 守卫 / 预算面板 —— 可视化「为何/何时会停」：迭代、成本、成功分、截止、无进展、震荡。
+ * 最逼近极限者标注为「预计停因」；终态后以实际 termination_reason 替换预测。
+ */
+export function RoutineGuardPanel({
+  routine,
+  iterations,
+}: {
+  routine: RoutineDTO;
+  iterations: RoutineIterationDTO[];
+}) {
+  const now = useClock();
+  const isTerminal = TERMINAL.has(routine.status);
+
+  const iterRatio = routine.max_iterations ? routine.iteration_count / routine.max_iterations : null;
+  const costRatio = routine.max_cost_usd ? routine.total_cost_usd / routine.max_cost_usd : null;
+
+  // 截止逼近度：created_at → deadline_at 的已用比例。
+  const deadline = useMemo(() => {
+    if (!routine.deadline_at) return null;
+    const remain = remainingMs(routine.deadline_at, now);
+    if (remain == null) return null;
+    const created = routine.created_at ? Date.parse(routine.created_at) : NaN;
+    const dl = Date.parse(routine.deadline_at);
+    const ratio =
+      !Number.isNaN(created) && dl > created ? Math.min(1, (now - created) / (dl - created)) : null;
+    return { remain, ratio };
+  }, [routine.deadline_at, routine.created_at, now]);
+
+  // 无进展尾部计数（近似：尾部 stalled/regressed 连续数）+ 震荡/不可恢复告警。
+  const { streak, oscillation, unrecoverable } = useMemo(() => {
+    const evaluated = [...iterations]
+      .sort((a, b) => a.seq - b.seq)
+      .filter((it) => it.status === "evaluated" && it.verdict != null);
+    let s = 0;
+    for (let i = evaluated.length - 1; i >= 0; i--) {
+      const v = evaluated[i].verdict;
+      if (v === "stalled" || v === "regressed") s++;
+      else break;
+    }
+    const last4 = evaluated.slice(-4).map((it) => it.verdict);
+    return {
+      streak: s,
+      oscillation: last4.includes("regressed") && last4.includes("progressing"),
+      unrecoverable: last4.includes("unrecoverable"),
+    };
+  }, [iterations]);
+
+  // 预计停因（非终态时）：取逼近度最高者。
+  const predicted = useMemo(() => {
+    if (isTerminal) return null;
+    const cands: { label: string; ratio: number }[] = [];
+    if (iterRatio != null) cands.push({ label: "max_iterations", ratio: iterRatio });
+    if (costRatio != null) cands.push({ label: "max_cost", ratio: costRatio });
+    if (deadline?.ratio != null) cands.push({ label: "deadline", ratio: deadline.ratio });
+    if (routine.no_progress_patience > 0)
+      cands.push({ label: "no_progress", ratio: streak / routine.no_progress_patience });
+    cands.sort((a, b) => b.ratio - a.ratio);
+    const top = cands[0];
+    return top && top.ratio >= 0.85 ? top : null;
+  }, [isTerminal, iterRatio, costRatio, deadline, streak, routine.no_progress_patience]);
+
+  return (
+    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+      <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        守卫 / 预算 · Why will it stop?
+      </h3>
+
+      {isTerminal ? (
+        <div className="mb-3 rounded-lg border border-border bg-muted/40 p-2.5 text-[11px]">
+          <span className="text-text-muted">实际终止原因：</span>
+          <span className="font-semibold text-foreground">{routine.termination_reason ?? "—"}</span>
+        </div>
+      ) : predicted ? (
+        <div className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-2.5 text-[11px] text-amber-700 dark:text-amber-300">
+          ⚠ 预计停因：<span className="font-semibold">{predicted.label}</span>（
+          {Math.round(predicted.ratio * 100)}%）
+        </div>
+      ) : null}
+
+      <div className="space-y-2.5">
+        <RoutineMeter
+          label="Iterations"
+          valueText={
+            routine.max_iterations
+              ? `${routine.iteration_count} / ${routine.max_iterations}`
+              : `${routine.iteration_count}（无上限）`
+          }
+          ratio={iterRatio}
+          fillClass={iterRatio == null ? "bg-sky-500/50" : limitFillClass(iterRatio)}
+        />
+        <RoutineMeter
+          label="Cost (USD)"
+          valueText={
+            routine.max_cost_usd
+              ? `$${routine.total_cost_usd.toFixed(3)} / $${routine.max_cost_usd}`
+              : `$${routine.total_cost_usd.toFixed(3)}（无上限）`
+          }
+          ratio={costRatio}
+          fillClass={costRatio == null ? "bg-sky-500/50" : limitFillClass(costRatio)}
+        />
+        <RoutineMeter
+          label="Success Score"
+          valueText={`best ${routine.best_score ?? "—"} → 阈值 ${routine.success_score_threshold}`}
+          ratio={routine.best_score != null ? routine.best_score / 100 : null}
+          fillClass={scoreFillClass(routine.best_score, routine.success_score_threshold)}
+          notchPct={routine.success_score_threshold}
+        />
+        {deadline && (
+          <RoutineMeter
+            label="Deadline"
+            valueText={deadline.remain > 0 ? `${formatDuration(deadline.remain)} 剩余` : "已到期"}
+            ratio={deadline.ratio}
+            fillClass={deadline.ratio == null ? "bg-sky-500/50" : limitFillClass(deadline.ratio)}
+          />
+        )}
+
+        {/* 无进展计数 */}
+        <div>
+          <div className="flex items-baseline justify-between text-[10px] text-text-muted">
+            <span>No-progress（停滞）</span>
+            <span className="tabular-nums text-text-secondary">
+              {streak} / {routine.no_progress_patience}
+            </span>
+          </div>
+          <div className="mt-1 flex gap-1">
+            {Array.from({ length: Math.max(1, routine.no_progress_patience) }).map((_, i) => (
+              <div
+                key={i}
+                className={`h-1.5 flex-1 rounded-full ${i < streak ? "bg-amber-500" : "bg-muted"}`}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 震荡 / 不可恢复告警 */}
+      {(oscillation || unrecoverable) && !isTerminal && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {oscillation && (
+            <span className="rounded-full bg-orange-500/10 px-2 py-0.5 text-[10px] font-semibold text-orange-700 dark:text-orange-300">
+              震荡风险
+            </span>
+          )}
+          {unrecoverable && (
+            <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold text-red-700 dark:text-red-300">
+              不可恢复信号
+            </span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -4,7 +4,10 @@ import { useState } from "react";
 
 import type { RoutineIterationDTO } from "@/features/routine";
 
+import { LiveElapsed, StaticDuration } from "./ElapsedClock";
 import { iterationDotClass, scoreColorClass, verdictClass } from "./status-style";
+
+const ACTIVE_TIMING: ReadonlySet<string> = new Set(["dispatched", "in_flight", "executed"]);
 
 interface RoutineIterationTimelineProps {
   iterations: RoutineIterationDTO[];
@@ -45,9 +48,14 @@ function IterationCard({
 }) {
   const [expanded, setExpanded] = useState(false);
   const isPendingApproval = it.status === "pending_approval";
+  const isActive = !it.finished_at && ACTIVE_TIMING.has(it.status);
 
   return (
-    <li className="rounded-lg border border-border p-3">
+    <li
+      className={`rounded-lg border p-3 ${
+        isActive ? "border-sky-400/50 bg-sky-500/[0.03]" : "border-border"
+      }`}
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className={`inline-block h-2 w-2 rounded-full ${iterationDotClass(it.status)}`} />
@@ -101,7 +109,16 @@ function IterationCard({
         <span>turns: {it.turn_count}</span>
         <span>cost: ${it.cost_usd.toFixed(4)}</span>
         {it.gate_exit_code != null && <span>gate exit: {it.gate_exit_code}</span>}
-        {it.started_at && <span>{new Date(it.started_at).toLocaleTimeString()}</span>}
+        {isActive ? (
+          <LiveElapsed startedAt={it.started_at} prefix="⏱ " />
+        ) : (
+          <StaticDuration startedAt={it.started_at} finishedAt={it.finished_at} prefix="⏱ " />
+        )}
+        {it.started_at && (
+          <span title={new Date(it.started_at).toLocaleString()}>
+            {new Date(it.started_at).toLocaleTimeString()}
+          </span>
+        )}
       </div>
 
       {/* 审批门控操作 */}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -5,9 +5,8 @@ import { useState } from "react";
 import type { RoutineIterationDTO } from "@/features/routine";
 
 import { LiveElapsed, StaticDuration } from "./ElapsedClock";
+import { ACTIVE_TIMING } from "./routine-loop";
 import { iterationDotClass, scoreColorClass, verdictClass } from "./status-style";
-
-const ACTIVE_TIMING: ReadonlySet<string> = new Set(["dispatched", "in_flight", "executed"]);
 
 interface RoutineIterationTimelineProps {
   iterations: RoutineIterationDTO[];

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopBar.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopBar.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { LOOP_STAGES, LOOP_STAGE_META, type LoopSnapshot, type LoopStage } from "./routine-loop";
+
+/**
+ * Evaluator-Optimizer 闭环阶段条 —— 4 段等宽步进器（Dispatch→Execute→Evaluate→Decide）。
+ *
+ * 复用于 Fleet 卡片（compact）与 Run 循环图（md，带标签）。颜色取自 [[routine-loop]] 的
+ * ``LOOP_STAGE_META.dot``，与时间线点位同源。活动段描边 + 可选脉冲；done 模式下 Decide 段
+ * 按终态着色（succeeded 绿 / failed 红 / cancelled 灰），避免「全绿误读为成功」。
+ */
+
+interface RoutineLoopBarProps {
+  snapshot: LoopSnapshot;
+  size?: "sm" | "md";
+  /** 是否在段下方渲染阶段标签（Run 视图用）。 */
+  showLabels?: boolean;
+  className?: string;
+}
+
+/** done 模式下 Decide 段的终态着色。 */
+function decideDoneDot(routineStatus: LoopSnapshot["routineStatus"]): string {
+  switch (routineStatus) {
+    case "succeeded":
+      return "bg-emerald-500";
+    case "failed":
+      return "bg-red-500";
+    case "cancelled":
+      return "bg-text-muted";
+    default:
+      return "bg-emerald-500";
+  }
+}
+
+function segClass(
+  stage: LoopStage,
+  snapshot: LoopSnapshot,
+): { cls: string; pulse: boolean } {
+  const state = snapshot.stageStates[stage];
+  if (state === "pending") return { cls: "bg-muted", pulse: false };
+
+  let dot = LOOP_STAGE_META[stage].dot;
+  if (snapshot.mode === "done" && stage === "decide") {
+    dot = decideDoneDot(snapshot.routineStatus);
+  }
+  if (state === "active") {
+    return { cls: `${dot} ring-2 ring-foreground/20`, pulse: snapshot.pulsing };
+  }
+  return { cls: dot, pulse: false }; // done
+}
+
+export function RoutineLoopBar({ snapshot, size = "sm", showLabels = false, className }: RoutineLoopBarProps) {
+  const barH = size === "md" ? "h-2.5" : "h-1.5";
+  const ariaLabel =
+    snapshot.mode === "looping" && snapshot.activeStage
+      ? `当前阶段：${LOOP_STAGE_META[snapshot.activeStage].label}`
+      : `闭环：${snapshot.mode}`;
+
+  return (
+    <div className={className} role="img" aria-label={ariaLabel}>
+      <div className="flex items-center gap-1">
+        {LOOP_STAGES.map((stage) => {
+          const { cls, pulse } = segClass(stage, snapshot);
+          const meta = LOOP_STAGE_META[stage];
+          const isActive = snapshot.stageStates[stage] === "active";
+          return (
+            <div
+              key={stage}
+              title={`${meta.label} · ${snapshot.stageStates[stage]} · ${meta.desc}`}
+              className={`flex-1 rounded-full ${barH} ${cls} ${pulse ? "animate-pulse" : ""} ${
+                isActive ? "" : "opacity-90"
+              } transition-colors`}
+            />
+          );
+        })}
+      </div>
+      {showLabels && (
+        <div className="mt-1.5 flex items-center gap-1">
+          {LOOP_STAGES.map((stage) => {
+            const isActive = snapshot.stageStates[stage] === "active";
+            const isDone = snapshot.stageStates[stage] === "done";
+            return (
+              <div
+                key={stage}
+                className={`flex-1 text-center text-[10px] tracking-tight ${
+                  isActive
+                    ? "font-semibold text-foreground"
+                    : isDone
+                      ? "text-text-secondary"
+                      : "text-text-muted"
+                }`}
+              >
+                {LOOP_STAGE_META[stage].label}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Repeat } from "lucide-react";
+
+import type { RoutineDTO, RoutineIterationDTO } from "@/features/routine";
+
+import { LiveElapsed } from "./ElapsedClock";
+import { RoutineLoopBar } from "./RoutineLoopBar";
+import { LOOP_STAGE_META, type LoopSnapshot } from "./routine-loop";
+import { verdictClass } from "./status-style";
+
+const ACTIVE_TIMING: ReadonlySet<string> = new Set(["dispatched", "in_flight", "executed"]);
+
+/**
+ * Evaluator-Optimizer 闭环图 —— 4 阶段步进器 + 实时状态行 + Reflexion 反馈说明。
+ * 把「Decide → reflection → Dispatch」的反思反馈边显式呈现（区别于普通流水线）。
+ */
+export function RoutineLoopDiagram({
+  snapshot,
+  latest,
+  routine,
+}: {
+  snapshot: LoopSnapshot;
+  latest: RoutineIterationDTO | undefined;
+  routine: RoutineDTO;
+}) {
+  const timing = !!latest && ACTIVE_TIMING.has(latest.status) && !latest.finished_at;
+
+  return (
+    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          闭环过程 · Evaluator–Optimizer Loop
+        </h3>
+        {snapshot.mode === "looping" && snapshot.activeStage && (
+          <span className="text-[11px] font-medium text-foreground">
+            {LOOP_STAGE_META[snapshot.activeStage].label}
+            {snapshot.pulsing && <span className="ml-1 text-text-muted">进行中…</span>}
+          </span>
+        )}
+      </div>
+
+      <RoutineLoopBar snapshot={snapshot} size="md" showLabels />
+
+      {/* 实时 / 终态状态行 */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-text-secondary">
+        {timing && latest ? (
+          <>
+            <span className="inline-flex items-center gap-1">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
+              迭代 #{latest.seq}
+            </span>
+            <LiveElapsed startedAt={latest.started_at} prefix="⏱ " className="text-foreground" />
+            <span className="text-text-muted">{latest.turn_count} turns</span>
+            <span className="text-text-muted">${latest.cost_usd.toFixed(4)}</span>
+          </>
+        ) : snapshot.mode === "done" ? (
+          <span className="text-text-muted">
+            已结束{snapshot.terminationReason ? ` · 终止原因：${snapshot.terminationReason}` : ""}
+          </span>
+        ) : snapshot.mode === "paused" ? (
+          <span className="text-amber-600 dark:text-amber-400">已暂停 · 恢复后继续迭代</span>
+        ) : snapshot.mode === "waiting-approval" ? (
+          <span className="text-amber-600 dark:text-amber-400">等待人工审批后派发下一轮迭代</span>
+        ) : snapshot.mode === "idle" ? (
+          <span className="text-text-muted">尚未启动</span>
+        ) : null}
+        {latest?.verdict && (
+          <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${verdictClass(latest.verdict)}`}>
+            {latest.verdict}
+          </span>
+        )}
+      </div>
+
+      {/* Reflexion 反馈边 */}
+      <div className="mt-3 flex items-start gap-2 rounded-lg border border-dashed border-border bg-muted/30 p-2.5">
+        <Repeat className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+        <div className="min-w-0 text-[11px] text-text-secondary">
+          <span className="font-medium text-foreground">Reflexion 反馈</span>
+          ：Decide 后将上轮反思注入下轮 Dispatch 提示，驱动自迭代。
+          {latest?.reflection && (
+            <span className="mt-1 block italic text-text-muted">💡 最近反思：{latest.reflection}</span>
+          )}
+          {!latest?.reflection && routine.reflections.length > 0 && (
+            <span className="mt-1 block italic text-text-muted">💡 {routine.reflections[routine.reflections.length - 1]}</span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
@@ -6,10 +6,8 @@ import type { RoutineDTO, RoutineIterationDTO } from "@/features/routine";
 
 import { LiveElapsed } from "./ElapsedClock";
 import { RoutineLoopBar } from "./RoutineLoopBar";
-import { LOOP_STAGE_META, type LoopSnapshot } from "./routine-loop";
+import { ACTIVE_TIMING, LOOP_STAGE_META, type LoopSnapshot } from "./routine-loop";
 import { verdictClass } from "./status-style";
-
-const ACTIVE_TIMING: ReadonlySet<string> = new Set(["dispatched", "in_flight", "executed"]);
 
 /**
  * Evaluator-Optimizer 闭环图 —— 4 阶段步进器 + 实时状态行 + Reflexion 反馈说明。
@@ -24,7 +22,8 @@ export function RoutineLoopDiagram({
   latest: RoutineIterationDTO | undefined;
   routine: RoutineDTO;
 }) {
-  const timing = !!latest && ACTIVE_TIMING.has(latest.status) && !latest.finished_at;
+  const timing =
+    snapshot.mode === "looping" && !!latest && ACTIVE_TIMING.has(latest.status) && !latest.finished_at;
 
   return (
     <section className="rounded-card border border-border bg-card p-4 shadow-sm">

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineMeter.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineMeter.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * 通用细进度条 —— 标签 + 右侧读数 + 填充条（可选阈值刻痕）。
+ * 复用于 Fleet 卡片（迭代/成本）与 Run 守卫面板（迭代/成本/成功分/截止）。
+ */
+export function RoutineMeter({
+  label,
+  valueText,
+  ratio,
+  fillClass,
+  /** 阈值刻痕位置（0-100），如成功阈值线。 */
+  notchPct,
+  className,
+}: {
+  label: string;
+  valueText: string;
+  ratio: number | null;
+  fillClass: string;
+  notchPct?: number;
+  className?: string;
+}) {
+  const pct = ratio == null ? 0 : Math.min(100, Math.max(0, ratio * 100));
+  return (
+    <div className={className}>
+      <div className="flex items-baseline justify-between text-[10px] text-text-muted">
+        <span>{label}</span>
+        <span className="tabular-nums text-text-secondary">{valueText}</span>
+      </div>
+      <div className="relative mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full ${fillClass} transition-[width] duration-300 ease-out`}
+          style={{ width: `${pct}%` }}
+        />
+        {notchPct != null && (
+          <div
+            className="absolute top-0 h-full w-px bg-foreground/40"
+            style={{ left: `${Math.min(100, Math.max(0, notchPct))}%` }}
+            aria-hidden
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo } from "react";
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+import type { ExecStatus, IterationStatus, RoutineIterationDTO, Verdict } from "@/features/routine";
+
+import { useClock } from "./ClockProvider";
+import { NULL_HEX, VERDICT_HEX } from "./chart-colors";
+import { formatDuration } from "./routine-format";
+
+const ACTIVE_TIMING: ReadonlySet<IterationStatus> = new Set(["dispatched", "in_flight", "executed"]);
+
+interface GanttRow {
+  label: string;
+  seq: number;
+  offset: number; // 距 run 起点的秒数（透明占位）
+  dur: number; // 执行区间秒数（可见）
+  status: IterationStatus;
+  verdict: Verdict | null;
+  exec_status: ExecStatus | null;
+  cost: number;
+  turns: number;
+  inFlight: boolean;
+}
+
+function barColor(row: GanttRow): string {
+  if (row.exec_status === "error" || row.exec_status === "timeout") return "#ef4444";
+  if (row.inFlight) return "#0ea5e9";
+  if (row.verdict) return VERDICT_HEX[row.verdict];
+  return NULL_HEX;
+}
+
+interface TooltipPayloadItem {
+  payload?: GanttRow;
+}
+
+function GanttTooltip({ active, payload }: { active?: boolean; payload?: TooltipPayloadItem[] }) {
+  // dur 系列在前，取其 payload。
+  const row = payload?.find((p) => p.payload)?.payload;
+  if (!active || !row) return null;
+  return (
+    <div className="rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] shadow-md">
+      <div className="font-semibold text-foreground">
+        迭代 #{row.seq} · {row.status}
+        {row.inFlight && " · 进行中"}
+      </div>
+      <div className="text-text-secondary">用时: {formatDuration(row.dur * 1000)}</div>
+      {row.verdict && <div className="text-text-secondary">verdict: {row.verdict}</div>}
+      {row.exec_status && <div className="text-text-muted">exec: {row.exec_status}</div>}
+      <div className="text-text-muted">
+        {row.turns} turns · ${row.cost.toFixed(4)}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 迭代甘特时间线 —— 一行一迭代，共享 run 时钟。
+ *
+ * 诚实时间编码：bar 跨度 = ``[started_at, finished_at]`` = **执行段**（finished_at 设于写回，
+ * 评估阶段后端不记时间戳，故评估不占时长）；在途迭代延伸至 now（随时钟动）。
+ * 颜色：error/timeout 红、在途蓝、否则按 verdict。
+ */
+export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDTO[] }) {
+  const now = useClock();
+
+  const rows = useMemo<GanttRow[]>(() => {
+    const started = [...iterations]
+      .filter((it) => it.started_at)
+      .sort((a, b) => a.seq - b.seq);
+    if (started.length === 0) return [];
+    const starts = started.map((it) => Date.parse(it.started_at as string)).filter((n) => !Number.isNaN(n));
+    const runStart = Math.min(...starts);
+    return started.map((it) => {
+      const start = Date.parse(it.started_at as string);
+      const inFlight = !it.finished_at && ACTIVE_TIMING.has(it.status);
+      const end = it.finished_at ? Date.parse(it.finished_at) : now;
+      const safeStart = Number.isNaN(start) ? runStart : start;
+      return {
+        label: `#${it.seq}`,
+        seq: it.seq,
+        offset: Math.max(0, (safeStart - runStart) / 1000),
+        dur: Math.max(0.1, (Math.max(end, safeStart) - safeStart) / 1000),
+        status: it.status,
+        verdict: it.verdict,
+        exec_status: it.exec_status,
+        cost: it.cost_usd,
+        turns: it.turn_count,
+        inFlight,
+      };
+    });
+  }, [iterations, now]);
+
+  return (
+    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+      <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        迭代时间线 · Run Timeline（执行区间）
+      </h3>
+      {rows.length === 0 ? (
+        <p className="py-8 text-center text-[11px] text-text-muted">尚无可视化的执行区间</p>
+      ) : (
+        <div style={{ height: Math.max(120, rows.length * 30 + 36), minWidth: 1 }} className="w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={rows} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 8 }} barCategoryGap={6}>
+              <XAxis
+                type="number"
+                stroke="currentColor"
+                fontSize={10}
+                tickFormatter={(v: number) => formatDuration(v * 1000)}
+              />
+              <YAxis type="category" dataKey="label" width={40} stroke="currentColor" fontSize={10} />
+              <Tooltip content={<GanttTooltip />} cursor={{ fill: "var(--color-muted, #f4f4f5)", opacity: 0.4 }} />
+              {/* 透明占位：run 起点 → 本迭代起点 */}
+              <Bar dataKey="offset" stackId="t" fill="transparent" isAnimationActive={false} />
+              {/* 可见执行区间 */}
+              <Bar dataKey="dur" stackId="t" radius={[2, 2, 2, 2]} isAnimationActive={false}>
+                {rows.map((row) => (
+                  <Cell key={row.seq} fill={barColor(row)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
@@ -8,8 +8,7 @@ import type { ExecStatus, IterationStatus, RoutineIterationDTO, Verdict } from "
 import { useClock } from "./ClockProvider";
 import { NULL_HEX, VERDICT_HEX } from "./chart-colors";
 import { formatDuration } from "./routine-format";
-
-const ACTIVE_TIMING: ReadonlySet<IterationStatus> = new Set(["dispatched", "in_flight", "executed"]);
+import { ACTIVE_TIMING } from "./routine-loop";
 
 interface GanttRow {
   label: string;

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { RoutineDTO } from "@/features/routine";
+
+import { ReflectionFlow } from "./ReflectionFlow";
+import { RoutineConvergenceChart } from "./RoutineConvergenceChart";
+import { RoutineGuardPanel } from "./RoutineGuardPanel";
+import { RoutineIterationTimeline } from "./RoutineIterationTimeline";
+import { RoutineLoopDiagram } from "./RoutineLoopDiagram";
+import { RoutineRunGantt } from "./RoutineRunGantt";
+import { loopStageOf } from "./routine-loop";
+
+/**
+ * 单任务「全过程」视图主体 —— 闭环图 + 守卫面板 + 收敛趋势 + 甘特时间线 + 反思流 + 迭代明细。
+ * 置于深链路由 ``/interface/routine/[id]``（外层由 ClockProvider 包裹以驱动实时计时）。
+ */
+export function RoutineRunView({
+  routine,
+  onApproveIteration,
+  onRejectIteration,
+  busy,
+}: {
+  routine: RoutineDTO;
+  onApproveIteration: (iterationId: string) => void;
+  onRejectIteration: (iterationId: string) => void;
+  busy?: boolean;
+}) {
+  const iterations = useMemo(() => routine.iterations ?? [], [routine.iterations]);
+  const asc = useMemo(() => [...iterations].sort((a, b) => a.seq - b.seq), [iterations]);
+  const desc = useMemo(() => [...iterations].sort((a, b) => b.seq - a.seq), [iterations]);
+  const latest = asc[asc.length - 1];
+  const snapshot = loopStageOf(latest, routine);
+
+  return (
+    <div className="space-y-4">
+      {/* 目标 / 验收标准 */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+          <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Goal</h3>
+          <p className="whitespace-pre-wrap break-words text-xs text-foreground">{routine.goal}</p>
+        </section>
+        <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+          <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+            Acceptance Criteria
+          </h3>
+          <p className="whitespace-pre-wrap break-words text-xs text-text-secondary">
+            {routine.acceptance_criteria}
+          </p>
+        </section>
+      </div>
+
+      {/* 闭环过程 */}
+      <RoutineLoopDiagram snapshot={snapshot} latest={latest} routine={routine} />
+
+      {/* 守卫 / 预算 */}
+      <RoutineGuardPanel routine={routine} iterations={asc} />
+
+      {/* 收敛趋势 + 甘特 */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <RoutineConvergenceChart
+          iterations={asc}
+          threshold={routine.success_score_threshold}
+          bestScore={routine.best_score}
+        />
+        <RoutineRunGantt iterations={asc} />
+      </div>
+
+      {/* 反思记忆流 */}
+      <ReflectionFlow iterations={asc} />
+
+      {/* 迭代明细 */}
+      <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+        <h3 className="mb-3 text-[10px] uppercase tracking-wider text-muted-foreground">
+          迭代明细 · Iterations ({iterations.length})
+        </h3>
+        <RoutineIterationTimeline
+          iterations={desc}
+          onApprove={onApproveIteration}
+          onReject={onRejectIteration}
+          busy={busy}
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineViewToggle.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineViewToggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { navPillClassName, navRailContainerClassName } from "@/components/ui/nav-styles";
+
+export type RoutineView = "table" | "fleet";
+
+/** Table ⇄ Live 分段切换（复用统一胶囊样式；状态经 URL ``?view=`` 派生）。 */
+export function RoutineViewToggle({
+  view,
+  onChange,
+}: {
+  view: RoutineView;
+  onChange: (v: RoutineView) => void;
+}) {
+  const items: { value: RoutineView; label: string }[] = [
+    { value: "table", label: "Table" },
+    { value: "fleet", label: "Live" },
+  ];
+  return (
+    <div className={navRailContainerClassName} role="tablist" aria-label="Routine view">
+      {items.map((it) => (
+        <button
+          key={it.value}
+          type="button"
+          role="tab"
+          aria-selected={view === it.value}
+          onClick={() => onChange(it.value)}
+          className={navPillClassName(view === it.value, "cursor-pointer")}
+        >
+          {it.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/chart-colors.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/chart-colors.ts
@@ -1,0 +1,13 @@
+import type { Verdict } from "@/features/routine";
+
+/** verdict → 图表 SVG 填充 hex（与 [[status-style]] 的 verdictClass 同语义）。 */
+export const VERDICT_HEX: Record<Verdict, string> = {
+  pass: "#10b981", // emerald
+  progressing: "#0ea5e9", // sky
+  stalled: "#f59e0b", // amber
+  regressed: "#f97316", // orange
+  unrecoverable: "#ef4444", // red
+};
+
+/** 未评估 / 未知 verdict 的中性色。 */
+export const NULL_HEX = "#94a3b8"; // slate

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
@@ -1,0 +1,29 @@
+import type { RoutineStatus } from "@/features/routine";
+
+/**
+ * Routine 控制动作 —— 抽屉（RoutineDetailDrawer）与 Run 全过程页（[id]/page）共享的单一事实源，
+ * 避免「允许的状态转换 / 文案」在两处手工同步而静默分叉。
+ */
+export type ControlAction = "start" | "pause" | "resume" | "cancel";
+
+/** 动作 → 按钮文案。 */
+export const CONTROL_LABEL: Record<ControlAction, string> = {
+  start: "Start",
+  pause: "Pause",
+  resume: "Resume",
+  cancel: "Cancel",
+};
+
+/** 依 Routine 状态计算可用控制动作。 */
+export function controlsFor(status: RoutineStatus): ControlAction[] {
+  switch (status) {
+    case "pending":
+      return ["start"];
+    case "running":
+      return ["pause", "cancel"];
+    case "paused":
+      return ["resume", "cancel"];
+    default:
+      return [];
+  }
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-format.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-format.ts
@@ -1,0 +1,28 @@
+/** Routine 视图共享的轻量格式化工具。 */
+
+/** 毫秒 → 秒表样式时长：<1h 为 ``M:SS``，≥1h 为 ``H:MM:SS``。 */
+export function formatDuration(ms: number): string {
+  const safe = Number.isFinite(ms) && ms > 0 ? ms : 0;
+  const totalSec = Math.floor(safe / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
+
+/** 区间毫秒数；任一端缺失或非法返回 null。 */
+export function spanMs(startedAt: string | null | undefined, endAt: number): number | null {
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  if (Number.isNaN(start)) return null;
+  return Math.max(0, endAt - start);
+}
+
+/** 截止时间倒计时（毫秒），过期为 0；缺失返回 null。 */
+export function remainingMs(deadlineAt: string | null | undefined, now: number): number | null {
+  if (!deadlineAt) return null;
+  const dl = Date.parse(deadlineAt);
+  if (Number.isNaN(dl)) return null;
+  return Math.max(0, dl - now);
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-loop.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-loop.ts
@@ -1,0 +1,197 @@
+/**
+ * Evaluator-Optimizer 闭环阶段派生 —— 单一事实源。
+ *
+ * 一个 Routine 的每次迭代经历 4 个规范阶段：
+ *   Dispatch（构建提示并派发） → Execute（Claude Code 执行） → Evaluate（门控 + LLM 评审） → Decide（继续/终止）
+ * 本模块把「最新迭代的 ``status``」+「Routine 级 ``status``」映射为可供步进器/卡片渲染的快照，
+ * 颜色与 [[status-style]] 的 ``iterationDotClass`` 同源，使阶段条与时间线点位一致。
+ */
+
+import type {
+  IterationStatus,
+  RoutineDTO,
+  RoutineStatus,
+  Verdict,
+} from "@/features/routine";
+
+/** 4 个规范闭环阶段（按时序）。 */
+export type LoopStage = "dispatch" | "execute" | "evaluate" | "decide";
+
+export const LOOP_STAGES: readonly LoopStage[] = [
+  "dispatch",
+  "execute",
+  "evaluate",
+  "decide",
+] as const;
+
+/** 闭环整体模式。 */
+export type LoopMode =
+  | "looping" // 正常迭代中（某阶段进行）
+  | "waiting-approval" // 等待人工审批后才派发
+  | "paused" // 已暂停（冻结）
+  | "done" // 终态（succeeded/failed/cancelled）
+  | "idle"; // 未启动 / 无迭代
+
+/** 单阶段在步进器中的状态。 */
+export type StageState = "pending" | "active" | "done";
+
+/** 闭环快照 —— 供 RoutineLoopBar / RoutineLoopDiagram / FleetCard 渲染。 */
+export interface LoopSnapshot {
+  mode: LoopMode;
+  /** 当前活动阶段（仅 looping / waiting-approval 有意义，否则 null）。 */
+  activeStage: LoopStage | null;
+  /** 活动阶段是否脉冲（执行中 / 评估中 / 等待审批时为 true）。 */
+  pulsing: boolean;
+  /** 每阶段状态，用于步进器分段着色。 */
+  stageStates: Record<LoopStage, StageState>;
+  /** decided 时的 verdict（若有）。 */
+  verdict: Verdict | null;
+  /** done 时的终止原因（若有）。 */
+  terminationReason: string | null;
+  /** 透传 Routine 级状态，便于渲染层做整体判断。 */
+  routineStatus: RoutineStatus;
+}
+
+/** 阶段静态元数据：标签、点位配色（与 iterationDotClass 同源）、描述。 */
+export const LOOP_STAGE_META: Record<
+  LoopStage,
+  { label: string; dot: string; desc: string }
+> = {
+  dispatch: { label: "Dispatch", dot: "bg-sky-400", desc: "构建提示并派发迭代" },
+  execute: { label: "Execute", dot: "bg-sky-500", desc: "Claude Code 执行（多轮）" },
+  evaluate: { label: "Evaluate", dot: "bg-violet-500", desc: "命令门控 + LLM 评审" },
+  decide: { label: "Decide", dot: "bg-emerald-500", desc: "继续迭代或终止" },
+};
+
+/** loopStageOf 入参：只读取 status / verdict，兼容完整 DTO 与精简 Lite。 */
+export type LatestIterationInput =
+  | { status: IterationStatus; verdict?: Verdict | null }
+  | null
+  | undefined;
+
+const TERMINAL_ROUTINE: ReadonlySet<RoutineStatus> = new Set([
+  "succeeded",
+  "failed",
+  "cancelled",
+]);
+
+const ALL_PENDING = (): Record<LoopStage, StageState> => ({
+  dispatch: "pending",
+  execute: "pending",
+  evaluate: "pending",
+  decide: "pending",
+});
+
+const ALL_DONE = (): Record<LoopStage, StageState> => ({
+  dispatch: "done",
+  execute: "done",
+  evaluate: "done",
+  decide: "done",
+});
+
+/** 由迭代状态推导各阶段进度。 */
+function stageStatesFor(status: IterationStatus | undefined): Record<LoopStage, StageState> {
+  switch (status) {
+    case "dispatched":
+    case "pending_approval":
+      return { dispatch: "active", execute: "pending", evaluate: "pending", decide: "pending" };
+    case "in_flight":
+      return { dispatch: "done", execute: "active", evaluate: "pending", decide: "pending" };
+    case "executed":
+      return { dispatch: "done", execute: "done", evaluate: "active", decide: "pending" };
+    case "evaluated":
+      return ALL_DONE();
+    default: // reaped / aborted / undefined
+      return ALL_PENDING();
+  }
+}
+
+/** 由迭代状态推导活动阶段与脉冲。 */
+function activeFor(status: IterationStatus): { stage: LoopStage | null; pulsing: boolean } {
+  switch (status) {
+    case "dispatched":
+      return { stage: "dispatch", pulsing: false };
+    case "in_flight":
+      return { stage: "execute", pulsing: true };
+    case "executed":
+      return { stage: "evaluate", pulsing: true };
+    case "evaluated":
+      return { stage: "decide", pulsing: false };
+    default:
+      return { stage: null, pulsing: false };
+  }
+}
+
+/**
+ * 推导闭环快照。
+ *
+ * 优先级：终态 > 暂停 > 未启动/无迭代 > 等待审批 > 正常循环。
+ */
+export function loopStageOf(
+  latest: LatestIterationInput,
+  routine: Pick<RoutineDTO, "status" | "termination_reason">,
+): LoopSnapshot {
+  // 终态：全部完成
+  if (TERMINAL_ROUTINE.has(routine.status)) {
+    return {
+      mode: "done",
+      activeStage: null,
+      pulsing: false,
+      stageStates: ALL_DONE(),
+      verdict: latest?.verdict ?? null,
+      terminationReason: routine.termination_reason ?? null,
+      routineStatus: routine.status,
+    };
+  }
+
+  // 暂停：保留最后阶段进度但冻结（不脉冲）
+  if (routine.status === "paused") {
+    return {
+      mode: "paused",
+      activeStage: null,
+      pulsing: false,
+      stageStates: stageStatesFor(latest?.status),
+      verdict: latest?.verdict ?? null,
+      terminationReason: null,
+      routineStatus: routine.status,
+    };
+  }
+
+  // 未启动 / 尚无迭代信息
+  if (routine.status === "pending" || !latest) {
+    return {
+      mode: "idle",
+      activeStage: null,
+      pulsing: false,
+      stageStates: ALL_PENDING(),
+      verdict: null,
+      terminationReason: null,
+      routineStatus: routine.status,
+    };
+  }
+
+  // 等待人工审批（派发前门控）
+  if (latest.status === "pending_approval") {
+    return {
+      mode: "waiting-approval",
+      activeStage: "dispatch",
+      pulsing: true,
+      stageStates: stageStatesFor("pending_approval"),
+      verdict: null,
+      terminationReason: null,
+      routineStatus: routine.status,
+    };
+  }
+
+  // 正常循环
+  const { stage, pulsing } = activeFor(latest.status);
+  return {
+    mode: "looping",
+    activeStage: stage,
+    pulsing,
+    stageStates: stageStatesFor(latest.status),
+    verdict: latest.verdict ?? null,
+    terminationReason: null,
+    routineStatus: routine.status,
+  };
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-loop.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-loop.ts
@@ -14,6 +14,16 @@ import type {
   Verdict,
 } from "@/features/routine";
 
+/**
+ * 「在途计时」迭代状态集 —— 迭代正在派发/执行/待评估，UI 据此判定是否渲染实时耗时。
+ * 单一事实源：Fleet 卡片、迭代时间线、闭环图、甘特图共用，杜绝多处重复声明。
+ */
+export const ACTIVE_TIMING: ReadonlySet<IterationStatus> = new Set([
+  "dispatched",
+  "in_flight",
+  "executed",
+]);
+
 /** 4 个规范闭环阶段（按时序）。 */
 export type LoopStage = "dispatch" | "execute" | "evaluate" | "decide";
 

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -47,6 +47,22 @@ export function scoreColorClass(score: number | null | undefined): string {
   return "text-red-600 dark:text-red-400";
 }
 
+/** 预算/守卫逼近度（0-1）→ 进度条填充配色（<80% 绿，<95% 琥珀，≥95% 红）。 */
+export function limitFillClass(ratio: number | null | undefined): string {
+  if (ratio == null) return "bg-muted-foreground/40";
+  if (ratio >= 0.95) return "bg-red-500";
+  if (ratio >= 0.8) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+/** 评分 → 温度条填充配色（≥阈值 绿，≥阈值·0.6 琥珀，否则 红）。 */
+export function scoreFillClass(score: number | null | undefined, threshold = 85): string {
+  if (score == null) return "bg-muted-foreground/40";
+  if (score >= threshold) return "bg-emerald-500";
+  if (score >= threshold * 0.6) return "bg-amber-500";
+  return "bg-red-500";
+}
+
 /** verdict → 徽章配色。 */
 export function verdictClass(verdict: Verdict | null | undefined): string {
   switch (verdict) {

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import { ErrorBanner } from "@/components/ui/ErrorState";
@@ -14,7 +15,7 @@ import {
   fetchRoutineDetail,
   rejectIteration,
   updateRoutine,
-  useRoutineData,
+  useRoutineLive,
   useRoutineStream,
 } from "@/features/routine";
 import type {
@@ -24,16 +25,24 @@ import type {
   RoutineUpdatePayload,
 } from "@/features/routine";
 
+import { ClockProvider } from "./_components/ClockProvider";
 import { RoutineDetailDrawer } from "./_components/RoutineDetailDrawer";
 import { RoutineFilterBar } from "./_components/RoutineFilterBar";
+import { RoutineFleetView } from "./_components/RoutineFleetView";
 import { RoutineFormDialog } from "./_components/RoutineFormDialog";
 import { RoutineHeader } from "./_components/RoutineHeader";
 import { RoutineKpiStrip } from "./_components/RoutineKpiStrip";
 import { RoutineTable } from "./_components/RoutineTable";
+import { RoutineViewToggle, type RoutineView } from "./_components/RoutineViewToggle";
 
 const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "" };
 
-export default function RoutinePage() {
+function RoutinePageInner() {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const view: RoutineView = sp.get("view") === "fleet" ? "fleet" : "table";
+  const selId = sp.get("sel");
+
   const [filters, setFilters] = useState<Partial<RoutineFilters>>(DEFAULT_FILTERS);
   const [selected, setSelected] = useState<RoutineDTO | null>(null);
   const [formOpen, setFormOpen] = useState(false);
@@ -41,35 +50,97 @@ export default function RoutinePage() {
   const [actionBusy, setActionBusy] = useState(false);
 
   const { confirm, confirmDialog } = useConfirmDialog();
-  const { routines, kpis, loading, error, refresh } = useRoutineData(filters);
+  const {
+    routines,
+    kpis,
+    loading,
+    error,
+    refresh,
+    latestByRoutine,
+    seedLatest,
+    applyRoutineEvent,
+    applyIterationEvent,
+  } = useRoutineLive(filters);
 
-  // 刷新当前选中详情（含迭代）
+  // 时钟仅在有运行中任务时滴答（无在途零开销）。
+  const clockActive = useMemo(() => routines.some((r) => r.status === "running"), [routines]);
+
+  // 刷新当前选中详情（含迭代）。
   const refreshSelected = useCallback(async (id: string) => {
     try {
       const detail = await fetchRoutineDetail(id);
       setSelected(detail);
     } catch {
-      // ignore — drawer 可能已关闭
+      // ignore — 抽屉可能已关闭
     }
   }, []);
 
-  // SSE：路由 / 迭代事件到达时刷新列表与详情
+  // ?sel 派生选中态：URL 变化即加载/清空详情（使浏览器后退 / Esc / 遮罩点击一致关闭）。
+  useEffect(() => {
+    if (!selId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 由 URL ?sel 同步选中态（外部源）
+      setSelected(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const detail = await fetchRoutineDetail(selId);
+        if (!cancelled) setSelected(detail);
+      } catch {
+        // ignore
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selId]);
+
+  // URL 导航助手（依赖 sp/router，仅在路由变化时重建 → 不破坏子组件 memo）。
+  const setView = useCallback(
+    (v: RoutineView) => {
+      const next = new URLSearchParams(sp.toString());
+      if (v === "fleet") next.set("view", "fleet");
+      else next.delete("view");
+      router.replace(`?${next.toString()}`, { scroll: false });
+    },
+    [router, sp],
+  );
+
+  const openDetail = useCallback(
+    (r: RoutineDTO) => {
+      setSelected(r); // 乐观即时打开（完整迭代由 ?sel effect 拉取）
+      const next = new URLSearchParams(sp.toString());
+      next.set("sel", r.id);
+      router.push(`?${next.toString()}`, { scroll: false });
+    },
+    [router, sp],
+  );
+
+  const closeDetail = useCallback(() => {
+    const next = new URLSearchParams(sp.toString());
+    next.delete("sel");
+    router.replace(`?${next.toString()}`, { scroll: false });
+  }, [router, sp]);
+
+  const openFull = useCallback(
+    (r: RoutineDTO) => {
+      router.push(`/interface/routine/${r.id}`);
+    },
+    [router],
+  );
+
+  // SSE：路由事件去抖动刷新列表；迭代事件即时驱动闭环阶段；选中详情按需刷新。
   const { connected } = useRoutineStream({
-    onRoutineEvent: () => {
-      void refresh();
-      if (selected) void refreshSelected(selected.id);
+    onRoutineEvent: (ev) => {
+      applyRoutineEvent();
+      if (selId && ev.id === selId) void refreshSelected(selId);
     },
     onIterationEvent: (ev) => {
-      if (selected && (ev.routine_id === selected.id || ev.id === selected.id)) {
-        void refreshSelected(selected.id);
-      }
+      applyIterationEvent(ev);
+      if (selId && (ev.routine_id === selId || ev.id === selId)) void refreshSelected(selId);
     },
   });
-
-  const openDetail = async (r: RoutineDTO) => {
-    setSelected(r);
-    void refreshSelected(r.id);
-  };
 
   const handleControl = async (action: "start" | "pause" | "resume" | "cancel") => {
     if (!selected) return;
@@ -141,7 +212,7 @@ export default function RoutinePage() {
     try {
       await deleteRoutine(r.id);
       toast.success("Routine deleted");
-      setSelected(null);
+      closeDetail();
       refresh();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to delete");
@@ -158,7 +229,7 @@ export default function RoutinePage() {
       toast.success("Routine created");
       setFormOpen(false);
       refresh();
-      void openDetail(created);
+      openDetail(created);
     } else if (mode === "edit" && id) {
       const updated = await updateRoutine(id, body as RoutineUpdatePayload);
       toast.success("Routine updated");
@@ -172,33 +243,68 @@ export default function RoutinePage() {
     <div className="flex h-full flex-col bg-muted">
       <InterfaceNav title="Routine" />
       <div className="flex-1 overflow-auto">
-        <div className="space-y-5 px-6 py-6">
-          <RoutineHeader connected={connected} onRefresh={refresh} loading={loading} onCreate={handleCreate} />
+        <ClockProvider active={clockActive}>
+          <div className="space-y-5 px-6 py-6">
+            <RoutineHeader connected={connected} onRefresh={refresh} loading={loading} onCreate={handleCreate} />
 
-          {error && <ErrorBanner message={error} />}
+            {error && <ErrorBanner message={error} />}
 
-          <RoutineKpiStrip kpis={kpis} loading={loading} />
-          <RoutineFilterBar filters={filters} onChange={setFilters} />
-          <RoutineTable routines={routines} loading={loading} onSelect={openDetail} />
+            <RoutineKpiStrip kpis={kpis} loading={loading} />
 
-          {selected && (
-            <RoutineDetailDrawer
-              routine={selected}
-              onClose={() => setSelected(null)}
-              onControl={handleControl}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-              onApproveIteration={handleApprove}
-              onRejectIteration={handleReject}
-              busy={actionBusy}
-            />
-          )}
-        </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <RoutineViewToggle view={view} onChange={setView} />
+              <div className="min-w-[200px] flex-1">
+                <RoutineFilterBar filters={filters} onChange={setFilters} />
+              </div>
+            </div>
+
+            {view === "table" ? (
+              <RoutineTable routines={routines} loading={loading} onSelect={openDetail} />
+            ) : (
+              <RoutineFleetView
+                routines={routines}
+                latestByRoutine={latestByRoutine}
+                loading={loading}
+                seedLatest={seedLatest}
+                onOpenDetail={openDetail}
+                onOpenFull={openFull}
+              />
+            )}
+
+            {selected && (
+              <RoutineDetailDrawer
+                routine={selected}
+                onClose={closeDetail}
+                onOpenFull={() => openFull(selected)}
+                onControl={handleControl}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onApproveIteration={handleApprove}
+                onRejectIteration={handleReject}
+                busy={actionBusy}
+              />
+            )}
+          </div>
+        </ClockProvider>
       </div>
 
       <RoutineFormDialog open={formOpen} routine={editing} onClose={() => setFormOpen(false)} onSubmit={handleFormSubmit} />
 
       {confirmDialog}
     </div>
+  );
+}
+
+export default function RoutinePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full flex-col bg-muted">
+          <InterfaceNav title="Routine" />
+        </div>
+      }
+    >
+      <RoutinePageInner />
+    </Suspense>
   );
 }

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineDetailLive.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineDetailLive.ts
@@ -1,0 +1,74 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * 同 useRoutineData：useEffect 内调用 fetcher 间接 setState 的既有数据加载模式。
+ */
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchRoutineDetail } from "../api";
+import type { RoutineDTO } from "../types";
+import { useRoutineStream } from "./useRoutineStream";
+
+const REFRESH_DEBOUNCE_MS = 500;
+
+/**
+ * 单 Routine 详情实时 hook（Run 全过程页用）。
+ *
+ * - 拉取 ``recent`` 条迭代的完整详情；
+ * - 订阅**过滤后**的 SSE（仅本 routine，事件量低），事件到达去抖动重拉详情；
+ * - 暴露 ``connected`` 供实时指示，``reload`` 供控制动作后刷新。
+ */
+export function useRoutineDetailLive(id: string | null, recent = 50) {
+  const [routine, setRoutine] = useState<RoutineDTO | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reqIdRef = useRef(0);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    const reqId = ++reqIdRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const detail = await fetchRoutineDetail(id, recent);
+      if (reqId !== reqIdRef.current) return;
+      setRoutine(detail);
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return;
+      setError(err instanceof Error ? err.message : "Failed to load routine");
+    } finally {
+      if (reqId === reqIdRef.current) setLoading(false);
+    }
+  }, [id, recent]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // SSE → 去抖动重拉（合并事件突发）。
+  const loadRef = useRef(load);
+  useEffect(() => {
+    loadRef.current = load;
+  }, [load]);
+  const debTimer = useRef<number | null>(null);
+  const schedule = useCallback(() => {
+    if (debTimer.current !== null) return;
+    debTimer.current = window.setTimeout(() => {
+      debTimer.current = null;
+      void loadRef.current();
+    }, REFRESH_DEBOUNCE_MS);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (debTimer.current !== null) window.clearTimeout(debTimer.current);
+    };
+  }, []);
+
+  const { connected } = useRoutineStream({
+    routineId: id ?? undefined,
+    onRoutineEvent: schedule,
+    onIterationEvent: schedule,
+  });
+
+  return { routine, loading, error, reload: load, connected };
+}

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineLive.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineLive.ts
@@ -28,11 +28,6 @@ import { useRoutineData } from "./useRoutineData";
  */
 
 const REFRESH_DEBOUNCE_MS = 500;
-const ACTIVE_ITER: ReadonlySet<IterationStatus> = new Set([
-  "dispatched",
-  "in_flight",
-  "executed",
-]);
 
 type LatestMap = Record<string, RoutineIterationLite>;
 
@@ -69,7 +64,7 @@ export function useRoutineLive(filters: Partial<RoutineFilters>) {
   const seedLatest = useCallback((routineId: string, lite: RoutineIterationLite) => {
     setLatest((prev) => {
       const cur = prev[routineId];
-      // 已有同一迭代且带 started_at（客户端已戳）时，保留更精确的客户端起始时刻。
+      // 同一迭代时优先采用 lite 的 authoritative started_at，缺失才回退已有客户端近似戳。
       if (cur && cur.id && lite.id && cur.id === lite.id) {
         return { ...prev, [routineId]: { ...lite, started_at: lite.started_at ?? cur.started_at } };
       }
@@ -207,7 +202,8 @@ export function useFleetSeed(
         try {
           const detail = await fetchRoutineDetail(id, 1);
           const it = detail.iterations?.[0];
-          if (!cancelled && it) seedRef.current(id, liteFromIteration(it));
+          if (cancelled) return seededRef.current.delete(id);
+          if (it) seedRef.current(id, liteFromIteration(it));
         } catch {
           // 探测失败不致命：SSE 后续仍会驱动阶段（仅缺 authoritative started_at）。
           seededRef.current.delete(id);
@@ -220,5 +216,3 @@ export function useFleetSeed(
     // eslint-disable-next-line react-hooks/exhaustive-deps -- 以稳定的 candKey 触发
   }, [candKey]);
 }
-
-export { ACTIVE_ITER };

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineLive.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineLive.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { fetchRoutineDetail } from "../api";
+import type {
+  IterationStatus,
+  RoutineDTO,
+  RoutineFilters,
+  RoutineIterationLite,
+  RoutineStreamEvent,
+  Verdict,
+} from "../types";
+import { useRoutineData } from "./useRoutineData";
+
+/**
+ * Routine 实时数据层 —— 在 [[useRoutineData]] 之上叠加：
+ *
+ * 1. **去抖动结构刷新**：SSE 事件不再每条触发全量重拉，而是合并到 ~500ms 尾沿，
+ *    用于更新列表级数字（iteration_count / cost / best_score）与排序/KPI，杜绝 hammering。
+ * 2. **latestByRoutine 映射**：按 routine_id 维护「当前迭代精简快照」，由 SSE 即时驱动闭环阶段，
+ *    跨列表刷新存活（不被重拉清空）。
+ * 3. **客户端起始时刻**：SSE ``in_flight`` 事件不带 started_at，首次见到即以客户端时刻近似戳记
+ *    （误差 < 1s），配合 [[useRoutineData]] 列表与 ``recent=1`` 探测（authoritative started_at）。
+ *
+ * 订阅本身仍由页面持有的 [[useRoutineStream]] 负责（保留单连接 + connected 指示），
+ * 本 hook 仅暴露事件应用方法供其回调。
+ */
+
+const REFRESH_DEBOUNCE_MS = 500;
+const ACTIVE_ITER: ReadonlySet<IterationStatus> = new Set([
+  "dispatched",
+  "in_flight",
+  "executed",
+]);
+
+type LatestMap = Record<string, RoutineIterationLite>;
+
+function asNumber(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+export function useRoutineLive(filters: Partial<RoutineFilters>) {
+  const base = useRoutineData(filters);
+  const [latestByRoutine, setLatest] = useState<LatestMap>({});
+
+  // 去抖动刷新：始终调用最新的 base.refresh（filterKey 变化时其 identity 会变）。
+  const refreshRef = useRef(base.refresh);
+  useEffect(() => {
+    refreshRef.current = base.refresh;
+  }, [base.refresh]);
+  const debTimer = useRef<number | null>(null);
+
+  const scheduleRefresh = useCallback(() => {
+    if (debTimer.current !== null) return; // 已有待发，合并
+    debTimer.current = window.setTimeout(() => {
+      debTimer.current = null;
+      void refreshRef.current();
+    }, REFRESH_DEBOUNCE_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debTimer.current !== null) window.clearTimeout(debTimer.current);
+    };
+  }, []);
+
+  /** 直接以一个 Lite 覆盖某 routine 的当前迭代（用于 recent=1 探测 / 详情回填）。 */
+  const seedLatest = useCallback((routineId: string, lite: RoutineIterationLite) => {
+    setLatest((prev) => {
+      const cur = prev[routineId];
+      // 已有同一迭代且带 started_at（客户端已戳）时，保留更精确的客户端起始时刻。
+      if (cur && cur.id && lite.id && cur.id === lite.id) {
+        return { ...prev, [routineId]: { ...lite, started_at: lite.started_at ?? cur.started_at } };
+      }
+      return { ...prev, [routineId]: lite };
+    });
+  }, []);
+
+  /** 应用一条 ``iteration`` 事件：合并到 latestByRoutine（按迭代 id 辨识换代）。 */
+  const applyIterationEvent = useCallback(
+    (ev: RoutineStreamEvent) => {
+      const routineId = ev.routine_id;
+      const status = ev.status as IterationStatus | undefined;
+      if (!routineId || !status) return;
+      const evId = typeof ev.id === "string" ? ev.id : undefined;
+
+      setLatest((prev) => {
+        const cur = prev[routineId];
+        const isNewIteration = !cur || (evId !== undefined && cur.id !== evId);
+
+        // 起始时刻：仅在「新迭代刚进入 in_flight」时以客户端时刻近似戳记。
+        let startedAt = isNewIteration ? undefined : cur?.started_at;
+        if (status === "in_flight" && !startedAt) {
+          startedAt = new Date().toISOString();
+        }
+
+        const next: RoutineIterationLite = {
+          id: evId ?? cur?.id,
+          seq: asNumber(ev.seq) ?? (isNewIteration ? undefined : cur?.seq),
+          status,
+          score: "score" in ev ? (asNumber(ev.score) ?? null) : isNewIteration ? null : cur?.score,
+          verdict:
+            "verdict" in ev
+              ? ((ev.verdict as Verdict | null) ?? null)
+              : isNewIteration
+                ? null
+                : cur?.verdict,
+          turn_count: asNumber(ev.turn_count) ?? (isNewIteration ? undefined : cur?.turn_count),
+          cost_usd: asNumber(ev.cost_usd) ?? (isNewIteration ? undefined : cur?.cost_usd),
+          started_at: startedAt,
+          finished_at: isNewIteration ? undefined : cur?.finished_at,
+        };
+        return { ...prev, [routineId]: next };
+      });
+
+      scheduleRefresh(); // 列表级数字（iteration_count/cost/best_score）稍后对齐
+    },
+    [scheduleRefresh],
+  );
+
+  /** 应用一条 ``routine`` 事件：结构性变化（状态/排序/KPI）去抖动重拉。 */
+  const applyRoutineEvent = useCallback(() => {
+    scheduleRefresh();
+  }, [scheduleRefresh]);
+
+  return {
+    routines: base.routines,
+    kpis: base.kpis,
+    loading: base.loading,
+    error: base.error,
+    refresh: base.refresh,
+    latestByRoutine,
+    seedLatest,
+    applyRoutineEvent,
+    applyIterationEvent,
+  };
+}
+
+/** 从完整迭代 DTO 投影出 Lite（供 recent=1 探测回填）。 */
+export function liteFromIteration(it: {
+  id: string;
+  seq: number;
+  status: IterationStatus;
+  score: number | null;
+  verdict: Verdict | null;
+  turn_count: number;
+  cost_usd: number;
+  started_at: string | null;
+  finished_at: string | null;
+}): RoutineIterationLite {
+  return {
+    id: it.id,
+    seq: it.seq,
+    status: it.status,
+    score: it.score,
+    verdict: it.verdict,
+    turn_count: it.turn_count,
+    cost_usd: it.cost_usd,
+    started_at: it.started_at,
+    finished_at: it.finished_at,
+  };
+}
+
+/**
+ * Fleet 种子探测 —— 进入 Live 视图时，为缺失「当前迭代」信息的运行中/暂停 Routine
+ * 拉一次 ``recent=1`` 详情回填 authoritative started_at。有界（一次性、按 routine 去重、
+ * 上限封顶），非每 tick 轮询。
+ */
+const SEED_CAP = 24;
+
+export function useFleetSeed(
+  active: boolean,
+  routines: RoutineDTO[],
+  latestByRoutine: Record<string, RoutineIterationLite>,
+  seedLatest: (routineId: string, lite: RoutineIterationLite) => void,
+) {
+  const seededRef = useRef<Set<string>>(new Set());
+  const seedRef = useRef(seedLatest);
+  useEffect(() => {
+    seedRef.current = seedLatest;
+  }, [seedLatest]);
+
+  // 候选（纯属性派生，不读 ref）：运行中/暂停、且 map 中尚无带 started_at 的当前迭代。
+  const candidates = useMemo(() => {
+    if (!active) return [];
+    return routines
+      .filter((r) => r.status === "running" || r.status === "paused")
+      .filter((r) => {
+        const lite = latestByRoutine[r.id];
+        return !lite || !lite.started_at;
+      })
+      .slice(0, SEED_CAP)
+      .map((r) => r.id);
+  }, [active, routines, latestByRoutine]);
+
+  const candKey = candidates.join(",");
+
+  useEffect(() => {
+    // 去重（本会话未种过）在 effect 内读 ref，避免渲染期访问。
+    const toSeed = candidates.filter((id) => !seededRef.current.has(id));
+    if (toSeed.length === 0) return;
+    let cancelled = false;
+    for (const id of toSeed) seededRef.current.add(id);
+    void Promise.all(
+      toSeed.map(async (id) => {
+        try {
+          const detail = await fetchRoutineDetail(id, 1);
+          const it = detail.iterations?.[0];
+          if (!cancelled && it) seedRef.current(id, liteFromIteration(it));
+        } catch {
+          // 探测失败不致命：SSE 后续仍会驱动阶段（仅缺 authoritative started_at）。
+          seededRef.current.delete(id);
+        }
+      }),
+    );
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 以稳定的 candKey 触发
+  }, [candKey]);
+}
+
+export { ACTIVE_ITER };

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -10,6 +10,7 @@ export type {
   ExecStatus,
   RoutineDTO,
   RoutineIterationDTO,
+  RoutineIterationLite,
   RoutineKpis,
   RoutineListResponse,
   IterationListResponse,
@@ -34,3 +35,5 @@ export {
 
 export { useRoutineData } from "./hooks/useRoutineData";
 export { useRoutineStream } from "./hooks/useRoutineStream";
+export { useRoutineLive, useFleetSeed, liteFromIteration } from "./hooks/useRoutineLive";
+export { useRoutineDetailLive } from "./hooks/useRoutineDetailLive";

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -80,6 +80,24 @@ export interface RoutineIterationDTO {
   finished_at: string | null;
 }
 
+/**
+ * 迭代的精简快照 —— 由 SSE ``iteration`` 事件或 ``recent=1`` 探测填充，
+ * 供 Fleet 卡片在不拉取完整详情的前提下推导当前闭环阶段与实时耗时。
+ * 字段为 ``RoutineIterationDTO`` 的子集（全部可选，SSE 载荷可能不完整）。
+ */
+export interface RoutineIterationLite {
+  /** 迭代 ID —— 用于辨识「换了一个新迭代」（SSE 事件恒带 id）。 */
+  id?: string;
+  seq?: number;
+  status: IterationStatus;
+  score?: number | null;
+  verdict?: Verdict | null;
+  turn_count?: number;
+  cost_usd?: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+}
+
 export interface RoutineKpis {
   total: number;
   running: number;

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
@@ -1,0 +1,260 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "@/features/routine/api";
+import { liteFromIteration, useFleetSeed, useRoutineLive } from "@/features/routine/hooks/useRoutineLive";
+import type {
+  RoutineDTO,
+  RoutineIterationDTO,
+  RoutineIterationLite,
+  RoutineKpis,
+  RoutineStreamEvent,
+} from "@/features/routine";
+
+/**
+ * useRoutineLive 实时数据层单测。
+ *
+ * 覆盖：① liteFromIteration 投影；② applyIterationEvent 的「新迭代客户端戳记 / 同迭代沿用」
+ * 两条分支与缺字段早退；③ seedLatest 的「同迭代优先权威 started_at / 否则覆盖」；
+ * ④ applyRoutineEvent / applyIterationEvent 去抖动触发列表 refresh；⑤ useFleetSeed 的
+ * recent=1 探测回填与 active=false / 空候选短路。
+ */
+
+const KPIS: RoutineKpis = {
+  total: 1,
+  running: 1,
+  paused: 0,
+  succeeded: 0,
+  failed: 0,
+  cancelled: 0,
+  pending: 0,
+  total_cost_usd: 0,
+  avg_iterations: 0,
+};
+
+function makeRoutine(id: string, status: RoutineDTO["status"] = "running"): RoutineDTO {
+  return {
+    id,
+    key: id,
+    title: id,
+    display_name: null,
+    description: null,
+    goal: "g",
+    acceptance_criteria: "ac",
+    cwd: null,
+    verification_command: null,
+    status,
+    termination_reason: null,
+    max_iterations: 20,
+    max_cost_usd: 5,
+    deadline_at: null,
+    success_score_threshold: 85,
+    no_progress_patience: 3,
+    approval_mode: "auto",
+    iteration_count: 0,
+    total_cost_usd: 0,
+    best_score: null,
+    last_score: null,
+    claude_session_id: null,
+    reflections: [],
+    config: {},
+    owner_id: null,
+    agent_id: null,
+    created_at: null,
+    updated_at: null,
+  };
+}
+
+function makeIteration(id: string): RoutineIterationDTO {
+  return {
+    id,
+    routine_id: "r1",
+    seq: 1,
+    status: "in_flight",
+    prompt: null,
+    resume_session_id: null,
+    exec_status: null,
+    summary: null,
+    claude_session_id: null,
+    cost_usd: 0.05,
+    turn_count: 2,
+    exec_error: null,
+    score: null,
+    verdict: null,
+    reflection: null,
+    eval_error: null,
+    gate_exit_code: null,
+    started_at: "2026-01-01T00:00:00.000Z",
+    finished_at: null,
+  };
+}
+
+describe("liteFromIteration", () => {
+  it("将完整迭代 DTO 投影为字段子集 Lite", () => {
+    const lite = liteFromIteration({
+      id: "it1",
+      seq: 2,
+      status: "evaluated",
+      score: 80,
+      verdict: "progressing",
+      turn_count: 3,
+      cost_usd: 0.12,
+      started_at: "2026-01-01T00:00:00.000Z",
+      finished_at: "2026-01-01T00:01:00.000Z",
+    });
+    expect(lite).toEqual({
+      id: "it1",
+      seq: 2,
+      status: "evaluated",
+      score: 80,
+      verdict: "progressing",
+      turn_count: 3,
+      cost_usd: 0.12,
+      started_at: "2026-01-01T00:00:00.000Z",
+      finished_at: "2026-01-01T00:01:00.000Z",
+    });
+  });
+});
+
+describe("useRoutineLive", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, "fetchRoutines").mockResolvedValue({
+      items: [makeRoutine("r1")],
+      next_cursor: null,
+      has_more: false,
+    });
+    vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("applyIterationEvent: 新迭代进入 in_flight 时客户端戳记 started_at，同迭代后续事件沿用", async () => {
+    const { result } = renderHook(() => useRoutineLive({}));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.applyIterationEvent({
+        type: "iteration",
+        id: "it1",
+        routine_id: "r1",
+        status: "in_flight",
+        seq: 1,
+        turn_count: 0,
+        cost_usd: 0,
+      } satisfies RoutineStreamEvent);
+    });
+    const first = result.current.latestByRoutine["r1"];
+    expect(first?.status).toBe("in_flight");
+    expect(first?.seq).toBe(1);
+    expect(first?.started_at).toBeTruthy();
+
+    // 同一迭代后续事件：沿用既有 started_at，并更新 score/verdict（走 cur 分支）。
+    act(() => {
+      result.current.applyIterationEvent({
+        type: "iteration",
+        id: "it1",
+        routine_id: "r1",
+        status: "evaluated",
+        score: 88,
+        verdict: "pass",
+      } satisfies RoutineStreamEvent);
+    });
+    const second = result.current.latestByRoutine["r1"];
+    expect(second?.status).toBe("evaluated");
+    expect(second?.score).toBe(88);
+    expect(second?.verdict).toBe("pass");
+    expect(second?.started_at).toBe(first?.started_at);
+
+    // 缺 routine_id 的事件被忽略（早退分支），不改变状态。
+    act(() => {
+      result.current.applyIterationEvent({ type: "iteration", id: "x", status: "in_flight" });
+    });
+    expect(Object.keys(result.current.latestByRoutine)).toEqual(["r1"]);
+  });
+
+  it("seedLatest: 同一迭代优先权威 started_at，缺失则回退已有客户端戳", () => {
+    const { result } = renderHook(() => useRoutineLive({}));
+
+    const authoritative: RoutineIterationLite = {
+      id: "it1",
+      seq: 1,
+      status: "in_flight",
+      started_at: "2026-01-01T00:00:00.000Z",
+    };
+    act(() => result.current.seedLatest("r1", authoritative));
+    expect(result.current.latestByRoutine["r1"]?.started_at).toBe("2026-01-01T00:00:00.000Z");
+
+    // 同 id 但新 lite 无 started_at → 回退已有；状态仍更新。
+    act(() =>
+      result.current.seedLatest("r1", { id: "it1", seq: 1, status: "executed", started_at: null }),
+    );
+    expect(result.current.latestByRoutine["r1"]?.status).toBe("executed");
+    expect(result.current.latestByRoutine["r1"]?.started_at).toBe("2026-01-01T00:00:00.000Z");
+
+    // 不同 routine：直接写入。
+    act(() => result.current.seedLatest("r2", { id: "it9", seq: 1, status: "dispatched" }));
+    expect(result.current.latestByRoutine["r2"]?.id).toBe("it9");
+  });
+
+  it("applyRoutineEvent / 重复调用合并去抖动，最终触发一次列表 refresh", async () => {
+    const { result } = renderHook(() => useRoutineLive({}));
+    await waitFor(() => expect(api.fetchRoutines).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.applyRoutineEvent();
+      result.current.applyRoutineEvent(); // 第二次命中「已有待发」早退分支
+    });
+
+    await waitFor(() => expect(api.fetchRoutines).toHaveBeenCalledTimes(2), { timeout: 1500 });
+  });
+});
+
+describe("useFleetSeed", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("为缺 started_at 的运行中 routine 拉 recent=1 并回填权威迭代", async () => {
+    const detailSpy = vi.spyOn(api, "fetchRoutineDetail").mockResolvedValue({
+      ...makeRoutine("r1"),
+      iterations: [makeIteration("it1")],
+    });
+    const seed = vi.fn();
+
+    renderHook(() => useFleetSeed(true, [makeRoutine("r1")], {}, seed));
+
+    await waitFor(() => expect(detailSpy).toHaveBeenCalledWith("r1", 1));
+    await waitFor(() =>
+      expect(seed).toHaveBeenCalledWith("r1", expect.objectContaining({ id: "it1", started_at: "2026-01-01T00:00:00.000Z" })),
+    );
+  });
+
+  it("active=false 时不发起探测", () => {
+    const detailSpy = vi.spyOn(api, "fetchRoutineDetail");
+    const seed = vi.fn();
+
+    renderHook(() => useFleetSeed(false, [makeRoutine("r1")], {}, seed));
+
+    expect(detailSpy).not.toHaveBeenCalled();
+    expect(seed).not.toHaveBeenCalled();
+  });
+
+  it("已有带 started_at 的当前迭代时跳过该 routine（空候选短路）", () => {
+    const detailSpy = vi.spyOn(api, "fetchRoutineDetail");
+    const seed = vi.fn();
+    const latest: Record<string, RoutineIterationLite> = {
+      r1: { id: "it1", seq: 1, status: "in_flight", started_at: "2026-01-01T00:00:00.000Z" },
+    };
+
+    renderHook(() => useFleetSeed(true, [makeRoutine("r1")], latest, seed));
+
+    expect(detailSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -112,8 +112,10 @@ class ClaudeCodeService:
                 result_text = msg.result
             if hasattr(msg, "session_id") and msg.session_id:
                 session_id = msg.session_id
-            if hasattr(msg, "cost_usd") and msg.cost_usd:
-                cost = msg.cost_usd
+            # claude-code-sdk ResultMessage 暴露 ``total_cost_usd``；兼容旧字段 ``cost_usd``。
+            cost_val = getattr(msg, "total_cost_usd", None) or getattr(msg, "cost_usd", None)
+            if cost_val:
+                cost = cost_val
             if hasattr(msg, "num_turns") and msg.num_turns:
                 turns = msg.num_turns
             if hasattr(msg, "is_error") and msg.is_error:
@@ -180,7 +182,8 @@ class ClaudeCodeService:
                 if evt_type == _EVT_RESULT:
                     result_text = event.get("result", "")
                     session_id = event.get("session_id")
-                    cost = event.get("cost_usd", 0.0)
+                    # claude CLI 的 result 事件字段为 ``total_cost_usd``；兼容旧字段 ``cost_usd``。
+                    cost = event.get("total_cost_usd") or event.get("cost_usd") or 0.0
                     turns = event.get("num_turns", 0)
                 elif evt_type == _EVT_ASSISTANT:
                     content = event.get("content", "")


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 长周期自主任务（Evaluator-Optimizer 自迭代闭环）此前在 UI 上只有表格态，缺乏对「运行全过程」的实时可观测性；同时 Claude Code 成本解析字段错误，导致成本守卫与成本可视化恒为 0。
- 关联上下文/Issue/文档：Routine 子系统（Engine 编排 + Claude Code 执行 + SSE 实时事件）。本分支在功能落地后经过一轮多维度 AI 代码评审（双重对抗式验证），并已修复确认的 6 项发现。

# 核心变更
- **Routine 运行可视化**：新增 Fleet 实时视图（卡片化运行/暂停任务，闭环阶段条 + 实时计时 + 迭代/成本/评分指标）与 Run 全过程深链页 `/interface/routine/[id]`（闭环图、守卫/预算面板「为何/何时会停」、评分收敛趋势、迭代甘特时间线、Reflexion 反思记忆流、迭代明细）；Table ⇄ Live 切换经 URL `?view` / `?sel` 派生。
- **实时数据层**：`useRoutineLive`（SSE 去抖动结构刷新 + `latestByRoutine` 即时驱动闭环阶段 + 客户端起始时刻近似）、`useRoutineDetailLive`（单任务过滤订阅 + 去抖重拉）、`useFleetSeed`（有界 `recent=1` 探测回填权威 `started_at`）；单时钟 `ClockProvider` 1Hz 心跳（可见性暂停、无在途零开销）。
- **成本解析修复**：`service.py` 改用 SDK/CLI 真实字段 `total_cost_usd`（兼容旧 `cost_usd`），修复成本守卫与成本可视化恒为 0。
- **评审修复（6 项）**：① `useFleetSeed` 批量探测取消竞态（取消时撤销 `seededRef` 标记以重试）；②③ Fleet/Loop 视图暂停态计时矛盾（按 `snapshot.mode === "looping"` 门控，与 `loopStageOf` 单一事实源一致）；④ `ACTIVE_TIMING` 归并为 `routine-loop.ts` 单一导出并删除死导出；⑤ 抽取 `ControlAction`/`CONTROL_LABEL`/`controlsFor` 至 `routine-controls.ts` 供抽屉与 Run 页共享；⑥ 修正 `seedLatest` 误导性注释。

# 风险与回滚
- 主要风险：以纯前端可视化为主（新增页面/组件/hooks），不改后端数据契约；唯一后端改动为成本字段解析，向后兼容旧字段、影响面收敛于成本统计。SSE 合并与客户端时刻仅用于近似展示，不作权威数据源。
- 回滚方式：revert 本 PR 的 3 个提交即可；成本解析修复可单独 revert `4ffcaaaa`。

# 验证证据
- 单元测试：本批次为可视化与重构，未新增（暂停态计时回归用例见 Next Best Action）。
- 集成测试：—
- E2E/Workflow：经多维度 AI 代码评审 + 双重对抗式验证（20 子代理）确认 6 项发现并落地修复。
- 覆盖率/关键截图：`eslint --max-warnings=0` 通过；`tsc -p tsconfig.json --noEmit` 退出码 0。

# 影响范围
- 前端：`apps/negentropy-ui` Routine 模块（新增 ~18 组件/hooks/工具，改造 `routine/page.tsx`、`RoutineDetailDrawer`、`RoutineIterationTimeline`、`features/routine/{types,index}`）。
- 后端：`apps/negentropy` `engine/claude_code/service.py` 成本字段解析。
- GitHub Actions / 文档：无。

# Next Best Action
- 为暂停态计时矛盾补一条前端回归用例（`routine.status="paused"` 且 `latest.status="in_flight"` 时 `timing` 应为假），并对 `loopStageOf` 状态机补单测，锁定本次修复。

🤖 Generated with [Claude Code](https://github.com/claude)
