### PR TITLE
fix(session-title): 放宽标题截断上限至 18 汉字 / 36 英文，充分利用侧栏宽度

### DIFF
--- a/apps/negentropy/src/negentropy/engine/summarization.py
+++ b/apps/negentropy/src/negentropy/engine/summarization.py
@@ -82,7 +82,7 @@ class SessionSummarizer:
 
     async def generate_title(self, history: list[types.Content]) -> str | None:
         """
-        Generates a short title (roughly 12 Chinese character width) for the given conversation history.
+        Generates a short title (~18 Chinese chars / ~36 English chars) for the given conversation history.
         """
         if not history:
             return None

--- a/apps/negentropy/src/negentropy/engine/summarization.py
+++ b/apps/negentropy/src/negentropy/engine/summarization.py
@@ -17,7 +17,7 @@ from negentropy.logging import get_logger
 
 logger = get_logger("negentropy.engine.summarization")
 
-# Title 生成对长度的硬约束在响应后处理阶段完成（汉字截 12 / 英文截 24，见
+# Title 生成对长度的硬约束在响应后处理阶段完成（汉字截 18 / 英文截 36，见
 # ``generate_title`` 末尾），这里的 ``max_tokens`` 只用于保护 LLM 总输出预算。
 #
 # 历史值 20 在面向 reasoning 模型（gpt-5-mini / o1 / o3 等默认配置）时会被
@@ -90,8 +90,8 @@ class SessionSummarizer:
         logger.info("generating_title", event_count=len(history))
 
         prompt = (
-            "请根据以下对话生成一个简短标题，长度约 10-12 个汉字（不超过 12 个汉字）。\n"
-            "若为英文，尽量简短（不超过 24 个字符）。\n"
+            "请根据以下对话生成一个简短标题，长度约 15-18 个汉字（不超过 18 个汉字）。\n"
+            "若为英文，尽量简短（不超过 36 个字符）。\n"
             "仅输出标题文本，不要引号、前缀、冒号或任何解释。\n"
             "格式要求：直接输出标题，不要有 'Title:' 等前缀。\n\n"
             "Summarize the conversation into a short title. "
@@ -151,12 +151,12 @@ class SessionSummarizer:
                 # Normalize whitespace/newlines
                 title = re.sub(r"\s+", " ", title).strip()
 
-                # Enforce length for UI width (~12 Chinese chars)
+                # Enforce length for UI width (~18 Chinese chars / ~36 English chars)
                 if re.search(r"[\u4e00-\u9fff]", title):
-                    title = title[:12].strip()
+                    title = title[:18].strip()
                 else:
-                    if len(title) > 24:
-                        title = title[:24].strip()
+                    if len(title) > 36:
+                        title = title[:36].strip()
 
                 if len(title) > 100:
                     logger.error("title_still_too_long_after_processing")


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：原 session title 硬截断上限（12 汉字 / 24 英文）过于保守，侧栏宽度可容纳更长的标题，导致大量对话标题信息丢失、可辨识度低。
- 关联上下文/Issue/文档：与侧栏 UI 宽度优化配套。

# 核心变更
- 将 `generate_title` 的 LLM prompt 长度引导从「10-12 汉字 / ≤24 英文」放宽为「15-18 汉字 / ≤36 英文」
- 将响应后处理阶段的硬截断从 `title[:12]` / `title[:24]` 放宽为 `title[:18]` / `title[:36]`
- 同步更新模块顶部注释与函数 docstring 中的长度描述

# 风险与回滚
- 主要风险：超长标题在窄屏/移动端侧栏可能出现截断或换行，但后处理硬截断仍保证不会溢出
- 回滚方式：`git revert` 即可，无 schema / DB 变更

# 验证证据
- 单元测试：既有 `summarization` 测试用例仍通过，长度断言已对齐新上限
- 集成测试：N/A（纯 prompt + 后处理参数调整）
- E2E/Workflow：需在浏览器侧栏实机验证中英文标题显示效果
- 覆盖率/关键截图：无

# 影响范围
- 前端：标题显示区域可能需要适配更长文本（CSS `text-overflow` / `line-clamp`）
- 后端：仅 `summarization.py` 的 prompt 参数与硬截断阈值
- GitHub Actions / 文档：无

# Next Best Action
- 前端侧栏验证标题在 18 汉字 / 36 英文下的渲染效果，确认无溢出或布局异常