### PR TITLE
refactor(tool-form): 重构 ToolFormDialog 为标准三段式布局，修复编辑框过窄问题

### DIFF
--- a/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolFormDialog.tsx
@@ -9,6 +9,7 @@
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { Button } from "@/components/ui/Button";
 
 interface BuiltinTool {
   id: string;
@@ -148,8 +149,6 @@ export function ToolFormDialog({
     }
   };
 
-  if (!open) return null;
-
   const renderDynamicField = (
     key: string,
     schema: FieldSchema,
@@ -191,32 +190,47 @@ export function ToolFormDialog({
   };
 
   return (
-    <OverlayDismissLayer open={open} onClose={onClose}>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div className="w-full max-w-xl max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-card p-6 shadow-xl">
-          <h2 className="text-lg font-semibold text-foreground mb-4">
-            {tool ? `Edit Tool: ${tool.display_name || tool.name}` : "Add Tool"}
-          </h2>
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={submitting}
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-2xl flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl sm:max-h-[calc(100vh-2rem)]"
+    >
+      {/* ── Header ── */}
+      <div className="border-b border-border px-5 py-4 sm:px-6">
+        <h2 className="text-lg font-semibold text-foreground">
+          {tool ? `Edit Tool: ${tool.display_name || tool.name}` : "Add Tool"}
+        </h2>
+        <p className="mt-1 text-sm text-text-muted">
+          Configure tool credentials and runtime parameters.
+        </p>
+      </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {/* 基本信息 */}
-            {!tool && (
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Name <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                  placeholder="e.g. google_search"
-                  required
-                />
-              </div>
-            )}
-
-            <div className="grid grid-cols-2 gap-4">
+      {/* ── Body ── */}
+      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
+          {/* 基本信息 */}
+          <section className="space-y-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+              Basic Information
+            </h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {!tool && (
+                <div className="sm:col-span-2">
+                  <label className="block text-sm font-medium text-text-secondary mb-1">
+                    Name <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                    placeholder="e.g. google_search"
+                    required
+                  />
+                </div>
+              )}
               <div>
                 <label className="block text-sm font-medium text-text-secondary mb-1">
                   Display Name
@@ -245,103 +259,95 @@ export function ToolFormDialog({
                   <option value="claude_code">Agent</option>
                 </select>
               </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-text-secondary mb-1">
-                Description
-              </label>
-              <textarea
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                rows={2}
-                placeholder="Tool description"
-              />
-            </div>
-
-            {/* 凭证字段 */}
-            {Object.keys(credentialFieldDefs).length > 0 && (
-              <div>
-                <h3 className="text-sm font-semibold text-foreground mb-2">
-                  Credentials
-                </h3>
-                <div className="space-y-3 rounded-md border border-border p-3">
-                  {Object.entries(credentialFieldDefs).map(([key, schema]) =>
-                    renderDynamicField(key, schema, credentialFields[key], (k, v) =>
-                      setCredentialFields((prev) => ({ ...prev, [k]: v })),
-                    ),
-                  )}
-                </div>
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  Description
+                </label>
+                <textarea
+                  value={formData.description}
+                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
+                  rows={2}
+                  placeholder="Tool description"
+                />
               </div>
-            )}
+            </div>
+          </section>
 
-            {/* 配置字段 */}
-            {Object.keys(configFieldDefs).length > 0 && (
-              <div>
-                <h3 className="text-sm font-semibold text-foreground mb-2">
-                  Configuration
-                </h3>
-                <div className="space-y-3 rounded-md border border-border p-3">
-                  {Object.entries(configFieldDefs).map(([key, schema]) =>
-                    renderDynamicField(key, schema, configFields[key], (k, v) =>
-                      setConfigFields((prev) => ({ ...prev, [k]: v })),
-                    ),
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* 测试结果 */}
-            {testResult && (
-              <div
-                className={`rounded-md p-3 text-sm ${
-                  testResult.success
-                    ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
-                    : "bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400"
-                }`}
-              >
-                {testResult.message}
-                {testResult.success && testResult.latency_ms !== undefined && (
-                  <span className="ml-2 text-xs opacity-70">({testResult.latency_ms}ms)</span>
+          {/* 凭证字段 */}
+          {Object.keys(credentialFieldDefs).length > 0 && (
+            <section className="space-y-4">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                Credentials
+              </h3>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {Object.entries(credentialFieldDefs).map(([key, schema]) =>
+                  renderDynamicField(key, schema, credentialFields[key], (k, v) =>
+                    setCredentialFields((prev) => ({ ...prev, [k]: v })),
+                  ),
                 )}
               </div>
-            )}
+            </section>
+          )}
 
-            {/* 操作按钮 */}
-            <div className="flex items-center justify-between pt-2">
-              <div>
-                {tool && (
-                  <button
-                    type="button"
-                    onClick={handleTest}
-                    disabled={testing || submitting}
-                    className="rounded-md border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-muted disabled:opacity-50"
-                  >
-                    {testing ? "Testing..." : "Test Connection"}
-                  </button>
+          {/* 配置字段 */}
+          {Object.keys(configFieldDefs).length > 0 && (
+            <section className="space-y-4">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+                Configuration
+              </h3>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {Object.entries(configFieldDefs).map(([key, schema]) =>
+                  renderDynamicField(key, schema, configFields[key], (k, v) =>
+                    setConfigFields((prev) => ({ ...prev, [k]: v })),
+                  ),
                 )}
               </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="rounded-md border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-muted"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={submitting}
-                  className="rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 disabled:opacity-50"
-                >
-                  {submitting ? "Saving..." : tool ? "Update" : "Create"}
-                </button>
-              </div>
+            </section>
+          )}
+
+          {/* 测试结果 */}
+          {testResult && (
+            <div
+              className={`rounded-md p-3 text-sm ${
+                testResult.success
+                  ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
+                  : "bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400"
+              }`}
+            >
+              {testResult.message}
+              {testResult.success && testResult.latency_ms !== undefined && (
+                <span className="ml-2 text-xs opacity-70">({testResult.latency_ms}ms)</span>
+              )}
             </div>
-          </form>
+          )}
         </div>
-      </div>
+
+        {/* ── Footer ── */}
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border bg-card px-5 py-4 sm:px-6">
+          <div>
+            {tool && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleTest}
+                disabled={testing || submitting}
+                loading={testing}
+              >
+                Test Connection
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="neutral" disabled={submitting}>
+              {submitting ? "Saving..." : tool ? "Update" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </form>
     </OverlayDismissLayer>
   );
 }


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：ToolFormDialog 原布局为单一居中卡片，缺乏 Header/Body/Footer 结构化分区，表单内容区与操作按钮共享滚动区域，编辑字段宽度受限于 `max-w-xl` 导致输入框过窄，影响操作体验。
- 关联上下文/Issue/文档：`4bfb0e5b` 后续 UI 优化

# 核心变更
- 将 `ToolFormDialog` 从平铺卡片布局重构为 **Header / Body（可滚动）/ Footer（固定）** 三段式标准对话框布局
- 利用 `OverlayDismissLayer` 的 `containerClassName` / `contentClassName` / `busy` 属性实现内容区溢出滚动与提交防误关闭
- 将原生 `<button>` 替换为项目标准 `Button` 组件，使用 `variant`（outline / ghost / neutral）和 `loading` 属性统一按钮样式
- 表单字段区改为响应式 `sm:grid-cols-2` 网格，容器宽度由 `max-w-xl` 扩展为 `max-w-2xl`
- Credentials / Configuration 区块移除 border 包裹，改用 section heading 分组

# 风险与回滚
- 主要风险：纯 UI 布局变更，不涉及数据逻辑，风险极低
- 回滚方式：`git revert` 该 commit

# 验证证据
- 单元测试：无新增（纯 UI 重构）
- 集成测试：N/A
- E2E/Workflow：需浏览器手动验证对话框打开 / 编辑 / 提交 / 关闭流程
- 覆盖率/关键截图：N/A

# 影响范围
- 前端：`ToolFormDialog.tsx` 单文件，121 行新增 / 115 行删除
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action
- 浏览器实机验证 ToolFormDialog 的打开、编辑、Test Connection、Submit、Cancel 全流程
- 验证深色模式下对话框视觉一致性