### PR TITLE
fix(routine): 启用 Routine 编排循环 + 新增 preening-substrate 预设模板

### DIFF
--- a/apps/negentropy/src/negentropy/agents/routine_presets/preening_substrate.yaml
+++ b/apps/negentropy/src/negentropy/agents/routine_presets/preening_substrate.yaml
@@ -1,0 +1,47 @@
+# ────────────────────────────────────────────────────────────
+# Routine Preset — 项目架构清减（Preening Substrate）
+#
+# 审批模式: first（首轮需人工审批 plan）
+# 命令门控: ruff check（客观锚点）
+# 重点展示: 正交分解 + 语义规范化 + 代码清减的 Evaluator-Optimizer 自主迭代，
+#           首轮 plan 审批确保方向正确，后续迭代全自动推进
+# ────────────────────────────────────────────────────────────
+
+preset_id: preening_substrate
+display_name: "项目架构清减"
+description: >
+  对目标项目执行正交分解与工程熵减：调用 /preening-substrate 技能，
+  按功能维度正交分解目标模块、精简冗余代码、规范化命名。
+  首轮需要人工审批 plan，后续由 LLM-as-Judge + Command Gate 驱动自动迭代。
+category: architecture
+version: 1.0.0
+features_showcase:
+  - "审批模式: first — 首轮 plan 需人工确认方向"
+  - "Command Gate — ruff check 作为客观验证锚点"
+  - "Reflexion — 跨迭代反思记忆驱动自改进"
+  - "LLM-as-Judge — 结构化评分 + verdict 判定"
+
+title: "Preening Substrate"
+goal: >
+  对目标项目执行 /preening-substrate 命令，进行全面的正交分解与工程熵减。
+  请使用 Skill 工具调用 preening-substrate 技能，对项目各代码模块执行：
+  1. 正交分解 — 按功能维度对对象、模型、函数、文件进行解耦，确保单一职责与清晰边界；
+  2. 代码清减 — 精简冗余逻辑、死代码和过度抽象，量化汇报变更前后行数差异；
+  3. 语义规范化 — 审视所有命名使其精确反映实际功能与业务语义。
+
+  约束：不得破坏现有功能特性，不得引入新缺陷。
+acceptance_criteria: >
+  1. 所有变更通过现有测试套件（uv run pytest，无回归）；
+  2. 变更前后代码行数减少 ≥5%，且无功能性回归；
+  3. 至少 3 个模块完成正交分解（职责单一、边界清晰）；
+  4. 所有公共 API 签名和核心运行时行为不变；
+  5. Ruff lint 零新增违规（uv run ruff check）。
+verification_command: "uv run ruff check"
+max_iterations: 20
+max_cost_usd: 15.0
+success_score_threshold: 85
+no_progress_patience: 3
+approval_mode: first
+config:
+  permission_mode: plan
+  max_turns: 30

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -187,7 +187,7 @@ memory:
 
 # --- Routine 配置（长周期自主任务迭代执行：Evaluator-Optimizer + Reflexion）---
 routine:
-  enabled: false                             # 灰度开关：关闭时 routine_inspector 心跳 no-op，不影响调度引擎
+  enabled: true                              # Routine 编排循环已启用：routine_inspector 心跳驱动 Evaluate-Dispatch 闭环
   inspector_interval_seconds: 25             # 心跳 tick 间隔；与种子 routine_inspector ScheduledTask 一致
   max_concurrent_executions: 2               # 全局并发 Claude Code 执行上限（进程内信号量）
   lease_slack_seconds: 60                    # Runner lease 宽裕量；崩溃恢复 reaper 据此判定孤儿迭代


### PR DESCRIPTION
## 问题

"Preening Substrate Self" Routine 一直显示 `running` 状态但 `iteration_count=0`，从未真正开始工作。

### 根因分析

`config.default.yaml` 中 `routine.enabled: false`，导致 `routine_inspector` 每 25s 心跳直接返回 `"routine disabled"`，不执行任何 REAP/EVALUATE/DISPATCH 操作。Routine 虽可被创建并设为 `running`，但 inspector 永远不会为其派发迭代。

**证据**：`scheduler/executions` API 显示 recent routine_inspector executions 的 `output_summary` 均为 `"routine disabled"`。

## 变更内容

### 1. 启用 Routine 特性开关

**文件**: `config.default.yaml` (line 190)

```diff
- enabled: false  # 灰度开关：关闭时 routine_inspector 心跳 no-op
+ enabled: true   # Routine 编排循环已启用
```

### 2. 新增 preening-substrate Routine 预设模板

**新文件**: `routine_presets/preening_substrate.yaml`

| 字段 | 值 |
|------|-----|
| preset_id | `preening_substrate` |
| category | `architecture` |
| approval_mode | `first`（首轮 plan 需人工确认） |
| verification_command | `uv run ruff check` |
| max_iterations | 20 |
| max_cost_usd | 15.0 |
| success_score_threshold | 85 |

支持从 Preset Picker 一键创建项目架构清减任务。

## 验证

- [x] Inspector 从 `"routine disabled"` 变为 `"reaped=0 evaluated=0 launched=1"`
- [x] Routine 详情页显示迭代 #1 为 `in_flight`，Loop Diagram 处于 Execute 阶段
- [x] Fleet View 卡片正确展示运行状态和实时计时
- [x] 新预设通过 `GET /routines/presets` API 正确暴露
- [x] Pre-commit hooks (Ruff lint/format, YAML check) 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)