### PR TITLE
fix(catalog-tree): 修复目录树层级显示错位与详情面板截断问题

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_components/LibraryShell.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/LibraryShell.tsx
@@ -251,6 +251,7 @@ export function LibraryShell() {
             <NodeDetailPanel
               node={treeApi.selectedNode}
               catalogId={catalogId ?? ""}
+              nodes={treeApi.nodes}
               onUpdate={treeApi.refresh}
               onDelete={handleDeleted}
             />

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/CatalogTree.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/CatalogTree.tsx
@@ -42,23 +42,58 @@ export function CatalogTree({
   onDrop,
   onDragEnd,
 }: CatalogTreeProps) {
+  // Reorder flat list into DFS (depth-first) traversal order.
+  // Backend CTE returns nodes grouped by depth level (all depth-0 first,
+  // then all depth-1, etc.), which breaks visual parent-child grouping
+  // in a flat-list renderer. DFS order ensures children appear right
+  // after their parent with correct sibling ordering by sort_order.
+  const dfsOrderedNodes = useMemo(() => {
+    const childrenMap = new Map<string, CatalogNode[]>();
+    const roots: CatalogNode[] = [];
+
+    for (const node of nodes) {
+      if (node.parent_id) {
+        const siblings = childrenMap.get(node.parent_id) ?? [];
+        siblings.push(node);
+        childrenMap.set(node.parent_id, siblings);
+      } else {
+        roots.push(node);
+      }
+    }
+
+    const sortByOrder = (a: CatalogNode, b: CatalogNode) =>
+      a.sort_order - b.sort_order;
+    roots.sort(sortByOrder);
+    for (const siblings of childrenMap.values()) {
+      siblings.sort(sortByOrder);
+    }
+
+    const result: CatalogNode[] = [];
+    const visit = (node: CatalogNode) => {
+      result.push(node);
+      for (const child of childrenMap.get(node.id) ?? []) visit(child);
+    };
+    for (const root of roots) visit(root);
+    return result;
+  }, [nodes]);
+
   // Build children count map
   const childrenCountMap = useMemo(() => {
     const map = new Map<string, number>();
-    for (const node of nodes) {
+    for (const node of dfsOrderedNodes) {
       if (node.parent_id) {
         map.set(node.parent_id, (map.get(node.parent_id) || 0) + 1);
       }
     }
     return map;
-  }, [nodes]);
+  }, [dfsOrderedNodes]);
 
   // Search filtering: match nodes + their ancestors
   const filteredNodeIds = useMemo(() => {
     if (!searchQuery.trim()) return null;
     const q = searchQuery.toLowerCase();
     const matched = new Set<string>();
-    for (const node of nodes) {
+    for (const node of dfsOrderedNodes) {
       if (node.name.toLowerCase().includes(q)) {
         matched.add(node.id);
         // Include ancestors
@@ -68,7 +103,7 @@ export function CatalogTree({
       }
     }
     return matched;
-  }, [nodes, searchQuery]);
+  }, [dfsOrderedNodes, searchQuery]);
 
   // Visibility filter: show root nodes + children whose parent is expanded
   // When searching, auto-expand matched ancestors
@@ -76,20 +111,20 @@ export function CatalogTree({
     const effectiveExpanded = new Set(expandedIds);
     // Auto-expand ancestors of search matches
     if (filteredNodeIds) {
-      for (const node of nodes) {
+      for (const node of dfsOrderedNodes) {
         if (filteredNodeIds.has(node.id) && node.parent_id) {
           effectiveExpanded.add(node.parent_id);
         }
       }
     }
 
-    return nodes.filter((node) => {
+    return dfsOrderedNodes.filter((node) => {
       // Apply search filter
       if (filteredNodeIds && !filteredNodeIds.has(node.id)) return false;
       if (node.parent_id === null) return true;
       return effectiveExpanded.has(node.parent_id);
     });
-  }, [nodes, expandedIds, filteredNodeIds]);
+  }, [dfsOrderedNodes, expandedIds, filteredNodeIds]);
 
   // Highlight matching text
   const highlightMatch = (text: string) => {

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/NodeDetailPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/NodeDetailPanel.tsx
@@ -14,6 +14,8 @@ import { DocumentAssignmentSection } from "./DocumentAssignmentSection";
 interface NodeDetailPanelProps {
   node: CatalogNode | null;
   catalogId: string;
+  /** Full node list for resolving parent name and computing sibling position */
+  nodes: CatalogNode[];
   onUpdate: () => void;
   onDelete: () => void;
 }
@@ -21,6 +23,7 @@ interface NodeDetailPanelProps {
 export function NodeDetailPanel({
   node,
   catalogId,
+  nodes,
   onUpdate,
   onDelete,
 }: NodeDetailPanelProps) {
@@ -154,23 +157,51 @@ export function NodeDetailPanel({
 
       {/* Metadata info */}
       <div className="px-5 py-4 space-y-3 text-xs">
-        <div className="flex justify-between">
+        <div className="flex justify-between items-center">
           <span className="text-muted-foreground">ID</span>
-          <span className="font-mono text-foreground/60">
-            {node.id.slice(0, 8)}…
-          </span>
+          <button
+            type="button"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(node.id);
+                toast.success("ID 已复制");
+              } catch {
+                toast.error("复制失败");
+              }
+            }}
+            className="font-mono text-foreground/60 hover:text-foreground transition-colors cursor-pointer flex items-center gap-1"
+            title="点击复制完整 ID"
+          >
+            <span className="text-[11px]">{node.id}</span>
+            <svg className="h-3 w-3 shrink-0 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+          </button>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">父节点</span>
-          <span>
+          <span className="text-foreground/80">
             {node.parent_id
-              ? `${node.parent_id.slice(0, 8)}…`
+              ? (() => {
+                  const parent = nodes.find((n) => n.id === node.parent_id);
+                  return parent ? parent.name : node.parent_id;
+                })()
               : "（根节点）"}
           </span>
         </div>
         <div className="flex justify-between">
           <span className="text-muted-foreground">排序</span>
-          <span>{node.sort_order}</span>
+          <span className="text-foreground/80">
+            {(() => {
+              const siblings = nodes
+                .filter((n) => n.parent_id === node.parent_id)
+                .sort((a, b) => a.sort_order - b.sort_order);
+              const idx = siblings.findIndex((n) => n.id === node.id);
+              return idx >= 0
+                ? `第 ${idx + 1} / ${siblings.length}`
+                : "-";
+            })()}
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## 问题

Wiki 目录树存在三类显示问题：

1. **层级显示错位**：二级节点（如 Blog、Paper）实际属于「Harness Engineering」，但始终显示在「Negentropy」下方
2. **详情面板截断**：节点 ID 和父节点被截断为 8 字符；排序显示原始内部值（如 2000）
3. **拖拽重归属受影响**：层级错位导致拖拽体验混乱

### 根因

后端 CTE 返回的扁平列表按 `ORDER BY depth, sort_order, name` 排序——所有 depth=0 节点在前、depth=1 节点在后。前端直接按此顺序渲染（仅靠 depth 缩进），导致子节点在视觉上脱离父节点。

## 修复

### CatalogTree.tsx — DFS 前序遍历排序
- 新增 `dfsOrderedNodes`：以 `parent_id` 建立 `childrenMap`，从根节点开始 DFS 前序遍历
- 同级节点按 `sort_order` 排序，确保子节点紧随父节点之后
- 后续 `filteredNodeIds`、`visibleNodes`、`childrenCountMap` 统一基于 DFS 序计算

### NodeDetailPanel.tsx — 完整信息展示
- **ID**：显示完整 UUID + 点击复制按钮
- **父节点**：从截断 ID 改为显示父节点名称（如「Harness Engineering」）
- **排序**：从原始 `sort_order`（如 2000）改为语义化位置序号（如「第 1 / 3」）

### LibraryShell.tsx — 传递 nodes prop
- 将 `treeApi.nodes` 传递至 `NodeDetailPanel`，支持父节点名称查找与同级位置计算

## 涉及文件

| 文件 | 变更 |
|------|------|
| `CatalogTree.tsx` | +DFS 排序逻辑 |
| `NodeDetailPanel.tsx` | ID 完整化 + 父节点名称 + 语义化排序 |
| `LibraryShell.tsx` | 传递 `nodes` prop |

## 验证

- [x] TypeScript 类型检查通过（修改文件零新增错误）
- [x] Pre-commit hooks 全部通过（ESLint / Ruff / trailing whitespace）
- [ ] 浏览器实机验证：展开多级目录树确认层级正确
- [ ] 浏览器实机验证：选中节点确认详情面板信息完整
- [ ] 浏览器实机验证：拖拽节点至另一父节点中间区域确认重归属

🤖 Generated with [Claude Code](https://claude.com/claude-code)