### PR TITLE
fix(wiki-footer): 修复 4 列网格空列致页脚左偏，改用 Flex 居中布局并简化响应式;

### DIFF
--- a/apps/negentropy-wiki/src/styles/components/home-footer.css
+++ b/apps/negentropy-wiki/src/styles/components/home-footer.css
@@ -8,9 +8,10 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 2.5rem clamp(1rem, 3vw, 2rem) 1.5rem;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem clamp(2.5rem, 6vw, 5rem);
 }
 
 .wiki-footer-col-title {
@@ -40,22 +41,17 @@
 }
 
 .wiki-footer-bottom {
-  grid-column: 1 / -1;
+  flex-basis: 100%;
   padding-top: 1.5rem;
   border-top: 1px solid var(--wiki-footer-border);
   font-size: 0.82em;
   color: var(--wiki-footer-text-secondary);
+  text-align: center;
 }
 
-/* Responsive */
+/* Responsive — flex 的 wrap + 居中已天然处理窄屏换行与居中堆叠，仅需收紧间距 */
 @media (max-width: 768px) {
   .wiki-footer-inner {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1.5rem;
-  }
-}
-@media (max-width: 480px) {
-  .wiki-footer-inner {
-    grid-template-columns: 1fr;
+    gap: 1.5rem clamp(1.5rem, 5vw, 3rem);
   }
 }


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 首页页脚 `.wiki-footer-inner` 使用 `grid-template-columns: repeat(4, 1fr)` 写死 4 列，但 `FOOTER_LINK_GROUPS` 实际仅有 3 个导航分组（知识体系 / 场景应用 / 资源），第 4 列恒为空，导致内容占据左侧 3/4、整体明显左偏；版权行亦未水平居中。
- 关联上下文/Issue/文档：工作分支 `ThreeFish-AI/wiki-home-center-content`；改动文件 `apps/negentropy-wiki/src/styles/components/home-footer.css`，由组件 `apps/negentropy-wiki/src/components/home/WikiFooter.tsx` 单一消费。

# 核心变更
- 容器布局：`.wiki-footer-inner` 由 CSS Grid 改为 Flexbox（`display: flex; flex-wrap: wrap; justify-content: center`），使 3 个内容列作为整体水平居中，从根因上消除空列导致的左偏。
- 间距策略：`gap` 改为行/列分设的 `2rem clamp(2.5rem, 6vw, 5rem)`，水平列距随视口在 2.5–5rem 间自适应。
- 版权行：`.wiki-footer-bottom` 由 `grid-column: 1 / -1` 改为 `flex-basis: 100%` 独占整行（Flex 中 100% 基准宽度的子项必然换行独占），并新增 `text-align: center` 实现版权文案居中。
- 响应式简化：移除 768px→2 列、480px→1 列两处栅格断点（Flex 的 wrap + 居中已天然处理窄屏换行与居中堆叠），仅保留 768px 下收紧 `gap`。

# 风险与回滚
- 主要风险：纯视觉样式调整，无任何逻辑、接口或数据改动。唯一可见差异是列宽由等宽（1fr）变为按内容自适应（“资源”列更窄），此为 `justify-content: center` 居中方案的预期表现，非缺陷。
- 回滚方式：`git revert 97b26a6d` 即可完整恢复原 4 列栅格布局。

# 验证证据
- 单元测试：不涉及（纯样式改动，无可测逻辑）。
- 集成测试：不涉及。
- E2E/Workflow：静态核验通过——经 `grep` 确认 `.wiki-footer-*` 系列类仅被 `WikiFooter.tsx` 单一消费，改动无涟漪；按内容宽度估算，3 列 + 列距在 320px 窄屏视口下仍可单行居中容纳，不会横向溢出，移除断点无回归。
- 覆盖率/关键截图：建议合并前补充桌面/移动视口实机截图（见 Next Best Action）。

# 影响范围
- 前端：仅 `apps/negentropy-wiki` 首页页脚样式（`home-footer.css`），范围自包含。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 在备用端口拉起 `negentropy-wiki` dev server，使用浏览器在桌面与移动视口分别验证“列组水平居中、版权行全宽居中、窄屏自然换行”，并将实机截图补充至本 PR 作为视觉回归证据。
