### PR TITLE
style(graph-engine): 对调图引擎切换器中 Sigma 与 d3-force 的展示位置;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -544,15 +544,15 @@ export default function KnowledgeGraphPage() {
                   {viewTab === "graph" && (
                     <div className="flex rounded-lg border border-border text-micro">
                       <button
-                        onClick={() => setRenderer("sigma")}
-                        title="Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）"
+                        onClick={() => setRenderer("d3")}
+                        title="d3-force（Phase 1 兼容回退）"
                         className={`px-2 py-1 font-medium outline-hidden transition-colors ${
-                          renderer === "sigma"
+                          renderer === "d3"
                             ? "bg-foreground text-background"
                             : "text-text-muted hover:text-foreground"
                         } rounded-l-lg`}
                       >
-                        Sigma
+                        d3-force
                       </button>
                       <button
                         onClick={() => setRenderer("3d")}
@@ -566,15 +566,15 @@ export default function KnowledgeGraphPage() {
                         3D
                       </button>
                       <button
-                        onClick={() => setRenderer("d3")}
-                        title="d3-force（Phase 1 兼容回退）"
+                        onClick={() => setRenderer("sigma")}
+                        title="Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）"
                         className={`px-2 py-1 font-medium outline-hidden transition-colors border-x border-border ${
-                          renderer === "d3"
+                          renderer === "sigma"
                             ? "bg-foreground text-background"
                             : "text-text-muted hover:text-foreground"
                         }`}
                       >
-                        d3-force
+                        Sigma
                       </button>
                       <button
                         onClick={() => setRenderer("force-graph")}

--- a/apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx
@@ -44,17 +44,17 @@ type RendererId = "sigma" | "3d" | "d3" | "force-graph" | "cytoscape";
 // 切换器配置（label / title 与主站 page.tsx 切换器对齐）。后续主站渲染器增减时，
 // 在此数组同步增删即可。
 const RENDERERS: { id: RendererId; label: string; title: string }[] = [
-  {
-    id: "sigma",
-    label: "Sigma",
-    title: "Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）",
-  },
+  { id: "d3", label: "d3-force", title: "d3-force 力导向 + SVG 渲染" },
   {
     id: "3d",
     label: "3D",
     title: "3D WebGL（three.js + d3-force-3d，支持三维旋转）",
   },
-  { id: "d3", label: "d3-force", title: "d3-force 力导向 + SVG 渲染" },
+  {
+    id: "sigma",
+    label: "Sigma",
+    title: "Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）",
+  },
   {
     id: "force-graph",
     label: "Force Graph",

--- a/apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx
@@ -4,7 +4,7 @@
  * WikiGraphRenderer — Wiki 知识图谱渲染器切换容器
  *
  * 与主站 `apps/negentropy-ui/.../knowledge/graph/page.tsx` 的右上角分段切换器
- * 对齐：提供 Sigma / 3D / d3-force / Force Graph / Cytoscape 五种引擎，用户可
+ * 对齐：提供 d3-force / 3D / Sigma / Force Graph / Cytoscape 五种引擎，用户可
  * 自由切换，默认 Sigma WebGL。
  *
  * 数据由服务端页面（`/:pubSlug/graph`）一次性 fetch 后下传，本组件仅消费 props


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：知识图谱图引擎切换器中 Sigma 与 d3-force 的展示位置需对调，使主站与 Wiki 两处切换器顺序统一为 `d3-force · 3D · Sigma · Force Graph · Cytoscape`。
- 关联上下文/Issue/文档：延续图谱多渲染器（Phase 1~4）演进；切换器在主站 [`app/knowledge/graph/page.tsx`](apps/negentropy-ui/app/knowledge/graph/page.tsx) 与 Wiki [`WikiGraphRenderer.tsx`](apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx) 两处需保持顺序对齐。

# 核心变更
- **主站 `page.tsx`**：交换位置 1 与位置 3 两按钮的 `onClick` / `title` / 选中判断 / 文案；位置专属圆角与边框类（`rounded-l-lg`、`border-x`）**原地保留**，避免连体药丸圆角错位。
- **Wiki `WikiGraphRenderer.tsx`**：重排 `RENDERERS` 数组（`sigma` ↔ `d3` 互换），圆角与分隔线由容器级 CSS 相邻兄弟选择器 `.wiki-graph-render-btn + .wiki-graph-render-btn` 自动处理；并同步顶部 docstring 引擎枚举顺序，与数组及主站切换器三者一致。

# 风险与回滚
- 主要风险：极低。纯展示顺序调整，默认引擎仍为 `Sigma`，各引擎渲染分发逻辑与 Canvas 组件均不变，逻辑严格等价；无 order-dependent 逻辑或测试快照受影响。
- 回滚方式：`git revert` 本分支两次提交（`bbf8014e`、`9bc8a2e7`）即可恢复原顺序。

# 验证证据
- 单元测试：无相关用例（纯 UI 顺序调整，无可断言的行为变化）。
- 集成测试：N/A。
- E2E/Workflow：pre-commit 钩子通过（`next lint` ✓、trailing whitespace / EOF / merge-conflict 等卫生检查 ✓）。
- 覆盖率/关键截图：diff 审查确认主站与 Wiki 两处切换器顺序一致；默认引擎 `useState("sigma")` 未变，"默认引擎" 文案仍准确。

# 影响范围
- 前端：知识图谱图引擎切换器（主站 + Wiki），仅涉及展示顺序与文档注释。
- 后端：无。
- GitHub Actions / 文档：仅更新 Wiki 组件内 docstring，无构建/CI 配置变更。

# Next Best Action
- 合入后可在浏览器实机确认两处切换器视觉顺序与连体药丸圆角渲染正常。
- 后续若再增减渲染器，需同步主站 `page.tsx` 按钮组、Wiki `RENDERERS` 数组及其 docstring 三处，保持单一事实源对齐。
