### PR TITLE
fix(wiki-mermaid): 深色主题下 Mermaid 全图类型连线/箭头/文字不可见修复

### DIFF
--- a/apps/negentropy-wiki/src/styles/components/markdown.css
+++ b/apps/negentropy-wiki/src/styles/components/markdown.css
@@ -199,6 +199,49 @@
   font-family: var(--wiki-code-font);
 }
 
+/* === Mermaid 深色主题可读性修复（flowchart / graph）===
+   Mermaid 固定以浅色 default 主题渲染（MermaidDiagram.tsx 硬编码 theme:"default"），
+   深色背景下默认 #333 连线/箭头不可见、#ffffde 子图框突兀。此处仅在深色主题下
+   覆写「默认主题」的线条/表面色。作者通过 classDef/style/linkStyle 设定的配色被
+   Mermaid 以内联 `…!important` 输出，优先级高于此处外部 !important，故逐图自定义色
+   原样保留。浅色模式不受影响（规则仅限深色作用域）。 */
+
+/* (1) 显式深色 */
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.flowchart-link, .edgePath > .path) {
+  stroke: rgba(234, 238, 246, 0.62) !important;
+}
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.marker, .marker path, .arrowheadPath, .arrowMarkerPath) {
+  fill: rgba(234, 238, 246, 0.62) !important;
+  stroke: rgba(234, 238, 246, 0.62) !important;
+}
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg .cluster rect {
+  fill: var(--wiki-bg-secondary) !important; /* #161618 浅黄→深表面 */
+  stroke: rgba(234, 244, 250, 0.18) !important;
+}
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.cluster-label, .cluster) :is(text, span) {
+  fill: var(--wiki-text) !important; /* 子图标题 #333→浅色 */
+  color: var(--wiki-text) !important;
+}
+
+/* (2) 跟随系统深色（无显式属性时） */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.flowchart-link, .edgePath > .path) {
+    stroke: rgba(234, 238, 246, 0.62) !important;
+  }
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.marker, .marker path, .arrowheadPath, .arrowMarkerPath) {
+    fill: rgba(234, 238, 246, 0.62) !important;
+    stroke: rgba(234, 238, 246, 0.62) !important;
+  }
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg .cluster rect {
+    fill: var(--wiki-bg-secondary) !important;
+    stroke: rgba(234, 244, 250, 0.18) !important;
+  }
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.cluster-label, .cluster) :is(text, span) {
+    fill: var(--wiki-text) !important;
+    color: var(--wiki-text) !important;
+  }
+}
+
 /* Responsive table container */
 .wiki-responsive-table {
   margin: 1rem 0;

--- a/apps/negentropy-wiki/src/styles/components/markdown.css
+++ b/apps/negentropy-wiki/src/styles/components/markdown.css
@@ -199,36 +199,49 @@
   font-family: var(--wiki-code-font);
 }
 
-/* === Mermaid 深色主题可读性修复（flowchart / graph）===
+/* === Mermaid 深色主题可读性修复（全图类型）===
    Mermaid 固定以浅色 default 主题渲染（MermaidDiagram.tsx 硬编码 theme:"default"），
-   深色背景下默认 #333 连线/箭头不可见、#ffffde 子图框突兀。此处仅在深色主题下
-   覆写「默认主题」的线条/表面色。作者通过 classDef/style/linkStyle 设定的配色被
-   Mermaid 以内联 `…!important` 输出，优先级高于此处外部 !important，故逐图自定义色
-   原样保留。浅色模式不受影响（规则仅限深色作用域）。 */
+   深色背景下默认 #333 连线/箭头/关系连接符、以及浮于画布的文字（时序消息）几乎不可见，
+   #ffffde 子图框突兀。此处仅在深色主题下覆写「默认主题」的线条/箭头/表面/浮动文字色。
+   作者通过 classDef/style/linkStyle 设定的配色被 Mermaid 以内联 `…!important` 输出，
+   优先级高于此处外部 !important，故逐图自定义色原样保留；浅色模式不受影响。
+   注：节点/实体/参与者/便签等「浅底盒子」内的文字本就可读，刻意不予改动（避免浅底浅字）。
+   选择器均为实测确认：flowchart/ER/state/sequence 四类已实机覆盖。 */
 
 /* (1) 显式深色 */
-[data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.flowchart-link, .edgePath > .path) {
-  stroke: rgba(234, 238, 246, 0.62) !important;
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg
+  :is(.flowchart-link, .edgePath > .path, .relationshipLine, .transition, .messageLine0, .messageLine1) {
+  stroke: rgba(234, 238, 246, 0.62) !important; /* flowchart/ER/state/sequence 连线 */
 }
-[data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.marker, .marker path, .arrowheadPath, .arrowMarkerPath) {
-  fill: rgba(234, 238, 246, 0.62) !important;
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.marker, .arrowheadPath, .arrowMarkerPath),
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg marker :is(path, circle, polygon, line) {
+  fill: rgba(234, 238, 246, 0.62) !important; /* 各类箭头 / 关系端点标记 */
   stroke: rgba(234, 238, 246, 0.62) !important;
 }
 [data-color-scheme="dark"] .wiki-mermaid-diagram svg .cluster rect {
-  fill: var(--wiki-bg-secondary) !important; /* #161618 浅黄→深表面 */
+  fill: var(--wiki-bg-secondary) !important; /* 子图框 #ffffde→深表面 */
   stroke: rgba(234, 244, 250, 0.18) !important;
 }
 [data-color-scheme="dark"] .wiki-mermaid-diagram svg :is(.cluster-label, .cluster) :is(text, span) {
   fill: var(--wiki-text) !important; /* 子图标题 #333→浅色 */
   color: var(--wiki-text) !important;
 }
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg .messageText {
+  fill: var(--wiki-text) !important; /* 时序消息文字（浮于透明画布） */
+}
+[data-color-scheme="dark"] .wiki-mermaid-diagram svg[aria-roledescription="stateDiagram"] circle {
+  fill: var(--wiki-text) !important; /* 状态图 起止节点实心点 */
+  stroke: var(--wiki-text) !important;
+}
 
 /* (2) 跟随系统深色（无显式属性时） */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.flowchart-link, .edgePath > .path) {
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg
+    :is(.flowchart-link, .edgePath > .path, .relationshipLine, .transition, .messageLine0, .messageLine1) {
     stroke: rgba(234, 238, 246, 0.62) !important;
   }
-  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.marker, .marker path, .arrowheadPath, .arrowMarkerPath) {
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.marker, .arrowheadPath, .arrowMarkerPath),
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg marker :is(path, circle, polygon, line) {
     fill: rgba(234, 238, 246, 0.62) !important;
     stroke: rgba(234, 238, 246, 0.62) !important;
   }
@@ -239,6 +252,13 @@
   :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg :is(.cluster-label, .cluster) :is(text, span) {
     fill: var(--wiki-text) !important;
     color: var(--wiki-text) !important;
+  }
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg .messageText {
+    fill: var(--wiki-text) !important;
+  }
+  :root:not([data-color-scheme="light"]) .wiki-mermaid-diagram svg[aria-roledescription="stateDiagram"] circle {
+    fill: var(--wiki-text) !important;
+    stroke: var(--wiki-text) !important;
   }
 }
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Mermaid 图表在深色主题下，连线、箭头、关系连接符等使用默认浅色（#333），子图框背景为 #ffffde，在深色背景下几乎不可见。Mermaid 组件硬编码 `theme:"default"`，不随站点主题切换。
- 关联上下文：[[reference_wiki_mermaid_dark_theme_fix]]

# 核心变更
- 在 `markdown.css` 中新增深色主题 Mermaid 可读性覆写（+63 行），覆盖 flowchart、ER、状态、时序四类图表
- 修复内容：
  - **连线**：flowchart-link / edgePath / relationshipLine / transition / messageLine — 默认 #333 → `rgba(234,238,246,0.62)`
  - **箭头**：marker / arrowheadPath / arrowMarkerPath — 同步重着色
  - **子图框**：cluster rect — #ffffde → `var(--wiki-bg-secondary)` + 淡色边框
  - **浮动文字**：cluster-label / messageText — #333 → `var(--wiki-text)`
  - **状态图起止节点**：实心圆点 → `var(--wiki-text)`
- 双模式深色支持：`[data-color-scheme="dark"]`（显式深色）+ `@media (prefers-color-scheme: dark)` + `:root:not([data-color-scheme="light"])`（跟随系统），覆盖三种用户场景
- `!important` 优先级策略：外联 `!important` 覆写 Mermaid 默认内联样式；用户通过 classDef/style/linkStyle 自定义的配色因内联 `!important` 优先级更高而被保留，浅色模式不受影响

# 风险与回滚
- 主要风险：Mermaid 版本升级后 CSS 类名可能变化，导致选择器失效
- 回滚方式：`git revert` 删除新增的 CSS 块即可

# 验证证据
- 单元测试：CSS 变更无单元测试
- E2E：已在 alt-port dev server 上实机验证 flowchart / ER / state / sequence 四类图表深色主题可读性

# 影响范围
- 前端：`apps/negentropy-wiki/src/styles/components/markdown.css`
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 后续可考虑从根源解决：让 Mermaid 组件根据站点主题动态切换 `theme` 参数（`"default"` / `"dark"`），而非依赖外部 CSS 覆写