### PR TITLE
style(wiki-header): 导航项左右分栏 + 已登录用户头像靠右显示

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -62,22 +62,9 @@ export function WikiHeader({
           />
           <span className="wiki-header-name">Negentropy Wiki</span>
         </Link>
-        <nav className="wiki-header-tabs" aria-label="主导航">
-          {homeLinks
-            ? homeLinks.map((link) => (
-                <Link key={link.href} href={link.href} className="wiki-header-tab">
-                  {link.label}
-                </Link>
-              ))
-            : items.map((item) => (
-                <WikiHeaderTab
-                  key={`${item.entry_id ?? "c"}:${item.entry_slug}`}
-                  item={item}
-                  pubSlug={pubSlug!}
-                  isActive={!graphTab?.active && item.entry_slug === activeTopSlug}
-                />
-              ))}
-          {graphTab?.show && (
+        {/* LEFT: Knowledge Graph tab only */}
+        {graphTab?.show && (
+          <nav className="wiki-header-tabs wiki-header-tabs--left" aria-label="特色导航">
             <Link
               href={`/${pubSlug}/graph`}
               className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
@@ -85,8 +72,28 @@ export function WikiHeader({
             >
               {graphTab.label ?? "Knowledge Graph"}
             </Link>
-          )}
-        </nav>
+          </nav>
+        )}
+
+        {/* RIGHT: Content navigation tabs */}
+        {(items.length > 0 || (homeLinks && homeLinks.length > 0)) && (
+          <nav className="wiki-header-tabs wiki-header-tabs--right" aria-label="主导航">
+            {homeLinks
+              ? homeLinks.map((link) => (
+                  <Link key={link.href} href={link.href} className="wiki-header-tab">
+                    {link.label}
+                  </Link>
+                ))
+              : items.map((item) => (
+                  <WikiHeaderTab
+                    key={`${item.entry_id ?? "c"}:${item.entry_slug}`}
+                    item={item}
+                    pubSlug={pubSlug!}
+                    isActive={!graphTab?.active && item.entry_slug === activeTopSlug}
+                  />
+                ))}
+          </nav>
+        )}
         <div className="wiki-header-slot">
           {searchBox}
           {actions}

--- a/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
@@ -3,12 +3,52 @@
 import { useWikiAuth } from "@/lib/auth/wiki-auth";
 
 export function WikiHeaderActions() {
-  const { status, login } = useWikiAuth();
+  const { status, user, login } = useWikiAuth();
 
   return (
     <div className="wiki-header-actions">
-      {/* Auth zone: only show login for unauthenticated users */}
-      {status === "unauthenticated" && (
+      {/* GitHub */}
+      <a
+        href="https://github.com/ThreeFish-AI/negentropy"
+        className="wiki-header-action-btn"
+        target="_blank"
+        rel="noopener noreferrer"
+        title="GitHub"
+        aria-label="GitHub 仓库"
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+        </svg>
+      </a>
+
+      {/* Auth zone: avatar (authenticated) / login icon (unauthenticated) */}
+      {status === "authenticated" && user ? (
+        <button
+          type="button"
+          className="wiki-header-action-btn wiki-header-avatar"
+          title={user.name || user.email || "用户"}
+          aria-label={user.name || "用户"}
+        >
+          {user.picture ? (
+            <img
+              src={user.picture}
+              alt=""
+              width={24}
+              height={24}
+              className="wiki-header-avatar-img"
+            />
+          ) : (
+            <span className="wiki-header-avatar-initials">
+              {(user.name || user.email || "?").charAt(0).toUpperCase()}
+            </span>
+          )}
+        </button>
+      ) : status === "unauthenticated" ? (
         <button
           type="button"
           className="wiki-header-action-btn"
@@ -30,26 +70,7 @@ export function WikiHeaderActions() {
             <circle cx="12" cy="7" r="4" />
           </svg>
         </button>
-      )}
-
-      {/* GitHub */}
-      <a
-        href="https://github.com/ThreeFish-AI/negentropy"
-        className="wiki-header-action-btn"
-        target="_blank"
-        rel="noopener noreferrer"
-        title="GitHub"
-        aria-label="GitHub 仓库"
-      >
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-        >
-          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-        </svg>
-      </a>
+      ) : null}
     </div>
   );
 }

--- a/apps/negentropy-wiki/src/styles/components/header.css
+++ b/apps/negentropy-wiki/src/styles/components/header.css
@@ -53,11 +53,20 @@
   display: flex;
   align-items: stretch;
   gap: 0.25rem;
-  flex: 1;
   min-width: 0;
   height: 100%;
   overflow-x: auto;
   scrollbar-width: none;
+}
+/* 左栏导航：仅 Knowledge Graph，内容宽度不伸缩 */
+.wiki-header-tabs--left {
+  flex: 0 0 auto;
+  justify-content: flex-start;
+}
+/* 右栏导航：内容 tabs，flex-grow 填充间隔 + 右对齐 */
+.wiki-header-tabs--right {
+  flex: 1 1 0;
+  justify-content: flex-end;
 }
 .wiki-header-tabs::-webkit-scrollbar {
   display: none;
@@ -261,12 +270,42 @@
   color: var(--wiki-text);
 }
 
+/* User avatar */
+.wiki-header-avatar {
+  padding: 0;
+  overflow: hidden;
+}
+.wiki-header-avatar-img {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+  pointer-events: none;
+}
+.wiki-header-avatar-initials {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--wiki-primary-light);
+  color: var(--wiki-accent);
+  font-size: 0.75em;
+  font-weight: 600;
+  line-height: 1;
+}
+
 @media (max-width: 768px) {
   /* 仅隐藏顶栏内的搜索框；侧栏/移动抽屉中的搜索框保持可见 */
   .wiki-header .wiki-search-box {
     display: none;
   }
   .wiki-header-dropdown-panel {
+    display: none;
+  }
+  /* 移动端隐藏右侧内容导航，由 sidebar/drawer 承载 */
+  .wiki-header-tabs--right {
     display: none;
   }
 }


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki Header 导航项统一居中排列，缺乏视觉层次；已登录用户无头像反馈，与未登录状态无明显区分
- 关联上下文/Issue/文档：commit 476de9c3

# 核心变更
- **导航左右分栏**：将 Header 内的单个 `<nav>` 拆分为两个独立导航区——左栏（`--left`）承载 Knowledge Graph 特色 tab，右栏（`--right`）承载内容导航 tabs，通过 `flex: 0 0 auto` / `flex: 1 1 0` + `justify-content` 实现左右自然分隔
- **已登录用户头像**：`WikiHeaderActions` 新增 authenticated 状态下的头像展示（OAuth `user.picture` → 圆形头像；无 picture → 首字母 initials），替代原登录按钮；GitHub 链接移至头像前方保持一致的视觉锚点
- **响应式适配**：移动端（≤768px）通过 `display: none` 隐藏右侧内容导航（由 sidebar/drawer 承载），左栏 Knowledge Graph 保持可见

# 风险与回滚
- 主要风险：分栏布局在极端窄屏下可能挤压中间间距；头像 `<img>` 无 `onError` 降级（仅处理了 `picture` 为空的情况）
- 回滚方式：`git revert 476de9c3`

# 验证证据
- 单元测试：无（纯 UI 样式变更）
- 集成测试：无
- E2E/Workflow：需浏览器实机验证左右分栏布局与头像渲染
- 覆盖率/关键截图：待补充

# 影响范围
- 前端：`WikiHeader.tsx`、`WikiHeaderActions.tsx`、`header.css`（109 行增 / 42 行删）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证：alt-port dev server 确认左右分栏布局、头像显示、移动端响应式行为
- 可选增强：头像按钮点击展开用户菜单（logout / profile）