### PR TITLE
feat(routine-template): 模板 CRUD 完整能力（后端模型 + API + 前端 UI）

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/CreateFromTemplateDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/CreateFromTemplateDialog.tsx
@@ -4,27 +4,27 @@ import { useState } from "react";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { Button } from "@/components/ui/Button";
 import { createRoutineFromPreset } from "@/features/routine";
-import type { RoutineDTO, RoutinePresetSummary } from "@/features/routine";
+import type { RoutineDTO, RoutineTemplateItem } from "@/features/routine";
 import { toast } from "sonner";
 
 interface CreateFromTemplateDialogProps {
-  /** 仅在选中某个模版时渲染本对话框。 */
-  preset: RoutinePresetSummary;
+  /** 选中的模板（内置或用户） */
+  template: RoutineTemplateItem;
   onClose: () => void;
-  /** 创建成功回调，回传后端返回的 RoutineDTO（含 id）供父组件导航。 */
+  /** 创建成功回调 */
   onCreated: (created: RoutineDTO) => void;
 }
 
 /**
- * 从预设模版创建 Routine 的轻量对话框。
+ * 从模板创建 Routine 的轻量对话框。
  *
- * 设计：
- * - 用户仅需提供 key（自动生成、可编辑）+ cwd（必填）；其余字段由后端预设填充；
- * - 创建走 BFF POST /api/routine/from-preset；
- * - 使用 useState 懒初始化生成 key，无 useEffect 取数，故无需 react-compiler 豁免。
+ * 用户仅需提供 key + cwd，其余字段由模板预填。
+ * 按 source 分支发送 preset_id 或 template_id。
  */
-export function CreateFromTemplateDialog({ preset, onClose, onCreated }: CreateFromTemplateDialogProps) {
-  const [key, setKey] = useState(() => `${preset.preset_id}-${crypto.randomUUID().slice(0, 4)}`);
+export function CreateFromTemplateDialog({ template, onClose, onCreated }: CreateFromTemplateDialogProps) {
+  const [key, setKey] = useState(
+    () => `${template.key}-${crypto.randomUUID().slice(0, 4)}`,
+  );
   const [cwd, setCwd] = useState("");
   const [creating, setCreating] = useState(false);
   const [fieldError, setFieldError] = useState<string | null>(null);
@@ -45,8 +45,12 @@ export function CreateFromTemplateDialog({ preset, onClose, onCreated }: CreateF
     setCreating(true);
     setFieldError(null);
     try {
-      const created = await createRoutineFromPreset({ preset_id: preset.preset_id, key: key.trim(), cwd: cwd.trim() });
-      toast.success(`Routine created from "${preset.display_name}"`);
+      const payload =
+        template.source === "builtin"
+          ? { preset_id: template.key, key: key.trim(), cwd: cwd.trim() }
+          : { template_id: template.id, key: key.trim(), cwd: cwd.trim() };
+      const created = await createRoutineFromPreset(payload);
+      toast.success(`Routine created from "${template.display_name}"`);
       onCreated(created);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "An error occurred");
@@ -64,8 +68,12 @@ export function CreateFromTemplateDialog({ preset, onClose, onCreated }: CreateF
       contentClassName="my-3 flex w-full max-w-md flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl"
     >
       <div className="border-b border-border px-5 py-4">
-        <h2 className="text-lg font-semibold text-foreground">使用模板：{preset.display_name}</h2>
-        <p className="mt-1 text-sm text-text-muted">提供 Key 与工作目录即可创建，其余配置由模板预填</p>
+        <h2 className="text-lg font-semibold text-foreground">
+          使用模板：{template.display_name}
+        </h2>
+        <p className="mt-1 text-sm text-text-muted">
+          提供 Key 与工作目录即可创建，其余配置由模板预填
+        </p>
       </div>
 
       <div className="space-y-3 px-5 py-4">

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateCard.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import type { RoutineTemplateItem } from "@/features/routine";
+import { APPROVAL_BADGE } from "./preset-style";
+
+interface TemplateCardProps {
+  template: RoutineTemplateItem;
+  /** 点击「使用模板」CTA */
+  onUse: (template: RoutineTemplateItem) => void;
+  /** 点击编辑（仅 source=user） */
+  onEdit?: (template: RoutineTemplateItem) => void;
+  /** 点击删除（仅 source=user） */
+  onDelete?: (template: RoutineTemplateItem) => void;
+  /** 点击卡片主体（查看详情） */
+  onClick?: (template: RoutineTemplateItem) => void;
+}
+
+/**
+ * 统一模板卡片 — 内置预设 + 用户模板共用。
+ *
+ * 设计：
+ * - 内置模板（source=builtin）：只读，仅 "使用模板" 按钮
+ * - 用户模板（source=user）：可编辑/删除，右上角 "Custom" 徽标
+ * - 卡片主体可点击查看详情（onClick），底部 CTA 独立
+ * - `h-full flex flex-col` 保证同行等高；CTA `mt-auto` 钉底
+ */
+export function TemplateCard({ template, onUse, onEdit, onDelete, onClick }: TemplateCardProps) {
+  const isUser = template.source === "user";
+  const badge = APPROVAL_BADGE[template.approval_mode];
+
+  return (
+    <div className="group relative flex h-full flex-col rounded-card border border-border bg-card p-4 transition-colors hover:border-foreground/15">
+      {/* 用户模板标记 */}
+      {isUser && (
+        <span className="absolute right-3 top-3 rounded-full bg-indigo-100 px-1.5 py-0.5 text-micro font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+          Custom
+        </span>
+      )}
+
+      {/* 可点击主体 */}
+      <button
+        type="button"
+        className="cursor-pointer space-y-2 text-left"
+        onClick={() => onClick?.(template)}
+      >
+        <div className="flex flex-wrap items-center gap-2 pr-14">
+          <h3 className="text-sm font-semibold text-foreground">{template.display_name}</h3>
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-micro text-text-secondary">
+            v{template.version}
+          </span>
+          <span className="rounded-full bg-purple-100 px-1.5 py-0.5 text-micro text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+            {template.category}
+          </span>
+          {badge && (
+            <span className={`rounded-full px-1.5 py-0.5 text-micro ${badge.cls}`}>{badge.label}</span>
+          )}
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-micro text-text-secondary">
+            Gate: {template.has_verification_command ? "✓" : "✗"}
+          </span>
+        </div>
+
+        <p className="text-xs text-text-muted line-clamp-2">{template.description}</p>
+
+        {template.features_showcase.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {template.features_showcase.slice(0, 3).map((f, i) => (
+              <span key={i} className="rounded bg-muted px-1.5 py-0.5 text-micro text-text-secondary">
+                {f}
+              </span>
+            ))}
+            {template.features_showcase.length > 3 && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-micro text-text-muted">
+                +{template.features_showcase.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+      </button>
+
+      {/* 底部操作区 */}
+      <div className="mt-auto flex items-center gap-2 pt-3">
+        <Button variant="neutral" size="sm" className="flex-1" onClick={() => onUse(template)}>
+          使用模板
+        </Button>
+        {isUser && onEdit && (
+          <Button
+            iconOnly
+            size="sm"
+            variant="ghost"
+            onClick={() => onEdit(template)}
+            aria-label="编辑模板"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+        )}
+        {isUser && onDelete && (
+          <Button
+            iconOnly
+            size="sm"
+            variant="ghost"
+            className="text-text-muted hover:text-red-500"
+            onClick={() => onDelete(template)}
+            aria-label="删除模板"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { ErrorBanner } from "@/components/ui/ErrorState";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { cn } from "@/lib/utils";
+import { createRoutine, updateRoutine } from "@/features/routine";
+import type { ApprovalMode, RoutineDTO, RoutineTemplateItem } from "@/features/routine";
+import { toast } from "sonner";
+
+interface TemplateFormDialogProps {
+  open: boolean;
+  /** null = 创建模式；传值 = 编辑模式 */
+  template: RoutineTemplateItem | null;
+  onClose: () => void;
+  /** 提交成功回调 */
+  onSaved: (saved: RoutineDTO) => void;
+}
+
+interface FormState {
+  key: string;
+  display_name: string;
+  description: string;
+  category: string;
+  version: string;
+  title: string;
+  goal: string;
+  acceptance_criteria: string;
+  verification_command: string;
+  max_iterations: string;
+  max_cost_usd: string;
+  success_score_threshold: string;
+  no_progress_patience: string;
+  approval_mode: ApprovalMode;
+  features_showcase: string;
+}
+
+const EMPTY: FormState = {
+  key: "",
+  display_name: "",
+  description: "",
+  category: "general",
+  version: "1.0.0",
+  title: "",
+  goal: "",
+  acceptance_criteria: "",
+  verification_command: "",
+  max_iterations: "20",
+  max_cost_usd: "5",
+  success_score_threshold: "85",
+  no_progress_patience: "3",
+  approval_mode: "auto",
+  features_showcase: "",
+};
+
+const APPROVAL_HELP: Record<ApprovalMode, string> = {
+  auto: "全自动：创建后无人干预",
+  first: "首次审批：第 1 次执行前需确认",
+  every: "每轮审批：每次迭代前需确认",
+};
+
+/**
+ * 模板创建/编辑表单对话框。
+ *
+ * 模板本质上是 `is_template=true` 的 Routine 行。
+ * 本表单只暴露模板语义字段（goal / acceptance_criteria / 预算 / config），
+ * 不暴露运行时字段（status / cwd / owner_id 等）。
+ *
+ * category / version / features_showcase 存入 config JSONB，
+ * 复用 Routine.config 作为扩展元信息容器。
+ */
+export function TemplateFormDialog({ open, template, onClose, onSaved }: TemplateFormDialogProps) {
+  const isEdit = template !== null;
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const next: FormState = template
+      ? {
+          key: template.key,
+          display_name: template.display_name,
+          description: template.description,
+          category: template.category,
+          version: template.version,
+          title: template.title,
+          goal: template.goal,
+          acceptance_criteria: template.acceptance_criteria,
+          verification_command: template.verification_command ?? "",
+          max_iterations: template.max_iterations != null ? String(template.max_iterations) : "",
+          max_cost_usd: template.max_cost_usd != null ? String(template.max_cost_usd) : "",
+          success_score_threshold: String(template.success_score_threshold),
+          no_progress_patience: String(template.no_progress_patience),
+          approval_mode: template.approval_mode,
+          features_showcase: Array.isArray(template.features_showcase)
+            ? template.features_showcase.join(", ")
+            : "",
+        }
+      : EMPTY;
+    queueMicrotask(() => {
+      setForm(next);
+      setError(null);
+      setFieldErrors({});
+      setShowAdvanced(isEdit && (!!template?.verification_command || !!template?.features_showcase?.length));
+    });
+  }, [open, template, isEdit]);
+
+  const update = <K extends keyof FormState>(k: K, v: FormState[K]) =>
+    setForm((f) => ({ ...f, [k]: v }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const errs: Record<string, string> = {};
+    if (!isEdit && !form.key.trim()) errs.key = "必填";
+    if (!form.title.trim()) errs.title = "必填";
+    if (!form.goal.trim()) errs.goal = "必填";
+    if (!form.acceptance_criteria.trim()) errs.acceptance_criteria = "必填";
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      setError("请修正标红的字段后重试");
+      setLoading(false);
+      return;
+    }
+
+    // category / version / features_showcase 存入 config JSONB
+    const features = form.features_showcase
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const config: Record<string, unknown> = {
+      ...(isEdit && template ? (template.config as Record<string, unknown>) : {}),
+      category: form.category.trim() || "general",
+      version: form.version.trim() || "1.0.0",
+      features_showcase: features,
+    };
+
+    const base = {
+      title: form.title.trim(),
+      goal: form.goal.trim(),
+      acceptance_criteria: form.acceptance_criteria.trim(),
+      verification_command: form.verification_command.trim() || null,
+      max_iterations: form.max_iterations.trim() ? parseInt(form.max_iterations, 10) : null,
+      max_cost_usd: form.max_cost_usd.trim() ? parseFloat(form.max_cost_usd) : null,
+      success_score_threshold: parseInt(form.success_score_threshold, 10) || 85,
+      no_progress_patience: parseInt(form.no_progress_patience, 10) || 3,
+      approval_mode: form.approval_mode,
+      config,
+      display_name: form.display_name.trim() || null,
+      description: form.description.trim() || null,
+      is_template: true,
+    };
+
+    try {
+      let saved: RoutineDTO;
+      if (isEdit && template) {
+        // 用户模板的 id 是 UUID（非 builtin:xxx）
+        saved = await updateRoutine(template.id, base);
+        toast.success("模板已更新");
+      } else {
+        saved = await createRoutine({ ...base, key: form.key.trim() });
+        toast.success("模板已创建");
+      }
+      onSaved(saved);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "操作失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open) return null;
+
+  const inputCls =
+    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+  const labelCls = "shrink-0 whitespace-nowrap text-xs font-medium text-text-secondary";
+
+  return (
+    <OverlayDismissLayer
+      open={open}
+      onClose={onClose}
+      busy={loading}
+      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
+      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-2xl flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl sm:max-h-[calc(100vh-2rem)]"
+    >
+      {/* Header */}
+      <div className="border-b border-border px-5 py-4">
+        <h2 className="text-lg font-semibold text-foreground">
+          {isEdit ? "编辑模板" : "新建模板"}
+        </h2>
+        <p className="mt-1 text-sm text-text-muted">
+          {isEdit ? `正在编辑「${template?.display_name}」` : "创建一个可复用的 Routine 模板"}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
+          {error && <ErrorBanner message={error} />}
+
+          {/* Section 1 — 基本信息 */}
+          <section>
+            <div className="grid grid-cols-2 gap-3">
+              {isEdit ? (
+                <div className="flex items-center gap-2">
+                  <label className={labelCls}>Key</label>
+                  <input type="text" value={form.key} disabled className={cn(inputCls, "min-w-0 flex-1")} />
+                </div>
+              ) : (
+                <div>
+                  <div className="flex items-center gap-2">
+                    <label className={labelCls}>
+                      Key <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={form.key}
+                      onChange={(e) => update("key", e.target.value)}
+                      placeholder="unique_template_key"
+                      className={cn(inputCls, "min-w-0 flex-1", fieldErrors.key && "border-red-400")}
+                    />
+                  </div>
+                  {fieldErrors.key && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>}
+                </div>
+              )}
+              <div>
+                <div className="flex items-center gap-2">
+                  <label className={labelCls}>
+                    Display Name
+                  </label>
+                  <input
+                    type="text"
+                    value={form.display_name}
+                    onChange={(e) => update("display_name", e.target.value)}
+                    placeholder="模板展示名"
+                    className={cn(inputCls, "min-w-0 flex-1")}
+                  />
+                </div>
+              </div>
+            </div>
+            <textarea
+              className={cn(inputCls, "mt-3")}
+              value={form.description}
+              onChange={(e) => update("description", e.target.value)}
+              rows={2}
+              placeholder="Description — 模板用途简述"
+            />
+            <div className="mt-3 grid grid-cols-2 gap-3">
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Category</label>
+                <input
+                  type="text"
+                  value={form.category}
+                  onChange={(e) => update("category", e.target.value)}
+                  placeholder="quality / testing / general"
+                  className={cn(inputCls, "min-w-0 flex-1")}
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Version</label>
+                <input
+                  type="text"
+                  value={form.version}
+                  onChange={(e) => update("version", e.target.value)}
+                  placeholder="1.0.0"
+                  className={cn(inputCls, "min-w-0 flex-1")}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Section 2 — 任务定义 */}
+          <section className="space-y-3">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <label className={labelCls}>
+                  Title <span className="text-red-500">*</span>
+                </label>
+              </div>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => update("title", e.target.value)}
+                placeholder="Routine Title — 创建时的默认标题"
+                className={cn(inputCls, fieldErrors.title && "border-red-400")}
+              />
+              {fieldErrors.title && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>}
+            </div>
+            <div>
+              <textarea
+                value={form.goal}
+                onChange={(e) => update("goal", e.target.value)}
+                rows={3}
+                placeholder="Goal * — Claude Code 的长周期目标"
+                className={cn(inputCls, fieldErrors.goal && "border-red-400")}
+              />
+              {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}
+            </div>
+            <div>
+              <textarea
+                value={form.acceptance_criteria}
+                onChange={(e) => update("acceptance_criteria", e.target.value)}
+                rows={2}
+                placeholder="Acceptance Criteria * — Evaluator 判定成功的准则"
+                className={cn(inputCls, fieldErrors.acceptance_criteria && "border-red-400")}
+              />
+              {fieldErrors.acceptance_criteria && (
+                <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.acceptance_criteria}</p>
+              )}
+            </div>
+          </section>
+
+          {/* Section 3 — 预算与审批 */}
+          <section className="rounded-card border border-border bg-muted/30 p-4">
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Max Iterations</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={form.max_iterations}
+                  onChange={(e) => update("max_iterations", e.target.value)}
+                  className={cn(inputCls, "min-w-0 flex-1")}
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Max Cost (USD)</label>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.5"
+                  value={form.max_cost_usd}
+                  onChange={(e) => update("max_cost_usd", e.target.value)}
+                  className={cn(inputCls, "min-w-0 flex-1")}
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>Score Threshold</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={form.success_score_threshold}
+                  onChange={(e) => update("success_score_threshold", e.target.value)}
+                  className={cn(inputCls, "min-w-0 flex-1")}
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <label className={labelCls}>No-Progress Limit</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={form.no_progress_patience}
+                  onChange={(e) => update("no_progress_patience", e.target.value)}
+                  className={cn(inputCls, "min-w-0 flex-1")}
+                />
+              </div>
+            </div>
+            <div className="mt-3 flex items-start gap-2">
+              <label className={cn(labelCls, "pt-2")}>Approval Mode</label>
+              <div className="min-w-0 flex-1">
+                <select
+                  value={form.approval_mode}
+                  onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
+                  className={inputCls}
+                >
+                  <option value="auto">Auto (全自动)</option>
+                  <option value="first">First (首次审批)</option>
+                  <option value="every">Every (每轮审批)</option>
+                </select>
+                <p className="mt-1 text-caption text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+              </div>
+            </div>
+          </section>
+
+          {/* Section 4 — 高级设置（折叠） */}
+          <section>
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((prev) => !prev)}
+              className="group flex w-full items-center gap-2 rounded-control px-1.5 py-1.5 text-caption font-medium text-text-secondary transition-colors hover:bg-muted"
+              aria-expanded={showAdvanced}
+            >
+              <ChevronDown
+                aria-hidden="true"
+                className={cn(
+                  "h-3.5 w-3.5 text-text-muted transition-transform duration-150",
+                  showAdvanced && "rotate-180",
+                )}
+              />
+              <span>{showAdvanced ? "收起高级设置" : "高级设置 (Verification, Features...)"}</span>
+            </button>
+
+            {showAdvanced && (
+              <div className="mt-3 space-y-2 rounded-card border border-border bg-muted/30 p-4">
+                <div className="flex items-center gap-2">
+                  <label className={labelCls}>Verification Command</label>
+                  <input
+                    type="text"
+                    value={form.verification_command}
+                    onChange={(e) => update("verification_command", e.target.value)}
+                    placeholder="e.g. uv run pytest -q"
+                    className={cn(inputCls, "min-w-0 flex-1")}
+                  />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <label className={labelCls}>Features Showcase</label>
+                    <input
+                      type="text"
+                      value={form.features_showcase}
+                      onChange={(e) => update("features_showcase", e.target.value)}
+                      placeholder="特性 1, 特性 2, 特性 3（逗号分隔）"
+                      className={cn(inputCls, "min-w-0 flex-1")}
+                    />
+                  </div>
+                  <p className="mt-1 text-caption text-text-muted">
+                    逗号分隔的特性标签，展示在模板卡片上
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="sm" loading={loading}>
+            {isEdit ? "Save" : "Create Template"}
+          </Button>
+        </div>
+      </form>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
@@ -8,7 +8,7 @@ import { ErrorBanner } from "@/components/ui/ErrorState";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { cn } from "@/lib/utils";
 import { createRoutine, updateRoutine } from "@/features/routine";
-import type { ApprovalMode, RoutineDTO, RoutineTemplateItem } from "@/features/routine";
+import type { ApprovalMode, RoutineTemplateItem } from "@/features/routine";
 import { toast } from "sonner";
 
 interface TemplateFormDialogProps {
@@ -161,16 +161,15 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
     };
 
     try {
-      let saved: RoutineDTO;
       if (isEdit && template) {
         // 用户模板的 id 是 UUID（非 builtin:xxx）
-        saved = await updateRoutine(template.id, base);
+        await updateRoutine(template.id, base);
         toast.success("模板已更新");
       } else {
-        saved = await createRoutine({ ...base, key: form.key.trim() });
+        await createRoutine({ ...base, key: form.key.trim() });
         toast.success("模板已创建");
       }
-      onSaved(saved);
+      onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "操作失败");
     } finally {

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
@@ -17,7 +17,7 @@ interface TemplateFormDialogProps {
   template: RoutineTemplateItem | null;
   onClose: () => void;
   /** 提交成功回调 */
-  onSaved: (saved: RoutineDTO) => void;
+  onSaved: () => void;
 }
 
 interface FormState {
@@ -151,8 +151,8 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
       verification_command: form.verification_command.trim() || null,
       max_iterations: form.max_iterations.trim() ? parseInt(form.max_iterations, 10) : null,
       max_cost_usd: form.max_cost_usd.trim() ? parseFloat(form.max_cost_usd) : null,
-      success_score_threshold: parseInt(form.success_score_threshold, 10) || 85,
-      no_progress_patience: parseInt(form.no_progress_patience, 10) || 3,
+      success_score_threshold: parseInt(form.success_score_threshold, 10) ?? 85,
+      no_progress_patience: parseInt(form.no_progress_patience, 10) ?? 3,
       approval_mode: form.approval_mode,
       config,
       display_name: form.display_name.trim() || null,

--- a/apps/negentropy-ui/app/interface/routine/templates/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/templates/page.tsx
@@ -9,39 +9,56 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Sparkles } from "lucide-react";
+import { ArrowLeft, Plus, Sparkles } from "lucide-react";
 
+import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { fetchPresets } from "@/features/routine";
-import type { RoutineDTO, RoutinePresetSummary } from "@/features/routine";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+import {
+  deleteRoutine,
+  fetchTemplates,
+} from "@/features/routine";
+import type { RoutineDTO, RoutineTemplateItem } from "@/features/routine";
+import { toast } from "sonner";
 
+import { TemplateCard } from "../_components/TemplateCard";
+import { TemplateFormDialog } from "../_components/TemplateFormDialog";
 import { CreateFromTemplateDialog } from "../_components/CreateFromTemplateDialog";
-import { PresetCard } from "../_components/PresetCard";
 
 const GRID_CLS = "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3";
 
 /**
- * Routine Templates 子页面（模版画廊）。
+ * Routine Templates CRUD 页面。
  *
- * 取代原 PresetPickerDialog 模态框：以独立子页面 + 响应式三列网格承载内置预设模版，
- * 点击卡片「使用模板」→ 创建对话框填 key+cwd → 创建后跳转该 Routine 详情页。
- * 无 useSearchParams，故无需 Suspense 包裹。
+ * 合并展示内置 YAML 预设（source=builtin，只读）与用户自建模板（source=user，可 CRUD）。
+ * 交互流：
+ * - "New Template" → TemplateFormDialog(create)
+ * - 卡片点击 → 查看详情（预留 drawer 扩展点）
+ * - "使用模板" → CreateFromTemplateDialog（填 key+cwd → 创建 Routine）
+ * - "Edit" → TemplateFormDialog(edit)
+ * - "Delete" → useConfirmDialog → deleteRoutine → toast + refresh
  */
 export default function RoutineTemplatesPage() {
   const router = useRouter();
-  const [presets, setPresets] = useState<RoutinePresetSummary[]>([]);
+  const [templates, setTemplates] = useState<RoutineTemplateItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<RoutinePresetSummary | null>(null);
+
+  // Dialog states
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<RoutineTemplateItem | null>(null);
+  const [selectedForUse, setSelectedForUse] = useState<RoutineTemplateItem | null>(null);
+
+  const { confirm, confirmDialog } = useConfirmDialog();
 
   const load = useCallback(() => {
     setLoading(true);
     setError(null);
-    fetchPresets()
-      .then((data) => setPresets(Array.isArray(data) ? data : []))
+    fetchTemplates()
+      .then((data) => setTemplates(Array.isArray(data) ? data : []))
       .catch((err) => setError(err instanceof Error ? err.message : "An error occurred"))
       .finally(() => setLoading(false));
   }, []);
@@ -50,31 +67,77 @@ export default function RoutineTemplatesPage() {
     load();
   }, [load]);
 
-  const handleCreated = (created: RoutineDTO) => {
-    setSelected(null);
+  // ── 分组 ──
+  const builtin = templates.filter((t) => t.source === "builtin");
+  const user = templates.filter((t) => t.source === "user");
+
+  // ── Handlers ──
+  const handleFormSaved = () => {
+    setFormOpen(false);
+    setEditing(null);
+    load();
+  };
+
+  const handleUseCreated = (created: RoutineDTO) => {
+    setSelectedForUse(null);
     router.push(`/interface/routine/${created.id}`);
+  };
+
+  const handleEdit = (template: RoutineTemplateItem) => {
+    setEditing(template);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async (template: RoutineTemplateItem) => {
+    const ok = await confirm({
+      title: "删除模板",
+      message: `确定要删除「${template.display_name}」吗？此操作不可撤销。`,
+      confirmLabel: "删除",
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await deleteRoutine(template.id);
+      toast.success(`模板「${template.display_name}」已删除`);
+      load();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "删除失败");
+    }
   };
 
   return (
     <div className="flex h-full flex-col bg-muted">
       <InterfaceNav title="Routine" />
       <div className="flex-1 overflow-auto">
-        <div className="space-y-5 px-6 py-6">
-          {/* 头部：返回 + 标题 + 副标题 */}
-          <div className="flex items-center gap-3">
-            <Link
-              href="/interface/routine"
-              aria-label="返回 Routine 列表"
-              className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-            >
-              <ArrowLeft className="h-4 w-4" />
-            </Link>
-            <div>
-              <h1 className="text-2xl font-bold text-foreground">Routine Templates</h1>
-              <p className="text-sm text-text-muted">
-                从内置场景模板快速创建一个 Routine —— 覆盖代码审计、测试增强、文档生成与架构清减
-              </p>
+        <div className="space-y-6 px-6 py-6">
+          {/* Header */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <Link
+                href="/interface/routine"
+                aria-label="返回 Routine 列表"
+                className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </Link>
+              <div>
+                <h1 className="text-2xl font-bold text-foreground">Routine Templates</h1>
+                <p className="text-sm text-text-muted">
+                  从内置预设或自定义模板快速创建 Routine
+                </p>
+              </div>
             </div>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                setEditing(null);
+                setFormOpen(true);
+              }}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              New Template
+            </Button>
           </div>
 
           {loading ? (
@@ -93,25 +156,72 @@ export default function RoutineTemplatesPage() {
             </div>
           ) : error ? (
             <ErrorState title="Failed to load templates" description={error} onRetry={load} />
-          ) : presets.length === 0 ? (
-            <EmptyState icon={Sparkles} title="No built-in templates available." />
+          ) : templates.length === 0 ? (
+            <EmptyState icon={Sparkles} title="No templates available." />
           ) : (
-            <div className={GRID_CLS}>
-              {presets.map((preset) => (
-                <PresetCard key={preset.preset_id} preset={preset} onUse={setSelected} />
-              ))}
-            </div>
+            <>
+              {/* Built-in section */}
+              {builtin.length > 0 && (
+                <section>
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    内置模板
+                  </h2>
+                  <div className={GRID_CLS}>
+                    {builtin.map((t) => (
+                      <TemplateCard
+                        key={t.id}
+                        template={t}
+                        onUse={setSelectedForUse}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* User templates section */}
+              {user.length > 0 && (
+                <section>
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    我的模板
+                  </h2>
+                  <div className={GRID_CLS}>
+                    {user.map((t) => (
+                      <TemplateCard
+                        key={t.id}
+                        template={t}
+                        onUse={setSelectedForUse}
+                        onEdit={handleEdit}
+                        onDelete={handleDelete}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
           )}
         </div>
       </div>
 
-      {selected && (
+      {/* Dialogs */}
+      <TemplateFormDialog
+        open={formOpen}
+        template={editing}
+        onClose={() => {
+          setFormOpen(false);
+          setEditing(null);
+        }}
+        onSaved={handleFormSaved}
+      />
+
+      {selectedForUse && (
         <CreateFromTemplateDialog
-          preset={selected}
-          onClose={() => setSelected(null)}
-          onCreated={handleCreated}
+          template={selectedForUse}
+          onClose={() => setSelectedForUse(null)}
+          onCreated={handleUseCreated}
         />
       )}
+
+      {confirmDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/features/routine/api.ts
+++ b/apps/negentropy-ui/features/routine/api.ts
@@ -14,6 +14,7 @@ import type {
   RoutineListResponse,
   RoutineIterationDTO,
   RoutinePresetSummary,
+  RoutineTemplateItem,
   RoutineUpdatePayload,
 } from "./types";
 
@@ -131,4 +132,15 @@ export async function createRoutineFromPreset(
   body: RoutineFromPresetPayload,
 ): Promise<RoutineDTO> {
   return jsonFetch("/from-preset", { method: "POST", body: JSON.stringify(body) });
+}
+
+// ---------------------------------------------------------------------------
+// Templates（合并模板列表）
+// ---------------------------------------------------------------------------
+
+export async function fetchTemplates(category?: string): Promise<RoutineTemplateItem[]> {
+  const sp = new URLSearchParams();
+  if (category) sp.set("category", category);
+  const q = sp.toString();
+  return jsonFetch(`/templates${q ? `?${q}` : ""}`);
 }

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -21,6 +21,8 @@ export type {
   RoutineStreamEvent,
   RoutinePresetSummary,
   RoutineFromPresetPayload,
+  TemplateSource,
+  RoutineTemplateItem,
 } from "./types";
 
 export {
@@ -36,6 +38,7 @@ export {
   rejectIteration,
   fetchPresets,
   createRoutineFromPreset,
+  fetchTemplates,
 } from "./api";
 
 export { useRoutineData } from "./hooks/useRoutineData";

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -59,6 +59,8 @@ export interface RoutineDTO {
   agent_id: string | null;
   created_at: string | null;
   updated_at: string | null;
+  /** true 时本行为 Routine Template */
+  is_template: boolean;
   // 仅 detail 端点返回
   iterations?: RoutineIterationDTO[];
 }
@@ -151,6 +153,7 @@ export interface RoutineCreatePayload {
   config?: Record<string, unknown>;
   display_name?: string | null;
   description?: string | null;
+  is_template?: boolean;
 }
 
 /** 更新请求体（全部可选） */
@@ -179,7 +182,41 @@ export interface RoutinePresetSummary {
 
 /** POST /routines/from-preset 请求体 */
 export interface RoutineFromPresetPayload {
-  preset_id: string;
+  preset_id?: string;
+  template_id?: string;
   key: string;
   cwd: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template（合并模板列表）
+// ---------------------------------------------------------------------------
+
+/** 模板来源判别器 */
+export type TemplateSource = "builtin" | "user";
+
+/** GET /routines/templates 返回的统一模板条目（内置 + 用户合并） */
+export interface RoutineTemplateItem {
+  id: string;
+  source: TemplateSource;
+  key: string;
+  display_name: string;
+  description: string;
+  category: string;
+  version: string;
+  features_showcase: string[];
+  title: string;
+  goal: string;
+  acceptance_criteria: string;
+  verification_command: string | null;
+  max_iterations: number | null;
+  max_cost_usd: number | null;
+  success_score_threshold: number;
+  no_progress_patience: number;
+  approval_mode: ApprovalMode;
+  config: Record<string, unknown>;
+  has_verification_command: boolean;
+  owner_id: string | null;
+  created_at: string | null;
+  updated_at: string | null;
 }

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
@@ -56,6 +56,7 @@ function makeRoutine(id: string): RoutineDTO {
     agent_id: null,
     created_at: null,
     updated_at: null,
+    is_template: false,
   };
 }
 

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
@@ -64,6 +64,7 @@ function makeRoutine(id: string, status: RoutineDTO["status"] = "running"): Rout
     agent_id: null,
     created_at: null,
     updated_at: null,
+    is_template: false,
   };
 }
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0050_routine_is_template.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0050_routine_is_template.py
@@ -1,0 +1,75 @@
+"""为 routines 表新增 is_template 列 — 将 Routine 与 Template 统一为同一张表。
+
+Revision ID: 0050
+Revises: 0049
+Create Date: 2026-05-31 00:00:00.000000+00:00
+
+设计动机：
+    将「Routine Template」合并到 ``routines`` 表中，通过 ``is_template = true``
+    标记模板行。模板与普通 Routine 共享相同的数据结构（goal / acceptance_criteria /
+    预算守卫 / config 等），无需独立的模板表，保持数据模型正交简洁。
+
+    使用流程：
+    - 创建模板：POST /routines with is_template=true
+    - 浏览模板：GET /routines?is_template=true（含内置 YAML 预设合并）
+    - 从模板创建 Routine：复制模板字段到新 Routine 行（is_template=false）
+    - 编辑/删除模板：常规 Routine CRUD，限定 is_template=true 过滤
+
+    server_default='false'：对既有行安全回填，所有现有 Routine 保持为非模板。
+
+幂等性：
+    加列前以 information_schema 探测列存在性（仿 0049 范式）。
+
+参考文献：
+[1] 0049_routine_phase_and_pr.py — information_schema 幂等加列范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0050"
+down_revision: str | None = "0049"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :s AND table_name = :t AND column_name = :c"
+            ),
+            {"s": SCHEMA, "t": table_name, "c": column_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if not _column_exists(bind, "routines", "is_template"):
+        op.add_column(
+            "routines",
+            sa.Column(
+                "is_template",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+                comment="true 时本行为 Routine Template，可作为创建 Routine 的模板来源",
+            ),
+            schema=SCHEMA,
+        )
+        op.create_index("ix_routines_is_template", "routines", ["is_template"], schema=SCHEMA)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    if _column_exists(bind, "routines", "is_template"):
+        op.drop_index("ix_routines_is_template", table_name="routines", schema=SCHEMA)
+        op.drop_column("routines", "is_template", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -114,6 +114,7 @@ class RoutineCreateRequest(BaseModel):
     agent_id: UUID | None = None
     display_name: str | None = None
     description: str | None = None
+    is_template: bool = False
 
 
 class RoutineUpdateRequest(BaseModel):
@@ -138,7 +139,8 @@ class ControlBody(BaseModel):
 
 
 class RoutineFromPresetRequest(BaseModel):
-    preset_id: str = Field(..., min_length=1)
+    preset_id: str | None = Field(default=None, min_length=1, description="内置预设 ID")
+    template_id: UUID | None = Field(default=None, description="用户模板 Routine UUID")
     key: str = Field(..., min_length=1, max_length=192)
     cwd: str = Field(..., min_length=1)
 
@@ -180,6 +182,7 @@ def _serialize_routine(r: Routine, *, iterations: list[RoutineIteration] | None 
         "agent_id": str(r.agent_id) if r.agent_id else None,
         "created_at": r.created_at.isoformat() if r.created_at else None,
         "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+        "is_template": r.is_template,
     }
     if iterations is not None:
         data["iterations"] = [_serialize_iteration(it) for it in iterations]
@@ -273,31 +276,157 @@ async def list_routine_presets() -> list[dict[str, Any]]:
     ]
 
 
-@router.post("/from-preset", status_code=201)
-async def create_routine_from_preset(body: RoutineFromPresetRequest) -> dict[str, Any]:
-    """从内置预设创建 Routine。用户提供 key + cwd，其余字段由预设填充。"""
+@router.get("/templates")
+async def list_templates(
+    category: str | None = Query(None, description="按 category 筛选"),
+) -> list[dict[str, Any]]:
+    """合并模板列表：内置 YAML 预设（source=builtin）+ 用户自建模板（source=user）。
+
+    返回统一结构，前端区分 source 决定是否允许编辑/删除。
+    """
+    # ── 1. 内置 YAML 预设 → 统一结构 ──
     from negentropy.agents.routine_presets import load_all
 
-    presets = {p.preset_id: p for p in load_all()}
-    preset = presets.get(body.preset_id)
-    if preset is None:
-        raise HTTPException(status_code=404, detail=f"Preset '{body.preset_id}' not found")
+    builtin: list[dict[str, Any]] = []
+    for p in load_all():
+        if category and p.category != category:
+            continue
+        builtin.append(
+            {
+                "id": f"builtin:{p.preset_id}",
+                "source": "builtin",
+                "key": p.preset_id,
+                "display_name": p.display_name,
+                "description": p.description,
+                "category": p.category,
+                "version": p.version,
+                "features_showcase": p.features_showcase,
+                "title": p.title,
+                "goal": p.goal,
+                "acceptance_criteria": p.acceptance_criteria,
+                "verification_command": p.verification_command,
+                "max_iterations": p.max_iterations,
+                "max_cost_usd": p.max_cost_usd,
+                "success_score_threshold": p.success_score_threshold,
+                "no_progress_patience": p.no_progress_patience,
+                "approval_mode": p.approval_mode,
+                "config": p.config or {},
+                "has_verification_command": p.verification_command is not None,
+                "owner_id": None,
+                "created_at": None,
+                "updated_at": None,
+            }
+        )
+
+    # ── 2. 用户模板（is_template=true 的 Routine 行）→ 统一结构 ──
+    user_templates: list[dict[str, Any]] = []
+    async with db_session.AsyncSessionLocal() as db:
+        stmt = select(Routine).where(Routine.is_template.is_(True)).order_by(Routine.created_at.desc())
+        rows = (await db.execute(stmt)).scalars().all()
+        for r in rows:
+            if category and (r.description or "") != category:
+                # category 存储在 description 字段的 category 信息中不直接可用
+                # Routine 模型没有 category 字段，通过 config.category 或直接不过滤
+                pass
+            user_templates.append(
+                {
+                    "id": str(r.id),
+                    "source": "user",
+                    "key": r.key,
+                    "display_name": r.display_name or r.title,
+                    "description": r.description or "",
+                    "category": (r.config or {}).get("category", "general"),
+                    "version": (r.config or {}).get("version", "1.0.0"),
+                    "features_showcase": (r.config or {}).get("features_showcase", []),
+                    "title": r.title,
+                    "goal": r.goal,
+                    "acceptance_criteria": r.acceptance_criteria,
+                    "verification_command": r.verification_command,
+                    "max_iterations": r.max_iterations,
+                    "max_cost_usd": r.max_cost_usd,
+                    "success_score_threshold": r.success_score_threshold,
+                    "no_progress_patience": r.no_progress_patience,
+                    "approval_mode": r.approval_mode,
+                    "config": r.config or {},
+                    "has_verification_command": r.verification_command is not None,
+                    "owner_id": r.owner_id,
+                    "created_at": r.created_at.isoformat() if r.created_at else None,
+                    "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+                }
+            )
+
+    # ── 3. 合并 + 排序 ──
+    merged = builtin + user_templates
+    merged.sort(key=lambda t: (t.get("category", ""), t.get("display_name", "")))
+
+    # 后置 category 过滤（已在内置和用户分别过滤的基础上统一再筛一次）
+    if category:
+        merged = [t for t in merged if t.get("category") == category]
+
+    return merged
+
+
+@router.post("/from-preset", status_code=201)
+async def create_routine_from_preset(body: RoutineFromPresetRequest) -> dict[str, Any]:
+    """从内置预设或用户模板创建 Routine。用户提供 key + cwd，其余字段由来源填充。
+
+    支持两种来源（互斥）：
+    - preset_id：从内置 YAML 预设创建
+    - template_id：从用户自建模板（is_template=true 的 Routine 行）创建
+    """
+    if body.preset_id and body.template_id:
+        raise HTTPException(status_code=400, detail="preset_id and template_id are mutually exclusive")
+    if not body.preset_id and not body.template_id:
+        raise HTTPException(status_code=400, detail="either preset_id or template_id is required")
+
+    # ── 来源 1：内置 YAML 预设 ──
+    if body.preset_id:
+        from negentropy.agents.routine_presets import load_all
+
+        presets = {p.preset_id: p for p in load_all()}
+        preset = presets.get(body.preset_id)
+        if preset is None:
+            raise HTTPException(status_code=404, detail=f"Preset '{body.preset_id}' not found")
+
+        create_req = RoutineCreateRequest(
+            key=body.key,
+            title=preset.title,
+            goal=preset.goal,
+            acceptance_criteria=preset.acceptance_criteria,
+            cwd=body.cwd,
+            verification_command=preset.verification_command,
+            max_iterations=preset.max_iterations,
+            max_cost_usd=preset.max_cost_usd,
+            success_score_threshold=preset.success_score_threshold,
+            no_progress_patience=preset.no_progress_patience,
+            approval_mode=preset.approval_mode,
+            config=preset.config or {},
+            display_name=preset.display_name,
+            description=preset.description,
+        )
+        return await create_routine(create_req)
+
+    # ── 来源 2：用户模板 Routine ──
+    async with db_session.AsyncSessionLocal() as db:
+        tmpl = await db.get(Routine, body.template_id)
+        if tmpl is None or not tmpl.is_template:
+            raise HTTPException(status_code=404, detail=f"Template '{body.template_id}' not found")
 
     create_req = RoutineCreateRequest(
         key=body.key,
-        title=preset.title,
-        goal=preset.goal,
-        acceptance_criteria=preset.acceptance_criteria,
+        title=tmpl.title,
+        goal=tmpl.goal,
+        acceptance_criteria=tmpl.acceptance_criteria,
         cwd=body.cwd,
-        verification_command=preset.verification_command,
-        max_iterations=preset.max_iterations,
-        max_cost_usd=preset.max_cost_usd,
-        success_score_threshold=preset.success_score_threshold,
-        no_progress_patience=preset.no_progress_patience,
-        approval_mode=preset.approval_mode,
-        config=preset.config or {},
-        display_name=preset.display_name,
-        description=preset.description,
+        verification_command=tmpl.verification_command,
+        max_iterations=tmpl.max_iterations,
+        max_cost_usd=tmpl.max_cost_usd,
+        success_score_threshold=tmpl.success_score_threshold,
+        no_progress_patience=tmpl.no_progress_patience,
+        approval_mode=tmpl.approval_mode,
+        config=(tmpl.config or {}),
+        display_name=tmpl.display_name,
+        description=tmpl.description,
     )
     return await create_routine(create_req)
 
@@ -369,6 +498,7 @@ async def list_routines(
     status: str | None = Query(None),
     owner_id: str | None = Query(None),
     q: str | None = Query(None, description="按 key / title 模糊搜索"),
+    is_template: bool | None = Query(None, description="过滤模板行"),
     limit: int = Query(50, ge=1, le=200),
     cursor: str | None = Query(None, description="上一页末尾 updated_at ISO 串"),
 ) -> dict[str, Any]:
@@ -379,6 +509,8 @@ async def list_routines(
             stmt = stmt.where(Routine.status == status)
         if owner_id:
             stmt = stmt.where(Routine.owner_id == owner_id)
+        if is_template is not None:
+            stmt = stmt.where(Routine.is_template == is_template)
         if q:
             like = f"%{q}%"
             stmt = stmt.where((Routine.key.ilike(like)) | (Routine.title.ilike(like)))
@@ -490,6 +622,7 @@ async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
             agent_id=body.agent_id,
             display_name=body.display_name,
             description=body.description,
+            is_template=body.is_template,
         )
         db.add(routine)
         try:

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -324,10 +324,8 @@ async def list_templates(
         stmt = select(Routine).where(Routine.is_template.is_(True)).order_by(Routine.created_at.desc())
         rows = (await db.execute(stmt)).scalars().all()
         for r in rows:
-            if category and (r.description or "") != category:
-                # category 存储在 description 字段的 category 信息中不直接可用
-                # Routine 模型没有 category 字段，通过 config.category 或直接不过滤
-                pass
+            if category and (r.config or {}).get("category", "general") != category:
+                continue
             user_templates.append(
                 {
                     "id": str(r.id),

--- a/apps/negentropy/src/negentropy/models/routine.py
+++ b/apps/negentropy/src/negentropy/models/routine.py
@@ -27,6 +27,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     Float,
     ForeignKey,
@@ -132,6 +133,15 @@ class Routine(Base, UUIDMixin, TimestampMixin):
     reflections: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
     config: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")
 
+    # --- 模板标记 ---
+    is_template: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+        comment="true 时本行为 Routine Template，可作为创建 Routine 的模板来源",
+    )
+
     iterations: Mapped[list[RoutineIteration]] = relationship(
         back_populates="routine",
         cascade="all, delete-orphan",
@@ -141,6 +151,7 @@ class Routine(Base, UUIDMixin, TimestampMixin):
     __table_args__ = (
         Index("ix_routines_status", "status"),
         Index("ix_routines_owner", "owner_id"),
+        Index("ix_routines_is_template", "is_template"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：将 Routine 模板从"仅内置 YAML 预设"扩展为"内置预设 + 用户自建模板"的统一 CRUD 体系，用户可在 UI 上创建、编辑、删除自定义模板，并从任意模板快速创建 Routine。
- 关联上下文/Issue/文档：前序 PR #775（预设模板升级为独立子页面）、#773（Routine 执行层修复）

# 核心变更
- **数据模型**：Routine 表新增 `is_template` 布尔列（`server_default=false`，幂等迁移 0050），模板与普通 Routine 共享同一张表，通过标记区分。
- **后端 API**：
  - `GET /routines/templates`：合并返回内置 YAML 预设（`source=builtin`）与用户模板（`source=user`），支持 `category` 筛选。
  - `POST /routines/from-preset`：扩展支持 `template_id`（用户模板）与 `preset_id`（内置预设）互斥二选一。
  - `GET /routines`：新增 `is_template` 查询参数过滤。
  - `POST /routines`：支持 `is_template=true` 创建模板行。
- **前端 UI**：
  - `templates/page.tsx`：升级为完整 CRUD 页面，内置模板与用户模板分组展示，支持新建、编辑、删除。
  - `TemplateCard.tsx`：统一卡片组件，内置模板只读、用户模板带编辑/删除操作。
  - `TemplateFormDialog.tsx`：模板创建/编辑表单对话框，暴露 goal、acceptance_criteria、预算守卫等模板语义字段。
  - `CreateFromTemplateDialog.tsx`：适配 `source` 分支，内置走 `preset_id`、用户走 `template_id`。
- **类型与 API 层**：`types.ts` 新增 `RoutineTemplateItem`、`TemplateSource`；`api.ts` 新增 `fetchTemplates()`；统一导出。

# 风险与回滚
- 主要风险：`is_template` 列默认 `false`，对既有 Routine 数据无影响；迁移幂等（information_schema 探测）。
- 回滚方式：Alembic downgrade 0050（删列 + 删索引）；前端回退到 PresetCard + fetchPresets 旧路径。

# 验证证据
- 单元测试：暂无新增（CRUD 走已有 Routine API 路径）。
- 集成测试：手动验证创建/编辑/删除模板 + 从模板创建 Routine 全流程。
- E2E/Workflow：Pre-commit hooks 全部通过（ruff lint/format、ESLint）。
- 覆盖率/关键截图：无。

# 影响范围
- 前端：`apps/negentropy-ui/` — templates 页面重构、新增 TemplateCard/TemplateFormDialog 组件、types/api 导出更新。
- 后端：`apps/negentropy/` — Routine 模型加列、routine_api 新增端点、Alembic 迁移 0050。
- GitHub Actions / 文档：无影响。

# Next Best Action
- 为模板 CRUD 端点补充集成测试覆盖。
- 考虑模板分享机制（跨 owner 可见性）。
- 前端增加模板详情查看（drawer/sheet）交互。