### PR TITLE
feat(wiki-header): 用户头像移至主题切换右侧并添加点击式下拉菜单

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -15,6 +15,7 @@ import { WikiSidebar } from "@/components/WikiSidebar";
 import { WikiToc } from "@/components/WikiToc";
 import { WikiSearchBox } from "@/components/WikiSearchBox";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
+import { WikiUserMenu } from "@/components/WikiUserMenu";
 import { extractHeadings } from "@/lib/markdown-headings";
 import { buildBreadcrumbPath } from "@/lib/wiki-api";
 import { MarkdownRenderer } from "@/components/markdown/MarkdownRenderer";
@@ -159,6 +160,7 @@ export default async function WikiEntryPage({ params }: Props) {
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
+      userMenu={<WikiUserMenu />}
       graphTab={{ active: false, show: hasAnyEntry }}
     />
   );

--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -4,6 +4,7 @@ import { ThemePreference } from "@/components/ThemePreference";
 import { WikiGraphRenderer } from "@/components/WikiGraphRenderer";
 import { WikiHeader } from "@/components/WikiHeader";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
+import { WikiUserMenu } from "@/components/WikiUserMenu";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import {
   countLeafEntries,
@@ -84,6 +85,7 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
+      userMenu={<WikiUserMenu />}
       graphTab={{ active: true, show: entriesTotal > 0 }}
     />
   );

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -13,6 +13,7 @@ import { ThemePreference } from "@/components/ThemePreference";
 import { WikiSidebar } from "@/components/WikiSidebar";
 import { WikiSearchBox } from "@/components/WikiSearchBox";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
+import { WikiUserMenu } from "@/components/WikiUserMenu";
 import Link from "next/link";
 import { WikiFooter } from "@/components/home/WikiFooter";
 
@@ -92,6 +93,7 @@ export default async function WikiPublicationPage({ params }: Props) {
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
+      userMenu={<WikiUserMenu />}
       graphTab={{ active: false, show: entriesTotal > 0 }}
     />
   );

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -11,6 +11,7 @@ import { WikiHeader } from "@/components/WikiHeader";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import { ThemePreference } from "@/components/ThemePreference";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
+import { WikiUserMenu } from "@/components/WikiUserMenu";
 import { HomeCard } from "@/components/home/HomeCard";
 import { GalaxyHeroMount } from "@/components/home/GalaxyHeroMount";
 import { WikiFooter } from "@/components/home/WikiFooter";
@@ -91,6 +92,7 @@ export default async function WikiHomePage() {
       homeLinks={homeLinks}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
+      userMenu={<WikiUserMenu />}
       pubSlug={firstPubSlug}
       graphTab={
         firstPubSlug

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -33,6 +33,7 @@ interface WikiHeaderProps {
   graphTab?: WikiHeaderGraphTab;
   searchBox?: React.ReactNode;
   actions?: React.ReactNode;
+  userMenu?: React.ReactNode;
   homeLinks?: HomeLink[];
 }
 
@@ -44,6 +45,7 @@ export function WikiHeader({
   graphTab,
   searchBox,
   actions,
+  userMenu,
   homeLinks,
 }: WikiHeaderProps) {
   if (!items.length && !homeLinks?.length && !(graphTab?.show)) return null;
@@ -98,6 +100,7 @@ export function WikiHeader({
           {searchBox}
           {actions}
           {headerSlot}
+          {userMenu}
         </div>
       </div>
     </header>

--- a/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeaderActions.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useWikiAuth } from "@/lib/auth/wiki-auth";
-
+/**
+ * Wiki 头部右侧操作区 — GitHub 仓库链接
+ *
+ * 用户菜单（登录/登出）已迁至 WikiUserMenu 组件。
+ */
 export function WikiHeaderActions() {
-  const { status, user, login } = useWikiAuth();
-
   return (
     <div className="wiki-header-actions">
       {/* GitHub */}
@@ -25,52 +26,6 @@ export function WikiHeaderActions() {
           <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
         </svg>
       </a>
-
-      {/* Auth zone: avatar (authenticated) / login icon (unauthenticated) */}
-      {status === "authenticated" && user ? (
-        <button
-          type="button"
-          className="wiki-header-action-btn wiki-header-avatar"
-          title={user.name || user.email || "用户"}
-          aria-label={user.name || "用户"}
-        >
-          {user.picture ? (
-            <img
-              src={user.picture}
-              alt=""
-              width={24}
-              height={24}
-              className="wiki-header-avatar-img"
-            />
-          ) : (
-            <span className="wiki-header-avatar-initials">
-              {(user.name || user.email || "?").charAt(0).toUpperCase()}
-            </span>
-          )}
-        </button>
-      ) : status === "unauthenticated" ? (
-        <button
-          type="button"
-          className="wiki-header-action-btn"
-          onClick={login}
-          title="登录"
-          aria-label="登录"
-        >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-            <circle cx="12" cy="7" r="4" />
-          </svg>
-        </button>
-      ) : null}
     </div>
   );
 }

--- a/apps/negentropy-wiki/src/components/WikiUserMenu.tsx
+++ b/apps/negentropy-wiki/src/components/WikiUserMenu.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useWikiAuth } from "@/lib/auth/wiki-auth";
+
+/**
+ * Wiki 头部用户菜单 — 点击式下拉
+ *
+ * - 已登录：头像按钮 → 下拉面板（用户信息 + 退出登录）
+ * - 未登录：用户图标按钮 → 下拉面板（登录入口）
+ * - loading：不渲染
+ */
+export function WikiUserMenu() {
+  const { status, user, login, logout } = useWikiAuth();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // 点击外部关闭
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Escape 关闭
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  const handleToggle = useCallback(() => setOpen((prev) => !prev), []);
+  const handleClose = useCallback(() => setOpen(false), []);
+
+  const handleLogout = useCallback(async () => {
+    setOpen(false);
+    await logout();
+  }, [logout]);
+
+  const handleLogin = useCallback(() => {
+    setOpen(false);
+    login();
+  }, [login]);
+
+  if (status === "loading") return null;
+
+  const displayName = user?.name || user?.email || "用户";
+
+  return (
+    <div className="wiki-user-menu" ref={menuRef}>
+      <button
+        type="button"
+        className="wiki-header-action-btn wiki-user-menu-trigger"
+        onClick={handleToggle}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={status === "authenticated" ? displayName : "用户菜单"}
+        title={status === "authenticated" ? displayName : "登录"}
+      >
+        {status === "authenticated" && user ? (
+          user.picture ? (
+            <img
+              src={user.picture}
+              alt=""
+              width={24}
+              height={24}
+              className="wiki-header-avatar-img"
+            />
+          ) : (
+            <span className="wiki-header-avatar-initials">
+              {displayName.charAt(0).toUpperCase()}
+            </span>
+          )
+        ) : (
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div className="wiki-user-menu-panel" role="menu">
+          {status === "authenticated" && user ? (
+            <>
+              <div className="wiki-user-menu-header">
+                <span className="wiki-user-menu-name">{user.name || "用户"}</span>
+                {user.email && (
+                  <span className="wiki-user-menu-email">{user.email}</span>
+                )}
+              </div>
+              <div className="wiki-user-menu-separator" />
+              <button
+                type="button"
+                className="wiki-user-menu-item"
+                role="menuitem"
+                onClick={handleLogout}
+              >
+                退出登录
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              className="wiki-user-menu-item"
+              role="menuitem"
+              onClick={handleLogin}
+            >
+              登录
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-wiki/src/components/WikiUserMenu.tsx
+++ b/apps/negentropy-wiki/src/components/WikiUserMenu.tsx
@@ -39,7 +39,6 @@ export function WikiUserMenu() {
   }, [open]);
 
   const handleToggle = useCallback(() => setOpen((prev) => !prev), []);
-  const handleClose = useCallback(() => setOpen(false), []);
 
   const handleLogout = useCallback(async () => {
     setOpen(false);

--- a/apps/negentropy-wiki/src/styles/components/header.css
+++ b/apps/negentropy-wiki/src/styles/components/header.css
@@ -270,7 +270,7 @@
   color: var(--wiki-text);
 }
 
-/* User avatar */
+/* User avatar — shared by WikiHeaderActions & WikiUserMenu */
 .wiki-header-avatar {
   padding: 0;
   overflow: hidden;
@@ -294,6 +294,92 @@
   font-size: 0.75em;
   font-weight: 600;
   line-height: 1;
+}
+
+/* ---- User menu (click-based dropdown) ---- */
+.wiki-user-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.wiki-user-menu-trigger {
+  padding: 0;
+  overflow: hidden;
+}
+
+.wiki-user-menu-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 50;
+  min-width: 180px;
+  padding: 0.5rem 0;
+  background: var(--wiki-bg);
+  border: 1px solid var(--wiki-border);
+  border-radius: 8px;
+  box-shadow: 0 5px 40px 0 rgba(0, 0, 0, 0.15);
+  animation: wiki-user-menu-in 0.15s ease;
+}
+
+@keyframes wiki-user-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.wiki-user-menu-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.5rem 0.85rem;
+}
+
+.wiki-user-menu-name {
+  font-size: 0.88em;
+  font-weight: 600;
+  color: var(--wiki-text);
+  line-height: 1.3;
+}
+
+.wiki-user-menu-email {
+  font-size: 0.78em;
+  color: var(--wiki-text-secondary);
+  line-height: 1.3;
+  word-break: break-all;
+}
+
+.wiki-user-menu-separator {
+  height: 1px;
+  margin: 0.35rem 0;
+  background: var(--wiki-border);
+}
+
+.wiki-user-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.88em;
+  color: var(--wiki-text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.wiki-user-menu-item:hover {
+  background: var(--wiki-primary-light);
+  color: var(--wiki-accent);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 头部用户头像原本嵌在 WikiHeaderActions 内，与 GitHub 链接混在一起，缺乏独立的用户菜单交互能力（无法查看用户信息、退出登录）
- 关联上下文/Issue/文档：无

# 核心变更
- 将用户头像/登录按钮从 `WikiHeaderActions` 抽取为独立的 `WikiUserMenu` 组件
- `WikiHeader` 新增 `userMenu` prop，将用户菜单渲染至主题切换右侧
- `WikiUserMenu` 实现点击式下拉面板：已登录显示用户名+邮箱+退出登录，未登录显示登录入口
- 下拉面板支持点击外部关闭、Escape 键关闭，带入场动画
- 配套新增 `header.css` 中的下拉菜单样式

# 风险与回滚
- 主要风险：低。变更仅涉及前端 UI 组件拆分，无后端/数据层影响
- 回滚方式：`git revert` 本分支所有提交

# 验证证据
- 单元测试：无（纯 UI 展示组件）
- 集成测试：无
- E2E/Workflow：通过 ESLint (next lint) 检查
- 覆盖率/关键截图：无

# 影响范围
- 前端：`negentropy-wiki` — WikiHeader、WikiHeaderActions（精简）、新增 WikiUserMenu、4 个页面路由接入
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 建议浏览器实机验证下拉菜单在明暗主题下的视觉效果与交互行为