### PR TITLE
feat(routine-template): 模板库 UI/UX 重构 — 简约、直观、专业

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/InlineCreateFromTemplate.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/InlineCreateFromTemplate.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { createRoutineFromPreset } from "@/features/routine";
+import type { RoutineDTO, RoutineTemplateItem } from "@/features/routine";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+interface InlineCreateFromTemplateProps {
+  template: RoutineTemplateItem;
+  onClose: () => void;
+  /** 创建成功回调 */
+  onCreated: (created: RoutineDTO) => void;
+}
+
+/**
+ * 内联创建栏 — 在卡片下方展开，替代模态弹窗。
+ *
+ * 用户仅需提供工作目录，Key 自动生成。
+ * 按 source 分支发送 preset_id 或 template_id。
+ */
+export function InlineCreateFromTemplate({
+  template,
+  onClose,
+  onCreated,
+}: InlineCreateFromTemplateProps) {
+  const [cwd, setCwd] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const key = `${template.key}-${crypto.randomUUID().slice(0, 4)}`;
+
+  const inputCls =
+    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+  const handleCreate = async () => {
+    if (!cwd.trim()) {
+      setFieldError("工作目录为必填项");
+      return;
+    }
+    setCreating(true);
+    setFieldError(null);
+    try {
+      const payload =
+        template.source === "builtin"
+          ? { preset_id: template.key, key, cwd: cwd.trim() }
+          : { template_id: template.id, key, cwd: cwd.trim() };
+      const created = await createRoutineFromPreset(payload);
+      toast.success(`已基于「${template.display_name}」创建 Routine`);
+      onCreated(created);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "创建失败");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="animate-enter rounded-card border border-t-0 border-border bg-card p-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <label className="mb-1 block text-[10px] font-medium text-text-muted">
+            Key（自动生成）
+          </label>
+          <input type="text" value={key} disabled className={cn(inputCls, "text-text-muted")} />
+        </div>
+        <div className="flex-[2]">
+          <label className="mb-1 block text-[10px] font-medium text-text-muted">
+            工作目录 <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={cwd}
+            onChange={(e) => {
+              setCwd(e.target.value);
+              if (fieldError) setFieldError(null);
+            }}
+            placeholder="/path/to/project"
+            className={cn(inputCls, fieldError && !cwd.trim() && "border-red-400")}
+          />
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={creating}>
+            取消
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            loading={creating}
+            disabled={!cwd.trim()}
+            onClick={handleCreate}
+          >
+            创建并跳转 →
+          </Button>
+        </div>
+      </div>
+      {fieldError && (
+        <p className="mt-1 text-[10px] text-red-500">{fieldError}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/InlineCreateFromTemplate.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/InlineCreateFromTemplate.tsx
@@ -29,7 +29,7 @@ export function InlineCreateFromTemplate({
   const [creating, setCreating] = useState(false);
   const [fieldError, setFieldError] = useState<string | null>(null);
 
-  const key = `${template.key}-${crypto.randomUUID().slice(0, 4)}`;
+  const [key] = useState(() => `${template.key}-${crypto.randomUUID().slice(0, 4)}`);
 
   const inputCls =
     "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Trash2, ShieldCheck } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import type { RoutineTemplateItem } from "@/features/routine";
@@ -8,106 +8,134 @@ import { APPROVAL_BADGE } from "./preset-style";
 
 interface TemplateCardProps {
   template: RoutineTemplateItem;
-  /** 点击「使用模板」CTA */
+  /** 点击卡片主体 → 打开详情抽屉 */
+  onDetail?: (template: RoutineTemplateItem) => void;
+  /** 点击「使用此模板」CTA */
   onUse: (template: RoutineTemplateItem) => void;
   /** 点击编辑（仅 source=user） */
   onEdit?: (template: RoutineTemplateItem) => void;
   /** 点击删除（仅 source=user） */
   onDelete?: (template: RoutineTemplateItem) => void;
-  /** 点击卡片主体（查看详情） */
-  onClick?: (template: RoutineTemplateItem) => void;
 }
 
 /**
  * 统一模板卡片 — 内置预设 + 用户模板共用。
  *
  * 设计：
- * - 内置模板（source=builtin）：只读，仅 "使用模板" 按钮
- * - 用户模板（source=user）：可编辑/删除，右上角 "Custom" 徽标
- * - 卡片主体可点击查看详情（onClick），底部 CTA 独立
+ * - 顶部：category 标签（浏览维度）+ 来源标识
+ * - 主体：名称 + version 后缀 + 描述
+ * - 底部元数据：审批模式 pill + 验证盾牌图标
+ * - CTA：「使用此模板」
+ * - 悬停：用户模板右上角显示编辑/删除图标
  * - `h-full flex flex-col` 保证同行等高；CTA `mt-auto` 钉底
  */
-export function TemplateCard({ template, onUse, onEdit, onDelete, onClick }: TemplateCardProps) {
+export function TemplateCard({ template, onDetail, onUse, onEdit, onDelete }: TemplateCardProps) {
   const isUser = template.source === "user";
   const badge = APPROVAL_BADGE[template.approval_mode];
 
   return (
-    <div className="group relative flex h-full flex-col rounded-card border border-border bg-card p-4 transition-colors hover:border-foreground/15">
-      {/* 用户模板标记 */}
+    <div className="group relative flex h-full flex-col rounded-card border border-border bg-card p-4 transition-all hover:border-foreground/15 hover:shadow-md">
+      {/* 用户模板悬停操作（右上角叠加） */}
       {isUser && (
-        <span className="absolute right-3 top-3 rounded-full bg-indigo-100 px-1.5 py-0.5 text-micro font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
-          Custom
-        </span>
+        <div className="absolute right-2 top-2 z-10 flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+          {onEdit && (
+            <Button
+              iconOnly
+              size="sm"
+              variant="ghost"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(template);
+              }}
+              aria-label="编辑模板"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </Button>
+          )}
+          {onDelete && (
+            <Button
+              iconOnly
+              size="sm"
+              variant="ghost"
+              className="text-text-muted hover:text-red-500"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(template);
+              }}
+              aria-label="删除模板"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
       )}
 
       {/* 可点击主体 */}
       <button
         type="button"
         className="cursor-pointer space-y-2 text-left"
-        onClick={() => onClick?.(template)}
+        onClick={() => onDetail?.(template)}
       >
-        <div className="flex flex-wrap items-center gap-2 pr-14">
-          <h3 className="text-sm font-semibold text-foreground">{template.display_name}</h3>
-          <span className="rounded-full bg-muted px-1.5 py-0.5 text-micro text-text-secondary">
-            v{template.version}
-          </span>
-          <span className="rounded-full bg-purple-100 px-1.5 py-0.5 text-micro text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+        {/* 顶行：category + 来源标识 */}
+        <div className="flex items-center justify-between">
+          <span className="text-micro font-medium uppercase tracking-wider text-text-muted">
             {template.category}
           </span>
-          {badge && (
-            <span className={`rounded-full px-1.5 py-0.5 text-micro ${badge.cls}`}>{badge.label}</span>
+          {isUser ? (
+            <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-micro font-medium text-primary">
+              自建
+            </span>
+          ) : (
+            <span className="rounded-full bg-muted px-1.5 py-0.5 text-micro font-medium text-text-secondary">
+              内置
+            </span>
           )}
-          <span className="rounded-full bg-muted px-1.5 py-0.5 text-micro text-text-secondary">
-            Gate: {template.has_verification_command ? "✓" : "✗"}
-          </span>
         </div>
 
-        <p className="text-xs text-text-muted line-clamp-2">{template.description}</p>
+        {/* 名称 + version 后缀 */}
+        <div>
+          <h3 className="text-body-lg font-semibold text-foreground">
+            {template.display_name}
+            <span className="ml-1.5 text-micro font-normal text-text-muted">
+              v{template.version}
+            </span>
+          </h3>
+        </div>
 
-        {template.features_showcase.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {template.features_showcase.slice(0, 3).map((f, i) => (
-              <span key={i} className="rounded bg-muted px-1.5 py-0.5 text-micro text-text-secondary">
-                {f}
-              </span>
-            ))}
-            {template.features_showcase.length > 3 && (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-micro text-text-muted">
-                +{template.features_showcase.length - 3}
-              </span>
-            )}
-          </div>
-        )}
+        {/* 描述 */}
+        <p className="text-xs leading-relaxed text-text-muted line-clamp-2">
+          {template.description}
+        </p>
       </button>
 
-      {/* 底部操作区 */}
+      {/* 底部：元数据 + CTA */}
       <div className="mt-auto flex items-center gap-2 pt-3">
-        <Button variant="neutral" size="sm" className="flex-1" onClick={() => onUse(template)}>
-          使用模板
+        {/* 元数据区 */}
+        <div className="flex flex-1 flex-wrap items-center gap-1.5">
+          {badge && (
+            <span className={`rounded-full px-1.5 py-0.5 text-micro ${badge.cls}`}>
+              {badge.label}
+            </span>
+          )}
+          {template.has_verification_command && (
+            <span className="flex items-center gap-0.5 text-micro text-emerald-600 dark:text-emerald-400">
+              <ShieldCheck className="h-3 w-3" />
+              验证门控
+            </span>
+          )}
+        </div>
+
+        {/* 主 CTA */}
+        <Button
+          variant="neutral"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUse(template);
+          }}
+        >
+          使用此模板
         </Button>
-        {isUser && onEdit && (
-          <Button
-            iconOnly
-            size="sm"
-            variant="ghost"
-            onClick={() => onEdit(template)}
-            aria-label="编辑模板"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </Button>
-        )}
-        {isUser && onDelete && (
-          <Button
-            iconOnly
-            size="sm"
-            variant="ghost"
-            className="text-text-muted hover:text-red-500"
-            onClick={() => onDelete(template)}
-            aria-label="删除模板"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateDetailDrawer.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import type { RoutineTemplateItem } from "@/features/routine";
+import { APPROVAL_BADGE } from "./preset-style";
+
+interface TemplateDetailDrawerProps {
+  template: RoutineTemplateItem;
+  onClose: () => void;
+  /** 点击「使用此模板」CTA */
+  onUse: (template: RoutineTemplateItem) => void;
+  /** 点击编辑（仅 source=user） */
+  onEdit?: (template: RoutineTemplateItem) => void;
+  /** 点击删除（仅 source=user） */
+  onDelete?: (template: RoutineTemplateItem) => void;
+}
+
+function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between py-1.5 text-xs">
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className="ml-4 break-all text-right text-foreground">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * 模板详情侧滑抽屉。
+ *
+ * 复用 RoutineDetailDrawer 的 translateX 滑入模式。
+ * 展示模板完整配置：目标、验收标准、预算、审批模式、验证命令、特性。
+ * Footer 含「使用此模板」主 CTA + 编辑/删除（仅用户模板）。
+ */
+export function TemplateDetailDrawer({
+  template,
+  onClose,
+  onUse,
+  onEdit,
+  onDelete,
+}: TemplateDetailDrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const isUser = template.source === "user";
+  const badge = APPROVAL_BADGE[template.approval_mode];
+
+  // Escape 关闭
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  // 滑入动画
+  useEffect(() => {
+    const el = panelRef.current;
+    if (!el) return;
+    el.style.transform = "translateX(100%)";
+    requestAnimationFrame(() => {
+      el.style.transition = "transform 200ms ease-out";
+      el.style.transform = "translateX(0)";
+    });
+  }, []);
+
+  return (
+    <>
+      {/* 遮罩层 */}
+      <div className="fixed inset-0 z-40 bg-overlay" onClick={onClose} />
+
+      {/* 侧滑面板 */}
+      <div
+        ref={panelRef}
+        className="fixed inset-y-0 right-0 z-50 flex w-[460px] max-w-[92vw] flex-col border-l border-border bg-card shadow-xl"
+        style={{ transform: "translateX(100%)" }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-sm font-bold text-foreground">{template.display_name}</h2>
+              {isUser ? (
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+                  自建
+                </span>
+              ) : (
+                <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold text-text-secondary">
+                  内置
+                </span>
+              )}
+            </div>
+            <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
+              <span>{template.key}</span>
+              <span className="text-border">|</span>
+              <span>{template.category}</span>
+              <span className="text-border">|</span>
+              <span>v{template.version}</span>
+              {badge && (
+                <>
+                  <span className="text-border">|</span>
+                  <span className={`rounded-full px-1.5 py-px text-[9px] ${badge.cls}`}>
+                    {badge.label}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="关闭详情"
+            className="cursor-pointer rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 space-y-5 overflow-auto px-5 py-4">
+          {/* 描述 */}
+          {template.description && (
+            <section>
+              <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                描述
+              </h3>
+              <p className="whitespace-pre-wrap break-words text-xs text-text-secondary">
+                {template.description}
+              </p>
+            </section>
+          )}
+
+          {/* 目标 */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+              执行目标
+            </h3>
+            <p className="whitespace-pre-wrap break-words rounded-lg border border-border p-3 text-xs text-foreground">
+              {template.goal}
+            </p>
+          </section>
+
+          {/* 验收标准 */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+              验收标准
+            </h3>
+            <p className="whitespace-pre-wrap break-words rounded-lg border border-border p-3 text-xs text-text-secondary">
+              {template.acceptance_criteria}
+            </p>
+          </section>
+
+          {/* 配置 */}
+          <section>
+            <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+              配置
+            </h3>
+            <div className="rounded-lg border border-border p-3">
+              <DetailField label="最大迭代">
+                {template.max_iterations ?? "∞"}
+              </DetailField>
+              <DetailField label="预算上限">
+                {template.max_cost_usd != null ? `$${template.max_cost_usd}` : "∞"}
+              </DetailField>
+              <DetailField label="成功阈值">
+                {template.success_score_threshold}
+              </DetailField>
+              <DetailField label="无进展上限">
+                {template.no_progress_patience}
+              </DetailField>
+              <DetailField label="审批模式">
+                {badge?.label ?? template.approval_mode}
+              </DetailField>
+              {template.verification_command && (
+                <DetailField label="验证命令">
+                  <code className="text-[10px]">{template.verification_command}</code>
+                </DetailField>
+              )}
+            </div>
+          </section>
+
+          {/* 特性 */}
+          {template.features_showcase.length > 0 && (
+            <section>
+              <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                特性
+              </h3>
+              <div className="flex flex-wrap gap-1.5">
+                {template.features_showcase.map((f, i) => (
+                  <span
+                    key={i}
+                    className="rounded-full bg-muted px-2.5 py-1 text-xs text-text-secondary"
+                  >
+                    {f}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center gap-2 border-t border-border px-5 py-3">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => onUse(template)}
+          >
+            使用此模板
+          </Button>
+          {isUser && onEdit && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onEdit(template)}
+              aria-label="编辑模板"
+            >
+              <Pencil className="mr-1 h-3.5 w-3.5" />
+              编辑
+            </Button>
+          )}
+          {isUser && onDelete && (
+            <button
+              onClick={() => onDelete(template)}
+              className="cursor-pointer rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-500/10 dark:border-red-800 dark:text-red-400"
+            >
+              <Trash2 className="mr-1 inline h-3 w-3 align-[-2px]" />
+              删除
+            </button>
+          )}
+          <div className="flex-1" />
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            关闭
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateFormDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ChevronDown } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
@@ -62,15 +61,26 @@ const APPROVAL_HELP: Record<ApprovalMode, string> = {
   every: "每轮审批：每次迭代前需确认",
 };
 
+const STEPS = [
+  { key: "basic", label: "基础" },
+  { key: "task", label: "任务" },
+  { key: "config", label: "配置" },
+] as const;
+
+const CATEGORY_OPTIONS = [
+  { value: "general", label: "通用" },
+  { value: "quality", label: "质量" },
+  { value: "testing", label: "测试" },
+  { value: "documentation", label: "文档" },
+  { value: "custom", label: "自定义" },
+];
+
 /**
- * 模板创建/编辑表单对话框。
+ * 模板创建/编辑表单对话框 — 三步向导。
  *
- * 模板本质上是 `is_template=true` 的 Routine 行。
- * 本表单只暴露模板语义字段（goal / acceptance_criteria / 预算 / config），
- * 不暴露运行时字段（status / cwd / owner_id 等）。
- *
- * category / version / features_showcase 存入 config JSONB，
- * 复用 Routine.config 作为扩展元信息容器。
+ * 步骤 0（基础）：Key、显示名称、描述、分类、版本
+ * 步骤 1（任务）：任务标题、执行目标、验收标准
+ * 步骤 2（配置）：预算参数、审批模式、验证命令、特性标签
  */
 export function TemplateFormDialog({ open, template, onClose, onSaved }: TemplateFormDialogProps) {
   const isEdit = template !== null;
@@ -78,7 +88,7 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [step, setStep] = useState(0);
 
   useEffect(() => {
     if (!open) return;
@@ -107,31 +117,49 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
       setForm(next);
       setError(null);
       setFieldErrors({});
-      setShowAdvanced(isEdit && (!!template?.verification_command || !!template?.features_showcase?.length));
+      setStep(0);
     });
   }, [open, template, isEdit]);
 
   const update = <K extends keyof FormState>(k: K, v: FormState[K]) =>
     setForm((f) => ({ ...f, [k]: v }));
 
+  // ── 每步校验 ──
+  const validateStep = (s: number): boolean => {
+    const errs: Record<string, string> = {};
+    if (s === 0) {
+      if (!isEdit && !form.key.trim()) errs.key = "必填";
+    } else if (s === 1) {
+      if (!form.title.trim()) errs.title = "必填";
+      if (!form.goal.trim()) errs.goal = "必填";
+      if (!form.acceptance_criteria.trim()) errs.acceptance_criteria = "必填";
+    }
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      setError("请修正标红的字段后继续");
+      return false;
+    }
+    setFieldErrors({});
+    setError(null);
+    return true;
+  };
+
+  const handleNext = () => {
+    if (!validateStep(step)) return;
+    setStep((s) => Math.min(s + 1, STEPS.length - 1));
+  };
+
+  const handlePrev = () => {
+    setStep((s) => Math.max(s - 1, 0));
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validateStep(step)) return;
+
     setLoading(true);
     setError(null);
 
-    const errs: Record<string, string> = {};
-    if (!isEdit && !form.key.trim()) errs.key = "必填";
-    if (!form.title.trim()) errs.title = "必填";
-    if (!form.goal.trim()) errs.goal = "必填";
-    if (!form.acceptance_criteria.trim()) errs.acceptance_criteria = "必填";
-    if (Object.keys(errs).length > 0) {
-      setFieldErrors(errs);
-      setError("请修正标红的字段后重试");
-      setLoading(false);
-      return;
-    }
-
-    // category / version / features_showcase 存入 config JSONB
     const features = form.features_showcase
       .split(",")
       .map((s) => s.trim())
@@ -162,7 +190,6 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
 
     try {
       if (isEdit && template) {
-        // 用户模板的 id 是 UUID（非 builtin:xxx）
         await updateRoutine(template.id, base);
         toast.success("模板已更新");
       } else {
@@ -180,8 +207,9 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
   if (!open) return null;
 
   const inputCls =
-    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
-  const labelCls = "shrink-0 whitespace-nowrap text-xs font-medium text-text-secondary";
+    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+  const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
+  const textareaCls = cn(inputCls, "min-h-[72px] resize-y");
 
   return (
     <OverlayDismissLayer
@@ -199,245 +227,291 @@ export function TemplateFormDialog({ open, template, onClose, onSaved }: Templat
         <p className="mt-1 text-sm text-text-muted">
           {isEdit ? `正在编辑「${template?.display_name}」` : "创建一个可复用的 Routine 模板"}
         </p>
+        {/* 步骤指示器 */}
+        <div className="mt-3 flex items-center gap-1">
+          {STEPS.map((s, i) => (
+            <div key={s.key} className="flex items-center gap-1">
+              {i > 0 && <div className="h-px w-4 bg-border" />}
+              <div
+                className={cn(
+                  "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors",
+                  i === step
+                    ? "bg-primary/10 text-primary"
+                    : i < step
+                      ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                      : "bg-muted text-text-muted",
+                )}
+              >
+                {i < step ? (
+                  <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <span className="text-[10px]">{i + 1}</span>
+                )}
+                <span>{s.label}</span>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
       <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
-        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        <div className="min-h-0 flex-1 px-5 py-4">
           {error && <ErrorBanner message={error} />}
 
-          {/* Section 1 — 基本信息 */}
-          <section>
-            <div className="grid grid-cols-2 gap-3">
-              {isEdit ? (
-                <div className="flex items-center gap-2">
-                  <label className={labelCls}>Key</label>
-                  <input type="text" value={form.key} disabled className={cn(inputCls, "min-w-0 flex-1")} />
-                </div>
-              ) : (
-                <div>
-                  <div className="flex items-center gap-2">
+          {/* 步骤 0 — 基础信息 */}
+          {step === 0 && (
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                {isEdit ? (
+                  <div>
+                    <label className={labelCls}>模板标识</label>
+                    <input type="text" value={form.key} disabled className={inputCls} />
+                  </div>
+                ) : (
+                  <div>
                     <label className={labelCls}>
-                      Key <span className="text-red-500">*</span>
+                      模板标识 <span className="text-red-500">*</span>
                     </label>
                     <input
                       type="text"
                       value={form.key}
                       onChange={(e) => update("key", e.target.value)}
                       placeholder="unique_template_key"
-                      className={cn(inputCls, "min-w-0 flex-1", fieldErrors.key && "border-red-400")}
+                      className={cn(inputCls, fieldErrors.key && "border-red-400")}
                     />
+                    {fieldErrors.key && (
+                      <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>
+                    )}
                   </div>
-                  {fieldErrors.key && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.key}</p>}
-                </div>
-              )}
-              <div>
-                <div className="flex items-center gap-2">
-                  <label className={labelCls}>
-                    Display Name
-                  </label>
+                )}
+                <div>
+                  <label className={labelCls}>显示名称</label>
                   <input
                     type="text"
                     value={form.display_name}
                     onChange={(e) => update("display_name", e.target.value)}
                     placeholder="模板展示名"
-                    className={cn(inputCls, "min-w-0 flex-1")}
+                    className={inputCls}
+                  />
+                </div>
+              </div>
+              <div>
+                <label className={labelCls}>描述</label>
+                <textarea
+                  className={cn(inputCls, "resize-y")}
+                  value={form.description}
+                  onChange={(e) => update("description", e.target.value)}
+                  rows={2}
+                  placeholder="模板用途简述"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelCls}>分类</label>
+                  <select
+                    value={form.category}
+                    onChange={(e) => update("category", e.target.value)}
+                    className={inputCls}
+                  >
+                    {CATEGORY_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className={labelCls}>版本</label>
+                  <input
+                    type="text"
+                    value={form.version}
+                    onChange={(e) => update("version", e.target.value)}
+                    placeholder="1.0.0"
+                    className={inputCls}
                   />
                 </div>
               </div>
             </div>
-            <textarea
-              className={cn(inputCls, "mt-3")}
-              value={form.description}
-              onChange={(e) => update("description", e.target.value)}
-              rows={2}
-              placeholder="Description — 模板用途简述"
-            />
-            <div className="mt-3 grid grid-cols-2 gap-3">
-              <div className="flex items-center gap-2">
-                <label className={labelCls}>Category</label>
-                <input
-                  type="text"
-                  value={form.category}
-                  onChange={(e) => update("category", e.target.value)}
-                  placeholder="quality / testing / general"
-                  className={cn(inputCls, "min-w-0 flex-1")}
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <label className={labelCls}>Version</label>
-                <input
-                  type="text"
-                  value={form.version}
-                  onChange={(e) => update("version", e.target.value)}
-                  placeholder="1.0.0"
-                  className={cn(inputCls, "min-w-0 flex-1")}
-                />
-              </div>
-            </div>
-          </section>
+          )}
 
-          {/* Section 2 — 任务定义 */}
-          <section className="space-y-3">
-            <div>
-              <div className="flex items-center gap-2 mb-1">
+          {/* 步骤 1 — 任务定义 */}
+          {step === 1 && (
+            <div className="space-y-3">
+              <div>
                 <label className={labelCls}>
-                  Title <span className="text-red-500">*</span>
+                  任务标题 <span className="text-red-500">*</span>
                 </label>
+                <input
+                  type="text"
+                  value={form.title}
+                  onChange={(e) => update("title", e.target.value)}
+                  placeholder="创建时的默认标题"
+                  className={cn(inputCls, fieldErrors.title && "border-red-400")}
+                />
+                {fieldErrors.title && (
+                  <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>
+                )}
               </div>
-              <input
-                type="text"
-                value={form.title}
-                onChange={(e) => update("title", e.target.value)}
-                placeholder="Routine Title — 创建时的默认标题"
-                className={cn(inputCls, fieldErrors.title && "border-red-400")}
-              />
-              {fieldErrors.title && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.title}</p>}
+              <div>
+                <label className={labelCls}>
+                  执行目标 <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={form.goal}
+                  onChange={(e) => update("goal", e.target.value)}
+                  rows={4}
+                  placeholder="Claude Code 的长周期目标"
+                  className={cn(textareaCls, fieldErrors.goal && "border-red-400")}
+                />
+                {fieldErrors.goal && (
+                  <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>
+                )}
+              </div>
+              <div>
+                <label className={labelCls}>
+                  验收标准 <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  value={form.acceptance_criteria}
+                  onChange={(e) => update("acceptance_criteria", e.target.value)}
+                  rows={3}
+                  placeholder="Evaluator 判定成功的准则"
+                  className={cn(textareaCls, fieldErrors.acceptance_criteria && "border-red-400")}
+                />
+                {fieldErrors.acceptance_criteria && (
+                  <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.acceptance_criteria}</p>
+                )}
+              </div>
             </div>
-            <div>
-              <textarea
-                value={form.goal}
-                onChange={(e) => update("goal", e.target.value)}
-                rows={3}
-                placeholder="Goal * — Claude Code 的长周期目标"
-                className={cn(inputCls, fieldErrors.goal && "border-red-400")}
-              />
-              {fieldErrors.goal && <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.goal}</p>}
-            </div>
-            <div>
-              <textarea
-                value={form.acceptance_criteria}
-                onChange={(e) => update("acceptance_criteria", e.target.value)}
-                rows={2}
-                placeholder="Acceptance Criteria * — Evaluator 判定成功的准则"
-                className={cn(inputCls, fieldErrors.acceptance_criteria && "border-red-400")}
-              />
-              {fieldErrors.acceptance_criteria && (
-                <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors.acceptance_criteria}</p>
-              )}
-            </div>
-          </section>
+          )}
 
-          {/* Section 3 — 预算与审批 */}
-          <section className="rounded-card border border-border bg-muted/30 p-4">
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2">
-              <div className="flex items-center gap-2">
-                <label className={labelCls}>Max Iterations</label>
-                <input
-                  type="number"
-                  min={1}
-                  value={form.max_iterations}
-                  onChange={(e) => update("max_iterations", e.target.value)}
-                  className={cn(inputCls, "min-w-0 flex-1")}
-                />
+          {/* 步骤 2 — 配置 */}
+          {step === 2 && (
+            <div className="space-y-4">
+              {/* 预算参数 */}
+              <div className="rounded-card border border-border bg-muted/30 p-4">
+                <h4 className="mb-3 text-xs font-medium text-text-secondary">预算与限制</h4>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+                  <div>
+                    <label className={labelCls}>最大迭代</label>
+                    <input
+                      type="number"
+                      min={1}
+                      value={form.max_iterations}
+                      onChange={(e) => update("max_iterations", e.target.value)}
+                      className={inputCls}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelCls}>预算上限 (USD)</label>
+                    <input
+                      type="number"
+                      min={0}
+                      step="0.5"
+                      value={form.max_cost_usd}
+                      onChange={(e) => update("max_cost_usd", e.target.value)}
+                      className={inputCls}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelCls}>成功阈值</label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={100}
+                      value={form.success_score_threshold}
+                      onChange={(e) => update("success_score_threshold", e.target.value)}
+                      className={inputCls}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelCls}>无进展上限</label>
+                    <input
+                      type="number"
+                      min={1}
+                      value={form.no_progress_patience}
+                      onChange={(e) => update("no_progress_patience", e.target.value)}
+                      className={inputCls}
+                    />
+                  </div>
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <label className={labelCls}>Max Cost (USD)</label>
-                <input
-                  type="number"
-                  min={0}
-                  step="0.5"
-                  value={form.max_cost_usd}
-                  onChange={(e) => update("max_cost_usd", e.target.value)}
-                  className={cn(inputCls, "min-w-0 flex-1")}
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <label className={labelCls}>Score Threshold</label>
-                <input
-                  type="number"
-                  min={0}
-                  max={100}
-                  value={form.success_score_threshold}
-                  onChange={(e) => update("success_score_threshold", e.target.value)}
-                  className={cn(inputCls, "min-w-0 flex-1")}
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <label className={labelCls}>No-Progress Limit</label>
-                <input
-                  type="number"
-                  min={1}
-                  value={form.no_progress_patience}
-                  onChange={(e) => update("no_progress_patience", e.target.value)}
-                  className={cn(inputCls, "min-w-0 flex-1")}
-                />
-              </div>
-            </div>
-            <div className="mt-3 flex items-start gap-2">
-              <label className={cn(labelCls, "pt-2")}>Approval Mode</label>
-              <div className="min-w-0 flex-1">
+
+              {/* 审批模式 */}
+              <div>
+                <label className={labelCls}>审批模式</label>
                 <select
                   value={form.approval_mode}
                   onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
                   className={inputCls}
                 >
-                  <option value="auto">Auto (全自动)</option>
-                  <option value="first">First (首次审批)</option>
-                  <option value="every">Every (每轮审批)</option>
+                  <option value="auto">全自动 — 创建后无人干预</option>
+                  <option value="first">首次审批 — 第 1 次执行前需确认</option>
+                  <option value="every">每轮审批 — 每次迭代前需确认</option>
                 </select>
-                <p className="mt-1 text-caption text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+                <p className="mt-1 text-caption text-text-muted">
+                  {APPROVAL_HELP[form.approval_mode]}
+                </p>
+              </div>
+
+              {/* 验证命令 */}
+              <div>
+                <label className={labelCls}>验证命令</label>
+                <input
+                  type="text"
+                  value={form.verification_command}
+                  onChange={(e) => update("verification_command", e.target.value)}
+                  placeholder="例如 uv run pytest -q"
+                  className={inputCls}
+                />
+                <p className="mt-1 text-caption text-text-muted">
+                  迭代结束后的命令门控，通过后才算完成
+                </p>
+              </div>
+
+              {/* 特性标签 */}
+              <div>
+                <label className={labelCls}>特性标签</label>
+                <input
+                  type="text"
+                  value={form.features_showcase}
+                  onChange={(e) => update("features_showcase", e.target.value)}
+                  placeholder="特性 1, 特性 2, 特性 3（逗号分隔）"
+                  className={inputCls}
+                />
+                <p className="mt-1 text-caption text-text-muted">
+                  展示在模板卡片上的特性标签，逗号分隔
+                </p>
               </div>
             </div>
-          </section>
-
-          {/* Section 4 — 高级设置（折叠） */}
-          <section>
-            <button
-              type="button"
-              onClick={() => setShowAdvanced((prev) => !prev)}
-              className="group flex w-full items-center gap-2 rounded-control px-1.5 py-1.5 text-caption font-medium text-text-secondary transition-colors hover:bg-muted"
-              aria-expanded={showAdvanced}
-            >
-              <ChevronDown
-                aria-hidden="true"
-                className={cn(
-                  "h-3.5 w-3.5 text-text-muted transition-transform duration-150",
-                  showAdvanced && "rotate-180",
-                )}
-              />
-              <span>{showAdvanced ? "收起高级设置" : "高级设置 (Verification, Features...)"}</span>
-            </button>
-
-            {showAdvanced && (
-              <div className="mt-3 space-y-2 rounded-card border border-border bg-muted/30 p-4">
-                <div className="flex items-center gap-2">
-                  <label className={labelCls}>Verification Command</label>
-                  <input
-                    type="text"
-                    value={form.verification_command}
-                    onChange={(e) => update("verification_command", e.target.value)}
-                    placeholder="e.g. uv run pytest -q"
-                    className={cn(inputCls, "min-w-0 flex-1")}
-                  />
-                </div>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <label className={labelCls}>Features Showcase</label>
-                    <input
-                      type="text"
-                      value={form.features_showcase}
-                      onChange={(e) => update("features_showcase", e.target.value)}
-                      placeholder="特性 1, 特性 2, 特性 3（逗号分隔）"
-                      className={cn(inputCls, "min-w-0 flex-1")}
-                    />
-                  </div>
-                  <p className="mt-1 text-caption text-text-muted">
-                    逗号分隔的特性标签，展示在模板卡片上
-                  </p>
-                </div>
-              </div>
-            )}
-          </section>
+          )}
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
-          <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={loading}>
-            Cancel
-          </Button>
-          <Button type="submit" variant="primary" size="sm" loading={loading}>
-            {isEdit ? "Save" : "Create Template"}
-          </Button>
+        <div className="flex items-center justify-between gap-2 border-t border-border px-5 py-3">
+          <div>
+            {step > 0 && (
+              <Button type="button" variant="ghost" size="sm" onClick={handlePrev} disabled={loading}>
+                上一步
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={loading}>
+              取消
+            </Button>
+            {step < STEPS.length - 1 ? (
+              <Button type="button" variant="primary" size="sm" onClick={handleNext}>
+                下一步
+              </Button>
+            ) : (
+              <Button type="submit" variant="primary" size="sm" loading={loading}>
+                {isEdit ? "保存更改" : "创建模板"}
+              </Button>
+            )}
+          </div>
         </div>
       </form>
     </OverlayDismissLayer>

--- a/apps/negentropy-ui/app/interface/routine/templates/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/templates/page.tsx
@@ -6,10 +6,10 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Plus, Sparkles } from "lucide-react";
+import { ArrowLeft, Plus, Search, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -23,23 +23,28 @@ import {
 } from "@/features/routine";
 import type { RoutineDTO, RoutineTemplateItem } from "@/features/routine";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 import { TemplateCard } from "../_components/TemplateCard";
 import { TemplateFormDialog } from "../_components/TemplateFormDialog";
-import { CreateFromTemplateDialog } from "../_components/CreateFromTemplateDialog";
+import { TemplateDetailDrawer } from "../_components/TemplateDetailDrawer";
+import { InlineCreateFromTemplate } from "../_components/InlineCreateFromTemplate";
 
 const GRID_CLS = "grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3";
+
+type SourceFilter = "all" | "builtin" | "user";
 
 /**
  * Routine Templates CRUD 页面。
  *
  * 合并展示内置 YAML 预设（source=builtin，只读）与用户自建模板（source=user，可 CRUD）。
+ * 提供搜索、分类筛选、来源切换；点击卡片打开详情抽屉。
  * 交互流：
- * - "New Template" → TemplateFormDialog(create)
- * - 卡片点击 → 查看详情（预留 drawer 扩展点）
- * - "使用模板" → CreateFromTemplateDialog（填 key+cwd → 创建 Routine）
- * - "Edit" → TemplateFormDialog(edit)
- * - "Delete" → useConfirmDialog → deleteRoutine → toast + refresh
+ * - "新建模板" → TemplateFormDialog(create)
+ * - 卡片点击 → TemplateDetailDrawer（详情抽屉）
+ * - "使用此模板" → 内联创建栏（填 cwd → 创建 Routine → 跳转）
+ * - "编辑" → TemplateFormDialog(edit)
+ * - "删除" → useConfirmDialog → deleteRoutine → toast + refresh
  */
 export default function RoutineTemplatesPage() {
   const router = useRouter();
@@ -47,10 +52,16 @@ export default function RoutineTemplatesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Dialog states
+  // 筛选状态
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+
+  // Dialog / Drawer 状态
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<RoutineTemplateItem | null>(null);
-  const [selectedForUse, setSelectedForUse] = useState<RoutineTemplateItem | null>(null);
+  const [activeUseTemplateId, setActiveUseTemplateId] = useState<string | null>(null);
+  const [selectedForDetail, setSelectedForDetail] = useState<RoutineTemplateItem | null>(null);
 
   const { confirm, confirmDialog } = useConfirmDialog();
 
@@ -67,9 +78,33 @@ export default function RoutineTemplatesPage() {
     load();
   }, [load]);
 
-  // ── 分组 ──
-  const builtin = templates.filter((t) => t.source === "builtin");
-  const user = templates.filter((t) => t.source === "user");
+  // ── 动态分类列表 ──
+  const categories = useMemo(() => {
+    const cats = new Set(templates.map((t) => t.category));
+    return ["全部", ...Array.from(cats).sort()];
+  }, [templates]);
+
+  // ── 客户端过滤 ──
+  const filtered = useMemo(() => {
+    return templates.filter((t) => {
+      // 来源过滤
+      if (sourceFilter === "builtin" && t.source !== "builtin") return false;
+      if (sourceFilter === "user" && t.source !== "user") return false;
+      // 分类过滤
+      if (activeCategory && activeCategory !== "全部" && t.category !== activeCategory) return false;
+      // 搜索过滤
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        const matches =
+          t.display_name.toLowerCase().includes(q) ||
+          t.key.toLowerCase().includes(q) ||
+          (t.description ?? "").toLowerCase().includes(q) ||
+          t.category.toLowerCase().includes(q);
+        if (!matches) return false;
+      }
+      return true;
+    });
+  }, [templates, sourceFilter, activeCategory, searchQuery]);
 
   // ── Handlers ──
   const handleFormSaved = () => {
@@ -79,11 +114,12 @@ export default function RoutineTemplatesPage() {
   };
 
   const handleUseCreated = (created: RoutineDTO) => {
-    setSelectedForUse(null);
+    setActiveUseTemplateId(null);
     router.push(`/interface/routine/${created.id}`);
   };
 
   const handleEdit = (template: RoutineTemplateItem) => {
+    setSelectedForDetail(null);
     setEditing(template);
     setFormOpen(true);
   };
@@ -99,17 +135,21 @@ export default function RoutineTemplatesPage() {
     try {
       await deleteRoutine(template.id);
       toast.success(`模板「${template.display_name}」已删除`);
+      setSelectedForDetail(null);
       load();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "删除失败");
     }
   };
 
+  const inputCls =
+    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:border-border focus:outline-none focus:ring-1 focus:ring-ring";
+
   return (
     <div className="flex h-full flex-col bg-muted">
       <InterfaceNav title="Routine" />
       <div className="flex-1 overflow-auto">
-        <div className="space-y-6 px-6 py-6">
+        <div className="space-y-5 px-6 py-6">
           {/* Header */}
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
@@ -121,7 +161,7 @@ export default function RoutineTemplatesPage() {
                 <ArrowLeft className="h-4 w-4" />
               </Link>
               <div>
-                <h1 className="text-2xl font-bold text-foreground">Routine Templates</h1>
+                <h1 className="text-2xl font-bold text-foreground">模板库</h1>
                 <p className="text-sm text-text-muted">
                   从内置预设或自定义模板快速创建 Routine
                 </p>
@@ -136,73 +176,141 @@ export default function RoutineTemplatesPage() {
               }}
             >
               <Plus className="mr-1 h-4 w-4" />
-              New Template
+              新建模板
             </Button>
           </div>
 
+          {/* 命令栏：搜索 + 分类 + 来源切换 */}
+          {!error && templates.length > 0 && (
+            <div className="flex flex-col gap-3">
+              {/* 搜索框 */}
+              <div className="relative max-w-sm">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="搜索模板名称、描述、分类…"
+                  className={cn(inputCls, "pl-9")}
+                />
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                {/* 分类标签栏 */}
+                <div className="flex items-center gap-1 overflow-x-auto">
+                  {categories.map((cat) => (
+                    <button
+                      key={cat}
+                      onClick={() => setActiveCategory(cat === "全部" ? null : cat)}
+                      className={cn(
+                        "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                        (cat === "全部" && !activeCategory) || cat === activeCategory
+                          ? "bg-primary/10 text-primary"
+                          : "bg-card text-text-secondary hover:bg-border/60",
+                      )}
+                    >
+                      {cat}
+                    </button>
+                  ))}
+                </div>
+
+                {/* 来源切换 */}
+                <div className="flex items-center rounded-control border border-border bg-card p-0.5">
+                  {([
+                    { value: "all" as const, label: "全部" },
+                    { value: "builtin" as const, label: "内置" },
+                    { value: "user" as const, label: "我的" },
+                  ]).map((opt) => (
+                    <button
+                      key={opt.value}
+                      onClick={() => setSourceFilter(opt.value)}
+                      className={cn(
+                        "rounded-control px-3 py-1 text-xs font-medium transition-colors",
+                        sourceFilter === opt.value
+                          ? "bg-muted text-foreground shadow-xs"
+                          : "text-text-muted hover:text-foreground",
+                      )}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* 内容区 */}
           {loading ? (
             <div className={GRID_CLS}>
               {[0, 1, 2].map((i) => (
                 <div key={i} className="rounded-card border border-border bg-card p-4">
-                  <Skeleton className="mb-3 h-5 w-1/3" />
-                  <div className="mb-2 flex gap-2">
-                    <Skeleton className="h-4 w-16 rounded-full" />
-                    <Skeleton className="h-4 w-12 rounded-full" />
-                  </div>
+                  <Skeleton className="mb-2 h-3 w-16" />
+                  <Skeleton className="mb-2 h-5 w-1/2" />
                   <Skeleton className="mb-1 h-4 w-full" />
                   <Skeleton className="h-4 w-3/4" />
                 </div>
               ))}
             </div>
           ) : error ? (
-            <ErrorState title="Failed to load templates" description={error} onRetry={load} />
+            <ErrorState title="加载模板失败" description={error} onRetry={load} />
           ) : templates.length === 0 ? (
-            <EmptyState icon={Sparkles} title="No templates available." />
+            <EmptyState icon={Sparkles} title="暂无模板" />
+          ) : filtered.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-sm text-text-muted">没有匹配的模板</p>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-2"
+                onClick={() => {
+                  setSearchQuery("");
+                  setActiveCategory(null);
+                  setSourceFilter("all");
+                }}
+              >
+                清除筛选
+              </Button>
+            </div>
           ) : (
-            <>
-              {/* Built-in section */}
-              {builtin.length > 0 && (
-                <section>
-                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
-                    内置模板
-                  </h2>
-                  <div className={GRID_CLS}>
-                    {builtin.map((t) => (
-                      <TemplateCard
-                        key={t.id}
-                        template={t}
-                        onUse={setSelectedForUse}
-                      />
-                    ))}
-                  </div>
-                </section>
-              )}
-
-              {/* User templates section */}
-              {user.length > 0 && (
-                <section>
-                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
-                    我的模板
-                  </h2>
-                  <div className={GRID_CLS}>
-                    {user.map((t) => (
-                      <TemplateCard
-                        key={t.id}
-                        template={t}
-                        onUse={setSelectedForUse}
-                        onEdit={handleEdit}
-                        onDelete={handleDelete}
-                      />
-                    ))}
-                  </div>
-                </section>
-              )}
-            </>
+            <div className={GRID_CLS}>
+              {filtered.map((t) => (
+                <div key={t.id}>
+                  <TemplateCard
+                    template={t}
+                    onDetail={setSelectedForDetail}
+                    onUse={(tmpl) => setActiveUseTemplateId(tmpl.id)}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                  />
+                  {activeUseTemplateId === t.id && (
+                    <InlineCreateFromTemplate
+                      template={t}
+                      onClose={() => setActiveUseTemplateId(null)}
+                      onCreated={handleUseCreated}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
           )}
         </div>
       </div>
 
-      {/* Dialogs */}
+      {/* 详情抽屉 */}
+      {selectedForDetail && (
+        <TemplateDetailDrawer
+          template={selectedForDetail}
+          onClose={() => setSelectedForDetail(null)}
+          onUse={(t) => {
+            setSelectedForDetail(null);
+            setActiveUseTemplateId(t.id);
+          }}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
+      )}
+
+      {/* 表单对话框 */}
       <TemplateFormDialog
         open={formOpen}
         template={editing}
@@ -212,14 +320,6 @@ export default function RoutineTemplatesPage() {
         }}
         onSaved={handleFormSaved}
       />
-
-      {selectedForUse && (
-        <CreateFromTemplateDialog
-          template={selectedForUse}
-          onClose={() => setSelectedForUse(null)}
-          onCreated={handleUseCreated}
-        />
-      )}
 
       {confirmDialog}
     </div>


### PR DESCRIPTION
## 概述

对 Routine 模板库（`/interface/routine/templates`）进行整体 UI/UX 重构，目标是**简约、直观、专业**。在内置预设 + 用户自建模板的统一管理基础上，引入搜索/分类/来源筛选、侧滑详情抽屉、三步向导表单与内联创建栏，显著降低模板浏览与创建的认知摩擦。

> 本分支已合并 `origin/feature/1.x.x`，解决了与 #783（模板详情 Drawer）的语义冲突，并吸收其防御性改进。详见下方「合并与冲突解决」。

## 主要变更

### 1. TemplateCard — 卡片降噪
- 移除冗余 badge，`category` 提升为顶部标签，`version` 内联到名称后缀
- `approval_mode` 下沉为底部 pill；`ShieldCheck` 验证盾牌图标替代原 `Gate: ✓/✗` 文本
- 悬停时右上角浮现编辑/删除图标（仅用户模板）
- 来源标识优化（自建 / 内置），语言统一中文

### 2. TemplateDetailDrawer — 新建侧滑详情抽屉
- 点击卡片主体滑入，展示完整配置：执行目标、验收标准、预算参数、审批模式、验证命令、特性标签
- 支持 Escape / 遮罩关闭；Footer 含「使用此模板 / 编辑 / 删除」操作

### 3. templates/page.tsx — 检索与筛选
- 新增搜索框（名称 / Key / 描述 / 分类）+ 动态分类标签栏 + 来源三段切换（全部 / 内置 / 我的）
- 合并原双 section 为统一过滤网格；空筛选结果提供「清除筛选」快捷入口
- 语言统一中文

### 4. TemplateFormDialog — 三步向导
- 重构为「基础 / 任务 / 配置」三步，步骤指示器 + 每步独立校验
- 验证命令与特性标签从折叠区提升为常驻字段；分类改为下拉选择；全部中文标签

### 5. InlineCreateFromTemplate — 内联创建栏
- 在卡片下方展开，替代模态弹窗；Key 自动生成（只读），仅「工作目录」为必填
- 一次只展开一个；按 source 分支发送 `preset_id` / `template_id`

### 6. 修复
- 内联创建栏自动生成的 Key 改用 `useState` 惰性初始化，避免每次渲染（如输入框击键）重新生成 UUID 导致显示值抖动

## 合并与冲突解决

并入 `origin/feature/1.x.x` 的 #783、#784，其中 #783 与本分支均独立实现了「模板详情查看」，构成语义冲突：

| 维度 | 本分支（重构版，保留） | origin #783（弃用） |
|------|----------------------|--------------------|
| 详情抽屉 | 手写 translateX + 条件挂载 + 中文 | BaseDrawer + framer-motion + 始终挂载 + 英文 |
| 卡片回调 | `onDetail` | `onClick` |
| 使用模板 | `InlineCreateFromTemplate` 内联栏 | `CreateFromTemplateDialog` 弹窗 |
| 列表 | 搜索 + 分类 + 来源筛选 | 双 section 分组 |

解决策略：以本分支重构版为主体（接口契合、整体协调），同时**吸收 origin 的 `handleDelete`「内置模板不可删除」source 守卫**。`CreateFromTemplateDialog` 已被内联创建栏取代且无外部引用（保留文件不删除）。

## 验证

- ✅ TypeScript 类型检查（`tsc --noEmit`）exit 0
- ✅ ESLint（5 个改动文件，`--max-warnings=0`）零警告
- ✅ 单元测试（vitest）95 文件 / 755 用例全绿

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)