### PR TITLE
fix(wiki-home-card): 补齐 Catalog 节点描述经 Wiki 条目同步链路至首页卡片;

### DIFF
--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -66,8 +66,9 @@ export default async function WikiHomePage() {
         homeLinks.push({ label: title, href });
         homeCards.push({
           title,
+          // 优先节点级描述（Catalog 节点 description）→ 回退 Publication 级描述 → 占位
+          description: item.entry_description || pub.description || "暂无描述",
           href,
-          description: pub.description || "暂无描述",
           Icon: getPublicationIcon(pub.name),
         });
       }

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -62,6 +62,8 @@ export interface WikiNavTreeItem {
   entry_id: string | null;
   entry_slug: string;
   entry_title: string;
+  /** 容器节点从 Catalog 节点同步而来的描述；DOCUMENT / 历史合成节点为 null */
+  entry_description?: string | null;
   is_index_page: boolean;
   /** 叶节点的源文档；容器节点为 null */
   document_id: string | null;

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0051_wiki_entry_add_description.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0051_wiki_entry_add_description.py
@@ -1,0 +1,48 @@
+"""wiki_publication_entries 新增 entry_description 列以同步 Catalog 节点描述
+
+Revision ID: 0051
+Revises: 0050
+Create Date: 2026-05-31 00:00:00.000000+00:00
+
+设计动机：
+    Wiki 站点首页「内容主题」卡片按 Publication 的导航树一级节点（CONTAINER
+    容器条目）渲染，需展示各节点的描述。描述源自 Catalog 节点
+    ``DocCatalogEntry.description``，但此前 CONTAINER 条目（``WikiPublicationEntry``）
+    仅持久化 ``entry_title``、未携带描述，导致描述无法经「同步落库 → 导航树 →
+    API → SSG」链路抵达首页卡片。
+
+    新增 ``entry_description`` 列，作为 ``entry_title`` 的同生命周期姊妹字段：
+    在 ``wiki_service.sync_entries_from_catalog`` 同步时从 Catalog 节点
+    ``description`` 拷入，发布快照（SNAPSHOT 模式）一并冻结，保持「定版快照」语义。
+
+幂等性：
+    使用 ``ADD COLUMN IF NOT EXISTS`` 保证重复执行安全；downgrade 仅
+    ``DROP COLUMN`` 该新增列，不触碰其它业务数据。既有行 ``entry_description``
+    为 ``NULL``，需用户主动触发「从 Catalog 同步」/「同步并发布」回填
+    （与 0040 ``display_name`` 同范式，不在迁移中隐式回填）。
+
+参考文献：
+[1] 0040_add_knowledge_document_display_name.py — Wiki 显示字段幂等加列范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0051"
+down_revision: str | None = "0050"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(f"ALTER TABLE {SCHEMA}.wiki_publication_entries ADD COLUMN IF NOT EXISTS entry_description TEXT")
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"ALTER TABLE {SCHEMA}.wiki_publication_entries DROP COLUMN IF EXISTS entry_description"))

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -280,6 +280,7 @@ class WikiDao:
         catalog_node_id: UUID,
         entry_slug: str,
         entry_title: str | None,
+        entry_description: str | None = None,
         entry_path: str | None,
     ) -> WikiPublicationEntry:
         """创建或更新 CONTAINER 类型条目（幂等：同一 publication+catalog_node 组合只保留一条）。
@@ -301,6 +302,7 @@ class WikiDao:
         if rec is not None:
             rec.entry_slug = entry_slug
             rec.entry_title = entry_title
+            rec.entry_description = entry_description
             rec.entry_path = entry_path
         else:
             rec = WikiPublicationEntry(
@@ -309,6 +311,7 @@ class WikiDao:
                 catalog_node_id=catalog_node_id,
                 entry_slug=entry_slug,
                 entry_title=entry_title,
+                entry_description=entry_description,
                 entry_path=entry_path,
                 is_index_page=False,
                 entry_kind="CONTAINER",

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -198,9 +198,9 @@ class WikiPublishingService:
     ) -> None:
         """SNAPSHOT 模式：冻结当前 entries 到 wiki_publication_snapshots。
 
-        frozen_entries 仅冻结条目映射元数据（id/slug/title/path/is_index_page/
-        document_id），不冗余 markdown 内容——SSG 仍从 ``KnowledgeDocument``
-        按 document_id 拉取，避免快照表膨胀。
+        frozen_entries 仅冻结条目映射元数据（id/slug/title/description/path/
+        is_index_page/document_id），不冗余 markdown 内容——SSG 仍从
+        ``KnowledgeDocument`` 按 document_id 拉取，避免快照表膨胀。
         """
         entries = await WikiDao.get_entries(db, pub.id)
         frozen = [
@@ -208,6 +208,7 @@ class WikiPublishingService:
                 "entry_id": str(e.id),
                 "entry_slug": e.entry_slug,
                 "entry_title": e.entry_title,
+                "entry_description": e.entry_description,
                 "entry_path": e.entry_path,
                 "is_index_page": bool(e.is_index_page),
                 "document_id": str(e.document_id),
@@ -505,6 +506,7 @@ class WikiPublishingService:
                 catalog_node_id=node["id"],
                 entry_slug=final_slug,
                 entry_title=node.get("name") or path_slugs[-1],
+                entry_description=node.get("description"),
                 entry_path=entry_path,
             )
             synced_node_ids.add(str(node["id"]))

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_tree.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_tree.py
@@ -22,8 +22,8 @@ JSON 数组）合成嵌套的导航树。
 
 输出约定：
   - 返回 ``list[NavTreeItem]``，每个节点形如
-    ``{entry_id, entry_slug, entry_title, is_index_page, document_id,
-       catalog_node_id, entry_kind, children}``；
+    ``{entry_id, entry_slug, entry_title, entry_description, is_index_page,
+       document_id, catalog_node_id, entry_kind, children}``；
   - 合成型容器节点（仅在缺 CONTAINER 时回退）``entry_id`` / ``document_id`` /
     ``catalog_node_id`` 为 ``None``，``entry_kind=CONTAINER``。
 """
@@ -63,6 +63,7 @@ def _entry_to_item(entry: Any) -> dict:
         "entry_id": str(entry_id) if entry_id else None,
         "entry_slug": entry.entry_slug,
         "entry_title": entry.entry_title or entry.entry_slug,
+        "entry_description": getattr(entry, "entry_description", None),
         "is_index_page": bool(getattr(entry, "is_index_page", False)),
         "document_id": str(document_id) if document_id else None,
         "catalog_node_id": str(catalog_node_id) if catalog_node_id else None,
@@ -77,6 +78,7 @@ def _make_synthetic_container(slug_path: str, title_segment: str) -> dict:
         "entry_id": None,
         "entry_slug": slug_path,
         "entry_title": title_segment,
+        "entry_description": None,
         "is_index_page": False,
         "document_id": None,
         "catalog_node_id": None,

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -302,6 +302,7 @@ class WikiPublicationEntry(Base, UUIDMixin, TimestampMixin):
 
     其它字段：
       - ``entry_slug`` / ``entry_title``：URL 段与标题（CONTAINER 取 Catalog 节点 name）。
+      - ``entry_description``：CONTAINER 取 Catalog 节点 description，供 SSG 首页卡片展示。
       - ``is_index_page``：标记是否为该 Publication 首页（仅 DOCUMENT 有意义）。
       - ``entry_path``：导航树层级路径（Materialized Path，list[str] JSON 串）。
     """
@@ -329,6 +330,9 @@ class WikiPublicationEntry(Base, UUIDMixin, TimestampMixin):
     )
     entry_slug: Mapped[str] = mapped_column(String(255), nullable=False)
     entry_title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # CONTAINER 条目从 Catalog 节点 description 拷入（entry_title 的同生命周期姊妹字段），
+    # 供 SSG 首页「内容主题」卡片展示；DOCUMENT 条目通常为 NULL。
+    entry_description: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Materialized Path：list[str] 以 JSON 字符串形式存储；历史列名 entry_order。
     entry_path: Mapped[str | None] = mapped_column("entry_path", JSONB)
     is_index_page: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -316,6 +316,66 @@ class TestWikiCatalogSync:
         renamed_events = [e for e in result["errors"] if e.startswith("renamed:")]
         assert any(f"{doc_id}" in e and "parent/eng->" in e for e in renamed_events), result["errors"]
 
+    @pytest.mark.asyncio
+    async def test_sync_passes_node_description_to_container_entry(self, monkeypatch):
+        """Catalog 节点 description 应随同步落库到 CONTAINER 条目。
+
+        回归首页「内容主题」卡片描述缺失缺陷：此前 ``_apply_container_mappings`` 仅传
+        ``entry_title`` 而丢弃 ``description``，致节点描述无法经「导航树 → API → SSG」
+        抵达首页卡片。锁定描述自 ``node['description']`` 透传至 ``entry_description``。
+        """
+        service = WikiPublishingService()
+        publication_id = uuid4()
+        root_node_id = uuid4()
+        fake_db = _FakeAsyncSession()
+        container_writes: list[dict[str, object]] = []
+
+        async def fake_get_subtree(db, node_id):
+            _ = db
+            assert node_id == root_node_id
+            return [
+                {
+                    "id": root_node_id,
+                    "parent_id": None,
+                    "slug": "harness-engineering",
+                    "name": "Harness Engineering",
+                    "description": "智能体工程化综述",
+                }
+            ]
+
+        async def fake_get_node_documents(db, catalog_node_id, limit=500):
+            _ = (db, catalog_node_id, limit)
+            return [], 0
+
+        async def fake_upsert_container_entry(db, **kwargs):
+            _ = db
+            container_writes.append(kwargs)
+
+        async def fake_remove_stale_entries(db, publication_id, keep_document_ids, keep_container_node_ids=None):
+            _ = (db, publication_id, keep_document_ids, keep_container_node_ids)
+            return 0
+
+        monkeypatch.setattr("negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
+        )
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service.WikiDao.upsert_container_entry", fake_upsert_container_entry
+        )
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service.WikiDao.remove_stale_entries", fake_remove_stale_entries
+        )
+
+        await service.sync_entries_from_catalog(
+            fake_db,
+            publication_id=publication_id,
+            catalog_node_ids=[root_node_id],
+        )
+
+        assert len(container_writes) == 1
+        assert container_writes[0]["entry_title"] == "Harness Engineering"
+        assert container_writes[0]["entry_description"] == "智能体工程化综述"
+
 
 # ---------------------------------------------------------------------------
 # 最小 FakeAsyncSession — 仅支持 add / flush 协议

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_tree.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_tree.py
@@ -24,6 +24,7 @@ def _entry(
     is_index_page: bool = False,
     entry_kind: str = "DOCUMENT",
     catalog_node_id: object | None = None,
+    entry_description: str | None = None,
 ) -> SimpleNamespace:
     """生成测试用 entry-like 对象（DOCUMENT 默认；指定 entry_kind=CONTAINER 时切换语义）。"""
     return SimpleNamespace(
@@ -34,6 +35,7 @@ def _entry(
         else (None if entry_kind == "DOCUMENT" else uuid4()),
         entry_slug=entry_slug,
         entry_title=entry_title or entry_slug,
+        entry_description=entry_description,
         is_index_page=is_index_page,
         entry_path=entry_path,
         entry_kind=entry_kind,
@@ -218,3 +220,47 @@ class TestBuildNavTreeContainerEntries:
                 _walk(it.get("children", []))
 
         _walk(tree)
+
+
+class TestBuildNavTreeEntryDescription:
+    """节点描述（entry_description）经导航树原样透传 —— 首页「内容主题」卡片描述同步链路。"""
+
+    def test_container_entry_description_flows_into_item(self):
+        """CONTAINER 条目的 entry_description 应原样进入导航 item，供 SSG 首页卡片展示。"""
+        container = _entry(
+            entry_slug="harness-engineering",
+            entry_path=["harness-engineering"],
+            entry_kind="CONTAINER",
+            entry_title="Harness Engineering",
+            entry_description="智能体工程化综述",
+        )
+        tree = build_nav_tree([container])
+        assert tree[0]["entry_description"] == "智能体工程化综述"
+
+    def test_entry_description_defaults_to_none(self):
+        """未设置 entry_description 时 item 字段为 None。"""
+        e = _entry(entry_slug="overview", entry_path=["overview"])
+        tree = build_nav_tree([e])
+        assert tree[0]["entry_description"] is None
+
+    def test_missing_attr_falls_back_to_none(self):
+        """entry 对象缺 entry_description 属性时（旧 duck 对象）应经 getattr 安全回退 None。"""
+        bare = SimpleNamespace(
+            id=uuid4(),
+            document_id=uuid4(),
+            catalog_node_id=None,
+            entry_slug="solo",
+            entry_title="Solo",
+            is_index_page=False,
+            entry_path=["solo"],
+            entry_kind="DOCUMENT",
+        )  # 故意不含 entry_description 属性
+        tree = build_nav_tree([bare])
+        assert tree[0]["entry_description"] is None
+
+    def test_synthetic_container_has_none_description(self):
+        """缺 CONTAINER 时合成的容器节点 entry_description 应为 None（保持 item 形状统一）。"""
+        leaf = _entry(entry_slug="legacy/doc", entry_path=["legacy", "doc"])
+        tree = build_nav_tree([leaf])
+        assert tree[0]["entry_id"] is None  # 合成容器
+        assert tree[0]["entry_description"] is None

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2641,7 +2641,7 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
 
 ---
 
-## ISSUE-103 Wiki 节点描述未同步至站点首页卡片（条目层缺列 + 前端取值错源）
+## ISSUE-104 Wiki 节点描述未同步至站点首页卡片（条目层缺列 + 前端取值错源）
 
 - **表因**：主站点 Knowledge / Wiki 为根节点 Harness Engineering（描述「智能体工程化综述」）、Negentropy（描述「熵减引擎设计概念与使用指引」）填了 `DocCatalogEntry.description`，但 wiki 站点首页「内容主题」卡片只显示标题、描述缺失。
 - **根因（两处独立断裂）**：

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2639,6 +2639,27 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
 - **后续补充（tracking-[...] 宽标签语义化）**：复用上述范式处理剩余 14 处 `tracking-[0.14~0.24em]`。实测其中 **13 处为 `uppercase` 宽间距标签眼纹**（一致设计模式，众数 0.18em），新增 `--tracking-label: 0.18em` 语义令牌收敛；**剔除** 1 处非 uppercase 的作者名 pill（`MessageBubble.tsx` 的 `tracking-[0.14em]`，语义不符且非该模式）。computed-style 量化收口：众数 0.18em→0.18em 渲染零变化、0.16em→0.18em +1.6px、极端 0.24em→0.18em 短标题 −5.3px（已知可见、可接受，因属短 section 标题且更趋一致）。`rounded-[1.5~2rem]`(6) 与 `gap-[2px]`(1) 为定制一次性值、无对应令牌且 ROI 低，**不纳入**。教训补充：⑤ad-hoc 值语义化前必须先按「是否同一设计模式」分类（此处以 `uppercase` 判别 label vs pill），勿因值相近就盲并；⑥单令牌吸收一段值域时，用 computed-style 量化**最坏值**的累计宽度位移（非单 gap 差），据此判定可接受性而非仅看 em 差。
 - **后续补充（review 收口：sub-10px 下限与冗余清理）**：评审指出原 `text-[8/9px]` 并入 `text-micro` 后，`RetrievedChunkCard` 评分徽标 `isCompact` 分支残留冗余 `text-micro`（base 已是 micro），致紧凑态字号不再随密度收缩、仅 padding 收紧。**确认 10px 为 micro 档下限**（8px 近不可读，10px 更佳且与「可接受可见位移」口径自洽），删除该 3 处冗余类（`text-micro` 计数 267→264，渲染零变化）；标准缩档 base `text-caption`→compact `text-micro`(11→10px) 保持不动。教训⑦：单令牌设最小档后，原低于该档的散值会被**静默上调**——机械替换须对「低于令牌最小档」的来源值单独标注，勿令「残留=0」的计数对账掩盖真实像素位移。
 
+---
+
+## ISSUE-103 Wiki 节点描述未同步至站点首页卡片（条目层缺列 + 前端取值错源）
+
+- **表因**：主站点 Knowledge / Wiki 为根节点 Harness Engineering（描述「智能体工程化综述」）、Negentropy（描述「熵减引擎设计概念与使用指引」）填了 `DocCatalogEntry.description`，但 wiki 站点首页「内容主题」卡片只显示标题、描述缺失。
+- **根因（两处独立断裂）**：
+  1. **后端条目层丢字段**：`CatalogDao.get_subtree` 返回的 node dict 含 `description`，但 `wiki_service._apply_container_mappings` 调 `WikiDao.upsert_container_entry(...)` 时只传 `entry_title` 未传描述；且 `WikiPublicationEntry` 根本无 description 列——描述自同步落库即丢失，导航树（`wiki_tree._entry_to_item`）/ nav-tree API / 前端类型一路皆无该字段。`upsert_container_entry` docstring 早已声明容器条目应承载「title、description、entry_id」，属"文档承诺、实现缺失"。
+  2. **前端取值错源**：`apps/negentropy-wiki/src/app/page.tsx` 首页卡片按 nav tree 一级节点逐个生成，却用 Publication 级 `pub.description` 给所有卡片赋值（对同一 Publication 恒相同，且该 Publication 描述为空 → 回退「暂无描述」），而非节点级描述。
+- **处理方式**（反规范化，与 `entry_title` 同生命周期）：
+  1. 迁移 `0051`：`wiki_publication_entries` 加可空列 `entry_description TEXT`（`ADD COLUMN IF NOT EXISTS`，不回填）；
+  2. 模型 `WikiPublicationEntry` 加 `entry_description`；DAO `upsert_container_entry` 加 `entry_description` 参数并写入更新/创建两分支；
+  3. Service `_apply_container_mappings` 传 `entry_description=node.get("description")`；`_freeze_snapshot` frozen dict 同步冻结该字段；
+  4. `wiki_tree._entry_to_item` 经 `getattr(entry, "entry_description", None)` 输出，合成容器补 `None` 保形；
+  5. 前端 `WikiNavTreeItem` 加可选 `entry_description`；`page.tsx` 改为 `item.entry_description || pub.description || "暂无描述"`（节点级优先 → Publication 级回退 → 占位）。
+- **后续防范**：
+  1. **denormalize 字段须全链同改**：`WikiPublicationEntry` 这类"发布快照"表新增展示字段，必须同步覆盖「DAO upsert 参数 + sync 服务写入 + 快照冻结 + nav tree 输出 + 前端类型 + 渲染取值」六层，漏任一层即断链；
+  2. **docstring 承诺即契约**：`upsert_container_entry` docstring 写了 description 却从未实现，属危险的"虚假完备"——新增/审阅时须核对 docstring 声明字段与签名/落库是否一致；
+  3. **逐节点卡片禁用聚合级字段兜底**：前端按节点渲染的卡片，描述/图标等须取节点自身字段，`pub.*` 仅作回退，勿对所有同级卡片赋同一聚合级值。
+- **生效注意**：与 `entry_title`/`display_name`（ISSUE-040）一致，新列对**既有已发布数据**需用户主动点一次「同步并发布」回填后首页卡片才显示描述（迁移不隐式回填）。
+- **同类问题影响**：与 ISSUE-002（`sync_entries_from_catalog` 死代码 + 契约缺口）同域——凡 Catalog → Wiki Publication 的字段映射（未来 icon / cover / order 等节点元数据）都须按"六层全链"核对；其它经 `getattr` 读 ORM 的 duck 调用点新增字段时记得给安全默认。
+
 ## ISSUE-103 模型下拉 Default 占位移除 + 默认 gpt-5-nano + test-vendor 残留清理与 fixture 清理加固（2026-05-30）
 
 - **需求触因**：Home/Studio 中栏 Composer 的 LLM 下拉首项为可清除的 "Default" 占位（`value=""` = 不指定模型，后端回退硬编码默认），且下拉里出现一个 `TEST-VENDOR` 分组的 `Test Model`。用户要求：①移除 Default 占位、默认显式选中 `openai/gpt-5-nano`；②清除 TEST-VENDOR。


### PR DESCRIPTION
# 背景
- Wiki 站点首页「内容主题」卡片只显示标题、描述全部回退为「暂无描述」。Catalog 节点已填写 `description`，但该字段未到达前端——链路两处断裂：①后端 `WikiPublicationEntry` 无 `entry_description` 列，同步时丢弃描述；②前端 `page.tsx` 误取 Publication 级 `pub.description` 而非节点级描述。
- 关联上下文：ISSUE-104、ISSUE-002（同域同步契约缺口）、ISSUE-040（`display_name` 同范式加列）

# 核心变更
- **迁移 0051**：`wiki_publication_entries` 新增可空列 `entry_description TEXT`（`ADD COLUMN IF NOT EXISTS` 幂等，不回填既有数据）
- **模型 / DAO**：`WikiPublicationEntry` 加 `entry_description` 字段；`upsert_container_entry` 在更新与创建两分支均写入
- **Service 同步**：`_apply_container_mappings` 透传 `node.get("description")`；`_freeze_snapshot` 一并冻结该字段（前向一致）
- **导航树**：`_entry_to_item` 经 `getattr(entry, "entry_description", None)` 安全输出，合成容器补 `None` 保形
- **前端**：`WikiNavTreeItem` 加可选 `entry_description`；`page.tsx` 改为 `item.entry_description || pub.description || "暂无描述"`（节点级优先 → Publication 级回退 → 占位）

# 风险与回滚
- 主要风险：迁移不回填，**既有已发布 Publication 需手动「同步并发布」一次**后首页卡片才显示描述（与 ISSUE-040 `display_name` 同范式）
- 回滚方式：`downgrade` 执行 `DROP COLUMN IF EXISTS entry_description`，前端自然回退到 `pub.description || "暂无描述"`

# 验证证据
- 单元测试：`test_sync_passes_node_description_to_container_entry` — 锁定描述自 `node[\"description\"]` 透传至 `entry_description`
- 单元测试：`TestBuildNavTreeEntryDescription`（4 例）— CONTAINER 透传、默认 None、旧 duck 对象安全回退、合成容器保形
- 集成测试：无（全链路涉及 Catalog / Wiki / SSG 多服务，由单元测试逐层覆盖）
- E2E/Workflow：需在 alt-port dev server 实机回归首页卡片描述显示

# 影响范围
- 前端：`apps/negentropy-wiki/src/app/page.tsx`（渲染取值）、`wiki-api.ts`（类型声明）
- 后端：`models/perception.py`（模型）、`wiki_dao.py`（DAO）、`wiki_service.py`（同步+冻结）、`wiki_tree.py`（导航树输出）、迁移 0051
- GitHub Actions / 文档：`docs/.agents/issue.md`（ISSUE-104 摘要）

# Next Best Action
- 实机回归：对既有已发布 Wiki 站点执行一次「同步并发布」，确认首页卡片描述正确填充
- 未来同类字段映射（icon / cover / order）须按「六层全链」核对清单执行