### PR TITLE
feat(routine): 为失败/取消的 Routine 新增「重新启动」重跑能力

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, RotateCcw } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/Button";
@@ -19,8 +19,9 @@ import {
 
 import { ClockProvider } from "../_components/ClockProvider";
 import { RoutineRunView } from "../_components/RoutineRunView";
-import { CONTROL_LABEL, controlsFor, type ControlAction } from "../_components/routine-controls";
+import { canRestart, CONTROL_LABEL, controlsFor, type ControlAction } from "../_components/routine-controls";
 import { phaseClass, phaseLabel, routineStatusClass } from "../_components/status-style";
+import { useRestartRoutine } from "../_components/useRestartRoutine";
 
 export default function RoutineRunPage() {
   const params = useParams<{ id: string }>();
@@ -81,6 +82,8 @@ export default function RoutineRunPage() {
     [id, reload],
   );
 
+  const { requestRestart, restartDialog } = useRestartRoutine(() => void reload());
+
   const clockActive = routine?.status === "running";
   const controls = routine ? controlsFor(routine.status) : [];
 
@@ -139,6 +142,17 @@ export default function RoutineRunPage() {
                     {CONTROL_LABEL[action]}
                   </Button>
                 ))}
+                {routine && canRestart(routine.status) && (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    disabled={busy}
+                    leftIcon={<RotateCcw className="h-4 w-4" />}
+                    onClick={() => requestRestart(routine)}
+                  >
+                    Restart
+                  </Button>
+                )}
               </div>
             </div>
 
@@ -165,6 +179,7 @@ export default function RoutineRunPage() {
           </div>
         </ClockProvider>
       </div>
+      {restartDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RestartRoutineDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RestartRoutineDialog.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useId, useState } from "react";
+import { RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import type { RoutineDTO } from "@/features/routine";
+
+/**
+ * Routine 重启确认对话框。
+ *
+ * Restart 复位运行态并重跑，且会产生新成本——属「需确认」操作（不可静默触发）。
+ * 用户可在此**选择是否携带既往反思记忆**（Reflexion 跨尝试学习）。既往迭代作为历史保留。
+ * 视觉与 a11y 复用 {@link OverlayDismissLayer}（焦点陷阱 / Esc / 遮罩关闭 / aria-modal），
+ * 与全站 ConfirmDialog 同源；Restart 为建设性恢复操作，用 primary（非红色）。
+ */
+export interface RestartRoutineDialogProps {
+  routine: RoutineDTO;
+  busy?: boolean;
+  /** confirm 回带反思去留选择（true=保留）。 */
+  onConfirm: (keepReflections: boolean) => void;
+  onCancel: () => void;
+}
+
+export function RestartRoutineDialog({
+  routine,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: RestartRoutineDialogProps) {
+  const titleId = useId();
+  const reflectId = useId();
+  const [keepReflections, setKeepReflections] = useState(true);
+
+  const name = routine.display_name || routine.title || routine.key;
+  const reason = routine.termination_reason;
+  const deadlineHit = reason === "deadline";
+
+  return (
+    <OverlayDismissLayer
+      open
+      onClose={onCancel}
+      busy={busy}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-modal border border-border bg-card shadow-xl"
+      contentProps={{ role: "dialog", "aria-modal": true, "aria-labelledby": titleId }}
+    >
+      <div className="px-5 py-4 sm:px-6" data-testid="restart-dialog">
+        <h2 id={titleId} className="text-lg font-semibold text-foreground">
+          Restart Routine
+        </h2>
+        <div className="mt-2 space-y-3 text-sm text-text-secondary">
+          <p>
+            Re-run{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground">{name}</code>{" "}
+            from scratch. This resets the iteration count, cost, scores, and session, and starts a fresh
+            attempt. Prior iterations are kept as history. A new run will incur cost.
+          </p>
+
+          {reason && (
+            <p className="text-[13px] text-text-muted">
+              Last run ended:{" "}
+              <span className="font-medium text-text-secondary">{reason}</span>
+            </p>
+          )}
+
+          {deadlineHit && (
+            <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-700 dark:text-amber-300">
+              This run hit its deadline. If the deadline has already passed, edit the routine to update or
+              clear it first — otherwise the restart will be blocked.
+            </p>
+          )}
+
+          <label
+            htmlFor={reflectId}
+            className="flex cursor-pointer items-start gap-2.5 rounded-md border border-border bg-muted/30 px-3 py-2.5"
+          >
+            <input
+              id={reflectId}
+              type="checkbox"
+              checked={keepReflections}
+              onChange={(e) => setKeepReflections(e.target.checked)}
+              disabled={busy}
+              className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <span className="min-w-0">
+              <span className="block text-[13px] font-medium text-foreground">
+                Carry over prior reflections
+              </span>
+              <span className="block text-[12px] text-text-muted">
+                The new attempt remembers lessons learned from past iterations. Uncheck for a clean slate.
+              </span>
+            </span>
+          </label>
+        </div>
+      </div>
+      <div className="flex justify-end gap-3 border-t border-border px-5 py-4 sm:px-6">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          leftIcon={<RotateCcw className="h-4 w-4" />}
+          onClick={() => onConfirm(keepReflections)}
+          loading={busy}
+        >
+          Restart
+        </Button>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { ChevronDown, ExternalLink, Trash2 } from "lucide-react";
+import { ChevronDown, ExternalLink, RotateCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/Button";
@@ -18,7 +18,7 @@ import type {
   RoutineUpdatePayload,
 } from "@/features/routine";
 
-import { CONTROL_LABEL, controlsFor, type ControlAction } from "./routine-controls";
+import { canRestart, CONTROL_LABEL, controlsFor, type ControlAction } from "./routine-controls";
 import { phaseClass, phaseLabel, routineStatusClass } from "./status-style";
 
 /**
@@ -59,6 +59,8 @@ interface RoutineEditDrawerProps {
   onUse?: (template: RoutineTemplateItem) => void;
   /** routine-edit 生命周期控制（start/pause/resume/cancel）。 */
   onControl?: (action: ControlAction) => void;
+  /** routine-edit 终态（failed/cancelled）重新启动重跑（打开确认对话框）。 */
+  onRestart?: (routine: RoutineDTO) => void;
   /** 删除（routine-edit 终态 / template-edit 用户模板）。 */
   onDelete?: (target: RoutineDTO | RoutineTemplateItem) => void;
   /** routine-edit「Full View →」深链到 /interface/routine/[id]。 */
@@ -227,6 +229,7 @@ export function RoutineEditDrawer({
   onSaved,
   onUse,
   onControl,
+  onRestart,
   onDelete,
   onOpenFull,
   busy,
@@ -851,6 +854,18 @@ export function RoutineEditDrawer({
                   {CONTROL_LABEL[action]}
                 </Button>
               ))}
+            {mode.kind === "routine-edit" && onRestart && canRestart(mode.routine.status) && (
+              <Button
+                type="button"
+                variant="neutral"
+                size="sm"
+                disabled={busy}
+                leftIcon={<RotateCcw className="h-3.5 w-3.5" />}
+                onClick={() => onRestart(mode.routine)}
+              >
+                Restart
+              </Button>
+            )}
             {mode.kind === "template-edit" && !isBuiltinTemplate && onDelete && (
               <button
                 type="button"

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { RotateCcw } from "lucide-react";
+
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
 
+import { canRestart } from "./routine-controls";
 import { routineStatusClass, scoreColorClass } from "./status-style";
 
 interface RoutineTableProps {
@@ -10,9 +13,11 @@ interface RoutineTableProps {
   loading: boolean;
   onSelect: (r: RoutineDTO) => void;
   onOpenFull: (r: RoutineDTO) => void;
+  /** 失败 / 取消行内一键重启（打开确认对话框）。 */
+  onRestart?: (r: RoutineDTO) => void;
 }
 
-export function RoutineTable({ routines, loading, onSelect, onOpenFull }: RoutineTableProps) {
+export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart }: RoutineTableProps) {
   if (loading && routines.length === 0) {
     return (
       <div className="space-y-2">
@@ -81,16 +86,31 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull }: Routin
                 {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
               </td>
               <td className="px-4 py-3 text-right">
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onOpenFull(r);
-                  }}
-                  className="cursor-pointer rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  全过程 →
-                </button>
+                <div className="flex items-center justify-end gap-3">
+                  {onRestart && canRestart(r.status) && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRestart(r);
+                      }}
+                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      Restart
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onOpenFull(r);
+                    }}
+                    className="cursor-pointer rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    全过程 →
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
@@ -27,3 +27,11 @@ export function controlsFor(status: RoutineStatus): ControlAction[] {
       return [];
   }
 }
+
+/**
+ * 是否可「重新启动」——仅非成功终态（failed / cancelled）。
+ * Restart 不走即时控制（controlsFor），需对话框门控（反思选择 + 代价确认），故单列判定。
+ */
+export function canRestart(status: RoutineStatus): boolean {
+  return status === "failed" || status === "cancelled";
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/useRestartRoutine.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/useRestartRoutine.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { restartRoutine, type RoutineDTO } from "@/features/routine";
+
+import { RestartRoutineDialog } from "./RestartRoutineDialog";
+
+/**
+ * 重启 Routine 的单一逻辑源——列表行内、抽屉、详情页三处入口共用，避免逻辑分叉。
+ *
+ * 返回 `requestRestart(r)`（打开确认对话框）、`restartDialog`（待渲染的对话框节点）、`busy`。
+ * 确认后调 {@link restartRoutine}，成功/失败 toast，并回调 `onDone(updated)` 供调用方刷新。
+ */
+export function useRestartRoutine(onDone?: (updated: RoutineDTO) => void) {
+  const [target, setTarget] = useState<RoutineDTO | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const requestRestart = useCallback((r: RoutineDTO) => setTarget(r), []);
+  const cancel = useCallback(() => {
+    if (!busy) setTarget(null);
+  }, [busy]);
+
+  const confirm = useCallback(
+    async (keepReflections: boolean) => {
+      if (!target) return;
+      setBusy(true);
+      try {
+        const updated = await restartRoutine(target.id, { keep_reflections: keepReflections });
+        toast.success("Routine restarted");
+        setTarget(null);
+        onDone?.(updated);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Failed to restart");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [target, onDone],
+  );
+
+  const restartDialog = target ? (
+    <RestartRoutineDialog routine={target} busy={busy} onConfirm={confirm} onCancel={cancel} />
+  ) : null;
+
+  return { requestRestart, restartDialog, busy };
+}

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -25,6 +25,7 @@ import { RoutineFilterBar } from "./_components/RoutineFilterBar";
 import { RoutineHeader } from "./_components/RoutineHeader";
 import { RoutineKpiStrip } from "./_components/RoutineKpiStrip";
 import { RoutineTable } from "./_components/RoutineTable";
+import { useRestartRoutine } from "./_components/useRestartRoutine";
 
 const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "" };
 
@@ -62,6 +63,12 @@ function RoutinePageInner() {
       // ignore — 抽屉可能已关闭
     }
   }, []);
+
+  // 重启失败 / 取消的 routine（列表行内 + 抽屉共用单一逻辑源）。
+  const { requestRestart, restartDialog } = useRestartRoutine((updated) => {
+    refresh();
+    if (selId === updated.id) void refreshSelected(updated.id);
+  });
 
   // ?sel 派生选中态：URL 变化即加载/清空详情（使浏览器后退 / Esc / 遮罩点击一致关闭）。
   useEffect(() => {
@@ -194,7 +201,13 @@ function RoutinePageInner() {
               <RoutineFilterBar filters={filters} onChange={setFilters} />
             </div>
 
-            <RoutineTable routines={routines} loading={loading} onSelect={openDetail} onOpenFull={openFull} />
+            <RoutineTable
+              routines={routines}
+              loading={loading}
+              onSelect={openDetail}
+              onOpenFull={openFull}
+              onRestart={requestRestart}
+            />
           </div>
         </ClockProvider>
       </div>
@@ -206,6 +219,7 @@ function RoutinePageInner() {
           onClose={() => (createOpen ? setCreateOpen(false) : closeDetail())}
           onSaved={handleSaved}
           onControl={handleControl}
+          onRestart={requestRestart}
           onDelete={(target) => handleDelete(target as RoutineDTO)}
           onOpenFull={openFull}
           busy={actionBusy}
@@ -213,6 +227,7 @@ function RoutinePageInner() {
       )}
 
       {confirmDialog}
+      {restartDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/features/routine/api.ts
+++ b/apps/negentropy-ui/features/routine/api.ts
@@ -98,6 +98,20 @@ export async function controlRoutine(routineId: string, action: ControlAction): 
   return jsonFetch(`/${encodeURIComponent(routineId)}/${action}`, { method: "POST" });
 }
 
+/**
+ * 重启失败 / 取消的 routine：复位运行态并重跑。`keep_reflections` 决定是否携带既往反思记忆。
+ * 仅对 failed/cancelled 终态有效（后端守卫，否则 409）。
+ */
+export async function restartRoutine(
+  routineId: string,
+  body: { keep_reflections: boolean },
+): Promise<RoutineDTO> {
+  return jsonFetch(`/${encodeURIComponent(routineId)}/restart`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
 export async function approveIteration(
   routineId: string,
   iterationId: string,

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -32,6 +32,7 @@ export {
   updateRoutine,
   deleteRoutine,
   controlRoutine,
+  restartRoutine,
   approveIteration,
   rejectIteration,
   fetchTemplates,

--- a/apps/negentropy-ui/tests/unit/features/routine/routine-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/routine/routine-api.test.ts
@@ -18,8 +18,10 @@ import {
   fetchRoutineDetail,
   fetchRoutines,
   rejectIteration,
+  restartRoutine,
   updateRoutine,
 } from "@/features/routine/api";
+import { canRestart } from "@/app/interface/routine/_components/routine-controls";
 
 /** 构造一个成功的 JSON Response。 */
 function jsonResponse(body: unknown, status = 200): Response {
@@ -121,12 +123,34 @@ describe("routine api · 写入端点", () => {
     expect(init.method).toBe("POST");
   });
 
+  it("restartRoutine 命中 /restart 并 POST keep_reflections", async () => {
+    const spy = mockFetch(() => jsonResponse({ id: "r1", status: "running" }));
+    await restartRoutine("r1", { keep_reflections: false });
+    const { url, init } = lastCall(spy);
+    expect(url).toBe("/api/routine/r1/restart");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({ keep_reflections: false });
+  });
+
   it("approveIteration / rejectIteration 命中迭代审批路径", async () => {
     const spy = mockFetch(() => jsonResponse({ id: "it1" }));
     await approveIteration("r1", "it1");
     expect(lastCall(spy).url).toBe("/api/routine/r1/iterations/it1/approve");
     await rejectIteration("r1", "it1");
     expect(lastCall(spy).url).toBe("/api/routine/r1/iterations/it1/reject");
+  });
+});
+
+describe("routine controls · canRestart", () => {
+  it("仅对非成功终态（failed / cancelled）为真", () => {
+    expect(canRestart("failed")).toBe(true);
+    expect(canRestart("cancelled")).toBe(true);
+  });
+
+  it("对其余状态为假（含 succeeded / running / paused / pending）", () => {
+    for (const s of ["pending", "running", "paused", "succeeded"] as const) {
+      expect(canRestart(s)).toBe(false);
+    }
   });
 });
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0052_routine_eval_floor_seq.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0052_routine_eval_floor_seq.py
@@ -1,0 +1,72 @@
+"""为 Routine 新增 eval_floor_seq（决策窗口水位线），支撑失败任务「重新启动 / 重跑」。
+
+Revision ID: 0052
+Revises: 0051
+Create Date: 2026-05-31 12:00:00.000000+00:00
+
+设计动机：
+    失败 / 取消的 Routine 需要「一键重跑」能力。重启时复位运行态计数器（iteration_count /
+    total_cost_usd / score / session / phase / pr_url）并将 status 置回 running 即可让编排器重新派发；
+    但 ``decide()`` 的 no_progress / oscillation / 连续失败守卫均基于 ``_evaluated_history()``——
+    它返回该 routine **全部** evaluated 迭代。若新一轮迭代追加在旧迭代之后，会被**旧一轮评分**判定为
+    停滞而被立即再次终止。
+
+      ``routines.eval_floor_seq``：决策窗口水位线。仅 ``seq > eval_floor_seq`` 的迭代参与
+      决策 / 审批判定。重启时置为当前 ``MAX(seq)``，使新一轮尝试拥有干净的判定窗口，
+      同时**保留**既往迭代行（审计 + ``uq_routine_iterations_seq`` 唯一性，``_next_seq()`` 取
+      ``MAX(seq)+1`` 天然不冲突）。server_default='0' 对既有行安全回填（等价「全窗口」语义不变）。
+
+幂等性：
+    加列前以 information_schema 探测列存在性（仿 0048/0049 范式），便于半失败重试。
+
+参考文献：
+[1] 0049_routine_phase_and_pr.py — information_schema 幂等 DDL + schema 限定范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0052"
+down_revision: str | None = "0051"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :s AND table_name = :t AND column_name = :c"
+            ),
+            {"s": SCHEMA, "t": table_name, "c": column_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if not _column_exists(bind, "routines", "eval_floor_seq"):
+        op.add_column(
+            "routines",
+            sa.Column(
+                "eval_floor_seq",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+                comment="决策窗口水位线：仅 seq > 此值的迭代参与 decide/审批判定；重启时置为当前 MAX(seq)",
+            ),
+            schema=SCHEMA,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    if _column_exists(bind, "routines", "eval_floor_seq"):
+        op.drop_column("routines", "eval_floor_seq", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -201,8 +201,9 @@ class RoutineOrchestrator:
                 if not routine.pr_url:
                     routine.pr_url = phase_mod.extract_pr_url(latest.summary)
 
-            # 决策（decision.py 保持纯守卫；相位化 routine 由 orchestrator 解释 SUCCESS）
-            history = await self._evaluated_history(db, routine_id)
+            # 决策（decision.py 保持纯守卫；相位化 routine 由 orchestrator 解释 SUCCESS）。
+            # 仅取「本次尝试」窗口（seq > eval_floor_seq）：重启后旧迭代不污染停滞/振荡判定。
+            history = await self._evaluated_history(db, routine_id, floor=routine.eval_floor_seq)
             verdict = decision_mod.decide(routine, latest, history)
             if phase_mod.is_phased(routine.config):
                 self._advance_phase_or_terminate(routine, verdict)
@@ -280,7 +281,9 @@ class RoutineOrchestrator:
                 prompt = build_prompt(routine, max_reflections=settings.routine.max_reflections_injected)
                 phased = phase_mod.is_phased(routine.config)
                 has_prior_impl = (
-                    await self._has_prior_phase_iteration(db, routine.id, phase_mod.PHASE_IMPLEMENT)
+                    await self._has_prior_phase_iteration(
+                        db, routine.id, phase_mod.PHASE_IMPLEMENT, floor=routine.eval_floor_seq
+                    )
                     if phased
                     else False
                 )
@@ -466,7 +469,8 @@ class RoutineOrchestrator:
         ).scalar_one_or_none()
 
     @staticmethod
-    async def _evaluated_history(db: AsyncSession, routine_id: UUID) -> list[RoutineIteration]:
+    async def _evaluated_history(db: AsyncSession, routine_id: UUID, *, floor: int = 0) -> list[RoutineIteration]:
+        """本次尝试的已评估迭代历史（seq > floor）。floor=eval_floor_seq 隔离重启前的旧迭代。"""
         return list(
             (
                 await db.execute(
@@ -474,6 +478,7 @@ class RoutineOrchestrator:
                     .where(
                         RoutineIteration.routine_id == routine_id,
                         RoutineIteration.status == "evaluated",
+                        RoutineIteration.seq > floor,
                     )
                     .order_by(RoutineIteration.seq.asc())
                 )
@@ -483,8 +488,11 @@ class RoutineOrchestrator:
         )
 
     @staticmethod
-    async def _has_prior_phase_iteration(db: AsyncSession, routine_id: UUID, phase: str) -> bool:
-        """该 routine 是否已存在指定相位的非废弃迭代（用于「首个 implement 迭代」审批判定）。"""
+    async def _has_prior_phase_iteration(db: AsyncSession, routine_id: UUID, phase: str, *, floor: int = 0) -> bool:
+        """本次尝试是否已存在指定相位的非废弃迭代（用于「首个 implement 迭代」审批判定）。
+
+        仅看 seq > floor 的迭代：重启（eval_floor_seq 抬高）后会**重新门控**首个 implement 迭代。
+        """
         row = (
             await db.execute(
                 select(RoutineIteration.id)
@@ -492,6 +500,7 @@ class RoutineOrchestrator:
                     RoutineIteration.routine_id == routine_id,
                     RoutineIteration.phase == phase,
                     RoutineIteration.status.not_in(("aborted", "reaped")),
+                    RoutineIteration.seq > floor,
                 )
                 .limit(1)
             )

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -13,6 +13,7 @@
 - POST   /routines/{id}/pause                暂停（running → paused，中止在途迭代）
 - POST   /routines/{id}/resume               恢复（paused → running）
 - POST   /routines/{id}/cancel               取消（→ cancelled）
+- POST   /routines/{id}/restart              重启（failed/cancelled → running，复位运行态 + 抬高决策水位线）
 - POST   /routines/{id}/iterations/{iid}/approve   审批通过待执行迭代
 - POST   /routines/{id}/iterations/{iid}/reject    驳回待执行迭代
 - GET    /routines/stream                    SSE 实时事件（routine + iteration）
@@ -135,6 +136,10 @@ class RoutineUpdateRequest(BaseModel):
 
 class ControlBody(BaseModel):
     reason: str | None = None
+
+
+class RestartBody(BaseModel):
+    keep_reflections: bool = True  # True=携带既往反思（Reflexion 跨尝试学习）；False=清空重来
 
 
 # ---------------------------------------------------------------------------
@@ -675,6 +680,68 @@ async def cancel_routine(routine_id: UUID, body: ControlBody | None = None) -> d
     return _serialize_routine(r)
 
 
+@router.post("/{routine_id}/restart")
+async def restart_routine(routine_id: UUID, body: RestartBody | None = None) -> dict[str, Any]:
+    """重新启动失败 / 取消的 routine：非成功终态 → running，复位运行态并开启新一轮尝试。
+
+    复位运行期计数器（迭代数 / 成本 / 评分 / session / 相位 / PR）使预算守卫从零重新计；
+    抬高 ``eval_floor_seq`` 至当前 ``MAX(seq)`` 使新一轮的停滞 / 振荡 / 审批判定不被既往迭代污染
+    （旧迭代行**保留**供审计，seq 唯一性由 ``_next_seq`` 取 ``MAX(seq)+1`` 保证）。
+    ``deadline`` 为绝对时间，无法靠归零复活——已过期则拒绝并引导用户先更新截止时间。
+    """
+    keep_reflections = body.keep_reflections if body is not None else True
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id, with_for_update=True)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if r.status not in ("failed", "cancelled"):
+            raise HTTPException(
+                status_code=409,
+                detail=f"cannot restart from status '{r.status}'; only failed/cancelled routines can be restarted",
+            )
+        if r.deadline_at is not None:
+            deadline = r.deadline_at if r.deadline_at.tzinfo else r.deadline_at.replace(tzinfo=UTC)
+            if _utcnow() >= deadline:
+                raise HTTPException(
+                    status_code=409,
+                    detail="deadline has passed; update or clear the deadline before restarting",
+                )
+
+        # 闭合上一轮遗留的全部非终态迭代（含 executed）。终态 routine 理论上不应有在途迭代，
+        # 但 cancel 会保留 executed 迭代、且崩溃/reaper 竞态可能遗留孤儿；若不闭合，重启后
+        # 这些旧迭代会被 _find_routines_pending_eval / _has_active_iteration 拾取，污染新尝试
+        # 评分/反思、阻塞派发甚至即刻误终止。须在抬高 eval_floor_seq 前完成（同一事务内）。
+        await _abort_active_iterations(db, routine_id, include_executed=True)
+
+        max_seq = (
+            await db.execute(
+                select(func.coalesce(func.max(RoutineIteration.seq), 0)).where(
+                    RoutineIteration.routine_id == routine_id
+                )
+            )
+        ).scalar_one()
+
+        # 复位运行态（保留任务定义 / 预算策略 / 既往迭代行）
+        r.status = "running"
+        r.termination_reason = None
+        r.iteration_count = 0
+        r.total_cost_usd = 0.0
+        r.best_score = None
+        r.last_score = None
+        r.claude_session_id = None
+        r.current_phase = phase_mod.initial_phase(r.config)
+        r.pr_url = None
+        r.eval_floor_seq = int(max_seq)
+        if not keep_reflections:
+            r.reflections = {}
+
+        await db.commit()
+        await db.refresh(r)
+    _KPI_CACHE.invalidate()
+    await _publish_routine(r)
+    return _serialize_routine(r)
+
+
 # ---------------------------------------------------------------------------
 # 审批门控：approve / reject
 # ---------------------------------------------------------------------------
@@ -716,8 +783,13 @@ async def reject_iteration(routine_id: UUID, iteration_id: UUID) -> dict[str, An
 # ---------------------------------------------------------------------------
 
 
-async def _abort_active_iterations(db, routine_id: UUID) -> None:
-    """中止该 routine 当前在途/待执行迭代：请求 runner abort + 标记 aborted。"""
+async def _abort_active_iterations(db, routine_id: UUID, *, include_executed: bool = False) -> None:
+    """中止该 routine 当前在途/待执行迭代：请求 runner abort + 标记 aborted。
+
+    默认（pause/cancel）保留 ``executed`` 迭代（结果已产出，待评估）。``include_executed=True``
+    时（restart）连同 ``executed`` 一并闭合为 aborted——重启开启全新尝试，上一轮遗留的未评估
+    结果不应被新一轮的评估/派发链路拾取（否则会污染新尝试评分/反思甚至即刻误终止）。
+    """
     from negentropy.engine.routine.runner import get_runner
 
     runner = get_runner()
@@ -733,11 +805,12 @@ async def _abort_active_iterations(db, routine_id: UUID) -> None:
         .scalars()
         .all()
     )
+    abortable = _NON_TERMINAL_ITER if include_executed else ("pending_approval", "dispatched", "in_flight")
     now = _utcnow()
     for it in rows:
         runner.request_abort(it.id)
-        # executed 等待评估的不强行中止（结果已产出）；其余标记 aborted
-        if it.status in ("pending_approval", "dispatched", "in_flight"):
+        # executed 等待评估的默认不强行中止（结果已产出）；其余（含 restart 的 executed）标记 aborted
+        if it.status in abortable:
             it.status = "aborted"
             it.finished_at = now
             it.lease_expires_at = None

--- a/apps/negentropy/src/negentropy/models/routine.py
+++ b/apps/negentropy/src/negentropy/models/routine.py
@@ -128,6 +128,9 @@ class Routine(Base, UUIDMixin, TimestampMixin):
     best_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     last_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
     claude_session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # 决策窗口水位线：仅 seq > 此值的迭代参与 decide/审批判定。重启失败 routine 时置为当前
+    # MAX(seq)，使新一轮尝试的停滞/振荡/审批判定不被既往迭代「污染」（旧迭代仍保留供审计）。
+    eval_floor_seq: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
 
     # --- Reflexion 反思记忆 + Claude Code 配置覆盖 ---
     reflections: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default="{}")

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -278,6 +278,46 @@ async def test_redispatch_after_aborted_iteration_uses_next_seq():
         await _cleanup(rid)
 
 
+# 重启决策窗口隔离的 A/B 对照：两用例数据完全相同（seq1-5），仅 eval_floor_seq 不同（4 vs 0），
+# 结果相反——证明 eval_floor_seq 确实将停滞判定收敛到「本次尝试」，而非由旧迭代评分驱动。
+# 旧尝试设高基线（seq1=90）+ 多条低分（seq2-4=40），使 no_progress 的「窗口前最优」基线为 90。
+async def _seed_restart_pollution_case(eval_floor_seq: int, iteration_count: int) -> uuid.UUID:
+    rid = await _make_routine(
+        no_progress_patience=3, eval_floor_seq=eval_floor_seq, iteration_count=iteration_count, max_iterations=50
+    )
+    await _add_iteration(rid, seq=1, status="evaluated", score=90, verdict="progressing")
+    await _add_iteration(rid, seq=2, status="evaluated", score=40, verdict="progressing")
+    await _add_iteration(rid, seq=3, status="evaluated", score=40, verdict="progressing")
+    await _add_iteration(rid, seq=4, status="evaluated", score=40, verdict="progressing")
+    await _add_iteration(rid, seq=5, status="executed", exec_status="success", summary="wip")
+    return rid
+
+
+async def test_evaluate_floor_isolates_restarted_attempt():
+    """重启回归：eval_floor_seq=4 把旧 seq1-4 排除在决策窗口外，新一轮不被旧历史误判 no_progress。"""
+    rid = await _seed_restart_pollution_case(eval_floor_seq=4, iteration_count=1)
+    try:
+        await _evaluate_phased(rid, score=40, verdict="progressing")
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "running"  # 新窗口几无历史 → 不判停滞
+    finally:
+        await _cleanup(rid)
+
+
+async def test_evaluate_without_floor_pre_history_triggers_no_progress():
+    """对照：floor=0（未隔离）时旧高基线历史使新低分迭代被 no_progress 终止——证明 floor 的必要性。"""
+    rid = await _seed_restart_pollution_case(eval_floor_seq=0, iteration_count=5)
+    try:
+        await _evaluate_phased(rid, score=40, verdict="progressing")
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "failed"
+            assert r.termination_reason == "no_progress"
+    finally:
+        await _cleanup(rid)
+
+
 async def test_write_back_no_double_count_when_reaped_midflight():
     """回归（code review #5）：迭代在执行中被 reaper 标记 reaped 后，
     runner 的 write-back 不应把它复活为 executed、也不应重复累加 iteration_count/cost。"""

--- a/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
@@ -15,11 +15,12 @@
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import httpx
 import pytest
 from fastapi import FastAPI
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select
 
 import negentropy.db.session as db_session
 from negentropy.interface.routine_api import router
@@ -155,5 +156,162 @@ async def test_iteration_approve_reject():
             # reject → aborted
             rj = await c.post(f"/routines/{rid}/iterations/{iid2}/reject")
             assert rj.status_code == 200 and rj.json()["status"] == "aborted"
+    finally:
+        await _cleanup("itest_api_")
+
+
+async def test_restart_failed_resets_run_state_and_sets_floor():
+    """失败 routine 重启：复位运行态计数器，抬高 eval_floor_seq=MAX(seq)，保留既往迭代与反思。"""
+    app = _app()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            r = await c.post(
+                "/routines",
+                json={
+                    "key": key,
+                    "title": "Restart Reset",
+                    "goal": "g",
+                    "acceptance_criteria": "a",
+                    "max_cost_usd": 10,
+                },
+            )
+            rid = r.json()["id"]
+
+        # 造 failed 终态 + 累积运行态 + 两条 evaluated 迭代（seq 1,2）
+        async with db_session.AsyncSessionLocal() as db:
+            ro = await db.get(Routine, uuid.UUID(rid))
+            ro.status = "failed"
+            ro.termination_reason = "max_cost"
+            ro.iteration_count = 3
+            ro.total_cost_usd = 9.9
+            ro.best_score = 55
+            ro.last_score = 50
+            ro.claude_session_id = "sess-old"
+            ro.pr_url = "https://github.com/o/r/pull/1"
+            ro.reflections = {"items": ["lesson A", "lesson B"]}
+            db.add_all(
+                [
+                    RoutineIteration(routine_id=ro.id, seq=1, status="evaluated", score=40, verdict="progressing"),
+                    RoutineIteration(routine_id=ro.id, seq=2, status="evaluated", score=55, verdict="progressing"),
+                ]
+            )
+            await db.commit()
+
+        async with _client(app) as c:
+            res = await c.post(f"/routines/{rid}/restart", json={"keep_reflections": True})
+            assert res.status_code == 200, res.text
+            body = res.json()
+            assert body["status"] == "running"
+            assert body["termination_reason"] is None
+            assert body["iteration_count"] == 0
+            assert body["total_cost_usd"] == 0.0
+            assert body["best_score"] is None
+            assert body["last_score"] is None
+            assert body["claude_session_id"] is None
+            assert body["pr_url"] is None
+            assert body["reflections"] == ["lesson A", "lesson B"]  # keep_reflections=True 保留
+
+        async with db_session.AsyncSessionLocal() as db:
+            ro = await db.get(Routine, uuid.UUID(rid))
+            assert ro.eval_floor_seq == 2  # = MAX(seq)，新一轮决策窗口隔离旧迭代
+            # 旧迭代行保留供审计（未删除）
+            cnt = (
+                await db.execute(
+                    select(func.count()).select_from(RoutineIteration).where(RoutineIteration.routine_id == ro.id)
+                )
+            ).scalar_one()
+            assert cnt == 2
+    finally:
+        await _cleanup("itest_api_")
+
+
+async def test_restart_closes_leftover_nonterminal_iterations():
+    """回归（code review）：cancel 保留 executed 迭代；restart 须闭合全部遗留非终态迭代，
+
+    否则重启后 _find_routines_pending_eval/_has_active_iteration 会拾取旧迭代污染新尝试。
+    """
+    app = _app()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            r = await c.post(
+                "/routines",
+                json={"key": key, "title": "Restart Leftover", "goal": "g", "acceptance_criteria": "a"},
+            )
+            rid = r.json()["id"]
+
+        # cancelled 终态 + 遗留一条未评估的 executed 迭代（cancel 不会中止 executed）+ 一条 pending_approval
+        async with db_session.AsyncSessionLocal() as db:
+            ro = await db.get(Routine, uuid.UUID(rid))
+            ro.status = "cancelled"
+            db.add_all(
+                [
+                    RoutineIteration(routine_id=ro.id, seq=1, status="executed", exec_status="success", summary="old"),
+                    RoutineIteration(routine_id=ro.id, seq=2, status="pending_approval", prompt="p"),
+                ]
+            )
+            await db.commit()
+
+        async with _client(app) as c:
+            res = await c.post(f"/routines/{rid}/restart", json={"keep_reflections": True})
+            assert res.status_code == 200 and res.json()["status"] == "running"
+
+        # 遗留迭代须全部闭合为 aborted（无任何非终态行残留），eval_floor_seq=MAX(seq)=2
+        async with db_session.AsyncSessionLocal() as db:
+            its = (
+                (await db.execute(select(RoutineIteration).where(RoutineIteration.routine_id == uuid.UUID(rid))))
+                .scalars()
+                .all()
+            )
+            assert {it.seq: it.status for it in its} == {1: "aborted", 2: "aborted"}
+            ro = await db.get(Routine, uuid.UUID(rid))
+            assert ro.eval_floor_seq == 2
+    finally:
+        await _cleanup("itest_api_")
+
+
+async def test_restart_guards_and_reflection_reset():
+    """重启守卫：仅 failed/cancelled 可重启；keep_reflections=False 清空反思；过期 deadline → 409。"""
+    app = _app()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            r = await c.post(
+                "/routines",
+                json={"key": key, "title": "Restart Guard", "goal": "g", "acceptance_criteria": "a"},
+            )
+            rid = r.json()["id"]
+            # pending → 409
+            assert (await c.post(f"/routines/{rid}/restart")).status_code == 409
+            # running → 409
+            await c.post(f"/routines/{rid}/start")
+            assert (await c.post(f"/routines/{rid}/restart")).status_code == 409
+
+        # cancelled + 既往反思
+        async with db_session.AsyncSessionLocal() as db:
+            ro = await db.get(Routine, uuid.UUID(rid))
+            ro.status = "cancelled"
+            ro.reflections = {"items": ["old lesson"]}
+            await db.commit()
+
+        async with _client(app) as c:
+            # cancelled 可重启 + keep_reflections=False → 清空反思
+            res = await c.post(f"/routines/{rid}/restart", json={"keep_reflections": False})
+            assert res.status_code == 200 and res.json()["status"] == "running"
+            assert res.json()["reflections"] == []
+
+        # failed + 过期 deadline → 409（绝对时间无法靠归零复活）
+        async with db_session.AsyncSessionLocal() as db:
+            ro = await db.get(Routine, uuid.UUID(rid))
+            ro.status = "failed"
+            ro.termination_reason = "deadline"
+            ro.deadline_at = datetime(2000, 1, 1, tzinfo=UTC)
+            await db.commit()
+
+        async with _client(app) as c:
+            past = await c.post(f"/routines/{rid}/restart")
+            assert past.status_code == 409
+            assert "deadline" in past.json()["detail"]
     finally:
         await _cleanup("itest_api_")


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface/Routine 中进入 `failed`/`cancelled` 终态的任务此前**只能删除、无重跑路径**（`controlsFor()` 对终态返回空）。截图中如 `项目架构清减`（failed / max_cost / 3-20 / best 55）这类任务，用户只能新建全新 Routine 重来，丢失任务定义复用与既往迭代/反思的审计价值。
- 关联上下文：用户附图诉求「failed 的 Routine 应提供重新启动重跑能力」；结合 UI/UX Skill 设计交互。

# 核心变更
- **后端 · 决策窗口隔离（正确性基石）**：新增 `Routine.eval_floor_seq` 水位线列 + 迁移 `0052`（幂等、`negentropy` schema）；编排器 `_evaluated_history` / `_has_prior_phase_iteration` 增 `floor` 过滤，使重启后的「停滞/振荡/审批」判定**仅基于本次尝试**——否则新一轮会被上一轮高分迭代误判为 `no_progress` 而即刻再次终止。
- **后端 · 重启端点**：`POST /routines/{id}/restart`，守卫仅 `failed`/`cancelled` 可重启、过期 `deadline` 拒绝并引导；复位运行态（迭代数/成本/评分/session/相位/PR），抬高 `eval_floor_seq` 至当前 `MAX(seq)`，`keep_reflections` 决定是否携带既往反思；重启前以 `include_executed=True` 复用 `_abort_active_iterations` 闭合全部遗留非终态迭代（含 cancel 保留的 `executed`），避免旧迭代被评估链路拾取污染新尝试。
- **前端 · 三处入口单一逻辑源**：`RestartRoutineDialog`（失败原因 + 反思去留开关 + deadline 提示，复用 `OverlayDismissLayer`）+ `useRestartRoutine` Hook，供列表行内、编辑抽屉、详情页头部共用；Restart 为建设性恢复操作用 primary（非红色 Delete），代理 pass-through 零改动。

# 风险与回滚
- 主要风险：① `eval_floor_seq` 过滤改动了 `_evaluated_history` 行为，已加 A/B 对照回归用例锁定；② 运行中的引擎进程需重启加载新代码后 `/restart` 路由方生效（迁移向后兼容，旧代码无视新列）。
- 回滚方式：还原本分支提交即可；迁移 `0052` 为纯加列（`server_default='0'`，语义等价「全窗口」），可安全 `alembic downgrade` 或保留无害。

# 验证证据
- 单元测试：前端 `routine-api.test.ts` 16 项通过（`restartRoutine` 路由 + body、`canRestart` 判定）；后端 `test_routine_decision`/`test_routine_phase` 30 项通过。
- 集成测试：后端 `test_routine_api` + `test_routine_orchestrator` 共 19 项通过，覆盖 200/409 守卫、反思去留、`eval_floor_seq=MAX(seq)`、遗留 `executed`/`pending_approval` 迭代闭合、决策窗口隔离 A/B 对照。
- E2E/Workflow：workspace alt-port dev server 实机验证——失败行显示 Restart、paused 行不显示；对话框正确呈现失败原因与反思开关。
- 覆盖率/关键截图：ruff check/format、ESLint、tsc 自身文件零错误；明暗双模式对话框对比度已核对。

# 影响范围
- 前端：`features/routine`（api/index）、`app/interface/routine`（page、`[id]/page`、`_components` 新增 2 文件 + 改 3 文件）。
- 后端：`models/routine.py`、迁移 `0052`、`engine/routine/orchestrator.py`、`interface/routine_api.py`。
- GitHub Actions / 文档：无 CI 配置变更；端点清单 docstring 已同步。

# Next Best Action
- 重启运行中的 Negentropy 引擎进程以加载 `/restart` 路由（DB 迁移已应用，向后兼容）；随后可对截图中失败任务实机走一次完整重跑闭环验证。