### PR TITLE
feat(routine-audit): 审计步骤行展示更完整操作对象并补充每行时间戳;

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -189,7 +189,7 @@ function mergeEvents(
       title: a.title ?? null,
       payload: a.payload ?? {},
       cost_usd: a.cost_usd ?? null,
-      created_at: null,
+      created_at: a.ts ?? null, // 服务端 emit 时刻：在途行据此显示时间戳（持久化后由 DB created_at 覆盖）
     });
   }
   for (const e of persisted) {

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -92,6 +92,33 @@ function payloadIsError(payload: Record<string, unknown>): boolean {
   return payload?.is_error === true;
 }
 
+/**
+ * 路径感知的单行标题拆分：以最后一个 ``/`` 切出末段（文件名）。
+ * 仅当末段非空且不含空白才钉尾（规避对含空格命令/正则的误拆），否则整串走纯 truncate。
+ */
+function splitPathLikeTitle(title: string): { head: string; tail: string } {
+  const i = title.lastIndexOf("/");
+  if (i < 0) return { head: title, tail: "" };
+  const tail = title.slice(i + 1);
+  if (!tail || /\s/.test(tail)) return { head: title, tail: "" };
+  return { head: title.slice(0, i + 1), tail };
+}
+
+/**
+ * 单行「路径感知」标题：前缀走 truncate（空间紧张时在头尾之间出省略号），文件名末段 ``shrink-0``
+ * 永不裁剪 —— 即 ``/Users/.../foo.py`` 效果，宽度自适应。非路径标题退化为整串单行 truncate。
+ * ``truncate`` 自带 ``overflow:hidden`` 使该 flex 子项 auto 最小尺寸归零，无需额外 ``min-w-0``。
+ */
+function EventTitle({ title }: { title: string }) {
+  const { head, tail } = splitPathLikeTitle(title);
+  return (
+    <span className="flex min-w-0 flex-1 items-baseline text-xs text-foreground" title={title}>
+      <span className="truncate">{head}</span>
+      {tail && <span className="shrink-0">{tail}</span>}
+    </span>
+  );
+}
+
 function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
   const [open, setOpen] = useState(false);
   const isError = payloadIsError(ev.payload);
@@ -124,9 +151,7 @@ function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
             aria-hidden
           />
         )}
-        <span className="min-w-0 flex-1 truncate text-xs text-foreground" title={title}>
-          {title}
-        </span>
+        <EventTitle title={title} />
         {isError && (
           <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-red-600 dark:text-red-400">
             error
@@ -134,6 +159,14 @@ function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
         )}
         {ev.cost_usd != null && ev.cost_usd > 0 && (
           <span className="shrink-0 text-[10px] tabular-nums text-text-muted">${ev.cost_usd.toFixed(4)}</span>
+        )}
+        {ev.created_at && (
+          <span
+            className="shrink-0 text-[10px] tabular-nums text-text-muted"
+            title={new Date(ev.created_at).toLocaleString()}
+          >
+            {new Date(ev.created_at).toLocaleTimeString()}
+          </span>
         )}
         <span className="shrink-0 text-[10px] tabular-nums text-text-muted">#{ev.seq}</span>
       </button>

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -129,7 +129,8 @@ export interface IterationEventsResponse {
 
 /**
  * 实时 ``action`` 事件载荷 —— SSE 推送的动作事件（携带 routine_id/iteration_id/seq + 归一化字段）。
- * 无 ``id``（尚未落库），无 ``created_at``；前端据 ``(iteration_id, seq)`` 与持久化事件去重合并。
+ * 无 ``id``（尚未落库）；``ts`` 为服务端 emit 时刻（ISO 串），合并时回填为在途行的 ``created_at``。
+ * 前端据 ``(iteration_id, seq)`` 与持久化事件去重合并。
  */
 export interface RoutineActionStreamEvent {
   type: "action";
@@ -141,6 +142,8 @@ export interface RoutineActionStreamEvent {
   title?: string | null;
   payload?: Record<string, unknown>;
   cost_usd?: number | null;
+  /** 服务端 emit 时刻（ISO 8601）；持久化前的实时行据此显示时间戳。 */
+  ts?: string | null;
 }
 
 /**

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { IterationEventTimeline } from "@/app/interface/routine/_components/IterationEventTimeline";
+import type { RoutineIterationEventDTO } from "@/features/routine";
+
+/** 构造一条 tool_use 审计事件（归入「执行」分组，必渲染一行）。 */
+function makeEvent(overrides: Partial<RoutineIterationEventDTO> = {}): RoutineIterationEventDTO {
+  return {
+    id: "e1",
+    iteration_id: "it1",
+    routine_id: "r1",
+    seq: 1,
+    event_type: "tool_use",
+    tool_name: "Read",
+    title: "Read /repo/a/b/c/target_file.py",
+    payload: {},
+    cost_usd: null,
+    created_at: "2026-06-01T09:08:07+00:00",
+    ...overrides,
+  };
+}
+
+describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳", () => {
+  it("路径标题：文件名尾部成独立块永不裁剪，完整标题进 title 悬浮", () => {
+    const title = "Read /repo/a/b/c/target_file.py";
+    render(<IterationEventTimeline events={[makeEvent({ title })]} />);
+    // 文件名尾部单独成 span（前缀即便被 truncate 也不会丢失）
+    expect(screen.getByText("target_file.py")).toBeInTheDocument();
+    // 完整标题可悬浮查看（拆分为头/尾两段，故整串只存在于 title 属性）
+    expect(document.querySelector(`[title="${title}"]`)).not.toBeNull();
+  });
+
+  it("每行渲染本地化时间戳，悬浮显示完整日期时间", () => {
+    const created = "2026-06-01T09:08:07+00:00";
+    render(<IterationEventTimeline events={[makeEvent({ created_at: created })]} />);
+    // 与组件同口径计算，规避 CI 时区/locale 漂移
+    expect(screen.getByText(new Date(created).toLocaleTimeString())).toBeInTheDocument();
+    expect(document.querySelector(`[title="${new Date(created).toLocaleString()}"]`)).not.toBeNull();
+  });
+
+  it("created_at 为空时不渲染时间戳（防御 null，覆盖在途未落库占位）", () => {
+    const probe = new Date("2026-06-01T09:08:07+00:00").toLocaleTimeString();
+    render(<IterationEventTimeline events={[makeEvent({ created_at: null })]} />);
+    expect(screen.queryByText(probe)).toBeNull();
+  });
+
+  it("非路径标题（无斜杠）整串渲染，不误拆尾段", () => {
+    render(<IterationEventTimeline events={[makeEvent({ tool_name: "Bash", title: "Bash: pytest -q" })]} />);
+    expect(screen.getByText("Bash: pytest -q")).toBeInTheDocument();
+  });
+});

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -93,7 +93,10 @@ def _tool_title(name: str | None, tool_input: Any) -> str | None:
     for key in ("file_path", "path", "notebook_path", "command", "pattern", "query", "url"):
         val = tool_input.get(key)
         if isinstance(val, str) and val:
-            short = val if len(val) <= 80 else val[:80] + "…"
+            # 上限 200：容纳绝大多数真实 workspace 路径/命令（"Read " + 200 < 255 DB 标题列上限）；
+            # 仍保留头部截断——command/pattern/query 的头部即主信息，路径则交由前端「路径感知」单行
+            # 截断保留文件名尾部。
+            short = val if len(val) <= 200 else val[:200] + "…"
             sep = ": " if key in ("command", "pattern", "query") else " "
             return f"{name}{sep}{short}"
     return name

--- a/apps/negentropy/src/negentropy/engine/routine/runner.py
+++ b/apps/negentropy/src/negentropy/engine/routine/runner.py
@@ -167,7 +167,11 @@ class RoutineRunner:
 
         async def _sink(evt: dict[str, Any]) -> None:
             with suppress(Exception):
-                await get_bus().publish({"type": "action", "routine_id": rid, "iteration_id": iid, **evt})
+                # ts：服务端 emit 时刻（与持久化 created_at 同为服务端时间），供前端为在途行渲染时间戳；
+                # 仅注入发布载荷，不污染用于写回持久化的 result.events（其时间走 DB server_default）。
+                await get_bus().publish(
+                    {"type": "action", "routine_id": rid, "iteration_id": iid, "ts": _utcnow().isoformat(), **evt}
+                )
 
         return _sink
 

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_event_capture.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_event_capture.py
@@ -14,6 +14,7 @@ from negentropy.engine.claude_code.service import (
     _coerce_content,
     _emit_events,
     _normalize_stream_event,
+    _tool_title,
 )
 
 
@@ -75,6 +76,20 @@ def test_tool_use_bash_title_uses_command():
         }
     )
     assert out[0]["title"] == "Bash: pytest -q"
+
+
+def test_tool_title_truncation_cap_is_200():
+    """标题截断上限 200：≤200 全保留（含文件名尾部不丢失），>200 才头部截断 + 省略号。"""
+    # ≤200 的深层路径：完整保留，文件名尾部可见（旧 80 上限下会被砍掉）
+    deep = "/repo/" + "seg/" * 40 + "target.py"  # 6 + 160 + 9 = 175
+    assert len(deep) <= 200
+    assert _tool_title("Read", {"file_path": deep}) == f"Read {deep}"
+    assert _tool_title("Read", {"file_path": deep}).endswith("target.py")
+
+    # >200 的超长路径：参数部分截到 200 + 省略号
+    long_path = "/repo/" + "seg/" * 60 + "target.py"  # 6 + 240 + 9 = 255 > 200
+    assert len(long_path) > 200
+    assert _tool_title("Read", {"file_path": long_path}) == f"Read {long_path[:200]}…"
 
 
 def test_assistant_thinking_block():


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 迭代「全过程审计」抽屉中，步骤行的操作对象（文件路径/命令）被严重截断——后端 80 字符头部截断恰好丢掉最有信息量的文件名尾部，前端单行 CSS `truncate` 再次按视口裁剪；且每行缺少时间戳，无法判断动作发生时刻与节奏（在途迭代尤甚：实时 SSE 事件无任何时间字段）。
- 关联上下文：用户反馈（截图「迭代 #12 · 全过程审计」），按确认方案「单行中间省略·保留头部与文件名尾部 + 绝对时刻 HH:mm:ss」实施。

# 核心变更
- 后端 `_tool_title` 标题参数截断上限 80→200（仍 < 255 DB 列上限），避免文件名尾部在数据层就丢失。
- 实时动作发布载荷补发服务端 emit 时刻 `ts`，使在途迭代行也能显示时间戳，且不污染用于写回持久化的 `result.events`。
- 前端新增 `EventTitle`「路径感知」单行截断（前缀 `truncate`、文件名末段 `shrink-0` 永不裁剪，即 `Read /repo/.../target.py` 效果），并在每行渲染 `toLocaleTimeString()` 时间戳 + 完整日期悬浮。
- `RoutineActionStreamEvent` 增可选 `ts`，`mergeEvents` 回填为在途行 `created_at`（已完成迭代仍用 DB `created_at`）。

# 风险与回滚
- 主要风险：纯展示层增强，风险低；后端 `ts` 需引擎/perceives 重启后在途行才生效；存量历史标题保持原 80 字符值（非回溯）。
- 回滚方式：`git revert` 本提交即可——无 DB schema / SSE 事件契约变更（仅新增可选字段），合并去重键 `(iteration_id, seq)` 不变。

# 验证证据
- 单元测试：后端 18 passed（含新增 200 字符边界用例 `test_tool_title_truncation_cap_is_200`）；前端新增 `IterationEventTimeline` 渲染测试 4 passed。
- 集成测试：Routine 既有前端用例 27 passed 回归通过。
- E2E/Workflow：未起实机 dev server 截图 / 在途 SSE 真链路核对（需完整后端栈 + 真实 routine 数据）；以确定性渲染测试覆盖可见 DOM 行为（文件名尾不裁剪 / 时间戳渲染 / null 防御 / 非路径回退）。
- 覆盖率/关键证据：`tsc --noEmit` exit 0、ESLint exit 0、pre-commit（ruff lint/format、ESLint）全部 Passed。

# 影响范围
- 前端：`IterationEventTimeline.tsx`、`IterationAuditDrawer.tsx`、`features/routine/types.ts`、新增组件测试。
- 后端：`engine/claude_code/service.py`、`engine/routine/runner.py`、`tests/unit_tests/engine/test_routine_event_capture.py`。
- GitHub Actions / 文档：无。

# Next Best Action
- 提供运行中的后端 + 一个含迭代事件的 routine，我可起 alt-port dev server 截图核对明暗主题与窄视口表现；并在引擎重启后验证在途行时间戳真链路。