### PR TITLE
feat(routine-template): 内置模板支持编辑并「另存为我的模板」(copy-on-write)

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -244,7 +244,8 @@ export function RoutineEditDrawer({
   const liveRoutine = mode.kind === "routine-edit" ? mode.routine : null;
   const isRunning = liveRoutine?.status === "running";
   const isBuiltinTemplate = mode.kind === "template-edit" && mode.template.source === "builtin";
-  const readOnly = isRunning || isBuiltinTemplate; // 运行中锁定 / 内置模板只读
+  // 仅运行中锁定；内置模板改为「可编辑 → 另存为我的模板」(copy-on-write)，以 create 语义提交一份用户副本。
+  const readOnly = isRunning;
   const requireCwd = mode.kind === "use-template";
 
   // ── 表单草稿态（仅挂载时 seed 一次）──
@@ -327,7 +328,8 @@ export function RoutineEditDrawer({
     if (readOnly) return;
 
     const errs: Record<string, string> = {};
-    if (op === "create" && !form.key.trim()) errs.key = "Key is required";
+    // 内置模板另存为副本走 create 语义，同样需要唯一 Key（op 仍为 edit，故单列判断）。
+    if ((op === "create" || isBuiltinTemplate) && !form.key.trim()) errs.key = "Key is required";
     if (!form.title.trim()) errs.title = "Title is required";
     if (!form.goal.trim()) errs.goal = "Goal is required";
     if (!form.acceptance_criteria.trim()) errs.acceptance_criteria = "Acceptance criteria is required";
@@ -394,25 +396,37 @@ export function RoutineEditDrawer({
 
     try {
       let result: RoutineDTO;
-      if (mode.kind === "routine-edit" || mode.kind === "template-edit") {
+      // 内置模板（builtin）无可改写的后端实体，编辑保存=另存为新的用户模板，故走 create 分支。
+      if ((mode.kind === "routine-edit" || mode.kind === "template-edit") && !isBuiltinTemplate) {
         // 用判别式收窄取 id（不用 as 强转，保持联合的穷尽性，未来新增 mode 时由编译器兜底）。
         const id = mode.kind === "routine-edit" ? mode.routine.id : mode.template.id;
         result = await updateRoutine(id, base as RoutineUpdatePayload);
         toast.success(entity === "template" ? "Template updated" : "Routine updated");
         setBaseline(form); // 重置脏基线（edit 类抽屉保持打开）
       } else {
+        // 含：routine-create / template-create / use-template / 内置模板「另存为我的模板」(copy-on-write)
         result = await createRoutine({ ...base, key: form.key.trim() } as RoutineCreatePayload);
         toast.success(
-          mode.kind === "template-create"
-            ? "Template created"
-            : mode.kind === "use-template"
-              ? `Routine created from "${mode.template.display_name}"`
-              : "Routine created",
+          isBuiltinTemplate
+            ? `Saved "${form.display_name.trim() || form.title.trim()}" as your template`
+            : mode.kind === "template-create"
+              ? "Template created"
+              : mode.kind === "use-template"
+                ? `Routine created from "${mode.template.display_name}"`
+                : "Routine created",
         );
       }
       onSaved(result, mode.kind);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An error occurred");
+      const msg = err instanceof Error ? err.message : "An error occurred";
+      // 内置模板另存时 Key 撞库（后端 409 "key already exists"）→ 定位到 Key 字段并给出修复指引
+      // （error-placement / error-clarity / aria-live-errors），而非仅顶部一条泛化报错。
+      if (isBuiltinTemplate && /already exists/i.test(msg)) {
+        setFieldErrors((e) => ({ ...e, key: "This key already exists — choose a different one." }));
+        setError("A template with this key already exists. Edit the Key field and try again.");
+      } else {
+        setError(msg);
+      }
     } finally {
       setLoading(false);
     }
@@ -451,7 +465,11 @@ export function RoutineEditDrawer({
 
   // 字段级错误渲染助手（普通函数，非组件 —— 避免 render 期创建组件丢失状态）。
   const renderFieldError = (name: string) =>
-    fieldErrors[name] ? <p className="mt-0.5 text-[10px] text-red-500">{fieldErrors[name]}</p> : null;
+    fieldErrors[name] ? (
+      <p role="alert" className="mt-0.5 text-[10px] text-red-500">
+        {fieldErrors[name]}
+      </p>
+    ) : null;
 
   return (
     <>
@@ -515,12 +533,23 @@ export function RoutineEditDrawer({
 
         <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
-            {/* 只读态说明（运行中 / 内置模板）—— 含恢复路径 */}
+            {/* 运行中锁定（只读，中性条）—— 含恢复路径 */}
             {readOnly && (
               <div className="rounded-card border border-border bg-muted/40 px-4 py-2.5 text-xs text-text-secondary">
-                {isRunning
-                  ? "This Routine is running. Pause it to edit its configuration."
-                  : "Built-in template — fields are read-only. Click Use to create a Routine from it."}
+                This Routine is running. Pause it to edit its configuration.
+              </div>
+            )}
+
+            {/* 内置模板：copy-on-write 信息条（非锁定语义；主色调以与禁用/只读态视觉区分） */}
+            {isBuiltinTemplate && (
+              <div
+                role="note"
+                className="rounded-card border border-primary/30 bg-primary/5 px-4 py-2.5 text-xs text-text-secondary"
+              >
+                Built-in preset. Editing and saving creates{" "}
+                <strong className="font-medium text-foreground">your own editable copy</strong>; the built-in preset
+                stays unchanged. You can also click <strong className="font-medium text-foreground">Use</strong> to
+                create a Routine directly.
               </div>
             )}
 
@@ -529,16 +558,19 @@ export function RoutineEditDrawer({
             {/* Key + Title */}
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className={labelCls}>Key{op === "create" && reqMark}</label>
+                <label className={labelCls}>Key{(op === "create" || isBuiltinTemplate) && reqMark}</label>
                 <input
                   type="text"
                   value={form.key}
                   onChange={(e) => update("key", e.target.value)}
-                  disabled={op === "edit" || readOnly}
+                  disabled={readOnly || (op === "edit" && !isBuiltinTemplate)}
                   placeholder="unique_key"
                   className={cn(inputCls, fieldErrors.key && "border-red-400")}
                 />
                 {renderFieldError("key")}
+                {isBuiltinTemplate && !fieldErrors.key && (
+                  <p className="mt-0.5 text-[10px] text-text-muted">Saved as a new template — pick a unique key.</p>
+                )}
               </div>
               <div>
                 <label className={labelCls}>Title{reqMark}</label>
@@ -889,7 +921,7 @@ export function RoutineEditDrawer({
             {mode.kind === "template-edit" && onUse && (
               <Button
                 type="button"
-                variant={isBuiltinTemplate ? "primary" : "outline"}
+                variant="outline"
                 size="sm"
                 disabled={loading}
                 onClick={() => onUse(mode.template)}
@@ -899,7 +931,13 @@ export function RoutineEditDrawer({
             )}
             {!readOnly && (
               <Button type="submit" variant="primary" size="sm" loading={loading}>
-                {op === "edit" ? "Save" : entity === "template" ? "Create Template" : "Create Routine"}
+                {isBuiltinTemplate
+                  ? "Save as my copy"
+                  : op === "edit"
+                    ? "Save"
+                    : entity === "template"
+                      ? "Create Template"
+                      : "Create Routine"}
               </Button>
             )}
             {mode.kind === "routine-edit" &&

--- a/apps/negentropy-ui/app/interface/routine/templates/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/templates/page.tsx
@@ -110,7 +110,11 @@ export default function RoutineTemplatesPage() {
       setDrawerMode(null);
       router.push(`/interface/routine/${result.id}`);
     } else if (kind === "template-edit") {
-      // 编辑保存 → 抽屉保持打开；草稿脏基线由 RoutineEditDrawer 内部 setBaseline(form) 重置。
+      // 内置模板「另存为我的模板」实为新建用户副本 → 关闭抽屉（新副本随 load 落到「我的」）；
+      // 用户模板就地保存 → 抽屉保持打开，草稿脏基线由 RoutineEditDrawer 内部 setBaseline(form) 重置。
+      if (drawerMode?.kind === "template-edit" && drawerMode.template.source === "builtin") {
+        setDrawerMode(null);
+      }
       load();
     } else {
       setDrawerMode(null);


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface / Routine「模板库」中点击**内置模板**（如「项目架构清减」）打开 Edit 抽屉时，所有属性字段只读、且没有 Save 按钮，无法基于内置预设定制自己的模板。
- 关联上下文/Issue/文档：内置模板源自代码仓库 YAML 预设（`apps/negentropy/src/negentropy/agents/routine_presets/*.yaml`，运行时加载、全局共享、纳入 Git，**无可改写它的后端实体**）；用户模板为 `routines` 表 `is_template=true` 行，本就支持编辑 + Save。

# 核心变更
- 采用业界经典 **Copy-on-Write**（对标 VS Code 默认只读+用户覆盖 / Figma·Notion 复制再编辑 / GitHub Fork）：内置模板字段改为可编辑，新增主操作「**Save as my copy**」，复用既有 `POST /routines + is_template:true` 将内置预设 fork 为用户自有模板（落到「我的」），**内置预设保持原样**。
- `RoutineEditDrawer.tsx`：解除内置只读锁（仅保留「运行中」锁定）；Key 字段在内置另存时可编辑+必填；提交按内置/用户分流到 create/update；撞库 409 内联归位到 Key 字段（`role=alert`）；copy-on-write 信息条以主色调与只读条区分；单一主 CTA（`Use` 降为次级）。
- `templates/page.tsx`：内置另存成功后关闭抽屉；用户模板就地编辑仍保持打开。

# 风险与回滚
- 主要风险：低。**纯前端、零后端改动、零数据库迁移、零新依赖**；复用经验证的「新建模板」链路，用户模板编辑/删除/Use 行为保持不变。
- 回滚方式：`git revert 13f8b8c9`（单 commit，仅 2 个前端文件）。

# 验证证据
- 单元测试：本次为前端交互改动，未新增单测。
- 集成测试：—
- E2E/Workflow：真实登录态 Chrome（后端 `:3292` + 工作区 UI `:3193`，明暗双主题）实机走查 —— 内置字段可编辑 + 另存生成用户副本且**预设不变**（后端核验 `source=user` 行已落库）；同 Key 再存 → 409 内联报错并可改 Key 恢复；用户模板就地更新（同 id、无新行、抽屉保持打开）；Console 仅一条**故意触发**的 409（已被 UI 优雅捕获）。测试数据已清理（DB 回到 4 内置 / 0 用户）。
- 覆盖率/关键截图：暗色模式抽屉截图 `.context/routine-template-edit-darkmode.png`（gitignored）。静态门禁：`tsc --noEmit` 0 error、`eslint` 0 warning、pre-commit hooks 全通过。

# 影响范围
- 前端：`apps/negentropy-ui` Routine 模板库抽屉（`RoutineEditDrawer`）与模板页（`templates/page`）。
- 后端：无（复用既有 `POST /routines`）。
- GitHub Actions / 文档：无。

# Next Best Action
- Review 合入 `feature/1.x.x`；如需将抽屉文案统一中文化（横幅/按钮/toast，约 6 处）可另起跟进。
