### PR TITLE
feat(facts-card): 语义化重设计 Memory/Facts 卡片，更直观紧凑且信息零丢失;

### DIFF
--- a/apps/negentropy-ui/app/memory/facts/_components/FactCard.tsx
+++ b/apps/negentropy-ui/app/memory/facts/_components/FactCard.tsx
@@ -1,77 +1,122 @@
 "use client";
 
-import { JsonViewer } from "@/components/ui/JsonViewer";
+import {
+  Clock,
+  History,
+  Lightbulb,
+  Scale,
+  Share2,
+  SlidersHorizontal,
+  Tag,
+  User,
+  type LucideIcon,
+} from "lucide-react";
+
 import type { FactItem } from "@/features/memory";
 
 import {
   formatConfidenceColor,
+  formatImportanceColor,
+  formatPercent,
   formatShortDate,
   formatValidityLabel,
-  getConfidenceLevel,
   isExpired,
 } from "../_lib/fact-helpers";
+import { FactValueView } from "./FactValueView";
 
 // ============================================================================
 // Sub-components
 // ============================================================================
 
-const FACT_TYPE_STYLES: Record<string, string> = {
-  preference:
-    "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
-  profile:
-    "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
-  knowledge:
-    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+interface FactTypeMeta {
+  icon: LucideIcon;
+  className: string;
+}
+
+// 类型徽标：图标 + 文字（色不单独表意）。补齐后端实际写入的 relation/rule，
+// 未知类型回退到中性 Tag 样式。
+const FACT_TYPE_META: Record<string, FactTypeMeta> = {
+  preference: {
+    icon: SlidersHorizontal,
+    className: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  },
+  profile: {
+    icon: User,
+    className:
+      "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  },
+  knowledge: {
+    icon: Lightbulb,
+    className:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  },
+  relation: {
+    icon: Share2,
+    className:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  },
+  rule: {
+    icon: Scale,
+    className: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+  },
+};
+
+const DEFAULT_TYPE_META: FactTypeMeta = {
+  icon: Tag,
+  className: "bg-muted text-text-secondary",
 };
 
 function FactTypeBadge({ type }: { type: string }) {
-  const style =
-    FACT_TYPE_STYLES[type] ??
-    "bg-muted text-text-secondary";
+  const meta = FACT_TYPE_META[type] ?? DEFAULT_TYPE_META;
+  const Icon = meta.icon;
   return (
     <span
-      className={`inline-flex shrink-0 items-center px-2 py-0.5 text-micro font-medium rounded-full ${style}`}
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-micro font-medium ${meta.className}`}
     >
+      <Icon className="h-3 w-3" aria-hidden />
       {type}
     </span>
   );
 }
 
-function ConfidenceBar({ confidence }: { confidence: number }) {
-  const percent = Math.round(
-    (Number.isFinite(confidence) ? confidence : 0) * 100,
-  );
+/** 置信度：紧凑迷你进度条 + 百分比（progressbar 语义保留给 e2e/可达性）。 */
+function ConfidenceMeter({ confidence }: { confidence: number }) {
+  const percent = formatPercent(confidence);
   const colorClass = formatConfidenceColor(confidence);
-  const level = getConfidenceLevel(confidence);
-
-  const levelLabel: Record<string, string> = {
-    high: "高",
-    medium: "中",
-    low: "低",
-  };
-
   return (
-    <div className="flex items-center gap-2">
-      <div
-        className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-muted"
+    <span className="flex items-center gap-1.5" title={`置信度 ${percent}%`}>
+      <span
+        className="relative h-1 w-7 overflow-hidden rounded-full bg-muted"
         role="progressbar"
         aria-valuenow={percent}
         aria-valuemin={0}
         aria-valuemax={100}
         aria-label={`置信度 ${percent}%`}
       >
-        <div
-          className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ease-out ${colorClass}`}
+        <span
+          className={`absolute inset-y-0 left-0 rounded-full ${colorClass}`}
           style={{ width: `${percent}%` }}
         />
-      </div>
-      <span className="shrink-0 text-micro font-mono text-text-muted tabular-nums">
-        {percent}%
-        <span className="ml-0.5 text-text-muted">
-          {levelLabel[level]}
-        </span>
       </span>
-    </div>
+      <span className="text-micro font-mono tabular-nums text-text-muted">
+        {percent}%
+      </span>
+    </span>
+  );
+}
+
+/** 重要度：低强度圆点 + 百分比（配色对齐右侧 Legend）。 */
+function ImportanceDot({ score }: { score: number }) {
+  const percent = formatPercent(score);
+  const colorClass = formatImportanceColor(score);
+  return (
+    <span className="flex items-center gap-1" title={`重要度 ${percent}%`}>
+      <span className={`h-1.5 w-1.5 rounded-full ${colorClass}`} aria-hidden />
+      <span className="text-micro font-mono tabular-nums text-text-muted">
+        {percent}%
+      </span>
+      <span className="sr-only">重要度 {percent}%</span>
+    </span>
   );
 }
 
@@ -82,12 +127,11 @@ function TemporalBadge({ fact }: { fact: FactItem }) {
   const expired = isExpired(fact);
   return (
     <span
-      className={
-        expired
-          ? "text-rose-500 dark:text-rose-400"
-          : "text-text-muted"
-      }
+      className={`inline-flex items-center gap-1 ${
+        expired ? "text-rose-500 dark:text-rose-400" : "text-text-muted"
+      }`}
     >
+      <Clock className="h-3 w-3 shrink-0" aria-hidden />
       {label}
     </span>
   );
@@ -104,37 +148,52 @@ interface FactCardProps {
 }
 
 export function FactCard({ fact, userLabel, onShowHistory }: FactCardProps) {
+  const accentClass = formatConfidenceColor(fact.confidence);
+
   return (
-    <article className="rounded-2xl border border-border bg-card p-5 shadow-sm">
-      <ConfidenceBar confidence={fact.confidence} />
+    <article className="group relative flex flex-col gap-2.5 overflow-hidden rounded-card border border-border bg-card p-4 text-card-foreground shadow-sm transition-[box-shadow,border-color] duration-150 ease-out hover:border-foreground/15 hover:shadow-md">
+      {/* 顶部强调线 = 置信度等级色（装饰性，可达性由下方进度条承载） */}
+      <span className={`absolute inset-x-0 top-0 h-0.5 ${accentClass}`} aria-hidden />
 
-      <div className="mt-3 flex items-start justify-between gap-2">
-        <p className="text-sm font-semibold text-foreground leading-tight">
-          {fact.key}
-        </p>
+      {/* 行1：类型 · 置信度 · 重要度 */}
+      <div className="flex items-center justify-between gap-2">
         <FactTypeBadge type={fact.fact_type} />
-      </div>
-
-      <div className="mt-3 rounded-lg border border-border bg-muted/50 p-3">
-        <JsonViewer data={fact.value} />
-      </div>
-
-      <div className="mt-3 flex items-center justify-between text-caption text-text-muted">
-        <div className="flex items-center gap-3">
-          <TemporalBadge fact={fact} />
-          {fact.created_at && (
-            <span>{formatShortDate(fact.created_at)}</span>
+        <div className="flex shrink-0 items-center gap-2.5">
+          <ConfidenceMeter confidence={fact.confidence} />
+          {typeof fact.importance_score === "number" && (
+            <ImportanceDot score={fact.importance_score} />
           )}
+        </div>
+      </div>
+
+      {/* 行2：key 眼纹（弱化属性标签，title 显示全文） */}
+      <p
+        className="truncate font-mono text-micro uppercase tracking-wider text-text-muted"
+        title={fact.key}
+      >
+        {fact.key}
+      </p>
+
+      {/* 行3：语义化 value（hero） */}
+      <FactValueView value={fact.value} />
+
+      {/* 行4：元信息 + History */}
+      <div className="mt-0.5 flex items-center justify-between gap-2 text-caption text-text-muted">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+          <TemporalBadge fact={fact} />
+          {fact.created_at && <span>{formatShortDate(fact.created_at)}</span>}
           {userLabel && (
-            <span className="truncate rounded-full border border-border px-1.5 py-px text-micro">
+            <span className="max-w-[10rem] truncate rounded-full border border-border px-1.5 py-px text-micro">
               {userLabel}
             </span>
           )}
         </div>
         <button
-          className="text-text-muted underline hover:text-text-secondary"
+          type="button"
+          className="inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-text-muted transition-colors hover:bg-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           onClick={() => onShowHistory(fact.id)}
         >
+          <History className="h-3 w-3 shrink-0" aria-hidden />
           History
         </button>
       </div>

--- a/apps/negentropy-ui/app/memory/facts/_components/FactValueView.tsx
+++ b/apps/negentropy-ui/app/memory/facts/_components/FactValueView.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Braces } from "lucide-react";
+
+import { JsonViewer } from "@/components/ui/JsonViewer";
+
+/**
+ * Fact value 的语义化渲染器（形状感知）。
+ *
+ * 后端写入的 `value` 经核实为「扁平」对象，常见三种形状：
+ *   1. 纯文本包装  {text: "prefers Python"}
+ *   2. 三元组       {entity|subject, relation|predicate, target|object}
+ *   3. 通用扁平对象 {name: "TypeScript"} 等
+ * 默认以「给人看」的方式渲染；右上角「{ }」按钮可随时切回原始 JSON，
+ * 复用既有 JsonViewer（自带复制），确保信息零丢失 + 保留开发者视角。
+ */
+
+// 纯包装键：仅承载一句文本，渲染时剥离键名直接显示句子。
+const WRAPPER_KEYS = new Set([
+  "text",
+  "value",
+  "content",
+  "description",
+  "note",
+  "statement",
+  "fact",
+]);
+
+// 三元组各槽位的同义键（按顺序取第一个非空命中），紧扣后端实际写入的形状。
+const SUBJECT_KEYS = ["subject", "entity", "source", "head"];
+const RELATION_KEYS = ["predicate", "relation", "rel"];
+const OBJECT_KEYS = ["object", "target", "tail"];
+
+interface Triple {
+  subject: unknown;
+  relation: string;
+  object: unknown;
+  hasObject: boolean;
+  rest: Array<[string, unknown]>;
+}
+
+function pickKey(obj: Record<string, unknown>, keys: string[]): string | null {
+  for (const k of keys) {
+    if (k in obj && obj[k] != null && obj[k] !== "") return k;
+  }
+  return null;
+}
+
+function detectTriple(value: Record<string, unknown>): Triple | null {
+  const subjectKey = pickKey(value, SUBJECT_KEYS);
+  const relationKey = pickKey(value, RELATION_KEYS);
+  if (!subjectKey || !relationKey) return null;
+
+  const objectKey = pickKey(value, OBJECT_KEYS);
+  const consumed = new Set(
+    [subjectKey, relationKey, objectKey].filter((k): k is string => Boolean(k)),
+  );
+  return {
+    subject: value[subjectKey],
+    relation: String(value[relationKey]),
+    object: objectKey ? value[objectKey] : undefined,
+    hasObject: Boolean(objectKey),
+    // 三元组之外的多余键（如 evidence）补渲染为键值行，默认视图不丢信息。
+    rest: Object.entries(value).filter(([k]) => !consumed.has(k)),
+  };
+}
+
+function detectText(value: Record<string, unknown>): string | null {
+  const entries = Object.entries(value);
+  if (entries.length !== 1) return null;
+  const [k, v] = entries[0];
+  if (!WRAPPER_KEYS.has(k.toLowerCase())) return null;
+  if (v == null) return null;
+  if (typeof v === "object") return null;
+  return String(v);
+}
+
+// ============================================================================
+// 原子值渲染
+// ============================================================================
+
+function ScalarChip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-md bg-muted/70 px-1.5 py-0.5 text-caption text-foreground">
+      {children}
+    </span>
+  );
+}
+
+function stringifyScalar(v: unknown): string {
+  if (typeof v === "object" && v !== null) return JSON.stringify(v);
+  return String(v);
+}
+
+function ValueAtom({ value }: { value: unknown }) {
+  if (value === null || value === undefined || value === "") {
+    return <span className="text-text-muted">—</span>;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="text-text-muted">—</span>;
+    return (
+      <span className="inline-flex flex-wrap items-center gap-1">
+        {value.map((item, i) => (
+          <ScalarChip key={i}>{stringifyScalar(item)}</ScalarChip>
+        ))}
+      </span>
+    );
+  }
+  if (typeof value === "object") {
+    // 嵌套对象（罕见）——紧凑单行展示，完整结构可经「{ }」查看原始 JSON。
+    return (
+      <span className="break-all font-mono text-caption text-foreground">
+        {JSON.stringify(value)}
+      </span>
+    );
+  }
+  if (typeof value === "boolean") {
+    return <span className="font-mono text-foreground">{value ? "true" : "false"}</span>;
+  }
+  return <span className="break-words text-foreground">{String(value)}</span>;
+}
+
+// ============================================================================
+// 视图分支
+// ============================================================================
+
+function KeyValueList({ entries }: { entries: Array<[string, unknown]> }) {
+  return (
+    <dl className="grid gap-1">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex items-baseline gap-2">
+          <dt className="shrink-0 font-mono text-caption text-text-muted">{k}</dt>
+          <dd className="min-w-0 text-sm">
+            <ValueAtom value={v} />
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function TripleView({ triple }: { triple: Triple }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm">
+        <span className="break-words font-medium text-foreground">
+          {String(triple.subject)}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-md bg-muted px-1.5 py-0.5 text-caption text-text-secondary">
+          {triple.relation}
+          <ArrowRight className="h-3 w-3 shrink-0" aria-hidden />
+        </span>
+        {triple.hasObject ? (
+          <ValueAtom value={triple.object} />
+        ) : (
+          <span className="text-text-muted">—</span>
+        )}
+      </div>
+      {triple.rest.length > 0 && <KeyValueList entries={triple.rest} />}
+    </div>
+  );
+}
+
+// ============================================================================
+// FactValueView
+// ============================================================================
+
+export function FactValueView({ value }: { value: Record<string, unknown> }) {
+  const [showRaw, setShowRaw] = useState(false);
+
+  const isPlainObject =
+    value != null && typeof value === "object" && !Array.isArray(value);
+  const isEmpty = !isPlainObject || Object.keys(value).length === 0;
+
+  const text = isPlainObject ? detectText(value) : null;
+  const triple = isPlainObject && !text ? detectTriple(value) : null;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setShowRaw((s) => !s)}
+        aria-pressed={showRaw}
+        aria-label={showRaw ? "返回语义视图" : "查看原始 JSON"}
+        title={showRaw ? "返回语义视图" : "查看原始 JSON"}
+        className={`absolute right-0 top-0 z-10 rounded-md p-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          showRaw
+            ? "bg-muted text-foreground"
+            : "text-text-muted/70 hover:bg-muted hover:text-foreground"
+        }`}
+      >
+        <Braces className="h-3.5 w-3.5" aria-hidden />
+      </button>
+
+      <div className="pr-7">
+        {showRaw ? (
+          <div className="rounded-lg border border-border bg-muted/40 p-2.5">
+            <JsonViewer data={value} />
+          </div>
+        ) : isEmpty ? (
+          <p className="text-sm text-text-muted">（空）</p>
+        ) : text != null ? (
+          <p className="break-words text-sm text-foreground">{text}</p>
+        ) : triple ? (
+          <TripleView triple={triple} />
+        ) : (
+          <KeyValueList entries={Object.entries(value)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/memory/facts/_lib/fact-helpers.ts
+++ b/apps/negentropy-ui/app/memory/facts/_lib/fact-helpers.ts
@@ -31,6 +31,41 @@ export function formatConfidenceColor(confidence: number): string {
 }
 
 // ============================================================================
+// Importance
+// ============================================================================
+
+export type ImportanceLevel = "high" | "medium" | "low";
+
+// 阈值与配色对齐右侧共享 Legend（Importance：高≥70%、中40–70%、低<40%）。
+const IMPORTANCE_THRESHOLDS = { high: 0.7, medium: 0.4 } as const;
+
+export function getImportanceLevel(score: number): ImportanceLevel {
+  const s = Number.isFinite(score) ? score : 0;
+  if (s >= IMPORTANCE_THRESHOLDS.high) return "high";
+  if (s >= IMPORTANCE_THRESHOLDS.medium) return "medium";
+  return "low";
+}
+
+const IMPORTANCE_COLORS: Record<ImportanceLevel, string> = {
+  high: "bg-blue-500",
+  medium: "bg-cyan-500",
+  low: "bg-slate-400",
+};
+
+export function formatImportanceColor(score: number): string {
+  return IMPORTANCE_COLORS[getImportanceLevel(score)];
+}
+
+// ============================================================================
+// Percent
+// ============================================================================
+
+/** 将 0–1 评分格式化为整数百分比；非有限值归零，避免渲染 NaN%。 */
+export function formatPercent(value: number): number {
+  return Math.round((Number.isFinite(value) ? value : 0) * 100);
+}
+
+// ============================================================================
 // Date Formatting
 // ============================================================================
 

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -66,6 +66,8 @@ export interface FactItem {
   key: string;
   value: Record<string, unknown>;
   confidence: number;
+  /** 重要度评分 (0–1)，后端 `/api/memory/facts` 返回；缺省视为未知不渲染。 */
+  importance_score?: number;
   valid_from?: string;
   valid_until?: string;
   created_at?: string;


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Memory / Facts 页面的事实卡片以开发者向 JSON 树呈现 `value`，标题与内容冗余、嵌套容器与留白偏重，导致「不直观、不简约、不紧凑」；且后端与右侧 Legend 已有 importance 维度，卡片却未展示。
- 关联上下文/Issue/文档：用户附图标注的两张三元组知识卡为典型痛点；设计方向经 `ui-ux-pro-max`（Data-Dense Dashboard）技能确认（最小内边距、状态色、可扫描、暗色全支持，且不靠颜色单独表意）。

# 核心变更
- **新增 `FactValueView`（语义化渲染器）**：形状感知渲染 `value`——三元组 → 「主体 [关系→] 客体」chips、`{text}` → 句子、扁平对象 → `键 → 值` 列表，三元组额外键补渲染不丢信息；右上角 `{ }` 一键切回原始 JSON（复用既有 `JsonViewer`，自带复制），信息零丢失。
- **重写 `FactCard`（布局/层级/密度）**：改用设计令牌（`rounded-card` / `p-4` / 软阴影 + 顶部置信度强调线），整行置信度条收敛为 header 紧凑迷你进度条（保留 `role="progressbar"`）；类型徽标加 lucide 图标并补全 `relation/rule/custom`。
- **新增 Importance 指标**：低强度圆点 + 数值，阈值与配色对齐右侧共享 Legend（blue/cyan/slate）；`FactItem` 补 `importance_score?` 字段，`fact-helpers` 增重要度等级/配色与百分比工具。

# 风险与回滚
- 主要风险：`value` 为非预期/深层嵌套形状时语义渲染降级——已用「通用键值列表」+「`{ }` 原始 JSON」双重兜底，保证不丢信息；纯前端展示层改动，不触碰后端与数据。
- 回滚方式：`git revert bda763bc` 即可完整还原（仅 4 文件、纯 UI 层）。

# 验证证据
- 单元测试：vitest **9/9** 通过（含 `memory-api`）。
- 集成测试：`tsc --noEmit` 与 `eslint --max-warnings=0` 均绿；pre-commit hooks 全过。
- E2E/Workflow：`tests/e2e/memory/facts.spec.ts` **5/5** 通过——6 条 DOM 契约（`<article>` 根 / `key` / `fact_type` / `role=progressbar` / `History` 按钮 / `userLabel`）全部保留。
- 覆盖率/关键截图：真实 Chromium + 富 mock 数据（9 卡覆盖三元组/文本/键值/空值/过期/长数组/各色阶）验过明色 · 暗色 · lg(1024) · 移动(390)；`{ }` 原始 JSON 切换正常。

# 影响范围
- 前端：仅 `app/memory/facts/*`（`FactCard`、新增 `FactValueView`、`fact-helpers`）与 `features/memory/utils/memory-api.ts`（`FactItem` 加可选字段）；`LegendCard` / `page.tsx` / `JsonViewer` 未改（防涟漪、复用驱动）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并前建议在真实后端环境（非当前 502）下对真实事实数据做一轮实机回归；后续可评估让共享 `LegendCard` 在 Facts 页区分「置信度（Confidence）」与「Retention」语义，使图例对 Facts 更名副其实。
