### PR TITLE
fix(routine-audit): 修复迭代执行期间详细步骤丢失 — 引入 StreamingEventPersister 增量持久化

### DIFF
--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -67,6 +67,13 @@ class RoutineSettings(BaseSettings):
         default=None,
         description="评估器 LLM-as-Judge 模型覆盖；为空时走 task_registry 的 routine.evaluate 解析",
     )
+    event_streaming_flush_seconds: int = Field(
+        default=30,
+        ge=5,
+        le=300,
+        description="StreamingEventPersister 增量 flush 间隔（秒）；"
+        "迭代执行期间每隔此时间将已捕获事件增量落库，使页面 reload 后仍可见审计步骤",
+    )
 
     # --- 隔离 worktree（基于基线分支的隔离工作区 + 自动 PR 回基线）---
     worktree_root: str | None = Field(

--- a/apps/negentropy/src/negentropy/engine/routine/runner.py
+++ b/apps/negentropy/src/negentropy/engine/routine/runner.py
@@ -35,6 +35,7 @@ from negentropy.logging import get_logger
 from negentropy.models.routine import Routine, RoutineIteration, RoutineIterationEvent
 
 from .bus import get_bus
+from .streaming_persister import StreamingEventPersister
 
 logger = get_logger("negentropy.engine.routine.runner")
 
@@ -131,8 +132,21 @@ class RoutineRunner:
 
             # 2) 执行 Claude Code（长耗时，受 config.timeout_seconds 约束）
             #    capture_events 开启时附 on_event sink：每个动作经非阻塞总线实时发布（边跑边看）。
-            sink = self._make_action_sink(iteration_id, routine_id) if settings.routine.capture_events else None
-            result = await ClaudeCodeService.invoke(prompt, config, abort_event=abort, on_event=sink)
+            #    StreamingEventPersister 增量 flush：使页面 reload 后仍可见已完成的审计步骤。
+            persister: StreamingEventPersister | None = None
+            if settings.routine.capture_events:
+                persister = StreamingEventPersister(
+                    iteration_id, routine_id, flush_interval_seconds=settings.routine.event_streaming_flush_seconds
+                )
+                persister.start()
+            sink = (
+                self._make_action_sink(iteration_id, routine_id, persister) if settings.routine.capture_events else None
+            )
+            try:
+                result = await ClaudeCodeService.invoke(prompt, config, abort_event=abort, on_event=sink)
+            finally:
+                if persister is not None:
+                    await persister.finalize()
 
             # 3) 写回结果（abort 命中则标记 aborted，否则 executed）
             if abort.is_set():
@@ -156,12 +170,13 @@ class RoutineRunner:
             )
 
     @staticmethod
-    def _make_action_sink(iteration_id: UUID, routine_id: UUID):
+    def _make_action_sink(iteration_id: UUID, routine_id: UUID, persister: StreamingEventPersister | None = None):
         """构造「全过程」动作实时发布回调：每个归一化动作经非阻塞总线广播为 ``action`` 事件。
 
         best-effort：``RoutineBus.publish`` 为 ``put_nowait`` + 丢旧，绝不阻塞 CC 执行；
         异常一律 suppress（实时是增强，持久化端点才是事实源）。事件携带 ``seq``（服务定格，
         与写回持久化一致），前端据 ``(iteration_id, seq)`` 去重合并实时与历史动作。
+        当 ``persister`` 非空时同步追加到缓冲，由后台定时器增量刷入 DB。
         """
         rid, iid = str(routine_id), str(iteration_id)
 
@@ -172,6 +187,8 @@ class RoutineRunner:
                 await get_bus().publish(
                     {"type": "action", "routine_id": rid, "iteration_id": iid, "ts": _utcnow().isoformat(), **evt}
                 )
+            if persister is not None:
+                persister.buffer(evt)
 
         return _sink
 
@@ -228,10 +245,12 @@ class RoutineRunner:
                     routine.iteration_count = (routine.iteration_count or 0) + 1
                     if result.session_id:
                         routine.claude_session_id = result.session_id
-                # 「全过程」动作事件持久化：仅当本次写回确实把迭代由 in_flight 翻转 executed
-                # （rowcount==1，与计数同条件）时落库，与状态翻转同事务，绝不为 reaped/aborted 留孤儿行。
-                if settings.routine.capture_events and result.events:
-                    await self._persist_events(db, iteration_id, routine_id, result.events)
+            # 「全过程」动作事件持久化（reconciliation backstop）：
+            # 不再受 rowcount==1 门控——即使迭代已被 reaper 标记 reaped，仍确保事件落库
+            # （StreamingEventPersister 已增量刷入部分事件，此处补齐尾部 + 终态事件）。
+            # ON CONFLICT DO NOTHING 使其与增量 flush 完全幂等。
+            if settings.routine.capture_events and result.events:
+                await self._persist_events(db, iteration_id, routine_id, result.events)
             await db.commit()
 
     @staticmethod

--- a/apps/negentropy/src/negentropy/engine/routine/streaming_persister.py
+++ b/apps/negentropy/src/negentropy/engine/routine/streaming_persister.py
@@ -1,0 +1,166 @@
+"""StreamingEventPersister — 迭代执行期间的增量动作事件持久化。
+
+职责：在 Claude Code 执行长耗时迭代期间，每隔数秒将已捕获的动作事件增量写回 DB，
+使前端 reload 后仍能看到「已完成」部分的审计步骤（而非仅在终端写回时一次性落库）。
+
+生命周期：``start()`` → 多次 ``buffer(evt)`` → ``finalize()``（终端 flush + 清理）。
+``finalize`` 后实例不可再用。
+
+设计约束：
+- ``buffer`` 为同步追加（非阻塞），由 ``_emit_events`` 的 ``on_event`` 回调调用。
+- ``_flush`` 使用短生命周期 DB session（与 Runner 其它路径一致）。
+- DB 写入失败不终止执行：失败的事件留在缓冲区，下次 flush 或 ``finalize`` 重试。
+- ``ON CONFLICT (iteration_id, seq) DO NOTHING`` 保证与终端写回 ``_persist_events``
+  完全幂等。
+
+参考文献：
+[1] PostgreSQL Docs, *INSERT ... ON CONFLICT DO NOTHING*, 2024. 幂等 upsert。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+import negentropy.db.session as db_session
+from negentropy.logging import get_logger
+from negentropy.models.routine import RoutineIterationEvent
+
+logger = get_logger("negentropy.engine.routine.streaming_persister")
+
+# 单字段截断上限（与 runner._persist_events / service._EVENT_FIELD_CAP 一致）
+_FIELD_CAP = 16 * 1024
+
+
+class StreamingEventPersister:
+    """缓冲动作事件并定期增量刷入 DB。
+
+    用法::
+
+        p = StreamingEventPersister(iteration_id, routine_id)
+        p.start()                          # 启动后台 flush 定时器
+        # ... 执行期间，on_event 回调调用 p.buffer(evt) ...
+        await p.finalize()                 # 终端 flush + 停止定时器
+    """
+
+    def __init__(
+        self,
+        iteration_id: UUID,
+        routine_id: UUID,
+        flush_interval_seconds: float = 30.0,
+    ) -> None:
+        self._iteration_id = iteration_id
+        self._routine_id = routine_id
+        self._flush_interval = flush_interval_seconds
+        self._buffer: list[dict[str, Any]] = []
+        self._flushed_up_to: int = 0  # _buffer 中已成功刷入 DB 的事件下标
+        self._task: asyncio.Task | None = None
+        self._finalized = False
+
+    # ------------------------------------------------------------------
+    # 公开 API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """启动后台 flush 定时器（asyncio.Task）。仅调用一次。"""
+        if self._finalized:
+            return
+        self._task = asyncio.create_task(self._flush_loop(), name=f"streaming-persister-{self._iteration_id}")
+
+    def buffer(self, evt: dict[str, Any]) -> None:
+        """追加事件到内存缓冲（同步，非阻塞）。
+
+        由 ``_make_action_sink`` 闭包在 ``on_event`` 回调中调用。
+        ``evt`` 应携带 ``seq``（由 ``_emit_events`` 按到达顺序定格）。
+        """
+        if self._finalized:
+            return
+        self._buffer.append(evt)
+
+    async def finalize(self) -> None:
+        """终端 flush + 取消定时器。幂等（多次调用安全）。"""
+        if self._finalized:
+            return
+        self._finalized = True
+        if self._task is not None:
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        # 终端 flush：将所有未刷入的事件落库
+        await self._flush()
+
+    @property
+    def flushed_count(self) -> int:
+        """已成功刷入 DB 的事件数（仅供测试/监控）。"""
+        return self._flushed_up_to
+
+    # ------------------------------------------------------------------
+    # 内部实现
+    # ------------------------------------------------------------------
+
+    async def _flush_loop(self) -> None:
+        """后台定时器：每隔 ``_flush_interval`` 秒刷一次。"""
+        while not self._finalized:
+            try:
+                await asyncio.sleep(self._flush_interval)
+            except asyncio.CancelledError:
+                return  # finalize() 取消了我们；它自己会做终端 flush
+            await self._flush()
+
+    async def _flush(self) -> None:
+        """将缓冲区中未刷入的事件批量写入 DB。
+
+        失败不抛错、不前移游标：下次 flush 或 finalize 会重试。
+        ``ON CONFLICT (iteration_id, seq) DO NOTHING`` 与终端写回幂等。
+        """
+        pending = self._buffer[self._flushed_up_to :]
+        if not pending:
+            return
+        rows = [_evt_to_row(self._iteration_id, self._routine_id, e) for e in pending]
+        try:
+            async with db_session.AsyncSessionLocal() as db:
+                stmt = (
+                    pg_insert(RoutineIterationEvent)
+                    .values(rows)
+                    .on_conflict_do_nothing(index_elements=["iteration_id", "seq"])
+                )
+                await db.execute(stmt)
+                await db.commit()
+            self._flushed_up_to += len(pending)
+        except Exception:
+            logger.warning(
+                "streaming_persister_flush_failed",
+                iteration_id=str(self._iteration_id),
+                pending_count=len(pending),
+                exc_info=True,
+            )
+            # 不前移游标，下次重试
+
+
+# ------------------------------------------------------------------
+# 工具函数（与 runner._persist_events 行逻辑一致，提取为共享函数）
+# ------------------------------------------------------------------
+
+
+def _evt_to_row(iteration_id: UUID, routine_id: UUID, evt: dict[str, Any]) -> dict[str, Any]:
+    """单条事件 dict → DB 行 dict（含字段截断保护）。"""
+    title = evt.get("title")
+    tool_name = evt.get("tool_name")
+    return {
+        "iteration_id": iteration_id,
+        "routine_id": routine_id,
+        "seq": int(evt.get("seq", 0)),
+        "event_type": str(evt.get("event_type") or "unknown")[:24],
+        "tool_name": str(tool_name)[:128] if tool_name is not None else None,
+        "title": str(title)[:255] if title is not None else None,
+        "payload": evt.get("payload") or {},
+        "cost_usd": evt.get("cost_usd"),
+    }
+
+
+__all__ = ["StreamingEventPersister"]

--- a/apps/negentropy/tests/unit_tests/engine/test_streaming_persister.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_streaming_persister.py
@@ -1,0 +1,291 @@
+"""StreamingEventPersister 单测 — 增量事件持久化核心逻辑（mock DB）。
+
+覆盖：buffer 累积、定时 flush、终端 finalize、幂等性、失败重试、事件行转换。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from negentropy.engine.routine.streaming_persister import (
+    StreamingEventPersister,
+    _evt_to_row,
+)
+
+
+def _evt(seq: int, event_type: str = "tool_use", title: str = "Read foo.py") -> dict:
+    return {
+        "seq": seq,
+        "event_type": event_type,
+        "tool_name": "Read" if event_type == "tool_use" else None,
+        "title": title,
+        "payload": {"file_path": "foo.py"},
+        "cost_usd": None,
+    }
+
+
+class TestEvtToRow:
+    """_evt_to_row 字段截断与默认值。"""
+
+    def test_basic_mapping(self):
+        row = _evt_to_row(uuid4(), uuid4(), _evt(0))
+        assert row["seq"] == 0
+        assert row["event_type"] == "tool_use"
+        assert row["tool_name"] == "Read"
+        assert row["title"] == "Read foo.py"
+
+    def test_missing_seq_defaults_to_zero(self):
+        row = _evt_to_row(uuid4(), uuid4(), {"event_type": "assistant"})
+        assert row["seq"] == 0
+
+    def test_long_event_type_truncated_to_24(self):
+        row = _evt_to_row(uuid4(), uuid4(), {"seq": 0, "event_type": "a" * 30})
+        assert len(row["event_type"]) == 24
+
+    def test_long_title_truncated_to_255(self):
+        row = _evt_to_row(uuid4(), uuid4(), {"seq": 0, "event_type": "x", "title": "t" * 300})
+        assert len(row["title"]) == 255
+
+    def test_long_tool_name_truncated_to_128(self):
+        row = _evt_to_row(uuid4(), uuid4(), {"seq": 0, "event_type": "x", "tool_name": "T" * 200})
+        assert len(row["tool_name"]) == 128
+
+    def test_null_fields_stay_null(self):
+        row = _evt_to_row(uuid4(), uuid4(), {"seq": 0})
+        assert row["tool_name"] is None
+        assert row["title"] is None
+
+
+class TestBuffer:
+    """buffer() 同步追加行为。"""
+
+    def test_buffer_accumulates(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+        p.buffer(_evt(1))
+        p.buffer(_evt(2))
+        assert len(p._buffer) == 3
+        assert p._buffer[0]["seq"] == 0
+        assert p._buffer[2]["seq"] == 2
+
+    def test_buffer_after_finalize_is_noop(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        # finalize without start → still marks finalized
+        asyncio.get_event_loop().run_until_complete(p.finalize())
+        p.buffer(_evt(0))
+        assert len(p._buffer) == 0
+
+
+class TestFlush:
+    """_flush 增量 DB 写入。"""
+
+    @pytest.mark.asyncio
+    async def test_flush_writes_pending_events(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+        p.buffer(_evt(1))
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        # 模拟 async with
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mock_db_mod:
+            mock_db_mod.AsyncSessionLocal.return_value = mock_session_ctx
+            await p._flush()
+
+        mock_db.execute.assert_called_once()
+        assert p._flushed_up_to == 2
+
+    @pytest.mark.asyncio
+    async def test_flush_on_empty_buffer_is_noop(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mock_db_mod:
+            await p._flush()
+        mock_db_mod.AsyncSessionLocal.assert_not_called()
+        assert p._flushed_up_to == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_failure_does_not_advance_counter(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+        mock_db.commit = AsyncMock()
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mock_db_mod:
+            mock_db_mod.AsyncSessionLocal.return_value = mock_session_ctx
+            await p._flush()  # should NOT raise
+
+        assert p._flushed_up_to == 0  # not advanced
+
+    @pytest.mark.asyncio
+    async def test_flush_failure_then_success_retries(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+        p.buffer(_evt(1))
+
+        # 第一次 flush 失败
+        mock_db_fail = AsyncMock()
+        mock_db_fail.execute = AsyncMock(side_effect=RuntimeError("timeout"))
+        mock_db_fail.commit = AsyncMock()
+        ctx_fail = AsyncMock()
+        ctx_fail.__aenter__ = AsyncMock(return_value=mock_db_fail)
+        ctx_fail.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx_fail
+            await p._flush()
+        assert p._flushed_up_to == 0
+
+        # 第二次 flush 成功
+        mock_db_ok = AsyncMock()
+        mock_db_ok.execute = AsyncMock()
+        mock_db_ok.commit = AsyncMock()
+        ctx_ok = AsyncMock()
+        ctx_ok.__aenter__ = AsyncMock(return_value=mock_db_ok)
+        ctx_ok.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx_ok
+            await p._flush()
+        assert p._flushed_up_to == 2
+
+    @pytest.mark.asyncio
+    async def test_flush_only_writes_unflushed_portion(self):
+        """增量 flush：仅刷入新增事件，不重复已刷入的。"""
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+        p.buffer(_evt(1))
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx
+            await p._flush()
+        assert p._flushed_up_to == 2
+
+        # 追加新事件
+        p.buffer(_evt(2))
+        mock_db2 = AsyncMock()
+        mock_db2.execute = AsyncMock()
+        mock_db2.commit = AsyncMock()
+        ctx2 = AsyncMock()
+        ctx2.__aenter__ = AsyncMock(return_value=mock_db2)
+        ctx2.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx2
+            await p._flush()
+        assert p._flushed_up_to == 3
+        # 第二次 flush 仅写入了 1 条（seq=2）——通过 flushed_up_to 增量验证
+
+
+class TestFinalize:
+    """finalize 幂等性与终端 flush。"""
+
+    @pytest.mark.asyncio
+    async def test_finalize_flushes_remaining(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx
+            await p.finalize()
+
+        assert p._flushed_up_to == 1
+        assert p._finalized is True
+
+    @pytest.mark.asyncio
+    async def test_finalize_idempotent(self):
+        p = StreamingEventPersister(uuid4(), uuid4())
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx
+            await p.finalize()
+            await p.finalize()  # 二次调用不应报错
+
+        # flush 仅执行一次（空缓冲区 flush 不会调 DB）
+        mock_db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_finalize_cancels_background_task(self):
+        p = StreamingEventPersister(uuid4(), uuid4(), flush_interval_seconds=999)
+        p.start()
+        assert p._task is not None
+        await p.finalize()
+        assert p._task is None
+
+
+class TestFlushLoop:
+    """后台定时 flush。"""
+
+    @pytest.mark.asyncio
+    async def test_timer_fires_and_flushes(self):
+        p = StreamingEventPersister(uuid4(), uuid4(), flush_interval_seconds=0.05)
+        p.buffer(_evt(0))
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx
+            p.start()
+            await asyncio.sleep(0.15)  # 等待至少一次 flush
+            await p.finalize()
+
+        assert p._flushed_up_to >= 1
+
+    @pytest.mark.asyncio
+    async def test_start_without_start_no_flush(self):
+        """未 start() 时无后台 flush，finalize 仍能终端刷入。"""
+        p = StreamingEventPersister(uuid4(), uuid4())
+        p.buffer(_evt(0))
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("negentropy.engine.routine.streaming_persister.db_session") as mod:
+            mod.AsyncSessionLocal.return_value = ctx
+            # 不 start，直接 finalize
+            await p.finalize()
+
+        assert p._flushed_up_to == 1


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 迭代执行期间（`in_flight`）的审计动作事件仅在终端写回（`_do_write_back`）时一次性批量落库，页面 reload 后步骤全部消失；abort/reaped 路径则完全丢弃事件。
- DB 实证：`preening_substrate-9f1c` #11 执行 71 分钟，1003 条事件全部在终端写回时刻 24 秒内批量插入；执行期间 0 条持久化事件。

# 核心变更
- **新增 `StreamingEventPersister`**：后台 asyncio 定时器每 30s 将已捕获事件增量 flush 到 DB（`ON CONFLICT DO NOTHING` 保证与终端写回幂等）
- **修改 `Runner._run()`**：创建 persister + `try/finally` 确保 `finalize()` 在 abort/异常路径仍执行
- **修改 `_do_write_back()`**：事件持久化移出 `rowcount==1` 门控，reaped 迭代亦保留事件
- **修改 `_make_action_sink()`**：同步追加 `persister.buffer(evt)`，零阻塞
- **新增配置**：`event_streaming_flush_seconds`（默认 30，范围 5-300）

# 风险与回滚
- 主要风险：增量 flush 引入额外的 DB 写入频次（每 30s 一次短事务）；DB 写入失败不终止执行，事件留在缓冲区下次重试
- 回滚方式：`git revert` 该 commit 即可恢复原有终端批量写回行为

# 验证证据
- 单元测试：18 个新测试覆盖 buffer/flush/finalize/幂等性/失败重试/行转换
- 集成测试：24 个既有集成测试 + 60 个既有单元测试全部通过（0 回归）
- E2E/Workflow：生产 DB 实证查询验证了根因分析
- 覆盖率/关键截图：pre-commit hooks（ruff lint + ruff format）全绿

# 影响范围
- 前端：无变更（现有 `mergeEvents(persisted, liveActions)` 逻辑已天然适配增量持久化）
- 后端：`runner.py`、`streaming_persister.py`（新增）、`config/routine.py`
- GitHub Actions / 文档：无

# Next Best Action
- 观察下一次长耗时 Routine 迭代的增量持久化效果，确认页面 reload 后审计步骤可见
