### PR TITLE
style(routine): 统一「查看全过程」文案为 Full View

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -91,7 +91,7 @@ export function IterationAuditDrawer({
   // 合并持久化 + 实时（持久化优先），按 seq 去重升序。
   const merged = useMemo(() => mergeEvents(persisted, isInFlight ? (liveActions ?? []) : []), [persisted, liveActions, isInFlight]);
 
-  const title = iteration ? `迭代 #${iteration.seq} · 全过程审计` : "全过程审计";
+  const title = iteration ? `Iteration #${iteration.seq} · Full View` : "Full View";
 
   return (
     <BaseDrawer

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -87,12 +87,12 @@ function IterationCard({
             <button
               type="button"
               onClick={() => onAudit(it)}
-              aria-label={`查看迭代 #${it.seq} 全过程`}
-              title="查看全过程（所有动作的输入/输出/上下文）"
+              aria-label={`Iteration #${it.seq} Full View`}
+              title="Full View (all actions I/O & context)"
               className="flex cursor-pointer items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] font-medium text-text-secondary transition-colors hover:bg-muted/60 hover:text-foreground"
             >
               <ListTree className="h-3 w-3" aria-hidden />
-              全过程
+              Full View
             </button>
           )}
         </div>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -108,7 +108,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                     }}
                     className="cursor-pointer rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
-                    全过程 →
+                    Full View →
                   </button>
                 </div>
               </td>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface / Routine 页面中「查看全过程」相关文案表达不统一（`全过程 →`、`全过程`、`查看全过程`、`全过程审计`、`Full View` 混用），需统一为英文 `Full View` 以提升 UI 一致性。
- 关联上下文/Issue/文档：用户反馈文案不一致

# 核心变更
- `RoutineTable.tsx`：列表页链接文案 `全过程 →` → `Full View →`
- `RoutineIterationTimeline.tsx`：迭代时间线按钮的 aria-label / title / 可见文本统一为 `Full View`
- `IterationAuditDrawer.tsx`：审计抽屉标题 `全过程审计` → `Full View`
- `RoutineEditDrawer.tsx`：已是 `Full View`，无需修改

# 风险与回滚
- 主要风险：纯文案变更，无逻辑风险
- 回滚方式：`git revert`

# 验证证据
- 单元测试：N/A（纯文案）
- 集成测试：N/A
- E2E/Workflow：人工浏览器验证
- 覆盖率/关键截图：grep 确认用户可见文案中无残留「全过程」

# 影响范围
- 前端：`apps/negentropy-ui/app/interface/routine/_components/` 下 3 个组件
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证各处文案显示正确