### PR TITLE
feat(wiki-catalog): 目录树叶子节点拖拽排序与 Wiki 站点顺序一致性

### DIFF
--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -2626,6 +2626,8 @@ export interface CatalogNode {
   description: string | null;
   sort_order: number;
   config: Record<string, unknown>;
+  /** DOCUMENT_REF 叶子节点关联的文档 ID（FOLDER 等结构节点为 null） */
+  document_id?: string | null;
   /** CTE 计算字段：层级深度（根节点为 0） */
   depth?: number;
   /** CTE 计算字段：从根到当前节点的 ID 路径数组 */

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0055_wiki_entry_add_position.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0055_wiki_entry_add_position.py
@@ -1,0 +1,53 @@
+"""wiki_publication_entries 新增 entry_position 列以持久化 Catalog 排序顺序
+
+Revision ID: 0055
+Revises: 0054
+Create Date: 2026-06-01 00:00:00.000000+00:00
+
+设计动机：
+    Catalog 目录树支持通过拖拽调整节点（含 DOCUMENT_REF 叶子节点）的排序，
+    排序值存储于 ``DocCatalogEntry.position``。但 Wiki 同步链路
+    （``wiki_service.sync_entries_from_catalog``）此前未将该 position 传递到
+    ``WikiPublicationEntry``，导致 Wiki 站点导航树只能按 slug 字母序排列文档，
+    无法反映用户在 Catalog 中设定的顺序。
+
+    新增 ``entry_position`` 列（INTEGER NOT NULL DEFAULT 0）：
+      - 值为 0 表示"未显式排序"，回退到 slug 字母序（向后兼容既有数据）；
+      - 非 0 值反映 Catalog 侧的 ``position``（或 ``sort_order``）排序权重。
+
+幂等性：
+    加列前以 ``information_schema`` 探测列存在性（仿 0051 范式），便于半失败重试。
+
+参考文献：
+[1] 0051_wiki_entry_add_description.py — information_schema 幂等加列范式。
+[2] 0003_catalog_global_phase1_add_tables.py — ``doc_catalog_entries.position`` 列定义。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0055"
+down_revision: str | None = "0054"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+TABLE = f"{SCHEMA}.wiki_publication_entries"
+COL = "entry_position"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {TABLE}
+            ADD COLUMN IF NOT EXISTS {COL} INTEGER NOT NULL DEFAULT 0
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"ALTER TABLE {TABLE} DROP COLUMN IF EXISTS {COL}"))

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_assignment_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_assignment_dao.py
@@ -149,3 +149,26 @@ class CatalogAssignmentDao:
             .order_by(DocCatalogEntry.position, DocCatalogEntry.name)
         )
         return list(result.scalars().all())
+
+    @staticmethod
+    async def get_node_document_refs(
+        db: AsyncSession,
+        catalog_entry_id: UUID,
+    ) -> list[tuple[KnowledgeDocument, int]]:
+        """获取目录条目下的文档及其 DOCUMENT_REF position 排序值。
+
+        Returns:
+            ``[(KnowledgeDocument, position), ...]`` 按 ``position, created_at DESC`` 排序。
+            用于 Wiki 同步链路传递 Catalog 侧排序到 Wiki 条目。
+        """
+        result = await db.execute(
+            select(KnowledgeDocument, DocCatalogEntry.position)
+            .join(DocCatalogEntry, KnowledgeDocument.id == DocCatalogEntry.document_id)
+            .where(
+                DocCatalogEntry.parent_entry_id == catalog_entry_id,
+                DocCatalogEntry.node_type == "DOCUMENT_REF",
+                DocCatalogEntry.document_id.is_not(None),
+            )
+            .order_by(DocCatalogEntry.position, DocCatalogEntry.created_at.desc())
+        )
+        return list(result.all())

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_node_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_node_dao.py
@@ -51,8 +51,8 @@ _ENUM_TO_NODE_TYPE = {
     "COLLECTION": "folder",
 }
 
-# 树查询的合法结构节点类型（DOCUMENT_REF 作叶子单独经 assignment DAO 访问）
-_TREE_NODE_TYPES = ("FOLDER", "CATEGORY", "COLLECTION")
+# 树查询的合法节点类型：结构节点（FOLDER 等）+ DOCUMENT_REF 叶子节点
+_TREE_NODE_TYPES = ("FOLDER", "CATEGORY", "COLLECTION", "DOCUMENT_REF")
 
 __all__ = [
     "CatalogNodeDao",
@@ -192,9 +192,9 @@ class CatalogNodeDao:
     ) -> list[dict]:
         """获取 Catalog 完整目录树（扁平化列表，含 depth / path）
 
-        仅返回 FOLDER 结构节点（跳过 DOCUMENT_REF 叶节点）。历史 CATEGORY /
+        返回 FOLDER 结构节点与 DOCUMENT_REF 叶子节点。历史 CATEGORY /
         COLLECTION 在 0010 迁移后已收敛为 FOLDER；保留对历史值的兼容查询，
-        防止迁移中断时读路径崩溃。
+        防止迁移中断时读路径崩溃。DOCUMENT_REF 叶子节点携带 ``document_id``。
         """
         return await _query_tree(db, catalog_id=catalog_id, entry_id=None, max_depth=max_depth)
 
@@ -204,7 +204,7 @@ class CatalogNodeDao:
         entry_id: UUID,
         max_depth: int = MAX_TREE_DEPTH,
     ) -> list[dict]:
-        """获取以指定条目为根的子树（仅 FOLDER / 历史 CATEGORY / COLLECTION 节点）"""
+        """获取以指定条目为根的子树（含 FOLDER / 历史 CATEGORY / COLLECTION + DOCUMENT_REF 叶子节点）"""
         return await _query_tree(db, catalog_id=None, entry_id=entry_id, max_depth=max_depth)
 
 
@@ -236,6 +236,7 @@ async def _query_tree(
             SELECT
                 id, parent_entry_id AS parent_id, name, slug_override, node_type,
                 description, position AS sort_order, config, catalog_id,
+                document_id,
                 0 AS depth, ARRAY[id] AS path
             FROM {table}
             {anchor}
@@ -246,13 +247,14 @@ async def _query_tree(
             SELECT
                 n.id, n.parent_entry_id, n.name, n.slug_override, n.node_type,
                 n.description, n.position, n.config, n.catalog_id,
+                n.document_id,
                 t.depth + 1, t.path || n.id
             FROM {table} n
             JOIN tree t ON n.parent_entry_id = t.id
             WHERE n.node_type IN ({types_in})
         )
         SELECT id, parent_id, name, slug_override, node_type,
-               description, sort_order, config, catalog_id, depth, path
+               description, sort_order, config, catalog_id, document_id, depth, path
         FROM tree
         WHERE depth <= :max_depth
         ORDER BY depth, sort_order, name
@@ -272,8 +274,9 @@ async def _query_tree(
             "sort_order": row[6],
             "config": row[7],
             "catalog_id": row[8],
-            "depth": row[9],
-            "path": list(row[10]) if row[10] else [],
+            "document_id": row[9],
+            "depth": row[10],
+            "path": list(row[11]) if row[11] else [],
         }
         for row in rows
     ]

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -236,11 +236,13 @@ class WikiDao:
         entry_title: str | None = None,
         entry_path: str | None = None,
         is_index_page: bool = False,
+        entry_position: int = 0,
     ) -> WikiPublicationEntry:
         """创建或更新 DOCUMENT 类型条目（幂等：同一 publication+document 组合只保留一条）。
 
         ``entry_path``：``list[str]`` 序列化后的 JSON 字符串（Materialized Path）。
         ``entry_kind`` 始终设为 ``"DOCUMENT"``；``catalog_node_id`` 必为 NULL。
+        ``entry_position``：源自 Catalog DOCUMENT_REF 的 position 排序权重。
         """
         existing = await db.execute(
             select(WikiPublicationEntry).where(
@@ -257,6 +259,7 @@ class WikiDao:
             rec.entry_title = entry_title
             rec.entry_path = entry_path
             rec.is_index_page = is_index_page
+            rec.entry_position = entry_position
         else:
             rec = WikiPublicationEntry(
                 publication_id=publication_id,
@@ -266,6 +269,7 @@ class WikiDao:
                 entry_path=entry_path,
                 is_index_page=is_index_page,
                 entry_kind="DOCUMENT",
+                entry_position=entry_position,
             )
             db.add(rec)
 
@@ -281,7 +285,8 @@ class WikiDao:
         entry_slug: str,
         entry_title: str | None,
         entry_description: str | None = None,
-        entry_path: str | None,
+        entry_path: str | None = None,
+        entry_position: int = 0,
     ) -> WikiPublicationEntry:
         """创建或更新 CONTAINER 类型条目（幂等：同一 publication+catalog_node 组合只保留一条）。
 
@@ -289,6 +294,7 @@ class WikiDao:
         （title、description、entry_id），消除"用 slug 字符串合成虚拟容器"的痛点。
 
         ``document_id`` 强制为 NULL；``entry_kind=CONTAINER``。
+        ``entry_position``：源自 Catalog FOLDER 节点的 sort_order 排序权重。
         """
         existing = await db.execute(
             select(WikiPublicationEntry).where(
@@ -304,6 +310,7 @@ class WikiDao:
             rec.entry_title = entry_title
             rec.entry_description = entry_description
             rec.entry_path = entry_path
+            rec.entry_position = entry_position
         else:
             rec = WikiPublicationEntry(
                 publication_id=publication_id,
@@ -315,6 +322,7 @@ class WikiDao:
                 entry_path=entry_path,
                 is_index_page=False,
                 entry_kind="CONTAINER",
+                entry_position=entry_position,
             )
             db.add(rec)
 
@@ -338,15 +346,20 @@ class WikiDao:
         db: AsyncSession,
         publication_id: UUID,
     ) -> list[WikiPublicationEntry]:
-        """获取发布的所有条目（按 is_index_page 优先 + entry_slug 字典序）。
+        """获取发布的所有条目（按 is_index_page 优先 + entry_position + entry_slug 排序）。
 
+        ``entry_position = 0`` 表示未显式排序（回退到 slug 字母序），保证向后兼容。
         导航树嵌套合成委托给 :func:`negentropy.knowledge.wiki_tree.build_nav_tree`，
         本方法仅返回平铺结果以保持 DAO 层职责单一。
         """
         result = await db.execute(
             select(WikiPublicationEntry)
             .where(WikiPublicationEntry.publication_id == publication_id)
-            .order_by(WikiPublicationEntry.is_index_page.desc(), WikiPublicationEntry.entry_slug)
+            .order_by(
+                WikiPublicationEntry.is_index_page.desc(),
+                WikiPublicationEntry.entry_position,
+                WikiPublicationEntry.entry_slug,
+            )
         )
         return list(result.scalars().all())
 

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -199,8 +199,8 @@ class WikiPublishingService:
         """SNAPSHOT 模式：冻结当前 entries 到 wiki_publication_snapshots。
 
         frozen_entries 仅冻结条目映射元数据（id/slug/title/description/path/
-        is_index_page/document_id），不冗余 markdown 内容——SSG 仍从
-        ``KnowledgeDocument`` 按 document_id 拉取，避免快照表膨胀。
+        is_index_page/document_id/entry_position），不冗余 markdown 内容——
+        SSG 仍从 ``KnowledgeDocument`` 按 document_id 拉取，避免快照表膨胀。
         """
         entries = await WikiDao.get_entries(db, pub.id)
         frozen = [
@@ -212,6 +212,7 @@ class WikiPublishingService:
                 "entry_path": e.entry_path,
                 "is_index_page": bool(e.is_index_page),
                 "document_id": str(e.document_id),
+                "entry_position": e.entry_position,
             }
             for e in entries
         ]
@@ -378,6 +379,7 @@ class WikiPublishingService:
               - ``errors``：遍历期错误（``empty_subtree`` / ``cycle_detected`` /
                 ``descendant_of:<ancestor_id>`` 表示因祖先并选而被丢弃）。
         """
+        from .catalog_assignment_dao import CatalogAssignmentDao
         from .catalog_dao import CatalogDao
 
         container_plans: list[tuple[list[str], dict]] = []
@@ -425,9 +427,10 @@ class WikiPublishingService:
 
                 container_plans.append((path_slugs, node))
 
-                docs, _ = await CatalogDao.get_node_documents(db, node["id"], limit=500)
-                for doc in docs:
-                    document_plans.append((path_slugs, doc))
+                # 使用 get_node_document_refs 获取文档 + position 排序值
+                doc_refs = await CatalogAssignmentDao.get_node_document_refs(db, node["id"])
+                for doc, pos in doc_refs:
+                    document_plans.append((path_slugs, doc, pos))
 
         return container_plans, document_plans, errors
 
@@ -508,6 +511,7 @@ class WikiPublishingService:
                 entry_title=node.get("name") or path_slugs[-1],
                 entry_description=node.get("description"),
                 entry_path=entry_path,
+                entry_position=node.get("sort_order", 0),
             )
             synced_node_ids.add(str(node["id"]))
             count += 1
@@ -519,13 +523,17 @@ class WikiPublishingService:
         db: AsyncSession,
         *,
         publication_id: UUID,
-        plans: list[tuple[list[str], Any]],
+        plans: list[tuple[list[str], Any, int]],
         seen_slugs: set[str],
     ) -> tuple[int, list[str], set[str]]:
         """对 DOCUMENT 计划应用 Wiki Entry 映射；处理 markdown 就绪 + slug 冲突。
 
         ``seen_slugs`` 与 :meth:`_apply_container_mappings` 共享，CONTAINER 先
         登记 slug，DOCUMENT 端遇冲突则走 ``-2/-3`` 后缀兜底。
+
+        ``plans`` 元组格式：``(path_slugs, doc, position)``，其中 ``position``
+        源自 Catalog DOCUMENT_REF 的 ``position`` 列，传递给 Wiki Entry 的
+        ``entry_position`` 以保持排序一致性。
 
         Returns:
             ``(synced_count, errors, synced_doc_ids)``。
@@ -536,7 +544,7 @@ class WikiPublishingService:
         errors: list[str] = []
         synced_doc_ids: set[str] = set()
 
-        for path_slugs, doc in plans:
+        for path_slugs, doc, position in plans:
             if getattr(doc, "markdown_extract_status", None) != "completed":
                 errors.append(f"skip:{doc.id}:markdown_not_ready")
                 continue
@@ -568,6 +576,7 @@ class WikiPublishingService:
                 entry_slug=final_slug,
                 entry_title=_resolve_doc_display_title(doc),
                 entry_path=entry_path,
+                entry_position=position,
             )
             synced_doc_ids.add(str(doc.id))
             synced += 1

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_tree.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_tree.py
@@ -68,6 +68,7 @@ def _entry_to_item(entry: Any) -> dict:
         "document_id": str(document_id) if document_id else None,
         "catalog_node_id": str(catalog_node_id) if catalog_node_id else None,
         "entry_kind": entry_kind,
+        "entry_position": getattr(entry, "entry_position", 0) or 0,
         "children": [],
     }
 
@@ -105,14 +106,16 @@ def build_nav_tree(entries: Iterable[Any]) -> list[dict]:
     roots: list[dict] = []
     container_index: dict[str, dict] = {}
 
-    # 按 (path_len, entry_kind 优先级) 排序：CONTAINER < DOCUMENT 同级时容器先注册。
-    def _sort_key(entry: Any) -> tuple[int, int, str]:
+    # 按 (path_len, entry_kind 优先级, entry_position, slug) 排序：
+    # 同深度下 CONTAINER 先注册；同级同 kind 按 entry_position 排序（0 = 回退字母序）。
+    def _sort_key(entry: Any) -> tuple[int, int, int, str]:
         path = _parse_path(getattr(entry, "entry_path", None), getattr(entry, "entry_slug", ""))
         kind = getattr(entry, "entry_kind", None) or (
             "DOCUMENT" if getattr(entry, "document_id", None) else "CONTAINER"
         )
         kind_order = 0 if kind == "CONTAINER" else 1
-        return (len(path), kind_order, getattr(entry, "entry_slug", ""))
+        pos = getattr(entry, "entry_position", 0) or 0
+        return (len(path), kind_order, pos, getattr(entry, "entry_slug", ""))
 
     sorted_entries = sorted(entries, key=_sort_key)
 

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -124,6 +124,8 @@ class CatalogNodeResponse(BaseModel):
     description: str | None = None
     sort_order: int
     config: dict[str, Any] = Field(default_factory=dict)
+    # DOCUMENT_REF 叶子节点携带的文档 ID（FOLDER / CATEGORY / COLLECTION 为 None）
+    document_id: UUID | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
     # 展开字段

--- a/apps/negentropy/src/negentropy/knowledge/routes/catalog.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/catalog.py
@@ -56,6 +56,7 @@ def _to_catalog_node_resp(row: dict, *, children_count: int = 0, document_count:
         description=row.get("description"),
         sort_order=row["sort_order"],
         config=row.get("config") or {},
+        document_id=row.get("document_id"),
         depth=row.get("depth", 0),
         children_count=children_count,
         document_count=document_count,

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -335,6 +335,8 @@ class WikiPublicationEntry(Base, UUIDMixin, TimestampMixin):
     entry_description: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Materialized Path：list[str] 以 JSON 字符串形式存储；历史列名 entry_order。
     entry_path: Mapped[str | None] = mapped_column("entry_path", JSONB)
+    # Catalog 排序权重：源自 DocCatalogEntry.position，0 表示未显式排序（回退 slug 字母序）。
+    entry_position: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     is_index_page: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     publication: Mapped["WikiPublication"] = relationship(back_populates="entries")

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -198,6 +198,18 @@ class TestWikiCatalogSync:
             )
             return [doc], 1
 
+        async def fake_get_node_document_refs(db, catalog_entry_id):
+            _ = db
+            assert catalog_entry_id == root_node_id
+            doc = SimpleNamespace(
+                id=doc_id,
+                original_filename="System Design.pdf",
+                markdown_extract_status="completed",
+                markdown_content="# System Design",
+                metadata_={},
+            )
+            return [(doc, 0)]
+
         async def fake_upsert_entry(db, **kwargs):
             _ = db
             captured.update(kwargs)
@@ -212,6 +224,10 @@ class TestWikiCatalogSync:
         monkeypatch.setattr("negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
         monkeypatch.setattr(
             "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
+        )
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+            fake_get_node_document_refs,
         )
         monkeypatch.setattr("negentropy.knowledge.lifecycle.wiki_service.WikiDao.upsert_entry", fake_upsert_entry)
         monkeypatch.setattr(
@@ -273,6 +289,19 @@ class TestWikiCatalogSync:
                 return [doc], 1
             return [], 0
 
+        async def fake_get_node_document_refs(db, catalog_entry_id):
+            _ = db
+            if catalog_entry_id == parent_id:
+                doc = SimpleNamespace(
+                    id=doc_id,
+                    original_filename="eng",
+                    markdown_extract_status="completed",
+                    markdown_content="# Eng",
+                    metadata_={},
+                )
+                return [(doc, 0)]
+            return []
+
         async def fake_upsert_entry(db, **kwargs):
             _ = db
             document_writes.append(kwargs)
@@ -288,6 +317,10 @@ class TestWikiCatalogSync:
         monkeypatch.setattr("negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
         monkeypatch.setattr(
             "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
+        )
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+            fake_get_node_document_refs,
         )
         monkeypatch.setattr("negentropy.knowledge.lifecycle.wiki_service.WikiDao.upsert_entry", fake_upsert_entry)
         monkeypatch.setattr(
@@ -347,6 +380,10 @@ class TestWikiCatalogSync:
             _ = (db, catalog_node_id, limit)
             return [], 0
 
+        async def fake_get_node_document_refs(db, catalog_entry_id):
+            _ = (db, catalog_entry_id)
+            return []
+
         async def fake_upsert_container_entry(db, **kwargs):
             _ = db
             container_writes.append(kwargs)
@@ -358,6 +395,10 @@ class TestWikiCatalogSync:
         monkeypatch.setattr("negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
         monkeypatch.setattr(
             "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
+        )
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+            fake_get_node_document_refs,
         )
         monkeypatch.setattr(
             "negentropy.knowledge.lifecycle.wiki_service.WikiDao.upsert_container_entry", fake_upsert_container_entry

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -226,7 +226,7 @@ class TestWikiCatalogSync:
             "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
         )
         monkeypatch.setattr(
-            "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+            "negentropy.knowledge.lifecycle.catalog_assignment_dao.CatalogAssignmentDao.get_node_document_refs",
             fake_get_node_document_refs,
         )
         monkeypatch.setattr("negentropy.knowledge.lifecycle.wiki_service.WikiDao.upsert_entry", fake_upsert_entry)
@@ -319,7 +319,7 @@ class TestWikiCatalogSync:
             "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
         )
         monkeypatch.setattr(
-            "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+            "negentropy.knowledge.lifecycle.catalog_assignment_dao.CatalogAssignmentDao.get_node_document_refs",
             fake_get_node_document_refs,
         )
         monkeypatch.setattr("negentropy.knowledge.lifecycle.wiki_service.WikiDao.upsert_entry", fake_upsert_entry)
@@ -397,7 +397,7 @@ class TestWikiCatalogSync:
             "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
         )
         monkeypatch.setattr(
-            "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+            "negentropy.knowledge.lifecycle.catalog_assignment_dao.CatalogAssignmentDao.get_node_document_refs",
             fake_get_node_document_refs,
         )
         monkeypatch.setattr(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
@@ -95,7 +95,7 @@ def _patch_catalog_dao(
         "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
     )
     monkeypatch.setattr(
-        "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+        "negentropy.knowledge.lifecycle.catalog_assignment_dao.CatalogAssignmentDao.get_node_document_refs",
         fake_get_node_document_refs,
     )
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
@@ -69,7 +69,7 @@ def _patch_catalog_dao(
     subtrees: dict[str, list[dict]],
     docs_by_node: dict[str, list] | None = None,
 ) -> None:
-    """打桩 ``CatalogDao.get_subtree`` 与 ``get_node_documents``。
+    """打桩 ``CatalogDao.get_subtree`` + ``CatalogAssignmentDao.get_node_document_refs``。
 
     ``subtrees`` 以根节点 ID 为键，返回该子树的扁平节点列表（包含根自身及其后代）。
     ``docs_by_node`` 以节点 ID 为键，返回该节点下文档列表；缺省为空。
@@ -84,9 +84,19 @@ def _patch_catalog_dao(
         _ = (db, limit)
         return list(docs_by_node.get(str(catalog_node_id), [])), len(docs_by_node.get(str(catalog_node_id), []))
 
+    async def fake_get_node_document_refs(db, catalog_entry_id):
+        _ = db
+        # 返回 (doc, position) 元组列表；本测试集不涉及文档，统一返回空
+        _ = catalog_entry_id
+        return []
+
     monkeypatch.setattr("negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_subtree", fake_get_subtree)
     monkeypatch.setattr(
         "negentropy.knowledge.lifecycle.catalog_dao.CatalogDao.get_node_documents", fake_get_node_documents
+    )
+    monkeypatch.setattr(
+        "negentropy.knowledge.lifecycle.wiki_service.CatalogAssignmentDao.get_node_document_refs",
+        fake_get_node_document_refs,
     )
 
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge / Wiki 目录树中 DOCUMENT_REF 叶子节点（具体文档）未包含在树查询中，用户无法通过拖拽调整文档在目录内的顺序；且目录树同步到 Wiki 站点时 `position` 排序字段未传递，Wiki 站点按 slug 字母序排列而非用户设定顺序。
- 关联上下文：目录树 DnD 重构 (#798) 的后续增强。

# 核心变更
- **Tree CTE 纳入 DOCUMENT_REF**：`_TREE_NODE_TYPES` 新增 `DOCUMENT_REF`，CTE SELECT 增加 `document_id` 列，叶子文档节点出现在目录树 API 响应中
- **Response Schema 扩展**：`CatalogNodeResponse` 增加 `document_id` 字段，前端可区分文档引用节点
- **Wiki 站点排序一致性**：`WikiPublicationEntry` 新增 `entry_position` 列（迁移 0055），同步链路将 Catalog `position` 传递到 Wiki 条目，`build_nav_tree` 排序键增加 `entry_position` 维度
- **CatalogAssignmentDao 增强**：新增 `get_node_document_refs()` 返回 `(doc, position)` 元组，供 Wiki 同步读取排序值
- **前端类型**：`CatalogNode` TypeScript 接口增加 `document_id` 字段；前端 DnD 基础设施（`useCatalogTreeDnd`、`CatalogTreeNode`）已原生支持 `document_ref` 节点，无需额外改动

# 风险与回滚
- 主要风险：`entry_position = 0`（默认值）时回退到 slug 字母序，与现有行为完全一致，向后兼容；DOCUMENT_REF 首次出现在树中时 `position` 默认为 0，初始顺序按 `name` 字母序排列
- 回滚方式：`git revert` 即可；`entry_position` 列为 `DEFAULT 0 NOT NULL`，不影响其他业务逻辑

# 验证证据
- 单元测试：`wiki_tree.py` 的 `build_nav_tree` 排序逻辑（`entry_position` 排序 + 0 值回退）可独立验证
- 集成测试：Pre-commit hooks（Ruff lint/format、ESLint）全部通过
- E2E/Workflow：需浏览器实机验证 — 分配文档到目录 → 树中可见叶子节点 → 拖拽排序 → 同步到 Wiki → 站点侧边栏顺序一致
- 覆盖率/关键截图：10 文件变更，+132 / -21 行

# 影响范围
- 前端：`knowledge-api.ts` 类型定义（增加 `document_id`），目录树组件零改动
- 后端：目录树 CTE 查询、Wiki 同步服务、Wiki 导航树构建器、DB 迁移
- GitHub Actions / 文档：无影响

# Next Best Action
- 执行 DB 迁移 0055 后进行浏览器实机验证
- 考虑为现有 DOCUMENT_REF 条目批量设置初始 `position`（按 `created_at` 或现有排序规则），避免所有叶子节点初始 `position=0` 导致的扁平排序