### PR TITLE
feat(memory-facts): Facts 卡片分页查询与展示（每页 12 条）

### DIFF
--- a/apps/negentropy-ui/app/memory/facts/page.tsx
+++ b/apps/negentropy-ui/app/memory/facts/page.tsx
@@ -6,7 +6,8 @@
  */
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { MemoryNav } from "@/components/ui/MemoryNav";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -28,6 +29,7 @@ import {
 import { FactCard } from "./_components/FactCard";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
+const PAGE_SIZE = 12; // 4 rows × 3 columns
 
 export default function MemoryFactsPage() {
   const [users, setUsers] = useState<Array<{ id: string; label: string }>>([]);
@@ -37,6 +39,7 @@ export default function MemoryFactsPage() {
   const [payload, setPayload] = useState<FactListPayload | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [currentPage, setCurrentPage] = useState(0); // 0-indexed
 
   // Fact History modal state
   const [historyFactId, setHistoryFactId] = useState<string | null>(null);
@@ -44,11 +47,17 @@ export default function MemoryFactsPage() {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
 
-  const loadFacts = useCallback(async () => {
+  const loadFacts = useCallback(async (page = 0) => {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await fetchFacts(activeUserId ?? undefined, APP_NAME);
+      const data = await fetchFacts(
+        activeUserId ?? undefined,
+        APP_NAME,
+        undefined,
+        PAGE_SIZE,
+        page * PAGE_SIZE,
+      );
       setPayload(data);
     } catch (err) {
       setError(err as Error);
@@ -66,14 +75,27 @@ export default function MemoryFactsPage() {
   }, []);
 
   useEffect(() => {
-    loadFacts();
+    setCurrentPage(0);
+    loadFacts(0);
   }, [loadFacts]);
 
   const facts = payload?.items || [];
+  const total = payload?.total ?? 0;
+  const totalPages = useMemo(() => Math.max(1, Math.ceil(total / PAGE_SIZE)), [total]);
+  const safePage = Math.min(currentPage, totalPages - 1);
   const userLabelMap = new Map(users.map((u) => [u.id, u.label || u.id]));
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      setCurrentPage(page);
+      loadFacts(page);
+    },
+    [loadFacts],
+  );
 
   const handleSearch = async () => {
     if (!searchQuery.trim() || !activeUserId) return;
+    setCurrentPage(0);
     setIsLoading(true);
     setError(null);
     try {
@@ -81,6 +103,8 @@ export default function MemoryFactsPage() {
         app_name: APP_NAME,
         user_id: activeUserId,
         query: searchQuery.trim(),
+        limit: PAGE_SIZE,
+        offset: 0,
       });
       setPayload(result);
     } catch (err) {
@@ -92,7 +116,8 @@ export default function MemoryFactsPage() {
 
   const handleClearSearch = () => {
     setSearchQuery("");
-    loadFacts();
+    setCurrentPage(0);
+    loadFacts(0);
   };
 
   const handleShowHistory = async (factId: string) => {
@@ -138,8 +163,8 @@ export default function MemoryFactsPage() {
                 <SidebarCard title="Facts Overview">
                   <p className="mt-2 text-caption text-muted-foreground">
                     {activeUserId
-                      ? `${facts.length} facts for selected user`
-                      : `${facts.length} facts across ${users.length} users`}
+                      ? `${total} facts for selected user`
+                      : `${total} facts across ${users.length} users`}
                   </p>
                   {!activeUserId && users.length > 0 && (
                     <div className="mt-3 space-y-1.5">
@@ -206,16 +231,51 @@ export default function MemoryFactsPage() {
                 title={activeUserId ? "No facts found for this user." : "No facts found."}
               />
             ) : (
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {facts.map((fact) => (
-                  <FactCard
-                    key={fact.id}
-                    fact={fact}
-                    userLabel={activeUserId ? undefined : userLabelMap.get(fact.user_id)}
-                    onShowHistory={handleShowHistory}
-                  />
-                ))}
-              </div>
+              <>
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {facts.map((fact) => (
+                    <FactCard
+                      key={fact.id}
+                      fact={fact}
+                      userLabel={activeUserId ? undefined : userLabelMap.get(fact.user_id)}
+                      onShowHistory={handleShowHistory}
+                    />
+                  ))}
+                </div>
+
+                {/* Pagination controls */}
+                {total > PAGE_SIZE && (
+                  <div className="mt-6 flex items-center justify-between">
+                    <span className="text-micro text-muted-foreground">
+                      {safePage * PAGE_SIZE + 1}–{Math.min((safePage + 1) * PAGE_SIZE, total)} of{" "}
+                      {total}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={safePage <= 0 || isLoading}
+                        onClick={() => handlePageChange(safePage - 1)}
+                        aria-label="Previous page"
+                      >
+                        <ChevronLeft className="h-3.5 w-3.5" />
+                      </Button>
+                      <span className="min-w-[5rem] text-center text-xs text-muted-foreground">
+                        {safePage + 1} / {totalPages}
+                      </span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={safePage >= totalPages - 1 || isLoading}
+                        onClick={() => handlePageChange(safePage + 1)}
+                        aria-label="Next page"
+                      >
+                        <ChevronRight className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </MemorySidebarLayout>
         </div>

--- a/apps/negentropy-ui/features/memory/hooks/useMemoryFacts.ts
+++ b/apps/negentropy-ui/features/memory/hooks/useMemoryFacts.ts
@@ -23,6 +23,7 @@ export interface UseMemoryFactsOptions {
   userId: string;
   factType?: string;
   limit?: number;
+  offset?: number;
 }
 
 export interface UseMemoryFactsReturnValue {
@@ -37,7 +38,7 @@ export interface UseMemoryFactsReturnValue {
 export function useMemoryFacts(
   options: UseMemoryFactsOptions,
 ): UseMemoryFactsReturnValue {
-  const { appName, userId, factType, limit } = options;
+  const { appName, userId, factType, limit, offset } = options;
 
   const [payload, setPayload] = useState<FactListPayload | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -47,14 +48,14 @@ export function useMemoryFacts(
     setIsLoading(true);
     setError(null);
     try {
-      const data = await fetchFacts(userId, appName, factType, limit);
+      const data = await fetchFacts(userId, appName, factType, limit, offset);
       setPayload(data);
     } catch (err) {
       setError(err as Error);
     } finally {
       setIsLoading(false);
     }
-  }, [appName, userId, factType, limit]);
+  }, [appName, userId, factType, limit, offset]);
 
   const search = useCallback(
     async (query: string) => {
@@ -66,6 +67,7 @@ export function useMemoryFacts(
           user_id: userId,
           query,
           limit,
+          offset,
         });
         setPayload(result);
       } catch (err) {
@@ -74,7 +76,7 @@ export function useMemoryFacts(
         setIsLoading(false);
       }
     },
-    [appName, userId, limit],
+    [appName, userId, limit, offset],
   );
 
   const clearSearch = useCallback(() => {

--- a/apps/negentropy-ui/features/memory/utils/memory-api.ts
+++ b/apps/negentropy-ui/features/memory/utils/memory-api.ts
@@ -75,6 +75,7 @@ export interface FactItem {
 
 export interface FactListPayload {
   count: number;
+  total: number;
   items: FactItem[];
 }
 
@@ -352,12 +353,14 @@ export async function fetchFacts(
   appName?: string,
   factType?: string,
   limit?: number,
+  offset?: number,
 ): Promise<FactListPayload> {
   const params = new URLSearchParams();
   if (userId) params.set("user_id", userId);
   if (appName) params.set("app_name", appName);
   if (factType) params.set("fact_type", factType);
   if (limit) params.set("limit", String(limit));
+  if (offset) params.set("offset", String(offset));
   const qs = params.toString() ? `?${params.toString()}` : "";
 
   const res = await fetch(`/api/memory/facts${qs}`, {
@@ -374,6 +377,7 @@ export async function searchFacts(params: {
   user_id: string;
   query: string;
   limit?: number;
+  offset?: number;
 }): Promise<FactListPayload> {
   const res = await fetch("/api/memory/facts/search", {
     method: "POST",

--- a/apps/negentropy/src/negentropy/engine/adapters/postgres/fact_service.py
+++ b/apps/negentropy/src/negentropy/engine/adapters/postgres/fact_service.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 import negentropy.db.session as db_session
@@ -213,6 +213,7 @@ class FactService:
         app_name: str,
         query: str,
         limit: int = 10,
+        offset: int = 0,
     ) -> list[Fact]:
         """搜索相关 Fact
 
@@ -223,6 +224,7 @@ class FactService:
             app_name: 应用名称
             query: 搜索查询
             limit: 返回数量限制
+            offset: 偏移量（分页）
 
         Returns:
             匹配的 Fact 列表
@@ -238,6 +240,7 @@ class FactService:
                     app_name=app_name,
                     query_embedding=query_embedding,
                     limit=limit,
+                    offset=offset,
                     now=now,
                 )
             except Exception as exc:
@@ -258,10 +261,47 @@ class FactService:
                     (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
                 )
                 .order_by(Fact.created_at.desc())
+                .offset(offset)
                 .limit(limit)
             )
             result = await db.execute(stmt)
             return list(result.scalars().all())
+
+    async def count_search_facts(
+        self,
+        *,
+        user_id: str,
+        app_name: str,
+        query: str,
+    ) -> int:
+        """统计搜索匹配的 Fact 总数（用于分页）
+
+        使用与 search_facts ilike 回退相同的 WHERE 条件进行 COUNT。
+        向量语义检索的总数用 ilike 近似（搜索结果量小，可接受）。
+
+        Args:
+            user_id: 用户 ID
+            app_name: 应用名称
+            query: 搜索查询
+
+        Returns:
+            匹配的 Fact 总数
+        """
+        now = datetime.now(UTC)
+
+        async with db_session.AsyncSessionLocal() as db:
+            stmt = (
+                select(func.count())
+                .select_from(Fact)
+                .where(
+                    Fact.user_id == user_id,
+                    Fact.app_name == app_name,
+                    Fact.key.ilike(f"%{query}%"),
+                    (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
+                )
+            )
+            result = await db.execute(stmt)
+            return result.scalar_one()
 
     async def _semantic_search_facts(
         self,
@@ -270,9 +310,13 @@ class FactService:
         app_name: str,
         query_embedding: list[float],
         limit: int,
-        now: datetime,
+        offset: int = 0,
+        now: datetime | None = None,
     ) -> list[Fact]:
         """向量语义检索 Fact"""
+        if now is None:
+            now = datetime.now(UTC)
+
         async with db_session.AsyncSessionLocal() as db:
             distance = Fact.embedding.op("<=>")(query_embedding)
             stmt = (
@@ -284,6 +328,7 @@ class FactService:
                     (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
                 )
                 .order_by(distance.asc())
+                .offset(offset)
                 .limit(limit)
             )
             result = await db.execute(stmt)
@@ -340,6 +385,7 @@ class FactService:
         app_name: str,
         fact_type: str | None = None,
         limit: int = 100,
+        offset: int = 0,
     ) -> list[Fact]:
         """列出有效 Fact
 
@@ -348,6 +394,7 @@ class FactService:
             app_name: 应用名称
             fact_type: 可选的事实类型过滤
             limit: 返回数量限制
+            offset: 偏移量（分页）
 
         Returns:
             Fact 列表
@@ -368,10 +415,47 @@ class FactService:
             if fact_type:
                 stmt = stmt.where(Fact.fact_type == fact_type)
 
-            stmt = stmt.order_by(Fact.created_at.desc()).limit(limit)
+            stmt = stmt.order_by(Fact.created_at.desc()).offset(offset).limit(limit)
 
             result = await db.execute(stmt)
             return list(result.scalars().all())
+
+    async def count_facts(
+        self,
+        *,
+        user_id: str | None = None,
+        app_name: str,
+        fact_type: str | None = None,
+    ) -> int:
+        """统计有效 Fact 总数（用于分页）
+
+        与 list_facts 使用相同的 WHERE 条件，但不应用 ORDER BY / LIMIT / OFFSET。
+
+        Args:
+            user_id: 用户 ID，为 None 时统计所有用户的 Facts
+            app_name: 应用名称
+            fact_type: 可选的事实类型过滤
+
+        Returns:
+            符合条件的 Fact 总数
+        """
+        now = datetime.now(UTC)
+
+        async with db_session.AsyncSessionLocal() as db:
+            conditions = [
+                Fact.app_name == app_name,
+                Fact.status == "active",
+                (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
+            ]
+            if user_id is not None:
+                conditions.append(Fact.user_id == user_id)
+
+            if fact_type:
+                conditions.append(Fact.fact_type == fact_type)
+
+            stmt = select(func.count()).select_from(Fact).where(*conditions)
+            result = await db.execute(stmt)
+            return result.scalar_one()
 
     @staticmethod
     def _cosine_similarity(a: list[float], b: list[float]) -> float:

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -115,6 +115,7 @@ class FactItem(BaseModel):
 
 class FactListResponse(BaseModel):
     count: int
+    total: int = 0
     items: list[FactItem] = Field(default_factory=list)
 
 
@@ -123,6 +124,7 @@ class FactSearchRequest(BaseModel):
     user_id: str
     query: str
     limit: int = 10
+    offset: int = 0
 
 
 class AuditRequest(BaseModel):
@@ -523,16 +525,24 @@ async def list_facts(
     user_id: str | None = Query(default=None),
     fact_type: str | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
 ) -> FactListResponse:
-    """获取用户的 Facts (语义记忆)"""
+    """获取用户的 Facts (语义记忆)，支持分页"""
     resolved_app = _resolve_app_name(app_name)
     fact_service = get_fact_service()
+
+    total = await fact_service.count_facts(
+        user_id=user_id,
+        app_name=resolved_app,
+        fact_type=fact_type,
+    )
 
     facts = await fact_service.list_facts(
         user_id=user_id,
         app_name=resolved_app,
         fact_type=fact_type,
         limit=limit,
+        offset=offset,
     )
 
     items = [
@@ -552,7 +562,7 @@ async def list_facts(
         for f in facts
     ]
 
-    return FactListResponse(count=len(items), items=items)
+    return FactListResponse(count=len(items), total=total, items=items)
 
 
 @router.post("/facts/search", response_model=FactListResponse)
@@ -564,11 +574,18 @@ async def search_facts(payload: FactSearchRequest) -> FactListResponse:
     resolved_app = _resolve_app_name(payload.app_name)
     fact_service = get_fact_service()
 
+    total = await fact_service.count_search_facts(
+        user_id=payload.user_id,
+        app_name=resolved_app,
+        query=payload.query,
+    )
+
     facts = await fact_service.search_facts(
         user_id=payload.user_id,
         app_name=resolved_app,
         query=payload.query,
         limit=payload.limit,
+        offset=payload.offset,
     )
 
     items = [
@@ -588,7 +605,7 @@ async def search_facts(payload: FactSearchRequest) -> FactListResponse:
         for f in facts
     ]
 
-    return FactListResponse(count=len(items), items=items)
+    return FactListResponse(count=len(items), total=total, items=items)
 
 
 @router.post("/audit", response_model=AuditResponse)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Memory/Facts 页面此前一次性加载并渲染用户全部 Facts，数据量增大时存在性能与浏览体验问题。
- 关联上下文/Issue/文档：需求为按页分批查询与展示，每页 4 行 × 3 列 = 12 条，按 `created_at` 倒序。

# 核心变更
- **后端 Service** (`fact_service.py`)：`list_facts`/`search_facts` 增加 `offset` 参数；新增 `count_facts`/`count_search_facts` 用于总数统计（向量检索总数以 ilike 近似）。
- **后端 API** (`api.py`)：`FactListResponse` 增加 `total` 字段，`list_facts`/`search_facts` 端点增加 `offset` 参数并回填 `total`。
- **前端** (`memory-api.ts` / `useMemoryFacts.ts` / `page.tsx`)：`FactListPayload` 增加 `total`，API 与 Hook 透传 `offset`；页面落地 offset 分页状态、Previous/Next 控件与「X–Y of N」条目范围指示，Sidebar 概览改显 `total` 总数。

# 风险与回滚
- 主要风险：offset 分页在深翻页时性能退化（Facts 量适中，可接受）；切换用户/搜索/清除搜索均已重置页码至首页，`safePage` 防越界。
- 回滚方式：单 commit，`git revert` 即可；后端 `total` 字段为附加式扩展，向后兼容旧消费者。

# 验证证据
- 单元测试：暂未新增针对 offset/count 的用例。
- 集成测试：—
- E2E/Workflow：—
- 覆盖率/关键截图：本地 `tsc --noEmit` 修改文件无新增类型错误；Python AST 语法校验通过；pre-commit（Ruff lint/format、ESLint）全部 Passed。

# 影响范围
- 前端：Memory/Facts 页面、memory feature API 客户端与 Hook。
- 后端：FactService 与 `/memory/facts`、`/memory/facts/search` 端点（代理层无需改动，参数自动透传）。
- GitHub Actions / 文档：无。

# Next Best Action
- 补充后端 `count_facts`/`list_facts(offset=)` 与前端分页交互的单元/E2E 用例；后续可将分页页码同步至 URL search params 以支持浏览器前进/后退。
