### PR TITLE
feat(routine-iteration): 迭代审计抽屉拓宽至 2/3 屏幕宽度，迭代卡片整体可点击

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -99,7 +99,7 @@ export function IterationAuditDrawer({
       onClose={onClose}
       title={title}
       subtitle={iteration ? <IterationMetaBar iteration={iteration} /> : undefined}
-      widthClassName="w-[min(760px,92vw)] max-w-none"
+      widthClassName="w-2/3"
     >
       <div className="px-5 py-4">
         {error && <ErrorBanner message={error} onRetry={load} />}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -57,7 +57,10 @@ function IterationCard({
 
   return (
     <li
-      className={`rounded-lg border p-3 ${
+      onClick={() => onAudit?.(it)}
+      className={`rounded-lg border p-3 transition-colors ${
+        onAudit ? "cursor-pointer hover:border-primary/40 hover:bg-muted/30" : ""
+      } ${
         isActive ? "border-sky-400/50 bg-sky-500/[0.03]" : "border-border"
       }`}
     >
@@ -86,13 +89,16 @@ function IterationCard({
           {onAudit && (
             <button
               type="button"
-              onClick={() => onAudit(it)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onAudit(it);
+              }}
               aria-label={`Iteration #${it.seq} Full View`}
               title="Full View (all actions I/O & context)"
               className="flex cursor-pointer items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] font-medium text-text-secondary transition-colors hover:bg-muted/60 hover:text-foreground"
             >
               <ListTree className="h-3 w-3" aria-hidden />
-              Full View
+              View Details
             </button>
           )}
         </div>
@@ -113,7 +119,7 @@ function IterationCard({
           {expanded || it.summary.length <= 280 ? it.summary : `${it.summary.slice(0, 280)}…`}
           {it.summary.length > 280 && (
             <button
-              onClick={() => setExpanded((v) => !v)}
+              onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
               className="ml-1 cursor-pointer text-sky-600 hover:underline dark:text-sky-400"
             >
               {expanded ? "收起" : "展开"}
@@ -166,14 +172,14 @@ function IterationCard({
           </span>
           <div className="flex-1" />
           <button
-            onClick={() => onApprove(it.id)}
+            onClick={(e) => { e.stopPropagation(); onApprove(it.id); }}
             disabled={busy}
             className="cursor-pointer rounded-md border border-emerald-200 px-2.5 py-1 text-[11px] font-medium text-emerald-600 hover:bg-emerald-500/10 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-400"
           >
             Approve
           </button>
           <button
-            onClick={() => onReject(it.id)}
+            onClick={(e) => { e.stopPropagation(); onReject(it.id); }}
             disabled={busy}
             className="cursor-pointer rounded-md border border-red-200 px-2.5 py-1 text-[11px] font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50 dark:border-red-800 dark:text-red-400"
           >


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 全过程查看页中迭代卡片的「全过程」审计抽屉宽度仅 760px（约屏幕 40%），信息展示空间不足；且触发入口仅限「全过程」按钮，交互不直观
- 关联上下文/Issue/文档：Routine 迭代详情查看体验优化

# 核心变更
- `IterationAuditDrawer` 的 `widthClassName` 从 `w-[min(760px,92vw)]` 改为 `w-2/3`，抽屉占用视口 66.67%
- `IterationCard` 的 `<li>` 根元素添加 `onClick → onAudit`、`cursor-pointer` 及 hover 效果，整卡可点击触发审计抽屉
- Approve/Reject/摘要展开按钮添加 `e.stopPropagation()`，防止冒泡误触发抽屉
- 按钮文案从「Full View」改为「View Details」，作为整卡可点击的视觉提示

# 风险与回滚
- 主要风险：宽屏设备上抽屉占比 2/3 可能偏宽；Approve/Reject 按钮的 stopPropagation 若遗漏可能导致误触发
- 回滚方式：`git revert` 即可，改动仅涉及 2 个文件

# 验证证据
- 单元测试：无新增（纯 UI 交互变更）
- 集成测试：`pnpm --filter negentropy-ui build` 构建通过，零错误
- E2E/Workflow：N/A
- 覆盖率/关键截图：需浏览器实机验证

# 影响范围
- 前端：`IterationAuditDrawer.tsx`、`RoutineIterationTimeline.tsx`（negentropy-ui）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证：打开 `/interface/routine/[id]`，确认整卡点击打开抽屉、抽屉宽度约 2/3、Approve/Reject 不误触发