### PR TITLE
fix(routine-iteration): 为抽屉宽度添加 clamp 三端兜底（min 480px / 2/3 / max 1100px）

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -99,7 +99,7 @@ export function IterationAuditDrawer({
       onClose={onClose}
       title={title}
       subtitle={iteration ? <IterationMetaBar iteration={iteration} /> : undefined}
-      widthClassName="[width:66.67%]"
+      widthClassName="[width:clamp(480px,66.67%,1100px)]"
     >
       <div className="px-5 py-4">
         {error && <ErrorBanner message={error} onRetry={load} />}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：PR #803 使用 [width:66.67%] 固定 2/3 比例，但缺乏小屏最小宽度与超宽屏最大宽度兜底
- 关联上下文：PR #802 → PR #803

# 核心变更
- IterationAuditDrawer 的 widthClassName 从 [width:66.67%] 改为 [width:clamp(480px,66.67%,1100px)]
- 三端效果：手机 480px min 兜底 / 常规屏 2/3 视口 / 超宽屏 1100px max 兜底

# 风险与回滚
- 主要风险：无，仅修改一个 CSS 属性值
- 回滚方式：git revert

# 验证证据
- 构建验证：pnpm --filter negentropy-ui build 通过
- 无冲突，rebase 干净基于最新 feature/1.x.x

# 影响范围
- 前端：IterationAuditDrawer.tsx（1 行）
- 后端：无

# Next Best Action
- 浏览器实机验证不同视口宽度下抽屉表现