### PR TITLE
fix(wiki-sync): 修复「同步并发布」二级节点报 KNOWLEDGE_UPSTREAM_ERROR

### DIFF
--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -425,9 +425,15 @@ class WikiPublishingService:
                     errors.append(f"node:{cycle_node_id}:cycle_detected")
                     continue
 
-                container_plans.append((path_slugs, node))
+                # 仅 FOLDER（含历史 CATEGORY / COLLECTION）成为 CONTAINER
+                # Wiki 条目；DOCUMENT_REF 是文档引用叶子节点，不是结构容器，
+                # 不应创建 CONTAINER 条目（否则其 slug 可能与已有 DOCUMENT 条目
+                # 冲突触发 uq_wiki_entry_pub_slug 唯一约束违反）。
+                if node.get("node_type") == "folder":
+                    container_plans.append((path_slugs, node))
 
-                # 使用 get_node_document_refs 获取文档 + position 排序值
+                # 使用 get_node_document_refs 获取文档 + position 排序值；
+                # 对 DOCUMENT_REF 节点调用返回空集（无 DOCUMENT_REF 子节点），无副作用。
                 doc_refs = await CatalogAssignmentDao.get_node_document_refs(db, node["id"])
                 for doc, pos in doc_refs:
                     document_plans.append((path_slugs, doc, pos))

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -315,6 +315,7 @@ class SyncFromCatalogResponse(BaseModel):
     """从目录同步到 Wiki 的响应"""
 
     synced_count: int = 0
+    container_count: int = 0
     errors: list[str] = Field(default_factory=list)
     removed_count: int = 0
 

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -393,12 +393,35 @@ async def sync_wiki_from_catalog(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Wiki publication not found",
             )
-        result = await wiki_svc.sync_entries_from_catalog(
-            db,
-            publication_id=pub_id,
-            catalog_node_ids=body.catalog_node_ids,
-        )
-        await db.commit()
+        try:
+            result = await wiki_svc.sync_entries_from_catalog(
+                db,
+                publication_id=pub_id,
+                catalog_node_ids=body.catalog_node_ids,
+            )
+            await db.commit()
+        except IntegrityError as exc:
+            await db.rollback()
+            logger.error(
+                "wiki_sync_integrity_error",
+                pub_id=str(pub_id),
+                orig=str(exc.orig),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"同步数据冲突，请重试：{exc.orig}",
+            ) from exc
+        except Exception as exc:
+            await db.rollback()
+            logger.error(
+                "wiki_sync_error",
+                pub_id=str(pub_id),
+                error=str(exc),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"同步失败：{exc}",
+            ) from exc
 
     logger.info(
         "api_wiki_sync_from_catalog",


### PR DESCRIPTION
## 背景

Wiki「同步并发布」功能在同步二级 Catalog 节点（如 "Harness Engineering" 和 "Negentropy"）时报 `KNOWLEDGE_UPSTREAM_ERROR` / "Internal Server Error"（HTTP 500），同步操作完全不可用。

**根因分析**：`_collect_subtree_plans` 遍历子树时未做节点类型过滤，将 DOCUMENT_REF 叶子节点（文档引用）错误加入 `container_plans`，导致 `upsert_container_entry` 为其创建 CONTAINER Wiki 条目。这些伪 CONTAINER 条目的 slug 与已有 DOCUMENT 条目冲突，触发 `uq_wiki_entry_pub_slug` 唯一约束违反（`IntegrityError`）。路由层未捕获此异常，Starlette 返回纯文本 500 响应，BFF 代理层无法解析 JSON 后包装为 `KNOWLEDGE_UPSTREAM_ERROR`。

## 核心变更

**`wiki_service.py` — 根因修复**
- `_collect_subtree_plans` P3 循环添加 `node_type == "folder"` 过滤
- 仅 FOLDER 节点（含历史 CATEGORY / COLLECTION）创建 CONTAINER Wiki 条目
- DOCUMENT_REF 叶子节点不再被错误地当作结构容器，`get_node_document_refs` 对其返回空集无副作用

**`lifecycle_schemas.py` — Schema 补全**
- `SyncFromCatalogResponse` 添加 `container_count: int = 0` 字段，与 `sync_entries_from_catalog` 返回值对齐

**`routes/wiki.py` — 防御性异常处理**
- `sync_wiki_from_catalog` 路由处理器包裹 try/except
- 捕获 `IntegrityError` → 返回 409 + 结构化 JSON 错误
- 捕获通用 `Exception` → 返回 500 + 结构化 JSON 错误 + 结构化日志
- 避免数据库异常穿透到 Starlette 返回纯文本 500

## 验证证据

- ✅ 后端 API 直接调用：`{"synced_count": 19, "container_count": 8, "errors": [], "removed_count": 0}`
- ✅ 浏览器实机 E2E：选择 Harness Engineering + Negentropy → 同步成功 → 发布成功（v19→v20）→ ISR 已触发
- ✅ Pre-commit hooks 全部通过（ruff lint + ruff format）

## 影响范围

| 层 | 影响 |
|---|------|
| 后端 | 3 文件变更（wiki_service / lifecycle_schemas / routes/wiki） |
| 前端 | 无代码变更（BFF 代理层透传后端响应） |
| 数据 | 旧同步产生的伪 CONTAINER 条目将在下次全量同步时被自动清理 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)