### PR TITLE
fix(routine-iteration): 将 BaseDrawer w-full 从硬编码迁入 widthClassName 默认值，根治抽屉宽度覆盖失效

### DIFF
--- a/apps/negentropy-ui/app/memory/core-blocks/_components/CoreBlockEditorDrawer.tsx
+++ b/apps/negentropy-ui/app/memory/core-blocks/_components/CoreBlockEditorDrawer.tsx
@@ -93,7 +93,7 @@ export function CoreBlockEditorDrawer({
       subtitle={
         isEdit ? `${editing?.scope} · ${editing?.label}` : "常驻记忆块（always-injected）"
       }
-      widthClassName="max-w-[480px]"
+      widthClassName="w-full max-w-[480px]"
       footer={
         <div className="flex items-center justify-end gap-2">
           <Button variant="outline" size="sm" onClick={onClose}>

--- a/apps/negentropy-ui/components/ui/BaseDrawer.tsx
+++ b/apps/negentropy-ui/components/ui/BaseDrawer.tsx
@@ -46,7 +46,7 @@ export function BaseDrawer({
   subtitle,
   footer,
   side = "right",
-  widthClassName = "max-w-md",
+  widthClassName = "w-full max-w-md",
   closeOnBackdrop = true,
   closeOnEscape = true,
   showClose = true,
@@ -92,7 +92,7 @@ export function BaseDrawer({
             aria-labelledby={title ? titleId : undefined}
             tabIndex={-1}
             className={cn(
-              "relative flex h-full w-full flex-col bg-card shadow-xl outline-none",
+              "relative flex h-full flex-col bg-card shadow-xl outline-none",
               side === "right"
                 ? "border-l border-border"
                 : "border-r border-border",

--- a/apps/negentropy-ui/features/memory/components/MemoryAssociationsDrawer.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemoryAssociationsDrawer.tsx
@@ -67,7 +67,7 @@ export function MemoryAssociationsDrawer({
       title="Associations"
       subtitle={memorySnippet}
       side="right"
-      widthClassName="max-w-[420px]"
+      widthClassName="w-full max-w-[420px]"
     >
       <div className="space-y-3 px-5 py-4">
         {loading ? (


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：cn() 不含 tailwind-merge，BaseDrawer 基类硬编码 w-full 与消费者传入的 [width:clamp(...)] 同层级共存时，CSS 层面 w-full 优先级更高，导致抽屉始终渲染为 100% 宽度
- 关联上下文：PR #803 → PR #804 的根因修复

# 核心变更
- BaseDrawer 基类移除硬编码 w-full，默认 widthClassName 从 max-w-md 改为 w-full max-w-md
- MemoryAssociationsDrawer、CoreBlockEditorDrawer 补 w-full 前缀保持原有行为
- IterationAuditDrawer 传 [width:clamp(480px,66.67%,1100px)] 不再被 w-full 覆盖

# 风险与回滚
- 主要风险：其他 BaseDrawer 消费者需确认已传 widthClassName（当前仅 3 个消费者，均已处理）
- 回滚方式：git revert

# 验证证据
- 构建验证：pnpm --filter negentropy-ui build 通过
- 浏览器实机验证：抽屉宽度 853.375px = 视口 66.67%（1280px），修复前为 1280px（100%）
- 无冲突，rebase 干净基于最新 feature/1.x.x

# 影响范围
- 前端：BaseDrawer.tsx、MemoryAssociationsDrawer.tsx、CoreBlockEditorDrawer.tsx（3 文件）
- 后端：无

# Next Best Action
- 合并后可在 Memory/CoreBlock 的抽屉页面验证原有宽度不受影响