### PR TITLE
fix(wiki-catalog): 修复目录树叶子节点拖拽排序失效（三端协同修复）

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_hooks/useCatalogTreeDnd.ts
+++ b/apps/negentropy-ui/app/knowledge/wiki/_hooks/useCatalogTreeDnd.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type DragEndEvent,
   type DragMoveEvent,
@@ -94,6 +94,10 @@ export function useCatalogTreeDnd({
   const initialPointerRef = useRef({ x: 0, y: 0 });
   const autoExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMovingRef = useRef(false);
+  const nodesRef = useRef(nodes);
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
 
   // ---- derived ----
   const activeNode = useMemo(
@@ -212,7 +216,17 @@ export function useCatalogTreeDnd({
           .sort((a, b) => a.sort_order - b.sort_order);
         const idx = siblings.findIndex((s) => s.id === targetNodeId);
 
-        if (position === "before") {
+        // Fallback: when all siblings share the same sort_order (e.g. all 0
+        // from assign_document's historical default), fractional indexing
+        // collapses to the same value and the no-op check skips the move.
+        // Use index-based gaps instead.
+        const allSame =
+          siblings.length > 1 &&
+          siblings.every((s) => s.sort_order === siblings[0].sort_order);
+
+        if (allSame) {
+          sortOrder = (idx + (position === "after" ? 2 : 1)) * SORT_GAP;
+        } else if (position === "before") {
           const prev = idx > 0 ? siblings[idx - 1].sort_order : 0;
           sortOrder = (prev + targetNode.sort_order) / 2;
         } else {
@@ -237,7 +251,10 @@ export function useCatalogTreeDnd({
     async (parentId: string | null) => {
       if (!catalogId) return;
 
-      const siblings = nodes
+      // Use the latest nodes from the ref instead of closure-captured stale
+      // data — onMove has already called refresh() which updates React state.
+      const currentNodes = nodesRef.current;
+      const siblings = currentNodes
         .filter((n) => n.parent_id === parentId)
         .sort((a, b) => a.sort_order - b.sort_order);
 
@@ -259,7 +276,7 @@ export function useCatalogTreeDnd({
       );
       await onRefresh();
     },
-    [catalogId, nodes, onRefresh],
+    [catalogId, onRefresh],
   );
 
   // ---------------------------------------------------------------------------

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0056_catalog_entry_reindex_position.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0056_catalog_entry_reindex_position.py
@@ -1,0 +1,49 @@
+"""Reindex catalog entries with position=0 to incrementing SORT_GAP intervals
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-06-01 00:00:00.000000+00:00
+
+设计动机：
+    历史 ``assign_document`` 未设置 ``position``，导致所有 DOCUMENT_REF
+    叶子节点 ``position`` 默认为 0。前端拖拽排序的分数索引算法在全部兄弟
+    sort_order 相同时坍缩为同一值，致使拖拽移动被 no-op 检查跳过。
+
+    本迁移按 ``parent_entry_id`` 分组、``created_at`` 排序，为 ``position=0``
+    的记录赋予 ``(ROW_NUMBER * 1000)`` 递增值，确保存量数据可正常拖拽排序。
+"""
+
+from alembic import op
+
+revision = "0056"
+down_revision = "0055"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "negentropy"
+TABLE = f"{SCHEMA}.doc_catalog_entries"
+SORT_GAP = 1000
+
+
+def upgrade() -> None:
+    op.execute(f"""
+        WITH ranked AS (
+            SELECT
+                id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY parent_entry_id
+                    ORDER BY created_at
+                ) AS rn
+            FROM {TABLE}
+            WHERE position = 0
+        )
+        UPDATE {TABLE} e
+        SET position = r.rn * {SORT_GAP}
+        FROM ranked r
+        WHERE e.id = r.id
+    """)
+
+
+def downgrade() -> None:
+    # Reindexing is not reversible to a meaningful prior state.
+    pass

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_assignment_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_assignment_dao.py
@@ -58,6 +58,15 @@ class CatalogAssignmentDao:
         source_corpus_id = doc.corpus_id if doc else None
         doc_name = (doc.original_filename or str(document_id)) if doc else str(document_id)
 
+        # 查询兄弟节点中最大 position，确保新 DOCUMENT_REF 获得递增排序值
+        # （避免全部默认 0 导致前端拖拽排序分数索引坍缩）
+        max_pos_result = await db.execute(
+            select(func.coalesce(func.max(DocCatalogEntry.position), 0)).where(
+                DocCatalogEntry.parent_entry_id == catalog_entry_id,
+            )
+        )
+        max_pos = max_pos_result.scalar() or 0
+
         entry = DocCatalogEntry(
             catalog_id=catalog_id,
             parent_entry_id=catalog_entry_id,
@@ -66,6 +75,7 @@ class CatalogAssignmentDao:
             node_type="DOCUMENT_REF",
             name=doc_name,
             status="ACTIVE",
+            position=max_pos + 1000,
         )
         db.add(entry)
         await db.flush()

--- a/apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_catalog_dao_unit.py
@@ -410,6 +410,8 @@ class TestCatalogMembership:
                 _FakeResult(scalar_value=parent_entry),
                 # 3. KnowledgeDocument 查询
                 _FakeResult(scalar_value=doc),
+                # 4. MAX(position) 查询 → 兄弟节点中无现有记录，返回 0
+                _FakeResult(scalar_value=0),
             ]
         )
 
@@ -426,6 +428,7 @@ class TestCatalogMembership:
         assert created.document_id == document_id
         assert created.node_type == "DOCUMENT_REF"
         assert created.source_corpus_id == corpus_id
+        assert created.position == 1000  # max_pos(0) + SORT_GAP(1000)
         assert result is created
 
     @pytest.mark.asyncio

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -271,8 +271,14 @@ class TestWikiCatalogSync:
             _ = db
             assert node_id == parent_id
             return [
-                {"id": parent_id, "parent_id": None, "slug": "parent", "name": "Parent"},
-                {"id": eng_folder_id, "parent_id": parent_id, "slug": "eng", "name": "Engineering"},
+                {"id": parent_id, "parent_id": None, "slug": "parent", "name": "Parent", "node_type": "folder"},
+                {
+                    "id": eng_folder_id,
+                    "parent_id": parent_id,
+                    "slug": "eng",
+                    "name": "Engineering",
+                    "node_type": "folder",
+                },
             ]
 
         async def fake_get_node_documents(db, catalog_node_id, limit=500):
@@ -373,6 +379,7 @@ class TestWikiCatalogSync:
                     "slug": "harness-engineering",
                     "name": "Harness Engineering",
                     "description": "智能体工程化综述",
+                    "node_type": "folder",
                 }
             ]
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_sync_helpers.py
@@ -17,7 +17,7 @@ from negentropy.knowledge.lifecycle.wiki_service import WikiPublishingService
 
 
 def _node(node_id: str, slug: str, parent_id: str | None) -> dict:
-    return {"id": node_id, "slug": slug, "parent_id": parent_id}
+    return {"id": node_id, "slug": slug, "parent_id": parent_id, "node_type": "folder"}
 
 
 class TestBuildPathSlugs:


### PR DESCRIPTION
# 背景

Knowledge/Wiki 目录树中 `document_ref` 类型的叶子节点（文档节点）拖拽排序功能不生效。PR#800 已添加叶子节点拖拽排序基础设施（CTE 查询含 DOCUMENT_REF、Wiki 同步 entry_position），但拖拽本身因 **三端 Bug 协同** 导致失效。

**根因链路**：`assign_document` 创建所有 DOCUMENT_REF 时 `position` 默认为 0 → 前端分数索引 `(0+0)/2=0` 坍缩 → no-op 检查 `Math.abs(0-0) < 0.001` 跳过移动 → 唯一有效场景是拖到末尾节点之后，用户体验极差。

# 核心变更

| 层级 | 文件 | 修复内容 |
|------|------|----------|
| **后端主因** | `catalog_assignment_dao.py` | `assign_document` 查询 `MAX(position)` 设置递增值 `+1000`，避免全部默认 0 |
| **前端直接原因** | `useCatalogTreeDnd.ts` `calculateMove` | 检测全相同 `sort_order` 时改用索引间距 `(idx + offset) * SORT_GAP`，替代坍缩的分数索引 |
| **前端次生** | `useCatalogTreeDnd.ts` `reindexSiblings` | 通过 `nodesRef` + `useEffect` 读取最新数据，避免过时闭包导致 reindex 以错误顺序重排节点 |
| **存量数据** | 迁移 `0056`（新文件） | 按 `parent_entry_id` 分组、`created_at` 排序，对 `position=0` 的记录赋予 `(ROW_NUMBER * 1000)` 递增值 |
| **测试** | `test_catalog_dao_unit.py` | 更新 `test_assign_document_creates_membership` 验证 `position == 1000` |

# 风险与回滚

- **主要风险**：迁移 `0056` 对存量数据执行 UPDATE，仅影响 `position=0` 的行；downgrade 为空操作（不可逆）
- **回滚方式**：`git revert` 回滚代码变更；如需恢复原始 position 可手动执行 `UPDATE ... SET position = 0 WHERE ...`

# 验证证据

- **单元测试**：`test_assign_document_creates_membership` 已更新并全部通过（6 passed）
- **集成测试**：已有 `TestCatalogMembershipIntegration` 覆盖 assign/unassign 生命周期（真实 DB）
- **Pre-commit hooks**：Ruff lint/format + ESLint (React Compiler rules) 全部通过
- **待验证**：部署后浏览器实机拖拽排序测试

# 影响范围

- **前端**：`useCatalogTreeDnd.ts`（calculateMove + reindexSiblings）
- **后端**：`catalog_assignment_dao.py`（assign_document 递增 position）
- **数据库**：新增迁移 `0056`
- **CI/文档**：无影响

# Next Best Action

部署后浏览器实机验证：在同一文件夹下拖拽文档叶子节点到不同位置，确认顺序变更生效并检查 Network 面板 PATCH 请求包含正确 `sort_order`。