### PR TITLE
fix(wiki-codeblock): 修复 rehype-highlight 语法高亮代码块渲染为 [object Object] 的问题

### DIFF
--- a/apps/negentropy-wiki/src/components/markdown/CodeBlock.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/CodeBlock.tsx
@@ -1,25 +1,30 @@
 "use client";
 
+import React from "react";
 import { useState, useCallback, useRef } from "react";
 
 interface CodeBlockProps {
-  children: string;
+  children: React.ReactNode;
   className?: string;
+  /** 纯文本内容，供「复制」按钮使用；若未提供则从 DOM 提取 */
+  codeText?: string;
 }
 
-export function CodeBlock({ children, className }: CodeBlockProps) {
+export function CodeBlock({ children, className, codeText }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const preRef = useRef<HTMLPreElement>(null);
 
   const language = className?.replace("language-", "") ?? "";
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(children).then(() => {
+    const text = codeText ?? preRef.current?.textContent ?? "";
+    navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => setCopied(false), 2000);
     });
-  }, [children]);
+  }, [codeText]);
 
   return (
     <div className="wiki-code-block" style={{ position: "relative" }}>
@@ -32,7 +37,7 @@ export function CodeBlock({ children, className }: CodeBlockProps) {
       >
         {copied ? "已复制" : "复制"}
       </button>
-      <pre>
+      <pre ref={preRef}>
         <code className={className}>{children}</code>
       </pre>
     </div>

--- a/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
@@ -70,8 +70,8 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
                 return <MermaidDiagram code={codeChild.value} />;
               }
               return (
-                <CodeBlock className={codeChild.className}>
-                  {codeChild.value}
+                <CodeBlock className={codeChild.className} codeText={codeChild.value}>
+                  {codeChild.reactChildren}
                 </CodeBlock>
               );
             }
@@ -115,17 +115,37 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   );
 }
 
-function extractCodeChild(children: React.ReactNode): { value: string; className?: string } | null {
+/**
+ * 从 React 元素树中递归提取纯文本（叶子字符串拼接）。
+ * rehype-highlight 将 code children 转为 <span class="hljs-*"> 元素树，
+ * 此函数遍历该树提取纯文本，供「复制」按钮和 Mermaid 使用。
+ */
+function extractTextContent(node: React.ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (!node || typeof node !== "object") return "";
+  if (Array.isArray(node)) return node.map(extractTextContent).join("");
+  if ("props" in node) {
+    const el = node as { props?: { children?: React.ReactNode } };
+    return extractTextContent(el.props?.children);
+  }
+  return "";
+}
+
+function extractCodeChild(
+  children: React.ReactNode,
+): { value: string; className?: string; reactChildren: React.ReactNode } | null {
   if (!children) return null;
   const reactChildren = Array.isArray(children) ? children : [children];
   for (const child of reactChildren) {
     if (child && typeof child === "object" && "props" in child) {
       const codeEl = child as { props?: { children?: React.ReactNode; className?: string } };
       if (codeEl.props?.children != null) {
-        const value = typeof codeEl.props.children === "string"
-          ? codeEl.props.children
-          : String(codeEl.props.children);
-        return { value, className: codeEl.props.className };
+        const codeChildren = codeEl.props.children;
+        const value = typeof codeChildren === "string"
+          ? codeChildren
+          : extractTextContent(codeChildren);
+        return { value, className: codeEl.props.className, reactChildren: codeChildren };
       }
     }
   }


### PR DESCRIPTION
# 背景
- Wiki 站点渲染含语法高亮的 fenced code block（TypeScript 等语言）时，所有被 `rehype-highlight` 包裹为 `<span class="hljs-*">` 的 token 均显示为 `[object Object]`，而纯文本 token（空格、换行）正常
- 根因：`MarkdownRenderer.tsx` 的 `extractCodeChild` 函数在 `rehype-highlight` 已将 `code.props.children` 从 `string` 转为 `ReactElement[]`（span 树）后，仍用 `String()` 提取文本——对 React 元素数组调用 `String()` 产出 `[object Object]`

# 核心变更
- **`MarkdownRenderer.tsx`**：新增 `extractTextContent()` 递归提取纯文本；`extractCodeChild` 返回 `{ value, className, reactChildren }` 三元组——`value` 纯文本供复制/Mermaid，`reactChildren` 原样传递给 `CodeBlock` 保留高亮 span 树
- **`CodeBlock.tsx`**：`children` 类型从 `string` 改为 `ReactNode`（承载高亮 span 树）；新增 `codeText` prop 供复制按钮；DOM `textContent` 作为兜底

# 风险与回滚
- 主要风险：极低，仅影响 wiki 代码块渲染路径，不涉及数据层或后端
- 回滚方式：`git revert` 单次 commit 即可

# 验证证据
- TypeScript 类型检查通过（`tsc --noEmit`）
- ESLint / pre-commit hooks 全部通过
- 浏览器实机验证待执行

# 影响范围
- 前端：`apps/negentropy-wiki` 的 Markdown 代码块渲染（`MarkdownRenderer` + `CodeBlock`）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 启动 wiki dev server（alt-port 3093）进行浏览器实机验证，确认 TypeScript 代码块语法高亮正常渲染、「复制」按钮复制纯文本、Mermaid 图表正常
