### PR TITLE
fix(wiki-catalog): 目录树叶子节点拖拽排序即时生效（乐观更新 + 展开状态保留）

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_hooks/useCatalogTree.ts
+++ b/apps/negentropy-ui/app/knowledge/wiki/_hooks/useCatalogTree.ts
@@ -43,11 +43,17 @@ export function useCatalogTree({ catalogId }: UseCatalogTreeOptions) {
     try {
       const data = await fetchCatalogTree(catalogId);
       setNodes(data);
-      // Auto-expand first level
-      const rootIds = data
-        .filter((n) => (n.depth ?? 0) === 0)
-        .map((n) => n.id);
-      setExpandedIds(new Set(rootIds));
+      // Preserve existing expanded state; only auto-expand root on first load.
+      // Also handles catalogId switch: stale IDs are pruned against the new node set.
+      setExpandedIds((prev) => {
+        const validIds = new Set(data.map((n) => n.id));
+        const filtered = new Set([...prev].filter((id) => validIds.has(id)));
+        if (filtered.size > 0) return filtered;
+        const rootIds = data
+          .filter((n) => (n.depth ?? 0) === 0)
+          .map((n) => n.id);
+        return new Set(rootIds);
+      });
     } catch (err) {
       console.error("Failed to load catalog tree:", err);
       setNodes([]);
@@ -140,18 +146,63 @@ export function useCatalogTree({ catalogId }: UseCatalogTreeOptions) {
       newSortOrder: number,
     ) => {
       if (!catalogId) return;
+
+      // Capture snapshots inside setState callbacks for atomicity
+      let snapNodes: CatalogNode[] | null = null;
+      let snapExpanded: Set<string> | null = null;
+
+      // Optimistic update: immediately reflect the move in local state,
+      // including path/depth recalculation for cross-folder moves.
+      setNodes((prev) => {
+        snapNodes = prev.map((n) => ({ ...n })); // defensive shallow copy
+        return prev.map((n) => {
+          if (n.id !== nodeId) return n;
+          const targetParent = newParentId
+            ? prev.find((p) => p.id === newParentId)
+            : null;
+          const newPath = targetParent
+            ? [...(targetParent.path ?? []), targetParent.id]
+            : [];
+          const newDepth = targetParent
+            ? (targetParent.depth ?? 0) + 1
+            : 0;
+          return {
+            ...n,
+            parent_id: newParentId,
+            sort_order: newSortOrder,
+            path: newPath,
+            depth: newDepth,
+          };
+        });
+      });
+
+      // Auto-expand the target folder when moving into a new parent
+      setExpandedIds((prev) => {
+        snapExpanded = new Set(prev);
+        if (newParentId && !prev.has(newParentId)) {
+          const next = new Set(prev);
+          next.add(newParentId);
+          return next;
+        }
+        return prev;
+      });
+
       try {
         await updateCatalogNode(catalogId, nodeId, {
           parent_id: newParentId,
           sort_order: newSortOrder,
         });
-        await refresh();
+        // Success — no full refresh needed; reindexSiblings will refresh
+        // when necessary and it now preserves expandedIds.
       } catch (err) {
+        // Rollback to pre-move snapshot
+        if (snapNodes) setNodes(snapNodes);
+        if (snapExpanded) setExpandedIds(snapExpanded);
         toast.error(err instanceof Error ? err.message : "移动失败");
         throw err;
       }
     },
-    [catalogId, refresh],
+    [catalogId],
   );
 
   return {


### PR DESCRIPTION
# 背景
- Wiki/Knowledge 目录树的叶子节点（`document_ref`）通过拖拽调整排序或归属后，变更不即时生效，树自动收缩回仅根节点展开的状态
- 根因：`useCatalogTree.ts` 的 `refresh()` 每次调用都将 `expandedIds` 硬重置为仅包含根节点 ID；拖拽后 `moveNode` → `refresh()` + `reindexSiblings` → `onRefresh()` 双重重置，导致用户展开状态丢失

# 核心变更
- **`refresh()` 保留展开状态**：已有 `expandedIds` 时保留（仅过滤掉新数据中不存在的陈旧 ID），首次加载才自动展开根节点；`catalogId` 切换时自动清理旧 ID
- **`moveNode` 乐观更新**：先在 `setState` 回调中原子性捕获快照并即时修改本地 `nodes`（含 `path`/`depth` 重算用于跨目录移动），再异步 PATCH API；失败时用快照回滚
- **消除双重刷新**：`moveNode` 不再调用 `refresh()`，由 `reindexSiblings` 按需触发刷新（现已保留展开状态）

# 风险与回滚
- 主要风险：乐观更新窗口期内 `path`/`depth` 对子孙节点的级联修正未覆盖（仅修正了被拖节点自身），但 `reindexSiblings` 的后续刷新会在毫秒级修正
- 回滚方式：`git revert` 单个 commit 即可

# 验证证据
- 单元测试：既有测试不受影响
- 集成测试：N/A
- E2E/Workflow：浏览器实机验证通过——重命名触发 `refresh()` 后 Paper（4 子节点）和 Blog（2 子节点）均保持展开 ✅
- 覆盖率/关键截图：服务端排序持久化验证通过 ✅

# 影响范围
- 前端：`apps/negentropy-ui/app/knowledge/wiki/_hooks/useCatalogTree.ts`（+58 / -7）
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action
- 建议手动在浏览器中实际拖拽叶子节点验证完整的 DnD 即时生效体验（自动化工具无法模拟 @dnd-kit 的 Pointer 事件）