### PR TITLE
style(drawer): 统一全项目抽屉宽度为 clamp 响应式规范，消除碎片化体验

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityDrawer.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/ActivityDrawer.tsx
@@ -61,7 +61,7 @@ export function ActivityDrawer({ open, onClose }: ActivityDrawerProps) {
         aria-label="Close drawer"
         className="absolute inset-0 bg-overlay backdrop-blur-[2px]"
       />
-      <aside className="relative z-10 flex h-full w-full max-w-[480px] flex-col border-l border-border bg-card shadow-xl">
+      <aside className="relative z-10 flex h-full [width:clamp(480px,66.67%,1100px)] flex-col border-l border-border bg-card shadow-xl">
         {/* Header */}
         <header className="border-b border-border px-4 py-3">
           <div className="flex items-center justify-between">

--- a/apps/negentropy-ui/app/(home)/dashboard/_components/TaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/TaskDetailDrawer.tsx
@@ -88,7 +88,7 @@ export function TaskDetailDrawer({ task, onClose, onTaskChanged }: TaskDetailDra
         aria-label="Close drawer"
         className="absolute inset-0 bg-overlay backdrop-blur-[2px]"
       />
-      <aside className="relative z-10 flex h-full w-full max-w-[480px] flex-col border-l border-border bg-card shadow-xl">
+      <aside className="relative z-10 flex h-full [width:clamp(480px,66.67%,1100px)] flex-col border-l border-border bg-card shadow-xl">
         <header className="border-b border-border px-4 py-3">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -485,7 +485,7 @@ export function RoutineEditDrawer({
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
-        className="fixed inset-y-0 right-0 z-50 flex w-[690px] max-w-[92vw] flex-col border-l border-border bg-card shadow-xl outline-none"
+        className="fixed inset-y-0 right-0 z-50 flex [width:clamp(480px,66.67%,1100px)] flex-col border-l border-border bg-card shadow-xl outline-none"
         style={{ transform: "translateX(100%)" }}
       >
         {/* Header */}

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
@@ -91,7 +91,7 @@ export function SchedulerTaskDetailDrawer({
       {/* Panel */}
       <div
         ref={panelRef}
-        className="fixed inset-y-0 right-0 z-50 w-[420px] max-w-[90vw] bg-card border-l border-border shadow-xl flex flex-col"
+        className="fixed inset-y-0 right-0 z-50 [width:clamp(480px,66.67%,1100px)] bg-card border-l border-border shadow-xl flex flex-col"
         style={{ transform: "translateX(100%)" }}
       >
         {/* Header */}

--- a/apps/negentropy-ui/app/memory/core-blocks/_components/CoreBlockEditorDrawer.tsx
+++ b/apps/negentropy-ui/app/memory/core-blocks/_components/CoreBlockEditorDrawer.tsx
@@ -93,7 +93,7 @@ export function CoreBlockEditorDrawer({
       subtitle={
         isEdit ? `${editing?.scope} · ${editing?.label}` : "常驻记忆块（always-injected）"
       }
-      widthClassName="w-full max-w-[480px]"
+      widthClassName="[width:clamp(480px,66.67%,1100px)]"
       footer={
         <div className="flex items-center justify-end gap-2">
           <Button variant="outline" size="sm" onClick={onClose}>

--- a/apps/negentropy-ui/components/ui/BaseDrawer.tsx
+++ b/apps/negentropy-ui/components/ui/BaseDrawer.tsx
@@ -28,7 +28,7 @@ export interface BaseDrawerProps {
   footer?: ReactNode;
   /** 滑出方向。默认 right。 */
   side?: "right" | "left";
-  /** 面板宽度类（如 "max-w-md" / "w-[480px]"）。默认 max-w-md。 */
+  /** 面板宽度类。默认 [width:clamp(480px,66.67%,1100px)]（最小 480px / 理想视口 2/3 / 最大 1100px）。 */
   widthClassName?: string;
   closeOnBackdrop?: boolean;
   closeOnEscape?: boolean;
@@ -46,7 +46,7 @@ export function BaseDrawer({
   subtitle,
   footer,
   side = "right",
-  widthClassName = "w-full max-w-md",
+  widthClassName = "[width:clamp(480px,66.67%,1100px)]",
   closeOnBackdrop = true,
   closeOnEscape = true,
   showClose = true,

--- a/apps/negentropy-ui/features/memory/components/MemoryAssociationsDrawer.tsx
+++ b/apps/negentropy-ui/features/memory/components/MemoryAssociationsDrawer.tsx
@@ -67,7 +67,7 @@ export function MemoryAssociationsDrawer({
       title="Associations"
       subtitle={memorySnippet}
       side="right"
-      widthClassName="w-full max-w-[420px]"
+      widthClassName="[width:clamp(480px,66.67%,1100px)]"
     >
       <div className="space-y-3 px-5 py-4">
         {loading ? (

--- a/apps/negentropy-wiki/src/styles/components/agent-chat.css
+++ b/apps/negentropy-wiki/src/styles/components/agent-chat.css
@@ -43,7 +43,7 @@
   position: fixed;
   right: 24px;
   bottom: 92px; /* FAB(56) + gap(12) + margin(24) */
-  width: min(420px, calc(100vw - 48px));
+  width: clamp(480px, 66.67vw, 1100px);
   height: min(620px, calc(100vh - 140px));
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
# 背景
- 项目内各抽屉式页面宽度碎片化（420px / 480px / 690px / 800px），视觉体验不一致。需统一为响应式宽度规范 `clamp(480px, 66.67%, 1100px)`（最小 480px / 理想视口 2/3 / 最大 1100px），以 IterationAuditDrawer 为标杆。

# 核心变更
- **BaseDrawer 默认值**：`w-full max-w-md`（448px）→ `[width:clamp(480px,66.67%,1100px)]`，未来新建抽屉自动继承标准宽度
- **BaseDrawer 消费者**（CoreBlockEditorDrawer、MemoryAssociationsDrawer）：更新 `widthClassName` prop
- **自实现抽屉**（ActivityDrawer、TaskDetailDrawer、RoutineEditDrawer、SchedulerTaskDetailDrawer）：替换 inline width class
- **Wiki ChatDrawer**：CSS `width: min(420px,...)` → `width: clamp(480px, 66.67vw, 1100px)`
- **StateDrawer 不变更**：非业务抽屉，属 UI 基础观测面板

# 风险与回滚
- 主要风险：ChatDrawer（浮动聊天面板）从 420px 扩至最大 1100px 视觉变化显著；RoutineEditDrawer（2 列表单）在大宽度下布局需目视确认
- 回滚方式：`git revert` 单个 commit 即可完整回滚

# 验证证据
- 单元测试：无新增（纯样式变更）
- 集成测试：Pre-commit hooks（ESLint、Ruff、trailing whitespace）全部通过
- E2E/Workflow：建议在 1280px / 1440px / 1920px / 768px 视口下逐抽屉目视验证
- 覆盖率/关键截图：待浏览器实机验证

# 影响范围
- 前端：negentropy-ui（7 文件）+ negentropy-wiki（1 文件），共 8 文件、9 行变更
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证各抽屉在不同视口宽度下的渲染效果，重点关注 RoutineEditDrawer（2 列表单）和 ChatDrawer（浮动面板比例）