### PR TITLE
fix(routine-timeline): 修复 View Details 抽屉页时间线图标与文字未水平对齐的问题

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -129,7 +129,7 @@ function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
   return (
     <li className="relative -ml-px pl-4">
       {/* 时间线节点圆点 */}
-      <span className="absolute left-0 top-2.5 -translate-x-1/2">
+      <span className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2">
         <span
           className={`flex h-5 w-5 items-center justify-center rounded-full ring-2 ring-card ${eventTypeClass(ev.event_type, isError)}`}
         >


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：View Details 抽屉页中时间线左侧圆形图标节点与右侧文字行未水平对齐，图标整体偏下约 6px
- 关联上下文/Issue/文档：无

# 核心变更
- 将 `IterationEventTimeline.tsx` 中图标节点的硬编码 `top-2.5`（10px 固定偏移）替换为百分比居中定位 `top-1/2 -translate-y-1/2`，使图标自动垂直居中于 `<li>` 高度（即 `<button>` 高度），无论按钮内容高度如何变化都能保持对齐

# 风险与回滚
- 主要风险：极低，仅修改一行 CSS 类，无逻辑变更
- 回滚方式：`git revert`

# 验证证据
- 单元测试：无（纯 CSS 样式变更）
- 集成测试：无
- E2E/Workflow：无
- 覆盖率/关键截图：需浏览器实机验证，确认图标与文字行水平对齐

# 影响范围
- 前端：`IterationEventTimeline.tsx` — View Details 抽屉页事件时间线组件
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证：启动 dev server 后打开 Routine 页 → Full View → View Details，确认图标与文字对齐效果