### PR TITLE
feat(routine): 迭代超时默认值调整为 3h 并支持 UI 配置与手动终止操作

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -22,6 +22,7 @@ import { RoutineRunView } from "../_components/RoutineRunView";
 import { canRestart, CONTROL_LABEL, controlsFor, type ControlAction } from "../_components/routine-controls";
 import { phaseClass, phaseLabel, routineStatusClass } from "../_components/status-style";
 import { useRestartRoutine } from "../_components/useRestartRoutine";
+import { useTerminateRoutine } from "../_components/useTerminateRoutine";
 
 export default function RoutineRunPage() {
   const params = useParams<{ id: string }>();
@@ -29,14 +30,22 @@ export default function RoutineRunPage() {
   const { routine, loading, error, reload, connected, liveActionsByIteration } = useRoutineDetailLive(id);
   const [busy, setBusy] = useState(false);
 
+  // 终止 routine（需确认对话框门控）。
+  const { requestTerminate, terminateDialog } = useTerminateRoutine(() => void reload());
+
+  // 生命周期控制：cancel 路由到确认对话框；其余直接执行。
   const handleControl = useCallback(
     async (action: ControlAction) => {
       if (!id) return;
+      if (action === "cancel") {
+        if (routine) requestTerminate(routine);
+        return;
+      }
       setBusy(true);
       try {
         await controlRoutine(id, action);
         toast.success(
-          `Routine ${{ start: "started", pause: "paused", resume: "resumed", cancel: "cancelled" }[action]}`,
+          `Routine ${{ start: "started", pause: "paused", resume: "resumed" }[action]}`,
         );
         await reload();
       } catch (err) {
@@ -45,7 +54,7 @@ export default function RoutineRunPage() {
         setBusy(false);
       }
     },
-    [id, reload],
+    [id, reload, routine, requestTerminate],
   );
 
   const handleApprove = useCallback(
@@ -134,7 +143,7 @@ export default function RoutineRunPage() {
                 {controls.map((action) => (
                   <Button
                     key={action}
-                    variant={action === "cancel" ? "outline" : "neutral"}
+                    variant={action === "cancel" ? "danger" : "neutral"}
                     size="sm"
                     disabled={busy}
                     onClick={() => handleControl(action)}
@@ -181,6 +190,7 @@ export default function RoutineRunPage() {
         </ClockProvider>
       </div>
       {restartDialog}
+      {terminateDialog}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -91,6 +91,7 @@ interface FormState {
   max_turns: string;
   permission_mode: string;
   allowed_tools: string;
+  timeout_seconds: string;
   // 模板元数据（template entity）
   category: string;
   version: string;
@@ -116,6 +117,7 @@ const DEFAULTS: FormState = {
   max_turns: "",
   permission_mode: "",
   allowed_tools: "",
+  timeout_seconds: "",
   category: "general",
   version: "1.0.0",
   features_showcase: "",
@@ -142,12 +144,13 @@ const CATEGORY_OPTIONS = [
 ];
 
 /** 从 config 提取 Claude Code 覆盖键 → 表单字符串。 */
-function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "max_turns" | "permission_mode" | "allowed_tools"> {
+function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "max_turns" | "permission_mode" | "allowed_tools" | "timeout_seconds"> {
   return {
     model: (cfg.model as string) ?? "",
     max_turns: cfg.max_turns != null ? String(cfg.max_turns) : "",
     permission_mode: (cfg.permission_mode as string) ?? "",
     allowed_tools: Array.isArray(cfg.allowed_tools) ? (cfg.allowed_tools as string[]).join(", ") : "",
+    timeout_seconds: cfg.timeout_seconds != null ? String(cfg.timeout_seconds) : "",
   };
 }
 
@@ -258,7 +261,7 @@ export function RoutineEditDrawer({
   // 用 form 的初值同源 seed（initializer 仅挂载时取值），避免 use-template 的随机 key 双生致恒脏。
   const [baseline, setBaseline] = useState<FormState>(form);
   const [showAdvanced, setShowAdvanced] = useState(
-    () => entity === "routine" && !!(form.model || form.max_turns || form.permission_mode || form.allowed_tools),
+    () => entity === "routine" && !!(form.model || form.max_turns || form.permission_mode || form.allowed_tools || form.timeout_seconds),
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -383,6 +386,8 @@ export function RoutineEditDrawer({
       if (form.allowed_tools.trim())
         config.allowed_tools = form.allowed_tools.split(",").map((s) => s.trim()).filter(Boolean);
       else delete config.allowed_tools;
+      if (form.timeout_seconds.trim()) config.timeout_seconds = parseInt(form.timeout_seconds, 10);
+      else delete config.timeout_seconds;
       extra = { cwd: form.cwd.trim() || null, baseline_branch: form.baseline_branch.trim() || null };
     } else {
       // 模板元数据收敛进 config（与列表 API 的读取契约对齐）
@@ -645,7 +650,7 @@ export function RoutineEditDrawer({
             {/* Budget & Approval */}
             <section className="rounded-card border border-border bg-muted/30 p-4">
               <h3 className="mb-3 text-xs font-medium text-text-secondary">Budget &amp; Approval</h3>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+              <div className="grid grid-cols-3 gap-x-6 gap-y-2">
                 <div className="flex items-center gap-2">
                   <label className={labelInlineCls}>Max Iterations</label>
                   <input
@@ -691,6 +696,20 @@ export function RoutineEditDrawer({
                     disabled={readOnly}
                     className={cn(inputCls, "min-w-0 flex-1")}
                   />
+                </div>
+                <div className="col-span-2 flex items-center gap-2">
+                  <label className={labelInlineCls}>Iteration Timeout</label>
+                  <input
+                    type="number"
+                    min={300}
+                    max={86400}
+                    value={form.timeout_seconds}
+                    onChange={(e) => update("timeout_seconds", e.target.value)}
+                    disabled={readOnly}
+                    placeholder="10800"
+                    className={cn(inputCls, "min-w-0 w-32")}
+                  />
+                  <span className="text-[11px] text-text-muted">seconds (default 3h)</span>
                 </div>
               </div>
               <div className="mt-3 flex items-start gap-2">
@@ -899,7 +918,7 @@ export function RoutineEditDrawer({
                 <Button
                   key={action}
                   type="button"
-                  variant={action === "cancel" ? "outline" : "neutral"}
+                  variant={action === "cancel" ? "danger" : "neutral"}
                   size="sm"
                   disabled={busy}
                   onClick={() => onControl(action)}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { ExternalLink, RotateCcw } from "lucide-react";
+import { ExternalLink, OctagonX, RotateCcw } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
 
-import { canRestart } from "./routine-controls";
+import { canCancel, canRestart } from "./routine-controls";
 import { routineStatusClass, scoreColorClass } from "./status-style";
 
 interface RoutineTableProps {
@@ -15,9 +15,11 @@ interface RoutineTableProps {
   onOpenFull: (r: RoutineDTO) => void;
   /** 失败 / 取消行内一键重启（打开确认对话框）。 */
   onRestart?: (r: RoutineDTO) => void;
+  /** 运行中 / 暂停行内终止（打开确认对话框）。 */
+  onTerminate?: (r: RoutineDTO) => void;
 }
 
-export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart }: RoutineTableProps) {
+export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart, onTerminate }: RoutineTableProps) {
   if (loading && routines.length === 0) {
     return (
       <div className="space-y-2">
@@ -98,6 +100,19 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                     >
                       <RotateCcw className="h-3 w-3" />
                       Restart
+                    </button>
+                  )}
+                  {onTerminate && canCancel(r.status) && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onTerminate(r);
+                      }}
+                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-red-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-red-400"
+                    >
+                      <OctagonX className="h-3 w-3" />
+                      Terminate
                     </button>
                   )}
                   <button

--- a/apps/negentropy-ui/app/interface/routine/_components/TerminateRoutineDialog.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TerminateRoutineDialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useId } from "react";
+import { OctagonX } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import type { RoutineDTO } from "@/features/routine";
+
+/**
+ * Routine 终止确认对话框。
+ *
+ * 终止将取消 Routine 并中止正在执行的迭代——属「破坏性」操作，需确认门控。
+ * 视觉与 a11y 复用 {@link OverlayDismissLayer}（焦点陷阱 / Esc / 遮罩关闭 / aria-modal），
+ * 与 {@link RestartRoutineDialog} 同源；终止为破坏性操作，用 danger（红色）+ autoFocus 安全侧。
+ */
+export interface TerminateRoutineDialogProps {
+  routine: RoutineDTO;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function TerminateRoutineDialog({
+  routine,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: TerminateRoutineDialogProps) {
+  const titleId = useId();
+  const name = routine.display_name || routine.title || routine.key;
+
+  return (
+    <OverlayDismissLayer
+      open
+      onClose={onCancel}
+      busy={busy}
+      containerClassName="flex min-h-full items-center justify-center p-4"
+      contentClassName="w-full max-w-md rounded-modal border border-border bg-card shadow-xl"
+      contentProps={{ role: "dialog", "aria-modal": true, "aria-labelledby": titleId }}
+    >
+      <div className="px-5 py-4 sm:px-6" data-testid="terminate-dialog">
+        <h2 id={titleId} className="text-lg font-semibold text-red-600 dark:text-red-400">
+          Terminate Routine
+        </h2>
+        <div className="mt-2 space-y-3 text-sm text-text-secondary">
+          <p>
+            Terminate{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground">{name}</code>?
+            This will immediately cancel the routine and abort any in-flight iteration.
+          </p>
+          <p className="text-[13px] text-text-muted">
+            This action cannot be undone. You can restart the routine later if needed.
+          </p>
+        </div>
+      </div>
+      <div className="flex justify-end gap-3 border-t border-border px-5 py-4 sm:px-6">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={busy} autoFocus>
+          Keep Running
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          leftIcon={<OctagonX className="h-4 w-4" />}
+          onClick={onConfirm}
+          loading={busy}
+        >
+          Terminate
+        </Button>
+      </div>
+    </OverlayDismissLayer>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
@@ -11,7 +11,7 @@ export const CONTROL_LABEL: Record<ControlAction, string> = {
   start: "Start",
   pause: "Pause",
   resume: "Resume",
-  cancel: "Cancel",
+  cancel: "Terminate",
 };
 
 /** 依 Routine 状态计算可用控制动作。 */
@@ -26,6 +26,14 @@ export function controlsFor(status: RoutineStatus): ControlAction[] {
     default:
       return [];
   }
+}
+
+/**
+ * 是否可「终止」——非终态（pending / running / paused）均可。
+ * 供列表页行内 Terminate 按钮 + 确认对话框门控。
+ */
+export function canCancel(status: RoutineStatus): boolean {
+  return status === "pending" || status === "running" || status === "paused";
 }
 
 /**

--- a/apps/negentropy-ui/app/interface/routine/_components/useTerminateRoutine.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/useTerminateRoutine.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+import { controlRoutine, type RoutineDTO } from "@/features/routine";
+
+import { TerminateRoutineDialog } from "./TerminateRoutineDialog";
+
+/**
+ * 终止 Routine 的单一逻辑源——列表行内、抽屉、详情页三处入口共用，避免逻辑分叉。
+ *
+ * 返回 `requestTerminate(r)`（打开确认对话框）、`terminateDialog`（待渲染的对话框节点）、`busy`。
+ * 确认后调 {@link controlRoutine}(id, "cancel")，成功/失败 toast，并回调 `onDone(updated)` 供调用方刷新。
+ */
+export function useTerminateRoutine(onDone?: (updated: RoutineDTO) => void) {
+  const [target, setTarget] = useState<RoutineDTO | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const requestTerminate = useCallback((r: RoutineDTO) => setTarget(r), []);
+  const cancel = useCallback(() => {
+    if (!busy) setTarget(null);
+  }, [busy]);
+
+  const confirm = useCallback(async () => {
+    if (!target) return;
+    setBusy(true);
+    try {
+      const updated = await controlRoutine(target.id, "cancel");
+      toast.success("Routine terminated");
+      setTarget(null);
+      onDone?.(updated);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to terminate");
+    } finally {
+      setBusy(false);
+    }
+  }, [target, onDone]);
+
+  const terminateDialog = target ? (
+    <TerminateRoutineDialog routine={target} busy={busy} onConfirm={confirm} onCancel={cancel} />
+  ) : null;
+
+  return { requestTerminate, terminateDialog, busy };
+}

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -26,6 +26,7 @@ import { RoutineHeader } from "./_components/RoutineHeader";
 import { RoutineKpiStrip } from "./_components/RoutineKpiStrip";
 import { RoutineTable } from "./_components/RoutineTable";
 import { useRestartRoutine } from "./_components/useRestartRoutine";
+import { useTerminateRoutine } from "./_components/useTerminateRoutine";
 
 const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "" };
 
@@ -66,6 +67,12 @@ function RoutinePageInner() {
 
   // 重启失败 / 取消的 routine（列表行内 + 抽屉共用单一逻辑源）。
   const { requestRestart, restartDialog } = useRestartRoutine((updated) => {
+    refresh();
+    if (selId === updated.id) void refreshSelected(updated.id);
+  });
+
+  // 终止运行中 / 暂停的 routine（列表行内 + 抽屉共用单一逻辑源）。
+  const { requestTerminate, terminateDialog } = useTerminateRoutine((updated) => {
     refresh();
     if (selId === updated.id) void refreshSelected(updated.id);
   });
@@ -126,12 +133,17 @@ function RoutinePageInner() {
     },
   });
 
+  // 生命周期控制：cancel 路由到确认对话框；其余直接执行。
   const handleControl = async (action: "start" | "pause" | "resume" | "cancel") => {
     if (!selected) return;
+    if (action === "cancel") {
+      requestTerminate(selected);
+      return;
+    }
     setActionBusy(true);
     try {
       const updated = await controlRoutine(selected.id, action);
-      toast.success(`Routine ${{ start: "started", pause: "paused", resume: "resumed", cancel: "cancelled" }[action]}`);
+      toast.success(`Routine ${{ start: "started", pause: "paused", resume: "resumed" }[action]}`);
       await refreshSelected(updated.id);
       refresh();
     } catch (err) {
@@ -207,6 +219,7 @@ function RoutinePageInner() {
               onSelect={openDetail}
               onOpenFull={openFull}
               onRestart={requestRestart}
+              onTerminate={requestTerminate}
             />
           </div>
         </ClockProvider>
@@ -228,6 +241,7 @@ function RoutinePageInner() {
 
       {confirmDialog}
       {restartDialog}
+      {terminateDialog}
     </div>
   );
 }

--- a/apps/negentropy/src/negentropy/agents/routine_presets/preening_substrate.yaml
+++ b/apps/negentropy/src/negentropy/agents/routine_presets/preening_substrate.yaml
@@ -49,4 +49,4 @@ config:
   workflow: phased        # 启用三相位：PLAN(产出计划)→IMPLEMENT(落地)→FINALIZE(自检+建 PR)→人工 Merge
   permission_mode: plan   # PLAN 相位初值；orchestrator 按相位推进切到 acceptEdits（IMPLEMENT/FINALIZE）
   max_turns: 30
-  timeout_seconds: 1800   # 单轮 30min 上限，远超旧 300s 默认，杜绝深度任务超时空转
+  timeout_seconds: 10800  # 单轮 3h 上限，远超旧 300s 默认，杜绝深度任务超时空转

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -63,6 +63,12 @@ class RoutineSettings(BaseSettings):
     default_max_cost_usd: float = Field(
         default=5.0, ge=0.0, description="创建 routine 时 max_cost_usd 的默认值（成本熔断守卫）"
     )
+    default_iteration_timeout_seconds: int = Field(
+        default=10800,
+        ge=300,
+        le=86400,
+        description="Routine 单次迭代的默认执行超时（秒）；被 routine.config.timeout_seconds 覆盖。默认 3h。",
+    )
     evaluator_model: str | None = Field(
         default=None,
         description="评估器 LLM-as-Judge 模型覆盖；为空时走 task_registry 的 routine.evaluate 解析",

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -543,6 +543,8 @@ class RoutineOrchestrator:
             config.permission_mode = phase_mod.permission_mode_for(routine.current_phase)
         elif overrides.get("permission_mode"):
             config.permission_mode = overrides["permission_mode"]
+        # Routine 级默认覆盖全局 CC 默认（3h vs 5min）；per-routine config 可再覆盖。
+        config.timeout_seconds = float(settings.routine.default_iteration_timeout_seconds)
         if overrides.get("timeout_seconds"):
             config.timeout_seconds = float(overrides["timeout_seconds"])
         config.resume_session_id = routine.claude_session_id


### PR DESCRIPTION
## 概述

Routine 系统迭代超时与终止操作两项增强：

### 1. 迭代超时默认值调整（30min → 3h）

- `RoutineSettings` 新增 `default_iteration_timeout_seconds=10800`（3h）
- Orchestrator `_build_config()` 将此值注入为 Routine 级默认（覆盖全局 CC 5min 默认），per-routine config 仍可覆盖
- `preening_substrate` preset 的 `timeout_seconds` 同步从 1800 → 10800

### 2. 迭代超时时间支持 UI 配置

- `RoutineEditDrawer` Budget & Approval 区新增「Iteration Timeout」字段（秒级输入，默认 10800s/3h）
- 值存储在 `routine.config.timeout_seconds` JSONB 字段中，创建/编辑均可配置

### 3. 手动终止操作 UI 支持

- 新增 `TerminateRoutineDialog` 确认对话框（破坏性红色风格 + autoFocus 安全侧）
- 新增 `useTerminateRoutine` hook（复刻 useRestartRoutine 模式）
- `RoutineTable` 行内新增红色 Terminate 操作（running/paused 状态可见）
- 列表页、详情页的 cancel 动作路由到确认对话框门控，cancel 按钮改用 `danger` variant
- `routine-controls` 新增 `canCancel` 辅助函数，cancel 标签改名为 Terminate

## 改动文件

| 文件 | 变更 |
|------|------|
| `config/routine.py` | 新增 `default_iteration_timeout_seconds` 字段 |
| `engine/routine/orchestrator.py` | `_build_config()` 注入 Routine 级超时默认 |
| `agents/routine_presets/preening_substrate.yaml` | timeout 1800 → 10800 |
| `routine-controls.ts` | 新增 `canCancel`，label 改为 Terminate |
| `TerminateRoutineDialog.tsx` | **新建** — 终止确认对话框 |
| `useTerminateRoutine.tsx` | **新建** — 终止 hook |
| `RoutineTable.tsx` | 添加 Terminate 行内操作 |
| `page.tsx` (列表页) | 集成 useTerminateRoutine |
| `[id]/page.tsx` (详情页) | 集成 useTerminateRoutine + danger 样式 |
| `RoutineEditDrawer.tsx` | cancel 按钮 danger 样式 + Iteration Timeout 字段 |

## 验证

- ✅ TypeScript 类型检查通过（routine 相关文件零错误）
- ✅ ESLint 全部通过
- ✅ Pre-commit hooks（ruff lint + format）全部通过
- ✅ 后端 `RoutineSettings` 新字段符合 Pydantic 验证约束（300–86400）

🤖 Generated with [Claude Code](https://claude.com/claude-code)