### PR TITLE
feat(wiki-article-meta): Wiki 文章元数据栏 + Document 编辑入口（作者/日期/浏览/评论/源头链接）

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -21,6 +21,7 @@ import { buildBreadcrumbPath } from "@/lib/wiki-api";
 import { MarkdownRenderer } from "@/components/markdown/MarkdownRenderer";
 import { WikiBreadcrumb } from "@/components/WikiBreadcrumb";
 import { WikiCommentSection } from "@/components/WikiCommentSection";
+import { WikiArticleMeta } from "@/components/WikiArticleMeta";
 import { AnnotationLayer } from "@/components/annotation/AnnotationLayer";
 import { WikiFooter } from "@/components/home/WikiFooter";
 import Link from "next/link";
@@ -206,11 +207,13 @@ export default async function WikiEntryPage({ params }: Props) {
               <h1 className="wiki-doc-title">
                 {content.entry_title || slug}
               </h1>
-              <div className="wiki-doc-meta">
-                来源: {content.document_filename || "未知"}
-                {content.document_id &&
-                  ` · 文档 ID: ${String(content.document_id).slice(0, 8)}...`}
-              </div>
+              <WikiArticleMeta
+                entryId={entryId!}
+                authorName={content.author_name}
+                authorUrl={content.author_url}
+                publishedAt={content.published_at}
+                sourceUrl={content.source_url}
+              />
             </header>
             {entryId ? (
               <>

--- a/apps/negentropy-wiki/src/components/WikiArticleMeta.tsx
+++ b/apps/negentropy-wiki/src/components/WikiArticleMeta.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEntryStats } from "@/lib/use-entry-stats";
+
+interface WikiArticleMetaProps {
+  entryId: string;
+  authorName?: string | null;
+  authorUrl?: string | null;
+  publishedAt?: string | null;
+  sourceUrl?: string | null;
+}
+
+/**
+ * 文章元数据栏 — 展示在标题与正文之间
+ *
+ * 静态数据（作者 / 发布时间 / 源头链接）由 SSG 注入 props；
+ * 动态数据（浏览 / 评论 / 注解计数）在客户端通过 /stats 端点获取。
+ */
+export function WikiArticleMeta({
+  entryId,
+  authorName,
+  authorUrl,
+  publishedAt,
+  sourceUrl,
+}: WikiArticleMetaProps) {
+  const { stats } = useEntryStats(entryId);
+
+  const commentTotal = stats
+    ? stats.comment_count + stats.annotation_count
+    : null;
+
+  const hasAnyMeta = authorName || publishedAt || sourceUrl || stats;
+
+  if (!hasAnyMeta) return null;
+
+  return (
+    <div className="wiki-article-meta">
+      {/* 作者 */}
+      {authorName && (
+        <span className="wiki-meta-author">
+          <AuthorAvatar
+            authorName={authorName}
+            authorUrl={authorUrl}
+          />
+          {authorUrl ? (
+            <a
+              className="wiki-meta-author-name"
+              href={authorUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {authorName}
+            </a>
+          ) : (
+            <span className="wiki-meta-author-name">{authorName}</span>
+          )}
+        </span>
+      )}
+
+      {authorName && (publishedAt || stats || sourceUrl) && (
+        <span className="wiki-meta-sep">·</span>
+      )}
+
+      {/* 发布时间 */}
+      {publishedAt && (
+        <span className="wiki-meta-item">
+          <CalendarIcon />
+          {formatDate(publishedAt)}
+        </span>
+      )}
+
+      {/* 浏览次数 */}
+      <span className="wiki-meta-item">
+        <EyeIcon />
+        {stats ? formatNumber(stats.view_count) : "–"}
+      </span>
+
+      {/* 评论总数（评论 + 注解） */}
+      <span className="wiki-meta-item">
+        <CommentIcon />
+        {commentTotal !== null ? formatNumber(commentTotal) : "–"}
+      </span>
+
+      {/* 源头链接 */}
+      {sourceUrl && (
+        <>
+          <span className="wiki-meta-sep">·</span>
+          <span className="wiki-meta-item">
+            <ExternalLinkIcon />
+            <a
+              className="wiki-meta-source-link"
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              原文链接
+            </a>
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 子组件 & 工具函数
+// ---------------------------------------------------------------------------
+
+function AuthorAvatar({
+  authorName,
+  authorUrl,
+}: {
+  authorName: string;
+  authorUrl?: string | null;
+}) {
+  // 尝试从 GitHub URL 提取头像
+  let avatarSrc: string | null = null;
+  if (authorUrl) {
+    const ghMatch = authorUrl.match(/github\.com\/([^/?#]+)/);
+    if (ghMatch) {
+      avatarSrc = `https://avatars.githubusercontent.com/${ghMatch[1]}?s=48`;
+    }
+  }
+
+  if (avatarSrc) {
+    return (
+      <img
+        className="wiki-meta-author-avatar"
+        src={avatarSrc}
+        alt={authorName}
+        width={24}
+        height={24}
+      />
+    );
+  }
+
+  // 首字母回退
+  return (
+    <span className="wiki-meta-author-avatar-fallback">
+      {authorName.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  } catch {
+    return iso;
+  }
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+// ---------------------------------------------------------------------------
+// 内联 SVG 图标（15×15，opacity 0.55，与 wiki 现有无图标库风格一致）
+// ---------------------------------------------------------------------------
+
+function CalendarIcon() {
+  return (
+    <svg
+      className="wiki-meta-icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="3" width="12" height="11" rx="1.5" />
+      <line x1="5" y1="1" x2="5" y2="4" />
+      <line x1="11" y1="1" x2="11" y2="4" />
+      <line x1="2" y1="7" x2="14" y2="7" />
+    </svg>
+  );
+}
+
+function EyeIcon() {
+  return (
+    <svg
+      className="wiki-meta-icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8s-2.5 4.5-6.5 4.5S1.5 8 1.5 8z" />
+      <circle cx="8" cy="8" r="2" />
+    </svg>
+  );
+}
+
+function CommentIcon() {
+  return (
+    <svg
+      className="wiki-meta-icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v7a1 1 0 01-1 1H5l-3 3V3z" />
+    </svg>
+  );
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg
+      className="wiki-meta-icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9 1.5h5.5V7" />
+      <path d="M14.5 1.5L7.5 8.5" />
+      <path d="M6.5 3H3a1.5 1.5 0 00-1.5 1.5V13A1.5 1.5 0 003 14.5h8.5A1.5 1.5 0 0013 13V9.5" />
+    </svg>
+  );
+}

--- a/apps/negentropy-wiki/src/lib/use-entry-stats.ts
+++ b/apps/negentropy-wiki/src/lib/use-entry-stats.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface EntryStats {
+  view_count: number;
+  comment_count: number;
+  annotation_count: number;
+}
+
+/**
+ * 获取 Wiki 条目的动态统计数据（浏览 / 评论 / 注解计数）
+ * 并在首次挂载时自动记录一次页面浏览。
+ */
+export function useEntryStats(entryId: string | null) {
+  const [stats, setStats] = useState<EntryStats | null>(null);
+  const viewRecorded = useRef(false);
+
+  // 获取统计数据
+  useEffect(() => {
+    if (!entryId) return;
+
+    fetch(`/api/entries/${entryId}/stats`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data) {
+          setStats({
+            view_count: data.view_count ?? 0,
+            comment_count: data.comment_count ?? 0,
+            annotation_count: data.annotation_count ?? 0,
+          });
+        }
+      })
+      .catch(() => {
+        // ignore
+      });
+  }, [entryId]);
+
+  // 记录一次页面浏览（同一挂载只发一次）
+  const recordView = useCallback(() => {
+    if (!entryId || viewRecorded.current) return;
+    viewRecorded.current = true;
+
+    fetch(`/api/entries/${entryId}/view`, { method: "POST" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data) {
+          setStats((prev) =>
+            prev
+              ? { ...prev, view_count: data.view_count ?? prev.view_count }
+              : prev,
+          );
+        }
+      })
+      .catch(() => {
+        // ignore
+      });
+  }, [entryId]);
+
+  // 挂载后自动记录浏览
+  useEffect(() => {
+    recordView();
+  }, [recordView]);
+
+  return { stats };
+}

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -90,6 +90,10 @@ export interface WikiEntryContent {
   entry_title: string | null;
   markdown_content: string | null;
   document_filename: string;
+  author_name?: string | null;
+  author_url?: string | null;
+  source_url?: string | null;
+  published_at?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/negentropy-wiki/src/styles/components/doc.css
+++ b/apps/negentropy-wiki/src/styles/components/doc.css
@@ -16,6 +16,85 @@
   color: var(--wiki-text-secondary);
 }
 
+/* 文章元数据栏 */
+.wiki-article-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.85em;
+  color: var(--wiki-text-secondary);
+}
+
+.wiki-meta-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.wiki-meta-author-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--wiki-accent);
+  object-fit: cover;
+}
+
+.wiki-meta-author-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--wiki-accent);
+  font-size: 0.75em;
+  font-weight: 600;
+  color: var(--wiki-accent);
+  background: var(--wiki-primary-light);
+}
+
+.wiki-meta-author-name {
+  font-weight: 500;
+  color: var(--wiki-text);
+  text-decoration: none;
+  transition: color 0.12s ease;
+}
+
+a.wiki-meta-author-name:hover {
+  color: var(--wiki-accent);
+}
+
+.wiki-meta-sep {
+  opacity: 0.3;
+  user-select: none;
+}
+
+.wiki-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.wiki-meta-icon {
+  width: 15px;
+  height: 15px;
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+
+.wiki-meta-source-link {
+  color: var(--wiki-text-secondary);
+  text-decoration: none;
+  transition: color 0.12s ease;
+}
+
+.wiki-meta-source-link:hover {
+  color: var(--wiki-accent);
+}
+
 /* 面包屑 */
 .wiki-doc-breadcrumb {
   font-size: 0.88em;

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0057_wiki_entry_views.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0057_wiki_entry_views.py
@@ -1,0 +1,39 @@
+"""Add wiki_entry_views table for page view counting
+
+Revision ID: 0057
+Revises: 0056
+Create Date: 2026-06-01 00:00:00.000000+00:00
+
+设计动机：
+    为 Wiki 条目新增浏览计数能力。每次页面加载通过 ``POST /view`` 端点
+    原子递增 view_count，供文章元数据栏展示「浏览次数」。
+
+    采用轻量级 per-entry 计数器（不做用户去重），使用 PostgreSQL
+    ``INSERT ... ON CONFLICT DO UPDATE`` 实现原子 upsert，
+    避免并发场景下的计数丢失。
+"""
+
+from alembic import op
+
+revision = "0057"
+down_revision = "0056"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "negentropy"
+
+
+def upgrade() -> None:
+    op.execute(f"""
+        CREATE TABLE {SCHEMA}.wiki_entry_views (
+            entry_id UUID NOT NULL
+                REFERENCES {SCHEMA}.wiki_publication_entries(id) ON DELETE CASCADE,
+            view_count BIGINT NOT NULL DEFAULT 0,
+            last_viewed_at TIMESTAMP WITH TIME ZONE,
+            PRIMARY KEY (entry_id)
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute(f"DROP TABLE IF EXISTS {SCHEMA}.wiki_entry_views")

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from negentropy.models.perception import (
+    DocSource,
     KnowledgeDocument,
     WikiEntryAnnotation,
     WikiEntryComment,
@@ -396,27 +397,46 @@ class WikiDao:
         db: AsyncSession,
         entry_id: UUID,
     ) -> dict | None:
-        """获取条目关联文档的 Markdown 内容
+        """获取条目关联文档的 Markdown 内容及来源元数据
 
         Returns:
-            包含 markdown_content, title, metadata 的字典；文档不存在则返回 None
+            包含 markdown_content, title, metadata, author, source_url 等的字典；
+            文档不存在则返回 None
         """
         result = await db.execute(
             select(
                 WikiPublicationEntry.document_id,
+                WikiPublicationEntry.created_at,
                 KnowledgeDocument.original_filename,
                 KnowledgeDocument.display_name,
                 KnowledgeDocument.markdown_content,
                 KnowledgeDocument.metadata_,
+                KnowledgeDocument.source_id,
+                DocSource.source_url,
+                DocSource.original_url,
+                DocSource.author,
             )
             .join(KnowledgeDocument, WikiPublicationEntry.document_id == KnowledgeDocument.id)
+            .outerjoin(DocSource, KnowledgeDocument.source_id == DocSource.id)
             .where(WikiPublicationEntry.id == entry_id)
         )
         row = result.one_or_none()
         if row is None:
             return None
 
-        doc_id, filename, display_name, markdown_content, metadata = row
+        (
+            doc_id,
+            entry_created_at,
+            filename,
+            display_name,
+            markdown_content,
+            metadata,
+            _source_id,
+            doc_source_url,
+            doc_original_url,
+            doc_author,
+        ) = row
+
         # 与 wiki_service._resolve_doc_display_title 保持同源优先级：
         # display_name (用户覆盖) -> metadata_.title -> original_filename。
         resolved_title = (display_name or "").strip()
@@ -426,6 +446,14 @@ class WikiDao:
                 resolved_title = meta_title.strip()
         if not resolved_title:
             resolved_title = filename or "Untitled"
+
+        # 来源 URL 解析：URL 文档取 origin_url / source_url；File 文档取 metadata 中的 source_uri
+        source_type = (metadata or {}).get("source_type")
+        if source_type == "url":
+            resolved_source_url = doc_original_url or doc_source_url
+        else:
+            resolved_source_url = (metadata or {}).get("source_uri")
+
         return {
             "document_id": doc_id,
             "filename": filename,
@@ -433,7 +461,22 @@ class WikiDao:
             "markdown_content": markdown_content or "",
             "title": resolved_title,
             "metadata": metadata or {},
+            "entry_created_at": entry_created_at,
+            "author": doc_author,
+            "source_url": resolved_source_url,
         }
+
+    # ------------------------------------------------------------------
+    # 浏览计数
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def get_view_count(db: AsyncSession, entry_id: UUID) -> int:
+        """获取条目的浏览次数"""
+        from negentropy.models.perception import WikiEntryViews
+
+        result = await db.execute(select(WikiEntryViews.view_count).where(WikiEntryViews.entry_id == entry_id))
+        return result.scalar() or 0
 
     # ------------------------------------------------------------------
     # 导航树（薄委托）

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -276,7 +276,7 @@ class WikiEntryResponse(BaseModel):
 
 
 class WikiEntryContentResponse(BaseModel):
-    """Wiki 条目内容响应（含 Markdown）"""
+    """Wiki 条目内容响应（含 Markdown + 文章元数据）"""
 
     entry_id: UUID
     document_id: UUID
@@ -284,6 +284,10 @@ class WikiEntryContentResponse(BaseModel):
     entry_title: str | None
     markdown_content: str | None = None
     document_filename: str = ""
+    author_name: str | None = None
+    author_url: str | None = None
+    source_url: str | None = None
+    published_at: str | None = None
 
 
 class WikiNavTreeResponse(BaseModel):

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -8,10 +8,11 @@ from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError  # noqa: F401
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
 from negentropy.auth.deps import get_current_user
@@ -21,7 +22,7 @@ from negentropy.knowledge._shared import (
     _get_wiki_service,
 )
 from negentropy.logging import get_logger
-from negentropy.models.perception import KnowledgeDocument, WikiPublicationEntry
+from negentropy.models.perception import KnowledgeDocument, WikiEntryAnnotation, WikiEntryComment, WikiPublicationEntry
 
 if TYPE_CHECKING:
     pass
@@ -550,6 +551,39 @@ async def get_wiki_entry_content(entry_id: UUID) -> WikiEntryContentResponse:
 
     logger.info("api_wiki_entry_content", entry_id=str(entry_id))
 
+    # 解析作者信息：metadata 手动覆盖 > DocSource.author
+    metadata = content_data.get("metadata", {})
+    author_raw = metadata.get("author") or content_data.get("author")
+    author_name: str | None = None
+    author_url: str | None = None
+
+    if author_raw:
+        author_str = str(author_raw).strip()
+        # metadata 中手动指定的 author_url 优先
+        explicit_url = metadata.get("author_url")
+        if explicit_url and isinstance(explicit_url, str):
+            author_url = explicit_url
+            if not author_name:
+                if author_str.startswith("http"):
+                    author_name = author_str.rstrip("/").rsplit("/", 1)[-1]
+                else:
+                    author_name = author_str
+        elif author_str.startswith("http"):
+            # author 字段本身是 URL（如 GitHub profile），提取显示名
+            author_url = author_str
+            author_name = author_str.rstrip("/").rsplit("/", 1)[-1]
+        else:
+            author_name = author_str
+
+    # 来源 URL
+    source_url = content_data.get("source_url")
+
+    # 发布时间
+    published_at = None
+    entry_created_at = content_data.get("entry_created_at")
+    if entry_created_at:
+        published_at = entry_created_at.isoformat() if hasattr(entry_created_at, "isoformat") else str(entry_created_at)
+
     return WikiEntryContentResponse(
         entry_id=entry_id,
         document_id=content_data["document_id"],
@@ -557,6 +591,10 @@ async def get_wiki_entry_content(entry_id: UUID) -> WikiEntryContentResponse:
         entry_title=content_data["title"],
         markdown_content=content_data["markdown_content"],
         document_filename=content_data["filename"] or "",
+        author_name=author_name,
+        author_url=author_url,
+        source_url=source_url,
+        published_at=published_at,
     )
 
 
@@ -823,3 +861,74 @@ async def delete_entry_annotation(
         await db.commit()
 
     return {"detail": "Annotation deleted"}
+
+
+# ---------------------------------------------------------------------------
+# 文章元数据：浏览计数 + 动态统计
+# ---------------------------------------------------------------------------
+
+
+@router.post("/wiki/entries/{entry_id}/view")
+async def record_entry_view(entry_id: UUID):
+    """记录一次页面浏览（公开，无需鉴权）
+
+    使用 PostgreSQL INSERT ... ON CONFLICT DO UPDATE 原子递增 view_count。
+    """
+    from negentropy.models.perception import WikiEntryViews
+
+    async with AsyncSessionLocal() as db:
+        # 原子 upsert：不存在则插入(1)，已存在则 +1
+        stmt = sa.text(f"""
+            INSERT INTO {WikiEntryViews.__table__.schema}.{WikiEntryViews.__tablename__}
+                (entry_id, view_count, last_viewed_at)
+            VALUES (:eid, 1, now())
+            ON CONFLICT (entry_id) DO UPDATE SET
+                view_count = {WikiEntryViews.__table__.schema}.{WikiEntryViews.__tablename__}.view_count + 1,
+                last_viewed_at = now()
+            RETURNING view_count
+        """)
+        result = await db.execute(stmt, {"eid": str(entry_id)})
+        new_count = result.scalar_one()
+        await db.commit()
+
+    return {"view_count": new_count}
+
+
+@router.get("/wiki/entries/{entry_id}/stats")
+async def get_entry_stats(entry_id: UUID):
+    """获取条目的动态统计数据（公开）
+
+    一次请求返回浏览次数、评论数、注解数，供前端元数据栏展示。
+    """
+    from negentropy.models.perception import WikiEntryViews
+
+    async with AsyncSessionLocal() as db:
+        # 浏览计数
+        view_result = await db.execute(select(WikiEntryViews.view_count).where(WikiEntryViews.entry_id == entry_id))
+        view_count = view_result.scalar() or 0
+
+        # 评论计数
+        comment_count = await db.scalar(
+            select(func.count())
+            .select_from(WikiEntryComment)
+            .where(
+                WikiEntryComment.entry_id == entry_id,
+                WikiEntryComment.status == "active",
+            )
+        )
+
+        # 注解计数
+        annotation_count = await db.scalar(
+            select(func.count())
+            .select_from(WikiEntryAnnotation)
+            .where(
+                WikiEntryAnnotation.entry_id == entry_id,
+                WikiEntryAnnotation.status == "active",
+            )
+        )
+
+    return {
+        "view_count": view_count,
+        "comment_count": comment_count or 0,
+        "annotation_count": annotation_count or 0,
+    }

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -3,6 +3,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     DateTime,
     Float,
@@ -413,6 +414,25 @@ class WikiEntryAnnotation(Base, UUIDMixin, TimestampMixin):
         Index("ix_wiki_annotations_user_id", "user_id"),
         {"schema": NEGENTROPY_SCHEMA},
     )
+
+
+class WikiEntryViews(Base):
+    """Wiki 条目浏览计数
+
+    轻量级 per-entry 计数器，每次页面加载通过 POST /view 原子递增。
+    不做用户去重，使用 PostgreSQL INSERT ... ON CONFLICT DO UPDATE 实现原子 upsert。
+    """
+
+    __tablename__ = "wiki_entry_views"
+
+    entry_id: Mapped[UUID] = mapped_column(
+        fk("wiki_publication_entries", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    view_count: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0, server_default="0")
+    last_viewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = ({"schema": NEGENTROPY_SCHEMA},)
 
 
 # =============================================================================


### PR DESCRIPTION
# 背景
- Wiki 内容页标题下方仅显示「来源: 文件名 · 文档 ID」的极简元信息，缺乏文章级上下文（作者、发布时间、浏览量、评论数、源头链接），影响阅读体验与内容溯源。
- 同时，Knowledge Base Document 详情页缺少 author / author_url / source_url / published_at 的编辑入口，File 来源文档无法维护这些元数据。

# 核心变更

## 第一批：Wiki 文章元数据栏（2 笔提交）

### 后端（5 文件）
- **新增迁移 0057**：创建 `wiki_entry_views` 表，per-entry 浏览计数（`INSERT ... ON CONFLICT` 原子 upsert）
- **新增 ORM 模型**：`WikiEntryViews`（BigInteger view_count + last_viewed_at）
- **扩展 DAO**：`get_entry_content()` LEFT JOIN `DocSource`，返回 author/source_url/entry_created_at
- **扩展 Schema**：`WikiEntryContentResponse` 新增 `author_name`/`author_url`/`source_url`/`published_at`
- **新增路由**：`POST /entries/{id}/view`（浏览计数）+ `GET /entries/{id}/stats`（view/comment/annotation 统计）

### 前端（5 文件）
- **新建组件** `WikiArticleMeta`：GitHub 头像解析、内联 SVG 图标、深浅主题自动适配
- **新建 Hook** `useEntryStats`：获取动态统计 + 自动记录页面浏览（防重入）
- **集成页面**：替换 `page.tsx` 中 `wiki-doc-meta` 为 `WikiArticleMeta` 组件

## 第二批：Document 编辑入口补齐（2 笔提交）

### 后端（3 文件）
- **扩展 Schema** `DocumentUpdateRequest`：新增 `author`/`author_url`/`source_url`/`published_at` 字段，合并写入 `metadata_` JSONB
- **扩展路由** `PATCH /documents/{id}`：调用已有 `update_document_metadata()` 处理 metadata patch
- **统一 Wiki source_url 解析**：File 文档兼容 `source_url` 和 `source_uri` 两个键

### 前端（2 文件）
- **扩展 API** `updateDocument()`：支持 author/author_url/source_url/published_at patch
- **新增 Article Metadata 面板**：Document 详情页 Metadata strip 下方新增编辑面板（默认只读，pencil icon → inline edit → Save/Cancel），Source URL 支持超链接跳转

# 风险与回滚
- 主要风险：浏览计数为轻量级 per-page-load 递增，不做用户去重
- 回滚方式：revert 本 PR 4 笔提交；迁移为 CREATE TABLE 可安全 DROP

# 验证证据
- ✅ `pnpm build`（negentropy-ui + negentropy-wiki）通过，零 TypeScript 错误
- ✅ Python 语法校验通过
- ✅ pre-commit hooks（ruff lint + ruff format + ESLint）全部通过
- ⏳ 待实机验证

# 影响范围
- 前端：`apps/negentropy-wiki/`（元数据栏）、`apps/negentropy-ui/`（Document 编辑面板）
- 后端：`apps/negentropy/`（迁移、模型、DAO、Schema、路由）
- GitHub Actions / 文档：无影响

# Next Best Action
- 实机验证：启动后端 + wiki dev server，确认元数据栏和编辑面板端到端工作正常