### PR TITLE
fix(agent-dialog): 修复 Edit Agent 模态框切换 Model 时被意外关闭；重设计为紧凑专业布局

### DIFF
--- a/apps/negentropy-ui/app/interface/agents/_components/AgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentFormDialog.tsx
@@ -6,10 +6,11 @@
  */
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useId } from "react";
+import { ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
-import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { BaseModal } from "@/components/ui/BaseModal";
 import { LlmModelSelect } from "@/components/ui/LlmModelSelect";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { fetchModelConfigs, type ModelConfigItem } from "@/features/knowledge/utils/knowledge-api";
@@ -49,6 +50,13 @@ interface NegentropyTemplate {
   tools: string[];
 }
 
+/* ── Shared style constants ── */
+const INPUT =
+  "w-full rounded-md border border-border bg-input px-3 py-1.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring";
+const MONO =
+  "w-full rounded-md border border-border bg-input px-3 py-1.5 text-sm font-mono text-foreground outline-none focus:ring-1 focus:ring-ring";
+const LABEL = "mb-1 block text-xs font-medium text-text-muted";
+
 export function AgentFormDialog({
   open,
   onClose,
@@ -56,6 +64,7 @@ export function AgentFormDialog({
   agent,
 }: AgentFormDialogProps) {
   const { confirm, confirmDialog } = useConfirmDialog();
+  const formId = useId();
   const [formData, setFormData] = useState({
     name: "",
     display_name: "",
@@ -75,7 +84,9 @@ export function AgentFormDialog({
   const [templates, setTemplates] = useState<NegentropyTemplate[]>([]);
   const [selectedTemplateName, setSelectedTemplateName] = useState("");
   const [llmModels, setLlmModels] = useState<ModelConfigItem[]>([]);
-  const [availableTools, setAvailableTools] = useState<Array<{ name: string; display_name: string | null; source: string }>>([]);
+  const [availableTools, setAvailableTools] = useState<
+    Array<{ name: string; display_name: string | null; source: string }>
+  >([]);
 
   const applyTemplate = (template: NegentropyTemplate) => {
     setFormData({
@@ -104,7 +115,13 @@ export function AgentFormDialog({
         system_prompt: agent.system_prompt || "",
         model: agent.model || "",
         config: JSON.stringify(agent.config || {}, null, 2),
-        adk_config: JSON.stringify(agent.adk_config || (agent.config as { adk_config?: unknown })?.adk_config || {}, null, 2),
+        adk_config: JSON.stringify(
+          agent.adk_config ||
+            (agent.config as { adk_config?: unknown })?.adk_config ||
+            {},
+          null,
+          2,
+        ),
         skills: Array.isArray(agent.skills) ? agent.skills.join("\n") : "",
         tools: Array.isArray(agent.tools) ? agent.tools.join("\n") : "",
         is_enabled: agent.is_enabled,
@@ -136,7 +153,10 @@ export function AgentFormDialog({
     let mounted = true;
     (async () => {
       try {
-        const list = await fetchModelConfigs({ modelType: "llm", enabled: true });
+        const list = await fetchModelConfigs({
+          modelType: "llm",
+          enabled: true,
+        });
         if (mounted) {
           setLlmModels(list);
         }
@@ -175,7 +195,9 @@ export function AgentFormDialog({
     let mounted = true;
     const fetchTemplates = async () => {
       try {
-        const response = await fetch("/api/interface/agents/templates/negentropy");
+        const response = await fetch(
+          "/api/interface/agents/templates/negentropy",
+        );
         if (!response.ok) return;
         const data = (await response.json()) as NegentropyTemplate[];
         if (mounted) {
@@ -273,287 +295,278 @@ export function AgentFormDialog({
     }
   };
 
-  if (!open) return null;
+  /* ── Helper: update a single form field ── */
+  const setField = <K extends keyof typeof formData>(
+    key: K,
+    value: (typeof formData)[K],
+  ) => setFormData((prev) => ({ ...prev, [key]: value }));
 
   return (
     <>
-      <OverlayDismissLayer
-      open={open}
-      onClose={onClose}
-      busy={loading}
-      containerClassName="flex min-h-full items-start justify-center overflow-y-auto p-3 sm:p-6"
-      contentClassName="my-3 flex max-h-[calc(100vh-1rem)] w-full max-w-6xl flex-col overflow-hidden rounded-modal border border-border bg-card shadow-xl sm:max-h-[calc(100vh-2rem)]"
-    >
-          <div className="border-b border-border px-5 py-4 sm:px-6">
-            <h2 className="text-lg font-semibold text-foreground">
-              {agent ? "Edit Agent" : "Add Agent"}
-            </h2>
-            <p className="mt-1 text-sm text-text-muted">
-              Keep fields consistent with ADK while optimizing readability for longer configurations.
-            </p>
+      <BaseModal
+        open={open}
+        title={agent ? "Edit Agent" : "Add Agent"}
+        subtitle="Configure agent properties and runtime behavior"
+        onClose={onClose}
+        size="xl"
+        closeOnBackdrop={!loading}
+        closeOnEscape={!loading}
+        footer={
+          <>
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              form={formId}
+              variant="neutral"
+              disabled={loading}
+            >
+              {loading ? "Saving..." : agent ? "Update" : "Create"}
+            </Button>
+          </>
+        }
+      >
+        <form id={formId} onSubmit={handleSubmit} className="space-y-4">
+          {/* ── Template selector (create only) ── */}
+          {!agent && templates.length > 0 && (
+            <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
+              <span className="shrink-0 text-xs text-text-muted">
+                Template
+              </span>
+              <select
+                value={selectedTemplateName}
+                onChange={(e) => setSelectedTemplateName(e.target.value)}
+                className={INPUT}
+              >
+                <option value="">Select template</option>
+                {templates.map((t) => (
+                  <option key={t.name} value={t.name}>
+                    {t.display_name || t.name}
+                  </option>
+                ))}
+              </select>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!selectedTemplateName}
+                onClick={() => {
+                  const target = templates.find(
+                    (item) => item.name === selectedTemplateName,
+                  );
+                  if (target) applyTemplate(target);
+                }}
+              >
+                Apply
+              </Button>
+            </div>
+          )}
+
+          {error && <ErrorBanner message={error} />}
+
+          {/* ── Identity ── */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className={LABEL}>Name *</label>
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setField("name", e.target.value)}
+                className={INPUT}
+                placeholder="my-agent"
+                required
+              />
+            </div>
+            <div>
+              <label className={LABEL}>Display Name</label>
+              <input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setField("display_name", e.target.value)}
+                className={INPUT}
+                placeholder="My Agent"
+              />
+            </div>
+          </div>
+          <div>
+            <label className={LABEL}>Description</label>
+            <textarea
+              value={formData.description}
+              onChange={(e) => setField("description", e.target.value)}
+              className={INPUT}
+              rows={2}
+              placeholder="Brief description of this agent"
+            />
           </div>
 
-          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
-            <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
-              {!agent && templates.length > 0 && (
-                <section className="rounded-lg border border-border bg-muted/50 p-4">
-                  <label className="mb-2 block text-sm font-medium text-text-secondary">
-                    Negentropy Built-in Templates
-                  </label>
-                  <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                    <select
-                      value={selectedTemplateName}
-                      onChange={(e) => setSelectedTemplateName(e.target.value)}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                    >
-                      <option value="">Select template</option>
-                      {templates.map((template) => (
-                        <option key={template.name} value={template.name}>
-                          {template.display_name || template.name}
-                        </option>
-                      ))}
-                    </select>
-                    <Button
+          {/* ── Runtime ── */}
+          <div className="border-t border-border" />
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className={LABEL}>Agent Type *</label>
+              <select
+                value={formData.agent_type}
+                onChange={(e) => setField("agent_type", e.target.value)}
+                className={INPUT}
+              >
+                <option value="llm_agent">LLM Agent</option>
+                <option value="sequential_agent">Sequential Agent</option>
+                <option value="parallel_agent">Parallel Agent</option>
+                <option value="loop_agent">Loop Agent</option>
+                <option value="custom_agent">Custom Agent</option>
+              </select>
+            </div>
+            <div>
+              <label className={LABEL}>Model</label>
+              <LlmModelSelect
+                models={llmModels}
+                value={formData.model}
+                onChange={(v) => setField("model", v)}
+                allowClear
+                placeholder="Default"
+                ariaLabel="Agent 使用的 LLM"
+                className="w-full"
+              />
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className={LABEL}>Visibility</label>
+              <select
+                value={formData.visibility}
+                onChange={(e) => setField("visibility", e.target.value)}
+                className={INPUT}
+              >
+                <option value="private">Private</option>
+                <option value="shared">Shared</option>
+                <option value="public">Public</option>
+              </select>
+            </div>
+            <div className="flex items-end pb-0.5">
+              <label className="flex items-center gap-2 text-xs text-text-muted">
+                <input
+                  type="checkbox"
+                  checked={formData.is_enabled}
+                  onChange={(e) => setField("is_enabled", e.target.checked)}
+                  className="rounded border-border"
+                />
+                Enabled
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <label className={LABEL}>System Prompt</label>
+            <textarea
+              value={formData.system_prompt}
+              onChange={(e) => setField("system_prompt", e.target.value)}
+              className={MONO}
+              rows={4}
+              placeholder="You are a specialized agent for..."
+            />
+          </div>
+
+          {/* ── Tools ── */}
+          <div className="border-t border-border" />
+
+          <div>
+            <label className={LABEL}>Tools</label>
+            {availableTools.length > 0 && (
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {availableTools.map((t) => {
+                  const currentTools = formData.tools
+                    .split("\n")
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                  const isSelected = currentTools.includes(t.name);
+                  return (
+                    <button
+                      key={t.name}
                       type="button"
-                      variant="outline"
-                      disabled={!selectedTemplateName}
                       onClick={() => {
-                        const target = templates.find((item) => item.name === selectedTemplateName);
-                        if (target) applyTemplate(target);
+                        const tools = formData.tools
+                          .split("\n")
+                          .map((s) => s.trim())
+                          .filter(Boolean);
+                        const next = isSelected
+                          ? tools.filter((n) => n !== t.name)
+                          : [...tools, t.name];
+                        setField("tools", next.join("\n"));
                       }}
+                      className={
+                        "inline-flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
+                        (isSelected
+                          ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+                          : "bg-muted text-text-secondary hover:bg-border/60 dark:hover:bg-border")
+                      }
                     >
-                      Apply
-                    </Button>
-                  </div>
-                </section>
-              )}
+                      <span className="text-micro opacity-60">
+                        {t.source === "builtin" ? "●" : "◆"}
+                      </span>
+                      {t.display_name || t.name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            <textarea
+              value={formData.tools}
+              onChange={(e) => setField("tools", e.target.value)}
+              className={MONO}
+              rows={2}
+              placeholder="Select from above or type tool names (one per line)"
+            />
+          </div>
 
-              {error && <ErrorBanner message={error} />}
-
-              <section className="space-y-4">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-                  Basic Information
-                </h3>
-                <div className="grid gap-4 lg:grid-cols-2">
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Name *
-                    </label>
-                    <input
-                      type="text"
-                      value={formData.name}
-                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                      placeholder="my-agent"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Display Name
-                    </label>
-                    <input
-                      type="text"
-                      value={formData.display_name}
-                      onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                      placeholder="My Agent"
-                    />
-                  </div>
-                  <div className="lg:col-span-2">
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Description
-                    </label>
-                    <textarea
-                      value={formData.description}
-                      onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                      rows={2}
-                      placeholder="Description of this agent"
-                    />
-                  </div>
-                </div>
-              </section>
-
-              <section className="space-y-4">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-                  Runtime Setup
-                </h3>
-                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Agent Type *
-                    </label>
-                    <select
-                      value={formData.agent_type}
-                      onChange={(e) => setFormData({ ...formData, agent_type: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                    >
-                      <option value="llm_agent">LLM Agent</option>
-                      <option value="sequential_agent">Sequential Agent</option>
-                      <option value="parallel_agent">Parallel Agent</option>
-                      <option value="loop_agent">Loop Agent</option>
-                      <option value="custom_agent">Custom Agent</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Model
-                    </label>
-                    <LlmModelSelect
-                      models={llmModels}
-                      value={formData.model}
-                      onChange={(v) => setFormData({ ...formData, model: v })}
-                      allowClear
-                      placeholder="Default"
-                      ariaLabel="Agent 使用的 LLM"
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Visibility
-                    </label>
-                    <select
-                      value={formData.visibility}
-                      onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                    >
-                      <option value="private">Private</option>
-                      <option value="shared">Shared</option>
-                      <option value="public">Public</option>
-                    </select>
-                  </div>
-                  <div className="flex items-end">
-                    <label className="flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm text-text-secondary">
-                      <input
-                        type="checkbox"
-                        checked={formData.is_enabled}
-                        onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
-                        className="rounded border-border"
-                      />
-                      Enabled
-                    </label>
-                  </div>
-                </div>
-
+          {/* ── Advanced Configuration ── */}
+          <details className="group border-t border-border pt-3">
+            <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium text-text-muted transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
+              <ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" />
+              Advanced Configuration
+            </summary>
+            <div className="mt-3 space-y-4">
+              <div>
+                <label className={LABEL}>Skills (one per line)</label>
+                <textarea
+                  value={formData.skills}
+                  onChange={(e) => setField("skills", e.target.value)}
+                  className={MONO}
+                  rows={3}
+                  placeholder="code-review&#10;document-analysis"
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-text-secondary">
-                    System Prompt
-                  </label>
+                  <label className={LABEL}>Config (JSON)</label>
                   <textarea
-                    value={formData.system_prompt}
-                    onChange={(e) => setFormData({ ...formData, system_prompt: e.target.value })}
-                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                    rows={5}
-                    placeholder="You are a specialized agent for..."
+                    value={formData.config}
+                    onChange={(e) => setField("config", e.target.value)}
+                    className={MONO}
+                    rows={6}
+                    placeholder='{"temperature": 0.7}'
                   />
                 </div>
-
-                <div className="grid gap-4 lg:grid-cols-2">
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Skills (one per line)
-                    </label>
-                    <textarea
-                      value={formData.skills}
-                      onChange={(e) => setFormData({ ...formData, skills: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                      rows={4}
-                      placeholder="code-review&#10;document-analysis"
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Tools
-                    </label>
-                    {availableTools.length > 0 && (
-                      <div className="mb-2 flex flex-wrap gap-1.5">
-                        {availableTools.map((t) => {
-                          const currentTools = formData.tools.split("\n").map((s) => s.trim()).filter(Boolean);
-                          const isSelected = currentTools.includes(t.name);
-                          return (
-                            <button
-                              key={t.name}
-                              type="button"
-                              onClick={() => {
-                                const tools = formData.tools.split("\n").map((s) => s.trim()).filter(Boolean);
-                                const next = isSelected
-                                  ? tools.filter((n) => n !== t.name)
-                                  : [...tools, t.name];
-                                setFormData({ ...formData, tools: next.join("\n") });
-                              }}
-                              className={
-                                "inline-flex cursor-pointer items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
-                                (isSelected
-                                  ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
-                                  : "bg-muted text-text-secondary hover:bg-border/60 dark:hover:bg-border")
-                              }
-                            >
-                              <span className="text-micro opacity-60">{t.source === "builtin" ? "●" : "◆"}</span>
-                              {t.display_name || t.name}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    )}
-                    <textarea
-                      value={formData.tools}
-                      onChange={(e) => setFormData({ ...formData, tools: e.target.value })}
-                      className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                      rows={3}
-                      placeholder="Select from above or type tool names (one per line)"
-                    />
-                  </div>
+                <div>
+                  <label className={LABEL}>ADK Config (JSON)</label>
+                  <textarea
+                    value={formData.adk_config}
+                    onChange={(e) => setField("adk_config", e.target.value)}
+                    className={MONO}
+                    rows={6}
+                    placeholder='{"agent_class":"LlmAgent","output_key":"perception_output"}'
+                  />
+                  <p className="mt-1 text-[11px] text-text-muted">
+                    Full-fidelity ADK config. Empty → auto-generate minimal
+                    config.
+                  </p>
                 </div>
-              </section>
-
-              <section className="space-y-4">
-                <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
-                  JSON Configuration
-                </h3>
-                <div className="grid gap-4 xl:grid-cols-2">
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Config (JSON)
-                    </label>
-                    <textarea
-                      value={formData.config}
-                      onChange={(e) => setFormData({ ...formData, config: e.target.value })}
-                      className="min-h-[220px] w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                      rows={8}
-                      placeholder='{"temperature": 0.7}'
-                    />
-                  </div>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      ADK Config (JSON, full-fidelity)
-                    </label>
-                    <textarea
-                      value={formData.adk_config}
-                      onChange={(e) => setFormData({ ...formData, adk_config: e.target.value })}
-                      className="min-h-[220px] w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                      rows={8}
-                      placeholder='{"agent_class":"LlmAgent","output_key":"perception_output","disallow_transfer_to_parent":true}'
-                    />
-                    <p className="mt-1 text-xs text-text-muted">
-                      Use this field to capture all ADK agent capabilities. Empty value will auto-generate a minimal ADK config.
-                    </p>
-                  </div>
-                </div>
-              </section>
+              </div>
             </div>
-
-            <div className="flex shrink-0 justify-end gap-3 border-t border-border bg-card px-5 py-4 sm:px-6">
-              <Button type="button" variant="ghost" onClick={onClose}>
-                Cancel
-              </Button>
-              <Button type="submit" variant="neutral" disabled={loading}>
-                {loading ? "Saving..." : agent ? "Update" : "Create"}
-              </Button>
-            </div>
-          </form>
-      </OverlayDismissLayer>
+          </details>
+        </form>
+      </BaseModal>
       {confirmDialog}
     </>
   );

--- a/apps/negentropy-ui/components/ui/BaseModal.tsx
+++ b/apps/negentropy-ui/components/ui/BaseModal.tsx
@@ -37,7 +37,7 @@ export interface BaseModalProps {
    * 卡片宽度档位。`md` ≈ max-w-md（创建对话框等表单），`lg` ≈ max-w-lg
    * （节点选择树等更宽视图）。默认 `md`。
    */
-  size?: "sm" | "md" | "lg";
+  size?: "sm" | "md" | "lg" | "xl";
   /**
    * 是否允许点击遮罩关闭。默认 `true`；正在执行不可中断的提交流时可关闭。
    */
@@ -52,6 +52,7 @@ const SIZE_CLASS: Record<NonNullable<BaseModalProps["size"]>, string> = {
   sm: "max-w-sm",
   md: "max-w-md",
   lg: "max-w-lg",
+  xl: "max-w-2xl",
 };
 
 const SPRING_TRANSITION = { type: "spring" as const, damping: 28, stiffness: 320 };

--- a/apps/negentropy-ui/components/ui/LlmModelSelect.tsx
+++ b/apps/negentropy-ui/components/ui/LlmModelSelect.tsx
@@ -248,6 +248,7 @@ export function LlmModelSelect({
               visibility: measuredTop === null ? "hidden" : undefined,
             }}
             onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => e.stopPropagation()}
           >
             {allowClear && (
               <ModelOption


### PR DESCRIPTION
# 背景
- **Edit Agent 模态框中切换 Model 时，模态框被直接关闭**，用户无法修改 Model 字段
- **根因**：`LlmModelSelect` 下拉面板通过 `createPortal` 渲染到 `document.body`，React 合成事件沿 **React 组件树**（非 DOM 树）冒泡至 `OverlayDismissLayer` 的 wrapper `onClick`，其 `contentRef.contains(target)` 检查因 Portal 节点不在 `contentRef` 内而失败，触发 `onClose()` → 模态框关闭
- 此外，模态框布局过于松散（max-w-6xl）、视觉层次不清晰，需重设计

# 核心变更

### Bug Fix
- **`LlmModelSelect.tsx`**：Portaled 下拉容器添加 `onClick={(e) => e.stopPropagation()}`，截断 React 合成事件冒泡链路
- **`AgentFormDialog.tsx`**：从 `OverlayDismissLayer` 迁移至 `BaseModal`（其卡片 div 内置 `e.stopPropagation()`），双重防护

### UI Redesign
| 改动 | Before | After |
|------|--------|-------|
| 模态壳层 | `OverlayDismissLayer`（无动画） | `BaseModal`（framer-motion 弹性缩放） |
| 宽度 | max-w-6xl (1152px) | max-w-2xl (672px) |
| 分组方式 | 大写 Section Headers | 留白 + 分割线 |
| 布局 | 4 栏 + 大间距 | 紧凑双栏 |
| JSON Config | 默认展开 | 折叠进 `<details>` Advanced 区域 |
| Template | 独立 bordered section | 内联单行 |
| Skills | 独立 textarea | 移入 Advanced |

### 基建扩展
- **`BaseModal.tsx`**：扩展 `size` 类型增加 `"xl"` (max-w-2xl) 档位

# 风险与回滚
- 主要风险：模态框从 `OverlayDismissLayer` 迁移至 `BaseModal`，loading 防关闭行为需一致（已通过 `closeOnBackdrop={!loading}` / `closeOnEscape={!loading}` 覆盖）
- 回滚方式：`git revert` 即可

# 验证证据
- ✅ TypeScript 编译：修改文件零类型错误
- ✅ Next.js 编译：`GET /interface/agents 200`，无编译错误
- ✅ Pre-commit hooks：ESLint / ruff 全部通过
- ⏳ 实机交互验证：需后端 auth 服务运行环境

# 影响范围
- 前端：`AgentFormDialog`、`BaseModal`、`LlmModelSelect` 三个组件
- 后端：无变更

# Next Best Action
- 在后端服务运行环境下实机验证：Model 下拉切换不关闭模态框、Escape/Backdrop 交互、Add/Edit 双模式表单提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)