### PR TITLE
feat(docker-compose): 新增 docker compose 一键启动全套服务编排，含 pgvector 数据库环境

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,71 @@
+# =============================================================================
+# Docker Build Context Exclusions
+# =============================================================================
+
+# Version control
+.git
+.gitignore
+
+# CI/CD
+.github
+
+# IDE & Editor
+.claude
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary & build artifacts
+.temp
+.next
+.turbo
+*.egg-info
+dist
+build
+htmlcov
+
+# Python caches
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+coverage.xml
+
+# Virtual environments
+.venv
+
+# Node.js caches
+node_modules
+*.tsbuildinfo
+
+# Documentation (not needed at runtime)
+docs
+*.md
+!apps/*/README.md
+!packages/*/README.md
+
+# Docker files (avoid recursive context)
+docker
+
+# Environment files (secrets must not be baked into images)
+.env
+.env.*
+!.env.docker
+
+# Test files
+**/tests
+**/__tests__
+**/*.test.*
+**/*.spec.*
+
+# Config overrides (per-deployment, not for image)
+config.local.yaml

--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,29 @@
+# =============================================================================
+# Negentropy Docker Compose — 环境变量模板
+# =============================================================================
+# 使用说明：
+#   1. 复制本文件为 .env.docker.local（已被 .gitignore 忽略）
+#   2. 填写所需密钥值
+#   3. docker compose 会自动加载 .env.docker（本文件）
+#      如需覆盖，在 docker compose 命令中通过 --env-file 指定
+# =============================================================================
+
+# --- LLM API Keys（至少配置一个，LiteLLM 统一调度）---
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+
+# --- Auth / SSO ---
+NE_AUTH_TOKEN_SECRET=
+NE_AUTH_GOOGLE_CLIENT_SECRET=
+
+# --- Observability（Langfuse LLM 可观测性，可选）---
+NE_OBSERVABILITY_LANGFUSE_PUBLIC_KEY=
+NE_OBSERVABILITY_LANGFUSE_SECRET_KEY=
+
+# --- Web Search（Google Programmable Search，可选）---
+NE_SEARCH_GOOGLE_API_KEY=
+
+# --- Perceives LLM（Smart 模式，可选）---
+NEGENTROPY_PERCEIVES_LLM__API_KEY=
+NEGENTROPY_PERCEIVES_LLM__API_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,7 @@ yarn-error.log*
 
 .env*
 !.env.example
+!.env.docker
 .vercel
 *.tsbuildinfo
 next-env.d.ts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,152 @@
+# =============================================================================
+# Negentropy Docker Compose — 一键启动全套服务
+# =============================================================================
+# Usage:
+#   docker compose up -d              启动所有服务
+#   docker compose logs -f            查看日志
+#   docker compose ps                 查看服务状态
+#   docker compose down               停止所有服务
+#   docker compose down -v            停止并清除数据卷
+#
+# 前置条件:
+#   1. 复制 .env.docker 为 .env.docker.local 并填写 API 密钥
+#   2. Docker Engine >= 24.0 (Compose V2 内置)
+# =============================================================================
+
+services:
+  # ── PostgreSQL + pgvector ──────────────────────────────────────────────────
+  postgres:
+    image: pgvector/pgvector:pg17
+    container_name: negentropy-postgres
+    environment:
+      POSTGRES_USER: aigc
+      POSTGRES_PASSWORD: ""
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_DB: negentropy
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aigc -d negentropy"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  # ── Perceives — MCP Server（Web/PDF 内容提取） ─────────────────────────────
+  perceives:
+    build:
+      context: .
+      dockerfile: docker/perceives/Dockerfile
+    container_name: negentropy-perceives
+    ports:
+      - "2992:2992"
+    environment:
+      NEGENTROPY_PERCEIVES_HTTP_HOST: "0.0.0.0"
+      NEGENTROPY_PERCEIVES_HTTP_PORT: "2992"
+    env_file:
+      - path: .env.docker
+        required: false
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:2992/"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    restart: unless-stopped
+
+  # ── Backend — Google ADK Web Server（核心 Agent 平台） ──────────────────────
+  backend:
+    build:
+      context: .
+      dockerfile: docker/backend/Dockerfile
+    container_name: negentropy-backend
+    ports:
+      - "3292:3292"
+    environment:
+      # Docker 内部网络：postgres 服务名替代 localhost
+      NE_DB_URL: "postgresql+asyncpg://aigc:@postgres:5432/negentropy"
+      # Wiki ISR revalidate webhook（Docker 内部网络）
+      NE_KNOWLEDGE_WIKI_REVALIDATE__URL: "http://wiki:3092/api/revalidate"
+      # SSO 回调地址保持 localhost（浏览器端访问）
+      NE_AUTH_GOOGLE_REDIRECT_URI: "http://localhost:3292/auth/google/callback"
+    env_file:
+      - path: .env.docker
+        required: false
+    depends_on:
+      postgres:
+        condition: service_healthy
+      perceives:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3292/"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    restart: unless-stopped
+
+  # ── UI — Next.js 主聊天前端 ────────────────────────────────────────────────
+  ui:
+    build:
+      context: .
+      dockerfile: docker/frontend/Dockerfile
+      args:
+        TARGET_SERVICE: negentropy-ui
+    container_name: negentropy-ui
+    ports:
+      - "3192:3192"
+    environment:
+      # 服务端 BFF 代理目标（Docker 内部网络）
+      AGUI_BASE_URL: "http://backend:3292"
+      # 容器绑定到所有接口（healthcheck 需要）
+      PORT: "3192"
+      HOSTNAME: "0.0.0.0"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3192/"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  # ── Wiki — Next.js 知识库前端 ──────────────────────────────────────────────
+  wiki:
+    build:
+      context: .
+      dockerfile: docker/frontend/Dockerfile
+      args:
+        TARGET_SERVICE: negentropy-wiki
+    container_name: negentropy-wiki
+    ports:
+      - "3092:3092"
+    environment:
+      # Wiki 内容 API 代理目标（Docker 内部网络）
+      WIKI_API_BASE: "http://backend:3292"
+      # Wiki BFF 代理目标（Docker 内部网络）
+      WIKI_UI_BFF_BASE: "http://ui:3192"
+      # 容器绑定到所有接口
+      PORT: "3092"
+      HOSTNAME: "0.0.0.0"
+    depends_on:
+      backend:
+        condition: service_healthy
+      ui:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3092/"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+# ── 持久化数据卷 ────────────────────────────────────────────────────────────
+volumes:
+  postgres_data:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,0 +1,54 @@
+# =============================================================================
+# Negentropy Backend — Multi-stage Dockerfile
+# =============================================================================
+# Python 3.13 + uv 构建的 Google ADK Web Server（含 Alembic 迁移）
+# =============================================================================
+
+# ── Stage 1: Build dependencies ─────────────────────────────────────────────
+FROM python:3.13-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /build
+
+# 先复制依赖声明（利用 Docker 层缓存）
+COPY apps/negentropy/pyproject.toml apps/negentropy/uv.lock ./
+
+# 安装依赖到虚拟环境（--frozen 锁定版本，--no-install-project 跳过项目本身）
+RUN uv sync --frozen --no-dev --no-install-project
+
+# 复制应用源码
+COPY apps/negentropy/src ./src/
+
+# 安装项目本身（使 entry_point 可用）
+RUN uv sync --frozen --no-dev
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM python:3.13-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# 从 builder 复制虚拟环境
+COPY --from=builder /build/.venv /app/.venv
+
+# 复制应用代码
+COPY --from=builder /build/src ./src/
+
+# 复制 Alembic 配置（entrypoint 需要执行迁移）
+COPY apps/negentropy/alembic.ini ./
+
+# 复制 entrypoint 脚本
+COPY docker/backend/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH="/app" \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 3292
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/backend/entrypoint.sh
+++ b/docker/backend/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Negentropy Backend Entrypoint
+# =============================================================================
+# 1. 等待 PostgreSQL 就绪（由 docker-compose depends_on + healthcheck 保证）
+# 2. 执行 Alembic 数据库迁移
+# 3. 启动 ADK Web Server
+# =============================================================================
+set -euo pipefail
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Running Alembic migrations..."
+alembic upgrade head
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Alembic migrations completed."
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting Negentropy backend server..."
+exec negentropy serve --host 0.0.0.0 --port 3292

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,0 +1,76 @@
+# =============================================================================
+# Negentropy Frontend — Multi-stage Dockerfile (Shared for UI & Wiki)
+# =============================================================================
+# Node 22 + pnpm monorepo 构建 Next.js standalone 输出
+# 通过 TARGET_SERVICE build arg 区分 negentropy-ui / negentropy-wiki
+# =============================================================================
+
+ARG TARGET_SERVICE=negentropy-ui
+
+# ── Stage 1: Install dependencies ───────────────────────────────────────────
+FROM node:22-slim AS deps
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# 先复制 workspace 根文件（利用 Docker 层缓存）
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+
+# 复制所有 package.json（workspace resolution 需要）
+COPY packages/agents-chat-core/package.json ./packages/agents-chat-core/package.json
+COPY apps/negentropy-ui/package.json ./apps/negentropy-ui/package.json
+COPY apps/negentropy-wiki/package.json ./apps/negentropy-wiki/package.json
+
+# 安装依赖（frozen lockfile）
+RUN pnpm install --frozen-lockfile
+
+# ── Stage 2: Build ──────────────────────────────────────────────────────────
+FROM deps AS builder
+
+ARG TARGET_SERVICE
+
+# 复制共享库源码
+COPY packages/agents-chat-core/ ./packages/agents-chat-core/
+
+# 复制目标应用源码
+COPY apps/${TARGET_SERVICE}/ ./apps/${TARGET_SERVICE}/
+
+# 先构建共享库 @negentropy/agents-chat-core（ui/wiki 均依赖）
+RUN pnpm --filter @negentropy/agents-chat-core build
+
+# 构建目标应用（NEGENTROPY_CORE_PREBUILT=1 跳过 core 重复构建）
+WORKDIR /app/apps/${TARGET_SERVICE}
+ENV NEGENTROPY_CORE_PREBUILT=1
+RUN pnpm build
+
+# ── Stage 3: Production runtime ─────────────────────────────────────────────
+FROM node:22-slim AS runner
+
+ARG TARGET_SERVICE
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# 复制 standalone 输出（Next.js 独立部署产物）
+# monorepo 模式下 standalone 输出包含 apps/<service>/ 目录结构
+COPY --from=builder /app/apps/${TARGET_SERVICE}/.next/standalone ./
+
+# 复制 static 资源和 public（standalone 不自动包含）
+COPY --from=builder /app/apps/${TARGET_SERVICE}/.next/static ./apps/${TARGET_SERVICE}/.next/static
+COPY --from=builder /app/apps/${TARGET_SERVICE}/public ./apps/${TARGET_SERVICE}/public
+
+# 复制生产启动脚本（处理 standalone 输出路径检测与 symlink）
+COPY --from=builder /app/apps/${TARGET_SERVICE}/scripts ./apps/${TARGET_SERVICE}/scripts
+COPY --from=builder /app/apps/${TARGET_SERVICE}/package.json ./apps/${TARGET_SERVICE}/package.json
+
+WORKDIR /app/apps/${TARGET_SERVICE}
+
+# start-production.mjs 默认 PORT=3192（ui）或 3092（wiki），HOSTNAME=localhost
+# Docker 环境变量 PORT / HOSTNAME 会覆盖默认值
+CMD ["node", "./scripts/start-production.mjs"]

--- a/docker/perceives/Dockerfile
+++ b/docker/perceives/Dockerfile
@@ -1,0 +1,44 @@
+# =============================================================================
+# Negentropy Perceives — Multi-stage Dockerfile
+# =============================================================================
+# Python 3.13 + uv 构建的 FastMCP MCP Server（Web/PDF 内容提取）
+# =============================================================================
+
+# ── Stage 1: Build dependencies ─────────────────────────────────────────────
+FROM python:3.13-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /build
+
+# 先复制依赖声明（利用 Docker 层缓存）
+COPY apps/negentropy-perceives/pyproject.toml apps/negentropy-perceives/uv.lock ./
+
+# 安装依赖到虚拟环境
+RUN uv sync --frozen --no-dev --no-install-project
+
+# 复制应用源码
+COPY apps/negentropy-perceives/src ./src/
+
+# 安装项目本身
+RUN uv sync --frozen --no-dev
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM python:3.13-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# 从 builder 复制虚拟环境
+COPY --from=builder /build/.venv /app/.venv
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH="/app" \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 2992
+
+CMD ["negentropy-perceives"]

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,10 @@
+-- =============================================================================
+-- Negentropy PostgreSQL Initialization
+-- =============================================================================
+-- Pre-create extensions required by the Negentropy platform.
+-- Alembic migrations also execute CREATE EXTENSION IF NOT EXISTS (idempotent),
+-- but pre-creating here ensures extensions are available before any migration runs.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "vector";


### PR DESCRIPTION
# 背景
- 项目通过 `scripts/cli.sh start` 管理本地 4 个服务（perceives / backend / ui / wiki）+ 外部 PostgreSQL，缺少容器化部署方案。本次新增 Docker Compose 定义，实现 `docker compose up` 一键拉起全套子模块与 PostgreSQL+pgvector 数据库。

# 核心变更

**`docker-compose.yml`** — 5 服务编排：
- `postgres`：pgvector/pgvector:pg17，命名卷持久化，healthcheck `pg_isready`
- `perceives`：Python 3.13 + uv 多阶段构建，FastMCP 绑定 `0.0.0.0:2992`
- `backend`：Python 3.13 + uv 多阶段构建，`entrypoint.sh` 执行 Alembic 迁移后启动 ADK Server
- `ui` / `wiki`：共享 `docker/frontend/Dockerfile`，Node 22 + pnpm monorepo 构建 Next.js standalone，`TARGET_SERVICE` build arg 参数化

**Docker 网络适配**：
| 环境变量 | 本地默认 | Docker 覆盖 |
|---------|---------|------------|
| `NE_DB_URL` | `localhost:5432` | `postgres:5432` |
| `NEGENTROPY_PERCEIVES_HTTP_HOST` | `localhost` | `0.0.0.0` |
| `AGUI_BASE_URL` | `http://localhost:3292` | `http://backend:3292` |
| `WIKI_API_BASE` | `http://localhost:3292` | `http://backend:3292` |
| `WIKI_UI_BFF_BASE` | `http://localhost:3192` | `http://ui:3192` |

**辅助文件**：
- `docker/postgres/init.sql` — 预创建 uuid-ossp / vector 扩展
- `.env.docker` — 密钥模板（API Keys / SSO / Observability）
- `.dockerignore` — 排除 .git / node_modules / .venv / docs 等
- `.gitignore` — 添加 `!.env.docker` 例外

**启动依赖链**：`postgres (healthy)` → `perceives (healthy)` → `backend (healthy)` → `ui (healthy)` → `wiki`

# 风险与回滚
- 主要风险：perceives 镜像含 ML 依赖（PyMuPDF / Docling / MinerU），首次构建约 2-4GB；`uv sync --frozen` 要求 lock 文件与源码结构严格一致
- 回滚方式：`git revert` 即可，所有变更均为新增文件，无修改既有源码

# 验证证据
- `docker compose config --quiet` YAML 语法验证通过
- `docker compose config --services` 输出 5 个服务
- pre-commit hooks（ruff / ESLint / YAML check）全部通过

# 影响范围
- 前端：无既有代码变更
- 后端：无既有代码变更
- GitHub Actions / 文档：`.gitignore` 新增 1 行

# Next Best Action
- 实机 `docker compose build` 验证多阶段构建完整通过
- `docker compose up -d` 全服务健康就绪后，补充 Docker 使用文档