### PR TITLE
feat(routine-step-owner): 为 Routine 迭代步骤添加「主导人」归属标识

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -14,6 +14,7 @@ import {
   type RoutineIterationDTO,
   type RoutineIterationEventDTO,
 } from "@/features/routine";
+import { AGENT_ROLE_META, countAgentRoles, deriveIterationDriver, type AgentRole } from "@/features/routine";
 
 import { IterationEventTimeline } from "./IterationEventTimeline";
 import { phaseClass, phaseLabel, scoreColorClass, verdictClass } from "./status-style";
@@ -91,6 +92,9 @@ export function IterationAuditDrawer({
   // 合并持久化 + 实时（持久化优先），按 seq 去重升序。
   const merged = useMemo(() => mergeEvents(persisted, isInFlight ? (liveActions ?? []) : []), [persisted, liveActions, isInFlight]);
 
+  // 主导人统计：从已合并的事件中统计各主导人的事件数
+  const roleCounts = useMemo(() => countAgentRoles(merged), [merged]);
+
   const title = iteration ? `Iteration #${iteration.seq} · Full View` : "Full View";
 
   return (
@@ -98,7 +102,7 @@ export function IterationAuditDrawer({
       open={open}
       onClose={onClose}
       title={title}
-      subtitle={iteration ? <IterationMetaBar iteration={iteration} /> : undefined}
+      subtitle={iteration ? <IterationMetaBar iteration={iteration} roleCounts={roleCounts} /> : undefined}
       widthClassName="[width:clamp(480px,66.67%,1100px)]"
     >
       <div className="px-5 py-4">
@@ -116,8 +120,15 @@ export function IterationAuditDrawer({
   );
 }
 
-/** 抽屉副标题：相位 / 状态 / verdict / 评分 + 成本 / 轮数 / session 元信息。 */
-function IterationMetaBar({ iteration }: { iteration: RoutineIterationDTO }) {
+/** 抽屉副标题：相位 / 状态 / verdict / 评分 + 成本 / 轮数 / 主导人摘要。 */
+function IterationMetaBar({
+  iteration,
+  roleCounts,
+}: {
+  iteration: RoutineIterationDTO;
+  roleCounts: Array<[AgentRole, number]>;
+}) {
+  const driver = deriveIterationDriver(iteration.status);
   return (
     <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
       {iteration.phase && (
@@ -137,10 +148,38 @@ function IterationMetaBar({ iteration }: { iteration: RoutineIterationDTO }) {
       <span className="text-text-muted">·</span>
       <span className="text-[11px] tabular-nums text-text-muted">turns {iteration.turn_count}</span>
       <span className="text-[11px] tabular-nums text-text-muted">${iteration.cost_usd.toFixed(4)}</span>
+      {/* 主导人摘要 pill 列表 */}
+      {roleCounts.length > 0 && (
+        <>
+          <span className="text-text-muted">·</span>
+          {roleCounts.map(([role, count]) => {
+            const meta = AGENT_ROLE_META[role];
+            const Icon = meta.icon;
+            return (
+              <span key={role} className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${meta.badgeClass}`}>
+                <Icon className="h-2.5 w-2.5" aria-hidden />
+                {meta.label} ({count})
+              </span>
+            );
+          })}
+        </>
+      )}
+      {/* 当前阶段主导人指示（仅活跃迭代） */}
+      {driver && (
+        <>
+          <span className="text-text-muted">·</span>
+          <span className={`inline-flex items-center gap-0.5 text-[10px] font-medium ${AGENT_ROLE_META[driver].badgeClass}`}>
+            ▸ {AGENT_ROLE_META[driver].label}
+          </span>
+        </>
+      )}
       {iteration.claude_session_id && (
-        <span className="truncate font-mono text-[10px] text-text-muted" title={iteration.claude_session_id}>
-          {iteration.claude_session_id.slice(0, 8)}
-        </span>
+        <>
+          <span className="text-text-muted">·</span>
+          <span className="truncate font-mono text-[10px] text-text-muted" title={iteration.claude_session_id}>
+            {iteration.claude_session_id.slice(0, 8)}
+          </span>
+        </>
       )}
     </span>
   );

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { ChevronRight, type LucideIcon } from "lucide-react";
 
 import { JsonViewer } from "@/components/ui/JsonViewer";
+import { AGENT_ROLE_META, deriveAgentRole, type AgentRole } from "@/features/routine";
 import type { RoutineIterationEventDTO } from "@/features/routine";
 
 import {
@@ -18,6 +19,18 @@ import {
 /** 渲染 Lucide 图标 —— 以 prop 传入组件引用，避免「render 期间创建组件」lint 误报。 */
 function EventIcon({ icon: Icon, className }: { icon: LucideIcon; className?: string }) {
   return <Icon className={className} aria-hidden />;
+}
+
+/** 主导人徽章 —— 分组标题右侧小 pill，显示步骤的执行者归属。 */
+function AgentRoleBadge({ role }: { role: AgentRole }) {
+  const meta = AGENT_ROLE_META[role];
+  const Icon = meta.icon;
+  return (
+    <span className={`ml-auto inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${meta.badgeClass}`}>
+      <Icon className="h-3 w-3" aria-hidden />
+      {meta.label}
+    </span>
+  );
 }
 
 /**
@@ -55,8 +68,9 @@ export function IterationEventTimeline({
                 {EVENT_GROUP_LABEL[g]}
               </h4>
               <span className="text-[10px] tabular-nums text-text-muted">{list.length}</span>
+              <AgentRoleBadge role={deriveAgentRole(list[0].event_type)} />
               {live && g === "execution" && (
-                <span className="ml-auto inline-flex items-center gap-1 text-[10px] font-medium text-sky-600 dark:text-sky-400">
+                <span className="inline-flex items-center gap-1 text-[10px] font-medium text-sky-600 dark:text-sky-400">
                   <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
                   LIVE
                 </span>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ListTree } from "lucide-react";
 
 import type { RoutineIterationDTO } from "@/features/routine";
+import { AGENT_ROLE_META, deriveIterationDriver } from "@/features/routine";
 
 import { LiveElapsed, StaticDuration } from "./ElapsedClock";
 import { ACTIVE_TIMING } from "./routine-loop";
@@ -144,6 +145,19 @@ function IterationCard({
 
       {/* 指标行 */}
       <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-text-muted">
+        {/* 当前阶段主导人指示 */}
+        {(() => {
+          const driver = deriveIterationDriver(it.status);
+          if (!driver) return null;
+          const meta = AGENT_ROLE_META[driver];
+          const Icon = meta.icon;
+          return (
+            <span className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 font-medium ${meta.badgeClass}`}>
+              <Icon className="h-2.5 w-2.5" aria-hidden />
+              {meta.label}
+            </span>
+          );
+        })()}
         {it.exec_status && <span>exec: {it.exec_status}</span>}
         <span>turns: {it.turn_count}</span>
         <span>cost: ${it.cost_usd.toFixed(4)}</span>

--- a/apps/negentropy-ui/features/routine/agent-role.ts
+++ b/apps/negentropy-ui/features/routine/agent-role.ts
@@ -1,0 +1,141 @@
+/**
+ * Routine 迭代步骤「主导人」归属标识。
+ *
+ * 基于 event_type 推导当前步骤的执行者（Negentropy Engine / Claude Code / 五翼 Faculty）。
+ * Phase 1：纯前端推导，零迁移成本；Phase 2（五翼 Faculty 接入后）改为从后端 agent_role 字段读取。
+ */
+
+import { Bot, BrainCircuit, Cpu, Eye, Hand, Megaphone, Sparkles, type LucideIcon } from "lucide-react";
+
+import type { RoutineEventType, IterationStatus } from "./types";
+
+// ---------------------------------------------------------------------------
+// 类型
+// ---------------------------------------------------------------------------
+
+/** Agent 主导人角色（当前实际参与者 + 五翼 Faculty 预留）。 */
+export type AgentRole =
+  | "engine"
+  | "claude_code"
+  | "perception"
+  | "action"
+  | "internalization"
+  | "contemplation"
+  | "influence";
+
+/** 角色元数据。 */
+export interface AgentRoleMeta {
+  /** 用户可见的显示名。 */
+  label: string;
+  /** 英文显示名。 */
+  labelEn: string;
+  /** Lucide 图标。 */
+  icon: LucideIcon;
+  /** 徽章 Tailwind 配色（深色模式安全高对比度）。 */
+  badgeClass: string;
+}
+
+// ---------------------------------------------------------------------------
+// 角色元数据映射表
+// ---------------------------------------------------------------------------
+
+export const AGENT_ROLE_META: Record<AgentRole, AgentRoleMeta> = {
+  engine: {
+    label: "Negentropy",
+    labelEn: "Negentropy",
+    icon: Cpu,
+    badgeClass: "bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  },
+  claude_code: {
+    label: "Claude Code",
+    labelEn: "Claude Code",
+    icon: Bot,
+    badgeClass: "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  },
+  perception: {
+    label: "慧眼",
+    labelEn: "Perception",
+    icon: Eye,
+    badgeClass: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+  },
+  action: {
+    label: "妙手",
+    labelEn: "Action",
+    icon: Hand,
+    badgeClass: "bg-orange-500/10 text-orange-700 dark:text-orange-300",
+  },
+  internalization: {
+    label: "本心",
+    labelEn: "Internalization",
+    icon: BrainCircuit,
+    badgeClass: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  },
+  contemplation: {
+    label: "元神",
+    labelEn: "Contemplation",
+    icon: Sparkles,
+    badgeClass: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300",
+  },
+  influence: {
+    label: "喉舌",
+    labelEn: "Influence",
+    icon: Megaphone,
+    badgeClass: "bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 推导函数
+// ---------------------------------------------------------------------------
+
+/**
+ * 事件类型 → 主导人推导。
+ *
+ * - gate / evaluation → Engine（命令门控 / LLM-as-Judge）
+ * - 其余（system / assistant / tool_use / tool_result / result）→ Claude Code（执行者）
+ */
+export function deriveAgentRole(eventType: RoutineEventType): AgentRole {
+  switch (eventType) {
+    case "gate":
+    case "evaluation":
+      return "engine";
+    default:
+      return "claude_code";
+  }
+}
+
+/**
+ * 迭代状态 → 当前阶段主导人推导（用于迭代卡片指示器）。
+ *
+ * - `pending_approval` / `dispatched` / `executed` → Engine（编排/评估阶段）
+ * - `in_flight` → Claude Code（执行阶段）
+ * - 终态 → null（已完成/已终止）
+ */
+export function deriveIterationDriver(status: IterationStatus): AgentRole | null {
+  switch (status) {
+    case "pending_approval":
+    case "dispatched":
+    case "executed":
+      return "engine";
+    case "in_flight":
+      return "claude_code";
+    default:
+      return null;
+  }
+}
+
+/**
+ * 统计一组事件中各主导人的事件数。
+ *
+ * 返回按事件数降序排列的 `[AgentRole, count][]`，用于主导人摘要 pill 列表。
+ */
+export function countAgentRoles(
+  events: Array<{ event_type: RoutineEventType }>,
+): Array<[AgentRole, number]> {
+  const counts = new Map<AgentRole, number>();
+  for (const ev of events) {
+    const role = deriveAgentRole(ev.event_type);
+    counts.set(role, (counts.get(role) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -27,6 +27,9 @@ export type {
   RoutineTemplateItem,
 } from "./types";
 
+export type { AgentRole, AgentRoleMeta } from "./agent-role";
+export { AGENT_ROLE_META, deriveAgentRole, deriveIterationDriver, countAgentRoles } from "./agent-role";
+
 export {
   fetchKpis,
   fetchRoutines,


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：Routine 详情页 View Detail 抽屉中，每个步骤仅显示事件类型图标和标题，用户无法直观辨别当前节点是 **Negentropy**（编排/评估）还是 **Claude Code**（执行）在主导，缺乏对迭代流程中责任归属的可观测性
- 关联上下文/文档：Routine Engine 采用 Evaluator-Optimizer 模式，Engine 负责编排调度（Dispatch）、命令门控（Gate）、LLM-as-Judge 评估（Evaluation），Claude Code 负责全部执行动作（system/assistant/tool_use/tool_result/result）

# 核心变更

- **新建 `agent-role.ts` 模块**：定义 `AgentRole` 类型（含五翼 Faculty 预留）、角色元数据映射表（显示名 / Lucide 图标 / 深色模式安全配色），以及 `deriveAgentRole`（事件类型→主导人）、`deriveIterationDriver`（迭代状态→当前阶段主导人）、`countAgentRoles`（统计各主导人事件数）三个纯函数
- **IterationEventTimeline**：分组标题行右侧添加 `AgentRoleBadge` 徽章组件——Execution/Result 组显示 `🤖 Claude Code`，Gate/Evaluation 组显示 `⚙️ Negentropy`
- **IterationAuditDrawer**：MetaBar 区域新增主导人摘要 pill 列表（如 `⚙️ Negentropy (2) · 🤖 Claude Code (15)`），以及活跃迭代的当前阶段主导人指示（`▸ Negentropy` / `▸ Claude Code`）
- **RoutineIterationTimeline**：迭代卡片 metrics 行添加基于状态的主导人徽章（`in_flight` → Claude Code，`dispatched`/`executed` → Negentropy，终态不显示）
- **设计决策**：采用纯前端推导策略（Phase 1），基于 `event_type` 确定性映射，零迁移成本；五翼 Faculty 类型与配色已预留，待 Phase 2 后端 `agent_role` 字段接入即可启用

# 风险与回滚

- 主要风险：纯 UI 变更，不涉及数据模型或后端逻辑，风险极低
- 回滚方式：`git revert` 单次提交即可完整回滚

# 验证证据

- 单元测试：TypeScript 类型检查通过（`tsc --noEmit`），本次改动文件零编译错误
- 集成测试：ESLint / Ruff / pre-commit hooks 全部通过
- E2E/Workflow：需浏览器实机验证（Routine 详情页 → View Details → 确认徽章展示）
- 覆盖率/关键截图：5 个文件变更，218 行新增，7 行删除

# 影响范围

- 前端：`features/routine/` 新增模块 + 3 个 UI 组件（IterationEventTimeline / IterationAuditDrawer / RoutineIterationTimeline）
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action

- 浏览器实机验证：打开 Routine 详情页，点击 View Details，确认 Execution/Result 组标题右侧显示 `Claude Code` 徽章，Gate/Evaluation 组显示 `Negentropy` 徽章，抽屉 MetaBar 显示主导人摘要 pill
- 验证深色模式下所有徽章对比度清晰可辨