### PR TITLE
feat(routine): 将迭代 max_turns 默认值调整为 1000 并提升至配置页 Budget 区

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -114,7 +114,7 @@ const DEFAULTS: FormState = {
   no_progress_patience: "3",
   approval_mode: "auto",
   model: "",
-  max_turns: "",
+  max_turns: "1000",
   permission_mode: "",
   allowed_tools: "",
   timeout_seconds: "",
@@ -147,7 +147,7 @@ const CATEGORY_OPTIONS = [
 function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "max_turns" | "permission_mode" | "allowed_tools" | "timeout_seconds"> {
   return {
     model: (cfg.model as string) ?? "",
-    max_turns: cfg.max_turns != null ? String(cfg.max_turns) : "",
+    max_turns: cfg.max_turns != null ? String(cfg.max_turns) : "1000",
     permission_mode: (cfg.permission_mode as string) ?? "",
     allowed_tools: Array.isArray(cfg.allowed_tools) ? (cfg.allowed_tools as string[]).join(", ") : "",
     timeout_seconds: cfg.timeout_seconds != null ? String(cfg.timeout_seconds) : "",
@@ -697,6 +697,17 @@ export function RoutineEditDrawer({
                     className={cn(inputCls, "min-w-0 flex-1")}
                   />
                 </div>
+                <div className="flex items-center gap-2">
+                  <label className={labelInlineCls}>Max Turns / Iter.</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={form.max_turns}
+                    onChange={(e) => update("max_turns", e.target.value)}
+                    disabled={readOnly}
+                    className={cn(inputCls, "min-w-0 flex-1")}
+                  />
+                </div>
                 <div className="col-span-2 flex items-center gap-2">
                   <label className={labelInlineCls}>Iteration Timeout</label>
                   <input
@@ -854,18 +865,6 @@ export function RoutineEditDrawer({
                 {showAdvanced && (
                   <div className="mt-3 space-y-2 rounded-card border border-border bg-muted/30 p-4">
                     <div className="grid grid-cols-2 gap-3">
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Max Turns / Iter.</label>
-                        <input
-                          type="number"
-                          min={1}
-                          value={form.max_turns}
-                          onChange={(e) => update("max_turns", e.target.value)}
-                          disabled={readOnly}
-                          placeholder="default"
-                          className={cn(inputCls, "min-w-0 flex-1")}
-                        />
-                      </div>
                       <div className="flex items-center gap-2">
                         <label className={labelInlineCls}>Permission Mode</label>
                         <select

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -63,6 +63,11 @@ class RoutineSettings(BaseSettings):
     default_max_cost_usd: float = Field(
         default=5.0, ge=0.0, description="创建 routine 时 max_cost_usd 的默认值（成本熔断守卫）"
     )
+    default_max_turns: int = Field(
+        default=1000,
+        ge=1,
+        description="Routine 单次迭代 Claude Code 执行的默认最大交互轮次；被 routine.config.max_turns 覆盖。",
+    )
     default_iteration_timeout_seconds: int = Field(
         default=10800,
         ge=300,

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -529,6 +529,8 @@ class RoutineOrchestrator:
         effective_cwd = routine.worktree_path if phase_mod.is_worktree_routine(routine) else routine.cwd
         if effective_cwd:
             config.cwd = effective_cwd
+        # Routine 级默认覆盖全局 CC 默认（1000 vs 20）；per-routine config 可再覆盖。
+        config.max_turns = settings.routine.default_max_turns
         if overrides.get("max_turns"):
             config.max_turns = int(overrides["max_turns"])
         if overrides.get("model"):


### PR DESCRIPTION
## 概述

Routine 子系统的每次迭代（Iteration）会启动一次 Claude Code 执行，其最大交互轮次由 `max_turns` 参数控制。当前默认值为 **20**（全局 `ClaudeCodeConfig` 默认），且该字段被折叠在 Advanced Settings 区，不易发现。

本 PR 将 Routine 场景的默认值改为 **1000**，并将该参数从 Advanced 折叠区提升至 **Budget & Approval** 区直接可见。

## 改动清单

### 后端

- **`config/routine.py`**：`RoutineSettings` 新增 `default_max_turns: int = 1000`，遵循已有的 `default_max_iterations` / `default_iteration_timeout_seconds` 同一模式
- **`orchestrator.py`**：`_build_config()` 在应用 per-routine override 之前，先以 `settings.routine.default_max_turns` 覆盖全局 CC 默认（20→1000），与 `timeout_seconds` 的处理方式一致

### 前端

- **`RoutineEditDrawer.tsx`**：
  - `DEFAULTS.max_turns` 由 `""` 改为 `"1000"`，新建 Routine 时表单即显示默认值
  - `ccFromConfig()` fallback 同步更新为 `"1000"`
  - `Max Turns / Iter.` 字段从 Advanced Settings 折叠区移至 Budget & Approval 区 grid 中，与 Max Iterations、Max Cost 等同级排列

## 影响范围

- **新建 Routine**：表单 Budget 区直接可见 Max Turns / Iter. 字段，默认值 1000
- **已有 Routine**（config 中无 `max_turns`）：执行时自动获得 1000 的 Routine 级默认值（无需迁移）
- **已有 Routine**（config 中有显式 `max_turns`）：按用户设定值执行，不受影响
- **非 Routine 的 Claude Code 调用**：不受影响，仍使用全局默认 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)