### PR TITLE
feat(doc-metadata): Document 详情页 Article Metadata 编辑入口（作者/来源/发布时间）

### DIFF
--- a/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
@@ -21,6 +21,7 @@ import {
   downloadDocument,
   fetchDocumentDetail,
   refreshDocumentMarkdown,
+  updateDocument,
 } from "@/features/knowledge/utils/knowledge-api";
 import { formatRelativeTime } from "@/features/knowledge/utils/pipeline-helpers";
 import { DocumentMarkdownRenderer } from "@/features/knowledge/components/DocumentMarkdownRenderer";
@@ -139,6 +140,16 @@ export default function DocumentDetailPage() {
   const [isDownloading, setIsDownloading] = useState(false);
   const [isRefreshingMarkdown, setIsRefreshingMarkdown] = useState(false);
 
+  // Article Metadata editing state
+  const [isEditingMeta, setIsEditingMeta] = useState(false);
+  const [isSavingMeta, setIsSavingMeta] = useState(false);
+  const [metaDraft, setMetaDraft] = useState({
+    author: "",
+    author_url: "",
+    source_url: "",
+    published_at: "",
+  });
+
   const requestAppName = detail?.app_name || APP_NAME;
 
   // ---- Data fetching ----
@@ -218,6 +229,44 @@ export default function DocumentDetailPage() {
   };
 
   // ---- Derived state ----
+
+  const meta = detail?.metadata as Record<string, string> | undefined;
+
+  const startMetaEdit = useCallback(() => {
+    if (!detail) return;
+    const m = (detail.metadata as Record<string, string>) || {};
+    setMetaDraft({
+      author: m.author || "",
+      author_url: m.author_url || "",
+      source_url: m.source_url || m.source_uri || "",
+      published_at: m.published_at || "",
+    });
+    setIsEditingMeta(true);
+  }, [detail]);
+
+  const cancelMetaEdit = useCallback(() => {
+    setIsEditingMeta(false);
+  }, []);
+
+  const commitMetaEdit = useCallback(async () => {
+    if (!detail) return;
+    setIsSavingMeta(true);
+    try {
+      await updateDocument(detail.corpus_id, detail.id, {
+        author: metaDraft.author.trim() || null,
+        author_url: metaDraft.author_url.trim() || null,
+        source_url: metaDraft.source_url.trim() || null,
+        published_at: metaDraft.published_at.trim() || null,
+      });
+      toast.success("Article metadata saved — Wiki will update after next publish");
+      setIsEditingMeta(false);
+      await loadDetail();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save metadata");
+    } finally {
+      setIsSavingMeta(false);
+    }
+  }, [detail, metaDraft, loadDetail]);
 
   const statusBadge = getStatusBadge(detail?.status || "");
   const markdownStatus =
@@ -361,6 +410,132 @@ export default function DocumentDetailPage() {
                   {formatRelativeTime(detail.created_at ?? undefined)}
                 </span>
               </div>
+            </div>
+
+            {/* Article Metadata panel (Wiki 文章元数据编辑) */}
+            <div className="mb-4 rounded-lg border border-border bg-muted px-4 py-3 text-xs">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+                  Article Metadata
+                </h3>
+                {!isEditingMeta ? (
+                  <button
+                    type="button"
+                    onClick={startMetaEdit}
+                    className="flex items-center gap-1 rounded px-1.5 py-0.5 text-text-muted hover:text-foreground hover:bg-border/40 transition-colors"
+                    title="Edit article metadata"
+                  >
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                    </svg>
+                  </button>
+                ) : (
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => void commitMetaEdit()}
+                      disabled={isSavingMeta}
+                      className="flex items-center gap-1 rounded px-2 py-0.5 text-emerald-600 hover:bg-emerald-100 dark:hover:bg-emerald-900/30 disabled:opacity-50"
+                    >
+                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      {isSavingMeta ? "..." : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancelMetaEdit}
+                      disabled={isSavingMeta}
+                      className="flex items-center gap-1 rounded px-2 py-0.5 text-text-muted hover:bg-border/40 disabled:opacity-50"
+                    >
+                      <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {isEditingMeta ? (
+                <div className="grid grid-cols-[120px_1fr] gap-x-4 gap-y-2 items-center">
+                  <label className="text-text-muted">Author</label>
+                  <input
+                    type="text"
+                    value={metaDraft.author}
+                    onChange={(e) => setMetaDraft((d) => ({ ...d, author: e.target.value }))}
+                    placeholder="e.g. Anthropic Engineering"
+                    className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-text-muted/50 focus:outline-none focus:ring-1 focus:ring-foreground/20"
+                  />
+                  <label className="text-text-muted">Author URL</label>
+                  <input
+                    type="url"
+                    value={metaDraft.author_url}
+                    onChange={(e) => setMetaDraft((d) => ({ ...d, author_url: e.target.value }))}
+                    placeholder="e.g. https://github.com/username"
+                    className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-text-muted/50 focus:outline-none focus:ring-1 focus:ring-foreground/20"
+                  />
+                  <label className="text-text-muted">Source URL</label>
+                  <input
+                    type="url"
+                    value={metaDraft.source_url}
+                    onChange={(e) => setMetaDraft((d) => ({ ...d, source_url: e.target.value }))}
+                    placeholder="e.g. https://example.com/article"
+                    className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-text-muted/50 focus:outline-none focus:ring-1 focus:ring-foreground/20"
+                  />
+                  <label className="text-text-muted">Published At</label>
+                  <input
+                    type="date"
+                    value={metaDraft.published_at}
+                    onChange={(e) => setMetaDraft((d) => ({ ...d, published_at: e.target.value }))}
+                    className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-foreground/20"
+                  />
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-1 sm:grid-cols-4">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="shrink-0 text-text-muted">Author</span>
+                    <span className="truncate font-medium text-foreground">
+                      {meta?.author || <span className="text-text-muted/50">–</span>}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="shrink-0 text-text-muted">Source</span>
+                    {meta?.source_url || meta?.source_uri ? (
+                      <a
+                        href={(meta?.source_url || meta?.source_uri) as string}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate font-medium text-foreground underline decoration-text-muted/40 hover:text-blue-600 dark:hover:text-blue-400"
+                      >
+                        {(meta?.source_url || meta?.source_uri) as string}
+                      </a>
+                    ) : (
+                      <span className="text-text-muted/50">–</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="shrink-0 text-text-muted">Published</span>
+                    <span className="truncate font-medium text-foreground">
+                      {meta?.published_at || <span className="text-text-muted/50">–</span>}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="shrink-0 text-text-muted">Author URL</span>
+                    {meta?.author_url ? (
+                      <a
+                        href={meta.author_url as string}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate font-medium text-foreground underline decoration-text-muted/40 hover:text-blue-600 dark:hover:text-blue-400"
+                      >
+                        {meta.author_url as string}
+                      </a>
+                    ) : (
+                      <span className="text-text-muted/50">–</span>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Markdown content card */}

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1429,16 +1429,23 @@ export async function fetchDocumentDetail(
 }
 
 /**
- * 更新文档元信息（目前仅支持 `display_name`）。
+ * 更新文档元信息（display_name + Wiki 文章元数据）。
  *
- * - 传入 `null` 或仅空白字符串 → 清除覆盖；Wiki 站点回退到
- *   `metadata.title -> original_filename`。
- * - 长度上限 255；超过由后端返回 422。
+ * - `display_name`: 传入 `null` 或仅空白字符串 → 清除覆盖；Wiki 站点回退到
+ *   `metadata.title -> original_filename`。长度上限 255。
+ * - `author` / `author_url` / `source_url` / `published_at`: 合并写入
+ *   `metadata` JSONB；传空字符串清除对应键。
  */
 export async function updateDocument(
   corpusId: string,
   documentId: string,
-  patch: { display_name?: string | null },
+  patch: {
+    display_name?: string | null;
+    author?: string | null;
+    author_url?: string | null;
+    source_url?: string | null;
+    published_at?: string | null;
+  },
   params?: { appName?: string },
 ): Promise<KnowledgeDocument> {
   const body: Record<string, unknown> = { ...patch };

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_dao.py
@@ -447,12 +447,12 @@ class WikiDao:
         if not resolved_title:
             resolved_title = filename or "Untitled"
 
-        # 来源 URL 解析：URL 文档取 origin_url / source_url；File 文档取 metadata 中的 source_uri
+        # 来源 URL 解析：URL 文档取 DocSource；File 文档取 metadata
         source_type = (metadata or {}).get("source_type")
         if source_type == "url":
             resolved_source_url = doc_original_url or doc_source_url
         else:
-            resolved_source_url = (metadata or {}).get("source_uri")
+            resolved_source_url = (metadata or {}).get("source_url") or (metadata or {}).get("source_uri")
 
         return {
             "document_id": doc_id,

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -205,10 +205,12 @@ async def update_document(
     document_id: UUID,
     payload: DocumentUpdateRequest,
 ) -> DocumentResponse:
-    """更新文档元信息（当前仅支持 ``display_name``）。
+    """更新文档元信息（display_name + Wiki 文章元数据）。
 
     - ``display_name`` 为 ``None`` / 空白时清除覆盖，展示侧回退到
       ``metadata_.title -> original_filename``；
+    - ``author`` / ``author_url`` / ``source_url`` / ``published_at`` 合并写入
+      ``metadata_`` JSONB；传空字符串清除对应键；
     - 与 :func:`get_document_detail` 一致的 ``corpus_id`` / ``app_name`` 权限校验。
     """
     resolved_app = _resolve_app_name(payload.app_name)
@@ -216,6 +218,21 @@ async def update_document(
     from negentropy.storage.service import DocumentStorageService
 
     storage_service = DocumentStorageService()
+
+    # 合并 metadata_ JSONB 中的 Wiki 文章元数据字段
+    meta_keys = ("author", "author_url", "source_url", "published_at")
+    metadata_patch: dict[str, str | None] = {}
+    for key in meta_keys:
+        val = getattr(payload, key, None)
+        if val is not None:
+            # 空字符串视为清除，否则设置值
+            metadata_patch[key] = val.strip() or None
+
+    if metadata_patch:
+        await storage_service.update_document_metadata(
+            document_id=document_id,
+            metadata_patch=metadata_patch,
+        )
 
     try:
         doc = await storage_service.update_document_display_name(

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -596,10 +596,21 @@ class DocumentResponse(BaseModel):
 
 
 class DocumentUpdateRequest(BaseModel):
-    """文档元信息更新请求（目前仅支持 ``display_name``）。"""
+    """文档元信息更新请求。
+
+    ``display_name`` 直接更新列字段；
+    ``author`` / ``author_url`` / ``source_url`` / ``published_at`` 合并写入
+    ``metadata_`` JSONB，供 Wiki 文章元数据栏读取。
+    传空字符串视为清除对应键。
+    """
 
     display_name: str | None = Field(default=None, max_length=255)
     app_name: str | None = None
+    # Wiki 文章元数据（合并写入 metadata_ JSONB）
+    author: str | None = None
+    author_url: str | None = None
+    source_url: str | None = None
+    published_at: str | None = None
 
 
 class DocumentDetailResponse(DocumentResponse):


### PR DESCRIPTION
# 背景
- 上轮 PR #814 已在 Wiki 内容页添加文章元数据栏（作者/日期/浏览/评论/源头链接），但 Knowledge Base Document 详情页缺少这些字段的编辑入口。
- File 来源文档无法维护 author/author_url/source_url/published_at，导致 Wiki 文章元数据栏部分字段始终为空。

# 核心变更

## 后端（3 文件）
- **扩展 Schema** `DocumentUpdateRequest`：新增 `author`/`author_url`/`source_url`/`published_at`，合并写入 `metadata_` JSONB
- **扩展路由** `PATCH /documents/{id}`：复用已有 `update_document_metadata()` 处理 metadata patch，空字符串清除对应键
- **统一 Wiki source_url 解析**：File 文档兼容 `source_url`（UI 编辑写入）和 `source_uri`（旧键名）两个键

## 前端（2 文件）
- **扩展 API** `updateDocument()`：patch 类型新增 author/author_url/source_url/published_at
- **新增 Article Metadata 面板**：Document 详情页 Metadata strip 下方新增编辑面板
  - 只读状态：显示 Author / Source URL（超链接可跳转）/ Published At / Author URL，空值灰色 `–`
  - 编辑状态：pencil icon → inline edit（URL 输入框 / Date picker）→ Save/Cancel
  - 保存后自动同步到 Wiki 文章元数据栏（下次发布/ISR 窗口生效）

# 风险与回滚
- 主要风险：metadata patch 为合并写入，不会覆盖其他 metadata 键
- 回滚方式：revert 本 PR 2 笔提交

# 验证证据
- ✅ `pnpm build`（negentropy-ui）通过，零 TypeScript 错误
- ✅ Python 语法校验通过
- ✅ pre-commit hooks（ruff lint + ruff format + ESLint）全部通过

# 影响范围
- 前端：`apps/negentropy-ui/`（Document 详情页编辑面板 + API 类型）
- 后端：`apps/negentropy/`（Schema + 路由 + Wiki DAO 解析）

# Next Best Action
- 实机验证：启动后端 + negentropy-ui dev server，打开 Document 详情页编辑 Article Metadata，确认保存后 Wiki 展示同步