### PR TITLE
fix(claude-code): 注入真实 Anthropic 凭证修复 Routine 子进程 529→401 鉴权失败

### DIFF
--- a/apps/negentropy/src/negentropy/agents/tools/claude_code.py
+++ b/apps/negentropy/src/negentropy/agents/tools/claude_code.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from google.adk.tools import ToolContext
 
+from negentropy.engine.claude_code.credentials import resolve_claude_code_credential
 from negentropy.engine.claude_code.models import ClaudeCodeConfig
 from negentropy.engine.claude_code.service import ClaudeCodeService
 
@@ -51,6 +52,8 @@ async def invoke_claude_code(
         permission_mode=cc_defaults.get("permission_mode", "auto"),
         timeout_seconds=float(cc_defaults.get("timeout_seconds", 300.0)),
         mcp_config=cc_defaults.get("mcp_config"),
+        # 注入真实 Anthropic 凭证（state 中的 credentials > 环境变量），与 Routine 路径一致。
+        credential=resolve_claude_code_credential(cc_defaults.get("credentials")),
     )
 
     # 3. 解析 allowed_tools

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0039_seed_claude_code_builtin_tool.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0039_seed_claude_code_builtin_tool.py
@@ -110,8 +110,18 @@ CLAUDE_CODE_CONFIG_SCHEMA = {
         },
     },
     "credentials": {
-        # ANTHROPIC_API_KEY 由 VendorConfig 统一管理，不在 builtin_tools 表中存储明文。
-        # 此处保留空字典占位，便于未来扩展 per-tool 凭据时无需再次 schema 迁移。
+        # Claude Code 子进程出示给 coding-proxy 的「真实 Anthropic 凭证」。
+        # 留空则回退环境变量（CLAUDE_CODE_OAUTH_TOKEN / sk-ant- ANTHROPIC_API_KEY）/ 交互式登录态。
+        # 注意：这与 VendorConfig(anthropic) 的网关 key 是不同凭证命名空间——后者对根
+        # /v1/messages failover anthropic tier 无效（详见迁移 0058 与 engine/claude_code/credentials.py）。
+        "oauth_token": {
+            "type": "password",
+            "title": "Claude Code OAuth Token",
+            "description": (
+                "claude.ai 订阅长期令牌（`claude setup-token` 生成，注入为 Bearer）；"
+                "亦可填真实 `sk-ant-` API Key（注入为 x-api-key）。留空则回退环境变量 / 交互式登录态。"
+            ),
+        },
     },
 }
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0058_claude_code_credentials_schema.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0058_claude_code_credentials_schema.py
@@ -1,0 +1,85 @@
+"""Declare claude_code config_schema.credentials.oauth_token field for Tools UI
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-06-02 00:00:00.000000+00:00
+
+设计动机：
+    修复 Routine 调用 Claude Code 的 529→401 鉴权失败（详见
+    ``engine/claude_code/credentials.py``）。Claude Code 子进程过去未注入真实 Anthropic
+    凭证，headless 场景回退交互式登录态失败，致 coding-proxy 的 failover anthropic tier
+    转发空凭证 → 401。
+
+    修复需运维在 Interface → Tools → Claude Code 填入「真实 Anthropic 凭证」
+    （``claude setup-token`` 长期令牌，或真实 ``sk-ant-`` API Key），存于
+    ``builtin_tools.claude_code.credentials.oauth_token``。本迁移仅为既有
+    ``claude_code`` 行的 ``config_schema.credentials`` **声明该字段定义**，使
+    ``ToolFormDialog`` 动态渲染出对应（password 脱敏）输入框。
+
+    迁移 0039 以 ``ON CONFLICT (name) DO NOTHING`` 种子化该行，故更新 0039 常量不会回灌
+    既有行——必须由本迁移幂等补声明。
+
+幂等 / 非破坏性：
+    - 仅 ``jsonb_set`` 覆盖 ``config_schema -> 'credentials'``（字段「定义」），
+      **不触碰 ``credentials`` 列**（用户已填的真实凭证值），不删除任何数据。
+    - 多次执行结果一致。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "negentropy"
+
+# 与 0039 的 CLAUDE_CODE_CONFIG_SCHEMA["credentials"] 保持一致（单一事实源：UI 字段定义）。
+_CREDENTIALS_SCHEMA = {
+    "oauth_token": {
+        "type": "password",
+        "title": "Claude Code OAuth Token",
+        "description": (
+            "claude.ai 订阅长期令牌（`claude setup-token` 生成，注入为 Bearer）；"
+            "亦可填真实 `sk-ant-` API Key（注入为 x-api-key）。留空则回退环境变量 / 交互式登录态。"
+        ),
+    },
+}
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.builtin_tools
+            SET config_schema = jsonb_set(
+                COALESCE(config_schema, '{{}}'::jsonb),
+                '{{credentials}}',
+                :cred_schema,
+                true
+            )
+            WHERE name = 'claude_code' AND owner_id = 'system'
+            """
+        ).bindparams(
+            sa.bindparam("cred_schema", value=_CREDENTIALS_SCHEMA, type_=sa.dialects.postgresql.JSONB),
+        )
+    )
+
+
+def downgrade() -> None:
+    # 回退为空 credentials 占位（与 0039 原始语义一致）；不删除 credentials 列中的存储凭证值。
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.builtin_tools
+            SET config_schema = jsonb_set(
+                COALESCE(config_schema, '{{}}'::jsonb),
+                '{{credentials}}',
+                '{{}}'::jsonb,
+                true
+            )
+            WHERE name = 'claude_code' AND owner_id = 'system'
+            """
+        )
+    )

--- a/apps/negentropy/src/negentropy/engine/claude_code/credentials.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/credentials.py
@@ -1,0 +1,71 @@
+"""Claude Code 子进程凭证解析 —— 让 headless 调用出示「真实 Anthropic 凭证」。
+
+## 为什么需要它
+
+Routine 引擎运行在 detached 后台进程（``negentropy serve``，无 TTY / GUI）内，
+通过 ``ClaudeCodeService`` 以子进程方式拉起 ``claude`` CLI。该子进程过去未注入任何
+Anthropic 凭证：当环境缺 ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` 时，Claude Code
+会回退去读 macOS Keychain 的交互式登录态（claude.ai OAuth）—— 后台进程拿不到该登录态，
+于是向 coding-proxy 出示了无效/缺失凭证。代理主 tier（zhipu/GLM）忽略客户端鉴权用自己的
+key（故正常，仅偶发 529 过载）；529 触发 failover 到「透明转发客户端鉴权」的 anthropic
+tier，把无效凭证原样转发给 ``api.anthropic.com`` → 401。
+
+本模块把「真实 Anthropic 凭证」从单一事实源解析出来，由 ``ClaudeCodeService`` 注入子进程
+环境变量（见 ``service._build_subprocess_env``），使 failover 鉴权成功、且与交互式登录态解耦。
+
+## 凭证来源优先级（单一事实源 + 运维兜底）
+
+1. **Interface / Tools UI**：``builtin_tools.claude_code.credentials`` 的 ``oauth_token`` /
+   ``api_key`` 字段（入库、UI 脱敏、热轮换免重启）。脱敏占位值（含 ``****``）视为「未配置」。
+2. **环境变量兜底**：``CLAUDE_CODE_OAUTH_TOKEN``；或 ``ANTHROPIC_API_KEY``（仅当为真实
+   ``sk-ant-`` 前缀，避免误用 AfterShip 32 位网关 key）。
+3. 均无 → ``None``：不注入，保持既有行为（继承环境 / 交互式登录态），不破坏开发与终端场景。
+
+凭证为敏感数据，**绝不写入日志**（调用方亦不得记录返回值）。
+"""
+
+from __future__ import annotations
+
+import os
+
+# 与 ``interface/api.py::_mask_credentials`` 产生的脱敏占位保持一致的判定语义：
+# 脱敏值形如 "abcd****wxyz" 或 "****"，一律含此标记。
+_MASK_MARKER = "****"
+
+# 真实 Anthropic API Key 前缀。AfterShip 网关 key（32 位 hex，如 ``0f12ec0…``）不带此前缀，
+# 用作 ``x-api-key`` 会被根 ``/v1/messages`` failover anthropic tier 转发后 401，故须排除。
+_ANTHROPIC_API_KEY_PREFIX = "sk-ant-"
+
+
+def _is_masked(value: str) -> bool:
+    """判断是否为 ``_mask_credentials`` 产生的脱敏占位值（含 ``****``）。"""
+    return _MASK_MARKER in value
+
+
+def resolve_claude_code_credential(credentials: dict | None) -> str | None:
+    """解析注入 Claude Code 子进程的真实 Anthropic 凭证。
+
+    Args:
+        credentials: ``builtin_tools.claude_code.credentials`` 字典（可为 ``None``）。
+            识别 ``oauth_token``（订阅长期令牌，Bearer）与 ``api_key``（``sk-ant-`` API Key）。
+
+    Returns:
+        去除首尾空白的凭证字符串；无任何可用来源时返回 ``None``。脱敏占位值按「未配置」处理。
+    """
+    if credentials:
+        for key in ("oauth_token", "api_key"):
+            tok = credentials.get(key)
+            if isinstance(tok, str):
+                tok = tok.strip()
+                if tok and not _is_masked(tok):
+                    return tok
+
+    env_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+    if env_token:
+        return env_token
+
+    env_api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if env_api_key.startswith(_ANTHROPIC_API_KEY_PREFIX):
+        return env_api_key
+
+    return None

--- a/apps/negentropy/src/negentropy/engine/claude_code/models.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/models.py
@@ -44,6 +44,11 @@ class ClaudeCodeConfig:
     mcp_config: dict[str, Any] | None = None
     resume_session_id: str | None = None
 
+    # 注入子进程的真实 Anthropic 凭证（OAuth 长期令牌 / sk-ant- API Key）。
+    # 由 credentials.resolve_claude_code_credential 解析，ClaudeCodeService 据此构建子进程 env。
+    # repr=False / compare=False：secret 绝不入 repr（防日志、traceback 泄露），亦不参与相等比较。
+    credential: str | None = field(default=None, repr=False, compare=False)
+
     # 默认允许的工具集
     _DEFAULT_TOOLS: list[str] = field(
         default_factory=lambda: ["Bash", "Read", "Write", "Edit", "Glob", "Grep"],

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -275,6 +275,50 @@ class ClaudeCodeService:
                 cls._sdk_available = False
         return cls._sdk_available
 
+    # ------------------------------------------------------------------
+    # 子进程凭证注入（根因修复：headless Routine 子进程须出示真实 Anthropic 凭证）
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _credential_env(credential: str | None) -> dict[str, str | None]:
+        """计算凭证对环境的「覆盖项」：值为 str → 设置；值为 None → 删除该键。
+
+        - ``sk-ant-`` 前缀 → 真实 Anthropic API Key，走 ``ANTHROPIC_API_KEY``（x-api-key）；
+        - 否则 → claude.ai 订阅 OAuth 长期令牌，走 ``ANTHROPIC_AUTH_TOKEN`` +
+          ``CLAUDE_CODE_OAUTH_TOKEN``（Bearer）。
+        - 删除「未选中」的另一类凭证键，消除 Claude Code 内 key/token 的优先级歧义。
+        - **绝不触碰 ``ANTHROPIC_BASE_URL``**（须保持指向 coding-proxy 根 ``/v1/messages``）。
+
+        ``credential`` 为空 → 返回空字典（不施加任何覆盖，等价继承父环境）。
+        """
+        if not credential:
+            return {}
+        if credential.startswith("sk-ant-"):
+            return {
+                "ANTHROPIC_API_KEY": credential,
+                "ANTHROPIC_AUTH_TOKEN": None,
+                "CLAUDE_CODE_OAUTH_TOKEN": None,
+            }
+        return {
+            "ANTHROPIC_AUTH_TOKEN": credential,
+            "CLAUDE_CODE_OAUTH_TOKEN": credential,
+            "ANTHROPIC_API_KEY": None,
+        }
+
+    @staticmethod
+    def _build_subprocess_env(credential: str | None) -> dict[str, str]:
+        """构建子进程环境：``os.environ`` 副本叠加凭证覆盖（不就地修改 ``os.environ``）。
+
+        无凭证时返回纯继承副本，功能等价于不传 ``env=``，故不破坏交互式 / 开发 / 终端场景。
+        """
+        env = os.environ.copy()
+        for key, value in ClaudeCodeService._credential_env(credential).items():
+            if value is None:
+                env.pop(key, None)
+            else:
+                env[key] = value
+        return env
+
     @staticmethod
     async def invoke(
         prompt: str,
@@ -372,6 +416,16 @@ class ClaudeCodeService:
             options.resume = config.resume_session_id
         if config.model:
             options.model = config.model
+        # 镜像 CLI 路径：注入真实 Anthropic 凭证。优先经 SDK 的 ``options.env``（避免全局 os.environ
+        # 突变带来的并发不安全）；旧版 SDK 无该字段时仅告警——CLI 才是当前已装且权威的执行路径。
+        if config.credential:
+            if hasattr(options, "env"):
+                options.env = ClaudeCodeService._build_subprocess_env(config.credential)
+            else:
+                logger.warning(
+                    "claude_code_sdk_credential_inject_unsupported",
+                    reason="ClaudeCodeOptions has no 'env' field; credential not injected on SDK path",
+                )
 
         result_text = ""
         session_id = None
@@ -472,6 +526,7 @@ class ClaudeCodeService:
             permission_mode=config.permission_mode,
             mcp_config=config.mcp_config,
             resume_session_id=config.resume_session_id,
+            credential=config.credential,  # 必须透传：否则注入凭证在此重建处被静默丢弃 → 退回 401
         )
 
         args = ClaudeCodeService._build_cli_args(prompt, config)
@@ -482,6 +537,8 @@ class ClaudeCodeService:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=config.cwd,
+                # 注入真实 Anthropic 凭证到子进程环境（根因修复）。无凭证时等价继承父环境。
+                env=ClaudeCodeService._build_subprocess_env(config.credential),
                 limit=_STREAM_READER_LIMIT,  # 抬高 StreamReader 缓冲（兜底；主防线为手动分块读取）
             )
         except FileNotFoundError:
@@ -673,6 +730,7 @@ class ClaudeCodeService:
                 cli_path=cli,
                 max_turns=1,
                 timeout_seconds=300.0,
+                credential=config.credential,  # 透传凭证：Test Connection 亦须出示真实凭证
             ),
         )
         latency = round((time.monotonic() - t0) * 1000)

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
@@ -93,6 +93,7 @@ async def _load_claude_code_defaults():
     from sqlalchemy import select
 
     from negentropy.db.session import AsyncSessionLocal
+    from negentropy.engine.claude_code.credentials import resolve_claude_code_credential
     from negentropy.engine.claude_code.models import ClaudeCodeConfig
     from negentropy.models.builtin_tool import BuiltinTool
 
@@ -107,6 +108,10 @@ async def _load_claude_code_defaults():
         )
         result = await db.execute(stmt)
         tool = result.scalar_one_or_none()
+
+    # 单一汇聚点：解析注入子进程的真实 Anthropic 凭证（UI credentials > 环境变量 > None）。
+    # 此处一改即覆盖 scheduler handler 与 orchestrator._build_config 两条派发路径。
+    credential = resolve_claude_code_credential(tool.credentials if tool else None)
 
     if tool:
         cfg = tool.config or {}
@@ -123,7 +128,8 @@ async def _load_claude_code_defaults():
             timeout_seconds=float(cfg.get("timeout_seconds", 300.0)),
             permission_mode=cfg.get("permission_mode", "auto"),
             mcp_config=cfg.get("mcp_config"),
+            credential=credential,
         )
     # 无 DB 配置时，尝试解析默认 "claude" 为绝对路径
     default_cli = shutil.which("claude") or "claude"
-    return ClaudeCodeConfig(cli_path=default_cli)
+    return ClaudeCodeConfig(cli_path=default_cli, credential=credential)

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -1630,6 +1630,7 @@ async def test_builtin_tool(
             return BuiltinToolTestResponse(success=False, message=f"Connection failed: {exc}")
 
     if tool.tool_type == "claude_code":
+        from negentropy.engine.claude_code.credentials import resolve_claude_code_credential
         from negentropy.engine.claude_code.models import ClaudeCodeConfig
         from negentropy.engine.claude_code.service import ClaudeCodeService
 
@@ -1637,6 +1638,8 @@ async def test_builtin_tool(
             cli_path=config.get("cli_path", "claude"),
             model=config.get("model"),
             timeout_seconds=300.0,
+            # 注入真实 Anthropic 凭证（UI credentials > 环境变量），令未保存即测试也走真实凭证。
+            credential=resolve_claude_code_credential(credentials),
         )
         result = await ClaudeCodeService.test_connection(cc_config)
         latency = result.get("latency_ms")

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_credentials.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_credentials.py
@@ -1,0 +1,66 @@
+"""resolve_claude_code_credential 解析优先级单测。
+
+锁定：UI credentials > 环境变量（CLAUDE_CODE_OAUTH_TOKEN / sk-ant- ANTHROPIC_API_KEY）> None；
+脱敏占位值按「未配置」处理；AfterShip 32 位网关 key 不被误用。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from negentropy.engine.claude_code.credentials import resolve_claude_code_credential
+
+
+@pytest.fixture(autouse=True)
+def _clear_cc_env(monkeypatch):
+    """隔离环境：清除可能影响判定的凭证类环境变量。"""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+
+def test_ui_oauth_token_wins():
+    assert resolve_claude_code_credential({"oauth_token": "sk-ant-oat01-real"}) == "sk-ant-oat01-real"
+
+
+def test_ui_api_key_used_when_no_oauth_token():
+    assert resolve_claude_code_credential({"api_key": "sk-ant-api03-real"}) == "sk-ant-api03-real"
+
+
+def test_ui_oauth_token_preferred_over_api_key():
+    creds = {"oauth_token": "tok-oauth", "api_key": "sk-ant-api03-x"}
+    assert resolve_claude_code_credential(creds) == "tok-oauth"
+
+
+def test_masked_value_treated_as_unconfigured(monkeypatch):
+    """前端回传脱敏占位（含 ****）应视为未配置，回退环境/None，绝不出示脱敏串。"""
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "env-oauth-token")
+    assert resolve_claude_code_credential({"oauth_token": "sk-a****real"}) == "env-oauth-token"
+
+
+def test_env_oauth_token_fallback(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "env-oauth-token")
+    assert resolve_claude_code_credential(None) == "env-oauth-token"
+    assert resolve_claude_code_credential({}) == "env-oauth-token"
+
+
+def test_env_anthropic_api_key_only_when_real_sk_ant(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-fromenv")
+    assert resolve_claude_code_credential(None) == "sk-ant-api03-fromenv"
+
+
+def test_env_gateway_key_is_rejected(monkeypatch):
+    """AfterShip 32 位网关 key（非 sk-ant-）不可用作 CC 凭证，避免根 failover tier 401。"""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "0f12ec02e91345bb82d14a91b9bea8ca")
+    assert resolve_claude_code_credential(None) is None
+
+
+def test_no_source_returns_none():
+    assert resolve_claude_code_credential(None) is None
+    assert resolve_claude_code_credential({}) is None
+    assert resolve_claude_code_credential({"oauth_token": "", "api_key": "   "}) is None
+
+
+def test_oauth_token_env_precedes_api_key_env(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "env-oauth")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-x")
+    assert resolve_claude_code_credential(None) == "env-oauth"

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -98,3 +98,100 @@ async def test_effective_permission_mode_normalizes_aliases():
 async def test_default_timeout_is_routine_appropriate():
     # 默认超时已自 300s 抬高，避免深度任务空转超时。
     assert ClaudeCodeConfig().timeout_seconds >= 900.0
+
+
+# ---------------------------------------------------------------------------
+# 子进程凭证注入（修复 Routine 529→401 鉴权失败的回归锁定）
+# ---------------------------------------------------------------------------
+
+
+async def test_build_subprocess_env_oauth_token_uses_bearer(monkeypatch):
+    """非 sk-ant- 凭证（OAuth 长期令牌）→ Bearer 两键，且清除 x-api-key 键。"""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:3392")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "0f12ec02e91345bb82d14a91b9bea8ca")  # 网关 key，应被清除
+    env = ClaudeCodeService._build_subprocess_env("sk-ant-oat01-deadbeef-token")
+    # sk-ant- 前缀 → 走 API Key 分支
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant-oat01-deadbeef-token"
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+    # base_url 始终保留
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3392"
+
+
+async def test_build_subprocess_env_plain_oauth_token_uses_bearer(monkeypatch):
+    """普通（非 sk-ant-）OAuth 令牌 → ANTHROPIC_AUTH_TOKEN + CLAUDE_CODE_OAUTH_TOKEN，清 API Key。"""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:3392")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "0f12ec02e91345bb82d14a91b9bea8ca")
+    env = ClaudeCodeService._build_subprocess_env("oauth-subscription-token-xyz")
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "oauth-subscription-token-xyz"
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-subscription-token-xyz"
+    assert "ANTHROPIC_API_KEY" not in env  # 网关 key 被清除，消除优先级歧义
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3392"
+
+
+async def test_build_subprocess_env_none_is_pure_inheritance(monkeypatch):
+    """无凭证 → 纯继承副本，不增删任何凭证键（等价不传 env=）。"""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:3392")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    env = ClaudeCodeService._build_subprocess_env(None)
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3392"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+
+async def test_build_subprocess_env_does_not_mutate_os_environ(monkeypatch):
+    """构建环境绝不就地修改 os.environ（并发隔离安全）。"""
+    import os
+
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    ClaudeCodeService._build_subprocess_env("oauth-token-abc")
+    assert "ANTHROPIC_AUTH_TOKEN" not in os.environ
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in os.environ
+
+
+async def test_invoke_cli_passes_credential_env_and_survives_reconstruction(monkeypatch):
+    """端到端锁定：_invoke_cli 重建 config 后仍保留 credential，并把它注入子进程 env=。
+
+    回归点：service.py 在 463 行用 resolved CLI 路径重建 ClaudeCodeConfig；若漏传
+    credential，注入字段会被静默丢弃 → 退回 401。本测试 mock create_subprocess_exec 抓 env=。
+    """
+    captured: dict = {}
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.stdout = _FakeStream(b"")  # 立即 EOF
+            self.stderr = _FakeStream(b"")
+            self.returncode = 0
+
+        def terminate(self) -> None:  # noqa: D401
+            pass
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _fake_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs.get("env")
+        return _FakeProc()
+
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:3392")
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+
+    cfg = ClaudeCodeConfig(cli_path="claude", cwd=None, max_turns=1, credential="oauth-token-from-ui")
+    await ClaudeCodeService.invoke("ping", cfg)
+
+    env = captured["env"]
+    assert env is not None, "必须向子进程传入 env="
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "oauth-token-from-ui"
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "oauth-token-from-ui"
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:3392"
+
+
+async def test_config_repr_omits_credential_secret():
+    """secret 绝不出现在 repr（防日志 / traceback 泄露）。"""
+    cfg = ClaudeCodeConfig(credential="super-secret-oauth-token")
+    assert "super-secret-oauth-token" not in repr(cfg)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface / Routine 的 Routine 任务调用 Claude Code 反复出现 `Tier zhipu error 529 → failover → Tier anthropic 401 authentication_error`，而终端 / Conductor 调用完全正常。
- 关联上下文：根因为 headless 后台进程 `negentropy serve`（无 TTY/GUI）拉起的 `claude` 子进程**未注入任何 Anthropic 凭证**，回退读取交互式 macOS Keychain 登录态失败 → 向 coding-proxy 出示空/失效凭证；zhipu 主层用代理自己的 key（仅偶发瞬时 529 过载），529 触发 failover 到「透明转发客户端凭证」的 anthropic 层 → 空凭证转发 `api.anthropic.com` → 401。迁移 0039 早已声明「凭证应注入子进程 env」却从未实现；现有 `anthropic` VendorConfig 为 AfterShip 网关 key，对根 `/v1/messages` failover 层无效，不可复用。

# 核心变更
- 新增 `engine/claude_code/credentials.py`：`resolve_claude_code_credential`，单一事实源解析真实凭证（Tools UI credentials > 环境变量 > None），脱敏占位按未配置处理，排除 32 位网关 key 误用。
- `ClaudeCodeConfig` 增加 `credential` 字段（`repr=False` 防 secret 泄露）；`service.py` 新增 `_build_subprocess_env`（`sk-ant-`→`ANTHROPIC_API_KEY`/x-api-key；否则→`ANTHROPIC_AUTH_TOKEN`+`CLAUDE_CODE_OAUTH_TOKEN`/Bearer，清非选项键，保留 `ANTHROPIC_BASE_URL`，不就地改 `os.environ`），`_invoke_cli` 传 `env=` 并在 config 重建处透传 `credential`（防静默丢弃），`_invoke_sdk` / `test_connection` 同步镜像。
- `_load_claude_code_defaults` 单点解析（覆盖 scheduler handler 与 orchestrator）；`test_builtin_tool` 与 `invoke_claude_code` 同步接线。
- 迁移 0058 幂等声明 `claude_code.config_schema.credentials.oauth_token`(password) 字段供 Tools UI 渲染（同步 0039 常量）；仅改字段定义，非破坏性。

# 风险与回滚
- 主要风险：低。无凭证时 `_build_subprocess_env(None)` 等价旧行为（全继承环境），不影响交互式/开发/终端；不触碰代理路由、`/api/anthropic` LiteLLM 网关路径与 `model_resolver`。需运维在 Tools 填入 `claude setup-token` 令牌后 failover 才生效。
- 回滚方式：revert 本 PR；迁移 0058 `downgrade` 将 `config_schema.credentials` 置空（**不删除** `credentials` 列中已存储的凭证值）。

# 验证证据
- 单元测试：新增/扩展 30 项（令牌类型分流 / base-url 保留 / 无凭证回退 / 重建保留 credential / repr 不泄密；resolver 优先级 / 网关 key 拒绝）全绿；相邻 65 项（scheduler handlers + builtin tool API）无回归；ruff + pre-commit 通过。
- 集成测试：N/A（真实 CLI + 代理 + token 不入 CI）。
- E2E/Workflow：本地抓包确认注入后 `claude` 向 `/v1/messages?beta=true` 发出 `Authorization: Bearer …`；并以真实 coding-proxy 日志实证根因——anthropic 层 **577 次成功**（有效 OAuth 被接受）vs **27 次 headless 401**，且 529 在 opus-4-7/4-8 间共享（同 `glm-5.1`、时间成簇=瞬时过载，非 Negentropy 独有）；源码确认 failover 时原始客户端 headers 原样透传。
- 覆盖率/关键截图：待运维接入真实 token 后的 Routine 实机闭环（见 Next Best Action）。

# 影响范围
- 前端：无需改码（`ToolFormDialog` 已动态渲染 `config_schema.credentials` 的 password 字段）。
- 后端：`engine/claude_code/*`、`engine/schedulers/handlers/claude_code.py`、`interface/api.py`、`agents/tools/claude_code.py`、`db/migrations`。
- GitHub Actions / 文档：新增迁移 0058；无 CI 配置变更。

# Next Best Action
- 运维执行 `claude setup-token` 生成长期令牌 → Interface / Tools / Claude Code 的「Claude Code OAuth Token」字段填入 → 主项目 `uv run alembic upgrade head` + 重启 `negentropy serve` → 触发一次 Routine，确认代理日志不再出现 `Tier anthropic … 401`。
