### PR TITLE
fix(claude-code): Test Connection 直连验证 Anthropic API Key + api_retry 事件归一化

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -209,6 +209,8 @@ export function eventTypeLabel(eventType: RoutineEventType): string {
   switch (eventType) {
     case "system":
       return "会话初始化";
+    case "system_retry":
+      return "API 重试";
     case "assistant":
       return "推理";
     case "tool_use":

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -97,12 +97,13 @@ export interface RoutineIterationDTO {
 
 /**
  * 「全过程」动作级审计事件类型：
- * - 执行阶段：system（init）/ assistant（中间消息）/ tool_use（工具调用）/ tool_result（工具结果）/ result（最终产出）
+ * - 执行阶段：system（init）/ system_retry（API 重试，含 401/429）/ assistant（中间消息）/ tool_use（工具调用）/ tool_result（工具结果）/ result（最终产出）
  * - 评估阶段：gate（命令门控）/ evaluation（LLM-as-Judge）
  * - _truncated：动作数超上限的哨兵
  */
 export type RoutineEventType =
   | "system"
+  | "system_retry"
   | "assistant"
   | "tool_use"
   | "tool_result"

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -142,6 +142,22 @@ def _normalize_stream_event(raw: dict[str, Any]) -> list[dict[str, Any]]:
             )
         ]
 
+    # system/api_retry：Claude Code 内部 API 重试（含认证失败 401、限流 429 等）
+    if etype == _EVT_SYSTEM and raw.get("subtype") == "api_retry":
+        return [
+            _evt(
+                "system_retry",
+                {
+                    "error": raw.get("error"),
+                    "error_status": raw.get("error_status"),
+                    "attempt": raw.get("attempt"),
+                    "max_retries": raw.get("max_retries"),
+                    "retry_delay_ms": raw.get("retry_delay_ms"),
+                },
+                title=f"api_retry (HTTP {raw.get('error_status', '?')})",
+            )
+        ]
+
     # assistant：message.content 块列表 → text / tool_use / thinking；兼容旧扁平 content
     if etype == _EVT_ASSISTANT:
         content = (raw.get("message") or {}).get("content", raw.get("content"))
@@ -318,6 +334,52 @@ class ClaudeCodeService:
             else:
                 env[key] = value
         return env
+
+    # ------------------------------------------------------------------
+    # 凭证直连验证（绕过 coding-proxy，检出无效 Anthropic API Key）
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _verify_anthropic_credential_direct(credential: str) -> dict[str, Any] | None:
+        """直连 ``api.anthropic.com`` 验证 ``sk-ant-`` API Key 有效性（绕过 coding-proxy）。
+
+        coding-proxy 主 tier (zhipu) 用自有 key 完全忽略客户端 ``x-api-key``——
+        Test Connection 经 proxy 的 prompt 测试永远无法检出无效/过期/吊销的 Anthropic 凭证。
+        本方法绕过 proxy 发送最小请求（haiku, max_tokens=1），仅验证 key 是否通过认证层。
+
+        Returns:
+            ``None`` = 验证通过（或非认证类错误）；``dict`` = 凭证无效，应立即返回给前端。
+        """
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.post(
+                    "https://api.anthropic.com/v1/messages",
+                    headers={
+                        "x-api-key": credential,
+                        "anthropic-version": "2023-06-01",
+                        "content-type": "application/json",
+                    },
+                    json={
+                        "model": "claude-haiku-4-5-20251001",
+                        "max_tokens": 1,
+                        "messages": [{"role": "user", "content": "ok"}],
+                    },
+                )
+                if resp.status_code == 401:
+                    body = resp.json()
+                    msg = body.get("error", {}).get("message", "invalid x-api-key")
+                    return {
+                        "success": False,
+                        "message": f"Anthropic API Key 无效：{msg}（直连 api.anthropic.com 验证）",
+                        "detail": "Key 被远程 API 拒绝，请检查是否过期/吊销/权限不足。",
+                    }
+                # 200 / 400 / 404 / 429 等都说明 key 通过了认证层（非 401 即视为有效）。
+                return None
+        except Exception as exc:
+            logger.warning("anthropic_credential_direct_verify_error", error=str(exc))
+            return None  # 网络问题不阻断后续 proxy 测试
 
     @staticmethod
     async def invoke(
@@ -722,7 +784,15 @@ class ClaudeCodeService:
         except Exception as exc:
             return {"success": False, "message": f"claude --version failed: {exc}"}
 
-        # 2. 简单 prompt 测试
+        # 1.5 直连验证 Anthropic API Key（仅 sk-ant- 类型）
+        #   coding-proxy 主 tier (zhipu) 用自有 key，不验证客户端凭证 → Test Connection 通过 ≠ 凭证有效。
+        #   此步绕过 proxy 直连 api.anthropic.com，检出无效/过期/吊销的 key。
+        if config.credential and config.credential.startswith("sk-ant-"):
+            cred_error = await ClaudeCodeService._verify_anthropic_credential_direct(config.credential)
+            if cred_error:
+                return cred_error
+
+        # 2. 简单 prompt 测试（经 coding-proxy）
         t0 = time.monotonic()
         test_result = await ClaudeCodeService.invoke(
             "respond with exactly: OK",


### PR DESCRIPTION
## 问题

Routine 调用 Claude Code 时出现大量 401 认证失败重试（最多 10 次），但 Interface / Tools 页的 Test Connection 始终通过。

### 根因

coding-proxy 日志铁证：

```
error_msg=invalid x-api-key
response_body_preview={"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}
```

存储在 `builtin_tools.credentials.oauth_token` 的 Anthropic API Key (`sk-ant-o...`, 108 chars) **已被 `api.anthropic.com` 判定为无效**。

**Test Connection 未能检出此问题**，因为它走 coding-proxy → zhipu 主 tier（自有 key，忽略客户端 `x-api-key`），从未触发 anthropic failover 路径的鉴权验证。

| | Test Connection | Routine 调用 |
|---|---|---|
| 走哪个 tier | zhipu（自有 key） | zhipu 529 → failover anthropic |
| 是否验证 Anthropic Key | ❌ 不验证 | ✅ 透传给 `api.anthropic.com` |
| 结果 | 200 OK | 401 `invalid x-api-key` |

### 附带问题

401 重试事件 (`system/api_retry`) 被后端落入通用兜底 → 前端统一标为「会话初始化」，严重误导运维诊断。

## 修复

### Fix 1（运维，非代码）：更新无效的 Anthropic API Key

用户需在 Interface / Tools / Claude Code 页面替换当前无效的 `sk-ant-` key。

### Fix 2（代码）：Test Connection 直连验证

新增 `_verify_anthropic_credential_direct()` 方法：
- **有 `sk-ant-` key** → 直连 `api.anthropic.com` 最小请求验证（haiku, max_tokens=1），401 则立即报错
- **无 key（None / OAuth token）** → 跳过直连验证，走原有 proxy 测试

### Fix 3（代码）：api_retry 事件归一化

- 后端 `_normalize_stream_event` 识别 `subtype=api_retry` → 新 `event_type=system_retry`
- 前端 `eventTypeLabel` + `RoutineEventType` 添加 `system_retry` → "API 重试"

## 变更文件

| 文件 | 变更 |
|------|------|
| `engine/claude_code/service.py` | `_verify_anthropic_credential_direct` 新方法 + `test_connection` 调用 + `_normalize_stream_event` api_retry 处理 |
| `status-style.ts` | `eventTypeLabel` 添加 `system_retry` |
| `features/routine/types.ts` | `RoutineEventType` 添加 `system_retry` |

## 验证

- ✅ 21 个单元测试全部通过
- ⏳ 浏览器实机验证需重启后端 serve 进程后进行

🤖 Generated with [Claude Code](https://claude.com/claude-code)