### PR TITLE
feat(TiltedCard): Interface 核心卡片统一应用 ReactBits 3D 倾斜特效

### DIFF
--- a/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@/components/providers/AuthProvider";
+import { TiltedCard } from "@/components/ui/TiltedCard";
 
 interface Agent {
   id: string;
@@ -33,6 +34,7 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
   const isAdmin = user?.roles?.includes("admin") ?? false;
   const canEdit = isAdmin || !agent.is_builtin;
   return (
+    <TiltedCard>
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-card p-4">
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
@@ -144,5 +146,6 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
         </div>
       </div>
     </div>
+    </TiltedCard>
   );
 }

--- a/apps/negentropy-ui/components/ui/TiltedCard.tsx
+++ b/apps/negentropy-ui/components/ui/TiltedCard.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { type ReactNode, useCallback, useRef } from "react";
+import {
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+} from "framer-motion";
+import { cn } from "@/lib/utils";
+
+/** 默认弹簧配置（适配文本卡片：低幅度需更快响应）。 */
+const DEFAULT_SPRING = { damping: 30, stiffness: 200, mass: 1.5 };
+
+interface TiltedCardProps {
+  children: ReactNode;
+  className?: string;
+  /** 倾斜幅度（度），默认 8（原 reactbits TiltedCard 为 14，文本卡片降低）。 */
+  tiltAmplitude?: number;
+  /** 悬停缩放倍率，默认 1.03（原 reactbits 为 1.1，网格布局降低）。 */
+  scaleOnHover?: number;
+  /** 弹簧物理参数。 */
+  springConfig?: { damping: number; stiffness: number; mass: number };
+}
+
+/**
+ * 3D 倾斜卡片包装器（参考 ReactBits TiltedCard，适配文本内容卡片）。
+ *
+ * 子元素跟随鼠标产生 3D 透视倾斜 + 缩放 + 动态阴影，全部基于弹簧物理。
+ * 尊重 prefers-reduced-motion：降级为直接渲染子元素。
+ *
+ * @see https://reactbits.dev/components/tilted-card
+ */
+export function TiltedCard({
+  children,
+  className,
+  tiltAmplitude = 8,
+  scaleOnHover = 1.03,
+  springConfig = DEFAULT_SPRING,
+}: TiltedCardProps) {
+  const prefersReduced = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  /* ---- Motion Values（一次性创建，.set() 更新零重渲染） ---- */
+
+  const rawRotateX = useMotionValue(0);
+  const rawRotateY = useMotionValue(0);
+  const rawScale = useMotionValue(1);
+  const rawShadowProgress = useMotionValue(0);
+
+  const rotateX = useSpring(rawRotateX, springConfig);
+  const rotateY = useSpring(rawRotateY, springConfig);
+  const smoothScale = useSpring(rawScale, springConfig);
+  const smoothShadow = useSpring(rawShadowProgress, springConfig);
+
+  /* ---- 动态阴影：0→1 映射为低→高阴影 ---- */
+
+  const boxShadow = useTransform(smoothShadow, [0, 1], [
+    "0 1px 2px rgba(0,0,0,0.04)",
+    "0 10px 28px -4px rgba(0,0,0,0.12), 0 4px 10px -2px rgba(0,0,0,0.06)",
+  ]);
+
+  /* ---- 鼠标事件（useCallback 防重建） ---- */
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const offsetX = e.clientX - rect.left - rect.width / 2;
+      const offsetY = e.clientY - rect.top - rect.height / 2;
+      const halfW = rect.width / 2;
+      const halfH = rect.height / 2;
+
+      // 归一化 [-1, 1] × 幅度 → rotateX/Y
+      rawRotateY.set((offsetX / halfW) * tiltAmplitude);
+      rawRotateX.set((-offsetY / halfH) * tiltAmplitude);
+
+      // 阴影进度 = 光标到中心的归一化距离
+      const distance = Math.sqrt(offsetX * offsetX + offsetY * offsetY);
+      const maxDist = Math.sqrt(halfW * halfW + halfH * halfH);
+      rawShadowProgress.set(Math.min(distance / maxDist, 1));
+    },
+    [rawRotateX, rawRotateY, rawShadowProgress, tiltAmplitude],
+  );
+
+  const handleMouseEnter = useCallback(() => {
+    rawScale.set(scaleOnHover);
+  }, [rawScale, scaleOnHover]);
+
+  const handleMouseLeave = useCallback(() => {
+    rawRotateX.set(0);
+    rawRotateY.set(0);
+    rawScale.set(1);
+    rawShadowProgress.set(0);
+  }, [rawRotateX, rawRotateY, rawScale, rawShadowProgress]);
+
+  /* ---- prefers-reduced-motion 降级 ---- */
+
+  if (prefersReduced) {
+    return <div className={className}>{children}</div>;
+  }
+
+  /* ---- 渲染：外层 perspective 容器 + 内层 motion.div 承载 transform ---- */
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("h-full", className)}
+      onMouseMove={handleMouseMove}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{ perspective: 800 }}
+    >
+      <motion.div
+        className="h-full"
+        style={{
+          rotateX,
+          rotateY,
+          scale: smoothScale,
+          boxShadow,
+          willChange: "transform, box-shadow",
+        }}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/tests/unit/interface/AgentCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/interface/AgentCard.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/components/providers/AuthProvider", () => ({
   }),
 }));
 
+vi.mock("@/components/ui/TiltedCard", () => ({
+  TiltedCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
 const baseAgent = {
   id: "a1",
   owner_id: "u1",
@@ -46,7 +50,8 @@ describe("AgentCard", () => {
       <AgentCard agent={baseAgent} onEdit={vi.fn()} onDelete={vi.fn()} />
     );
 
-    const root = container.firstElementChild;
+    // mock TiltedCard 包裹一层 div，实际卡片是其子元素
+    const root = container.firstElementChild?.firstElementChild;
     expect(root).toHaveClass("h-full");
 
     const description = screen.getByText((content) => content.includes("Handles long description"));


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface 板块各功能卡（Agent / Skill / Tool / MCP / Template）此前完全静态，缺乏交互反馈；同时 Routine 模板库自建卡右上角「自建」标识与 hover 浮出的编辑/删除图标重叠。
- 关联上下文/文档：参考 [ReactBits Tilted Card](https://reactbits.dev/components/tilted-card)，统一为卡片引入跟随光标的 3D 倾斜动态特效。

# 核心变更
- 新增可复用组件 `components/ui/TiltedCard.tsx`：基于 framer-motion 弹簧物理（damping 30 / stiffness 200 / mass 1.5）实现 3D 透视倾斜 + 悬停缩放 + 动态阴影增强，`useMotionValue.set` + `useTransform` 零重渲染，尊重 `prefers-reduced-motion` 降级为纯静态。
- 推广至 Interface 五类核心卡：**Agent / Skill / Tool**（同构，直接包裹固定高度网格卡根 div）；**MCP**（复合卡外科式包裹——仅 `h-[176px]` 摘要矩形倾斜，可展开 tools/resources 区作为兄弟节点保持静止）；**Template**（整卡导航卡，pointer events 不拦截，点击/CTA/编辑穿透正常，保留内层 hover 阴影）。
- 修复 Routine 模板库自建卡「自建」标识与编辑/删除图标重叠：标识 `group-hover` 淡出让位，非 hover 态完整可见、信息无损。
- 范围控制（二阶思维）：`cognizes-ui` / `negentropy-wiki` 无 framer-motion 依赖，本次不动；密集列表 / 聊天流 / HITL 交互卡跳过，规避滚动抖动与眩晕风险。

# 风险与回滚
- 主要风险：极低。改动收敛于 UI 层，无后端/接口/数据变更；reduced-motion 自动降级。
- 回滚方式：还原各卡的 `<TiltedCard>` 包裹 + 删除 `TiltedCard.tsx` 即可，无副作用残留。

# 验证证据
- 单元测试：`negentropy-ui` 全量 **100 文件 / 788 用例通过**（含 AgentCard/SkillCard/ToolCard/TemplateCard/McpServerCard 卡片测试）；ESLint + tsc 改动文件零告警。
- E2E/实机：Playwright 可见实例 + mock 路由逐页验证——倾斜方向精确跟随光标（左上 rotateX>0/rotateY<0、右下反转）、spring 回弹归零、相邻卡片隔离、reduced-motion 降级为静态；**MCP 展开区 transform=none 不倾斜**；**Template 点击主体打开详情抽屉穿透正常**。
- 关键截图：各卡 hover 倾斜态、模板卡重叠修复前后对比（hover 时「自建」淡出、图标无重叠）。

# 影响范围
- 前端：`apps/negentropy-ui`（新增 TiltedCard 组件 + Agent/Skill/Tool/MCP/Template 五卡包裹 + 模板卡重叠修复 + 4 个卡片单测）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 后续若需进一步统一，可评估 Dashboard 指标卡 / Memory 健康卡等展示型面板（当前作为内联统计块跳过）；跨 app（wiki/cognizes-ui）如需同款特效，需先引入 framer-motion 依赖再适配。
