### PR TITLE
fix(routine-list): 修正 Clean Up Worktree 按钮在列表恒不显示的缺陷

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -104,7 +104,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                       Restart
                     </button>
                   )}
-                  {onCleanupWorktree && canCleanupWorktree(r.status, r.worktree_status, r.worktree_path) && (
+                  {onCleanupWorktree && canCleanupWorktree(r.status, r.worktree_path) && (
                     <button
                       type="button"
                       onClick={(e) => {

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { cn } from "@/lib/utils";
 import type { RoutineDTO } from "@/features/routine";
 
+import { canCleanupWorktree } from "./routine-controls";
 import {
   worktreePolicyDescription,
   worktreeStatusClass,
@@ -13,8 +14,6 @@ import {
 } from "./status-style";
 
 type WorktreeStatus = "active" | "cleaned" | "orphaned" | "none";
-
-const TERMINAL = new Set(["succeeded", "failed", "cancelled"]);
 
 interface RoutineWorkspaceCardProps {
   routine: Pick<
@@ -46,9 +45,7 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
   if (!routine.baseline_branch) return null;
 
   const ws = (routine.worktree_status ?? "none") as WorktreeStatus;
-  const isTerminal = TERMINAL.has(routine.status);
-  const canCleanup =
-    isTerminal && (ws === "active" || ws === "orphaned") && routine.worktree_path != null;
+  const canCleanup = canCleanupWorktree(routine.status, routine.worktree_path);
 
   return (
     <section className="rounded-card border border-border bg-card p-4 shadow-sm">

--- a/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/routine-controls.ts
@@ -45,17 +45,20 @@ export function canRestart(status: RoutineStatus): boolean {
 }
 
 /**
- * 是否可「清理 worktree」——终态 + worktree 仍活跃（active / orphaned）+ worktree_path 非空。
+ * 是否可「清理 worktree」——精确镜像后端 `cleanup-worktree` 端点守卫：终态 + `worktree_path` 非空。
+ *
+ * 不依赖 `worktree_status`：列表端点为避免 N+1 磁盘检查不计算该字段（恒为 null），而 `worktree_path`
+ * 由 DB 直出始终可用。依 `compute_worktree_status` 逻辑，`worktree_path != null` 严格等价于
+ * 状态 active / orphaned（cleaned / none 均要求 worktree_path 为空），故两者判定结果一致。
+ *
  * 供列表页行内 Clean Up 按钮 + RoutineWorkspaceCard 共享的单一事实源。
  */
 export function canCleanupWorktree(
   status: RoutineStatus,
-  worktreeStatus?: string | null,
   worktreePath?: string | null,
 ): boolean {
   return (
     (status === "succeeded" || status === "failed" || status === "cancelled") &&
-    (worktreeStatus === "active" || worktreeStatus === "orphaned") &&
     worktreePath != null
   );
 }


### PR DESCRIPTION
## 背景

PR #828 已将「Routine 列表操作列新增 Clean Up Worktree 按钮」合入基线，但合并时纳入的是**第一版实现**——其按钮显示判定依赖 `worktree_status`，导致按钮在列表中**恒不显示**。本 PR 提供该缺陷的纯净修复。

## 根因

后端列表端点 `GET /routines` 为避免 N+1 磁盘检查（每行 `os.walk` worktree 目录），**有意不调用** `compute_worktree_status`，因此列表返回的每个 routine 的 `worktree_status` 字段恒为 `null`（仅详情端点 `GET /routines/{id}` 计算）。

curl 实测同一条 eligible routine：

| 端点 | `worktree_path` | `worktree_status` |
|------|----------------|-------------------|
| 列表 `/routines` | ✅ 非空 | ❌ **`null`** |
| 详情 `/routines/{id}` | ✅ 非空 | ✅ `"active"` |

原判定 `worktreeStatus === "active" || "orphaned"` 在列表里永远 false → 按钮永不出现。

## 修复

`canCleanupWorktree` 改为仅依赖 **`status`（终态）+ `worktree_path != null`**，精确镜像后端 `cleanup-worktree` 端点守卫。依 `compute_worktree_status` 逻辑，`worktree_path != null` 严格等价于 active/orphaned（cleaned/none 均要求 path 为空），故**详情页 RoutineWorkspaceCard 行为不变**。`RoutineWorkspaceCard` 一并复用该函数，消除两处判定分叉风险。

## 验证

- **数据层**：curl 对比 list/detail 端点确认根因
- **逻辑层**：对完整 10 行真实列表套用新判定 → 恰 1 行（终态 + worktree_path 非空）显示按钮，其余（running 非终态、已清理 path=null、pending）均正确隐藏
- **质量门**：tsc 类型检查通过、ESLint 通过、pre-commit hooks 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)