### PR TITLE
fix(routine): 将单迭代动作事件捕获上限从硬编码 1000 提升为可配置的 max_events_per_iter

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -61,8 +61,8 @@ export function IterationAuditDrawer({
     setError(null);
     setPersisted([]);
     try {
-      // 单迭代动作数有上界（后端封顶 1000），一次性取全量（limit=1000）。
-      const res = await fetchIterationEvents(routineId, iterationId, { limit: 1000 });
+      // 单迭代动作数有上界（后端由 max_events_per_iter 配置，默认 5000），一次性取全量。
+      const res = await fetchIterationEvents(routineId, iterationId, { limit: 100000 });
       if (reqId !== reqIdRef.current) return;
       setPersisted(res.items);
     } catch (err) {

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineDetailLive.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineDetailLive.ts
@@ -10,8 +10,8 @@ import type { RoutineActionStreamEvent, RoutineDTO, RoutineStreamEvent } from ".
 import { useRoutineStream } from "./useRoutineStream";
 
 const REFRESH_DEBOUNCE_MS = 500;
-/** 单迭代实时动作缓冲上限（与后端 _MAX_EVENTS_PER_ITER 对齐，防内存膨胀）。 */
-const MAX_LIVE_ACTIONS = 1000;
+/** 单迭代实时动作缓冲上限（与后端 max_events_per_iter 对齐，防内存膨胀）。 */
+const MAX_LIVE_ACTIONS = 100000;
 
 /** 每迭代的实时动作缓冲：按 iteration_id 归集，按 seq 去重升序。 */
 export type LiveActionsByIteration = Record<string, RoutineActionStreamEvent[]>;

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -198,6 +198,7 @@ routine:
   context_reset_max: 10                       # CC 会话上下文耗尽自动重置 session 冷启动上限；超过落回 unrecoverable（0=关闭自愈）
   default_max_iterations: 20                 # 创建 routine 默认迭代硬上限
   default_max_cost_usd: 5.0                  # 创建 routine 默认成本熔断（USD）
+  max_events_per_iter: 5000                  # 单迭代动作事件捕获上限（Full View 审计）
   evaluator_model: null                      # LLM-as-Judge 模型覆盖；null 走 task_registry 的 routine.evaluate
   # 隔离 worktree（基于基线分支的隔离工作区 + 自动 PR 回基线）
   worktree_root: null                        # worktree 根目录；null → 运行期解析为仓库同级 <project_parent>/.negentropy-worktrees

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -75,6 +75,13 @@ class RoutineSettings(BaseSettings):
         ge=1,
         description="Routine 单次迭代 Claude Code 执行的默认最大交互轮次；被 routine.config.max_turns 覆盖。",
     )
+    max_events_per_iter: int = Field(
+        default=5000,
+        ge=100,
+        le=100000,
+        description="单迭代至多捕获的动作事件数（Full View 审计上限）；防 DB/SSE 膨胀。"
+        "超出后追加 _truncated 伪事件并停止捕获，Claude Code 进程本身不受影响。",
+    )
     default_iteration_timeout_seconds: int = Field(
         default=10800,
         ge=300,

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -68,9 +68,8 @@ def _classify_result_error(result_event: dict[str, Any] | None, returncode: int 
     return None
 
 
-# 「全过程」动作级审计：单字段截断上限 + 单迭代事件条数上限（防 DB / SSE 膨胀）。
+# 「全过程」动作级审计：单字段截断上限（防 DB / SSE 膨胀）。
 _EVENT_FIELD_CAP = 16 * 1024  # 16 KiB / 字段
-_MAX_EVENTS_PER_ITER = 1000  # 单迭代至多捕获的动作事件数
 
 # on_event sink：服务逐条把归一化动作回调给调用方（Runner）用于实时发布。best-effort。
 EventSink = Callable[[dict[str, Any]], Awaitable[None]]
@@ -293,15 +292,18 @@ async def _emit_events(
     """
     if events_holder is None:
         return
+    from negentropy.config import settings
+
+    max_events = settings.routine.max_events_per_iter
     for evt in _normalize_stream_event(raw):
-        if len(events_holder) >= _MAX_EVENTS_PER_ITER:
+        if len(events_holder) >= max_events:
             if events_holder and events_holder[-1].get("event_type") != "_truncated":
                 events_holder.append(
                     {
                         "seq": len(events_holder),
                         "event_type": "_truncated",
                         "tool_name": None,
-                        "title": f"动作数超过 {_MAX_EVENTS_PER_ITER} 上限，后续动作未记录",
+                        "title": f"动作数超过 {max_events} 上限，后续动作未记录",
                         "payload": {},
                         "cost_usd": None,
                     }

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -544,7 +544,7 @@ async def list_iterations(
 async def list_iteration_events(
     routine_id: UUID,
     iteration_id: UUID,
-    limit: int = Query(200, ge=1, le=1000),
+    limit: int = Query(200, ge=1, le=100000),
     after_seq: int | None = Query(None, description="分页：返回 seq 大于此值的事件（升序）"),
 ) -> dict[str, Any]:
     """单次迭代的「全过程」动作级审计事件流（工具调用/结果/中间消息/结果/门控/评估，按 seq 升序）。"""

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_event_capture.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_event_capture.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from negentropy.engine.claude_code.service import (
     _EVENT_FIELD_CAP,
-    _MAX_EVENTS_PER_ITER,
     _cap,
     _coerce_content,
     _emit_events,
@@ -237,13 +236,17 @@ async def test_emit_events_assigns_monotonic_seq_and_pairs_tool_use_result():
 
 
 async def test_emit_events_caps_at_max_with_sentinel():
+    """事件数达到 max_events_per_iter 后追加 _truncated 哨兵并停止捕获。"""
+    from negentropy.config import settings
+
+    cap = settings.routine.max_events_per_iter
     holder: list[dict] = []
     # 灌入远超上限的 assistant 文本事件
-    for i in range(_MAX_EVENTS_PER_ITER + 50):
+    for i in range(cap + 50):
         await _emit_events(
             {"type": "assistant", "message": {"content": [{"type": "text", "text": f"t{i}"}]}}, holder, None
         )
-    assert len(holder) <= _MAX_EVENTS_PER_ITER + 1  # 含一条 _truncated 哨兵
+    assert len(holder) <= cap + 1  # 含一条 _truncated 哨兵
     assert holder[-1]["event_type"] == "_truncated"
 
 


### PR DESCRIPTION
## 问题

Routine 迭代的 Full View 中，"Claude Code (1000)" 标签和步骤编号停在 #999（共 1000 步），之后的所有执行动作不可见。

## 根因

`service.py` 中的 **`_MAX_EVENTS_PER_ITER = 1000`** 硬编码常量截断了单迭代的动作事件捕获数。当 Claude Code 执行产生超过 1000 个事件（tool call、message 等）时，系统追加 `_truncated` 伪事件后停止捕获。

限制链路：
| 层级 | 限制 | 说明 |
|------|------|------|
| 事件捕获 | `_MAX_EVENTS_PER_ITER = 1000` | 硬编码 |
| API 查询 | `limit le=1000` | 与捕获对齐 |
| 前端拉取 | `limit=1000` | 与后端对齐 |

注意：此限制**仅影响 Full View 审计可见性**，不影响 Claude Code 进程本身的执行。

## 修复

将 `\_MAX_EVENTS_PER_ITER` 从硬编码常量提升为 **`RoutineSettings.max\_events\_per\_iter`** 配置项：

| 改动 | 文件 | 内容 |
|------|------|------|
| 新增配置字段 | `config/routine.py` | `max_events_per_iter: int = Field(default=5000, ge=100, le=100000)` |
| YAML 配置行 | `config.default.yaml` | `max_events_per_iter: 5000` |
| 移除硬编码 | `service.py` | 删除 `_MAX_EVENTS_PER_ITER`，从 `settings` 动态读取 |
| API 放大 | `routine_api.py` | `limit le` 从 1000 → 100000 |
| 前端同步 | `IterationAuditDrawer.tsx` | limit 从 1000 → 100000 |
| 前端同步 | `useRoutineDetailLive.ts` | `MAX_LIVE_ACTIONS` 从 1000 → 100000 |
| 测试适配 | `test_routine_event_capture.py` | 移除硬编码导入，使用 settings 实际值 |

## 验证

- [x] 23 个单测全部通过
- [x] pre-commit hooks（ruff lint/format、ESLint）全部通过
- [x] 向后兼容：新默认值 5000 比原 1000 大 5 倍，已有 Routine 不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>