### PR TITLE
feat(routine): 迭代内上下文压缩自愈，替代跨迭代冷启动 (#840)

### DIFF
--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -138,6 +138,27 @@ class RoutineSettings(BaseSettings):
         description="单次迭代内自动应答次数上限；防止 runaway（CC 反复问同样问题）。",
     )
 
+    # --- 上下文压缩（迭代内：提前触发 auto-compact + 迭代内重试续接）---
+    context_compact_enabled: bool = Field(
+        default=True,
+        description="启用迭代内上下文压缩：提前触发 CC auto-compact + 迭代内重试续接，"
+        "延长单次迭代寿命，减少跨迭代冷启动。",
+    )
+    context_compact_threshold_pct: int = Field(
+        default=70,
+        ge=20,
+        le=90,
+        description="注入 CLAUDE_AUTOCOMPACT_PCT_OVERRIDE 的百分比阈值。"
+        "值越小压缩越早越频繁，但留出更多 headroom。默认 70（即 context 达 70% 时触发压缩）。",
+    )
+    context_compact_max_retries: int = Field(
+        default=2,
+        ge=0,
+        le=5,
+        description="单次迭代内遇到 context_exhausted 时的最大重试次数。"
+        "每次重试在当前迭代内以新 session 续接。0=禁用迭代内重试，直接走跨迭代冷启动。",
+    )
+
     @classmethod
     def settings_customise_sources(
         cls,

--- a/apps/negentropy/src/negentropy/engine/claude_code/models.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/models.py
@@ -52,6 +52,10 @@ class ClaudeCodeConfig:
     # 供 LLM 生成与任务目标一致的确定性回答。
     auto_answer_context: dict[str, Any] | None = None
 
+    # 上下文压缩：注入 CLAUDE_AUTOCOMPACT_PCT_OVERRIDE 环境变量，控制 CC auto-compact 触发阈值。
+    # None = 使用 CLI 默认值（~83%）；整数（如 70）= context 达该百分比时触发压缩。
+    compact_threshold_pct: int | None = None
+
     # 注入子进程的真实 Anthropic 凭证（sk-ant-oat… 订阅 OAuth 令牌 / sk-ant-api… Console API Key）。
     # 由 credentials.resolve_claude_code_credential 解析，ClaudeCodeService 据此构建子进程 env。
     # repr=False / compare=False：secret 绝不入 repr（防日志、traceback 泄露），亦不参与相等比较。

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -198,7 +198,18 @@ def _normalize_stream_event(raw: dict[str, Any]) -> list[dict[str, Any]]:
             )
         ]
 
-    # system/* 其余非 init/api_retry（task_started / task_completed 等）
+    # system/compact_boundary：CC auto-compact 触发（上下文压缩边界）
+    if etype == _EVT_SYSTEM and raw.get("subtype") == "compact_boundary":
+        meta = raw.get("compact_metadata", {})
+        return [
+            _evt(
+                "system_compact",
+                {"trigger": meta.get("trigger"), "pre_tokens": meta.get("pre_tokens")},
+                title=f"context compact ({meta.get('trigger', 'unknown')})",
+            )
+        ]
+
+    # system/* 其余非 init/api_retry/compact_boundary（task_started / task_completed 等）
     if etype == _EVT_SYSTEM:
         subtype = raw.get("subtype") or "unknown"
         return [_evt("system", {"raw": _cap_json(raw)}, title=subtype)]
@@ -375,10 +386,16 @@ class ClaudeCodeService:
         }
 
     @staticmethod
-    def _build_subprocess_env(credential: str | None) -> dict[str, str]:
+    def _build_subprocess_env(
+        credential: str | None,
+        *,
+        compact_threshold_pct: int | None = None,
+    ) -> dict[str, str]:
         """构建子进程环境：``os.environ`` 副本叠加凭证覆盖（不就地修改 ``os.environ``）。
 
         无凭证时返回纯继承副本，功能等价于不传 ``env=``，故不破坏交互式 / 开发 / 终端场景。
+        ``compact_threshold_pct`` 注入 ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`` 控制 CC auto-compact
+        触发时机（值越小压缩越早，预留更多 headroom；None=使用 CLI 默认值）。
         """
         env = os.environ.copy()
         for key, value in ClaudeCodeService._credential_env(credential).items():
@@ -386,6 +403,8 @@ class ClaudeCodeService:
                 env.pop(key, None)
             else:
                 env[key] = value
+        if compact_threshold_pct is not None:
+            env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] = str(compact_threshold_pct)
         return env
 
     # ------------------------------------------------------------------
@@ -662,6 +681,7 @@ class ClaudeCodeService:
             mcp_config=config.mcp_config,
             resume_session_id=config.resume_session_id,
             credential=config.credential,  # 必须透传：否则注入凭证在此重建处被静默丢弃 → 退回 401
+            compact_threshold_pct=config.compact_threshold_pct,
         )
 
         args = ClaudeCodeService._build_cli_args(prompt, config)
@@ -674,7 +694,9 @@ class ClaudeCodeService:
                 stderr=asyncio.subprocess.PIPE,
                 cwd=config.cwd,
                 # 注入真实 Anthropic 凭证到子进程环境（根因修复）。无凭证时等价继承父环境。
-                env=ClaudeCodeService._build_subprocess_env(config.credential),
+                env=ClaudeCodeService._build_subprocess_env(
+                    config.credential, compact_threshold_pct=config.compact_threshold_pct
+                ),
                 limit=_STREAM_READER_LIMIT,  # 抬高 StreamReader 缓冲（兜底；主防线为手动分块读取）
             )
         except FileNotFoundError:
@@ -1004,6 +1026,7 @@ class ClaudeCodeService:
             credential=config.credential,
             interactive=config.interactive,
             auto_answer_context=config.auto_answer_context,
+            compact_threshold_pct=config.compact_threshold_pct,
         )
 
         args = ClaudeCodeService._build_cli_args(prompt, config)
@@ -1015,7 +1038,9 @@ class ClaudeCodeService:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=config.cwd,
-                env=ClaudeCodeService._build_subprocess_env(config.credential),
+                env=ClaudeCodeService._build_subprocess_env(
+                    config.credential, compact_threshold_pct=config.compact_threshold_pct
+                ),
                 limit=_STREAM_READER_LIMIT,
             )
         except FileNotFoundError:

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -569,6 +569,9 @@ class RoutineOrchestrator:
         if overrides.get("timeout_seconds"):
             config.timeout_seconds = float(overrides["timeout_seconds"])
         config.resume_session_id = routine.claude_session_id
+        # 上下文压缩：注入 auto-compact 阈值，提前触发 CC 内置压缩，延长单次迭代寿命。
+        if settings.routine.context_compact_enabled:
+            config.compact_threshold_pct = settings.routine.context_compact_threshold_pct
         # 启用交互模式：Engine 自动应答 AskUserQuestion，使 CC 继续执行而非失败退出。
         if settings.routine.auto_answer_questions:
             config.interactive = True

--- a/apps/negentropy/src/negentropy/engine/routine/runner.py
+++ b/apps/negentropy/src/negentropy/engine/routine/runner.py
@@ -19,6 +19,8 @@ B 进程的 reaper 可能误判 A 进程仍在执行的迭代为孤儿——``is
 from __future__ import annotations
 
 import asyncio
+import copy
+import time
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -42,6 +44,50 @@ logger = get_logger("negentropy.engine.routine.runner")
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# 迭代内上下文压缩续接辅助函数
+# ---------------------------------------------------------------------------
+
+_COMPACT_RETRY_PROMPT_TEMPLATE = (
+    "# 上下文续接 (Context Continuation)\n\n"
+    "上一次 Claude Code 会话因上下文窗口耗尽被自动压缩重启。\n"
+    "以下是压缩前的执行摘要，请据此继续推进任务。\n\n"
+    "## 原始任务\n{original_prompt}\n\n"
+    "## 已完成的工作摘要\n{summary}\n\n"
+    "## 指令\n"
+    "请从上述摘要断点继续工作，聚焦尚未完成的验收标准项。"
+    "不要重复已完成的工作。所有文件变更已持久化在当前工作目录中。"
+)
+
+
+def _build_compact_retry_prompt(result, original_prompt: str) -> str:
+    """构建上下文耗尽后的迭代内续接 prompt。
+
+    将原始任务 prompt + CC 返回的执行摘要合成为续接 prompt，
+    使新 CC 会话能在无历史上下文的情况下从断点继续工作。
+    """
+    summary = (result.summary or "")[:2000]
+    return _COMPACT_RETRY_PROMPT_TEMPLATE.format(original_prompt=original_prompt, summary=summary)
+
+
+def _reset_config_for_retry(config: ClaudeCodeConfig) -> ClaudeCodeConfig:
+    """克隆配置但清空 session 续接，强制 CC 以新会话启动。
+
+    使用 ``copy.copy`` 浅拷贝：ClaudeCodeConfig 的字段均为不可变类型或
+    由调用方自行管理的容器（``allowed_tools`` 等），浅拷贝语义安全。
+    """
+    new = copy.copy(config)
+    new.resume_session_id = None  # 强制新会话
+    return new
+
+
+def _with_reduced_timeout(config: ClaudeCodeConfig, remaining_seconds: float) -> ClaudeCodeConfig:
+    """克隆配置并设置剩余超时时间（下限 60s 防无意义短命重试）。"""
+    new = copy.copy(config)
+    new.timeout_seconds = max(60.0, remaining_seconds)
+    return new
 
 
 class RoutineRunner:
@@ -133,6 +179,8 @@ class RoutineRunner:
             # 2) 执行 Claude Code（长耗时，受 config.timeout_seconds 约束）
             #    capture_events 开启时附 on_event sink：每个动作经非阻塞总线实时发布（边跑边看）。
             #    StreamingEventPersister 增量 flush：使页面 reload 后仍可见已完成的审计步骤。
+            #    迭代内上下文压缩重试：当 CC context 耗尽时，不清空迭代、在同迭代内以新 session 续接，
+            #    通过续接 prompt 传递已完成工作摘要，使任务在当前迭代内继续推进。
             persister: StreamingEventPersister | None = None
             if settings.routine.capture_events:
                 persister = StreamingEventPersister(
@@ -142,11 +190,64 @@ class RoutineRunner:
             sink = (
                 self._make_action_sink(iteration_id, routine_id, persister) if settings.routine.capture_events else None
             )
+
+            compact_max_retries = (
+                settings.routine.context_compact_max_retries if settings.routine.context_compact_enabled else 0
+            )
+            compact_retry_count = 0
+            cumulative_cost = 0.0
+            cumulative_turns = 0
+            overall_deadline = time.monotonic() + config.timeout_seconds
+            result = None
+
             try:
-                result = await ClaudeCodeService.invoke(prompt, config, abort_event=abort, on_event=sink)
+                while True:
+                    # 重试时检查剩余时间是否足够（至少 60s，防无意义短命重试）
+                    remaining = overall_deadline - time.monotonic()
+                    if remaining < 60 and compact_retry_count > 0:
+                        logger.warning("routine_compact_retry_timeout_exhausted", remaining_s=round(remaining, 1))
+                        break
+
+                    invoke_config = config if compact_retry_count == 0 else _with_reduced_timeout(config, remaining)
+                    result = await ClaudeCodeService.invoke(prompt, invoke_config, abort_event=abort, on_event=sink)
+                    cumulative_cost += result.cost_usd or 0.0
+                    cumulative_turns += result.turn_count or 0
+
+                    # 成功或非上下文耗尽错误：直接退出循环
+                    if (
+                        result.status == "success"
+                        or getattr(result, "error_kind", None) != ERROR_KIND_CONTEXT_EXHAUSTED
+                    ):
+                        break
+
+                    # 上下文耗尽但重试次数已用尽：退出循环（回退到 Layer 3 跨迭代冷启动）
+                    if compact_retry_count >= compact_max_retries:
+                        logger.info(
+                            "routine_compact_retries_exhausted",
+                            retries=compact_retry_count,
+                            max_retries=compact_max_retries,
+                        )
+                        break
+
+                    # 迭代内重试：清空 session（强制新会话）+ 构建续接 prompt
+                    compact_retry_count += 1
+                    logger.info(
+                        "routine_compact_retry",
+                        iteration_id=str(iteration_id),
+                        retry=compact_retry_count,
+                        max_retries=compact_max_retries,
+                        previous_session=result.session_id,
+                    )
+                    prompt = _build_compact_retry_prompt(result, prompt)
+                    config = _reset_config_for_retry(config)
             finally:
                 if persister is not None:
                     await persister.finalize()
+
+            # 累积 cost/turns 覆盖到最终 result（跨重试汇总）
+            if result is not None:
+                result.cost_usd = cumulative_cost
+                result.turn_count = cumulative_turns
 
             # 3) 写回结果（abort 命中则标记 aborted，否则 executed）
             if abort.is_set():
@@ -156,7 +257,7 @@ class RoutineRunner:
                 )
                 return
 
-            await self._write_back(iteration_id, routine_id, result)
+            await self._write_back(iteration_id, routine_id, result, compact_retry_count=compact_retry_count)
             await get_bus().publish(
                 {
                     "type": "iteration",
@@ -210,14 +311,31 @@ class RoutineRunner:
             )
             await db.commit()
 
-    async def _write_back(self, iteration_id: UUID, routine_id: UUID, result) -> None:
+    async def _write_back(
+        self,
+        iteration_id: UUID,
+        routine_id: UUID,
+        result,
+        *,
+        compact_retry_count: int = 0,
+    ) -> None:
         """原子写回执行结果 + 更新父 routine 反规范化累计。
 
         用 ``asyncio.shield`` 包裹，避免关停取消时丢失已完成的 Claude Code 结果。
+        ``compact_retry_count`` 记录迭代内上下文压缩重试次数，写入 iteration metrics。
         """
-        await asyncio.shield(self._do_write_back(iteration_id, routine_id, result))
+        await asyncio.shield(
+            self._do_write_back(iteration_id, routine_id, result, compact_retry_count=compact_retry_count)
+        )
 
-    async def _do_write_back(self, iteration_id: UUID, routine_id: UUID, result) -> None:
+    async def _do_write_back(
+        self,
+        iteration_id: UUID,
+        routine_id: UUID,
+        result,
+        *,
+        compact_retry_count: int = 0,
+    ) -> None:
         exec_status = "success" if result.status == "success" else result.status  # success|error|timeout
         async with db_session.AsyncSessionLocal() as db:
             # 仅当迭代仍处于 in_flight 时才翻转为 executed：若期间已被 reaper 标记 reaped
@@ -264,10 +382,16 @@ class RoutineRunner:
                         routine.claude_session_id = result.session_id
                 # 给 iteration 打 context_exhausted 标记：供 decision 将"可自愈失败"从连续失败计数剔除，
                 # 避免被误判为 unrecoverable（runaway 由 routine.reflections._context_resets 上限兜底）。
-                if is_ctx:
+                # 同时记录迭代内压缩重试次数（compact_retries > 0 表示迭代内发生了续接）。
+                if is_ctx or compact_retry_count > 0:
                     it = await db.get(RoutineIteration, iteration_id)
                     if it is not None:
-                        it.metrics = {**(it.metrics or {}), "context_exhausted": True}
+                        metrics = {**(it.metrics or {})}
+                        if is_ctx:
+                            metrics["context_exhausted"] = True
+                        if compact_retry_count > 0:
+                            metrics["compact_retries"] = compact_retry_count
+                        it.metrics = metrics
             # 「全过程」动作事件持久化（reconciliation backstop）：
             # 不再受 rowcount==1 门控——即使迭代已被 reaper 标记 reaped，仍确保事件落库
             # （StreamingEventPersister 已增量刷入部分事件，此处补齐尾部 + 终态事件）。

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -437,6 +437,90 @@ async def test_classify_non_string_result_payload():
     assert _classify_result_error(evt, 1) == ERROR_KIND_CONTEXT_EXHAUSTED
 
 
+# ---------------------------------------------------------------------------
+# 上下文压缩：CLAUDE_AUTOCOMPACT_PCT_OVERRIDE 环境变量注入（Layer 1 — 预防）
+# ---------------------------------------------------------------------------
+
+
+async def test_build_subprocess_env_injects_autocompact_threshold(monkeypatch):
+    """compact_threshold_pct 非空时注入 CLAUDE_AUTOCOMPACT_PCT_OVERRIDE。"""
+    monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+    env = ClaudeCodeService._build_subprocess_env(None, compact_threshold_pct=70)
+    assert env.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE") == "70"
+
+
+async def test_build_subprocess_env_skips_autocompact_when_none(monkeypatch):
+    """compact_threshold_pct=None 时不注入环境变量（使用 CLI 默认值）。"""
+    monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+    env = ClaudeCodeService._build_subprocess_env(None, compact_threshold_pct=None)
+    assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" not in env
+
+
+async def test_build_subprocess_env_autocompact_coexists_with_credential(monkeypatch):
+    """compact_threshold_pct 与凭证注入互不干扰。"""
+    monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+    env = ClaudeCodeService._build_subprocess_env("sk-ant-api03-testkey", compact_threshold_pct=50)
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant-api03-testkey"
+    assert env["CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"] == "50"
+
+
+# ---------------------------------------------------------------------------
+# compact_boundary 事件归一化（审计增强）
+# ---------------------------------------------------------------------------
+
+
+def _normalize(raw: dict) -> list[dict]:
+    """便利包装：调用 _normalize_stream_event 并返回结果。"""
+    from negentropy.engine.claude_code.service import _normalize_stream_event
+
+    return _normalize_stream_event(raw)
+
+
+def test_normalize_compact_boundary_event():
+    """CC auto-compact 触发时的 compact_boundary 事件被正确归一化为 system_compact。"""
+    raw = {
+        "type": "system",
+        "subtype": "compact_boundary",
+        "compact_metadata": {"trigger": "auto", "pre_tokens": 150000},
+    }
+    events = _normalize(raw)
+    assert len(events) == 1
+    evt = events[0]
+    assert evt["event_type"] == "system_compact"
+    assert evt["title"] == "context compact (auto)"
+    assert evt["payload"]["trigger"] == "auto"
+    assert evt["payload"]["pre_tokens"] == 150000
+
+
+def test_normalize_compact_boundary_manual_trigger():
+    """手动 /compact 触发的 compact_boundary 事件。"""
+    raw = {
+        "type": "system",
+        "subtype": "compact_boundary",
+        "compact_metadata": {"trigger": "manual"},
+    }
+    events = _normalize(raw)
+    assert events[0]["title"] == "context compact (manual)"
+
+
+def test_normalize_compact_boundary_without_metadata():
+    """compact_boundary 事件缺少 compact_metadata 时不报错。"""
+    raw = {"type": "system", "subtype": "compact_boundary"}
+    events = _normalize(raw)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "system_compact"
+    assert events[0]["payload"]["trigger"] is None
+
+
+def test_normalize_system_other_not_affected_by_compact():
+    """非 compact_boundary 的 system/* 事件仍走原有 catch-all 路径。"""
+    raw = {"type": "system", "subtype": "task_started"}
+    events = _normalize(raw)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "system"
+    assert events[0]["title"] == "task_started"
+
+
 class _FakeProcWithEvents:
     """模拟非交互 claude 子进程：吐预置 stream-json 事件后 EOF，returncode 可控。"""
 

--- a/apps/negentropy/tests/unit_tests/engine/test_runner_compact_retry.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_runner_compact_retry.py
@@ -1,0 +1,250 @@
+"""Runner 迭代内上下文压缩重试逻辑的单测。
+
+覆盖辅助函数和重试循环的核心判定路径：
+- ``_build_compact_retry_prompt``：续接 prompt 合成
+- ``_reset_config_for_retry``：配置克隆 + session 清空
+- ``_with_reduced_timeout``：超时缩减 + 下限守卫
+- 重试循环的 5 种退出条件
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from negentropy.engine.claude_code.models import ClaudeCodeConfig, ClaudeCodeResult
+from negentropy.engine.routine.runner import (
+    _build_compact_retry_prompt,
+    _reset_config_for_retry,
+    _with_reduced_timeout,
+)
+
+# ---------------------------------------------------------------------------
+# 辅助函数单测
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCompactRetryPrompt:
+    """续接 prompt 合成测试。"""
+
+    def test_includes_original_prompt_and_summary(self):
+        result = ClaudeCodeResult(status="error", summary="已创建 hello.py", error_kind="context_exhausted")
+        prompt = _build_compact_retry_prompt(result, "请创建 hello.py 输出 Hello World")
+
+        assert "请创建 hello.py 输出 Hello World" in prompt
+        assert "已创建 hello.py" in prompt
+        assert "上下文续接" in prompt
+
+    def test_empty_summary_uses_empty_string(self):
+        result = ClaudeCodeResult(status="error", summary="", error_kind="context_exhausted")
+        prompt = _build_compact_retry_prompt(result, "原始任务")
+
+        assert "原始任务" in prompt
+        # 空 summary 不导致格式异常
+        assert "## 已完成的工作摘要\n\n" in prompt
+
+    def test_none_summary_handled(self):
+        result = ClaudeCodeResult(status="error", summary=None, error_kind="context_exhausted")
+        prompt = _build_compact_retry_prompt(result, "原始任务")
+        assert "原始任务" in prompt
+
+    def test_long_summary_truncated_to_2000_chars(self):
+        result = ClaudeCodeResult(status="error", summary="x" * 5000, error_kind="context_exhausted")
+        prompt = _build_compact_retry_prompt(result, "任务")
+        # summary 被截断到 2000 字符
+        summary_section = prompt.split("## 已完成的工作摘要\n")[1].split("\n\n## 指令")[0]
+        assert len(summary_section) == 2000
+
+
+class TestResetConfigForRetry:
+    """配置克隆 + session 清空测试。"""
+
+    def test_clears_resume_session_id(self):
+        cfg = ClaudeCodeConfig(resume_session_id="old-session-123", cwd="/tmp/test")
+        new = _reset_config_for_retry(cfg)
+
+        assert new.resume_session_id is None
+        assert new.cwd == "/tmp/test"  # 其他字段保留
+
+    def test_original_config_not_mutated(self):
+        cfg = ClaudeCodeConfig(resume_session_id="old-session-123")
+        _reset_config_for_retry(cfg)
+
+        assert cfg.resume_session_id == "old-session-123"  # 原始不被修改
+
+    def test_preserves_all_other_fields(self):
+        cfg = ClaudeCodeConfig(
+            cli_path="/usr/bin/claude",
+            model="claude-opus-4-8",
+            max_turns=500,
+            timeout_seconds=900.0,
+            credential="secret-token",
+            compact_threshold_pct=70,
+            resume_session_id="session-to-clear",
+        )
+        new = _reset_config_for_retry(cfg)
+
+        assert new.cli_path == "/usr/bin/claude"
+        assert new.model == "claude-opus-4-8"
+        assert new.max_turns == 500
+        assert new.timeout_seconds == 900.0
+        assert new.credential == "secret-token"
+        assert new.compact_threshold_pct == 70
+        assert new.resume_session_id is None
+
+
+class TestWithReducedTimeout:
+    """超时缩减测试。"""
+
+    def test_sets_timeout_to_remaining(self):
+        cfg = ClaudeCodeConfig(timeout_seconds=900.0)
+        new = _with_reduced_timeout(cfg, 300.0)
+
+        assert new.timeout_seconds == 300.0
+
+    def test_minimum_timeout_is_60_seconds(self):
+        cfg = ClaudeCodeConfig(timeout_seconds=900.0)
+        new = _with_reduced_timeout(cfg, 30.0)
+
+        assert new.timeout_seconds == 60.0  # 下限
+
+    def test_preserves_other_fields(self):
+        cfg = ClaudeCodeConfig(
+            timeout_seconds=900.0,
+            resume_session_id="session-id",
+            compact_threshold_pct=70,
+        )
+        new = _with_reduced_timeout(cfg, 120.0)
+
+        assert new.resume_session_id == "session-id"
+        assert new.compact_threshold_pct == 70
+        assert new.timeout_seconds == 120.0
+
+    def test_original_config_not_mutated(self):
+        cfg = ClaudeCodeConfig(timeout_seconds=900.0)
+        _with_reduced_timeout(cfg, 100.0)
+
+        assert cfg.timeout_seconds == 900.0
+
+
+# ---------------------------------------------------------------------------
+# 重试循环逻辑的判定条件测试（通过模拟 _run 内的 while 循环逻辑验证）
+# ---------------------------------------------------------------------------
+
+
+class TestRetryLoopConditions:
+    """验证重试循环的 5 种退出条件（在 _run 方法的 while True 中）。
+
+    这些测试直接验证判定条件逻辑，不启动真实 Runner（避免 DB 依赖）。
+    """
+
+    def test_success_exits_without_retry(self):
+        """条件 1：result.status == "success" → 不重试，直接退出。"""
+        result = ClaudeCodeResult(status="success", summary="done")
+        should_exit = result.status == "success"
+        assert should_exit is True
+
+    def test_non_context_error_exits_without_retry(self):
+        """条件 2：error_kind != context_exhausted → 不重试，直接退出。"""
+        result = ClaudeCodeResult(status="error", summary="", error="file not found", error_kind=None)
+        should_exit = result.status != "success" and getattr(result, "error_kind", None) != "context_exhausted"
+        # error_kind=None → 不等于 context_exhausted → 退出
+        assert should_exit is True
+
+    def test_context_exhausted_with_retries_remaining_triggers_retry(self):
+        """条件 3：context_exhausted 且 retries < max → 应触发重试。"""
+        from negentropy.engine.claude_code.service import ERROR_KIND_CONTEXT_EXHAUSTED
+
+        result = ClaudeCodeResult(
+            status="error",
+            summary="部分完成",
+            error="CLI exited with code 1",
+            error_kind=ERROR_KIND_CONTEXT_EXHAUSTED,
+        )
+        compact_retry_count = 0
+        compact_max_retries = 2
+
+        should_exit = result.status == "success"
+        is_ctx = getattr(result, "error_kind", None) == ERROR_KIND_CONTEXT_EXHAUSTED
+        if not should_exit and is_ctx:
+            should_exit = compact_retry_count >= compact_max_retries
+
+        assert should_exit is False  # 0 < 2，不退出，继续重试
+
+    def test_context_exhausted_retries_exhausted_exits(self):
+        """条件 4：context_exhausted 且 retries >= max → 退出（回退到 Layer 3）。"""
+        from negentropy.engine.claude_code.service import ERROR_KIND_CONTEXT_EXHAUSTED
+
+        result = ClaudeCodeResult(
+            status="error",
+            summary="",
+            error_kind=ERROR_KIND_CONTEXT_EXHAUSTED,
+        )
+        compact_retry_count = 2
+        compact_max_retries = 2
+
+        should_exit = result.status == "success"
+        is_ctx = getattr(result, "error_kind", None) == ERROR_KIND_CONTEXT_EXHAUSTED
+        if not should_exit and is_ctx:
+            should_exit = compact_retry_count >= compact_max_retries
+
+        assert should_exit is True  # 2 >= 2，退出
+
+    def test_timeout_remaining_less_than_60s_on_retry_exits(self):
+        """条件 5：剩余时间 < 60s 且已在重试中 → 退出（无意义短命重试）。"""
+        remaining = 45.0
+        compact_retry_count = 1  # 已在重试中
+
+        should_exit = remaining < 60 and compact_retry_count > 0
+        assert should_exit is True
+
+    def test_timeout_remaining_sufficient_does_not_exit(self):
+        """剩余时间 >= 60s → 不因此退出。"""
+        remaining = 120.0
+        compact_retry_count = 1
+
+        should_exit = remaining < 60 and compact_retry_count > 0
+        assert should_exit is False
+
+    def test_first_attempt_ignores_timeout_check(self):
+        """首次调用（compact_retry_count=0）不受剩余时间检查限制。"""
+        remaining = 30.0
+        compact_retry_count = 0  # 首次
+
+        should_exit = remaining < 60 and compact_retry_count > 0
+        assert should_exit is False  # 首次不受此约束
+
+    def test_compact_disabled_means_zero_retries(self):
+        """context_compact_enabled=False → compact_max_retries=0 → 不重试。"""
+        context_compact_enabled = False
+        context_compact_max_retries = 2  # 配置值被忽略
+
+        compact_max_retries = context_compact_max_retries if context_compact_enabled else 0
+        assert compact_max_retries == 0
+
+
+class TestCumulativeCostTracking:
+    """验证跨重试的 cost/turns 累积逻辑。"""
+
+    def test_accumulates_cost_across_retries(self):
+        results = [
+            ClaudeCodeResult(status="error", summary="", cost_usd=0.5, turn_count=10, error_kind="context_exhausted"),
+            ClaudeCodeResult(status="success", summary="done", cost_usd=0.3, turn_count=5),
+        ]
+        cumulative_cost = 0.0
+        cumulative_turns = 0
+        for r in results:
+            cumulative_cost += r.cost_usd or 0.0
+            cumulative_turns += r.turn_count or 0
+
+        assert cumulative_cost == pytest.approx(0.8)
+        assert cumulative_turns == 15
+
+    def test_handles_none_cost_gracefully(self):
+        result = ClaudeCodeResult(status="error", summary="", cost_usd=None, turn_count=None)
+        cumulative_cost = 0.0
+        cumulative_turns = 0
+        cumulative_cost += result.cost_usd or 0.0
+        cumulative_turns += result.turn_count or 0
+
+        assert cumulative_cost == 0.0
+        assert cumulative_turns == 0


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 任务执行中，当 Claude Code 的 context window 达到模型限制时，CLI 子进程以 exit code 1 退出，当前迭代被标记为异常终止，需要通过下一轮迭代冷启动自愈衔接。这导致已完成的工作被浪费，且每轮 context exhaustion 消耗一次 `context_reset_max` 额度。
- 关联上下文：Routine 长周期自主任务子系统 [[project_routine_system]](/.claude/projects/-Users-cm-huang-Documents-projects-aurelius-negentropy/memory/project_routine_system.md)；CC 会话上下文耗尽死亡螺旋修复 [[project_routine_context_exhaustion_self_heal]](/.claude/projects/-Users-cm-huang-Documents-projects-aurelius-negentropy/memory/project_routine_context_exhaustion_self_heal.md)

# 核心变更

采用三层纵深防御架构，在 context window 耗尽时优先在迭代内自愈，而非跨迭代冷启动：

**Layer 1 — 预防（环境变量注入）**：向 CC 子进程注入 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` 环境变量（默认 70%），提前触发 CC 内置 auto-compact 机制，预留更多 headroom。零侵入，利用 CC 自身能力。

**Layer 2 — 反应（迭代内重试续接）**：当 Layer 1 仍无法阻止 context exhaustion 时，在 Runner `_run()` 方法内发起同迭代重试——清空 `resume_session_id`（强制新 session），保持同 `cwd`（worktree 持久化文件变更），注入"上下文续接 prompt"传递已完成工作摘要。成本和轮次跨重试累积，总超时由 lease 兜底。

**Layer 3 — 兜底（现有跨迭代冷启动）**：Layer 1+2 均失败时回退到现有行为——迭代以 `error_kind=context_exhausted` 结束，Runner 清空 session，下一迭代冷启动。此层未改动。

**审计增强**：新增 `compact_boundary` 事件归一化（`system_compact` 事件类型），提供压缩可观测性；迭代 metrics 新增 `compact_retries` 字段。

**新增配置**（`RoutineSettings`，支持 YAML/env/per-routine 覆盖）：
- `context_compact_enabled`：总开关（默认 `true`）
- `context_compact_threshold_pct`：auto-compact 触发百分比（默认 `70`，范围 20-90）
- `context_compact_max_retries`：迭代内最大重试次数（默认 `2`，范围 0-5）

# 风险与回滚
- 主要风险：迭代内重试可能导致总执行时间接近 lease 上限（`timeout + 60s`），极端情况下 reaper 可能介入。重试使用剩余时间（下限 60s）缓解此风险。
- 回滚方式：设置 `context_compact_enabled: false` 即可完全回退到原行为（零代码改动）；`context_compact_max_retries: 0` 仅禁用迭代内重试但保留提前 compact。

# 验证证据
- 单元测试：54 个测试用例全部通过
  - `test_claude_code_service.py`：新增 7 个测试（环境变量注入 3 个 + compact_boundary 事件 4 个）
  - `test_runner_compact_retry.py`：新增 21 个测试（辅助函数 11 个 + 重试循环条件 8 个 + cost 累积 2 个）
- 集成测试：待实机验证（需长时间运行的 Routine 任务触发 context exhaustion）
- E2E/Workflow：待浏览器验证（观察 `system_compact` 审计事件和 `compact_retries` 指标）
- 覆盖率/关键截图：所有 pre-commit hooks（ruff lint + ruff format）通过

# 影响范围
- 前端：无直接影响；迭代详情页可展示新增的 `system_compact` 审计事件和 `compact_retries` 指标
- 后端：`config/routine.py`、`claude_code/service.py`、`claude_code/models.py`、`routine/runner.py`、`routine/orchestrator.py` 共 5 个模块
- GitHub Actions / 文档：无 CI 变更；Routine 系统设计文档可补充上下文压缩描述

# Next Best Action
- 创建一个会快速消耗 context 的 Routine 测试任务，实机验证三层防御的完整链路
- 在 Routine 详情页前端展示 `system_compact` 审计事件（类似 `system_retry` 的样式）
- 补充 Routine 系统设计文档中关于上下文压缩机制的描述