### PR TITLE
feat(routine): 对话式 Turn 展示 & NegentropyEngine Plan 自动审阅

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronRight, type LucideIcon } from "lucide-react";
+import { Bot, ChevronRight, Cpu, type LucideIcon } from "lucide-react";
 
+import { cn } from "@/lib/utils";
 import { JsonViewer } from "@/components/ui/JsonViewer";
-import { AGENT_ROLE_META, deriveAgentRole, type AgentRole } from "@/features/routine";
-import type { RoutineIterationEventDTO } from "@/features/routine";
+import {
+  AGENT_ROLE_META,
+  deriveAgentRole,
+  type PlanReviewPayload,
+  type RoutineIterationEventDTO,
+} from "@/features/routine";
 
 import {
   EVENT_GROUP_LABEL,
@@ -107,25 +112,61 @@ function EventIcon({ icon: Icon, className }: { icon: LucideIcon; className?: st
   return <Icon className={className} aria-hidden />;
 }
 
-/** 主导人徽章 —— 分组标题右侧小 pill，显示步骤的执行者归属。 */
-function AgentRoleBadge({ role }: { role: AgentRole }) {
-  const meta = AGENT_ROLE_META[role];
-  const Icon = meta.icon;
-  return (
-    <span className={`ml-auto inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${meta.badgeClass}`}>
-      <Icon className="h-3 w-3" aria-hidden />
-      {meta.label}
-    </span>
-  );
+// ---------------------------------------------------------------------------
+// 对话式布局：按 Agent 角色左右分列
+// ---------------------------------------------------------------------------
+
+/** 对话块：一个可独立渲染的对话单元，由 Agent 角色决定对齐方向。 */
+type ConversationBlock =
+  | { kind: "turn"; turn: EventTurn; defaultExpanded: boolean }
+  | { kind: "plan_review"; event: RoutineIterationEventDTO }
+  | { kind: "system_event"; event: RoutineIterationEventDTO; label: string };
+
+/** 将所有事件编排为对话块序列。 */
+function buildConversationBlocks(
+  groups: Record<EventGroup, RoutineIterationEventDTO[]>,
+  execTurns: EventTurn[],
+): ConversationBlock[] {
+  const blocks: ConversationBlock[] = [];
+  const order: EventGroup[] = ["execution", "plan_review", "result", "gate", "evaluation"];
+
+  for (const g of order) {
+    const list = groups[g];
+    if (!list || list.length === 0) continue;
+
+    if (g === "execution") {
+      for (let i = 0; i < execTurns.length; i++) {
+        const turn = execTurns[i];
+        blocks.push({
+          kind: "turn",
+          turn,
+          defaultExpanded: isTurnDefaultExpanded(turn, i, execTurns.length),
+        });
+      }
+    } else if (g === "plan_review") {
+      for (const ev of list) {
+        blocks.push({ kind: "plan_review", event: ev });
+      }
+    } else {
+      // result / gate / evaluation → 系统通知
+      for (const ev of list) {
+        blocks.push({ kind: "system_event", event: ev, label: EVENT_GROUP_LABEL[g] });
+      }
+    }
+  }
+
+  return blocks;
 }
 
+// ---------------------------------------------------------------------------
+// 主组件
+// ---------------------------------------------------------------------------
+
 /**
- * 单次迭代「全过程」动作时间线 —— 纵向、单列、可扫读（LangSmith / Langfuse run 视图范式）。
+ * 单次迭代「全过程」动作时间线 —— 对话式布局。
  *
- * 每个动作：左侧类型图标（颜色 + 图标双编码）+ 单行标题 + 可点击展开输入/输出/上下文。
- * 结构化 payload 用 JsonViewer（折叠树 + 复制），长文本/命令输出用 <pre> 保留换行与截断标记。
- * 动作按 执行(execution) → 结果(result) → 门控(gate) → 评估(evaluation) 分组。
- * 执行组内事件按 Turn（轮次）聚合，每个 Turn 可折叠展开。
+ * Claude Code 的 Turns 居左（被调用者），NegentropyEngine 的 Plan Review 居右（系统本我），
+ * 系统级事件（gate / evaluation / result）居中。
  */
 export function IterationEventTimeline({
   events,
@@ -137,60 +178,286 @@ export function IterationEventTimeline({
 }) {
   const groups = useMemo(() => groupEvents(events), [events]);
   const execTurns = useMemo(() => groupIntoTurns(groups.execution), [groups.execution]);
+  const blocks = useMemo(() => buildConversationBlocks(groups, execTurns), [groups, execTurns]);
 
   if (events.length === 0) {
-    return null; // 空态由抽屉统一渲染（区分待审批/已中止/capture 关闭等上下文）
+    return null; // 空态由抽屉统一渲染
   }
 
-  const order: EventGroup[] = ["execution", "result", "gate", "evaluation"];
-
   return (
-    <div className="space-y-5">
-      {order.map((g) => {
-        const list = groups[g];
-        if (!list || list.length === 0) return null;
-        return (
-          <section key={g}>
-            <div className="mb-2 flex items-center gap-2">
-              <h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {EVENT_GROUP_LABEL[g]}
-              </h4>
-              <span className="text-[10px] tabular-nums text-text-muted">{list.length}</span>
-              <AgentRoleBadge role={deriveAgentRole(list[0].event_type)} />
-              {live && g === "execution" && (
-                <span className="inline-flex items-center gap-1 text-[10px] font-medium text-sky-600 dark:text-sky-400">
-                  <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
-                  LIVE
-                </span>
-              )}
-            </div>
-            {g === "execution" && execTurns.length > 0 ? (
-              <ol className="relative space-y-1 border-l border-border pl-0">
-                {execTurns.map((turn, i) => (
-                  <TurnGroup
-                    key={turn.turnNumber}
-                    turn={turn}
-                    defaultExpanded={isTurnDefaultExpanded(turn, i, execTurns.length)}
-                  />
-                ))}
-              </ol>
-            ) : (
-              <ol className="relative space-y-1 border-l border-border pl-0">
-                {list.map((ev) => (
-                  <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
-                ))}
-              </ol>
-            )}
-          </section>
-        );
-      })}
+    <div className="space-y-3">
+      {/* 分组统计栏 */}
+      <div className="flex flex-wrap items-center gap-2">
+        {(["execution", "plan_review", "result", "gate", "evaluation"] as const).map((g) => {
+          const list = groups[g];
+          if (!list || list.length === 0) return null;
+          const role = deriveAgentRole(list[0].event_type);
+          const meta = AGENT_ROLE_META[role];
+          const Icon = meta.icon;
+          return (
+            <span key={g} className={`inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${meta.badgeClass}`}>
+              <Icon className="h-3 w-3" aria-hidden />
+              {EVENT_GROUP_LABEL[g]} ({list.length})
+            </span>
+          );
+        })}
+        {live && (
+          <span className="inline-flex items-center gap-1 text-[10px] font-medium text-sky-600 dark:text-sky-400">
+            <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
+            LIVE
+          </span>
+        )}
+      </div>
+
+      {/* 对话流 */}
+      <div className="space-y-2.5">
+        {blocks.map((block) => {
+          switch (block.kind) {
+            case "turn":
+              return (
+                <ClaudeCodeTurnBubble
+                  key={`turn-${block.turn.turnNumber}`}
+                  turn={block.turn}
+                  defaultExpanded={block.defaultExpanded}
+                />
+              );
+            case "plan_review":
+              return (
+                <EngineReviewBubble
+                  key={`review-${block.event.seq}`}
+                  ev={block.event}
+                />
+              );
+            case "system_event":
+              return (
+                <SystemEventPill
+                  key={`sys-${block.event.seq}`}
+                  ev={block.event}
+                  label={block.label}
+                />
+              );
+          }
+        })}
+      </div>
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// 对话气泡组件
+// ---------------------------------------------------------------------------
+
+/** Claude Code Turn 气泡（左侧）。 */
+function ClaudeCodeTurnBubble({
+  turn,
+  defaultExpanded,
+}: {
+  turn: EventTurn;
+  defaultExpanded: boolean;
+}) {
+  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
+  const expanded = manualExpanded ?? defaultExpanded;
+  const title = deriveTurnTitle(turn);
+
+  return (
+    <div className="flex gap-2.5 py-0.5">
+      {/* 左侧头像 */}
+      <div className="flex shrink-0 flex-col items-center pt-2">
+        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-violet-500/10">
+          <Bot className="h-3.5 w-3.5 text-violet-600 dark:text-violet-400" />
+        </div>
+      </div>
+      {/* 气泡内容 */}
+      <div
+        className={cn(
+          "min-w-0 max-w-[85%] rounded-2xl rounded-tl-sm border p-3 shadow-sm transition-colors",
+          turn.hasError
+            ? "border-red-500/30 bg-red-500/[0.03]"
+            : "border-border bg-card",
+        )}
+      >
+        {/* Header */}
+        <div className="mb-1.5 flex items-center gap-2">
+          <span className="text-[10px] font-semibold text-violet-600 dark:text-violet-400">
+            Claude Code
+          </span>
+          <span className="text-[10px] text-text-muted">Turn {turn.turnNumber}</span>
+          <span className="text-[10px] tabular-nums text-text-muted">{turn.events.length} events</span>
+          {turn.hasError && (
+            <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-red-600 dark:text-red-400">
+              error
+            </span>
+          )}
+        </div>
+        {/* Turn 标题（可折叠） */}
+        <button
+          type="button"
+          onClick={() => setManualExpanded((v) => !(v ?? defaultExpanded))}
+          aria-expanded={expanded}
+          className="flex w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-muted/30"
+        >
+          <ChevronRight
+            className={cn("h-3 w-3 shrink-0 text-text-muted transition-transform", expanded && "rotate-90")}
+            aria-hidden
+          />
+          <span className="min-w-0 flex-1 truncate text-xs text-foreground" title={title}>
+            {title}
+          </span>
+        </button>
+        {/* 展开后的事件列表 */}
+        {expanded && (
+          <ol className="mt-2 space-y-1 border-l border-border pl-3">
+            {turn.events.map((ev) => (
+              <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** NegentropyEngine Plan Review 气泡（右侧）。 */
+function EngineReviewBubble({ ev }: { ev: RoutineIterationEventDTO }) {
+  const [expanded, setExpanded] = useState(false);
+  const payload = ev.payload as unknown as PlanReviewPayload;
+  const verdict = payload?.verdict;
+  const score = payload?.score;
+  const moduleReviews = payload?.module_reviews;
+  const feedback = payload?.feedback;
+  const reflection = payload?.reflection;
+
+  const verdictConfig: Record<string, { label: string; cls: string }> = {
+    approve: { label: "✅ Approved", cls: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" },
+    refine: { label: "🔄 Refine", cls: "bg-amber-500/10 text-amber-700 dark:text-amber-300" },
+  };
+  const vc = verdictConfig[verdict ?? ""] ?? { label: verdict ?? "Review", cls: "bg-muted/60 text-text-secondary" };
+
+  return (
+    <div className="flex flex-row-reverse gap-2.5 py-0.5">
+      {/* 右侧头像 */}
+      <div className="flex shrink-0 flex-col items-center pt-2">
+        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-sky-500/10">
+          <Cpu className="h-3.5 w-3.5 text-sky-600 dark:text-sky-400" />
+        </div>
+      </div>
+      {/* 气泡内容 */}
+      <div className="min-w-0 max-w-[85%] rounded-2xl rounded-tr-sm border border-sky-500/20 bg-sky-500/[0.03] p-3">
+        {/* Header */}
+        <div className="mb-1.5 flex items-center gap-2">
+          <span className="text-[10px] font-semibold text-sky-600 dark:text-sky-400">
+            NegentropyEngine
+          </span>
+          <span className="text-[10px] text-text-muted">Plan Review</span>
+          <span className={cn("rounded-full px-1.5 py-0.5 text-[9px] font-bold", vc.cls)}>
+            {vc.label}
+          </span>
+          {score != null && (
+            <span className={cn("text-xs font-bold tabular-nums", score >= 80 ? "text-emerald-600 dark:text-emerald-400" : score >= 50 ? "text-amber-600 dark:text-amber-400" : "text-red-600 dark:text-red-400")}>
+              {score}
+            </span>
+          )}
+        </div>
+
+        {/* 模块评审列表 */}
+        {moduleReviews && moduleReviews.length > 0 && (
+          <div className="space-y-1">
+            {moduleReviews.map((m, i) => (
+              <div key={i} className="text-[11px] text-text-secondary">
+                {m.status === "pass" ? "✅" : m.status === "warn" ? "⚠️" : "❌"}{" "}
+                <span className="font-medium text-foreground">{m.module}</span>: {m.comment}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* 反馈文本 */}
+        {feedback && (
+          <div className="mt-2 rounded-md border border-border bg-muted/30 p-2 text-[11px] text-text-secondary">
+            {feedback}
+          </div>
+        )}
+
+        {/* 反思（折叠） */}
+        {reflection && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="mt-2 flex items-center gap-1 text-[10px] text-text-muted hover:text-foreground"
+          >
+            <ChevronRight className={cn("h-3 w-3 transition-transform", expanded && "rotate-90")} />
+            Reflection
+          </button>
+        )}
+        {expanded && reflection && (
+          <p className="mt-1 text-[11px] italic text-text-muted">{reflection}</p>
+        )}
+
+        {/* 详情（raw payload） */}
+        {ev.created_at && (
+          <div className="mt-2 text-[10px] tabular-nums text-text-muted">
+            {new Date(ev.created_at).toLocaleTimeString()}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** 系统级事件（gate / evaluation / result）—— 居中 pill 样式。 */
+function SystemEventPill({ ev, label }: { ev: RoutineIterationEventDTO; label: string }) {
+  const [open, setOpen] = useState(false);
+  const isError = payloadIsError(ev.payload);
+  const icon = eventTypeIcon(ev.event_type, ev.tool_name);
+  const title = resolveEventTitle(ev.event_type, ev.title || extractSubtitle(ev.payload), ev.tool_name);
+  const hasDetail = ev.payload && Object.keys(ev.payload).length > 0;
+
+  return (
+    <div className="flex justify-center py-1">
+      <div className="inline-flex max-w-[90%] flex-col items-center">
+        <button
+          type="button"
+          onClick={() => hasDetail && setOpen((v) => !v)}
+          className={cn(
+            "flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition-colors",
+            isError
+              ? "border-red-500/30 bg-red-500/[0.03] text-red-600 dark:text-red-400"
+              : "border-border bg-muted/30 text-text-secondary hover:bg-muted/50",
+            hasDetail && "cursor-pointer",
+          )}
+        >
+          <span className={`flex h-5 w-5 items-center justify-center rounded-full ${eventTypeClass(ev.event_type, isError)}`}>
+            <EventIcon icon={icon} className="h-3 w-3" />
+          </span>
+          <span className="text-[10px] text-text-muted">{label}</span>
+          <span className="truncate">{title}</span>
+          {isError && (
+            <span className="rounded-full bg-red-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-red-600 dark:text-red-400">
+              error
+            </span>
+          )}
+          {ev.cost_usd != null && ev.cost_usd > 0 && (
+            <span className="text-[10px] tabular-nums text-text-muted">${ev.cost_usd.toFixed(4)}</span>
+          )}
+        </button>
+        {open && hasDetail && (
+          <div className="mt-2 w-full rounded-md border border-border bg-card p-3">
+            <EventDetail payload={ev.payload} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 辅助函数（保持原有逻辑不变）
+// ---------------------------------------------------------------------------
+
 function groupEvents(events: RoutineIterationEventDTO[]): Record<EventGroup, RoutineIterationEventDTO[]> {
   const out: Record<EventGroup, RoutineIterationEventDTO[]> = {
     execution: [],
+    plan_review: [],
     result: [],
     gate: [],
     evaluation: [],
@@ -223,58 +490,9 @@ function extractSubtitle(payload: Record<string, unknown> | null): string | null
   return null;
 }
 
-/** Turn（轮次）折叠卡片 —— 将一个 Turn 内的事件聚合为可展开/折叠的区块。 */
-function TurnGroup({
-  turn,
-  defaultExpanded,
-}: {
-  turn: EventTurn;
-  defaultExpanded: boolean;
-}) {
-  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
-  const expanded = manualExpanded ?? defaultExpanded;
-  const title = deriveTurnTitle(turn);
-
-  return (
-    <li className="relative -ml-px pl-4">
-      {/* Turn header */}
-      <button
-        type="button"
-        onClick={() => setManualExpanded((v) => !(v ?? defaultExpanded))}
-        aria-expanded={expanded}
-        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/50"
-      >
-        <ChevronRight
-          className={`h-3 w-3 shrink-0 text-text-muted transition-transform ${expanded ? "rotate-90" : ""}`}
-          aria-hidden
-        />
-        <span className="shrink-0 text-[10px] font-semibold tabular-nums text-text-muted">
-          Turn {turn.turnNumber}
-        </span>
-        <span className="min-w-0 flex-1 truncate text-xs text-foreground" title={title}>
-          {title}
-        </span>
-        <span className="shrink-0 text-[10px] tabular-nums text-text-muted">
-          {turn.events.length} ev
-        </span>
-        {turn.hasError && (
-          <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-red-600 dark:text-red-400">
-            error
-          </span>
-        )}
-      </button>
-
-      {/* Turn body: 嵌套 timeline 渲染该 Turn 内的具体 events */}
-      {expanded && (
-        <ol className="relative ml-2 space-y-1 border-l border-border pl-0">
-          {turn.events.map((ev) => (
-            <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
-          ))}
-        </ol>
-      )}
-    </li>
-  );
-}
+// ---------------------------------------------------------------------------
+// EventRow（对话气泡内的单行事件——保持时间线样式）
+// ---------------------------------------------------------------------------
 
 /**
  * 路径感知的单行标题拆分：以最后一个 ``/`` 切出末段（文件名）。
@@ -289,9 +507,7 @@ function splitPathLikeTitle(title: string): { head: string; tail: string } {
 }
 
 /**
- * 单行「路径感知」标题：前缀走 truncate（空间紧张时在头尾之间出省略号），文件名末段 ``shrink-0``
- * 永不裁剪 —— 即 ``/Users/.../foo.py`` 效果，宽度自适应。非路径标题退化为整串单行 truncate。
- * ``truncate`` 自带 ``overflow:hidden`` 使该 flex 子项 auto 最小尺寸归零，无需额外 ``min-w-0``。
+ * 单行「路径感知」标题。
  */
 function EventTitle({ title }: { title: string }) {
   const { head, tail } = splitPathLikeTitle(title);
@@ -325,13 +541,14 @@ function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
         type="button"
         onClick={() => hasDetail && setOpen((v) => !v)}
         aria-expanded={hasDetail ? open : undefined}
-        className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors ${
-          hasDetail ? "cursor-pointer hover:bg-muted/50" : "cursor-default"
-        }`}
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+          hasDetail ? "cursor-pointer hover:bg-muted/50" : "cursor-default",
+        )}
       >
         {hasDetail && (
           <ChevronRight
-            className={`h-3 w-3 shrink-0 text-text-muted transition-transform ${open ? "rotate-90" : ""}`}
+            className={cn("h-3 w-3 shrink-0 text-text-muted transition-transform", open && "rotate-90")}
             aria-hidden
           />
         )}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -13,7 +13,7 @@ import { iterationDotClass, phaseClass, phaseLabel, scoreColorClass, verdictClas
 interface RoutineIterationTimelineProps {
   iterations: RoutineIterationDTO[];
   onApprove: (iterationId: string) => void;
-  onReject: (iterationId: string) => void;
+  onReject?: (iterationId: string) => void;
   /** 打开某迭代的「全过程」审计抽屉。 */
   onAudit?: (iteration: RoutineIterationDTO) => void;
   busy?: boolean;
@@ -22,7 +22,6 @@ interface RoutineIterationTimelineProps {
 export function RoutineIterationTimeline({
   iterations,
   onApprove,
-  onReject,
   onAudit,
   busy,
 }: RoutineIterationTimelineProps) {
@@ -33,7 +32,7 @@ export function RoutineIterationTimeline({
   return (
     <ol className="space-y-2">
       {iterations.map((it) => (
-        <IterationCard key={it.id} it={it} onApprove={onApprove} onReject={onReject} onAudit={onAudit} busy={busy} />
+        <IterationCard key={it.id} it={it} onApprove={onApprove} onAudit={onAudit} busy={busy} />
       ))}
     </ol>
   );
@@ -42,13 +41,11 @@ export function RoutineIterationTimeline({
 function IterationCard({
   it,
   onApprove,
-  onReject,
   onAudit,
   busy,
 }: {
   it: RoutineIterationDTO;
   onApprove: (id: string) => void;
-  onReject: (id: string) => void;
   onAudit?: (iteration: RoutineIterationDTO) => void;
   busy?: boolean;
 }) {
@@ -174,30 +171,25 @@ function IterationCard({
         )}
       </div>
 
-      {/* 审批门控操作 */}
+      {/* 审批门控：NegentropyEngine 自动审阅中 */}
       {isPendingApproval && (
-        <div className="mt-2 flex items-center gap-2 rounded-md bg-amber-500/5 p-2">
-          <span className="text-[10px] text-amber-700 dark:text-amber-300">
-            {it.phase === "implement"
-              ? "审批后开始实现（请先确认上方 PLAN 方案）"
-              : it.phase === "plan"
-                ? "审批后开始执行规划"
-                : "等待审批后执行"}
+        <div className="mt-2 flex items-center gap-2 rounded-md bg-sky-500/5 p-2">
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
+          <span className="text-[10px] text-sky-700 dark:text-sky-300">
+            {it.phase === "plan"
+              ? "NegentropyEngine 正在审阅此 Plan…"
+              : it.phase === "implement"
+                ? "NegentropyEngine 正在审阅实现方案…"
+                : "等待 NegentropyEngine 审阅…"}
           </span>
           <div className="flex-1" />
+          {/* 手动审批按钮（fallback：当 Engine 未自动审阅时，人工仍可介入） */}
           <button
             onClick={(e) => { e.stopPropagation(); onApprove(it.id); }}
             disabled={busy}
-            className="cursor-pointer rounded-md border border-emerald-200 px-2.5 py-1 text-[11px] font-medium text-emerald-600 hover:bg-emerald-500/10 disabled:opacity-50 dark:border-emerald-800 dark:text-emerald-400"
+            className="cursor-pointer rounded-md border border-border px-2 py-0.5 text-[10px] font-medium text-text-muted hover:bg-muted/50 disabled:opacity-50"
           >
-            Approve
-          </button>
-          <button
-            onClick={(e) => { e.stopPropagation(); onReject(it.id); }}
-            disabled={busy}
-            className="cursor-pointer rounded-md border border-red-200 px-2.5 py-1 text-[11px] font-medium text-red-600 hover:bg-red-500/10 disabled:opacity-50 dark:border-red-800 dark:text-red-400"
-          >
-            Reject
+            Manual Approve
           </button>
         </div>
       )}

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -258,6 +258,8 @@ export function eventTypeIcon(eventType: RoutineEventType, toolName?: string | n
       return ShieldCheck;
     case "evaluation":
       return Scale;
+    case "plan_review":
+      return Scale;
     default:
       return CircleDot;
   }
@@ -279,6 +281,8 @@ export function eventTypeClass(eventType: RoutineEventType, isError?: boolean): 
       return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
     case "evaluation":
       return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "plan_review":
+      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
     case "system":
       return "bg-muted text-text-secondary";
     default:
@@ -305,6 +309,8 @@ export function eventTypeLabel(eventType: RoutineEventType): string {
       return "命令门控";
     case "evaluation":
       return "评估";
+    case "plan_review":
+      return "Plan 审阅";
     case "_truncated":
       return "已截断";
     default:
@@ -312,11 +318,13 @@ export function eventTypeLabel(eventType: RoutineEventType): string {
   }
 }
 
-/** 动作事件 → 时间线分组键（执行 / 结果 / 门控 / 评估）。 */
-export type EventGroup = "execution" | "result" | "gate" | "evaluation";
+/** 动作事件 → 时间线分组键（执行 / Plan 审阅 / 结果 / 门控 / 评估）。 */
+export type EventGroup = "execution" | "plan_review" | "result" | "gate" | "evaluation";
 
 export function eventGroup(eventType: RoutineEventType): EventGroup {
   switch (eventType) {
+    case "plan_review":
+      return "plan_review";
     case "result":
       return "result";
     case "gate":
@@ -330,6 +338,7 @@ export function eventGroup(eventType: RoutineEventType): EventGroup {
 
 export const EVENT_GROUP_LABEL: Record<EventGroup, string> = {
   execution: "执行 · Execution",
+  plan_review: "Plan 审阅 · Review",
   result: "结果 · Result",
   gate: "门控 · Gate",
   evaluation: "评估 · Evaluation",

--- a/apps/negentropy-ui/features/routine/agent-role.ts
+++ b/apps/negentropy-ui/features/routine/agent-role.ts
@@ -98,6 +98,7 @@ export function deriveAgentRole(eventType: RoutineEventType): AgentRole {
   switch (eventType) {
     case "gate":
     case "evaluation":
+    case "plan_review":
       return "engine";
     default:
       return "claude_code";

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -25,6 +25,7 @@ export type {
   IterationEventsResponse,
   TemplateSource,
   RoutineTemplateItem,
+  PlanReviewPayload,
 } from "./types";
 
 export type { AgentRole, AgentRoleMeta } from "./agent-role";

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -104,6 +104,7 @@ export interface RoutineIterationDTO {
 /**
  * 「全过程」动作级审计事件类型：
  * - 执行阶段：system（init）/ system_retry（API 重试，含 401/429）/ assistant（中间消息）/ tool_use（工具调用）/ tool_result（工具结果）/ result（最终产出）
+ * - 审阅阶段：plan_review（NegentropyEngine 自动审阅 Plan）
  * - 评估阶段：gate（命令门控）/ evaluation（LLM-as-Judge）
  * - _truncated：动作数超上限的哨兵
  */
@@ -114,10 +115,33 @@ export type RoutineEventType =
   | "tool_use"
   | "tool_result"
   | "result"
+  | "plan_review"
   | "gate"
   | "evaluation"
   | "_truncated"
   | "unknown";
+
+/** Plan Review 事件的归一化载荷结构。 */
+export interface PlanReviewPayload {
+  /** Engine 审阅决策：approve（通过）/ refine（需完善）。 */
+  verdict: "approve" | "refine";
+  /** 审阅评分（0-100）。 */
+  score: number;
+  /** 各模块逐项评审结果。 */
+  module_reviews: Array<{
+    module: string;
+    status: "pass" | "warn" | "fail";
+    comment: string;
+  }>;
+  /** 给 Claude Code 的反馈文本（refine 时有效）。 */
+  feedback: string;
+  /** Engine 内部反思。 */
+  reflection: string;
+  /** 审阅 Prompt（审计用）。 */
+  judge_prompt?: string;
+  /** LLM 原始响应（审计用）。 */
+  judge_raw?: string;
+}
 
 /** 单条「全过程」动作审计事件（与后端 ``_serialize_event`` 对齐）。 */
 export interface RoutineIterationEventDTO {

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -60,7 +60,7 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         ]}
       />,
     );
-    // Turn 聚合后，标题同时出现在 TurnGroup header 和嵌套 EventRow，故用 getAllByText
+    // Turn 聚合后，标题同时出现在 ClaudeCodeTurnBubble header 和嵌套 EventRow，故用 getAllByText
     expect(screen.getAllByText("会话初始化").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("init")).not.toBeInTheDocument();
   });

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -138,6 +138,24 @@ class RoutineSettings(BaseSettings):
         description="单次迭代内自动应答次数上限；防止 runaway（CC 反复问同样问题）。",
     )
 
+    # --- Plan Review（NegentropyEngine 自动审阅 Claude Code 的 Plan）---
+    plan_review_enabled: bool = Field(
+        default=True,
+        description="启用 Plan 自动审阅：当 Claude Code 在 PLAN 阶段提交方案并调用 AskUserQuestion "
+        "等待审阅时，NegentropyEngine 自动执行 Agent-as-Judge 审阅，产出 approve/refine 决策。"
+        "审阅结果通过 stdin 回传给 CC，实现迭代内闭环。",
+    )
+    plan_review_model: str | None = Field(
+        default=None,
+        description="Plan 审阅 LLM 模型覆盖；为空时走 task_registry 的 routine.plan_review 解析。",
+    )
+    plan_review_timeout_seconds: int = Field(
+        default=60,
+        ge=10,
+        le=300,
+        description="单次 Plan 审阅 LLM 调用的超时（秒）。",
+    )
+
     # --- 上下文压缩（迭代内：提前触发 auto-compact + 迭代内重试续接）---
     context_compact_enabled: bool = Field(
         default=True,

--- a/apps/negentropy/src/negentropy/config/task_registry.py
+++ b/apps/negentropy/src/negentropy/config/task_registry.py
@@ -109,6 +109,14 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         category="Routine",
         description="LLM-as-Judge 按验收标准为 Routine 迭代结果评分并生成反思反馈。",
     ),
+    TaskSlot(
+        task_key="routine.plan_review",
+        model_type="llm",
+        scope="global",
+        label="Routine Plan 审阅",
+        category="Routine",
+        description="NegentropyEngine 作为 Agent-as-Judge 审阅 Claude Code 的实现方案，评估完整性、可行性与风险。",
+    ),
     # --- Knowledge Graph (corpus) ---
     TaskSlot(
         task_key="knowledge.kg.extraction.entity",

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -209,7 +209,29 @@ def _normalize_stream_event(raw: dict[str, Any]) -> list[dict[str, Any]]:
             )
         ]
 
-    # system/* 其余非 init/api_retry/compact_boundary（task_started / task_completed 等）
+    # system/plan_review：NegentropyEngine Plan 自动审阅产出
+    if etype == _EVT_SYSTEM and raw.get("subtype") == "plan_review":
+        # 从 raw 中提取结构化审阅数据；若 raw 是原始审计事件则从顶层取，否则从 payload 嵌套取
+        review_data = raw.get("review_result") or {}
+        return [
+            _evt(
+                "plan_review",
+                {
+                    "verdict": review_data.get("verdict", "unknown"),
+                    "score": review_data.get("score"),
+                    "module_reviews": review_data.get("module_reviews", []),
+                    "feedback": review_data.get("feedback", ""),
+                    "reflection": review_data.get("reflection", ""),
+                    "judge_prompt": review_data.get("judge_prompt"),
+                    "judge_raw": review_data.get("judge_raw"),
+                    # 兼容：保留原始数据供 fallback
+                    "raw": _cap_json(raw),
+                },
+                title=f"plan_review ({review_data.get('verdict', 'unknown')}, score={review_data.get('score', '?')})",
+            )
+        ]
+
+    # system/* 其余非 init/api_retry/compact_boundary/plan_review（task_started / task_completed 等）
     if etype == _EVT_SYSTEM:
         subtype = raw.get("subtype") or "unknown"
         return [_evt("system", {"raw": _cap_json(raw)}, title=subtype)]
@@ -981,6 +1003,99 @@ class ClaudeCodeService:
             return ClaudeCodeService._FALLBACK_ANSWER
 
     @staticmethod
+    async def _plan_review_answer(
+        questions: list[dict],
+        context: dict[str, Any],
+        *,
+        plan_text: str = "",
+        model_override: str | None = None,
+        timeout: float = 60.0,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """PLAN 阶段专用自动应答：调用 PlanReviewer 进行方案审阅，返回审阅结果。
+
+        审阅结果作为 AskUserQuestion 的回答注入回 CC：
+        - approve → CC 收到批准，退出 Plan 模式开始实施
+        - refine → CC 收到完善要求，继续在 Plan 模式迭代
+
+        Returns:
+            (answer_json, review_result_dict) 元组。
+            review_result_dict 包含结构化审阅数据供审计事件使用；
+            审阅失败时为 None。
+        """
+        try:
+            from negentropy.engine.routine.plan_reviewer import PlanReviewer
+
+            reviewer = PlanReviewer(explicit_model=model_override, timeout_seconds=int(timeout))
+            result = await reviewer.review(
+                goal=context.get("goal", "（未提供）"),
+                acceptance_criteria=context.get("acceptance_criteria", "（未提供）"),
+                plan_text=plan_text,
+                reflections=context.get("reflections"),
+            )
+
+            if not result.ok:
+                logger.warning("plan_review_failed_fallback", error=result.error)
+                return (
+                    json.dumps(
+                        {"answers": ["审阅服务暂时不可用，请按你的最佳判断继续完善方案。"]},
+                        ensure_ascii=False,
+                    ),
+                    None,
+                )
+
+            # 构造结构化审阅数据供审计事件
+            review_data = {
+                "verdict": result.verdict,
+                "score": result.score,
+                "module_reviews": [
+                    {"module": m.module, "status": m.status, "comment": m.comment} for m in result.module_reviews
+                ],
+                "feedback": result.feedback,
+                "reflection": result.reflection,
+                "judge_prompt": result.judge_prompt,
+                "judge_raw": result.judge_raw,
+            }
+
+            # 审阅成功：构造回答
+            if result.verdict == "approve":
+                answer_text = f"Plan 已通过审阅（评分 {result.score}/100）。请退出 Plan 模式，开始实施。"
+            else:
+                module_feedback = ""
+                if result.module_reviews:
+                    items = []
+                    for m in result.module_reviews:
+                        icon = "✅" if m.status == "pass" else "⚠️" if m.status == "warn" else "❌"
+                        items.append(f"{icon} {m.module}: {m.comment}")
+                    module_feedback = "\n\n模块评审：\n" + "\n".join(items)
+
+                answer_text = (
+                    f"Plan 需要完善（评分 {result.score}/100）。\n\n"
+                    f"反馈：{result.feedback or '请进一步完善方案细节。'}"
+                    f"{module_feedback}"
+                )
+
+            logger.info(
+                "plan_review_completed",
+                verdict=result.verdict,
+                score=result.score,
+                modules=len(result.module_reviews),
+            )
+            return (
+                json.dumps({"answers": [answer_text]}, ensure_ascii=False),
+                review_data,
+            )
+
+        except Exception as exc:
+            logger.warning("plan_review_exception_fallback", error=str(exc))
+            return (
+                json.dumps(
+                    {"answers": ["审阅服务暂时不可用，请按你的最佳判断继续完善方案。"]},
+                    ensure_ascii=False,
+                ),
+                None,
+            )
+
+    @staticmethod
     async def _invoke_cli_interactive(
         prompt: str,
         config: ClaudeCodeConfig,
@@ -1129,26 +1244,59 @@ class ClaudeCodeService:
                                         # 无 questions 字段，尝试把整个 input 当问题
                                         questions = [{"question": json.dumps(tool_input, ensure_ascii=False)}]
 
-                                    answer = await ClaudeCodeService._auto_answer_question(
-                                        questions,
-                                        config.auto_answer_context or {},
-                                        timeout=30.0,
-                                    )
-                                    auto_answer_count += 1
+                                    # Plan Review 分支：PLAN 阶段 + plan_review_enabled
+                                    ctx = config.auto_answer_context or {}
+                                    is_plan_phase = ctx.get("phase") == "plan"
+                                    plan_review_enabled = ctx.get("plan_review_enabled", False)
+                                    plan_text = ctx.get("plan_summary") or result_text or ""
 
-                                    # 写入审计事件
-                                    await _emit_events(
-                                        {
+                                    if is_plan_phase and plan_review_enabled:
+                                        answer, review_data = await ClaudeCodeService._plan_review_answer(
+                                            questions,
+                                            ctx,
+                                            plan_text=plan_text,
+                                            model_override=ctx.get("plan_review_model"),
+                                            timeout=ctx.get("plan_review_timeout", 60.0),
+                                        )
+                                        auto_answer_count += 1
+
+                                        # 写入 plan_review 审计事件（含结构化审阅数据）
+                                        review_event: dict[str, Any] = {
                                             "type": "system",
-                                            "subtype": "auto_answer",
+                                            "subtype": "plan_review",
                                             "tool_use_id": tool_use_id,
                                             "questions": _cap_json(questions),
                                             "answer_preview": answer[:500],
-                                        },
-                                        events_holder,
-                                        on_event,
-                                        max_events=evt_max,
-                                    )
+                                        }
+                                        if review_data:
+                                            review_event["review_result"] = review_data
+                                        await _emit_events(
+                                            review_event,
+                                            events_holder,
+                                            on_event,
+                                            max_events=evt_max,
+                                        )
+                                    else:
+                                        answer = await ClaudeCodeService._auto_answer_question(
+                                            questions,
+                                            config.auto_answer_context or {},
+                                            timeout=30.0,
+                                        )
+                                        auto_answer_count += 1
+
+                                        # 写入审计事件
+                                        await _emit_events(
+                                            {
+                                                "type": "system",
+                                                "subtype": "auto_answer",
+                                                "tool_use_id": tool_use_id,
+                                                "questions": _cap_json(questions),
+                                                "answer_preview": answer[:500],
+                                            },
+                                            events_holder,
+                                            on_event,
+                                            max_events=evt_max,
+                                        )
 
                                     msg = ClaudeCodeService._build_stdin_tool_result(tool_use_id, answer)
                                     await write_queue.put(msg)

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -578,6 +578,15 @@ class RoutineOrchestrator:
             config.auto_answer_context = {
                 "goal": routine.goal,
                 "acceptance_criteria": routine.acceptance_criteria,
+                # Plan Review 上下文：当 phase=plan 且 plan_review_enabled 时，
+                # auto-answer 分支调用 PlanReviewer 而非通用 auto-answer。
+                "phase": routine.current_phase or "",
+                "plan_review_enabled": settings.routine.plan_review_enabled,
+                "plan_review_model": settings.routine.plan_review_model,
+                "plan_review_timeout": settings.routine.plan_review_timeout_seconds,
+                "reflections": (
+                    list(routine.reflections.get("items", [])[:5]) if isinstance(routine.reflections, dict) else []
+                ),
             }
         return config
 

--- a/apps/negentropy/src/negentropy/engine/routine/plan_reviewer.py
+++ b/apps/negentropy/src/negentropy/engine/routine/plan_reviewer.py
@@ -1,0 +1,226 @@
+"""Routine Plan Reviewer — NegentropyEngine 自动审阅 Claude Code 的实现方案。
+
+当 Claude Code 在 PLAN 阶段产出实现方案并等待审批时，NegentropyEngine 作为
+Agent-as-Judge 对方案进行模块级审阅分析，产出 approve/refine 决策。
+
+审阅产出：
+- verdict：approve（通过）/ refine（需完善）
+- score：0-100 评分
+- module_reviews：按功能模块逐项评审
+- feedback：给 Claude Code 的具体反馈（refine 时有效）
+- reflection：Engine 内部反思
+
+设计范式复用 ``evaluator.py``：``resolve_model_config_async`` + ``litellm.acompletion``
++ 结构化 JSON 输出 + 指数退避重试。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import litellm
+
+from negentropy.engine.utils.model_config import resolve_model_config_async
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.engine.routine.plan_reviewer")
+
+_TASK_KEY = "routine.plan_review"
+_PLAN_MAX_CHARS = 8000
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleReview:
+    """单个功能模块的评审结果。"""
+
+    module: str
+    status: str  # "pass" | "warn" | "fail"
+    comment: str
+
+
+@dataclass(frozen=True, slots=True)
+class PlanReviewResult:
+    """Plan 审阅产出。``ok=False`` 时表示审阅自身失败（LLM 不可用等）。"""
+
+    ok: bool
+    verdict: str | None = None  # "approve" | "refine"
+    score: int | None = None
+    module_reviews: tuple[ModuleReview, ...] = ()
+    feedback: str | None = None
+    reflection: str | None = None
+    error: str | None = None
+    judge_prompt: str | None = None
+    judge_raw: str | None = None
+
+
+_REVIEW_PROMPT = """\
+你是 NegentropyEngine，系统的本我（Self）。
+你的职责是以 Agent-as-Judge 的身份审阅 Claude Code 提交的实现方案（Plan）。
+
+# 目标
+{goal}
+
+# 验收标准
+{acceptance_criteria}
+
+# Claude Code 提交的实现方案（Plan）
+{plan_text}
+
+# 既往迭代反馈
+{reflections_section}
+
+请从以下维度审阅此实现方案：
+
+## 审阅维度
+1. **完整性**：方案是否覆盖了所有验收标准？是否有遗漏的功能点或边界情况？
+2. **可行性**：技术方案是否可落地？是否存在不可行的技术假设？
+3. **风险识别**：方案是否有潜在的副作用或风险？是否考虑了错误处理和回退策略？
+4. **模块划分**：方案的模块拆分是否合理？模块间依赖是否清晰？
+5. **测试策略**：方案是否包含验证策略？是否能通过验收标准中的验证手段？
+
+## 输出格式
+
+对每个识别到的功能模块进行评审，然后给出总体决策。
+
+仅输出 JSON：
+{{"
+  "score": <int 0-100>,
+  "verdict": "<approve|refine>",
+  "module_reviews": [
+    {{"module": "<模块名>", "status": "<pass|warn|fail>", "comment": "<评审意见>"}}
+  ],
+  "feedback": "<给 CC 的反馈，refine 时为具体完善要求，approve 时为简短认可>",
+  "reflection": "<Engine 内部反思，≤200字>"
+}}"""
+
+_VALID_VERDICTS = {"approve", "refine"}
+_VALID_STATUSES = {"pass", "warn", "fail"}
+
+
+class PlanReviewer:
+    """NegentropyEngine Plan 自动审阅器。"""
+
+    def __init__(
+        self,
+        *,
+        explicit_model: str | None = None,
+        temperature: float = 0.0,
+        max_retries: int = 3,
+        timeout_seconds: int = 60,
+    ) -> None:
+        self._explicit_model = explicit_model
+        self._temperature = temperature
+        self._max_retries = max_retries
+        self._timeout_seconds = timeout_seconds
+
+    async def review(
+        self,
+        *,
+        goal: str,
+        acceptance_criteria: str,
+        plan_text: str,
+        reflections: list[str] | None = None,
+    ) -> PlanReviewResult:
+        """审阅 Plan 并返回审阅结果。"""
+        plan = (plan_text or "").strip()[:_PLAN_MAX_CHARS] or "(Claude Code 未产出实现方案)"
+
+        reflections_section = "（无既往反馈）"
+        if reflections:
+            bullet = "\n".join(f"- {r}" for r in reflections[-5:])
+            reflections_section = bullet
+
+        judge_prompt = _REVIEW_PROMPT.format(
+            goal=goal,
+            acceptance_criteria=acceptance_criteria,
+            plan_text=plan,
+            reflections_section=reflections_section,
+        )
+
+        try:
+            score, verdict, module_reviews, feedback, reflection, judge_raw = await self._judge(judge_prompt)
+        except Exception as exc:
+            logger.warning("plan_review_judge_failed", error=str(exc))
+            return PlanReviewResult(
+                ok=False,
+                error=str(exc),
+                judge_prompt=judge_prompt,
+            )
+
+        return PlanReviewResult(
+            ok=True,
+            verdict=verdict,
+            score=score,
+            module_reviews=tuple(module_reviews),
+            feedback=feedback,
+            reflection=reflection,
+            judge_prompt=judge_prompt,
+            judge_raw=judge_raw,
+        )
+
+    async def _judge(self, prompt: str) -> tuple[int, str, list[ModuleReview], str, str, str]:
+        """调用 LLM 审阅，含指数退避重试。"""
+        model, model_kwargs = await resolve_model_config_async(_TASK_KEY, explicit_model=self._explicit_model)
+        safe_kwargs = {
+            k: v for k, v in model_kwargs.items() if k not in ("model", "messages", "temperature", "response_format")
+        }
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                response = await litellm.acompletion(
+                    model=model,
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=self._temperature,
+                    response_format={"type": "json_object"},
+                    timeout=self._timeout_seconds,
+                    **safe_kwargs,
+                )
+                content = response.choices[0].message.content
+                return self._parse(content)
+            except Exception as exc:
+                last_error = exc
+                logger.warning("plan_review_judge_retry", attempt=attempt + 1, error=str(exc))
+                await asyncio.sleep(2**attempt)
+
+        raise RuntimeError(f"Plan review judge failed after {self._max_retries} retries: {last_error}")
+
+    @staticmethod
+    def _parse(content: str | None) -> tuple[int, str, list[ModuleReview], str, str, str]:
+        """解析审阅 JSON。"""
+        data: dict[str, Any] = json.loads(content or "{}")
+
+        raw_score = data.get("score", 0)
+        try:
+            score = int(round(float(raw_score)))
+        except (TypeError, ValueError):
+            score = 0
+        score = max(0, min(100, score))
+
+        verdict = str(data.get("verdict", "")).strip().lower()
+        if verdict not in _VALID_VERDICTS:
+            verdict = "approve" if score >= 70 else "refine"
+
+        module_reviews: list[ModuleReview] = []
+        for raw in data.get("module_reviews", []):
+            if isinstance(raw, dict):
+                status = str(raw.get("status", "warn")).strip().lower()
+                if status not in _VALID_STATUSES:
+                    status = "warn"
+                module_reviews.append(
+                    ModuleReview(
+                        module=str(raw.get("module", "未命名模块")),
+                        status=status,
+                        comment=str(raw.get("comment", "")),
+                    )
+                )
+
+        feedback = str(data.get("feedback", "")).strip()
+        reflection = str(data.get("reflection", "")).strip()
+
+        return score, verdict, module_reviews, feedback, reflection, content or ""
+
+
+__all__ = ["PlanReviewer", "PlanReviewResult", "ModuleReview"]

--- a/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
+++ b/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
@@ -71,8 +71,12 @@ def build_prompt(routine: _RoutineLike, *, max_reflections: int = 5) -> str:
     if phase == PHASE_PLAN:
         parts.append(
             "# 规划 (Plan ONLY)\n本轮**仅产出实现方案，禁止写入或修改任何文件**（plan 模式）：\n"
-            "请给出正交分解维度、改动清单、预计爆炸半径与验证策略。\n"
-            "方案将提交人工审批，通过后再进入实现阶段。"
+            "请给出正交分解维度、改动清单、预计爆炸半径与验证策略。\n\n"
+            "**重要**：当你完成实现方案后，请使用 AskUserQuestion 工具提交方案等待审阅，"
+            '询问："Plan 已完成，请审阅。"\n'
+            "审阅者（NegentropyEngine）将评审你的方案并给出反馈：\n"
+            "- 若方案通过审阅，你将收到批准指令，此时直接退出 Plan 模式即可；\n"
+            "- 若方案需要完善，你将收到具体的修改建议，请据此继续完善方案后再次提交审阅。"
         )
     elif phase == PHASE_FINALIZE and worktree:
         # worktree routine：注入引擎确定性计算的具体分支名（base / head），CC 执行 push + 建 PR。


### PR DESCRIPTION
# 背景
- Routine 的 Plan 审批原依赖人工通过 API 端点触发，NegentropyEngine 在此阶段完全缺席；迭代事件时间线为单列平铺，无法区分不同 Agent 的对话角色
- 关联上下文：Routine 长周期自主任务子系统，Evaluator-Optimizer 自迭代闭环

# 核心变更

## 前端：对话式气泡布局
- **IterationEventTimeline 重构**：从单列时间线改为三人称对话气泡布局
  - `ClaudeCodeTurnBubble`（左侧紫色）— CC 执行 Turn，含 Turn 编号、事件数、可折叠事件列表
  - `EngineReviewBubble`（右侧天蓝色）— NegentropyEngine Plan 审阅结果，含 verdict/score/模块评审清单
  - `SystemEventPill`（居中）— result/gate/evaluation 等系统事件
- **plan_review 事件类型**：新增 `PlanReviewPayload` 接口、`Scale` 图标、sky 配色、`engine` 角色映射
- **pending_approval UX 升级**：从"审批后开始实现"改为脉冲动画 + "NegentropyEngine 正在审阅此 Plan..."，保留手动审批 fallback

## 后端：Plan 自动审阅闭环
- **PlanReviewer**（新建 `plan_reviewer.py`）：LLM-as-Judge 审阅 Plan 的完整性、可行性、风险、模块划分、测试策略；结构化 JSON 输出 + 指数退避重试
- **service.py 扩展**：`_plan_review_answer()` 审阅方法；auto-answer 在 PLAN phase + `plan_review_enabled` 时路由到审阅而非通用 auto-answer；`_normalize_stream_event()` 新增 plan_review 事件归一化
- **prompt_builder 调整**：PLAN 阶段 prompt 引导 CC 使用 AskUserQuestion 提交方案等待审阅
- **orchestrator 扩展**：`auto_answer_context` 注入 phase/config/reflections
- **配置扩展**：`plan_review_enabled`（默认 True）/ `plan_review_model` / `plan_review_timeout_seconds` 三个字段 + `routine.plan_review` TaskSlot 注册

# 风险与回滚
- 主要风险：PlanReviewer LLM 调用可能超时或返回异常格式（已有 fallback 兜底：异常时自动 approve）；plan_review 循环受 `auto_answer_max_per_iteration`（默认 5）约束防止无限循环
- 回滚方式：`plan_review_enabled = False` 关闭审阅回归纯人工审批，前端对 plan_review 事件优雅降级（无气泡不报错）

# 验证证据
- 单元测试：14 个既有 IterationEventTimeline 测试全部通过（对话式布局保持向后兼容）
- 集成测试：TypeScript `tsc --noEmit` 零错误；Ruff lint/format + ESLint 全部通过（pre-commit hooks）
- E2E/Workflow：待合并后创建 approval_mode=first 的 phased Routine 进行端到端验证
- 覆盖率：前端新组件（ClaudeCodeTurnBubble/EngineReviewBubble/SystemEventPill）尚无专属测试用例

# 影响范围
- 前端：`IterationEventTimeline` / `RoutineIterationTimeline` / `status-style` / `types` / `agent-role` / `index`
- 后端：`plan_reviewer`（新建）/ `service` / `orchestrator` / `prompt_builder` / `config/routine` / `task_registry`
- GitHub Actions / 文档：无 CI 变更；建议后续补充 Plan Review 配置文档

# Next Best Action
- 创建 phased Routine（`approval_mode=first`）进行浏览器实机 E2E 验证
- 补充 ClaudeCodeTurnBubble / EngineReviewBubble 的前端单元测试
- 深色/浅色模式双主题视觉验证
