### PR TITLE
feat(routine): Running 状态下运行时安全字段可调（Success Score 阈值内联编辑）

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import type { RoutineDTO, RoutineIterationDTO } from "@/features/routine";
+import { updateRoutine } from "@/features/routine/api";
 
 import { useClock } from "./ClockProvider";
 import { RoutineMeter } from "./RoutineMeter";
@@ -14,6 +15,9 @@ const TERMINAL: ReadonlySet<string> = new Set(["succeeded", "failed", "cancelled
 /**
  * 守卫 / 预算面板 —— 可视化「为何/何时会停」：迭代、成本、成功分、截止、无进展、震荡。
  * 最逼近极限者标注为「预计停因」；终态后以实际 termination_reason 替换预测。
+ *
+ * 非终态下 Success Score 阈值支持内联编辑（点击徽章 → 数字输入框 → Enter/Blur 确认），
+ * 让用户在 Running 状态下即可动态调整成功阈值。
  */
 export function RoutineGuardPanel({
   routine,
@@ -112,13 +116,7 @@ export function RoutineGuardPanel({
           ratio={costRatio}
           fillClass={costRatio == null ? "bg-sky-500/50" : limitFillClass(costRatio)}
         />
-        <RoutineMeter
-          label="Success Score"
-          valueText={`best ${routine.best_score ?? "—"} → 阈值 ${routine.success_score_threshold}`}
-          ratio={routine.best_score != null ? routine.best_score / 100 : null}
-          fillClass={scoreFillClass(routine.best_score, routine.success_score_threshold)}
-          notchPct={routine.success_score_threshold}
-        />
+        <SuccessScoreMeter routine={routine} />
         {deadline && (
           <RoutineMeter
             label="Deadline"
@@ -163,5 +161,113 @@ export function RoutineGuardPanel({
         </div>
       )}
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Success Score 内联阈值编辑器
+// ---------------------------------------------------------------------------
+
+/** 非终态下可内联编辑阈值的 Success Score 行 */
+function SuccessScoreMeter({ routine }: { routine: RoutineDTO }) {
+  const isTerminal = TERMINAL.has(routine.status);
+  const threshold = routine.success_score_threshold;
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(threshold));
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const openEditor = useCallback(() => {
+    if (isTerminal) return;
+    setDraft(String(threshold));
+    setEditing(true);
+    // Focus after React renders the input
+    requestAnimationFrame(() => inputRef.current?.select());
+  }, [isTerminal, threshold]);
+
+  const commit = useCallback(async () => {
+    const next = Math.max(0, Math.min(100, Number.parseInt(draft, 10)));
+    if (Number.isNaN(next) || next === threshold) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateRoutine(routine.id, { success_score_threshold: next });
+      // SSE debounced refetch 或父组件刷新会自然更新 routine prop
+    } catch {
+      // revert on failure
+      setDraft(String(threshold));
+    } finally {
+      setSaving(false);
+      setEditing(false);
+    }
+  }, [draft, routine.id, threshold]);
+
+  const cancel = useCallback(() => {
+    setDraft(String(threshold));
+    setEditing(false);
+  }, [threshold]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cancel();
+      }
+    },
+    [commit, cancel],
+  );
+
+  // 阈值文字区：终态 → 纯文本；非终态 → 可点击徽章 / 编辑态
+  const thresholdElement = isTerminal ? (
+    <span className="tabular-nums">阈值 {threshold}</span>
+  ) : editing ? (
+    <input
+      ref={inputRef}
+      type="number"
+      min={0}
+      max={100}
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={onKeyDown}
+      disabled={saving}
+      className="h-4 w-12 rounded border border-border bg-background px-1 text-right text-[10px] tabular-nums text-text-secondary focus:outline-none focus:ring-1 focus:ring-primary"
+      autoFocus
+    />
+  ) : (
+    <button
+      type="button"
+      onClick={openEditor}
+      className="inline-flex items-center gap-0.5 rounded px-1 text-[10px] tabular-nums text-text-secondary transition-colors hover:bg-muted hover:text-foreground"
+      title="点击调整 Success Score 阈值"
+    >
+      阈值 <span className="font-semibold">{threshold}</span>
+      <svg
+        className="h-2.5 w-2.5 opacity-40"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path d="M11.5 2.5l2 2L5.5 12.5H3.5v-2l8-8z" />
+      </svg>
+    </button>
+  );
+
+  return (
+    <RoutineMeter
+      label="Success Score"
+      valueText={`best ${routine.best_score ?? "—"}`}
+      ratio={routine.best_score != null ? routine.best_score / 100 : null}
+      fillClass={scoreFillClass(routine.best_score, routine.success_score_threshold)}
+      notchPct={routine.success_score_threshold}
+      rightElement={thresholdElement}
+    />
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineMeter.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineMeter.tsx
@@ -11,6 +11,8 @@ export function RoutineMeter({
   fillClass,
   /** 阈值刻痕位置（0-100），如成功阈值线。 */
   notchPct,
+  /** 自定义右侧内容（替代 valueText 文本）。 */
+  rightElement,
   className,
 }: {
   label: string;
@@ -18,6 +20,7 @@ export function RoutineMeter({
   ratio: number | null;
   fillClass: string;
   notchPct?: number;
+  rightElement?: React.ReactNode;
   className?: string;
 }) {
   const pct = ratio == null ? 0 : Math.min(100, Math.max(0, ratio * 100));
@@ -25,7 +28,7 @@ export function RoutineMeter({
     <div className={className}>
       <div className="flex items-baseline justify-between text-[10px] text-text-muted">
         <span>{label}</span>
-        <span className="tabular-nums text-text-secondary">{valueText}</span>
+        {rightElement ?? <span className="tabular-nums text-text-secondary">{valueText}</span>}
       </div>
       <div className="relative mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
         <div

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -57,6 +57,22 @@ router = APIRouter(prefix="/routines", tags=["routines"])
 # 终态：不可再启动 / 编辑调度
 _TERMINAL = ("succeeded", "failed", "cancelled")
 _ACTIVE = ("running", "paused")
+
+# Running 状态下允许在线调整的字段（不影响执行语义的安全字段）。
+# 其余字段（goal / cwd / baseline_branch / verification_command / approval_mode / config 等）
+# 仍需 pause 后方可修改。
+_RUNTIME_SAFE_FIELDS: frozenset[str] = frozenset(
+    {
+        "success_score_threshold",  # 成功判定阈值
+        "max_iterations",  # 迭代预算
+        "max_cost_usd",  # 成本预算
+        "deadline_at",  # 截止时间
+        "no_progress_patience",  # 停滞容忍度
+        "title",  # 纯展示元数据
+        "display_name",  # 纯展示元数据
+        "description",  # 纯展示元数据
+    }
+)
 _NON_TERMINAL_ITER = ("pending_approval", "dispatched", "in_flight", "executed")
 _DEFAULT_RECENT_ITERATIONS = 20
 
@@ -633,16 +649,27 @@ async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
 
 @router.put("/{routine_id}")
 async def update_routine(routine_id: UUID, body: RoutineUpdateRequest) -> dict[str, Any]:
-    if body.cwd and not os.path.isdir(body.cwd):
-        raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{body.cwd}'")
+    update_data = body.model_dump(exclude_unset=True)
+
     async with db_session.AsyncSessionLocal() as db:
         r = await db.get(Routine, routine_id)
         if r is None:
             raise HTTPException(status_code=404, detail="routine not found")
-        if r.status == "running":
-            raise HTTPException(status_code=409, detail="cannot edit a running routine; pause it first")
 
-        update_data = body.model_dump(exclude_unset=True)
+        # Running 状态下仅允许运行时安全字段；非安全字段需 pause 后修改。
+        if r.status == "running":
+            requested = set(update_data.keys())
+            unsafe = requested - _RUNTIME_SAFE_FIELDS
+            if unsafe:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"cannot edit {', '.join(sorted(unsafe))} while running; pause first",
+                )
+
+        # cwd 目录存在性校验（非 running 路径，unsafe 已被上方拦截）
+        if "cwd" in update_data and update_data["cwd"] and not os.path.isdir(update_data["cwd"]):
+            raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{update_data['cwd']}'")
+
         for field_name, value in update_data.items():
             setattr(r, field_name, value)
 
@@ -654,6 +681,9 @@ async def update_routine(routine_id: UUID, body: RoutineUpdateRequest) -> dict[s
             except workspace.WorkspaceError as exc:
                 await db.rollback()
                 raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        if r.status == "running" and update_data:
+            logger.info("routine_runtime_update", routine_id=str(routine_id), fields=sorted(update_data.keys()))
 
         try:
             await db.commit()

--- a/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
@@ -123,8 +123,17 @@ async def test_full_crud_and_control_lifecycle(git_repo):
             st = await c.post(f"/routines/{rid}/start")
             assert st.status_code == 200 and st.json()["status"] == "running"
 
-            # 运行中不可编辑 → 409
+            # 运行中不可编辑 unsafe 字段 → 409
             assert (await c.put(f"/routines/{rid}", json={"goal": "x"})).status_code == 409
+
+            # 运行中可编辑 runtime-safe 字段（success_score_threshold）→ 200
+            safe_upd = await c.put(f"/routines/{rid}", json={"success_score_threshold": 70})
+            assert safe_upd.status_code == 200 and safe_upd.json()["success_score_threshold"] == 70
+
+            # 运行中混合 safe/unsafe → 409（整体被拒）
+            assert (
+                await c.put(f"/routines/{rid}", json={"success_score_threshold": 60, "goal": "y"})
+            ).status_code == 409
 
             # pause → resume
             assert (await c.post(f"/routines/{rid}/pause")).json()["status"] == "paused"
@@ -477,5 +486,77 @@ async def test_start_requires_worktree_fields_409():
             rid = r.json()["id"]
             st = await c.post(f"/routines/{rid}/start")
             assert st.status_code == 409  # 执行前提缺失 → 拒绝启动
+    finally:
+        await _cleanup("itest_api_")
+
+
+# ---------------------------------------------------------------------------
+# Running 状态运行时安全字段编辑
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_safe_fields_update_while_running(git_repo):
+    """Running 状态下允许调整运行时安全字段（阈值 / 预算 / 元数据），拒绝语义敏感字段。"""
+    app = _app()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            r = await c.post(
+                "/routines",
+                json={
+                    "key": key,
+                    "title": "Runtime Safe",
+                    "goal": "实现功能 X",
+                    "acceptance_criteria": "测试通过",
+                    "cwd": git_repo,
+                    "baseline_branch": "main",
+                    "success_score_threshold": 90,
+                    "max_iterations": 10,
+                },
+            )
+            rid = r.json()["id"]
+            await c.post(f"/routines/{rid}/start")
+            assert r.json()["success_score_threshold"] == 90
+
+            # 1) 安全字段：success_score_threshold → 200
+            res = await c.put(f"/routines/{rid}", json={"success_score_threshold": 75})
+            assert res.status_code == 200
+            assert res.json()["success_score_threshold"] == 75
+
+            # 2) 多个安全字段同时更新 → 200
+            res = await c.put(
+                f"/routines/{rid}",
+                json={"success_score_threshold": 70, "max_iterations": 20, "title": "Updated Title"},
+            )
+            assert res.status_code == 200
+            body = res.json()
+            assert body["success_score_threshold"] == 70
+            assert body["max_iterations"] == 20
+            assert body["title"] == "Updated Title"
+
+            # 3) unsafe 字段：goal → 409
+            res = await c.put(f"/routines/{rid}", json={"goal": "new goal"})
+            assert res.status_code == 409
+            assert "goal" in res.json()["detail"]
+
+            # 4) unsafe 字段：cwd → 409
+            res = await c.put(f"/routines/{rid}", json={"cwd": "/tmp"})
+            assert res.status_code == 409
+            assert "cwd" in res.json()["detail"]
+
+            # 5) 混合 safe + unsafe → 409（整体被拒）
+            res = await c.put(f"/routines/{rid}", json={"success_score_threshold": 80, "acceptance_criteria": "x"})
+            assert res.status_code == 409
+            assert "acceptance_criteria" in res.json()["detail"]
+
+            # 6) 空 body → 200（无变更）
+            res = await c.put(f"/routines/{rid}", json={})
+            assert res.status_code == 200
+
+            # 7) 非 running 状态（pause 后）全字段可编辑（回归）
+            await c.post(f"/routines/{rid}/pause")
+            res = await c.put(f"/routines/{rid}", json={"goal": "paused goal", "success_score_threshold": 85})
+            assert res.status_code == 200
+            assert res.json()["goal"] == "paused goal"
     finally:
         await _cleanup("itest_api_")

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
@@ -231,6 +231,38 @@ def test_decide_success_tail_resets_failure_count():
 
 
 # ---------------------------------------------------------------------------
+# 运行时阈值调整：模拟 Running 状态下 API 修改 success_score_threshold 后决策变化
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_threshold_lowering_triggers_success():
+    """运行中降低阈值：score=80 < 原阈值 85 → continue；改为 75 → terminate(SUCCESS)。"""
+    it = FakeIter(score=80, verdict="pass", gate_exit_code=0)
+
+    # 原阈值 85：score 未达标 → 继续
+    r = FakeRoutine(success_score_threshold=85, best_score=80)
+    assert d.decide(r, it, [it]).action == "continue"
+
+    # 模拟运行中 API 将阈值降至 75：score 达标 → 成功终止
+    r2 = FakeRoutine(success_score_threshold=75, best_score=80)
+    res = d.decide(r2, it, [it])
+    assert res.is_terminate and res.reason == d.REASON_SUCCESS
+
+
+def test_runtime_threshold_raising_prevents_premature_success():
+    """运行中提高阈值：score=90 >= 原阈值 85 → 成功；改为 95 → 继续。"""
+    it = FakeIter(score=90, verdict="pass", gate_exit_code=0)
+
+    # 原阈值 85：达标 → 成功
+    r = FakeRoutine(success_score_threshold=85, best_score=90)
+    assert d.decide(r, it, [it]).reason == d.REASON_SUCCESS
+
+    # 阈值提高到 95：未达标 → 继续
+    r2 = FakeRoutine(success_score_threshold=95, best_score=90)
+    assert d.decide(r2, it, [it]).action == "continue"
+
+
+# ---------------------------------------------------------------------------
 # prompt_builder
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# 背景
- Routine 任务执行中（Running 状态），用户可能需要动态调整 `success_score_threshold`。例如运行 10 个迭代后发现原始阈值过高，希望降低阈值让任务在合理分数下成功完结。当前 `PUT /routines/{id}` 对 Running 状态执行全字段一刀切拦截（409），阻塞了这一合理需求。

# 核心变更
- **后端选择性放行**：在 `routine_api.py` 定义 `_RUNTIME_SAFE_FIELDS` 集合（`success_score_threshold`、`max_iterations`、`max_cost_usd`、`deadline_at`、`no_progress_patience`、`title`、`display_name`、`description`），将 blanket running-block 替换为选择性验证——安全字段放行 + info 日志，`goal`/`cwd`/`baseline_branch` 等语义敏感字段仍锁定
- **前端内联编辑**：`RoutineGuardPanel` Success Score 区域增加可点击阈值徽章（铅笔图标），点击展开 `<input type="number">` 内联编辑器，Enter/Blur 确认调用 `updateRoutine` API，Escape 取消；`RoutineMeter` 组件扩展 `rightElement` prop

# 风险与回滚
- 主要风险：Running 时 PUT 与 Orchestrator 评估并发写入同一 Routine 行（窗口极小，Orchestrator tick ~10s，PUT 毫秒级完成）
- 回滚方式：`git revert` 单个 commit 即可

# 验证证据
- 单元测试：`test_runtime_threshold_lowering_triggers_success` / `test_runtime_threshold_raising_prevents_premature_success` — 模拟运行中阈值调整的决策效果
- 集成测试：`test_runtime_safe_fields_update_while_running` — 覆盖安全字段 200、非安全 409、混合 409、空 body 200、pause 后全字段回归共 7 个场景
- 全量集成测试 11/11 PASSED，零回归

# 影响范围
- 前端：`RoutineGuardPanel.tsx`（内联编辑器）、`RoutineMeter.tsx`（新增 prop）
- 后端：`routine_api.py`（选择性放行逻辑，`decision.py` 纯函数无需改动）
- GitHub Actions / 文档：无影响

# Next Best Action
- 端到端实机验证：启动 negentropy serve + UI dev server → 创建并启动 routine → 运行中在 GuardPanel 点击阈值徽章修改 → 观察下轮评估是否按新阈值判定成功