### PR TITLE
fix(routine): Iteration 事件气泡按 seq 时序交织排列

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -123,36 +123,58 @@ type ConversationBlock =
   | { kind: "plan_review"; event: RoutineIterationEventDTO }
   | { kind: "engine_event"; event: RoutineIterationEventDTO; label: string };
 
-/** 将所有事件编排为对话块序列。 */
+/** 将已累积的 execution 事件聚合为 Turn 块并追加到 blocks，同时维护全局 Turn 编号。 */
+function flushAccumulator(
+  acc: RoutineIterationEventDTO[],
+  blocks: ConversationBlock[],
+  turnOffset: { value: number },
+): void {
+  if (acc.length === 0) return;
+  const turns = groupIntoTurns(acc);
+  for (let i = 0; i < turns.length; i++) {
+    // 重编号以保持全局连续（groupIntoTurns 内部从 1 开始，需加上偏移）
+    turns[i].turnNumber = turnOffset.value + i + 1;
+    // defaultExpanded 暂设 false，由 buildConversationBlocks 后置统一设置
+    blocks.push({ kind: "turn", turn: turns[i], defaultExpanded: false });
+  }
+  turnOffset.value += turns.length;
+  acc.length = 0;
+}
+
+/** 将所有事件按 seq 时序编排为对话块序列（Claude Code Turn 与 Engine 事件交织排列）。 */
 function buildConversationBlocks(
-  groups: Record<EventGroup, RoutineIterationEventDTO[]>,
-  execTurns: EventTurn[],
+  sortedEvents: RoutineIterationEventDTO[],
 ): ConversationBlock[] {
   const blocks: ConversationBlock[] = [];
-  const order: EventGroup[] = ["execution", "plan_review", "result", "gate", "evaluation"];
+  const acc: RoutineIterationEventDTO[] = [];
+  const turnOffset = { value: 0 };
 
-  for (const g of order) {
-    const list = groups[g];
-    if (!list || list.length === 0) continue;
+  for (const ev of [...sortedEvents].sort((a, b) => a.seq - b.seq)) {
+    const g = eventGroup(ev.event_type);
 
     if (g === "execution") {
-      for (let i = 0; i < execTurns.length; i++) {
-        const turn = execTurns[i];
-        blocks.push({
-          kind: "turn",
-          turn,
-          defaultExpanded: isTurnDefaultExpanded(turn, i, execTurns.length),
-        });
-      }
-    } else if (g === "plan_review") {
-      for (const ev of list) {
-        blocks.push({ kind: "plan_review", event: ev });
-      }
+      acc.push(ev);
     } else {
-      // result / gate / evaluation → Engine 右侧气泡
-      for (const ev of list) {
+      // Engine 事件前先刷出已累积的 execution Turn
+      flushAccumulator(acc, blocks, turnOffset);
+
+      if (g === "plan_review") {
+        blocks.push({ kind: "plan_review", event: ev });
+      } else {
+        // result / gate / evaluation → Engine 右侧气泡
         blocks.push({ kind: "engine_event", event: ev, label: EVENT_GROUP_LABEL[g] });
       }
+    }
+  }
+
+  // 刷出尾部残留的 execution 事件
+  flushAccumulator(acc, blocks, turnOffset);
+
+  // 设置 defaultExpanded：最后一轮 + 含错轮次展开
+  const totalTurns = turnOffset.value;
+  for (const b of blocks) {
+    if (b.kind === "turn") {
+      b.defaultExpanded = isTurnDefaultExpanded(b.turn, b.turn.turnNumber - 1, totalTurns);
     }
   }
 
@@ -177,9 +199,10 @@ export function IterationEventTimeline({
   /** 是否处于在途实时态（显示 LIVE 脉冲）。 */
   live?: boolean;
 }) {
+  // 统计栏仍按分类计数
   const groups = useMemo(() => groupEvents(events), [events]);
-  const execTurns = useMemo(() => groupIntoTurns(groups.execution), [groups.execution]);
-  const blocks = useMemo(() => buildConversationBlocks(groups, execTurns), [groups, execTurns]);
+  // 对话块按 seq 时序交织排列（Turn 与 Engine 事件穿插）
+  const blocks = useMemo(() => buildConversationBlocks(events), [events]);
 
   if (events.length === 0) {
     return null; // 空态由抽屉统一渲染

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -168,3 +168,109 @@ describe("IterationEventTimeline 事件标题翻译", () => {
     expect(screen.getByText("推理")).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// 交织排序：Engine 事件按 seq 时序穿插在 Claude Code Turn 之间
+// ---------------------------------------------------------------------------
+
+describe("IterationEventTimeline 交织排序", () => {
+  /** 获取对话流容器的子元素列表，每个子元素即一个气泡行。 */
+  function getFlowChildren(container: HTMLElement): Element[] {
+    const flow = container.querySelector(".space-y-2\\.5");
+    if (!flow) return [];
+    return Array.from(flow.children);
+  }
+
+  /** 从气泡行列表中提取标签序列：Turn N / Plan Review / Result / Gate / Evaluation。 */
+  function getBubbleLabels(rows: Element[]): string[] {
+    return rows.map((el) => {
+      // 使用 querySelector 精确匹配 header 内的标签 span
+      // Claude Code Turn: header 含 "Claude Code" span
+      const ccSpan = el.querySelector("span.text-violet-600, span.text-violet-400");
+      if (ccSpan) {
+        // 找同级的 "Turn N" span
+        const turnSpan = el.querySelector("span.text-text-muted");
+        if (turnSpan) {
+          const m = turnSpan.textContent?.match(/^Turn (\d+)$/);
+          if (m) return `Turn ${m[1]}`;
+        }
+        return "Turn ?";
+      }
+      // Engine 气泡：查 "NegentropyEngine" span 后的 type label
+      const engineLabel = el.querySelector("span.text-sky-600, span.text-sky-400");
+      if (engineLabel) {
+        // 找同级的 label span
+        const spans = el.querySelectorAll("span");
+        for (const s of spans) {
+          const t = s.textContent?.trim() ?? "";
+          if (t === "Plan Review") return "Plan Review";
+          if (t.startsWith("结果")) return "Result";
+          if (t.startsWith("门控")) return "Gate";
+          if (t.startsWith("评估")) return "Evaluation";
+        }
+      }
+      return "Unknown";
+    });
+  }
+
+  it("plan_review 按 seq 穿插在 Turn 之间（单 Turn 刷新）", () => {
+    // seq=0 assistant → Turn 1 | seq=1 plan_review | seq=2 assistant → Turn 2
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "第一步" } }),
+      makeEvent({ seq: 1, event_type: "plan_review", title: "Plan Review", tool_name: null, payload: { verdict: "approve", score: 85, module_reviews: [], feedback: null, reflection: null } }),
+      makeEvent({ seq: 2, event_type: "assistant", title: null, tool_name: null, payload: { text: "第二步" } }),
+    ];
+
+    const { container } = render(<IterationEventTimeline events={events} />);
+    const labels = getBubbleLabels(getFlowChildren(container));
+
+    // 期望：Turn 1 → Plan Review → Turn 2（plan_review 按 seq 穿插在两个 Turn 之间）
+    expect(labels).toEqual(["Turn 1", "Plan Review", "Turn 2"]);
+  });
+
+  it("result/gate/evaluation 在最后一个 Turn 之后按 seq 排列", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "执行" } }),
+      makeEvent({ seq: 1, event_type: "result", title: "success", tool_name: null, payload: { result: "done", is_error: false } }),
+      makeEvent({ seq: 2, event_type: "gate", title: "gate", tool_name: null, payload: { command: "pytest", exit_code: 0, output: "OK" } }),
+      makeEvent({ seq: 3, event_type: "evaluation", title: "eval", tool_name: null, payload: { score: 90, verdict: "succeeded", reflection: "好" } }),
+    ];
+
+    const { container } = render(<IterationEventTimeline events={events} />);
+    const labels = getBubbleLabels(getFlowChildren(container));
+
+    // 期望：Turn 1 → Result → Gate → Evaluation
+    expect(labels).toEqual(["Turn 1", "Result", "Gate", "Evaluation"]);
+  });
+
+  it("多个 plan_review 穿插时全局 Turn 编号连续", () => {
+    // seq=0 assistant → Turn 1 | seq=1 plan_review | seq=2 assistant → Turn 2 | seq=3 plan_review | seq=4 assistant → Turn 3
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "第一步" } }),
+      makeEvent({ seq: 1, event_type: "plan_review", title: "Plan Review", tool_name: null, payload: { verdict: "approve", score: 80, module_reviews: [], feedback: null, reflection: null } }),
+      makeEvent({ seq: 2, event_type: "assistant", title: null, tool_name: null, payload: { text: "第二步" } }),
+      makeEvent({ seq: 3, event_type: "plan_review", title: "Plan Review", tool_name: null, payload: { verdict: "refine", score: 60, module_reviews: [], feedback: null, reflection: null } }),
+      makeEvent({ seq: 4, event_type: "assistant", title: null, tool_name: null, payload: { text: "第三步" } }),
+    ];
+
+    const { container } = render(<IterationEventTimeline events={events} />);
+    const labels = getBubbleLabels(getFlowChildren(container));
+
+    // 期望：Turn 1 → Plan Review → Turn 2 → Plan Review → Turn 3（编号连续不重置）
+    expect(labels).toEqual(["Turn 1", "Plan Review", "Turn 2", "Plan Review", "Turn 3"]);
+  });
+
+  it("纯 execution 事件无 Engine 事件时仍正常渲染", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "干活" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /x.py" }),
+    ];
+
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    // 单个 Turn，无 Engine 气泡
+    const labels = getBubbleLabels(getFlowChildren(container));
+    expect(labels).toEqual(["Turn 1"]);
+    expect(screen.queryByText("NegentropyEngine")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 问题

Routine 迭代详情页中，NegentropyEngine 的气泡（Plan Review / Result / Gate / Evaluation）全部堆积在对话流末尾，而非按时间线与 Claude Code Turn 穿插排列。

**根因**：`buildConversationBlocks` 按**固定分类顺序**渲染（`execution → plan_review → result → gate → evaluation`），忽略了跨类别的 `seq` 时序。

## 修复

重写 `buildConversationBlocks` 为 **seq 单流交织排序**：

| 修改前 | 修改后 |
|--------|--------|
| 按分类分桶，固定顺序渲染 | 按全量事件 `seq` 升序单遍扫描 |
| 所有 CC Turn → 所有 Engine 气泡 | Engine 气泡出现在对应 CC Turn 的正确时间线位置 |

核心变更：
- 新增 `flushAccumulator` 辅助函数，按 Turn 边界聚合 execution 事件并维护全局连续编号
- 遇 Engine 事件时先刷出已累积的 Turn，再发射 Engine 块
- `defaultExpanded` 后置统一设置（最后一轮 + 含错轮展开）
- 统计栏仍按分类计数，不受影响

## 测试

- 原有 788 个测试全部通过
- 新增 4 个交织排序测试用例：
  - plan_review 按 seq 穿插在 Turn 之间
  - result/gate/evaluation 在最后一个 Turn 之后按 seq 排列
  - 多个 plan_review 穿插时全局 Turn 编号连续
  - 纯 execution 事件无 Engine 事件时仍正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)