### PR TITLE
fix(RoutineEditDrawer): Template 编辑保存丢失 CC Config 字段 + 表单一致性修复;

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -157,6 +157,25 @@ function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "
   };
 }
 
+/** 将表单 CC 配置字段写入 config 对象（原地修改，ccFromConfig 的逆操作）。 */
+function applyCCConfig(
+  config: Record<string, unknown>,
+  form: Pick<FormState, "model" | "max_turns" | "max_events_per_iter" | "permission_mode" | "allowed_tools" | "timeout_seconds">,
+): void {
+  if (form.model.trim()) config.model = form.model.trim();
+  else delete config.model;
+  if (form.max_turns.trim()) config.max_turns = parseInt(form.max_turns, 10);
+  else delete config.max_turns;
+  if (form.max_events_per_iter.trim()) config.max_events_per_iter = parseInt(form.max_events_per_iter, 10);
+  else delete config.max_events_per_iter;
+  if (form.permission_mode.trim()) config.permission_mode = form.permission_mode.trim();
+  else delete config.permission_mode;
+  if (form.allowed_tools.trim()) config.allowed_tools = form.allowed_tools.split(",").map((s) => s.trim()).filter(Boolean);
+  else delete config.allowed_tools;
+  if (form.timeout_seconds.trim()) config.timeout_seconds = parseInt(form.timeout_seconds, 10);
+  else delete config.timeout_seconds;
+}
+
 /** 依 mode 构造初始表单（仅在挂载时调用一次，避免 SSE 刷新回灌草稿）。 */
 function buildInitial(mode: DrawerMode): FormState {
   switch (mode.kind) {
@@ -400,7 +419,7 @@ export function RoutineEditDrawer({
     let config: Record<string, unknown>;
     let extra: Partial<RoutineCreatePayload> = {};
     if (entity === "routine") {
-      // 继承既有 config，仅增删本表单管理的 4 个 CC 键，保留 system_prompt 等未暴露键
+      // 继承既有 config，仅增删本表单管理的 CC 键，保留 system_prompt 等未暴露键
       const inherited =
         mode.kind === "routine-edit"
           ? ((mode.routine.config as Record<string, unknown>) ?? {})
@@ -408,19 +427,7 @@ export function RoutineEditDrawer({
             ? ((mode.template.config as Record<string, unknown>) ?? {})
             : {};
       config = { ...inherited };
-      if (form.model.trim()) config.model = form.model.trim();
-      else delete config.model;
-      if (form.max_turns.trim()) config.max_turns = parseInt(form.max_turns, 10);
-      else delete config.max_turns;
-      if (form.max_events_per_iter.trim()) config.max_events_per_iter = parseInt(form.max_events_per_iter, 10);
-      else delete config.max_events_per_iter;
-      if (form.permission_mode.trim()) config.permission_mode = form.permission_mode.trim();
-      else delete config.permission_mode;
-      if (form.allowed_tools.trim())
-        config.allowed_tools = form.allowed_tools.split(",").map((s) => s.trim()).filter(Boolean);
-      else delete config.allowed_tools;
-      if (form.timeout_seconds.trim()) config.timeout_seconds = parseInt(form.timeout_seconds, 10);
-      else delete config.timeout_seconds;
+      applyCCConfig(config, form);
       extra = { cwd: form.cwd.trim() || null, baseline_branch: form.baseline_branch.trim() || null };
     } else {
       // 模板元数据收敛进 config（与列表 API 的读取契约对齐）
@@ -432,6 +439,7 @@ export function RoutineEditDrawer({
         version: form.version.trim() || "1.0.0",
         features_showcase: form.features_showcase.split(",").map((s) => s.trim()).filter(Boolean),
       };
+      applyCCConfig(config, form);
       extra = { is_template: true };
     }
 
@@ -891,9 +899,8 @@ export function RoutineEditDrawer({
                     </div>
                   )}
 
-                  {/* Claude Code Config（仅 routine entity）*/}
-                  {entity === "routine" && (
-                    <div className="border-t border-border pt-3">
+                  {/* Claude Code Config */}
+                  <div className="border-t border-border pt-3">
                       <h4 className="mb-2 text-xs font-medium text-text-secondary">Claude Code Config</h4>
                       <div className="grid grid-cols-2 gap-3">
                         <div className="flex items-center gap-2">
@@ -934,7 +941,6 @@ export function RoutineEditDrawer({
                         />
                       </div>
                     </div>
-                  )}
                 </div>
               )}
             </section>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Edit Template 抽屉页中修改「Max Turns / Iter.」等 CC 配置字段后保存无效——值被静默丢弃。此外「Claude Code Config」区域（Model / Permission Mode / Allowed Tools）被 `entity === "routine"` 守卫隐藏，Template 编辑时不可见，导致 Routine 与 Template 编辑表单不一致。
- 关联上下文/Issue/文档：用户报告截图确认为「Edit Template」抽屉页；根因为 `handleSubmit` template 分支构建 config 时仅写入 category/version/features_showcase。

# 核心变更
- 提取 `applyCCConfig` 共享辅助函数（`ccFromConfig` 的逆操作），将表单 CC 配置字段（max_turns / max_events_per_iter / timeout_seconds / model / permission_mode / allowed_tools）写入 config 对象
- 重构 routine 分支：内联 CC 配置代码替换为 `applyCCConfig(config, form)` 调用（行为零变化，消除重复）
- 修复 template 分支：写入模板元数据后调用 `applyCCConfig(config, form)`，CC 配置字段随模板持久化（核心 Bug Fix）
- 移除「Claude Code Config」区域的 `entity === "routine"` 守卫，使 Template 也可编辑 Model / Permission Mode / Allowed Tools

# 风险与回滚
- 主要风险：低。routine 分支行为零变化（纯提取重构）；template 分支新增 CC config 写入为增量行为，空值 → delete，与 routine 逻辑一致
- 回滚方式：`git revert` 单 commit 即可

# 验证证据
- 单元测试：无（前端 UI 组件）
- 集成测试：无
- E2E/Workflow：TypeScript 编译通过（`tsc --noEmit` 零增量错误）；Pre-commit hooks（ESLint / trailing whitespace / ruff）全部通过
- 覆盖率/关键截图：需浏览器实机验证——Edit Template → 修改 Max Turns / Iter. → Save → 重新打开 → 确认值已持久化

# 影响范围
- 前端：`RoutineEditDrawer.tsx`（+24/-18，唯一改动文件）
- 后端：无改动（`PUT /routines/{id}` 已支持 config JSONB 全量替换）
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器实机验证 Template 编辑保存 CC Config 字段 + Claude Code Config 区域可见性
- 验证 Routine 编辑回归（Max Turns / Iter. 保存不受影响）
- 验证 Template CC config 透传：含 Model 覆盖的模板 → Use Template → 确认 Model 字段预填