### PR TITLE
fix(routine): CC 子进程默认扩展 WebFetch/WebSearch 工具 + mcp_config/disallowed_tools 传递修复

### DIFF
--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -573,6 +573,12 @@ class ClaudeCodeService:
             permission_mode=config.effective_permission_mode(),
             cwd=config.cwd,
         )
+        # MCP 服务器配置：SDK 直接接受 dict 格式（{name: config}）。
+        if config.mcp_config:
+            options.mcp_servers = config.mcp_config
+        # 明确禁止的工具：即使 allowed_tools 包含也不可调用。
+        if config.disallowed_tools:
+            options.disallowed_tools = config.disallowed_tools
         if config.resume_session_id:
             options.resume = config.resume_session_id
         if config.model:
@@ -879,6 +885,13 @@ class ClaudeCodeService:
         # （claude CLI 不支持 --cwd 选项，传了会报 unknown option 错误）
         if config.allowed_tools:
             args += ["--allowed-tools", ",".join(config.allowed_tools)]
+        # 明确禁止的工具列表。
+        if config.disallowed_tools:
+            args += ["--disallowed-tools", ",".join(config.disallowed_tools)]
+        # MCP 服务器配置：CLI --mcp-config 接受 JSON string 或文件路径。
+        # 使用 {"mcpServers": {...}} 封装格式（与 .mcp.json 文件格式一致）。
+        if config.mcp_config:
+            args += ["--mcp-config", json.dumps({"mcpServers": config.mcp_config})]
         # 双向交互模式：允许通过 stdin 实时注入 tool_result 等结构化消息。
         # 用于 Routine 执行中 Engine 自动应答 AskUserQuestion。
         if config.interactive:

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -46,6 +46,21 @@ from .runner import get_runner
 
 logger = get_logger("negentropy.engine.routine.orchestrator")
 
+# Routine 场景默认扩展工具集。
+# 全局 _DEFAULT_TOOLS（6 个基础工具）不含 WebSearch/WebFetch，
+# 但 Routine goal 常见"通过互联网深入调研"等需求，默认扩展。
+# per-routine config.allowed_tools 可显式覆盖此默认值。
+_ROUTINE_DEFAULT_TOOLS = [
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+]
+
 # 非终态迭代状态（一个 routine 同时至多存在一个）
 _NON_TERMINAL_ITER = ("pending_approval", "dispatched", "in_flight", "executed")
 # 每 tick 评估/派发的 routine 批量上限，避免单 tick 过载
@@ -905,8 +920,19 @@ class RoutineOrchestrator:
             config.model = overrides["model"]
         if overrides.get("system_prompt"):
             config.system_prompt = overrides["system_prompt"]
+        # 工具白名单优先级：per-routine config > Routine 扩展默认 > 全局默认。
         if overrides.get("allowed_tools"):
             config.allowed_tools = overrides["allowed_tools"]
+        else:
+            # 全局默认（6 个基础工具）不含 WebSearch/WebFetch；
+            # Routine 常见"互联网调研"需求，默认扩展。
+            config.allowed_tools = _ROUTINE_DEFAULT_TOOLS
+        # per-routine 可显式禁止特定工具（即使 allowed_tools 包含它们）。
+        if overrides.get("disallowed_tools"):
+            config.disallowed_tools = overrides["disallowed_tools"]
+        # per-routine 可覆盖/补充全局 mcp_config（MCP 服务器配置）。
+        if overrides.get("mcp_config"):
+            config.mcp_config = overrides["mcp_config"]
         # permission_mode 由相位决定（PLAN 仅规划、IMPLEMENT/FINALIZE 落盘）——对 worktree routine
         # 与 phased routine 均生效（覆盖 preset 静态值）；旧扁平 routine 沿用 preset 覆盖或全局默认。
         if phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config):

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/claude_code.py
@@ -123,6 +123,7 @@ async def _load_claude_code_defaults():
             model=cfg.get("model"),
             system_prompt=cfg.get("system_prompt"),
             allowed_tools=cfg.get("allowed_tools"),
+            disallowed_tools=cfg.get("disallowed_tools"),
             cwd=cfg.get("cwd") or cfg.get("default_cwd"),
             max_turns=cfg.get("max_turns", 500),
             timeout_seconds=float(cfg.get("timeout_seconds", 300.0)),

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -566,3 +566,66 @@ async def test_reap_workspaces_cleans_succeeded_routine():
             assert r.worktree_path is None  # 句柄已清
     finally:
         await _cleanup(rid)
+
+
+# ---------------------------------------------------------------------------
+# _build_config 工具白名单扩展（Routine 默认含 WebFetch/WebSearch）
+# ---------------------------------------------------------------------------
+
+
+async def test_build_config_uses_routine_default_tools():
+    """_build_config 默认使用 Routine 扩展工具集（含 WebFetch/WebSearch），而非全局 6 工具默认。"""
+    rid = await _make_routine(cwd="/tmp", config={})
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            config = await orch._build_config(r)
+            # 扩展默认包含 WebFetch + WebSearch
+            assert "WebFetch" in config.allowed_tools
+            assert "WebSearch" in config.allowed_tools
+            # 基础工具也在
+            assert "Bash" in config.allowed_tools
+            assert "Edit" in config.allowed_tools
+    finally:
+        await _cleanup(rid)
+
+
+async def test_build_config_per_routine_tools_override():
+    """per-routine config.allowed_tools 显式指定时，覆盖 Routine 扩展默认值。"""
+    rid = await _make_routine(cwd="/tmp", config={"allowed_tools": ["Bash", "Read"]})
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            config = await orch._build_config(r)
+            assert config.allowed_tools == ["Bash", "Read"]
+    finally:
+        await _cleanup(rid)
+
+
+async def test_build_config_disallowed_tools_passthrough():
+    """per-routine config.disallowed_tools 正确透传到 ClaudeCodeConfig。"""
+    rid = await _make_routine(cwd="/tmp", config={"disallowed_tools": ["Task"]})
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            config = await orch._build_config(r)
+            assert config.disallowed_tools == ["Task"]
+    finally:
+        await _cleanup(rid)
+
+
+async def test_build_config_mcp_config_passthrough():
+    """per-routine config.mcp_config 正确透传到 ClaudeCodeConfig。"""
+    mcp = {"test-server": {"type": "stdio", "command": "echo"}}
+    rid = await _make_routine(cwd="/tmp", config={"mcp_config": mcp})
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            config = await orch._build_config(r)
+            assert config.mcp_config == mcp
+    finally:
+        await _cleanup(rid)

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -582,3 +582,44 @@ async def test_invoke_cli_no_error_kind_on_success(monkeypatch):
 
     assert result.status == "success"
     assert result.error_kind is None
+
+
+# ---------------------------------------------------------------------------
+# _build_cli_args：mcp_config / disallowed_tools 传递回归锁定
+# ---------------------------------------------------------------------------
+
+
+async def test_build_cli_args_includes_mcp_config():
+    """mcp_config 非 None 时注入 --mcp-config，封装为 {"mcpServers": {...}} JSON string。"""
+    mcp = {"my-server": {"type": "stdio", "command": "npx", "args": ["-y", "some-mcp"]}}
+    config = ClaudeCodeConfig(mcp_config=mcp)
+    args = ClaudeCodeService._build_cli_args("hello", config)
+    assert "--mcp-config" in args
+    idx = args.index("--mcp-config")
+    payload = json.loads(args[idx + 1])
+    assert "mcpServers" in payload
+    assert "my-server" in payload["mcpServers"]
+
+
+async def test_build_cli_args_omits_mcp_config_when_none():
+    """mcp_config 为 None 时不注入 --mcp-config。"""
+    config = ClaudeCodeConfig(mcp_config=None)
+    args = ClaudeCodeService._build_cli_args("hello", config)
+    assert "--mcp-config" not in args
+
+
+async def test_build_cli_args_includes_disallowed_tools():
+    """disallowed_tools 非 None 时注入 --disallowed-tools。"""
+    config = ClaudeCodeConfig(disallowed_tools=["Task", "WebSearch"])
+    args = ClaudeCodeService._build_cli_args("hello", config)
+    assert "--disallowed-tools" in args
+    idx = args.index("--disallowed-tools")
+    assert "Task" in args[idx + 1]
+    assert "WebSearch" in args[idx + 1]
+
+
+async def test_build_cli_args_omits_disallowed_tools_when_none():
+    """disallowed_tools 为 None 时不注入 --disallowed-tools。"""
+    config = ClaudeCodeConfig(disallowed_tools=None)
+    args = ClaudeCodeService._build_cli_args("hello", config)
+    assert "--disallowed-tools" not in args


### PR DESCRIPTION
## 问题

Routine CC 子进程无法使用任何网络工具（WebSearch、WebFetch、MCP 工具），即使 goal 中明确要求"通过互联网深入调研"。

## 根因

| # | 问题 | 代码位置 | 严重度 |
|---|------|----------|--------|
| 1 | `allowed_tools` 默认仅 `["Bash","Read","Write","Edit","Glob","Grep"]`，不含 WebSearch/WebFetch | `models.py:65` + 迁移 `0039:50` | **主因** |
| 2 | `mcp_config` 字段存在但 SDK/CLI 路径均未传递 | `service.py:569-574` / `:858-886` | 次要 |
| 3 | `disallowed_tools` 字段存在但未传递（死代码） | 同上 | 清理项 |

配置链路：`DB builtin_tools.config` → `_load_claude_code_defaults()` → `orchestrator._build_config()` → `--allowed-tools` / SDK `allowed_tools`。Routine 的 `config` 无 `allowed_tools` 覆盖 → 回退全局默认（6 个工具）。

## 修复

### Fix 1: Routine 扩展工具白名单（主修复）
- `orchestrator.py`: 新增 `_ROUTINE_DEFAULT_TOOLS`（含 `WebFetch`/`WebSearch`），`_build_config` 在 per-routine 未覆盖时使用扩展默认值
- 全局 `_DEFAULT_TOOLS`（6 工具）不变，仅 Routine 路径扩展

### Fix 2: 传递 `mcp_config` 给 CC 子进程
- SDK 路径：设置 `options.mcp_servers = config.mcp_config`
- CLI 路径：添加 `--mcp-config` 参数

### Fix 3: 传递 `disallowed_tools` + 清理死代码
- SDK 路径：设置 `options.disallowed_tools`
- CLI 路径：添加 `--disallowed-tools` 参数
- `_load_claude_code_defaults`：从 DB 读取 `disallowed_tools`

## 测试

+8 新增测试（orchestrator 4 + service 4），全部 62 测试通过 ✅

## 变更文件

| 文件 | 变更 |
|------|------|
| `engine/routine/orchestrator.py` | 新增 `_ROUTINE_DEFAULT_TOOLS`，修改 `_build_config` |
| `engine/claude_code/service.py` | SDK 路径传递 `mcp_servers`/`disallowed_tools`，CLI 路径添加 `--mcp-config`/`--disallowed-tools` |
| `engine/schedulers/handlers/claude_code.py` | `_load_claude_code_defaults` 读取 `disallowed_tools` |
| `tests/integration_tests/engine/test_routine_orchestrator.py` | +4 测试 |
| `tests/unit_tests/engine/test_claude_code_service.py` | +4 测试 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)