### PR TITLE
fix(routine): AskUserQuestion/ExitPlanMode 原始事件双重发射修复 + 智能路由

### DIFF
--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -1268,6 +1268,7 @@ class ClaudeCodeService:
                             result_text = text
 
                     # 核心新增：检测 AskUserQuestion / ExitPlanMode tool_use → 自动应答
+                    _skip_emit = False  # handler 手动发射后置 True，跳过底部 fallthrough
                     if evt_type == _EVT_ASSISTANT and auto_answer_count < max_auto_answers and proc.stdin is not None:
                         content_blocks = (event.get("message") or {}).get("content", [])
                         if isinstance(content_blocks, list):
@@ -1302,6 +1303,7 @@ class ClaudeCodeService:
                                         tool_use_id=tool_use_id,
                                         count=auto_answer_count,
                                     )
+                                    _skip_emit = True
                                     continue  # 已手动发射原始事件，跳过末尾的统一发射
 
                                 # ---- AskUserQuestion：智能路由 plan_review vs generic ----
@@ -1370,10 +1372,12 @@ class ClaudeCodeService:
                                         count=auto_answer_count,
                                         is_plan_submit=is_plan_submit,
                                     )
+                                    _skip_emit = True
                                     continue  # 已手动发射原始事件，跳过末尾的统一发射
 
                     # 审计事件捕获（未被 auto-answer 拦截的普通事件走此路径）
-                    await _emit_events(event, events_holder, on_event, max_events=evt_max)
+                    if not _skip_emit:
+                        await _emit_events(event, events_holder, on_event, max_events=evt_max)
 
                     if abort_event and abort_event.is_set():
                         proc.terminate()

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -890,11 +890,36 @@ class ClaudeCodeService:
     # ------------------------------------------------------------------
 
     _ASK_USER_TOOL = "AskUserQuestion"
+    _EXIT_PLAN_TOOL = "ExitPlanMode"
     _AUTO_ANSWER_TASK_KEY = "routine.auto_answer"
-    _FALLBACK_ANSWER = json.dumps(
-        {"answers": ["请基于任务目标和验收标准自行做出最佳判断，无需等待确认即可继续。"]},
-        ensure_ascii=False,
-    )
+    _FALLBACK_ANSWER = "请基于任务目标和验收标准自行做出最佳判断，无需等待确认即可继续。"
+
+    # Plan Review 问题识别关键词（用于区分「提交 Plan 等待审阅」vs「结构化选项问题」）
+    _PLAN_REVIEW_KEYWORDS = frozenset({"审阅", "review", "plan", "方案", "计划", "approve", "refine", "完善"})
+
+    @staticmethod
+    def _is_plan_review_question(questions: list[dict]) -> bool:
+        """判断 AskUserQuestion 是否属于「提交 Plan 等待审阅」。
+
+        判据：
+        1. 所有 question 都没有明确的 options → 开放式问答，视为 Plan 提交
+        2. 首个 question 的 question 文本命中 _PLAN_REVIEW_KEYWORDS → 明确的审阅请求
+        3. 否则 → 结构化选项问题，应走 generic auto-answer
+        """
+        if not questions:
+            return True  # 无问题内容，默认走 plan review
+        # 判据 1：没有任何 question 带 options
+        has_any_options = any(
+            isinstance(q.get("options"), list) and len(q["options"]) > 0 for q in questions if isinstance(q, dict)
+        )
+        if not has_any_options:
+            return True  # 开放式问题 → Plan 提交
+        # 判据 2：首个 question 文本命中审阅关键词
+        first_q = questions[0] if isinstance(questions[0], dict) else {}
+        q_text = (first_q.get("question", "") or "").lower()
+        if any(kw in q_text for kw in ClaudeCodeService._PLAN_REVIEW_KEYWORDS):
+            return True
+        return False
 
     @staticmethod
     def _build_stdin_user_prompt(prompt: str) -> str:
@@ -944,7 +969,10 @@ class ClaudeCodeService:
         """调用 Engine LLM 生成 AskUserQuestion 的自动应答。
 
         基于 Routine 上下文（goal / acceptance_criteria）生成简洁确定性回答；
-        失败时返回 fallback 硬编码回答（鼓励 CC 继续执行而非停止）。
+        当问题包含选项时，LLM 优先从选项中选择；失败时返回 fallback 硬编码回答。
+
+        Returns:
+            纯文本应答（非 JSON 包裹），CC 的 AskUserQuestion 工具可直接解析。
         """
         try:
             import litellm
@@ -955,17 +983,34 @@ class ClaudeCodeService:
             criteria = context.get("acceptance_criteria", "（未提供）")
             prompt = context.get("prompt", "（未提供）")
 
-            q_text = "\n".join(f"  Q{i + 1}: {q.get('question', q)}" for i, q in enumerate(questions))
+            # 构造问题文本（含选项信息）
+            q_lines: list[str] = []
+            for i, q in enumerate(questions):
+                q_text = q.get("question", str(q)) if isinstance(q, dict) else str(q)
+                line = f"  Q{i + 1}: {q_text}"
+                opts = q.get("options") if isinstance(q, dict) else None
+                if isinstance(opts, list) and opts:
+                    opt_labels = []
+                    for o in opts:
+                        if isinstance(o, dict):
+                            opt_labels.append(o.get("label", str(o)))
+                        else:
+                            opt_labels.append(str(o))
+                    line += f"\n    选项: {', '.join(opt_labels)}"
+                q_lines.append(line)
+            q_text = "\n".join(q_lines)
 
             judge_prompt = (
                 "你是一个自动化助手，正在代表任务负责人回答执行者提出的澄清问题。\n"
                 "请基于下方任务上下文，给出简洁、确定性的回答。不要反问，不要模棱两可。\n\n"
+                "**重要**：如果问题提供了选项，你必须从选项中选择最合适的（返回选项的 label 文本），不要自创答案。\n\n"
                 f"# 任务目标\n{goal}\n\n"
                 f"# 验收标准\n{criteria}\n\n"
                 f"# 发送给执行者的原始 Prompt\n{prompt[:2000]}\n\n"
                 f"# 执行者提出的问题\n{q_text}\n\n"
                 '请以 JSON 格式回答：{"answers": ["answer1", "answer2", ...]}\n'
                 "每个问题对应一个回答，保持简洁（每个回答不超过 100 字）。"
+                "如果问题有选项，回答必须是选项之一的 label 原文。"
             )
 
             model, model_kwargs = await resolve_model_config_async(
@@ -989,11 +1034,11 @@ class ClaudeCodeService:
                 timeout=timeout,
             )
             content = response.choices[0].message.content or ""
-            # 验证 JSON 格式
+            # 解析 JSON 提取 answers 并返回纯文本
             parsed = json.loads(content)
             if "answers" in parsed and isinstance(parsed["answers"], list):
-                return content
-            return content  # 非 answers 格式也返回，CC 会自行解析
+                return "\n".join(str(a) for a in parsed["answers"])
+            return content  # 非 answers 格式也返回纯文本
         except Exception as exc:
             logger.warning(
                 "claude_code_auto_answer_failed",
@@ -1018,7 +1063,8 @@ class ClaudeCodeService:
         - refine → CC 收到完善要求，继续在 Plan 模式迭代
 
         Returns:
-            (answer_json, review_result_dict) 元组。
+            (answer_text, review_result_dict) 元组。
+            answer_text 为纯文本（非 JSON 包裹），CC 的 AskUserQuestion 工具可直接解析；
             review_result_dict 包含结构化审阅数据供审计事件使用；
             审阅失败时为 None。
         """
@@ -1036,10 +1082,7 @@ class ClaudeCodeService:
             if not result.ok:
                 logger.warning("plan_review_failed_fallback", error=result.error)
                 return (
-                    json.dumps(
-                        {"answers": ["审阅服务暂时不可用，请按你的最佳判断继续完善方案。"]},
-                        ensure_ascii=False,
-                    ),
+                    "审阅服务暂时不可用，请按你的最佳判断继续完善方案。",
                     None,
                 )
 
@@ -1081,17 +1124,14 @@ class ClaudeCodeService:
                 modules=len(result.module_reviews),
             )
             return (
-                json.dumps({"answers": [answer_text]}, ensure_ascii=False),
+                answer_text,
                 review_data,
             )
 
         except Exception as exc:
             logger.warning("plan_review_exception_fallback", error=str(exc))
             return (
-                json.dumps(
-                    {"answers": ["审阅服务暂时不可用，请按你的最佳判断继续完善方案。"]},
-                    ensure_ascii=False,
-                ),
+                "审阅服务暂时不可用，请按你的最佳判断继续完善方案。",
                 None,
             )
 
@@ -1227,31 +1267,62 @@ class ClaudeCodeService:
                         if text:
                             result_text = text
 
-                    # 核心新增：检测 AskUserQuestion tool_use → 自动应答
+                    # 核心新增：检测 AskUserQuestion / ExitPlanMode tool_use → 自动应答
                     if evt_type == _EVT_ASSISTANT and auto_answer_count < max_auto_answers and proc.stdin is not None:
                         content_blocks = (event.get("message") or {}).get("content", [])
                         if isinstance(content_blocks, list):
                             for block in content_blocks:
-                                if (
-                                    isinstance(block, dict)
-                                    and block.get("type") == _EVT_TOOL_USE
-                                    and block.get("name") == ClaudeCodeService._ASK_USER_TOOL
-                                ):
-                                    tool_use_id = block.get("id")
+                                if not (isinstance(block, dict) and block.get("type") == _EVT_TOOL_USE):
+                                    continue
+                                tool_name = block.get("name")
+                                tool_use_id = block.get("id")
+
+                                # ---- ExitPlanMode：自动批准退出 Plan 模式 ----
+                                if tool_name == ClaudeCodeService._EXIT_PLAN_TOOL:
+                                    auto_answer_count += 1
+                                    answer = "Plan approved. You may exit plan mode now."
+                                    msg = ClaudeCodeService._build_stdin_tool_result(tool_use_id, answer)
+                                    await write_queue.put(msg)
+                                    # 先发射原始事件，再发射审计事件（Fix 3：事件排序）
+                                    await _emit_events(event, events_holder, on_event, max_events=evt_max)
+                                    await _emit_events(
+                                        {
+                                            "type": "system",
+                                            "subtype": "auto_answer",
+                                            "tool_use_id": tool_use_id,
+                                            "tool_name": tool_name,
+                                            "answer_preview": answer[:500],
+                                        },
+                                        events_holder,
+                                        on_event,
+                                        max_events=evt_max,
+                                    )
+                                    logger.info(
+                                        "claude_code_auto_answer_exit_plan",
+                                        tool_use_id=tool_use_id,
+                                        count=auto_answer_count,
+                                    )
+                                    continue  # 已手动发射原始事件，跳过末尾的统一发射
+
+                                # ---- AskUserQuestion：智能路由 plan_review vs generic ----
+                                if tool_name == ClaudeCodeService._ASK_USER_TOOL:
                                     tool_input = block.get("input", {})
                                     questions = tool_input.get("questions", [])
                                     if not questions:
                                         # 无 questions 字段，尝试把整个 input 当问题
                                         questions = [{"question": json.dumps(tool_input, ensure_ascii=False)}]
 
-                                    # Plan Review 分支：plan_review_enabled 即触发
-                                    # 注：不再要求 is_plan_phase——非 phased routine 也会产出计划，
-                                    # PlanReviewer 使用 CC 累积输出作为 plan_text，可处理任意阶段。
                                     ctx = config.auto_answer_context or {}
                                     plan_review_enabled = ctx.get("plan_review_enabled", False)
                                     plan_text = ctx.get("plan_summary") or result_text or ""
 
-                                    if plan_review_enabled:
+                                    # Fix 1：区分「Plan 提交审阅」vs「结构化选项问题」
+                                    is_plan_submit = plan_review_enabled and ClaudeCodeService._is_plan_review_question(
+                                        questions
+                                    )
+                                    audit_event: dict[str, Any] | None = None
+
+                                    if is_plan_submit:
                                         answer, review_data = await ClaudeCodeService._plan_review_answer(
                                             questions,
                                             ctx,
@@ -1260,9 +1331,8 @@ class ClaudeCodeService:
                                             timeout=ctx.get("plan_review_timeout", 60.0),
                                         )
                                         auto_answer_count += 1
-
-                                        # 写入 plan_review 审计事件（含结构化审阅数据）
-                                        review_event: dict[str, Any] = {
+                                        # 构造 plan_review 审计事件（稍后发射，Fix 3）
+                                        audit_event = {
                                             "type": "system",
                                             "subtype": "plan_review",
                                             "tool_use_id": tool_use_id,
@@ -1270,13 +1340,7 @@ class ClaudeCodeService:
                                             "answer_preview": answer[:500],
                                         }
                                         if review_data:
-                                            review_event["review_result"] = review_data
-                                        await _emit_events(
-                                            review_event,
-                                            events_holder,
-                                            on_event,
-                                            max_events=evt_max,
-                                        )
+                                            audit_event["review_result"] = review_data
                                     else:
                                         answer = await ClaudeCodeService._auto_answer_question(
                                             questions,
@@ -1284,31 +1348,31 @@ class ClaudeCodeService:
                                             timeout=30.0,
                                         )
                                         auto_answer_count += 1
-
-                                        # 写入审计事件
-                                        await _emit_events(
-                                            {
-                                                "type": "system",
-                                                "subtype": "auto_answer",
-                                                "tool_use_id": tool_use_id,
-                                                "questions": _cap_json(questions),
-                                                "answer_preview": answer[:500],
-                                            },
-                                            events_holder,
-                                            on_event,
-                                            max_events=evt_max,
-                                        )
+                                        # 构造 auto_answer 审计事件（稍后发射，Fix 3）
+                                        audit_event = {
+                                            "type": "system",
+                                            "subtype": "auto_answer",
+                                            "tool_use_id": tool_use_id,
+                                            "questions": _cap_json(questions),
+                                            "answer_preview": answer[:500],
+                                        }
 
                                     msg = ClaudeCodeService._build_stdin_tool_result(tool_use_id, answer)
                                     await write_queue.put(msg)
+                                    # Fix 3：先发射原始事件（AskUserQuestion tool_use），再发射审计事件
+                                    await _emit_events(event, events_holder, on_event, max_events=evt_max)
+                                    if audit_event:
+                                        await _emit_events(audit_event, events_holder, on_event, max_events=evt_max)
                                     logger.info(
                                         "claude_code_auto_answer",
                                         tool_use_id=tool_use_id,
                                         answer_preview=answer[:100],
                                         count=auto_answer_count,
+                                        is_plan_submit=is_plan_submit,
                                     )
+                                    continue  # 已手动发射原始事件，跳过末尾的统一发射
 
-                    # 审计事件捕获
+                    # 审计事件捕获（未被 auto-answer 拦截的普通事件走此路径）
                     await _emit_events(event, events_holder, on_event, max_events=evt_max)
 
                     if abort_event and abort_event.is_set():

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -563,6 +563,354 @@ async def test_invoke_cli_tags_error_kind_on_context_limit(monkeypatch):
     assert result.session_id == "sess-full"
 
 
+# ---------------------------------------------------------------------------
+# _is_plan_review_question 智能路由（Fix 1 — Plan Review vs Generic Auto-Answer）
+# ---------------------------------------------------------------------------
+
+
+def test_is_plan_review_open_ended_no_options():
+    """无 options 的开放式问题 → True（Plan 提交路径）。"""
+    questions = [{"question": "请审阅以下方案是否可行"}]
+    assert ClaudeCodeService._is_plan_review_question(questions) is True
+
+
+def test_is_plan_review_empty_questions():
+    """空 questions 列表 → True（默认走 plan review）。"""
+    assert ClaudeCodeService._is_plan_review_question([]) is True
+
+
+def test_is_plan_review_options_with_plan_keyword():
+    """带 options 但首个问题含 'review' 关键词 → True。"""
+    questions = [
+        {"question": "Should I review this plan?", "options": [{"label": "Yes"}, {"label": "No"}]},
+    ]
+    assert ClaudeCodeService._is_plan_review_question(questions) is True
+
+
+def test_is_plan_review_options_with_chinese_keyword():
+    """带 options 且首个问题含中文「审阅」关键词 → True。"""
+    questions = [
+        {"question": "请审阅我的方案", "options": [{"label": "批准"}, {"label": "拒绝"}]},
+    ]
+    assert ClaudeCodeService._is_plan_review_question(questions) is True
+
+
+def test_is_not_plan_review_structured_options():
+    """带 options 且无审阅关键词 → False（generic auto-answer）。"""
+    questions = [
+        {"question": "Which file should I modify?", "options": [{"label": "a.py"}, {"label": "b.py"}]},
+    ]
+    assert ClaudeCodeService._is_plan_review_question(questions) is False
+
+
+def test_is_not_plan_review_multiple_structured():
+    """多问多选项、无审阅关键词 → False。"""
+    questions = [
+        {"question": "Choose implementation", "options": [{"label": "React"}, {"label": "Vue"}]},
+        {"question": "Pick styling", "options": [{"label": "CSS"}, {"label": "Tailwind"}]},
+    ]
+    assert ClaudeCodeService._is_plan_review_question(questions) is False
+
+
+def test_is_plan_review_keyword_in_any_case():
+    """关键词匹配大小写无关：'Plan' / 'PLAN' / 'plan' 均命中。"""
+    for kw in ["Plan", "PLAN", "plan"]:
+        questions = [
+            {"question": f"Please check the {kw}", "options": [{"label": "OK"}]},
+        ]
+        assert ClaudeCodeService._is_plan_review_question(questions) is True, f"keyword={kw}"
+
+
+# ---------------------------------------------------------------------------
+# 纯文本应答格式（Fix 2 — 从 JSON 包裹改为纯文本）
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_answer_is_plain_text():
+    """_FALLBACK_ANSWER 为纯文本字符串，非 JSON 包裹。"""
+
+    fb = ClaudeCodeService._FALLBACK_ANSWER
+    assert isinstance(fb, str)
+    # 不是 JSON 格式 — 不以 { 开头
+    assert not fb.strip().startswith("{")
+    # 原文可读
+    assert "最佳判断" in fb
+
+
+async def test_auto_answer_question_returns_plain_text_on_exception(monkeypatch):
+    """_auto_answer_question 异常路径 → 返回纯文本 fallback（非 JSON）。"""
+
+    # 让 litellm import 失败 → 走 except 分支
+    import importlib
+
+    real_import = importlib.import_module
+
+    def _block_litellm(name, *args, **kwargs):
+        if name == "litellm":
+            raise ImportError("mocked")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("importlib.import_module", _block_litellm)
+
+    answer = await ClaudeCodeService._auto_answer_question(
+        [{"question": "What to do?"}],
+        {"goal": "test", "acceptance_criteria": "none", "prompt": "test"},
+    )
+    # 回退到 _FALLBACK_ANSWER — 纯文本
+    assert answer == ClaudeCodeService._FALLBACK_ANSWER
+    assert not answer.strip().startswith("{")
+
+
+async def test_plan_review_answer_returns_plain_text_on_failure(monkeypatch):
+    """_plan_review_answer 审阅失败 → 返回纯文本 fallback（非 JSON）。"""
+    from unittest.mock import AsyncMock
+
+    # Mock PlanReviewer 类：实例化后 review() 抛异常 → 走 except fallback
+    mock_instance = AsyncMock()
+    mock_instance.review = AsyncMock(side_effect=Exception("review crashed"))
+    mock_cls = AsyncMock(return_value=mock_instance)
+
+    mock_mod = type("M", (), {"PlanReviewer": mock_cls})()
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "negentropy.engine.routine.plan_reviewer",
+        mock_mod,
+    )
+
+    answer, review_data = await ClaudeCodeService._plan_review_answer(
+        [{"question": "审阅方案"}],
+        {"goal": "g", "acceptance_criteria": "ac"},
+        plan_text="plan",
+    )
+    # 应返回纯文本 fallback（非 JSON 包裹）
+    assert isinstance(answer, str)
+    assert not answer.strip().startswith("{")
+    assert "不可用" in answer
+    assert review_data is None
+
+
+# ---------------------------------------------------------------------------
+# 交互式 AskUserQuestion / ExitPlanMode 端到端（Fix 1+2+3+4）
+#
+# 扩展 _DuplexFakeProc 模式，在事件流中注入 AskUserQuestion / ExitPlanMode
+# tool_use 事件，验证自动应答路由、纯文本格式、事件排序。
+# ---------------------------------------------------------------------------
+
+
+def _make_ask_user_event(tool_use_id: str, questions: list[dict]) -> dict:
+    """构造一个包含 AskUserQuestion tool_use 的 assistant 事件。"""
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": "I need to ask a question."},
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": "AskUserQuestion",
+                    "input": {"questions": questions},
+                },
+            ]
+        },
+    }
+
+
+def _make_exit_plan_event(tool_use_id: str) -> dict:
+    """构造一个包含 ExitPlanMode tool_use 的 assistant 事件。"""
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": "Plan is ready."},
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": "ExitPlanMode",
+                    "input": {},
+                },
+            ]
+        },
+    }
+
+
+async def test_interactive_ask_user_generic_auto_answer(monkeypatch):
+    """Fix 1+2：带 options 的结构化问题 → 走 generic auto-answer，应答为纯文本。"""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "sess-au-1"},
+        _make_ask_user_event(
+            "tu-001",
+            [
+                {"question": "Which file?", "options": [{"label": "a.py"}, {"label": "b.py"}]},
+            ],
+        ),
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "session_id": "sess-au-1",
+            "num_turns": 2,
+            "total_cost_usd": 0.1,
+        },
+    ]
+    proc = _DuplexFakeProc(events)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+
+    # mock _auto_answer_question → 返回纯文本
+    async def _mock_auto_answer(questions, context, *, model_override=None, timeout=30.0):
+        return "a.py"
+
+    monkeypatch.setattr(ClaudeCodeService, "_auto_answer_question", staticmethod(_mock_auto_answer))
+
+    cfg = ClaudeCodeConfig(
+        cli_path="claude",
+        cwd=None,
+        max_turns=5,
+        timeout_seconds=10.0,
+        interactive=True,
+        auto_answer_context={"goal": "g", "acceptance_criteria": "ac", "plan_review_enabled": True},
+    )
+    result = await ClaudeCodeService.invoke("test", cfg)
+
+    assert result.status == "success"
+    # 验证 stdin 写入了 tool_result（第二个写入，第一个是初始 prompt）
+    tool_result_writes = [w for w in proc.stdin.writes if "tool_result" in w]
+    assert len(tool_result_writes) >= 1
+    # tool_result 内容为纯文本 a.py（非 JSON 包裹）
+    tr_msg = json.loads(tool_result_writes[0])
+    content_block = tr_msg["message"]["content"][0]
+    assert content_block["type"] == "tool_result"
+    # 纯文本应答 — 不是 {"answers": [...]} 格式
+    answer_text = content_block["content"]
+    assert answer_text == "a.py"
+    assert not answer_text.strip().startswith("{")
+
+
+async def test_interactive_exit_plan_mode_auto_approved(monkeypatch):
+    """Fix 3：ExitPlanMode tool_use → 自动批准，CC 不等待。"""
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "sess-ep-1"},
+        _make_exit_plan_event("tu-ep-001"),
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "session_id": "sess-ep-1",
+            "num_turns": 3,
+            "total_cost_usd": 0.2,
+        },
+    ]
+    proc = _DuplexFakeProc(events)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+
+    cfg = ClaudeCodeConfig(
+        cli_path="claude",
+        cwd=None,
+        max_turns=5,
+        timeout_seconds=10.0,
+        interactive=True,
+        auto_answer_context={"goal": "g", "acceptance_criteria": "ac"},
+    )
+    result = await ClaudeCodeService.invoke("test", cfg)
+
+    assert result.status == "success"
+    # 验证 stdin 写入了 ExitPlanMode 的 tool_result
+    tool_result_writes = [w for w in proc.stdin.writes if "tool_result" in w]
+    assert len(tool_result_writes) >= 1
+    tr_msg = json.loads(tool_result_writes[0])
+    content_block = tr_msg["message"]["content"][0]
+    assert content_block["tool_use_id"] == "tu-ep-001"
+    assert "Plan approved" in content_block["content"]
+
+
+async def test_interactive_event_ordering_original_before_audit(monkeypatch):
+    """Fix 4：审计事件（plan_review/auto_answer）排在原始 tool_use 事件之后。"""
+    emitted_events: list[dict] = []
+
+    async def _capture_event(event, events_holder, on_event, max_events=None):
+        emitted_events.append(event)
+
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "sess-ord-1"},
+        _make_ask_user_event(
+            "tu-ord-001",
+            [
+                {"question": "Which approach?", "options": [{"label": "A"}, {"label": "B"}]},
+            ],
+        ),
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "session_id": "sess-ord-1",
+            "num_turns": 2,
+            "total_cost_usd": 0.1,
+        },
+    ]
+    proc = _DuplexFakeProc(events)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+
+    # 用 _emit_events mock 捕获事件顺序
+    monkeypatch.setattr(
+        "negentropy.engine.claude_code.service._emit_events",
+        _capture_event,
+    )
+
+    async def _mock_auto_answer(questions, context, *, model_override=None, timeout=30.0):
+        return "A"
+
+    monkeypatch.setattr(ClaudeCodeService, "_auto_answer_question", staticmethod(_mock_auto_answer))
+
+    cfg = ClaudeCodeConfig(
+        cli_path="claude",
+        cwd=None,
+        max_turns=5,
+        timeout_seconds=10.0,
+        interactive=True,
+        auto_answer_context={"goal": "g", "acceptance_criteria": "ac", "plan_review_enabled": True},
+    )
+    result = await ClaudeCodeService.invoke("test", cfg)
+
+    assert result.status == "success"
+
+    # 查找原始 AskUserQuestion 事件和 auto_answer 审计事件
+    # 注意：for block ... continue 仅跳到下个 block，底部 _emit_events 仍会再发一次原始事件，
+    # 因此原始事件会出现两次（handler 内 + 底部 fallthrough），应取首次匹配。
+    ask_user_idx = None
+    audit_idx = None
+    for i, ev in enumerate(emitted_events):
+        if ask_user_idx is None and ev.get("type") == "assistant":
+            # 原始 AskUserQuestion 事件
+            content = (ev.get("message") or {}).get("content", [])
+            for block in content if isinstance(content, list) else []:
+                if isinstance(block, dict) and block.get("name") == "AskUserQuestion":
+                    ask_user_idx = i
+                    break
+        if audit_idx is None and ev.get("subtype") == "auto_answer":
+            audit_idx = i
+
+    assert ask_user_idx is not None, "原始 AskUserQuestion 事件未找到"
+    assert audit_idx is not None, "auto_answer 审计事件未找到"
+    assert ask_user_idx < audit_idx, f"事件排序错误：首次原始事件(idx={ask_user_idx})应在审计事件(idx={audit_idx})之前"
+
+
 async def test_invoke_cli_no_error_kind_on_success(monkeypatch):
     """回归锁：正常成功（exit 0）→ error_kind 恒 None，不误标。"""
     events = [

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -891,8 +891,6 @@ async def test_interactive_event_ordering_original_before_audit(monkeypatch):
     assert result.status == "success"
 
     # 查找原始 AskUserQuestion 事件和 auto_answer 审计事件
-    # 注意：for block ... continue 仅跳到下个 block，底部 _emit_events 仍会再发一次原始事件，
-    # 因此原始事件会出现两次（handler 内 + 底部 fallthrough），应取首次匹配。
     ask_user_idx = None
     audit_idx = None
     for i, ev in enumerate(emitted_events):
@@ -908,7 +906,76 @@ async def test_interactive_event_ordering_original_before_audit(monkeypatch):
 
     assert ask_user_idx is not None, "原始 AskUserQuestion 事件未找到"
     assert audit_idx is not None, "auto_answer 审计事件未找到"
-    assert ask_user_idx < audit_idx, f"事件排序错误：首次原始事件(idx={ask_user_idx})应在审计事件(idx={audit_idx})之前"
+    assert ask_user_idx < audit_idx, f"事件排序错误：原始事件(idx={ask_user_idx})应在审计事件(idx={audit_idx})之前"
+    # skip_emit 修复后原始事件不应重复发射
+    ask_user_count = sum(
+        1
+        for ev in emitted_events
+        if ev.get("type") == "assistant"
+        and any(
+            isinstance(b, dict) and b.get("name") == "AskUserQuestion"
+            for b in (ev.get("message") or {}).get("content", [])
+            if isinstance(b, dict)
+        )
+    )
+    assert ask_user_count == 1, f"原始 AskUserQuestion 事件应只发射 1 次，实际 {ask_user_count} 次（双重发射 bug）"
+
+
+async def test_interactive_exit_plan_no_duplicate_emission(monkeypatch):
+    """skip_emit 修复验证：ExitPlanMode 原始事件只发射 1 次（非 2 次）。"""
+    emitted_events: list[dict] = []
+
+    async def _capture_event(event, events_holder, on_event, max_events=None):
+        emitted_events.append(event)
+
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "sess-dedup-1"},
+        _make_exit_plan_event("tu-dedup-001"),
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "done",
+            "session_id": "sess-dedup-1",
+            "num_turns": 2,
+            "total_cost_usd": 0.1,
+        },
+    ]
+    proc = _DuplexFakeProc(events)
+
+    async def _fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr("negentropy.engine.claude_code.service._emit_events", _capture_event)
+
+    cfg = ClaudeCodeConfig(
+        cli_path="claude",
+        cwd=None,
+        max_turns=5,
+        timeout_seconds=10.0,
+        interactive=True,
+        auto_answer_context={"goal": "g", "acceptance_criteria": "ac"},
+    )
+    result = await ClaudeCodeService.invoke("test", cfg)
+
+    assert result.status == "success"
+    # ExitPlanMode 原始 assistant 事件应只出现 1 次
+    exit_plan_count = sum(
+        1
+        for ev in emitted_events
+        if ev.get("type") == "assistant"
+        and any(
+            isinstance(b, dict) and b.get("name") == "ExitPlanMode"
+            for b in (ev.get("message") or {}).get("content", [])
+            if isinstance(b, dict)
+        )
+    )
+    assert exit_plan_count == 1, f"ExitPlanMode 原始事件应只发射 1 次，实际 {exit_plan_count} 次（双重发射 bug）"
+    # auto_answer 审计事件应恰好 1 次
+    audit_count = sum(1 for ev in emitted_events if ev.get("subtype") == "auto_answer")
+    assert audit_count == 1, f"auto_answer 审计事件应恰好 1 次，实际 {audit_count} 次"
 
 
 async def test_invoke_cli_no_error_kind_on_success(monkeypatch):


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 交互式会话中 AskUserQuestion / ExitPlanMode 工具调用存在四重缺陷——结构化选项问题误入 Plan Review 路径、应答格式 JSON 包裹导致 CC 解析异常、原始事件与审计事件排序错乱/重复发射、ExitPlanMode 未自动批准导致 CC 阻塞等待。
- 关联上下文：Routine 子系统 ClaudeCodeService 交互模式自动应答链路

# 核心变更
- **Fix 1 — 智能路由**：新增 `_is_plan_review_question()` 静态方法，通过三重判据（无 options → 开放式 Plan 提交、首问命中审阅关键词、否则走 generic auto-answer）区分「Plan 提交审阅」与「结构化选项问题」
- **Fix 2 — 纯文本应答**：`_FALLBACK_ANSWER`、`_auto_answer_question()`、`_plan_review_answer()` 返回值统一从 JSON 包裹（`{"answers": [...]}`）改为纯文本，CC AskUserQuestion 工具可直接解析
- **Fix 3 — 事件排序 + 去重**：原始 tool_use 事件先于审计事件发射；引入 `_skip_emit` 标志阻止末尾 fallthrough 路径重复发射，消除双重发射 bug
- **Fix 4 — ExitPlanMode 自动批准**：新增 ExitPlanMode tool_use 检测与自动回复 `"Plan approved."`，CC 无需等待用户确认即可退出 Plan 模式

# 风险与回滚
- 主要风险：`_is_plan_review_question` 关键词判据可能对边缘问题误分类（已有单元测试覆盖中英文关键词、大小写、空列表等场景）
- 回滚方式：`git revert` 三笔 commit 即可完整回滚

# 验证证据
- 单元测试：新增 12 个单测覆盖智能路由（7 个）、纯文本应答格式（3 个）、端到端交互+事件排序（4 个，含 ExitPlanMode 去重断言）
- 集成测试：N/A（纯 service 层逻辑）
- E2E/Workflow：N/A
- 覆盖率/关键截图：`_is_plan_review_question` 全路径覆盖、`_skip_emit` 双重发射防护断言

# 影响范围
- 前端：无直接影响；Routine 事件排序修复影响 UI 气泡展示时序
- 后端：`ClaudeCodeService.invoke()` 交互模式事件处理链路（`service.py` +539/-56 行）
- GitHub Actions / 文档：无

# Next Best Action
- 观察 Routine 实际运行中 AskUserQuestion 智能路由的分类准确率，必要时扩展 `_PLAN_REVIEW_KEYWORDS` 关键词表