### PR TITLE
fix(routine): 防止 Claude Code 子进程读取不相关兄弟项目文件

### DIFF
--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -85,6 +85,43 @@ def _cap(value: str | None, limit: int = _EVENT_FIELD_CAP) -> str | None:
     return value
 
 
+def _build_scope_system_prompt(routine: Routine) -> str:
+    """构建文件系统作用域限制的 system prompt 片段（对所有 routine 类型生效）。
+
+    system_prompt 层级的指令优先级高于用户 prompt 中的任务描述，
+    使作用域限制即使当 goal 文本引用了外部绝对路径时也能生效。
+
+    根因修复：worktree 存储在项目父目录的 ``.negentropy-worktrees/`` 下，
+    与兄弟项目（如 coding-proxy、attention）同级；Claude Code 自主探索
+    时可能误读这些不相关项目。本函数通过 system prompt 显式限定读取范围。
+    """
+    cwd = routine.cwd or ""
+    wt_path = getattr(routine, "worktree_path", None) or ""
+    is_wt = phase_mod.is_worktree_routine(routine)
+
+    if is_wt and wt_path:
+        source_line = f"\n  - The source project: `{cwd}` (read-only reference)." if cwd else ""
+        return (
+            "## File System Scope (文件系统作用域)\n"
+            f"Working directory: `{wt_path}` (isolated worktree).\n"
+            "READ scope — you may ONLY read files within:\n"
+            f"  1. The worktree directory and its subdirectories.{source_line}\n"
+            "  2. Absolute paths explicitly referenced in the task goal.\n"
+            "You MUST NOT read, list, or explore sibling directories of the worktree parent "
+            "or any other local projects outside the above scope.\n"
+            "Exceptions: WebSearch, WebFetch, and MCP tools are not restricted."
+        )
+    elif cwd:
+        return (
+            "## File System Scope (文件系统作用域)\n"
+            f"Project root: `{cwd}`.\n"
+            "You may ONLY read files within the project root and its subdirectories. "
+            "You MUST NOT read, list, or explore sibling directories or other local projects.\n"
+            "Exceptions: WebSearch, WebFetch, and MCP tools are not restricted."
+        )
+    return ""
+
+
 def _lease_extension() -> timedelta:
     """本进程仍在执行时的 lease 顺延量（= inspector 间隔 + slack）。"""
     return timedelta(seconds=settings.routine.inspector_interval_seconds + settings.routine.lease_slack_seconds)
@@ -918,7 +955,16 @@ class RoutineOrchestrator:
             config.max_events_per_iter = int(overrides["max_events_per_iter"])
         if overrides.get("model"):
             config.model = overrides["model"]
-        if overrides.get("system_prompt"):
+        # 注入作用域限制到 system_prompt（最高优先级指令层）。
+        # 即使 goal 文本引用了外部绝对路径，system prompt 层的作用域限制也能防止
+        # Claude Code 自主探索兄弟项目目录。
+        scope_instruction = _build_scope_system_prompt(routine)
+        if scope_instruction:
+            if overrides.get("system_prompt"):
+                config.system_prompt = scope_instruction + "\n\n" + overrides["system_prompt"]
+            else:
+                config.system_prompt = scope_instruction
+        elif overrides.get("system_prompt"):
             config.system_prompt = overrides["system_prompt"]
         # 工具白名单优先级：per-routine config > Routine 扩展默认 > 全局默认。
         if overrides.get("allowed_tools"):

--- a/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
+++ b/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
@@ -27,6 +27,7 @@ class _RoutineLike(Protocol):
     current_phase: str
     baseline_branch: str | None
     work_branch: str | None
+    cwd: str | None
 
 
 def build_prompt(
@@ -70,11 +71,24 @@ def build_prompt(
     if worktree:
         baseline = getattr(routine, "baseline_branch", None) or "(baseline)"
         work_branch = getattr(routine, "work_branch", None)
+        source_cwd = getattr(routine, "cwd", None) or ""
+        scope_note = ""
+        if source_cwd:
+            scope_note = f"\n   - 源项目目录 `{source_cwd}` 及其子目录（仅参考，不可修改）"
         parts.append(
             "# 隔离工作区 (Isolated Worktree)\n你正在一个隔离 git worktree（当前工作目录）中工作：\n"
             f"- 工作分支：`{work_branch or '（引擎将基于基线创建）'}`\n"
-            f"- 基线分支：`{baseline}`\n"
-            "请仅在当前工作目录内改动；**绝不**切换分支、推送或污染基线分支与 master/main。"
+            f"- 基线分支：`{baseline}`\n\n"
+            "## 作用域限制 (Scope Constraints)\n"
+            "**读取范围**：仅允许读取以下目录中的文件：\n"
+            "   1. 当前工作目录（worktree）及其子目录"
+            f"{scope_note}\n"
+            "   2. Goal 中通过绝对路径明确引用的外部目录（仅限引用处）\n"
+            "**绝不**浏览、列出或读取工作目录的兄弟目录、父目录的其他子项目、"
+            "或任何与任务无关的本地文件系统路径。\n\n"
+            "**写入范围**：仅在当前工作目录内改动；"
+            "**绝不**切换分支、推送或污染基线分支与 master/main。\n\n"
+            "**例外**：WebSearch、WebFetch 等 internet 工具不受此限制。"
         )
 
     reflections = _recent_reflections(routine, max_reflections)

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from negentropy.engine.routine import phase as phase_mod
-from negentropy.engine.routine.orchestrator import RoutineOrchestrator
+from negentropy.engine.routine.orchestrator import RoutineOrchestrator, _build_scope_system_prompt
 from negentropy.engine.routine.prompt_builder import build_prompt
 
 
@@ -40,6 +40,7 @@ def _routine(**kw):
         reflections={},
         claude_session_id=None,
         current_phase="implement",
+        cwd="/tmp/test-project",
     )
     base.update(kw)
     return SimpleNamespace(**base)
@@ -55,6 +56,8 @@ def _wt_routine(**kw):
         current_phase="implement",
         baseline_branch="origin/feature/1.x.x",
         work_branch="routine/demo-20260601",
+        cwd="/path/to/source-project",
+        worktree_path="/path/to/.negentropy-worktrees/demo-20260601",
     )
     base.update(kw)
     return SimpleNamespace(**base)
@@ -133,3 +136,58 @@ def test_needs_approval_flat_preserves_seq1_semantics():
     na = RoutineOrchestrator._needs_approval
     assert na("first", phased=False, phase="implement", has_prior_implement=False, seq=1) is True
     assert na("first", phased=False, phase="implement", has_prior_implement=False, seq=2) is False
+
+
+# ── 作用域限制 (Scope Constraints) 测试 ──
+
+
+def test_build_prompt_worktree_has_scope_constraints():
+    """Worktree routine prompt 包含读取范围限制。"""
+    p = build_prompt(_wt_routine())
+    assert "作用域限制" in p
+    assert "读取范围" in p
+    assert "绝不" in p
+    assert "兄弟目录" in p
+
+
+def test_build_prompt_worktree_scope_includes_source_cwd():
+    """有 cwd 时 worktree 作用域限制包含源项目路径。"""
+    p = build_prompt(_wt_routine(cwd="/path/to/my-source"))
+    assert "源项目目录" in p
+    assert "/path/to/my-source" in p
+
+
+def test_build_prompt_worktree_scope_without_cwd():
+    """无 cwd 时 worktree 作用域限制不含源项目行。"""
+    p = build_prompt(_wt_routine(cwd=""))
+    assert "源项目目录" not in p
+
+
+def test_build_scope_system_prompt_worktree():
+    """worktree routine 的 system prompt 作用域限制。"""
+    r = _wt_routine(
+        cwd="/Users/cm.huang/Documents/projects/aurelius/data-la-maps",
+        worktree_path="/Users/cm.huang/Documents/projects/aurelius/.negentropy-worktrees/demo",
+    )
+    sp = _build_scope_system_prompt(r)
+    assert "File System Scope" in sp
+    assert "isolated worktree" in sp
+    assert "source project" in sp
+    assert "data-la-maps" in sp
+    assert "MUST NOT" in sp
+
+
+def test_build_scope_system_prompt_flat_routine():
+    """非 worktree routine 的 system prompt 作用域限制。"""
+    r = _routine(cwd="/tmp/my-project")
+    sp = _build_scope_system_prompt(r)
+    assert "File System Scope" in sp
+    assert "my-project" in sp
+    assert "MUST NOT" in sp
+
+
+def test_build_scope_system_prompt_no_cwd():
+    """无 cwd 时不注入作用域限制（向后兼容）。"""
+    r = _routine(cwd=None)
+    sp = _build_scope_system_prompt(r)
+    assert sp == ""


### PR DESCRIPTION
## 问题

Routine 任务（worktree 类型）执行时，Claude Code 子进程会自主读取 `coding-proxy`、`attention` 等不相关兄弟项目的文件。

### 根因

Worktree 存储在项目父目录的 `.negentropy-worktrees/` 下，与兄弟项目同级。Prompt 中仅限制了**写入**范围（"仅在当前工作目录内改动"），未限制**读取**范围。Claude Code 自主探索文件系统时发现并读取了兄弟项目文件。

```
/Users/cm.huang/Documents/projects/aurelius/
├── .negentropy-worktrees/          ← worktree 存储目录
│   └── project-remaster-8a55-.../  ← Claude Code CWD
├── data-la-maps/                   ← 目标项目
├── coding-proxy/                   ← ❌ 无关项目（被误读）
├── attention/                      ← ❌ 无关项目（被误读）
```

## 修复

采用 **prompt 层面增强**（两层防御）：

### 1. 增强 worktree prompt 指令（`prompt_builder.py`）
- 将单一写入限制升级为「读取 + 写入」双重限制
- 明确列出允许读取的目录：worktree、源项目、Goal 中引用的路径
- 明确禁止浏览/读取兄弟目录和父目录的其他子项目
- 扩展 `_RoutineLike` Protocol 添加 `cwd` 属性

### 2. 注入 system_prompt 层作用域限制（`orchestrator.py`）
- 新增 `_build_scope_system_prompt()` 函数，对 worktree routine 和普通 routine 分别构建作用域限制
- 在 `_build_config()` 中将作用域限制注入到 `config.system_prompt`（最高优先级指令层）
- 即使 Goal 文本引用了外部绝对路径，system prompt 层的限制也能防止自主探索

### 3. 新增 6 个测试用例（`test_routine_phase.py`）
- `test_build_prompt_worktree_has_scope_constraints` — 验证作用域限制关键词
- `test_build_prompt_worktree_scope_includes_source_cwd` — 验证源项目路径
- `test_build_prompt_worktree_scope_without_cwd` — 验证无 cwd 时降级
- `test_build_scope_system_prompt_worktree` — 验证 worktree system prompt
- `test_build_scope_system_prompt_flat_routine` — 验证普通 routine system prompt
- `test_build_scope_system_prompt_no_cwd` — 验证向后兼容

## 测试

```
18 passed in 40.75s  ✅
```

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)