### PR TITLE
fix(Routine): Template 类型 Routine 从列表页过滤，仅在模板库页展示

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -29,7 +29,7 @@ import { RoutineTable } from "./_components/RoutineTable";
 import { useRestartRoutine } from "./_components/useRestartRoutine";
 import { useTerminateRoutine } from "./_components/useTerminateRoutine";
 
-const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "" };
+const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "", is_template: false };
 
 function RoutinePageInner() {
   const router = useRouter();

--- a/apps/negentropy-ui/features/routine/api.ts
+++ b/apps/negentropy-ui/features/routine/api.ts
@@ -49,6 +49,7 @@ export async function fetchRoutines(filters: Partial<RoutineFilters> = {}): Prom
   const sp = new URLSearchParams();
   if (filters.status) sp.set("status", filters.status);
   if (filters.q) sp.set("q", filters.q);
+  if (filters.is_template != null) sp.set("is_template", String(filters.is_template));
   const q = sp.toString();
   return jsonFetch(`${q ? `?${q}` : ""}`);
 }

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineData.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineData.ts
@@ -24,7 +24,11 @@ export function useRoutineData(filters: Partial<RoutineFilters>) {
   const [error, setError] = useState<string | null>(null);
 
   // 序列化 filters 以稳定 effect 依赖
-  const filterKey = JSON.stringify({ status: filters.status ?? null, q: filters.q ?? "" });
+  const filterKey = JSON.stringify({
+    status: filters.status ?? null,
+    q: filters.q ?? "",
+    is_template: filters.is_template ?? null,
+  });
   const reqIdRef = useRef(0);
 
   const load = useCallback(async () => {

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -230,6 +230,7 @@ export interface IterationListResponse {
 export interface RoutineFilters {
   status: RoutineStatus | null;
   q: string;
+  is_template?: boolean | null;
 }
 
 /** 创建请求体 */

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -273,11 +273,23 @@ async def get_kpis() -> dict[str, Any]:
         return cached
 
     async with db_session.AsyncSessionLocal() as db:
-        status_counts_rows = (await db.execute(select(Routine.status, func.count()).group_by(Routine.status))).all()
+        status_counts_rows = (
+            await db.execute(
+                select(Routine.status, func.count()).where(Routine.is_template.is_(False)).group_by(Routine.status)
+            )
+        ).all()
         status_counts = {row[0]: row[1] for row in status_counts_rows}
         total = sum(status_counts.values())
-        total_cost = (await db.execute(select(func.coalesce(func.sum(Routine.total_cost_usd), 0.0)))).scalar() or 0.0
-        avg_iter = (await db.execute(select(func.coalesce(func.avg(Routine.iteration_count), 0.0)))).scalar() or 0.0
+        total_cost = (
+            await db.execute(
+                select(func.coalesce(func.sum(Routine.total_cost_usd), 0.0)).where(Routine.is_template.is_(False))
+            )
+        ).scalar() or 0.0
+        avg_iter = (
+            await db.execute(
+                select(func.coalesce(func.avg(Routine.iteration_count), 0.0)).where(Routine.is_template.is_(False))
+            )
+        ).scalar() or 0.0
 
     result = {
         "total": total,


### PR DESCRIPTION
## 变更背景

Routine Template（`is_template=true`）目前会出现在 Routine 列表页面中，与普通 Routine 混在一起显示。Template 应仅在模板库页面（卡片形式）中展示，不应出现在 Routine 列表页。

## 变更内容

### 前端（4 个文件）

| 文件 | 改动 |
|------|------|
| `features/routine/types.ts` | `RoutineFilters` 接口增加 `is_template` 可选字段 |
| `features/routine/api.ts` | `fetchRoutines` 传递 `is_template` 查询参数到后端 |
| `features/routine/hooks/useRoutineData.ts` | `filterKey` 序列化纳入 `is_template` |
| `app/interface/routine/page.tsx` | 列表页默认过滤 `is_template: false` |

### 后端（1 个文件）

| 文件 | 改动 |
|------|------|
| `interface/routine_api.py` | KPI 接口 `get_kpis` 统计排除 Template 行（status 计数、total_cost、avg_iterations） |

## 验证方式

1. Routine 列表页不再显示 `is_template=true` 的 Routine
2. 模板库页面（`/interface/routine/templates`）Template 卡片仍正常显示
3. KPI 数字仅统计非 Template 的 Routine
4. 创建新 Routine（非 Template）仍正常出现在列表
5. 创建新 Template 仅出现在模板库，不出现在列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)