### PR TITLE
feat(routine): Iteration 事件时间线 Turn 内动作组（ActionGroup）分组与折叠

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -18,6 +18,7 @@ import {
   eventGroup,
   eventTypeClass,
   eventTypeIcon,
+  eventTypeLabel,
   resolveEventTitle,
   scoreColorClass,
 } from "./status-style";
@@ -76,6 +77,104 @@ function groupIntoTurns(events: RoutineIterationEventDTO[]): EventTurn[] {
   return turns;
 }
 
+// ---------------------------------------------------------------------------
+// ActionGroup（动作组）—— 将 Turn 内事件按 assistant 边界细分为逻辑动作
+// ---------------------------------------------------------------------------
+
+/** Turn 内的「动作组」—— 以 assistant 事件为分组边界。
+ *  典型模式：assistant → tool_use → tool_result = 一个动作。
+ *  纯思考（assistant 无后续 tool_use）也构成一个动作组。 */
+interface ActionGroup {
+  /** 组内事件，按 seq 升序。 */
+  events: RoutineIterationEventDTO[];
+  /** 组内是否包含 tool_use 事件（决定图标/标题策略）。 */
+  hasToolUse: boolean;
+  /** 组内是否包含 is_error === true 的 tool_result。 */
+  hasError: boolean;
+}
+
+/** 将 Turn 内事件按 assistant 边界细分为动作组。
+ *  每个 `assistant` 事件是分组边界，两个 `assistant` 之间的所有事件（含首个）
+ *  构成一个 ActionGroup。
+ *  - `[assistant, tool_use, tool_result]` → 1 组（典型动作）
+ *  - `[assistant]` → 1 组（纯思考/总结）
+ *  - `[system]` → 1 组（初始化）
+ *  - `[assistant, tool_use×N, tool_result×N]` → 1 组（并行调用）
+ */
+function groupIntoActions(events: RoutineIterationEventDTO[]): ActionGroup[] {
+  if (events.length === 0) return [];
+
+  const groups: ActionGroup[] = [];
+  let current: ActionGroup = { events: [], hasToolUse: false, hasError: false };
+
+  for (const ev of events) {
+    const isBoundary =
+      ev.event_type === "assistant" && current.events.length > 0;
+
+    if (isBoundary) {
+      groups.push(current);
+      current = { events: [], hasToolUse: false, hasError: false };
+    }
+
+    current.events.push(ev);
+
+    if (ev.event_type === "tool_use") current.hasToolUse = true;
+    if (ev.event_type === "tool_result" && payloadIsError(ev.payload)) current.hasError = true;
+  }
+
+  groups.push(current);
+  return groups;
+}
+
+/** 从 ActionGroup 推导人可读标题。
+ *  优先级：
+ *  1. 若组内有 tool_use → resolveEventTitle(tool_use)
+ *  2. 若 assistant title 是已知子类型 → 翻译标签（如 "thinking" → "思考"）
+ *  3. 若 assistant 有 payload.text → 首行 80 字符截断
+ *  4. 兜底 → resolveEventTitle() 通用标签
+ */
+function deriveActionGroupTitle(group: ActionGroup): string {
+  // 优先使用 tool_use 的标题
+  const toolUse = group.events.find((e) => e.event_type === "tool_use");
+  if (toolUse) {
+    return resolveEventTitle(toolUse.event_type, toolUse.title, toolUse.tool_name);
+  }
+
+  // assistant 事件
+  const assistant = group.events.find((e) => e.event_type === "assistant");
+  if (assistant) {
+    // 若 title 是已知子类型（如 "thinking"），优先使用翻译标签
+    const resolved = resolveEventTitle(assistant.event_type, assistant.title, assistant.tool_name);
+    const genericLabel = eventTypeLabel("assistant"); // "推理"
+    if (resolved !== genericLabel) return resolved;
+
+    // 尝试从 payload.text 提取描述性标题
+    const text = typeof assistant.payload?.text === "string"
+      ? (assistant.payload.text as string).trim()
+      : "";
+    if (text) {
+      const firstLine = text.split("\n")[0];
+      return firstLine.length > 80 ? firstLine.slice(0, 80) + "…" : firstLine;
+    }
+    return resolved;
+  }
+
+  // 兜底：system 等其他事件
+  const first = group.events[0];
+  return resolveEventTitle(first.event_type, first.title || extractSubtitle(first.payload), first.tool_name);
+}
+
+/** 从 ActionGroup 推导图标。 */
+function deriveActionGroupIcon(group: ActionGroup): LucideIcon {
+  if (group.hasToolUse) {
+    const toolUse = group.events.find((e) => e.event_type === "tool_use")!;
+    return eventTypeIcon("tool_use", toolUse.tool_name);
+  }
+  const assistant = group.events.find((e) => e.event_type === "assistant");
+  if (assistant) return eventTypeIcon("assistant");
+  return eventTypeIcon(group.events[0].event_type);
+}
+
 /** 从 Turn 的首事件及事件序列中推导人可读标题。
  * 优先级：assistant payload.text（首行 80 字符）→ 首个 tool_use 标题 → assistant 标题翻译 → 兜底。
  */
@@ -101,11 +200,11 @@ function deriveTurnTitle(turn: EventTurn): string {
   return `Turn ${turn.turnNumber}`;
 }
 
-/** 默认展开策略：最后一轮 + 含错轮次 → 展开；其余 → 折叠。 */
-function isTurnDefaultExpanded(turn: EventTurn, index: number, total: number): boolean {
-  if (index === total - 1) return true; // 最后一轮：展开（当前活跃）
-  if (turn.hasError) return true; // 含错轮次：展开（错误可见性）
-  return false;
+/** 默认展开策略：所有 Turn 均展开。
+ *  动作组提供紧凑摘要，展开所有 Turn 可一览完整执行流。 */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function isTurnDefaultExpanded(_turn: EventTurn, _index: number, _total: number): boolean {
+  return true;
 }
 
 /** 渲染 Lucide 图标 —— 以 prop 传入组件引用，避免「render 期间创建组件」lint 误报。 */
@@ -282,6 +381,7 @@ function ClaudeCodeTurnBubble({
   const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
   const expanded = manualExpanded ?? defaultExpanded;
   const title = deriveTurnTitle(turn);
+  const actionGroups = useMemo(() => groupIntoActions(turn.events), [turn.events]);
 
   return (
     <div className="flex gap-2.5 py-0.5">
@@ -328,11 +428,14 @@ function ClaudeCodeTurnBubble({
             {title}
           </span>
         </button>
-        {/* 展开后的事件列表 */}
+        {/* 展开后的动作组列表 */}
         {expanded && (
           <ol className="mt-2 space-y-1 border-l border-border pl-3">
-            {turn.events.map((ev) => (
-              <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
+            {actionGroups.map((group, gi) => (
+              <ActionGroupRow
+                key={`action-${gi}-${group.events[0]?.seq}`}
+                group={group}
+              />
             ))}
           </ol>
         )}
@@ -685,6 +788,73 @@ function EventTitle({ title }: { title: string }) {
       <span className="truncate">{head}</span>
       {tail && <span className="shrink-0">{tail}</span>}
     </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ActionGroupRow（Turn 内的可折叠动作组）
+// ---------------------------------------------------------------------------
+
+/** Turn 内的单个「动作组」—— 折叠态显示动作摘要，展开态显示 EventRow 列表。 */
+function ActionGroupRow({ group }: { group: ActionGroup }) {
+  const [expanded, setExpanded] = useState(false);
+  const icon = deriveActionGroupIcon(group);
+  const title = deriveActionGroupTitle(group);
+  const count = group.events.length;
+
+  return (
+    <li className="relative -ml-px pl-4">
+      {/* 时间线节点圆点 */}
+      <span className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <span
+          className={cn(
+            "flex h-5 w-5 items-center justify-center rounded-full ring-2 ring-card",
+            group.hasError
+              ? "bg-red-500/10 text-red-600 dark:text-red-400"
+              : group.hasToolUse
+                ? "bg-sky-500/10 text-sky-700 dark:text-sky-300"
+                : "bg-violet-500/10 text-violet-700 dark:text-violet-300",
+          )}
+        >
+          <EventIcon icon={icon} className="h-3 w-3" />
+        </span>
+      </span>
+
+      {/* 可折叠标题 */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/50"
+      >
+        <ChevronRight
+          className={cn("h-3 w-3 shrink-0 text-text-muted transition-transform", expanded && "rotate-90")}
+          aria-hidden
+        />
+        <EventTitle title={title} />
+        {/* 事件数量 badge（仅 >1 时显示） */}
+        {count > 1 && (
+          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[9px] font-medium tabular-nums text-text-muted">
+            {count}
+          </span>
+        )}
+        {/* 错误 badge */}
+        {group.hasError && (
+          <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-red-600 dark:text-red-400">
+            error
+          </span>
+        )}
+      </button>
+
+      {/* 展开后：嵌套 EventRow 列表 */}
+      {expanded && (
+        <ol className="mt-1 space-y-0.5 border-l border-border pl-3">
+          {group.events.map((ev) => (
+            <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
+          ))}
+        </ol>
+      )}
+    </li>
   );
 }
 

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { IterationEventTimeline } from "@/app/interface/routine/_components/IterationEventTimeline";
@@ -21,11 +21,21 @@ function makeEvent(overrides: Partial<RoutineIterationEventDTO> = {}): RoutineIt
   };
 }
 
+/** 找到 ActionGroupRow 的折叠按钮（含 ChevronRight 的 button）并点击展开。 */
+function expandFirstActionGroup() {
+  // ActionGroupRow 的 button 带有 aria-expanded="false"
+  const buttons = screen.getAllByRole("button");
+  const actionBtn = buttons.find(
+    (btn) => btn.getAttribute("aria-expanded") === "false" && btn.querySelector(".lucide-chevron-right"),
+  );
+  if (actionBtn) fireEvent.click(actionBtn);
+}
+
 describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳", () => {
   it("路径标题：文件名尾部成独立块永不裁剪，完整标题进 title 悬浮", () => {
     const title = "Read /repo/a/b/c/target_file.py";
     render(<IterationEventTimeline events={[makeEvent({ title })]} />);
-    // 文件名尾部单独成 span（前缀即便被 truncate 也不会丢失）
+    // ActionGroupRow 折叠态使用 EventTitle 组件，同样做路径拆分
     expect(screen.getByText("target_file.py")).toBeInTheDocument();
     // 完整标题可悬浮查看（拆分为头/尾两段，故整串只存在于 title 属性）
     expect(document.querySelector(`[title="${title}"]`)).not.toBeNull();
@@ -34,6 +44,8 @@ describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳",
   it("每行渲染本地化时间戳，悬浮显示完整日期时间", () => {
     const created = "2026-06-01T09:08:07+00:00";
     render(<IterationEventTimeline events={[makeEvent({ created_at: created })]} />);
+    // 时间戳在 ActionGroupRow 内部的 EventRow 中，需先展开
+    expandFirstActionGroup();
     // 与组件同口径计算，规避 CI 时区/locale 漂移
     expect(screen.getByText(new Date(created).toLocaleTimeString())).toBeInTheDocument();
     expect(document.querySelector(`[title="${new Date(created).toLocaleString()}"]`)).not.toBeNull();
@@ -42,6 +54,8 @@ describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳",
   it("created_at 为空时不渲染时间戳（防御 null，覆盖在途未落库占位）", () => {
     const probe = new Date("2026-06-01T09:08:07+00:00").toLocaleTimeString();
     render(<IterationEventTimeline events={[makeEvent({ created_at: null })]} />);
+    // ActionGroupRow 折叠态不显示时间戳，展开后也不应有
+    expandFirstActionGroup();
     expect(screen.queryByText(probe)).toBeNull();
   });
 
@@ -60,7 +74,7 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         ]}
       />,
     );
-    // Turn 聚合后，标题同时出现在 ClaudeCodeTurnBubble header 和嵌套 EventRow，故用 getAllByText
+    // Turn 展开 → ActionGroupRow 折叠态标题 + Turn header 均显示翻译后的标题
     expect(screen.getAllByText("会话初始化").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("init")).not.toBeInTheDocument();
   });
@@ -124,7 +138,8 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         events={[makeEvent({ event_type: "assistant", title: "thinking", tool_name: null, payload: { text: "…" } })]}
       />,
     );
-    expect(screen.getByText("思考")).toBeInTheDocument();
+    // "思考" 出现在 ActionGroupRow 折叠态标题（deriveActionGroupTitle 优先使用已知子类型翻译）
+    expect(screen.getAllByText("思考").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("thinking")).not.toBeInTheDocument();
   });
 
@@ -165,7 +180,9 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         events={[makeEvent({ event_type: "assistant", title: null, tool_name: null, payload: { text: "…" } })]}
       />,
     );
-    expect(screen.getByText("推理")).toBeInTheDocument();
+    // payload.text "…" 被 ActionGroupRow 标题优先使用；展开后 EventRow 中显示「推理」
+    expandFirstActionGroup();
+    expect(screen.getAllByText("推理").length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -272,5 +289,137 @@ describe("IterationEventTimeline 交织排序", () => {
     const labels = getBubbleLabels(getFlowChildren(container));
     expect(labels).toEqual(["Turn 1"]);
     expect(screen.queryByText("NegentropyEngine")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ActionGroup 分组测试
+// ---------------------------------------------------------------------------
+
+describe("IterationEventTimeline ActionGroup 分组", () => {
+  /** 获取 Turn 内所有 ActionGroupRow 的折叠按钮。
+   *  ActionGroupRow 渲染为 <li class="relative -ml-px pl-4">，内含 <button aria-expanded>。 */
+  function getActionGroupButtons(container: HTMLElement): HTMLButtonElement[] {
+    // ActionGroupRow 的 <li> 有 `relative -ml-px pl-4` class
+    const lis = container.querySelectorAll("li.relative.pl-4");
+    return Array.from(lis)
+      .map((li) => li.querySelector<HTMLButtonElement>("button[aria-expanded]"))
+      .filter((btn): btn is HTMLButtonElement => btn !== null);
+  }
+
+  /** 获取所有 ActionGroupRow 的标题（从 button 内的 [title] 属性提取）。 */
+  function getActionGroupTitles(container: HTMLElement): string[] {
+    return getActionGroupButtons(container).map((btn) => {
+      const titleEl = btn.querySelector("[title]");
+      return titleEl?.getAttribute("title") ?? "";
+    });
+  }
+
+  it("典型 [assistant, tool_use, tool_result] 序列聚合为 1 个动作组", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "让我读取文件" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /src/main.ts" }),
+      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: { text: "file content" } }),
+    ];
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    // 应有 1 个 ActionGroupRow，标题为 tool_use 的标题
+    const titles = getActionGroupTitles(container);
+    expect(titles.length).toBe(1);
+    expect(titles).toContain("Read /src/main.ts");
+  });
+
+  it("多个 [assistant, tool_use, tool_result] 序列分为多个动作组", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "第一步" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /a.ts" }),
+      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
+      makeEvent({ seq: 3, event_type: "assistant", title: null, tool_name: null, payload: { text: "第二步" } }),
+      makeEvent({ seq: 4, event_type: "tool_use", tool_name: "Edit", title: "Edit /a.ts" }),
+      makeEvent({ seq: 5, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
+      makeEvent({ seq: 6, event_type: "assistant", title: null, tool_name: null, payload: { text: "完成" } }),
+    ];
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    const titles = getActionGroupTitles(container);
+    // 3 个 ActionGroup: Read, Edit, "完成"
+    expect(titles.length).toBe(3);
+    expect(titles).toContain("Read /a.ts");
+    expect(titles).toContain("Edit /a.ts");
+  });
+
+  it("单个 system 事件形成独立动作组", () => {
+    render(
+      <IterationEventTimeline
+        events={[makeEvent({ event_type: "system", title: "init", tool_name: null, payload: {} })]}
+      />,
+    );
+    // ActionGroupRow 标题为 "会话初始化"
+    expect(screen.getAllByText("会话初始化").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("并行 tool_use 事件归入同一动作组", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "并行读取" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /a.ts" }),
+      makeEvent({ seq: 2, event_type: "tool_use", tool_name: "Read", title: "Read /b.ts" }),
+      makeEvent({ seq: 3, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
+      makeEvent({ seq: 4, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
+    ];
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    // 只有 1 个 ActionGroupRow，标题为首个 tool_use 的标题
+    const titles = getActionGroupTitles(container);
+    expect(titles.length).toBe(1);
+    expect(titles).toContain("Read /a.ts");
+  });
+
+  it("ActionGroupRow count > 1 时渲染数量 badge", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "动作" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /x.ts" }),
+      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
+    ];
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    // 数量 badge 在 ActionGroupRow 按钮内，显示 "3"
+    const btn = getActionGroupButtons(container)[0];
+    expect(btn?.textContent).toContain("3");
+  });
+
+  it("ActionGroupRow hasError 时渲染错误 badge", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "尝试" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Bash", title: "Bash: fail" }),
+      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: { is_error: true, text: "error output" } }),
+    ];
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    // 错误 badge 在 ActionGroupRow 按钮内
+    const btn = getActionGroupButtons(container)[0];
+    const errorBadge = btn?.querySelector(".bg-red-500\\/10");
+    expect(errorBadge?.textContent).toContain("error");
+  });
+
+  it("点击 ActionGroupRow 展开后显示 EventRow 列表", () => {
+    const created = "2026-06-01T09:08:07+00:00";
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "动作" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /x.ts", created_at: created }),
+      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
+    ];
+    const { container } = render(<IterationEventTimeline events={events} />);
+
+    // 展开前：ActionGroupRow 折叠态，内部 EventRow 不在 DOM
+    const btn = getActionGroupButtons(container)[0];
+    expect(btn?.getAttribute("aria-expanded")).toBe("false");
+
+    // 点击展开
+    fireEvent.click(btn!);
+
+    // 展开后：EventRow 可见（通过 seq 标记确认）
+    expect(screen.getByText("#1")).toBeInTheDocument();
+    // 时间戳也可见（可能多个 EventRow 有相同时间戳，用 getAllByText）
+    expect(screen.getAllByText(new Date(created).toLocaleTimeString()).length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Iteration Full View 中 Turn 展开后直接平铺所有 EventRow，当单 Turn 事件数量较多时（如 50-200 条），信息密度过低，难以快速定位关键动作（如工具调用、错误）。
- 关联上下文/Issue/文档：[#853](https://github.com/ThreeFish-AI/negentropy/pull/853)（事件按 seq 时序交织排列）的后续增强。

# 核心变更
- 引入 **ActionGroup（动作组）** 概念层：在 Turn 与 EventRow 之间新增 `groupIntoActions()` 分组函数，以 `assistant` 事件为边界将 Turn 内事件细分为逻辑动作组（典型模式：`assistant → tool_use → tool_result = 一个动作`）。
- 新增 `ActionGroupRow` 可折叠组件：折叠态显示动作摘要（标题 + 事件数量 badge + 可选 error badge），展开态显示嵌套 EventRow 列表。
- 标题推导优先级：tool_use 标题 > assistant 已知子类型翻译（如 `thinking → 思考`）> payload.text 首行 80 字符截断 > 兜底标签。
- Turn 默认展开策略改为**全部展开**：因动作组已提供紧凑摘要，展开所有 Turn 可一览完整执行流。
- 适配现有测试 + 新增 7 个 ActionGroup 分组专项测试（分组逻辑、并行 tool_use、count badge、error badge、展开交互）。

# 风险与回滚
- 主要风险：ActionGroup 作为新增中间层，可能影响长列表渲染性能（useMemo 缓解）；Turn 默认全部展开可能增加初始 DOM 节点数。
- 回滚方式：`git revert` 即可，变更仅涉及 2 个文件。

# 验证证据
- 单元测试：7 个新增 ActionGroup 分组测试全部通过（典型序列、并行 tool_use、error badge、展开交互等）。
- 集成测试：无新增，不影响现有集成测试。
- E2E/Workflow：实机浏览器验证通过（`localhost:3192`），覆盖简单场景（2 turns / 5 events）和复杂场景（17 turns / 46 events，含错误状态、并行 tool_use、路径拆分）。
- 覆盖率/关键截图：错误状态三级传播（EventRow → ActionGroup → Turn）验证正确；Engine 事件（Result/Gate/Evaluation）右侧气泡渲染不受影响。

# 影响范围
- 前端：`IterationEventTimeline.tsx`（+186 行），`IterationEventTimeline.test.tsx`（+159 行）
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action
- 观察 ActionGroup 在超长 Turn（200+ events）下的渲染性能，必要时引入虚拟滚动。
- 评估是否需要 ActionGroup 默认展开策略（如含错的动作组默认展开）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)