### PR TITLE
fix(Routine): 移除 Iteration 事件时间线 ActionGroup 中间聚合层，Turn 内事件直接平铺展示

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -19,7 +19,7 @@ import {
   eventGroup,
   eventTypeClass,
   eventTypeIcon,
-  eventTypeLabel,
+
   resolveEventTitle,
   scoreColorClass,
   deriveTaskStatus,
@@ -79,104 +79,6 @@ function groupIntoTurns(events: RoutineIterationEventDTO[]): EventTurn[] {
 
   if (current) turns.push(current);
   return turns;
-}
-
-// ---------------------------------------------------------------------------
-// ActionGroup（动作组）—— 将 Turn 内事件按 assistant 边界细分为逻辑动作
-// ---------------------------------------------------------------------------
-
-/** Turn 内的「动作组」—— 以 assistant 事件为分组边界。
- *  典型模式：assistant → tool_use → tool_result = 一个动作。
- *  纯思考（assistant 无后续 tool_use）也构成一个动作组。 */
-interface ActionGroup {
-  /** 组内事件，按 seq 升序。 */
-  events: RoutineIterationEventDTO[];
-  /** 组内是否包含 tool_use 事件（决定图标/标题策略）。 */
-  hasToolUse: boolean;
-  /** 组内是否包含 is_error === true 的 tool_result。 */
-  hasError: boolean;
-}
-
-/** 将 Turn 内事件按 assistant 边界细分为动作组。
- *  每个 `assistant` 事件是分组边界，两个 `assistant` 之间的所有事件（含首个）
- *  构成一个 ActionGroup。
- *  - `[assistant, tool_use, tool_result]` → 1 组（典型动作）
- *  - `[assistant]` → 1 组（纯思考/总结）
- *  - `[system]` → 1 组（初始化）
- *  - `[assistant, tool_use×N, tool_result×N]` → 1 组（并行调用）
- */
-function groupIntoActions(events: RoutineIterationEventDTO[]): ActionGroup[] {
-  if (events.length === 0) return [];
-
-  const groups: ActionGroup[] = [];
-  let current: ActionGroup = { events: [], hasToolUse: false, hasError: false };
-
-  for (const ev of events) {
-    const isBoundary =
-      ev.event_type === "assistant" && current.events.length > 0;
-
-    if (isBoundary) {
-      groups.push(current);
-      current = { events: [], hasToolUse: false, hasError: false };
-    }
-
-    current.events.push(ev);
-
-    if (ev.event_type === "tool_use") current.hasToolUse = true;
-    if (ev.event_type === "tool_result" && payloadIsError(ev.payload)) current.hasError = true;
-  }
-
-  groups.push(current);
-  return groups;
-}
-
-/** 从 ActionGroup 推导人可读标题。
- *  优先级：
- *  1. 若组内有 tool_use → resolveEventTitle(tool_use)
- *  2. 若 assistant title 是已知子类型 → 翻译标签（如 "thinking" → "思考"）
- *  3. 若 assistant 有 payload.text → 首行 80 字符截断
- *  4. 兜底 → resolveEventTitle() 通用标签
- */
-function deriveActionGroupTitle(group: ActionGroup): string {
-  // 优先使用 tool_use 的标题
-  const toolUse = group.events.find((e) => e.event_type === "tool_use");
-  if (toolUse) {
-    return resolveEventTitle(toolUse.event_type, toolUse.title, toolUse.tool_name);
-  }
-
-  // assistant 事件
-  const assistant = group.events.find((e) => e.event_type === "assistant");
-  if (assistant) {
-    // 若 title 是已知子类型（如 "thinking"），优先使用翻译标签
-    const resolved = resolveEventTitle(assistant.event_type, assistant.title, assistant.tool_name);
-    const genericLabel = eventTypeLabel("assistant"); // "推理"
-    if (resolved !== genericLabel) return resolved;
-
-    // 尝试从 payload.text 提取描述性标题
-    const text = typeof assistant.payload?.text === "string"
-      ? (assistant.payload.text as string).trim()
-      : "";
-    if (text) {
-      const firstLine = text.split("\n")[0];
-      return firstLine.length > 80 ? firstLine.slice(0, 80) + "…" : firstLine;
-    }
-    return resolved;
-  }
-
-  // 兜底：system 等其他事件
-  const first = group.events[0];
-  return resolveEventTitle(first.event_type, first.title || extractSubtitle(first.payload), first.tool_name);
-}
-
-/** 从 ActionGroup 推导图标。 */
-function deriveActionGroupIcon(group: ActionGroup): LucideIcon {
-  if (group.hasToolUse) {
-    const toolUse = group.events.find((e) => e.event_type === "tool_use")!;
-    return eventTypeIcon("tool_use", toolUse.tool_name);
-  }
-  const assistant = group.events.find((e) => e.event_type === "assistant");
-  if (assistant) return eventTypeIcon("assistant");
-  return eventTypeIcon(group.events[0].event_type);
 }
 
 /** 从 Turn 的首事件及事件序列中推导人可读标题。
@@ -460,8 +362,7 @@ function SpeakerGroupBubble({ group }: { group: SpeakerGroup }) {
 }
 
 /** Claude Code Turn 气泡（左侧）。
- *  Turn 不再可折叠，ActionGroupRow 列表始终在 Header 下方直接展示，
- *  消除 Turn 标题与 ActionGroup 标题的重复文案问题。 */
+ *  Turn 内事件直接平铺为 EventRow 列表，无中间聚合层。 */
 function ClaudeCodeTurnBubble({
   turn,
   showHeader = true,
@@ -471,7 +372,6 @@ function ClaudeCodeTurnBubble({
   showHeader?: boolean;
 }) {
   const title = deriveTurnTitle(turn);
-  const actionGroups = useMemo(() => groupIntoActions(turn.events), [turn.events]);
 
   return (
     <div className={cn("py-0.5", showHeader && "flex gap-2.5")}>
@@ -507,20 +407,17 @@ function ClaudeCodeTurnBubble({
               error
             </span>
           )}
-          {/* 多 ActionGroup 时显示 Turn 摘要副标题；单组时不显示以避免与 ActionGroup 标题重复 */}
-          {actionGroups.length > 1 && (
+          {/* 多事件时显示 Turn 摘要副标题 */}
+          {turn.events.length > 1 && (
             <span className="min-w-0 flex-1 truncate text-[10px] text-text-muted" title={title}>
               {title}
             </span>
           )}
         </div>
-        {/* ActionGroupRow 列表——始终可见，无折叠层 */}
+        {/* EventRow 列表——始终可见，直接平铺 */}
         <ol className="space-y-1 border-l border-border pl-3">
-          {actionGroups.map((group, gi) => (
-            <ActionGroupRow
-              key={`action-${gi}-${group.events[0]?.seq}`}
-              group={group}
-            />
+          {turn.events.map((ev) => (
+            <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
           ))}
         </ol>
       </div>
@@ -885,73 +782,6 @@ function EventTitle({ title }: { title: string }) {
       <span className="truncate">{head}</span>
       {tail && <span className="shrink-0">{tail}</span>}
     </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ActionGroupRow（Turn 内的可折叠动作组）
-// ---------------------------------------------------------------------------
-
-/** Turn 内的单个「动作组」—— 折叠态显示动作摘要，展开态显示 EventRow 列表。 */
-function ActionGroupRow({ group }: { group: ActionGroup }) {
-  const [expanded, setExpanded] = useState(false);
-  const icon = deriveActionGroupIcon(group);
-  const title = deriveActionGroupTitle(group);
-  const count = group.events.length;
-
-  return (
-    <li className="relative -ml-px pl-4">
-      {/* 时间线节点圆点 */}
-      <span className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2">
-        <span
-          className={cn(
-            "flex h-5 w-5 items-center justify-center rounded-full ring-2 ring-card",
-            group.hasError
-              ? "bg-red-500/10 text-red-600 dark:text-red-400"
-              : group.hasToolUse
-                ? "bg-sky-500/10 text-sky-700 dark:text-sky-300"
-                : "bg-violet-500/10 text-violet-700 dark:text-violet-300",
-          )}
-        >
-          <EventIcon icon={icon} className="h-3 w-3" />
-        </span>
-      </span>
-
-      {/* 可折叠标题 */}
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/50"
-      >
-        <ChevronRight
-          className={cn("h-3 w-3 shrink-0 text-text-muted transition-transform", expanded && "rotate-90")}
-          aria-hidden
-        />
-        <EventTitle title={title} />
-        {/* 事件数量 badge（仅 >1 时显示） */}
-        {count > 1 && (
-          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[9px] font-medium tabular-nums text-text-muted">
-            {count}
-          </span>
-        )}
-        {/* 错误 badge */}
-        {group.hasError && (
-          <span className="shrink-0 rounded-full bg-red-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-red-600 dark:text-red-400">
-            error
-          </span>
-        )}
-      </button>
-
-      {/* 展开后：嵌套 EventRow 列表 */}
-      {expanded && (
-        <ol className="mt-1 space-y-0.5 border-l border-border pl-3">
-          {group.events.map((ev) => (
-            <EventRow key={`${ev.seq}-${ev.id}`} ev={ev} />
-          ))}
-        </ol>
-      )}
-    </li>
   );
 }
 

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+
 import { describe, expect, it } from "vitest";
 
 import { IterationEventTimeline } from "@/app/interface/routine/_components/IterationEventTimeline";
@@ -21,21 +22,11 @@ function makeEvent(overrides: Partial<RoutineIterationEventDTO> = {}): RoutineIt
   };
 }
 
-/** 找到 ActionGroupRow 的折叠按钮（含 ChevronRight 的 button）并点击展开。 */
-function expandFirstActionGroup() {
-  // ActionGroupRow 的 button 带有 aria-expanded="false"
-  const buttons = screen.getAllByRole("button");
-  const actionBtn = buttons.find(
-    (btn) => btn.getAttribute("aria-expanded") === "false" && btn.querySelector(".lucide-chevron-right"),
-  );
-  if (actionBtn) fireEvent.click(actionBtn);
-}
-
 describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳", () => {
   it("路径标题：文件名尾部成独立块永不裁剪，完整标题进 title 悬浮", () => {
     const title = "Read /repo/a/b/c/target_file.py";
     render(<IterationEventTimeline events={[makeEvent({ title })]} />);
-    // ActionGroupRow 折叠态使用 EventTitle 组件，同样做路径拆分
+    // EventRow 使用 EventTitle 组件做路径拆分
     expect(screen.getByText("target_file.py")).toBeInTheDocument();
     // 完整标题可悬浮查看（拆分为头/尾两段，故整串只存在于 title 属性）
     expect(document.querySelector(`[title="${title}"]`)).not.toBeNull();
@@ -44,9 +35,7 @@ describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳",
   it("每行渲染本地化时间戳，悬浮显示完整日期时间", () => {
     const created = "2026-06-01T09:08:07+00:00";
     render(<IterationEventTimeline events={[makeEvent({ created_at: created })]} />);
-    // 时间戳在 ActionGroupRow 内部的 EventRow 中，需先展开
-    expandFirstActionGroup();
-    // 与组件同口径计算，规避 CI 时区/locale 漂移
+    // EventRow 直接可见，无需展开
     expect(screen.getByText(new Date(created).toLocaleTimeString())).toBeInTheDocument();
     expect(document.querySelector(`[title="${new Date(created).toLocaleString()}"]`)).not.toBeNull();
   });
@@ -54,8 +43,7 @@ describe("IterationEventTimeline 步骤行：路径完整度 + 每行时间戳",
   it("created_at 为空时不渲染时间戳（防御 null，覆盖在途未落库占位）", () => {
     const probe = new Date("2026-06-01T09:08:07+00:00").toLocaleTimeString();
     render(<IterationEventTimeline events={[makeEvent({ created_at: null })]} />);
-    // ActionGroupRow 折叠态不显示时间戳，展开后也不应有
-    expandFirstActionGroup();
+    // EventRow 直接可见，无时间戳
     expect(screen.queryByText(probe)).toBeNull();
   });
 
@@ -74,7 +62,7 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         ]}
       />,
     );
-    // Turn 展开 → ActionGroupRow 折叠态标题 + Turn header 均显示翻译后的标题
+    // EventRow 直接可见，显示翻译后的标题
     expect(screen.getAllByText("会话初始化").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("init")).not.toBeInTheDocument();
   });
@@ -138,7 +126,7 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         events={[makeEvent({ event_type: "assistant", title: "thinking", tool_name: null, payload: { text: "…" } })]}
       />,
     );
-    // "思考" 出现在 ActionGroupRow 折叠态标题（deriveActionGroupTitle 优先使用已知子类型翻译）
+    // EventRow 直接渲染，显示翻译后的标题
     expect(screen.getAllByText("思考").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("thinking")).not.toBeInTheDocument();
   });
@@ -180,8 +168,7 @@ describe("IterationEventTimeline 事件标题翻译", () => {
         events={[makeEvent({ event_type: "assistant", title: null, tool_name: null, payload: { text: "…" } })]}
       />,
     );
-    // payload.text "…" 被 ActionGroupRow 标题优先使用；展开后 EventRow 中显示「推理」
-    expandFirstActionGroup();
+    // EventRow 直接可见，显示「推理」
     expect(screen.getAllByText("推理").length).toBeGreaterThanOrEqual(1);
   });
 });
@@ -254,10 +241,25 @@ describe("IterationEventTimeline 交织排序", () => {
     ];
 
     const { container } = render(<IterationEventTimeline events={events} />);
-    const labels = getBubbleLabels(getFlowChildren(container));
 
-    // 期望：Turn 1 → Result → Gate → Evaluation
-    expect(labels).toEqual(["Turn 1", "Result", "Gate", "Evaluation"]);
+    // 验证所有元素存在
+    expect(screen.getByText("Turn 1")).toBeInTheDocument();
+    expect(screen.getByText("✅ Success")).toBeInTheDocument();
+    expect(screen.getByText("✅ Passed")).toBeInTheDocument();
+    expect(screen.getByText("✅ Succeeded")).toBeInTheDocument();
+
+    // 验证 DOM 顺序：Turn 1 → Result → Gate → Evaluation（连续 engine 事件被 SpeakerGroupBubble 合并为一组）
+    const html = container.querySelector(".space-y-2\\.5")!.innerHTML;
+    const indices = [
+      html.indexOf("Turn 1"),
+      html.indexOf("✅ Success"),
+      html.indexOf("✅ Passed"),
+      html.indexOf("✅ Succeeded"),
+    ];
+    // 严格递增 → 时序正确
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeGreaterThan(indices[i - 1]);
+    }
   });
 
   it("多个 plan_review 穿插时全局 Turn 编号连续", () => {
@@ -346,18 +348,8 @@ describe("IterationEventTimeline TaskCreate/TaskUpdate 增强", () => {
     expect(screen.getByText("TaskUpdate: 已完成行政区划迁移")).toBeInTheDocument();
   });
 
-  /** 依次展开 Turn 和 ActionGroupRow 以暴露内部 EventRow（合并 ActionGroup 后双层折叠）。 */
-  function expandActionGroup(container: HTMLElement) {
-    // 第一层：展开 Turn
-    const turnBtns = container.querySelectorAll<HTMLButtonElement>("button[aria-expanded='false']");
-    turnBtns.forEach((btn) => fireEvent.click(btn));
-    // 第二层：展开 ActionGroupRow
-    const agBtns = container.querySelectorAll<HTMLButtonElement>("button[aria-expanded='false']");
-    agBtns.forEach((btn) => fireEvent.click(btn));
-  }
-
   it("TaskUpdate in_progress 事件渲染状态指示器（蓝点 + 标签）", () => {
-    const { container } = render(
+    render(
       <IterationEventTimeline
         events={[
           makeEvent({
@@ -368,9 +360,7 @@ describe("IterationEventTimeline TaskCreate/TaskUpdate 增强", () => {
         ]}
       />,
     );
-    // ActionGroupRow 默认折叠，需先展开
-    expandActionGroup(container);
-    // 状态标签文字
+    // EventRow 直接可见，无需展开
     expect(screen.getByText("in progress")).toBeInTheDocument();
     // 状态圆点（animate-pulse 类）
     const dot = document.querySelector(".animate-pulse.inline-block");
@@ -379,7 +369,7 @@ describe("IterationEventTimeline TaskCreate/TaskUpdate 增强", () => {
   });
 
   it("TaskUpdate completed 事件渲染绿色状态圆点", () => {
-    const { container } = render(
+    render(
       <IterationEventTimeline
         events={[
           makeEvent({
@@ -390,14 +380,13 @@ describe("IterationEventTimeline TaskCreate/TaskUpdate 增强", () => {
         ]}
       />,
     );
-    expandActionGroup(container);
     expect(screen.getByText("completed")).toBeInTheDocument();
     const dot = document.querySelector(".bg-emerald-500.inline-block");
     expect(dot).not.toBeNull();
   });
 
   it("TaskCreate 无显式 status 默认显示 pending 状态", () => {
-    const { container } = render(
+    render(
       <IterationEventTimeline
         events={[
           makeEvent({
@@ -408,7 +397,6 @@ describe("IterationEventTimeline TaskCreate/TaskUpdate 增强", () => {
         ]}
       />,
     );
-    expandActionGroup(container);
     expect(screen.getByText("pending")).toBeInTheDocument();
     const dot = document.querySelector(".bg-text-muted.inline-block");
     expect(dot).not.toBeNull();
@@ -423,43 +411,25 @@ describe("IterationEventTimeline TaskCreate/TaskUpdate 增强", () => {
 });
 
 // ---------------------------------------------------------------------------
-// ActionGroup 分组测试
+// Turn → Event 直接渲染（无 ActionGroup 中间层）
 // ---------------------------------------------------------------------------
 
-describe("IterationEventTimeline ActionGroup 分组", () => {
-  /** 获取 Turn 内所有 ActionGroupRow 的折叠按钮。
-   *  ActionGroupRow 渲染为 <li class="relative -ml-px pl-4">，内含 <button aria-expanded>。 */
-  function getActionGroupButtons(container: HTMLElement): HTMLButtonElement[] {
-    // ActionGroupRow 的 <li> 有 `relative -ml-px pl-4` class
-    const lis = container.querySelectorAll("li.relative.pl-4");
-    return Array.from(lis)
-      .map((li) => li.querySelector<HTMLButtonElement>("button[aria-expanded]"))
-      .filter((btn): btn is HTMLButtonElement => btn !== null);
-  }
-
-  /** 获取所有 ActionGroupRow 的标题（从 button 内的 [title] 属性提取）。 */
-  function getActionGroupTitles(container: HTMLElement): string[] {
-    return getActionGroupButtons(container).map((btn) => {
-      const titleEl = btn.querySelector("[title]");
-      return titleEl?.getAttribute("title") ?? "";
-    });
-  }
-
-  it("典型 [assistant, tool_use, tool_result] 序列聚合为 1 个动作组", () => {
+describe("IterationEventTimeline Turn → Event 直接渲染", () => {
+  it("Turn 内所有事件直接渲染为 EventRow，无需展开", () => {
     const events: RoutineIterationEventDTO[] = [
-      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "让我读取文件" } }),
-      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /src/main.ts" }),
-      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: { text: "file content" } }),
+      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "动作" } }),
+      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /x.ts", created_at: "2026-06-01T09:08:07+00:00" }),
+      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
     ];
-    const { container } = render(<IterationEventTimeline events={events} />);
+    render(<IterationEventTimeline events={events} />);
 
-    // 应有 1 个 ActionGroupRow，标题为 tool_use 的标题
-    const titles = getActionGroupTitles(container);
-    expect(titles.length).toBe(1);
-    expect(titles).toContain("Read /src/main.ts");
+    // EventRow 的 seq 标记直接可见（无需展开）
+    expect(screen.getByText("#0")).toBeInTheDocument();
+    expect(screen.getByText("#1")).toBeInTheDocument();
+    expect(screen.getByText("#2")).toBeInTheDocument();
   });
 
-  it("多个 [assistant, tool_use, tool_result] 序列分为多个动作组", () => {
+  it("多 Turn 时各 Turn 事件独立平铺", () => {
     const events: RoutineIterationEventDTO[] = [
       makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "第一步" } }),
       makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /a.ts" }),
@@ -467,89 +437,13 @@ describe("IterationEventTimeline ActionGroup 分组", () => {
       makeEvent({ seq: 3, event_type: "assistant", title: null, tool_name: null, payload: { text: "第二步" } }),
       makeEvent({ seq: 4, event_type: "tool_use", tool_name: "Edit", title: "Edit /a.ts" }),
       makeEvent({ seq: 5, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
-      makeEvent({ seq: 6, event_type: "assistant", title: null, tool_name: null, payload: { text: "完成" } }),
     ];
-    const { container } = render(<IterationEventTimeline events={events} />);
+    render(<IterationEventTimeline events={events} />);
 
-    const titles = getActionGroupTitles(container);
-    // 3 个 ActionGroup: Read, Edit, "完成"
-    expect(titles.length).toBe(3);
-    expect(titles).toContain("Read /a.ts");
-    expect(titles).toContain("Edit /a.ts");
-  });
-
-  it("单个 system 事件形成独立动作组", () => {
-    render(
-      <IterationEventTimeline
-        events={[makeEvent({ event_type: "system", title: "init", tool_name: null, payload: {} })]}
-      />,
-    );
-    // ActionGroupRow 标题为 "会话初始化"
-    expect(screen.getAllByText("会话初始化").length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("并行 tool_use 事件归入同一动作组", () => {
-    const events: RoutineIterationEventDTO[] = [
-      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "并行读取" } }),
-      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /a.ts" }),
-      makeEvent({ seq: 2, event_type: "tool_use", tool_name: "Read", title: "Read /b.ts" }),
-      makeEvent({ seq: 3, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
-      makeEvent({ seq: 4, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
-    ];
-    const { container } = render(<IterationEventTimeline events={events} />);
-
-    // 只有 1 个 ActionGroupRow，标题为首个 tool_use 的标题
-    const titles = getActionGroupTitles(container);
-    expect(titles.length).toBe(1);
-    expect(titles).toContain("Read /a.ts");
-  });
-
-  it("ActionGroupRow count > 1 时渲染数量 badge", () => {
-    const events: RoutineIterationEventDTO[] = [
-      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "动作" } }),
-      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /x.ts" }),
-      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
-    ];
-    const { container } = render(<IterationEventTimeline events={events} />);
-
-    // 数量 badge 在 ActionGroupRow 按钮内，显示 "3"
-    const btn = getActionGroupButtons(container)[0];
-    expect(btn?.textContent).toContain("3");
-  });
-
-  it("ActionGroupRow hasError 时渲染错误 badge", () => {
-    const events: RoutineIterationEventDTO[] = [
-      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "尝试" } }),
-      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Bash", title: "Bash: fail" }),
-      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: { is_error: true, text: "error output" } }),
-    ];
-    const { container } = render(<IterationEventTimeline events={events} />);
-
-    // 错误 badge 在 ActionGroupRow 按钮内
-    const btn = getActionGroupButtons(container)[0];
-    const errorBadge = btn?.querySelector(".bg-red-500\\/10");
-    expect(errorBadge?.textContent).toContain("error");
-  });
-
-  it("点击 ActionGroupRow 展开后显示 EventRow 列表", () => {
-    const created = "2026-06-01T09:08:07+00:00";
-    const events: RoutineIterationEventDTO[] = [
-      makeEvent({ seq: 0, event_type: "assistant", title: null, tool_name: null, payload: { text: "动作" } }),
-      makeEvent({ seq: 1, event_type: "tool_use", tool_name: "Read", title: "Read /x.ts", created_at: created }),
-      makeEvent({ seq: 2, event_type: "tool_result", tool_name: null, title: null, payload: {} }),
-    ];
-    const { container } = render(<IterationEventTimeline events={events} />);
-
-    // 展开前：ActionGroupRow 折叠态，内部 EventRow 不在 DOM
-    const btn = getActionGroupButtons(container)[0];
-    expect(btn?.getAttribute("aria-expanded")).toBe("false");
-
-    // 点击展开
-    fireEvent.click(btn!);
-
-    // 展开后：EventRow 可见（通过 seq 标记确认）
+    // Turn 1 和 Turn 2 的 seq 标记均可见
+    expect(screen.getByText("#0")).toBeInTheDocument();
     expect(screen.getByText("#1")).toBeInTheDocument();
-    // 时间戳也可见（可能多个 EventRow 有相同时间戳，用 getAllByText）
-    expect(screen.getAllByText(new Date(created).toLocaleTimeString()).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("#3")).toBeInTheDocument();
+    expect(screen.getByText("#4")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Iteration 事件时间线中 Turn 与 Event 之间存在 ActionGroup 中间聚合层（如 "Bash: uv run pytest..."），需展开折叠才能看到实际事件，增加了信息获取的层级摩擦
- 关联上下文：#862 连续气泡聚合系列优化的延续

# 核心变更
- **移除 ActionGroupRow 组件**及其全部支撑代码（`ActionGroup` 接口、`groupIntoActions()`、`deriveActionGroupTitle/Icon`），净减 330 行
- **ClaudeCodeTurnBubble 直接渲染 EventRow**：`turn.events.map(ev => <EventRow>)` 替代原来的 `actionGroups.map(group => <ActionGroupRow>)`
- 副标题条件从 `actionGroups.length > 1` 调整为 `turn.events.length > 1`，更直观地控制 Turn 摘要显示
- 测试同步清理：移除 `expandFirstActionGroup`/`expandActionGroup` 辅助函数和 ActionGroup 分组测试块，新增直接可见验证用例；修复连续 engine 事件被 SpeakerGroupBubble 合并后的 DOM 顺序断言

# 风险与回滚
- 主要风险：低。改动局限于前端展示层，不涉及数据模型或 API 变更；EventRow 组件本身未修改，各事件仍可独立展开查看详情
- 回滚方式：`git revert` 单个 commit 即可恢复

# 验证证据
- 单元测试：27 个测试全部通过（含新增的 "Turn → Event 直接渲染" 验证用例）
- 集成测试：N/A（纯前端组件变更）
- E2E/Workflow：实机验证 http://localhost:3192 确认 Turn 1（7 events）直接平铺 #0~#6 事件，无中间聚合层
- 覆盖率/关键截图：已通过浏览器截图确认 Iteration #28 的 Turn 1/2/3 均正确展示

# 影响范围
- 前端：`IterationEventTimeline.tsx`（-276 行）、`IterationEventTimeline.test.tsx`（-54 行）
- 后端：无变更
- GitHub Actions / 文档：无变更

# Next Best Action
- 后续可考虑：当 Turn 内事件数量过多（如 Turn 4 有 157 个事件）时的分页或虚拟滚动优化