### PR TITLE
fix(Catalog): 目录节点拖拽排序支持浮点 sort_order，修复 422 错误

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0061_catalog_entry_position_float.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0061_catalog_entry_position_float.py
@@ -1,0 +1,35 @@
+"""Alter catalog_entries.position from INTEGER to DOUBLE PRECISION
+
+Revision ID: 0061
+Revises: 0060
+Create Date: 2026-06-05 00:00:00.000000+00:00
+
+设计动机：
+    前端目录树拖拽排序采用分数索引（Fractional Indexing）策略：取相邻节点
+    ``sort_order`` 的中点（如 ``(0 + 1625) / 2 = 812.5``）作为新位置。
+    后端 ``position`` 列为 ``INTEGER``，无法存储浮点值，导致 Pydantic 验证
+    在 API 边界即拦截并返回 422 Unprocessable Entity。
+
+    本迁移将 ``position`` 列从 ``INTEGER`` 改为 ``DOUBLE PRECISION``，使后端
+    全栈（Pydantic schema → Service → DAO → DB）均支持浮点排序值。
+
+    现有整数数据在类型变更后语义不变（``1000`` 作为 ``1000.0`` 存储）。
+"""
+
+from alembic import op
+
+revision = "0061"
+down_revision = "0060"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "negentropy"
+TABLE = f"{SCHEMA}.doc_catalog_entries"
+
+
+def upgrade() -> None:
+    op.execute(f"ALTER TABLE {TABLE} ALTER COLUMN position TYPE DOUBLE PRECISION")
+
+
+def downgrade() -> None:
+    op.execute(f"ALTER TABLE {TABLE} ALTER COLUMN position TYPE INTEGER USING position::INTEGER")

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_node_dao.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_node_dao.py
@@ -88,7 +88,7 @@ class CatalogNodeDao:
         parent_id: UUID | None = None,
         node_type: str = "folder",
         description: str | None = None,
-        sort_order: int = 0,
+        sort_order: float = 0,
         config: dict | None = None,
     ) -> DocCatalogEntry:
         """创建目录条目节点（FOLDER；DOCUMENT_REF 仅由 assign_document 自动创建）"""
@@ -144,7 +144,7 @@ class CatalogNodeDao:
         parent_id: UUID | None = None,
         node_type: str | None = None,
         description: str | None = None,
-        sort_order: int | None = None,
+        sort_order: float | None = None,
         config: dict | None = None,
     ) -> DocCatalogEntry | None:
         """更新目录条目节点（仅更新传入的非 None 字段）"""

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/catalog_service.py
@@ -141,7 +141,7 @@ class CatalogService:
         parent_id: UUID | None = None,
         node_type: str = "folder",
         description: str | None = None,
-        sort_order: int = 0,
+        sort_order: float = 0,
         config: dict | None = None,
     ) -> DocCatalogEntry:
         """创建目录节点（FOLDER 是唯一用户可创建类型）

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -79,7 +79,7 @@ class CatalogNodeCreateRequest(BaseModel):
     parent_id: UUID | None = None
     node_type: str = "folder"
     description: str | None = None
-    sort_order: int = 0
+    sort_order: float = 0
     config: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("node_type")
@@ -106,7 +106,7 @@ class CatalogNodeUpdateRequest(BaseModel):
     parent_id: UUID | None = None
     node_type: str | None = None
     description: str | None = None
-    sort_order: int | None = None
+    sort_order: float | None = None
     config: dict[str, Any] | None = None
 
 
@@ -122,7 +122,7 @@ class CatalogNodeResponse(BaseModel):
     slug: str
     node_type: str
     description: str | None = None
-    sort_order: int
+    sort_order: float
     config: dict[str, Any] = Field(default_factory=dict)
     # DOCUMENT_REF 叶子节点携带的文档 ID（FOLDER / CATEGORY / COLLECTION 为 None）
     document_id: UUID | None = None

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_types.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_types.py
@@ -81,7 +81,7 @@ class CatalogNodeRecord:
     slug: str
     node_type: str  # CatalogNodeType value
     description: str | None = None
-    sort_order: int = 0
+    sort_order: float = 0
     config: dict[str, Any] = field(default_factory=dict)
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -100,7 +100,7 @@ class CatalogTreeItem:
     name: str
     slug: str
     node_type: str
-    sort_order: int
+    sort_order: float
     depth: int
     path: str = ""  # 完整路径 /parent/child/current
     has_children: bool = False

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -793,7 +793,7 @@ class DocCatalogEntry(Base, UUIDMixin, TimestampMixin):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug_override: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    position: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    position: Mapped[float] = mapped_column(Float, nullable=False, default=0, server_default="0")
     status: Mapped[str] = mapped_column(
         SAEnum(
             "ACTIVE",


### PR DESCRIPTION
## 问题

在 Knowledge / Wiki 目录树中拖拽节点时，前端采用**分数索引（Fractional Indexing）**策略计算目标位置——取相邻节点 sort_order 的中点（如 `812.5`）。但后端 Pydantic schema 将 sort_order 声明为 `int`，导致 API 返回：

```
422 Unprocessable Entity
{"detail":[{"type":"int_from_float","loc":["body","sort_order"],"msg":"Input should be a valid integer, got a number with a fractional part","input":812.5}]}
```

## 修复方案

将后端全栈 `sort_order` / `position` 类型从 `int` / `Integer` 升级为 `float` / `Float`：

| 层 | 文件 | 变更 |
|---|---|---|
| Pydantic Schema | `lifecycle_schemas.py` | 3 处 `sort_order: int` → `float` |
| Dataclass 类型 | `lifecycle_types.py` | 2 处 `sort_order: int` → `float` |
| Service 层 | `catalog_service.py` | 参数类型 `int` → `float` |
| DAO 层 | `catalog_node_dao.py` | 2 处参数类型 `int` → `float` |
| DB Model | `perception.py` | `position` 列 `Integer` → `Float` |
| Migration | `0061_catalog_entry_position_float.py` | `ALTER COLUMN position TYPE DOUBLE PRECISION` |

前端无需修改（TypeScript `number` 天然兼容 int/float）。

## 验证

- ✅ Ruff lint + format 通过
- ✅ Alembic migration 执行成功
- ✅ API 测试：`PATCH {.../entries/id} {"sort_order": 812.5}` 返回 200
- ✅ 浏览器实机验证：Wiki 目录树拖拽排序操作正常，无 422 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)