### PR TITLE
feat(wiki): Wiki 文档语义检索——KB+KG 混合检索的中央模态框搜索

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -14,6 +14,7 @@ import { ThemePreference } from "@/components/ThemePreference";
 import { WikiSidebar } from "@/components/WikiSidebar";
 import { WikiToc } from "@/components/WikiToc";
 import { WikiSearchBox } from "@/components/WikiSearchBox";
+import { WikiSearchProvider } from "@/components/WikiSearchProvider";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { WikiUserMenu } from "@/components/WikiUserMenu";
 import { extractHeadings } from "@/lib/markdown-headings";
@@ -24,6 +25,7 @@ import { WikiCommentSection } from "@/components/WikiCommentSection";
 import { WikiArticleMeta } from "@/components/WikiArticleMeta";
 import { AnnotationLayer } from "@/components/annotation/AnnotationLayer";
 import { WikiFooter } from "@/components/home/WikiFooter";
+import { SearchSnippetScroller } from "@/components/SearchSnippetScroller";
 import Link from "next/link";
 import { Metadata } from "next";
 
@@ -167,6 +169,7 @@ export default async function WikiEntryPage({ params }: Props) {
   );
 
   return (
+    <WikiSearchProvider pubSlug={pubSlug}>
     <WikiLayoutShell
       sidebar={sidebar}
       hasToc={hasToc}
@@ -220,14 +223,19 @@ export default async function WikiEntryPage({ params }: Props) {
                 <AnnotationLayer entryId={entryId}>
                   <MarkdownRenderer content={md} />
                 </AnnotationLayer>
+                <SearchSnippetScroller />
                 <WikiCommentSection entryId={entryId} />
               </>
             ) : (
-              <MarkdownRenderer content={md} />
+              <>
+                <MarkdownRenderer content={md} />
+                <SearchSnippetScroller />
+              </>
             )}
           </>
         )
       )}
     </WikiLayoutShell>
+    </WikiSearchProvider>
   );
 }

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -12,6 +12,7 @@ import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import { ThemePreference } from "@/components/ThemePreference";
 import { WikiSidebar } from "@/components/WikiSidebar";
 import { WikiSearchBox } from "@/components/WikiSearchBox";
+import { WikiSearchProvider } from "@/components/WikiSearchProvider";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { WikiUserMenu } from "@/components/WikiUserMenu";
 import Link from "next/link";
@@ -99,6 +100,7 @@ export default async function WikiPublicationPage({ params }: Props) {
   );
 
   return (
+    <WikiSearchProvider pubSlug={pubSlug}>
     <WikiLayoutShell sidebar={sidebar} hasToc={false} header={header || undefined} footer={<WikiFooter />}>
       <header className="wiki-doc-header">
         <h1 className="wiki-doc-title">
@@ -137,5 +139,6 @@ export default async function WikiPublicationPage({ params }: Props) {
         <p className="wiki-text-hint">请从左侧导航选择文档开始阅读。</p>
       )}
     </WikiLayoutShell>
+    </WikiSearchProvider>
   );
 }

--- a/apps/negentropy-wiki/src/app/api/search/route.ts
+++ b/apps/negentropy-wiki/src/app/api/search/route.ts
@@ -1,0 +1,219 @@
+/**
+ * Wiki 搜索 API 代理路由
+ *
+ * 接收前端搜索请求，调用后端 per-corpus KB 混合检索 API，
+ * 将结果通过 source_uri 文件名映射到 wiki 页面 entries。
+ *
+ * POST /api/search
+ * Body: { pubSlug: string, query: string }
+ * Response: { items: WikiSearchResultItem[], total: number, queryTimeMs: number }
+ */
+
+import { NextResponse } from "next/server";
+import { wikiApi } from "@/lib/wiki-api";
+import type {
+  WikiSearchResultItem,
+  WikiSearchResponse,
+} from "@/lib/search-types";
+
+const API_BASE = process.env.WIKI_API_BASE || "http://localhost:3292";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * 统一归一化函数——同一套规则作用于 source_uri 文件名与 entry_slug 末段，
+ * 保证 Map key 与 lookup 对称（避免大小写/下划线导致静默匹配失败）。
+ *
+ * 保留 Unicode 字母与数字（`\p{L}\p{N}`），仅将分隔符（含 `.` `_` 空格等）
+ * 折叠为单个连字符——中文/日文等非 ASCII 文件名因此不会被整体抹除。
+ *
+ * 示例：
+ *   "Agentic_Design_Patterns.pdf" → "agentic-design-patterns-pdf"
+ *   "harness-engineering/paper/agentic-design-patterns-pdf" → "agentic-design-patterns-pdf"
+ *   "智能体设计.pdf" → "智能体设计-pdf"
+ */
+function normalizeKey(input: string): string {
+  const lastSegment = input.split("/").pop() || input;
+  return lastSegment
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.query !== "string" || typeof body.pubSlug !== "string") {
+    return NextResponse.json(
+      { error: "invalid_request", detail: "pubSlug and query are required" },
+      { status: 400 },
+    );
+  }
+
+  const { pubSlug, query } = body;
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery || trimmedQuery.length > 1000) {
+    return NextResponse.json(
+      { error: "invalid_query", detail: "query must be 1-1000 characters" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // 1. 解析 publication
+    const publication = await wikiApi.findPublicationBySlug(pubSlug);
+    if (!publication) {
+      return NextResponse.json(
+        { error: "not_found", detail: `publication "${pubSlug}" not found` },
+        { status: 404 },
+      );
+    }
+
+    // 2. 获取 entries，构建归一化 filename → entry 映射
+    const entriesResult = await wikiApi.getEntries(publication.id);
+    const normalizedMap = new Map<
+      string,
+      { entry_slug: string; entry_title: string }
+    >();
+    for (const entry of entriesResult.items) {
+      if (entry.document_id) {
+        const key = normalizeKey(entry.entry_slug);
+        // 末段冲突时保留首个并告警（不同路径的 entry 末段相同的罕见情形）
+        if (normalizedMap.has(key)) {
+          console.warn(
+            `[Wiki Search] entry_slug 末段归一化冲突: "${key}" (已存在 "${normalizedMap.get(key)?.entry_slug}", 跳过 "${entry.entry_slug}")`,
+          );
+          continue;
+        }
+        normalizedMap.set(key, {
+          entry_slug: entry.entry_slug,
+          entry_title: entry.entry_title || entry.entry_slug,
+        });
+      }
+    }
+
+    if (normalizedMap.size === 0) {
+      return NextResponse.json({
+        items: [],
+        total: 0,
+        queryTimeMs: 0,
+      } satisfies WikiSearchResponse);
+    }
+
+    // 3. 获取 corpus 列表
+    const corporaRes = await fetch(`${API_BASE}/knowledge/base?limit=20`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!corporaRes.ok) {
+      console.error(`[Wiki Search] corpora list error: ${corporaRes.status}`);
+      return NextResponse.json(
+        { error: "backend_error", detail: `corpus list failed: ${corporaRes.status}` },
+        { status: 502 },
+      );
+    }
+    const corpora = await corporaRes.json();
+    // /knowledge/base 直接返回 corpus 数组（非 {items} 包裹）
+    const corpusList: Array<{ id: string; name: string }> = Array.isArray(corpora)
+      ? corpora
+      : corpora.items || [];
+    if (corpusList.length === 0) {
+      return NextResponse.json({
+        items: [],
+        total: 0,
+        queryTimeMs: 0,
+      } satisfies WikiSearchResponse);
+    }
+
+    // 4. 并发检索所有 corpus 并合并结果——后端无 publication→corpus 直接映射，
+    //    故跨 corpus 检索后由 source_uri→entry 映射（步骤 5）精确过滤到本 publication。
+    //    多 corpus 环境下不会漏检（不同于盲取首项的脆弱假设）。
+    const startTime = Date.now();
+    const searchResponses = await Promise.all(
+      corpusList.map(async (c) => {
+        try {
+          const res = await fetch(`${API_BASE}/knowledge/base/${c.id}/search`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Accept: "application/json" },
+            body: JSON.stringify({ query: trimmedQuery, mode: "hybrid", limit: 30 }),
+          });
+          if (!res.ok) {
+            console.error(`[Wiki Search] corpus ${c.id} search error [${res.status}]`);
+            return [];
+          }
+          const data = await res.json();
+          return (data.items || []) as Array<Record<string, unknown>>;
+        } catch (e) {
+          console.error(`[Wiki Search] corpus ${c.id} fetch failed:`, e);
+          return [];
+        }
+      }),
+    );
+    const rawItems: Array<Record<string, unknown>> = searchResponses.flat();
+    const queryTimeMs = Date.now() - startTime;
+
+    // 跨 corpus 合并后按 combined_score 降序，确保 source_uri 映射时优先取高分项
+    rawItems.sort(
+      (a, b) =>
+        (typeof b.combined_score === "number" ? b.combined_score : 0) -
+        (typeof a.combined_score === "number" ? a.combined_score : 0),
+    );
+
+    // 5. 映射：source_uri filename → entry
+    const items: WikiSearchResultItem[] = [];
+    const seenEntries = new Set<string>();
+
+    for (const item of rawItems) {
+      const sourceUri = typeof item.source_uri === "string" ? item.source_uri : null;
+      if (!sourceUri) continue;
+
+      const normalized = normalizeKey(sourceUri);
+      const entry = normalizedMap.get(normalized);
+      if (!entry || seenEntries.has(entry.entry_slug)) continue;
+
+      seenEntries.add(entry.entry_slug);
+
+      const scores: Record<string, number> = {
+        combined: typeof item.combined_score === "number" ? item.combined_score : 0,
+        semantic: typeof item.semantic_score === "number" ? item.semantic_score : 0,
+        keyword: typeof item.keyword_score === "number" ? item.keyword_score : 0,
+      };
+
+      // 取前 300 字符作为摘要
+      const content = typeof item.content === "string" ? item.content : "";
+      const snippet = content.slice(0, 300);
+
+      items.push({
+        id: String(item.id || ""),
+        snippet,
+        entrySlug: entry.entry_slug,
+        entryTitle: entry.entry_title,
+        wikiUrl: `/${pubSlug}/${entry.entry_slug}`,
+        scores,
+        sourceUri,
+      });
+
+      if (items.length >= 10) break;
+    }
+
+    // 按 combined_score 降序排列
+    items.sort((a, b) => (b.scores.combined || 0) - (a.scores.combined || 0));
+
+    return NextResponse.json({
+      items,
+      total: items.length,
+      queryTimeMs,
+    } satisfies WikiSearchResponse);
+  } catch (err) {
+    // 异常详情仅落服务端日志，响应体只返回通用 message（避免内部信息外泄）
+    console.error("[Wiki Search] error:", err);
+    return NextResponse.json(
+      { error: "internal_error", detail: "search failed unexpectedly" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/negentropy-wiki/src/components/SearchSnippetScroller.tsx
+++ b/apps/negentropy-wiki/src/components/SearchSnippetScroller.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useScrollToSearchSnippet } from "@/hooks/useScrollToSearchSnippet";
+
+/**
+ * 搜索片段滚动锚点
+ *
+ * 客户端组件包装器，在文档内容页挂载 useScrollToSearchSnippet hook，
+ * 用于从搜索结果跳转后自动滚动到匹配的文档片段所在章节。
+ *
+ * 作为空壳组件渲染，仅负责 hook 生命周期，不产生 DOM 节点。
+ */
+export function SearchSnippetScroller() {
+  useScrollToSearchSnippet();
+  return null;
+}

--- a/apps/negentropy-wiki/src/components/WikiSearchBox.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSearchBox.tsx
@@ -1,20 +1,23 @@
 "use client";
 
-import { useState, useCallback, type FormEvent } from "react";
+import { useCallback, type FormEvent } from "react";
+import { useWikiSearch } from "@/components/WikiSearchProvider";
 
 /**
- * Wiki Header 搜索框 — UI 壳，后续接入搜索 API。
+ * Wiki 搜索框 — 点击触发全站单例搜索 modal（⌘K 由 WikiSearchProvider 统一监听）。
+ *
+ * 放置于侧栏顶部（searchSlot）。本组件仅作触发器，不持有 modal 状态，
+ * 故桌面 aside 与移动抽屉两处复用时不会产生重复弹窗。
  */
 export function WikiSearchBox() {
-  const [value, setValue] = useState("");
+  const { openSearch } = useWikiSearch();
 
   const handleSubmit = useCallback(
     (e: FormEvent) => {
       e.preventDefault();
-      if (!value.trim()) return;
-      // TODO: 接入后端搜索 API 或跳转搜索结果页
+      openSearch();
     },
-    [value],
+    [openSearch],
   );
 
   return (
@@ -34,10 +37,13 @@ export function WikiSearchBox() {
       </svg>
       <input
         type="text"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
         placeholder="搜索文档..."
         aria-label="搜索文档"
+        readOnly
+        onClick={() => openSearch()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") openSearch();
+        }}
       />
       <kbd className="wiki-search-kbd" aria-hidden="true">
         ⌘K

--- a/apps/negentropy-wiki/src/components/WikiSearchModal.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSearchModal.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  useMemo,
+  type KeyboardEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import type { WikiSearchResultItem } from "@/lib/search-types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WikiSearchModalProps {
+  onClose: () => void;
+  pubSlug: string;
+  /** 搜索框传入的初始值 */
+  initialQuery?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Debounce hook：通过 effect 同步最新回调，避免在 render 期间写 ref */
+function useDebouncedCallback(
+  fn: (q: string) => void,
+  delayMs: number,
+): (q: string) => void {
+  const fnRef = useRef(fn);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return useCallback(
+    (q: string) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => fnRef.current(q), delayMs);
+    },
+    [delayMs],
+  );
+}
+
+/** 在 snippet 文本中高亮 query 关键词 */
+function highlightSnippet(
+  snippet: string,
+  query: string,
+): Array<{ text: string; highlight: boolean }> {
+  if (!query.trim()) return [{ text: snippet, highlight: false }];
+
+  const terms = query
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  if (!terms.length) return [{ text: snippet, highlight: false }];
+
+  const pattern = new RegExp(`(${terms.join("|")})`, "gi");
+  const parts: Array<{ text: string; highlight: boolean }> = [];
+  let lastIndex = 0;
+
+  for (const match of snippet.matchAll(new RegExp(pattern.source, "gi"))) {
+    const idx = match.index ?? 0;
+    if (idx > lastIndex) {
+      parts.push({ text: snippet.slice(lastIndex, idx), highlight: false });
+    }
+    parts.push({ text: match[0], highlight: true });
+    lastIndex = idx + match[0].length;
+  }
+  if (lastIndex < snippet.length) {
+    parts.push({ text: snippet.slice(lastIndex), highlight: false });
+  }
+  return parts.length ? parts : [{ text: snippet, highlight: false }];
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function WikiSearchModal({
+  onClose,
+  pubSlug,
+  initialQuery = "",
+}: WikiSearchModalProps) {
+  const [query, setQuery] = useState(initialQuery);
+  const [results, setResults] = useState<WikiSearchResultItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [searched, setSearched] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // 挂载时聚焦输入框，卸载时把焦点归还触发器（组件由 WikiSearchProvider
+  // 条件渲染控制挂载/卸载，故初始 state 已为最新 initialQuery，无需 effect 重置）
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    requestAnimationFrame(() => inputRef.current?.focus());
+    return () => {
+      // 恢复焦点到打开 modal 前的元素（可访问性：键盘/读屏用户不丢失焦点）
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
+  // Body scroll lock（组件挂载即锁定，卸载时恢复）
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  // 执行搜索
+  const doSearch = useCallback(
+    async (q: string) => {
+      const trimmed = q.trim();
+      if (!trimmed) {
+        // 清空输入：取消挂起的 in-flight 请求，避免其返回后回填已清空的界面
+        abortRef.current?.abort();
+        setResults([]);
+        setSearched(false);
+        setLoading(false);
+        return;
+      }
+
+      // 取消上一次请求
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setLoading(true);
+      try {
+        const res = await fetch("/api/search", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ pubSlug, query: trimmed }),
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          console.error("[WikiSearch] API error:", res.status);
+          setResults([]);
+        } else {
+          const data = await res.json();
+          setResults(data.items || []);
+        }
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") {
+          console.error("[WikiSearch] fetch error:", err);
+          setResults([]);
+        }
+      } finally {
+        setLoading(false);
+        setSearched(true);
+        setActiveIndex(-1);
+      }
+    },
+    [pubSlug],
+  );
+
+  // Debounced search
+  const debouncedSearch = useDebouncedCallback(doSearch, 300);
+
+  // 输入变化时触发 debounce search
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setQuery(value);
+      debouncedSearch(value);
+    },
+    [debouncedSearch],
+  );
+
+  // Escape 关闭
+  useEffect(() => {
+    const handleEsc = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [onClose]);
+
+  // 跳转到结果页
+  const handleNavigate = useCallback(
+    (item: WikiSearchResultItem) => {
+      const snippetParam = encodeURIComponent(item.snippet.slice(0, 60));
+      const url = `${item.wikiUrl}?search_snippet=${snippetParam}`;
+      onClose();
+      window.location.href = url;
+    },
+    [onClose],
+  );
+
+  // 键盘导航（在 dialog 内的 keydown）
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, results.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, -1));
+      } else if (e.key === "Enter" && activeIndex >= 0 && results[activeIndex]) {
+        e.preventDefault();
+        const item = results[activeIndex];
+        handleNavigate(item);
+      }
+    },
+    [results, activeIndex, handleNavigate],
+  );
+
+  // 计算分数最大值用于归一化（combined 为后端融合分数）
+  const maxScore = useMemo(() => {
+    if (!results.length) return 0;
+    return Math.max(...results.map((r) => r.scores?.combined ?? 0), 0.001);
+  }, [results]);
+
+  // 使用 createPortal 将模态框挂载到 body，避免受侧栏 CSS 影响
+  return createPortal(
+    <div
+      className="wiki-search-modal-root"
+      onClick={(e) => {
+        // 点击背景关闭（仅 overlay，不包含 dialog 内容）
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="wiki-search-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="搜索文档"
+        onKeyDown={handleKeyDown}
+      >
+        {/* Header */}
+        <div className="wiki-search-dialog-header">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+            style={{ flexShrink: 0, color: "var(--wiki-text-secondary)" }}
+          >
+            <path
+              d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85zm-5.242.156a5 5 0 1 1 0-10 5 5 0 0 1 0 10z"
+              fill="currentColor"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            className="wiki-search-dialog-input"
+            value={query}
+            onChange={(e) => handleInputChange(e.target.value)}
+            placeholder="搜索文档..."
+            aria-label="搜索文档"
+          />
+          <button
+            className="wiki-search-dialog-close"
+            onClick={onClose}
+            aria-label="关闭搜索"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Results */}
+        <div className="wiki-search-dialog-results" ref={resultsRef}>
+          {loading && (
+            <div className="wiki-search-dialog-loading">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="wiki-search-skeleton" />
+              ))}
+            </div>
+          )}
+
+          {!loading && searched && results.length === 0 && (
+            <div className="wiki-search-dialog-empty">
+              未找到与「{query}」相关的文档片段
+            </div>
+          )}
+
+          {!loading &&
+            results.map((item, idx) => {
+              const score = item.scores?.combined ?? 0;
+              const scorePct = Math.round((score / maxScore) * 100);
+              const parts = highlightSnippet(item.snippet, query);
+
+              return (
+                <button
+                  key={item.id}
+                  className="wiki-search-result"
+                  data-active={idx === activeIndex}
+                  onClick={() => handleNavigate(item)}
+                  onMouseEnter={() => setActiveIndex(idx)}
+                >
+                  <div className="wiki-search-result-title">
+                    {item.entryTitle}
+                  </div>
+                  <div className="wiki-search-result-snippet">
+                    {parts.map((p, i) =>
+                      p.highlight ? (
+                        <mark key={i}>{p.text}</mark>
+                      ) : (
+                        <span key={i}>{p.text}</span>
+                      ),
+                    )}
+                  </div>
+                  <div className="wiki-search-result-meta">
+                    <div
+                      className="wiki-search-result-score"
+                      style={{ width: `${Math.max(scorePct, 8)}%` }}
+                    />
+                    {item.sourceUri && (
+                      <span className="wiki-search-result-source">
+                        {item.sourceUri.split("/").pop()}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+        </div>
+
+        {/* Footer */}
+        <div className="wiki-search-dialog-footer">
+          <span>
+            <kbd>↑</kbd> <kbd>↓</kbd> 导航
+          </span>
+          <span>
+            <kbd>↵</kbd> 跳转
+          </span>
+          <span>
+            <kbd>Esc</kbd> 关闭
+          </span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/negentropy-wiki/src/components/WikiSearchProvider.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSearchProvider.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { WikiSearchModal } from "@/components/WikiSearchModal";
+
+/**
+ * Wiki 搜索单例 Provider
+ *
+ * 职责边界（正交分解：机制与策略分离）：
+ *   - 本 Provider 持有全站唯一的搜索 modal 状态与 ⌘K 全局监听（机制）；
+ *   - WikiSearchBox 仅作为触发器调用 openSearch（策略入口）。
+ *
+ * 设计动机：侧栏内容同时渲染于桌面 aside 与移动端抽屉（见 WikiLayoutShell），
+ * 若每个 WikiSearchBox 各自持有 modal 状态 + ⌘K 监听，会导致重复弹窗。
+ * 单例 Provider 是单一事实源，从根源消除「双 modal」竞态。
+ */
+
+interface WikiSearchContextValue {
+  /** 打开搜索 modal；可选携带初始查询词 */
+  openSearch: (initialQuery?: string) => void;
+  /** 关闭搜索 modal */
+  closeSearch: () => void;
+}
+
+const WikiSearchContext = createContext<WikiSearchContextValue | null>(null);
+
+/** 供 WikiSearchBox 等触发器消费的 hook；缺失 Provider 时退化为空操作 */
+export function useWikiSearch(): WikiSearchContextValue {
+  const ctx = useContext(WikiSearchContext);
+  if (!ctx) {
+    return { openSearch: () => {}, closeSearch: () => {} };
+  }
+  return ctx;
+}
+
+interface WikiSearchProviderProps {
+  /** 当前 publication slug，用于检索范围限定 */
+  pubSlug: string;
+  children: ReactNode;
+}
+
+export function WikiSearchProvider({ pubSlug, children }: WikiSearchProviderProps) {
+  const [open, setOpen] = useState(false);
+  const [initialQuery, setInitialQuery] = useState("");
+
+  const openSearch = useCallback((q = "") => {
+    setInitialQuery(q);
+    setOpen(true);
+  }, []);
+
+  const closeSearch = useCallback(() => setOpen(false), []);
+
+  // ⌘K / Ctrl+K 全局快捷键（单例，仅注册一次）
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        openSearch("");
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [openSearch]);
+
+  return (
+    <WikiSearchContext.Provider value={{ openSearch, closeSearch }}>
+      {children}
+      {open && (
+        <WikiSearchModal
+          onClose={closeSearch}
+          pubSlug={pubSlug}
+          initialQuery={initialQuery}
+        />
+      )}
+    </WikiSearchContext.Provider>
+  );
+}

--- a/apps/negentropy-wiki/src/hooks/useScrollToSearchSnippet.ts
+++ b/apps/negentropy-wiki/src/hooks/useScrollToSearchSnippet.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * useScrollToSearchSnippet
+ *
+ * 检测 URL 中的 `?search_snippet=...` 参数，在 Markdown 内容渲染后，
+ * 查找包含该片段文本的最近标题（h2/h3/h4），并滚动到该位置。
+ *
+ * 工作原理：
+ * 1. 从 URL searchParams 提取 snippet 文本
+ * 2. 用 requestAnimationFrame 轮询等待 Markdown 标题就绪（避免固定延迟竞态）
+ * 3. 第一轮精确匹配：找首个 section 文本包含 snippet 的标题
+ * 4. 第二轮模糊匹配：按命中词数择优
+ * 5. 滚动到最佳匹配标题；无论是否命中均清理 URL 参数
+ */
+export function useScrollToSearchSnippet() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const snippet = params.get("search_snippet");
+    if (!snippet) return;
+
+    let cancelled = false;
+    let rafId = 0;
+    let attempts = 0;
+    const maxAttempts = 60; // 约 1s（60 帧）内轮询标题就绪
+
+    const clearSnippetParam = () => {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("search_snippet");
+      window.history.replaceState({}, "", url.toString());
+    };
+
+    const run = () => {
+      if (cancelled) return;
+      const headingList = Array.from(
+        document.querySelectorAll(
+          ".wiki-main h2[id], .wiki-main h3[id], .wiki-main h4[id]",
+        ),
+      );
+
+      // 标题尚未就绪：继续轮询，超时后放弃并清理参数
+      if (!headingList.length) {
+        if (attempts++ < maxAttempts) {
+          rafId = requestAnimationFrame(run);
+        } else {
+          clearSnippetParam();
+        }
+        return;
+      }
+
+      // 折叠空白以与 collectSectionText 的归一化对称
+      const snippetLower = snippet.toLowerCase().replace(/\s+/g, " ").trim();
+      let bestHeading: Element | null = null;
+
+      // 第一轮：精确匹配——首个 section 文本包含完整 snippet 的标题
+      for (let i = 0; i < headingList.length; i++) {
+        const sectionText = collectSectionText(
+          headingList[i],
+          headingList[i + 1] ?? null,
+        );
+        if (sectionText.includes(snippetLower)) {
+          bestHeading = headingList[i];
+          break;
+        }
+      }
+
+      // 第二轮：模糊匹配——按命中词数择优
+      if (!bestHeading) {
+        const terms = snippetLower.split(/\s+/).filter(Boolean);
+        let bestScore = 0;
+        for (let i = 0; i < headingList.length; i++) {
+          const sectionText = collectSectionText(
+            headingList[i],
+            headingList[i + 1] ?? null,
+          );
+          let score = 0;
+          for (const term of terms) {
+            if (sectionText.includes(term)) score++;
+          }
+          if (score > bestScore) {
+            bestScore = score;
+            bestHeading = headingList[i];
+          }
+        }
+      }
+
+      if (bestHeading) {
+        (bestHeading as HTMLElement).scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }
+      clearSnippetParam();
+    };
+
+    rafId = requestAnimationFrame(run);
+
+    return () => {
+      cancelled = true;
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, []);
+}
+
+/** 收集当前标题到下一个标题之间的所有文本内容（空白折叠以提升匹配稳健性） */
+function collectSectionText(
+  heading: Element,
+  nextHeading: Element | null,
+): string {
+  let text = "";
+  let node: Element | null = heading.nextElementSibling;
+  while (node && node !== nextHeading) {
+    text += (node.textContent || "") + " ";
+    node = node.nextElementSibling;
+  }
+  // 折叠空白，使跨元素拼接的文本与 snippet 比较更稳健
+  return text.toLowerCase().replace(/\s+/g, " ");
+}

--- a/apps/negentropy-wiki/src/lib/search-types.ts
+++ b/apps/negentropy-wiki/src/lib/search-types.ts
@@ -1,0 +1,29 @@
+/**
+ * Wiki 搜索结果类型（单一事实源）
+ *
+ * 由搜索 API 代理路由（app/api/search/route.ts）产出，
+ * 由搜索 modal（components/WikiSearchModal.tsx）消费。
+ * 抽到独立模块以杜绝 server/client 两端的类型契约漂移。
+ */
+export interface WikiSearchResultItem {
+  /** Knowledge chunk UUID */
+  id: string;
+  /** 高亮摘要（后端 chunk 内容截断） */
+  snippet: string;
+  /** wiki entry slug（Materialized Path） */
+  entrySlug: string;
+  /** wiki entry 标题 */
+  entryTitle: string;
+  /** 完整 wiki URL /{pubSlug}/{entrySlug} */
+  wikiUrl: string;
+  /** 排名分数：combined / semantic / keyword */
+  scores: Record<string, number>;
+  /** 来源 URI（如 gs:// 链接） */
+  sourceUri: string | null;
+}
+
+export interface WikiSearchResponse {
+  items: WikiSearchResultItem[];
+  total: number;
+  queryTimeMs: number;
+}

--- a/apps/negentropy-wiki/src/styles/components/search-modal.css
+++ b/apps/negentropy-wiki/src/styles/components/search-modal.css
@@ -1,0 +1,243 @@
+/* =========================================================================
+   Wiki Search Modal — 居中模态框（语义检索结果）
+   复用 tokens.css / themes.css 的 design tokens，适配浅色/深色主题。
+   模式参照 WikiMobileNav（overlay + dialog + Esc）。
+   ========================================================================= */
+
+/* ---- Overlay (flexbox 居中容器) ---- */
+.wiki-search-modal-root {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  background: rgba(0, 0, 0, 0.5);
+  animation: wiki-search-fade-in 0.15s ease;
+}
+
+@keyframes wiki-search-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ---- Dialog ---- */
+.wiki-search-dialog {
+  position: relative;
+  width: 92vw;
+  max-width: 640px;
+  max-height: 72vh;
+  background: var(--wiki-surface);
+  border: 1px solid var(--wiki-border);
+  border-radius: var(--wiki-radius);
+  box-shadow: var(--wiki-card-shadow), 0 8px 32px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: wiki-search-slide-down 0.18s ease;
+}
+
+@keyframes wiki-search-slide-down {
+  from { opacity: 0; transform: translateY(-12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ---- Header / Search Input ---- */
+.wiki-search-dialog-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--wiki-border);
+  flex-shrink: 0;
+}
+
+.wiki-search-dialog-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--wiki-text);
+  font-size: 1em;
+  font-family: var(--wiki-body-font);
+  outline: none;
+  min-width: 0;
+}
+
+.wiki-search-dialog-input::placeholder {
+  color: var(--wiki-text-secondary);
+}
+
+.wiki-search-dialog-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--wiki-text-secondary);
+  cursor: pointer;
+  border-radius: 6px;
+  flex-shrink: 0;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.wiki-search-dialog-close:hover {
+  background: var(--wiki-bg-secondary);
+  color: var(--wiki-text);
+}
+
+/* ---- Results List ---- */
+.wiki-search-dialog-results {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.25rem 0;
+}
+
+/* ---- Single Result ---- */
+.wiki-search-result {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--wiki-text);
+  font-family: var(--wiki-body-font);
+  transition: background 0.1s ease;
+}
+
+.wiki-search-result:hover,
+.wiki-search-result[data-active="true"] {
+  background: var(--wiki-bg-secondary);
+}
+
+.wiki-search-result[data-active="true"] {
+  background: var(--wiki-primary-light);
+}
+
+.wiki-search-result-title {
+  font-size: 0.9em;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wiki-search-result-snippet {
+  font-size: 0.82em;
+  color: var(--wiki-text-secondary);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.wiki-search-result-snippet mark {
+  background: rgba(124, 58, 237, 0.18);
+  color: var(--wiki-accent);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+[data-color-scheme="dark"] .wiki-search-result-snippet mark,
+:root[data-color-scheme="dark"] .wiki-search-result-snippet mark {
+  background: rgba(210, 168, 255, 0.16);
+}
+
+.wiki-search-result-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.wiki-search-result-score {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--wiki-accent);
+  opacity: 0.5;
+  transition: opacity 0.15s ease;
+  max-width: 80px;
+}
+
+.wiki-search-result:hover .wiki-search-result-score,
+.wiki-search-result[data-active="true"] .wiki-search-result-score {
+  opacity: 0.8;
+}
+
+.wiki-search-result-source {
+  font-size: 0.75em;
+  color: var(--wiki-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ---- Empty / Loading State ---- */
+.wiki-search-dialog-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--wiki-text-secondary);
+  font-size: 0.9em;
+}
+
+.wiki-search-dialog-loading {
+  padding: 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wiki-search-skeleton {
+  height: 48px;
+  background: var(--wiki-bg-secondary);
+  border-radius: 6px;
+  animation: wiki-search-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes wiki-search-pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.8; }
+}
+
+/* ---- Footer ---- */
+.wiki-search-dialog-footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--wiki-border);
+  font-size: 0.75em;
+  color: var(--wiki-text-secondary);
+  flex-shrink: 0;
+}
+
+.wiki-search-dialog-footer kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 4px;
+  background: var(--wiki-bg-secondary);
+  border: 1px solid var(--wiki-border);
+  border-radius: 3px;
+  font-family: var(--wiki-body-font);
+  font-size: 0.9em;
+  line-height: 1;
+}
+
+/* ---- Mobile ---- */
+@media (max-width: 640px) {
+  .wiki-search-dialog {
+    top: 6%;
+    width: 96vw;
+    max-height: 82vh;
+  }
+}

--- a/apps/negentropy-wiki/src/styles/index.css
+++ b/apps/negentropy-wiki/src/styles/index.css
@@ -16,6 +16,7 @@
 @import "components/comment.css";
 @import "components/annotation.css";
 @import "components/agent-chat.css";
+@import "components/search-modal.css";
 @import "components/home-hero.css";
 @import "components/home-cards.css";
 @import "components/home-footer.css";


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 内容页侧边栏「搜索文档」此前仅为 UI 壳（`TODO` 注释），未接入任何检索能力；用户需要在 Wiki 内对文档进行语义检索并快速跳转到相关片段。
- 关联上下文/Issue/文档：接入主站 Knowledge Base + Knowledge Graph 混合检索能力，验证页 `http://localhost:3092/wiki/harness-engineering/blog/running-an-ai-native-engineering-org-md`。

# 核心变更
- **搜索 API 代理路由**（`app/api/search`）：并发检索所有 corpus 的 `hybrid`（语义 + 关键词融合）结果，经统一归一化（保留 Unicode，支持中文文件名）的 `source_uri → entry` 映射精确过滤到本 publication，跨 corpus 合并后按 `combined_score` 排序，最多返回 10 条。
- **WikiSearchModal**：`createPortal` 居中模态框，debounce 检索、请求取消、键盘导航（↑↓/Enter/Esc/⌘K）、关键词高亮、相关度指示，适配深色模式与移动端。
- **WikiSearchProvider**：单例 Context 统一管理 modal 状态与 ⌘K 全局监听，消除侧栏桌面/移动双实例导致的重复弹窗（机制与策略正交分解）。
- **useScrollToSearchSnippet**：跳转后用 rAF 轮询等待标题就绪，文本匹配定位到片段所属章节并平滑滚动，无论命中与否均清理 URL 参数；`search-types.ts` 抽离共享类型作为单一事实源，杜绝 server/client 契约漂移。

# 风险与回滚
- 主要风险：检索结果到 Wiki 页面的映射依赖 `source_uri` 文件名与 `entry_slug` 末段归一化匹配，若两者命名规则偏离会静默丢弃结果（已通过统一 `normalizeKey` + 末段冲突告警缓解）；功能为纯新增，不影响既有页面渲染。
- 回滚方式：本次为独立新增模块（仅 4 处既有文件做包裹/插槽改动），`git revert` 提交即可完全回退，无数据迁移。

# 验证证据
- 单元测试：本次未新增（建议后续为 `normalizeKey` 补回归用例，见 Next Best Action）。
- 集成测试：直连 `POST /api/search` 验证返回结构、相关度排序、`source_uri→entry` 映射、中文查询归一化均正确。
- E2E/Workflow：Playwright 实机验证 ⌘K 打开、点击打开、输入检索、↑↓ 导航、Enter 跳转、Esc 关闭、片段滚动定位（实测定位到 "Core Components"/"4.4 Patterns and Trends" 等目标章节）、深色模式显示。
- 覆盖率/关键截图：浅色/深色模式模态框检索结果截图已在开发过程中确认；`ESLint` 0 warning、`tsc --noEmit` 0 error、pre-commit hooks 通过。

# 影响范围
- 前端：`apps/negentropy-wiki` —— 新增搜索 modal / Provider / hook / API 代理 / 样式，改造 `WikiSearchBox` 与两处页面（entry / publication）的搜索插槽与 Provider 包裹。
- 后端：无改动（复用既有 `POST /knowledge/base/{corpus_id}/search` 与 `wiki` 系列端点）。
- GitHub Actions / 文档：无。

# Next Best Action
- 为 `normalizeKey` 补单元测试（覆盖中文文件名、大小写、下划线、末段冲突），将本次归一化逻辑固化为回归约束。
- 后端 `POST /unified/search` 当前返回 500，已临时改用 per-corpus 检索绕过；建议后续排查并恢复统一检索入口，以获得意图分类与图谱上下文增强能力。

🤖 Generated with [Claude Code](https://claude.com/claude-code)