### PR TITLE
feat(Routine): Routine 详情页模块默认折叠 + Iterations 分页

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
@@ -13,6 +13,8 @@ import {
   YAxis,
 } from "recharts";
 
+import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
+
 import type { RoutineIterationDTO, Verdict } from "@/features/routine";
 
 import { NULL_HEX, VERDICT_HEX } from "./chart-colors";
@@ -64,10 +66,7 @@ export function RoutineConvergenceChart({
   const hasScores = data.some((d) => d.score != null);
 
   return (
-    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-      <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-        评分收敛趋势 · Convergence
-      </h3>
+    <CollapsibleSection title="评分收敛趋势 · Convergence">
       {!hasScores ? (
         <p className="py-8 text-center text-[11px] text-text-muted">尚无评分数据</p>
       ) : (
@@ -114,6 +113,6 @@ export function RoutineConvergenceChart({
           </ResponsiveContainer>
         </div>
       )}
-    </section>
+    </CollapsibleSection>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ListTree } from "lucide-react";
+import { ChevronLeft, ChevronRight, ListTree } from "lucide-react";
 
 import type { RoutineIterationDTO } from "@/features/routine";
 import { AGENT_ROLE_META, deriveIterationDriver } from "@/features/routine";
@@ -9,6 +9,8 @@ import { AGENT_ROLE_META, deriveIterationDriver } from "@/features/routine";
 import { LiveElapsed, StaticDuration } from "./ElapsedClock";
 import { ACTIVE_TIMING } from "./routine-loop";
 import { iterationDotClass, phaseClass, phaseLabel, scoreColorClass, verdictClass } from "./status-style";
+
+const PAGE_SIZE = 10;
 
 interface RoutineIterationTimelineProps {
   iterations: RoutineIterationDTO[];
@@ -25,16 +27,48 @@ export function RoutineIterationTimeline({
   onAudit,
   busy,
 }: RoutineIterationTimelineProps) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.ceil(iterations.length / PAGE_SIZE);
+  const safePage = Math.min(page, Math.max(0, totalPages - 1));
+  const pageItems = iterations.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
   if (iterations.length === 0) {
     return <p className="text-[11px] text-text-muted">No iterations yet.</p>;
   }
 
   return (
-    <ol className="space-y-2">
-      {iterations.map((it) => (
-        <IterationCard key={it.id} it={it} onApprove={onApprove} onAudit={onAudit} busy={busy} />
-      ))}
-    </ol>
+    <>
+      <ol className="space-y-2">
+        {pageItems.map((it) => (
+          <IterationCard key={it.id} it={it} onApprove={onApprove} onAudit={onAudit} busy={busy} />
+        ))}
+      </ol>
+      {totalPages > 1 && (
+        <div className="mt-3 flex items-center justify-center gap-2 border-t border-border pt-3 text-[11px] text-text-muted">
+          <button
+            type="button"
+            disabled={safePage <= 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            aria-label="上一页"
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </button>
+          <span className="font-medium tabular-nums">
+            {safePage + 1} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={safePage >= totalPages - 1}
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            aria-label="下一页"
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-text-muted hover:text-text-primary disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
@@ -3,6 +3,8 @@
 import { useMemo } from "react";
 import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
+import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
+
 import type { ExecStatus, IterationStatus, RoutineIterationDTO, Verdict } from "@/features/routine";
 
 import { useClock } from "./ClockProvider";
@@ -92,10 +94,7 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
   }, [iterations, now]);
 
   return (
-    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-      <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-        迭代时间线 · Run Timeline（执行区间）
-      </h3>
+    <CollapsibleSection title="迭代时间线 · Run Timeline（执行区间）">
       {rows.length === 0 ? (
         <p className="py-8 text-center text-[11px] text-text-muted">尚无可视化的执行区间</p>
       ) : (
@@ -122,6 +121,6 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
           </ResponsiveContainer>
         </div>
       )}
-    </section>
+    </CollapsibleSection>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from "react";
 
 import type { LiveActionsByIteration, RoutineDTO, RoutineIterationDTO } from "@/features/routine";
 
+import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
+
 import { IterationAuditDrawer } from "./IterationAuditDrawer";
 import { ReflectionFlow } from "./ReflectionFlow";
 import { RoutineConvergenceChart } from "./RoutineConvergenceChart";
@@ -55,18 +57,14 @@ export function RoutineRunView({
     <div className="space-y-4">
       {/* 目标 / 验收标准 */}
       <div className="grid gap-4 lg:grid-cols-2">
-        <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-          <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Goal</h3>
+        <CollapsibleSection title="Goal">
           <p className="whitespace-pre-wrap break-words text-xs text-foreground">{routine.goal}</p>
-        </section>
-        <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-          <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-            Acceptance Criteria
-          </h3>
+        </CollapsibleSection>
+        <CollapsibleSection title="Acceptance Criteria">
           <p className="whitespace-pre-wrap break-words text-xs text-text-secondary">
             {routine.acceptance_criteria}
           </p>
-        </section>
+        </CollapsibleSection>
       </div>
 
       {/* 隔离工作区（worktree 生命周期状态 + 手动清理）*/}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
@@ -3,6 +3,7 @@
 import { FolderTree, HardDrive, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
+import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
 import { cn } from "@/lib/utils";
 import type { RoutineDTO } from "@/features/routine";
 
@@ -48,13 +49,14 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
   const canCleanup = canCleanupWorktree(routine.status, routine.worktree_path);
 
   return (
-    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-      {/* 标题行 + 状态徽章 */}
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <h3 className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+    <CollapsibleSection
+      title={
+        <>
           <FolderTree className="h-3.5 w-3.5" />
           Isolated Workspace
-        </h3>
+        </>
+      }
+      headerExtra={
         <span
           className={cn(
             "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold",
@@ -72,8 +74,8 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
           />
           {worktreeStatusLabel(ws)}
         </span>
-      </div>
-
+      }
+    >
       {/* 信息网格 */}
       <dl className="grid gap-x-4 gap-y-1.5 text-xs sm:grid-cols-[auto_1fr]">
         <dt className="text-text-muted">Baseline</dt>
@@ -123,6 +125,6 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
           )}
         </div>
       )}
-    </section>
+    </CollapsibleSection>
   );
 }

--- a/apps/negentropy-ui/components/ui/CollapsibleSection.tsx
+++ b/apps/negentropy-ui/components/ui/CollapsibleSection.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { type ReactNode, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface CollapsibleSectionProps {
+  /** 标题栏内容（文本 / icon + 文本组合） */
+  title: ReactNode;
+  /** 折叠区域的展开内容 */
+  children: ReactNode;
+  /** 初始是否展开，默认 false */
+  defaultExpanded?: boolean;
+  /** 额外 className 覆盖外层 section */
+  className?: string;
+  /** 标题栏右侧附加内容（如状态徽标、计数） */
+  headerExtra?: ReactNode;
+}
+
+/**
+ * 可折叠卡片区段 —— 统一的「标题栏点击 → 展开/收起」交互模式。
+ * 样式与 ReflectionFlow 手写折叠模式保持一致。
+ */
+export function CollapsibleSection({
+  title,
+  children,
+  defaultExpanded = false,
+  className,
+  headerExtra,
+}: CollapsibleSectionProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <section className={cn("rounded-card border border-border bg-card p-4 shadow-sm", className)}>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="group flex w-full items-center justify-between gap-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span className="flex items-center gap-1.5">{title}</span>
+        <div className="flex items-center gap-2">
+          {headerExtra}
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              "h-3.5 w-3.5 shrink-0 transition-transform duration-150",
+              expanded && "rotate-180",
+            )}
+          />
+        </div>
+      </button>
+      {expanded && <div className="mt-3">{children}</div>}
+    </section>
+  );
+}


### PR DESCRIPTION
## 变更说明

Routine 任务详情页信息密度过高，本次改动将次要模块改为默认折叠，并对迭代明细增加分页，改善信息层级和浏览体验。

### 具体变更

1. **新建 `CollapsibleSection` 通用组件** — 基于 Reflexion 手写折叠模式提取，支持 title、children、defaultExpanded、headerExtra 等属性
2. **5 个模块改为默认折叠**：
   - Goal（目标）
   - Acceptance Criteria（验收标准）
   - Isolated Workspace（隔离工作区）
   - 评分收敛趋势 · Convergence
   - 迭代时间线 · Run Timeline（执行区间）
3. **Iterations 分页** — 每页 10 条，按时间倒序，复用项目已有的 Icon-only 分页模式

### 涉及文件

| 文件 | 操作 |
|------|------|
| `components/ui/CollapsibleSection.tsx` | 新建 |
| `routine/_components/RoutineRunView.tsx` | Goal/AC 改用 CollapsibleSection |
| `routine/_components/RoutineWorkspaceCard.tsx` | 外壳改为 CollapsibleSection |
| `routine/_components/RoutineConvergenceChart.tsx` | 外壳改为 CollapsibleSection |
| `routine/_components/RoutineRunGantt.tsx` | 外壳改为 CollapsibleSection |
| `routine/_components/RoutineIterationTimeline.tsx` | 增加分页逻辑 |

> 所有文件路径前缀: `apps/negentropy-ui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)