### PR TITLE
fix(Routine): Iteration 详情右侧气泡 NegentropyEngine 文案靠右对齐

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -463,7 +463,7 @@ function EngineReviewBubble({ ev, showHeader = true }: { ev: RoutineIterationEve
       {/* 气泡内容 */}
       <div className={cn("min-w-0 rounded-2xl border border-sky-500/20 bg-sky-500/[0.03] p-3", showHeader ? "max-w-[85%] rounded-tr-sm" : "w-full")}>
         {/* Header（仅独立渲染时显示发言人标签，verdict/score 始终显示） */}
-        <div className="mb-1.5 flex items-center gap-2">
+        <div className="mb-1.5 flex items-center justify-end gap-2">
           {showHeader && (
             <>
               <span className="text-[10px] font-semibold text-sky-600 dark:text-sky-400">
@@ -582,7 +582,7 @@ function EngineEventBubble({ ev, label, showHeader = true }: { ev: RoutineIterat
         )}
       >
         {/* Header（仅独立渲染时显示发言人标签） */}
-        <div className="mb-1.5 flex items-center gap-2">
+        <div className="mb-1.5 flex items-center justify-end gap-2">
           {showHeader && (
             <>
               <span className="text-[10px] font-semibold text-sky-600 dark:text-sky-400">


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Iteration 详情中 NegentropyEngine 右侧气泡的 header 文案（"NegentropyEngine" + badge）默认左对齐，与右侧气泡的视觉流向不一致，应靠右显示以符合聊天气泡的对向排版语义。
- 关联上下文/Issue/文档：Routine Iteration 事件时间线组件。

# 核心变更
- 在 `IterationEventTimeline.tsx` 的 `EngineReviewBubble`（Plan Review 气泡）和 `EngineEventBubble`（gate/evaluation/result 气泡）两个组件的 header `<div>` 上添加 `justify-end`，使 header 内容靠右对齐。

# 风险与回滚
- 主要风险：极低，仅涉及 CSS 类名变更，不影响逻辑和结构。
- 回滚方式：`git revert` 即可。

# 验证证据
- 单元测试：N/A（纯样式变更）
- 集成测试：N/A
- E2E/Workflow：打开 Routine → Iteration 详情抽屉，确认右侧气泡中 "NegentropyEngine" 文案及 badge 整体靠右显示。
- 覆盖率/关键截图：见附件

# 影响范围
- 前端：`IterationEventTimeline.tsx` 中右侧气泡 header 对齐方式
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 浏览器中验证实际渲染效果，确认深色/浅色模式下均正常。
