### PR TITLE
fix(Routine): 修复 Worktree 隔离越线读取问题，移除源项目目录的显式读取授权

### DIFF
--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -92,24 +92,29 @@ def _build_scope_system_prompt(routine: Routine) -> str:
     system_prompt 层级的指令优先级高于用户 prompt 中的任务描述，
     使作用域限制即使当 goal 文本引用了外部绝对路径时也能生效。
 
-    根因修复：worktree 存储在项目父目录的 ``.negentropy-worktrees/`` 下，
-    与兄弟项目（如 coding-proxy、attention）同级；Claude Code 自主探索
-    时可能误读这些不相关项目。本函数通过 system prompt 显式限定读取范围。
+    隔离保证：worktree 存储在项目父目录的 ``.negentropy-worktrees/`` 下，
+    与兄弟项目同级；Claude Code 自主探索时可能误读这些不相关项目或源
+    项目目录（可能在不同分支）。本函数通过 system prompt 显式限定：仅
+    允许读取 worktree 目录内的文件，绝不授权访问源项目或兄弟目录。
+    worktree 已包含基线分支的完整检出，无需引用源项目。
     """
     cwd = routine.cwd or ""
     wt_path = getattr(routine, "worktree_path", None) or ""
     is_wt = phase_mod.is_worktree_routine(routine)
 
     if is_wt and wt_path:
-        source_line = f"\n  - The source project: `{cwd}` (read-only reference)." if cwd else ""
+        baseline = getattr(routine, "baseline_branch", None) or ""
+        baseline_note = f"\nBaseline branch: `{baseline}`." if baseline else ""
         return (
             "## File System Scope (文件系统作用域)\n"
-            f"Working directory: `{wt_path}` (isolated worktree).\n"
+            f"Working directory: `{wt_path}` (isolated worktree).{baseline_note}\n"
             "READ scope — you may ONLY read files within:\n"
-            f"  1. The worktree directory and its subdirectories.{source_line}\n"
+            "  1. The worktree directory and its subdirectories.\n"
             "  2. Absolute paths explicitly referenced in the task goal.\n"
-            "You MUST NOT read, list, or explore sibling directories of the worktree parent "
-            "or any other local projects outside the above scope.\n"
+            "You MUST NOT read from any directory outside the worktree, including the "
+            "original source project directory, sibling directories, or any other local path. "
+            "The worktree contains a complete checkout of the baseline branch — there is no "
+            "need to reference the source project.\n"
             "Exceptions: WebSearch, WebFetch, and MCP tools are not restricted."
         )
     elif cwd:

--- a/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
+++ b/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
@@ -71,21 +71,17 @@ def build_prompt(
     if worktree:
         baseline = getattr(routine, "baseline_branch", None) or "(baseline)"
         work_branch = getattr(routine, "work_branch", None)
-        source_cwd = getattr(routine, "cwd", None) or ""
-        scope_note = ""
-        if source_cwd:
-            scope_note = f"\n   - 源项目目录 `{source_cwd}` 及其子目录（仅参考，不可修改）"
         parts.append(
             "# 隔离工作区 (Isolated Worktree)\n你正在一个隔离 git worktree（当前工作目录）中工作：\n"
             f"- 工作分支：`{work_branch or '（引擎将基于基线创建）'}`\n"
             f"- 基线分支：`{baseline}`\n\n"
             "## 作用域限制 (Scope Constraints)\n"
             "**读取范围**：仅允许读取以下目录中的文件：\n"
-            "   1. 当前工作目录（worktree）及其子目录"
-            f"{scope_note}\n"
+            "   1. 当前工作目录（worktree）及其子目录\n"
             "   2. Goal 中通过绝对路径明确引用的外部目录（仅限引用处）\n"
             "**绝不**浏览、列出或读取工作目录的兄弟目录、父目录的其他子项目、"
-            "或任何与任务无关的本地文件系统路径。\n\n"
+            "源项目目录、或任何与任务无关的本地文件系统路径。\n"
+            "worktree 包含基线分支的完整检出，无需引用源项目。\n\n"
             "**写入范围**：仅在当前工作目录内改动；"
             "**绝不**切换分支、推送或污染基线分支与 master/main。\n\n"
             "**例外**：WebSearch、WebFetch 等 internet 工具不受此限制。"

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
@@ -150,21 +150,21 @@ def test_build_prompt_worktree_has_scope_constraints():
     assert "兄弟目录" in p
 
 
-def test_build_prompt_worktree_scope_includes_source_cwd():
-    """有 cwd 时 worktree 作用域限制包含源项目路径。"""
+def test_build_prompt_worktree_scope_excludes_source_cwd():
+    """Worktree 作用域限制绝不包含源项目路径（worktree 包含完整检出）。"""
     p = build_prompt(_wt_routine(cwd="/path/to/my-source"))
-    assert "源项目目录" in p
-    assert "/path/to/my-source" in p
+    assert "/path/to/my-source" not in p
 
 
-def test_build_prompt_worktree_scope_without_cwd():
-    """无 cwd 时 worktree 作用域限制不含源项目行。"""
-    p = build_prompt(_wt_routine(cwd=""))
-    assert "源项目目录" not in p
+def test_build_prompt_worktree_scope_prohibits_source_project():
+    """Worktree prompt 明确禁止读取源项目目录。"""
+    p = build_prompt(_wt_routine(cwd="/path/to/my-source"))
+    assert "源项目目录" in p  # 出现在禁止列表中
+    assert "无需引用源项目" in p
 
 
 def test_build_scope_system_prompt_worktree():
-    """worktree routine 的 system prompt 作用域限制。"""
+    """Worktree routine system prompt 禁止读取源项目目录。"""
     r = _wt_routine(
         cwd="/Users/cm.huang/Documents/projects/aurelius/data-la-maps",
         worktree_path="/Users/cm.huang/Documents/projects/aurelius/.negentropy-worktrees/demo",
@@ -172,9 +172,20 @@ def test_build_scope_system_prompt_worktree():
     sp = _build_scope_system_prompt(r)
     assert "File System Scope" in sp
     assert "isolated worktree" in sp
-    assert "source project" in sp
-    assert "data-la-maps" in sp
+    assert "data-la-maps" not in sp  # 源项目路径绝不在 scope 指令中
     assert "MUST NOT" in sp
+    assert "original source project directory" in sp  # 明确禁止源项目
+    assert "Baseline branch" in sp  # 提及基线分支名
+
+
+def test_build_prompt_worktree_never_leaks_source_cwd():
+    """回归测试：worktree prompt 绝不泄露 routine.cwd 路径（隔离保证）。"""
+    r = _wt_routine(cwd="/secret/source/project")
+    p = build_prompt(r)
+    sp = _build_scope_system_prompt(r)
+    # 两个 prompt 层都不得泄露源项目路径
+    assert "/secret/source/project" not in p
+    assert "/secret/source/project" not in sp
 
 
 def test_build_scope_system_prompt_flat_routine():


### PR DESCRIPTION
## 问题

Routine 任务通过 `git worktree add` 从指定基线分支（如 `origin/feature/1.x.x`）创建隔离工作环境，但 Claude Code Agent 在执行时会**越线读取源项目目录**（`routine.cwd`），该目录可能 checkout 在完全不同的分支上，导致 Agent 获取到不属于基线分支的代码上下文，破坏了隔离保证。

## 根因

两处提示构建代码**显式授权** Agent 读取源项目目录作为"只读参考"：

1. **`orchestrator.py`** `_build_scope_system_prompt()` 中的 `source_line`：将 `routine.cwd` 列为合法读取目标
2. **`prompt_builder.py`** `build_prompt()` 中的 `scope_note`：将源项目目录列为"仅参考"的读取范围

而 worktree 已包含基线分支的**完整检出**，根本无需引用源项目。源项目目录 (`routine.cwd`) 可能 checkout 在 `master` 或其他分支上，导致 Agent 读到与基线分支不一致的代码。

## 修复方案

| 文件 | 变更 |
|------|------|
| `orchestrator.py` | 移除 `source_line` 对源项目的读取授权；增加基线分支名称标注；加强禁止指令 |
| `prompt_builder.py` | 移除 `source_cwd`/`scope_note` 块；将"源项目目录"加入禁止列表 |
| `test_routine_phase.py` | 重写 2 个断言错误行为的测试，新增 1 个回归测试验证隔离保证 |

## 测试

- ✅ 单元测试 19/19 通过（`test_routine_phase.py`）
- ✅ Worktree 生命周期测试 8/8 通过（`test_routine_workspace.py`）
- ✅ 集成测试中 2 个预存失败已确认非本次变更引起（stash 前后复现一致）
- ✅ Pre-commit hooks（ruff lint + format）全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)