### PR TITLE
fix(Routine): McpServersPanel 合并 .mcp.json 原生 MCP 服务器，解决面板仅显示 DB 注册服务器的问题 (#872 follow-up)

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -30,6 +30,8 @@ interface IterationAuditDrawerProps {
   iteration: RoutineIterationDTO | null;
   /** 该迭代的实时动作缓冲（来自 useRoutineDetailLive，仅在途迭代有值）。 */
   liveActions?: RoutineActionStreamEvent[];
+  /** 项目根路径（含 .mcp.json），用于 MCP Server 面板合并原生配置。 */
+  projectPath?: string | null;
 }
 
 /**
@@ -46,6 +48,7 @@ export function IterationAuditDrawer({
   routineId,
   iteration,
   liveActions,
+  projectPath,
 }: IterationAuditDrawerProps) {
   const [persisted, setPersisted] = useState<RoutineIterationEventDTO[]>([]);
   const [loading, setLoading] = useState(false);
@@ -109,10 +112,10 @@ export function IterationAuditDrawer({
       <div className="px-5 py-4">
         {error && <ErrorBanner message={error} onRetry={load} />}
 
-        {/* MCP Server/Tool 面板 — 从系统 MCP API 实时获取已启用的 Server 及 Tools */}
+        {/* MCP Server/Tool 面板 — 从系统 MCP API 实时获取已启用的 Server 及 Tools（含 .mcp.json 合并） */}
         {iteration && (
           <div className="mb-3">
-            <McpServersPanel />
+            <McpServersPanel projectPath={projectPath} />
           </div>
         )}
 

--- a/apps/negentropy-ui/app/interface/routine/_components/McpServersPanel.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/McpServersPanel.tsx
@@ -24,6 +24,8 @@ interface McpServerItem {
   transport_type: string;
   is_enabled: boolean;
   tool_count: number;
+  /** MCP 配置来源：db | mcp_json | both */
+  source?: "db" | "mcp_json" | "both";
 }
 
 interface McpToolItem {
@@ -34,6 +36,17 @@ interface McpToolItem {
   is_enabled: boolean;
 }
 
+/** UUID(int=0) 哨兵值，标记无 DB 记录的 .mcp.json 服务器。 */
+const MCP_JSON_SENTINEL_ID = "00000000-0000-0000-0000-000000000000";
+
+// ---------------------------------------------------------------------------
+// 组件 Props
+// ---------------------------------------------------------------------------
+export interface McpServersPanelProps {
+  /** 项目根路径（含 .mcp.json），用于合并原生 MCP 配置。 */
+  projectPath?: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // 组件
 // ---------------------------------------------------------------------------
@@ -41,11 +54,11 @@ interface McpToolItem {
 /**
  * Iteration 详情中的 MCP Server/Tool 面板。
  *
- * 直接从系统 MCP API（``/api/interface/mcp/servers``）实时获取所有已启用的
- * Server 及其 Tools，不依赖后端快照——确保所有迭代（含历史）均能展示当前
- * Claude Code 可用的 MCP 能力。
+ * 从系统 MCP API（``/api/interface/mcp/servers``）实时获取所有已启用的
+ * Server 及其 Tools。当传入 ``projectPath`` 时，API 会额外合并该项目
+ * ``.mcp.json`` 中定义的 MCP 服务器，展示 Claude Code 可用的完整 MCP 能力。
  */
-export function McpServersPanel() {
+export function McpServersPanel({ projectPath }: McpServersPanelProps) {
   const [servers, setServers] = useState<McpServerItem[]>([]);
   const [toolsMap, setToolsMap] = useState<Record<string, McpToolItem[]>>({});
   const [loading, setLoading] = useState(true);
@@ -55,16 +68,22 @@ export function McpServersPanel() {
     setLoading(true);
     setError(null);
     try {
-      // 1. 获取所有已启用的 MCP Server
-      const res = await fetch("/api/interface/mcp/servers", { cache: "no-store" });
+      // 1. 获取所有已启用的 MCP Server（含 .mcp.json 合并）
+      const params = new URLSearchParams();
+      if (projectPath) params.set("projectPath", projectPath);
+      const qs = params.toString();
+      const url = `/api/interface/mcp/servers${qs ? `?${qs}` : ""}`;
+
+      const res = await fetch(url, { cache: "no-store" });
       if (!res.ok) throw new Error(`MCP servers API → ${res.status}`);
       const allServers: McpServerItem[] = await res.json();
       const enabled = allServers.filter((s) => s.is_enabled);
       setServers(enabled);
 
-      // 2. 并行获取各 Server 的已启用 Tools
+      // 2. 并行获取各 DB Server 的已启用 Tools（.mcp.json 服务器跳过）
+      const dbServers = enabled.filter((s) => s.id !== MCP_JSON_SENTINEL_ID);
       const entries = await Promise.all(
-        enabled.map(async (s) => {
+        dbServers.map(async (s) => {
           try {
             const tRes = await fetch(`/api/interface/mcp/servers/${s.id}/tools`, { cache: "no-store" });
             if (!tRes.ok) return [s.id, []] as const;
@@ -81,7 +100,7 @@ export function McpServersPanel() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [projectPath]);
 
   useEffect(() => {
     void load();
@@ -121,8 +140,10 @@ export function McpServersPanel() {
       <div className="space-y-1.5">
         {servers.map((server) => {
           const tools = toolsMap[server.id] ?? [];
+          const source = server.source ?? "db";
+          const isMcpJson = source === "mcp_json";
           return (
-            <details key={server.id} className="group/details">
+            <details key={server.id + server.name} className="group/details">
               <summary className="flex cursor-pointer items-center gap-2 rounded-lg px-1.5 py-1 text-xs hover:bg-border/40 [&::-webkit-details-marker]:hidden">
                 {/* Chevron */}
                 <svg
@@ -145,6 +166,19 @@ export function McpServersPanel() {
                   {transportLabel(server.transport_type)}
                 </span>
 
+                {/* Source badge */}
+                <span
+                  className={`inline-flex shrink-0 items-center rounded-full px-1.5 py-px text-[10px] font-medium ${
+                    isMcpJson
+                      ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                      : source === "both"
+                        ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+                        : "bg-slate-100 text-slate-600 dark:bg-slate-800/50 dark:text-slate-400"
+                  }`}
+                >
+                  {isMcpJson ? ".mcp.json" : source === "both" ? "DB + .mcp.json" : "DB"}
+                </span>
+
                 {/* Display name (if different from name) */}
                 {server.display_name && server.display_name !== server.name && (
                   <span className="truncate text-[10px] text-text-muted">— {server.display_name}</span>
@@ -152,12 +186,16 @@ export function McpServersPanel() {
 
                 {/* Tool count */}
                 <span className="ml-auto shrink-0 text-[10px] tabular-nums text-text-muted">
-                  {tools.length > 0 ? `${tools.length} tools` : `${server.tool_count} tools`}
+                  {isMcpJson ? "runtime" : tools.length > 0 ? `${tools.length} tools` : `${server.tool_count} tools`}
                 </span>
               </summary>
 
-              {/* Tool list */}
-              {tools.length > 0 ? (
+              {/* Tool list — .mcp.json 服务器显示提示，DB 服务器展示 tools */}
+              {isMcpJson ? (
+                <p className="ml-4.5 pb-1 text-[10px] text-text-muted">
+                  Tools discoverable at runtime by Claude Code (not registered in system catalog)
+                </p>
+              ) : tools.length > 0 ? (
                 <div className="ml-4.5 mt-1 flex flex-wrap gap-1.5 pb-1">
                   {tools.map((tool) => {
                     const label = tool.display_name || tool.title || tool.name;

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -122,6 +122,7 @@ export function RoutineRunView({
         routineId={routine.id}
         iteration={auditIteration}
         liveActions={auditId ? liveActionsByIteration?.[auditId] : undefined}
+        projectPath={routine.cwd}
       />
     </div>
   );

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -515,7 +515,7 @@ class RoutineOrchestrator:
                 if not needs_approval:
                     config = await self._build_config(routine)
                     # 快照系统中所有已启用的 MCP server/tool 元数据到 iteration.metrics（历史可追溯）
-                    mcp_meta = await self._resolve_mcp_meta(db)
+                    mcp_meta = await self._resolve_mcp_meta(db, cwd=routine.cwd)
                     if mcp_meta:
                         iteration.metrics = {**(iteration.metrics or {}), "mcp_servers": mcp_meta}
                     launch_specs.append((iteration.id, routine.id, prompt, config))
@@ -570,7 +570,7 @@ class RoutineOrchestrator:
                     continue
                 config = await self._build_config(routine)
                 # 快照系统中所有已启用的 MCP server/tool 元数据到 iteration.metrics（历史可追溯）
-                mcp_meta = await self._resolve_mcp_meta(db)
+                mcp_meta = await self._resolve_mcp_meta(db, cwd=routine.cwd)
                 if mcp_meta:
                     it.metrics = {**(it.metrics or {}), "mcp_servers": mcp_meta}
                 # 记忆注入：待审批迭代在 approve 时重建 prompt（含最新记忆上下文）。
@@ -1021,13 +1021,16 @@ class RoutineOrchestrator:
         return config
 
     @staticmethod
-    async def _resolve_mcp_meta(db: AsyncSession) -> list[dict]:
+    async def _resolve_mcp_meta(db: AsyncSession, cwd: str | None = None) -> list[dict]:
         """快照系统中所有已启用的 MCP server 及其 tool 元数据。
 
         直接查询 ``mcp_servers`` / ``mcp_tools`` 目录表，不依赖 Claude Code 传入的
         ``mcp_config``——因为 MCP Server 可通过多种途径配置（Claude Code 用户级配置、
         项目级 .mcp.json、Negentropy 系统 MCP 目录等），仅从 ``mcp_config`` 无法
         覆盖全部来源。目录表是系统已知的 Server 全集。
+
+        当 *cwd* 非空时，额外读取项目 ``.mcp.json`` 中的 MCP 配置并合并（按 name
+        去重），确保快照覆盖 Claude Code 原生发现的所有 MCP。
 
         注意：仅保存公开元数据，不含 transport config 中的 env / headers 等敏感字段。
         """
@@ -1037,11 +1040,10 @@ class RoutineOrchestrator:
             .all()
         )
 
-        if not servers:
-            return []
-
         result: list[dict] = []
+        db_names: set[str] = set()
         for server in servers:
+            db_names.add(server.name)
             tools = (
                 await db.execute(
                     select(
@@ -1072,6 +1074,24 @@ class RoutineOrchestrator:
                     ],
                 }
             )
+
+        # 合并 .mcp.json 中独有的服务器（DB 中不存在的）
+        if cwd:
+            from negentropy.interface.mcp_config_resolver import derive_transport_type, read_mcp_json
+
+            mcp_json_servers = read_mcp_json(cwd)
+            for name, config in mcp_json_servers.items():
+                if name not in db_names:
+                    result.append(
+                        {
+                            "name": name,
+                            "display_name": None,
+                            "description": "Auto-discovered from .mcp.json",
+                            "transport_type": derive_transport_type(config),
+                            "tools": [],
+                            "source": "mcp_json",
+                        }
+                    )
 
         return result
 

--- a/apps/negentropy/src/negentropy/interface/api.py
+++ b/apps/negentropy/src/negentropy/interface/api.py
@@ -268,6 +268,8 @@ class McpServerResponse(BaseModel):
     resource_template_count: int = 0
     # 「系统内置」统一对外字段，前端据此渲染 Built-In 徽标 + 隐藏 Edit/Delete。
     is_builtin: bool = False
+    # MCP 配置来源：db（系统 MCP 目录）、mcp_json（项目 .mcp.json 原生配置）、both（两者均有）。
+    source: str = "db"
 
     class Config:
         from_attributes = True
@@ -727,42 +729,65 @@ async def _mcp_load_throttle_or_snapshot(db, server_id: UUID) -> LoadToolsRespon
 
 
 @router.get("/mcp/servers", response_model=list[McpServerResponse])
-async def list_mcp_servers(user: AuthUser = Depends(get_current_user)) -> list[McpServerResponse]:
-    """列出用户可见的 MCP 服务器"""
+async def list_mcp_servers(
+    user: AuthUser = Depends(get_current_user),
+    project_path: str | None = Query(None, alias="projectPath"),
+) -> list[McpServerResponse]:
+    """列出用户可见的 MCP 服务器，可选合并项目 ``.mcp.json`` 中定义的服务器。"""
+    # ---- 1. DB 注册服务器 ----
+    db_servers: list[McpServerResponse] = []
+    db_names: set[str] = set()
+
     async with AsyncSessionLocal() as db:
         visible_ids = await get_visible_plugin_ids(db, "mcp_server", user)
-        if not visible_ids:
-            return []
+        if visible_ids:
+            # tool_count 与 resource_template_count 分两段查询：避免单条 SQL 的
+            # JOIN 笛卡尔积导致两类计数互相膨胀。
+            tool_count_stmt = (
+                select(McpTool.server_id, func.count(McpTool.id))
+                .where(McpTool.server_id.in_(visible_ids))
+                .group_by(McpTool.server_id)
+            )
+            tool_count_rows = (await db.execute(tool_count_stmt)).all()
+            tool_count_map: dict[UUID, int] = {row[0]: row[1] for row in tool_count_rows}
 
-        # tool_count 与 resource_template_count 分两段查询：避免单条 SQL 的
-        # JOIN 笛卡尔积导致两类计数互相膨胀。
-        tool_count_stmt = (
-            select(McpTool.server_id, func.count(McpTool.id))
-            .where(McpTool.server_id.in_(visible_ids))
-            .group_by(McpTool.server_id)
-        )
-        tool_count_rows = (await db.execute(tool_count_stmt)).all()
-        tool_count_map: dict[UUID, int] = {row[0]: row[1] for row in tool_count_rows}
+            template_count_stmt = (
+                select(McpResourceTemplate.server_id, func.count(McpResourceTemplate.id))
+                .where(McpResourceTemplate.server_id.in_(visible_ids))
+                .group_by(McpResourceTemplate.server_id)
+            )
+            template_count_rows = (await db.execute(template_count_stmt)).all()
+            template_count_map: dict[UUID, int] = {row[0]: row[1] for row in template_count_rows}
 
-        template_count_stmt = (
-            select(McpResourceTemplate.server_id, func.count(McpResourceTemplate.id))
-            .where(McpResourceTemplate.server_id.in_(visible_ids))
-            .group_by(McpResourceTemplate.server_id)
-        )
-        template_count_rows = (await db.execute(template_count_stmt)).all()
-        template_count_map: dict[UUID, int] = {row[0]: row[1] for row in template_count_rows}
+            servers_stmt = select(McpServer).where(McpServer.id.in_(visible_ids)).order_by(McpServer.created_at.desc())
+            servers = (await db.execute(servers_stmt)).scalars().all()
 
-        servers_stmt = select(McpServer).where(McpServer.id.in_(visible_ids)).order_by(McpServer.created_at.desc())
-        servers = (await db.execute(servers_stmt)).scalars().all()
+            db_servers = [
+                _mcp_server_to_response(
+                    s,
+                    tool_count_map.get(s.id, 0),
+                    template_count_map.get(s.id, 0),
+                )
+                for s in servers
+            ]
+            db_names = {s.name for s in servers}
 
-    return [
-        _mcp_server_to_response(
-            server,
-            tool_count_map.get(server.id, 0),
-            template_count_map.get(server.id, 0),
-        )
-        for server in servers
+    # ---- 2. .mcp.json 原生配置（可选） ----
+    from negentropy.interface.mcp_config_resolver import read_mcp_json
+
+    mcp_json_servers = read_mcp_json(project_path)
+
+    # 标记 DB 服务器中同时存在于 .mcp.json 的为 "both"
+    for srv in db_servers:
+        if srv.name in mcp_json_servers:
+            srv.source = "both"
+
+    # 合并 .mcp.json 独有的服务器（DB 中不存在）
+    mcp_json_only = [
+        _mcp_json_server_to_response(name, config) for name, config in mcp_json_servers.items() if name not in db_names
     ]
+
+    return db_servers + mcp_json_only
 
 
 @router.post("/mcp/servers", response_model=McpServerResponse, status_code=status.HTTP_201_CREATED)
@@ -906,6 +931,36 @@ def _mcp_server_to_response(
         resource_template_count=resource_template_count or 0,
         # 显式列优先；旧库未迁移到 0033 时回退 owner_id 前缀，与 permissions 模块保持一致。
         is_builtin=bool(getattr(server, "is_system", False)) or (server.owner_id or "").startswith("system"),
+    )
+
+
+def _mcp_json_server_to_response(name: str, config: dict[str, Any]) -> McpServerResponse:
+    """将 ``.mcp.json`` 中的单条服务器配置转换为 ``McpServerResponse``。
+
+    使用 ``UUID(int=0)`` 哨兵值标记「无 DB 记录」，前端据此跳过 tools 获取。
+    """
+    from negentropy.interface.mcp_config_resolver import derive_transport_type
+
+    return McpServerResponse(
+        id=UUID(int=0),
+        owner_id="",
+        visibility="private",
+        name=name,
+        display_name=None,
+        description="Auto-discovered from .mcp.json",
+        transport_type=derive_transport_type(config),
+        command=config.get("command"),
+        args=config.get("args", []),
+        env={},
+        url=config.get("url"),
+        headers={},
+        is_enabled=True,
+        auto_start=False,
+        config={},
+        tool_count=0,
+        resource_template_count=0,
+        is_builtin=False,
+        source="mcp_json",
     )
 
 

--- a/apps/negentropy/src/negentropy/interface/mcp_config_resolver.py
+++ b/apps/negentropy/src/negentropy/interface/mcp_config_resolver.py
@@ -1,0 +1,62 @@
+"""Resolve MCP server configs from project-level ``.mcp.json`` files.
+
+Claude Code natively discovers MCP servers from ``.mcp.json`` in the working
+directory and ``~/.claude/``.  The Negentropy system API only knows about
+DB-registered servers (``mcp_servers`` table).  This module bridges the gap
+by parsing ``.mcp.json`` and producing lightweight dicts that can be merged
+into the API response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def read_mcp_json(project_path: str | None) -> dict[str, dict[str, Any]]:
+    """Read ``.mcp.json`` from *project_path* and return ``{name: config}``.
+
+    Returns an empty dict when:
+    - *project_path* is ``None`` or empty
+    - ``.mcp.json`` does not exist
+    - the file is malformed JSON or missing ``mcpServers``
+    """
+    if not project_path:
+        return {}
+
+    mcp_json_path = Path(project_path) / ".mcp.json"
+    if not mcp_json_path.is_file():
+        return {}
+
+    try:
+        data = json.loads(mcp_json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("mcp_json_read_failed", path=str(mcp_json_path), error=str(exc))
+        return {}
+
+    servers: dict[str, dict[str, Any]] = data.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        return {}
+
+    return servers
+
+
+def derive_transport_type(config: dict[str, Any]) -> str:
+    """Derive MCP transport type from a ``.mcp.json`` server config entry.
+
+    Priority:
+    1. Explicit ``"type"`` field (``http`` / ``sse`` / ``stdio``)
+    2. Presence of ``"url"`` → ``http`` (or ``sse`` if URL path ends with ``/sse``)
+    3. Fallback → ``stdio``
+    """
+    explicit = config.get("type")
+    if explicit in ("http", "sse", "stdio"):
+        return explicit
+    if config.get("url"):
+        url: str = config.get("url", "")
+        return "sse" if "/sse" in url else "http"
+    return "stdio"


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 详情页的 MCP Servers 面板仅显示 DB 注册的 MCP 服务器（2 个），而用户通过项目 `.mcp.json` 配置的 MCP 服务器（如 zai-mcp-server、web-search-prime、web-reader、zread）对 Routine 的 Claude Code 执行实际可用，但面板无法展示。PR #872 将 McpServersPanel 从后端快照改为实时 API 后，此缺口暴露。
- 关联上下文/Issue/文档：#872 follow-up

# 核心变更

### 根因分析
系统存在两个独立的 MCP 服务器来源：
1. **Negentropy Plugin System**（`mcp_servers` DB 表）—— API 可查询，面板可展示
2. **Claude Code 原生配置**（项目级 `.mcp.json`）—— Routine 的 Claude Code 子进程通过原生机制自动发现并使用，但对 Negentropy 后端和 API 不可见

### 变更清单

| 文件 | 变更说明 |
|------|---------|
| `mcp_config_resolver.py` (新建) | `.mcp.json` 解析工具：`read_mcp_json()` 读取项目配置、`derive_transport_type()` 推断传输类型，容错设计（文件不存在/格式错误返回空 dict） |
| `api.py` | `list_mcp_servers` API 新增可选 `projectPath` 查询参数，读取该路径下的 `.mcp.json` 并与 DB 服务器按 `name` 去重合并；`McpServerResponse` 新增 `source` 字段（`db` / `mcp_json` / `both`）；新增 `_mcp_json_server_to_response()` 辅助函数（使用 `UUID(int=0)` 哨兵值标记无 DB 记录的服务器） |
| `McpServersPanel.tsx` | 接受 `projectPath` prop 并拼接到 API 请求；`.mcp.json` 独有服务器跳过 tools 获取；渲染来源徽章（DB / .mcp.json / DB + .mcp.json）；工具区域显示"运行时由 Claude Code 自动发现"提示 |
| `IterationAuditDrawer.tsx` | 新增 `projectPath` prop 并透传给 `McpServersPanel` |
| `RoutineRunView.tsx` | 从 `routine.cwd`（项目根路径）派生 `projectPath` 并传递给 `IterationAuditDrawer` |
| `orchestrator.py` | `_resolve_mcp_meta()` 新增 `cwd` 参数，合并 `.mcp.json` 服务器到迭代快照元数据，确保历史迭代审计完整性 |

# 风险与回滚
- 主要风险：`.mcp.json` 可能含敏感信息（API keys），但 `mcp_config_resolver` 仅提取 `name`/`type`/`url`/`command`/`args` 等公开元数据，**不返回 `env`/`headers`**；`.mcp.json` 服务器使用 `UUID(int=0)` 哨兵值，tools API 自然 404 无副作用
- 回滚方式：`git revert` 即可，无数据库迁移、无破坏性变更

# 验证证据
- 单元测试：`mcp_config_resolver` 模块逻辑验证通过（6 个服务器正确发现，transport type 推断正确，边界情况全部通过）
- 集成测试：N/A
- E2E/Workflow：浏览器实机验证 — 打开 Routine 详情页 Iteration #30 的 MCP Servers 面板，确认从 **2 servers → 6 servers · 8 Tools**：
  - `negentropy-perceives` 和 `time` 正确标记为 **DB + .mcp.json**（去重成功）
  - `zai-mcp-server`、`web-search-prime`、`web-reader`、`zread` 正确标记为 **.mcp.json** 来源
  - DB 服务器的 tools 列表正常展示（time: 2 tools, negentropy-perceives: 6 tools）
- 覆盖率/关键截图：已通过浏览器实机验证

# 影响范围
- 前端：`McpServersPanel.tsx`、`IterationAuditDrawer.tsx`、`RoutineRunView.tsx`（+72 行）
- 后端：`api.py`、`mcp_config_resolver.py`（新增）、`orchestrator.py`（+157 行）
- GitHub Actions / 文档：无影响

# Next Best Action
- 可考虑为 `.mcp.json` 服务器的 tools 列表增加运行时发现能力（连接 MCP 服务器动态获取 tools），进一步提升面板信息的完整性

🤖 Generated with [Claude Code](https://claude.com/claude-code)