### PR TITLE
fix(Routine): Evaluate 后台化解除心跳阻塞 + 会话续接死亡螺旋自愈

### DIFF
--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -57,6 +57,24 @@ class RoutineSettings(BaseSettings):
     eval_failure_patience: int = Field(
         default=3, ge=1, description="评估器连续失败容忍次数，超过则终止 routine 为 unrecoverable_error"
     )
+    evaluate_judge_timeout_seconds: int = Field(
+        default=60,
+        ge=10,
+        le=600,
+        description="LLM-as-Judge 单次调用显式超时（秒）。缺失时 litellm 默认无超时，慢/挂起的推理模型"
+        "调用会无界阻塞，曾是「卡在 Evaluate」的根因之一。",
+    )
+    evaluate_max_concurrent: int = Field(
+        default=4,
+        ge=1,
+        le=32,
+        description="后台评估并发上限（进程内信号量）。Evaluate 已从心跳剥离为后台任务，受此限流。",
+    )
+    evaluate_lease_slack_seconds: int = Field(
+        default=60,
+        ge=10,
+        description="后台评估迭代的 lease 宽裕量：lease = gate 超时 + judge 超时 + 此值，用于崩溃恢复 reaper 判定。",
+    )
     context_reset_max: int = Field(
         default=10,
         ge=0,

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -33,6 +33,15 @@ _SUMMARY_MAX_LEN = 2000
 # 单一事实源：runner / decision 经此常量与 metrics 键比对，避免魔法字符串散落。
 ERROR_KIND_CONTEXT_EXHAUSTED = "context_exhausted"
 
+# 可恢复错误：``--resume <id>`` 指向的会话已不存在（CLI 以 rc=1 立即退出，
+# stderr: "No conversation found with session ID: <id>"）。根因：routine 跨迭代续接的
+# claude_session_id 在 worktree 重建 / 进程重启 / CC 会话存储清理后失效。若不自愈，
+# 每轮迭代立即失败（0 turns / $0）并连续累计为 unrecoverable —— 即「会话续接死亡螺旋」。
+# 处置（策略层 Runner）：清空 routine.claude_session_id 冷启动，并在迭代内以新会话重试。
+ERROR_KIND_SESSION_NOT_FOUND = "session_not_found"
+# 会话失效的 stderr 文本信号（大小写无关）；CC 各版本措辞稳定为此句式。
+_SESSION_NOT_FOUND_RE = re.compile(r"No conversation found with session ID", re.IGNORECASE)
+
 # 上下文耗尽的「文本信号」（主据）：大小写无关匹配 result 事件正文。实测 CLI 形态为
 # {is_error:true, subtype:"success", result:"API Error: The model has reached its
 # context window limit."}（subtype 误导，故不能依赖 subtype，须以 is_error + 文本为准）。
@@ -46,15 +55,29 @@ _CONTEXT_EXHAUSTION_RE = re.compile(
 _CONTEXT_SUBTYPES = frozenset({"error_max_context", "error_context_length", "error_context_window"})
 
 
-def _classify_result_error(result_event: dict[str, Any] | None, returncode: int | None) -> str | None:
-    """据 CLI 的 result 事件 + 退出码识别「可恢复错误类型」（纯函数，无 IO）。
+def _classify_result_error(
+    result_event: dict[str, Any] | None,
+    returncode: int | None,
+    *,
+    stderr_text: str | None = None,
+) -> str | None:
+    """据 CLI 的 result 事件 / stderr / 退出码识别「可恢复错误类型」（纯函数，无 IO）。
 
-    仅在 ``returncode != 0`` 时考察；双信号 OR：
-    - 文本信号：result 正文命中 ``_CONTEXT_EXHAUSTION_RE``（主据，实测 subtype 不可靠）；
-    - 结构信号：``is_error is True`` 且 subtype ∈ ``_CONTEXT_SUBTYPES``（前瞻冗余）。
-    命中任一 → ``ERROR_KIND_CONTEXT_EXHAUSTED``；否则 ``None``（含成功路径、result 事件缺席）。
+    仅在 ``returncode != 0`` 时考察，按优先级：
+    1. 会话失效（stderr 信号）：``stderr`` 命中 ``_SESSION_NOT_FOUND_RE`` → ``ERROR_KIND_SESSION_NOT_FOUND``。
+       须先于 result 事件判定——会话失效时 CLI 在产出任何 result 事件前即退出，``result_event`` 缺席。
+    2. 上下文耗尽（result 事件双信号 OR）：
+       - 文本信号：result 正文命中 ``_CONTEXT_EXHAUSTION_RE``（主据，实测 subtype 不可靠）；
+       - 结构信号：``is_error is True`` 且 subtype ∈ ``_CONTEXT_SUBTYPES``（前瞻冗余）。
+       命中任一 → ``ERROR_KIND_CONTEXT_EXHAUSTED``。
+    否则 ``None``（含成功路径、result 事件缺席且无 stderr 信号）。
     """
-    if returncode == 0 or not result_event:
+    if returncode == 0:
+        return None
+    # 1) 会话失效：stderr 文本信号优先（result 事件此时通常缺席）
+    if stderr_text and _SESSION_NOT_FOUND_RE.search(stderr_text):
+        return ERROR_KIND_SESSION_NOT_FOUND
+    if not result_event:
         return None
     is_err = result_event.get("is_error") is True
     subtype = result_event.get("subtype")
@@ -820,7 +843,7 @@ class ClaudeCodeService:
             error_msg = "; ".join(parts)
 
         # 错误分类（机制层）：识别"会话上下文耗尽"等可恢复错误，供策略层（Runner）据此自愈。
-        error_kind = _classify_result_error(last_result_event, proc.returncode)
+        error_kind = _classify_result_error(last_result_event, proc.returncode, stderr_text=stderr_text)
 
         return ClaudeCodeResult(
             status=status,
@@ -1478,7 +1501,7 @@ class ClaudeCodeService:
             error_msg = "; ".join(parts)
 
         # 错误分类（机制层）：与非交互路径共用同一纯函数，杜绝两路径逻辑漂移。
-        error_kind = _classify_result_error(last_result_event, proc.returncode)
+        error_kind = _classify_result_error(last_result_event, proc.returncode, stderr_text=stderr_text)
 
         return ClaudeCodeResult(
             status=status,

--- a/apps/negentropy/src/negentropy/engine/routine/decision.py
+++ b/apps/negentropy/src/negentropy/engine/routine/decision.py
@@ -157,7 +157,12 @@ def _consecutive_exec_failures(history: list[_IterationLike], *, max_context_res
     count = 0
     for it in reversed(history):
         if it.exec_status in ("error", "timeout"):
-            if max_context_resets > 0 and (getattr(it, "metrics", None) or {}).get("context_exhausted"):
+            metrics = getattr(it, "metrics", None) or {}
+            # 会话失效（session_not_found）：Runner 已无条件清空续接会话冷启动自愈——下轮必不再 resume，
+            # 故此类失败透明跳过（无 context_reset 上限语义，runaway 由 no_progress/max_iterations 兜底）。
+            if metrics.get("session_reset"):
+                continue
+            if max_context_resets > 0 and metrics.get("context_exhausted"):
                 continue  # 可自愈失败：透明跳过，不计数也不 break
             count += 1
         else:

--- a/apps/negentropy/src/negentropy/engine/routine/evaluator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/evaluator.py
@@ -103,11 +103,15 @@ class RoutineEvaluator:
         temperature: float = 0.0,
         max_retries: int = 3,
         gate_timeout_seconds: int = 120,
+        judge_timeout_seconds: int = 60,
     ) -> None:
         self._explicit_model = explicit_model
         self._temperature = temperature
         self._max_retries = max_retries
         self._gate_timeout_seconds = gate_timeout_seconds
+        # LLM Judge 单次调用显式超时（与 PlanReviewer 对齐）。缺失时 litellm 默认无超时，
+        # 慢/挂起的推理模型调用会无界阻塞——历史上这是「卡在 Evaluate」的根因之一。
+        self._judge_timeout_seconds = judge_timeout_seconds
 
     async def evaluate(self, routine: _RoutineLike, iteration: _IterationLike) -> EvaluationResult:
         """评估一次迭代产出，返回 score / verdict / reflection / gate_exit_code。
@@ -240,6 +244,7 @@ class RoutineEvaluator:
                     messages=[{"role": "user", "content": prompt}],
                     temperature=self._temperature,
                     response_format={"type": "json_object"},
+                    timeout=self._judge_timeout_seconds,
                     **safe_kwargs,
                 )
                 content = response.choices[0].message.content

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -40,7 +40,7 @@ from . import decision as decision_mod
 from . import phase as phase_mod
 from . import workspace
 from .bus import get_bus
-from .evaluator import RoutineEvaluator
+from .evaluator import EvaluationResult, RoutineEvaluator
 from .memory_extractor import IterationMemoryExtractor, MemoryExtractionResult, compute_decay_override
 from .prompt_builder import append_reflection, build_prompt
 from .runner import get_runner
@@ -62,8 +62,9 @@ _ROUTINE_DEFAULT_TOOLS = [
     "WebSearch",
 ]
 
-# 非终态迭代状态（一个 routine 同时至多存在一个）
-_NON_TERMINAL_ITER = ("pending_approval", "dispatched", "in_flight", "executed")
+# 非终态迭代状态（一个 routine 同时至多存在一个）。
+# 'evaluating' = 已执行完毕、后台评估在途；纳入「单在途」判定，避免评估期间误派发新迭代。
+_NON_TERMINAL_ITER = ("pending_approval", "dispatched", "in_flight", "executed", "evaluating")
 # 每 tick 评估/派发的 routine 批量上限，避免单 tick 过载
 _BATCH_LIMIT = 10
 # 「全过程」审计事件单字段截断上限（与 claude_code.service 一致），防 DB 膨胀。
@@ -140,10 +141,15 @@ class RoutineOrchestrator:
         self._evaluator = RoutineEvaluator(
             explicit_model=settings.routine.evaluator_model,
             gate_timeout_seconds=settings.routine.gate_timeout_seconds,
+            judge_timeout_seconds=settings.routine.evaluate_judge_timeout_seconds,
         )
         self._memory_extractor: IterationMemoryExtractor | None = None
         # 强引用集合：防止 fire-and-forget 的 extraction task 被 GC 回收。
         self._bg_extraction_tasks: set[asyncio.Task] = set()
+        # 后台评估任务注册表（每 routine 至多一个在途评估）：心跳只认领+触发，重活由后台任务承担，
+        # 使心跳 handler 恒轻量、彻底解耦其 60s 超时（与 Runner 执行下沉同构）。键为 routine_id。
+        self._eval_tasks: dict[UUID, asyncio.Task] = {}
+        self._eval_semaphore: asyncio.Semaphore | None = None
 
     async def _ensure_memory_extractor(self) -> IterationMemoryExtractor | None:
         """懒初始化记忆提取器（受 ``memory_extraction_enabled`` 门控）。"""
@@ -201,6 +207,32 @@ class RoutineOrchestrator:
                 it.lease_expires_at = None
                 it.exec_error = it.exec_error or "reaped: lease expired (process restart or hang)"
                 reaped += 1
+
+            # 评估在途孤儿：lease 过期且本进程评估注册表不再持有 → 回退 executed 供下轮重新认领评估。
+            # 评估幂等可重入，回退优于标记 reaped——避免已完成的有效执行产出被误废。
+            eval_rows = (
+                (
+                    await db.execute(
+                        select(RoutineIteration)
+                        .where(
+                            RoutineIteration.status == "evaluating",
+                            RoutineIteration.lease_expires_at.is_not(None),
+                            RoutineIteration.lease_expires_at < now,
+                        )
+                        .limit(_BATCH_LIMIT)
+                        .with_for_update(skip_locked=True)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for it in eval_rows:
+                if it.routine_id in self._eval_tasks:
+                    it.lease_expires_at = now + self._eval_lease()  # 本进程仍在评估 → 顺延 lease
+                    continue
+                it.status = "executed"
+                it.lease_expires_at = None
+                reaped += 1
             await db.commit()
         if reaped:
             logger.info("routine_reaped_orphans", count=reaped)
@@ -244,18 +276,275 @@ class RoutineOrchestrator:
     # (b) EVALUATE + DECIDE
     # ------------------------------------------------------------------
     async def _evaluate_and_decide(self) -> int:
-        """对最新迭代处于 executed 的 routine 评估 + 决策。"""
+        """认领最新迭代为 executed 的 routine 并触发后台评估（非阻塞）。
+
+        心跳仅做轻量认领（executed→evaluating + lease）+ 触发后台任务，绝不内联 await gate/judge——
+        与 Runner 执行下沉同构，使心跳 handler 恒远低于其 60s 超时。重活（gate 命令 + LLM Judge +
+        决策 + 写回 + 事件 + 记忆提取）由 ``_do_evaluate`` 后台任务承担，受 ``_eval_semaphore`` 限流。
+        返回本 tick 新触发的评估数（供 handler 汇报）。
+        """
         async with db_session.AsyncSessionLocal() as db:
             routine_ids = await self._find_routines_pending_eval(db)
 
-        evaluated = 0
+        launched = 0
         for routine_id in routine_ids[:_BATCH_LIMIT]:
+            if routine_id in self._eval_tasks:
+                continue  # 本进程已在评估该 routine
             try:
-                if await self._evaluate_one(routine_id):
-                    evaluated += 1
-            except Exception as exc:  # 单 routine 失败不阻断整体巡检
-                logger.warning("routine_evaluate_one_failed", routine_id=str(routine_id), error=str(exc))
-        return evaluated
+                iteration_id = await self._claim_for_eval(routine_id)
+            except Exception as exc:  # 单 routine 认领失败不阻断整体巡检
+                logger.warning("routine_eval_claim_failed", routine_id=str(routine_id), error=str(exc))
+                continue
+            if iteration_id is None:
+                continue
+            self._spawn_eval_task(routine_id, iteration_id)
+            launched += 1
+        return launched
+
+    def _get_eval_semaphore(self) -> asyncio.Semaphore:
+        if self._eval_semaphore is None:
+            self._eval_semaphore = asyncio.Semaphore(settings.routine.evaluate_max_concurrent)
+        return self._eval_semaphore
+
+    def _eval_lease(self) -> timedelta:
+        """评估在途迭代的崩溃恢复 lease：gate 超时 + judge 超时(×3 重试) + slack。"""
+        return timedelta(
+            seconds=(
+                settings.routine.gate_timeout_seconds
+                + settings.routine.evaluate_judge_timeout_seconds * 3
+                + settings.routine.evaluate_lease_slack_seconds
+            )
+        )
+
+    def _eval_guard_seconds(self) -> float:
+        """后台评估整体兜底超时（略小于 lease，避免与 reaper 抢占）。"""
+        return float(settings.routine.gate_timeout_seconds + settings.routine.evaluate_judge_timeout_seconds * 3 + 30)
+
+    async def _claim_for_eval(self, routine_id: UUID) -> UUID | None:
+        """认领待评估迭代：锁定事务内把最新 executed 迭代翻转 evaluating + 设 lease。
+
+        返回被认领迭代 id；若 routine 非 running 或最新迭代已非 executed（竞态）则返回 None。
+        """
+        lease = _utcnow() + self._eval_lease()
+        async with db_session.AsyncSessionLocal() as db:
+            routine = await db.get(Routine, routine_id, with_for_update=True)
+            if routine is None or routine.status != "running":
+                return None
+            latest = await self._latest_iteration(db, routine_id)
+            if latest is None or latest.status != "executed":
+                return None
+            latest.status = "evaluating"
+            latest.lease_expires_at = lease
+            iteration_id = latest.id
+            phase = latest.phase
+            await db.commit()
+        # 发布「评估中」状态，前端 Loop 图据此显示 Evaluate 进行中（不再静默卡顿）。
+        await get_bus().publish(
+            {
+                "type": "iteration",
+                "id": str(iteration_id),
+                "routine_id": str(routine_id),
+                "status": "evaluating",
+                "phase": phase,
+            }
+        )
+        return iteration_id
+
+    def _spawn_eval_task(self, routine_id: UUID, iteration_id: UUID) -> None:
+        """启动后台评估任务（强引用入 _eval_tasks 防 GC，完成自动移除）。"""
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(
+            self._evaluate_one_bg(routine_id, iteration_id),
+            name=f"routine-eval-{iteration_id}",
+        )
+        self._eval_tasks[routine_id] = task
+
+        def _cleanup(_t: asyncio.Task, _rid: UUID = routine_id) -> None:
+            self._eval_tasks.pop(_rid, None)
+
+        task.add_done_callback(_cleanup)
+
+    async def _evaluate_one_bg(self, routine_id: UUID, iteration_id: UUID) -> None:
+        """后台评估单元：受信号量限流；异常兜底把 evaluating 迭代回退 executed 供下轮重评。"""
+        async with self._get_eval_semaphore():
+            try:
+                await self._do_evaluate(routine_id, iteration_id)
+            except Exception as exc:
+                logger.warning(
+                    "routine_evaluate_bg_failed",
+                    routine_id=str(routine_id),
+                    iteration_id=str(iteration_id),
+                    error=str(exc),
+                )
+                await self._reset_evaluating_to_executed(routine_id, iteration_id)
+
+    async def _reset_evaluating_to_executed(self, routine_id: UUID, iteration_id: UUID) -> None:
+        """把仍处于 evaluating 的迭代回退为 executed（清 lease），供下一 tick 重新认领评估。"""
+        with suppress(Exception):
+            async with db_session.AsyncSessionLocal() as db:
+                it = await db.get(RoutineIteration, iteration_id)
+                if it is not None and it.status == "evaluating":
+                    it.status = "executed"
+                    it.lease_expires_at = None
+                    await db.commit()
+
+    async def _do_evaluate(self, routine_id: UUID, iteration_id: UUID) -> None:
+        """评估已认领（evaluating）迭代并据决策推进状态机（后台任务，不阻塞心跳）。
+
+        两段式以避免长 LLM 调用期间持锁：① 无锁读取只读快照跑 gate+judge；② 短事务锁定写回，
+        期间重新校验状态（routine 可能被 pause/cancel、迭代可能被 reaper 改写）。
+        """
+        from types import SimpleNamespace
+
+        # ① 读取评估所需只读快照（不持锁，规避 gate+judge 长耗时阻塞 routine 行）
+        async with db_session.AsyncSessionLocal() as db:
+            routine = await db.get(Routine, routine_id)
+            latest = await db.get(RoutineIteration, iteration_id)
+            if routine is None or routine.status != "running" or latest is None or latest.status != "evaluating":
+                await self._reset_evaluating_to_executed(routine_id, iteration_id)
+                return
+            routine_eval_view = SimpleNamespace(
+                goal=routine.goal,
+                acceptance_criteria=routine.acceptance_criteria,
+                cwd=routine.cwd,
+                verification_command=routine.verification_command,
+                worktree_path=routine.worktree_path,
+            )
+            iter_eval_view = SimpleNamespace(
+                exec_status=latest.exec_status,
+                summary=latest.summary,
+                exec_error=latest.exec_error,
+            )
+
+        # ② 跑 gate + LLM Judge（带整体兜底超时；gate/judge 各自亦有独立超时）
+        try:
+            result = await asyncio.wait_for(
+                self._evaluator.evaluate(routine_eval_view, iter_eval_view),
+                timeout=self._eval_guard_seconds(),
+            )
+        except TimeoutError:
+            result = EvaluationResult(ok=False, error=f"evaluation guard timeout ({self._eval_guard_seconds()}s)")
+
+        # ③ 短事务锁定写回（重新校验状态）
+        async with db_session.AsyncSessionLocal() as db:
+            routine = await db.get(Routine, routine_id, with_for_update=True)
+            latest = await db.get(RoutineIteration, iteration_id)
+            if routine is None or routine.status != "running" or latest is None or latest.status != "evaluating":
+                # 评估期间状态被改写（pause/cancel/reaped）→ 丢弃本次结果；仍 evaluating 则回退 executed
+                if latest is not None and latest.status == "evaluating":
+                    latest.status = "executed"
+                    latest.lease_expires_at = None
+                    await db.commit()
+                return
+
+            if not result.ok:
+                # 评估失败：记录 + 计数；超阈值终止，否则回退 executed 供下轮重评（保留 eval_attempts）
+                attempts = int((latest.metrics or {}).get("eval_attempts", 0)) + 1
+                latest.eval_error = result.error
+                latest.metrics = {**(latest.metrics or {}), "eval_attempts": attempts}
+                latest.lease_expires_at = None
+                eval_events: list[dict] = []
+                if attempts >= settings.routine.eval_failure_patience:
+                    self._terminate(routine, decision_mod.REASON_UNRECOVERABLE)
+                    latest.status = "evaluated"
+                    latest.verdict = "unrecoverable"
+                    eval_events = await self._persist_eval_events(db, routine, latest, result)
+                else:
+                    latest.status = "executed"
+                await db.commit()
+                await self._publish_routine(routine)
+                await self._publish_iteration_status(routine_id, latest)
+                await self._publish_action_events(routine_id, latest.id, eval_events)
+                return
+
+            # 写入评估结果
+            latest.score = result.score
+            latest.verdict = result.verdict
+            latest.reflection = result.reflection
+            latest.gate_exit_code = result.gate_exit_code
+            latest.status = "evaluated"
+            latest.lease_expires_at = None
+
+            # 更新 routine 反规范化评分 + 追加反思
+            routine.last_score = result.score
+            if result.score is not None:
+                routine.best_score = (
+                    result.score if routine.best_score is None else max(routine.best_score, result.score)
+                )
+            if result.reflection:
+                routine.reflections = append_reflection(routine.reflections, result.reflection)
+
+            # FINALIZE 相位：从本轮 summary 捕获 PR 链接（一次性，幂等）。
+            phased_flow = phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config)
+            if phased_flow and routine.current_phase == phase_mod.PHASE_FINALIZE and not routine.pr_url:
+                routine.pr_url = phase_mod.extract_pr_url(latest.summary)
+
+            # 决策（仅取「本次尝试」窗口 seq > eval_floor_seq，重启后旧迭代不污染停滞/振荡判定）。
+            history = await self._evaluated_history(db, routine_id, floor=routine.eval_floor_seq)
+            verdict = decision_mod.decide(
+                routine, latest, history, max_context_resets=settings.routine.context_reset_max
+            )
+            if phased_flow:
+                self._advance_phase_or_terminate(routine, verdict)
+            elif verdict.is_terminate:
+                self._terminate(routine, verdict.reason or decision_mod.REASON_SUCCESS)
+
+            eval_events = await self._persist_eval_events(db, routine, latest, result)
+
+            # 记忆提取所需参数（commit 后读取 DB 对象会过期，提前提取纯数据）。
+            was_running_before_commit = routine.status == "running"
+            routine_id_str = str(routine_id)
+            routine_key = routine.key
+            owner_id = routine.owner_id
+            routine_goal = routine.goal
+            routine_criteria = routine.acceptance_criteria
+            iteration_snap = {
+                "seq": latest.seq,
+                "score": latest.score,
+                "verdict": latest.verdict,
+                "reflection": latest.reflection,
+                "summary": latest.summary,
+                "gate_exit_code": latest.gate_exit_code,
+                "prompt": latest.prompt,
+            }
+            history_snap = [
+                {
+                    "seq": it.seq,
+                    "score": it.score,
+                    "verdict": it.verdict,
+                    "reflection": it.reflection,
+                    "status": it.status,
+                    "summary": it.summary,
+                }
+                for it in history
+            ]
+
+            await db.commit()
+            await self._publish_routine(routine)
+            await get_bus().publish(
+                {
+                    "type": "iteration",
+                    "id": str(latest.id),
+                    "routine_id": str(routine_id),
+                    "status": "evaluated",
+                    "phase": latest.phase,
+                    "score": result.score,
+                    "verdict": result.verdict,
+                }
+            )
+            await self._publish_action_events(routine_id, latest.id, eval_events)
+
+            # 记忆提取（fire-and-forget，commit 后执行，不阻塞）。
+            self._fire_memory_extraction(
+                routine_id_str,
+                routine_key,
+                owner_id,
+                routine_goal,
+                routine_criteria,
+                iteration_snap,
+                history_snap,
+                was_running_before_commit,
+            )
 
     async def _find_routines_pending_eval(self, db: AsyncSession) -> list[UUID]:
         """找出「最新迭代为 executed」的运行中 routine。"""
@@ -1203,6 +1492,21 @@ class RoutineOrchestrator:
                 "status": iteration.status,
                 "seq": iteration.seq,
                 "phase": iteration.phase,
+            }
+        )
+
+    @staticmethod
+    async def _publish_iteration_status(routine_id: UUID, iteration: RoutineIteration) -> None:
+        """发布迭代当前状态快照（用于评估失败回退 executed / 终止翻转 evaluated 的实时通知）。"""
+        await get_bus().publish(
+            {
+                "type": "iteration",
+                "id": str(iteration.id),
+                "routine_id": str(routine_id),
+                "status": iteration.status,
+                "phase": iteration.phase,
+                "score": iteration.score,
+                "verdict": iteration.verdict,
             }
         )
 

--- a/apps/negentropy/src/negentropy/engine/routine/runner.py
+++ b/apps/negentropy/src/negentropy/engine/routine/runner.py
@@ -32,7 +32,11 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 import negentropy.db.session as db_session
 from negentropy.config import settings
 from negentropy.engine.claude_code.models import ClaudeCodeConfig
-from negentropy.engine.claude_code.service import ERROR_KIND_CONTEXT_EXHAUSTED, ClaudeCodeService
+from negentropy.engine.claude_code.service import (
+    ERROR_KIND_CONTEXT_EXHAUSTED,
+    ERROR_KIND_SESSION_NOT_FOUND,
+    ClaudeCodeService,
+)
 from negentropy.logging import get_logger
 from negentropy.models.routine import Routine, RoutineIteration, RoutineIterationEvent
 
@@ -195,6 +199,10 @@ class RoutineRunner:
                 settings.routine.context_compact_max_retries if settings.routine.context_compact_enabled else 0
             )
             compact_retry_count = 0
+            # 会话失效（session_not_found）迭代内冷启动重试：独立于上下文压缩开关，因为续接会话
+            # 已彻底不存在、再 resume 永不可能成功，必须清空 session 冷启动。预算固定为 2。
+            session_retry_count = 0
+            session_max_retries = 2
             cumulative_cost = 0.0
             cumulative_turns = 0
             overall_deadline = time.monotonic() + config.timeout_seconds
@@ -204,21 +212,38 @@ class RoutineRunner:
                 while True:
                     # 重试时检查剩余时间是否足够（至少 60s，防无意义短命重试）
                     remaining = overall_deadline - time.monotonic()
-                    if remaining < 60 and compact_retry_count > 0:
-                        logger.warning("routine_compact_retry_timeout_exhausted", remaining_s=round(remaining, 1))
+                    retried = compact_retry_count > 0 or session_retry_count > 0
+                    if remaining < 60 and retried:
+                        logger.warning("routine_retry_timeout_exhausted", remaining_s=round(remaining, 1))
                         break
 
-                    invoke_config = config if compact_retry_count == 0 else _with_reduced_timeout(config, remaining)
+                    invoke_config = config if not retried else _with_reduced_timeout(config, remaining)
                     result = await ClaudeCodeService.invoke(prompt, invoke_config, abort_event=abort, on_event=sink)
                     cumulative_cost += result.cost_usd or 0.0
                     cumulative_turns += result.turn_count or 0
 
-                    # 成功或非上下文耗尽错误：直接退出循环
-                    if (
-                        result.status == "success"
-                        or getattr(result, "error_kind", None) != ERROR_KIND_CONTEXT_EXHAUSTED
+                    kind = getattr(result, "error_kind", None)
+                    # 成功或非可恢复错误：直接退出循环
+                    if result.status == "success" or kind not in (
+                        ERROR_KIND_CONTEXT_EXHAUSTED,
+                        ERROR_KIND_SESSION_NOT_FOUND,
                     ):
                         break
+
+                    # 会话失效：清空 session 冷启动重试，沿用原始 prompt（无工作产出，无需续接摘要）。
+                    if kind == ERROR_KIND_SESSION_NOT_FOUND:
+                        if session_retry_count >= session_max_retries:
+                            logger.warning("routine_session_reset_retries_exhausted", retries=session_retry_count)
+                            break
+                        session_retry_count += 1
+                        logger.info(
+                            "routine_session_reset_retry",
+                            iteration_id=str(iteration_id),
+                            retry=session_retry_count,
+                            stale_session=invoke_config.resume_session_id,
+                        )
+                        config = _reset_config_for_retry(config)  # 清空 resume_session_id；prompt 保持原始
+                        continue
 
                     # 上下文耗尽但重试次数已用尽：退出循环（回退到 Layer 3 跨迭代冷启动）
                     if compact_retry_count >= compact_max_retries:
@@ -229,7 +254,7 @@ class RoutineRunner:
                         )
                         break
 
-                    # 迭代内重试：清空 session（强制新会话）+ 构建续接 prompt
+                    # 上下文耗尽迭代内重试：清空 session（强制新会话）+ 构建续接 prompt
                     compact_retry_count += 1
                     logger.info(
                         "routine_compact_retry",
@@ -257,7 +282,13 @@ class RoutineRunner:
                 )
                 return
 
-            await self._write_back(iteration_id, routine_id, result, compact_retry_count=compact_retry_count)
+            await self._write_back(
+                iteration_id,
+                routine_id,
+                result,
+                compact_retry_count=compact_retry_count,
+                session_retry_count=session_retry_count,
+            )
             await get_bus().publish(
                 {
                     "type": "iteration",
@@ -318,14 +349,22 @@ class RoutineRunner:
         result,
         *,
         compact_retry_count: int = 0,
+        session_retry_count: int = 0,
     ) -> None:
         """原子写回执行结果 + 更新父 routine 反规范化累计。
 
         用 ``asyncio.shield`` 包裹，避免关停取消时丢失已完成的 Claude Code 结果。
-        ``compact_retry_count`` 记录迭代内上下文压缩重试次数，写入 iteration metrics。
+        ``compact_retry_count`` 记录迭代内上下文压缩重试次数；``session_retry_count`` 记录会话失效
+        冷启动重试次数；均写入 iteration metrics。
         """
         await asyncio.shield(
-            self._do_write_back(iteration_id, routine_id, result, compact_retry_count=compact_retry_count)
+            self._do_write_back(
+                iteration_id,
+                routine_id,
+                result,
+                compact_retry_count=compact_retry_count,
+                session_retry_count=session_retry_count,
+            )
         )
 
     async def _do_write_back(
@@ -335,6 +374,7 @@ class RoutineRunner:
         result,
         *,
         compact_retry_count: int = 0,
+        session_retry_count: int = 0,
     ) -> None:
         exec_status = "success" if result.status == "success" else result.status  # success|error|timeout
         async with db_session.AsyncSessionLocal() as db:
@@ -359,14 +399,21 @@ class RoutineRunner:
                 # 上下文耗尽判定（根因：原实现无条件回写 session_id，把 routine 永久钉死在已耗尽
                 # 的会话，导致 resume 后每轮立即撞上下文上限的"死亡螺旋"）。提前到 routine 取用之前
                 # 计算，使 routine 缺失时下方 iteration 标记块仍能安全引用。
-                is_ctx = getattr(result, "error_kind", None) == ERROR_KIND_CONTEXT_EXHAUSTED
+                error_kind = getattr(result, "error_kind", None)
+                is_ctx = error_kind == ERROR_KIND_CONTEXT_EXHAUSTED
+                # 会话失效：迭代内冷启动重试发生过（session_retry_count>0），或最终结果仍为会话失效。
+                is_session_gone = error_kind == ERROR_KIND_SESSION_NOT_FOUND or session_retry_count > 0
                 # 父 routine 累计：成本累加、迭代计数 +1、会话续接。
                 routine = await db.get(Routine, routine_id)
                 if routine is not None:
                     routine.total_cost_usd = (routine.total_cost_usd or 0.0) + (result.cost_usd or 0.0)
                     routine.iteration_count = (routine.iteration_count or 0) + 1
-                    # 会话续接的三态决策：
-                    if is_ctx:
+                    # 会话续接决策（优先级：会话失效 > 上下文耗尽 > 正常续接）：
+                    if error_kind == ERROR_KIND_SESSION_NOT_FOUND:
+                        # (0) 续接会话已彻底失效 → 无条件清空冷启动（再 resume 永不可能成功，
+                        # 无 context_reset 上限语义；runaway 由 no_progress/max_iterations 守卫兜底）。
+                        routine.claude_session_id = None
+                    elif is_ctx:
                         resets = int((routine.reflections or {}).get("_context_resets", 0))
                         if resets < settings.routine.context_reset_max:
                             # (a) 上下文耗尽且未达上限 → 清空污染会话，使下轮在同 worktree 冷启动续干
@@ -378,19 +425,23 @@ class RoutineRunner:
                             # (b) 达自动重置上限 → 不再清空，记标记，落回原 unrecoverable 自然路径（防 runaway）。
                             routine.reflections = {**(routine.reflections or {}), "_context_reset_exhausted": True}
                     elif result.session_id:
-                        # (c) 非上下文耗尽（含成功 / 普通 error / timeout）→ 维持原会话续接逻辑。
+                        # (c) 非上述可恢复错误（含成功 / 普通 error / timeout）→ 维持原会话续接逻辑。
+                        # 注：会话失效冷启动重试成功后 result.session_id 为新会话，经此分支正确续接。
                         routine.claude_session_id = result.session_id
-                # 给 iteration 打 context_exhausted 标记：供 decision 将"可自愈失败"从连续失败计数剔除，
-                # 避免被误判为 unrecoverable（runaway 由 routine.reflections._context_resets 上限兜底）。
-                # 同时记录迭代内压缩重试次数（compact_retries > 0 表示迭代内发生了续接）。
-                if is_ctx or compact_retry_count > 0:
+                # 给 iteration 打可自愈标记：供 decision 将"可自愈失败"从连续失败计数剔除，避免被误判为
+                # unrecoverable。同时记录迭代内重试次数（compact_retries / session_resets > 0 表示发生续接/冷启动）。
+                if is_ctx or is_session_gone or compact_retry_count > 0:
                     it = await db.get(RoutineIteration, iteration_id)
                     if it is not None:
                         metrics = {**(it.metrics or {})}
                         if is_ctx:
                             metrics["context_exhausted"] = True
+                        if is_session_gone:
+                            metrics["session_reset"] = True
                         if compact_retry_count > 0:
                             metrics["compact_retries"] = compact_retry_count
+                        if session_retry_count > 0:
+                            metrics["session_retries"] = session_retry_count
                         it.metrics = metrics
             # 「全过程」动作事件持久化（reconciliation backstop）：
             # 不再受 rowcount==1 门控——即使迭代已被 reaper 标记 reaped，仍确保事件落库

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -36,6 +36,20 @@ def _key(prefix: str = "itest_routine") -> str:
     return f"{prefix}_{uuid.uuid4().hex[:8]}"
 
 
+async def _evaluate_and_drain(orch: RoutineOrchestrator) -> int:
+    """触发评估并等待后台评估任务完成（评估已从心跳剥离为后台任务）。
+
+    ``_evaluate_and_decide`` 现仅认领 executed 迭代并 spawn 后台评估任务（非阻塞）。
+    集成测试需等待这些后台任务收尾后再断言终态，故 await ``orch._eval_tasks`` 全部完成。
+    返回本 tick 新触发的评估数（与认领数一致）。
+    """
+    launched = await orch._evaluate_and_decide()  # noqa: SLF001
+    tasks = list(orch._eval_tasks.values())  # noqa: SLF001
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    return launched
+
+
 async def _make_routine(**overrides) -> uuid.UUID:
     defaults = dict(
         key=_key(),
@@ -87,7 +101,7 @@ async def test_evaluate_high_score_terminates_succeeded():
                 return_value=EvaluationResult(ok=True, score=92, verdict="pass", reflection="很好", gate_exit_code=None)
             ),
         ):
-            count = await orch._evaluate_and_decide()
+            count = await _evaluate_and_drain(orch)
         assert count == 1
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
@@ -111,7 +125,7 @@ async def test_evaluate_progressing_continues():
                 return_value=EvaluationResult(ok=True, score=55, verdict="progressing", reflection="继续改进")
             ),
         ):
-            await orch._evaluate_and_decide()
+            await _evaluate_and_drain(orch)
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
             assert r.status == "running"  # 未终止
@@ -121,14 +135,14 @@ async def test_evaluate_progressing_continues():
 
 
 async def _evaluate_phased(rid, *, score, verdict):
-    """辅助：以 mock evaluator 跑一次评估-决策，返回评估计数。"""
+    """辅助：以 mock evaluator 跑一次评估-决策（含后台任务收尾），返回评估计数。"""
     orch = RoutineOrchestrator()
     with patch.object(
         orch._evaluator,
         "evaluate",
         new=AsyncMock(return_value=EvaluationResult(ok=True, score=score, verdict=verdict, reflection="r")),
     ):
-        return await orch._evaluate_and_decide()
+        return await _evaluate_and_drain(orch)
 
 
 async def test_phased_plan_advances_to_implement():
@@ -185,6 +199,121 @@ async def test_phased_finalize_with_pr_succeeds():
             assert r.status == "succeeded"
             assert r.termination_reason == "success"
             assert r.pr_url == "https://github.com/o/r/pull/77"
+    finally:
+        await _cleanup(rid)
+
+
+async def test_evaluate_slow_judge_does_not_block_heartbeat():
+    """根因回归（卡在 Evaluate）：评估已从心跳剥离为后台任务。
+
+    模拟一个耗时远超心跳 60s 超时的 Judge：``_evaluate_and_decide``（心跳认领阶段）必须近乎瞬时返回，
+    迭代被认领为 ``evaluating``；后台任务完成后才翻转 ``evaluated``。证明慢 Judge 不再阻塞心跳。
+    """
+    import time as _time
+
+    rid = await _make_routine(iteration_count=1)
+    iid = await _add_iteration(rid, seq=1)
+    try:
+        orch = RoutineOrchestrator()
+
+        async def _slow_eval(*_a, **_k):
+            await asyncio.sleep(0.4)  # 代表"远超 60s"的慢调用；测试用 0.4s 验证非阻塞语义
+            return EvaluationResult(ok=True, score=92, verdict="pass", reflection="ok")
+
+        with patch.object(orch._evaluator, "evaluate", new=AsyncMock(side_effect=_slow_eval)):
+            t0 = _time.monotonic()
+            launched = await orch._evaluate_and_decide()  # 心跳认领阶段：应近乎瞬时
+            claim_elapsed = _time.monotonic() - t0
+            assert launched == 1
+            assert claim_elapsed < 0.2, f"心跳认领不应阻塞在慢 Judge 上，实测 {claim_elapsed:.2f}s"
+
+            # 认领后迭代应为 evaluating（后台任务尚未完成）
+            async with db_session.AsyncSessionLocal() as db:
+                it = await db.get(RoutineIteration, iid)
+                assert it.status == "evaluating"
+
+            # 等待后台评估任务收尾
+            await asyncio.gather(*orch._eval_tasks.values(), return_exceptions=True)
+
+        async with db_session.AsyncSessionLocal() as db:
+            it = await db.get(RoutineIteration, iid)
+            assert it.status == "evaluated"
+            r = await db.get(Routine, rid)
+            assert r.status == "succeeded"
+            assert r.best_score == 92
+    finally:
+        await _cleanup(rid)
+
+
+async def test_evaluate_failure_below_patience_resets_to_executed():
+    """评估失败且未达容忍阈值 → 迭代回退 executed（清 lease）供下轮重评，eval_attempts 累加。
+
+    后台化前是「留在 executed」；后台化后认领时已置 evaluating，失败路径须显式回退 executed，
+    否则迭代被永久钉死在 evaluating（新版"卡死"风险），故此回归锁。
+    """
+    rid = await _make_routine(iteration_count=1)
+    iid = await _add_iteration(rid, seq=1)
+    try:
+        orch = RoutineOrchestrator()
+        with patch.object(
+            orch._evaluator,
+            "evaluate",
+            new=AsyncMock(return_value=EvaluationResult(ok=False, error="LLM unavailable")),
+        ):
+            await _evaluate_and_drain(orch)
+        async with db_session.AsyncSessionLocal() as db:
+            it = await db.get(RoutineIteration, iid)
+            assert it.status == "executed"  # 回退供重评（非永久 evaluating）
+            assert it.lease_expires_at is None
+            assert int((it.metrics or {}).get("eval_attempts", 0)) == 1
+            assert it.eval_error == "LLM unavailable"
+            r = await db.get(Routine, rid)
+            assert r.status == "running"  # 未终止
+    finally:
+        await _cleanup(rid)
+
+
+async def test_evaluate_failure_at_patience_terminates_unrecoverable():
+    """评估失败累计达 eval_failure_patience → 迭代翻转 evaluated(unrecoverable) 且 routine 终止。"""
+    from negentropy.config import settings
+
+    rid = await _make_routine(iteration_count=1)
+    # 预置 eval_attempts = patience-1，使本轮失败即触达阈值
+    iid = await _add_iteration(rid, seq=1, metrics={"eval_attempts": settings.routine.eval_failure_patience - 1})
+    try:
+        orch = RoutineOrchestrator()
+        with patch.object(
+            orch._evaluator,
+            "evaluate",
+            new=AsyncMock(return_value=EvaluationResult(ok=False, error="LLM down")),
+        ):
+            await _evaluate_and_drain(orch)
+        async with db_session.AsyncSessionLocal() as db:
+            it = await db.get(RoutineIteration, iid)
+            assert it.status == "evaluated"
+            assert it.verdict == "unrecoverable"
+            r = await db.get(Routine, rid)
+            assert r.status == "failed"
+            assert r.termination_reason == decision_mod.REASON_UNRECOVERABLE
+    finally:
+        await _cleanup(rid)
+
+
+async def test_reap_orphan_evaluating_resets_to_executed():
+    """崩溃恢复回归：lease 过期的 evaluating 孤儿迭代（本进程不再持有）→ 回退 executed 供重评。"""
+    from datetime import UTC, datetime, timedelta
+
+    rid = await _make_routine(iteration_count=1)
+    expired = datetime.now(UTC) - timedelta(seconds=10)
+    iid = await _add_iteration(rid, seq=1, status="evaluating", lease_expires_at=expired)
+    try:
+        orch = RoutineOrchestrator()  # _eval_tasks 空 → 不持有该迭代
+        reaped = await orch._reap_orphans()
+        assert reaped >= 1
+        async with db_session.AsyncSessionLocal() as db:
+            it = await db.get(RoutineIteration, iid)
+            assert it.status == "executed"
+            assert it.lease_expires_at is None
     finally:
         await _cleanup(rid)
 
@@ -469,6 +598,41 @@ async def test_write_back_context_exhausted_at_reset_cap_keeps_session_and_marks
                 assert (r.reflections or {}).get("_context_reset_exhausted") is True
         finally:
             await _cleanup(rid)
+
+
+async def test_write_back_session_not_found_clears_session_unconditionally():
+    """根因回归（会话续接死亡螺旋）：``--resume`` 会话失效（session_not_found）→ 无条件清空
+    routine.claude_session_id 冷启动，并给 iteration.metrics 打 session_reset 标记。
+
+    复刻模板 9e90c3c7 seq3-5 现场：陈旧 claude_session_id 使每轮 resume 立即失败
+    （0 turns/$0），原实现不自愈 → 连续 unrecoverable。修复后清空会话使下轮冷启动。"""
+    from negentropy.engine.claude_code.service import ERROR_KIND_SESSION_NOT_FOUND
+    from negentropy.engine.routine.runner import get_runner
+
+    rid = await _make_routine(approval_mode="auto", iteration_count=0, claude_session_id="stale-session")
+    iid = await _add_iteration(rid, seq=1, status="in_flight", exec_status=None, summary=None)
+    try:
+        runner = get_runner()
+        fake = ClaudeCodeResult(
+            status="error",
+            summary="",
+            session_id=None,
+            cost_usd=0.0,
+            turn_count=0,
+            error="CLI exited with code 1; stderr: No conversation found with session ID: stale-session",
+            error_kind=ERROR_KIND_SESSION_NOT_FOUND,
+        )
+        await runner._do_write_back(iid, rid, fake)  # noqa: SLF001
+
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.claude_session_id is None  # 失效会话被清空 → 下轮冷启动
+            assert r.iteration_count == 1
+            it = await db.get(RoutineIteration, iid)
+            assert it.status == "executed"
+            assert (it.metrics or {}).get("session_reset") is True
+    finally:
+        await _cleanup(rid)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -18,6 +18,7 @@ import pytest
 from negentropy.engine.claude_code.models import ClaudeCodeConfig
 from negentropy.engine.claude_code.service import (
     ERROR_KIND_CONTEXT_EXHAUSTED,
+    ERROR_KIND_SESSION_NOT_FOUND,
     ClaudeCodeService,
     _classify_result_error,
 )
@@ -431,6 +432,33 @@ async def test_classify_missing_result_event_is_none():
     assert _classify_result_error(None, 1) is None
 
 
+async def test_classify_session_not_found_from_stderr():
+    """根因回归（会话续接死亡螺旋）：stderr 命中 "No conversation found with session ID"
+    → ERROR_KIND_SESSION_NOT_FOUND。会话失效时 CLI 在产出 result 事件前即退出（event 缺席），
+    故须从 stderr 识别。复刻模板 9e90c3c7 seq3-5 现场。"""
+    stderr = "No conversation found with session ID: e7b7755c-cfae-41bc-9a61-f36aa5c3dcb0"
+    assert _classify_result_error(None, 1, stderr_text=stderr) == ERROR_KIND_SESSION_NOT_FOUND
+
+
+async def test_classify_session_not_found_case_insensitive():
+    """会话失效信号大小写无关匹配。"""
+    stderr = "no CONVERSATION found with SESSION id: abc"
+    assert _classify_result_error(None, 1, stderr_text=stderr) == ERROR_KIND_SESSION_NOT_FOUND
+
+
+async def test_classify_session_not_found_takes_priority_over_context():
+    """会话失效优先于上下文耗尽判定（stderr 信号先于 result 事件考察）。"""
+    evt = {"type": "result", "is_error": True, "result": "reached its context window limit"}
+    stderr = "No conversation found with session ID: x"
+    assert _classify_result_error(evt, 1, stderr_text=stderr) == ERROR_KIND_SESSION_NOT_FOUND
+
+
+async def test_classify_session_not_found_only_when_returncode_nonzero():
+    """退出码 0 时不判会话失效（不误伤成功路径）。"""
+    stderr = "No conversation found with session ID: x"
+    assert _classify_result_error(None, 0, stderr_text=stderr) is None
+
+
 async def test_classify_non_string_result_payload():
     """result 为非字符串（对象）时序列化后匹配，不抛错。"""
     evt = {"type": "result", "is_error": True, "result": {"error": "reached its context window limit"}}
@@ -640,17 +668,32 @@ def test_fallback_answer_is_plain_text():
 async def test_auto_answer_question_returns_plain_text_on_exception(monkeypatch):
     """_auto_answer_question 异常路径 → 返回纯文本 fallback（非 JSON）。"""
 
-    # 让 litellm import 失败 → 走 except 分支
+    # 让 litellm import 失败 → 走 except 分支。
+    # 关键（测试隔离）：被测函数以 `import litellm` 语句导入；一旦 litellm 已在 sys.modules 缓存
+    # （任一先行测试导入过），import 语句直接从缓存绑定、不再触发 __import__，仅 mock importlib
+    # 无法拦截。故先从 sys.modules 逐出 litellm，并同时 mock builtins.__import__，使 import 语句
+    # 真正重走导入解析并被拦截。否则本用例的通过与否取决于测试执行顺序（pre-existing 隔离脆弱性）。
+    import builtins
     import importlib
+    import sys
+
+    monkeypatch.delitem(sys.modules, "litellm", raising=False)
 
     real_import = importlib.import_module
+    real_builtin_import = builtins.__import__
 
     def _block_litellm(name, *args, **kwargs):
         if name == "litellm":
             raise ImportError("mocked")
         return real_import(name, *args, **kwargs)
 
+    def _block_builtin_import(name, *args, **kwargs):
+        if name == "litellm" or name.startswith("litellm."):
+            raise ImportError("mocked")
+        return real_builtin_import(name, *args, **kwargs)
+
     monkeypatch.setattr("importlib.import_module", _block_litellm)
+    monkeypatch.setattr(builtins, "__import__", _block_builtin_import)
 
     answer = await ClaudeCodeService._auto_answer_question(
         [{"question": "What to do?"}],

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
@@ -219,6 +219,23 @@ def test_decide_context_exhausted_does_not_break_count_chain():
     assert res.is_terminate and res.reason == d.REASON_UNRECOVERABLE
 
 
+def _session_reset_fail(seq: int) -> FakeIter:
+    """会话失效自愈迭代：exec error + metrics.session_reset 标记（Runner 已冷启动清空会话）。"""
+    return FakeIter(seq=seq, exec_status="error", score=40, verdict="progressing", metrics={"session_reset": True})
+
+
+def test_decide_session_reset_failures_not_unrecoverable():
+    """根因回归（会话续接死亡螺旋）：连续 session_reset 失败始终豁免连续失败计数（无 reset_max 门控）。
+
+    复刻模板 9e90c3c7 seq3-5：陈旧会话使每轮 resume 立即失败；Runner 已冷启动清空会话，
+    这些"可自愈失败"应透明跳过，不被误判 unrecoverable。与 context_exhausted 不同：会话失效
+    无 reset_max 上限语义（runaway 由 no_progress/max_iterations 兜底），故 reset_max=0 亦豁免。"""
+    r = FakeRoutine(best_score=50, no_progress_patience=10, success_score_threshold=99)
+    hist = [_session_reset_fail(i) for i in range(2, 6)]  # 4 次连续会话失效失败
+    assert d.decide(r, hist[-1], hist, max_context_resets=0).action == "continue"
+    assert d.decide(r, hist[-1], hist, max_context_resets=10).action == "continue"
+
+
 def test_decide_success_tail_resets_failure_count():
     """成功迭代在尾部 → 连续失败计数归零（break），不受自愈逻辑影响。"""
     r = FakeRoutine(best_score=50, no_progress_patience=10, success_score_threshold=99)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine「Dispatch→Execute→Evaluate→Decide」闭环存在两处根因级缺陷，导致任务执行一个 Iteration 后**永久卡在 Evaluate**、且无法持续迭代。
  1. **卡在 Evaluate（架构性）**：`inspect_once()` 在 60s 心跳 handler（`registry.py` `asyncio.timeout(60)`）内**同步内联**执行 Evaluate，而 Evaluate 会跑 gate 命令（≤120s）+ **无显式超时**的 LLM Judge。一旦 gate+judge 超过 60s，整个 tick 被取消 → `db.commit()` 永不执行 → 迭代滞留 `executed` → 下一 tick 重复 → 死锁。Execute 早已下沉为后台 Runner，唯独 Evaluate 没有。
  2. **会话续接死亡螺旋**：陈旧 `claude_session_id` 使 `--resume` 每轮立即失败（`No conversation found with session ID`，0 turns/$0）。原实现仅自愈 `context_exhausted`、不识别会话失效 → 连续 3 次 exec error → `unrecoverable`。实机模板任务 `9e90c3c7`（Maps Go→Python 复刻）seq3–5 即复现此现象。
- 关联上下文：分支 `ThreeFish-AI/routine-evaluate-loop-fix`；实机基线证据取自运行中后端 `/routines/9e90c3c7-...` 的迭代历史。

# 核心变更
- **Evaluate 后台化**（`orchestrator.py`）：心跳仅「认领 `executed`→`evaluating` + 设 lease」并 spawn 后台评估任务（受 `evaluate_max_concurrent` 信号量限流），重活（gate+judge+decide+写回+事件+记忆提取）由 `_do_evaluate` 承担，采用「无锁读快照→跑评估→短事务锁定写回」两段式，彻底解耦 60s 心跳超时，支持多 routine 并发评估。
- **崩溃/失败兜底**：新增 `evaluating` 孤儿 reaper（lease 过期且本进程不持有 → 回退 `executed` 重评）；评估失败未达容忍阈值时显式回退 `executed`，杜绝新版「钉死在 evaluating」。
- **Judge 显式超时**（`evaluator.py` + `config/routine.py`）：`litellm.acompletion` 补 `timeout`（与 `PlanReviewer` 对齐），后台任务再加 `asyncio.wait_for` 兜底；新增 `evaluate_judge_timeout_seconds` / `evaluate_max_concurrent` / `evaluate_lease_slack_seconds` 配置旋钮。
- **会话续接死亡螺旋自愈**（`service.py` + `runner.py` + `decision.py`）：新增 `ERROR_KIND_SESSION_NOT_FOUND`（从 stderr 识别，优先于 result 事件）；Runner 迭代内冷启动重试（清空 `resume_session_id`）+ 写回无条件清空失效会话；decision 将 `session_reset` 失败豁免出连续失败计数。
- **附带修复**测试隔离脆弱性：`test_auto_answer_question_returns_plain_text_on_exception` 在 litellm 已缓存时因 `import` 语句不触发 mock 而随执行顺序偶发失败，改为逐出 `sys.modules` + mock `builtins.__import__`，使其稳定。

# 风险与回滚
- 主要风险：Evaluate 改为异步执行后，单 tick 不再返回评估终态——已通过「认领→后台→reaper 兜底→失败回退」闭环消除滞留风险，并由新回归测试锁定；评估并发上限默认 4，不冲击 Runner 执行并发（默认 2）。
- 回滚方式：本次为纯逻辑变更、无 DB schema 迁移（复用 `lease_expires_at` + 新增 `evaluating` 状态字符串值，列为 `VARCHAR(24)` 无需 DDL），`git revert` 单 commit 即可完全回退。

# 验证证据
- 单元测试：`test_routine_decision.py`（新增 session_reset 豁免）、`test_claude_code_service.py`（新增 4 例 stderr 会话失效分类）全绿；`tests/unit_tests/engine/` 全量 856 passed。
- 集成测试：`test_routine_orchestrator.py` 25→适配后全绿，新增「慢 Judge 不阻塞心跳/评估失败回退/达阈值终止/evaluating 孤儿 reap/会话失效清空」回归用例。
- 关键链路：心跳认领阶段实测 <0.2s（不阻塞在 0.4s 慢 Judge 上）；routine 全量 unit+integration 168 passed。
- 工具链：`ruff check` / `ruff format` 全部通过，pre-commit hooks 全绿。

# 影响范围
- 前端：无（SSE 事件协议保持兼容，新增 `evaluating` 状态为增量）。
- 后端：Routine 编排器/执行器/评估器/决策守卫/CC 服务 + 配置。
- GitHub Actions / 文档：无 CI 配置变更。

# Next Best Action
- 后续 PR 落地 Worktree 物理隔离（CC 原生 `sandbox.enabled` Seatbelt + `permissions.deny` 只读源工程）与目标交互流（Plan→Negentropy Review→…→PR→Merge）端到端打通，并以 Maps Go→Python 复刻任务实机迭代验收至生产级。

🤖 Generated with [Claude Code](https://claude.com/claude-code)