### PR TITLE
fix(Routine): 复刻类长任务全闭环加固——worktree 源码只读物理读授权 + 测试库隔离 + PLAN 相位门控

### DIFF
--- a/apps/negentropy/src/negentropy/engine/claude_code/models.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/models.py
@@ -45,6 +45,15 @@ class ClaudeCodeConfig:
     mcp_config: dict[str, Any] | None = None
     resume_session_id: str | None = None
 
+    # 额外授予的「只读源目录」绝对路径列表。映射 SDK ClaudeAgentOptions.add_dirs 与
+    # CLI 重复 ``--add-dir <path>``（逐目录，非逗号合并）。注意：``--add-dir`` 同时授予
+    # 读+写，只读性由 ``settings`` 的 permissions.deny(Edit(//<dir>/**)) 物理保证
+    # （deny 优先级最高，acceptEdits/bypassPermissions 不可越权）。
+    add_dirs: list[str] | None = None
+    # CC settings.json 内容（JSON 字符串）或文件路径。映射 SDK options.settings /
+    # CLI ``--settings``。本仓库用其注入 permissions.deny 把 add_dirs 锁为只读。
+    settings: str | None = None
+
     # 双向交互模式：启用 stdin PIPE + stream-json 输入，允许 Engine 自动应答
     # Claude Code 的 AskUserQuestion 等交互式工具调用（Routine 执行场景）。
     interactive: bool = False

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -617,6 +617,19 @@ class ClaudeCodeService:
             options.resume = config.resume_session_id
         if config.model:
             options.model = config.model
+        # 额外只读源目录（镜像 CLI --add-dir）。新版 SDK 暴露 ``add_dirs``（list[str | Path]）；
+        # 旧版无该字段时仅告警——CLI 才是当前已装且权威的执行路径。
+        if config.add_dirs:
+            if hasattr(options, "add_dirs"):
+                options.add_dirs = list(config.add_dirs)
+            else:
+                logger.warning(
+                    "claude_code_sdk_add_dirs_unsupported",
+                    reason="ClaudeCodeOptions has no 'add_dirs'; CLI path authoritative",
+                )
+        # settings.json（承载只读 deny 规则）；新版 SDK 暴露 ``settings``。
+        if config.settings and hasattr(options, "settings"):
+            options.settings = config.settings
         # 镜像 CLI 路径：注入真实 Anthropic 凭证。优先经 SDK 的 ``options.env``（避免全局 os.environ
         # 突变带来的并发不安全）；旧版 SDK 无该字段时仅告警——CLI 才是当前已装且权威的执行路径。
         if config.credential:
@@ -744,6 +757,8 @@ class ClaudeCodeService:
             resume_session_id=config.resume_session_id,
             credential=config.credential,  # 必须透传：否则注入凭证在此重建处被静默丢弃 → 退回 401
             compact_threshold_pct=config.compact_threshold_pct,
+            add_dirs=config.add_dirs,  # 必须透传：否则 --add-dir 在此重建处被静默丢弃 → CC 读不到源码
+            settings=config.settings,  # 必须透传：否则只读 deny 规则被静默丢弃 → 源码可写
         )
 
         args = ClaudeCodeService._build_cli_args(prompt, config)
@@ -922,6 +937,14 @@ class ClaudeCodeService:
         # 明确禁止的工具列表。
         if config.disallowed_tools:
             args += ["--disallowed-tools", ",".join(config.disallowed_tools)]
+        # 额外只读源目录：CLI 接受重复 ``--add-dir <path>``（逐目录，不接受逗号合并形式）。
+        # 授予 CC 读取 worktree 之外的源项目（如待复刻的 Go 源码）；只读性由下方 --settings 锁定。
+        if config.add_dirs:
+            for d in config.add_dirs:
+                args += ["--add-dir", d]
+        # settings.json（JSON 字符串）：承载 permissions.deny，把 add_dirs 物理锁为只读。
+        if config.settings:
+            args += ["--settings", config.settings]
         # MCP 服务器配置：CLI --mcp-config 接受 JSON string 或文件路径。
         # 使用 {"mcpServers": {...}} 封装格式（与 .mcp.json 文件格式一致）。
         if config.mcp_config:
@@ -1229,6 +1252,8 @@ class ClaudeCodeService:
             interactive=config.interactive,
             auto_answer_context=config.auto_answer_context,
             compact_threshold_pct=config.compact_threshold_pct,
+            add_dirs=config.add_dirs,  # 必须透传：否则 --add-dir 在交互式重建处被静默丢弃
+            settings=config.settings,  # 必须透传：否则只读 deny 规则被静默丢弃
         )
 
         args = ClaudeCodeService._build_cli_args(prompt, config)

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -22,6 +22,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
@@ -87,6 +89,45 @@ def _cap(value: str | None, limit: int = _EVENT_FIELD_CAP) -> str | None:
     return value
 
 
+def _normalize_read_dirs(raw: object) -> list[str]:
+    """规整 ``config.read_dirs`` → 去重的绝对路径 ``list[str]``（容忍 str/list/杂质）。
+
+    这些是「额外授予 CC 读取的源目录」（如待复刻的 Go 源项目）；落地为 CLI ``--add-dir``
+    与 system prompt 的显式 READ 授权，并由 :func:`_build_readonly_settings` 锁为只读。
+    """
+    if not raw:
+        return []
+    items: list[object]
+    if isinstance(raw, str):
+        items = [raw]
+    elif isinstance(raw, (list, tuple)):
+        items = list(raw)
+    else:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for it in items:
+        if not isinstance(it, str) or not it.strip():
+            continue
+        p = os.path.abspath(os.path.expanduser(it.strip()))
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def _build_readonly_settings(read_dirs: list[str]) -> str:
+    """生成 CC ``settings.json``（JSON 字符串）：对每个 add_dir 注入 ``Edit`` deny 锁为只读。
+
+    ``Edit`` deny 覆盖 CC 所有内建写工具（Edit/Write/MultiEdit/NotebookEdit）及其识别的
+    Bash 写命令；deny 优先于 allow，且不可被任何层（含 ``permission_mode``/``--add-dir``）放行。
+    ``//`` 前缀 = 文件系统绝对路径锚点（gitignore 语义）。CC 仍可 **读取** 这些源目录
+    （Read 无 deny），但不能改写——worktree（cwd）无 deny，写入正常。
+    """
+    deny = [f"Edit(//{d.lstrip('/')}/**)" for d in read_dirs]
+    return json.dumps({"permissions": {"deny": deny}})
+
+
 def _build_scope_system_prompt(routine: Routine) -> str:
     """构建文件系统作用域限制的 system prompt 片段（对所有 routine 类型生效）。
 
@@ -96,28 +137,38 @@ def _build_scope_system_prompt(routine: Routine) -> str:
     隔离保证：worktree 存储在项目父目录的 ``.negentropy-worktrees/`` 下，
     与兄弟项目同级；Claude Code 自主探索时可能误读这些不相关项目或源
     项目目录（可能在不同分支）。本函数通过 system prompt 显式限定：仅
-    允许读取 worktree 目录内的文件，绝不授权访问源项目或兄弟目录。
-    worktree 已包含基线分支的完整检出，无需引用源项目。
+    允许读取 worktree 目录与「显式授予的只读源目录」（``config.read_dirs``，
+    经 ``--add-dir`` 物理授权），绝不授权访问其余兄弟目录。
     """
     cwd = routine.cwd or ""
     wt_path = getattr(routine, "worktree_path", None) or ""
     is_wt = phase_mod.is_worktree_routine(routine)
+    read_dirs = _normalize_read_dirs((getattr(routine, "config", None) or {}).get("read_dirs"))
 
     if is_wt and wt_path:
         baseline = getattr(routine, "baseline_branch", None) or ""
         baseline_note = f"\nBaseline branch: `{baseline}`." if baseline else ""
-        return (
-            "## File System Scope (文件系统作用域)\n"
-            f"Working directory: `{wt_path}` (isolated worktree).{baseline_note}\n"
-            "READ scope — you may ONLY read files within:\n"
-            "  1. The worktree directory and its subdirectories.\n"
-            "  2. Absolute paths explicitly referenced in the task goal.\n"
-            "You MUST NOT read from any directory outside the worktree, including the "
-            "original source project directory, sibling directories, or any other local path. "
-            "The worktree contains a complete checkout of the baseline branch — there is no "
-            "need to reference the source project.\n"
-            "Exceptions: WebSearch, WebFetch, and MCP tools are not restricted."
+        lines = [
+            "## File System Scope (文件系统作用域)",
+            f"Working directory: `{wt_path}` (isolated worktree).{baseline_note}",
+            "READ scope — you may ONLY read files within:",
+            "  1. The worktree directory and its subdirectories.",
+        ]
+        if read_dirs:
+            for i, d in enumerate(read_dirs, start=2):
+                lines.append(f"  {i}. `{d}` (READ-ONLY source — you may READ but MUST NOT write/edit here).")
+            lines.append(
+                "WRITE scope — you may create/modify files ONLY inside the worktree. "
+                "The granted source directories above are read-only references for reproduction."
+            )
+        else:
+            lines.append("  2. Absolute paths explicitly referenced in the task goal.")
+        lines.append(
+            "You MUST NOT read from any directory outside the scope above, including unrelated "
+            "sibling projects or any other local path."
         )
+        lines.append("Exceptions: WebSearch, WebFetch, and MCP tools are not restricted.")
+        return "\n".join(lines)
     elif cwd:
         return (
             "## File System Scope (文件系统作用域)\n"
@@ -403,11 +454,16 @@ class RoutineOrchestrator:
             if routine is None or routine.status != "running" or latest is None or latest.status != "evaluating":
                 await self._reset_evaluating_to_executed(routine_id, iteration_id)
                 return
+            # PLAN 相位仅产出方案、未落盘任何实现，运行验证门控（如 uv run pytest）既无意义、
+            # 又徒增 gate 超时延迟，且把「无实现自然失败」的门控输出喂给 Judge 会错误压低方案评分。
+            # 故 PLAN 相位跳过门控（置空 verification_command），Judge 纯评估方案质量；
+            # IMPLEMENT/FINALIZE 相位照常跑门控。
+            skip_gate_in_plan = routine.current_phase == phase_mod.PHASE_PLAN
             routine_eval_view = SimpleNamespace(
                 goal=routine.goal,
                 acceptance_criteria=routine.acceptance_criteria,
                 cwd=routine.cwd,
-                verification_command=routine.verification_command,
+                verification_command=None if skip_gate_in_plan else routine.verification_command,
                 worktree_path=routine.worktree_path,
             )
             iter_eval_view = SimpleNamespace(
@@ -1282,6 +1338,14 @@ class RoutineOrchestrator:
         # per-routine 可覆盖/补充全局 mcp_config（MCP 服务器配置）。
         if overrides.get("mcp_config"):
             config.mcp_config = overrides["mcp_config"]
+        # 额外只读源目录（per-routine config.read_dirs 覆盖）。worktree routine 的 goal 常需读取
+        # 源项目（如待复刻的 platform-maps/jerusalem-v3 Go 源码）；此处把声明的目录物理授予 CC
+        # （CLI --add-dir / SDK add_dirs），并以 settings 的 permissions.deny 锁为只读
+        # （--add-dir 默认授予读+写，deny 把源码改写物理封死，仅 worktree 可写）。
+        read_dirs = _normalize_read_dirs(overrides.get("read_dirs"))
+        if read_dirs:
+            config.add_dirs = read_dirs
+            config.settings = _build_readonly_settings(read_dirs)
         # permission_mode 由相位决定（PLAN 仅规划、IMPLEMENT/FINALIZE 落盘）——对 worktree routine
         # 与 phased routine 均生效（覆盖 preset 静态值）；旧扁平 routine 沿用 preset 覆盖或全局默认。
         if phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config):

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -601,10 +601,30 @@ async def list_iteration_events(
 # ---------------------------------------------------------------------------
 
 
+def _validate_read_dirs(config: dict[str, Any] | None) -> None:
+    """校验 ``config.read_dirs``：字符串数组，每项绝对化后须为已存在目录（422 友好报错）。
+
+    这些目录会经 ``--add-dir`` 物理授予 CC 只读访问（见 orchestrator._build_config）；
+    校验为防御性早反馈——CLI 自身亦在 launch 时校验路径存在，故 None/缺省时直接放行。
+    """
+    if not config:
+        return
+    raw = config.get("read_dirs")
+    if raw is None:
+        return
+    if not isinstance(raw, list) or not all(isinstance(x, str) for x in raw):
+        raise HTTPException(status_code=422, detail="config.read_dirs must be a list of directory paths")
+    for d in raw:
+        p = os.path.abspath(os.path.expanduser(d.strip())) if d.strip() else ""
+        if not p or not os.path.isdir(p):
+            raise HTTPException(status_code=422, detail=f"read_dir does not exist or is not a directory: '{d}'")
+
+
 @router.post("")
 async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
     if body.cwd and not os.path.isdir(body.cwd):
         raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{body.cwd}'")
+    _validate_read_dirs(body.config)
     # 提供了 Project Path (cwd) + Baseline Branch 时即时校验仓库/基线（早反馈）。存在性的硬约束
     # 由 start 守卫强制（执行前提），允许 API 侧先创建草稿；前端创建可执行 routine 时已强制二者。
     if body.cwd and body.baseline_branch:
@@ -682,6 +702,8 @@ async def update_routine(routine_id: UUID, body: RoutineUpdateRequest) -> dict[s
         # cwd 目录存在性校验（非 running 路径，unsafe 已被上方拦截）
         if "cwd" in update_data and update_data["cwd"] and not os.path.isdir(update_data["cwd"]):
             raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{update_data['cwd']}'")
+        if "config" in update_data:
+            _validate_read_dirs(update_data["config"])
 
         for field_name, value in update_data.items():
             setattr(r, field_name, value)

--- a/apps/negentropy/tests/conftest.py
+++ b/apps/negentropy/tests/conftest.py
@@ -1,3 +1,6 @@
+import asyncio
+from urllib.parse import urlsplit, urlunsplit
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -6,11 +9,85 @@ from negentropy.db import deps as db_deps
 from negentropy.db import session as db_session
 
 
+def _derive_test_db_urls(prod_url: str) -> tuple[str, str, str]:
+    """从生产 DSN 派生测试库相关 DSN：库名 ``<name>`` → ``<name>_test``。
+
+    返回 ``(test_async_dsn, maintenance_pg_dsn, test_db_name)``。
+    维护库连 ``postgres``（CREATE DATABASE 不能在目标库自身或事务内执行）。
+    """
+    parts = urlsplit(prod_url)
+    db_name = parts.path.lstrip("/") or "negentropy"
+    test_db = f"{db_name}_test"
+    test_url = urlunsplit(parts._replace(path=f"/{test_db}"))
+    # 维护连接用纯 postgresql:// 驱动名（asyncpg.connect 不认 +asyncpg 后缀）
+    maint_scheme = parts.scheme.split("+", 1)[0]
+    maint_url = urlunsplit(parts._replace(scheme=maint_scheme, path="/postgres"))
+    return test_url, maint_url, test_db
+
+
+async def _ensure_database(maint_url: str, test_db: str) -> None:
+    """幂等创建测试库（asyncpg autocommit）。已存在则 no-op。"""
+    import asyncpg
+
+    conn = await asyncpg.connect(maint_url)
+    try:
+        exists = await conn.fetchval("SELECT 1 FROM pg_database WHERE datname = $1", test_db)
+        if not exists:
+            await conn.execute(f'CREATE DATABASE "{test_db}"')
+    finally:
+        await conn.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_test_database():
+    """会话级强制隔离：所有测试在专用 ``<db>_test`` 库运行，**绝不触碰生产库**。
+
+    根因防护（ISSUE-111）：此前 ``db_engine`` 与 ``test_migrations.reset_database`` 直接读
+    ``settings.database_url``（生产 ``negentropy`` 库）——
+
+      1. ``test_migrations`` 的 ``command.downgrade(base)`` 会**摧毁全部生产数据**
+         （routines / knowledge / memory / sessions…），违反 AGENTS.md「严禁删除现有数据」；
+      2. orchestrator 集成测试的 ``_dispatch_due`` / ``_evaluate_and_decide`` 扫描**全部** running
+         routine，会污染真实任务（实证：测试夹具 ``WorkspaceInfo('/tmp/wt/dispatch-auto')`` 经
+         ``_dispatch_due`` 写入了生产模板 routine 的 iter2，触发其后的会话死亡螺旋）。
+
+    修复：会话开始即把 ``settings.database.url`` 改写为 ``<db>_test``。``database_url`` 是纯
+    ``@property``（``str(self.database.url)``），且同进程 alembic（``env.py`` 读 ``settings.database_url``）
+    与 ``_sync_database_url`` 均经此读取——单一改写点即让 ``db_engine`` / alembic / 迁移测试全部
+    落到测试库。再幂等创建并 ``upgrade head`` 测试库，使非迁移类集成测试有完整 schema。
+    """
+    prod_url = str(settings.database_url)
+    if prod_url.rstrip("/").endswith("_test"):
+        # 已指向测试库（外部经 NE_DB_URL 显式设定）→ 直接放行，仅确保 schema。
+        yield
+        return
+
+    from alembic import command
+    from alembic.config import Config
+
+    test_url, maint_url, test_db = _derive_test_db_urls(prod_url)
+    asyncio.run(_ensure_database(maint_url, test_db))
+
+    # DatabaseSettings 是 frozen 模型（不能改 settings.database.url）；改覆盖 Settings 类的
+    # ``database_url`` 纯属性即可——alembic env.py / _sync_database_url / 本文件 db_engine 全经它
+    # 读取 DSN。session 级保存/还原，绝不残留影响其它进程。
+    settings_cls = type(settings)
+    original_prop = settings_cls.database_url
+    settings_cls.database_url = property(lambda _self, _u=test_url: _u)
+    try:
+        command.upgrade(Config("alembic.ini"), "head")  # env.py 读 settings.database_url → 测试库
+        yield
+    finally:
+        settings_cls.database_url = original_prop
+
+
 @pytest.fixture(scope="function")
 async def db_engine():
     """
     Function-scoped database engine for tests.
     Ensures the engine is created within the correct event loop scope (function).
+
+    绑定到 ``settings.database_url``——已被 ``_isolate_test_database`` 改写为测试库，绝不连生产库。
     """
     engine = create_async_engine(
         str(settings.database_url),

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -159,6 +159,54 @@ async def test_phased_plan_advances_to_implement():
         await _cleanup(rid)
 
 
+async def test_plan_phase_skips_verification_gate():
+    """PLAN 相位评估跳过验证门控（verification_command 置空）——方案阶段无实现，跑 pytest 既无意义又污染评分。"""
+    rid = await _make_routine(
+        config={"workflow": "phased"},
+        current_phase="plan",
+        iteration_count=1,
+        verification_command="uv run pytest -q",
+    )
+    await _add_iteration(rid, seq=1, phase="plan")
+    captured: dict = {}
+
+    async def _capture(routine_view, iter_view):
+        captured["vc"] = routine_view.verification_command
+        return EvaluationResult(ok=True, score=40, verdict="progressing", reflection="r")
+
+    try:
+        orch = RoutineOrchestrator()
+        with patch.object(orch._evaluator, "evaluate", new=AsyncMock(side_effect=_capture)):
+            await _evaluate_and_drain(orch)
+        assert captured["vc"] is None  # PLAN 相位门控被跳过
+    finally:
+        await _cleanup(rid)
+
+
+async def test_implement_phase_runs_verification_gate():
+    """IMPLEMENT 相位评估正常传入 verification_command（门控照跑），与 PLAN 跳过形成对照。"""
+    rid = await _make_routine(
+        config={"workflow": "phased"},
+        current_phase="implement",
+        iteration_count=2,
+        verification_command="uv run pytest -q",
+    )
+    await _add_iteration(rid, seq=1, phase="implement")
+    captured: dict = {}
+
+    async def _capture(routine_view, iter_view):
+        captured["vc"] = routine_view.verification_command
+        return EvaluationResult(ok=True, score=55, verdict="progressing", reflection="r", gate_exit_code=0)
+
+    try:
+        orch = RoutineOrchestrator()
+        with patch.object(orch._evaluator, "evaluate", new=AsyncMock(side_effect=_capture)):
+            await _evaluate_and_drain(orch)
+        assert captured["vc"] == "uv run pytest -q"  # IMPLEMENT 相位门控照跑
+    finally:
+        await _cleanup(rid)
+
+
 async def test_phased_implement_success_advances_to_finalize():
     """相位化：IMPLEMENT 命中成功阈值 → 推进到 FINALIZE（不直接 succeeded）。"""
     rid = await _make_routine(config={"workflow": "phased"}, current_phase="implement", iteration_count=2)

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -1081,3 +1081,122 @@ async def test_build_cli_args_omits_disallowed_tools_when_none():
     config = ClaudeCodeConfig(disallowed_tools=None)
     args = ClaudeCodeService._build_cli_args("hello", config)
     assert "--disallowed-tools" not in args
+
+
+# ---------------------------------------------------------------------------
+# add_dirs（额外只读源目录，--add-dir）+ settings（只读 deny）—— P0-1 物理读授权回归锁定
+#
+# 根因：Routine goal 要求 CC 读取 worktree 之外的源项目（如待复刻的 Go 源码），但引擎
+# 此前零 --add-dir 接线，且 /add-dir 是交互式 slash 命令、在 claude -p 子进程中不生效 →
+# system prompt 声称「可读」而运行时无法兑现。修复：config.read_dirs → config.add_dirs →
+# CLI 重复 --add-dir + settings 的 permissions.deny(Edit(//src/**)) 锁只读。
+# ---------------------------------------------------------------------------
+
+
+async def test_build_cli_args_emits_repeated_add_dir():
+    """add_dirs 非空时逐目录注入 --add-dir（非逗号合并）。"""
+    config = ClaudeCodeConfig(add_dirs=["/src/a", "/src/b"])
+    args = ClaudeCodeService._build_cli_args("hello", config)
+    assert args.count("--add-dir") == 2
+    # 每个 --add-dir 紧跟其路径
+    idxs = [i for i, a in enumerate(args) if a == "--add-dir"]
+    vals = {args[i + 1] for i in idxs}
+    assert vals == {"/src/a", "/src/b"}
+    # 绝不能逗号合并
+    assert "/src/a,/src/b" not in args
+
+
+async def test_build_cli_args_omits_add_dir_when_none():
+    """add_dirs 为 None 时不注入 --add-dir。"""
+    args = ClaudeCodeService._build_cli_args("hello", ClaudeCodeConfig(add_dirs=None))
+    assert "--add-dir" not in args
+
+
+async def test_build_cli_args_emits_settings():
+    """settings 非空时注入 --settings <json>。"""
+    settings_json = '{"permissions": {"deny": ["Edit(//src/**)"]}}'
+    config = ClaudeCodeConfig(settings=settings_json)
+    args = ClaudeCodeService._build_cli_args("hello", config)
+    assert "--settings" in args
+    assert args[args.index("--settings") + 1] == settings_json
+
+
+async def test_build_cli_args_omits_settings_when_none():
+    """settings 为 None 时不注入 --settings。"""
+    args = ClaudeCodeService._build_cli_args("hello", ClaudeCodeConfig(settings=None))
+    assert "--settings" not in args
+
+
+async def test_invoke_cli_reconstruction_preserves_add_dirs_and_settings(monkeypatch):
+    """端到端锁定：非交互 _invoke_cli 重建 config 后仍保留 add_dirs/settings 并落到子进程 argv。
+
+    回归点：service.py 用 resolved CLI 路径重建 ClaudeCodeConfig；若漏传 add_dirs/settings，
+    --add-dir / --settings 会被静默丢弃 → CC 读不到源码 / 源码可写。镜像 credential 回归。
+    """
+    captured: dict = {}
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.stdout = _FakeStream(b"")
+            self.stderr = _FakeStream(b"")
+            self.returncode = 0
+
+        def terminate(self) -> None:
+            pass
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _fake_exec(*args, **kwargs):
+        captured["args"] = list(args)
+        return _FakeProc()
+
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+
+    settings_json = '{"permissions": {"deny": ["Edit(//src/go/**)"]}}'
+    cfg = ClaudeCodeConfig(cli_path="claude", cwd=None, max_turns=1, add_dirs=["/src/go"], settings=settings_json)
+    await ClaudeCodeService.invoke("ping", cfg)
+
+    argv = captured["args"]
+    assert "--add-dir" in argv and "/src/go" in argv, "重建后 --add-dir 不可丢失"
+    assert "--settings" in argv and settings_json in argv, "重建后 --settings 不可丢失"
+
+
+async def test_invoke_cli_interactive_reconstruction_preserves_add_dirs_and_settings(monkeypatch):
+    """端到端锁定：交互式 _invoke_cli_interactive 重建 config 后仍保留 add_dirs/settings。
+
+    Routine 实际走交互式路径（interactive=True）；该路径有**独立的** config 重建点，
+    必须同样透传 add_dirs/settings，否则 worktree routine 的源码读授权被丢弃。
+    """
+    captured: dict = {}
+    events = [
+        {"type": "system", "subtype": "init", "session_id": "s1"},
+        {"type": "result", "subtype": "success", "result": "ok", "session_id": "s1", "num_turns": 1},
+    ]
+
+    async def _fake_exec(*args, **kwargs):
+        captured["args"] = list(args)
+        return _DuplexFakeProc(events)
+
+    monkeypatch.setattr(ClaudeCodeService, "_check_sdk", classmethod(lambda cls: False))
+    monkeypatch.setattr("negentropy.engine.claude_code.service.shutil.which", lambda p: "/usr/bin/claude")
+    monkeypatch.setattr("negentropy.engine.claude_code.service.asyncio.create_subprocess_exec", _fake_exec)
+
+    settings_json = '{"permissions": {"deny": ["Edit(//src/go/**)"]}}'
+    cfg = ClaudeCodeConfig(
+        cli_path="claude",
+        cwd=None,
+        max_turns=5,
+        timeout_seconds=10.0,
+        interactive=True,
+        auto_answer_context={"goal": "g", "acceptance_criteria": "ac"},
+        add_dirs=["/src/go"],
+        settings=settings_json,
+    )
+    await ClaudeCodeService.invoke("ping", cfg)
+
+    argv = captured["args"]
+    assert "--add-dir" in argv and "/src/go" in argv, "交互式重建后 --add-dir 不可丢失"
+    assert "--settings" in argv and settings_json in argv, "交互式重建后 --settings 不可丢失"

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from negentropy.engine.routine import phase as phase_mod
-from negentropy.engine.routine.orchestrator import RoutineOrchestrator, _build_scope_system_prompt
+from negentropy.engine.routine.orchestrator import (
+    RoutineOrchestrator,
+    _build_readonly_settings,
+    _build_scope_system_prompt,
+    _normalize_read_dirs,
+)
 from negentropy.engine.routine.prompt_builder import build_prompt
 
 
@@ -174,8 +179,31 @@ def test_build_scope_system_prompt_worktree():
     assert "isolated worktree" in sp
     assert "data-la-maps" not in sp  # 源项目路径绝不在 scope 指令中
     assert "MUST NOT" in sp
-    assert "original source project directory" in sp  # 明确禁止源项目
+    # 无 read_dirs 时回退旧契约：仅 goal 显式引用的绝对路径可读，其余一律禁止
+    assert "Absolute paths explicitly referenced in the task goal" in sp
     assert "Baseline branch" in sp  # 提及基线分支名
+
+
+def test_build_scope_system_prompt_worktree_grants_readonly_read_dirs():
+    """配置 config.read_dirs 后，scope prompt 显式枚举授予的只读源目录并标 READ-ONLY。"""
+    src = "/Users/cm.huang/conductor/workspaces/platform-maps/jerusalem-v3"
+    r = _wt_routine(
+        cwd="/Users/cm.huang/Documents/projects/aurelius/data-la-maps",
+        worktree_path="/Users/cm.huang/Documents/projects/aurelius/.negentropy-worktrees/demo",
+        config={"read_dirs": [src]},
+    )
+    sp = _build_scope_system_prompt(r)
+    assert src in sp  # 授予目录被显式列出（物理 --add-dir 与 prompt 一致）
+    assert "READ-ONLY" in sp
+    assert "MUST NOT write/edit here" in sp
+    assert "ONLY inside the worktree" in sp  # 写范围限定 worktree
+
+
+def test_build_scope_system_prompt_worktree_no_config_attr_safe():
+    """routine 无 config 属性时不抛 AttributeError（SimpleNamespace 替身鲁棒性）。"""
+    r = _wt_routine()  # 不含 config
+    sp = _build_scope_system_prompt(r)  # 不应抛异常
+    assert "File System Scope" in sp
 
 
 def test_build_prompt_worktree_never_leaks_source_cwd():
@@ -186,6 +214,29 @@ def test_build_prompt_worktree_never_leaks_source_cwd():
     # 两个 prompt 层都不得泄露源项目路径
     assert "/secret/source/project" not in p
     assert "/secret/source/project" not in sp
+
+
+def test_normalize_read_dirs_dedups_absolutizes_and_filters():
+    """规整：绝对化 + 展开 ~ + 去重 + 丢弃非字符串/空串；非 list/str 入参返回空。"""
+    import os
+
+    home_a = os.path.abspath(os.path.expanduser("~/a"))
+    assert _normalize_read_dirs(["~/a", os.path.expanduser("~/a"), "  ", None, 123]) == [home_a]
+    assert _normalize_read_dirs("/x") == ["/x"]  # 单字符串容忍
+    assert _normalize_read_dirs(None) == []
+    assert _normalize_read_dirs({"k": "v"}) == []  # 非 list/str → 空
+
+
+def test_build_readonly_settings_denies_edit_with_absolute_anchor():
+    """只读 settings：每个目录生成 Edit(//<abs>/**) deny，且无 allow 削弱。"""
+    import json
+
+    s = _build_readonly_settings(["/Users/x/src", "/opt/go"])
+    parsed = json.loads(s)
+    deny = parsed["permissions"]["deny"]
+    assert "Edit(//Users/x/src/**)" in deny
+    assert "Edit(//opt/go/**)" in deny
+    assert "allow" not in parsed["permissions"]  # 绝不放行
 
 
 def test_build_scope_system_prompt_flat_routine():

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2769,3 +2769,52 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
   4. **巨型长任务会耗尽 1M 上下文**：本例模型为 `claude-opus-4-7[1m]`，单轮 157 turns 即撑满。长周期 routine 必须具备跨会话的上下文管理（冷启动自愈 + reflections 注入 + worktree 持久），不能假设单一会话能承载整个任务。
 - **验证**：①单元（`test_claude_code_service.py` 10 例覆盖 `_classify_result_error` 用 seq=4 真实事件 fixture / 全 marker 大小写容错 / subtype 独立信号 / 负例防误判 / `_invoke_cli` 端到端打标签；`test_routine_decision.py` 5 例覆盖可自愈失败放行 / reset_max=0 退化 / 普通 error 仍 unrecoverable / continue 不隔断链 / success 归零）+ 集成（`test_routine_orchestrator.py` 3 例覆盖 runner 写回清 session+标记 / 成功正常续接 / 达上限封顶）；routine+claude_code 全量 **144 用例全绿**，零回归；ruff clean。②**实机全闭环**（Chrome devtools，复活 `a83d9c94`）：改 DB 复活（`status=running`、`claude_session_id=NULL`、`eval_floor_seq=5` 隔离旧失败窗口、保留 worktree）后，inspector 下一 tick dispatch seq=6——CC 子进程 `claude -p`（**无 `--resume`，确认冷启动**）、`resume_session_id=NULL`、189s 内产 **339 审计事件含 112 tool_use**（对比旧 seq=4/5 仅 ~6 事件 1 turn 即死），routine 持续 `running`、worktree（123.3M seq=1 产出）完整保留。UI 迭代时间线、Evaluator-Optimizer Loop、Reflexion 注入面板全部正确渲染。
 - **同类问题影响 / 跨上下文注意**：缺陷自 Routine 子系统引入即潜伏，凡「单会话上下文撑满」的长任务全部受害（短任务因不撑满上下文不触发）。承 ISSUE-108 修复使 Routine 全闭环可跑通后，本缺陷是「跑得足够久」才暴露的下一层失败模式——**只有用巨型真实任务实机长跑才能发现，单测与小任务均无法触发**。修复纯后端（service.py/runner.py/decision.py/config），无 schema/迁移变更，无前端改动；新增字段/参数均默认向后兼容（`error_kind=None`、`max_context_resets=0` 退化原行为）。
+
+## ISSUE-110 Routine worktree 隔离缺失「源目录只读读授权」物理通道——Prompt 声称可读而运行时无法兑现（复刻类长任务硬阻断，2026-06-06）
+
+- **表因**：以「Maps 项目复刻」（`9e90c3c7`，Go `platform-maps/jerusalem-v3`→Python `data-la-maps`）为模板的复刻类 routine，goal 明确要求 CC「通过 `/add-dir` 加载 source-project 全量代码进行源项目全方位分析」，但 CC 在隔离 worktree 中实际**读不到** worktree 之外的 Go 源码（407 文件）；隔离 system prompt（ISSUE 见 commit `002f58dd`）虽声称「goal 显式引用的绝对路径可读」(rule 2)，却无任何物理机制兑现该读权限。复刻因「看不到源」而不可能做好（历史 iter1 仅靠零散探索拿到 92 分，本质是盲人摸象）。
+- **根因**：**Prompt 授予了运行时无法兑现的读权限——隔离的物理层与 prompt 层不一致**：
+  1. CC 子进程 cwd 被钉在隔离 worktree；Claude Code 对 cwd 之外的路径默认不可读，需经 `--add-dir`（CLI）/`add_dirs`（SDK）显式授予；
+  2. goal 让 CC 用 `/add-dir`——但 `/add-dir` 是**交互式 slash 命令**，在 `claude -p` 非交互子进程 / SDK `query()` 中**完全不生效**；
+  3. `grep -rniE "add[_-]?dir|additional_director"` 全 `engine/` **零命中**——`ClaudeCodeConfig` 无 `add_dirs` 字段，`_build_cli_args` 不发 `--add-dir`，`_build_config` 也无来源接线。三层皆缺，rule 2 的「可读」沦为空头支票。
+- **处理方式**（物理授权 + 只读封锁 + prompt 对齐，最小干预）：
+  1. `claude_code/models.py`：`ClaudeCodeConfig` 增 `add_dirs: list[str]|None` + `settings: str|None`（repr 安全）；
+  2. `claude_code/service.py`：`_build_cli_args` 逐目录发 `--add-dir <path>`（**非逗号合并**，经 SDK 源码 `subprocess_cli.py::_build_command` 核实）+ `--settings <json>`；`_invoke_sdk` 经 `hasattr` 守卫设 `options.add_dirs`/`options.settings`（SDK 未装时仅告警，CLI 为权威路径）；**两处** config 重建点（`_invoke_cli` + `_invoke_cli_interactive`）均补透传 `add_dirs`/`settings`（同 credential 静默丢弃回归类——Routine 实际走交互式路径）；
+  3. `routine/orchestrator.py`：新增 `_normalize_read_dirs`（绝对化+去重+滤杂质）与 `_build_readonly_settings`（对每个 add_dir 生成 `permissions.deny:["Edit(//<abs>/**)"]`，`//` 为文件系统绝对锚点）；`_build_config` 从 `routine.config.read_dirs` 填充 `config.add_dirs` + `config.settings`——`--add-dir` 默认授予**读+写**，故必须以 `Edit` deny 把源码物理锁只读（deny 优先级最高，`acceptEdits/bypassPermissions/--add-dir` 均不可越权；CC 仍可 Read，但 Edit/Write/MultiEdit/识别的 Bash 写命令被封死，worktree/cwd 无 deny 写入正常）；`_build_scope_system_prompt` 改为枚举「worktree + 授予的只读源目录（标 READ-ONLY）」并禁止其余，使 prompt 层与物理层一致（无 read_dirs 时回退旧 rule 2 文案，零回归）；
+  4. `interface/routine_api.py`：新增 `_validate_read_dirs`，create/update 校验 `config.read_dirs` 为字符串数组且每项绝对化后是已存在目录（422 早反馈）。
+- **后续防范**：
+  1. **物理隔离的「授予」与「禁止」必须成对、且都落到运行时**——只声明「禁止读 X」而不提供「允许读 Y」的物理通道，会把本可达成的任务变成不可能；任何「prompt 说可读/可写」的语句都要追问「运行时有无对应的物理机制（`--add-dir`/`permissions.allow`/挂载）兑现」，否则即是 ISSUE-110 式的「空头权限」；
+  2. **`--add-dir` 是读+写双授**：凡需「只读引用外部目录」，必须叠加 `settings.permissions.deny(Edit(//dir/**))` 物理锁只读，不能依赖 prompt 自律（Prompt 无强制力）；
+  3. **交互式 slash 命令（`/add-dir`/`/model`/`/compact`…）在 `-p` 非交互子进程中全部无效**——凡 goal/prompt 指示 CC 执行 slash 命令的，引擎都须翻译为等价 CLI flag 或 settings，不能寄望 CC 在 headless 下「自己敲」；
+  4. **config 重建点是字段静默丢失的高发区**：`service.py` 有 `_invoke_cli` 与 `_invoke_cli_interactive` 两处 `ClaudeCodeConfig(...)` 逐字段重建，新增任何 config 字段都须同步两处 + 加「重建后字段存活」回归（镜像既有 credential 回归）。
+- **同类问题影响**：所有「在隔离环境中需读取环境外资源」的 routine（复刻、迁移、跨仓重构、对照基线 diff 等）此前全部受害；`config.read_dirs` 为通用解。审计点：凡 goal 含外部绝对路径引用的 worktree routine，须显式配 `read_dirs` 方能让 CC 物理读到。
+- **验证**：①单元（`test_claude_code_service.py` 7 例：`--add-dir` 逐目录非逗号 / `--settings` 注入 / None 时不发 / 非交互+交互**两处**重建存活；`test_routine_phase.py` 4 例：scope prompt 枚举授予目录且标 READ-ONLY+写限 worktree / 无 read_dirs 回退旧契约 / 无 config 属性不抛 / `_normalize_read_dirs` 去重绝对化滤杂 / `_build_readonly_settings` 绝对锚点 deny 无 allow 削弱）；`routine_phase`+`claude_code` 全量 **84 用例全绿**。②**实机**（Chrome 实机跟踪 + ps/DB）：探针 routine（`77efcd8e`，phased）dispatch 后，运行中 `claude -p` 子进程 argv 实测含 `--permission-mode plan`、`--add-dir /Users/.../jerusalem-v3`、`--settings {"permissions":{"deny":["Edit(//Users/.../jerusalem-v3/**)"]}}`；plan 相位 9 分钟内 CC 对 Go 源 `find/ls/Read` **124 次**（README/go.mod/Makefile/Dockerfile…），零 session/compact 重试——源码物理可读、改写被 deny 封锁，复刻首次具备「看得见源」的前提。③**重派发链路**（iter2/implement）：`--resume <iter1 session>`、cwd 恒为隔离 worktree（**非历史 `/tmp/wt/dispatch-auto`**）、`--add-dir` 与只读 deny 跨迭代保持、`--permission-mode` 随相位 plan→acceptEdits 切换——历史 iter2-5 的「cwd 错位 + 会话死亡螺旋」失败链已端到端愈合。
+
+## ISSUE-111 测试套件直连生产库——`test_migrations` 降级摧毁生产数据 + orchestrator 测试污染真实 routine（潜伏数据灾难，2026-06-06）
+
+- **表因**：以模板 routine（`9e90c3c7`）复刻任务实机长跑时，发现其历史 iter2 失败于 `working directory does not exist: '/tmp/wt/dispatch-auto'`——而 `/tmp/wt/dispatch-auto` 是 `test_routine_orchestrator.py` 的测试夹具值，却写进了**生产** routine 的迭代行。顺藤摸瓜发现整个测试套件直连生产 `negentropy` 库。
+- **根因**：**测试无独立数据库，与生产共享 `negentropy` 库**：
+  1. `tests/conftest.py::db_engine` 直接 `create_async_engine(str(settings.database_url))`——生产库；
+  2. `tests/integration_tests/db/test_migrations.py::reset_database`（autouse）执行 `command.downgrade(alembic_config, "base")`——**把生产库降级到 base，DROP 全部表 = 摧毁 routines/knowledge/memory/sessions 全部数据**，违反 [AGENTS.md「严禁删除现有数据」](../../CLAUDE.md)；其 `_sync_database_url()` 亦读 `settings.database_url`（生产）；
+  3. `orchestrator._dispatch_due` / `_evaluate_and_decide` 查询条件为 `Routine.status=='running'`（**扫描全部** running routine，不限于测试自建行）；集成测试 patch `ensure_workspace`→`WorkspaceInfo('/tmp/wt/dispatch-auto')` 后调 `_dispatch_due`，会把该假 cwd 派发给当时正在 running 的**真实**模板 routine → CC 报 cwd 不存在 → 该 routine 随后陷入会话死亡螺旋（ISSUE-110 表征的历史 iter2-5 即源于此）。
+  - 模板 routine 至今尚存，说明全量 `pytest tests/` 本地近期未跑全——否则 `reset_database` 一次即清空生产库。这是「跑得够全才爆」的潜伏数据灾难。
+- **处理方式**（会话级强制隔离到专用测试库，单一改写点）：
+  1. `tests/conftest.py` 新增 session 级 autouse fixture `_isolate_test_database`：幂等 `CREATE DATABASE negentropy_test`（asyncpg autocommit 连维护库 `postgres`）→ 覆盖 `Settings` 类的 `database_url` 纯属性返回测试库 DSN → `alembic upgrade head` 迁移测试库 → yield → 还原属性；
+  2. 选「覆盖 `database_url` 属性」而非改 `settings.database.url`——后者是 frozen pydantic 模型（`_check_frozen` 拒写）；而 `database_url` 是 `@property`（`str(self.database.url)`），且**同进程** alembic env.py（`configuration["sqlalchemy.url"]=str(settings.database_url)`）、`_sync_database_url`、conftest `db_engine` 全经它读 DSN——改一处即让迁移测试的 down/up、orchestrator 集成测试、全部 DB 访问落到 `negentropy_test`，绝不触碰生产库；
+  3. `db_engine` 无需改动（读 `settings.database_url`，已被改写）。
+- **后续防范**：
+  1. **测试**与**生产**必须物理分库——任何 conftest/fixture 直读 `settings.database_url` 建引擎或跑 DDL 都是红线，CR 必须确认测试落到 `*_test` 库；
+  2. **破坏性 DDL 的 autouse fixture（`downgrade base` / `DROP` / `TRUNCATE`）尤其危险**——必须在物理隔离的库上执行，且 fixture 自身应断言所连库名以 `_test` 结尾方可放行；
+  3. **扫描全表的编排逻辑（`status=='running'`）在共享库下会跨数据污染**——集成测试 patch workspace/外部副作用时，必须保证库隔离，否则测试副作用外溢到生产行；
+  4. 可选加固：在 `_isolate_test_database` 起始 `assert not str(settings.database_url).rstrip('/').endswith('/negentropy')` 之外，再对生产库名做显式黑名单断言，杜绝任何回退路径直连生产。
+- **同类问题影响**：所有 `tests/integration_tests/**` 此前都在生产库跑（knowledge/memory/mcp/interface 等）；隔离后一律落 `negentropy_test`。承 [ISSUE-100](#)（test_runner 污染 sys.modules）同源——测试隔离是系统性议题，DB 层是其最危险的一环。
+- **验证**：隔离前快照生产库 `routines=30 / iterations=174 / 模板存在`；跑 `test_migrations.py`（含 stairway down→up，历史会清生产库）+ `test_routine_orchestrator.py` + `test_routine_phase.py` 共 **59 例全绿**；跑后生产库快照**完全不变**（30/174/模板在），`negentropy_test` 库建成且 `routines=0`（干净隔离）——数据灾难闸门关闭。
+
+## ISSUE-112 Routine PLAN 相位评估误跑验证门控（pytest），对无实现的方案污染评分（2026-06-06）
+
+- **表因**：phased routine 的 PLAN 相位迭代评估后，迭代行 `gate_exit_code=5`（pytest「no tests collected」）、`verdict=stalled`、`score=50`——方案阶段尚无任何实现，却跑了 `uv run pytest -q`。
+- **根因**：`orchestrator._do_evaluate` 构建 `routine_eval_view` 时无条件透传 `verification_command`，`evaluator.evaluate` 凡 `verification_command` 非空即跑门控（`if routine.verification_command:`），**不区分相位**。PLAN 相位无实现，门控必然失败（exit 5/非零），其失败输出喂给 LLM Judge 会错误压低方案评分，且白白消耗 gate 超时延迟。
+- **处理方式**（最小干预）：`_do_evaluate` 中 `skip_gate_in_plan = routine.current_phase == PHASE_PLAN`，PLAN 相位把 `routine_eval_view.verification_command` 置 None——`evaluate` 的既有 `if verification_command:` 守卫自然跳过门控，Judge 纯评估方案质量；IMPLEMENT/FINALIZE 相位门控照跑。
+- **后续防范**：门控/验证类副作用必须「相位感知」——PLAN（无产物）跳过、IMPLEMENT/FINALIZE（有产物）执行；任何「无条件对当前工作区跑测试」的逻辑都要先问「此相位有无可验证的产物」。
+- **同类问题影响**：所有配 `verification_command` 的 phased routine 的 PLAN 相位评分此前都被门控失败拉低；本修复使方案阶段评分回归方案质量本身。
+- **验证**：集成测试 `test_plan_phase_skips_verification_gate`（PLAN 相位 eval_view.verification_command 为 None）+ `test_implement_phase_runs_verification_gate`（IMPLEMENT 相位照传）对照锁定，全绿；实机「before」证据：探针 PLAN 迭代 `gate_exit_code=5`（修复前）。


### PR DESCRIPTION
## 背景

以「Maps 项目复刻」（Go `platform-maps/jerusalem-v3` 一比一复刻为 Python `data-la-maps`）这一巨型自迭代 Routine 为活体探针，**实机闭环**（启动服务 → 浏览器全程跟踪 → 发现缺陷 → 修复 → 实证）排查并加固 Routine 引擎，使其达生产部署级。本 PR 修复 3 类缺陷（详见 [issue.md](docs/.agents/issue.md) ISSUE-110/111/112），并验证此前 `729bfe54`（Evaluate 后台化 + 会话续接自愈）与 `002f58dd`（Worktree 隔离）两轮修复确已生效。

## 缺陷与修复

### ISSUE-110 · worktree 缺失「源目录只读读授权」物理通道（复刻类硬阻断）
- **根因**：任务 goal 要求 CC 用 `/add-dir` 读取 worktree 之外的 Go 源码，但引擎**零** `--add-dir` 接线、`/add-dir` 又是交互式命令在 `claude -p` 子进程中不生效——隔离 system prompt 声称「可读」而运行时无法兑现，复刻因「看不见源」不可能做好。
- **修复**：`ClaudeCodeConfig` 增 `add_dirs`/`settings`，经 CLI 重复 `--add-dir`（逐目录）与 SDK `add_dirs` 双路接线，**两处** config 重建点均透传；`_build_config` 从 `config.read_dirs` 填充并生成 `permissions.deny(Edit(//src/**))` 把源码**物理锁只读**；scope system prompt 枚举授予目录使物理层与 prompt 层一致；API 校验 `read_dirs`。

### ISSUE-111 · 测试套件直连生产库（潜伏数据灾难）
- **根因**：`conftest` 与 `test_migrations.reset_database` 直读 `settings.database_url`（生产 `negentropy` 库）——前者使 `downgrade base` **摧毁全部生产数据**，后者使 orchestrator 集成测试扫描全部 running routine **污染真实任务**（实证：测试夹具 `/tmp/wt/dispatch-auto` 经 `_dispatch_due` 写入了生产模板 routine，触发其会话死亡螺旋）。
- **修复**：会话级 autouse fixture 强制隔离到专用 `negentropy_test` 库（幂等建库 + 迁移 + 覆盖 `database_url` 属性），使迁移测试、编排测试、全部 DB 访问绝不触碰生产库。

### ISSUE-112 · PLAN 相位误跑验证门控污染评分
- **根因**：`_do_evaluate` 无条件透传 `verification_command`，PLAN 相位（无实现）也跑 `uv run pytest`，门控失败输出错误压低方案评分。
- **修复**：PLAN 相位置空 `verification_command` 跳过门控，Judge 纯评估方案质量；IMPLEMENT/FINALIZE 照跑。

## 验证

- **回归**：`uv run pytest` 引擎 + routine-api 全量 **974 passed / 2 skipped**；新增单元/集成回归覆盖每个修复点（`--add-dir` 逐目录非逗号、两处重建存活、scope 只读枚举、PLAN 跳过/IMPLEMENT 照跑门控对照等）；ruff clean。
- **测试库隔离实证**：隔离前生产库 `routines=30/iterations=174/模板存在`；跑含 `downgrade base` 的迁移测试后生产库**完全不变**，`negentropy_test` 干净隔离。
- **实机全闭环**（浏览器 + DB + ps）：探针 routine 实测 `claude` 子进程 argv 含 `--add-dir <jerusalem-v3>` + `--settings(Edit deny)` + `--permission-mode`；PLAN 相位 CC 对 Go 源 `find/ls/Read` **124 次**；IMPLEMENT 相位向 worktree 写出 `pyproject.toml`/`Makefile`/`src/`/9 个 `.py`，而 **Go 源码全程零修改**（只读 deny 物理生效）；plan→plan_review→evaluate→decide→**重派发**链路 cwd 恒为隔离 worktree（非历史 `/tmp/wt/dispatch-auto`）、`--resume` 会话续接、相位 plan→acceptEdits 切换——历史 iter2-5 的「cwd 错位 + 会话死亡螺旋」失败链端到端愈合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)