### PR TITLE
style(RoutineIterationView): Turn 气泡单行化 + 间距与内边距紧凑化

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -257,7 +257,7 @@ export function IterationEventTimeline({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-1">
       {/* 分组统计栏 */}
       <div className="flex flex-wrap items-center gap-2">
         {(["execution", "plan_review", "result", "gate", "evaluation"] as const).map((g) => {
@@ -282,7 +282,7 @@ export function IterationEventTimeline({
       </div>
 
       {/* 对话流（按同发言人聚合） */}
-      <div className="space-y-2.5">
+      <div className="space-y-1">
         {speakerGroups.map((group) => (
           <SpeakerGroupBubble key={group.id} group={group} />
         ))}
@@ -353,7 +353,7 @@ function SpeakerGroupBubble({ group }: { group: SpeakerGroup }) {
         </div>
       </div>
       {/* 聚合内容区 */}
-      <div className="min-w-0 max-w-[85%] space-y-2">
+      <div className="min-w-0 max-w-[85%] space-y-[3px]">
         {/* 统一发言人标签 */}
         <div className="flex items-center gap-2 px-1">
           <span className={cn(
@@ -396,40 +396,37 @@ function ClaudeCodeTurnBubble({
       {/* 气泡内容 */}
       <div
         className={cn(
-          "min-w-0 rounded-2xl border p-3 shadow-sm transition-colors",
+          "min-w-0 rounded-2xl border p-1 shadow-sm transition-colors",
           showHeader ? "max-w-[85%] rounded-tl-sm" : "w-full",
           turn.hasError
             ? "border-red-500/30 bg-red-500/[0.03]"
             : "border-border bg-card",
         )}
       >
-        {/* 可点击的折叠 Header */}
+        {/* 可点击的折叠 Header（单行：箭头 · 发言人 · Turn N · 事件数 · error · 摘要标题） */}
         <button
           type="button"
           onClick={() => setCollapsed((v) => !v)}
-          className="-mx-1 flex w-full flex-col gap-1 rounded-lg px-1 py-0.5 text-left transition-colors hover:bg-muted/40"
+          className="-mx-1 flex w-full items-center gap-2 rounded-lg px-1 py-0.5 text-left transition-colors hover:bg-muted/40"
         >
-          {/* 元信息行：折叠箭头 · 发言人 · Turn N · 事件数 · error 徽章 */}
-          <span className="flex w-full items-center gap-2">
-            <ChevronRight
-              className={cn("h-3.5 w-3.5 shrink-0 text-text-muted transition-transform", !collapsed && "rotate-90")}
-              aria-hidden
-            />
-            {showHeader && (
-              <span className="text-xs font-semibold text-violet-600 dark:text-violet-400">
-                Claude Code
-              </span>
-            )}
-            <span className="text-sm font-semibold text-foreground">Turn {turn.turnNumber}</span>
-            <span className="text-caption tabular-nums text-text-secondary">{turn.events.length} events</span>
-            {turn.hasError && (
-              <span className={cn(BADGE_BASE, "shrink-0 bg-red-500/10 text-red-600 dark:text-red-400")}>
-                error
-              </span>
-            )}
-          </span>
-          {/* 摘要标题（独占整行，折叠态快速了解 Turn 内容；溢出截断 + 全文 tooltip） */}
-          <span className="block truncate pl-5 text-body font-medium text-text-secondary" title={title}>
+          <ChevronRight
+            className={cn("h-3.5 w-3.5 shrink-0 text-text-muted transition-transform", !collapsed && "rotate-90")}
+            aria-hidden
+          />
+          {showHeader && (
+            <span className="text-xs font-semibold text-violet-600 dark:text-violet-400">
+              Claude Code
+            </span>
+          )}
+          <span className="text-sm font-semibold text-foreground">Turn {turn.turnNumber}</span>
+          <span className="text-caption tabular-nums text-text-secondary">{turn.events.length} events</span>
+          {turn.hasError && (
+            <span className={cn(BADGE_BASE, "shrink-0 bg-red-500/10 text-red-600 dark:text-red-400")}>
+              error
+            </span>
+          )}
+          {/* 摘要标题（占据剩余空间，溢出截断 + 全文 tooltip） */}
+          <span className="min-w-0 flex-1 truncate text-body font-medium text-text-secondary" title={title}>
             {title}
           </span>
         </button>


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Turn 气泡的序号行与摘要标题行分占两行，垂直空间浪费；Turns 间距与气泡内边距偏大，信息密度不足
- 关联上下文：承接 #881（全过程视图重构）的后续 UI 优化

# 核心变更
- **Turn 单行化**：将折叠态的「Turn N · X events」行与摘要标题行合并为同一行，摘要紧跟 events 计数右侧，溢出截断 + tooltip 全文
- **间距紧凑化**：对话流 `space-y-2.5` → `space-y-1`、同组 Turn `space-y-2` → `space-y-[3px]`，约为原来 1/3
- **内边距紧凑化**：Turn 气泡 `p-3` (12px) → `p-1` (4px)，约为原来 1/3

# 风险与回滚
- 主要风险：纯 UI 样式调整，无逻辑变更，风险极低
- 回滚方式：`git revert` 单个 commit 即可

# 验证证据
- 单元测试：无逻辑变更，无新增测试
- E2E/Workflow：浏览器实机验证 Iteration #3 全过程视图，确认单行显示与紧凑间距效果
- 覆盖率/关键截图：Turn 1~12 均正确显示为 `Turn N X events 摘要标题` 单行格式

# 影响范围
- 前端：`IterationEventTimeline.tsx`（1 文件，24 行变更）
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 深色模式下验证对比度与可读性