### PR TITLE
feat(RoutineIterationView): Iteration 视图文本 Markdown 渲染化

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -13,6 +13,7 @@ import {
   type RoutineIterationEventDTO,
 } from "@/features/routine";
 
+import { MarkdownText } from "./MarkdownText";
 import {
   EVENT_GROUP_LABEL,
   type EventGroup,
@@ -506,10 +507,10 @@ function EngineReviewBubble({ ev, showHeader = true }: { ev: RoutineIterationEve
           </div>
         )}
 
-        {/* 反馈文本 */}
+        {/* 反馈文本（Markdown 渲染） */}
         {feedback && (
-          <div className="mt-2 rounded-md border border-border bg-muted/30 p-2 text-caption leading-caption text-text-secondary">
-            {feedback}
+          <div className="mt-2 rounded-md border border-border bg-muted/30 p-2">
+            <MarkdownText content={feedback} />
           </div>
         )}
 
@@ -525,7 +526,7 @@ function EngineReviewBubble({ ev, showHeader = true }: { ev: RoutineIterationEve
           </button>
         )}
         {expanded && reflection && (
-          <p className="mt-1 text-caption italic leading-caption text-text-secondary">{reflection}</p>
+          <MarkdownText content={reflection} className="mt-1 italic" />
         )}
 
         {/* 详情（raw payload） */}
@@ -663,7 +664,9 @@ function EngineEventBubble({ ev, label, showHeader = true }: { ev: RoutineIterat
               </div>
             )}
             {resultText && (
-              <div className="mt-1 line-clamp-3 text-caption leading-caption text-text-secondary">{resultText}</div>
+              <div className="mt-1 line-clamp-3">
+                <MarkdownText content={resultText} />
+              </div>
             )}
           </>
         )}
@@ -704,7 +707,7 @@ function EngineEventBubble({ ev, label, showHeader = true }: { ev: RoutineIterat
               </button>
             )}
             {reflectionOpen && reflection && (
-              <p className="mt-1 text-caption italic leading-caption text-text-secondary">{reflection}</p>
+              <MarkdownText content={reflection} className="mt-1 italic" />
             )}
           </>
         )}
@@ -877,16 +880,27 @@ function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
   );
 }
 
-/** 长文本字段（直接渲染为可读 pre，而非 JSON 字符串字面量）。 */
-const TEXT_FIELDS = ["text", "output", "result", "prompt", "raw", "reflection", "command"] as const;
+/** 长文本字段 —— 以 Markdown 渲染（人类可读文本）。 */
+const MARKDOWN_FIELDS = new Set(["text", "reflection"]);
+
+/** 长文本字段 —— 以等宽 pre 渲染（代码/命令/原始输出）。 */
+const PREFORMATTED_FIELDS = new Set(["output", "result", "prompt", "raw", "command"]);
+
+/** 所有长文本字段（用于从 payload 中提取）。 */
+const ALL_TEXT_FIELDS = new Set([...MARKDOWN_FIELDS, ...PREFORMATTED_FIELDS]);
 
 function EventDetail({ payload }: { payload: Record<string, unknown> }) {
   // 拆出长文本字段单独渲染（可读性优于 JSON 字面量），其余结构化字段交给 JsonViewer。
-  const textBlocks: Array<{ key: string; value: string }> = [];
+  const markdownBlocks: Array<{ key: string; value: string }> = [];
+  const preformattedBlocks: Array<{ key: string; value: string }> = [];
   const rest: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(payload)) {
-    if ((TEXT_FIELDS as readonly string[]).includes(k) && typeof v === "string" && v.length > 0) {
-      textBlocks.push({ key: k, value: v });
+    if (ALL_TEXT_FIELDS.has(k) && typeof v === "string" && v.length > 0) {
+      if (MARKDOWN_FIELDS.has(k)) {
+        markdownBlocks.push({ key: k, value: v });
+      } else {
+        preformattedBlocks.push({ key: k, value: v });
+      }
     } else if (v !== null && v !== undefined && v !== "") {
       rest[k] = v;
     }
@@ -894,7 +908,15 @@ function EventDetail({ payload }: { payload: Record<string, unknown> }) {
 
   return (
     <>
-      {textBlocks.map(({ key, value }) => (
+      {markdownBlocks.map(({ key, value }) => (
+        <div key={key}>
+          <div className="mb-1 text-micro font-medium uppercase tracking-overline text-text-secondary">{key}</div>
+          <div className="max-h-72 overflow-auto rounded-md border border-border bg-muted/40 p-2">
+            <MarkdownText content={value} />
+          </div>
+        </div>
+      ))}
+      {preformattedBlocks.map(({ key, value }) => (
         <div key={key}>
           <div className="mb-1 text-micro font-medium uppercase tracking-overline text-text-secondary">{key}</div>
           <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 p-2 font-mono text-caption leading-relaxed text-text-secondary">

--- a/apps/negentropy-ui/app/interface/routine/_components/MarkdownText.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/MarkdownText.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+
+import { cn } from "@/lib/utils";
+import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
+
+// ---------------------------------------------------------------------------
+// 样式常量 —— Tailwind arbitrary variants 覆盖 Markdown 各元素
+// 字号基准 text-[11px]（text-caption），与 Iteration 视图一致
+// 参考 McpServerCard.tsx 的 MARKDOWN_CONTENT_CLASS 模式
+// ---------------------------------------------------------------------------
+
+const MARKDOWN_TEXT_CLASS = [
+  "overflow-hidden break-words whitespace-normal text-[11px] leading-[1.6] text-text-secondary",
+
+  // 段落
+  "[&_p]:my-0",
+  "[&_p+*]:mt-2",
+
+  // 标题
+  "[&_h1]:text-sm [&_h1]:font-bold [&_h1]:tracking-heading [&_h1]:mb-1.5 [&_h1]:mt-3 [&_h1]:text-foreground",
+  "[&_h2]:text-xs [&_h2]:font-bold [&_h2]:tracking-heading [&_h2]:mb-1.5 [&_h2]:mt-2.5 [&_h2]:text-foreground",
+  "[&_h3]:text-[11px] [&_h3]:font-semibold [&_h3]:mb-1 [&_h3]:mt-2 [&_h3]:text-foreground",
+  "[&_h1+*]:mt-1 [&_h2+*]:mt-1 [&_h3+*]:mt-1",
+
+  // 列表
+  "[&_ul]:list-disc [&_ul]:space-y-0.5 [&_ul]:pl-4",
+  "[&_ol]:list-decimal [&_ol]:space-y-0.5 [&_ol]:pl-4",
+  "[&_li]:leading-snug",
+
+  // 行内代码
+  "[&_code]:rounded [&_code]:bg-muted/60 [&_code]:px-1 [&_code]:py-px [&_code]:font-mono [&_code]:text-[0.9em]",
+
+  // 代码块
+  "[&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted/40 [&_pre]:p-2 [&_pre]:text-[11px]",
+  "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
+
+  // 表格
+  "[&_table]:my-2 [&_table]:w-full [&_table]:border-collapse [&_table]:text-[10px]",
+  "[&_thead]:bg-muted/40",
+  "[&_th]:border [&_th]:border-border [&_th]:px-1.5 [&_th]:py-1 [&_th]:text-left [&_th]:font-semibold [&_th]:text-text-secondary",
+  "[&_td]:border [&_td]:border-border [&_td]:px-1.5 [&_td]:py-1 [&_td]:align-top",
+
+  // 链接
+  "[&_a]:text-sky-600 [&_a]:underline [&_a]:underline-offset-2 dark:[&_a]:text-sky-400",
+
+  // 引用
+  "[&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-text-muted",
+
+  // 分割线
+  "[&_hr]:my-2 [&_hr]:border-border",
+].join(" ");
+
+// ---------------------------------------------------------------------------
+// 组件
+// ---------------------------------------------------------------------------
+
+interface MarkdownTextProps {
+  content: string;
+  className?: string;
+}
+
+/**
+ * 轻量 Markdown 渲染组件，专为 Routine Iteration 视图的文本字段设计。
+ *
+ * 复用全局 remark/rehype 插件链（GFM + 数学公式），
+ * 字号基准 text-[11px]，通过 Tailwind arbitrary variants 样式化输出。
+ */
+export function MarkdownText({ content, className }: MarkdownTextProps) {
+  if (!content) return null;
+
+  return (
+    <div className={cn(MARKDOWN_TEXT_CLASS, className)}>
+      <ReactMarkdown remarkPlugins={defaultRemarkPlugins} rehypePlugins={defaultRehypePlugins}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -7,6 +7,7 @@ import type { RoutineIterationDTO } from "@/features/routine";
 import { AGENT_ROLE_META, deriveIterationDriver } from "@/features/routine";
 
 import { LiveElapsed, StaticDuration } from "./ElapsedClock";
+import { MarkdownText } from "./MarkdownText";
 import { ACTIVE_TIMING } from "./routine-loop";
 import { iterationDotClass, phaseClass, phaseLabel, scoreColorClass, verdictClass } from "./status-style";
 
@@ -143,12 +144,12 @@ function IterationCard({
         </div>
       )}
 
-      {/* 执行摘要 */}
+      {/* 执行摘要（Markdown 渲染） */}
       {it.summary && (
-        <p
-          className={`${it.phase === "plan" ? "mt-1" : "mt-2"} whitespace-pre-wrap break-words text-[11px] text-text-secondary`}
-        >
-          {expanded || it.summary.length <= 280 ? it.summary : `${it.summary.slice(0, 280)}…`}
+        <div className={it.phase === "plan" ? "mt-1" : "mt-2"}>
+          <MarkdownText
+            content={expanded || it.summary.length <= 280 ? it.summary : `${it.summary.slice(0, 280)}…`}
+          />
           {it.summary.length > 280 && (
             <button
               onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
@@ -157,7 +158,7 @@ function IterationCard({
               {expanded ? "收起" : "展开"}
             </button>
           )}
-        </p>
+        </div>
       )}
 
       {/* 执行失败信息 */}
@@ -167,11 +168,12 @@ function IterationCard({
         </pre>
       )}
 
-      {/* 评估反思 */}
+      {/* 评估反思（Markdown 渲染） */}
       {it.reflection && (
-        <p className="mt-2 rounded bg-muted/40 p-2 text-[11px] italic text-text-secondary">
-          💡 {it.reflection}
-        </p>
+        <div className="mt-2 rounded bg-muted/40 p-2">
+          <span className="mr-1">💡</span>
+          <MarkdownText content={it.reflection} className="[&_p]:inline" />
+        </div>
       )}
 
       {/* 指标行 */}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 任务详情页 Iteration 区域的文本内容（summary、reflection、feedback、result 等）以纯文本形式展示，Markdown 格式的表格、标题、列表等无法正确渲染，可读性差。
- 关联上下文/Issue/文档：用户反馈截图显示 #3 Iteration 中的 Markdown 表格、标题等内容应渲染为富文本。

# 核心变更
- **新建 `MarkdownText` 组件**（`_components/MarkdownText.tsx`）：封装 `react-markdown` + `remark-gfm` + `remark-math` + `rehype-katex`，采用 Tailwind arbitrary variants 样式方案，字号基准 `text-[11px]` 与 Iteration 视图一致
- **`RoutineIterationTimeline`**：summary、reflection 字段从纯 `<p>` 替换为 `MarkdownText` 渲染，保留展开/收起逻辑
- **`IterationEventTimeline`**：feedback、reflection、resultText 替换为 `MarkdownText` 渲染
- **EventDetail 字段分流**：`text`/`reflection` 走 Markdown 渲染，`output`/`command`/`raw`/`prompt`/`result` 保持 `<pre>` 等宽渲染

# 风险与回滚
- 主要风险：部分旧数据的文本内容可能不是合法 Markdown，渲染后可能出现意外的格式化效果（如未转义的 `#`、`|` 等字符被误解析）
- 回滚方式：`git revert` 该 commit 即可恢复纯文本渲染

# 验证证据
- 单元测试：无新增（纯 UI 渲染变更）
- 集成测试：ESLint + Next.js lint + TypeScript 编译均通过
- E2E/Workflow：需在浏览器中访问 Routine 详情页验证 Markdown 渲染效果
- 覆盖率/关键截图：待手动验证

# 影响范围
- 前端：`negentropy-ui` → Routine 模块的 Iteration 卡片、审计抽屉中的文本展示
- 后端：无
- GitHub Actions / 文档：无

# Next Best Action
- 在浏览器中验证 Routine 详情页各文本字段的 Markdown 渲染效果，确认表格、标题、列表等格式正确展示