### PR TITLE
style(RoutineDetail): 重构 Routine 详情页排版可读性——清除超小字号、提升对比度、强化布局层次

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -116,67 +116,72 @@ export default function RoutineRunPage() {
       <InterfaceNav title="Routine" />
       <div className="flex-1 overflow-auto">
         <ClockProvider active={!!clockActive}>
-          <div className="space-y-4 px-6 py-6">
-            {/* 头部：返回 + 标题 + 状态 + 控制 */}
-            <div className="flex items-center justify-between gap-3">
-              <div className="flex min-w-0 items-center gap-3">
-                <Link
-                  href="/interface/routine"
-                  aria-label="返回 Routine 列表"
-                  className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-                >
-                  <ArrowLeft className="h-4 w-4" />
-                </Link>
-                <div className="min-w-0">
-                  <h1 className="truncate text-xl font-bold text-foreground">
-                    {routine?.display_name || routine?.title || "Routine"}
-                  </h1>
-                  {routine?.key && <p className="truncate text-[11px] text-text-muted">{routine.key}</p>}
+          <div className="space-y-6 px-8 py-8">
+            {/* 头部：返回 + 标题 + 状态 + 控制（双行结构） */}
+            <div className="border-b border-border pb-5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <Link
+                    href="/interface/routine"
+                    aria-label="返回 Routine 列表"
+                    className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                  </Link>
+                  <div className="min-w-0">
+                    <h1 className="truncate text-xl font-bold text-foreground">
+                      {routine?.display_name || routine?.title || "Routine"}
+                    </h1>
+                  </div>
+                  {routine && (
+                    <span
+                      className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(routine.status)}`}
+                    >
+                      {routine.status}
+                    </span>
+                  )}
+                  {routine?.current_phase && routine.status === "running" && (
+                    <span
+                      className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${phaseClass(routine.current_phase)}`}
+                    >
+                      {phaseLabel(routine.current_phase)}
+                    </span>
+                  )}
                 </div>
-                {routine && (
-                  <span
-                    className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(routine.status)}`}
-                  >
-                    {routine.status}
-                  </span>
-                )}
-                {routine?.current_phase && routine.status === "running" && (
-                  <span
-                    className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${phaseClass(routine.current_phase)}`}
-                  >
-                    {phaseLabel(routine.current_phase)}
-                  </span>
-                )}
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <span className="flex shrink-0 items-center gap-1.5 text-xs text-text-secondary">
                   <span
                     className={`inline-block h-2 w-2 rounded-full ${connected ? "bg-emerald-500" : "animate-pulse bg-text-muted"}`}
                   />
                   {connected ? "Live" : "Reconnecting..."}
                 </span>
-                {controls.map((action) => (
-                  <Button
-                    key={action}
-                    variant={action === "cancel" ? "danger" : "neutral"}
-                    size="sm"
-                    disabled={busy}
-                    onClick={() => handleControl(action)}
-                  >
-                    {CONTROL_LABEL[action]}
-                  </Button>
-                ))}
-                {routine && canRestart(routine.status) && (
-                  <Button
-                    variant="primary"
-                    size="sm"
-                    disabled={busy}
-                    leftIcon={<RotateCcw className="h-4 w-4" />}
-                    onClick={() => requestRestart(routine)}
-                  >
-                    Restart
-                  </Button>
-                )}
+              </div>
+              <div className="mt-1.5 flex items-center justify-between gap-3">
+                {routine?.key && <p className="truncate font-mono text-xs text-text-secondary">{routine.key}</p>}
+                <div className="flex-1" />
+                <div className="flex shrink-0 items-center gap-2">
+                  {controls.map((action) => (
+                    <Button
+                      key={action}
+                      variant={action === "cancel" ? "danger" : "neutral"}
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => handleControl(action)}
+                    >
+                      {CONTROL_LABEL[action]}
+                    </Button>
+                  ))}
+                  {routine && canRestart(routine.status) && (
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      disabled={busy}
+                      leftIcon={<RotateCcw className="h-4 w-4" />}
+                      onClick={() => requestRestart(routine)}
+                    >
+                      Restart
+                    </Button>
+                  )}
+                </div>
               </div>
             </div>
 

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -24,7 +24,7 @@ import { phaseClass, phaseLabel, scoreColorClass, verdictClass } from "./status-
 const IN_FLIGHT_STATUSES = new Set(["pending_approval", "dispatched", "in_flight", "executed"]);
 
 /** 元信息条统一胶囊基类（phase / verdict / 主导人 / driver 共用，与时间线徽章同形）。 */
-const PILL = "rounded-full px-2 py-0.5 text-micro font-semibold";
+const PILL = "rounded-full px-2.5 py-0.5 text-xs font-semibold";
 
 interface IterationAuditDrawerProps {
   open: boolean;
@@ -112,7 +112,7 @@ export function IterationAuditDrawer({
       subtitle={iteration ? <IterationMetaBar iteration={iteration} roleCounts={roleCounts} /> : undefined}
       widthClassName="[width:clamp(480px,66.67%,1100px)]"
     >
-      <div className="px-5 py-4">
+      <div className="px-6 py-5">
         {error && <ErrorBanner message={error} onRetry={load} />}
 
         {/* MCP Server/Tool 面板 — 从系统 MCP API 实时获取已启用的 Server 及 Tools（含 .mcp.json 合并） */}
@@ -144,13 +144,13 @@ function IterationMetaBar({
 }) {
   const driver = deriveIterationDriver(iteration.status);
   return (
-    <span className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+    <span className="flex flex-wrap items-center gap-x-2.5 gap-y-2">
       {iteration.phase && (
         <span className={`${PILL} ${phaseClass(iteration.phase)}`}>
           {phaseLabel(iteration.phase)}
         </span>
       )}
-      <span className="text-caption font-medium text-text-secondary">{iteration.status}</span>
+      <span className="text-xs font-medium text-text-secondary">{iteration.status}</span>
       {iteration.verdict && (
         <span className={`${PILL} ${verdictClass(iteration.verdict)}`}>
           {iteration.verdict}
@@ -160,8 +160,8 @@ function IterationMetaBar({
         <span className={`text-sm font-bold tabular-nums ${scoreColorClass(iteration.score)}`}>{iteration.score}</span>
       )}
       <span className="text-text-muted">·</span>
-      <span className="text-caption tabular-nums text-text-secondary">turns {iteration.turn_count}</span>
-      <span className="text-caption tabular-nums text-text-secondary">${iteration.cost_usd.toFixed(4)}</span>
+      <span className="text-xs tabular-nums text-text-secondary">turns {iteration.turn_count}</span>
+      <span className="text-xs tabular-nums text-text-secondary">${iteration.cost_usd.toFixed(4)}</span>
       {/* 主导人摘要 pill 列表 */}
       {roleCounts.length > 0 && (
         <>
@@ -190,7 +190,7 @@ function IterationMetaBar({
       {iteration.claude_session_id && (
         <>
           <span className="text-text-muted">·</span>
-          <span className="truncate font-mono text-caption text-text-secondary" title={iteration.claude_session_id}>
+          <span className="truncate font-mono text-xs text-text-secondary" title={iteration.claude_session_id}>
             {iteration.claude_session_id.slice(0, 8)}
           </span>
         </>
@@ -206,7 +206,7 @@ function EmptyState({ iteration }: { iteration: RoutineIterationDTO | null }) {
   else if (iteration?.status === "aborted") hint = "该迭代已中止，未捕获动作记录。";
   else if (iteration?.status === "reaped") hint = "该迭代因执行超时被回收，未捕获完整动作记录。";
   return (
-    <div className="rounded-card border border-dashed border-border bg-card py-12 text-center text-sm text-text-muted">
+    <div className="rounded-card border border-dashed border-border bg-card py-12 text-center text-sm text-text-secondary">
       {hint}
     </div>
   );

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -32,9 +32,9 @@ import {
 // ---------------------------------------------------------------------------
 
 /** 统一徽章胶囊基类（error / verdict / result / gate / evaluation / 统计 pill 共用）。 */
-const BADGE_BASE = "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-micro font-semibold";
-/** 三级元信息字样（时间戳 / seq# / cost / 计数）：caption 字号 + 次级对比度 + 等宽数字。 */
-const META_TEXT = "shrink-0 text-caption tabular-nums text-text-secondary";
+const BADGE_BASE = "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold";
+/** 三级元信息字样（时间戳 / seq# / cost / 计数）：xs 字号 + 次级对比度 + 等宽数字。 */
+const META_TEXT = "shrink-0 text-xs tabular-nums text-text-secondary";
 
 // ---------------------------------------------------------------------------
 // Turn（轮次）聚合 —— 将执行阶段事件按 Claude Code 的 Turn 边界分组
@@ -257,7 +257,7 @@ export function IterationEventTimeline({
   }
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-2">
       {/* 分组统计栏 */}
       <div className="flex flex-wrap items-center gap-2">
         {(["execution", "plan_review", "result", "gate", "evaluation"] as const).map((g) => {
@@ -282,7 +282,7 @@ export function IterationEventTimeline({
       </div>
 
       {/* 对话流（按同发言人聚合） */}
-      <div className="space-y-1">
+      <div className="space-y-2">
         {speakerGroups.map((group) => (
           <SpeakerGroupBubble key={group.id} group={group} />
         ))}
@@ -670,7 +670,7 @@ function EngineEventBubble({ ev, label, showHeader = true }: { ev: RoutineIterat
           <>
             {command && (
               <div className="rounded-md border border-border bg-muted/30 p-2 font-mono text-caption text-text-secondary">
-                <span className="text-micro font-medium uppercase tracking-overline text-text-secondary">$ </span>
+                <span className="text-caption font-medium uppercase tracking-overline text-text-secondary">$ </span>
                 {command}
               </div>
             )}
@@ -843,7 +843,7 @@ function EventRow({ ev }: { ev: RoutineIterationEventDTO }) {
             <span
               className={`inline-block h-1.5 w-1.5 rounded-full ${taskStatusDotClass(taskStatus)}`}
             />
-            <span className="text-micro font-medium text-text-secondary">{taskStatusLabel(taskStatus)}</span>
+            <span className="text-caption font-medium text-text-secondary">{taskStatusLabel(taskStatus)}</span>
           </span>
         )}
         {isError && (
@@ -893,7 +893,7 @@ function EventDetail({ payload }: { payload: Record<string, unknown> }) {
     <>
       {textBlocks.map(({ key, value }) => (
         <div key={key}>
-          <div className="mb-1 text-micro font-medium uppercase tracking-overline text-text-secondary">{key}</div>
+          <div className="mb-1 text-caption font-medium uppercase tracking-overline text-text-secondary">{key}</div>
           <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/40 p-2 font-mono text-caption leading-relaxed text-text-secondary">
             {value}
           </pre>

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -257,7 +257,7 @@ export function IterationEventTimeline({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-1">
       {/* 分组统计栏 */}
       <div className="flex flex-wrap items-center gap-2">
         {(["execution", "plan_review", "result", "gate", "evaluation"] as const).map((g) => {
@@ -282,7 +282,7 @@ export function IterationEventTimeline({
       </div>
 
       {/* 对话流（按同发言人聚合） */}
-      <div className="space-y-2.5">
+      <div className="space-y-1">
         {speakerGroups.map((group) => (
           <SpeakerGroupBubble key={group.id} group={group} />
         ))}
@@ -353,7 +353,7 @@ function SpeakerGroupBubble({ group }: { group: SpeakerGroup }) {
         </div>
       </div>
       {/* 聚合内容区 */}
-      <div className="min-w-0 max-w-[85%] space-y-2">
+      <div className="min-w-0 max-w-[85%] space-y-[3px]">
         {/* 统一发言人标签 */}
         <div className="flex items-center gap-2 px-1">
           <span className={cn(
@@ -396,40 +396,37 @@ function ClaudeCodeTurnBubble({
       {/* 气泡内容 */}
       <div
         className={cn(
-          "min-w-0 rounded-2xl border p-3 shadow-sm transition-colors",
+          "min-w-0 rounded-2xl border p-1 shadow-sm transition-colors",
           showHeader ? "max-w-[85%] rounded-tl-sm" : "w-full",
           turn.hasError
             ? "border-red-500/30 bg-red-500/[0.03]"
             : "border-border bg-card",
         )}
       >
-        {/* 可点击的折叠 Header */}
+        {/* 可点击的折叠 Header（单行：箭头 · 发言人 · Turn N · 事件数 · error · 摘要标题） */}
         <button
           type="button"
           onClick={() => setCollapsed((v) => !v)}
-          className="-mx-1 flex w-full flex-col gap-1 rounded-lg px-1 py-0.5 text-left transition-colors hover:bg-muted/40"
+          className="-mx-1 flex w-full items-center gap-2 rounded-lg px-1 py-0.5 text-left transition-colors hover:bg-muted/40"
         >
-          {/* 元信息行：折叠箭头 · 发言人 · Turn N · 事件数 · error 徽章 */}
-          <span className="flex w-full items-center gap-2">
-            <ChevronRight
-              className={cn("h-3.5 w-3.5 shrink-0 text-text-muted transition-transform", !collapsed && "rotate-90")}
-              aria-hidden
-            />
-            {showHeader && (
-              <span className="text-xs font-semibold text-violet-600 dark:text-violet-400">
-                Claude Code
-              </span>
-            )}
-            <span className="text-sm font-semibold text-foreground">Turn {turn.turnNumber}</span>
-            <span className="text-caption tabular-nums text-text-secondary">{turn.events.length} events</span>
-            {turn.hasError && (
-              <span className={cn(BADGE_BASE, "shrink-0 bg-red-500/10 text-red-600 dark:text-red-400")}>
-                error
-              </span>
-            )}
-          </span>
-          {/* 摘要标题（独占整行，折叠态快速了解 Turn 内容；溢出截断 + 全文 tooltip） */}
-          <span className="block truncate pl-5 text-body font-medium text-text-secondary" title={title}>
+          <ChevronRight
+            className={cn("h-3.5 w-3.5 shrink-0 text-text-muted transition-transform", !collapsed && "rotate-90")}
+            aria-hidden
+          />
+          {showHeader && (
+            <span className="text-xs font-semibold text-violet-600 dark:text-violet-400">
+              Claude Code
+            </span>
+          )}
+          <span className="text-sm font-semibold text-foreground">Turn {turn.turnNumber}</span>
+          <span className="text-caption tabular-nums text-text-secondary">{turn.events.length} events</span>
+          {turn.hasError && (
+            <span className={cn(BADGE_BASE, "shrink-0 bg-red-500/10 text-red-600 dark:text-red-400")}>
+              error
+            </span>
+          )}
+          {/* 摘要标题（占据剩余空间，溢出截断 + 全文 tooltip） */}
+          <span className="min-w-0 flex-1 truncate text-body font-medium text-text-secondary" title={title}>
             {title}
           </span>
         </button>

--- a/apps/negentropy-ui/app/interface/routine/_components/McpServersPanel.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/McpServersPanel.tsx
@@ -117,7 +117,7 @@ export function McpServersPanel({ projectPath }: McpServersPanelProps) {
       <div className="rounded-xl border border-border bg-muted/30 p-3">
         <div className="flex items-center gap-1.5">
           <span className="text-sm font-semibold text-violet-600 dark:text-violet-400">MCP Servers</span>
-          <span className="text-[10px] text-text-muted animate-pulse">加载中…</span>
+          <span className="text-xs text-text-secondary animate-pulse">加载中…</span>
         </div>
       </div>
     );
@@ -131,7 +131,7 @@ export function McpServersPanel({ projectPath }: McpServersPanelProps) {
       {/* Header */}
       <div className="mb-2 flex items-center gap-1.5">
         <span className="text-sm font-semibold text-violet-600 dark:text-violet-400">MCP Servers</span>
-        <span className="text-[10px] text-text-muted">
+        <span className="text-xs text-text-secondary">
           ({servers.length}) · {totalTools} Tools
         </span>
       </div>
@@ -162,13 +162,13 @@ export function McpServersPanel({ projectPath }: McpServersPanelProps) {
                 <span className="font-mono font-medium text-text-secondary">{server.name}</span>
 
                 {/* Transport type pill */}
-                <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-1.5 py-px text-[10px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
+                <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-2.5 py-px text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
                   {transportLabel(server.transport_type)}
                 </span>
 
                 {/* Source badge */}
                 <span
-                  className={`inline-flex shrink-0 items-center rounded-full px-1.5 py-px text-[10px] font-medium ${
+                  className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-px text-xs font-medium ${
                     isMcpJson
                       ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
                       : source === "both"
@@ -181,18 +181,18 @@ export function McpServersPanel({ projectPath }: McpServersPanelProps) {
 
                 {/* Display name (if different from name) */}
                 {server.display_name && server.display_name !== server.name && (
-                  <span className="truncate text-[10px] text-text-muted">— {server.display_name}</span>
+                  <span className="truncate text-xs text-text-secondary">— {server.display_name}</span>
                 )}
 
                 {/* Tool count */}
-                <span className="ml-auto shrink-0 text-[10px] tabular-nums text-text-muted">
+                <span className="ml-auto shrink-0 text-xs tabular-nums text-text-secondary">
                   {isMcpJson ? "runtime" : tools.length > 0 ? `${tools.length} tools` : `${server.tool_count} tools`}
                 </span>
               </summary>
 
               {/* Tool list — .mcp.json 服务器显示提示，DB 服务器展示 tools */}
               {isMcpJson ? (
-                <p className="ml-4.5 pb-1 text-[10px] text-text-muted">
+                <p className="ml-4.5 pb-1 text-xs text-text-secondary">
                   Tools discoverable at runtime by Claude Code (not registered in system catalog)
                 </p>
               ) : tools.length > 0 ? (
@@ -207,7 +207,7 @@ export function McpServersPanel({ projectPath }: McpServersPanelProps) {
                         {label}
                         {/* Hover tooltip for description */}
                         {tool.description && (
-                          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-1.5 hidden max-w-72 -translate-x-1/2 rounded-lg border border-border bg-card/95 px-2.5 py-1.5 text-[10px] leading-relaxed text-text-secondary shadow-lg backdrop-blur group-hover/tool:block">
+                          <span className="pointer-events-none absolute left-1/2 top-full z-20 mt-1.5 hidden max-w-72 -translate-x-1/2 rounded-lg border border-border bg-card/95 px-2.5 py-1.5 text-xs leading-relaxed text-text-secondary shadow-lg backdrop-blur group-hover/tool:block">
                             {tool.description}
                           </span>
                         )}
@@ -216,7 +216,7 @@ export function McpServersPanel({ projectPath }: McpServersPanelProps) {
                   })}
                 </div>
               ) : (
-                <p className="ml-4.5 pb-1 text-[10px] text-text-muted">
+                <p className="ml-4.5 pb-1 text-xs text-text-secondary">
                   {server.tool_count > 0
                     ? `${server.tool_count} 个工具已注册（点击展开加载详情）`
                     : "无已发现的工具"}

--- a/apps/negentropy-ui/app/interface/routine/_components/ReflectionFlow.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/ReflectionFlow.tsx
@@ -32,10 +32,10 @@ export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO
   if (items.length === 0) {
     return (
       <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-        <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">
           反思记忆流 · Reflexion
         </h3>
-        <p className="py-4 text-center text-[11px] text-text-muted">暂无反思记录</p>
+        <p className="py-4 text-center text-sm text-text-secondary">暂无反思记录</p>
       </section>
     );
   }
@@ -46,7 +46,7 @@ export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="group flex w-full items-center justify-between gap-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+        className="group flex w-full items-center justify-between gap-2 text-xs uppercase tracking-overline text-text-secondary transition-colors hover:text-foreground"
       >
         <span>反思记忆流 · Reflexion（reflection → 下轮 prompt）</span>
         <ChevronDown
@@ -61,17 +61,17 @@ export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO
         <ol className="mt-3 space-y-3">
           {items.map(({ it, next }) => (
             <li key={it.id} className="rounded-lg border border-border p-2.5">
-              <div className="flex items-center gap-2 text-[11px]">
+              <div className="flex items-center gap-2 text-xs">
                 <span className="font-semibold text-foreground">#{it.seq}</span>
                 {it.verdict && (
-                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${verdictClass(it.verdict)}`}>
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${verdictClass(it.verdict)}`}>
                     {it.verdict}
                   </span>
                 )}
               </div>
-              <p className="mt-1 text-[11px] italic text-text-secondary">💡 {it.reflection}</p>
+              <p className="mt-1 text-caption italic text-text-secondary">💡 {it.reflection}</p>
               {next?.prompt && (
-                <div className="mt-2 flex items-start gap-1.5 rounded bg-muted/40 p-2 text-[10px] text-text-muted">
+                <div className="mt-2 flex items-start gap-1.5 rounded bg-muted/40 p-2 text-xs text-text-secondary">
                   <CornerDownRight className="mt-0.5 h-3 w-3 shrink-0 text-primary" aria-hidden />
                   <span className="min-w-0">
                     注入 <span className="font-medium text-text-secondary">#{next.seq}</span> 提示：{head(next.prompt)}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
@@ -35,7 +35,7 @@ function ConvergenceTooltip({ active, payload }: { active?: boolean; payload?: T
   const row = payload[0]?.payload;
   if (!row) return null;
   return (
-    <div className="rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] shadow-md">
+    <div className="rounded-md border border-border bg-card px-2.5 py-1.5 text-xs shadow-md">
       <div className="font-semibold text-foreground">迭代 #{row.seq}</div>
       <div className="text-text-secondary">score: {row.score ?? "—"}</div>
       {row.verdict && <div className="text-text-secondary">verdict: {row.verdict}</div>}
@@ -68,7 +68,7 @@ export function RoutineConvergenceChart({
   return (
     <CollapsibleSection title="评分收敛趋势 · Convergence">
       {!hasScores ? (
-        <p className="py-8 text-center text-[11px] text-text-muted">尚无评分数据</p>
+        <p className="py-8 text-center text-sm text-text-secondary">尚无评分数据</p>
       ) : (
         <div className="h-56 min-h-[14rem] w-full" style={{ minWidth: 1 }}>
           <ResponsiveContainer width="100%" height="100%">
@@ -80,17 +80,17 @@ export function RoutineConvergenceChart({
                 domain={["dataMin", "dataMax"]}
                 allowDecimals={false}
                 stroke="currentColor"
-                fontSize={11}
+                fontSize={12}
                 tickFormatter={(v) => `#${v}`}
               />
-              <YAxis domain={[0, 100]} ticks={[0, 25, 50, 75, 100]} stroke="currentColor" fontSize={11} />
+              <YAxis domain={[0, 100]} ticks={[0, 25, 50, 75, 100]} stroke="currentColor" fontSize={12} />
               <Tooltip content={<ConvergenceTooltip />} />
               <ReferenceLine
                 y={threshold}
                 stroke="#10b981"
                 strokeDasharray="4 4"
                 strokeOpacity={0.7}
-                label={{ value: `阈值 ${threshold}`, position: "right", fontSize: 10, fill: "#10b981" }}
+                label={{ value: `阈值 ${threshold}`, position: "right", fontSize: 12, fill: "#10b981" }}
               />
               {bestScore != null && (
                 <ReferenceLine y={bestScore} stroke="#6366f1" strokeDasharray="2 4" strokeOpacity={0.6} />

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -517,7 +517,7 @@ export function RoutineEditDrawer({
   // 字段级错误渲染助手（普通函数，非组件 —— 避免 render 期创建组件丢失状态）。
   const renderFieldError = (name: string) =>
     fieldErrors[name] ? (
-      <p role="alert" className="mt-0.5 text-[10px] text-red-500">
+      <p role="alert" className="mt-0.5 text-xs text-red-500">
         {fieldErrors[name]}
       </p>
     ) : null;
@@ -543,27 +543,27 @@ export function RoutineEditDrawer({
               </h2>
               {liveRoutine && (
                 <span
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(liveRoutine.status)}`}
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(liveRoutine.status)}`}
                 >
                   {liveRoutine.status}
                 </span>
               )}
               {liveRoutine?.current_phase && liveRoutine.status === "running" && (
                 <span
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${phaseClass(liveRoutine.current_phase)}`}
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${phaseClass(liveRoutine.current_phase)}`}
                 >
                   {phaseLabel(liveRoutine.current_phase)}
                 </span>
               )}
             </div>
-            <p className="mt-0.5 truncate text-[11px] text-text-muted">{subtitle}</p>
+            <p className="mt-0.5 truncate text-xs text-text-secondary">{subtitle}</p>
           </div>
           <div className="flex shrink-0 items-center gap-1">
             {mode.kind === "routine-edit" && onOpenFull && (
               <button
                 type="button"
                 onClick={() => onOpenFull(mode.routine)}
-                className="flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-primary underline-offset-4 transition-colors hover:bg-muted/50 hover:underline"
+                className="flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-primary underline-offset-4 transition-colors hover:bg-muted/50 hover:underline"
               >
                 Full View
                 <ExternalLink className="h-3 w-3" />
@@ -632,11 +632,11 @@ export function RoutineEditDrawer({
                   />
                   {renderFieldError("key")}
                   {isBuiltinTemplate && !fieldErrors.key && (
-                    <p className="mt-0.5 text-[10px] text-text-muted">Saved as a new template — pick a unique key.</p>
+                    <p className="mt-0.5 text-xs text-text-secondary">Saved as a new template — pick a unique key.</p>
                   )}
                 </div>
               ) : (
-                <p className="mt-1 text-[10px] font-mono text-text-muted">key: {form.key}</p>
+                <p className="mt-1 text-xs font-mono text-text-secondary">key: {form.key}</p>
               )}
             </div>
 
@@ -707,7 +707,7 @@ export function RoutineEditDrawer({
                 placeholder="e.g. uv run pytest -q"
                 className={inputCls}
               />
-              <p className="mt-1 text-caption text-text-muted">
+              <p className="mt-1 text-caption text-text-secondary">
                 Test-driven gate — a non-zero exit code caps the score, mitigating LLM-judge bias.
               </p>
             </div>
@@ -832,7 +832,7 @@ export function RoutineEditDrawer({
                             </option>
                           ))}
                         </select>
-                        <p className="mt-1 text-caption text-text-muted">{APPROVAL_HELP[form.approval_mode]}</p>
+                        <p className="mt-1 text-caption text-text-secondary">{APPROVAL_HELP[form.approval_mode]}</p>
                       </div>
                     </div>
                   </div>
@@ -892,7 +892,7 @@ export function RoutineEditDrawer({
                           placeholder="feature 1, feature 2, feature 3"
                           className={inputCls}
                         />
-                        <p className="mt-1 text-caption text-text-muted">
+                        <p className="mt-1 text-caption text-text-secondary">
                           Feature tags shown on the template card (comma-separated).
                         </p>
                       </div>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
@@ -79,17 +79,17 @@ export function RoutineGuardPanel({
 
   return (
     <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-      <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+      <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">
         守卫 / 预算 · Why will it stop?
       </h3>
 
       {isTerminal ? (
-        <div className="mb-3 rounded-lg border border-border bg-muted/40 p-2.5 text-[11px]">
-          <span className="text-text-muted">实际终止原因：</span>
+        <div className="mb-3 rounded-lg border border-border bg-muted/40 p-2.5 text-body">
+          <span className="text-text-secondary">实际终止原因：</span>
           <span className="font-semibold text-foreground">{routine.termination_reason ?? "—"}</span>
         </div>
       ) : predicted ? (
-        <div className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-2.5 text-[11px] text-amber-700 dark:text-amber-300">
+        <div className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-2.5 text-body text-amber-700 dark:text-amber-300">
           ⚠ 预计停因：<span className="font-semibold">{predicted.label}</span>（
           {Math.round(predicted.ratio * 100)}%）
         </div>
@@ -128,7 +128,7 @@ export function RoutineGuardPanel({
 
         {/* 无进展计数 */}
         <div>
-          <div className="flex items-baseline justify-between text-[10px] text-text-muted">
+          <div className="flex items-baseline justify-between text-xs text-text-secondary">
             <span>No-progress（停滞）</span>
             <span className="tabular-nums text-text-secondary">
               {streak} / {routine.no_progress_patience}
@@ -149,12 +149,12 @@ export function RoutineGuardPanel({
       {(oscillation || unrecoverable) && !isTerminal && (
         <div className="mt-3 flex flex-wrap gap-1.5">
           {oscillation && (
-            <span className="rounded-full bg-orange-500/10 px-2 py-0.5 text-[10px] font-semibold text-orange-700 dark:text-orange-300">
+            <span className="rounded-full bg-orange-500/10 px-2 py-0.5 text-xs font-semibold text-orange-700 dark:text-orange-300">
               震荡风险
             </span>
           )}
           {unrecoverable && (
-            <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold text-red-700 dark:text-red-300">
+            <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-semibold text-red-700 dark:text-red-300">
               不可恢复信号
             </span>
           )}
@@ -237,14 +237,14 @@ function SuccessScoreMeter({ routine }: { routine: RoutineDTO }) {
       onBlur={commit}
       onKeyDown={onKeyDown}
       disabled={saving}
-      className="h-4 w-12 rounded border border-border bg-background px-1 text-right text-[10px] tabular-nums text-text-secondary focus:outline-none focus:ring-1 focus:ring-primary"
+      className="h-4 w-12 rounded border border-border bg-background px-1 text-right text-xs tabular-nums text-text-secondary focus:outline-none focus:ring-1 focus:ring-primary"
       autoFocus
     />
   ) : (
     <button
       type="button"
       onClick={openEditor}
-      className="inline-flex items-center gap-0.5 rounded px-1 text-[10px] tabular-nums text-text-secondary transition-colors hover:bg-muted hover:text-foreground"
+      className="inline-flex items-center gap-0.5 rounded px-1 text-xs tabular-nums text-text-secondary transition-colors hover:bg-muted hover:text-foreground"
       title="点击调整 Success Score 阈值"
     >
       阈值 <span className="font-semibold">{threshold}</span>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -33,7 +33,7 @@ export function RoutineIterationTimeline({
   const pageItems = iterations.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
 
   if (iterations.length === 0) {
-    return <p className="text-[11px] text-text-muted">No iterations yet.</p>;
+    return <p className="text-sm text-text-secondary">No iterations yet.</p>;
   }
 
   return (
@@ -44,7 +44,7 @@ export function RoutineIterationTimeline({
         ))}
       </ol>
       {totalPages > 1 && (
-        <div className="mt-3 flex items-center justify-center gap-2 border-t border-border pt-3 text-[11px] text-text-muted">
+        <div className="mt-3 flex items-center justify-center gap-2 border-t border-border pt-3 text-xs text-text-secondary">
           <button
             type="button"
             disabled={safePage <= 0}
@@ -90,10 +90,10 @@ function IterationCard({
   return (
     <li
       onClick={() => onAudit?.(it)}
-      className={`rounded-lg border p-3 transition-colors ${
+      className={`rounded-lg border p-4 transition-colors ${
         onAudit ? "cursor-pointer hover:border-primary/40 hover:bg-muted/30" : ""
       } ${
-        isActive ? "border-sky-400/50 bg-sky-500/[0.03]" : "border-border"
+        isActive ? "border-sky-500/60 bg-sky-500/[0.05] ring-1 ring-sky-500/20" : "border-border"
       }`}
     >
       <div className="flex items-center justify-between">
@@ -102,16 +102,16 @@ function IterationCard({
           <span className="text-xs font-semibold text-foreground">#{it.seq}</span>
           {it.phase && (
             <span
-              className={`rounded-full px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide ${phaseClass(it.phase)}`}
+              className={`rounded-full px-2 py-0.5 text-xs font-bold uppercase tracking-wide ${phaseClass(it.phase)}`}
             >
               {phaseLabel(it.phase)}
             </span>
           )}
-          <span className="text-[10px] text-text-muted">{it.status}</span>
+          <span className="text-xs text-text-secondary">{it.status}</span>
         </div>
         <div className="flex items-center gap-2">
           {it.verdict && (
-            <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${verdictClass(it.verdict)}`}>
+            <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${verdictClass(it.verdict)}`}>
               {it.verdict}
             </span>
           )}
@@ -127,7 +127,7 @@ function IterationCard({
               }}
               aria-label={`Iteration #${it.seq} Full View`}
               title="Full View (all actions I/O & context)"
-              className="flex cursor-pointer items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] font-medium text-text-secondary transition-colors hover:bg-muted/60 hover:text-foreground"
+              className="flex cursor-pointer items-center gap-1 rounded-md border border-border px-2 py-0.5 text-xs font-medium text-text-secondary transition-colors hover:bg-muted/60 hover:text-foreground"
             >
               <ListTree className="h-3 w-3" aria-hidden />
               View Details
@@ -138,7 +138,7 @@ function IterationCard({
 
       {/* PLAN 阶段：摘要即「执行计划」，加标签以便人工审批前定位 */}
       {it.phase === "plan" && it.summary && (
-        <div className="mt-2 text-[10px] font-bold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+        <div className="mt-2 text-xs font-bold uppercase tracking-wide text-amber-700 dark:text-amber-300">
           📋 执行计划 (Plan)
         </div>
       )}
@@ -146,7 +146,7 @@ function IterationCard({
       {/* 执行摘要 */}
       {it.summary && (
         <p
-          className={`${it.phase === "plan" ? "mt-1" : "mt-2"} whitespace-pre-wrap break-words text-[11px] text-text-secondary`}
+          className={`${it.phase === "plan" ? "mt-1" : "mt-2"} whitespace-pre-wrap break-words text-body text-text-secondary`}
         >
           {expanded || it.summary.length <= 280 ? it.summary : `${it.summary.slice(0, 280)}…`}
           {it.summary.length > 280 && (
@@ -162,20 +162,20 @@ function IterationCard({
 
       {/* 执行失败信息 */}
       {it.exec_error && (
-        <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-500/5 p-2 text-[10px] text-red-600 dark:text-red-400">
+        <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-500/5 p-2 text-caption text-red-600 dark:text-red-400">
           {it.exec_error}
         </pre>
       )}
 
       {/* 评估反思 */}
       {it.reflection && (
-        <p className="mt-2 rounded bg-muted/40 p-2 text-[11px] italic text-text-secondary">
+        <p className="mt-2 rounded bg-muted/40 p-2 text-caption italic text-text-secondary">
           💡 {it.reflection}
         </p>
       )}
 
       {/* 指标行 */}
-      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-text-muted">
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
         {/* 当前阶段主导人指示 */}
         {(() => {
           const driver = deriveIterationDriver(it.status);
@@ -209,7 +209,7 @@ function IterationCard({
       {isPendingApproval && (
         <div className="mt-2 flex items-center gap-2 rounded-md bg-sky-500/5 p-2">
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
-          <span className="text-[10px] text-sky-700 dark:text-sky-300">
+          <span className="text-xs text-sky-700 dark:text-sky-300">
             {it.phase === "plan"
               ? "NegentropyEngine 正在审阅此 Plan…"
               : it.phase === "implement"
@@ -221,7 +221,7 @@ function IterationCard({
           <button
             onClick={(e) => { e.stopPropagation(); onApprove(it.id); }}
             disabled={busy}
-            className="cursor-pointer rounded-md border border-border px-2 py-0.5 text-[10px] font-medium text-text-muted hover:bg-muted/50 disabled:opacity-50"
+            className="cursor-pointer rounded-md border border-border px-2 py-0.5 text-xs font-medium text-text-secondary hover:bg-muted/50 disabled:opacity-50"
           >
             Manual Approve
           </button>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineKpiStrip.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineKpiStrip.tsx
@@ -11,9 +11,9 @@ interface RoutineKpiStripProps {
 function MetricCell({ label, value, sub, color }: { label: string; value: string; sub?: string; color?: string }) {
   return (
     <div className="rounded-xl border border-border bg-card p-3 flex-1 min-w-0">
-      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{label}</div>
+      <div className="text-xs uppercase tracking-overline text-text-secondary mb-1">{label}</div>
       <div className={`text-lg font-bold tabular-nums ${color ?? "text-foreground"}`}>{value}</div>
-      {sub && <div className="text-[10px] text-muted-foreground mt-0.5">{sub}</div>}
+      {sub && <div className="text-xs text-text-secondary mt-0.5">{sub}</div>}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopBar.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopBar.tsx
@@ -82,7 +82,7 @@ export function RoutineLoopBar({ snapshot, size = "sm", showLabels = false, clas
             return (
               <div
                 key={stage}
-                className={`flex-1 text-center text-[10px] tracking-tight ${
+                className={`flex-1 text-center text-xs tracking-tight ${
                   isActive
                     ? "font-semibold text-foreground"
                     : isDone

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
@@ -28,13 +28,13 @@ export function RoutineLoopDiagram({
   return (
     <section className="rounded-card border border-border bg-card p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground">
+        <h3 className="text-xs uppercase tracking-overline text-text-secondary">
           闭环过程 · Evaluator–Optimizer Loop
         </h3>
         {snapshot.mode === "looping" && snapshot.activeStage && (
-          <span className="text-[11px] font-medium text-foreground">
+          <span className="text-body font-medium text-foreground">
             {LOOP_STAGE_META[snapshot.activeStage].label}
-            {snapshot.pulsing && <span className="ml-1 text-text-muted">进行中…</span>}
+            {snapshot.pulsing && <span className="ml-1 text-text-secondary">进行中…</span>}
           </span>
         )}
       </div>
@@ -43,14 +43,14 @@ export function RoutineLoopDiagram({
 
       {/* 收尾阶段指示（独立于 4 段闭环，FINALIZE 时点亮）*/}
       {routine.current_phase === "finalize" && routine.status === "running" && (
-        <div className="mt-2 flex items-center gap-2 rounded-md bg-violet-500/5 p-2 text-[11px] text-violet-700 dark:text-violet-300">
+        <div className="mt-2 flex items-center gap-2 rounded-md bg-violet-500/5 p-2 text-body text-violet-700 dark:text-violet-300">
           <GitPullRequest className="h-3.5 w-3.5 shrink-0" aria-hidden />
           收尾阶段 · 运行 ruff + pytest，修复后创建 PR（待人工 Merge）
         </div>
       )}
 
       {/* 实时 / 终态状态行 */}
-      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-text-secondary">
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-secondary">
         {timing && latest ? (
           <>
             <span className="inline-flex items-center gap-1">
@@ -58,11 +58,11 @@ export function RoutineLoopDiagram({
               迭代 #{latest.seq}
             </span>
             <LiveElapsed startedAt={latest.started_at} prefix="⏱ " className="text-foreground" />
-            <span className="text-text-muted">{latest.turn_count} turns</span>
-            <span className="text-text-muted">${latest.cost_usd.toFixed(4)}</span>
+            <span className="text-text-secondary">{latest.turn_count} turns</span>
+            <span className="text-text-secondary">${latest.cost_usd.toFixed(4)}</span>
           </>
         ) : snapshot.mode === "done" ? (
-          <span className="text-text-muted">
+          <span className="text-text-secondary">
             已结束{snapshot.terminationReason ? ` · 终止原因：${snapshot.terminationReason}` : ""}
           </span>
         ) : snapshot.mode === "paused" ? (
@@ -70,10 +70,10 @@ export function RoutineLoopDiagram({
         ) : snapshot.mode === "waiting-approval" ? (
           <span className="text-amber-600 dark:text-amber-400">等待人工审批后派发下一轮迭代</span>
         ) : snapshot.mode === "idle" ? (
-          <span className="text-text-muted">尚未启动</span>
+          <span className="text-text-secondary">尚未启动</span>
         ) : null}
         {latest?.verdict && (
-          <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${verdictClass(latest.verdict)}`}>
+          <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${verdictClass(latest.verdict)}`}>
             {latest.verdict}
           </span>
         )}
@@ -82,14 +82,14 @@ export function RoutineLoopDiagram({
       {/* Reflexion 反馈边 */}
       <div className="mt-3 flex items-start gap-2 rounded-lg border border-dashed border-border bg-muted/30 p-2.5">
         <Repeat className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
-        <div className="min-w-0 text-[11px] text-text-secondary">
-          <span className="font-medium text-foreground">Reflexion 反馈</span>
+        <div className="min-w-0 text-xs text-text-secondary">
+          <span className="font-semibold text-foreground">Reflexion 反馈</span>
           ：Decide 后将上轮反思注入下轮 Dispatch 提示，驱动自迭代。
           {latest?.reflection && (
-            <span className="mt-1 block italic text-text-muted">💡 最近反思：{latest.reflection}</span>
+            <span className="mt-1 block italic text-text-secondary">💡 最近反思：{latest.reflection}</span>
           )}
           {!latest?.reflection && routine.reflections.length > 0 && (
-            <span className="mt-1 block italic text-text-muted">💡 {routine.reflections[routine.reflections.length - 1]}</span>
+            <span className="mt-1 block italic text-text-secondary">💡 {routine.reflections[routine.reflections.length - 1]}</span>
           )}
         </div>
       </div>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineMeter.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineMeter.tsx
@@ -26,7 +26,7 @@ export function RoutineMeter({
   const pct = ratio == null ? 0 : Math.min(100, Math.max(0, ratio * 100));
   return (
     <div className={className}>
-      <div className="flex items-baseline justify-between text-[10px] text-text-muted">
+      <div className="flex items-baseline justify-between text-xs text-text-secondary">
         <span>{label}</span>
         {rightElement ?? <span className="tabular-nums text-text-secondary">{valueText}</span>}
       </div>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
@@ -16,7 +16,7 @@ export function RoutinePrCard({ prUrl }: { prUrl: string | null | undefined }) {
         href={prUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="min-w-0 flex-1 truncate text-xs font-medium text-violet-700 underline-offset-2 hover:underline dark:text-violet-300"
+        className="min-w-0 flex-1 truncate text-body font-medium text-violet-700 underline-offset-2 hover:underline dark:text-violet-300"
         title={prUrl}
       >
         查看 PR
@@ -25,7 +25,7 @@ export function RoutinePrCard({ prUrl }: { prUrl: string | null | undefined }) {
         href={prUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-200 px-2.5 py-1 text-[11px] font-medium text-emerald-600 hover:bg-emerald-500/10 dark:border-emerald-800 dark:text-emerald-400"
+        className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-200 px-2.5 py-1 text-xs font-medium text-emerald-600 hover:bg-emerald-500/10 dark:border-emerald-800 dark:text-emerald-400"
       >
         在 GitHub 合并 →
       </a>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
@@ -41,7 +41,7 @@ function GanttTooltip({ active, payload }: { active?: boolean; payload?: Tooltip
   const row = payload?.find((p) => p.payload)?.payload;
   if (!active || !row) return null;
   return (
-    <div className="rounded-md border border-border bg-card px-2.5 py-1.5 text-[11px] shadow-md">
+    <div className="rounded-md border border-border bg-card px-2.5 py-1.5 text-xs shadow-md">
       <div className="font-semibold text-foreground">
         迭代 #{row.seq} · {row.status}
         {row.inFlight && " · 进行中"}
@@ -96,7 +96,7 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
   return (
     <CollapsibleSection title="迭代时间线 · Run Timeline（执行区间）">
       {rows.length === 0 ? (
-        <p className="py-8 text-center text-[11px] text-text-muted">尚无可视化的执行区间</p>
+        <p className="py-8 text-center text-sm text-text-secondary">尚无可视化的执行区间</p>
       ) : (
         <div style={{ height: Math.max(120, rows.length * 30 + 36), minWidth: 1 }} className="w-full">
           <ResponsiveContainer width="100%" height="100%">
@@ -104,10 +104,10 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
               <XAxis
                 type="number"
                 stroke="currentColor"
-                fontSize={10}
+                fontSize={12}
                 tickFormatter={(v: number) => formatDuration(v * 1000)}
               />
-              <YAxis type="category" dataKey="label" width={40} stroke="currentColor" fontSize={10} />
+              <YAxis type="category" dataKey="label" width={40} stroke="currentColor" fontSize={12} />
               <Tooltip content={<GanttTooltip />} cursor={{ fill: "var(--color-muted, #f4f4f5)", opacity: 0.4 }} />
               {/* 透明占位：run 起点 → 本迭代起点 */}
               <Bar dataKey="offset" stackId="t" fill="transparent" isAnimationActive={false} />

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -54,14 +54,14 @@ export function RoutineRunView({
   );
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* 目标 / 验收标准 */}
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div className="grid gap-5 lg:grid-cols-2">
         <CollapsibleSection title="Goal">
-          <p className="whitespace-pre-wrap break-words text-xs text-foreground">{routine.goal}</p>
+          <p className="whitespace-pre-wrap break-words text-body text-foreground">{routine.goal}</p>
         </CollapsibleSection>
         <CollapsibleSection title="Acceptance Criteria">
-          <p className="whitespace-pre-wrap break-words text-xs text-text-secondary">
+          <p className="whitespace-pre-wrap break-words text-body text-text-secondary">
             {routine.acceptance_criteria}
           </p>
         </CollapsibleSection>
@@ -77,7 +77,7 @@ export function RoutineRunView({
       {/* Pull Request（FINALIZE 产出，等待人工 Merge）*/}
       {routine.pr_url && (
         <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-          <h3 className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">Pull Request</h3>
+          <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">Pull Request</h3>
           <RoutinePrCard prUrl={routine.pr_url} />
         </section>
       )}
@@ -89,7 +89,7 @@ export function RoutineRunView({
       <RoutineGuardPanel routine={routine} iterations={asc} />
 
       {/* 收敛趋势 + 甘特 */}
-      <div className="grid gap-4 lg:grid-cols-2">
+      <div className="grid gap-5 lg:grid-cols-2">
         <RoutineConvergenceChart
           iterations={asc}
           threshold={routine.success_score_threshold}
@@ -103,7 +103,7 @@ export function RoutineRunView({
 
       {/* 迭代明细 */}
       <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-        <h3 className="mb-3 text-[10px] uppercase tracking-wider text-muted-foreground">
+        <h3 className="mb-3 text-xs uppercase tracking-overline text-text-secondary">
           迭代明细 · Iterations ({iterations.length})
         </h3>
         <RoutineIterationTimeline

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineScoreSparkline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineScoreSparkline.tsx
@@ -22,7 +22,7 @@ export function RoutineScoreSparkline({
     .filter((p): p is { s: number; i: number } => p.s != null);
 
   if (pts.length === 0) {
-    return <div className="text-[10px] text-text-muted">尚无评分数据</div>;
+    return <div className="text-xs text-text-secondary">尚无评分数据</div>;
   }
 
   const pad = 4;

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -35,7 +35,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
   if (routines.length === 0) {
     return (
       <div className="rounded-xl border border-dashed border-border bg-card py-12 text-center">
-        <p className="text-sm text-text-muted">No routines yet. Create your first autonomous task.</p>
+        <p className="text-sm text-text-secondary">No routines yet. Create your first autonomous task.</p>
       </div>
     );
   }
@@ -44,7 +44,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
     <div className="overflow-hidden rounded-xl border border-border bg-card">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-border text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+          <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
             <th className="px-4 py-2.5 font-medium">Name</th>
             <th className="px-4 py-2.5 font-medium">Status</th>
             <th className="px-4 py-2.5 font-medium">Progress</th>
@@ -63,16 +63,16 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
             >
               <td className="px-4 py-3">
                 <div className="font-medium text-foreground">{r.display_name || r.title}</div>
-                <div className="text-[10px] text-text-muted">{r.key}</div>
+                <div className="text-xs text-text-secondary">{r.key}</div>
               </td>
               <td className="px-4 py-3">
                 <span
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold ${routineStatusClass(r.status)}`}
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
                 >
                   {r.status}
                 </span>
                 {r.termination_reason && (
-                  <div className="mt-0.5 text-[10px] text-text-muted">{r.termination_reason}</div>
+                  <div className="mt-0.5 text-xs text-text-secondary">{r.termination_reason}</div>
                 )}
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
@@ -84,9 +84,9 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
                 ${r.total_cost_usd.toFixed(3)}
-                {r.max_cost_usd ? <span className="text-text-muted"> / ${r.max_cost_usd}</span> : null}
+                {r.max_cost_usd ? <span className="text-text-secondary"> / ${r.max_cost_usd}</span> : null}
               </td>
-              <td className="px-4 py-3 text-[11px] text-text-muted">
+              <td className="px-4 py-3 text-xs text-text-secondary">
                 {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
               </td>
               <td className="px-4 py-3 text-right">

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
@@ -59,7 +59,7 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
       headerExtra={
         <span
           className={cn(
-            "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold",
+            "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold",
             worktreeStatusClass(ws),
           )}
         >
@@ -78,22 +78,22 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
     >
       {/* 信息网格 */}
       <dl className="grid gap-x-4 gap-y-1.5 text-xs sm:grid-cols-[auto_1fr]">
-        <dt className="text-text-muted">Baseline</dt>
+        <dt className="text-text-secondary">Baseline</dt>
         <dd className="break-all font-mono text-text-secondary">{routine.baseline_branch}</dd>
 
-        <dt className="text-text-muted">Work branch</dt>
+        <dt className="text-text-secondary">Work branch</dt>
         <dd className="break-all font-mono text-text-secondary">{routine.work_branch ?? "—"}</dd>
 
         {ws === "active" && routine.worktree_path && (
           <>
-            <dt className="text-text-muted">Worktree</dt>
+            <dt className="text-text-secondary">Worktree</dt>
             <dd className="break-all font-mono text-text-secondary">{routine.worktree_path}</dd>
           </>
         )}
 
         {routine.worktree_disk_usage && ws === "active" && (
           <>
-            <dt className="flex items-center gap-1 text-text-muted">
+            <dt className="flex items-center gap-1 text-text-secondary">
               <HardDrive className="h-3 w-3" />
               Disk usage
             </dt>
@@ -119,7 +119,7 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
             </Button>
           )}
           {routine.worktree_cleanup_policy && (
-            <span className="text-[10px] text-text-muted">
+            <span className="text-xs text-text-secondary">
               {worktreePolicyDescription(routine.worktree_cleanup_policy)}
             </span>
           )}

--- a/apps/negentropy-ui/app/interface/routine/_components/TemplateCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/TemplateCard.tsx
@@ -80,16 +80,16 @@ export function TemplateCard({ template, onDetail, onUse, onEdit, onDelete }: Te
       >
         {/* 顶行：category + 来源标识 */}
         <div className="flex items-center justify-between">
-          <span className="text-micro font-medium uppercase tracking-wider text-text-muted">
+          <span className="text-xs font-medium uppercase tracking-overline text-text-secondary">
             {template.category}
           </span>
           {isUser ? (
             // 自建模板 hover 时右上角浮出编辑/删除图标，标识淡出让位避免重叠
-            <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-micro font-medium text-primary transition-opacity group-hover:opacity-0">
+            <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary transition-opacity group-hover:opacity-0">
               自建
             </span>
           ) : (
-            <span className="rounded-full bg-muted px-1.5 py-0.5 text-micro font-medium text-text-secondary">
+            <span className="rounded-full bg-muted px-1.5 py-0.5 text-xs font-medium text-text-secondary">
               内置
             </span>
           )}
@@ -99,14 +99,14 @@ export function TemplateCard({ template, onDetail, onUse, onEdit, onDelete }: Te
         <div>
           <h3 className="text-body-lg font-semibold text-foreground">
             {template.display_name}
-            <span className="ml-1.5 text-micro font-normal text-text-muted">
+            <span className="ml-1.5 text-caption font-normal text-text-secondary">
               v{template.version}
             </span>
           </h3>
         </div>
 
         {/* 描述 */}
-        <p className="text-xs leading-relaxed text-text-muted line-clamp-2">
+        <p className="text-xs leading-relaxed text-text-secondary line-clamp-2">
           {template.description}
         </p>
       </button>
@@ -116,12 +116,12 @@ export function TemplateCard({ template, onDetail, onUse, onEdit, onDelete }: Te
         {/* 元数据区 */}
         <div className="flex flex-1 flex-wrap items-center gap-1.5">
           {badge && (
-            <span className={`rounded-full px-1.5 py-0.5 text-micro ${badge.cls}`}>
+            <span className={`rounded-full px-1.5 py-0.5 text-xs ${badge.cls}`}>
               {badge.label}
             </span>
           )}
           {template.has_verification_command && (
-            <span className="flex items-center gap-0.5 text-micro text-emerald-600 dark:text-emerald-400">
+            <span className="flex items-center gap-0.5 text-xs text-emerald-600 dark:text-emerald-400">
               <ShieldCheck className="h-3 w-3" />
               验证门控
             </span>

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -71,11 +71,11 @@ export function resolveEventTitle(
 export function phaseClass(phase: RoutinePhase | null | undefined): string {
   switch (phase) {
     case "plan":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "bg-amber-500/15 text-amber-800 dark:text-amber-200";
     case "implement":
-      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "bg-sky-500/15 text-sky-800 dark:text-sky-200";
     case "finalize":
-      return "bg-violet-500/10 text-violet-700 dark:text-violet-300";
+      return "bg-violet-500/15 text-violet-800 dark:text-violet-200";
     default:
       return "bg-muted/60 text-text-secondary";
   }
@@ -99,13 +99,13 @@ export function phaseLabel(phase: RoutinePhase | null | undefined): string {
 export function routineStatusClass(status: RoutineStatus): string {
   switch (status) {
     case "running":
-      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "bg-sky-500/15 text-sky-800 dark:text-sky-200";
     case "paused":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "bg-amber-500/15 text-amber-800 dark:text-amber-200";
     case "succeeded":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "bg-emerald-500/15 text-emerald-800 dark:text-emerald-200";
     case "failed":
-      return "bg-red-500/10 text-red-700 dark:text-red-300";
+      return "bg-red-500/15 text-red-800 dark:text-red-200";
     case "cancelled":
       return "bg-muted text-text-secondary line-through";
     default: // pending
@@ -158,13 +158,13 @@ export function limitFillClass(ratio: number | null | undefined): string {
 export function worktreeStatusClass(status: string | null | undefined): string {
   switch (status) {
     case "active":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "bg-emerald-500/15 text-emerald-800 dark:text-emerald-200";
     case "cleaned":
       return "bg-muted text-text-secondary";
     case "orphaned":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "bg-amber-500/15 text-amber-800 dark:text-amber-200";
     default:
-      return "bg-muted/60 text-text-muted";
+      return "bg-muted/60 text-text-secondary";
   }
 }
 
@@ -208,15 +208,15 @@ export function scoreFillClass(score: number | null | undefined, threshold = 85)
 export function verdictClass(verdict: Verdict | null | undefined): string {
   switch (verdict) {
     case "pass":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "bg-emerald-500/15 text-emerald-800 dark:text-emerald-200";
     case "progressing":
-      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "bg-sky-500/15 text-sky-800 dark:text-sky-200";
     case "stalled":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "bg-amber-500/15 text-amber-800 dark:text-amber-200";
     case "regressed":
-      return "bg-orange-500/10 text-orange-700 dark:text-orange-300";
+      return "bg-orange-500/15 text-orange-800 dark:text-orange-200";
     case "unrecoverable":
-      return "bg-red-500/10 text-red-700 dark:text-red-300";
+      return "bg-red-500/15 text-red-800 dark:text-red-200";
     default:
       return "bg-muted/60 text-text-secondary";
   }
@@ -282,26 +282,26 @@ export function eventTypeIcon(eventType: RoutineEventType, toolName?: string | n
 
 /** 动作事件类型 → 图标容器配色（语义色，深色模式安全对比）。 */
 export function eventTypeClass(eventType: RoutineEventType, isError?: boolean): string {
-  if (isError) return "bg-red-500/10 text-red-600 dark:text-red-400";
+  if (isError) return "bg-red-500/15 text-red-800 dark:text-red-200";
   switch (eventType) {
     case "tool_use":
-      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "bg-sky-500/15 text-sky-800 dark:text-sky-200";
     case "tool_result":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "bg-emerald-500/15 text-emerald-800 dark:text-emerald-200";
     case "assistant":
-      return "bg-violet-500/10 text-violet-700 dark:text-violet-300";
+      return "bg-violet-500/15 text-violet-800 dark:text-violet-200";
     case "result":
-      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+      return "bg-emerald-500/15 text-emerald-800 dark:text-emerald-200";
     case "gate":
-      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "bg-sky-500/15 text-sky-800 dark:text-sky-200";
     case "evaluation":
-      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+      return "bg-amber-500/15 text-amber-800 dark:text-amber-200";
     case "plan_review":
-      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+      return "bg-sky-500/15 text-sky-800 dark:text-sky-200";
     case "system":
       return "bg-muted text-text-secondary";
     default:
-      return "bg-muted/60 text-text-muted";
+      return "bg-muted/60 text-text-secondary";
   }
 }
 

--- a/apps/negentropy-ui/components/ui/CollapsibleSection.tsx
+++ b/apps/negentropy-ui/components/ui/CollapsibleSection.tsx
@@ -32,12 +32,12 @@ export function CollapsibleSection({
   const [expanded, setExpanded] = useState(defaultExpanded);
 
   return (
-    <section className={cn("rounded-card border border-border bg-card p-4 shadow-sm", className)}>
+    <section className={cn("rounded-card border border-border bg-card p-5 shadow-sm", className)}>
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="group flex w-full items-center justify-between gap-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+        className="group flex w-full items-center justify-between gap-2 text-xs font-medium uppercase tracking-overline text-text-secondary transition-colors hover:text-foreground"
       >
         <span className="flex items-center gap-1.5">{title}</span>
         <div className="flex items-center gap-2">
@@ -45,7 +45,7 @@ export function CollapsibleSection({
           <ChevronDown
             aria-hidden="true"
             className={cn(
-              "h-3.5 w-3.5 shrink-0 transition-transform duration-150",
+              "h-4 w-4 shrink-0 transition-transform duration-150",
               expanded && "rotate-180",
             )}
           />


### PR DESCRIPTION
## 背景

Routine 详情页（`/interface/routine/[id]`）存在严重的可读性问题：字体过小（大量使用 9px~11px）、颜色过淡（过度使用 `text-text-muted`，对比度仅 ~4.65:1），导致页面内容难以辨认。

本 PR 在**不丢失任何信息、不删减任何功能**的前提下，系统性提升排版可读性与视觉层次，并与基线分支 `feature/1.x.x` 上的「Turn 气泡单行化」（#882）、「迭代视图 Markdown 渲染化」（#883）无缝融合。

## 核心改动

### 1. 三级字号体系（清除全部超小字号）
- 清除全部 `text-[9px]` / `text-[10px]` / `text-micro`（**114 处**），统一升至 `text-xs`(12px) 或 `text-body`(14px)
- `text-caption`(11px) 仅保留给引用文本、事件明细标签等真正的辅助信息
- `MarkdownText` 组件基准字号由 `text-[11px]` 提升至 `text-body`(14px)，表格/代码块等内部元素同步对齐字号体系

### 2. 对比度提升（WCAG 2.1 AA 合规）
- 可读文本由 `text-text-muted`(zinc-500, ~4.65:1) 统一升级为 `text-text-secondary`(zinc-600, ~7.45:1)
- `text-text-muted` 仅保留用于分隔点 `·` 等装饰性元素

### 3. Badge 可见性增强
- 背景透明度 `/10` → `/15`
- 文字色阶加沉/提亮一级（如 `sky-700`→`sky-800`、`dark:sky-300`→`sky-200`）

### 4. 布局呼吸感
- 页面外边距 24px→32px、区段间距 16px→24px、网格间距 16px→20px、卡片内边距增大
- `CollapsibleSection` 标题升级为 `tracking-overline`，Chevron 图标放大

### 5. 页面头部双行重构
- 标题 + 状态徽章在上、Key + 控制按钮在下，加底部分隔线，层次更清晰

### 6. 迭代卡片改进
- 活跃迭代加 `ring` 高亮，Phase Badge / 摘要 / 指标行字号全面提升

## 涉及范围

23 个文件（`apps/negentropy-ui/app/interface/routine/` 及共享组件 `CollapsibleSection`），净改动 +217 / -212。

## 验证

- ✅ TypeScript 类型检查通过（仅 `.next` 缓存的无关错误）
- ✅ ESLint pre-commit hooks 全部通过
- ✅ 浏览器实测：详情页 + 「全过程」审计抽屉均渲染正常，Markdown 富文本表格、Turn 气泡、字号可读性三者无缝共存
- ✅ 已合并基线 `feature/1.x.x`，冲突已彻底消除（含 Markdown 渲染与可读性改进的融合）
- ✅ 零信息丢失、零功能删减

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>