### PR TITLE
feat(Routine): Plan→Review→Implement 收敛为单迭代闭环（引擎两段式串接）;

### DIFF
--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -189,6 +189,14 @@ class RoutineSettings(BaseSettings):
         "审阅大型方案需 >60s，过小会触发 litellm.Timeout 致评审失败、CC 落回 'Answer questions?'（ISSUE-129）。"
         "per-routine 可经 config.plan_review_timeout_seconds 覆盖。",
     )
+    plan_review_unified_loop: bool = Field(
+        default=True,
+        description="启用「单迭代内 Plan→Review→Implement 闭环」：对所有 worktree routine，引擎在同一 Iteration "
+        "内串接两段 Claude Code 调用——①plan 模式(原生只读写锁)+真实 Plan Review 钩子(ExitPlanMode/"
+        "AskUserQuestion 均评审、含 refine 闭环)，批准后捕获会话；②acceptEdits + --resume 续接同一会话完成实施。"
+        "评审与实施同属一个迭代气泡、会话上下文连续，取代旧的 PLAN/IMPLEMENT 分裂两迭代流程。"
+        "关闭则回退旧行为（phased 走两迭代、flat 无评审），无需改代码即可一键回退。",
+    )
 
     # --- 上下文压缩（迭代内：提前触发 auto-compact + 迭代内重试续接）---
     context_compact_enabled: bool = Field(

--- a/apps/negentropy/src/negentropy/engine/claude_code/models.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/models.py
@@ -61,6 +61,13 @@ class ClaudeCodeConfig:
     # 供 LLM 生成与任务目标一致的确定性回答。
     auto_answer_context: dict[str, Any] | None = None
 
+    # 单迭代两段式（Plan Review 统一闭环）：当 ``plan_stage_config`` 非空时，Runner 在同一
+    # Iteration 内先以本段配置（permission_mode="plan" + Plan Review 钩子）跑「方案制定+评审」段，
+    # 捕获 session 后再以本对象（acceptEdits + resume）跑「实施」段。``plan_stage_prompt`` 为该段
+    # 使用的 plan prompt。repr/compare=False：嵌套 config 不入 repr、不参与相等比较，避免递归噪声。
+    plan_stage_prompt: str | None = None
+    plan_stage_config: ClaudeCodeConfig | None = field(default=None, repr=False, compare=False)
+
     # 上下文压缩：注入 CLAUDE_AUTOCOMPACT_PCT_OVERRIDE 环境变量，控制 CC auto-compact 触发阈值。
     # None = 使用 CLI 默认值（~83%）；整数（如 70）= context 达该百分比时触发压缩。
     compact_threshold_pct: int | None = None

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -386,6 +386,23 @@ async def _emit_events(
                 await on_event(evt)
 
 
+async def emit_raw_event(
+    raw: dict[str, Any],
+    events_holder: list[dict[str, Any]] | None,
+    on_event: EventSink | None,
+    *,
+    max_events: int | None = None,
+) -> None:
+    """公开包装：把一条「原始 stream 事件」归一化后注入 ``events_holder``（定格 seq）并实时回调。
+
+    供 Runner 在单迭代两段式的「段间」注入 NegentropyEngine 的 Plan Review 评审事件
+    （``raw = {"type":"system","subtype":"plan_review","review_result": {...}}``）。复用
+    ``_normalize_stream_event`` 的 plan_review 分支，使评审作为独立事件渲染为 Engine「发言」，
+    其 seq 紧接 plan 段之后、与随后 implement 段事件无冲突（共享同一 ``events_holder``）。
+    """
+    await _emit_events(raw, events_holder, on_event, max_events=max_events)
+
+
 # 子进程 stdout 读取：手动分块 + 抬高 StreamReader 缓冲上限，规避 asyncio readline() 默认
 # 64KiB 上限导致的 LimitOverrunError（stream-json 单行可达数 MiB，如大 tool_result）。
 _STREAM_READER_LIMIT = 16 * 1024 * 1024  # 16 MiB
@@ -523,6 +540,7 @@ class ClaudeCodeService:
         config: ClaudeCodeConfig,
         abort_event: asyncio.Event | None = None,
         on_event: EventSink | None = None,
+        events_holder: list[dict[str, Any]] | None = None,
     ) -> ClaudeCodeResult:
         """调用 Claude Code 并等待完整结果。
 
@@ -531,13 +549,18 @@ class ClaudeCodeService:
         ``on_event``：可选「全过程」动作回调，服务每解析出一个归一化动作即 best-effort
         回调一次（供 Runner 实时发布 SSE）。无论成功 / 超时 / 取消 / 出错，已捕获的动作
         都会回带到 ``ClaudeCodeResult.events``（含 seq），供写回持久化。
+
+        ``events_holder``：可选「外部共享」动作容器。为空则内部新建（默认行为）；非空则跨多次
+        ``invoke`` 复用同一列表，使事件 ``seq`` 连续单调——单迭代两段式（plan 段 + implement 段）
+        据此保证两段事件 seq 无冲突（避免 ``ON CONFLICT(iteration_id,seq)`` 丢事件）。
         """
         t0 = time.monotonic()
         # 可变容器：内部协程一旦从 stream 起始 init 事件解析出 session_id 即写入，
         # 使超时/取消（wait_for 丢弃内部局部结果）路径仍能回带 session_id，让下一迭代续接。
         session_holder: dict[str, str | None] = {"session_id": None}
         # 同理：动作事件外溢容器，超时/取消/出错路径回带已捕获的部分事件流。
-        events_holder: list[dict[str, Any]] = []
+        # 外部传入则共享（跨段 seq 连续），否则内部新建。
+        events_holder = events_holder if events_holder is not None else []
         try:
             if ClaudeCodeService._check_sdk():
                 coro = ClaudeCodeService._invoke_sdk(

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
 import sys
@@ -142,10 +143,17 @@ def _build_readonly_settings(read_dirs: list[str]) -> str:
     return json.dumps({"permissions": {"deny": deny}})
 
 
-def _write_plan_review_ctx(routine: Routine) -> str:
+def _review_sidecar_path(iteration_id: UUID) -> str:
+    """Plan Review 评审结果 sidecar（JSONL）路径——按 iteration_id 键，杜绝跨迭代/跨 routine 串味。"""
+    return os.path.join(tempfile.gettempdir(), "negentropy-pr-ctx", f"{iteration_id}.reviews.jsonl")
+
+
+def _write_plan_review_ctx(routine: Routine, iteration_id: UUID, *, mode: str = "unified") -> str:
     """写 per-iteration Plan Review 上下文文件，供 PreToolUse 钩子读取（避免经 env 传长文本）。
 
-    返回上下文文件绝对路径。内容：goal/acceptance/reflections/model/timeout。
+    返回上下文文件绝对路径。内容：goal/acceptance/reflections/model/timeout/mode/iteration_id/
+    review_sidecar_path。``mode``：``unified``（ExitPlanMode 亦真实评审、写 sidecar）/``legacy``
+    （ExitPlanMode 仅消噪、不评审）。按 iteration_id 键，避免并发 routine 共用 routine.id 文件串味。
     """
     reflections = (
         list((routine.reflections or {}).get("items", [])[:5]) if isinstance(routine.reflections, dict) else []
@@ -164,11 +172,14 @@ def _write_plan_review_ctx(routine: Routine) -> str:
         "reflections": reflections,
         "model": plan_review_model,
         "timeout": plan_review_timeout,
+        "mode": mode,
+        "iteration_id": str(iteration_id),
+        "review_sidecar_path": _review_sidecar_path(iteration_id),
     }
     ctx_dir = os.path.join(tempfile.gettempdir(), "negentropy-pr-ctx")
     with suppress(OSError):
         os.makedirs(ctx_dir, exist_ok=True)
-    path = os.path.join(ctx_dir, f"{routine.id}.json")
+    path = os.path.join(ctx_dir, f"{iteration_id}.json")
     with open(path, "w", encoding="utf-8") as f:
         json.dump(ctx, f, ensure_ascii=False)
     return path
@@ -189,12 +200,37 @@ def _plan_review_hook_command(ctx_path: str) -> str:
     return f'"{py}" "{hook_path}" "{ctx_path}"'
 
 
+def _plan_review_hook_pre(ctx_path: str, review_timeout: int, *, exit_plan_full_review: bool) -> list[dict]:
+    """构造 PreToolUse 钩子项（AskUserQuestion + ExitPlanMode），合并进 settings.hooks.PreToolUse。
+
+    - ``AskUserQuestion`` 恒跑真实评审 → timeout=``review_timeout+45``（ISSUE-129 公式：单次尝试 +
+      引擎冷启动余量；钩子内 PlanReviewer ``max_retries=1``）。
+    - ``ExitPlanMode``：``exit_plan_full_review=True``（unified，CC 原生方案提交方式）亦跑真实评审 →
+      同 full timeout；``=False``（legacy）仅瞬时返回「已批准」消噪 → timeout=15。
+    """
+    hook_cmd = _plan_review_hook_command(ctx_path)
+    hook_timeout = review_timeout + 45
+    exit_timeout = hook_timeout if exit_plan_full_review else 15
+    return [
+        {"matcher": "AskUserQuestion", "hooks": [{"type": "command", "command": hook_cmd, "timeout": hook_timeout}]},
+        {"matcher": "ExitPlanMode", "hooks": [{"type": "command", "command": hook_cmd, "timeout": exit_timeout}]},
+    ]
+
+
 def _is_plan_review_active(routine: Routine) -> bool:
-    """是否对本次（PLAN 相位）启用 Engine Plan Review 同轮钩子（ISSUE-123）。"""
+    """是否对本 routine 启用 Engine Plan Review 钩子（ISSUE-123）。
+
+    - 统一闭环开（``plan_review_unified_loop``，默认）：对**所有 worktree routine** 启用，**不再受
+      PLAN 相位约束**——Runner 在迭代内以独立 plan 段（permission_mode=plan）跑评审，任何相位的
+      worktree routine 首段都需评审钩子，故判定式仅看 ``is_worktree_routine``。
+    - 统一闭环关：回退旧判定——仅 phased/worktree routine 的 PLAN 相位启用（ISSUE-123 原行为）。
+    """
+    if not (settings.routine.auto_answer_questions and settings.routine.plan_review_enabled):
+        return False
+    if settings.routine.plan_review_unified_loop:
+        return phase_mod.is_worktree_routine(routine)
     return bool(
-        settings.routine.auto_answer_questions
-        and settings.routine.plan_review_enabled
-        and routine.current_phase == phase_mod.PHASE_PLAN
+        routine.current_phase == phase_mod.PHASE_PLAN
         and (phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config))
     )
 
@@ -818,7 +854,7 @@ class RoutineOrchestrator:
                 await self._publish_iteration_created(routine.id, iteration)
 
                 if not needs_approval:
-                    config = await self._build_config(routine)
+                    config = await self._build_config(routine, iteration.id)
                     # 快照系统中所有已启用的 MCP server/tool 元数据到 iteration.metrics（历史可追溯）
                     mcp_meta = await self._resolve_mcp_meta(db, cwd=routine.cwd)
                     if mcp_meta:
@@ -873,7 +909,7 @@ class RoutineOrchestrator:
                     dirty = True
                     await self._publish_routine(routine)
                     continue
-                config = await self._build_config(routine)
+                config = await self._build_config(routine, it.id)
                 # 快照系统中所有已启用的 MCP server/tool 元数据到 iteration.metrics（历史可追溯）
                 mcp_meta = await self._resolve_mcp_meta(db, cwd=routine.cwd)
                 if mcp_meta:
@@ -1247,11 +1283,16 @@ class RoutineOrchestrator:
         routine.work_branch = info.branch
         return True
 
-    async def _build_config(self, routine: Routine):
+    async def _build_config(self, routine: Routine, iteration_id: UUID):
         """构建本次执行的 ClaudeCodeConfig：全局默认 + routine 覆盖 + session 续接。
 
         worktree routine：CC 实际 cwd 指向引擎备好的隔离 worktree（``worktree_path`` 由
         ``_ensure_workspace`` 在 launch 前写入）；``cwd`` 仅作 worktree 派生源（仓库根）。
+
+        统一闭环（``plan_review_unified_loop``，worktree routine + fresh 会话）：返回的主 config 为
+        **implement 段**（acceptEdits），并挂载 ``plan_stage_config``/``plan_stage_prompt``（**plan 段**：
+        permission_mode=plan + 真实评审钩子）。Runner 据此在同一迭代内先评审、批准后 --resume 续接实施。
+        ``iteration_id`` 用于按迭代键定位 Plan Review ctx/sidecar 文件，避免并发 routine 串味。
         """
         from negentropy.engine.schedulers.handlers.claude_code import _load_claude_code_defaults
 
@@ -1303,44 +1344,27 @@ class RoutineOrchestrator:
         read_dirs = _normalize_read_dirs(overrides.get("read_dirs"))
         if read_dirs:
             config.add_dirs = read_dirs
-        # CC settings.json：合并「源码只读 deny」+「Plan Review PreToolUse 钩子」。
+        # CC settings.json 基底：源码只读 deny（read_dirs 非空时）。Plan Review 钩子按 unified/legacy 分别注入。
         settings_obj: dict = json.loads(_build_readonly_settings(read_dirs)) if read_dirs else {}
         plan_review_active = _is_plan_review_active(routine)
-        if plan_review_active:
-            # ISSUE-123：PLAN 相位经 PreToolUse 钩子拦截 AskUserQuestion，由 Engine 评审并同轮
-            # deny+reason 回灌 CC（headless 下 stdin auto-answer 对 AskUserQuestion 无效）。
-            ctx_path = _write_plan_review_ctx(routine)
-            # hook timeout 必须覆盖钩子实际耗时（引擎冷启动 ~10s + PlanReviewer 单次 LLM 调用 ≤ review_timeout），
-            # 否则超 Claude Code PreToolUse 超时被杀 → CC 落回 "Answer questions?"（ISSUE-123/129）。
-            # 钩子内 PlanReviewer max_retries=1（见 plan_review_hook），故 = per-routine review_timeout + 冷启动余量；
-            # per-routine config.plan_review_timeout_seconds 覆盖（强模型大方案需 >60s，ISSUE-129）。
-            review_timeout = int(
-                (routine.config or {}).get("plan_review_timeout_seconds")
-                or settings.routine.plan_review_timeout_seconds
-            )
-            hook_timeout = review_timeout + 45
-            hook_cmd = _plan_review_hook_command(ctx_path)
+        # 统一闭环：worktree routine + 开关开。主 config = implement 段；plan 段独立挂载（见文末）。
+        unified = bool(settings.routine.plan_review_unified_loop and phase_mod.is_worktree_routine(routine))
+        # per-routine 审阅超时覆盖（ISSUE-129）：强模型审阅大型方案需 >60s，可经 config 抬高。
+        review_timeout = int(
+            (routine.config or {}).get("plan_review_timeout_seconds") or settings.routine.plan_review_timeout_seconds
+        )
+        # Legacy 路径（统一闭环关）：评审钩子直接注入主 config（PLAN 相位，ISSUE-123 原行为；
+        # ExitPlanMode 仅消噪不评审）。unified 路径：钩子注入独立 plan 段（见文末），主 config 不挂钩子。
+        if plan_review_active and not unified:
+            ctx_path = _write_plan_review_ctx(routine, iteration_id, mode="legacy")
             pre = settings_obj.setdefault("hooks", {}).setdefault("PreToolUse", [])
-            pre.append(
-                {
-                    "matcher": "AskUserQuestion",
-                    "hooks": [{"type": "command", "command": hook_cmd, "timeout": hook_timeout}],
-                }
-            )
-            # ISSUE-126：ExitPlanMode 同走钩子返回「已批准、进入实施」deny+reason，消除 headless 下
-            # opaque "Exit plan mode?" is_error 噪声（allow 经实验不能消除，故同钩子分支处理）。
-            # 该分支无 LLM、瞬时返回，无需大 timeout。
-            pre.append(
-                {
-                    "matcher": "ExitPlanMode",
-                    "hooks": [{"type": "command", "command": hook_cmd, "timeout": 15}],
-                }
-            )
+            pre.extend(_plan_review_hook_pre(ctx_path, review_timeout, exit_plan_full_review=False))
         if settings_obj:
             config.settings = json.dumps(settings_obj, ensure_ascii=False)
-        # permission_mode 由相位决定（PLAN 仅规划、IMPLEMENT/FINALIZE 落盘）——对 worktree routine
-        # 与 phased routine 均生效（覆盖 preset 静态值）；旧扁平 routine 沿用 preset 覆盖或全局默认。
-        if phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config):
+        # permission_mode：unified 主 config = implement 段（acceptEdits 落盘）；其余沿用相位/preset 覆盖。
+        if unified:
+            config.permission_mode = "acceptEdits"
+        elif phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config):
             config.permission_mode = phase_mod.permission_mode_for(routine.current_phase)
         elif overrides.get("permission_mode"):
             config.permission_mode = overrides["permission_mode"]
@@ -1366,19 +1390,41 @@ class RoutineOrchestrator:
             config.auto_answer_context = {
                 "goal": routine.goal,
                 "acceptance_criteria": routine.acceptance_criteria,
-                # Plan Review 上下文：当 phase=plan 且 plan_review_enabled 时，
-                # auto-answer 分支调用 PlanReviewer 而非通用 auto-answer。
                 "phase": routine.current_phase or "",
                 "plan_review_enabled": settings.routine.plan_review_enabled,
-                # ISSUE-123：PLAN 相位评审改由 PreToolUse 钩子同轮投递；置真令交互式 reader
-                # 跳过其（对 AskUserQuestion 无效且会重复评审的）内联 plan-review 应答分支。
-                "plan_review_via_hook": plan_review_active,
+                # 主 config 在 unified 下为 implement 段、不做评审，故 via_hook 仅在 legacy 评审激活时为真
+                # （置真令交互式 reader 跳过对 AskUserQuestion 无效且会重复评审的内联 plan-review 应答分支）。
+                "plan_review_via_hook": plan_review_active and not unified,
                 "plan_review_model": settings.routine.plan_review_model,
                 "plan_review_timeout": settings.routine.plan_review_timeout_seconds,
                 "reflections": (
                     list(routine.reflections.get("items", [])[:5]) if isinstance(routine.reflections, dict) else []
                 ),
             }
+        # 统一闭环：构建迭代内独立 plan 段（permission_mode=plan + 真实评审钩子），**仅 fresh（无续接会话）**触发；
+        # 续接迭代沿用单段 implement（方案已批准、会话续接，无需重评审）。上下文耗尽清空会话后下轮会重新 plan。
+        if unified and plan_review_active and not routine.claude_session_id:
+            plan_settings_obj: dict = json.loads(_build_readonly_settings(read_dirs)) if read_dirs else {}
+            plan_ctx_path = _write_plan_review_ctx(routine, iteration_id, mode="unified")
+            plan_pre = plan_settings_obj.setdefault("hooks", {}).setdefault("PreToolUse", [])
+            plan_pre.extend(_plan_review_hook_pre(plan_ctx_path, review_timeout, exit_plan_full_review=True))
+            plan_config = copy.copy(config)
+            plan_config.permission_mode = "plan"  # 原生只读写锁：plan 段禁止落盘
+            plan_config.settings = json.dumps(plan_settings_obj, ensure_ascii=False)
+            plan_config.resume_session_id = None  # plan 段以全新会话起（无续接）
+            plan_config.plan_stage_config = None  # 防自嵌套
+            plan_config.plan_stage_prompt = None
+            if config.auto_answer_context is not None:
+                _ac = dict(config.auto_answer_context)
+                _ac["plan_review_via_hook"] = True  # plan 段确由钩子评审
+                _ac["phase"] = phase_mod.PHASE_PLAN
+                plan_config.auto_answer_context = _ac
+            config.plan_stage_config = plan_config
+            config.plan_stage_prompt = build_prompt(
+                routine,
+                max_reflections=settings.routine.max_reflections_injected,
+                stage=phase_mod.PHASE_PLAN,
+            )
         return config
 
     @staticmethod

--- a/apps/negentropy/src/negentropy/engine/routine/plan_review_hook.py
+++ b/apps/negentropy/src/negentropy/engine/routine/plan_review_hook.py
@@ -33,6 +33,7 @@ import asyncio
 import json
 import os
 import sys
+from contextlib import suppress
 
 # === stdout 纯净化（仅在以脚本路径执行钩子时生效，import 时绝不执行）===
 # 本文件须以**脚本路径**方式执行（``python <path> <ctx>``，见 orchestrator._plan_review_hook_command），
@@ -92,10 +93,31 @@ def _emit(reason: str) -> None:
     os.write(fd, (payload + "\n").encode("utf-8"))
 
 
+def _append_review_sidecar(path: str | None, record: dict) -> None:
+    """把单次评审结果以 JSONL 追加写入 sidecar（供 Runner 段间读取并注入 plan_review 发言）。
+
+    O_APPEND 单行追加；CC 串行调用工具，同一 iteration 的钩子子进程不并发，写入安全。
+    任何异常一律吞掉——sidecar 仅用于「发言」呈现，绝不可影响评审反馈主链路。
+    """
+    if not path:
+        return
+    with suppress(Exception):
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
 def _extract_plan_text(tool_input: dict) -> str:
-    """从 AskUserQuestion 的 tool_input 提取 CC 提交的方案全文（拼接各 question 文本）。"""
+    """从 ExitPlanMode / AskUserQuestion 的 tool_input 提取 CC 提交的方案全文。
+
+    - ExitPlanMode：``tool_input = {"plan": "<markdown 方案全文>"}``（CC 原生提交方式）。
+    - AskUserQuestion：``tool_input = {"questions": [{"question": "<方案>"}...]}``（PLAN prompt 约束）。
+    """
     if not isinstance(tool_input, dict):
         return ""
+    # ExitPlanMode：优先取 plan 字段（CC 原生方案提交载荷）。
+    plan = tool_input.get("plan")
+    if isinstance(plan, str) and plan.strip():
+        return plan.strip()
     qs = tool_input.get("questions")
     parts: list[str] = []
     if isinstance(qs, list):
@@ -131,14 +153,36 @@ async def _run(payload: dict, ctx: dict) -> str:
         plan_text=plan_text,
         reflections=reflections if isinstance(reflections, list) else None,
     )
-    # 批准后**结束本轮**而非调用 ExitPlanMode（ISSUE-128）：相位推进（PLAN→IMPLEMENT）纯由引擎
-    # `_advance_phase_or_terminate` 在下一次评估驱动，不依赖 CC 退出 Plan 模式；而 headless ExitPlanMode
-    # 恒被 CLI 标 is_error，CC 会误判失败而循环重试、空耗 turns。故批准/失败兜底均指示 CC「直接结束本轮」。
+    sidecar = ctx.get("review_sidecar_path")
+    # 批准后**结束本轮**而非调用 ExitPlanMode（ISSUE-128）：单迭代两段式下，Runner 在批准后于
+    # 同一 Iteration 内 --resume 续接 implement 段；而 headless ExitPlanMode 恒被 CLI 标 is_error，
+    # CC 会误判失败而循环重试、空耗 turns。故批准/失败兜底均指示 CC「直接结束本轮」，由引擎续接实施。
     if not result.ok:
+        # 评审自身失败（LLM 不可用等）：写一条「不可用」发言供审计，并 fail-open 放行实施（不死锁）。
+        _append_review_sidecar(
+            sidecar,
+            {"verdict": "unavailable", "score": None, "feedback": result.error or "评审执行失败", "module_reviews": []},
+        )
         return (
             "（NegentropyEngine 评审暂不可用）请**直接结束本轮**"
-            "（不要调用 ExitPlanMode 或 AskUserQuestion）；引擎将自动推进到实施阶段。"
+            "（不要调用 ExitPlanMode 或 AskUserQuestion）；引擎将续接实施阶段。"
         )
+
+    # 写结构化评审结果到 sidecar，供 Runner 段间注入 plan_review 事件（渲染为 NegentropyEngine 发言）。
+    _append_review_sidecar(
+        sidecar,
+        {
+            "verdict": result.verdict,
+            "score": result.score,
+            "module_reviews": [
+                {"module": m.module, "status": m.status, "comment": m.comment} for m in result.module_reviews
+            ],
+            "feedback": result.feedback or "",
+            "reflection": result.reflection or "",
+            "judge_prompt": result.judge_prompt,
+            "judge_raw": result.judge_raw,
+        },
+    )
 
     score = result.score if result.score is not None else "?"
     feedback = (result.feedback or "").strip()
@@ -147,13 +191,13 @@ async def _run(payload: dict, ctx: dict) -> str:
             f"✅ NegentropyEngine 已通过本方案审阅（评分 {score}/100）。"
             f"{('审阅意见：' + feedback) if feedback else ''}\n"
             "方案已批准。请**直接结束本轮回复**——无需调用 ExitPlanMode 或任何工具；"
-            "引擎会自动推进到实施（IMPLEMENT）阶段并据本方案派发实施迭代。"
+            "引擎将在同一迭代内续接实施（IMPLEMENT）阶段并据本方案推进。"
         )
     # refine（或兜底）
     return (
         f"🔄 NegentropyEngine 审阅：方案需完善（评分 {score}/100）。\n"
         f"具体修改建议：{feedback or '请补全验收标准覆盖、风险与回退、测试策略等薄弱项。'}\n"
-        "请据此**修订方案后再次调用 AskUserQuestion 提交审阅**；切勿在未达标前退出 Plan 模式。"
+        "请据此**修订方案后再次提交审阅**（ExitPlanMode 或 AskUserQuestion 均可）；切勿在未达标前退出 Plan 模式。"
     )
 
 
@@ -174,12 +218,8 @@ def main() -> None:
     except Exception:
         payload = {}
     tool_name = payload.get("tool_name") or ""
-    # ExitPlanMode：返回「已批准、进入实施」的 deny+reason（消除 opaque "Exit plan mode?" 噪声）。
-    if tool_name == "ExitPlanMode":
-        _emit(_EXIT_APPROVED_REASON)
-        return
-    # 仅处理 AskUserQuestion；其它工具不干预（输出空）。
-    if tool_name != "AskUserQuestion":
+    # 仅处理两个方案提交工具；其它工具不干预（输出空）。
+    if tool_name not in ("AskUserQuestion", "ExitPlanMode"):
         return
     ctx: dict = {}
     if len(sys.argv) > 1:
@@ -188,12 +228,18 @@ def main() -> None:
                 ctx = json.load(f)
         except Exception:
             ctx = {}
+    # legacy 模式（plan_review_unified_loop 关闭）：CC 经 AskUserQuestion 提交方案，ExitPlanMode 仅
+    # 返回「已批准」消噪、不评审（保留 ISSUE-126 行为）。unified 模式：ExitPlanMode（CC 原生提交方式）
+    # 与 AskUserQuestion 均走真实 PlanReviewer 评审。
+    if tool_name == "ExitPlanMode" and ctx.get("mode") != "unified":
+        _emit(_EXIT_APPROVED_REASON)
+        return
     try:
         reason = asyncio.run(_run(payload, ctx))
     except Exception as exc:  # fail-open：绝不卡死 CC
         reason = (
             "（NegentropyEngine 评审执行异常："
-            f"{str(exc)[:160]}）请直接调用 ExitPlanMode 退出 Plan 模式继续，不要再次调用 AskUserQuestion。"
+            f"{str(exc)[:160]}）请**直接结束本轮**，不要再次调用 ExitPlanMode 或 AskUserQuestion；引擎将续接实施阶段。"
         )
     _emit(reason)
 

--- a/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
+++ b/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
@@ -35,13 +35,14 @@ def build_prompt(
     *,
     max_reflections: int = 5,
     memory_context: str | None = None,
+    stage: str | None = None,
 ) -> str:
-    """构建发送给 Claude Code 的迭代 prompt（按相位分支）。
+    """构建发送给 Claude Code 的迭代 prompt（按相位/段分支）。
 
     通用部分：目标 + 验收标准 + [记忆上下文] + 最近 N 条反思（Reflexion 注入，来自
     ``routine.reflections["items"]``）。尾部指令依相位而定：
 
-    - PLAN     仅产出方案、禁写盘（plan 模式），待人工审批；
+    - PLAN     仅产出方案、禁写盘（plan 模式），提交评审；
     - FINALIZE 自检 ruff/pytest、修复、建 PR 并回带 ``PR_URL=`` sentinel；
     - IMPLEMENT（含扁平工作流）首轮「开始」/续接「继续」—— 与相位化前一致。
 
@@ -49,8 +50,14 @@ def build_prompt(
         routine: Routine-like 对象
         max_reflections: 注入的最近反思条数
         memory_context: 可选的记忆上下文文本（来自 Memory Module 检索）
+        stage: 显式覆盖本次 prompt 的「段」。统一闭环（``plan_review_unified_loop``）下，引擎在
+            同一迭代内先以 ``stage=PHASE_PLAN`` 取 plan 段 prompt（ExitPlanMode/AskUserQuestion 均
+            被评审），批准后以默认（``stage=None`` → 按 ``current_phase``）取 implement 段 prompt。
+            为空时沿用旧逻辑（相位由 ``routine.current_phase`` 决定）。
     """
-    phase = getattr(routine, "current_phase", PHASE_IMPLEMENT) or PHASE_IMPLEMENT
+    # 显式 plan 段（统一闭环）：ExitPlanMode 与 AskUserQuestion 均被钩子真实评审。
+    unified_plan = stage == PHASE_PLAN
+    phase = stage or getattr(routine, "current_phase", PHASE_IMPLEMENT) or PHASE_IMPLEMENT
     is_resume = bool(routine.claude_session_id)
     worktree = is_worktree_routine(routine)
 
@@ -95,7 +102,21 @@ def build_prompt(
             "以下是对你此前尝试的评估反馈，请逐条针对性改进：\n" + bullet
         )
 
-    if phase == PHASE_PLAN:
+    if phase == PHASE_PLAN and unified_plan:
+        # 统一闭环 plan 段：ExitPlanMode（CC 原生方案提交方式）与 AskUserQuestion 均被钩子真实评审。
+        parts.append(
+            "# 规划 (Plan ONLY)\n本段**仅产出实现方案，禁止写入或修改任何文件**（plan 模式）：\n"
+            "请给出正交分解维度、改动清单、预计爆炸半径与验证策略。\n\n"
+            "**提交审阅（重要）**：完成方案后，调用 **ExitPlanMode**（或 AskUserQuestion）把**完整方案全文**"
+            "提交给 NegentropyEngine 审阅——ExitPlanMode 写入 `plan` 字段；AskUserQuestion 写入 `question` 字段"
+            "（审阅者只读该字段，方案务必完整自包含）。\n"
+            "NegentropyEngine 将在**同一轮内**通过该工具的返回结果直接给你审阅反馈：\n"
+            "  - 若返回「🔄 需完善」：请据反馈**修订方案后再次提交审阅**，直至通过；\n"
+            "  - 若返回「✅ 已通过/已批准」：请**直接结束本轮回复**，**不要再调用任何工具**——"
+            "引擎将在**同一迭代内**自动续接你的会话进入实施阶段（headless 下勿自行退出 plan 模式或写文件）。"
+        )
+    elif phase == PHASE_PLAN:
+        # Legacy（统一闭环关、phased PLAN 相位）：仅 AskUserQuestion 被评审，ExitPlanMode 自动放行。
         parts.append(
             "# 规划 (Plan ONLY)\n本轮**仅产出实现方案，禁止写入或修改任何文件**（plan 模式）：\n"
             "请给出正交分解维度、改动清单、预计爆炸半径与验证策略。\n\n"

--- a/apps/negentropy/src/negentropy/engine/routine/runner.py
+++ b/apps/negentropy/src/negentropy/engine/routine/runner.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
+import os
 import time
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
@@ -36,6 +38,7 @@ from negentropy.engine.claude_code.service import (
     ERROR_KIND_CONTEXT_EXHAUSTED,
     ERROR_KIND_SESSION_NOT_FOUND,
     ClaudeCodeService,
+    emit_raw_event,
 )
 from negentropy.logging import get_logger
 from negentropy.models.routine import Routine, RoutineIteration, RoutineIterationEvent
@@ -195,6 +198,10 @@ class RoutineRunner:
                 self._make_action_sink(iteration_id, routine_id, persister) if settings.routine.capture_events else None
             )
 
+            # 共享动作容器：跨「plan 段 + implement 段（含重试）」复用同一 list，使事件 seq 连续单调，
+            # 避免两段事件 ``ON CONFLICT(iteration_id,seq)`` 互相覆盖（单迭代两段式 seq 唯一性保证）。
+            events_holder: list[dict[str, Any]] = []
+
             compact_max_retries = (
                 settings.routine.context_compact_max_retries if settings.routine.context_compact_enabled else 0
             )
@@ -205,10 +212,37 @@ class RoutineRunner:
             session_max_retries = 2
             cumulative_cost = 0.0
             cumulative_turns = 0
+            # overall_deadline 用**原始** config.timeout_seconds 界定「本迭代总预算」，统一覆盖 plan 段 +
+            # implement 段（及其重试）。plan 段在此之后执行、消耗的时间从 implement 段剩余预算中扣除。
             overall_deadline = time.monotonic() + config.timeout_seconds
             result = None
 
             try:
+                # 单迭代两段式：先跑 plan 段（permission_mode=plan + 真实评审钩子），批准后于同一迭代内
+                # --resume 续接 implement 段。plan 段事件与随后注入的 plan_review 发言共享 events_holder，
+                # seq 紧接其后；批准后把 implement 段 --resume 到 plan 段会话、超时收敛到剩余预算。
+                if config.plan_stage_config is not None and not abort.is_set():
+                    plan_cfg = _with_reduced_timeout(config.plan_stage_config, overall_deadline - time.monotonic())
+                    plan_result = await ClaudeCodeService.invoke(
+                        config.plan_stage_prompt or prompt,
+                        plan_cfg,
+                        abort_event=abort,
+                        on_event=sink,
+                        events_holder=events_holder,
+                    )
+                    cumulative_cost += plan_result.cost_usd or 0.0
+                    cumulative_turns += plan_result.turn_count or 0
+                    result = plan_result  # 兜底：若 implement 段未及运行（abort/超时），仍回带 plan 段产出
+                    # 读 sidecar，把每次评审注入为 plan_review 事件 → 渲染为 NegentropyEngine「发言」。
+                    await self._inject_plan_review_events(
+                        iteration_id, events_holder, sink, max_events=config.max_events_per_iter
+                    )
+                    # implement 段：续接 plan 段会话（携带已批准方案上下文）、超时为剩余预算、卸下 plan 段防重复。
+                    config = _with_reduced_timeout(config, overall_deadline - time.monotonic())
+                    config.resume_session_id = plan_result.session_id or config.resume_session_id
+                    config.plan_stage_config = None
+                    config.plan_stage_prompt = None
+
                 while True:
                     # 重试时检查剩余时间是否足够（至少 60s，防无意义短命重试）
                     remaining = overall_deadline - time.monotonic()
@@ -218,7 +252,9 @@ class RoutineRunner:
                         break
 
                     invoke_config = config if not retried else _with_reduced_timeout(config, remaining)
-                    result = await ClaudeCodeService.invoke(prompt, invoke_config, abort_event=abort, on_event=sink)
+                    result = await ClaudeCodeService.invoke(
+                        prompt, invoke_config, abort_event=abort, on_event=sink, events_holder=events_holder
+                    )
                     cumulative_cost += result.cost_usd or 0.0
                     cumulative_turns += result.turn_count or 0
 
@@ -268,6 +304,8 @@ class RoutineRunner:
             finally:
                 if persister is not None:
                     await persister.finalize()
+                # 清理 Plan Review sidecar/ctx 临时文件（按 iteration_id 键，幂等 best-effort）。
+                self._cleanup_plan_review_files(iteration_id)
 
             # 累积 cost/turns 覆盖到最终 result（跨重试汇总）
             if result is not None:
@@ -323,6 +361,56 @@ class RoutineRunner:
                 persister.buffer(evt)
 
         return _sink
+
+    @staticmethod
+    async def _inject_plan_review_events(
+        iteration_id: UUID,
+        events_holder: list[dict[str, Any]],
+        sink,
+        *,
+        max_events: int | None,
+    ) -> None:
+        """读 plan 段评审 sidecar(JSONL)，把每条评审注入为 ``plan_review`` 事件（共享 seq）。
+
+        渲染侧 ``deriveAgentRole("plan_review")→engine``，故注入后即呈现为 NegentropyEngine「发言」；
+        seq 由共享 ``events_holder`` 续接 plan 段之后、与随后 implement 段无冲突。任何异常一律吞掉——
+        发言呈现是增强项，绝不可影响实施主链路。
+        """
+        # 复用 orchestrator 的单一路径口径（与钩子写入端同源），懒导入规避包内循环依赖。
+        from .orchestrator import _review_sidecar_path
+
+        path = _review_sidecar_path(iteration_id)
+        try:
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+        except OSError:
+            return
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except Exception:
+                continue
+            with suppress(Exception):
+                await emit_raw_event(
+                    {"type": "system", "subtype": "plan_review", "review_result": record},
+                    events_holder,
+                    sink,
+                    max_events=max_events,
+                )
+
+    @staticmethod
+    def _cleanup_plan_review_files(iteration_id: UUID) -> None:
+        """best-effort 清理本迭代的 Plan Review sidecar + ctx 临时文件（按 iteration_id 键，幂等）。"""
+        from .orchestrator import _review_sidecar_path
+
+        sidecar = _review_sidecar_path(iteration_id)
+        ctx_file = os.path.join(os.path.dirname(sidecar), f"{iteration_id}.json")
+        for p in (sidecar, ctx_file):
+            with suppress(OSError):
+                os.remove(p)
 
     async def _mark_in_flight(self, iteration_id: UUID, lease: datetime) -> None:
         async with db_session.AsyncSessionLocal() as db:

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -376,11 +376,9 @@ async def test_dispatch_auto_launches_and_writes_back():
         orch = RoutineOrchestrator()
         fake = ClaudeCodeResult(status="success", summary="ok", session_id="s1", cost_usd=0.05, turn_count=2)
         info = WorkspaceInfo(path="/tmp/wt/dispatch-auto", branch="routine/dispatch-auto")
+        mock_invoke = AsyncMock(return_value=fake)
         with (
-            patch(
-                "negentropy.engine.claude_code.service.ClaudeCodeService.invoke",
-                new=AsyncMock(return_value=fake),
-            ),
+            patch("negentropy.engine.claude_code.service.ClaudeCodeService.invoke", new=mock_invoke),
             patch("negentropy.engine.routine.workspace.ensure_worktree", new=AsyncMock(return_value=info)),
         ):
             launched = await orch._dispatch_due()
@@ -388,13 +386,16 @@ async def test_dispatch_auto_launches_and_writes_back():
             await asyncio.sleep(1.2)  # 等待后台 runner 写回
         async with db_session.AsyncSessionLocal() as db:
             its = (await db.execute(select(RoutineIteration).where(RoutineIteration.routine_id == rid))).scalars().all()
-            assert len(its) == 1
+            # 统一闭环：fresh worktree routine 在**同一个** Iteration 内串接 plan 段 + implement 段两次 CC 调用。
+            assert len(its) == 1, "plan 段与 implement 段同属一个 Iteration（不分裂为两迭代）"
             assert its[0].status == "executed"
             assert its[0].exec_status == "success"
+            assert mock_invoke.call_count == 2, "两段式：plan 段 + implement 段各一次 CC 调用"
             r = await db.get(Routine, rid)
             assert r.iteration_count == 1
             assert r.claude_session_id == "s1"
-            assert r.total_cost_usd == pytest.approx(0.05)
+            # cost/turns 跨两段累加：plan 段 0.05 + implement 段 0.05 = 0.1
+            assert r.total_cost_usd == pytest.approx(0.1)
     finally:
         await _cleanup(rid)
 
@@ -732,7 +733,7 @@ async def test_ensure_workspace_targets_worktree_in_build_config():
                 await db.commit()
             async with db_session.AsyncSessionLocal() as db:
                 r = await db.get(Routine, rid)
-                config = await orch._build_config(r)
+                config = await orch._build_config(r, r.id)
                 assert config.cwd == "/tmp/wt/demo-x"  # CC 实际 cwd = worktree
                 assert config.permission_mode == "acceptEdits"  # implement 相位
     finally:
@@ -792,7 +793,7 @@ async def test_build_config_uses_routine_default_tools():
         orch = RoutineOrchestrator()
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
-            config = await orch._build_config(r)
+            config = await orch._build_config(r, r.id)
             # 扩展默认包含 WebFetch + WebSearch
             assert "WebFetch" in config.allowed_tools
             assert "WebSearch" in config.allowed_tools
@@ -810,7 +811,7 @@ async def test_build_config_per_routine_tools_override():
         orch = RoutineOrchestrator()
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
-            config = await orch._build_config(r)
+            config = await orch._build_config(r, r.id)
             # 显式覆盖的基础工具保留在前
             assert config.allowed_tools[:2] == ["Bash", "Read"]
             # auto_answer 默认开 → 交互工具被强制并入（见 test_build_config_forces_interactive_tools）
@@ -832,7 +833,7 @@ async def test_build_config_forces_interactive_tools_when_auto_answer():
         orch = RoutineOrchestrator()
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
-            config = await orch._build_config(r)
+            config = await orch._build_config(r, r.id)
             assert "AskUserQuestion" in config.allowed_tools, "交互应答须放行 AskUserQuestion"
             assert "ExitPlanMode" in config.allowed_tools, "交互应答须放行 ExitPlanMode"
             # 不重复并入（幂等）
@@ -848,7 +849,7 @@ async def test_build_config_disallowed_tools_passthrough():
         orch = RoutineOrchestrator()
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
-            config = await orch._build_config(r)
+            config = await orch._build_config(r, r.id)
             assert config.disallowed_tools == ["Task"]
     finally:
         await _cleanup(rid)
@@ -868,7 +869,7 @@ async def test_build_config_mcp_config_merges_into_default():
         orch = RoutineOrchestrator()
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
-            config = await orch._build_config(r)
+            config = await orch._build_config(r, r.id)
             # per-routine 具名 server 已合并
             assert config.mcp_config["test-server"] == mcp["test-server"]
             # 系统默认 playwright 浏览器 MCP 未被覆盖抹除
@@ -889,8 +890,96 @@ async def test_build_config_default_provisions_playwright_browser_mcp():
         orch = RoutineOrchestrator()
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
-            config = await orch._build_config(r)
+            config = await orch._build_config(r, r.id)
             assert "playwright" in (config.mcp_config or {})
             assert "mcp__playwright" in config.allowed_tools
     finally:
         await _cleanup(rid)
+
+
+# ---------------------------------------------------------------------------
+# 单迭代两段式 Plan Review 闭环（plan_review_unified_loop）
+# ---------------------------------------------------------------------------
+
+
+async def test_build_config_unified_attaches_plan_stage(tmp_path, monkeypatch):
+    """统一闭环（默认开）+ flat worktree + fresh：主 config=implement 段(acceptEdits、无评审钩子)，
+    挂载独立 plan 段(permission_mode=plan + ExitPlanMode/AskUserQuestion 真实评审钩子 + plan prompt)。"""
+    import json as _json
+
+    from negentropy.engine.routine import orchestrator as orch_mod
+
+    monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    rid = await _make_routine(baseline_branch="origin/feature/1.x.x", cwd="/repo", current_phase="implement")
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            iid = uuid.uuid4()
+            config = await orch._build_config(r, iid)
+            # 主 config = implement 段：acceptEdits、不挂评审钩子、via_hook=False
+            assert config.permission_mode == "acceptEdits"
+            main_settings = _json.loads(config.settings) if config.settings else {}
+            assert not main_settings.get("hooks"), "主(implement)config 不应挂评审钩子——评审在 plan 段"
+            assert config.auto_answer_context["plan_review_via_hook"] is False
+            # plan 段：permission_mode=plan、无续接、双工具真实评审钩子、plan prompt
+            ps = config.plan_stage_config
+            assert ps is not None and ps.permission_mode == "plan"
+            assert ps.resume_session_id is None
+            assert ps.plan_stage_config is None  # 防自嵌套
+            pre = _json.loads(ps.settings)["hooks"]["PreToolUse"]
+            matchers = {h["matcher"]: h["hooks"][0]["timeout"] for h in pre}
+            assert "AskUserQuestion" in matchers and "ExitPlanMode" in matchers
+            # unified：ExitPlanMode 亦跑真实评审 → 与 AskUserQuestion 同 full timeout（非 legacy 的 15）
+            assert matchers["ExitPlanMode"] == matchers["AskUserQuestion"] > 15
+            assert ps.auto_answer_context["plan_review_via_hook"] is True
+            assert config.plan_stage_prompt and "提交" in config.plan_stage_prompt
+            # ctx 文件 mode=unified、按 iteration_id 键
+            ctx = _json.loads((tmp_path / "negentropy-pr-ctx" / f"{iid}.json").read_text(encoding="utf-8"))
+            assert ctx["mode"] == "unified" and ctx["iteration_id"] == str(iid)
+    finally:
+        await _cleanup(rid)
+
+
+async def test_build_config_unified_resume_skips_plan_stage(tmp_path, monkeypatch):
+    """统一闭环 + worktree + 已有续接会话（续接迭代）：不挂 plan 段，单段 implement（方案已批准）。"""
+    from negentropy.engine.routine import orchestrator as orch_mod
+
+    monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    rid = await _make_routine(
+        baseline_branch="origin/feature/1.x.x",
+        cwd="/repo",
+        current_phase="implement",
+        claude_session_id="sess-abc",
+    )
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            config = await orch._build_config(r, uuid.uuid4())
+            assert config.permission_mode == "acceptEdits"
+            assert config.plan_stage_config is None, "续接迭代不应再挂 plan 段（方案已批准、会话续接）"
+            assert config.resume_session_id == "sess-abc"
+    finally:
+        await _cleanup(rid)
+
+
+async def test_is_plan_review_active_toggle_rollback():
+    """rollback：plan_review_unified_loop=False → 回退旧判定（仅 PLAN 相位 worktree/phased 启用）。"""
+    from types import SimpleNamespace
+
+    from negentropy.config import settings
+    from negentropy.engine.routine import orchestrator as orch_mod
+
+    wt_impl = SimpleNamespace(current_phase="implement", baseline_branch="origin/x", config={})
+    wt_plan = SimpleNamespace(current_phase="plan", baseline_branch="origin/x", config={})
+    # 默认 unified=True：worktree 任何相位均激活（含 implement，故 flat worktree routine 首段获评审）
+    assert orch_mod._is_plan_review_active(wt_impl) is True
+    assert orch_mod._is_plan_review_active(wt_plan) is True
+    # 关闭 unified（绕过 pydantic frozen 直改实例字典，测试后还原）→ 回退旧判定
+    object.__setattr__(settings.routine, "plan_review_unified_loop", False)
+    try:
+        assert orch_mod._is_plan_review_active(wt_impl) is False, "legacy：implement 相位不激活评审"
+        assert orch_mod._is_plan_review_active(wt_plan) is True, "legacy：仅 PLAN 相位激活评审"
+    finally:
+        object.__setattr__(settings.routine, "plan_review_unified_loop", True)

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
@@ -113,6 +113,24 @@ def test_build_prompt_flat_implement_no_checkpoint():
     assert "迭代检查点" not in build_prompt(_routine(current_phase="implement"))
 
 
+def test_build_prompt_unified_plan_stage():
+    """统一闭环 plan 段（stage=plan，覆盖 current_phase）：仅产出方案、禁写盘；允许 ExitPlanMode
+    或 AskUserQuestion 提交评审（二者均被钩子真实评审）；批准后结束本轮、引擎同迭代续接实施。"""
+    # current_phase=implement 的 worktree routine，显式以 stage=plan 取 plan 段 prompt
+    p = build_prompt(_wt_routine(current_phase="implement"), stage="plan")
+    assert "仅产出实现方案" in p and "禁止写入" in p
+    assert "ExitPlanMode" in p and "AskUserQuestion" in p  # 两个提交工具均提及
+    assert "结束本轮" in p and "续接" in p  # 批准后结束本轮、引擎续接实施
+    assert "迭代检查点" not in p  # plan 段不提交（checkpoint 仅 implement）
+
+
+def test_build_prompt_legacy_plan_phase_asks_only():
+    """legacy（不传 stage、current_phase=plan）：仅指示 AskUserQuestion 提交（ExitPlanMode 自动放行不评审）。"""
+    p = build_prompt(_wt_routine(current_phase="plan"))
+    assert "AskUserQuestion" in p
+    assert "仅产出实现方案" in p
+
+
 def test_build_prompt_flat_finalize_unchanged_when_no_baseline():
     """旧扁平 routine（无 baseline）保留泛化收尾文案，不注入具体 push/--head。"""
     p = build_prompt(_routine(current_phase="finalize"))

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_plan_review_hook.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_plan_review_hook.py
@@ -15,6 +15,12 @@ def test_extract_plan_text_from_questions():
     assert "完整方案全文 ABC" in h._extract_plan_text(ti)
 
 
+def test_extract_plan_text_from_exit_plan_mode():
+    """ExitPlanMode 的 tool_input={"plan": ...}（CC 原生方案提交方式）须被正确提取。"""
+    ti = {"plan": "# 实现方案\n正交分解 + 改动清单 XYZ"}
+    assert "正交分解 + 改动清单 XYZ" in h._extract_plan_text(ti)
+
+
 def test_extract_plan_text_fallback_to_input():
     assert "raw" in h._extract_plan_text({"raw": "x"})
 
@@ -61,6 +67,60 @@ async def test_run_review_unavailable_fail_open(monkeypatch):
     reason = await h._run({"tool_input": {}}, {"goal": "g", "acceptance_criteria": "a"})
     # fail-open：不卡死，指示 CC 结束本轮（不再调用工具），引擎自动推进（ISSUE-128）
     assert "结束本轮" in reason and "不要" in reason
+
+
+async def test_run_unified_writes_sidecar(monkeypatch, tmp_path):
+    """unified：评审结果（approve/refine/不可用）均以 JSONL 追加写入 sidecar，供 Runner 注入发言。"""
+    import json
+
+    sidecar = str(tmp_path / "iter.reviews.jsonl")
+    # 1) approve
+    _patch_review(
+        monkeypatch,
+        PlanReviewResult(ok=True, verdict="approve", score=88, feedback="ok", reflection="rf"),
+    )
+    reason = await h._run(
+        {"tool_input": {"plan": "p"}},
+        {"goal": "g", "acceptance_criteria": "a", "review_sidecar_path": sidecar},
+    )
+    assert "续接实施" in reason  # 统一闭环批准文案指示引擎同迭代续接实施
+    # 2) refine（追加第二行）
+    _patch_review(monkeypatch, PlanReviewResult(ok=True, verdict="refine", score=40, feedback="补测试"))
+    await h._run(
+        {"tool_input": {"plan": "p2"}},
+        {"goal": "g", "acceptance_criteria": "a", "review_sidecar_path": sidecar},
+    )
+    lines = [json.loads(x) for x in open(sidecar, encoding="utf-8").read().splitlines() if x.strip()]
+    assert len(lines) == 2
+    assert lines[0]["verdict"] == "approve" and lines[0]["score"] == 88
+    assert lines[1]["verdict"] == "refine" and lines[1]["score"] == 40
+
+
+def test_main_exit_plan_unified_runs_review(monkeypatch, tmp_path):
+    """unified（ctx.mode=unified）下，ExitPlanMode 走真实评审 _run（而非 legacy 直接批准）。"""
+    import json
+
+    ctx = {"goal": "g", "acceptance_criteria": "a", "mode": "unified", "review_sidecar_path": str(tmp_path / "r.jsonl")}
+    ctx_path = tmp_path / "ctx.json"
+    ctx_path.write_text(json.dumps(ctx), encoding="utf-8")
+
+    ran = {"n": 0}
+
+    async def _fake_run(payload, c):
+        ran["n"] += 1
+        assert c.get("mode") == "unified"
+        return "REVIEWED"
+
+    monkeypatch.setattr(h, "_run", _fake_run)
+    captured = {}
+    monkeypatch.setattr(h, "_emit", lambda r: captured.__setitem__("reason", r))
+    monkeypatch.setattr(
+        "sys.stdin", __import__("io").StringIO(json.dumps({"tool_name": "ExitPlanMode", "tool_input": {"plan": "x"}}))
+    )
+    monkeypatch.setattr("sys.argv", ["plan_review_hook.py", str(ctx_path)])
+    h.main()
+    assert ran["n"] == 1, "unified 下 ExitPlanMode 须走真实评审"
+    assert captured.get("reason") == "REVIEWED"
 
 
 # --- ISSUE-126/128：ExitPlanMode 同走钩子返回「已批准、结束本轮」deny+reason ---
@@ -128,10 +188,16 @@ def test_write_plan_review_ctx_per_routine_model_override(tmp_path, monkeypatch)
         reflections={"items": ["r1"]},
         config={"plan_review_model": "anthropic/claude-sonnet-4-6"},
     )
-    path = orch_mod._write_plan_review_ctx(routine)
+    iid = uuid.uuid4()
+    path = orch_mod._write_plan_review_ctx(routine, iid, mode="unified")
     ctx = json.load(open(path, encoding="utf-8"))
     assert ctx["model"] == "anthropic/claude-sonnet-4-6", "per-routine plan_review_model 须覆盖全局默认"
     assert ctx["goal"] == "g" and ctx["reflections"] == ["r1"]
+    # 新增字段：mode / iteration_id / review_sidecar_path（按 iteration_id 键）
+    assert ctx["mode"] == "unified"
+    assert ctx["iteration_id"] == str(iid)
+    assert ctx["review_sidecar_path"] == orch_mod._review_sidecar_path(iid)
+    assert path.endswith(f"{iid}.json")  # ctx 文件按 iteration_id 键
 
 
 def test_write_plan_review_ctx_falls_back_to_global(tmp_path, monkeypatch):
@@ -145,6 +211,7 @@ def test_write_plan_review_ctx_falls_back_to_global(tmp_path, monkeypatch):
 
     monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
     routine = SimpleNamespace(id=uuid.uuid4(), goal="g", acceptance_criteria="a", reflections={}, config={})
-    path = orch_mod._write_plan_review_ctx(routine)
+    path = orch_mod._write_plan_review_ctx(routine, uuid.uuid4())
     ctx = json.load(open(path, encoding="utf-8"))
     assert ctx["model"] == settings.routine.plan_review_model  # 全局默认（None → 走 task_registry）
+    assert ctx["mode"] == "unified"  # 默认 mode

--- a/apps/negentropy/tests/unit_tests/engine/test_runner_plan_review_stage.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_runner_plan_review_stage.py
@@ -1,0 +1,94 @@
+"""Runner 单迭代两段式 Plan Review 闭环单测。
+
+锁定：
+- ``emit_raw_event`` 把 plan_review 原始事件归一化注入共享 holder（seq 连续、回调外溢）；
+- ``RoutineRunner._inject_plan_review_events`` 读 sidecar → 注入 plan_review 事件，seq 续接既有事件之后；
+- ``_cleanup_plan_review_files`` 幂等清理 sidecar/ctx。
+
+这些是「单迭代内 plan 段评审 → NegentropyEngine 发言 → implement 段」闭环的关键缝合点，
+不依赖真实 Claude Code / DB。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+from negentropy.engine.claude_code.service import emit_raw_event
+from negentropy.engine.routine import orchestrator as orch_mod
+from negentropy.engine.routine.runner import RoutineRunner
+
+
+async def test_emit_raw_event_normalizes_plan_review_with_continuous_seq():
+    """emit_raw_event 把 system/plan_review 归一化为 plan_review 事件，seq 续接共享 holder。"""
+    holder: list[dict] = [{"seq": 0, "event_type": "tool_use", "tool_name": "ExitPlanMode", "payload": {}}]
+    streamed: list[dict] = []
+
+    async def sink(evt):
+        streamed.append(evt)
+
+    raw = {
+        "type": "system",
+        "subtype": "plan_review",
+        "review_result": {"verdict": "approve", "score": 91, "feedback": "结构清晰", "module_reviews": []},
+    }
+    await emit_raw_event(raw, holder, sink)
+
+    assert holder[-1]["event_type"] == "plan_review"
+    assert holder[-1]["seq"] == 1  # 续接 seq=0 之后
+    assert holder[-1]["payload"]["verdict"] == "approve" and holder[-1]["payload"]["score"] == 91
+    # deriveAgentRole("plan_review")→engine：该事件即渲染为 NegentropyEngine 发言
+    assert streamed and streamed[-1]["event_type"] == "plan_review"
+
+
+async def test_inject_plan_review_events_from_sidecar(tmp_path, monkeypatch):
+    """从 sidecar(JSONL) 注入多条 plan_review 事件，seq 续接既有事件、payload 完整。"""
+    monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    iid = uuid.uuid4()
+    sidecar = orch_mod._review_sidecar_path(iid)
+    os.makedirs(os.path.dirname(sidecar), exist_ok=True)
+    with open(sidecar, "w", encoding="utf-8") as f:
+        f.write(json.dumps({"verdict": "refine", "score": 40, "feedback": "补测试", "module_reviews": []}) + "\n")
+        f.write(json.dumps({"verdict": "approve", "score": 90, "feedback": "ok", "module_reviews": []}) + "\n")
+
+    # 预置一个 plan 段事件（seq=0），验证注入续接其后
+    holder: list[dict] = [{"seq": 0, "event_type": "tool_use", "tool_name": "ExitPlanMode", "payload": {}}]
+    streamed: list[dict] = []
+
+    async def sink(evt):
+        streamed.append(evt)
+
+    await RoutineRunner._inject_plan_review_events(iid, holder, sink, max_events=None)
+
+    pr = [e for e in holder if e["event_type"] == "plan_review"]
+    assert len(pr) == 2
+    assert pr[0]["seq"] == 1 and pr[1]["seq"] == 2  # 连续、无冲突
+    assert pr[0]["payload"]["verdict"] == "refine" and pr[0]["payload"]["score"] == 40
+    assert pr[1]["payload"]["verdict"] == "approve" and pr[1]["payload"]["score"] == 90
+    # 实时回调外溢（前端据此显示 Engine 发言）
+    assert len([e for e in streamed if e["event_type"] == "plan_review"]) == 2
+
+
+async def test_inject_plan_review_events_missing_sidecar_is_noop(tmp_path, monkeypatch):
+    """sidecar 不存在（CC 未提交方案/评审未触发）→ 不注入、不抛错。"""
+    monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    holder: list[dict] = []
+    await RoutineRunner._inject_plan_review_events(uuid.uuid4(), holder, None, max_events=None)
+    assert holder == []
+
+
+def test_cleanup_plan_review_files_idempotent(tmp_path, monkeypatch):
+    """清理 sidecar + ctx 文件，幂等（文件不存在亦不抛错）。"""
+    monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    iid = uuid.uuid4()
+    sidecar = orch_mod._review_sidecar_path(iid)
+    ctx_file = os.path.join(os.path.dirname(sidecar), f"{iid}.json")
+    os.makedirs(os.path.dirname(sidecar), exist_ok=True)
+    open(sidecar, "w").close()
+    open(ctx_file, "w").close()
+
+    RoutineRunner._cleanup_plan_review_files(iid)
+    assert not os.path.exists(sidecar) and not os.path.exists(ctx_file)
+    # 再次调用幂等（文件已删，不抛错）
+    RoutineRunner._cleanup_plan_review_files(iid)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：实测 routine（`00043167` / project-remaster-501b）中 Claude Code 的实现方案**从未经 NegentropyEngine 评审**即被实施（flat worktree routine 未注入评审钩子；且 CC 以原生 **ExitPlanMode** 提交方案，而旧钩子对其无评审直接放行），并且 PLAN/IMPLEMENT 被相位机拆成多个零散 Iteration（迭代碎片化）。
- 关联上下文/Issue/文档：延续 ISSUE-123/126/128/129「Plan Review 同轮反馈」；本次按 Design B 将整条闭环收敛进**单个 Iteration**。

# 核心变更
- 新增 `plan_review_unified_loop` 总开关（默认开、可一键回退）；对**所有 worktree routine** 启用单迭代两段式。
- Runner 在**同一个 Iteration 行**内串接两段 CC 调用：①`plan` 模式（原生只读写锁）+ 真实评审钩子（**ExitPlanMode 与 AskUserQuestion 均跑 PlanReviewer**、含同轮 refine 闭环），批准后捕获 session；②`acceptEdits` + `--resume` 续接同一会话完成实施 → 产出执行结论 → 既有 EVALUATE 跑 gate 回归+打分。
- 钩子对 ExitPlanMode 改走真实评审并将结果写入 sidecar；Runner 段间经**共享 `events_holder`** 注入 `plan_review` 事件 → UI 渲染为 NegentropyEngine「发言」（seq 连续、规避 `ON CONFLICT(iteration_id,seq)` 丢事件）。
- `_is_plan_review_active` 去掉 PLAN 相位约束（按 `is_worktree_routine` 判定）；`_build_config(+iteration_id)` 构建 plan 段 config（ExitPlanMode 钩子改 full timeout）；`build_prompt(+stage)` 输出 plan 段文案。相位机/决策/eval/FINALIZE-PR **全部不变**。

# 风险与回滚
- 主要风险：worktree routine 首迭代多一次 plan 段 CC 调用（成本/耗时上升，两段共享同一迭代超时预算）；plan 段批准后依赖 CC 在 resume 会话内继续实施。
- 回滚方式：`NE_ROUTINE_PLAN_REVIEW_UNIFIED_LOOP=false`（或 config.local.yaml）一键回退旧流程，**无需回退代码**。

# 验证证据
- 单元测试：hook（ExitPlanMode 真实评审 + sidecar + `{"plan":...}` 解析）、prompt_builder（`stage=plan`）、runner（两段 seq 连续 + plan_review 注入 + 清理）。
- 集成测试：`_build_config` 单迭代两段式注入 / resume 跳过 plan 段 / rollback 开关；`test_dispatch_auto_launches_and_writes_back` 锁定「两段同属一个 Iteration、cost 累加」。
- E2E/Workflow：钩子**真实子进程冒烟**确认 stdout 纯净 JSON + 路由正确；完整浏览器实机回归待引擎部署到本分支后进行（见 Next Best Action）。
- 覆盖率/关键截图：相关 **949 项 `uv run pytest` 全绿**、`ruff check/format` 全过、pre-commit 钩子全过。

# 影响范围
- 前端：无（复用既有 `plan_review` → engine 发言渲染，`agent-role.ts` / `IterationEventTimeline.tsx` 无改动）。
- 后端：`config/routine.py`、`claude_code/{models,service}.py`、`routine/{orchestrator,runner,prompt_builder,plan_review_hook}.py`。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后将运行中引擎（主仓，端口 3292）切到本分支，并以**全新** worktree routine 触发，经已认证 Chrome 验证「单气泡内 plan → 评审发言 → approve → 实施 → 评估」闭环 + DB 旁证（`00043167` 已带 session，会被当作续接、不走 plan 段，故须新建 routine 验证）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
