### PR TITLE
feat(ClaudeCode): 将 Interface/Tools 默认模型升级为 claude-opus-4-8

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0039_seed_claude_code_builtin_tool.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0039_seed_claude_code_builtin_tool.py
@@ -128,7 +128,7 @@ CLAUDE_CODE_CONFIG_SCHEMA = {
 
 CLAUDE_CODE_CONFIG_DEFAULT = {
     "cli_path": "claude",
-    "model": None,
+    "model": "claude-opus-4-8",
     "system_prompt": None,
     "default_cwd": None,
     "max_turns": 500,

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0065_claude_code_default_model_opus48.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0065_claude_code_default_model_opus48.py
@@ -1,0 +1,66 @@
+"""将 claude_code 内置工具默认模型从 null 升级为 claude-opus-4-8
+
+Revision ID: 0065
+Revises: 0064
+Create Date: 2026-06-08 00:00:00.000000+00:00
+
+设计动机：
+    迁移 0039 seed 的 ``builtin_tools.config.model`` 默认为 ``null``，
+    运行时由 Claude Code SDK/CLI 自身决定模型——当前默认解析为 ``claude-opus-4-7``。
+    为使 Routine 任务中 Claude Code 始终走最新 ``claude-opus-4-8`` 模型，
+    需显式将该默认值写入数据库。
+
+幂等 / 非破坏性：
+    - 仅当 ``config ->> 'model' IS NULL`` 时才更新，不覆盖运维已自定义的模型设置。
+    - 多次执行结果一致。
+    - downgrade 恢复为 null，不影响其他 config 字段。
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0065"
+down_revision = "0064"
+branch_labels = None
+depends_on = None
+
+SCHEMA = "negentropy"
+
+_DEFAULT_MODEL = "claude-opus-4-8"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.builtin_tools
+            SET config = jsonb_set(
+                config,
+                '{{model}}',
+                to_jsonb(:model),
+                true
+            )
+            WHERE name = 'claude_code'
+              AND owner_id = 'system'
+              AND config ->> 'model' IS NULL
+            """
+        ).bindparams(
+            sa.bindparam("model", value=_DEFAULT_MODEL),
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.builtin_tools
+            SET config = config || '{{"model": null}}'::jsonb
+            WHERE name = 'claude_code'
+              AND owner_id = 'system'
+              AND config ->> 'model' = :model
+            """
+        ).bindparams(
+            sa.bindparam("model", value=_DEFAULT_MODEL),
+        )
+    )


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 任务中 Claude Code 的执行模型默认为 `null`（回退至 SDK/CLI 默认值 `claude-opus-4-7`），需显式升级为最新模型 `claude-opus-4-8`
- 关联上下文/Issue/文档：Interface / Tools 页面 Claude Code 配置项

# 核心变更
- 更新迁移 0039 种子常量 `CLAUDE_CODE_CONFIG_DEFAULT.model` 从 `None` 改为 `"claude-opus-4-8"`，确保新安装直接使用最新模型
- 新增迁移 0065：幂等地将已有部署 `builtin_tools` 表中 `claude_code` 记录的 `config.model` 从 `null` 更新为 `"claude-opus-4-8"`（仅当当前值为 `null` 时更新，不覆盖运维已自定义的模型设置）

# 风险与回滚
- 主要风险：迁移 0065 仅影响 `config ->> model IS NULL` 的行，已自定义模型的部署不受影响
- 回滚方式：`downgrade` 迁移 0065 将 `model` 恢复为 `null`；Interface / Tools 页面也可手动清空 Model Override 字段

# 验证证据
- 单元测试：86 个 Claude Code 相关单测全部通过（含 `test_claude_code_service`、`test_invoke_claude_code_defaults`、`test_runner_compact_retry`）
- 集成测试：迁移 0065 在测试数据库中成功执行 `upgrade`/`downgrade`
- E2E/Workflow：N/A
- 覆盖率/关键截图：pre-commit hooks（ruff lint/format）全部通过

# 影响范围
- 前端：Interface / Tools 页面 Claude Code 卡片 Model Override 字段将显示 `claude-opus-4-8`
- 后端：迁移 0039 种子常量 + 新迁移 0065；运行时 `ClaudeCodeConfig.model` 解析路径不变
- GitHub Actions / 文档：N/A

# Next Best Action
- 部署后验证 Interface / Tools 页面 Model Override 字段默认值为 `claude-opus-4-8`
- 确认 Routine 任务执行时 Claude Code 使用 `claude-opus-4-8` 模型