### PR TITLE
feat(Knowledge): Pipeline Run 卡片重试按钮移至首行状态标签左侧;

### DIFF
--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -202,6 +202,33 @@ function PipelineRunCardContent({
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {/* 双入口重试（断点续传 / 重新开始）：置于状态标签左侧，仅终态 + 可重试时显示 */}
+          {showRetryButtons && (
+            <>
+              {onResume && (
+                <button
+                  type="button"
+                  disabled={retrySubmitting}
+                  onClick={(e) => handleRetryClick(e, onResume)}
+                  title="从最后一个完成的切片继续处理（复用 checkpoint）"
+                  className="rounded-md bg-amber-600 px-2 py-0.5 text-caption font-semibold text-white shadow-sm transition-colors hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-amber-500 dark:hover:bg-amber-400"
+                >
+                  {retrySubmitting ? "处理中…" : "断点续传"}
+                </button>
+              )}
+              {onRestart && (
+                <button
+                  type="button"
+                  disabled={retrySubmitting}
+                  onClick={(e) => handleRetryClick(e, onRestart)}
+                  title="丢弃 checkpoint，全量重新处理"
+                  className="rounded-md border border-border px-2 py-0.5 text-caption font-semibold text-text-secondary transition-colors hover:border-foreground/40 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  重新开始
+                </button>
+              )}
+            </>
+          )}
           <PipelineStatusBadge status={status} />
           {showCancelButton && (
             <button
@@ -338,34 +365,6 @@ function PipelineRunCardContent({
         }
         return null;
       })()}
-
-      {/* 第五行：双入口重试（断点续传 / 重新开始）——仅终态 + 可重试时显示 */}
-      {showRetryButtons && (
-        <div className="mt-2 flex items-center gap-2">
-          {onResume && (
-            <button
-              type="button"
-              disabled={retrySubmitting}
-              onClick={(e) => handleRetryClick(e, onResume)}
-              title="从最后一个完成的切片继续处理（复用 checkpoint）"
-              className="rounded-md bg-amber-600 px-2.5 py-1 text-caption font-semibold text-white shadow-sm transition-colors hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-amber-500 dark:hover:bg-amber-400"
-            >
-              {retrySubmitting ? "处理中…" : "断点续传"}
-            </button>
-          )}
-          {onRestart && (
-            <button
-              type="button"
-              disabled={retrySubmitting}
-              onClick={(e) => handleRetryClick(e, onRestart)}
-              title="丢弃 checkpoint，全量重新处理"
-              className="rounded-md border border-border px-2.5 py-1 text-caption font-semibold text-text-secondary transition-colors hover:border-foreground/40 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              重新开始
-            </button>
-          )}
-        </div>
-      )}
     </>
   );
 }

--- a/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx
@@ -202,7 +202,7 @@ function PipelineRunCardContent({
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {/* 双入口重试（断点续传 / 重新开始）：置于状态标签左侧，仅终态 + 可重试时显示 */}
+          {/* 双入口重试（断点续传 / 重新开始）：置于状态标签左侧，canRetry 为真时显示（不限定 run 终态，详见上方 showRetryButtons 说明） */}
           {showRetryButtons && (
             <>
               {onResume && (

--- a/apps/negentropy-ui/tests/unit/knowledge/PipelineRunCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/PipelineRunCard.test.tsx
@@ -86,3 +86,69 @@ describe("PipelineRunCard 取消按钮", () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("PipelineRunCard 重试按钮（断点续传 / 重新开始）", () => {
+  it("canRetry=true 且提供 onResume/onRestart 时显示两个按钮", () => {
+    render(
+      <PipelineRunCard
+        {...baseProps}
+        status="failed"
+        canRetry
+        onResume={vi.fn()}
+        onRestart={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "断点续传" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "重新开始" })).toBeInTheDocument();
+  });
+
+  it("canRetry=false 时即使提供回调也不显示重试按钮", () => {
+    render(
+      <PipelineRunCard
+        {...baseProps}
+        status="failed"
+        canRetry={false}
+        onResume={vi.fn()}
+        onRestart={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "断点续传" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "重新开始" })).toBeNull();
+  });
+
+  it("点击「断点续传」触发 onResume", () => {
+    const onResume = vi.fn();
+    render(
+      <PipelineRunCard {...baseProps} status="failed" canRetry onResume={onResume} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "断点续传" }));
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("点击「重新开始」触发 onRestart", () => {
+    const onRestart = vi.fn();
+    render(
+      <PipelineRunCard {...baseProps} status="failed" canRetry onRestart={onRestart} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "重新开始" }));
+    expect(onRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("selectable 模式下点击重试按钮 stopPropagation 不触发 onSelect", () => {
+    const onSelect = vi.fn();
+    const onResume = vi.fn();
+    render(
+      <PipelineRunCard
+        {...baseProps}
+        status="failed"
+        mode="selectable"
+        canRetry
+        onSelect={onSelect}
+        onResume={onResume}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "断点续传" }));
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge / Pipelines 页 Pipeline Runs 卡片的「断点续传 / 重新开始」按钮原置于卡片底部独立一行，与状态徽标分离，失败态下重试操作不够直观、卡片偏高。
- 关联上下文/Issue/文档：用户附图（红框标注）要求将重试按钮移至卡片首行状态标签（如 `FAILED`）左侧。

# 核心变更
- 将 `PipelineRunCard` 双入口重试按钮（断点续传 / 重新开始）从第五行上移至首行 `<PipelineStatusBadge>` 之前，渲染顺序变为 `[断点续传][重新开始][状态徽标][取消X]`，即位于状态标签左侧。
- 按钮内边距由 `px-2.5 py-1` 收为 `px-2 py-0.5`，与徽标同高、不撑高首行；删除原第五行独立按钮块，终态失败卡片更紧凑。
- 回调与可见性契约（`canRetry`/`onResume`/`onRestart`）、`selectable` 模式 `stopPropagation` 防误选行为保持不变；重试与取消按钮按状态互斥，首行不会三者同现。

# 风险与回滚
- 主要风险：极低。纯前端单组件 JSX 位置调整，不触及 API / handler / 状态判定逻辑；长 Run ID 在窄卡片下的截断让位行为与原「徽标 + 取消」一致。
- 回滚方式：`git revert` 本 PR 合并提交即可恢复原底部按钮布局。

# 验证证据
- 单元测试：`PipelineRunCard.test.tsx` 15 passed（10 原取消用例 + 5 新增重试用例：存在性 / `canRetry=false` 隐藏 / 点击触发 `onResume`·`onRestart` / `selectable` 防冒泡）。
- 集成测试：不涉及（无后端 / 接口变更）。
- E2E/Workflow：浏览器实机视觉确认需后端存在 `failed`/`partial`/`cancelled` 且关联文档的 KB run 方可渲染按钮；本次为确定性位置调整（同 flex 容器内按钮先于徽标 → LTR 下必在其左），已由单测覆盖功能行为。
- 覆盖率/关键截图：`tsc --noEmit` 无错误；ESLint exit 0；pre-commit 钩子全部通过。

# 影响范围
- 前端：`apps/negentropy-ui/features/knowledge/components/PipelineRunCard.tsx`、`apps/negentropy-ui/tests/unit/knowledge/PipelineRunCard.test.tsx`。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后可对 `failed` 态 KB run 截图归档，作为该卡片布局的视觉基线。
