### PR TITLE
feat(Routine): 新增 Additional Dirs 只读目录配置;

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -92,6 +92,7 @@ interface FormState {
   max_events_per_iter: string;
   permission_mode: string;
   allowed_tools: string;
+  read_dirs: string;
   timeout_seconds: string;
   // 模板元数据（template entity）
   category: string;
@@ -119,6 +120,7 @@ const DEFAULTS: FormState = {
   max_events_per_iter: "",
   permission_mode: "",
   allowed_tools: "",
+  read_dirs: "",
   timeout_seconds: "",
   category: "general",
   version: "1.0.0",
@@ -146,13 +148,14 @@ const CATEGORY_OPTIONS = [
 ];
 
 /** 从 config 提取 Claude Code 覆盖键 → 表单字符串。 */
-function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "max_turns" | "max_events_per_iter" | "permission_mode" | "allowed_tools" | "timeout_seconds"> {
+function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "max_turns" | "max_events_per_iter" | "permission_mode" | "allowed_tools" | "read_dirs" | "timeout_seconds"> {
   return {
     model: (cfg.model as string) ?? "",
     max_turns: cfg.max_turns != null ? String(cfg.max_turns) : "1000",
     max_events_per_iter: cfg.max_events_per_iter != null ? String(cfg.max_events_per_iter) : "",
     permission_mode: (cfg.permission_mode as string) ?? "",
     allowed_tools: Array.isArray(cfg.allowed_tools) ? (cfg.allowed_tools as string[]).join(", ") : "",
+    read_dirs: Array.isArray(cfg.read_dirs) ? (cfg.read_dirs as string[]).join(", ") : "",
     timeout_seconds: cfg.timeout_seconds != null ? String(cfg.timeout_seconds) : "",
   };
 }
@@ -160,7 +163,7 @@ function ccFromConfig(cfg: Record<string, unknown>): Pick<FormState, "model" | "
 /** 将表单 CC 配置字段写入 config 对象（原地修改，ccFromConfig 的逆操作）。 */
 function applyCCConfig(
   config: Record<string, unknown>,
-  form: Pick<FormState, "model" | "max_turns" | "max_events_per_iter" | "permission_mode" | "allowed_tools" | "timeout_seconds">,
+  form: Pick<FormState, "model" | "max_turns" | "max_events_per_iter" | "permission_mode" | "allowed_tools" | "read_dirs" | "timeout_seconds">,
 ): void {
   if (form.model.trim()) config.model = form.model.trim();
   else delete config.model;
@@ -172,6 +175,8 @@ function applyCCConfig(
   else delete config.permission_mode;
   if (form.allowed_tools.trim()) config.allowed_tools = form.allowed_tools.split(",").map((s) => s.trim()).filter(Boolean);
   else delete config.allowed_tools;
+  if (form.read_dirs.trim()) config.read_dirs = form.read_dirs.split(",").map((s) => s.trim()).filter(Boolean);
+  else delete config.read_dirs;
   if (form.timeout_seconds.trim()) config.timeout_seconds = parseInt(form.timeout_seconds, 10);
   else delete config.timeout_seconds;
 }
@@ -668,32 +673,49 @@ export function RoutineEditDrawer({
 
             {/* ── Execution Context（仅 routine entity）── */}
             {entity === "routine" && (
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className={labelCls}>Project Path{requireWorktree && reqMark}</label>
-                  <input
-                    type="text"
-                    value={form.cwd}
-                    onChange={(e) => update("cwd", e.target.value)}
-                    disabled={readOnly}
-                    placeholder="/path/to/repo"
-                    className={cn(inputCls, fieldErrors.cwd && "border-red-400")}
-                  />
-                  {renderFieldError("cwd")}
+              <>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className={labelCls}>Project Path{requireWorktree && reqMark}</label>
+                    <input
+                      type="text"
+                      value={form.cwd}
+                      onChange={(e) => update("cwd", e.target.value)}
+                      disabled={readOnly}
+                      placeholder="/path/to/repo"
+                      className={cn(inputCls, fieldErrors.cwd && "border-red-400")}
+                    />
+                    {renderFieldError("cwd")}
+                  </div>
+                  <div>
+                    <label className={labelCls}>Baseline Branch{requireWorktree && reqMark}</label>
+                    <input
+                      type="text"
+                      value={form.baseline_branch}
+                      onChange={(e) => update("baseline_branch", e.target.value)}
+                      disabled={readOnly}
+                      placeholder="e.g. origin/feature/1.x.x"
+                      className={cn(inputCls, fieldErrors.baseline_branch && "border-red-400")}
+                    />
+                    {renderFieldError("baseline_branch")}
+                  </div>
                 </div>
                 <div>
-                  <label className={labelCls}>Baseline Branch{requireWorktree && reqMark}</label>
+                  <label className={labelCls}>Additional Dirs</label>
                   <input
                     type="text"
-                    value={form.baseline_branch}
-                    onChange={(e) => update("baseline_branch", e.target.value)}
+                    value={form.read_dirs}
+                    onChange={(e) => update("read_dirs", e.target.value)}
                     disabled={readOnly}
-                    placeholder="e.g. origin/feature/1.x.x"
-                    className={cn(inputCls, fieldErrors.baseline_branch && "border-red-400")}
+                    placeholder="/path/to/other/repo, /path/to/docs"
+                    className={inputCls}
                   />
-                  {renderFieldError("baseline_branch")}
+                  <p className="mt-1 text-caption text-text-secondary">
+                    额外授予 Claude Code 只读访问的目录（逗号分隔），映射到 <code className="text-xs">--add-dir</code>。仅 Project
+                    Worktree 可写，这些目录均为只读。
+                  </p>
                 </div>
-              </div>
+              </>
             )}
 
             {/* ── Verification ── */}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 配置页缺少 `config.read_dirs` 的可视化编辑入口，用户无法在创建或编辑 Routine 时声明 Claude Code 需要只读访问的额外目录。
- 关联上下文/Issue/文档：该字段映射后端已有的 `config.read_dirs` 契约，并由引擎转换为 Claude Code `--add-dir` 只读访问能力。

# 核心变更
- 在 Routine 编辑抽屉表单状态中新增 `read_dirs` 字段，并与 `config.read_dirs` 做双向映射。
- 在 Execution Context 区域新增 Additional Dirs 输入框，支持以逗号分隔多个目录。
- 保存 Routine 或模板时保留既有 config，仅增删当前表单管理的 Claude Code 配置键，避免覆盖未暴露配置。

# 风险与回滚
- 主要风险：用户输入不存在的目录时，后端会按既有 `_validate_read_dirs` 逻辑返回 422，需要用户修正路径后重试。
- 回滚方式：回滚本分支提交即可移除前端入口，后端既有 `config.read_dirs` 契约不受影响。

# 验证证据
- 单元测试：未新增专项单测，本次为单文件前端表单接线。
- 集成测试：未运行。
- E2E/Workflow：未运行。
- 覆盖率/关键截图：未采集。
- 静态验证：`pnpm --filter negentropy-ui typecheck`、`pnpm --filter negentropy-ui lint`、`git diff --check origin/feature/1.x.x...HEAD` 均通过。

# 影响范围
- 前端：Routine 创建/编辑抽屉新增 Additional Dirs 配置入口。
- 后端：无代码变更，复用既有 `config.read_dirs` 校验与执行链路。
- GitHub Actions / 文档：无变更。

# Next Best Action
- 合并前建议在实机 Routine 创建/编辑流程中录入一个存在目录，确认保存后详情返回的 `config.read_dirs` 与运行时 `--add-dir` 参数一致。
