### PR TITLE
feat(Knowledge): 文件上传大小限制从 50MB 提升至 200MB 并开放 YAML 配置

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
@@ -7,7 +7,7 @@ import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 // 支持的文件扩展名
 const SUPPORTED_EXTENSIONS = [".txt", ".md", ".markdown", ".pdf"];
-const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200MB
 
 interface AddSourceDialogProps {
   isOpen: boolean;

--- a/apps/negentropy-ui/app/knowledge/base/_components/IngestFileDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/IngestFileDialog.tsx
@@ -10,7 +10,7 @@ import { FileText, FileType, UploadCloud, X } from "lucide-react";
 // 常量
 // ---------------------------------------------------------------------------
 
-const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MB
 
 type FileTab = "pdf" | "markdown";
 
@@ -30,7 +30,7 @@ const TAB_CONFIG: Record<FileTab, TabConfig> = {
     Icon: FileText,
     description: "PDF 文档将通过 AI 提取转换为 Markdown",
     label: "PDF",
-    supportedFormats: "支持 .pdf（最大 50 MB）",
+    supportedFormats: "支持 .pdf（最大 200 MB）",
   },
   markdown: {
     accept: ".txt,.md,.markdown",
@@ -38,7 +38,7 @@ const TAB_CONFIG: Record<FileTab, TabConfig> = {
     Icon: FileType,
     description: "Markdown 与纯文本文件直接摄入，无需格式转换",
     label: "Markdown",
-    supportedFormats: "支持 .md, .markdown, .txt（最大 50 MB）",
+    supportedFormats: "支持 .md, .markdown, .txt（最大 200 MB）",
   },
 };
 

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -209,6 +209,7 @@ routine:
 
 # --- Knowledge 配置 ---
 knowledge:
+  max_file_size_mb: 200                   # 文件上传大小上限 (MB)
   # Wiki SSG ISR 主动 revalidate webhook：publish/unpublish 完成后向 SSG 通知立即重渲染。
   # 未配置 url → 退化为「被动 ISR」（SSG 自身 5 分钟窗口刷新），不阻塞发布主链路。
   # secret 通过环境变量 NE_KNOWLEDGE_WIKI_REVALIDATE__SECRET 注入（生产必填，本地可空）。

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -127,6 +127,13 @@ class KnowledgeSettings(BaseSettings):
         frozen=True,
     )
 
+    max_file_size_mb: int = Field(
+        default=200,
+        ge=1,
+        le=1024,
+        description="Knowledge 文件上传大小上限 (MB)。",
+    )
+
     default_extractor_routes: DefaultExtractorRoutesSettings = Field(
         default_factory=DefaultExtractorRoutesSettings,
     )

--- a/apps/negentropy/src/negentropy/knowledge/routes/ingest.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/ingest.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError  # noqa: F401
 
 from negentropy.auth.deps import get_optional_user
 from negentropy.auth.service import AuthUser
+from negentropy.config import settings
 from negentropy.knowledge._shared import (
     _extract_legacy_chunking_payload,
     _get_service,
@@ -245,10 +246,6 @@ async def ingest_url(
         ) from exc
 
 
-# 文件大小限制 (50MB)
-MAX_FILE_SIZE = 50 * 1024 * 1024
-
-
 async def _extract_and_store_document_markdown_from_gcs(
     *,
     document_id: UUID,
@@ -396,14 +393,15 @@ async def ingest_file(
         content = await file.read()
 
         # 文件大小验证
-        if len(content) > MAX_FILE_SIZE:
+        max_file_size = settings.knowledge.max_file_size_mb * 1024 * 1024
+        if len(content) > max_file_size:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={
                     "code": "FILE_TOO_LARGE",
-                    "message": f"File size exceeds limit ({MAX_FILE_SIZE / 1024 / 1024:.0f}MB)",
+                    "message": f"File size exceeds limit ({max_file_size / 1024 / 1024:.0f}MB)",
                     "size": len(content),
-                    "max_size": MAX_FILE_SIZE,
+                    "max_size": max_file_size,
                 },
             )
 


### PR DESCRIPTION
## 变更摘要

Knowledge / Knowledge Base Corpus 的「Ingest from File」功能文件上传大小限制从 **50MB** 提升至 **200MB**，并将该值开放给 YAML 配置。

## 改动内容

| 文件 | 变更 |
|------|------|
| `config/knowledge.py` | `KnowledgeSettings` 新增 `max_file_size_mb` 字段（默认 200，范围 1-1024） |
| `config.default.yaml` | `knowledge` 段新增 `max_file_size_mb: 200` 默认值 |
| `routes/ingest.py` | 消除硬编码 `MAX_FILE_SIZE` 常量，改用 `settings.knowledge.max_file_size_mb` |
| `IngestFileDialog.tsx` | 前端限制值与提示文案从 50 MB → 200 MB |
| `AddSourceDialog.tsx` | 前端限制值从 50MB → 200MB |

## 配置方式

```yaml
# config.local.yaml
knowledge:
  max_file_size_mb: 500
```

或环境变量：`NE_KNOWLEDGE_MAX_FILE_SIZE_MB=500`