### PR TITLE
feat(Knowledge-Translate): 翻译任务接入 PipelineRun 追踪，Pipelines 页可见翻译流水线

### DIFF
--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -749,7 +749,8 @@ export type PipelineOperation =
   | "import_document"
   | "replace_source"
   | "sync_source"
-  | "rebuild_source";
+  | "rebuild_source"
+  | "translate";
 
 /**
  * Pipeline 错误对象。

--- a/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/pipeline-helpers.ts
@@ -24,6 +24,7 @@ export const OPERATION_LABELS: Record<string, string> = {
   replace_source: "替换源",
   sync_source: "同步源",
   rebuild_source: "重建源",
+  translate: "文档翻译",
   graph_build: "图谱构建",
 };
 
@@ -57,6 +58,11 @@ export const STAGE_ORDER = [
   "chunk",
   "embed",
   "persist",
+  // 翻译阶段
+  "chunking",
+  "agent_execution",
+  "validation",
+  "storing",
   // KG 构建阶段
   "kg_extracting",
   "kg_resolving",
@@ -87,6 +93,11 @@ export const STAGE_LABELS: Record<string, string> = {
   chunk: "文本分块",
   embed: "向量化",
   persist: "持久化",
+  // 翻译阶段
+  chunking: "文档分块",
+  agent_execution: "Agent 翻译",
+  validation: "校验拼接",
+  storing: "译文落库",
   // KG 构建阶段
   kg_extracting: "实体抽取",
   kg_resolving: "实体消解",
@@ -241,6 +252,31 @@ export const STAGE_COLORS: Record<
     completed: "bg-cyan-500",
     failed: "bg-cyan-700",
     skipped: "bg-cyan-300 dark:bg-cyan-600",
+  },
+  // 翻译阶段
+  chunking: {
+    running: "bg-amber-400",
+    completed: "bg-amber-500",
+    failed: "bg-amber-700",
+    skipped: "bg-amber-300 dark:bg-amber-600",
+  },
+  agent_execution: {
+    running: "bg-purple-400",
+    completed: "bg-purple-500",
+    failed: "bg-purple-700",
+    skipped: "bg-purple-300 dark:bg-purple-600",
+  },
+  validation: {
+    running: "bg-orange-400",
+    completed: "bg-orange-500",
+    failed: "bg-orange-700",
+    skipped: "bg-orange-300 dark:bg-orange-600",
+  },
+  storing: {
+    running: "bg-teal-400",
+    completed: "bg-teal-500",
+    failed: "bg-teal-700",
+    skipped: "bg-teal-300 dark:bg-teal-600",
   },
 };
 

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -392,18 +392,18 @@ async def translate_documents(
     """批量翻译文档（Documents 页 Translate 按钮）。
 
     执行链：本端点逐文档资格检查并同步置 ``metadata_.translation.status=processing``
-    （列表轮询立刻可见）→ BackgroundTasks 派发 ``DocumentTranslationService`` →
-    InfluenceFaculty（装配 document-translate 技能 + invoke_claude_code）驱动 Claude Code
+    （列表轮询立刻可见）→ 创建 PipelineRun 记录 → BackgroundTasks 派发
+    ``KnowledgeService.execute_translate_pipeline`` → InfluenceFaculty
+    （装配 document-translate 技能 + invoke_claude_code）驱动 Claude Code
     分块翻译 → 译文作为新文档分录落库（metadata 标记译自来源）。
     """
     from datetime import UTC, datetime
 
-    from negentropy.knowledge.translation import DocumentTranslationService
     from negentropy.storage.service import DocumentStorageService
 
     resolved_app = _resolve_app_name(payload.app_name)
     storage_service = DocumentStorageService()
-    translation_service = DocumentTranslationService()
+    service = _get_service()
 
     accepted: list[UUID] = []
     skipped: list[DocumentTranslateSkipped] = []
@@ -413,6 +413,17 @@ async def translate_documents(
         if reason:
             skipped.append(DocumentTranslateSkipped(document_id=document_id, reason=reason))
             continue
+
+        # 创建 PipelineRun 记录（Pipelines 页面可见）
+        run_id = await service.create_pipeline(
+            app_name=resolved_app,
+            operation="translate",
+            input_data={
+                "document_id": str(document_id),
+                "target_language": payload.target_language,
+                "filename": doc.original_filename,
+            },
+        )
 
         await storage_service.update_document_metadata(
             document_id=document_id,
@@ -427,9 +438,11 @@ async def translate_documents(
             },
         )
         background_tasks.add_task(
-            translation_service.translate_document,
+            service.execute_translate_pipeline,
+            run_id=run_id,
             document_id=document_id,
             target_language=payload.target_language,
+            app_name=resolved_app,
         )
         accepted.append(document_id)
 

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -118,7 +118,8 @@ def _extract_source_label(input_data: dict[str, Any]) -> str:
 
 
 # Pipeline 操作类型
-PipelineOperation = str  # "ingest_text" | "ingest_url" | "replace_source" | "sync_source" | "rebuild_source"
+PipelineOperation = str  # noqa: E501
+# "ingest_text" | "ingest_url" | "replace_source" | "sync_source" | "rebuild_source" | "translate"
 
 # Pipeline 阶段状态
 PipelineStageStatus = str  # "pending" | "running" | "completed" | "failed" | "skipped"
@@ -2249,6 +2250,68 @@ class KnowledgeService:
         except Exception as exc:
             await self._fail_pipeline_execution(tracker, exc)
             return []
+        finally:
+            try:
+                await tracker.ensure_finalized()
+            except Exception:
+                pass
+            unregister_cancellable_run(run_id)
+
+    async def execute_translate_pipeline(
+        self,
+        *,
+        run_id: str,
+        document_id: UUID,
+        target_language: str,
+        app_name: str,
+    ) -> None:
+        """执行 translate Pipeline（后台任务）。
+
+        由 BackgroundTasks 调用，使用已有的 run_id 追踪翻译各阶段执行状态。
+        翻译实际工作委托 DocumentTranslationService，tracker 通过参数透传至
+        服务内部，在 chunking / agent_execution / validation / storing 四个
+        阶段边界记录状态。
+        """
+        if not self._pipeline_dao:
+            raise ValueError("pipeline_dao is required for async pipeline operations")
+
+        tracker = PipelineTracker(
+            dao=self._pipeline_dao,
+            app_name=app_name,
+            operation="translate",
+            run_id=run_id,
+        )
+        await self._resume_async_pipeline_tracker(tracker)
+
+        logger.info(
+            "pipeline_execution_started",
+            run_id=run_id,
+            document_id=str(document_id),
+            operation="translate",
+        )
+
+        try:
+            from negentropy.knowledge.translation import DocumentTranslationService
+
+            translation_service = DocumentTranslationService()
+            await translation_service.translate_document(
+                document_id=document_id,
+                target_language=target_language,
+                tracker=tracker,
+            )
+            await tracker.complete({"document_id": str(document_id)})
+
+            logger.info(
+                "pipeline_execution_completed",
+                run_id=run_id,
+                document_id=str(document_id),
+                operation="translate",
+            )
+
+        except PipelineCancelled as cancel_exc:
+            await tracker.cancel(last_stage=cancel_exc.last_stage)
+        except Exception as exc:
+            await self._fail_pipeline_execution(tracker, exc)
         finally:
             try:
                 await tracker.ensure_finalized()

--- a/apps/negentropy/src/negentropy/knowledge/translation/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/translation/service.py
@@ -88,10 +88,17 @@ class DocumentTranslationService:
         self._max_chars = max_chars
 
     # ------------------------------------------------------------------ #
-    # 入口：BackgroundTasks 调用，永不向上抛（失败落 metadata + 日志）。
+    # 入口：BackgroundTasks 调用。失败落 metadata + 日志；
+    # 当 tracker 存在时 re-raise 以便 execute_translate_pipeline 写 fail 终态。
     # ------------------------------------------------------------------ #
 
-    async def translate_document(self, *, document_id: UUID, target_language: str = "zh") -> None:
+    async def translate_document(
+        self,
+        *,
+        document_id: UUID,
+        target_language: str = "zh",
+        tracker: Any | None = None,
+    ) -> None:
         async with _INFLIGHT_LOCK:
             if document_id in _INFLIGHT:
                 logger.info("document_translation_inflight_skip", document_id=str(document_id))
@@ -99,7 +106,7 @@ class DocumentTranslationService:
             _INFLIGHT.add(document_id)
         try:
             async with _SEMAPHORE:
-                await self._run(document_id=document_id, target_language=target_language)
+                await self._run(document_id=document_id, target_language=target_language, tracker=tracker)
         except Exception as exc:
             logger.error(
                 "document_translation_failed",
@@ -113,6 +120,8 @@ class DocumentTranslationService:
                 target_language=target_language,
                 error=str(exc)[:500],
             )
+            if tracker:
+                raise
         finally:
             _INFLIGHT.discard(document_id)
 
@@ -120,7 +129,7 @@ class DocumentTranslationService:
     # 主流程
     # ------------------------------------------------------------------ #
 
-    async def _run(self, *, document_id: UUID, target_language: str) -> None:
+    async def _run(self, *, document_id: UUID, target_language: str, tracker: Any | None = None) -> None:
         from negentropy.storage.service import DocumentStorageService
 
         storage = DocumentStorageService()
@@ -145,6 +154,11 @@ class DocumentTranslationService:
         chunks = split_markdown(markdown, max_chars=self._max_chars)
         if not chunks:
             raise TranslationError("split_markdown returned no chunks for non-empty markdown")
+
+        if tracker:
+            await tracker.start_stage("chunking")
+            await tracker.complete_stage("chunking", output={"chunk_count": len(chunks)})
+
         workdir = Path(tempfile.mkdtemp(prefix=f"negentropy-translate-{str(document_id)[:8]}-"))
         try:
             await self._execute_in_workdir(
@@ -154,6 +168,7 @@ class DocumentTranslationService:
                 chunks=chunks,
                 workdir=workdir,
                 target_language=target_language,
+                tracker=tracker,
             )
         except Exception:
             # 失败保留 workdir 供排障（错误信息由入口写 metadata）。
@@ -174,6 +189,7 @@ class DocumentTranslationService:
         chunks: list[str],
         workdir: Path,
         target_language: str,
+        tracker: Any | None = None,
     ) -> None:
         source_dir = workdir / "source"
         translated_dir = workdir / "translated"
@@ -196,6 +212,9 @@ class DocumentTranslationService:
             tool_timeout=tool_timeout,
         )
 
+        # 阶段：Agent 翻译执行（含可选重跑）
+        if tracker:
+            await tracker.start_stage("agent_execution")
         await asyncio.wait_for(self._run_influence(task_msg), timeout=total_timeout)
 
         invalid = self._invalid_chunks(translated_dir, chunks)
@@ -212,11 +231,21 @@ class DocumentTranslationService:
             invalid = self._invalid_chunks(translated_dir, chunks)
             if invalid:
                 raise TranslationError(f"translated chunks invalid after retry: {invalid[:5]}")
+        if tracker:
+            await tracker.complete_stage("agent_execution", output={"chunk_count": chunk_count})
 
+        # 阶段：校验拼接
+        if tracker:
+            await tracker.start_stage("validation")
         translated_md, warnings = self._assemble_and_validate(
             chunks=chunks, translated_dir=translated_dir, source_markdown=markdown
         )
+        if tracker:
+            await tracker.complete_stage("validation", output={"warnings_count": len(warnings)})
 
+        # 阶段：译文落库
+        if tracker:
+            await tracker.start_stage("storing")
         target_doc = await self._store_target_document(
             storage=storage,
             source_doc=doc,
@@ -224,6 +253,8 @@ class DocumentTranslationService:
             target_language=target_language,
             warnings=warnings,
         )
+        if tracker:
+            await tracker.complete_stage("storing", output={"target_document_id": str(target_doc.id)})
 
         await self._mark_translation(
             doc.id,


### PR DESCRIPTION
## 概述

翻译任务接入 PipelineRun 追踪体系，翻译执行过程在 Pipelines 页面可见。

## 变更内容

### 后端
- **service.py**: 新增 `execute_translate_pipeline` 方法，遵循 `execute_ingest_text_pipeline` 模式，将翻译流程纳入 PipelineRun 追踪
- **translation/service.py**: `translate_document`/`_run`/`_execute_in_workdir` 接入可选 `tracker` 参数，在 chunking / agent_execution / validation / storing 四阶段边界追踪状态；tracker 存在时 re-raise 以上报 PipelineRun
- **routes/documents.py**: `translate` endpoint 创建 PipelineRun 记录并切换 BackgroundTask 目标

### 前端
- **knowledge-api.ts**: 追加 `translate` 操作类型
- **pipeline-helpers.ts**: 翻译阶段展示常量

## 验证

```bash
# 后端单测
uv run pytest tests/ -x -q

# 前端单测
pnpm --filter negentropy-ui test
```

## 关联

- 前置 PR: #905（文档批量翻译功能 — Translate 按钮与 InfluenceFaculty 执行链）
- 本 PR 仅包含 PipelineRun 追踪增量变更（5 文件，+155 / -11）