### PR TITLE
feat(Interface): Agents 卡片点击编辑、拖拽排序与 Edit 对话框 Tab 化重构

### DIFF
--- a/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
@@ -59,26 +59,8 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
     >
       <TiltedCard disabled={isDragging}>
         <div
-          role={canEdit ? "button" : undefined}
-          tabIndex={canEdit ? 0 : undefined}
-          aria-label={
-            canEdit
-              ? `Edit ${agent.display_name || agent.name}`
-              : undefined
-          }
-          onClick={canEdit ? onEdit : undefined}
-          onKeyDown={
-            canEdit
-              ? (e: React.KeyboardEvent) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    onEdit();
-                  }
-                }
-              : undefined
-          }
           className={[
-            "flex h-full flex-col overflow-hidden rounded-xl border bg-card p-4 transition-colors",
+            "relative flex h-full flex-col overflow-hidden rounded-xl border bg-card p-4 transition-colors",
             canEdit
               ? "cursor-pointer border-border hover:border-primary/30"
               : "border-border",
@@ -87,7 +69,15 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
             .filter(Boolean)
             .join(" ")}
         >
-          <div className="flex min-h-0 flex-1 flex-col">
+          {canEdit && (
+            <button
+              type="button"
+              aria-label={`Edit ${agent.display_name || agent.name}`}
+              onClick={onEdit}
+              className="absolute inset-0 z-10 cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          )}
+          <div className="relative z-20 flex min-h-0 flex-1 flex-col pointer-events-none">
             {/* Header: drag handle + title + delete */}
             <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
               <div className="flex min-w-0 items-start gap-1">
@@ -96,7 +86,7 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
                   {...listeners}
                   type="button"
                   aria-label={`Drag ${agent.display_name || agent.name}`}
-                  className="mt-0.5 cursor-grab rounded p-1.5 text-text-muted/40 transition-colors hover:bg-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+                  className="pointer-events-auto mt-0.5 cursor-grab rounded p-1.5 text-text-muted/40 transition-colors hover:bg-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
                 >
                   <GripVertical className="h-4 w-4" />
                 </button>
@@ -113,7 +103,7 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
                     }}
                     title="Delete Agent"
                     aria-label={`Delete ${agent.display_name || agent.name}`}
-                    className="cursor-pointer rounded-md p-1.5 text-text-muted transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                    className="pointer-events-auto cursor-pointer rounded-md p-1.5 text-text-muted transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:bg-red-900/20 dark:hover:text-red-400"
                   >
                     <Trash2 className="h-4 w-4" />
                   </button>

--- a/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
@@ -2,6 +2,9 @@
 
 import { useAuth } from "@/components/providers/AuthProvider";
 import { TiltedCard } from "@/components/ui/TiltedCard";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Trash2 } from "lucide-react";
 
 interface Agent {
   id: string;
@@ -33,119 +36,175 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
   const { user } = useAuth();
   const isAdmin = user?.roles?.includes("admin") ?? false;
   const canEdit = isAdmin || !agent.is_builtin;
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: agent.id });
+
+  const sortableStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
-    <TiltedCard>
-    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-card p-4">
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
-          <h3 className="truncate text-lg font-semibold text-foreground">
-            {agent.display_name || agent.name}
-          </h3>
-          <div className="flex shrink-0 items-center gap-2">
-            {canEdit && (
-              <>
+    <div
+      ref={setNodeRef}
+      style={sortableStyle}
+      className={isDragging ? "relative z-10" : undefined}
+    >
+      <TiltedCard disabled={isDragging}>
+        <div
+          role={canEdit ? "button" : undefined}
+          tabIndex={canEdit ? 0 : undefined}
+          aria-label={
+            canEdit
+              ? `Edit ${agent.display_name || agent.name}`
+              : undefined
+          }
+          onClick={canEdit ? onEdit : undefined}
+          onKeyDown={
+            canEdit
+              ? (e: React.KeyboardEvent) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onEdit();
+                  }
+                }
+              : undefined
+          }
+          className={[
+            "flex h-full flex-col overflow-hidden rounded-xl border bg-card p-4 transition-colors",
+            canEdit
+              ? "cursor-pointer border-border hover:border-primary/30"
+              : "border-border",
+            isDragging ? "opacity-50 shadow-lg" : undefined,
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <div className="flex min-h-0 flex-1 flex-col">
+            {/* Header: drag handle + title + delete */}
+            <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
+              <div className="flex min-w-0 items-start gap-1">
                 <button
-                  onClick={onEdit}
-                  title="Edit Agent"
-                  aria-label={`Edit ${agent.display_name || agent.name}`}
-                  className="cursor-pointer rounded-md p-2 text-text-muted transition-colors hover:bg-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+                  {...attributes}
+                  {...listeners}
+                  type="button"
+                  aria-label={`Drag ${agent.display_name || agent.name}`}
+                  className="mt-0.5 cursor-grab rounded p-1.5 text-text-muted/40 transition-colors hover:bg-muted hover:text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
+                  <GripVertical className="h-4 w-4" />
                 </button>
-                <button
-                  onClick={onDelete}
-                  title="Delete Agent"
-                  aria-label={`Delete ${agent.display_name || agent.name}`}
-                  className="cursor-pointer rounded-md p-2 text-text-muted transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                <h3 className="truncate text-lg font-semibold text-foreground">
+                  {agent.display_name || agent.name}
+                </h3>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                {canEdit && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete();
+                    }}
+                    title="Delete Agent"
+                    aria-label={`Delete ${agent.display_name || agent.name}`}
+                    className="cursor-pointer rounded-md p-1.5 text-text-muted transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Badges */}
+            <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap pl-6">
+              {agent.is_enabled ? (
+                <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                  Enabled
+                </span>
+              ) : (
+                <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-text-secondary">
+                  Disabled
+                </span>
+              )}
+              <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
+                {agent.agent_type}
+              </span>
+              <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                {agent.visibility}
+              </span>
+              {agent.kind === "root" && (
+                <span
+                  className="inline-flex shrink-0 items-center rounded-full bg-violet-100 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:bg-violet-900/30 dark:text-violet-300"
+                  title="Negentropy 主 Agent，编辑后通过 InstructionProvider 在运行时生效"
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  Root
+                </span>
+              )}
+              {agent.is_builtin && (
+                <span
+                  className="inline-flex min-w-0 items-center truncate rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                  title="系统内置：对全员可见，仅 admin 可编辑"
+                >
+                  Built-In
+                </span>
+              )}
+            </div>
+
+            {/* Description */}
+            <p
+              className="mb-1 ml-6 h-[60px] min-w-0 w-full overflow-hidden leading-5 line-clamp-3 text-sm text-text-muted"
+              title={agent.description || "No description"}
+            >
+              {agent.description || "No description"}
+            </p>
+
+            {/* Footer metadata */}
+            <div className="mt-auto flex ml-6 min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-text-muted">
+              {agent.model && (
+                <span className="inline-flex min-w-0 items-center gap-1 truncate" title={agent.model}>
+                  <svg className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                   </svg>
-                </button>
-              </>
-            )}
+                  <span className="truncate">{agent.model}</span>
+                </span>
+              )}
+              {"agent_class" in agent.adk_config &&
+                typeof agent.adk_config["agent_class"] === "string" && (
+                <span
+                  className="inline-flex min-w-0 items-center gap-1 truncate"
+                  title={String(agent.adk_config["agent_class"])}
+                >
+                  <svg className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                  <span className="truncate">{String(agent.adk_config["agent_class"])}</span>
+                </span>
+              )}
+              {agent.tools && agent.tools.length > 0 && (
+                <span className="inline-flex shrink-0 items-center gap-1">
+                  <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  {agent.tools.length} tools
+                </span>
+              )}
+              <span className="inline-flex min-w-0 items-center gap-1 truncate" title={`source: ${agent.source}`}>
+                <svg className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span className="truncate">source: {agent.source}</span>
+              </span>
+            </div>
           </div>
         </div>
-        <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
-          {agent.is_enabled ? (
-            <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
-              Enabled
-            </span>
-          ) : (
-            <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-text-secondary">
-              Disabled
-            </span>
-          )}
-          <span className="inline-flex shrink-0 items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">
-            {agent.agent_type}
-          </span>
-          <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
-            {agent.visibility}
-          </span>
-          {agent.kind === "root" && (
-            <span
-              className="inline-flex shrink-0 items-center rounded-full bg-violet-100 px-2 py-0.5 text-xs font-semibold text-violet-700 dark:bg-violet-900/30 dark:text-violet-300"
-              title="Negentropy 主 Agent，编辑后通过 InstructionProvider 在运行时生效"
-            >
-              Root
-            </span>
-          )}
-          {agent.is_builtin && (
-            <span
-              className="inline-flex min-w-0 items-center truncate rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
-              title="系统内置：对全员可见，仅 admin 可编辑"
-            >
-              Built-In
-            </span>
-          )}
-        </div>
-        <p
-          className="mb-1 h-[60px] min-w-0 w-full overflow-hidden leading-5 line-clamp-3 text-sm text-text-muted"
-          title={agent.description || "No description"}
-        >
-          {agent.description || "No description"}
-        </p>
-        <div className="mt-auto flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-text-muted">
-          {agent.model && (
-            <span className="inline-flex min-w-0 items-center gap-1 truncate" title={agent.model}>
-              <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
-              <span className="truncate">{agent.model}</span>
-            </span>
-          )}
-          {"agent_class" in agent.adk_config &&
-            typeof agent.adk_config["agent_class"] === "string" && (
-            <span
-              className="inline-flex min-w-0 items-center gap-1 truncate"
-              title={String(agent.adk_config["agent_class"])}
-            >
-              <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-              <span className="truncate">{String(agent.adk_config["agent_class"])}</span>
-            </span>
-          )}
-          {agent.tools && agent.tools.length > 0 && (
-            <span className="inline-flex shrink-0 items-center gap-1">
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-              {agent.tools.length} tools
-            </span>
-          )}
-          <span className="inline-flex min-w-0 items-center gap-1 truncate" title={`source: ${agent.source}`}>
-            <svg className="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
-            <span className="truncate">source: {agent.source}</span>
-          </span>
-        </div>
-      </div>
+      </TiltedCard>
     </div>
-    </TiltedCard>
   );
 }

--- a/apps/negentropy-ui/app/interface/agents/_components/AgentFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentFormDialog.tsx
@@ -6,14 +6,22 @@
  */
 "use client";
 
-import { useState, useEffect, useId } from "react";
-import { ChevronRight } from "lucide-react";
+import { useState, useEffect, useId, type ReactNode } from "react";
+import {
+  Settings2,
+  MessageSquareCode,
+  Wrench,
+} from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
 import { BaseModal } from "@/components/ui/BaseModal";
 import { LlmModelSelect } from "@/components/ui/LlmModelSelect";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
-import { fetchModelConfigs, type ModelConfigItem } from "@/features/knowledge/utils/knowledge-api";
+import {
+  fetchModelConfigs,
+  type ModelConfigItem,
+} from "@/features/knowledge/utils/knowledge-api";
+import { cn } from "@/lib/utils";
 
 interface Agent {
   id: string;
@@ -55,7 +63,60 @@ const INPUT =
   "w-full rounded-md border border-border bg-input px-3 py-1.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring";
 const MONO =
   "w-full rounded-md border border-border bg-input px-3 py-1.5 text-sm font-mono text-foreground outline-none focus:ring-1 focus:ring-ring";
-const LABEL = "mb-1 block text-xs font-medium text-text-muted";
+const LABEL = "mb-1.5 block text-xs font-medium text-text-muted";
+
+/* ── Tab definitions ── */
+const TABS = [
+  { key: "general", label: "General", icon: Settings2 },
+  { key: "prompt-tools", label: "Prompt & Tools", icon: MessageSquareCode },
+  { key: "advanced", label: "Advanced", icon: Wrench },
+] as const;
+
+type TabKey = (typeof TABS)[number]["key"];
+
+function TabButton({
+  label,
+  icon: Icon,
+  active,
+  onClick,
+  tabId,
+  panelId,
+}: {
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  active: boolean;
+  onClick: () => void;
+  tabId: string;
+  panelId: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={tabId}
+      aria-selected={active}
+      aria-controls={panelId}
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-text-muted hover:text-text-secondary",
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {label}
+    </button>
+  );
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="mb-3 mt-1 text-[11px] font-medium uppercase tracking-wider text-text-muted/60">
+      {children}
+    </div>
+  );
+}
 
 export function AgentFormDialog({
   open,
@@ -65,6 +126,8 @@ export function AgentFormDialog({
 }: AgentFormDialogProps) {
   const { confirm, confirmDialog } = useConfirmDialog();
   const formId = useId();
+  const tabBaseId = useId();
+  const [activeTab, setActiveTab] = useState<TabKey>("general");
   const [formData, setFormData] = useState({
     name: "",
     display_name: "",
@@ -103,6 +166,7 @@ export function AgentFormDialog({
       is_enabled: true,
       visibility: "private",
     });
+    setSelectedTemplateName(template.name);
   };
 
   useEffect(() => {
@@ -146,6 +210,7 @@ export function AgentFormDialog({
       setSelectedTemplateName("");
     }
     setError(null);
+    setActiveTab("general");
   }, [agent, open]);
 
   useEffect(() => {
@@ -295,11 +360,280 @@ export function AgentFormDialog({
     }
   };
 
-  /* ── Helper: update a single form field ── */
   const setField = <K extends keyof typeof formData>(
     key: K,
     value: (typeof formData)[K],
   ) => setFormData((prev) => ({ ...prev, [key]: value }));
+
+  /* ── Tab: General ── */
+  const renderGeneral = () => (
+    <div className="space-y-5">
+      {/* Template selector (create only) */}
+      {!agent && templates.length > 0 && (
+        <div>
+          <SectionLabel>Template</SectionLabel>
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {templates.map((t) => {
+              const selected = selectedTemplateName === t.name;
+              return (
+                <button
+                  key={t.name}
+                  type="button"
+                  onClick={() =>
+                    selected
+                      ? setSelectedTemplateName("")
+                      : setSelectedTemplateName(t.name)
+                  }
+                  className={cn(
+                    "flex shrink-0 flex-col rounded-lg border px-3 py-2 text-left transition-all min-w-[140px] max-w-[200px]",
+                    selected
+                      ? "border-primary bg-primary/5 ring-2 ring-primary/20"
+                      : "border-border bg-card hover:border-border/80 hover:bg-muted/50",
+                  )}
+                >
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {t.display_name || t.name}
+                  </span>
+                  {t.description && (
+                    <span className="mt-0.5 line-clamp-2 text-[11px] leading-tight text-text-muted">
+                      {t.description}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          {selectedTemplateName && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              onClick={() => {
+                const target = templates.find(
+                  (item) => item.name === selectedTemplateName,
+                );
+                if (target) applyTemplate(target);
+              }}
+            >
+              Apply Template
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Identity */}
+      <SectionLabel>Identity</SectionLabel>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <label className={LABEL}>Name *</label>
+          <input
+            type="text"
+            value={formData.name}
+            onChange={(e) => setField("name", e.target.value)}
+            className={INPUT}
+            placeholder="my-agent"
+            required
+          />
+        </div>
+        <div>
+          <label className={LABEL}>Display Name</label>
+          <input
+            type="text"
+            value={formData.display_name}
+            onChange={(e) => setField("display_name", e.target.value)}
+            className={INPUT}
+            placeholder="My Agent"
+          />
+        </div>
+      </div>
+      <div>
+        <label className={LABEL}>Description</label>
+        <textarea
+          value={formData.description}
+          onChange={(e) => setField("description", e.target.value)}
+          className={INPUT}
+          rows={2}
+          placeholder="Brief description of this agent"
+        />
+      </div>
+
+      {/* Runtime */}
+      <SectionLabel>Runtime</SectionLabel>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <label className={LABEL}>Agent Type *</label>
+          <select
+            value={formData.agent_type}
+            onChange={(e) => setField("agent_type", e.target.value)}
+            className={INPUT}
+          >
+            <option value="llm_agent">LLM Agent</option>
+            <option value="sequential_agent">Sequential Agent</option>
+            <option value="parallel_agent">Parallel Agent</option>
+            <option value="loop_agent">Loop Agent</option>
+            <option value="custom_agent">Custom Agent</option>
+          </select>
+        </div>
+        <div>
+          <label className={LABEL}>Model</label>
+          <LlmModelSelect
+            models={llmModels}
+            value={formData.model}
+            onChange={(v) => setField("model", v)}
+            allowClear
+            placeholder="Default"
+            ariaLabel="Agent 使用的 LLM"
+            className="w-full"
+          />
+        </div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <label className={LABEL}>Visibility</label>
+          <select
+            value={formData.visibility}
+            onChange={(e) => setField("visibility", e.target.value)}
+            className={INPUT}
+          >
+            <option value="private">Private</option>
+            <option value="shared">Shared</option>
+            <option value="public">Public</option>
+          </select>
+        </div>
+        <div className="flex items-end pb-0.5">
+          <label className="flex items-center gap-3 text-sm text-text-secondary">
+            <button
+              type="button"
+              role="switch"
+              aria-checked={formData.is_enabled}
+              onClick={() => setField("is_enabled", !formData.is_enabled)}
+              className={cn(
+                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                formData.is_enabled ? "bg-primary" : "bg-border",
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                  formData.is_enabled ? "translate-x-4" : "translate-x-0",
+                )}
+              />
+            </button>
+            Enabled
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+
+  /* ── Tab: Prompt & Tools ── */
+  const renderPromptTools = () => (
+    <div className="space-y-5">
+      <SectionLabel>System Prompt</SectionLabel>
+      <div>
+        <textarea
+          value={formData.system_prompt}
+          onChange={(e) => setField("system_prompt", e.target.value)}
+          className={MONO}
+          rows={8}
+          placeholder="You are a specialized agent for..."
+        />
+      </div>
+
+      <SectionLabel>Tools</SectionLabel>
+      <div>
+        {availableTools.length > 0 && (
+          <div className="mb-2.5 flex flex-wrap gap-1.5">
+            {availableTools.map((t) => {
+              const currentTools = formData.tools
+                .split("\n")
+                .map((s) => s.trim())
+                .filter(Boolean);
+              const isSelected = currentTools.includes(t.name);
+              return (
+                <button
+                  key={t.name}
+                  type="button"
+                  onClick={() => {
+                    const tools = formData.tools
+                      .split("\n")
+                      .map((s) => s.trim())
+                      .filter(Boolean);
+                    const next = isSelected
+                      ? tools.filter((n) => n !== t.name)
+                      : [...tools, t.name];
+                    setField("tools", next.join("\n"));
+                  }}
+                  className={
+                    "inline-flex cursor-pointer items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
+                    (isSelected
+                      ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+                      : "bg-muted text-text-secondary hover:bg-border/60 dark:hover:bg-border")
+                  }
+                >
+                  <span className="text-micro opacity-60">
+                    {t.source === "builtin" ? "●" : "◆"}
+                  </span>
+                  {t.display_name || t.name}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        <textarea
+          value={formData.tools}
+          onChange={(e) => setField("tools", e.target.value)}
+          className={MONO}
+          rows={3}
+          placeholder="Select from above or type tool names (one per line)"
+        />
+      </div>
+    </div>
+  );
+
+  /* ── Tab: Advanced ── */
+  const renderAdvanced = () => (
+    <div className="space-y-5">
+      <SectionLabel>Skills</SectionLabel>
+      <div>
+        <textarea
+          value={formData.skills}
+          onChange={(e) => setField("skills", e.target.value)}
+          className={MONO}
+          rows={3}
+          placeholder="code-review&#10;document-analysis"
+        />
+      </div>
+
+      <SectionLabel>Configuration</SectionLabel>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label className={LABEL}>Config (JSON)</label>
+          <textarea
+            value={formData.config}
+            onChange={(e) => setField("config", e.target.value)}
+            className={MONO}
+            rows={6}
+            placeholder='{"temperature": 0.7}'
+          />
+        </div>
+        <div>
+          <label className={LABEL}>ADK Config (JSON)</label>
+          <textarea
+            value={formData.adk_config}
+            onChange={(e) => setField("adk_config", e.target.value)}
+            className={MONO}
+            rows={6}
+            placeholder='{"agent_class":"LlmAgent","output_key":"perception_output"}'
+          />
+          <p className="mt-1 text-[11px] text-text-muted">
+            Full-fidelity ADK config. Empty → auto-generate minimal config.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <>
@@ -308,7 +642,7 @@ export function AgentFormDialog({
         title={agent ? "Edit Agent" : "Add Agent"}
         subtitle="Configure agent properties and runtime behavior"
         onClose={onClose}
-        size="xl"
+        size="2xl"
         closeOnBackdrop={!loading}
         closeOnEscape={!loading}
         footer={
@@ -328,243 +662,41 @@ export function AgentFormDialog({
         }
       >
         <form id={formId} onSubmit={handleSubmit} className="space-y-4">
-          {/* ── Template selector (create only) ── */}
-          {!agent && templates.length > 0 && (
-            <div className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2">
-              <span className="shrink-0 text-xs text-text-muted">
-                Template
-              </span>
-              <select
-                value={selectedTemplateName}
-                onChange={(e) => setSelectedTemplateName(e.target.value)}
-                className={INPUT}
-              >
-                <option value="">Select template</option>
-                {templates.map((t) => (
-                  <option key={t.name} value={t.name}>
-                    {t.display_name || t.name}
-                  </option>
-                ))}
-              </select>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={!selectedTemplateName}
-                onClick={() => {
-                  const target = templates.find(
-                    (item) => item.name === selectedTemplateName,
-                  );
-                  if (target) applyTemplate(target);
-                }}
-              >
-                Apply
-              </Button>
-            </div>
-          )}
-
           {error && <ErrorBanner message={error} />}
 
-          {/* ── Identity ── */}
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div>
-              <label className={LABEL}>Name *</label>
-              <input
-                type="text"
-                value={formData.name}
-                onChange={(e) => setField("name", e.target.value)}
-                className={INPUT}
-                placeholder="my-agent"
-                required
-              />
-            </div>
-            <div>
-              <label className={LABEL}>Display Name</label>
-              <input
-                type="text"
-                value={formData.display_name}
-                onChange={(e) => setField("display_name", e.target.value)}
-                className={INPUT}
-                placeholder="My Agent"
-              />
-            </div>
-          </div>
-          <div>
-            <label className={LABEL}>Description</label>
-            <textarea
-              value={formData.description}
-              onChange={(e) => setField("description", e.target.value)}
-              className={INPUT}
-              rows={2}
-              placeholder="Brief description of this agent"
-            />
-          </div>
-
-          {/* ── Runtime ── */}
-          <div className="border-t border-border" />
-
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div>
-              <label className={LABEL}>Agent Type *</label>
-              <select
-                value={formData.agent_type}
-                onChange={(e) => setField("agent_type", e.target.value)}
-                className={INPUT}
-              >
-                <option value="llm_agent">LLM Agent</option>
-                <option value="sequential_agent">Sequential Agent</option>
-                <option value="parallel_agent">Parallel Agent</option>
-                <option value="loop_agent">Loop Agent</option>
-                <option value="custom_agent">Custom Agent</option>
-              </select>
-            </div>
-            <div>
-              <label className={LABEL}>Model</label>
-              <LlmModelSelect
-                models={llmModels}
-                value={formData.model}
-                onChange={(v) => setField("model", v)}
-                allowClear
-                placeholder="Default"
-                ariaLabel="Agent 使用的 LLM"
-                className="w-full"
-              />
-            </div>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div>
-              <label className={LABEL}>Visibility</label>
-              <select
-                value={formData.visibility}
-                onChange={(e) => setField("visibility", e.target.value)}
-                className={INPUT}
-              >
-                <option value="private">Private</option>
-                <option value="shared">Shared</option>
-                <option value="public">Public</option>
-              </select>
-            </div>
-            <div className="flex items-end pb-0.5">
-              <label className="flex items-center gap-2 text-xs text-text-muted">
-                <input
-                  type="checkbox"
-                  checked={formData.is_enabled}
-                  onChange={(e) => setField("is_enabled", e.target.checked)}
-                  className="rounded border-border"
+          {/* Tab bar */}
+          <div
+            role="tablist"
+            className="-mx-6 -mt-3 flex gap-0 overflow-x-auto border-b border-border px-6"
+          >
+            {TABS.map((tab) => {
+              const tabId = `${tabBaseId}-tab-${tab.key}`;
+              const panelId = `${tabBaseId}-panel-${tab.key}`;
+              return (
+                <TabButton
+                  key={tab.key}
+                  label={tab.label}
+                  icon={tab.icon}
+                  active={activeTab === tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  tabId={tabId}
+                  panelId={panelId}
                 />
-                Enabled
-              </label>
-            </div>
+              );
+            })}
           </div>
 
-          <div>
-            <label className={LABEL}>System Prompt</label>
-            <textarea
-              value={formData.system_prompt}
-              onChange={(e) => setField("system_prompt", e.target.value)}
-              className={MONO}
-              rows={4}
-              placeholder="You are a specialized agent for..."
-            />
+          {/* Tab panels */}
+          <div
+            role="tabpanel"
+            id={`${tabBaseId}-panel-${activeTab}`}
+            aria-labelledby={`${tabBaseId}-tab-${activeTab}`}
+            className="pt-1"
+          >
+            {activeTab === "general" && renderGeneral()}
+            {activeTab === "prompt-tools" && renderPromptTools()}
+            {activeTab === "advanced" && renderAdvanced()}
           </div>
-
-          {/* ── Tools ── */}
-          <div className="border-t border-border" />
-
-          <div>
-            <label className={LABEL}>Tools</label>
-            {availableTools.length > 0 && (
-              <div className="mb-2 flex flex-wrap gap-1.5">
-                {availableTools.map((t) => {
-                  const currentTools = formData.tools
-                    .split("\n")
-                    .map((s) => s.trim())
-                    .filter(Boolean);
-                  const isSelected = currentTools.includes(t.name);
-                  return (
-                    <button
-                      key={t.name}
-                      type="button"
-                      onClick={() => {
-                        const tools = formData.tools
-                          .split("\n")
-                          .map((s) => s.trim())
-                          .filter(Boolean);
-                        const next = isSelected
-                          ? tools.filter((n) => n !== t.name)
-                          : [...tools, t.name];
-                        setField("tools", next.join("\n"));
-                      }}
-                      className={
-                        "inline-flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
-                        (isSelected
-                          ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
-                          : "bg-muted text-text-secondary hover:bg-border/60 dark:hover:bg-border")
-                      }
-                    >
-                      <span className="text-micro opacity-60">
-                        {t.source === "builtin" ? "●" : "◆"}
-                      </span>
-                      {t.display_name || t.name}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-            <textarea
-              value={formData.tools}
-              onChange={(e) => setField("tools", e.target.value)}
-              className={MONO}
-              rows={2}
-              placeholder="Select from above or type tool names (one per line)"
-            />
-          </div>
-
-          {/* ── Advanced Configuration ── */}
-          <details className="group border-t border-border pt-3">
-            <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium text-text-muted transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
-              <ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" />
-              Advanced Configuration
-            </summary>
-            <div className="mt-3 space-y-4">
-              <div>
-                <label className={LABEL}>Skills (one per line)</label>
-                <textarea
-                  value={formData.skills}
-                  onChange={(e) => setField("skills", e.target.value)}
-                  className={MONO}
-                  rows={3}
-                  placeholder="code-review&#10;document-analysis"
-                />
-              </div>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div>
-                  <label className={LABEL}>Config (JSON)</label>
-                  <textarea
-                    value={formData.config}
-                    onChange={(e) => setField("config", e.target.value)}
-                    className={MONO}
-                    rows={6}
-                    placeholder='{"temperature": 0.7}'
-                  />
-                </div>
-                <div>
-                  <label className={LABEL}>ADK Config (JSON)</label>
-                  <textarea
-                    value={formData.adk_config}
-                    onChange={(e) => setField("adk_config", e.target.value)}
-                    className={MONO}
-                    rows={6}
-                    placeholder='{"agent_class":"LlmAgent","output_key":"perception_output"}'
-                  />
-                  <p className="mt-1 text-[11px] text-text-muted">
-                    Full-fidelity ADK config. Empty → auto-generate minimal
-                    config.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </details>
         </form>
       </BaseModal>
       {confirmDialog}

--- a/apps/negentropy-ui/app/interface/agents/page.tsx
+++ b/apps/negentropy-ui/app/interface/agents/page.tsx
@@ -67,6 +67,7 @@ export default function AgentsPage() {
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingAgent, setEditingAgent] = useState<Agent | null>(null);
+  const [manualOrder, setManualOrder] = useState(false);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -85,6 +86,7 @@ export default function AgentsPage() {
       }
       const data = await response.json();
       setAgents(data);
+      setManualOrder(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
@@ -160,6 +162,7 @@ export default function AgentsPage() {
   };
 
   const sortedAgents = useMemo(() => {
+    if (manualOrder) return agents;
     const rank = (agent: Agent) => (agent.kind === "root" ? 0 : 1);
     return [...agents].sort((a, b) => {
       const diff = rank(a) - rank(b);
@@ -168,13 +171,14 @@ export default function AgentsPage() {
       }
       return a.name.localeCompare(b.name);
     });
-  }, [agents]);
+  }, [agents, manualOrder]);
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
       if (!over || active.id === over.id) return;
 
+      setManualOrder(true);
       setAgents((prev) => {
         const oldIndex = prev.findIndex((a) => a.id === active.id);
         const newIndex = prev.findIndex((a) => a.id === over.id);

--- a/apps/negentropy-ui/app/interface/agents/page.tsx
+++ b/apps/negentropy-ui/app/interface/agents/page.tsx
@@ -6,8 +6,23 @@
  */
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { Bot } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  rectSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -34,7 +49,6 @@ interface Agent {
   source: string;
   is_builtin: boolean;
   is_enabled: boolean;
-  // "root" = Negentropy 主 Agent；"agent"（默认）= Faculty 或用户自定义 Agent
   kind?: "root" | "agent";
 }
 
@@ -53,6 +67,15 @@ export default function AgentsPage() {
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingAgent, setEditingAgent] = useState<Agent | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   const fetchAgents = async () => {
     try {
@@ -136,7 +159,6 @@ export default function AgentsPage() {
     setEditingAgent(null);
   };
 
-  // Root Agent 置顶；其余按 name 字典序保持稳定，避免 fetchAgents 顺序波动。
   const sortedAgents = useMemo(() => {
     const rank = (agent: Agent) => (agent.kind === "root" ? 0 : 1);
     return [...agents].sort((a, b) => {
@@ -147,6 +169,21 @@ export default function AgentsPage() {
       return a.name.localeCompare(b.name);
     });
   }, [agents]);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      setAgents((prev) => {
+        const oldIndex = prev.findIndex((a) => a.id === active.id);
+        const newIndex = prev.findIndex((a) => a.id === over.id);
+        if (oldIndex === -1 || newIndex === -1) return prev;
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    },
+    [],
+  );
 
   const handleFormSubmit = async (data: Record<string, unknown>) => {
     try {
@@ -179,7 +216,7 @@ export default function AgentsPage() {
       <div className="flex-1 overflow-auto">
         <div className="px-6 py-6">
           <div className="w-full">
-            <div className="flex items-center justify-between mb-6">
+            <div className="mb-6 flex items-center justify-between">
               <div>
                 <h1 className="text-2xl font-bold text-foreground">
                   Agents
@@ -235,20 +272,31 @@ export default function AgentsPage() {
                 }
               />
             ) : (
-              <div
-                data-testid="agents-grid"
-                className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
               >
-                {sortedAgents.map((agent) => (
-                  <div key={agent.id} className="h-[176px]" data-testid="agent-grid-item">
-                    <AgentCard
-                      agent={agent}
-                      onEdit={() => handleEdit(agent)}
-                      onDelete={() => handleDelete(agent.id)}
-                    />
+                <SortableContext
+                  items={sortedAgents.map((a) => a.id)}
+                  strategy={rectSortingStrategy}
+                >
+                  <div
+                    data-testid="agents-grid"
+                    className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
+                  >
+                    {sortedAgents.map((agent) => (
+                      <div key={agent.id} className="h-[176px]" data-testid="agent-grid-item">
+                        <AgentCard
+                          agent={agent}
+                          onEdit={() => handleEdit(agent)}
+                          onDelete={() => handleDelete(agent.id)}
+                        />
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
+                </SortableContext>
+              </DndContext>
             )}
           </div>
         </div>

--- a/apps/negentropy-ui/components/ui/BaseModal.tsx
+++ b/apps/negentropy-ui/components/ui/BaseModal.tsx
@@ -37,7 +37,7 @@ export interface BaseModalProps {
    * 卡片宽度档位。`md` ≈ max-w-md（创建对话框等表单），`lg` ≈ max-w-lg
    * （节点选择树等更宽视图）。默认 `md`。
    */
-  size?: "sm" | "md" | "lg" | "xl";
+  size?: "sm" | "md" | "lg" | "xl" | "2xl";
   /**
    * 是否允许点击遮罩关闭。默认 `true`；正在执行不可中断的提交流时可关闭。
    */
@@ -53,6 +53,7 @@ const SIZE_CLASS: Record<NonNullable<BaseModalProps["size"]>, string> = {
   md: "max-w-md",
   lg: "max-w-lg",
   xl: "max-w-2xl",
+  "2xl": "max-w-3xl",
 };
 
 const SPRING_TRANSITION = { type: "spring" as const, damping: 28, stiffness: 320 };

--- a/apps/negentropy-ui/components/ui/TiltedCard.tsx
+++ b/apps/negentropy-ui/components/ui/TiltedCard.tsx
@@ -22,6 +22,8 @@ interface TiltedCardProps {
   scaleOnHover?: number;
   /** 弹簧物理参数。 */
   springConfig?: { damping: number; stiffness: number; mass: number };
+  /** 禁用倾斜效果（拖拽场景下使用）。 */
+  disabled?: boolean;
 }
 
 /**
@@ -38,6 +40,7 @@ export function TiltedCard({
   tiltAmplitude = 8,
   scaleOnHover = 1.03,
   springConfig = DEFAULT_SPRING,
+  disabled = false,
 }: TiltedCardProps) {
   const prefersReduced = useReducedMotion();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -95,9 +98,9 @@ export function TiltedCard({
     rawShadowProgress.set(0);
   }, [rawRotateX, rawRotateY, rawScale, rawShadowProgress]);
 
-  /* ---- prefers-reduced-motion 降级 ---- */
+  /* ---- prefers-reduced-motion / disabled 降级 ---- */
 
-  if (prefersReduced) {
+  if (prefersReduced || disabled) {
     return <div className={className}>{children}</div>;
   }
 

--- a/apps/negentropy-ui/tests/unit/interface/AgentCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/interface/AgentCard.test.tsx
@@ -12,6 +12,17 @@ vi.mock("@/components/ui/TiltedCard", () => ({
   TiltedCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
 const baseAgent = {
   id: "a1",
   owner_id: "u1",
@@ -33,12 +44,16 @@ const baseAgent = {
 };
 
 describe("AgentCard", () => {
-  it("calls edit and delete handlers", async () => {
+  it("calls edit handler on card click and delete handler on delete button", async () => {
     const onEdit = vi.fn();
     const onDelete = vi.fn();
     render(<AgentCard agent={baseAgent} onEdit={onEdit} onDelete={onDelete} />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Edit PerceptionFaculty" }));
+    // Clicking the card body triggers onEdit
+    const card = screen.getByRole("button", { name: "Edit PerceptionFaculty" });
+    await userEvent.click(card);
+
+    // Delete button triggers onDelete
     await userEvent.click(screen.getByRole("button", { name: "Delete PerceptionFaculty" }));
 
     expect(onEdit).toHaveBeenCalledTimes(1);
@@ -50,9 +65,11 @@ describe("AgentCard", () => {
       <AgentCard agent={baseAgent} onEdit={vi.fn()} onDelete={vi.fn()} />
     );
 
-    // mock TiltedCard 包裹一层 div，实际卡片是其子元素
-    const root = container.firstElementChild?.firstElementChild;
-    expect(root).toHaveClass("h-full");
+    // DOM: useSortable div > TiltedCard div > card div (with h-full)
+    const sortableWrapper = container.firstElementChild;
+    const tiltedCardWrapper = sortableWrapper?.firstElementChild;
+    const card = tiltedCardWrapper?.firstElementChild;
+    expect(card).toHaveClass("h-full");
 
     const description = screen.getByText((content) => content.includes("Handles long description"));
     expect(description).toHaveAttribute("title", baseAgent.description);


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface / Agents 页面的卡片缺乏直观交互——点击卡片无响应（需精准点击角落小图标）、卡片无法排序、Edit Agent 表单扁平冗长且信息层次不足；
- 关联上下文/Issue/文档：基于 Agents 页面 UI 交互升级需求（点击卡片即编辑、拖拽排序对齐、Edit 模态框 UX 重构）。

# 核心变更
- **整卡点击编辑**：AgentCard 主体升级为 `role=button`（含 `aria-label` / `tabIndex` / Enter & Space 键盘支持），点击任意区域打开 Edit 模态框；移除独立 Edit 按钮，Delete 按钮以 `stopPropagation` 隔离；不可编辑卡片（非 admin 的 Built-In）保持无点击行为；
- **网格拖拽排序**：基于既有依赖 `@dnd-kit/sortable`（`rectSortingStrategy`）+ `@dnd-kit/core`（`PointerSensor` 8px 激活距离 + `KeyboardSensor` 方向键排序），左上角 `GripVertical` 手柄触发拖拽，与点击编辑互不干扰；拖拽态 `opacity-50 + shadow-lg`，松手自动吸附网格对齐；
- **Edit 对话框 Tab 化重构**：表单拆分为 General / Prompt & Tools / Advanced 三个 Tab（完整 `tab/tabpanel` aria 关联），模板选择器从下拉升级为横向卡片列表，Enabled 从 checkbox 升级为 toggle switch（`role=switch`），模态框宽度升级至 `2xl`（max-w-3xl）；
- **基础组件最小扩展**：TiltedCard 新增 `disabled` prop（拖拽期间禁用 3D 倾斜），BaseModal `SIZE_CLASS` 新增 `2xl` 档位。

# 风险与回滚
- 主要风险：AgentCard DOM 结构变化（新增 sortable 包裹层与拖拽手柄）可能影响依赖其结构的样式或测试——已同步适配单元测试；拖拽排序为纯客户端行为，刷新后恢复默认排序（Root 置顶 + name 字典序），无后端写入风险；
- 回滚方式：revert 本提交即可，无数据库迁移、无 API 变更、无依赖新增（@dnd-kit 此前已在 package.json 中）。

# 验证证据
- 单元测试：`tests/unit/interface/` 全量通过（10 个测试文件 / 24 个用例），AgentCard 测试已适配新交互（整卡点击触发 onEdit、Delete 按钮独立触发 onDelete）；
- 集成测试：N/A（纯前端 UI 交互变更）；
- E2E/Workflow：N/A；
- 覆盖率/关键截图：ESLint 0 error 0 warning；`tsc --noEmit` 对改动文件无新增错误；pre-commit hooks（ESLint negentropy-ui）通过。

# 影响范围
- 前端：`apps/negentropy-ui` Interface / Agents 页面（page.tsx、AgentCard、AgentFormDialog）及通用组件 TiltedCard、BaseModal（均为向后兼容的可选 prop / 枚举扩展，不影响既有调用方）；
- 后端：无；
- GitHub Actions / 文档：无。

# Next Best Action
- 若需排序持久化，可在后端 Agent 模型增加 `sort_order` 字段并在 `onDragEnd` 中 PATCH 写回（fractional indexing 模式可参考 Wiki Catalog Tree 的实现）；
- AgentFormDialog 的 Tab 布局模式可推广至 SkillFormDialog / ToolFormDialog / McpServerFormDialog，统一 Interface 系列表单的 UX 范式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)