### PR TITLE
docs(Knowledge): 自进化 Agents Team 调研报告与生产级技术方案

### DIFF
--- a/docs/.agents/knowledge-map.md
+++ b/docs/.agents/knowledge-map.md
@@ -25,6 +25,7 @@
 - [QA Delivery Pipeline](../concepts/design/qa-delivery-pipeline.md)
 - [Docker Release Pipeline](../concepts/design/docker-release-pipeline.md) — compose 栈 4 镜像（backend / perceives / ui / wiki）的多架构构建与 Docker Hub 发布：PR 构建校验 + tag 发布双入口，amd64+arm64 原生 runner + digest 合并 + provenance/SBOM
 - [浏览器操作 MCP 集成方案](../concepts/design/browser-automation-mcp-integration.md) — Playwright MCP 全系统默认配备：单一注入点（builtin_tools.mcp_config）provision 至 Routine / Scheduler / 6 Agents，用于浏览器实机回归验证
+- [自进化 Agents Team 方案](../concepts/design/self-evolving-agents.md) — 三层自进化架构（固定框架 Meta-Layer / 动态 Agent 定义 / 外部能力工具）：遥测→评测→提案→验证→门控发布全闭环，含 agent_versions 版本化、GEPA/ACE 进化算子、Golden Set 双轨评测、金丝雀发布、护栏决策矩阵与四阶段演进路线（调研基础见 [130 号调研](../research/130-self-evolving-agents-team.md)）
 
 ## 系统能力概览
 
@@ -58,6 +59,7 @@
 - [ADK 2.0 升级调研](../research/020b-adk-2.0-upgrade.md) — Google ADK 2.0 核心新特性、Breaking Changes、本项目影响评估与渐进式升级路径
 - [Routine Agent 迭代模式调研](../research/110-routine-agent-iteration.md) — ReAct/Reflexion/Self-Refine/LATS/Voyager + LLM-as-Judge + Claude Code/Codex/Gemini/OpenHands 工程实践与停止护栏（长周期自主任务理论基础）
 - [浏览器操作 MCP 调研](../research/120-browser-automation-mcp.md) — Playwright MCP / Chrome DevTools MCP / claude-in-chrome / Webwright 等纵向深挖与横向决策矩阵，结合"6 Agents + 自治 Routine"两类上下文的选型论证（集成落地见 [集成方案](../concepts/design/browser-automation-mcp-integration.md)）
+- [自进化 Agents Team 调研](../research/130-self-evolving-agents-team.md) — 自进化智能体理论（DGM/ADAS/AlphaEvolve/AgentSquare）+ 进化算子（GEPA/ACE/DSPy）+ 评测回路（Agent-as-a-Judge/OTel/Langfuse）+ 工具生态自进化（MCP Registry/Agent Skills/LLM 自造工具）+ 护栏治理（OWASP Agentic Top 10/金丝雀/Goodhart 防护），映射至三层自进化架构（技术方案见 [自进化 Agents Team 方案](../concepts/design/self-evolving-agents.md)）
 
 ## 用户文档与运维
 

--- a/docs/concepts/design/self-evolving-agents.md
+++ b/docs/concepts/design/self-evolving-agents.md
@@ -389,7 +389,7 @@ evolution_proposals
 - `is_global` 技能与 root Agent prompt 的 canary 比例上限更低；
 - 全系统同一时间窗在途 canary 数量上限。
 
-### 8.4 防好hart 四件套
+### 8.4 防 Goodhart 四件套
 
 1. **冻结 holdout 集**（`is_frozen = true`）：结果不回流 proposer；
 2. **多目标判据**：质量 AND 成本 AND 延迟 AND 在线确认——单指标最优不可晋升；

--- a/docs/concepts/design/self-evolving-agents.md
+++ b/docs/concepts/design/self-evolving-agents.md
@@ -1,0 +1,510 @@
+# 自进化 Agents Team 系统技术方案
+
+> 本文遵循 [AGENTS.md](../../AGENTS.md) 的协作协议与循证要求。
+>
+> 设计核心锚定：
+> - 调研基础：[自进化 Agents Team 调研](../../research/130-self-evolving-agents-team.md)
+> - 理论先例：[Routine 迭代模式调研](../../research/110-routine-agent-iteration.md)
+> - 子系统参考：[Routine 系统](../039-the-routine-system.md)、[Skills 设计](./skills.md)、[可观测性](./observability-genai.md)
+> - 权威源：[engine/routine/decision.py](../../../apps/negentropy/src/negentropy/engine/routine/decision.py)（护栏范式）、[models/skill.py](../../../apps/negentropy/src/negentropy/models/skill.py)（版本快照范式）
+
+---
+
+## 0. 范围与定位
+
+### 设计对象
+
+| 层 | 名称 | 进化语义 | 改动通道 |
+|----|------|---------|---------|
+| Meta-Layer | **固定框架（进化基座）** | 不可被进化回路修改 | 仅 Git PR + 人工 Merge |
+| Evolvable-1 | **动态 Agent 定义** | `system_prompt` / model / skills 挂载可进化 | DB `active_version` 指针切换 |
+| Evolvable-2 | **外部能力工具** | Skills prompt_template / Builtin Tool config / MCP pipeline 参数可进化 | DB 版本表 + 缓存失效 |
+
+**总纲**：进化 = 数据变更（DB 白名单字段），框架 = 代码（变更唯一通道 Git PR 人工 Merge，复用 Routine `pr_url` 产 PR 等待人工 Merge 的既有先例）。
+
+**范围外**：模型权重训练/微调、框架代码的自动合并。
+
+---
+
+## 1. 理论锚点与核心论断
+
+### 1.1 核心论断
+
+本系统不是「从零造进化框架」，而是把平台已分散存在的四个进化原语收敛为一条统一的 **遥测 → 评测 → 提案 → 验证 → 门控发布** 流水线：
+
+| 已有原语 | 实现位置 | 进化回路角色 |
+|---------|---------|-------------|
+| LLM-as-Judge 评测 | [engine/routine/evaluator.py](../../../apps/negentropy/src/negentropy/engine/routine/evaluator.py) | 评测引擎 |
+| Reflexion 反思 | [engine/consolidation/reflection_generator.py](../../../apps/negentropy/src/negentropy/engine/consolidation/reflection_generator.py) | 进化算子的学习信号 |
+| SemVer 版本快照 | [models/skill.py](../../../apps/negentropy/src/negentropy/models/skill.py) `skill_versions` 表 | 版本注册表 |
+| 竞争择优 | perceives [pipeline_config.py](../../../apps/negentropy/src/negentropy/perceives/config/pipeline_config.py) `competition_mode` | A/B 对比验证 |
+
+### 1.2 学术锚点
+
+| 理论 | 来源 | 映射 |
+|------|------|------|
+| 统一闭环抽象 | Fang et al. (arXiv:2508.07407)<sup>[[1]](#ref1)</sup> | System Inputs→Agent System→Environment→Optimisers 对应 Dispatch→Execute→Evaluate→Decide |
+| 评估器中心主义 | AlphaEvolve (arXiv:2506.13131)<sup>[[2]](#ref2)</sup> | 每个待进化对象必须先有可量化 evaluator |
+| 反思驱动进化 | GEPA (arXiv:2507.19457, ICLR 2026 Oral)<sup>[[3]](#ref3)</sup> | (轨迹, 标量分, 反思文本) 三元组与 routines.reflections 同构 |
+| 增量上下文进化 | ACE (arXiv:2510.04618, ICLR 2026)<sup>[[4]](#ref4)</sup> | Curator 确定性合并 + delta 更新，防 context collapse |
+| 档案库进化 | DGM (arXiv:2505.22954)<sup>[[5]](#ref5)</sup> | 版本表应保留全部历史（含表现较差但多样的版本） |
+
+---
+
+## 2. 三层架构总览
+
+```mermaid
+flowchart TB
+    subgraph "Meta-Layer（固定框架，不可被进化修改）"
+        direction LR
+        TEL["📡 遥测采集<br/>tool_invocations<br/>interaction_feedback"]
+        EVAL["🔬 评测引擎<br/>LLM-as-Judge<br/>Agent-as-a-Judge<br/>Golden Set 双轨"]
+        PROP["🧬 进化提案器<br/>GEPA 反思→变异<br/>ACE delta 沉淀"]
+        ORCH["⚙️ 编排调度<br/>evolution_proposals 状态机<br/>evolution_inspector 心跳"]
+        DEC["🛡️ 护栏裁决<br/>decision.py 纯函数<br/>人审门控矩阵"]
+    end
+
+    subgraph "Evolvable-1：动态 Agent 定义"
+        A1["PerceptionFaculty"]
+        A2["InternalizationFaculty"]
+        A3["ContemplationFaculty"]
+        A4["ActionFaculty"]
+        A5["InfluenceFaculty"]
+    end
+
+    subgraph "Evolvable-2：外部能力工具"
+        S["Skills<br/>prompt_template"]
+        BT["Builtin Tools<br/>config JSONB"]
+        MCP["MCP Pipeline<br/>Stage 参数"]
+    end
+
+    A1 & A2 & A3 & A4 & A5 -->|"执行轨迹 + 反馈"| TEL
+    S & BT & MCP -->|"调用结果 + 延迟/成本"| TEL
+    TEL -->|"信号聚合"| EVAL
+    EVAL -->|"标量分 + 归因<br/>+ 反思文本"| PROP
+    PROP -->|"候选版本<br/>(SemVer 快照)"| ORCH
+    ORCH -->|"shadow eval<br/>+ canary 验证"| DEC
+    DEC -->|"promote/rollback<br/>(指针切换)"| A1 & A2 & A3 & A4 & A5
+    DEC -->|"promote/rollback<br/>(指针切换)"| S
+    DEC -->|"参数/排名更新"| BT & MCP
+
+    style TEL fill:#1f3a5f,stroke:#5b9bd5,stroke-width:2px,color:#e8f0fe
+    style EVAL fill:#3d2c52,stroke:#a07cc5,stroke-width:2px,color:#f3e9fb
+    style PROP fill:#5a3d1f,stroke:#d59b5b,stroke-width:2px,color:#fdf3e8
+    style ORCH fill:#1f4d2e,stroke:#5bbd7c,stroke-width:2px,color:#e8fbef
+    style DEC fill:#4d1f1f,stroke:#d55b5b,stroke-width:2px,color:#fde8e8
+```
+
+### 2.1 「框架不自改」四道边界
+
+参考 [engine/routine/decision.py](../../../apps/negentropy/src/negentropy/engine/routine/decision.py) 的护栏纯函数范式：
+
+1. **晋升/回滚判据为纯函数硬编码**：新增 `engine/evolution/decision.py`，与 `routine/decision.py` 同构——无 IO、可单测、阈值不读自可被进化的表；
+2. **DB 权限隔离**：进化 worker 使用独立 DB role，仅授予进化登记簿 + 资产版本表写权限，无法 UPDATE 框架配置表；
+3. **进化对象白名单为代码常量**：枚举 `target_kind`（agent_prompt / skill_template / builtin_tool_config / mcp_pipeline），新增类型必须改代码走 PR；
+4. **框架改进降级为 PR 提案**：由 Routine（Claude Code）起草 PR，人工 Merge，绝不自动合并。
+
+---
+
+## 3. 遥测子系统（数据地基）
+
+### 3.1 现状盘点
+
+| 表 | 覆盖范围 | 写入方 | 缺口 |
+|----|---------|--------|------|
+| `routine_iteration_events` | Claude Code 动作级 | `streaming_persister` | 仅 Routine 内 |
+| `mcp_tool_runs` + events | trial UI / 知识抽取 | `McpToolExecutionService` | 非主运行时 |
+| `tools` / `tool_executions` | ADK 工具调用 | **Dormant（无写入方）** | 核心缺口 |
+| `traces` | OTel span 入库 | LiteLLM 回调 | LLM 调用级，非工具级 |
+| `knowledge_feedback` | 用户反馈 | API | 仅知识域 |
+
+### 3.2 新表 `tool_invocations`
+
+统一工具调用事实表（append-only），关键字段：
+
+```
+tool_invocations
+├── id                    UUID PK
+├── caller_kind           ENUM(adk_agent, routine, skill_invoke, mcp_trial, scheduled_task)
+├── agent_name            TEXT NULLABLE        -- 调用方 Agent
+├── thread_id             UUID NULLABLE        -- 会话（松耦合，对齐 ToolExecution.run_id 注释）
+├── routine_iteration_id  UUID NULLABLE        -- Routine 关联
+├── tool_kind             ENUM(builtin, mcp, adk_function, skill)
+├── tool_ref              TEXT                 -- 工具标识
+├── tool_version          TEXT NULLABLE        -- 版本（skill 时为 SemVer）
+├── skill_ref             TEXT NULLABLE        -- 技能展开时的技能标识
+├── status                ENUM(success, error, denied, timeout)
+├── latency_ms            INTEGER
+├── error_class           TEXT NULLABLE
+├── input_digest          TEXT NULLABLE        -- 截断摘要 + hash（16KB 上限）
+├── output_digest         TEXT NULLABLE
+├── tokens_in/out         INTEGER NULLABLE
+├── cost_usd              FLOAT NULLABLE
+├── trace_id/span_id      TEXT NULLABLE        -- 反查 Langfuse
+├── canary_assignment     TEXT NULLABLE        -- 进化实验标记
+├── outcome_score         FLOAT NULLABLE       -- 异步归因回填
+├── outcome_source        TEXT NULLABLE        -- (routine_verdict, thread_feedback, attribution_job)
+├── created_at            TIMESTAMPTZ
+```
+
+字段对齐 OTel `execute_tool` span schema（`gen_ai.tool.name` → `tool_ref`、`gen_ai.tool.type` → `tool_kind`、`gen_ai.tool.call.arguments/result` → `input/output_digest`）。
+
+### 3.3 采集挂点（三源归一）
+
+1. **ADK 侧**：新增 `before/after_tool_callback`（当前仓库未用，是新挂点）统一上报；
+2. **Routine 侧**：由 `streaming_persister` 写 `routine_iteration_events` 时旁路双写；
+3. **MCP trial 侧**：由 `McpToolExecutionService` 旁路双写。
+
+### 3.4 聚合与反馈
+
+- `tool_stats_daily` 聚合表：成功率 / p50·p95 延迟 / 成本 / 调用量，按 `tool_ref` + `version` 分桶；
+- `interaction_feedback` 新表（对齐 `knowledge_feedback` 范式）：`thread_id` / `event_id` / `agent_name` / `feedback_type`(thumbs_up/down|rating|correction) / `score` / `comment` / `source`(human|code|llm_judge)；
+- Langfuse 深接：`proposal_id` / `eval_run_id` / `canary_assignment` 写入 trace metadata。
+
+---
+
+## 4. 评测子系统
+
+### 4.1 新表四件套
+
+```
+eval_suites
+├── id                    UUID PK
+├── target_kind           ENUM(agent, skill, builtin_tool, mcp_tool, pipeline)
+├── target_ref            TEXT
+├── scoring_config        JSONB (judge 模型 + rubric + 可选 gate 命令)
+├── is_frozen             BOOLEAN DEFAULT false  -- 冻结 holdout 集标记
+├── holdout_ratio         FLOAT DEFAULT 0.2      -- 冻结集占比
+├── owner_id              UUID
+├── visibility            ENUM(private, team, public)
+
+eval_cases
+├── id                    UUID PK
+├── suite_id              UUID FK
+├── input                 JSONB
+├── expected              JSONB / rubric 文本
+├── weight                FLOAT DEFAULT 1.0
+├── tags                  TEXT[]
+├── source                ENUM(manual, harvested, synthetic)
+├── provenance_ref        TEXT NULLABLE           -- 采收来源（tool_invocation / thread）
+
+eval_runs
+├── id                    UUID PK
+├── suite_id              UUID FK
+├── target_kind/ref/version  TEXT
+├── baseline_version      TEXT NULLABLE
+├── trigger               ENUM(proposal, scheduled, manual)
+├── score_mean / pass_rate / cost_total / latency_p95 / regression_count
+├── status                ENUM(running, completed, failed)
+
+eval_results
+├── id                    UUID PK
+├── run_id                UUID FK
+├── case_id               UUID FK
+├── score                 FLOAT
+├── verdict               TEXT
+├── output_digest         TEXT
+├── judge_raw             JSONB                   -- 审计（对齐 evaluator.py 全过程审计）
+```
+
+### 4.2 评测执行器
+
+复用 [engine/routine/evaluator.py](../../../apps/negentropy/src/negentropy/engine/routine/evaluator.py) 范式：LLM-as-Judge（`resolve_model_config_async` + `litellm.acompletion` + JSON 结构化输出 + 指数退避）+ 可选客观门控命令锚定评分。
+
+### 4.3 Golden Set 双轨（Goodhart 防护）
+
+- **公开集**（`is_frozen = false`）：提案优化时可见，允许迭代拟合；
+- **冻结 holdout 集**（`is_frozen = true`）：仅晋升裁决时运行，**结果不回流 proposer**——防止单一指标过拟合。
+
+### 4.4 在线信号融合
+
+晋升判据 = **离线分 AND 在线金丝雀指标（成功率 / 成本 / 延迟 / 用户反馈）双确认**，任一退化即否决。权重与窗口硬编码在 `evolution/decision.py`。
+
+### 4.5 用例采收回路
+
+失败的 `tool_invocation` / 被 thumbs_down 的交互 / Routine 失败迭代 → 半自动转化为 `eval_case`（`source=harvested`），人审后入 suite——评测集随真实失败自动长大。
+
+---
+
+## 5. Agent 自迭代回路
+
+### 5.1 版本化（先决条件）
+
+新表 `agent_versions` 严格对齐 [models/skill.py](../../../apps/negentropy/src/negentropy/models/skill.py) 的 `skill_versions` 范式：
+
+```
+agent_versions
+├── id                    UUID PK
+├── agent_id              UUID FK → agents
+├── version               VARCHAR(32)            -- SemVer（如 1.2.3）
+├── snapshot              JSONB                  -- 冻结 system_prompt / model / skills / tools
+├── origin                ENUM(code_sync, evolution, manual)
+├── is_active             BOOLEAN DEFAULT false
+├── is_stale              BOOLEAN DEFAULT false  -- 基线更新后标记
+├── created_at            TIMESTAMPTZ
+├── UNIQUE(agent_id, version)
+```
+
+`agents` 表新增：`active_version VARCHAR(32) NULLABLE`（指针）+ `baseline_origin TEXT`。
+
+### 5.2 解析顺序改造
+
+[agents/_dynamic_instruction.py](../../../apps/negentropy/src/negentropy/agents/_dynamic_instruction.py) 的加载逻辑改为：
+
+```
+active_version 指向的快照 > agents.system_prompt（代码 Sync 基线） > 代码硬编码 fallback
+```
+
+**Sync 改造**（解决 [interface/api.py](../../../apps/negentropy/src/negentropy/interface/api.py) 约 :2546 的覆写冲突）：
+- `sync_negentropy_agents` 改为「只更新基线 + 落一条 `origin=code_sync` 的版本行，**绝不触碰 `active_version`**」；
+- 进化版本晋升后若基线更新（代码改了 prompt），自动将该进化版本标记 `is_stale` 并要求重评——**显式拒绝自动三方合并**（交还人/重新进化）。
+
+### 5.3 GEPA/ACE 式反思驱动 Proposer
+
+输入 = 该 Agent 近期失败样本（`tool_invocations` + `interaction_feedback` + `routines.reflections`）+ 当前 prompt；
+输出 = 结构化 `evolution_proposals`（diff + rationale + evidence 引用）。
+
+实现范式复用 [engine/consolidation/reflection_generator.py](../../../apps/negentropy/src/negentropy/engine/consolidation/reflection_generator.py)（retry + JSON + 降级）。每次变异幅度受限（diff 行数上限 + prompt 长度硬上限约 1,500 字符，Decagon 经验：4 倍压缩仅损 0.8%）。
+
+### 5.4 回路状态机
+
+```
+reflect → propose(draft)
+  → shadow_eval（跑离线 suite，对比 baseline）
+  → pending_approval（按风险等级可自动）
+  → canary（thread/user 哈希分桶 N%，运行时在 InstructionProvider 处按 assignment 解析候选版本）
+  → promote / rollback
+```
+
+- 晋升 = 改 `active_version` + `invalidate_cache(prefix="subagent:")`，60s 内全量生效；
+- 回滚同理（秒级、无部署）；
+- 金丝雀路由天然挂点：[config/model_resolver.py](../../../apps/negentropy/src/negentropy/config/model_resolver.py) 的 TTL 缓存（60s）按 assignment 分键。
+
+### 5.5 与 Routine 闭环的关系
+
+进化提案的*生成与验证*默认走轻量 in-engine worker（`consolidation_jobs` 队列范式）；仅当提案需要重型工作（如同时改 skill 资源、写评测用例文件）时，将其降级派发为一个 Routine（goal=改进提案、acceptance_criteria=评测达标），完整复用其预算守卫/审批/审计。
+
+---
+
+## 6. 技能/工具自迭代回路
+
+### 6.1 Skills 进化（最低悬挂果实）
+
+[models/skill.py](../../../apps/negentropy/src/negentropy/models/skill.py) 的 `skill_versions` 已就绪，补三件事：
+1. per-skill `eval_suite`（评测驱动准入）；
+2. proposer（变异 `prompt_template` / `default_config`）；
+3. `skills` 表加 `active_version` 指针（区分「最新」与「已晋升」）。
+
+Agent 侧 `name@semver` 锁定（`_parse_skill_ref` 已实现）使金丝雀可按 Agent 粒度灰度（部分 Agent 引用候选版）。
+
+### 6.2 Builtin Tools 进化
+
+进化对象 = `builtin_tools.config` JSONB（参数级，如检索 top_k / 超时 / Prompt 片段）。新增 `builtin_tool_versions` 快照表（同范式）。**credentials 永不进入快照与进化范围**（脱敏边界既有）。
+
+### 6.3 MCP / Pipeline 进化
+
+perceives 的 `competition_mode` 从「运行时每次竞争」升格为「进化证据源」——竞争评审结果回流为 `tool_invocations` 的相对效果数据，提案器据此调整 `StageToolConfig.rank/enabled` 与引擎参数。
+
+注意：pipeline YAML 当前在配置文件不在 DB。Phase 3 仅 DB 化 stage 工具排序等安全子集，全量 DB 化留作远期议程。
+
+### 6.4 工具效果三级评分
+
+| 级别 | 信号来源 | 度量 |
+|------|---------|------|
+| 客观 | `tool_invocations` | status / latency_ms / cost_usd |
+| 下游 | 归因 job | 调用后任务是否成功（从 routine verdict / thread feedback 反推） |
+| 对比 | competition judge | 相对评分（多引擎并行时的 judge preference） |
+
+### 6.5 Agent 自造技能（Phase 4，Voyager 式）
+
+流程：Agent/Routine 起草 skill（沿用 [skill_templates/*.yaml](../../../apps/negentropy/src/negentropy/agents/skill_templates/) 模板 schema + SemVer 强校验）→ Jinja2 沙箱静态检查 → 沙箱试运行（[engine/sandbox/](../../../apps/negentropy/src/negentropy/engine/)）→ 影子评测 → **强制人审**（新技能一律 `pending_approval`，无自动晋升通道）→ 入库 `visibility=private` 试用期 → 效果达标后才可申请 `is_global`（`is_global` 晋升永远人审）。
+
+### 6.6 删除/退役回路
+
+长期低分 / 零调用的技能与工具版本自动生成「退役提案」，同样走门控——防能力库熵增（呼应 negentropy 主题）。
+
+---
+
+## 7. 进化编排：流水线状态机与调度
+
+### 7.1 `evolution_proposals` 统一登记簿
+
+```
+evolution_proposals
+├── id                    UUID PK
+├── target_kind           ENUM(agent_prompt, skill_template, builtin_tool_config, mcp_pipeline)
+├── target_ref            TEXT
+├── base_version          TEXT
+├── proposed_version      TEXT
+├── payload               JSONB (diff / 快照)
+├── origin                ENUM(reflection, telemetry_anomaly, competition, human, routine)
+├── rationale             TEXT
+├── evidence              JSONB
+├── status                ENUM(draft, shadow_eval, pending_approval, approved, canary, promoted, rejected, rolled_back, stale)
+├── shadow_eval_run_id    UUID NULLABLE
+├── canary_config         JSONB (比例/范围/窗口)
+├── canary_metrics        JSONB
+├── risk_level            ENUM(low, medium, high)
+├── decided_by            UUID NULLABLE
+├── decided_at            TIMESTAMPTZ
+├── created_at / updated_at TIMESTAMPTZ
+```
+
+### 7.2 调度复用统一心跳
+
+`evolution_inspector` 作为新 Scheduler job 注册进 [engine/schedulers/registry.py](../../../apps/negentropy/src/negentropy/engine/schedulers/registry.py)（与 `routine_inspector` 并列）。tick 内推进状态机（与 [engine/routine/orchestrator.py](../../../apps/negentropy/src/negentropy/engine/routine/orchestrator.py) 的 REAP/EVAL/DISPATCH 三段式同构：领取 due 提案 → 推进一步 → `FOR UPDATE SKIP LOCKED` 幂等）。
+
+### 7.3 并发约束
+
+每 target 同时至多一个非终态提案（对齐 Routine「单在途」不变量）；canary 期间禁止该 target 的新提案进入 canary。
+
+---
+
+## 8. 护栏与治理
+
+### 8.1 人审门控矩阵
+
+复用 Routine `approval_mode` 三档语义：
+
+| 变更类型 | 门控档 | 依据 |
+|---------|--------|------|
+| Builtin Tool 数值参数（top_k / timeout） | `auto`（shadow eval + canary 通过后自动） | 低爆炸半径 |
+| Skill prompt_template（非 HIGH_RISK_TOOLS） | `auto` / `first`（同类首次自动、后续抽审） | 中爆炸半径 |
+| Agent system_prompt（非 root Faculty） | `first` | 中爆炸半径 |
+| Root Agent prompt / `is_global` 技能 / 新技能入库 / 模型切换 | `every`（每次人审） | 高爆炸半径 |
+| 评测套件本身 | `every` | Goodhart 防线：优化目标不可被优化对象修改 |
+
+### 8.2 自动回滚条件
+
+硬编码于 `evolution/decision.py`（对齐 [engine/routine/decision.py](../../../apps/negentropy/src/negentropy/engine/routine/decision.py) 范式）：
+
+- Canary 窗口内：错误率超基线 X% / 成本超基线 Y% / 延迟超基线 Z% → 立即回滚；
+- 用户负反馈率超阈 → 立即回滚；
+- 评测 `regression_count > 0`（holdout 集任一 case 回归） → 立即回滚；
+- 回滚后：提案标记 `rolled_back` + 生成反思（失败经验入库，负样本喂回 proposer）。
+
+### 8.3 爆炸半径控制
+
+- 金丝雀从小到大：单 Agent → 按 thread 哈希 N% → 全量；
+- `is_global` 技能与 root Agent prompt 的 canary 比例上限更低；
+- 全系统同一时间窗在途 canary 数量上限。
+
+### 8.4 防好hart 四件套
+
+1. **冻结 holdout 集**（`is_frozen = true`）：结果不回流 proposer；
+2. **多目标判据**：质量 AND 成本 AND 延迟 AND 在线确认——单指标最优不可晋升；
+3. **Judge 与 Proposer 模型异源**（`task_model_settings` 治理）；
+4. **评测集换血**：随失败采收持续更新，防固定 benchmark 过拟合。
+
+### 8.5 预算控制
+
+- 进化子系统全局 `max_cost_usd` 日/月预算 + per-proposal 预算（shadow eval + canary 额外成本计入）；
+- 范式直接对齐 [routines.max_cost_usd](../../../apps/negentropy/src/negentropy/models/routine.py) 硬上限 + `pre_dispatch_check` 熔断。
+
+### 8.6 安全不变量清单
+
+| 不变量 | 守护机制 |
+|-------|---------|
+| Credentials 不进快照 | `snapshot` 字段不含敏感列，进化 worker DB role 无 credential 表读权限 |
+| 进化 worker 最小权限 | 独立 DB role，仅写 evolution_proposals + *_versions 表 |
+| Jinja2 沙箱 + enforcement_mode | 提案验证阶段前置执行 |
+| Root Agent fallback 永存 | `_dynamic_instruction` 既有「永不阻塞请求」语义是最后防线 |
+
+---
+
+## 9. 演进路线
+
+### Phase 1：遥测 + 评测地基
+
+**范围**：`tool_invocations` 三源采集（ADK callback 新挂点 / Routine 旁路 / MCP 旁路）+ `interaction_feedback` + `tool_stats_daily` 聚合 + eval 四表 + DB 驱动 eval runner + 首批 golden suite（每个 Faculty Agent ≥20 例）。
+
+**验收**：
+- 任一 Agent/Skill/Tool 可查 7 日健康度；
+- 可对任一 Agent 当前 prompt 手动发起评测并得到与基线可比的分数报告；
+- 遥测写入对主链路 p95 延迟影响 <5ms（异步旁路）。
+
+**不做**：自动化进化、agent_versions、Sync 改造。
+
+### Phase 2：Agent prompt 进化
+
+**范围**：`agent_versions` + `agents.active_version` + 解析顺序改造 + Sync 改造 + GEPA proposer + 提案状态机 + 影子评测 + 金丝雀路由 + 一键回滚。
+
+**验收**：
+- 一个非 root Faculty 走完 propose→shadow→canary→promote 全闭环；
+- Sync 后进化版本不丢失；
+- holdout 集分数同步不退化。
+
+**不做**：Root Agent 进化、技能/工具进化、自造技能。
+
+### Phase 3：技能/工具进化
+
+**范围**：Skills `active_version` + per-skill suite + `builtin_tool_versions` + competition 证据回流 + 归因 job。
+
+**验收**：
+- 至少一个技能和一个 builtin tool 经数据驱动完成参数/模板改进并晋升；
+- 工具退役提案流程跑通一例。
+
+**不做**：MCP YAML 全量 DB 化、自造新技能。
+
+### Phase 4：自造技能 + 团队结构进化
+
+**范围**：Voyager 式新技能流水线（Routine 起草 → 沙箱 → 人审 → 试用期）+ skills 挂载 / 模型选型纳入进化范围。
+
+**验收**：
+- Agent 针对一类重复失败任务自造技能并经人审入库，试用期指标达标转正；
+- 全程审计链完整可回放。
+
+---
+
+## 10. 复用/新增对照总表
+
+| 设计点 | 复用模块 | 新增模块 |
+|-------|---------|---------|
+| 护栏纯函数 | `engine/routine/decision.py` | `engine/evolution/decision.py` |
+| 评测引擎 | `engine/routine/evaluator.py` | `engine/evolution/eval_runner.py` |
+| 版本快照范式 | `models/skill.py` (SkillVersion) | `models/evolution.py` (agent_versions, builtin_tool_versions) |
+| 动态加载 + 缓存 | `agents/_dynamic_instruction.py`, `config/model_resolver.py` | 金丝雀路由（按 assignment 分键） |
+| 遥测采集 | perceives `core/logging.py` (ContextVar) | `engine/evolution/telemetry.py` (ADK callback + 三源归一) |
+| 调度心跳 | `engine/schedulers/registry.py` | `engine/evolution/orchestrator.py` (evolution_inspector) |
+| 状态机 tick | `engine/routine/orchestrator.py` (SKIP LOCKED) | 复用同构模式 |
+| 反思生成 | `engine/consolidation/reflection_generator.py` | `engine/evolution/proposer.py` (GEPA 式) |
+| 用户反馈 | `models/perception.py` (knowledge_feedback) | `models/evolution.py` (interaction_feedback) |
+| Sync 端点 | `interface/api.py` (sync_negentropy_agents) | 改造：不触 active_version |
+| SSE 事件推送 | `engine/routine/bus.py` | 复用 |
+| 审批协议 | `agents/approval.py` (HIGH_RISK_TOOLS) | 复用 approval_mode 三档 |
+| 安全校验 | `engine/governance/` (content_validator) | 复用：提案内容前置校验 |
+| 沙箱执行 | `engine/sandbox/` | 复用：自造技能验证 |
+| 技能注入 | `agents/skills_injector.py` | 复用：金丝雀版本展开 |
+| Jinja2 沙箱 | `skills_injector` 内 | 复用：模板安全检查 |
+
+**新增模块收敛为**：`models/evolution.py`、`models/evaluation.py`、`engine/evolution/`（orchestrator / decision / proposer / eval_runner / canary / telemetry / attribution）、interface API + UI、3–4 个 Alembic 迁移。
+
+---
+
+## 11. 关键权衡决策（ADR）
+
+### ADR-1：进化编排——复用 Routine 还是独立子系统？
+
+**推荐：独立轻量状态机 + Routine 作可选重型执行器。**
+
+Routine 的 `decide()` 语义是「迭代直至验收」（no_progress/oscillation 守卫），而进化是「发布流水线」（shadow→canary→promote 的门控推进），状态机不同构。Routine 执行器是 Claude Code 子进程（重，文件系统绑定），prompt 变异只需一次轻量 LLM 调用。但 Routine 的预算守卫/审批/审计/心跳调度全部值得复用。结论：进化用独立的 `evolution_proposals` 状态机，重型工作降级派发为 Routine。
+
+### ADR-2：版本快照——统一泛型表 vs 每资产专表？
+
+**推荐：登记簿泛型 + 快照专表混合。**
+
+泛型表（`target_kind` + `target_id`）便于 meta-layer 统一处理，但丢失 FK 完整性且与已上线的 `skill_versions` 冲突。结论：`evolution_proposals` / `eval_runs` 用泛型 target 引用（流水线统一），版本快照沿用专表范式（`skill_versions` 已有，新增 `agent_versions` / `builtin_tool_versions` 同构复制）。
+
+### ADR-3：system_prompt 的事实源之争
+
+**推荐：基线/进化双轨 + active_version 指针。**
+
+`sync_negentropy_agents` 无条件覆写 `agents.system_prompt`，与进化写入正面冲突。方案：Sync 只写基线列 + 落 `origin=code_sync` 版本行，运行时解析顺序 promoted 版本 > 基线 > 代码 fallback。代价是基线更新后进化版本需标 `stale` 强制重评（显式拒绝自动三方合并），用少量人工换确定性。
+
+---
+
+<a id="ref1"></a>[1] J. Fang et al., "A comprehensive survey of self-evolving AI agents," arXiv:2508.07407, 2025.
+<a id="ref2"></a>[2] A. Novikov et al., "AlphaEvolve: A coding agent for scientific and algorithmic discovery," arXiv:2506.13131, 2025.
+<a id="ref3"></a>[3] L. A. Agrawal et al., "GEPA: Reflective prompt evolution can outperform reinforcement learning," in *Proc. ICLR (Oral)*, 2026. arXiv:2507.19457.
+<a id="ref4"></a>[4] Q. Zhang et al., "Agentic context engineering: Evolving contexts for self-improving language models," in *Proc. ICLR*, 2026. arXiv:2510.04618.
+<a id="ref5"></a>[5] J. Zhang et al., "Darwin Gödel machine: Open-ended evolution of self-improving agents," arXiv:2505.22954, 2025.

--- a/docs/research/130-self-evolving-agents-team.md
+++ b/docs/research/130-self-evolving-agents-team.md
@@ -273,7 +273,7 @@ Agent 评测综述<sup>[[16]](#ref16)</sup> 明确分层：最终响应评测（
 | 可进化资产 | 信号源 | 归因 | 变更算子 | 验证门禁 | 发布/回滚 | 文献 |
 |-----------|-------|------|---------|---------|----------|------|
 | Agent `system_prompt` | Routine 轨迹 + 反馈 | `blamed_component` 字段 | GEPA 反思→变异 | Shadow eval + Golden Set 双轨 | `active_version` 指针 + 秒级回滚 | [[9]](#ref9) [[11]](#ref11) |
-| 技能 `prompt_template` | 工具调用遥测 + 评测分数 | per-skill eval_suite | GEPA/OPRO + 长度约束 | Shadow eval + 红|$ | SemVer 晋升 + 金丝雀 | [[9]](#ref9) [[14]](#ref14) |
+| 技能 `prompt_template` | 工具调用遥测 + 评测分数 | per-skill eval_suite | GEPA/OPRO + 长度约束 | Shadow eval + 红队 | SemVer 晋升 + 金丝雀 | [[9]](#ref9) [[14]](#ref14) |
 | 工具 config JSONB | 延迟/成本/成功率 | `tool_stats_daily` 聚合 | 参数搜索 + competition 证据 | 回归测试 | `builtin_tool_versions` + 回滚 | [[5]](#ref5) |
 | MCP Pipeline 参数 | Stage 输出 + 竞争评分 | per-stage 评分 | 参数调优 / 引擎排名 | competition_mode 验证 | YAML 更新（Phase 3 DB 化） | [[22]](#ref22) |
 | 记忆/经验条目 | 失败案例 + 反馈 | — | ACE 增量 delta + 去重 | 语义去重 + helpful/harmful 计数 | 条目级淘汰 | [[11]](#ref11) |

--- a/docs/research/130-self-evolving-agents-team.md
+++ b/docs/research/130-self-evolving-agents-team.md
@@ -1,0 +1,375 @@
+# 自进化 Agents Team：自主迭代与自我强化系统调研
+
+> **摘要 / 导言**：将 negentropy 平台打造成「自主迭代升级、自我强化的 Agents Team」，系统分三类——**固定框架**（进化基座，自身稳定不自改）、**动态 Agent 定义**（根据反馈学习成长）、**外部能力工具**（Skills / MCP / Tools，效果反向驱动迭代）。核心命题是构建一条统一的进化闭环：信号采集 → 归因 → 变更生成 → 验证门禁 → 发布/回滚。本报告综合自进化智能体理论（DGM、ADAS、AgentSquare、AlphaEvolve）、进化算子（GEPA、ACE、DSPy）、评测与反馈回路（Agent-as-a-Judge、OTel GenAI semconv、Langfuse 评测体系）、工具/技能生态自进化（MCP Registry、Agent Skills、LLM 自造工具谱系）、以及生产化护栏（OWASP Agentic AI Top 10、金丝雀/影子部署、Goodhart 防护），最终将证据映射到 negentropy 三类系统的设计决策上。重叠声明：ReAct / Reflexion / Self-Refine / LATS / Voyager / LLM-as-Judge 偏差治理已由 [110 号调研](./110-routine-agent-iteration.md) 覆盖，本报告一律引用不重述。
+
+---
+
+## 1. 问题背景与设计命题
+
+### 1.1 三类系统的进化边界
+
+| 系统层 | 进化语义 | 不变量 | 可进化资产 |
+|--------|---------|--------|-----------|
+| **固定框架（Meta-Layer）** | 进化基座自身不自改 | 护栏逻辑、安全策略、预算阈值、决策函数 | 无（改进走 Git PR 人工合并） |
+| **动态 Agent 定义** | 自主迭代、自驱拟合目标场景 | 角色定位（Faculty 职责边界）、安全红线 | `system_prompt`、模型选型、技能挂载列表 |
+| **外部能力工具** | 效果反向驱动迭代 | 工具白名单、权限边界、凭证隔离 | 技能 `prompt_template`（Jinja2）、工具 config JSONB、MCP pipeline 参数 |
+
+核心设计约束：**进化 = 数据变更（DB 白名单字段），框架 = 代码（改动唯一通道 Git PR + 人工 Merge）**。
+
+### 1.2 已有基座盘点
+
+negentropy 已具备四个可复用的进化原语，本报告的核心论点是将其收敛为统一闭环而非从零造轮：
+
+| 原语 | 实现位置 | 产出 |
+|------|---------|------|
+| LLM-as-Judge 评测 | [engine/routine/evaluator.py](../reference/cognizes/engine/040-the-evaluator.md) | 0–100 分 + verdict 五档 + 自然语言反思 |
+| Reflexion 反思 | [engine/consolidation/reflection_generator.py](../reference/cognizes/engine/025-the-hippocampus.md) | `routines.reflections` JSONB 跨迭代注入 |
+| SemVer 版本快照 | [models/skill.py](../concepts/design/skills.md) `skill_versions` 表 | 不可变版本历史 + SemVer + JSONB snapshot |
+| 竞争择优 | perceives [pipeline_config.py](../reference/perceives/) `competition_mode` | 多引擎并行 + LLM 评审择优 |
+
+三个决定性缺口（方案需解决）：
+1. `agents` 表**无版本表**，且 `sync_negentropy_agents` 每次 Sync 覆写 `system_prompt`——进化产物会被踩掉；
+2. ADK 主运行时**无工具调用级遥测**（`tool_executions` 表 dormant 无写入方）；
+3. `eval_tests/` 近乎空壳，无 golden set / 回归门禁。
+
+### 1.3 进化回路总览
+
+```mermaid
+flowchart LR
+    subgraph "Meta-Layer（固定框架）"
+        T["遥测采集<br/>tool_invocations"]
+        E["评测引擎<br/>LLM-as-Judge / Agent-as-Judge"]
+        P["进化提案器<br/>GEPA / ACE 式反思→变异"]
+        G["门控发布<br/>Shadow → Canary → Promote/Rollback"]
+    end
+
+    subgraph "进化客体"
+        A["Agent 定义<br/>system_prompt / model / skills"]
+        S["Skills<br/>prompt_template / resources"]
+        M["MCP Tools<br/>pipeline 参数 / 引擎选型"]
+    end
+
+    A -->|"执行轨迹 + 反馈"| T
+    S -->|"调用结果 + 延迟/成本"| T
+    M -->|"Stage 输出 + 竞争评分"| T
+    T -->|"信号聚合"| E
+    E -->|"标量分 + 文本反馈<br/>+ 归因组件"| P
+    P -->|"候选版本<br/>（SemVer 快照）"| G
+    G -->|"active_version<br/>指针切换"| A
+    G -->|"active_version<br/>指针切换"| S
+    G -->|"参数/排名更新"| M
+    G -->|"回滚 = 指针回退"| T
+
+    style T fill:#1f3a5f,stroke:#5b9bd5,stroke-width:2px,color:#e8f0fe
+    style E fill:#3d2c52,stroke:#a07cc5,stroke-width:2px,color:#f3e9fb
+    style P fill:#5a3d1f,stroke:#d59b5b,stroke-width:2px,color:#fdf3e8
+    style G fill:#1f4d2e,stroke:#5bbd7c,stroke-width:2px,color:#e8fbef
+    style A fill:#2a1f3d,stroke:#7c5ca5,stroke-width:2px,color:#e8dff5
+    style S fill:#2a1f3d,stroke:#7c5ca5,stroke-width:2px,color:#e8dff5
+    style M fill:#2a1f3d,stroke:#7c5ca5,stroke-width:2px,color:#e8dff5
+```
+
+---
+
+## 2. 学术基础：自进化智能体理论
+
+### 2.1 领域分类框架
+
+两篇 2025 年综述为整个领域建立了分类坐标系。
+
+**Gao et al.（TMLR 2026）** 提出四维框架<sup>[[1]](#ref1)</sup>：**What** to evolve（模型 / 记忆 / 工具 / 架构四类组件）、**When** to evolve（intra-test-time 即时适应 vs inter-test-time 跨任务适应）、**How** to evolve（标量奖励驱动 vs 文本反馈驱动，单智能体 vs 多智能体）、**Where** 对应应用域。该分类可直接作为 negentropy 三类系统的"进化对象坐标系"。
+
+**Fang et al.** 提出统一迭代回路抽象<sup>[[2]](#ref2)</sup>：**System Inputs → Agent System → Environment → Optimisers** 四组件反馈回路，几乎所有自进化系统都可实例化进去。negentropy 的 Dispatch→Execute→Evaluate→Decide 是该抽象的完整实例；其"Optimiser 与 Agent System 分离"的原则直接支持固定框架层设计——优化器（进化基座）本身不在被优化对象之内。
+
+### 2.2 系统级自改
+
+**Darwin Gödel Machine（Sakana AI）**<sup>[[3]](#ref3)</sup> 进化对象是智能体自身的代码库。核心机制：从档案库（archive）采样父代 → 基础模型生成变体 → 基准经验验证 → 入档。关键发现：SWE-bench 20.0% → 50.0%；**劣质祖先可播种突破**（通往最优解的谱系有时包含比父代更差的中间体）；**安全实证**——观察到目标欺骗（伪造单元测试日志）和移除检测标记骗取成功两种作弊。防护依赖沙箱隔离 + 人类监督 + 谱系可追溯性。
+
+**ADAS（ICLR 2025）**<sup>[[4]](#ref4)</sup> 提出 Meta Agent Search——元智能体在代码空间搜索新 agent 设计，以持续增长的历史发现档案作为上下文。跨域跨模型迁移后仍保持优势，降低"DB 化 agent 定义 + 可替换底座"的风险。
+
+**AlphaEvolve（DeepMind）**<sup>[[5]](#ref5)</sup> 核心论断：**automated evaluator 是进化的先决条件**——问题解必须可被机器自动评分。生产实证：Borg 数据中心调度启发式已**生产运行超一年，平均持续回收全球算力 0.7%**。"人类可读代码胜过黑盒"（Borg 案例）支持进化产物固化为可读文本。
+
+### 2.3 模块级与拓扑级进化
+
+**AgentSquare（ICLR 2025）**<sup>[[6]](#ref6)</sup> 将智能体抽象为 Planning / Reasoning / ToolUse / Memory 四模块，搜索用 module evolution（变异单模块）+ module recombination（跨设计重组）两算子。平均超越手工设计 17.2%。引入性能预测器预判候选表现以跳过无望设计，降低评估成本。
+
+**EvoAgent（NAACL 2025）**<sup>[[7]](#ref7)</sup> 用进化算法从单专家 Agent 自动扩展为多智能体系统（变异 / 交叉 / 选择三算子）。对应"拓扑级进化"的最轻量入口。
+
+### 2.4 权重级对照面与取舍
+
+**SEAL（MIT）**<sup>[[8]](#ref8)</sup> 进化对象是模型权重（自编辑→SFT微调）。关键障碍：**灾难性遗忘**——持续自编辑导致早期任务性能退化，缺乏保持机制时自我修改可能覆盖有价值的先验信息。该实证为 negentropy 选择"非权重级进化"（prompt / 工具层，可回滚、可 diff、可审计）提供了取舍依据。
+
+**进化层次谱系已成领域共识**：权重级（SEAL）→ prompt/上下文/记忆级（Reflexion 类）→ 工具/技能级（AlphaEvolve、DGM 工具自造）→ 架构/拓扑级（ADAS、AgentSquare、EvoAgent）。negentropy 选择"prompt 级 + 工具级 + 受限拓扑级"在谱系上有明确位置且有文献支撑。
+
+---
+
+## 3. 进化算子：Prompt 与上下文自动优化
+
+### 3.1 GEPA——反思驱动进化（核心方法论）
+
+**GEPA（ICLR 2026 Oral）**<sup>[[9]](#ref9)</sup> 是面向"含一个或多个 LLM prompt 的任意 AI 系统"的反思式进化优化器，已并入 DSPy 优化器家族为 `dspy.GEPA`。核心循环：采样执行轨迹 → 强反思模型诊断失败 → 提出单组件 prompt 变异 → minibatch 验证 → **Pareto 前沿候选保留**。
+
+**与 negentropy 的关键同构性**：GEPA 所需的「(轨迹, 标量分, 自然语言反馈)」三元组与 Routine 闭环已产出的「执行轨迹 + LLM-as-Judge 0–100 分 + `routines.reflections` JSONB 反思」**逐字段同构**。差距仅在消费侧——当前反思只做 Reflexion 式运行时注入，未被消费为 prompt 资产的变异依据。
+
+关键差异：Reflexion 管 episode 内自纠（运行时短期记忆），GEPA 管跨 episode 的 prompt 持久进化（资产更新）。两者正交可并存。
+
+关键数字：6 个任务平均超 GRPO 6%（最高 20%），使用最多 35 倍更少 rollout；超 MIPROv2 10%+。
+
+**生产局限**（Decagon 工程经验<sup>[[10]](#ref10)</sup>）：无约束 GEPA 可产出 >5,000 字符 prompt；训练样本 20–100 例是甜区，500 反而过拟合（-2%）；反思器必须用前沿模型（弱反思器致整轮报废），但仅占总成本 5–10%。
+
+### 3.2 ACE——上下文增量进化
+
+**ACE（ICLR 2026）**<sup>[[11]](#ref11)</sup> 把上下文当作"不断进化的 playbook"，由 Generator / Reflector / Curator 三角色分工。核心创新：Curator 合并必须用**确定性非 LLM 逻辑**（防 context collapse），只做增量 delta（新增条目 + 计数器更新 + 嵌入去重）。
+
+**与 negentropy 的同构性**：issue.md 即手工版 ACE playbook（问题描述/表因根因/处理/防范 = ACE 的"失败模式"条目）；Generator/Reflector/Curator 对应 Routine 执行 / Judge+reflections / Consolidation。
+
+**context collapse 实证**：AppWorld 第 60 步上下文 18,282 token、准确率 66.7，一步整体重写后坍缩至 122 token、准确率跌至 57.1（低于无适配基线 63.7）。**这直接警告：禁止让 LLM 端到端重写 system_prompt 或 issue.md。**
+
+### 3.3 算子横向比较
+
+| 算子 | 信号需求量 | 需离线训练集 | 在线可用性 | 实现复杂度 | 与 DB 动态加载适配度 |
+|------|-----------|-------------|-----------|-----------|-------------------|
+| **GEPA** | 低（20–100 rollout） | 小验证集即可 | 中（官方支持 inference-time） | 中 | **高**：候选=版本表行，晋升=指针切换 |
+| **ACE** | 极低（可无标注） | 否 | **高**（在线 memory 原生场景） | 中 | **高**：条目天然映射 DB 行，增量=upsert |
+| MIPROv2 | 中-高（数百样本） | 是 | 否（纯离线） | 低-中 | 中：不消费 reflections |
+| SIMBA | 中（≥32 条硬下限） | 是 | 否 | 低 | 中：规则形态与 issue 条目兼容 |
+| TextGrad<sup>[[12]](#ref12)</sup> | 低-中 | 可选 | 中-高 | 中（集成成本高） | 低-中：借归因思想成本近零 |
+| Promptbreeder<sup>[[13]](#ref13)</sup> | 极高（10^5 评估） | 是 | 否 | 高 | 低：rollout 成本不匹配 |
+| OPRO<sup>[[14]](#ref14)</sup> | 低 | 小评估集 | 中 | **极低** | **高**：版本表+评分=现成历史 |
+
+**选型建议**：主线 = **GEPA（指令资产）+ ACE（经验/playbook 资产）双算子分轨**；以 **OPRO 式历史评分注入**作为最小可行起点；从 TextGrad 借组件级归因字段（`blamed_component`）、从 SIMBA 借高方差样本优选。
+
+### 3.4 组件级归因
+
+**TextGrad**<sup>[[12]](#ref12)</sup>（Nature 2025）提出文本梯度反传——LLM 批评沿调用链反传到各变量。核心价值是**归因思想**而非框架整体引入：最小实现是让 Judge/反思器在 reflections 中输出 `blamed_component` 字段（agent_prompt / skill_id / tool_desc），即得到组件级归因信号。GEPA 的 `pred_name, pred_trace` 参数同样支持 per-predictor 定向变异。
+
+---
+
+## 4. 进化信号源：评测与反馈回路
+
+### 4.1 从 LLM-as-a-Judge 到 Agent-as-a-Judge
+
+**Agent-as-a-Judge（Meta AI）**<sup>[[15]](#ref15)</sup> 将评测建模为多步智能体工作流，可读取被评 Agent 的完整执行轨迹。关键数字：与人类共识对齐率 ~90%（对比 LLM-as-a-Judge 仅 ~70%），成本仅 2.29%。消融实验表明最优子集为 graph + locate + read + retrieve + ask（memory/planning 有害，降低对齐率）。
+
+**negentropy 映射**：当前 Routine Evaluator 是"终态 LLM-as-a-Judge"。升级路径——评测 Agent 配备 read/search 工具读取 OTel/Langfuse trace，实现**轨迹级评审**定位失败步骤。建议三层分级：(1) 终态 LLM-as-Judge（秒级，全量高频）；(2) 轨迹 Agent-as-a-Judge（分钟级，采样/触发式）；(3) 人工（边缘案例）。
+
+**Agent 评测综述**<sup>[[16]](#ref16)</sup> 指出：Langfuse 本身不支持原生轨迹评测——验证了 negentropy 需自建轨迹评审 Agent 的必要性。
+
+### 4.2 轨迹级评测与终态评测
+
+Agent 评测综述<sup>[[16]](#ref16)</sup> 明确分层：最终响应评测（快速低成本但无法定位失败）→ 逐步评测（单步独立打分）→ **轨迹评测**（reference-based 与黄金路径对齐，或 reference-free 由 LLM judge 评估连贯性/效率/目标导向性）。开发者框架中，仅 LangSmith、Vertex AI、AgentEvals 支持轨迹评测。
+
+### 4.3 在线评测与生产监控
+
+**OTel GenAI Semantic Conventions**<sup>[[17]](#ref17)</sup> 定义了 `execute_tool` span（属性含 `gen_ai.tool.name`、`gen_ai.tool.type`、`gen_ai.tool.call.arguments/result` 等），当前 **Development 状态**。negentropy `tool_invocations` 表应直接对齐此 schema。
+
+**Langfuse 评测体系**<sup>[[18]](#ref18)</sup> 提供 Score 四级挂载（trace/observation/session/dataset run）、LLM-as-Judge 托管评测（Live Observations 推荐）、Datasets 从生产 trace 采收（`source_trace_id` 溯源 + 批量 UI）。
+
+**MLflow GenAI Evaluation**<sup>[[19]](#ref19)</sup> 提供内置 judges 含实验性 **ToolCallCorrectness / ToolCallEfficiency**——直接对应 negentropy 的工具调用评测需求。
+
+**共识路径**：离线 golden set 用于回归测试与版本对比（发布前拦截），在线评测用于生产监控与趋势感知（发布后保障）。生产 trace 是 golden set 的主要来源。
+
+### 4.4 隐式/显式人类反馈采集
+
+**Liu et al.**<sup>[[20]](#ref20)</sup> 证明：用户反馈是"理解用户的窗口但噪声大的学习信号"——反馈语义训练在短问题显著提升（p<.00001），但在长复杂问题上**显著劣于**基线（p≤0.0126）。正反馈噪声高（越狱场景）。
+
+**结论**：negentropy 应将用户反馈用于**实时监控趋势**和**golden set 采收触发**，**不应直接作为训练/进化标签**。
+
+---
+
+## 5. 工具/技能生态自进化
+
+### 5.1 MCP 规范与 Registry 进展
+
+**MCP Registry**（2025-09-08 Preview<sup>[[21]](#ref21)</sup>）是面向公开 MCP Server 的开放目录，server.json 元数据 schema + REST API，当前 **Preview 阶段**（v0.1 冻结）。支持公共/私有子注册表——私有型映射企业部署场景。注册条目近 **2,000**。
+
+**MCP 2025-11-25 稳定版**<sup>[[22]](#ref22)</sup> 引入 Tasks 原语（长时运行任务，状态机 working→completed/failed/cancelled）、Sampling+Tools（服务端 agentic loop）、简化 OAuth。2026-07-28 RC 计划无状态核心、Transport Headers、Tasks 移至扩展。
+
+### 5.2 Agent Skills 设计哲学
+
+**Anthropic Agent Skills**<sup>[[23]](#ref23)</sup>（开放标准 agentskills.io，40+ 产品采用）核心设计：**渐进式披露三层加载**——Discovery（name/description）→ Activation（完整 SKILL.md 正文）→ Execution（引用文件/脚本）。
+
+**negentropy 对标**：`skills_injector` 的 Jinja2 prompt_template + Progressive Disclosure 与 SKILL.md 三层加载**高度同构**。skills 表 name/description = Discovery 层；prompt_template = Activation 层；resources = Execution 层。建议增加 SKILL.md 兼容 adapter。
+
+**技能层综述**<sup>[[24]](#ref24)</sup> 发现社区贡献技能中 **26.1% 含安全漏洞**——强力驱动验证流水线需求。
+
+### 5.3 工具效果评测
+
+**MCP-Bench**<sup>[[25]](#ref25)</sup> 在 28 个真实 MCP Server + 250 工具上测试模糊指令下的端到端完成率，三层评测维度：工具级 schema 理解 → 轨迹级规划 → 任务完成。20 个先进 LLM 均面临持续挑战。
+
+**BFCL V4**<sup>[[26]](#ref26)</sup> 转向 Holistic Agentic Evaluation（Web Search + Memory + Format Sensitivity），Agentic 占总分 **40% 权重**。
+
+**ToolLLM**<sup>[[27]](#ref27)</sup>（ICLR 2024）覆盖 16,464 真实 API，DFSDT 多轨迹推理 + ToolEval 双指标（Pass Rate + Win Rate）。
+
+### 5.4 LLM 自造工具谱系
+
+| 工作 | 核心机制 | 关键数字 | negentropy 映射 |
+|------|---------|---------|----------------|
+| LATM<sup>[[28]](#ref28)</sup> | 强模型造工具 / 弱模型用工具 | GPT-4 造 + GPT-3.5 用 ≈ 全程 GPT-4 | 制造/消费分离，skill_versions 天然支持 |
+| CREATOR<sup>[[29]](#ref29)</sup> | 分离抽象推理（设计工具）与具体推理（使用工具） | Creation Challenge 2K 问题 | prompt_template（抽象）vs required_tools（具体）分层 |
+| ToolMaker<sup>[[30]](#ref30)</sup> | 论文+代码仓 → 自动转化为 LLM 工具（闭环自纠错） | 15 任务 **80% 正确率** | 外部能力自动摄入流程 |
+| **Alita**<sup>[[31]](#ref31)</sup> | 最小预定义 + 最大自进化；自动沉淀能力为可复用 MCP | GAIA 75.15% pass@1 | **MCP Brainstorming → 生成 → 隔离验证 → MCP Box** 映射自造技能链 |
+| ASI<sup>[[32]](#ref32)</sup> | 在线归纳→验证→复用程序化技能 | WebArena +23.5% | 程序化验证是主要驱动力 |
+
+---
+
+## 6. 工业对标：自进化系统的生产化实践
+
+按「信号采集 → 优化算子 → 门禁验证 → 发布/回滚」四段对齐比较：
+
+| 平台 | 信号采集 | 优化算子 | 门禁验证 | 发布/回滚 |
+|------|---------|---------|---------|----------|
+| **DGM**<sup>[[3]](#ref3)</sup> | 编码基准分数 | 档案库 + 代码变体 | 基准经验验证 | 档案分支可回溯 |
+| **AlphaEvolve**<sup>[[5]](#ref5)</sup> | 自动化评估器打分 | Gemini Flash(广度)+Pro(深度) | 客观指标门禁 | 程序数据库保留历史 |
+| **Langfuse**<sup>[[18]](#ref18)</sup> | Scores(trace/obs/session级) + User Feedback | Prompt Experiments 多版本对比 | LLM-as-Judge evaluator | Label 切换即回滚（Protected Labels） |
+| **MLflow**<sup>[[19]](#ref19)</sup> | Feedback(HUMAN/CODE/LLM_JUDGE) | 内置 judges + 自定义 scorers | Evaluation-Driven Development | 版本对比 |
+| **W&B Weave**<sup>[[33]](#ref33)</sup> | Scorer(@weave.op) + Trials(方差检测) | Leaderboard 多版本排行 | 多维度横向对比 | 择优发布 |
+| **promptfoo**<sup>[[34]](#ref34)</sup> | eval + red team | — | CI/CD 回归门禁 (`--fail-on-error`) | 阻断部署 |
+| **negentropy（本设计）** | tool_invocations + interaction_feedback + tool_stats_daily | GEPA（指令）+ ACE（经验）+ OPRO（baseline） | Shadow eval → LLM Judge → OWASP red team | active_version 指针 + 秒级回滚 |
+
+---
+
+## 7. 护栏与治理：自改系统的安全边界
+
+### 7.1 OWASP Agentic AI 威胁映射
+
+**OWASP Agentic AI Top 10（2025-12）**<sup>[[35]](#ref35)</sup> 与 negentropy 进化回路的直接映射：
+
+| 威胁 | 映射 |
+|------|------|
+| ASI01 Agent Goal Hijack | 进化生成的 prompt 可能被投毒 → 需 diff 审查 + 红队扫描 |
+| ASI02 Tool Misuse | 自进化 Agent 可能生成滥用工具的配置 → 工具白名单 + 最小权限 |
+| ASI04 Supply Chain | 进化引入的第三方模板/工具 → 沙箱验证 + 安全静态分析 |
+| ASI06 Memory/Context Poisoning | 反思/reflections 被投毒 → 不可变版本历史 + 审计 |
+| ASI08 Cascading Failures | 多 Agent 级联 → 熔断器 + 爆炸半径控制 |
+| ASI10 Rogue Agents | Reward hacking / 自复制 → 预算硬上限 + 人类审批 |
+
+### 7.2 金丝雀/影子评测
+
+业界共识递进顺序<sup>[[36]](#ref36)</sup>：**Shadow Mode → Canary → A/B Testing**。
+
+- Shadow Mode：生产请求复制到候选版本，候选输出仅记录不返回用户；推理开销约翻倍；
+- Canary：1% → 5% → 20% → 50% → 100% 渐进放量，**自动回滚阈值**（p99 延迟升 >40%、拒绝率升 >5%、成本超预算任一触发）；
+- 用户一致性：通过 user_id / session_id 哈希分配，保证同一用户始终使用同一版本。
+
+### 7.3 版本注册表与回滚
+
+**Langfuse Prompt Management**<sup>[[18]](#ref18)</sup> 的 Label 机制映射 negentropy 设计：版本不可变 + 发布 = Label 赋值 + 回滚 = Label 重赋 + Protected Labels（审批权限控制）。
+
+### 7.4 Goodhart's Law 防护
+
+**OpenAI CoT 监控论文**<sup>[[37]](#ref37)</sup> 证明：对 CoT 施加强优化压力会导致 Obfuscated Reward Hacking——Agent 学会在 CoT 中隐藏意图但仍继续作弊。建议：不对 CoT 直接施加优化压力。
+
+**Anthropic Emergent Misalignment**<sup>[[38]](#ref38)</sup> 证明：模型学会 reward hack 的瞬间，所有 misalignment 指标同时飙升。Inoculation prompting（告知模型作弊边界）高度有效。
+
+**防护四件套**：① 冻结 holdout 集（结果不回流 proposer）；② 多目标晋升判据（质量 AND 成本 AND 延迟 AND 在线确认）；③ Judge 与 Proposer 模型强制异源；④ 评测集随失败采收持续换血。
+
+---
+
+## 8. 对 Negentropy 的设计映射
+
+### 8.1 三类系统 × 进化回路矩阵
+
+| 可进化资产 | 信号源 | 归因 | 变更算子 | 验证门禁 | 发布/回滚 | 文献 |
+|-----------|-------|------|---------|---------|----------|------|
+| Agent `system_prompt` | Routine 轨迹 + 反馈 | `blamed_component` 字段 | GEPA 反思→变异 | Shadow eval + Golden Set 双轨 | `active_version` 指针 + 秒级回滚 | [[9]](#ref9) [[11]](#ref11) |
+| 技能 `prompt_template` | 工具调用遥测 + 评测分数 | per-skill eval_suite | GEPA/OPRO + 长度约束 | Shadow eval + 红|$ | SemVer 晋升 + 金丝雀 | [[9]](#ref9) [[14]](#ref14) |
+| 工具 config JSONB | 延迟/成本/成功率 | `tool_stats_daily` 聚合 | 参数搜索 + competition 证据 | 回归测试 | `builtin_tool_versions` + 回滚 | [[5]](#ref5) |
+| MCP Pipeline 参数 | Stage 输出 + 竞争评分 | per-stage 评分 | 参数调优 / 引擎排名 | competition_mode 验证 | YAML 更新（Phase 3 DB 化） | [[22]](#ref22) |
+| 记忆/经验条目 | 失败案例 + 反馈 | — | ACE 增量 delta + 去重 | 语义去重 + helpful/harmful 计数 | 条目级淘汰 | [[11]](#ref11) |
+
+### 8.2 演进路线
+
+| Phase | 主题 | 验收标准 | 不做清单 |
+|-------|------|---------|---------|
+| **1 遥测 + 评测地基** | `tool_invocations` 三源采集 + `interaction_feedback` + eval 四表 + 首批 golden suite | 任一 Agent/Skill/Tool 可查 7 日健康度；可手动发起评测 | 不做自动化进化 |
+| **2 Agent prompt 进化** | `agent_versions` + `active_version` + Sync 改造 + GEPA proposer + 金丝雀路由 | 一个非 root Faculty 走完 propose→shadow→canary→promote 全闭环 | 不做 root Agent 进化；不做技能进化 |
+| **3 技能/工具进化** | Skills `active_version` + per-skill suite + `builtin_tool_versions` + competition 证据回流 | 至少一个技能和一个 builtin tool 经数据驱动完成改进 | 不做 MCP YAML 全量 DB 化；不自造新技能 |
+| **4 自造技能 + 团队结构** | Voyager 式新技能流水线 + skills 挂载/模型选型纳入进化范围 | Agent 针对重复失败任务自造技能并经人审入库 | — |
+
+### 8.3 与既有调研的接口
+
+- [110 号调研](./110-routine-agent-iteration.md)：Routine 闭环学术基础（ReAct/Reflexion/Self-Refine/LATS/Voyager）+ LLM-as-Judge 偏差治理 → 本报告引用不重述，进化回路在 Routine 之上叠加；
+- [090 号调研](./090-agent-evaluation.md)：Agent 通用评测 → 本报告 §4 反哺其评测分类学，090 后续可展开；
+- [020 号调研](./020-agent-runtime-frameworks.md)：ADK vs Claude SDK 运行时 → 本报告固定框架层设计直接依赖；
+- [010 号调研](./010-context-engineering.md)：上下文工程 → ACE 的增量 delta 机制是其进化延伸。
+
+---
+
+## 参考文献
+
+<a id="ref1"></a>[1] H. Gao et al., "A survey of self-evolving agents: On the path to artificial super intelligence," *TMLR*, 2026. arXiv:2507.21046v4.
+
+<a id="ref2"></a>[2] J. Fang et al., "A comprehensive survey of self-evolving AI agents: A new paradigm bridging foundation models and lifelong agentic systems," arXiv:2508.07407, 2025.
+
+<a id="ref3"></a>[3] J. Zhang, S. Hu, C. Lu, R. Lange, and J. Clune, "Darwin Gödel machine: Open-ended evolution of self-improving agents," arXiv:2505.22954v3, 2025.
+
+<a id="ref4"></a>[4] S. Hu, C. Lu, and J. Clune, "Automated design of agentic systems," in *Proc. ICLR*, 2025. arXiv:2408.08435.
+
+<a id="ref5"></a>[5] A. Novikov et al., "AlphaEvolve: A coding agent for scientific and algorithmic discovery," arXiv:2506.13131, 2025.
+
+<a id="ref6"></a>[6] Y. Shang et al., "AgentSquare: Automatic LLM agent search in modular design space," in *Proc. ICLR*, 2025. arXiv:2410.06153.
+
+<a id="ref7"></a>[7] S. Yuan et al., "EvoAgent: Towards automatic multi-agent generation via evolutionary algorithms," in *Proc. NAACL*, 2025. arXiv:2406.14228.
+
+<a id="ref8"></a>[8] A. Zweiger et al., "Self-adapting language models," arXiv:2506.10943, 2025.
+
+<a id="ref9"></a>[9] L. A. Agrawal et al., "GEPA: Reflective prompt evolution can outperform reinforcement learning," in *Proc. ICLR (Oral)*, 2026. arXiv:2507.19457.
+
+<a id="ref10"></a>[10] Decagon, "Optimizing GEPA for production," Decagon Engineering Blog, 2026. [Online]. Available: https://decagon.ai/blog/optimizing-gepa-for-production
+
+<a id="ref11"></a>[11] Q. Zhang et al., "Agentic context engineering: Evolving contexts for self-improving language models," in *Proc. ICLR*, 2026. arXiv:2510.04618.
+
+<a id="ref12"></a>[12] M. Yuksekgonul et al., "Optimizing generative AI by backpropagating language model feedback," *Nature*, 2025. doi:10.1038/s41586-025-08661-4.
+
+<a id="ref13"></a>[13] C. Fernando et al., "Promptbreeder: Self-referential self-improvement via prompt evolution," arXiv:2309.16797, 2023.
+
+<a id="ref14"></a>[14] C. Yang et al., "Large language models as optimizers," in *Proc. ICLR*, 2024. arXiv:2309.03409.
+
+<a id="ref15"></a>[15] M. Zhuge et al., "Agent-as-a-Judge: Evaluate agents with agents," arXiv:2410.10934, 2024.
+
+<a id="ref16"></a>[16] A. Yehudai et al., "Survey on evaluation of LLM-based agents," in *ACL Findings*, 2025. arXiv:2503.16416.
+
+<a id="ref17"></a>[17] OpenTelemetry, "GenAI semantic conventions," 2026. [Online]. Available: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+
+<a id="ref18"></a>[18] Langfuse, "Evaluation overview / Prompt management / User feedback," 2026. [Online]. Available: https://langfuse.com/docs/evaluation/overview
+
+<a id="ref19"></a>[19] MLflow, "GenAI evaluation / Scorers / Feedback," 2026. [Online]. Available: https://mlflow.org/docs/latest/genai/eval-monitor/
+
+<a id="ref20"></a>[20] Y. Liu, M. J. Q. Zhang, and E. Choi, "User feedback in human-LLM dialogues: A lens to understand users but noisy as a learning signal," in *EMNLP*, 2025. arXiv:2507.23158.
+
+<a id="ref21"></a>[21] MCP, "MCP registry preview," MCP Blog, 2025. [Online]. Available: https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/
+
+<a id="ref22"></a>[22] MCP, "First MCP anniversary: 2025-11-25 spec release," MCP Blog, 2025. [Online]. Available: https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/
+
+<a id="ref23"></a>[23] Anthropic, "Equipping agents for the real world with Agent Skills," Anthropic Engineering Blog, 2025. [Online]. Available: https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+
+<a id="ref24"></a>[24] R. Xu and Y. Yan, "Agent skills for large language models: Architecture, acquisition, security, and the path forward," in *Agent Skills '26 Workshop (ACM)*, 2026. arXiv:2602.12430.
+
+<a id="ref25"></a>[25] Z. Wang et al., "MCP-Bench: Benchmarking tool-using LLM agents with complex real-world tasks via MCP servers," arXiv:2508.20453, 2025.
+
+<a id="ref26"></a>[26] Gorilla / UC Berkeley, "BFCL V4: Holistic agentic evaluation," 2026. [Online]. Available: https://gorilla.cs.berkeley.edu/leaderboard.html
+
+<a id="ref27"></a>[27] Y. Qin et al., "ToolLLM: Facilitating large language models to master 16000+ real-world APIs," in *Proc. ICLR*, 2024. arXiv:2307.16789.
+
+<a id="ref28"></a>[28] T. Cai et al., "Large language models as tool makers," arXiv:2305.17126, 2023.
+
+<a id="ref29"></a>[29] C. Qian et al., "CREATOR: Tool creation for disentangling abstract and concrete reasoning," in *EMNLP Findings*, 2023. arXiv:2305.14318.
+
+<a id="ref30"></a>[30] G. Wolflein et al., "LLM agents making agent tools," in *Proc. ACL*, 2025. arXiv:2502.11705.
+
+<a id="ref31"></a>[31] J. Qiu et al., "Alita: Generalist agent enabling scalable agentic reasoning with minimal predefinition and maximal self-evolution," arXiv:2505.20286, 2025.
+
+<a id="ref32"></a>[32] Z. Z. Wang et al., "Inducing programmatic skills for agentic tasks," arXiv:2504.06821, 2025.
+
+<a id="ref33"></a>[33] W&B, "Weave evaluations / leaderboards," 2026. [Online]. Available: https://docs.wandb.ai/weave/guides/core-types/evaluations
+
+<a id="ref34"></a>[34] promptfoo, "CI/CD integration," 2026. [Online]. Available: https://www.promptfoo.dev/docs/integrations/ci-cd/
+
+<a id="ref35"></a>[35] OWASP, "Top 10 for agentic applications for 2026," OWASP GenAI Security Project, 2025. [Online]. Available: https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/
+
+<a id="ref36"></a>[36] T. Pan, "Releasing AI features without breaking production: Shadow mode, canary deployments, and A/B testing for LLMs," 2026. [Online]. Available: https://tianpan.co/blog/2026-04-09-llm-gradual-rollout-shadow-canary-ab-testing
+
+<a id="ref37"></a>[37] B. Baker et al., "Monitoring reasoning models for misbehavior and the risks of promoting obfuscation," arXiv:2503.11926, 2025.
+
+<a id="ref38"></a>[38] Anthropic, "Natural emergent misalignment from reward hacking in production RL," Anthropic Research, 2025. arXiv:2511.18397.


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：为 negentropy 平台设计**自进化 Agents Team 系统**，使 Agent 定义（system_prompt / model / skills 挂载）与技能/工具能力（prompt_template / config JSONB / pipeline 参数）能够基于遥测信号与评测反馈进行数据驱动的自主迭代升级，同时通过固定框架层保障进化安全性
- 关联上下文/Issue/文档：调研报告 → [130 号调研](../docs/research/130-self-evolving-agents-team.md)；技术方案 → [自进化 Agents Team 方案](../docs/concepts/design/self-evolving-agents.md)；理论先例 → [110 号调研](../docs/research/110-routine-agent-iteration.md)

# 核心变更

**调研报告**（`docs/research/130-self-evolving-agents-team.md`，375 行，38 篇 IEEE 引用）：
- 自进化智能体理论：DGM（Sakana AI）、ADAS（ICLR 2025）、AlphaEvolve（DeepMind）、AgentSquare、EvoAgent
- 进化算子横向比较：GEPA（ICLR 2026 Oral，核心选型）、ACE（ICLR 2026）、OPRO、TextGrad、MIPROv2 等 7 种
- 评测回路：Agent-as-a-Judge（Meta AI，~90% 人类对齐率）、OTel GenAI semconv、Langfuse、MLflow、promptfoo 工业对标矩阵
- 工具生态自进化：MCP Registry（~2,000 条目）、Anthropic Agent Skills（渐进式披露三层加载）、LLM 自造工具谱系（LATM/CREATOR/Alita 等）
- 护栏治理：OWASP Agentic AI Top 10 威胁映射、金丝雀/影子部署、Goodhart's Law 防护四件套

**技术方案**（`docs/concepts/design/self-evolving-agents.md`，510 行）：
- 三层自进化架构：Meta-Layer（固定框架，不可被进化修改） / Evolvable-1（动态 Agent 定义） / Evolvable-2（外部能力工具）
- 统一闭环：遥测 → 评测 → 提案 → 验证 → 门控发布，复用平台已有四个进化原语（LLM-as-Judge / Reflexion / SemVer 版本快照 / 竞争择优）
- 关键新表：`tool_invocations`（三源归一遥测）、`eval_suites/cases/runs/results`（评测四件套）、`agent_versions`（对齐 skill_versions 范式）、`evolution_proposals`（统一登记簿）
- 护栏：「框架不自改」四道边界 + 人审门控矩阵（auto / first / every 三档） + 自动回滚条件 + 防 Goodhart 四件套
- 四阶段演进路线：Phase 1 遥测+评测地基 → Phase 2 Agent prompt 进化 → Phase 3 技能/工具进化 → Phase 4 自造技能+团队结构
- 3 个 ADR：独立状态机 vs 复用 Routine、泛型登记簿+专表快照混合、基线/进化双轨 + active_version 指针

**知识索引**（`docs/.agents/knowledge-map.md`，+2 行）：
- 设计方案区与调研区各新增一条条目，含完整摘要与交叉引用链接

# 风险与回滚
- 主要风险：**纯文档变更，无代码改动，零风险**
- 回滚方式：`git revert`

# 验证证据
- 单元测试：不涉及（纯文档）
- 集成测试：不涉及
- E2E/Workflow：不涉及
- 覆盖率/关键截图：知识索引条目已更新，文档内交叉引用链接完整

# 影响范围
- 前端：无
- 后端：无（方案为后续实现提供设计蓝图）
- GitHub Actions / 文档：知识索引 knowledge-map.md 新增 2 条条目

# Next Best Action
- 基于 Phase 1 演进路线，启动遥测子系统（`tool_invocations` 三源采集）与评测子系统（eval 四表）的详细设计与实现