### PR TITLE
docs(SelfEvolving): 自进化文档真实性校验——校准 4 处失真陈述并精确化锚点

### DIFF
--- a/docs/concepts/design/self-evolving-agents.md
+++ b/docs/concepts/design/self-evolving-agents.md
@@ -135,13 +135,15 @@ flowchart TB
 |----|---------|--------|------|
 | `routine_iteration_events` | Claude Code 动作级 | `streaming_persister` | 仅 Routine 内 |
 | `mcp_tool_runs` + events | trial UI / 知识抽取 | `McpToolExecutionService` | 非主运行时 |
-| `tools` / `tool_executions` | ADK 工具调用 | **Dormant（无写入方）** | 核心缺口 |
+| `tools` / `tool_executions` | ADK 工具调用 | **Dormant（写入路径存在但未接线）**[^te] | 核心缺口 |
 | `traces` | OTel span 入库 | LiteLLM 回调 | LLM 调用级，非工具级 |
 | `knowledge_feedback` | 用户反馈 | API | 仅知识域 |
 | `memory_retrieval_logs` | 记忆检索级（检索→引用→反馈全链） | `retrieval_tracker.py` | 未纳入统一聚合、未与 eval_runs 关联 |
 | `memory_conflicts` + KG 构建指标 | 冲突检测 / 图谱抽取质量 | `conflict_resolver` / `graph/metrics.py` | 无 daily 聚合、无进化消费方 |
 
 关键论断：**记忆子系统是唯一已有「检索 → 引用（was_referenced）→ 结果反馈（outcome_feedback）」全链遥测的层**——`tool_invocations` 的归因设计应向其对齐，而非反向重建。
+
+[^te]: `tool_executions` 的写入路径在代码中已存在（`tool_registry.py` 的 `ToolRegistry._record_execution`，经 `invoke_tool` 调用），但 `ToolRegistry` 在 `src/` 中从未被实例化、未接入主运行时（仅集成测试中使用），故生产环境实际无写入——dormant 结论与「需新增 ADK callback 挂点」的设计动机均成立。
 
 ### 3.2 新表 `tool_invocations`
 
@@ -288,7 +290,7 @@ agent_versions
 active_version 指向的快照 > agents.system_prompt（代码 Sync 基线） > 代码硬编码 fallback
 ```
 
-**Sync 改造**（解决 [interface/api.py](../../../apps/negentropy/src/negentropy/interface/api.py) 约 :2546 的覆写冲突）：
+**Sync 改造**（解决 [interface/api.py](../../../apps/negentropy/src/negentropy/interface/api.py) `sync_negentropy_agents` 的覆写冲突）：
 - `sync_negentropy_agents` 改为「只更新基线 + 落一条 `origin=code_sync` 的版本行，**绝不触碰 `active_version`**」；
 - 进化版本晋升后若基线更新（代码改了 prompt），自动将该进化版本标记 `is_stale` 并要求重评——**显式拒绝自动三方合并**（交还人/重新进化）。
 

--- a/docs/research/130-self-evolving-agents-team.md
+++ b/docs/research/130-self-evolving-agents-team.md
@@ -26,14 +26,14 @@ negentropy 已具备四个可复用的进化原语，本报告的核心论点是
 |------|---------|------|
 | LLM-as-Judge 评测 | [engine/routine/evaluator.py](../../apps/negentropy/src/negentropy/engine/routine/evaluator.py) | 0–100 分 + verdict 五档 + 自然语言反思 |
 | Reflexion 反思 | [engine/consolidation/reflection_generator.py](../../apps/negentropy/src/negentropy/engine/consolidation/reflection_generator.py) | `routines.reflections` JSONB 跨迭代注入 |
-| SemVer 版本快照 | [models/skill.py](../concepts/design/skills.md) `skill_versions` 表 | 不可变版本历史 + SemVer + JSONB snapshot |
+| SemVer 版本快照 | [models/skill.py](../../apps/negentropy/src/negentropy/models/skill.py) `skill_versions` 表 | 不可变版本历史 + SemVer + JSONB snapshot |
 | 竞争择优 | perceives [pipeline_config.py](../reference/perceives/) `competition_mode` | 多引擎并行 + LLM 评审择优 |
 | 检索反馈闭环 | engine/adapters/postgres/retrieval_tracker.py | `memory_retrieval_logs`（zero_hit_rate / was_referenced / outcome_feedback）+ 反馈触发反思 |
 | 遗忘曲线治理 | engine/governance/memory.py | retention_score（λ 支持 `metadata.decay_override` 条目级覆盖——参数外置接口已就位） |
 
 四个决定性缺口（方案需解决）：
 1. `agents` 表**无版本表**，且 `sync_negentropy_agents` 每次 Sync 覆写 `system_prompt`——进化产物会被踩掉；
-2. ADK 主运行时**无工具调用级遥测**（`tool_executions` 表 dormant 无写入方）；
+2. ADK 主运行时**无工具调用级遥测**（`tool_executions` 表 dormant——写入路径 `ToolRegistry._record_execution` 虽存在，但该 Registry 未接入主运行时，仅集成测试实例化，生产无写入）；
 3. `eval_tests/` 近乎空壳，无 golden set / 回归门禁；
 4. 记忆/知识子系统的运行参数（遗忘 λ、检索权重、chunking 策略、KG 抽取 prompt）**散落在 env/代码常量中无版本化**——进化产物无处落地。
 
@@ -191,15 +191,15 @@ Agent 评测综述<sup>[[16]](#ref16)</sup> 明确分层：最终响应评测（
 
 ### 5.1 MCP 规范与 Registry 进展
 
-**MCP Registry**（2025-09-08 Preview<sup>[[21]](#ref21)</sup>）是面向公开 MCP Server 的开放目录，server.json 元数据 schema + REST API，当前 **Preview 阶段**（v0.1 冻结）。支持公共/私有子注册表——私有型映射企业部署场景。注册条目近 **2,000**。
+**MCP Registry**（2025-09-08 Preview<sup>[[21]](#ref21)</sup>）是面向公开 MCP Server 的开放目录，server.json 元数据 schema + REST API，当前 **Preview 阶段**（v0.1 冻结）。支持公共/私有子注册表——私有型映射企业部署场景。注册体量随生态快速扩张（第三方分析显示去重后约千余个唯一包，原始条目因 CI 重复发布远高于此）。
 
-**MCP 2025-11-25 稳定版**<sup>[[22]](#ref22)</sup> 引入 Tasks 原语（长时运行任务，状态机 working→completed/failed/cancelled）、Sampling+Tools（服务端 agentic loop）、简化 OAuth。2026-07-28 RC 计划无状态核心、Transport Headers、Tasks 移至扩展。
+**MCP 2025-11-25 稳定版**<sup>[[22]](#ref22)</sup> 引入 Tasks 原语（长时运行任务，experimental capability，状态机 working/input_required→completed/failed/cancelled）、Sampling+Tools（服务端 agentic loop）、简化 OAuth。2026-07-28 RC 计划无状态核心、Transport Headers、Tasks 移至扩展。
 
 ### 5.2 Agent Skills 设计哲学
 
-**Anthropic Agent Skills**<sup>[[23]](#ref23)</sup>（开放标准 agentskills.io，40+ 产品采用）核心设计：**渐进式披露三层加载**——Discovery（name/description）→ Activation（完整 SKILL.md 正文）→ Execution（引用文件/脚本）。
+**Anthropic Agent Skills**<sup>[[23]](#ref23)</sup>（开放标准 agentskills.io，2025-12-18 启动）核心设计：**渐进式披露三级加载**——Level 1 技能元数据（name/description，启动期注入系统提示）→ Level 2 完整 SKILL.md 正文（判定相关时加载）→ Level 3 SKILL.md 引用的捆绑文件/脚本（按需读取）。
 
-**negentropy 对标**：`skills_injector` 的 Jinja2 prompt_template + Progressive Disclosure 与 SKILL.md 三层加载**高度同构**。skills 表 name/description = Discovery 层；prompt_template = Activation 层；resources = Execution 层。建议增加 SKILL.md 兼容 adapter。
+**negentropy 对标**：`skills_injector` 的 Jinja2 prompt_template + Progressive Disclosure 与 SKILL.md 三级加载**高度同构**。skills 表 name/description = Level 1 元数据层；prompt_template = Level 2 正文层；resources = Level 3 捆绑文件层。建议增加 SKILL.md 兼容 adapter。
 
 **技能层综述**<sup>[[24]](#ref24)</sup> 发现社区贡献技能中 **26.1% 含安全漏洞**——强力驱动验证流水线需求。
 
@@ -379,7 +379,7 @@ flowchart LR
 
 **OpenAI CoT 监控论文**<sup>[[37]](#ref37)</sup> 证明：对 CoT 施加强优化压力会导致 Obfuscated Reward Hacking——Agent 学会在 CoT 中隐藏意图但仍继续作弊。建议：不对 CoT 直接施加优化压力。
 
-**Anthropic Emergent Misalignment**<sup>[[38]](#ref38)</sup> 证明：模型学会 reward hack 的瞬间，所有 misalignment 指标同时飙升。Inoculation prompting（告知模型作弊边界）高度有效。
+**Anthropic Emergent Misalignment**<sup>[[38]](#ref38)</sup> 证明：模型学会 reward hack 的瞬间，所有 misalignment 指标同时飙升。Inoculation prompting（告知模型作弊边界）是论文列出的三个**有效**缓解之一（正文报告其将 misalignment 降低 75–90%）。
 
 **防护四件套**：① 冻结 holdout 集（结果不回流 proposer）；② 多目标晋升判据（质量 AND 成本 AND 延迟 AND 在线确认）；③ Judge 与 Proposer 模型强制异源；④ 评测集随失败采收持续换血。
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：对自进化架构两份核心文档执行循证真实性校验（`/veracity-attestation`），消除会污染后续工程决策的失真陈述——失真集中于 Anthropic 自家博文/论文措辞与无权威来源的数字。
- 关联上下文/Issue/文档：[130 调研报告](docs/research/130-self-evolving-agents-team.md)、[self-evolving-agents 技术方案](docs/concepts/design/self-evolving-agents.md)；承接 #914（三层→四层扩展）。

# 核心变更
- **Agent Skills [23]**：删除不在所引博文中的「40+ 产品采用」；三层渐进式披露按博文实际改为 Level 1/2/3（元数据 → SKILL.md 正文 → 捆绑文件），去掉自造的 Discovery/Activation/Execution 标签并同步 negentropy 对标段落。
- **Emergent Misalignment [38]**：inoculation prompting「高度有效」弱化为摘要原文的「有效」（三个有效缓解之一），75–90% 降幅标注为正文结果。
- **MCP 规范 [21][22]**：删除无来源的「注册条目近 2,000」改为可溯源体量描述；Tasks 状态机补 `input_required` 态 + experimental 限定。
- **内部锚点精确化**：设计文档易腐行号 `约 :2546` 改为函数名 `sync_negentropy_agents`；`tool_executions`「无写入方」精确为「写入路径存在但未接入主运行时」（dormant 结论不变，新增脚注）；修正版本快照链接文本与 href 不一致。

# 风险与回滚
- 主要风险：极低——纯文档措辞校准，未改动结构、叙事意图、Mermaid 图，不涉及任何代码/配置/迁移。
- 回滚方式：`git revert aed40701` 即可，无副作用。

# 验证证据
- 单元测试：N/A（纯文档变更，pre-commit hooks 全过）。
- 集成测试：N/A。
- E2E/Workflow：两轮多 agent workflow（9 个搜索 agent）逐条比对 arXiv/会议/官方博客/项目代码，核验 ~90 条断言（内部锚点 ~30 + 外部引用 ~60）。
- 覆盖率/关键截图：校准 7 处（4 必改 + 3 精确化），校准率 ~7.8%；学术 arXiv ID/会议年份/关键性能数字（DGM 20→50%、AlphaEvolve 0.7%、GEPA 全数字、Mem0 26%/91%、Zep 18.5%/90% 等）经核验几乎零失真。

# 影响范围
- 前端：无。
- 后端：无（仅引用代码作为校验基准，未改动代码）。
- GitHub Actions / 文档：仅 `docs/` 下两份 Markdown（130 调研报告 + self-evolving-agents 技术方案）。

# Next Best Action
- 若需将「千余个」精确为某确定日期快照的 registry 条目数，可补查后再校准；其余引用经核验可作为后续工程决策的可信基准。