### PR TITLE
docs(Docker): 首次发布操作手册沉淀——docker-operations 新增 §7.0 首发指引

### DIFF
--- a/docs/.agents/knowledge-map.md
+++ b/docs/.agents/knowledge-map.md
@@ -24,7 +24,7 @@
 - [Observability / GenAI 可观测性](../concepts/design/observability-genai.md)
 - [QA Delivery Pipeline](../concepts/design/qa-delivery-pipeline.md)
 - [Docker Release Pipeline](../concepts/design/docker-release-pipeline.md) — compose 栈 4 镜像（backend / perceives / ui / wiki）的多架构构建与 Docker Hub 发布：PR 构建校验 + tag 发布双入口，amd64+arm64 原生 runner + digest 合并 + provenance/SBOM
-- [Docker Compose 运维指引](../concepts/docker-operations.md) — compose 栈 5 服务的部署、日常操作、开发工作流与故障排查：首次部署、版本管理、健康检查、日志查看、卷备份、常见故障排除
+- [Docker Compose 运维指引](../concepts/docker-operations.md) — compose 栈 5 服务的部署、日常操作、开发工作流与故障排查：首次部署、首次发布、版本管理、健康检查、日志查看、卷备份、常见故障排除
 - [浏览器操作 MCP 集成方案](../concepts/design/browser-automation-mcp-integration.md) — Playwright MCP 全系统默认配备：单一注入点（builtin_tools.mcp_config）provision 至 Routine / Scheduler / 6 Agents，用于浏览器实机回归验证
 - [自进化 Agents Team 方案](../concepts/design/self-evolving-agents.md) — 四层自进化架构（固定框架 Meta-Layer / 动态 Agent 定义 / 外部能力工具 / 记忆与知识系统）：遥测→评测→提案→验证→门控发布全闭环，含 agent_versions 版本化、GEPA/ACE 进化算子、记忆/知识配置进化回路（基质/客体分轨 ADR-4）、Golden Set 双轨评测、金丝雀发布、护栏决策矩阵与四阶段演进路线（调研基础见 [130 号调研](../research/130-self-evolving-agents-team.md)）
 

--- a/docs/concepts/design/docker-release-pipeline.md
+++ b/docs/concepts/design/docker-release-pipeline.md
@@ -108,6 +108,8 @@ docker compose up -d
 2. **首发用 prerelease 小步验证**：推 tag `negentropy-v<x.y.z>-rc.1`，验证 `docker buildx imagetools inspect threefishai/negentropy-backend:<x.y.z>-rc.1` 含 amd64+arm64 双平台；
 3. **正式发布**：推 tag `negentropy-v<x.y.z>`，联动产出 `x.y.z` / `x.y` / `latest`。
 
+> **首次发布**（`negentropy-v*` tag 数为 0、镜像仓库不存在）的专属准备——版本号 ↔ pyproject 耦合、首发陷阱速查、`negentropy doctor` 端到端自检——见 [Docker Compose 运维指引 §7.0](../docker-operations.md#7-发布运维)。
+
 ## 相关文件
 
 - [reusable-negentropy-docker.yml](../../../.github/workflows/reusable-negentropy-docker.yml) — 机制层：构建 + digest 合并

--- a/docs/concepts/docker-operations.md
+++ b/docs/concepts/docker-operations.md
@@ -444,6 +444,51 @@ docker buildx imagetools inspect threefishai/negentropy-backend:latest
 
 > 镜像构建与流水线设计详见 [Docker Release Pipeline](./design/docker-release-pipeline.md)。本节聚焦发布操作的**执行步骤**。
 
+### 7.0 首次发布（First Release）
+
+> 当 `negentropy-v*` tag 数为 0、且 `threefishai` 命名空间下 4 个镜像仓库均不存在时即为**首次发布**——在常规 [7.1 检查清单](#71-发布前检查清单) / [7.2 发布流程](#72-发布流程) 之外，需额外关注以下首发专属事项。
+
+**① 首发判定**（确认确为第一次）：
+
+```bash
+# 仓内无历史发布 tag（预期为空）
+git tag --list 'negentropy-v*'
+
+# Docker Hub 上镜像仓库不存在（HTTP 404 即从未发布）
+curl -s -o /dev/null -w '%{http_code}\n' https://hub.docker.com/v2/repositories/threefishai/negentropy-backend/tags/
+```
+
+**② 版本号决策**（⚠️ 非显而易见的耦合）：
+
+Docker 镜像 tag 由 git tag 派生（`negentropy-v<x.y.z>` → `<x.y.z>`），但 `package-release` 用 `uv build` 打的 wheel 取自 [`apps/negentropy/pyproject.toml`](../../apps/negentropy/pyproject.toml) 的 `version`。**首发 tag 务必与 pyproject `version` 对齐**，否则 GitHub Release 标题、wheel 命名、Docker 镜像 tag 三者错位。
+
+| 当前 pyproject `version` | 推荐首发 tag |
+|:---|:---|
+| `0.1.0` | `negentropy-v0.1.0` |
+
+> 若需发布更高版本（如 `1.0.0`），须先 bump pyproject / package.json —— 属代码改动，不属于纯发布操作。
+
+**③ 首发陷阱速查**：
+
+| 陷阱 | 说明 |
+|:---|:---|
+| Secrets 必须 **Repository 级** | `uses:` 型 `docker-release` job 无法声明 environment，environment-scoped secrets 对其不可见 → `Login to Docker Hub` 失败。详见 [Release Pipeline 前置配置](./design/docker-release-pipeline.md)。 |
+| fork 防御 | `docker-release` 含 `if: github.repository_owner == 'ThreeFish-AI'`；非 ThreeFish-AI 仓库推 tag 不会发布。 |
+| PG 来自上游命名空间 | 消费者 `pull` 会从 `pgvector` 官方拉 `pgvector/pgvector:pg17` + 从 `threefishai` 拉 4 个应用镜像——属「复用上游 PG」方案的预期外观，非异常。 |
+| 消费者必填 LLM key | PG 无密钥（trust 认证），但应用不填至少一个 LLM key 与 `NE_AUTH_TOKEN_SECRET` 无法正常服务。密钥准备见 [§2.3 环境变量设置](#23-环境变量设置)。 |
+| 勿混入 `.local.yml` | 消费者使用裸 `docker-compose.yml`，勿叠加 `docker-compose.local.yml`（开发期 inmemory / 关 langfuse 覆盖）或 `./dev` 脚本。 |
+
+**④ 首发端到端验证**（在 [7.3 发布后验证](#73-发布后验证) 基础上补应用层自检）：
+
+```bash
+export NEGENTROPY_IMAGE_TAG=0.1.0
+docker compose -f docker-compose.yml up -d --no-build
+curl -fsS http://localhost:3292/health                               # backend 健康（HTTP 200）
+docker compose -f docker-compose.yml exec backend negentropy doctor  # 应用自检（含 DB / pgvector 扩展）
+```
+
+> **判定**：5 服务（postgres / perceives / backend / ui / wiki）均 `healthy` + `/health` 返回 200 + `negentropy doctor` 通过 = 首次发布成功。
+
 ### 7.1 发布前检查清单
 
 - [ ] 所有 CI 门禁通过（backend QA + UI QA）


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：将 Negentropy 全套（含 PostgreSQL）发布到 Docker Hub 的操作知识缺失「首次发布」专属指引——现有 `docker-operations.md` §7 与 `docker-release-pipeline.md` 仅覆盖常规发布流程/前置配置，未说明首次发布（无历史 tag、镜像仓库不存在）特有的版本号耦合、陷阱与端到端自检。
- 关联上下文/Issue/文档：[docker-operations.md](docs/concepts/docker-operations.md)、[docker-release-pipeline.md](docs/concepts/design/docker-release-pipeline.md)；首发版本号取 `0.1.0`（对齐 `apps/negentropy/pyproject.toml`）。

# 核心变更
- `docs/concepts/docker-operations.md`：新增 **§7.0 首次发布（First Release）** 小节（+45 行），聚焦首发专属增量、零重复既有 §7.1–7.5：
  - ① 首发判定（`git tag --list 'negentropy-v*'` + Docker Hub API 404）
  - ② **版本号 ↔ pyproject 耦合陷阱**（核心：首发 tag 须与 pyproject `version` 对齐，否则 GitHub Release 标题 / wheel 命名 / Docker 镜像 tag 三者错位）
  - ③ 首发陷阱速查表（repo 级 Secrets / fork 防御 / PG 上游命名空间 / 消费者必填 LLM key / 勿混 `.local.yml`）
  - ④ `negentropy doctor` + `/health` 端到端自检
- `docs/concepts/design/docker-release-pipeline.md`：「发布操作手册」补交叉链接至 §7.0（双向锚定）。
- `docs/.agents/knowledge-map.md`：docker-operations 索引描述补「首次发布」（满足 AGENTS.md「文档变更即时同步索引」）。

# 风险与回滚
- 主要风险：纯文档增量，无代码/配置/CI 改动，零运行时风险；内部锚点已校验真实存在。
- 回滚方式：`git revert <commit>` 即可。

# 验证证据
- 单元测试：N/A（纯文档）。
- 集成测试：N/A。
- E2E/Workflow：`docker compose -f docker-compose.yml config -q` 通过（与 CI `negentropy-docker-validate.yml` 同款 lint）；pre-commit 钩子全过（trim/EOF/YAML/TOML/merge-conflict/large-file）。
- 覆盖率/关键截图：4 个内部锚点目标标题（§7.1 / §7.2 / §7.3 / §2.3）均 grep 确认存在，无死链。

# 影响范围
- 前端：无。
- 后端：无。
- GitHub Actions / 文档：仅文档（docker-operations.md / docker-release-pipeline.md / knowledge-map.md）。

# Next Best Action
- 推进真实首发：Phase 0（Docker Hub 创建 `threefishai` 命名空间 + 4 仓库 + PAT；GitHub 配置 repository 级 `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`）→ Phase 1 干跑（dispatch `publish_release=false`）→ 推 `negentropy-v0.1.0-rc.1` 验双架构 → 推 `negentropy-v0.1.0` 正式发布。详见本次新增 §7.0。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
