### PR TITLE
fix(Docker): 修复 PR 构建被取消——cache-to 按 push 门控消除冗长缓存上传根因

### DIFF
--- a/.github/workflows/reusable-negentropy-docker.yml
+++ b/.github/workflows/reusable-negentropy-docker.yml
@@ -159,7 +159,10 @@ jobs:
           # cache scope 按 镜像 × 平台 隔离（共 8 个），mode=max 导出全部
           # 构建阶段层（multi-stage 下 builder 层缓存是命中率关键）
           cache-from: type=gha,scope=docker-${{ matrix.image.name }}-${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,scope=docker-${{ matrix.image.name }}-${{ env.PLATFORM_PAIR }},mode=max
+          # cache-to 仅发布（push=true）时导出：PR 校验构建即弃，cache-to 上传对当前构建
+          # 零收益，却因 mode=max 全量上传中间阶段层（perceives venv 单层曾达 8.5 分钟）
+          # 拖慢 ~14 分钟并放大被并发取消的窗口。cache-from 保留，PR 仍可命中发布预热缓存。
+          cache-to: ${{ inputs.push && format('type=gha,scope=docker-{0}-{1},mode=max', matrix.image.name, env.PLATFORM_PAIR) || '' }}
           outputs: type=image,name=docker.io/${{ env.REGISTRY_NAMESPACE }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
 
       - name: Export digest


### PR DESCRIPTION
## 背景

PR #918 的 "Docker Build Validation" workflow 执行异常：\`Build negentropy-perceives (linux/amd64)\` 的 \`Build image (push by digest when enabled)\` 步骤报 \`Error: The operation was canceled.\`（[run 27769280408](https://github.com/ThreeFish-AI/negentropy/actions/runs/27769280408)，conclusion=cancelled）。其余 7 个 build job（backend/ui/wiki × 两架构 + perceives arm64）均成功。

## 根因（循证，已从日志确证）

双重叠加：

1. **病理根因——\`cache-to: type=gha,mode=max\` 缓存导出主宰 wall-clock**（对当前 PR 构建零收益）。
   - perceives 镜像本体在 \`15:16:26\` 即构建完成（\`#19 DONE 250.2s\`），但随后的 \`#20 exporting to GitHub Actions Cache\`（cache-to 上传）从 15:16:26 一路耗到 15:30:40 被取消仍未结束——**单层 venv（\`1765bf7…\`）上传耗时 510.9s ≈ 8.5 分钟**，全程 14+ 分钟。
   - 冷启动诱因：PR 大幅改写 perceives \`uv.lock\`（−284/+114 行，含 docling/docling-core/aiohttp/pyjwt 重依赖），GHA 缓存未命中 → 全量重建多 GB venv → \`mode=max\` 需上传全部中间构建阶段层。
2. **取消触发器——caller workflow 并发取消**。\`negentropy-docker-validate.yml\` 配 \`cancel-in-progress: true\`；\`15:30:39\` 有人向 PR 推了第二个 commit（触发后继 run 27770579777），同一并发组命中 \`cancel-in-progress\` → \`15:30:40\` 杀掉仍卡在缓存上传的前一个 run。

并发取消本身是正确设计；问题在于被击中的 run 被"对当前构建零收益"的冗长 cache-to 上传拖慢。

## 修复（最小干预，1 处改动）

将 \`reusable-negentropy-docker.yml\` 的 \`cache-to\` 按 \`inputs.push\` 门控：

- PR 校验（\`push=false\`）→ \`cache-to\` 为空串（=不导出，build-push-action 过滤空串后不注入 \`--cache-to\`），消除冗长上传。
- 发布（\`push=true\`）→ 保留 \`mode=max\` 全量预热，为后续 PR 命中缓存。
- \`cache-from\` 保持无条件——PR 构建仍可命中发布预热的缓存（纯收益、零成本）。
- 与同文件 \`provenance\`/\`sbom\` 的"PR 不推送则关闭非必要开销"门控约定一致。

\`\`\`yaml
cache-from: type=gha,scope=docker-\${{ matrix.image.name }}-\${{ env.PLATFORM_PAIR }}
cache-to: \${{ inputs.push && format('type=gha,scope=docker-{0}-{1},mode=max', matrix.image.name, env.PLATFORM_PAIR) || '' }}
\`\`\`

### 明确不改（已论证）
- \`concurrency.cancel-in-progress: true\`（正确设计，关掉会堆叠同 PR 多 run）。
- \`timeout-minutes: 45\`（实际 18 分钟即被取消，离上限很远）。
- matrix \`fail-fast: false\`（保留部分失败信号，利于诊断）。
- 不退回 \`mode=min\`（命中关键层是 builder 的 \`uv sync\` venv，mode=min 几乎零帮助）。

## 验证

- ✅ YAML 语法校验通过（\`yaml.safe_load\`）；actionlint 无新增告警（唯一 SC2129 为既有无关项）。
- 🔄 实机回归：本 PR 触发的 Docker Build Validation 中，perceives (amd64) step 7 日志**不应再出现 \`#20 exporting to GitHub Actions Cache\`**，构建在镜像导出（\`#19 DONE\`）后即结束，耗时回落至与其余镜像一致的 ~6 分钟内。

## Next Best Action（结构性后续，不在本次最小改动内）

1. **拆分 perceives venv 层（最高 ROI）**：在 \`docker/perceives/Dockerfile\` 把 \`uv sync\` 拆为"先装重依赖（变动少、命中率高）→ 再装业务依赖（变动多、层小）"，让一次 \`uv.lock\` 大改不再触发整层 GB 级重建。
2. **\`type=registry\` cache（发布侧）**：若发布构建 GHA cache 上传仍成瓶颈，可改 registry cache（不受 GHA 10GB/层限制）；代价是 fork PR 无 secrets 场景受限，故仅限发布侧。
3. **独立核查后继 run 27770579777**：该 run 同样在 perceives amd64 失败（conclusion=failure，~5.5 分钟），但日志存储已失效（\`BlobNotFound\`）无法取报错。建议在 1.x.x 发布前确认 perceives amd64 不存在第二个 commit 引入的独立构建回归。