### PR TITLE
perf(GHA): 工作流效率优化——并发去重、矩阵收敛、超时护栏

### DIFF
--- a/.github/workflows/cognizes-backend-tests.yml
+++ b/.github/workflows/cognizes-backend-tests.yml
@@ -2,7 +2,8 @@ name: Cognizes Backend Test Suite
 
 on:
   push:
-    branches: ["**"]
+    # 仅默认分支直推触发；其余分支由下方 pull_request 承担 CI，避免同提交 push+PR 双触发。
+    branches: [master, main, develop]
     paths:
       - "apps/cognizes/**"
       - ".github/workflows/cognizes-backend-tests.yml"

--- a/.github/workflows/cognizes-ruff.yml
+++ b/.github/workflows/cognizes-ruff.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Python with uv
         uses: ./.github/actions/setup-python-uv
@@ -88,8 +88,9 @@ jobs:
             EXISTING_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
 
             echo "Updating existing PR #$PR_NUMBER on branch $EXISTING_BRANCH"
-            git checkout "$EXISTING_BRANCH"
-            git pull origin "$EXISTING_BRANCH"
+            # fetch-depth:1 仅拉取触发分支；显式浅取既有修复分支后再切换，避免 checkout 失败
+            git fetch --depth 1 origin "$EXISTING_BRANCH"
+            git checkout -B "$EXISTING_BRANCH" "origin/$EXISTING_BRANCH"
             uv run ruff check src/cognizes/ tests/ --fix
             uv run ruff format src/cognizes/ tests/
 

--- a/.github/workflows/cognizes-ui-tests.yml
+++ b/.github/workflows/cognizes-ui-tests.yml
@@ -2,7 +2,8 @@ name: Cognizes UI Test Suite
 
 on:
   push:
-    branches: ["**"]
+    # 仅默认分支直推触发；其余分支由下方 pull_request 承担 CI，避免同提交 push+PR 双触发。
+    branches: [master, main, develop]
     paths:
       - "apps/cognizes-ui/**"
       - "apps/cognizes/tests/ui/**"

--- a/.github/workflows/negentropy-backend-tests.yml
+++ b/.github/workflows/negentropy-backend-tests.yml
@@ -2,8 +2,11 @@ name: Backend Test Suite
 
 on:
   push:
+    # 仅默认分支直推触发；其余分支由下方 pull_request 承担 CI，避免同提交 push+PR 双触发。
     branches:
-      - "**"
+      - master
+      - main
+      - develop
     paths:
       - "apps/negentropy/**"
       - "apps/negentropy-ui/lib/adk.ts"

--- a/.github/workflows/negentropy-dependency-review.yml
+++ b/.github/workflows/negentropy-dependency-review.yml
@@ -17,10 +17,15 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/negentropy-perceives-ci.yml
+++ b/.github/workflows/negentropy-perceives-ci.yml
@@ -30,13 +30,49 @@ defaults:
     working-directory: apps/negentropy-perceives
 
 jobs:
+  # 动态矩阵：跨平台全量（ubuntu/windows/macos）仅在「合并闸口」事件触发——
+  # PR / 默认分支(master,main,develop)推送 / 周期 / 手动 / workflow_call；
+  # feature/** 等短分支推送仅跑 ubuntu（macOS 10×/Windows 2× 高成本），跨平台由 PR 保证。
+  matrix-prep:
+    name: Prepare Test Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      os_matrix: ${{ steps.set.outputs.os_matrix }}
+    steps:
+      - name: Resolve OS matrix
+        id: set
+        shell: bash
+        run: |
+          event="${{ github.event_name }}"
+          ref="${{ github.ref }}"
+          full="false"
+          if [[ "$event" == "pull_request" \
+             || "$event" == "schedule" \
+             || "$event" == "workflow_dispatch" \
+             || "$event" == "workflow_call" ]]; then
+            full="true"
+          elif [[ "$event" == "push" ]]; then
+            case "$ref" in
+              refs/heads/master|refs/heads/main|refs/heads/develop) full="true" ;;
+              *) full="false" ;;
+            esac
+          fi
+          if [[ "$full" == "true" ]]; then
+            echo 'os_matrix=["ubuntu-latest","windows-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os_matrix=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Test on ${{ matrix.os }}
+    needs: [matrix-prep]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ${{ fromJSON(needs.matrix-prep.outputs.os_matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -47,11 +83,31 @@ jobs:
           working-directory: apps/negentropy-perceives
           enable-cache: "true"
 
-      - name: Run tests
-        run: uv run pytest -v --tb=short -n auto --timeout=300 -m "not slow"
+      # 合并原独立 coverage job：测试步骤直接产出 coverage（term/xml/html），
+      # 仅在 ubuntu 腿上传 artifact + Codecov（ubuntu 恒在矩阵中，确保唯一上传，避免各 OS 重复）。
+      - name: Run tests with coverage
+        run: uv run pytest -v --tb=short -n auto --timeout=300 -m "not slow" --cov=negentropy.perceives --cov-report=term --cov-report=xml --cov-report=html
         timeout-minutes: 20
         env:
           NEGENTROPY_PERCEIVES_ENABLE_JAVASCRIPT: "false"
+
+      - name: Upload coverage reports
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: perceives-coverage-report
+          path: |
+            apps/negentropy-perceives/coverage.xml
+            apps/negentropy-perceives/htmlcov/
+
+      - name: Upload to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./apps/negentropy-perceives/coverage.xml
+          flags: perceives-unittests
+          name: perceives-codecov-umbrella
+          fail_ci_if_error: false
 
   lint:
     name: Lint & Type Check
@@ -188,37 +244,3 @@ jobs:
           name: perceives-dist-test
           path: apps/negentropy-perceives/dist/
           retention-days: 7
-
-  coverage:
-    name: Coverage Report
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python with uv
-        uses: ./.github/actions/setup-python-uv
-        with:
-          working-directory: apps/negentropy-perceives
-
-      - name: Run tests with coverage
-        run: uv run pytest --cov=negentropy.perceives --cov-report=xml --cov-report=html --cov-report=term -n auto --timeout=300 -m "not slow"
-        timeout-minutes: 20
-        env:
-          NEGENTROPY_PERCEIVES_ENABLE_JAVASCRIPT: "false"
-
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: perceives-coverage-report
-          path: |
-            apps/negentropy-perceives/coverage.xml
-            apps/negentropy-perceives/htmlcov/
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./apps/negentropy-perceives/coverage.xml
-          flags: perceives-unittests
-          name: perceives-codecov-umbrella
-          fail_ci_if_error: false

--- a/.github/workflows/negentropy-perceives-ci.yml
+++ b/.github/workflows/negentropy-perceives-ci.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: read
 
+# 该工作流同时被直接触发（push/PR）与被 release 经 workflow_call 调用；
+# group 追加 event_name 后缀，隔离发布校验运行，避免重推 tag 时误取消在途校验。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: apps/negentropy-perceives
@@ -50,6 +56,7 @@ jobs:
   lint:
     name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +78,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -155,6 +163,7 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/negentropy-perceives-dependencies.yml
+++ b/.github/workflows/negentropy-perceives-dependencies.yml
@@ -9,6 +9,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# 自动建 PR 并独占分支（delete-branch: true）；不可中途取消，避免半成品 PR/分支残留。
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 defaults:
   run:
     working-directory: apps/negentropy-perceives
@@ -17,6 +22,7 @@ jobs:
   update:
     name: Update Dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/negentropy-perceives-release.yml
+++ b/.github/workflows/negentropy-perceives-release.yml
@@ -10,6 +10,11 @@ permissions:
   contents: write
   id-token: write
 
+# 发布流水线串行化：同一 tag 的重推/重跑不得互相取消，避免发布产物半途中断。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 defaults:
   run:
     working-directory: apps/negentropy-perceives
@@ -23,6 +28,7 @@ jobs:
     name: Build Distribution
     runs-on: ubuntu-latest
     needs: validate
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -112,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, pre-release-github]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 10
 
     environment:
       name: testpypi
@@ -162,6 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: approval
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4
@@ -196,6 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: promote-release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && needs.promote-release.result == 'success'
+    timeout-minutes: 10
 
     environment:
       name: pypi

--- a/.github/workflows/negentropy-perceives-review.yml
+++ b/.github/workflows/negentropy-perceives-review.yml
@@ -17,6 +17,10 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-review:
     name: PR Code Review

--- a/.github/workflows/negentropy-ui-tests.yml
+++ b/.github/workflows/negentropy-ui-tests.yml
@@ -2,8 +2,11 @@ name: UI Test Suite
 
 on:
   push:
+    # 仅默认分支直推触发；其余分支由下方 pull_request 承担 CI，避免同提交 push+PR 双触发。
     branches:
-      - "**"
+      - master
+      - main
+      - develop
     paths:
       - "apps/negentropy-ui/**"
       - ".github/workflows/negentropy-ui-tests.yml"


### PR DESCRIPTION
## 背景

`.github/workflows/` 下 20 个 workflow 中，5 个缺失 `concurrency`，相同的 workflow/Job 在连续推送时会重复执行、占用 runner 时间与资源；perceives-ci 在每次 `feature/**` 推送上都跑 macOS(10×)/Windows(2×) 全量矩阵；5 个测试类 workflow 的 push+PR 双触发导致同一提交跑两次全量；部分 job 缺 `timeout-minutes` 存在挂起风险。本 PR 在**不改变测试覆盖语义**前提下做效率与健壮性优化。

> 业界范式依据：[GitHub · Using concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)、[Discussion #41518](https://github.com/orgs/community/discussions/41518)、[adamj.eu · avoid double runs](https://adamj.eu/tech/2025/05/14/github-actions-avoid-simple-on/)、[Discussion #26940](https://github.com/orgs/community/discussions/26940)。

## 改动总览（10 文件，分 4 批次提交）

### 批次 1 — Tier 1：并发补齐 + 超时护栏（零行为变更）
为 5 个缺并发的工作流补齐 `concurrency` 与关键 job 的 `timeout-minutes`：

| Workflow | 并发策略 | 超时补充 |
|---|---|---|
| `negentropy-dependency-review.yml` | `cancel=true` | job 10min |
| `negentropy-perceives-ci.yml` | `cancel=true`（group 追加 `${{ github.event_name }}`，隔离 release 的 `workflow_call` 校验，防误取消） | lint 15 / security 20 / build 15 |
| `negentropy-perceives-review.yml` | `cancel=true`（sticky 评论由后续运行刷新） | 已有 20min |
| `negentropy-perceives-dependencies.yml` | `cancel=false`（独占建 PR 分支，不可中途取消） | update 30min |
| `negentropy-perceives-release.yml` | `cancel=false`（发布串行化） | build 15 / 发布系列各 10min（不设人工 approval 门） |

### 批次 2 — perceives-ci 矩阵收敛 + 合并冗余 coverage（最大成本节约）
- 新增 `matrix-prep` job 动态输出 `os_matrix`：**PR / 默认分支推送 / 周期 / 手动 / workflow_call → 全 3-OS；`feature/**` 推送 → 仅 ubuntu**。
- `test` job 合并原独立 `coverage` job（直接产出 `--cov` term/xml/html），coverage 仅在 ubuntu 腿上传 artifact + Codecov。
- 删除独立 `coverage` job，消除 ubuntu 上一次完整 pytest 重复执行。

### 批次 3 — 4 个测试 workflow push 触发收窄
`cognizes-backend/ui-tests`、`negentropy-backend/ui-tests` 的 `on.push.branches` 由 `["**"]` → `[master, main, develop]`，`pull_request` 维持 `["**"]`。消除同提交 push+PR 双触发。

### 批次 4 — cognizes-ruff 浅克隆
checkout `fetch-depth: 0 → 1`；既有修复分支更新路径改为 `git fetch --depth 1` + `checkout -B`，适配浅克隆。

## 关键设计决策：A 与 C 的冲突裁定

选项 A（perceives-ci 矩阵收敛）要求 `feature/**` 保留在 push（仅跑 ubuntu）；选项 C（push 收窄）要求移除 `feature/**`——**两者在 perceives-ci 上直接互斥**。

**裁定**：perceives-ci 采用 **A**（3-OS 矩阵工作流中收益最大，把冗余的 feature 推送从昂贵 3-OS 降为廉价单 ubuntu，且保留 PR 前快速反馈）；**C 原样应用于其余 4 个无矩阵的单 runner 测试 workflow**（无矩阵可收敛，去重为正解）。如需 perceives-ci 改采 C（移除 feature 推送、仅 PR 跑全量），可据此调整 `matrix-prep` 与 push 触发器。

## 验证

- `actionlint .github/workflows/*.yml`：**0 个结构性错误**（仅余既有 `run:` 脚本的 shellcheck 风格提示，均位于未改动脚本，非本次引入）。
- 全部 20 个 workflow YAML 合法性校验通过。
- `matrix-prep` 逻辑实测：PR/master/develop 推送/workflow_call/schedule/dispatch → 3-OS；`feature/**` 推送 → ubuntu-only。
- 并发分组与 push 收窄经结构核对：push 仅默认分支触发，pull_request 覆盖所有分支。

## 风险与缓解
- **perceives-ci 误取消 release 校验**：group 追加 `event_name`，且 tag ref 与 branch ref 本就异组，双保险。
- **feature 推送丢跨平台反馈**：PR 闸口仍跑全 3-OS，合并前必经跨平台校验。
- **`feature/1.x.x` 直推丢 push CI**：内容经 PR 合入已校验；如依赖直推可在对应 workflow 的 push.branches 追加该分支。
- **发布类被取消**：perceives-release / perceives-dependencies 一律 `cancel-in-progress: false`。

---

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>