### PR TITLE
fix(GHA): perceives 无 checkout job 继承 working-directory 致 CI 失败，matrix-prep/approval 覆盖至 workspace 根

### DIFF
--- a/.github/workflows/negentropy-perceives-ci.yml
+++ b/.github/workflows/negentropy-perceives-ci.yml
@@ -37,6 +37,12 @@ jobs:
     name: Prepare Test Matrix
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    # 该 job 仅依据 github 上下文计算 OS 矩阵、不读取仓库文件，故不执行 checkout；
+    # 必须覆盖 workflow 级 working-directory（apps/negentropy-perceives 在 checkout 前不存在，
+    # 否则 bash 启动报 "No such file or directory"），改在 workspace 根运行。
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
     outputs:
       os_matrix: ${{ steps.set.outputs.os_matrix }}
     steps:

--- a/.github/workflows/negentropy-perceives-release.yml
+++ b/.github/workflows/negentropy-perceives-release.yml
@@ -147,6 +147,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pre-release-github, testpypi]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    # 该 job 仅向 $GITHUB_STEP_SUMMARY 写审批清单、不读取仓库文件，故不执行 checkout；
+    # 必须覆盖 workflow 级 working-directory（apps/negentropy-perceives 在 checkout 前不存在，
+    # 否则 bash 启动报 "No such file or directory"），改在 workspace 根运行。与 perceives-ci
+    # matrix-prep 同根因（无 checkout job 继承 perceives 工作目录）。
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
 
     environment:
       name: production


### PR DESCRIPTION
# 背景

- 本次变更要解决的问题：GHA [run 27800242750](https://github.com/ThreeFish-AI/negentropy/actions/runs/27800242750)（PR #926 的 `Perceives CI`）`Prepare Test Matrix` job 失败——bash 启动报 `An error occurred trying to start process '/usr/bin/bash' with working directory '.../apps/negentropy-perceives'. No such file or directory`，导致依赖它的 `test` job 未启动。
- 关联上下文：根因来自 [PR#924](https://github.com/ThreeFish-AI/negentropy/pull/924)「工作流效率优化」新增的 `matrix-prep` job；同根因还波及 `negentropy-perceives-release.yml` 的 `approval` job（潜伏，仅 tag 推送触发）。

# 核心变更

- **根因**：`negentropy-perceives-ci.yml` / `negentropy-perceives-release.yml` 顶层设 `defaults.run.working-directory: apps/negentropy-perceives`。`matrix-prep`（#924 新增，仅依据 `github` 上下文计算 OS 矩阵）与 `approval`（仅向 `$GITHUB_STEP_SUMMARY` 写审批清单）这两个 job **不执行 checkout**，其 `run:` 步骤继承该默认工作目录，而该目录在 checkout 前不存在 → bash 启动即崩。
- **修复**：为这两个 job 增加 job 级 `defaults.run.working-directory: ${{ github.workspace }}` 覆盖，使 `run:` 步骤在 runner 必建的 workspace 根启动。
  - [.github/workflows/negentropy-perceives-ci.yml](.github/workflows/negentropy-perceives-ci.yml)：`matrix-prep`
  - [.github/workflows/negentropy-perceives-release.yml](.github/workflows/negentropy-perceives-release.yml)：`approval`
- **范围核验**：全量扫描所有 workflow 的「顶层 working-directory + 无 checkout + 含 run 步骤」job，确认**仅此 2 处**同类隐患（`perceives-dependencies.update` 等其余 job 均有 checkout 或无 run 步骤）。

# 风险与回滚

- 主要风险：极低。job 级 `defaults.run.working-directory` 覆盖是 GitHub Actions 官方支持语义（job 级优先于 workflow 级），`${{ github.workspace }}` 在 runner 启动 job 时即存在、不依赖 checkout；两个 job 的 run 步骤本就不读取 perceives 子目录文件。
- 回滚方式：删除两个 job 新增的 `defaults` 块即可还原。

# 验证证据

- 单元测试：N/A（仅 CI 配置变更）。
- E2E/Workflow：本 PR 触发 `Perceives CI`（pull_request 命中本 yml 路径）——预期 `Prepare Test Matrix` 通过、`Test on ubuntu/windows/macos`（PR 闸口全矩阵）正常启动并通过。**以 CI 在线运行结果为最终判据**。
- `approval` job 仅 tag 推送（`perceives-v*`）触发，无法经 PR CI 验证；修复为同根因最小覆盖，逻辑等价于已验证的 matrix-prep。

# 影响范围

- 前端：无。
- 后端：无。
- GitHub Actions / 文档：`negentropy-perceives-ci.yml`（matrix-prep）、`negentropy-perceives-release.yml`（approval）。

# Next Best Action

- 观察本 PR 的 `Perceives CI` 在线运行结果，确认 matrix-prep + test 全绿。
- 后续可考虑：将「无 checkout 的 job 不得继承子路径 working-directory」纳入 workflow 评审 checklist，防同类回归。
