### PR TITLE
fix(Docker): 修复多服务镜像启动失败与 postgres 主机端口冲突

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,10 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: negentropy
     ports:
-      - "5432:5432"
+      # 主机端口可经 NE_POSTGRES_HOST_PORT 覆盖（默认 5432，规避本机 PG 或同端口容器冲突）；
+      # 容器间通信仍走 service 名 postgres:5432，backend 的 NE_DB_URL 无需改动。
+      # 注意：本变量为 Compose 插值变量，须设于 shell 环境或根目录 .env（非 .env.docker*）。
+      - "${NE_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -9,7 +9,10 @@ FROM python:3.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-WORKDIR /build
+# 与 runtime stage 同路径（/app）：uv 生成的 console_script shebang 与 editable install
+# 的 .pth 会被固化为该绝对路径，builder/runtime 一致方能在 runtime 正确解析（否则 exec 报
+# "no such file or directory"、容器退出码 255）。
+WORKDIR /app
 
 # 先复制依赖声明与 README（pyproject.toml 引用 README.md，hatchling 构建需要）
 COPY apps/negentropy/pyproject.toml apps/negentropy/uv.lock apps/negentropy/README.md ./
@@ -32,11 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# 从 builder 复制虚拟环境
-COPY --from=builder /build/.venv /app/.venv
+# 从 builder 复制虚拟环境（builder/runtime 同为 /app，确保 console_script shebang 生效）
+COPY --from=builder /app/.venv /app/.venv
 
 # 复制应用代码
-COPY --from=builder /build/src ./src/
+COPY --from=builder /app/src ./src/
 
 # 复制 Alembic 配置（entrypoint 需要执行迁移）
 COPY apps/negentropy/alembic.ini ./

--- a/docker/perceives/Dockerfile
+++ b/docker/perceives/Dockerfile
@@ -9,7 +9,10 @@ FROM python:3.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-WORKDIR /build
+# 与 runtime stage 同路径（/app）：uv 生成的 console_script shebang 与 editable install
+# 的 .pth 会被固化为该绝对路径，builder/runtime 一致方能在 runtime 正确解析（否则 exec 报
+# "no such file or directory"、容器退出码 255）。
+WORKDIR /app
 
 # 先复制依赖声明与 README（pyproject.toml 引用 README.md，hatchling 构建需要）
 COPY apps/negentropy-perceives/pyproject.toml apps/negentropy-perceives/uv.lock apps/negentropy-perceives/README.md ./
@@ -32,8 +35,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# 从 builder 复制虚拟环境
-COPY --from=builder /build/.venv /app/.venv
+# 从 builder 复制虚拟环境（builder/runtime 同为 /app，确保 console_script shebang 生效）
+COPY --from=builder /app/.venv /app/.venv
+# 复制应用源码（editable install 的 .pth 指向 /app/src，runtime 须就位）
+COPY --from=builder /app/src ./src/
 
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH="/app" \

--- a/docs/concepts/docker-operations.md
+++ b/docs/concepts/docker-operations.md
@@ -408,13 +408,14 @@ flowchart TD
 
 | 问题 | 症状 | 根因 | 解决方案 |
 |:---|:---|:---|:---|
-| **端口冲突** | `bind: address already in use` | 本地 PostgreSQL 或其他进程占用了 :5432 / :3292 等端口 | `lsof -i :<port>` 定位占用进程，停止后重试；或修改 `docker-compose.yml` 中主机端口映射 |
+| **端口冲突** | `port is already allocated`（被其他容器占用）或 `bind: address already in use`（被宿主机进程占用） | 本机 PostgreSQL 或其他容器/进程占用了 :5432 / :3292 等主机端口 | `docker ps`（查容器）/ `lsof -i :<port>`（查进程）定位占用者；postgres 主机端口可经 `NE_POSTGRES_HOST_PORT`（设于根目录 `.env` 或 shell）改映射，无需停用既有服务；其余服务端口同理编辑 `docker-compose.yml` |
 | **数据卷损坏** | postgres 启动失败，日志显示数据目录错误 | 主机异常重启后 `postgres_data` 卷状态不一致 | `docker compose down && docker volume rm <project>_postgres_data && docker compose up -d`（⚠ 数据不可恢复） |
 | **镜像拉取失败** | `manifest not found` | `NEGENTROPY_IMAGE_TAG` 指定了不存在的标签 | 确认标签存在：`docker manifest inspect threefishai/negentropy-backend:<tag>` |
 | **健康检查超时** | 容器持续 `(unhealthy)` | 服务启动慢或探针目标不可达 | 查看日志 `docker compose logs <service>`；首次构建镜像时 backend 的 `start_period` 可能不够，等待后重试 |
 | **依赖链阻塞** | 服务一直等待，未启动 | 上游服务未达到 healthy 状态 | postgres 与 perceives 无级联关系、应分别独立排查；级联链为 postgres/perceives → backend → ui → wiki，按此顺序逐级确认上游 healthy |
 | **环境变量未加载** | 认证失败或 API Key 缺失 | `.env.docker.local` 未创建或密钥为空 | 确认文件存在且值已填写：`cat .env.docker.local \| grep -v '^#' \| grep -v '^$'` |
 | **架构不匹配** | `exec format error` | 在 amd64 主机运行 arm64 单架构镜像（或反之） | 使用多架构清单（默认行为），不要指定特定架构 digest |
+| **Python 服务 exec 失败** | `exec /app/.venv/bin/<script>: no such file or directory`，容器退出码 255 | 多阶段 Dockerfile 中 builder 与 runtime `WORKDIR` 不一致，`uv sync` 生成的 console_script shebang 被固化为 builder 绝对路径（如 `/build/.venv/bin/python3`），runtime 不存在 | builder 与 runtime 须保持相同 `WORKDIR`（本项目统一 `/app`），参见 [`docker/perceives/Dockerfile`](../../docker/perceives/Dockerfile)、[`docker/backend/Dockerfile`](../../docker/backend/Dockerfile) |
 
 ### 6.3 调试命令参考
 


### PR DESCRIPTION
## 背景

通过 CI 发布 `0.0.1-rc.1` 镜像后，本地 `docker compose up -d --no-build` 启动遇到两个**相互独立**的故障：

1. `negentropy-postgres` 启动失败：`Bind for 127.0.0.1:5432 failed: port is already allocated`
2. `negentropy-perceives` 持续 `Restarting (255)`，进而 backend / ui / wiki 因 `depends_on ... service_healthy` 级联卡死

## 根因诊断（均为镜像内/运行时实测）

**故障 A — postgres 主机端口冲突**
- 实际占用者：`assets-postgres-1` 容器（langfuse 栈）已占 Docker 层 `127.0.0.1:5432`，叠加本机 brew `postgresql@16`（Docker 报 `port is already allocated` 正是「被另一容器占用」的典型措辞）
- `docker-compose.yml` 硬编码 `"5432:5432"`，无任何变量插值，不可经环境变量改主机端口

**故障 B — Python 服务镜像 console_script shebang 失效（perceives + backend 同病）**
- 日志铁证：`exec /app/.venv/bin/negentropy-perceives: no such file or directory`
- 进镜像实测：console_script shebang 写死 `#!/build/.venv/bin/python3`，而 runtime 镜像**无 `/build/` 目录**
- 根因：两 Dockerfile 的 builder `WORKDIR /build` ≠ runtime `WORKDIR /app`，`uv sync` 把 console_script shebang 固化为 builder 绝对路径，多阶段 COPY 后失效
- backend 的 `alembic` / `negentropy` console_script 同病；**非架构问题**（本地镜像与宿主机均为 arm64，CI 双架构也正确）

## 修复

| 文件 | 改动 |
|---|---|
| `docker/perceives/Dockerfile`、`docker/backend/Dockerfile` | builder `WORKDIR /build`→`/app`，COPY 源路径同步；perceives runtime 补 `COPY src`（editable install 依赖） |
| `docker-compose.yml` | postgres 主机端口参数化 `${NE_POSTGRES_HOST_PORT:-5432}:5432`，默认向后兼容，容器间通信仍走 `postgres:5432` |
| `docs/concepts/docker-operations.md` | 端口冲突处置（`NE_POSTGRES_HOST_PORT`）+ console_script exec 失效排查经验 |

## 验证（端到端）

本地 build + up 后全栈 **5/5 healthy**：

| 服务 | 端口 | 探活 |
|---|---|---|
| postgres | `:15432` | 直连 PG 17.10 (pgvector) ✅ |
| perceives | `:2992/mcp` | 406（ASGI 就绪）✅ |
| backend | `:3292/` | 307 ✅ |
| ui | `:3192/` | 307 ✅ |
| wiki | `:3092/` | 200 ✅ |

- 镜像内回归：console_script shebang 已变为 `#!/app/.venv/bin/python3`，`negentropy --help` exec 退出码 **0**（原 255）
- 本机 `:5432` 仍归既有 brew postgres，**未受任何影响**

## 部署注意

- 合并后需重新触发 CI 发布（覆盖 `0.0.1-rc.1` 或发 `0.0.1-rc.2`），**已发布的 rc.1 镜像含本缺陷**
- 本地启动：根目录 `.env` 设 `NE_POSTGRES_HOST_PORT=15432` 规避端口冲突；叠加 `docker-compose.local.yml`（`./dev` 自动拼接）规避 GCS 凭证（制品回退 inmemory）

🤖 Generated with [Claude Code](https://claude.com/claude-code)