### PR TITLE
fix(Backend): GCS 凭证缺失时 ArtifactService 优雅降级 inmemory

### DIFF
--- a/apps/negentropy/src/negentropy/engine/factories/artifacts.py
+++ b/apps/negentropy/src/negentropy/engine/factories/artifacts.py
@@ -15,6 +15,9 @@ import google.auth
 from google.adk.artifacts import BaseArtifactService
 
 from negentropy.config import settings
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.engine.factories.artifacts")
 
 if TYPE_CHECKING:
     pass
@@ -35,18 +38,30 @@ def create_inmemory_artifact_service() -> BaseArtifactService:
 
 
 def create_gcs_artifact_service() -> BaseArtifactService:
-    """创建 GCS 后端"""
-    from google.adk.artifacts import GcsArtifactService
+    """创建 GCS 后端；Bucket 或凭证缺失时优雅降级为 inmemory 并告警。
+
+    ArtifactService 属可选外部依赖：本地 / 无凭证场景不应因此阻断服务启动，故采用
+    优雅降级（fail-open with warning）而非硬失败。生产环境务必配置 GCS 凭证与 bucket
+    ——缺失将降级为 inmemory（制品不持久化、重启丢失）并打 WARNING 日志以暴露问题。
+    """
+    from google.adk.artifacts import GcsArtifactService, InMemoryArtifactService
 
     if not settings.gcs_bucket_name:
-        raise ValueError("GCS ArtifactService requires GCS_BUCKET_NAME to be set")
+        logger.warning(
+            "GCS_BUCKET_NAME 未配置，ArtifactService 降级为 inmemory（仅适用本地开发；"
+            "生产环境请配置 GCS bucket 与凭证，否则制品将不持久化）"
+        )
+        return InMemoryArtifactService()
 
-    # verify credentials exist
+    # 凭证缺失 → 降级（生产凭证配错时亦不崩溃，但 WARNING 暴露问题，优于服务完全不可用）
     try:
         google.auth.default()
     except google.auth.exceptions.DefaultCredentialsError:
-        msg = "GCS ArtifactService requires Google Cloud credentials (e.g. GOOGLE_APPLICATION_CREDENTIALS)"
-        raise ValueError(msg) from None
+        logger.warning(
+            "GCS 凭证缺失（未设置 GOOGLE_APPLICATION_CREDENTIALS），ArtifactService 降级为 inmemory"
+            "（仅适用本地开发；生产环境请注入 GCS 凭证，否则制品将不持久化）"
+        )
+        return InMemoryArtifactService()
 
     return GcsArtifactService(bucket_name=settings.gcs_bucket_name)
 


### PR DESCRIPTION
## 背景

发布 `0.0.1-rc.2` 后复测，`docker compose up -d`（裸启动，**不叠 `docker-compose.local.yml`**）backend unhealthy。**rc.2 镜像本身正确**（shebang 已修复，退出码 1 非 255，成功进入 `negentropy serve`），根因独立。

## 根因

- `config.default.yaml` 默认 `artifact_backend=gcs`，`create_gcs_artifact_service` 在无 GCP 凭证时 **硬 raise** → 阻断 serve 启动
- 此前仅 `docker-compose.local.yml`（`NE_SVC_ARTIFACT_BACKEND=inmemory`）可规避
- **不能改默认配置为 inmemory**：`docker-compose.yml` 注释明确「生产部署也走单文件 + `.env.docker.local`」

## 修复

`create_gcs_artifact_service`（`apps/negentropy/src/negentropy/engine/factories/artifacts.py`）在 **bucket / 凭证缺失时优雅降级 `InMemoryArtifactService` + WARNING**（fail-open with warning）：

| 场景 | 行为 |
|---|---|
| 生产（有凭证） | 正常走 GCS，**零影响** |
| 本地（无凭证） | 自动回退 inmemory + 告警，`docker compose up` 开箱即用 |
| 生产凭证配错 | 降级 + WARN 暴露问题（优于服务崩溃） |

## 验证

裸 `docker compose up`（不叠 local.yml，复现用户命令）全栈 **5/5 healthy**：

```
Alembic migrations completed.
Starting Negentropy backend server...
WARNING | GCS 凭证缺失（未设置 GOOGLE_APPLICATION_CREDENTIALS），ArtifactService 降级为 inmemory
```

镜像内单元验证：`get_artifact_service()` 在 `config=gcs` + 无凭证下返回 `InMemoryArtifactService`（不 raise）。

## 关联

- 承接已合并的 #929（Docker shebang + 端口修复），本 PR 解决 rc.2 暴露的下一层阻塞
- 合并后需发 **rc.3** 让发布镜像含此修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)