### PR TITLE
fix(Extraction): 并发摄入 PDF 加 (server, source_kind) 闸门，修复双双 1200s 超时

### DIFF
--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -247,6 +247,24 @@ class KnowledgeSettings(BaseSettings):
         le=1024,
         description="Knowledge 文件上传大小上限 (MB)。",
     )
+    extraction_max_concurrency: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "同一 (MCP server, source_kind) 维度的最大并发提取调用数。"
+            "perceives 重引擎（docling/mineru/marker）每引擎仅 1 个 worker 且全局共享，"
+            "单机 MPS 上并发 PDF 提取会互相争抢 GPU/worker 致切片超时级联；默认 1（严格串行，"
+            "最稳），多 worker/多 perceives 实例可经 NE_KNOWLEDGE_EXTRACTION_MAX_CONCURRENCY 调大。"
+        ),
+    )
+    extraction_queue_timeout_seconds: int = Field(
+        default=3600,
+        ge=1,
+        description=(
+            "提取调用在并发闸门排队等待的上限秒数；超时则该 target 失败"
+            "（failure_category=concurrency_queue_timeout），交由 failover/上层处理，避免无限空等。"
+        ),
+    )
 
     default_extractor_routes: DefaultExtractorRoutesSettings = Field(
         default_factory=DefaultExtractorRoutesSettings,

--- a/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import os
 import re
 import tempfile
+import time
 import urllib.parse
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -14,6 +17,7 @@ from uuid import UUID
 import litellm
 from sqlalchemy import select, update
 
+from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.interface.execution import RUN_ORIGIN_KNOWLEDGE_EXTRACTION, McpToolExecutionService
 from negentropy.logging import get_logger
@@ -37,6 +41,95 @@ ROUTE_FILE_MD = "file_md"
 ROUTE_FILE_GENERIC = "file_generic"
 MAX_LLM_PLANNING_PAYLOAD_CHARS = 16_000
 MAX_LLM_VALIDATION_ERROR_CHARS = 1_500
+
+
+# ---------------------------------------------------------------------------
+# 并发闸门：按 (MCP server_id, source_kind) 维度限制并发提取调用
+# ---------------------------------------------------------------------------
+# 动机：perceives 重引擎（docling/mineru/marker）每引擎仅 1 个 worker 且全局共享，
+# 单机 MPS 上并发 PDF 提取会互相争抢 GPU/worker，导致切片超时级联、双双撞穿总超时
+# （见 .temp/run 日志：两个并发 PDF 均 1200s 超时）。此处在后端调用 MCP 之前加闸门，
+# 同一 (server, source_kind) 默认串行（N=1，可经 NE_KNOWLEDGE_EXTRACTION_MAX_CONCURRENCY 调大）。
+#
+# 关键：闸门在 _call_tool_with_plan 调用之外获取——排队等待不计入单次 MCP 调用的超时预算
+# （asyncio.timeout 在 execute_tool→call_tool 内部），故排队任务仍享有完整超时预算。
+# 粒度取 (server_id, source_kind) 而非全局：PDF 工具共享 docling 池需串行，
+# 而 URL/webpage 用 scrapy/selenium 等不同引擎，不应被 PDF 阻塞。
+_EXTRACTION_GATES: dict[tuple[str, SourceKind], asyncio.Semaphore] = {}
+_EXTRACTION_GATES_LOCK = asyncio.Lock()
+_EXTRACTION_INFLIGHT: dict[tuple[str, SourceKind], int] = {}
+
+
+class ExtractionGateQueueTimeout(Exception):
+    """并发闸门排队超时（调用方应转为 ``concurrency_queue_timeout`` 失败）。"""
+
+    def __init__(self, *, server_id: str, source_kind: SourceKind, waited_seconds: float) -> None:
+        self.server_id = server_id
+        self.source_kind = source_kind
+        self.waited_seconds = waited_seconds
+        super().__init__(f"extraction gate queue timeout after {waited_seconds:.1f}s")
+
+
+async def _get_extraction_gate(server_id: str, source_kind: SourceKind) -> asyncio.Semaphore:
+    """获取或懒创建 (server_id, source_kind) 维度的并发信号量（进程内单例）。"""
+    key = (server_id, source_kind)
+    async with _EXTRACTION_GATES_LOCK:
+        gate = _EXTRACTION_GATES.get(key)
+        if gate is None:
+            gate = asyncio.Semaphore(max(1, settings.knowledge.extraction_max_concurrency))
+            _EXTRACTION_GATES[key] = gate
+            _EXTRACTION_INFLIGHT[key] = 0
+        return gate
+
+
+@asynccontextmanager
+async def _extraction_gate(server_id: str, source_kind: SourceKind):
+    """按 (server_id, source_kind) 维度的并发闸门上下文。
+
+    - 排队等待发生在 ``async with`` 进入阶段（即 MCP 调用之前），不侵蚀单次调用超时预算；
+    - 排队超过 ``extraction_queue_timeout_seconds`` 则抛 :class:`ExtractionGateQueueTimeout`，
+      由调用方转为 ``concurrency_queue_timeout`` 失败，避免无限空等。
+    - ``asyncio.Semaphore`` 在 FastAPI/Starlette 单 event loop 下安全（3.10+ 懒绑定 loop，
+      且 knowledge/translation/service.py 同模式已生产可用）。
+    """
+    key = (server_id, source_kind)
+    gate = await _get_extraction_gate(server_id, source_kind)
+    limit = settings.knowledge.extraction_max_concurrency
+    queue_t0 = time.monotonic()
+    try:
+        await asyncio.wait_for(
+            gate.acquire(),
+            timeout=settings.knowledge.extraction_queue_timeout_seconds,
+        )
+    except TimeoutError as exc:
+        raise ExtractionGateQueueTimeout(
+            server_id=server_id,
+            source_kind=source_kind,
+            waited_seconds=time.monotonic() - queue_t0,
+        ) from exc
+    _EXTRACTION_INFLIGHT[key] = _EXTRACTION_INFLIGHT.get(key, 0) + 1
+    logger.info(
+        "extraction_gate_acquired",
+        server_id=server_id,
+        source_kind=source_kind,
+        waited_seconds=round(time.monotonic() - queue_t0, 3),
+        inflight=_EXTRACTION_INFLIGHT[key],
+        limit=limit,
+    )
+    held_t0 = time.monotonic()
+    try:
+        yield
+    finally:
+        _EXTRACTION_INFLIGHT[key] = max(0, _EXTRACTION_INFLIGHT.get(key, 0) - 1)
+        gate.release()
+        logger.info(
+            "extraction_gate_released",
+            server_id=server_id,
+            source_kind=source_kind,
+            held_seconds=round(time.monotonic() - held_t0, 3),
+            inflight=_EXTRACTION_INFLIGHT[key],
+            limit=limit,
+        )
 
 
 @dataclass(slots=True)
@@ -2276,14 +2369,57 @@ class DataExtractorProvider:
                     resume=resume,
                 )
 
-                result, resolved_resources, resource_errors = await self._call_tool_with_plan(
-                    server=server,
-                    target=target,
-                    plan=plan,
-                    tracker=tracker,
-                    stage_name=stage_name,
-                    cancel_event=cancel_event,
-                )
+                # 并发闸门：按 (server_id, source_kind) 串行化对同一 perceives 的重引擎调用，
+                # 排队等待不计入下方 execute_tool→call_tool 内的 asyncio.timeout 预算。
+                try:
+                    async with _extraction_gate(str(server.id), source_kind):
+                        result, resolved_resources, resource_errors = await self._call_tool_with_plan(
+                            server=server,
+                            target=target,
+                            plan=plan,
+                            tracker=tracker,
+                            stage_name=stage_name,
+                            cancel_event=cancel_event,
+                        )
+                except ExtractionGateQueueTimeout as gate_timeout:
+                    logger.warning(
+                        "extraction_gate_queue_timeout",
+                        server_id=gate_timeout.server_id,
+                        source_kind=gate_timeout.source_kind,
+                        waited_seconds=round(gate_timeout.waited_seconds, 3),
+                    )
+                    invocation_trace.append(
+                        {
+                            "attempt": index + 1,
+                            "adapter_name": plan.adapter_name,
+                            "reasoning_source": plan.reasoning_source,
+                            "diagnostics": plan.diagnostics,
+                            "success": False,
+                            "error": str(gate_timeout),
+                            "failure_category": "concurrency_queue_timeout",
+                            "duration_ms": int(gate_timeout.waited_seconds * 1000),
+                            "resource_links_total": 0,
+                            "resource_read_success": 0,
+                            "resource_read_failed": 0,
+                        }
+                    )
+                    return {
+                        "success": False,
+                        "attempt": ExtractionAttempt(
+                            server_id=str(target.server_id),
+                            server_name=server.name,
+                            tool_name=target.tool_name,
+                            status="failed",
+                            duration_ms=int(gate_timeout.waited_seconds * 1000),
+                            error=str(gate_timeout),
+                            failure_category="concurrency_queue_timeout",
+                            diagnostics={
+                                "server_id": str(server.id),
+                                "source_kind": source_kind,
+                                "adapter_attempts": invocation_trace,
+                            },
+                        ),
+                    }
                 invocation_trace.append(
                     {
                         "attempt": index + 1,

--- a/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_extraction_provider.py
@@ -4,16 +4,21 @@
 包括批量/单文件 schema 适配、重试机制、failover 和契约诊断。
 """
 
+import asyncio
+from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
+from negentropy.knowledge.ingestion import extraction as extraction_mod
 from negentropy.knowledge.ingestion.extraction import (
     ROUTE_FILE_PDF,
     AdaptiveToolInvocationPlan,
     DataExtractorProvider,
+    ExtractionGateQueueTimeout,
+    _extraction_gate,
 )
 
 from .conftest import (
@@ -1245,3 +1250,96 @@ async def test_negentropy_perceives_provider_reads_enhanced_assets_from_output_d
     assert extracted.assets[0].name == "img_1.png"
     assert extracted.assets[0].local_path == str((output_dir / "img_1.png").resolve())
     assert extracted.assets[0].metadata["source"] == "enhanced_output_directory"
+
+
+# ---------------------------------------------------------------------------
+# 并发闸门 _extraction_gate：串行化 / 粒度隔离 / 排队超时
+#
+# 动机见 extraction.py 模块注释：perceives 重引擎单 worker + 单机 MPS，
+# 并发 PDF 提取会互相争抢致双双超时。此处直接验证闸门语义。
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_extraction_gates() -> Iterator[None]:
+    """每个用例前后清空模块级闸门状态，确保 (server_id, source_kind) 用例隔离。"""
+    extraction_mod._EXTRACTION_GATES.clear()
+    extraction_mod._EXTRACTION_INFLIGHT.clear()
+    yield
+    extraction_mod._EXTRACTION_GATES.clear()
+    extraction_mod._EXTRACTION_INFLIGHT.clear()
+
+
+async def _measure_concurrent_entries(
+    server_id: str,
+    source_kinds: list[str],
+    *,
+    hold_seconds: float = 0.05,
+) -> tuple[int, int]:
+    """并发对给定 (server_id, source_kind) 序列各进入一次闸门，返回 (最大并发数, 完成数)。"""
+    state: dict[str, int] = {"concurrent": 0, "max": 0, "done": 0}
+    lock = asyncio.Lock()
+
+    async def enter(source_kind: str) -> None:
+        async with _extraction_gate(server_id, source_kind):
+            async with lock:
+                state["concurrent"] += 1
+                state["max"] = max(state["max"], state["concurrent"])
+            await asyncio.sleep(hold_seconds)
+            async with lock:
+                state["concurrent"] -= 1
+                state["done"] += 1
+
+    await asyncio.gather(*(enter(sk) for sk in source_kinds))
+    return state["max"], state["done"]
+
+
+@pytest.mark.asyncio
+async def test_extraction_gate_serializes_same_server_and_source_kind() -> None:
+    """同一 (server, source_kind)、limit=1：两次进入严格互斥，最大并发为 1。"""
+    max_concurrent, done = await _measure_concurrent_entries(str(uuid4()), [ROUTE_FILE_PDF, ROUTE_FILE_PDF])
+    assert done == 2
+    assert max_concurrent == 1  # 闸门限流 1 → 任意时刻至多 1 个在临界区
+
+
+@pytest.mark.asyncio
+async def test_extraction_gate_isolates_different_source_kinds() -> None:
+    """同一 server、不同 source_kind（file_pdf vs url）使用独立闸门，可真并发（max=2）。
+
+    防止误把 URL/webpage 抓取（scrapy/selenium）与 PDF 提取（docling）串到一起。
+    """
+    max_concurrent, done = await _measure_concurrent_entries(str(uuid4()), ["file_pdf", "url"])
+    assert done == 2
+    assert max_concurrent == 2  # 不同 source_kind → 不同闸门 → 真并发
+
+
+@pytest.mark.asyncio
+async def test_extraction_gate_queue_timeout_raises_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """排队超过 queue_timeout 抛 ExtractionGateQueueTimeout，而非无限空等。"""
+    monkeypatch.setattr(
+        extraction_mod,
+        "settings",
+        SimpleNamespace(
+            knowledge=SimpleNamespace(
+                extraction_max_concurrency=1,
+                extraction_queue_timeout_seconds=0.2,
+            )
+        ),
+    )
+    server_id = str(uuid4())
+    release_holder = asyncio.Event()
+
+    async def hold() -> None:
+        async with _extraction_gate(server_id, ROUTE_FILE_PDF):
+            await asyncio.wait_for(release_holder.wait(), timeout=2.0)
+
+    holder = asyncio.create_task(hold())
+    await asyncio.sleep(0.05)  # 让 holder 先进入临界区占住 limit=1 的闸门
+
+    try:
+        with pytest.raises(ExtractionGateQueueTimeout):
+            async with _extraction_gate(server_id, ROUTE_FILE_PDF):
+                pytest.fail("排队超时不应进入临界区")
+    finally:
+        release_holder.set()
+        await holder


### PR DESCRIPTION
## 背景

通过「Ingest from File」**同时**摄入两个 PDF，两个 pipeline run 双双 FAILED，错误均为 `主 MCP 提取: Connection timeout after 1200.0s`。

## 根因（双层无界并发，单机 MPS 上互相压垮）

**后端层** — `knowledge/routes/ingest.py` 用 FastAPI `BackgroundTasks` 派发 `execute_ingest_file_pipeline`，**无任何并发闸门**；两个 ingest 请求 → 两个并发 MCP 调用打到同一 perceives。MCP 客户端每次新建 transport/session，无连接池。

**perceives 层** — `EngineWorkerPool` 全局单例，**每种重引擎（docling/mineru/marker）仅 1 个 subprocess worker**，per-engine `asyncio.Lock` 串行；`_middleware.py` 无任务级并发限制器；`ops/pdf.py` 切片严格串行、`per_slice_timeout=300s` 硬编码。

**级联过程**（`.temp/run` 双层日志实证）：两 PDF 并发 → 争抢共享单一 docling worker + 本地 MPS GPU（跨任务共用 docling `pid=93100`/mineru `pid=77699`）→ 每 20 页切片从 ~1-2min 拖到 300s 超时（`[batch 1/6]→[2/6]→[3/6]` 连续 `timed out`）→ 6 切片潜力 > 1200s 总预算 → 双双撞穿。failover 又因并发下 docling 返回空 → `document_payload_recognized_but_empty`（**空负载是争用的下游症状**）。

## 方案（优雅串行，N=1，仅后端闸门）

在 `DataExtractorProvider` 的 MCP 调用**之外**加 `(server_id, source_kind)` 维度并发闸门：
- 默认 `N=1`，可经 `NE_KNOWLEDGE_EXTRACTION_MAX_CONCURRENCY` 调大；
- **排队等待不计入单次调用超时预算**（`asyncio.timeout` 在 `execute_tool→call_tool` 内部，闸门在其外层）——排队任务仍享有完整 1200s/3600s 预算；
- 排队超时（默认 3600s）转为 `concurrency_queue_timeout` 干净失败，交由 failover/上层处理，避免无限空等；
- 粒度取 `(server_id, source_kind)`：PDF 工具共享 docling 池需串行，URL/webpage 用 scrapy/selenium 等不同引擎，独立闸门不被 PDF 阻塞。

**不动 perceives**（后端闸门已使 perceives 不再承受并发重负载；资源所有者侧护栏留作未来加固）；**不消费 `pdf_worker_pool_size` 死配置**（单机 MPS 增 worker 会 OOM，方向相反）。

## 改动文件

| 文件 | 改动 |
| --- | --- |
| `config/knowledge.py` | `KnowledgeSettings` 新增 `extraction_max_concurrency`(默认1) + `extraction_queue_timeout_seconds`(默认3600) |
| `knowledge/ingestion/extraction.py` | 模块级 `_extraction_gate` 上下文（仿 `translation/service.py` 的 `_SEMAPHORE` 模式）+ `_invoke_target` 调用点包裹 + 结构化日志（acquired/released/queue_timeout） |
| `tests/unit_tests/knowledge/test_extraction_provider.py` | `_extraction_gate` 串行性 / 粒度隔离(file_pdf vs url) / 排队超时 3 个单测 |

## 验证

- ✅ 单测：`uv run pytest tests/unit_tests/knowledge/test_extraction_provider.py` → **21 passed**（18 既有无回归 + 3 新增）；
- ✅ lint/format：`ruff check` + `ruff format` 干净，pre-commit 全绿；
- ⏳ 本地集成回归（需部署到 live 引擎）：并发摄入两 PDF，观察 `backend.log` 出现 `extraction_gate_acquired/released`（第二个 `waited_seconds>0`）、`perceives.log` 同一时刻仅 1 个 PDF pipeline 活跃，**两个 run 均 succeeded**。

## 已知权衡

- validation-error 重试会重新 acquire/release 闸门（罕见路径，非致命）：本将闸门锚在 `_call_tool_with_plan` 调用点而非整个 plan-retry 循环，以换取外科手术式精简 diff；验证重试是低概率边缘路径，重新排队至多增加一个任务时长，不影响正确性。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>