### PR TITLE
fix(Perceives): ocrmac 缺失时 fail-safe 禁用 docling OCR，修复 PDF 提取挂起

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/docling.py
@@ -383,15 +383,24 @@ class DoclingEngine:
         )
 
         # macOS 原生 OCR 引擎（Apple Vision Framework）
+        # 注意：OcrMacOptions 仅是选项类（始终可 import），真正的运行时依赖是 ocrmac 包。
+        # 若 ocrmac 未安装却启用 mac_native OCR，docling 会在 OCR 执行阶段失败甚至挂起整个
+        # pipeline（实证：pipeline 路径 1200s 超时、batch 路径 empty 降级；见 .temp/run 日志）。
+        # 故在此探测运行时依赖：缺失则主动禁用 OCR（文本型 PDF 仍可正常抽取）并告警，
+        # 而非留下一个无法执行的 mac_native OCR 配置导致挂起。
         if device_cfg.ocr_engine == "mac_native" and self._enable_ocr:
             try:
+                import ocrmac  # noqa: F401 — 运行时依赖探测（区别于 OcrMacOptions 选项类）
                 from docling.datamodel.pipeline_options import OcrMacOptions  # type: ignore[import-untyped]
 
                 pipeline_options.ocr_options = OcrMacOptions()
                 logger.info("macOS 原生 OCR (Apple Vision Framework) 已启用")
             except ImportError:
-                logger.debug(
-                    "OcrMacOptions 不可用（需 docling[mac] 依赖），使用默认 OCR 引擎"
+                pipeline_options.do_ocr = False
+                logger.warning(
+                    "docling_mac_native_ocr_disabled：mac_native OCR 已配置但 ocrmac 运行时依赖未安装，"
+                    "已禁用 OCR 以避免 docling 挂起/失败（文本型 PDF 不受影响；扫描版 PDF 请安装 "
+                    "ocrmac：uv add 'ocrmac;sys_platform==\"darwin\"' 后启用）。"
                 )
 
         # 硬件加速配置


### PR DESCRIPTION
## 背景

并发摄入 PDF 修复（#941 后端并发闸门）部署后，单个/并发 PDF 摄入**仍失败**。浏览器 pipeline 页与日志复核发现真正根因在 perceives 引擎层。

## 根因（与并发无关）

perceives 日志实证（`.temp/run/perceives.log`，部署 #941 后 20:49+）：

- **pipeline 路径**（`parse_pdf_to_markdown`）：`layout_analysis` 选 docling，从 20:49:19 **挂起至 21:09:08（整整 1200s）** 被总超时强杀，per-slice 300s 超时未触发。
- **batch 路径**（`parse_pdfs_to_markdown`）：docling **快速失败** `ocrmac is not correctly installed` → 降级 opendataloader → 返回**空** → backend `empty_payload`。
- 两路皆败 → 无论并发与否，PDF 摄入均失败。

**机制**：docling 默认 `ocr_enabled=true`，macOS 上 `device_config` 自动选 `mac_native` OCR（`OcrMacOptions`）。但 `OcrMacOptions` 仅是选项类（始终可 import），**真正的运行时依赖 `ocrmac` 包未安装**（pyproject 无此依赖）→ docling 在 OCR 执行阶段失败/挂起。受控测试确认：`do_ocr=False` 时 docling 可在预算内完成（不再挂起）。

## 修复

`docling.py` 启用 mac_native OCR 前探测 `ocrmac` **运行时包**（区别于 `OcrMacOptions` 选项类）；缺失则 `do_ocr=False` + 告警，而非留下无法执行的 OCR 配置导致挂起。

- 文本型 PDF（如 arXiv 论文，born-digital）不受影响，照常抽取；
- 扫描版 PDF 需后续 `uv add 'ocrmac;sys_platform=="darwin"'` 启用原生 OCR。

## 改动

| 文件 | 改动 |
| --- | --- |
| `apps/negentropy-perceives/.../pdf/engines/docling.py` | mac_native OCR 启用条件改为探测 ocrmac 运行时；缺失则禁用 OCR + 告警 |

## 验证

- ✅ ruff lint/format + mypy（perceives）全过；
- ✅ 受控测试：`DoclingEngine(enable_ocr=False)` 对失败 PDF 不再挂起，可完成；
- ⏳ 部署 live + 重启 perceives 后，复跑失败 PDF 确认 pipeline 在预算内成功。

## 关联

- 与 #941（后端并发闸门）正交：#941 解决并发争抢，本 PR 解决引擎层 docling 挂起。两者叠加后「并发摄入多 PDF」端到端可用。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>