### PR TITLE
fix(WikiGraph): 知识图谱页画布铺满视口并消除上下空白与多余边框

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -96,23 +96,6 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
       variant="home"
     >
       <div className="wiki-graph-page">
-        <header className="wiki-graph-page-header">
-          <div className="wiki-doc-meta">
-            版本 v{publication.version}
-            {graph && graph.nodes.length > 0 && (
-              <>
-                {" · "}
-                {graph.nodes.length} 节点 · {graph.edges.length} 边
-                {graph.truncated && graph.total_entities > graph.nodes.length && (
-                  <>
-                    {" · "}共 {graph.total_entities} 实体
-                  </>
-                )}
-              </>
-            )}
-          </div>
-        </header>
-
         <WikiGraphBody
           pubSlug={pubSlug}
           publication={publication}
@@ -135,7 +118,12 @@ interface WikiGraphBodyProps {
   graphError: string | null;
 }
 
-function WikiGraphBody({ pubSlug, graph, graphError }: WikiGraphBodyProps) {
+function WikiGraphBody({
+  pubSlug,
+  publication,
+  graph,
+  graphError,
+}: WikiGraphBodyProps) {
   if (graphError) {
     return (
       <div className="wiki-graph-error">
@@ -179,6 +167,7 @@ function WikiGraphBody({ pubSlug, graph, graphError }: WikiGraphBodyProps) {
     <div className="wiki-graph-canvas-wrap">
       <WikiGraphRenderer
         pubSlug={pubSlug}
+        version={publication.version}
         nodes={graph.nodes}
         edges={graph.edges}
         truncated={graph.truncated}

--- a/apps/negentropy-wiki/src/components/WikiCytoscapeCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiCytoscapeCanvas.tsx
@@ -88,16 +88,12 @@ interface WikiCytoscapeCanvasProps {
   pubSlug: string;
   nodes: WikiGraphNode[];
   edges: WikiGraphEdge[];
-  truncated?: boolean;
-  totalEntities?: number;
 }
 
 export function WikiCytoscapeCanvas({
   pubSlug,
   nodes,
   edges,
-  truncated = false,
-  totalEntities,
 }: WikiCytoscapeCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const cyRef = useRef<Core | null>(null);
@@ -217,18 +213,6 @@ export function WikiCytoscapeCanvas({
   return (
     <div className="wiki-graph-canvas-root">
       <div ref={containerRef} className="wiki-graph-canvas-stage" />
-
-      <div className="wiki-graph-canvas-overlay">
-        <span className="wiki-graph-badge">
-          {nodes.length} 节点 · {edges.length} 边 · Cytoscape
-        </span>
-        {truncated && totalEntities != null && (
-          <span className="wiki-graph-badge wiki-graph-badge-warn">
-            已按 importance 截断（共 {totalEntities} 个实体，仅显示 top-
-            {nodes.length}）
-          </span>
-        )}
-      </div>
     </div>
   );
 }

--- a/apps/negentropy-wiki/src/components/WikiD3ForceCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiD3ForceCanvas.tsx
@@ -49,16 +49,12 @@ interface WikiD3ForceCanvasProps {
   pubSlug: string;
   nodes: WikiGraphNode[];
   edges: WikiGraphEdge[];
-  truncated?: boolean;
-  totalEntities?: number;
 }
 
 export function WikiD3ForceCanvas({
   pubSlug,
   nodes,
   edges,
-  truncated = false,
-  totalEntities,
 }: WikiD3ForceCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
@@ -309,18 +305,6 @@ export function WikiD3ForceCanvas({
             )}
           </g>
         </svg>
-      </div>
-
-      <div className="wiki-graph-canvas-overlay">
-        <span className="wiki-graph-badge">
-          {nodes.length} 节点 · {edges.length} 边 · d3 SVG
-        </span>
-        {truncated && totalEntities != null && (
-          <span className="wiki-graph-badge wiki-graph-badge-warn">
-            已按 importance 截断（共 {totalEntities} 个实体，仅显示 top-
-            {nodes.length}）
-          </span>
-        )}
       </div>
     </div>
   );

--- a/apps/negentropy-wiki/src/components/WikiForceGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiForceGraphCanvas.tsx
@@ -98,16 +98,12 @@ interface WikiForceGraphCanvasProps {
   pubSlug: string;
   nodes: WikiGraphNode[];
   edges: WikiGraphEdge[];
-  truncated?: boolean;
-  totalEntities?: number;
 }
 
 export function WikiForceGraphCanvas({
   pubSlug,
   nodes,
   edges,
-  truncated = false,
-  totalEntities,
 }: WikiForceGraphCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -229,18 +225,6 @@ export function WikiForceGraphCanvas({
             cooldownTicks={200}
             d3AlphaDecay={0.03}
           />
-        )}
-      </div>
-
-      <div className="wiki-graph-canvas-overlay">
-        <span className="wiki-graph-badge">
-          {nodes.length} 节点 · {edges.length} 边 · ForceGraph 2D
-        </span>
-        {truncated && totalEntities != null && (
-          <span className="wiki-graph-badge wiki-graph-badge-warn">
-            已按 importance 截断（共 {totalEntities} 个实体，仅显示 top-
-            {nodes.length}）
-          </span>
         )}
       </div>
     </div>

--- a/apps/negentropy-wiki/src/components/WikiGraph3DCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraph3DCanvas.tsx
@@ -37,16 +37,12 @@ interface WikiGraph3DCanvasProps {
   pubSlug: string;
   nodes: WikiGraphNode[];
   edges: WikiGraphEdge[];
-  truncated?: boolean;
-  totalEntities?: number;
 }
 
 export function WikiGraph3DCanvas({
   pubSlug,
   nodes,
   edges,
-  truncated = false,
-  totalEntities,
 }: WikiGraph3DCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -195,18 +191,6 @@ export function WikiGraph3DCanvas({
             enableNodeDrag={true}
             showNavInfo={false}
           />
-        )}
-      </div>
-
-      <div className="wiki-graph-canvas-overlay">
-        <span className="wiki-graph-badge">
-          {nodes.length} 节点 · {edges.length} 边 · 3D WebGL
-        </span>
-        {truncated && totalEntities != null && (
-          <span className="wiki-graph-badge wiki-graph-badge-warn">
-            已按 importance 截断（共 {totalEntities} 个实体，仅显示 top-
-            {nodes.length}）
-          </span>
         )}
       </div>
     </div>

--- a/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphCanvas.tsx
@@ -49,24 +49,12 @@ interface WikiGraphCanvasProps {
   pubSlug: string;
   nodes: WikiGraphNode[];
   edges: WikiGraphEdge[];
-  /**
-   * 截断横幅阈值：节点数 >= 此值时显示提示。
-   * 与后端 ``max_nodes`` 默认 300 相协调，避免误报。
-   */
-  truncateThreshold?: number;
-  /** 是否实际被后端截断（来自响应的 truncated 字段） */
-  truncated?: boolean;
-  /** 截断前的实体总数（来自响应的 total_entities） */
-  totalEntities?: number;
 }
 
 export function WikiGraphCanvas({
   pubSlug,
   nodes,
   edges,
-  truncateThreshold = 500,
-  truncated = false,
-  totalEntities,
 }: WikiGraphCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   // 通过 unknown 桥接绕过 ESM 默认导出类型在 ESLint --max-warnings=0 下的过严校验。
@@ -200,26 +188,9 @@ export function WikiGraphCanvas({
     sigma.refresh();
   }, [isDark]);
 
-  const exceedsThreshold = nodes.length >= truncateThreshold;
-  const showTruncatedBanner = truncated || exceedsThreshold;
-
   return (
     <div className="wiki-graph-canvas-root">
       <div ref={containerRef} className="wiki-graph-canvas-stage" />
-
-      {/* 状态横幅：左上角统计 + 截断提示 */}
-      <div className="wiki-graph-canvas-overlay">
-        <span className="wiki-graph-badge">
-          {nodes.length} 节点 · {edges.length} 边 · Sigma WebGL
-        </span>
-        {showTruncatedBanner && (
-          <span className="wiki-graph-badge wiki-graph-badge-warn">
-            {truncated && totalEntities
-              ? `已按 importance 截断（共 ${totalEntities} 个实体，仅显示 top-${nodes.length}）`
-              : "图谱过大，建议在实体列表中筛选"}
-          </span>
-        )}
-      </div>
     </div>
   );
 }

--- a/apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/WikiGraphRenderer.tsx
@@ -42,29 +42,50 @@ const WikiCytoscapeCanvas = dynamic(
 type RendererId = "sigma" | "3d" | "d3" | "force-graph" | "cytoscape";
 
 // 切换器配置（label / title 与主站 page.tsx 切换器对齐）。后续主站渲染器增减时，
-// 在此数组同步增删即可。
-const RENDERERS: { id: RendererId; label: string; title: string }[] = [
-  { id: "d3", label: "d3-force", title: "d3-force 力导向 + SVG 渲染" },
+// 在此数组同步增删即可。`suffix` 为左上角浮层徽标中显示的引擎名（与各渲染器历史
+// 文案一一对应），随当前选中引擎切换。
+const RENDERERS: {
+  id: RendererId;
+  label: string;
+  title: string;
+  suffix: string;
+}[] = [
+  {
+    id: "d3",
+    label: "d3-force",
+    title: "d3-force 力导向 + SVG 渲染",
+    suffix: "d3 SVG",
+  },
   {
     id: "3d",
     label: "3D",
     title: "3D WebGL（three.js + d3-force-3d，支持三维旋转）",
+    suffix: "3D WebGL",
   },
   {
     id: "sigma",
     label: "Sigma",
     title: "Sigma.js v3 WebGL 渲染（高性能，适合大图，默认引擎）",
+    suffix: "Sigma WebGL",
   },
   {
     id: "force-graph",
     label: "Force Graph",
     title: "react-force-graph-2d（粒子流动效果，视觉表现力强）",
+    suffix: "ForceGraph 2D",
   },
-  { id: "cytoscape", label: "Cytoscape", title: "Cytoscape.js + fCoSE 布局" },
+  {
+    id: "cytoscape",
+    label: "Cytoscape",
+    title: "Cytoscape.js + fCoSE 布局",
+    suffix: "Cytoscape",
+  },
 ];
 
 interface WikiGraphRendererProps {
   pubSlug: string;
+  /** Publication 版本号，与统计一起渲染于左上角浮层徽标 */
+  version: number;
   nodes: WikiGraphNode[];
   edges: WikiGraphEdge[];
   truncated: boolean;
@@ -73,13 +94,18 @@ interface WikiGraphRendererProps {
 
 export function WikiGraphRenderer({
   pubSlug,
+  version,
   nodes,
   edges,
   truncated,
   totalEntities,
 }: WikiGraphRendererProps) {
   const [renderer, setRenderer] = useState<RendererId>("d3");
-  const common = { pubSlug, nodes, edges, truncated, totalEntities };
+  // 统计数据对 5 个引擎完全相同（仅引擎名后缀不同），故浮层徽标上提至本父组件，
+  // 作为版本/统计的单一事实源；各画布组件不再各自重复渲染 overlay。
+  const common = { pubSlug, nodes, edges };
+  const activeSuffix =
+    RENDERERS.find((r) => r.id === renderer)?.suffix ?? renderer;
 
   return (
     <div className="wiki-graph-render-root">
@@ -100,6 +126,18 @@ export function WikiGraphRenderer({
             {r.label}
           </button>
         ))}
+      </div>
+
+      <div className="wiki-graph-canvas-overlay">
+        <span className="wiki-graph-badge">
+          v{version} · {nodes.length} 节点 · {edges.length} 边 · {activeSuffix}
+        </span>
+        {truncated && totalEntities != null && (
+          <span className="wiki-graph-badge wiki-graph-badge-warn">
+            已按 importance 截断（共 {totalEntities} 个实体，仅显示 top-
+            {nodes.length}）
+          </span>
+        )}
       </div>
 
       {renderer === "sigma" && <WikiGraphCanvas {...common} />}

--- a/apps/negentropy-wiki/src/styles/components/graph.css
+++ b/apps/negentropy-wiki/src/styles/components/graph.css
@@ -9,13 +9,15 @@
   max-width: 100%;
 }
 
-.wiki-graph-page-header {
-  padding: 1.5rem clamp(1.25rem, 4vw, 3rem) 0.5rem;
-}
-
+/* 图谱画布容器：铺满 header 以下的整个视口高度。
+ *
+ * 高度公式复用 layout.css 中 .wiki-sidebar / .wiki-toc-aside 的既有模式
+ * （height: calc(100vh - var(--wiki-header-height))），以 --wiki-header-height
+ * 为单一事实源，杜绝魔数；box-sizing: border-box（base.css）保证 1px 边框计入
+ * 高度，故 overflow: hidden 下不会撑出滚动条。版本/统计由 WikiGraphRenderer 的
+ * 左上角浮层徽标承载，不再占用独立的页头条带。 */
 .wiki-graph-canvas-wrap {
-  height: calc(100vh - 200px);
-  min-height: 480px;
+  height: calc(100vh - var(--wiki-header-height));
   width: 100%;
   position: relative;
   border: 1px solid var(--wiki-border);


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：negentropy-wiki 站点 `/:pubSlug/graph` 知识图谱页的图谱模块未铺满浏览器导航栏以下的上下空白区域，边框未随视口自适应——根因有二：① 容器高度被写死为魔数 `calc(100vh - 200px)`，多减约 89px 形成底部死区，且 `min-height: 480px` 在矮窗口下撑出滚动条；② 图谱上方有一条独立元信息条占据顶部空白。
- 关联上下文/Issue/文档：用户截图反馈（上、下两处红框）；对齐主站 `apps/negentropy-ui` 知识图谱页的全视口布局与浮层徽标做法。

# 核心变更
- `styles/components/graph.css`：容器高度改用 `calc(100vh - var(--wiki-header-height))`，复用 `layout.css` 既有模式、以 header 高度令牌为单一事实源杜绝魔数；移除 `min-height: 480px` 让边框随视口自适应收缩；删除已无引用的 `.wiki-graph-page-header` 规则。
- `[pubSlug]/graph/page.tsx`：删除独立元信息条 `header`，将 `publication.version` 下传渲染器。
- `WikiGraphRenderer.tsx`：将版本/统计/引擎名/截断告警上提为图谱内**唯一**左上角浮层徽标，随引擎切换实时更新。
- 5 个画布组件（D3/Sigma/3D/ForceGraph/Cytoscape）：移除各自重复的 overlay 与 `truncated`/`totalEntities` 冗余 props（正交分解、单一事实源），Sigma 顺带移除冗余的客户端阈值启发式。净减 64 行。

# 风险与回滚
- 主要风险：纯前端 CSS/布局与组件 props 收窄，无数据与接口变更；error/empty/no_kg 等非图谱分支不再显示版本号（次要、可接受，正常态不受影响）。
- 回滚方式：`git revert` 本 PR 合并提交即可，无迁移、无副作用。

# 验证证据
- 单元测试：无新增（纯布局变更）；`pnpm lint` 0 error、`pnpm build` 静态导出通过、全部 pre-commit hooks 通过。
- 集成测试：N/A。
- E2E/Workflow：工作区独立 dev 实例（127.0.0.1:3199，避开 live 引擎）实机核验——几何实测 `canvas顶=60`（上间隙 0）、`canvas底=900=视口底`（下间隙 0）、页面不可滚动；5 引擎逐一切换均铺满、0 控制台错误、浮层后缀正确更新；缩放 1024×560 容器自动收缩至 500px、贴合视口、无滚动条。
- 覆盖率/关键截图：浅色/深色模式各截图核验通过（图谱铺满、浮层与切换器互不遮挡）。

# 影响范围
- 前端：仅 `apps/negentropy-wiki` 知识图谱页（布局 CSS + 6 个图谱组件）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后部署 wiki 站点，于真实多节点 Publication 的图谱页回归确认大图场景下铺满与切换表现；如需保留「截断阈值提示」语义，可评估在父级浮层统一承载。