### PR TITLE
feat(Wiki): 新增保留一级目录「Negentropy」并随「同步并发布」同步 docs/

### DIFF
--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000001.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000001.json
@@ -1,0 +1,12 @@
+{
+  "entry_id": "d0c00000-0000-4000-8000-000000000001",
+  "document_id": "d0c00000-0000-4000-8000-0000000000a1",
+  "entry_slug": "readme",
+  "entry_title": "Negentropy 用户手册",
+  "markdown_content": "# Negentropy 用户手册\n\n这是 **Negentropy 保留一级目录** 的开发种子样本（fixture）。真实站点中，本目录由主站「同步并发布」时从仓库 `docs/` 公开子集（README + concepts + reference + research）自动合成，置于「Knowledge Graph」标签左侧。\n\n## 导航\n\n- [认识 Negentropy](/negentropy/concepts/overview)\n\n> 真实导出内容由后端 `WikiExportService` + `wiki_docs_ingest` 生成；此处仅为构建兜底的最小样本。",
+  "document_filename": "README.md",
+  "author_name": null,
+  "author_url": null,
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/README.md",
+  "published_at": null
+}

--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000003.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000003.json
@@ -1,0 +1,12 @@
+{
+  "entry_id": "d0c00000-0000-4000-8000-000000000003",
+  "document_id": "d0c00000-0000-4000-8000-0000000000a3",
+  "entry_slug": "concepts/overview",
+  "entry_title": "认识 Negentropy",
+  "markdown_content": "# 认识 Negentropy\n\nNegentropy 以「熵减」为核心理念，通过上下文锚定、复用驱动与标准化流水线对抗系统的无序熵增。\n\n本页为保留一级目录下 `concepts/` 容器中的样本文档。返回 [手册首页](/negentropy/readme)。",
+  "document_filename": "overview.md",
+  "author_name": null,
+  "author_url": null,
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/concepts/user-guide/overview.md",
+  "published_at": null
+}

--- a/apps/negentropy-wiki/content.fixture/index.json
+++ b/apps/negentropy-wiki/content.fixture/index.json
@@ -3,7 +3,8 @@
   "generated_at": "2026-06-20T00:00:00Z",
   "exporter_version": "dev-seed-0.0.1",
   "publications": [
-    { "slug": "negentropy-handbook", "id": "11111111-1111-4111-8111-111111111111", "version": 3 }
+    { "slug": "negentropy-handbook", "id": "11111111-1111-4111-8111-111111111111", "version": 3 },
+    { "slug": "negentropy", "id": "d0c00000-0000-4000-8000-000000000000", "version": 1 }
   ],
   "pubs": {
     "negentropy-handbook": {
@@ -18,6 +19,20 @@
         "22222222-2222-4222-9222-2222222222c1",
         "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
         "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2"
+      ]
+    },
+    "negentropy": {
+      "id": "d0c00000-0000-4000-8000-000000000000",
+      "version": 1,
+      "entry_slug_to_id": {
+        "readme": "d0c00000-0000-4000-8000-000000000001",
+        "concepts": "d0c00000-0000-4000-8000-000000000002",
+        "concepts/overview": "d0c00000-0000-4000-8000-000000000003"
+      },
+      "entry_ids": [
+        "d0c00000-0000-4000-8000-000000000001",
+        "d0c00000-0000-4000-8000-000000000002",
+        "d0c00000-0000-4000-8000-000000000003"
       ]
     }
   }

--- a/apps/negentropy-wiki/content.fixture/publications.json
+++ b/apps/negentropy-wiki/content.fixture/publications.json
@@ -15,7 +15,23 @@
       "created_at": "2026-06-01T00:00:00Z",
       "updated_at": "2026-06-20T00:00:00Z",
       "entries_count": 2
+    },
+    {
+      "id": "d0c00000-0000-4000-8000-000000000000",
+      "catalog_id": "d0c00000-0000-4000-8000-000000000000",
+      "app_name": "negentropy",
+      "publish_mode": "snapshot",
+      "name": "Negentropy",
+      "slug": "negentropy",
+      "description": "Negentropy 工程文档 — 源自仓库 docs/（开发种子 fixture，仅含最小样本）。",
+      "status": "published",
+      "theme": "docs",
+      "version": 1,
+      "published_at": null,
+      "created_at": null,
+      "updated_at": null,
+      "entries_count": 2
     }
   ],
-  "total": 1
+  "total": 2
 }

--- a/apps/negentropy-wiki/content.fixture/publications/negentropy/entries-index.json
+++ b/apps/negentropy-wiki/content.fixture/publications/negentropy/entries-index.json
@@ -1,0 +1,31 @@
+{
+  "items": [
+    {
+      "id": "d0c00000-0000-4000-8000-000000000001",
+      "document_id": "d0c00000-0000-4000-8000-0000000000a1",
+      "entry_slug": "readme",
+      "entry_title": "Negentropy 用户手册",
+      "is_index_page": true
+    },
+    {
+      "id": "d0c00000-0000-4000-8000-000000000002",
+      "document_id": null,
+      "entry_slug": "concepts",
+      "entry_title": "Concepts",
+      "is_index_page": false
+    },
+    {
+      "id": "d0c00000-0000-4000-8000-000000000003",
+      "document_id": "d0c00000-0000-4000-8000-0000000000a3",
+      "entry_slug": "concepts/overview",
+      "entry_title": "认识 Negentropy",
+      "is_index_page": false
+    }
+  ],
+  "total": 3,
+  "slug_to_id": {
+    "readme": "d0c00000-0000-4000-8000-000000000001",
+    "concepts": "d0c00000-0000-4000-8000-000000000002",
+    "concepts/overview": "d0c00000-0000-4000-8000-000000000003"
+  }
+}

--- a/apps/negentropy-wiki/content.fixture/publications/negentropy/nav-tree.json
+++ b/apps/negentropy-wiki/content.fixture/publications/negentropy/nav-tree.json
@@ -1,0 +1,41 @@
+{
+  "publication_id": "d0c00000-0000-4000-8000-000000000000",
+  "nav_tree": {
+    "items": [
+      {
+        "entry_id": "d0c00000-0000-4000-8000-000000000001",
+        "entry_slug": "readme",
+        "entry_title": "Negentropy 用户手册",
+        "entry_description": null,
+        "is_index_page": true,
+        "document_id": "d0c00000-0000-4000-8000-0000000000a1",
+        "catalog_node_id": null,
+        "entry_kind": "DOCUMENT",
+        "children": []
+      },
+      {
+        "entry_id": "d0c00000-0000-4000-8000-000000000002",
+        "entry_slug": "concepts",
+        "entry_title": "Concepts",
+        "entry_description": null,
+        "is_index_page": false,
+        "document_id": null,
+        "catalog_node_id": null,
+        "entry_kind": "CONTAINER",
+        "children": [
+          {
+            "entry_id": "d0c00000-0000-4000-8000-000000000003",
+            "entry_slug": "concepts/overview",
+            "entry_title": "认识 Negentropy",
+            "entry_description": null,
+            "is_index_page": false,
+            "document_id": "d0c00000-0000-4000-8000-0000000000a3",
+            "catalog_node_id": null,
+            "entry_kind": "DOCUMENT",
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/negentropy-wiki/content.fixture/publications/negentropy/publication.json
+++ b/apps/negentropy-wiki/content.fixture/publications/negentropy/publication.json
@@ -1,0 +1,16 @@
+{
+  "id": "d0c00000-0000-4000-8000-000000000000",
+  "catalog_id": "d0c00000-0000-4000-8000-000000000000",
+  "app_name": "negentropy",
+  "publish_mode": "snapshot",
+  "name": "Negentropy",
+  "slug": "negentropy",
+  "description": "Negentropy 工程文档 — 源自仓库 docs/（开发种子 fixture，仅含最小样本）。",
+  "status": "published",
+  "theme": "docs",
+  "version": 1,
+  "published_at": null,
+  "created_at": null,
+  "updated_at": null,
+  "entries_count": 2
+}

--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,7 +1,11 @@
 import {
   findFirstDocumentSlug,
+  isReservedDocsSlug,
   joinEntrySlug,
   resolveSectionView,
+  RESERVED_DOCS_HOME,
+  RESERVED_DOCS_LABEL,
+  RESERVED_DOCS_SLUG,
   type WikiEntry,
   type WikiEntryContent,
   type WikiNavTreeItem,
@@ -154,6 +158,10 @@ export default async function WikiEntryPage({ params }: Props) {
     />
   );
 
+  const isReserved = isReservedDocsSlug(pubSlug);
+  const reservedExists =
+    isReserved || (await wikiApi.findPublicationBySlug(RESERVED_DOCS_SLUG)) !== null;
+
   const header = sectionView.headerItems.length > 0 && (
     <WikiHeader
       pubSlug={pubSlug}
@@ -161,7 +169,12 @@ export default async function WikiEntryPage({ params }: Props) {
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      graphTab={{ active: false, show: hasAnyEntry }}
+      reservedTab={
+        reservedExists
+          ? { show: true, active: isReserved, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
+          : undefined
+      }
+      graphTab={{ active: false, show: hasAnyEntry && !isReserved }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -7,7 +7,11 @@ import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import {
   countLeafEntries,
+  isReservedDocsSlug,
   resolveSectionView,
+  RESERVED_DOCS_HOME,
+  RESERVED_DOCS_LABEL,
+  RESERVED_DOCS_SLUG,
   type WikiNavTreeItem,
   type WikiPublication,
 } from "@/lib/wiki-api";
@@ -77,6 +81,10 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
   const entriesTotal = countLeafEntries(navItems);
   const sectionView = resolveSectionView(navItems);
 
+  const isReserved = isReservedDocsSlug(pubSlug);
+  const reservedExists =
+    isReserved || (await wikiApi.findPublicationBySlug(RESERVED_DOCS_SLUG)) !== null;
+
   const header = sectionView.headerItems.length > 0 && (
     <WikiHeader
       pubSlug={pubSlug}
@@ -84,7 +92,12 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      graphTab={{ active: true, show: entriesTotal > 0 }}
+      reservedTab={
+        reservedExists
+          ? { show: true, active: isReserved, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
+          : undefined
+      }
+      graphTab={{ active: true, show: entriesTotal > 0 && !isReserved }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -2,7 +2,11 @@ import {
   countLeafEntries,
   findFirstDocumentSlug,
   findIndexEntry,
+  isReservedDocsSlug,
   resolveSectionView,
+  RESERVED_DOCS_HOME,
+  RESERVED_DOCS_LABEL,
+  RESERVED_DOCS_SLUG,
   type WikiPublication,
   type WikiNavTreeItem,
 } from "@/lib/wiki-api";
@@ -71,6 +75,12 @@ export default async function WikiPublicationPage({ params }: Props) {
   const entriesTotal = countLeafEntries(navItems);
   const sectionView = resolveSectionView(navItems);
 
+  // 保留一级目录「Negentropy」：左侧标签恒在（存在保留 pub 时），当前在该 pub 时高亮；
+  // 保留 docs 目录无 KG，故其页面隐藏 Knowledge Graph 标签。
+  const isReserved = isReservedDocsSlug(pubSlug);
+  const reservedExists =
+    isReserved || (await wikiApi.findPublicationBySlug(RESERVED_DOCS_SLUG)) !== null;
+
   const catalogItem = sectionView.activeItem;
   const catalogTargetSlug = catalogItem ? findFirstDocumentSlug(catalogItem) : null;
   const catalogName = catalogItem
@@ -97,7 +107,12 @@ export default async function WikiPublicationPage({ params }: Props) {
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      graphTab={{ active: false, show: entriesTotal > 0 }}
+      reservedTab={
+        reservedExists
+          ? { show: true, active: isReserved, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
+          : undefined
+      }
+      graphTab={{ active: false, show: entriesTotal > 0 && !isReserved }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -2,6 +2,9 @@ import type { ComponentType } from "react";
 
 import {
   findFirstDocumentSlug,
+  isReservedDocsSlug,
+  RESERVED_DOCS_HOME,
+  RESERVED_DOCS_LABEL,
   type WikiNavTreeItem,
   type WikiPublication,
 } from "@/lib/wiki-api";
@@ -54,6 +57,9 @@ export default async function WikiHomePage() {
   }[] = [];
 
   for (const { pub, items } of navTrees) {
+    // 保留一级目录「Negentropy」不进右区内容标签 / 卡片：它由左侧保留标签 + 领衔卡片单独承载，
+    // 避免「左侧保留标签」与「右区普通标签」双重出现。
+    if (isReservedDocsSlug(pub.slug)) continue;
     if (items.length > 0) {
       // 有 nav tree 一级节点时，从中构建导航项
       for (const item of items) {
@@ -80,10 +86,21 @@ export default async function WikiHomePage() {
     }
   }
 
+  // 保留一级目录领衔首页卡片（置于普通卡片之前），与左侧保留标签呼应。
+  const reservedPub = publications.find((p) => isReservedDocsSlug(p.slug));
+  if (reservedPub) {
+    homeCards.unshift({
+      title: RESERVED_DOCS_LABEL,
+      href: RESERVED_DOCS_HOME,
+      description: reservedPub.description || "Negentropy 工程文档 — 源自仓库 docs/。",
+      Icon: getPublicationIcon(reservedPub.name),
+    });
+  }
+
   const firstHref = homeCards.length > 0 ? homeCards[0].href : undefined;
 
-  const firstPubSlug =
-    publications.length > 0 ? publications[0].slug : undefined;
+  // Knowledge Graph 标签指向首个**非保留** publication（保留 docs 目录无 KG）。
+  const firstPubSlug = publications.find((p) => !isReservedDocsSlug(p.slug))?.slug;
 
   const header = (
     <WikiHeader
@@ -91,6 +108,11 @@ export default async function WikiHomePage() {
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
       pubSlug={firstPubSlug}
+      reservedTab={
+        reservedPub
+          ? { show: true, active: false, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
+          : undefined
+      }
       graphTab={
         firstPubSlug
           ? { show: true, active: false, label: "Knowledge Graph" }
@@ -99,9 +121,14 @@ export default async function WikiHomePage() {
     />
   );
 
+  // 移动端侧栏：保留目录领衔，其后接普通右区导航项。
+  const mobileLinks = reservedPub
+    ? [{ label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }, ...homeLinks]
+    : homeLinks;
+
   const sidebar = (
     <div className="home-mobile-sidebar">
-      {homeLinks.map((link) => (
+      {mobileLinks.map((link) => (
         <a
           key={link.href}
           href={link.href}

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -20,6 +20,14 @@ interface WikiHeaderGraphTab {
   label?: string;
 }
 
+/** 保留一级目录「Negentropy」标签（置于 Knowledge Graph 左侧的系统保留入口）。 */
+interface WikiHeaderReservedTab {
+  show: boolean;
+  active?: boolean;
+  label?: string;
+  href: string;
+}
+
 interface HomeLink {
   label: string;
   href: string;
@@ -30,6 +38,7 @@ interface WikiHeaderProps {
   items?: WikiNavTreeItem[];
   activeTopSlug?: string;
   headerSlot?: React.ReactNode;
+  reservedTab?: WikiHeaderReservedTab;
   graphTab?: WikiHeaderGraphTab;
   searchBox?: React.ReactNode;
   actions?: React.ReactNode;
@@ -42,13 +51,14 @@ export function WikiHeader({
   items = [],
   activeTopSlug,
   headerSlot,
+  reservedTab,
   graphTab,
   searchBox,
   actions,
   userMenu,
   homeLinks,
 }: WikiHeaderProps) {
-  if (!items.length && !homeLinks?.length && !(graphTab?.show)) return null;
+  if (!items.length && !homeLinks?.length && !(graphTab?.show) && !(reservedTab?.show)) return null;
 
   return (
     <header className="wiki-header">
@@ -64,16 +74,27 @@ export function WikiHeader({
           />
           <span className="wiki-header-name">Negentropy Wiki</span>
         </Link>
-        {/* LEFT: Knowledge Graph tab only */}
-        {graphTab?.show && (
+        {/* LEFT: 保留一级目录「Negentropy」（最左）+ Knowledge Graph */}
+        {(reservedTab?.show || graphTab?.show) && (
           <nav className="wiki-header-tabs wiki-header-tabs--left" aria-label="特色导航">
-            <Link
-              href={`/${pubSlug}/graph`}
-              className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
-              aria-current={graphTab.active ? "page" : undefined}
-            >
-              {graphTab.label ?? "Knowledge Graph"}
-            </Link>
+            {reservedTab?.show && (
+              <Link
+                href={reservedTab.href}
+                className={`wiki-header-tab${reservedTab.active ? " active" : ""}`}
+                aria-current={reservedTab.active ? "page" : undefined}
+              >
+                {reservedTab.label ?? "Negentropy"}
+              </Link>
+            )}
+            {graphTab?.show && (
+              <Link
+                href={`/${pubSlug}/graph`}
+                className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
+                aria-current={graphTab.active ? "page" : undefined}
+              >
+                {graphTab.label ?? "Knowledge Graph"}
+              </Link>
+            )}
           </nav>
         )}
 

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -12,6 +12,31 @@
  */
 
 // ---------------------------------------------------------------------------
+// 保留一级目录「Negentropy」（来自仓库 docs/，由后端导出器合成进内容包）
+//
+// 单一事实源：slug / 首页 / 标签文案集中于此，供 Header 左侧保留标签与首页卡片
+// 共享，避免散落的字符串字面量漂移。与后端 ``WikiDocsSyncSettings.reserved_slug``
+// 保持一致（默认 "negentropy"）。
+// ---------------------------------------------------------------------------
+
+/** 保留 docs 一级目录的 publication slug（与后端 reserved_slug 对齐）。 */
+export const RESERVED_DOCS_SLUG = "negentropy";
+
+/** 保留 docs 一级目录首页 entry slug（docs/README.md → "readme"）。 */
+export const RESERVED_DOCS_INDEX_SLUG = "readme";
+
+/** 保留一级目录首页 href（Header 左侧标签 / 首页卡片跳转目标）。 */
+export const RESERVED_DOCS_HOME = `/${RESERVED_DOCS_SLUG}/${RESERVED_DOCS_INDEX_SLUG}`;
+
+/** 保留一级目录的头部标签文案。 */
+export const RESERVED_DOCS_LABEL = "Negentropy";
+
+/** 判定某 publication slug 是否为保留 docs 目录（用于首页右区过滤等）。 */
+export function isReservedDocsSlug(slug: string | null | undefined): boolean {
+  return slug === RESERVED_DOCS_SLUG;
+}
+
+// ---------------------------------------------------------------------------
 // 类型定义
 // ---------------------------------------------------------------------------
 

--- a/apps/negentropy-wiki/tests/lib/content-source.test.ts
+++ b/apps/negentropy-wiki/tests/lib/content-source.test.ts
@@ -23,11 +23,13 @@ describe("LocalContentClient（读取静态内容包 fixture）", () => {
     wikiApi = mod.wikiApi;
   });
 
-  it("listPublications 返回 fixture 中的 handbook", async () => {
+  it("listPublications 返回 fixture 中的 handbook 与保留 docs 目录", async () => {
     const { items, total } = await wikiApi.listPublications();
-    expect(total).toBe(1);
-    expect(items[0].slug).toBe("negentropy-handbook");
-    expect(items[0].status).toBe("published");
+    expect(total).toBe(2);
+    const slugs = items.map((p: { slug: string }) => p.slug);
+    expect(slugs).toContain("negentropy-handbook");
+    expect(slugs).toContain("negentropy");
+    expect(items.every((p: { status: string }) => p.status === "published")).toBe(true);
   });
 
   it("findPublicationBySlug 按 slug 命中 publication", async () => {
@@ -81,5 +83,38 @@ describe("LocalContentClient（读取静态内容包 fixture）", () => {
     await expect(
       wikiApi.getPublicationGraph("00000000-0000-0000-0000-000000000000"),
     ).rejects.toThrow(/publication not found/);
+  });
+
+  // 保留一级目录「Negentropy」（源自仓库 docs/）的内容包契约。
+  it("保留 docs 目录：'negentropy' 命中，DOCUMENT 携带非空 document_id 且正文可载", async () => {
+    const pub = await wikiApi.findPublicationBySlug("negentropy");
+    expect(pub).not.toBeNull();
+    expect(pub.slug).toBe("negentropy");
+
+    const { nav_tree } = await wikiApi.getNavTree(pub.id);
+    const topSlugs = nav_tree.items.map((i: { entry_slug: string }) => i.entry_slug);
+    expect(topSlugs).toContain("readme"); // docs/README.md → 首页
+    expect(topSlugs).toContain("concepts");
+
+    const concepts = nav_tree.items.find(
+      (i: { entry_slug: string }) => i.entry_slug === "concepts",
+    );
+    expect(concepts.entry_kind).toBe("CONTAINER");
+    expect(concepts.document_id).toBeNull();
+
+    const overview = concepts.children[0];
+    expect(overview.entry_kind).toBe("DOCUMENT");
+    // 关键约束：DOCUMENT 必须携带非空 document_id（否则页面判「失效」不渲染正文）。
+    expect(overview.document_id).not.toBeNull();
+
+    const content = await wikiApi.getEntryContent(overview.entry_id);
+    expect(content.markdown_content).toContain("熵减");
+  });
+
+  it("getPublicationGraph 对保留 docs 目录降级为 no_kg（无 graph.json）", async () => {
+    const pub = await wikiApi.findPublicationBySlug("negentropy");
+    const graph = await wikiApi.getPublicationGraph(pub.id);
+    expect(graph.status).toBe("no_kg");
+    expect(graph.nodes.length).toBe(0);
   });
 });

--- a/apps/negentropy-wiki/tests/lib/wiki-reserved-docs.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-reserved-docs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isReservedDocsSlug,
+  RESERVED_DOCS_HOME,
+  RESERVED_DOCS_INDEX_SLUG,
+  RESERVED_DOCS_LABEL,
+  RESERVED_DOCS_SLUG,
+} from "@/lib/wiki-api";
+
+// 保留一级目录「Negentropy」的常量与判定（Header 左侧标签 / 首页右区过滤的单一事实源）。
+describe("保留 docs 目录常量与 isReservedDocsSlug", () => {
+  it("常量取值与后端 reserved_slug 默认值对齐", () => {
+    expect(RESERVED_DOCS_SLUG).toBe("negentropy");
+    expect(RESERVED_DOCS_INDEX_SLUG).toBe("readme");
+    expect(RESERVED_DOCS_HOME).toBe("/negentropy/readme");
+    expect(RESERVED_DOCS_LABEL).toBe("Negentropy");
+  });
+
+  it("isReservedDocsSlug 仅对保留 slug 为真，其余（含 null/空）为假", () => {
+    expect(isReservedDocsSlug("negentropy")).toBe(true);
+    expect(isReservedDocsSlug("negentropy-handbook")).toBe(false);
+    expect(isReservedDocsSlug("concepts")).toBe(false);
+    expect(isReservedDocsSlug(null)).toBe(false);
+    expect(isReservedDocsSlug(undefined)).toBe(false);
+    expect(isReservedDocsSlug("")).toBe(false);
+  });
+});

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -155,6 +155,76 @@ class WikiExportSettings(BaseModel):
     )
 
 
+class WikiDocsSyncSettings(BaseModel):
+    """仓库 ``docs/`` → wiki「保留一级目录 Negentropy」同步配置。
+
+    与 ``wiki_export`` 正交：``wiki_export`` 序列化主站 DB 已发布内容；本块把仓库
+    ``docs/`` 公开子集合成为一个**保留 Publication**（slug=``negentropy``）注入同一
+    静态内容包。导出器（``export_wiki_content.py``）在完整 repo checkout 中运行，
+    故 ``docs/`` 在盘可读；合成产物随既有 ``content/`` 交付链路下发，无新增运行期依赖。
+
+    取舍：``docs/`` 非 DB 内容、与 wiki 应用同仓，故由导出步骤一次性烘焙为静态条目，
+    使「同步并发布」天然附带刷新 docs，且 wiki 端零改动地复用既有内容包 schema 与路由。
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description="True 时导出期把 docs/ 公开子集合成为保留 Publication 注入内容包；False 关闭。",
+    )
+    docs_root: str | None = Field(
+        default=None,
+        description="docs/ 绝对路径；缺省时由 resolve_docs_root 经哨兵探测自动定位仓库 docs/。",
+    )
+    include_dirs: list[str] = Field(
+        default_factory=lambda: ["concepts", "reference", "research"],
+        description="纳入同步的 docs/ 一级子目录（公开子集）。",
+    )
+    include_root_readme: bool = Field(
+        default=True,
+        description="是否把 docs/README.md 作为保留 Publication 首页（slug=readme）。",
+    )
+    exclude_dirs: list[str] = Field(
+        default_factory=lambda: [".agents", "i18n"],
+        description="排除的 docs/ 一级子目录（内部协议/截图、国际化）。",
+    )
+    exclude_dir_names: list[str] = Field(
+        default_factory=lambda: ["zh-CN"],
+        description="任意层级按目录名排除的目录（如嵌套 locale 目录），与 i18n 排除意图一致。",
+    )
+    exclude_suffixes: list[str] = Field(
+        default_factory=lambda: [".zh.md"],
+        description="按文件名后缀排除（如 locale 变体 *.zh.md），避免重复 slug 与多语噪声。",
+    )
+    reserved_slug: str = Field(
+        default="negentropy",
+        description="保留 Publication 的 slug（站内一级目录路由前缀 /<slug>/...）。",
+    )
+    reserved_name: str = Field(
+        default="Negentropy",
+        description="保留 Publication 显示名（首页卡片 / 头部标签）。",
+    )
+    reserved_description: str | None = Field(
+        default="Negentropy 工程文档 — 源自主站仓库 docs/。",
+        description="保留 Publication 描述（首页卡片副文）。",
+    )
+    github_owner: str = Field(
+        default="ThreeFish-AI",
+        description="源码/仓库链接重写目标 owner（GitHub blob URL）。",
+    )
+    github_repo: str = Field(
+        default="negentropy",
+        description="源码/仓库链接重写目标 repo（GitHub blob URL）。",
+    )
+    github_ref: str = Field(
+        default="main",
+        description="GitHub blob 链接的 ref（分支/标签/SHA）；CI 可经 env 覆盖为 commit SHA 得永久链接。",
+    )
+    github_docs_prefix: str = Field(
+        default="docs",
+        description="docs/ 在仓库内的路径前缀，用于解析指向 docs 外/未纳入文档的 GitHub 兜底链接。",
+    )
+
+
 class WikiPagesPublishSettings(BaseModel):
     """Wiki 本地自动发布到静态托管（如 GitHub Pages）配置。
 
@@ -277,6 +347,9 @@ class KnowledgeSettings(BaseSettings):
     )
     wiki_export: WikiExportSettings = Field(
         default_factory=WikiExportSettings,
+    )
+    wiki_docs_sync: WikiDocsSyncSettings = Field(
+        default_factory=WikiDocsSyncSettings,
     )
     wiki_pages_publish: WikiPagesPublishSettings = Field(
         default_factory=WikiPagesPublishSettings,

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_docs_ingest.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_docs_ingest.py
@@ -1,0 +1,539 @@
+"""仓库 ``docs/`` → wiki 保留 Publication「Negentropy」合成器。
+
+把仓库 ``docs/`` 公开子集（``README.md`` + ``include_dirs``）烘焙为一个
+slug=``negentropy`` 的**保留 Publication** 内容包片段，注入 ``WikiExportService``
+产出的同一静态内容包，使 wiki 端零改动地复用既有 schema 与页面路由。
+
+设计要点（Orthogonal Decomposition / DRY）：
+  - **纯函数 + 无自身文件 IO**：仅遍历 ``docs/`` 读文本、返回内存片段
+    （``DocsPackFragment``），文件统一由 ``WikiExportService`` 落盘（与 DB 导出
+    共用 ``_write_json`` 与 ``publications.json`` / ``index.json`` 聚合）。
+  - **字段形状对齐**：``publication`` 仿 ``_serialize_publication``、entry 仿
+    ``build_entry_content_response``，与内容包 schema 逐字段一致。
+  - **确定性 UUIDv5**：同路径恒得同 id ⇒ 站内 URL 稳定、CI diff 干净。
+  - **链接重写尽力而为**：相对 ``.md`` → 站内 slug；源码/仓库路径 → GitHub blob；
+    图片 → GitHub raw；外链与纯锚点保留；单链失败仅 WARN，绝不抛错。
+
+与 ``wiki_export_service`` 正交：后者序列化 DB 已发布内容；本模块从仓库文件系统
+合成保留目录，二者在导出器中汇流为单一内容包。
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from negentropy.config.knowledge import WikiDocsSyncSettings
+from negentropy.logging import get_logger
+
+logger = get_logger(__name__.rsplit(".", 1)[0])
+
+# 固定命名空间（切勿变更：变更将导致所有 docs 条目 id/URL 漂移）。
+_DOCS_NS = uuid.UUID("6e0e9c4a-2f3b-5d71-9a8c-7b1e4f0d2a55")
+
+# 视为目录「索引页」的文件名（不分大小写，README 优先于 index）。
+_INDEX_BASENAMES = ("readme", "index")
+
+# markdown 行内链接 / 图片：``[text](url)`` / ``![alt](url "title")`` / ``[text](<url>)``。
+# text 允许一层嵌套 ``[...]``（如代码路径中的 Next.js 动态段 ``[sessionId]``），
+# 否则会在首个 ``]`` 处断裂、漏匹配此类链接。
+_INLINE_LINK_RE = re.compile(
+    r"(?P<bang>!?)\[(?P<text>(?:[^\[\]]|\[[^\[\]]*\])*)\]\(\s*"
+    r"(?P<url><[^>]+>|[^)\s]+)"
+    r"(?P<title>\s+\"[^\"]*\"|\s+'[^']*')?\s*\)"
+)
+# 引用式定义：``[id]: url``（行首）。
+_REF_DEF_RE = re.compile(r"(?m)^(?P<indent>[ ]{0,3})\[(?P<id>[^\]]+)\]:\s*(?P<url><[^>]+>|\S+)")
+
+# 首个 ATX H1（代码围栏之前）。
+_H1_RE = re.compile(r"(?m)^#[ \t]+(?P<title>.+?)[ \t]*#*[ \t]*$")
+_FENCE_RE = re.compile(r"(?m)^[ \t]*(```|~~~)")
+
+
+@dataclass
+class DocsPackFragment:
+    """``docs/`` 合成内容包片段（由 WikiExportService 落盘 / 聚合）。"""
+
+    publication: dict[str, Any]
+    nav_tree: dict[str, Any]
+    entries_index: dict[str, Any]
+    entry_payloads: dict[str, dict[str, Any]] = field(default_factory=dict)
+    index_pub: dict[str, Any] = field(default_factory=dict)
+    pub_index_row: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# 定位仓库 docs/
+# ---------------------------------------------------------------------------
+
+
+def resolve_docs_root(cfg: WikiDocsSyncSettings) -> Path | None:
+    """定位仓库 ``docs/``。
+
+    ``cfg.docs_root`` 显式指定优先；否则从本文件向上「哨兵探测」——首个既含
+    ``docs/README.md`` 又含 ``apps/`` 的祖先目录即仓库根，返回其 ``docs/``。
+    CI checkout 与本地 ``sync-wiki-content.sh`` 行为一致，无需 git 子进程。
+    找不到则 WARN 返回 ``None``（导出器据此跳过 docs 同步）。
+    """
+    if cfg.docs_root:
+        root = Path(cfg.docs_root).expanduser().resolve()
+        if (root / "README.md").is_file():
+            return root
+        logger.warning("wiki_docs_root_invalid", docs_root=str(root))
+        return None
+
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "docs" / "README.md").is_file() and (parent / "apps").is_dir():
+            return parent / "docs"
+    logger.warning("wiki_docs_root_not_found", searched_from=str(here))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 确定性 ID / slug / 标题 / 自然序
+# ---------------------------------------------------------------------------
+
+
+def _pub_id(slug: str) -> str:
+    return str(uuid.uuid5(_DOCS_NS, f"publication:{slug}"))
+
+
+def _entry_id(rel_or_dir: str) -> str:
+    return str(uuid.uuid5(_DOCS_NS, f"entry:{rel_or_dir}"))
+
+
+def _container_id(rel_dir: str) -> str:
+    return str(uuid.uuid5(_DOCS_NS, f"container:{rel_dir}"))
+
+
+def _document_id(rel_path: str) -> str:
+    return str(uuid.uuid5(_DOCS_NS, f"document:{rel_path}"))
+
+
+def _slug_segment(name: str) -> str:
+    """单路径段 slugify：小写、空白/下划线→``-``、剔非 ``[a-z0-9.-]``、收敛连字符。"""
+    s = name.strip().lower()
+    s = re.sub(r"[\s_]+", "-", s)
+    s = re.sub(r"[^a-z0-9.\-]+", "", s)
+    s = re.sub(r"-{2,}", "-", s).strip("-.")
+    return s or "untitled"
+
+
+def doc_slug_for(rel_posix: str) -> str:
+    """docs 相对路径 → 站内 entry slug（Materialized Path，用 ``/`` 连接）。
+
+    - 顶层 ``README.md`` → ``readme``；
+    - 目录 ``README.md`` / ``index.md`` → ``<dir slug>/readme``；
+    - 其余 → ``<dir slug>/<文件名去 .md 的 slug>``。
+    """
+    p = PurePosixPath(rel_posix)
+    stem = p.name[:-3] if p.name.lower().endswith(".md") else p.name
+    parent_segs = [_slug_segment(s) for s in p.parent.parts if s not in (".", "")]
+    if stem.lower() in _INDEX_BASENAMES:
+        return "/".join([*parent_segs, "readme"]) if parent_segs else "readme"
+    return "/".join([*parent_segs, _slug_segment(stem)])
+
+
+def _dir_slug_for(rel_dir_posix: str) -> str:
+    """docs 子目录相对路径 → 容器 slug。"""
+    return "/".join(_slug_segment(s) for s in PurePosixPath(rel_dir_posix).parts if s not in (".", ""))
+
+
+def _natural_key(name: str) -> list[Any]:
+    """自然序键：数字串按整数比较（``020a`` < ``020b`` < ``030`` < ``100``）。"""
+    parts = re.split(r"(\d+)", name.lower())
+    return [int(tok) if tok.isdigit() else tok for tok in parts]
+
+
+def _humanize(stem: str) -> str:
+    """无 H1 时的标题兜底：剥前缀序号、分隔符转空格。"""
+    s = re.sub(r"^\d+[a-z]*[-_]+", "", stem)
+    s = re.sub(r"[-_]+", " ", s).strip()
+    return s or stem
+
+
+def _extract_title(markdown: str, fallback_stem: str) -> str:
+    """取首个 ATX H1（代码围栏之前、剥行内反引号）；无则 humanize 文件名。"""
+    fence = _FENCE_RE.search(markdown)
+    scope = markdown[: fence.start()] if fence else markdown
+    m = _H1_RE.search(scope)
+    if m:
+        title = m.group("title").strip().replace("`", "")
+        if title:
+            return title
+    return _humanize(fallback_stem)
+
+
+# ---------------------------------------------------------------------------
+# 链接重写
+# ---------------------------------------------------------------------------
+
+
+def _is_external(url: str) -> bool:
+    return bool(re.match(r"^(?:[a-z][a-z0-9+.\-]*:|//)", url, re.IGNORECASE))
+
+
+def _github_blob(cfg: WikiDocsSyncSettings, repo_path: str, anchor: str) -> str:
+    return f"https://github.com/{cfg.github_owner}/{cfg.github_repo}/blob/{cfg.github_ref}/{repo_path}{anchor}"
+
+
+def _github_raw(cfg: WikiDocsSyncSettings, repo_path: str) -> str:
+    return f"https://raw.githubusercontent.com/{cfg.github_owner}/{cfg.github_repo}/{cfg.github_ref}/{repo_path}"
+
+
+def _rewrite_target(
+    raw_url: str,
+    *,
+    is_image: bool,
+    current_rel_path: str,
+    included_slugs: set[str],
+    cfg: WikiDocsSyncSettings,
+) -> str:
+    """单个链接目标重写（纯函数，失败返回原值）。"""
+    url = raw_url.strip()
+    if url.startswith("<") and url.endswith(">"):
+        url = url[1:-1].strip()
+
+    if not url or url.startswith("#") or _is_external(url):
+        return raw_url
+
+    path_part, sep, frag = url.partition("#")
+    anchor = (sep + frag) if sep else ""
+    if not path_part:
+        return raw_url
+
+    docs_prefix = cfg.github_docs_prefix.strip("/")
+    docs_root_prefix = f"{docs_prefix}/" if docs_prefix else ""
+    cur_repo_path = f"{docs_prefix}/{current_rel_path}" if docs_prefix else current_rel_path
+    cur_dir = posixpath.dirname(cur_repo_path)
+    target_repo = posixpath.normpath(posixpath.join(cur_dir, path_part))
+
+    # 解析越出仓库根：docs 内多见「过度 ../」的源码/同级链接（作者按非仓库基准书写）。
+    # 钳制前导 ../ 串恢复作者意图：剩余串先按 docs 相对解释（恢复站内 .md 跳转），
+    # 否则按仓库根相对解释（源码/根级文档 → GitHub）。
+    if target_repo.startswith(".."):
+        clamped = re.sub(r"^(?:\.\./)+", "", target_repo)
+        if not clamped or clamped.startswith(".."):
+            logger.warning("wiki_docs_link_escape", doc=current_rel_path, url=url)
+            return raw_url
+        if not is_image and clamped.lower().endswith(".md") and doc_slug_for(clamped) in included_slugs:
+            return f"/{cfg.reserved_slug}/{doc_slug_for(clamped)}{anchor}"
+        if is_image:
+            return _github_raw(cfg, clamped)
+        return _github_blob(cfg, clamped, anchor)
+
+    in_docs = target_repo.startswith(docs_root_prefix) if docs_root_prefix else True
+
+    if is_image:
+        # 图片走 GitHub raw（blob 不内联渲染）。
+        return _github_raw(cfg, target_repo)
+
+    if in_docs and target_repo.lower().endswith(".md"):
+        rel_to_docs = target_repo[len(docs_root_prefix) :] if docs_root_prefix else target_repo
+        slug = doc_slug_for(rel_to_docs)
+        if slug in included_slugs:
+            return f"/{cfg.reserved_slug}/{slug}{anchor}"
+        # docs 内但未纳入子集（.agents/i18n/locale 等）→ GitHub blob 兜底。
+        return _github_blob(cfg, target_repo, anchor)
+
+    # docs 外仓库路径（源码、根级文档等）→ GitHub blob。
+    return _github_blob(cfg, target_repo, anchor)
+
+
+def rewrite_doc_links(
+    markdown: str,
+    *,
+    current_rel_path: str,
+    included_slugs: set[str],
+    cfg: WikiDocsSyncSettings,
+) -> str:
+    """重写一篇文档内的相对链接 / 图片（行内 + 引用式定义）。"""
+    if not markdown:
+        return markdown
+
+    def _inline(m: re.Match[str]) -> str:
+        new_url = _rewrite_target(
+            m.group("url"),
+            is_image=bool(m.group("bang")),
+            current_rel_path=current_rel_path,
+            included_slugs=included_slugs,
+            cfg=cfg,
+        )
+        title = m.group("title") or ""
+        return f"{m.group('bang')}[{m.group('text')}]({new_url}{title})"
+
+    def _refdef(m: re.Match[str]) -> str:
+        new_url = _rewrite_target(
+            m.group("url"),
+            is_image=False,
+            current_rel_path=current_rel_path,
+            included_slugs=included_slugs,
+            cfg=cfg,
+        )
+        return f"{m.group('indent')}[{m.group('id')}]: {new_url}"
+
+    out = _INLINE_LINK_RE.sub(_inline, markdown)
+    out = _REF_DEF_RE.sub(_refdef, out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 文件收集 + 树构建
+# ---------------------------------------------------------------------------
+
+
+def _is_excluded(rel_posix: str, cfg: WikiDocsSyncSettings) -> bool:
+    parts = PurePosixPath(rel_posix).parts
+    name = parts[-1]
+    if name.lower().endswith(tuple(s.lower() for s in cfg.exclude_suffixes)):
+        return True
+    excluded_names = {d.lower() for d in cfg.exclude_dir_names}
+    if any(part.lower() in excluded_names for part in parts[:-1]):
+        return True
+    return False
+
+
+def _collect_files(docs_root: Path, cfg: WikiDocsSyncSettings) -> list[str]:
+    """收集纳入的 ``.md`` 相对路径（posix），已应用排除规则。"""
+    rels: list[str] = []
+    if cfg.include_root_readme and (docs_root / "README.md").is_file():
+        rels.append("README.md")
+
+    for inc in cfg.include_dirs:
+        base = docs_root / inc
+        if not base.is_dir():
+            logger.warning("wiki_docs_include_dir_missing", include_dir=inc)
+            continue
+        for fp in sorted(base.rglob("*.md")):
+            rel = fp.relative_to(docs_root).as_posix()
+            if _is_excluded(rel, cfg):
+                continue
+            rels.append(rel)
+    return rels
+
+
+class _Node:
+    """构树用可变节点（容器或文档）。"""
+
+    __slots__ = ("slug", "title", "is_doc", "rel_path", "sort_name", "is_index", "children")
+
+    def __init__(self, slug: str, title: str, *, is_doc: bool, rel_path: str | None, sort_name: str) -> None:
+        self.slug = slug
+        self.title = title
+        self.is_doc = is_doc
+        self.rel_path = rel_path
+        self.sort_name = sort_name
+        self.is_index = False
+        self.children: dict[str, _Node] = {}
+
+
+def build_docs_pack(cfg: WikiDocsSyncSettings) -> DocsPackFragment | None:
+    """遍历 docs/ 子集 → 合成 ``negentropy`` 保留 Publication 片段；禁用/缺失返回 None。"""
+    if not cfg.enabled:
+        return None
+    docs_root = resolve_docs_root(cfg)
+    if docs_root is None:
+        return None
+
+    rels = _collect_files(docs_root, cfg)
+    if not rels:
+        logger.warning("wiki_docs_no_files", docs_root=str(docs_root))
+        return None
+
+    # 第一遍：预计算全部文档 slug，供链接重写判定「站内可达」。
+    doc_slugs: dict[str, str] = {}  # rel_path -> slug
+    seen_slugs: set[str] = set()
+    for rel in rels:
+        slug = doc_slug_for(rel)
+        if slug in seen_slugs:
+            # 确定性去重：附加 -doc 后缀（极少见，folder-README 让位文件名）。
+            alt = f"{slug}-doc"
+            i = 2
+            while alt in seen_slugs:
+                alt = f"{slug}-doc-{i}"
+                i += 1
+            logger.warning("wiki_docs_slug_collision", rel=rel, slug=slug, resolved=alt)
+            slug = alt
+        seen_slugs.add(slug)
+        doc_slugs[rel] = slug
+    included_slugs = set(doc_slugs.values())
+
+    # 第二遍：构建容器/文档树。
+    root_children: dict[str, _Node] = {}
+    for rel in rels:
+        slug = doc_slugs[rel]
+        p = PurePosixPath(rel)
+        title = _extract_title((docs_root / rel).read_text(encoding="utf-8", errors="replace"), p.stem)
+        is_index = p.name.lower().rsplit(".", 1)[0] in _INDEX_BASENAMES
+
+        if len(p.parts) == 1:
+            # 顶层文件（docs/README.md）。
+            node = _Node(slug, title, is_doc=True, rel_path=rel, sort_name=p.name)
+            node.is_index = is_index
+            root_children[slug] = node
+            continue
+
+        # 逐级建容器。
+        cursor = root_children
+        dir_parts: list[str] = []
+        for seg in p.parts[:-1]:
+            dir_parts.append(seg)
+            dir_rel = "/".join(dir_parts)
+            cslug = _dir_slug_for(dir_rel)
+            child = cursor.get(cslug)
+            if child is None:
+                child = _Node(cslug, _humanize(seg), is_doc=False, rel_path=None, sort_name=seg)
+                cursor[cslug] = child
+            cursor = child.children
+        doc_node = _Node(slug, title, is_doc=True, rel_path=rel, sort_name=p.name)
+        doc_node.is_index = is_index
+        cursor[slug] = doc_node
+
+    pub_slug = cfg.reserved_slug
+    pub_id = _pub_id(pub_slug)
+
+    entry_payloads: dict[str, dict[str, Any]] = {}
+    entries_items: list[dict[str, Any]] = []
+    slug_to_id: dict[str, str] = {}
+    entry_ids: list[str] = []
+    docs_prefix = cfg.github_docs_prefix.strip("/")
+
+    def _doc_source_url(rel_path: str) -> str:
+        repo_path = f"{docs_prefix}/{rel_path}" if docs_prefix else rel_path
+        return f"https://github.com/{cfg.github_owner}/{cfg.github_repo}/blob/{cfg.github_ref}/{repo_path}"
+
+    def _sort_children(nodes: dict[str, _Node]) -> list[_Node]:
+        # 索引页优先，其余按自然序（目录/文件交错）。
+        return sorted(nodes.values(), key=lambda n: (not n.is_index, _natural_key(n.sort_name)))
+
+    def _has_doc_descendant(node: _Node) -> bool:
+        if node.is_doc:
+            return True
+        return any(_has_doc_descendant(c) for c in node.children.values())
+
+    def _emit(node: _Node) -> dict[str, Any] | None:
+        """DFS 生成 nav item + 旁路填充 entries-index / entry_payloads。"""
+        if not node.is_doc and not _has_doc_descendant(node):
+            return None  # 剪枝空容器
+
+        if node.is_doc:
+            eid = _entry_id(node.rel_path or node.slug)
+            did = _document_id(node.rel_path or node.slug)
+            raw_md = (docs_root / node.rel_path).read_text(encoding="utf-8", errors="replace")
+            md = rewrite_doc_links(raw_md, current_rel_path=node.rel_path or "", included_slugs=included_slugs, cfg=cfg)
+            entry_payloads[eid] = {
+                "entry_id": eid,
+                "document_id": did,
+                "entry_slug": node.slug,
+                "entry_title": node.title,
+                "markdown_content": md,
+                "document_filename": PurePosixPath(node.rel_path).name,
+                "author_name": None,
+                "author_url": None,
+                "source_url": _doc_source_url(node.rel_path),
+                "published_at": None,
+            }
+            entries_items.append(
+                {
+                    "id": eid,
+                    "document_id": did,
+                    "entry_slug": node.slug,
+                    "entry_title": node.title,
+                    "is_index_page": node.is_index,
+                }
+            )
+            slug_to_id[node.slug] = eid
+            entry_ids.append(eid)
+            return {
+                "entry_id": eid,
+                "entry_slug": node.slug,
+                "entry_title": node.title,
+                "entry_description": None,
+                "is_index_page": node.is_index,
+                "document_id": did,
+                "catalog_node_id": None,
+                "entry_kind": "DOCUMENT",
+                "children": [],
+            }
+
+        # 容器
+        cid = _container_id(node.slug)
+        entries_items.append(
+            {
+                "id": cid,
+                "document_id": None,
+                "entry_slug": node.slug,
+                "entry_title": node.title,
+                "is_index_page": False,
+            }
+        )
+        slug_to_id[node.slug] = cid
+        entry_ids.append(cid)
+        children_items: list[dict[str, Any]] = []
+        for child in _sort_children(node.children):
+            emitted = _emit(child)
+            if emitted is not None:
+                children_items.append(emitted)
+        return {
+            "entry_id": cid,
+            "entry_slug": node.slug,
+            "entry_title": node.title,
+            "entry_description": None,
+            "is_index_page": False,
+            "document_id": None,
+            "catalog_node_id": None,
+            "entry_kind": "CONTAINER",
+            "children": children_items,
+        }
+
+    nav_items: list[dict[str, Any]] = []
+    for top in _sort_children(root_children):
+        emitted = _emit(top)
+        if emitted is not None:
+            nav_items.append(emitted)
+
+    doc_count = len(entry_payloads)
+    publication = {
+        "id": pub_id,
+        "catalog_id": pub_id,  # 无 DB catalog：自指占位（字段非空契约）。
+        "app_name": pub_slug,
+        "publish_mode": "snapshot",
+        "name": cfg.reserved_name,
+        "slug": pub_slug,
+        "description": cfg.reserved_description,
+        "status": "published",
+        "theme": "docs",
+        "version": 1,
+        "published_at": None,
+        "created_at": None,
+        "updated_at": None,
+        "entries_count": doc_count,
+    }
+
+    return DocsPackFragment(
+        publication=publication,
+        nav_tree={"publication_id": pub_id, "nav_tree": {"items": nav_items}},
+        entries_index={"items": entries_items, "total": len(entries_items), "slug_to_id": slug_to_id},
+        entry_payloads=entry_payloads,
+        index_pub={
+            "id": pub_id,
+            "version": 1,
+            "entry_slug_to_id": slug_to_id,
+            "entry_ids": entry_ids,
+        },
+        pub_index_row={"slug": pub_slug, "id": pub_id, "version": 1},
+    )
+
+
+__all__ = [
+    "DocsPackFragment",
+    "build_docs_pack",
+    "doc_slug_for",
+    "resolve_docs_root",
+    "rewrite_doc_links",
+]

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_export_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_export_service.py
@@ -38,6 +38,7 @@ from negentropy.knowledge.lifecycle.wiki_dao import WikiDao
 from negentropy.logging import get_logger
 from negentropy.models.perception import WikiPublication
 
+from .wiki_docs_ingest import build_docs_pack
 from .wiki_graph_service import get_publication_graph
 from .wiki_service import build_entry_content_response
 
@@ -175,10 +176,39 @@ class WikiExportService:
                 "entry_ids": [str(e.id) for e in entries],
             }
 
-        # publications.json + index.json（复用主循环缓存的 publication 序列化结果）
+        # 保留一级目录「Negentropy」：把仓库 docs/ 公开子集合成为 reserved publication
+        # 注入同一内容包（DB pub 循环之后、聚合写盘之前；_reset 已清目录）。与 DB pub
+        # 走同一 _write_json / index 聚合，wiki 端零改动复用 schema 与页面路由。
+        docs_items: list[dict[str, Any]] = []
+        docs_cfg = settings.knowledge.wiki_docs_sync
+        if docs_cfg.enabled and docs_cfg.reserved_slug in {p.slug for p in pubs}:
+            # DB 已存在同名 slug 的 publication：让位 DB（避免双源覆盖），跳过 docs 合成。
+            logger.warning("wiki_export_docs_slug_conflict", slug=docs_cfg.reserved_slug)
+        elif docs_cfg.enabled:
+            frag = build_docs_pack(docs_cfg)
+            if frag is not None:
+                docs_dir = pubs_root / docs_cfg.reserved_slug
+                docs_dir.mkdir(parents=True, exist_ok=True)
+                self._write_json(docs_dir / "publication.json", frag.publication, result)
+                self._write_json(docs_dir / "nav-tree.json", frag.nav_tree, result)
+                self._write_json(docs_dir / "entries-index.json", frag.entries_index, result)
+                for eid, payload in frag.entry_payloads.items():
+                    self._write_json(entries_dir / f"{eid}.json", payload, result)
+                    result.entries += 1
+                pubs_index.append(frag.pub_index_row)
+                index_pubs[docs_cfg.reserved_slug] = frag.index_pub
+                docs_items.append(frag.publication)
+                result.publications.append(docs_cfg.reserved_slug)
+                logger.info(
+                    "wiki_export_docs_pack",
+                    slug=docs_cfg.reserved_slug,
+                    entries=len(frag.entry_payloads),
+                )
+
+        # publications.json + index.json（复用主循环缓存的 publication 序列化结果 + docs pack）
         pubs_payload = {
-            "items": [self._pub_cache[str(pub.id)] for pub in pubs],
-            "total": len(pubs),
+            "items": [self._pub_cache[str(pub.id)] for pub in pubs] + docs_items,
+            "total": len(pubs) + len(docs_items),
         }
         self._write_json(out_dir / "publications.json", pubs_payload, result)
         self._write_json(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_docs_ingest.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_docs_ingest.py
@@ -1,0 +1,209 @@
+"""``wiki_docs_ingest`` 单测：docs/ → 保留 Publication 合成（纯函数，无 DB）。
+
+覆盖：slug 派生 / 确定性 ID / 标题抽取 / 自然序 / nav-tree 形态（DOCUMENT 的
+document_id 与 entry_id 非空）/ 链接重写（站内 / GitHub / 图片 / 过度 ../ 钳制）/
+排除规则（.agents·i18n·*.zh.md·locale 目录）/ 空容器剪枝 / enabled=False。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from negentropy.config.knowledge import WikiDocsSyncSettings
+from negentropy.knowledge.lifecycle.wiki_docs_ingest import (
+    _container_id,
+    _document_id,
+    _entry_id,
+    build_docs_pack,
+    doc_slug_for,
+    resolve_docs_root,
+    rewrite_doc_links,
+)
+
+
+def _write(p: Path, text: str = "# 标题\n\n正文\n") -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture
+def docs_tree(tmp_path: Path) -> Path:
+    """构造最小但覆盖关键分支的假 docs/ 树。"""
+    docs = tmp_path / "docs"
+    _write(docs / "README.md", "# 根手册\n\n见 [Alpha](./concepts/010-alpha.md)。\n")
+    _write(docs / "concepts" / "010-alpha.md", "# Alpha\n")
+    _write(docs / "concepts" / "020a-beta.md", "# Beta\n")
+    _write(docs / "concepts" / "100-late.md", "# Late\n")
+    _write(docs / "concepts" / "user-guide" / "README.md", "# 用户指南\n")
+    _write(docs / "concepts" / "user-guide" / "quickstart.md", "# 快速上手\n")
+    _write(docs / "reference" / "cognizes" / "readme.md", "# Cognizes\n")
+    _write(docs / "reference" / "cognizes" / "guide.md", "# Guide\n")
+    _write(docs / "reference" / "cognizes" / "guide.zh.md", "# 指南（中文，应被排除）\n")
+    _write(docs / "reference" / "cognizes" / "zh-CN" / "localized.md", "# 本地化（应被排除）\n")
+    _write(docs / "concepts" / "empty-dir" / ".keep", "")  # 无 .md → 空容器应被剪枝
+    # 不在 include_dirs / 被 exclude_dirs 覆盖的目录：
+    _write(docs / ".agents" / "issue.md", "# 内部 Issue\n")
+    _write(docs / "i18n" / "zh-CN" / "x.md", "# i18n\n")
+    return docs
+
+
+def _cfg(docs: Path, **kw) -> WikiDocsSyncSettings:
+    return WikiDocsSyncSettings(docs_root=str(docs), **kw)
+
+
+# ---------------------------------------------------------------------------
+# slug / id / title
+# ---------------------------------------------------------------------------
+
+
+def test_doc_slug_for_rules():
+    assert doc_slug_for("README.md") == "readme"
+    assert doc_slug_for("concepts/user-guide/quickstart.md") == "concepts/user-guide/quickstart"
+    assert doc_slug_for("reference/cognizes/README.md") == "reference/cognizes/readme"
+    assert doc_slug_for("reference/cognizes/index.md") == "reference/cognizes/readme"
+    # 空格 / 大小写逐段 slugify
+    assert doc_slug_for("reference/cognizes/Context Engineering.md") == "reference/cognizes/context-engineering"
+
+
+def test_ids_deterministic_and_distinct():
+    # 同输入恒定（稳定 URL / 干净 diff）
+    assert _entry_id("a/b.md") == _entry_id("a/b.md")
+    assert _document_id("a/b.md") == _document_id("a/b.md")
+    assert _container_id("a") == _container_id("a")
+    # 三类前缀互不碰撞
+    assert len({_entry_id("a/b.md"), _document_id("a/b.md"), _container_id("a/b.md")}) == 3
+
+
+# ---------------------------------------------------------------------------
+# resolve_docs_root
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_docs_root_explicit_and_missing(tmp_path: Path, docs_tree: Path):
+    assert resolve_docs_root(_cfg(docs_tree)) == docs_tree
+    missing = WikiDocsSyncSettings(docs_root=str(tmp_path / "nope"))
+    assert resolve_docs_root(missing) is None
+
+
+# ---------------------------------------------------------------------------
+# build_docs_pack：结构 / 排除 / 剪枝 / 排序
+# ---------------------------------------------------------------------------
+
+
+def test_build_disabled_returns_none(docs_tree: Path):
+    assert build_docs_pack(_cfg(docs_tree, enabled=False)) is None
+
+
+def test_build_pack_structure_and_exclusions(docs_tree: Path):
+    frag = build_docs_pack(_cfg(docs_tree))
+    assert frag is not None
+    slugs = set(frag.entries_index["slug_to_id"])
+
+    # 顶层顺序：README 首位，其后 include_dirs 自然序。
+    top = [i["entry_slug"] for i in frag.nav_tree["nav_tree"]["items"]]
+    assert top[0] == "readme"
+    assert "concepts" in top and "reference" in top
+
+    # 纳入文档
+    assert "concepts/010-alpha" in slugs
+    assert "concepts/user-guide/quickstart" in slugs
+    assert "reference/cognizes/guide" in slugs
+
+    # 排除：*.zh.md / locale 目录 / 未纳入的 .agents·i18n
+    assert "reference/cognizes/guide.zh" not in slugs
+    assert not any("zh-cn" in s for s in slugs)
+    assert not any(s.startswith("agents") or s.startswith(".agents") for s in slugs)
+    assert not any(s.startswith("i18n") for s in slugs)
+
+    # 空容器剪枝：concepts/empty-dir 不应出现
+    assert "concepts/empty-dir" not in slugs
+
+
+def test_nav_document_carries_nonnull_ids(docs_tree: Path):
+    """关键约束：DOCUMENT 节点 document_id 与 entry_id 必须非空。"""
+    frag = build_docs_pack(_cfg(docs_tree))
+    assert frag is not None
+
+    def walk(items):
+        for it in items:
+            if it["entry_kind"] == "DOCUMENT":
+                assert it["entry_id"], it
+                assert it["document_id"] is not None, it
+            else:
+                assert it["document_id"] is None
+            walk(it.get("children", []))
+
+    walk(frag.nav_tree["nav_tree"]["items"])
+    # entries-index 中每个 DOCUMENT 条目都有对应 entry payload 且 document_id 非空
+    for e in frag.entries_index["items"]:
+        if e["document_id"] is not None:
+            assert e["id"] in frag.entry_payloads
+            assert frag.entry_payloads[e["id"]]["document_id"] is not None
+
+
+def test_natural_ordering_within_concepts(docs_tree: Path):
+    frag = build_docs_pack(_cfg(docs_tree))
+    assert frag is not None
+    concepts = next(i for i in frag.nav_tree["nav_tree"]["items"] if i["entry_slug"] == "concepts")
+    child_slugs = [c["entry_slug"] for c in concepts["children"] if c["entry_kind"] == "DOCUMENT"]
+    # 010 < 020a < 100（自然序，非字典序）
+    assert child_slugs == ["concepts/010-alpha", "concepts/020a-beta", "concepts/100-late"]
+
+
+def test_folder_readme_is_index_and_first(docs_tree: Path):
+    frag = build_docs_pack(_cfg(docs_tree))
+    assert frag is not None
+    concepts = next(i for i in frag.nav_tree["nav_tree"]["items"] if i["entry_slug"] == "concepts")
+    ug = next(c for c in concepts["children"] if c["entry_slug"] == "concepts/user-guide")
+    assert ug["entry_kind"] == "CONTAINER"
+    assert ug["children"][0]["entry_slug"] == "concepts/user-guide/readme"
+    assert ug["children"][0]["is_index_page"] is True
+
+
+def test_title_extraction_and_publication_fields(docs_tree: Path):
+    frag = build_docs_pack(_cfg(docs_tree))
+    assert frag is not None
+    readme_id = frag.entries_index["slug_to_id"]["readme"]
+    assert frag.entry_payloads[readme_id]["entry_title"] == "根手册"
+    assert frag.publication["slug"] == "negentropy"
+    assert frag.publication["status"] == "published"
+    assert frag.publication["entries_count"] == len(frag.entry_payloads)
+
+
+# ---------------------------------------------------------------------------
+# 链接重写（表驱动）
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_links_table():
+    cfg = WikiDocsSyncSettings()  # 默认 github_owner/repo/ref
+    included = {"concepts/framework", "concepts/user-guide/overview"}
+    cur = "concepts/035-the-knowledge-base.md"
+
+    cases = {
+        # 外链 / 纯锚点：原样
+        "[x](https://example.com)": "https://example.com",
+        "[x](#section)": "#section",
+        # 站内 .md（同级）→ /negentropy/<slug>，锚点保留
+        "[f](./framework.md#11-x)": "/negentropy/concepts/framework#11-x",
+        # 过度 ../ 的站内 .md → 钳制后仍命中站内
+        "[f](../../../concepts/framework.md)": "/negentropy/concepts/framework",
+        # 过度 ../ 的源码路径 → 钳制为仓库根 → GitHub blob
+        "[src](../../../../apps/negentropy/src/x.py)": (
+            "https://github.com/ThreeFish-AI/negentropy/blob/main/apps/negentropy/src/x.py"
+        ),
+        # docs 内但未纳入子集（.agents）→ GitHub blob
+        "[i](../.agents/issue.md)": ("https://github.com/ThreeFish-AI/negentropy/blob/main/docs/.agents/issue.md"),
+        # 图片 → GitHub raw
+        "![img](../assets/a.png)": "https://raw.githubusercontent.com/ThreeFish-AI/negentropy/main/docs/assets/a.png",
+    }
+    for src, expected_url in cases.items():
+        out = rewrite_doc_links(src, current_rel_path=cur, included_slugs=included, cfg=cfg)
+        assert expected_url in out, f"{src!r} -> {out!r}"
+
+    # 嵌套 [] 的链接文案（Next.js 动态段）仍被匹配重写
+    nested = "[`app/[id]/route.ts`](../../../../apps/x/app/[id]/route.ts)"
+    out = rewrite_doc_links(nested, current_rel_path=cur, included_slugs=included, cfg=cfg)
+    assert "github.com/ThreeFish-AI/negentropy/blob/main/apps/x/app/[id]/route.ts" in out

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_export_docs_pub.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_export_docs_pub.py
@@ -1,0 +1,137 @@
+"""WikiExportService 注入保留 docs Publication 的导出聚合单测。
+
+通过 monkeypatch ``WikiDao.list_publications`` 返回空 DB pub 列表，仅触发 docs-pack
+注入路径（无需真实 DB），断言：``publications.json`` / ``index.json`` 含 negentropy、
+各文件落盘、DB 同名 slug 冲突时跳过、两次导出对未变 docs 幂等。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from negentropy.knowledge.lifecycle.wiki_export_service import WikiExportService
+
+_MOD = "negentropy.knowledge.lifecycle.wiki_export_service"
+
+
+@pytest.fixture
+def docs_tree(tmp_path: Path) -> Path:
+    docs = tmp_path / "docs"
+    (docs / "concepts").mkdir(parents=True)
+    (docs / "README.md").write_text("# 根\n\n见 [A](./concepts/a.md)。\n", encoding="utf-8")
+    (docs / "concepts" / "a.md").write_text("# A\n", encoding="utf-8")
+    return docs
+
+
+def _patch_docs_cfg(docs_root: Path, *, enabled: bool = True):
+    """patch settings.knowledge.wiki_docs_sync 指向假 docs 树（保持其余默认）。"""
+    from negentropy.config.knowledge import WikiDocsSyncSettings
+
+    cfg = WikiDocsSyncSettings(docs_root=str(docs_root), enabled=enabled)
+    # settings 是 frozen，整体替换其 knowledge.wiki_docs_sync 取值用 SimpleNamespace 旁路。
+    from types import SimpleNamespace
+
+    fake_settings = SimpleNamespace(
+        knowledge=SimpleNamespace(
+            wiki_docs_sync=cfg,
+            wiki_export=SimpleNamespace(bake_assets=False, asset_base_url=None),
+        )
+    )
+    return patch(f"{_MOD}.settings", fake_settings)
+
+
+async def _export(out: Path) -> None:
+    svc = WikiExportService()
+    with patch(f"{_MOD}.WikiDao.list_publications", new=AsyncMock(return_value=([], 0))):
+        await svc.export_all_published(db=None, out_dir=out)
+
+
+@pytest.mark.asyncio
+async def test_docs_pub_injected_into_pack(tmp_path: Path, docs_tree: Path):
+    out = tmp_path / "content"
+    with _patch_docs_cfg(docs_tree):
+        await _export(out)
+
+    pubs = json.loads((out / "publications.json").read_text())
+    assert any(p["slug"] == "negentropy" for p in pubs["items"])
+    assert pubs["total"] == 1  # DB 空 + 1 个 docs pub
+
+    idx = json.loads((out / "index.json").read_text())
+    assert any(r["slug"] == "negentropy" for r in idx["publications"])
+    assert "negentropy" in idx["pubs"]
+
+    neg = out / "publications" / "negentropy"
+    for name in ("publication.json", "nav-tree.json", "entries-index.json"):
+        assert (neg / name).is_file()
+    # README + concepts/a → 2 篇文档 entry 文件
+    eindex = json.loads((neg / "entries-index.json").read_text())
+    doc_ids = [e["id"] for e in eindex["items"] if e["document_id"] is not None]
+    assert len(doc_ids) == 2
+    for did in doc_ids:
+        assert (out / "entries" / f"{did}.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_disabled_skips_docs_pub(tmp_path: Path, docs_tree: Path):
+    out = tmp_path / "content"
+    with _patch_docs_cfg(docs_tree, enabled=False):
+        await _export(out)
+    pubs = json.loads((out / "publications.json").read_text())
+    assert not any(p["slug"] == "negentropy" for p in pubs["items"])
+    assert not (out / "publications" / "negentropy").exists()
+
+
+@pytest.mark.asyncio
+async def test_db_slug_conflict_skips_docs(tmp_path: Path, docs_tree: Path):
+    """DB 已存在同名 slug 的 publication → 让位 DB，跳过 docs 合成。"""
+    out = tmp_path / "content"
+    from types import SimpleNamespace
+    from uuid import UUID
+
+    # WikiPublication 替身：覆盖 _serialize_publication 读取的全部字段。
+    db_pub = SimpleNamespace(
+        id=UUID("11111111-1111-4111-8111-111111111111"),
+        catalog_id=UUID("44444444-4444-4444-8444-444444444441"),
+        app_name="negentropy",
+        publish_mode="LIVE",
+        name="DB 占用 negentropy",
+        slug="negentropy",
+        description=None,
+        status="published",
+        theme="docs",
+        version=1,
+        published_at=None,
+        created_at=None,
+        updated_at=None,
+    )
+
+    svc = WikiExportService()
+    with _patch_docs_cfg(docs_tree):
+        with (
+            patch(f"{_MOD}.WikiDao.list_publications", new=AsyncMock(return_value=([db_pub], 1))),
+            patch(f"{_MOD}.WikiDao.get_entries", new=AsyncMock(return_value=[])),
+            patch(f"{_MOD}.WikiDao.get_nav_tree", new=AsyncMock(return_value=[])),
+            patch(f"{_MOD}.get_publication_graph", new=AsyncMock(return_value=None)),
+        ):
+            await svc.export_all_published(db=None, out_dir=out)
+
+    pubs = json.loads((out / "publications.json").read_text())
+    # 仅 DB pub（1 个），docs 合成被跳过（未额外注入第二个 negentropy）
+    assert [p["slug"] for p in pubs["items"]] == ["negentropy"]
+    assert pubs["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_across_exports(tmp_path: Path, docs_tree: Path):
+    out1, out2 = tmp_path / "c1", tmp_path / "c2"
+    with _patch_docs_cfg(docs_tree):
+        await _export(out1)
+        await _export(out2)
+    # 未变 docs → index.json 的 pubs（含确定性 entry_ids）逐字节一致。
+    i1 = json.loads((out1 / "index.json").read_text())["pubs"]["negentropy"]
+    i2 = json.loads((out2 / "index.json").read_text())["pubs"]["negentropy"]
+    assert i1 == i2


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`negentropy-wiki` 站点缺少承载主站仓库 `docs/` 工程文档的入口。需新增**系统保留一级目录「Negentropy」**，置于「Knowledge Graph」标签**左侧**，并在主站「Knowledge / Wiki」的「同步并发布」时自动同步 `docs/` 最新目录与内容。
- 关联上下文：wiki 为纯静态站，内容包由 `WikiExportService` 在 publish → `trigger_wiki_redeploy` → CI（完整 repo checkout）运行 `export_wiki_content.py` 时产出；本变更复用该链路，将 `docs/` 折叠进同一内容包，天然随「同步并发布」刷新。

# 核心变更
- **新增 `wiki_docs_ingest.py`**：纯函数遍历 `docs/` 公开子集（README + `concepts/` + `reference/` + `research/`，排除 `.agents/`、`i18n/`、`*.zh.md`、locale 目录），合成 slug=`negentropy` 的保留 Publication 内容包片段。确定性 UUIDv5（稳定 URL、干净 diff）、逐段 slugify、首个 H1 取标题、目录 `README` 领衔索引页、自然序排序、空容器剪枝；链接重写：相对 `.md`→站内 slug、源码/仓库路径→GitHub blob、图片→GitHub raw、外链与锚点保留、过度 `../` 钳制恢复作者意图、嵌套 `[]` 文案兼容、尽力而为不抛错。
- **`WikiExportService` 集成**：DB pub 循环后注入保留 pub，folds 入 `publications.json`/`index.json`；DB 同名 slug 优先（跳过 docs 合成）、`enabled` 开关、docs 无 KG 故不写 `graph.json`。
- **配置 `WikiDocsSyncSettings`**：include/exclude、`reserved_slug`、GitHub owner/repo/ref 等，与 `wiki_export` 正交。
- **前端**：`WikiHeader` 新增 `reservedTab` 渲染于 `--left` nav 首位（Knowledge Graph 左侧）；首页过滤右区保留 slug 并领衔卡片、graph 标签指向首个非保留 pub；`[pubSlug]` 三类路由透传 `reservedTab`、docs 页隐藏 graph 标签并高亮保留标签；`RESERVED_DOCS_*` 常量作单一事实源、以 pub 存在为前提自隐。
- **兜底**：`content.fixture/` 注入最小 `negentropy` pub，保 fresh-clone build-smoke 与 `/negentropy/*` 静态生成。

# 风险与回滚
- 主要风险：纯新增、正交于既有逻辑；最坏情况为保留目录内个别链接失效。`enabled=False` 可整体关闭；DB 同名 slug 自动让位，绝不覆盖既有 publication；无 DB 迁移、无破坏性变更。
- 回滚方式：revert 本 PR 单一 commit 即可。

# 验证证据
- 单元测试：后端新增 14（ingester/导出聚合）+ 既有 11（asset-rewrite）全过；前端 vitest 68 全过；ESLint 0 error。
- 集成测试：对**真实 `docs/`** 跑通——106 篇文档、1009 条链接全部解析（377 站内 / 627 GitHub / 5 raw）、两次导出 ID 确定性幂等。
- E2E：`next build`（fixture 兜底）成功生成 `/negentropy`、`/negentropy/graph` 及条目页。
- 关键核验：渲染产物首页头部顺序为 `['Negentropy', 'Knowledge Graph']`（Negentropy 在左）；`/negentropy/readme` 保留标签高亮且 graph 标签正确隐藏。

# 影响范围
- 前端：`negentropy-wiki` 头部、首页、`[pubSlug]` 三类路由 + 类型常量 + fixture + 测试。
- 后端：`negentropy` 新增 `wiki_docs_ingest` 模块、导出器集成、`WikiDocsSyncSettings` 配置 + 测试。
- GitHub Actions / 文档：无改动；复用既有 `wiki-content-export.yml` 导出链路。

# Next Best Action
- 合并后在生产部署侧确认导出器把含 `negentropy` 的 `content/` 烘焙进 wiki 镜像；如需，可另开任务核对 CI `wiki-content-export.yml` 对 gitignored `content/` 的 `git add`（既有行为，DB pub 亦受此影响）。
