### PR TITLE
feat(Wiki): 发布入口一体化 + 双目标发布（测试 / 生产）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Wiki 发布入口一体化 + 双目标发布**：`/knowledge/wiki` 工具栏的「从 Catalog 同步」「同步并发布」「仅发布」收敛为单一 **「发布」** 按钮（选 Catalog 节点 → 同步 → 发布），并新增**发布目标选择器**：
+  - **测试环境**：后端 spawn `scripts/build-wiki-local.sh`（导出 `content/` + `next build` 重建本地 `:3092`）。
+  - **生产环境**：spawn `scripts/publish-wiki-pages.sh` 推送到 [`threefish-ai.github.io`](https://github.com/ThreeFish-AI/threefish-ai.github.io) `master` 分支，直接更新 [https://threefish-ai.github.io/](https://threefish-ai.github.io/)；`gh auth token` 可用即零配置，生产目标经 destructive 二次确认（不可逆）。
+  - `POST /wiki/publications/{pub_id}/publish` 新增可选请求体 `{ target: "local" | "production" }`（缺省 `local`）；响应回填 `target` / `site_url`。
+
 ## [0.0.1](https://github.com/ThreeFish-AI/negentropy/releases/tag/v0.0.1) - 2026-06-19
 
 首个公开 MVP。立意于薛定谔「熵减」，Negentropy 不在于打造 Agent，而是构建持续自我进化的认知系统，直面当下 AI 助手的五大熵增痛点——**信息过载、金鱼记忆、浅尝辄止、纸上谈兵、晦涩难懂**，把混沌输入转化为有序、可落地的高价值输出。

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesList.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesList.tsx
@@ -44,7 +44,7 @@ function flattenNavTree(
 export function WikiEntriesList({
   navTree,
   loading,
-  emptyHint = "暂无条目，点击「从 Catalog 同步」拉取",
+  emptyHint = "暂无条目，点击「发布」拉取",
 }: WikiEntriesListProps) {
   const flat = useMemo(() => {
     const out: FlatItem[] = [];

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesPreview.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesPreview.tsx
@@ -20,7 +20,7 @@ interface WikiEntriesPreviewProps {
 }
 
 export interface WikiEntriesPreviewHandle {
-  /** 由父组件在「从 Catalog 同步」成功后调用，刷新导航树。 */
+  /** 由父组件在「发布」（同步）成功后调用，刷新导航树。 */
   refresh: () => void;
 }
 

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublishToolbar.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiPublishToolbar.tsx
@@ -14,16 +14,16 @@ import {
   syncWikiEntriesFromCatalog,
   unpublishWiki,
   type WikiPublication,
+  type WikiPublishTarget,
   type WikiRevalidationStatus,
 } from "@/features/knowledge";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
+import { cn } from "@/lib/utils";
 import { WikiStatusBadge } from "./WikiStatusBadge";
 import { CatalogNodeSelectorDialog } from "./CatalogNodeSelectorDialog";
 import { CreateWikiPublicationDialog } from "./CreateWikiPublicationDialog";
 import { WikiPublishPipeline } from "./WikiPublishPipeline";
-
-type SyncMode = "sync-only" | "sync-and-publish";
 
 interface WikiPublishToolbarProps {
   catalogId: string;
@@ -54,7 +54,9 @@ export function WikiPublishToolbar({
   const { confirm, confirmDialog } = useConfirmDialog();
   const [createOpen, setCreateOpen] = useState(false);
   const [selectorOpen, setSelectorOpen] = useState(false);
-  const [selectorMode, setSelectorMode] = useState<SyncMode>("sync-only");
+  // 发布目标：测试环境（本地 wiki :3092）/ 生产环境（threefish-ai.github.io master）。
+  // 默认测试环境（安全侧）：生产发布经 handleSyncConfirm 内 destructive 二次确认。
+  const [publishTarget, setPublishTarget] = useState<WikiPublishTarget>("local");
   const [submitting, setSubmitting] = useState(false);
   const [pipelineActive, setPipelineActive] = useState(false);
   const [pipelineRevalidation, setPipelineRevalidation] =
@@ -72,24 +74,6 @@ export function WikiPublishToolbar({
     setPipelineRevalidation(null);
     setPipelineTargetVersion(null);
   }, [pubId]);
-
-  const handlePublish = useCallback(async () => {
-    if (!pubId) return;
-    setSubmitting(true);
-    setPipelineActive(true);
-    try {
-      const resp = await publishWiki(pubId);
-      setPipelineRevalidation(resp.revalidation ?? null);
-      setPipelineTargetVersion(resp.version);
-      toast.success(`发布成功：v${resp.version}，${resp.entries_count} 个条目`);
-      onPublicationsChanged();
-    } catch (err) {
-      setPipelineActive(false);
-      toast.error(err instanceof Error ? err.message : "发布失败");
-    } finally {
-      setSubmitting(false);
-    }
-  }, [pubId, onPublicationsChanged]);
 
   const handleUnpublish = useCallback(async () => {
     if (!pubId) return;
@@ -141,6 +125,20 @@ export function WikiPublishToolbar({
   const handleSyncConfirm = useCallback(
     async (catalogNodeIds: string[]) => {
       if (!pubId) return;
+      // 先关闭节点选择器，避免与后续确认对话框堆叠。
+      setSelectorOpen(false);
+      // 生产环境为不可逆推送（直接更新 threefish-ai.github.io 生产站点），二次确认。
+      if (publishTarget === "production") {
+        const confirmed = await confirm({
+          title: "发布到生产环境",
+          message:
+            "将推送至 threefish-ai.github.io 的 master 分支，直接更新 https://threefish-ai.github.io/ 生产站点，操作不可逆。确认继续？",
+          confirmLabel: "确认发布到生产",
+          destructive: true,
+        });
+        if (!confirmed) return;
+      }
+      const targetLabel = publishTarget === "production" ? "生产环境" : "测试环境";
       setSubmitting(true);
       setPipelineActive(false);
       try {
@@ -156,25 +154,23 @@ export function WikiPublishToolbar({
         if (resp.errors.length > 0) {
           console.warn("[wiki sync] errors:", resp.errors);
         }
-        setSelectorOpen(false);
         onAfterSync?.();
-        if (selectorMode === "sync-and-publish") {
-          setPipelineActive(true);
-          const pubResp = await publishWiki(pubId);
-          setPipelineRevalidation(pubResp.revalidation ?? null);
-          setPipelineTargetVersion(pubResp.version);
-          toast.success(`发布成功：v${pubResp.version}`);
-        }
+        // 同步完成随即发布到所选目标（重建/推送由后端 fire-and-forget spawn 承担）。
+        setPipelineActive(true);
+        const pubResp = await publishWiki(pubId, publishTarget);
+        setPipelineRevalidation(pubResp.revalidation ?? null);
+        setPipelineTargetVersion(pubResp.version);
+        const sitePart = pubResp.site_url ? `，站点 ${pubResp.site_url}` : "";
+        toast.success(`发布成功：v${pubResp.version}（${targetLabel}${sitePart}）`);
         onPublicationsChanged();
       } catch (err) {
         setPipelineActive(false);
-        const msg = selectorMode === "sync-and-publish" ? "操作失败" : "同步失败";
-        toast.error(err instanceof Error ? err.message : msg);
+        toast.error(err instanceof Error ? err.message : "发布失败");
       } finally {
         setSubmitting(false);
       }
     },
-    [pubId, selectorMode, onAfterSync, onPublicationsChanged],
+    [pubId, publishTarget, confirm, onAfterSync, onPublicationsChanged],
   );
 
   return (
@@ -235,41 +231,57 @@ export function WikiPublishToolbar({
 
         {/* 操作按钮组 */}
         <div className="ml-auto flex flex-wrap items-center gap-2">
-          <button
-            onClick={() => {
-              setSelectorMode("sync-only");
-              setSelectorOpen(true);
-            }}
-            disabled={actionsDisabled}
-            className="px-3 py-1.5 text-sm rounded-md border border-border bg-background hover:bg-muted disabled:opacity-50"
+          {/* 发布目标：测试环境（本地 :3092）/ 生产环境（threefish-ai.github.io） */}
+          <div
+            role="group"
+            aria-label="选择发布目标"
+            className="flex items-center rounded-md border border-border overflow-hidden"
           >
-            从 Catalog 同步
-          </button>
+            <button
+              type="button"
+              onClick={() => setPublishTarget("local")}
+              disabled={actionsDisabled}
+              title="发布到本地 negentropy-wiki 测试站点（:3092）"
+              aria-pressed={publishTarget === "local"}
+              className={cn(
+                "px-2.5 py-1.5 text-xs disabled:opacity-50",
+                publishTarget === "local"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:bg-muted",
+              )}
+            >
+              测试环境
+            </button>
+            <button
+              type="button"
+              onClick={() => setPublishTarget("production")}
+              disabled={actionsDisabled}
+              title="发布到 threefish-ai.github.io master（生产站点）"
+              aria-pressed={publishTarget === "production"}
+              className={cn(
+                "px-2.5 py-1.5 text-xs border-l border-border disabled:opacity-50",
+                publishTarget === "production"
+                  ? "bg-amber-600 text-white"
+                  : "bg-background text-muted-foreground hover:bg-muted",
+              )}
+            >
+              生产环境
+            </button>
+          </div>
           <button
-            onClick={() => {
-              setSelectorMode("sync-and-publish");
-              setSelectorOpen(true);
-            }}
+            onClick={() => setSelectorOpen(true)}
             disabled={actionsDisabled}
             className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50"
           >
-            同步并发布
+            发布
           </button>
-          {isPublished ? (
+          {isPublished && (
             <button
               onClick={handleUnpublish}
               disabled={actionsDisabled}
               className="px-3 py-1.5 text-sm rounded-md border border-border text-muted-foreground hover:bg-muted disabled:opacity-50"
             >
               取消发布
-            </button>
-          ) : (
-            <button
-              onClick={handlePublish}
-              disabled={actionsDisabled}
-              className="px-3 py-1.5 text-sm rounded-md border border-emerald-500/30 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-900/20 dark:text-emerald-300 disabled:opacity-50"
-            >
-              仅发布
             </button>
           )}
           <button
@@ -305,14 +317,8 @@ export function WikiPublishToolbar({
           onClose={() => setSelectorOpen(false)}
           onConfirm={handleSyncConfirm}
           submitting={submitting}
-          confirmLabel={
-            selectorMode === "sync-and-publish" ? "同步并发布" : "确认同步"
-          }
-          title={
-            selectorMode === "sync-and-publish"
-              ? "选择同步源后直接发布"
-              : "选择要同步的 Catalog 节点"
-          }
+          confirmLabel="发布"
+          title="选择同步源后发布"
         />
       )}
       {confirmDialog}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -234,6 +234,7 @@ export type {
   WikiNavTreeItem,
   WikiNavTreeResponse,
   WikiPublishActionResponse,
+  WikiPublishTarget,
   WikiRevalidationStatus,
   SyncFromCatalogParams,
   SyncFromCatalogResponse,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -3104,6 +3104,14 @@ export interface WikiNavTreeResponse {
 
 export type WikiRevalidationStatus = "dispatched" | "failed" | "not_configured";
 
+/**
+ * Wiki 发布目标环境：
+ * - `local`（测试环境）：重建本地 negentropy-wiki 站点（:3092）。
+ * - `production`（生产环境）：推送到 threefish-ai.github.io master，
+ *   直接更新 https://threefish-ai.github.io/。
+ */
+export type WikiPublishTarget = "local" | "production";
+
 export interface WikiPublishActionResponse {
   publication_id: string;
   status: WikiPublicationStatus;
@@ -3112,6 +3120,10 @@ export interface WikiPublishActionResponse {
   entries_count: number;
   message: string;
   revalidation?: WikiRevalidationStatus;
+  /** 本次发布的目标环境（local/production） */
+  target?: WikiPublishTarget;
+  /** 上线站点 base URL（供「查看站点」跳转） */
+  site_url?: string | null;
 }
 
 export interface SyncFromCatalogParams {
@@ -3195,10 +3207,18 @@ export async function deleteWikiPublication(pubId: string): Promise<void> {
   if (!res.ok) throw new Error(`Failed to delete wiki publication: ${res.statusText}`);
 }
 
-/** 发布 Wiki（draft/published → published，递增版本号） */
-export async function publishWiki(pubId: string): Promise<WikiPublishActionResponse> {
+/**
+ * 发布 Wiki（draft/published → published，递增版本号）。
+ * @param target 发布目标环境，缺省 `local`（测试环境，安全侧默认）。
+ */
+export async function publishWiki(
+  pubId: string,
+  target: WikiPublishTarget = "local",
+): Promise<WikiPublishActionResponse> {
   const res = await fetch(`/api/knowledge/wiki/publications/${pubId}/publish`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ target }),
   });
   if (!res.ok) throw new Error(`Failed to publish wiki: ${res.statusText}`);
   return res.json();

--- a/apps/negentropy-ui/tests/unit/knowledge/WikiPublishToolbar.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/WikiPublishToolbar.test.tsx
@@ -1,13 +1,17 @@
 /**
  * WikiPublishToolbar 行为契约测试
  *
- * 锁定 PR「Wiki 模块：发布入口一体化」中的关键契约：
- *   1. 无发布对象 / 加载中 → 操作按钮全部 disabled；
- *   2. selectedPub.status === "published" 时显示「取消发布」，否则显示「仅发布」；
- *   3. 点「仅发布」→ publishWiki 被调用并 toast 成功；
- *   4. 点「取消发布」→ confirm 通过后 unpublishWiki 被调用；
- *   5. 点「删除」→ confirm 通过后 deleteWikiPublication + onPublicationDeleted；
- *   6. 「从 Catalog 同步」与「同步并发布」按钮存在，且 syncWikiEntriesFromCatalog 通过对话框 onConfirm 流入。
+ * 锁定「Wiki 发布入口一体化 + 双目标发布」PR 的关键契约：
+ *   1. 无发布对象 / 加载中 → 操作按钮（发布 / 删除 / 目标选择器）全部 disabled；
+ *   2. 目标选择器恒显（测试环境 / 生产环境）；draft 与 published 均显示「发布」，
+ *      额外仅 published 显示「取消发布」；
+ *   3. 默认测试环境：点「发布」→ 节点选择器确认后先 syncWikiEntriesFromCatalog
+ *      再 publishWiki(pubId, "local")，不触发生产确认；
+ *   4. 选「生产环境」+ 发布：节点确认后经 destructive confirm 二次确认，
+ *      通过后 publishWiki(pubId, "production")；
+ *   5. 生产确认被拒：不 sync 不 publish；
+ *   6. 点「取消发布」→ confirm 通过后 unpublishWiki 被调用；
+ *   7. 点「删除」→ confirm 通过后 deleteWikiPublication + onPublicationDeleted。
  */
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -15,6 +19,10 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { WikiPublishToolbar } from "@/app/knowledge/wiki/_components/WikiPublishToolbar";
 import type { WikiPublication } from "@/features/knowledge";
+
+// useConfirmDialog 的 confirm 抽出为模块级 mock，便于按用例控制确认结果。
+// 变量名须以 mock 开头（vitest vi.mock 提升规则）。
+const mockConfirm = vi.fn().mockResolvedValue(true);
 
 vi.mock("@/features/knowledge", () => ({
   publishWiki: vi.fn(),
@@ -27,10 +35,9 @@ vi.mock("@/lib/activity-toast", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-// 简化 confirm dialog：默认始终确认。
 vi.mock("@/components/ui/useConfirmDialog", () => ({
   useConfirmDialog: () => ({
-    confirm: vi.fn().mockResolvedValue(true),
+    confirm: mockConfirm,
     confirmDialog: null,
   }),
 }));
@@ -84,6 +91,7 @@ import {
 const draftPub: WikiPublication = {
   id: "pub-1",
   catalog_id: "cat-1",
+  app_name: "negentropy",
   name: "Demo Wiki",
   slug: "demo",
   description: null,
@@ -91,7 +99,7 @@ const draftPub: WikiPublication = {
   status: "draft",
   version: 1,
   entries_count: 3,
-  publish_mode: "LIVE",
+  publish_mode: "live",
   created_at: "",
   updated_at: "",
   published_at: null,
@@ -115,10 +123,14 @@ const baseHandlers = {
 describe("WikiPublishToolbar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockConfirm.mockReset();
+    mockConfirm.mockResolvedValue(true);
     vi.mocked(publishWiki).mockResolvedValue({
       version: 2,
       entries_count: 3,
       revalidation: "dispatched",
+      target: "local",
+      site_url: "http://localhost:3092",
     } as never);
     vi.mocked(unpublishWiki).mockResolvedValue({
       version: 2,
@@ -143,13 +155,13 @@ describe("WikiPublishToolbar", () => {
         {...baseHandlers}
       />,
     );
-    expect(screen.getByText("从 Catalog 同步").closest("button")).toBeDisabled();
-    expect(screen.getByText("同步并发布").closest("button")).toBeDisabled();
-    expect(screen.getByText("仅发布").closest("button")).toBeDisabled();
+    expect(screen.getByText("发布").closest("button")).toBeDisabled();
     expect(screen.getByText("删除").closest("button")).toBeDisabled();
+    expect(screen.getByText("测试环境").closest("button")).toBeDisabled();
+    expect(screen.getByText("生产环境").closest("button")).toBeDisabled();
   });
 
-  it("draft 状态显示「仅发布」，published 状态显示「取消发布」", () => {
+  it("draft 与 published 均显示「发布」+目标选择器；仅 published 额外显示「取消发布」", () => {
     const { rerender } = render(
       <WikiPublishToolbar
         catalogId="cat-1"
@@ -160,7 +172,9 @@ describe("WikiPublishToolbar", () => {
         {...baseHandlers}
       />,
     );
-    expect(screen.getByText("仅发布")).toBeInTheDocument();
+    expect(screen.getByText("发布")).toBeInTheDocument();
+    expect(screen.getByText("测试环境")).toBeInTheDocument();
+    expect(screen.getByText("生产环境")).toBeInTheDocument();
     expect(screen.queryByText("取消发布")).not.toBeInTheDocument();
 
     rerender(
@@ -173,11 +187,11 @@ describe("WikiPublishToolbar", () => {
         {...baseHandlers}
       />,
     );
+    expect(screen.getByText("发布")).toBeInTheDocument();
     expect(screen.getByText("取消发布")).toBeInTheDocument();
-    expect(screen.queryByText("仅发布")).not.toBeInTheDocument();
   });
 
-  it("点「仅发布」调用 publishWiki(pubId) 并触发 onPublicationsChanged", async () => {
+  it("默认测试环境：点「发布」→ 选节点确认后先同步再 publishWiki(pubId,'local')，不触发生产确认", async () => {
     render(
       <WikiPublishToolbar
         catalogId="cat-1"
@@ -188,11 +202,72 @@ describe("WikiPublishToolbar", () => {
         {...baseHandlers}
       />,
     );
-    fireEvent.click(screen.getByText("仅发布"));
+    fireEvent.click(screen.getByText("发布"));
+    expect(await screen.findByTestId("mock-selector")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("mock-selector-confirm"));
     await waitFor(() => {
-      expect(publishWiki).toHaveBeenCalledWith(draftPub.id);
+      expect(syncWikiEntriesFromCatalog).toHaveBeenCalledWith(draftPub.id, {
+        catalog_node_ids: ["node-1"],
+      });
     });
-    expect(baseHandlers.onPublicationsChanged).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(publishWiki).toHaveBeenCalledWith(draftPub.id, "local");
+    });
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(baseHandlers.onAfterSync).toHaveBeenCalled();
+  });
+
+  it("选「生产环境」+ 发布：节点确认后经 destructive confirm，通过后 publishWiki(pubId,'production')", async () => {
+    render(
+      <WikiPublishToolbar
+        catalogId="cat-1"
+        publications={[draftPub]}
+        selectedPub={draftPub}
+        selectedId={draftPub.id}
+        publicationsLoading={false}
+        {...baseHandlers}
+      />,
+    );
+    fireEvent.click(screen.getByText("生产环境"));
+    fireEvent.click(screen.getByText("发布"));
+    await screen.findByTestId("mock-selector");
+
+    fireEvent.click(screen.getByTestId("mock-selector-confirm"));
+    await waitFor(() => {
+      expect(mockConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "发布到生产环境", destructive: true }),
+    );
+    await waitFor(() => {
+      expect(syncWikiEntriesFromCatalog).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(publishWiki).toHaveBeenCalledWith(draftPub.id, "production");
+    });
+  });
+
+  it("生产确认被拒时不 sync 不 publish", async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+    render(
+      <WikiPublishToolbar
+        catalogId="cat-1"
+        publications={[draftPub]}
+        selectedPub={draftPub}
+        selectedId={draftPub.id}
+        publicationsLoading={false}
+        {...baseHandlers}
+      />,
+    );
+    fireEvent.click(screen.getByText("生产环境"));
+    fireEvent.click(screen.getByText("发布"));
+    fireEvent.click(await screen.findByTestId("mock-selector-confirm"));
+    await waitFor(() => {
+      expect(mockConfirm).toHaveBeenCalledTimes(1);
+    });
+    expect(syncWikiEntriesFromCatalog).not.toHaveBeenCalled();
+    expect(publishWiki).not.toHaveBeenCalled();
   });
 
   it("点「取消发布」确认后调用 unpublishWiki", async () => {
@@ -228,51 +303,5 @@ describe("WikiPublishToolbar", () => {
       expect(deleteWikiPublication).toHaveBeenCalledWith(draftPub.id);
     });
     expect(baseHandlers.onPublicationDeleted).toHaveBeenCalled();
-  });
-
-  it("「同步并发布」打开选择器；选择器确认后先同步再发布", async () => {
-    render(
-      <WikiPublishToolbar
-        catalogId="cat-1"
-        publications={[draftPub]}
-        selectedPub={draftPub}
-        selectedId={draftPub.id}
-        publicationsLoading={false}
-        {...baseHandlers}
-      />,
-    );
-    fireEvent.click(screen.getByText("同步并发布"));
-    // 选择器以「同步并发布」确认文案展开
-    expect(await screen.findByTestId("mock-selector")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("mock-selector-confirm"));
-    await waitFor(() => {
-      expect(syncWikiEntriesFromCatalog).toHaveBeenCalledWith(draftPub.id, {
-        catalog_node_ids: ["node-1"],
-      });
-    });
-    await waitFor(() => {
-      expect(publishWiki).toHaveBeenCalledWith(draftPub.id);
-    });
-    expect(baseHandlers.onAfterSync).toHaveBeenCalled();
-  });
-
-  it("「从 Catalog 同步」仅同步不发布", async () => {
-    render(
-      <WikiPublishToolbar
-        catalogId="cat-1"
-        publications={[draftPub]}
-        selectedPub={draftPub}
-        selectedId={draftPub.id}
-        publicationsLoading={false}
-        {...baseHandlers}
-      />,
-    );
-    fireEvent.click(screen.getByText("从 Catalog 同步"));
-    fireEvent.click(await screen.findByTestId("mock-selector-confirm"));
-    await waitFor(() => {
-      expect(syncWikiEntriesFromCatalog).toHaveBeenCalled();
-    });
-    expect(publishWiki).not.toHaveBeenCalled();
   });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/wiki-nav-tree.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/wiki-nav-tree.test.tsx
@@ -131,7 +131,7 @@ describe("WikiEntriesList 渲染", () => {
   it("空数组渲染默认 emptyHint 文案", () => {
     render(<WikiEntriesList navTree={[]} loading={false} />);
     expect(
-      screen.getByText("暂无条目，点击「从 Catalog 同步」拉取"),
+      screen.getByText("暂无条目，点击「发布」拉取"),
     ).toBeInTheDocument();
   });
 });

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -236,11 +236,18 @@ class WikiPagesPublishSettings(BaseModel):
 
     **默认 ``enabled=False``** —— 不影响生产与现有 publish 流程；仅本地显式开启。
     spawn 为 fire-and-forget（不阻塞 publish 返回、失败仅 WARN）。
+
+    注：新「发布」入口以显式 ``target=production`` 触发 ``_spawn_pages_publish``，
+    不再受 ``enabled`` 门控（目标即授权）；``enabled`` 保留为遗留自动发布开关，
+    供未接入新 UI 的旧流程兼容。
     """
 
     enabled: bool = Field(
         default=False,
-        description="True 时 publish 后后台 spawn script 自动发布到 Pages；默认关闭。",
+        description=(
+            "遗留自动发布开关：True 时任意 publish 后后台 spawn script 推送到 Pages。"
+            "新「发布」入口以显式 target=production 触发，不再读取本字段。默认关闭。"
+        ),
     )
     script: str = Field(
         default="scripts/publish-wiki-pages.sh",

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -17,7 +17,10 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from negentropy.knowledge.lifecycle_schemas import WikiEntryContentResponse
+from negentropy.knowledge.lifecycle_schemas import (
+    WikiEntryContentResponse,
+    WikiPublishTarget,
+)
 from negentropy.logging import get_logger
 from negentropy.models.perception import WikiPublication, WikiPublicationEntry
 
@@ -28,43 +31,39 @@ from .wiki_redeploy import trigger_wiki_redeploy
 logger = get_logger(__name__.rsplit(".", 1)[0])
 
 
-def _maybe_spawn_pages_publish() -> None:
-    """本地场景：publish 后后台 spawn 脚本自动发布 Wiki 到 GitHub Pages。
+def _spawn_wiki_deploy_script(
+    script_relpath: str,
+    *,
+    env_overrides: dict[str, str] | None = None,
+    spawn_log_key: str,
+) -> None:
+    """fire-and-forget spawn 一个相对仓库根的 wiki 部署脚本。
 
-    仅当 ``settings.knowledge.wiki_pages_publish.enabled`` 显式开启时执行
-    （默认关闭，不影响生产与现有 publish 流程）。fire-and-forget：
-    ``subprocess.Popen`` 不阻塞 publish 返回；任何异常仅 WARN，绝不冒泡。
+    ``subprocess.Popen`` 脱离请求生命周期后台运行；任何异常仅 WARN，绝不冒泡
+    （``next build`` / git push 耗时且非事务性，不阻塞 publish 返回）。
+    脚本路径为固定内部相对值（``script_relpath`` 不拼接外部输入），env 仅透传
+    受信配置。
 
-    与 ``trigger_wiki_redeploy``（webhook → 云端 CI）正交：本地用 spawn、
-    分域/云端用 webhook。脚本路径来自配置（固定相对仓库根，不拼接外部输入）。
+    与 ``trigger_wiki_redeploy``（webhook → 云端 CI）正交：本地 spawn 用本函数、
+    分域/云端用 webhook。
     """
-    from negentropy.config import settings
-
-    cfg = settings.knowledge.wiki_pages_publish
-    if not cfg.enabled:
-        return
     try:
         import subprocess
         from pathlib import Path
 
         # 仓库根：本文件位于 apps/negentropy/src/negentropy/knowledge/lifecycle/。
         repo_root = Path(__file__).resolve().parents[6]
-        script_path = (repo_root / cfg.script).resolve()
+        script_path = (repo_root / script_relpath).resolve()
         if not script_path.is_file():
-            logger.warning("wiki_pages_publish_script_missing", script=str(script_path))
+            logger.warning("wiki_deploy_script_missing", script=str(script_path))
             return
 
         env = dict(os.environ)
-        if cfg.repo:
-            env["WIKI_PAGES_REPO"] = cfg.repo
-        env["WIKI_PAGES_BRANCH"] = cfg.branch
-        if cfg.token is not None:
-            token_value = cfg.token.get_secret_value()
-            if token_value:
-                env["WIKI_PAGES_TOKEN"] = token_value
+        if env_overrides:
+            env.update(env_overrides)
 
         # fire-and-forget：脱离请求生命周期后台运行；输出交由脚本自身/系统日志。
-        subprocess.Popen(  # noqa: S603 - 固定脚本路径，env 不拼接外部输入
+        subprocess.Popen(  # noqa: S603 - 固定脚本路径，env 仅透传受信配置
             ["bash", str(script_path)],
             cwd=str(repo_root),
             env=env,
@@ -72,9 +71,49 @@ def _maybe_spawn_pages_publish() -> None:
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
-        logger.info("wiki_pages_publish_spawned", script=str(script_path), branch=cfg.branch)
+        logger.info(spawn_log_key, script=str(script_path))
     except Exception as exc:  # noqa: BLE001 - 主动吞噬：spawn 失败不阻塞发布
-        logger.warning("wiki_pages_publish_spawn_failed", error=str(exc))
+        logger.warning(f"{spawn_log_key}_failed", error=str(exc))
+
+
+def _spawn_pages_publish() -> None:
+    """生产目标：spawn ``publish-wiki-pages.sh``。
+
+    全链路「导出（烘焙图片）→ next build → rsync → git push 到
+    ``threefish-ai.github.io`` master」，直接更新 https://threefish-ai.github.io/。
+    目标仓库/分支/token 由 ``wiki_pages_publish`` 配置可选覆盖；缺省时脚本回退
+    ``gh auth token`` / SSH 凭证。fire-and-forget（由 ``publish(target=PRODUCTION)``
+    显式触发）。
+    """
+    from negentropy.config import settings
+
+    cfg = settings.knowledge.wiki_pages_publish
+    env_overrides: dict[str, str] = {"WIKI_PAGES_BRANCH": cfg.branch}
+    if cfg.repo:
+        env_overrides["WIKI_PAGES_REPO"] = cfg.repo
+    if cfg.token is not None:
+        token_value = cfg.token.get_secret_value()
+        if token_value:
+            env_overrides["WIKI_PAGES_TOKEN"] = token_value
+    _spawn_wiki_deploy_script(
+        cfg.script,
+        env_overrides=env_overrides,
+        spawn_log_key="wiki_pages_publish_spawned",
+    )
+
+
+def _spawn_local_wiki_rebuild() -> None:
+    """本地目标：spawn ``build-wiki-local.sh``。
+
+    「导出 ``content/`` → ``next build`` 重建 ``apps/negentropy-wiki/out/``」，
+    重建后由本地 wiki（``:3092``）serve 新产物（测试环境）。
+    fire-and-forget（由 ``publish(target=LOCAL)`` 触发，默认目标）。
+    """
+    _spawn_wiki_deploy_script(
+        "scripts/build-wiki-local.sh",
+        env_overrides=None,
+        spawn_log_key="wiki_local_rebuild_spawned",
+    )
 
 
 # 合法主题列表
@@ -246,11 +285,22 @@ class WikiPublishingService:
     # 发布操作 (状态流转)
     # ------------------------------------------------------------------
 
-    async def publish(self, db: AsyncSession, pub_id: UUID) -> tuple[WikiPublication | None, str]:
+    async def publish(
+        self,
+        db: AsyncSession,
+        pub_id: UUID,
+        *,
+        target: WikiPublishTarget = WikiPublishTarget.LOCAL,
+    ) -> tuple[WikiPublication | None, str]:
         """触发发布：draft/published → published，递增版本号。
 
         - ``publish_mode == 'SNAPSHOT'``：同步冻结 entries 到 snapshots 表。
-        - 配置了 ``wiki_revalidate.url``：异步通知 SSG 主动 ISR revalidate（失败仅 WARN）。
+        - 始终触发 ``trigger_wiki_redeploy``（webhook → 云端 CI；本地未配置即 no-op，
+          保留云端部署回溯兼容）。
+        - 按 ``target`` fire-and-forget spawn 部署脚本（不阻塞 publish 返回）：
+          - ``LOCAL``：重建本地 wiki（``build-wiki-local.sh``，测试环境）。
+          - ``PRODUCTION``：推送到 ``threefish-ai.github.io`` master
+            （``publish-wiki-pages.sh``，生产环境）。
 
         Returns:
             ``(publication, revalidation_status)`` — revalidation_status 为
@@ -274,8 +324,12 @@ class WikiPublishingService:
                 app_name=pub.app_name,
                 event="publish",
             )
-            # 本地自动发布到 GitHub Pages（默认关闭；fire-and-forget，不阻塞）。
-            _maybe_spawn_pages_publish()
+            # 目标路由 spawn（fire-and-forget）：显式目标即授权，不再受
+            # wiki_pages_publish.enabled 门控。
+            if target == WikiPublishTarget.PRODUCTION:
+                _spawn_pages_publish()
+            else:
+                _spawn_local_wiki_rebuild()
 
         return pub, revalidation
 

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle_schemas.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from typing import Any
 from uuid import UUID
 
@@ -297,6 +298,36 @@ class WikiNavTreeResponse(BaseModel):
     nav_tree: dict[str, Any]  # 嵌套树结构
 
 
+class WikiPublishTarget(str, Enum):
+    """Wiki 发布目标环境。
+
+    - ``LOCAL``：测试环境，导出 ``content/`` + ``next build`` 重建本地
+      ``apps/negentropy-wiki/out/``，由本地 wiki（``:3092``）serve。
+    - ``PRODUCTION``：生产环境，执行 ``publish-wiki-pages.sh`` 全链路
+      （导出烘焙 + ``next build`` + rsync + git push 到 ``threefish-ai.github.io``
+      ``master``），直接更新 https://threefish-ai.github.io/。
+    """
+
+    LOCAL = "local"
+    PRODUCTION = "production"
+
+
+# 发布目标 → 上线后站点 base URL（供前端「查看站点」跳转）。
+WIKI_PUBLISH_TARGET_SITE_URL: dict[WikiPublishTarget, str] = {
+    WikiPublishTarget.LOCAL: "http://localhost:3092",
+    WikiPublishTarget.PRODUCTION: "https://threefish-ai.github.io",
+}
+
+
+class WikiPublishRequest(BaseModel):
+    """发布请求体。
+
+    ``target`` 缺省为 ``local``（安全侧默认：不触碰生产站点）。
+    """
+
+    target: WikiPublishTarget = WikiPublishTarget.LOCAL
+
+
 class WikiPublishActionResponse(BaseModel):
     """发布操作响应"""
 
@@ -307,6 +338,9 @@ class WikiPublishActionResponse(BaseModel):
     entries_count: int
     message: str
     revalidation: str = "not_configured"  # Literal["dispatched", "failed", "not_configured"]
+    # 本次发布的目标环境（local/production）与上线站点 URL（供前端「查看站点」）。
+    target: str = WikiPublishTarget.LOCAL.value
+    site_url: str | None = None
 
 
 class SyncFromCatalogRequest(BaseModel):

--- a/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/wiki.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 # Lifecycle schema imports
 from negentropy.knowledge.lifecycle_schemas import (  # noqa: F401
+    WIKI_PUBLISH_TARGET_SITE_URL,
     AssignDocumentRequest,
     CatalogTreeResponse,
     CategorySuggestionResponse,
@@ -44,6 +45,7 @@ from negentropy.knowledge.lifecycle_schemas import (  # noqa: F401
     WikiEntryContentResponse,
     WikiNavTreeResponse,
     WikiPublishActionResponse,
+    WikiPublishRequest,
 )
 from negentropy.knowledge.lifecycle_schemas import SyncFromCatalogRequest as _SyncFromCatalogReq
 from negentropy.knowledge.lifecycle_schemas import SyncFromCatalogResponse as _SyncFromCatalogResp
@@ -288,17 +290,26 @@ async def delete_wiki_publication(pub_id: UUID):
 
 
 @router.post("/wiki/publications/{pub_id}/publish")
-async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
+async def publish_wiki(
+    pub_id: UUID,
+    body: WikiPublishRequest | None = None,
+) -> WikiPublishActionResponse:
     """触发发布：将 draft/published 状态转为 published，递增版本号
 
-    SSG 应用 (apps/negentropy-wiki) 在 ISR 再验证窗口内会自动拉取最新数据。
-    响应中的 revalidation 字段反映 ISR 主动通知的状态。
+    请求体 ``target`` 指定发布目标：
+      - ``local``（缺省，测试环境）：重建本地 wiki（``:3092``）。
+      - ``production``（生产环境）：推送到 ``threefish-ai.github.io`` master，
+        直接更新 https://threefish-ai.github.io/。
+
+    响应中的 ``revalidation`` 反映 webhook 派发状态；``target`` / ``site_url``
+    回填本次目标与上线站点 URL。
     """
+    target = (body or WikiPublishRequest()).target
     wiki_svc = _get_wiki_service()
 
     async with AsyncSessionLocal() as db:
         try:
-            pub, revalidation_status = await wiki_svc.publish(db, pub_id)
+            pub, revalidation_status = await wiki_svc.publish(db, pub_id, target=target)
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
@@ -308,7 +319,7 @@ async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         doc_count = await wiki_svc.count_document_entries(db, pub_id)
         await db.commit()
 
-    logger.info("api_publish_wiki", pub_id=str(pub_id), version=pub.version)
+    logger.info("api_publish_wiki", pub_id=str(pub_id), version=pub.version, target=target.value)
 
     return WikiPublishActionResponse(
         publication_id=pub.id,
@@ -318,6 +329,8 @@ async def publish_wiki(pub_id: UUID) -> WikiPublishActionResponse:
         entries_count=doc_count,
         message=f"Published successfully (v{pub.version})",
         revalidation=revalidation_status,
+        target=target.value,
+        site_url=WIKI_PUBLISH_TARGET_SITE_URL.get(target),
     )
 
 

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_service_unit.py
@@ -17,6 +17,11 @@ import pytest
 import sqlalchemy.orm
 
 from negentropy.knowledge.lifecycle.wiki_service import WikiPublishingService
+from negentropy.knowledge.lifecycle_schemas import (
+    WIKI_PUBLISH_TARGET_SITE_URL,
+    WikiPublishActionResponse,
+    WikiPublishTarget,
+)
 
 # ---------------------------------------------------------------------------
 # 修复 KnowledgeDocument <-> DocSource 双向 FK 的 AmbiguousForeignKeysError
@@ -167,6 +172,159 @@ class TestWikiDelegationMethods:
         session = _FakeAsyncSession()
         result = await service.delete_publication(session, pub_id=uuid4())
         assert result is False  # FakeAsyncSession.execute 返回 None → 删除失败
+
+
+# ---------------------------------------------------------------------------
+# publish(target=...) 双目标路由
+# ---------------------------------------------------------------------------
+
+
+def _fake_published_pub() -> SimpleNamespace:
+    """publish() 内部访问的最小 pub 形状（LIVE 模式，跳过 _freeze_snapshot）。"""
+    return SimpleNamespace(
+        id=uuid4(),
+        slug="demo",
+        app_name="negentropy",
+        publish_mode="LIVE",
+    )
+
+
+class TestWikiPublishTargetRouting:
+    """publish(target=...) 按目标路由 fire-and-forget spawn 部署脚本。
+
+    锁定「双目标发布」契约：
+      - 缺省 / ``LOCAL`` → ``_spawn_local_wiki_rebuild``（测试环境，:3092）。
+      - ``PRODUCTION`` → ``_spawn_pages_publish``（生产 threefish-ai.github.io master）。
+    """
+
+    async def _publish_with_target(
+        self,
+        monkeypatch,
+        *,
+        target: WikiPublishTarget | None,
+        spawned: list[str],
+    ) -> None:
+        service = WikiPublishingService()
+        session = _FakeAsyncSession()
+        fake_pub = _fake_published_pub()
+
+        async def fake_dao_publish(db, pub_id):
+            _ = (db, pub_id)
+            return fake_pub
+
+        async def fake_redeploy(**kwargs):
+            _ = kwargs
+            return "dispatched"
+
+        monkeypatch.setattr("negentropy.knowledge.lifecycle.wiki_service.WikiDao.publish", fake_dao_publish)
+        monkeypatch.setattr("negentropy.knowledge.lifecycle.wiki_service.trigger_wiki_redeploy", fake_redeploy)
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service._spawn_local_wiki_rebuild",
+            lambda: spawned.append("local"),
+        )
+        monkeypatch.setattr(
+            "negentropy.knowledge.lifecycle.wiki_service._spawn_pages_publish",
+            lambda: spawned.append("production"),
+        )
+
+        kwargs: dict[str, object] = {}
+        if target is not None:
+            kwargs["target"] = target
+        pub, revalidation = await service.publish(session, pub_id=fake_pub.id, **kwargs)
+        assert pub is fake_pub
+        assert revalidation == "dispatched"
+
+    @pytest.mark.asyncio
+    async def test_default_target_routes_to_local_rebuild(self, monkeypatch):
+        spawned: list[str] = []
+        await self._publish_with_target(monkeypatch, target=None, spawned=spawned)
+        assert spawned == ["local"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_local_target_routes_to_local_rebuild(self, monkeypatch):
+        spawned: list[str] = []
+        await self._publish_with_target(monkeypatch, target=WikiPublishTarget.LOCAL, spawned=spawned)
+        assert spawned == ["local"]
+
+    @pytest.mark.asyncio
+    async def test_production_target_routes_to_pages_publish(self, monkeypatch):
+        spawned: list[str] = []
+        await self._publish_with_target(monkeypatch, target=WikiPublishTarget.PRODUCTION, spawned=spawned)
+        assert spawned == ["production"]
+
+
+class TestWikiPublishDeploySpawn:
+    """``_spawn_wiki_deploy_script`` 的脚本解析与 Popen 派发（不实际执行脚本）。"""
+
+    def test_invokes_bash_with_resolved_script(self, monkeypatch):
+        captured: dict[str, object] = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured["cwd"] = kwargs.get("cwd")
+                captured["start_new_session"] = kwargs.get("start_new_session")
+
+        # _spawn_wiki_deploy_script 内部 `import subprocess` 后调用 subprocess.Popen，
+        # 直接 patch subprocess 模块属性即可生效。
+        import negentropy.knowledge.lifecycle.wiki_service as svc
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        svc._spawn_wiki_deploy_script(
+            "scripts/build-wiki-local.sh",
+            spawn_log_key="wiki_local_rebuild_spawned",
+        )
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "bash"
+        assert str(cmd[1]).endswith("scripts/build-wiki-local.sh")
+        assert captured["start_new_session"] is True
+
+    def test_missing_script_skips_popen(self, monkeypatch):
+        popen_called: list[bool] = []
+
+        class _FakePopen:
+            def __init__(self, *a, **k):
+                popen_called.append(True)
+
+        import negentropy.knowledge.lifecycle.wiki_service as svc
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        svc._spawn_wiki_deploy_script(
+            "scripts/__definitely_missing__.sh",
+            spawn_log_key="wiki_missing_spawned",
+        )
+        assert popen_called == []  # 脚本缺失时仅 WARN，不 Popen
+
+
+def test_publish_action_response_carries_target_and_site_url():
+    """WikiPublishActionResponse 透传 target / site_url（供前端「查看站点」）。"""
+    resp = WikiPublishActionResponse(
+        publication_id=uuid4(),
+        status="published",
+        version=2,
+        published_at=None,
+        entries_count=3,
+        message="ok",
+        target=WikiPublishTarget.PRODUCTION.value,
+        site_url=WIKI_PUBLISH_TARGET_SITE_URL[WikiPublishTarget.PRODUCTION],
+    )
+    assert resp.target == "production"
+    assert resp.site_url == "https://threefish-ai.github.io"
+
+    # 缺省：target=local、site_url=None
+    default_resp = WikiPublishActionResponse(
+        publication_id=uuid4(),
+        status="published",
+        version=1,
+        published_at=None,
+        entries_count=0,
+        message="ok",
+    )
+    assert default_resp.target == "local"
+    assert default_resp.site_url is None
 
 
 class TestWikiCatalogSync:

--- a/docs/reference/wiki/deployment.md
+++ b/docs/reference/wiki/deployment.md
@@ -266,20 +266,29 @@ curl -s -o /dev/null -w "%{http_code}\n" https://<remote>/<pubSlug>/   # 期望 
 ./scripts/cli.sh restart   # 自动 sync-wiki-content.sh + pnpm build
 ```
 
+> 在 `/knowledge/wiki` 选择**「测试环境」**目标「发布」时，后端会 fire-and-forget spawn
+> [`scripts/build-wiki-local.sh`](../../../scripts/build-wiki-local.sh)（复用
+> [`sync-wiki-content.sh`](../../../scripts/sync-wiki-content.sh) + `next build`），
+> 等价于上述本地刷新的「导出 + 重建」步骤——无需手动 `cli.sh restart` 即可在 `:3092` 看到新内容。
+
 详见 [Wiki README · 本地刷新](../../../apps/negentropy-wiki/README.md)。
 
-### 3.5b 路径 D：本地 publish 自动发布到 GitHub Pages（本地主站 → threefish-ai.github.io）
+### 3.5b 路径 D：发布到 GitHub Pages（本地主站 → threefish-ai.github.io）
 
-**适用**：主站**纯本地**（DB 不公网暴露），希望在 `/knowledge/wiki`「同步并发布」后**自动**把站点上线到独立的 GitHub Pages 仓库（如 `threefish-ai.github.io`）。
+**适用**：主站**纯本地**（DB 不公网暴露），希望在 `/knowledge/wiki` 选择**「生产环境」**目标「发布」后**自动**把站点上线到独立的 GitHub Pages 仓库（如 `threefish-ai.github.io`）。
 
 **为什么不是云端 CI**：`wiki-content-export.yml`（§3.4）在 GitHub 云端 runner 跑，需 `NE_DB_URL` 连主站 DB——本地 DB 云端连不上。故由**后端在 publish 后后台 spawn 本地脚本**完成「导出 → 构建 → 推 Pages」，全程在本地。
+
+> 入口：`publish(target=production)` → spawn `publish-wiki-pages.sh`（与「测试环境」目标的
+> `build-wiki-local.sh` 共享「导出 + 构建」前两步，生产目标额外 rsync + git push）。
+> 显式目标即授权——不再依赖 `ENABLED` 开关（该开关保留为遗留自动发布兼容）。
 
 **图片自包含**：本路径用 `bake_assets=true` 把图片字节烘焙进 `out/assets/`（见 [§4.4](#44-图片烘焙-bake_assets)），站点**零主站运行时依赖**——即使主站不公网可达，公网 Pages 上图片照常显示。
 
 ```mermaid
 flowchart LR
   subgraph Local["本地主站"]
-    PUB["/UI 同步并发布/"] --> SVC["wiki_service.publish()"]
+    PUB["/UI 发布 · 选「生产环境」/"] --> SVC["wiki_service.publish(target=production)"]
     SVC -->|"spawn（fire-and-forget）"| SH["publish-wiki-pages.sh"]
     SH --> EXP["export（烘焙图片）→ content/"]
     EXP --> BUILD["next build → out/"]
@@ -294,18 +303,20 @@ flowchart LR
 **一次性配置**：
 
 1. **目标仓库 Pages**：`threefish-ai.github.io` → Settings → Pages → Source 选 `Deploy from a branch`，分支 `master` / root（user/org pages 根域默认分支即 `master`，无需 `basePath`）。
-2. **推送凭证**：本地对该仓库有 push 权限。脚本支持三种凭证（优先级从高到低）：① `WIKI_PAGES_TOKEN` 环境变量（GitHub PAT）；② `gh auth token`（装了 gh CLI 且已登录则自动取）；③ SSH key（`WIKI_PAGES_REPO` 用 `git@` URL 时）。**推荐 token**——最契合无 SSH key 的环境。
-3. **主站后端开关**（env 或 `config.local.yaml`）：
+2. **推送凭证**：本地对该仓库有 push 权限。脚本支持三种凭证（优先级从高到低）：① `WIKI_PAGES_TOKEN` 环境变量（GitHub PAT）；② `gh auth token`（装了 gh CLI 且已登录则自动取）；③ SSH key（`WIKI_PAGES_REPO` 用 `git@` URL 时）。**零配置最快**：`gh auth login` 后直接选「生产环境」发布即可。
 
-   ```bash
-   NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__ENABLED=true
-   NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__REPO=https://github.com/ThreeFish-AI/threefish-ai.github.io.git
-   NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__BRANCH=master
-   # 可选：HTTPS 推送 token（缺省则脚本回退 gh auth token / SSH）
-   NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__TOKEN=ghp_xxx
-   ```
+   > 仅当需覆盖默认仓库/分支或禁用 `gh auth` 回退时，才需下列 env：
+   >
+   > ```bash
+   > NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__REPO=https://github.com/ThreeFish-AI/threefish-ai.github.io.git
+   > NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__BRANCH=master
+   > # 可选：HTTPS 推送 token（缺省则脚本回退 gh auth token / SSH）
+   > NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__TOKEN=ghp_xxx
+   > # 遗留：True 时任意 publish 即推 Pages（新流程已由显式 target 触发，通常无需开启）
+   > # NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__ENABLED=true
+   > ```
 
-**之后**：在主站点「同步并发布」→ 后端后台跑 `scripts/publish-wiki-pages.sh` →（导出含图片 → 构建 → 备份目标分支 → rsync `out/` + push）→ 数十秒后 `https://threefish-ai.github.io/` 更新。spawn 为 fire-and-forget，**不阻塞 publish 接口**（失败仅后端 WARN 日志）。
+**之后**：在主站点选择**「生产环境」**目标 → 点 **「发布」**（destructive 二次确认）→ 后端后台跑 `scripts/publish-wiki-pages.sh` →（导出含图片 → 构建 → 备份目标分支 → rsync `out/` + push）→ 数十秒后 `https://threefish-ai.github.io/` 更新。spawn 为 fire-and-forget，**不阻塞 publish 接口**（失败仅后端 WARN 日志）。
 
 **手动 fallback / 首次验证**：
 

--- a/docs/reference/wiki/user-guide/publishing.md
+++ b/docs/reference/wiki/user-guide/publishing.md
@@ -10,38 +10,48 @@ Negentropy Wiki 是知识库的**对外发布窗口**，将知识库中整理好
 
 ### 8.2 内容发布流程
 
-> 📦 **下游刷新机制已变更**：wiki 纯静态化后不再有运行时 ISR。「同步并发布」的 UI 操作不变，
-> 但发布后内容需经「**导出 → 重建**」才上线（本地 `cli.sh restart` 已内置；远程部署见
-> [`deployment.md`](../deployment.md)）。下图与下文中的「ISR 增量更新 / webhook」描述仅作历史参考。
+> 📦 **下游刷新机制**：wiki 纯静态化（`output: export`）后无运行时 ISR，内容上线需经
+> 「**导出 `content/` → `next build` 重建**」。发布入口已一体化为顶部粘性工具栏的单一
+> **「发布」** 按钮，并支持**双目标**：
+>
+> - **测试环境**：重建本地 `negentropy-wiki`（`http://localhost:3092`）。
+> - **生产环境**：推送到 [`threefish-ai.github.io`](https://github.com/ThreeFish-AI/threefish-ai.github.io) `master` 分支，直接更新 [https://threefish-ai.github.io/](https://threefish-ai.github.io/)。
+>
+> 重建 / 推送由后端在「发布」后 **fire-and-forget spawn** 承担；本地 `cli.sh restart` 亦内置相同闭环。
+> 完整部署拓扑见 [`deployment.md`](../deployment.md)。
 
 ```mermaid
 flowchart LR
-    KB["📚 知识库<br/>Corpus / Documents"] --> Publish["📤 创建 Wiki Publication"]
-    Publish --> Wiki["🌐 Wiki 站点<br/>SSG + ISR"]
-    Wiki --> User["👤 用户浏览"]
-
-    Wiki -.->|"ISR 增量更新<br/>(5 分钟)"| KB
+    KB["📚 知识库<br/>Corpus / Documents"] --> Publish["📤 发布<br/>选节点 + 选目标"]
+    Publish --> Build["🔨 导出 + 重建<br/>content/ → out/"]
+    Build --> Local["🏠 测试环境<br/>本地 :3092"]
+    Build --> Prod["🌐 生产环境<br/>threefish-ai.github.io"]
+    Local --> User["👤 用户浏览"]
+    Prod --> User
 
     classDef proc fill:#DBEAFE,stroke:#1E3A8A,color:#000
     classDef wiki fill:#D1FAE5,stroke:#065F46,color:#000
+    classDef prod fill:#FEE2E2,stroke:#991B1B,color:#000
 
-    class Publish proc
-    class Wiki,User wiki
+    class Publish,Build proc
+    class Local wiki
+    class Prod prod
 ```
 
 #### 8.2.1 在控制台一步步发布（实操指南）
 
-> 适用于已经在 `/knowledge/wiki` 编排好 Catalog 树，希望把已编排内容推送到 negentropy-wiki 站点的运营/编辑同学。
-> UI 入口在 [Knowledge / Wiki 模块发布入口一体化](../../../../CHANGELOG.md) 之后改为「顶部粘性发布工具栏」，不再有「Catalog/Publish」模式切换。
+> 适用于已经在 `/knowledge/wiki` 编排好 Catalog 树，希望把已编排内容发布到 wiki 站点的运营/编辑同学。
+> UI 入口为「顶部粘性发布工具栏」——单一 **「发布」** 按钮承担「选节点同步 → 选目标发布」全流程，
+> 并支持在「测试环境 / 生产环境」间切换。
 
 ##### 前置条件
 
-| 项                             | 说明                                                                                                                 |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| Catalog 树                     | 已在左栏完成层级编排，叶子节点已挂载文档（含已提取的 Markdown，否则同步会跳过未提取条目）                            |
-| 后端服务                       | `pnpm dev:negentropy`（默认 `:3292`，与 `WIKI_API_BASE` 一致）                                                       |
-| Wiki 站点                      | `pnpm dev:wiki`（默认 `:3092`，与 `NEXT_PUBLIC_WIKI_SSG_BASE_URL` 一致）                                             |
-| 主动 ISR webhook（可选但推荐） | 后端环境变量 `NE_KNOWLEDGE_WIKI_REVALIDATE__URL=http://localhost:3092/api/revalidate`；未配置时退化为 5 分钟被动 ISR |
+| 项                       | 说明                                                                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Catalog 树               | 已在左栏完成层级编排，叶子节点已挂载文档（含已提取的 Markdown，否则同步会跳过未提取条目）                                                  |
+| 后端服务                 | `pnpm dev:negentropy`（默认 `:3292`，与 `WIKI_API_BASE` 一致）                                                                             |
+| 测试环境 wiki 站点       | `pnpm dev:wiki`（默认 `:3092`，与 `NEXT_PUBLIC_WIKI_SSG_BASE_URL` 一致）；发布后由后端 spawn 重建                                          |
+| 生产环境推送凭证（生产目标） | `gh auth token` 可用（对 `threefish-ai.github.io` 有写权限）即可零配置；或配置 `NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__TOKEN=<PAT>`（详见 [deployment.md](../deployment.md)） |
 
 ##### 第一次发布：从 0 到 1
 
@@ -51,41 +61,46 @@ flowchart LR
    - **Slug**：站点 URL 前缀，例如 `engineering`（会自动从名称推导，可手动覆盖）
    - **描述**（可选）：发布的目标受众与内容范围
    - **主题**：`default` / `book` / `docs`
-3. **同步条目**：工具栏点 **「从 Catalog 同步」** → 在节点选择器中勾选要发布的子树（可选多个，包含子节点） → 点 **「确认同步」**。同步完成后 toast 提示「同步成功：新增/保留 N 条」。
-4. **触发发布**：工具栏点 **「同步并发布」**（蓝色 primary 按钮，等价于「同步」+「发布」的组合操作）。Pipeline 状态条出现，分三步：
-   - `保存版本`（同步完成即 ✓）
-   - `通知 SSG`（webhook 已派发 → dispatched）
-   - `验证内容`（站点轮询返回的版本 ≥ 目标版本 → confirmed）
-5. **访问站点验证**：打开 `${NEXT_PUBLIC_WIKI_SSG_BASE_URL}/${slug}`（默认 `http://localhost:3092/engineering`），看到新版本内容即发布成功。
+3. **选择发布目标**：工具栏右侧的目标选择器默认 **「测试环境」**（本地 `:3092`）。需要上线公开站点时切到 **「生产环境」**。
+4. **触发发布**：工具栏点 **「发布」**（蓝色 primary 按钮）→ 在节点选择器勾选要发布的子树（可选多个，含子节点）→ 点 **「发布」** 确认。
+   - 同步阶段：toast 提示「同步成功：新增/保留 N 条」（⚠️ 全量覆盖：未选子树内的既有条目将被删除）。
+   - **生产目标**会额外弹出 **destructive 二次确认**（提示推送 `threefish-ai.github.io` master 不可逆），确认后才执行。
+   - 发布阶段：后端 fire-and-forget spawn 重建 / 推送；toast 提示「发布成功：vN（测试/生产环境，站点 …）」。
+5. **访问站点验证**：
+   - 测试环境：打开 `http://localhost:3092/${slug}`（重建完成片刻后见新内容）。
+   - 生产环境：等待 GitHub Pages 部署后打开 `https://threefish-ai.github.io/${slug}`。
 
 ##### 日常增量发布（已有发布对象）
 
 1. 在 Catalog 树修改节点内容（编辑文档、调整层级、增删节点）。
-2. 顶部工具栏从下拉中选中目标发布对象。
-3. 直接点 **「同步并发布」** —— 一键完成「同步增量」+「触发 ISR」。
+2. 顶部工具栏从下拉中选中目标发布对象，选择「测试环境」或「生产环境」。
+3. 直接点 **「发布」** → 勾选子树 → 确认 —— 一键完成「同步 + 重建/推送」。
 
-> 若仅修改了节点元数据但未修改文档内容，建议先「从 Catalog 同步」校对条目数与告警，再点「仅发布」推送新版本。
+> 重建 / 推送为 fire-and-forget：失败仅入后端日志，不回传前端。若发布后站点未见更新，查
+> `./scripts/cli.sh logs`（测试环境 wiki 日志）或 GitHub Actions（生产环境 pages 部署）。
 
 ##### 取消发布与回滚
 
 | 场景                             | 操作                                                                                                                                            |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| 临时下线 Publication（保留草稿） | 工具栏点 **「取消发布」** → 确认后版本回退为草稿，访客 404                                                                                      |
+| 临时下线 Publication（保留草稿） | 工具栏点 **「取消发布」**（仅 published 态出现）→ 确认后版本回退为草稿，访客 404                                                               |
 | 删除整个 Publication（不可逆）   | 工具栏点 **「删除」** → 二次确认后，发布对象及历史版本一并清除                                                                                  |
 | 误发布想回到上一版本             | 当前不提供「版本回滚」UI；按 [运维指引 §12.3 WikiPublication 多版本与回退](../ops.md#123-wikipublication-多版本与回退) 手动恢复 `ARCHIVED` 版本 |
 
 ##### 配置说明（环境变量）
 
-| 变量                                | 作用范围        | 默认值                     | 说明                                                             |
-| ----------------------------------- | --------------- | -------------------------- | ---------------------------------------------------------------- |
-| `NE_KNOWLEDGE_WIKI_REVALIDATE__URL` | 后端 negentropy | （未配置时退化为被动 ISR） | 发布/取消发布完成后，POST 到此 URL 触发 SSG `/api/revalidate`    |
-| `NEXT_PUBLIC_WIKI_SSG_BASE_URL`     | 前端 ui         | `http://localhost:3092`    | 工具栏 Pipeline 用此 URL 轮询 `/api/content-status` 做新鲜度验证 |
-| `WIKI_API_BASE`                     | 站点 wiki       | `http://localhost:3292`    | SSG 端的后端 API 反向代理目标                                    |
+| 变量                                              | 作用范围        | 默认值                          | 说明                                                                 |
+| ------------------------------------------------- | --------------- | ------------------------------- | -------------------------------------------------------------------- |
+| `NEXT_PUBLIC_WIKI_SSG_BASE_URL`                   | 前端 ui         | `http://localhost:3092`         | 工具栏 Pipeline 轮询 `/api/content-status` 做新鲜度验证（测试环境）  |
+| `WIKI_API_BASE`                                   | 站点 wiki       | `http://localhost:3292`         | SSG 端的后端 API 反向代理目标                                        |
+| `NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__TOKEN`          | 后端 negentropy | （未配置时回退 `gh auth token`）| 生产目标 HTTPS 推送 GitHub PAT；透传 `publish-wiki-pages.sh`         |
+| `NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__REPO`           | 后端 negentropy | `threefish-ai.github.io.git`    | 生产目标 Pages 仓库（可覆盖）                                        |
+| `NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__BRANCH`         | 后端 negentropy | `master`                        | 生产目标 Pages 分支                                                  |
 
 ##### 常见问题（FAQ）
 
-- **「同步并发布」后首页持续显示「暂无已发布的 Wiki」** → 多半是端口错配或 ISR webhook 未触达。详见 [运维指引 §8 故障排除](../ops.md#8-故障排除)。
-- **Pipeline 卡在「验证内容」步** → 站点未配置或不可达；改用被动 5 分钟 ISR 也能更新。
+- **「发布」后首页持续显示「暂无已发布的 Wiki」** → 多为重建 / 推送未完成或失败。测试环境查 `cli.sh logs`；生产环境查 GitHub Actions。详见 [运维指引 §8 故障排除](../ops.md#8-故障排除)。
+- **生产目标发布未生效** → 确认 `gh auth token` 对 `threefish-ai.github.io` 有写权限；或配置 `NE_KNOWLEDGE_WIKI_PAGES_PUBLISH__TOKEN`。
 - **看不到「+ 新建」按钮** → 检查 Catalog 是否已加载（`catalogId` 非空）；后端 `/knowledge/catalogs/singleton` 是否返回正常。
 
 ### 8.3 主题与深色模式

--- a/scripts/build-wiki-local.sh
+++ b/scripts/build-wiki-local.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# build-wiki-local.sh — 本地一键重建 negentropy-wiki 测试站点（:3092）
+#
+# 链路：主站 DB 导出已发布内容 → content/ → next build 重建 out/。
+# wiki 纯静态化（output: export）后无运行时刷新：内容更新必须「导出 + 重建」，
+# 重建后由本地 wiki（serve out -l 3092）提供新产物。
+#
+# 由后端 publish(target=local) 后 fire-and-forget spawn，或手动执行。
+# 与 publish-wiki-pages.sh 共享「导出 + 重建」前两步，但**不**推送任何远端仓库
+# —— 仅作用于本机 out/（测试环境）。
+#
+# 前置：
+#   - postgres 运行中（NE_DB_URL 未设时用默认 localhost:5432/negentropy）
+#   - 至少有一个 status=published 的 Wiki publication（主站「发布」后即满足）
+#
+# 用法：
+#   ./scripts/build-wiki-local.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+
+log() { printf '\033[34m[build-wiki-local]\033[0m %s\n' "$*"; }
+err() { printf '\033[31m[build-wiki-local] ERROR:\033[0m %s\n' "$*" >&2; }
+
+# Step 1: 导出已发布 Wiki 内容 → content/（复用既有导出脚本，其内部已处理
+# NE_SVC_ARTIFACT_BACKEND=inmemory 容错与 DB 连接）。
+log "Step 1/2 导出 Wiki 内容 → content/"
+bash "$REPO_ROOT/scripts/sync-wiki-content.sh" \
+  || { err "内容导出失败（postgres 未就绪 / 无已发布内容？）"; exit 1; }
+
+# Step 2: next build → out/（content/ 在构建期烘焙进静态产物）。
+log "Step 2/2 next build → out/"
+(cd "$REPO_ROOT" && pnpm --filter negentropy-wiki build) \
+  || { err "wiki 构建失败"; exit 1; }
+
+[ -f "$REPO_ROOT/apps/negentropy-wiki/out/index.html" ] \
+  || { err "构建产物缺失：apps/negentropy-wiki/out/index.html"; exit 1; }
+
+log "完成：本地 wiki 已重建，http://localhost:3092 将提供新内容"


### PR DESCRIPTION
## 背景

合并两条诉求为一次实现：

1. **入口一体化**：`/knowledge/wiki` 工具栏的「从 Catalog 同步」「同步并发布」「仅发布」三个语义重叠入口收敛为单一「发布」按钮（选 Catalog 节点 → 同步 → 发布）。
2. **双目标发布**：「发布」支持选择目标环境：
   - **测试环境**：重建本地 `negentropy-wiki`（`:3092`）。
   - **生产环境**：推送到 [`threefish-ai.github.io`](https://github.com/ThreeFish-AI/threefish-ai.github.io) `master`，直接更新 https://threefish-ai.github.io/。

## 实现要点

**后端**
- 新增 `WikiPublishTarget`（local/production）+ `WikiPublishRequest`；`WikiPublishActionResponse` 回填 `target` / `site_url`。
- `publish(target)` 按目标 fire-and-forget spawn：`_spawn_local_wiki_rebuild`（`build-wiki-local.sh`）/ `_spawn_pages_publish`（`publish-wiki-pages.sh`），共用 `_spawn_wiki_deploy_script`。
- 显式目标即授权，移除 `wiki_pages_publish.enabled` 硬门控（该开关保留为遗留自动发布兼容）。
- `POST /wiki/publications/{pub_id}/publish` 接收可选 `{target}` 请求体（缺省 `local`）。

**脚本**：新增 `scripts/build-wiki-local.sh`（导出 `content/` + `next build`，镜像 `publish-wiki-pages.sh` 前两步，复用 `sync-wiki-content.sh`）。

**前端**：`publishWiki(pubId, target)` 携带 `{target}` body；工具栏收敛为单一「发布」按钮 + 内联目标选择器（测试 / 生产），生产目标经 destructive 二次确认（推送 `master` 不可逆）。

## 安全与风险

- 生产发布不可逆：目标选择器**默认测试环境** + 生产 **destructive `confirm`** 双重防护。
- 生产依赖 `gh auth token`（已确认对 `threefish-ai.github.io` 有写权限），零配置复用既有 `publish-wiki-pages.sh`。
- fire-and-forget：`next build` / git push 失败仅入后端日志，不阻塞 publish 返回（与既有生产路径一致限制）。

## 验证

- 后端单测 18 passed（含 publish 目标路由 / spawn / 响应字段）；集成 `test_wiki_publish_modes` 14 passed（向后兼容）。
- 前端 knowledge 全量 211 passed（25 files）；ESLint / tsc（改动文件）clean。
- ruff check + format clean；pre-commit hooks passed。
- 端到端：因本地有运行中引擎（同 DB / 端口），未在此工作区起第二引擎实测；待合并后在 live 环境验证两目标发布。