### PR TITLE
fix(Wiki): 保留一级目录「Negentropy」子项收敛为左侧二级下拉菜单

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,10 +1,9 @@
 import {
+  buildReservedDocsTab,
   findFirstDocumentSlug,
   isReservedDocsSlug,
   joinEntrySlug,
   resolveSectionView,
-  RESERVED_DOCS_HOME,
-  RESERVED_DOCS_LABEL,
   RESERVED_DOCS_SLUG,
   type WikiEntry,
   type WikiEntryContent,
@@ -162,18 +161,24 @@ export default async function WikiEntryPage({ params }: Props) {
   const reservedExists =
     isReserved || (await wikiApi.findPublicationBySlug(RESERVED_DOCS_SLUG)) !== null;
 
+  // 身处保留 pub 时，把其 nav-tree 第一层注入左侧「Negentropy」标签的二级下拉，
+  // 并清空右侧 `--right` 一级 tabs，避免子项与下拉重复出现（首页同此过滤意图）。
+  const reservedTab = buildReservedDocsTab({
+    reservedExists,
+    isReserved,
+    items: sectionView.headerItems,
+    activeChildSlug: sectionView.activeTopSlug,
+  });
+  const headerItems = isReserved ? [] : sectionView.headerItems;
+
   const header = sectionView.headerItems.length > 0 && (
     <WikiHeader
       pubSlug={pubSlug}
-      items={sectionView.headerItems}
+      items={headerItems}
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      reservedTab={
-        reservedExists
-          ? { show: true, active: isReserved, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
-          : undefined
-      }
+      reservedTab={reservedTab}
       graphTab={{ active: false, show: hasAnyEntry && !isReserved }}
     />
   );

--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -6,11 +6,10 @@ import { WikiHeader } from "@/components/WikiHeader";
 import { WikiHeaderActions } from "@/components/WikiHeaderActions";
 import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import {
+  buildReservedDocsTab,
   countLeafEntries,
   isReservedDocsSlug,
   resolveSectionView,
-  RESERVED_DOCS_HOME,
-  RESERVED_DOCS_LABEL,
   RESERVED_DOCS_SLUG,
   type WikiNavTreeItem,
   type WikiPublication,
@@ -85,18 +84,24 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
   const reservedExists =
     isReserved || (await wikiApi.findPublicationBySlug(RESERVED_DOCS_SLUG)) !== null;
 
+  // 身处保留 pub 时，把其 nav-tree 第一层注入左侧「Negentropy」标签的二级下拉，
+  // 并清空右侧 `--right` 一级 tabs，避免子项与下拉重复出现（首页同此过滤意图）。
+  const reservedTab = buildReservedDocsTab({
+    reservedExists,
+    isReserved,
+    items: sectionView.headerItems,
+    activeChildSlug: sectionView.activeTopSlug,
+  });
+  const headerItems = isReserved ? [] : sectionView.headerItems;
+
   const header = sectionView.headerItems.length > 0 && (
     <WikiHeader
       pubSlug={pubSlug}
-      items={sectionView.headerItems}
+      items={headerItems}
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      reservedTab={
-        reservedExists
-          ? { show: true, active: isReserved, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
-          : undefined
-      }
+      reservedTab={reservedTab}
       graphTab={{ active: true, show: entriesTotal > 0 && !isReserved }}
     />
   );

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -1,11 +1,10 @@
 import {
+  buildReservedDocsTab,
   countLeafEntries,
   findFirstDocumentSlug,
   findIndexEntry,
   isReservedDocsSlug,
   resolveSectionView,
-  RESERVED_DOCS_HOME,
-  RESERVED_DOCS_LABEL,
   RESERVED_DOCS_SLUG,
   type WikiPublication,
   type WikiNavTreeItem,
@@ -100,18 +99,24 @@ export default async function WikiPublicationPage({ params }: Props) {
     />
   );
 
+  // 身处保留 pub 时，把其 nav-tree 第一层注入左侧「Negentropy」标签的二级下拉，
+  // 并清空右侧 `--right` 一级 tabs，避免子项与下拉重复出现（首页同此过滤意图）。
+  const reservedTab = buildReservedDocsTab({
+    reservedExists,
+    isReserved,
+    items: sectionView.headerItems,
+    activeChildSlug: sectionView.activeTopSlug,
+  });
+  const headerItems = isReserved ? [] : sectionView.headerItems;
+
   const header = sectionView.headerItems.length > 0 && (
     <WikiHeader
       pubSlug={pubSlug}
-      items={sectionView.headerItems}
+      items={headerItems}
       activeTopSlug={sectionView.activeTopSlug}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      reservedTab={
-        reservedExists
-          ? { show: true, active: isReserved, label: RESERVED_DOCS_LABEL, href: RESERVED_DOCS_HOME }
-          : undefined
-      }
+      reservedTab={reservedTab}
       graphTab={{ active: false, show: entriesTotal > 0 && !isReserved }}
     />
   );

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import {
   findFirstDocumentSlug,
   isContainerItem,
+  RESERVED_DOCS_SLUG,
+  type ReservedDocsTab,
   type WikiNavTreeItem,
 } from "@/lib/wiki-api";
 
@@ -20,14 +22,6 @@ interface WikiHeaderGraphTab {
   label?: string;
 }
 
-/** 保留一级目录「Negentropy」标签（置于 Knowledge Graph 左侧的系统保留入口）。 */
-interface WikiHeaderReservedTab {
-  show: boolean;
-  active?: boolean;
-  label?: string;
-  href: string;
-}
-
 interface HomeLink {
   label: string;
   href: string;
@@ -38,7 +32,8 @@ interface WikiHeaderProps {
   items?: WikiNavTreeItem[];
   activeTopSlug?: string;
   headerSlot?: React.ReactNode;
-  reservedTab?: WikiHeaderReservedTab;
+  /** 左侧「Negentropy」保留标签；`items` 非空时渲染为二级下拉（见 ReservedDocsTab）。 */
+  reservedTab?: ReservedDocsTab;
   graphTab?: WikiHeaderGraphTab;
   searchBox?: React.ReactNode;
   actions?: React.ReactNode;
@@ -77,15 +72,25 @@ export function WikiHeader({
         {/* LEFT: 保留一级目录「Negentropy」（最左）+ Knowledge Graph */}
         {(reservedTab?.show || graphTab?.show) && (
           <nav className="wiki-header-tabs wiki-header-tabs--left" aria-label="特色导航">
-            {reservedTab?.show && (
-              <Link
-                href={reservedTab.href}
-                className={`wiki-header-tab${reservedTab.active ? " active" : ""}`}
-                aria-current={reservedTab.active ? "page" : undefined}
-              >
-                {reservedTab.label ?? "Negentropy"}
-              </Link>
-            )}
+            {reservedTab?.show &&
+              (reservedTab.items && reservedTab.items.length > 0 ? (
+                <HeaderDropdown
+                  label={reservedTab.label ?? "Negentropy"}
+                  href={reservedTab.href}
+                  active={reservedTab.active}
+                  panelItems={reservedTab.items}
+                  pubSlug={RESERVED_DOCS_SLUG}
+                  activeChildSlug={reservedTab.activeChildSlug}
+                />
+              ) : (
+                <Link
+                  href={reservedTab.href}
+                  className={`wiki-header-tab${reservedTab.active ? " active" : ""}`}
+                  aria-current={reservedTab.active ? "page" : undefined}
+                >
+                  {reservedTab.label ?? "Negentropy"}
+                </Link>
+              ))}
             {graphTab?.show && (
               <Link
                 href={`/${pubSlug}/graph`}
@@ -160,32 +165,13 @@ function WikiHeaderTab({ item, pubSlug, isActive }: WikiHeaderTabProps) {
   // Container with children → render dropdown
   if (hasChildren) {
     return (
-      <div className={`wiki-header-dropdown${isActive ? " active" : ""}`}>
-        <Link
-          href={`/${pubSlug}/${targetSlug}`}
-          className="wiki-header-dropdown-trigger"
-          aria-current={isActive ? "page" : undefined}
-        >
-          {label}
-          <span className="wiki-header-dropdown-arrow">▼</span>
-        </Link>
-        <div className="wiki-header-dropdown-panel">
-          {item.children!.map((child) => {
-            const childTarget = pickTabTargetSlug(child);
-            const childLabel = child.entry_title || child.entry_slug;
-            if (!childTarget) return null;
-            return (
-              <Link
-                key={`${child.entry_id ?? "c"}:${child.entry_slug}`}
-                href={`/${pubSlug}/${childTarget}`}
-                className="wiki-header-dropdown-item"
-              >
-                {childLabel}
-              </Link>
-            );
-          })}
-        </div>
-      </div>
+      <HeaderDropdown
+        label={label}
+        href={`/${pubSlug}/${targetSlug}`}
+        active={isActive}
+        panelItems={item.children ?? []}
+        pubSlug={pubSlug}
+      />
     );
   }
 
@@ -197,6 +183,65 @@ function WikiHeaderTab({ item, pubSlug, isActive }: WikiHeaderTabProps) {
     >
       {label}
     </Link>
+  );
+}
+
+interface HeaderDropdownProps {
+  label: string;
+  href: string;
+  active?: boolean;
+  panelItems: WikiNavTreeItem[];
+  /** 面板条目链接的 pubSlug 前缀（容器 tab 用当前 pub，保留标签用 RESERVED_DOCS_SLUG）。 */
+  pubSlug: string;
+  /** 当前激活的第一层 slug，命中则对应面板项高亮。 */
+  activeChildSlug?: string;
+}
+
+/**
+ * CSS-only 下拉原语（hover/focus-within）—— Header tab 容器分支与左侧「Negentropy」
+ * 保留标签共用，确保两处联级菜单视觉与行为一致。
+ *
+ * 面板对每个 item 取 `pickTabTargetSlug` 作为跳转目标（CONTAINER → 首个后代文档），
+ * 跳过无可达文档的条目；`activeChildSlug` 命中时给该项加 active 态。
+ */
+function HeaderDropdown({
+  label,
+  href,
+  active,
+  panelItems,
+  pubSlug,
+  activeChildSlug,
+}: HeaderDropdownProps) {
+  return (
+    <div className={`wiki-header-dropdown${active ? " active" : ""}`}>
+      <Link
+        href={href}
+        className="wiki-header-dropdown-trigger"
+        aria-current={active ? "page" : undefined}
+      >
+        {label}
+        <span className="wiki-header-dropdown-arrow">▼</span>
+      </Link>
+      <div className="wiki-header-dropdown-panel">
+        {panelItems.map((child) => {
+          const childTarget = pickTabTargetSlug(child);
+          if (!childTarget) return null;
+          const childLabel = child.entry_title || child.entry_slug;
+          const childActive =
+            activeChildSlug != null && child.entry_slug === activeChildSlug;
+          return (
+            <Link
+              key={`${child.entry_id ?? "c"}:${child.entry_slug}`}
+              href={`/${pubSlug}/${childTarget}`}
+              className={`wiki-header-dropdown-item${childActive ? " active" : ""}`}
+              aria-current={childActive ? "page" : undefined}
+            >
+              {childLabel}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -36,6 +36,52 @@ export function isReservedDocsSlug(slug: string | null | undefined): boolean {
   return slug === RESERVED_DOCS_SLUG;
 }
 
+/**
+ * WikiHeader 左侧「Negentropy」保留标签的渲染输入。
+ *
+ * - `items` 缺省 → 纯链接标签（首页 / 非保留 pub 页），点击直达保留 docs 首页；
+ * - `items` 非空 → 渲染为二级下拉（联级菜单），面板列出保留 pub 第一层章节，
+ *   仅在「身处保留 pub」时由 `buildReservedDocsTab` 注入。
+ */
+export interface ReservedDocsTab {
+  show: boolean;
+  active?: boolean;
+  label?: string;
+  href: string;
+  /** 保留下拉面板条目（保留 pub nav-tree 第一层）；缺省时渲染纯链接。 */
+  items?: WikiNavTreeItem[];
+  /** 当前激活的第一层 slug，用于下拉项高亮。 */
+  activeChildSlug?: string;
+}
+
+/**
+ * 派生左侧「Negentropy」保留标签的 Header 渲染输入（单一事实源）。
+ *
+ * 集中"身处保留 pub 时把 nav-tree 第一层折叠进左侧下拉、其它页面保持纯链接"的规则，
+ * 杜绝三个 pub 页面各自重复实现，亦与首页「保留 pub 不进 `--right`」的过滤意图呼应。
+ *
+ * - `reservedExists=false` → `undefined`（保留 pub 不存在，不渲染标签）；
+ * - `isReserved=true`（身处保留 pub）→ 注入 `items` + `activeChildSlug`，调用方同时应
+ *   据 `isReserved` 清空 `--right` 一级 tabs（避免子项与左侧下拉重复出现）；
+ * - 其它页面 → 纯链接（`items` 不注入），点击直达保留 docs 首页。
+ */
+export function buildReservedDocsTab(opts: {
+  reservedExists: boolean;
+  isReserved: boolean;
+  items?: WikiNavTreeItem[];
+  activeChildSlug?: string;
+}): ReservedDocsTab | undefined {
+  if (!opts.reservedExists) return undefined;
+  return {
+    show: true,
+    active: opts.isReserved,
+    label: RESERVED_DOCS_LABEL,
+    href: RESERVED_DOCS_HOME,
+    items: opts.isReserved ? opts.items : undefined,
+    activeChildSlug: opts.activeChildSlug,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // 类型定义
 // ---------------------------------------------------------------------------

--- a/apps/negentropy-wiki/src/styles/components/header.css
+++ b/apps/negentropy-wiki/src/styles/components/header.css
@@ -187,6 +187,12 @@
   color: var(--wiki-accent);
   text-decoration: none;
 }
+/* 当前激活章节（与触发器 active 同语义，标识所属二级菜单的当前页） */
+.wiki-header-dropdown-item.active {
+  color: var(--wiki-accent);
+  background: var(--wiki-primary-light);
+  font-weight: 600;
+}
 
 /* Header slot (right side) */
 .wiki-header-slot {

--- a/apps/negentropy-wiki/tests/lib/wiki-reserved-docs.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-reserved-docs.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildReservedDocsTab,
   isReservedDocsSlug,
   RESERVED_DOCS_HOME,
   RESERVED_DOCS_INDEX_SLUG,
   RESERVED_DOCS_LABEL,
   RESERVED_DOCS_SLUG,
+  type WikiNavTreeItem,
 } from "@/lib/wiki-api";
 
 // 保留一级目录「Negentropy」的常量与判定（Header 左侧标签 / 首页右区过滤的单一事实源）。
@@ -24,5 +26,80 @@ describe("保留 docs 目录常量与 isReservedDocsSlug", () => {
     expect(isReservedDocsSlug(null)).toBe(false);
     expect(isReservedDocsSlug(undefined)).toBe(false);
     expect(isReservedDocsSlug("")).toBe(false);
+  });
+});
+
+// buildReservedDocsTab：把"身处保留 pub 时把 nav-tree 第一层折叠进左侧下拉、其它页面纯链接"
+// 的规则集中于此，三个 pub 页面共享，杜绝重复实现。
+describe("buildReservedDocsTab", () => {
+  const reservedItems: WikiNavTreeItem[] = [
+    {
+      entry_id: "readme-id",
+      entry_slug: "readme",
+      entry_title: "Negentropy 用户手册",
+      is_index_page: true,
+      document_id: "doc-readme",
+    },
+    {
+      entry_id: "concepts-id",
+      entry_slug: "concepts",
+      entry_title: "Concepts",
+      is_index_page: false,
+      document_id: null,
+      entry_kind: "CONTAINER",
+      children: [
+        {
+          entry_id: "overview-id",
+          entry_slug: "concepts/overview",
+          entry_title: "认识 Negentropy",
+          is_index_page: false,
+          document_id: "doc-overview",
+        },
+      ],
+    },
+  ];
+
+  it("reservedExists=false → undefined（保留 pub 不存在，不渲染标签）", () => {
+    expect(buildReservedDocsTab({ reservedExists: false, isReserved: false })).toBeUndefined();
+    expect(buildReservedDocsTab({ reservedExists: false, isReserved: true })).toBeUndefined();
+  });
+
+  it("身处保留 pub（isReserved=true）→ 注入 items + activeChildSlug，渲染为下拉", () => {
+    const tab = buildReservedDocsTab({
+      reservedExists: true,
+      isReserved: true,
+      items: reservedItems,
+      activeChildSlug: "concepts",
+    });
+    expect(tab).toEqual({
+      show: true,
+      active: true,
+      label: RESERVED_DOCS_LABEL,
+      href: RESERVED_DOCS_HOME,
+      items: reservedItems,
+      activeChildSlug: "concepts",
+    });
+  });
+
+  it("其它页面（isReserved=false）→ items 不注入（纯链接），active=false", () => {
+    const tab = buildReservedDocsTab({
+      reservedExists: true,
+      isReserved: false,
+      items: reservedItems,
+      activeChildSlug: "readme",
+    });
+    expect(tab?.show).toBe(true);
+    expect(tab?.active).toBe(false);
+    expect(tab?.items).toBeUndefined();
+    // activeChildSlug 即便传入也不再有意义（纯链接无下拉），但保持透传不抛错
+    expect(tab?.activeChildSlug).toBe("readme");
+    expect(tab?.label).toBe(RESERVED_DOCS_LABEL);
+    expect(tab?.href).toBe(RESERVED_DOCS_HOME);
+  });
+
+  it("label/href 与 RESERVED_DOCS_* 常量族对齐（单一事实源）", () => {
+    const tab = buildReservedDocsTab({ reservedExists: true, isReserved: true, items: [] });
+    expect(tab?.label).toBe(RESERVED_DOCS_LABEL);
+    expect(tab?.href).toBe(`/${RESERVED_DOCS_SLUG}/${RESERVED_DOCS_INDEX_SLUG}`);
   });
 });


### PR DESCRIPTION
## 问题

访问 `/negentropy/readme/`（保留 docs 目录「Negentropy」首页）时，其下属章节 `concepts` / `reference` / `research`（及 `Negentropy 用户手册`）被错误地渲染为顶部 header **右侧 `--right` 区的一级 tabs**，与左侧 `--left` 区的 `Negentropy` 保留标签**平级并列**，造成「子项覆盖右侧一级菜单」的层级错位。

**期望**：这些章节应是 `Negentropy` 一级标签的**二级下拉菜单（联级）**——hover 左侧 `Negentropy` 标签时下拉展开 `用户手册 / Concepts / Reference / Research`，右侧 `--right` 区不再承载它们。

## 根因

后端 nav-tree 结构**正确**（`wiki_docs_ingest` 合成的保留 pub 第一层为 `readme(DOCUMENT) + concepts/reference/research(CONTAINER)`，无需改动）。Bug 纯在前端渲染：`WikiHeader` 把当前 pub 的 nav-tree 第一层提升为 `--right` 一级 tabs，而三个保留 pub 页面把保留 pub **自身**第一层塞进 `items`，导致章节被当成一级 tabs。

对照：首页已用 `isReservedDocsSlug` 过滤保留 pub 出 `--right`——佐证「保留 pub 子项不应进 `--right`」正是既有设计意图。

## 修复（前端 only）

核心：**保留 pub 页面**把 nav-tree 第一层注入左侧 `Negentropy` 保留标签的**二级下拉**，同时清空 `--right` 区；**其它页面**保持纯链接不变。

- `wiki-api.ts`：新增 `ReservedDocsTab` 类型与 `buildReservedDocsTab` 纯函数，集中「身处保留 pub 时把第一层折叠进左侧下拉、其它页面保持纯链接」的规则（单一事实源）。
- `WikiHeader.tsx`：抽取共享 `HeaderDropdown` 原语，容器 tab 与保留标签共用；保留标签在 `items` 非空时渲染为 CSS-only 二级下拉，面板项支持 active 高亮。
- 三个保留 pub 页面（pub 首页 / 文档详情 / 图谱页）接入 helper，身处保留 pub 时清空 `--right` 一级 tabs，章节入口收敛到左侧下拉。
- `header.css`：复用既有 `.wiki-header-dropdown*` 全套，仅补 `.wiki-header-dropdown-item.active`。

## 验证

- **单测**：`pnpm vitest run` → 10 文件 / 72 用例全绿（含新增 `buildReservedDocsTab` 4 个用例）。
- **构建**：`pnpm -F negentropy-wiki build` → 静态导出成功，路由 `/negentropy/readme`、`/negentropy/graph` 等均正常生成。
- **lint**：0 错误（既有警告均不在本次改动文件内）；pre-commit `next lint` 通过。
- **循证（SSG 产物）**：`/negentropy/readme/` 的 header 已含 `Negentropy ▼` 下拉触发器 + 面板（`Negentropy 用户手册`[active] / `Concepts`），`--right` 区消失；非保留 pub（`negentropy-handbook`）`--right` 章节 tabs 与容器下拉行为完整保留，无回归。
- **实机回归**：本地 serve 构建产物，hover `Negentropy ▼` 下拉展开二级菜单，布局清爽无错位。

## 不在本次范围

- 移动端：readme 索引页左侧 sidebar 本就只渲染 `activeItem.children`（既有局限），本次不改变（桌面端章节切换已由新下拉覆盖，移动端无回归）。
- 首页：保留标签维持纯链接（首页已正确过滤、且保留 pub 由领衔卡片承载）。
- 后端 nav-tree 合成：结构正确，不动。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)