### PR TITLE
fix(cli): 修复 restart 启动日志暴露的控制流缺陷与上游构建告警;

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/DimensionCharts.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/DimensionCharts.tsx
@@ -36,8 +36,9 @@ function ChartCard({ title, children }: { title: string; children: React.ReactNo
   return (
     <div className="rounded-lg border border-border bg-card p-3 shadow-sm">
       <div className="mb-2 text-caption uppercase tracking-overline text-muted-foreground">{title}</div>
-      {/* 显式 min-h 让 ResponsiveContainer 即便在 SSR / Flex 折叠时仍有非负尺寸，
-          避免 recharts "width(-1) and height(-1)" 警告。 */}
+      {/* 外层 min-h 在客户端 Flex 折叠时保底；真正消除 recharts SSR "width(-1)" 警告的是
+          ResponsiveContainer 的 minWidth/minHeight props —— recharts 以 max(measured, min) 兜底，
+          不依赖 CSS layout（SSG 在 Node 无 layout，外层 CSS min-width 并不生效）。 */}
       <div className="h-56 min-h-[14rem] w-full" style={{ minWidth: 1 }}>
         {children}
       </div>
@@ -63,7 +64,7 @@ export function DimensionCharts({ byRole, byScenario, byOwner }: DimensionCharts
   return (
     <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
       <ChartCard title="Role × Success / Failed">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
           <BarChart data={roleData} margin={{ top: 8, right: 12, bottom: 8, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#3f3f46" strokeOpacity={0.2} />
             <XAxis dataKey="name" stroke="currentColor" fontSize={11} />
@@ -82,7 +83,7 @@ export function DimensionCharts({ byRole, byScenario, byOwner }: DimensionCharts
         </ResponsiveContainer>
       </ChartCard>
       <ChartCard title="Scenario × Runs">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
           <BarChart
             data={scenarioData}
             layout="vertical"
@@ -103,7 +104,7 @@ export function DimensionCharts({ byRole, byScenario, byOwner }: DimensionCharts
         </ResponsiveContainer>
       </ChartCard>
       <ChartCard title="Owner × Runs">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
           <PieChart>
             <Tooltip
               contentStyle={{

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
@@ -71,7 +71,7 @@ export function RoutineConvergenceChart({
         <p className="py-8 text-center text-sm text-text-secondary">尚无评分数据</p>
       ) : (
         <div className="h-56 min-h-[14rem] w-full" style={{ minWidth: 1 }}>
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <ComposedChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: -8 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#3f3f46" strokeOpacity={0.2} />
               <XAxis

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
@@ -99,7 +99,7 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
         <p className="py-8 text-center text-sm text-text-secondary">尚无可视化的执行区间</p>
       ) : (
         <div style={{ height: Math.max(120, rows.length * 30 + 36), minWidth: 1 }} className="w-full">
-          <ResponsiveContainer width="100%" height="100%">
+          <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <BarChart data={rows} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 8 }} barCategoryGap={6}>
               <XAxis
                 type="number"

--- a/apps/negentropy-ui/app/memory/insights/_components/SystemMetricsPanel.tsx
+++ b/apps/negentropy-ui/app/memory/insights/_components/SystemMetricsPanel.tsx
@@ -142,7 +142,7 @@ export function SystemMetricsPanel({ metrics, loading }: SystemMetricsPanelProps
         <div>
           <GroupTitle>Retention Distribution</GroupTitle>
           <div className="h-28 w-full rounded-xl border border-border bg-muted/20 p-2">
-            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+            <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
               <BarChart data={retentionData} margin={{ top: 4, right: 8, bottom: 0, left: -24 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
                 <XAxis

--- a/apps/negentropy-wiki/next.config.ts
+++ b/apps/negentropy-wiki/next.config.ts
@@ -51,11 +51,10 @@ function stableBuildId(): string {
 const nextConfig: NextConfig = {
   output: "export",
   trailingSlash: true,
-  // 限定 NFT 追踪根到 wiki 包自身（`next build` 时 process.cwd() 即 wiki 包根）。
-  // content-source.ts 的 process.cwd() 动态 fs 会让 Turbopack NFT 保守追踪整个 monorepo
-  // 并告警「Encountered unexpected file in NFT list」；显式指定追踪根可收敛范围、消除噪音。
-  // output:"export" 静态产物本就不依赖 NFT（其仅用于 standalone/serverless 打包），此项零功能影响。
-  outputFileTracingRoot: process.cwd(),
+  // 不设 outputFileTracingRoot：曾尝试收敛到 wiki 包根（process.cwd()），但 CI 的 pnpm
+  // hoisting 把 next 提升至 monorepo 根 node_modules，收缩 Turbopack 边界后从 src/app
+  // 解析不到 next/package.json 致构建失败（本地 node_modules 布局不同故未暴露）。
+  // output:"export" 静态产物不依赖 NFT，「unexpected file in NFT list」为无害诊断，保留默认根即可。
   images: {
     unoptimized: true,
   },

--- a/apps/negentropy-wiki/next.config.ts
+++ b/apps/negentropy-wiki/next.config.ts
@@ -51,6 +51,11 @@ function stableBuildId(): string {
 const nextConfig: NextConfig = {
   output: "export",
   trailingSlash: true,
+  // 限定 NFT 追踪根到 wiki 包自身（`next build` 时 process.cwd() 即 wiki 包根）。
+  // content-source.ts 的 process.cwd() 动态 fs 会让 Turbopack NFT 保守追踪整个 monorepo
+  // 并告警「Encountered unexpected file in NFT list」；显式指定追踪根可收敛范围、消除噪音。
+  // output:"export" 静态产物本就不依赖 NFT（其仅用于 standalone/serverless 打包），此项零功能影响。
+  outputFileTracingRoot: process.cwd(),
   images: {
     unoptimized: true,
   },

--- a/docs/research/031-vector-databases-selection.md
+++ b/docs/research/031-vector-databases-selection.md
@@ -316,7 +316,7 @@ tags:
 - **定位:** MongoDB Atlas 云数据平台的全托管向量搜索服务。它是 MongoDB 聚合管道（Aggregation Pipeline）中的一个功能模块（不是一个独立的数据库）<sup>[[18]](#ref18)</sup>。
 - **核心架构:**
   - **Lucene 集成:** 向量搜索底层依赖于 Apache Lucene 库。MongoDB 通过内部的同步机制（基于 Oplog），将主数据库（mongod 进程）中的数据实时同步到 Sidecar（侧车）搜索节点（mongot 进程）中，并在那里构建 HNSW 索引。
-  - **聚合管道 ($vectorSearch):** 向量搜索并非独立的 API，而是作为聚合管道的第一阶段 $vectorSearch 存在。这意味着你可以将向量搜索的结果无缝传递给后续的 MongoDB 阶段（如 $match, $project, $lookup），在数据库内部完成复杂的“向量 + 标量 + 关联查询”逻辑，无需应用层组装。
+  - **聚合管道 (`$vectorSearch`):** 向量搜索并非独立的 API，而是作为聚合管道的第一阶段 `$vectorSearch` 存在。这意味着你可以将向量搜索的结果无缝传递给后续的 MongoDB 阶段（如 `$match`, `$project`, `$lookup`），在数据库内部完成复杂的“向量 + 标量 + 关联查询”逻辑，无需应用层组装。
   - **预过滤 (Pre-filtering):** 利用 Lucene 的能力，支持在 HNSW 遍历前进行高效的元数据过滤（基于 MQL 语法），这对于多租户或带权限控制的 RAG 系统至关重要。
   - **搜索模式:**
     - **ANN (Approximate):** 默认的近似最近邻搜索，使用 HNSW 索引，速度快但可能有召回损失。
@@ -524,7 +524,7 @@ tags:
      - **生产阶段:** 如果文档数量超过 500 万，或者需要精细的权限控制（如 HR 文档只能 HR 看），迁移至 **Weaviate** 或 **Qdrant**。因为它们对 Filter Search 的优化更好。
 2. **场景 B：企业级知识库 (+精准的文本匹配)**
    - **推荐:** **Weaviate**、**Elasticsearch**、**MongoDB Atlas**。
-   - **理由:** 纯向量搜索在匹配专有名词（如产品型号“X-2000”、人名、法律条款号）时效果很差，因为这些词在 Embedding 空间中可能被“平均化”了（Out-of-vocabulary 问题），必须结合关键词检索解决 OOV 问题。Weaviate 利用 RRF 自动平衡关键词和向量权重、ES 的 kNN + Filter、MongoDB Atlas 的 Lucene 全文检索（$vectorSearch + $search）都具备良好的 Hybrid Search 能力。
+   - **理由:** 纯向量搜索在匹配专有名词（如产品型号“X-2000”、人名、法律条款号）时效果很差，因为这些词在 Embedding 空间中可能被“平均化”了（Out-of-vocabulary 问题），必须结合关键词检索解决 OOV 问题。Weaviate 利用 RRF 自动平衡关键词和向量权重、ES 的 kNN + Filter、MongoDB Atlas 的 Lucene 全文检索（`$vectorSearch` + `$search`）都具备良好的 Hybrid Search 能力。
 3. **场景 C：高并发推荐系统 / 广告投放 / 图像搜索**
    - **推荐:** **Milvus** (通用高性能), **Vertex AI** (Google 生态), 或 **Vespa** (复杂计算)。
    - **理由:** 这里的瓶颈是 QPS（每秒查询数）、Latency（延迟）、写入实时性。如果需要每秒处理数万次查询，且要求 10ms 内返回，**Redis** 或 **Qdrant** 是单机性价比之选；如果规模大到需要分布式，Milvus 的存算分离架构能让你独立扩容查询节点（Query Node）以保证高并发（Milvus 对 GPU 索引的支持可以进一步降低超大规模下的延迟），消息队列架构保证了写入不丢数据。Vespa 可以在检索时做复杂的重排序（Re-ranking），适合广告业务。

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -288,7 +288,7 @@ cmd_start() {
       exit 1
     fi
   done
-  log_ok "uv $(uv --version 2>/dev/null | head -1), pnpm $(pnpm --version 2>/dev/null)"
+  log_ok "$(uv --version 2>/dev/null | head -1), pnpm $(pnpm --version 2>/dev/null)"
 
   if ! $no_pull && git -C "$REPO_ROOT" rev-parse --is-inside-work-tree &>/dev/null; then
     log_info "拉取最新代码..."
@@ -330,11 +330,11 @@ cmd_start() {
   # Phase 4 — 前端构建
   if ! $skip_build; then
     log_phase "Phase 4/5: 前端构建"
-    # 依赖链：perceives（MCP 前置）→ backend（ui BFF 数据源，wiki 不再依赖 backend）。
-    # wiki 纯静态化后构建期只读本地 content/，无需 backend 在线；此处 backend 仅为
-    # ui 运行时提前就绪。
-    start_service "$SVC_PERCEIVES" || log_warn "perceives 启动失败，backend 可能降级"
-    start_service "$SVC_BACKEND" || log_warn "backend 启动失败，ui BFF 将不可用"
+    # 构建期零服务依赖：
+    #   - sync-wiki-content.sh 直连 PostgreSQL（不经 backend HTTP）；
+    #   - wiki next build 读本地 content/（output:"export"，零 backend/DB）；
+    #   - ui next build 不调用运行时 backend。
+    # 故 perceives/backend 统一延后到 Phase 5 按依赖链启动，构建期不占端口、无孤儿风险。
 
     # agents-chat-core 仍是 ui 的工作区依赖（wiki 纯静态化后已移除该依赖）。
     # tsup 配置 clean:true（每次构建先清空 dist），故在此显式构建一次，并通过
@@ -364,14 +364,24 @@ cmd_start() {
 
   # Phase 5 — 服务启动
   log_phase "Phase 5/5: 服务启动"
-  # 注册 trap：启动过程中 Ctrl+C 清理已启动的服务
-  trap 'log_warn "收到中断信号，清理已启动的服务..."; cmd_stop; exit 130' INT TERM
+  # EXIT trap 兜底：启动未完成时，无论 errexit 失败还是收到中断信号，都清理已启动的服务。
+  # 选用 EXIT 而非 INT/TERM：set -e 下前台命令失败时 shell 在命令边界前即 errexit 退出，
+  # INT/TERM trap 不会被触发；唯有 EXIT trap 在 errexit 退出路径上仍保证执行（bash 语义）。
+  _STARTUP_DONE=0
+  _cleanup_on_exit() {
+    trap - EXIT INT TERM          # 首行清空 trap，防 handler 重入
+    [ "${_STARTUP_DONE:-0}" = "1" ] && return 0
+    log_warn "启动未完成，清理已启动的服务..."
+    cmd_stop >/dev/null 2>&1 || true
+  }
+  trap '_cleanup_on_exit' EXIT
 
   for svc in "${ALL_SERVICES[@]}"; do
-    start_service "$svc" || { log_error "${svc} 启动失败，中止"; cmd_stop; exit 1; }
+    start_service "$svc" || { log_error "${svc} 启动失败，中止"; exit 1; }
   done
 
-  trap - INT TERM
+  _STARTUP_DONE=1
+  trap - EXIT INT TERM            # 全部成功：清除兜底，避免脚本正常退出误杀刚启动的服务
 
   echo ""
   log_ok "所有服务已启动"
@@ -424,28 +434,28 @@ cmd_logs() {
 cmd_build() {
   log_phase "仅构建（不启动）"
   run_dir_init
-  # 依赖链：perceives（MCP 前置）→ backend（ui BFF 数据源；wiki 纯静态化后独立构建）
-  start_service "$SVC_PERCEIVES" || log_warn "perceives 启动失败，backend 可能降级"
-  start_service "$SVC_BACKEND" || log_warn "backend 启动失败，ui BFF 将不可用"
+  # 构建期零服务依赖：sync-wiki-content.sh 直连 PostgreSQL（不经 backend HTTP），
+  # wiki next build 读本地 content/（output:"export"，零 backend/DB），
+  # ui next build 不调用运行时 backend —— 全程无需启动任何服务。
   # 纯静态 wiki：构建前从 DB 导出已发布内容（本地 publish→build 闭环）。
   log_info "同步 Wiki 已发布内容到 content/..."
   bash "$REPO_ROOT/scripts/sync-wiki-content.sh" \
     || log_warn "Wiki 内容导出失败（DB 未就绪 / 未迁移 / 无已发布内容？）沿用既有 content/"
+
+  # agents-chat-core 是 ui 的工作区依赖（wiki 纯静态化后已移除该依赖）。
+  # tsup 配置 clean:true（每次构建先清空 dist），故在此显式构建一次，并通过
+  # NEGENTROPY_CORE_PREBUILT 让 ui 的 prebuild 跳过重建（与 cmd_start 一致）。
+  log_info "构建 agents-chat-core..."
+  (cd "$REPO_ROOT" && pnpm --filter @negentropy/agents-chat-core build) \
+    || { log_error "agents-chat-core 构建失败"; exit 1; }
+
   log_info "构建 ui + wiki (并行)..."
-  (cd "$REPO_ROOT/apps/negentropy-ui" && pnpm build) &
+  (cd "$REPO_ROOT/apps/negentropy-ui" && NEGENTROPY_CORE_PREBUILT=1 pnpm build) &
   local pid_ui=$!
   (cd "$REPO_ROOT/apps/negentropy-wiki" && pnpm build) &
   local pid_wiki=$!
   local _rc=0; wait "$pid_ui" || _rc=$?; wait "$pid_wiki" || _rc=$?
-  # 倒序回收，先停 backend 再停 perceives
-  if (( _rc )); then
-    log_error "前端构建失败"
-    stop_service "$SVC_BACKEND"
-    stop_service "$SVC_PERCEIVES"
-    exit 1
-  fi
-  stop_service "$SVC_BACKEND"
-  stop_service "$SVC_PERCEIVES"
+  (( _rc )) && { log_error "前端构建失败"; exit 1; }
   log_ok "前端构建完成"
 }
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`scripts/cli.sh restart` 启动日志暴露多处缺陷——Phase 4「前端构建」提前启动 perceives/backend 致 Phase 5 误报「已在运行」、构建期无清理 trap 致 Ctrl+C 留孤儿进程、版本日志重复打印工具名（`uv uv`）、`cmd_build` 与 `cmd_start` 构建链不一致；并伴生 wiki 构建的 LaTeX 中文误入 math mode、ui recharts 图表 SSR 宽高 -1 等上游告警。
- 关联上下文：启动日志诊断驱动的新修复，无对应既有 Issue。

# 核心变更
- **cli.sh 控制流正交分解**：移除 Phase 4 冗余的 perceives/backend 启动（构建期零服务依赖已三方证伪），统一收敛至 Phase 5 按依赖链启动；Phase 5 由不可靠的 INT/TERM trap 改为 **EXIT trap 兜底**（`set -e` errexit 路径上唯一保证执行的 hook），配 `_STARTUP_DONE` 守卫防正常退出误杀服务。
- **cmd_build 对齐 cmd_start**：移除构建期服务启停，显式构建 agents-chat-core 并设 `NEGENTROPY_CORE_PREBUILT=1`，消除 tsup `clean:true` 下的 prebuild 竞态。
- **版本日志去重**：`log_ok "uv $(uv --version…)"` → `log_ok "$(uv --version…)"`，消除 `uv uv 0.11.16`。
- **B1 LaTeX**：`docs/research/031-vector-databases-selection.md` 第 319/527 行 MongoDB 运算符（`$vectorSearch`/`$match`/`$project`/`$lookup`/`$search`）改反引号行内代码，避免 remark-math 误判为 LaTeX 定界符致中文整句进入 math mode。
- **B3 recharts SSR**：DimensionCharts / SystemMetricsPanel / RoutineRunGantt / RoutineConvergenceChart 四组件的 ResponsiveContainer 补 `minWidth={1} minHeight={1}` props，以 recharts `max(measured, min)` 兜底消除 SSG width(-1)。
- **B2 Turbopack NFT（已回退）**：曾尝试 `outputFileTracingRoot: process.cwd()` 收敛 NFT 追踪根，但 CI 的 pnpm hoisting 将 next 提升至 monorepo 根 node_modules、收缩 Turbopack 边界后从 src/app 解析不到 next/package.json 致 wiki-quality 构建失败（本地 node_modules 布局不同故未暴露）。已在 `e9c05821` 回退并保留经验注释；该 NFT 告警为无害诊断（output:export 不依赖 NFT），不再处理。

# 风险与回滚
- 主要风险：方案 Q 改变 restart 时序（backend 不再构建期预热，延后至 Phase 5 约 7s 启动）；EXIT trap 时机错误可能误杀服务（已由 `_STARTUP_DONE` + `trap - EXIT` 双保险 + bash 语义微测试验证）。
- 回滚方式：`git revert` 相关 commit；cli.sh 回滚最小，仅需恢复 Phase 4 两行 `start_service`。

# 验证证据
- 单元测试：`bash scripts/tests/test_log_rotation.sh` → **PASS=10 FAIL=0**。
- 集成测试：`bash -n scripts/cli.sh` 语法通过；EXIT trap bash 语义微测试证实 errexit 时触发、正常完成时不误触发。
- E2E/Workflow：pre-commit hooks（ESLint negentropy-ui / next lint negentropy-wiki）全部 Passed；shellcheck 仅 1 条既有 SC2086（非本次引入）。
- CI：首次推送 wiki-quality 失败（B2 收缩 Turbopack 边界），已在 `e9c05821` 回退修复，待 CI 重跑确认。
- 覆盖率：restart 全流程 + Ctrl+C `lsof` 孤儿清理验证待主仓执行（conductor 工作区与 live 引擎同 DB/端口冲突）。

# 影响范围
- 前端：4 个 recharts 组件加 SSR 尺寸守卫（渲染逻辑不变）。
- 后端：无（cli.sh 为编排脚本，服务代码未改）。
- GitHub Actions / 文档：`docs/research/031-vector-databases-selection.md` 修正 LaTeX 书写。

# Next Best Action
- 关注 PR #949 wiki-quality CI 重跑结果（`e9c05821` 推送后），确认构建恢复。
- 在主仓执行 `./scripts/cli.sh restart` 全流程验证：Phase 顺序 / `uv` 去重 / 告警清零 / Ctrl+C `lsof` 孤儿清理。