### PR TITLE
fix(UI): 移除 Home/Studio 输入框模型选择框冗余的下拉箭头

### DIFF
--- a/apps/negentropy-ui/components/ui/Composer.tsx
+++ b/apps/negentropy-ui/components/ui/Composer.tsx
@@ -485,6 +485,7 @@ export function Composer({
               onChange={(v) => onSelectedLlmModelChange?.(v === "" ? null : v)}
               allowClear={false}
               ariaLabel="选择主 Agent 使用的 LLM"
+              showChevron={false}
             />
           )}
           {showThinkingToggle && (

--- a/apps/negentropy-ui/components/ui/LlmModelSelect.tsx
+++ b/apps/negentropy-ui/components/ui/LlmModelSelect.tsx
@@ -15,6 +15,7 @@ type LlmModelSelectProps = {
   disabled?: boolean;
   className?: string;
   ariaLabel?: string;
+  showChevron?: boolean;
 };
 
 function buildFullModelName(vendor: string, modelName: string): string {
@@ -39,6 +40,7 @@ export function LlmModelSelect({
   disabled,
   className,
   ariaLabel,
+  showChevron = true,
 }: LlmModelSelectProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [navIdx, setNavIdx] = useState(0);
@@ -219,13 +221,15 @@ export function LlmModelSelect({
         aria-haspopup="listbox"
         disabled={disabled}
         onClick={handleTriggerClick}
-        className="h-7 rounded-md border border-border/50 bg-transparent pl-2 pr-6 text-xs text-foreground outline-none transition-colors hover:border-border hover:bg-border-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer focus-visible:ring-2 focus-visible:ring-ring"
+        className={`h-7 rounded-md border border-border/50 bg-transparent pl-2 ${showChevron ? "pr-6" : "pr-2"} text-xs text-foreground outline-none transition-colors hover:border-border hover:bg-border-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer focus-visible:ring-2 focus-visible:ring-ring`}
       >
         <span className="truncate max-w-48 inline-block align-middle">{displayLabel}</span>
-        <ChevronDown
-          className={`pointer-events-none absolute right-1.5 h-3 w-3 text-text-muted transition-transform ${isOpen ? "rotate-180" : ""}`}
-          aria-hidden
-        />
+        {showChevron && (
+          <ChevronDown
+            className={`pointer-events-none absolute right-1.5 h-3 w-3 text-text-muted transition-transform ${isOpen ? "rotate-180" : ""}`}
+            aria-hidden
+          />
+        )}
       </button>
 
       {isOpen &&


### PR DESCRIPTION
## 背景

用户反馈：Home / Studio 页中栏下部聊天输入框（Composer）内，左侧模型选择框（显示如 `gpt-5-nano`）右下角的 `ChevronDown` 下拉箭头在此紧凑内联场景中显得冗余，需要移除。

## 爆炸半径分析

该模型选择器为共享组件 `LlmModelSelect`，被两处复用：

| 调用方 | 上下文 | 是否保留箭头 |
|---|---|---|
| `Composer`（聊天输入框） | 紧凑内联 pill，紧邻附件按钮 + Thinking 开关 | ❌ 移除（本次诉求） |
| `AgentFormDrawer`（Agent 配置表单） | 带 `<label>Model</label>` 的表单字段，与原生 `<select>`（Agent Type / Visibility）并列 | ✅ 保留（与相邻原生下拉视觉一致） |

原生 `<select>` 天然带下拉箭头，若全局移除会破坏 AgentFormDrawer 的视觉一致性，故采用「作用域可控」方案，而非全局移除。

## 方案

采用「默认显示 + 调用方 opt-out」的 prop：

- `apps/negentropy-ui/components/ui/LlmModelSelect.tsx`
  - 新增 `showChevron?: boolean`（默认 `true`，保留既有行为）
  - 按钮右内边距联动：`showChevron ? "pr-6" : "pr-2"`，隐藏箭头时收紧内边距，避免出现死空隙
  - `ChevronDown` 改为条件渲染：`{showChevron && (<ChevronDown ... />)}`
- `apps/negentropy-ui/components/ui/Composer.tsx`
  - 仅在此调用方传入 `showChevron={false}`
- `AgentFormDrawer.tsx` —— **零改动**，走默认 `true`

无障碍不受影响：`<button>` 仍保留 `aria-haspopup="listbox"` 与 `aria-expanded`，屏幕阅读器仍播报为下拉。

## 验证

- ✅ `pnpm typecheck`（`tsc --noEmit`）通过
- ✅ `pnpm lint`（`eslint --max-warnings=0`）通过
- ✅ pre-commit hooks（含 ESLint）通过
- 待人工实机回归：`pnpm dev` → `http://localhost:3192/studio`
  - Home/Studio 输入框：模型选择框右下角箭头已消失、左右内边距对称、点击仍可正常展开/收起下拉
  - Agent 配置抽屉（Interface → Agents）：Model 字段下拉箭头仍在，与相邻原生 `<select>` 一致

---
🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)