### PR TITLE
feat(Knowledge): 文档 File Name 支持就地重命名并全局传播;

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/_components/retrieved-chunk-presenter.ts
+++ b/apps/negentropy-ui/app/knowledge/base/_components/retrieved-chunk-presenter.ts
@@ -29,6 +29,8 @@ interface RetrievedChunkMetadata extends Record<string, unknown> {
   parent_chunk_index?: number | string;
   chunk_index?: number | string;
   original_filename?: string;
+  /** 用户重命名覆盖（display_name），优先于 original_filename。 */
+  display_name?: string;
   matched_child_chunk_indices?: unknown[];
   matched_child_chunks?: Array<{
     id?: string;
@@ -73,6 +75,17 @@ function basenameFromUri(sourceUri?: string): string | null {
 }
 
 function resolveSourceLabel(match: KnowledgeMatch, metadata: RetrievedChunkMetadata) {
+  // 优先 display_name（用户重命名覆盖）→ original_filename → source_uri basename
+  const displayName = typeof metadata.display_name === "string"
+    ? metadata.display_name.trim()
+    : "";
+  if (displayName) {
+    return {
+      label: displayName,
+      title: displayName,
+    };
+  }
+
   const explicit = typeof metadata.original_filename === "string"
     ? metadata.original_filename.trim()
     : "";

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -37,6 +37,7 @@ import {
   unarchiveDocument,
   downloadDocument,
   deleteDocument,
+  effectiveDocumentName,
   normalizeChunkingConfig,
   PipelineStatusBadge,
 } from "@/features/knowledge";
@@ -892,7 +893,7 @@ export default function KnowledgeBasePage() {
                                 className="min-w-0 text-left"
                                 onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id })}
                               >
-                                <p className="truncate text-sm font-medium">{doc.original_filename}</p>
+                                <p className="truncate text-sm font-medium">{effectiveDocumentName(doc)}</p>
                                 <div className="flex items-center gap-1.5 text-caption text-muted-foreground">
                                   <span>{sourceType} · {doc.file_size} bytes</span>
                                   <PipelineStatusBadge

--- a/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/features/knowledge/utils/knowledge-api";
 import {
   downloadDocument,
+  effectiveDocumentName,
   fetchDocumentDetail,
   LIBRARY_CORPUS_SEGMENT,
   refreshDocumentMarkdown,
@@ -286,7 +287,7 @@ export default function DocumentDetailPage() {
   return (
     <div className="flex h-full flex-col bg-background">
       <KnowledgeNav
-        title={detail?.original_filename || "Document Detail"}
+        title={detail ? effectiveDocumentName(detail) : "Document Detail"}
       />
 
       {/* Action bar */}
@@ -359,8 +360,8 @@ export default function DocumentDetailPage() {
               {getFileIcon(detail.content_type)}
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
-                  <h1 className="truncate text-xl font-semibold text-foreground" title={detail.original_filename}>
-                    {detail.original_filename}
+                  <h1 className="truncate text-xl font-semibold text-foreground" title={effectiveDocumentName(detail)}>
+                    {effectiveDocumentName(detail)}
                   </h1>
                   <span className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-micro font-medium ${statusBadge.bg} ${statusBadge.text}`}>
                     {statusBadge.label}

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -22,7 +22,10 @@ import {
   CorpusRecord,
   formatRelativeTime,
   LIBRARY_CORPUS_SEGMENT,
+  effectiveDocumentName,
+  useInlineDocumentRename,
 } from "@/features/knowledge";
+import { Check, Pencil, X } from "lucide-react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
@@ -168,6 +171,27 @@ export default function DocumentsPage() {
   useHeartbeatPoll(silentReload, {
     enabled: anyTranslating || anyExtracting,
     fireImmediately: false,
+  });
+
+  // 行内重命名 File Name → 写入 display_name（逻辑下沉到 useInlineDocumentRename，
+  // 与 Wiki 目录共用）。保存成功后按服务端返回值局部 patch，避免全量 loadDocuments
+  // 与心跳轮询/分页互相打架。
+  const handleRenameSaved = useCallback((updated: KnowledgeDocument) => {
+    setDocuments((docs) => docs.map((d) => (d.id === updated.id ? updated : d)));
+  }, []);
+  const {
+    editingId,
+    editDraft,
+    setEditDraft,
+    saving: renaming,
+    editInputRef,
+    startEdit,
+    cancelEdit,
+    commitEdit,
+    handleKeyDown,
+  } = useInlineDocumentRename({
+    onSaved: handleRenameSaved,
+    savingToast: "文件名称已更新",
   });
 
   const totalPages = Math.ceil(total / pageSize);
@@ -421,7 +445,7 @@ export default function DocumentsPage() {
                   {documents.map((doc) => (
                     <div
                       key={doc.id}
-                      className="flex items-center px-4 py-3 text-sm hover:bg-muted/30 transition-colors"
+                      className="group flex items-center px-4 py-3 text-sm hover:bg-muted/30 transition-colors"
                     >
                       {/* 勾选 - 固定宽 */}
                       <div className="w-8 shrink-0 flex justify-center">
@@ -439,17 +463,65 @@ export default function DocumentsPage() {
                         />
                       </div>
                       <div className="grid grid-cols-12 gap-2 flex-1 items-center">
-                      {/* 文件名 - col-span-3 */}
+                      {/* 文件名 - col-span-3，支持就地重命名（写 display_name） */}
                       <div className="col-span-3 flex items-center gap-2">
                         {getFileIcon(doc.content_type)}
-                        <div className="min-w-0">
-                          <p className="font-medium text-foreground truncate" title={doc.original_filename}>
-                            {doc.original_filename}
-                          </p>
-                          <p className="text-xs text-muted-foreground truncate">
-                            {doc.content_type || "Unknown"}
-                          </p>
-                        </div>
+                        {editingId === doc.id ? (
+                          <div className="flex items-center gap-1 min-w-0 flex-1">
+                            <input
+                              ref={editInputRef}
+                              type="text"
+                              value={editDraft}
+                              onChange={(e) => setEditDraft(e.target.value)}
+                              onKeyDown={(e) => handleKeyDown(e, doc)}
+                              placeholder="留空则使用源名称"
+                              maxLength={255}
+                              disabled={renaming}
+                              aria-label="编辑文件名称"
+                              className="flex-1 min-w-0 h-6 px-1.5 text-sm rounded border border-primary/50 bg-transparent focus:outline-none focus:ring-1 focus:ring-primary"
+                            />
+                            <button
+                              onClick={() => void commitEdit(doc)}
+                              disabled={renaming}
+                              title="保存"
+                              aria-label="保存文件名称"
+                              className="shrink-0 p-0.5 rounded text-muted-foreground hover:text-green-600 disabled:opacity-50"
+                            >
+                              <Check className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              onClick={cancelEdit}
+                              disabled={renaming}
+                              title="取消"
+                              aria-label="取消编辑"
+                              className="shrink-0 p-0.5 rounded text-muted-foreground hover:text-red-500 disabled:opacity-50"
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        ) : (
+                          <div className="min-w-0 flex-1 flex items-center gap-1">
+                            <div className="min-w-0">
+                              <p
+                                className="font-medium text-foreground truncate"
+                                title={effectiveDocumentName(doc)}
+                              >
+                                {effectiveDocumentName(doc)}
+                              </p>
+                              <p className="text-xs text-muted-foreground truncate">
+                                {doc.content_type || "Unknown"}
+                              </p>
+                            </div>
+                            <button
+                              onClick={() => startEdit(doc)}
+                              title="编辑文件名称"
+                              aria-label="编辑文件名称"
+                              className="shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 rounded text-muted-foreground hover:text-blue-600 hover:bg-blue-50 transition-opacity"
+                            >
+                              <Pencil className="h-3 w-3" />
+                            </button>
+                          </div>
+                        )}
                       </div>
 
                       {/* 大小 - col-span-1 */}

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
@@ -6,12 +6,12 @@
  */
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   fetchCatalogNodeDocuments,
   unassignDocumentFromNode,
-  updateDocument,
-  KnowledgeDocument,
+  useInlineDocumentRename,
+  type KnowledgeDocument,
 } from "@/features/knowledge";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { toast } from "@/lib/activity-toast";
@@ -41,11 +41,6 @@ export function DocumentAssignmentSection({
   const [docs, setDocs] = useState<KnowledgeDocument[]>([]);
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
-  // 行内编辑态：正在编辑的文档 id
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editDraft, setEditDraft] = useState("");
-  const [saving, setSaving] = useState(false);
-  const editInputRef = useRef<HTMLInputElement>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -62,14 +57,6 @@ export function DocumentAssignmentSection({
   useEffect(() => {
     void refresh();
   }, [refresh]);
-
-  // 编辑态挂载后自动聚焦
-  useEffect(() => {
-    if (editingId) {
-      editInputRef.current?.focus();
-      editInputRef.current?.select();
-    }
-  }, [editingId]);
 
   const handleRemove = useCallback(
     async (docId: string, filename: string) => {
@@ -95,51 +82,21 @@ export function DocumentAssignmentSection({
     void refresh();
   }, [refresh]);
 
-  const startEdit = useCallback((doc: KnowledgeDocument) => {
-    setEditingId(doc.id);
-    setEditDraft(doc.display_name ?? "");
-  }, []);
-
-  const cancelEdit = useCallback(() => {
-    setEditingId(null);
-    setEditDraft("");
-  }, []);
-
-  const commitEdit = useCallback(
-    async (doc: KnowledgeDocument) => {
-      const trimmed = editDraft.trim() || null;
-      // 无变化时静默退出
-      if (trimmed === (doc.display_name ?? null)) {
-        cancelEdit();
-        return;
-      }
-      setSaving(true);
-      try {
-        await updateDocument(doc.corpus_id, doc.id, { display_name: trimmed });
-        toast.success("保存成功，下次发布生效");
-        setEditingId(null);
-        setEditDraft("");
-        await refresh();
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : "保存失败");
-      } finally {
-        setSaving(false);
-      }
-    },
-    [cancelEdit, editDraft, refresh],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent, doc: KnowledgeDocument) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        void commitEdit(doc);
-      } else if (e.key === "Escape") {
-        cancelEdit();
-      }
-    },
-    [cancelEdit, commitEdit],
-  );
+  // 行内重命名 display_name（逻辑下沉到 useInlineDocumentRename，与 Documents 页共用）
+  const {
+    editingId,
+    editDraft,
+    setEditDraft,
+    saving,
+    editInputRef,
+    startEdit,
+    cancelEdit,
+    commitEdit,
+    handleKeyDown,
+  } = useInlineDocumentRename({
+    onSaved: () => refresh(),
+    savingToast: "保存成功，下次发布生效",
+  });
 
   return (
     <div className="px-5 py-4 border-t border-border">

--- a/apps/negentropy-ui/features/knowledge/hooks/useInlineDocumentRename.ts
+++ b/apps/negentropy-ui/features/knowledge/hooks/useInlineDocumentRename.ts
@@ -1,0 +1,119 @@
+/**
+ * 文档 display_name 行内重命名 Hook（单一职责、复用驱动）。
+ *
+ * 抽取自 Wiki 目录 `DocumentAssignmentSection` 的行内编辑逻辑，供 Knowledge → Documents
+ * 页与 Wiki 目录共用，避免双份漂移。调用方经 `onSaved(updated)` 回写各自 state
+ * （Documents 页做局部 patch；Wiki 目录走 `refresh()`）。
+ *
+ * 遵循 AGENTS.md：Single Source of Truth（display_name 写入仅此一处）、Reuse-Driven。
+ */
+
+"use client";
+
+import { type KeyboardEvent, type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+import { type KnowledgeDocument, updateDocument } from "../utils/knowledge-api";
+import { toast } from "@/lib/activity-toast";
+
+export interface UseInlineDocumentRenameOptions {
+  /** 保存成功后回调，参数为服务端返回的规范化文档（含最终 display_name）。 */
+  onSaved: (updated: KnowledgeDocument) => void | Promise<void>;
+  /** 保存成功 toast 文案（默认「保存成功」）。 */
+  savingToast?: string;
+}
+
+export interface UseInlineDocumentRename {
+  editingId: string | null;
+  editDraft: string;
+  setEditDraft: (value: string) => void;
+  saving: boolean;
+  editInputRef: RefObject<HTMLInputElement | null>;
+  startEdit: (doc: KnowledgeDocument) => void;
+  cancelEdit: () => void;
+  commitEdit: (doc: KnowledgeDocument) => void;
+  handleKeyDown: (e: KeyboardEvent, doc: KnowledgeDocument) => void;
+}
+
+/**
+ * 管理单个文档 `display_name` 的行内编辑生命周期（编辑/草稿/保存/聚焦/快捷键）。
+ *
+ * - Enter 保存、Escape 取消；
+ * - 无变化时静默退出；
+ * - 失败保留编辑态供重试，并 toast 报错；
+ * - 保存期间 `saving=true`，调用方据此禁用输入与按钮。
+ */
+export function useInlineDocumentRename({
+  onSaved,
+  savingToast = "保存成功",
+}: UseInlineDocumentRenameOptions): UseInlineDocumentRename {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  // 编辑态挂载后自动聚焦并全选
+  useEffect(() => {
+    if (editingId) {
+      editInputRef.current?.focus();
+      editInputRef.current?.select();
+    }
+  }, [editingId]);
+
+  const startEdit = useCallback((doc: KnowledgeDocument) => {
+    setEditingId(doc.id);
+    setEditDraft(doc.display_name ?? "");
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setEditingId(null);
+    setEditDraft("");
+  }, []);
+
+  const commitEdit = useCallback(
+    async (doc: KnowledgeDocument) => {
+      const trimmed = editDraft.trim() || null;
+      // 无变化时静默退出
+      if (trimmed === (doc.display_name ?? null)) {
+        cancelEdit();
+        return;
+      }
+      setSaving(true);
+      try {
+        const updated = await updateDocument(doc.corpus_id, doc.id, { display_name: trimmed });
+        toast.success(savingToast);
+        setEditingId(null);
+        setEditDraft("");
+        await onSaved(updated);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "保存失败");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [cancelEdit, editDraft, onSaved, savingToast],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent, doc: KnowledgeDocument) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void commitEdit(doc);
+      } else if (e.key === "Escape") {
+        cancelEdit();
+      }
+    },
+    [cancelEdit, commitEdit],
+  );
+
+  return {
+    editingId,
+    editDraft,
+    setEditDraft,
+    saving,
+    editInputRef,
+    startEdit,
+    cancelEdit,
+    commitEdit,
+    handleKeyDown,
+  };
+}

--- a/apps/negentropy-ui/features/knowledge/index.ts
+++ b/apps/negentropy-ui/features/knowledge/index.ts
@@ -33,6 +33,12 @@ export type {
   UseKnowledgeSearchReturnValue,
 } from "./hooks/useKnowledgeSearch";
 
+export { useInlineDocumentRename } from "./hooks/useInlineDocumentRename";
+export type {
+  UseInlineDocumentRenameOptions,
+  UseInlineDocumentRename,
+} from "./hooks/useInlineDocumentRename";
+
 // ============================================================================
 // Utils (API Functions)
 // ============================================================================
@@ -68,6 +74,7 @@ export {
   fetchDocumentChunks,
   fetchDocumentChunkDetail,
   updateDocument,
+  effectiveDocumentName,
   updateDocumentChunk,
   regenerateDocumentChunkFamily,
   refreshDocumentMarkdown,

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1363,6 +1363,20 @@ export interface KnowledgeDocumentDetail extends KnowledgeDocument {
   markdown_uri: string | null;
 }
 
+/**
+ * 文件列表语境下的「有效名称」：`display_name`（用户重命名覆盖）→ `original_filename`。
+ *
+ * 注意：与 Wiki 目录的 `effectiveDisplayName`（含 `metadata.title` 三段回退）**刻意分离** ——
+ * 「File Name」列只应显示用户填的名或源文件名，不该把 PDF 自动抽取的 title 污染进来；
+ * `metadata.title` 回退是 Wiki 发布语境（后端 `_resolve_doc_display_title`）的职责。
+ */
+export function effectiveDocumentName(
+  doc: Pick<KnowledgeDocument, "display_name" | "original_filename">,
+): string {
+  const displayName = (doc.display_name ?? "").trim();
+  return displayName || doc.original_filename;
+}
+
 export interface DocumentMarkdownRefreshResponse {
   document_id: string;
   status: string;

--- a/apps/negentropy/src/negentropy/knowledge/_shared.py
+++ b/apps/negentropy/src/negentropy/knowledge/_shared.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -658,11 +659,44 @@ def _serialize_document_chunk_item(item: KnowledgeRecord, siblings: list[Knowled
     }
 
 
+def effective_display_name(doc: Any) -> str:
+    """文档展示名的单一事实源（ORM 级）。
+
+    优先级：``display_name``（用户手填覆盖）→ ``metadata_.title``
+    （PDF / 抓取自动抽取）→ ``original_filename``（不可变兜底）。
+
+    用于 Wiki 发布 entry_title 解析等需要「文档标题」的 ORM 级场景。
+    chunk 字典级读取方见
+    :meth:`KnowledgeRepository._infer_display_name`，二者语义对齐、须同步演进。
+    """
+    display_name = (getattr(doc, "display_name", None) or "").strip()
+    if display_name:
+        return display_name
+    meta = getattr(doc, "metadata_", None) or {}
+    meta_title = meta.get("title")
+    if isinstance(meta_title, str) and meta_title.strip():
+        return meta_title.strip()
+    return doc.original_filename
+
+
+def effective_download_filename(original_filename: str, display_name: str | None) -> str:
+    """下载文件名：``display_name`` 覆盖 → ``original_filename``，并保留原扩展名。
+
+    扩展名取自物理文件名，确保下载内容与扩展名一致、可被正确打开；
+    用户名已以相同扩展名（大小写不敏感）结尾则不重复追加。URL 文档的
+    ``.md`` 收尾由调用方在拿到本结果后另行处理。
+    """
+    ext = os.path.splitext(original_filename)[1]
+    base = (display_name or "").strip() or original_filename
+    return f"{base}{ext}" if (ext and not base.lower().endswith(ext.lower())) else base
+
+
 def _build_document_chunk_metadata(doc: Any, items: list[KnowledgeRecord]) -> dict[str, Any]:
     chunk_stats = ((doc.metadata_ or {}).get("chunk_stats") or {}) if doc else {}
     total_retrieval_count = sum(item.retrieval_count for item in items)
     return {
         "original_filename": getattr(doc, "original_filename", None),
+        "display_name": getattr(doc, "display_name", None) or None,
         "file_size": getattr(doc, "file_size", None),
         "upload_date": doc.created_at.isoformat() if getattr(doc, "created_at", None) else None,
         "last_update_date": doc.updated_at.isoformat() if getattr(doc, "updated_at", None) else None,

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_service.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from negentropy.knowledge._shared import effective_display_name
 from negentropy.knowledge.lifecycle_schemas import (
     WikiEntryContentResponse,
     WikiPublishTarget,
@@ -191,6 +192,7 @@ def build_entry_content_response(
 def _resolve_doc_display_title(doc: Any) -> str:
     """决定文档在 Wiki 站点上的展示标题（单一事实源）。
 
+    委托给 :func:`negentropy.knowledge._shared.effective_display_name`，
     优先级：``display_name``（用户手填覆盖）→ ``metadata_.title``
     （PDF / 抓取自动抽取）→ ``original_filename``（兜底）。
 
@@ -198,13 +200,7 @@ def _resolve_doc_display_title(doc: Any) -> str:
     ``routes.wiki.get_entry_content``，保证后端 entry_title 与前端
     SSG 展示一致。
     """
-    display_name = (getattr(doc, "display_name", None) or "").strip()
-    if display_name:
-        return display_name
-    meta_title = (doc.metadata_ or {}).get("title") if getattr(doc, "metadata_", None) else None
-    if isinstance(meta_title, str) and meta_title.strip():
-        return meta_title.strip()
-    return doc.original_filename
+    return effective_display_name(doc)
 
 
 class WikiPublishingService:

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/citation_search.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/citation_search.py
@@ -71,7 +71,8 @@ def format_citation(
     """
     meta = metadata or {}
     arxiv_id = (meta.get("arxiv_id") or "").strip()
-    title = (meta.get("title") or "").strip()
+    # 优先 display_name（用户重命名覆盖），回退到抽取标题 title
+    title = (meta.get("display_name") or "").strip() or (meta.get("title") or "").strip()
     authors = meta.get("authors") or []
     if not isinstance(authors, list):
         authors = []

--- a/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
+++ b/apps/negentropy/src/negentropy/knowledge/retrieval/repository.py
@@ -1326,7 +1326,17 @@ class KnowledgeRepository:
 
     @staticmethod
     def _infer_display_name(metadata: dict[str, Any] | None) -> str | None:
-        raw = (metadata or {}).get("original_filename")
+        """从 chunk metadata 推断展示名（dict 级读取方）。
+
+        优先 ``display_name``（用户重命名覆盖，由
+        :meth:`DocumentStorageService.update_document_display_name` 回填）→
+        回退 ``original_filename``。与 ``_shared.effective_display_name``（ORM 级）
+        语义对齐，二者须同步演进。
+        """
+        m = metadata or {}
+        raw = m.get("display_name")
+        if not (isinstance(raw, str) and raw.strip()):
+            raw = m.get("original_filename")
         return raw if isinstance(raw, str) and raw.strip() else None
 
     @staticmethod

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -19,6 +19,7 @@ from negentropy.knowledge._shared import (
     _resolve_document_source_uri,
     _resolve_documents_archived_set,
     _resolve_user_display_names,
+    effective_download_filename,
 )
 from negentropy.knowledge.api_helpers import _resolve_app_name
 from negentropy.knowledge.schemas import (
@@ -583,8 +584,9 @@ async def _download_document_impl(
             detail={"code": "DOWNLOAD_FAILED", "message": "Failed to download document"},
         ) from exc
 
-    # 编码文件名以支持中文
-    filename = doc.original_filename
+    # 文件名跟随用户重命名：display_name 覆盖 → original_filename，
+    # 并保留 original_filename 的扩展名，确保下载内容与扩展名一致可正确打开。
+    filename = effective_download_filename(doc.original_filename, doc.display_name)
     if is_url_doc and not filename.lower().endswith(".md"):
         filename = f"{filename}.md"
     encoded_filename = urllib.parse.quote(filename)

--- a/apps/negentropy/src/negentropy/knowledge/routes/ingest.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/ingest.py
@@ -427,6 +427,10 @@ async def ingest_file(
             meta["content_uri"] = content_uri
         if doc_record:
             meta["document_id"] = str(doc_record.id)
+            # 携带 display_name 覆盖，使检索/引用类展示跟随用户重命名（见
+            # DocumentStorageService.update_document_display_name 的回填逻辑）。
+            if getattr(doc_record, "display_name", None):
+                meta["display_name"] = doc_record.display_name
 
         run_id = await service.create_pipeline(
             app_name=resolved_app,

--- a/apps/negentropy/src/negentropy/knowledge/service.py
+++ b/apps/negentropy/src/negentropy/knowledge/service.py
@@ -1126,6 +1126,9 @@ class KnowledgeService:
             meta["source_type"] = "url"
             meta["origin_url"] = url
             meta["document_id"] = str(doc_record.id)
+            # 携带 display_name 覆盖，使检索/引用类展示跟随用户重命名。
+            if getattr(doc_record, "display_name", None):
+                meta["display_name"] = doc_record.display_name
             meta["extractor_trace"] = extraction_result.trace
             if stored_assets:
                 meta["extracted_assets"] = stored_assets

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -6,15 +6,17 @@ including deduplication, listing, and deletion.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
+from negentropy.models.base import NEGENTROPY_SCHEMA
 from negentropy.models.perception import KnowledgeDocument
 from negentropy.serialization import strip_nul_chars
 
@@ -622,6 +624,9 @@ class DocumentStorageService:
           展示侧回退到 ``metadata_.title -> original_filename``）。
         - 长度上限 255；超过抛 ``ValueError``。
         - 与 :meth:`get_document` 一致的 ``corpus_id`` / ``app_name`` 权限校验。
+        - 同事务回填该文档所有 chunk 的 ``metadata.display_name``（附加式），
+          使检索命中片段、来源摘要、聊天引用等 chunk 派生展示即时跟随重命名，
+          无需重新 ingest；``display_name`` 清空时同步删除该键。
 
         Args:
             document_id: 文档 UUID
@@ -658,12 +663,52 @@ class DocumentStorageService:
                 return None
 
             doc.display_name = normalized
+
+            # 同事务回填该文档所有 chunk 的 metadata.display_name（附加式，
+            # 不破坏 original_filename），使检索/引用类展示即时跟随重命名。
+            # chunk 仅经 metadata JSONB 中的 document_id 软关联文档（无 FK 列），
+            # 物理列名为 metadata（ORM 属性为 metadata_）。
+            if normalized is not None:
+                backfill_stmt = text(
+                    f"""
+                    UPDATE {NEGENTROPY_SCHEMA}.knowledge
+                    SET metadata = jsonb_set(
+                        COALESCE(metadata, '{{}}'::jsonb),
+                        '{{display_name}}',
+                        :display_name_json::jsonb
+                    )
+                    WHERE metadata->>'document_id' = :document_id
+                    """
+                )
+                backfill_result = await db.execute(
+                    backfill_stmt,
+                    {
+                        "document_id": str(document_id),
+                        "display_name_json": json.dumps(normalized),
+                    },
+                )
+                chunks_updated = backfill_result.rowcount or 0
+            else:
+                clear_stmt = text(
+                    f"""
+                    UPDATE {NEGENTROPY_SCHEMA}.knowledge
+                    SET metadata = metadata - 'display_name'
+                    WHERE metadata->>'document_id' = :document_id
+                    """
+                )
+                clear_result = await db.execute(
+                    clear_stmt,
+                    {"document_id": str(document_id)},
+                )
+                chunks_updated = clear_result.rowcount or 0
+
             await db.commit()
             await db.refresh(doc)
             logger.info(
                 "document_display_name_updated",
                 doc_id=str(document_id),
                 cleared=normalized is None,
+                chunks_updated=chunks_updated,
             )
             return doc
 

--- a/apps/negentropy/tests/unit_tests/agents/test_perception_citation.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_perception_citation.py
@@ -79,6 +79,27 @@ def test_format_citation_legacy_no_metadata_no_uri():
     assert citation == "[4] Unknown source"
 
 
+def test_format_citation_prefers_display_name_over_title():
+    """用户重命名覆盖（display_name）优先于抽取标题 title，使聊天引用题录跟随重命名。"""
+    from negentropy.agents.tools.perception import _format_citation
+
+    citation = _format_citation(
+        metadata={
+            "arxiv_id": "2310.11511",
+            "title": "Self-RAG: Learning to Retrieve, Generate, and Critique",
+            "display_name": "我的读书笔记",
+            "authors": ["Akari Asai"],
+            "published_at": "2024-01-15T08:30:00Z",
+        },
+        source_uri="https://arxiv.org/pdf/2310.11511.pdf",
+        idx=7,
+    )
+    assert "我的读书笔记" in citation
+    # 被覆盖的 title 不应再出现
+    assert "Self-RAG" not in citation
+    assert citation.startswith("[7]")
+
+
 def test_format_citation_handles_malformed_authors_field():
     """authors 字段不是 list 时（比如脏数据 = "Alice"）也不应抛。"""
     from negentropy.agents.tools.perception import _format_citation

--- a/apps/negentropy/tests/unit_tests/knowledge/test_display_name_helpers.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_display_name_helpers.py
@@ -1,0 +1,74 @@
+"""文档展示名 / 下载文件名单一事实源 helper 单测（纯函数，无 DB）。
+
+覆盖 ``negentropy.knowledge._shared``：
+- :func:`effective_display_name`：``display_name → metadata_.title → original_filename`` 回退链。
+- :func:`effective_download_filename`：``display_name`` 覆盖 + 保留原扩展名。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from negentropy.knowledge._shared import effective_display_name, effective_download_filename
+
+# ----------------------------------------------------------------------------
+# effective_display_name
+# ----------------------------------------------------------------------------
+
+
+def _doc(**kwargs):
+    """构造最小文档对象（display_name / metadata_ / original_filename）。"""
+    base = {"display_name": None, "metadata_": {}, "original_filename": "report.pdf"}
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def test_effective_display_name_prefers_display_name():
+    assert effective_display_name(_doc(display_name="Q3 Report")) == "Q3 Report"
+
+
+def test_effective_display_name_falls_back_to_metadata_title():
+    assert effective_display_name(_doc(display_name=None, metadata_={"title": "Quarterly"})) == "Quarterly"
+
+
+def test_effective_display_name_falls_back_to_original_filename():
+    assert effective_display_name(_doc(display_name=None, metadata_={})) == "report.pdf"
+
+
+def test_effective_display_name_ignores_blank_display_name_and_blank_title():
+    assert effective_display_name(_doc(display_name="   ", metadata_={"title": "  "})) == "report.pdf"
+
+
+def test_effective_display_name_strips_whitespace():
+    assert effective_display_name(_doc(display_name="  Q3 Report  ")) == "Q3 Report"
+
+
+# ----------------------------------------------------------------------------
+# effective_download_filename
+# ----------------------------------------------------------------------------
+
+
+def test_download_filename_appends_extension_when_missing():
+    assert effective_download_filename("report.pdf", "Q3 Report") == "Q3 Report.pdf"
+
+
+def test_download_filename_does_not_double_append_extension():
+    assert effective_download_filename("report.pdf", "Q3 Report.pdf") == "Q3 Report.pdf"
+
+
+def test_download_filename_extension_match_is_case_insensitive():
+    assert effective_download_filename("report.pdf", "Q3 Report.PDF") == "Q3 Report.PDF"
+
+
+def test_download_filename_falls_back_to_original_when_no_display_name():
+    assert effective_download_filename("report.pdf", None) == "report.pdf"
+    assert effective_download_filename("report.pdf", "   ") == "report.pdf"
+
+
+def test_download_filename_preserves_extension_when_display_name_has_other_ext():
+    # 用户名带别的扩展名时仍以物理文件扩展名为准，保证可正确打开
+    assert effective_download_filename("report.pdf", "notes.txt") == "notes.txt.pdf"
+
+
+def test_download_filename_without_extension_in_original():
+    assert effective_download_filename("README", "My Readme") == "My Readme"

--- a/apps/negentropy/tests/unit_tests/knowledge/test_repository_source_summary.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_repository_source_summary.py
@@ -15,3 +15,29 @@ def test_infer_display_name_ignores_blank_or_invalid_values():
     assert KnowledgeRepository._infer_display_name({"original_filename": 123}) is None
     assert KnowledgeRepository._infer_display_name({}) is None
     assert KnowledgeRepository._infer_display_name(None) is None
+
+
+def test_infer_display_name_prefers_display_name_over_original_filename():
+    """用户重命名覆盖（display_name）优先于 original_filename（chunk metadata 回填后）。"""
+    assert (
+        KnowledgeRepository._infer_display_name(
+            {"display_name": "Q3 Report", "original_filename": "ugly-hash.pdf"},
+        )
+        == "Q3 Report"
+    )
+
+
+def test_infer_display_name_falls_back_to_original_when_display_name_blank():
+    """display_name 为空 / 非字符串时回退到 original_filename。"""
+    assert (
+        KnowledgeRepository._infer_display_name(
+            {"display_name": "   ", "original_filename": "fallback.pdf"},
+        )
+        == "fallback.pdf"
+    )
+    assert (
+        KnowledgeRepository._infer_display_name(
+            {"display_name": 123, "original_filename": "fallback.pdf"},
+        )
+        == "fallback.pdf"
+    )

--- a/apps/negentropy/tests/unit_tests/storage/test_document_display_name_backfill.py
+++ b/apps/negentropy/tests/unit_tests/storage/test_document_display_name_backfill.py
@@ -1,0 +1,153 @@
+"""DocumentStorageService.update_document_display_name 的 chunk 回填单测。
+
+mock ``AsyncSessionLocal`` 边界（不连真实库），验证：
+- 设置 display_name 时：同事务对 ``negentropy.knowledge`` 做附加式 ``jsonb_set`` 回填
+  （写 ``metadata.display_name``），参数化绑定用户文本（防注入），并记录 rowcount；
+- 清空 display_name 时：走 ``metadata - 'display_name'`` 删键分支；
+- 文档不存在时返回 None 且不触发回填；
+- 库文档（corpus_id=None）路径同样走回填（匹配 0 行由 DB 决定，不影响逻辑）。
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import TextClause
+
+from negentropy.storage.service import DocumentStorageService
+
+
+class _FakeResult:
+    def __init__(self, scalar=None, rowcount=0):
+        self._scalar = scalar
+        self.rowcount = rowcount
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+
+class _FakeSession:
+    """记录 execute / commit / refresh 调用的假会话。"""
+
+    def __init__(self, scalar, rowcount=3):
+        self._scalar = scalar
+        self._rowcount = rowcount
+        self.executes: list[tuple[object, dict | None]] = []
+        self.committed = False
+        self.refreshed = False
+
+    async def execute(self, stmt, params=None):
+        self.executes.append((stmt, params))
+        if isinstance(stmt, TextClause):
+            return _FakeResult(rowcount=self._rowcount)
+        return _FakeResult(scalar=self._scalar)
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, obj):
+        self.refreshed = True
+
+
+class _FakeSessionCM:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _make_doc(**overrides):
+    base = {
+        "id": uuid4(),
+        "display_name": None,
+        "corpus_id": None,
+        "app_name": "negentropy",
+        "metadata_": {},
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+async def test_set_display_name_backfills_chunks_with_parameterized_jsonb_set():
+    doc = _make_doc()
+    session = _FakeSession(scalar=doc, rowcount=7)
+    cm = _FakeSessionCM(session)
+
+    with patch("negentropy.storage.service.AsyncSessionLocal", return_value=cm):
+        svc = DocumentStorageService()
+        result = await svc.update_document_display_name(document_id=doc.id, display_name="我的新名称")
+
+    assert result is doc
+    assert doc.display_name == "我的新名称"
+    assert session.committed and session.refreshed
+
+    # 两次 execute：select(KnowledgeDocument) + 回填 TextClause
+    assert len(session.executes) == 2
+    assert not isinstance(session.executes[0][0], TextClause)  # 首次是 select，非 text
+    backfill_stmt, params = session.executes[1]
+    assert isinstance(backfill_stmt, TextClause)
+    sql = backfill_stmt.text
+    assert "jsonb_set" in sql
+    assert "{display_name}" in sql
+    assert "metadata->>'document_id'" in sql
+    # 参数化绑定（而非字符串拼接）——防注入与转义
+    assert params == {"document_id": str(doc.id), "display_name_json": json.dumps("我的新名称")}
+
+
+@pytest.mark.asyncio
+async def test_clear_display_name_uses_jsonb_delete_key_branch():
+    doc = _make_doc(display_name="旧名称")
+    session = _FakeSession(scalar=doc, rowcount=2)
+    cm = _FakeSessionCM(session)
+
+    with patch("negentropy.storage.service.AsyncSessionLocal", return_value=cm):
+        svc = DocumentStorageService()
+        result = await svc.update_document_display_name(document_id=doc.id, display_name="   ")
+
+    assert result is doc
+    assert doc.display_name is None  # 空白归一化为 None
+    backfill_stmt, params = session.executes[1]
+    sql = backfill_stmt.text
+    assert "- 'display_name'" in sql  # 删键分支
+    assert "jsonb_set" not in sql
+    # 清空分支只需 document_id
+    assert params == {"document_id": str(doc.id)}
+
+
+@pytest.mark.asyncio
+async def test_missing_document_returns_none_and_skips_backfill():
+    session = _FakeSession(scalar=None)
+    cm = _FakeSessionCM(session)
+
+    with patch("negentropy.storage.service.AsyncSessionLocal", return_value=cm):
+        svc = DocumentStorageService()
+        result = await svc.update_document_display_name(document_id=uuid4(), display_name="x")
+
+    assert result is None
+    # 仅 select，不触发回填、不提交
+    assert len(session.executes) == 1
+    assert not session.committed
+
+
+@pytest.mark.asyncio
+async def test_library_document_still_runs_backfill_statement():
+    """库文档（corpus_id=None）在逻辑上同样执行回填语句；匹配 0 行由 DB 决定。"""
+    doc = _make_doc(corpus_id=None)
+    session = _FakeSession(scalar=doc, rowcount=0)
+    cm = _FakeSessionCM(session)
+
+    with patch("negentropy.storage.service.AsyncSessionLocal", return_value=cm):
+        svc = DocumentStorageService()
+        await svc.update_document_display_name(document_id=doc.id, display_name="Library Doc")
+
+    assert len(session.executes) == 2  # select + backfill（rowcount=0 但语句仍执行）
+    assert session.committed


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge → Documents 页的 File Name 为只读，用户无法重命名文档；且任意引用该文档的位置（语料库列表、检索来源标签、聊天引用题录、下载文件名等）需一致显示重命名后的名称。
- 关联上下文/Issue/文档：用户需求「允许就地修改 Documents 的 File Name 并全局传播」。

# 核心变更
- Documents 页 File Name 列支持就地编辑（hover 铅笔 → input + ✓/✕），写入既有 `display_name` 字段，保持 `original_filename` 不可变；保存按服务端返回值局部 patch，避免全量刷新与心跳轮询打架。
- 抽取 `useInlineDocumentRename` hook，重构 Wiki 目录 `DocumentAssignmentSection` 消费它，与 Documents 页共用同一份编辑逻辑（DRY）。
- 后端 `update_document_display_name` 在**同一事务**内对该文档所有 chunk 做附加式 `jsonb_set` 回填 `metadata.display_name`（清空则删键），参数化绑定防注入；`_infer_display_name` / `format_citation` / 检索来源标签均改为优先 `display_name`，即时跟随、无需重新 ingest。
- 下载文件名跟随重命名并保留原扩展名（中文走 `filename*=UTF-8''`）；`_shared` 新增 `effective_display_name` / `effective_download_filename` 单一事实源 helper，`wiki_service._resolve_doc_display_title` 委托之。

# 风险与回滚
- 主要风险：chunk 回填为单条批量 UPDATE（按 `metadata->>'document_id'` 过滤），超大文档（数万 chunk）会短暂持锁；属用户触发的低频操作，可接受。用户文本经参数化绑定，无 SQL 注入面。
- 回滚方式：revert 本提交即可。`display_name` 列早已存在（migration 0040），chunk 侧 `display_name` 为附加式 JSONB 键，回滚不影响 `original_filename` 与既有数据。

# 验证证据
- 单元测试：新增/触及 32 测试通过（`display_name` 优先级回退、`format_citation` 覆盖、chunk 回填 SQL 参数化绑定断言、下载文件名派生）；knowledge+storage+perception 共 1057 测试通过、零回归。
- 集成测试：复用既有 ingest / repository 单测覆盖，无回归。
- E2E/Workflow：前端 `pnpm typecheck` 与 ESLint 均退出 0；提交时 pre-commit 全部 Passed（Ruff lint/format、ESLint、通用卫生）。
- 覆盖率/关键截图：待浏览器端到端回归（重命名 → 语料库/检索/下载跟随）。

# 影响范围
- 前端：Documents 页、Knowledge Base 语料库文档列表、文档详情页、检索片段来源标签、Wiki 目录归属文档编辑组件。
- 后端：文档 `display_name` 更新链路、ingest chunk 元数据、检索/引用展示、下载文件名、Wiki entry_title 解析。
- GitHub Actions / 文档：无。

# Next Best Action
- 浏览器端到端回归：重命名文档后核对语料库列表、检索命中片段来源标签、聊天引用题录、下载文件名均跟随；清空名称回退到源文件名。
- 评估是否需为 `metadata->>'document_id'` 加表达式索引（仅当单库 chunk 量极大且重命名频繁时）。
