### PR TITLE
fix(Knowledge): 修复重命名回填 SQL 的 asyncpg 参数绑定语法错误;

### DIFF
--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -675,7 +675,7 @@ class DocumentStorageService:
                     SET metadata = jsonb_set(
                         COALESCE(metadata, '{{}}'::jsonb),
                         '{{display_name}}',
-                        :display_name_json::jsonb
+                        CAST(:display_name_json AS jsonb)
                     )
                     WHERE metadata->>'document_id' = :document_id
                     """

--- a/apps/negentropy/tests/unit_tests/storage/test_document_display_name_backfill.py
+++ b/apps/negentropy/tests/unit_tests/storage/test_document_display_name_backfill.py
@@ -102,6 +102,17 @@ async def test_set_display_name_backfills_chunks_with_parameterized_jsonb_set():
     # 参数化绑定（而非字符串拼接）——防注入与转义
     assert params == {"document_id": str(doc.id), "display_name_json": json.dumps("我的新名称")}
 
+    # 回归守护：两个命名参数都必须被 asyncpg 方言编译为位置占位符（$N）。
+    # 曾因 ``:display_name_json::jsonb`` 的 ``::cast`` 紧贴参数，SQLAlchemy 解析器
+    # 未识别该参数 → asyncpg 收到字面 ``:`` → ``PostgresSyntaxError``（生产 500）。
+    # 必须用 ``CAST(:param AS jsonb)`` 让参数被绑定。
+    from sqlalchemy.dialects import postgresql
+
+    compiled = str(backfill_stmt.compile(dialect=postgresql.asyncpg.dialect()))
+    assert ":display_name_json" not in compiled  # 不得残留字面 ':name'
+    assert ":document_id" not in compiled
+    assert "$1" in compiled and "$2" in compiled  # 两者都被绑定为位置参数
+
 
 @pytest.mark.asyncio
 async def test_clear_display_name_uses_jsonb_delete_key_branch():


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge → Documents 页编辑文档 File Name 时 PATCH 返回 500（`KNOWLEDGE_UPSTREAM_ERROR`），重命名功能不可用。
- 关联上下文/Issue/文档：display_name 重命名 + chunk 回填链路（已并入 `feature/1.x.x`）；本 PR 为线上 500 的热修。

# 核心变更
- `storage/service.py::update_document_display_name` 的 chunk 回填 SQL：将 `:display_name_json::jsonb` 改为 `CAST(:display_name_json AS jsonb)`。
- 回归守护：`test_document_display_name_backfill.py` 新增编译期断言——两命名参数经 asyncpg 方言编译后均绑定为位置占位符 `$N`，不得残留字面 `:name`，防止同类 `cast-breaks-binding` 再次回归。

# 根因
`:display_name_json::jsonb` 的 `::cast` 紧贴命名参数，SQLAlchemy `text()` 解析器未识别该参数 → 仅 `:document_id` 被绑成 `$1`，`:display_name_json` 以字面 `:` 残留 → asyncpg 抛 `PostgresSyntaxError: syntax error at or near ":"` → 路由 500。已用出错文档 ID 在开发库实跑复现并验证修复（SET/CLEAR 两分支均编译执行通过）。

# 风险与回滚
- 主要风险：无功能行为变化，仅修正 SQL 参数绑定方式；回填语义（附加式写 `metadata.display_name`、清空删键）不变。
- 回滚方式：revert 本提交即可。

# 验证证据
- 单元测试：`tests/unit_tests/storage/test_document_display_name_backfill.py` 4 测试通过（含新增回归守护）。
- 集成测试：开发库实跑出错文档 ID 的 SET/CLEAR 回填 SQL，均编译执行通过（rowcount=0，display_name 正常落库）。
- E2E/Workflow：待后端重启后浏览器回归（重命名 PATCH 不再 500，名称在语料库/检索/下载跟随）。
- 覆盖率/关键截图：—

# 影响范围
- 前端：无。
- 后端：`DocumentStorageService.update_document_display_name` 的 chunk 回填语句（重命名链路）。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后重启 `negentropy serve` 使修复生效（运行中实例无 `--reload`）。
- 关联：旧特性 PR #953（`ThreeFish-AI/edit-document-filename`）的内容已并入 `feature/1.x.x`，可关闭。
