### PR TITLE
fix(Wiki): Knowledge Graph 标签全页恒显并指向有 KG 的动态 pub

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -179,7 +179,11 @@ export default async function WikiEntryPage({ params }: Props) {
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
       reservedTab={reservedTab}
-      graphTab={{ active: false, show: hasAnyEntry && !isReserved }}
+      graphTab={{
+        active: false,
+        show: !!headerNav.graphPubSlug,
+        href: headerNav.graphPubSlug ? `/${headerNav.graphPubSlug}/graph` : undefined,
+      }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -98,7 +98,11 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
       reservedTab={reservedTab}
-      graphTab={{ active: true, show: entriesTotal > 0 && !isReserved }}
+      graphTab={{
+        active: pubSlug === headerNav.graphPubSlug,
+        show: !!headerNav.graphPubSlug,
+        href: headerNav.graphPubSlug ? `/${headerNav.graphPubSlug}/graph` : undefined,
+      }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -107,7 +107,11 @@ export default async function WikiPublicationPage({ params }: Props) {
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
       reservedTab={reservedTab}
-      graphTab={{ active: false, show: entriesTotal > 0 && !isReserved }}
+      graphTab={{
+        active: false,
+        show: !!headerNav.graphPubSlug,
+        href: headerNav.graphPubSlug ? `/${headerNav.graphPubSlug}/graph` : undefined,
+      }}
     />
   );
 

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -103,27 +103,29 @@ export default async function WikiHomePage() {
 
   const firstHref = homeCards.length > 0 ? homeCards[0].href : undefined;
 
-  // Knowledge Graph 标签指向首个**非保留** publication（保留 docs 目录无 KG）。
-  const firstPubSlug = publications.find(
-    (p) => !isReservedDocsSlug(p.slug),
-  )?.slug;
-
   // 首页不身处任何 pub：reservedTab 纯链接、不高亮，右区不高亮。
   const reservedTab = buildReservedDocsTab({
     reservedExists: headerNav.reservedExists,
     isReserved: false,
   });
+  // Knowledge Graph 标签恒指向有 KG 的动态 pub（首个非保留 pub；保留 docs 目录无 KG）。
+  const graphPubSlug = headerNav.graphPubSlug;
 
   const header = (
     <WikiHeader
       topNav={headerNav.topNav}
       headerSlot={<ThemePreference />}
       actions={<WikiHeaderActions />}
-      pubSlug={firstPubSlug}
+      pubSlug={graphPubSlug}
       reservedTab={reservedTab}
       graphTab={
-        firstPubSlug
-          ? { show: true, active: false, label: "Knowledge Graph" }
+        graphPubSlug
+          ? {
+              show: true,
+              active: false,
+              label: "Knowledge Graph",
+              href: `/${graphPubSlug}/graph`,
+            }
           : undefined
       }
     />

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -22,6 +22,8 @@ interface WikiHeaderGraphTab {
   show: boolean;
   active: boolean;
   label?: string;
+  /** 知识图谱页 href（缺省回退 `/${pubSlug}/graph`）；全站顶栏恒指向有 KG 的 pub。 */
+  href?: string;
 }
 
 interface WikiHeaderProps {
@@ -84,7 +86,7 @@ export function WikiHeader({
             )}
             {graphTab?.show && (
               <Link
-                href={`/${pubSlug}/graph`}
+                href={graphTab.href ?? `/${pubSlug}/graph`}
                 className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
                 aria-current={graphTab.active ? "page" : undefined}
               >

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -86,7 +86,9 @@ export interface HeaderTopNavItem {
  * 全站稳定的顶栏导航模型（单一事实源）。
  *
  * - `reservedExists`：保留 pub（slug=`negentropy`）是否存在 → 决定是否渲染左侧纯链接标签；
- * - `topNav`：其余（非保留）pub 的 nav-tree 第一层 → 右区一级 tabs（每项带自身 pubSlug）。
+ * - `topNav`：其余（非保留）pub 的 nav-tree 第一层 → 右区一级 tabs（每项带自身 pubSlug）；
+ * - `graphPubSlug`：首个非保留 pub 的 slug（其知识图谱可作为全站顶栏「Knowledge Graph」
+ *   入口；保留 pub 由 docs/ 合成、无 KG）。
  *
  * 保留 pub 第一层不进顶栏（改由左栏全树侧栏承载），与右区在 publication 维度互斥，
  * 故同一节点不会重复出现。
@@ -94,6 +96,7 @@ export interface HeaderTopNavItem {
 export interface HeaderNav {
   reservedExists: boolean;
   topNav: HeaderTopNavItem[];
+  graphPubSlug?: string;
 }
 
 /**
@@ -110,19 +113,22 @@ export function buildHeaderNav(
   pubNavTrees: { slug: string; items: WikiNavTreeItem[] }[],
 ): HeaderNav {
   let reservedExists = false;
+  let graphPubSlug: string | undefined;
   const topNav: HeaderTopNavItem[] = [];
 
   for (const { slug, items } of pubNavTrees) {
     if (isReservedDocsSlug(slug)) {
       reservedExists = true;
     } else {
+      // 首个非保留 pub 作为知识图谱入口（保留 pub 由 docs/ 合成、无 KG）。
+      if (!graphPubSlug) graphPubSlug = slug;
       for (const item of items) {
         topNav.push({ pubSlug: slug, item });
       }
     }
   }
 
-  return { reservedExists, topNav };
+  return { reservedExists, topNav, graphPubSlug };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/negentropy-wiki/tests/lib/wiki-header-nav.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-header-nav.test.ts
@@ -40,12 +40,12 @@ function container(slug: string, children: WikiNavTreeItem[] = []): WikiNavTreeI
 }
 
 describe("buildHeaderNav", () => {
-  it("空输入 → 全空模型（无保留、无 topNav）", () => {
+  it("空输入 → 全空模型（无保留、无 topNav、无 graphPubSlug）", () => {
     const nav = buildHeaderNav([]);
-    expect(nav).toEqual({ reservedExists: false, topNav: [] });
+    expect(nav).toEqual({ reservedExists: false, topNav: [], graphPubSlug: undefined });
   });
 
-  it("仅保留 pub → reservedExists=true、topNav 为空（其第一层交左栏全树，不入顶栏）", () => {
+  it("仅保留 pub → reservedExists=true、topNav 为空、无 graphPubSlug（保留 pub 无 KG）", () => {
     const nav = buildHeaderNav([
       {
         slug: RESERVED_DOCS_SLUG,
@@ -54,9 +54,10 @@ describe("buildHeaderNav", () => {
     ]);
     expect(nav.reservedExists).toBe(true);
     expect(nav.topNav).toEqual([]);
+    expect(nav.graphPubSlug).toBeUndefined();
   });
 
-  it("仅非保留 pub → topNav 每项携带正确 pubSlug，reservedExists=false", () => {
+  it("仅非保留 pub → topNav 每项携带正确 pubSlug、graphPubSlug=首个非保留 pub", () => {
     const wikiItems = [
       container("harness-engineering", [doc("harness-engineering/getting-started")]),
       doc("sinestesia-of-cognition"),
@@ -69,6 +70,7 @@ describe("buildHeaderNav", () => {
       "harness-engineering",
       "sinestesia-of-cognition",
     ]);
+    expect(nav.graphPubSlug).toBe("wiki");
   });
 
   it("混合（1 保留 + 2 非保留）→ 保留 pub 不进 topNav、顺序稳定、各带自身 pubSlug", () => {
@@ -78,6 +80,8 @@ describe("buildHeaderNav", () => {
       { slug: "blog", items: [doc("post-1"), doc("post-2")] },
     ]);
     expect(nav.reservedExists).toBe(true);
+    // graphPubSlug 取首个非保留 pub（即便保留 pub 排在前面）
+    expect(nav.graphPubSlug).toBe("wiki");
     // 非保留 pub 第一层进 topNav，顺序 = 入参顺序，pubSlug 各自归属
     expect(nav.topNav.map((t) => `${t.pubSlug}:${t.item.entry_slug}`)).toEqual([
       "wiki:harness-engineering",


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：进入 `/negentropy/readme/` 等保留 pub 页面时，顶栏「Knowledge Graph」一级菜单消失。该修复原在 #954 分支但**未被并入** #954 的 squash（`854e6e10` 仅含迭代二「纯链接+全树侧栏」，缺本 graphPubSlug 修复），故 `feature/1.x.x` 的 `graph/page.tsx` 仍是旧 `graphTab`。
- 关联上下文/Issue/文档：#954；`graphTab` 此前以 `show: ... && !isReserved` 在保留 pub 隐藏，且链接到 `/当前pub/graph`（保留 pub 由 docs/ 合成、无 KG，无意义）。

# 核心变更
- **wiki-api**：`HeaderNav` 新增 `graphPubSlug`（首个非保留 pub slug，即有 KG 的 pub），`buildHeaderNav` 填充。
- **WikiHeader**：`graphTab` 新增 `href` 字段（缺省回退 `/${pubSlug}/graph`），KG 链接用 `graphTab.href`。
- **四个页面**：`graphTab` 改为 `show=!!graphPubSlug` 且 `href=/${graphPubSlug}/graph`，移除 `!isReserved` 隐藏；graph 页 `active` 仅当 `当前 pub===graphPubSlug`；首页 `firstPubSlug` 收敛为 `headerNav.graphPubSlug`（单一事实源）。
- **测试**：`buildHeaderNav` 补 `graphPubSlug` 断言（空/仅保留/仅动态/混合）。

# 风险与回滚
- 主要风险：`graphTab` API 新增可选 `href` 字段，消费方仅 4 个页面、无组件快照测试，爆炸半径受控。
- 回滚方式：纯前端渲染层改动，无后端/DB/迁移；`git revert` 本 PR 合并提交即可回退，经既有 `publish-wiki-pages.sh` 重新发布生效。

# 验证证据
- 单元测试：`pnpm test` **97 passed（13 files）**（含 #955–#958 新增测试与本 PR 的 graphPubSlug 断言全绿）。
- 集成测试：`pnpm build`（`next build` SSG 全量导出）通过。
- E2E/Workflow：实测 `/negentropy/readme` 顶栏 `Negentropy → Knowledge Graph(/wiki/graph) → Harness Engineering → Sinestesia of Cognition` **全显并存**；`/wiki/graph` 上 KG 标签 `active` 高亮（`aria-current="page"`）。

# 冲突处理
- 基线为最新 `origin/feature/1.x.x`（含 #955–#958）。从该基线新建分支并 cherry-pick 原修复单提交，与 #958（标题去冗余，同改 `[...entrySlug]/page.tsx`）等**自动合并无冲突**。

# 影响范围
- 前端：`apps/negentropy-wiki` 的 wiki-api / WikiHeader / 四个页面 / wiki-header-nav 测试。
- 后端：无（纯静态渲染层）。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后经既有发布链路（`publish-wiki-pages.sh` → GitHub Pages）部署，在生产站点 `/negentropy/*`、`/wiki/*`、首页核验 Knowledge Graph 标签全页恒显且 `/wiki/graph` 高亮。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)