### PR TITLE
feat(Wiki): 正文图片支持单击全页 Lightbox 最大化查看;

### DIFF
--- a/apps/negentropy-wiki/src/components/markdown/ImageLightbox.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/ImageLightbox.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+interface ImageLightboxProps {
+  src: string;
+  alt?: string;
+  onClose: () => void;
+}
+
+/**
+ * 图片全页最大化遮罩（Lightbox）。
+ *
+ * 交互范式参照 WikiSearchModal：createPortal 挂到 document.body，Esc / 点遮罩空白 /
+ * 点图片本身 / 点关闭按钮均可关闭；打开时锁 body 滚动并把焦点收入遮罩，关闭后还原
+ * 触发元素焦点。
+ *
+ * SSG 安全：next.config `output:"export"` 下，本组件仅在父组件 open=true 时挂载，
+ * 构建期与 hydrate 期 open 均为 false 故不执行 createPortal —— 与 WikiSearchModal 同构。
+ */
+export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // 打开时聚焦遮罩（Esc 即时生效），关闭时把焦点归还触发元素
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    requestAnimationFrame(() => rootRef.current?.focus());
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+
+  // Body 滚动锁
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  // Escape 关闭
+  useEffect(() => {
+    const handleEsc = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      ref={rootRef}
+      className="wiki-lightbox-root"
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt || "图片预览"}
+      tabIndex={-1}
+      onClick={(e) => {
+        // 仅点遮罩空白处关闭；点图片 / 关闭按钮由各自 handler 处理，不会命中此条件。
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <img
+        src={src}
+        alt={alt ?? ""}
+        className="wiki-lightbox-image"
+        decoding="async"
+        onClick={onClose}
+      />
+      <button
+        type="button"
+        className="wiki-lightbox-close"
+        onClick={onClose}
+        aria-label="关闭图片预览"
+      >
+        ✕
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
@@ -10,6 +10,7 @@ import { CodeBlock } from "./CodeBlock";
 import { AnchorHeading } from "./AnchorHeading";
 import { ResponsiveTable } from "./ResponsiveTable";
 import { MermaidDiagram } from "./MermaidDiagram";
+import { ZoomableImage } from "./ZoomableImage";
 
 const wikiSanitizeSchema: typeof defaultSchema = {
   ...defaultSchema,
@@ -78,35 +79,19 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
             return <pre>{children}</pre>;
           },
           table: ({ children }) => <ResponsiveTable>{children}</ResponsiveTable>,
-          img: ({ src, alt, width, height, style }) => {
-            // ISSUE-094 R8：透传后端 _image_to_markdown 输出的 width / height /
-            // style，避免图片自然宽度（PNG 像素）造成 PDF→Markdown 视觉缩放失真。
-            //
-            // 大图（width ≥ 400px，PDF figure region 渲染产物）使用 width:100%
-            // 填满容器，与 PDF 原版 figure 占满正文栏全宽的视觉等价。
-            // 小图（inline icon 等）保持 max-width:100% 不主动撑开。
-            const pxWidth = width ? parseInt(String(width), 10) : 0;
-            const isLargeFigure = pxWidth >= 400;
-            const mergedStyle: React.CSSProperties = {
-              ...(style && typeof style === "object" ? style : {}),
-              ...(isLargeFigure
-                ? { width: "100%", maxWidth: "100%", height: "auto" }
-                : {}),
-              borderRadius: "var(--wiki-radius)",
-            };
-            // eslint-disable-next-line @next/next/no-img-element
-            return (
-              <img
-                src={src}
-                alt={alt ?? ""}
-                width={width}
-                height={height}
-                loading="lazy"
-                decoding="async"
-                style={mergedStyle}
-              />
-            );
-          },
+          // 单击图片在整页 Lightbox 中最大化查看（业界常规 click-to-zoom 交互）。
+          // 显式解构丢弃 react-markdown 传入的 hast `node`，避免无用节点对象跨
+          // Server→Client 边界。isLargeFigure 等宽度逻辑已迁入 ZoomableImage。
+          img: ({ src, alt, title, width, height, style }) => (
+            <ZoomableImage
+              src={src}
+              alt={alt}
+              title={title}
+              width={width}
+              height={height}
+              style={style}
+            />
+          ),
         }}
       >
         {content}

--- a/apps/negentropy-wiki/src/components/markdown/ZoomableImage.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/ZoomableImage.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import {
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { ImageLightbox } from "./ImageLightbox";
+
+interface ZoomableImageProps {
+  src?: string;
+  alt?: string;
+  title?: string;
+  width?: string | number;
+  height?: string | number;
+  style?: CSSProperties;
+}
+
+/**
+ * 正文图片包装：单击在整页 Lightbox 中最大化查看。
+ *
+ * 由 MarkdownRenderer 的 components.img 指向 —— 服务端组件引用 client 组件，
+ * 与 CodeBlock / MermaidDiagram 同构（Server→Client 边界合规）。不接收 react-markdown
+ * 传入的 hast `node`，避免无用节点对象跨 RSC 边界增大 payload。
+ *
+ * ISSUE-094 R8：透传后端 _image_to_markdown 输出的 width / height / style，
+ * 大图（width ≥ 400px，PDF figure region 渲染产物）使用 width:100% 填满容器，与
+ * PDF 原版 figure 占满正文栏全宽的视觉等价；小图（inline icon 等）保持 max-width:100%
+ * 不主动撑开。该逻辑自 MarkdownRenderer 迁入，保持单一事实源。
+ */
+export function ZoomableImage({ src, alt, title, width, height, style }: ZoomableImageProps) {
+  const [open, setOpen] = useState(false);
+
+  const pxWidth = width ? parseInt(String(width), 10) : 0;
+  const isLargeFigure = pxWidth >= 400;
+  const mergedStyle: CSSProperties = {
+    ...(style && typeof style === "object" ? style : {}),
+    ...(isLargeFigure ? { width: "100%", maxWidth: "100%", height: "auto" } : {}),
+    borderRadius: "var(--wiki-radius)",
+    cursor: "zoom-in",
+  };
+
+  // 空 src 降级：渲染裸 img，不绑点击、不进 Lightbox
+  if (!src) {
+    return <img alt={alt ?? ""} style={mergedStyle} />;
+  }
+
+  // 图片可能被 <a> 包裹（markdown `[![](x)](y)`），preventDefault 阻止默认导航转而打开预览
+  const handleClick = (e: ReactMouseEvent<HTMLImageElement>) => {
+    e.preventDefault();
+    setOpen(true);
+  };
+
+  // 键盘可达：Enter / Space 触发预览
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLImageElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt ?? ""}
+        title={title}
+        width={width}
+        height={height}
+        loading="lazy"
+        decoding="async"
+        style={mergedStyle}
+        tabIndex={0}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      />
+      {open && <ImageLightbox src={src} alt={alt} onClose={() => setOpen(false)} />}
+    </>
+  );
+}

--- a/apps/negentropy-wiki/src/styles/components/lightbox.css
+++ b/apps/negentropy-wiki/src/styles/components/lightbox.css
@@ -1,0 +1,71 @@
+/* =========================================================================
+   Wiki Lightbox — 图片全页最大化遮罩
+   复用 tokens.css 的 design tokens；overlay 范式参照 search-modal.css。
+   暗色遮罩主题无关，浅色 / 深色模式均正确，无需 data-color-scheme 分支。
+   ========================================================================= */
+
+.wiki-lightbox-root {
+  position: fixed;
+  inset: 0;
+  z-index: 110; /* 高于搜索 modal 的 100 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4vh 4vw;
+  background: rgba(0, 0, 0, 0.82);
+  cursor: zoom-out; /* 暗示点击空白处关闭 */
+  animation: wiki-lightbox-fade-in 0.15s ease;
+}
+
+@keyframes wiki-lightbox-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.wiki-lightbox-image {
+  max-width: 92vw;
+  max-height: 88vh;
+  object-fit: contain;
+  border-radius: var(--wiki-radius);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  cursor: zoom-out; /* 再点图片关闭 */
+  animation: wiki-lightbox-zoom-in 0.18s ease;
+}
+
+@keyframes wiki-lightbox-zoom-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.wiki-lightbox-close {
+  position: absolute;
+  top: 2vh;
+  right: 2vw;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: var(--wiki-radius);
+  background: rgba(0, 0, 0, 0.42);
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.wiki-lightbox-close:hover {
+  background: rgba(0, 0, 0, 0.64);
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #ffffff;
+}
+
+/* 尊重「减少动态」偏好 */
+@media (prefers-reduced-motion: reduce) {
+  .wiki-lightbox-root,
+  .wiki-lightbox-image {
+    animation: none;
+  }
+}

--- a/apps/negentropy-wiki/src/styles/components/markdown.css
+++ b/apps/negentropy-wiki/src/styles/components/markdown.css
@@ -80,6 +80,7 @@
   max-width: 100%;
   height: auto;
   margin: 0.75rem 0;
+  cursor: zoom-in; /* 暗示可单击放大；具体交互由 ZoomableImage 承载 */
 }
 
 /* 引用块 */

--- a/apps/negentropy-wiki/src/styles/index.css
+++ b/apps/negentropy-wiki/src/styles/index.css
@@ -14,6 +14,7 @@
 @import "components/doc.css";
 @import "components/graph.css";
 @import "components/search-modal.css";
+@import "components/lightbox.css";
 @import "components/home-hero.css";
 @import "components/home-cards.css";
 @import "components/home-footer.css";


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 正文图片原先为裸 `<img>` 标签，单击无任何响应，缺少业界常规的「单击图片 → 全页最大化查看」交互（Lightbox）。
- 关联上下文：图片渲染的单一事实源为 `MarkdownRenderer` 的 `components.img`；复用项目既有 `WikiSearchModal` 的 overlay 范式（createPortal + Esc + body 锁 + 焦点还原），不引入第三方库。

# 核心变更
- 新增 `ZoomableImage`（"use client"）包装正文 `<img>`：迁入既有 `isLargeFigure` 宽度判定逻辑，单击 / Enter / Space 打开预览，`cursor: zoom-in` 悬停暗示，空 `src` 降级为裸 img。
- 新增 `ImageLightbox`（"use client"）：`createPortal` 挂到 `document.body`，点遮罩空白 / 点图片 / 按 Esc 三种方式关闭；打开时锁 body 滚动并收入焦点，关闭后还原触发元素焦点；`role="dialog"` / `aria-modal="true"`。
- `MarkdownRenderer` 的 `img` 指向 `ZoomableImage`，显式解构丢弃 react-markdown 传入的 hast `node`，避免无用节点对象跨 Server→Client 边界。
- 新增 `lightbox.css`（z-index 110 高于搜索 modal、`object-fit: contain`、淡入动画、`prefers-reduced-motion` 兼容），并在 `markdown.css` 为正文图片加 `cursor: zoom-in`。

# 风险与回滚
- 主要风险：低。无新增依赖、无 rehype-sanitize schema / next.config 改动；Mermaid 走 `components.pre` 分支、不经过 `img`，自动排除。
- 回滚方式：revert 提交 `c0a70fbe`，或将 `MarkdownRenderer` 的 `img` 改回内联渲染即可恢复裸 `<img>`。

# 验证证据
- 单元测试：暂无（可选后续补强 `ZoomableImage` 点击与宽度阈值用例）。
- 集成测试：N/A。
- E2E/Workflow：浏览器实测含图文档 `/wiki/harness-engineering/getting-started/`——点图打开、点图 / 点遮罩 / Esc 三种关闭、body 滚动锁与关闭后恢复、`cursor: zoom-in`、`tabIndex=0`、`role/aria-modal`、`z-index:110`、大图 `92vw/88vh + contain` 均符合预期。
- 覆盖率/关键截图：`pnpm lint` 0 error（本次新增 warning 已清零）；`pnpm build` TypeScript 通过 + SSG 21/21 页静态导出成功（无 `document is not defined`）+ pagefind 索引成功。

# 影响范围
- 前端：`apps/negentropy-wiki`（MarkdownRenderer + 2 个新组件 + 3 个 CSS 文件）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 后续可按需补：同页多图左右键切换（需 Context 注册表，当前按 YAGNI 未做）、大图像素级缩放查看、`ZoomableImage` 单元测试。