### PR TITLE
style(Wiki): 浅色主题首页 Hero 提亮，消除黑白板块硬切

### DIFF
--- a/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
+++ b/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
@@ -3,6 +3,8 @@
 import { Renderer, Program, Mesh, Color, Triangle } from "ogl";
 import { useEffect, useRef } from "react";
 
+import { useIsDark } from "@/lib/wiki-color-scheme";
+
 /* ── GLSL Vertex Shader ── */
 const vertexShader = /* glsl */ `
 attribute vec2 uv;
@@ -35,6 +37,7 @@ uniform float uRepulsionStrength;
 uniform float uMouseActiveFactor;
 uniform float uAutoCenterRepulsion;
 uniform bool uTransparent;
+uniform vec3 uStarColor; // 浅底暗紫描点色（仅透明分支使用）
 varying vec2 vUv;
 
 #define NUM_LAYER 4.0
@@ -143,10 +146,12 @@ void main() {
     col += StarLayer(uv * scale + i * 453.32) * fade;
   }
   if (uTransparent) {
-    float alpha = length(col);
-    alpha = smoothstep(0.0, 0.3, alpha);
+    // 浅底模式：累加亮星在白/浅紫底上不可见（亮 on 亮，对比度趋零），故以累加量为
+    // 「星强度图」、输出暗紫描点 uStarColor，alpha 由强度 smoothstep 控制 → 浅底上的微妙星点。
+    float intensity = length(col);
+    float alpha = smoothstep(0.0, 0.3, intensity);
     alpha = min(alpha, 1.0);
-    gl_FragColor = vec4(col, alpha);
+    gl_FragColor = vec4(uStarColor, alpha);
   } else {
     gl_FragColor = vec4(col, 1.0);
   }
@@ -159,30 +164,41 @@ interface GalaxyBackgroundProps {
 
 export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
   const ctnDom = useRef<HTMLDivElement>(null);
+  const isDark = useIsDark();
 
   useEffect(() => {
     if (!ctnDom.current) return;
     const ctn = ctnDom.current;
+
+    // 防御性前置清理：主题切换触发 teardown+recreate 时，杜绝残留 canvas 致重影。
+    while (ctn.firstChild) ctn.removeChild(ctn.firstChild);
 
     // 无障碍：减弱动画
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
 
-    // 主题预设 — 紫罗兰夜空，对齐 SquareDocs 深色主题
-    // 低饱和 → 以银白星点为主、紫罗兰为底，克制而非彩虹色
-    const transparent = false;
-    const glowIntensity = 0.5;
+    // 主题预设 ——
+    //   深色：紫罗兰夜空 + additive 亮星（原状，对齐 SquareDocs 深色）；
+    //   浅色：透明画布 + 暗紫描点（shader 透明分支），稀疏微妙星点点缀浅紫渐变。
+    // 注意：OGL `alpha` 标志锁定在 Renderer 创建时、不可热改，故切换主题必须 teardown+recreate
+    //       （effect deps=[isDark]），与 Cytoscape/3DGraph 的「就地刷新」本质不同 —— 勿回退。
+    const transparent = !isDark;
+    const glowIntensity = isDark ? 0.5 : 0.15;
     const hueShift = 280;
     const saturation = 0.28;
     const disableAnimation = prefersReducedMotion;
     const starSpeed = 0.5;
-    const density = 1.2;
+    const density = isDark ? 1.2 : 0.4; // 浅色稀疏描点
     const speed = 1.0;
-    const mouseRepulsion = true;
+    const mouseRepulsion = isDark; // 浅底排斥不可见且抢占指针，关闭
     const repulsionStrength = 2;
-    const twinkleIntensity = 0.4;
+    const twinkleIntensity = isDark ? 0.4 : 0.2;
     const rotationSpeed = 0.1;
+    // 浅底暗紫描点色（~#4a2d78）；深色走 additive 亮星路径，此值不参与
+    const starColor: [number, number, number] = isDark
+      ? [1.0, 1.0, 1.0]
+      : [0.29, 0.18, 0.47];
 
     const targetMousePos = { x: 0.5, y: 0.5 };
     const smoothMousePos = { x: 0.5, y: 0.5 };
@@ -244,6 +260,9 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
         uMouseActiveFactor: { value: 0.0 },
         uAutoCenterRepulsion: { value: 0 },
         uTransparent: { value: transparent },
+        uStarColor: {
+          value: new Color(starColor[0], starColor[1], starColor[2]),
+        },
       },
     });
 
@@ -311,7 +330,7 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
       }
       gl.getExtension("WEBGL_lose_context")?.loseContext();
     };
-  }, []);
+  }, [isDark]);
 
   return <div ref={ctnDom} className={className} aria-hidden="true" />;
 }

--- a/apps/negentropy-wiki/src/styles/components/home-footer.css
+++ b/apps/negentropy-wiki/src/styles/components/home-footer.css
@@ -1,7 +1,30 @@
 /* Wiki 页脚 — 全站深色 */
 .wiki-footer {
+  position: relative; /* ::before 羽化锚定所需 */
   background: var(--wiki-footer-bg);
   color: var(--wiki-footer-text);
+}
+
+/*
+ * 仅首页「卡片区(白) → 深色页脚」浅色主题羽化：页脚顶部叠一层白→深渐变，柔化像素级硬切。
+ * 作用域 #wiki-root:has(.wiki-layout--home) 隔离 —— 内容页页脚不受影响。
+ * 深色主题 --wiki-footer-fade=none / --wiki-footer-fade-height=0 → ::before 不可见、padding-top 回落。
+ */
+#wiki-root:has(.wiki-layout--home) .wiki-footer::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: var(--wiki-footer-fade-height);
+  background: var(--wiki-footer-fade);
+  z-index: 0;
+  pointer-events: none;
+}
+#wiki-root:has(.wiki-layout--home) .wiki-footer-inner {
+  position: relative;
+  z-index: 1; /* 内容浮于羽化渐变之上 */
+  padding-top: calc(var(--wiki-footer-fade-height) + 0.625rem);
 }
 
 .wiki-footer-inner {

--- a/apps/negentropy-wiki/src/styles/components/home-hero.css
+++ b/apps/negentropy-wiki/src/styles/components/home-hero.css
@@ -3,7 +3,7 @@
   position: relative;
   overflow: hidden;
   background: var(--wiki-hero-base);
-  color: #ffffff;
+  color: var(--wiki-hero-text);
   text-align: center;
   padding: 5rem 2rem 4rem;
 }
@@ -46,17 +46,24 @@
 .home-hero-cta {
   display: inline-block;
   padding: 0.7rem 1.8rem;
-  border: 2px solid #ffffff;
+  border: 2px solid var(--wiki-hero-cta-border);
   border-radius: 24px;
-  color: #ffffff;
+  background: var(--wiki-hero-cta-bg);
+  color: var(--wiki-hero-cta-color);
   font-size: 0.95em;
   font-weight: 600;
   text-decoration: none;
   transition: background 0.15s ease, color 0.15s ease;
 }
 .home-hero-cta:hover {
+  /* 反相反馈：浅色「紫底白字 → 白底紫字」、深色「白边透明 → 白底紫字」，两套主题一致 */
   background: #ffffff;
   color: var(--wiki-home-accent);
+}
+/* 实心紫 CTA 上显式焦点环：全局 :focus-visible 为 accent 描边，紫底之上不可见，故覆写 */
+.home-hero-cta:focus-visible {
+  outline: 2px solid var(--wiki-hero-cta-color);
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/negentropy-wiki/src/styles/themes.css
+++ b/apps/negentropy-wiki/src/styles/themes.css
@@ -35,6 +35,16 @@
 
   /* Footer 更深 */
   --wiki-footer-bg: #0a0a0b;
+  /* 深色两端皆深、无硬切，跳过浅色页脚羽化 */
+  --wiki-footer-fade: none;
+  --wiki-footer-fade-height: 0px;
+
+  /* Hero —— 深空平铺（Galaxy 画布覆盖其上）+ 白字 / 白边描边 CTA，浅色改造在深色零回归 */
+  --wiki-hero-base: #140d24;
+  --wiki-hero-text: #ffffff;
+  --wiki-hero-cta-bg: transparent;
+  --wiki-hero-cta-color: #ffffff;
+  --wiki-hero-cta-border: #ffffff;
 
   /* Callout 深色覆写 */
   --wiki-note-bg: rgba(210, 168, 255, 0.1);
@@ -77,6 +87,14 @@
       transparent 70%
     );
     --wiki-footer-bg: #0a0a0b;
+    --wiki-footer-fade: none;
+    --wiki-footer-fade-height: 0px;
+    /* Hero —— 深空平铺 + 白字 / 白边 CTA（与显式深色块保持一致，防 system-dark 漏浅色） */
+    --wiki-hero-base: #140d24;
+    --wiki-hero-text: #ffffff;
+    --wiki-hero-cta-bg: transparent;
+    --wiki-hero-cta-color: #ffffff;
+    --wiki-hero-cta-border: #ffffff;
     --wiki-note-bg: rgba(210, 168, 255, 0.1);
     --wiki-warn-text: #fbbf24;
     --wiki-warn-bg: rgba(245, 158, 11, 0.12);

--- a/apps/negentropy-wiki/src/styles/tokens.css
+++ b/apps/negentropy-wiki/src/styles/tokens.css
@@ -66,18 +66,31 @@
     transparent 70%
   );
 
-  /* 首页 Hero — 深紫罗兰夜空（Galaxy 之下的基色，两套主题一致） */
-  --wiki-hero-base: #140d24;
-  --wiki-hero-blob-1: #3b1d6e;
-  --wiki-hero-blob-2: #6d28d9;
-  --wiki-hero-blob-3: #1e1140;
-  --wiki-hero-blob-4: #4c1d95;
+  /* 首页 Hero —— 浅紫「绽放」渐变：首尾回到页面底色 var(--wiki-bg)，与顶栏/卡片区
+     像素级无缝；中段最浓 #faf7ff（唯一新增魔法色，≤ Squaredocs 的极浅调性）。
+     深色主题在 themes.css 覆写为 #140d24 深空平铺（Galaxy 画布覆盖其上）。 */
+  --wiki-hero-base: linear-gradient(180deg, var(--wiki-bg) 0%, #faf7ff 45%, var(--wiki-bg) 100%);
+  /* Hero 文字 / CTA —— 浅色：深字 + 紫实心 CTA（#6d28d9 对 #fff 对比度 ≈7:1）；
+     深色 themes.css 覆写回「白字 + 白边描边 CTA」，保持深空 Hero 零回归。 */
+  --wiki-hero-text: var(--wiki-text);
+  --wiki-hero-cta-bg: var(--wiki-accent-hover);
+  --wiki-hero-cta-color: #ffffff;
+  --wiki-hero-cta-border: transparent;
 
   /* Footer — 全站深色 */
   --wiki-footer-bg: #0f0f12;
   --wiki-footer-text: #ffffff;
   --wiki-footer-text-secondary: rgba(255, 255, 255, 0.66);
   --wiki-footer-border: rgba(255, 255, 255, 0.1);
+  /* 首页「卡片区(白) → 深色页脚」浅色主题羽化（白→深渐变，柔化硬切）；
+     仅首页命中（见 home-footer.css 的 :has 作用域）；深色 themes.css 置 none/0 跳过 */
+  --wiki-footer-fade: linear-gradient(
+    180deg,
+    var(--wiki-bg) 0%,
+    var(--wiki-bg) 35%,
+    var(--wiki-footer-bg) 100%
+  );
+  --wiki-footer-fade-height: 96px;
 
   /* Primary light（active 背景叠色） */
   --wiki-primary-light: rgba(124, 58, 237, 0.1);


### PR DESCRIPTION
## 背景

首页在**浅色主题**下，纵向色块为「深空黑 Hero → 纯白卡片区 → 深色页脚」，两处接缝均为像素级硬切，显得突兀。参照主题 **Squaredocs** 为通体浅色、干净统一的文档站，代码内亦处处注释「对齐 SquareDocs」。

## 根因

- **Hero 实际比 token 更黑**：可见底色是 Galaxy WebGL 画布 `clearColor(0,0,0,1)` 纯黑，遮住了 token `#140d24`。
- **接缝 A（Hero→卡片）**：`.home-hero` 底边（黑）→ 卡片区（白）。
- **接缝 B（卡片→页脚）**：`.wiki-layout--home`（白）→ `.wiki-footer`（`#0f0f12`）。
- 经 3 视角对抗式 stress-test 锁定 4 个必备技术点：① shader 必须改（additive 亮星在浅底不可见）；② 渐变首尾须 = `var(--wiki-bg)`；③ 两处 dark 块都要镜像 token；④ `useIsDark()` + teardown/recreate。

## 方案（Light-only 改造，深色零回归）

1. **Hero 提亮**：`--wiki-hero-base` 改为浅紫「绽放」渐变（白 ↔ `#faf7ff` ↔ 白），首尾回到 `var(--wiki-bg)`，与顶栏/卡片区**像素级无缝**。
2. **Galaxy 星点浅色可见**：着色器透明分支由「输出累加亮色」改为「以累加量为强度图、输出暗紫描点 `uStarColor`」——仅调 uniform 无法让 additive 亮星在浅底可见（亮 on 亮），必须改 shader。浅色稀疏描点（density 0.4 / glow 0.15），深色走原 additive 亮星路径不变。
3. **文字 / CTA token 化**：浅色深字 + 紫实心 CTA（`#6d28d9` 对 `#fff` 对比度 ≈ 7:1）+ 实心 CTA 显式 focus 环。
4. **GalaxyBackground 主题感知**：复用既有 `useIsDark()` + effect deps `[isDark]`；OGL `alpha` 标志锁定在 Renderer 创建时不可热改，故切换主题 teardown + recreate（+ 防御性清空防重影），与 Cytoscape / 3DGraph 的「就地刷新」本质不同。
5. **页脚羽化**：首页页脚顶部叠白 → 深渐变（`#wiki-root:has(.wiki-layout--home)` 作用域隔离，**内容页页脚不受影响**）。
6. 清理死代码 `--wiki-hero-blob-*` token。

## 验证（conductor 工作区 `next dev` :3093，全部通过）

- ✅ 浅色：Hero 浅紫渐变 + **暗紫星点清晰可见** + 深字 + 紫实心 CTA；Hero → 卡片无缝；页脚羽化无硬切。
- ✅ 深色：**零回归**（深空亮星 Hero、白字、白边描边 CTA 逐像素一致）。
- ✅ 主题切换：连切 5 次（10 次 teardown/recreate），canvas 数恒为 1（无重影 / 泄漏），控制台零报错。
- ✅ 移动端 375px：CTA 不换行、卡片单列、无横向溢出。
- ✅ `tsc --noEmit` 通过（仅一项与本次无关的既有测试告警）；pre-commit `next lint` 通过。

## 不在范围

- 深色主题零改动；全站深色页脚不改（仅本次首页浅色羽化）；真正 Squaredocs 式浅页脚属独立设计 pass。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
