### PR TITLE
fix(Wiki): 修复左栏导航在短正文页随正文上滑消失的 sticky 脱粘

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
+++ b/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
@@ -132,6 +132,7 @@ export function WikiLayoutShell({
           <WikiMobileNav topNav={mobileTopNav}>{sidebar}</WikiMobileNav>
           <div className="wiki-layout wiki-layout--home" data-header={header ? "" : undefined}>
             <main className="wiki-main wiki-main--home">{children}</main>
+            {footer}
           </div>
         </>
       ) : (
@@ -141,10 +142,10 @@ export function WikiLayoutShell({
             <aside className="wiki-sidebar">{sidebar}</aside>
             <main className="wiki-main">{children}</main>
             {hasToc && <aside className="wiki-toc-aside">{toc}</aside>}
+            {footer}
           </div>
         </>
       )}
-      {footer}
     </TocContext.Provider>
   );
 }

--- a/apps/negentropy-wiki/src/styles/base.css
+++ b/apps/negentropy-wiki/src/styles/base.css
@@ -72,3 +72,16 @@ a:hover {
     scroll-behavior: auto;
   }
 }
+
+/*
+ * 桌面端防护 footer full-bleed（width:100vw，见 home-footer.css）在 Windows 经典滚动条下
+ * 因 100vw 含滚动条宽度而溢出引起的横向滚动。`clip` 不创建 scroll container（异于 `hidden`），
+ * 不改变 sticky 的 scrolling ancestor，故不影响 sidebar 的垂直吸顶。
+ * 仅桌面（≥769px）：移动端 footer 在窄屏不溢出（100vw=可视宽），且避免裁剪移动端 header
+ * 既有的窄屏溢出布局（属无关既有问题，不在本次 sidebar 修复范围）。
+ */
+@media (min-width: 769px) {
+  body.wiki-body {
+    overflow-x: clip;
+  }
+}

--- a/apps/negentropy-wiki/src/styles/components/home-footer.css
+++ b/apps/negentropy-wiki/src/styles/components/home-footer.css
@@ -2,6 +2,20 @@
 .wiki-footer {
   background: var(--wiki-footer-bg);
   color: var(--wiki-footer-text);
+  /*
+   * Footer 现作为最后一个 grid item 纳入 .wiki-layout（见 WikiLayoutShell.tsx），
+   * 使左栏 .wiki-sidebar 的 sticky 包含块覆盖整篇文档（含页脚）——根治「短正文页
+   * 滚到页脚区时 sidebar 因 grid area 提前耗尽而脱粘、随正文上滑消失」。
+   *
+   * - grid-column:1/-1：跨越 sidebar/main/toc 全部列（grid 列数随 data-toc 三态变化皆适配）；
+   *   home 变体为 block 布局，此声明被忽略，无副作用。
+   * - width:100vw + 对称负 margin：full-bleed 全宽背景，保留移入前 footer 贯穿视口的
+   *   深色视觉（不随 .wiki-layout 的 1404px 容器限宽）。50% 相对 grid cell（整行宽）。
+   */
+  grid-column: 1 / -1;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
 }
 
 .wiki-footer-inner {

--- a/apps/negentropy-wiki/src/styles/layout.css
+++ b/apps/negentropy-wiki/src/styles/layout.css
@@ -21,6 +21,10 @@
   border-right: 1px solid var(--wiki-border);
   position: sticky;
   top: 0;
+  /* grid item 钉顶：对齐 .wiki-toc-aside 的正确 sticky 实践（sticky grid item 需显式
+     align-self:start 钉顶而非默认 stretch）。全程吸顶的根本保障是 footer 纳入 grid
+     扩展 sticky 包含块覆盖整篇文档（见 home-footer.css 与 WikiLayoutShell.tsx）。 */
+  align-self: start;
   height: 100vh;
   overflow-y: auto;
   padding: 1.5rem 1rem;


### PR DESCRIPTION
## 背景

Wiki 站点（`apps/negentropy-wiki`）三栏布局中，左栏 `.wiki-sidebar` 用 `position: sticky` 期望悬浮吸顶于顶部一级导航栏（header，60px）下边缘。但**当左栏导航内容总高度不超过浏览器视口时**，sidebar 没有吸顶，而是随正文一起向上滑动，最终被推到 header 上方导致看不见。

## 根因（实测确证）

通过 Playwright 实测几何数据，定位到真正根因（并推翻了初版「`align-self` 缺失」的理论假设）：

- `.wiki-layout`（grid 容器）高度 = **800px**（被 `min-height:100vh` 限制 ≈ 视口高）；
- `.wiki-sidebar` box = **740px**（`height: calc(100vh - 60px)`）；
- → sticky 可移动空间 = 800 − 740 = **仅 60px**；
- 但 `footer`（315px）在 `.wiki-layout` **之外**，撑出 docHeight=1175，页面可滚动 375px；
- → 滚动超过 60px 后，sidebar 超出 grid area 底部，被迫脱粘上滑直至消失（scrollY=375 时 sidebar.top=-255）。

即：sidebar 的 sticky 包含块（grid area）不足以覆盖整篇可滚动文档（footer 在 grid 外撑出额外可滚动量）。

## 方案

将 footer 纳入 `.wiki-layout` grid（作为最后一个 grid item），使 sidebar 的 sticky 包含块覆盖整篇文档（含页脚），从根本上消除脱粘。

| 文件 | 改动 |
|---|---|
| `WikiLayoutShell.tsx` | footer 从 `.wiki-layout` 外移入 content / home 两变体内部 |
| `home-footer.css` | `.wiki-footer` 补 `grid-column:1/-1` + `width:100vw` + 对称负 margin（full-bleed，保留移入前贯穿视口的深色背景） |
| `layout.css` | `.wiki-sidebar` 补 `align-self:start`（对齐 `.wiki-toc-aside` 的 sticky grid item 钉顶实践） |
| `base.css` | 桌面(≥769px) `body overflow-x:clip` 防护 full-bleed 在 Windows 经典滚动条下的横向溢出（clip 不创建 scroll container，不影响 sticky） |

## 验证（next dev + Playwright）

| 场景 | 结果 |
|---|---|
| 桌面 1280/1920 · 短正文页 (`data-toc=none`) | sidebar 全程 `top=60` 吸顶 ✅ |
| 桌面 1920 · 三列 TOC 长正文页 (`data-toc=collapsed`) | sidebar 全程吸顶，footer 跨三列 full-width ✅ |
| home 首页 (block 布局) | footer full-width 不变，无 sidebar ✅ |
| 移动端 375 | sidebar 隐藏，footer full-width，`overflow-x` 回到 `visible` 不裁剪既有 header 布局 ✅ |
| footer 全宽深色背景 | 宽屏 `footerLeft=0` / `footerWidth=1920`，无横向溢出 ✅ |

lint: **0 errors**（9 warnings 均为既有无关文件）。