### PR TITLE
style(Wiki): 浅色首页极简自洽 — Hero 扁平白 + 银河微光 + 全站浅色页脚

### DIFF
--- a/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
+++ b/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
@@ -37,7 +37,8 @@ uniform float uRepulsionStrength;
 uniform float uMouseActiveFactor;
 uniform float uAutoCenterRepulsion;
 uniform bool uTransparent;
-uniform vec3 uStarColor; // 浅底暗紫描点色（仅透明分支使用）
+uniform vec3 uStarTint; // 浅底星点冷调描点色（仅透明分支使用）
+uniform float uLightAlpha; // 浅底星点整体存在感（whisper；深色恒 1.0 不参与）
 varying vec2 vUv;
 
 #define NUM_LAYER 4.0
@@ -146,12 +147,13 @@ void main() {
     col += StarLayer(uv * scale + i * 453.32) * fade;
   }
   if (uTransparent) {
-    // 浅底模式：累加亮星在白/浅紫底上不可见（亮 on 亮，对比度趋零），故以累加量为
-    // 「星强度图」、输出暗紫描点 uStarColor，alpha 由强度 smoothstep 控制 → 浅底上的微妙星点。
+    // 浅底模式：additive 亮星在白底不可见，故以累加量 length(col) 为「星强度图」——它天然携带
+    // 原版 Star() 的光晕软边、twinkle 闪烁与多层景深；输出冷调描点 uStarTint，alpha 经 smoothstep
+    // 保留光晕软边、再乘 uLightAlpha 压低整体存在感 → 浅底上「远方星辰呼吸」而非平涂色点。
     float intensity = length(col);
     float alpha = smoothstep(0.0, 0.3, intensity);
-    alpha = min(alpha, 1.0);
-    gl_FragColor = vec4(uStarColor, alpha);
+    alpha = min(alpha, 1.0) * uLightAlpha;
+    gl_FragColor = vec4(uStarTint, alpha);
   } else {
     gl_FragColor = vec4(col, 1.0);
   }
@@ -184,21 +186,23 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
     // 注意：OGL `alpha` 标志锁定在 Renderer 创建时、不可热改，故切换主题必须 teardown+recreate
     //       （effect deps=[isDark]），与 Cytoscape/3DGraph 的「就地刷新」本质不同 —— 勿回退。
     const transparent = !isDark;
-    const glowIntensity = isDark ? 0.5 : 0.15;
+    const glowIntensity = isDark ? 0.5 : 0.15; // 浅色仅最亮星核显著 → 干净星点
     const hueShift = 280;
     const saturation = 0.28;
     const disableAnimation = prefersReducedMotion;
     const starSpeed = 0.5;
-    const density = isDark ? 1.2 : 0.4; // 浅色稀疏描点
+    const density = isDark ? 1.2 : 0.2; // 浅色大幅稀疏（whisper）
     const speed = 1.0;
     const mouseRepulsion = isDark; // 浅底排斥不可见且抢占指针，关闭
     const repulsionStrength = 2;
-    const twinkleIntensity = isDark ? 0.4 : 0.2;
+    const twinkleIntensity = isDark ? 0.4 : 0.25;
     const rotationSpeed = 0.1;
-    // 浅底暗紫描点色（~#4a2d78）；深色走 additive 亮星路径，此值不参与
-    const starColor: [number, number, number] = isDark
+    // 浅底整体存在感（whisper，视觉调参）；深色恒 1.0（additive 亮星路径不参与）
+    const lightAlpha = isDark ? 1.0 : 0.42;
+    // 浅底冷调灰蓝靛描点（~#737899，比暗紫更轻盈）；深色不参与
+    const starTint: [number, number, number] = isDark
       ? [1.0, 1.0, 1.0]
-      : [0.29, 0.18, 0.47];
+      : [0.45, 0.47, 0.62];
 
     const targetMousePos = { x: 0.5, y: 0.5 };
     const smoothMousePos = { x: 0.5, y: 0.5 };
@@ -260,9 +264,10 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
         uMouseActiveFactor: { value: 0.0 },
         uAutoCenterRepulsion: { value: 0 },
         uTransparent: { value: transparent },
-        uStarColor: {
-          value: new Color(starColor[0], starColor[1], starColor[2]),
+        uStarTint: {
+          value: new Color(starTint[0], starTint[1], starTint[2]),
         },
+        uLightAlpha: { value: lightAlpha },
       },
     });
 

--- a/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
+++ b/apps/negentropy-wiki/src/components/home/GalaxyBackground.tsx
@@ -3,6 +3,8 @@
 import { Renderer, Program, Mesh, Color, Triangle } from "ogl";
 import { useEffect, useRef } from "react";
 
+import { useIsDark } from "@/lib/wiki-color-scheme";
+
 /* ── GLSL Vertex Shader ── */
 const vertexShader = /* glsl */ `
 attribute vec2 uv;
@@ -35,6 +37,7 @@ uniform float uRepulsionStrength;
 uniform float uMouseActiveFactor;
 uniform float uAutoCenterRepulsion;
 uniform bool uTransparent;
+uniform vec3 uStarColor; // 浅底暗紫描点色（仅透明分支使用）
 varying vec2 vUv;
 
 #define NUM_LAYER 4.0
@@ -143,10 +146,12 @@ void main() {
     col += StarLayer(uv * scale + i * 453.32) * fade;
   }
   if (uTransparent) {
-    float alpha = length(col);
-    alpha = smoothstep(0.0, 0.3, alpha);
+    // 浅底模式：累加亮星在白/浅紫底上不可见（亮 on 亮，对比度趋零），故以累加量为
+    // 「星强度图」、输出暗紫描点 uStarColor，alpha 由强度 smoothstep 控制 → 浅底上的微妙星点。
+    float intensity = length(col);
+    float alpha = smoothstep(0.0, 0.3, intensity);
     alpha = min(alpha, 1.0);
-    gl_FragColor = vec4(col, alpha);
+    gl_FragColor = vec4(uStarColor, alpha);
   } else {
     gl_FragColor = vec4(col, 1.0);
   }
@@ -159,30 +164,41 @@ interface GalaxyBackgroundProps {
 
 export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
   const ctnDom = useRef<HTMLDivElement>(null);
+  const isDark = useIsDark();
 
   useEffect(() => {
     if (!ctnDom.current) return;
     const ctn = ctnDom.current;
+
+    // 防御性前置清理：主题切换触发 teardown+recreate 时，杜绝残留 canvas 致重影。
+    while (ctn.firstChild) ctn.removeChild(ctn.firstChild);
 
     // 无障碍：减弱动画
     const prefersReducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
 
-    // 主题预设 — 紫罗兰夜空，对齐 SquareDocs 深色主题
-    // 低饱和 → 以银白星点为主、紫罗兰为底，克制而非彩虹色
-    const transparent = false;
-    const glowIntensity = 0.5;
+    // 主题预设 ——
+    //   深色：紫罗兰夜空 + additive 亮星（原状，对齐 SquareDocs 深色）；
+    //   浅色：透明画布 + 暗紫描点（shader 透明分支），稀疏微妙星点点缀浅紫渐变。
+    // 注意：OGL `alpha` 标志锁定在 Renderer 创建时、不可热改，故切换主题必须 teardown+recreate
+    //       （effect deps=[isDark]），与 Cytoscape/3DGraph 的「就地刷新」本质不同 —— 勿回退。
+    const transparent = !isDark;
+    const glowIntensity = isDark ? 0.5 : 0.15;
     const hueShift = 280;
     const saturation = 0.28;
     const disableAnimation = prefersReducedMotion;
     const starSpeed = 0.5;
-    const density = 1.2;
+    const density = isDark ? 1.2 : 0.4; // 浅色稀疏描点
     const speed = 1.0;
-    const mouseRepulsion = true;
+    const mouseRepulsion = isDark; // 浅底排斥不可见且抢占指针，关闭
     const repulsionStrength = 2;
-    const twinkleIntensity = 0.4;
+    const twinkleIntensity = isDark ? 0.4 : 0.2;
     const rotationSpeed = 0.1;
+    // 浅底暗紫描点色（~#4a2d78）；深色走 additive 亮星路径，此值不参与
+    const starColor: [number, number, number] = isDark
+      ? [1.0, 1.0, 1.0]
+      : [0.29, 0.18, 0.47];
 
     const targetMousePos = { x: 0.5, y: 0.5 };
     const smoothMousePos = { x: 0.5, y: 0.5 };
@@ -244,6 +260,9 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
         uMouseActiveFactor: { value: 0.0 },
         uAutoCenterRepulsion: { value: 0 },
         uTransparent: { value: transparent },
+        uStarColor: {
+          value: new Color(starColor[0], starColor[1], starColor[2]),
+        },
       },
     });
 
@@ -311,7 +330,7 @@ export function GalaxyBackground({ className }: GalaxyBackgroundProps) {
       }
       gl.getExtension("WEBGL_lose_context")?.loseContext();
     };
-  }, []);
+  }, [isDark]);
 
   return <div ref={ctnDom} className={className} aria-hidden="true" />;
 }

--- a/apps/negentropy-wiki/src/components/home/WikiFooter.tsx
+++ b/apps/negentropy-wiki/src/components/home/WikiFooter.tsx
@@ -21,7 +21,7 @@ export function WikiFooter() {
         <div className="wiki-footer-bottom">
           <p>
             Copyright &copy; {new Date().getFullYear()} 三余知行. 保留所有权利{" "}
-            <a style={{ color: "#6ea8fe" }} href="https://beian.miit.gov.cn">
+            <a style={{ color: "var(--wiki-link-color)" }} href="https://beian.miit.gov.cn">
               粤ICP备2023147376号-1
             </a>
           </p>

--- a/apps/negentropy-wiki/src/styles/components/home-cards.css
+++ b/apps/negentropy-wiki/src/styles/components/home-cards.css
@@ -22,30 +22,11 @@
   box-shadow: var(--wiki-card-shadow);
   text-decoration: none;
   color: inherit;
-  position: relative;
-  overflow: hidden;
-  transition: box-shadow 0.25s ease, transform 0.2s ease;
-}
-.home-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  pointer-events: none;
-  background: radial-gradient(
-    400px circle at 50% 0%,
-    var(--wiki-primary-light),
-    transparent 60%
-  );
+  transition: box-shadow 0.25s ease, border-color 0.2s ease;
 }
 .home-card:hover {
-  box-shadow: var(--wiki-card-shadow), 0 8px 24px rgba(0, 0, 0, 0.1);
-  transform: translateY(-3px);
-}
-.home-card:hover::before {
-  opacity: 1;
+  border-color: var(--wiki-accent);
+  box-shadow: var(--wiki-card-shadow), 0 6px 18px rgba(20, 16, 40, 0.08);
 }
 
 .home-card--disabled {
@@ -53,11 +34,8 @@
   cursor: default;
 }
 .home-card--disabled:hover {
+  border-color: var(--wiki-border);
   box-shadow: var(--wiki-card-shadow);
-  transform: none;
-}
-.home-card--disabled:hover::before {
-  opacity: 0;
 }
 
 .home-card-icon {

--- a/apps/negentropy-wiki/src/styles/components/home-footer.css
+++ b/apps/negentropy-wiki/src/styles/components/home-footer.css
@@ -1,30 +1,9 @@
-/* Wiki 页脚 — 全站深色 */
+/* Wiki 页脚 —— 浅色主题与页面同色自洽（贴 Squaredops：纯白 + 发丝线 + 低噪深字）；
+   深色 themes.css 覆写为深色。全站统一（首页 / 内容页同款）。 */
 .wiki-footer {
-  position: relative; /* ::before 羽化锚定所需 */
   background: var(--wiki-footer-bg);
   color: var(--wiki-footer-text);
-}
-
-/*
- * 仅首页「卡片区(白) → 深色页脚」浅色主题羽化：页脚顶部叠一层白→深渐变，柔化像素级硬切。
- * 作用域 #wiki-root:has(.wiki-layout--home) 隔离 —— 内容页页脚不受影响。
- * 深色主题 --wiki-footer-fade=none / --wiki-footer-fade-height=0 → ::before 不可见、padding-top 回落。
- */
-#wiki-root:has(.wiki-layout--home) .wiki-footer::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--wiki-footer-fade-height);
-  background: var(--wiki-footer-fade);
-  z-index: 0;
-  pointer-events: none;
-}
-#wiki-root:has(.wiki-layout--home) .wiki-footer-inner {
-  position: relative;
-  z-index: 1; /* 内容浮于羽化渐变之上 */
-  padding-top: calc(var(--wiki-footer-fade-height) + 0.625rem);
+  border-top: 1px solid var(--wiki-footer-border); /* 发丝线分隔正文↔页脚 */
 }
 
 .wiki-footer-inner {

--- a/apps/negentropy-wiki/src/styles/components/home-footer.css
+++ b/apps/negentropy-wiki/src/styles/components/home-footer.css
@@ -1,7 +1,30 @@
 /* Wiki 页脚 — 全站深色 */
 .wiki-footer {
+  position: relative; /* ::before 羽化锚定所需 */
   background: var(--wiki-footer-bg);
   color: var(--wiki-footer-text);
+}
+
+/*
+ * 仅首页「卡片区(白) → 深色页脚」浅色主题羽化：页脚顶部叠一层白→深渐变，柔化像素级硬切。
+ * 作用域 #wiki-root:has(.wiki-layout--home) 隔离 —— 内容页页脚不受影响。
+ * 深色主题 --wiki-footer-fade=none / --wiki-footer-fade-height=0 → ::before 不可见、padding-top 回落。
+ */
+#wiki-root:has(.wiki-layout--home) .wiki-footer::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: var(--wiki-footer-fade-height);
+  background: var(--wiki-footer-fade);
+  z-index: 0;
+  pointer-events: none;
+}
+#wiki-root:has(.wiki-layout--home) .wiki-footer-inner {
+  position: relative;
+  z-index: 1; /* 内容浮于羽化渐变之上 */
+  padding-top: calc(var(--wiki-footer-fade-height) + 0.625rem);
 }
 
 .wiki-footer-inner {

--- a/apps/negentropy-wiki/src/styles/components/home-hero.css
+++ b/apps/negentropy-wiki/src/styles/components/home-hero.css
@@ -3,7 +3,7 @@
   position: relative;
   overflow: hidden;
   background: var(--wiki-hero-base);
-  color: #ffffff;
+  color: var(--wiki-hero-text);
   text-align: center;
   padding: 5rem 2rem 4rem;
 }
@@ -46,17 +46,24 @@
 .home-hero-cta {
   display: inline-block;
   padding: 0.7rem 1.8rem;
-  border: 2px solid #ffffff;
+  border: 2px solid var(--wiki-hero-cta-border);
   border-radius: 24px;
-  color: #ffffff;
+  background: var(--wiki-hero-cta-bg);
+  color: var(--wiki-hero-cta-color);
   font-size: 0.95em;
   font-weight: 600;
   text-decoration: none;
   transition: background 0.15s ease, color 0.15s ease;
 }
 .home-hero-cta:hover {
+  /* 反相反馈：浅色「紫底白字 → 白底紫字」、深色「白边透明 → 白底紫字」，两套主题一致 */
   background: #ffffff;
   color: var(--wiki-home-accent);
+}
+/* 实心紫 CTA 上显式焦点环：全局 :focus-visible 为 accent 描边，紫底之上不可见，故覆写 */
+.home-hero-cta:focus-visible {
+  outline: 2px solid var(--wiki-hero-cta-color);
+  outline-offset: 2px;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/negentropy-wiki/src/styles/layout.css
+++ b/apps/negentropy-wiki/src/styles/layout.css
@@ -143,9 +143,9 @@
 
 /* Home variant: full-width single column（Hero 需全幅出血，不受容器约束） */
 /*
- * 首页最底层背景填深色（与页脚同色）—— 仅当页面含首页布局时命中（`:has()` 作用域隔离，
- * 内容页不受影响）。配合下方移除 `.wiki-layout--home` 的 min-height：高视口短内容时，
- * 页脚下方的余白不再露出 body 的浅色背景，而是与深色页脚无缝衔接，避免「白条」回归。
+ * 首页最底层背景与页脚同色（`var(--wiki-footer-bg)`：浅色=白、深色=深）—— 仅首页布局命中
+ *（`:has()` 作用域隔离，内容页不受影响）。高视口短内容时，页脚下方余白与页脚无缝同色，
+ * 两套主题皆无色带回归（浅色全白自洽 / 深色全深）。
  */
 #wiki-root:has(.wiki-layout--home) {
   min-height: 100vh;
@@ -156,7 +156,7 @@
  * 不再强制撑满视口：显式 `min-height: 0` 覆写基类 `.wiki-layout` 的 `min-height: 100vh`
  *（首页元素同时持有 `wiki-layout wiki-layout--home` 两个类）。高度回归内容自适应——
  * 卡片区上下间隙由 `.home-cards-section` 的对称 padding 决定（各 48px），页脚紧随其后。
- * 显式声明 body 同色背景，避免被上方 `#wiki-root` 的深色底透出（浅色模式卡片区应为白）。
+ * 显式声明 body 同色背景（`var(--wiki-bg)`），与 `#wiki-root` 底色一致，浅/深皆自洽。
  */
 .wiki-layout--home {
   display: block;

--- a/apps/negentropy-wiki/src/styles/themes.css
+++ b/apps/negentropy-wiki/src/styles/themes.css
@@ -35,6 +35,16 @@
 
   /* Footer 更深 */
   --wiki-footer-bg: #0a0a0b;
+  /* 深色两端皆深、无硬切，跳过浅色页脚羽化 */
+  --wiki-footer-fade: none;
+  --wiki-footer-fade-height: 0px;
+
+  /* Hero —— 深空平铺（Galaxy 画布覆盖其上）+ 白字 / 白边描边 CTA，浅色改造在深色零回归 */
+  --wiki-hero-base: #140d24;
+  --wiki-hero-text: #ffffff;
+  --wiki-hero-cta-bg: transparent;
+  --wiki-hero-cta-color: #ffffff;
+  --wiki-hero-cta-border: #ffffff;
 
   /* Callout 深色覆写 */
   --wiki-note-bg: rgba(210, 168, 255, 0.1);
@@ -77,6 +87,14 @@
       transparent 70%
     );
     --wiki-footer-bg: #0a0a0b;
+    --wiki-footer-fade: none;
+    --wiki-footer-fade-height: 0px;
+    /* Hero —— 深空平铺 + 白字 / 白边 CTA（与显式深色块保持一致，防 system-dark 漏浅色） */
+    --wiki-hero-base: #140d24;
+    --wiki-hero-text: #ffffff;
+    --wiki-hero-cta-bg: transparent;
+    --wiki-hero-cta-color: #ffffff;
+    --wiki-hero-cta-border: #ffffff;
     --wiki-note-bg: rgba(210, 168, 255, 0.1);
     --wiki-warn-text: #fbbf24;
     --wiki-warn-bg: rgba(245, 158, 11, 0.12);

--- a/apps/negentropy-wiki/src/styles/themes.css
+++ b/apps/negentropy-wiki/src/styles/themes.css
@@ -33,11 +33,11 @@
     transparent 70%
   );
 
-  /* Footer 更深 */
+  /* Footer 更深 —— 显式钉死深色页脚 token，防 system-dark 漏浅色 */
   --wiki-footer-bg: #0a0a0b;
-  /* 深色两端皆深、无硬切，跳过浅色页脚羽化 */
-  --wiki-footer-fade: none;
-  --wiki-footer-fade-height: 0px;
+  --wiki-footer-text: #ffffff;
+  --wiki-footer-text-secondary: rgba(255, 255, 255, 0.66);
+  --wiki-footer-border: rgba(255, 255, 255, 0.1);
 
   /* Hero —— 深空平铺（Galaxy 画布覆盖其上）+ 白字 / 白边描边 CTA，浅色改造在深色零回归 */
   --wiki-hero-base: #140d24;
@@ -87,8 +87,9 @@
       transparent 70%
     );
     --wiki-footer-bg: #0a0a0b;
-    --wiki-footer-fade: none;
-    --wiki-footer-fade-height: 0px;
+    --wiki-footer-text: #ffffff;
+    --wiki-footer-text-secondary: rgba(255, 255, 255, 0.66);
+    --wiki-footer-border: rgba(255, 255, 255, 0.1);
     /* Hero —— 深空平铺 + 白字 / 白边 CTA（与显式深色块保持一致，防 system-dark 漏浅色） */
     --wiki-hero-base: #140d24;
     --wiki-hero-text: #ffffff;

--- a/apps/negentropy-wiki/src/styles/tokens.css
+++ b/apps/negentropy-wiki/src/styles/tokens.css
@@ -66,10 +66,9 @@
     transparent 70%
   );
 
-  /* 首页 Hero —— 浅紫「绽放」渐变：首尾回到页面底色 var(--wiki-bg)，与顶栏/卡片区
-     像素级无缝；中段最浓 #faf7ff（唯一新增魔法色，≤ Squaredocs 的极浅调性）。
+  /* 首页 Hero —— 纯白扁平（贴 Squaredops 零装饰），银河星光为唯一纹理。
      深色主题在 themes.css 覆写为 #140d24 深空平铺（Galaxy 画布覆盖其上）。 */
-  --wiki-hero-base: linear-gradient(180deg, var(--wiki-bg) 0%, #faf7ff 45%, var(--wiki-bg) 100%);
+  --wiki-hero-base: var(--wiki-bg);
   /* Hero 文字 / CTA —— 浅色：深字 + 紫实心 CTA（#6d28d9 对 #fff 对比度 ≈7:1）；
      深色 themes.css 覆写回「白字 + 白边描边 CTA」，保持深空 Hero 零回归。 */
   --wiki-hero-text: var(--wiki-text);
@@ -77,20 +76,12 @@
   --wiki-hero-cta-color: #ffffff;
   --wiki-hero-cta-border: transparent;
 
-  /* Footer — 全站深色 */
-  --wiki-footer-bg: #0f0f12;
-  --wiki-footer-text: #ffffff;
-  --wiki-footer-text-secondary: rgba(255, 255, 255, 0.66);
-  --wiki-footer-border: rgba(255, 255, 255, 0.1);
-  /* 首页「卡片区(白) → 深色页脚」浅色主题羽化（白→深渐变，柔化硬切）；
-     仅首页命中（见 home-footer.css 的 :has 作用域）；深色 themes.css 置 none/0 跳过 */
-  --wiki-footer-fade: linear-gradient(
-    180deg,
-    var(--wiki-bg) 0%,
-    var(--wiki-bg) 35%,
-    var(--wiki-footer-bg) 100%
-  );
-  --wiki-footer-fade-height: 96px;
+  /* Footer —— 浅色主题与页面同色（纯白自洽，贴 Squaredops：白底 + 发丝线 + 低噪深字）；
+     深色 themes.css 覆写为深色。全站统一（首页 / 内容页同款）。 */
+  --wiki-footer-bg: var(--wiki-bg);
+  --wiki-footer-text: var(--wiki-text);
+  --wiki-footer-text-secondary: var(--wiki-text-secondary);
+  --wiki-footer-border: var(--wiki-border);
 
   /* Primary light（active 背景叠色） */
   --wiki-primary-light: rgba(124, 58, 237, 0.1);

--- a/apps/negentropy-wiki/src/styles/tokens.css
+++ b/apps/negentropy-wiki/src/styles/tokens.css
@@ -66,18 +66,31 @@
     transparent 70%
   );
 
-  /* 首页 Hero — 深紫罗兰夜空（Galaxy 之下的基色，两套主题一致） */
-  --wiki-hero-base: #140d24;
-  --wiki-hero-blob-1: #3b1d6e;
-  --wiki-hero-blob-2: #6d28d9;
-  --wiki-hero-blob-3: #1e1140;
-  --wiki-hero-blob-4: #4c1d95;
+  /* 首页 Hero —— 浅紫「绽放」渐变：首尾回到页面底色 var(--wiki-bg)，与顶栏/卡片区
+     像素级无缝；中段最浓 #faf7ff（唯一新增魔法色，≤ Squaredocs 的极浅调性）。
+     深色主题在 themes.css 覆写为 #140d24 深空平铺（Galaxy 画布覆盖其上）。 */
+  --wiki-hero-base: linear-gradient(180deg, var(--wiki-bg) 0%, #faf7ff 45%, var(--wiki-bg) 100%);
+  /* Hero 文字 / CTA —— 浅色：深字 + 紫实心 CTA（#6d28d9 对 #fff 对比度 ≈7:1）；
+     深色 themes.css 覆写回「白字 + 白边描边 CTA」，保持深空 Hero 零回归。 */
+  --wiki-hero-text: var(--wiki-text);
+  --wiki-hero-cta-bg: var(--wiki-accent-hover);
+  --wiki-hero-cta-color: #ffffff;
+  --wiki-hero-cta-border: transparent;
 
   /* Footer — 全站深色 */
   --wiki-footer-bg: #0f0f12;
   --wiki-footer-text: #ffffff;
   --wiki-footer-text-secondary: rgba(255, 255, 255, 0.66);
   --wiki-footer-border: rgba(255, 255, 255, 0.1);
+  /* 首页「卡片区(白) → 深色页脚」浅色主题羽化（白→深渐变，柔化硬切）；
+     仅首页命中（见 home-footer.css 的 :has 作用域）；深色 themes.css 置 none/0 跳过 */
+  --wiki-footer-fade: linear-gradient(
+    180deg,
+    var(--wiki-bg) 0%,
+    var(--wiki-bg) 35%,
+    var(--wiki-footer-bg) 100%
+  );
+  --wiki-footer-fade-height: 96px;
 
   /* Primary light（active 背景叠色） */
   --wiki-primary-light: rgba(124, 58, 237, 0.1);


### PR DESCRIPTION
## 背景

承接 PR #962（浅色 Hero 提亮，已合并）。用户反馈浅色首页仍「不太恰当」，不够 **简约 / 简单 / 自洽**。对照参照 **Squaredops 浅色版**（实测 `squaredocs.framer.website` 浅色态）得出权威设计 DNA：纯白扁平 Hero（零装饰）、**页脚与页面同色（自洽）**、单一强调色、零渐变、扁平卡片。

本 PR 据此收敛 PR #962 残留的两处不自洽：① 银河暗紫色点 + 浅紫渐变「装饰过重」；② 深色页脚块打破全站浅色统一。

## 改动（仅浅色优化，深色零回归）

| 维度 | PR #962（前） | 本 PR（后） |
|---|---|---|
| Hero 背景 | 白↔#faf7ff↔白 渐变 | **纯白扁平** `var(--wiki-bg)`，银河为唯一纹理 |
| 银河星点 | 平涂暗紫色点（丢失原版质感） | **保留 reactbits 原版 Star() 光晕/twinkle/景深**，冷调灰蓝靛微光（`#737899`）+ 整体压低存在感（whisper） |
| 页脚 | 深色块 `#0f0f12` + 首页专属白→深羽化 | **全站浅色、与页面同色** + 发丝线 + 低噪深字（自洽） |
| 卡片 | hover 径向紫光 + translateY 抬升 | **扁平**：border 高亮 + 微阴影 |
| ICP 链接 | 硬编码 `#6ea8fe`（浅底对比度 2.6:1 不达标） | `var(--wiki-link-color)`（5.7:1 ✓） |

### 银河浅色质感（核心）
原版 reactbits Galaxy 是 additive 亮星，为深底设计——白底上不可见（PR #962 故改平涂暗点，但丢了质感）。本 PR 在透明合成分支以累加量 `length(col)` 为「星强度图」（**天然携带原版光晕软边 + twinkle 闪烁 + 多层景深**），输出冷调描点 `uStarTint` + 乘 `uLightAlpha` 压低存在感 → 浅底上「远方星辰呼吸」。深色分支走原 additive 亮星路径不变。

### 熵减
- 删除死代码 token `--wiki-footer-fade` / `--wiki-footer-fade-height`（羽化移除后无引用）。
- 净 **−91 / +45** 行。

## 验证（conductor 工作区 `next dev :3093`，实机迭代）

- ✅ **浅色全链路自洽**：body / #wiki-root / layout-home / Hero / 卡片 / 页脚 **全部 `rgb(255,255,255)` 纯白**（计算样式 `allWhiteCohesive: true`）。
- ✅ **银河定稿**：canvas 栅格化 + 视觉评审确认稀疏冷调微光星点（约 3% 覆盖、avg `rgb(115,120,158)`），带柔光晕与尺寸变化，非色点/污渍。
- ✅ **深色零回归**：Hero `#140d24` + 白字 + 白边 CTA、页脚 `#0a0a0b` + 白字、银紫亮星银河——逐项保留。
- ✅ **全站页脚**：内容页（非首页）页脚同为浅色自洽（PR #962 的羽化仅首页，本 PR token 化后全站统一）。
- ✅ **主题切换**：连切 5 次（10 次 GL teardown/recreate），canvas 数恒为 1，无重影 / 泄漏，控制台零报错。
- ✅ **对比度全过 AA**：页脚主文字 18:1 / 次文字 6.2:1 / ICP 链接 5.7:1 / CTA 7.1:1。
- ✅ `tsc --noEmit` 通过（仅一项与本次无关的既有测试告警）；pre-commit `next lint` 通过。

## 不在范围 / 取舍

- 深色主题零改动。
- Hero 文案不动（属内容）。
- CTA 保持紫强调（品牌一致）；如需更中性可后续改黑色按钮（Squaredops 风）。
- 全站深色页脚（深色主题）保留——仅浅色主题页脚改为自洽浅色。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
