### PR TITLE
feat(Wiki): 首页强制暗色主题并隐藏切换按钮

### DIFF
--- a/apps/negentropy-wiki/src/app/layout.tsx
+++ b/apps/negentropy-wiki/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
+import { HomePageThemeGuard } from "@/components/HomePageThemeGuard";
+
 /**
  * 自托管 Inter（对齐 SquareDocs 字形观感）。
  * 仅加载 latin 子集，CJK 中文由 --wiki-*-font 令牌的系统字体回退兜底。
@@ -29,10 +31,17 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
-/* 主题统一为 SquareDocs 紫罗兰单一主题，仅保留外观（浅/深/系统）的 FOUC 防闪脚本 */
+/* 主题统一为 SquareDocs 紫罗兰单一主题，仅保留外观（浅/深/系统）的 FOUC 防闪脚本。
+ * 首页（路由 "/"）强制暗色：先于 localStorage 判定并直接钉 dark，杜绝「偏好浅色 →
+ * 首屏先亮后暗」的闪烁；离开首页后由 HomePageThemeGuard 从 localStorage 恢复偏好。 */
 const THEME_INIT = `
 (function(){
   try {
+    var path = location.pathname;
+    if (path === "/" || path === "") {
+      document.documentElement.setAttribute("data-color-scheme", "dark");
+      return;
+    }
     var c = localStorage.getItem('wiki:color-scheme');
     if (c && c !== 'system') document.documentElement.setAttribute('data-color-scheme', c);
   } catch(e) {}
@@ -53,9 +62,8 @@ export default function RootLayout({
         <a href="#wiki-main" className="skip-link">
           跳到主要内容
         </a>
-        <div id="wiki-root">
-          {children}
-        </div>
+        <HomePageThemeGuard />
+        <div id="wiki-root">{children}</div>
       </body>
     </html>
   );

--- a/apps/negentropy-wiki/src/components/HomePageThemeGuard.tsx
+++ b/apps/negentropy-wiki/src/components/HomePageThemeGuard.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useLayoutEffect } from "react";
+import { usePathname } from "next/navigation";
+
+import { applyColorScheme, getStoredColorScheme } from "@/lib/wiki-color-scheme";
+
+/**
+ * 同构 effect：客户端取 `useLayoutEffect`（commit 后、paint 前同步执行，客户端导航
+ * 切换主题零闪烁）；SSR / SSG 预渲染取 `useEffect`（规避 `useLayoutEffect` 在无
+ * `window` 环境下的服务端告警）。模块加载时按 `typeof window` 一次性锁定，客户端
+ * bundle 恒为 `useLayoutEffect`，含水合首帧亦在 paint 前生效。
+ */
+const useIsoMorphicEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+/** 站点首页判定（`trailingSlash: true` 下 `usePathname()` 返回 `"/"`，`""` 为防御兜底）。 */
+function isHomePath(pathname: string | null): boolean {
+  return pathname === "/" || pathname === "";
+}
+
+/**
+ * 首页强制暗色外观的站点级守卫。
+ *
+ * 挂在根 `layout.tsx`，跨所有路由持久存在，覆盖「客户端导航」时序窗口（首屏硬刷新
+ * 由 `layout.tsx` 的 FOUC 防闪脚本兜底）。核心不变量：**仅覆写 DOM 外观，绝不写
+ * localStorage**——首页强制暗色是临时外观覆写，不污染用户偏好；离开首页时从
+ * localStorage 重新 apply 偏好，自然恢复。
+ *
+ * - 首页（`pathname === "/"`）：钉 `<html data-color-scheme="dark">`；
+ * - 非首页：apply 用户 localStorage 偏好（`"system"` → 移除属性，跟随系统）。
+ *
+ * 注意：`WikiLayoutShell` 的 `variant="home"` 不等于站点首页（图谱页亦用之），
+ * 故判定一律基于路由 `pathname`，与布局变体解耦。
+ */
+export function HomePageThemeGuard() {
+  const pathname = usePathname();
+
+  useIsoMorphicEffect(() => {
+    if (typeof window === "undefined") return;
+    if (isHomePath(pathname)) {
+      applyColorScheme("dark");
+    } else {
+      applyColorScheme(getStoredColorScheme());
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/negentropy-wiki/src/components/ThemePreference.tsx
+++ b/apps/negentropy-wiki/src/components/ThemePreference.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { usePathname } from "next/navigation";
 
-import { COLOR_SCHEME_KEY } from "@/lib/wiki-color-scheme";
-
-type ColorScheme = "light" | "dark" | "system";
-
-function getStoredValue(key: string, fallback: string): string {
-  if (typeof window === "undefined") return fallback;
-  return localStorage.getItem(key) ?? fallback;
-}
+import {
+  COLOR_SCHEME_KEY,
+  applyColorScheme,
+  getStoredColorScheme,
+  type ColorScheme,
+} from "@/lib/wiki-color-scheme";
 
 function subscribe(cb: () => void) {
   const handler = (e: StorageEvent) => {
@@ -27,9 +26,11 @@ function subscribeSystemDark(cb: () => void) {
 }
 
 export function ThemePreference() {
+  const pathname = usePathname();
+
   const colorScheme = useSyncExternalStore(
     subscribe,
-    () => getStoredValue(COLOR_SCHEME_KEY, "system") as ColorScheme,
+    () => getStoredColorScheme(),
     () => "system" as ColorScheme,
   );
 
@@ -42,21 +43,29 @@ export function ThemePreference() {
   );
 
   // 水合后据 localStorage 重新断言外观，兜底内联脚本/水合差异导致的 data-color-scheme 丢失。
+  // 首页由 HomePageThemeGuard 强制暗色管控：此处须跳过，避免把外观还原成 localStorage 偏好
+  // （否则会覆盖 guard 在 paint 前钉定的 dark）。
   useEffect(() => {
-    applyColorScheme(getStoredValue(COLOR_SCHEME_KEY, "system") as ColorScheme);
-  }, []);
+    if (pathname === "/" || pathname === "") return;
+    applyColorScheme(getStoredColorScheme());
+  }, [pathname]);
 
   const resolvedDark =
     colorScheme === "dark" || (colorScheme === "system" && systemDark);
 
   const handleToggle = useCallback(() => {
-    const current = getStoredValue(COLOR_SCHEME_KEY, "system") as ColorScheme;
+    const current = getStoredColorScheme();
     const isDark = current === "dark" || (current === "system" && systemDark);
     const next: "light" | "dark" = isDark ? "light" : "dark";
     localStorage.setItem(COLOR_SCHEME_KEY, next);
     applyColorScheme(next);
     window.dispatchEvent(new StorageEvent("storage", { key: COLOR_SCHEME_KEY }));
   }, [systemDark]);
+
+  // 首页强制暗色：隐藏切换按钮（不允许切回浅色）。
+  // 注意须在所有 hooks 调用之后再 early return，保证 hooks 调用顺序恒定。
+  // graph 页等 pathname≠"/" 不受影响，按钮照常渲染。
+  if (pathname === "/" || pathname === "") return null;
 
   return (
     <button
@@ -83,20 +92,4 @@ export function ThemePreference() {
       )}
     </button>
   );
-}
-
-function applyColorScheme(cs: ColorScheme) {
-  const el = document.documentElement;
-  if (cs === "system") {
-    el.removeAttribute("data-color-scheme");
-  } else {
-    el.setAttribute("data-color-scheme", cs);
-  }
-}
-
-export function initThemeFromStorage() {
-  const cs = localStorage.getItem(COLOR_SCHEME_KEY) as ColorScheme | null;
-  if (cs && cs !== "system") {
-    document.documentElement.setAttribute("data-color-scheme", cs);
-  }
 }

--- a/apps/negentropy-wiki/src/lib/wiki-color-scheme.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-color-scheme.ts
@@ -56,3 +56,36 @@ export function useIsDark(): boolean {
     () => false,
   );
 }
+
+/** 颜色方案字面量（与 localStorage 存储值一致）。 */
+export type ColorScheme = "light" | "dark" | "system";
+
+/**
+ * 读取 localStorage 中的主题偏好，缺失 / 异常（隐私模式等）回退 `"system"`。
+ * SSR 安全：服务端 / SSG 预渲染阶段无 `window`，恒返回 `"system"`。
+ */
+export function getStoredColorScheme(): ColorScheme {
+  if (typeof window === "undefined") return "system";
+  try {
+    const v = window.localStorage.getItem(COLOR_SCHEME_KEY);
+    return v === "light" || v === "dark" || v === "system" ? v : "system";
+  } catch {
+    return "system";
+  }
+}
+
+/**
+ * 把颜色方案应用到 `<html data-color-scheme>`（仅改 DOM，不写 localStorage）。
+ *
+ * - `"system"`：移除属性，交由 CSS `@media (prefers-color-scheme)` 跟随系统；
+ * - `"light"` / `"dark"`：显式设属性，覆盖系统偏好。
+ *
+ * 该属性是主题的单一事实源：`detectDark()`、`useIsDark()`、Galaxy 画布与各图谱
+ * 渲染器均读取它，故只需翻转此属性即可让全站暗色感知同步。
+ */
+export function applyColorScheme(cs: ColorScheme): void {
+  if (typeof document === "undefined") return;
+  const el = document.documentElement;
+  if (cs === "system") el.removeAttribute("data-color-scheme");
+  else el.setAttribute("data-color-scheme", cs);
+}


### PR DESCRIPTION
## 背景

Wiki 站点首页需始终以暗色主题呈现：隐藏主题切换按钮、强制停留在暗色，且首页不可被切到亮色；离开首页后恢复正常切换。

## 改动

围绕主题单一事实源 `<html data-color-scheme>` 属性，在三个时序窗口正交落地。核心不变量：**首页时该属性恒为 `dark`，且绝不写 localStorage**（不污染用户偏好，离开首页时从 localStorage 恢复即可）。

| 时序窗口 | 落点 | 机制 |
|---|---|---|
| 硬刷新首屏 | `layout.tsx` FOUC 防闪脚本 | `location.pathname === "/"` 时先于 localStorage 钉定 `dark`，杜绝首屏先亮后暗 |
| 客户端导航 | 新增 `HomePageThemeGuard`（挂根 layout） | `usePathname()` + `useLayoutEffect`（paint 前同步），首页钉 dark、离开恢复偏好 |
| 隐藏切换按钮 | `ThemePreference` | 首页 `usePathname()` 早返回 `null` |

辅助：`applyColorScheme` / `getStoredColorScheme` 提升至 `wiki-color-scheme.ts` 作为单一事实源，消除 `ThemePreference` 与守卫间的逻辑漂移。

> **关键陷阱**：`WikiLayoutShell` 的 `variant="home"` 不等于站点首页（图谱页 `/{pubSlug}/graph` 也用它，语义是“全宽布局”），故首页判定一律基于路由 `pathname === "/"`，与布局变体解耦。

## 验证

- `pnpm lint` **0 错误**；`pnpm test` **97 项全绿**；`pnpm build` SSG 成功（含图谱页 `/wiki/graph`、`/negentropy/graph`，证明 `variant="home"` 页面未受影响）。
- 浏览器实机覆盖边界：偏好 `light` 硬刷新首页 → 首屏即暗且 `localStorage` 未被污染；离开首页 → 恢复 `light`；图谱页按钮可见、点击可切换；客户端导航（点 logo）进首页 → guard 在无 FOUC 下强制 dark。

## 已知小瑕疵（本期不处理）

`<meta name="theme-color">` 仍按系统 `prefers-color-scheme` 取值，首页强制暗色时浏览器地址栏 chrome 可能有 1-2px 颜色割裂；首页为全屏深空 Galaxy 画布，视觉掩盖明显，ROI 低，后续单开 task 处理。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>