### PR TITLE
fix(Wiki): 修复三栏 sticky 侧栏遮盖页脚

### DIFF
--- a/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
+++ b/apps/negentropy-wiki/src/components/WikiLayoutShell.tsx
@@ -132,8 +132,8 @@ export function WikiLayoutShell({
           <WikiMobileNav topNav={mobileTopNav}>{sidebar}</WikiMobileNav>
           <div className="wiki-layout wiki-layout--home" data-header={header ? "" : undefined}>
             <main className="wiki-main wiki-main--home">{children}</main>
-            {footer}
           </div>
+          {footer}
         </>
       ) : (
         <>
@@ -142,8 +142,8 @@ export function WikiLayoutShell({
             <aside className="wiki-sidebar">{sidebar}</aside>
             <main className="wiki-main">{children}</main>
             {hasToc && <aside className="wiki-toc-aside">{toc}</aside>}
-            {footer}
           </div>
+          {footer}
         </>
       )}
     </TocContext.Provider>

--- a/apps/negentropy-wiki/src/styles/components/home-footer.css
+++ b/apps/negentropy-wiki/src/styles/components/home-footer.css
@@ -5,19 +5,15 @@
   color: var(--wiki-footer-text);
   border-top: 1px solid var(--wiki-footer-border); /* 发丝线分隔正文↔页脚 */
   /*
-   * Footer 现作为最后一个 grid item 纳入 .wiki-layout（见 WikiLayoutShell.tsx），
-   * 使左栏 .wiki-sidebar 的 sticky 包含块覆盖整篇文档（含页脚）——根治「短正文页
-   * 滚到页脚区时 sidebar 因 grid area 提前耗尽而脱粘、随正文上滑消失」。
+   * Footer 渲染在 .wiki-layout 之外、作为其兄弟节点（父为全宽的 #wiki-root，见
+   * WikiLayoutShell.tsx）——使左 .wiki-sidebar / 右 .wiki-toc-aside 的 sticky 脱粘
+   * 下边界（= 直接父 .wiki-layout 的 content box 底）精确落在 footer 顶部，滚到页底时
+   * 左右栏底边停在页脚上边界，绝不遮盖页脚（对齐 Docusaurus / VitePress / Stripe Docs）。
    *
-   * - grid-column:1/-1：跨越 sidebar/main/toc 全部列（grid 列数随 data-toc 三态变化皆适配）；
-   *   home 变体为 block 布局，此声明被忽略，无副作用。
-   * - width:100vw + 对称负 margin：full-bleed 全宽背景，保留 footer 贯穿视口的视觉
-   *   （不随 .wiki-layout 的 1404px 容器限宽）。50% 相对 grid cell（整行宽）。
+   * #wiki-root 全宽无 max-width/padding，footer 作为 block 默认撑满视口，无需 full-bleed
+   * 出血计算（旧 width:100vw + 负 margin 在 Windows 经典滚动条下会被 body overflow-x:clip
+   * 硬切右端并整体左移，已移除）。内容居中由 .wiki-footer-inner 的 max-width:1200px 承担。
    */
-  grid-column: 1 / -1;
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
 }
 
 .wiki-footer-inner {

--- a/apps/negentropy-wiki/src/styles/layout.css
+++ b/apps/negentropy-wiki/src/styles/layout.css
@@ -22,8 +22,9 @@
   position: sticky;
   top: 0;
   /* grid item 钉顶：对齐 .wiki-toc-aside 的正确 sticky 实践（sticky grid item 需显式
-     align-self:start 钉顶而非默认 stretch）。全程吸顶的根本保障是 footer 纳入 grid
-     扩展 sticky 包含块覆盖整篇文档（见 home-footer.css 与 WikiLayoutShell.tsx）。 */
+     align-self:start 钉顶而非默认 stretch）。脱粘下边界 = 直接父 .wiki-layout 的 content
+     box 底；footer 现作为 .wiki-layout 的兄弟置于其外（见 WikiLayoutShell.tsx 与
+     home-footer.css），故该边界 = footer 顶部，滚到页底时左右栏底边停在页脚上沿不遮盖。 */
   align-self: start;
   height: 100vh;
   overflow-y: auto;


### PR DESCRIPTION
## 背景

Wiki 三栏布局（左导航 / 中正文 / 右目录）的左右栏使用 `position: sticky` 吸顶。滚动到页面最下方时，左栏菜单与右栏目录的下部**遮盖了底部页脚模块**（「知行 / 智践 / 链接」），左右栏底边越过页脚顶部。

## 根因

上一个 commit `cb226ae9`（修复「短正文页 sidebar 脱粘」）将 `.wiki-footer` 移入了 `.wiki-layout` grid 容器内部，注释称「全程吸顶的根本保障是 footer 纳入 grid 扩展 sticky 包含块」。该判断与 CSS sticky 语义**相反**，正是本 bug 元凶：

- sticky 元素的脱粘下边界 = 其直接父级 `.wiki-layout` 的 content box 底部；
- footer 移入 grid 后该 content box 底部 = **footer 底部**，导致左右栏脱粘区间延伸到页脚行内，滚到页底时底边越过页脚顶部、遮盖页脚上半部分。

## 方案

将 footer 移回 `.wiki-layout` grid 容器之外（成为兄弟节点，父为全宽 `#wiki-root`），使 sticky 脱粘边界 = footer 顶部，左右栏底边精确停在页脚上沿（0 重叠）。对齐 Docusaurus / VitePress / Stripe Docs 标准结构。

| 文件 | 改动 |
|---|---|
| `WikiLayoutShell.tsx` | content / home 两变体把 `{footer}` 移出 `.wiki-layout`（grid 之外，兄弟节点） |
| `home-footer.css` | 删除 `grid-column` / `width:100vw` / 两条负 margin（父全宽后无需 full-bleed；旧写法在 Windows 经典滚动条下会被 `overflow-x:clip` 切右端并左移） |
| `layout.css` | 订正 `.wiki-sidebar` sticky 注释（**CSS 规则不变**——盖 footer 与 `height` 无关，保留立柱视觉） |

`base.css` 的 `overflow-x:clip`、`toc.css` 折叠态 sticky、`height:calc(100vh-header)` 均**不动**（零成本防御 / 无关 / 非根因）。

## 取舍

`cb226ae9` 修复的「短正文页 sidebar 全程贴顶（含 footer 区上方）」会部分回归：短正文页滚到底时侧栏随正文自然上滑结束。此为几何必然（侧栏高于父容器则无法全程贴顶），且符合「footer 区不立导航立柱」的产品语义（主流文档站皆然）。优先根治「遮盖页脚」这一明确视觉 bug。

## 验证（next dev :3093，真实滚动 + getBoundingClientRect）

| 场景 | sidebar/toc 底边 vs footer 顶 | 结论 |
|---|---|---|
| **bug 态**（临时把 footer 移回 grid，复现 cb226ae9） | 重叠 **680px** | ❌ 遮盖（复现用户截图现象） |
| **修复态**（footer 出 grid） | **0 重叠** | ✅ 不遮盖 |

- `wiki/harness-engineering/getting-started`（三栏 TOC collapsed）：滚到底 sidebar.bottom = toc.bottom = footer.top，0 重叠
- `negentropy/concepts/user-guide/skills-advanced`（无 TOC）：滚到底 sidebar.bottom = footer.top，0 重叠
- 首页（home 变体）：footer 全宽（width = viewport）、无横向滚动条；footer 已移出 `.wiki-layout`（父为 `#wiki-root`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
