### PR TITLE
fix(Wiki): 全站内链规范化为尾斜杠，修复 nginx 下首页模块跳转失败

### DIFF
--- a/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/[...entrySlug]/page.tsx
@@ -1,7 +1,9 @@
 import {
   buildReservedDocsTab,
+  graphHref,
   isReservedDocsSlug,
   joinEntrySlug,
+  pubHref,
   resolveSectionView,
   resolveSidebarView,
   type WikiEntry,
@@ -108,7 +110,7 @@ export default async function WikiEntryPage({ params }: Props) {
           文档 &quot;{slug}&quot; 的源文件已被移除或转移，条目暂时无法访问。
         </p>
         <div className="wiki-not-found-actions">
-          <Link href={`/${pubSlug}`}>← 返回 {pubSlug}</Link>
+          <Link href={pubHref(pubSlug)}>← 返回 {pubSlug}</Link>
           <Link href="/">返回首页</Link>
         </div>
       </main>
@@ -123,7 +125,7 @@ export default async function WikiEntryPage({ params }: Props) {
           文档 &quot;{slug}&quot; 不存在或未发布
         </p>
         <div className="wiki-not-found-actions">
-          <Link href={`/${pubSlug}`}>← 返回 {pubSlug}</Link>
+          <Link href={pubHref(pubSlug)}>← 返回 {pubSlug}</Link>
           <Link href="/">返回首页</Link>
         </div>
       </main>
@@ -182,7 +184,7 @@ export default async function WikiEntryPage({ params }: Props) {
       graphTab={{
         active: false,
         show: !!headerNav.graphPubSlug,
-        href: headerNav.graphPubSlug ? `/${headerNav.graphPubSlug}/graph` : undefined,
+        href: headerNav.graphPubSlug ? graphHref(headerNav.graphPubSlug) : undefined,
       }}
     />
   );

--- a/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/graph/page.tsx
@@ -9,7 +9,9 @@ import { WikiLayoutShell } from "@/components/WikiLayoutShell";
 import {
   buildReservedDocsTab,
   countLeafEntries,
+  graphHref,
   isReservedDocsSlug,
+  pubHref,
   resolveSectionView,
   type WikiNavTreeItem,
   type WikiPublication,
@@ -101,7 +103,7 @@ export default async function WikiPublicationGraphPage({ params }: Props) {
       graphTab={{
         active: pubSlug === headerNav.graphPubSlug,
         show: !!headerNav.graphPubSlug,
-        href: headerNav.graphPubSlug ? `/${headerNav.graphPubSlug}/graph` : undefined,
+        href: headerNav.graphPubSlug ? graphHref(headerNav.graphPubSlug) : undefined,
       }}
     />
   );
@@ -152,7 +154,7 @@ function WikiGraphBody({
       <div className="wiki-graph-error">
         <p className="wiki-text-hint">
           图谱数据暂时不可用，请稍后重试或返回
-          <Link href={`/${pubSlug}`} style={{ marginLeft: "0.3em" }}>
+          <Link href={pubHref(pubSlug)} style={{ marginLeft: "0.3em" }}>
             Publication 首页
           </Link>
           。

--- a/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
+++ b/apps/negentropy-wiki/src/app/[pubSlug]/page.tsx
@@ -1,6 +1,8 @@
 import {
   buildReservedDocsTab,
   countLeafEntries,
+  entryHref,
+  graphHref,
   isReservedDocsSlug,
   resolveSectionView,
   resolveSidebarView,
@@ -110,7 +112,7 @@ export default async function WikiPublicationPage({ params }: Props) {
       graphTab={{
         active: false,
         show: !!headerNav.graphPubSlug,
-        href: headerNav.graphPubSlug ? `/${headerNav.graphPubSlug}/graph` : undefined,
+        href: headerNav.graphPubSlug ? graphHref(headerNav.graphPubSlug) : undefined,
       }}
     />
   );
@@ -126,7 +128,7 @@ export default async function WikiPublicationPage({ params }: Props) {
         <h1 className="wiki-doc-title">
           {sidebarView.catalogName ? (
             sidebarView.catalogTargetSlug ? (
-              <Link href={`/${pubSlug}/${sidebarView.catalogTargetSlug}`}>
+              <Link href={entryHref(pubSlug, sidebarView.catalogTargetSlug)}>
                 {sidebarView.catalogName}
               </Link>
             ) : (
@@ -155,7 +157,7 @@ export default async function WikiPublicationPage({ params }: Props) {
       ) : sidebarView.indexEntry ? (
         <p className="wiki-text-hint">
           请从左侧导航选择文档，或直接访问{" "}
-          <Link href={`/${pubSlug}/${sidebarView.indexEntry.entry_slug}`}>首页</Link>。
+          <Link href={entryHref(pubSlug, sidebarView.indexEntry.entry_slug)}>首页</Link>。
         </p>
       ) : (
         <p className="wiki-text-hint">请从左侧导航选择文档开始阅读。</p>

--- a/apps/negentropy-wiki/src/app/page.tsx
+++ b/apps/negentropy-wiki/src/app/page.tsx
@@ -3,8 +3,11 @@ import type { ComponentType } from "react";
 import {
   buildHeaderNav,
   buildReservedDocsTab,
+  entryHref,
   findFirstDocumentSlug,
+  graphHref,
   isReservedDocsSlug,
+  pubHref,
   RESERVED_DOCS_HOME,
   RESERVED_DOCS_LABEL,
   type WikiNavTreeItem,
@@ -20,12 +23,6 @@ import { HomeCard } from "@/components/home/HomeCard";
 import { GalaxyHeroMount } from "@/components/home/GalaxyHeroMount";
 import { WikiFooter } from "@/components/home/WikiFooter";
 import { getPublicationIcon } from "@/components/home/CardIcons";
-
-/** 从 nav tree 一级节点构建跳转 href */
-function buildEntryHref(pubSlug: string, item: WikiNavTreeItem): string {
-  const target = findFirstDocumentSlug(item);
-  return target ? `/${pubSlug}/${target}` : `/${pubSlug}`;
-}
 
 export default async function WikiHomePage() {
   let publications: WikiPublication[] = [];
@@ -70,7 +67,9 @@ export default async function WikiHomePage() {
       // 有 nav tree 一级节点时，从中构建卡片
       for (const item of items) {
         const title = item.entry_title || item.entry_slug;
-        const href = buildEntryHref(pub.slug, item);
+        // CONTAINER → DFS 首个后代 DOCUMENT；DOCUMENT → 自身。href 经 SSOT helper 带尾斜杠。
+        const firstDoc = findFirstDocumentSlug(item);
+        const href = firstDoc ? entryHref(pub.slug, firstDoc) : pubHref(pub.slug);
         homeCards.push({
           title,
           // 优先节点级描述（Catalog 节点 description）→ 回退 Publication 级描述 → 占位
@@ -83,7 +82,7 @@ export default async function WikiHomePage() {
       // nav tree 为空或 API 失败时，用 publication 自身作为兜底
       homeCards.push({
         title: pub.name,
-        href: `/${pub.slug}`,
+        href: pubHref(pub.slug),
         description: pub.description || "暂无描述",
         Icon: getPublicationIcon(pub.name),
       });
@@ -124,7 +123,7 @@ export default async function WikiHomePage() {
               show: true,
               active: false,
               label: "Knowledge Graph",
-              href: `/${graphPubSlug}/graph`,
+              href: graphHref(graphPubSlug),
             }
           : undefined
       }

--- a/apps/negentropy-wiki/src/components/WikiBreadcrumb.tsx
+++ b/apps/negentropy-wiki/src/components/WikiBreadcrumb.tsx
@@ -1,3 +1,5 @@
+import { entryHref } from "@/lib/wiki-api";
+
 interface BreadcrumbItem {
   label: string;
   slug: string | null;
@@ -17,7 +19,7 @@ export function WikiBreadcrumb({ items, pubSlug }: WikiBreadcrumbProps) {
         <span key={i}>
           {i > 0 && <span className="wiki-doc-breadcrumb-sep">›</span>}
           {item.slug ? (
-            <a href={`/${pubSlug}/${item.slug}`} className="wiki-doc-breadcrumb-link">
+            <a href={entryHref(pubSlug, item.slug)} className="wiki-doc-breadcrumb-link">
               {item.label}
             </a>
           ) : (

--- a/apps/negentropy-wiki/src/components/WikiHeader.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeader.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import {
+  entryHref,
   findFirstDocumentSlug,
+  graphHref,
   isContainerItem,
   type HeaderTopNavItem,
   type ReservedDocsTab,
@@ -86,7 +88,7 @@ export function WikiHeader({
             )}
             {graphTab?.show && (
               <Link
-                href={graphTab.href ?? `/${pubSlug}/graph`}
+                href={graphTab.href ?? graphHref(pubSlug ?? "")}
                 className={`wiki-header-tab${graphTab.active ? " active" : ""}`}
                 aria-current={graphTab.active ? "page" : undefined}
               >
@@ -152,7 +154,7 @@ function WikiHeaderTab({ item, pubSlug, isActive }: WikiHeaderTabProps) {
 
   return (
     <Link
-      href={`/${pubSlug}/${targetSlug}`}
+      href={entryHref(pubSlug, targetSlug)}
       className={`wiki-header-tab${isActive ? " active" : ""}`}
       aria-current={isActive ? "page" : undefined}
     >

--- a/apps/negentropy-wiki/src/components/WikiHeaderMobileNav.tsx
+++ b/apps/negentropy-wiki/src/components/WikiHeaderMobileNav.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import {
+  entryHref,
   findFirstDocumentSlug,
   RESERVED_DOCS_HOME,
   RESERVED_DOCS_LABEL,
@@ -29,7 +30,7 @@ interface WikiHeaderMobileNavProps {
 /** CONTAINER → 首个后代 DOCUMENT slug；DOCUMENT → 自身 slug；无文档 → null。 */
 function targetHref(pubSlug: string, item: WikiNavTreeItem): string | null {
   const target = findFirstDocumentSlug(item);
-  return target ? `/${pubSlug}/${target}` : null;
+  return target ? entryHref(pubSlug, target) : null;
 }
 
 export function WikiHeaderMobileNav({ reservedTab, topNav = [] }: WikiHeaderMobileNavProps) {

--- a/apps/negentropy-wiki/src/components/WikiNavTree.tsx
+++ b/apps/negentropy-wiki/src/components/WikiNavTree.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { isContainerItem, type WikiNavTreeItem } from "@/lib/wiki-api";
+import { entryHref, isContainerItem, type WikiNavTreeItem } from "@/lib/wiki-api";
 
 /**
  * 计算「当前页祖先链」的 entry_slug 集合，用于初始化展开态。
@@ -121,7 +121,7 @@ function WikiNavNode({
         ) : (
           <Link
             ref={linkRef}
-            href={`/${pubSlug}/${item.entry_slug}`}
+            href={entryHref(pubSlug, item.entry_slug)}
             className={`wiki-nav-link${isActive ? " active" : ""}`}
             aria-current={isActive ? "page" : undefined}
           >

--- a/apps/negentropy-wiki/src/components/WikiPager.tsx
+++ b/apps/negentropy-wiki/src/components/WikiPager.tsx
@@ -1,3 +1,5 @@
+import { entryHref } from "@/lib/wiki-api";
+
 interface PagerLink {
   title: string;
   slug: string;
@@ -27,7 +29,7 @@ export function WikiPager({ prev, next, pubSlug }: WikiPagerProps) {
     >
       {prev ? (
         <a
-          href={`/${pubSlug}/${prev.slug}`}
+          href={entryHref(pubSlug, prev.slug)}
           style={{
             color: "var(--wiki-accent)",
             textDecoration: "none",
@@ -45,7 +47,7 @@ export function WikiPager({ prev, next, pubSlug }: WikiPagerProps) {
       )}
       {next ? (
         <a
-          href={`/${pubSlug}/${next.slug}`}
+          href={entryHref(pubSlug, next.slug)}
           style={{
             color: "var(--wiki-accent)",
             textDecoration: "none",

--- a/apps/negentropy-wiki/src/components/WikiSidebar.tsx
+++ b/apps/negentropy-wiki/src/components/WikiSidebar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { WikiNavTree } from "./WikiNavTree";
-import type { WikiNavTreeItem } from "@/lib/wiki-api";
+import { entryHref, type WikiNavTreeItem } from "@/lib/wiki-api";
 
 /**
  * Wiki 侧边栏 — 统一 Publication 首页与文档详情页的左栏渲染。
@@ -58,7 +58,7 @@ export function WikiSidebar({
           {catalogName ? (
             catalogTargetSlug ? (
               renderBrand(
-                `/${pubSlug}/${catalogTargetSlug}`,
+                entryHref(pubSlug, catalogTargetSlug),
                 catalogName,
                 "wiki-sidebar-brand",
               )
@@ -91,7 +91,7 @@ export function WikiSidebar({
       )}
       {!isEntryPage && indexEntry && (
         <Link
-          href={`/${pubSlug}/${indexEntry.entry_slug}`}
+          href={entryHref(pubSlug, indexEntry.entry_slug)}
           className="wiki-nav-link active"
         >
           🏠 首页

--- a/apps/negentropy-wiki/src/lib/wiki-api.ts
+++ b/apps/negentropy-wiki/src/lib/wiki-api.ts
@@ -12,6 +12,54 @@
  */
 
 // ---------------------------------------------------------------------------
+// 内链 href 规范化（单一事实源）
+//
+// `next.config.ts` 设 `trailingSlash: true`，静态导出为每个路由产出目录式 HTML
+// （`/pub/entry/` → `out/pub/entry/index.html`）。故全站内链须统一带尾斜杠，
+// 方能在 nginx / static-web-server / GitHub Pages 等任意静态托管下稳定命中目录 index
+// （无尾斜杠的目录型 URL 在部分 nginx 配置——如 SPA fallback 或缺 `$uri/`——下会 404）。
+// 所有内链 href 须经此处的 helper 构造，杜绝散落的 `` `/${...}` `` 内联拼装漂移。
+// ---------------------------------------------------------------------------
+
+/**
+ * 为站内绝对路径补尾斜杠；外部 URL、同页 hash、根路径原样返回。
+ *
+ * - 空 / `http(s)://` / `#` 开头 → 原样（外部链接 / 同页锚点，非路由）；
+ * - 根 `/` → 原样（避免产出 `//`，顺带保护 `/#anchor`、`/?q`）；
+ * - 其余站内路径 → 保证以 `/` 结尾（幂等），并把 query / hash 移到尾斜杠之后。
+ */
+export function ensureTrailingSlash(path: string): string {
+  if (!path) return path;
+  if (/^https?:\/\//i.test(path)) return path;
+  if (path.startsWith("#")) return path;
+  // 仅对核心路径补斜杠，query / hash 原样后置
+  const queryIdx = path.indexOf("?");
+  const hashIdx = path.indexOf("#");
+  let end = path.length;
+  if (queryIdx !== -1) end = Math.min(end, queryIdx);
+  if (hashIdx !== -1) end = Math.min(end, hashIdx);
+  const core = path.slice(0, end);
+  if (core === "/" || core === "") return path;
+  const suffix = path.slice(end);
+  return core.endsWith("/") ? path : `${core}/${suffix}`;
+}
+
+/** entry 文档页 href：`/{pubSlug}/{entrySlug}/`（entrySlug 可含 Materialized Path `/`）。 */
+export function entryHref(pubSlug: string, entrySlug: string): string {
+  return ensureTrailingSlash(`/${pubSlug}/${entrySlug}`);
+}
+
+/** publication 根页 href：`/{pubSlug}/`。 */
+export function pubHref(pubSlug: string): string {
+  return ensureTrailingSlash(`/${pubSlug}`);
+}
+
+/** 知识图谱页 href：`/{pubSlug}/graph/`。 */
+export function graphHref(pubSlug: string): string {
+  return ensureTrailingSlash(`/${pubSlug}/graph`);
+}
+
+// ---------------------------------------------------------------------------
 // 保留一级目录「Negentropy」（来自仓库 docs/，由后端导出器合成进内容包）
 //
 // 单一事实源：slug / 首页 / 标签文案集中于此，供 Header 左侧保留标签与首页卡片
@@ -25,8 +73,8 @@ export const RESERVED_DOCS_SLUG = "negentropy";
 /** 保留 docs 一级目录首页 entry slug（docs/README.md → "readme"）。 */
 export const RESERVED_DOCS_INDEX_SLUG = "readme";
 
-/** 保留一级目录首页 href（Header 左侧标签 / 首页卡片跳转目标）。 */
-export const RESERVED_DOCS_HOME = `/${RESERVED_DOCS_SLUG}/${RESERVED_DOCS_INDEX_SLUG}`;
+/** 保留一级目录首页 href（Header 左侧标签 / 首页卡片跳转目标，目录式带尾斜杠）。 */
+export const RESERVED_DOCS_HOME = entryHref(RESERVED_DOCS_SLUG, RESERVED_DOCS_INDEX_SLUG);
 
 /** 保留一级目录的头部标签文案。 */
 export const RESERVED_DOCS_LABEL = "Negentropy";

--- a/apps/negentropy-wiki/tests/lib/wiki-href.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-href.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { ensureTrailingSlash, entryHref, graphHref, pubHref } from "@/lib/wiki-api";
+
+// 内链 href 规范化（单一事实源）：`trailingSlash: true` 静态导出产出目录式 HTML，
+// 全站内链须经 helper 带尾斜杠，方能在 nginx / static-web-server / Pages 下稳定命中。
+describe("ensureTrailingSlash", () => {
+  it("站内绝对路径补尾斜杠；已带斜杠幂等", () => {
+    expect(ensureTrailingSlash("/negentropy/readme")).toBe("/negentropy/readme/");
+    expect(ensureTrailingSlash("/foo/bar")).toBe("/foo/bar/");
+    expect(ensureTrailingSlash("/foo/")).toBe("/foo/");
+  });
+
+  it("根路径不产出双斜杠，顺带保护根级 hash/query", () => {
+    expect(ensureTrailingSlash("/")).toBe("/");
+    expect(ensureTrailingSlash("/#anchor")).toBe("/#anchor");
+    expect(ensureTrailingSlash("/?q=1")).toBe("/?q=1");
+  });
+
+  it("外部 URL 与同页 hash 原样返回（非路由）", () => {
+    expect(ensureTrailingSlash("https://example.com/y")).toBe("https://example.com/y");
+    expect(ensureTrailingSlash("http://example.com")).toBe("http://example.com");
+    expect(ensureTrailingSlash("#anchor")).toBe("#anchor");
+  });
+
+  it("query / hash 后置于尾斜杠之后", () => {
+    expect(ensureTrailingSlash("/foo?q=1")).toBe("/foo/?q=1");
+    expect(ensureTrailingSlash("/foo#x")).toBe("/foo/#x");
+    expect(ensureTrailingSlash("/foo?q=1#x")).toBe("/foo/?q=1#x");
+  });
+
+  it("Materialized Path 形 entry slug（含 /）正常补尾斜杠", () => {
+    expect(ensureTrailingSlash("/wiki/harness-engineering/getting-started")).toBe(
+      "/wiki/harness-engineering/getting-started/",
+    );
+  });
+
+  it("空串原样返回", () => {
+    expect(ensureTrailingSlash("")).toBe("");
+  });
+});
+
+describe("链接构建器（entryHref / pubHref / graphHref）", () => {
+  it("产出规范尾斜杠路径", () => {
+    expect(entryHref("negentropy", "readme")).toBe("/negentropy/readme/");
+    expect(entryHref("wiki", "harness-engineering/getting-started")).toBe(
+      "/wiki/harness-engineering/getting-started/",
+    );
+    expect(pubHref("wiki")).toBe("/wiki/");
+    expect(graphHref("wiki")).toBe("/wiki/graph/");
+  });
+});

--- a/apps/negentropy-wiki/tests/lib/wiki-reserved-docs.test.ts
+++ b/apps/negentropy-wiki/tests/lib/wiki-reserved-docs.test.ts
@@ -14,7 +14,7 @@ describe("保留 docs 目录常量与 isReservedDocsSlug", () => {
   it("常量取值与后端 reserved_slug 默认值对齐", () => {
     expect(RESERVED_DOCS_SLUG).toBe("negentropy");
     expect(RESERVED_DOCS_INDEX_SLUG).toBe("readme");
-    expect(RESERVED_DOCS_HOME).toBe("/negentropy/readme");
+    expect(RESERVED_DOCS_HOME).toBe("/negentropy/readme/");
     expect(RESERVED_DOCS_LABEL).toBe("Negentropy");
   });
 
@@ -59,6 +59,6 @@ describe("buildReservedDocsTab", () => {
   it("label/href 与 RESERVED_DOCS_* 常量族对齐（单一事实源）", () => {
     const tab = buildReservedDocsTab({ reservedExists: true, isReserved: true });
     expect(tab?.label).toBe(RESERVED_DOCS_LABEL);
-    expect(tab?.href).toBe(`/${RESERVED_DOCS_SLUG}/${RESERVED_DOCS_INDEX_SLUG}`);
+    expect(tab?.href).toBe(`/${RESERVED_DOCS_SLUG}/${RESERVED_DOCS_INDEX_SLUG}/`);
   });
 });

--- a/docs/reference/wiki/deployment.md
+++ b/docs/reference/wiki/deployment.md
@@ -121,10 +121,17 @@ server {
   listen 80;
   server_name wiki.example.com;
   root /var/www/negentropy-wiki/out;   # 指向 out/
+  index index.html;                    # 显式声明：使 $uri/ 能解析到目录 index.html
 
-  # 目录式 HTML：/pub/entry/ → /pub/entry/index.html
+  # 目录式 HTML：/pub/entry/ → /pub/entry/index.html。
+  # try_files 的 $uri/ 分支使「无尾斜杠」请求（如 /pub/entry）也能内部命中目录 index，
+  # 故无论链接是否带尾斜杠均可访问（静态导出不产出 .html，无需 $uri.html）。
   location / {
-    try_files $uri $uri/ $uri.html =404;
+    try_files $uri $uri/ =404;
+
+    # 可选 SEO 规范化：把无尾斜杠的目录型 URL 301 到尾斜杠（单一规范 URL）。
+    # 启用后上述 try_files 的无尾斜杠兜底可移除。
+    # rewrite ^([^.]*[^/])$ $1/ permanent;
   }
 
   # pagefind 搜索索引（随 out/ 一起部署）
@@ -422,7 +429,7 @@ curl -s http://localhost:8080/            # 200 + 含真实文章
 
 ### 5.3 其他
 
-- **端口/反代 404**：`trailingSlash:true` 生成目录式 HTML（`/pub/entry/`），静态层 `try_files $uri $uri/ $uri.html` 即可，无需 SPA fallback。
+- **端口/反代 404**：`trailingSlash:true` 生成目录式 HTML（`/pub/entry/`），静态层 `try_files $uri $uri/ =404` + `index index.html` 即可，无尾斜杠请求亦能命中目录 index，无需 SPA fallback。
 - **图片不显示**：markdown 图片重写为主站资产端点 `/knowledge/wiki/documents/{doc}/assets/{file}`（PostgreSQL bytea 流式提供，#935）。wiki 与主站**分域部署**时须配置 `NE_KNOWLEDGE_WIKI_EXPORT__ASSET_BASE_URL` 为主站可达前缀并确保网络可达；同源反代可省略。
 - **导出报 `artifact_backend` 校验错**：用 `sync-wiki-content.sh`（已置 inmemory）或手动 `NE_SVC_ARTIFACT_BACKEND=inmemory`。
 


### PR DESCRIPTION
## 问题

经 nginx 托管 Wiki 时，点击首页 4 个模块（「Negentropy 用户手册」Hero CTA、「Negentropy」「Harness Engineering」「Sinestesia of Cognition」卡片）跳转到的 URL **不带尾斜杠**（如 `/negentropy/readme`、`/wiki/sinestesia-of-cognition`），在常见 nginx 配置（SPA fallback 或缺 `$uri/`）下无法命中目录 `index.html`，导致跳转失败。

## 根因

Wiki 为 Next.js 纯静态导出（`output: "export"` + `trailingSlash: true`），为每个路由产出**目录式 HTML**（`/pub/entry/` → `out/pub/entry/index.html`）。但全站约 25 处内链均以内联 `` `/${pubSlug}/${slug}` `` 拼装、**统一不带尾斜杠**，违反项目自身的 `trailingSlash: true` 契约。无尾斜杠时 nginx 行为随配置而变（易碎）；**带尾斜杠时，nginx 在几乎任意 sane 配置下都能稳定服务目录 `index.html`**。

## 方案（根因修复 + 服务端兜底，双层保障）

**① 前端单一事实源（SSOT）规范化** — `src/lib/wiki-api.ts`
- 新增 `ensureTrailingSlash(path)` + 三个语义化构建器 `entryHref` / `pubHref` / `graphHref`（均委托给 `ensureTrailingSlash`），根路径、外部 URL、同页 hash 原样返回。
- `RESERVED_DOCS_HOME` 经 `entryHref` 派生为 `/negentropy/readme/`（一处改动覆盖 Hero CTA、Negentropy 卡片、顶栏/移动端保留标签）。
- 迁移首页 4 模块及**全站**内链（顶栏 tab、侧栏、导航树、面包屑、翻页、三个动态页返回链接/graph 链接）到 helper，统一带尾斜杠，对所有托管平台（nginx/Docker/Pages/CDN）稳健，不依赖特定服务器配置。

**② nginx 部署文档加固** — `docs/reference/wiki/deployment.md`
- `try_files $uri $uri.html =404` → `try_files $uri $uri/ =404`（静态导出不产出 `.html`，`$uri/` 才是无尾斜杠请求命中目录 index 的关键）。
- 显式补 `index index.html;`，使无尾斜杠请求（书签/外链）亦能 200；附可选 `rewrite ... permanent;` SEO 规范化注释。

> 激活态高亮基于 **slug 相等**（非 `pathname === href`），已核实补尾斜杠不破坏顶栏/侧栏高亮。

## 验证（循证）

- **单测**：`pnpm --filter negentropy-wiki test` → 104 passed（含新增 `wiki-href.test.ts` 边界测试 + 更新的 `wiki-reserved-docs.test.ts`），耗时 ~12s。
- **Lint**：`next lint` 0 errors（8 个 warning 均为既有项，与本次无关）。
- **构建**：`pnpm --filter negentropy-wiki build` 成功，产物为目录式 HTML（`out/negentropy/readme/index.html` 等）。
- **产物 href**：grep 渲染 HTML 确认全站 React 内链已带尾斜杠（`/negentropy/readme/`、`/wiki/sinestesia-of-cognition/` 等）。
- **nginx 场景（决定性）**：以忠实复刻 nginx `try_files $uri $uri/ =404` + `index index.html` 语义的静态服务对 `out/` 实测——4 个首页模块目标在**带/不带尾斜杠两种形式下均 200**且内容正确，`/notexist` 正确 404。

## 备注

- `content.fixture/` 中一处开发用 fixture markdown 残留硬编码无尾斜杠链接（非 React 渲染、非生产内容，生产内容由 DB 导出），由 nginx 服务端兜底覆盖，不在本次代码迁移范围内。