### PR TITLE
fix(Wiki): 修复「原文链接」错误指向 main 分支导致 404

### DIFF
--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000001.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000001.json
@@ -7,6 +7,6 @@
   "document_filename": "README.md",
   "author_name": null,
   "author_url": null,
-  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/README.md",
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/master/docs/README.md",
   "published_at": null
 }

--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000003.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000003.json
@@ -7,6 +7,6 @@
   "document_filename": "overview.md",
   "author_name": null,
   "author_url": null,
-  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/concepts/user-guide/overview.md",
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/master/docs/concepts/user-guide/overview.md",
   "published_at": null
 }

--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000007.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000007.json
@@ -7,6 +7,6 @@
   "document_filename": "overview.md",
   "author_name": null,
   "author_url": null,
-  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/research/overview.md",
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/master/docs/research/overview.md",
   "published_at": null
 }

--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000009.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000009.json
@@ -7,6 +7,6 @@
   "document_filename": "skills-advanced.md",
   "author_name": null,
   "author_url": null,
-  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/concepts/user-guide/skills-advanced.md",
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/master/docs/concepts/user-guide/skills-advanced.md",
   "published_at": null
 }

--- a/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000011.json
+++ b/apps/negentropy-wiki/content.fixture/entries/d0c00000-0000-4000-8000-000000000011.json
@@ -7,6 +7,6 @@
   "document_filename": "readme.md",
   "author_name": null,
   "author_url": null,
-  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/main/docs/reference/cognizes/README.md",
+  "source_url": "https://github.com/ThreeFish-AI/negentropy/blob/master/docs/reference/cognizes/README.md",
   "published_at": null
 }

--- a/apps/negentropy/src/negentropy/config/knowledge.py
+++ b/apps/negentropy/src/negentropy/config/knowledge.py
@@ -216,7 +216,7 @@ class WikiDocsSyncSettings(BaseModel):
         description="源码/仓库链接重写目标 repo（GitHub blob URL）。",
     )
     github_ref: str = Field(
-        default="main",
+        default="master",
         description="GitHub blob 链接的 ref（分支/标签/SHA）；CI 可经 env 覆盖为 commit SHA 得永久链接。",
     )
     github_docs_prefix: str = Field(

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_docs_ingest.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_docs_ingest.py
@@ -193,12 +193,12 @@ def test_rewrite_links_table():
         "[f](../../../concepts/framework.md)": "/negentropy/concepts/framework",
         # 过度 ../ 的源码路径 → 钳制为仓库根 → GitHub blob
         "[src](../../../../apps/negentropy/src/x.py)": (
-            "https://github.com/ThreeFish-AI/negentropy/blob/main/apps/negentropy/src/x.py"
+            "https://github.com/ThreeFish-AI/negentropy/blob/master/apps/negentropy/src/x.py"
         ),
         # docs 内但未纳入子集（.agents）→ GitHub blob
-        "[i](../.agents/issue.md)": ("https://github.com/ThreeFish-AI/negentropy/blob/main/docs/.agents/issue.md"),
+        "[i](../.agents/issue.md)": ("https://github.com/ThreeFish-AI/negentropy/blob/master/docs/.agents/issue.md"),
         # 图片 → GitHub raw
-        "![img](../assets/a.png)": "https://raw.githubusercontent.com/ThreeFish-AI/negentropy/main/docs/assets/a.png",
+        "![img](../assets/a.png)": "https://raw.githubusercontent.com/ThreeFish-AI/negentropy/master/docs/assets/a.png",
     }
     for src, expected_url in cases.items():
         out = rewrite_doc_links(src, current_rel_path=cur, included_slugs=included, cfg=cfg)
@@ -207,7 +207,7 @@ def test_rewrite_links_table():
     # 嵌套 [] 的链接文案（Next.js 动态段）仍被匹配重写
     nested = "[`app/[id]/route.ts`](../../../../apps/x/app/[id]/route.ts)"
     out = rewrite_doc_links(nested, current_rel_path=cur, included_slugs=included, cfg=cfg)
-    assert "github.com/ThreeFish-AI/negentropy/blob/main/apps/x/app/[id]/route.ts" in out
+    assert "github.com/ThreeFish-AI/negentropy/blob/master/apps/x/app/[id]/route.ts" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

生产 wiki 页面（如 https://threefish-ai.github.io/negentropy/concepts/035-the-knowledge-base/ ）每篇文章底部的「原文链接」（以及正文里被重写的源码/图片链接）会跳转到 GitHub 仓库 \`ThreeFish-AI/negentropy\` 的 **\`main\`** 分支，但该仓库默认分支是 **\`master\`**，导致链接全部 404 打不开。

## 根因（单一事实源）

\`apps/negentropy/src/negentropy/config/knowledge.py\` 中 \`WikiDocsSyncSettings.github_ref\` 默认值硬编码为 \`main\`，与仓库默认分支 \`master\` 不一致（同文件 \`WikiPagesPublishSettings.branch\` 默认值反而已是 \`master\`，自相矛盾）。

所有源码链接 URL 均由该字段经 \`wiki_docs_ingest\` 的 \`_github_blob\` / \`_github_raw\` / \`_doc_source_url\` 三个函数拼接而来，env / docker 均无显式覆盖，故**改默认值即根治**，无需改动这些函数（它们已正确引用 \`cfg.github_ref\`）。

```
knowledge.py github_ref="master"
  → wiki_docs_ingest._doc_source_url() 拼出 blob/master/...
  → export_wiki_content.py 写入 entries/*.json 的 source_url
  → Next.js page.tsx 读取 source_url 传给 WikiArticleMeta
  → 渲染为「原文链接」<a href>
```

## 改动清单（7 文件，10 增 10 删）

1. **根因（1 处）**：\`knowledge.py\` \`github_ref\` 默认值 \`main\` → \`master\`
2. **Fixture 种子数据（5 文件）**：\`content.fixture/entries/d0c00000-*.json\` 的 \`source_url\` 中 \`blob/main\` → \`blob/master\`（构建兜底/CI 冒烟用）
3. **测试断言（4 行）**：\`test_wiki_docs_ingest.py\` 链接重写用例期望值 \`main\` → \`master\`

## 明确不改（避免误伤）

- **外部第三方仓库**（ragflow / dify / FastGPT / google/adk-python / BettaFish / langfuse / docling / litellm 等）的 \`blob/main\` 均为正常引用，保持不动。
- 仓库首页无分支链接（\`WikiHeaderActions.tsx\`、\`footer-links.ts\`）会自动重定向到默认分支 master，无需改。

## 验证

- ✅ \`grep\` 确认本仓库 \`main\` 分支引用残留 **0 行**（外部仓库引用保留）
- ✅ \`test_rewrite_links_table\` 单测通过（确认链接重写输出 master，\`knowledge.py\` 导入正常）
- ✅ 5 个 fixture JSON 有效，\`source_url\` 全部为 \`blob/master\`

## 上线生效（后续单独执行）

代码合入后，线上链接需在**重新导出内容**时才烤入 \`master\`：部署/重启引擎（运行中引擎从主仓启动）后，由后端 publish 自动 spawn \`publish-wiki-pages.sh\`（导出 → next build → 推 out/ 到 Pages 仓库 master 分支），GitHub Pages 数十秒内更新。此为对外发布动作，需确认后单独执行。