### PR TITLE
pref(Memory): 优化 Overview 后端检索，合并串行查询并新增 app_name 索引

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/env.py
+++ b/apps/negentropy/src/negentropy/db/migrations/env.py
@@ -86,6 +86,7 @@ _IGNORED_INDEXES = frozenset(
         "idx_consolidation_jobs_status",  # consolidation_jobs 索引由迁移 0044 持有
         "idx_consolidation_jobs_thread",  # 同上
         "idx_consolidation_jobs_pending",  # 部分索引 (WHERE status = 'pending')，同上
+        "ix_kg_entities_app_active",  # 部分索引 (WHERE is_active)，由迁移 0073 持有
     }
 )
 

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0073_memory_dashboard_indexes.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0073_memory_dashboard_indexes.py
@@ -1,0 +1,78 @@
+"""Memory Overview Dashboard 查询加速索引 (app_name 前导复合 / 部分索引)
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-06-26 00:00:00.000000+00:00
+
+设计动机 (Index as the scale lever):
+  Memory Overview 的 dashboard / metrics / health 端点
+  (engine/api.py `/dashboard`、engine/observability/memory_metrics.py)
+  反复以 `app_name`(可选 + `user_id`) 对下列表做聚合扫描，EXPLAIN ANALYZE
+  确认全部为 Seq Scan：
+    memories              — 每行携带 Vector(1536)≈6KB，Seq Scan 把 embedding 拖过 I/O
+    facts                 — 现有 unique 以 user_id 前导，无法服务 app_name-only
+    kg_entities           — WHERE app_name=? AND is_active IS TRUE (无 app_name 索引)
+    memory_audit_logs     — app_name + created_at>=24h 窗口 (unique 第二列是 user_id)
+    memory_retrieval_logs — app_name + created_at (现索引以 user_id 前导)
+
+前导列法则 (leading-column rule):
+  复合 (app_name, user_id) 经前导列同时服务 app_name-only 与 app_name+user_id，
+  故无需另建 app_name 单列索引 (避免冗余 / 写放大)。现有以 user_id / corpus_id
+  前导的索引对 app-scoped 谓词无效，这是新建索引的根因。
+
+为何不加 covering / INCLUDE:
+  index-only scan 需 visibility map 全可见；memories 写频高 (retention /
+  importance 常更新)，页面少全可见 → 退回堆访问。主要收益 (整表 6KB Seq Scan →
+  app 维度索引扫描) 已被普通 b-tree 捕获，INCLUDE 仅省去 app 子集上的少量堆
+  访问而膨胀索引，当前不值得。
+
+迁移安全 (CONCURRENTLY):
+  Alembic 默认在事务内运行 (env.py begin_transaction)；CREATE INDEX
+  CONCURRENTLY 不能在事务内执行。沿用 0010 的 ``autocommit_block`` 跳出事务，
+  配合 0029 的 ``IF NOT EXISTS`` 幂等守卫，使大表建索引不阻塞写入且可重入
+  (CONCURRENTLY 失败会留下 INVALID 索引，IF NOT EXISTS + 重跑可恢复)。
+  ``autocommit_block`` 内语句不随后续失败回滚，但本迁移仅建索引且各自
+  ``IF NOT EXISTS``，可安全重跑。
+
+参考文献:
+  [1] PostgreSQL Documentation, "Building Indexes Concurrently",
+      "Partial Indexes", "Index-Only Scans and Covering Indexes".
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0073"
+down_revision: str | None = "0072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+# (索引名, 建索引 ON 子句)。CONCURRENTLY + IF NOT EXISTS 在 autocommit_block 内执行。
+_INDEXES: list[tuple[str, str]] = [
+    ("ix_memories_app_user", f"ON {SCHEMA}.memories (app_name, user_id)"),
+    ("ix_facts_app_user", f"ON {SCHEMA}.facts (app_name, user_id)"),
+    # 谓词须与 memory_metrics.py 查询的 `is_active IS TRUE` 逐字匹配：PG 的部分索引
+    # 谓词证明器不会把 `is_active IS TRUE`(BooleanTest) 蕴含为裸布尔 `is_active`，
+    # 用 `WHERE is_active` 会导致该查询无法命中索引（已实测验证）。
+    ("ix_kg_entities_app_active", f"ON {SCHEMA}.kg_entities (app_name) WHERE is_active IS TRUE"),
+    ("ix_memory_audit_logs_app_created", f"ON {SCHEMA}.memory_audit_logs (app_name, created_at)"),
+    ("ix_memory_retrieval_logs_app_created", f"ON {SCHEMA}.memory_retrieval_logs (app_name, created_at)"),
+]
+
+
+def upgrade() -> None:
+    # CONCURRENTLY 必须在事务外执行（autocommit_block），沿用 0010 模式。
+    with op.get_context().autocommit_block():
+        for name, suffix in _INDEXES:
+            op.execute(sa.text(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} {suffix}"))
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for name, _ in reversed(_INDEXES):
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {SCHEMA}.{name}"))

--- a/apps/negentropy/src/negentropy/engine/api.py
+++ b/apps/negentropy/src/negentropy/engine/api.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select, text, union
+from sqlalchemy import case, func, select, text, union
 
 from negentropy.auth.deps import get_current_user, get_optional_user, resolve_user_with_db_roles
 from negentropy.auth.service import AuthUser
@@ -250,70 +250,43 @@ async def get_memory_dashboard(
             audit_filters.append(MemoryAuditLog.user_id == user_id)
             fact_filters.append(Fact.user_id == user_id)
 
-        # 用户数
-        user_count = await db.scalar(select(func.count(func.distinct(Memory.user_id))).where(*memory_filters))
-
-        # 记忆总数
-        memory_count = await db.scalar(
-            select(func.count()).select_from(select(Memory).where(*memory_filters).subquery())
-        )
-
-        # Facts 数量
         now = datetime.now(UTC)
+
+        # memories 上 6 个聚合共享同一 memory_filters，合并为单条 select 单次往返
+        # （count/avg/sum(case)）。语义与原逐条 count/avg 等价：
+        # - memory_count: func.count() == 旧 count(subquery)
+        # - low/high: sum(case(...,1,else_=0)) == 旧 count(filtered subquery)（空集 NULL→0 由 `or 0` 兜底）
+        mem_stmt = select(
+            func.count(func.distinct(Memory.user_id)).label("user_count"),
+            func.count().label("memory_count"),
+            func.avg(Memory.retention_score).label("avg_retention"),
+            func.avg(Memory.importance_score).label("avg_importance"),
+            func.sum(case((Memory.retention_score < 0.1, 1), else_=0)).label("low_retention"),
+            func.sum(case((Memory.importance_score >= 0.7, 1), else_=0)).label("high_importance"),
+        ).where(*memory_filters)
+        mem_row = (await db.execute(mem_stmt)).one()
+
+        # Facts 数量（保留 valid_until 有效期过滤；去掉多余 subquery wrap）
         fact_count = await db.scalar(
-            select(func.count()).select_from(
-                select(Fact)
-                .where(
-                    *fact_filters,
-                    (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
-                )
-                .subquery()
-            )
-        )
-
-        # 平均 retention_score
-        avg_retention = await db.scalar(select(func.avg(Memory.retention_score)).where(*memory_filters))
-
-        # 平均 importance_score
-        avg_importance = await db.scalar(select(func.avg(Memory.importance_score)).where(*memory_filters))
-
-        # 低保留记忆数 (retention_score < 0.1)
-        low_retention_count = await db.scalar(
-            select(func.count()).select_from(
-                select(Memory)
-                .where(
-                    *memory_filters,
-                    Memory.retention_score < 0.1,
-                )
-                .subquery()
-            )
-        )
-
-        # 高重要性记忆数 (importance_score >= 0.7)
-        high_importance_count = await db.scalar(
-            select(func.count()).select_from(
-                select(Memory)
-                .where(
-                    *memory_filters,
-                    Memory.importance_score >= 0.7,
-                )
-                .subquery()
+            select(func.count())
+            .select_from(Fact)
+            .where(
+                *fact_filters,
+                (Fact.valid_until.is_(None)) | (Fact.valid_until > now),
             )
         )
 
         # 近期审计数
-        recent_audit_count = await db.scalar(
-            select(func.count()).select_from(select(MemoryAuditLog).where(*audit_filters).subquery())
-        )
+        recent_audit_count = await db.scalar(select(func.count()).select_from(MemoryAuditLog).where(*audit_filters))
 
     return MemoryDashboardResponse(
-        user_count=user_count or 0,
-        memory_count=memory_count or 0,
+        user_count=mem_row.user_count or 0,
+        memory_count=mem_row.memory_count or 0,
         fact_count=fact_count or 0,
-        avg_retention_score=round(float(avg_retention or 0), 4),
-        avg_importance_score=round(float(avg_importance or 0), 4),
-        low_retention_count=low_retention_count or 0,
-        high_importance_count=high_importance_count or 0,
+        avg_retention_score=round(float(mem_row.avg_retention or 0), 4),
+        avg_importance_score=round(float(mem_row.avg_importance or 0), 4),
+        low_retention_count=mem_row.low_retention or 0,
+        high_importance_count=mem_row.high_importance or 0,
         recent_audit_count=recent_audit_count or 0,
     )
 

--- a/apps/negentropy/src/negentropy/engine/observability/health_checker.py
+++ b/apps/negentropy/src/negentropy/engine/observability/health_checker.py
@@ -24,16 +24,42 @@ async def check_memory_health() -> dict[str, Any]:
     status = "healthy"
     checks: dict[str, Any] = {}
 
-    # 1. DB 连通性
+    # 1 & 3. DB 连通性 + 核心表行数合并到单 session（旧实现开两个独立 session）：
+    # 两个 inner try 保留失败粒度（「连通 OK 但计数失败」仍可区分）；外层 try 复现
+    # 旧行为——session/checkout 完全不可用时 db 与 tables 均标记 error 并降级。
     try:
         async with db_session.AsyncSessionLocal() as db:
-            await db.execute(sa.text("SELECT 1"))
-        checks["db"] = {"status": "ok"}
+            try:
+                await db.execute(sa.text("SELECT 1"))
+                checks["db"] = {"status": "ok"}
+            except Exception as exc:
+                checks["db"] = {"status": "error", "detail": str(exc)[:200]}
+                status = "degraded"
+
+            # 核心表行数（无过滤全表 count，用于快速诊断空表）：两个标量子查询
+            # 并入单次往返。
+            try:
+                from negentropy.models.internalization import Fact, Memory
+
+                counts_stmt = sa.select(
+                    sa.select(sa.func.count()).select_from(Memory).scalar_subquery().label("memories"),
+                    sa.select(sa.func.count()).select_from(Fact).scalar_subquery().label("facts"),
+                )
+                row = (await db.execute(counts_stmt)).one()
+                checks["tables"] = {
+                    "memories": row.memories or 0,
+                    "facts": row.facts or 0,
+                }
+            except Exception as exc:
+                await db.rollback()
+                checks["tables"] = {"status": "error", "detail": str(exc)[:200]}
+                status = "degraded"
     except Exception as exc:
-        checks["db"] = {"status": "error", "detail": str(exc)[:200]}
+        checks.setdefault("db", {"status": "error", "detail": str(exc)[:200]})
+        checks.setdefault("tables", {"status": "error", "detail": str(exc)[:200]})
         status = "degraded"
 
-    # 2. Feature flags
+    # 2. Feature flags（纯配置读，独立于 DB：即使 DB / 会话不可用也必采集，与旧行为一致）
     try:
         from negentropy.config import settings as global_settings
 
@@ -62,21 +88,6 @@ async def check_memory_health() -> dict[str, Any]:
             logger.warning("pii_engine_probe_failed", error=str(exc)[:200])
     except Exception as exc:
         checks["features"] = {"status": "error", "detail": str(exc)[:200]}
-        status = "degraded"
-
-    # 3. 核心表行数（用于快速诊断空表问题）
-    try:
-        async with db_session.AsyncSessionLocal() as db:
-            from negentropy.models.internalization import Fact, Memory
-
-            mem_count = (await db.execute(sa.select(sa.func.count()).select_from(Memory))).scalar() or 0
-            fact_count = (await db.execute(sa.select(sa.func.count()).select_from(Fact))).scalar() or 0
-            checks["tables"] = {
-                "memories": mem_count,
-                "facts": fact_count,
-            }
-    except Exception as exc:
-        checks["tables"] = {"status": "error", "detail": str(exc)[:200]}
         status = "degraded"
 
     return {"status": status, "checks": checks}

--- a/apps/negentropy/src/negentropy/engine/observability/memory_metrics.py
+++ b/apps/negentropy/src/negentropy/engine/observability/memory_metrics.py
@@ -37,20 +37,30 @@ async def get_memory_metrics(*, user_id: str | None = None, app_name: str = "neg
     window_24h = now - timedelta(hours=24)
 
     async with db_session.AsyncSessionLocal() as db:
-        # --- Retention 分布 ---
-        retention_stmt = sa.select(
+        # --- Retention 分布 + PII 检测率 ---
+        # 二者 WHERE 完全相同（app_name + 非 deleted + 可选 user_id），合并为单条
+        # memories 扫描：消除一次重复全表扫描。pii 的分母 total == retention total，
+        # 故 pii_detection_rate 逐字节不变。
+        mem_filters = [
+            Memory.app_name == app_name,
+            sa.func.coalesce(Memory.metadata_["deleted"].astext, "false") != "true",
+        ]
+        if user_id:
+            mem_filters.append(Memory.user_id == user_id)
+        mem_stmt = sa.select(
             sa.func.avg(Memory.retention_score).label("avg"),
             sa.func.percentile_cont(0.1).within_group(Memory.retention_score.asc()).label("p10"),
             sa.func.percentile_cont(0.9).within_group(Memory.retention_score.asc()).label("p90"),
             sa.func.count().label("total"),
             sa.func.sum(sa.case((Memory.retention_score < 0.1, 1), else_=0)).label("low_count"),
-        ).where(
-            Memory.app_name == app_name,
-            sa.func.coalesce(Memory.metadata_["deleted"].astext, "false") != "true",
-        )
-        if user_id:
-            retention_stmt = retention_stmt.where(Memory.user_id == user_id)
-        ret_row = (await db.execute(retention_stmt)).one()
+            sa.func.sum(
+                sa.case(
+                    (Memory.metadata_["pii_flags"].astext.isnot(None), 1),
+                    else_=0,
+                )
+            ).label("with_pii"),
+        ).where(*mem_filters)
+        ret_row = (await db.execute(mem_stmt)).one()
 
         # --- 搜索指标（24h） ---
         search_stmt = sa.select(
@@ -80,22 +90,7 @@ async def get_memory_metrics(*, user_id: str | None = None, app_name: str = "neg
             audit_stmt = audit_stmt.where(MemoryAuditLog.user_id == user_id)
         audit_row = (await db.execute(audit_stmt)).one()
 
-        # --- PII 检测率 ---
-        pii_stmt = sa.select(
-            sa.func.count().label("total"),
-            sa.func.sum(
-                sa.case(
-                    (Memory.metadata_["pii_flags"].astext.isnot(None), 1),
-                    else_=0,
-                )
-            ).label("with_pii"),
-        ).where(
-            Memory.app_name == app_name,
-            sa.func.coalesce(Memory.metadata_["deleted"].astext, "false") != "true",
-        )
-        if user_id:
-            pii_stmt = pii_stmt.where(Memory.user_id == user_id)
-        pii_row = (await db.execute(pii_stmt)).one()
+        # PII 检测率已并入上方 mem_stmt（ret_row.with_pii / total），无需独立扫描。
 
         # --- Facts & Associations ---
         fact_count = (
@@ -132,8 +127,9 @@ async def get_memory_metrics(*, user_id: str | None = None, app_name: str = "neg
     with_feedback = search_row.with_feedback_24h or 0
     helpful = search_row.helpful_24h or 0
     audit_total = audit_row.total_24h or 0
-    pii_total = pii_row.total or 0
-    pii_with = pii_row.with_pii or 0
+    # pii 与 retention 同一 WHERE，分母 total 等价，直接复用合并行
+    pii_total = ret_row.total or 0
+    pii_with = ret_row.with_pii or 0
 
     return {
         # 搜索指标

--- a/apps/negentropy/src/negentropy/models/internalization.py
+++ b/apps/negentropy/src/negentropy/models/internalization.py
@@ -5,7 +5,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import UUID as SA_UUID
-from sqlalchemy import Float, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
@@ -38,6 +38,13 @@ class Memory(Base, UUIDMixin, TimestampMixin):
     # Relationships? Memory usually stands alone or links to thread.
     # The schema references threads(id).
 
+    __table_args__ = (
+        # Overview dashboard / metrics 以 app_name(+user_id) 聚合扫描，前导复合索引
+        # 同时服务 app_name-only 与 app_name+user_id（migration 0073）。
+        Index("ix_memories_app_user", "app_name", "user_id"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
 
 class Fact(Base, UUIDMixin, TimestampMixin):
     __tablename__ = "facts"
@@ -63,6 +70,8 @@ class Fact(Base, UUIDMixin, TimestampMixin):
 
     __table_args__ = (
         UniqueConstraint("user_id", "app_name", "fact_type", "key", name="facts_user_key_unique"),
+        # 现有 unique 以 user_id 前导，无法服务 app_name-only 聚合；补复合索引（migration 0073）。
+        Index("ix_facts_app_user", "app_name", "user_id"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 
@@ -99,6 +108,9 @@ class MemoryAuditLog(Base, UUIDMixin, TimestampMixin):
         UniqueConstraint(
             "app_name", "user_id", "memory_id", "idempotency_key", name="memory_audit_logs_idempotency_unique"
         ),
+        # metrics 以 app_name + created_at>=24h 窗口聚合；unique 第二列是 user_id 无法服务
+        # created_at 范围（migration 0073）。
+        Index("ix_memory_audit_logs_app_created", "app_name", "created_at"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 
@@ -155,7 +167,12 @@ class MemoryRetrievalLog(Base, UUIDMixin):
     outcome_feedback: Mapped[str | None] = mapped_column(String(50))
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP, server_default=func.now(), nullable=False)
 
-    __table_args__ = ({"schema": NEGENTROPY_SCHEMA},)
+    __table_args__ = (
+        # metrics 以 app_name + created_at 聚合；现有 ix_memory_retrieval_logs_user_app
+        # 以 user_id 前导，无法服务 app-scoped 查询（migration 0073）。
+        Index("ix_memory_retrieval_logs_app_created", "app_name", "created_at"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
 
 
 class MemoryConflict(Base, UUIDMixin, TimestampMixin):

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -3307,3 +3307,21 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
   3. **验证**：`build_docs_pack` 真实导出 nav-tree 逐级核验 + `pnpm build` 127 页 + 浏览器实机（侧栏顺序正确、frontmatter 不泄漏、标题取 frontmatter title）。
 - **后续防范**：① 新写文档 frontmatter 必须是**合法 YAML**——值含冒号/特殊字符须加引号，否则 `sidebar_position` 会被静默忽略（ingest 仅 WARN 不中断）；② 任何「消费 markdown frontmatter」的链路（渲染/搜索索引/链接重写）都须**先剥离围栏**再处理正文，禁止把 frontmatter 当正文传递；③ 排序位次变更用**小数中点插入**避免重排整段；DB 出版物路径（`entry_position`）与 docs 路径（`sidebar_position`/`_category_.json`）正交，互不影响。
 - **同类问题影响**：仓内其他「文件 → 站点」合成链路若引入 frontmatter 元数据，须复用本 PR 的 `_parse_frontmatter` 惯例（`isinstance(dict)` 守卫 + 失败回退原文 + 剥离不回填）。
+
+---
+
+## ISSUE-148 Memory Overview 后端检索串行 N+1 + 缺索引全表扫描
+
+- **表因**：首次加载 `/memory/overview` 各模块数据加载慢（用户感知 >5s）。页面一次性并行拉取 `/api/memory/dashboard`、`/api/memory/health`、`/api/memory/metrics`（admin）三端点（无轮询），经 Next.js BFF 代理到后端 `engine/api.py`。
+- **根因**（两层；循证：EXPLAIN ANALYZE + 实测）：
+  1. **首屏 >5s 的直接主因是 dev-only**：本机 UI 为 `next dev --webpack`，首次访问触发 webpack 按需编译路由/bundle；后端三端点实测直连 `:3292` 仅 ~20–46ms、BFF ~40ms（dev DB 极小：memories=1/facts=47/audit=11）。非后端检索瓶颈。
+  2. **但后端确有随规模放大的真实低效**（本 PR 目标）：① 串行 N+1——`/dashboard` 串行 8 次 `db.scalar()`（6 次打 memories 同一过滤）、`/health` 开 2 个独立 session、`/metrics` 7 次含 2 次相同 WHERE 重复全扫 memories；② 缺索引——`memories`/`facts`/`memory_audit_logs`/`kg_entities` 对 `app_name`(+`user_id`) 聚合全部 Seq Scan，且 `memories` 每行携带 `Vector(1536)`≈6KB，Seq Scan 把 embedding 拖过 I/O。
+- **处理方式**（本次 PR，纯查询合并 + 索引，逐字节契约不变，**不引入缓存/不引入 asyncio.gather**）：
+  1. **dashboard**（`engine/api.py`）：6 个 memories 聚合合并为单条 `select(count/avg/sum(case))`，fact/audit 各 1 条 → 8 往返降为 3。`func.count()`≡旧 `count(subquery)`、`sum(case(...,1,else_=0))`≡旧 `count(filtered subquery)`（空集 NULL→0 由 `or 0` 兜底）。
+  2. **metrics**（`memory_metrics.py`）：`retention_stmt`+`pii_stmt` WHERE 完全相同 → 合并单条，`pii_total` 复用合并行 `total`（分母等价，`pii_detection_rate` 逐字节不变）；消除一次 memories 全扫。
+  3. **health**（`health_checker.py`）：2 session→1；两个无过滤 count 用双标量子查询并入单往返；保留 `SELECT 1` 探针；双 inner try + 外层 try **保留失败粒度**（「连通 OK 但计数失败」/「会话完全不可用 db+tables 均 error」）。
+  4. **索引迁移 0073** + ORM `__table_args__` 同步：`ix_memories_app_user(app_name,user_id)`、`ix_facts_app_user`、`ix_kg_entities_app_active(app_name) WHERE is_active IS TRUE`、`ix_memory_audit_logs_app_created(app_name,created_at)`、`ix_memory_retrieval_logs_app_created`。CONCURRENTLY + `autocommit_block`（沿用 0010）+ `IF NOT EXISTS`（沿用 0029），可重入；kg 部分索引入 `env.py _IGNORED_INDEXES`（沿用仓库部分索引惯例）。
+- **关键坑（务必复用经验）**：PG **部分索引谓词证明器不会把 `is_active IS TRUE`（BooleanTest）蕴含为裸布尔 `is_active`**。最初写 `WHERE is_active` 建成的索引，对实际查询 `... AND is_active IS TRUE`（`memory_metrics.py`）**完全无法命中**（`SET enable_seqscan=off` 仍走 Seq Scan，cost 带 1e10 惩罚）。修正：部分索引谓词须与查询 `BooleanTest` 形态**逐字匹配**（改为 `WHERE is_active IS TRUE`），改后 Index Only Scan 命中。**前导列法则**同理：`(app_name,user_id)` 经前导列服务 `app_name`-only，故无需单列 `app_name` 索引；现有以 `user_id`/`corpus_id` 前导的索引对 app-scoped 查询无效。
+- **验证**：受控种子（独立 `app_name='__perf_verify__'`，覆盖 low_retention/high_importance 边界/deleted/pii/valid_until 各分支，验后清理）对比 NEW 合并查询 vs OLD 逐条查询——dashboard 三 user 维度全字段 MATCH；`dashboard.memory_count=5`(含 deleted) vs `metrics.memory_total=4`(排除 deleted)、`dashboard.fact_count=2`(过滤过期) vs `metrics.fact_count=3`(不过滤) 证差异化过滤器保留。956 engine 单测全过；alembic up/down 幂等；autogenerate 无漂移；ruff 通过。
+- **后续防范**：① 新建部分索引务必让谓词与查询布尔表达式 AST 形态一致（`IS TRUE` vs 裸布尔不互通），建索引后用 `SET enable_seqscan=off; EXPLAIN` 实测命中；② 多聚合同表同 WHERE 应合并为单条 `select(... sum(case))`（复用 `retrieval_tracker.py`/`scheduler_api.py` 惯例），勿逐条 `db.scalar`；③ 跨表计数因基数不同不能合并（笛卡尔积污染），按表拆条是下限；④ 区分「dev webpack 首屏编译慢」与「后端检索慢」——前者非后端范畴，勿误改后端；⑤ pool_size=5/max_overflow=10 下慎用 `asyncio.gather` 多 session（连接放大），优先单 session 多语句合并。
+- **同类问题影响**：knowledge 模块若新增 dashboard/metrics 聚合端点应复用本 PR 合并范式与 `(app_name,user_id)` 前导索引惯例；所有 `app_name`-scoped 聚合查询都应核查是否落到以 `user_id` 前导的既有索引（无效）。


### PR DESCRIPTION
# 背景
- **本次变更要解决的问题**：首次加载 `/memory/overview` 各模块数据加载偏慢。该页一次性并行拉取 `/api/memory/dashboard`、`/api/memory/health`、`/api/memory/metrics` 三端点，经 EXPLAIN ANALYZE + 实测诊断后定位后端两类随规模放大的低效：① 串行 N+1 查询；② 缺 `app_name` 索引导致全表 Seq Scan（`memories` 每行携带 `Vector(1536)`≈6KB，Seq Scan 把 embedding 拖过 I/O，是生产规模真正瓶颈）。
- **关联上下文/Issue/文档**：[ISSUE-148](docs/.agents/issue.md)（含 PG 部分索引谓词 `IS TRUE` vs 裸布尔不互通的关键坑）。诊断附记：本机首屏 >5s 的直接主因是 dev-only 的 `next dev --webpack` 按需编译，非后端检索；本 PR 聚焦后端真实低效，不降低任何功能特性。

# 核心变更
- **dashboard**（`engine/api.py`）：memories 上 6 个聚合合并为单条 `select(count/avg/sum(case))`，fact/audit 各 1 条 —— 8 次 `db.scalar` 往返降为 **3 次**。
- **metrics**（`memory_metrics.py`）：retention 与 pii 两条相同 WHERE 的 memories 查询合并为单条，pii 分母复用合并行 `total`，**消除一次 memories 全表扫描**。
- **health**（`health_checker.py`）：2 个独立 session 合并为 1，双 count 用标量子查询并入单次往返；保留 `SELECT 1` 探针与失败粒度。
- **索引迁移 0073** + ORM `__table_args__` 同步：新增 5 个 `app_name` 前导复合/部分索引（`ix_memories_app_user`、`ix_facts_app_user`、`ix_kg_entities_app_active WHERE is_active IS TRUE`、`ix_memory_audit_logs_app_created`、`ix_memory_retrieval_logs_app_created`），CONCURRENTLY + `autocommit_block` + `IF NOT EXISTS`，Seq Scan → Index Scan。
- 按用户决策：**不引入缓存、不引入 `asyncio.gather` 并发**，纯查询合并 + 索引；响应字段逐字节不变。

# 风险与回滚
- **主要风险**：查询合并的语义等价性（差异化过滤器：dashboard `fact_count` 过滤 `valid_until`、metrics 不过滤；metrics 过滤 `metadata.deleted`、dashboard 不过滤；health count 无过滤）；已逐条锁定并由等价性验证兜底。索引为纯增量，仅增写路径维护开销。
- **回滚方式**：三个 commit 独立可还原；迁移 `alembic downgrade -1`（已验证幂等对称）。

# 验证证据
- **单元测试**：956 个 engine 单测全过（含 `test_memory_observability.py` / `test_memory_api_authz.py`）。
- **集成测试**：受控种子数据（独立 `app_name`，覆盖 low_retention/high_importance 边界/deleted/pii/valid_until 各分支，验后清理）对比 NEW 合并查询 vs OLD 逐条查询，dashboard 三 user 维度**全字段 MATCH**；`memory_count=5`(含 deleted) vs `memory_total=4`(排除)、`fact_count=2`(过滤过期) vs `3`(不过滤) 证差异化过滤器保留。
- **E2E/Workflow**：alembic up/down 幂等验证；autogenerate 无 ORM 漂移。
- **覆盖率/关键截图**：`EXPLAIN (ANALYZE)` 证 `ix_memories_app_user` Bitmap Index Scan、`ix_kg_entities_app_active` Index Only Scan 命中；ruff lint+format 通过。

# 影响范围
- **前端**：无改动（响应契约逐字节不变，`MemoryPipelineDiagram`/`MemoryKpiStrip` 优雅降级不受影响）。
- **后端**：`engine/api.py`、`engine/observability/{memory_metrics,health_checker}.py`、`models/internalization.py`、迁移 `0073` + `migrations/env.py`。
- **GitHub Actions / 文档**：`docs/.agents/issue.md` 新增 ISSUE-148；无 CI 配置变更。

# Next Best Action
- 合并后在生产/预发执行 `alembic upgrade head` 应用 0073；建议在已具备规模数据的环境上用 `EXPLAIN (ANALYZE, BUFFERS)` 复测命中与 `shared read` 下降，作为规模化收益的最终佐证。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)