### PR TITLE
feat(Knowledge): 文档详情页 PDF 源文档新增「Markdown | PDF」原文预览切换

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -87,6 +87,16 @@ type ProxyOptions = {
    * 调用方按端点语义显式启用（仅 GET 推荐启用，POST 重试会触发副作用）。
    */
   retry?: RetryOptions;
+  /**
+   * 仅 `proxyGetBinary` 消费：把上游二进制响应的 `Content-Disposition` 强制为
+   * `inline`，使浏览器（`<object>`/`<iframe>`）内联渲染而非触发下载。默认
+   * `undefined` → 原样透传上游头部，行为不变（向后兼容）。
+   *
+   * 设计动机：后端 `/download` 端点固定回传 `attachment`（语义为「下载」），
+   * 但 PDF 源文档「预览」场景需要内联渲染。复用同一后端端点、仅在 BFF 层改写
+   * 响应头，避免后端为预览新增并行端点（单一事实源 + 最小干预）。
+   */
+  responseDisposition?: "inline";
 };
 
 /** 上游响应被视作 transient 的状态码集合 */
@@ -544,8 +554,29 @@ export async function proxyGetBinary(
   const contentDisposition = upstreamResponse.headers.get("content-disposition");
   const contentType = upstreamResponse.headers.get("content-type");
   const cacheControl = upstreamResponse.headers.get("cache-control");
-  if (contentDisposition) responseHeaders.set("content-disposition", contentDisposition);
-  if (contentType) responseHeaders.set("content-type", contentType);
+
+  if (options.responseDisposition === "inline") {
+    // 预览语义：把上游的 `attachment` 改写为 `inline`，保留 `filename*` 等参数，
+    // 让浏览器内联渲染 PDF 而非触发下载。上游缺失头部时也显式置 `inline`。
+    if (contentDisposition) {
+      responseHeaders.set(
+        "content-disposition",
+        contentDisposition.replace(/^\s*attachment/i, "inline"),
+      );
+    } else {
+      responseHeaders.set("content-disposition", "inline");
+    }
+    // 兜底：.pdf 文件但上游 MIME 缺失/为通用二进制时，回退为 application/pdf，
+    // 否则浏览器可能拒绝内联渲染。已知具体类型则原样透传。
+    if (!contentType || contentType === "application/octet-stream") {
+      responseHeaders.set("content-type", "application/pdf");
+    } else {
+      responseHeaders.set("content-type", contentType);
+    }
+  } else {
+    if (contentDisposition) responseHeaders.set("content-disposition", contentDisposition);
+    if (contentType) responseHeaders.set("content-type", contentType);
+  }
   if (cacheControl) responseHeaders.set("cache-control", cacheControl);
 
   return new NextResponse(upstreamResponse.body, {

--- a/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/preview/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/base/[corpusId]/documents/[documentId]/preview/route.ts
@@ -1,0 +1,22 @@
+import { proxyGetBinary } from "../../../../../_proxy";
+
+/**
+ * GET /api/knowledge/base/{corpusId}/documents/{documentId}/preview
+ *
+ * 内联预览文档原始文件（PDF 源文档「PDF 原文」视图）。
+ * 复用后端 `/download` 端点（同一份字节），仅在 BFF 层把 `Content-Disposition`
+ * 改写为 `inline`，使 `<object>`/`<iframe>` 能内联渲染而非触发下载。
+ */
+export async function GET(
+  request: Request,
+  context: {
+    params: Promise<{ corpusId: string; documentId: string }>;
+  },
+) {
+  const { corpusId, documentId } = await context.params;
+  return proxyGetBinary(
+    request,
+    `/knowledge/base/${corpusId}/documents/${documentId}/download`,
+    { responseDisposition: "inline" },
+  );
+}

--- a/apps/negentropy-ui/app/api/knowledge/documents/[documentId]/preview/route.ts
+++ b/apps/negentropy-ui/app/api/knowledge/documents/[documentId]/preview/route.ts
@@ -1,0 +1,20 @@
+import { proxyGetBinary } from "../../../_proxy";
+
+/**
+ * GET /api/knowledge/documents/{documentId}/preview
+ *
+ * 内联预览文档原始文件（库文档 / 跨 corpus 直达）。
+ * 与 corpus 作用域 preview 同构：复用后端 `/download` 字节，BFF 层改写
+ * `Content-Disposition` 为 `inline`，供 PDF 原文视图内联渲染。
+ */
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ documentId: string }> },
+) {
+  const { documentId } = await context.params;
+  return proxyGetBinary(
+    request,
+    `/knowledge/documents/${documentId}/download`,
+    { responseDisposition: "inline" },
+  );
+}

--- a/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
@@ -18,15 +18,18 @@ import type {
   KnowledgeDocumentDetail,
 } from "@/features/knowledge/utils/knowledge-api";
 import {
+  documentPreviewUrl,
   downloadDocument,
   effectiveDocumentName,
   fetchDocumentDetail,
+  isPdfDocument,
   LIBRARY_CORPUS_SEGMENT,
   refreshDocumentMarkdown,
   updateDocument,
 } from "@/features/knowledge/utils/knowledge-api";
 import { formatRelativeTime } from "@/features/knowledge/utils/pipeline-helpers";
 import { DocumentMarkdownRenderer } from "@/features/knowledge/components/DocumentMarkdownRenderer";
+import { DocumentPdfViewer } from "@/features/knowledge/components/DocumentPdfViewer";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
@@ -143,6 +146,8 @@ export default function DocumentDetailPage() {
   const [detailError, setDetailError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isRefreshingMarkdown, setIsRefreshingMarkdown] = useState(false);
+  // 文档预览模式：仅当源文档为 PDF 时才会出现「PDF」切换；默认 Markdown，保持现状。
+  const [viewMode, setViewMode] = useState<"markdown" | "pdf">("markdown");
 
   // Article Metadata editing state
   const [isEditingMeta, setIsEditingMeta] = useState(false);
@@ -282,6 +287,11 @@ export default function DocumentDetailPage() {
     detail?.markdown_extract_error,
   );
 
+  // 源文档是否为 PDF —— 决定是否展示「Markdown | PDF」切换。
+  const isPdf = detail ? isPdfDocument(detail) : false;
+  // 仅在 PDF 文档 + 选中 PDF 标签时渲染原文查看器；其余一律走 Markdown 分支。
+  const showPdf = isPdf && viewMode === "pdf";
+
   // ---- Render ----
 
   return (
@@ -305,7 +315,43 @@ export default function DocumentDetailPage() {
           Back to Documents
         </Link>
 
-        <div className="flex-1" />
+        {/* 顶部中栏：Markdown | PDF 切换（仅 PDF 源文档显示，居中于操作栏） */}
+        <div className="flex flex-1 justify-center">
+          {isPdf ? (
+            <div
+              role="tablist"
+              aria-label="Document view mode"
+              className="inline-flex items-center rounded-lg border border-border bg-muted p-0.5 text-xs font-semibold"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={viewMode === "markdown"}
+                onClick={() => setViewMode("markdown")}
+                className={`rounded-md px-3 py-1 transition-colors ${
+                  viewMode === "markdown"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-text-muted hover:text-foreground"
+                }`}
+              >
+                Markdown
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={viewMode === "pdf"}
+                onClick={() => setViewMode("pdf")}
+                className={`rounded-md px-3 py-1 transition-colors ${
+                  viewMode === "pdf"
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-text-muted hover:text-foreground"
+                }`}
+              >
+                PDF
+              </button>
+            </div>
+          ) : null}
+        </div>
 
         <button
           onClick={handleRefreshMarkdown}
@@ -548,41 +594,52 @@ export default function DocumentDetailPage() {
               )}
             </div>
 
-            {/* Markdown content card */}
+            {/* Content card: Markdown 解析视图 / PDF 原文视图（由顶部中栏切换） */}
             <div className="rounded-xl border border-border p-4">
               <div className="mb-3 flex items-center justify-between">
-                <h2 className="text-sm font-semibold text-foreground">Markdown Content</h2>
+                <h2 className="text-sm font-semibold text-foreground">
+                  {showPdf ? "PDF Source" : "Markdown Content"}
+                </h2>
                 <span className="text-xs text-text-muted">
-                  {detail.markdown_extracted_at ? `Updated ${formatRelativeTime(detail.markdown_extracted_at ?? undefined)}` : ""}
+                  {!showPdf && detail.markdown_extracted_at
+                    ? `Updated ${formatRelativeTime(detail.markdown_extracted_at ?? undefined)}`
+                    : ""}
                 </span>
               </div>
 
-              <div className="rounded-lg bg-muted p-4">
-                {loadingDetail ? (
-                  <p className="text-sm text-text-muted">Loading markdown content...</p>
-                ) : detailError ? (
-                  <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
-                ) : markdownStatus === "processing" || markdownStatus === "pending" ? (
-                  <p className="text-sm text-text-muted">
-                    Markdown extraction is running in background. This page will auto-refresh.
-                  </p>
-                ) : markdownStatus === "failed" ? (
-                  <p className="text-sm text-red-600 dark:text-red-400">
-                    {detail.markdown_extract_error || "Markdown extraction failed. You can re-ingest this source to retry."}
-                  </p>
-                ) : (detail.markdown_content || "").trim().length === 0 ? (
-                  <p className="text-sm text-amber-600 dark:text-amber-400">
-                    Markdown content is empty. Click <strong>Re-Parse</strong> to regenerate from the source document.
-                  </p>
-                ) : (
-                  <DocumentMarkdownRenderer
-                    content={detail.markdown_content || ""}
-                    corpusId={corpusId}
-                    documentId={documentId}
-                    appName={requestAppName}
-                  />
-                )}
-              </div>
+              {showPdf ? (
+                <DocumentPdfViewer
+                  src={documentPreviewUrl(corpusId, documentId, { appName: requestAppName })}
+                  filename={effectiveDocumentName(detail)}
+                />
+              ) : (
+                <div className="rounded-lg bg-muted p-4">
+                  {loadingDetail ? (
+                    <p className="text-sm text-text-muted">Loading markdown content...</p>
+                  ) : detailError ? (
+                    <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
+                  ) : markdownStatus === "processing" || markdownStatus === "pending" ? (
+                    <p className="text-sm text-text-muted">
+                      Markdown extraction is running in background. This page will auto-refresh.
+                    </p>
+                  ) : markdownStatus === "failed" ? (
+                    <p className="text-sm text-red-600 dark:text-red-400">
+                      {detail.markdown_extract_error || "Markdown extraction failed. You can re-ingest this source to retry."}
+                    </p>
+                  ) : (detail.markdown_content || "").trim().length === 0 ? (
+                    <p className="text-sm text-amber-600 dark:text-amber-400">
+                      Markdown content is empty. Click <strong>Re-Parse</strong> to regenerate from the source document.
+                    </p>
+                  ) : (
+                    <DocumentMarkdownRenderer
+                      content={detail.markdown_content || ""}
+                      corpusId={corpusId}
+                      documentId={documentId}
+                      appName={requestAppName}
+                    />
+                  )}
+                </div>
+              )}
             </div>
           </div>
         ) : null}

--- a/apps/negentropy-ui/features/knowledge/components/DocumentPdfViewer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentPdfViewer.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface DocumentPdfViewerProps {
+  /** 内联预览 URL（同源 BFF `/preview` 路由，自动携带 cookie 鉴权）。 */
+  src: string;
+  /** 源文件名，用于无障碍标题与兜底链接文案。 */
+  filename?: string;
+  className?: string;
+}
+
+/**
+ * PDF 原文查看器 —— 以原生浏览器 PDF 查看器内联渲染源 PDF 文档。
+ *
+ * 采用业界「最大兼容」组合：`<object>`（主）内嵌 `<iframe>`（兜底），渲染时走
+ * 浏览器/OS 自带查看器（缩放、搜索、打印、翻页、文本选择、CJK 字体均开箱即用），
+ * 无需引入 pdf.js / worker / cMaps（熵减 + 最小干预）。顶部始终提供「在新标签打开」
+ * 链接作为无障碍逃生通道与终极兜底。
+ *
+ * src 指向同源 BFF `/preview` 路由，浏览器以 `Content-Type: application/pdf` +
+ * `Content-Disposition: inline` 内联渲染；同源子请求自动携带 cookie 完成鉴权。
+ */
+export function DocumentPdfViewer({
+  src,
+  filename,
+  className,
+}: DocumentPdfViewerProps) {
+  const title = filename ? `PDF 预览：${filename}` : "PDF 预览";
+
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      <div className="flex justify-end">
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-text-muted hover:text-foreground"
+        >
+          在新标签打开
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5h5m0 0v5m0-5L10 14M5 5v14h14" />
+          </svg>
+        </a>
+      </div>
+
+      <div className="h-[calc(100vh-240px)] min-h-[600px] w-full overflow-hidden rounded-lg border border-border bg-background">
+        {/* object（主）→ iframe（兜底）→ 链接（终极兜底） */}
+        <object data={src} type="application/pdf" aria-label={title} className="h-full w-full">
+          <iframe src={src} title={title} className="h-full w-full border-0">
+            <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-text-muted">
+              <p>当前浏览器无法内联预览此 PDF。</p>
+              <a
+                href={src}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-lg bg-foreground px-3 py-1.5 text-xs font-semibold text-background hover:opacity-90"
+              >
+                在新标签页打开 PDF
+              </a>
+            </div>
+          </iframe>
+        </object>
+      </div>
+    </div>
+  );
+}
+
+export default DocumentPdfViewer;

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1377,6 +1377,23 @@ export function effectiveDocumentName(
   return displayName || doc.original_filename;
 }
 
+/**
+ * 判定源文档是否为 PDF —— 决定文档详情页是否展示「Markdown | PDF」切换标签。
+ *
+ * 双重判据（任一命中即视为 PDF），覆盖 MIME 缺失但扩展名为 .pdf 的历史数据：
+ *  - `content_type` 含 "pdf"（如 `application/pdf`，大小写不敏感）；
+ *  - `original_filename` 以 `.pdf` 结尾。
+ *
+ * URL / Markdown / 其他类型文档均返回 false，从而不显示 PDF 预览入口。
+ */
+export function isPdfDocument(
+  doc: Pick<KnowledgeDocument, "content_type" | "original_filename">,
+): boolean {
+  const contentType = (doc.content_type ?? "").toLowerCase();
+  if (contentType.includes("pdf")) return true;
+  return /\.pdf$/i.test(doc.original_filename ?? "");
+}
+
 export interface DocumentMarkdownRefreshResponse {
   document_id: string;
   status: string;
@@ -1531,6 +1548,26 @@ function documentApiBase(corpusId: string | null, documentId: string): string {
   return corpusId
     ? `/api/knowledge/base/${corpusId}/documents/${documentId}`
     : `/api/knowledge/documents/${documentId}`;
+}
+
+/**
+ * 文档原文「内联预览」URL（PDF 原文视图的 `<object>`/`<iframe>` src）。
+ *
+ * 走 BFF `/preview` 路由：复用后端 `/download` 字节、仅把 `Content-Disposition`
+ * 改写为 `inline`。库文档（corpusId=null）与 corpus 文档的路径分支由
+ * {@link documentApiBase} 统一收敛。同源请求自动携带 cookie 完成鉴权，故此处
+ * 仅需返回 URL 字符串，无需手工拼接鉴权头。
+ */
+export function documentPreviewUrl(
+  corpusId: string | null,
+  documentId: string,
+  params?: { appName?: string },
+): string {
+  const query = new URLSearchParams();
+  if (params?.appName) query.set("app_name", params.appName);
+  const qs = query.toString();
+  const base = `${documentApiBase(corpusId, documentId)}/preview`;
+  return qs ? `${base}?${qs}` : base;
 }
 
 export async function deleteDocument(

--- a/apps/negentropy-ui/tests/unit/knowledge/DocumentPdfViewer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DocumentPdfViewer.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { DocumentPdfViewer } from "@/features/knowledge/components/DocumentPdfViewer";
+
+describe("DocumentPdfViewer", () => {
+  const SRC = "/api/knowledge/base/corpus-1/documents/doc-1/preview?app_name=negentropy";
+
+  it("以 <object type=application/pdf data=src> 内联渲染 PDF", () => {
+    const { container } = render(<DocumentPdfViewer src={SRC} filename="report.pdf" />);
+
+    const object = container.querySelector("object");
+    expect(object).not.toBeNull();
+    expect(object).toHaveAttribute("type", "application/pdf");
+    expect(object).toHaveAttribute("data", SRC);
+  });
+
+  it("嵌套 <iframe> 作为兜底并指向同一 src", () => {
+    const { container } = render(<DocumentPdfViewer src={SRC} />);
+
+    const iframe = container.querySelector("object iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe).toHaveAttribute("src", SRC);
+  });
+
+  it("始终提供「在新标签打开」逃生链接（target=_blank + noopener）", () => {
+    const { container } = render(<DocumentPdfViewer src={SRC} filename="report.pdf" />);
+
+    const links = Array.from(container.querySelectorAll(`a[href="${SRC}"]`));
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute("target", "_blank");
+    expect(links[0]?.getAttribute("rel")).toContain("noopener");
+  });
+});

--- a/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/knowledge-api.test.ts
@@ -3,8 +3,10 @@ import {
   buildCorpusConfig,
   createCatalogNode,
   deleteDocument,
+  documentPreviewUrl,
   fetchDocumentDetail,
   importDocumentFile,
+  isPdfDocument,
   importDocumentUrl,
   ingestDocument,
   refreshDocumentMarkdown,
@@ -792,6 +794,62 @@ describe("库文档（corpusId=null）API 路径分支", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(String(fetchSpy.mock.calls[0][0])).toBe(
       "/api/knowledge/documents/doc-1/refresh_markdown",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PDF 源文档判定 + 内联预览 URL（文档详情页「Markdown | PDF」切换支撑）
+// ---------------------------------------------------------------------------
+
+describe("isPdfDocument", () => {
+  it("content_type 为 application/pdf 时判为 PDF", () => {
+    expect(
+      isPdfDocument({ content_type: "application/pdf", original_filename: "a.bin" }),
+    ).toBe(true);
+  });
+
+  it("content_type 大小写混合含 pdf 仍判为 PDF", () => {
+    expect(
+      isPdfDocument({ content_type: "Application/PDF", original_filename: "a" }),
+    ).toBe(true);
+  });
+
+  it("content_type 缺失但文件名以 .pdf 结尾时判为 PDF（兜底历史数据）", () => {
+    expect(
+      isPdfDocument({ content_type: null, original_filename: "report.PDF" }),
+    ).toBe(true);
+  });
+
+  it("URL / Markdown / 其他类型文档判为非 PDF", () => {
+    expect(
+      isPdfDocument({ content_type: "text/markdown", original_filename: "notes.md" }),
+    ).toBe(false);
+    expect(
+      isPdfDocument({ content_type: "text/html", original_filename: "post" }),
+    ).toBe(false);
+    expect(
+      isPdfDocument({ content_type: null, original_filename: "image.png" }),
+    ).toBe(false);
+  });
+});
+
+describe("documentPreviewUrl", () => {
+  it("corpus 文档走 corpus 作用域 /preview 路径并带 app_name", () => {
+    expect(
+      documentPreviewUrl("corpus-1", "doc-1", { appName: "negentropy" }),
+    ).toBe("/api/knowledge/base/corpus-1/documents/doc-1/preview?app_name=negentropy");
+  });
+
+  it("库文档（corpusId=null）走无 corpus 平行 /preview 路径", () => {
+    expect(
+      documentPreviewUrl(null, "doc-1", { appName: "negentropy" }),
+    ).toBe("/api/knowledge/documents/doc-1/preview?app_name=negentropy");
+  });
+
+  it("未提供 appName 时不拼接查询串", () => {
+    expect(documentPreviewUrl("corpus-1", "doc-1")).toBe(
+      "/api/knowledge/base/corpus-1/documents/doc-1/preview",
     );
   });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge / Documents 文档详情页（`/knowledge/documents/{corpusId}/{documentId}`）此前仅展示**解析后的 Markdown**，当源文档为 PDF 时无法在页内查看**原始 PDF**，只能下载到本地比对。
- 关联上下文/Issue/文档：用户需求 —— 在页面顶部中栏新增「Markdown | PDF」切换，PDF 标签以源 PDF 文档呈现，并为前端选择最佳 PDF 渲染方案。

# 核心变更
- **顶部中栏切换**：文档详情页操作栏中间新增「Markdown | PDF」分段切换（**仅 PDF 源文档显示**），默认 Markdown，非 PDF 文档行为零变化；切换仅依赖 `isPdf`，与 Markdown 解析状态无关（解析失败/为空也能看原文）。
- **PDF 渲染器选型（原生方案）**：新增 `DocumentPdfViewer`，采用原生浏览器查看器（`<object>`+`<iframe>`+逃生链接组合）。经调研选择该方案而非 `react-pdf`/pdf.js —— **零新增运行时依赖**、保真渲染含中文、自带缩放/搜索/打印/翻页，规避 worker/SSR/cMaps 成本（契合内部桌面工具场景与「熵减/最小干预」原则）。
- **复用既有链路，后端零改动**：BFF `proxyGetBinary` 新增 `responseDisposition:"inline"`，将上游 `Content-Disposition` 由 `attachment` 改写为 `inline`（并兜底 `application/pdf`）；新增 corpus 与 library 两条 `/preview` 路由，复用后端既有 `/download` 字节。
- **工具函数**：`knowledge-api.ts` 新增纯函数 `isPdfDocument()`（MIME 含 pdf 或 `.pdf` 扩展名）与 `documentPreviewUrl()`（复用 `documentApiBase` 收敛 corpus/library 分支）。

# 风险与回滚
- 主要风险：低。后端与存储/解析链路零改动；`responseDisposition` 默认不启用，现有 `/download` 及所有其他代理调用行为不变；同源 `<object>/<iframe>` 自动携带 cookie 完成鉴权（与 Download 同机制）；大文件走 URL 流式直连不占 JS 内存。
- 回滚方式：纯前端/BFF 增量改动，`git revert` 提交 `9993f0f5` 即可完全还原，无数据迁移。

# 验证证据
- 单元测试：knowledge 全套 **26 文件 / 221 用例**全绿（含新增 9 例：`isPdfDocument`/`documentPreviewUrl`/`DocumentPdfViewer`），无回归。
- 集成测试：`pnpm typecheck` 干净通过；改动文件 ESLint `--max-warnings=0` 通过；pre-commit 钩子（含 negentropy-ui ESLint）全过。
- E2E/Workflow：未在本会话执行（文档页需 SSO 登录态）；需在部署本变更的栈上由维护者自检：PDF 文档出现切换且默认 Markdown 同现状 → 切到 PDF 内联渲染（缩放/中文正常）→ 非 PDF 文档无切换（回归）→ 库文档 PDF 走 `/api/knowledge/documents/{id}/preview` → DevTools 确认 `/preview` 响应 `200 + application/pdf + Content-Disposition: inline`。
- 覆盖率/关键截图：N/A。

# 影响范围
- 前端：文档详情页 `page.tsx`（新增 `viewMode` 状态 + 中栏切换 + 内容区条件渲染，现有 Markdown 分支不动）、新增 `DocumentPdfViewer.tsx`、`knowledge-api.ts` 两个纯函数。
- 后端：**无改动**（复用既有 `/download` 端点）。
- GitHub Actions / 文档：无。BFF 层 `_proxy.ts` 增量扩展 + 新增 2 条 `/preview` 路由。

# Next Best Action
- 部署后由维护者执行上述实机回归（可用已登录 Chrome 驱动 E2E）；如后续需面向公网移动端或注释/表单能力，再评估升级到 pdf.js 渲染。
