### PR TITLE
feat(Repositories): 新增 Repositories 注册管理页并接入 Routine 仓库选择

### DIFF
--- a/apps/negentropy-ui/app/api/interface/repositories/[repositoryId]/route.ts
+++ b/apps/negentropy-ui/app/api/interface/repositories/[repositoryId]/route.ts
@@ -1,0 +1,33 @@
+import { proxyDelete, proxyGet, proxyPatch } from "@/app/api/interface/_proxy";
+
+/**
+ * 单个 Repository API 代理端点
+ *
+ * GET    /api/interface/repositories/{repositoryId} - 获取详情
+ * PATCH  /api/interface/repositories/{repositoryId} - 更新
+ * DELETE /api/interface/repositories/{repositoryId} - 删除
+ */
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ repositoryId: string }> },
+) {
+  const { repositoryId } = await params;
+  return proxyGet(request, `/interface/repositories/${repositoryId}`);
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ repositoryId: string }> },
+) {
+  const { repositoryId } = await params;
+  return proxyPatch(request, `/interface/repositories/${repositoryId}`);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ repositoryId: string }> },
+) {
+  const { repositoryId } = await params;
+  return proxyDelete(request, `/interface/repositories/${repositoryId}`);
+}

--- a/apps/negentropy-ui/app/api/interface/repositories/inspect/route.ts
+++ b/apps/negentropy-ui/app/api/interface/repositories/inspect/route.ts
@@ -1,0 +1,14 @@
+import { proxyPost } from "@/app/api/interface/_proxy";
+
+/**
+ * Repository 分支枚举代理端点
+ *
+ * POST /api/interface/repositories/inspect
+ *   body: { local_path } -> 后端枚举该本地仓库的 git 分支，供注册时基线下拉。
+ *
+ * 独立静态段（与 [repositoryId] 动态段并存）：枚举发生在 Repo 保存前、尚无 id 时。
+ */
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/interface/repositories/inspect");
+}

--- a/apps/negentropy-ui/app/api/interface/repositories/route.ts
+++ b/apps/negentropy-ui/app/api/interface/repositories/route.ts
@@ -1,0 +1,16 @@
+import { proxyGet, proxyPost } from "@/app/api/interface/_proxy";
+
+/**
+ * Repositories 集合 API 代理端点
+ *
+ * GET  /api/interface/repositories - 列出可见的 Repository
+ * POST /api/interface/repositories - 注册新 Repository
+ */
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/interface/repositories");
+}
+
+export async function POST(request: Request) {
+  return proxyPost(request, "/interface/repositories");
+}

--- a/apps/negentropy-ui/app/interface/repositories/_components/RepositoryCard.tsx
+++ b/apps/negentropy-ui/app/interface/repositories/_components/RepositoryCard.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { GitBranch, Github } from "lucide-react";
+import type { RepositoryDTO } from "@/features/repositories";
+
+interface RepositoryCardProps {
+  repository: RepositoryDTO;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function RepositoryCard({
+  repository,
+  onEdit,
+  onDelete,
+}: RepositoryCardProps) {
+  const displayLabel = repository.display_name || repository.name;
+
+  return (
+    <div className="group relative flex h-[196px] flex-col rounded-xl border border-border bg-card p-4">
+      {/* 卡片整体覆盖按钮：点击空白区进入编辑（操作按钮以更高 z-index 覆盖其上） */}
+      <button
+        type="button"
+        onClick={onEdit}
+        aria-label={`Edit ${displayLabel}`}
+        className="absolute inset-0 z-10 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+      />
+
+      <div className="relative z-20 flex min-h-0 flex-1 flex-col pointer-events-none">
+        <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
+          <h3 className="truncate text-lg font-semibold text-foreground">
+            {displayLabel}
+          </h3>
+          <div className="flex shrink-0 items-center gap-2 pointer-events-auto">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
+              title="Edit Repository"
+              aria-label={`Edit ${displayLabel}`}
+              className="rounded-md p-2 text-text-muted hover:bg-muted hover:text-text-secondary"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+              </svg>
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              title="Delete Repository"
+              aria-label={`Delete ${displayLabel}`}
+              className="rounded-md p-2 text-text-muted hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* 状态徽章行 */}
+        <div className="mb-2 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
+          {repository.is_enabled ? (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+              Enabled
+            </span>
+          ) : (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-text-secondary">
+              Disabled
+            </span>
+          )}
+          {repository.is_builtin && (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+              Built-In
+            </span>
+          )}
+          <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+            {repository.visibility}
+          </span>
+        </div>
+
+        {/* 本地路径（等宽小字、truncate、悬浮提示全文） */}
+        <p
+          className="mb-2 min-w-0 truncate font-mono text-xs text-text-muted"
+          title={repository.local_path}
+        >
+          {repository.local_path}
+        </p>
+
+        {/* 基线分支 + GitHub 地址 */}
+        <div className="mt-auto flex min-w-0 flex-col gap-1.5 pt-1 text-xs text-text-muted">
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <GitBranch className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span className="truncate font-mono" title={repository.baseline_branch}>
+              {repository.baseline_branch}
+            </span>
+          </span>
+          <span className="inline-flex min-w-0 items-center gap-1.5">
+            <Github className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span className="truncate" title={repository.github_url}>
+              {repository.github_url}
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/repositories/_components/RepositoryFormDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/repositories/_components/RepositoryFormDrawer.tsx
@@ -1,0 +1,351 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * React 19 + eslint-plugin-react-hooks v7.1.1 的 React Compiler 兼容新规则集
+ * 在该文件中命中既有代码模式（useEffect 内 seed 表单 / ref 写入 / deps 校验等）。
+ * 这些代码功能正确，仅是新规则严格度提升导致的告警；
+ * TODO(react-compiler): 按 React Compiler 范式 / SWR / useSyncExternalStore 重构。
+ */
+"use client";
+
+import {
+  useState,
+  useEffect,
+  useId,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
+import { toast } from "sonner";
+import { BaseDrawer } from "@/components/ui/BaseDrawer";
+import { Button } from "@/components/ui/Button";
+import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+import { inspectBranches } from "@/features/repositories";
+import type {
+  RepositoryCreatePayload,
+  RepositoryDTO,
+  RepositoryUpdatePayload,
+} from "@/features/repositories";
+
+interface RepositoryFormDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (
+    data: RepositoryCreatePayload | RepositoryUpdatePayload,
+  ) => Promise<void>;
+  repository: RepositoryDTO | null;
+}
+
+const EMPTY_FORM = {
+  name: "",
+  display_name: "",
+  description: "",
+  github_url: "",
+  local_path: "",
+  baseline_branch: "",
+};
+
+type RepositoryForm = typeof EMPTY_FORM;
+
+export function RepositoryFormDrawer({
+  open,
+  onClose,
+  onSubmit,
+  repository,
+}: RepositoryFormDrawerProps) {
+  const formId = useId();
+  const [formData, setFormData] = useState<RepositoryForm>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+
+  // ── Inspect Branches 交互态 ──
+  const [branches, setBranches] = useState<string[]>([]);
+  const [inspecting, setInspecting] = useState(false);
+  const [inspectError, setInspectError] = useState<string | null>(null);
+
+  // ── 脏检基线 ──
+  const [baseline, setBaseline] = useState<RepositoryForm>(EMPTY_FORM);
+  const isDirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(baseline),
+    [formData, baseline],
+  );
+
+  const { confirm, confirmDialog } = useConfirmDialog();
+  const confirmingRef = useRef(false);
+
+  const requestClose = useCallback(async () => {
+    if (confirmingRef.current) return;
+    if (!isDirty) {
+      onClose();
+      return;
+    }
+    confirmingRef.current = true;
+    const ok = await confirm({
+      title: "Discard changes?",
+      message: "You have unsaved changes. Closing now will discard them.",
+      confirmLabel: "Discard",
+      cancelLabel: "Keep editing",
+      destructive: true,
+    });
+    confirmingRef.current = false;
+    if (ok) onClose();
+  }, [isDirty, confirm, onClose]);
+
+  // Escape 键关闭（脏检确认）
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") void requestClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, requestClose]);
+
+  // open / repository 变化时 seed 表单与基线
+  useEffect(() => {
+    if (repository) {
+      const seeded: RepositoryForm = {
+        name: repository.name,
+        display_name: repository.display_name || "",
+        description: repository.description || "",
+        github_url: repository.github_url,
+        local_path: repository.local_path,
+        baseline_branch: repository.baseline_branch,
+      };
+      setFormData(seeded);
+      setBaseline(seeded);
+      // 把已存基线分支作为单元素种子塞入候选，确保未点 Inspect 也能正确显示当前选中分支
+      setBranches(repository.baseline_branch ? [repository.baseline_branch] : []);
+    } else {
+      setFormData(EMPTY_FORM);
+      setBaseline(EMPTY_FORM);
+      setBranches([]);
+    }
+    setInspectError(null);
+  }, [repository, open]);
+
+  // 枚举分支（手动按钮触发，不做自动 debounce 请求）
+  const handleInspect = async () => {
+    const path = formData.local_path.trim();
+    if (!path) {
+      const message = "Please enter a local path first";
+      setInspectError(message);
+      toast.error(message);
+      return;
+    }
+    setInspecting(true);
+    setInspectError(null);
+    try {
+      const result = await inspectBranches(path);
+      // remote 在前（baseline 常为 origin/feature/x.y 这类远端跟踪名），合并去重
+      const merged = Array.from(new Set([...result.remote, ...result.local]));
+      setBranches(merged);
+      // 当前 baseline 不在新列表时，预选 default_remote 下匹配项或首项
+      setFormData((prev) => {
+        if (prev.baseline_branch && merged.includes(prev.baseline_branch)) {
+          return prev;
+        }
+        const prefix = `${result.default_remote}/`;
+        const preferred =
+          merged.find((b) => b.startsWith(prefix)) ?? merged[0] ?? "";
+        return { ...prev, baseline_branch: preferred };
+      });
+      if (merged.length === 0) {
+        toast.error("No branches found at this path");
+      } else {
+        toast.success(`Found ${merged.length} branch(es)`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Inspect failed";
+      setInspectError(message);
+      toast.error(message);
+    } finally {
+      setInspecting(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const name = formData.name.trim();
+      const payload: RepositoryCreatePayload | RepositoryUpdatePayload = {
+        name,
+        display_name: formData.display_name.trim() || null,
+        description: formData.description.trim() || null,
+        github_url: formData.github_url.trim(),
+        local_path: formData.local_path.trim(),
+        baseline_branch: formData.baseline_branch.trim(),
+      };
+      await onSubmit(payload);
+      // 成功后把 baseline 设为当前 form 以重置 isDirty（对齐 ToolFormDrawer）
+      setBaseline(formData);
+    } catch {
+      // onSubmit already handles toast
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <BaseDrawer
+        open={open}
+        title={
+          repository
+            ? `Edit Repository: ${repository.display_name || repository.name}`
+            : "Add Repository"
+        }
+        subtitle="Register a local git repository to drive Routine isolation worktrees."
+        onClose={() => void requestClose()}
+        closeOnBackdrop={!submitting}
+        closeOnEscape={false}
+        footer={
+          <div className="flex items-center justify-end gap-3">
+            <Button type="button" variant="ghost" onClick={() => void requestClose()}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              form={formId}
+              variant="neutral"
+              disabled={submitting}
+            >
+              {submitting ? "Saving..." : repository ? "Update" : "Create"}
+            </Button>
+          </div>
+        }
+      >
+        <form id={formId} onSubmit={handleSubmit} className="space-y-6 px-5 py-5">
+          {/* 基本信息 */}
+          <section className="space-y-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+              Basic Information
+            </h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                  placeholder="e.g. negentropy"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  Display Name
+                </label>
+                <input
+                  type="text"
+                  value={formData.display_name}
+                  onChange={(e) =>
+                    setFormData({ ...formData, display_name: e.target.value })
+                  }
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
+                  placeholder="e.g. Negentropy"
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  GitHub URL <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="url"
+                  value={formData.github_url}
+                  onChange={(e) =>
+                    setFormData({ ...formData, github_url: e.target.value })
+                  }
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
+                  placeholder="https://github.com/org/repo"
+                  required
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  Description
+                </label>
+                <textarea
+                  value={formData.description}
+                  onChange={(e) =>
+                    setFormData({ ...formData, description: e.target.value })
+                  }
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
+                  rows={2}
+                  placeholder="Repository description"
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* 本地仓库 + 分支枚举 */}
+          <section className="space-y-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
+              Local Repository
+            </h3>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  Local Path <span className="text-red-500">*</span>
+                </label>
+                <div className="flex items-start gap-2">
+                  <input
+                    type="text"
+                    value={formData.local_path}
+                    onChange={(e) =>
+                      setFormData({ ...formData, local_path: e.target.value })
+                    }
+                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                    placeholder="/path/to/repo"
+                    required
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleInspect}
+                    disabled={inspecting || submitting}
+                    loading={inspecting}
+                    className="shrink-0"
+                  >
+                    Inspect Branches
+                  </Button>
+                </div>
+                {inspectError && (
+                  <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                    {inspectError}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-text-secondary mb-1">
+                  Baseline Branch <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={formData.baseline_branch}
+                  onChange={(e) =>
+                    setFormData({ ...formData, baseline_branch: e.target.value })
+                  }
+                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground disabled:opacity-50"
+                  disabled={branches.length === 0}
+                  required
+                >
+                  {branches.length === 0 ? (
+                    <option value="">Inspect branches first…</option>
+                  ) : (
+                    branches.map((branch) => (
+                      <option key={branch} value={branch}>
+                        {branch}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+            </div>
+          </section>
+        </form>
+      </BaseDrawer>
+      {confirmDialog}
+    </>
+  );
+}

--- a/apps/negentropy-ui/app/interface/repositories/page.tsx
+++ b/apps/negentropy-ui/app/interface/repositories/page.tsx
@@ -1,0 +1,218 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * React 19 + eslint-plugin-react-hooks v7.1.1 的 React Compiler 兼容新规则集
+ * 在该文件中命中既有代码模式（useEffect 内调用 fetcher / ref 写入 / deps 校验等）。
+ * 这些代码功能正确，仅是新规则严格度提升导致的告警；
+ * TODO(react-compiler): 按 React Compiler 范式 / SWR / useSyncExternalStore 重构。
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { FolderGit2 } from "lucide-react";
+import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { ErrorState } from "@/components/ui/ErrorState";
+import { EmptyState } from "@/components/ui/EmptyState";
+import {
+  createRepository,
+  deleteRepository,
+  fetchRepositories,
+  updateRepository,
+} from "@/features/repositories";
+import type {
+  RepositoryCreatePayload,
+  RepositoryDTO,
+  RepositoryUpdatePayload,
+} from "@/features/repositories";
+import { RepositoryCard } from "./_components/RepositoryCard";
+import { RepositoryFormDrawer } from "./_components/RepositoryFormDrawer";
+
+export default function RepositoriesPage() {
+  const [repositories, setRepositories] = useState<RepositoryDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingRepository, setEditingRepository] = useState<RepositoryDTO | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<RepositoryDTO | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const loadRepositories = useCallback(async () => {
+    try {
+      const data = await fetchRepositories();
+      setRepositories(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRepositories();
+  }, [loadRepositories]);
+
+  const handleCreate = () => {
+    setEditingRepository(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (repository: RepositoryDTO) => {
+    setEditingRepository(repository);
+    setDialogOpen(true);
+  };
+
+  const handleDeleteRequest = (repository: RepositoryDTO) => {
+    setPendingDelete(repository);
+  };
+
+  const handleDeleteConfirmed = async () => {
+    if (!pendingDelete) return;
+    const target = pendingDelete;
+    setDeleting(true);
+    try {
+      await deleteRepository(target.id);
+      toast.success(`Deleted repository "${target.display_name || target.name}"`);
+      setPendingDelete(null);
+      void loadRepositories();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleDialogClose = () => {
+    setDialogOpen(false);
+    setEditingRepository(null);
+  };
+
+  const handleFormSubmit = async (
+    data: RepositoryCreatePayload | RepositoryUpdatePayload,
+  ) => {
+    try {
+      if (editingRepository) {
+        await updateRepository(editingRepository.id, data as RepositoryUpdatePayload);
+      } else {
+        await createRepository(data as RepositoryCreatePayload);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to save repository";
+      toast.error(message);
+      // 抛出以让抽屉保持打开（对齐 tools 页 handleFormSubmit 语义）
+      throw err instanceof Error ? err : new Error(message);
+    }
+
+    const label = data.display_name || data.name;
+    toast.success(
+      editingRepository
+        ? `Updated repository "${label}"`
+        : `Created repository "${label}"`,
+    );
+    handleDialogClose();
+    void loadRepositories();
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-muted">
+      <InterfaceNav title="Repositories" />
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 py-6">
+          <div className="w-full">
+            <div className="flex items-center justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-bold text-foreground">
+                  Repositories
+                </h1>
+                <p className="text-sm text-text-muted">
+                  Register local git repositories to drive Routine isolation worktrees.
+                </p>
+              </div>
+              <button
+                onClick={handleCreate}
+                className="inline-flex items-center justify-center rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+              >
+                Add Repository
+              </button>
+            </div>
+
+            {loading ? (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {[0, 1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="h-[196px] rounded-xl border border-border bg-card p-4"
+                  >
+                    <Skeleton className="mb-3 h-5 w-1/3" />
+                    <div className="mb-2 flex gap-2">
+                      <Skeleton className="h-4 w-16 rounded-full" />
+                      <Skeleton className="h-4 w-12 rounded-full" />
+                    </div>
+                    <Skeleton className="mb-1 h-4 w-full" />
+                    <Skeleton className="h-4 w-3/4" />
+                  </div>
+                ))}
+              </div>
+            ) : error ? (
+              <ErrorState
+                title="Failed to load repositories"
+                description={error}
+                onRetry={loadRepositories}
+              />
+            ) : repositories.length === 0 ? (
+              <EmptyState
+                icon={FolderGit2}
+                title="No repositories registered yet"
+                action={
+                  <button
+                    onClick={handleCreate}
+                    className="text-sm text-text-secondary hover:text-foreground transition-colors"
+                  >
+                    Register your first repository →
+                  </button>
+                }
+              />
+            ) : (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {repositories.map((repository) => (
+                  <RepositoryCard
+                    key={repository.id}
+                    repository={repository}
+                    onEdit={() => handleEdit(repository)}
+                    onDelete={() => handleDeleteRequest(repository)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <RepositoryFormDrawer
+        open={dialogOpen}
+        onClose={handleDialogClose}
+        onSubmit={handleFormSubmit}
+        repository={editingRepository}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete repository?"
+        message={
+          pendingDelete
+            ? `"${pendingDelete.display_name || pendingDelete.name}" will be permanently removed. Routines referencing this repository will fall back to a manually entered path. This action cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        destructive
+        busy={deleting}
+        onCancel={() => {
+          if (!deleting) setPendingDelete(null);
+        }}
+        onConfirm={handleDeleteConfirmed}
+      />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -17,6 +17,8 @@ import type {
   RoutineTemplateItem,
   RoutineUpdatePayload,
 } from "@/features/routine";
+import { fetchRepositories } from "@/features/repositories";
+import type { RepositoryDTO } from "@/features/repositories";
 
 import { canRestart, CONTROL_LABEL, controlsFor, type ControlAction } from "./routine-controls";
 import { phaseClass, phaseLabel, routineStatusClass } from "./status-style";
@@ -95,6 +97,8 @@ interface FormState {
   acceptance_criteria: string;
   cwd: string;
   baseline_branch: string;
+  /** 关联的已注册 Repository id（空串 = 未关联 = 手填模式）。 */
+  repository_id: string;
   verification_command: string;
   max_iterations: string;
   max_cost_usd: string;
@@ -125,6 +129,7 @@ const DEFAULTS: FormState = {
   acceptance_criteria: "",
   cwd: "",
   baseline_branch: "",
+  repository_id: "",
   verification_command: "",
   max_iterations: "20",
   max_cost_usd: "5",
@@ -218,6 +223,7 @@ function buildInitial(mode: DrawerMode): FormState {
         acceptance_criteria: r.acceptance_criteria,
         cwd: r.cwd ?? "",
         baseline_branch: r.baseline_branch ?? "",
+        repository_id: r.repository_id ?? "",
         verification_command: r.verification_command ?? "",
         max_iterations: r.max_iterations != null ? String(r.max_iterations) : "",
         max_cost_usd: r.max_cost_usd != null ? String(r.max_cost_usd) : "",
@@ -344,6 +350,34 @@ export function RoutineEditDrawer({
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const confirmingRef = useRef(false); // 弃改确认进行中 → 抑制重复关闭
 
+  // ── Repository 关联选择（仅 routine entity）——单一事实源：选定后仅提交 repository_id，
+  //    cwd/baseline 由后端派生（提交 null）；未选则回退手填 cwd/baseline。──
+  const [repos, setRepos] = useState<RepositoryDTO[]>([]);
+  useEffect(() => {
+    if (entity !== "routine") return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await fetchRepositories();
+        if (!cancelled) setRepos(list);
+      } catch {
+        /* 静默：下拉退化为空，仍可手填 cwd/baseline */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [entity]);
+  const selectedRepo = useMemo(
+    () => repos.find((r) => r.id === form.repository_id) ?? null,
+    [repos, form.repository_id],
+  );
+  const repoLinked = entity === "routine" && !!form.repository_id;
+  const onPickRepository = (repoId: string) => {
+    setForm((f) => ({ ...f, repository_id: repoId }));
+    setFieldErrors((e) => ({ ...e, cwd: "", baseline_branch: "" }));
+  };
+
   const isDirty = useMemo(
     () => JSON.stringify(form) !== JSON.stringify(baseline),
     [form, baseline],
@@ -424,8 +458,10 @@ export function RoutineEditDrawer({
       if (!form.title.trim()) errs.title = "Name is required";
       if (!form.goal.trim()) errs.goal = "Goal is required";
       if (!form.acceptance_criteria.trim()) errs.acceptance_criteria = "Acceptance criteria is required";
-      if (requireWorktree && !form.cwd.trim()) errs.cwd = "Project Path is required";
-      if (requireWorktree && !form.baseline_branch.trim()) errs.baseline_branch = "Baseline Branch is required";
+      // 关联 Repository 时由后端派生 cwd/baseline，跳过手填必填校验；未关联则照旧。
+      if (requireWorktree && !repoLinked && !form.cwd.trim()) errs.cwd = "Project Path is required";
+      if (requireWorktree && !repoLinked && !form.baseline_branch.trim())
+        errs.baseline_branch = "Baseline Branch is required";
     } else {
       // Running 状态：安全字段的基本验证
       if (!form.title.trim()) errs.title = "Name is required";
@@ -467,7 +503,15 @@ export function RoutineEditDrawer({
             : {};
       config = { ...inherited };
       applyCCConfig(config, form);
-      extra = { cwd: form.cwd.trim() || null, baseline_branch: form.baseline_branch.trim() || null };
+      // 单一事实源：关联 Repository 时仅提交 repository_id（cwd/baseline 由后端派生，提交 null）；
+      // 未关联则提交手填 cwd/baseline、清空 repository_id。
+      extra = form.repository_id
+        ? { repository_id: form.repository_id, cwd: null, baseline_branch: null }
+        : {
+            repository_id: null,
+            cwd: form.cwd.trim() || null,
+            baseline_branch: form.baseline_branch.trim() || null,
+          };
     } else {
       // 模板元数据收敛进 config（与列表 API 的读取契约对齐）
       const inherited =
@@ -801,32 +845,82 @@ export function RoutineEditDrawer({
             {/* ── Execution Context（仅 routine entity）── */}
             {entity === "routine" && (
               <>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className={labelCls}>Project Path{requireWorktree && !isFieldDisabled("cwd") && reqMark}</label>
-                    <input
-                      type="text"
-                      value={form.cwd}
-                      onChange={(e) => update("cwd", e.target.value)}
-                      disabled={isFieldDisabled("cwd")}
-                      placeholder="/path/to/repo"
-                      className={cn(inputCls, fieldErrors.cwd && "border-red-400")}
-                    />
-                    {renderFieldError("cwd")}
-                  </div>
-                  <div>
-                    <label className={labelCls}>Baseline Branch{requireWorktree && !isFieldDisabled("baseline_branch") && reqMark}</label>
-                    <input
-                      type="text"
-                      value={form.baseline_branch}
-                      onChange={(e) => update("baseline_branch", e.target.value)}
-                      disabled={isFieldDisabled("baseline_branch")}
-                      placeholder="e.g. origin/feature/1.x.x"
-                      className={cn(inputCls, fieldErrors.baseline_branch && "border-red-400")}
-                    />
-                    {renderFieldError("baseline_branch")}
-                  </div>
+                <div>
+                  <label className={labelCls}>Repository</label>
+                  <select
+                    value={form.repository_id}
+                    onChange={(e) => onPickRepository(e.target.value)}
+                    disabled={isFieldDisabled("cwd")}
+                    className={inputCls}
+                  >
+                    <option value="">— Manual (enter path &amp; branch below) —</option>
+                    {repos.map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {r.display_name || r.name}
+                      </option>
+                    ))}
+                    {repoLinked && !selectedRepo && (
+                      <option value={form.repository_id}>(repository unavailable — switch to Manual)</option>
+                    )}
+                  </select>
+                  <p className="mt-1 text-caption text-text-secondary">
+                    选择已注册的 Repository 以自动派生 Project Path 与 Baseline Branch；或选 Manual 手动填写。
+                  </p>
                 </div>
+
+                {repoLinked ? (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className={labelCls}>Project Path</label>
+                      <input
+                        type="text"
+                        value={selectedRepo?.local_path ?? ""}
+                        disabled
+                        readOnly
+                        placeholder="（仓库信息加载中或不可用）"
+                        className={cn(inputCls, "opacity-70")}
+                      />
+                    </div>
+                    <div>
+                      <label className={labelCls}>Baseline Branch</label>
+                      <input
+                        type="text"
+                        value={selectedRepo?.baseline_branch ?? ""}
+                        disabled
+                        readOnly
+                        placeholder="（仓库信息加载中或不可用）"
+                        className={cn(inputCls, "opacity-70")}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className={labelCls}>Project Path{requireWorktree && !isFieldDisabled("cwd") && reqMark}</label>
+                      <input
+                        type="text"
+                        value={form.cwd}
+                        onChange={(e) => update("cwd", e.target.value)}
+                        disabled={isFieldDisabled("cwd")}
+                        placeholder="/path/to/repo"
+                        className={cn(inputCls, fieldErrors.cwd && "border-red-400")}
+                      />
+                      {renderFieldError("cwd")}
+                    </div>
+                    <div>
+                      <label className={labelCls}>Baseline Branch{requireWorktree && !isFieldDisabled("baseline_branch") && reqMark}</label>
+                      <input
+                        type="text"
+                        value={form.baseline_branch}
+                        onChange={(e) => update("baseline_branch", e.target.value)}
+                        disabled={isFieldDisabled("baseline_branch")}
+                        placeholder="e.g. origin/feature/1.x.x"
+                        className={cn(inputCls, fieldErrors.baseline_branch && "border-red-400")}
+                      />
+                      {renderFieldError("baseline_branch")}
+                    </div>
+                  </div>
+                )}
                 <div>
                   <label className={labelCls}>Additional Dirs</label>
                   <input

--- a/apps/negentropy-ui/components/ui/InterfaceNav.tsx
+++ b/apps/negentropy-ui/components/ui/InterfaceNav.tsx
@@ -19,6 +19,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/interface/mcp", label: MCP_HUB_LABEL },
   { href: "/interface/skills", label: "Skills" },
   { href: "/interface/tools", label: "Tools" },
+  { href: "/interface/repositories", label: "Repositories" },
   { href: "/interface/scheduler", label: "Scheduler" },
   { href: "/interface/routine", label: "Routine" },
 ];

--- a/apps/negentropy-ui/features/repositories/api.ts
+++ b/apps/negentropy-ui/features/repositories/api.ts
@@ -1,0 +1,59 @@
+/**
+ * Repository 数据访问层 —— 经 /api/interface/repositories 代理转发到后端 /interface/repositories。
+ */
+
+import type {
+  BranchInspectResponse,
+  RepositoryCreatePayload,
+  RepositoryDTO,
+  RepositoryUpdatePayload,
+} from "./types";
+
+const API_ROOT = "/api/interface/repositories";
+
+async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_ROOT}${path}`, {
+    cache: "no-store",
+    ...init,
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const body = await res.json();
+      detail = body?.detail || body?.error?.message || body?.message || JSON.stringify(body);
+    } catch {
+      detail = await res.text().catch(() => "");
+    }
+    throw new Error(detail || `${res.status} ${res.statusText}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+export async function fetchRepositories(): Promise<RepositoryDTO[]> {
+  return jsonFetch("");
+}
+
+export async function createRepository(body: RepositoryCreatePayload): Promise<RepositoryDTO> {
+  return jsonFetch("", { method: "POST", body: JSON.stringify(body) });
+}
+
+export async function updateRepository(
+  id: string,
+  body: RepositoryUpdatePayload,
+): Promise<RepositoryDTO> {
+  return jsonFetch(`/${encodeURIComponent(id)}`, { method: "PATCH", body: JSON.stringify(body) });
+}
+
+export async function deleteRepository(id: string): Promise<void> {
+  return jsonFetch(`/${encodeURIComponent(id)}`, { method: "DELETE" });
+}
+
+/** 给定本地仓库根路径枚举其 git 分支（填好 local_path 后调用，类比 Test Connection）。 */
+export async function inspectBranches(localPath: string): Promise<BranchInspectResponse> {
+  return jsonFetch("/inspect", {
+    method: "POST",
+    body: JSON.stringify({ local_path: localPath }),
+  });
+}

--- a/apps/negentropy-ui/features/repositories/index.ts
+++ b/apps/negentropy-ui/features/repositories/index.ts
@@ -1,0 +1,13 @@
+export type {
+  BranchInspectResponse,
+  RepositoryCreatePayload,
+  RepositoryDTO,
+  RepositoryUpdatePayload,
+} from "./types";
+export {
+  createRepository,
+  deleteRepository,
+  fetchRepositories,
+  inspectBranches,
+  updateRepository,
+} from "./api";

--- a/apps/negentropy-ui/features/repositories/types.ts
+++ b/apps/negentropy-ui/features/repositories/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Repository 资源类型 —— 与后端 /interface/repositories 序列化契约（RepositoryResponse）对齐。
+ *
+ * Repository 注册「引擎主机上已 clone 的本地仓库根路径 + GitHub 地址 + 基线分支」，供 Routine
+ * 下拉选择并派生隔离 worktree 配置（见 features/routine 的 repository_id）。
+ */
+
+export interface RepositoryDTO {
+  id: string;
+  owner_id: string;
+  visibility: string;
+  name: string;
+  display_name: string | null;
+  description: string | null;
+  github_url: string;
+  local_path: string;
+  baseline_branch: string;
+  default_remote: string;
+  is_enabled: boolean;
+  is_builtin: boolean;
+  config: Record<string, unknown>;
+  sort_order: number;
+}
+
+/** 创建请求体（name/github_url/local_path/baseline_branch 必填）。 */
+export interface RepositoryCreatePayload {
+  name: string;
+  display_name?: string | null;
+  description?: string | null;
+  github_url: string;
+  local_path: string;
+  baseline_branch: string;
+  default_remote?: string;
+  is_enabled?: boolean;
+  visibility?: string;
+}
+
+/** 更新请求体（全可选）。 */
+export type RepositoryUpdatePayload = Partial<RepositoryCreatePayload>;
+
+/** 分支枚举端点返回：给定 local_path 的本地 + 远端跟踪分支。 */
+export interface BranchInspectResponse {
+  local: string[];
+  remote: string[];
+  default_remote: string;
+}

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -40,6 +40,8 @@ export interface RoutineDTO {
   cwd: string | null;
   /** 隔离 worktree 的基线分支 + PR base（如 origin/feature/1.x.x）。 */
   baseline_branch: string | null;
+  /** 可选关联的已注册 Repository（单一事实源指针）；非空时由后端派生 cwd/baseline_branch。 */
+  repository_id: string | null;
   verification_command: string | null;
   status: RoutineStatus;
   termination_reason: string | null;
@@ -264,6 +266,8 @@ export interface RoutineCreatePayload {
   acceptance_criteria: string;
   cwd?: string | null;
   baseline_branch?: string | null;
+  /** 关联已注册 Repository（单一事实源指针）；选定后后端派生 cwd/baseline，二者可留空。 */
+  repository_id?: string | null;
   verification_command?: string | null;
   max_iterations?: number | null;
   max_cost_usd?: number | null;

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0074_create_repositories.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0074_create_repositories.py
@@ -1,0 +1,107 @@
+"""创建 repositories 表 —— GitHub 地址 + 本地仓库根路径 + 基线分支锚点资源（第 5 类 plugin）。
+
+Revision ID: 0074
+Revises: 0073
+Create Date: 2026-06-26 00:00:00.000000+00:00
+
+设计动机：
+    把「引擎主机上已 clone 的本地仓库根路径 + GitHub 地址 + 基线分支」注册为可复用资源，
+    供 Routine 下拉选择并派生隔离 worktree 的 cwd/baseline_branch（见 models/repository.py）。
+    权限模型完全复用 plugin 体系（owner_id + visibility + is_system）。
+
+幂等性：
+    建表前以 information_schema 探测表存在性（仿 0054 范式），便于半失败重试。
+
+枚举复用：
+    visibility 列复用 0001 已建的 negentropy.pluginvisibility（create_type=False），
+    **绝不**重建 enum 类型，否则报 "type already exists"。downgrade 亦不 DROP TYPE
+    （该类型由 0001 拥有、被 mcp/skill/agent/builtin_tool 共用）。
+
+参考文献：
+[1] 0054_routine_worktree.py — information_schema 幂等 + schema 限定范式。
+[2] 0036_builtin_tools_visibility_enum.py — 复用既有 pluginvisibility（create_type=False）范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0074"
+down_revision: str | None = "0073"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_schema = :s AND table_name = :t"),
+            {"s": SCHEMA, "t": table_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _table_exists(bind, "repositories"):
+        return
+
+    # 复用 0001 已建的 enum；create_type=False 防重复 CREATE TYPE。
+    plugin_visibility = postgresql.ENUM(
+        "PRIVATE",
+        "SHARED",
+        "PUBLIC",
+        name="pluginvisibility",
+        schema=SCHEMA,
+        create_type=False,
+    )
+
+    op.create_table(
+        "repositories",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("owner_id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "visibility",
+            plugin_visibility,
+            nullable=False,
+            server_default=sa.text("'PRIVATE'::negentropy.pluginvisibility"),
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("github_url", sa.String(length=1024), nullable=False),
+        sa.Column("local_path", sa.Text(), nullable=False),
+        sa.Column("baseline_branch", sa.String(length=255), nullable=False),
+        sa.Column("default_remote", sa.String(length=255), nullable=False, server_default="origin"),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("is_system", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("config", postgresql.JSONB(), nullable=True, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("name", name="repositories_name_unique"),
+        schema=SCHEMA,
+    )
+    op.create_index("ix_repositories_owner", "repositories", ["owner_id"], schema=SCHEMA)
+    op.create_index("ix_repositories_visibility", "repositories", ["visibility"], schema=SCHEMA)
+    op.create_index("ix_repositories_is_system", "repositories", ["is_system"], schema=SCHEMA)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not _table_exists(bind, "repositories"):
+        return
+    op.drop_index("ix_repositories_is_system", table_name="repositories", schema=SCHEMA)
+    op.drop_index("ix_repositories_visibility", table_name="repositories", schema=SCHEMA)
+    op.drop_index("ix_repositories_owner", table_name="repositories", schema=SCHEMA)
+    op.drop_table("repositories", schema=SCHEMA)
+    # 不 DROP TYPE pluginvisibility —— 它由 0001 拥有、被 mcp/skill/agent/builtin_tool 共用。

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0075_routine_repository_id.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0075_routine_repository_id.py
@@ -1,0 +1,69 @@
+"""为 routines 新增可选 repository_id（FK→repositories.id, ondelete=SET NULL）。
+
+Revision ID: 0075
+Revises: 0074
+Create Date: 2026-06-26 00:00:01.000000+00:00
+
+设计动机：
+    Routine 以 ``repository_id`` 指针关联已注册 Repository（单一事实源）。非空时由
+    workspace.resolve_effective_repo 派生有效 cwd(=local_path)/baseline_branch；为空则
+    回退现有手填 cwd/baseline_branch（保留向后兼容，不破坏存量 Routine）。
+
+    ondelete=SET NULL：删除 Repository 仅把引用它的 routines.repository_id 置空（解除关联），
+    不级联删除 Routine；之后解析回退到手填值。
+
+幂等性：
+    加列 / 索引前以 information_schema 探测（仿 0054）。FK 目标表 repositories 由 0074 保证先建。
+
+参考文献：
+[1] 0054_routine_worktree.py — information_schema 幂等加列范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0075"
+down_revision: str | None = "0074"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :s AND table_name = :t AND column_name = :c"
+            ),
+            {"s": SCHEMA, "t": table_name, "c": column_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _column_exists(bind, "routines", "repository_id"):
+        op.add_column(
+            "routines",
+            sa.Column(
+                "repository_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey(f"{SCHEMA}.repositories.id", ondelete="SET NULL"),
+                nullable=True,
+                comment="可选关联 Repository（单一事实源指针）；非空时派生 cwd/baseline_branch；SET NULL 仅解除关联",
+            ),
+            schema=SCHEMA,
+        )
+        op.create_index("ix_routines_repository_id", "routines", ["repository_id"], schema=SCHEMA)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _column_exists(bind, "routines", "repository_id"):
+        op.drop_index("ix_routines_repository_id", table_name="routines", schema=SCHEMA)
+        op.drop_column("routines", "repository_id", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/engine/bootstrap.py
+++ b/apps/negentropy/src/negentropy/engine/bootstrap.py
@@ -433,6 +433,7 @@ def apply_adk_patches():
         from negentropy.engine.sessions_api import router as sessions_router
         from negentropy.interface.api import router as interface_router
         from negentropy.interface.models_api import router as interface_models_router
+        from negentropy.interface.repository_api import router as interface_repository_router
         from negentropy.interface.routine_api import router as interface_routine_router
         from negentropy.interface.scheduler_api import router as interface_scheduler_router
         from negentropy.interface.task_models_api import corpus_router as interface_task_models_corpus_router
@@ -573,6 +574,7 @@ def apply_adk_patches():
             app.include_router(interface_router)
             app.include_router(interface_models_router)
             app.include_router(interface_task_models_router)
+            app.include_router(interface_repository_router)
             logger.info("Interface API router mounted under /interface")
         if not any(route.path.startswith("/scheduler") for route in app.router.routes):
             app.include_router(interface_scheduler_router)

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -35,11 +35,13 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
 
 import negentropy.db.session as db_session
 from negentropy.config import settings
 from negentropy.logging import get_logger
 from negentropy.models.mcp import McpServer, McpTool
+from negentropy.models.repository import Repository
 from negentropy.models.routine import Routine, RoutineIteration, RoutineIterationEvent
 
 from . import decision as decision_mod
@@ -590,6 +592,8 @@ class RoutineOrchestrator:
             if routine is None or routine.status != "running" or latest is None or latest.status != "evaluating":
                 await self._reset_evaluating_to_executed(routine_id, iteration_id)
                 return
+            # 注入有效仓库配置（repository_id → cwd），使 gate cwd 快照（worktree_path 回退）正确。
+            await self._hydrate_effective_repo(db, routine)
             # PLAN 相位仅产出方案、未落盘任何实现，运行验证门控（如 uv run pytest）既无意义、
             # 又徒增 gate 超时延迟，且把「无实现自然失败」的门控输出喂给 Judge 会错误压低方案评分。
             # 故 PLAN 相位跳过门控（置空 verification_command），Judge 纯评估方案质量；
@@ -629,12 +633,16 @@ class RoutineOrchestrator:
             routine = await db.get(Routine, routine_id, with_for_update=True)
             latest = await db.get(RoutineIteration, iteration_id)
             if routine is None or routine.status != "running" or latest is None or latest.status != "evaluating":
+                # 注：此分支不读 cwd/baseline，无需 hydrate。
                 # 评估期间状态被改写（pause/cancel/reaped）→ 丢弃本次结果；仍 evaluating 则回退 executed
                 if latest is not None and latest.status == "evaluating":
                     latest.status = "executed"
                     latest.lease_expires_at = None
                     await db.commit()
                 return
+
+            # 注入有效仓库配置（repository_id → baseline），早于下方 is_worktree_routine 判定。
+            await self._hydrate_effective_repo(db, routine)
 
             if not result.ok:
                 # 评估失败：记录 + 计数；超阈值终止，否则回退 executed 供下轮重评（保留 eval_attempts）
@@ -806,6 +814,9 @@ class RoutineOrchestrator:
             for routine in routines:
                 if slots <= 0:
                     break
+                # 注入有效仓库配置（repository_id 指针 → cwd/baseline）——必须早于下方 baseline
+                # 守卫、is_phased/is_worktree 判定与 _ensure_workspace。
+                await self._hydrate_effective_repo(db, routine)
                 # 已有非终态迭代 → 跳过（每 routine 单在途）
                 if await self._has_active_iteration(db, routine.id):
                     continue
@@ -930,6 +941,8 @@ class RoutineOrchestrator:
                 routine = await db.get(Routine, it.routine_id)
                 if routine is None:
                     continue
+                # 注入有效仓库配置（repository_id → cwd/baseline），早于 _ensure_workspace / _build_config。
+                await self._hydrate_effective_repo(db, routine)
                 # 确保隔离 worktree 就绪（待审批迭代在此刻才创建工作区）。失败 → 终止 routine +
                 # 闭合该迭代为 aborted，跳过 launch。
                 if not await self._ensure_workspace(routine):
@@ -1321,6 +1334,27 @@ class RoutineOrchestrator:
                 error=str(exc),
             )
             return None
+
+    async def _hydrate_effective_repo(self, db: AsyncSession, routine: Routine) -> None:
+        """把关联 Repository 的 local_path/baseline_branch 注入内存 routine（单一事实源）。
+
+        Routine 仅持 ``repository_id`` 指针、不存 cwd/baseline 副本；本方法在 dispatch / evaluate
+        装载 routine 后、**任何** ``is_worktree_routine`` / baseline 判定与 ``ensure_worktree`` 之前
+        调用，用 ``set_committed_value`` 把有效 cwd/baseline 写入内存对象——该 API 将值标记为
+        「已从 DB 加载」，**不进 session.dirty**，故同事务对 ``worktree_path``/``work_branch``/评分等
+        的 commit 不会把派生值持久化进 ``routines`` 行（DB 中 cwd/baseline_branch 保持原值，避免副本）。
+
+        ``repository_id`` 为空 → no-op（沿用手填 cwd/baseline_branch）；Repository 已删（FK SET NULL
+        竞态）→ 回退手填值，不抛。
+        """
+        if routine.repository_id is None:
+            return
+        repository = await db.get(Repository, routine.repository_id)
+        if repository is None:
+            return
+        eff_cwd, eff_baseline = workspace.resolve_effective_repo(routine, repository)
+        set_committed_value(routine, "cwd", eff_cwd)
+        set_committed_value(routine, "baseline_branch", eff_baseline)
 
     async def _ensure_workspace(self, routine: Routine) -> bool:
         """worktree routine：确保隔离 worktree 就绪并把 ``worktree_path``/``work_branch`` 写回

--- a/apps/negentropy/src/negentropy/engine/routine/workspace.py
+++ b/apps/negentropy/src/negentropy/engine/routine/workspace.py
@@ -64,6 +64,13 @@ class _RoutineLike(Protocol):
     worktree_path: str | None
 
 
+class _RepositoryLike(Protocol):
+    """已注册 Repository 的最小契约：派生隔离 worktree 所需的本地根 + 基线分支。"""
+
+    local_path: str
+    baseline_branch: str
+
+
 @dataclass(frozen=True, slots=True)
 class WorkspaceInfo:
     """隔离工作区句柄：worktree 路径（= CC 实际 cwd）+ 工作分支名。"""
@@ -233,6 +240,70 @@ async def _try_fetch(project_path: str, baseline_branch: str, settings: RoutineS
     )
     if rc != 0:
         logger.info("routine_worktree_fetch_skipped", baseline=baseline_branch, detail=err[:200])
+
+
+# ---------------------------------------------------------------------------
+# 有效仓库配置解析（单一事实源：Routine 持 repository_id 指针，不存副本）
+# ---------------------------------------------------------------------------
+
+
+def resolve_effective_repo(routine: _RoutineLike, repository: _RepositoryLike | None) -> tuple[str | None, str | None]:
+    """解析 routine 的「有效仓库配置」(cwd, baseline_branch)（纯函数，无 IO）。
+
+    单一事实源：Routine 仅持有 ``repository_id`` 指针（FK），不复制 Repository 的
+    local_path/baseline_branch 副本。调用方负责在 ``repository_id`` 非空时预取 Repository
+    并传入；本函数据此选取权威值：
+
+    - ``repository`` 非空 → ``(repository.local_path, repository.baseline_branch)``（指针优先）。
+    - ``repository`` 为空（未关联 / 已删 / 竞态）→ 回退手填 ``(routine.cwd, routine.baseline_branch)``。
+
+    对 ``repository=None`` 安全回退（不抛），故 FK ``SET NULL`` 后仍优雅降级到手填配置。
+    """
+    if repository is not None:
+        return repository.local_path, repository.baseline_branch
+    return routine.cwd, routine.baseline_branch
+
+
+async def list_branches(
+    project_path: str | None,
+    settings: RoutineSettings,
+    *,
+    fetch: bool | None = None,
+) -> dict[str, list[str] | str]:
+    """枚举本地仓库的本地分支 + 远端跟踪分支（供前端基线分支下拉）。
+
+    校验 ``project_path`` 为已存在的 git 工作树（非法抛 ``WorkspaceError`` → API 转 422）。
+    best-effort ``git fetch <remote>``（默认随 ``settings.git_fetch_before_worktree``，失败不阻断）
+    后以 ``branch --format`` 枚举：
+
+    - ``local``：``git -C <p> branch --format=%(refname:short)``。
+    - ``remote``：``git -C <p> branch -r --format=%(refname:short)``（剔除 ``<remote>/HEAD`` 指针）。
+
+    Returns:
+        ``{"local": [...], "remote": [...], "default_remote": settings.git_remote}``。
+    """
+    if not project_path:
+        raise WorkspaceError("分支枚举需提供本地仓库根路径（local_path）")
+    if not os.path.isdir(project_path):
+        raise WorkspaceError(f"本地仓库路径不存在：'{project_path}'")
+
+    timeout = float(settings.git_timeout_seconds)
+    rc, out, _ = await _run_git(["-C", project_path, "rev-parse", "--is-inside-work-tree"], timeout=timeout)
+    if rc != 0 or out.strip() != "true":
+        raise WorkspaceError(f"路径不是 git 工作树：'{project_path}'")
+
+    do_fetch = settings.git_fetch_before_worktree if fetch is None else fetch
+    if do_fetch:
+        # best-effort 全量 fetch（失败不阻断；不指定 base 以拉全部远端分支供下拉）。
+        await _run_git(["-C", project_path, "fetch", settings.git_remote], timeout=timeout)
+
+    rc, out, _ = await _run_git(["-C", project_path, "branch", "--format=%(refname:short)"], timeout=timeout)
+    local = [ln.strip() for ln in out.splitlines() if ln.strip()] if rc == 0 else []
+
+    rc, out, _ = await _run_git(["-C", project_path, "branch", "-r", "--format=%(refname:short)"], timeout=timeout)
+    remote = [ln.strip() for ln in out.splitlines() if ln.strip() and "/HEAD" not in ln] if rc == 0 else []
+
+    return {"local": local, "remote": remote, "default_remote": settings.git_remote}
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +578,8 @@ __all__ = [
     "WorkspaceError",
     "WorkspaceInfo",
     "validate_repo",
+    "list_branches",
+    "resolve_effective_repo",
     "ensure_worktree",
     "remove_worktree",
     "normalize_base_branch",

--- a/apps/negentropy/src/negentropy/interface/permissions.py
+++ b/apps/negentropy/src/negentropy/interface/permissions.py
@@ -17,6 +17,7 @@ from negentropy.models.plugin import (
     PluginPermission,
     PluginPermissionType,
     PluginVisibility,
+    Repository,
     Skill,
 )
 
@@ -29,6 +30,7 @@ PLUGIN_TYPE_MODEL_MAP = {
     "skill": Skill,
     "agent": Agent,
     "builtin_tool": BuiltinTool,
+    "repository": Repository,
 }
 
 

--- a/apps/negentropy/src/negentropy/interface/repository_api.py
+++ b/apps/negentropy/src/negentropy/interface/repository_api.py
@@ -1,0 +1,280 @@
+"""/interface/repositories/* —— Repository 资源 CRUD + 分支枚举。
+
+定位：
+    把「引擎主机上已 clone 的本地仓库根路径 + GitHub 地址 + 基线分支」注册为可复用资源，
+    供 Routine 下拉选择（见 routine_api 的 ``repository_id``）。Repository 是与
+    mcp/skill/agent/builtin_tool 并列的第 5 类 plugin 资源，复用 permissions 的可见性体系
+    （owner_id + visibility + is_system + check_plugin_*）。
+
+端点风格对齐 interface/api.py 的 McpServer：AsyncSessionLocal + Depends(get_current_user)
++ permissions.check_plugin_* + _repository_to_response。注册时调用 workspace.validate_repo
+对本地仓库根 + 基线分支做即时校验（非法转 422），并提供 /inspect 枚举分支供前端基线下拉。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
+
+import negentropy.db.session as db_session
+from negentropy.auth.deps import get_current_user
+from negentropy.auth.service import AuthUser
+from negentropy.config import settings
+from negentropy.engine.routine import workspace
+from negentropy.logging import get_logger
+from negentropy.models.plugin import PluginVisibility, Repository
+
+from .permissions import check_plugin_access, check_plugin_ownership, get_visible_plugin_ids
+
+logger = get_logger("negentropy.interface.repository_api")
+
+router = APIRouter(prefix="/interface/repositories", tags=["interface"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Request / Response
+# ---------------------------------------------------------------------------
+
+
+class RepositoryCreateRequest(BaseModel):
+    name: str
+    display_name: str | None = None
+    description: str | None = None
+    github_url: str
+    local_path: str
+    baseline_branch: str
+    default_remote: str = "origin"
+    is_enabled: bool = True
+    config: dict[str, Any] = Field(default_factory=dict)
+    visibility: str = "private"
+
+
+class RepositoryUpdateRequest(BaseModel):
+    name: str | None = None
+    display_name: str | None = None
+    description: str | None = None
+    github_url: str | None = None
+    local_path: str | None = None
+    baseline_branch: str | None = None
+    default_remote: str | None = None
+    is_enabled: bool | None = None
+    config: dict[str, Any] | None = None
+    visibility: str | None = None
+
+
+class RepositoryResponse(BaseModel):
+    id: UUID
+    owner_id: str
+    visibility: str
+    name: str
+    display_name: str | None = None
+    description: str | None = None
+    github_url: str
+    local_path: str
+    baseline_branch: str
+    default_remote: str = "origin"
+    is_enabled: bool = True
+    is_builtin: bool = False
+    config: dict[str, Any] = Field(default_factory=dict)
+    sort_order: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+class BranchInspectRequest(BaseModel):
+    local_path: str
+    fetch: bool | None = None  # None=随 settings.git_fetch_before_worktree
+
+
+class BranchInspectResponse(BaseModel):
+    local: list[str] = Field(default_factory=list)
+    remote: list[str] = Field(default_factory=list)
+    default_remote: str = "origin"
+
+
+def _repository_to_response(repo: Repository) -> RepositoryResponse:
+    return RepositoryResponse(
+        id=repo.id,
+        owner_id=repo.owner_id,
+        visibility=repo.visibility.value,
+        name=repo.name,
+        display_name=repo.display_name,
+        description=repo.description,
+        github_url=repo.github_url,
+        local_path=repo.local_path,
+        baseline_branch=repo.baseline_branch,
+        default_remote=repo.default_remote,
+        is_enabled=repo.is_enabled,
+        is_builtin=bool(repo.is_system),
+        config=repo.config or {},
+        sort_order=repo.sort_order,
+    )
+
+
+async def _validate_local_repo(local_path: str, baseline_branch: str) -> None:
+    """复用 workspace.validate_repo：校验 local_path 是 git 工作树 + baseline 可解析；非法转 422。"""
+    try:
+        await workspace.validate_repo(local_path, baseline_branch, settings.routine)
+    except workspace.WorkspaceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# 分支枚举（供前端注册时基线下拉）
+# ---------------------------------------------------------------------------
+
+
+@router.post("/inspect", response_model=BranchInspectResponse)
+async def inspect_repository_branches(
+    payload: BranchInspectRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> BranchInspectResponse:
+    """读取 local_path 的本地 + 远端跟踪分支（best-effort fetch 后），供注册时基线下拉。
+
+    用 local_path 而非 repository_id —— 注册流程在 Repo 保存前即需枚举分支。
+    """
+    try:
+        result = await workspace.list_branches(payload.local_path, settings.routine, fetch=payload.fetch)
+    except workspace.WorkspaceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return BranchInspectResponse(
+        local=list(result.get("local", [])),
+        remote=list(result.get("remote", [])),
+        default_remote=str(result.get("default_remote", "origin")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=list[RepositoryResponse])
+async def list_repositories(user: AuthUser = Depends(get_current_user)) -> list[RepositoryResponse]:
+    """列出当前用户可见的 Repository（owner / public / shared / system）。"""
+    async with db_session.AsyncSessionLocal() as db:
+        visible_ids = await get_visible_plugin_ids(db, "repository", user)
+        if not visible_ids:
+            return []
+        stmt = (
+            select(Repository)
+            .where(Repository.id.in_(visible_ids))
+            .order_by(Repository.sort_order.asc(), Repository.created_at.desc())
+        )
+        repos = (await db.execute(stmt)).scalars().all()
+        return [_repository_to_response(r) for r in repos]
+
+
+@router.post("", response_model=RepositoryResponse, status_code=status.HTTP_201_CREATED)
+async def create_repository(
+    payload: RepositoryCreateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> RepositoryResponse:
+    """注册新 Repository：先校验本地仓库根 + 基线分支，再落库。"""
+    await _validate_local_repo(payload.local_path, payload.baseline_branch)
+    async with db_session.AsyncSessionLocal() as db:
+        existing = await db.scalar(select(Repository).where(Repository.name == payload.name))
+        if existing:
+            raise HTTPException(status_code=400, detail="Repository name already exists")
+        repo = Repository(
+            owner_id=user.user_id,
+            visibility=PluginVisibility(payload.visibility),
+            name=payload.name,
+            display_name=payload.display_name,
+            description=payload.description,
+            github_url=payload.github_url,
+            local_path=payload.local_path,
+            baseline_branch=payload.baseline_branch,
+            default_remote=payload.default_remote,
+            is_enabled=payload.is_enabled,
+            config=payload.config,
+        )
+        db.add(repo)
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            # 唯一约束兜底并发竞态（查重后落库前的窗口）。
+            await db.rollback()
+            raise HTTPException(status_code=409, detail="Repository name already exists") from exc
+        await db.refresh(repo)
+    return _repository_to_response(repo)
+
+
+@router.get("/{repository_id}", response_model=RepositoryResponse)
+async def get_repository(
+    repository_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> RepositoryResponse:
+    async with db_session.AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "repository", repository_id, user, "view")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+        repo = await db.get(Repository, repository_id)
+        if not repo:
+            raise HTTPException(status_code=404, detail="Repository not found")
+    return _repository_to_response(repo)
+
+
+@router.patch("/{repository_id}", response_model=RepositoryResponse)
+async def update_repository(
+    repository_id: UUID,
+    payload: RepositoryUpdateRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> RepositoryResponse:
+    async with db_session.AsyncSessionLocal() as db:
+        has_access, error = await check_plugin_access(db, "repository", repository_id, user, "edit")
+        if not has_access:
+            raise HTTPException(status_code=403, detail=error)
+        repo = await db.get(Repository, repository_id)
+        if not repo:
+            raise HTTPException(status_code=404, detail="Repository not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+        if "name" in update_data:
+            new_name = str(update_data["name"] or "").strip()
+            if not new_name:
+                raise HTTPException(status_code=400, detail="Repository name cannot be empty")
+            if new_name != repo.name:
+                dup = await db.scalar(
+                    select(Repository).where(and_(Repository.name == new_name, Repository.id != repository_id))
+                )
+                if dup:
+                    raise HTTPException(status_code=400, detail="Repository name already exists")
+            update_data["name"] = new_name
+        if "visibility" in update_data:
+            update_data["visibility"] = PluginVisibility(update_data["visibility"])
+
+        # local_path / baseline_branch 任一变更 → 以合并后的有效值重新校验。
+        if ("local_path" in update_data) or ("baseline_branch" in update_data):
+            eff_path = update_data.get("local_path", repo.local_path)
+            eff_base = update_data.get("baseline_branch", repo.baseline_branch)
+            await _validate_local_repo(eff_path, eff_base)
+
+        for key, value in update_data.items():
+            setattr(repo, key, value)
+        await db.commit()
+        await db.refresh(repo)
+    return _repository_to_response(repo)
+
+
+@router.delete("/{repository_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_repository(
+    repository_id: UUID,
+    user: AuthUser = Depends(get_current_user),
+) -> None:
+    """删除 Repository（仅 owner）。引用它的 Routine 经 FK SET NULL 自动解除关联、回退手填配置。"""
+    async with db_session.AsyncSessionLocal() as db:
+        is_owner, error = await check_plugin_ownership(db, "repository", repository_id, user)
+        if not is_owner:
+            raise HTTPException(status_code=403, detail=error)
+        repo = await db.get(Repository, repository_id)
+        if not repo:
+            raise HTTPException(status_code=404, detail="Repository not found")
+        await db.delete(repo)
+        await db.commit()

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -48,6 +48,7 @@ from negentropy.config import settings
 from negentropy.engine.routine import phase as phase_mod
 from negentropy.engine.routine import workspace
 from negentropy.logging import get_logger
+from negentropy.models.repository import Repository
 from negentropy.models.routine import Routine, RoutineIteration, RoutineIterationEvent
 
 logger = get_logger("negentropy.interface.routine_api")
@@ -123,6 +124,9 @@ class RoutineCreateRequest(BaseModel):
     acceptance_criteria: str = Field(..., min_length=1)
     cwd: str | None = None
     baseline_branch: str | None = Field(default=None, max_length=255)
+    # 可选关联的已注册 Repository（单一事实源指针）：非空时派生有效 cwd/baseline_branch，
+    # 此时 cwd/baseline_branch 手填值可留空（不复制副本）。
+    repository_id: UUID | None = None
     verification_command: str | None = None
     max_iterations: int | None = Field(default=None, ge=1, le=1000)
     max_cost_usd: float | None = Field(default=None, ge=0)
@@ -144,6 +148,7 @@ class RoutineUpdateRequest(BaseModel):
     acceptance_criteria: str | None = None
     cwd: str | None = None
     baseline_branch: str | None = Field(default=None, max_length=255)
+    repository_id: UUID | None = None
     verification_command: str | None = None
     max_iterations: int | None = Field(default=None, ge=1, le=1000)
     max_cost_usd: float | None = Field(default=None, ge=0)
@@ -185,6 +190,7 @@ def _serialize_routine(
         "acceptance_criteria": r.acceptance_criteria,
         "cwd": r.cwd,
         "baseline_branch": r.baseline_branch,
+        "repository_id": str(r.repository_id) if r.repository_id else None,
         "verification_command": r.verification_command,
         "status": r.status,
         "termination_reason": r.termination_reason,
@@ -620,19 +626,54 @@ def _validate_read_dirs(config: dict[str, Any] | None) -> None:
             raise HTTPException(status_code=422, detail=f"read_dir does not exist or is not a directory: '{d}'")
 
 
-@router.post("")
-async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
-    if body.cwd and not os.path.isdir(body.cwd):
-        raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{body.cwd}'")
-    _validate_read_dirs(body.config)
-    # 提供了 Project Path (cwd) + Baseline Branch 时即时校验仓库/基线（早反馈）。存在性的硬约束
-    # 由 start 守卫强制（执行前提），允许 API 侧先创建草稿；前端创建可执行 routine 时已强制二者。
-    if body.cwd and body.baseline_branch:
+async def _resolve_repository(db, repository_id: UUID | None) -> Repository | None:
+    """repository_id 非空时取 Repository（缺失→422，供 API 早反馈）；否则 None。"""
+    if repository_id is None:
+        return None
+    repo = await db.get(Repository, repository_id)
+    if repo is None:
+        raise HTTPException(status_code=422, detail=f"repository not found: {repository_id}")
+    return repo
+
+
+async def _validate_effective_repo(eff_cwd: str | None, eff_baseline: str | None) -> None:
+    """二者皆有值时即时校验仓库/基线（非法转 422）。允许草稿态暂缺其一。"""
+    if eff_cwd and eff_baseline:
         try:
-            await workspace.validate_repo(body.cwd, body.baseline_branch, settings.routine)
+            await workspace.validate_repo(eff_cwd, eff_baseline, settings.routine)
         except workspace.WorkspaceError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+async def _require_effective_repo(db, r: Routine, *, validate: bool) -> None:
+    """start/resume/restart 守卫：非模板 routine 须具备有效仓库配置（repository_id 指针优先）。
+
+    缺失（手填与 Repo 皆未提供）→ 409；validate=True 时额外 workspace.validate_repo（start 用）。
+    """
+    repository = await _resolve_repository(db, r.repository_id)
+    eff_cwd, eff_baseline = workspace.resolve_effective_repo(r, repository)
+    if not (eff_cwd and eff_baseline):
+        raise HTTPException(
+            status_code=409,
+            detail="需补全 Project Path (cwd) 与 Baseline Branch，或选择已注册 Repository（隔离 worktree 的前提）",
+        )
+    if validate:
+        await _validate_effective_repo(eff_cwd, eff_baseline)
+
+
+@router.post("")
+async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
+    _validate_read_dirs(body.config)
     async with db_session.AsyncSessionLocal() as db:
+        # 解析有效仓库配置（repository_id 指针优先；否则手填 cwd/baseline）。
+        repository = await _resolve_repository(db, body.repository_id)
+        eff_cwd = repository.local_path if repository is not None else body.cwd
+        eff_baseline = repository.baseline_branch if repository is not None else body.baseline_branch
+        # 未关联 Repo 且手填 cwd 时校验目录存在（早反馈）；关联 Repo 时由 validate_repo 统一校验。
+        if repository is None and body.cwd and not os.path.isdir(body.cwd):
+            raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{body.cwd}'")
+        # 即时校验有效仓库/基线（二者皆有值时）；存在性硬约束由 start 守卫强制，允许先创建草稿。
+        await _validate_effective_repo(eff_cwd, eff_baseline)
         routine = Routine(
             key=body.key,
             title=body.title,
@@ -640,6 +681,7 @@ async def create_routine(body: RoutineCreateRequest) -> dict[str, Any]:
             acceptance_criteria=body.acceptance_criteria,
             cwd=body.cwd,
             baseline_branch=body.baseline_branch,
+            repository_id=body.repository_id,
             verification_command=body.verification_command,
             status="pending",
             max_iterations=body.max_iterations
@@ -699,23 +741,26 @@ async def update_routine(routine_id: UUID, body: RoutineUpdateRequest) -> dict[s
                     detail=f"cannot edit {', '.join(sorted(unsafe))} while running; pause first",
                 )
 
-        # cwd 目录存在性校验（非 running 路径，unsafe 已被上方拦截）
-        if "cwd" in update_data and update_data["cwd"] and not os.path.isdir(update_data["cwd"]):
-            raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{update_data['cwd']}'")
         if "config" in update_data:
             _validate_read_dirs(update_data["config"])
 
         for field_name, value in update_data.items():
             setattr(r, field_name, value)
 
-        # 校验合并后的仓库/基线（仅当二者皆有值时即时校验；强制性由 create + start 守卫保证，
-        # 允许增量编辑期间暂缺其一）。
-        if not r.is_template and r.cwd and r.baseline_branch:
+        # 解析合并后的有效仓库配置（repository_id 指针优先；否则手填 cwd/baseline）。
+        repository = await _resolve_repository(db, r.repository_id)
+        eff_cwd, eff_baseline = workspace.resolve_effective_repo(r, repository)
+        # 未关联 Repo 且手填 cwd 非空 → 校验目录存在（非 running 路径，unsafe 已被上方拦截）。
+        if repository is None and r.cwd and not os.path.isdir(r.cwd):
+            raise HTTPException(status_code=422, detail=f"cwd directory does not exist: '{r.cwd}'")
+        # 校验合并后的有效仓库/基线（仅当二者皆有值时；强制性由 create + start 守卫保证，
+        # 允许增量编辑期间暂缺其一）。模板跳过。
+        if not r.is_template:
             try:
-                await workspace.validate_repo(r.cwd, r.baseline_branch, settings.routine)
-            except workspace.WorkspaceError as exc:
+                await _validate_effective_repo(eff_cwd, eff_baseline)
+            except HTTPException:
                 await db.rollback()
-                raise HTTPException(status_code=422, detail=str(exc)) from exc
+                raise
 
         if r.status == "running" and update_data:
             logger.info("routine_runtime_update", routine_id=str(routine_id), fields=sorted(update_data.keys()))
@@ -775,18 +820,10 @@ async def start_routine(routine_id: UUID, body: ControlBody | None = None) -> di
             raise HTTPException(status_code=404, detail="routine not found")
         if r.status not in ("pending", "paused"):
             raise HTTPException(status_code=409, detail=f"cannot start from status '{r.status}'")
-        # worktree 隔离守卫（执行硬前提）：可执行 routine 启动前须具备 Project Path (cwd) +
-        # Baseline Branch（保护未回填的旧行；模板不在此路径启动），并校验仓库/基线可用。
+        # worktree 隔离守卫（执行硬前提）：可执行 routine 启动前须具备有效仓库配置
+        # （repository_id 指针优先，否则手填 cwd + baseline_branch；模板不在此路径启动），并校验可用。
         if not r.is_template:
-            if not (r.cwd and r.baseline_branch):
-                raise HTTPException(
-                    status_code=409,
-                    detail="启动前需补全 Project Path (cwd) 与 Baseline Branch（隔离 worktree 的前提）",
-                )
-            try:
-                await workspace.validate_repo(r.cwd, r.baseline_branch, settings.routine)
-            except workspace.WorkspaceError as exc:
-                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            await _require_effective_repo(db, r, validate=True)
         r.status = "running"
         r.termination_reason = None
         await db.commit()
@@ -823,13 +860,9 @@ async def resume_routine(routine_id: UUID, body: ControlBody | None = None) -> d
             raise HTTPException(status_code=404, detail="routine not found")
         if r.status != "paused":
             raise HTTPException(status_code=409, detail=f"cannot resume from status '{r.status}'")
-        # worktree 隔离守卫（与 start 端点对齐）：非模板 routine 恢复前须具备 cwd + baseline_branch。
+        # worktree 隔离守卫（与 start 端点对齐）：非模板 routine 恢复前须具备有效仓库配置。
         if not r.is_template:
-            if not (r.cwd and r.baseline_branch):
-                raise HTTPException(
-                    status_code=409,
-                    detail="恢复前需补全 Project Path (cwd) 与 Baseline Branch（隔离 worktree 的前提）",
-                )
+            await _require_effective_repo(db, r, validate=False)
         r.status = "running"
         await db.commit()
         await db.refresh(r)
@@ -883,13 +916,9 @@ async def restart_routine(routine_id: UUID, body: RestartBody | None = None) -> 
                     status_code=409,
                     detail="deadline has passed; update or clear the deadline before restarting",
                 )
-        # worktree 隔离守卫（与 start 端点对齐）：非模板 routine 重启前须具备 cwd + baseline_branch。
+        # worktree 隔离守卫（与 start 端点对齐）：非模板 routine 重启前须具备有效仓库配置。
         if not r.is_template:
-            if not (r.cwd and r.baseline_branch):
-                raise HTTPException(
-                    status_code=409,
-                    detail="重启前需补全 Project Path (cwd) 与 Baseline Branch（隔离 worktree 的前提）",
-                )
+            await _require_effective_repo(db, r, validate=False)
 
         # 闭合上一轮遗留的全部非终态迭代（含 executed）。终态 routine 理论上不应有在途迭代，
         # 但 cancel 会保留 executed 迭代、且崩溃/reaper 竞态可能遗留孤儿；若不闭合，重启后

--- a/apps/negentropy/src/negentropy/models/__init__.py
+++ b/apps/negentropy/src/negentropy/models/__init__.py
@@ -26,6 +26,7 @@ from .perception import (
 )
 from .plugin_common import PluginPermission, PluginPermissionType, PluginVisibility
 from .pulse import Event, Thread
+from .repository import Repository
 from .routine import Routine, RoutineIteration
 from .scheduled_task import ScheduledTask, TaskExecution
 from .security import Credential
@@ -101,6 +102,8 @@ __all__ = [
     # Scheduled Task (统一心跳调度)
     "ScheduledTask",
     "TaskExecution",
+    # Repository (本地仓库锚点 — 第 5 类 plugin 资源)
+    "Repository",
     # Routine (长周期自主任务迭代)
     "Routine",
     "RoutineIteration",

--- a/apps/negentropy/src/negentropy/models/plugin.py
+++ b/apps/negentropy/src/negentropy/models/plugin.py
@@ -14,4 +14,5 @@ from .builtin_tool import BuiltinTool, ensure_dict  # noqa: F401
 from .mcp import McpResourceTemplate, McpServer, McpTool  # noqa: F401
 from .mcp_runtime import McpToolRun, McpToolRunEvent, McpTrialAsset  # noqa: F401
 from .plugin_common import PluginPermission, PluginPermissionType, PluginVisibility  # noqa: F401
+from .repository import Repository  # noqa: F401
 from .skill import Skill, SkillSchedule, SkillVersion  # noqa: F401

--- a/apps/negentropy/src/negentropy/models/repository.py
+++ b/apps/negentropy/src/negentropy/models/repository.py
@@ -1,0 +1,75 @@
+"""Repository 资源 — GitHub 地址 + 引擎主机本地仓库根路径 + 基线分支锚点。
+
+定位（与 mcp/skill/agent/builtin_tool 并列的第 5 类 plugin 资源）：
+    Repository 把「引擎主机上已 clone 的本地仓库根路径」+ GitHub 地址 + 基线分支注册为
+    可复用资源。Routine 选定某 Repository 后，从中派生隔离 worktree 所需的 cwd(=local_path)
+    与 baseline_branch。本资源**不引入任何 clone 远程仓库的逻辑** —— worktree 仍由
+    engine/routine/workspace.py 基于 local_path 创建（fetch 基线最新 → 建隔离工作分支）。
+
+权限模型：
+    完全复用 plugin 体系（owner_id + visibility + is_system + permissions.check_plugin_*）。
+    通过 permissions.PLUGIN_TYPE_MODEL_MAP 的 "repository" 键接入，无需新增权限代码。
+
+单一事实源：
+    Routine 仅持有 ``repository_id`` 指针（FK，ondelete=SET NULL），**不**复制 Repository 的
+    local_path/baseline_branch 副本；有效配置在校验 / dispatch 时解析（见
+    workspace.resolve_effective_repo）。
+"""
+
+from typing import Any
+
+from sqlalchemy import Boolean, Enum, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin
+from .plugin_common import PluginVisibility
+
+
+class Repository(Base, UUIDMixin, TimestampMixin):
+    """已注册的本地仓库锚点（GitHub 地址 + 本地根路径 + 基线分支）。"""
+
+    __tablename__ = "repositories"
+
+    # --- 所有权与可见性（对齐 McpServer / Skill / Agent）---
+    owner_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    visibility: Mapped[PluginVisibility] = mapped_column(
+        Enum(PluginVisibility, schema=NEGENTROPY_SCHEMA), nullable=False, default=PluginVisibility.PRIVATE
+    )
+
+    # --- 基本信息 ---
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(255))
+    description: Mapped[str | None] = mapped_column(Text)
+
+    # --- Repository 专属锚点 ---
+    # GitHub 远程地址（展示 / 溯源用；不触发任何 clone）。
+    github_url: Mapped[str] = mapped_column(String(1024), nullable=False)
+    # 引擎主机上已 clone 的本地仓库根路径（= Routine 派生的 cwd / git worktree 的 project_path）。
+    local_path: Mapped[str] = mapped_column(Text, nullable=False)
+    # 基线分支 + PR base（如 origin/feature/1.x.x）；注册时由分支枚举端点提供下拉候选。
+    baseline_branch: Mapped[str] = mapped_column(String(255), nullable=False)
+    # fetch / PR base 归一所用的 git 远端名（对齐 RoutineSettings.git_remote 默认）。
+    default_remote: Mapped[str] = mapped_column(String(255), nullable=False, default="origin", server_default="origin")
+
+    # --- 状态与配置（对齐 McpServer）---
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    # 「系统内置」标识：与 McpServer.is_system / BuiltinTool.is_system 对齐，
+    # 作为 permissions._is_plugin_builtin 的可见性 / 权限判断单一事实源。
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, server_default="{}")
+
+    # 排序：前端拖拽排序后的持久化序号（预留），值越小越靠前。
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+
+    __table_args__ = (
+        # 唯一约束放 name —— 允许同一 GitHub repo 以不同 name / baseline 注册多条。
+        UniqueConstraint("name", name="repositories_name_unique"),
+        Index("ix_repositories_owner", "owner_id"),
+        Index("ix_repositories_visibility", "visibility"),
+        Index("ix_repositories_is_system", "is_system"),
+        {"schema": NEGENTROPY_SCHEMA},
+    )
+
+
+__all__ = ["Repository"]

--- a/apps/negentropy/src/negentropy/models/routine.py
+++ b/apps/negentropy/src/negentropy/models/routine.py
@@ -42,7 +42,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin
+from .base import NEGENTROPY_SCHEMA, Base, TimestampMixin, UUIDMixin, fk
 
 
 class Routine(Base, UUIDMixin, TimestampMixin):
@@ -68,6 +68,10 @@ class Routine(Base, UUIDMixin, TimestampMixin):
     key: Mapped[str] = mapped_column(String(192), unique=True, nullable=False)
     owner_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     agent_id: Mapped[UUID | None] = mapped_column(PG_UUID(as_uuid=True), nullable=True)
+    # 可选关联的已注册 Repository（单一事实源指针）：非空时由 worktree.resolve_effective_repo
+    # 派生有效 cwd(=local_path)/baseline_branch；为空则回退手填的 cwd/baseline_branch。
+    # ondelete=SET NULL：删除 Repository 仅解除关联，不级联删 Routine。
+    repository_id: Mapped[UUID | None] = mapped_column(fk("repositories", ondelete="SET NULL"), nullable=True)
 
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -166,6 +170,7 @@ class Routine(Base, UUIDMixin, TimestampMixin):
         Index("ix_routines_status", "status"),
         Index("ix_routines_owner", "owner_id"),
         Index("ix_routines_is_template", "is_template"),
+        Index("ix_routines_repository_id", "repository_id"),
         {"schema": NEGENTROPY_SCHEMA},
     )
 

--- a/apps/negentropy/tests/integration_tests/interface/test_repository_api.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_repository_api.py
@@ -1,0 +1,305 @@
+"""Repository API + Routine 关联 全链路集成测试 — 真实 Postgres + ASGI + 真实 git。
+
+覆盖：
+- Repository CRUD：create / 非法 local_path 422 / 重复 name 400 / list / get / patch / delete 204
+- 分支枚举：POST /inspect 返回分支；非法路径 422
+- Routine 关联：带 repository_id 创建（cwd/baseline 留空仍过校验）→ 序列化含 repository_id；
+  start 守卫用 Repo 派生配置放行；running 改 repository_id → 409；删除 Repo → FK SET NULL 回退
+- 单一事实源红线：_hydrate_effective_repo 注入内存有效 cwd/baseline，dispatch commit 后
+  DB routines.cwd/baseline_branch 仍为 NULL（不被副本污染）
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from sqlalchemy import delete
+
+import negentropy.db.session as db_session
+from negentropy.auth.deps import get_current_user
+from negentropy.auth.service import AuthUser
+from negentropy.engine.routine.orchestrator import RoutineOrchestrator
+from negentropy.interface.repository_api import router as repo_router
+from negentropy.interface.routine_api import router as routine_router
+from negentropy.models.plugin import PluginVisibility, Repository
+from negentropy.models.routine import Routine
+
+pytestmark = pytest.mark.asyncio
+
+
+def _name() -> str:
+    return f"itest_repo_{uuid.uuid4().hex[:8]}"
+
+
+def _key() -> str:
+    return f"itest_repo_rt_{uuid.uuid4().hex[:8]}"
+
+
+def _user() -> AuthUser:
+    return AuthUser(
+        user_id="itest_repo_user",
+        email=None,
+        name=None,
+        picture=None,
+        roles=["user"],
+        provider="test",
+        subject="itest_repo_user",
+        domain=None,
+    )
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(repo_router)
+    app.include_router(routine_router)
+    app.dependency_overrides[get_current_user] = _user
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def _cleanup(name_prefix: str, key_prefix: str) -> None:
+    async with db_session.AsyncSessionLocal() as db:
+        await db.execute(delete(Routine).where(Routine.key.like(f"{key_prefix}%")))
+        await db.execute(delete(Repository).where(Repository.name.like(f"{name_prefix}%")))
+        await db.commit()
+
+
+@pytest.fixture(scope="module")
+def git_repo(tmp_path_factory) -> str:
+    """模块级临时 git 仓库（含 main + feature/x 分支），供注册校验与分支枚举。"""
+    repo = tmp_path_factory.mktemp("repo_api_repo")
+    p = str(repo)
+    subprocess.run(["git", "init", "-q", p], check=True)
+    subprocess.run(["git", "-C", p, "config", "user.email", "t@t.io"], check=True)
+    subprocess.run(["git", "-C", p, "config", "user.name", "t"], check=True)
+    (repo / "README.md").write_text("# repo\n")
+    subprocess.run(["git", "-C", p, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", p, "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", p, "branch", "-M", "main"], check=True)
+    subprocess.run(["git", "-C", p, "branch", "feature/x"], check=True)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Repository CRUD + inspect
+# ---------------------------------------------------------------------------
+
+
+async def test_repository_crud_and_inspect(git_repo):
+    app = _app()
+    name = _name()
+    try:
+        async with _client(app) as c:
+            # CREATE（合法本地仓库 + 基线）
+            r = await c.post(
+                "/interface/repositories",
+                json={
+                    "name": name,
+                    "display_name": "Repo One",
+                    "github_url": "https://github.com/org/repo",
+                    "local_path": git_repo,
+                    "baseline_branch": "main",
+                },
+            )
+            assert r.status_code == 201, r.text
+            repo_id = r.json()["id"]
+            assert r.json()["local_path"] == git_repo
+            assert r.json()["baseline_branch"] == "main"
+            assert r.json()["owner_id"] == "itest_repo_user"
+
+            # CREATE 非法 local_path → 422
+            bad = await c.post(
+                "/interface/repositories",
+                json={
+                    "name": _name(),
+                    "github_url": "https://github.com/org/repo",
+                    "local_path": "/nonexistent/path/xyz",
+                    "baseline_branch": "main",
+                },
+            )
+            assert bad.status_code == 422, bad.text
+
+            # 重复 name → 400
+            dup = await c.post(
+                "/interface/repositories",
+                json={
+                    "name": name,
+                    "github_url": "https://github.com/org/repo",
+                    "local_path": git_repo,
+                    "baseline_branch": "main",
+                },
+            )
+            assert dup.status_code == 400, dup.text
+
+            # LIST（含刚建的）
+            lst = await c.get("/interface/repositories")
+            assert lst.status_code == 200
+            assert any(x["id"] == repo_id for x in lst.json())
+
+            # GET 详情
+            got = await c.get(f"/interface/repositories/{repo_id}")
+            assert got.status_code == 200 and got.json()["name"] == name
+
+            # PATCH display_name
+            upd = await c.patch(f"/interface/repositories/{repo_id}", json={"display_name": "Renamed"})
+            assert upd.status_code == 200 and upd.json()["display_name"] == "Renamed"
+
+            # PATCH 非法 local_path → 422
+            bad_upd = await c.patch(f"/interface/repositories/{repo_id}", json={"local_path": "/nope/xyz"})
+            assert bad_upd.status_code == 422
+
+            # inspect 分支枚举 → 含 main + feature/x
+            ins = await c.post("/interface/repositories/inspect", json={"local_path": git_repo})
+            assert ins.status_code == 200, ins.text
+            local = set(ins.json()["local"])
+            assert "main" in local and "feature/x" in local
+
+            # inspect 非法路径 → 422
+            bad_ins = await c.post("/interface/repositories/inspect", json={"local_path": "/nope/xyz"})
+            assert bad_ins.status_code == 422
+
+            # DELETE → 204
+            dele = await c.delete(f"/interface/repositories/{repo_id}")
+            assert dele.status_code == 204
+            # 删除后再取：access 检查先于存在性，找不到行返回 403（与 McpServer get 行为一致）。
+            assert (await c.get(f"/interface/repositories/{repo_id}")).status_code in (403, 404)
+    finally:
+        await _cleanup(name, _key())
+
+
+# ---------------------------------------------------------------------------
+# Routine 关联（repository_id 指针，单一事实源）
+# ---------------------------------------------------------------------------
+
+
+async def test_routine_with_repository_id_lifecycle(git_repo):
+    app = _app()
+    name = _name()
+    key = _key()
+    try:
+        async with _client(app) as c:
+            # 注册 Repository
+            r = await c.post(
+                "/interface/repositories",
+                json={
+                    "name": name,
+                    "github_url": "https://github.com/org/repo",
+                    "local_path": git_repo,
+                    "baseline_branch": "main",
+                },
+            )
+            assert r.status_code == 201, r.text
+            repo_id = r.json()["id"]
+
+            # 创建 Routine：仅给 repository_id，cwd/baseline 留空 → 仍过校验（后端从 Repo 派生）
+            cr = await c.post(
+                "/routines",
+                json={
+                    "key": key,
+                    "title": "Repo-linked routine",
+                    "goal": "实现 X",
+                    "acceptance_criteria": "通过",
+                    "repository_id": repo_id,
+                    "max_iterations": 5,
+                },
+            )
+            assert cr.status_code == 200, cr.text
+            rid = cr.json()["id"]
+            # 序列化含 repository_id；cwd/baseline 仍为 null（不存副本）
+            assert cr.json()["repository_id"] == repo_id
+            assert cr.json()["cwd"] is None
+            assert cr.json()["baseline_branch"] is None
+
+            # start：守卫用 Repo 派生配置放行（即便 routine.cwd 为空）
+            st = await c.post(f"/routines/{rid}/start")
+            assert st.status_code == 200, st.text
+            assert st.json()["status"] == "running"
+
+            # running 态改 repository_id → 409（非 runtime-safe）
+            bad = await c.put(f"/routines/{rid}", json={"repository_id": repo_id})
+            assert bad.status_code == 409, bad.text
+
+            # 删除 Repository → FK SET NULL：routine.repository_id 置空（解除关联）
+            # 先 pause 以便后续可观察（删除 Repo 不依赖 routine 状态）
+            await c.post(f"/routines/{rid}/pause")
+            dele = await c.delete(f"/interface/repositories/{repo_id}")
+            assert dele.status_code == 204
+            async with db_session.AsyncSessionLocal() as db:
+                routine = await db.get(Routine, uuid.UUID(rid))
+                assert routine is not None
+                assert routine.repository_id is None  # SET NULL 生效
+    finally:
+        await _cleanup(name, key)
+
+
+# ---------------------------------------------------------------------------
+# 单一事实源红线：dispatch 注入不污染 DB
+# ---------------------------------------------------------------------------
+
+
+async def test_hydrate_effective_repo_does_not_pollute_db(git_repo):
+    """repository_id 非空的 routine 经 _hydrate + 一次 commit 后，DB cwd/baseline 仍为 NULL。
+
+    set_committed_value 注入的内存有效值不进 dirty 集合，故 dispatch 写回 worktree_path 的
+    commit 不会把派生 cwd/baseline 持久化进 routines 行（单一事实源不被副本污染）。
+    """
+    name = _name()
+    key = _key()
+    try:
+        async with db_session.AsyncSessionLocal() as db:
+            repo = Repository(
+                owner_id="itest_repo_user",
+                visibility=PluginVisibility.PRIVATE,
+                name=name,
+                github_url="https://github.com/org/repo",
+                local_path=git_repo,
+                baseline_branch="main",
+            )
+            db.add(repo)
+            await db.commit()
+            await db.refresh(repo)
+            repo_id = repo.id
+
+        async with db_session.AsyncSessionLocal() as db:
+            routine = Routine(
+                key=key,
+                title="hydrate",
+                goal="g",
+                acceptance_criteria="a",
+                status="running",
+                repository_id=repo_id,
+                cwd=None,
+                baseline_branch=None,
+                reflections={},
+                config={},
+            )
+            db.add(routine)
+            await db.commit()
+            rid = routine.id
+
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            routine = await db.get(Routine, rid)
+            await orch._hydrate_effective_repo(db, routine)  # noqa: SLF001
+            # 内存注入了有效配置
+            assert routine.cwd == git_repo
+            assert routine.baseline_branch == "main"
+            # 模拟 dispatch 写回 worktree 句柄并提交
+            routine.worktree_path = "/tmp/fake-wt"
+            await db.commit()
+
+        # 红线：DB 中 cwd/baseline 仍为 NULL，worktree_path 已持久化
+        async with db_session.AsyncSessionLocal() as db:
+            routine = await db.get(Routine, rid)
+            assert routine.cwd is None, "cwd 被副本污染了（单一事实源被破坏）"
+            assert routine.baseline_branch is None, "baseline_branch 被副本污染了"
+            assert routine.worktree_path == "/tmp/fake-wt"
+    finally:
+        await _cleanup(name, key)

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_repo_resolve.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_repo_resolve.py
@@ -1,0 +1,94 @@
+"""Repository 有效配置解析 + 分支枚举单测 — 纯函数 + 真实 git（tmp_path），无 DB / 无网络。
+
+覆盖：
+- ``resolve_effective_repo``：指针优先 / 手填回退 / repository=None 安全降级。
+- ``list_branches``：枚举本地分支（含额外分支），非法路径抛 WorkspaceError。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from negentropy.engine.routine import workspace as ws
+
+pytestmark = pytest.mark.asyncio
+
+
+def _settings(**kw):
+    """轻量 RoutineSettings 替身（仅 list_branches 用到的字段）；默认关 fetch 保持 hermetic。"""
+    base = dict(git_remote="origin", git_fetch_before_worktree=False, git_timeout_seconds=30)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _make_git_repo(path, *, extra_branches: tuple[str, ...] = ()) -> str:
+    """建含 main 分支与初始提交的 git 仓库，可选追加额外本地分支，返回路径字符串。"""
+    p = str(path)
+    subprocess.run(["git", "init", "-q", p], check=True)
+    subprocess.run(["git", "-C", p, "config", "user.email", "t@t.io"], check=True)
+    subprocess.run(["git", "-C", p, "config", "user.name", "t"], check=True)
+    (path / "README.md").write_text("# repo\n")
+    subprocess.run(["git", "-C", p, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", p, "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", p, "branch", "-M", "main"], check=True)
+    for b in extra_branches:
+        subprocess.run(["git", "-C", p, "branch", b], check=True)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# resolve_effective_repo（纯函数：指针优先 / 手填回退）
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_effective_repo_pointer_wins():
+    """repository 非空 → 返回 Repository 的 local_path/baseline（即便 routine 手填了其它值）。"""
+    routine = SimpleNamespace(cwd="/manual/path", baseline_branch="manual-branch")
+    repository = SimpleNamespace(local_path="/repo/root", baseline_branch="origin/feature/1.x.x")
+    assert ws.resolve_effective_repo(routine, repository) == ("/repo/root", "origin/feature/1.x.x")
+
+
+def test_resolve_effective_repo_manual_fallback():
+    """repository 为空（未关联）→ 回退手填 cwd/baseline。"""
+    routine = SimpleNamespace(cwd="/manual/path", baseline_branch="main")
+    assert ws.resolve_effective_repo(routine, None) == ("/manual/path", "main")
+
+
+def test_resolve_effective_repo_none_repo_safe_when_manual_empty():
+    """repository=None（已删/竞态）且手填亦空 → 返回 (None, None)，不抛。"""
+    routine = SimpleNamespace(cwd=None, baseline_branch=None)
+    assert ws.resolve_effective_repo(routine, None) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# list_branches（真实 git）
+# ---------------------------------------------------------------------------
+
+
+async def test_list_branches_enumerates_local(tmp_path):
+    repo = _make_git_repo(tmp_path / "repo", extra_branches=("feature/x", "release/2.0"))
+    result = await ws.list_branches(repo, _settings())
+    local = set(result["local"])
+    assert "main" in local
+    assert "feature/x" in local
+    assert "release/2.0" in local
+    assert result["default_remote"] == "origin"
+    # 无远端 → remote 为空（hermetic，无 origin）。
+    assert result["remote"] == []
+
+
+async def test_list_branches_rejects_non_repo(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(ws.WorkspaceError):
+        await ws.list_branches(str(plain), _settings())
+
+
+async def test_list_branches_rejects_missing_path(tmp_path):
+    with pytest.raises(ws.WorkspaceError):
+        await ws.list_branches(str(tmp_path / "nope"), _settings())
+    with pytest.raises(ws.WorkspaceError):
+        await ws.list_branches(None, _settings())


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 指定工作仓库此前靠手填 `cwd`（本地仓库根）+ `baseline_branch` 两个自由文本字段，重复且易错，缺乏集中注册表。
- 关联上下文/Issue/文档：完全复用现有隔离 worktree 引擎（`engine/routine/workspace.py`，不引入远程 clone）；Repository 作为与 mcp/skill/agent/builtin_tool 并列的第 5 类 plugin 资源，纳入既有可见性权限体系。

# 核心变更
- 新增 **Interface → Repositories** 页（导航位于 Tools 与 Scheduler 之间）：注册「GitHub 地址 + 引擎主机本地仓库根 + 基线分支」，支持 **Inspect Branches** 枚举本地仓库分支并下拉选定基线。
- Routine 配置接入：新增可选「Repository」下拉，选定后由后端派生隔离 worktree 配置；未选则回退现有手填模式（不破坏存量 Routine）。
- 后端：`Repository` 模型 + 迁移 0074/0075（复用 `pluginvisibility` enum；`routines.repository_id` FK `ON DELETE SET NULL`）；CRUD API + `/inspect` 分支枚举；`workspace.list_branches` / `resolve_effective_repo`；`permissions.PLUGIN_TYPE_MODEL_MAP` 新增 `repository`。
- **单一事实源**：Routine 仅存 `repository_id` 指针、不存 cwd/baseline 副本；`routine_api` 的 create/update/start/resume/restart 5 处守卫改用「有效配置」，`orchestrator` dispatch/evaluate 装载点用 `set_committed_value` 注入有效 cwd/baseline 且不持久化（DB 不被污染）。

# 风险与回滚
- 主要风险：dispatch 注入若实现不当可能把派生值写回 DB（破坏单一事实源）；独立迁移引用既有 enum 若误建会冲突。两者已分别由「红线」测试与 `create_type=False` 规避。
- 回滚方式：还原本分支提交；迁移 `alembic downgrade`（0075→0074，幂等可逆，已 round-trip 验证）。改动均为加性（新表 + 可空列），存量 Routine 不受影响。

# 验证证据
- 单元测试：`test_routine_repo_resolve.py` 6 项（解析指针优先/手填回退、`list_branches`）全过。
- 集成测试：`test_repository_api.py` 3 项（CRUD+inspect、Routine `repository_id` 全生命周期、**「dispatch 后 DB cwd 不被污染」红线**）全过。
- E2E/Workflow：本工作区 `next dev` 实机走查导航位置 / Repositories 页 / Add Repository 抽屉（Inspect Branches）/ Routine 抽屉 Repository 下拉的渲染与优雅降级。
- 覆盖率/关键截图：现有 routine/workspace 回归 104 项 + 迁移 up/down round-trip 6 项全绿；后端 ruff、前端 ESLint + scoped tsc 干净。

# 影响范围
- 前端：新增 Repositories 页/组件/API 代理/`features/repositories` 数据层；改 `InterfaceNav`、`RoutineEditDrawer`、`features/routine/types`。
- 后端：新增 `Repository` 模型/`repository_api`/迁移 0074·0075；改 `permissions`、`workspace`、`routine_api`、`orchestrator`、`bootstrap`、`models` 导出注册。
- GitHub Actions / 文档：无 CI 配置改动；无文档改动。

# Next Best Action
- 合并前在目标环境执行 `uv run alembic upgrade head` 应用 0074/0075，随后走完整数据链路 E2E（创建 Repo → Inspect 选基线 → Routine 选用 → start，确认基于该 Repo 基线分支创建隔离 worktree）。
