### PR TITLE
feat(Scheduler): 任务详情抽屉新增 Handler 源码与解释查看

### DIFF
--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerHandlerSource.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerHandlerSource.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { fetchHandlerSource, type HandlerSourceResponse } from "@/features/scheduler";
+
+/**
+ * 任务详情抽屉「实现逻辑」区。
+ *
+ * 默认折叠，首次展开才向 ``GET /api/scheduler/handlers/{handler_kind}/source``
+ * 拉取该 handler 的整模块源码 + docstring + descriptor 描述——避免每次开抽屉都发请求。
+ * 展示「解释」（描述 + docstring）与「源码」（带复制按钮的代码块）。
+ */
+
+function CopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation();
+      try {
+        await navigator.clipboard.writeText(code);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy handler source", err);
+      }
+    },
+    [code],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title="复制源码"
+      className="absolute top-2 right-2 rounded-md bg-card/80 px-2 py-1 text-micro font-medium text-muted-foreground opacity-70 transition-colors hover:bg-muted/60 hover:text-foreground group-hover:opacity-100"
+    >
+      {copied ? "已复制" : "复制"}
+    </button>
+  );
+}
+
+export function SchedulerHandlerSource({ handlerKind }: { handlerKind: string }) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<HandlerSourceResponse | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await fetchHandlerSource(handlerKind));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [handlerKind]);
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      const next = !prev;
+      if (next && !data && !loading) void load();
+      return next;
+    });
+  }, [data, loading, load]);
+
+  // 解释：优先入口函数 docstring，回退模块 docstring
+  const explanation = data ? data.function_docstring ?? data.module_docstring : null;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      {/* 折叠开关 */}
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="flex w-full cursor-pointer items-center gap-2 px-3 py-2.5 text-xs text-foreground transition-colors hover:bg-muted/40"
+      >
+        <svg
+          className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${open ? "rotate-90" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+        <span className="font-medium">查看 Handler 源码与解释</span>
+        <code className="text-micro text-muted-foreground">{handlerKind}</code>
+      </button>
+
+      {open && (
+        <div className="space-y-3 border-t border-border px-3 py-3">
+          {loading && <p className="text-xs text-muted-foreground">加载中…</p>}
+
+          {error && !loading && (
+            <div className="space-y-2">
+              <p className="text-xs text-red-600 dark:text-red-400 break-all">源码加载失败：{error}</p>
+              <button
+                type="button"
+                onClick={() => void load()}
+                className="cursor-pointer rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/50"
+              >
+                重试
+              </button>
+            </div>
+          )}
+
+          {data && !loading && !error && (
+            <>
+              {/* 元信息 */}
+              <div className="space-y-0.5 text-micro text-muted-foreground">
+                <div className="font-medium text-foreground">{data.label}</div>
+                {data.file_path && (
+                  <div className="break-all font-mono">
+                    {data.file_path}
+                    {data.function_lineno ? `:${data.function_lineno}` : ""}
+                  </div>
+                )}
+              </div>
+
+              {/* 解释：描述 + docstring */}
+              {(data.description || explanation) && (
+                <div className="space-y-2 rounded-md bg-muted/40 p-3">
+                  {data.description && (
+                    <p className="text-xs leading-relaxed text-foreground whitespace-pre-wrap break-words">
+                      {data.description}
+                    </p>
+                  )}
+                  {explanation && (
+                    <p className="text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap break-words">
+                      {explanation}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* 源码 */}
+              {data.module_source ? (
+                <div className="group relative">
+                  <CopyButton code={data.module_source} />
+                  <pre className="max-h-[480px] overflow-auto rounded-md bg-muted/40 p-3 text-xs leading-relaxed">
+                    <code className="font-mono text-foreground whitespace-pre">{data.module_source}</code>
+                  </pre>
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">源码不可读取。</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef } from "react";
 import { Button } from "@/components/ui/Button";
 import type { ScheduledTaskDTO } from "@/features/scheduler";
 
+import { SchedulerHandlerSource } from "./SchedulerHandlerSource";
+
 interface SchedulerTaskDetailDrawerProps {
   task: ScheduledTaskDTO;
   onClose: () => void;
@@ -216,6 +218,12 @@ export function SchedulerTaskDetailDrawer({
               </div>
             </section>
           )}
+
+          {/* 实现逻辑：Handler 源码与解释 */}
+          <section>
+            <h3 className="text-micro uppercase tracking-overline text-muted-foreground mb-2">实现逻辑</h3>
+            <SchedulerHandlerSource key={task.handler_kind} handlerKind={task.handler_kind} />
+          </section>
         </div>
 
         {/* Footer */}

--- a/apps/negentropy-ui/features/scheduler/api.ts
+++ b/apps/negentropy-ui/features/scheduler/api.ts
@@ -8,6 +8,7 @@ import type {
   DashboardFilters,
   ExecutionListResponse,
   HandlerListResponse,
+  HandlerSourceResponse,
   KpiResponse,
   ScheduledTaskDTO,
   StatsGroupBy,
@@ -107,6 +108,11 @@ export async function toggleTaskEnabled(
 
 export async function fetchHandlers(): Promise<HandlerListResponse> {
   return jsonFetch("/handlers");
+}
+
+/** 拉取指定 handler 的实现源码 + docstring + 描述（驱动任务详情抽屉「实现逻辑」区）。 */
+export async function fetchHandlerSource(handlerKind: string): Promise<HandlerSourceResponse> {
+  return jsonFetch(`/handlers/${encodeURIComponent(handlerKind)}/source`);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/negentropy-ui/features/scheduler/index.ts
+++ b/apps/negentropy-ui/features/scheduler/index.ts
@@ -26,6 +26,7 @@ export type {
   PayloadFieldSchema,
   HandlerDescriptor,
   HandlerListResponse,
+  HandlerSourceResponse,
   TaskWritePayload,
 } from "./types";
 
@@ -39,6 +40,7 @@ export {
   runTaskNow,
   toggleTaskEnabled,
   fetchHandlers,
+  fetchHandlerSource,
   createTask,
   updateTask,
   deleteTask,

--- a/apps/negentropy-ui/features/scheduler/types.ts
+++ b/apps/negentropy-ui/features/scheduler/types.ts
@@ -153,6 +153,26 @@ export interface HandlerListResponse {
   items: HandlerDescriptor[];
 }
 
+/**
+ * Handler 实现源码 + 解释。
+ * 与后端 ``interface/scheduler_api.py::_build_handler_source`` 对齐，
+ * 供任务详情抽屉「实现逻辑」区展示。
+ */
+export interface HandlerSourceResponse {
+  handler_kind: string;
+  label: string;
+  description: string | null;
+  module: string | null;
+  file_path: string | null;
+  function_name: string;
+  function_lineno: number | null;
+  function_docstring: string | null;
+  module_docstring: string | null;
+  module_source: string | null;
+  function_source: string | null;
+  language: string;
+}
+
 // ---------------------------------------------------------------------------
 // CRUD 请求载荷
 // ---------------------------------------------------------------------------

--- a/apps/negentropy/src/negentropy/interface/scheduler_api.py
+++ b/apps/negentropy/src/negentropy/interface/scheduler_api.py
@@ -585,6 +585,71 @@ async def list_handler_descriptors() -> dict[str, Any]:
     return {"items": [_serialize_descriptor(d) for d in list_descriptors()]}
 
 
+def _build_handler_source(handler_kind: str) -> dict[str, Any] | None:
+    """从注册表解析 ``handler_kind`` → 返回模块源码 + docstring + descriptor 元数据。
+
+    ``handler_kind`` 仅作 ``HANDLER_REGISTRY`` 字典键查找，绝不接受/拼接文件路径，
+    故无路径穿越风险；未命中返回 ``None``（由端点转 404）。源码经 ``inspect`` 从
+    已加载模块获取——反映**实际运行中**的实现。
+
+    抽成纯函数（不触 DB）以便免 Postgres 单测，与 ``GET /handlers/{kind}/source`` 端点解耦。
+    """
+    import inspect
+
+    from negentropy.engine.schedulers.handlers import (
+        _bootstrap_default_handlers,
+        get_descriptor,
+        get_handler,
+    )
+
+    _bootstrap_default_handlers()  # 幂等：确保 handler 模块已 import → 已注册
+    fn = get_handler(handler_kind)
+    if fn is None:
+        return None
+
+    module = inspect.getmodule(fn)
+
+    def _src(obj: Any) -> str | None:
+        try:
+            return inspect.getsource(obj)
+        except (OSError, TypeError):
+            return None
+
+    try:
+        _, fn_lineno = inspect.getsourcelines(fn)
+    except (OSError, TypeError):
+        fn_lineno = None
+
+    d = get_descriptor(handler_kind)
+    raw_file = getattr(module, "__file__", None)
+    # 仅展示用：裁剪为 src/ 之后的仓库相对路径
+    file_path = raw_file.split("/src/", 1)[-1] if raw_file and "/src/" in raw_file else raw_file
+
+    return {
+        "handler_kind": handler_kind,
+        "label": d.label if d else handler_kind,
+        "description": d.description if d else None,
+        "module": module.__name__ if module else None,
+        "file_path": file_path,
+        "function_name": fn.__name__,
+        "function_lineno": fn_lineno,
+        "function_docstring": inspect.getdoc(fn),
+        "module_docstring": inspect.getdoc(module) if module else None,
+        "module_source": _src(module),  # 主体：整模块（含入口函数 + 私有 _run_* 辅助 + descriptor）
+        "function_source": _src(fn),  # 备用：仅注册入口函数
+        "language": "python",
+    }
+
+
+@router.get("/handlers/{handler_kind}/source")
+async def get_handler_source(handler_kind: str = Path(..., max_length=64)) -> dict[str, Any]:
+    """返回指定 Handler 的实现源码 + docstring + 描述（驱动 UI「实现逻辑」区）。"""
+    data = _build_handler_source(handler_kind)
+    if data is None:
+        raise HTTPException(status_code=404, detail=f"unknown handler_kind: {handler_kind}")
+    return data
+
+
 # ---------------------------------------------------------------------------
 # CRUD — Pydantic 请求模型
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/tests/unit_tests/interface/test_scheduler_api.py
+++ b/apps/negentropy/tests/unit_tests/interface/test_scheduler_api.py
@@ -41,6 +41,7 @@ def test_router_exposes_all_endpoints():
         "/scheduler/tasks/{task_id}/toggle",
         "/scheduler/stream",
         "/scheduler/handlers",
+        "/scheduler/handlers/{handler_kind}/source",
     }
     assert expected <= paths
 
@@ -108,6 +109,35 @@ def test_serialize_descriptor():
     # 验证 applies_when 正确序列化
     threshold_field = next(f for f in data["payload_fields"] if f["name"] == "threshold")
     assert threshold_field["applies_when"] == ["cleanup_memories"]
+
+
+def test_build_handler_source_known_handler():
+    """命中已注册 handler → 返回整模块源码 + docstring + descriptor 元数据。"""
+    from negentropy.interface.scheduler_api import _build_handler_source
+
+    data = _build_handler_source("pgvector_check")
+    assert data is not None
+    assert data["handler_kind"] == "pgvector_check"
+    assert data["language"] == "python"
+    # 整模块源码：应含注册装饰器本身（证明拿到的是模块而非裸函数）
+    assert data["module_source"] and 'register_handler("pgvector_check")' in data["module_source"]
+    # 入口函数源码 + 行号
+    assert data["function_name"].endswith("handler")
+    assert data["function_source"] and "def " in data["function_source"]
+    assert isinstance(data["function_lineno"], int) and data["function_lineno"] > 0
+    # 解释：descriptor 描述 + 至少一处 docstring 非空
+    assert data["description"]
+    assert data["function_docstring"] or data["module_docstring"]
+    # file_path 已裁剪为 src/ 之后的仓库相对路径
+    assert data["file_path"] and data["file_path"].startswith("negentropy/")
+    assert "/src/" not in data["file_path"]
+
+
+def test_build_handler_source_unknown_returns_none():
+    """未注册 handler_kind → None（端点据此转 404）。"""
+    from negentropy.interface.scheduler_api import _build_handler_source
+
+    assert _build_handler_source("__definitely_not_a_handler__") is None
 
 
 class TestValidateTaskSpec:


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Scheduler 任务表的 `handler_kind` 列只显示字符串键（如 `routine_inspector`、`memory_automation`），用户无法在 UI 上得知该 handler「到底做了什么、代码怎么实现」，只能回仓库翻 Python 源文件。
- 关联上下文/Issue/文档：用户需求——在任务详情中直接查看 handler 的实现源码或解释。

# 核心变更
- 后端：新增纯函数 `_build_handler_source`，经 `inspect` 自省 handler **整模块源码** + docstring + descriptor 元数据，并暴露 `GET /scheduler/handlers/{handler_kind}/source` 端点。
- 前端：新增 `SchedulerHandlerSource` 组件（默认折叠、首次展开懒加载、源码块带复制按钮），接入任务详情抽屉「实现逻辑」区；扩展 `features/scheduler` 的类型与 api client。

# 风险与回滚
- 主要风险：极低——纯加法（+289 行、0 删除），不改代理路由/bootstrap/表格/全局 markdown 插件/chat 渲染；源码暴露仅限注册表白名单，`handler_kind` 仅作字典键查找、不拼接文件路径，杜绝路径穿越，未命中转 404。
- 回滚方式：revert 本 commit（`8930d066`）即可，无数据迁移、无 schema 变更。

# 验证证据
- 单元测试：`tests/unit_tests/interface/test_scheduler_api.py` 新增命中/404 用例，整文件 18 passed（纯函数、免 Postgres）。
- 集成测试：N/A（端点不触 DB）。
- E2E/Workflow：in-process 实跑 `_build_handler_source("memory_automation")` 返回 8319B 源码，含 `register_handler(...)` 与三个私有 `_run_*` 实现；端点 404 路径校验通过。
- 覆盖率/关键截图：前端 `tsc` typecheck + ESLint 零告警；后端 ruff check/format 干净；commit 全部 pre-commit hooks Passed。

# 影响范围
- 前端：`app/interface/scheduler/_components/{SchedulerHandlerSource,SchedulerTaskDetailDrawer}.tsx`、`features/scheduler/{types,api,index}.ts`。
- 后端：`interface/scheduler_api.py`（新增 helper + 端点）、`tests/unit_tests/interface/test_scheduler_api.py`。
- GitHub Actions / 文档：无。

# Next Best Action
- 待后端在部署/本地环境就绪后，按「/interface/scheduler → 点任务行 → 展开『实现逻辑』」做一次浏览器视觉回归（切换不同 handler 确认内容随之变化）。