### PR TITLE
feat(KnowledgeGraph): 图谱页默认聚焦 Harness Engineering 语料库

### DIFF
--- a/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
@@ -9,9 +9,19 @@ interface CorpusSelectorProps {
   value: string | null;
   onChange: (corpusId: string) => void;
   onCorporaLoaded?: (corpora: CorpusRecord[]) => void;
+  /**
+   * 首次加载时优先按名称选中的语料库；命中则默认选它，未命中（或未提供）回退到列表第一个。
+   * 用于让特定页面（如图谱页）默认聚焦某个语料库，而不将业务名硬编码进本通用组件。
+   */
+  defaultCorpusName?: string;
 }
 
-export function CorpusSelector({ value, onChange, onCorporaLoaded }: CorpusSelectorProps) {
+export function CorpusSelector({
+  value,
+  onChange,
+  onCorporaLoaded,
+  defaultCorpusName,
+}: CorpusSelectorProps) {
   const [corpora, setCorpora] = useState<CorpusRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const autoSelected = useRef(!!value);
@@ -25,7 +35,10 @@ export function CorpusSelector({ value, onChange, onCorporaLoaded }: CorpusSelec
           onCorporaLoaded?.(data);
           if (!autoSelected.current && data.length > 0) {
             autoSelected.current = true;
-            onChange(data[0].id);
+            const preferred = defaultCorpusName
+              ? data.find((c) => c.name === defaultCorpusName)
+              : undefined;
+            onChange((preferred ?? data[0]).id);
           }
         }
       })
@@ -36,7 +49,7 @@ export function CorpusSelector({ value, onChange, onCorporaLoaded }: CorpusSelec
     return () => {
       mounted = false;
     };
-  }, [onChange, onCorporaLoaded]);
+  }, [onChange, onCorporaLoaded, defaultCorpusName]);
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/negentropy-ui/app/knowledge/graph/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/page.tsx
@@ -76,6 +76,10 @@ const GraphCanvas3D = dynamic(
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
+// 图谱页默认聚焦的语料库名称；列表中命中则默认选中并加载其图谱，
+// 未命中时回退到列表第一个（见 CorpusSelector 的 defaultCorpusName 逻辑）。
+const DEFAULT_GRAPH_CORPUS_NAME = "Harness Engineering";
+
 const PANEL_DEFS = [
   { key: "model-config" as const, label: "模型设置" },
   { key: "global-search" as const, label: "全局问答" },
@@ -484,7 +488,12 @@ export default function KnowledgeGraphPage() {
               {/* Toolbar — 三段式：左 CorpusSelector / 中 SearchBar / 右 viewTab+渲染器+构建按钮+Pill */}
               <div className="flex items-center gap-3">
                 {/* 左 */}
-                <CorpusSelector value={corpusId} onChange={setCorpusId} onCorporaLoaded={setCorpora} />
+                <CorpusSelector
+                  value={corpusId}
+                  onChange={setCorpusId}
+                  onCorporaLoaded={setCorpora}
+                  defaultCorpusName={DEFAULT_GRAPH_CORPUS_NAME}
+                />
 
                 {/* 中（仅图谱视图 + 已选语料库时显示）*/}
                 <div className="flex-1 min-w-0 flex justify-center">

--- a/apps/negentropy-ui/tests/unit/knowledge/CorpusSelector.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/CorpusSelector.test.tsx
@@ -1,0 +1,97 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CorpusRecord } from "@/features/knowledge";
+
+// 仅 mock 组件运行时实际用到的 fetchCorpora；CorpusRecord 为类型,运行时无需导出。
+const fetchCorporaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/knowledge", () => ({
+  fetchCorpora: fetchCorporaMock,
+}));
+
+import { CorpusSelector } from "@/app/knowledge/graph/_components/CorpusSelector";
+
+const mkCorpus = (id: string, name: string): CorpusRecord => ({
+  id,
+  name,
+  app_name: "negentropy",
+  knowledge_count: 0,
+});
+
+describe("CorpusSelector 默认选中逻辑", () => {
+  beforeEach(() => {
+    fetchCorporaMock.mockReset();
+  });
+
+  it("提供 defaultCorpusName 且列表命中时,默认选中该语料库(即便不在首位)", async () => {
+    fetchCorporaMock.mockResolvedValue([
+      mkCorpus("a", "Other Corpus"),
+      mkCorpus("b", "Harness Engineering"),
+    ]);
+    const onChange = vi.fn();
+
+    render(
+      <CorpusSelector
+        value={null}
+        onChange={onChange}
+        defaultCorpusName="Harness Engineering"
+      />,
+    );
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("b"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("列表未命中 defaultCorpusName 时,回退到列表第一个", async () => {
+    fetchCorporaMock.mockResolvedValue([
+      mkCorpus("a", "Other Corpus"),
+      mkCorpus("c", "Another Corpus"),
+    ]);
+    const onChange = vi.fn();
+
+    render(
+      <CorpusSelector
+        value={null}
+        onChange={onChange}
+        defaultCorpusName="Harness Engineering"
+      />,
+    );
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("a"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("未提供 defaultCorpusName 时,保持旧行为:选中列表第一个", async () => {
+    fetchCorporaMock.mockResolvedValue([
+      mkCorpus("a", "Other Corpus"),
+      mkCorpus("b", "Harness Engineering"),
+    ]);
+    const onChange = vi.fn();
+
+    render(<CorpusSelector value={null} onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith("a"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("已有选中值(value 非空)时不触发自动选中", async () => {
+    fetchCorporaMock.mockResolvedValue([
+      mkCorpus("a", "Other Corpus"),
+      mkCorpus("b", "Harness Engineering"),
+    ]);
+    const onChange = vi.fn();
+
+    render(
+      <CorpusSelector
+        value="a"
+        onChange={onChange}
+        defaultCorpusName="Harness Engineering"
+      />,
+    );
+
+    // 等待 fetchCorpora 解析完成后,onChange 仍不应被自动调用。
+    await waitFor(() => expect(fetchCorporaMock).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/knowledge/graph` 进入时默认选中「列表第一个（按创建时间倒序，即最近创建）」语料库；当前线上数据首位为 `Sinestesia of Cognition`，导致默认并非期望的 `Harness Engineering`。
- 关联上下文/Issue/文档：用户诉求「图谱页默认打开 Harness Engineering Corpus 图谱」；后端迁移 `0064_seed_pdf_fidelity_restore_skill` 已将 `Harness Engineering` 作为既定默认目标 Corpus。

# 核心变更
- `CorpusSelector` 新增可选 prop `defaultCorpusName`：首次加载按名称优先选中，未命中（或未提供）回退 `data[0]`（完全保留旧行为），并加入 `useEffect` 依赖。
- 图谱页 `page.tsx` 注入常量 `DEFAULT_GRAPH_CORPUS_NAME = "Harness Engineering"`，将「默认名」下沉到页面而非硬编码进通用选择器，符合最小干预与复用驱动。
- 新增单测覆盖四条路径：按名命中（非首位）/ 未命中回退首个 / 无默认名向后兼容 / 已有选中值不触发自动选中。

# 风险与回滚
- 主要风险：极低；仅改前端首屏默认选中逻辑，按名匹配失败即回退原行为，用户手动切换不受影响；无后端/接口/数据改动。
- 回滚方式：`git revert fbed49d3`，或移除 `page.tsx` 中 `defaultCorpusName` 传参即恢复旧默认。

# 验证证据
- 单元测试：新增 `apps/negentropy-ui/tests/unit/knowledge/CorpusSelector.test.tsx` 共 4 用例,vitest 全通过。
- 集成测试：N/A（无后端/接口改动）。
- E2E/Workflow：未跑（`:3192` 为主仓 `.next/standalone` 生产构建,尚未反映本工作区改动）。
- 覆盖率/关键截图：经运行中后端 API 核实现存 2 个语料库（`Sinestesia of Cognition` 首位 / `Harness Engineering` 非首位且存在）,本改动将默认由前者切换为后者；`tsc --noEmit`（app + vitest 配置）与 ESLint 均通过。

# 影响范围
- 前端：`apps/negentropy-ui` 图谱页（`/knowledge/graph`）默认语料库选中逻辑。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后重建 `:3192` 主仓 standalone（或本工作区另起 `next dev` 指向同后端）,做一次浏览器实机截图留档确认默认生效。