### PR TITLE
perf(Knowledge): PDF 预览启用 HTTP Range 渐进加载与条件缓存，提速大文档首屏渲染

### DIFF
--- a/apps/negentropy-ui/app/api/knowledge/_proxy.ts
+++ b/apps/negentropy-ui/app/api/knowledge/_proxy.ts
@@ -35,6 +35,15 @@ const getBaseUrl = getKnowledgeBaseUrl;
 export const DEFAULT_PROXY_TIMEOUT_MS = 30_000;
 
 /**
+ * 二进制（PDF / 下载 / 资产）代理默认超时（毫秒）。
+ *
+ * 大 PDF 的「无 Range 全量 GET」在慢链路上可能超过 30s 文本默认值；而启用 Range 后
+ * 浏览器原生查看器只发小块请求、个个很快，绝不触及此上限。提高到 120s 仅为兜底首屏
+ * 全量拉取（如旧后端未升级或客户端不发 Range 时）。调用方仍可通过 `timeoutMs` 覆盖。
+ */
+export const DEFAULT_BINARY_PROXY_TIMEOUT_MS = 120_000;
+
+/**
  * 长任务超时（毫秒）：KG build 等长流程的调用方传入此常量。
  * 15min 经验值：覆盖典型 1k chunk 全量构建（含 5 个后置阶段）后仍有冗余；
  * 当前修复（连接池泄漏 + 阶段化进度）后正常构建应在 5min 内完成，超时一般意味着真故障。
@@ -516,13 +525,22 @@ export async function proxyGetBinary(
   const upstreamUrl = new URL(path, baseUrl);
   const incomingUrl = new URL(request.url);
   upstreamUrl.search = incomingUrl.search;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_PROXY_TIMEOUT_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BINARY_PROXY_TIMEOUT_MS;
+
+  // 二进制场景额外透传 Range + 条件请求头：使浏览器原生 PDF 查看器可发起分块/范围
+  // 请求并复用缓存，后端据此回 206/304/416。仅在此局部补头，不动共享的
+  // extractForwardHeaders（JSON 代理无需这些头）。
+  const forwardHeaders = extractForwardHeaders(request);
+  for (const name of ["range", "if-none-match", "if-modified-since", "if-range"] as const) {
+    const value = request.headers.get(name);
+    if (value) forwardHeaders.set(name, value);
+  }
 
   let upstreamResponse: Response;
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: "GET",
-      headers: extractForwardHeaders(request),
+      headers: forwardHeaders,
       cache: "no-store",
       signal: AbortSignal.timeout(timeoutMs),
     });
@@ -531,29 +549,13 @@ export async function proxyGetBinary(
     return errorResponse(code, message, status);
   }
 
-  if (!upstreamResponse.ok) {
-    // 复用 proxyDelete 的错误处理模式
-    const contentType = upstreamResponse.headers.get("content-type");
-    if (contentType?.includes("application/json")) {
-      try {
-        const errorJson = await upstreamResponse.json();
-        return NextResponse.json(errorJson, { status: upstreamResponse.status });
-      } catch {
-        // fallback
-      }
-    }
-    return errorResponse(
-      "KNOWLEDGE_UPSTREAM_ERROR",
-      "Upstream returned non-OK status",
-      upstreamResponse.status,
-    );
-  }
-
-  // 转发二进制响应，保留必要的 headers
+  // 构造透传响应头（304/200/206/416 共用）。除既有 content-type / disposition /
+  // cache-control 外，补充 Range + 缓存协商所需头，使浏览器原生查看器能：
+  //  - 渐进式分块渲染大 PDF（accept-ranges + content-range + content-length）
+  //  - 跨视图切换 / 重访复用缓存（etag + last-modified + cache-control）
   const responseHeaders = new Headers();
   const contentDisposition = upstreamResponse.headers.get("content-disposition");
   const contentType = upstreamResponse.headers.get("content-type");
-  const cacheControl = upstreamResponse.headers.get("cache-control");
 
   if (options.responseDisposition === "inline") {
     // 预览语义：把上游的 `attachment` 改写为 `inline`，保留 `filename*` 等参数，
@@ -577,8 +579,59 @@ export async function proxyGetBinary(
     if (contentDisposition) responseHeaders.set("content-disposition", contentDisposition);
     if (contentType) responseHeaders.set("content-type", contentType);
   }
-  if (cacheControl) responseHeaders.set("cache-control", cacheControl);
 
+  // 范围 + 缓存协商头：存在才透传（旧后端未升级时全部缺失 → no-op，行为不变）。
+  for (const name of [
+    "cache-control",
+    "accept-ranges",
+    "content-range",
+    "content-length",
+    "etag",
+    "last-modified",
+  ] as const) {
+    const value = upstreamResponse.headers.get(name);
+    if (value) responseHeaders.set(name, value);
+  }
+
+  // 304 Not Modified：无 body。必须在 `!ok` 分支之前拦截（304 非 ok，否则会被
+  // 误包装成 JSON 错误信封）。保留 etag/cache-control 让浏览器继续命中本地缓存。
+  if (upstreamResponse.status === 304) {
+    try {
+      await upstreamResponse.arrayBuffer(); // drain（304 通常空 body），避免半开连接
+    } catch {
+      /* ignore drain errors */
+    }
+    return new NextResponse(null, { status: 304, headers: responseHeaders });
+  }
+
+  // 206 Partial Content（ok）与 416 Range Not Satisfiable（非 ok）都需带
+  // content-range 原样透传，不能进入下方 JSON 错误包装。
+  if (upstreamResponse.status === 206 || upstreamResponse.status === 416) {
+    return new NextResponse(upstreamResponse.body, {
+      status: upstreamResponse.status,
+      headers: responseHeaders,
+    });
+  }
+
+  if (!upstreamResponse.ok) {
+    // 复用 proxyDelete 的错误处理模式
+    const errorContentType = upstreamResponse.headers.get("content-type");
+    if (errorContentType?.includes("application/json")) {
+      try {
+        const errorJson = await upstreamResponse.json();
+        return NextResponse.json(errorJson, { status: upstreamResponse.status });
+      } catch {
+        // fallback
+      }
+    }
+    return errorResponse(
+      "KNOWLEDGE_UPSTREAM_ERROR",
+      "Upstream returned non-OK status",
+      upstreamResponse.status,
+    );
+  }
+
+  // 200 OK（全量 / 已升级后端的首块）流式透传。
   return new NextResponse(upstreamResponse.body, {
     status: upstreamResponse.status,
     headers: responseHeaders,

--- a/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
@@ -6,7 +6,7 @@
  */
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { toast } from "@/lib/activity-toast";
@@ -302,6 +302,23 @@ export default function DocumentDetailPage() {
   // 仅在 PDF 文档 + 选中 PDF 标签时渲染原文查看器；其余一律走 Markdown 分支。
   const showPdf = isPdf && viewMode === "pdf";
 
+  // PDF「意图预取」：默认视图是 Markdown 且多数用户不会点开 PDF，故不在挂载时预取
+  // （会让所有人白白下载整份 PDF）。改在用户对 PDF 标签产生意图（hover/focus）时，
+  // 用低优先级 `<link rel=prefetch>` 预热浏览器缓存一次，使随后点击近乎秒开。
+  // 后端已为预览端点补齐 ETag/Cache-Control，预取内容可被 `<object>` 命中复用。
+  const pdfPrefetchedRef = useRef(false);
+  const prefetchPdf = useCallback(() => {
+    if (pdfPrefetchedRef.current || !isPdf) return;
+    pdfPrefetchedRef.current = true;
+    const href = documentPreviewUrl(corpusId, documentId, { appName: requestAppName });
+    const link = document.createElement("link");
+    link.rel = "prefetch";
+    link.as = "document"; // 原生查看器以 document/object 加载，as=document 对齐缓存分区
+    link.href = href;
+    link.setAttribute("fetchpriority", "low"); // 不与首屏 markdown 资源争抢带宽
+    document.head.appendChild(link);
+  }, [isPdf, corpusId, documentId, requestAppName]);
+
   // ---- Render ----
 
   return (
@@ -351,6 +368,8 @@ export default function DocumentDetailPage() {
                 role="tab"
                 aria-selected={viewMode === "pdf"}
                 onClick={() => setViewMode("pdf")}
+                onPointerEnter={prefetchPdf}
+                onFocus={prefetchPdf}
                 className={`rounded-md px-3 py-1 transition-colors ${
                   viewMode === "pdf"
                     ? "bg-background text-foreground shadow-sm"

--- a/apps/negentropy-ui/features/knowledge/components/DocumentPdfViewer.tsx
+++ b/apps/negentropy-ui/features/knowledge/components/DocumentPdfViewer.tsx
@@ -45,9 +45,23 @@ export function DocumentPdfViewer({
         </a>
       </div>
 
-      <div className="h-[calc(100vh-240px)] min-h-[600px] w-full overflow-hidden rounded-lg border border-border bg-background">
-        {/* object（主）→ iframe（兜底）→ 链接（终极兜底） */}
-        <object data={src} type="application/pdf" aria-label={title} className="h-full w-full">
+      <div className="relative h-[calc(100vh-240px)] min-h-[600px] w-full overflow-hidden rounded-lg border border-border bg-background">
+        {/* 加载占位层（底层 z-0）：原生查看器渲染后其不透明背景会自然覆盖此层，
+            无需 JS 状态、无 `<object>` onLoad 跨浏览器不可靠导致的卡死风险。
+            aria-hidden 避免对读屏用户暴露装饰性 loading。 */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 z-0 flex flex-col items-center justify-center gap-3 text-text-muted"
+        >
+          <svg className="h-6 w-6 animate-spin" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+          </svg>
+          <p className="text-xs">正在加载 PDF…</p>
+        </div>
+
+        {/* object（主）→ iframe（兜底）→ 链接（终极兜底），层级置于占位层之上 */}
+        <object data={src} type="application/pdf" aria-label={title} className="relative z-10 h-full w-full">
           <iframe src={src} title={title} className="h-full w-full border-0">
             <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-text-muted">
               <p>当前浏览器无法内联预览此 PDF。</p>

--- a/apps/negentropy-ui/tests/unit/knowledge/DocumentPdfViewer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/DocumentPdfViewer.test.tsx
@@ -29,4 +29,14 @@ describe("DocumentPdfViewer", () => {
     expect(links[0]).toHaveAttribute("target", "_blank");
     expect(links[0]?.getAttribute("rel")).toContain("noopener");
   });
+
+  it("渲染加载占位（spinner），供原生查看器绘制前占位（纯 CSS、无 onLoad 依赖）", () => {
+    const { container } = render(<DocumentPdfViewer src={SRC} />);
+
+    // 占位层位于 <object> 之下（z-0），原生查看器绘制后其不透明背景自然覆盖。
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).not.toBeNull();
+    // object 仍嵌套 iframe 兜底，结构未因占位层而破坏。
+    expect(container.querySelector("object iframe")).not.toBeNull();
+  });
 });

--- a/apps/negentropy-ui/tests/unit/knowledge/proxy-get-binary.test.ts
+++ b/apps/negentropy-ui/tests/unit/knowledge/proxy-get-binary.test.ts
@@ -1,0 +1,179 @@
+/**
+ * BFF proxyGetBinary：HTTP Range + 条件缓存透传测试。
+ *
+ * 锁定 PDF 预览渐进式渲染与缓存复用的代理层契约：
+ *   - 向上游转发 Range / If-None-Match 等条件请求头；
+ *   - 透传 206 + Content-Range / Accept-Ranges / Content-Length / ETag；
+ *   - 304 在 `!ok` 分支前拦截，返回空 body + ETag（不被误包装成 JSON 错误）；
+ *   - 416 带 Content-Range 原样透传；
+ *   - 预览 inline 改写仍生效；下载（attachment）不变。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { proxyGetBinary } from "@/app/api/knowledge/_proxy";
+
+vi.mock("@/lib/sso", () => ({
+  buildAuthHeaders: () => new Headers(),
+}));
+
+vi.mock("@/lib/server/backend-url", () => ({
+  getKnowledgeBaseUrl: () => "http://upstream.test",
+}));
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request(
+    "http://localhost:3192/api/knowledge/base/c1/documents/d1/preview?app_name=negentropy",
+    { method: "GET", headers: new Headers(headers) },
+  );
+}
+
+const PATH = "/knowledge/base/c1/documents/d1/download";
+
+describe("proxyGetBinary Range + 缓存透传", () => {
+  it("向上游转发 Range / 条件请求头", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 206,
+        headers: { "content-range": "bytes 0-2/100", "accept-ranges": "bytes" },
+      }),
+    );
+
+    await proxyGetBinary(
+      makeRequest({ Range: "bytes=0-2", "If-None-Match": '"abc"' }),
+      PATH,
+      { responseDisposition: "inline" },
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    const sent = init.headers as Headers;
+    expect(sent.get("range")).toBe("bytes=0-2");
+    expect(sent.get("if-none-match")).toBe('"abc"');
+  });
+
+  it("透传 206 + Content-Range / Accept-Ranges / Content-Length", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([9, 9, 9, 9]), {
+        status: 206,
+        headers: {
+          "content-range": "bytes 0-3/5000",
+          "accept-ranges": "bytes",
+          "content-length": "4",
+          "content-type": "application/pdf",
+          etag: '"deadbeef"',
+        },
+      }),
+    );
+
+    const res = await proxyGetBinary(makeRequest({ Range: "bytes=0-3" }), PATH, {
+      responseDisposition: "inline",
+    });
+
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 0-3/5000");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("content-length")).toBe("4");
+    expect(res.headers.get("etag")).toBe('"deadbeef"');
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(new Uint8Array([9, 9, 9, 9]));
+  });
+
+  it("304 拦截于 !ok 之前：返回空 body + 保留 ETag/Cache-Control", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 304,
+        headers: { etag: '"abc"', "cache-control": "private, max-age=300, must-revalidate" },
+      }),
+    );
+
+    const res = await proxyGetBinary(makeRequest({ "If-None-Match": '"abc"' }), PATH, {
+      responseDisposition: "inline",
+    });
+
+    expect(res.status).toBe(304);
+    expect(res.headers.get("etag")).toBe('"abc"');
+    expect(res.headers.get("cache-control")).toBe("private, max-age=300, must-revalidate");
+    expect(await res.text()).toBe("");
+  });
+
+  it("416 带 Content-Range 原样透传（不被包装成 JSON 错误）", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 416,
+        headers: { "content-range": "bytes */5000" },
+      }),
+    );
+
+    const res = await proxyGetBinary(makeRequest({ Range: "bytes=99999-" }), PATH, {
+      responseDisposition: "inline",
+    });
+
+    expect(res.status).toBe(416);
+    expect(res.headers.get("content-range")).toBe("bytes */5000");
+  });
+
+  it("预览 inline 改写：attachment → inline，并透传校验器头", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: {
+          "content-disposition": "attachment; filename*=UTF-8''r.pdf",
+          "content-type": "application/pdf",
+          "accept-ranges": "bytes",
+          "content-length": "1",
+          etag: '"e1"',
+        },
+      }),
+    );
+
+    const res = await proxyGetBinary(makeRequest(), PATH, { responseDisposition: "inline" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-disposition")).toMatch(/^inline/);
+    expect(res.headers.get("content-disposition")).toContain("r.pdf");
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("etag")).toBe('"e1"');
+  });
+
+  it("inline 兜底：octet-stream MIME 回退为 application/pdf", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+
+    const res = await proxyGetBinary(makeRequest(), PATH, { responseDisposition: "inline" });
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+  });
+
+  it("下载（无 inline）：attachment 保持不变，并透传范围/缓存头", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([1, 2]), {
+        status: 200,
+        headers: {
+          "content-disposition": "attachment; filename*=UTF-8''r.pdf",
+          "content-type": "application/pdf",
+          "accept-ranges": "bytes",
+          etag: '"e2"',
+        },
+      }),
+    );
+
+    const res = await proxyGetBinary(makeRequest(), PATH);
+
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment/);
+    expect(res.headers.get("accept-ranges")).toBe("bytes");
+    expect(res.headers.get("etag")).toBe('"e2"');
+  });
+});

--- a/apps/negentropy/src/negentropy/knowledge/_http_range.py
+++ b/apps/negentropy/src/negentropy/knowledge/_http_range.py
@@ -1,0 +1,223 @@
+"""HTTP Range / 条件请求决策助手（RFC 9110/7233）。
+
+为「字节源自 PostgreSQL ``bytea``、非磁盘文件」的下载/预览端点补齐 Starlette
+``FileResponse`` 未暴露的范围决策能力：解析 ``Range`` / ``If-Range`` /
+``If-None-Match`` / ``If-Modified-Since``，裁决 ``200 / 206 / 304 / 416`` 并产出
+对应响应头。本模块为**纯函数、无 DB 依赖**，可脱库单测；实际字节读取与传输由
+调用方（路由层 + 存储层 ``substring`` 部分读）完成，机制与策略正交。
+
+设计取舍：
+
+- **强 ETag**：原文按 ``file_hash``（SHA-256）内容寻址，使用强校验器
+  ``"{file_hash}"``，令 ``If-None-Match`` / ``If-Range`` 判定精确。
+- **单段 Range**：仅支持单段 ``bytes=`` 区间；多段逗号 Range **退化为 200 全量**
+  （规避 ``multipart/byteranges`` 复杂度，浏览器原生 PDF 查看器对此退化兼容良好）。
+- **条件优先级**：``If-None-Match`` 优先于 ``If-Modified-Since``（RFC 9110 §13.2.2）。
+- **越界裁剪**：``end`` 超出 EOF 时裁剪到 ``total-1``（返回可用部分），仅当
+  ``start >= total`` 才判 416（RFC 9110 §14.1.2）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from email.utils import format_datetime, parsedate_to_datetime
+
+__all__ = [
+    "RangeSpec",
+    "RangeDecision",
+    "build_etag",
+    "http_date",
+    "decide_range_response",
+]
+
+
+@dataclass(frozen=True)
+class RangeSpec:
+    """206 响应需读取的字节切片（``start`` 0-based，闭区间长度为 ``length``）。"""
+
+    start: int
+    """0-based 起始偏移（含）。"""
+    length: int
+    """切片字节数（恒 > 0）。"""
+    total: int
+    """资源总字节数。"""
+
+
+@dataclass(frozen=True)
+class RangeDecision:
+    """范围 / 条件请求裁决结果。"""
+
+    status_code: int
+    """``200`` | ``206`` | ``304`` | ``416``。"""
+    headers: dict[str, str]
+    """该响应应携带的头部（已含 ``Accept-Ranges`` / ``ETag`` 等）。"""
+    spec: RangeSpec | None
+    """仅 ``206`` 时非空，指示调用方需读取的字节切片。"""
+    is_full: bool
+    """``True`` 表示调用方应回整份资源（``200``）。"""
+
+
+def build_etag(file_hash: str) -> str:
+    """由内容哈希构造强 ETag（带双引号）。"""
+    return f'"{file_hash}"'
+
+
+def http_date(dt: datetime) -> str:
+    """格式化为 RFC 1123 HTTP-date（GMT）。"""
+    return format_datetime(dt, usegmt=True)
+
+
+def _normalize_etag(token: str) -> str:
+    """去除空白与 ``W/`` 弱校验前缀，便于按值比较。"""
+    return token.strip().removeprefix("W/").strip()
+
+
+def _etag_matches(if_none_match: str, etag: str) -> bool:
+    """``If-None-Match`` 是否命中：支持 ``*`` 与逗号分隔列表，按值比较。"""
+    candidate = if_none_match.strip()
+    if candidate == "*":
+        return True
+    target = _normalize_etag(etag)
+    return any(tok and _normalize_etag(tok) == target for tok in candidate.split(","))
+
+
+def _safe_parse_http_date(value: str) -> datetime | None:
+    """宽松解析 HTTP-date；非法/缺失返回 ``None``（保守地不触发 304）。"""
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    return dt
+
+
+def _parse_range_header(range_header: str, total: int) -> tuple[int, int] | str:
+    """解析单段 ``bytes=`` Range。
+
+    Returns:
+        - ``(start, end)``：可满足的闭区间（``end`` 已裁剪到 ``total-1``）。
+        - ``"ignore"``：非 ``bytes=`` / 多段 / 语法非法 → 调用方应回 200 全量。
+        - ``"unsatisfiable"``：语法合法但越界 → 调用方应回 416。
+    """
+    value = range_header.strip()
+    prefix = "bytes="
+    if not value.lower().startswith(prefix):
+        return "ignore"
+    spec = value[len(prefix) :].strip()
+    if "," in spec:  # 多段 Range：退化为 200 全量
+        return "ignore"
+    if "-" not in spec:
+        return "ignore"
+
+    start_s, _, end_s = spec.partition("-")
+    start_s, end_s = start_s.strip(), end_s.strip()
+    try:
+        if start_s == "":
+            # 后缀区间 ``-N``：末尾 N 字节
+            if end_s == "":
+                return "ignore"
+            suffix = int(end_s)
+            if suffix <= 0 or total == 0:
+                return "unsatisfiable"
+            start = 0 if suffix >= total else total - suffix
+            return (start, total - 1)
+
+        start = int(start_s)
+        if start < 0:
+            return "ignore"
+        if total == 0 or start >= total:
+            return "unsatisfiable"
+        if end_s == "":
+            return (start, total - 1)
+        end = int(end_s)
+        if end < start:
+            return "ignore"  # 非法区间，忽略 → 200 全量
+        return (start, min(end, total - 1))
+    except ValueError:
+        return "ignore"
+
+
+def decide_range_response(
+    *,
+    total_size: int,
+    etag: str,
+    last_modified: datetime,
+    cache_control: str,
+    content_type: str,
+    range_header: str | None,
+    if_range: str | None,
+    if_none_match: str | None,
+    if_modified_since: str | None,
+) -> RangeDecision:
+    """裁决一次下载/预览请求应返回 200 / 206 / 304 / 416 及其响应头。
+
+    Args:
+        total_size: 资源总字节数（来自 ``file_size`` / blob ``size``）。
+        etag: 强 ETag（``build_etag(file_hash)``）。
+        last_modified: 资源最后修改时间（tz-aware）。
+        cache_control: ``Cache-Control`` 头值。
+        content_type: 资源 MIME。
+        range_header / if_range / if_none_match / if_modified_since: 对应请求头原值。
+
+    Returns:
+        :class:`RangeDecision`。调用方据 ``status_code`` 分发：304/416 回空 body；
+        ``is_full`` 回整份；``spec`` 非空时读取切片回 206。
+    """
+    base_headers: dict[str, str] = {
+        "Accept-Ranges": "bytes",
+        "ETag": etag,
+        "Last-Modified": http_date(last_modified),
+        "Cache-Control": cache_control,
+        "Content-Type": content_type,
+    }
+
+    # 1) 条件 GET：If-None-Match 优先于 If-Modified-Since（RFC 9110 §13.2.2）。
+    not_modified = False
+    if if_none_match is not None:
+        not_modified = _etag_matches(if_none_match, etag)
+    elif if_modified_since is not None:
+        ims = _safe_parse_http_date(if_modified_since)
+        if ims is not None:
+            try:
+                not_modified = last_modified.replace(microsecond=0) <= ims
+            except TypeError:
+                # naive/aware 混比等异常：保守地不触发 304。
+                not_modified = False
+    if not_modified:
+        # 304：无 body、无 Content-Length / Content-Range。
+        return RangeDecision(304, dict(base_headers), spec=None, is_full=False)
+
+    def full_200() -> RangeDecision:
+        headers = dict(base_headers)
+        headers["Content-Length"] = str(total_size)
+        return RangeDecision(200, headers, spec=None, is_full=True)
+
+    # 2) 无 Range（或语法不可解析）→ 200 全量。
+    if not range_header:
+        return full_200()
+
+    # 3) If-Range：存在且与当前强 ETag 不匹配 → 忽略 Range，回 200 全量。
+    #    （If-Range 亦可为 HTTP-date 形态；此处仅认强 ETag，其余一律保守回 200，
+    #    不影响正确性，仅放弃该次 Range 优化。）
+    if if_range is not None and _normalize_etag(if_range) != _normalize_etag(etag):
+        return full_200()
+
+    parsed = _parse_range_header(range_header, total_size)
+    if parsed == "ignore":
+        return full_200()
+    if parsed == "unsatisfiable":
+        headers = dict(base_headers)
+        headers["Content-Range"] = f"bytes */{total_size}"
+        return RangeDecision(416, headers, spec=None, is_full=False)
+
+    start, end = parsed  # type: ignore[misc]  # 此处必为 (int, int)
+    length = end - start + 1
+    headers = dict(base_headers)
+    headers["Content-Range"] = f"bytes {start}-{end}/{total_size}"
+    headers["Content-Length"] = str(length)
+    return RangeDecision(
+        206,
+        headers,
+        spec=RangeSpec(start=start, length=length, total=total_size),
+        is_full=False,
+    )

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -8,10 +8,11 @@ from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, status
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request, status
+from fastapi.responses import Response, StreamingResponse
 from pydantic import ValidationError  # noqa: F401
 
+from negentropy.knowledge._http_range import build_etag, decide_range_response
 from negentropy.knowledge._shared import (
     _build_document_response,
     _get_service,
@@ -51,6 +52,11 @@ from negentropy.knowledge.lifecycle_schemas import (  # noqa: F401
 
 logger = get_logger("negentropy.knowledge.api")
 router = APIRouter()
+
+# 原文（PDF 等）下载/预览的缓存策略：内容按 file_hash 内容寻址、强 ETag 保证正确性，
+# 故允许浏览器短期缓存以加速「Markdown↔PDF 切换 / 在新标签打开 / 重访」，过期后
+# 凭 If-None-Match 廉价 304 校验。不使用 `immutable`——同一 document_id 可被重传。
+DOWNLOAD_CACHE_CONTROL = "private, max-age=300, must-revalidate"
 
 
 @router.get("/base/{corpus_id}/documents", response_model=DocumentListResponse)
@@ -534,11 +540,21 @@ async def delete_document(
 
 async def _download_document_impl(
     *,
+    request: Request,
     document_id: UUID,
     corpus_id: UUID | None,
     app_name: str | None,
 ):
-    """下载文档原始文件，返回 StreamingResponse（带 Content-Disposition 头）。"""
+    """下载/预览文档原始文件。
+
+    - **URL 源文档**：返回其 Markdown 正文（``text/markdown``，``attachment``），不施加
+      Range —— 显示内容与历史完全一致。
+    - **二进制源文档（PDF 等）**：支持 HTTP Range（``206``）与条件缓存（``ETag`` /
+      ``If-None-Match`` → ``304``；越界 → ``416``），并补齐 ``Accept-Ranges`` /
+      ``Content-Length`` / ``Last-Modified`` / ``Cache-Control``。使浏览器原生 PDF 查看器
+      可渐进式渲染大文件、并跨视图切换复用缓存。``Content-Disposition`` 固定 ``attachment``
+      （预览场景由 BFF 代理改写为 ``inline``，下载按钮行为不变）。
+    """
     resolved_app = _resolve_app_name(app_name)
 
     from negentropy.storage import StorageError
@@ -562,23 +578,86 @@ async def _download_document_impl(
     metadata = doc.metadata_ or {}
     is_url_doc = metadata.get("source_type") == "url"
 
-    # 下载文件内容
-    try:
-        if is_url_doc:
+    # 文件名跟随用户重命名：display_name 覆盖 → original_filename，
+    # 并保留 original_filename 的扩展名，确保下载内容与扩展名一致可正确打开。
+    filename = effective_download_filename(doc.original_filename, doc.display_name)
+    if is_url_doc and not filename.lower().endswith(".md"):
+        filename = f"{filename}.md"
+    encoded_filename = urllib.parse.quote(filename)
+    content_disposition = f"attachment; filename*=UTF-8''{encoded_filename}"
+
+    # URL 源文档：返回 Markdown 正文（不支持 Range，行为与历史一致）。
+    if is_url_doc:
+        try:
             markdown_text = await storage_service.get_document_markdown(document_id)
-            if not markdown_text:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail={"code": "DOCUMENT_NOT_FOUND", "message": "Document markdown content not found"},
-                )
-            content = markdown_text.encode("utf-8")
-        else:
-            content = await storage_service.get_document_content(document_id)
-            if content is None:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail={"code": "DOCUMENT_NOT_FOUND", "message": "Document content not found"},
-                )
+        except StorageError as exc:
+            logger.error("document_download_failed", doc_id=str(document_id), error=str(exc))
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={"code": "DOWNLOAD_FAILED", "message": "Failed to download document"},
+            ) from exc
+        if not markdown_text:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "DOCUMENT_NOT_FOUND", "message": "Document markdown content not found"},
+            )
+        return StreamingResponse(
+            BytesIO(markdown_text.encode("utf-8")),
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": content_disposition},
+        )
+
+    # 二进制源文档：Range + 条件缓存协商。
+    media_type = doc.content_type or "application/octet-stream"
+    total_size = doc.file_size
+    if not total_size:
+        # file_size 理论 NOT NULL；异常存量数据回退按 blob 实际大小。
+        try:
+            total_size = await storage_service.get_blob_size_by_uri(doc.content_uri) or 0
+        except StorageError as exc:
+            logger.error("document_download_failed", doc_id=str(document_id), error=str(exc))
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail={"code": "DOWNLOAD_FAILED", "message": "Failed to download document"},
+            ) from exc
+
+    decision = decide_range_response(
+        total_size=total_size,
+        etag=build_etag(doc.file_hash),
+        last_modified=doc.updated_at,
+        cache_control=DOWNLOAD_CACHE_CONTROL,
+        content_type=media_type,
+        range_header=request.headers.get("range"),
+        if_range=request.headers.get("if-range"),
+        if_none_match=request.headers.get("if-none-match"),
+        if_modified_since=request.headers.get("if-modified-since"),
+    )
+    headers = dict(decision.headers)
+    headers["Content-Disposition"] = content_disposition
+
+    # 304 / 416：无 body（416 头已含 Content-Range: bytes */{total}）。
+    if decision.status_code in (status.HTTP_304_NOT_MODIFIED, status.HTTP_416_RANGE_NOT_SATISFIABLE):
+        return Response(status_code=decision.status_code, headers=headers)
+
+    try:
+        if decision.spec is not None:
+            # 206：只读所需切片（PostgreSQL substring 部分读，不入整块内存）。
+            chunk = await storage_service.download_blob_range_by_uri(
+                doc.content_uri, decision.spec.start, decision.spec.length
+            )
+            return Response(
+                content=chunk,
+                status_code=status.HTTP_206_PARTIAL_CONTENT,
+                media_type=media_type,
+                headers=headers,
+            )
+        # 200 全量：复用既有读取路径，与「下载」按钮字节完全一致。
+        content = await storage_service.get_document_content(document_id)
+        if content is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"code": "DOCUMENT_NOT_FOUND", "message": "Document content not found"},
+            )
     except StorageError as exc:
         logger.error("document_download_failed", doc_id=str(document_id), error=str(exc))
         raise HTTPException(
@@ -586,39 +665,34 @@ async def _download_document_impl(
             detail={"code": "DOWNLOAD_FAILED", "message": "Failed to download document"},
         ) from exc
 
-    # 文件名跟随用户重命名：display_name 覆盖 → original_filename，
-    # 并保留 original_filename 的扩展名，确保下载内容与扩展名一致可正确打开。
-    filename = effective_download_filename(doc.original_filename, doc.display_name)
-    if is_url_doc and not filename.lower().endswith(".md"):
-        filename = f"{filename}.md"
-    encoded_filename = urllib.parse.quote(filename)
-
     return StreamingResponse(
         BytesIO(content),
-        media_type="text/markdown; charset=utf-8" if is_url_doc else (doc.content_type or "application/octet-stream"),
-        headers={
-            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
-        },
+        media_type=media_type,
+        headers=headers,
     )
 
 
 @router.get("/base/{corpus_id}/documents/{document_id}/download")
 async def download_document(
+    request: Request,
     corpus_id: UUID,
     document_id: UUID,
     app_name: str | None = Query(default=None),
 ):
-    """下载文档原始文件
+    """下载/预览文档原始文件（支持 Range + 条件缓存）
 
     Args:
+        request: 用于读取 Range / 条件请求头
         corpus_id: 知识库 ID
         document_id: 文档 ID
         app_name: 应用名称
 
     Returns:
-        StreamingResponse: 文件流（带 Content-Disposition 头）
+        Response: 200 全量 / 206 分段 / 304 未改动 / 416 区间不可满足
     """
-    return await _download_document_impl(document_id=document_id, corpus_id=corpus_id, app_name=app_name)
+    return await _download_document_impl(
+        request=request, document_id=document_id, corpus_id=corpus_id, app_name=app_name
+    )
 
 
 async def _get_document_asset_impl(

--- a/apps/negentropy/src/negentropy/knowledge/routes/library.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/library.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
 
 from negentropy.auth.deps import get_optional_user
 from negentropy.auth.service import AuthUser
@@ -262,11 +262,12 @@ async def delete_library_document(
 
 @router.get("/documents/{document_id}/download")
 async def download_library_document(
+    request: Request,
     document_id: UUID,
     app_name: str | None = Query(default=None),
 ):
-    """下载文档原始文件。"""
-    return await _download_document_impl(document_id=document_id, corpus_id=None, app_name=app_name)
+    """下载/预览库文档原始文件（支持 Range + 条件缓存）。"""
+    return await _download_document_impl(request=request, document_id=document_id, corpus_id=None, app_name=app_name)
 
 
 @router.post(

--- a/apps/negentropy/src/negentropy/storage/postgres_client.py
+++ b/apps/negentropy/src/negentropy/storage/postgres_client.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import hashlib
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -107,6 +107,43 @@ class PostgresBlobStorage:
         content = row[0]
         logger.info("blob_download_completed", uri=uri, size=len(content))
         return content
+
+    async def get_size(self, uri: str) -> int | None:
+        """按 URI 返回对象字节数（仅读 ``size`` 列，不取 ``content``）。"""
+        key = parse_uri(uri)
+        try:
+            async with db_session.AsyncSessionLocal() as db:
+                result = await db.execute(select(BlobObject.size).where(BlobObject.key == key))
+                row = result.one_or_none()
+        except SQLAlchemyError as exc:
+            logger.error("blob_get_size_failed", uri=uri, error=str(exc))
+            raise StorageError(f"Failed to get blob size {uri}: {exc}") from exc
+
+        return None if row is None else int(row[0])
+
+    async def download_range(self, uri: str, start: int, length: int) -> bytes:
+        """下载 ``[start, start+length)`` 字节切片。
+
+        用 PostgreSQL ``substring(content FROM :from FOR :for)`` 只取所需切片，
+        避免大 PDF 全量入内存。注意 ``substring`` 为 **1-based**，故 ``start + 1``。
+        """
+        key = parse_uri(uri)
+        try:
+            async with db_session.AsyncSessionLocal() as db:
+                slice_col = func.substring(BlobObject.content, start + 1, length)
+                result = await db.execute(select(slice_col).where(BlobObject.key == key))
+                row = result.one_or_none()
+        except SQLAlchemyError as exc:
+            logger.error("blob_download_range_failed", uri=uri, error=str(exc))
+            raise StorageError(f"Failed to download blob range {uri}: {exc}") from exc
+
+        if row is None:
+            raise StorageError(f"Blob not found: {uri}")
+
+        # asyncpg 对 bytea 可能回 memoryview，统一归一为 bytes。
+        chunk = bytes(row[0])
+        logger.info("blob_download_range_completed", uri=uri, start=start, length=len(chunk))
+        return chunk
 
     async def delete(self, uri: str) -> None:
         """按 URI 删除 blob（不存在视为成功，幂等）。"""

--- a/apps/negentropy/src/negentropy/storage/protocol.py
+++ b/apps/negentropy/src/negentropy/storage/protocol.py
@@ -85,6 +85,41 @@ class BlobStorage(Protocol):
         """
         ...
 
+    async def get_size(self, uri: str) -> int | None:
+        """按 blob URI 返回对象字节数（不读取内容）。
+
+        用于 HTTP Range 协商：调用方据此计算 ``Content-Range`` / 裁剪区间，
+        无需先下载整块内容。
+
+        Args:
+            uri: ``pgblob://{key}`` URI。
+
+        Returns:
+            字节数；对象不存在返回 ``None``。
+
+        Raises:
+            StorageError: 查询失败。
+        """
+        ...
+
+    async def download_range(self, uri: str, start: int, length: int) -> bytes:
+        """按 blob URI 下载 ``[start, start+length)`` 字节切片。
+
+        仅读取所需切片（PostgreSQL ``substring``），避免大文件全量入内存。
+
+        Args:
+            uri: ``pgblob://{key}`` URI。
+            start: 0-based 起始偏移（含）。
+            length: 切片字节数（> 0）。
+
+        Returns:
+            切片字节（长度 ≤ ``length``，若越界则为可用部分）。
+
+        Raises:
+            StorageError: 下载失败 / 对象不存在。
+        """
+        ...
+
     async def delete(self, uri: str) -> None:
         """按 blob URI 删除对象（不存在视为成功，幂等）。
 

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -895,3 +895,14 @@ class DocumentStorageService:
             StorageError: If blob download fails
         """
         return await self._get_blob().download(content_uri)
+
+    async def get_blob_size_by_uri(self, content_uri: str) -> int | None:
+        """按 blob URI 返回字节数（用于 HTTP Range 协商，不取 content）。
+
+        路由层已持有 ``doc.content_uri``，经此直通避免重复 ``get_document``。
+        """
+        return await self._get_blob().get_size(content_uri)
+
+    async def download_blob_range_by_uri(self, content_uri: str, start: int, length: int) -> bytes:
+        """按 blob URI 下载 ``[start, start+length)`` 字节切片（HTTP 206 用）。"""
+        return await self._get_blob().download_range(content_uri, start, length)

--- a/apps/negentropy/tests/integration_tests/storage/test_postgres_blob.py
+++ b/apps/negentropy/tests/integration_tests/storage/test_postgres_blob.py
@@ -50,6 +50,33 @@ class TestUploadDownload:
             await storage.download("pgblob://knowledge/nonexistent/key")
 
 
+class TestRangeReads:
+    """``get_size`` / ``download_range``（HTTP Range 部分读）。"""
+
+    async def test_get_size_matches_content_length(self, storage):
+        content = bytes(range(256)) * 4  # 1024 字节
+        uri = await storage.upload(content, "knowledge/app/c/size.bin")
+        assert await storage.get_size(uri) == len(content)
+
+    async def test_get_size_missing_returns_none(self, storage):
+        assert await storage.get_size("pgblob://knowledge/missing/size.bin") is None
+
+    async def test_download_range_byte_exact(self, storage):
+        # 用 0x00..0xff 全字节序列证明按字节精确（非文本化、非编码错位）。
+        content = bytes(range(256)) * 4  # 1024 字节
+        uri = await storage.upload(content, "knowledge/app/c/range.bin")
+        # 起始
+        assert await storage.download_range(uri, 0, 100) == content[0:100]
+        # 中段
+        assert await storage.download_range(uri, 500, 123) == content[500:623]
+        # 尾部
+        assert await storage.download_range(uri, len(content) - 10, 10) == content[-10:]
+
+    async def test_download_range_missing_raises(self, storage):
+        with pytest.raises(StorageError):
+            await storage.download_range("pgblob://knowledge/missing/range.bin", 0, 10)
+
+
 class TestDeleteAndExists:
     async def test_exists_true_after_upload(self, storage):
         await storage.upload(b"data", "knowledge/app/c/exists.bin")

--- a/apps/negentropy/tests/unit_tests/knowledge/test_document_download_range.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_document_download_range.py
@@ -1,0 +1,129 @@
+"""文档下载/预览端点的 HTTP Range + 条件缓存路由测试。
+
+经 ``FastAPI() + include_router + TestClient`` 驱动真实请求头解析，``monkeypatch``
+注入 Fake ``DocumentStorageService`` 以脱离 blob/DB，断言 200/206/304/416 分发、
+切片正确性、校验器头，以及 **URL 源文档仍返回 Markdown、不施加 Range**（显示内容回归护栏）。
+同时覆盖 corpus 与 library 两条路由（共用同一 ``_download_document_impl``）。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from negentropy.knowledge.routes import documents as documents_routes
+from negentropy.knowledge.routes import library as library_routes
+
+PDF_BYTES = bytes(range(256)) * 4  # 1024 字节，确定性可切片
+MD_TEXT = "# Hello\n\n正文内容。"
+FILE_HASH = "ab" * 32  # 64 hex
+UPDATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+ETAG = f'"{FILE_HASH}"'
+
+
+class _FakeDoc:
+    def __init__(self, *, is_url: bool = False) -> None:
+        self.metadata_ = {"source_type": "url"} if is_url else {}
+        self.original_filename = "page.html" if is_url else "report.pdf"
+        self.display_name = None
+        self.content_type = "text/html" if is_url else "application/pdf"
+        self.file_size = 0 if is_url else len(PDF_BYTES)
+        self.file_hash = FILE_HASH
+        self.updated_at = UPDATED_AT
+        self.content_uri = "pgblob://knowledge/app/c/report.pdf"
+
+
+class _FakeService:
+    def __init__(self, doc: _FakeDoc) -> None:
+        self._doc = doc
+
+    async def get_document(self, *, document_id, corpus_id=None, app_name=None):
+        return self._doc
+
+    async def get_document_content(self, document_id):
+        return PDF_BYTES
+
+    async def download_blob_range_by_uri(self, content_uri, start, length):
+        return PDF_BYTES[start : start + length]
+
+    async def get_blob_size_by_uri(self, content_uri):
+        return len(PDF_BYTES)
+
+    async def get_document_markdown(self, document_id):
+        return MD_TEXT
+
+
+def _client(monkeypatch, doc: _FakeDoc) -> TestClient:
+    # 路由内 `from negentropy.storage.service import DocumentStorageService` 在调用时
+    # 绑定，故 patch 模块属性为返回 Fake 的工厂（impl 以无参 `DocumentStorageService()` 构造）。
+    monkeypatch.setattr("negentropy.storage.service.DocumentStorageService", lambda: _FakeService(doc))
+    app = FastAPI()
+    app.include_router(documents_routes.router)
+    app.include_router(library_routes.router)
+    return TestClient(app)
+
+
+CORPUS_URL = "/base/11111111-1111-1111-1111-111111111111/documents/22222222-2222-2222-2222-222222222222/download"
+LIBRARY_URL = "/documents/22222222-2222-2222-2222-222222222222/download"
+
+
+class TestBinaryRange:
+    def test_plain_get_returns_200_with_validators(self, monkeypatch):
+        client = _client(monkeypatch, _FakeDoc())
+        r = client.get(CORPUS_URL)
+        assert r.status_code == 200
+        assert r.headers["accept-ranges"] == "bytes"
+        assert r.headers["content-length"] == str(len(PDF_BYTES))
+        assert r.headers["etag"] == ETAG
+        assert "last-modified" in r.headers
+        assert r.headers["cache-control"] == documents_routes.DOWNLOAD_CACHE_CONTROL
+        assert r.headers["content-disposition"].lower().startswith("attachment")
+        assert "content-range" not in r.headers
+        assert r.content == PDF_BYTES
+
+    def test_range_returns_206_exact_slice(self, monkeypatch):
+        client = _client(monkeypatch, _FakeDoc())
+        r = client.get(CORPUS_URL, headers={"Range": "bytes=0-99"})
+        assert r.status_code == 206
+        assert r.headers["content-range"] == f"bytes 0-99/{len(PDF_BYTES)}"
+        assert r.headers["content-length"] == "100"
+        assert r.content == PDF_BYTES[0:100]
+
+    def test_suffix_range(self, monkeypatch):
+        client = _client(monkeypatch, _FakeDoc())
+        r = client.get(CORPUS_URL, headers={"Range": "bytes=-10"})
+        assert r.status_code == 206
+        assert r.content == PDF_BYTES[-10:]
+
+    def test_if_none_match_returns_304_empty(self, monkeypatch):
+        client = _client(monkeypatch, _FakeDoc())
+        r = client.get(CORPUS_URL, headers={"If-None-Match": ETAG})
+        assert r.status_code == 304
+        assert r.content == b""
+        assert r.headers["etag"] == ETAG
+
+    def test_unsatisfiable_range_returns_416(self, monkeypatch):
+        client = _client(monkeypatch, _FakeDoc())
+        r = client.get(CORPUS_URL, headers={"Range": "bytes=100000-100100"})
+        assert r.status_code == 416
+        assert r.headers["content-range"] == f"bytes */{len(PDF_BYTES)}"
+
+    def test_library_route_supports_range(self, monkeypatch):
+        client = _client(monkeypatch, _FakeDoc())
+        r = client.get(LIBRARY_URL, headers={"Range": "bytes=10-19"})
+        assert r.status_code == 206
+        assert r.content == PDF_BYTES[10:20]
+
+
+class TestUrlDocUnchanged:
+    def test_url_doc_returns_markdown_without_range(self, monkeypatch):
+        # 显示内容回归护栏：URL 源文档仍返回 Markdown，不施加 Range，附 attachment。
+        client = _client(monkeypatch, _FakeDoc(is_url=True))
+        r = client.get(CORPUS_URL, headers={"Range": "bytes=0-9"})
+        assert r.status_code == 200  # 不是 206
+        assert r.headers["content-type"].startswith("text/markdown")
+        assert "content-range" not in r.headers
+        assert r.headers["content-disposition"].lower().startswith("attachment")
+        assert r.content == MD_TEXT.encode("utf-8")

--- a/apps/negentropy/tests/unit_tests/knowledge/test_http_range.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_http_range.py
@@ -1,0 +1,181 @@
+"""``negentropy.knowledge._http_range`` 纯函数单元测试（RFC 9110/7233 语义）。
+
+覆盖 200/206/304/416 全分支与条件请求优先级、Range 解析各形态（闭区间 / 开区间 /
+后缀 / 越界裁剪 / 不可满足 / 多段退化）及空文件边界。本模块为纯函数，断言不依赖 DB。
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from negentropy.knowledge._http_range import (
+    RangeSpec,
+    build_etag,
+    decide_range_response,
+    http_date,
+)
+
+LM = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+ETAG = '"deadbeef"'
+CACHE = "private, max-age=300, must-revalidate"
+CT = "application/pdf"
+
+
+def _decide(total=1000, *, range_header=None, if_range=None, if_none_match=None, if_modified_since=None):
+    return decide_range_response(
+        total_size=total,
+        etag=ETAG,
+        last_modified=LM,
+        cache_control=CACHE,
+        content_type=CT,
+        range_header=range_header,
+        if_range=if_range,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
+    )
+
+
+class TestPrimitives:
+    def test_build_etag_is_quoted_strong(self):
+        assert build_etag("abc123") == '"abc123"'
+
+    def test_http_date_rfc1123_gmt(self):
+        assert http_date(LM) == "Fri, 02 Jan 2026 03:04:05 GMT"
+
+
+class TestFull200:
+    def test_no_range_returns_200_with_full_headers(self):
+        d = _decide()
+        assert d.status_code == 200
+        assert d.is_full is True
+        assert d.spec is None
+        assert d.headers["Accept-Ranges"] == "bytes"
+        assert d.headers["Content-Length"] == "1000"
+        assert d.headers["ETag"] == ETAG
+        assert d.headers["Last-Modified"] == "Fri, 02 Jan 2026 03:04:05 GMT"
+        assert d.headers["Cache-Control"] == CACHE
+        assert d.headers["Content-Type"] == CT
+        assert "Content-Range" not in d.headers
+
+    def test_non_bytes_unit_ignored(self):
+        assert _decide(range_header="items=0-1").status_code == 200
+
+    def test_malformed_range_ignored(self):
+        assert _decide(range_header="bytes=abc").status_code == 200
+
+    def test_multi_range_degrades_to_full(self):
+        d = _decide(range_header="bytes=0-10,20-30")
+        assert d.status_code == 200
+        assert d.is_full is True
+
+    def test_inverted_range_ignored(self):
+        # end < start 视为非法 → 回 200 全量
+        assert _decide(range_header="bytes=500-100").status_code == 200
+
+
+class TestPartial206:
+    def test_closed_range(self):
+        d = _decide(range_header="bytes=0-99")
+        assert d.status_code == 206
+        assert d.headers["Content-Range"] == "bytes 0-99/1000"
+        assert d.headers["Content-Length"] == "100"
+        assert d.spec == RangeSpec(start=0, length=100, total=1000)
+        assert "Accept-Ranges" in d.headers
+
+    def test_open_ended_range(self):
+        d = _decide(range_header="bytes=100-")
+        assert d.status_code == 206
+        assert d.headers["Content-Range"] == "bytes 100-999/1000"
+        assert d.headers["Content-Length"] == "900"
+        assert d.spec == RangeSpec(start=100, length=900, total=1000)
+
+    def test_suffix_range(self):
+        d = _decide(range_header="bytes=-50")
+        assert d.status_code == 206
+        assert d.headers["Content-Range"] == "bytes 950-999/1000"
+        assert d.spec == RangeSpec(start=950, length=50, total=1000)
+
+    def test_suffix_larger_than_total_returns_whole(self):
+        d = _decide(range_header="bytes=-2000")
+        assert d.status_code == 206
+        assert d.headers["Content-Range"] == "bytes 0-999/1000"
+        assert d.spec == RangeSpec(start=0, length=1000, total=1000)
+
+    def test_end_beyond_eof_is_clamped(self):
+        d = _decide(total=50, range_header="bytes=0-99")
+        assert d.status_code == 206
+        assert d.headers["Content-Range"] == "bytes 0-49/50"
+        assert d.headers["Content-Length"] == "50"
+
+
+class TestUnsatisfiable416:
+    def test_start_beyond_eof(self):
+        d = _decide(total=1000, range_header="bytes=1000-1100")
+        assert d.status_code == 416
+        assert d.headers["Content-Range"] == "bytes */1000"
+        assert d.spec is None
+        assert "Content-Length" not in d.headers
+
+    def test_zero_suffix(self):
+        assert _decide(range_header="bytes=-0").status_code == 416
+
+
+class TestConditional:
+    def test_if_none_match_hit_returns_304(self):
+        d = _decide(if_none_match=ETAG)
+        assert d.status_code == 304
+        assert d.headers["ETag"] == ETAG
+        assert "Content-Length" not in d.headers
+        assert "Content-Range" not in d.headers
+
+    def test_if_none_match_star_returns_304(self):
+        assert _decide(if_none_match="*").status_code == 304
+
+    def test_if_none_match_weak_form_matches(self):
+        assert _decide(if_none_match=f"W/{ETAG}").status_code == 304
+
+    def test_if_none_match_miss_proceeds(self):
+        assert _decide(if_none_match='"other"').status_code == 200
+
+    def test_if_none_match_precedes_if_modified_since(self):
+        # INM 不命中时即便 IMS 命中也不应 304（INM 优先）
+        future = http_date(LM + timedelta(days=1))
+        d = _decide(if_none_match='"other"', if_modified_since=future)
+        assert d.status_code == 200
+
+    def test_if_modified_since_not_modified_returns_304(self):
+        future = http_date(LM + timedelta(seconds=10))
+        assert _decide(if_modified_since=future).status_code == 304
+
+    def test_if_modified_since_modified_returns_200(self):
+        past = http_date(LM - timedelta(seconds=10))
+        assert _decide(if_modified_since=past).status_code == 200
+
+    def test_if_modified_since_malformed_ignored(self):
+        assert _decide(if_modified_since="not-a-date").status_code == 200
+
+    def test_conditional_304_takes_precedence_over_range(self):
+        # 条件命中时无视 Range，直接 304
+        assert _decide(range_header="bytes=0-99", if_none_match=ETAG).status_code == 304
+
+
+class TestIfRange:
+    def test_if_range_match_serves_206(self):
+        d = _decide(range_header="bytes=0-99", if_range=ETAG)
+        assert d.status_code == 206
+
+    def test_if_range_mismatch_serves_full_200(self):
+        d = _decide(range_header="bytes=0-99", if_range='"stale"')
+        assert d.status_code == 200
+        assert d.is_full is True
+
+
+class TestEmptyResource:
+    def test_no_range_zero_length(self):
+        d = _decide(total=0)
+        assert d.status_code == 200
+        assert d.headers["Content-Length"] == "0"
+
+    def test_any_range_on_empty_is_416(self):
+        assert _decide(total=0, range_header="bytes=0-0").status_code == 416
+        assert _decide(total=0, range_header="bytes=-5").status_code == 416


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Knowledge/Documents 文档详情页查看 **PDF 源文档原文**时，浏览器原生查看器因后端未回 `Accept-Ranges`/`Content-Length` 而**必须整份下载完毕才渲染首页**，大 PDF 首屏极慢；BFF 二进制代理又吞掉 `Range`/缓存头、并把 `304` 误判为错误，进一步阻断渐进式加载与缓存复用。
- 关联上下文/Issue/文档：用户诉求「优化 PDF 视图加载与渲染速度，且不影响内容显示效果」。采用业界标准 HTTP Range（RFC 9110/7233）+ 条件缓存，沿用原生查看器路线（不引入 pdf.js/worker）。

# 核心变更
- **后端**：新增纯函数 `_http_range.py`（裁决 `200/206/304/416`，强 `ETag=file_hash`）；`PostgresBlobStorage` 增 `get_size`/`download_range`（PG `substring` **仅读所需切片**，不入整块内存）；下载/预览端点（corpus + library 两路由）按 `Range` 分发并补 `Accept-Ranges`/`Content-Length`/`ETag`/`Last-Modified`/`Cache-Control`。
- **BFF**：`proxyGetBinary` 转发 `Range`/条件请求头，先于 `!ok` 分支拦截 `304`/`416`，透传 `Content-Range`/`Accept-Ranges`/`Content-Length`/`ETag`/`Last-Modified`；二进制超时提至 120s（一处修改覆盖全部 preview/download/asset 路由）。
- **前端**：`DocumentPdfViewer` 加纯 CSS 加载占位（置于 `<object>` 之下、无 `onLoad` 依赖，无卡死风险）；详情页 PDF 标签 hover/focus「意图预取」，使切换近乎秒开。

# 风险与回滚
- 主要风险：渐进加载依赖端到端透传，BFF 漏传头时**退化为整份下载（不致错）**；**URL 源文档 Markdown 分支与「下载」按钮 `attachment` 行为完全不变**（已加回归护栏测试）。无 DB schema / 迁移变更。
- 回滚方式：本变更为单一提交，`git revert` 即可；三层各自独立安全（前端缺后端时透传缺失头为 no-op，后端缺前端亦无破坏）。

# 验证证据
- 单元测试：后端 `_http_range` 全分支（Range 解析/条件优先级/边界）+ 路由 `200/206/304/416` 分发；前端 `proxy-get-binary` 范围/缓存透传断言、`DocumentPdfViewer` 占位断言。
- 集成测试：`test_postgres_blob` 新增 `download_range`/`get_size` 字节精确用例（`0x00..0xff` 序列证明非文本化错位）。
- E2E/Workflow：实机 DevTools 回归（`/preview` 多次 `206`+`Content-Range`、切换/刷新 `304`）**建议部署后执行**——运行中引擎从主仓启动、不宜对同库并起第二引擎，且后端改动需部署后才作用于 live。
- 覆盖率/关键截图：后端 50 例、前端 knowledge 238 例全通过；`ruff check`/`format`、`eslint`、`tsc` 均干净。

# 影响范围
- 前端：`app/api/knowledge/_proxy.ts`、`features/knowledge/components/DocumentPdfViewer.tsx`、文档详情页 `page.tsx`。
- 后端：`knowledge/_http_range.py`（新）、`knowledge/routes/{documents,library}.py`、`storage/{postgres_client,protocol,service}.py`。
- GitHub Actions / 文档：无 CI 配置变更；无数据库 schema / 迁移变更。

# Next Best Action
- 部署后用已认证 Chrome 打开大 PDF → DevTools Network 确认 `/preview` 出现多次 `206`+`Content-Range`、切换/刷新走 `304`、下载按钮仍 `attachment` 全量、Markdown/CJK/图片显示无变化。
- 若需进一步压缩**非线性化**大 PDF 首屏，可评估入库时 `qpdf --linearize`、或将 `blob_objects.content` 设 `STORAGE EXTERNAL` 提升 `substring` 部分读效率（实测有需要再做）。
