### PR TITLE
fix(Interface): 修复 Agents/Tools/MCP/Skills 卡片中栏描述右侧溢出卡片

### DIFF
--- a/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx
@@ -104,7 +104,7 @@ export function AgentCard({ agent, onEdit, onDelete }: AgentCardProps) {
 
         {/* Description */}
         <p
-          className="mb-1 ml-6 h-[60px] min-w-0 w-full overflow-hidden leading-5 line-clamp-3 text-sm text-text-muted"
+          className="mb-1 pl-6 pr-2 h-[60px] min-w-0 overflow-hidden leading-5 line-clamp-3 text-sm text-text-muted"
           title={agent.description || "No description"}
         >
           {agent.description || "No description"}

--- a/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
@@ -952,7 +952,7 @@ export function McpServerCard({
           </div>
 
           <p
-            className="mb-1 ml-6 h-[60px] min-w-0 w-full overflow-hidden text-sm leading-5 text-text-muted line-clamp-3"
+            className="mb-1 pl-6 pr-2 h-[60px] min-w-0 overflow-hidden text-sm leading-5 text-text-muted line-clamp-3"
             title={summaryDescription}
           >
             {summaryDescription}

--- a/apps/negentropy-ui/app/interface/skills/_components/SkillCard.tsx
+++ b/apps/negentropy-ui/app/interface/skills/_components/SkillCard.tsx
@@ -230,7 +230,7 @@ export function SkillCard({
           )}
         </div>
         <p
-          className="mb-1 ml-6 h-20 min-w-0 w-full overflow-hidden break-words text-sm leading-5 text-text-muted line-clamp-4"
+          className="mb-1 pl-6 pr-2 h-20 min-w-0 overflow-hidden break-words text-sm leading-5 text-text-muted line-clamp-4"
           title={skill.description || "No description"}
         >
           {skill.description || "No description"}

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx
@@ -171,7 +171,7 @@ export function ToolCard({
           )}
         </div>
         <p
-          className="mb-1 ml-6 h-20 min-w-0 w-full overflow-hidden break-words text-sm leading-5 text-text-muted line-clamp-4"
+          className="mb-1 pl-6 pr-2 h-20 min-w-0 overflow-hidden break-words text-sm leading-5 text-text-muted line-clamp-4"
           title={tool.description || "No description"}
         >
           {tool.description || "No description"}


### PR DESCRIPTION
## 背景与问题

Interface 各页(Agents / Tools / MCP / Skills)的卡片中,**中栏描述文案右侧溢出卡片边界**、被贴边裁切而无留白(以 Agents 页 `ContemplationFaculty`、`InfluenceFaculty` 最为明显)。

## 根因(读码定位)

描述段落 `<p>` 同时使用了 `ml-6`(`margin-left: 24px`)与 `w-full`(`width: 100%`)。在 flex 纵向容器中 `w-full` 已等于容器整宽,叠加 24px 左外边距后,**盒子右沿比卡片内容区多出 24px**——吃掉外层包装器 `p-4`(16px)的右内边距,并被卡片 `overflow-hidden` 在内边距盒处裁切,致使描述前两行文字一路贴到右边框被拦腰切断。

> 佐证:同卡片页脚行用 `ml-6` 但**不带** `w-full`,渲染正常;徽章行用 `pl-6` 同样正常。即 `w-full` 为异常项。

## 改动

该 `ml-6 … w-full` 写法是同一份复制粘贴骨架,**完全一致地存在于 4 个同级卡片**,故一并修复(保持 Interface 各页视觉一致)。每文件仅改 1 行 className,统一 `ml-6 … w-full` → `pl-6 pr-2`:

- 去 `w-full`:盒子靠 flex 默认 `align-items: stretch` 恰好钉在卡片内容区两侧,**从根上消除溢出**;
- `pl-6`:保留描述相对标题/徽章行的左缩进对齐(徽章行本就用 `pl-6`,左侧观感零变化);
- `pr-2`:在外层 `p-4`(16px)之上再内收,**右侧总间隙 ≈ 24px ≈ 1.5–1.7 倍字宽**(`text-sm`≈14px),落实"约 1.5 倍字宽"诉求。

涉及文件:

- `apps/negentropy-ui/app/interface/agents/_components/AgentCard.tsx`
- `apps/negentropy-ui/app/interface/tools/_components/ToolCard.tsx`
- `apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx`
- `apps/negentropy-ui/app/interface/skills/_components/SkillCard.tsx`

## 验证

- **静态检查**:pre-commit 全量通过,其中 ESLint(negentropy-ui)Passed。
- **实机视觉回归**(本地 dev `:3195`,真实登录态):
  - Agents 页(`line-clamp-3 h-[60px]` 变体)与 Tools 页(`line-clamp-4 break-words h-20` 变体)描述右侧均有清晰留白、**无字符贴边/裁切**;
  - 左缩进、行数(line-clamp)、卡片高度均不变;长 token(如 `invoke_claude_code`)经 `break-words` 正常换行。