### PR TITLE
refactor(Routine): 迭代明细卡片改为折叠式渐进披露

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, ListTree } from "lucide-react";
 
 import type { RoutineIterationDTO } from "@/features/routine";
 import { AGENT_ROLE_META, deriveIterationDriver } from "@/features/routine";
+import { cn } from "@/lib/utils";
 
 import { LiveElapsed, StaticDuration } from "./ElapsedClock";
 import { MarkdownText } from "./MarkdownText";
@@ -39,7 +40,7 @@ export function RoutineIterationTimeline({
 
   return (
     <>
-      <ol className="space-y-2">
+      <ol className="space-y-1.5">
         {pageItems.map((it) => (
           <IterationCard key={it.id} it={it} onApprove={onApprove} onAudit={onAudit} busy={busy} />
         ))}
@@ -73,6 +74,44 @@ export function RoutineIterationTimeline({
   );
 }
 
+/** Iteration 状态 → 简短中文标签（收起态无 summary 时降级占位用）。 */
+const ITERATION_STATUS_LABEL: Record<string, string> = {
+  pending_approval: "待审批",
+  dispatched: "已派发",
+  in_flight: "执行中",
+  executed: "已执行",
+  evaluated: "已评估",
+  reaped: "已收割",
+  aborted: "已中止",
+};
+
+/** 收起态单行摘要：取 summary 首行、剥离常见 Markdown 记号、超长截断；
+ * summary 为空时降级为「相位 · 状态」占位。纯机械处理，无 LLM。 */
+function summaryHeadline(it: RoutineIterationDTO): { text: string; full: string | null } {
+  const raw = it.summary?.trim();
+  if (!raw) {
+    const ph = it.phase ? phaseLabel(it.phase) : "";
+    const st = ITERATION_STATUS_LABEL[it.status] ?? it.status;
+    return { text: [ph, st].filter(Boolean).join(" · "), full: null };
+  }
+  // 取首条「有意义」行：跳过空行与纯分隔线（--- / *** / ___）
+  const firstLine =
+    raw.split("\n").map((l) => l.trim()).find((l) => l.length > 0 && !/^(?:[-*_]\s*){3,}$/.test(l)) ?? "";
+  const stripped = firstLine
+    .replace(/^#+\s*/, "") // ATX 标题
+    .replace(/^[-*+]\s+/, "") // 列表项
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // 链接 → 文本
+    .replace(/\*\*([^*]+)\*\*/g, "$1") // **加粗**
+    .replace(/__([^_]+)__/g, "$1") // __加粗__
+    .replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1") // _斜体_（词边界，保留 PR_URL / file_name 等中间下划线）
+    .replace(/(?<!\w)\*([^*]+)\*(?!\w)/g, "$1") // *斜体*
+    .replace(/~~([^~]+)~~/g, "$1") // ~~删除线~~
+    .replace(/`([^`]+)`/g, "$1") // `行内代码`
+    .trim();
+  const text = stripped.length > 100 ? `${stripped.slice(0, 100)}…` : stripped;
+  return { text: text || raw.slice(0, 100), full: raw };
+}
+
 function IterationCard({
   it,
   onApprove,
@@ -84,41 +123,79 @@ function IterationCard({
   onAudit?: (iteration: RoutineIterationDTO) => void;
   busy?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const isPendingApproval = it.status === "pending_approval";
   const isActive = !it.finished_at && ACTIVE_TIMING.has(it.status);
+  const isPendingApproval = it.status === "pending_approval";
+  // 活跃迭代（待审批 / 执行中 / 已派发）默认展开以暴露实时计时与审批入口；已完成默认收起。
+  const [expanded, setExpanded] = useState(isActive);
+  const bodyId = `iter-${it.id}-body`;
+  const headline = summaryHeadline(it);
 
   return (
     <li
-      onClick={() => onAudit?.(it)}
-      className={`rounded-lg border p-4 transition-colors ${
-        onAudit ? "cursor-pointer hover:border-primary/40 hover:bg-muted/30" : ""
-      } ${
-        isActive ? "border-sky-500/60 bg-sky-500/[0.05] ring-1 ring-sky-500/20" : "border-border"
-      }`}
+      className={cn(
+        "overflow-hidden rounded-lg border transition-colors",
+        isActive
+          ? "border-sky-500/60 bg-sky-500/[0.05] ring-1 ring-sky-500/20"
+          : expanded
+            ? "border-border"
+            : "border-transparent hover:border-border/60",
+      )}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className={`inline-block h-2 w-2 rounded-full ${iterationDotClass(it.status)}`} />
-          <span className="text-xs font-semibold text-foreground">#{it.seq}</span>
+      {/* 头部单行：展开切换（chevron + 标识 + 摘要首行）+ 右侧操作区（避免 button 套 button） */}
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          aria-label={expanded ? `收起迭代 #${it.seq} 详情` : `展开迭代 #${it.seq} 详情`}
+          className="group/head flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ChevronRight
+            className={cn(
+              "h-3.5 w-3.5 shrink-0 text-text-muted transition-transform duration-150 group-hover/head:text-foreground",
+              expanded && "rotate-90",
+            )}
+            aria-hidden
+          />
+          <span className={cn("inline-block h-2 w-2 shrink-0 rounded-full", iterationDotClass(it.status))} />
+          <span className="shrink-0 text-xs font-semibold text-foreground">#{it.seq}</span>
           {it.phase && (
             <span
-              className={`rounded-full px-2 py-0.5 text-xs font-bold uppercase tracking-wide ${phaseClass(it.phase)}`}
+              className={cn(
+                "shrink-0 rounded-full px-2 py-0.5 text-xs font-bold uppercase tracking-wide",
+                phaseClass(it.phase),
+              )}
             >
               {phaseLabel(it.phase)}
             </span>
           )}
-          <span className="text-xs text-text-secondary">{it.status}</span>
-        </div>
-        <div className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 truncate text-xs text-text-secondary" title={headline.full ?? undefined}>
+            {headline.text}
+          </span>
+        </button>
+
+        <div className="flex shrink-0 items-center gap-2">
           {it.verdict && (
-            <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${verdictClass(it.verdict)}`}>
+            <span className={cn("rounded-full px-2.5 py-0.5 text-xs font-semibold", verdictClass(it.verdict))}>
               {it.verdict}
             </span>
           )}
           {it.score != null && (
-            <span className={`text-sm font-bold tabular-nums ${scoreColorClass(it.score)}`}>{it.score}</span>
+            <span className={cn("text-sm font-bold tabular-nums", scoreColorClass(it.score))}>{it.score}</span>
           )}
+          {/* 收起态核心元信息：turns · cost · elapsed（小屏隐藏，保留 verdict / score / View Full） */}
+          <span className="hidden items-center gap-1.5 text-xs text-text-secondary sm:flex">
+            <span className="tabular-nums">{it.turn_count}t</span>
+            <span className="text-text-muted">·</span>
+            <span className="tabular-nums">${it.cost_usd.toFixed(4)}</span>
+            <span className="text-text-muted">·</span>
+            {isActive ? (
+              <LiveElapsed startedAt={it.started_at} />
+            ) : (
+              <StaticDuration startedAt={it.started_at} finishedAt={it.finished_at} />
+            )}
+          </span>
           {onAudit && (
             <button
               type="button"
@@ -128,105 +205,108 @@ function IterationCard({
               }}
               aria-label={`Iteration #${it.seq} Full View`}
               title="Full View (all actions I/O & context)"
-              className="flex cursor-pointer items-center gap-1 rounded-md border border-border px-2 py-0.5 text-xs font-medium text-text-secondary transition-colors hover:bg-muted/60 hover:text-foreground"
+              className="flex cursor-pointer items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
               <ListTree className="h-3 w-3" aria-hidden />
-              View Details
+              View Full
             </button>
           )}
         </div>
       </div>
 
-      {/* PLAN 阶段：摘要即「执行计划」，加标签以便人工审批前定位 */}
-      {it.phase === "plan" && it.summary && (
-        <div className="mt-2 text-xs font-bold uppercase tracking-wide text-amber-700 dark:text-amber-300">
-          📋 执行计划 (Plan)
-        </div>
-      )}
-
-      {/* 执行摘要（Markdown 渲染） */}
-      {it.summary && (
-        <div className={it.phase === "plan" ? "mt-1" : "mt-2"}>
-          <MarkdownText
-            content={expanded || it.summary.length <= 280 ? it.summary : `${it.summary.slice(0, 280)}…`}
-          />
-          {it.summary.length > 280 && (
-            <button
-              onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
-              className="ml-1 cursor-pointer text-sky-600 hover:underline dark:text-sky-400"
-            >
-              {expanded ? "收起" : "展开"}
-            </button>
+      {/* 展开态明细框（头部 100% 复用，仅 chevron 翻转） */}
+      {expanded && (
+        <div
+          id={bodyId}
+          role="region"
+          aria-label={`Iteration #${it.seq} 详情`}
+          className="space-y-2 border-t border-border/60 px-4 py-3"
+        >
+          {/* PLAN 阶段：摘要即「执行计划」，加标签以便人工审批前定位 */}
+          {it.phase === "plan" && it.summary && (
+            <div className="text-xs font-bold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+              📋 执行计划 (Plan)
+            </div>
           )}
-        </div>
-      )}
 
-      {/* 执行失败信息 */}
-      {it.exec_error && (
-        <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-500/5 p-2 text-caption text-red-600 dark:text-red-400">
-          {it.exec_error}
-        </pre>
-      )}
+          {/* 执行摘要（Markdown 全文渲染） */}
+          {it.summary && (
+            <div className={it.phase === "plan" ? "mt-1" : ""}>
+              <MarkdownText content={it.summary} />
+            </div>
+          )}
 
-      {/* 评估反思（Markdown 渲染） */}
-      {it.reflection && (
-        <div className="mt-2 rounded bg-muted/40 p-2">
-          <span className="mr-1">💡</span>
-          <MarkdownText content={it.reflection} className="[&_p]:inline" />
-        </div>
-      )}
+          {/* 执行失败信息 */}
+          {it.exec_error && (
+            <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-all rounded bg-red-500/5 p-2 text-caption text-red-600 dark:text-red-400">
+              {it.exec_error}
+            </pre>
+          )}
 
-      {/* 指标行 */}
-      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
-        {/* 当前阶段主导人指示 */}
-        {(() => {
-          const driver = deriveIterationDriver(it.status);
-          if (!driver) return null;
-          const meta = AGENT_ROLE_META[driver];
-          const Icon = meta.icon;
-          return (
-            <span className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 font-medium ${meta.badgeClass}`}>
-              <Icon className="h-2.5 w-2.5" aria-hidden />
-              {meta.label}
-            </span>
-          );
-        })()}
-        {it.exec_status && <span>exec: {it.exec_status}</span>}
-        <span>turns: {it.turn_count}</span>
-        <span>cost: ${it.cost_usd.toFixed(4)}</span>
-        {it.gate_exit_code != null && <span>gate exit: {it.gate_exit_code}</span>}
-        {isActive ? (
-          <LiveElapsed startedAt={it.started_at} prefix="⏱ " />
-        ) : (
-          <StaticDuration startedAt={it.started_at} finishedAt={it.finished_at} prefix="⏱ " />
-        )}
-        {it.started_at && (
-          <span title={new Date(it.started_at).toLocaleString()}>
-            {new Date(it.started_at).toLocaleTimeString()}
-          </span>
-        )}
-      </div>
+          {/* 评估反思（Markdown 渲染） */}
+          {it.reflection && (
+            <div className="rounded bg-muted/40 p-2">
+              <span className="mr-1">💡</span>
+              <MarkdownText content={it.reflection} className="[&_p]:inline" />
+            </div>
+          )}
 
-      {/* 审批门控：NegentropyEngine 自动审阅中 */}
-      {isPendingApproval && (
-        <div className="mt-2 flex items-center gap-2 rounded-md bg-sky-500/5 p-2">
-          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
-          <span className="text-xs text-sky-700 dark:text-sky-300">
-            {it.phase === "plan"
-              ? "NegentropyEngine 正在审阅此 Plan…"
-              : it.phase === "implement"
-                ? "NegentropyEngine 正在审阅实现方案…"
-                : "等待 NegentropyEngine 审阅…"}
-          </span>
-          <div className="flex-1" />
-          {/* 手动审批按钮（fallback：当 Engine 未自动审阅时，人工仍可介入） */}
-          <button
-            onClick={(e) => { e.stopPropagation(); onApprove(it.id); }}
-            disabled={busy}
-            className="cursor-pointer rounded-md border border-border px-2 py-0.5 text-xs font-medium text-text-secondary hover:bg-muted/50 disabled:opacity-50"
-          >
-            Manual Approve
-          </button>
+          {/* 完整指标行 */}
+          <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
+            {/* 当前阶段主导人指示 */}
+            {(() => {
+              const driver = deriveIterationDriver(it.status);
+              if (!driver) return null;
+              const meta = AGENT_ROLE_META[driver];
+              const Icon = meta.icon;
+              return (
+                <span className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 font-medium ${meta.badgeClass}`}>
+                  <Icon className="h-2.5 w-2.5" aria-hidden />
+                  {meta.label}
+                </span>
+              );
+            })()}
+            {it.exec_status && <span>exec: {it.exec_status}</span>}
+            <span>turns: {it.turn_count}</span>
+            <span>cost: ${it.cost_usd.toFixed(4)}</span>
+            {it.gate_exit_code != null && <span>gate exit: {it.gate_exit_code}</span>}
+            {isActive ? (
+              <LiveElapsed startedAt={it.started_at} prefix="⏱ " />
+            ) : (
+              <StaticDuration startedAt={it.started_at} finishedAt={it.finished_at} prefix="⏱ " />
+            )}
+            {it.started_at && (
+              <span title={new Date(it.started_at).toLocaleString()}>
+                {new Date(it.started_at).toLocaleTimeString()}
+              </span>
+            )}
+          </div>
+
+          {/* 审批门控：NegentropyEngine 自动审阅中 */}
+          {isPendingApproval && (
+            <div className="flex items-center gap-2 rounded-md bg-sky-500/5 p-2">
+              <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500" />
+              <span className="text-xs text-sky-700 dark:text-sky-300">
+                {it.phase === "plan"
+                  ? "NegentropyEngine 正在审阅此 Plan…"
+                  : it.phase === "implement"
+                    ? "NegentropyEngine 正在审阅实现方案…"
+                    : "等待 NegentropyEngine 审阅…"}
+              </span>
+              <div className="flex-1" />
+              {/* 手动审批按钮（fallback：当 Engine 未自动审阅时，人工仍可介入） */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApprove(it.id);
+                }}
+                disabled={busy}
+                className="cursor-pointer rounded-md border border-border px-2 py-0.5 text-xs font-medium text-text-secondary hover:bg-muted/50 disabled:opacity-50"
+              >
+                Manual Approve
+              </button>
+            </div>
+          )}
         </div>
       )}
     </li>


### PR DESCRIPTION
## 背景

Routine 详情页「迭代明细 · Iterations」区块原每张卡片**始终全展开**（summary 全文 + 反思 + 错误 + 指标 + 审批门控一次性铺满），信息密度高、纵向占用大、难以快速扫视多条迭代。借鉴 paseo Session 列表的视觉语言，将卡片改为**渐进式披露（Progressive Disclosure）**。

## 改动（仅改 `RoutineIterationTimeline.tsx`，props 契约不变，不动后端/数据模型/审计抽屉）

- **收起态（默认）**：单行紧凑展示关键信息 —— `[展开箭头][状态点]#seq[相位徽章]摘要首行(truncate)[verdict][score] turns·cost·耗时 [View Full]`；小屏隐藏 turns/cost/耗时，保留 verdict/score/View Full。
- **展开**（点击箭头或头部）：就地向下展开完整摘要(Markdown)、评估反思、执行错误、完整指标行、审批门控；箭头 `rotate-90` 翻转。
- **View Full**：打开既有「全过程」审计抽屉查看该 Iteration 的 Turns（动作级事件流 / 人机转录）。按钮由 `View Details` 更名为 `View Full`，对齐抽屉标题 `Full View`。
- **活跃迭代**（待审批 / 执行中 / 已派发）默认展开以暴露实时计时与审批入口；已完成默认收起。
- 新增纯函数 `summaryHeadline`：取 summary 首行、剥离 Markdown 记号（标题/列表/链接/配对强调，**词边界保留 `PR_URL`/文件名等中间下划线**）、跳过纯分隔线（`---`）、超长截断；为空时降级为「相位 · 状态」。
- 移除旧的 summary 280 字符双重折叠与「整卡点击开抽屉」行为 —— 展开与查看全过程职责分离，消除歧义。
- 复用同仓库 paseo 等价物 `ExpandableToolCallRow` 的折叠范式（`ChevronRight` + `rotate-90`、borderless 收起 hover、`aria-expanded`/`aria-controls` 可访问披露），不引入新依赖。

## 设计依据

渐进式披露、截断配 ellipsis + 悬停/展开兜底、`tabular-nums` 防数值跳动、color + 文本双编码（verdict 徽章）—— 经 `ui-ux-pro-max` skill 校准。

## 验证

- ✅ `pnpm exec eslint --max-warnings=0` 通过
- ✅ `pnpm exec tsc -p tsconfig.json --noEmit` 通过
- ✅ pre-commit hooks 通过（ESLint / 空白 / 文件尾）
- ✅ 浏览器实测（工作区 `next dev :3194`）：收起态单行布局、展开交互（`aria-expanded` 翻转 + 明细区含 summary/reflection/exec/turns/cost + 箭头旋转）、View Full、分页、headline 提取均符合预期。

## 关键文件

- `apps/negentropy-ui/app/interface/routine/_components/RoutineIterationTimeline.tsx`（+185 / -105）

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)