### PR TITLE
feat(Routine): 列表分页 + Full View 模块抽屉化(右缘竖排标签呼出)

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/ReflectionFlow.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/ReflectionFlow.tsx
@@ -18,7 +18,14 @@ function head(text: string | null, n = 140): string {
  * Reflexion 记忆流 —— 把「迭代 N 的 reflection 注入迭代 N+1 的 prompt」这条反馈边显式化，
  * 是闭环之所以「自迭代」的关键。仅展示最近若干条以保持精炼。
  */
-export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO[] }) {
+export function ReflectionFlow({
+  iterations,
+  bare = false,
+}: {
+  iterations: RoutineIterationDTO[];
+  /** 抽屉内渲染：省去卡片外壳/标题/折叠,直接展开列表（标题由抽屉头提供）。 */
+  bare?: boolean;
+}) {
   const [expanded, setExpanded] = useState(false);
   const asc = useMemo(() => [...iterations].sort((a, b) => a.seq - b.seq), [iterations]);
   const items = useMemo(() => {
@@ -30,37 +37,24 @@ export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO
   }, [asc]);
 
   if (items.length === 0) {
+    const empty = (
+      <p className="py-4 text-center text-sm text-text-secondary">暂无反思记录</p>
+    );
+    if (bare) return empty;
     return (
       <section className="rounded-card border border-border bg-card p-4 shadow-sm">
         <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">
           反思记忆流 · Reflexion
         </h3>
-        <p className="py-4 text-center text-sm text-text-secondary">暂无反思记录</p>
+        {empty}
       </section>
     );
   }
 
-  return (
-    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-        className="group flex w-full items-center justify-between gap-2 text-xs uppercase tracking-overline text-text-secondary transition-colors hover:text-foreground"
-      >
-        <span>反思记忆流 · Reflexion（reflection → 下轮 prompt）</span>
-        <ChevronDown
-          aria-hidden="true"
-          className={cn(
-            "h-3.5 w-3.5 shrink-0 transition-transform duration-150",
-            expanded && "rotate-180",
-          )}
-        />
-      </button>
-      {expanded && (
-        <ol className="mt-3 space-y-3">
-          {items.map(({ it, next }) => (
-            <li key={it.id} className="rounded-lg border border-border p-2.5">
+  const list = (
+    <ol className="space-y-3">
+      {items.map(({ it, next }) => (
+        <li key={it.id} className="rounded-lg border border-border p-2.5">
               <div className="flex items-center gap-2 text-xs">
                 <span className="font-semibold text-foreground">#{it.seq}</span>
                 {it.verdict && (
@@ -81,7 +75,28 @@ export function ReflectionFlow({ iterations }: { iterations: RoutineIterationDTO
             </li>
           ))}
         </ol>
-      )}
+  );
+
+  if (bare) return list;
+
+  return (
+    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="group flex w-full items-center justify-between gap-2 text-xs uppercase tracking-overline text-text-secondary transition-colors hover:text-foreground"
+      >
+        <span>反思记忆流 · Reflexion（reflection → 下轮 prompt）</span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 transition-transform duration-150",
+            expanded && "rotate-180",
+          )}
+        />
+      </button>
+      {expanded && <div className="mt-3">{list}</div>}
     </section>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineConvergenceChart.tsx
@@ -52,10 +52,13 @@ export function RoutineConvergenceChart({
   iterations,
   threshold,
   bestScore,
+  bare = false,
 }: {
   iterations: RoutineIterationDTO[];
   threshold: number;
   bestScore: number | null;
+  /** 抽屉内渲染：省去 CollapsibleSection 标题/折叠壳，仅渲染内容（标题由抽屉头提供）。 */
+  bare?: boolean;
 }) {
   const data: Row[] = iterations.map((it) => ({
     seq: it.seq,
@@ -65,12 +68,10 @@ export function RoutineConvergenceChart({
   }));
   const hasScores = data.some((d) => d.score != null);
 
-  return (
-    <CollapsibleSection title="评分收敛趋势 · Convergence">
-      {!hasScores ? (
-        <p className="py-8 text-center text-sm text-text-secondary">尚无评分数据</p>
-      ) : (
-        <div className="h-56 min-h-[14rem] w-full" style={{ minWidth: 1 }}>
+  const body = !hasScores ? (
+    <p className="py-8 text-center text-sm text-text-secondary">尚无评分数据</p>
+  ) : (
+    <div className="h-56 min-h-[14rem] w-full" style={{ minWidth: 1 }}>
           <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <ComposedChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: -8 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#3f3f46" strokeOpacity={0.2} />
@@ -112,7 +113,11 @@ export function RoutineConvergenceChart({
             </ComposedChart>
           </ResponsiveContainer>
         </div>
-      )}
-    </CollapsibleSection>
+  );
+
+  return bare ? (
+    body
+  ) : (
+    <CollapsibleSection title="评分收敛趋势 · Convergence">{body}</CollapsibleSection>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineGuardPanel.tsx
@@ -22,9 +22,12 @@ const TERMINAL: ReadonlySet<string> = new Set(["succeeded", "failed", "cancelled
 export function RoutineGuardPanel({
   routine,
   iterations,
+  bare = false,
 }: {
   routine: RoutineDTO;
   iterations: RoutineIterationDTO[];
+  /** 抽屉内渲染：省去卡片外壳与标题（标题由抽屉头提供）。 */
+  bare?: boolean;
 }) {
   const now = useClock();
   const isTerminal = TERMINAL.has(routine.status);
@@ -78,10 +81,12 @@ export function RoutineGuardPanel({
   }, [isTerminal, iterRatio, costRatio, deadline, streak, routine.no_progress_patience]);
 
   return (
-    <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-      <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">
-        守卫 / 预算 · Why will it stop?
-      </h3>
+    <section className={bare ? "" : "rounded-card border border-border bg-card p-4 shadow-sm"}>
+      {!bare && (
+        <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">
+          守卫 / 预算 · Why will it stop?
+        </h3>
+      )}
 
       {isTerminal ? (
         <div className="mb-3 rounded-lg border border-border bg-muted/40 p-2.5 text-body">

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunGantt.tsx
@@ -63,7 +63,14 @@ function GanttTooltip({ active, payload }: { active?: boolean; payload?: Tooltip
  * 评估阶段后端不记时间戳，故评估不占时长）；在途迭代延伸至 now（随时钟动）。
  * 颜色：error/timeout 红、在途蓝、否则按 verdict。
  */
-export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDTO[] }) {
+export function RoutineRunGantt({
+  iterations,
+  bare = false,
+}: {
+  iterations: RoutineIterationDTO[];
+  /** 抽屉内渲染：省去 CollapsibleSection 标题/折叠壳，仅渲染内容（标题由抽屉头提供）。 */
+  bare?: boolean;
+}) {
   const now = useClock();
 
   const rows = useMemo<GanttRow[]>(() => {
@@ -93,12 +100,10 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
     });
   }, [iterations, now]);
 
-  return (
-    <CollapsibleSection title="迭代时间线 · Run Timeline（执行区间）">
-      {rows.length === 0 ? (
-        <p className="py-8 text-center text-sm text-text-secondary">尚无可视化的执行区间</p>
-      ) : (
-        <div style={{ height: Math.max(120, rows.length * 30 + 36), minWidth: 1 }} className="w-full">
+  const body = rows.length === 0 ? (
+    <p className="py-8 text-center text-sm text-text-secondary">尚无可视化的执行区间</p>
+  ) : (
+    <div style={{ height: Math.max(120, rows.length * 30 + 36), minWidth: 1 }} className="w-full">
           <ResponsiveContainer width="100%" height="100%" minWidth={1} minHeight={1}>
             <BarChart data={rows} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 8 }} barCategoryGap={6}>
               <XAxis
@@ -120,7 +125,11 @@ export function RoutineRunGantt({ iterations }: { iterations: RoutineIterationDT
             </BarChart>
           </ResponsiveContainer>
         </div>
-      )}
-    </CollapsibleSection>
+  );
+
+  return bare ? (
+    body
+  ) : (
+    <CollapsibleSection title="迭代时间线 · Run Timeline（执行区间）">{body}</CollapsibleSection>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState } from "react";
 
 import type { LiveActionsByIteration, RoutineDTO, RoutineIterationDTO } from "@/features/routine";
 
-import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
+import { BaseDrawer } from "@/components/ui/BaseDrawer";
+import { EdgePanelRail, type EdgePanelDef } from "@/components/ui/EdgePanelRail";
 
 import { IterationAuditDrawer } from "./IterationAuditDrawer";
 import { ReflectionFlow } from "./ReflectionFlow";
@@ -18,12 +19,31 @@ import { RoutineWorkspaceCard } from "./RoutineWorkspaceCard";
 import { loopStageOf } from "./routine-loop";
 
 /**
- * 单任务「全过程」视图主体 —— 闭环图 + 守卫面板 + 收敛趋势 + 甘特时间线 + 反思流 + 迭代明细。
- * 置于深链路由 ``/interface/routine/[id]``（外层由 ClockProvider 包裹以驱动实时计时）。
+ * 单任务「全过程」视图主体。
  *
- * 迭代明细的每张卡片可下钻「全过程」审计抽屉，按时间线还原该轮所有动作（工具调用/结果/
- * 中间消息/门控/评估）的输入/输出/上下文，并叠加在途迭代的实时动作流。
+ * 信息架构（渐进披露）：主列仅置**闭环过程**（顶部）+ **迭代明细**（其下）两块核心内容；
+ * 其余模块（目标 / 验收标准 / 隔离工作区 / PR / 守卫预算 / 收敛趋势 / 执行时间线 / 反思记忆流）
+ * 收敛为**右缘竖排标签**呼出的右侧抽屉（仿 Knowledge Graph 页 PanelRail 交互），按需查看、互不干扰。
+ *
+ * 迭代明细每张卡片可下钻「全过程」审计抽屉，按时间线还原该轮所有动作的输入/输出/上下文，
+ * 并叠加在途迭代的实时动作流。模块抽屉与审计抽屉**互斥**（同一时刻仅一个开启，避免双遮罩叠加）。
+ *
+ * 置于深链路由 ``/interface/routine/[id]``（外层由 ClockProvider 包裹以驱动实时计时）。
  */
+
+type ModuleKey =
+  | "goal"
+  | "acceptance"
+  | "workspace"
+  | "pr"
+  | "guard"
+  | "convergence"
+  | "timeline"
+  | "reflexion";
+
+/** 模块抽屉宽度：收敛图/甘特/反思流受益于更宽视口，小屏回退 90vw 区间。 */
+const MODULE_DRAWER_WIDTH = "[width:clamp(360px,66vw,1100px)]";
+
 export function RoutineRunView({
   routine,
   onApproveIteration,
@@ -45,77 +65,174 @@ export function RoutineRunView({
   const latest = asc[asc.length - 1];
   const snapshot = loopStageOf(latest, routine);
 
-  // 「全过程」审计抽屉：选中迭代下钻。从最新 routine.iterations 派生当前迭代，使在途状态/评分
-  // 随详情重拉同步更新（抽屉据此在终态回查权威事件列表）。
+  // 模块抽屉（右缘标签呼出）。从最新 routine.iterations 派生当前迭代，使在途状态/评分随详情重拉同步。
+  const [openModule, setOpenModule] = useState<ModuleKey | null>(null);
   const [auditId, setAuditId] = useState<string | null>(null);
   const auditIteration = useMemo(
     () => (auditId ? (iterations.find((it) => it.id === auditId) ?? null) : null),
     [auditId, iterations],
   );
 
+  // 互斥：打开任一抽屉即关闭另一类，避免两个 z-[45] 遮罩叠加（双重变暗 + 焦点陷阱冲突）。
+  const toggleModule = (key: ModuleKey) => {
+    setAuditId(null);
+    setOpenModule((prev) => (prev === key ? null : key));
+  };
+  const closeModule = () => setOpenModule(null);
+  const openAudit = (it: RoutineIterationDTO) => {
+    setOpenModule(null);
+    setAuditId(it.id);
+  };
+
+  const panels: EdgePanelDef<ModuleKey>[] = [
+    { key: "goal", label: "Goal" },
+    { key: "acceptance", label: "验收" },
+    { key: "workspace", label: "工作区" },
+    { key: "pr", label: "PR", visible: !!routine.pr_url },
+    { key: "guard", label: "守卫" },
+    { key: "convergence", label: "收敛" },
+    { key: "timeline", label: "时间线" },
+    { key: "reflexion", label: "反思" },
+  ];
+
   return (
-    <div className="space-y-6">
-      {/* 目标 / 验收标准 */}
-      <div className="grid gap-5 lg:grid-cols-2">
-        <CollapsibleSection title="Goal">
-          <p className="whitespace-pre-wrap break-words text-body text-foreground">{routine.goal}</p>
-        </CollapsibleSection>
-        <CollapsibleSection title="Acceptance Criteria">
-          <p className="whitespace-pre-wrap break-words text-body text-text-secondary">
+    <>
+      {/* 主列：顶部闭环图 + 其下迭代明细（右侧留白为竖排标签让位）*/}
+      <div className="space-y-6 pr-12">
+        {/* 闭环过程 */}
+        <RoutineLoopDiagram snapshot={snapshot} latest={latest} routine={routine} />
+
+        {/* 迭代明细 */}
+        <section className="rounded-card border border-border bg-card p-4 shadow-sm">
+          <h3 className="mb-3 text-xs uppercase tracking-overline text-text-secondary">
+            迭代明细 · Iterations ({iterations.length})
+          </h3>
+          <RoutineIterationTimeline
+            iterations={desc}
+            onApprove={onApproveIteration}
+            onReject={onRejectIteration}
+            onAudit={openAudit}
+            busy={busy}
+          />
+        </section>
+      </div>
+
+      {/* 右缘竖排标签轨道（fixed 常驻，垂直居中，避开顶部导航）*/}
+      <div className="fixed right-0 top-1/2 z-40 max-h-[calc(100vh-7rem)] -translate-y-1/2 overflow-y-auto">
+        <EdgePanelRail
+          panels={panels}
+          openKey={openModule}
+          onToggle={toggleModule}
+          ariaLabel="模块面板"
+        />
+      </div>
+
+      {/* 模块抽屉（单开，宽·模态，标题统一由抽屉头提供）*/}
+      <BaseDrawer
+        open={openModule === "goal"}
+        onClose={closeModule}
+        title="Goal · 目标"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <p className="max-w-prose whitespace-pre-wrap break-words text-body text-foreground">
+            {routine.goal}
+          </p>
+        </div>
+      </BaseDrawer>
+
+      <BaseDrawer
+        open={openModule === "acceptance"}
+        onClose={closeModule}
+        title="Acceptance Criteria · 验收标准"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <p className="max-w-prose whitespace-pre-wrap break-words text-body text-text-secondary">
             {routine.acceptance_criteria}
           </p>
-        </CollapsibleSection>
-      </div>
+        </div>
+      </BaseDrawer>
 
-      {/* 隔离工作区（worktree 生命周期状态 + 手动清理）*/}
-      <RoutineWorkspaceCard
-        routine={routine}
-        onCleanup={onCleanupWorktree ?? (() => {})}
-        cleanupBusy={busy}
-      />
+      <BaseDrawer
+        open={openModule === "workspace"}
+        onClose={closeModule}
+        title="ISOLATED WORKSPACE · 隔离工作区"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <RoutineWorkspaceCard
+            routine={routine}
+            onCleanup={onCleanupWorktree ?? (() => {})}
+            cleanupBusy={busy}
+            bare
+          />
+        </div>
+      </BaseDrawer>
 
-      {/* Pull Request（FINALIZE 产出，等待人工 Merge）*/}
       {routine.pr_url && (
-        <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-          <h3 className="mb-2 text-xs uppercase tracking-overline text-text-secondary">Pull Request</h3>
-          <RoutinePrCard prUrl={routine.pr_url} />
-        </section>
+        <BaseDrawer
+          open={openModule === "pr"}
+          onClose={closeModule}
+          title="PULL REQUEST"
+          widthClassName={MODULE_DRAWER_WIDTH}
+        >
+          <div className="px-5 py-5">
+            <RoutinePrCard prUrl={routine.pr_url} />
+          </div>
+        </BaseDrawer>
       )}
 
-      {/* 闭环过程 */}
-      <RoutineLoopDiagram snapshot={snapshot} latest={latest} routine={routine} />
+      <BaseDrawer
+        open={openModule === "guard"}
+        onClose={closeModule}
+        title="守卫 / 预算 · Why will it stop?"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <RoutineGuardPanel routine={routine} iterations={asc} bare />
+        </div>
+      </BaseDrawer>
 
-      {/* 守卫 / 预算 */}
-      <RoutineGuardPanel routine={routine} iterations={asc} />
+      <BaseDrawer
+        open={openModule === "convergence"}
+        onClose={closeModule}
+        title="评分收敛趋势 · Convergence"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <RoutineConvergenceChart
+            iterations={asc}
+            threshold={routine.success_score_threshold}
+            bestScore={routine.best_score}
+            bare
+          />
+        </div>
+      </BaseDrawer>
 
-      {/* 收敛趋势 + 甘特 */}
-      <div className="grid gap-5 lg:grid-cols-2">
-        <RoutineConvergenceChart
-          iterations={asc}
-          threshold={routine.success_score_threshold}
-          bestScore={routine.best_score}
-        />
-        <RoutineRunGantt iterations={asc} />
-      </div>
+      <BaseDrawer
+        open={openModule === "timeline"}
+        onClose={closeModule}
+        title="迭代时间线 · Run Timeline"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <RoutineRunGantt iterations={asc} bare />
+        </div>
+      </BaseDrawer>
 
-      {/* 反思记忆流 */}
-      <ReflectionFlow iterations={asc} />
+      <BaseDrawer
+        open={openModule === "reflexion"}
+        onClose={closeModule}
+        title="反思记忆流 · Reflexion"
+        widthClassName={MODULE_DRAWER_WIDTH}
+      >
+        <div className="px-5 py-5">
+          <ReflectionFlow iterations={asc} bare />
+        </div>
+      </BaseDrawer>
 
-      {/* 迭代明细 */}
-      <section className="rounded-card border border-border bg-card p-4 shadow-sm">
-        <h3 className="mb-3 text-xs uppercase tracking-overline text-text-secondary">
-          迭代明细 · Iterations ({iterations.length})
-        </h3>
-        <RoutineIterationTimeline
-          iterations={desc}
-          onApprove={onApproveIteration}
-          onReject={onRejectIteration}
-          onAudit={(it: RoutineIterationDTO) => setAuditId(it.id)}
-          busy={busy}
-        />
-      </section>
-
-      {/* 「全过程」审计抽屉 */}
+      {/* 「全过程」审计抽屉（迭代卡片下钻，与模块抽屉互斥）*/}
       <IterationAuditDrawer
         open={auditId != null}
         onClose={() => setAuditId(null)}
@@ -124,6 +241,6 @@ export function RoutineRunView({
         liveActions={auditId ? liveActionsByIteration?.[auditId] : undefined}
         projectPath={routine.cwd}
       />
-    </div>
+    </>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineWorkspaceCard.tsx
@@ -29,6 +29,8 @@ interface RoutineWorkspaceCardProps {
   >;
   onCleanup: () => void;
   cleanupBusy?: boolean;
+  /** 抽屉内渲染：省去 CollapsibleSection 标题/折叠壳，仅渲染状态徽标 + 内容（标题由抽屉头提供）。 */
+  bare?: boolean;
 }
 
 /**
@@ -42,40 +44,34 @@ interface RoutineWorkspaceCardProps {
  *
  * 清理按钮仅对终态 routine（succeeded/failed/cancelled）+ active/orphaned 状态可见。
  */
-export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: RoutineWorkspaceCardProps) {
+export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy, bare = false }: RoutineWorkspaceCardProps) {
   if (!routine.baseline_branch) return null;
 
   const ws = (routine.worktree_status ?? "none") as WorktreeStatus;
   const canCleanup = canCleanupWorktree(routine.status, routine.worktree_path);
 
-  return (
-    <CollapsibleSection
-      title={
-        <>
-          <FolderTree className="h-3.5 w-3.5" />
-          Isolated Workspace
-        </>
-      }
-      headerExtra={
-        <span
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold",
-            worktreeStatusClass(ws),
-          )}
-        >
-          {/* 状态指示点 */}
-          <span
-            className={cn(
-              "inline-block h-1.5 w-1.5 rounded-full",
-              ws === "active" && "bg-emerald-500 animate-pulse",
-              ws === "cleaned" && "bg-muted-foreground/40",
-              ws === "orphaned" && "bg-amber-500",
-            )}
-          />
-          {worktreeStatusLabel(ws)}
-        </span>
-      }
+  const statusBadge = (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold",
+        worktreeStatusClass(ws),
+      )}
     >
+      {/* 状态指示点 */}
+      <span
+        className={cn(
+          "inline-block h-1.5 w-1.5 rounded-full",
+          ws === "active" && "bg-emerald-500 animate-pulse",
+          ws === "cleaned" && "bg-muted-foreground/40",
+          ws === "orphaned" && "bg-amber-500",
+        )}
+      />
+      {worktreeStatusLabel(ws)}
+    </span>
+  );
+
+  const body = (
+    <>
       {/* 信息网格 */}
       <dl className="grid gap-x-4 gap-y-1.5 text-xs sm:grid-cols-[auto_1fr]">
         <dt className="text-text-secondary">Baseline</dt>
@@ -125,6 +121,29 @@ export function RoutineWorkspaceCard({ routine, onCleanup, cleanupBusy }: Routin
           )}
         </div>
       )}
+    </>
+  );
+
+  if (bare) {
+    return (
+      <div className="space-y-3">
+        <div>{statusBadge}</div>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <CollapsibleSection
+      title={
+        <>
+          <FolderTree className="h-3.5 w-3.5" />
+          Isolated Workspace
+        </>
+      }
+      headerExtra={statusBadge}
+    >
+      {body}
     </CollapsibleSection>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { ErrorBanner } from "@/components/ui/ErrorState";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { Pagination } from "@/components/ui/Pagination";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import {
   cleanupWorktree,
@@ -31,6 +32,30 @@ import { useTerminateRoutine } from "./_components/useTerminateRoutine";
 
 const DEFAULT_FILTERS: Partial<RoutineFilters> = { status: null, q: "", is_template: false };
 
+const PAGE_SIZE = 10;
+
+/** 列表排序时间戳：updated_at 优先，缺失回退 created_at；无效/缺失返回 null。 */
+function rowTimestamp(r: RoutineDTO): number | null {
+  const raw = r.updated_at ?? r.created_at;
+  if (!raw) return null;
+  const t = Date.parse(raw);
+  return Number.isNaN(t) ? null : t;
+}
+
+/** Updated At 倒序：有时间者在前并按时间降序；皆缺失者置末；id 兜底保证刷新间排序稳定。 */
+function compareByUpdatedDesc(a: RoutineDTO, b: RoutineDTO): number {
+  const ta = rowTimestamp(a);
+  const tb = rowTimestamp(b);
+  if (ta != null && tb != null) {
+    if (tb !== ta) return tb - ta;
+  } else if (ta != null) {
+    return -1;
+  } else if (tb != null) {
+    return 1;
+  }
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
 function RoutinePageInner() {
   const router = useRouter();
   const sp = useSearchParams();
@@ -41,6 +66,7 @@ function RoutinePageInner() {
   // null = 抽屉关闭；"create" = 新建；否则由 ?sel 派生的 routine-edit。
   const [createOpen, setCreateOpen] = useState(false);
   const [actionBusy, setActionBusy] = useState(false);
+  const [page, setPage] = useState(1);
 
   const { confirm, confirmDialog } = useConfirmDialog();
   const {
@@ -55,6 +81,15 @@ function RoutinePageInner() {
 
   // 时钟仅在有运行中任务时滴答（无在途零开销）。
   const clockActive = useMemo(() => routines.some((r) => r.status === "running"), [routines]);
+
+  // 列表分页（客户端）：按 Updated At 倒序排序后切片。clockActive 与 KPI 仍读全量 routines，不受分页影响。
+  const sortedRoutines = useMemo(() => [...routines].sort(compareByUpdatedDesc), [routines]);
+  const totalPages = Math.max(1, Math.ceil(sortedRoutines.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages); // 渲染期钳制：列表变短时不滞留死页
+  const pageRoutines = useMemo(
+    () => sortedRoutines.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE),
+    [sortedRoutines, safePage],
+  );
 
   // 刷新当前选中详情（含迭代）。
   const refreshSelected = useCallback(async (id: string) => {
@@ -222,11 +257,17 @@ function RoutinePageInner() {
             <RoutineKpiStrip kpis={kpis} loading={loading} />
 
             <div className="min-w-[200px]">
-              <RoutineFilterBar filters={filters} onChange={setFilters} />
+              <RoutineFilterBar
+                filters={filters}
+                onChange={(f) => {
+                  setFilters(f);
+                  setPage(1); // 筛选变更回到第 1 页
+                }}
+              />
             </div>
 
             <RoutineTable
-              routines={routines}
+              routines={pageRoutines}
               loading={loading}
               onSelect={openDetail}
               onOpenFull={openFull}
@@ -234,6 +275,17 @@ function RoutinePageInner() {
               onTerminate={requestTerminate}
               onCleanupWorktree={handleCleanupWorktree}
             />
+
+            {sortedRoutines.length > 0 && (
+              <Pagination
+                page={safePage}
+                totalPages={totalPages}
+                onPageChange={setPage}
+                total={sortedRoutines.length}
+                itemLabel="routine"
+                disabled={loading}
+              />
+            )}
           </div>
         </ClockProvider>
       </div>

--- a/apps/negentropy-ui/components/ui/EdgePanelRail.tsx
+++ b/apps/negentropy-ui/components/ui/EdgePanelRail.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * 通用「边缘竖排标签轨道」（Reuse-Driven）。
+ *
+ * 抽象自 Knowledge Graph 页的 PanelRail：在容器边缘竖排各模块标题，点击切换其抽屉/面板。
+ * 本组件仅负责按钮列与激活视觉（vertical-rl 竖排文字 + 激活态蓝色描边 + chevron 旋转），
+ * **定位由调用方包裹层负责**（如 fixed 贴视口右缘 / flex 兄弟列）。泛型 key 不绑定具体业务枚举。
+ *
+ * 相较原 PanelRail 的增强：补 focus-visible 焦点环、min-h ≥ 44px 触达，满足无障碍基线。
+ */
+
+import { ChevronLeft } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface EdgePanelDef<K extends string = string> {
+  key: K;
+  label: string;
+  /** 默认 true；设为 false 则不渲染该标签。 */
+  visible?: boolean;
+}
+
+interface EdgePanelRailProps<K extends string = string> {
+  panels: EdgePanelDef<K>[];
+  /** 当前展开的面板 key；null 表示全部关闭。 */
+  openKey: K | null;
+  onToggle: (key: K) => void;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function EdgePanelRail<K extends string = string>({
+  panels,
+  openKey,
+  onToggle,
+  className,
+  ariaLabel = "面板切换",
+}: EdgePanelRailProps<K>) {
+  const visiblePanels = panels.filter((p) => p.visible !== false);
+  if (visiblePanels.length === 0) return null;
+
+  return (
+    <nav className={cn("flex flex-col items-stretch gap-1", className)} aria-label={ariaLabel}>
+      {visiblePanels.map((panel) => {
+        const isActive = openKey === panel.key;
+        return (
+          <button
+            key={panel.key}
+            type="button"
+            onClick={() => onToggle(panel.key)}
+            aria-label={isActive ? `关闭${panel.label}` : `打开${panel.label}`}
+            aria-expanded={isActive}
+            className={cn(
+              "flex min-h-[44px] flex-col items-center justify-center rounded-l-md border border-r-0 px-0 py-2 text-caption tracking-wide transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+              isActive
+                ? "border-l-2 border-l-blue-500 border-border bg-blue-50 font-medium text-blue-600 dark:border-l-blue-400 dark:bg-blue-950/30 dark:text-blue-400"
+                : "border-border bg-card text-text-muted hover:bg-muted hover:text-foreground",
+            )}
+            style={{ writingMode: "vertical-rl", textOrientation: "mixed" }}
+          >
+            <span>{panel.label}</span>
+            <ChevronLeft
+              className={cn(
+                "mt-1 h-2.5 w-2.5 flex-shrink-0 transition-transform",
+                isActive ? "rotate-180" : "",
+              )}
+            />
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/negentropy-ui/components/ui/Pagination.tsx
+++ b/apps/negentropy-ui/components/ui/Pagination.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * 通用分页控件（Reuse-Driven / Single Source of Truth）。
+ *
+ * 收敛此前各页（knowledge/documents、memory/facts 等）手搓的 Prev/Next 翻页：
+ * 复用统一 [[Button]] 视觉与焦点环，数字页码 + 省略号紧凑展示，1-indexed 语义。
+ * 纯展示 + 受控：页码状态由调用方持有，组件仅在边界内回调 onPageChange。
+ */
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+
+export interface PaginationProps {
+  /** 当前页（1-indexed）。 */
+  page: number;
+  /** 总页数（>= 1）。 */
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  /** 可选总条数，用于左侧 "N items" 计数文案。 */
+  total?: number;
+  /** 计数单位名（默认 "item"，自动追加复数 s）。 */
+  itemLabel?: string;
+  /** loading 时禁用全部按钮。 */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * 计算页码序列（含省略号占位）。
+ * totalPages <= 7 时全展开；否则恒显首末 + 当前 ±1，缺口以 "ellipsis" 占位。
+ */
+function buildPages(page: number, totalPages: number): (number | "ellipsis")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const pages: (number | "ellipsis")[] = [1];
+  const start = Math.max(2, page - 1);
+  const end = Math.min(totalPages - 1, page + 1);
+  if (start > 2) pages.push("ellipsis");
+  for (let i = start; i <= end; i++) pages.push(i);
+  if (end < totalPages - 1) pages.push("ellipsis");
+  pages.push(totalPages);
+  return pages;
+}
+
+function countLabel(total: number, itemLabel: string): string {
+  return `${total} ${itemLabel}${total === 1 ? "" : "s"}`;
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  total,
+  itemLabel = "item",
+  disabled = false,
+  className,
+}: PaginationProps) {
+  // 单页（或无数据）时不渲染翻页器；若提供了 total 则仅显示一行计数。
+  if (totalPages <= 1) {
+    if (total == null) return null;
+    return (
+      <div className={cn("flex justify-end text-micro tabular-nums text-text-secondary", className)}>
+        {countLabel(total, itemLabel)}
+      </div>
+    );
+  }
+
+  const pages = buildPages(page, totalPages);
+  const go = (target: number) => {
+    const next = Math.min(Math.max(1, target), totalPages);
+    if (next !== page) onPageChange(next);
+  };
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className={cn("flex items-center justify-between gap-3", className)}
+    >
+      <span className="text-micro tabular-nums text-text-secondary">
+        {total != null ? countLabel(total, itemLabel) : null}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          iconOnly
+          disabled={disabled || page <= 1}
+          onClick={() => go(page - 1)}
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        {pages.map((p, i) =>
+          p === "ellipsis" ? (
+            <span
+              key={`ellipsis-${i}`}
+              className="select-none px-1 text-text-muted"
+              aria-hidden
+            >
+              …
+            </span>
+          ) : (
+            <Button
+              key={p}
+              variant={p === page ? "primary" : "ghost"}
+              size="sm"
+              disabled={disabled}
+              onClick={() => go(p)}
+              aria-label={`Page ${p}`}
+              aria-current={p === page ? "page" : undefined}
+              className="min-w-8 px-2 tabular-nums"
+            >
+              {p}
+            </Button>
+          ),
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          iconOnly
+          disabled={disabled || page >= totalPages}
+          onClick={() => go(page + 1)}
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 列表页无分页（数量增长后冗长、排序不确定，难以聚焦最近更新项）；Full View 将约 10 个卡片模块纵向堆叠成超长滚动页，核心的「闭环过程」与「迭代明细」被淹没。
- 关联上下文/Issue/文档：UI/UX 改进任务（ui-ux-pro-max 技能指导）；抽屉「呼出方式」对齐 Knowledge Graph 页 PanelRail 的右缘竖排标签交互。

# 核心变更
- **列表分页**（客户端，默认 10/页，按 Updated At 倒序）：排序 `updated_at` 优先、缺失回退 `created_at`、`id` 兜底稳定；渲染期钳制 `safePage` 避免删除后滞留死页；筛选变更回第 1 页；`clockActive`/KPI 仍读全量数组不受分页影响。新增可复用 `components/ui/Pagination.tsx`。
- **Full View 重排**：主列仅保留「闭环过程 · Evaluator–Optimizer Loop」（顶）+「迭代明细 · Iterations」（下）；其余 8 模块（目标 / 验收标准 / 隔离工作区 / PR / 守卫预算 / 收敛趋势 / 执行时间线 / 反思记忆流）迁入宽·模态 `BaseDrawer`，由右缘竖排标签呼出（仿 Knowledge Graph）。
- 新增通用 `components/ui/EdgePanelRail.tsx`（抽象自 KG PanelRail，泛型 key + 补 focus-visible 焦点环与 44px 触达）。
- 5 个模块组件（收敛图/甘特/工作区/守卫预算/反思流）新增 `bare` 无壳渲染（抽屉内省去卡片/标题/折叠，标题统一由抽屉头提供），非 bare 行为保持不变。
- 模块抽屉与迭代审计抽屉互斥（同一时刻仅一个开启），避免两个 `z-[45]` 遮罩叠加。

# 风险与回滚
- 主要风险：纯前端展示层重排，无数据/接口/后端变更；客户端分页随 fleet 规模显著增大需后续迁移后端 `next_cursor`（已在注释标注权衡）。
- 回滚方式：revert 本 PR 两个 commit 即可完全还原。

# 验证证据
- 单元测试：不涉及（纯展示层，无逻辑单测改动）。
- 集成测试：不涉及。
- E2E/Workflow：`next dev` 实机，`/interface/routine` 与 `/interface/routine/[id]` 均返回 HTTP 200、dev 日志 0 错误。
- 覆盖率/关键截图：`pnpm typecheck` 与 `pnpm lint`（`--max-warnings=0`）全绿；独立 code-review 无 critical 项（确认分页排序/切片正确、`bare` 非壳态与原渲染逐组件一致、抽屉互斥与 z-index 层级正确）。

# 影响范围
- 前端：`apps/negentropy-ui` Routine 模块（列表页 + Full View）+ 新增 2 个通用 UI 组件（`Pagination`/`EdgePanelRail`）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后建议用真实登录态在浏览器逐项回归：分页翻页/排序、各模块抽屉呼出与互斥、深色模式对比度，并补关键截图。
- 后续可将 KG PanelRail 统一迁移至 `EdgePanelRail`（单一事实源）；fleet 规模化时把列表分页迁移到后端 `next_cursor` 契约。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
