### PR TITLE
feat(Scheduler): Tasks 列表分页去滚动条并按 Last 倒序,复用 Routine 分页控件

### DIFF
--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskTable.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskTable.tsx
@@ -4,7 +4,10 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import type { ScheduledTaskDTO } from "@/features/scheduler";
 
 interface SchedulerTaskTableProps {
+  /** 当前页要渲染的任务（已由调用方排序 + 切片）。 */
   tasks: ScheduledTaskDTO[];
+  /** 任务总数，用于表头计数；缺省回退到 tasks.length。 */
+  total?: number;
   loading: boolean;
   onToggle: (id: string, enabled: boolean) => void;
   onRun: (id: string) => void;
@@ -66,6 +69,7 @@ function SkeletonRow() {
 
 export function SchedulerTaskTable({
   tasks,
+  total,
   loading,
   onToggle,
   onRun,
@@ -74,11 +78,11 @@ export function SchedulerTaskTable({
   return (
     <div className="rounded-xl border border-border bg-card shadow-sm">
       <div className="border-b border-border px-3 py-2 text-caption uppercase tracking-overline text-muted-foreground">
-        Tasks ({tasks.length})
+        Tasks ({total ?? tasks.length})
       </div>
-      <div className="max-h-[540px] overflow-auto">
+      <div className="overflow-x-auto">
         <table className="w-full text-xs">
-          <thead className="sticky top-0 bg-card text-muted-foreground z-10">
+          <thead className="bg-card text-muted-foreground">
             <tr className="border-b border-border">
               <th className="px-3 py-2 text-left font-medium">Task</th>
               <th className="px-3 py-2 text-left font-medium">Description</th>

--- a/apps/negentropy-ui/app/interface/scheduler/page.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import type { DashboardFilters, ScheduledTaskDTO, TaskWritePayload } from "@/features/scheduler";
 import { runTaskNow, toggleTaskEnabled, createTask, updateTask, deleteTask } from "@/features/scheduler/api";
 import { ErrorBanner } from "@/components/ui/ErrorState";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
+import { Pagination } from "@/components/ui/Pagination";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 
 import { useSchedulerData } from "@/app/(home)/dashboard/_hooks/useSchedulerData";
@@ -29,6 +30,29 @@ const DEFAULT_FILTERS: DashboardFilters = {
   category: null,
   window: "24h",
 };
+
+const PAGE_SIZE = 10;
+
+/** 解析 last_fire_at 为毫秒；无值/非法返回 null（用于沉底）。 */
+function lastFireMs(t: ScheduledTaskDTO): number | null {
+  if (!t.last_fire_at) return null;
+  const ms = Date.parse(t.last_fire_at);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** 按 Last（上次触发）时间倒序；从未触发(null)沉底，id 兜底稳定排序。 */
+function compareByLastFireDesc(a: ScheduledTaskDTO, b: ScheduledTaskDTO): number {
+  const ta = lastFireMs(a);
+  const tb = lastFireMs(b);
+  if (ta != null && tb != null) {
+    if (tb !== ta) return tb - ta;
+  } else if (ta != null) {
+    return -1;
+  } else if (tb != null) {
+    return 1;
+  }
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
 
 export default function SchedulerPage() {
   const [activeTab, setActiveTab] = useState<"tasks" | "executions" | "stats">("tasks");
@@ -56,6 +80,16 @@ export default function SchedulerPage() {
   } = useSchedulerData(filters);
 
   const { connected } = useSchedulerStream({ onExecution: pushExecution });
+
+  // ---- Tasks 排序 + 分页（镜像 Routine：排序 → totalPages/safePage → 切片）----
+  const [page, setPage] = useState(1);
+  const sortedTasks = useMemo(() => [...tasks].sort(compareByLastFireDesc), [tasks]);
+  const totalPages = Math.max(1, Math.ceil(sortedTasks.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageTasks = useMemo(
+    () => sortedTasks.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE),
+    [sortedTasks, safePage],
+  );
 
   // 反向深链：?task_key=<key> 打开指定任务详情抽屉（来自 Routine 详情「派生自 Scheduler」回链）。
   // 用 window.location.search（client-only effect）规避 useSearchParams 的 Suspense 边界要求。
@@ -172,16 +206,36 @@ export default function SchedulerPage() {
           {error && <ErrorBanner message={error} />}
 
           <SchedulerKpiStrip kpis={kpis} loading={loading} />
-          <SchedulerFilterBar filters={filters} tasks={tasks} onFiltersChange={setFilters} />
+          <SchedulerFilterBar
+            filters={filters}
+            tasks={tasks}
+            onFiltersChange={(f) => {
+              setFilters(f);
+              setPage(1);
+            }}
+          />
 
           {activeTab === "tasks" && (
-            <SchedulerTaskTable
-              tasks={tasks}
-              loading={loading}
-              onToggle={handleToggle}
-              onRun={handleRun}
-              onSelect={setSelectedTask}
-            />
+            <>
+              <SchedulerTaskTable
+                tasks={pageTasks}
+                total={sortedTasks.length}
+                loading={loading}
+                onToggle={handleToggle}
+                onRun={handleRun}
+                onSelect={setSelectedTask}
+              />
+              {sortedTasks.length > 0 && (
+                <Pagination
+                  page={safePage}
+                  totalPages={totalPages}
+                  onPageChange={setPage}
+                  total={sortedTasks.length}
+                  itemLabel="task"
+                  disabled={loading}
+                />
+              )}
+            </>
           )}
 
           {activeTab === "executions" && (


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/interface/scheduler` 的 Tasks 列表此前塞进固定高度滚动容器（`max-h-[540px] overflow-auto`），任务多时右侧出现纵向滚动条，且列表未排序、无分页，与同仓库 Routine 页体验不一致。
- 关联上下文/Issue/文档：对齐 Routine 列表分页范式（commit `daf9bba3`，#990）；复用通用分页控件 `apps/negentropy-ui/components/ui/Pagination.tsx`。

# 核心变更
- `app/interface/scheduler/page.tsx`：新增 `PAGE_SIZE=10` 与 `compareByLastFireDesc`（按 `last_fire_at` 倒序、从未触发的 null 沉底、`id` 兜底稳定排序）；`useMemo` 派生 `sortedTasks / totalPages / safePage / pageTasks`，仅将**当页 10 条**传入表格；筛选变更时 `setPage(1)` 回到第 1 页；表格下渲染复用的 `<Pagination itemLabel="task" total={总数}>`（左侧计数 + 右侧 Prev/页码/Next）。
- `_components/SchedulerTaskTable.tsx`：`max-h-[540px] overflow-auto` → `overflow-x-auto`（消除右侧纵向滚动条，保留窄屏横向滚动，避免 9 列撑破）；`thead` 去掉 `sticky top-0 z-10`（无内部纵向滚动后已无意义）；新增**可选** `total` prop，使表头 “Tasks (N)” 显示总数而非当页数。

# 风险与回滚
- 主要风险：纯前端展示层改动，唯一行为差异是列表由滚动改为分页、默认按 Last 倒序；不涉及数据获取 / 后端 / SSE 流 / `?task_key` 深链。
- 回滚方式：`git revert <commit>` 即可还原两文件，无数据 / schema 变更。

# 验证证据
- 单元测试：未新增（展示层改动，复用已在 Routine 验证过的 `Pagination` 组件与同款排序/切片范式）。
- 集成测试：—
- E2E/Workflow：—
- 覆盖率/关键截图：`pnpm --filter negentropy-ui typecheck` ✓、`eslint --max-warnings=0` ✓、pre-commit 钩子全过；实机渲染需本分支部署后于 3192 验证（运行实例为主仓 standalone 构建、且后端需用户已认证 session，本地工作区无法拉取任务数据）。

# 影响范围
- 前端：Scheduler 页 Tasks 标签页（列表分页 + 按 Last 倒序 + 去滚动条）；`SchedulerTaskTable` 新增向后兼容的可选 `total` prop（当前仅 `scheduler/page.tsx` 调用）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 部署本分支后于 `/interface/scheduler` 实机回归：Tasks 列表无纵向滚动条、默认每页 10 条且按 Last 倒序（未触发沉底）、翻页/筛选回第 1 页、表头显示总数、任务 ≤10 不出现翻页器、`?task_key` 深链仍能打开详情抽屉。
