### PR TITLE
feat(Interface): Repositories 卡片对齐 Agents 卡片体系并支持拖拽排序;

### DIFF
--- a/apps/negentropy-ui/app/api/interface/repositories/reorder/route.ts
+++ b/apps/negentropy-ui/app/api/interface/repositories/reorder/route.ts
@@ -1,0 +1,11 @@
+import { proxyPatch } from "@/app/api/interface/_proxy";
+
+/**
+ * Repository 批量排序端点
+ *
+ * PATCH /api/interface/repositories/reorder - 批量更新 Repository 排序序号
+ */
+
+export async function PATCH(request: Request) {
+  return proxyPatch(request, "/interface/repositories/reorder");
+}

--- a/apps/negentropy-ui/app/interface/repositories/_components/RepositoryCard.tsx
+++ b/apps/negentropy-ui/app/interface/repositories/_components/RepositoryCard.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { GitBranch, Github } from "lucide-react";
+import { GitBranch, Github, Trash2 } from "lucide-react";
+import { useAuth } from "@/components/providers/AuthProvider";
+import {
+  SortableCardWrapper,
+  SortableDragHandle,
+} from "@/components/ui/SortableCardWrapper";
 import type { RepositoryDTO } from "@/features/repositories";
 
 interface RepositoryCardProps {
@@ -14,55 +19,46 @@ export function RepositoryCard({
   onEdit,
   onDelete,
 }: RepositoryCardProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.roles?.includes("admin") ?? false;
+  const canEdit = isAdmin || !repository.is_builtin;
+
   const displayLabel = repository.display_name || repository.name;
 
   return (
-    <div className="group relative flex h-[196px] flex-col rounded-xl border border-border bg-card p-4">
-      {/* 卡片整体覆盖按钮：点击空白区进入编辑（操作按钮以更高 z-index 覆盖其上） */}
-      <button
-        type="button"
-        onClick={onEdit}
-        aria-label={`Edit ${displayLabel}`}
-        className="absolute inset-0 z-10 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card"
-      />
-
+    <SortableCardWrapper
+      id={repository.id}
+      onEdit={canEdit ? onEdit : undefined}
+      canEdit={canEdit}
+    >
       <div className="relative z-20 flex min-h-0 flex-1 flex-col pointer-events-none">
+        {/* Header: drag handle + title + delete */}
         <div className="mb-1 flex min-w-0 items-start justify-between gap-2">
-          <h3 className="truncate text-lg font-semibold text-foreground">
-            {displayLabel}
-          </h3>
-          <div className="flex shrink-0 items-center gap-2 pointer-events-auto">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit();
-              }}
-              title="Edit Repository"
-              aria-label={`Edit ${displayLabel}`}
-              className="rounded-md p-2 text-text-muted hover:bg-muted hover:text-text-secondary"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
-              title="Delete Repository"
-              aria-label={`Delete ${displayLabel}`}
-              className="rounded-md p-2 text-text-muted hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-            >
-              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
+          <div className="flex min-w-0 items-start gap-1">
+            <SortableDragHandle />
+            <h3 className="truncate text-lg font-semibold text-foreground">
+              {displayLabel}
+            </h3>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {canEdit && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                title="Delete Repository"
+                aria-label={`Delete ${displayLabel}`}
+                className="pointer-events-auto cursor-pointer rounded-md p-1.5 text-text-muted transition-colors hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:bg-red-900/20 dark:hover:text-red-400"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            )}
           </div>
         </div>
 
-        {/* 状态徽章行 */}
-        <div className="mb-2 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap">
+        {/* Badges */}
+        <div className="mb-1 flex min-w-0 flex-nowrap items-center gap-2 overflow-hidden whitespace-nowrap pl-6">
           {repository.is_enabled ? (
             <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
               Enabled
@@ -72,40 +68,65 @@ export function RepositoryCard({
               Disabled
             </span>
           )}
-          {repository.is_builtin && (
-            <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-              Built-In
-            </span>
-          )}
           <span className="inline-flex shrink-0 items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
             {repository.visibility}
           </span>
+          {repository.is_builtin && (
+            <span
+              className="inline-flex min-w-0 items-center truncate rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+              title="系统内置：对全员可见，仅 admin 可编辑"
+            >
+              Built-In
+            </span>
+          )}
         </div>
 
-        {/* 本地路径（等宽小字、truncate、悬浮提示全文） */}
+        {/* Description */}
         <p
-          className="mb-2 min-w-0 truncate font-mono text-xs text-text-muted"
-          title={repository.local_path}
+          className="mb-1 pl-6 pr-2 h-[60px] min-w-0 overflow-hidden leading-5 line-clamp-3 text-sm text-text-muted"
+          title={repository.description || "No description"}
         >
-          {repository.local_path}
+          {repository.description || "No description"}
         </p>
 
-        {/* 基线分支 + GitHub 地址 */}
-        <div className="mt-auto flex min-w-0 flex-col gap-1.5 pt-1 text-xs text-text-muted">
-          <span className="inline-flex min-w-0 items-center gap-1.5">
+        {/* Footer metadata：baseline branch + GitHub + 本地路径 */}
+        <div className="mt-auto ml-6 flex min-w-0 flex-nowrap items-center gap-3 overflow-hidden whitespace-nowrap pt-1 text-xs text-text-muted">
+          <span
+            className="inline-flex min-w-0 items-center gap-1 truncate font-mono"
+            title={repository.baseline_branch}
+          >
             <GitBranch className="h-3.5 w-3.5 shrink-0" aria-hidden />
-            <span className="truncate font-mono" title={repository.baseline_branch}>
-              {repository.baseline_branch}
-            </span>
+            <span className="truncate">{repository.baseline_branch}</span>
           </span>
-          <span className="inline-flex min-w-0 items-center gap-1.5">
+          <span
+            className="inline-flex min-w-0 items-center gap-1 truncate"
+            title={repository.github_url}
+          >
             <Github className="h-3.5 w-3.5 shrink-0" aria-hidden />
-            <span className="truncate" title={repository.github_url}>
-              {repository.github_url}
-            </span>
+            <span className="truncate">{repository.github_url}</span>
+          </span>
+          <span
+            className="inline-flex min-w-0 items-center gap-1 truncate font-mono"
+            title={repository.local_path}
+          >
+            <svg
+              className="h-3.5 w-3.5 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+              />
+            </svg>
+            <span className="truncate">{repository.local_path}</span>
           </span>
         </div>
       </div>
-    </div>
+    </SortableCardWrapper>
   );
 }

--- a/apps/negentropy-ui/app/interface/repositories/page.tsx
+++ b/apps/negentropy-ui/app/interface/repositories/page.tsx
@@ -14,10 +14,13 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { ErrorState } from "@/components/ui/ErrorState";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { SortableCardGrid } from "@/components/ui/SortableCardGrid";
+import { useSortableCardGrid } from "@/app/interface/_hooks/useSortableCardGrid";
 import {
   createRepository,
   deleteRepository,
   fetchRepositories,
+  reorderRepositories,
   updateRepository,
 } from "@/features/repositories";
 import type {
@@ -52,6 +55,17 @@ export default function RepositoriesPage() {
   useEffect(() => {
     void loadRepositories();
   }, [loadRepositories]);
+
+  // 拖拽排序：乐观更新本地顺序 + 持久化到后端；失败回退重载（对齐 skills/tools 页）
+  const { sortableItemIds, handleDragEnd } = useSortableCardGrid({
+    items: repositories,
+    onReorder: (reordered) => {
+      setRepositories(reordered as RepositoryDTO[]);
+      reorderRepositories(
+        reordered.map((r) => ({ id: r.id, sort_order: r.sort_order ?? 0 })),
+      ).catch(() => void loadRepositories());
+    },
+  });
 
   const handleCreate = () => {
     setEditingRepository(null);
@@ -142,7 +156,7 @@ export default function RepositoriesPage() {
                 {[0, 1, 2].map((i) => (
                   <div
                     key={i}
-                    className="h-[196px] rounded-xl border border-border bg-card p-4"
+                    className="h-[180px] rounded-xl border border-border bg-card p-4"
                   >
                     <Skeleton className="mb-3 h-5 w-1/3" />
                     <div className="mb-2 flex gap-2">
@@ -174,7 +188,11 @@ export default function RepositoriesPage() {
                 }
               />
             ) : (
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <SortableCardGrid
+                itemIds={sortableItemIds}
+                onDragEnd={handleDragEnd}
+                data-testid="repositories-grid"
+              >
                 {repositories.map((repository) => (
                   <RepositoryCard
                     key={repository.id}
@@ -183,7 +201,7 @@ export default function RepositoriesPage() {
                     onDelete={() => handleDeleteRequest(repository)}
                   />
                 ))}
-              </div>
+              </SortableCardGrid>
             )}
           </div>
         </div>

--- a/apps/negentropy-ui/features/repositories/api.ts
+++ b/apps/negentropy-ui/features/repositories/api.ts
@@ -50,6 +50,13 @@ export async function deleteRepository(id: string): Promise<void> {
   return jsonFetch(`/${encodeURIComponent(id)}`, { method: "DELETE" });
 }
 
+/** 批量更新 Repository 排序序号（前端拖拽后调用），返回排序后的完整可见列表。 */
+export async function reorderRepositories(
+  items: Array<{ id: string; sort_order: number }>,
+): Promise<RepositoryDTO[]> {
+  return jsonFetch("/reorder", { method: "PATCH", body: JSON.stringify({ items }) });
+}
+
 /** 给定本地仓库根路径枚举其 git 分支（填好 local_path 后调用，类比 Test Connection）。 */
 export async function inspectBranches(localPath: string): Promise<BranchInspectResponse> {
   return jsonFetch("/inspect", {

--- a/apps/negentropy-ui/features/repositories/index.ts
+++ b/apps/negentropy-ui/features/repositories/index.ts
@@ -9,5 +9,6 @@ export {
   deleteRepository,
   fetchRepositories,
   inspectBranches,
+  reorderRepositories,
   updateRepository,
 } from "./api";

--- a/apps/negentropy/src/negentropy/interface/repository_api.py
+++ b/apps/negentropy/src/negentropy/interface/repository_api.py
@@ -206,6 +206,61 @@ async def create_repository(
     return _repository_to_response(repo)
 
 
+# ---------------------------------------------------------------------------
+# Reorder（批量排序）—— 必须声明在 /{repository_id} 之前
+# ---------------------------------------------------------------------------
+
+
+class RepositoryReorderItem(BaseModel):
+    id: UUID
+    sort_order: int
+
+
+class RepositoryReorderRequest(BaseModel):
+    items: list[RepositoryReorderItem]
+
+
+@router.patch("/reorder", response_model=list[RepositoryResponse])
+async def reorder_repositories(
+    payload: RepositoryReorderRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> list[RepositoryResponse]:
+    """批量更新 Repository 排序序号。前端拖拽后调用，传入所有可见 Repository 的 id + sort_order。
+
+    ⚠️ 必须声明在 ``/{repository_id}`` 之前——Starlette 按声明顺序匹配路由，否则
+    "reorder" 会被当作路径参数解析为 UUID 而 422。语义对齐 agents/tools 的 reorder：
+    以可见集合为闸门，``sort_order`` 为共享列。
+    """
+    async with db_session.AsyncSessionLocal() as db:
+        visible_ids = await get_visible_plugin_ids(db, "repository", user)
+        if not visible_ids:
+            return []
+
+        visible_set = set(visible_ids)
+        for item in payload.items:
+            if item.id not in visible_set:
+                raise HTTPException(status_code=403, detail=f"No edit permission for repository {item.id}")
+
+        # 批量查询所有目标 repo，避免 N+1
+        target_ids = [item.id for item in payload.items]
+        result = await db.execute(select(Repository).where(Repository.id.in_(target_ids)))
+        repo_map = {r.id: r for r in result.scalars().all()}
+        for item in payload.items:
+            repo = repo_map.get(item.id)
+            if repo:
+                repo.sort_order = item.sort_order
+
+        await db.commit()
+
+        stmt = (
+            select(Repository)
+            .where(Repository.id.in_(visible_ids))
+            .order_by(Repository.sort_order.asc(), Repository.created_at.desc())
+        )
+        repos = (await db.execute(stmt)).scalars().all()
+        return [_repository_to_response(r) for r in repos]
+
+
 @router.get("/{repository_id}", response_model=RepositoryResponse)
 async def get_repository(
     repository_id: UUID,


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/interface/repositories` 的卡片是整个 `/interface/` 区域**唯一**未复用共享可排序卡片体系的页面（Agents/Skills/Tools/MCP 均已统一），存在 3D 倾斜/悬停高亮、拖拽手柄、点击空白编辑、徽章缩进、拖拽排序等 UX 不一致，且 `RepositoryDTO.description` 字段一直未渲染。
- 关联上下文：收敛到 `SortableCardWrapper` / `SortableCardGrid` / `useSortableCardGrid` 共享体系；后端 `Repository.sort_order` 列与列表排序查询已就绪，仅缺 reorder 端点，无需 DB 迁移。

# 核心变更
- **后端** `repository_api.py`：新增 `PATCH /interface/repositories/reorder`（照搬 Tools 的 `reorder_builtin_tools`：批量查询避免 N+1 + `get_visible_plugin_ids` 可见性闸门 + 返回排序后列表）。
  - ⚠️ 关键正确性：端点必须声明在 `/{repository_id}` **之前**，否则 Starlette 会把 `"reorder"` 当作 UUID 路径参数吞掉而 422。已框架层实测确认顺序无误。
- **前端代理**：新增 `app/api/interface/repositories/reorder/route.ts`（照搬 `agents/reorder`）。
- **数据层** `features/repositories`：新增 `reorderRepositories` 并在 barrel 导出。
- **卡片重写** `RepositoryCard.tsx`：以 `AgentCard.tsx` 为蓝本复用 `SortableCardWrapper` + `SortableDragHandle`——统一 3D 倾斜/悬停高亮、点击空白编辑、统一删除按钮（`Trash2`）、徽章 `pl-6` 缩进；新增描述区块（`line-clamp-3`）与页脚元数据行（baseline_branch / github_url / local_path，图标+truncate）；`canEdit = isAdmin || !is_builtin` 对 built-in 仓库门控（与 Agents 一致，后端已以权限兜底）。
- **页面接线** `repositories/page.tsx`：`useSortableCardGrid` + `SortableCardGrid` 替换手写 grid，乐观更新本地顺序、失败回退重载（对齐 skills/tools 页）。

# 风险与回滚
- 主要风险：reorder 端点路由顺序若误置于 `/{repository_id}` 之后会 422（已实测规避）；`sort_order` 为共享列，任一可见者重排影响全体（与 agents/tools 既有共享语义一致，非本次引入）。
- 回滚方式：`revert` 本提交即可，无 schema 迁移、无破坏性数据变更。

# 验证证据
- 单元测试：无新增（全程复用既有共享组件，无新逻辑分支）。
- 集成测试：后端 router 导入实测，`PATCH /interface/repositories/reorder` 已注册且声明顺序先于 `/{repository_id}`；模块 AST/Ruff 通过。
- E2E/Workflow：本工作区 dev server 编译 `/interface/repositories` → HTTP 200，零编译错误；未授权态浏览器确认路由与鉴权中间件正常重定向登录页。
- 覆盖率/关键截图：TypeScript typecheck 0 错误、ESLint clean、Ruff clean；**像素级授权态比对未完成**（MCP 浏览器无登录态，按浏览器验证协议不得自行完成 OAuth）。

# 影响范围
- 前端：`/interface/repositories` 页面与卡片；新增 reorder 代理路由。
- 后端：`interface/repository_api.py` 新增 reorder 端点；无 DB 迁移。
- GitHub Actions / 文档：无。

# Next Best Action
- 部署后端后用真实登录态 Chrome 做一次卡片像素比对 + 拖拽排序持久化回归（刷新验证 `sort_order` 落库、失败回退路径）。
