### PR TITLE
fix(Patrol): 单文档成本预算 5→30，避免重自治任务 2 轮即 max_cost 终止

### DIFF
--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -218,6 +218,7 @@ routine:
   patrol_baseline_branch: "origin/feature/1.x.x"
   patrol_input_dir: "/tmp/negentropy-patrol"  # 源 PDF 暂存 + 候选 Markdown 输出根
   patrol_max_iterations_per_doc: 8           # 单文档巡检 Routine 迭代硬上限
+  patrol_max_cost_usd_per_doc: 30.0          # 单文档成本熔断（USD）；重自治任务单轮约 $3-4，30 容许 ~8 轮收敛（原 5 致 2 轮撞顶）
   patrol_regression_sample_size: 6           # 非回归基线样本数
 
 # --- Knowledge 配置 ---

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -311,6 +311,13 @@ class RoutineSettings(BaseSettings):
         le=50,
         description="单文档巡检 Routine 的迭代硬上限（拟合到满分或触上限即终止）。",
     )
+    patrol_max_cost_usd_per_doc: float = Field(
+        default=30.0,
+        ge=0.0,
+        description="单文档巡检 Routine 的成本熔断（USD）。巡检是重自治任务（opus + 扩展思考"
+        " + perceives 重转 + worktree），单轮约 $3-4；默认 30 容许 ~8 轮迭代收敛。"
+        "原沿用全局 default_max_cost_usd=5，2 轮即撞顶 max_cost 终止（实测 $6.92）。",
+    )
     patrol_regression_sample_size: int = Field(
         default=6,
         ge=1,

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -436,7 +436,7 @@ def _build_patrol_routine(
         verification_command=None,
         status="running",
         max_iterations=settings.routine.patrol_max_iterations_per_doc,
-        max_cost_usd=settings.routine.default_max_cost_usd,
+        max_cost_usd=settings.routine.patrol_max_cost_usd_per_doc,
         deadline_at=None,
         success_score_threshold=100,
         no_progress_patience=3,  # per-Routine DB 列默认值（非 RoutineSettings 属性）

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -65,6 +65,7 @@ async def test_create_and_start_patrol_routine_persists_real_row(db_engine):
         assert row.no_progress_patience == 3  # per-Routine 默认（非 settings）—— 回归点
         assert row.success_score_threshold == 100
         assert row.max_iterations == 8  # settings.routine.patrol_max_iterations_per_doc
+        assert row.max_cost_usd == 30.0  # patrol 专属预算（非全局 default_max_cost_usd=5）
         assert row.owner_id == "system"
         assert row.is_template is False
         assert row.key.startswith("pdf-fidelity-patrol/")


### PR DESCRIPTION
## 失败根因（实机诊断 Routine `83fb782f`）

```
status=failed  termination=max_cost  cost=$6.92  iter=2/8  best=62
```

巡检闭环**实际在干活**——iter1 评分 62（progressing），评审反思：「Algorithm 1 伪代码从 2 行恢复至 40 步完整内容，修复有效」。但仅 **2 轮就撞成本顶** `max_cost` 终止。

根因：巡检 Routine 沿用全局 `default_max_cost_usd=5.0`，而单轮（opus-4-8 + 扩展思考 + perceives 重转 + worktree）约 **$3-4**，2 轮即 **$6.92 > $5** → `max_cost` 终止（远未到 `no_progress_patience=3` 或 `max_iterations=8`）。

## 修复
新增 patrol 专属预算 `patrol_max_cost_usd_per_doc`（默认 **30.0**，容许 ~8 轮收敛）：
- `config/routine.py` + `config.default.yaml`：新增字段（30.0，可经 YAML/env 调）。
- `handlers/pdf_fidelity_patrol.py`：`max_cost_usd` 改用 `patrol_max_cost_usd_per_doc`（不再 `default_max_cost_usd=5`）。

## 效果
巡检可跑满 `max_iterations=8` 或至 `no_progress_patience=3` stalled **自然终止**，而非 2 轮撞顶 `failed`。

## 诚实边界（独立问题，非本修范围）
评分振荡（iter1 62 → iter2 42 stalled）由 perceives 非确定性 + LLM-judge 方差所致，需后续单独治理（采样固定页/评分一致性）。本修解除成本硬阻塞，让闭环能跑到自然终点。

## 验证
ruff 全绿；handler + PG 集成（断言 `max_cost_usd==30.0`）共 12 例通过。基于最新 `origin/feature/1.x.x`。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
