### PR TITLE
fix(Patrol): 巡检任务链文档标题改用修正后的 display_name，弃用原始上传文件名

### DIFF
--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -36,6 +36,7 @@ import sqlalchemy as sa
 from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
+from negentropy.models.perception import resolve_effective_display_name
 from negentropy.models.repository import Repository
 from negentropy.models.routine import Routine
 
@@ -51,6 +52,16 @@ PATROL_REPO_NAME = "negentropy"
 PATROL_KEY_PREFIX = "pdf-fidelity-patrol"
 CANDIDATE_MD_FILENAME = "patrol-candidate.md"
 SOURCE_PDF_FILENAME = "source.pdf"
+
+
+def _doc_display_title(doc: dict[str, Any]) -> str:
+    """文档展示标题（复用 ``perception.resolve_effective_display_name`` SSOT 内核）。
+
+    raw-SQL dict 直喂纯解析器：``display_name``（用户修正）→ ``metadata_title``
+    （PDF 自动抽取）→ ``original_filename``（兜底）。避免把 knowledge 重图拖入 engine 顶层。
+    """
+    return resolve_effective_display_name(doc.get("display_name"), doc.get("metadata_title"), doc["original_filename"])
+
 
 register_descriptor(
     HandlerDescriptor(
@@ -165,11 +176,11 @@ async def _run_patrol_tick(*, task_key: str) -> HandlerResult:
         "patrol_routine_started",
         doc_id=doc_id,
         routine_id=str(routine_id),
-        doc_title=doc["original_filename"],
+        doc_title=_doc_display_title(doc),
     )
     return HandlerResult(
         status="ok",
-        output_summary=f"patrol started: doc={doc_id} ({doc['original_filename']})",
+        output_summary=f"patrol started: doc={doc_id} ({_doc_display_title(doc)})",
         metrics={
             "reason": "spawned",
             "doc_id": doc_id,
@@ -320,7 +331,8 @@ async def _select_next_pending_doc(db, *, skip_ids: set[str]) -> dict[str, Any] 
         params["skip"] = tuple(skip_ids)
 
     sql = (
-        "SELECT id, content_uri, original_filename FROM negentropy.knowledge_documents "
+        "SELECT id, content_uri, original_filename, display_name, metadata->>'title' "
+        "FROM negentropy.knowledge_documents "
         "WHERE app_name = :app "
         "AND COALESCE(content_type,'') ILIKE '%pdf%' "
         "AND markdown_extract_status = 'completed' "
@@ -334,7 +346,13 @@ async def _select_next_pending_doc(db, *, skip_ids: set[str]) -> dict[str, Any] 
     r = row.fetchone()
     if not r:
         return None
-    return {"id": r[0], "content_uri": r[1], "original_filename": r[2]}
+    return {
+        "id": r[0],
+        "content_uri": r[1],
+        "original_filename": r[2],
+        "display_name": r[3],
+        "metadata_title": r[4],
+    }
 
 
 async def _select_regression_sample(db, *, size: int) -> list[str]:
@@ -413,7 +431,7 @@ def _build_patrol_routine(
     )
 
     doc_id = str(doc["id"])
-    doc_title = doc["original_filename"]
+    doc_title = _doc_display_title(doc)
     short = uuid.uuid4().hex[:8]
     return Routine(
         key=f"{PATROL_KEY_PREFIX}/{doc_id}/{short}",

--- a/apps/negentropy/src/negentropy/knowledge/_shared.py
+++ b/apps/negentropy/src/negentropy/knowledge/_shared.py
@@ -13,7 +13,7 @@ from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.knowledge.types import KnowledgeRecord
 from negentropy.logging import get_logger
-from negentropy.models.perception import Knowledge
+from negentropy.models.perception import Knowledge, resolve_effective_display_name
 from negentropy.models.plugin import McpServer, McpTool
 from negentropy.models.pulse import UserState
 
@@ -669,14 +669,8 @@ def effective_display_name(doc: Any) -> str:
     chunk 字典级读取方见
     :meth:`KnowledgeRepository._infer_display_name`，二者语义对齐、须同步演进。
     """
-    display_name = (getattr(doc, "display_name", None) or "").strip()
-    if display_name:
-        return display_name
     meta = getattr(doc, "metadata_", None) or {}
-    meta_title = meta.get("title")
-    if isinstance(meta_title, str) and meta_title.strip():
-        return meta_title.strip()
-    return doc.original_filename
+    return resolve_effective_display_name(getattr(doc, "display_name", None), meta.get("title"), doc.original_filename)
 
 
 def effective_download_filename(original_filename: str, display_name: str | None) -> str:

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -162,6 +162,28 @@ class KnowledgeDocument(Base, UUIDMixin, TimestampMixin):
 
 
 # =============================================================================
+# 文档展示名解析（单一事实源内核）
+# =============================================================================
+
+
+def resolve_effective_display_name(display_name: str | None, metadata_title: Any, original_filename: str) -> str:
+    """文档展示名的纯函数解析（单一事实源内核，无 IO / 无 ORM 依赖）。
+
+    优先级：``display_name``（用户手填覆盖）→ ``metadata_.title``（PDF / 抓取自动抽取，
+    须为非空 str）→ ``original_filename``（不可变兜底）。
+
+    供 ``_shared.effective_display_name``（ORM 级 duck-typed）与 raw-SQL dict 级场景
+    （如 ``pdf_fidelity_patrol`` handler）共同复用，避免 3-tier 回退链多处重复实现。
+    """
+    name = (display_name or "").strip()
+    if name:
+        return name
+    if isinstance(metadata_title, str) and metadata_title.strip():
+        return metadata_title.strip()
+    return original_filename
+
+
+# =============================================================================
 # Phase 2: 文档来源追踪
 # =============================================================================
 

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -90,9 +90,25 @@ def test_derive_repo_root_package_fallback_finds_ancestor():
 def test_select_next_pending_doc_returns_dict():
     import asyncio
 
-    db = _FakeDB(fetchone=("doc-uuid", "pgblob://k", "report.pdf"))
+    db = _FakeDB(fetchone=("doc-uuid", "pgblob://k", "report.pdf", None, None))
     doc = asyncio.run(patrol._select_next_pending_doc(db, skip_ids=set()))
-    assert doc == {"id": "doc-uuid", "content_uri": "pgblob://k", "original_filename": "report.pdf"}
+    assert doc == {
+        "id": "doc-uuid",
+        "content_uri": "pgblob://k",
+        "original_filename": "report.pdf",
+        "display_name": None,
+        "metadata_title": None,
+    }
+
+
+def test_select_next_pending_doc_carries_corrected_title_fields():
+    """display_name / metadata_title 透传到返回 dict，供 _doc_display_title 三级解析。"""
+    import asyncio
+
+    db = _FakeDB(fetchone=("doc-uuid", "pgblob://k", "report.pdf", "用户改名", None))
+    doc = asyncio.run(patrol._select_next_pending_doc(db, skip_ids=set()))
+    assert doc["display_name"] == "用户改名"
+    assert doc["metadata_title"] is None
 
 
 def test_select_next_pending_doc_none_when_empty():
@@ -205,3 +221,56 @@ def test_build_patrol_routine_constructs_without_attribute_error():
     assert routine.config["source_task_key"] == "pdf_fidelity_patrol"
     assert "system_prompt" in routine.config
     assert routine.config["read_dirs"] == ["/tmp/patrol"]
+    # 标题源：未修正时回退 original_filename（_doc_display_title 经 SSOT 解析）
+    assert routine.title == "PDF 高保真巡检：report.pdf"
+
+
+def test_build_patrol_routine_uses_corrected_display_name():
+    """回归本次目标：用户修正后的 display_name 透传到 Routine 标题/展示名/描述/goal，
+    原始文件名不再出现在用户可见标题链路。"""
+    import uuid as _uuid
+
+    doc = {
+        "id": _uuid.uuid4(),
+        "original_filename": "scan_2023.pdf",
+        "display_name": "用户修正标题",
+        "metadata_title": None,
+    }
+    routine = patrol._build_patrol_routine(
+        repo_id=_uuid.uuid4(),
+        baseline_branch="origin/feature/1.x.x",
+        doc=doc,
+        source_pdf_path="/tmp/patrol/source.pdf",
+        source_read_dir="/tmp/patrol",
+        regression_sample=["s1"],
+        source_task_key="pdf_fidelity_patrol",
+    )
+    assert routine.title == "PDF 高保真巡检：用户修正标题"
+    assert routine.display_name == "PDF Fidelity Patrol · 用户修正标题"
+    assert "用户修正标题" in routine.description
+    assert "用户修正标题" in routine.goal
+    # 原始文件名不得出现在用户可见标题链路
+    assert "scan_2023.pdf" not in routine.title
+    assert "scan_2023.pdf" not in routine.display_name
+
+
+def test_build_patrol_routine_falls_back_to_metadata_title():
+    """display_name 缺省时回退到 PDF 自动抽取的 metadata_title（三级解析器第二级）。"""
+    import uuid as _uuid
+
+    doc = {
+        "id": _uuid.uuid4(),
+        "original_filename": "scan_2023.pdf",
+        "display_name": None,
+        "metadata_title": "自动抽取的文档标题",
+    }
+    routine = patrol._build_patrol_routine(
+        repo_id=_uuid.uuid4(),
+        baseline_branch="origin/feature/1.x.x",
+        doc=doc,
+        source_pdf_path="/tmp/p.pdf",
+        source_read_dir="/tmp",
+        regression_sample=[],
+        source_task_key="pdf_fidelity_patrol",
+    )
+    assert routine.title == "PDF 高保真巡检：自动抽取的文档标题"

--- a/apps/negentropy/tests/unit_tests/knowledge/test_display_name_helpers.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_display_name_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from negentropy.knowledge._shared import effective_display_name, effective_download_filename
+from negentropy.models.perception import resolve_effective_display_name
 
 # ----------------------------------------------------------------------------
 # effective_display_name
@@ -41,6 +42,32 @@ def test_effective_display_name_ignores_blank_display_name_and_blank_title():
 
 def test_effective_display_name_strips_whitespace():
     assert effective_display_name(_doc(display_name="  Q3 Report  ")) == "Q3 Report"
+
+
+# ----------------------------------------------------------------------------
+# resolve_effective_display_name（纯解析器内核；handler raw-SQL dict 级入口）
+# ----------------------------------------------------------------------------
+
+
+def test_resolve_prefers_display_name():
+    assert resolve_effective_display_name("用户改名", "Quarterly", "scan.pdf") == "用户改名"
+
+
+def test_resolve_falls_back_to_metadata_title():
+    assert resolve_effective_display_name(None, "Quarterly", "scan.pdf") == "Quarterly"
+
+
+def test_resolve_falls_back_to_original_filename():
+    assert resolve_effective_display_name(None, None, "scan.pdf") == "scan.pdf"
+
+
+def test_resolve_ignores_blank_and_non_str_title():
+    assert resolve_effective_display_name("   ", "  ", "scan.pdf") == "scan.pdf"
+    assert resolve_effective_display_name(None, 123, "scan.pdf") == "scan.pdf"  # 非 str 守卫
+
+
+def test_resolve_strips_whitespace():
+    assert resolve_effective_display_name("  Q3 Report  ", None, "scan.pdf") == "Q3 Report"
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

「PDF Fidelity Patrol（PDF→Markdown 高保真自拟合巡检）」是 Scheduler 按 `interval` 启动的 Routine 任务，为每份生产 PDF 创建巡检 Routine。但其**整条任务链**（Routine 标题 / 展示名 / 描述 / goal→prompt→CC 迭代→PR 标题 / 日志）此前都用**上传时的原始文件名**（如 `scan_2023.pdf`）指代文档——毫无语义、无法辨识文档处理的是什么。

用户已在 Knowledge / Document 的「File Name」处人工修正过文档标题（落库 `knowledge_documents.display_name`）。本 PR 使整条任务链改用该修正标题指代文档。

## 改动要点

- **抽纯解析器 SSOT 内核**：`perception.resolve_effective_display_name(display_name, metadata_title, original_filename)`，三级回退 `display_name → metadata.title → original_filename`（无 IO / 无 ORM 依赖，import-light）。
- **`_shared.effective_display_name` 委派复用**：语义字节级不变，现有 wiki / 检索 / 测试调用方零改动（单一事实源，不重复实现 3-tier 链）。
- **Patrol handler**：
  - `_select_next_pending_doc` 取数拓宽 `display_name`、`metadata->>'title'`（物理列名 `metadata`，先例 `engine/title_inspector.py`）；
  - 新增 `_doc_display_title(doc)` 经纯解析器就地解析；
  - 替换 3 个使用点（`doc_title` 赋值、`logger`、`output_summary`），向下流入整条 Routine 任务链。
- **原始文件名仅作末级兜底**：用户可见路径不再读 `original_filename`。

## 不在范围

`patrol_memory.py` 记忆内容只用不可变 `doc_id` 索引（从不使用原始文件名），不违反诉求；记忆须按 `doc_id` 键化（用户改名后仍正确），强行塞可变标题属 YAGNI。

## 验证

- 纯逻辑单测 37 项全过：`test_pdf_fidelity_patrol_handler.py` / `test_patrol_prompt.py` / `test_display_name_helpers.py`（含新增「修正标题透传」「metadata_title 回退」「纯解析器」用例）；
- PG 集成测试 `test_pdf_fidelity_patrol_integration.py`（真实执行拓宽后 `metadata->>'title'` raw SQL，确认列名正确、签名不变）；
- 直连 PG 复核取数 5 列、`metadata->>'title'` 为 NULL 时正确兜底；
- pre-commit ruff lint + format 通过。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
