### PR TITLE
fix(Interface): 修复 Scheduler 派生 Routine 跳转后 Routine 抽屉无法关闭

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
@@ -67,6 +67,13 @@ function RoutinePageInner() {
   const [createOpen, setCreateOpen] = useState(false);
   const [actionBusy, setActionBusy] = useState(false);
   const [page, setPage] = useState(1);
+
+  // SSE ghost-reopen 守卫：镜像 selected 供异步 SSE 回调读取「抽屉是否仍打开」，
+  // 关闭时在 closeDetail 内同步清空，杜绝 stale-id 事件在 setSelected 提交前重开抽屉（§2）。
+  const selectedRef = useRef<RoutineDTO | null>(selected);
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
 
   const { confirm, confirmDialog } = useConfirmDialog();
   const {
@@ -145,6 +152,10 @@ function RoutinePageInner() {
   );
 
   const closeDetail = useCallback(() => {
+    // 乐观即时关闭：与 openDetail 对称，使 drawerMode 立即变 null、抽屉卸载，
+    // 规避 Next.js 同路由纯 query nav 下 useSearchParams 反应式不可靠（深链冷启动场景，§1）。
+    selectedRef.current = null; // 同步清空：覆盖 setSelected(null) 提交前的微秒级竞态窗，配合 SSE 守卫杜绝 ghost 重开
+    setSelected(null);
     const next = new URLSearchParams(sp.toString());
     next.delete("sel");
     router.replace(`?${next.toString()}`, { scroll: false });
@@ -161,11 +172,15 @@ function RoutinePageInner() {
   const { connected } = useRoutineStream({
     onRoutineEvent: (ev) => {
       applyRoutineEvent();
-      if (selId && ev.id === selId) void refreshSelected(selId);
+      // 以实际打开的 routine（selectedRef）为准，而非 URL 的 selId——后者在深链冷启动场景下可能 stale，
+      // 会用旧 id 把已乐观关闭的抽屉重新打开（ghost-reopen，§2）。
+      const id = selectedRef.current?.id;
+      if (id && ev.id === id) void refreshSelected(id);
     },
     onIterationEvent: (ev) => {
       applyIterationEvent(ev);
-      if (selId && (ev.routine_id === selId || ev.id === selId)) void refreshSelected(selId);
+      const id = selectedRef.current?.id;
+      if (id && (ev.routine_id === id || ev.id === id)) void refreshSelected(id);
     },
   });
 

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
@@ -42,12 +43,12 @@ function SpawnedRoutineLink({ metrics }: { metrics: Record<string, unknown> | un
   if (!rid) return null;
   const docId = typeof metrics?.doc_id === "string" ? metrics.doc_id : null;
   return (
-    <a
+    <Link
       href={`/interface/routine?sel=${encodeURIComponent(rid)}`}
       className="inline-flex items-center gap-1 text-micro text-blue-600 dark:text-blue-400 hover:underline w-fit"
     >
       派生 Routine →{docId ? `（doc ${docId.slice(0, 8)}）` : ""}
-    </a>
+    </Link>
   );
 }
 

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 
 import { Button } from "@/components/ui/Button";
 import { fetchTaskDetail } from "@/features/scheduler";
@@ -135,7 +136,7 @@ function SpawnedRoutinesSection({ taskKey, taskId }: { taskKey: string; taskId: 
           </div>
         ) : (
           routines.map((r) => (
-            <a
+            <Link
               key={r.id}
               href={`/interface/routine?sel=${encodeURIComponent(r.id)}`}
               className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-muted/50 transition-colors"
@@ -153,7 +154,7 @@ function SpawnedRoutinesSection({ taskKey, taskId }: { taskKey: string; taskId: 
                 {r.pr_url && <span className="text-blue-600 dark:text-blue-400">PR</span>}
                 <span>→</span>
               </span>
-            </a>
+            </Link>
           ))
         )}
       </div>


### PR DESCRIPTION
## 背景

从 Scheduler 详情抽屉的「派生 Routine 列表」点跳转按钮（裸 `<a href="/interface/routine?sel=<id>">`）进入 Routine 详情抽屉后，点击空白遮罩或右上角 X 都**无法关闭**；而从 Routine 列表页内打开抽屉时，同样操作可正常关闭。两种入口关闭行为不一致。

## 根因

**关闭语义不对称**：
- Routine 抽屉关闭走「URL 单向流」：`closeDetail` 仅 `router.replace("?")` 删 `?sel` → 依赖 `useSearchParams` 反应式更新 → 触发 `useEffect[selId]` → `setSelected(null)` → 抽屉卸载。
- Scheduler 抽屉关闭是纯 React state（`setSelectedTask(null)`），无 URL 依赖——这正是其反向链（Routine 抽屉 → Scheduler）可正常关闭的原因。

**触发器**：Scheduler 抽屉里的裸 `<a href>` 在 Next.js 中必触发**全页刷新**，Routine 页面冷启动 mount 且初始即带 `?sel`。此时 `<Suspense>` 包裹下的 `useSearchParams` 对「同路由、组件自身发起的 `router.replace` 纯 query 删除」反应式不可靠（Next.js App Router 已知脆弱点），`selId` 未翻 null → 关闭 effect 不触发 → 抽屉卡住。列表页内打开时页面已 mount、Suspense 已 resolve，`router.push/replace` 正常回流，故可关闭。

**内证**：`scheduler/page.tsx` 的反向深链刻意「用 `window.location.search` 规避 useSearchParams 的 Suspense 边界要求」——本仓已踩过同类坑。

**排除**：z-index 叠放遮挡假说不成立——裸 `<a>` 全页刷新会卸载内联渲染（非 portal）的 Scheduler 抽屉。

## 修复

- **§1 closeDetail 乐观关闭（核心）**：与 `openDetail`（乐观 `setSelected(r)`）对称，在 `router.replace` 前先 `setSelected(null)`，使 `drawerMode` 立即变 null、抽屉卸载，**不再依赖 `useSearchParams` 反应式更新**。一处改动覆盖全部关闭入口（X / 遮罩 / Esc / Cancel / 删除）。
- **§2 SSE ghost-reopen 守卫（防回归）**：引入 `selectedRef` 镜像 `selected`（关闭时同步清空），`useRoutineStream` 回调改用实际打开的 routine 而非 URL 的 `selId`，防止乐观关闭后 stale-id 事件把抽屉「关了又自己弹回来」。
- **§3 跳转源 `<a>` 改 `<Link>`（一致性）**：`SchedulerTaskDetailDrawer` 与 `SchedulerExecutionPanel` 的派生 Routine 跳转由裸 `<a>` 改 `next/link` 的 `<Link>`，消除全页刷新、收窄触发面。

## 改动文件

- `app/interface/routine/page.tsx`：§1 §2（核心）
- `app/interface/scheduler/_components/SchedulerTaskDetailDrawer.tsx`、`SchedulerExecutionPanel.tsx`：§3

## 验证

- `pnpm typecheck` ✅、`pnpm lint`（零警告）✅、`pnpm test`（870 单测全通过，含 `SchedulerExecutionPanel.patrol.test.tsx` 验证 `<Link>` 的 href）✅
- §1 为确定性修复：`setSelected(null)` → `drawerMode` 派生 null → 抽屉卸载，纯 React 状态、不依赖 `useSearchParams`，构造层即根除「无法关闭」。

### 实机复现步骤（需登录态）
1. \`pnpm dev\`，登录态打开 \`/interface/scheduler\`。
2. 打开含派生 Routine 的任务详情抽屉 → 点派生 Routine 跳转 → 确认 Routine 抽屉可由 遮罩 / X / Esc 关闭（修复前不可）。
3. 回归：列表页内打开可关闭、后退键可关闭、删除后立即关闭。
4. SSE ghost-reopen：深链打开 running routine 抽屉 → 乐观关闭 → 确认抽屉不会自己弹回。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>