### PR TITLE
fix(Routine): 单 Workspace 机制 + Plan 模式统一启动 + 巡检预算 ×50

### DIFF
--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -217,8 +217,8 @@ routine:
   patrol_repo_local_path: null               # null → 运行期从 negentropy 包路径自动推导仓库根；不可解析时报 repo_not_configured
   patrol_baseline_branch: "origin/feature/1.x.x"
   patrol_input_dir: "/tmp/negentropy-patrol"  # 源 PDF 暂存 + 候选 Markdown 输出根
-  patrol_max_iterations_per_doc: 8           # 单文档巡检 Routine 迭代硬上限
-  patrol_max_cost_usd_per_doc: 30.0          # 单文档成本熔断（USD）；重自治任务单轮约 $3-4，30 容许 ~8 轮收敛（原 5 致 2 轮撞顶）
+  patrol_max_iterations_per_doc: 400         # 单文档巡检 Routine 迭代硬上限（×50：原 8）
+  patrol_max_cost_usd_per_doc: 1500.0        # 单文档成本熔断（USD）；×50（原 30）容许数百轮深度拟合收敛（原 5 致 2 轮撞顶）
   patrol_regression_sample_size: 6           # 非回归基线样本数
 
 # --- Knowledge 配置 ---

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -306,17 +306,17 @@ class RoutineSettings(BaseSettings):
         description="源 PDF 暂存与候选 Markdown 输出根目录（按 doc_id 建子目录）。",
     )
     patrol_max_iterations_per_doc: int = Field(
-        default=8,
+        default=400,
         ge=1,
-        le=50,
+        le=500,
         description="单文档巡检 Routine 的迭代硬上限（拟合到满分或触上限即终止）。",
     )
     patrol_max_cost_usd_per_doc: float = Field(
-        default=30.0,
+        default=1500.0,
         ge=0.0,
         description="单文档巡检 Routine 的成本熔断（USD）。巡检是重自治任务（opus + 扩展思考"
-        " + perceives 重转 + worktree），单轮约 $3-4；默认 30 容许 ~8 轮迭代收敛。"
-        "原沿用全局 default_max_cost_usd=5，2 轮即撞顶 max_cost 终止（实测 $6.92）。",
+        " + perceives 重转 + worktree），单轮约 $3-4；默认 1500 容许数百轮深度拟合收敛。"
+        "原 30 仅容许 ~8 轮即触顶；按需在当前基础上 ×50（400 轮 / $1500）以支持长链路自拟合。",
     )
     patrol_regression_sample_size: int = Field(
         default=6,

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -1454,8 +1454,11 @@ class RoutineOrchestrator:
         # CC settings.json 基底：源码只读 deny（read_dirs 非空时）。Plan Review 钩子按 unified/legacy 分别注入。
         settings_obj: dict = json.loads(_build_readonly_settings(read_dirs)) if read_dirs else {}
         plan_review_active = _is_plan_review_active(routine)
+        # Plan 审批通道（默认 clean stdin）：plan_review_via_hook=False → reader 内 _plan_review_answer 经
+        # stdin 写干净 tool_result（approve/refine），无 deny→is_error；=True 才回灌 PreToolUse deny 钩子
+        # （历史默认 True，headless 下 deny→is_error 致 UI 报错/交互断联，故现默认关）。巡检即用默认 False 走通。
+        via_hook = bool((routine.config or {}).get("plan_review_via_hook", False))
         # 统一闭环：worktree + 全局开关开 + per-routine 未关闭。主 config = implement 段；plan 段独立挂载（见文末）。
-        # config.plan_review_enabled=False（如巡检）→ 不挂 plan 段、直接 implement 段，规避 headless deny→is_error。
         unified = bool(
             settings.routine.plan_review_unified_loop
             and phase_mod.is_worktree_routine(routine)
@@ -1467,7 +1470,8 @@ class RoutineOrchestrator:
         )
         # Legacy 路径（统一闭环关）：评审钩子直接注入主 config（PLAN 相位，ISSUE-123 原行为；
         # ExitPlanMode 仅消噪不评审）。unified 路径：钩子注入独立 plan 段（见文末），主 config 不挂钩子。
-        if plan_review_active and not unified:
+        if plan_review_active and not unified and via_hook:
+            # legacy + deny 钩子通道（opt-in）：via_hook=False 时不挂钩子，改由 reader clean stdin 应答。
             ctx_path = _write_plan_review_ctx(routine, iteration_id, mode="legacy")
             pre = settings_obj.setdefault("hooks", {}).setdefault("PreToolUse", [])
             pre.extend(_plan_review_hook_pre(ctx_path, review_timeout, exit_plan_full_review=False))
@@ -1504,9 +1508,9 @@ class RoutineOrchestrator:
                 "acceptance_criteria": routine.acceptance_criteria,
                 "phase": routine.current_phase or "",
                 "plan_review_enabled": settings.routine.plan_review_enabled,
-                # 主 config 在 unified 下为 implement 段、不做评审，故 via_hook 仅在 legacy 评审激活时为真
-                # （置真令交互式 reader 跳过对 AskUserQuestion 无效且会重复评审的内联 plan-review 应答分支）。
-                "plan_review_via_hook": plan_review_active and not unified,
+                # 主 config 在 unified 下为 implement 段、不做评审；legacy 评审激活且走 deny 钩子时置真，
+                # 令交互式 reader 跳过内联 plan-review 应答（避免与钩子重复）；via_hook=False 时 reader 走 clean stdin。
+                "plan_review_via_hook": plan_review_active and not unified and via_hook,
                 "plan_review_model": settings.routine.plan_review_model,
                 "plan_review_timeout": settings.routine.plan_review_timeout_seconds,
                 "reflections": (
@@ -1516,11 +1520,9 @@ class RoutineOrchestrator:
         # 统一闭环：构建迭代内独立 plan 段（permission_mode=plan + 真实评审钩子），**仅 fresh（无续接会话）**触发；
         # 续接迭代沿用单段 implement（方案已批准、会话续接，无需重评审）。上下文耗尽清空会话后下轮会重新 plan。
         if unified and plan_review_active and not routine.claude_session_id:
-            # per-routine 评审通道：plan_review_via_hook=True（默认）→ PreToolUse deny 钩子回灌评审
-            # （deny→is_error）；=False（如巡检）→ 不挂钩子，reader 内 _plan_review_answer 经
-            # stdin 写干净 tool_result（approve/refine），CC↔Engine 正常交流、恰当时 Approve。
-            # 后者经实测 auto_answer 路径（DB 中 19 例 ExitPlanMode 应答）证明 stdin 通道可用。
-            via_hook = bool((routine.config or {}).get("plan_review_via_hook", True))
+            # per-routine 评审通道（沿用上文 via_hook，默认 False=clean stdin）：=True 才挂 PreToolUse deny 钩子
+            # （deny→is_error）；=False → reader 内 _plan_review_answer 经 stdin 写干净 tool_result（approve/refine），
+            # CC↔Engine 正常交流、恰当时 Approve。后者经实测 auto_answer 路径（DB 中 19 例 ExitPlanMode 应答）证明可用。
             plan_settings_obj: dict = json.loads(_build_readonly_settings(read_dirs)) if read_dirs else {}
             plan_ctx_path = _write_plan_review_ctx(routine, iteration_id, mode="unified")
             plan_pre = plan_settings_obj.setdefault("hooks", {}).setdefault("PreToolUse", [])

--- a/apps/negentropy/src/negentropy/engine/routine/workspace.py
+++ b/apps/negentropy/src/negentropy/engine/routine/workspace.py
@@ -337,6 +337,20 @@ async def ensure_worktree(routine: _RoutineLike, settings: RoutineSettings) -> W
         if routine.worktree_path and routine.work_branch:
             if await _is_valid_worktree(routine.worktree_path, routine.work_branch, timeout):
                 return WorkspaceInfo(routine.worktree_path, routine.work_branch)
+            # CC 可能在 worktree 内漂移 HEAD（git switch/checkout 偏离 work_branch）。此时目录仍是
+            # 有效 git worktree——re-anchor：把 HEAD 切回 work_branch，**不重建目录**（Engine「巡检 +
+            # 保持」单一 workspace）。仅当目录缺失/非 git worktree 才回落重建。
+            if await _is_git_worktree(routine.worktree_path, timeout):
+                logger.warning(
+                    "routine_worktree_head_drifted",
+                    routine_id=str(routine.id),
+                    path=routine.worktree_path,
+                    expected=routine.work_branch,
+                    actual=await _get_head_branch(routine.worktree_path, timeout),
+                )
+                if await _reanchor_head(routine.worktree_path, routine.work_branch, timeout):
+                    return WorkspaceInfo(routine.worktree_path, routine.work_branch)
+                # re-anchor 失败（极少：work_branch ref 丢失等）→ 回落既有重建兜底。
             logger.warning(
                 "routine_worktree_stale_recreate",
                 routine_id=str(routine.id),
@@ -398,6 +412,69 @@ async def _is_valid_worktree(path: str, expected_branch: str, timeout: float) ->
         return False
     rc, out, _ = await _run_git(["-C", path, "rev-parse", "--abbrev-ref", "HEAD"], timeout=timeout)
     return rc == 0 and out.strip() == expected_branch
+
+
+async def _is_git_worktree(path: str, timeout: float) -> bool:
+    """路径是否为有效 git 工作树（不论 HEAD 当前在哪条分支 / 是否 detached）。
+
+    与 ``_is_valid_worktree`` 的区别：后者额外要求 HEAD 恰在 ``expected_branch``；本函数只判
+    「目录在 + 是 git 工作树」，用于区分「HEAD 漂移（可 re-anchor）」与「目录缺失/非 worktree（需重建）」。
+    """
+    if not os.path.isdir(path):
+        return False
+    rc, out, _ = await _run_git(["-C", path, "rev-parse", "--is-inside-work-tree"], timeout=timeout)
+    return rc == 0 and out.strip() == "true"
+
+
+async def _get_head_branch(path: str, timeout: float) -> str | None:
+    """当前 HEAD 的符号引用分支名；detached HEAD（输出 ``HEAD``）或查询失败 → None。"""
+    rc, out, _ = await _run_git(["-C", path, "rev-parse", "--abbrev-ref", "HEAD"], timeout=timeout)
+    if rc != 0:
+        return None
+    name = out.strip()
+    if not name or name == "HEAD":
+        return None
+    return name
+
+
+async def _reanchor_head(worktree_path: str, work_branch: str, timeout: float) -> bool:
+    """把漂移的 worktree HEAD 切回 ``work_branch``（re-anchor，**不重建目录**）。
+
+    纯 workspace 机制：CC 在 worktree 内 ``git switch``/``checkout`` 偏离 work_branch 时，由 Engine
+    在下轮派发前把 HEAD 切回，维系「一个 Routine 终生单一工作分支 + 单一 worktree」不变量。
+
+    - 干净切换优先；脏工作树致 ``git switch`` 拒绝时，``stash push → switch → stash pop`` 兜底。
+    - best-effort：任一步失败返回 False，调用方回落 ``stale_recreate`` 重建。偏离分支上的提交留在其
+      分支 ref 不丢；work_branch 上的提交保留。
+    """
+    rc, _, err = await _run_git(["-C", worktree_path, "switch", work_branch], timeout=timeout)
+    if rc == 0:
+        logger.info("routine_worktree_reanchored", path=worktree_path, branch=work_branch)
+        return True
+    # 切换失败——仅当工作树确有未提交改动时尝试 stash 兜底（否则多为 work_branch ref 丢失，stash 无益）。
+    rc_st, status_out, _ = await _run_git(["-C", worktree_path, "status", "--porcelain"], timeout=timeout)
+    if rc_st == 0 and status_out.strip():
+        await _run_git(["-C", worktree_path, "stash", "push", "-m", "negentropy-reanchor"], timeout=timeout)
+        rc2, _, err2 = await _run_git(["-C", worktree_path, "switch", work_branch], timeout=timeout)
+        if rc2 == 0:
+            # stash pop best-effort：冲突时留 stash 供人工处理，不阻断 re-anchor 成局。
+            await _run_git(["-C", worktree_path, "stash", "pop"], timeout=timeout)
+            logger.info("routine_worktree_reanchored_with_stash", path=worktree_path, branch=work_branch)
+            return True
+        logger.warning(
+            "routine_worktree_reanchor_failed_after_stash",
+            path=worktree_path,
+            branch=work_branch,
+            detail=(err2 or "")[:200],
+        )
+        return False
+    logger.warning(
+        "routine_worktree_reanchor_failed",
+        path=worktree_path,
+        branch=work_branch,
+        detail=(err or "")[:200],
+    )
+    return False
 
 
 async def _local_branch_exists(project_path: str, branch: str, timeout: float) -> bool:

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -978,7 +978,8 @@ async def test_build_config_kb_mcp_absent_when_unavailable(monkeypatch):
 
 async def test_build_config_unified_attaches_plan_stage(tmp_path, monkeypatch):
     """统一闭环（默认开）+ flat worktree + fresh：主 config=implement 段(acceptEdits、无评审钩子)，
-    挂载独立 plan 段(permission_mode=plan + ExitPlanMode/AskUserQuestion 真实评审钩子 + plan prompt)。"""
+    挂载独立 plan 段(permission_mode=plan)。默认 plan_review_via_hook=False → 走 clean stdin（reader
+    内 _plan_review_answer），plan 段不挂 PreToolUse deny 钩子（无 deny→is_error）。"""
     import json as _json
 
     from negentropy.engine.routine import orchestrator as orch_mod
@@ -996,21 +997,50 @@ async def test_build_config_unified_attaches_plan_stage(tmp_path, monkeypatch):
             main_settings = _json.loads(config.settings) if config.settings else {}
             assert not main_settings.get("hooks"), "主(implement)config 不应挂评审钩子——评审在 plan 段"
             assert config.auto_answer_context["plan_review_via_hook"] is False
-            # plan 段：permission_mode=plan、无续接、双工具真实评审钩子、plan prompt
+            # plan 段：permission_mode=plan、无续接、plan prompt
             ps = config.plan_stage_config
             assert ps is not None and ps.permission_mode == "plan"
             assert ps.resume_session_id is None
             assert ps.plan_stage_config is None  # 防自嵌套
+            # 默认 clean stdin（via_hook=False）：plan 段不挂 PreToolUse deny 钩子
+            ps_settings = _json.loads(ps.settings) if ps.settings else {}
+            assert (ps_settings.get("hooks") or {}).get("PreToolUse", []) == []
+            assert ps.auto_answer_context["plan_review_via_hook"] is False
+            assert config.plan_stage_prompt and "提交" in config.plan_stage_prompt
+            # ctx 文件 mode=unified、按 iteration_id 键
+            ctx = _json.loads((tmp_path / "negentropy-pr-ctx" / f"{iid}.json").read_text(encoding="utf-8"))
+            assert ctx["mode"] == "unified" and ctx["iteration_id"] == str(iid)
+    finally:
+        await _cleanup(rid)
+
+
+async def test_build_config_unified_plan_stage_via_hook_opt_in(tmp_path, monkeypatch):
+    """opt-in：per-routine config plan_review_via_hook=True → plan 段挂 PreToolUse deny 钩子
+    （AskUserQuestion + ExitPlanMode，unified 下 ExitPlanMode 跑真实评审用 full timeout）。"""
+    import json as _json
+
+    from negentropy.engine.routine import orchestrator as orch_mod
+
+    monkeypatch.setattr(orch_mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    rid = await _make_routine(
+        baseline_branch="origin/feature/1.x.x",
+        cwd="/repo",
+        current_phase="implement",
+        config={"plan_review_via_hook": True},
+    )
+    try:
+        orch = RoutineOrchestrator()
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            config = await orch._build_config(r, uuid.uuid4())
+            ps = config.plan_stage_config
+            assert ps is not None and ps.permission_mode == "plan"
             pre = _json.loads(ps.settings)["hooks"]["PreToolUse"]
             matchers = {h["matcher"]: h["hooks"][0]["timeout"] for h in pre}
             assert "AskUserQuestion" in matchers and "ExitPlanMode" in matchers
             # unified：ExitPlanMode 亦跑真实评审 → 与 AskUserQuestion 同 full timeout（非 legacy 的 15）
             assert matchers["ExitPlanMode"] == matchers["AskUserQuestion"] > 15
             assert ps.auto_answer_context["plan_review_via_hook"] is True
-            assert config.plan_stage_prompt and "提交" in config.plan_stage_prompt
-            # ctx 文件 mode=unified、按 iteration_id 键
-            ctx = _json.loads((tmp_path / "negentropy-pr-ctx" / f"{iid}.json").read_text(encoding="utf-8"))
-            assert ctx["mode"] == "unified" and ctx["iteration_id"] == str(iid)
     finally:
         await _cleanup(rid)
 

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -64,8 +64,8 @@ async def test_create_and_start_patrol_routine_persists_real_row(db_engine):
         assert row.baseline_branch == "origin/feature/1.x.x"
         assert row.no_progress_patience == 3  # per-Routine 默认（非 settings）—— 回归点
         assert row.success_score_threshold == 100
-        assert row.max_iterations == 8  # settings.routine.patrol_max_iterations_per_doc
-        assert row.max_cost_usd == 30.0  # patrol 专属预算（非全局 default_max_cost_usd=5）
+        assert row.max_iterations == 400  # settings.routine.patrol_max_iterations_per_doc（×50：原 8）
+        assert row.max_cost_usd == 1500.0  # patrol 专属预算（×50：原 30；非全局 default_max_cost_usd=5）
         assert row.owner_id == "system"
         assert row.is_template is False
         assert row.key.startswith("pdf-fidelity-patrol/")

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_workspace.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_workspace.py
@@ -175,6 +175,61 @@ async def test_ensure_worktree_creates_then_reuses(tmp_path):
     assert (info2.path, info2.branch) == (info.path, info.branch)
 
 
+async def test_ensure_worktree_reanchors_when_head_drifted(tmp_path):
+    """CC 在 worktree 内 ``git switch`` 漂离 work_branch → 下轮 ensure_worktree re-anchor 切回，
+    **不移除/不重建目录**（未跟踪 marker 文件保留，证明非 stale_recreate）。维系单一 workspace。"""
+    repo = _make_git_repo(tmp_path / "repo")
+    s = _settings(str(tmp_path / "wt"))
+    r = _routine(repo)
+    info = await ws.ensure_worktree(r, s)
+    r.worktree_path, r.work_branch = info.path, info.branch
+
+    # 在 worktree 内留未跟踪 marker：re-anchor 保留；stale_recreate（remove+re-add）会丢。
+    marker = Path(info.path) / "marker.txt"
+    marker.write_text("persist")
+    # CC 漂移：切到一条新分支
+    subprocess.run(["git", "-C", info.path, "checkout", "-b", "stray"], check=True, capture_output=True)
+    assert _head_branch(info.path) == "stray"
+
+    info2 = await ws.ensure_worktree(r, s)
+    assert (info2.path, info2.branch) == (info.path, info.branch)  # 同一 workspace
+    assert _head_branch(info.path) == info.branch  # HEAD 已 re-anchor 回 work_branch
+    assert marker.exists() and marker.read_text() == "persist"  # 目录未重建
+
+
+async def test_ensure_worktree_reanchors_detached_head(tmp_path):
+    """CC 漂移到 detached HEAD（``git checkout --detach``）→ re-anchor 切回 work_branch。"""
+    repo = _make_git_repo(tmp_path / "repo")
+    s = _settings(str(tmp_path / "wt"))
+    r = _routine(repo)
+    info = await ws.ensure_worktree(r, s)
+    r.worktree_path, r.work_branch = info.path, info.branch
+
+    subprocess.run(["git", "-C", info.path, "checkout", "--detach"], check=True, capture_output=True)
+    assert _head_branch(info.path) == "HEAD"  # detached
+
+    info2 = await ws.ensure_worktree(r, s)
+    assert (info2.path, info2.branch) == (info.path, info.branch)
+    assert _head_branch(info.path) == info.branch
+
+
+async def test_ensure_worktree_reanchors_with_dirty_worktree(tmp_path):
+    """漂移 + 脏工作树 → re-anchor 兜底切回 work_branch（clean-carry 或 stash），工作树改动不阻断。"""
+    repo = _make_git_repo(tmp_path / "repo")
+    s = _settings(str(tmp_path / "wt"))
+    r = _routine(repo)
+    info = await ws.ensure_worktree(r, s)
+    r.worktree_path, r.work_branch = info.path, info.branch
+
+    # 脏工作树（改已跟踪文件）+ 漂移到新分支
+    (Path(info.path) / "README.md").write_text("# changed")
+    subprocess.run(["git", "-C", info.path, "checkout", "-b", "stray"], check=True, capture_output=True)
+
+    info2 = await ws.ensure_worktree(r, s)
+    assert (info2.path, info2.branch) == (info.path, info.branch)
+    assert _head_branch(info.path) == info.branch  # 无论 clean-carry 还是 stash，HEAD 已回 work_branch
+
+
 async def test_remove_worktree_idempotent(tmp_path):
     import os
 


### PR DESCRIPTION
## 背景

PDF Fidelity Patrol 等 Routine 难以收敛，根因有三，本 PR 一并解决：

1. **CC 漂移致 worktree 重建丢进度**：引擎本就按设计 pin「一个 Routine 单 worktree + 单 branch」，但 CC 在 worktree 内 `git switch`/`checkout` 漂移 HEAD 后，`ensure_worktree` 的 `_is_valid_worktree` 失败 → `stale_recreate` 强制移除并重建 worktree 目录（churn + 丢失偏离提交）→ 不收敛。
2. **Plan 审批 deny→is_error**：`plan_review_via_hook` 默认 `True`（PreToolUse deny 钩子），headless 下 `deny→is_error` 致 UI 报错/交互中断；仅巡检已切 `False`（clean stdin）走通。
3. **巡检预算过小**：8 轮 / \$30 触顶即终止，重自治任务来不及收敛。

## 改动一：Workspace re-anchor 机制（引擎级，非权限禁用）

`workspace.py::ensure_worktree` 复用守卫拆三分支：① 有效 worktree 直接复用；② 目录在且是 git worktree 但 HEAD≠work_branch（CC 漂移）→ **re-anchor**（`git switch` 切回，脏工作树 stash 兜底），**不移动除/不重建目录**；③ 目录缺失/非 worktree → 既有 stale_recreate 重建兜底。

Engine「巡检 + 保持」单一 workspace：发现 CC 漂移即主动拉回 work_branch，避免重建丢进度。新增 `_is_git_worktree` / `_get_head_branch` / `_reanchor_head`。**不做任何 permissions.deny**（遵循「非权限约束，是 workspace 机制约束」）。

## 改动二：Plan 审批统一走 clean stdin（所有 Routine 无 error）

`orchestrator.py`：`plan_review_via_hook` 默认 `True→False`——所有 Routine 默认经 reader 内 `_plan_review_answer` 以 stdin 写干净 tool_result（CC 出 Plan → NegentropyEngine Review → 经 AskUserQuestion 交互答复 Approve → 续接 Implement），无 deny→is_error、不中断；deny 钩子降级为 opt-in。legacy 评审路径同步门控；订正陈旧注释。统一闭环 plan 段对所有 worktree Routine 默认启用；交互与结果经既有 `plan_review` 事件组呈现到 Iteration Full View。

## 改动三：巡检预算 ×50

`patrol_max_iterations_per_doc` 8→400（`le` 上限 50→500）、`patrol_max_cost_usd_per_doc` \$30→\$1500；`config.default.yaml` 与单测同步。

## 验证

- **Workspace re-anchor 单测**（新增 3 例 + 既有 22 例全过）：HEAD 漂移→re-anchor 不重建（marker 保留）；detached HEAD→切回；脏工作树→兜底切回；非 git 目录→回落 teardown。
- **Plan 审批单测**：149 项单元 + 6 项 PG 集成全过（更新 unified plan-stage 默认 clean stdin 断言；新增 via_hook=True opt-in 用例锁定 deny 钩子路径；clean stdin ExitPlanMode/AskUserQuestion 应答无 is_error）。
- **巡检预算**：集成测试断言 400 / \$1500 通过。
- 全分支 115 项测试通过；pre-commit ruff lint + format 通过。

## 交付

三个逻辑提交：`fix(Routine): workspace re-anchor` / `fix(Routine): Plan 审批默认走 clean stdin` / `fix(Patrol): 单文档巡检预算 ×50`。

## 风险与边界

- re-anchor 仅在派发间（不与运行中迭代并发）；脏工作树 stash 冲突等极端情况回落既有 stale_recreate（不引入新失败态）。
- ×50 预算（400 轮 / \$1500）为实验值；`le` 抬到 500 留余量。
- 非 worktree Routine 的 plan 段 cwd/事件细节以「用户 Routine 均 worktree、已全覆盖」为底线，非 worktree 后续演进。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
