### PR TITLE
fix(Wiki): 归属文档列表纵向自适应占满、发布条目悬浮底部抽屉化、顶部编辑区精修

### DIFF
--- a/apps/negentropy-ui/app/knowledge/wiki/_components/LibraryShell.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/LibraryShell.tsx
@@ -174,7 +174,7 @@ export function LibraryShell() {
         />
 
         <main className="flex-1 min-w-0 rounded-2xl border border-border bg-card shadow-sm overflow-hidden flex flex-col">
-          <div className="flex-1 min-h-0 overflow-auto">
+          <div className="flex min-h-0 flex-1 flex-col">
             <NodeDetailPanel
               node={treeApi.selectedNode}
               catalogId={catalogId ?? ""}

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesList.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesList.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { WikiNavTreeItem } from "@/features/knowledge";
+import { Folder, FileText } from "./catalog/icons";
 
 interface WikiEntriesListProps {
   navTree: WikiNavTreeItem[];
@@ -69,16 +70,18 @@ export function WikiEntriesList({
   }
 
   return (
-    <div className="rounded-lg border border-border bg-background divide-y divide-border max-h-[420px] overflow-y-auto">
+    <div className="rounded-lg border border-border bg-background divide-y divide-border">
       {flat.map((item) => (
         <div
           key={item.key}
           className="flex items-center gap-2 px-3 py-1.5 text-sm"
           style={{ paddingLeft: `${item.depth * 16 + 12}px` }}
         >
-          <span className="text-muted-foreground text-xs">
-            {item.isContainer ? "📁" : "📄"}
-          </span>
+          {item.isContainer ? (
+            <Folder className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+          ) : (
+            <FileText className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+          )}
           <span
             className={`truncate ${
               item.isContainer

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesPreview.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/WikiEntriesPreview.tsx
@@ -13,6 +13,7 @@ import {
   type WikiPublication,
 } from "@/features/knowledge";
 import { toast } from "@/lib/activity-toast";
+import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { WikiEntriesList } from "./WikiEntriesList";
 
 interface WikiEntriesPreviewProps {
@@ -75,35 +76,44 @@ export const WikiEntriesPreview = forwardRef<
   const entryCount = publication.entries_count;
 
   return (
-    <div className="border-t border-border bg-card/40">
-      <div className="flex items-center justify-between px-5 py-2.5">
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="flex items-center gap-2 text-sm hover:opacity-80 transition-opacity"
-          aria-expanded={open}
-          aria-controls="wiki-entries-preview-body"
-        >
-          <span className="text-xs text-muted-foreground">{open ? "▾" : "▸"}</span>
-          <span className="font-medium">该发布包含 {entryCount} 个条目</span>
-          <span className="text-xs text-muted-foreground">（展开查看导航结构）</span>
-        </button>
-        {open && (
+    <>
+      <div className="border-t border-border bg-card/40">
+        <div className="flex items-center px-5 py-2.5">
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="flex items-center gap-2 text-sm transition-opacity hover:opacity-80"
+            aria-expanded={open}
+            aria-haspopup="dialog"
+          >
+            <span className="font-medium text-foreground">
+              该发布包含 {entryCount} 个条目
+            </span>
+            <span className="text-xs text-text-muted">（点击查看导航结构）</span>
+          </button>
+        </div>
+      </div>
+      <BaseDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        side="bottom"
+        title="导航结构"
+        subtitle={`该发布包含 ${entryCount} 个条目`}
+        headerActions={
           <button
             type="button"
             onClick={() => void loadNavTree()}
             disabled={loading}
-            className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+            className="text-xs text-text-muted transition-colors hover:text-foreground disabled:opacity-50"
           >
             刷新
           </button>
-        )}
-      </div>
-      {open && (
-        <div id="wiki-entries-preview-body" className="px-5 pb-4">
+        }
+      >
+        <div className="p-5">
           <WikiEntriesList navTree={navTree} loading={loading} />
         </div>
-      )}
-    </div>
+      </BaseDrawer>
+    </>
   );
 });

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx
@@ -14,6 +14,7 @@ import {
   type KnowledgeDocument,
 } from "@/features/knowledge";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+import { Button } from "@/components/ui/Button";
 import { toast } from "@/lib/activity-toast";
 import { Plus, Trash2, Pencil, Check, X } from "./icons";
 import { AddDocumentsDialog } from "./AddDocumentsDialog";
@@ -108,19 +109,20 @@ export function DocumentAssignmentSection({
   });
 
   return (
-    <div className="px-5 py-4 border-t border-border">
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+    <div className="flex min-h-0 flex-1 flex-col border-t border-border px-5 py-4">
+      <div className="mb-3 flex shrink-0 items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           归属文档 ({docs.length})
         </h3>
-        <button
+        <Button
+          variant="outline"
+          size="sm"
+          leftIcon={<Plus className="h-3 w-3" />}
           onClick={() => setAdding(true)}
           disabled={!catalogId}
-          className="flex items-center gap-1 px-2 py-1 text-xs rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          <Plus className="h-3 w-3" />
           添加文档
-        </button>
+        </Button>
       </div>
 
       {loading ? (
@@ -128,7 +130,7 @@ export function DocumentAssignmentSection({
       ) : docs.length === 0 ? (
         <p className="text-xs text-muted-foreground/60 italic">暂无归属文档</p>
       ) : (
-        <ul className="space-y-1 max-h-[280px] overflow-y-auto">
+        <ul className="space-y-1 min-h-0 flex-1 overflow-y-auto">
           {docs.map((doc) => {
             const isEditing = editingId === doc.id;
             const effectiveName = effectiveDisplayName(doc);
@@ -158,7 +160,7 @@ export function DocumentAssignmentSection({
                         onClick={() => void commitEdit(doc)}
                         disabled={saving}
                         title="保存"
-                        className="p-0.5 rounded text-muted-foreground hover:text-green-600 disabled:opacity-50"
+                        className="rounded p-0.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
                       >
                         <Check className="h-3.5 w-3.5" />
                       </button>
@@ -166,7 +168,7 @@ export function DocumentAssignmentSection({
                         onClick={cancelEdit}
                         disabled={saving}
                         title="取消"
-                        className="p-0.5 rounded text-muted-foreground hover:text-red-500 disabled:opacity-50"
+                        className="rounded p-0.5 text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
                       >
                         <X className="h-3.5 w-3.5" />
                       </button>
@@ -193,14 +195,14 @@ export function DocumentAssignmentSection({
                     <button
                       onClick={() => startEdit(doc)}
                       title="编辑 Wiki 显示名称"
-                      className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 rounded text-muted-foreground hover:text-blue-600 hover:bg-blue-50 transition-opacity"
+                      className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus:opacity-100 group-hover:opacity-100"
                     >
                       <Pencil className="h-3 w-3" />
                     </button>
                     <button
                       onClick={() => handleRemove(doc.id, doc.original_filename)}
                       title="从节点移除"
-                      className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 rounded text-muted-foreground hover:text-red-600 hover:bg-red-50 transition-opacity"
+                      className="rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus:opacity-100 group-hover:opacity-100"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/NodeDetailPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/NodeDetailPanel.tsx
@@ -7,6 +7,7 @@ import {
   deleteCatalogNode,
 } from "@/features/knowledge";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+import { Button } from "@/components/ui/Button";
 import { toast } from "@/lib/activity-toast";
 import { Pencil, Trash2 } from "./icons";
 import { DocumentAssignmentSection } from "./DocumentAssignmentSection";
@@ -33,7 +34,7 @@ export function NodeDetailPanel({
 
   if (!node) {
     return (
-      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      <div className="flex flex-1 items-center justify-center text-sm text-text-muted">
         选择一个节点查看详情
       </div>
     );
@@ -69,86 +70,95 @@ export function NodeDetailPanel({
 
   return (
     <>
-      <div className="flex flex-col h-full overflow-y-auto">
+      <div className="flex h-full min-h-0 flex-1 flex-col">
       {/* Header */}
-      <div className="border-b border-border px-5 py-4">
-        <div className="flex items-start justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">
+      <div className="shrink-0 border-b border-border px-5 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-lg font-semibold tracking-heading text-foreground">
               {node.name}
             </h2>
-            <p className="text-xs text-muted-foreground mt-0.5">
+            <p
+              className="mt-0.5 truncate text-xs text-text-muted"
+              title={`${node.node_type} · slug: ${node.slug}${node.depth != null ? ` · 深度: ${node.depth}` : ""}`}
+            >
               {node.node_type} · slug: {node.slug}
               {node.depth != null && ` · 深度: ${node.depth}`}
             </p>
           </div>
-          <div className="flex gap-1">
-            <button
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
               onClick={() => {
                 setDescValue(node.description ?? "");
                 setEditingDesc(true);
               }}
-              className="p-1.5 rounded text-muted-foreground hover:text-blue-600 hover:bg-blue-50 transition-colors"
+              aria-label="编辑描述"
               title="编辑描述"
             >
               <Pencil className="h-4 w-4" />
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              iconOnly
               onClick={handleDelete}
-              className="p-1.5 rounded text-muted-foreground hover:text-red-600 hover:bg-red-50 transition-colors"
+              aria-label="删除节点"
               title="删除节点"
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
             >
               <Trash2 className="h-4 w-4" />
-            </button>
+            </Button>
           </div>
         </div>
       </div>
 
       {/* Description editor */}
-      <div className="px-5 py-4 border-b border-border">
+      <div className="shrink-0 border-b border-border px-5 py-3">
         {editingDesc ? (
           <div className="space-y-2">
             <textarea
               value={descValue}
               onChange={(e) => setDescValue(e.target.value)}
-              placeholder="输入节点描述..."
-              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground min-h-[80px] resize-y focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="为这个节点写一句描述…"
+              className="w-full min-h-[80px] resize-y rounded-control border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               autoFocus
             />
             <div className="flex justify-end gap-2">
-              <button
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => {
                   setEditingDesc(false);
                   setDescValue("");
                 }}
-                className="px-3 py-1 text-xs rounded-md border border-border text-muted-foreground hover:bg-muted"
               >
                 取消
-              </button>
-              <button
-                onClick={handleSaveDesc}
-                className="px-3 py-1 text-xs rounded-md bg-primary text-primary-foreground hover:opacity-90"
-              >
+              </Button>
+              <Button variant="primary" size="sm" onClick={handleSaveDesc}>
                 保存
-              </button>
+              </Button>
             </div>
           </div>
         ) : (
           <div>
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
+            <p className="mb-1 text-xs font-medium uppercase tracking-wider text-text-muted">
               描述
             </p>
             {node.description ? (
-              <p className="text-sm text-foreground/80">{node.description}</p>
+              <p className="text-sm leading-relaxed text-text-secondary">{node.description}</p>
             ) : (
               <button
+                type="button"
                 onClick={() => {
                   setDescValue(node.description ?? "");
                   setEditingDesc(true);
                 }}
-                className="text-sm text-muted-foreground/60 italic hover:text-muted-foreground"
+                className="text-sm italic text-text-muted transition-colors hover:text-foreground"
               >
-                点击添加描述...
+                点击添加描述…
               </button>
             )}
           </div>
@@ -156,9 +166,9 @@ export function NodeDetailPanel({
       </div>
 
       {/* Metadata info */}
-      <div className="px-5 py-4 space-y-3 text-xs">
-        <div className="flex justify-between items-center">
-          <span className="text-muted-foreground">ID</span>
+      <div className="grid shrink-0 grid-cols-2 gap-x-4 gap-y-1.5 px-5 py-3 text-xs">
+        <div className="col-span-2 flex items-center justify-between gap-2">
+          <span className="text-text-muted">ID</span>
           <button
             type="button"
             onClick={async () => {
@@ -169,7 +179,7 @@ export function NodeDetailPanel({
                 toast.error("复制失败");
               }
             }}
-            className="font-mono text-foreground/60 hover:text-foreground transition-colors cursor-pointer flex items-center gap-1"
+            className="flex cursor-pointer items-center gap-1 font-mono text-text-muted transition-colors hover:text-foreground"
             title="点击复制完整 ID"
           >
             <span className="text-[11px]">{node.id}</span>
@@ -178,9 +188,9 @@ export function NodeDetailPanel({
             </svg>
           </button>
         </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">父节点</span>
-          <span className="text-foreground/80">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-text-muted">父节点</span>
+          <span className="truncate text-foreground">
             {node.parent_id
               ? (() => {
                   const parent = nodes.find((n) => n.id === node.parent_id);
@@ -189,9 +199,9 @@ export function NodeDetailPanel({
               : "（根节点）"}
           </span>
         </div>
-        <div className="flex justify-between">
-          <span className="text-muted-foreground">排序</span>
-          <span className="text-foreground/80">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-text-muted">排序</span>
+          <span className="text-foreground">
             {(() => {
               const siblings = nodes
                 .filter((n) => n.parent_id === node.parent_id)

--- a/apps/negentropy-ui/components/ui/BaseDrawer.tsx
+++ b/apps/negentropy-ui/components/ui/BaseDrawer.tsx
@@ -28,8 +28,8 @@ export interface BaseDrawerProps {
   /** 标题栏右侧、关闭按钮左侧的额外操作区（如 "Full View" 链接）。 */
   headerActions?: ReactNode;
   footer?: ReactNode;
-  /** 滑出方向。默认 right。 */
-  side?: "right" | "left";
+  /** 滑出方向。默认 right。bottom 为底部抽屉（模态底部 sheet，高度上限 70vh、顶部圆角）。 */
+  side?: "right" | "left" | "bottom";
   /** 面板宽度类。默认 [width:clamp(480px,66.67%,1100px)]（最小 480px / 理想视口 2/3 / 最大 1100px）。 */
   widthClassName?: string;
   closeOnBackdrop?: boolean;
@@ -68,6 +68,16 @@ export function BaseDrawer({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, closeOnEscape, onClose]);
 
+  const isBottom = side === "bottom";
+  // bottom 抽屉按高度收敛（顶部圆角 + max-h-70vh + 居中限宽），不复用水平向的 widthClassName
+  const panelClassName = isBottom
+    ? "relative flex flex-col bg-card shadow-xl outline-none max-h-[70vh] w-full max-w-5xl border-t border-border rounded-t-2xl"
+    : cn(
+        "relative flex h-full flex-col bg-card shadow-xl outline-none",
+        side === "right" ? "border-l border-border" : "border-r border-border",
+        widthClassName,
+      );
+
   if (typeof document === "undefined") return null;
 
   return createPortal(
@@ -76,7 +86,11 @@ export function BaseDrawer({
         <div
           className={cn(
             "fixed inset-0 z-[45] flex",
-            side === "right" ? "justify-end" : "justify-start",
+            isBottom
+              ? "items-end justify-center"
+              : side === "right"
+                ? "justify-end"
+                : "justify-start",
           )}
         >
           <motion.div
@@ -94,16 +108,10 @@ export function BaseDrawer({
             aria-modal="true"
             aria-labelledby={title ? titleId : undefined}
             tabIndex={-1}
-            className={cn(
-              "relative flex h-full flex-col bg-card shadow-xl outline-none",
-              side === "right"
-                ? "border-l border-border"
-                : "border-r border-border",
-              widthClassName,
-            )}
-            initial={{ x: side === "right" ? "100%" : "-100%" }}
-            animate={{ x: 0 }}
-            exit={{ x: side === "right" ? "100%" : "-100%" }}
+            className={panelClassName}
+            initial={isBottom ? { y: "100%" } : { x: side === "right" ? "100%" : "-100%" }}
+            animate={isBottom ? { y: 0 } : { x: 0 }}
+            exit={isBottom ? { y: "100%" } : { x: side === "right" ? "100%" : "-100%" }}
             transition={SPRING_TRANSITION}
           >
             {(title || showClose) && (


### PR DESCRIPTION
## 背景

Wiki 编辑页右侧详情面板存在三个相互关联的布局/体验问题：

1. **归属文档列表「假滚动 + 底部留白」**：\`<ul>\` 被 \`max-h-[280px]\` 硬封顶，面板下方仍有空白时即在 280px 处提前出现滚动条，未纵向占满。
2. **「该发布包含 N 个条目」展开挤占上方列表**：展开体走普通文档流内联渲染，向下挤压上方归属文档列表，而非悬浮覆盖。
3. **顶部编辑区冗余且偏离设计系统**：三段 \`py-4\` 堆叠、元信息 3 行竖排、大量原生 \`<button>\` + 硬编码调色板色（深色模式失真、缺 focus ring、绕开 token 与 \`<Button>\` 原语）。

## 改动

### 1. 归属文档列表纵向自适应（flex 高度链重建）
- 去掉 \`<ul>\` 的 \`max-h-[280px]\` 封顶；去掉 \`LibraryShell\` wrapper 与 \`NodeDetailPanel\` root 的双重 \`overflow\`（冗余双滚动）。
- 重建 flex 高度链：chrome（Header/描述/元信息/段头）\`shrink-0\` 固定，归属文档列表 \`flex-1 min-h-0 overflow-y-auto\` 弹性占满 —— 列表纵向占满、仅真正溢出时滚动、底部不再留白。

### 2. 「该发布包含 N 个条目」改为悬浮底部抽屉
- 复用并扩展通用抽屉原语 \`BaseDrawer\`，**新增 \`side=\"bottom\"\`**（模态底部 sheet：portal + 遮罩 + 焦点陷阱 + Escape + 弹性滑入，z-[45]；**非破坏性扩展**，现有 right/left 调用方零影响）。
- \`WikiEntriesPreview\` 触发条保留为面板底部定高内联条；展开体由内联改为 \`<BaseDrawer side=\"bottom\">\` 悬浮覆盖，不再挤占上方列表。懒加载与发布后命令式刷新契约不变。
- 导航树 \`📁/📄\` emoji → Lucide \`Folder\`/\`FileText\` 图标，统一 icon 语言。

### 3. 顶部编辑区精修
- Header \`py-4 → py-3\`、副标题单行 \`truncate + title\`；元信息 3 行竖排 → 2 列网格（ID 单行 + 父节点/排序两列），回收纵向空间。
- 原生 \`<button>\` → \`<Button>\` 原语（编辑/删除 ghost iconOnly、取消 outline、保存 primary、添加文档 outline+leftIcon），自带 focus-visible ring / disabled / scale。
- 清除全部硬编码调色板色（\`blue-50\`/\`red-50\`/\`green-600\` 等）→ 设计 token（\`--primary\`/\`--destructive\`/\`text-text-muted\`），修复深色模式失真。

## 文件
- \`components/ui/BaseDrawer.tsx\` — 新增 \`side=\"bottom\"\`
- \`app/knowledge/wiki/_components/LibraryShell.tsx\` — wrapper flex 高度链
- \`app/knowledge/wiki/_components/catalog/NodeDetailPanel.tsx\` — root flex + chrome shrink-0 + 顶部三段精修
- \`app/knowledge/wiki/_components/catalog/DocumentAssignmentSection.tsx\` — 外层 flex-1 + \`<ul>\` 去封顶 + 行内按钮 token
- \`app/knowledge/wiki/_components/WikiEntriesPreview.tsx\` — 内联展开 → 底部抽屉
- \`app/knowledge/wiki/_components/WikiEntriesList.tsx\` — 去 max-h + emoji → Lucide

## 验证
- ✅ \`tsc -p tsconfig.json --noEmit\` 通过
- ✅ \`eslint\`（含 pre-commit hook）通过，0 warning
- ✅ \`tests/unit/knowledge/wiki-nav-tree.test.tsx\` 5/5 通过（emoji→icon 与去 max-h 未破坏渲染契约）
- ⏳ 视觉/交互回归（列表占满、底部抽屉悬浮不挤压、深浅色、focus ring）建议在已认证环境合并前复核一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)