### PR TITLE
fix(Routine): 解除 Clean Up 同步 rmtree 阻塞事件循环与 DB 会话占用，致全站阻塞;

### DIFF
--- a/apps/negentropy/src/negentropy/config/__init__.py
+++ b/apps/negentropy/src/negentropy/config/__init__.py
@@ -209,6 +209,10 @@ class Settings(BaseSettings):
         return self.database.pool_recycle
 
     @property
+    def db_pool_timeout(self) -> int:
+        return self.database.pool_timeout
+
+    @property
     def db_echo(self) -> bool:
         return self.database.echo
 

--- a/apps/negentropy/src/negentropy/config/database.py
+++ b/apps/negentropy/src/negentropy/config/database.py
@@ -23,6 +23,7 @@ class DatabaseSettings(BaseSettings):
     pool_size: int = Field(default=5, description="Connection pool size")
     max_overflow: int = Field(default=10, description="Max overflow connections")
     pool_recycle: int = Field(default=3600, description="Pool recycle time in seconds")
+    pool_timeout: int = Field(default=10, description="Seconds to wait for a pooled connection before giving up")
     echo: bool = Field(default=False, description="Echo SQL statements")
 
     @classmethod

--- a/apps/negentropy/src/negentropy/db/session.py
+++ b/apps/negentropy/src/negentropy/db/session.py
@@ -8,6 +8,7 @@ engine = create_async_engine(
     pool_size=settings.db_pool_size,
     max_overflow=settings.db_max_overflow,
     pool_recycle=settings.db_pool_recycle,
+    pool_timeout=settings.db_pool_timeout,
     echo=settings.db_echo,
 )
 

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -32,7 +32,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
@@ -437,12 +437,15 @@ class RoutineOrchestrator:
 
         分支保留：仅 succeeded 删本地分支（PR 已在 origin，无碍）；failed/cancelled 一律
         ``keep_branch=True`` 保留本地分支与检查点提交，使其重启可从上一检查点续作（单一分支不变量）。
+
+        慢操作（git/rmtree）须在 DB 会话**外**逐个执行：会话仅做短查 + 批量短写，避免单个会话横跨
+        最多 ``_BATCH_LIMIT`` 个串行回收而长期占用连接池连接；rmtree 已卸载线程池，回收期不阻塞事件循环。
         """
         policy = settings.routine.worktree_cleanup
         if policy == "never":
             return 0
         statuses = ("succeeded",) if policy == "on_success" else ("succeeded", "failed", "cancelled")
-        cleaned = 0
+        # ① 短会话：拉取待清理 routine（expire_on_commit=False → detached 后属性可读）。
         async with db_session.AsyncSessionLocal() as db:
             rows = (
                 (
@@ -455,12 +458,16 @@ class RoutineOrchestrator:
                 .scalars()
                 .all()
             )
-            for r in rows:
-                with suppress(Exception):
-                    await workspace.remove_worktree(r, settings.routine, keep_branch=(r.status != "succeeded"))
-                r.worktree_path = None
-                cleaned += 1
-            await db.commit()
+        # ② 会话外：逐个 best-effort 回收（纯 git/FS、无 DB；不占连接、不阻塞事件循环）。
+        for r in rows:
+            with suppress(Exception):
+                await workspace.remove_worktree(r, settings.routine, keep_branch=(r.status != "succeeded"))
+        # ③ 短会话：批量置空 + 提交（保持「先回收、后置空」语义）。
+        if rows:
+            async with db_session.AsyncSessionLocal() as db:
+                await db.execute(update(Routine).where(Routine.id.in_([r.id for r in rows])).values(worktree_path=None))
+                await db.commit()
+        cleaned = len(rows)
         if cleaned:
             logger.info("routine_reaped_workspaces", count=cleaned, policy=policy)
         return cleaned

--- a/apps/negentropy/src/negentropy/engine/routine/workspace.py
+++ b/apps/negentropy/src/negentropy/engine/routine/workspace.py
@@ -373,8 +373,9 @@ async def ensure_worktree(routine: _RoutineLike, settings: RoutineSettings) -> W
         if os.path.isdir(worktree_path):
             await _run_git(["-C", project_path, "worktree", "remove", "--force", worktree_path], timeout=timeout)
             if os.path.isdir(worktree_path):
+                # 同 remove_worktree：同步 rmtree 须离事件循环，避免派发期阻塞全站其他请求。
                 with suppress(OSError):
-                    shutil.rmtree(worktree_path, ignore_errors=True)
+                    await asyncio.to_thread(shutil.rmtree, worktree_path, ignore_errors=True)
 
         if settings.git_fetch_before_worktree:
             await _try_fetch(project_path, baseline, settings)
@@ -580,8 +581,10 @@ async def remove_worktree(
                 await _run_git(["-C", project_path, "branch", "-D", routine.work_branch], timeout=timeout)
         # 兜底：若目录仍残留（worktree remove 失败或 project_path 已失效），直接删目录。
         if os.path.isdir(path):
+            # rmtree 是纯同步递归删除，对巨型 worktree（node_modules/.git/构建产物）可耗时数十秒；
+            # 必须卸载到线程池，否则会冻结单 uvicorn 事件循环、阻塞全站其他请求（同 graph_algorithms 范式）。
             with suppress(OSError):
-                shutil.rmtree(path, ignore_errors=True)
+                await asyncio.to_thread(shutil.rmtree, path, ignore_errors=True)
         logger.info("routine_worktree_removed", routine_id=str(routine.id), path=path)
     _LOCKS.pop(routine.id, None)
 

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -789,16 +789,23 @@ async def update_routine(routine_id: UUID, body: RoutineUpdateRequest) -> dict[s
 
 @router.delete("/{routine_id}")
 async def delete_routine(routine_id: UUID) -> dict[str, Any]:
+    # ① 短会话：校验 + 读取（detached 后属性可读，供会话外回收）。
     async with db_session.AsyncSessionLocal() as db:
         r = await db.get(Routine, routine_id)
         if r is None:
             raise HTTPException(status_code=404, detail="routine not found")
         if r.status in _ACTIVE:
             raise HTTPException(status_code=409, detail=f"cannot delete a {r.status} routine; cancel it first")
-        # 删除前回收隔离 worktree（行将消失，无论策略均须清，避免孤儿；best-effort）。
-        if r.worktree_path:
-            with suppress(Exception):
-                await workspace.remove_worktree(r, settings.routine)
+    # ② 会话外：删除前回收隔离 worktree（行将消失，无论策略均须清，避免孤儿；best-effort；不占连接、不阻塞事件循环）。
+    if r.worktree_path:
+        with suppress(Exception):
+            await workspace.remove_worktree(r, settings.routine)
+    # ③ 短会话：删行 + 提交（保持「先回收、后删行」语义；并发已删则视作幂等成功）。
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            _KPI_CACHE.invalidate()
+            return {"ok": True, "deleted_routine_id": str(routine_id)}
         try:
             await db.delete(r)
             await db.commit()
@@ -973,7 +980,11 @@ async def cleanup_worktree(routine_id: UUID) -> dict[str, Any]:
 
     终态 routine（succeeded/failed/cancelled）在 worktree 仍活跃时可用于手动触发磁盘回收，
     无需等待周期巡检器。``work_branch`` 保留供审计/PR 溯源。
+
+    慢操作（git/rmtree）须在 DB 会话**外**执行：会话仅做短读 + 短写，避免长时间占用连接池连接；
+    其本身亦不阻塞事件循环（``remove_worktree`` 内 rmtree 已卸载线程池），故清理期间全站其他请求不受影响。
     """
+    # ① 短会话：校验 + 读取（worktree_path 仍非空，供会话外清理）。
     async with db_session.AsyncSessionLocal() as db:
         r = await db.get(Routine, routine_id)
         if r is None:
@@ -988,9 +999,12 @@ async def cleanup_worktree(routine_id: UUID) -> dict[str, Any]:
             )
         if not r.worktree_path:
             raise HTTPException(status_code=409, detail="worktree already cleaned up or never created")
-        # best-effort 回收：异常仅日志，不阻断。
-        with suppress(Exception):
-            await workspace.remove_worktree(r, settings.routine)
+    # ② 会话外：best-effort 回收（expire_on_commit=False → r 已 detached 但属性可读；纯 git/FS，无 DB）。
+    with suppress(Exception):
+        await workspace.remove_worktree(r, settings.routine)
+    # ③ 短会话：置空 + 提交（保持「先回收、后置空」语义）。
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
         r.worktree_path = None
         await db.commit()
         await db.refresh(r)

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_workspace.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_workspace.py
@@ -6,9 +6,11 @@ ensure_worktree 创建 + 幂等复用；remove_worktree 幂等回收。
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
@@ -470,3 +472,68 @@ async def test_remove_worktree_default_deletes_local_branch(tmp_path):
     await ws.remove_worktree(r, s)
     assert not os.path.isdir(info.path)
     assert _local_branch_exists(repo, info.branch) is False  # 本地分支已删
+
+
+# ---------------------------------------------------------------------------
+# 事件循环非阻塞回归 —— rmtree 兜底须离事件循环（asyncio.to_thread），不冻结全站
+# ---------------------------------------------------------------------------
+
+
+def _make_big_tree(root: Path, file_count: int = 6000) -> None:
+    """在 root 下造一棵含 file_count 个小文件（分散于 ~50 子目录）的目录树，供 rmtree 产生可观耗时。"""
+    root.mkdir(parents=True, exist_ok=True)
+    for i in range(file_count):
+        d = root / f"d{i % 50}"
+        d.mkdir(exist_ok=True)
+        (d / f"f{i}.txt").write_text("x")
+
+
+async def test_remove_worktree_does_not_block_event_loop(tmp_path):
+    """回归：remove_worktree 的 rmtree 兜底已卸载到线程池（asyncio.to_thread），不再冻结事件循环。
+
+    构造含大量文件的伪 worktree 目录，令 ``cwd`` 失效以跳过 git 子命令、直击 rmtree 兜底（即原同步
+    阻塞点）；回收期间并发跑紧凑 asyncio 心跳，断言心跳单次间隔远小于一次完整 rmtree 耗时——证明
+    阻塞 IO 已离事件循环。修复前（直调 shutil.rmtree），心跳会在 rmtree 期间整体停滞 ≈ rmtree 耗时。
+    """
+    wt = tmp_path / "big_worktree"
+    _make_big_tree(wt)
+
+    # 量出同步 rmtree 基线耗时（= 修复前会冻结事件循环的时长）。
+    baseline = tmp_path / "baseline_worktree"
+    shutil.copytree(wt, baseline)
+    t0 = time.perf_counter()
+    shutil.rmtree(baseline)
+    rmtree_secs = time.perf_counter() - t0
+    if rmtree_secs < 0.1:
+        pytest.skip(f"本机 rmtree 过快（{rmtree_secs * 1000:.0f}ms < 100ms），测试无区分度")
+
+    s = _settings(str(tmp_path / "wt"))
+    # cwd 指向不存在路径 → 跳过 git 子命令，直击 rmtree 兜底（原同步阻塞点）。
+    r = _routine(str(tmp_path / "nonexistent_repo"), worktree_path=str(wt))
+
+    gaps: list[float] = []
+
+    async def heartbeat(steps: int = 60, interval: float = 0.01) -> None:
+        loop = asyncio.get_running_loop()
+        last = loop.time()
+        for _ in range(steps):
+            await asyncio.sleep(interval)
+            now = loop.time()
+            gaps.append(now - last)
+            last = now
+
+    # 先起心跳后台任务并预热若干 tick，再开始回收——确保 rmtree 运行时心跳正处节拍中；
+    # 否则同步阻塞的 remove_worktree 会在单个事件循环步长内跑完、心跳尚未启动，掩盖阻塞。
+    # 「事件循环被同步 rmtree 冻结」会直接表现为某次心跳间隔 ≈ rmtree 整体耗时。
+    hb = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0.05)  # 预热：让心跳先跑几个 tick
+    await ws.remove_worktree(r, s)  # 期间心跳仍在后台跑
+    await hb  # 收尾剩余 tick
+
+    assert not wt.exists()  # 清理仍完整生效（正确性不变）
+    assert gaps, "心跳未运行"
+    max_gap = max(gaps)
+    # 心跳单次间隔不应接近 rmtree 整体耗时：修复前 max_gap ≈ rmtree_secs，修复后 ≪ rmtree_secs。
+    assert max_gap < rmtree_secs * 0.5, (
+        f"事件循环疑似被阻塞：max_gap={max_gap * 1000:.0f}ms，rmtree 基线={rmtree_secs * 1000:.0f}ms"
+    )


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/interface/routine` 页「Clean Up」触发后端 `cleanup-worktree` → `workspace.remove_worktree()`，其中 `shutil.rmtree` 在 async 函数内同步执行，会冻结单 uvicorn 事件循环数十秒（巨型 worktree 含 node_modules/.git），叠加 DB 会话横跨慢操作占用连接池，导致**全站所有页面长时间无法打开**。
- 关联上下文：根因经 5 子代理并发审计 + 主代理独立复核定位；后端为单 uvicorn worker（多 worker 被禁，会破坏单引擎所有者不变量），故任何 async 端点内的同步阻塞 IO 即表现为整站阻塞。

# 核心变更
- **rmtree 卸载线程池**：`remove_worktree`/`ensure_worktree` 的 `shutil.rmtree` 改经 `await asyncio.to_thread(...)`（复用本仓 `knowledge/graph/graph_algorithms.py:280` 范式）。1 处改动惠及 Clean Up / restart / delete / 巡检 `_reap_workspaces` / 派发全部调用方，事件循环不再被冻结。
- **慢操作移出 DB 会话**：`cleanup_worktree`、`delete_routine`、`_reap_workspaces` 统一改为「短会话读校验 → 会话外清理 → 短会话写提交」三段式，即时归还连接池连接，杜绝长事务占用致池耗尽（依赖 `db/session.py` 的 `expire_on_commit=False`，detached ORM 对象属性可读）。
- **连接池显式 pool_timeout**：`config/database.py` 增 `pool_timeout=10s`（原 SQLAlchemy 默认 30s），耗尽时快速失败而非长挂。
- **回归测试**：新增 `test_remove_worktree_does_not_block_event_loop`（大目录树 + 后台心跳，断言心跳间隔远小于一次完整 rmtree 耗时）。

# 风险与回滚
- 主要风险：低。仅改变 rmtree 的执行线程与 DB 会话边界；清理完整性（git worktree remove/prune/branch -D + rmtree 兜底）、best-effort/幂等、DB 一致性、原有「先回收后置空/删行」顺序与 404/409 守卫均不变；无 API/前端契约变更。
- 回滚方式：`git revert 36f31f07`。

# 验证证据
- 单元测试：`test_routine_workspace.py` 26 项全绿（含新增回归测试 + 既有用例无回归）；回归测试已验证有齿——把 rmtree 临时回退为同步时 **FAIL**（心跳 gap 1056ms ≈ rmtree 耗时），恢复修复后 **PASS**。需 pgvector Postgres（`negentropy_test` 库；本机 PG 16.14 + pgvector 0.8.1）。
- 集成测试：N/A（纯机制层变更，未触及 DB schema/迁移）。
- E2E/Workflow：待 live 验证（需部署改动至运行中引擎后，借用户已认证 Chrome 实操）。
- 覆盖率/关键截图：`uv run pytest` 通过；ruff lint/format 通过；pre-commit 全部 hook 通过。

# 影响范围
- 前端：无（前端无需改动，Clean Up 仍为同步 await 语义）。
- 后端：`apps/negentropy` 的 routine workspace 清理链路（`workspace.py`、`routine_api.py`、`orchestrator.py`）+ DB 会话/连接池配置（`db/session.py`、`config/database.py`、`config/__init__.py`）。
- GitHub Actions / 文档：无。

# Next Best Action
- 部署改动至运行中引擎后，在 `/interface/routine` 对大 worktree 触发 Clean Up、并行窗口持续刷新其他页面，确认清理期间即时响应（live E2E 实操验证）。
