### PR TITLE
fix(Routine): Clean Up 按钮点击即时反馈——行内 busy/disabled + spinner 防二次点击;

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ExternalLink, OctagonX, RotateCcw, Trash2 } from "lucide-react";
+import { ExternalLink, Loader2, OctagonX, RotateCcw, Trash2 } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
@@ -19,9 +19,11 @@ interface RoutineTableProps {
   onTerminate?: (r: RoutineDTO) => void;
   /** 终态 + worktree 活跃时行内清理 worktree。 */
   onCleanupWorktree?: (r: RoutineDTO) => void;
+  /** 正在清理的 routine id（行内按钮 busy/disabled + spinner，防二次点击；null 表示无在途）。 */
+  cleanupBusyId?: string | null;
 }
 
-export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart, onTerminate, onCleanupWorktree }: RoutineTableProps) {
+export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart, onTerminate, onCleanupWorktree, cleanupBusyId }: RoutineTableProps) {
   if (loading && routines.length === 0) {
     return (
       <div className="space-y-2">
@@ -114,13 +116,20 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                   {onCleanupWorktree && canCleanupWorktree(r.status, r.worktree_path) && (
                     <button
                       type="button"
+                      disabled={cleanupBusyId === r.id}
+                      aria-busy={cleanupBusyId === r.id || undefined}
+                      aria-label={`Clean Up worktree for ${r.display_name || r.title}`}
                       onClick={(e) => {
                         e.stopPropagation();
                         onCleanupWorktree(r);
                       }}
-                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-amber-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-amber-400"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-amber-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:no-underline dark:text-amber-400"
                     >
-                      <Trash2 className="h-3 w-3" />
+                      {cleanupBusyId === r.id ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-3 w-3" />
+                      )}
                       Clean Up
                     </button>
                   )}

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -66,6 +66,8 @@ function RoutinePageInner() {
   // null = 抽屉关闭；"create" = 新建；否则由 ?sel 派生的 routine-edit。
   const [createOpen, setCreateOpen] = useState(false);
   const [actionBusy, setActionBusy] = useState(false);
+  // 行内 Clean Up 在途 routine id（null=无）；按钮 busy/disabled + spinner，防二次点击。
+  const [cleanupBusyId, setCleanupBusyId] = useState<string | null>(null);
   const [page, setPage] = useState(1);
 
   // SSE ghost-reopen 守卫：镜像 selected 供异步 SSE 回调读取「抽屉是否仍打开」，
@@ -229,6 +231,7 @@ function RoutinePageInner() {
   };
 
   const handleCleanupWorktree = async (r: RoutineDTO) => {
+    setCleanupBusyId(r.id);
     try {
       await cleanupWorktree(r.id);
       toast.success("Worktree cleaned up");
@@ -236,6 +239,8 @@ function RoutinePageInner() {
       if (selId === r.id) void refreshSelected(r.id);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to clean up worktree");
+    } finally {
+      setCleanupBusyId(null);
     }
   };
 
@@ -289,6 +294,7 @@ function RoutinePageInner() {
               onRestart={requestRestart}
               onTerminate={requestTerminate}
               onCleanupWorktree={handleCleanupWorktree}
+              cleanupBusyId={cleanupBusyId}
             />
 
             {sortedRoutines.length > 0 && (


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/interface/routine` 列表页行内「Clean Up」按钮点击后**无即时反馈**（无 loading 态、不禁用），用户无从知晓是否生效，且可在请求在途时重复点击触发多次清理。
- 关联上下文：详情/抽屉的卡片变体（`RoutineWorkspaceCard` 经 `RoutineRunView`）已有 `cleanupBusy` 禁用态；列表变体（`RoutineTable`）此前缺失，交互不一致。本次补齐列表页，复用 `[id]/page.tsx` 既有 `busy` 范式与 `Button` 组件的 `loading`/`aria-busy` 约定。

# 核心变更
- `page.tsx`：新增 `cleanupBusyId` 行级状态（正在清理的 routine id，`null` 表示无在途）；`handleCleanupWorktree` 点击即置位、`finally` 复位，并下传 `RoutineTable`。
- `RoutineTable.tsx`：Clean Up 按钮据 `cleanupBusyId === r.id` 进入 `disabled` + `aria-busy`，图标由 `Trash2` 切为 `Loader2` 旋转，并加 `disabled:opacity-50 / cursor-not-allowed / hover:no-underline` 与 `aria-label`。成功后 `refresh()` 使该行 `worktree_path` 变空 → 按钮自然消失（已清理），形成完整反馈闭环。

# 风险与回滚
- 主要风险：低。纯前端交互态，不影响清理逻辑/数据；仅禁用当前点击行，其余行不受影响（后端 worktree 清理已并发安全——见已合并的 #1002）。
- 回滚方式：`git revert`。

# 验证证据
- 单元测试：N/A（纯展示态变更）。
- 集成测试：N/A。
- E2E/Workflow：待 live 实操（点击 Clean Up → 按钮即灰显 + 旋转、防二次点击；成功 toast + 按钮消失）。
- 覆盖率/关键截图：`tsc --noEmit`（negentropy-ui）通过；`eslint --max-warnings=0` 通过；pre-commit 全部 hook 通过。

# 影响范围
- 前端：`apps/negentropy-ui` 列表页 routine 表格（`RoutineTable.tsx`、`page.tsx`）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- live 实操验证点击反馈（需部署 + 已认证 Chrome）；后续可考虑同模式补齐 Restart/Terminate 行内按钮的点击反馈（二者目前靠确认弹窗提供反馈，非本次范围）。
