### PR TITLE
fix(Routine): decide() 补齐 Judge verdict=pass 成功旁路，巡检收敛成功态不再被 no_progress 误判 failed

### DIFF
--- a/apps/negentropy/src/negentropy/engine/routine/decision.py
+++ b/apps/negentropy/src/negentropy/engine/routine/decision.py
@@ -101,6 +101,7 @@ def decide(
     *,
     now: datetime | None = None,
     max_context_resets: int = 0,
+    accept_verdict_pass: bool = False,
 ) -> Decision:
     """评估后的核心决策：成功 / 终止 / 继续。
 
@@ -113,15 +114,25 @@ def decide(
             的失败被视为"可自愈"，不计入连续执行失败——runaway 由 Runner 侧重置计数上限兜底）。
             默认 0 = 关闭该豁免，退化为原行为（向后兼容）。纯函数边界：上限由调用方显式注入，
             decision 不读 settings。
+        accept_verdict_pass: 为 True 时，Judge 的 ``verdict == "pass"``（验收标准达成·可终止）亦
+            判为成功（仍需门控通过）。默认 False 以保留「评分阈值是权威成功闸门」契约——避免在
+            常规 routine 上让 LLM-as-Judge 的 pass 单方面越过阈值触发不可逆成功。仅用于完成判据无法
+            被单一分数阈值捕获的任务（如巡检：``success_score_threshold=100`` 与 Judge 评分尺度
+            「全部满足≈90-100」结构性失配，且 acceptance 允许「仅剩 unfixable 即 done」由 Judge
+            在 <100 分判 pass）——这类任务经 ``config.accept_verdict_pass=True`` 显式开启旁路。
 
     Returns:
         Decision。优先级：成功 > 不可恢复 > 预算/截止 > 停滞 > 振荡 > 继续。
+        成功由「score 达阈值」OR「accept_verdict_pass 且 verdict=pass」触发（均需门控通过）。
     """
     now = now or _utcnow()
 
-    # 1) 成功：评分达标 AND（无门控 或 门控通过）
-    if latest.score is not None and latest.score >= routine.success_score_threshold:
-        if latest.gate_exit_code in (None, 0):
+    # 1) 成功：评分达标 OR（accept_verdict_pass 时）Judge 显式判 pass；均需门控通过（或无门控）。
+    # pass 是 Judge 的权威完成裁决（"达到验收标准，可终止"）。门控检查置外层（gate∉{None,0} 时整块
+    # 跳过），保护 ISSUE-115「门控超时/失败≠门控通过」——对 pass 旁路同样适用，避免误判成功。
+    if latest.gate_exit_code in (None, 0):
+        score_met = latest.score is not None and latest.score >= routine.success_score_threshold
+        if score_met or (accept_verdict_pass and latest.verdict == "pass"):
             return Decision("terminate", REASON_SUCCESS)
 
     # 2) 不可恢复：judge 显式判定 / 连续执行失败 / 连续评估失败

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -700,7 +700,13 @@ class RoutineOrchestrator:
             # 决策（仅取「本次尝试」窗口 seq > eval_floor_seq，重启后旧迭代不污染停滞/振荡判定）。
             history = await self._evaluated_history(db, routine_id, floor=routine.eval_floor_seq)
             verdict = decision_mod.decide(
-                routine, latest, history, max_context_resets=settings.routine.context_reset_max
+                routine,
+                latest,
+                history,
+                max_context_resets=settings.routine.context_reset_max,
+                # per-routine 开启「Judge verdict=pass 亦判成功」旁路（config.accept_verdict_pass）：
+                # 用于完成判据无法被单一分数阈值捕获的任务（如巡检 threshold=100 与 Judge 评分尺度失配）。
+                accept_verdict_pass=bool((routine.config or {}).get("accept_verdict_pass")),
             )
             if phased_flow:
                 self._advance_phase_or_terminate(routine, verdict)

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
@@ -160,6 +160,13 @@ def build_routine_config(
         # 但走 **clean stdin 应答**路径（reader 内 _plan_review_answer → 干净 tool_result），
         # 而非 PreToolUse deny 钩子（deny→is_error 致 UI 报错、交互断联）。
         "plan_review_via_hook": False,
+        # 开启「Judge verdict=pass 亦判成功」旁路（消费见 orchestrator.decide()）。
+        # 巡检完成判据含「仅剩 unfixable 即 done」carve-out（见 build_acceptance_criteria），Judge
+        # 据此对 <100 的分判 verdict=pass；但 success_score_threshold=100 与 Judge 评分尺度
+        # （"全部满足≈90-100"）结构性失配，score 恒 <100，致 decide() 成功路径永不触发、反被
+        # no_progress 误判 failed（曾致 Routine 861ab544 收敛成功态被判 failed）。开启此旁路让 Judge
+        # 的权威完成裁决（verdict=pass + 门控通过）成为第二成功通道，与阈值路径并列。
+        "accept_verdict_pass": True,
     }
     if extra:
         cfg.update(extra)

--- a/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
@@ -51,6 +51,9 @@ def test_build_routine_config_shape():
     assert cfg["system_prompt"] == PATROL_SYSTEM_PROMPT
     # Plan Review 保持启用，但走 clean stdin 应答（非 deny 钩子→is_error）
     assert cfg["plan_review_via_hook"] is False
+    # 巡检完成判据含「仅剩 unfixable 即 done」carve-out，threshold=100 与 Judge 评分尺度失配，
+    # 故开启 accept_verdict_pass 旁路让 Judge 的 pass 成为第二成功通道（防 no_progress 误判 failed）
+    assert cfg["accept_verdict_pass"] is True
 
 
 def test_build_routine_config_extra_override():

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
@@ -104,6 +104,52 @@ def test_decide_success_blocked_by_gate_timeout_sentinel():
     assert d.decide(r, it, [it]).action == "continue"
 
 
+# ---------------------------------------------------------------------------
+# accept_verdict_pass 旁路：Judge verdict=pass 亦判成功（默认关闭，opt-in 开启）
+# ---------------------------------------------------------------------------
+
+
+def test_decide_verdict_pass_triggers_success_when_optin():
+    """巡检回归（Routine 861ab544）：threshold=100 与 Judge 评分尺度「全部满足≈90-100」结构性
+    失配，score=88 恒 <100；但 acceptance 允许「仅剩 unfixable 即 done」，Judge 据此判 verdict=pass。
+    accept_verdict_pass=True 后 pass 应判成功，而非落入 no_progress 误判 failed。复现 seq=9 场景。"""
+    r = FakeRoutine(success_score_threshold=100, best_score=88)
+    it = FakeIter(score=88, verdict="pass", gate_exit_code=None)
+    res = d.decide(r, it, [it], accept_verdict_pass=True)
+    assert res.is_terminate and res.reason == d.REASON_SUCCESS
+
+
+def test_decide_verdict_pass_not_success_by_default():
+    """向后兼容锁：默认 accept_verdict_pass=False 时，verdict=pass 但 score<threshold 不判成功，
+    保留「评分阈值是权威成功闸门」契约（对照 test_runtime_threshold_lowering_triggers_success）。"""
+    r = FakeRoutine(success_score_threshold=100, best_score=88)
+    it = FakeIter(score=88, verdict="pass", gate_exit_code=None)
+    assert d.decide(r, it, [it]).action == "continue"
+
+
+def test_decide_verdict_pass_optin_blocked_by_failing_gate():
+    """门控守卫对 pass 旁路同样生效（ISSUE-115 回归锁）：gate 失败时即便 opt-in + verdict=pass
+    也不判成功，避免把失败验证状态误判成功。"""
+    r = FakeRoutine(success_score_threshold=100, best_score=88)
+    it = FakeIter(score=88, verdict="pass", gate_exit_code=1)
+    assert d.decide(r, it, [it], accept_verdict_pass=True).action == "continue"
+
+
+def test_decide_verdict_pass_optin_blocked_by_gate_timeout():
+    """门控超时(124)≠通过（ISSUE-115）：opt-in + verdict=pass 但 gate 超时亦不判成功。"""
+    r = FakeRoutine(success_score_threshold=100, best_score=88)
+    it = FakeIter(score=88, verdict="pass", gate_exit_code=124)
+    assert d.decide(r, it, [it], accept_verdict_pass=True).action == "continue"
+
+
+def test_decide_verdict_pass_optin_not_triggered_when_progressing():
+    """opt-in 只认 verdict=pass：verdict=progressing 时即便 opt-in 也不判成功，照常走停滞/振荡/
+    继续判定（此处 score=88<100、单条历史 → continue）。"""
+    r = FakeRoutine(success_score_threshold=100, best_score=88)
+    it = FakeIter(score=88, verdict="progressing", gate_exit_code=None)
+    assert d.decide(r, it, [it], accept_verdict_pass=True).action == "continue"
+
+
 def test_decide_unrecoverable_verdict():
     r = FakeRoutine(best_score=40)
     it = FakeIter(score=40, verdict="unrecoverable")


### PR DESCRIPTION
## 背景

Routine `861ab544`（PDF 高保真巡检）理应收敛为 **succeeded**，却被判 **failed(no_progress)**。Judge 在 seq 9–13 连续 5 次给出 `verdict=pass`（"达到验收标准，可终止"），引擎却标失败。

## 根因

`decide()` 成功路径**仅看 `score >= success_score_threshold`，完全忽略 Judge 的 `verdict=pass`**：

- 巡检 `success_score_threshold=100`（`pdf_fidelity_patrol.py:551`），但 Judge 评分尺度（`evaluator.py:55`「验收标准全部满足≈90-100」）使 100 不可达；
- 巡检 `acceptance_criteria` 明文允许「剩余差异均已计入 unfixable（≥5 次修复失败）…此时亦可判 done」，Judge 据此对 82–88 分判 `verdict=pass`；
- 结果：成功路径永不触发，评分在 88 处自然平台化 → `_is_no_progress` 误读为停滞 → `terminate(no_progress)` → `failed`。

### 此类状态判别问题归纳

| 缺陷模式 | 表现 |
|---|---|
| **信号语义失配** | 高保真分类完成信号（`verdict=pass`）被低保真数值阈值（`score>=threshold`）遮蔽 |
| **阈值不可达死路** | threshold 与评估器评分尺度结构性失配 + acceptance 含 carve-out → score 成功路径永不触发 |
| **停滞守卫误杀** | 评分在"已完成但未满分"处平台化 → 停滞守卫把"完成"误读为"停滞" |

**一句话**：决策层把"完成"等价于"分数达标"，丢弃了评估器产出的、更权威的分类完成裁决。

## 修复方案：Opt-in `accept_verdict_pass` 成功旁路

`decide()` 成功路径 OR 上「`accept_verdict_pass=True` 且 `verdict==pass`」，作为**默认关闭**的关键字参数；orchestrator 从 `routine.config` 透传；巡检 `build_routine_config` 显式开启。

**为何选 opt-in 而非一刀切**：现有单测 `test_runtime_threshold_lowering_triggers_success` 明确编码「`score=80+pass+threshold=85→continue`」（阈值是权威闸门），与 `acceptance_unmet_score_cap`（ISSUE-116）"警惕 raw pass"哲学一致。opt-in 默认 False → **13 个既有 decide 单测零改动、全量 routine 零行为变化**，仅巡检显式声明"Judge pass 也是完成信号"。

**门控守卫前置**：成功块改为外层先判 `gate_exit_code in (None, 0)`，对 score 路径与 pass 旁路统一生效，守护 ISSUE-115「超时/失败≠门控通过」。

**否决的防御方案**（二阶思维）：
- `acceptance_unmet_score_cap` —— 否决：cap 在 `acceptance_met=False` 时封顶 score，但巡检"有产出地修复中"迭代本就 acceptance_met=False，封顶会扭曲评分轨迹、破坏 `_is_no_progress` 信号。
- 硬编码 `evaluator_model` —— 不纳入：模型 id 部署相关、易腐。假阳性 pass 已由多层兜底（Judge 严格 prompt + CC contract 缺陷清单 + 巡检内部非回归门控 + 可 review 的 PR 工件）。

## 改动清单

- `decision.py`：`decide()` 新增 `accept_verdict_pass` 参数 + 成功块 OR 分支（门控前置）
- `orchestrator.py`：`decide()` 调用从 `routine.config` 透传 flag
- `patrol_prompt.py`：`build_routine_config` 置 `accept_verdict_pass=True`
- `test_routine_decision.py`：+5 个 opt-in 用例
- `test_patrol_prompt.py`：+1 断言

## 验证

```
uv run pytest tests/unit_tests/engine/test_routine_decision.py               tests/unit_tests/engine/test_patrol_prompt.py               tests/unit_tests/engine/test_routine_evaluator_gate.py               tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py -q
# 68 passed in 82.97s
```

- 5 个新 opt-in 用例全绿（含复现 seq=9 收敛成功、门控失败/超时阻断、verdict≠pass 不触发）
- 回归契约用例 `test_runtime_threshold_lowering_triggers_success` 等保持 PASSED（"阈值权威"契约未破坏）
- pre-commit（ruff lint/format）全部通过

## 链路

巡检首次 `verdict=pass`（score<100, gate=None）→ `decide()` SUCCESS → `_advance_phase_or_terminate` IMPLEMENT→FINALIZE → CC 非回归门控 + 建 PR → 捕获 pr_url → `succeeded`，并经 `_propagate_patrol_outcomes` 回写 ScheduledTask 为 `ok`。

> 注：既有失败 Routine `861ab544` 已终态、不可回溯翻转；本修复作用于**未来**巡检 Routine。

🤖 Generated with [Claude Code](https://claude.com/claude-code)