### PR TITLE
fix(Patrol): 巡检终态确定性推进文档，修始终拟同一份 PDF 死循环

### DIFF
--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -220,6 +220,7 @@ routine:
   patrol_max_iterations_per_doc: 400         # 单文档巡检 Routine 迭代硬上限（×50：原 8）
   patrol_max_cost_usd_per_doc: 1500.0        # 单文档成本熔断（USD）；×50（原 30）容许数百轮深度拟合收敛（原 5 致 2 轮撞顶）
   patrol_regression_sample_size: 6           # 非回归基线样本数
+  patrol_qualified_score_threshold: 95       # 巡检文档「合格」分阈值；best_score≥此值→done 推进(success_score_threshold 同步取此)，否则 unfixable 尽力(亦推进)
 
 # --- Knowledge 配置 ---
 knowledge:

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -324,6 +324,16 @@ class RoutineSettings(BaseSettings):
         le=30,
         description="非回归基线样本数（首次巡检时分层抽取的生产 PDF 文档数）。",
     )
+    patrol_qualified_score_threshold: int = Field(
+        default=95,
+        ge=0,
+        le=100,
+        description="巡检文档「合格」分阈值（0-100）。巡检 Routine 的 success_score_threshold 取此值——"
+        "best_score 达此值即判 done（合格）并经 decide() 判 SUCCESS；低于此值（尽力）记 unfixable。"
+        "二者皆推进文档、不再死循环（修「始终拟合同一份文档」根因）。"
+        "终态沉淀双信号：契约自报 done 或 best_score ≥ 此阈值 → done，否则 unfixable；"
+        "仅对 succeeded/failed 终态生效，cancelled 不沉淀。",
+    )
 
     @classmethod
     def settings_customise_sources(

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_memory.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_memory.py
@@ -277,11 +277,13 @@ class PatrolMemoryStore:
     # ------------------------------------------------------------------
 
     async def persist_contract(self, *, contract: dict[str, Any], routine_id: str) -> None:
-        """把一轮 ``pdf-fidelity-contract`` 解析为结构化记忆。
+        """把一轮 ``pdf-fidelity-contract`` 解析为结构化记忆（契约直驱变体）。
 
         - status==done → record_done；status==unfixable → record_doc_unfixable。
-        - unfixable_regions → 逐条 record_unfixable_region（去重：同 locator 已存在则跳过）。
-        - patterns → 逐条 record_pattern。
+        - unfixable_regions / patterns → 复用 ``_extract_regions_and_patterns``（去重提取）。
+
+        注：handler 的终态沉淀已切到 ``persist_terminal_outcome``（best_score 兜底，保证文档推进）。
+        本方法保留为「契约 status 直驱」语义入口（会话中途落库等场景），二者共享提取逻辑。
         """
         doc_id = str(contract.get("doc_id") or "").strip()
         if not doc_id:
@@ -294,6 +296,10 @@ class PatrolMemoryStore:
         elif status == "unfixable":
             await self.record_doc_unfixable(doc_id=doc_id, score=score, routine_id=routine_id)
 
+        await self._extract_regions_and_patterns(doc_id=doc_id, contract=contract)
+
+    async def _extract_regions_and_patterns(self, *, doc_id: str, contract: dict[str, Any]) -> None:
+        """从契约提取 unfixable_regions（去重：同 locator 已存在则跳过）+ patterns。"""
         existing = {r.get("locator") for r in await self.get_unfixable_regions(doc_id)}
         for region in contract.get("unfixable_regions") or []:
             if not isinstance(region, dict):
@@ -323,6 +329,53 @@ class PatrolMemoryStore:
                 fix_summary=str(pat.get("fix_summary") or ""),
                 module=str(pat.get("module") or ""),
             )
+
+    async def persist_terminal_outcome(
+        self,
+        *,
+        doc_id: str,
+        routine_id: str,
+        best_score: int | None,
+        qualified_threshold: int,
+        contract: dict[str, Any] | None = None,
+        routine_status: str,
+    ) -> None:
+        """终态 Routine 的**确定性状态沉淀**（文档推进的 SSOT 写者）。
+
+        保证每个 succeeded/failed 终态 Routine 必定把其文档标为 done 或 unfixable——
+        从而文档进 ``skip_ids``、被推进，不再因 agent 不自报 done 而死循环（修根因）。
+
+        判定优先级（与 handler ``_finalize_terminal_patrols`` 对齐）：
+        1) ``routine_status == 'cancelled'`` → 不写状态记忆（用户干预，文档保持可被重新选中）。
+        2) 契约自报 status == 'done' → done（agent 显式收敛声明，最强信号）。
+        3) ``best_score`` is not None and best_score >= qualified_threshold → done（合格，评估器权威峰值）。
+        4) 否则 → unfixable（尽力，含 best_score=None 的首轮崩）。
+
+        ``score`` 字段写 ``best_score``（跨迭代峰值，非末轮分）；cancelled 不写、不提取。
+        仍尽力提取契约内 unfixable_regions / patterns（done/unfixable 均可，复用既有去重逻辑）。
+        ``doc_id`` 由调用方权威传入（routine config 的 doc_id），不依赖契约自报。
+        """
+        doc_id = str(doc_id or "").strip()
+        if not doc_id:
+            return
+        if routine_status == "cancelled":
+            return  # 用户干预语义：不沉淀状态，文档可被重新选中
+
+        contract_status = str((contract or {}).get("status") or "").strip().lower()
+        if contract_status == "done":
+            terminal = "done"
+        elif best_score is not None and best_score >= qualified_threshold:
+            terminal = "done"
+        else:
+            terminal = "unfixable"
+
+        if terminal == "done":
+            await self.record_done(doc_id=doc_id, score=best_score, routine_id=routine_id)
+        else:
+            await self.record_doc_unfixable(doc_id=doc_id, score=best_score, routine_id=routine_id)
+
+        if contract:
+            await self._extract_regions_and_patterns(doc_id=doc_id, contract=contract)
 
 
 __all__ = [

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
@@ -106,29 +106,50 @@ def build_goal(
     doc_title: str,
     source_pdf_path: str,
     candidate_md_path: str,
+    qualified_threshold: int,
+    known_unfixable_regions: list[dict[str, Any]] | None = None,
 ) -> str:
-    """构造巡检 Routine 的 goal（文档级动态参数注入）。"""
+    """构造巡检 Routine 的 goal（文档级动态参数注入）。
+
+    - ``qualified_threshold``：合格分阈值，注入 done 判定（达此或仅剩 unfixable 即 done）。
+    - ``known_unfixable_regions``：该文档**已知 unfixable 区域**（跨 Routine 记忆复用），注入避让清单。
+    """
+    unfixable_hint = ""
+    if known_unfixable_regions:
+        locators = ", ".join(
+            str(r.get("locator") or "").strip()
+            for r in known_unfixable_regions
+            if isinstance(r, dict) and str(r.get("locator") or "").strip()
+        )
+        if locators:
+            unfixable_hint = f"\n- **已知 unfixable 区域（勿再尝试修复，评分不计）**：{locators}"
     return (
         f"本轮迭代：评估生产 PDF《{doc_title}》（doc_id={doc_id}）当前 Markdown 与源 PDF 的视觉保真度（0-100）。\n"
         f"- 源 PDF（只读）：{source_pdf_path}\n"
-        f"- 候选 Markdown（每轮覆盖写）：{candidate_md_path}\n"
+        f"- 候选 Markdown（每轮覆盖写）：{candidate_md_path}{unfixable_hint}\n"
         f"严格按 system_prompt 闭环执行（重转 → 渲染 → **采样**比对 → 评分 → [一处定点修复 → 重转复核] → 契约）。"
         f"**勿过度探查、勿逐页读全部图、勿 spawn Agent 子任务**——这是上轮 context 耗尽未推进的根因。"
-        f"score=100 或仅剩 unfixable 即 done。"
+        f"score≥{qualified_threshold}（合格阈值）或仅剩 unfixable 即 done。"
     )
 
 
-def build_acceptance_criteria(*, baseline_branch: str) -> str:
+def build_acceptance_criteria(*, baseline_branch: str, qualified_threshold: int) -> str:
     """构造巡检 Routine 的 acceptance_criteria。
 
-    允许「满分 100」在仅剩 unfixable carve-out 时达成（carve-out 不扣分），避免死循环。
+    合格阈值为 ``qualified_threshold``（默认 95）：达此分即判合格 done、Routine 经 decide() 判 SUCCESS。
+    允许在仅剩 unfixable carve-out 时达成（carve-out 不扣分），避免死循环。
+    含显式评分指引：收敛文档须评 ``qualified_threshold``-100，防评估器压分致本应成功的 Routine 误判 Failed。
     """
     return (
         "该文档所有页面/模块（文字、段落顺序、高清原图及显示尺寸、目录锚点、表格、数学公式、"
-        "代码块、脚注）与源 PDF 视觉一致（Contemplation 评分 100）；或剩余差异均已计入 "
+        "代码块、脚注）与源 PDF 视觉一致；或剩余差异均已计入 "
         "`pdf-fidelity-unfixable`（≥5 次修复失败）并由 Internalization 写入记忆——此时亦可判 done。\n"
-        "完成判据：每轮以 `pdf-fidelity-contract` JSON 收尾；done 时 score=100 且 defects 为空"
-        "（或仅剩 unfixable）；Perceives 改动经非回归门控通过后以 PR 合回基线 "
+        "**评分指引（重要）**：当文档已收敛（可修复模块全部一致；剩余差异均已列入 "
+        f"`pdf-fidelity-unfixable` 忽略不计）时，acceptance_met=true 且 score 应为 "
+        f"**{qualified_threshold}-100**（unfixable 模块不扣分）；仍有可修复缺陷时方在 "
+        f"{qualified_threshold} 以下评分。**勿对已收敛文档压低分数**，致本应成功的 Routine 误判失败。\n"
+        "完成判据：每轮以 `pdf-fidelity-contract` JSON 收尾；done 时 score≥"
+        f"{qualified_threshold} 且 defects 为空（或仅剩 unfixable）；Perceives 改动经非回归门控通过后以 PR 合回基线 "
         f"`{baseline_branch}`。"
     )
 

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -5,8 +5,10 @@
 1. **确保巡检 Repository**：幂等 upsert 名为 ``negentropy`` 的 Repository（local_path 从
    ``settings.routine.patrol_repo_local_path`` 或 negentropy 包路径推导；无法确定则返回
    not configured，引导改用 Interface/Repositories 手工注册）。
-2. **沉淀终态巡检 Routine 的契约记忆**：扫到 ``config->>'patrol'=true`` 且已终态但未落记忆的
-   Routine，解析其末轮 ``pdf-fidelity-contract`` JSON，写 done/unfixable/pattern 记忆。
+2. **确定性沉淀终态巡检 Routine 的文档终态**：扫到 ``config->>'patrol'=true`` 且已终态但未落记忆的
+   Routine，依 ``best_score`` + 合格阈值（``patrol_qualified_score_threshold``，契约自报 done 兜底）
+   把文档标 done（合格）/unfixable（尽力）——保证文档必进 ``skip_ids``、被推进，不再死循环；
+   cancelled 不沉淀（用户干预，文档保持可被重新选中）。
 3. **跳过并发**：存在 ``status='running'`` 的巡检 Routine → 本 tick SKIP（保证「上一轮结束后
    再启下一轮」；ScheduledTask 的 ``interval`` 计 ``next_fire_at = 完成时刻 + 3600s``，叠加此
    互斥即满足「巡检进行中则等待其结束 + 1h」语义）。
@@ -14,7 +16,8 @@
    ``markdown_extract_status='completed'``，排除记忆中已 done/unfixable 的 doc_id。
 5. **预取源 PDF**：``BlobStorage.download(content_uri)`` → 暂存到 ``patrol_input_dir/<doc_id>/``。
 6. **创建并启动巡检 Routine**（``status='running'``，绑定 Repository，worktree + FINALIZE PR +
-   0-100 评估闭环）。其 Claude Code 会话即 NegentropyEngine，依三系部协议循环拟合至满分。
+   0-100 评估闭环）。其 Claude Code 会话即 NegentropyEngine，依三系部协议循环拟合至合格阈值
+   （``success_score_threshold=patrol_qualified_score_threshold``，默认 95）即 SUCCESS、推进下一份。
 
 真正的 Claude Code 长耗执行交由 ``routine_inspector``（25s tick）驱动的 Routine 编排闭环异步完成，
 本 handler 恒不阻塞调度心跳。
@@ -275,16 +278,29 @@ async def _ensure_patrol_repository(db, *, baseline_branch: str) -> uuid.UUID | 
 
 
 async def _finalize_terminal_patrols(db) -> int:
-    """对终态但未落记忆的巡检 Routine，解析末轮契约 → 写记忆 → 标记 memory_persisted。
+    """对终态但未落记忆的巡检 Routine，**确定性**沉淀文档终态 → 标记 memory_persisted。
 
-    返回沉淀条数。
+    每个 succeeded/failed 终态 Routine 必定把其文档标为 done（合格）/unfixable（尽力），
+    从而文档进 skip_ids、被推进——不再因 agent 不自报 done 而死循环（修「始终拟合同一份文档」根因）。
+    cancelled 不沉淀状态（用户干预，文档保持可被重新选中），仅标记避免每 tick 重扫。
+
+    终态判定（``PatrolMemoryStore.persist_terminal_outcome``）：契约自报 done **或** best_score ≥
+    ``patrol_qualified_score_threshold`` → done；否则 unfixable；cancelled 跳过。
+    score 写 best_score（跨迭代权威峰值，非末轮分）；契约缺失/解析失败亦以 best_score 兜底沉淀。
+
+    同文档多 Routine 时按 ``best_score ASC NULLS FIRST`` 处理 → upsert 末写即最高 best_score，
+    保证「最佳拟合」语义（cancelled/NULL 先处理、被高分覆盖）。
+
+    返回处理条数。
     """
     rows = await db.execute(
         sa.text(
-            "SELECT id, key FROM negentropy.routines "
+            "SELECT id, status, best_score, config->>'doc_id' AS doc_id "
+            "FROM negentropy.routines "
             "WHERE config->>'patrol' = 'true' "
             "AND status IN ('succeeded','failed','cancelled') "
-            "AND (config->>'memory_persisted' IS NULL OR config->>'memory_persisted' <> 'true')"
+            "AND (config->>'memory_persisted' IS NULL OR config->>'memory_persisted' <> 'true') "
+            "ORDER BY best_score ASC NULLS FIRST"
         )
     )
     candidates = rows.fetchall()
@@ -294,9 +310,18 @@ async def _finalize_terminal_patrols(db) -> int:
     from negentropy.engine.routine.patrol_memory import PatrolMemoryStore, parse_contract
 
     store = PatrolMemoryStore(db)
+    qualified_threshold = settings.routine.patrol_qualified_score_threshold
     count = 0
-    for routine_id, _key in candidates:
+    for routine_id, routine_status, best_score, doc_id_cfg in candidates:
         rid = uuid.UUID(str(routine_id))
+
+        if routine_status == "cancelled":
+            # 用户干预：不沉淀状态记忆（文档保持可被重新选中），仅标记避免每 tick 重扫。
+            await _mark_memory_persisted(db, rid)
+            count += 1
+            continue
+
+        # 末轮契约（doc_id 兜底 + regions/patterns 提取；best_score 兜底保证契约缺失亦沉淀）
         summ_row = await db.execute(
             sa.text(
                 "SELECT summary FROM negentropy.routine_iterations "
@@ -306,21 +331,45 @@ async def _finalize_terminal_patrols(db) -> int:
         )
         summary = summ_row.scalar()
         contract = parse_contract(summary if isinstance(summary, str) else None)
-        if contract:
-            try:
-                await store.persist_contract(contract=contract, routine_id=str(rid))
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("patrol_persist_contract_failed", routine_id=str(rid), error=str(exc))
-                continue
-        await db.execute(
-            sa.text(
-                "UPDATE negentropy.routines "
-                "SET config = COALESCE(config,'{}'::jsonb) || jsonb_build_object('memory_persisted', true) "
-                "WHERE id = :rid"
-            ).bindparams(rid=rid)
-        )
+
+        # doc_id 优先 routine config（handler 创建时权威写入），契约内兜底
+        doc_id = str(doc_id_cfg or "").strip() or str((contract or {}).get("doc_id") or "").strip()
+        if not doc_id:
+            # config 与契约均无 doc_id（异常）——无法沉淀，仅标记避免重扫（防御性，不应发生）。
+            logger.warning("patrol_finalize_missing_doc_id", routine_id=str(rid))
+            await _mark_memory_persisted(db, rid)
+            count += 1
+            continue
+
+        try:
+            await store.persist_terminal_outcome(
+                doc_id=doc_id,
+                routine_id=str(rid),
+                best_score=int(best_score) if best_score is not None else None,
+                qualified_threshold=qualified_threshold,
+                contract=contract,
+                routine_status=routine_status,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("patrol_persist_terminal_outcome_failed", routine_id=str(rid), error=str(exc))
+            await _mark_memory_persisted(db, rid)
+            count += 1
+            continue
+
+        await _mark_memory_persisted(db, rid)
         count += 1
     return count
+
+
+async def _mark_memory_persisted(db, rid: uuid.UUID) -> None:
+    """幂等标记 Routine 的契约记忆已沉淀（避免每 tick 重扫致日志/IO 膨胀）。"""
+    await db.execute(
+        sa.text(
+            "UPDATE negentropy.routines "
+            "SET config = COALESCE(config,'{}'::jsonb) || jsonb_build_object('memory_persisted', true) "
+            "WHERE id = :rid"
+        ).bindparams(rid=rid)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -508,6 +557,7 @@ def _build_patrol_routine(
     source_read_dir: str,
     regression_sample: list[str],
     source_task_key: str,
+    known_unfixable_regions: list[dict[str, Any]] | None = None,
 ) -> Routine:
     """构造巡检 Routine ORM 对象（纯函数，无 DB —— 可单测验证字段装配无 AttributeError）。
 
@@ -525,21 +575,27 @@ def _build_patrol_routine(
     doc_id = str(doc["id"])
     doc_title = _doc_display_title(doc)
     short = uuid.uuid4().hex[:8]
+    qualified_threshold = settings.routine.patrol_qualified_score_threshold
     return Routine(
         key=f"{PATROL_KEY_PREFIX}/{doc_id}/{short}",
         title=f"PDF 高保真巡检：{doc_title}",
         display_name=f"PDF Fidelity Patrol · {doc_title}",
         description=(
             f"NegentropyEngine 巡检生产 PDF《{doc_title}》→ Markdown 高保真自拟合。"
-            "三系部循环（视觉对比→改 perceives→重转→记忆）至满分；PR 合回基线。"
+            "三系部循环（视觉对比→改 perceives→重转→记忆）至合格阈值；PR 合回基线。"
         ),
         goal=build_goal(
             doc_id=doc_id,
             doc_title=doc_title,
             source_pdf_path=source_pdf_path,
             candidate_md_path=CANDIDATE_MD_FILENAME,
+            qualified_threshold=qualified_threshold,
+            known_unfixable_regions=known_unfixable_regions,
         ),
-        acceptance_criteria=build_acceptance_criteria(baseline_branch=baseline_branch),
+        acceptance_criteria=build_acceptance_criteria(
+            baseline_branch=baseline_branch,
+            qualified_threshold=qualified_threshold,
+        ),
         cwd=None,  # 由 repository_id 派生 worktree cwd（单一事实源指针）
         baseline_branch=baseline_branch,
         repository_id=repo_id,
@@ -548,7 +604,7 @@ def _build_patrol_routine(
         max_iterations=settings.routine.patrol_max_iterations_per_doc,
         max_cost_usd=settings.routine.patrol_max_cost_usd_per_doc,
         deadline_at=None,
-        success_score_threshold=100,
+        success_score_threshold=qualified_threshold,  # 合格阈值（默认 95）：收敛即 SUCCESS，不再误标 Failed
         no_progress_patience=3,  # per-Routine DB 列默认值（非 RoutineSettings 属性）
         approval_mode="auto",
         config=build_routine_config(
@@ -581,7 +637,11 @@ async def _create_and_start_patrol_routine(
     """构造（_build_patrol_routine）+ 落库 + flush，返回 routine id。
 
     DB 写集中于此；构造逻辑（字段装配）抽到纯函数 _build_patrol_routine 便于无 DB 单测。
+    构造前取出该文档**已知 unfixable 区域**注入 goal（跨 Routine 复用避让——修复「只写不读」半失效）。
     """
+    from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
+
+    known_unfixable_regions = await PatrolMemoryStore(db).get_unfixable_regions(str(doc["id"]))
     routine = _build_patrol_routine(
         repo_id=repo_id,
         baseline_branch=baseline_branch,
@@ -590,6 +650,7 @@ async def _create_and_start_patrol_routine(
         source_read_dir=source_read_dir,
         regression_sample=regression_sample,
         source_task_key=source_task_key,
+        known_unfixable_regions=known_unfixable_regions,
     )
     db.add(routine)
     await db.flush()

--- a/apps/negentropy/tests/unit_tests/engine/test_patrol_memory.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_patrol_memory.py
@@ -154,3 +154,164 @@ def test_persist_contract_dedup_existing_region():
 
     asyncio.run(store.persist_contract(contract=contract, routine_id="r4"))
     assert [r["locator"] for r in store.regions] == ["page2-tbl"]
+
+
+# ---------------------------------------------------------------------------
+# persist_terminal_outcome：终态确定性沉淀（文档推进 SSOT —— 修「始终拟合同一份文档」根因）
+# 判定：契约自报 done 或 best_score≥阈值 → done；否则 unfixable；cancelled 跳过。
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def test_persist_terminal_outcome_failed_high_score_marks_done():
+    """failed + best_score=97 ≥ 95 + progressing 契约 → done（核心：progressing 不再死循环）。"""
+    store = _FakeStore()
+    contract = {"doc_id": "d1", "score": 70, "status": "progressing", "unfixable_regions": [], "patterns": []}
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d1",
+            routine_id="r1",
+            best_score=97,
+            qualified_threshold=95,
+            contract=contract,
+            routine_status="failed",
+        )
+    )
+    assert store.done == [{"doc_id": "d1", "score": 97, "routine_id": "r1"}]
+    assert store.doc_unfixable == []
+
+
+def test_persist_terminal_outcome_failed_low_score_marks_unfixable():
+    """failed + best_score=52 < 95 → unfixable（尽力，亦推进）。"""
+    store = _FakeStore()
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d2",
+            routine_id="r2",
+            best_score=52,
+            qualified_threshold=95,
+            contract=None,
+            routine_status="failed",
+        )
+    )
+    assert store.doc_unfixable == [{"doc_id": "d2", "score": 52, "routine_id": "r2"}]
+    assert store.done == []
+
+
+def test_persist_terminal_outcome_null_best_score_marks_unfixable():
+    """failed + best_score=None（首轮崩）→ unfixable（保证推进，不死循环）。"""
+    store = _FakeStore()
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d3",
+            routine_id="r3",
+            best_score=None,
+            qualified_threshold=95,
+            contract=None,
+            routine_status="failed",
+        )
+    )
+    assert store.doc_unfixable == [{"doc_id": "d3", "score": None, "routine_id": "r3"}]
+
+
+def test_persist_terminal_outcome_contract_done_overrides_low_best_score():
+    """契约自报 done + best_score=70(<95) → done（agent 显式收敛声明优先于阈值）。"""
+    store = _FakeStore()
+    contract = {"doc_id": "d4", "score": 70, "status": "done", "unfixable_regions": [], "patterns": []}
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d4",
+            routine_id="r4",
+            best_score=70,
+            qualified_threshold=95,
+            contract=contract,
+            routine_status="failed",
+        )
+    )
+    assert store.done == [{"doc_id": "d4", "score": 70, "routine_id": "r4"}]
+
+
+def test_persist_terminal_outcome_cancelled_skips_persist():
+    """cancelled + best_score=97 → 不写任何状态、不提取 regions/patterns（用户干预，文档可重选）。"""
+    store = _FakeStore()
+    contract = {
+        "doc_id": "d5",
+        "score": 97,
+        "status": "done",
+        "unfixable_regions": [{"locator": "p1-x", "attempts": 5, "reason": "r"}],
+        "patterns": [{"defect_type": "t", "fix_summary": "f", "module": "m"}],
+    }
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d5",
+            routine_id="r5",
+            best_score=97,
+            qualified_threshold=95,
+            contract=contract,
+            routine_status="cancelled",
+        )
+    )
+    assert store.done == [] and store.doc_unfixable == []
+    assert store.regions == [] and store.patterns == []
+
+
+def test_persist_terminal_outcome_threshold_boundary_is_inclusive():
+    """best_score 恰等于阈值(95) → done（>=边界）。"""
+    store = _FakeStore()
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d6",
+            routine_id="r6",
+            best_score=95,
+            qualified_threshold=95,
+            contract=None,
+            routine_status="failed",
+        )
+    )
+    assert store.done == [{"doc_id": "d6", "score": 95, "routine_id": "r6"}]
+
+
+def test_persist_terminal_outcome_no_doc_id_skipped():
+    """doc_id='' → 不写任何记忆（防御性）。"""
+    store = _FakeStore()
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="",
+            routine_id="r7",
+            best_score=97,
+            qualified_threshold=95,
+            contract=None,
+            routine_status="failed",
+        )
+    )
+    assert store.done == [] and store.doc_unfixable == []
+
+
+def test_persist_terminal_outcome_extracts_regions_and_patterns():
+    """done 判定下，契约内 unfixable_regions / patterns 仍被提取（复用既有去重逻辑）。"""
+    store = _FakeStore()
+    contract = {
+        "doc_id": "d8",
+        "score": 97,
+        "status": "progressing",
+        "unfixable_regions": [{"locator": "p3-t2", "attempts": 5, "reason": "扫描版"}],
+        "patterns": [{"defect_type": "table", "fix_summary": "调阈值", "module": "pdf/"}],
+    }
+    _run(
+        store.persist_terminal_outcome(
+            doc_id="d8",
+            routine_id="r8",
+            best_score=97,
+            qualified_threshold=95,
+            contract=contract,
+            routine_status="succeeded",
+        )
+    )
+    assert store.done == [{"doc_id": "d8", "score": 97, "routine_id": "r8"}]
+    assert [r["locator"] for r in store.regions] == ["p3-t2"]
+    assert store.patterns[0]["defect_type"] == "table"

--- a/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
@@ -17,6 +17,7 @@ def test_build_goal_injects_doc_params():
         doc_title="论文 A",
         source_pdf_path="/tmp/patrol/doc-123/source.pdf",
         candidate_md_path="patrol-candidate.md",
+        qualified_threshold=95,
     )
     assert "doc-123" in g
     assert "论文 A" in g
@@ -24,14 +25,51 @@ def test_build_goal_injects_doc_params():
     assert "patrol-candidate.md" in g
     assert "保真度" in g  # 紧凑目标：本轮评分（非开放式「调度三系部」）
     assert "采样" in g  # 防过度探查：采样比对
+    assert "95" in g  # 合格阈值注入 done 判定
+    assert "合格阈值" in g
+
+
+def test_build_goal_injects_known_unfixable_regions():
+    """已知 unfixable 区域注入避让清单（跨 Routine 记忆复用——修复「只写不读」半失效）。"""
+    g = build_goal(
+        doc_id="doc-9",
+        doc_title="论文 B",
+        source_pdf_path="/tmp/patrol/doc-9/source.pdf",
+        candidate_md_path="patrol-candidate.md",
+        qualified_threshold=95,
+        known_unfixable_regions=[
+            {"locator": "page3-table2"},
+            {"locator": "page7-formula1"},
+            {"locator": ""},  # 空 locator 应被过滤
+        ],
+    )
+    assert "已知 unfixable 区域" in g
+    assert "page3-table2" in g
+    assert "page7-formula1" in g
+    assert "评分不计" in g
+
+
+def test_build_goal_no_unfixable_hint_when_empty():
+    """无已知 unfixable 区域时不附加避让段（避免空提示噪声）。"""
+    g = build_goal(
+        doc_id="d",
+        doc_title="t",
+        source_pdf_path="/p.pdf",
+        candidate_md_path="c.md",
+        qualified_threshold=95,
+        known_unfixable_regions=None,
+    )
+    assert "已知 unfixable 区域" not in g
 
 
 def test_build_acceptance_criteria_allows_unfixable_carveout():
-    ac = build_acceptance_criteria(baseline_branch="origin/feature/1.x.x")
-    assert "100" in ac
+    ac = build_acceptance_criteria(baseline_branch="origin/feature/1.x.x", qualified_threshold=95)
+    assert "95" in ac  # 合格阈值（取代旧「满分 100」门槛）
+    assert "100" in ac  # 收敛评分区间 95-100
     assert "unfixable" in ac
     assert "origin/feature/1.x.x" in ac
     assert "pdf-fidelity-contract" in ac
+    assert "评分指引" in ac  # 防评估器压分致本应成功的 Routine 误判 Failed
 
 
 def test_build_routine_config_shape():

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -208,6 +208,25 @@ def test_run_patrol_tick_carries_lifecycle_markers():
     assert "stage_source_pdf_failed" in body
 
 
+def test_finalize_terminal_patrols_branches_present():
+    """白盒：_finalize_terminal_patrols 含确定性推进的关键分支（防重构丢失）。
+
+    - ``cancelled`` 显式跳过沉淀（用户干预，文档保持可重新选中）。
+    - ``persist_terminal_outcome`` 调用（best_score 兜底，修「始终拟合同一份文档」根因）。
+    - 候选查询取 best_score/doc_id 且 ``ORDER BY ... best_score``（同文档多 Routine 最佳拟合胜出）。
+    - ``patrol_qualified_score_threshold`` 注入合格阈值。
+    """
+    import inspect
+
+    body = inspect.getsource(patrol._finalize_terminal_patrols)
+    assert "cancelled" in body  # cancelled 分支（不沉淀状态）
+    assert "persist_terminal_outcome" in body  # 确定性终态沉淀（SSOT 写者）
+    assert "best_score" in body  # 候选查询取 best_score + ORDER BY
+    assert "patrol_qualified_score_threshold" in body  # 合格阈值注入
+    # _mark_memory_persisted 抽出（消除重复 UPDATE）
+    assert hasattr(patrol, "_mark_memory_persisted")
+
+
 # ---------------------------------------------------------------------------
 # _build_patrol_routine：构造巡检 Routine（回归 no_progress_patience 误读 settings 致全量异常）
 # ---------------------------------------------------------------------------
@@ -234,7 +253,7 @@ def test_build_patrol_routine_constructs_without_attribute_error():
     )
     # 关键字段装配正确（与 routine_api.create_routine 口径对齐）
     assert routine.no_progress_patience == 3  # per-Routine 默认，非 settings
-    assert routine.success_score_threshold == 100
+    assert routine.success_score_threshold == 95  # 合格阈值（patrol_qualified_score_threshold；原 100→收敛即 SUCCESS）
     assert routine.status == "running"
     assert routine.repository_id == repo_id
     assert routine.baseline_branch == "origin/feature/1.x.x"

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -30,7 +30,7 @@ from negentropy.engine.schedulers.handlers import (
 )
 from negentropy.models.plugin_common import PluginVisibility
 from negentropy.models.repository import Repository
-from negentropy.models.routine import Routine
+from negentropy.models.routine import Routine, RoutineIteration
 from negentropy.models.scheduled_task import ScheduledTask, TaskExecution
 
 
@@ -75,7 +75,7 @@ async def test_create_and_start_patrol_routine_persists_real_row(db_engine):
         assert row.repository_id == repo_id
         assert row.baseline_branch == "origin/feature/1.x.x"
         assert row.no_progress_patience == 3  # per-Routine 默认（非 settings）—— 回归点
-        assert row.success_score_threshold == 100
+        assert row.success_score_threshold == 95  # 合格阈值（patrol_qualified_score_threshold；原 100→收敛即 SUCCESS）
         assert row.max_iterations == 400  # settings.routine.patrol_max_iterations_per_doc（×50：原 8）
         assert row.max_cost_usd == 1500.0  # patrol 专属预算（×50：原 30；非全局 default_max_cost_usd=5）
         assert row.owner_id == "system"
@@ -233,6 +233,255 @@ async def test_propagate_idempotent(db_engine):
     async with factory() as db:
         task = (await db.execute(select(ScheduledTask).where(ScheduledTask.key == task_key))).scalar_one()
         assert task.consecutive_failures == 1  # 未因二次调用重复累加
+
+
+# ---------------------------------------------------------------------------
+# _finalize_terminal_patrols：终态确定性沉淀 → 文档推进（修「始终拟合同一份文档」根因）
+# ---------------------------------------------------------------------------
+
+
+def _contract_summary(*, score, status):
+    """构造一份 ``pdf-fidelity-contract`` JSON 块 summary（喂 routine_iterations.summary）。"""
+    import json
+
+    payload = {
+        "doc_id": "x",
+        "score": score,
+        "status": status,
+        "defects": [],
+        "unfixable_regions": [],
+        "patterns": [],
+        "perceives_diff_summary": "",
+        "non_regression": "n/a",
+    }
+    return f"```pdf-fidelity-contract\n{json.dumps(payload)}\n```"
+
+
+async def _seed_terminal_patrol_with_outcome(
+    db_engine,
+    *,
+    status,
+    best_score=None,
+    contract_summary=None,
+    doc_id=None,
+):
+    """落库一条终态 patrol Routine（可选 best_score + 末轮 evaluated 契约 summary）。
+
+    返回 ``(routine_id, doc_id)``；doc_id 取自创建时写入（_create_and_start 用 doc['id']）。
+    """
+    factory = _sf(db_engine)
+    async with factory() as db:
+        repo = Repository(
+            owner_id="system",
+            visibility=PluginVisibility.PUBLIC,
+            name=f"negentropy-fin-{uuid.uuid4().hex[:8]}",
+            display_name="fin-test",
+            github_url="https://github.com/ThreeFish-AI/negentropy",
+            local_path="/tmp/nonexistent-patrol-repo",
+            baseline_branch="origin/feature/1.x.x",
+            default_remote="origin",
+        )
+        db.add(repo)
+        await db.flush()
+        doc_id = doc_id or str(uuid.uuid4())
+        doc = {"id": doc_id, "original_filename": "spec.pdf"}
+        routine_id = await patrol._create_and_start_patrol_routine(
+            db,
+            repo_id=repo.id,
+            baseline_branch="origin/feature/1.x.x",
+            doc=doc,
+            source_pdf_path="/tmp/patrol/source.pdf",
+            source_read_dir="/tmp/patrol",
+            regression_sample=[],
+            source_task_key=f"pdf_fidelity_patrol-fin-{uuid.uuid4().hex[:6]}",
+        )
+        routine = await db.get(Routine, routine_id)
+        routine.status = status
+        routine.termination_reason = (
+            "success" if status == "succeeded" else ("user_cancelled" if status == "cancelled" else "no_progress")
+        )
+        if best_score is not None:
+            routine.best_score = best_score
+        if contract_summary is not None:
+            db.add(
+                RoutineIteration(
+                    routine_id=routine_id,
+                    seq=1,
+                    status="evaluated",
+                    summary=contract_summary,
+                    score=best_score,
+                )
+            )
+        await db.commit()
+    return routine_id, str(doc_id)
+
+
+async def _status_memory(db_engine, doc_id):
+    """读取某 doc 的 pdf-fidelity-status 记忆 (status, score)；无则 None。"""
+    from sqlalchemy import text
+
+    from negentropy.config import settings
+
+    factory = _sf(db_engine)
+    async with factory() as db:
+        return (
+            await db.execute(
+                text(
+                    "SELECT metadata->>'status' AS st, metadata->>'score' AS sc "
+                    "FROM negentropy.memories "
+                    "WHERE app_name = :app AND user_id = 'system' "
+                    "AND metadata->>'tag' = 'pdf-fidelity-status' AND metadata->>'doc_id' = :d "
+                    "LIMIT 1"
+                ),
+                {"app": settings.app_name, "d": str(doc_id)},
+            )
+        ).fetchone()
+
+
+async def test_finalize_failed_high_score_marks_done_and_advances(db_engine):
+    """failed best_score=97 ≥ 95 → done(score=97)，doc 进 skip_ids（推进生效，不再死循环）。"""
+    from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
+
+    factory = _sf(db_engine)
+    _, doc_id = await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97)
+    async with factory() as db:
+        n = await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+    assert n >= 1
+
+    row = await _status_memory(db_engine, doc_id)
+    assert row is not None and row.st == "done" and row.sc == "97"
+
+    async with factory() as db:
+        assert doc_id in await PatrolMemoryStore(db).get_skip_doc_ids()
+
+
+async def test_finalize_failed_low_score_marks_unfixable_and_advances(db_engine):
+    """failed best_score=52 < 95 → unfixable(score=52)，doc 仍进 skip_ids（尽力亦推进）。"""
+    from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
+
+    factory = _sf(db_engine)
+    _, doc_id = await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=52)
+    async with factory() as db:
+        await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+    row = await _status_memory(db_engine, doc_id)
+    assert row is not None and row.st == "unfixable" and row.sc == "52"
+    async with factory() as db:
+        assert doc_id in await PatrolMemoryStore(db).get_skip_doc_ids()
+
+
+async def test_finalize_progressing_contract_advances(db_engine):
+    """末轮 progressing 契约 + best_score=96 ≥ 95 → done（核心：progressing 不再致死循环）。"""
+    from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
+
+    factory = _sf(db_engine)
+    _, doc_id = await _seed_terminal_patrol_with_outcome(
+        db_engine,
+        status="failed",
+        best_score=96,
+        contract_summary=_contract_summary(score=80, status="progressing"),
+    )
+    async with factory() as db:
+        await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+    row = await _status_memory(db_engine, doc_id)
+    assert row is not None and row.st == "done"  # best_score 兜底，progressing 不阻断推进
+    async with factory() as db:
+        assert doc_id in await PatrolMemoryStore(db).get_skip_doc_ids()
+
+
+async def test_finalize_missing_contract_falls_back_to_best_score(db_engine):
+    """末轮无 evaluated summary（契约缺失）+ best_score=88 < 95 → unfixable（best_score 兜底沉淀）。"""
+    _, doc_id = await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=88)
+    factory = _sf(db_engine)
+    async with factory() as db:
+        await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+    row = await _status_memory(db_engine, doc_id)
+    assert row is not None and row.st == "unfixable"
+
+
+async def test_finalize_cancelled_does_not_persist_status(db_engine):
+    """cancelled best_score=97 → 不写状态记忆、doc 不进 skip_ids（保持可重选），memory_persisted=true。"""
+    from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
+
+    factory = _sf(db_engine)
+    routine_id, doc_id = await _seed_terminal_patrol_with_outcome(
+        db_engine,
+        status="cancelled",
+        best_score=97,
+    )
+    async with factory() as db:
+        n = await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+    assert n >= 1
+    assert await _status_memory(db_engine, doc_id) is None  # 不沉淀状态
+    async with factory() as db:
+        assert doc_id not in await PatrolMemoryStore(db).get_skip_doc_ids()  # 保持可被重新选中
+        routine = await db.get(Routine, routine_id)
+        assert routine.config.get("memory_persisted") is True  # 仍标记（避免每 tick 重扫）
+
+
+async def test_finalize_multiple_routines_same_doc_best_wins(db_engine):
+    """同 doc 两条终态 Routine（best_score 52 与 97）→ 最终 done(score=97)（ORDER BY best_score 最佳拟合胜出）。"""
+    doc_id = str(uuid.uuid4())
+    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=52, doc_id=doc_id)
+    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97, doc_id=doc_id)
+    factory = _sf(db_engine)
+    async with factory() as db:
+        await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+    row = await _status_memory(db_engine, doc_id)
+    assert row is not None and row.st == "done" and row.sc == "97"
+
+
+async def _seed_knowledge_pdf(db_engine, *, filename):
+    """落库一条 knowledge_documents（pdf + completed）；返回其 id。"""
+    from negentropy.config import settings
+    from negentropy.models.perception import KnowledgeDocument
+
+    factory = _sf(db_engine)
+    async with factory() as db:
+        doc = KnowledgeDocument(
+            app_name=settings.app_name,
+            file_hash=uuid.uuid4().hex,
+            original_filename=filename,
+            content_uri=f"pgblob://test/{uuid.uuid4().hex}",
+            content_type="application/pdf",
+            file_size=1024,
+            markdown_extract_status="completed",
+        )
+        db.add(doc)
+        await db.commit()
+        return doc.id
+
+
+async def test_select_advances_after_done(db_engine):
+    """端到端推进：把 A 标 done → _select_next_pending_doc 不再返回 A（推进生效，不再卡 A）。
+
+    用相对断言（``≠ A``）而非「== B」：测试库（``negentropy_test``）不跨 session 清空，全局
+    ``_select_next_pending_doc`` 可能命中前次遗留文档；核心是证明「已合格的 A 不再被选中」，
+    鲁棒于累积数据。B 仅用于保证「仍有 pending 文档」。
+    """
+    from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
+
+    factory = _sf(db_engine)
+    doc_a = await _seed_knowledge_pdf(db_engine, filename="patrol-advance-a.pdf")
+    await _seed_knowledge_pdf(db_engine, filename="patrol-advance-b.pdf")  # 保证至少一份 pending
+
+    # A 经一次终态 Routine 标 done
+    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97, doc_id=str(doc_a))
+    async with factory() as db:
+        await patrol._finalize_terminal_patrols(db)
+        await db.commit()
+
+    async with factory() as db:
+        skip = await PatrolMemoryStore(db).get_skip_doc_ids()
+        next_doc = await patrol._select_next_pending_doc(db, skip_ids=skip)
+    assert str(doc_a) in skip  # A 已 done → 进 skip_ids（推进核心信号）
+    assert next_doc is not None  # 仍有待检文档（B 或其它 pending）
+    assert str(next_doc["id"]) != str(doc_a)  # 推进：不再选中已合格的 A（修「始终卡 A」根因）
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：「PDF Fidelity Patrol」Scheduler 派生的 Routine 始终只拟合首份 PDF（Building Effective AI Coding Agents），处理后不标记合格、不推进到 Knowledge/Documents 中的下一份，陷入死循环。DB 实证：20+ Routine 全卡同一文档、全 failed/cancelled，`pdf-fidelity-status` 记忆 0 行。
- 关联上下文/根因：文档推进(`skip_ids`)耦合于 agent 契约自报 `done`/`unfixable`，但 Routine 常因 `no_progress`/`max_cost` 终止、末轮契约恒为 `progressing`，致文档永不进 `skip_ids`、每 tick 重新选中最早文档；且 `_finalize` 即便契约缺失/`progressing` 仍标 `memory_persisted=true`，永久不再重试。

# 核心变更
- **配置**：新增 `patrol_qualified_score_threshold`（默认 95），巡检 Routine 的 `success_score_threshold` 同步取此值——收敛(95+)即 SUCCESS，不再把本该成功的 Routine 误判为 Failed。
- **记忆层（SSOT）**：新增 `PatrolMemoryStore.persist_terminal_outcome` 确定性沉淀——契约自报 done 或 `best_score≥阈值` → done(合格)，否则 unfixable(尽力)，cancelled 不沉淀；保证每个终态 Routine 必推进其文档。抽取 `_extract_regions_and_patterns` 复用。
- **Handler**：重构 `_finalize_terminal_patrols` 用 `best_score` 兜底（契约缺失亦沉淀）、`cancelled` 显式跳过、`ORDER BY best_score ASC NULLS FIRST`（同文档多 Routine 最佳拟合胜出）、`score` 写权威峰值；抽 `_mark_memory_persisted`。
- **Prompt**：`build_goal` 注入已知 unfixable 区域避让清单（修复 `get_unfixable_regions` 只写不读的半失效）；`acceptance_criteria` 增显式评分指引，防收敛文档被评估器压分 <95。
- 历史数据按需求不动，由后续新 Routine（新逻辑）正确推进。

# 风险与回滚
- 主要风险：合格阈值 95 为新增默认值，个别文档此前或能冲更高分，现达 95 即 SUCCESS 提前结束（预期权衡：优先保证推进与收敛，避免死循环）。
- 回滚方式：还原本提交即可；阈值可经 `NE_ROUTINE_PATROL_QUALIFIED_SCORE_THRESHOLD` 环境变量或 YAML 调整（含调回 100）。

# 验证证据
- 单元测试：`test_patrol_memory.py`(+8 persist_terminal_outcome 用例)、`test_patrol_prompt.py`、`test_pdf_fidelity_patrol_handler.py`（白盒 `_finalize` 分支 + `success_score_threshold=95` 断言）全绿。
- 集成测试：`test_pdf_fidelity_patrol_integration.py` +7 推进闭环用例（progressing→推进、cancelled 不沉淀、同文档最佳拟合胜出、端到端推进）全绿，两次跑无 flaky。
- E2E/Workflow：相邻 routine 决策/评估器测试 52 用例无回归；ruff lint + format + pre-commit hooks 全绿。

# 影响范围
- 前端：无（`patrol-reason.ts` 既有 `no_pending_docs` 映射复用，无需改动）。
- 后端：`config/routine.py`、`config.default.yaml`、`engine/routine/patrol_memory.py`、`engine/routine/patrol_prompt.py`、`engine/schedulers/handlers/pdf_fidelity_patrol.py`。
- GitHub Actions / 文档：无。

# Next Best Action
- 部署后观察首个 tick：`task_executions.metrics.doc_id` 不再恒为 `4a43aba4`，后续 tick 依次推进至 Knowledge/Documents 中其余 PDF，直至全部达合格/尽力状态。
