### PR TITLE
fix(Patrol): 修复 PDF Fidelity Patrol 原始文件名兜底与同文档重复 Routine

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/convenience.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/convenience.py
@@ -545,6 +545,13 @@ async def run_pdf_pipeline(
     code_output = _unwrap(stage_results.get("code_detection"))
     assembly_output = _unwrap(stage_results.get("assembly"))
 
+    # PDF /Title 在预处理 Stage 已抽取（PreprocessingOutput.metadata["title"]）但历史在此被丢弃；
+    # 透传进 PipelineResult.metadata，供下游（文档标题回填 / 巡检命名）复用（Fix B1）。
+    _pdf_title = ""
+    if isinstance(preprocessing_output, PreprocessingOutput):
+        _raw_title = preprocessing_output.metadata.get("title")
+        _pdf_title = str(_raw_title).strip() if _raw_title else ""
+
     # 如果有 assembly 输出，直接使用
     if assembly_output and isinstance(assembly_output, AssemblyOutput):
         image_output_typed = (
@@ -590,7 +597,10 @@ async def run_pdf_pipeline(
             stage_results={
                 k: _serialize_stage_result(v) for k, v in stage_results.items()
             },
-            metadata=assembly_output.metadata,
+            metadata={
+                **assembly_output.metadata,
+                **({"title": _pdf_title} if _pdf_title else {}),
+            },
             image_assets=image_assets,
         )
 
@@ -603,6 +613,7 @@ async def run_pdf_pipeline(
             success=True,
             markdown=text_output.full_text,
             word_count=text_output.word_count,
+            metadata={"title": _pdf_title} if _pdf_title else {},
             characteristics=(
                 preprocessing_output.characteristics
                 if isinstance(preprocessing_output, PreprocessingOutput)

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -134,9 +134,12 @@ async def _run_patrol_tick(*, task_key: str) -> HandlerResult:
             )
         finalized = await _finalize_terminal_patrols(db)
         propagated = await _propagate_patrol_outcomes(db)
+        collapsed = await _collapse_superseded_patrols(db)
         await db.commit()
         if propagated:
             logger.info("patrol_outcomes_propagated", count=propagated)
+        if collapsed:
+            logger.info("patrol_superseded_collapsed", count=collapsed)
 
     # 跳过并发（独立短事务，避免长读）
     async with AsyncSessionLocal() as db:
@@ -447,6 +450,67 @@ async def _propagate_patrol_outcomes(db) -> int:
 
 
 # ---------------------------------------------------------------------------
+# 收敛「一文一巡检」：取消冗余/原始文件名兜底的终态巡检 Routine（去重 + 改名自愈）
+# ---------------------------------------------------------------------------
+
+
+async def _collapse_superseded_patrols(db) -> int:
+    """收敛「一文一巡检」：每 doc 至多保留一条终态巡检 Routine，余者（冗余 / 原始文件名兜底）取消。
+
+    背景：历史 ``_select_next_pending_doc`` 缺一文一巡检守卫，**失败的巡检不落 done/unfixable
+    记忆即被重选**，致同一 doc 累积大量 failed Routine（实证：单 doc 可达十余条，全部 max_cost /
+    no_progress 失败）；且文档改名前创建的 Routine 名字兜底成 ``original_filename``（如
+    ``2603.05344v3.pdf``）。本函数在 tick 开头收敛历史脏数据，与 Fix A（NOT EXISTS 防新增）配合
+    达成「一文一活跃巡检」不变量。
+
+    规则（仅作用于**终态** succeeded/failed Routine，绝不触碰 running/paused——不中断在跑任务）：
+      - 每 doc 按「非原始名优先 → succeeded 优先 → 最新优先」排序，**保留 rank 1**，取消其余（冗余）。
+      - 文档已有更优名源（``display_name`` 或 ``metadata->>'title'``）时，其「原始文件名兜底」Routine
+        即便 rank 1 也取消——下一 tick 以更优名重建（自愈）；无更优名源时保留 rank 1（原始名为其
+        当前最佳可用名，待用户改名 / Fix B 回填标题后自愈）。
+
+    **保留一条终态 Routine 是防重试死循环的必要条件**：否则 NOT EXISTS 放行 → 重巡 → 失败 →
+    再取消 → 再重巡……无限循环。取消而非删除以保留审计轨迹（routine_iterations/events 随 routine
+    CASCADE 删除）；``outcome_propagated=true`` 阻止被取消的冗余 Routine 回写 ScheduledTask 聚合态
+    （聚合态以保留的那条为准）。幂等：仅作用于非 cancelled 终态行。返回取消条数。
+    """
+    result = await db.execute(
+        sa.text(
+            "WITH ranked AS ("
+            "  SELECT r.id,"
+            "    ROW_NUMBER() OVER ("
+            "      PARTITION BY r.config->>'doc_id'"
+            "      ORDER BY"
+            "        CASE WHEN r.title = ('PDF 高保真巡检：' || kd.original_filename)"
+            "              OR r.display_name = ('PDF Fidelity Patrol · ' || kd.original_filename)"
+            "             THEN 1 ELSE 0 END,"
+            "        CASE WHEN r.status = 'succeeded' THEN 0 ELSE 1 END,"
+            "        r.created_at DESC"
+            "    ) AS rn,"
+            "    CASE WHEN COALESCE(NULLIF(kd.display_name, ''), NULLIF(kd.metadata->>'title', '')) IS NOT NULL"
+            "         THEN 1 ELSE 0 END AS has_name,"
+            "    CASE WHEN r.title = ('PDF 高保真巡检：' || kd.original_filename)"
+            "          OR r.display_name = ('PDF Fidelity Patrol · ' || kd.original_filename)"
+            "         THEN 1 ELSE 0 END AS is_raw"
+            "  FROM negentropy.routines r"
+            "  JOIN negentropy.knowledge_documents kd ON kd.id::text = r.config->>'doc_id'"
+            "  WHERE r.config->>'patrol' = 'true'"
+            "    AND r.status IN ('succeeded', 'failed')"
+            ") "
+            "UPDATE negentropy.routines "
+            "SET status = 'cancelled', termination_reason = 'superseded_patrol', "
+            "    config = COALESCE(config, '{}'::jsonb) || jsonb_build_object('outcome_propagated', true) "
+            "WHERE id IN ("
+            "  SELECT id FROM ranked"
+            "  WHERE rn > 1"
+            "     OR (has_name = 1 AND is_raw = 1)"
+            ")"
+        )
+    )
+    return result.rowcount or 0
+
+
+# ---------------------------------------------------------------------------
 # 并发跳过
 # ---------------------------------------------------------------------------
 
@@ -464,7 +528,20 @@ async def _has_running_patrol(db) -> bool:
 
 
 async def _select_next_pending_doc(db, *, skip_ids: set[str]) -> dict[str, Any] | None:
-    """选最早入库、未 done/unfixable 的 PDF 文档（content_type=pdf 且转换已完成）。"""
+    """选最早入库、未 done/unfixable 的 PDF 文档（content_type=pdf 且转换已完成）。
+
+    两道守卫（缺一不可）：
+      - **命名门控**：``display_name`` 或 ``metadata->>'title'`` 至少有一个非空，否则跳过。
+        巡检 Routine 名字在创建时刻定格（``_doc_display_title`` 三级解析），无更优名源时会兜底成
+        ``original_filename``（如 ``2603.05344v3.pdf``）——本门控从源头杜绝「原始文件名兜底」巡检。
+        新导入经 Fix B（Perceives 标题透传 + 回填）自动获得 ``metadata.title``；存量无标题文档待
+        用户改名 / 重新抽取后入选（绝不以原始文件名兜底发起巡检）。
+      - **一文一活跃巡检**（Fix A）：``NOT EXISTS`` 排除已有**非 cancelled** 巡检 Routine 的文档
+        （``config->>'doc_id'`` 为 SSOT 指针）。排除 cancelled 使「取消」成为合法复位——被取消的冗余
+        Routine 不再阻塞同 doc 以当前有效名重建（见 ``_collapse_superseded_patrols``）。
+
+    与 ``skip_ids``（done/unfixable 终态语义）正交互补。
+    """
     params: dict[str, Any] = {"app": settings.app_name}
     exclude_clause = ""
     if skip_ids:
@@ -477,6 +554,13 @@ async def _select_next_pending_doc(db, *, skip_ids: set[str]) -> dict[str, Any] 
         "WHERE app_name = :app "
         "AND COALESCE(content_type,'') ILIKE '%pdf%' "
         "AND markdown_extract_status = 'completed' "
+        "AND COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL "
+        "AND NOT EXISTS ("
+        "  SELECT 1 FROM negentropy.routines r "
+        "  WHERE r.config->>'patrol' = 'true' "
+        "  AND r.config->>'doc_id' = knowledge_documents.id::text "
+        "  AND r.status <> 'cancelled'"
+        ") "
         f"{exclude_clause} "
         "ORDER BY created_at ASC LIMIT 1"
     )

--- a/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
+++ b/apps/negentropy/src/negentropy/knowledge/ingestion/extraction.py
@@ -2886,6 +2886,16 @@ async def store_extracted_document_artifacts(
         markdown_content=rewritten_markdown,
         markdown_uri=markdown_uri,
     )
+    # 回填 PDF 自动抽取的标题进 knowledge_documents.metadata（Fix B2）。
+    # 历史仅 URL-sync 路径回填 title；文件导入路径丢失标题，致巡检命名兜底成原始文件名
+    # （如 2603.05344v3.pdf）。对齐 knowledge/service.py 的 URL-sync 回填口径；空白不回填，
+    # 失败不阻断导入（标题为附加增强，markdown 已先行落库）。
+    _title = str((extracted.metadata or {}).get("title") or "").strip()
+    if _title:
+        try:
+            await storage_service.update_document_metadata(document_id=document_id, metadata_patch={"title": _title})
+        except Exception:  # noqa: BLE001
+            logger.warning("backfill_document_title_failed", document_id=str(document_id))
     stored_assets = await persist_extracted_assets(
         document_id=document_id,
         assets=extracted.assets,

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -20,10 +20,11 @@ from negentropy.engine.schedulers.handlers import pdf_fidelity_patrol as patrol
 
 
 class _FakeResult:
-    def __init__(self, *, fetchone: Any = None, fetchall: Any = None, scalar: Any = None) -> None:
+    def __init__(self, *, fetchone: Any = None, fetchall: Any = None, scalar: Any = None, rowcount: int = 0) -> None:
         self._fetchone = fetchone
         self._fetchall = fetchall
         self._scalar = scalar
+        self.rowcount = rowcount
 
     def fetchone(self):  # noqa: ANN201
         return self._fetchone
@@ -128,6 +129,55 @@ def test_select_next_pending_doc_skip_set_passes_expanding_param():
     _stmt, params = db.executed[0]
     assert params["app"]  # 含 app_name 绑定
     assert "skip" in params
+
+
+def test_select_next_pending_doc_sql_contains_per_doc_uniqueness_guard():
+    """Fix A + 命名门控：emitted SQL 必含「命名门控」+「一文一活跃巡检」NOT EXISTS 守卫（排除 cancelled）。
+
+    FakeDB 不解析 SQL，仅以串存在性守护不变量防回归——后续重构若误删命名门控 / NOT EXISTS /
+    把 cancelled 纳入阻塞，本断言即失败。真实 SQL 语义由集成测试覆盖。
+    """
+    import asyncio
+
+    db = _FakeDB(fetchone=None)
+    asyncio.run(patrol._select_next_pending_doc(db, skip_ids=set()))
+    stmt = db.executed[0][0]
+    # 命名门控：display_name 或 metadata->>'title' 至少一个非空（杜绝原始文件名兜底）
+    assert "COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL" in stmt
+    assert "NOT EXISTS" in stmt
+    assert "config->>'patrol'" in stmt
+    assert "config->>'doc_id'" in stmt
+    assert "status <> 'cancelled'" in stmt  # cancelled 排除（取消即复位）
+
+
+# ---------------------------------------------------------------------------
+# _collapse_superseded_patrols：收敛「一文一巡检」（去重 + 原始文件名兜底自愈）
+# ---------------------------------------------------------------------------
+
+
+def test_collapse_superseded_patrols_emits_dedupe_update():
+    """Fix C：发射一条「一文一巡检」去重 UPDATE（CTE 排序保留 rank 1），关键片段就位且返回 rowcount。
+
+    FakeDB 不解析 SQL；以串存在性守护不变量防回归——保留 rank 1（非原始名/succeeded/最新优先）、
+    取消 rn>1 冗余 + has_name&is_raw（有更优名源时的原始文件名兜底）。真实语义见集成测试。
+    """
+    import asyncio
+
+    db = _FakeDB(rowcount=3)
+    n = asyncio.run(patrol._collapse_superseded_patrols(db))
+    assert n == 3
+    assert len(db.executed) == 1
+    stmt = db.executed[0][0]
+    assert "WITH ranked" in stmt  # CTE 排序选保留项
+    assert "ROW_NUMBER()" in stmt
+    assert "PARTITION BY r.config->>'doc_id'" in stmt  # 按 doc 分组
+    assert "status IN ('succeeded', 'failed')" in stmt  # 仅终态（不触碰 running/paused）
+    assert "UPDATE negentropy.routines" in stmt
+    assert "status = 'cancelled'" in stmt
+    assert "superseded_patrol" in stmt
+    assert "outcome_propagated" in stmt  # 不回写 ScheduledTask 聚合态
+    assert "rn > 1" in stmt  # 取消冗余
+    assert "has_name = 1 AND is_raw = 1" in stmt  # 有更优名源时取消原始文件名兜底
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -439,7 +439,11 @@ async def test_finalize_multiple_routines_same_doc_best_wins(db_engine):
 
 
 async def _seed_knowledge_pdf(db_engine, *, filename):
-    """落库一条 knowledge_documents（pdf + completed）；返回其 id。"""
+    """落库一条 knowledge_documents（pdf + completed）；返回其 id。
+
+    带 ``display_name``：命名门控（``_select_next_pending_doc``）要求文档至少有 display_name
+    或 metadata.title 之一，否则被跳过——测试文档须具名才可被选中（测试的是推进逻辑，非命名）。
+    """
     from negentropy.config import settings
     from negentropy.models.perception import KnowledgeDocument
 
@@ -449,6 +453,7 @@ async def _seed_knowledge_pdf(db_engine, *, filename):
             app_name=settings.app_name,
             file_hash=uuid.uuid4().hex,
             original_filename=filename,
+            display_name=filename,
             content_uri=f"pgblob://test/{uuid.uuid4().hex}",
             content_type="application/pdf",
             file_size=1024,

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -15,9 +15,10 @@ import time
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from negentropy.config import settings
 from negentropy.engine.schedulers import registry as registry_mod
 from negentropy.engine.schedulers.handlers import (
     PATROL_LIFECYCLE_IDLE,
@@ -28,6 +29,7 @@ from negentropy.engine.schedulers.handlers import (
 from negentropy.engine.schedulers.handlers import (
     pdf_fidelity_patrol as patrol,
 )
+from negentropy.models.perception import KnowledgeDocument
 from negentropy.models.plugin_common import PluginVisibility
 from negentropy.models.repository import Repository
 from negentropy.models.routine import Routine, RoutineIteration
@@ -582,3 +584,178 @@ async def test_finalize_normal_ok_resets_failures(db_engine, monkeypatch):
         assert t.last_status == "ok"
         assert t.last_error is None  # ok 覆盖
         assert t.consecutive_failures == 0  # 清零
+
+
+# ---------------------------------------------------------------------------
+# Fix A / Fix C：一文一活跃巡检守卫 + 取消原始文件名冗余 Routine（真实 PG）
+# ---------------------------------------------------------------------------
+
+
+async def _seed_pdf_document(
+    db_engine,
+    *,
+    original_filename: str = "spec.pdf",
+    display_name: str | None = None,
+    metadata_title: str | None = None,
+):
+    """落库一条 library PDF 文档（markdown_extract_status=completed）；返回 doc_id。"""
+    factory = _sf(db_engine)
+    async with factory() as db:
+        doc = KnowledgeDocument(
+            app_name=settings.app_name,
+            file_hash=uuid.uuid4().hex,
+            original_filename=original_filename,
+            content_uri=f"pgblob://test/{uuid.uuid4().hex}",
+            content_type="application/pdf",
+            file_size=1024,
+            status="active",
+            markdown_extract_status="completed",
+            display_name=display_name,
+            metadata_={"title": metadata_title} if metadata_title else {},
+        )
+        db.add(doc)
+        await db.commit()
+        return doc.id
+
+
+async def _seed_patrol_routine(
+    db_engine,
+    *,
+    doc_id,
+    title: str,
+    display_name: str,
+    status: str = "running",
+):
+    """落库一条绑定 doc_id 的巡检 Routine（最小必填字段 + patrol/doc_id 指针）；返回 routine_id。"""
+    factory = _sf(db_engine)
+    async with factory() as db:
+        routine = Routine(
+            key=f"pdf-fidelity-patrol/{doc_id}/{uuid.uuid4().hex[:8]}",
+            title=title,
+            display_name=display_name,
+            goal="patrol-test",
+            acceptance_criteria="patrol-test",
+            status=status,
+            config={"patrol": True, "doc_id": str(doc_id)},
+            owner_id="system",
+        )
+        db.add(routine)
+        await db.commit()
+        return routine.id
+
+
+async def _completed_pdf_doc_ids(db_engine) -> set[str]:
+    """当前 app 下所有 completed PDF 文档 id（构造 skip_ids 隔离被测文档，规避 created_at 排序串扰）。"""
+    factory = _sf(db_engine)
+    async with factory() as db:
+        rows = await db.execute(
+            text(
+                "SELECT id::text FROM negentropy.knowledge_documents "
+                "WHERE app_name = :app "
+                "AND COALESCE(content_type, '') ILIKE '%pdf%' "
+                "AND markdown_extract_status = 'completed'"
+            ).bindparams(app=settings.app_name)
+        )
+        return {r[0] for r in rows.fetchall()}
+
+
+async def test_select_next_pending_doc_one_active_patrol_per_doc_and_cancel_relets(db_engine):
+    """Fix A：已有非 cancelled 巡检 Routine 的文档不被重选；该 Routine cancelled 后重新入选（自愈复位）。"""
+    factory = _sf(db_engine)
+    doc_id = await _seed_pdf_document(db_engine, original_filename="guard.pdf", display_name="Guard Doc")
+    others = (await _completed_pdf_doc_ids(db_engine)) - {str(doc_id)}  # 隔离：仅被测 doc 为候选
+
+    # 1) 无巡检 → 被测 doc 可选
+    async with factory() as db:
+        doc = await patrol._select_next_pending_doc(db, skip_ids=others)
+    assert doc is not None and str(doc["id"]) == str(doc_id)
+
+    # 2) 建活跃巡检 → NOT EXISTS 阻塞被测 doc
+    await _seed_patrol_routine(
+        db_engine,
+        doc_id=doc_id,
+        title="PDF 高保真巡检：guard.pdf",
+        display_name="PDF Fidelity Patrol · guard.pdf",
+        status="running",
+    )
+    async with factory() as db:
+        doc = await patrol._select_next_pending_doc(db, skip_ids=others)
+    assert doc is None or str(doc["id"]) != str(doc_id)
+
+    # 3) 取消该巡检 → cancelled 排除 → 被测 doc 重新入选（自愈）
+    async with factory() as db:
+        await db.execute(
+            text(
+                "UPDATE negentropy.routines SET status = 'cancelled' "
+                "WHERE config->>'patrol' = 'true' AND config->>'doc_id' = :did"
+            ).bindparams(did=str(doc_id))
+        )
+        await db.commit()
+    async with factory() as db:
+        doc = await patrol._select_next_pending_doc(db, skip_ids=others)
+    assert doc is not None and str(doc["id"]) == str(doc_id)
+
+
+async def test_collapse_superseded_patrols_cancels_raw_keeps_corrected(db_engine):
+    """Fix C：取消「原始文件名兜底」的终态 Routine；非终态（running）修正名 Routine 不被触碰。"""
+    factory = _sf(db_engine)
+    doc_id = await _seed_pdf_document(db_engine, original_filename="raw.pdf", display_name="Real Title")
+    raw_id = await _seed_patrol_routine(
+        db_engine,
+        doc_id=doc_id,
+        title="PDF 高保真巡检：raw.pdf",
+        display_name="PDF Fidelity Patrol · raw.pdf",
+        status="succeeded",
+    )
+    good_id = await _seed_patrol_routine(
+        db_engine,
+        doc_id=doc_id,
+        title="PDF 高保真巡检：Real Title",
+        display_name="PDF Fidelity Patrol · Real Title",
+        status="running",  # 非终态 → 不得被收敛触碰（不中断在跑任务）
+    )
+
+    async with factory() as db:
+        collapsed = await patrol._collapse_superseded_patrols(db)
+        await db.commit()
+    assert collapsed >= 1
+
+    async with factory() as db:
+        raw = await db.get(Routine, raw_id)
+        good = await db.get(Routine, good_id)
+    assert raw.status == "cancelled"
+    assert raw.termination_reason == "superseded_patrol"
+    assert good.status == "running"  # 非终态修正名 Routine 保留
+
+
+async def test_collapse_superseded_patrols_collapses_surplus_to_one(db_engine):
+    """Fix C：同 doc 多条终态 Routine 收敛为恰好一条（防失败重选累积 + 防重试死循环）。"""
+    factory = _sf(db_engine)
+    doc_id = await _seed_pdf_document(db_engine, original_filename="surplus.pdf", display_name="Surplus Title")
+    # 三条同 doc 的修正名终态 Routine（模拟历史失败重选累积）
+    for _ in range(3):
+        await _seed_patrol_routine(
+            db_engine,
+            doc_id=doc_id,
+            title="PDF 高保真巡检：Surplus Title",
+            display_name="PDF Fidelity Patrol · Surplus Title",
+            status="failed",
+        )
+
+    async with factory() as db:
+        collapsed = await patrol._collapse_superseded_patrols(db)
+        await db.commit()
+    assert collapsed >= 2  # 3 → 1，至少取消 2
+
+    async with factory() as db:
+        remaining = (
+            await db.execute(
+                text(
+                    "SELECT count(*) FROM negentropy.routines "
+                    "WHERE config->>'patrol' = 'true' "
+                    "AND config->>'doc_id' = :did "
+                    "AND status <> 'cancelled'"
+                ).bindparams(did=str(doc_id))
+            )
+        ).scalar()
+    assert remaining == 1  # 恰好保留一条（防重试死循环）


### PR DESCRIPTION
## 背景

用户在 Routine 列表发现同一份文档（`2603.05344v3.pdf`）同时存在两条巡检 Routine：原始文件名兜底的 `PDF Fidelity Patrol · 2603.05344v3.pdf`（冗余）与修正名 `PDF Fidelity Patrol · Building Effective AI Coding Agents…`。要求：① 不该出现冗余/重复；② 巡检命名全局统一用「Documents 页修正后的 File Name」，永不用 Knowledge Documents 原始文件名。

## 根因（循证，三因子叠加）

只读复核生产库 `negentropy` 实证：单文档 `4a43…` 累积 **十余条 failed Routine**（全 `max_cost` / `no_progress` 失败），改名前的用原始名、改名后的用修正名。三因子：

1. **缺「一文一巡检」不变量**：`_select_next_pending_doc` 仅按 `skip_ids`（done/unfixable 记忆）排除；而该记忆只在巡检产出可解析 `pdf-fidelity-contract` 时才沉淀。**失败的巡检不落记忆即被重选** → 下一 tick 再建一条 → 无限累积。Routine `key` 带随机后缀，DB 唯一约束也抓不到同文档重复。
2. **命名在创建时刻定格**：`_doc_display_title` 三级解析 `display_name → metadata->>'title' → original_filename`。文件上传 PDF 的 `display_name` 建表即 NULL。
3. **PDF 标题被 Perceives 抽取后又丢弃**：预处理已读 `/Title`（`PreprocessingOutput.metadata["title"]`），但 `run_pdf_pipeline` 装配 `PipelineResult.metadata` 时只取 `assembly_output.metadata`（无 title）→ 文件导入永不回填 `metadata.title`（仅 URL-sync 路径回填）→ 首发巡检无 `display_name` 即兜底成 `2603.05344v3.pdf`。

## 修复

- **Fix A · 一文一活跃巡检守卫**（`pdf_fidelity_patrol.py`）：`_select_next_pending_doc` 增 `NOT EXISTS` 子查询，排除已有**非 cancelled**巡检 Routine 的文档（`config->>'doc_id'` 为 SSOT 指针）。排除 cancelled 使「取消」成为合法复位（自愈重巡）。
- **命名门控**：同函数增 `display_name` 或 `metadata->>'title'` 至少一非空的条件——从源头杜绝原始文件名兜底巡检。新导入经 Fix B 自动获 `metadata.title`；存量无标题文档待用户改名 / 重新抽取后入选。
- **Fix B1（`negentropy-perceives/…/convenience.py`）**：主路径与降级路径把 `preprocessing_output.metadata` 的 `title` 透传进 `PipelineResult.metadata`（仅追加 title，不覆盖装配统计）。
- **Fix B2（`extraction.py`）**：`store_extracted_document_artifacts` 在 Markdown 落库后回填 `metadata.title`（对齐 URL-sync 口径，失败不阻断导入）。
- **Fix C · 历史冗余收敛**（`pdf_fidelity_patrol.py`）：新增 `_collapse_superseded_patrols`，tick 开头收敛——每 doc 至多保留一条**终态**（succeeded/failed）巡检（非原始名 → succeeded → 最新优先），取消冗余与原始文件名兜底。仅作用于终态（绝不触碰 running）；保留一条是**防重试死循环**的必要条件；`outcome_propagated=true` 不污染 ScheduledTask 聚合态。

## 验证

- 只读复核生产库：`4a43…` 文档 ~13 条 failed Routine（改名前原始名 + 改名后修正名），`7f7d…`（同名 PDF 重复行，无标题，0 Routine）。
- 单测 `test_pdf_fidelity_patrol_handler.py`（FakeDB 捕 SQL）：增命名门控 / NOT EXISTS / cancelled 排除 / 收敛 CTE 的串存在性断言。
- 集成测 `test_pdf_fidelity_patrol_integration.py`（真实 PG）：增①一文一活跃守卫 + cancelled 重入选自愈；②原始名取消、修正名保留；③冗余收敛至恰好一条。
- `uv run pytest tests/unit_tests/engine/`（1014 passed）+ knowledge 抽取相关（143 passed）+ perceives 管线（35 passed）。

## 部署注意

- live 引擎自主仓 checkout 运行，**需部署本 PR 后 Fix C 才会在下一 tick 自动收敛** `4a43…` 的十余条冗余 Routine；部署前旧 handler 仍可能对无标题文档 `7f7d…` 发起原始名巡检，建议尽快合入。
- 存量 2 个无标题文档（`7f7d…` 重复行、`6c2b…` Loop-Engineering-IEEE.pdf）被命名门控跳过，待改名 / 重新抽取获标题后入选（如需全自动可后续加一次性标题回填任务）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>