### PR TITLE
fix(Routine): Clean Up 须先 hydrate Repository 派生 cwd，否则 git worktree/分支清理被静默跳过;

### DIFF
--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -458,6 +458,10 @@ class RoutineOrchestrator:
                 .scalars()
                 .all()
             )
+            # Repository 型 routine 的 cwd 列为 NULL——会话内先 hydrate 有效仓库根，否则会话外 remove_worktree
+            # 找不到仓库、git worktree remove / branch -D 被静默跳过（worktree/分支残留）。
+            for r in rows:
+                await self._hydrate_effective_repo(db, r)
         # ② 会话外：逐个 best-effort 回收（纯 git/FS、无 DB；不占连接、不阻塞事件循环）。
         for r in rows:
             with suppress(Exception):

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -42,6 +42,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm.attributes import set_committed_value
 
 import negentropy.db.session as db_session
 from negentropy.config import settings
@@ -641,6 +642,24 @@ async def _resolve_repository(db, repository_id: UUID | None) -> Repository | No
     return repo
 
 
+async def _hydrate_effective_repo(db, r: Routine) -> None:
+    """把关联 Repository 的 local_path/baseline 注入内存 routine（单一事实源，不持久化）。
+
+    镜像 ``orchestrator._hydrate_effective_repo``：Repository 型 routine 的 ``cwd`` **列**恒为 NULL
+    （仅持 ``repository_id`` 指针、DB 不存副本），而 ``remove_worktree`` 读 ``routine.cwd`` 定位仓库根跑
+    ``git worktree remove`` / ``branch -D``——须先 hydrate，否则 git 块被静默跳过、worktree/分支残留。
+    ``set_committed_value`` 标记「已加载」、不进 dirty、不持久化（维持单一事实源；detached 后仍可读）。
+    """
+    if r.repository_id is None:
+        return
+    repository = await db.get(Repository, r.repository_id)
+    if repository is None:
+        return
+    eff_cwd, eff_baseline = workspace.resolve_effective_repo(r, repository)
+    set_committed_value(r, "cwd", eff_cwd)
+    set_committed_value(r, "baseline_branch", eff_baseline)
+
+
 async def _validate_effective_repo(eff_cwd: str | None, eff_baseline: str | None) -> None:
     """二者皆有值时即时校验仓库/基线（非法转 422）。允许草稿态暂缺其一。"""
     if eff_cwd and eff_baseline:
@@ -796,6 +815,7 @@ async def delete_routine(routine_id: UUID) -> dict[str, Any]:
             raise HTTPException(status_code=404, detail="routine not found")
         if r.status in _ACTIVE:
             raise HTTPException(status_code=409, detail=f"cannot delete a {r.status} routine; cancel it first")
+        await _hydrate_effective_repo(db, r)  # 同 cleanup_worktree：hydrate 仓库根，防 git 清理被跳过
     # ② 会话外：删除前回收隔离 worktree（行将消失，无论策略均须清，避免孤儿；best-effort；不占连接、不阻塞事件循环）。
     if r.worktree_path:
         with suppress(Exception):
@@ -999,6 +1019,9 @@ async def cleanup_worktree(routine_id: UUID) -> dict[str, Any]:
             )
         if not r.worktree_path:
             raise HTTPException(status_code=409, detail="worktree already cleaned up or never created")
+        # Repository 型 routine 的 cwd 列为 NULL——hydrate 有效仓库根，否则 remove_worktree 找不到仓库、
+        # git worktree remove / branch -D 被静默跳过（worktree/分支残留）。
+        await _hydrate_effective_repo(db, r)
     # ② 会话外：best-effort 回收（expire_on_commit=False → r 已 detached 但属性可读；纯 git/FS，无 DB）。
     with suppress(Exception):
         await workspace.remove_worktree(r, settings.routine)

--- a/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import uuid
 from datetime import UTC, datetime
@@ -25,6 +26,8 @@ from sqlalchemy import delete, func, select
 
 import negentropy.db.session as db_session
 from negentropy.interface.routine_api import router
+from negentropy.models.plugin_common import PluginVisibility
+from negentropy.models.repository import Repository
 from negentropy.models.routine import Routine, RoutineIteration, RoutineIterationEvent
 
 pytestmark = pytest.mark.asyncio
@@ -560,3 +563,84 @@ async def test_runtime_safe_fields_update_while_running(git_repo):
             assert res.json()["goal"] == "paused goal"
     finally:
         await _cleanup("itest_api_")
+
+
+# ---------------------------------------------------------------------------
+# cleanup-worktree：Repository 型 routine 须 hydrate 仓库根才能真正清理（回归）
+# ---------------------------------------------------------------------------
+
+
+async def test_cleanup_worktree_hydrates_repository_and_removes_branch(git_repo, tmp_path):
+    """Repository 型 routine（cwd 列 NULL）的 cleanup-worktree 须 hydrate 仓库根，真正执行
+    git worktree remove + 删本地工作分支。
+
+    回归：修复前 ``remove_worktree`` 读 ``routine.cwd``（DB 列）= NULL → git 块整段被跳过，
+    worktree 仍在 repo 注册、工作分支残留（即"没清理干净"）。
+    """
+    key = _key()
+    work_branch = f"routine/itest-{uuid.uuid4().hex[:8]}"
+    wt_path = str(tmp_path / "wt")
+    # 预置真实 worktree + 工作分支（模拟引擎派发产物）
+    subprocess.run(["git", "-C", git_repo, "worktree", "add", "-b", work_branch, wt_path, "main"], check=True)
+    assert (
+        subprocess.run(
+            ["git", "-C", git_repo, "rev-parse", "--verify", "--quiet", f"refs/heads/{work_branch}"]
+        ).returncode
+        == 0
+    )
+
+    app = _app()
+    repo_id = None
+    try:
+        # Repository（local_path=git_repo）+ 终态 Routine（repository_id 指针；cwd 列 NULL，复现 bug 条件）
+        async with db_session.AsyncSessionLocal() as db:
+            repo = Repository(
+                owner_id="itest",
+                visibility=PluginVisibility.PRIVATE,
+                name=key,
+                github_url="https://example.invalid/itest",
+                local_path=git_repo,
+                baseline_branch="main",
+            )
+            db.add(repo)
+            await db.commit()
+            await db.refresh(repo)
+            repo_id = repo.id
+            r = Routine(
+                key=key,
+                title="T",
+                goal="g",
+                acceptance_criteria="a",
+                status="succeeded",
+                repository_id=repo.id,
+                cwd=None,
+                baseline_branch=None,
+                worktree_path=wt_path,
+                work_branch=work_branch,
+            )
+            db.add(r)
+            await db.commit()
+            rid = str(r.id)
+
+        async with _client(app) as c:
+            resp = await c.post(f"/routines/{rid}/cleanup-worktree")
+            assert resp.status_code == 200, resp.text
+
+        # worktree 目录已删
+        assert not os.path.isdir(wt_path)
+        # git worktree 注册已清除（修复前残留）
+        wt_list = subprocess.run(["git", "-C", git_repo, "worktree", "list"], capture_output=True, text=True).stdout
+        assert wt_path not in wt_list
+        # 本地工作分支已删（修复前残留）
+        rc = subprocess.run(
+            ["git", "-C", git_repo, "rev-parse", "--verify", "--quiet", f"refs/heads/{work_branch}"]
+        ).returncode
+        assert rc != 0
+    finally:
+        await _cleanup("itest_api_")
+        if repo_id is not None:
+            async with db_session.AsyncSessionLocal() as db:
+                await db.execute(delete(Repository).where(Repository.id == repo_id))
+                await db.commit()
+        subprocess.run(["git", "-C", git_repo, "worktree", "prune"], capture_output=True)
+        subprocess.run(["git", "-C", git_repo, "branch", "-D", work_branch], capture_output=True)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：对 Routine（尤以经 API 用 `repository_id` 创建的「Repository 型」routine）执行 Clean Up 后，**git worktree 未从 repo 注销、本地工作分支也未删除**——即"没清理干净"。
- 根因：Routine 模型为单一事实源，**只存 `repository_id` 指针、DB 不存 `cwd`/`baseline_branch` 副本**（`models/routine.py:71-74`；`orchestrator._hydrate_effective_repo` 注释明言"不进 dirty、不持久化"）。有效 `cwd` 仅在 dispatch 时经 `_hydrate_effective_repo` **注入内存**。但 `cleanup_worktree`/`delete_routine`/`_reap_workspaces` 调用 `remove_worktree` 前未 hydrate → `remove_worktree` 读 `routine.cwd`（DB 列）= **NULL** → `if project_path and os.path.isdir(project_path)` 为假 → **整个 git 块被静默跳过**（无 `git worktree remove`/`prune`/`branch -D`），只剩 rmtree 兜底删目录 → worktree 注册残留 + 工作分支残留。
- 与 #1002 关系：#1002（已合并）解决的是"Clean Up 阻塞全站"；本 PR 解决的是"Clean Up 没清干净"。两者独立——本缺口先于 #1002 存在（#1002 的会话/线程池改动不改变 `remove_worktree` 读到的 cwd 值，已逐行核对）。

# 核心变更
- **`routine_api.py`**：新增 `_hydrate_effective_repo(db, r)`（镜像 `orchestrator._hydrate_effective_repo`，`repository_id` 非空则取 Repository、用 `workspace.resolve_effective_repo` 把有效 `cwd`/`baseline` 经 `set_committed_value` 注入内存对象——不持久化，维持单一事实源）；在 `cleanup_worktree`、`delete_routine` 的读校验会话内调用。
- **`orchestrator.py`**：`_reap_workspaces` 在拉取待清理 routine 后、会话关闭前，逐行 `self._hydrate_effective_repo(db, r)`（巡检器此前同样漏 hydrate）。
- 三处 hydrate 后，`remove_worktree`（detached 对象）拿到真实仓库根，`git worktree remove --force` + `prune` + `branch -D` 正常执行。

# 风险与回滚
- 主要风险：低。仅新增"读校验会话内按 repository_id 取 Repository 并注入内存 cwd"（与 dispatch 路径 `_hydrate_effective_repo` 同构、不持久化）；不改变清理的 git/rmtree 步骤、best-effort/幂等、DB 一致性与既有顺序。
- 回滚方式：`git revert de7d40f2`。

# 验证证据
- 单元测试：N/A。
- 集成测试：新增 `test_cleanup_worktree_hydrates_repository_and_removes_branch`（真实 Postgres + ASGI）——建 Repository + 终态 Routine（cwd 列 NULL）+ 真实 worktree，调 `cleanup-worktree`，断言 worktree 目录删除、`git worktree list` 无残留、本地工作分支已删。**已验证有齿**：临时禁用 hydrate → 测试 FAIL（worktree 注册残留、显示 "prunable"）；恢复 → PASS。`test_routine_api.py` 全套 12 项绿。
- E2E/Workflow：待 live 实操（部署后对 Repository 型 routine 触发 Clean Up，确认 `git worktree list` / `git branch` 干净）。
- 覆盖率/关键截图：`uv run pytest` 通过；ruff lint/format 通过；pre-commit 全部 hook 通过。

# 影响范围
- 前端：无。
- 后端：`apps/negentropy` 的 routine worktree 清理链路（`interface/routine_api.py` 的 `cleanup_worktree`/`delete_routine`、`engine/routine/orchestrator.py` 的 `_reap_workspaces`）。
- GitHub Actions / 文档：无。

# Next Best Action
- 部署后 live 实操验证（Repository 型 routine Clean Up → worktree/分支真正清除）。顺带：`delete_routine` 与巡检 `_reap_workspaces` 的同源缺口已一并修复，可一并回归。
