### PR TITLE
fix(Routine): 巡检被 no_progress 假阳性误杀——decide 停滞判定补分数容差带

### DIFF
--- a/apps/negentropy/src/negentropy/engine/routine/decision.py
+++ b/apps/negentropy/src/negentropy/engine/routine/decision.py
@@ -102,6 +102,7 @@ def decide(
     now: datetime | None = None,
     max_context_resets: int = 0,
     accept_verdict_pass: bool = False,
+    no_progress_score_tolerance: int = 0,
 ) -> Decision:
     """评估后的核心决策：成功 / 终止 / 继续。
 
@@ -120,6 +121,12 @@ def decide(
             被单一分数阈值捕获的任务（如巡检：``success_score_threshold=100`` 与 Judge 评分尺度
             「全部满足≈90-100」结构性失配，且 acceptance 允许「仅剩 unfixable 即 done」由 Judge
             在 <100 分判 pass）——这类任务经 ``config.accept_verdict_pass=True`` 显式开启旁路。
+        no_progress_score_tolerance: 停滞判定的分数容差带（>0 时，窗口内评分落在
+            ``[历史最优 - tolerance, +∞)`` 即视为「接近最优·有进展」，不判停滞）。默认 0 = 点态
+            严格比较，退化为原行为（向后兼容）。仅用于 Judge 聚合分天然 ±振荡的长尾任务（如巡检：
+            修一处感知缺陷常压低另一处总分，±20 振荡），防一次早期运气高点使正常振荡永远清不过
+            历史最优 → 假阳性 no_progress 误杀。经 ``config.no_progress_score_tolerance`` 注入、
+            per-routine 开启。纯函数边界：容差由调用方显式注入，decision 不读 settings。
 
     Returns:
         Decision。优先级：成功 > 不可恢复 > 预算/截止 > 停滞 > 振荡 > 继续。
@@ -146,8 +153,8 @@ def decide(
     if budget.is_terminate:
         return budget
 
-    # 4) 进度停滞：最近 N 次评分均未超过历史最优
-    if _is_no_progress(routine, history):
+    # 4) 进度停滞：最近 N 次评分均未（含容差带）超过历史最优
+    if _is_no_progress(routine, history, no_progress_score_tolerance=no_progress_score_tolerance):
         return Decision("terminate", REASON_NO_PROGRESS)
 
     # 5) 振荡：verdict 在 progressing/regressed 间反复横跳且分数无上升趋势
@@ -181,11 +188,22 @@ def _consecutive_exec_failures(history: list[_IterationLike], *, max_context_res
     return count
 
 
-def _is_no_progress(routine: _RoutineLike, history: list[_IterationLike]) -> bool:
+def _is_no_progress(
+    routine: _RoutineLike,
+    history: list[_IterationLike],
+    *,
+    no_progress_score_tolerance: int = 0,
+) -> bool:
     """最近 ``no_progress_patience`` 次评分无一超过「窗口之前」的历史最优则视为停滞。
 
     基线取最近窗口之前的迭代最优分（``routine.best_score`` 含窗口自身，直接比较会恒真）；
     需窗口之前另有评分历史方可能触发，不足时不判停滞（给探索留出空间）。
+
+    ``no_progress_score_tolerance``（容差带）：窗口内任一评分落在
+    ``[best - tolerance, +∞)`` 即视为「接近历史最优·有进展」，不判停滞。默认 ``0`` 退化为
+    点态严格比较（``<= best``，逐字节向后兼容）。用于 Judge 聚合分天然 ±振荡的长尾任务
+    （如巡检：修一处感知缺陷常压低另一处总分，±20 振荡），防一次早期运气高点（watermark）
+    使正常振荡永远清不过 → 假阳性 no_progress 误杀正在收敛的任务。
     """
     patience = routine.no_progress_patience
     if patience <= 0:
@@ -193,12 +211,13 @@ def _is_no_progress(routine: _RoutineLike, history: list[_IterationLike]) -> boo
     scored = [it for it in history if it.score is not None]
     if len(scored) < patience:
         return False
-    # 基线 = 最近窗口之前的迭代最优分；窗口内若创出新高即视为有进展。
+    # 基线 = 最近窗口之前的迭代最优分；窗口内若创出新高（含容差带内接近最优）即视为有进展。
     best = max((it.score for it in scored[:-patience]), default=None)
     if best is None:
         return False  # 窗口前无评分历史 → 不判停滞
     recent = scored[-patience:]
-    return all(it.score <= best for it in recent)
+    threshold = best - no_progress_score_tolerance
+    return all(it.score <= threshold for it in recent)
 
 
 def _is_oscillating(history: list[_IterationLike]) -> bool:

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -711,6 +711,11 @@ class RoutineOrchestrator:
                 # per-routine 开启「Judge verdict=pass 亦判成功」旁路（config.accept_verdict_pass）：
                 # 用于完成判据无法被单一分数阈值捕获的任务（如巡检 threshold=100 与 Judge 评分尺度失配）。
                 accept_verdict_pass=bool((routine.config or {}).get("accept_verdict_pass")),
+                # per-routine 停滞判定分数容差带（config.no_progress_score_tolerance）：
+                # 用于 Judge 聚合分天然 ±振荡的长尾任务（如巡检：修一处感知缺陷常压低另一处总分），
+                # 防一次早期运气高点致正常振荡永远清不过历史最优 → 假阳性 no_progress 误杀。
+                # max(0,...) 防负值反向收紧；缺失键 → 0 退化原点态比较（向后兼容）。
+                no_progress_score_tolerance=max(0, int((routine.config or {}).get("no_progress_score_tolerance") or 0)),
             )
             if phased_flow:
                 self._advance_phase_or_terminate(routine, verdict)

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
@@ -188,6 +188,12 @@ def build_routine_config(
         # no_progress 误判 failed（曾致 Routine 861ab544 收敛成功态被判 failed）。开启此旁路让 Judge
         # 的权威完成裁决（verdict=pass + 门控通过）成为第二成功通道，与阈值路径并列。
         "accept_verdict_pass": True,
+        # 停滞判定分数容差带（消费见 orchestrator.decide()）。Judge 聚合分对「修一处感知缺陷、
+        # 回归压低另一处」的拟合任务天然 ±20 振荡，一次早期运气高点（watermark）会令正常振荡
+        # 永远清不过历史最优 → 假阳性 no_progress 误杀正在收敛的任务（曾致 PDF Fidelity Patrol
+        # 仅 6 轮即 failed、文档被永久标 unfixable）。设 20 = 典型振荡幅度，使窗口内任一评分接近
+        # 历史最优即视为「有进展/继续」，而非停滞误杀。
+        "no_progress_score_tolerance": 20,
     }
     if extra:
         cfg.update(extra)

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -315,6 +315,8 @@ def test_build_patrol_routine_constructs_without_attribute_error():
     assert routine.config["source_task_key"] == "pdf_fidelity_patrol"
     assert "system_prompt" in routine.config
     assert routine.config["read_dirs"] == ["/tmp/patrol"]
+    # 停滞容差带：防 Judge 聚合分 ±振荡致假阳性 no_progress 误杀（消费见 orchestrator.decide()）
+    assert routine.config["no_progress_score_tolerance"] == 20
     # 标题源：未修正时回退 original_filename（_doc_display_title 经 SSOT 解析）
     assert routine.title == "PDF 高保真巡检：report.pdf"
 

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_decision.py
@@ -191,6 +191,91 @@ def test_decide_no_progress_ignores_in_window_climb():
     assert d.decide(r, hist[-1], hist).action == "continue"
 
 
+# ---------------------------------------------------------------------------
+# no_progress_score_tolerance 容差带：Judge 聚合分天然 ±振荡的长尾任务（如巡检）防假阳性误杀
+# ---------------------------------------------------------------------------
+
+
+def test_decide_no_progress_rescued_by_score_tolerance_live_trajectory():
+    """核心回归（巡检 35ff2e9f）：真实轨迹 72→84→62→72→42→72，best=84（早期运气尖峰），
+    patience=3、窗口 [72,42,72] 点态全 ≤84 → 原逻辑误判 no_progress→failed（6 轮即挂、文档被永久
+    标 unfixable）。开启 tolerance=20 后 threshold=64，窗口内 72>64 即视为「接近最优·有进展」→ 继续。
+    success_score_threshold=95 高于全部评分，隔离成功分支、专测 no_progress 判定。"""
+    r = FakeRoutine(best_score=84, no_progress_patience=3, success_score_threshold=95)
+    hist = [
+        FakeIter(seq=1, score=72, verdict="progressing"),
+        FakeIter(seq=2, score=84, verdict="progressing"),
+        FakeIter(seq=3, score=62, verdict="stalled"),
+        FakeIter(seq=4, score=72, verdict="progressing"),
+        FakeIter(seq=5, score=42, verdict="stalled"),
+        FakeIter(seq=6, score=72, verdict="progressing"),
+    ]
+    assert d.decide(r, hist[-1], hist, no_progress_score_tolerance=20).action == "continue"
+
+
+def test_decide_no_progress_tolerance_default_zero_preserves_stall():
+    """向后兼容锁:同一真实轨迹下,默认 tolerance=0(点态严格比较)仍判 no_progress 终止,
+    证明容差带为纯 opt-in、不改变既有任何 routine 的行为。"""
+    r = FakeRoutine(best_score=84, no_progress_patience=3, success_score_threshold=95)
+    hist = [
+        FakeIter(seq=1, score=72, verdict="progressing"),
+        FakeIter(seq=2, score=84, verdict="progressing"),
+        FakeIter(seq=3, score=62, verdict="stalled"),
+        FakeIter(seq=4, score=72, verdict="progressing"),
+        FakeIter(seq=5, score=42, verdict="stalled"),
+        FakeIter(seq=6, score=72, verdict="progressing"),
+    ]
+    res = d.decide(r, hist[-1], hist)  # 不传 kwarg → 默认 0
+    assert res.is_terminate and res.reason == d.REASON_NO_PROGRESS
+
+
+def test_decide_no_progress_tolerance_flatline_well_below_best_still_stalls():
+    """未削弱真实停滞检测：窗口评分远低于历史最优（gap 50 > tolerance 20）时仍判停滞。
+    best=90（窗口前），窗口 [40,40,40] 全 ≤ threshold(70) → no_progress 正确触发。"""
+    r = FakeRoutine(best_score=90, no_progress_patience=3, success_score_threshold=95)
+    hist = [
+        FakeIter(seq=1, score=90, verdict="progressing"),
+        FakeIter(seq=2, score=40, verdict="stalled"),
+        FakeIter(seq=3, score=40, verdict="stalled"),
+        FakeIter(seq=4, score=40, verdict="stalled"),
+    ]
+    res = d.decide(r, hist[-1], hist, no_progress_score_tolerance=20)
+    assert res.is_terminate and res.reason == d.REASON_NO_PROGRESS
+
+
+def test_decide_no_progress_tolerance_boundary_exact_band_edge():
+    """边界精度锁：threshold = best - tolerance，比较为 `<= threshold`。
+    best=90、tolerance=20 → threshold=70；窗口 [70,69,70] 全 ≤70 → 停滞；
+    任一分越过边界（71>70）→ 继续。锁定 `best - tolerance` 的闭区间语义。"""
+    r = FakeRoutine(best_score=90, no_progress_patience=3, success_score_threshold=95)
+    base = [FakeIter(seq=1, score=90, verdict="progressing")]
+    stall = base + [
+        FakeIter(seq=2, score=70, verdict="stalled"),
+        FakeIter(seq=3, score=69, verdict="stalled"),
+        FakeIter(seq=4, score=70, verdict="stalled"),
+    ]
+    assert d.decide(r, stall[-1], stall, no_progress_score_tolerance=20).reason == d.REASON_NO_PROGRESS
+    progress = base + [
+        FakeIter(seq=2, score=70, verdict="progressing"),
+        FakeIter(seq=3, score=71, verdict="progressing"),
+        FakeIter(seq=4, score=70, verdict="progressing"),
+    ]
+    assert d.decide(r, progress[-1], progress, no_progress_score_tolerance=20).action == "continue"
+
+
+def test_decide_no_progress_tolerance_in_window_climb_still_continues():
+    """与既有 test_decide_no_progress_ignores_in_window_climb 交互守护：窗口内逐级爬升
+    （40→60→75→90，窗口前最优=40）在 tolerance=20 下照常继续，容差带不破坏爬升路径。"""
+    r = FakeRoutine(best_score=90, no_progress_patience=3, success_score_threshold=95)
+    hist = [
+        FakeIter(seq=1, score=40, verdict="progressing"),
+        FakeIter(seq=2, score=60, verdict="progressing"),
+        FakeIter(seq=3, score=75, verdict="progressing"),
+        FakeIter(seq=4, score=90, verdict="progressing"),
+    ]
+    assert d.decide(r, hist[-1], hist, no_progress_score_tolerance=20).action == "continue"
+
+
 def test_decide_oscillation():
     r = FakeRoutine(best_score=60, no_progress_patience=10)  # patience 大以排除 no_progress 抢先
     hist = [

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -3011,6 +3011,18 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
 
 ---
 
+## ISSUE-128 巡检 Routine 被 `_is_no_progress` 假阳性误杀为 failed：点态停滞判定对 Judge 聚合分天然振荡零容忍（2026-06-29）
+
+- **表因**：PDF Fidelity Patrol 巡检 Routine `35ff2e9f-9a25-4706-be38-96fa32c35628`（PDF→Markdown 效果值守与自主拟合优化）运行**仅 6 轮、花费 $28 / $1500 预算**即 `status=failed, termination_reason=no_progress`。用户预期：这类「尽力优化型」Routine 本不该 hard-fail，只应在运行时长与优化程度上有差异。实测迭代评分轨迹 `72→84→62→72→42→72`（`best_score=84` 为 seq 2 早期尖峰），各轮 reflection 均显示实质推进（图廊去重 14→1、双栏排序修复、伪 SQL 围栏消除）。
+- **根因**：`engine/routine/decision.py::_is_no_progress` 用**点态、零容差**的 `all(score <= 窗口前最优)` 判定停滞。Judge 聚合分对「修一处 perceives 缺陷、回归压低另一处」的拟合任务天然 **±20 振荡**；`patience=3` 时窗口前最优取 `max([72,84,62])=84`（一次早期运气尖峰立起 watermark），窗口 `[72,42,72]` 全 ≤84 → 误判停滞 → `decide()` 判 `terminate/no_progress` → `_terminate` 映射 `failed`。`accept_verdict_pass=True` 旁路兜不住：该旁路仅当 `verdict=="pass"`（"仅剩 unfixable 即 done"）触发，本文档仍有可修复缺陷，Judge 正确判 `progressing/stalled` 而非 `pass`——旁路为「收敛但分低」场景设计，不覆盖「仍在修复中但分震荡」场景。`_is_oscillating` 不接力误杀（其 verdict 过滤 `stalled`、仅认 `progressing/regressed`，巡检翻转是 `progressing↔stalled`，过滤后 `len<3` 永不满足；已用真实模块复现 `oscillating=False`）。
+- **二阶影响**：误杀后 `pdf_fidelity_patrol._finalize_terminal_patrols` → `patrol_memory.persist_terminal_outcome` 因 `best_score=84<qualified_threshold=95` 且契约非 done，把文档标 `unfixable` 永久进 `skip_ids` 不再巡检——**一次假阳性永久污染文档**。主修复消除上游假阳性后，该映射对「真正耗尽预算」场景语义正确，故本次不动下游（最小干预）。
+- **处理方式**（最小干预、向后兼容）：为 `_is_no_progress` 与 `decide()` 引入 per-call 关键字参数 `no_progress_score_tolerance: int = 0`（容差带）；比较改为 `all(score <= best - tolerance)`，窗口内任一评分落在 `[best-tolerance, +∞)` 即视为「接近最优·有进展」不判停滞。`tolerance=0` 逐字节退化原行为（向后兼容）。`orchestrator.py` decide 调用点镜像 `accept_verdict_pass` 从 `config.no_progress_score_tolerance` 透传（`max(0,int(...))` 防负值）；`patrol_prompt.build_routine_config` 注入 `no_progress_score_tolerance: 20`（典型振荡幅度）。`_RoutineLike` Protocol、`_is_oscillating`、`persist_terminal_outcome`、`_terminate`、ORM、迁移均不动。
+- **后续防范**：① 任何以 LLM-as-Judge 聚合分驱动的停滞/振荡判定，须考虑该分天然波动性，点态阈值判定对振荡型收敛任务须配容差带或趋势判定，不可零容差；② 「尽力优化型」Routine（巡检）的非成功终态（no_progress/oscillation/budget）映射为 hard `failed` 是更上游的语义债——理想应有 `converged`（尽力收敛）独立终态，由 `persist_terminal_outcome` 按 best_score 判 done/unfixable，列为后续演进（需谨慎处理 `_propagate_patrol_outcomes` 的 Scheduler 状态映射，不得回归 `be3b257a`「失败不再误标成功」）；③ **更深层根因（评分口径）**：决策用分是 Evaluator Judge 基于「本轮 summary」独立重打的分，每轮无历史、无客观锚点（巡检 `verification_command=None`），与 CC 自评的累计视觉一致度 `contract.score`（口径正确、应单调趋近 100）口径错配——这是评分大幅波动甚至走低的结构性根因，治本方向是让累计 contract.score 进入决策位，需独立评估其可信度（亦 LLM 自评），列为后续演进。
+- **同类问题影响**：所有 `accept_verdict_pass=True` 类「完成判据无法被单一分数阈值捕获」的长尾 Routine；与 ISSUE-116（评分越线封顶）、ISSUE-121（弱 Judge 误判 acceptance）正交但同属 LLM-as-Judge 评分链路稳定性议题。
+- **验证**：`test_routine_decision.py` 新增 5 例（核心回归编码真实轨迹 `72→84→62→72→42→72` 断言 `continue`、向后兼容锁 tolerance=0 仍 `no_progress`、平线远低于最优仍停滞、边界精度 `best-tolerance` 闭区间、in-window-climb 守护）+ `test_pdf_fidelity_patrol_handler.py` 补 config 断言；engine 全套单测 **1043 passed**、ruff All checks passed。真实数据回放：`decide(...,no_progress_score_tolerance=20)` 由 `terminate/no_progress` 反转为 `continue`。
+
+---
+
 ## ISSUE-118 Documents 页图片把自动文件名当 figcaption 显示 + 全局技能「卡片可见 ≠ Agent 可用」
 
 - **表因**：Knowledge/Documents 页渲染 perceives 抽取的 PDF 时，无图注的图片（如论文 logo `fig_p1_1.png`）下方显示出无语义的 "fig_p1_1.png" 文本；另：把技能标记 `is_system` 仅令其在 Skills 卡片对全员可见，却未注入任何 Agent 的 Progressive Disclosure。


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：PDF Fidelity Patrol 巡检 Routine（`35ff2e9f`，PDF→Markdown 效果值守与自主拟合优化）运行**仅 6 轮、花费 $28 / $1500 预算**即被判 `status=failed, termination_reason=no_progress`。这类「尽力优化型」任务本不该 hard-fail，经真实 DB 数据 + 真实 `decision` 模块复现，确认是被**假阳性停滞判定误杀**（每轮 reflection 均显示实质推进：图廊去重 14→1、双栏排序修复、伪 SQL 围栏消除）。
- 关联上下文/Issue/文档：[docs/.agents/issue.md](docs/.agents/issue.md) ISSUE-128；与 ISSUE-116/121（LLM-as-Judge 评分链路）正交同源。

# 核心变更
- **`decision.py`**：`_is_no_progress` / `decide()` 引入 per-call 关键字参数 `no_progress_score_tolerance: int = 0`（容差带），比较由 `all(score <= best)` 改为 `all(score <= best - tolerance)`——窗口内任一评分落在 `[best-tolerance, +∞)` 即视为「接近最优·有进展」不判停滞。默认 `0` 逐字节退化原行为（向后兼容）。
- **`orchestrator.py`**：decide 调用点镜像 `accept_verdict_pass`，从 `config.no_progress_score_tolerance` 透传，`max(0, int(...))` 防负值反向收紧。
- **`patrol_prompt.py`**：`build_routine_config` 注入 `no_progress_score_tolerance: 20`（典型振荡幅度）。
- **不改** `_is_oscillating`（其过滤 `stalled`、仅认 `progressing/regressed`，对巡检不接力误杀，已实测复现）、`persist_terminal_outcome`、`_terminate`、ORM、迁移。

# 风险与回滚
- 主要风险：容差值 `20` 按 ±20 振荡幅度标定，过大→真实停滞任务多耗预算（由既有 `max_iterations/max_cost/deadline` 硬上限兜底，无 runaway）；过小→噪声更大文档仍可能误杀。值在 config 单行可调。
- 回滚方式：纯 opt-in 改动，`tolerance` 默认 0 即原行为；revert 本 commit 或移除 `patrol_prompt.py` 的 config 注入即完全回退，零迁移、零 DB 改动。

# 验证证据
- 单元测试：`test_routine_decision.py` 新增 5 例（核心回归编码真实轨迹 `72→84→62→72→42→72` 断言 `continue`、向后兼容锁 `tolerance=0` 仍 `no_progress`、平线远低于最优仍停滞、边界精度 `best-tolerance` 闭区间、in-window-climb 守护）+ `test_pdf_fidelity_patrol_handler.py` 补 config 断言。
- 集成测试：engine 全套单测 **1043 passed**；ruff lint + format All checks passed。
- E2E/Workflow：真实数据回放——`decide(..., no_progress_score_tolerance=20)` 对 live 轨迹由 `terminate/no_progress` **反转为 `continue`**，`_is_no_progress(tol=20)=False`、`_is_oscillating=False`。
- 覆盖率/关键截图：N/A（纯函数决策逻辑，单测覆盖）。

# 影响范围
- 前端：无。
- 后端：`engine/routine/{decision,orchestrator,patrol_prompt}.py`；仅影响巡检类 Routine 的停滞判定灵敏度，不改 `failed` 语义、不影响其它 Routine（默认 `tolerance=0`）。
- GitHub Actions / 文档：`docs/.agents/issue.md` 新增 ISSUE-128。

# Next Best Action
- **评分口径根治（更上游）**：决策用分是 Evaluator Judge 基于「本轮 summary」独立重打、无历史无锚点（巡检 `verification_command=None`），与 CC 自评累计一致度 `contract.score`（应单调）口径错配——这是评分大幅波动甚至走低的结构性根因，治本方向是让累计 contract.score 进决策位（需评估 LLM 自评可信度）。
- **`converged` 独立终态**：「尽力优化型」Routine 的 no_progress/oscillation/budget 终态映射为 hard `failed` 属语义债，理想应有「尽力收敛」终态，由 `persist_terminal_outcome` 按 best_score 判 done/unfixable；改 Scheduler 状态映射须不回归 `be3b257a`「失败不再误标成功」。

🤖 Generated with [Claude Code](https://github.com/claude)