### PR TITLE
fix(Patrol): 修复巡检交付仅含 patrol-candidate.md 的 PR——候选移出 worktree + 引擎 no-op 干净终态

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,7 @@ apps/negentropy-ui/.userdata/
 .gitignore
 output/
 benchmarks/runs/
+
+# PDF Fidelity Patrol 临时候选产物（评估用重转 Markdown，正常落 worktree 外暂存目录；
+# 此条兜底 agent 路径漂移误在 worktree 写候选的极端场景，确保其永不进 commit/PR）
+patrol-candidate.md

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -698,8 +698,16 @@ class RoutineOrchestrator:
 
             # FINALIZE 相位：从本轮 summary 捕获 PR 链接（一次性，幂等）。
             phased_flow = phase_mod.is_worktree_routine(routine) or phase_mod.is_phased(routine.config)
-            if phased_flow and routine.current_phase == phase_mod.PHASE_FINALIZE and not routine.pr_url:
-                routine.pr_url = phase_mod.extract_pr_url(latest.summary)
+            finalize_noop = False
+            if phased_flow and routine.current_phase == phase_mod.PHASE_FINALIZE:
+                if not routine.pr_url:
+                    routine.pr_url = phase_mod.extract_pr_url(latest.summary)
+                # 巡检专属 clean no-op 探针：无 PR 且 worktree 相对基线 0 提交 → 无可交付改动
+                # （文档已达标、本轮未改 perceives）。严格限定 ``config.patrol``——普通 feature routine 的
+                # 「零改动收敛」语义不同（可能漏提交/跑空），不可一概判成功（首要安全护栏）。仅在 no-pr
+                # 路径触探针，避免常态 PR-captured 路径多跑一次 git 子进程。
+                if not routine.pr_url and bool((routine.config or {}).get("patrol")):
+                    finalize_noop = await self._finalize_is_noop(routine)
 
             # 决策（仅取「本次尝试」窗口 seq > eval_floor_seq，重启后旧迭代不污染停滞/振荡判定）。
             history = await self._evaluated_history(db, routine_id, floor=routine.eval_floor_seq)
@@ -718,7 +726,7 @@ class RoutineOrchestrator:
                 no_progress_score_tolerance=max(0, int((routine.config or {}).get("no_progress_score_tolerance") or 0)),
             )
             if phased_flow:
-                self._advance_phase_or_terminate(routine, verdict)
+                self._advance_phase_or_terminate(routine, verdict, finalize_noop=finalize_noop)
             elif verdict.is_terminate:
                 self._terminate(routine, verdict.reason or decision_mod.REASON_SUCCESS)
 
@@ -1026,12 +1034,41 @@ class RoutineOrchestrator:
             return seq == 1
         return False  # auto
 
-    def _advance_phase_or_terminate(self, routine: Routine, verdict: decision_mod.Decision) -> None:
+    async def _finalize_is_noop(self, routine: Routine) -> bool:
+        """FINALIZE 无可交付提交判定：worktree 相对基线 0 commits ahead → True（clean no-op）。
+
+        语义对齐 ``gh pr create`` 的「no commits between base and head」报错条件：用
+        ``rev-list --count <baseline>..HEAD == 0`` 度量「可建 PR 的提交载荷」，**不用**
+        ``git diff --quiet``（误判工作树脏污）。``baseline`` 取 ``routine.baseline_branch`` 原值
+        （worktree 据该 remote-tracking ref 建立）。rc≠0/解析失败 → 保守 False（绝不把不确定当成功）。
+
+        仅用于巡检（``config.patrol``）的「文档已达标、本轮零代码改动」干净收尾——避免修复候选
+        产物移出 worktree 后，无改动巡检在 FINALIZE 空转至 max_iterations 才 failed。
+        """
+        wt = getattr(routine, "worktree_path", None)
+        base = getattr(routine, "baseline_branch", None)
+        if not wt or not base:
+            return False
+        rc, out, _ = await workspace._run_git(
+            ["-C", wt, "rev-list", "--count", f"{base}..HEAD"],
+            timeout=float(settings.routine.git_timeout_seconds),
+        )
+        if rc != 0:
+            return False
+        try:
+            return int(out.strip() or "0") == 0
+        except ValueError:
+            return False
+
+    def _advance_phase_or_terminate(
+        self, routine: Routine, verdict: decision_mod.Decision, *, finalize_noop: bool = False
+    ) -> None:
         """相位化工作流：按相位解释 decision 的 SUCCESS，否则照常终止。
 
         - PLAN：非成功守卫（如不可恢复）照常终止；否则（成功或继续）推进到 IMPLEMENT；
         - IMPLEMENT：SUCCESS → 推进到 FINALIZE（不终止）；其它终止守卫 → failed；
-        - FINALIZE：一旦捕获 ``pr_url`` 即 succeeded（交人工 Merge）；否则非成功守卫 → failed，
+        - FINALIZE：捕获 ``pr_url`` 即 succeeded；或（``finalize_noop`` 且本轮成功裁决）判
+          clean no-op succeeded（无可交付改动、不开 PR）；否则非成功守卫 → failed，
           其余留在 FINALIZE 重试建 PR。
         """
         phase = routine.current_phase
@@ -1043,6 +1080,12 @@ class RoutineOrchestrator:
                 routine.current_phase = phase_mod.PHASE_IMPLEMENT
         elif phase == phase_mod.PHASE_FINALIZE:
             if routine.pr_url:
+                self._terminate(routine, decision_mod.REASON_SUCCESS)
+            elif finalize_noop and is_success:
+                # clean no-op：FINALIZE + 成功裁决 + worktree 相对基线 0 commits ahead + 无 PR
+                # → 无可交付改动（如文档已高保真、本轮未改 perceives）。判 succeeded 无 PR，不空转重试。
+                # 核心不变量：no-op 成功仅在「可证明零可交付提交」时可达（有提交者 finalize_noop=False，
+                # 仍须真实 pr_url 才成功）；且须合取本轮 is_success——非成功裁决绝不被 no-op 掩盖。
                 self._terminate(routine, decision_mod.REASON_SUCCESS)
             elif verdict.is_terminate and not is_success:
                 self._terminate(routine, verdict.reason or decision_mod.REASON_UNRECOVERABLE)

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
@@ -89,6 +89,9 @@ PATROL_SYSTEM_PROMPT = (
 ## 非回归门控（FINALIZE 开 PR 前必做）
 对注入的 `regression_sample`（一组多样化生产 PDF doc_id）用**本轮改动后** perceives 重转 + 采样评分；\
 任一样本分数**下降 >3 分**或转换失败 → **不得开 PR**，回退改动。通过才走既有 `gh pr create --base <baseline>`。
+**零代码改动即无 PR（交付物只能是 perceives 代码优化）**：若本轮（及历轮）未对 perceives 做任何代码改动\
+（worktree 相对基线 0 提交），说明该文档已达标、无需优化 → **不得开 PR**，直接以 done 收尾。候选 Markdown \
+是隔离工作区**之外**的临时评估产物（`-o` 指向暂存目录绝对路径），**绝不**纳入 worktree / commit / PR。
 
 ## 角色分工（轻量，勿展开探查）
 Contemplation=步骤 2-4（渲染+采样比对+评分）；Action=步骤 1/5（重转+定点改 perceives）；\

--- a/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
+++ b/apps/negentropy/src/negentropy/engine/routine/prompt_builder.py
@@ -163,6 +163,11 @@ def build_prompt(
         wb = getattr(routine, "work_branch", None) or "<work_branch>"
         parts.append(
             "# 收尾 (Finalize)\n验收标准已达标，现在隔离 worktree 内进行收尾交付：\n"
+            f"0. **先判定有无可交付改动**：`git rev-list --count {base}..HEAD`——\n"
+            "   - 输出为 `0`（无提交，如本文档已达标、本轮未改任何代码）：**跳过下列 push/PR**，"
+            "在最终回复**第一行**单独输出 `PR_URL=NONE`（无代码交付）后直接收尾——"
+            "引擎据 worktree 相对基线 0 提交判定为 clean no-op 成功，无需 PR；\n"
+            "   - 输出 ≥ `1`：继续下列建 PR 步骤；\n"
             "1. 运行 `uv run ruff check` 与 `uv run pytest`，修复全部失败；\n"
             "2. `git add -A` 后按仓库规范 `git commit`（**切勿**推送 master/main 等主分支）；\n"
             f"3. 推送工作分支到远端：`git push -u origin {wb}`；\n"

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -713,6 +713,12 @@ def _build_patrol_routine(
     doc_title = _doc_display_title(doc)
     short = uuid.uuid4().hex[:8]
     qualified_threshold = settings.routine.patrol_qualified_score_threshold
+    # 候选 Markdown 落「源 PDF 暂存目录」内（绝对路径，与 source.pdf 同级、worktree 之外）——
+    # 它是闭环重转/评估的临时产物（perceives parse-pdf -o），非交付物：置于 worktree 外可确保
+    # FINALIZE 的 `git add -A` 永不将其纳入 PR（修「PR 仅含 patrol-candidate.md」根因），
+    # 且恰为 patrol_input_dir 配置语义（「源 PDF 暂存与候选 Markdown 输出根目录」）。
+    # 经 bash 子进程写出（非 Edit 工具），不受 read_dirs 的 Edit-deny 限制。
+    candidate_md_path = str(Path(source_read_dir) / CANDIDATE_MD_FILENAME)
     return Routine(
         key=f"{PATROL_KEY_PREFIX}/{doc_id}/{short}",
         title=f"PDF 高保真巡检：{doc_title}",
@@ -725,7 +731,7 @@ def _build_patrol_routine(
             doc_id=doc_id,
             doc_title=doc_title,
             source_pdf_path=source_pdf_path,
-            candidate_md_path=CANDIDATE_MD_FILENAME,
+            candidate_md_path=candidate_md_path,
             qualified_threshold=qualified_threshold,
             known_unfixable_regions=known_unfixable_regions,
         ),
@@ -747,7 +753,7 @@ def _build_patrol_routine(
         config=build_routine_config(
             doc_id=doc_id,
             source_pdf_path=source_pdf_path,
-            candidate_md_path=CANDIDATE_MD_FILENAME,
+            candidate_md_path=candidate_md_path,
             source_read_dir=source_read_dir,
             regression_sample=regression_sample,
             extra={"source_task_key": source_task_key},

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -251,6 +251,76 @@ async def test_phased_finalize_with_pr_succeeds():
         await _cleanup(rid)
 
 
+async def test_patrol_finalize_noop_succeeds_without_pr():
+    """巡检 clean no-op：FINALIZE + 成功裁决 + worktree 相对基线 0 提交 + 无 PR → succeeded 无 PR。
+
+    回归 PR #1010：文档已达标（score≥阈值）、本轮未改 perceives → 候选移出 worktree（FIX 1）后
+    worktree 干净、无可交付提交 → 引擎据 0-commits 判 clean no-op 成功，不开 PR、不空转重试。
+    仅限 ``config.patrol``——普通 feature routine 的「零改动收敛」不可一概判成功（安全护栏）。
+    """
+    rid = await _make_routine(
+        config={"patrol": True},
+        current_phase="finalize",
+        baseline_branch="origin/feature/1.x.x",
+        success_score_threshold=95,
+        iteration_count=3,
+    )
+    await _add_iteration(rid, seq=1, phase="finalize", summary="文档已达标，本轮未改 perceives")
+    try:
+        orch = RoutineOrchestrator()
+        with (
+            patch.object(
+                orch._evaluator,
+                "evaluate",
+                new=AsyncMock(
+                    return_value=EvaluationResult(ok=True, score=96, verdict="pass", reflection="", gate_exit_code=None)
+                ),
+            ),
+            patch.object(orch, "_finalize_is_noop", new=AsyncMock(return_value=True)),
+        ):
+            await _evaluate_and_drain(orch)
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "succeeded"
+            assert r.termination_reason == "success"
+            assert r.pr_url is None  # 无可交付改动 → 不开 PR
+    finally:
+        await _cleanup(rid)
+
+
+async def test_patrol_finalize_with_commits_still_requires_pr():
+    """安全回归：巡检 FINALIZE + 成功裁决，但 worktree 有提交（探针 False）+ 无 PR → 仍须真实 PR，
+    留 running 在收尾重试。核心不变量：no-op 成功仅在「可证明零可交付提交」时可达。"""
+    rid = await _make_routine(
+        config={"patrol": True},
+        current_phase="finalize",
+        baseline_branch="origin/feature/1.x.x",
+        success_score_threshold=95,
+        iteration_count=3,
+    )
+    await _add_iteration(rid, seq=1, phase="finalize", summary="改了 perceives 但未输出链接")
+    try:
+        orch = RoutineOrchestrator()
+        with (
+            patch.object(
+                orch._evaluator,
+                "evaluate",
+                new=AsyncMock(
+                    return_value=EvaluationResult(ok=True, score=96, verdict="pass", reflection="", gate_exit_code=None)
+                ),
+            ),
+            patch.object(orch, "_finalize_is_noop", new=AsyncMock(return_value=False)),
+        ):
+            await _evaluate_and_drain(orch)
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.status == "running"  # 有提交但无 PR → 留收尾重试
+            assert r.current_phase == "finalize"
+            assert r.pr_url is None
+    finally:
+        await _cleanup(rid)
+
+
 async def test_evaluate_slow_judge_does_not_block_heartbeat():
     """根因回归（卡在 Evaluate）：评估已从心跳剥离为后台任务。
 

--- a/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
@@ -132,4 +132,6 @@ def test_system_prompt_contains_protocol_and_contract():
     assert "非回归" in PATROL_SYSTEM_PROMPT
     assert "refresh-markdown" in PATROL_SYSTEM_PROMPT  # 红线：禁止调生产重转
     assert "pdf-fidelity-contract" in PATROL_SYSTEM_PROMPT
+    # 零代码改动即无 PR（修「PR 仅含 patrol-candidate.md」根因：候选是 worktree 外临时产物、不纳入交付）
+    assert "零代码改动" in PATROL_SYSTEM_PROMPT
     assert "doc_id" in CONTRACT_SCHEMA

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -321,6 +321,36 @@ def test_build_patrol_routine_constructs_without_attribute_error():
     assert routine.title == "PDF 高保真巡检：report.pdf"
 
 
+def test_build_patrol_routine_candidate_md_is_absolute_outside_worktree():
+    """回归 PR #1010：候选 Markdown 须落在源 PDF 暂存目录内（绝对路径、worktree 之外）。
+
+    历史 bug：``candidate_md_path=CANDIDATE_MD_FILENAME``（相对文件名）→ agent 在 worktree 根写出
+    候选 → ``git add -A`` 将其提交并随 PR 推出（PR 仅含 ``patrol-candidate.md``）。候选是评估用
+    临时产物（perceives parse-pdf -o），须置 worktree 外、永不进 commit/PR。
+    """
+    import uuid as _uuid
+
+    repo_id = _uuid.uuid4()
+    doc = {"id": _uuid.uuid4(), "original_filename": "report.pdf"}
+    source_read_dir = "/tmp/negentropy-patrol/013c5ebc"
+    routine = patrol._build_patrol_routine(
+        repo_id=repo_id,
+        baseline_branch="origin/feature/1.x.x",
+        doc=doc,
+        source_pdf_path=f"{source_read_dir}/source.pdf",
+        source_read_dir=source_read_dir,
+        regression_sample=["s1"],
+        source_task_key="pdf_fidelity_patrol",
+    )
+    expected = f"{source_read_dir}/{patrol.CANDIDATE_MD_FILENAME}"
+    # 绝对路径、暂存目录内（source.pdf 同级）、worktree 之外
+    assert routine.config["candidate_md_path"] == expected
+    assert routine.config["candidate_md_path"] == str(Path(expected))
+    assert not routine.config["candidate_md_path"].startswith(patrol.CANDIDATE_MD_FILENAME)  # 非裸相对文件名
+    # goal 同步注入该绝对候选路径
+    assert expected in routine.goal
+
+
 def test_build_patrol_routine_uses_corrected_display_name():
     """回归本次目标：用户修正后的 display_name 透传到 Routine 标题/展示名/描述/goal，
     原始文件名不再出现在用户可见标题链路。"""

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_phase.py
@@ -118,6 +118,20 @@ def test_build_prompt_worktree_finalize_uses_pr_view_before_create():
     assert p.index("gh pr view") < p.index("gh pr create")
 
 
+def test_build_prompt_worktree_finalize_noop_guard():
+    """FINALIZE 无可交付守卫：先 `git rev-list --count <base>..HEAD` 判有无提交——
+    为 0（如巡检文档已达标、本轮未改代码）则跳过 push/PR、输出 ``PR_URL=NONE`` 直接收尾。
+    引擎的 rev-list 探针是权威闸门；此 prompt 守卫仅省一轮 ``gh pr create`` 报错空转。
+    回归 PR #1010（巡检交付仅含 patrol-candidate.md 的 PR）。"""
+    p = build_prompt(_wt_routine(current_phase="finalize"))
+    assert "rev-list --count" in p
+    assert "feature/1.x.x..HEAD" in p  # base 已归一（origin/ 剥离）
+    assert "PR_URL=NONE" in p  # 无可交付的惰性 sentinel（extract_pr_url 不识别）
+    # 守卫须在 push/gh pr create 之前（先判有无提交）
+    assert p.index("rev-list --count") < p.index("git push")
+    assert p.index("rev-list --count") < p.index("gh pr create")
+
+
 def test_build_prompt_worktree_implement_injects_checkpoint_commit():
     """worktree IMPLEMENT 相位注入迭代检查点提交指令（git add -A && git commit，仅提交不推送）。"""
     for ph in ("implement",):

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -3337,3 +3337,22 @@ R7 后浏览器对照 Section 2.1 区域发现两类正交缺陷：
 - **验证**：受控种子（独立 `app_name='__perf_verify__'`，覆盖 low_retention/high_importance 边界/deleted/pii/valid_until 各分支，验后清理）对比 NEW 合并查询 vs OLD 逐条查询——dashboard 三 user 维度全字段 MATCH；`dashboard.memory_count=5`(含 deleted) vs `metrics.memory_total=4`(排除 deleted)、`dashboard.fact_count=2`(过滤过期) vs `metrics.fact_count=3`(不过滤) 证差异化过滤器保留。956 engine 单测全过；alembic up/down 幂等；autogenerate 无漂移；ruff 通过。
 - **后续防范**：① 新建部分索引务必让谓词与查询布尔表达式 AST 形态一致（`IS TRUE` vs 裸布尔不互通），建索引后用 `SET enable_seqscan=off; EXPLAIN` 实测命中；② 多聚合同表同 WHERE 应合并为单条 `select(... sum(case))`（复用 `retrieval_tracker.py`/`scheduler_api.py` 惯例），勿逐条 `db.scalar`；③ 跨表计数因基数不同不能合并（笛卡尔积污染），按表拆条是下限；④ 区分「dev webpack 首屏编译慢」与「后端检索慢」——前者非后端范畴，勿误改后端；⑤ pool_size=5/max_overflow=10 下慎用 `asyncio.gather` 多 session（连接放大），优先单 session 多语句合并。
 - **同类问题影响**：knowledge 模块若新增 dashboard/metrics 聚合端点应复用本 PR 合并范式与 `(app_name,user_id)` 前导索引惯例；所有 `app_name`-scoped 聚合查询都应核查是否落到以 `user_id` 前导的既有索引（无效）。
+
+## ISSUE-149 PDF Fidelity Patrol 交付仅含 `patrol-candidate.md` 的 PR（候选产物落 worktree 被提交 + 引擎缺 no-op 终态）（2026-06-29）
+
+- **表因**：巡检 Routine（#1010）最终交付的 PR **仅含一个文件 `patrol-candidate.md`**（+676/−0），而非对 `apps/negentropy-perceives` 的代码优化——该 `.md` 是闭环步骤 1 `perceives parse-pdf -o` 的**评估用临时候选 Markdown**，根本不该进交付。
+- **根因**（三个叠加结构性缺陷）：
+  1. **候选产物落 worktree 内被 `git add -A` 提交**：`CANDIDATE_MD_FILENAME = "patrol-candidate.md"` 是**相对路径** → agent 在 worktree 根写出 → IMPLEMENT 检查点（`prompt_builder.py:199`）与 FINALIZE（`prompt_builder.py:167`）的 `git add -A` 将其提交并随 PR 推出。反证：渲染底图已正确落到 worktree 外 `/tmp/<doc_id>/render`，且 `patrol_input_dir` 配置 docstring 明示其为「源 PDF 暂存**与候选 Markdown 输出**根目录」——**相对路径是对设计意图的偏离**。
+  2. **「零代码改动」的收敛仍开 PR**：doc 早轮即 score≥合格阈值 95、无可修复缺陷 → 未改 perceives；worktree 内唯一变更就是候选 `.md`。
+  3. **引擎 FINALIZE 终态强依赖 `pr_url`**（`orchestrator._advance_phase_or_terminate`）：修缺陷 1 后无改动巡检无可提交、`gh pr create` 报「no commits between base and head」、永不产出 `pr_url` → Routine 在 FINALIZE **空转至 max_iterations(400) 才 failed**（虽 `persist_terminal_outcome` 因 best_score≥95 仍标 done，但白烧预算且终态 failed 污染 consecutive_failures）。
+- **处理方式**（PR #1012）：
+  1. **FIX1 候选移出 worktree**：`pdf_fidelity_patrol._build_patrol_routine` 将候选路径改为暂存目录内**绝对路径**（`source.pdf` 同级、worktree 之外）。写入经 bash 子进程 `-o`，不受 `read_dirs` 的 Edit-deny 限制（与 `/tmp/render` 同理）。
+  2. **FIX2 引擎 no-op 干净终态（仅 `config.patrol`）**：`orchestrator` 新增 `_finalize_is_noop`（`git rev-list --count <baseline>..HEAD == 0` → 无可交付）；`_advance_phase_or_terminate` 新增 `finalize_noop` 参数（默认 False，既有调用零变更），FINALIZE 下「无 PR + 0 提交 + 本轮成功裁决」判 succeeded 无 PR。配套 prompt（`prompt_builder` FINALIZE STEP0 守卫 + `patrol_prompt` 非回归门控补「零改动即 done 不开 PR」）。
+  3. **兜底**：`.gitignore` 忽略 `patrol-candidate.md`。
+- **关键坑（务必复用经验）**：
+  1. **「临时评估产物」与「交付物」须物理隔离**：任何 agent 在 worktree 内生成的中间产物（候选、渲染、报告），经 `git add -A` 会无条件进 commit/PR。须落到 worktree **之外**的暂存目录（如既有 `patrol_input_dir`/`/tmp`），而非靠 `.gitignore` 或「agent 自觉」——后者是软约束、终会漏。
+  2. **引擎「无 PR 即 failed」对「零改动收敛」任务是错配**：worktree routine 的 FINALIZE 终态强依赖 `pr_url`，对「达标即无需改代码」的自拟合任务会空转。no-op 成功须 **`rev-list --count` 量「提交载荷」**（精确对应 `gh pr create` 报错条件），**勿用 `git diff --quiet`**（误判工作树脏污）；且须 **合取本轮 `is_success`、严格限定 `config.patrol`**——普通 feature routine 的「零改动收敛」可能是漏提交/跑空，不可一概判成功（首要安全护栏）。核心不变量：**no-op 成功仅在「可证明零可交付提交」时可达**。
+  3. **async/sync 边界**：`_advance_phase_or_terminate` 是 sync（单 worker 事件循环禁阻塞 IO），no-op 的 git 探针须在 async 捕获点（`_do_evaluate` 内 pr_url 捕获同处）算好 bool、经参数传入 sync 方法，**勿在 sync 方法内直接调 git 子进程**。
+- **验证**：`test_pdf_fidelity_patrol_handler`（候选绝对路径 / worktree 外）、`test_routine_phase`（FINALIZE `rev-list --count` + `PR_URL=NONE` 守卫先于 push/create）、`test_patrol_prompt`（协议含「零代码改动」）、`test_routine_orchestrator` 集成（no-op 巡检→succeeded 无 PR；安全回归：有提交+无 PR→留 running 仍须真实 PR）；既有 finalize/worktree 用例 7/7 无回归；ruff lint+format 通过。
+- **后续防范**：① 新增「worktree 内生成中间产物」的 routine 须第一时间检查产物落点是否在 worktree 外；② 为「达标即完成、未必有代码改动」类任务设计 routine 时，须校验 FINALIZE 终态对「零改动」的处理（开 no-op 成功或文档化空转代价）；③ `git add -A` 是 worktree routine 的默认提交语义——任何不该进 PR 的产物都不能留在 worktree。
+- **同类问题影响**：所有派生 worktree + PR 的 routine（非仅巡检）若在 worktree 内写中间产物，都会复现「PR 含无关文件」；通用 worktree routine 若未来需要「零改动收敛」语义，可参考本 no-op 终态范式（但须各自论证安全性，本次刻意只为 patrol 开启）。


### PR DESCRIPTION
## 背景

Routine `8e8ce471`（派生自 Scheduler Task「PDF Fidelity Patrol（PDF→Markdown 高保真自拟合巡检）」）交付的 #1010 **仅含一个文件 `patrol-candidate.md`（+676/−0）**，标题「…score=96 收敛」。

巡检的预期交付物是**对 `apps/negentropy-perceives` 下 PDF→Markdown 处理逻辑的代码优化 PR**；`patrol-candidate.md` 只是闭环步骤 1 产出的**评估用临时候选 Markdown**（`perceives parse-pdf -o`），根本不该进入交付。

## 根因（三个叠加的结构性缺陷）

1. **临时候选产物落在 worktree 内、被 `git add -A` 提交。**
   `CANDIDATE_MD_FILENAME = "patrol-candidate.md"` 是**相对路径**，agent 在 worktree 根写出 → IMPLEMENT 检查点与 FINALIZE 的 `git add -A` 将其提交并随 PR 推出。反证：渲染底图已正确落到 worktree 外的 `/tmp/<doc_id>/render`，且 `patrol_input_dir` 配置 docstring 明示其为「源 PDF 暂存**与候选 Markdown 输出**根目录」——相对路径是对设计意图的偏离。
2. **「零代码改动」的收敛仍开 PR。** doc 013c5ebc 早轮即 score=96 ≥ 合格阈值 95、无可修复缺陷 → 未改 perceives；worktree 内唯一变更就是候选 `.md`。
3. **引擎 FINALIZE 终态强依赖 `pr_url`**（`orchestrator._advance_phase_or_terminate`）：修复缺陷 1 后无改动巡检无可提交、`gh pr create` 报「no commits between base and head」、永不产出 `pr_url` → 该 Routine 在 FINALIZE **空转至 max_iterations(400) 才 failed**。

## 修复方案

### FIX 1 — 候选 Markdown 移出 worktree（恢复设计意图）
`pdf_fidelity_patrol._build_patrol_routine` 将候选路径从相对文件名改为**暂存目录内的绝对路径**（`source.pdf` 同级、worktree 之外）。写入经 bash 子进程（`perceives parse-pdf -o`），不受 `read_dirs` 的 Edit-deny 限制（与 `/tmp/render` 同理）；worktree 内 `git add -A` 永不可见。

### FIX 2 — 引擎 FINALIZE「无可交付」干净终态（仅限巡检）
`orchestrator`：
- 新增 `_finalize_is_noop`：`git rev-list --count <baseline>..HEAD == 0` → 无可交付提交（保守：rc≠0/解析失败 → False）。
- `_advance_phase_or_terminate` 新增 `finalize_noop` 参数（默认 False，既有调用零变更）；FINALIZE 下「无 PR + 0 提交 + 本轮成功裁决」判 **succeeded 无 PR**。
- **严格合取 `is_success`、且仅 `config.patrol` 开启**——普通 feature routine 的「零改动收敛」（可能漏提交/跑空）不可一概判成功（首要安全护栏）。核心不变量：**no-op 成功仅在「可证明零可交付提交」时可达**。

配套 prompt（省一轮空转报错）：`prompt_builder` worktree FINALIZE 新增 STEP0（`rev-list --count` 为 0 → 输出 `PR_URL=NONE` 跳过 push/PR）；`patrol_prompt` 非回归门控补「零代码改动即 done 不开 PR、候选是 worktree 外临时产物不纳入交付」。

### 兜底
`.gitignore` 忽略 `patrol-candidate.md`，兜底 agent 路径漂移误在 worktree 写候选的极端场景。

## 预期效果
- 巡检 PR **仅含 perceives 代码改动**，永不含临时候选 `.md`。
- 已达标、无需改代码的文档：**不产出任何 PR**，引擎干净判 succeeded、记忆标 done、推进下一文档（零空转）。
- 有可修复缺陷的文档：照常产出**仅含 perceives 代码**的优化 PR。

## 测试
- `test_pdf_fidelity_patrol_handler`：候选路径为绝对路径、`== <source_read_dir>/patrol-candidate.md`（worktree 外）。
- `test_routine_phase`：FINALIZE prompt 含 `rev-list --count` 与 `PR_URL=NONE`，且守卫在 push/`gh pr create` 之前。
- `test_patrol_prompt`：系统协议含「零代码改动」规则。
- `test_routine_orchestrator`（集成，Postgres）：no-op 巡检 → succeeded / 无 PR；安全回归——有提交（探针 False）+ 无 PR → 留 running 仍须真实 PR。
- 既有 finalize/worktree 用例无回归（7/7 通过）；ruff lint+format 通过。

## 存量清理（建议人工确认）
junk PR #1010 可关闭并删其 head 分支（对外动作，建议由人工确认）。doc 013c5ebc 已因 best_score 96 标 done，不会重选复现。

## 范围外（仅记录）
巡检文档选择策略 / 合格阈值 95 是否过低致改动率不足，属调参/有效性议题，与本次「junk PR」根因正交，不在本次改动。
