### PR TITLE
docs(Changelog): 记录 cli.sh alembic 0078 迁移漂移修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cli.sh restart` 报 `Can't locate revision identified by '0078'`**：共享 `negentropy` dev DB 的 `alembic_version` 被超前 stamp 到 `0078`（`routine_iteration_events.agent_role` 列），但 `cli.sh` 从部署分支 `feature/1.x.x`（迁移树 head 仅到 `0077`）跑 alembic 时无法在自身树中定位 `0078`。根因是工作区（带未合并 PR #1013 的 migration 0078）曾以无效 env override 跑 alembic roundtrip——`NE_DATABASE__NAME` 并非 `DatabaseSettings` 真实字段，未重定向到临时库、实际落到共享 `negentropy` DB。修复：从工作区执行 `0078` 的 `downgrade()`（drop 空 `agent_role` 列，核查 113550 行该列 0 非空、零数据损失）realign DB 到 `0077`，与部署分支 head 对齐；前向安全已验证（`0077→0078` 幂等重应用，PR #1013 合并后自动复用）。防范：迁移测试须用真实 settings 字段或独立 DSN 重定向，勿依赖未映射的 env key。
+
 ### Changed
 
 - **Wiki 发布入口一体化 + 双目标发布**：`/knowledge/wiki` 工具栏的「从 Catalog 同步」「同步并发布」「仅发布」收敛为单一 **「发布」** 按钮（选 Catalog 节点 → 同步 → 发布），并新增**发布目标选择器**：


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/fix` 修复 `scripts/cli.sh restart` 报 `Can't locate revision identified by '0078'`（共享 dev DB 迁移指针漂移）后，需将修复摘要按项目规范沉淀到 CHANGELOG。PR #1013（Routine 多 Agent 归因）已合并，其 diff 未含 CHANGELOG，故独立提本 PR。
- 关联上下文：根因与修复详见 CHANGELOG 本次新增条目；相关迁移为 0078（agent_role，随 #1013 入 feature/1.x.x）。

# 核心变更
- CHANGELOG.md `[Unreleased]` 新增 `### Fixed` 段，记录：①问题（cli.sh 从部署分支 `feature/1.x.x` 跑 alembic 无法在自身迁移树定位 `0078`）；②根因（工作区以无效 env override `NE_DATABASE__NAME` 跑 alembic roundtrip，未重定向到临时库、实际 stamp 共享 `negentropy` DB 到 0078，超前于部署分支 head 0077）；③修复（执行 `0078.downgrade()` realign DB 到 0077，核查该列 0 非空零数据损失）；④防范（迁移测试须用真实 settings 字段或独立 DSN 重定向）。

# 风险与回滚
- 主要风险：纯文档变更，无运行时影响。
- 回滚方式：revert 该 commit（移除 CHANGELOG Fixed 段）。

# 验证证据
- 单元测试：N/A（仅 CHANGELOG.md，+4 行）。
- 集成测试：N/A。
- E2E/Workflow：cli.sh Phase 3 alembic 升级路径已实机验证（DB realign 至 0077 后 `upgrade head` 干净 no-op）。
- 覆盖率/关键截图：N/A。

# 影响范围
- 前端：无。
- 后端：无（仅文档）。
- GitHub Actions / 文档：CHANGELOG.md 新增 Fixed 段。

# Next Best Action
- 该 PR 为轻量文档沉淀，可直接合入；合入后 dev 环境的 alembic 状态记录与代码库一致。后续工作区迁移测试改用真实 DSN 重定向以防同类 drift。