### PR TITLE
fix(perceives/pdf): auto_batch 切片超时兜底 + 首页标题守卫

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
@@ -550,6 +550,20 @@ async def _run_batched_pipeline(
         completed[i] = slice_result
         _save_slice_checkpoint(checkpoint_dir, i, page_start, page_end, slice_result)
 
+    # 首页标题守卫：docling 在全量批次中偶发丢弃首页标题/作者/摘要块（p1 单独跑
+    # pymupdf 可完整产出）。对 page0 切片用 pymupdf page0 原文补回缺失前导内容，
+    # 覆盖 checkpoint resume 与新跑两条路径（resume 会跳过 _execute_slice_with_retry）。
+    if (
+        slice_ranges
+        and slice_ranges[0][0] == 0
+        and completed
+        and completed[0] is not None
+    ):
+        first_md = getattr(completed[0], "markdown", "") or ""
+        guarded = _ensure_first_page_header(first_md, pdf_source)
+        if guarded != first_md:
+            completed[0].markdown = guarded
+
     # 收集成功切片
     successful_results = [r for r in completed if r is not None]
     successful_ranges = [rg for r, rg in zip(completed, slice_ranges) if r is not None]
@@ -776,6 +790,83 @@ async def _fallback_slice_lightweight(
         engines_used=["pymupdf-fallback"],
         metadata={"fallback_engine": "pymupdf"},
     )
+
+
+def _ensure_first_page_header(markdown: str, pdf_source: str) -> str:
+    """首页标题守卫：若首页切片 markdown 缺失文档标题，用 pymupdf page0 原文补回。
+
+    背景：docling 文本引擎在全量批次中偶发丢弃首页标题/作者/摘要块，而 p1 单独跑
+    pymupdf 可完整产出。本守卫取 pymupdf page0 首个非空行（≈文档标题），若该标题
+    不在 markdown 中（任意位置），则把 page0 原文前导部分（标题+作者+摘要）以 H1
+    形式前置补回；截至首个已存在于 markdown 的行（去重边界），无重叠则截至首个
+    疑似章节标题（Contents / "1 Introduction" 等）。
+
+    幂等：标题已存在则原样返回；pymupdf 抽取失败/无 page0 文本则原样返回（安全降级）。
+    """
+    import re
+
+    if not markdown or not pdf_source:
+        return markdown
+    try:
+        from ..pdf._imports import import_fitz
+
+        fitz = import_fitz()
+        doc = fitz.open(pdf_source)
+        if doc.page_count == 0:
+            return markdown
+        p0_text = doc[0].get_text("text")
+        doc.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "首页标题守卫：pymupdf page0 抽取失败 source=%s err=%s", pdf_source, exc
+        )
+        return markdown
+
+    p0_lines = [ln.strip() for ln in p0_text.splitlines() if ln.strip()]
+    if not p0_lines:
+        return markdown
+    title = p0_lines[0]
+
+    def _norm(s: str) -> str:
+        return re.sub(r"\s+", " ", s).strip().lower()
+
+    title_norm = _norm(title)
+    md_norm = _norm(markdown)
+    # 标题已存在于 markdown（任意位置）→ 无需补回
+    if title_norm and title_norm in md_norm:
+        return markdown
+
+    # 去重边界：page0 中首个（除标题外）已存在于 markdown 的长行
+    boundary = None
+    for ln in p0_lines[1:]:
+        lnn = _norm(ln)
+        if lnn and len(lnn) >= 12 and lnn in md_norm:
+            boundary = ln
+            break
+
+    if boundary is not None:
+        idx = p0_text.find(boundary)
+        recovered = p0_text[:idx].strip() if idx > 0 else title
+    else:
+        # 无重叠：补到首个疑似章节标题（Contents / "1 Introduction" 等）前
+        rec_lines = [title]
+        for ln in p0_lines[1:]:
+            if re.match(r"^(?:contents|\d+(?:\.\d+)*\s+[A-Z])", ln, re.IGNORECASE):
+                break
+            rec_lines.append(ln)
+        recovered = "\n".join(rec_lines).strip()
+
+    if not recovered:
+        return markdown
+    # 标题作 H1，其余作正文段落
+    body = "\n".join(recovered.splitlines()[1:]).strip()
+    header_md = f"# {title}".strip()
+    if body:
+        header_md += "\n\n" + body
+    logger.info(
+        "首页标题守卫：补回缺失前导内容 title=%r chars=%d", title[:60], len(header_md)
+    )
+    return header_md + "\n\n" + markdown.lstrip()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
@@ -510,12 +510,39 @@ async def _run_batched_pipeline(
                 f"({per_slice_timeout:.0f}s budget)"
             )
             logger.warning("[batch %d/%d] %s", i + 1, len(slice_ranges), err)
+            fallback = await _fallback_slice_lightweight(
+                pdf_source=pdf_source,
+                page_range=(page_start, page_end),
+                output_dir=output_dir,
+                slice_index=i,
+                total_slices=len(slice_ranges),
+            )
+            if fallback is not None:
+                completed[i] = fallback
+                _save_slice_checkpoint(
+                    checkpoint_dir, i, page_start, page_end, fallback
+                )
+                continue
             partial_failures.append((page_start, page_end, err))
             _save_slice_failure(checkpoint_dir, i, page_start, page_end, err)
             continue
 
         if slice_result is None:
             err = f"slice [{page_start}, {page_end}) failed after retry"
+            logger.warning("[batch %d/%d] %s", i + 1, len(slice_ranges), err)
+            fallback = await _fallback_slice_lightweight(
+                pdf_source=pdf_source,
+                page_range=(page_start, page_end),
+                output_dir=output_dir,
+                slice_index=i,
+                total_slices=len(slice_ranges),
+            )
+            if fallback is not None:
+                completed[i] = fallback
+                _save_slice_checkpoint(
+                    checkpoint_dir, i, page_start, page_end, fallback
+                )
+                continue
             partial_failures.append((page_start, page_end, err))
             _save_slice_failure(checkpoint_dir, i, page_start, page_end, err)
             continue
@@ -654,6 +681,101 @@ async def _execute_slice_with_retry(
                 exc,
             )
     return None
+
+
+async def _fallback_slice_lightweight(
+    *,
+    pdf_source: str,
+    page_range: Tuple[int, int],
+    output_dir: Optional[str],
+    slice_index: int,
+    total_slices: int,
+) -> Optional[Any]:
+    """切片超时/二次失败后的轻量引擎兜底：用 pymupdf 回收文字内容。
+
+    必要性：auto 重型引擎（docling/mineru/marker）在大切片上可能整体超时，
+    原逻辑直接丢弃整段内容（如标题/摘要/目录/前几章），致 Markdown 从中段起始、
+    ``partial success``。本兜底在超时/失败后用本地快速引擎 pymupdf 重跑该切片
+    页范围，至少回收文字、标题与段落顺序，避免内容整段丢失（图片资产适配较重，
+    本兜底不回填 ``image_assets``；其文字保真已远胜于完全丢弃）。
+
+    Returns:
+        成功时返回 :class:`PipelineResult`（``engines_used`` 标记
+        ``pymupdf-fallback``）；兜底亦失败/超时/异常/空内容时返回 ``None``。
+    """
+    from ..pipeline import PipelineResult
+
+    start, end = page_range
+    fallback_budget = 120.0
+    try:
+        pdf_processor = create_pdf_processor(
+            enable_enhanced_features=False, output_dir=output_dir
+        )
+        async with asyncio.timeout(fallback_budget):
+            result = await pdf_processor.process_pdf(
+                pdf_source=pdf_source,
+                method="pymupdf",
+                include_metadata=False,
+                page_range=(start, end),
+                output_format="markdown",
+                extract_images=False,
+                extract_tables=False,
+                extract_formulas=False,
+                embed_images=False,
+                enhanced_options=None,
+            )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[batch %d/%d] 轻量兜底超时 pages=%d-%d budget=%ds",
+            slice_index + 1,
+            total_slices,
+            start + 1,
+            end,
+            int(fallback_budget),
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[batch %d/%d] 轻量兜底异常 pages=%d-%d: %s",
+            slice_index + 1,
+            total_slices,
+            start + 1,
+            end,
+            exc,
+        )
+        return None
+
+    if not result.get("success"):
+        logger.warning(
+            "[batch %d/%d] 轻量兜底失败 pages=%d-%d error=%s",
+            slice_index + 1,
+            total_slices,
+            start + 1,
+            end,
+            result.get("error", "unknown"),
+        )
+        return None
+
+    markdown = result.get("content", result.get("markdown", ""))
+    if not markdown.strip():
+        return None
+
+    logger.info(
+        "[batch %d/%d] 轻量兜底成功(pymupdf) pages=%d-%d words=%s",
+        slice_index + 1,
+        total_slices,
+        start + 1,
+        end,
+        result.get("word_count", 0),
+    )
+    return PipelineResult(
+        success=True,
+        markdown=markdown,
+        page_count=result.get("page_count", end - start),
+        word_count=result.get("word_count", 0),
+        engines_used=["pymupdf-fallback"],
+        metadata={"fallback_engine": "pymupdf"},
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景
PDF→Markdown 高保真巡检（doc_id=5e927c6d，71 页综述《Agent Harness Engineering: A Survey》）发现两个内容丢失缺陷，均源于 `apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py` 的 auto 批处理路径。

## 改动（纯增量，+213/-0，仅 ops/pdf.py）

### 1. 切片超时/失败后 pymupdf 轻量兜底（commit d0c44d55）
**问题**：auto 路径按页批处理时，单切片重型引擎（docling/mineru/marker）整体超时即被丢弃，致大文档前段（标题/摘要/目录/前几章，约 28%）整段缺失，Markdown 从中段起始并标记 `partial success`。
**修复**：在 `_run_batched_pipeline` 的超时与二次失败分支，丢弃前先以本地快速 pymupdf 引擎重跑该切片页范围（120s 预算），回收文字内容，封装为 `PipelineResult`（`engines_used` 标 `pymupdf-fallback`）；pymupdf 亦失败则优雅回退原 `partial_failure` 行为。

### 2. 首页标题守卫（commit a9f1649f）
**问题**：docling 文本引擎在全量批次中偶发丢弃首页标题/作者/摘要块（p1 单独跑 pymupdf 可完整产出），致 Markdown 从 Figure/Contents 起始、丢失论文身份信息。
**修复**：新增 `_ensure_first_page_header()`，在 `_run_batched_pipeline` 收集切片后对 page0 切片调用——用 pymupdf `page0.get_text` 取首行（标题），若不在该切片 markdown 中则以 H1 前置补回标题+作者+摘要（截至去重边界或首个章节标题）。置于循环后以覆盖 checkpoint resume 与新跑两条路径；幂等且 fitz 失败时安全降级。

## 验证
- 巡检文档：候选从 `partial success`（1276 行、缺前 28%）→ 完整 `Success`（1593 行），标题/11 作者/Abstract/目录/§1-13/References/附录/8 图/10 表齐全，保真度 90→96，判 done。
- 非回归：`test_pdf_auto_batch.py` 15/15 通过；ruff format/lint + mypy 通过。
- 改动为纯增量（只补内容不删），fake PDF 下 fitz 失败→安全降级原样返回，回归风险极低。

## 备注
perceives 全量单测有 1 个**与本次改动无关的既有失败**：`test_config.py::test_default_settings`（`concurrent_requests` 默认 32 vs 测试期望 16），属基线 config 测试漂移，本次 diff 仅 `ops/pdf.py`，未触碰 config，不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)