### PR TITLE
feat(Routine): Full View 重塑为「人↔CC 对话」主线（人先发言 + CC 冗余折叠）

### DIFF
--- a/apps/negentropy-ui/app/dev-transcript/TimelinePreview.tsx
+++ b/apps/negentropy-ui/app/dev-transcript/TimelinePreview.tsx
@@ -44,7 +44,12 @@ export function TimelinePreview() {
         人机交互回合（6 Agent ↔ Claude Code）
       </h2>
       <div data-testid="transcript-preview-human-loop" className="rounded-card border border-border bg-card p-4">
-        <IterationEventTimeline events={humanLoopEvents} />
+        <IterationEventTimeline
+          events={humanLoopEvents}
+          openingPrompt={
+            "你是 NegentropyEngine。请修复 number keys 注册逻辑：组合键（Shift+数字）与连击去抖，补单测，通过 `pnpm test`。验收：边缘 case 全覆盖、回归绿。"
+          }
+        />
       </div>
 
       <h2 className="mb-2 mt-6 text-body-lg font-semibold text-foreground">在途态（LIVE / 运行中）</h2>

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -125,7 +125,7 @@ export function IterationAuditDrawer({
         {loading && merged.length === 0 ? (
           <TimelineSkeleton />
         ) : merged.length > 0 ? (
-          <IterationEventTimeline events={merged} live={isInFlight} />
+          <IterationEventTimeline events={merged} live={isInFlight} openingPrompt={iteration?.prompt ?? null} />
         ) : (
           !error && <EmptyState iteration={iteration} />
         )}

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -23,10 +23,13 @@ const BADGE_BASE = "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 te
 export function IterationEventTimeline({
   events,
   live,
+  openingPrompt,
 }: {
   events: RoutineIterationEventDTO[];
   /** 是否处于在途实时态（显示 LIVE 脉冲；驱动工具行运行态）。 */
   live?: boolean;
+  /** 迭代任务 prompt（人下发给 CC 的任务）——非空时合成为开场「人→机」task_dispatch 回合。 */
+  openingPrompt?: string | null;
 }) {
   const groups = useMemo(() => groupEvents(events), [events]);
 
@@ -60,7 +63,7 @@ export function IterationEventTimeline({
       </div>
 
       {/* 扁平转录流 */}
-      <TranscriptView events={events} live={live} />
+      <TranscriptView events={events} live={live} openingPrompt={openingPrompt} />
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/transcript/AssistantText.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/transcript/AssistantText.tsx
@@ -1,23 +1,56 @@
 "use client";
 
-import { Brain } from "lucide-react";
+import { useState } from "react";
+import { AlertTriangle, Brain, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
 
 import { MarkdownText } from "../MarkdownText";
 import type { TranscriptItem } from "./types";
 
+/** CC 自报交互异常的模式（如 AskUserQuestion 在 headless 下被 CLI 报错）——命中则红显，让断链可见。 */
+const CC_ERROR_RE = /returned an error|AskUserQuestion.*\berror\b|tool_use_id.*not found/i;
+
 /**
- * Claude Code 的 assistant 文本 —— 行内流式 Markdown（无气泡、无逐行头像）。
- * thinking（推理）以灰显 Brain 前缀 + 斜体呈现，与正式回复区分。
+ * Claude Code 的 assistant 文本。
+ *
+ * - **交互异常**（匹配 ``CC_ERROR_RE``，如 "The AskUserQuestion returned an error"）：红显 + ⚠ 图标，
+ *   让人机交互断链可见（驱动后端修复）。
+ * - **thinking（推理）**：默认折叠为单行「思考…」，点击展开——避免长推理刷屏、淹没人机回合主线。
+ * - **正文**：行内流式 Markdown，提亮至 foreground。
  */
 export function AssistantText({ item }: { item: Extract<TranscriptItem, { kind: "assistant" }> }) {
-  if (item.thinking) {
+  if (CC_ERROR_RE.test(item.text)) {
     return (
-      <div className="flex gap-1.5">
-        <Brain className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden />
-        <MarkdownText content={item.text} className="italic [&_p]:text-text-secondary" />
+      <div className="flex gap-1.5 rounded-md border border-red-500/25 bg-red-500/[0.05] px-2 py-1.5">
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-500" aria-hidden />
+        <MarkdownText content={item.text} className="[&_p]:text-red-600 dark:[&_p]:text-red-400" />
       </div>
     );
   }
+  if (item.thinking) {
+    return <ThinkingText text={item.text} />;
+  }
   // 正文提亮至 foreground，贴合 paseo 中栏对比度
   return <MarkdownText content={item.text} className="[&_li]:text-foreground [&_p]:text-foreground" />;
+}
+
+/** 可折叠的 thinking 推理片段——默认收起为单行，点击展开全文。 */
+function ThinkingText({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="group inline-flex w-fit items-center gap-1 rounded-md px-1 py-0.5 text-caption text-text-muted transition-colors hover:bg-muted/40 hover:text-text-secondary"
+      >
+        <Brain className="h-3.5 w-3.5" aria-hidden />
+        <span>{open ? "思考展开" : "思考…"}</span>
+        <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} aria-hidden />
+      </button>
+      {open ? <MarkdownText content={text} className="mt-0.5 italic [&_p]:text-text-secondary" /> : null}
+    </div>
+  );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/transcript/TaskDispatchBubble.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/transcript/TaskDispatchBubble.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+
+import { MarkdownText } from "../MarkdownText";
+import { RoleHeader } from "./message-shared";
+
+/**
+ * 开场「人（一核 Engine）→ 机（Claude Code）」任务下发回合。
+ *
+ * 任务由 Negentropy Engine（一核，人）发起，故「人」先发言——此气泡即对话的第一句：
+ * 把 ``iteration.prompt``（目标 / 验收 / 反思 / 记忆注入）作为人下发给 CC 的任务，
+ * 仿 Conductor ``UserMessage``（背景高亮、整段任务文本），并标一核角色 + 「→ Claude Code」方向。
+ * 由 ``TranscriptView`` 据 ``openingPrompt`` 合成前置，非事件流原始项。
+ */
+export function TaskDispatchBubble({ prompt }: { prompt: string }) {
+  return (
+    <div className="min-w-0 max-w-[92%] rounded-2xl rounded-tr-sm border border-primary/20 bg-primary/[0.06] px-4 py-3">
+      <RoleHeader role="engine" sublabel="下发任务 · Dispatch">
+        <span className="inline-flex items-center gap-1 text-caption font-medium text-primary">
+          <ArrowRight className="h-3 w-3" aria-hidden />
+          Claude Code
+        </span>
+      </RoleHeader>
+      <MarkdownText content={prompt} />
+    </div>
+  );
+}

--- a/apps/negentropy-ui/app/interface/routine/_components/transcript/TranscriptView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/transcript/TranscriptView.tsx
@@ -15,14 +15,15 @@ import { HumanReplyBlock } from "./HumanReplyBlock";
 import { LucideGlyph } from "./Icon";
 import { normalizeTranscript } from "./normalize-transcript";
 import { PayloadDetail } from "./PayloadDetail";
+import { TaskDispatchBubble } from "./TaskDispatchBubble";
 import { ToolSummaryRow } from "./ToolSummaryRow";
 import { WorkingIndicator } from "./WorkingIndicator";
 import type { TranscriptItem } from "./types";
 
-/** 发言人侧：人机交互三分——human_reply 居右（人/6 Agent）、engine 居右（编排驱动方）、其余居左（机/Claude Code）。 */
+/** 发言人侧：人机交互三分——task_dispatch/human_reply 居右（人/6 Agent）、engine 居右（编排驱动方）、其余居左（机/Claude Code）。 */
 type Speaker = "cc" | "human" | "engine";
 function speaker(item: TranscriptItem): Speaker {
-  if (item.kind === "human_reply") return "human";
+  if (item.kind === "human_reply" || item.kind === "task_dispatch") return "human";
   if (item.kind === "engine") return "engine";
   return "cc";
 }
@@ -38,6 +39,8 @@ function gapClass(item: TranscriptItem, prev: TranscriptItem | null): string {
 /** 按 kind 分发渲染单项（key 与对齐/间距由外层 wrapper 统一处理）。 */
 function renderItem(item: TranscriptItem) {
   switch (item.kind) {
+    case "task_dispatch":
+      return <TaskDispatchBubble prompt={item.prompt} />;
     case "assistant":
       return <AssistantText item={item} />;
     case "tool":
@@ -57,13 +60,35 @@ function renderItem(item: TranscriptItem) {
   }
 }
 
+/** 稳定 key：task_dispatch 无 seq/id，用固定标识；其余用 kind+seq+id。 */
+function itemKey(item: TranscriptItem): string {
+  if (item.kind === "task_dispatch") return "task-dispatch";
+  return `${item.kind}-${item.seq}-${item.id}`;
+}
+
 /**
- * paseo 风格人机交互转录流：以「左右对齐」区分人机——Claude Code（机）裸文居左、紧凑工具行 /
- * 待决卡片，一核五翼 6 Agent（人）应答气泡居右、Engine 编排产出气泡居右；按 seq 时序交织，
- * 间距承载 turn 节奏。
+ * paseo 风格人机交互转录流：以「左右对齐」区分人机——开场 ``openingPrompt`` 合成「人（一核）→ 机」
+ * 任务下发回合居首，Claude Code（机）裸文居左、紧凑工具行 / 待决卡片，一核五翼 6 Agent（人）应答
+ * 气泡居右、Engine 编排产出气泡居右；按 seq 时序交织，间距承载 turn 节奏。
  */
-export function TranscriptView({ events, live }: { events: RoutineIterationEventDTO[]; live?: boolean }) {
-  const items = useMemo(() => normalizeTranscript(events, { live: !!live }), [events, live]);
+export function TranscriptView({
+  events,
+  live,
+  openingPrompt,
+}: {
+  events: RoutineIterationEventDTO[];
+  live?: boolean;
+  /** 迭代任务 prompt（人下发给 CC 的任务）——非空时合成为开场「人→机」task_dispatch 回合。 */
+  openingPrompt?: string | null;
+}) {
+  const normalized = useMemo(() => normalizeTranscript(events, { live: !!live }), [events, live]);
+  const items = useMemo<TranscriptItem[]>(
+    () =>
+      openingPrompt && openingPrompt.trim()
+        ? [{ kind: "task_dispatch", prompt: openingPrompt }, ...normalized]
+        : normalized,
+    [normalized, openingPrompt],
+  );
 
   // 在途态尾随运行指示器：末项若为待决的 CC 提交（等人裁决）显「Planning…」，否则「Working…」。
   const last = items[items.length - 1];
@@ -76,7 +101,7 @@ export function TranscriptView({ events, live }: { events: RoutineIterationEvent
         const side = speaker(item);
         return (
           <div
-            key={`${item.kind}-${item.seq}-${item.id}`}
+            key={itemKey(item)}
             className={cn(gapClass(item, prev), (side === "engine" || side === "human") && "flex justify-end")}
           >
             {renderItem(item)}

--- a/apps/negentropy-ui/app/interface/routine/_components/transcript/types.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/transcript/types.ts
@@ -64,11 +64,13 @@ export type HumanReplyMode =
 /**
  * 一条转录项：人机对话流的单元。
  *
+ * - 人（一核五翼 6 Agent）侧：``task_dispatch`` 开场任务下发 / ``human_reply`` 应答。
  * - 机（Claude Code）侧：``assistant`` 文本 / ``tool`` 调用 / ``tool_summary`` 折叠 / ``cc_request`` 提交。
- * - 人（一核五翼 6 Agent）侧：``human_reply`` 应答。
  * - 其余：``engine``（编排产出 gate/evaluation/result）/ ``system`` / ``truncated``。
  */
 export type TranscriptItem =
+  /** 开场「人（一核 Engine）→ 机」任务下发回合——由 iteration.prompt 合成，非事件流原始项。 */
+  | { kind: "task_dispatch"; prompt: string }
   | { kind: "assistant"; seq: number; id: string; text: string; thinking: boolean }
   | {
       kind: "tool";

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -132,14 +132,34 @@ describe("IterationEventTimeline assistant 文本", () => {
     expect(screen.getByText("正在检查当前分支。")).toBeInTheDocument();
   });
 
-  it("thinking 文本渲染其内容（不再显示『思考』标签）", () => {
+  it("thinking 默认折叠为「思考…」toggle，点击展开内容（避免长推理刷屏）", () => {
     render(
       <IterationEventTimeline
         events={[makeEvent({ event_type: "assistant", title: "thinking", tool_name: null, payload: { text: "推理内容在此" } })]}
       />,
     );
+    // 折叠态：toggle 可见、内容隐藏
+    expect(screen.getByText("思考…")).toBeInTheDocument();
+    expect(screen.queryByText("推理内容在此")).not.toBeInTheDocument();
+    // 点击展开
+    fireEvent.click(screen.getByText("思考…"));
     expect(screen.getByText("推理内容在此")).toBeInTheDocument();
-    expect(screen.queryByText("思考")).not.toBeInTheDocument();
+  });
+
+  it("CC 自报交互异常（returned an error）红显 + ⚠，让断链可见", () => {
+    render(
+      <IterationEventTimeline
+        events={[
+          makeEvent({
+            event_type: "assistant",
+            tool_name: null,
+            payload: { text: "The AskUserQuestion returned an error: invalid tool_use_id" },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/returned an error/)).toBeInTheDocument();
+    expect(screen.queryByText("思考…")).not.toBeInTheDocument();
   });
 
   it("空 assistant（仅 raw、无 text）不渲染空行", () => {
@@ -256,6 +276,28 @@ describe("IterationEventTimeline Engine 消息块", () => {
 // ---------------------------------------------------------------------------
 
 describe("IterationEventTimeline 人机回合（human_reply）", () => {
+  it("openingPrompt 合成开场「人(一核)→机」任务回合：人先发言", () => {
+    render(
+      <IterationEventTimeline
+        events={[makeEvent({ event_type: "assistant", tool_name: null, payload: { text: "我先调研。" } })]}
+        openingPrompt="你是 NegentropyEngine。请修复 number keys 注册逻辑。"
+      />,
+    );
+    // 一核（engine）角色 + 下发任务标签 + 任务正文在前（人先发言）
+    expect(screen.getByText("Negentropy")).toBeInTheDocument();
+    expect(screen.getByText("下发任务 · Dispatch")).toBeInTheDocument();
+    expect(screen.getByText(/请修复 number keys 注册逻辑/)).toBeInTheDocument();
+    // 任务回合（人侧）排在 CC 文本之前
+    const flow = document.querySelector(".flex.flex-col");
+    const html = flow?.innerHTML ?? "";
+    expect(html.indexOf("请修复 number keys 注册逻辑")).toBeLessThan(html.indexOf("我先调研。"));
+  });
+
+  it("openingPrompt 为空时不合成开场回合（兼容）", () => {
+    render(<IterationEventTimeline events={[makeEvent({ event_type: "assistant", tool_name: null, payload: { text: "干活" } })]} />);
+    expect(screen.queryByText("下发任务 · Dispatch")).not.toBeInTheDocument();
+  });
+
   it("plan_review approve 升格为 human_reply：显示元神角色 + Approved 徽章", () => {
     render(
       <IterationEventTimeline


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：真实 Routine（PDF 巡检 6609feb5）暴露 Full View 的结构性偏差——当前是「CC 工具日志 + 偶发 1 个 Review」（60 项里仅 2 项人侧），人机交互被淹没、且任务由 Engine 发起却让 CC 先发言，不符合「6 Agent（人）↔ Claude Code（机）对话」的原始要求。
- 关联上下文：本 PR 为渲染先行（独立 PR）；执行层修复（Plan Review 回路断链）与 FacultyBridge 真实多 Agent 紧随（分 PR）。根因诊断见 plan：headless CC 下 `plan_review_via_hook=False` 的 stdin 回灌对 AskUserQuestion 无效，致元神 refine 被忽略（PR 2a 修复）。

# 核心变更
- **「人」先发言**：`TranscriptView` 接收 `openingPrompt`（= `iteration.prompt`，任务由一核 Engine 发起），合成开场 `task_dispatch` 回合——新建 `TaskDispatchBubble`（Conductor `UserMessage` 范式：一核角色徽标 +「下发任务 · Dispatch」+「→ Claude Code」方向 + 任务正文，居右人侧、置首）。`IterationAuditDrawer` → `IterationEventTimeline` → `TranscriptView` 透传 `iteration.prompt`。
- **CC 冗余折叠**：`AssistantText` 的 thinking 默认折叠为「思考…」toggle（点击展开），避免长推理刷屏、淹没人机回合主线；工具折叠（`tool_summary` ≥3）保留。
- **交互异常可见**：`AssistantText` 命中 CC 自报错误模式（如 "The AskUserQuestion returned an error"）时红显 + ⚠，让人机交互断链可见（驱动 PR 2a）。

# 风险与回滚
- 主要风险：纯前端渲染变更，无运行时影响；transcript 节点模型加 `task_dispatch` kind（合成项，非事件流）。
- 回滚方式：revert 该 commit。

# 验证证据
- 单元测试：typecheck(prod+test)/lint=0；全量 **894 测试 / 110 文件通过**（新增 task_dispatch 开场/思考折叠/异常红显断言）。
- 集成测试：N/A（前端 only）。
- E2E/Workflow：dev-transcript 实机确认「一核下发任务 → CC → Review plan → 元神 Review」对话主线、人先发言（DOM 校验 order）。
- 覆盖率/关键截图：dev-transcript light/dark 已核对。

# 影响范围
- 前端：`apps/negentropy-ui` transcript 渲染层（TaskDispatchBubble 新建、TranscriptView/AssistantText/types 改）+ IterationAuditDrawer/IterationEventTimeline 透传 openingPrompt + dev-transcript fixture。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 紧随的 PR 2a（后端）：修复 Plan Review 回路断链——unified loop 的 plan 段强制走 PreToolUse 钩子（`via_hook=True`），让元神的 refine verdict/feedback 真实回灌 CC、被采纳（不再 `AskUserQuestion returned an error`）。其后 PR 2b：FacultyBridge 真实多 Agent，让元神/本心/妙手/慧眼/喉舌真正登场。