### PR TITLE
fix(perceives): CLI parse-pdf 补齐图片资产落盘，修复 ./images/ 引用死链

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
@@ -14,6 +14,43 @@ except ImportError:
     raise ImportError("CLI dependencies not installed. Install with: uv add typer rich")
 
 
+def _copy_image_assets(result, output: str) -> None:
+    """将抽取的图片资产拷贝到 markdown 输出目录的 ``images/`` 子目录。
+
+    传统（非 auto pipeline）路径把图片写到 ``EnhancedPDFProcessor.output_directory``
+    ——当上层未透传 ``output_dir`` 时即 ``tempfile.mkdtemp('enhanced_pdf_*')`` 临时目录。
+    此前 CLI 仅写 markdown 文本、不搬运图片资产，导致候选中 ``./images/<filename>``
+    引用全部死链。此处补齐资产落地，使 markdown 图片引用可达。
+
+    auto pipeline 路径自带 ``image_assets`` 落盘逻辑，其 ``enhanced_assets`` 结构不同，
+    ``output_directory`` 缺失时本函数直接 no-op，互不影响。
+    """
+    import shutil
+    from pathlib import Path
+
+    ea = getattr(result, "enhanced_assets", None) or {}
+    src_dir = ea.get("output_directory")
+    if not src_dir:
+        return
+    src_path = Path(src_dir)
+    if not src_path.is_dir():
+        return
+    image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
+    candidates = [
+        p for p in src_path.iterdir() if p.is_file() and p.suffix.lower() in image_exts
+    ]
+    if not candidates:
+        return
+    images_dst = Path(output).resolve().parent / "images"
+    images_dst.mkdir(parents=True, exist_ok=True)
+    for src in candidates:
+        try:
+            shutil.copy2(src, images_dst / src.name)
+        except OSError:
+            # 单图拷贝失败不应中断整体输出落盘（如只读源/目标磁盘满）。
+            pass
+
+
 def run(
     pdf_source: str = typer.Argument(..., help="PDF source (URL or local file path)"),
     method: str = typer.Option(
@@ -121,6 +158,9 @@ async def _run(
         from pathlib import Path
 
         Path(output).write_text(formatted, encoding="utf-8")
+        # 补齐图片资产落盘：传统路径图片写到 EnhancedPDFProcessor.output_directory
+        # （可能为临时目录），需拷贝到 -o 同级 images/ 使 ./images/<filename> 引用可达。
+        _copy_image_assets(result, output)
         console.print(f"[green]Output saved to {output}[/green]")
     else:
         console.print(formatted)


### PR DESCRIPTION
## 背景

PDF→Markdown 巡检（doc 53224706《Agentic Design Patterns》，482 页）发现：传统（非 auto pipeline）CLI 路径产出的 markdown 中，`./images/<filename>` 图片引用**全部死链**。

## 根因

- 传统路径把抽取图片写到 `EnhancedPDFProcessor.output_directory`——上层未透传 `output_dir` 时即 `tempfile.mkdtemp('enhanced_pdf_*')` 临时目录（`pdf/enhanced.py:67`）。
- CLI `parse-pdf` 此前**仅写 markdown 文本**（`cli/commands/parse_pdf.py`），不搬运图片资产 → 引用指向的 `images/` 不存在。
- 候选图片临时目录路径已在 `result.enhanced_assets["output_directory"]`（`get_extraction_summary()` 顶层字段）暴露，但未被消费。

## 改动（单文件 +40 行）

`apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py` 新增 `_copy_image_assets`：写完 markdown 后，从 `result.enhanced_assets["output_directory"]` 将图片 `shutil.copy2` 到 `-o` 同级 `images/`，使 `./images/<filename>` 引用可达。

- 仅拷贝图片扩展名文件；单图 `OSError` 不中断整体落盘。
- auto pipeline 路径 `enhanced_assets` 无 `output_directory` 字段 → `no-op`，互不影响。

## 验证

- 巡检：482 页 pymupdf 兜底转换 `images/` 落地 **65 张图**，markdown **75 个图片引用 0 不可达**（修复前全部死链）。
- 非回归：auto 方法 3 页小段 `Status: Success`（pipeline 路径不受影响）；全量 pymupdf 转换成功；pre-commit（ruff format/lint + mypy）全过；`pytest tests/unit` 333 passed（唯一失败 `test_config::test_default_settings` 系本机用户级 config 覆盖 `concurrent_requests=32` 所致，SSOT `config.default.yaml`=16、test 期望 16 均正确，CI 无此覆盖则通过，与本改动无关）。

## 影响面

纯增量、仅 CLI 输出落盘环节；不改变转换路由与文本产出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)