### PR TITLE
fix(perceives): PDF 高保真巡检三处修复（em-dash注释/公式去重/结果表TOC）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -821,7 +821,11 @@ class MarkdownFormatter:
             from ..pdf.math_formula import protect_math_content
 
             def _typography_inner(text: str) -> str:
-                text = re.sub(r"(?<!\-)\-\-(?!\-)", "\u2014", text)
+                # \u8d1f\u5411\u65ad\u8a00\u6269\u5c55\uff1a``<!--`` / ``-->`` \u7b49 HTML \u6ce8\u91ca\u5b9a\u754c\u7b26\u4e2d\u7684 ``--``
+                # \u4e0d\u8f6c\u4e3a em-dash\uff08lookbehind \u589e ``!``\u3001lookahead \u589e ``>``\uff09\u3002
+                # code block / LaTeX \u5df2\u7531 protect \u6d41\u7a0b\u4fdd\u62a4\uff0cHTML \u6ce8\u91ca\u6b64\u524d\u6f0f\u7f51\uff0c
+                # \u81f4 ``<!-- orphan images ... -->`` \u88ab\u7834\u574f\u4e3a\u53ef\u89c1\u5783\u573e ``<!\u2014 \u2026 \u2014>``\u3002
+                text = re.sub(r"(?<![!\-])\-\-(?![\->])", "\u2014", text)
 
                 # \u5f15\u7528\u7f16\u53f7\u7a7a\u683c\u538b\u7f29\uff1a"[ 103 ]" \u2192 "[103]"\uff0c"[ 95, 99, 105 ]" \u2192 "[95, 99, 105]"
                 text = re.sub(r"\[\s+(\d+(?:\s*,\s*\d+)*)\s+\]", r"[\1]", text)

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1296,6 +1296,9 @@ def _formula_text_signature(s: str) -> str:
     用于跨形式公式去重：
       - LaTeX 命令 ``\\xxx`` 全部剥除（``\\theta``、``\\in``、``\\wedge`` 等
         无文本字符等价，丢弃即可）；
+      - ``\\begin{...}{...}`` / ``\\end{...}`` 排版结构（如 ``\\begin{array}{r}``
+        的 ``array``/``r``/``l``/``c`` 列规格）整段剥除——这些是版式噪声而非
+        公式语义字符，混入会膨胀 fsig 致碎片文本块的覆盖率失真；
       - 大括号 / 下标符号 / 标点 / 空白 / Unicode 数学符号 全部丢弃；
       - 仅保留 ASCII 字母数字。
 
@@ -1303,6 +1306,8 @@ def _formula_text_signature(s: str) -> str:
     保留为独立字符，与 MinerU 提取的 LaTeX 字符序列（同样把 ``M _ { l }``
     拆为 ``M l`` 等）经归一化后几乎完全相同。该签名作为跨形式等价锚点。
     """
+    # 先剥离开 \begin{...} / \end{...} 及其紧随的列规格 {...}（版式结构噪声）
+    s = re.sub(r"\\(?:begin|end)\s*\{[^{}]*\}(?:\s*\{[^{}]*\})?", "", s)
     # 剥离 \xxx LaTeX 命令
     s = re.sub(r"\\[a-zA-Z]+\*?", "", s)
     # 仅保留 ASCII 字母数字
@@ -1339,12 +1344,22 @@ def _text_block_matches_formula(
     if len(text_sig) < 20:
         return False
     for fsig in sigs:
-        if fsig not in text_sig:
-            continue
-        # 子串匹配 → 进一步判定长度比例，过滤"公式埋在长正文段"假阳性
-        len_ratio = len(fsig) / max(len(text_sig), 1)
-        if len_ratio >= 0.85:
-            return True
+        # 正向：完整公式签名是文本块签名的子串（PyMuPDF 把整个公式视觉区
+        # 抽成一段字符流文本，签名与公式 LaTeX 几乎全等）。
+        if fsig in text_sig:
+            # 子串匹配 → 进一步判定长度比例，过滤"公式埋在长正文段"假阳性
+            len_ratio = len(fsig) / max(len(text_sig), 1)
+            if len_ratio >= 0.85:
+                return True
+        # 反向：文本块签名是公式签名的子串（PyMuPDF 把一个公式视觉区拆成
+        # 多个碎片文本块，每块签名是完整公式签名的片段，正向 fsig-in-text_sig
+        # 因 fsig 更长而失配）。要求文本块覆盖公式签名的较大比例(≥0.4)，
+        # 避免短巧合子串误杀正文——公式签名为密集字母数字串、无词边界，
+        # 正文连写词几乎不可能 ≥20 字符地落入其中，FP 风险极低。
+        if text_sig in fsig:
+            coverage = len(text_sig) / max(len(fsig), 1)
+            if coverage >= 0.4:
+                return True
     return False
 
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1626,6 +1626,13 @@ def _is_toc_table_text(text: str) -> bool:
     """
     if not text:
         return False
+    # 带 "Table N:" / "Figure N:" / "表 N:" caption 的结果表绝非目录（TOC）。
+    # 结果表常含数值列（如 P_drop=0.1 形似章节号、BLEU/params 整数形似页码），
+    # 会误命中下方的 section_no_rows / page_no_rows 启发式而被当成 TOC 丢弃
+    # （如 Attention 论文 Table 3 架构变体表）。caption 起手即排除。
+    first_line = text.split("\n", 1)[0].strip()
+    if re.match(r"^(?:Table|Figure|Tab\.|Fig\.|表|图)\s*\d", first_line, re.IGNORECASE):
+        return False
     lines = [ln for ln in text.split("\n") if ln.strip().startswith("|")]
     if len(lines) < 3:
         return False


### PR DESCRIPTION
## 概述

PDF→Markdown 高保真巡检（doc b7a03660，Attention Is All You Need）驱动的 perceives 三处定点修复。候选 Markdown 重转 + 采样比对定位缺陷，逐项最小改动 + 单元/重转验证，pre-commit ruff/mypy 通过，perceives 相关单测 587 passed。

## 变更

1. **em-dash 破坏 HTML 注释定界符** (`markdown/formatter.py`)
   `_apply_typography_fixes` 的 `--→—` 规则会把 `<!--`/`-->` 中的 `--` 转成 em-dash，致 HTML 注释渲染为可见垃圾（`<!— orphan images … —>`）。code block/LaTeX 已有保护，HTML 注释漏网。收紧正则负向断言（lookbehind 增 `!`、lookahead 增 `>`）跳过注释定界符，正常 em-dash 不变。

2. **公式碎片文本去重** (`pipeline/stages/pdf/assembly.py`)
   PyMuPDF 常把单公式视觉区抽成多个碎片文本块，每块签名短于完整公式签名，原正向 `fsig-in-text_sig` 失配，致公式重复（乱序行内文本 + 正确 LaTeX 块）。①`_formula_text_signature` 先剥离 `\begin{array}{...}` 列规格噪声；②`_text_block_matches_formula` 新增反向子串匹配 `text_sig-in-fsig`（覆盖率≥0.4）。复现文档 eq(1)/MultiHead/PE 去重生效，正文 FP 校验通过。

3. **结果表 TOC 误判修复** (`pipeline/stages/pdf/assembly.py`)
   `_is_toc_table_text` 把含数值列的结果表误判 TOC 丢弃（小数形似章节号、整数形似页码，如 Table 3 架构变体表）。新增 caption 守卫：首行以 `Table/Figure N` 起手即判非 TOC；真实多列 TOC 仍被正确捕获（单元验证）。

## 已知遗留（unfixable，非本 PR 范围）

- 表格提取非确定性（docling engine_pool 超时/缓存，cold/warm 0~4 表波动）——基础设施级。
- 公式残留 3 行（PyMuPDF 上下标渲染顺序 vs LaTeX 不可子串匹配）。
- 参考文献缺号（text_extraction engine-stage 丢弃）。
- 行内数学空格伪影（PyMuPDF 文本层 artifact）。

## 验证
- `uv run ruff check`：All checks passed
- `uv run pytest tests/unit`（perceives 相关）：587 passed, 5 skipped（PDF 资产缺失，无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
