### PR TITLE
feat(Routine): PR Merge 状态回写并在 Full View / 列表 / PR 抽屉三处标记「Merged」

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { ArrowLeft, RotateCcw } from "lucide-react";
+import { ArrowLeft, GitMerge, RotateCcw } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/Button";
@@ -15,6 +15,7 @@ import {
   cleanupWorktree,
   controlRoutine,
   rejectIteration,
+  syncRoutinePr,
   useRoutineDetailLive,
 } from "@/features/routine";
 
@@ -106,6 +107,17 @@ export default function RoutineRunPage() {
     }
   }, [id, reload]);
 
+  // 手动同步 PR 合并状态：合并后即时回写 pr_merged（无需等~5min 心跳轮询）。
+  const handleSyncPr = useCallback(async () => {
+    if (!id) return;
+    try {
+      await syncRoutinePr(id);
+      await reload();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to sync PR status");
+    }
+  }, [id, reload]);
+
   const { requestRestart, restartDialog } = useRestartRoutine(() => void reload());
 
   const clockActive = routine?.status === "running";
@@ -138,6 +150,12 @@ export default function RoutineRunPage() {
                       className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(routine.status)}`}
                     >
                       {routine.status}
+                    </span>
+                  )}
+                  {routine?.status === "succeeded" && routine.pr_url && routine.pr_merged && (
+                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-violet-500/10 px-2.5 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-300">
+                      <GitMerge className="h-3.5 w-3.5" aria-hidden />
+                      Merged
                     </span>
                   )}
                   {routine?.current_phase && routine.status === "running" && (
@@ -193,6 +211,7 @@ export default function RoutineRunPage() {
                 onApproveIteration={handleApprove}
                 onRejectIteration={handleReject}
                 onCleanupWorktree={handleCleanupWorktree}
+                onSyncPr={handleSyncPr}
                 liveActionsByIteration={liveActionsByIteration}
                 busy={busy}
               />

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
@@ -64,6 +64,7 @@ export function RoutineLoopDiagram({
         ) : snapshot.mode === "done" ? (
           <span className="text-text-secondary">
             已结束{snapshot.terminationReason ? ` · 终止原因：${snapshot.terminationReason}` : ""}
+            {routine.pr_url && routine.pr_merged ? " · PR 已合并" : ""}
           </span>
         ) : snapshot.mode === "paused" ? (
           <span className="text-amber-600 dark:text-amber-400">已暂停 · 恢复后继续迭代</span>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
@@ -1,14 +1,40 @@
 "use client";
 
-import { GitPullRequest } from "lucide-react";
+import { useState } from "react";
+import { GitMerge, GitPullRequest, Loader2, RefreshCw } from "lucide-react";
 
 /**
- * PR 卡片 —— FINALIZE 阶段 Claude Code 创建 PR 后，展示「查看 PR」与「在 GitHub 合并」。
+ * PR 卡片 —— FINALIZE 阶段 Claude Code 创建 PR 后，展示「查看 PR」与合并状态。
  *
- * 安全：合并是人工动作，此处仅 link-out 到 GitHub（不调用任何后端 merge 接口、不自动合并）。
+ * - ``merged`` 为真：渲染 violet「已合并 ✓」终态（合并是人工动作，已完成即不再提供合并入口）。
+ * - 否则：保留「在 GitHub 合并 →」外链 + 「同步 PR 状态」按钮（合并后即时回写，无需等~5min 心跳）。
+ *
+ * 安全：合并是人工动作，本组件仅 link-out 到 GitHub + 只读状态同步（不调用任何后端 merge 接口、不自动合并）。
  */
-export function RoutinePrCard({ prUrl }: { prUrl: string | null | undefined }) {
+export function RoutinePrCard({
+  prUrl,
+  merged,
+  onSync,
+}: {
+  prUrl: string | null | undefined;
+  merged?: boolean | null;
+  onSync?: () => void | Promise<void>;
+}) {
+  const [syncing, setSyncing] = useState(false);
   if (!prUrl) return null;
+
+  const isMerged = !!merged;
+
+  const handleSync = async () => {
+    if (syncing || !onSync) return;
+    setSyncing(true);
+    try {
+      await onSync();
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   return (
     <div className="flex items-center gap-2 rounded-lg border border-violet-500/30 bg-violet-500/[0.04] p-3">
       <GitPullRequest className="h-4 w-4 shrink-0 text-violet-600 dark:text-violet-400" aria-hidden />
@@ -21,14 +47,39 @@ export function RoutinePrCard({ prUrl }: { prUrl: string | null | undefined }) {
       >
         查看 PR
       </a>
-      <a
-        href={prUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-200 px-2.5 py-1 text-xs font-medium text-emerald-600 hover:bg-emerald-500/10 dark:border-emerald-800 dark:text-emerald-400"
-      >
-        在 GitHub 合并 →
-      </a>
+      {isMerged ? (
+        <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-violet-300 bg-violet-500/10 px-2.5 py-1 text-xs font-semibold text-violet-700 dark:border-violet-700 dark:text-violet-300">
+          <GitMerge className="h-3.5 w-3.5" aria-hidden />
+          已合并 ✓
+        </span>
+      ) : (
+        <>
+          <a
+            href={prUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex shrink-0 items-center gap-1 rounded-md border border-emerald-200 px-2.5 py-1 text-xs font-medium text-emerald-600 hover:bg-emerald-500/10 dark:border-emerald-800 dark:text-emerald-400"
+          >
+            在 GitHub 合并 →
+          </a>
+          {onSync && (
+            <button
+              type="button"
+              onClick={handleSync}
+              disabled={syncing}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-text-secondary hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-60"
+              title="合并后点此即时回写 Merged 状态（无需等心跳轮询）"
+            >
+              {syncing ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+              )}
+              同步状态
+            </button>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -49,6 +49,7 @@ export function RoutineRunView({
   onApproveIteration,
   onRejectIteration,
   onCleanupWorktree,
+  onSyncPr,
   liveActionsByIteration,
   busy,
 }: {
@@ -56,6 +57,8 @@ export function RoutineRunView({
   onApproveIteration: (iterationId: string) => void;
   onRejectIteration: (iterationId: string) => void;
   onCleanupWorktree?: () => void;
+  /** 手动同步 PR 合并状态（PR 抽屉「同步状态」按钮回调）。 */
+  onSyncPr?: () => void | Promise<void>;
   liveActionsByIteration?: LiveActionsByIteration;
   busy?: boolean;
 }) {
@@ -178,7 +181,7 @@ export function RoutineRunView({
           widthClassName={MODULE_DRAWER_WIDTH}
         >
           <div className="px-5 py-5">
-            <RoutinePrCard prUrl={routine.pr_url} />
+            <RoutinePrCard prUrl={routine.pr_url} merged={routine.pr_merged} onSync={onSyncPr} />
           </div>
         </BaseDrawer>
       )}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { ExternalLink, Loader2, OctagonX, RotateCcw, Trash2 } from "lucide-react";
+import { ExternalLink, GitMerge, Loader2, OctagonX, RotateCcw, Trash2 } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
 
 import { canCancel, canCleanupWorktree, canRestart } from "./routine-controls";
-import { routineStatusClass, scoreColorClass } from "./status-style";
+import { mergedBadgeClass, routineStatusClass, scoreColorClass } from "./status-style";
 
 interface RoutineTableProps {
   routines: RoutineDTO[];
@@ -75,11 +75,19 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                 <div className="text-xs text-text-secondary">{r.key}</div>
               </td>
               <td className="px-4 py-3">
-                <span
-                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
-                >
-                  {r.status}
-                </span>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
+                  >
+                    {r.status}
+                  </span>
+                  {r.pr_merged && (
+                    <span className={mergedBadgeClass}>
+                      <GitMerge className="h-3 w-3" aria-hidden />
+                      Merged
+                    </span>
+                  )}
+                </div>
                 {r.termination_reason && (
                   <div className="mt-0.5 text-xs text-text-secondary">{r.termination_reason}</div>
                 )}

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -114,6 +114,11 @@ export function routineStatusClass(status: RoutineStatus): string {
   }
 }
 
+/** 「PR 已合并」徽章配色（violet = GitHub merged 色 + 仓库 PR/finalize 强调色；区别于绿色 succeeded）。
+ *  列表行与详情头复用，保持「Merged」视觉单一事实源。 */
+export const mergedBadgeClass =
+  "inline-flex items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-micro font-semibold text-violet-700 dark:text-violet-300";
+
 /** 迭代状态 → 状态点配色。 */
 export function iterationDotClass(status: IterationStatus): string {
   switch (status) {

--- a/apps/negentropy-ui/features/routine/api.ts
+++ b/apps/negentropy-ui/features/routine/api.ts
@@ -158,6 +158,11 @@ export async function cleanupWorktree(routineId: string): Promise<RoutineDTO> {
   return jsonFetch(`/${encodeURIComponent(routineId)}/cleanup-worktree`, { method: "POST" });
 }
 
+/** 手动同步 PR 合并状态（即时回写 pr_merged；后端经 gh pr view 检测并 SSE 推送）。 */
+export async function syncRoutinePr(routineId: string): Promise<RoutineDTO> {
+  return jsonFetch(`/${encodeURIComponent(routineId)}/sync-pr`, { method: "POST" });
+}
+
 // ---------------------------------------------------------------------------
 // Templates（合并模板列表）
 // ---------------------------------------------------------------------------

--- a/apps/negentropy-ui/features/routine/index.ts
+++ b/apps/negentropy-ui/features/routine/index.ts
@@ -50,6 +50,7 @@ export {
   rejectIteration,
   fetchTemplates,
   cleanupWorktree,
+  syncRoutinePr,
 } from "./api";
 
 export { useRoutineData } from "./hooks/useRoutineData";

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -47,6 +47,8 @@ export interface RoutineDTO {
   termination_reason: string | null;
   current_phase: RoutinePhase | null;
   pr_url: string | null;
+  /** PR 是否已合并（true=已 Merge；null=未知/未检测，旧记录回退）。派生显示条件，非新状态值。 */
+  pr_merged: boolean | null;
   /** 引擎管理的运行期：本轮隔离工作分支（routine/<key>-<ts>）。 */
   work_branch: string | null;
   /** 引擎管理的运行期：隔离 worktree 文件系统路径（= CC 实际 cwd）。 */

--- a/apps/negentropy-ui/tests/unit/features/routine/RoutinePrCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/RoutinePrCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RoutinePrCard } from "@/app/interface/routine/_components/RoutinePrCard";
+
+/**
+ * RoutinePrCard 渲染单测——「已合并」终态 vs 待合并 + 同步按钮。
+ *
+ * 覆盖：① merged=true 渲染「已合并 ✓」且不再提供合并/同步入口；② 未合并渲染「在 GitHub 合并」
+ * 外链 + 「同步状态」按钮；③ 点同步按钮触发 onSync（带本地 syncing 自管理）。
+ */
+
+const PR_URL = "https://github.com/owner/repo/pull/123";
+
+describe("RoutinePrCard", () => {
+  it("merged=true 显示「已合并」且无合并外链 / 同步按钮", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={true} onSync={vi.fn()} />);
+    expect(screen.getByText("已合并 ✓")).toBeInTheDocument();
+    expect(screen.queryByText("在 GitHub 合并 →")).not.toBeInTheDocument();
+    expect(screen.queryByText("同步状态")).not.toBeInTheDocument();
+    // 「查看 PR」始终保留
+    expect(screen.getByText("查看 PR")).toBeInTheDocument();
+  });
+
+  it("未合并显示「在 GitHub 合并」外链 + 「同步状态」按钮", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={false} onSync={vi.fn()} />);
+    expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();
+    expect(screen.getByText("同步状态")).toBeInTheDocument();
+    expect(screen.queryByText("已合并 ✓")).not.toBeInTheDocument();
+  });
+
+  it("merged=null（未知/旧记录）按未合并渲染", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={null} onSync={vi.fn()} />);
+    expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();
+    expect(screen.queryByText("已合并 ✓")).not.toBeInTheDocument();
+  });
+
+  it("点击「同步状态」触发 onSync", () => {
+    const onSync = vi.fn(() => Promise.resolve());
+    render(<RoutinePrCard prUrl={PR_URL} merged={false} onSync={onSync} />);
+    fireEvent.click(screen.getByText("同步状态"));
+    expect(onSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("未提供 onSync 时不渲染同步按钮（仅合并外链）", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={false} />);
+    expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();
+    expect(screen.queryByText("同步状态")).not.toBeInTheDocument();
+  });
+
+  it("无 prUrl 时渲染为空", () => {
+    const { container } = render(<RoutinePrCard prUrl={null} merged={true} onSync={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
@@ -41,6 +41,7 @@ function makeRoutine(id: string): RoutineDTO {
     termination_reason: null,
     current_phase: null,
     pr_url: null,
+    pr_merged: null,
     work_branch: null,
     worktree_path: null,
     max_iterations: 20,

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
@@ -49,6 +49,7 @@ function makeRoutine(id: string, status: RoutineDTO["status"] = "running"): Rout
     termination_reason: null,
     current_phase: null,
     pr_url: null,
+    pr_merged: null,
     work_branch: null,
     worktree_path: null,
     max_iterations: 20,

--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -209,6 +209,11 @@ routine:
   git_remote: origin                         # fetch / PR base 归一所用 git 远端名
   git_fetch_before_worktree: true            # 建 worktree 前 best-effort git fetch（带超时，失败不阻断）
   git_timeout_seconds: 120                   # 单条 git 子命令执行超时（秒）
+  # --- PR 合并状态巡检（终态 routine 的 PR 被 Merge 后回写 pr_merged → 三处 UI 显示「Merged」）---
+  pr_merge_check_enabled: true               # gh 不在 PATH 时整段静默 no-op（绝不崩溃心跳）
+  pr_merge_check_interval_seconds: 300       # 同一 routine 最小重查间隔（节流，适配 25s 心跳）
+  pr_merge_check_timeout_seconds: 5          # 单次 gh pr view 子进程超时；超时整组 SIGKILL
+  pr_merge_check_batch: 3                    # 单 tick 批量上限（×5s ≈ pass 最坏 15s，留足心跳余量）
   # --- pdf-fidelity-patrol 巡检（#978）---
   # 部署期默认开启：enabled 的种子任务真正每 1h 派生 Routine（routine.enabled 已 true）。
   # 缺凭证/可解析仓库/已转换 PDF 文档时，Routine 创建后失败或 handler 跳过，原因写入

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -147,6 +147,21 @@ class RoutineSettings(BaseSettings):
     )
     git_timeout_seconds: int = Field(default=120, ge=5, description="单条 git 子命令执行超时（秒）")
 
+    # --- PR 合并状态巡检（终态 routine 的 PR 是否已被人工 Merge 回写 pr_merged）---
+    # 复用运行时已授权的 gh CLI 做 `gh pr view --json state,merged`；gh 不在 PATH 时整段 no-op。
+    pr_merge_check_enabled: bool = Field(
+        default=True, description="启用终态 routine 的 PR merge 状态巡检（需后端 PATH 可用 gh；缺失则静默 no-op）"
+    )
+    pr_merge_check_interval_seconds: int = Field(
+        default=300, ge=60, le=86400, description="同一 routine 的 PR merge 状态最小重查间隔（节流，适配 25s 心跳）"
+    )
+    pr_merge_check_timeout_seconds: int = Field(
+        default=5, ge=1, le=30, description="单次 gh pr view 子进程超时（秒）；超时整组 SIGKILL"
+    )
+    pr_merge_check_batch: int = Field(
+        default=3, ge=1, le=20, description="单 tick 内 PR merge 巡检的 routine 批量上限（×超时 ≈ pass 最坏耗时）"
+    )
+
     # --- Claude Code 交互式工具自动应答（AskUserQuestion 拦截）---
     auto_answer_questions: bool = Field(
         default=True,

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0079_routine_pr_merge.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0079_routine_pr_merge.py
@@ -1,0 +1,103 @@
+"""为 routines 新增 pr_merged / pr_merged_checked_at + PR 合并巡检部分索引。
+
+Revision ID: 0079
+Revises: 0078
+Create Date: 2026-06-30 00:00:01.000000+00:00
+
+设计动机：
+    Routine 在 FINALIZE 创建 PR 后即置 ``succeeded``，但 PR 在 GitHub 被人工 Merge 后无机制
+    回写。本迁移加两列（与 status 正交，不改状态机）：``pr_merged``（null=未知/未检测，
+    true=已 merge，false=closed-without-merge 停检）+ ``pr_merged_checked_at``（节流水位线）。
+    由 routine_inspector 心跳的 ``_sync_pr_merge_status`` pass 或手动 ``sync-pr`` 端点经
+    ``gh pr view --json state,merged`` 回填，并在 Full View / 列表 / PR 抽屉三处渲染「Merged」。
+
+    部分索引 ``ix_routines_pr_merge_due`` 仅覆盖「succeeded 且有 pr_url 且尚未确认为 merged」的
+    行——即巡检 due 集，保持索引极小且命中 25s 心跳的查询前缀。
+
+幂等性：
+    加列 / 索引前以 information_schema 探测（仿 0075/0078）。纯加 nullable 列，不删数据、不回填
+    （null=未知 对存量 succeeded routine 即正确语义）；回滚即 drop index + drop column（空列无数据风险）。
+
+参考文献：
+[1] 0075_routine_repository_id.py — information_schema 幂等加列范式。
+[2] 0078_routine_event_agent_role.py — 同上（nullable 加列）。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0079"
+down_revision: str | None = "0078"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :s AND table_name = :t AND column_name = :c"
+            ),
+            {"s": SCHEMA, "t": table_name, "c": column_name},
+        ).scalar()
+    )
+
+
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text("SELECT 1 FROM pg_indexes WHERE schemaname = :s AND tablename = :t AND indexname = :i"),
+            {"s": SCHEMA, "t": table_name, "i": index_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _column_exists(bind, "routines", "pr_merged"):
+        op.add_column(
+            "routines",
+            sa.Column(
+                "pr_merged",
+                sa.Boolean(),
+                nullable=True,
+                comment="PR 是否已 merge（null=未知/未检测；与 status 正交，不改状态机）",
+            ),
+            schema=SCHEMA,
+        )
+    if not _column_exists(bind, "routines", "pr_merged_checked_at"):
+        op.add_column(
+            "routines",
+            sa.Column(
+                "pr_merged_checked_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+                comment="上次 gh pr view 检测时间；节流用（同一 routine 最小重查间隔）",
+            ),
+            schema=SCHEMA,
+        )
+    if not _index_exists(bind, "routines", "ix_routines_pr_merge_due"):
+        op.create_index(
+            "ix_routines_pr_merge_due",
+            "routines",
+            [sa.text("pr_merged_checked_at")],
+            postgresql_where=sa.text(
+                "status = 'succeeded' AND pr_url IS NOT NULL AND COALESCE(pr_merged, false) = false"
+            ),
+            schema=SCHEMA,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _index_exists(bind, "routines", "ix_routines_pr_merge_due"):
+        op.drop_index("ix_routines_pr_merge_due", table_name="routines", schema=SCHEMA)
+    if _column_exists(bind, "routines", "pr_merged_checked_at"):
+        op.drop_column("routines", "pr_merged_checked_at", schema=SCHEMA)
+    if _column_exists(bind, "routines", "pr_merged"):
+        op.drop_column("routines", "pr_merged", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -32,7 +32,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import set_committed_value
@@ -355,12 +355,22 @@ class RoutineOrchestrator:
     # 主入口
     # ------------------------------------------------------------------
     async def inspect_once(self) -> dict[str, int]:
-        """单次巡检：reap(孤儿迭代 + worktree) → evaluate → dispatch。返回各阶段计数（供 handler 汇报）。"""
+        """单次巡检：reap(孤儿迭代 + worktree) → sync(PR 合并状态) → evaluate → dispatch。
+
+        返回各阶段计数（供 handler 汇报 + task_executions 观测）。
+        """
         reaped = await self._reap_orphans()
         cleaned = await self._reap_workspaces()
+        pr_synced = await self._sync_pr_merge_status()
         evaluated = await self._evaluate_and_decide()
         launched = await self._dispatch_due()
-        return {"reaped": reaped, "cleaned": cleaned, "evaluated": evaluated, "launched": launched}
+        return {
+            "reaped": reaped,
+            "cleaned": cleaned,
+            "pr_synced": pr_synced,
+            "evaluated": evaluated,
+            "launched": launched,
+        }
 
     # ------------------------------------------------------------------
     # (a) REAP
@@ -475,6 +485,87 @@ class RoutineOrchestrator:
         if cleaned:
             logger.info("routine_reaped_workspaces", count=cleaned, policy=policy)
         return cleaned
+
+    async def _sync_pr_merge_status(self) -> int:
+        """巡检终态 routine 的 PR 合并状态并回写 ``pr_merged``（best-effort，绝不阻塞/崩溃心跳）。
+
+        复用既有 ``gh`` CLI（仓库 GitHub 集成的唯一事实源）做只读 ``gh pr view --json state,merged``：
+        succeeded + pr_url 的 routine 在 FINALIZE 后处于「等待人工 Merge」态，人在 GitHub 合并后，
+        本 pass 把 ``pr_merged`` 回写为 True 并经 SSE 推送，使列表 / Full View / PR 抽屉三处显示「Merged」。
+
+        可降级（对齐 AGENTS.md「不引入新问题」）：``gh`` 缺失/未授权/超时/坏 URL → ``pr_status`` 返回
+        unknown，本 pass 静默跳过（节流水位线 ``pr_merged_checked_at`` 不推进，保持 due 下 tick 重试）；
+        心跳永不因本 pass 崩溃（双层兜底：pr_status 不抛 + 本 pass 单层 ``except Exception``）。
+
+        范式镜像 ``_reap_workspaces``：短会话查 due → 会话外做 gh 子进程（不占连接池）→ 短会话写回 + 推送。
+        due 集 = succeeded ∧ pr_url 非空 ∧ pr_merged 未确认为 True ∧ 距上次检测 > 节流间隔；批量上限适配 25s 心跳。
+
+        返回本轮新检出「已合并」的 routine 数（推 SSE 的次数）。详见 ``pr_status.fetch_pr_merge_status``。
+        """
+        if not settings.routine.pr_merge_check_enabled:
+            return 0
+        from . import pr_status  # 延迟导入：避免 import 期 which('gh') 探测进入与 PR 无关的测试路径
+
+        cutoff = _utcnow() - timedelta(seconds=settings.routine.pr_merge_check_interval_seconds)
+        batch = settings.routine.pr_merge_check_batch
+        timeout = float(settings.routine.pr_merge_check_timeout_seconds)
+
+        # ① 短会话：拉取 due routine 的 (id, pr_url)（expire_on_commit=False → detached 后可读）。
+        async with db_session.AsyncSessionLocal() as db:
+            rows = (
+                await db.execute(
+                    select(Routine.id, Routine.pr_url)
+                    .where(
+                        Routine.status == "succeeded",
+                        Routine.pr_url.is_not(None),
+                        or_(Routine.pr_merged.is_(None), Routine.pr_merged.is_(False)),
+                        or_(
+                            Routine.pr_merged_checked_at.is_(None),
+                            Routine.pr_merged_checked_at < cutoff,
+                        ),
+                    )
+                    .order_by(Routine.pr_merged_checked_at.asc().nullsfirst())
+                    .limit(batch)
+                )
+            ).all()
+        if not rows:
+            return 0
+
+        # ② 会话外：best-effort 检测每个 PR（gh 子进程带超时；pr_status 契约为绝不抛）。
+        checks: list[tuple[UUID, pr_status.PrMergeStatus]] = []
+        for rid, pr_url in rows:
+            url = pr_url or ""
+            # 坏 URL 预筛：直接判「未合并」落库停检，杜绝永滞 due 集（防饥饿）。
+            if not pr_status.is_valid_pr_url(url):
+                checks.append((rid, pr_status.PrMergeStatus(merged=False, state=None)))
+                continue
+            try:
+                st = await pr_status.fetch_pr_merge_status(url, timeout=timeout)
+            except Exception as exc:  # noqa: BLE001 — pr_status 契约为不抛；双保险兜底，护心跳
+                logger.warning("routine_pr_merge_check_failed", routine_id=str(rid), error=str(exc))
+                st = pr_status.PrMergeStatus(merged=None, state=None)
+            checks.append((rid, st))
+
+        # ③ 短会话：回写 + 提交；仅「新检出 merged」者推 SSE（commit 后属性仍可读：expire_on_commit=False）。
+        merged_ids: list[UUID] = []
+        now = _utcnow()
+        async with db_session.AsyncSessionLocal() as db:
+            for rid, st in checks:
+                r = await db.get(Routine, rid)
+                # 竞态守卫：restart/cancel/pr_url 清理等使其脱离 due → 跳过，不回写。
+                if r is None or r.status != "succeeded" or not r.pr_url:
+                    continue
+                if pr_status.apply_pr_merge_result(r, st, now):
+                    merged_ids.append(rid)
+            await db.commit()
+            for rid in merged_ids:
+                r = await db.get(Routine, rid)
+                if r is not None:
+                    with suppress(Exception):
+                        await self._publish_routine(r)
+        if merged_ids:
+            logger.info("routine_pr_merge_detected", count=len(merged_ids))
+        return len(merged_ids)
 
     # ------------------------------------------------------------------
     # (b) EVALUATE + DECIDE
@@ -1796,6 +1887,7 @@ class RoutineOrchestrator:
                 "total_cost_usd": routine.total_cost_usd,
                 "current_phase": routine.current_phase,
                 "pr_url": routine.pr_url,
+                "pr_merged": routine.pr_merged,
             }
         )
 

--- a/apps/negentropy/src/negentropy/engine/routine/pr_status.py
+++ b/apps/negentropy/src/negentropy/engine/routine/pr_status.py
@@ -1,0 +1,188 @@
+"""PR 合并状态检测——可降级的 ``gh pr view`` 只读封装。
+
+定位（机制/策略分离）：
+    本模块只做一件**确定性机制**：给定 PR 链接，best-effort 查询其合并状态，**绝不抛异常**。
+    何时查、查到后如何回写 Routine（策略）由 ``orchestrator._sync_pr_merge_status`` 与
+    ``routine_api`` 的手动 ``sync-pr`` 端点决定。
+
+为何复用 ``gh`` CLI：
+    ``gh`` 是本仓库 GitHub 集成的唯一事实源（CC 经 ``gh pr create`` 建 PR；``publish-wiki-pages.sh``
+    经 ``gh auth token`` 取 token）。后端不引入新 GitHub 客户端 / token，直接复用运行时已授权的
+    ``gh`` 做只读 ``gh pr view --json state,merged``。
+
+可降级契约（对齐 AGENTS.md「不引入新问题」）：
+    ``gh`` 不在 PATH / 未授权 / 超时 / rc≠0 / 坏 JSON / 坏 URL → 一律返回 ``PrMergeStatus(None, None)``
+    （unknown），**绝不抛异常**。调用方（心跳 pass）据此保持 due、下 tick 重试；心跳永不因本模块崩溃。
+    ``gh`` 缺失仅在本进程首次观测时 WARN 一次，避免 25s 心跳刷屏。
+
+子进程范式镜像 ``workspace._run_git`` / ``evaluator._run_gate``：``create_subprocess_exec`` +
+独立进程组（``start_new_session=True``）+ 超时整组 SIGKILL，防止 ``gh``/``git-remote`` 子进程变孤儿。
+
+参考文献：
+[1] GitHub CLI Docs, *gh pr view --json*. PR state/merged 字段查询。
+[2] workspace.py:_run_git — 子进程 + 进程组超时杀范式。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import signal
+from contextlib import suppress
+from dataclasses import dataclass
+
+from negentropy.logging import get_logger
+
+logger = get_logger("negentropy.engine.routine.pr_status")
+
+# 运行时探测一次 ``gh`` 是否在 PATH（进程内缓存；PATH 不随运行期变化）。None ⇒ 整特性关闭。
+GH_BIN: str | None = shutil.which("gh")
+
+# 合法 GitHub PR 链接形状（兼容 github.com 与 Enterprise 自建域；``.../pull/<n>``）。
+# 仅做形状校验避免对垃圾 URL 起 ``gh`` 子进程；``gh pr view`` 自行处理鉴权与可达性。
+_PR_URL_RE = re.compile(r"^https?://[^/\s]+/[^/\s]+/[^/\s]+/(?:pull|pulls)/\d+(?:[/?#].*)?$")
+
+# ``gh`` 缺失只 WARN 一次的进程内闸门（防心跳刷屏）。
+_warned_no_gh = False
+
+
+@dataclass(frozen=True, slots=True)
+class PrMergeStatus:
+    """``gh pr view`` 的 best-effort 结果。
+
+    Attributes:
+        merged: ``True``=已 merge；``False``=已确认为未 merge（如 OPEN/CLOSED-without-merge）；
+            ``None``=未知（``gh`` 缺失/未授权/超时/rc≠0/坏 JSON/坏 URL）。
+        state: ``OPEN``|``CLOSED``|``MERGED`` 或 ``None``。``None`` 表示 ``gh`` 未给出有效应答
+            （调用方据此决定是否节流——未应答则不推进 ``checked_at``，保持 due 下 tick 重试）。
+    """
+
+    merged: bool | None
+    state: str | None
+
+
+def gh_available() -> bool:
+    """运行时是否检测到 ``gh``。供心跳 pass / 端点快速短路判断。"""
+    return GH_BIN is not None
+
+
+def is_valid_pr_url(url: str | None) -> bool:
+    """PR 链接是否合法（``.../pull/<n>`` 形状，兼容 github.com 与 Enterprise 自建域）。"""
+    return bool(url) and bool(_PR_URL_RE.match(url))
+
+
+def apply_pr_merge_result(routine, st: PrMergeStatus, now) -> bool:
+    """把检测结果回写到 routine 的 ``pr_merged`` / ``pr_merged_checked_at``（鸭子类型，复用于
+    心跳 pass 与手动 ``sync-pr`` 端点，避免两处写回分支漂移）。
+
+    回写语义：
+    - ``merged is True`` → ``pr_merged=True`` + 推进 ``checked_at``；返回是否「新检出」合并
+      （之前非 True）——调用方据此决定是否推 SSE。
+    - ``merged is False``（OPEN / closed-without-merge）→ ``pr_merged=False`` + 推进 ``checked_at``
+      （确认为未合并即停检：部分索引谓词 ``COALESCE(pr_merged,false)=false`` 会把 True/False 都排除）。
+    - ``merged is None``：``state`` 非 None（gh 应答，如 OPEN 已被上面覆盖；此处防御）→ 仅推进
+      ``checked_at`` 节流；``state is None``（gh 未应答）→ **不动** ``checked_at``，保持 due 下 tick 重试。
+    """
+    if st.merged is True:
+        before = getattr(routine, "pr_merged", None)
+        routine.pr_merged = True
+        routine.pr_merged_checked_at = now
+        return before is not True
+    if st.merged is False:
+        routine.pr_merged = False
+        routine.pr_merged_checked_at = now
+        return False
+    # merged is None
+    if st.state is not None:
+        routine.pr_merged_checked_at = now
+    return False
+
+
+def _kill_process_group(proc) -> None:
+    """杀掉子进程所在进程组；失败则降级单进程 kill（同 workspace._run_git）。"""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        with suppress(Exception):
+            proc.kill()
+
+
+async def fetch_pr_merge_status(pr_url: str | None, *, timeout: float = 5.0) -> PrMergeStatus:
+    """Best-effort 查询 PR 合并状态。**契约：绝不抛异常。**
+
+    流程（任一失败即返回 ``PrMergeStatus(None, None)``）：
+    1. ``gh`` 不在 PATH → unknown（首次 WARN 一次）。
+    2. URL 形状不合法 → unknown（不起子进程）。
+    3. 起 ``gh pr view <url> --json state,merged`` 子进程，``timeout`` 超时整组 SIGKILL → unknown。
+    4. rc≠0（未授权 / 不可达 / PR 不存在）→ unknown。
+    5. stdout 非 JSON / 字段缺失 → unknown。
+    6. 成功：``state=MERGED`` 或 ``merged=true`` → merged=True；否则按 ``merged`` 布尔值。
+    """
+    global _warned_no_gh
+
+    if GH_BIN is None:
+        if not _warned_no_gh:
+            logger.warning(
+                "routine_pr_sync_disabled_no_gh",
+                reason="gh CLI not on PATH; PR merge status sync disabled (no-op)",
+            )
+            _warned_no_gh = True
+        return PrMergeStatus(merged=None, state=None)
+
+    if not pr_url or not _PR_URL_RE.match(pr_url):
+        logger.debug("routine_pr_merge_bad_url", pr_url=pr_url)
+        return PrMergeStatus(merged=None, state=None)
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            GH_BIN,
+            "pr",
+            "view",
+            pr_url,
+            "--json",
+            "state,merged",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+    except Exception as exc:  # spawn 失败（不应发生，GH_BIN 已探测）——兜底
+        logger.warning("routine_pr_view_spawn_failed", error=str(exc))
+        return PrMergeStatus(merged=None, state=None)
+
+    try:
+        stdout_b, _stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        _kill_process_group(proc)
+        with suppress(Exception):
+            await proc.communicate()
+        logger.warning("routine_pr_view_timeout", timeout=timeout)
+        return PrMergeStatus(merged=None, state=None)
+    except Exception as exc:  # communicate 异常——兜底，绝不向上抛
+        logger.warning("routine_pr_view_communicate_failed", error=str(exc))
+        return PrMergeStatus(merged=None, state=None)
+
+    if proc.returncode != 0:
+        # 未授权 / PR 不存在 / 不可达等——unknown，保持 due 下 tick 重试。
+        logger.debug("routine_pr_view_nonzero_rc", returncode=proc.returncode)
+        return PrMergeStatus(merged=None, state=None)
+
+    out = (stdout_b or b"").decode("utf-8", errors="replace").strip()
+    try:
+        raw = json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        logger.debug("routine_pr_view_bad_json", out_preview=out[:120])
+        return PrMergeStatus(merged=None, state=None)
+
+    if not isinstance(raw, dict):
+        return PrMergeStatus(merged=None, state=None)
+
+    state = raw.get("state")
+    merged_raw = raw.get("merged")
+    # state=MERGED 即判已合并（防御性：即便 merged 布尔缺失）；否则尊重 merged 布尔值。
+    if state == "MERGED":
+        return PrMergeStatus(merged=True, state=state)
+    merged = bool(merged_raw) if isinstance(merged_raw, bool) else None
+    return PrMergeStatus(merged=merged, state=state if isinstance(state, str) else None)

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/routine_inspector.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/routine_inspector.py
@@ -39,7 +39,10 @@ async def routine_inspector_handler(task) -> HandlerResult:
         result = await get_orchestrator().inspect_once()
         return HandlerResult(
             status="ok",
-            output_summary=(f"reaped={result['reaped']} evaluated={result['evaluated']} launched={result['launched']}"),
+            output_summary=(
+                f"reaped={result['reaped']} cleaned={result['cleaned']} "
+                f"pr_synced={result['pr_synced']} evaluated={result['evaluated']} launched={result['launched']}"
+            ),
             metrics=result,
         )
     except Exception as exc:

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -15,6 +15,7 @@
 - POST   /routines/{id}/cancel               取消（→ cancelled）
 - POST   /routines/{id}/restart              重启（failed/cancelled → running，复位运行态 + 抬高决策水位线）
 - POST   /routines/{id}/cleanup-worktree     手动回收终态 routine 的隔离 worktree
+- POST   /routines/{id}/sync-pr              手动同步 PR 合并状态（即时回写 pr_merged → 三处 UI 显示「Merged」）
 - POST   /routines/{id}/iterations/{iid}/approve   审批通过待执行迭代
 - POST   /routines/{id}/iterations/{iid}/reject    驳回待执行迭代
 - GET    /routines/stream                    SSE 实时事件（routine + iteration）
@@ -197,6 +198,7 @@ def _serialize_routine(
         "termination_reason": r.termination_reason,
         "current_phase": r.current_phase,
         "pr_url": r.pr_url,
+        "pr_merged": r.pr_merged,
         "work_branch": r.work_branch,
         "worktree_path": r.worktree_path,
         "worktree_status": worktree_meta.get("status") if worktree_meta else None,
@@ -977,6 +979,9 @@ async def restart_routine(routine_id: UUID, body: RestartBody | None = None) -> 
         r.claude_session_id = None
         r.current_phase = phase_mod.initial_phase(r.config)
         r.pr_url = None
+        # 复位 PR 合并状态：避免旧 PR 的 merged 污染新一轮 PR 的检测与「Merged」展示。
+        r.pr_merged = None
+        r.pr_merged_checked_at = None
         # 隔离 worktree：仅回收 worktree 目录、**保留终生单一工作分支**（含其检查点提交），
         # 使新一轮尝试在同一分支上从上一检查点续作（不铸新分支、不重建自基线）。下一次派发的
         # ensure_worktree 会按保留的 work_branch 重绑 worktree（本地分支存在则直接 checkout）。
@@ -1036,9 +1041,53 @@ async def cleanup_worktree(routine_id: UUID) -> dict[str, Any]:
     return _serialize_routine(r, worktree_meta=worktree_meta)
 
 
-# ---------------------------------------------------------------------------
-# 审批门控：approve / reject
-# ---------------------------------------------------------------------------
+@router.post("/{routine_id}/sync-pr")
+async def sync_pr_status(routine_id: UUID) -> dict[str, Any]:
+    """手动同步 routine 的 PR 合并状态（即时回写 ``pr_merged``，无需等~5min 心跳）。
+
+    用户在 GitHub 合并 PR 后点 PR 抽屉「同步 PR 状态」即时触发：复用 ``gh pr view --json state,merged``
+    回写 ``pr_merged`` 并经 SSE 推送，使列表 / Full View / PR 抽屉三处立即显示「Merged」。回写逻辑与
+    心跳 ``_sync_pr_merge_status`` 复用同一 ``apply_pr_merge_result``，避免两处分支漂移。
+
+    与心跳 pass 的差异：用户主动触发，故 ``gh`` 缺失/未授权/不可达时**显式 503**（心跳为静默 no-op）。
+    慢操作（gh 子进程）在 DB 会话外执行，不占连接池、不阻塞事件循环（同 cleanup-worktree 范式）。
+    """
+    from negentropy.engine.routine.pr_status import (
+        apply_pr_merge_result,
+        fetch_pr_merge_status,
+        gh_available,
+    )
+
+    # ① 短会话：校验 + 取 pr_url（会话外做 gh 子进程，不占连接池）。
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="routine not found")
+        if not r.pr_url:
+            raise HTTPException(status_code=409, detail="routine has no PR to sync (pr_url is empty)")
+        pr_url = r.pr_url
+
+    # ② 会话外：best-effort gh 检测（带超时）。gh 缺失或未应答 → 503（用户主动触发应显式暴露）。
+    if not gh_available():
+        raise HTTPException(status_code=503, detail="gh CLI not available on backend PATH; cannot sync PR status")
+    try:
+        st = await fetch_pr_merge_status(pr_url, timeout=float(settings.routine.pr_merge_check_timeout_seconds))
+    except Exception as exc:  # noqa: BLE001 — pr_status 契约为不抛；用户面兜底 502
+        raise HTTPException(status_code=502, detail=f"PR status check failed: {exc}") from exc
+    if st.merged is None and st.state is None:
+        raise HTTPException(
+            status_code=503,
+            detail="gh could not determine PR status (unauthorized / unreachable / timeout); retry later",
+        )
+
+    # ③ 短会话：回写 + 提交 + 推 SSE（expire_on_commit=False → r 提交后仍可读）。
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, routine_id)
+        apply_pr_merge_result(r, st, _utcnow())
+        await db.commit()
+        await db.refresh(r)
+        await _publish_routine(r)
+    return _serialize_routine(r)
 
 
 @router.post("/{routine_id}/iterations/{iteration_id}/approve")
@@ -1126,6 +1175,7 @@ async def _publish_routine(r: Routine) -> None:
             "total_cost_usd": r.total_cost_usd,
             "current_phase": r.current_phase,
             "pr_url": r.pr_url,
+            "pr_merged": r.pr_merged,
         }
     )
 

--- a/apps/negentropy/src/negentropy/models/routine.py
+++ b/apps/negentropy/src/negentropy/models/routine.py
@@ -132,6 +132,18 @@ class Routine(Base, UUIDMixin, TimestampMixin):
         nullable=True,
         comment="FINALIZE 阶段创建的 PR 链接；非空 + succeeded 表示等待人工 Merge",
     )
+    # PR 合并状态回写（与 status 正交，不改状态机）：succeeded + pr_url 后由巡检心跳或
+    # 手动「同步 PR 状态」经 ``gh pr view`` 检测回填。pr_merged=True 即「已 Merge」。
+    pr_merged: Mapped[bool | None] = mapped_column(
+        Boolean,
+        nullable=True,
+        comment="PR 是否已 merge（null=未知/未检测；与 status 正交，不改状态机）",
+    )
+    pr_merged_checked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="上次 gh pr view 检测时间；节流用（同一 routine 最小重查间隔）",
+    )
 
     # --- 运行期状态（反规范化，加速守卫判定）---
     iteration_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -23,7 +24,7 @@ from sqlalchemy import delete, select
 import negentropy.db.session as db_session
 from negentropy.engine.claude_code.models import ClaudeCodeResult
 from negentropy.engine.routine import decision as decision_mod
-from negentropy.engine.routine import workspace
+from negentropy.engine.routine import pr_status, workspace
 from negentropy.engine.routine.evaluator import EvaluationResult
 from negentropy.engine.routine.orchestrator import RoutineOrchestrator
 from negentropy.engine.routine.workspace import WorkspaceInfo
@@ -1206,3 +1207,132 @@ async def test_is_plan_review_active_toggle_rollback():
         assert orch_mod._is_plan_review_active(wt_plan) is True, "legacy：仅 PLAN 相位激活评审"
     finally:
         object.__setattr__(settings.routine, "plan_review_unified_loop", True)
+
+
+# ---------------------------------------------------------------------------
+# _sync_pr_merge_status：PR 合并状态巡检 pass（mock gh 检测，真实 Postgres）
+# ---------------------------------------------------------------------------
+
+_PR_URL = "https://github.com/owner/repo/pull/123"
+
+
+async def _make_succeeded_routine_with_pr(**overrides) -> uuid.UUID:
+    """种子一个 succeeded + pr_url 的 routine（FINALIZE 后「等待人工 Merge」态）。"""
+    defaults = dict(
+        key=_key(),
+        title="PR Merge Sync Test",
+        goal="g",
+        acceptance_criteria="ac",
+        status="succeeded",
+        termination_reason="success",
+        pr_url=_PR_URL,
+        pr_merged=None,
+        pr_merged_checked_at=None,
+        max_iterations=5,
+        success_score_threshold=85,
+        no_progress_patience=3,
+        approval_mode="auto",
+        iteration_count=1,
+        reflections={},
+        config={},
+    )
+    defaults.update(overrides)
+    async with db_session.AsyncSessionLocal() as db:
+        r = Routine(**defaults)
+        db.add(r)
+        await db.commit()
+        return r.id
+
+
+async def test_sync_pr_merge_status_detects_merged_and_publishes():
+    """succeeded + pr_url + 未知 → gh 报 MERGED → 回写 pr_merged=True + 推 SSE，返回 1。"""
+    rid = await _make_succeeded_routine_with_pr()
+    try:
+        orch = RoutineOrchestrator()
+        publish_mock = AsyncMock()
+        with (
+            patch(
+                "negentropy.engine.routine.pr_status.fetch_pr_merge_status",
+                new=AsyncMock(return_value=pr_status.PrMergeStatus(merged=True, state="MERGED")),
+            ),
+            patch.object(RoutineOrchestrator, "_publish_routine", new=publish_mock),
+        ):
+            count = await orch._sync_pr_merge_status()  # noqa: SLF001
+        assert count == 1
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.pr_merged is True
+            assert r.pr_merged_checked_at is not None
+        publish_mock.assert_awaited_once()
+    finally:
+        await _cleanup(rid)
+
+
+async def test_sync_pr_merge_status_skips_already_merged():
+    """pr_merged=True 的 routine 不在 due 集 → 不调 gh、不推 SSE，返回 0。"""
+    rid = await _make_succeeded_routine_with_pr(pr_merged=True, pr_merged_checked_at=None)
+    fetch_mock = AsyncMock()
+    try:
+        orch = RoutineOrchestrator()
+        with (
+            patch("negentropy.engine.routine.pr_status.fetch_pr_merge_status", new=fetch_mock),
+            patch.object(RoutineOrchestrator, "_publish_routine", new=AsyncMock()),
+        ):
+            count = await orch._sync_pr_merge_status()  # noqa: SLF001
+        assert count == 0
+        fetch_mock.assert_not_called()
+    finally:
+        await _cleanup(rid)
+
+
+async def test_sync_pr_merge_status_records_closed_unmerged():
+    """closed-without-merge（merged=False）→ 回写 pr_merged=False + 推进 checked_at（停检）。"""
+    rid = await _make_succeeded_routine_with_pr()
+    try:
+        orch = RoutineOrchestrator()
+        with patch(
+            "negentropy.engine.routine.pr_status.fetch_pr_merge_status",
+            new=AsyncMock(return_value=pr_status.PrMergeStatus(merged=False, state="CLOSED")),
+        ):
+            count = await orch._sync_pr_merge_status()  # noqa: SLF001
+        assert count == 0  # 非新检出 merged
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.pr_merged is False
+            assert r.pr_merged_checked_at is not None
+    finally:
+        await _cleanup(rid)
+
+
+async def test_sync_pr_merge_status_unknown_leaves_state_untouched():
+    """gh 未应答（merged=None, state=None）→ 不动 pr_merged/checked_at，保持 due 下 tick 重试。"""
+    rid = await _make_succeeded_routine_with_pr()
+    try:
+        orch = RoutineOrchestrator()
+        with patch(
+            "negentropy.engine.routine.pr_status.fetch_pr_merge_status",
+            new=AsyncMock(return_value=pr_status.PrMergeStatus(merged=None, state=None)),
+        ):
+            count = await orch._sync_pr_merge_status()  # noqa: SLF001
+        assert count == 0
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.pr_merged is None
+            assert r.pr_merged_checked_at is None  # 未应答 → 不推进节流
+    finally:
+        await _cleanup(rid)
+
+
+async def test_sync_pr_merge_status_throttle_skips_recently_checked():
+    """窗口内（checked_at 距今 < interval）→ 不在 due 集 → 不调 gh。"""
+    recent = datetime.now(UTC) - timedelta(seconds=10)
+    rid = await _make_succeeded_routine_with_pr(pr_merged=None, pr_merged_checked_at=recent)
+    fetch_mock = AsyncMock()
+    try:
+        orch = RoutineOrchestrator()
+        with patch("negentropy.engine.routine.pr_status.fetch_pr_merge_status", new=fetch_mock):
+            count = await orch._sync_pr_merge_status()  # noqa: SLF001
+        assert count == 0
+        fetch_mock.assert_not_called()
+    finally:
+        await _cleanup(rid)

--- a/apps/negentropy/tests/unit_tests/engine/test_pr_status.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pr_status.py
@@ -1,0 +1,240 @@
+"""pr_status 单元测试——``fetch_pr_merge_status`` 可降级契约（绝不抛异常）。
+
+覆盖：gh 缺失 / 坏 URL / MERGED / OPEN / CLOSED / rc≠0 / 坏 JSON / 超时（杀进程组）/ spawn 失败，
+以及 ``apply_pr_merge_result`` 的三分支回写语义。子进程以 fake proc 替代，零真实 gh / GitHub 依赖。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from negentropy.engine.routine import pr_status
+
+# 注：本模块混合 async（fetch_pr_merge_status）与同步（apply/is_valid）测试，故逐个标记
+# async 用例，不用模块级 pytestmark，避免同步测试被误标 asyncio 触发 PytestWarning。
+_asyncio = pytest.mark.asyncio
+
+_GOOD_URL = "https://github.com/owner/repo/pull/123"
+_BAD_URL = "not a url"
+
+
+class _FakeProc:
+    """模拟 ``asyncio.subprocess.Process``：可控 stdout / returncode / 超时 / kill。"""
+
+    def __init__(
+        self,
+        *,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+        sleep: float = 0.0,
+        pid: int = 999_999,
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.pid = pid
+        self._sleep = sleep
+        self._calls = 0
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        self._calls += 1
+        # 仅首次 sleep 模拟慢子进程；超时被杀后第二次 communicate 立即返回（避免测试挂起）。
+        if self._sleep and self._calls == 1:
+            await asyncio.sleep(self._sleep)
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def _patch_exec(monkeypatch, proc: _FakeProc | BaseException) -> None:
+    """把 ``asyncio.create_subprocess_exec`` 替换为返回 ``proc``（或抛 ``proc``）的协程。"""
+
+    async def _fake(*_args: Any, **_kwargs: Any) -> _FakeProc:
+        if isinstance(proc, BaseException):
+            raise proc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake)
+
+
+async def _fetch(url: str = _GOOD_URL, *, timeout: float = 5.0) -> pr_status.PrMergeStatus:
+    """包裹一层，强调「绝不抛」：任何异常在此处都算契约违反。"""
+    return await pr_status.fetch_pr_merge_status(url, timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# fetch_pr_merge_status：各路径均返回 PrMergeStatus 且不抛
+# ---------------------------------------------------------------------------
+
+
+@_asyncio
+async def test_gh_missing_returns_unknown_without_spawn(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", None)
+    spawned = False
+
+    async def _should_not_spawn(*_a: Any, **_k: Any) -> _FakeProc:  # pragma: no cover - 断言不调用
+        nonlocal spawned
+        spawned = True
+        raise RuntimeError("must not spawn")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _should_not_spawn)
+    st = await _fetch()
+    assert st == pr_status.PrMergeStatus(merged=None, state=None)
+    assert not spawned
+
+
+@_asyncio
+async def test_bad_url_returns_unknown_without_spawn(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    spawned = False
+
+    async def _should_not_spawn(*_a: Any, **_k: Any) -> _FakeProc:  # pragma: no cover
+        nonlocal spawned
+        spawned = True
+        raise RuntimeError("must not spawn")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _should_not_spawn)
+    st = await _fetch(_BAD_URL)
+    assert st.merged is None
+    assert not spawned
+
+
+@_asyncio
+async def test_merged_state_returns_true(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"MERGED","merged":true}'))
+    st = await _fetch()
+    assert st.merged is True
+    assert st.state == "MERGED"
+
+
+@_asyncio
+async def test_merged_state_infers_true_even_if_merged_field_missing(monkeypatch):
+    """state=MERGED 即判已合并（防御性：即便 merged 布尔缺失）。"""
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"MERGED"}'))
+    st = await _fetch()
+    assert st.merged is True
+
+
+@_asyncio
+async def test_open_state_returns_false(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"OPEN","merged":false}'))
+    st = await _fetch()
+    assert st.merged is False
+    assert st.state == "OPEN"
+
+
+@_asyncio
+async def test_closed_state_returns_false(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"CLOSED","merged":false}'))
+    st = await _fetch()
+    assert st.merged is False
+    assert st.state == "CLOSED"
+
+
+@_asyncio
+async def test_nonzero_returncode_returns_unknown(monkeypatch):
+    """rc≠0（未授权 / 不可达 / PR 不存在）→ unknown（保持 due 下 tick 重试）。"""
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b"", stderr=b"authentication required", returncode=1))
+    st = await _fetch()
+    assert st == pr_status.PrMergeStatus(merged=None, state=None)
+
+
+@_asyncio
+async def test_bad_json_returns_unknown(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b"not json at all"))
+    st = await _fetch()
+    assert st == pr_status.PrMergeStatus(merged=None, state=None)
+
+
+@_asyncio
+async def test_timeout_returns_unknown_and_kills_process_group(monkeypatch):
+    """超时 → unknown 且进程组被杀（_kill_process_group 兜底 proc.kill）。"""
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    proc = _FakeProc(stdout=b'{"state":"OPEN","merged":false}', sleep=1.0)
+    _patch_exec(monkeypatch, proc)
+    st = await _fetch(timeout=0.05)
+    assert st == pr_status.PrMergeStatus(merged=None, state=None)
+    assert proc.killed is True
+
+
+@_asyncio
+async def test_spawn_failure_returns_unknown(monkeypatch):
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, RuntimeError("spawn boom"))
+    st = await _fetch()
+    assert st == pr_status.PrMergeStatus(merged=None, state=None)
+
+
+# ---------------------------------------------------------------------------
+# apply_pr_merge_result：三分支回写语义（鸭子类型 routine）
+# ---------------------------------------------------------------------------
+
+
+class _RoutineLike:
+    """最小鸭子类型：仅携带 pr_merged / pr_merged_checked_at 两个属性。"""
+
+    def __init__(self, *, pr_merged=None, checked_at=None) -> None:
+        self.pr_merged = pr_merged
+        self.pr_merged_checked_at = checked_at
+
+
+def test_apply_merged_true_sets_true_and_advances_checked_at():
+    r = _RoutineLike()
+    now = "2026-06-30T00:00:00Z"
+    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=True, state="MERGED"), now)
+    assert newly is True
+    assert r.pr_merged is True
+    assert r.pr_merged_checked_at == now
+
+
+def test_apply_already_true_is_not_newly_detected():
+    r = _RoutineLike(pr_merged=True, checked_at="old")
+    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=True, state="MERGED"), "new")
+    assert newly is False  # 之前已是 True → 非新检出（不重复推 SSE）
+    assert r.pr_merged is True
+
+
+def test_apply_false_records_false_and_advances_checked_at():
+    """closed-without-merge：记 False 并推进 checked_at → 停检（退出 due 集）。"""
+    r = _RoutineLike()
+    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=False, state="CLOSED"), "now")
+    assert newly is False
+    assert r.pr_merged is False
+    assert r.pr_merged_checked_at == "now"
+
+
+def test_apply_unknown_with_state_advances_checked_at_only():
+    """gh 应答但 merged 未定（如 OPEN 已被 False 分支覆盖；此处防御 state 非 None）→ 仅节流。"""
+    r = _RoutineLike()
+    pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=None, state="OPEN"), "now")
+    assert r.pr_merged is None
+    assert r.pr_merged_checked_at == "now"
+
+
+def test_apply_unknown_without_state_leaves_checked_at_untouched():
+    """gh 未应答 → 不动 checked_at，保持 due 下 tick 重试。"""
+    r = _RoutineLike()
+    pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=None, state=None), "now")
+    assert r.pr_merged is None
+    assert r.pr_merged_checked_at is None
+
+
+def test_is_valid_pr_url_accepts_github_and_enterprise():
+    assert pr_status.is_valid_pr_url("https://github.com/o/r/pull/1")
+    assert pr_status.is_valid_pr_url("https://github.com/o/r/pull/123/files")
+    assert pr_status.is_valid_pr_url("https://gh.example.com/o/r/pulls/7")
+    assert not pr_status.is_valid_pr_url("https://github.com/o/r/issues/1")
+    assert not pr_status.is_valid_pr_url(None)
+    assert not pr_status.is_valid_pr_url("not a url")


### PR DESCRIPTION
## 背景

Routine 任务在 FINALIZE 阶段由 Claude Code 创建 GitHub PR 后，引擎立即把 routine 置为终态 `succeeded`（模型注释：`pr_url 非空 + succeeded` 表示「等待人工 Merge」）。**但 PR 在 GitHub 上被真正 Merge 后，没有任何机制把「已合并」回写给 Routine 实例**——此前全栈（DB 模型 / API / TS 类型 / 三个 UI 面）都没有 `merged` 概念，唯一的 PR 字段是 `pr_url`。

后果：PR 抽屉卡片**永远**显示「在 GitHub 合并 →」（即便 PR 早已合并），Full View 与 Routine 列表也无任何「Merged」标识。

## 方案

新增与 `status` **正交**的 `pr_merged` 列（**不**给状态机加枚举值，保持 `pending|running|paused|succeeded|failed|cancelled` 及 `_TERMINAL`/KPI/过滤器语义不变），由两条路径回写：

1. **后台巡检**：`routine_inspector` 心跳新增 `_sync_pr_merge_status` pass（镜像 `_reap_workspaces` 两段式会话），对 `succeeded ∧ pr_url ∧ 未确认 merged` 的 routine 复用**运行时已授权的 `gh` CLI** 做只读 `gh pr view --json state,merged`，节流 5min、批量 3，检出合并即落库并经 SSE 推送（列表 ~5min 内自动出现「Merged」）。
2. **手动同步**：PR 抽屉新增「同步状态」按钮 → `POST /routines/{id}/sync-pr`，合并后即时回写无需等心跳。

**三处 UI 标记**（violet 徽章 = GitHub merged 色 + 仓库 PR/finalize 强调色，区别于绿色 `succeeded`）：
- **PR 抽屉**：merged 后渲染非交互「已合并 ✓」（移除误导性合并 CTA）；
- **Full View**：详情头 status 徽章旁加「Merged」徽章（常驻首屏）+ done 态文本追加「· PR 已合并」；
- **Routine 列表**：`succeeded` 徽章旁追加「Merged」徽章（两枚徽章信息更清晰）。

## 设计要点（遵循 AGENTS.md）

- **正交分解 / 不改状态机**：`pr_merged` 为派生显示条件，非新状态值；
- **复用驱动**：复用既有 `gh` CLI（仓库 GitHub 集成唯一事实源）+ `_reap_workspaces` 会话范式 + `workspace._run_git` 子进程范式（超时整组 SIGKILL）；`apply_pr_merge_result` 统一写回分支供巡检与端点复用；
- **可降级，不引入新问题**：`gh` 不在 PATH / 未授权 / 超时 / 坏 URL / 坏 JSON → 一律返回 unknown 且**绝不抛异常**，**绝不阻塞或崩溃 25s 心跳**（缺 `gh` 仅首次 WARN 一次）；migration 仅加可空列 + 部分索引，**无数据删除/回滚风险**；
- **可观测**：合并检出写入 `task_executions.metrics`（`output_summary` 含 `pr_synced=N`）+ 日志 `routine_pr_merge_detected`；
- **边缘 Case**：restart 复位 `pr_merged` 防旧 PR 污染；closed-without-merge 记 `False` 停检；坏 URL 预筛防饥饿；并发 tick 幂等不锁行；nullable-bool 用 `or_(is_(None),is_(False))` 与部分索引谓词 `COALESCE(pr_merged,false)=false` 对齐。

## 关键文件

**后端**：`models/routine.py`、`db/migrations/versions/0079_routine_pr_merge.py`(新)、`engine/routine/pr_status.py`(新)、`engine/routine/orchestrator.py`、`interface/routine_api.py`、`config/routine.py`、`config.default.yaml`、`engine/schedulers/handlers/routine_inspector.py`
**前端**：`features/routine/{types,api,index}.ts`、`_components/{RoutinePrCard,RoutineRunView,RoutineTable,RoutineLoopDiagram,status-style}.{tsx,ts}`、`[id]/page.tsx`

## 验证

- ✅ 后端单测 `test_pr_status.py` 16 例全过（「绝不抛」契约全路径覆盖：gh 缺失/坏 URL/MERGED/OPEN/CLOSED/rc≠0/坏 JSON/超时杀进程组/spawn 失败 + `apply_pr_merge_result` 三分支）；
- ✅ 后端集成测 `_sync_pr_merge_status` 5 例全过（merged 检出+推 SSE / 已检不重查 / 节流 / closed 停检 / 未应答不动）；
- ✅ 前端 `RoutinePrCard` 渲染测 + `useRoutineLive` 13 例全过；TS typecheck（0 error）+ ESLint（0 warning）通过；
- ✅ Alembic 单一 head `0079`、线性 `0078 → 0079`；导入冒烟确认 `sync-pr` 路由注册、`GH_BIN` 可解析、orchestrator pass 就位；
- ℹ️ 全量 orchestrator 套件中 `test_dispatch_auto_launches_and_writes_back` 偶发失败系测试库跨会话累积的遗留 running routine 致 `_dispatch_due` 全表扫描计数偏高（已知环境性 flaky，与本 PR 正交——隔离运行通过，本 PR pass 仅触 `succeeded`）。

> 运行时假设：后端进程 env 需 `gh` 在 PATH 且已授权（本机 dev 成立，因 CC 经 `gh` 建 PR；冒烟实测 `GH_BIN=/opt/homebrew/bin/gh`）。不成立时整特性 no-op + 单次 WARN，心跳与现有功能零影响。

🤖 Generated with [Claude Code](https://github.com/claude)