### PR TITLE
fix(Routine): gh pr view 无 merged 字段致 PR 同步全失败——改用 state/mergedAt

### DIFF
--- a/apps/negentropy/src/negentropy/engine/routine/pr_status.py
+++ b/apps/negentropy/src/negentropy/engine/routine/pr_status.py
@@ -116,10 +116,14 @@ async def fetch_pr_merge_status(pr_url: str | None, *, timeout: float = 5.0) -> 
     流程（任一失败即返回 ``PrMergeStatus(None, None)``）：
     1. ``gh`` 不在 PATH → unknown（首次 WARN 一次）。
     2. URL 形状不合法 → unknown（不起子进程）。
-    3. 起 ``gh pr view <url> --json state,merged`` 子进程，``timeout`` 超时整组 SIGKILL → unknown。
+    3. 起 ``gh pr view <url> --json state,mergedAt`` 子进程，``timeout`` 超时整组 SIGKILL → unknown。
     4. rc≠0（未授权 / 不可达 / PR 不存在）→ unknown。
-    5. stdout 非 JSON / 字段缺失 → unknown。
-    6. 成功：``state=MERGED`` 或 ``merged=true`` → merged=True；否则按 ``merged`` 布尔值。
+    5. stdout 空 / 非 JSON / 字段缺失 → unknown（rc=0 但 stdout 空常为 gh 误用 JSON 字段，记 stderr 便于排查）。
+    6. 成功：``state=MERGED``（或 ``mergedAt`` 非空）→ merged=True；
+       否则（OPEN/CLOSED，``mergedAt`` 为 null）→ merged=False。
+
+    注：``gh pr view --json`` **无 ``merged`` 布尔字段**（误用会 rc=0 + 空输出，曾致本特性静默全失败）。
+    合并态权威信号是 ``state == "MERGED"``；``mergedAt`` 非空作 belt-and-suspenders。
     """
     global _warned_no_gh
 
@@ -143,7 +147,7 @@ async def fetch_pr_merge_status(pr_url: str | None, *, timeout: float = 5.0) -> 
             "view",
             pr_url,
             "--json",
-            "state,merged",
+            "state,mergedAt",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             start_new_session=True,
@@ -153,7 +157,7 @@ async def fetch_pr_merge_status(pr_url: str | None, *, timeout: float = 5.0) -> 
         return PrMergeStatus(merged=None, state=None)
 
     try:
-        stdout_b, _stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
         _kill_process_group(proc)
         with suppress(Exception):
@@ -170,6 +174,12 @@ async def fetch_pr_merge_status(pr_url: str | None, *, timeout: float = 5.0) -> 
         return PrMergeStatus(merged=None, state=None)
 
     out = (stdout_b or b"").decode("utf-8", errors="replace").strip()
+    if not out:
+        # rc=0 但 stdout 空——通常是 gh 误用 JSON 字段（如旧版误用 merged）等，stderr 有线索；
+        # 记 WARN 便于排查，避免静默 unknown（曾因 merged 字段不存在静默全失败）。
+        err = (stderr_b or b"").decode("utf-8", errors="replace").strip()
+        logger.warning("routine_pr_view_empty_stdout", returncode=proc.returncode, stderr_preview=err[:200])
+        return PrMergeStatus(merged=None, state=None)
     try:
         raw = json.loads(out)
     except (json.JSONDecodeError, ValueError):
@@ -180,9 +190,10 @@ async def fetch_pr_merge_status(pr_url: str | None, *, timeout: float = 5.0) -> 
         return PrMergeStatus(merged=None, state=None)
 
     state = raw.get("state")
-    merged_raw = raw.get("merged")
-    # state=MERGED 即判已合并（防御性：即便 merged 布尔缺失）；否则尊重 merged 布尔值。
-    if state == "MERGED":
-        return PrMergeStatus(merged=True, state=state)
-    merged = bool(merged_raw) if isinstance(merged_raw, bool) else None
-    return PrMergeStatus(merged=merged, state=state if isinstance(state, str) else None)
+    state_str = state if isinstance(state, str) else None
+    # 合并态权威信号：state == "MERGED"；mergedAt 非空作 belt-and-suspenders（gh 无 merged 布尔字段）。
+    merged_at = raw.get("mergedAt")
+    if state_str == "MERGED" or (isinstance(merged_at, str) and merged_at):
+        return PrMergeStatus(merged=True, state=state_str or "MERGED")
+    # state 为 OPEN/CLOSED 且无 mergedAt → 确认为未合并（gh 已应答，调用方据此节流/停检）。
+    return PrMergeStatus(merged=False, state=state_str)

--- a/apps/negentropy/tests/unit_tests/engine/test_pr_status.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pr_status.py
@@ -107,16 +107,20 @@ async def test_bad_url_returns_unknown_without_spawn(monkeypatch):
 
 @_asyncio
 async def test_merged_state_returns_true(monkeypatch):
+    """真实 gh 输出：state=MERGED + mergedAt 时间戳 → merged=True。"""
     monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
-    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"MERGED","merged":true}'))
+    _patch_exec(
+        monkeypatch,
+        _FakeProc(stdout=b'{"state":"MERGED","mergedAt":"2026-06-30T02:34:16Z","mergedBy":{"login":"x"}}'),
+    )
     st = await _fetch()
     assert st.merged is True
     assert st.state == "MERGED"
 
 
 @_asyncio
-async def test_merged_state_infers_true_even_if_merged_field_missing(monkeypatch):
-    """state=MERGED 即判已合并（防御性：即便 merged 布尔缺失）。"""
+async def test_merged_inferred_from_state_only(monkeypatch):
+    """state=MERGED 即判已合并（权威信号；即便缺 mergedAt）。"""
     monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
     _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"MERGED"}'))
     st = await _fetch()
@@ -124,9 +128,19 @@ async def test_merged_state_infers_true_even_if_merged_field_missing(monkeypatch
 
 
 @_asyncio
-async def test_open_state_returns_false(monkeypatch):
+async def test_merged_inferred_from_merged_at_only(monkeypatch):
+    """belt-and-suspenders：mergedAt 非空即判已合并（即便 state 异常缺失）。"""
     monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
-    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"OPEN","merged":false}'))
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"mergedAt":"2026-06-30T02:34:16Z"}'))
+    st = await _fetch()
+    assert st.merged is True
+
+
+@_asyncio
+async def test_open_state_returns_false(monkeypatch):
+    """OPEN + mergedAt=null → merged=False（gh 已应答，调用方据此节流）。"""
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"OPEN","mergedAt":null}'))
     st = await _fetch()
     assert st.merged is False
     assert st.state == "OPEN"
@@ -134,11 +148,25 @@ async def test_open_state_returns_false(monkeypatch):
 
 @_asyncio
 async def test_closed_state_returns_false(monkeypatch):
+    """CLOSED-without-merge → merged=False（停检）。"""
     monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
-    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"CLOSED","merged":false}'))
+    _patch_exec(monkeypatch, _FakeProc(stdout=b'{"state":"CLOSED","mergedAt":null}'))
     st = await _fetch()
     assert st.merged is False
     assert st.state == "CLOSED"
+
+
+@_asyncio
+async def test_empty_stdout_with_rc0_returns_unknown(monkeypatch):
+    """rc=0 但 stdout 空 → unknown（曾因 gh 误用 merged 字段静默全失败；现记 WARN stderr）。
+
+    回归 503 根因：旧代码请求不存在的 ``--json state,merged``，gh rc=0 + stderr 报
+    ``Unknown JSON field`` + stdout 空 → json.loads 失败 → unknown → 前端 503。
+    """
+    monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
+    _patch_exec(monkeypatch, _FakeProc(stdout=b"", stderr=b'Unknown JSON field: "merged"', returncode=0))
+    st = await _fetch()
+    assert st == pr_status.PrMergeStatus(merged=None, state=None)
 
 
 @_asyncio
@@ -162,7 +190,7 @@ async def test_bad_json_returns_unknown(monkeypatch):
 async def test_timeout_returns_unknown_and_kills_process_group(monkeypatch):
     """超时 → unknown 且进程组被杀（_kill_process_group 兜底 proc.kill）。"""
     monkeypatch.setattr(pr_status, "GH_BIN", "/fake/gh")
-    proc = _FakeProc(stdout=b'{"state":"OPEN","merged":false}', sleep=1.0)
+    proc = _FakeProc(stdout=b'{"state":"OPEN","mergedAt":null}', sleep=1.0)
     _patch_exec(monkeypatch, proc)
     st = await _fetch(timeout=0.05)
     assert st == pr_status.PrMergeStatus(merged=None, state=None)


### PR DESCRIPTION
## 背景

承接已合并的 #1024（PR Merge 状态回写）。复测发现**两个症状同一根因**：手动「同步状态」返回 503、心跳 5min 也不回写 Merged。

## 根因

> ``gh pr view --json`` **没有 ``merged`` 布尔字段**。

实测 ``gh pr view <url> --json state,merged`` 报 ``Unknown JSON field: "merged"``（rc=0，但 **stdout 空**、错误进 stderr）。#1024 的 ``fetch_pr_merge_status`` 请求了这个不存在的字段 → stdout 空 → ``json.loads`` 失败 → 永远返回 unknown：

- **手动「同步状态」**：unknown → 端点 503；
- **心跳巡检**：每个 tick 走同一失败路径，因 ``state is None`` 不推进 ``checked_at``、保持 due 反复重试却**永不成功** → 5min（乃至永远）不回写 Merged。

> Auth **非**问题：CC 的 ``_credential_env`` 只管 Anthropic 凭证，GitHub auth 靠继承的 OS env；CC 能建 PR ⇒ 容器内 gh 已 authed ⇒ 本特性的 ``gh pr view`` 同样能 auth。纯字段名错误。

## 修复

- ``pr_status.py``：``--json state,merged`` → ``--json state,mergedAt``；合并态权威信号改为 ``state == "MERGED"``，``mergedAt`` 非空作 belt-and-suspenders；OPEN/CLOSED（``mergedAt=null``）→ ``merged=False``（gh 已应答，据此节流/停检）。
- 健壮性：rc=0 但 stdout 空时记 **WARN + stderr 预览**（曾因此静默全失败），capture stderr 便于排查。
- 测试：fixture 改为真实 gh schema（``state``+``mergedAt``）；**新增 ``empty-stdout-with-rc0`` 回归用例**精确复现 503 根因；保留 merged-from-state-only / merged-from-mergedAt-only / OPEN / CLOSED 各分支。18 例全过。
- **端到端**：对真实已合并 PR #1022 / #1024 实跑 ``fetch_pr_merge_status`` → ``merged=True, state=MERGED`` ✓。

## 相对 feature/1.x.x 的改动

仅 2 个文件：``pr_status.py``（字段修复 + 健壮性）+ ``test_pr_status.py``（fixture + 回归用例）。无冲突，clean cherry-pick 于 ``origin/feature/1.x.x``。

## 教训

① ``shutil.which`` 只证「PATH 有 gh」**不证「已 auth」**；② 单测 fixture 是自写的、**发现不了字段名错误**——必须用真实 gh + 真实 PR 端到端验证（详见 [[backend-gh-cli-authed-runtime]]）。

## 部署提醒

后端跑在 Docker（``threefishai/negentropy-backend``），合入后需**重建/重启后端容器**才生效（``./dev restart backend``）。

🤖 Generated with [Claude Code](https://github.com/claude)