### PR TITLE
feat(Routine): PR 状态三态持久化（pr_state）+ Closed 对等打标 + 修复 updated_at 反复跳变

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { ArrowLeft, GitMerge, RotateCcw } from "lucide-react";
+import { ArrowLeft, GitMerge, RotateCcw, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/Button";
@@ -156,6 +156,12 @@ export default function RoutineRunPage() {
                     <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-violet-500/10 px-2.5 py-0.5 text-xs font-semibold text-violet-700 dark:text-violet-300">
                       <GitMerge className="h-3.5 w-3.5" aria-hidden />
                       Merged
+                    </span>
+                  )}
+                  {routine?.status === "succeeded" && routine.pr_url && routine.pr_state === "closed" && (
+                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-xs font-semibold text-text-secondary">
+                      <X className="h-3.5 w-3.5" aria-hidden />
+                      Closed
                     </span>
                   )}
                   {routine?.current_phase && routine.status === "running" && (

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
@@ -64,7 +64,11 @@ export function RoutineLoopDiagram({
         ) : snapshot.mode === "done" ? (
           <span className="text-text-secondary">
             已结束{snapshot.terminationReason ? ` · 终止原因：${snapshot.terminationReason}` : ""}
-            {routine.pr_url && routine.pr_merged ? " · PR 已合并" : ""}
+            {routine.pr_url && routine.pr_merged
+              ? " · PR 已合并"
+              : routine.pr_url && routine.pr_state === "closed"
+                ? " · PR 已关闭"
+                : ""}
           </span>
         ) : snapshot.mode === "paused" ? (
           <span className="text-amber-600 dark:text-amber-400">已暂停 · 恢复后继续迭代</span>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
@@ -1,29 +1,34 @@
 "use client";
 
 import { useState } from "react";
-import { GitMerge, GitPullRequest, Loader2, RefreshCw } from "lucide-react";
+import { GitMerge, GitPullRequest, Loader2, RefreshCw, X } from "lucide-react";
 
 /**
- * PR 卡片 —— FINALIZE 阶段 Claude Code 创建 PR 后，展示「查看 PR」与合并状态。
+ * PR 卡片 —— FINALIZE 阶段 Claude Code 创建 PR 后，展示「查看 PR」与 PR 状态。
  *
- * - ``merged`` 为真：渲染 violet「已合并 ✓」终态（合并是人工动作，已完成即不再提供合并入口）。
- * - 否则：保留「在 GitHub 合并 →」外链 + 「同步 PR 状态」按钮（合并后即时回写，无需等~5min 心跳）。
+ * 三态（由 pr_state 决定，merged 为派生快捷入参）：
+ * - ``merged`` 为真：violet「已合并 ✓」终态（合并是人工动作，已完成即不再提供合并入口）。
+ * - ``prState === "closed"``：muted「已关闭」终态（已关闭未合并，不能合并 → 无合并链接、无同步按钮）。
+ * - 否则（open / null）：保留「在 GitHub 合并 →」外链 + 「同步状态」按钮（合并后即时回写）。
  *
  * 安全：合并是人工动作，本组件仅 link-out 到 GitHub + 只读状态同步（不调用任何后端 merge 接口、不自动合并）。
  */
 export function RoutinePrCard({
   prUrl,
   merged,
+  prState,
   onSync,
 }: {
   prUrl: string | null | undefined;
   merged?: boolean | null;
+  prState?: "open" | "closed" | "merged" | null;
   onSync?: () => void | Promise<void>;
 }) {
   const [syncing, setSyncing] = useState(false);
   if (!prUrl) return null;
 
-  const isMerged = !!merged;
+  const isMerged = !!merged || prState === "merged";
+  const isClosed = !isMerged && prState === "closed";
 
   const handleSync = async () => {
     if (syncing || !onSync) return;
@@ -51,6 +56,11 @@ export function RoutinePrCard({
         <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-violet-300 bg-violet-500/10 px-2.5 py-1 text-xs font-semibold text-violet-700 dark:border-violet-700 dark:text-violet-300">
           <GitMerge className="h-3.5 w-3.5" aria-hidden />
           已合并 ✓
+        </span>
+      ) : isClosed ? (
+        <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-text-secondary">
+          <X className="h-3.5 w-3.5" aria-hidden />
+          已关闭
         </span>
       ) : (
         <>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineRunView.tsx
@@ -181,7 +181,12 @@ export function RoutineRunView({
           widthClassName={MODULE_DRAWER_WIDTH}
         >
           <div className="px-5 py-5">
-            <RoutinePrCard prUrl={routine.pr_url} merged={routine.pr_merged} onSync={onSyncPr} />
+            <RoutinePrCard
+              prUrl={routine.pr_url}
+              merged={routine.pr_merged}
+              prState={routine.pr_state}
+              onSync={onSyncPr}
+            />
           </div>
         </BaseDrawer>
       )}

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { ExternalLink, GitMerge, Loader2, OctagonX, RotateCcw, Trash2 } from "lucide-react";
+import { ExternalLink, GitMerge, Loader2, OctagonX, RotateCcw, Trash2, X } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
 
 import { canCancel, canCleanupWorktree, canRestart } from "./routine-controls";
-import { mergedBadgeClass, routineStatusClass, scoreColorClass } from "./status-style";
+import { closedBadgeClass, mergedBadgeClass, routineStatusClass, scoreColorClass } from "./status-style";
 
 interface RoutineTableProps {
   routines: RoutineDTO[];
@@ -88,6 +88,12 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                     <span className={mergedBadgeClass}>
                       <GitMerge className="h-3 w-3" aria-hidden />
                       Merged
+                    </span>
+                  )}
+                  {r.pr_state === "closed" && (
+                    <span className={closedBadgeClass}>
+                      <X className="h-3 w-3" aria-hidden />
+                      Closed
                     </span>
                   )}
                 </div>

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -119,6 +119,10 @@ export function routineStatusClass(status: RoutineStatus): string {
 export const mergedBadgeClass =
   "inline-flex items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-micro font-semibold text-violet-700 dark:text-violet-300";
 
+/** 「PR 已关闭（未合并）」徽章配色（muted/灰，区别于 failed-红 / merged-紫 / succeeded-绿）。 */
+export const closedBadgeClass =
+  "inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-micro font-semibold text-text-secondary";
+
 /** 迭代状态 → 状态点配色。 */
 export function iterationDotClass(status: IterationStatus): string {
   switch (status) {

--- a/apps/negentropy-ui/features/routine/types.ts
+++ b/apps/negentropy-ui/features/routine/types.ts
@@ -49,6 +49,8 @@ export interface RoutineDTO {
   pr_url: string | null;
   /** PR 是否已合并（true=已 Merge；null=未知/未检测，旧记录回退）。派生显示条件，非新状态值。 */
   pr_merged: boolean | null;
+  /** PR 状态（open|closed|merged；null=未知/未检测，旧记录回退）。区分 Open 与 Closed-without-merge。 */
+  pr_state: "open" | "closed" | "merged" | null;
   /** 引擎管理的运行期：本轮隔离工作分支（routine/<key>-<ts>）。 */
   work_branch: string | null;
   /** 引擎管理的运行期：隔离 worktree 文件系统路径（= CC 实际 cwd）。 */

--- a/apps/negentropy-ui/tests/unit/features/routine/RoutinePrCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/RoutinePrCard.test.tsx
@@ -22,6 +22,23 @@ describe("RoutinePrCard", () => {
     expect(screen.getByText("查看 PR")).toBeInTheDocument();
   });
 
+  it("prState=closed 显示「已关闭」且无合并外链 / 同步按钮（保留查看 PR）", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={false} prState="closed" onSync={vi.fn()} />);
+    expect(screen.getByText("已关闭")).toBeInTheDocument();
+    expect(screen.queryByText("在 GitHub 合并 →")).not.toBeInTheDocument();
+    expect(screen.queryByText("同步状态")).not.toBeInTheDocument();
+    expect(screen.queryByText("已合并 ✓")).not.toBeInTheDocument();
+    // 「查看 PR」始终保留
+    expect(screen.getByText("查看 PR")).toBeInTheDocument();
+  });
+
+  it("prState=open（显式）按待合并渲染（合并入口 + 同步按钮）", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={false} prState="open" onSync={vi.fn()} />);
+    expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();
+    expect(screen.getByText("同步状态")).toBeInTheDocument();
+    expect(screen.queryByText("已关闭")).not.toBeInTheDocument();
+  });
+
   it("未合并显示「在 GitHub 合并」外链 + 「同步状态」按钮", () => {
     render(<RoutinePrCard prUrl={PR_URL} merged={false} onSync={vi.fn()} />);
     expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
@@ -42,6 +42,7 @@ function makeRoutine(id: string): RoutineDTO {
     current_phase: null,
     pr_url: null,
     pr_merged: null,
+    pr_state: null,
     work_branch: null,
     worktree_path: null,
     max_iterations: 20,

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
@@ -50,6 +50,7 @@ function makeRoutine(id: string, status: RoutineDTO["status"] = "running"): Rout
     current_phase: null,
     pr_url: null,
     pr_merged: null,
+    pr_state: null,
     work_branch: null,
     worktree_path: null,
     max_iterations: 20,

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0080_routine_pr_state.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0080_routine_pr_state.py
@@ -1,0 +1,109 @@
+"""为 routines 新增 pr_state（open|closed|merged）+ 调整 PR 巡检部分索引谓词。
+
+Revision ID: 0080
+Revises: 0079
+Create Date: 2026-06-30 00:00:02.000000+00:00
+
+设计动机：
+    0079 仅持久化 ``pr_merged``（bool），gh 返回的 ``state``（OPEN/CLOSED/MERGED）被丢弃——
+    致 Open 与 Closed-without-merge 坍缩为同一个 ``pr_merged=False``，UI 无法区分（Closed 的 PR
+    在抽屉仍显示「在 GitHub 合并」入口，具误导性）。本迁移加 ``pr_state`` 权威状态列，使 UI 能对
+    Merged/Closed 对等打标；并据此调整 due 集：Open（可能后续合并）继续复检，Merged/Closed 终态排除
+    （顺带修掉 Closed 每 5min 复检的浪费）。
+
+    ``pr_merged``（bool）保留为派生反规范化（= ``pr_state=='merged'``），与既有 best_score/last_score
+    反规范化同范式，使既有 merged 查询/UI 字段零侵入。
+
+幂等性：
+    加列 / 索引前以 information_schema / pg_indexes 探测（仿 0079）。纯加 nullable 列 + 回填
+    ``pr_merged=true → pr_state='merged'``（无损；``pr_merged=false`` 行 open/closed 不可区分，
+    留 NULL 由下个节流窗口 gh 重定）；索引谓词变更须 drop+recreate。
+
+参考文献：
+[1] 0079_routine_pr_merge.py — information_schema 幂等加列 + 部分索引范式。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0080"
+down_revision: str | None = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+
+
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema = :s AND table_name = :t AND column_name = :c"
+            ),
+            {"s": SCHEMA, "t": table_name, "c": column_name},
+        ).scalar()
+    )
+
+
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text("SELECT 1 FROM pg_indexes WHERE schemaname = :s AND tablename = :t AND indexname = :i"),
+            {"s": SCHEMA, "t": table_name, "i": index_name},
+        ).scalar()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _column_exists(bind, "routines", "pr_state"):
+        op.add_column(
+            "routines",
+            sa.Column(
+                "pr_state",
+                sa.String(length=16),
+                nullable=True,
+                comment="PR 状态 open|closed|merged（null=未知/未检测；与 status 正交）",
+            ),
+            schema=SCHEMA,
+        )
+    # 回填：已确认 merged 的行无损标注；pr_merged=false 行 open/closed 不可区分，留 NULL 待 gh 重定。
+    op.execute(
+        sa.text("UPDATE negentropy.routines SET pr_state = 'merged' WHERE pr_state IS NULL AND pr_merged = true")
+    )
+    # 索引谓词从「pr_merged 未确认 True」改为「pr_state 未达终态（NULL 或 open）」——
+    # Open 仍可后续合并故复检，Merged/Closed 终态排除。drop+recreate（谓词变更）。
+    if _index_exists(bind, "routines", "ix_routines_pr_merge_due"):
+        op.drop_index("ix_routines_pr_merge_due", table_name="routines", schema=SCHEMA)
+    if not _index_exists(bind, "routines", "ix_routines_pr_merge_due"):
+        op.create_index(
+            "ix_routines_pr_merge_due",
+            "routines",
+            [sa.text("pr_merged_checked_at")],
+            postgresql_where=sa.text(
+                "status = 'succeeded' AND pr_url IS NOT NULL AND (pr_state IS NULL OR pr_state = 'open')"
+            ),
+            schema=SCHEMA,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _index_exists(bind, "routines", "ix_routines_pr_merge_due"):
+        op.drop_index("ix_routines_pr_merge_due", table_name="routines", schema=SCHEMA)
+    # 回滚到 0079 旧谓词（COALESCE(pr_merged,false)=false）。downgrade 丢失 0080 写入的 open/closed 区分，可接受。
+    if not _index_exists(bind, "routines", "ix_routines_pr_merge_due"):
+        op.create_index(
+            "ix_routines_pr_merge_due",
+            "routines",
+            [sa.text("pr_merged_checked_at")],
+            postgresql_where=sa.text(
+                "status = 'succeeded' AND pr_url IS NOT NULL AND COALESCE(pr_merged, false) = false"
+            ),
+            schema=SCHEMA,
+        )
+    if _column_exists(bind, "routines", "pr_state"):
+        op.drop_column("routines", "pr_state", schema=SCHEMA)

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -487,18 +487,22 @@ class RoutineOrchestrator:
         return cleaned
 
     async def _sync_pr_merge_status(self) -> int:
-        """巡检终态 routine 的 PR 合并状态并回写 ``pr_merged``（best-effort，绝不阻塞/崩溃心跳）。
+        """巡检终态 routine 的 PR 状态（open/closed/merged）并回写 ``pr_state``（best-effort，绝不阻塞/崩溃心跳）。
 
-        复用既有 ``gh`` CLI（仓库 GitHub 集成的唯一事实源）做只读 ``gh pr view --json state,merged``：
-        succeeded + pr_url 的 routine 在 FINALIZE 后处于「等待人工 Merge」态，人在 GitHub 合并后，
-        本 pass 把 ``pr_merged`` 回写为 True 并经 SSE 推送，使列表 / Full View / PR 抽屉三处显示「Merged」。
+        复用既有 ``gh`` CLI（仓库 GitHub 集成的唯一事实源）做只读 ``gh pr view --json state,mergedAt``：
+        succeeded + pr_url 的 routine 在 FINALIZE 后处于「等待人工 Merge」态，人在 GitHub 合并/关闭后，
+        本 pass 回写 ``pr_state`` 并经 SSE 推送 merged，使列表 / Full View / PR 抽屉三处显示「Merged」/「Closed」。
 
         可降级（对齐 AGENTS.md「不引入新问题」）：``gh`` 缺失/未授权/超时/坏 URL → ``pr_status`` 返回
-        unknown，本 pass 静默跳过（节流水位线 ``pr_merged_checked_at`` 不推进，保持 due 下 tick 重试）；
+        unknown（state=None），本 pass 静默跳过（不写、不推进 ``checked_at``，保持 due 下 tick 重试）；
         心跳永不因本 pass 崩溃（双层兜底：pr_status 不抛 + 本 pass 单层 ``except Exception``）。
 
-        范式镜像 ``_reap_workspaces``：短会话查 due → 会话外做 gh 子进程（不占连接池）→ 短会话写回 + 推送。
-        due 集 = succeeded ∧ pr_url 非空 ∧ pr_merged 未确认为 True ∧ 距上次检测 > 节流间隔；批量上限适配 25s 心跳。
+        due 集 = succeeded ∧ pr_url 非空 ∧ pr_state 未达终态（NULL 或 open）∧ 距上次检测 > 节流间隔。
+        Open（可能后续合并）继续复检；Merged/Closed 终态排除（顺带修掉 Closed 每 5min 复检的浪费）。
+
+        **不污染 updated_at**：写回用 Core ``update()``（绕过 ORM ``onupdate=func.now()``），仅当
+        ``pr_state`` 实际翻转时才把 ``updated_at`` 纳入 SET —— 纯节流水位线推进不再刷新 updated_at，
+        避免这些 routine 在列表（按 updated_at 排序）里反复乱跳。
 
         返回本轮新检出「已合并」的 routine 数（推 SSE 的次数）。详见 ``pr_status.fetch_pr_merge_status``。
         """
@@ -510,15 +514,16 @@ class RoutineOrchestrator:
         batch = settings.routine.pr_merge_check_batch
         timeout = float(settings.routine.pr_merge_check_timeout_seconds)
 
-        # ① 短会话：拉取 due routine 的 (id, pr_url)（expire_on_commit=False → detached 后可读）。
+        # ① 短会话：拉取 due routine 的 (id, pr_url, pr_state)（expire_on_commit=False → detached 后可读）。
         async with db_session.AsyncSessionLocal() as db:
             rows = (
                 await db.execute(
-                    select(Routine.id, Routine.pr_url)
+                    select(Routine.id, Routine.pr_url, Routine.pr_state)
                     .where(
                         Routine.status == "succeeded",
                         Routine.pr_url.is_not(None),
-                        or_(Routine.pr_merged.is_(None), Routine.pr_merged.is_(False)),
+                        # due = 未达终态（NULL 未知 或 open 仍可后续合并）；merged/closed 终态排除。
+                        or_(Routine.pr_state.is_(None), Routine.pr_state == "open"),
                         or_(
                             Routine.pr_merged_checked_at.is_(None),
                             Routine.pr_merged_checked_at < cutoff,
@@ -532,30 +537,45 @@ class RoutineOrchestrator:
             return 0
 
         # ② 会话外：best-effort 检测每个 PR（gh 子进程带超时；pr_status 契约为绝不抛）。
-        checks: list[tuple[UUID, pr_status.PrMergeStatus]] = []
-        for rid, pr_url in rows:
+        checks: list[tuple[UUID, str | None, pr_status.PrMergeStatus]] = []
+        for rid, pr_url, before_state in rows:
             url = pr_url or ""
-            # 坏 URL 预筛：直接判「未合并」落库停检，杜绝永滞 due 集（防饥饿）。
+            # 坏 URL 预筛：归一化为终态 closed（落库停检，杜绝永滞 due 集）；before_state 供翻转判定。
             if not pr_status.is_valid_pr_url(url):
-                checks.append((rid, pr_status.PrMergeStatus(merged=False, state=None)))
+                checks.append((rid, before_state, pr_status.PrMergeStatus(merged=False, state="CLOSED")))
                 continue
             try:
                 st = await pr_status.fetch_pr_merge_status(url, timeout=timeout)
             except Exception as exc:  # noqa: BLE001 — pr_status 契约为不抛；双保险兜底，护心跳
                 logger.warning("routine_pr_merge_check_failed", routine_id=str(rid), error=str(exc))
                 st = pr_status.PrMergeStatus(merged=None, state=None)
-            checks.append((rid, st))
+            checks.append((rid, before_state, st))
 
-        # ③ 短会话：回写 + 提交；仅「新检出 merged」者推 SSE（commit 后属性仍可读：expire_on_commit=False）。
+        # ③ 短会话：Core update 回写 + 提交；仅「新检出 merged」者推 SSE。
+        # **不污染 updated_at**：Routine.updated_at 带 ORM ``onupdate=func.now()``，Core update 仍会触发它
+        # （实证：见探针），故对「未翻转」分支显式 ``updated_at = Routine.updated_at`` 自引用保形——
+        # 仅状态实际翻转时才置为 now（列表只在 PR 真正合并/关闭时才重排，不随节流推进乱跳）。
+        # WHERE 含 status/pr_url 守卫：restart/cancel/pr_url 清理等使其脱离 due → UPDATE 匹配 0 行（no-op）。
         merged_ids: list[UUID] = []
         now = _utcnow()
         async with db_session.AsyncSessionLocal() as db:
-            for rid, st in checks:
-                r = await db.get(Routine, rid)
-                # 竞态守卫：restart/cancel/pr_url 清理等使其脱离 due → 跳过，不回写。
-                if r is None or r.status != "succeeded" or not r.pr_url:
-                    continue
-                if pr_status.apply_pr_merge_result(r, st, now):
+            for rid, before_state, st in checks:
+                new_state, changed = pr_status.compute_pr_write(before_state, st)
+                if new_state is None:
+                    continue  # gh 未应答 → 不写，保持 due 下 tick 重试
+                vals: dict[str, Any] = {
+                    "pr_state": new_state,
+                    "pr_merged": new_state == "merged",
+                    "pr_merged_checked_at": now,
+                    # 显式 updated_at：翻转→now；未翻转→自引用保形（绕过 onupdate，不刷 updated_at）。
+                    "updated_at": now if changed else Routine.updated_at,
+                }
+                await db.execute(
+                    update(Routine)
+                    .where(Routine.id == rid, Routine.status == "succeeded", Routine.pr_url.is_not(None))
+                    .values(**vals)
+                )
+                if new_state == "merged" and changed:
                     merged_ids.append(rid)
             await db.commit()
             for rid in merged_ids:
@@ -1888,6 +1908,7 @@ class RoutineOrchestrator:
                 "current_phase": routine.current_phase,
                 "pr_url": routine.pr_url,
                 "pr_merged": routine.pr_merged,
+                "pr_state": routine.pr_state,
             }
         )
 

--- a/apps/negentropy/src/negentropy/engine/routine/pr_status.py
+++ b/apps/negentropy/src/negentropy/engine/routine/pr_status.py
@@ -8,7 +8,7 @@
 为何复用 ``gh`` CLI：
     ``gh`` 是本仓库 GitHub 集成的唯一事实源（CC 经 ``gh pr create`` 建 PR；``publish-wiki-pages.sh``
     经 ``gh auth token`` 取 token）。后端不引入新 GitHub 客户端 / token，直接复用运行时已授权的
-    ``gh`` 做只读 ``gh pr view --json state,merged``。
+    ``gh`` 做只读 ``gh pr view --json state,mergedAt``。
 
 可降级契约（对齐 AGENTS.md「不引入新问题」）：
     ``gh`` 不在 PATH / 未授权 / 超时 / rc≠0 / 坏 JSON / 坏 URL → 一律返回 ``PrMergeStatus(None, None)``
@@ -74,31 +74,52 @@ def is_valid_pr_url(url: str | None) -> bool:
     return bool(url) and bool(_PR_URL_RE.match(url))
 
 
-def apply_pr_merge_result(routine, st: PrMergeStatus, now) -> bool:
-    """把检测结果回写到 routine 的 ``pr_merged`` / ``pr_merged_checked_at``（鸭子类型，复用于
-    心跳 pass 与手动 ``sync-pr`` 端点，避免两处写回分支漂移）。
+def next_pr_state(st: PrMergeStatus) -> str | None:
+    """gh 应答的归一化 ``pr_state``（``open``|``closed``|``merged``）。
 
-    回写语义：
-    - ``merged is True`` → ``pr_merged=True`` + 推进 ``checked_at``；返回是否「新检出」合并
-      （之前非 True）——调用方据此决定是否推 SSE。
-    - ``merged is False``（OPEN / closed-without-merge）→ ``pr_merged=False`` + 推进 ``checked_at``
-      （确认为未合并即停检：部分索引谓词 ``COALESCE(pr_merged,false)=false`` 会把 True/False 都排除）。
-    - ``merged is None``：``state`` 非 None（gh 应答，如 OPEN 已被上面覆盖；此处防御）→ 仅推进
-      ``checked_at`` 节流；``state is None``（gh 未应答）→ **不动** ``checked_at``，保持 due 下 tick 重试。
+    ``None`` = gh 未给出有效应答（缺失/超时/rc≠0/坏 JSON/坏 state）→ 调用方应**不写**，
+    保持 due 下 tick 重试（节流水位线 ``checked_at`` 亦不推进）。
     """
-    if st.merged is True:
-        before = getattr(routine, "pr_merged", None)
-        routine.pr_merged = True
-        routine.pr_merged_checked_at = now
-        return before is not True
-    if st.merged is False:
-        routine.pr_merged = False
-        routine.pr_merged_checked_at = now
+    if st.state is None:
+        return None
+    norm = st.state.lower()
+    return norm if norm in ("open", "closed", "merged") else None
+
+
+def compute_pr_write(before_state: str | None, st: PrMergeStatus) -> tuple[str | None, bool]:
+    """纯决策：由检测结果推导应写入的 ``pr_state`` 与「状态是否翻转」。
+
+    Returns:
+        ``(new_state, state_changed)`` —— ``new_state is None`` 表示 gh 未应答（不写）；
+        ``state_changed`` = ``new_state != before_state``（用于决定是否更新 ``updated_at`` / 推 SSE）。
+    """
+    new_state = next_pr_state(st)
+    if new_state is None:
+        return (None, False)
+    return (new_state, before_state != new_state)
+
+
+def apply_pr_merge_result(routine, st: PrMergeStatus, now) -> bool:
+    """把检测结果回写到 routine 的 ``pr_state`` / ``pr_merged`` / ``pr_merged_checked_at``
+    （鸭子类型，供手动 ``sync-pr`` 端点的 ORM 写回路径复用）。
+
+    状态化写回（``pr_state`` 权威、``pr_merged`` 派生 = ``pr_state=='merged'``）：
+    - gh 应答（state ∈ open/closed/merged）→ 写 ``pr_state`` + 派生 ``pr_merged`` + 推进 ``checked_at``；
+      返回是否「新检出 merged」（之前非 merged）——调用方据此决定是否推 SSE。
+    - gh 未应答（state is None）→ **不写**（保持 due 下 tick 重试），返回 False。
+
+    注：心跳 pass 不走此 ORM 路径（ORM flush 会刷新 ``updated_at`` 致列表乱跳），改用 Core
+    ``update()`` + ``compute_pr_merge_write``（见 orchestrator._sync_pr_merge_status）；本函数仅用于
+    用户主动触发的手动端点（updated_at 即便刷新可接受）。
+    """
+    new_state = next_pr_state(st)
+    if new_state is None:
         return False
-    # merged is None
-    if st.state is not None:
-        routine.pr_merged_checked_at = now
-    return False
+    before_merged = getattr(routine, "pr_merged", None)
+    routine.pr_state = new_state
+    routine.pr_merged = new_state == "merged"
+    routine.pr_merged_checked_at = now
+    return new_state == "merged" and before_merged is not True
 
 
 def _kill_process_group(proc) -> None:

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -199,6 +199,7 @@ def _serialize_routine(
         "current_phase": r.current_phase,
         "pr_url": r.pr_url,
         "pr_merged": r.pr_merged,
+        "pr_state": r.pr_state,
         "work_branch": r.work_branch,
         "worktree_path": r.worktree_path,
         "worktree_status": worktree_meta.get("status") if worktree_meta else None,
@@ -1000,8 +1001,9 @@ async def restart_routine(routine_id: UUID, body: RestartBody | None = None) -> 
         r.claude_session_id = None
         r.current_phase = phase_mod.initial_phase(r.config)
         r.pr_url = None
-        # 复位 PR 合并状态：避免旧 PR 的 merged 污染新一轮 PR 的检测与「Merged」展示。
+        # 复位 PR 合并状态：避免旧 PR 的 merged/state 污染新轮 PR 的检测与「Merged」/「Closed」展示。
         r.pr_merged = None
+        r.pr_state = None
         r.pr_merged_checked_at = None
         # 隔离 worktree：仅回收 worktree 目录、**保留终生单一工作分支**（含其检查点提交），
         # 使新一轮尝试在同一分支上从上一检查点续作（不铸新分支、不重建自基线）。下一次派发的
@@ -1197,6 +1199,7 @@ async def _publish_routine(r: Routine) -> None:
             "current_phase": r.current_phase,
             "pr_url": r.pr_url,
             "pr_merged": r.pr_merged,
+            "pr_state": r.pr_state,
         }
     )
 

--- a/apps/negentropy/src/negentropy/models/routine.py
+++ b/apps/negentropy/src/negentropy/models/routine.py
@@ -139,6 +139,14 @@ class Routine(Base, UUIDMixin, TimestampMixin):
         nullable=True,
         comment="PR 是否已 merge（null=未知/未检测；与 status 正交，不改状态机）",
     )
+    # PR 权威状态（gh pr view --json state）：open|closed|merged（null=未知/未检测）。
+    # 与 pr_merged 正交持久化以区分 Open 与 Closed-without-merge（两者 pr_merged 均为 False）；
+    # pr_merged 为派生反规范化布尔（= pr_state=='merged'），沿用 best_score/last_score 同范式。
+    pr_state: Mapped[str | None] = mapped_column(
+        String(16),
+        nullable=True,
+        comment="PR 状态 open|closed|merged（null=未知/未检测；与 status 正交）",
+    )
     pr_merged_checked_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,

--- a/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
+++ b/apps/negentropy/tests/integration_tests/engine/test_routine_orchestrator.py
@@ -1226,6 +1226,7 @@ async def _make_succeeded_routine_with_pr(**overrides) -> uuid.UUID:
         status="succeeded",
         termination_reason="success",
         pr_url=_PR_URL,
+        pr_state=None,
         pr_merged=None,
         pr_merged_checked_at=None,
         max_iterations=5,
@@ -1245,7 +1246,7 @@ async def _make_succeeded_routine_with_pr(**overrides) -> uuid.UUID:
 
 
 async def test_sync_pr_merge_status_detects_merged_and_publishes():
-    """succeeded + pr_url + 未知 → gh 报 MERGED → 回写 pr_merged=True + 推 SSE，返回 1。"""
+    """succeeded + pr_url + 未知 → gh 报 MERGED → 回写 pr_state=merged/pr_merged=True + 推 SSE，返回 1。"""
     rid = await _make_succeeded_routine_with_pr()
     try:
         orch = RoutineOrchestrator()
@@ -1261,6 +1262,7 @@ async def test_sync_pr_merge_status_detects_merged_and_publishes():
         assert count == 1
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
+            assert r.pr_state == "merged"
             assert r.pr_merged is True
             assert r.pr_merged_checked_at is not None
         publish_mock.assert_awaited_once()
@@ -1269,8 +1271,8 @@ async def test_sync_pr_merge_status_detects_merged_and_publishes():
 
 
 async def test_sync_pr_merge_status_skips_already_merged():
-    """pr_merged=True 的 routine 不在 due 集 → 不调 gh、不推 SSE，返回 0。"""
-    rid = await _make_succeeded_routine_with_pr(pr_merged=True, pr_merged_checked_at=None)
+    """pr_state=merged（终态）的 routine 不在 due 集 → 不调 gh、不推 SSE，返回 0。"""
+    rid = await _make_succeeded_routine_with_pr(pr_state="merged", pr_merged=True, pr_merged_checked_at=None)
     fetch_mock = AsyncMock()
     try:
         orch = RoutineOrchestrator()
@@ -1285,8 +1287,22 @@ async def test_sync_pr_merge_status_skips_already_merged():
         await _cleanup(rid)
 
 
+async def test_sync_pr_merge_status_closed_is_terminal_skips_recheck():
+    """pr_state=closed（终态）的 routine 不在 due 集 → 不调 gh（修掉 Closed 每 5min 复检的浪费）。"""
+    rid = await _make_succeeded_routine_with_pr(pr_state="closed", pr_merged=False, pr_merged_checked_at=None)
+    fetch_mock = AsyncMock()
+    try:
+        orch = RoutineOrchestrator()
+        with patch("negentropy.engine.routine.pr_status.fetch_pr_merge_status", new=fetch_mock):
+            count = await orch._sync_pr_merge_status()  # noqa: SLF001
+        assert count == 0
+        fetch_mock.assert_not_called()
+    finally:
+        await _cleanup(rid)
+
+
 async def test_sync_pr_merge_status_records_closed_unmerged():
-    """closed-without-merge（merged=False）→ 回写 pr_merged=False + 推进 checked_at（停检）。"""
+    """closed-without-merge → 回写 pr_state=closed/pr_merged=False + 推进 checked_at（之后停检）。"""
     rid = await _make_succeeded_routine_with_pr()
     try:
         orch = RoutineOrchestrator()
@@ -1298,6 +1314,7 @@ async def test_sync_pr_merge_status_records_closed_unmerged():
         assert count == 0  # 非新检出 merged
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
+            assert r.pr_state == "closed"
             assert r.pr_merged is False
             assert r.pr_merged_checked_at is not None
     finally:
@@ -1305,7 +1322,7 @@ async def test_sync_pr_merge_status_records_closed_unmerged():
 
 
 async def test_sync_pr_merge_status_unknown_leaves_state_untouched():
-    """gh 未应答（merged=None, state=None）→ 不动 pr_merged/checked_at，保持 due 下 tick 重试。"""
+    """gh 未应答（merged=None, state=None）→ 不动 pr_state/pr_merged/checked_at，保持 due 下 tick 重试。"""
     rid = await _make_succeeded_routine_with_pr()
     try:
         orch = RoutineOrchestrator()
@@ -1317,6 +1334,7 @@ async def test_sync_pr_merge_status_unknown_leaves_state_untouched():
         assert count == 0
         async with db_session.AsyncSessionLocal() as db:
             r = await db.get(Routine, rid)
+            assert r.pr_state is None
             assert r.pr_merged is None
             assert r.pr_merged_checked_at is None  # 未应答 → 不推进节流
     finally:
@@ -1326,7 +1344,7 @@ async def test_sync_pr_merge_status_unknown_leaves_state_untouched():
 async def test_sync_pr_merge_status_throttle_skips_recently_checked():
     """窗口内（checked_at 距今 < interval）→ 不在 due 集 → 不调 gh。"""
     recent = datetime.now(UTC) - timedelta(seconds=10)
-    rid = await _make_succeeded_routine_with_pr(pr_merged=None, pr_merged_checked_at=recent)
+    rid = await _make_succeeded_routine_with_pr(pr_state="open", pr_merged_checked_at=recent)
     fetch_mock = AsyncMock()
     try:
         orch = RoutineOrchestrator()
@@ -1334,5 +1352,61 @@ async def test_sync_pr_merge_status_throttle_skips_recently_checked():
             count = await orch._sync_pr_merge_status()  # noqa: SLF001
         assert count == 0
         fetch_mock.assert_not_called()
+    finally:
+        await _cleanup(rid)
+
+
+async def _updated_at(rid: uuid.UUID) -> datetime:
+    async with db_session.AsyncSessionLocal() as db:
+        r = await db.get(Routine, rid)
+        return r.updated_at
+
+
+async def test_sync_pr_merge_status_no_state_change_keeps_updated_at():
+    """重确认 Open（状态未翻转）→ 仅推进 checked_at（Core update），**不动 updated_at**（修列表乱跳）。"""
+    rid = await _make_succeeded_routine_with_pr(pr_state="open", pr_merged=False)
+    try:
+        before = await _updated_at(rid)
+        # gh 仍报 OPEN（与 before 相同 → state_changed=False）。
+        orch = RoutineOrchestrator()
+        with (
+            patch(
+                "negentropy.engine.routine.pr_status.fetch_pr_merge_status",
+                new=AsyncMock(return_value=pr_status.PrMergeStatus(merged=False, state="OPEN")),
+            ),
+            patch.object(RoutineOrchestrator, "_publish_routine", new=AsyncMock()),
+        ):
+            # checked_at=None（种子默认）→ 该 routine 已在 due 集，无需压缩节流窗口。
+            await orch._sync_pr_merge_status()  # noqa: SLF001
+        after = await _updated_at(rid)
+        # 无状态翻转 → Core update 不带 updated_at → updated_at 不变（修列表乱跳）
+        assert after == before
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.pr_merged_checked_at is not None  # checked_at 仍正常推进（节流）
+    finally:
+        await _cleanup(rid)
+
+
+async def test_sync_pr_merge_status_state_change_advances_updated_at():
+    """状态翻转（open→merged）→ 显式带 updated_at → updated_at 推进（真实变更才重排）。"""
+    rid = await _make_succeeded_routine_with_pr(pr_state="open", pr_merged=False)
+    try:
+        before = await _updated_at(rid)
+        orch = RoutineOrchestrator()
+        with (
+            patch(
+                "negentropy.engine.routine.pr_status.fetch_pr_merge_status",
+                new=AsyncMock(return_value=pr_status.PrMergeStatus(merged=True, state="MERGED")),
+            ),
+            patch.object(RoutineOrchestrator, "_publish_routine", new=AsyncMock()),
+        ):
+            await orch._sync_pr_merge_status()  # noqa: SLF001
+        after = await _updated_at(rid)
+        assert after >= before
+        # merged 落库（顺带校验）
+        async with db_session.AsyncSessionLocal() as db:
+            r = await db.get(Routine, rid)
+            assert r.pr_state == "merged"
     finally:
         await _cleanup(rid)

--- a/apps/negentropy/tests/unit_tests/engine/test_pr_status.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pr_status.py
@@ -206,55 +206,88 @@ async def test_spawn_failure_returns_unknown(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# apply_pr_merge_result：三分支回写语义（鸭子类型 routine）
+# next_pr_state / compute_pr_write：纯决策（心跳 pass Core 写回据此推导）
+# ---------------------------------------------------------------------------
+
+
+def test_next_pr_state_normalizes_and_validates():
+    assert pr_status.next_pr_state(pr_status.PrMergeStatus(merged=True, state="MERGED")) == "merged"
+    assert pr_status.next_pr_state(pr_status.PrMergeStatus(merged=False, state="OPEN")) == "open"
+    assert pr_status.next_pr_state(pr_status.PrMergeStatus(merged=False, state="CLOSED")) == "closed"
+    # 未应答 / 非法 state → None（调用方不写，保持 due 重试）
+    assert pr_status.next_pr_state(pr_status.PrMergeStatus(merged=None, state=None)) is None
+    assert pr_status.next_pr_state(pr_status.PrMergeStatus(merged=None, state="WEIRD")) is None
+
+
+def test_compute_pr_write_detects_change_and_noop():
+    # gh 未应答 → (None, False) 不写
+    assert pr_status.compute_pr_write("open", pr_status.PrMergeStatus(merged=None, state=None)) == (None, False)
+    # 状态翻转（决定 updated_at 是否刷新 / 是否推 SSE）
+    assert pr_status.compute_pr_write("open", pr_status.PrMergeStatus(merged=True, state="MERGED")) == ("merged", True)
+    assert pr_status.compute_pr_write(None, pr_status.PrMergeStatus(merged=False, state="CLOSED")) == ("closed", True)
+    # 状态未变（重确认 open / merged）→ changed=False（不刷 updated_at）
+    assert pr_status.compute_pr_write("open", pr_status.PrMergeStatus(merged=False, state="OPEN")) == ("open", False)
+    assert pr_status.compute_pr_write("merged", pr_status.PrMergeStatus(merged=True, state="MERGED")) == (
+        "merged",
+        False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply_pr_merge_result：状态化回写（鸭子类型 routine，供手动端点 ORM 路径）
 # ---------------------------------------------------------------------------
 
 
 class _RoutineLike:
-    """最小鸭子类型：仅携带 pr_merged / pr_merged_checked_at 两个属性。"""
+    """最小鸭子类型：携带 pr_state / pr_merged / pr_merged_checked_at。"""
 
-    def __init__(self, *, pr_merged=None, checked_at=None) -> None:
+    def __init__(self, *, pr_state=None, pr_merged=None, checked_at=None) -> None:
+        self.pr_state = pr_state
         self.pr_merged = pr_merged
         self.pr_merged_checked_at = checked_at
 
 
-def test_apply_merged_true_sets_true_and_advances_checked_at():
+def test_apply_merged_writes_state_and_derives_flag():
     r = _RoutineLike()
-    now = "2026-06-30T00:00:00Z"
-    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=True, state="MERGED"), now)
+    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=True, state="MERGED"), "now")
     assert newly is True
-    assert r.pr_merged is True
-    assert r.pr_merged_checked_at == now
+    assert r.pr_state == "merged"
+    assert r.pr_merged is True  # 派生 = (pr_state == 'merged')
+    assert r.pr_merged_checked_at == "now"
 
 
-def test_apply_already_true_is_not_newly_detected():
-    r = _RoutineLike(pr_merged=True, checked_at="old")
-    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=True, state="MERGED"), "new")
-    assert newly is False  # 之前已是 True → 非新检出（不重复推 SSE）
-    assert r.pr_merged is True
+def test_apply_already_merged_not_newly_detected():
+    r = _RoutineLike(pr_state="merged", pr_merged=True)
+    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=True, state="MERGED"), "now")
+    assert newly is False  # 之前已 merged → 非新检出（不重复推 SSE）
+    assert r.pr_state == "merged"
 
 
-def test_apply_false_records_false_and_advances_checked_at():
-    """closed-without-merge：记 False 并推进 checked_at → 停检（退出 due 集）。"""
+def test_apply_closed_writes_state_and_false_flag():
+    """closed-without-merge：写 pr_state='closed' + 派生 pr_merged=False + 推进 checked_at。"""
     r = _RoutineLike()
     newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=False, state="CLOSED"), "now")
     assert newly is False
+    assert r.pr_state == "closed"
     assert r.pr_merged is False
     assert r.pr_merged_checked_at == "now"
 
 
-def test_apply_unknown_with_state_advances_checked_at_only():
-    """gh 应答但 merged 未定（如 OPEN 已被 False 分支覆盖；此处防御 state 非 None）→ 仅节流。"""
+def test_apply_open_writes_state_and_false_flag():
+    """open：写 pr_state='open' + pr_merged=False + 推进 checked_at（Open 仍留 due 复检）。"""
     r = _RoutineLike()
-    pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=None, state="OPEN"), "now")
-    assert r.pr_merged is None
+    pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=False, state="OPEN"), "now")
+    assert r.pr_state == "open"
+    assert r.pr_merged is False
     assert r.pr_merged_checked_at == "now"
 
 
-def test_apply_unknown_without_state_leaves_checked_at_untouched():
-    """gh 未应答 → 不动 checked_at，保持 due 下 tick 重试。"""
+def test_apply_unknown_no_op_keeps_due():
+    """gh 未应答（state=None）→ 不写任何字段，保持 due 下 tick 重试。"""
     r = _RoutineLike()
-    pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=None, state=None), "now")
+    newly = pr_status.apply_pr_merge_result(r, pr_status.PrMergeStatus(merged=None, state=None), "now")
+    assert newly is False
+    assert r.pr_state is None
     assert r.pr_merged is None
     assert r.pr_merged_checked_at is None
 


### PR DESCRIPTION
## 背景

承接已合并的 #1024 / #1025（PR Merge 状态回写）。复测发现两个问题：

1. **PR 状态不完整**：原实现只持久化 `pr_merged`（bool），gh 返回的 `state`（OPEN/CLOSED/MERGED）被**丢弃**——Open 与 Closed-without-merge 坍缩为同一个 `pr_merged=False`。后果：**Closed 的 PR 在抽屉仍显示「在 GitHub 合并 →」**（误导：已关闭未合并的 PR 不能合并），列表 / Full View 也无「Closed」标识。
2. **updated_at 反复跳变（严重）**：`TimestampMixin.updated_at` 带 ORM 级 `onupdate=func.now()`，而心跳每 tick 写 `pr_merged_checked_at` 触发它 → 这些 routine 在列表（按 `updated_at` 排序）里**持续乱跳**。

## 方案

### ① PR 状态三态持久化 + Closed 对等打标
- 新增 `pr_state`（open|closed|merged）权威列；`pr_merged` 保留为派生反规范化（= `pr_state=='merged'`），与既有 `best_score`/`last_score` 同范式，零侵入既有 merged 查询/UI。
- UI 三处对 Merged/Closed 对等打标（用户决策：Open 视为默认待处理、不打额外徽章；Closed 用 muted/灰 + X 图标，区别于 failed-红/merged-紫/succeeded-绿）：
  - **PR 抽屉**：merged→「已合并 ✓」；closed→「已关闭」（无合并链接、无同步按钮，保留「查看 PR」）；open→既有合并入口 + 同步按钮；
  - **Full View 头部 + 列表**：succeeded 徽章旁追加 Merged / Closed 徽章；LoopDiagram done 态追加「· PR 已关闭」。
- due-set 改用 `pr_state`：Open（可能后续合并）继续复检，**Merged/Closed 终态排除**（顺带修掉 Closed 每 5min 复检的浪费）。

### ② 修复 updated_at 反复跳变
- 写回用 Core `update()`，并**显式 `updated_at = Routine.updated_at` 自引用保形**（实证：Core update 仍触发 onupdate；仅自引用方能保形——见下「实证」）。仅当 `pr_state` 实际翻转时才置 `updated_at=now` → 纯节流推进不再刷新 updated_at，列表只在 PR 真正合并/关闭时才重排。

## 验证（实证驱动，吸取 #1025 字段名教训）
- ✅ 后端单测 28 例：`next_pr_state`/`compute_pr_write` 纯决策 + 状态化 `apply_pr_merge_result` 各分支；
- ✅ 后端集成：merged/closed/unknown/throttle + **Closed 终态不复检回归** + **updated_at 无翻转不变 / 翻转推进回归**；
- ✅ **updated_at 机制实证探针**（一次性，已删）：Core update（plain）→ 刷新 ❌；Core update 自引用 `Routine.updated_at` → 保形 ✅；raw text → 保形 ✅。据此选定自引用方案；
- ✅ 真实 gh E2E：已合并 PR → `state=MERGED, merged=True`（CLOSED 路径本仓库无对应 PR，由单测 + 集成用真实 gh 输出形状覆盖）；
- ✅ 前端：typecheck:test 0 error、ESLint 0 warning、routine 套件 43 测试全过；Alembic 单一 head `0080`。

## 部署提醒
后端跑在 Docker，合入后需 `./dev restart backend` 生效；migration `0080` 由 conftest/部署自动 upgrade。

🤖 Generated with [Claude Code](https://github.com/claude)