### PR TITLE
feat(Routine): 列表改回纯翻页模式（10/页、updated_at 倒序、显示全部）

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -21,11 +21,9 @@ interface RoutineTableProps {
   onCleanupWorktree?: (r: RoutineDTO) => void;
   /** 正在清理的 routine id（行内按钮 busy/disabled + spinner，防二次点击；null 表示无在途）。 */
   cleanupBusyId?: string | null;
-  /** 无限滚动每页条数：每页首行挂 data-infinite-page 锚点，供翻页定位与滚动联动当前页。 */
-  pageSize?: number;
 }
 
-export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart, onTerminate, onCleanupWorktree, cleanupBusyId, pageSize }: RoutineTableProps) {
+export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestart, onTerminate, onCleanupWorktree, cleanupBusyId }: RoutineTableProps) {
   if (loading && routines.length === 0) {
     return (
       <div className="space-y-2">
@@ -59,10 +57,9 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
           </tr>
         </thead>
         <tbody>
-          {routines.map((r, i) => (
+          {routines.map((r) => (
             <tr
               key={r.id}
-              data-infinite-page={pageSize && i % pageSize === 0 ? Math.floor(i / pageSize) + 1 : undefined}
               onClick={() => onSelect(r)}
               className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
             >

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -8,7 +8,6 @@ import { ErrorBanner } from "@/components/ui/ErrorState";
 import { InterfaceNav } from "@/components/ui/InterfaceNav";
 import { Pagination } from "@/components/ui/Pagination";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
-import { useInfiniteScrollSentinel, useScrollPageSync } from "@/hooks/useInfiniteScrollSentinel";
 import {
   cleanupWorktree,
   controlRoutine,
@@ -45,11 +44,6 @@ function RoutinePageInner() {
   // 行内 Clean Up 在途 routine id（null=无）；按钮 busy/disabled + spinner，防二次点击。
   const [cleanupBusyId, setCleanupBusyId] = useState<string | null>(null);
 
-  // 无限滚动 + 翻页：滚动容器 ref（哨兵 / 滚动联动 observer 的 root）、程序化滚动闸门、待跳页号。
-  const scrollRootRef = useRef<HTMLDivElement | null>(null);
-  const programmaticScrollRef = useRef(false);
-  const pendingPageRef = useRef<number | null>(null);
-
   // SSE ghost-reopen 守卫：镜像 selected 供异步 SSE 回调读取「抽屉是否仍打开」，
   // 关闭时在 closeDetail 内同步清空，杜绝 stale-id 事件在 setSelected 提交前重开抽屉（§2）。
   const selectedRef = useRef<RoutineDTO | null>(selected);
@@ -70,54 +64,11 @@ function RoutinePageInner() {
     total,
     totalPages,
     goToPage,
-    loadMore,
-    hasMore,
-    loadingMore,
-    pageSize,
   } = useRoutineLive(filters);
 
-  // 时钟仅在有运行中任务时滴答（运行中任务 updated_at 最新、恒在已加载前缀内）。
+  // 时钟仅在有运行中任务时滴答（列表行用绝对时间、不消费时钟；此值仅控制 ClockProvider 心跳，
+  // 切片后按「当前页是否含运行中任务」判定，保守且无可见副作用）。
   const clockActive = useMemo(() => routines.some((r) => r.status === "running"), [routines]);
-
-  // 无限滚动哨兵：滚到底（提前 200px）→ 追加下一游标页。root = 页面级滚动容器。
-  const { sentinelRef } = useInfiniteScrollSentinel({
-    onReach: loadMore,
-    enabled: hasMore && !loadingMore && !loading,
-    root: scrollRootRef,
-  });
-
-  // 滚动联动当前页高亮：观测每页首行的 data-infinite-page 锚点，取最靠上可见页。
-  useScrollPageSync({
-    enabled: true,
-    onPageChange: goToPage,
-    root: scrollRootRef,
-    rescanKey: routines.length,
-    programmaticRef: programmaticScrollRef,
-  });
-
-  // 点页码跳页：先经 hook 确保该页已加载（游标顺序补齐 / 已加载即时），再滚动到该页锚点。
-  const handleGoToPage = useCallback(
-    (target: number) => {
-      pendingPageRef.current = target;
-      programmaticScrollRef.current = true; // 抑制 observer 回写，防跳页与联动互相递归
-      goToPage(target);
-    },
-    [goToPage],
-  );
-
-  // 待跳页锚点出现即平滑滚动（cursor 顺序补齐时，锚点随 routines 增长后再现 → effect 重跑命中）。
-  useEffect(() => {
-    const target = pendingPageRef.current;
-    if (target == null) return;
-    const anchor = scrollRootRef.current?.querySelector<HTMLElement>(`[data-infinite-page="${target}"]`);
-    if (!anchor) return; // 该页尚未渲染，待 routines 增长后重跑
-    anchor.scrollIntoView({ behavior: "smooth", block: "start" });
-    pendingPageRef.current = null;
-    const t = window.setTimeout(() => {
-      programmaticScrollRef.current = false;
-    }, 600);
-    return () => window.clearTimeout(t);
-  }, [currentPage, routines.length]);
 
   // 刷新当前选中详情（含迭代）。
   const refreshSelected = useCallback(async (id: string) => {
@@ -286,7 +237,7 @@ function RoutinePageInner() {
   return (
     <div className="flex h-full flex-col bg-muted">
       <InterfaceNav title="Routine" />
-      <div ref={scrollRootRef} className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto">
         <ClockProvider active={clockActive}>
           <div className="space-y-5 px-6 py-6">
             <RoutineHeader connected={connected} onRefresh={refresh} loading={loading} onCreate={() => setCreateOpen(true)} onFromPreset={() => router.push("/interface/routine/templates")} kpis={kpis} />
@@ -309,23 +260,18 @@ function RoutinePageInner() {
               onTerminate={requestTerminate}
               onCleanupWorktree={handleCleanupWorktree}
               cleanupBusyId={cleanupBusyId}
-              pageSize={pageSize}
             />
 
-            {/* 无限滚动哨兵：进入视口即追加下一页（hasMore 为否时 hook 自动停观察）。 */}
-            <div ref={sentinelRef} aria-hidden className="h-px w-full" />
-
-            {/* 居中翻页控件（页总数 + 控件组居中成组），与无限滚动并存；sticky 底栏始终可达。 */}
+            {/* 居中翻页控件（页总数 + 控件组居中成组）；sticky 底栏始终可达。 */}
             {routines.length > 0 && (
               <div className="sticky bottom-0 -mx-6 border-t border-border bg-muted/95 px-6 py-2.5 backdrop-blur supports-[backdrop-filter]:bg-muted/80">
                 <Pagination
                   page={currentPage}
                   totalPages={totalPages}
-                  onPageChange={handleGoToPage}
+                  onPageChange={goToPage}
                   total={total ?? undefined}
                   itemLabel="routine"
                   disabled={loading}
-                  loadingMore={loadingMore}
                 />
               </div>
             )}

--- a/apps/negentropy-ui/features/routine/api.ts
+++ b/apps/negentropy-ui/features/routine/api.ts
@@ -47,7 +47,7 @@ export async function fetchKpis(): Promise<RoutineKpis> {
 
 export async function fetchRoutines(
   filters: Partial<RoutineFilters> = {},
-  opts: { limit?: number; cursor?: string | null; signal?: AbortSignal } = {},
+  opts: { limit?: number; cursor?: string | null; offset?: number; signal?: AbortSignal } = {},
 ): Promise<RoutineListResponse> {
   const sp = new URLSearchParams();
   if (filters.status) sp.set("status", filters.status);
@@ -56,6 +56,7 @@ export async function fetchRoutines(
   if (filters.source_task_key) sp.set("source_task_key", filters.source_task_key);
   if (opts.limit) sp.set("limit", String(opts.limit));
   if (opts.cursor) sp.set("cursor", opts.cursor);
+  if (opts.offset != null) sp.set("offset", String(opts.offset));
   const q = sp.toString();
   return jsonFetch(`${q ? `?${q}` : ""}`, opts.signal ? { signal: opts.signal } : undefined);
 }

--- a/apps/negentropy-ui/features/routine/hooks/useRoutineData.ts
+++ b/apps/negentropy-ui/features/routine/hooks/useRoutineData.ts
@@ -7,7 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { useInfiniteList, type CursorFetcher } from "@/hooks/useInfiniteList";
+import { useInfiniteList, type OffsetFetcher } from "@/hooks/useInfiniteList";
 
 import { fetchKpis, fetchRoutines } from "../api";
 import type { RoutineDTO, RoutineFilters, RoutineKpis } from "../types";
@@ -18,20 +18,22 @@ export const ROUTINE_PAGE_SIZE = 10;
 /**
  * Routine 列表 + KPI 数据 hook。
  *
- * 列表改由 [[useInfiniteList]] 游标分页驱动（消除此前「仅取最近 50 条」上限），
- * 支持页码跳页 + 无限滚动；KPI 独立拉取（统计全量，不受列表 limit 影响）。
- * ``refresh()`` 供控制动作 / SSE 去抖刷新：原地重载已加载范围 + 重拉 KPI，不闪空。
+ * 列表由 [[useInfiniteList]] **偏移分页**驱动（``offset`` 模式）：每页 ``ROUTINE_PAGE_SIZE``
+ * 条、按后端 ``updated_at`` 倒序，``total`` 为无上限全量计数 → 可翻阅所有 Routine（无 50 条上限）。
+ * 该页以「纯翻页」呈现：``routines`` 仅暴露**当前页切片**（``items[(page-1)*size, page*size)``），
+ * 不再做无限滚动追加；KPI 独立拉取（统计全量，不受列表 limit 影响）。
+ * ``refresh()`` 供控制动作 / SSE 去抖刷新：原地重载当前页 + 重拉 KPI，不闪空。
  */
 export function useRoutineData(filters: Partial<RoutineFilters>) {
   const [kpis, setKpis] = useState<RoutineKpis | null>(null);
   const [kpiError, setKpiError] = useState<string | null>(null);
 
-  const fetcher = useMemo<CursorFetcher<RoutineDTO, Partial<RoutineFilters>>>(
+  const fetcher = useMemo<OffsetFetcher<RoutineDTO, Partial<RoutineFilters>>>(
     () => ({
-      kind: "cursor",
-      fetchPage: async ({ cursor, limit, filters: f, signal }) => {
-        const r = await fetchRoutines(f ?? {}, { limit, cursor: cursor as string | null, signal });
-        return { items: r.items, nextCursor: r.next_cursor, hasMore: r.has_more, total: r.total ?? null };
+      kind: "offset",
+      fetchRange: async ({ offset, limit, filters: f, signal }) => {
+        const r = await fetchRoutines(f ?? {}, { limit, offset, signal });
+        return { items: r.items, total: r.total ?? r.items.length };
       },
     }),
     [],
@@ -62,13 +64,17 @@ export function useRoutineData(filters: Partial<RoutineFilters>) {
     void loadKpis();
   }, [listRefresh, loadKpis]);
 
+  // 纯翻页：仅暴露当前页切片（连续前缀缓冲由 useInfiniteList 内部维护）。
+  const pageStart = (list.currentPage - 1) * ROUTINE_PAGE_SIZE;
+  const routines = list.items.slice(pageStart, pageStart + ROUTINE_PAGE_SIZE);
+
   return {
-    routines: list.items,
+    routines,
     kpis,
     loading: list.loading,
     error: list.error ?? kpiError,
     refresh,
-    // 分页控件 + 无限滚动控制
+    // 翻页控制（loadMore/hasMore/loadingMore 透传保留，纯翻页 UI 不再使用，最小化上层改动）
     currentPage: list.currentPage,
     total: list.total,
     totalPages: list.totalPages,

--- a/apps/negentropy-ui/tests/unit/features/routine/routine-api.test.ts
+++ b/apps/negentropy-ui/tests/unit/features/routine/routine-api.test.ts
@@ -67,6 +67,22 @@ describe("routine api · 读取端点", () => {
     expect(sp.get("q")).toBe("demo");
   });
 
+  it("fetchRoutines 透传 limit + offset 为查询参数", async () => {
+    const spy = mockFetch(() => jsonResponse({ items: [], next_cursor: null }));
+    await fetchRoutines({}, { limit: 10, offset: 20 });
+    const sp = new URL(lastCall(spy).url, "http://x").searchParams;
+    expect(sp.get("limit")).toBe("10");
+    expect(sp.get("offset")).toBe("20");
+  });
+
+  it("fetchRoutines 未给 offset 时不带 offset 参数", async () => {
+    const spy = mockFetch(() => jsonResponse({ items: [], next_cursor: null }));
+    await fetchRoutines({ status: "running" }, { limit: 10 });
+    const sp = new URL(lastCall(spy).url, "http://x").searchParams;
+    expect(sp.get("offset")).toBeNull();
+    expect(sp.get("limit")).toBe("10");
+  });
+
   it("fetchRoutineDetail 编码 id 并带上 recent", async () => {
     const spy = mockFetch(() => jsonResponse({ id: "a/b" }));
     await fetchRoutineDetail("a/b", 5);

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineData.test.tsx
@@ -1,7 +1,7 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useRoutineData } from "@/features/routine/hooks/useRoutineData";
+import { useRoutineData, ROUTINE_PAGE_SIZE } from "@/features/routine/hooks/useRoutineData";
 import * as api from "@/features/routine/api";
 import type { RoutineDTO, RoutineKpis } from "@/features/routine";
 
@@ -75,7 +75,7 @@ describe("useRoutineData", () => {
     vi.restoreAllMocks();
   });
 
-  it("挂载后游标拉取列表 + 独立拉取 KPI 并落地 state", async () => {
+  it("挂载后偏移拉取列表首页 + 独立拉取 KPI 并落地 state", async () => {
     const listSpy = vi
       .spyOn(api, "fetchRoutines")
       .mockResolvedValue({ items: [makeRoutine("r1")], next_cursor: null, has_more: false, total: 1 });
@@ -89,10 +89,11 @@ describe("useRoutineData", () => {
     expect(result.current.kpis).toMatchObject({ total: 2 });
     expect(result.current.error).toBeNull();
     expect(result.current.total).toBe(1);
-    // 游标分页：首页 cursor=null + 透传 limit；filters 作为第二实参的 filters 字段。
+    expect(result.current.totalPages).toBe(1);
+    // 偏移分页：首页 offset=0 + 透传 limit；filters 作为第二实参的 filters 字段。
     expect(listSpy).toHaveBeenCalledWith(
       { status: "running" },
-      expect.objectContaining({ cursor: null }),
+      expect.objectContaining({ offset: 0, limit: ROUTINE_PAGE_SIZE }),
     );
     expect(kpiSpy).toHaveBeenCalledTimes(1);
   });
@@ -111,7 +112,7 @@ describe("useRoutineData", () => {
 
     rerender({ q: "b" });
     await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
-    expect(listSpy).toHaveBeenLastCalledWith({ q: "b" }, expect.objectContaining({ cursor: null }));
+    expect(listSpy).toHaveBeenLastCalledWith({ q: "b" }, expect.objectContaining({ offset: 0 }));
   });
 
   it("拉取失败时写入 error", async () => {
@@ -137,5 +138,28 @@ describe("useRoutineData", () => {
     result.current.refresh();
     await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(kpiSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it("goToPage 以 offset 翻页并暴露当前页切片", async () => {
+    const all = Array.from({ length: 15 }, (_, i) => makeRoutine(`r${i}`));
+    const listSpy = vi.spyOn(api, "fetchRoutines").mockImplementation(async (_f, opts) => ({
+      items: all.slice(opts?.offset ?? 0, (opts?.offset ?? 0) + (opts?.limit ?? ROUTINE_PAGE_SIZE)),
+      next_cursor: null,
+      has_more: false,
+      total: all.length,
+    }));
+    vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
+
+    const { result } = renderHook(() => useRoutineData({}));
+    await waitFor(() => expect(result.current.routines).toHaveLength(ROUTINE_PAGE_SIZE));
+    expect(result.current.totalPages).toBe(2); // ceil(15/10)
+    expect(result.current.routines.map((r) => r.id)).toEqual([
+      "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9",
+    ]);
+
+    act(() => result.current.goToPage(2));
+    await waitFor(() => expect(result.current.routines.map((r) => r.id)).toEqual(["r10", "r11", "r12", "r13", "r14"]));
+    // 第 2 页以 offset=10 拉取剩余 5 条。
+    expect(listSpy).toHaveBeenLastCalledWith({}, expect.objectContaining({ offset: 10, limit: ROUTINE_PAGE_SIZE }));
   });
 });

--- a/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/useRoutineLive.test.tsx
@@ -136,6 +136,7 @@ describe("useRoutineLive", () => {
       items: [makeRoutine("r1")],
       next_cursor: null,
       has_more: false,
+      total: 1,
     });
     vi.spyOn(api, "fetchKpis").mockResolvedValue(KPIS);
   });

--- a/apps/negentropy/src/negentropy/interface/routine_api.py
+++ b/apps/negentropy/src/negentropy/interface/routine_api.py
@@ -484,11 +484,15 @@ async def list_routines(
         None, description="按 config.source_task_key 过滤（如 pdf_fidelity_patrol 派生的巡检 Routine）"
     ),
     limit: int = Query(50, ge=1, le=200),
-    cursor: str | None = Query(None, description="上一页末尾 updated_at ISO 串"),
+    cursor: str | None = Query(None, description="上一页末尾 updated_at ISO 串（与 offset 互斥）"),
+    offset: int | None = Query(None, ge=0, description="偏移分页起点（与 cursor 互斥；翻页模式）"),
 ) -> dict[str, Any]:
-    """路由清单：多维筛选 + 基于 updated_at 的游标分页。"""
+    """路由清单：多维筛选 + 基于 ``(updated_at, id)`` 的分页（cursor 游标 / offset 偏移二选一）。"""
+    if cursor and offset is not None:
+        raise HTTPException(status_code=400, detail="cursor and offset are mutually exclusive")
+    use_offset = offset is not None
     async with db_session.AsyncSessionLocal() as db:
-        # 收集筛选条件（不含 cursor）：行查询与 total 计数共用，避免重复逻辑。
+        # 收集筛选条件（不含分页约束）：行查询与 total 计数共用，避免重复逻辑。
         conditions = []
         if status:
             conditions.append(Routine.status == status)
@@ -502,27 +506,38 @@ async def list_routines(
         if source_task_key:
             conditions.append(Routine.config.op("->>")("source_task_key") == source_task_key)
 
+        # 稳定排序 (updated_at DESC, id DESC)：updated_at 有 onupdate、Routine 又是高频变更列表，
+        # id 兜底消除跨页重复/跳号（兼修 cursor 模式 tie-skip）。
         stmt = select(Routine)
         for cond in conditions:
             stmt = stmt.where(cond)
-        if cursor:
+        if not use_offset and cursor:
             try:
                 cursor_dt = datetime.fromisoformat(cursor)
             except ValueError:
                 raise HTTPException(status_code=400, detail="invalid cursor") from None
             stmt = stmt.where(Routine.updated_at < cursor_dt)
-        stmt = stmt.order_by(Routine.updated_at.desc()).limit(limit + 1)
+        stmt = stmt.order_by(Routine.updated_at.desc(), Routine.id.desc())
+        if use_offset:
+            stmt = stmt.offset(offset).limit(limit)
+        else:
+            stmt = stmt.limit(limit + 1)
         rows = (await db.execute(stmt)).scalars().all()
 
-        # total：当前筛选下的全量计数（不含 cursor 分页约束），供前端 totalPages 与「共 N 条」。
+        # total：当前筛选下的全量计数（不含分页约束），供前端 totalPages 与「共 N 条」。
         count_stmt = select(func.count()).select_from(Routine)
         for cond in conditions:
             count_stmt = count_stmt.where(cond)
         total = int((await db.execute(count_stmt)).scalar_one())
 
-    has_more = len(rows) > limit
-    rows = rows[:limit]
-    next_cursor = rows[-1].updated_at.isoformat() if has_more and rows else None
+    if use_offset:
+        # offset 模式：恰好取一页（无 limit+1 探测），has_more 由 total 推导；不产 cursor。
+        has_more = (offset + limit) < total
+        next_cursor = None
+    else:
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        next_cursor = rows[-1].updated_at.isoformat() if has_more and rows else None
     return {
         "items": [_serialize_routine(r) for r in rows],
         "next_cursor": next_cursor,

--- a/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
+++ b/apps/negentropy/tests/integration_tests/interface/test_routine_api.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import subprocess
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -156,6 +156,75 @@ async def test_full_crud_and_control_lifecycle(git_repo):
             assert (await c.get(f"/routines/{rid}")).status_code == 404
     finally:
         await _cleanup("itest_api_")
+
+
+async def test_list_offset_pagination_and_cursor_compat():
+    """offset 分页：翻页三段不重叠/连续、total 无上限、has_more/next_cursor 正确；cursor 路径兼容；二者同传 400。
+
+    历史脉络：#1023 前前端「客户端拉全量」受后端默认 limit=50 限制只能见最近 50 条；本次为
+    「纯翻页」新增 offset 随机访问，并以 (updated_at, id) 稳定排序消除跨页漂移。
+    """
+    app = _app()
+    prefix = f"itest_off_{uuid.uuid4().hex[:8]}"
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    try:
+        # 直接入库造 25 条（不同 updated_at、非模板），避免 25 次 POST；前缀唯一以相对化 total。
+        async with db_session.AsyncSessionLocal() as db:
+            for i in range(25):
+                db.add(
+                    Routine(
+                        key=f"{prefix}_{i:02d}",
+                        title=f"{prefix} {i}",
+                        goal="g",
+                        acceptance_criteria="ac",
+                        status="pending",
+                        is_template=False,
+                        updated_at=base + timedelta(minutes=i),
+                    )
+                )
+            await db.commit()
+
+        async with _client(app) as c:
+            common = {"q": prefix, "is_template": "false"}
+            # offset 分页：每页 10，共 3 页（10 / 10 / 5）
+            p1 = (await c.get("/routines", params={**common, "limit": 10, "offset": 0})).json()
+            assert p1["total"] == 25  # 无上限全量计数（不受 limit 影响）
+            assert p1["has_more"] is True
+            assert p1["next_cursor"] is None  # offset 模式不产 cursor
+            assert len(p1["items"]) == 10
+
+            p2 = (await c.get("/routines", params={**common, "limit": 10, "offset": 10})).json()
+            assert len(p2["items"]) == 10
+            assert p2["has_more"] is True
+
+            p3 = (await c.get("/routines", params={**common, "limit": 10, "offset": 20})).json()
+            assert len(p3["items"]) == 5
+            assert p3["has_more"] is False
+
+            # 三页互不重叠、合并去重为 25；updated_at 倒序 → 第 1 页恰为最新 10 条（key 15..24）。
+            all_ids = [it["id"] for it in p1["items"] + p2["items"] + p3["items"]]
+            assert len(set(all_ids)) == 25
+            assert {it["key"] for it in p1["items"]} == {f"{prefix}_{i:02d}" for i in range(15, 25)}
+
+            # offset 越界 → 空页，total 不变
+            p4 = (await c.get("/routines", params={"q": prefix, "limit": 10, "offset": 999})).json()
+            assert p4["items"] == []
+            assert p4["has_more"] is False
+            assert p4["total"] == 25
+
+            # cursor 路径（无 offset）仍兼容：has_more 时返回 next_cursor（ISO）
+            bc = (await c.get("/routines", params={"q": prefix, "limit": 10})).json()
+            assert len(bc["items"]) == 10
+            assert bc["has_more"] is True
+            assert bc["next_cursor"] is not None
+
+            # cursor + offset 同传 → 400 互斥
+            bad = await c.get("/routines", params={"q": prefix, "cursor": bc["next_cursor"], "offset": 0})
+            assert bad.status_code == 400
+    finally:
+        async with db_session.AsyncSessionLocal() as db:
+            await db.execute(delete(Routine).where(Routine.key.like(f"{prefix}%")))
+            await db.commit()
 
 
 async def test_iteration_approve_reject():


### PR DESCRIPTION
## 背景

Routine 页列表在 #1023 之后是「服务端游标 + 无限滚动 + 居中翻页控件」的混合形态。本 PR 将其**改回纯翻页模式**：每页 10 条、按 `updated_at` 倒序，并**消除「仅显示 50 条」上限、可翻阅到所有 Routine**。

历史脉络：#1023 之前是「客户端一次拉全量 + 本地切片分页」，但后端 `GET /routines` 默认 `limit=50`，导致前端实际只能看到最近 50 条——即「仅显示 50 个」的由来。#1023 用游标分页消除了该上限，但同时引入了无限滚动 UX。本 PR 保留「无上限、显示全部」的成果，仅把 UX 从滚动改回翻页。

## 改动

### 前端
- `useRoutineData`：fetcher 由 `cursor`（无限滚动）切到 `offset` 分页，`routines` 仅暴露**当前页切片**（`items[(page-1)*10, page*10)`）。复用全站统一 `useInfiniteList`——既不手写分页、也不改共享 hook，避免重新引入 #1023 收敛掉的碎片化。
- `page.tsx`：移除滚动哨兵 `useInfiniteScrollSentinel` 与滚动联动 `useScrollPageSync`、相关 ref 与 scroll 效果、哨兵 div；居中 `<Pagination>` 改 `onPageChange={goToPage}`，去掉 `loadingMore`。
- `RoutineTable`：去掉 `pageSize` prop 与 `data-infinite-page` 行锚点。
- `fetchRoutines`：opts 增 `offset` 透传（`cursor` 保留向后兼容；`SchedulerTaskDetailDrawer` 不传 opts，不受影响）。

### 后端 `GET /routines`
- 新增 `offset` 参数，与 `cursor` 互斥（同时给出 → 400）。
- offset 分支用 `.offset().limit()`（不用 `limit+1`），`has_more=(offset+limit)<total`、`next_cursor=None`；`total` 维持无上限 `COUNT(*)`。
- cursor 与 offset 两路 `order_by` 统一为 `(updated_at DESC, id DESC)`：消除 offset 跨页漂移，顺带修掉 cursor 模式既有的 tie-skip。

## 设计权衡（已评估并接受）
- **为何不改共享 `useInfiniteList` hook**：新增「单页替换」模式会波及全站 13 个消费者、且违背其「连续前缀缓冲」不变量；手写分页会重新引入 #1023 收敛掉的「13 处各自为政」碎片化。故仅 Routine 侧切 offset + 当前页切片，复用 hook 已固化的竞态保护（reqId + AbortController）/ refresh / goToPage。
- **翻页闪烁**：因 `routines` 为当前页切片，前向跳页时切片自然为空 → 原有 `loading && routines.length===0` 骨架门禁即正确触发；原地 SSE 刷新时切片非空则保持当前行（不闪空），既有门禁无需改动。
- **不加 `updated_at` 索引**：当前 Routine 体量下 `ORDER BY updated_at DESC OFFSET m LIMIT 10` 无性能问题；加索引需 Alembic 迁移（本仓存在 alembic 版本漂移风险）。列为后续可选优化。
- `clockActive` 不变：列表行用绝对时间、不消费 `ClockProvider`（`ElapsedClock` 仅用于详情/抽屉的 Timeline/LoopDiagram），切片对列表可见行为无影响。

## 验证
- 前端：912 单测全绿 + `tsc` typecheck + `eslint`（0 warning）+ `next build`（`/interface/routine` 编译通过）。
- 后端：`test_routine_api.py` 13 集成测试全绿（新增 offset 三页不重叠/越界/cursor 兼容/同传 400 用例）。
- 浏览器实操（建议人工复核）：10/页、Updated 倒序、翻页控件按 `total` 显示全部页（>50 条 → >5 页）、滚到底不再追加、Network 可见 `limit=10&offset=<n>`、SSE 当前页原地刷新。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
