### PR TITLE
feat(Routine): PR 抽屉/Full View/列表/闭环图补显「Open」徽章，与 Merged/Closed 对等

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { ArrowLeft, GitMerge, RotateCcw, X } from "lucide-react";
+import { ArrowLeft, GitMerge, GitPullRequest, RotateCcw, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/Button";
@@ -162,6 +162,12 @@ export default function RoutineRunPage() {
                     <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-xs font-semibold text-text-secondary">
                       <X className="h-3.5 w-3.5" aria-hidden />
                       Closed
+                    </span>
+                  )}
+                  {routine?.status === "succeeded" && routine.pr_url && routine.pr_state === "open" && (
+                    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-sky-500/10 px-2.5 py-0.5 text-xs font-semibold text-sky-700 dark:text-sky-300">
+                      <GitPullRequest className="h-3.5 w-3.5" aria-hidden />
+                      Open
                     </span>
                   )}
                   {routine?.current_phase && routine.status === "running" && (

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineLoopDiagram.tsx
@@ -68,7 +68,9 @@ export function RoutineLoopDiagram({
               ? " · PR 已合并"
               : routine.pr_url && routine.pr_state === "closed"
                 ? " · PR 已关闭"
-                : ""}
+                : routine.pr_url && routine.pr_state === "open"
+                  ? " · PR 开启中"
+                  : ""}
           </span>
         ) : snapshot.mode === "paused" ? (
           <span className="text-amber-600 dark:text-amber-400">已暂停 · 恢复后继续迭代</span>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutinePrCard.tsx
@@ -64,6 +64,12 @@ export function RoutinePrCard({
         </span>
       ) : (
         <>
+          {prState === "open" && (
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-sky-300 bg-sky-500/10 px-2 py-1 text-xs font-semibold text-sky-700 dark:border-sky-700 dark:text-sky-300">
+              <GitPullRequest className="h-3.5 w-3.5" aria-hidden />
+              Open
+            </span>
+          )}
           <a
             href={prUrl}
             target="_blank"

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { ExternalLink, GitMerge, Loader2, OctagonX, RotateCcw, Trash2, X } from "lucide-react";
+import { ExternalLink, GitMerge, GitPullRequest, Loader2, OctagonX, RotateCcw, Trash2, X } from "lucide-react";
 
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
 
 import { canCancel, canCleanupWorktree, canRestart } from "./routine-controls";
-import { closedBadgeClass, mergedBadgeClass, routineStatusClass, scoreColorClass } from "./status-style";
+import {
+  closedBadgeClass,
+  mergedBadgeClass,
+  openBadgeClass,
+  routineStatusClass,
+  scoreColorClass,
+} from "./status-style";
 
 interface RoutineTableProps {
   routines: RoutineDTO[];
@@ -91,6 +97,12 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                     <span className={closedBadgeClass}>
                       <X className="h-3 w-3" aria-hidden />
                       Closed
+                    </span>
+                  )}
+                  {r.pr_state === "open" && (
+                    <span className={openBadgeClass}>
+                      <GitPullRequest className="h-3 w-3" aria-hidden />
+                      Open
                     </span>
                   )}
                 </div>

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -123,6 +123,10 @@ export const mergedBadgeClass =
 export const closedBadgeClass =
   "inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-micro font-semibold text-text-secondary";
 
+/** 「PR 开启中（待合并）」徽章配色（sky/天蓝 = 活跃待处理；区别于 succeeded-绿/merged-紫/closed-灰/failed-红）。 */
+export const openBadgeClass =
+  "inline-flex items-center gap-1 rounded-full bg-sky-500/10 px-2 py-0.5 text-micro font-semibold text-sky-700 dark:text-sky-300";
+
 /** 迭代状态 → 状态点配色。 */
 export function iterationDotClass(status: IterationStatus): string {
   switch (status) {

--- a/apps/negentropy-ui/tests/unit/features/routine/RoutinePrCard.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/RoutinePrCard.test.tsx
@@ -32,11 +32,18 @@ describe("RoutinePrCard", () => {
     expect(screen.getByText("查看 PR")).toBeInTheDocument();
   });
 
-  it("prState=open（显式）按待合并渲染（合并入口 + 同步按钮）", () => {
+  it("prState=open（显式）渲染「Open」徽章 + 合并入口 + 同步按钮", () => {
     render(<RoutinePrCard prUrl={PR_URL} merged={false} prState="open" onSync={vi.fn()} />);
+    expect(screen.getByText("Open")).toBeInTheDocument();
     expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();
     expect(screen.getByText("同步状态")).toBeInTheDocument();
     expect(screen.queryByText("已关闭")).not.toBeInTheDocument();
+  });
+
+  it("prState=null（未知/旧记录）不渲染「Open」徽章（仅合并入口 + 同步）", () => {
+    render(<RoutinePrCard prUrl={PR_URL} merged={false} prState={null} onSync={vi.fn()} />);
+    expect(screen.queryByText("Open")).not.toBeInTheDocument();
+    expect(screen.getByText("在 GitHub 合并 →")).toBeInTheDocument();
   });
 
   it("未合并显示「在 GitHub 合并」外链 + 「同步状态」按钮", () => {


### PR DESCRIPTION
## 背景

承接已合并的 #1026（PR 状态三态持久化 + Merged/Closed 对等打标）。#1026 的 squash 合并早于「Open 徽章」提交，故 Open 状态当时未一并合入。本 PR 补齐：在所有状态面对等显式标记 **Open**（此前 Open 被视为默认待处理、不打徽章）。

## 改动（纯前端，6 文件 +42/-5）

后端无需改动（`pr_state='open'` 已由 #1026 持久化）。Open 徽章 = sky/天蓝 + `GitPullRequest` 图标，区别于 succeeded-绿 / merged-紫 / closed-灰 / failed-红。

| 位置 | Open 处理 |
|---|---|
| Routine 列表 | succeeded 徽章旁追加 sky「Open」徽章 |
| Full View 头部 | 同上 sky「Open」徽章 |
| 闭环图 done 态 | 追加「· PR 开启中」 |
| PR 抽屉卡片 | open 分支增「Open」徽章（保留「在 GitHub 合并」+「同步状态」入口） |

**准确性**：Open 徽章仅在 `pr_state === 'open'` 时显示；`null`（未知/未检测）不显示，避免对未巡检的 PR 误标 Open。

## 基线与冲突

基于最新 `origin/feature/1.x.x`（含 #1026/#1027/#1028）。与 #1028（列表改回纯翻页 + updated_at 倒序）同触 `RoutineTable.tsx`，**cherry-pick 时 git 自动合并无冲突**——#1028 的翻页布局与本 PR 的状态徽章正交共存。

## 验证
- typecheck:test 0 error、ESLint 0 warning、routine 套件 47 测试全过（含 #1028 新增的翻页测试）；
- 无冲突标记，diff 仅 6 个 Open 徽章文件。

🤖 Generated with [Claude Code](https://github.com/claude)