### PR TITLE
fix(perceives): 封面页冗余 orphan 图抑制（page-dominant 同页碎片去重）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/image_ref_normalizer.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/image_ref_normalizer.py
@@ -120,7 +120,10 @@ def _append_orphan_images(
     orphans = [
         img
         for img in images
-        if img.filename and img.filename not in referenced_basenames
+        if img.filename
+        and img.filename not in referenced_basenames
+        and img.filename
+        not in _redundant_orphan_basenames(markdown, images, referenced_basenames)
     ]
     if not orphans:
         return markdown
@@ -131,6 +134,82 @@ def _append_orphan_images(
         appended_lines.append("")
         appended_lines.append(f"![{alt}]({image_dir}/{img.filename})")
     return markdown.rstrip() + "\n".join(appended_lines) + "\n"
+
+
+# 近全页图的最小显示面积阈值（CSS px²）。assembly._image_to_markdown 以 bbox(pt)×4/3
+# 计算显示尺寸：近全页图约 680×950 ≈ 646k px²；正文 figure 通常 <300k（如 457×365≈167k）。
+# 取 500k 仅捕获真正的 page-dominant 图，避免误伤多图正文页的合法 figure。
+_PAGE_DOMINANT_MIN_AREA = 500_000
+
+
+def _img_tag_dims(markdown: str) -> dict[str, tuple[int, int]]:
+    """从 markdown 内嵌 ``<img src width height>`` 解析每张已引用图的显示尺寸。
+
+    assembly 阶段把图渲染为 HTML img 并携带 width/height（PDF bbox 派生，最准），
+    栅格 width/height 仅在 bbox 缺失时回退。属性顺序不固定，故逐标签提取。
+    """
+    dims: dict[str, tuple[int, int]] = {}
+    for tag in re.finditer(r"<img\b[^>]*>", markdown, re.IGNORECASE):
+        attrs = tag.group(0)
+        src_m = re.search(r'\bsrc\s*=\s*["\']([^"\']+)["\']', attrs)
+        w_m = re.search(r'\bwidth\s*=\s*["\'](\d+)["\']', attrs)
+        h_m = re.search(r'\bheight\s*=\s*["\'](\d+)["\']', attrs)
+        if not (src_m and w_m and h_m):
+            continue
+        src = src_m.group(1)
+        if src.startswith("data:"):
+            continue
+        bn = PurePosixPath(src).name
+        if bn:
+            dims[bn] = (int(w_m.group(1)), int(h_m.group(1)))
+    return dims
+
+
+def _redundant_orphan_basenames(
+    markdown: str,
+    images: Sequence[ImageMeta],
+    referenced_basenames: set[str],
+) -> set[str]:
+    """识别应抑制的冗余 orphan：与某张 page-dominant 已引用图同页的 orphan 碎片。
+
+    场景：封面/整页插图页，全页大图已被正文 ``<img>`` 引用（已含全部视觉内容），
+    同页其余未引用的嵌入图对象（logo/条码/图层碎片）作为 orphan 追加会与全页图
+    视觉重复。判定：已引用图显示面积 ≥ ``_PAGE_DOMINANT_MIN_AREA`` → page-dominant；
+    其所在页的其余 orphan 判为冗余碎片，抑制不追加。
+
+    安全性：仅当确有 page-dominant 已引用图且 page_number 可用时才抑制同页 orphan；
+    否则返回空集（no-op，保留既有 loss-averse orphan 行为），不误删多图正文页合法孤立图。
+    """
+    ref_dims = _img_tag_dims(markdown)
+    if not ref_dims:
+        return set()
+
+    basename_to_page: dict[str, int] = {}
+    for img in images:
+        fn = getattr(img, "filename", None)
+        pg = getattr(img, "page_number", None)
+        if fn and pg is not None:
+            basename_to_page[fn] = pg
+    if not basename_to_page:
+        return set()  # 无 page_number 维度，无法安全按页抑制
+
+    dominant_pages: set[int] = set()
+    for bn, (w, h) in ref_dims.items():
+        if w * h >= _PAGE_DOMINANT_MIN_AREA:
+            pg = basename_to_page.get(bn)
+            if pg is not None:
+                dominant_pages.add(pg)
+    if not dominant_pages:
+        return set()
+
+    redundant: set[str] = set()
+    for img in images:
+        fn = getattr(img, "filename", None)
+        if not fn or fn in referenced_basenames:
+            continue
+        if basename_to_page.get(fn) in dominant_pages:
+            redundant.add(fn)
+    return redundant
 
 
 def _replace_image_placeholders(

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1132,6 +1132,20 @@ class BuiltinAssembler(PDFToolBase):
                 def caption(self) -> Optional[str]:
                     return self._img.caption
 
+                # 暴露几何/页码信息，供 image_ref_normalizer 做"同页 page-dominant
+                # 大图抑制冗余 orphan 碎片"判定（如封面全页图 + 同页噪声碎片）。
+                @property
+                def width(self) -> Optional[int]:
+                    return getattr(self._img, "width", None)
+
+                @property
+                def height(self) -> Optional[int]:
+                    return getattr(self._img, "height", None)
+
+                @property
+                def page_number(self) -> Optional[int]:
+                    return getattr(self._img, "page_number", None)
+
             adapted_images = [_ImageMetaAdapter(img) for img in images]
             markdown = normalize_image_references(markdown, adapted_images)
 

--- a/apps/negentropy-perceives/tests/unit/test_image_ref_normalizer.py
+++ b/apps/negentropy-perceives/tests/unit/test_image_ref_normalizer.py
@@ -29,6 +29,9 @@ class FakeImage:
 
     filename: Optional[str] = None
     caption: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    page_number: Optional[int] = None
 
 
 # ============================================================
@@ -267,6 +270,90 @@ class TestOrphanImageAppend:
         images = [FakeImage(filename="img_0_0_20260525.png", caption="x")]
         result = normalize_image_references(md, images)
         assert "<!-- orphan images appended" not in result
+
+
+# ============================================================
+# page-dominant 同页 orphan 抑制
+# ============================================================
+class TestPageDominantOrphanSuppression:
+    """封面/整页插图页：全页大图已引用时，抑制同页冗余 orphan 碎片。"""
+
+    def test_cover_fragment_orphans_suppressed(self) -> None:
+        """封面全页图(816x1056)已引用，同页 2 张碎片 orphan 不再追加。"""
+        md = (
+            '<img src="./images/img_0_0.png" alt="cover" '
+            'width="816" height="1056" style="max-width:100%;height:auto;" />'
+        )
+        images = [
+            FakeImage(
+                filename="img_0_0.png",
+                caption="cover",
+                width=816,
+                height=1056,
+                page_number=0,
+            ),
+            FakeImage(filename="fig_p1_1.png", caption=None, page_number=0),
+            FakeImage(filename="fig_p1_2.png", caption=None, page_number=0),
+        ]
+        result = normalize_image_references(md, images)
+        assert "<!-- orphan images appended" not in result
+        assert "fig_p1_1.png" not in result
+        assert "fig_p1_2.png" not in result
+        # 主图保留
+        assert "img_0_0.png" in result
+
+    def test_content_figure_preserved_not_page_dominant(self) -> None:
+        """正文 figure(167k < 500k 阈值)非 page-dominant，同页 orphan 不抑制。"""
+        md = (
+            '<img src="./images/fig_p14_1.png" alt="图1.1" '
+            'width="457" height="365" style="max-width:100%;height:auto;" />'
+        )
+        images = [
+            FakeImage(
+                filename="fig_p14_1.png",
+                caption="图1.1",
+                width=457,
+                height=365,
+                page_number=13,
+            ),
+            FakeImage(filename="fig_p14_2.png", caption=None, page_number=13),
+        ]
+        result = normalize_image_references(md, images)
+        # 非主导图页：fig_p14_2 作为正常 orphan 仍追加
+        assert "<!-- orphan images appended" in result
+        assert "fig_p14_2.png" in result
+
+    def test_no_page_number_is_noop(self) -> None:
+        """page_number 缺失时安全降级，保留既有 orphan 追加行为。"""
+        md = '<img src="./images/big.png" alt="x" width="816" height="1056" />'
+        images = [
+            FakeImage(
+                filename="big.png", caption="x", width=816, height=1056
+            ),  # page_number=None
+            FakeImage(filename="frag.png", caption=None),  # page_number=None
+        ]
+        result = normalize_image_references(md, images)
+        # 无页码维度无法安全抑制 → frag.png 仍作为 orphan 追加（不丢图）
+        assert "<!-- orphan images appended" in result
+        assert "frag.png" in result
+
+    def test_orphan_on_different_page_not_suppressed(self) -> None:
+        """orphan 与 dominant 图不同页时不抑制（多页文档）。"""
+        md = '<img src="./images/cover.png" alt="cover" width="816" height="1056" />'
+        images = [
+            FakeImage(
+                filename="cover.png",
+                caption="cover",
+                width=816,
+                height=1056,
+                page_number=0,
+            ),
+            FakeImage(filename="other.png", caption=None, page_number=5),
+        ]
+        result = normalize_image_references(md, images)
+        # other.png 在第 5 页，不受第 0 页 dominant 影响 → 正常追加
+        assert "<!-- orphan images appended" in result
+        assert "other.png" in result
 
 
 # ============================================================


### PR DESCRIPTION
## 背景
PDF 高保真巡检《浪潮之巅 2019》（939 页）发现：封面/整页插图页的 Markdown 输出中，`image_ref_normalizer._append_orphan_images` 会把与全页大图同页的未引用嵌入图对象（封面 logo/条码/图层碎片）作为 orphan 追加到末尾，与已被正文 `<img>` 引用的全页封面图构成视觉重复。

## 改动（3 文件，+181）
- **`image_ref_normalizer.py`**：`_append_orphan_images` 新增 page-dominant 抑制。从 markdown `<img width/height>` 解析已引用图显示尺寸（assembly 由 PDF bbox 派生，最准），面积 ≥ `_PAGE_DOMINANT_MIN_AREA`(500k px²) 视为近全页图；其所在页的其余 orphan 判为冗余碎片，抑制不追加。新增 `_img_tag_dims`/`_redundant_orphan_basenames` 辅助。
- **`assembly.py`**：`_ImageMetaAdapter` 补暴露 `page_number`/`width`/`height`（底层 `ExtractedImage` 本有这些字段，此前被剥离）。
- **`test_image_ref_normalizer.py`**：`FakeImage` 补几何字段；新增 `TestPageDominantOrphanSuppression` 4 个用例（封面抑制 / 正文 figure 保留 / page_number 缺失 no-op / 不同页不抑制）。

## 安全性（非回归）
- 仅当确有 page-dominant 已引用图且 `page_number` 可用时才抑制同页 orphan；否则 no-op，保留既有 loss-averse orphan 行为。
- 正文 figure 通常 <300k px²（如《浪潮之巅》图1.1 = 457×365 ≈ 167k），远低于 500k 阈值，不受影响。

## 验证
- 实转《浪潮之巅》p1 封面：2 张冗余 orphan（fig_p1_1/fig_p1_2）已抑制，全页封面图保留。
- 自回归 p14 figure 1.1（167k，非 page-dominant）：合法 figure 正常保留，正文无丢失。
- 全套 34 normalizer 单测通过（含 4 新增）；ruff format/lint、mypy 通过。
- 注：`tests/unit/test_config.py` 有 3 个预存失败（`concurrent_requests` 默认 32 vs 期望 16，本地配置漂移），`git stash` 本改动后仍失败，与本次无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)