### PR TITLE
fix(perceives): PDF 高保真巡检四项修复（参考文献/章节序/图链/作者块+页眉）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
@@ -17,37 +17,57 @@ except ImportError:
 def _copy_image_assets(result, output: str) -> None:
     """将抽取的图片资产拷贝到 markdown 输出目录的 ``images/`` 子目录。
 
-    传统（非 auto pipeline）路径把图片写到 ``EnhancedPDFProcessor.output_directory``
-    ——当上层未透传 ``output_dir`` 时即 ``tempfile.mkdtemp('enhanced_pdf_*')`` 临时目录。
-    此前 CLI 仅写 markdown 文本、不搬运图片资产，导致候选中 ``./images/<filename>``
-    引用全部死链。此处补齐资产落地，使 markdown 图片引用可达。
-
-    auto pipeline 路径自带 ``image_assets`` 落盘逻辑，其 ``enhanced_assets`` 结构不同，
-    ``output_directory`` 缺失时本函数直接 no-op，互不影响。
+    两条路径：
+    1. 传统（非 auto pipeline）路径：图片写到 ``EnhancedPDFProcessor.output_directory``
+       （上层未透传 ``output_dir`` 时为 ``tempfile.mkdtemp('enhanced_pdf_*')``），
+       从该目录整目录拷贝。
+    2. auto pipeline 路径：``enhanced_assets`` 无 ``output_directory``，图片散落于
+       image_extraction 的 ``tempfile.mkdtemp('pdf_images_*')`` 临时目录，路径记录在
+       ``result.image_assets[i].image_path``。此前本函数对 auto 路径直接 no-op，
+       致 ``./images/<filename>`` 引用全部死链（ISSUE: auto 路径图链失效）。此处
+       按 ``image_assets`` 逐图拷贝补齐。
     """
     import shutil
     from pathlib import Path
 
+    images_dst = Path(output).resolve().parent / "images"
+    image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
+
+    # 路径 1：传统路径——从 output_directory 整目录拷贝
     ea = getattr(result, "enhanced_assets", None) or {}
     src_dir = ea.get("output_directory")
-    if not src_dir:
+    if src_dir and Path(src_dir).is_dir():
+        candidates = [
+            p
+            for p in Path(src_dir).iterdir()
+            if p.is_file() and p.suffix.lower() in image_exts
+        ]
+        if candidates:
+            images_dst.mkdir(parents=True, exist_ok=True)
+            for src in candidates:
+                try:
+                    shutil.copy2(src, images_dst / src.name)
+                except OSError:
+                    # 单图拷贝失败不应中断整体输出落盘。
+                    pass
         return
-    src_path = Path(src_dir)
-    if not src_path.is_dir():
+
+    # 路径 2：auto pipeline——按 image_assets 逐图拷贝
+    image_assets = getattr(result, "image_assets", None) or []
+    if not image_assets:
         return
-    image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
-    candidates = [
-        p for p in src_path.iterdir() if p.is_file() and p.suffix.lower() in image_exts
-    ]
-    if not candidates:
-        return
-    images_dst = Path(output).resolve().parent / "images"
     images_dst.mkdir(parents=True, exist_ok=True)
-    for src in candidates:
+    for asset in image_assets:
+        asset_src = getattr(asset, "image_path", None)
+        filename = getattr(asset, "filename", None)
+        if not asset_src or not filename:
+            continue
+        asset_src_path = Path(asset_src)
+        if not asset_src_path.is_file():
+            continue
         try:
-            shutil.copy2(src, images_dst / src.name)
+            shutil.copy2(asset_src_path, images_dst / filename)
         except OSError:
-            # 单图拷贝失败不应中断整体输出落盘（如只读源/目标磁盘满）。
             pass
 
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
@@ -243,7 +243,14 @@ async def parse_pdf_to_markdown(
                     output_format=output_format,
                     content=pipeline_result.markdown,
                     metadata=pipeline_result.metadata,
-                    page_count=getattr(pipeline_result, "page_count", 0),
+                    page_count=(
+                        # auto pipeline 的 asset_bundling 应从 preprocessing 回填
+                        # page_count，但部分降级路径未透传；为 0 时从源 PDF 兜底，
+                        # 避免 Statistics 暴露错误的 page_count=0（ISSUE: page_count=0）。
+                        getattr(pipeline_result, "page_count", 0)
+                        or detect_pdf_total_pages(pdf_source)
+                        or 0
+                    ),
                     word_count=pipeline_result.word_count,
                     conversion_time=elapsed_ms(_start) / 1000.0,
                     enhanced_assets=enhanced_assets,

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -515,6 +515,14 @@ class BuiltinAssembler(PDFToolBase):
                     if not (col0_ok and col1_ok):
                         is_two_col = False
 
+                    # 行优先守卫：两栏均无≥250pt 高块时，页面是横排多元素区
+                    # （典型：3 栏作者块 / 标题页装饰），count-path 会误判为双栏
+                    # 并按列优先排序，把同 y0 横排的作者重排成列序、破坏阅读序
+                    # （ISSUE: 作者块乱序）。仅当至少一栏有高块（真双栏正文）才
+                    # 保留列优先；否则降级行优先 (y0, x0)。body 正文页有高块不受影响。
+                    if is_two_col and not (col0_tall or col1_tall):
+                        is_two_col = False
+
                 for elem, bbox in items:
                     if is_two_col:
                         elem_width = bbox[2] - bbox[0]

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -483,22 +483,36 @@ class BuiltinAssembler(PDFToolBase):
                 if is_two_col:
                     _SUBSTANTIAL_W_PT = 100.0
                     _MIN_SUBSTANTIAL_PER_COL = 3
+                    # fitz/PyMuPDF 常把整栏正文合并为单个「高块」（宽~栏宽、高数百
+                    # pt）。这种块每栏仅 1 个，宽度可能略超 full_width_thr 被排除，
+                    # 致「每栏 ≥3 实质元素」校验误判真双栏正文页为单栏，进而按 y0
+                    # 排序把右栏（y0 较小）排到左栏之前（ISSUE: 双栏章节序错乱）。
+                    # 增加高度路径：每栏存在高度 ≥250pt 的块即视为实质栏
+                    # （正文栏块通常 280pt+；标题页摘要块 ~195pt 不致误判）。
+                    _TALL_BLOCK_H_PT = 250.0
                     full_width_thr = x_range * 0.7
                     col0_substantial = 0
                     col1_substantial = 0
+                    col0_tall = False
+                    col1_tall = False
                     for _, bx in items:
                         w = bx[2] - bx[0]
-                        if w < _SUBSTANTIAL_W_PT or w > full_width_thr:
-                            continue
+                        h = bx[3] - bx[1]
                         xc = (bx[0] + bx[2]) / 2
-                        if xc < split_x:
-                            col0_substantial += 1
-                        else:
-                            col1_substantial += 1
-                    if (
-                        col0_substantial < _MIN_SUBSTANTIAL_PER_COL
-                        or col1_substantial < _MIN_SUBSTANTIAL_PER_COL
-                    ):
+                        left = xc < split_x
+                        if _SUBSTANTIAL_W_PT <= w <= full_width_thr:
+                            if left:
+                                col0_substantial += 1
+                            else:
+                                col1_substantial += 1
+                        if h >= _TALL_BLOCK_H_PT:
+                            if left:
+                                col0_tall = True
+                            else:
+                                col1_tall = True
+                    col0_ok = col0_substantial >= _MIN_SUBSTANTIAL_PER_COL or col0_tall
+                    col1_ok = col1_substantial >= _MIN_SUBSTANTIAL_PER_COL or col1_tall
+                    if not (col0_ok and col1_ok):
                         is_two_col = False
 
                 for elem, bbox in items:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -237,15 +237,25 @@ class FitzTextExtractor(PDFToolBase):
             for page_idx in range(start_page, end_page):
                 pd = page_dict_blocks[page_idx]
                 page_height = pd.get("height", 792)
+                page_width = pd.get("width", 612.0)
                 raw_blocks = pd.get("blocks", [])
+
+                # 双栏阅读序：fitz 把每栏正文合并为单个大块，全局 (y0, x0) 排序
+                # 会把 y0 略小的右栏排到左栏之前（如右栏 §3.1 早于左栏 §3 正文）。
+                # 仅当页存在「一左一右、高度>30%页高、y 显著重叠」的栏块对时，
+                # 判为双栏正文页，改用 (栏, y0, x0)：左栏（含跨栏全宽块）先于右栏，
+                # 栏内自上而下。单栏页 / 复杂标题页（3 栏作者块，无高栏块对）
+                # 检测不到 → 沿用 (y0, x0)，零回归。
+                two_column = FitzTextExtractor._is_two_column_body(
+                    raw_blocks, page_width, page_height
+                )
 
                 page_blocks: List[TextBlock] = []
                 in_page_order = 0
                 for block in sorted(
                     raw_blocks,
-                    key=lambda b: (
-                        b.get("bbox", (0, 0, 0, 0))[1],
-                        b.get("bbox", (0, 0, 0, 0))[0],
+                    key=lambda b: FitzTextExtractor._page_reading_key(
+                        b, page_width, two_column
                     ),
                 ):
                     if block.get("type") != 0:
@@ -366,6 +376,72 @@ class FitzTextExtractor(PDFToolBase):
         finally:
             doc.close()
         return out
+
+    @staticmethod
+    def _is_two_column_body(
+        raw_blocks: list, page_width: float, page_height: float
+    ) -> bool:
+        """检测页面是否为「双栏正文」布局。
+
+        判据：存在两个文本块同时满足——(1)均非跨栏全宽块（宽度 ≤ 70% 页宽）；
+        (2)均较高（高度 > 30% 页高，排除标题/作者/摘要等短块）；(3)一个在中线
+        左侧、一个在右侧；(4)x 方向分离不重叠；(5)y 方向显著重叠（> 较小块
+        高度的 50%）。满足即认为存在左右两个正文栏块，需列优先阅读序。
+
+        该判据专门识别「整列正文大块」（fitz 把每栏合并为一个高块），与 3 栏
+        作者块、单栏页区分（后者无满足条件的块对 → 返回 False，沿用行优先排序）。
+        """
+        mid_x = page_width / 2.0
+        min_col_height = page_height * 0.3
+        cols: List[tuple] = []
+        for b in raw_blocks:
+            if b.get("type") != 0:
+                continue
+            x0, y0, x1, y1 = b.get("bbox", (0, 0, 0, 0))[:4]
+            if (x1 - x0) > page_width * 0.7:  # 跨栏全宽块
+                continue
+            if (y1 - y0) < min_col_height:  # 短块（标题/作者等）
+                continue
+            cols.append((x0, y0, x1, y1))
+        n = len(cols)
+        for i in range(n):
+            ax0, ay0, ax1, ay1 = cols[i]
+            a_cx = (ax0 + ax1) / 2.0
+            a_left = a_cx < mid_x
+            for j in range(i + 1, n):
+                bx0, by0, bx1, by1 = cols[j]
+                b_cx = (bx0 + bx1) / 2.0
+                # 一左一右（分属中线两侧）
+                if a_left == (b_cx < mid_x):
+                    continue
+                # x 方向分离（不重叠）
+                if not (ax1 <= bx0 or bx1 <= ax0):
+                    continue
+                # y 方向显著重叠
+                overlap_y = min(ay1, by1) - max(ay0, by0)
+                min_h = min(ay1 - ay0, by1 - by0)
+                if min_h > 0 and overlap_y > min_h * 0.5:
+                    return True
+        return False
+
+    @staticmethod
+    def _page_reading_key(block: dict, page_width: float, two_column: bool) -> tuple:
+        """块阅读序排序键。
+
+        - ``two_column=False``（单栏 / 复杂标题页）：返回 ``(y0, x0)``，行优先，
+          兼容旧行为。
+        - ``two_column=True``（双栏正文页）：返回 ``(栏, y0, x0)``，列优先——
+          跨栏全宽块（标题/页眉/通栏图）与左栏归 col=0，右栏归 col=1，左栏
+          整体先于右栏，栏内自上而下。修复右栏 y0 略小被排到左栏之前的问题。
+        """
+        bbox = block.get("bbox", (0, 0, 0, 0))
+        x0, y0, x1 = bbox[0], bbox[1], bbox[2]
+        if not two_column:
+            return (y0, x0)
+        if (x1 - x0) > page_width * 0.7:
+            return (0, y0, x0)
+        col = 0 if (x0 + x1) / 2.0 < page_width / 2.0 else 1
+        return (col, y0, x0)
 
     @staticmethod
     def _rejoin_spaced_words(text: str) -> str:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -456,18 +456,33 @@ class FitzTextExtractor(PDFToolBase):
         if y1 > page_height * 0.95 and 20 <= text_len <= 100:
             return True
 
-        # ACM/IEEE 会议论文页眉模式
-        _conf_patterns = [
-            r"Conference\s+acronym",
-            r"Proceedings\s+of",
-            r"In\s+Proceedings",
+        # ACM/IEEE 会议论文页眉模式。
+        # 版权/格式行（ACM Reference Format / Permission to make digital /
+        # Copyright ... ACM）只出现在真实页眉/页脚，绝不会出现在参考文献条目
+        # 中，无论长度都可安全判定为页眉。
+        _copyright_header_patterns = [
             r"ACM\s+Reference\s+Format",
             r"Permission\s+to\s+make\s+digital",
             r"Copyright\s+.*\d{4}\s+ACM",
         ]
-        for pat in _conf_patterns:
+        for pat in _copyright_header_patterns:
             if re.search(pat, text_stripped, re.IGNORECASE):
                 return True
+
+        # 会议/论文集模式（"In Proceedings of" / "Proceedings of" / 会议简称）
+        # 既出现在短页眉（如 "In Proceedings of SIGIR '26"）也高频出现在参考
+        # 文献条目中。用 re.search 子串匹配时，整列参考文献（数千字符，必含上述
+        # 短语）会被误判为会议页眉而整体丢弃（ISSUE: 参考文献整段丢失）。
+        # 仅当文本短（真页眉，< 200 字符）才判定；长块必为参考文献正文，保留。
+        # 与下方 DOI 行检测阈值一致。
+        if text_len < 200:
+            for pat in (
+                r"Conference\s+acronym",
+                r"Proceedings\s+of",
+                r"In\s+Proceedings",
+            ):
+                if re.search(pat, text_stripped, re.IGNORECASE):
+                    return True
 
         # DOI 行
         if re.search(r"https?://doi\.org/", text_stripped) and text_len < 200:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -564,6 +564,17 @@ class FitzTextExtractor(PDFToolBase):
         if re.search(r"https?://doi\.org/", text_stripped) and text_len < 200:
             return True
 
+        # 会议运行头：含「会议简称+'两位年份」（如 SIGIR '26 / ICML '24）+ 4 位
+        # 年份，且为短文本。这类运行头每页重复出现于页顶/页脚（位置启发式 5% 阈值
+        # 常漏判 y0≈7.8% 的页眉）。参考文献列块虽含会议名，但作为整栏大块（数千
+        # 字符）远超 text_len<200 阈值，不受影响（ISSUE: 运行页眉泄漏）。
+        if (
+            text_len < 200
+            and re.search(r"\b[A-Z][A-Z0-9]{1,8}\s*['’]\s*\d{2}\b", text_stripped)
+            and re.search(r"\b(?:19|20)\d{2}\b", text_stripped)
+        ):
+            return True
+
         return False
 
     @staticmethod


### PR DESCRIPTION
## 背景

PDF→Markdown 高保真巡检（doc_id 387cc29b，《LLM-Oriented Information Retrieval: A Denoising-First Perspective》，SIGIR '26 16 页双栏 survey）发现 auto pipeline 产出与源 PDF 视觉保真度仅 58 分，主导缺陷为参考文献整段丢失（40% 内容）。经四轮迭代定位并修复 6 类根因，文档收敛至 score 97、defects 清空。

## 变更（4 commits，均为最小定点改动）

| commit | 缺陷 | 根因 & 修复 |
|---|---|---|
| `104e6644` | 参考文献整段丢失（235 条全失） | `_is_header_footer` 会议模式 `re.search` 子串匹配把含 "In Proceedings of" 的整列参考文献误判为页眉丢弃。按模式是否仅出现在页眉分组：版权/格式模式始终判页眉；Proceedings/会议简称模式加 `text_len<200` 长度守卫。 |
| `b327de4b` | 双栏章节阅读序错乱（§3.5 早于 §3.4、§5 早于 §4.4） | fitz 把整栏正文合并为单个高块，assembly「每栏≥3 实质元素」校验失效致真双栏正文页误判单栏。assembly 列校验增加高度路径（每栏≥250pt 高块）+ `_extract_chunk` 双栏感知列优先排序。 |
| `276f57a9` | auto 路径图链失效（3 图引用死链） | CLI `_copy_image_assets` 仅从 `enhanced_assets.output_directory` 拷贝，auto 路径无此字段（图片在 image_extraction 的 temp 目录）。增加 fallback 按 `result.image_assets[i].image_path` 逐图拷贝到 `-o/images/`。 |
| `94df26d0` | 作者块乱序 + page_count=0 + 运行页眉泄漏 | (1) assembly 行优先守卫：两栏均无≥250pt 高块时降级行优先，修 3 栏作者块被 count-path 误判；(2) ops/pdf.py page_count 兜底（`detect_pdf_total_pages`）；(3) `_is_header_footer` 增加会议运行头模式（ACRONYM 'YY + 年份 + 短文本）。 |

## 验证

- **目标文档**：word_count 7596→15858，参考文献 [1]-[235] 全恢复，章节序正确（§3.4<§3.5、§4.4<§5<§6），作者序正确（Lu Dai→…→Hui Xiong），3 图落盘，page_count=16，运行页眉残留=0。
- **非回归**：939 页异构文档转换成功，word_count 32041 不变，图片落盘 0→145 张（同步修复），page_count 正确。
- **测试**：`uv run ruff check` 全过；`uv run pytest`（perceives 改动相关）392 passed / 3 skipped（本地 fixture 缺失）/ 0 failed。
- **pre-commit**：ruff format/lint、mypy 全过。

## 说明

- 改动均为加法式或带长度守卫，不改变单栏文档行为（零回归设计）。
- 会议页眉模式拆分（版权 vs Proceedings）+ text_len 守卫是核心防回归点：既修参考丢失又不误杀短页眉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)