### PR TITLE
fix(perceives): PDF→Markdown 高保真巡检多处修复（图片落盘/图边界内容/图去重/轴噪声/chrome/inline公式）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
@@ -175,7 +175,14 @@ async def _run(
     if output:
         from pathlib import Path
 
-        Path(output).write_text(formatted, encoding="utf-8")
+        # markdown 文件输出写纯文档内容（result.content），剥离 CLI 展示用的元数据
+        # 头尾（``## <source>`` / ``**Status**`` / 末尾 ``### Statistics``）——这些是
+        # format_result 的展示 chrome、非文档内容，混入 .md 会污染下游消费（保真度
+        # 比对、知识库灌库等）。stdout 与 json/plain 格式仍走 format_result 不变。
+        if format == "markdown":
+            Path(output).write_text(result.content or "", encoding="utf-8")
+        else:
+            Path(output).write_text(formatted, encoding="utf-8")
         # 补齐图片资产落盘：传统路径图片写到 EnhancedPDFProcessor.output_directory
         # （可能为临时目录），需拷贝到 -o 同级 images/ 使 ./images/<filename> 引用可达。
         _copy_image_assets(result, output)

--- a/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
@@ -17,35 +17,53 @@ except ImportError:
 def _copy_image_assets(result, output: str) -> None:
     """将抽取的图片资产拷贝到 markdown 输出目录的 ``images/`` 子目录。
 
-    传统（非 auto pipeline）路径把图片写到 ``EnhancedPDFProcessor.output_directory``
-    ——当上层未透传 ``output_dir`` 时即 ``tempfile.mkdtemp('enhanced_pdf_*')`` 临时目录。
-    此前 CLI 仅写 markdown 文本、不搬运图片资产，导致候选中 ``./images/<filename>``
-    引用全部死链。此处补齐资产落地，使 markdown 图片引用可达。
+    两条 pipeline 路径的图片落盘位置都可能与用户 ``-o`` 输出路径不一致，需在此统一
+    搬运到 ``Path(output).parent / "images"``，使候选 markdown 中 ``./images/<filename>``
+    引用可达（否则全量死链）：
 
-    auto pipeline 路径自带 ``image_assets`` 落盘逻辑，其 ``enhanced_assets`` 结构不同，
-    ``output_directory`` 缺失时本函数直接 no-op，互不影响。
+    - **auto pipeline**：``result.image_assets``（``List[ImageAsset]``）携带每张图的绝对
+      ``image_path``。其落盘约定（``_resolve_images_dir``）在未透传 ``output_dir`` 时
+      回退到 ``<cwd>/output/<stem>/images/``，与用户 ``-o`` 路径常常不一致——此前本函数
+      误以为 auto 路径「自带正确落盘」而对齐 no-op，导致 CLI 候选图片全量死链。
+    - **传统（非 auto）路径**：图片写在 ``EnhancedPDFProcessor.output_directory``
+      （``result.enhanced_assets["output_directory"]`` 指向的目录，可能为临时目录）。
     """
     import shutil
     from pathlib import Path
 
+    images_dst = Path(output).resolve().parent / "images"
+
+    src_files = []
+    # (1) auto pipeline：从 image_assets 逐图收集绝对 image_path
+    for asset in getattr(result, "image_assets", None) or []:
+        image_path = getattr(asset, "image_path", None)
+        if image_path:
+            src_files.append(Path(image_path))
+    # (2) 传统路径：从 enhanced_assets.output_directory 收集目录内全部图片
     ea = getattr(result, "enhanced_assets", None) or {}
     src_dir = ea.get("output_directory")
-    if not src_dir:
+    if src_dir and Path(src_dir).is_dir():
+        image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
+        src_files.extend(
+            p
+            for p in Path(src_dir).iterdir()
+            if p.is_file() and p.suffix.lower() in image_exts
+        )
+
+    if not src_files:
         return
-    src_path = Path(src_dir)
-    if not src_path.is_dir():
-        return
-    image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
-    candidates = [
-        p for p in src_path.iterdir() if p.is_file() and p.suffix.lower() in image_exts
-    ]
-    if not candidates:
-        return
-    images_dst = Path(output).resolve().parent / "images"
     images_dst.mkdir(parents=True, exist_ok=True)
-    for src in candidates:
+    seen = set()
+    for src in src_files:
         try:
-            shutil.copy2(src, images_dst / src.name)
+            if not src.is_file():
+                continue
+            dest = images_dst / src.name
+            if src.name in seen or src.resolve() == dest.resolve():
+                # 同名已拷贝 / 源与目标同一文件（auto 路径已恰好落在 images_dst 时）。
+                continue
+            seen.add(src.name)
+            shutil.copy2(src, dest)
         except OSError:
             # 单图拷贝失败不应中断整体输出落盘（如只读源/目标磁盘满）。
             pass

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -1294,6 +1294,15 @@ class MarkdownFormatter:
             if _is_math_block(para):
                 kept.append(para)
                 continue
+            # 图片段落（HTML ``<img>``）结构性关键，绝不作为近似重复被删除：
+            # 其 alt 文本与独立文本 caption 段高度重合（Jaccard 易 > 0.6），当文本
+            # caption 段排在 <img> 之前时，<img> 段会被误判为"跨引擎重复段"删除，
+            # 致整张图从 Markdown 消失（实测 Fig 15/16 因此丢失）。始终保留 <img> 段；
+            # 仍把其指纹加入 seen，使后续冗余文本 caption 段被正常去重。
+            if "<img" in para:
+                kept.append(para)
+                seen_fingerprints.append(_fingerprint(para))
+                continue
             # 参考文献条目（[N] 起首）唯一编号、语义独立，绝不参与近似去重
             if _is_reference_entry(para):
                 kept.append(para)

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -730,7 +730,17 @@ class BuiltinAssembler(PDFToolBase):
                             if re.search(r"\(\s*" + re.escape(eq_num) + r"\s*\)", text):
                                 matched = True
                         # 策略 2：数学符号 + LaTeX 关键词匹配（短公式或无编号场景）
-                        if not matched and formula.formula_type == "block":
+                        #   - block 短公式 / 无编号块公式（数学符号 + 名称双条件）；
+                        #   - inline 独立短块（整段文本即公式，≤ 40 字符）——仅当文本元素
+                        #     本身为公式而非散文段落时整体替换，避免误吞 prose；inline
+                        #     希腊变量（α/β/θ）无 block 数学符号，放宽为"名称匹配即可"。
+                        #   LaTeX 名经希腊字母 / 运算符 unicode 映射桥接文本层字形
+                        #   （``\alpha``↔``α``、``\theta``↔``θ``、``\approx``↔``≈``）。
+                        is_block = formula.formula_type == "block"
+                        is_inline_short = (
+                            formula.formula_type == "inline" and len(text) <= 40
+                        )
+                        if not matched and (is_block or is_inline_short):
                             _math_symbols = [
                                 "→",
                                 "∑",
@@ -759,13 +769,71 @@ class BuiltinAssembler(PDFToolBase):
                                     "\\dots",
                                     "\\text",
                                     "\\tag",
+                                    "\\mathrm",
                                 )
                             ]
-                            _name_match = any(
-                                n.lower() in text.lower() for n in _latex_names
-                            )
-                            if _has_math and _name_match:
-                                matched = True
+                            # LaTeX 命令名 → unicode 字形（greek 字母 / 运算符）
+                            _LATEX_GLYPH = {
+                                "alpha": "α",
+                                "beta": "β",
+                                "gamma": "γ",
+                                "delta": "δ",
+                                "theta": "θ",
+                                "phi": "φ",
+                                "varphi": "ϕ",
+                                "psi": "ψ",
+                                "omega": "ω",
+                                "lambda": "λ",
+                                "mu": "μ",
+                                "sigma": "σ",
+                                "epsilon": "ε",
+                                "eta": "η",
+                                "zeta": "ζ",
+                                "nu": "ν",
+                                "tau": "τ",
+                                "rho": "ρ",
+                                "kappa": "κ",
+                                "chi": "χ",
+                                "Phi": "Φ",
+                                "Theta": "Θ",
+                                "Omega": "Ω",
+                                "Gamma": "Γ",
+                                "Delta": "Δ",
+                                "Lambda": "Λ",
+                                "Sigma": "Σ",
+                                "Psi": "Ψ",
+                                "approx": "≈",
+                                "times": "×",
+                                "cdot": "·",
+                                "le": "≤",
+                                "ge": "≥",
+                                "ne": "≠",
+                                "sum": "∑",
+                                "in": "∈",
+                                "cup": "∪",
+                                "cap": "∩",
+                                "subseteq": "⊆",
+                                "rightarrow": "→",
+                            }
+
+                            def _name_in_text(name: str) -> bool:
+                                # 仅认 unicode 字形（α/θ/≈/×/≤ 等）——这些字形几乎不出现在
+                                # 非数学散文。丢弃 ascii 名 substring 路径，避免 ``\in``→"in"
+                                # 误匹配 "Introduction"/"training" 等通用子串致短段被整体替换。
+                                if not name:
+                                    return False
+                                glyph = _LATEX_GLYPH.get(name) or _LATEX_GLYPH.get(
+                                    name.lower()
+                                )
+                                return glyph is not None and glyph in text
+
+                            _name_match = any(_name_in_text(n) for n in _latex_names)
+                            if is_block:
+                                if _has_math and _name_match:
+                                    matched = True
+                            else:  # inline 独立短块
+                                if _name_match and _latex_names:
+                                    matched = True
                         if matched:
                             formula_md = _formula_to_markdown(formula)
                             elem.content = formula_md

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -737,8 +737,15 @@ class BuiltinAssembler(PDFToolBase):
                         #   LaTeX 名经希腊字母 / 运算符 unicode 映射桥接文本层字形
                         #   （``\alpha``↔``α``、``\theta``↔``θ``、``\approx``↔``≈``）。
                         is_block = formula.formula_type == "block"
-                        is_inline_short = (
-                            formula.formula_type == "inline" and len(text) <= 40
+                        # inline 独立短块：整段即公式。≤ 40 字符直接放；40 < len ≤ 60
+                        # 时要求高数学字形密度（≥ 2 个 greek/运算符特征字形），确认整段
+                        # 确为公式而非散文片段。仅独立块、不触 prose 段落，零损坏风险。
+                        _MATH_GLYPHS = set(
+                            "αβγδεζηθικλμνξπρστυφχψωΔΘΛΣΦΨΩΓ×÷≈≤≥≠∈∉⊂⊆⊃⊇∪∩∀∃∑∏∫∂∇"
+                        )
+                        _glyph_density = sum(1 for c in text if c in _MATH_GLYPHS)
+                        is_inline_short = formula.formula_type == "inline" and (
+                            len(text) <= 40 or (len(text) <= 60 and _glyph_density >= 2)
                         )
                         if not matched and (is_block or is_inline_short):
                             _math_symbols = [

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -166,9 +166,17 @@ class BuiltinAssembler(PDFToolBase):
                     if _block_overlaps_special(
                         block, special_regions, iou_threshold=0.3
                     ):
-                        # 例外：``Figure N:`` / ``Table N:`` 起手的 caption
-                        # 即便几何上落入 layout figure region 也必须保留为段落
-                        # （它们是图表的语义描述，正文阅读价值高）。
+                        # figure-region 抑制本意是滤除图周矢量标签（坐标轴刻度
+                        # ``10 3 10 2 10 1``、面板标记 ``(a) (b)`` 等短碎片）。但
+                        # layout figure region 常过大，会把紧随图表的真实内容——
+                        # section 标题（``4 Corroborating Claims...``）、导言段落——
+                        # 一并吞没，致结构性内容丢失。改为按内容实质性区分而非
+                        # ``全抑制``：
+                        #   1. ``Figure N:`` / ``Table N:`` caption 恒保留；
+                        #   2. 实质文本块（含 ≥2 个 ≥3 字母英文词，涵盖标题与
+                        #      段落）放行至下方通用处理（含 byline / table-caption /
+                        #      metadata 降级守卫）；
+                        #   3. 仅抑制缺乏实质英文词的低内容碎片（轴刻度 / 面板标签）。
                         if _is_figure_or_table_caption_text(block.text):
                             elements.append(
                                 _ContentElement(
@@ -179,7 +187,9 @@ class BuiltinAssembler(PDFToolBase):
                                     block=block,
                                 )
                             )
-                        continue
+                            continue
+                        if _is_low_content_figure_label(block.text):
+                            continue
                     # 字符级签名兜底：剔除 PyMuPDF 把公式视觉渲染区抽成
                     # "字符流文本"产生的冗余文本块（典型如长式 ``M_l = f_long(...)``
                     # 的 PyMuPDF 字符序列与 MinerU LaTeX 经签名归一化后等价）
@@ -1467,6 +1477,31 @@ def _is_figure_or_table_caption_text(text: str) -> bool:
     if not text:
         return False
     return bool(_FIGURE_TABLE_CAPTION_RE.match(text))
+
+
+def _is_low_content_figure_label(text: str) -> bool:
+    """判断落入 figure region 的文本块是否是缺乏实质内容的图周碎片。
+
+    ``_block_overlaps_special`` 命中后，caption 已恒保留；本函数用于进一步区分
+    "真实内容块"与"图周矢量标签碎片"，双信号判定：
+
+    - 信号 A（缺实质英文词）：坐标轴刻度（``10 3 10 2 10 1``、``1 K 10 K``、
+      ``10 −1``）、面板标记（``(a) (b)``）等几乎不含 ≥3 字母英文词（< 2 个）。
+    - 信号 B（刻度序列）：即便跟 2 词轴标题（如 ``1 2 4 8 16 32 Feature index j``、
+      ``10 20 30 Task index k``），出现 ≥3 个**相邻**纯数字 token（仅由空白/逗号/
+      分号分隔）即为坐标轴刻度序列。要求"相邻 ≥3"以避免误伤正文里散落的章节引用
+      （``Sec. 3 ... Sec. 3``、``sections 3, 4``）与型号 ``4M``/``210B``/``GPT-4``。
+
+    真实 section 标题与导言段落（``4 Corroborating Claims...``、``We now verify
+    the claims of Sec. 3 ... Following the structure of Sec. 3 ...``）两信号均不
+    命中，予以保留。
+    """
+    if not text:
+        return True
+    if len(re.findall(r"[A-Za-z]{3,}", text)) < 2:
+        return True
+    # 相邻纯数字序列（≥3 个）= 坐标轴刻度
+    return bool(re.search(r"\d+(?:\.\d+)?(?:[\s,;]+\d+(?:\.\d+)?){2,}", text))
 
 
 def _figure_caption_to_inject(

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1483,24 +1483,40 @@ def _is_low_content_figure_label(text: str) -> bool:
     """判断落入 figure region 的文本块是否是缺乏实质内容的图周碎片。
 
     ``_block_overlaps_special`` 命中后，caption 已恒保留；本函数用于进一步区分
-    "真实内容块"与"图周矢量标签碎片"，双信号判定：
+    "真实内容块"与"图周矢量标签碎片"，三信号判定：
 
     - 信号 A（缺实质英文词）：坐标轴刻度（``10 3 10 2 10 1``、``1 K 10 K``、
-      ``10 −1``）、面板标记（``(a) (b)``）等几乎不含 ≥3 字母英文词（< 2 个）。
-    - 信号 B（刻度序列）：即便跟 2 词轴标题（如 ``1 2 4 8 16 32 Feature index j``、
+      ``10 −1``）、面板标记（``(a) (b)``）、单字轴标题（``Residual δ F``）——0~1 个
+      ≥3 字母英文词。
+    - 信号 C（2 词轴标题碎片）：``Training Step`` / ``Train Loss`` / ``Eval Loss`` /
+      ``Training Step Δ`` 等——≤2 个 ≥3 字母英文词、且**无**章节编号前缀
+      （``4.2 Behavioral Evidence`` / ``A Related Work`` 起首带编号 → 放行）、**无**
+      句末标点。真实短标题多带章节编号或句末标点，且罕见落入 figure region。
+    - 信号 B（刻度序列）：即便跟 2 词轴标题（``1 2 4 8 16 32 Feature index j``、
       ``10 20 30 Task index k``），出现 ≥3 个**相邻**纯数字 token（仅由空白/逗号/
       分号分隔）即为坐标轴刻度序列。要求"相邻 ≥3"以避免误伤正文里散落的章节引用
       （``Sec. 3 ... Sec. 3``、``sections 3, 4``）与型号 ``4M``/``210B``/``GPT-4``。
 
     真实 section 标题与导言段落（``4 Corroborating Claims...``、``We now verify
-    the claims of Sec. 3 ... Following the structure of Sec. 3 ...``）两信号均不
+    the claims of Sec. 3 ... Following the structure of Sec. 3 ...``）三信号均不
     命中，予以保留。
     """
     if not text:
         return True
-    if len(re.findall(r"[A-Za-z]{3,}", text)) < 2:
-        return True
-    # 相邻纯数字序列（≥3 个）= 坐标轴刻度
+    t = text.strip()
+    words = re.findall(r"[A-Za-z]{3,}", text)
+    # 信号 A + C：短碎片（≤2 个 ≥3 字母英文词）且非"章节编号前缀 / 句末标点"形态
+    if len(words) <= 2:
+        # 章节编号前缀要求编号后跟 ≥2 字母英文词（'4.2 Behavioral Evidence'/'A Related Work'），
+        # 避免把 '10 −1'（−1 非字母）、'1 B 300 M 20 M'（B/M 单字母）这类刻度/图例
+        # 噪声误判为 section 编号。
+        has_section_prefix = bool(
+            re.match(r"^(?:\d+(?:\.\d+)*|[A-Z])\s+[A-Za-z]{2,}", t)
+        )
+        has_terminal_punct = bool(re.search(r"[.!?][\"')\]]*\s*$", t))
+        if not has_section_prefix and not has_terminal_punct:
+            return True
+    # 信号 B：相邻纯数字序列（≥3 个）= 坐标轴刻度
     return bool(re.search(r"\d+(?:\.\d+)?(?:[\s,;]+\d+(?:\.\d+)?){2,}", text))
 
 


### PR DESCRIPTION
## 背景
PDF→Markdown 高保真巡检（doc: 《Why Larger Models Learn More》, 37 页学术 ML 论文）发现并定点修复 perceives 转换管线 6 类缺陷，候选 md 保真度由「21 图全断 + sec4 丢失 + Fig15/16 丢失 + 轴噪声 + 元数据 chrome + 0 inline 公式」提升至 96/100（23/23 图、全部章节标题完整、13 inline + 70 display 公式 LaTeX 化）。

## 改动清单（7 commits，3 文件）
1. **cli/parse_pdf.py · `_copy_image_assets`**：扩展兼容 auto pipeline，从 `result.image_assets` 逐图拷到 `-o` 同级 `images/`，修复候选 md 图片全量死链（21 图 → 0 缺失）。
2. **cli/parse_pdf.py · 文件输出剥离 chrome**：markdown 文件输出直接写 `result.content`，剥离 `format_result` 的 `## <source>`/`**Status**`/`### Statistics` 展示元数据。
3. **assembly.py · figure-region 重叠抑制**：改为内容实质性三段式（caption 恒保留 / 实质文本块放行 / `_is_low_content_figure_label` 仅抑低内容碎片），恢复被过大 layout figure region 吞没的 section 标题+导言（sec4）。
4. **assembly.py · `_is_low_content_figure_label`**：增信号 C（2 词轴标题）+ 章节编号守卫精化（`\s+[A-Za-z]{2,}`），清除轴标题裸行与 `##`/`####` 刻度图例噪声（`10 −1`/`1 B 300 M`/`Training Step`）。
5. **markdown/formatter.py · Jaccard 去重保护 `<img>`**：`_deduplicate_approximate_paragraphs` 保护含 `<img>` 段，修复 Fig15/16 因 alt 与文本 caption 高相似被误判为跨引擎重复段删除。
6. **assembly.py · orphan 公式策略2 扩展 inline**：覆盖 inline 独立短块（≤40 + 40-60 高数学密度）+ LaTeX→unicode 字形映射（仅认字形不认 ascii substring 避免 `\in`→"in" 误匹配），inline `$...$` 由 0 → 13。

## 验证
- **perceives 相关单测全过**：assembly / image_ref_normalizer / math_formula / html_math_preservation / pdf_batch_merge / table_quality_filter 共 164 passed。
- **ruff format/lint + mypy**：全绿（pre-commit 各 commit 均过）。
- **巡检复核**：23/23 图 0 缺失、全部章节标题（含短标题）完整、sec4 标题+导言、Fig15/16、表格正确、零轴/刻度/图例噪声、零元数据 chrome。

## 已知预存失败（非本 PR 引入，超范围）
- `test_config.py` 3 项：`concurrent_requests` 默认值 CPU 核数派生（yaml 16 / 本机算出 32），环境性。
- `test_docling_engine.py` 6 errors：docling 引擎 setup（库/MLX 可用性），环境性。
- 本 PR 仅触 3 文件（parse_pdf.py / assembly.py / formatter.py），未碰 config/docling。

## 收敛
剩余差异（嵌入散文的 ~257 行内数学需 span 级字号分析、脚注内联属 markdown 无分页范式）已正式列入 `pdf-fidelity-unfixable`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)