### PR TITLE
fix(perceives): PDF 高保真巡检修复 auto pipeline 图片落盘/算法去重/代码块边界/caption 去重

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/cli/commands/parse_pdf.py
@@ -15,40 +15,102 @@ except ImportError:
 
 
 def _copy_image_assets(result, output: str) -> None:
-    """将抽取的图片资产拷贝到 markdown 输出目录的 ``images/`` 子目录。
+    """将抽取的图片资产统一兜底拷贝到 markdown 输出目录的 ``images/`` 子目录。
 
-    传统（非 auto pipeline）路径把图片写到 ``EnhancedPDFProcessor.output_directory``
-    ——当上层未透传 ``output_dir`` 时即 ``tempfile.mkdtemp('enhanced_pdf_*')`` 临时目录。
-    此前 CLI 仅写 markdown 文本、不搬运图片资产，导致候选中 ``./images/<filename>``
-    引用全部死链。此处补齐资产落地，使 markdown 图片引用可达。
+    从 result 的所有已知图片来源收集图片实体，拷贝到 ``-o`` 同级 ``images/``，
+    使 markdown 中 ``./images/<filename>`` 引用可达。覆盖三类来源：
 
-    auto pipeline 路径自带 ``image_assets`` 落盘逻辑，其 ``enhanced_assets`` 结构不同，
-    ``output_directory`` 缺失时本函数直接 no-op，互不影响。
+    1. 传统 ``EnhancedPDFProcessor.output_directory``（上层未透传 ``output_dir`` 时
+       即 ``tempfile.mkdtemp('enhanced_pdf_*')`` 临时目录）。
+    2. auto/processor 路径 ``enhanced_assets["images"]["items"][].local_path``——
+       其图片实体由 image_extraction stage 写入 ``tempfile.mkdtemp('pdf_images_')``
+       临时目录；mineru 失败回退等场景下 ``output_directory`` 缺失，此前 CLI 直接
+       no-op，导致候选 ``./images/*`` 全部死链。
+    3. image_extraction stage 临时目录（若透传到 ``enhanced_assets["_temp_output_dir"]``）。
+
+    任一来源命中即拷贝；单图拷贝失败不中断整体落盘。
     """
     import shutil
     from pathlib import Path
 
     ea = getattr(result, "enhanced_assets", None) or {}
-    src_dir = ea.get("output_directory")
-    if not src_dir:
-        return
-    src_path = Path(src_dir)
-    if not src_path.is_dir():
-        return
     image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp"}
-    candidates = [
-        p for p in src_path.iterdir() if p.is_file() and p.suffix.lower() in image_exts
-    ]
-    if not candidates:
-        return
     images_dst = Path(output).resolve().parent / "images"
+
+    src_files: list = []
+    seen: set = set()
+
+    def _add_file(p) -> None:
+        if not p:
+            return
+        path = Path(str(p))
+        if (
+            path.is_file()
+            and path.suffix.lower() in image_exts
+            and str(path) not in seen
+        ):
+            seen.add(str(path))
+            src_files.append(path)
+
+    def _add_dir(d) -> None:
+        if not d:
+            return
+        path = Path(str(d))
+        if path.is_dir():
+            for p in path.iterdir():
+                if p.is_file() and p.suffix.lower() in image_exts:
+                    _add_file(p)
+
+    # 来源 1：传统 EnhancedPDFProcessor.output_directory
+    _add_dir(ea.get("output_directory"))
+
+    # 来源 2：auto/processor 路径 enhanced_assets["images"]（dict 或 list）
+    images_meta = ea.get("images")
+    if isinstance(images_meta, dict):
+        items = images_meta.get("items") or images_meta.get("files") or []
+    elif isinstance(images_meta, (list, tuple)):
+        items = images_meta
+    else:
+        items = []
+    for it in items:
+        if isinstance(it, dict):
+            _add_file(it.get("local_path"))
+        else:
+            _add_file(getattr(it, "local_path", None))
+
+    # 来源 3：image_extraction stage 临时目录（若已透传到 enhanced_assets）
+    _add_dir(ea.get("_temp_output_dir"))
+
+    # 来源 4：PDFResponse.image_assets（ImageAssetModel 列表，auto pipeline 路径）。
+    # enhanced_assets 在 auto 路径仅含 images_extracted 计数，图片实体路径在本字段。
+    image_assets_field = getattr(result, "image_assets", None) or []
+    sample_paths = []
+    if isinstance(image_assets_field, (list, tuple)):
+        for it in image_assets_field:
+            p = getattr(it, "image_path", None) or getattr(it, "local_path", None)
+            sample_paths.append(p)
+            _add_file(p)
+
+    if not src_files:
+        console.print(
+            "[yellow]图片资产落盘：未发现任何图片源"
+            f"（enhanced_assets keys={list(ea.keys())},"
+            f" image_assets={len(image_assets_field)},"
+            f" sample_paths={sample_paths[:3]}）"
+            "——候选 ./images/* 引用可能死链[/yellow]"
+        )
+        return
+
     images_dst.mkdir(parents=True, exist_ok=True)
-    for src in candidates:
+    copied = 0
+    for src in src_files:
         try:
             shutil.copy2(src, images_dst / src.name)
+            copied += 1
         except OSError:
             # 单图拷贝失败不应中断整体输出落盘（如只读源/目标磁盘满）。
             pass
+    console.print(f"[dim]图片资产落盘：{copied}/{len(src_files)} -> {images_dst}[/dim]")
 
 
 def run(

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -534,10 +534,51 @@ class MarkdownFormatter:
         try:
             markdown_content = self._format_code_blocks(markdown_content)
             markdown_content = self._strip_running_headers(markdown_content)
+            markdown_content = self._strip_orphan_lang_labels(markdown_content)
             return markdown_content
         except Exception as e:
             logger.warning(f"Error in fidelity-safe formatting: {str(e)}")
             return markdown_content
+
+    def _strip_orphan_lang_labels(self, markdown_content: str) -> str:
+        """移除 fence 外孤立的纯语言字面行（如独立成段的 ``python``）。
+
+        抽取引擎（docling 等）偶把代码块的 lang 名字面作为独立文本行输出、
+        或在围栏修复后遗留裸 lang 行，表现为 fenced code 块之后紧跟一至多行
+        仅含语言名（``python`` / ``fortran`` / ``json`` 等）的孤立段落，破坏
+        排版。本 pass 先用占位符保护所有 fenced 代码块（含其 ``​```lang``
+        info string 行），再删除正文中"整行仅为已知语言名"的孤立行，最后还原
+        代码块，确保不误删围栏 info string 与真实代码内容。
+        """
+        protected: Dict[str, str] = {}
+
+        def _protect(match: re.Match) -> str:
+            key = f"%%ORPHANLANG_{len(protected)}%%"
+            protected[key] = match.group(0)
+            return key
+
+        # 保护所有 fenced 代码块整体（含首行 ```lang 与内容）
+        text = re.sub(
+            r"^```[^\n]*\n.*?^```[ \t]*$",
+            _protect,
+            markdown_content,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        # 删除 fence 外整行仅为已知代码语言名的孤立行（大小写不敏感）。
+        # 仅收录歧义性低的编程语言名，排除 "text" 等常见英文单词避免误删正文。
+        _lang_names = (
+            "python|fortran|algorithm|javascript|typescript|java|kotlin|"
+            "golang|rust|ruby|php|perl|scala|swift|cpp|csharp|matlab|"
+            "yaml|toml|dockerfile|makefile|graphql|protobuf"
+        )
+        text = re.sub(
+            rf"(?im)^[ \t]*(?:{_lang_names})[ \t]*$\n?",
+            "",
+            text,
+        )
+        for key, block in protected.items():
+            text = text.replace(key, block)
+        return text
 
     def _protect_code_blocks(self, markdown_content: str) -> Tuple[str, Dict[str, str]]:
         """提取所有 fenced 代码块并替换为占位符，防止格式化管线修改其内容。

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -332,15 +332,30 @@ class BuiltinAssembler(PDFToolBase):
                                 break
                     if _skip:
                         continue
+                    # 边界修正：截断引擎误纳的尾部章节标题/引言正文
+                    _kept_code, _tail_text = _split_code_tail_section(
+                        code_block.code or ""
+                    )
                     elements.append(
                         _ContentElement(
                             reading_order=code_block.reading_order,
                             page_number=code_block.page_number,
                             element_type="code",
-                            content=_code_block_to_markdown(code_block),
+                            content=_code_block_to_markdown(
+                                code_block, code_override=_kept_code
+                            ),
                             code_block=code_block,
                         )
                     )
+                    if _tail_text:
+                        elements.append(
+                            _ContentElement(
+                                reading_order=code_block.reading_order + 0.5,
+                                page_number=code_block.page_number,
+                                element_type="text",
+                                content=_tail_text,
+                            )
+                        )
 
             # 图片：落入表格 bbox 的散落图片（如表格内 logo）应予跳过，
             # 因为表格的 Markdown 版本已包含完整文本内容。
@@ -514,7 +529,7 @@ class BuiltinAssembler(PDFToolBase):
 
             def _sort_key(
                 elem: _ContentElement,
-            ) -> Tuple[int, int, float, float, int]:
+            ) -> Tuple[int, int, float, float, float]:
                 page = elem.page_number if elem.page_number is not None else 0
                 page = max(0, page)
                 col = _column_map.get(id(elem), 0)
@@ -1246,7 +1261,7 @@ class _ContentElement:
 
     def __init__(
         self,
-        reading_order: int,
+        reading_order: float,
         page_number: int,
         element_type: str,
         content: str,
@@ -1993,7 +2008,9 @@ _CODE_LANG_HEADER_MAP = {
 """
 
 
-def _code_block_to_markdown(code_block: ExtractedCodeBlock) -> str:
+def _code_block_to_markdown(
+    code_block: ExtractedCodeBlock, code_override: Optional[str] = None
+) -> str:
     """将代码块转换为 Markdown 代码围栏。
 
     R9 修复：docling 部分 PDF 上把代码块首行 lang 名字（如 ``Python``）当作
@@ -2006,8 +2023,11 @@ def _code_block_to_markdown(code_block: ExtractedCodeBlock) -> str:
       允许尾随空白）→ 提升为 fence info string，从 body 移除首行。
 
     不在 :data:`_CODE_LANG_HEADER_MAP` 中的首行不会被吞掉，避免误删合法代码。
+
+    ``code_override`` 非空时替代 ``code_block.code`` 作为 body，供调用方对 code
+    body 做预处理（如截断引擎误纳的尾部章节标题/正文）后再走 lang 头推断。
     """
-    code = code_block.code or ""
+    code = code_override if code_override is not None else (code_block.code or "")
     lang = (code_block.language or "").strip().lower()
 
     # 拆首行用于 lang 头识别
@@ -2036,6 +2056,34 @@ def _code_block_to_markdown(code_block: ExtractedCodeBlock) -> str:
         return f"```{inferred_lang}\n{rest}\n```"
 
     return f"```\n{code}\n```"
+
+
+def _split_code_tail_section(code: str) -> Tuple[str, str]:
+    """检测 code body 尾部被引擎误纳的章节标题块并截断。
+
+    docling/marker 有时把代码块后续的章节标题（上下装饰线 + "N Title"）连同
+    引言正文一起纳入同一 code body。检测首处 "装饰线 + 数字标题" 边界，在装饰
+    线前截断：返回 ``(kept_code, tail_text)``，kept_code 为算法/代码主体；
+    tail_text 为误纳尾部清洗后的正文（去掉装饰线与裸章节标题行——裸标题通常在
+    块外已有规范 ``## N Title`` 版本，视为冗余丢弃）。无边界则 ``(code, "")``。
+    """
+    if not code:
+        return code, ""
+    m = re.search(r"\n[-=]{10,}\s*\n\d+\s+[A-Z][^\n]*", code)
+    if not m:
+        return code, ""
+    kept = code[: m.start()].rstrip()
+    tail_raw = code[m.start() :].strip()
+    tail_lines: List[str] = []
+    for ln in tail_raw.split("\n"):
+        s = ln.strip()
+        if re.match(r"^[-=]{10,}$", s):
+            continue  # 装饰线
+        if re.match(r"^\d+\s+[A-Z][^\n]{15,}$", s):
+            continue  # 裸章节标题行（冗余，块外已有 ## 版本）
+        tail_lines.append(ln)
+    tail_text = "\n".join(tail_lines).strip()
+    return kept, tail_text
 
 
 # PDF 点（pt）→ CSS 像素（px）转换因子：

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -2101,15 +2101,26 @@ def _split_code_tail_section(code: str) -> Tuple[str, str]:
     _cut = min(_starts)
     kept = code[:_cut].rstrip()
     tail_raw = code[_cut:].strip()
-    tail_lines: List[str] = []
+    # 按 PDF 硬换行拆行、过滤装饰线/裸标题后，把连续正文行用空格合并为单一
+    # 段落（PDF 为版面宽度而插入的硬换行不应在 markdown 中断成多段）；仅真正
+    # 空行（PDF 段落边界）才切分为新段落，段落间以空行分隔。
+    _paragraphs: List[str] = []
+    _cur: List[str] = []
     for ln in tail_raw.split("\n"):
         s = ln.strip()
+        if not s:
+            if _cur:
+                _paragraphs.append(" ".join(_cur))
+                _cur = []
+            continue
         if re.match(r"^[-=]{10,}$", s):
             continue  # 装饰线
         if re.match(r"^\d+\s+[A-Z][^\n]{15,}$", s):
             continue  # 裸章节标题行（冗余，块外已有 ## 版本）
-        tail_lines.append(ln)
-    tail_text = "\n".join(tail_lines).strip()
+        _cur.append(s)
+    if _cur:
+        _paragraphs.append(" ".join(_cur))
+    tail_text = "\n\n".join(_paragraphs).strip()
     return kept, tail_text
 
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -690,6 +690,55 @@ class BuiltinAssembler(PDFToolBase):
                 except ImportError:
                     pass
 
+            # 2.1.2 同页同编号算法块跨类型去重：多引擎（PyMuPDF 文本块 /
+            #   docling/marker code 块 / code_detection algorithm 块）可能各自
+            #   产出同一 "Algorithm N" 的内容，导致同一算法在候选 markdown 中
+            #   重复出现（如纯文本标题 + 乱码内容文本 + fortran 块 + algorithm
+            #   块）。策略：(a) 同 (页码, 编号) 的算法 code 块仅保留内容最长者；
+            #   (b) 同页已存在算法 code 块时，移除同页冗余文本块——含同编号
+            #   Algorithm 标题的（标题重复），或含算法行号模式（≥2 个 "N:"，
+            #   PyMuPDF 字符流常把算法多行挤成乱码文本）。
+            _algo_num_re = re.compile(r"Algorithm\s+(\d+)", re.IGNORECASE)
+            _algo_code_by_key: Dict[Tuple[int, str], List[int]] = {}
+            for _i, _e in enumerate(elements):
+                if _i in _algo_remove or _e.element_type != "code":
+                    continue
+                _m = _algo_num_re.search(_e.content or "")
+                if not _m:
+                    continue
+                _algo_code_by_key.setdefault((_e.page_number, _m.group(1)), []).append(
+                    _i
+                )
+            # (a) 同页同编号算法 code 块：保留内容最长者
+            for _idxs in _algo_code_by_key.values():
+                if len(_idxs) <= 1:
+                    continue
+                _ranked = sorted(
+                    _idxs,
+                    key=lambda i: len((elements[i].content or "").strip()),
+                    reverse=True,
+                )
+                for _i in _ranked[1:]:
+                    _algo_remove.add(_i)
+            # (b) 同页存在算法 code 块时，移除同页冗余文本块
+            _algo_page_nums: Dict[int, set] = {}
+            for _pg, _num in _algo_code_by_key:
+                _algo_page_nums.setdefault(_pg, set()).add(_num)
+            for _i, _e in enumerate(elements):
+                if _i in _algo_remove or _e.element_type != "text" or not _e.block:
+                    continue
+                _nums = _algo_page_nums.get(_e.page_number)
+                if not _nums:
+                    continue
+                _content = _e.block.text or ""
+                _m2 = _algo_num_re.search(_content)
+                if (
+                    (_m2 and _m2.group(1) in _nums)
+                    or re.search(r"(?:^|\n)\s*\d+:\s", _content)
+                    or len(re.findall(r"\d+:\s", _content)) >= 2
+                ):
+                    _algo_remove.add(_i)
+
             if _algo_remove:
                 elements = [e for i, e in enumerate(elements) if i not in _algo_remove]
                 # 新增的算法代码块需要在排序后的位置插入，重新排序

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1164,10 +1164,23 @@ class BuiltinAssembler(PDFToolBase):
                     )
                     if cap_match:
                         cap_text = cap_match.group(1)
-                        cap_norm = _normalize_for_dedup(cap_text)
-                        if cap_norm in _seen_caption:
+                        # 同编号 Figure/Table caption 不论长短只保留首份：
+                        # 不同源（docling/PyMuPDF）常给出完整版与截断版，整段
+                        # 归一化文本不同会漏去重，改以 "figure N" / "table N"
+                        # 编号作去重键（编号在论文中唯一，不会误伤不同图表）。
+                        _cap_num = re.match(
+                            r"(?:Table|Figure)\s+\d+", cap_text, re.IGNORECASE
+                        )
+                        cap_key = (
+                            _cap_num.group(0).lower()
+                            if _cap_num
+                            else _normalize_for_dedup(cap_text)
+                        )
+                        # 仅对 text 元素去重：image 元素即使 caption 重复也保留，
+                        # 避免同编号 caption 已记录时把图片本身丢弃。
+                        if cap_key in _seen_caption and elem.element_type == "text":
                             continue
-                        _seen_caption.add(cap_norm)
+                        _seen_caption.add(cap_key)
                 _dd.append(elem)
             elements = _dd
 
@@ -2061,19 +2074,33 @@ def _code_block_to_markdown(
 def _split_code_tail_section(code: str) -> Tuple[str, str]:
     """检测 code body 尾部被引擎误纳的章节标题块并截断。
 
-    docling/marker 有时把代码块后续的章节标题（上下装饰线 + "N Title"）连同
-    引言正文一起纳入同一 code body。检测首处 "装饰线 + 数字标题" 边界，在装饰
-    线前截断：返回 ``(kept_code, tail_text)``，kept_code 为算法/代码主体；
-    tail_text 为误纳尾部清洗后的正文（去掉装饰线与裸章节标题行——裸标题通常在
-    块外已有规范 ``## N Title`` 版本，视为冗余丢弃）。无边界则 ``(code, "")``。
+    docling/marker 有时把代码块后续的章节标题（上下装饰线 + "N Title"）或图表
+    caption（``Figure N:`` / ``Table N:``）连同后续正文一起纳入同一 code body。
+    检测首处边界并在其前截断：返回 ``(kept_code, tail_text)``，kept_code 为算法/
+    代码主体；tail_text 为误纳尾部清洗后的正文（去掉装饰线与裸章节标题行——裸
+    标题/重复 caption 通常在块外已有规范版本，由后续 2.7 去重处理）。识别两类
+    边界，取最早者：(1) "装饰线(≥10 个 -/=) + 数字标题"；(2) 行首 ``Figure N:``
+    / ``Table N:`` caption。无边界则 ``(code, "")``。
     """
     if not code:
         return code, ""
-    m = re.search(r"\n[-=]{10,}\s*\n\d+\s+[A-Z][^\n]*", code)
-    if not m:
+    _starts = []
+    m1 = re.search(r"\n[-=]{10,}\s*\n\d+\s+[A-Z][^\n]*", code)
+    if m1:
+        _starts.append(m1.start())
+    # code 块尾部误纳的图表 caption（行首 Figure N: / Table N:）
+    m2 = re.search(
+        r"\n\s*(?:Figure|Fig\.?|Table|Tab\.?)\s+\d+\s*[:.\-]",
+        code,
+        re.IGNORECASE,
+    )
+    if m2:
+        _starts.append(m2.start())
+    if not _starts:
         return code, ""
-    kept = code[: m.start()].rstrip()
-    tail_raw = code[m.start() :].strip()
+    _cut = min(_starts)
+    kept = code[:_cut].rstrip()
+    tail_raw = code[_cut:].strip()
     tail_lines: List[str] = []
     for ln in tail_raw.split("\n"):
         s = ln.strip()


### PR DESCRIPTION
## 背景

PDF→Markdown 高保真巡检（doc_id=666ea2ee-e817-46e5-9145-f6b6f94bd365，《Self-Harness》19 页学术论文）识别并修复 `auto` pipeline 路径下多处视觉保真缺陷。6 轮迭代逐一定点修复，每处均重转复核 + 非回归单测通过。

## 变更概述（6 处定点修复，触及 3 文件）

1. **CLI 图片资产落盘兜底** (`cli/commands/parse_pdf.py`)
   auto pipeline 路径 `enhanced_assets` 仅含 `images_extracted` 计数、`output_directory` 缺失，`_copy_image_assets` 旧逻辑 no-op 致候选 `./images/*` 全部死链。改为多源统一兜底：新增从 `PDFResponse.image_assets`（`ImageAssetModel.image_path`）拷贝图片实体分支 + 诊断日志。修复后图片 12/12 落盘可达。

2. **同页同编号算法块跨类型去重** (`pipeline/stages/pdf/assembly.py`)
   多引擎各自产出同一 "Algorithm N" 致三重重复。新增 2.1.2：同页同编号算法 code 块保留最长者 + 移除同页冗余算法文本块。

3. **代码块边界修正** (`assembly.py`)
   `_split_code_tail_section`：截断 docling/marker 误纳入 code body 的章节标题/引言正文，释放为独立节点。

4. **Figure caption 跨元素去重** (`assembly.py`)
   caption 去重改以 "figure N"/"table N" 编号作键（完整/截断版同键）；`_split_code_tail_section` 扩展识别 code 尾部 caption 边界。

5. **清除 fence 外孤立语言字面行** (`markdown/formatter.py`)
   `format_fidelity_safe` 新增 `_strip_orphan_lang_labels`：占位符保护 fenced 块后删除整行仅为编程语言名的孤立行（排除 text 等歧义词）。

6. **合并 code tail 释放正文的软换行段落** (`assembly.py`)
   tail 拼接改为连续正文行空格合并为单段、仅真正空行切分，修复引言正文被拆两段。

## 验证

- 文档收敛：Algorithm 1=1、Figure 3=1、孤立 lang 行=0、code fence 成对、图片 9 引用全部可达、章节结构完整。
- 非回归：assembly/formatter/code/caption 相关模块单测全通过（340 passed）。
- 说明：`test_config.py` 3 个失败与本 PR 无关（本地 `concurrent_requests=32` 配置覆盖默认值 16 的环境漂移，本 PR 未触及 config）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)