### PR TITLE
feat(Routine): 头部三栏合并为单栏，作用说明迁入 info Tooltip 且 KPI 改单行

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineHeader.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineHeader.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { Fragment } from "react";
 import { Info } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Tooltip } from "@/components/ui/Tooltip";
-import type { RoutineKpis } from "@/features/routine";
+import type { RoutineFilters, RoutineKpis } from "@/features/routine";
+
+import { RoutineFilterBar } from "./RoutineFilterBar";
 
 interface RoutineHeaderProps {
   connected: boolean;
@@ -15,88 +18,115 @@ interface RoutineHeaderProps {
   onFromPreset?: () => void;
   /** 聚合 KPI；为 null 且非 loading 时展示占位文案，loading 时展示骨架。 */
   kpis: RoutineKpis | null;
+  /** 筛选状态（status / q）；由页面 state 透传，变更触发列表 reset 回第 1 页。 */
+  filters: Partial<RoutineFilters>;
+  onFiltersChange: (filters: Partial<RoutineFilters>) => void;
 }
 
 interface KpiRow {
   label: string;
   value: string;
-  sub?: string;
   color?: string;
 }
 
-/** Tooltip 内的 KPI 紧凑网格；复用原卡片条的状态语义色，并补全 `cancelled` 计数。 */
-function KpiTooltipContent({ kpis, loading }: { kpis: RoutineKpis | null; loading: boolean }) {
-  // loading 且无数据 → 骨架占位（图标仍可见，提示「正在聚合」）。
-  if (loading && !kpis) {
-    return (
-      <div className="grid grid-cols-2 gap-x-4 gap-y-2 py-0.5" aria-busy="true">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="flex flex-col gap-1">
-            <Skeleton className="h-2.5 w-10" />
-            <Skeleton className="h-3.5 w-8" />
-          </div>
-        ))}
-      </div>
-    );
-  }
-  // 无数据（非 loading）→ 简短占位；图标仍展示，保持布局稳定。
-  if (!kpis) {
-    return <span className="text-text-secondary">暂无指标数据</span>;
-  }
+/** Tooltip 顶部的作用说明（原头部 <p>，迁入以收敛纵向空间）。 */
+const ROUTINE_DESCRIPTION =
+  "Long-horizon autonomous task execution — Engine orchestrates, Claude Code executes";
 
+/** 单行 KPI：语义色 + 中点分隔，chip 不内部断行；底部脚注保留唯一独有指标 avg iters。 */
+function KpiStats({ kpis }: { kpis: RoutineKpis }) {
   const rows: KpiRow[] = [
-    { label: "Total", value: String(kpis.total), sub: `${kpis.pending} pending` },
+    { label: "Total", value: String(kpis.total) },
     { label: "Running", value: String(kpis.running), color: "text-sky-400" },
     { label: "Paused", value: String(kpis.paused), color: "text-amber-400" },
     { label: "Succeeded", value: String(kpis.succeeded), color: "text-emerald-400" },
     { label: "Failed", value: String(kpis.failed), color: "text-red-400" },
     { label: "Cancelled", value: String(kpis.cancelled), color: "text-zinc-400" },
-    { label: "Total Cost", value: `$${kpis.total_cost_usd.toFixed(2)}`, sub: `avg ${kpis.avg_iterations} iters` },
+    { label: "Total Cost", value: `$${kpis.total_cost_usd.toFixed(2)}` },
   ];
 
   return (
-    <div className="grid grid-cols-2 gap-x-4 gap-y-2 py-0.5">
-      {rows.map((r) => (
-        <div key={r.label} className="min-w-0">
-          <div className="text-micro uppercase tracking-overline text-text-secondary">{r.label}</div>
-          <div className={`text-caption font-bold tabular-nums ${r.color ?? "text-white dark:text-zinc-100"}`}>
-            {r.value}
-          </div>
-          {r.sub && <div className="text-micro text-text-secondary">{r.sub}</div>}
-        </div>
-      ))}
-    </div>
+    <>
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        {rows.map((r, i) => (
+          <Fragment key={r.label}>
+            {i > 0 && (
+              <span className="select-none text-zinc-500" aria-hidden>
+                ·
+              </span>
+            )}
+            <span className="inline-flex items-baseline gap-1 whitespace-nowrap">
+              <span className="text-micro uppercase tracking-overline text-zinc-400">{r.label}</span>
+              <span className={`text-caption font-bold tabular-nums ${r.color ?? "text-white dark:text-zinc-100"}`}>
+                {r.value}
+              </span>
+            </span>
+          </Fragment>
+        ))}
+      </div>
+      <div className="mt-2 text-micro text-zinc-400">avg {kpis.avg_iterations} iters/run</div>
+    </>
   );
 }
 
-export function RoutineHeader({ connected, onRefresh, loading, onCreate, onFromPreset, kpis }: RoutineHeaderProps) {
+/** Tooltip：作用说明 → hairline → 单行 KPI / 骨架 / 占位。 */
+function KpiTooltipContent({ kpis, loading }: { kpis: RoutineKpis | null; loading: boolean }) {
   return (
-    <div className="flex items-center justify-between">
-      <div>
-        <h1 className="flex items-center gap-1.5 text-2xl font-bold text-foreground">
-          Routine
-          <Tooltip
-            side="right"
-            align="center"
-            contentClassName="w-72"
-            triggerProps={{ "aria-label": "Routine 运行指标" }}
-            content={<KpiTooltipContent kpis={kpis} loading={loading} />}
-          >
-            <Info className="h-4 w-4 text-text-muted hover:text-text-secondary" aria-hidden />
-          </Tooltip>
-        </h1>
-        <p className="text-sm text-text-muted">
-          Long-horizon autonomous task execution — Engine orchestrates, Claude Code executes
-        </p>
+    <>
+      <p className="text-caption leading-relaxed text-zinc-400">{ROUTINE_DESCRIPTION}</p>
+      <div className="my-2 h-px bg-white/10" />
+      {/* loading 且无数据 → 骨架占位（保持 Tooltip 形态稳定）。 */}
+      {loading && !kpis ? (
+        <div className="flex flex-wrap items-center gap-2" aria-busy="true">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <Skeleton key={i} className="h-3 w-12" />
+          ))}
+        </div>
+      ) : !kpis ? (
+        // 无数据（非 loading）→ 简短占位。
+        <span className="text-zinc-400">暂无指标数据</span>
+      ) : (
+        <KpiStats kpis={kpis} />
+      )}
+    </>
+  );
+}
+
+export function RoutineHeader({
+  connected,
+  onRefresh,
+  loading,
+  onCreate,
+  onFromPreset,
+  kpis,
+  filters,
+  onFiltersChange,
+}: RoutineHeaderProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+      {/* 标题 + 运行指标 info */}
+      <h1 className="flex shrink-0 items-center gap-1.5 text-2xl font-bold text-foreground">
+        Routine
+        <Tooltip
+          side="right"
+          align="start"
+          contentClassName="w-[28rem] max-w-[92vw]"
+          triggerProps={{ "aria-label": "Routine 运行指标" }}
+          content={<KpiTooltipContent kpis={kpis} loading={loading} />}
+        >
+          <Info className="h-4 w-4 text-text-muted hover:text-text-secondary" aria-hidden />
+        </Tooltip>
+      </h1>
+
+      {/* 筛选栏：居右、可伸缩；空间紧时最先让位（min-w 保证搜索输入框 min-w-[200px] 生效）。 */}
+      <div className="flex min-w-[240px] flex-1 flex-wrap items-center justify-end gap-2">
+        <RoutineFilterBar filters={filters} onChange={onFiltersChange} />
       </div>
 
-      <div className="flex items-center gap-3">
+      {/* 动作按钮组：不收缩、不内部换行 */}
+      <div className="flex shrink-0 items-center gap-3">
         {onFromPreset && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onFromPreset}
-          >
+          <Button variant="outline" size="sm" onClick={onFromPreset}>
             Template
           </Button>
         )}

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -23,7 +23,6 @@ import type {
 
 import { ClockProvider } from "./_components/ClockProvider";
 import { RoutineEditDrawer, drawerKey, type DrawerMode } from "./_components/RoutineEditDrawer";
-import { RoutineFilterBar } from "./_components/RoutineFilterBar";
 import { RoutineHeader } from "./_components/RoutineHeader";
 import { RoutineTable } from "./_components/RoutineTable";
 import { useRestartRoutine } from "./_components/useRestartRoutine";
@@ -240,16 +239,19 @@ function RoutinePageInner() {
       <div className="flex-1 overflow-auto">
         <ClockProvider active={clockActive}>
           <div className="space-y-5 px-6 py-6">
-            <RoutineHeader connected={connected} onRefresh={refresh} loading={loading} onCreate={() => setCreateOpen(true)} onFromPreset={() => router.push("/interface/routine/templates")} kpis={kpis} />
+            <RoutineHeader
+              connected={connected}
+              onRefresh={refresh}
+              loading={loading}
+              onCreate={() => setCreateOpen(true)}
+              onFromPreset={() => router.push("/interface/routine/templates")}
+              kpis={kpis}
+              // 筛选变更由 useInfiniteList 自动 reset 回第 1 页
+              filters={filters}
+              onFiltersChange={setFilters}
+            />
 
             {error && <ErrorBanner message={error} />}
-
-            <div className="min-w-[200px]">
-              <RoutineFilterBar
-                filters={filters}
-                onChange={setFilters} // 筛选变更由 useInfiniteList 自动 reset 回第 1 页
-              />
-            </div>
 
             <RoutineTable
               routines={routines}


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Routine 页头部纵向占用三段独立可视块（标题行 / 作用说明 / 筛选栏），挤压下方表格可见行数；info 图标 Tooltip 内 KPI 以两列网格呈 4 行高，不够紧凑整洁。
- 关联上下文：Routine 列表页交互与信息密度优化。

# 核心变更
- 头部由「标题+按钮 / 独立说明 / 独立筛选栏」三段竖向堆叠 → **单行三 cell**：`[Routine ℹ️]` · 居右可伸缩筛选栏 · 动作按钮组；外层 `flex flex-wrap`，窄屏优雅换行，纵向约省 52px（≈ 多露一行表格）。
- 作用说明文案（"Long-horizon autonomous task execution — Engine orchestrates, Claude Code executes"）从页面 `<p>` 移入 info 图标 Tooltip 顶部（muted）。
- `KpiTooltipContent` 重设计：说明 → hairline 分隔线 → **7 个 KPI 单行横排**（语义色 + `·` 中点分隔，每 chip `whitespace-nowrap` 防大数值断行）→ 底部 `avg N iters/run` 脚注（保留唯一独有指标）；loading/空态同步收敛为单行骨架与占位，Tooltip 形态稳定。
- Tooltip 宽度 `w-72` → `w-[28rem] max-w-[92vw]`，方向改 `side="right" align="start"`。
- `page.tsx` 向 `RoutineHeader` 透传 `filters/onFiltersChange`，移除独立筛选栏块与页面级 import；`RoutineFilterBar.tsx` 无需改动（现有 `flex flex-wrap` 直接嵌入）。

# 风险与回滚
- 主要风险：纯布局/样式重构，无逻辑/数据流变更；窄屏（< ~720px）下头部换行为 2~3 行（优雅降级，不撑破下方表格）。
- 回滚方式：`git revert 6938e3cb`。

# 验证证据
- 单元测试：无（UI 布局变更，无新逻辑分支）。
- 集成测试：无。
- E2E/Workflow：`pnpm exec eslint`（改动两文件）通过；`tsc -p tsconfig.json --noEmit` 返回 `EXIT=0`；pre-commit hooks（含 negentropy-ui ESLint）全部通过。
- 覆盖率/关键截图：实机视觉回归待补 —— info Tooltip 单行 KPI 排版、窄屏换行、深色模式对比，需借用户已认证 Chrome 主 profile 访问 `/interface/routine`（编辑页 AuthGuard，Agent 不得代为 OAuth）。

# 影响范围
- 前端：`apps/negentropy-ui` Routine 列表页头部与 info Tooltip（仅 `RoutineHeader.tsx`、`page.tsx`）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 实机视觉回归（info Tooltip 单行 KPI、窄屏 wrap、深色模式对比），确认后视情补截图。