### PR TITLE
feat(Routine): 优化列表页头脚间距、标题 Tooltip 与表格列宽截断

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineHeader.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineHeader.tsx
@@ -33,7 +33,7 @@ interface KpiRow {
 const ROUTINE_DESCRIPTION =
   "Long-horizon autonomous task execution — Engine orchestrates, Claude Code executes";
 
-/** 单行 KPI：语义色 + 中点分隔，chip 不内部断行；底部脚注保留唯一独有指标 avg iters。 */
+/** 单行 KPI：语义色 + 中点分隔，chip 不内部断行；avg iters/run 折叠为末位 chip 以维持单行。 */
 function KpiStats({ kpis }: { kpis: RoutineKpis }) {
   const rows: KpiRow[] = [
     { label: "Total", value: String(kpis.total) },
@@ -43,29 +43,27 @@ function KpiStats({ kpis }: { kpis: RoutineKpis }) {
     { label: "Failed", value: String(kpis.failed), color: "text-red-400" },
     { label: "Cancelled", value: String(kpis.cancelled), color: "text-zinc-400" },
     { label: "Total Cost", value: `$${kpis.total_cost_usd.toFixed(2)}` },
+    { label: "avg iters/run", value: String(kpis.avg_iterations) },
   ];
 
   return (
-    <>
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        {rows.map((r, i) => (
-          <Fragment key={r.label}>
-            {i > 0 && (
-              <span className="select-none text-zinc-500" aria-hidden>
-                ·
-              </span>
-            )}
-            <span className="inline-flex items-baseline gap-1 whitespace-nowrap">
-              <span className="text-micro uppercase tracking-overline text-zinc-400">{r.label}</span>
-              <span className={`text-caption font-bold tabular-nums ${r.color ?? "text-white dark:text-zinc-100"}`}>
-                {r.value}
-              </span>
+    <div className="flex items-baseline gap-x-2">
+      {rows.map((r, i) => (
+        <Fragment key={r.label}>
+          {i > 0 && (
+            <span className="select-none text-zinc-500" aria-hidden>
+              ·
             </span>
-          </Fragment>
-        ))}
-      </div>
-      <div className="mt-2 text-micro text-zinc-400">avg {kpis.avg_iterations} iters/run</div>
-    </>
+          )}
+          <span className="inline-flex items-baseline gap-1 whitespace-nowrap">
+            <span className="text-micro uppercase tracking-overline text-zinc-400">{r.label}</span>
+            <span className={`text-caption font-bold tabular-nums ${r.color ?? "text-white dark:text-zinc-100"}`}>
+              {r.value}
+            </span>
+          </span>
+        </Fragment>
+      ))}
+    </div>
   );
 }
 
@@ -73,12 +71,12 @@ function KpiStats({ kpis }: { kpis: RoutineKpis }) {
 function KpiTooltipContent({ kpis, loading }: { kpis: RoutineKpis | null; loading: boolean }) {
   return (
     <>
-      <p className="text-caption leading-relaxed text-zinc-400">{ROUTINE_DESCRIPTION}</p>
+      <p className="whitespace-nowrap text-caption leading-relaxed text-zinc-400">{ROUTINE_DESCRIPTION}</p>
       <div className="my-2 h-px bg-white/10" />
       {/* loading 且无数据 → 骨架占位（保持 Tooltip 形态稳定）。 */}
       {loading && !kpis ? (
-        <div className="flex flex-wrap items-center gap-2" aria-busy="true">
-          {Array.from({ length: 7 }).map((_, i) => (
+        <div className="flex items-center gap-2" aria-busy="true">
+          {Array.from({ length: 8 }).map((_, i) => (
             <Skeleton key={i} className="h-3 w-12" />
           ))}
         </div>
@@ -110,7 +108,7 @@ export function RoutineHeader({
         <Tooltip
           side="right"
           align="start"
-          contentClassName="w-[28rem] max-w-[92vw]"
+          contentClassName="w-max max-w-[92vw]"
           triggerProps={{ "aria-label": "Routine 运行指标" }}
           content={<KpiTooltipContent kpis={kpis} loading={loading} />}
         >

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -50,7 +50,17 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
 
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
-      <table className="w-full text-sm">
+      <table className="w-full table-fixed text-sm">
+        {/* 固定列宽：百分比合计 100%，随容器等比缩放；与 <th> 解耦，超长内容由单元格 truncate 截断。 */}
+        <colgroup>
+          <col className="w-[28%]" />
+          <col className="w-[12%]" />
+          <col className="w-[10%]" />
+          <col className="w-[9%]" />
+          <col className="w-[12%]" />
+          <col className="w-[15%]" />
+          <col className="w-[14%]" />
+        </colgroup>
         <thead>
           <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
             <th className="px-4 py-2.5 font-medium">Name</th>
@@ -70,15 +80,19 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
               className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
             >
               <td className="px-4 py-3">
-                <div className="font-medium text-foreground flex items-center gap-2">
-                  <span className="truncate">{r.display_name || r.title}</span>
+                <div className="flex min-w-0 items-center gap-2 font-medium text-foreground">
+                  <span className="min-w-0 flex-1 truncate" title={r.display_name || r.title}>
+                    {r.display_name || r.title}
+                  </span>
                   {r.key.startsWith("pdf-fidelity-patrol/") && (
                     <span className="inline-flex items-center rounded-full bg-violet-500/10 px-1.5 py-0.5 text-micro font-semibold text-violet-700 dark:text-violet-300 shrink-0">
                       巡检
                     </span>
                   )}
                 </div>
-                <div className="text-xs text-text-secondary">{r.key}</div>
+                <div className="truncate text-xs text-text-secondary" title={r.key}>
+                  {r.key}
+                </div>
               </td>
               <td className="px-4 py-3">
                 <div className="flex flex-wrap items-center gap-1.5">
@@ -107,25 +121,44 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                   )}
                 </div>
                 {r.termination_reason && (
-                  <div className="mt-0.5 text-xs text-text-secondary">{r.termination_reason}</div>
+                  <div className="mt-0.5 truncate text-xs text-text-secondary" title={r.termination_reason}>
+                    {r.termination_reason}
+                  </div>
                 )}
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
-                {r.iteration_count}
-                {r.max_iterations ? ` / ${r.max_iterations}` : ""}
+                <span
+                  className="block truncate"
+                  title={`${r.iteration_count}${r.max_iterations ? ` / ${r.max_iterations}` : ""}`}
+                >
+                  {r.iteration_count}
+                  {r.max_iterations ? ` / ${r.max_iterations}` : ""}
+                </span>
               </td>
               <td className={`px-4 py-3 font-semibold tabular-nums ${scoreColorClass(r.best_score)}`}>
-                {r.best_score ?? "—"}
+                <span className="block truncate" title={String(r.best_score ?? "—")}>
+                  {r.best_score ?? "—"}
+                </span>
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
-                ${r.total_cost_usd.toFixed(3)}
-                {r.max_cost_usd ? <span className="text-text-secondary"> / ${r.max_cost_usd}</span> : null}
+                <span
+                  className="block truncate"
+                  title={`$${r.total_cost_usd.toFixed(3)}${r.max_cost_usd ? ` / $${r.max_cost_usd}` : ""}`}
+                >
+                  ${r.total_cost_usd.toFixed(3)}
+                  {r.max_cost_usd ? <span className="text-text-secondary"> / ${r.max_cost_usd}</span> : null}
+                </span>
               </td>
               <td className="px-4 py-3 text-xs text-text-secondary">
-                {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+                <span
+                  className="block truncate"
+                  title={r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+                >
+                  {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+                </span>
               </td>
               <td className="px-4 py-3 text-right">
-                <div className="flex items-center justify-end gap-3">
+                <div className="flex flex-wrap items-center justify-end gap-3">
                   {onRestart && canRestart(r.status) && (
                     <button
                       type="button"

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -238,7 +238,7 @@ function RoutinePageInner() {
       <InterfaceNav title="Routine" />
       <div className="flex-1 overflow-auto">
         <ClockProvider active={clockActive}>
-          <div className="space-y-5 px-6 py-6">
+          <div className="space-y-2.5 px-6 py-3">
             <RoutineHeader
               connected={connected}
               onRefresh={refresh}


### PR DESCRIPTION
## 背景

Routine 列表页（`/interface/routine`）在视觉与信息密度上存在三处可优化点（见 issue 附图）：头部/底部留白偏松、标题 ⓘ Tooltip 折行、表格列宽随内容漂移且长标题无截断（NAME 列虽写了 `truncate`，但因父级无宽度约束而实际不生效）。本次做针对性收敛，**所有改动仅限 Routine 页内部，不影响其它页面**。

## 改动

### 1. 头/脚板块上下间隙减半
- `page.tsx` 内容区容器 `space-y-5 px-6 py-6` → `space-y-2.5 px-6 py-3`
- 一次性减半头部板块（nav↔header、header↔table）与底部翻页板块（table↔pagination、pagination↔底）共四个间隙；翻页栏自身 `py-2.5` 点击热区保持不动。

### 2. 标题 ⓘ Tooltip 三行单行
- `contentClassName` 由 `w-[28rem]` 改为 `w-max max-w-[92vw]`，宽度自适应最宽行（窄屏 92vw 兜底）
- 描述句加 `whitespace-nowrap`、KPI 统计容器去 `flex-wrap`，各行单行不折
- 将原独占脚注的 `avg iters/run` 折叠进统计 chip 行（作为第 8 个 chip），浮层由原 **4 行** 收敛为稳定 **3 行**（描述 / 分割线 / 单行统计）

### 3. 表格固定列宽 + 超长截断
- `<table>` 改 `table-fixed`，新增 `<colgroup>` 定义七列百分比列宽（28 / 12 / 10 / 9 / 12 / 15 / 14，合计 100%）
- Name / Status(termination_reason) / Progress / Best Score / Cost / Updated 各文本格超长截断 `...`，并以**原生 `title`** 悬停显示完整内容（沿用 `SchedulerTaskTable`、`RoutineIterationTimeline` 等既有约定；未在可点击行内引入 radix Tooltip 触发器，避免嵌套 `<button>` 与每行多 Provider/Portal 开销及 a11y 退化）
- 修复 NAME 列 `truncate` 失效问题（补 `min-w-0` / `flex-1`，外层 flex 容器补 `min-w-0`）
- actions 列改 `flex-wrap`，防极端窄列下按钮被外层 `overflow-hidden` 裁切

## 验证

- `pnpm typecheck`（`tsc --noEmit`）✅
- `pnpm lint`（`eslint --max-warnings=0`）✅
- `next dev` 编译 `/interface/routine` 路由：GET 200、日志无 error/fail/warn ✅
- pre-commit hooks（ESLint 等）全部 Passed ✅

> 视觉回归（间距减半 / Tooltip 三行不折 / 列宽稳定与截断）需登录态，建议在已认证 Chrome 主 profile 下打开 Routine 页复核；窄屏下确认列等比缩放、文本截断、actions 按钮换行不裁切。

## 影响半径

三处改动均在 `app/interface/routine/` 内部（`page.tsx`、`RoutineHeader.tsx`、`RoutineTable.tsx`），不波及其它表格或页面。
