### PR TITLE
feat(routine-ui): Routine 列表页表格改造（页脚计数/状态单行/ID 独立列/列宽收敛）

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -2,12 +2,14 @@
 
 import { ExternalLink, GitMerge, GitPullRequest, Loader2, OctagonX, RotateCcw, Trash2, X } from "lucide-react";
 
+import { CopyButton } from "@/components/ui/CopyButton";
 import { Skeleton } from "@/components/ui/Skeleton";
 import type { RoutineDTO } from "@/features/routine";
 
 import { canCancel, canCleanupWorktree, canRestart } from "./routine-controls";
 import {
   closedBadgeClass,
+  composeStatusTitle,
   mergedBadgeClass,
   openBadgeClass,
   routineStatusClass,
@@ -51,19 +53,22 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card">
       <table className="w-full table-fixed text-sm">
-        {/* 固定列宽：百分比合计 100%，随容器等比缩放；与 <th> 解耦，超长内容由单元格 truncate 截断。 */}
+        {/* 固定列宽：百分比合计 100%，随容器等比缩放；与 <th> 解耦，超长内容由单元格 truncate 截断。
+            8 列须与下方 <thead> 的 8 个 <th> 严格对齐（数量错配不报错但会静默错位所有列）。 */}
         <colgroup>
-          <col className="w-[28%]" />
-          <col className="w-[12%]" />
-          <col className="w-[10%]" />
-          <col className="w-[9%]" />
-          <col className="w-[12%]" />
-          <col className="w-[15%]" />
-          <col className="w-[14%]" />
+          <col className="w-[20%]" /> {/* Name */}
+          <col className="w-[15%]" /> {/* ID */}
+          <col className="w-[15%]" /> {/* Status */}
+          <col className="w-[7%]" /> {/* Progress */}
+          <col className="w-[7%]" /> {/* Best Score */}
+          <col className="w-[10%]" /> {/* Cost */}
+          <col className="w-[12%]" /> {/* Updated */}
+          <col className="w-[14%]" /> {/* Actions */}
         </colgroup>
         <thead>
           <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
             <th className="px-4 py-2.5 font-medium">Name</th>
+            <th className="px-4 py-2.5 font-medium">ID</th>
             <th className="px-4 py-2.5 font-medium">Status</th>
             <th className="px-4 py-2.5 font-medium">Progress</th>
             <th className="px-4 py-2.5 font-medium">Best Score</th>
@@ -90,41 +95,55 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                     </span>
                   )}
                 </div>
-                <div className="truncate text-xs text-text-secondary" title={r.key}>
-                  {r.key}
+              </td>
+              <td className="px-4 py-3">
+                {/* 任务 ID（独立列）：约半宽截断展示，全文经 title 悬浮恢复 + 一键复制。 */}
+                <div className="flex min-w-0 items-center gap-1">
+                  <span
+                    className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary"
+                    title={r.key}
+                  >
+                    {r.key}
+                  </span>
+                  <CopyButton value={r.key} ariaLabel="复制 ID" className="shrink-0" />
                 </div>
               </td>
               <td className="px-4 py-3">
-                <div className="flex flex-wrap items-center gap-1.5">
+                {/* 状态芯片单行展示：不折行，溢出由 overflow-hidden 右缘裁切；title 悬浮显示全文。 */}
+                <div
+                  className="flex min-w-0 items-center gap-1.5 overflow-hidden"
+                  title={composeStatusTitle(r)}
+                >
                   <span
-                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
+                    className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
                   >
                     {r.status}
                   </span>
                   {r.pr_merged && (
-                    <span className={mergedBadgeClass}>
+                    <span className={`${mergedBadgeClass} shrink-0`}>
                       <GitMerge className="h-3 w-3" aria-hidden />
                       Merged
                     </span>
                   )}
                   {r.pr_state === "closed" && (
-                    <span className={closedBadgeClass}>
+                    <span className={`${closedBadgeClass} shrink-0`}>
                       <X className="h-3 w-3" aria-hidden />
                       Closed
                     </span>
                   )}
                   {r.pr_state === "open" && (
-                    <span className={openBadgeClass}>
+                    <span className={`${openBadgeClass} shrink-0`}>
                       <GitPullRequest className="h-3 w-3" aria-hidden />
                       Open
                     </span>
                   )}
+                  {/* 终止原因：succeeded 恒配 "success"，与状态芯片冗余故略去；其余（失败原因）内联同行截断。 */}
+                  {r.termination_reason && r.termination_reason !== "success" && (
+                    <span className="min-w-0 truncate text-xs text-text-secondary">
+                      {r.termination_reason}
+                    </span>
+                  )}
                 </div>
-                {r.termination_reason && (
-                  <div className="mt-0.5 truncate text-xs text-text-secondary" title={r.termination_reason}>
-                    {r.termination_reason}
-                  </div>
-                )}
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
                 <span

--- a/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
+++ b/apps/negentropy-ui/app/interface/routine/_components/status-style.ts
@@ -22,6 +22,7 @@ import {
 
 import type {
   IterationStatus,
+  RoutineDTO,
   RoutineEventType,
   RoutineIterationEventDTO,
   RoutinePhase,
@@ -126,6 +127,25 @@ export const closedBadgeClass =
 /** 「PR 开启中（待合并）」徽章配色（sky/天蓝 = 活跃待处理；区别于 succeeded-绿/merged-紫/closed-灰/failed-红）。 */
 export const openBadgeClass =
   "inline-flex items-center gap-1 rounded-full bg-sky-500/10 px-2 py-0.5 text-micro font-semibold text-sky-700 dark:text-sky-300";
+
+/** 组合 STATUS 单元格的悬浮全文（单一事实源）：状态 + PR 态 + 非冗余终止原因。
+ *
+ * 按与列表渲染一致的真值条件拼接（`succeeded` 恒配 `termination_reason="success"`，故 success 视为冗余略去），
+ * 经 `filter(Boolean)` 剔除空段，避免 `pr_state="merged"` 或 `null` 原因产生悬空的「·」分隔。
+ * 供单行截断的 STATUS 单元格以原生 `title` 悬浮恢复被裁切内容。 */
+export function composeStatusTitle(
+  r: Pick<RoutineDTO, "status" | "pr_merged" | "pr_state" | "termination_reason">,
+): string {
+  return [
+    r.status,
+    r.pr_merged ? "Merged" : null,
+    r.pr_state === "closed" ? "Closed" : null,
+    r.pr_state === "open" ? "Open" : null,
+    r.termination_reason && r.termination_reason !== "success" ? r.termination_reason : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
 
 /** 迭代状态 → 状态点配色。 */
 export function iterationDotClass(status: IterationStatus): string {

--- a/apps/negentropy-ui/app/interface/routine/page.tsx
+++ b/apps/negentropy-ui/app/interface/routine/page.tsx
@@ -274,6 +274,8 @@ function RoutinePageInner() {
                   total={total ?? undefined}
                   itemLabel="routine"
                   disabled={loading}
+                  // 计数字号增至 12px（比页号 14px 稍小，比默认 10px 明显增大），提升可读性。
+                  countClassName="text-xs"
                 />
               </div>
             )}

--- a/apps/negentropy-ui/components/ui/CopyButton.tsx
+++ b/apps/negentropy-ui/components/ui/CopyButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * 通用「复制到剪贴板」图标按钮（Reuse-Driven / Single Source of Truth）。
+ *
+ * 收敛此前各处内联的 `useState` + `navigator.clipboard.writeText` + lucide `Copy`/`Check` 范式
+ * （如 scheduler `SchedulerHandlerSource`、`MessageBubble` 等）。复制成功后图标 `Copy → Check`
+ * 短暂切换（~2s 回退）。相较内联实现补齐无障碍：显式 `type="button"` + `aria-label`（复制后切至
+ * 「已复制」语义）；点击内 `stopPropagation`/`preventDefault`，使其安全嵌于可点击行/卡片而不冒泡触发父级。
+ */
+
+import { useCallback, useState } from "react";
+
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface CopyButtonProps {
+  /** 待复制到剪贴板的文本。 */
+  value: string;
+  /** 无障碍标签 + 原生 title（默认「复制」；复制后统一切至「已复制」）。 */
+  ariaLabel?: string;
+  /** 图标尺寸类（默认 `h-3.5 w-3.5`）。 */
+  iconClassName?: string;
+  /** 追加到按钮根节点的类（如 `shrink-0`）。 */
+  className?: string;
+}
+
+export function CopyButton({
+  value,
+  ariaLabel = "复制",
+  iconClassName = "h-3.5 w-3.5",
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      // 嵌于可点击行/卡片时，阻断冒泡与默认行为，避免触发父级 onClick（如行内打开详情）。
+      e.stopPropagation();
+      e.preventDefault();
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy to clipboard", err);
+      }
+    },
+    [value],
+  );
+
+  const label = copied ? "已复制" : ariaLabel;
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={label}
+      title={label}
+      className={cn(
+        "inline-flex items-center justify-center rounded p-1 text-text-muted transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      {copied ? (
+        <Check className={cn(iconClassName, "text-emerald-500")} aria-hidden />
+      ) : (
+        <Copy className={iconClassName} aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/apps/negentropy-ui/components/ui/Pagination.tsx
+++ b/apps/negentropy-ui/components/ui/Pagination.tsx
@@ -29,6 +29,9 @@ export interface PaginationProps {
   /** 无限滚动「向后追加」在途时，于控件旁渲染小 spinner（不阻断翻页）。 */
   loadingMore?: boolean;
   className?: string;
+  /** 计数文案的字号类（默认 `text-micro`=10px）。调用方可覆盖为 `text-xs` 等以增大计数字号。
+   *  注意：基类不再含字号类，故此处传入的字号不会与 `text-micro` 冲突（`cn` 为朴素拼接）。 */
+  countClassName?: string;
 }
 
 /**
@@ -62,12 +65,13 @@ export function Pagination({
   disabled = false,
   loadingMore = false,
   className,
+  countClassName = "text-micro",
 }: PaginationProps) {
   // 单页（或无数据）时不渲染翻页器；若提供了 total 则仅显示一行居中计数。
   if (totalPages <= 1) {
     if (total == null) return null;
     return (
-      <div className={cn("flex justify-center text-micro tabular-nums text-text-secondary", className)}>
+      <div className={cn("flex justify-center tabular-nums text-text-secondary", countClassName, className)}>
         {countLabel(total, itemLabel)}
       </div>
     );
@@ -85,7 +89,7 @@ export function Pagination({
       className={cn("flex items-center justify-center gap-4", className)}
     >
       {total != null && (
-        <span className="text-micro tabular-nums text-text-secondary">
+        <span className={cn("tabular-nums text-text-secondary", countClassName)}>
           {countLabel(total, itemLabel)}
         </span>
       )}

--- a/apps/negentropy-ui/tests/unit/features/routine/RoutineTable.test.tsx
+++ b/apps/negentropy-ui/tests/unit/features/routine/RoutineTable.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RoutineTable } from "@/app/interface/routine/_components/RoutineTable";
+import type { RoutineDTO } from "@/features/routine";
+
+/**
+ * RoutineTable 列表渲染单测——覆盖本轮改造的关键行为：
+ *  ① 任务 ID 独立列渲染 `key` + Copy 按钮；点击复制写入剪贴板且**不**触发行 `onSelect`（验证 stopPropagation）；
+ *  ② STATUS 单元格：`succeeded` 芯片存在，且冗余的 `success`（termination_reason）不再单独渲染；
+ *  ③ 非 success 的终止原因（如 `no_progress`）仍可见。
+ *
+ * 注意：jsdom 与 tests/setup.ts 均未提供 Clipboard API，故在此显式桩 `navigator.clipboard.writeText`。
+ */
+
+function makeRoutine(overrides: Partial<RoutineDTO> = {}): RoutineDTO {
+  return {
+    id: "id-1",
+    key: "pdf-fidelity-patrol/387cc29b-c08f-49a1-9fc1-995b2782abcd",
+    title: "PDF Fidelity Patrol · Demo",
+    display_name: null,
+    description: null,
+    goal: "g",
+    acceptance_criteria: "ac",
+    cwd: null,
+    baseline_branch: null,
+    repository_id: null,
+    verification_command: null,
+    status: "succeeded",
+    termination_reason: "success",
+    current_phase: null,
+    pr_url: null,
+    pr_merged: null,
+    pr_state: null,
+    work_branch: null,
+    worktree_path: null,
+    max_iterations: 400,
+    max_cost_usd: 1500,
+    deadline_at: null,
+    success_score_threshold: 85,
+    no_progress_patience: 3,
+    approval_mode: "auto",
+    iteration_count: 6,
+    total_cost_usd: 26.758,
+    best_score: 95,
+    last_score: 95,
+    claude_session_id: null,
+    reflections: [],
+    config: {},
+    owner_id: null,
+    agent_id: null,
+    created_at: null,
+    updated_at: "2026-07-01T22:57:52Z",
+    is_template: false,
+    ...overrides,
+  };
+}
+
+describe("RoutineTable", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    // jsdom 无 Clipboard API —— 显式桩，供 CopyButton 的 navigator.clipboard.writeText 调用。
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("任务 ID 独立列渲染 key + Copy 按钮；点击复制写剪贴板且不触发行 onSelect", () => {
+    const onSelect = vi.fn();
+    const r = makeRoutine();
+    render(
+      <RoutineTable routines={[r]} loading={false} onSelect={onSelect} onOpenFull={vi.fn()} />,
+    );
+
+    // ID 列展示完整 key（截断由 CSS 处理，DOM 文本仍是全量）。
+    expect(screen.getByText(r.key)).toBeInTheDocument();
+
+    // 存在带无障碍标签的 Copy 按钮。
+    const copyBtn = screen.getByRole("button", { name: "复制 ID" });
+    fireEvent.click(copyBtn);
+
+    // writeText 以完整 key 同步调用（在 await 挂起前）。
+    expect(writeText).toHaveBeenCalledWith(r.key);
+    // stopPropagation 生效：点击复制不冒泡触发行级 onSelect（打开详情）。
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("STATUS：succeeded 芯片存在，且冗余的 success 文案不再单独渲染", () => {
+    render(
+      <RoutineTable
+        routines={[makeRoutine({ status: "succeeded", termination_reason: "success" })]}
+        loading={false}
+        onSelect={vi.fn()}
+        onOpenFull={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("succeeded")).toBeInTheDocument();
+    // 冗余的 "success"（原 termination_reason 行）应被抑制。
+    expect(screen.queryByText("success")).not.toBeInTheDocument();
+  });
+
+  it("STATUS：非 success 的终止原因（no_progress）仍可见", () => {
+    render(
+      <RoutineTable
+        routines={[makeRoutine({ status: "failed", termination_reason: "no_progress" })]}
+        loading={false}
+        onSelect={vi.fn()}
+        onOpenFull={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText("no_progress")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 背景

`/interface/routine` 列表页在上一轮列宽截断优化（`a9fedbf9`）后仍存在四处体验问题：

1. **页脚计数字号过小**：`75 routines` 为 `text-micro`(10px)，在页号(14px)旁过小、可读性差。
2. **STATUS 列多行冗余**：`succeeded` 芯片与其下方的 `success` 文案重复（后端事实：`status="succeeded"` 时 `termination_reason` 恒为 `"success"`）；`Merged`/`Closed`/`Open` 因 `flex-wrap` 各自换行，单元格最多 3 行。
3. **Name 列塞入任务 ID**：`r.key` 挤在名称下方第二行，缺少复制入口。
4. **Progress / Best Score / Updated 列过宽**：内容短（`6 / 400`、`95`、时间戳）却占过多横向空间。

## 改动内容

| 需求 | 方案 | 关键文件 |
|---|---|---|
| 页脚计数增大 | `Pagination` 新增可选 `countClassName`（默认 `text-micro` 保持现状，**零波及其余 11 处调用**），routine 页传 `text-xs`(12px，页号 14px，计数稍小) | `components/ui/Pagination.tsx`、`app/interface/routine/page.tsx` |
| STATUS 单行 + 去冗余 | 去 `flex-wrap`+`overflow-hidden`+芯片 `shrink-0`；`succeeded` 恒配的 `success` 判为冗余抑制；新增 `composeStatusTitle` 助手做悬浮全文（避免悬空分隔） | `_components/RoutineTable.tsx`、`_components/status-style.ts` |
| 任务 ID 独立列 + Copy | `r.key` 从 Name 第二行拆为独立列（`font-mono` 截断 + `title` 全文 + Copy 按钮）；抽取共享 `CopyButton` 原语，归并既有两处内联实现范式，补齐 a11y（`type=button` / `aria-label` / `stopPropagation`，点击不误开行内详情） | `_components/RoutineTable.tsx`、`components/ui/CopyButton.tsx`(新) |
| 列宽收敛 | `colgroup`/`thead` 同步 7→8 列：Name20 / ID15 / Status15 / Progress7 / BestScore7 / Cost10 / Updated12 / Actions14 | `_components/RoutineTable.tsx` |
| 回归保护 | 新增 `RoutineTable.test.tsx`（jsdom 显式桩 clipboard）：复制不误开详情、`success` 抑制、失败原因可见 | `tests/unit/features/routine/RoutineTable.test.tsx`(新) |

## 设计要点

- **复用驱动 / 最小干预**：沿用本表既有的 `truncate` + 原生 `title` 悬浮范式（即本表约定的「Tooltip」），不引入 Radix Tooltip；共享 `Pagination` 被 12 处复用，采用**可选 prop** 选择性开启，避免波及其余页面。
- **单一事实源**：`composeStatusTitle` 以与渲染一致的真值条件拼接（`pr_state="merged"`/`null` reason 不产生悬空 `·`）。
- **CopyButton 抽取**：既有 `SchedulerHandlerSource`、`MessageBubble` 两处内联同款实现，本 PR 抽取为 `components/ui/CopyButton` 共享原语并补齐无障碍；迁移既有两处为后续跟进，不扩大本次改动面。

## 验证

- **单测**：`pnpm --filter negentropy-ui test run tests/unit/features/routine` → **50 passed**（含新增 3 条）。
- **类型检查 / Lint**：改动文件 0 错 0 警；pre-commit hooks（含 `ESLint (negentropy-ui)`）全 Passed。
- **实机 DOM 验证**（工作区 dev）：8 列对齐 ✓ ｜ 页脚计数 12px < 页号 14px ✓ ｜ STATUS `flex-wrap:nowrap`+`overflow:hidden`、`title="succeeded · Merged"`、0/10 单元格出现裸 `success` ✓ ｜ Copy 点击不触发行内详情（`urlChanged:false`、`drawerOpened:false`）✓

## 备注

- 「任务 ID」取 `r.key`（列表 Name 第二行所示 `{preset}/{uuid}` 或 slug）。若产品实指数据库 `r.id`，仅切换一处取值即可。
- 生产出口 `localhost:3192` 为主仓生产 `next-server`，本工作区改动需部署到主仓重新构建后才在 :3192 生效。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
