### PR TITLE
refactor(utils): cn 升级 tailwind-merge，根因修复 Routine Tooltip 宽度;

### DIFF
--- a/apps/negentropy-ui/components/ui/Tooltip.tsx
+++ b/apps/negentropy-ui/components/ui/Tooltip.tsx
@@ -63,8 +63,11 @@ export const TooltipContent = forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         // 复用 MentionPopover 的浮层令牌；z-[60] 与现有浮层层级一致。
+        // 注意：宽度策略（max-w-*）不在此硬编码——本仓 cn() 为朴素拼接（无 tailwind-merge），
+        // 若基类含 max-w-sm，调用方经 contentClassName 传入的 max-w-* 无法覆盖（二者共存、由源码序决胜）。
+        // 故宽度默认下沉至 Tooltip 包装器的 contentClassName 默认值，保证可被干净覆盖。
         className={cn(
-          "z-[60] max-w-sm rounded-md border border-border bg-zinc-800 px-3 py-2 text-caption text-white shadow-lg",
+          "z-[60] rounded-md border border-border bg-zinc-800 px-3 py-2 text-caption text-white shadow-lg",
           "dark:bg-zinc-700 dark:text-zinc-100",
           className,
         )}
@@ -86,7 +89,9 @@ export function Tooltip({
   sideOffset = 6,
   delayDuration = 150,
   skipDelayDuration = 120,
-  contentClassName,
+  // 宽度策略的单一事实源（默认值）：未显式传入时沿用 max-w-sm（短文本 hug、长文本 384px 处换行）。
+  // 需背板随内容撑宽者传 "w-max max-w-[..]" 即可干净覆盖（基类已不含 max-w-*）。
+  contentClassName = "max-w-sm",
   triggerProps,
 }: TooltipProps) {
   return (

--- a/apps/negentropy-ui/components/ui/button-styles.ts
+++ b/apps/negentropy-ui/components/ui/button-styles.ts
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 type OutlineButtonTone = "neutral" | "danger";
 
 const outlineButtonBaseClassName =
-  "border bg-background transition-colors transition-[color,background-color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+  "border bg-background transition-[color,background-color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
 
 const outlineButtonToneClassNames: Record<OutlineButtonTone, string> = {
   neutral:

--- a/apps/negentropy-ui/lib/utils.ts
+++ b/apps/negentropy-ui/lib/utils.ts
@@ -1,3 +1,58 @@
-export function cn(...classes: (string | undefined | null | false)[]) {
-  return classes.filter(Boolean).join(" ");
+import { clsx, type ClassValue } from "clsx";
+import { extendTailwindMerge } from "tailwind-merge";
+
+/**
+ * cn — 类名合并原语：`tailwind-merge(clsx(...))`。
+ *
+ * 设计要点：
+ * - **正确覆盖**：相较早期「朴素拼接」实现，能识别 Tailwind 冲突类并令后者覆盖前者
+ *   （如 `cn("px-2","px-4")→"px-4"`、`cn("max-w-sm","max-w-[92vw]")→"max-w-[92vw]"`）。
+ * - **自定义 token 适配**：tailwind-merge 默认配置按 Tailwind v3 对齐，不识本仓 `@theme`
+ *   自定义 token；此处经 {@link extendTailwindMerge} 显式登记，避免误判（详见下文）。
+ * - **签名兼容**：保留 `string | undefined | null | false` 入参，并扩展支持 clsx 的
+ *   数组/对象（ClassValue）写法；返回值仍为 `string`。
+ *
+ * 为何 font-size 必须登记到 `classGroups` 而非 `theme`：
+ * - 本仓 `@theme` 定义了字号 token `--text-{display,h1..h4,body-lg,body,caption,micro}`，
+ *   生成工具类 `text-caption` 等——与颜色 `text-{color}`（如 `text-white`）共享 `text-` 前缀。
+ * - tailwind-merge 的 `text-color` 组带「任意值校验器」会兜底匹配任意 `text-*`；
+ *   若不把自定义字号显式归入 `font-size` 组，`text-caption` 会被判为颜色，与 `text-white`
+ *   同串时丢其一（全仓 229 行存在 `text-{size}+text-{color}` 同串共现，关乎大面积回归）。
+ * - 实测 `extend.theme` 对 `font-size` 不生效（颜色校验器优先）；`extend.classGroups` 经
+ *   `mergeConfigProperties` 的 concat 语义追加，默认字号（xs/sm/lg/...）与任意值校验器全保留。
+ */
+const FONT_SIZE_CUSTOM = [
+  "display",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "body-lg",
+  "body",
+  "caption",
+  "micro",
+] as const;
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      // 关键：自定义字号归入 font-size 组，避免被 text-color 任意值校验器吞并。
+      "font-size": [{ text: [...FONT_SIZE_CUSTOM] }],
+      // 以下当前虽无同组共现冲突，登记以保证语义自洽、前向安全（concat 追加，不覆盖默认）：
+      rounded: [{ rounded: ["modal", "card", "control"] }],
+      tracking: [{ tracking: ["heading", "body", "default", "caption", "overline", "label"] }],
+      leading: [{ leading: ["body-lg", "body", "caption"] }],
+      animate: [{ animate: ["enter", "fade-in", "slide-in-right", "shimmer", "working-pulse"] }],
+      duration: [{ duration: ["fast", "base", "slow"] }],
+    },
+  },
+});
+
+/**
+ * 合并类名：去 falsy、解 clsx 结构、消解 Tailwind 冲突类（后者胜）。
+ * @param inputs 类名（支持字符串 / 条件布尔 / 数组 / 对象，详见 clsx ClassValue）。
+ * @returns 合并后的单一类名字符串。
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
 }

--- a/apps/negentropy-ui/package.json
+++ b/apps/negentropy-ui/package.json
@@ -34,6 +34,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@negentropy/agents-chat-core": "workspace:*",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "clsx": "^2.1.1",
     "cytoscape": "^3.33.3",
     "cytoscape-fcose": "^2.2.0",
     "d3-drag": "^3.0.0",
@@ -66,6 +67,7 @@
     "rxjs": "7.8.1",
     "sigma": "^3.0.3",
     "sonner": "^2.0.7",
+    "tailwind-merge": "^2.6.1",
     "three-spritetext": "^1.10.0",
     "zod": "3.24.4"
   },

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -252,7 +252,11 @@ describe("KnowledgeBasePage", () => {
     expect(summary).not.toHaveTextContent("chunks:");
     expect(summary.className).toContain("truncate");
     expect(summary.className).toContain("self-center");
-    expect(settingsButton.className).toContain("transition-colors");
+    // outline 按钮基类以 transition-[color,...]（任意值）声明过渡属性；
+    // cn 升级为 tailwind-merge 后同组冲突正确收敛为单一声明，断言依实际落地类。
+    expect(settingsButton.className).toContain(
+      "transition-[color,background-color,border-color,box-shadow]",
+    );
     expect(settingsButton.className).toContain("hover:bg-muted");
     expect(settingsButton.className).toContain("hover:text-foreground");
     expect(settingsButton.className).toContain("focus-visible:ring-2");

--- a/apps/negentropy-ui/tests/unit/lib/utils.test.ts
+++ b/apps/negentropy-ui/tests/unit/lib/utils.test.ts
@@ -1,0 +1,116 @@
+/**
+ * cn 单元测试 —— 锁定 `tailwind-merge(clsx(...))` 的合并契约。
+ *
+ * 重点回归约束：
+ * - Tailwind 冲突类「后者覆盖前者」（朴素拼接做不到，是本次升级动机）；
+ * - 自定义 @theme 字号 token（text-caption 等）不被 text-color 任意值校验器吞并
+ *   （全仓 229 行 text-{size}+text-{color} 同串共现，关乎大面积回归）；
+ * - 默认字号 / 任意值字号 / 颜色组行为不回归；
+ * - Routine Tooltip 真实类串：max-w 覆盖 + 字号与颜色并存。
+ */
+import { describe, it, expect } from "vitest";
+
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  describe("基础合并（clsx 语义）", () => {
+    it("拼接无冲突类", () => {
+      expect(cn("a", "b")).toBe("a b");
+    });
+
+    it("过滤 falsy 值", () => {
+      expect(cn("a", false, null, undefined, "", 0 as never, "b")).toBe("a b");
+    });
+
+    it("条件布尔表达式", () => {
+      expect(cn("a", false && "x", "b", true && "c")).toBe("a b c");
+    });
+
+    it("嵌套数组", () => {
+      expect(cn(["a", ["b", false && "c"], "d"])).toBe("a b d");
+    });
+
+    it("对象写法（ClassDictionary）", () => {
+      expect(cn({ a: true, b: false, c: true })).toBe("a c");
+    });
+  });
+
+  describe("Tailwind 冲突类：后者覆盖前者", () => {
+    it("padding 冲突", () => {
+      expect(cn("px-2", "px-4")).toBe("px-4");
+    });
+
+    it("任意值 max-width 覆盖具名（Routine Tooltip 背板宽度根因）", () => {
+      expect(cn("max-w-sm", "max-w-[92vw]")).toBe("max-w-[92vw]");
+    });
+
+    it("颜色冲突：后者胜", () => {
+      expect(cn("text-white", "text-zinc-400")).toBe("text-zinc-400");
+    });
+
+    it("默认字号冲突：后者胜", () => {
+      expect(cn("text-lg", "text-xl")).toBe("text-xl");
+    });
+  });
+
+  describe("自定义 @theme token 不被误判（核心回归约束）", () => {
+    // 229 处 text-{size} + text-{color} 同串共现——字号与颜色必须并存
+    it.each<[string, string]>([
+      ["text-caption", "text-white"],
+      ["text-caption", "text-zinc-400"],
+      ["text-micro", "text-sky-600"],
+      ["text-body", "text-foreground"],
+      ["text-body-lg", "text-primary"],
+      ["text-display", "text-primary"],
+      ["text-h2", "text-foreground"],
+      ["text-h4", "text-zinc-500"],
+    ])("%s + %s 并存（字号≠颜色）", (a, b) => {
+      expect(cn(a, b)).toBe(`${a} ${b}`);
+    });
+
+    it("自定义字号同组：后者覆盖前者", () => {
+      expect(cn("text-caption", "text-micro")).toBe("text-micro");
+    });
+
+    it("默认字号与自定义字号同组：后者覆盖", () => {
+      expect(cn("text-base", "text-caption")).toBe("text-caption");
+      expect(cn("text-caption", "text-base")).toBe("text-base");
+      expect(cn("text-xs", "text-caption")).toBe("text-caption");
+    });
+
+    it("任意值字号（text-[13px]）仍被识别为字号组", () => {
+      expect(cn("text-caption", "text-[13px]")).toBe("text-[13px]");
+    });
+
+    it.each(["rounded-modal", "tracking-overline", "animate-fade-in", "duration-base", "leading-body"])(
+      "%s 单独使用保留",
+      (cls) => {
+        expect(cn(cls)).toBe(cls);
+      },
+    );
+  });
+
+  describe("真实场景：Routine Tooltip 类串", () => {
+    const STRUCTURAL =
+      "z-[60] rounded-md border border-border bg-zinc-800 px-3 py-2 text-caption text-white shadow-lg dark:bg-zinc-700 dark:text-zinc-100";
+
+    it("结构类 + w-max/max-w-[92vw] 覆盖：字号与颜色并存、max-w 正确落地", () => {
+      const merged = cn(STRUCTURAL, "w-max max-w-[92vw]");
+      // 字号 text-caption 与颜色 text-white 必须并存（旧朴素拼接本就并存，升级后仍并存）
+      expect(merged).toContain("text-caption");
+      expect(merged).toContain("text-white");
+      // 宽度策略正确落地
+      expect(merged).toContain("w-max");
+      expect(merged).toContain("max-w-[92vw]");
+      expect(merged).not.toContain("max-w-sm");
+    });
+
+    it("即便基类仍残留 max-w-sm，调用方 max-w-[92vw] 亦能覆盖（cn 升级独立可修复）", () => {
+      // 模拟 fix#1 之前的旧基类（含 max-w-sm），验证 cn 升级本身即可消除宽度冲突
+      const oldBase = `${STRUCTURAL} max-w-sm`;
+      const merged = cn(oldBase, "w-max max-w-[92vw]");
+      expect(merged).toContain("max-w-[92vw]");
+      expect(merged).not.toContain("max-w-sm");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,13 +61,13 @@ importers:
         version: 11.1.8
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nextjs-toploader:
         specifier: ^3.7.15
-        version: 3.9.17(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 3.9.17(next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.0
         version: 19.2.3
@@ -146,7 +146,7 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        version: 16.2.6(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       identity-obj-proxy:
         specifier: ^3.0.0
         version: 3.0.0
@@ -204,6 +204,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       cytoscape:
         specifier: ^3.33.3
         version: 3.33.3
@@ -251,7 +254,7 @@ importers:
         version: 3.0.0
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@8.0.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -300,6 +303,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tailwind-merge:
+        specifier: ^2.6.1
+        version: 2.6.1
       three-spritetext:
         specifier: ^1.10.0
         version: 1.10.0(three@0.184.0)
@@ -366,7 +372,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       jsdom:
         specifier: ^28.0.0
         version: 28.1.0
@@ -8347,7 +8353,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@22.19.19)(@vitest/coverage-v8@4.1.6)(jsdom@27.4.0)(msw@2.14.6(@types/node@22.19.19)(typescript@5.9.3))(vite@6.4.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0))
+      vitest: 4.1.6(@types/node@20.19.41)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(vite@6.4.3(@types/node@20.19.41)(jiti@2.7.0)(lightningcss@1.32.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -9302,18 +9308,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9342,6 +9348,26 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-next@16.2.6(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.6
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      globals: 16.4.0
+      typescript-eslint: 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
@@ -9350,7 +9376,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9361,7 +9387,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -9376,18 +9402,18 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@1.21.7)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9402,7 +9428,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9411,9 +9447,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9425,7 +9461,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9455,6 +9491,33 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      hasown: 2.0.3
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11235,9 +11298,35 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-toploader@3.9.17(next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      postcss: 8.5.14
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      styled-jsx: 5.1.6(react@19.2.3)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.60.0
+      babel-plugin-react-compiler: 1.0.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  nextjs-toploader@3.9.17(next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      next: 16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 19.2.3
@@ -12280,6 +12369,11 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@babel/core': 8.0.1
+
+  styled-jsx@5.1.6(react@19.2.3):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.3
 
   stylis@4.4.0: {}
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`/interface/routine` 页头 info Tooltip 的背板（边框/底色）宽度锁死在 ~384px，说明文案与单行 KPI 溢出边框之外。根因为 `cn()` 为朴素字符串拼接、无 `tailwind-merge`，调用方经 `contentClassName` 传入的 `max-w-*` 覆盖被基类 `max-w-sm` 静默吞掉。
- 关联上下文：为本会话先前 Routine Tooltip 外科修复补齐**上游根因技术债**——将 `cn` 升级为 `twMerge(clsx(...))`，从源头消除该类「覆盖被吞」隐患（影响全仓 200+ 处 `cn` 调用）。

# 核心变更
- **`fix(Tooltip)` · `components/ui/Tooltip.tsx`**：将宽度策略从 `TooltipContent` 基类硬编码的 `max-w-sm` 下沉为 `Tooltip` 包装器 `contentClassName` 的可覆盖缺省值（默认仍 `max-w-sm`），使 `w-max max-w-[92vw]` 等调用方覆盖能干净生效——背板随内容宽度撑起。未传 `contentClassName` 的调用方行为不变。
- **`refactor(utils)` · `lib/utils.ts`**：`cn` 由朴素拼接升级为 `twMerge(clsx(...))`，正确处理 Tailwind 冲突类覆盖（`max-w-sm → max-w-[92vw]`、`px-2 → px-4`）；经 `extendTailwindMerge` 登记本仓 `@theme` 自定义 token——关键为 `font-size`（`display/h1..h4/body-lg/body/caption/micro`），避免 `text-caption` 等被 `text-color` 任意值校验器吞并（全仓 **229 处** `text-{size}+text-{color}` 同串共现）；另防御性登记 `rounded/tracking/leading/animate/duration`。
  - 关键决策：登记走 `extend.classGroups`（非 `extend.theme`）——读 `tailwind-merge@2.6.1` 源码确认 `mergeConfigProperties` 在该层 `concat` 追加，默认字号 `xs/sm/lg/...` 与任意值校验器全保留（`extend.theme` 实测对 `font-size` 不生效）。
- **`components/ui/button-styles.ts`**：移除 `transition-colors transition-[color,...]` 同串冗余（twMerge 升级暴露的**孤立**潜在缺陷，全仓仅此一处）。
- **测试**：新增 `tests/unit/lib/utils.test.ts`（27 例）锁定合并契约；同步修正 `KnowledgeBasePage.test.tsx` 中依赖旧朴素拼接的过窄断言。
- 依赖：新增 runtime deps `clsx@^2.1.1`、`tailwind-merge@^2.6.1`。

# 风险与回滚
- 主要风险：`cn` 为全仓 200+ 处调用的核心工具，tailwind-merge 对自定义 token 误判会静默丢类。已通过 `extendTailwindMerge` 精确登记 + 27 例契约测试 + 全量 954 例回归兜底；并主动扫除暴露出的 `button-styles.ts` 冗余。
- 回滚方式：`git revert b3b0ddbf d61e899b`（两提交相互独立、可分粒度回滚）。

# 验证证据
- 单元测试：`tests/unit/lib/utils.test.ts` 27 例全 PASS（字号/颜色并存、冲突后者覆盖、默认字号不回归、任意值字号识别、clsx 数组/对象结构兼容、Routine Tooltip 真实类串）。
- 集成测试：`pnpm test` 全量 **954/954 通过、0 回归**（含 KnowledgeBasePage、KgBuildProgressPill 等）。
- E2E/Workflow：未新增；`cn` 为纯逻辑改动，单测已全覆盖契约。
- 覆盖率/关键截图：隔离 CSS 复刻对照（修复前背板锁 384px、文字外溢；修复后边框完整包裹内容），截图存于 `.temp/tooltip-width-repro-before-after.png`（gitignored，可按需复跑）。

# 影响范围
- 前端：`negentropy-ui` —— `Tooltip` 原语、`cn` 工具、`button-styles`；所有经 `cn` 合并类的组件行为一致或更优（无视觉回归）。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 实机抽检（可选）：3192 现为主仓生产 standalone（非本工作区、无 HMR）；如欲肉眼验证，可另起本工作区 dev（空闲端口）配合已认证 Chrome，重点验 Routine Tooltip 背板宽度与 KnowledgeBase Settings 按钮过渡样式。
