### PR TITLE
fix(routine-ui): 表格 Tooltip 单行不折 + Actions 列单行且加宽

### DIFF
--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, GitMerge, GitPullRequest, Loader2, OctagonX, RotateCcw, T
 
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import type { RoutineDTO } from "@/features/routine";
 
 import { canCancel, canCleanupWorktree, canRestart } from "./routine-controls";
@@ -56,14 +57,15 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
         {/* 固定列宽：百分比合计 100%，随容器等比缩放；与 <th> 解耦，超长内容由单元格 truncate 截断。
             8 列须与下方 <thead> 的 8 个 <th> 严格对齐（数量错配不报错但会静默错位所有列）。 */}
         <colgroup>
-          <col className="w-[20%]" /> {/* Name */}
-          <col className="w-[15%]" /> {/* ID */}
-          <col className="w-[15%]" /> {/* Status */}
+          <col className="w-[19%]" /> {/* Name */}
+          <col className="w-[14%]" /> {/* ID */}
+          <col className="w-[14%]" /> {/* Status */}
           <col className="w-[7%]" /> {/* Progress */}
           <col className="w-[7%]" /> {/* Best Score */}
           <col className="w-[10%]" /> {/* Cost */}
-          <col className="w-[12%]" /> {/* Updated */}
-          <col className="w-[14%]" /> {/* Actions */}
+          <col className="w-[10%]" /> {/* Updated */}
+          {/* Actions：预留足够宽度容纳「最多 3 个并发按钮」（Restart/Terminate 互斥，故至多 Restart+Clean Up+Full View），单行不折。 */}
+          <col className="w-[19%]" /> {/* Actions */}
         </colgroup>
         <thead>
           <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
@@ -86,9 +88,9 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
             >
               <td className="px-4 py-3">
                 <div className="flex min-w-0 items-center gap-2 font-medium text-foreground">
-                  <span className="min-w-0 flex-1 truncate" title={r.display_name || r.title}>
-                    {r.display_name || r.title}
-                  </span>
+                  <TextTooltip content={r.display_name || r.title}>
+                    <span className="min-w-0 flex-1 truncate">{r.display_name || r.title}</span>
+                  </TextTooltip>
                   {r.key.startsWith("pdf-fidelity-patrol/") && (
                     <span className="inline-flex items-center rounded-full bg-violet-500/10 px-1.5 py-0.5 text-micro font-semibold text-violet-700 dark:text-violet-300 shrink-0">
                       巡检
@@ -97,87 +99,84 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                 </div>
               </td>
               <td className="px-4 py-3">
-                {/* 任务 ID（独立列）：约半宽截断展示，全文经 title 悬浮恢复 + 一键复制。 */}
+                {/* 任务 ID（独立列）：约半宽截断展示，全文经悬浮单行恢复 + 一键复制。 */}
                 <div className="flex min-w-0 items-center gap-1">
-                  <span
-                    className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary"
-                    title={r.key}
-                  >
-                    {r.key}
-                  </span>
+                  <TextTooltip content={r.key}>
+                    <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary">
+                      {r.key}
+                    </span>
+                  </TextTooltip>
                   <CopyButton value={r.key} ariaLabel="复制 ID" className="shrink-0" />
                 </div>
               </td>
               <td className="px-4 py-3">
-                {/* 状态芯片单行展示：不折行，溢出由 overflow-hidden 右缘裁切；title 悬浮显示全文。 */}
-                <div
-                  className="flex min-w-0 items-center gap-1.5 overflow-hidden"
-                  title={composeStatusTitle(r)}
-                >
-                  <span
-                    className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
-                  >
-                    {r.status}
-                  </span>
-                  {r.pr_merged && (
-                    <span className={`${mergedBadgeClass} shrink-0`}>
-                      <GitMerge className="h-3 w-3" aria-hidden />
-                      Merged
+                {/* 状态芯片单行展示：不折行，溢出由 overflow-hidden 右缘裁切；悬浮 Tooltip（单行）显示完整组合标题。 */}
+                <TextTooltip content={composeStatusTitle(r)}>
+                  <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                    <span
+                      className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
+                    >
+                      {r.status}
                     </span>
-                  )}
-                  {r.pr_state === "closed" && (
-                    <span className={`${closedBadgeClass} shrink-0`}>
-                      <X className="h-3 w-3" aria-hidden />
-                      Closed
-                    </span>
-                  )}
-                  {r.pr_state === "open" && (
-                    <span className={`${openBadgeClass} shrink-0`}>
-                      <GitPullRequest className="h-3 w-3" aria-hidden />
-                      Open
-                    </span>
-                  )}
-                  {/* 终止原因：succeeded 恒配 "success"，与状态芯片冗余故略去；其余（失败原因）内联同行截断。 */}
-                  {r.termination_reason && r.termination_reason !== "success" && (
-                    <span className="min-w-0 truncate text-xs text-text-secondary">
-                      {r.termination_reason}
-                    </span>
-                  )}
-                </div>
+                    {r.pr_merged && (
+                      <span className={`${mergedBadgeClass} shrink-0`}>
+                        <GitMerge className="h-3 w-3" aria-hidden />
+                        Merged
+                      </span>
+                    )}
+                    {r.pr_state === "closed" && (
+                      <span className={`${closedBadgeClass} shrink-0`}>
+                        <X className="h-3 w-3" aria-hidden />
+                        Closed
+                      </span>
+                    )}
+                    {r.pr_state === "open" && (
+                      <span className={`${openBadgeClass} shrink-0`}>
+                        <GitPullRequest className="h-3 w-3" aria-hidden />
+                        Open
+                      </span>
+                    )}
+                    {/* 终止原因：succeeded 恒配 "success"，与状态芯片冗余故略去；其余（失败原因）内联同行截断。 */}
+                    {r.termination_reason && r.termination_reason !== "success" && (
+                      <span className="min-w-0 truncate text-xs text-text-secondary">
+                        {r.termination_reason}
+                      </span>
+                    )}
+                  </div>
+                </TextTooltip>
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
-                <span
-                  className="block truncate"
-                  title={`${r.iteration_count}${r.max_iterations ? ` / ${r.max_iterations}` : ""}`}
-                >
-                  {r.iteration_count}
-                  {r.max_iterations ? ` / ${r.max_iterations}` : ""}
-                </span>
+                <TextTooltip content={`${r.iteration_count}${r.max_iterations ? ` / ${r.max_iterations}` : ""}`}>
+                  <span className="block truncate">
+                    {r.iteration_count}
+                    {r.max_iterations ? ` / ${r.max_iterations}` : ""}
+                  </span>
+                </TextTooltip>
               </td>
               <td className={`px-4 py-3 font-semibold tabular-nums ${scoreColorClass(r.best_score)}`}>
-                <span className="block truncate" title={String(r.best_score ?? "—")}>
-                  {r.best_score ?? "—"}
-                </span>
+                <TextTooltip content={String(r.best_score ?? "—")}>
+                  <span className="block truncate">{r.best_score ?? "—"}</span>
+                </TextTooltip>
               </td>
               <td className="px-4 py-3 tabular-nums text-text-secondary">
-                <span
-                  className="block truncate"
-                  title={`$${r.total_cost_usd.toFixed(3)}${r.max_cost_usd ? ` / $${r.max_cost_usd}` : ""}`}
+                <TextTooltip
+                  content={`$${r.total_cost_usd.toFixed(3)}${r.max_cost_usd ? ` / $${r.max_cost_usd}` : ""}`}
                 >
-                  ${r.total_cost_usd.toFixed(3)}
-                  {r.max_cost_usd ? <span className="text-text-secondary"> / ${r.max_cost_usd}</span> : null}
-                </span>
+                  <span className="block truncate">
+                    ${r.total_cost_usd.toFixed(3)}
+                    {r.max_cost_usd ? <span className="text-text-secondary"> / ${r.max_cost_usd}</span> : null}
+                  </span>
+                </TextTooltip>
               </td>
               <td className="px-4 py-3 text-xs text-text-secondary">
-                <span
-                  className="block truncate"
-                  title={r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
-                >
-                  {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
-                </span>
+                <TextTooltip content={r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}>
+                  <span className="block truncate">
+                    {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+                  </span>
+                </TextTooltip>
               </td>
               <td className="px-4 py-3 text-right">
-                <div className="flex flex-wrap items-center justify-end gap-3">
+                <div className="flex items-center justify-end gap-2 overflow-hidden">
                   {onRestart && canRestart(r.status) && (
                     <button
                       type="button"
@@ -185,7 +184,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                         e.stopPropagation();
                         onRestart(r);
                       }}
-                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <RotateCcw className="h-3 w-3" />
                       Restart
@@ -201,7 +200,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                         e.stopPropagation();
                         onCleanupWorktree(r);
                       }}
-                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-amber-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:no-underline dark:text-amber-400"
+                      className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-amber-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:no-underline dark:text-amber-400"
                     >
                       {cleanupBusyId === r.id ? (
                         <Loader2 className="h-3 w-3 animate-spin" />
@@ -218,7 +217,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                         e.stopPropagation();
                         onTerminate(r);
                       }}
-                      className="inline-flex cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-red-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-red-400"
+                      className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded text-[11px] font-medium text-red-600 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-red-400"
                     >
                       <OctagonX className="h-3 w-3" />
                       Terminate
@@ -230,7 +229,7 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
                       e.stopPropagation();
                       onOpenFull(r);
                     }}
-                    className="inline-flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-primary underline-offset-4 transition-colors hover:bg-muted/50 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    className="inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-primary underline-offset-4 transition-colors hover:bg-muted/50 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     Full View
                     <ExternalLink className="h-3 w-3" />

--- a/apps/negentropy-ui/components/ui/TextTooltip.tsx
+++ b/apps/negentropy-ui/components/ui/TextTooltip.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * TextTooltip — 行内「截断文本」的单行悬浮提示原语。
+ *
+ * 与通用 [[Tooltip]] 的分工（正交分解）：
+ * - **触发器**：通用 `Tooltip` 内部包成 `<button>`（适合图标/操作触发）；本原语用 `asChild` 以
+ *   调用方元素（如 `<span class="truncate">`）为触发器，语义中立、不额外占用 tab stop、适合表格
+ *   密集单元格。
+ * - **内容**：默认 `whitespace-nowrap` + `max-w-none`，**强制单行不折**（满足列表页「Tooltip 不折行」
+ *   要求）；通用 `Tooltip` 默认 `max-w-sm` 富文本可折行。
+ * - **溢出感知**：仅当触发元素实际溢出（`scrollWidth > clientWidth`）才展开，避免未截断的单元格
+ *   弹出冗余提示。
+ *
+ * Radix `Tooltip.Trigger asChild` v1.2 不对 span 强加 `tabindex`，故不会污染键盘 tab 序。
+ */
+
+import { useRef, useState, type ReactElement, type ReactNode } from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+type Side = "top" | "right" | "bottom" | "left";
+type Align = "start" | "center" | "end";
+
+export interface TextTooltipProps {
+  /** 浮层内容（单行展示）。 */
+  content: ReactNode;
+  /** 触发器元素（须能接收 ref 与事件合并，通常为带 `truncate` 的 `<span>` / `<div>`）。 */
+  children: ReactElement;
+  side?: Side;
+  align?: Align;
+  /** 触发器与浮层间距（px），默认 6。 */
+  sideOffset?: number;
+  /** 悬停到出现的延迟（ms），默认 150。 */
+  delayDuration?: number;
+  /** 离开后再次出现的跳过延迟（ms），默认 120。 */
+  skipDelayDuration?: number;
+  /** 关闭溢出感知（默认仅截断时展开）；置 false 则恒展开（供内容与可见文本不一致的场景，如 STATUS 组合标题）。 */
+  showOnOverflowOnly?: boolean;
+}
+
+export function TextTooltip({
+  content,
+  children,
+  side = "top",
+  align = "center",
+  sideOffset = 6,
+  delayDuration = 150,
+  skipDelayDuration = 120,
+  showOnOverflowOnly = true,
+}: TextTooltipProps) {
+  const [open, setOpen] = useState(false);
+  // Radix Trigger ref 类型为 HTMLButtonElement；asChild 时实际指向调用方元素（span/div），
+  // 仅访问 Element 级属性（scrollWidth/clientWidth），类型对齐避免 cast。
+  const trigRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setOpen(false);
+      return;
+    }
+    // 展开门控：溢出感知模式下，仅当触发元素实际截断才展开（消除冗余提示）。
+    if (showOnOverflowOnly) {
+      const el = trigRef.current;
+      setOpen(!!el && el.scrollWidth > el.clientWidth);
+    } else {
+      setOpen(true);
+    }
+  };
+
+  return (
+    <TooltipPrimitive.Provider delayDuration={delayDuration} skipDelayDuration={skipDelayDuration}>
+      <TooltipPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+        <TooltipPrimitive.Trigger asChild ref={trigRef}>
+          {children}
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            side={side}
+            align={align}
+            sideOffset={sideOffset}
+            className="z-[60] max-w-none whitespace-nowrap rounded-md border border-border bg-zinc-800 px-2.5 py-1.5 text-caption text-white shadow-lg dark:bg-zinc-700 dark:text-zinc-100"
+          >
+            {content}
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}


### PR DESCRIPTION
## 背景

承接 #1041（已合并，仅落入「列表页表格改造」首笔）之后，本轮在其基础上补齐 **Tooltip 单行不折** 与 **Actions 列单行** 两项收尾。本 PR 基于最新 `origin/feature/1.x.x`（已含 #1041 + #1042 `cn` 升级 tailwind-merge）重建分支，**cherry-pick 零冲突**。

## 改动内容

| 主题 | 方案 | 关键文件 |
|---|---|---|
| Tooltip 单行不折 | 新增 `TextTooltip` 原语：Radix `asChild` 元素触发器（语义中立、不占用 tab stop，区别于通用 `Tooltip` 的 button 触发器）；内容 `whitespace-nowrap` + `max-w-none` 强制单行；**溢出感知**（`scrollWidth>clientWidth` 才展开，未截断的单元格不弹冗余提示）。Name/ID/Status/Progress/Best Score/Cost/Updated 七列原生 `title` 迁移至此 | `components/ui/TextTooltip.tsx`(新)、`_components/RoutineTable.tsx` |
| Actions 单行 + 加宽 | `flex-wrap`→`nowrap` + `overflow-hidden` + 各按钮 `shrink-0`（保持原宽不被压扁）+ `gap-3→gap-2`；列宽 14%→**19%**（实测容纳「至多 3 个并发按钮」：Restart 与 Terminate 状态互斥，最大组合 Restart+Clean Up+Full View≈210px < 19%≈233px） | `_components/RoutineTable.tsx` |
| 列宽再平衡 | 让出 5%：Name/ID/Status/Updated 各 -1%→Actions +5%，合计仍 100% | 同上 |

## 与 #1042 的关系（无冲突）

#1042 将 `cn()` 升级为 tailwind-merge，并将通用 `Tooltip` 的 `max-w-sm` 从基类下沉至 `contentClassName` 默认值（使 button 触发器的通用 Tooltip 可经 `contentClassName` 干净覆盖宽度）。本 PR 的 `TextTooltip` 为**独立的 asChild-span 触发器原语**（面向表格密集单元格，#1042 未覆盖该场景），其内容类直接硬编码于 `TooltipPrimitive.Content`（不经 `cn` 叠加），故与 #1042 的 `cn`/通用 `Tooltip` 改动**正交、零冲突**——cherry-pick 实测干净应用。

## 验证

- **单测**：`tests/unit/features/routine` + `tests/unit/lib/utils.test.ts` → **77 passed**（含 #1042 新增的 `cn` tailwind-merge 用例）。
- **typecheck / ESLint**：改动文件 0 错 0 警。
- **实机 DOM**（工作区 dev）：8 列对齐 `[19,14,14,7,7,10,10,19]%` ✓ ｜ Actions `flex-wrap:nowrap`+`overflow:hidden`+按钮 `shrink-0` ✓ ｜ 内容列原生 `title` 全部迁移（仅余 CopyButton 的按钮 title）✓ ｜ ID 列实测 `scrollWidth 458 > clientWidth 114`（截断→触发 Tooltip）✓
- **透明说明**：Radix Tooltip 的 hover 弹出依赖真实指针事件，jsdom/CDP 自动化均无法可靠触发，故「浮层弹出且单行」由源码硬编码（`whitespace-nowrap`/`max-w-none`）+ Radix 既有生产行为保证；本地 `pnpm dev` 悬停即可复核。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
