### PR TITLE
fix(perceives): PDF→Markdown 高保真九项修复（88 页综述 R10 迭代）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -404,6 +404,45 @@ def _strip_orphan_styles(markdown_content: str) -> str:
     return text
 
 
+# ---------------------------------------------------------------------------
+# 散落 inline 数学字形（U+1D400–1D7FF Mathematical Alphanumeric Symbols）归一
+# ---------------------------------------------------------------------------
+#
+# LaTeX 学术 PDF 经 docling/PyMuPDF 抽取后，inline 数学常被发射为「空格分隔的
+# 孤立数学斜体字形」（如 ``A 𝑡 = ⟨ 𝑀 𝜃 𝑡, 𝐻 𝑡⟩``），既不被识别为公式也不渲染
+# 为数学体。``_normalize_unicode_math`` 把这类散落字形在 formatter 末段（所有
+# 清理 pass 之后、块公式/代码块还原之前）归一为 KaTeX 可渲染的 ``$...$``。
+
+# 单独成 token 时也判为「数学运算符 / 标点」的字符集（``_wrap_math_runs`` 分类用）。
+# 故意不含 ascii ``- * # | >`` —— 它们更常是列表标记 / 表格 / 引用 / 标题，强行吸附
+# 会破坏结构；数学减号用 U+2212（−）、星号用 U+2217（∗）。
+_MATH_OP_PUNCT_CHARS: frozenset[str] = frozenset(
+    "=+·×÷±∓∗∘⋆∝⊂⊃⊆⊇∪∩∧∨¬⊕⊗≈≠≡≅∼≺≻≪≫∥⊥→←↔⟹⟸⟺⟶⟵↦⇒⇔⟨⟩⌈⌉⌊⌋()[]{},.≤≥∈∉∀∃∂∇√∞′″−"
+)
+
+# 「数字 + 可选尾标点 / 括号」token（如 ``1,`` ``42.)`` ``1)``）—— 视作可被数学 run
+# 吸附的 ATTACHABLE，避免 ``𝑡 𝑖 − 1,`` 中的 ``1,`` 因带逗号被误判 PLAIN 断开 run。
+_NUM_ATTACH_RE = re.compile(r"^[0-9]+[.,;:!?\[\](){}]*$")
+
+# inline 数学 run 内常见、但不在 ``UNICODE_TO_LATEX`` / ``MATH_LETTER_TO_LATEX``
+# 的字符兜底映射。
+_MATH_RUN_EXTRA_MAP: Dict[str, str] = {
+    "−": "-",  # U+2212 MINUS SIGN → ascii hyphen（math mode 渲染为减号）
+    "∗": r"\ast",  # U+2217 ASTERISK OPERATOR
+    "′": "'",
+    "″": "''",
+}
+
+# 数学 run 结尾的散文标点（句末句点 / 逗号等）—— 剥离到 ``$...$`` 之外，避免
+# ``$Et.$`` 这种把句末标点吞进数学的失真。group1 = 数学主体，group2 = 尾标点。
+_RUN_TRAILING_PUNCT_RE = re.compile(r"^(.*?)([.,;:!?]+)$")
+
+
+def _has_math_alnum_block(s: str) -> bool:
+    """文本是否含 U+1D400–1D7FF 数学字母块任一字符（斜体 / 粗体 / 双线体 / Greek 等）。"""
+    return any(0x1D400 <= ord(c) <= 0x1D7FF for c in s)
+
+
 class MarkdownFormatter:
     """Markdown formatting pipeline for enhancing raw Markdown output."""
 
@@ -500,6 +539,11 @@ class MarkdownFormatter:
                 markdown_content = self._restore_video_placeholders(
                     markdown_content, video_registry
                 )
+
+            # 散落 inline 数学字形（U+1D400–1D7FF）归一为 ``$...$``：必须在所有清理
+            # pass 之后、块公式 / 代码块还原之前执行——此时二者仍是占位符（天然跳过），
+            # 已有 inline ``$..$`` 由 pass 内 split-and-skip 保护。
+            markdown_content = self._normalize_unicode_math(markdown_content)
 
             # 还原块级数学公式占位符（须在 _cleanup_math_blocks 之后，
             # 这样数学块整体仍由本管线统一治理，但 LaTeX 主体内容不被修改）
@@ -637,7 +681,10 @@ class MarkdownFormatter:
 
         def _replacer(match: re.Match) -> str:
             placeholder = f"%%MATHBLOCK_{uuid.uuid4().hex[:12]}%%"
-            protected[placeholder] = match.group(0)
+            # 在保护入库前清理 KaTeX 不兼容 primitive——保护后管线只见占位符，
+            # 故必须在此对真实 LaTeX 内容施加清理（``_cleanup_math_blocks`` 阶段
+            # 已是占位符，正则命不中）。见 _sanitize_katex_incompatible。
+            protected[placeholder] = self._sanitize_katex_incompatible(match.group(0))
             return placeholder
 
         # 匹配独占两行的 ``$$`` 定界符之间的块级公式
@@ -650,6 +697,19 @@ class MarkdownFormatter:
         )
         return result, protected
 
+    @staticmethod
+    def _sanitize_katex_incompatible(latex: str) -> str:
+        """剥离 KaTeX 不支持的 TeX primitive，保留可渲染主体。
+
+        docling/mineru 对 ``\\left(..\\right)`` 的冗长编码形如
+        ``\\mathopen { } \\mathclose \\bgroup \\left( .. \\aftergroup \\egroup \\right)``；
+        其中 ``\\aftergroup`` KaTeX 完全不支持 → ParseError。这些 primitive 无渲染
+        语义，逐个剥离后 ``\\left(..\\right)`` 主体照常渲染。
+        """
+        latex = re.sub(r"\\mathopen\s*\{\s*\}\s*\\mathclose", "", latex)
+        latex = re.sub(r"\\(?:aftergroup|bgroup|egroup)\b\s*", "", latex)
+        return latex
+
     def _restore_math_blocks(
         self, markdown_content: str, protected: Dict[str, str]
     ) -> str:
@@ -657,6 +717,168 @@ class MarkdownFormatter:
         for placeholder, original in protected.items():
             markdown_content = markdown_content.replace(placeholder, original)
         return markdown_content
+
+    # ------------------------------------------------------------------
+    # 散落 inline 数学字形（U+1D400–1D7FF）→ ``$...$`` 归一
+    # ------------------------------------------------------------------
+
+    def _normalize_unicode_math(self, markdown_content: str) -> str:
+        """把散落的 Unicode 数学字母块字形归一为 KaTeX 可渲染的 inline ``$...$``。
+
+        背景：LaTeX 学术 PDF 经 docling/PyMuPDF 抽取后，inline 数学常被发射为
+        「空格分隔的孤立数学斜体字形」（如 ``A 𝑡 = ⟨ 𝑀 𝜃 𝑡, 𝐻 𝑡⟩``）。本 pass
+        在 protect 之后、restore 之前对**非代码、非块公式、非标题/表格**的段落做：
+
+        1. 按空白切 token，识别「数学 run」（含数学字母 / 数学运算符 / 紧邻单字符
+           ASCII 字母数字），跨 run 合并并剔除 run 内部空白伪影；
+        2. run 内每字符经 ``MATH_LETTER_TO_LATEX`` + ``UNICODE_TO_LATEX`` + 兜底
+           映射为 LaTeX，``\\name`` 命令与后续 ASCII 字母间补空格；
+        3. 整体包裹 ``$...$``，单字符数学符号也独立包裹（``$t$ denotes``）。
+
+        已有 inline ``$...$`` 与块公式 / 代码块占位符原样跳过。
+
+        已知限制：PDF 抽取丢失了下标 / 上标的字号信息，故 ``M_{\\theta_t}`` 仅能
+        还原为 ``$M \\theta t$``（数学体渲染但下标结构不可恢复）；完整下标还原需
+        在 text_extraction 阶段基于 span 字号检测，属后续工作。
+
+        可用环境变量 ``PERCEIVES_UNICODE_MATH_NORMALIZE=0`` 整体禁用。
+        """
+        if os.environ.get("PERCEIVES_UNICODE_MATH_NORMALIZE", "1") == "0":
+            return markdown_content
+        from ..pdf.math_formula import MATH_LETTER_CHARS
+
+        if not MATH_LETTER_CHARS.intersection(markdown_content):
+            return markdown_content  # 快路径：无数学字母块字符
+        return "\n".join(
+            self._normalize_unicode_math_line(line)
+            for line in markdown_content.split("\n")
+        )
+
+    def _normalize_unicode_math_line(self, line: str) -> str:
+        stripped = line.lstrip()
+        # 跳过结构性行：标题 / 表格行 / 代码块占位符（数学字母在这些行罕见且易误包）
+        if (
+            stripped.startswith("#")
+            or stripped.startswith("|")
+            or stripped.startswith("%%CODEBLOCK_")
+        ):
+            return line
+        if not _has_math_alnum_block(line):
+            return line
+        # 块公式占位符 %%MATHBLOCK_..%% 无 ``$``；已有 inline ``$...$`` split-and-skip
+        parts = re.split(r"(\$[^$\n]+\$)", line)
+        return "".join(
+            part
+            if (len(part) >= 3 and part[0] == "$" and part[-1] == "$")
+            else self._wrap_math_runs(part)
+            for part in parts
+        )
+
+    def _wrap_math_runs(self, segment: str) -> str:
+        if not segment or not _has_math_alnum_block(segment):
+            return segment
+        tokens = segment.split(" ")
+        if len(tokens) <= 1:
+            return self._wrap_one_token(segment)
+
+        math_kind, attach_kind, plain_kind = "MATH", "ATT", "PLAIN"
+
+        def classify(tok: str) -> str:
+            if not tok:
+                return plain_kind
+            # 含数学字母块字符（斜体 / 粗体 / 双线体 / Greek 等）→ MATH
+            if _has_math_alnum_block(tok):
+                return math_kind
+            # 纯数学运算符 / 标点 token
+            if all((c in _MATH_OP_PUNCT_CHARS) or c.isspace() for c in tok):
+                return math_kind
+            # 单字符 ASCII 字母数字 —— 可被 run 吸附
+            if len(tok) == 1 and tok.isascii() and tok.isalnum():
+                return attach_kind
+            # 「数字 + 尾标点 / 括号」（1, 42.) 1)）—— 可被 run 吸附
+            if _NUM_ATTACH_RE.match(tok):
+                return attach_kind
+            return plain_kind
+
+        def wrap_run(run_str: str) -> str:
+            """包裹一个数学 run，剥离结尾散文标点（句末句点等）到 ``$...$`` 之外。"""
+            m = _RUN_TRAILING_PUNCT_RE.match(run_str)
+            if m and _has_math_alnum_block(m.group(1)):
+                return "$" + self._math_run_to_latex(m.group(1)) + "$" + m.group(2)
+            return "$" + self._math_run_to_latex(run_str) + "$"
+
+        kinds = [classify(t) for t in tokens]
+        out: List[str] = []
+        i, n = 0, len(tokens)
+        while i < n:
+            if kinds[i] == plain_kind:
+                out.append(tokens[i])
+                i += 1
+                continue
+            # 收集连续 MATH / ATTACHABLE
+            j = i
+            has_math = False
+            while j < n and kinds[j] in (math_kind, attach_kind):
+                if kinds[j] == math_kind:
+                    has_math = True
+                j += 1
+            if has_math:
+                out.append(wrap_run("".join(tokens[i:j])))
+            else:
+                # 全 ATTACHABLE（无数学字母）—— 不包裹，原样输出
+                out.extend(tokens[i:j])
+            i = j
+        return " ".join(out)
+
+    def _wrap_one_token(self, tok: str) -> str:
+        if not tok or not _has_math_alnum_block(tok):
+            return tok
+        m = _RUN_TRAILING_PUNCT_RE.match(tok)
+        if m and _has_math_alnum_block(m.group(1)):
+            return "$" + self._math_run_to_latex(m.group(1)) + "$" + m.group(2)
+        return "$" + self._math_run_to_latex(tok) + "$"
+
+    def _math_run_to_latex(self, run_text: str) -> str:
+        from ..pdf.math_formula import MATH_LETTER_TO_LATEX, UNICODE_TO_LATEX
+
+        def mapped_of(ch: str) -> str:
+            if ch in MATH_LETTER_TO_LATEX:
+                return MATH_LETTER_TO_LATEX[ch]
+            if ch in UNICODE_TO_LATEX:
+                return UNICODE_TO_LATEX[ch]
+            if ch in _MATH_RUN_EXTRA_MAP:
+                return _MATH_RUN_EXTRA_MAP[ch]
+            # 源文本中的裸花括号（如集合构造式 ``{ α | ... }``）是 KaTeX 分组符，
+            # 空格切分后跨 ``$...$`` 片段易失衡致 ParseError（``Expected '}'``）。
+            # 转义为字面 ``\{`` / ``\}``——既避免失衡，又是集合记号的正确渲染。
+            # 结构性花括号来自映射命令（``\mathbf{x}`` 等多字符串），``m == "{"``
+            # 仅当命中裸源花括号，不误伤。
+            if ch == "{":
+                return r"\{"
+            if ch == "}":
+                return r"\}"
+            return ch
+
+        # 预先把每个原字符映射为 LaTeX，再按「映射后」相邻关系补空格——
+        # 这样 ``\theta`` 后跟原字符 ``𝑡``（非 ASCII）但映射后是 ``t``（ASCII），
+        # 仍能正确补空格为 ``\theta t``，避免 ``\thetat`` 粘连。
+        mapped = [mapped_of(ch) for ch in run_text]
+        out_chars: List[str] = []
+        n = len(mapped)
+        for i, m in enumerate(mapped):
+            out_chars.append(m)
+            # 当前是 ``\name`` 命令且下一个**映射后** token 以 ASCII 字母起 → 补空格
+            if (
+                m
+                and m[0] == "\\"
+                and m[-1].isalpha()
+                and i + 1 < n
+                and mapped[i + 1]
+                and mapped[i + 1][0].isalpha()
+                and mapped[i + 1][0].isascii()
+            ):
+                out_chars.append(" ")
+        return "".join(out_chars)
 
     def _format_tables(self, markdown_content: str) -> str:
         """Format and align Markdown tables."""
@@ -938,6 +1160,60 @@ class MarkdownFormatter:
         """
         return self._UNICODE_BULLET_RE.sub(r"\1- \3", markdown_content)
 
+    # 段落中部 bullet 分隔符：两侧需有空白，按 ``\s[bullet]\s`` 切分整行。
+    _MID_BULLET_SPLIT_RE = re.compile(r"\s+[●○■□▪▫◦▶▷›▸▹·•‣]\s+")
+
+    def _split_mid_paragraph_bullets(self, markdown_content: str) -> str:
+        """把段落中部残留的多个 Unicode 项目符号拆分为独立列表项。
+
+        行首 bullet 由 :meth:`_normalize_unicode_bullets` 处理；但 PDF 抽取常把
+        原生列表 ``• 项A • 项B • 项C`` 压平进单一段落，段落**中部**的 bullet 不被
+        行首规则覆盖（R9 ``list_bullet_residue`` 中 672 个段中残留）。本 pass 把
+        ``前文 • 项A • 项B`` 拆为 ``前文`` + ``- 项A`` + ``- 项B``。
+
+        守卫（避免误伤）：
+          - 仅当单行含 **≥ 2** 个「两侧带空白」的 bullet 时才拆分（单 bullet 保守
+            保留，多为正文顺带符号）；
+          - 每个拆出的 item 必须含字母 / 数字实义字符，否则判定为 ``• • •`` 装饰型
+            省略号（如图注 ``T₀ T₁ • • • T₂``），整行原样保留；
+          - 跳过表格行（含 ``|``）、标题（``#``）、代码 / 数学占位符（``%%``）、引用
+            （``>``）——本 pass 在 ``_protect_code_blocks`` / ``_protect_math_blocks``
+            之后运行，二者已是占位符，天然跳过。
+        """
+
+        def _has_word(s: str) -> bool:
+            return any(c.isalnum() for c in s)
+
+        out_lines: List[str] = []
+        for line in markdown_content.split("\n"):
+            stripped = line.strip()
+            if (
+                not stripped
+                or "|" in line
+                or stripped.startswith("#")
+                or stripped.startswith("%%")
+                or stripped.startswith(">")
+            ):
+                out_lines.append(line)
+                continue
+            parts = self._MID_BULLET_SPLIT_RE.split(line)
+            # parts 数 = bullet 数 + 1；需 ≥ 2 个 bullet ⇒ ≥ 3 段
+            if len(parts) < 3:
+                out_lines.append(line)
+                continue
+            pre = parts[0]
+            items = parts[1:]
+            # 装饰型 ``• • •``：任一 item 无实义字符 ⇒ 整行保留
+            if not all(_has_word(it) for it in items):
+                out_lines.append(line)
+                continue
+            # 前文行：已是列表项（``- ``）则原样保留；否则作为独立段落 / 标签行
+            if pre.strip():
+                out_lines.append(pre.rstrip())
+            for it in items:
+                out_lines.append(f"- {it.strip()}")
+        return "\n".join(out_lines)
+
     def _format_lists(self, markdown_content: str) -> str:
         """Improve list formatting and nesting."""
         try:
@@ -947,6 +1223,10 @@ class MarkdownFormatter:
             # 如果不规范化，下游 react-markdown 不会把它当作 list item 渲染，
             # 而是塞到段落里造成视觉破坏（R9 量化签名 list_bullet_residue=877）。
             markdown_content = self._normalize_unicode_bullets(markdown_content)
+
+            # 段落中部残留的多 bullet（``前文 • 项A • 项B``）拆分为独立列表项，
+            # 覆盖行首规则漏掉的段中场景。
+            markdown_content = self._split_mid_paragraph_bullets(markdown_content)
 
             lines = markdown_content.split("\n")
             formatted_lines = []
@@ -1466,6 +1746,9 @@ class MarkdownFormatter:
         - 空公式块 ``$$\\n$$`` 移除
         - 单行过长的公式行截断（超过 2000 字符的行可能是重复模式残留）
         - ``\\quad`` 连续出现超过 4 次截断
+
+        注：KaTeX 不兼容 primitive（``\\aftergroup`` 等）的清理在
+        ``_protect_math_blocks`` 保护入库时施加（此阶段块公式已是占位符）。
         """
         try:
             # 移除空公式块

--- a/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py
@@ -718,6 +718,7 @@ async def _execute_slice_with_retry(
                 extract_formulas=extract_formulas,
                 embed_images=embed_images,
                 output_dir=output_dir,
+                slice_index=slice_index,
             )
             if getattr(result, "success", False):
                 return result

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/mineru.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/mineru.py
@@ -133,7 +133,11 @@ class MinerUEngine:
                      'hybrid-http-client' / 'vlm-auto-engine' / 'hybrid-auto-engine'），
                      为 None 时根据设备自动选择。
         """
-        self._output_dir = Path(output_dir) if output_dir else None
+        # 显式根目录（调用方指定）：每次 convert 在其下开唯一子目录，保持切片隔离；
+        # None 时每次 convert 用独立系统临时目录。``_output_dir`` 由 _ensure_output_dir
+        # 每次 convert 重写为本次调用的实际目录（供 _normalize_output 读取）。
+        self._explicit_output_root = Path(output_dir) if output_dir else None
+        self._output_dir: Optional[Path] = None
         self._device = device
         self._backend = backend
         self._resolved_backend: Optional[str] = None
@@ -351,11 +355,28 @@ class MinerUEngine:
         return result
 
     def _ensure_output_dir(self) -> Path:
-        """确保输出目录存在并返回路径。
+        """为**本次** convert 创建独立的干净输出目录并返回。
 
-        若未指定输出目录，自动创建临时目录。
+        关键不变量（ISSUE：auto_batch 跨切片公式/表格/图片泄漏）：MinerU 引擎实例
+        在 engine pool 中跨切片复用；``_normalize_output`` 经 ``_find_content_list``
+        的 ``rglob`` 读取输出目录。若多个切片共用同一目录，当某切片 MinerU 解析
+        未生成 ``content_list.json`` 时，``rglob`` 会命中**前一切片遗留**的
+        ``content_list.json``，使该切片静默继承上一切片的公式/表格/图片
+        （实测 pages 21-40 切片首部逐字出现 page-5 的 Section 2 公式簇）。
+
+        修复：每次 convert 都用独立子目录（``tempfile.mkdtemp``），彻底隔离切片间
+        产物。这样 MinerU 解析失败时该切片得到干净的"空目录 → None"结果并降级
+        docling，而非污染性地继承旧产物。显式 ``output_dir`` 亦在其下创建唯一子目录，
+        保持隔离同时尊重调用方指定的根路径。
         """
-        if self._output_dir is None:
+        if self._explicit_output_root is not None:
+            self._explicit_output_root.mkdir(parents=True, exist_ok=True)
+            self._output_dir = Path(
+                tempfile.mkdtemp(
+                    prefix="mineru_call_", dir=str(self._explicit_output_root)
+                )
+            )
+        else:
             self._output_dir = Path(tempfile.mkdtemp(prefix="mineru_output_"))
         self._output_dir.mkdir(parents=True, exist_ok=True)
         return self._output_dir

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
@@ -9,6 +9,7 @@
 
 import logging
 import re
+import string
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
@@ -275,6 +276,104 @@ _SUBSCRIPT_MAP: Dict[str, str] = {
     "ᵢ": "_{i}",
     "ⱼ": "_{j}",
 }
+
+# ---------------------------------------------------------------------------
+# 1b. 数学字母块（U+1D400–1D7FF Mathematical Alphanumeric Symbols）→ LaTeX
+# ---------------------------------------------------------------------------
+#
+# 背景：LaTeX 学术 PDF 经 docling/PyMuPDF 抽取后，inline 数学常被发射为该块的
+# 「孤立斜体字形」（如 ``𝑈 𝑡``、``𝐻 𝑡``、``𝜃``），既不被识别为公式也不渲染为
+# 数学体。formatter 阶段需要把这些散落字形归一为 KaTeX 可渲染的 ``$...$``。
+#
+# 注意：本组映射**不并入** ``UNICODE_TO_LATEX``，避免污染 ``has_math_unicode``
+# 与既有 ``unicode_to_latex`` 调用者（formula_extraction / docling engine）；
+# 仅供 formatter 的 ``_normalize_unicode_math`` pass 按需取用。
+
+# Latin 斜体 → 裸 ASCII（KaTeX 数学模式默认 italic，省 token）
+_MATH_ITALIC_LATIN_MAP: Dict[str, str] = {}
+for _i, _letter in enumerate(string.ascii_uppercase):  # A-Z: U+1D434..U+1D44D
+    _MATH_ITALIC_LATIN_MAP[chr(0x1D434 + _i)] = _letter
+for _i, _letter in enumerate(string.ascii_lowercase):  # a-z: U+1D44E..U+1D467
+    _cp = 0x1D44E + _i
+    if _cp == 0x1D455:  # MATHEMATICAL ITALIC SMALL H 保留位（用 U+210E 替身）
+        continue
+    _MATH_ITALIC_LATIN_MAP[chr(_cp)] = _letter
+_MATH_ITALIC_LATIN_MAP["ℎ"] = "h"  # ℎ PLANCK CONSTANT（italic h 替身）
+
+# Latin 粗体 → \mathbf{X}（保留粗体语义，常表向量 / 矩阵）
+_MATH_BOLD_LATIN_MAP: Dict[str, str] = {}
+for _i, _letter in enumerate(string.ascii_uppercase):  # A-Z: U+1D400..U+1D419
+    _MATH_BOLD_LATIN_MAP[chr(0x1D400 + _i)] = r"\mathbf{" + _letter + "}"
+for _i, _letter in enumerate(string.ascii_lowercase):  # a-z: U+1D41A..U+1D433
+    _MATH_BOLD_LATIN_MAP[chr(0x1D41A + _i)] = r"\mathbf{" + _letter + "}"
+
+# Italic Greek 小写（U+1D6FC..）→ \name（与 _GREEK_LOWER_MAP 同命令）
+_MATH_ITALIC_GREEK_LOWER_MAP: Dict[str, str] = {
+    "\U0001d6fc": r"\alpha",  # 𝛼
+    "\U0001d6fd": r"\beta",
+    "\U0001d6fe": r"\gamma",
+    "\U0001d6ff": r"\delta",
+    "\U0001d700": r"\epsilon",
+    "\U0001d701": r"\zeta",
+    "\U0001d702": r"\eta",
+    "\U0001d703": r"\theta",  # 𝜃
+    "\U0001d704": r"\iota",
+    "\U0001d705": r"\kappa",
+    "\U0001d706": r"\lambda",
+    "\U0001d707": r"\mu",
+    "\U0001d708": r"\nu",
+    "\U0001d709": r"\xi",
+    "\U0001d70b": r"\pi",  # 𝜋（U+1D70A omicron 保留，用裸 o）
+    "\U0001d70c": r"\rho",
+    "\U0001d70e": r"\sigma",  # 𝜎
+    "\U0001d70f": r"\tau",  # 𝜏
+    "\U0001d710": r"\upsilon",
+    "\U0001d711": r"\phi",
+    "\U0001d712": r"\chi",
+    "\U0001d713": r"\psi",
+    "\U0001d714": r"\omega",
+    "\U0001d716": r"\varepsilon",
+    "\U0001d717": r"\vartheta",
+    "\U0001d719": r"\varphi",
+}
+
+# Italic Greek 大写（U+1D6E2..）→ 裸 ASCII 或 \Name（与 LaTeX 数学大写 Greek 一致）
+_MATH_ITALIC_GREEK_UPPER_MAP: Dict[str, str] = {
+    "\U0001d6e2": r"A",
+    "\U0001d6e3": r"B",
+    "\U0001d6e4": r"\Gamma",
+    "\U0001d6e5": r"\Delta",
+    "\U0001d6e6": r"E",
+    "\U0001d6e7": r"Z",
+    "\U0001d6e8": r"H",
+    "\U0001d6e9": r"\Theta",
+    "\U0001d6ea": r"I",
+    "\U0001d6eb": r"K",
+    "\U0001d6ec": r"\Lambda",
+    "\U0001d6ed": r"M",
+    "\U0001d6ee": r"N",
+    "\U0001d6ef": r"\Xi",
+    "\U0001d6f0": r"O",
+    "\U0001d6f1": r"\Pi",
+    "\U0001d6f2": r"P",
+    "\U0001d6f3": r"\Sigma",
+    "\U0001d6f4": r"T",
+    "\U0001d6f5": r"\Upsilon",
+    "\U0001d6f6": r"\Phi",
+    "\U0001d6f7": r"X",
+    "\U0001d6f8": r"\Psi",
+    "\U0001d6f9": r"\Omega",
+}
+
+# 合并：所有「数学字母块」字符 → LaTeX（formatter 的 inline 数学归一 pass 取用）
+MATH_LETTER_TO_LATEX: Dict[str, str] = {}
+MATH_LETTER_TO_LATEX.update(_MATH_ITALIC_LATIN_MAP)
+MATH_LETTER_TO_LATEX.update(_MATH_BOLD_LATIN_MAP)
+MATH_LETTER_TO_LATEX.update(_MATH_ITALIC_GREEK_LOWER_MAP)
+MATH_LETTER_TO_LATEX.update(_MATH_ITALIC_GREEK_UPPER_MAP)
+
+# 散落 inline 数学字形的快速检测集
+MATH_LETTER_CHARS = frozenset(MATH_LETTER_TO_LATEX.keys())
 
 # 合并所有 Unicode→LaTeX 映射
 UNICODE_TO_LATEX: Dict[str, str] = {}

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/convenience.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/convenience.py
@@ -135,6 +135,15 @@ def _build_assembly_input(
         raise ValueError(
             "assembly 输入缺失或类型不符：preprocessing Stage 未产出 PreprocessingOutput"
         )
+    # slice_index 由 run_pdf_pipeline 注入 PreprocessingInput.config，供 assembly
+    # 2.1 标题级联判定是否「册封论文标题」（仅切片 0 册封）。
+    slice_index = 0
+    cfg = getattr(initial_input, "config", None)
+    if isinstance(cfg, dict):
+        try:
+            slice_index = int(cfg.get("slice_index", 0) or 0)
+        except (TypeError, ValueError):
+            slice_index = 0
     return AssemblyInput(
         preprocessing=preprocessing,
         layout=_unwrap(results.get("layout_analysis")),
@@ -143,6 +152,7 @@ def _build_assembly_input(
         formulas=_unwrap(results.get("formula_extraction")),
         images=_unwrap(results.get("image_extraction")),
         code=_unwrap(results.get("code_detection")),
+        slice_index=slice_index,
     )
 
 
@@ -450,6 +460,7 @@ async def run_pdf_pipeline(
     extract_formulas: bool = True,
     embed_images: bool = False,
     output_dir: Optional[str] = None,
+    slice_index: int = 0,
 ) -> PipelineResult:
     """执行 PDF -> Markdown 完整管线。
 
@@ -461,6 +472,10 @@ async def run_pdf_pipeline(
         extract_formulas: 是否提取公式
         embed_images: 是否嵌入图片
         output_dir: 输出目录
+        slice_index: auto_batch 切片序号（从 0 开始）。仅切片 0 允许在 assembly
+            2.1 级联中「册封论文标题」（首个 H1/H2 视为标题）；切片 >0 的首个标题
+            是普通章节标题，不得册封——否则每切片首标题被误升为 H1（ISSUE：
+            auto_batch 下 4.2 / 8 / References 误判 h1）。
 
     Returns:
         PipelineResult 包含 Markdown 内容和统计数据
@@ -508,6 +523,8 @@ async def run_pdf_pipeline(
             "extract_formulas": extract_formulas,
             "embed_images": embed_images,
             "output_dir": output_dir,
+            # auto_batch 切片序号：assembly 2.1 标题级联据此决定是否「册封论文标题」
+            "slice_index": slice_index,
         },
     )
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/models/_pdf.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/models/_pdf.py
@@ -462,6 +462,10 @@ class AssemblyInput:
     code: Optional[CodeDetectionOutput] = None
     """代码检测结果。"""
 
+    slice_index: int = 0
+    """auto_batch 切片序号（从 0 开始）。仅切片 0 允许在 2.1 标题级联中「册封论文
+    标题」；切片 >0 的首个标题是普通章节标题，不得升为 H1。非分批路径恒为 0。"""
+
 
 @dataclass
 class AssemblyOutput:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import html
 import logging
 import re
+import unicodedata
 from typing import Dict, List, Optional, Tuple
 
 from ...base import Stage, StageResult
@@ -29,6 +30,10 @@ from ...registry import register_tool
 from .._base import PDFToolBase
 
 logger = logging.getLogger(__name__)
+
+# 论文顶层结构标题 ``Part I. / Part II. ...``（罗马数字 + 句点）。用于 2.1a 段把
+# 四个 Part 归一到统一层级（H2），修复 docling 跨切片赋级不一致。
+_PART_HEADING_RE = re.compile(r"^Part\s+[IVXLCDM]+[.．:：]", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +144,13 @@ class BuiltinAssembler(PDFToolBase):
                 for formula in input_data.formulas.formulas:
                     if formula.latex and formula.page_number is not None:
                         sig = _formula_text_signature(formula.latex)
-                        if len(sig) >= 20:
+                        # 阈值降至 ≥6：短公式（如 ``A_t=⟨M,H,U,E⟩`` sig=10、
+                        # ``z_i=H_{t_i}(τ_i)`` sig=6）也需入库，供
+                        # ``_text_block_matches_formula`` 的**精确相等**快路径去重
+                        # PyMuPDF inline 文本流与 MinerU 块公式的并存副本（Q9）。
+                        # 短签名在子串匹配路径中因 ratio/≥20 门天然失活，仅参与
+                        # 精确相等去重，无假阳性放大。
+                        if len(sig) >= 6:
                             formula_text_signatures.setdefault(
                                 formula.page_number, []
                             ).append(sig)
@@ -581,7 +592,13 @@ class BuiltinAssembler(PDFToolBase):
             #     情况 A：首个标题为 H1 → 论文标题，后续标题下移一级
             #     情况 B：首个标题为 H2（学术论文常见）→ 提升为 H1 作为论文标题，
             #             后续标题也下移一级（与情况 A 相同）
-            _first_h1_seen = False
+            #
+            # auto_batch 修正：论文标题只在**首个切片**（slice_index==0）出现。切片
+            # >0 的首个标题是普通章节标题（如 ``8.`` / ``4.2`` / ``References``），
+            # 若仍走「册封论文标题」分支会被误升为 H1。故切片 >0 时预置
+            # ``_first_h1_seen=True``，使所有标题统一走「后续下移一级」路径，与切片 0
+            # 册封标题后的其余标题保持一致的层级基准（ISSUE：auto_batch 切片首标题误判 h1）。
+            _first_h1_seen = getattr(input_data, "slice_index", 0) > 0
             for elem in elements:
                 content = elem.content.strip()
                 if not content.startswith("#"):
@@ -600,6 +617,20 @@ class BuiltinAssembler(PDFToolBase):
                     new_level = min(level + 1, 5)
                     new_content = "#" * new_level + content[level:]
                     elem.content = new_content
+
+            # 2.1a Part 结构标题层级归一：``Part I. / Part II. ...`` 是论文顶层结构
+            #     节点（位于编号 section 之上）。docling 跨切片对其赋级不一致
+            #     （实测同一文档 Part I–III 为 h4、Part IV 为 h3），且经上方级联后
+            #     进一步偏移。统一钉为 H2，使四个 Part 在 wiki WikiToc（h2–h4）中
+            #     呈现为一致的顶层导航节点（ISSUE：Part 标题层级不一致 / 语义偏弱）。
+            for elem in elements:
+                content = elem.content.strip()
+                if not content.startswith("#"):
+                    continue
+                level = len(content) - len(content.lstrip("#"))
+                heading_body = content[level:].strip()
+                if _PART_HEADING_RE.match(heading_body):
+                    elem.content = "## " + heading_body
 
             # 2.1b 标题质量过滤：S3 text_extraction 常将双栏正文段落
             #     误判为 H3/H4 标题。识别特征：
@@ -1156,6 +1187,10 @@ class BuiltinAssembler(PDFToolBase):
             # ``Fig. N:`` / ``Table N:`` 起手的 caption 段落时，把邻接段
             # 文本注入到 image，复用 2.6 段的 caption-vs-text 去重移除
             # 独立 caption 段落，恢复 PDF 中"图旁有 caption"视觉。
+            #
+            # ``claimed_captions``：已被某张图片认领的 caption 归一化文本集，供同页
+            # 游离 caption 兜底避免两张图抢同一段。
+            claimed_captions: set[str] = set()
             for i, img_elem in enumerate(elements):
                 if img_elem.element_type != "image" or img_elem.image is None:
                     continue
@@ -1177,8 +1212,20 @@ class BuiltinAssembler(PDFToolBase):
                     image_has_caption=bool(existing_cap),
                     next_text_block_text=next_text_content,
                 )
+                # 邻接失败兜底：同页游离 caption 关联（ISSUE：Figure N | caption
+                # 与其图片在阅读序中相隔较远——中间夹标题 / 分栏文本，邻接搜索遇
+                # 非 text 元素即中断）。当图片仍无 caption 时，在**同一页**范围内
+                # 搜索一个 ``Figure N |`` / ``Table N |`` 起手且尚未被其它图片认领
+                # 的游离 text 段，将其注入。仅在该页恰有唯一 captionless 图片时启用，
+                # 避免多图页误配（本文档 Figure 8 位于 p39：图在页首、caption 漂到
+                # ~90 行后，邻接兜底够不到）。
+                if injected is None and not existing_cap:
+                    injected = _find_same_page_orphan_caption(
+                        img_elem, elements, claimed_captions
+                    )
                 if injected is None:
                     continue
+                claimed_captions.add(_normalize_for_dedup(injected))
                 img_elem.image.caption = injected
                 img_elem.content = _image_to_markdown(img_elem.image)
                 logger.debug(
@@ -1265,7 +1312,7 @@ class BuiltinAssembler(PDFToolBase):
                             if alt_html:
                                 cap_source = html.unescape(alt_html.group(1))
                     cap_match = re.search(
-                        r"((?:Table|Figure)\s+\d+[:.][^\n]+)",
+                        r"((?:Table|Figure)\s+\d+\s*[:.|｜∣][^\n]+)",
                         cap_source,
                         re.IGNORECASE,
                     )
@@ -1506,7 +1553,16 @@ def _formula_text_signature(s: str) -> str:
     PyMuPDF 把 LaTeX 视觉渲染区抽成"字符流文本"时，对每个字形（含上下标）
     保留为独立字符，与 MinerU 提取的 LaTeX 字符序列（同样把 ``M _ { l }``
     拆为 ``M l`` 等）经归一化后几乎完全相同。该签名作为跨形式等价锚点。
+
+    NFKD 归一（关键）：PyMuPDF 抽取的 inline 公式常为 Unicode 数学字母块字形
+    （``A 𝑡 = ⟨ 𝑀 𝜃 𝑡 ...⟩``，U+1D400–1D7FF），旧实现仅保留 ASCII 会把
+    ``𝑡/𝑀/𝐻`` 等全部丢弃，签名坍缩为 ``a``，与 MinerU 的 LaTeX 块签名
+    ``atmthtutet`` 不匹配 → 两份公式并存（同一公式既有 PyMuPDF inline 文本流
+    又有 MinerU ``$$`` 块）。NFKD 把数学字母块折叠为 ASCII 兼容字符（``𝑡→t``、
+    ``𝑀→M``、``𝔼→E``），使两种形式签名一致，R8 跨形式去重方能命中。
     """
+    # NFKD 折叠 Unicode 数学字母块 → ASCII 兼容字符（跨形式签名对齐前提）
+    s = unicodedata.normalize("NFKD", s)
     # 先剥离开 \begin{...} / \end{...} 及其紧随的列规格 {...}（版式结构噪声）
     s = re.sub(r"\\(?:begin|end)\s*\{[^{}]*\}(?:\s*\{[^{}]*\})?", "", s)
     # 剥离 \xxx LaTeX 命令
@@ -1534,14 +1590,23 @@ def _text_block_matches_formula(
     若仅满足前置条件但 ``len_ratio < 0.85``，认为公式只是被嵌入更长正文段，
     属于"公式埋在长正文段"假阳性，保守保留文本块不予过滤。
 
-    仅在公式签名 ≥20 字符且文本块归一化后 ≥20 字符时启用，
+    子串匹配仅在公式签名 ≥20 字符且文本块归一化后 ≥20 字符时启用，
     避免短公式 / 短文本互相假阳性。
+
+    精确相等快路径（Q9）：短公式（如 ``A_t = ⟨M,H,U,E⟩`` 签名仅 10 字符）的
+    PyMuPDF inline 文本流与 MinerU ``$$`` 块并存时，签名 **完全相等** 而非仅子串。
+    完全相等是极强信号——整个文本块字符级恰好等于某公式（同页），几乎不可能是
+    正文巧合。故 ``text_sig == fsig`` 且 ≥6 字符时直接判为冗余，绕过 20 字符门。
     """
     page = block.page_number
     sigs = formula_signatures.get(page)
     if not sigs:
         return False
     text_sig = _formula_text_signature(block.text or "")
+    # 精确相等快路径：文本块签名恰好等于某公式签名 → 标准的"公式被同时抽成
+    # inline 文本流 + 块公式"冗余（Q9）。要求 ≥6 字符防超短巧合。
+    if len(text_sig) >= 6 and text_sig in sigs:
+        return True
     if len(text_sig) < 20:
         return False
     for fsig in sigs:
@@ -1651,8 +1716,10 @@ def _is_caption_duplicate(text: str, caption_norm: str, all_captions: set[str]) 
     return False
 
 
+# caption 分隔符：冒号 / 句点 / 连字符 / 竖线（``Figure 8 | ...`` 是本文档及大量
+# arXiv 论文的常见写法）。含 ASCII ``|`` 与全角 ``｜`` / 数学竖线 ``∣``。
 _FIGURE_TABLE_CAPTION_RE = re.compile(
-    r"^\s*(Figure|Fig\.?|Table|Tab\.?)\s+\d+\s*[:.\-]",
+    r"^\s*(Figure|Fig\.?|Table|Tab\.?)\s+\d+\s*[:.\-|｜∣]",
     re.IGNORECASE,
 )
 
@@ -1744,6 +1811,54 @@ def _figure_caption_to_inject(
     if not _is_figure_or_table_caption_text(text):
         return None
     return text
+
+
+def _find_same_page_orphan_caption(
+    img_elem: "_ContentElement",
+    elements: List["_ContentElement"],
+    claimed_captions: set[str],
+) -> Optional[str]:
+    """邻接兜底失败时，在**同一页**范围内为 captionless 图片寻找游离 caption。
+
+    背景：``Figure N |`` caption 与其图片在阅读序中可能相隔很远（中间夹章节标题
+    / 分栏文本），2.5.7 的邻接搜索遇非 text 元素即中断，够不到。典型如本文档
+    Figure 8（p39）：图在页首、caption 漂到约 90 行后。
+
+    策略（保守，避免多图页误配）：
+      - 仅在该图所在页**恰有唯一** captionless 图片时启用；
+      - 仅认领该页 ``Figure N |`` / ``Table N |`` 起手、尚未被其它图片认领
+        （``claimed_captions``）的 caption 段；
+      - 该页存在 ≥2 个此类游离 caption 时不认领（无法确定对应关系，交由后续
+        dedup 保留为独立段落，不制造错配）。
+
+    Returns:
+        应注入的 caption 文本（已 strip），无合适候选时 ``None``。
+    """
+    page = img_elem.page_number
+    # 同页 captionless 图片数：>1 则放弃（无法确定 caption 归属）
+    captionless_imgs_on_page = [
+        e
+        for e in elements
+        if e.element_type == "image"
+        and e.image is not None
+        and e.page_number == page
+        and not (e.image.caption or "").strip()
+    ]
+    if len(captionless_imgs_on_page) != 1:
+        return None
+    # 同页游离 caption 候选：Figure/Table N | 起手、未被认领的 text 段
+    candidates = [
+        (e.content or "").strip()
+        for e in elements
+        if e.element_type == "text"
+        and e.block is not None
+        and e.page_number == page
+        and _is_figure_or_table_caption_text((e.content or "").strip())
+        and _normalize_for_dedup((e.content or "").strip()) not in claimed_captions
+    ]
+    if len(candidates) != 1:
+        return None
+    return candidates[0]
 
 
 def _is_running_header_footer(text: str, page_number: Optional[int] = None) -> bool:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
@@ -210,6 +210,51 @@ def _expand_figure_bbox(
         return seed_bbox
     seed_area = seed_w * seed_h
 
+    # ── Step 0: 收集"正文段落"bbox（长文本块）────────────────────────
+    # 用于 Step 1/2 排除"内容容器型"矢量/文本：figure 的装饰矢量（细线、
+    # 列标题底纹、子标签盒）绝不包裹整段正文，而论文的 Abstract 底纹框 /
+    # 侧栏底色框会包裹长段落。若一个候选矢量把某长段落包在内部，说明它是
+    # 内容容器而非 figure 装饰，吸纳它会把该正文段一并烘进图片（实测
+    # Self-Improving Agents Figure 1 的 seed 上方紧邻 Abstract 底纹框，
+    # 吸纳后整段 Abstract 被烘入 figure PNG，与正文文本重复）。
+    # 阈值 ``_LONG_PARAGRAPH_CHARS`` 远高于 short_text_max_chars（80），
+    # 确保只排除真正的正文段落，不误伤多行长标签 / caption。
+    _LONG_PARAGRAPH_CHARS = 200
+    _para_bboxes: List[Tuple[float, float, float, float]] = []
+    _blocks_for_para = (
+        text_dict.get("blocks", []) if isinstance(text_dict, dict) else []
+    )
+    for _blk in _blocks_for_para:
+        if not isinstance(_blk, dict) or _blk.get("type", 0) != 0:
+            continue
+        _bb = _blk.get("bbox")
+        if not _bb or len(_bb) < 4:
+            continue
+        _tlen = 0
+        for _ln in _blk.get("lines", []):
+            for _sp in _ln.get("spans", []):
+                _tlen += len(_sp.get("text", ""))
+        if _tlen < _LONG_PARAGRAPH_CHARS:
+            continue
+        try:
+            _para_bboxes.append(tuple(float(v) for v in _bb[:4]))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+
+    def _encloses_paragraph(dx0: float, dy0: float, dx1: float, dy1: float) -> bool:
+        """候选矩形是否包裹（≥60% 面积覆盖）某个正文长段落 → 判为内容容器。"""
+        for px0, py0, px1, py1 in _para_bboxes:
+            pw, ph = px1 - px0, py1 - py0
+            if pw <= 0 or ph <= 0:
+                continue
+            ox0, oy0 = max(dx0, px0), max(dy0, py0)
+            ox1, oy1 = min(dx1, px1), min(dy1, py1)
+            if ox1 <= ox0 or oy1 <= oy0:
+                continue
+            if (ox1 - ox0) * (oy1 - oy0) / (pw * ph) >= 0.6:
+                return True
+        return False
+
     # ── Step 1: 矢量吸纳 ────────────────────────────────────────────
     search_y_top = sy0 - vertical_search_pt
     search_y_bot = sy1 + vertical_search_pt
@@ -239,6 +284,9 @@ def _expand_figure_bbox(
         drawing_w = dx1 - dx0
         # 以 drawing 自身宽度为分母的重叠比，过滤"擦边但不相关"的横向装饰线
         if h_overlap / max(drawing_w, 1e-6) < min_drawing_h_overlap_ratio:
+            continue
+        # 内容容器排除：该矢量包裹正文长段落（如 Abstract 底纹框）→ 不吸纳
+        if _encloses_paragraph(dx0, dy0, dx1, dy1):
             continue
         ex0 = min(ex0, dx0)
         ey0 = min(ey0, dy0)

--- a/apps/negentropy-perceives/tests/unit/test_assembly_helpers.py
+++ b/apps/negentropy-perceives/tests/unit/test_assembly_helpers.py
@@ -196,6 +196,25 @@ class TestFormulaTextSignature:
         # PyMuPDF 字符流文本经签名后应包含 LaTeX 签名（完整或前缀子串）
         assert sig_latex in sig_text or sig_text in sig_latex
 
+    def test_unicode_math_block_folds_to_ascii_signature(self) -> None:
+        """NFKD 折叠：PyMuPDF 抽取的 Unicode 数学字母块 inline 形式与 MinerU
+        LaTeX 块形式签名应一致，使 R8 跨形式去重命中（Q9：否则两份公式并存）。
+
+        旧实现仅保留 ASCII，会把 ``𝑡/𝑀/𝐻`` 全部丢弃致签名坍缩为 ``a``。
+        """
+        # PyMuPDF inline 文本流（Unicode 数学字母块 U+1D400–1D7FF）
+        text = "A 𝑡 = ⟨ 𝑀 𝜃 𝑡, 𝐻 𝑡, 𝑈 𝑡, 𝐸 𝑡 ⟩ ."
+        # MinerU LaTeX 块
+        latex = (
+            r"\mathcal { A } _ { t } = \langle M _ { \theta _ { t } } , "
+            r"H _ { t } , U _ { t } , E _ { t } \rangle ."
+        )
+        sig_text = _formula_text_signature(text)
+        sig_latex = _formula_text_signature(latex)
+        # 折叠后两者一致（均为 atmthtutet 量级），不再坍缩为单字符
+        assert sig_text == sig_latex
+        assert len(sig_text) > 5, f"签名坍缩（NFKD 未生效）：{sig_text!r}"
+
 
 class TestTextBlockMatchesFormula:
     """``_text_block_matches_formula`` 语义层兜底过滤契约。"""
@@ -239,8 +258,33 @@ class TestTextBlockMatchesFormula:
         assert _text_block_matches_formula(block, signatures) is False
 
     def test_short_signature_skipped(self) -> None:
-        """短公式签名 (<20 字符) 不参与匹配，避免假阳性。"""
-        # 短公式 ``E = mc^2`` 签名仅 ``emc2`` (4 字符)
+        """短公式签名 (<20 字符) 不参与**子串**匹配，避免假阳性。"""
+        # 短公式 ``E = mc^2`` 签名仅 ``emc2`` (4 字符)；prose 块非精确相等
         signatures = {0: [_formula_text_signature(r"E = m c ^ 2")]}
         block = self._block("Energy mass conversion E = m c squared formula")
+        assert _text_block_matches_formula(block, signatures) is False
+
+    def test_short_formula_exact_equality_deduped(self) -> None:
+        """Q9：短公式（sig 10 字符 < 20）的 PyMuPDF inline 文本流与 MinerU 块
+        并存时，签名**精确相等**应触发去重（绕过 20 字符子串门）。"""
+        latex = (
+            r"\mathcal { A } _ { t } = \langle M _ { \theta _ { t } } , "
+            r"H _ { t } , U _ { t } , E _ { t } \rangle ."
+        )
+        signatures = {4: [_formula_text_signature(latex)]}  # sig=atmthtutet (10)
+        block = self._block("A 𝑡 = ⟨ 𝑀 𝜃 𝑡, 𝐻 𝑡, 𝑈 𝑡, 𝐸 𝑡 ⟩ .", page=4)
+        assert _text_block_matches_formula(block, signatures) is True
+
+    def test_short_formula_embedded_in_prose_not_deduped(self) -> None:
+        """守卫：短公式嵌入更长正文句（非精确相等）不去重，保留正文。"""
+        latex = (
+            r"\mathcal { A } _ { t } = \langle M _ { \theta _ { t } } , "
+            r"H _ { t } , U _ { t } , E _ { t } \rangle ."
+        )
+        signatures = {4: [_formula_text_signature(latex)]}
+        block = self._block(
+            "Using the survey-wide runtime definition A 𝑡 = ⟨ 𝑀 𝜃 𝑡, 𝐻 𝑡, "
+            "𝑈 𝑡, 𝐸 𝑡 ⟩, the parameter path is the case in which the model",
+            page=4,
+        )
         assert _text_block_matches_formula(block, signatures) is False

--- a/apps/negentropy-perceives/tests/unit/test_assembly_samepage_caption.py
+++ b/apps/negentropy-perceives/tests/unit/test_assembly_samepage_caption.py
@@ -1,0 +1,179 @@
+"""assembly 同页游离 caption 关联 + caption 分隔符 ``|`` 支持单测。
+
+背景（ISSUE：Figure N | caption 与图片相隔远）：``Figure 8 | ...`` caption 与其
+图片在阅读序中相隔约 90 行（中间夹章节标题），2.5.7 邻接搜索遇非 text 元素即中断，
+够不到。修复：``_find_same_page_orphan_caption`` 在同页范围内为唯一 captionless
+图片认领唯一游离 caption；且 caption 分隔符扩展支持 ``|`` / ``｜`` / ``∣``。
+"""
+
+import asyncio
+from pathlib import Path
+
+from negentropy.perceives.pipeline.models._pdf import (
+    AssemblyInput,
+    DocumentCharacteristics,
+    ExtractedImage,
+    ImageExtractionOutput,
+    PreprocessingOutput,
+    TextBlock,
+    TextExtractionOutput,
+)
+from negentropy.perceives.pipeline.stages.pdf.assembly import (
+    BuiltinAssembler,
+    _is_figure_or_table_caption_text,
+)
+
+
+class TestCaptionSeparatorPipe:
+    """caption 分隔符扩展：``Figure N |`` 也被识别为图注。"""
+
+    def test_pipe_separator_recognized(self) -> None:
+        assert _is_figure_or_table_caption_text("Figure 8 | Two-axis map of regimes.")
+
+    def test_fullwidth_pipe_recognized(self) -> None:
+        assert _is_figure_or_table_caption_text("Figure 3｜Full-width bar chart.")
+
+    def test_colon_still_recognized(self) -> None:
+        assert _is_figure_or_table_caption_text("Figure 1: Overview of the survey.")
+
+    def test_prose_mention_not_caption(self) -> None:
+        assert not _is_figure_or_table_caption_text(
+            "This section discusses Figure 8 in the context of evolution."
+        )
+
+
+def _img_element(
+    filename: str,
+    page: int,
+    caption: str | None,
+    order: int,
+    bbox: tuple[float, float, float, float] = (50.0, 60.0, 500.0, 400.0),
+) -> ExtractedImage:
+    return ExtractedImage(
+        image_id=filename,
+        filename=filename,
+        page_number=page,
+        bbox=bbox,
+        caption=caption,
+        width=602,
+        height=388,
+    )
+
+
+def _run(images: list[ExtractedImage], blocks: list[TextBlock]) -> str:
+    ai = AssemblyInput(
+        preprocessing=PreprocessingOutput(
+            local_path=Path("/tmp/x.pdf"),
+            page_count=1,
+            characteristics=DocumentCharacteristics(),
+        ),
+        text=TextExtractionOutput(blocks=blocks),
+        images=ImageExtractionOutput(images=images, total_count=len(images)),
+    )
+    return asyncio.run(BuiltinAssembler().execute(ai)).output.markdown
+
+
+class TestSamePageOrphanCaption:
+    """同页游离 caption 关联到 captionless 图片（模拟 Figure 8 场景）。"""
+
+    def test_far_caption_associated_to_captionless_image(self) -> None:
+        """图在页首、caption 漂到远处（中间夹标题）→ 应关联进 img alt。"""
+        img = _img_element("fig_p39_1.png", page=38, caption=None, order=0)
+        blocks = [
+            # 中间夹的章节标题（打断邻接搜索）
+            TextBlock(
+                text="WHAT EVOLVES?",
+                page_number=38,
+                bbox=(50, 120, 500, 150),
+                block_type="heading",
+                heading_level=1,
+                reading_order=1,
+            ),
+            TextBlock(
+                text="TaskAgent Content Assets",
+                page_number=38,
+                bbox=(50, 160, 500, 190),
+                block_type="heading",
+                heading_level=2,
+                reading_order=2,
+            ),
+            # 游离 caption（同页，靠后）
+            TextBlock(
+                text=(
+                    "Figure 8 | Two-axis map of post-deployment agentic AI "
+                    "evolution regimes. Columns indicate what evolves."
+                ),
+                page_number=38,
+                bbox=(50, 800, 500, 860),
+                block_type="paragraph",
+                reading_order=90,
+            ),
+        ]
+        md = _run([img], blocks)
+        # caption 被注入 img alt（HTML img 形式，因有 bbox 尺寸）
+        assert 'alt="Figure 8 | Two-axis map' in md, md[:400]
+        # 游离 caption 段落被 2.6 去重移除（不再作为独立正文段落重复出现）
+        # 统计 "Figure 8 |" 出现次数：应仅在 alt 中出现 1 次
+        assert md.count("Figure 8 | Two-axis map") == 1, (
+            f"caption 未去重，出现 {md.count('Figure 8 | Two-axis map')} 次"
+        )
+
+    def test_two_captionless_images_same_page_not_matched(self) -> None:
+        """同页 ≥2 张 captionless 图片 + caption 非邻接 → 同页兜底不认领（保守放弃）。
+
+        中间夹标题使邻接兜底对两张图都失败，从而只考验同页兜底：该页有 2 张
+        captionless 图片，无法确定 caption 归属 → 应放弃，alt 仍为文件名。
+        """
+        imgs = [
+            _img_element(
+                "fig_a.png",
+                page=5,
+                caption=None,
+                order=0,
+                bbox=(50.0, 60.0, 500.0, 300.0),
+            ),
+            _img_element(
+                "fig_b.png",
+                page=5,
+                caption=None,
+                order=1,
+                bbox=(50.0, 320.0, 500.0, 560.0),
+            ),
+        ]
+        blocks = [
+            # 标题打断 fig_b 与 caption 的邻接（_figure_caption_to_inject 不认标题）
+            TextBlock(
+                text="Some Section Heading",
+                page_number=5,
+                bbox=(50, 600, 500, 630),
+                block_type="heading",
+                heading_level=2,
+                reading_order=10,
+            ),
+            TextBlock(
+                text="Figure 4 | Some caption text describing a figure.",
+                page_number=5,
+                bbox=(50, 800, 500, 850),
+                block_type="paragraph",
+                reading_order=50,
+            ),
+        ]
+        md = _run(imgs, blocks)
+        # 两张图都不应认领该 caption（alt 仍是文件名）
+        assert 'alt="fig_a.png"' in md
+        assert 'alt="fig_b.png"' in md
+
+    def test_captioned_image_not_overwritten(self) -> None:
+        """已有 caption 的图片不被同页游离 caption 覆盖。"""
+        img = _img_element("fig_c.png", page=7, caption="Figure 5 | Existing.", order=0)
+        blocks = [
+            TextBlock(
+                text="Figure 6 | A different orphan caption on same page.",
+                page_number=7,
+                bbox=(50, 800, 500, 850),
+                block_type="paragraph",
+                reading_order=50,
+            ),
+        ]
+        md = _run([img], blocks)
+        assert 'alt="Figure 5 | Existing.' in md

--- a/apps/negentropy-perceives/tests/unit/test_assembly_slice_heading_cascade.py
+++ b/apps/negentropy-perceives/tests/unit/test_assembly_slice_heading_cascade.py
@@ -1,0 +1,167 @@
+"""assembly 2.1 标题级联在 auto_batch 切片下的行为单测。
+
+背景（ISSUE：auto_batch 切片首标题误判 h1）：assembly 的 ``_first_h1_seen``
+是每次 assembly 调用的局部状态。auto_batch 下每个切片各跑一次 assembly，切片 >0
+的首个标题（如 ``8.`` / ``4.2`` / ``References``）会被误当作「论文标题」升为 H1。
+
+修复：``run_pdf_pipeline`` 把 ``slice_index`` 注入 ``PreprocessingInput.config``，
+经 ``AssemblyInput.slice_index`` 传入 assembly；切片 >0 时预置 ``_first_h1_seen=True``，
+所有标题统一走「后续下移一级」路径。
+"""
+
+import asyncio
+from pathlib import Path
+
+from negentropy.perceives.pipeline.models._pdf import (
+    AssemblyInput,
+    DocumentCharacteristics,
+    PreprocessingOutput,
+    TextBlock,
+    TextExtractionOutput,
+)
+from negentropy.perceives.pipeline.stages.pdf.assembly import BuiltinAssembler
+
+
+def _mk_input(blocks: list[TextBlock], slice_index: int) -> AssemblyInput:
+    return AssemblyInput(
+        preprocessing=PreprocessingOutput(
+            local_path=Path("/tmp/x.pdf"),
+            page_count=1,
+            characteristics=DocumentCharacteristics(),
+        ),
+        text=TextExtractionOutput(blocks=blocks),
+        slice_index=slice_index,
+    )
+
+
+def _heading(text: str, level: int, order: int, page: int = 0) -> TextBlock:
+    # 给足够大的 bbox y 间距，保证 reading order = 视觉顺序
+    return TextBlock(
+        text=text,
+        page_number=page,
+        bbox=(50.0, 100.0 + order * 40.0, 500.0, 130.0 + order * 40.0),
+        block_type="heading",
+        heading_level=level,
+        reading_order=order,
+    )
+
+
+def _run_assembly(blocks: list[TextBlock], slice_index: int) -> str:
+    stage = BuiltinAssembler()
+    result = asyncio.run(stage.execute(_mk_input(blocks, slice_index)))
+    return result.output.markdown
+
+
+def _heading_lines(md: str) -> list[str]:
+    return [ln for ln in md.split("\n") if ln.lstrip().startswith("#")]
+
+
+class TestSliceHeadingCascade:
+    """切片 0 册封论文标题；切片 >0 不册封，统一下移一级。"""
+
+    def test_slice0_coronates_first_h1_as_title(self) -> None:
+        """切片 0：首个 H1 保持论文标题，后续标题下移一级。"""
+        blocks = [
+            _heading("Paper Title", 1, 0),
+            _heading("1. Introduction", 1, 1),
+            _heading("2.1. Setup", 2, 2),
+        ]
+        md = _run_assembly(blocks, slice_index=0)
+        lines = _heading_lines(md)
+        assert any(ln.startswith("# ") and "Paper Title" in ln for ln in lines)
+        # 首个 H1 之后的 ``1. Introduction``（level 1）下移到 H2
+        assert any(ln.startswith("## ") and "Introduction" in ln for ln in lines)
+        # ``2.1. Setup``（level 2）下移到 H3
+        assert any(ln.startswith("### ") and "Setup" in ln for ln in lines)
+
+    def test_slice_gt0_does_not_coronate_first_heading(self) -> None:
+        """切片 >0：首个标题不被升为 H1，统一下移一级（回归 ISSUE 核心）。"""
+        blocks = [
+            _heading("8. Measuring Self-Improvement", 1, 0),
+            _heading("8.1. Why Evaluate", 2, 1),
+        ]
+        md = _run_assembly(blocks, slice_index=1)
+        lines = _heading_lines(md)
+        # 关键断言：切片首标题 ``8.`` 不得是 H1
+        assert not any(ln.startswith("# ") and "Measuring" in ln for ln in lines), (
+            f"切片 >0 首标题被误升 H1: {lines}"
+        )
+        # ``8.``（level 1）下移到 H2
+        assert any(ln.startswith("## ") and "Measuring" in ln for ln in lines)
+        # ``8.1``（level 2）下移到 H3
+        assert any(ln.startswith("### ") and "Why Evaluate" in ln for ln in lines)
+
+    def test_slice_gt0_level2_first_heading_not_promoted(self) -> None:
+        """切片 >0：首标题为 H2（如 ``4.2``）时不被提升为 H1。"""
+        blocks = [
+            _heading("4.2. Memory Representation", 2, 0),
+            _heading("4.2.1. Content Units", 3, 1),
+        ]
+        md = _run_assembly(blocks, slice_index=1)
+        lines = _heading_lines(md)
+        assert not any(
+            ln.startswith("# ") and "Memory Representation" in ln for ln in lines
+        ), f"切片 >0 的 H2 首标题被误升 H1: {lines}"
+        # ``4.2``（level 2）下移到 H3
+        assert any(
+            ln.startswith("### ") and "Memory Representation" in ln for ln in lines
+        )
+
+    def test_references_heading_slice_gt0(self) -> None:
+        """切片 >0：``References`` 单标题不被升为 H1。"""
+        blocks = [_heading("References", 1, 0)]
+        md = _run_assembly(blocks, slice_index=2)
+        lines = _heading_lines(md)
+        assert not any(
+            ln.strip().startswith("# ") and "References" in ln for ln in lines
+        ), f"References 被误升 H1: {lines}"
+
+    def test_part_headings_normalized_to_h2(self) -> None:
+        """``Part I. / Part IV.`` 顶层结构标题统一钉为 H2（跨切片赋级不一致修复）。"""
+        # 切片 0：模拟 docling 给 Part I 赋 h4、Part 前有论文标题
+        blocks = [
+            _heading("Paper Title", 1, 0),
+            _heading("Part I. Agents in the Era of Experience", 4, 1),
+            _heading("1. Introduction", 1, 2),
+        ]
+        md = _run_assembly(blocks, slice_index=0)
+        lines = _heading_lines(md)
+        # Part I 统一为 H2
+        assert any(ln.startswith("## ") and "Part I." in ln for ln in lines), (
+            f"Part I 未归一为 H2: {lines}"
+        )
+        # 不应残留 H4 的 Part
+        assert not any(ln.startswith("#### ") and "Part I." in ln for ln in lines)
+
+    def test_part_heading_slice_gt0_normalized(self) -> None:
+        """切片 >0 的 ``Part IV.``（源为 h3）也归一为 H2。"""
+        blocks = [
+            _heading("Part IV. Measurement, Safety, and Open Problems", 3, 0),
+            _heading("8. Measuring", 1, 1),
+        ]
+        md = _run_assembly(blocks, slice_index=1)
+        lines = _heading_lines(md)
+        assert any(ln.startswith("## ") and "Part IV." in ln for ln in lines), (
+            f"Part IV 未归一为 H2: {lines}"
+        )
+
+    def test_default_slice_index_zero_backward_compat(self) -> None:
+        """未指定 slice_index（非分批路径）默认 0，保持既有册封行为。"""
+        blocks = [
+            _heading("Paper Title", 1, 0),
+            _heading("1. Introduction", 1, 1),
+        ]
+        # 不传 slice_index → 默认 0
+        stage = BuiltinAssembler()
+        ai = AssemblyInput(
+            preprocessing=PreprocessingOutput(
+                local_path=Path("/tmp/x.pdf"),
+                page_count=1,
+                characteristics=DocumentCharacteristics(),
+            ),
+            text=TextExtractionOutput(blocks=blocks),
+        )
+        assert ai.slice_index == 0
+        md = asyncio.run(stage.execute(ai)).output.markdown
+        lines = _heading_lines(md)
+        assert any(ln.startswith("# ") and "Paper Title" in ln for ln in lines)

--- a/apps/negentropy-perceives/tests/unit/test_formatter_math_protection.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_math_protection.py
@@ -61,6 +61,38 @@ class TestFormatterMathProtection:
         assert "$\\alpha \\in \\mathbb{R}$" in result
         assert "$$f(x) = \\sum_{i=1}^{n} x_i^2$$" in result
 
+    def test_katex_incompatible_primitives_cleaned(self) -> None:
+        r"""docling/mineru 对 ``\left(..\right)`` 的冗长编码含 KaTeX 不支持的
+        ``\aftergroup`` / ``\bgroup`` / ``\egroup`` / 空 ``\mathopen{}\mathclose``，
+        会致 ParseError。``_sanitize_katex_incompatible`` 应剥离这些 primitive，
+        保留 ``\left(..\right)`` 主体。"""
+        latex = (
+            "$$\n\\begin{array} { r } { H = \\Phi \\mathopen { } \\mathclose "
+            "\\bgroup \\left( H , z \\aftergroup \\egroup \\right) . } "
+            "\\end{array}\n$$"
+        )
+        result = self.formatter._sanitize_katex_incompatible(latex)
+        assert "\\aftergroup" not in result
+        assert "\\bgroup" not in result
+        assert "\\egroup" not in result
+        assert "\\mathopen" not in result
+        # \left( .. \right) 主体保留
+        assert "\\left(" in result and "\\right)" in result
+
+    def test_katex_primitives_cleaned_through_full_pipeline(self) -> None:
+        r"""完整 format() 管线：块公式经 protect（清理 primitive）→ restore 后，
+        产物不再含 KaTeX 不兼容 primitive，且 ``\left(..\right)`` 保留。"""
+        md = (
+            "Intro text.\n\n"
+            "$$\n{ H = \\Phi \\mathopen { } \\mathclose \\bgroup "
+            "\\left( H , z \\aftergroup \\egroup \\right) . }\n$$\n\nOutro."
+        )
+        result = self.formatter.format(md)
+        assert "\\aftergroup" not in result
+        assert "\\bgroup" not in result
+        assert "\\mathopen" not in result
+        assert "\\left(" in result and "\\right)" in result
+
     def test_adjacent_similar_math_blocks_all_preserved(self) -> None:
         """同章节相邻的多条公式（共享大量变量与运算符令牌）必须全部保留，
         不得被 ``_deduplicate_approximate_paragraphs`` 的 Jaccard 相似度

--- a/apps/negentropy-perceives/tests/unit/test_formatter_mid_bullets.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_mid_bullets.py
@@ -1,0 +1,100 @@
+"""formatter._split_mid_paragraph_bullets 段落中部 Unicode bullet 拆分单测。
+
+背景（ISSUE：段中 bullet 残留）：PDF 抽取常把原生列表 ``• A • B • C`` 压平进
+单一段落，段落中部的 bullet 不被 ``_normalize_unicode_bullets`` 的行首规则覆盖。
+本 pass 把 ``前文 • A • B`` 拆为 ``前文`` + ``- A`` + ``- B``。
+"""
+
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+
+
+class TestSplitMidParagraphBullets:
+    def setup_method(self) -> None:
+        self.f = MarkdownFormatter()
+
+    def test_multi_bullet_paragraph_split(self) -> None:
+        """段落中部 ≥2 个 bullet 拆分为独立列表项，前文成独立段落。"""
+        md = "Cost • interaction cost • compute cost • operational cost"
+        out = self.f._split_mid_paragraph_bullets(md)
+        assert out == ("Cost\n- interaction cost\n- compute cost\n- operational cost")
+
+    def test_abbrev_dictionary_pattern_split(self) -> None:
+        """缩写词典型 ``• FG: ... • BR: ...`` 拆分（前置已是列表项则保留）。"""
+        md = "- FG: Forward Gain • BR: Backward Retention • IE: Improvement"
+        out = self.f._split_mid_paragraph_bullets(md)
+        assert out == (
+            "- FG: Forward Gain\n- BR: Backward Retention\n- IE: Improvement"
+        )
+
+    def test_decorative_ellipsis_bullets_preserved(self) -> None:
+        """装饰型 ``• • •``（无实义字符的 item）整行保留，不拆分。"""
+        md = "SIP-Bench T₀ T₁ • • • T₂ repeated evaluation"
+        assert self.f._split_mid_paragraph_bullets(md) == md
+
+    def test_single_bullet_conservative_preserved(self) -> None:
+        """单个段中 bullet 保守保留（不足以判定为列表压平）。"""
+        md = "discussed in Section 7. • Finally, we study the condition."
+        assert self.f._split_mid_paragraph_bullets(md) == md
+
+    def test_table_row_skipped(self) -> None:
+        """含 ``|`` 的表格行跳过。"""
+        md = "| a • b | c • d • e |"
+        assert self.f._split_mid_paragraph_bullets(md) == md
+
+    def test_heading_skipped(self) -> None:
+        """标题行跳过。"""
+        md = "## Section • sub • sub2 heading"
+        assert self.f._split_mid_paragraph_bullets(md) == md
+
+    def test_placeholder_line_skipped(self) -> None:
+        """代码 / 数学占位符行（%%）跳过。"""
+        md = "%%CODEBLOCK_abc123%% • x • y"
+        assert self.f._split_mid_paragraph_bullets(md) == md
+
+    def test_no_bullet_untouched(self) -> None:
+        """无 bullet 的普通段落不动。"""
+        md = "A perfectly normal paragraph with no bullets at all."
+        assert self.f._split_mid_paragraph_bullets(md) == md
+
+    def test_empty_pre_all_items(self) -> None:
+        """无前文（行以 bullet 空白起）时全部转列表项。"""
+        # _normalize_unicode_bullets 会先转行首 bullet；这里直接测中段逻辑
+        md = "intro • alpha item • beta item • gamma item"
+        out = self.f._split_mid_paragraph_bullets(md)
+        assert out == "intro\n- alpha item\n- beta item\n- gamma item"
+
+    def test_multiline_mixed(self) -> None:
+        """多行混合：仅命中行被拆，其余保留。"""
+        md = (
+            "Normal line one.\n"
+            "Metrics • FG gain • BR retention • IE efficiency\n"
+            "Normal line two."
+        )
+        out = self.f._split_mid_paragraph_bullets(md)
+        assert out == (
+            "Normal line one.\n"
+            "Metrics\n- FG gain\n- BR retention\n- IE efficiency\n"
+            "Normal line two."
+        )
+
+
+class TestSplitMidBulletsInPipeline:
+    def setup_method(self) -> None:
+        self.f = MarkdownFormatter()
+
+    def test_full_format_splits_mid_bullets(self) -> None:
+        """完整 format() 管线中段中 bullet 被拆为列表。"""
+        md = "Metrics • FG gain • BR retention • IE efficiency"
+        out = self.f.format(md)
+        assert "- FG gain" in out
+        assert "- BR retention" in out
+        assert "- IE efficiency" in out
+
+    def test_code_block_bullets_preserved_in_pipeline(self) -> None:
+        """代码块内的 bullet 不被拆（保护语义）。"""
+        md = "```\na • b • c\n```\n\nProse x • one • two • three"
+        out = self.f.format(md)
+        # 代码块内原样
+        assert "a • b • c" in out
+        # 散文内被拆
+        assert "- one" in out

--- a/apps/negentropy-perceives/tests/unit/test_formatter_unicode_math.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_unicode_math.py
@@ -1,0 +1,182 @@
+"""src/negentropy/perceives/markdown/formatter.py 散落 Unicode 数学字母块字形
+（U+1D400–1D7FF）归一为 inline ``$...$`` 的单元测试。
+
+背景见 ``formatter._normalize_unicode_math``：LaTeX 学术 PDF 经 docling/PyMuPDF
+抽取后，inline 数学常被发射为「空格分隔的孤立数学斜体字形」（如 ``A 𝑡 = ⟨ 𝑀 𝜃 𝑡⟩``），
+本 pass 把这类散落字形在 formatter 末段归一为 KaTeX 可渲染的 ``$...$``。
+"""
+
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+
+
+class TestNormalizeUnicodeMath:
+    """测试 _normalize_unicode_math 把散落数学字母字形包裹为 inline ``$...$``。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    # ------------------------------------------------------------------
+    # 基础：散落字形 → inline $...$
+    # ------------------------------------------------------------------
+
+    def test_standalone_math_letter_wrapped(self) -> None:
+        """孤立单字符数学字母 → $letter$，前后散文不动。"""
+        md = "𝑡 denotes wall-clock time."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "$t$ denotes wall-clock time."
+
+    def test_scattered_formula_run_merged(self) -> None:
+        """空格分隔的散落字形 run 合并为单个 $...$，剔除空白伪影。"""
+        md = "A 𝑡 = ⟨ 𝑀 𝜃 𝑡, 𝐻 𝑡, 𝑈 𝑡, 𝐸 𝑡 ⟩."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "$At=\\langle M\\theta t,Ht,Ut,Et\\rangle$."
+
+    def test_inline_math_with_arrow_op(self) -> None:
+        """数学运算符（→）纳入 run。"""
+        md = "𝜃 𝑡 → 𝜃 𝑡 + 1 updates the parameters."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "$\\theta t\\to\\theta t+1$ updates the parameters."
+
+    def test_double_struck_letter_wrapped(self) -> None:
+        """双线体 𝔼（U+1D53C）也要归一（在 _BLACKBOARD_MAP，非 MATH_LETTER_CHARS）。"""
+        md = "The set 𝔼 [ 𝑋 ] is the expectation."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "The set $\\mathbb{E}[X]$ is the expectation."
+
+    # ------------------------------------------------------------------
+    # 边界：run 断开 / 标点剥离
+    # ------------------------------------------------------------------
+
+    def test_run_breaks_at_english_word(self) -> None:
+        """英文单词断开 run：𝑀 𝜃 𝑡 is → $M\\theta t$ is。"""
+        md = "𝑀 𝜃 𝑡 is the base model."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "$M\\theta t$ is the base model."
+
+    def test_trailing_sentence_period_stripped(self) -> None:
+        """run 结尾的句末句点剥离到 $...$ 之外。"""
+        md = "vertical capability 𝐸 𝑡."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "vertical capability $Et$."
+
+    def test_number_with_trailing_comma_absorbed(self) -> None:
+        """「数字 + 尾逗号」（1,）可被 run 吸附合并进公式；结尾逗号再剥离到 $...$ 外。"""
+        md = "𝑡 𝑖 − 1,"
+        out = self.formatter._normalize_unicode_math(md)
+        # 关键：1 被并入公式（未因逗号断开 run），句末逗号剥离到数学之外
+        assert out == "$ti-1$,"
+
+    def test_math_minus_u2212_in_run(self) -> None:
+        """U+2212（−）数学减号纳入 run 并映射为 ascii hyphen。"""
+        md = "𝑡 𝑖 − 1 then."
+        out = self.formatter._normalize_unicode_math(md)
+        assert "$ti-1$" in out
+
+    # ------------------------------------------------------------------
+    # 保护：不误伤
+    # ------------------------------------------------------------------
+
+    def test_plain_english_untouched(self) -> None:
+        """无数学字母块的纯英文不动。"""
+        md = "Plain English sentence with no math at all."
+        assert self.formatter._normalize_unicode_math(md) == md
+
+    def test_existing_inline_math_preserved(self) -> None:
+        """已有 inline $...$ split-and-skip，内部不动。"""
+        md = "Cost $5 and value $\\theta$ here."
+        out = self.formatter._normalize_unicode_math(md)
+        # $\\theta$ 与 $5...$ 区间不被二次处理
+        assert "$\\theta$" in out
+
+    def test_heading_line_skipped(self) -> None:
+        """标题行（# 起首）跳过，即使含数学字母。"""
+        md = "## 3.2 𝑆 𝑡 heading"
+        assert self.formatter._normalize_unicode_math(md) == md
+
+    def test_table_row_skipped(self) -> None:
+        """表格行（| 起首）跳过。"""
+        md = "| col 𝑡 | col2 |"
+        assert self.formatter._normalize_unicode_math(md) == md
+
+    def test_list_item_marker_preserved(self) -> None:
+        """列表项的 - 标记不被吸附。"""
+        md = "- 𝑡 denotes the step index."
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "- $t$ denotes the step index."
+
+    # ------------------------------------------------------------------
+    # LaTeX 命令间距
+    # ------------------------------------------------------------------
+
+    def test_latex_command_space_before_ascii_letter(self) -> None:
+        """\\name 命令后跟（映射后）ASCII 字母补空格，防 \\thetat 粘连。"""
+        md = "𝜃 𝑡"
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "$\\theta t$"
+
+    def test_latex_command_no_space_before_op(self) -> None:
+        """\\name 命令后跟运算符（如 (）不补空格。"""
+        md = "( 𝛼 )"
+        out = self.formatter._normalize_unicode_math(md)
+        assert out == "$(\\alpha)$"
+
+    def test_set_builder_braces_escaped(self) -> None:
+        """集合构造式的裸花括号转义为 ``\\{`` / ``\\}``，避免跨 $..$ 片段失衡致
+        KaTeX ParseError（Expected '}'）。"""
+        md = "𝜏 𝑖 = { 𝛼 | time (𝛼) ∈[ 𝑡 𝑖 − 1, 𝑡 𝑖)}."
+        out = self.formatter._normalize_unicode_math(md)
+        # 裸花括号被转义
+        assert "\\{" in out and "\\}" in out
+        # 每个 $...$ 片段内未转义花括号数为 0（平衡）
+        import re as _re
+
+        for seg in _re.findall(r"\$([^$]+)\$", out):
+            assert len(_re.findall(r"(?<!\\)\{", seg)) == 0
+            assert len(_re.findall(r"(?<!\\)\}", seg)) == 0
+
+    def test_structural_braces_from_mapping_preserved(self) -> None:
+        """映射命令产生的结构性花括号（如 \\mathbf{V} 来自粗体字母）不被转义。"""
+        md = "𝐕"  # U+1D415 MATHEMATICAL BOLD CAPITAL V → \mathbf{V}
+        out = self.formatter._normalize_unicode_math(md)
+        assert "\\mathbf{V}" in out
+        assert "\\mathbf\\{" not in out
+
+    # ------------------------------------------------------------------
+    # feature flag
+    # ------------------------------------------------------------------
+
+    def test_feature_flag_disables_pass(self, monkeypatch) -> None:
+        """PERCEIVES_UNICODE_MATH_NORMALIZE=0 整体禁用。"""
+        monkeypatch.setenv("PERCEIVES_UNICODE_MATH_NORMALIZE", "0")
+        md = "𝑡 denotes time."
+        assert self.formatter._normalize_unicode_math(md) == md
+
+
+class TestNormalizeUnicodeMathFullPipeline:
+    """测试 _normalize_unicode_math 在完整 format() 管线中与 protect/restore 协同。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_block_math_preserved_through_pipeline(self) -> None:
+        """块公式 $$..$$ 经管线后仍完整，散落 inline 字形被包裹。"""
+        md = (
+            "Intro with 𝑡 inline.\n\n"
+            "$$\n\\mathcal{A}_t = \\langle M_t \\rangle\n$$\n\n"
+            "Outro with 𝜃 too."
+        )
+        out = self.formatter.format(md)
+        # 块公式主体完整保留
+        assert "\\mathcal{A}_t = \\langle M_t \\rangle" in out
+        # 散落 inline 字形被包裹
+        assert "$t$ inline" in out
+        assert "$\\theta$ too" in out
+
+    def test_code_block_not_touched(self) -> None:
+        """fenced 代码块内的数学字母块字形不被包裹（保护语义）。"""
+        md = "```\n𝑡 = 1\n```\n\nProse 𝑡 here."
+        out = self.formatter.format(md)
+        # 代码块内原样
+        assert "𝑡 = 1" in out
+        # 散文内被包裹
+        assert "$t$ here" in out

--- a/apps/negentropy-perceives/tests/unit/test_image_extraction_figure_clip.py
+++ b/apps/negentropy-perceives/tests/unit/test_image_extraction_figure_clip.py
@@ -304,3 +304,49 @@ class TestExpandFigureBbox:
         result = _expand_figure_bbox(seed, drawings=drawings, text_dict=text_dict)
         # 不吸纳：bbox 不变
         assert result == seed
+
+    # ──────────────────────────────────────────────────────────────
+    # T5：内容容器排除 —— 矢量包裹正文长段落（如 Abstract 底纹框）不吸纳
+    # ──────────────────────────────────────────────────────────────
+    def test_t5_content_container_drawing_excluded(self) -> None:
+        """种子上方紧邻一个"内容容器型"矢量（Abstract 底纹框），其内部包裹
+        整段正文（≥200 字符）。该矢量应被排除，不被吸纳到 figure bbox——
+        否则整段 Abstract 会被烘进 figure PNG，与正文文本重复（实测
+        Self-Improving Agents Figure 1）。"""
+        # 种子：figure 图区（y 494-734）
+        seed = (89.0, 494.0, 507.0, 734.0)
+        drawings = [
+            # Abstract 底纹框：紧邻种子上方（y 327-494），内部含长段落。
+            # 与种子水平重叠充分、垂直距 0，若无排除会被 step1 吸纳。
+            _drawing(72.0, 327.0, 523.0, 494.0),
+        ]
+        text_dict = {
+            "blocks": [
+                *self._column_paragraphs(),
+                # 底纹框内的 Abstract 长段落（978 字符 → 判定为正文段落）
+                _text_block(80.0, 340.0, 515.0, 480.0, "A" * 978),
+            ]
+        }
+        result = _expand_figure_bbox(seed, drawings=drawings, text_dict=text_dict)
+        # 关键：结果 y0 不应上移到 Abstract 底纹框（327）——底纹框被排除
+        assert result[1] >= 490.0, (
+            f"内容容器（Abstract 底纹框）未被排除：y0={result[1]:.0f} 上移到了段落区"
+        )
+
+    def test_t5b_short_label_container_still_absorbed(self) -> None:
+        """对照：矢量包裹的是**短标签**（< 200 字符）而非正文段落 → 仍正常吸纳
+        （不误伤 R7/R8 的列标题 / 子标签底盒吸纳能力）。"""
+        seed = (180.0, 482.0, 479.0, 682.0)
+        drawings = [
+            # 子标签底盒：上方 20pt，内部只有短标签文本
+            _drawing(180.0, 455.0, 479.0, 478.0),
+        ]
+        text_dict = {
+            "blocks": [
+                *self._column_paragraphs(),
+                _text_block(190.0, 460.0, 470.0, 475.0, "Context 1.0"),  # 短标签
+            ]
+        }
+        result = _expand_figure_bbox(seed, drawings=drawings, text_dict=text_dict)
+        # 短标签底盒正常吸纳：y0 上移到 455
+        assert result[1] <= 460.0, f"短标签底盒未被吸纳：y0={result[1]:.0f}"

--- a/apps/negentropy-perceives/tests/unit/test_mineru_engine.py
+++ b/apps/negentropy-perceives/tests/unit/test_mineru_engine.py
@@ -271,12 +271,31 @@ class TestMinerUOutputDir:
         assert output_dir.exists()
         assert output_dir.is_dir()
 
-    def test_ensure_output_dir_uses_specified(self, tmp_path: Path) -> None:
-        """指定 output_dir 时应使用该目录。"""
-        engine = MinerUEngine(output_dir=str(tmp_path / "mineru_out"))
+    def test_ensure_output_dir_uses_specified_root(self, tmp_path: Path) -> None:
+        """指定 output_dir 时在其**下**创建唯一子目录（保持切片隔离，尊重根路径）。"""
+        root = tmp_path / "mineru_out"
+        engine = MinerUEngine(output_dir=str(root))
         output_dir = engine._ensure_output_dir()
-        assert output_dir == tmp_path / "mineru_out"
         assert output_dir.exists()
+        # 实际目录是 root 下的唯一子目录，而非 root 本身
+        assert output_dir.parent == root
+        assert output_dir != root
+
+    def test_ensure_output_dir_isolated_across_calls(self, tmp_path: Path) -> None:
+        """跨 convert 调用（切片）每次得到独立目录——防止 rglob 命中前切片遗留
+        content_list.json 导致公式/表格/图片跨切片泄漏（ISSUE：auto_batch 泄漏）。"""
+        # 未指定根：两次调用目录不同
+        engine = MinerUEngine()
+        d1 = engine._ensure_output_dir()
+        d2 = engine._ensure_output_dir()
+        assert d1 != d2, "同一引擎复用时两次 convert 必须用独立目录"
+        # 指定根：两次调用在同一根下但子目录不同
+        root = tmp_path / "specified"
+        engine2 = MinerUEngine(output_dir=str(root))
+        e1 = engine2._ensure_output_dir()
+        e2 = engine2._ensure_output_dir()
+        assert e1 != e2
+        assert e1.parent == root and e2.parent == root
 
 
 # ============================================================

--- a/apps/negentropy-perceives/tests/unit/test_pdf_auto_batch.py
+++ b/apps/negentropy-perceives/tests/unit/test_pdf_auto_batch.py
@@ -87,6 +87,7 @@ class _PipelineCallLog:
             extract_formulas: bool = True,
             embed_images: bool = False,
             output_dir: Optional[str] = None,
+            slice_index: int = 0,
         ) -> PipelineResult:
             self.calls.append(
                 {
@@ -97,6 +98,7 @@ class _PipelineCallLog:
                     "extract_formulas": extract_formulas,
                     "embed_images": embed_images,
                     "output_dir": output_dir,
+                    "slice_index": slice_index,
                 }
             )
             i = idx["i"]
@@ -297,6 +299,9 @@ class TestRunBatchedPipeline:
             (40, 80),
             (80, 100),
         ]
+        # slice_index 与切片顺序对齐：assembly 据此决定是否「册封论文标题」
+        # （仅切片 0 册封；切片 >0 不得把首标题误升 H1）。
+        assert [c["slice_index"] for c in log.calls] == [0, 1, 2]
         # markdown 合并后包含 3 段
         assert "A" in (resp.content or "")
         assert "B" in (resp.content or "")

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2246,6 +2246,21 @@
   3. **跨形式签名的最小启用长度**：字符级扁平签名 ≥20 字符是经验阈值，更低易在短公式（如 ``\alpha = 0``）上产生假阳性匹配，更高漏过中等长度公式；
   4. **临时调试 env-gated 探针**：``NE_DEBUG_FORMULA=1`` 可在二轮根因定位中快速暴露 7 公式如何在 ``add → join → format → final`` 各环节流转，确认是 ``format()`` 内部某步骤丢弃，比再加 print 高效得多。该探针修复落地后已移除。
 
+### 第三轮迭代（R10，2026-07-05）：Self-Improving Agents 综述（88 页 / 双栏 / 数学密集）
+
+以 88 页新维度 PDF 为回归基线，暴露并修复 **9 类失真**（Q6 为伪命题）。完整逐项根因 / 修复 / 单测见 [pdf-harness-engineering-parity.md §9](./pdf-harness-engineering-parity.md#9-r10-增量self-improving-agents-综述88-页--a4-双栏-latex)，此处仅记跨上下文复用要点：
+
+- **两类 auto_batch 跨切片状态泄漏**（同源根因）：
+  - **Q2 标题层级**：assembly 2.1 级联 `_first_h1_seen` 是 per-slice 局部状态，切片 N>0 首标题被误册封 H1。修复：`slice_index` 贯穿 pipeline，切片>0 不册封。
+  - **Q4 公式跨切片泄漏**：MinerU 引擎 pool 复用时 `_ensure_output_dir` 缓存目录，某切片解析失败时 `rglob` 命中前切片遗留 `content_list.json`，静默继承其全部公式/表格/图片。修复：每次 `convert()` 用独立子目录隔离。
+- **三类仅浏览器渲染态可见的失真**（DB markdown 层不可见，实机验证发现）：Q7 figure 过度捕获（`_expand_figure_bbox` 把 Abstract 底纹框烘入图）、Q8 KaTeX ParseError（裸花括号失衡 + `\aftergroup` 等不兼容 primitive）、Q9 公式双份并存（inline 文本流 + block 未去重）。
+- **防范要点**：
+  1. **auto_batch 无共享可变状态铁律**：凡引擎/组装状态在切片间复用，产物目录须 per-call 唯一，级联/册封类状态须显式接收 slice_index；
+  2. **resume 缓存 + 进程热更盲区**：改 perceives 代码验证同一 PDF，必须①重启 MCP 进程（Python 无热重载）②清 `.batch_state/` checkpoint，否则 resume 复用旧切片跳过新代码——本轮曾因此白跑 2 次 re-ingest；
+  3. **1:1 还原验收必须走到浏览器渲染态**：Q7/Q8/Q9 在 DB markdown 层均"看似正确"，仅 KaTeX/图片渲染后才暴露；
+  4. **NFKD 折叠是 Unicode 数学↔LaTeX 跨形式去重的前提**：仅保留 ASCII 会把数学字母块（U+1D400–1D7FF）签名坍缩，须先 `unicodedata.normalize("NFKD")`；
+  5. **figure caption 双源**：多数 figure caption 已烘入 region PNG 像素，wiki/ui 不宜再从 alt 渲染 figcaption（双图注）。
+
 ### 第三轮迭代（2026-05-25 端到端质量回归：断字 / 公式漏检 / 标题误判 / TOC 错乱 / 图片孤儿）
 
 第二轮收尾后切到 71 页双栏 LaTeX 论文 `50714_Agent_Harness_Engineerin.pdf` 做端到端基线回归，再次定位 5 类独立根因（与第一/二轮正交、可单独 cherry-pick）：

--- a/docs/.agents/pdf-harness-engineering-parity.md
+++ b/docs/.agents/pdf-harness-engineering-parity.md
@@ -224,3 +224,65 @@ curl -X POST "http://localhost:3292/knowledge/base/{corpus}/documents/{doc}/refr
 
 # 验证完恢复：UPDATE ... SET url='http://localhost:2992/mcp' WHERE id=...
 ```
+
+> **R10 补充两条硬约束**（否则代码改动不生效，见 §9.4）：
+> 1. 改了 perceives `src/` 后**必须重启 MCP 进程**（Python 无热重载）；
+> 2. 对**同一 PDF** 重提取前**必须清 checkpoint**（`rm -rf output/.batch_state/*`），
+>    否则 auto_batch resume 复用旧切片、跳过新代码。
+
+## 9. R10 增量：Self-Improving Agents 综述（88 页 / A4 双栏 LaTeX）
+
+### 9.1 引发背景
+
+R9 基线是单栏教材（Agentic Design Patterns）；R10 选取 *Self-Improving Agents
+in the Era of Experience*（88 页 / A4 / LaTeX+hyperref / 数学符号密集 / 双栏综述）
+作为新维度回归基线，暴露 **9 类失真**（Q6 经核验为伪命题）。其中 2 类（Q2/Q4）
+是 auto_batch 分批引入的结构性缺陷（跨切片状态泄漏），3 类（Q7/Q8/Q9）仅在浏览器
+渲染态暴露（DB markdown 层不可见），凸显实机验证的不可替代性。
+
+### 9.2 九类失真修复
+
+| ID | 失真 | 责任 stage / 文件 | 修复手段 | 单测 |
+|---|---|---|---|---|
+| **Q1** | inline 数学近乎全无（88 页 326K 字符仅 2 个 `$...$`；`𝑈𝑡 / 𝜃 / 𝔼` 等散落数学斜体字形以纯文本存在，不渲染为数学体） | [`pdf/math_formula.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py) + [`markdown/formatter.py`](../../apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py) | (a) 补 U+1D400–1D7FF 数学字母块映射（`_MATH_ITALIC_LATIN_MAP` / `_MATH_BOLD_LATIN_MAP` / Italic Greek），暴露 `MATH_LETTER_TO_LATEX`；(b) formatter 主流程 protect 后新增 `_normalize_unicode_math` pass：以「连续数学字符 run + 紧邻 ASCII/下标/上标/运算符」为单元贪婪合并、单次 `$...$` 包裹，剥离尾部散文标点，`\name` 命令后按映射后字符补空格。误报防护：跳过代码块/块公式占位符/已有 inline `$..$`/标题/表格行；feature flag `PERCEIVES_UNICODE_MATH_NORMALIZE=0` 可禁用 | `test_formatter_unicode_math.py`（20） |
+| **Q2** | 标题层级错乱（`4.2` / `8` / `References` 误判 H1） | [`assembly.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py) + [`convenience.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/convenience.py) + [`ops/pdf.py`](../../apps/negentropy-perceives/src/negentropy/perceives/ops/pdf.py) + [`models/_pdf.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/models/_pdf.py) | **根因**：assembly 2.1 级联的 `_first_h1_seen` 是 per-slice 局部状态，auto_batch 下切片 N>0 首标题被误「册封」为论文标题（升 H1）。**修复**：`slice_index` 贯穿 `run_pdf_pipeline → PreprocessingInput.config → AssemblyInput → 级联`，切片 >0 时 `_first_h1_seen=True` 起始（不册封，统一下移一级）；新增 2.1a 段把 `Part I–IV` 归一为 H2（docling 跨切片赋级不一致修复） | `test_assembly_slice_heading_cascade.py`（7）+ 强化 `test_pdf_auto_batch.py` slice_index 不变量 |
+| **Q3** | Figure 8 图注（`Figure 8 \| ...`）与图片相隔约 90 行致关联失败漂成游离段落 | [`assembly.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py) | (a) caption 分隔符 `_FIGURE_TABLE_CAPTION_RE` 扩展支持 `\|` / `｜` / `∣`（本文档及大量 arXiv 论文用竖线，旧正则仅 `:.-`）；(b) 新增 `_find_same_page_orphan_caption`：邻接兜底失败时在同页范围内为唯一 captionless 图片认领唯一游离 caption（多图页保守放弃）。**注**：初评拟改 wiki `ZoomableImage` 渲染 figcaption，浏览器实机发现多数 figure 的图注已烘入 figure PNG（见 Q7），再渲染 figcaption 会双图注，故撤销 wiki 侧改动，仅保留 assembly 关联修复 | `test_assembly_samepage_caption.py`（7） |
+| **Q4** | 块公式跨切片泄漏（page-5 的 Section 2 公式簇逐字重现于 pages-21-40 切片首部；`0=t_0<t_1` 仅源于 p5 却出现在 slice 1） | [`pdf/engines/mineru.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pdf/engines/mineru.py) | **根因**：MinerU 引擎实例在 engine pool 跨切片复用，`_ensure_output_dir` 缓存 `self._output_dir`；当某切片 MinerU 解析未生成 `content_list.json` 时，`_find_content_list` 的 `rglob` 命中**前切片遗留**的 `content_list.json`，使该切片静默继承上切片全部公式/表格/图片。**修复**：每次 `convert()` 用独立子目录（`tempfile.mkdtemp`），彻底隔离切片间产物；显式 `output_dir` 亦在其下开唯一子目录。此修复同时消除表格/图片/代码的同类泄漏 | 更新 `test_mineru_engine.py`（+2 隔离不变量断言，共 64） |
+| **Q5** | 段落中部 Unicode bullet 残留（`前文 • 项A • 项B` 未拆为列表） | [`markdown/formatter.py`](../../apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py) | 新增 `_split_mid_paragraph_bullets`（`_normalize_unicode_bullets` 后调用）：单行 ≥2 个「两侧带空白」bullet 时拆为独立列表项，前文按句末标点独立成段；装饰型 `• • •`（无实义字符 item）整行保留。误报防护：跳过表格/标题/占位符/单 bullet 行 | `test_formatter_mid_bullets.py`（12） |
+| **Q6** | ~~图片总数偏低~~（伪命题） | — | 核验源 PDF 实际仅 9 图 + 2 logo = 11 张，产物 100% 覆盖（含纯矢量 Figure 3 经 R7 vector-region 路径正确渲染）。无缺陷，无需改动 | — |
+| **Q7** | figure region 过度捕获：`_expand_figure_bbox` 把图周内容烘入 figure PNG（Figure 1 烘入整段 Abstract + HomePage/GitHub 按钮，Abstract 在页面出现两次；多数图烘入运行页眉） | [`image_extraction.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py) | **根因**：Step 1 矢量吸纳把种子紧邻的"内容容器型"填充矩形（Abstract 底纹框）纳入 union，1.7× 扩展未触发 4.0× 退化保护。**修复**：新增 Step 0 收集正文长段落（≥200 字符）bbox + `_encloses_paragraph` 守卫——候选矢量若包裹（≥60% 覆盖）某正文长段落则判为内容容器、不吸纳。装饰矢量绝不含 200+ 字段落，故 R7/R8 的列标题/子标签/caption 吸纳能力零回退。实测 Figure 1 bbox 高度 630→371（Abstract 排除），raster 986→581px | `test_image_extraction_figure_clip.py`（+2 = 17） |
+| **Q8** | KaTeX ParseError（浏览器实机发现 3 处）：① 集合构造式裸花括号 `{α\|...}` 空格切分后跨 `$..$` 片段失衡（`Expected '}'`）；② docling/mineru 对 `\left(..\right)` 的冗长编码含 KaTeX 不支持的 `\aftergroup`/`\bgroup`/`\egroup`/空 `\mathopen{}\mathclose` | [`markdown/formatter.py`](../../apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py) | ①`_math_run_to_latex` 把裸源花括号转义为字面 `\{`/`\}`（既平衡又是集合记号正确渲染；结构性花括号来自多字符映射命令不误伤）；②`_protect_math_blocks` 保护入库时经 `_sanitize_katex_incompatible` 剥离不兼容 primitive（须在保护点施加——`_cleanup_math_blocks` 阶段块公式已是占位符），保留 `\left(..\right)` 主体 | `test_formatter_unicode_math.py`（含）+ `test_formatter_math_protection.py`（+2） |
+| **Q9** | 公式双份并存（浏览器实机发现）：同一 Section 2 公式既有 PyMuPDF inline 文本流（Q1 后渲染为 inline math）又有 MinerU `$$` 块，页面上下重复 | [`assembly.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py) | **根因**：R8 跨形式去重靠 `_formula_text_signature`，旧实现仅保留 ASCII，把 PyMuPDF 的 Unicode 数学字母块（`A 𝑡=⟨𝑀...⟩`）签名坍缩为 `a`，与 LaTeX 块签名 `atmthtutet` 不匹配 → 去重漏过。**修复**：(a) 签名计算前 `unicodedata.normalize("NFKD")` 折叠数学字母块为 ASCII（`𝑡→t`、`𝑀→M`、`𝔼→E`）；(b) 公式签名入库阈值 20→6，`_text_block_matches_formula` 增**精确相等**快路径（短公式绕过 20 字符子串门，仅整块字符级全等时去重，长正文嵌入不误伤） | `test_assembly_helpers.py`（+3） |
+
+### 9.3 量化效果（88 页综述全本）
+
+| 维度 | 修复前 | 修复后 | 状态 |
+|---|---|---|---|
+| inline `$...$` 数学（DB markdown） | 2 | **122** | ✅ |
+| KaTeX 渲染（浏览器 :3092） | ~2 | **165 inline + 15 display** | ✅ |
+| KaTeX ParseError（浏览器） | 3 | **0** | ✅ |
+| 误判 H1（4.2 / 8 / References） | 3 | **1**（仅论文标题） | ✅ |
+| Part 标题层级一致性 | h3/h4 混杂 | **统一 H2** | ✅ |
+| Figure 8 图注关联 | 游离段落 | **关联进 img alt** | ✅ |
+| 跨切片公式泄漏（Section 2 簇） | slice1 首部重现 6 公式 | **0** | ✅ |
+| 公式双份并存（inline+block） | 6 对 | **0** | ✅ |
+| 段中 bullet 残留 | ~26 | **≤1** | ✅ |
+| Figure 1 过度捕获（烘入 Abstract） | bbox h=630 / raster 986px | **h=371 / raster 581px** | ✅ |
+| 图片覆盖 | 11/11 | 11/11 | ✅ |
+| 新增/扩展单测 | — | **58** | 0 退化 |
+
+### 9.4 关键洞察（沉淀）
+
+- **auto_batch 切片间必须无共享可变状态**：Q2（assembly 级联 `_first_h1_seen`）与
+  Q4（mineru `_output_dir`）本质同源——per-slice 局部逻辑在跨切片复用的引擎/组装
+  流程中泄漏。凡「引擎实例在 engine pool 复用」的路径，产物落盘目录必须 per-call
+  唯一，级联/册封类状态必须显式接收 slice_index。
+- **auto_batch resume 缓存陷阱**：resume 按 PDF 内容 SHA-1 缓存切片到
+  `.batch_state/`；改 perceives 代码后重提取**同一 PDF**会 resume 跳过管线。验证
+  代码改动前须重启 MCP 进程 + 清 checkpoint（见 §8 补充）。
+- **浏览器实机验证不可省**：Q7（figure 烘入 Abstract）/ Q8（KaTeX ParseError）/
+  Q9（公式双份）均在 DB markdown 层不可见、仅浏览器渲染后暴露。1:1 还原验收必须
+  走到浏览器渲染态。
+- **figure caption 双源风险**：多数 figure 的 caption 已烘入 figure region PNG
+  （像素），故 wiki/ui 端不宜再从 alt 渲染 figcaption（会双图注）；caption 语义
+  由 alt 承载（无障碍 + 去重指纹），视觉由图内像素承载。


### PR DESCRIPTION
## 背景

以 88 页《Self-Improving Agents in the Era of Experience》综述（A4 双栏 / LaTeX / 数学密集）为新维度回归基线，端到端拟合 `negentropy-perceives.parse_pdf_to_markdown` 经 Knowledge Base「Harness Engineering」Corpus → Documents Ingest → Wiki 发布的一比一还原效果。逐页浏览器实机对比 PDF 原文与 wiki 渲染，发现并修复 **9 类失真**（Q6 经核验为伪命题）。

## 修复项

| ID | 失真 | 修复 |
|---|---|---|
| **Q1** | inline 数学近乎全无（散落 Unicode 数学字形不渲染） | `math_formula` 补 U+1D400–1D7FF 数学字母块映射；`formatter` 新增 `_normalize_unicode_math` pass 归一为 KaTeX inline（DB markdown 2→122，浏览器 165 inline+15 display） |
| **Q2** | 标题层级错乱（`4.2`/`8`/`References` 误判 H1） | `slice_index` 贯穿 pipeline，修复 auto_batch 切片首标题误册封 H1；`Part I–IV` 归一 H2 |
| **Q3** | Figure 8 图注脱离关联漂成游离段落 | caption 分隔符支持竖线 `\|`；新增同页游离 caption 兜底关联 |
| **Q4** | 块公式跨切片泄漏（Section 2 公式簇重现于后续切片） | mineru 每次 `convert()` 用独立输出子目录，杜绝 `rglob` 命中前切片残留 `content_list.json` |
| **Q5** | 段落中部 Unicode bullet 未拆列表 | 新增 `_split_mid_paragraph_bullets`（≥26→≤1） |
| **Q6** | ~~图片总数偏低~~ | 伪命题：源 PDF 实为 9 图+2 logo=11，产物 100% 覆盖，无需改动 |
| **Q7** | figure region 过度捕获（Figure 1 烘入整段 Abstract） | `_expand_figure_bbox` 排除包裹正文长段落的内容容器矢量（bbox h 630→371） |
| **Q8** | KaTeX ParseError ×3（裸花括号失衡 / `\aftergroup` 等不兼容 primitive） | 转义集合构造式裸花括号；保护入库时剥离不兼容 primitive（3→0） |
| **Q9** | 公式双份并存（inline 文本流 + block 重复） | 签名 NFKD 折叠 + 精确相等去重（6 对→0） |

> **关键洞察**：Q2/Q4 同源于「auto_batch 切片间共享可变状态泄漏」；Q7/Q8/Q9 仅在浏览器渲染态暴露、DB markdown 层不可见——1:1 还原验收必须走到浏览器渲染。详见 [`pdf-harness-engineering-parity.md §9`](docs/.agents/pdf-harness-engineering-parity.md)。

## 验证

- **单测**：新增 4 套件 + 扩展 5 套件，共 **58 例**；perceives 全量单测 **1888 passed**，0 退化（3 个 config 失败为环境预存，与本 PR 无关）。
- **端到端实机**：workspace perceives(:2993) + 切 DB 路由 + `refresh_markdown` 重提取 + wiki 本地发布(:3092) + 浏览器逐页对比源 PDF。auto_batch 88 页 → 5 切片全程无泄漏；Section 2 公式区一比一（每公式单份、KaTeX 0 ParseError）；Figure 1 排除 Abstract 后与原版视觉对齐。
- 验证完毕已恢复 DB perceives 路由至 `:2992`（live 默认）。

## 影响面

改动收敛于 `apps/negentropy-perceives/`（8 源码 + 9 测试）+ 2 文档；无 wiki/ui 侧改动（初评的 wiki figcaption 方案因多数图注已烘入 PNG 会致双图注，已撤销）。既有论文（Context Engineering 2.0 / Agentic Design Patterns）经 golden 与全量单测回归无退化。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)