### PR TITLE
feat(skill): PDF 高保真还原/巡检三件套对齐 R10（Skill 双 SSOT + 派生 Routine + 迁移 0090）

### DIFF
--- a/.agent/skills/pdf-fidelity-restore/SKILL.md
+++ b/.agent/skills/pdf-fidelity-restore/SKILL.md
@@ -39,7 +39,8 @@ Markdown，并通过浏览器逐页对比将差异修复至完全一致。
    - **渲染层**：`DocumentMarkdownRenderer` / sanitize schema / `DocumentImage`（图片宽高、表格、KaTeX、代码高亮、figure/figcaption、TOC 锚点）。
    - **摄取层**：图片链接重写、资产存储、元数据（`knowledge/ingestion/extraction.py`、`knowledge/_shared.py`）。
    - **管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取（`perceives/ops/pdf.py`）。
-   改后经 `refresh_markdown` 重摄取或重载页面，复核该项。
+   - **热更铁律（改 perceives `src/` 后必做，否则改动不生效）**：① 重启 perceives MCP 进程（Python 无热重载）；② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF 内容 SHA-1 缓存切片，不清则复用旧切片、跳过新代码，且完成异常快）。
+   改后经 `refresh_markdown` 重摄取或重载页面（**已清 checkpoint**），复核该项。
 8. **循环**：重复 6–7，直到逐页校验清单全绿；保留关键页源 PDF vs 渲染 Markdown 对比截图为证。
 
 ## 逐页校验清单
@@ -53,6 +54,12 @@ Markdown，并通过浏览器逐页对比将差异修复至完全一致。
 - [ ] 代码块语言识别与高亮正确
 - [ ] 脚注 / 注释完整
 
+## 关键洞察（R10 沉淀）
+
+- **auto_batch 切片间无共享可变状态**：引擎实例在 pool 复用时产物落盘目录须 per-call 唯一（`tempfile.mkdtemp`）；级联/册封类状态（如 `_first_h1_seen`）须显式接收 `slice_index`，否则跨切片泄漏（标题层级错乱 / 公式重现）。
+- **1:1 验收必须走到浏览器渲染态**：figure 过度捕获、KaTeX ParseError、公式双份等缺陷在 DB markdown 层不可见，仅浏览器渲染后暴露。
+- **figure 图注双源风险**：多数图注已烘入 figure region PNG 像素，故 wiki/ui **不得**再从 `alt` 渲染 `figcaption`（会双图注）；caption 语义由 `alt` 承载（无障碍 + 去重指纹），视觉由图内像素承载。
+
 ## 反模式（严禁）
 
 - 跳过逐页核对即声明完成；
@@ -62,3 +69,10 @@ Markdown，并通过浏览器逐页对比将差异修复至完全一致。
 ## 完成判据
 
 逐页校验清单全绿 + 关键页对比截图留证 + 整本 PDF 在 Documents 页可读性与一致性达最佳。
+
+## 资源 / 基线示例（R10）
+
+- 基线 PDF：`Self-Improving Agents in the Era of Experience: A Survey of Self- to Meta-Evolution.pdf`（88 页 / A4 双栏 LaTeX；corpus「Harness Engineering」）。
+- 基线 wiki 渲染对照：`http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/`
+- perceives 管线源码：`apps/negentropy-perceives`（monorepo `ThreeFish-AI/negentropy`，默认分支 `master`）。
+- 迭代记录：`docs/.agents/pdf-harness-engineering-parity.md` §9（R10 九项修复）。

--- a/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
+++ b/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
@@ -24,7 +24,7 @@ description: >-
   用 negentropy-perceives 的 parse_pdf_to_markdown 经 Knowledge Base Documents Ingest 将 PDF 一比一还原为可渲染
   Markdown（文字、段落顺序、高清原图、图片显示尺寸、目录、表格、数学公式、代码块、注释），大文件分批，逐页浏览器对比、发现一处修一处，直至完全一致。
 category: knowledge
-version: 1.0.0
+version: 1.1.0
 visibility: public
 priority: 20
 enforcement_mode: warning
@@ -65,8 +65,14 @@ prompt_template: |
      - **渲染层**：DocumentMarkdownRenderer / sanitize schema / DocumentImage（图片宽高、表格、KaTeX、代码高亮、figure/figcaption、TOC 锚点）。
      - **摄取层**：图片链接重写、资产存储、元数据。
      - **管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取。
-     改后经 refresh_markdown 重摄取或重载页面，复核该项。
+     - **热更铁律（改 perceives src/ 后必做，否则改动不生效）**：① 重启 perceives MCP 进程（Python 无热重载）；② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF 内容 SHA-1 缓存切片，不清则复用旧切片、跳过新代码，且完成异常快）。
+     改后经 refresh_markdown 重摄取或重载页面（**已清 checkpoint**），复核该项。
   8. **循环**：重复 6–7，直到逐页校验清单全绿；保留关键页源 PDF vs 渲染 Markdown 对比截图为证。
+
+  ## 关键洞察（R10 沉淀）
+  - **auto_batch 切片间无共享可变状态**：引擎实例在 pool 复用时产物落盘目录须 per-call 唯一（`tempfile.mkdtemp`）；级联/册封类状态（如 `_first_h1_seen`）须显式接收 `slice_index`，否则跨切片泄漏（标题层级错乱 / 公式重现）。
+  - **1:1 验收必须走到浏览器渲染态**：figure 过度捕获、KaTeX ParseError、公式双份等缺陷在 DB markdown 层不可见，仅浏览器渲染后暴露。
+  - **figure 图注双源风险**：多数图注已烘入 figure region PNG 像素，故 wiki/ui **不得**再从 `alt` 渲染 `figcaption`（会双图注）；caption 语义由 `alt` 承载（无障碍 + 去重指纹），视觉由图内像素承载。
 
   ## 反模式（严禁）
   - 跳过逐页核对即声明完成；
@@ -75,6 +81,12 @@ prompt_template: |
 
   ## 完成判据
   逐页校验清单全绿 + 关键页对比截图留证 + 整本 PDF 在 Documents 页可读性与一致性达最佳。
+
+  ## 资源 / 基线示例（R10）
+  - 基线 PDF：`Self-Improving Agents in the Era of Experience: A Survey of Self- to Meta-Evolution.pdf`（88 页 / A4 双栏 LaTeX；corpus「Harness Engineering」）。
+  - 基线 wiki 渲染对照：`http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/`
+  - perceives 管线源码：`apps/negentropy-perceives`（monorepo `ThreeFish-AI/negentropy`，默认分支 `master`）。
+  - 迭代记录：`docs/.agents/pdf-harness-engineering-parity.md` §9（R10 九项修复）。
 
 config_schema:
   type: object
@@ -117,6 +129,14 @@ resources:
     title: Harness Engineering corpus（默认目标语料库）
     lazy: true
   - type: url
-    ref: https://github.com/negentropy/negentropy-perceives
-    title: negentropy-perceives parse_pdf_to_markdown 工具文档
+    ref: https://github.com/ThreeFish-AI/negentropy/tree/master/apps/negentropy-perceives
+    title: negentropy-perceives parse_pdf_to_markdown 管线源码（monorepo，master）
+    lazy: true
+  - type: url
+    ref: http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/
+    title: R10 基线示例（88 页综述 wiki 渲染对照）
+    lazy: true
+  - type: doc
+    ref: docs/.agents/pdf-harness-engineering-parity.md
+    title: PDF 一比一还原质量迭代（§9 R10 九项修复）
     lazy: true

--- a/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
+++ b/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
@@ -136,7 +136,7 @@ resources:
     ref: http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/
     title: R10 基线示例（88 页综述 wiki 渲染对照）
     lazy: true
-  - type: doc
-    ref: docs/.agents/pdf-harness-engineering-parity.md
+  - type: url
+    ref: https://github.com/ThreeFish-AI/negentropy/blob/master/docs/.agents/pdf-harness-engineering-parity.md
     title: PDF 一比一还原质量迭代（§9 R10 九项修复）
     lazy: true

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0090_reseed_pdf_fidelity_restore_skill.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0090_reseed_pdf_fidelity_restore_skill.py
@@ -1,0 +1,246 @@
+"""Re-seed: pdf-fidelity-restore 全局技能内容刷新（R10 沉淀 + 死链修正）
+
+Revision ID: 0090
+Revises: 0089
+Create Date: 2026-07-05 00:00:00.000000+00:00
+
+设计动机：
+    0064 以 ``ON CONFLICT (name) DO NOTHING`` 首发种子了 ``pdf-fidelity-restore`` 全局技能行，
+    其 ``prompt_template`` / ``resources`` 是**冻结快照**。运行时 ``skills_injector.resolve_skills``
+    注入的是 **DB 行**（非 YAML/SKILL.md），故仅改 ``skill_templates/*.yaml`` 与
+    ``.agent/skills/*/SKILL.md`` 不会触达 live 的一核五翼 Agent —— 必须以一次非破坏 re-seed
+    把 R10 沉淀（热更铁律：改 perceives 须重启 MCP + 清 ``.batch_state``；关键洞察：切片无共享
+    可变状态 / 1:1 验收须到浏览器渲染态 / 图注勿双渲染）与 perceives 死链修正推到 DB 行。
+
+正交分解：
+    0064 专注「首发创建」（INSERT），本迁移专注「内容刷新」（UPDATE + 新版本快照），
+    不重复创建、不删除主行（主行的生命周期由 0064 owns）。
+
+幂等性 / 非破坏：
+    - upgrade：按 ``name`` 精确 UPDATE 现有行的 ``prompt_template`` / ``resources`` / ``version``
+      （行不存在则 UPDATE 影响 0 行，安全）；``skill_versions`` 1.1.0 快照以 ``NOT EXISTS`` 守卫。
+      重跑写入相同值，安全。
+    - downgrade：**非破坏 no-op**（AGENTS.md「谨慎回滚，严禁删数据」）。不删主行（那是 0064
+      downgrade 的职责），不回退内容（1.1.0 快照保留于 skill_versions 供审计）。
+
+SSOT 提示：
+    本迁移内嵌的 ``PROMPT_TEMPLATE`` / ``RESOURCES`` 是 R10 版**冻结快照**（Alembic 不可变原则），
+    与「活」定义 ``skill_templates/pdf_fidelity_restore.yaml``（version 1.1.0）+
+    ``.agent/skills/pdf-fidelity-restore/SKILL.md`` 首发内容一致。二 twin 骨架一致性由
+    ``tests/unit_tests/agents/test_skill_pdf_fidelity_parity.py`` 守卫。
+
+部署注意：
+    裸 SQL UPDATE **不触发** ``skills_injector.invalidate_global_skills_cache`` 的进程内失效；
+    已 warm 的引擎需重启（或等缓存 TTL）方见 1.1.0 正文。迁移随部署重启一并生效。
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "0090"
+down_revision: str | None = "0089"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+SKILL_NAME = "pdf-fidelity-restore"
+NEW_VERSION = "1.1.0"
+
+# R10 版正文冻结快照（与 skill_templates/pdf_fidelity_restore.yaml@1.1.0 一致）
+PROMPT_TEMPLATE = """你是「PDF 高保真还原」专家。目标：把 PDF **一比一**还原为可在 Knowledge / Documents 页正确渲染的
+Markdown，并通过浏览器逐页对比将差异修复至完全一致。
+
+## 输入
+- pdf_source：``{{ pdf_source }}``（本地绝对路径或 http(s) URL）
+- corpus_name：``{{ corpus_name }}``（目标 Corpus，默认 Harness Engineering）
+- method：``{{ method }}``（perceives 引擎：auto / smart / docling / mineru / marker / pymupdf / pypdf）
+- 分批：batch_page_size=``{{ batch_page_size }}``，batch_threshold_pages=``{{ batch_threshold_pages }}``
+
+## 一比一还原范围（缺一不可）
+文字、段落顺序、高清原图、**图片显示尺寸**、目录(TOC/锚点)、表格、数学公式(LaTeX/KaTeX)、
+代码块(语言与高亮)、脚注/注释。
+
+## 流程（自驱闭环）
+1. **基准**：用用户常用浏览器（真实登录态）打开源 PDF（``file://`` 或 URL）作为对照基线；不得绕过/模拟任何登录。
+2. **路由就绪**：确认目标 Corpus 的 ``config.extractor_routes`` 已把 ``source_kind=pdf`` 路由到
+   ``negentropy-perceives.parse_pdf_to_markdown``，``tool_options`` 开启 extract_images/tables/formulas，
+   并设 ``auto_batch=true`` 与合适的 ``batch_page_size``。
+3. **分批摄取**：经 Documents Ingest 上传 PDF。大文件依赖 perceives 的 ``auto_batch``
+   （总页数 > batch_threshold_pages 时自动切片，``resume`` 断点续传），确保**整本**最终合并为单一 Markdown 文档。
+4. **等待完成**：轮询文档 ``markdown_extract_status`` 至 ``completed``（失败则查 ``markdown_extract_error`` 并 refresh 重试）。
+5. **渲染核对**：在 Documents 页 View 渲染结果（react-markdown + remark-gfm/math + rehype-katex/raw/highlight/sanitize）。
+6. **逐页对比**：按上「一比一还原范围」逐页 / 逐模块比对源 PDF 与渲染 Markdown，逐条记录差异（页号 + 类别 + 现象）。
+7. **发现一处修一处（分层修复路由）**：
+   - **渲染层**：DocumentMarkdownRenderer / sanitize schema / DocumentImage（图片宽高、表格、KaTeX、代码高亮、figure/figcaption、TOC 锚点）。
+   - **摄取层**：图片链接重写、资产存储、元数据。
+   - **管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取。
+   - **热更铁律（改 perceives src/ 后必做，否则改动不生效）**：① 重启 perceives MCP 进程（Python 无热重载）；② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF 内容 SHA-1 缓存切片，不清则复用旧切片、跳过新代码，且完成异常快）。
+   改后经 refresh_markdown 重摄取或重载页面（**已清 checkpoint**），复核该项。
+8. **循环**：重复 6–7，直到逐页校验清单全绿；保留关键页源 PDF vs 渲染 Markdown 对比截图为证。
+
+## 关键洞察（R10 沉淀）
+- **auto_batch 切片间无共享可变状态**：引擎实例在 pool 复用时产物落盘目录须 per-call 唯一（`tempfile.mkdtemp`）；级联/册封类状态（如 `_first_h1_seen`）须显式接收 `slice_index`，否则跨切片泄漏（标题层级错乱 / 公式重现）。
+- **1:1 验收必须走到浏览器渲染态**：figure 过度捕获、KaTeX ParseError、公式双份等缺陷在 DB markdown 层不可见，仅浏览器渲染后暴露。
+- **figure 图注双源风险**：多数图注已烘入 figure region PNG 像素，故 wiki/ui **不得**再从 `alt` 渲染 `figcaption`（会双图注）；caption 语义由 `alt` 承载（无障碍 + 去重指纹），视觉由图内像素承载。
+
+## 反模式（严禁）
+- 跳过逐页核对即声明完成；
+- 只比文字而忽略图 / 表 / 公式 / 代码 / 注释；
+- 图片不还原原始显示尺寸（宽高）。
+
+## 完成判据
+逐页校验清单全绿 + 关键页对比截图留证 + 整本 PDF 在 Documents 页可读性与一致性达最佳。
+
+## 资源 / 基线示例（R10）
+- 基线 PDF：`Self-Improving Agents in the Era of Experience: A Survey of Self- to Meta-Evolution.pdf`（88 页 / A4 双栏 LaTeX；corpus「Harness Engineering」）。
+- 基线 wiki 渲染对照：`http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/`
+- perceives 管线源码：`apps/negentropy-perceives`（monorepo `ThreeFish-AI/negentropy`，默认分支 `master`）。
+- 迭代记录：`docs/.agents/pdf-harness-engineering-parity.md` §9（R10 九项修复）。
+"""
+
+DESCRIPTION = (
+    "用 negentropy-perceives 的 parse_pdf_to_markdown 经 Knowledge Base Documents Ingest 将 PDF "
+    "一比一还原为可渲染 Markdown（文字、段落顺序、高清原图、图片显示尺寸、目录、表格、数学公式、"
+    "代码块、注释），大文件分批，逐页浏览器对比、发现一处修一处，直至完全一致。"
+)
+
+REQUIRED_TOOLS = ["data-extractor", "parse_pdf_to_markdown", "ingest_to_corpus"]
+
+CONFIG_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "pdf_source": {"type": "string", "description": "本地绝对路径或 http(s) URL 的 PDF 源"},
+        "corpus_name": {
+            "type": "string",
+            "default": "Harness Engineering",
+            "description": "目标 Knowledge Corpus 名称",
+        },
+        "method": {
+            "type": "string",
+            "enum": ["auto", "smart", "docling", "mineru", "marker", "pymupdf", "pypdf"],
+            "default": "auto",
+            "description": "perceives 解析引擎",
+        },
+        "batch_page_size": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 40,
+            "description": "auto_batch 单切片最大页数",
+        },
+        "batch_threshold_pages": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 60,
+            "description": "超过该页数才启用 auto_batch 分批",
+        },
+    },
+    "required": ["pdf_source"],
+}
+
+DEFAULT_CONFIG = {
+    "corpus_name": "Harness Engineering",
+    "method": "auto",
+    "batch_page_size": 40,
+    "batch_threshold_pages": 60,
+}
+
+# R10 版 resources：修 0064 的 perceives 死链（github.com/negentropy/...）→ monorepo 子树，
+# 并追加 wiki 基线示例与 parity 迭代文档指针。
+RESOURCES = [
+    {
+        "type": "corpus",
+        "ref": "harness-engineering",
+        "title": "Harness Engineering corpus（默认目标语料库）",
+        "lazy": True,
+    },
+    {
+        "type": "url",
+        "ref": "https://github.com/ThreeFish-AI/negentropy/tree/master/apps/negentropy-perceives",
+        "title": "negentropy-perceives parse_pdf_to_markdown 管线源码（monorepo，master）",
+        "lazy": True,
+    },
+    {
+        "type": "url",
+        "ref": "http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/",
+        "title": "R10 基线示例（88 页综述 wiki 渲染对照）",
+        "lazy": True,
+    },
+    {
+        "type": "doc",
+        "ref": "docs/.agents/pdf-harness-engineering-parity.md",
+        "title": "PDF 一比一还原质量迭代（§9 R10 九项修复）",
+        "lazy": True,
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # --- 非破坏 UPDATE：仅刷新现有行的正文/资源/版本（行不存在则影响 0 行，安全）---
+    conn.execute(
+        sa.text(
+            f"""
+        UPDATE {SCHEMA}.skills
+        SET prompt_template = :prompt_template,
+            resources = :resources,
+            version = :version,
+            updated_at = now()
+        WHERE name = :name
+        """
+        ).bindparams(
+            sa.bindparam("prompt_template", value=PROMPT_TEMPLATE, type_=sa.Text),
+            sa.bindparam("resources", value=RESOURCES, type_=JSONB),
+            sa.bindparam("version", value=NEW_VERSION, type_=sa.Text),
+            sa.bindparam("name", value=SKILL_NAME, type_=sa.Text),
+        )
+    )
+
+    # --- 新版本快照（NOT EXISTS 守卫；让 name@1.1.0 引用可用，且保留审计轨迹）---
+    skill_id = conn.execute(
+        sa.text(f"SELECT id FROM {SCHEMA}.skills WHERE name = :name").bindparams(
+            sa.bindparam("name", value=SKILL_NAME, type_=sa.Text)
+        )
+    ).scalar()
+    if skill_id is not None:
+        snapshot = {
+            "name": SKILL_NAME,
+            "display_name": "PDF 高保真还原 (PDF Fidelity Restore)",
+            "description": DESCRIPTION,
+            "category": "knowledge",
+            "prompt_template": PROMPT_TEMPLATE,
+            "config_schema": CONFIG_SCHEMA,
+            "default_config": DEFAULT_CONFIG,
+            "required_tools": REQUIRED_TOOLS,
+            "priority": 20,
+            "enforcement_mode": "warning",
+            "resources": RESOURCES,
+            "is_global": True,
+        }
+        conn.execute(
+            sa.text(
+                f"""
+            INSERT INTO {SCHEMA}.skill_versions (skill_id, version, snapshot)
+            SELECT :skill_id, :version, :snapshot
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {SCHEMA}.skill_versions WHERE skill_id = :skill_id AND version = :version
+            )
+            """
+            ).bindparams(
+                sa.bindparam("skill_id", value=skill_id),
+                sa.bindparam("version", value=NEW_VERSION, type_=sa.Text),
+                sa.bindparam("snapshot", value=snapshot, type_=JSONB),
+            )
+        )
+
+
+def downgrade() -> None:
+    # 非破坏 no-op：不删主行（0064 owns 创建/删除），不回退正文；1.1.0 快照保留于
+    # skill_versions 供审计。内容再回退可手工从 1.0.0 skill_versions 快照恢复。
+    pass

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0090_reseed_pdf_fidelity_restore_skill.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0090_reseed_pdf_fidelity_restore_skill.py
@@ -172,8 +172,8 @@ RESOURCES = [
         "lazy": True,
     },
     {
-        "type": "doc",
-        "ref": "docs/.agents/pdf-harness-engineering-parity.md",
+        "type": "url",
+        "ref": "https://github.com/ThreeFish-AI/negentropy/blob/master/docs/.agents/pdf-harness-engineering-parity.md",
         "title": "PDF 一比一还原质量迭代（§9 R10 九项修复）",
         "lazy": True,
     },

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
@@ -71,9 +71,12 @@ PATROL_SYSTEM_PROMPT = (
 - 改 perceives 仅 `grep -rn` 定位目标函数、只读该函数上下文，**单轮最多改一处**。
 - 候选 Markdown 只写指定候选路径，**绝不调生产 refresh-markdown / 写 knowledge_documents.markdown_content**。
 - 仅在 worktree 内改代码；源 PDF 只读。
+- **checkpoint 热更铁律**：每轮重转前 `rm -rf output/.batch_state`——auto_batch resume 按源 PDF SHA-1 缓存切片，不清则复用旧切片、你的 perceives 改动不生效（曾致 R10 白跑 2 次）；CLI 不暴露 `--no-resume`，只能靠清 checkpoint。
+- **图注勿双渲染**：多数图注已烘入 figure region PNG 像素，勿据 `alt` 另 render `figcaption`（会双图注）；仅核对像素内图注与源 PDF 是否一致。
 
 ## 闭环（严格顺序，勿偏离）
-1. 重转候选（baseline 转换，图片/表格/公式默认全提取）：
+1. 重转候选（**每轮先清 checkpoint 再转**；图片/表格/公式默认全提取）：
+   `rm -rf output/.batch_state`  # auto_batch resume 按源 PDF SHA-1 缓存切片，不清则复用旧切片、perceives 改动不生效
    `uv run --project apps/negentropy-perceives perceives parse-pdf "<source_pdf_path>" -o "<candidate_md_path>" --method auto`
 2. 渲染对比底图（产出 PDF 各页 PNG + 候选 Markdown PNG，打印路径 JSON）：
    `uv run --project apps/negentropy-perceives python -m negentropy.perceives.tools._fidelity_render --pdf "<source_pdf_path>" --markdown "<candidate_md_path>" --out-dir "/tmp/<doc_id>/render" --dpi 120 --width 900`

--- a/apps/negentropy/tests/unit_tests/agents/test_skill_pdf_fidelity_parity.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_skill_pdf_fidelity_parity.py
@@ -1,0 +1,70 @@
+"""SKILL.md ↔ skill_templates/pdf_fidelity_restore.yaml 双 SSOT 骨架一致性守卫。
+
+两 twin（文件技能 ``.agent/skills/pdf-fidelity-restore/SKILL.md`` 供 Routine 的 Claude Code；
+DB 模板 ``pdf_fidelity_restore.yaml`` 供一核五翼）正文骨架须保持一致（见两文件顶部 SSOT 提示）。
+本测试断言共享章节头 + R10 关键约束子串 + 8 项校验维度在两处**同时存在**，防止改一处漏改
+另一处的静默漂移（此前无任何守卫）。纯文件读取 + YAML 加载，无 DB，亚秒级。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from negentropy.agents.skill_templates import load_all
+
+# 本文件：apps/negentropy/tests/unit_tests/agents/ → parents[5] = 仓库根
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SKILL_MD = _REPO_ROOT / ".agent/skills/pdf-fidelity-restore/SKILL.md"
+
+
+def _yaml_prompt_template() -> str:
+    tpl = {t.template_id: t for t in load_all()}["pdf_fidelity_restore"]
+    return tpl.prompt_template or ""
+
+
+def test_skill_md_file_exists():
+    assert _SKILL_MD.exists(), f"SKILL.md not found at {_SKILL_MD}"
+
+
+def test_twin_shared_section_headers():
+    """共享章节头须同时存在于两 twin（骨架一致）。"""
+    md = _SKILL_MD.read_text(encoding="utf-8")
+    body = _yaml_prompt_template()
+    for header in (
+        "## 输入",
+        "## 一比一还原范围",
+        "## 流程",
+        "## 关键洞察",
+        "## 反模式",
+        "## 完成判据",
+        "## 资源",
+    ):
+        assert header in md, f"SKILL.md missing header {header}"
+        assert header in body, f"YAML prompt_template missing header {header}"
+
+
+def test_twin_r10_constraints_present_in_both():
+    """R10 沉淀的关键约束子串须同时存在于两 twin（改一处漏另一处即红）。"""
+    md = _SKILL_MD.read_text(encoding="utf-8")
+    body = _yaml_prompt_template()
+    for needle in ("热更", ".batch_state", "figcaption", "浏览器渲染态", "slice_index"):
+        assert needle in md, f"SKILL.md missing R10 constraint: {needle}"
+        assert needle in body, f"YAML prompt_template missing R10 constraint: {needle}"
+
+
+def test_twin_fidelity_dimensions_present_in_both():
+    """一比一还原的 8 项维度须同时存在于两 twin。"""
+    md = _SKILL_MD.read_text(encoding="utf-8")
+    body = _yaml_prompt_template()
+    for dim in ("段落顺序", "图片显示尺寸", "目录", "表格", "数学公式", "代码块", "脚注"):
+        assert dim in md, f"SKILL.md missing dimension: {dim}"
+        assert dim in body, f"YAML prompt_template missing dimension: {dim}"
+
+
+def test_yaml_version_bumped_and_perceives_link_fixed():
+    """version 升到 1.1.0，且 perceives 资源指针修死链→monorepo 子树。"""
+    tpl = {t.template_id: t for t in load_all()}["pdf_fidelity_restore"]
+    assert tpl.version == "1.1.0"
+    refs = " ".join(str(r.get("ref", "")) for r in tpl.resources)
+    assert "github.com/negentropy/negentropy-perceives" not in refs  # 旧死链已移除
+    assert "ThreeFish-AI/negentropy" in refs  # 指向真实 monorepo

--- a/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
@@ -136,4 +136,6 @@ def test_system_prompt_contains_protocol_and_contract():
     assert "pdf-fidelity-contract" in PATROL_SYSTEM_PROMPT
     # 零代码改动即无 PR（修「PR 仅含 patrol-candidate.md」根因：候选是 worktree 外临时产物、不纳入交付）
     assert "零代码改动" in PATROL_SYSTEM_PROMPT
+    # R10 沉淀：每轮重转前须清 checkpoint，否则 auto_batch resume 复用旧切片、perceives 改动不生效
+    assert ".batch_state" in PATROL_SYSTEM_PROMPT
     assert "doc_id" in CONTRACT_SCHEMA

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2260,6 +2260,7 @@
   3. **1:1 还原验收必须走到浏览器渲染态**：Q7/Q8/Q9 在 DB markdown 层均"看似正确"，仅 KaTeX/图片渲染后才暴露；
   4. **NFKD 折叠是 Unicode 数学↔LaTeX 跨形式去重的前提**：仅保留 ASCII 会把数学字母块（U+1D400–1D7FF）签名坍缩，须先 `unicodedata.normalize("NFKD")`；
   5. **figure caption 双源**：多数 figure caption 已烘入 region PNG 像素，wiki/ui 不宜再从 alt 渲染 figcaption（双图注）。
+  6. **Codify 沉淀（2026-07-05）**：本轮洞察已对齐进三件套——巡检派生 Routine 的 `PATROL_SYSTEM_PROMPT`（`engine/routine/patrol_prompt.py`）step 1 前置 `rm -rf output/.batch_state`（CLI 不暴露 `--no-resume`，只能靠清 checkpoint 生效）；Skill 双 twin（`.agent/skills/pdf-fidelity-restore/SKILL.md` + `skill_templates/pdf_fidelity_restore.yaml@1.1.0`）补「热更铁律 / 关键洞察」并修 perceives 死链，经 migration `0090` 非破坏重播到 live DB 全局技能行（`is_global`，供一核五翼）。
 
 ### 第三轮迭代（2026-05-25 端到端质量回归：断字 / 公式漏检 / 标题误判 / TOC 错乱 / 图片孤儿）
 

--- a/docs/.agents/pdf-harness-engineering-parity.md
+++ b/docs/.agents/pdf-harness-engineering-parity.md
@@ -232,6 +232,13 @@ curl -X POST "http://localhost:3292/knowledge/base/{corpus}/documents/{doc}/refr
 
 ## 9. R10 增量：Self-Improving Agents 综述（88 页 / A4 双栏 LaTeX）
 
+### 9.0 基线样本（Codify 锚点）
+
+- **源 PDF**：`/Users/cm.huang/Documents/projects/aurelius/negentropy/assets/papers/source/Self-Improving Agents in the Era of Experience: A Survey of Self- to Meta-Evolution.pdf`（88 页 / A4 双栏 LaTeX）。
+- **Corpus**：Harness Engineering（`corpus_id=43bacd7e-d334-4ebe-b3f8-c724ce24ba6a`，`doc_id=9045a031-4a52-4992-b0ae-285dc76dac1a`）。
+- **wiki 渲染对照**：`http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/`
+- **同源三件套**：Skill [`.agent/skills/pdf-fidelity-restore/SKILL.md`](../../.agent/skills/pdf-fidelity-restore/SKILL.md) + [`skill_templates/pdf_fidelity_restore.yaml`](../../apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml)（DB 重播见 migration `0090`）；巡检派生 Routine 定义 [`patrol_prompt.py`](../../apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py)。本文档为该三件套的 **R10 基线示例**（巡检仍动态选文档，本 PDF 不固定为回归锚点）。
+
 ### 9.1 引发背景
 
 R9 基线是单栏教材（Agentic Design Patterns）；R10 选取 *Self-Improving Agents

--- a/docs/.agents/pdf-harness-engineering-parity.md
+++ b/docs/.agents/pdf-harness-engineering-parity.md
@@ -234,6 +234,8 @@ curl -X POST "http://localhost:3292/knowledge/base/{corpus}/documents/{doc}/refr
 
 ### 9.0 基线样本（Codify 锚点）
 
+> **环境相关样本（非跨环境常量）**：以下源 PDF 绝对路径、`corpus_id` / `doc_id` 与 `localhost` 端口均为本机快照——源 PDF 未入库（`git ls-files | grep assets/papers` 为空），UUID 随 Postgres 实例而变，`localhost:3092` 为本机静态服务端口。跨环境复现请按各自部署替换 PDF 路径 / corpus / doc ID / wiki 域名端口。
+
 - **源 PDF**：`/Users/cm.huang/Documents/projects/aurelius/negentropy/assets/papers/source/Self-Improving Agents in the Era of Experience: A Survey of Self- to Meta-Evolution.pdf`（88 页 / A4 双栏 LaTeX）。
 - **Corpus**：Harness Engineering（`corpus_id=43bacd7e-d334-4ebe-b3f8-c724ce24ba6a`，`doc_id=9045a031-4a52-4992-b0ae-285dc76dac1a`）。
 - **wiki 渲染对照**：`http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/`


### PR DESCRIPTION
## 背景

将「PDF→Markdown 一比一高保真还原」任务**沉淀并对齐**到三件套（已存在且在运行的 Scheduler `PDF Fidelity Patrol`、Skill `PDF 高保真还原`、派生 Routine 启动定义）。本 88 页 Self-Improving Agents 综述已在 R10（#1047）完成九项失真修复并经 :3092 浏览器验证，故本 PR 本质是**对齐/固化**而非从零还原：把 R10 沉淀的硬约束与洞察权威写进三件套，修发现的漂移。

## 改动清单（Phase A，纯代码/文档/迁移）

### 1. Skill 双 SSOT（文件 + DB 模板）
- `.agent/skills/pdf-fidelity-restore/SKILL.md` 与 `skill_templates/pdf_fidelity_restore.yaml@1.1.0` 同步：
  - **热更铁律**：改 perceives `src/` 后必须 ① 重启 MCP 进程（Python 无热重载）② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF-SHA1 缓存切片，不清则复用旧切片、跳过新代码）。
  - **关键洞察（R10 沉淀）**：auto_batch 切片间无共享可变状态（`slice_index` 不变量 / 引擎产物 per-call 唯一目录）；1:1 验收必须走到浏览器渲染态；figure 图注多已烘入 PNG → 勿再从 alt 渲染 figcaption（双图注）。
  - **修死链**：`resources` 的 perceives 指针 `github.com/negentropy/negentropy-perceives`（404）→ monorepo 子树 `github.com/ThreeFish-AI/negentropy/tree/master/apps/negentropy-perceives`。
  - **钉基线示例**：本 88 页综述 + wiki :3092 URL 记为 R10 基线样本（巡检仍动态选文档，不改选择逻辑）。

### 2. 迁移 `0090_reseed_pdf_fidelity_restore_skill`
- 运行时 `skills_injector` 注入读 **DB 行**而非 YAML；0064 是 `ON CONFLICT DO NOTHING`，改 YAML/SKILL.md 不触达 live 全局技能（`is_global`，供一核五翼）。0090 用**非破坏 UPDATE** 把 R10 正文/资源推到 DB 行 + 写 `skill_versions` 1.1.0 快照；`downgrade` 为 no-op（不删数据）。

### 3. 派生 Routine 定义 `patrol_prompt.py`
- `PATROL_SYSTEM_PROMPT` step 1 前置 `rm -rf output/.batch_state`：CLI 不暴露 `--no-resume`，改 perceives 后 resume 会复用旧切片、改动不生效（曾致 R10 白跑 2 次）。硬性约束补 checkpoint 热更铁律 + 图注勿双渲染。

### 4. 测试
- 新增 `test_skill_pdf_fidelity_parity.py`：守卫 SKILL.md ↔ YAML 正文骨架一致（共享章节头 + R10 关键子串 `.batch_state`/`figcaption`/`浏览器渲染态`/`slice_index` + 8 维校验 + 版本/死链修正），此前二 twin 无任何守卫、易静默漂移。
- `test_patrol_prompt.py` 增 `assert ".batch_state" in PATROL_SYSTEM_PROMPT`。

### 5. 文档
- `pdf-harness-engineering-parity.md` §9.0：钉本 PDF 路径/corpus_id/doc_id/wiki URL 为 R10 基线样本。
- `issue.md` R10 同条目防范要点补 #6（codify 沉淀），同 Issue 不多处维护。

## 验证
- 目标单测全绿：`test_skill_templates` + `test_skill_pdf_fidelity_parity` + `test_patrol_prompt`（20 passed）+ `test_pdf_fidelity_patrol_handler`（19 passed）。
- `alembic heads` 单 head `0090`；conftest 真实测试 DB 已应用 0090 upgrade 无 alembic 漂移。
- ruff lint + format 全过；pre-commit 全过。

## 风险
- 迁移用裸 SQL UPDATE 不触发 `invalidate_global_skills_cache` 的进程内失效 → **部署后需重启引擎**或等缓存 TTL，1.1.0 正文才对 warm 进程生效。
- `is_global` 技能注入全体 Agent；新增内容全在 `prompt_template`/`resources`（懒加载），常驻 `description` 未膨胀。
- 并发分支再加迁移会致多 head，`alembic heads` 已兜底。

## 后续（非本 PR 范围）
- **Phase B 端到端复验**：逐页 8 维浏览器对比源 PDF（CLI `_fidelity_render` 工作区可独立跑；live UI :3192 / wiki :3092 区分三渲染面，防假验证）。若发现新缺陷则进入 R11 修复环。
- **Phase C 激活巡检**：env override `NE_ROUTINE_ENABLED/PATROL_ENABLED=true` + 回填目标文档 `display_name`（命名闸门阻断项）+ live 引擎 3292 重启 + 两级状态观察（涉 live 部署，设 20 轮/$30 护栏首跑）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>