### PR TITLE
fix(perceives): PDF→Markdown 高保真 R11 长尾抛光（封面icon/URL/引用括号/数学下标/度数）

### DIFF
--- a/.github/workflows/negentropy-perceives-ci.yml
+++ b/.github/workflows/negentropy-perceives-ci.yml
@@ -194,6 +194,13 @@ jobs:
             --ignore-vuln PYSEC-2025-217
             --ignore-vuln PYSEC-2025-218
 
+            # transformers <5.3.0 模型加载路径 RCE（CVE-2026-4372：恶意 config.json 绕过
+            # trust_remote_code）；本项目不直接调用 transformers（经 docling / marker-pdf /
+            # surya 间接依赖），且仅加载第一方模型 artifact、不加载不可信 HF 仓库，攻击向量
+            # 不可达；transformers 锁定 <5.0.0 受 marker-pdf / docling 兼容交集制约（与上方
+            # PYSEC-2025-211..218 同约束），待交集支持 5.3.0+ 后升级
+            --ignore-vuln CVE-2026-4372
+
             # torch 2.10.0 本地内存破坏 / DoS，需攻击者构造恶意 tensor / pt2 文件；
             # 本项目仅加载第一方模型 artifact，无不可信输入路径，upstream 暂无 fix
             --ignore-vuln PYSEC-2025-189

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -458,12 +458,19 @@ _TIGHTEN_CITATION_BRACKET_MIN_LEN = 4
 # R11-B2：URL 路径段换行拆分空格折叠。
 # 匹配 ``https?://domain.tld`` 后的路径段（每段以 ``/`` 起始，允许两侧单空格
 # 容纳 PyMuPDF 换行插入的空格），由 ``_collapse_url_path_spaces`` 把斜杠两侧
-# 空格清零。完好 URL（无空格）经 ``\s*/\s*`` → ``/`` 等价替换零影响。
-_URL_PATH_SPACES_RE = re.compile(r"https?://[\w.-]+(?:\s*/\s*[\w.\-~%?:@&=+,#()*]+)+")
+# 空格清零。完好 URL（无空格）经 ``[ \t]*/[ \t]*`` → ``/`` 等价替换零影响。
+# R11-B2 fix：用 ``[ \t]*`` 而非 ``\s*``——本 pass 经 ``protect_math_content``
+# 全文档一次性调用（仅保护 ``$...$``，不保护散文/代码块），``\s*`` 跨 ``\n`` 会让
+# 行尾裸 URL 与下一行 ``/...`` 起首融合（``.../v2\n/key`` → ``.../v2/key``）。
+# PyMuPDF 的换行插入物是单个空格，``[ \t]*`` 既能覆盖又不会跨行。
+_URL_PATH_SPACES_RE = re.compile(
+    r"https?://[\w.-]+(?:[ \t]*/[ \t]*[\w.\-~%?:@&=+,#()*]+)+"
+)
 
 
 def _collapse_url_path_spaces(m: re.Match) -> str:
-    return re.sub(r"\s*/\s*", "/", m.group(0))
+    # 仅折叠行内空格/制表符——跨行融合由外层正则的 ``[ \t]*`` 边界阻断。
+    return re.sub(r"[ \t]*/[ \t]*", "/", m.group(0))
 
 
 def _tighten_citation_bracket(m: re.Match) -> str:
@@ -1366,13 +1373,16 @@ class MarkdownFormatter:
                 # R11-A：封面按钮行 icon 字形清理。``HomePage \xa7 GitHub`` 中的 ``\xa7``
                 # 是 GitHub 图标的 icon-font mojibake（非章节号），紧邻两个已知
                 # 按钮词时剥离。前置 ``\x80`` 等已由 _basic_cleanup 的 C1 strip 清除。
-                # 仅在按钮词之间命中，避免误伤 ``\xa78.2`` / ``\xa7 References`` 等章节引用。
+                # R11-A fix：第一组限定为封面按钮实际用词 ``HomePage|Homepage``（不再
+                # 含 ``Page|Site|Website|Demo`` 等散文常用词），并去掉 ``IGNORECASE``——
+                # 避免误伤 ``Site \xa7 Source`` / ``Page \xa7 Repository`` 等真实 ``\xa7``
+                # 章节引用（综述散文中 ``\xa7`` 是合法章节号）。封面按钮为固定 title-case，
+                # 第二组已显式列举 ``Github|GitHub`` 双大小写，case-sensitive 仍能命中。
                 text = re.sub(
-                    r"\b(HomePage|Homepage|Page|Site|Website|Demo)\s*\xa7\s+"
+                    r"\b(HomePage|Homepage)\s*\xa7\s+"
                     r"(Github|GitHub|Code|Project|Repository|Source|Repo|Docs|Documentation)\b",
                     r"\1 \2",
                     text,
-                    flags=re.IGNORECASE,
                 )
 
                 # \u5f15\u7528\u7f16\u53f7\u7a7a\u683c\u538b\u7f29\uff1a"[ 103 ]" \u2192 "[103]"\uff0c"[ 95, 99, 105 ]" \u2192 "[95, 99, 105]"

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -443,6 +443,42 @@ def _has_math_alnum_block(s: str) -> bool:
     return any(0x1D400 <= ord(c) <= 0x1D7FF for c in s)
 
 
+# R11-C：作者-年份引用括号内侧空格压缩的判定函数。
+# 命中条件——括号内容满足任一引用信号：
+#   - 含 4 位年份（``1999``–``2099``），允许尾部单个消歧小写字母（``2026b``）；
+#   - 含 ``et al.``（多作者引用）。
+# 不命中则原样返回，避免误伤 ``[CLS]`` / ``[MASK]`` / ``[note]`` 等 token 记号
+# 与 GFM 任务框 ``[ ]`` / ``[x]``（内容非空但无引用信号）。
+# 注：年份后 ``[a-z]?`` 适配 ``\citep`` 风格的 ``2026b`` / ``2025a`` 消歧后缀——
+# 单纯 ``\b2026\b`` 在 ``2026b`` 处无词边界（``b`` 亦 word char），会漏判。
+_CITATION_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}[a-z]?\b")
+_TIGHTEN_CITATION_BRACKET_MIN_LEN = 4
+
+
+# R11-B2：URL 路径段换行拆分空格折叠。
+# 匹配 ``https?://domain.tld`` 后的路径段（每段以 ``/`` 起始，允许两侧单空格
+# 容纳 PyMuPDF 换行插入的空格），由 ``_collapse_url_path_spaces`` 把斜杠两侧
+# 空格清零。完好 URL（无空格）经 ``\s*/\s*`` → ``/`` 等价替换零影响。
+_URL_PATH_SPACES_RE = re.compile(r"https?://[\w.-]+(?:\s*/\s*[\w.\-~%?:@&=+,#()*]+)+")
+
+
+def _collapse_url_path_spaces(m: re.Match) -> str:
+    return re.sub(r"\s*/\s*", "/", m.group(0))
+
+
+def _tighten_citation_bracket(m: re.Match) -> str:
+    inner = m.group(1)
+    stripped = inner.strip()
+    # 仅当首尾确有被折叠进来的空格时才需要改（避免对正常 ``[Author]`` 反复 hit）
+    if len(inner) == len(stripped):
+        return m.group(0)
+    if len(stripped) < _TIGHTEN_CITATION_BRACKET_MIN_LEN:
+        return m.group(0)
+    if _CITATION_YEAR_RE.search(stripped) or "et al." in stripped:
+        return f"[{stripped}]"
+    return m.group(0)
+
+
 class MarkdownFormatter:
     """Markdown formatting pipeline for enhancing raw Markdown output."""
 
@@ -1306,8 +1342,54 @@ class MarkdownFormatter:
                 # \u81f4 ``<!-- orphan images ... -->`` \u88ab\u7834\u574f\u4e3a\u53ef\u89c1\u5783\u573e ``<!\u2014 \u2026 \u2014>``\u3002
                 text = re.sub(r"(?<![!\-])\-\-(?![\->])", "\u2014", text)
 
+                # R11-B\uff1aURL \u534f\u8bae\u88ab\u62c6\u5206\u7a7a\u683c\u538b\u7f29 ``https: //`` \u2192 ``https://``\u3002
+                # References \u533a PyMuPDF \u62bd\u53d6 ``https://`` \u65f6\u628a ``://`` \u62c6\u4e3a
+                # ``:`` + `` //`` \u4e24\u4e2a span\uff0c``" ".join`` \u63d2\u5165\u7a7a\u683c\u3002\u538b\u7f29\u540e\u88f8 URL
+                # \u7531 remark-gfm autolink \u81ea\u52a8\u6e32\u67d3\u4e3a\u53ef\u70b9\u51fb\u94fe\u63a5\uff0c\u6062\u590d PDF \u8d85\u94fe\u63a5\u4fdd\u771f\u3002
+                text = re.sub(r"\b(https?:)\s+//", r"\1//", text)
+
+                # R11-B2\uff1aURL \u8def\u5f84\u6bb5\u88ab\u6362\u884c\u7b26\u62c6\u5206\u7a7a\u683c\u538b\u7f29\u3002
+                # ``https://arxiv.org/ abs/2604.06126`` \u2192 ``https://arxiv.org/abs/2604.06126``\u3002
+                # PyMuPDF \u5728 URL \u8def\u5f84\u6362\u884c\u5904\u63d2\u5165\u7a7a\u683c\uff08\u659c\u6760\u540e\uff09\uff0cReferences \u533a 21 \u5904\u3002
+                # \u5339\u914d ``https?://domain.tld`` \u540e\u7684\u8def\u5f84\u6bb5\uff08\u5141\u8bb8 ``/`` \u4e24\u4fa7\u5355\u7a7a\u683c\uff09\uff0c
+                # \u628a\u659c\u6760\u4e24\u4fa7\u7a7a\u683c\u5168\u90e8\u6298\u53e0\u3002\u5b8c\u597d\u7684 URL\uff08\u65e0\u7a7a\u683c\uff09\u96f6\u5f71\u54cd\u3002
+                text = _URL_PATH_SPACES_RE.sub(_collapse_url_path_spaces, text)
+
+                # R11-F\uff1a\u5ea6\u6570\u7b26\u53f7\u8131\u79bb\u4fee\u590d\u3002PDF \u4e2d ``45\u00b0`` \u88ab PyMuPDF \u62bd\u4e3a ``45 \u25e6``
+                # \uff08U+25E6 WHITE BULLET \u8bef\u4ee3 U+00B0 DEGREE SIGN\uff0c\u4e14\u4e0e\u6570\u5b57\u95f4\u591a\u7a7a\u683c\uff09\u3002
+                # \u4ec5\u5728 ``\u25e6`` \u7d27\u8ddf\u6570\u5b57\uff08\u53ef\u9009\u7a7a\u683c\uff09\u65f6\u8fd8\u539f\u4e3a ``\u00b0`` \u5e76\u8d34\u5408\u2014\u2014\u8868\u683c\u4e2d\u72ec\u7acb\u7684
+                # ``\u25e6``\uff08partial-support \u6807\u8bb0\uff0cTable 5 \u7b49\uff09\u65e0\u6570\u5b57\u524d\u7f00\uff0c\u4e0d\u53d7\u5f71\u54cd\u3002
+                # \u7528\u975e raw \u5b57\u7b26\u4e32\u8ba9 Python \u5148\u628a ``\u25e6``/``\u00b0`` \u89e3\u7801\u4e3a\u5b57\u9762\u5b57\u7b26\uff0c
+                # \u518d\u4ea4 re \u5339\u914d\uff08re \u4e0d\u652f\u6301 ``\uHHHH`` escape\uff0craw \u4e32\u4f1a\u62a5 bad escape\uff09\u3002
+                text = re.sub("(\\d)\\s*\u25e6", "\\1\u00b0", text)
+
+                # R11-A：封面按钮行 icon 字形清理。``HomePage \xa7 GitHub`` 中的 ``\xa7``
+                # 是 GitHub 图标的 icon-font mojibake（非章节号），紧邻两个已知
+                # 按钮词时剥离。前置 ``\x80`` 等已由 _basic_cleanup 的 C1 strip 清除。
+                # 仅在按钮词之间命中，避免误伤 ``\xa78.2`` / ``\xa7 References`` 等章节引用。
+                text = re.sub(
+                    r"\b(HomePage|Homepage|Page|Site|Website|Demo)\s*\xa7\s+"
+                    r"(Github|GitHub|Code|Project|Repository|Source|Repo|Docs|Documentation)\b",
+                    r"\1 \2",
+                    text,
+                    flags=re.IGNORECASE,
+                )
+
                 # \u5f15\u7528\u7f16\u53f7\u7a7a\u683c\u538b\u7f29\uff1a"[ 103 ]" \u2192 "[103]"\uff0c"[ 95, 99, 105 ]" \u2192 "[95, 99, 105]"
                 text = re.sub(r"\[\s+(\d+(?:\s*,\s*\d+)*)\s+\]", r"[\1]", text)
+
+                # R11-C\uff1a\u4f5c\u8005-\u5e74\u4efd\u5f15\u7528\u62ec\u53f7\u5185\u4fa7\u7a7a\u683c\u538b\u7f29
+                # ``[ Nakano et al., 2022 ]`` \u2192 ``[Nakano et al., 2022]``\u3002
+                # LaTeX hyperref \u7684\u5f15\u7528\u628a ``[`` / \u94fe\u63a5\u6587\u672c / ``]`` \u62bd\u4e3a\u72ec\u7acb span\uff0c
+                # ``" ".join`` \u5728\u62ec\u53f7\u5185\u4fa7\u63d2\u5165\u7a7a\u683c\uff0c\u4e0e PDF \u4e2d\u7d27\u8d34\u6587\u672c\u7684 ``[Author, Year]``
+                # \u4e0d\u4e00\u81f4\uff08\u5168\u6587\u6570\u767e\u5904\uff09\u3002\u538b\u7f29\u540e\u88f8 URL / \u5f15\u7528\u4ea6\u66f4\u5229\u4e8e GFM \u81ea\u52a8\u94fe\u63a5\u3002
+                # \u4ec5\u5f53\u62ec\u53f7\u5185\u5bb9\u51fa\u73b0 4 \u4f4d\u5e74\u4efd\u6216 ``et al.``\uff08\u5f15\u7528\u4fe1\u53f7\uff09\u624d\u538b\u7f29\uff0c\u907f\u514d\u8bef\u4f24
+                # ``[CLS]`` / ``[MASK]`` \u7b49 token \u8bb0\u53f7\u4e0e GFM \u4efb\u52a1\u6846 ``[ ]`` / ``[x]``\u3002
+                text = re.sub(
+                    r"\[([^\[\]\n]{2,})\]",
+                    _tighten_citation_bracket,
+                    text,
+                )
 
                 # \u91cd\u7ec4 PDF \u62c6\u89e3\u7684\u7ec4\u5408\u53d8\u97f3\u7b26\u53f7\uff1a``Pok \u00b4 emon`` / ``Baltru \u02c7 saitis``
                 # / ``Westh \u00a8 au\u00dfer`` / ``Perdig \u02dc ao`` \u7b49\u3002PyMuPDF \u628a
@@ -1708,6 +1790,12 @@ class MarkdownFormatter:
     def _basic_cleanup(self, markdown_content: str) -> str:
         """Apply basic cleanup operations."""
         try:
+            # R11-A：清除 C1 控制字符（U+0080–U+009F）。
+            # 这些是 PDF icon-font 字形的 mojibake 残留（如封面 HomePage 按钮前的
+            # U+0080 渲染为 ），在 markdown 中无意义且破坏视觉。U+0085 (NEL)、
+            # U+008A、U+008D 等同。仅清除 C1 区段，保留 Latin-1 可见字符（U+00A0+）。
+            markdown_content = re.sub(r"[\u0080-\u009f]", "", markdown_content)
+
             lines = []
             for line in markdown_content.split("\n"):
                 cleaned_line = line.rstrip()

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
@@ -411,6 +411,10 @@ _MATH_FONT_PATTERNS: List[re.Pattern] = [
     re.compile(r"Fira\s*Math", re.IGNORECASE),
     re.compile(r"Libertinus\s*Math", re.IGNORECASE),
     re.compile(r"TeX\s*Gyre.*Math", re.IGNORECASE),
+    # R11-D：XCharter 数学字体族（XCharterMathMI 等，Self-Improving Agents 综述使用）。
+    # 命名形态 ``<Foundry>Math<Variant>``，统一用 ``XCharter.*Math`` 覆盖 MI/SY/EX 等变体。
+    re.compile(r"XCharter.*Math", re.IGNORECASE),
+    re.compile(r"Charter.*Math", re.IGNORECASE),
 ]
 
 
@@ -492,13 +496,51 @@ def has_math_unicode(text: str) -> bool:
     return bool(_MATH_UNICODE_CHARS.intersection(text))
 
 
+def math_text_to_latex(text: str) -> str:
+    """将文本中的 Unicode 数学符号**和**数学字母块（U+1D400–1D7FF）映射为 LaTeX。
+
+    比 :func:`unicode_to_latex` 多覆盖数学斜体 / 粗体 / Greek 字母块——
+    ``𝑈`` → ``U``、``𝑡`` → ``t``、``𝔼`` → ``E``、``𝑴`` → ``\\mathbf{M}``。
+    用于 :class:`FormulaReconstructor` 重建行内数学时输出规范 LaTeX，
+    使下游 KaTeX 直接可渲染（而非依赖浏览器对 Unicode 数学字形的兜底渲染）。
+
+    采用「先逐字符映射、再统一补空格」两阶段：在 ``\\name`` 命令（尾字符为字母）
+    与紧邻的字母起首 token 之间插入空格，避免 ``\\langleM`` / ``\\thetat`` /
+    ``\\sigma n`` 粘连致 KaTeX 把 ``\\langleM`` 当作未知命令报 ParseError。
+    命令后跟 ``\\`` 起首的另一命令无需空格（``\\`` 天然终结前一名）。
+    """
+    if not text:
+        return text
+    mapped: list[str] = []
+    for ch in text:
+        if ch in MATH_LETTER_TO_LATEX:
+            mapped.append(MATH_LETTER_TO_LATEX[ch])
+        elif ch in UNICODE_TO_LATEX:
+            mapped.append(UNICODE_TO_LATEX[ch])
+        else:
+            mapped.append(ch)
+    out: list[str] = []
+    for m in mapped:
+        if (
+            out
+            and m
+            and m[0].isalpha()
+            and out[-1]
+            and "\\" in out[-1]
+            and out[-1][-1].isalpha()
+        ):
+            out.append(" ")
+        out.append(m)
+    return "".join(out)
+
+
 def detect_script_type(
     span_size: float,
     span_origin_y: float,
     baseline_y: float,
     normal_size: float,
     size_ratio_threshold: float = 0.75,
-    y_offset_threshold: float = 2.0,
+    y_offset_threshold: float = 1.0,
 ) -> str:
     """通过字号比例和 y 偏移判断上下标类型。
 
@@ -512,6 +554,12 @@ def detect_script_type(
 
     Returns:
         "superscript", "subscript", 或 "normal"
+
+    Note:
+        R11-D：``y_offset_threshold`` 从 2.0 调到 1.0。XCharter 等字体在下标排版上
+        的 baseline drop 仅 ~1.6pt（normal=11pt / sub=7.3pt），旧 2.0 阈值会漏检，
+        把 ``U_t`` 的 ``t`` 误判为 normal 致下标拍平。1.0pt 仍远大于 italic descender
+        的 origin 抖动（descender 不动 origin_y），零回归（既有 5pt 偏移用例不变）。
     """
     if normal_size <= 0:
         return "normal"
@@ -564,20 +612,79 @@ class FormulaReconstructor:
         sizes = [s.get("size", 0) for s in spans if s.get("text", "").strip()]
         if not sizes:
             return ""
-        normal_size = max(set(sizes), key=sizes.count)  # 众数
+        # R11-D2：``normal_size`` 取最大字号（base 文本最大，sub/sup 更小），
+        # 而非众数——纯数学行（所有 span 都是数学字体）若下标 span 数量多于 base
+        # （如 ``M_{\theta t}`` 2 下标 vs 1 base），众数会被下标字号拉低，致全部
+        # 被判 normal、漏 ``_{}`` 包裹。取 max 保证 base 字号被选为参照。
+        normal_size = max(sizes)
         baseline_y = line_dict.get("bbox", [0, 0, 0, 0])[1]
 
-        # 取所有 span 的中位 y 坐标作为基线参考
-        y_origins = [
-            s.get("origin", (0, 0))[1] for s in spans if s.get("text", "").strip()
+        # R11-D2：基线取自「正文字号」span 的 origin_y（正文 baseline），而非所有
+        # span 中位数——含多个下标 span 的行（如 ``M_{\theta t}``，2/3 span 是下标）
+        # 会被下标 origin 把中位数拉低，致下标被误判 normal、漏 ``_{}`` 包裹。
+        normal_origins = [
+            s.get("origin", (0, 0))[1]
+            for s in spans
+            if s.get("text", "").strip() and round(s.get("size", 0), 1) == normal_size
         ]
-        if y_origins:
-            y_origins_sorted = sorted(y_origins)
-            baseline_y = y_origins_sorted[len(y_origins_sorted) // 2]
+        if normal_origins:
+            _nos = sorted(normal_origins)
+            baseline_y = _nos[len(_nos) // 2]
+        else:
+            y_origins = [
+                s.get("origin", (0, 0))[1] for s in spans if s.get("text", "").strip()
+            ]
+            if y_origins:
+                _ys = sorted(y_origins)
+                baseline_y = _ys[len(_ys) // 2]
 
         result_parts: list[str] = []
         in_math = False
         math_buffer: list[str] = []
+        # R11-D2：合并连续同型（sub/sup）span 为单个 ``_{...}``/``^{...}`` 组，
+        # 避免 ``M_{\theta}_{t}`` 双下标 KaTeX ParseError。``pending_*`` 缓冲当前
+        # 同型组的原始字符，flush 时一次性经 ``math_text_to_latex`` 处理（保留
+        # ``\theta t`` 字母间空格、``i-1`` 紧凑数字等正确间距）。
+        pending_script: Optional[str] = None  # "subscript" / "superscript" / None
+        pending_chars: list[str] = []
+
+        def _flush_pending() -> None:
+            nonlocal pending_script, pending_chars
+            if pending_script and pending_chars:
+                marker = "_" if pending_script == "subscript" else "^"
+                content = math_text_to_latex("".join(pending_chars))
+                math_buffer.append(f"{marker}{{{content}}}")
+            pending_script = None
+            pending_chars = []
+
+        def _flush_math() -> None:
+            nonlocal in_math, math_buffer
+            _flush_pending()
+            if in_math and math_buffer:
+                math_content = "".join(math_buffer).strip()
+                if math_content:
+                    _push(f"${math_content}$")
+            in_math = False
+            math_buffer = []
+
+        def _push(new: str) -> None:
+            """R11-D：空格感知追加。
+
+            PyMuPDF span 文本常把词间空格放在相邻 span 的首尾（如 ``" 𝑈"``），
+            数学 span 经 ``strip`` 后丢失左空格，致散文与 ``$...$`` 粘连
+            （``side$U_t$supplies``）。在两个非空格边界之间补一个空格，
+            恢复 ``side $U_t$ supplies`` 的可读间距。
+            """
+            if not new:
+                return
+            if (
+                result_parts
+                and result_parts[-1]
+                and not result_parts[-1][-1].isspace()
+                and not new[0].isspace()
+            ):
+                result_parts.append(" ")
+            result_parts.append(new)
 
         for span in spans:
             text = span.get("text", "")
@@ -596,32 +703,27 @@ class FormulaReconstructor:
                     in_math = True
                     math_buffer = []
 
-                converted = unicode_to_latex(text)
-                if script == "superscript":
-                    converted = f"^{{{converted}}}"
-                elif script == "subscript":
-                    converted = f"_{{{converted}}}"
-                math_buffer.append(converted)
+                if script in ("subscript", "superscript"):
+                    # 同型连续 → 合并到当前组；异型 → 先 flush 再开新组
+                    if pending_script != script:
+                        _flush_pending()
+                        pending_script = script
+                    pending_chars.append(text)
+                else:
+                    # 数学正文 span（normal baseline）—— 先 flush 待并组
+                    _flush_pending()
+                    math_buffer.append(math_text_to_latex(text))
             else:
-                if in_math:
-                    # 结束数学区域
-                    math_content = "".join(math_buffer).strip()
-                    if math_content:
-                        result_parts.append(f"${math_content}$")
-                    in_math = False
-                    math_buffer = []
+                _flush_math()
 
                 # 对普通文本中的 Unicode 数学符号也做转换
                 if has_math_unicode(text):
-                    result_parts.append(f"${unicode_to_latex(text)}$")
+                    _push(f"${math_text_to_latex(text)}$")
                 else:
-                    result_parts.append(text)
+                    _push(text)
 
         # 行末仍在数学模式
-        if in_math and math_buffer:
-            math_content = "".join(math_buffer).strip()
-            if math_content:
-                result_parts.append(f"${math_content}$")
+        _flush_math()
 
         return "".join(result_parts)
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py
@@ -584,6 +584,19 @@ def detect_script_type(
 # 5. FormulaReconstructor（降级路径核心）
 # ---------------------------------------------------------------------------
 
+# R11-D2 fix：display-style 大运算符——在 ``\displaystyle`` 下字号显著大于 body，
+# ``max(sizes)`` 会把它们误选为 ``normal_size``，致 body 操作数 ratio<0.65 被判
+# superscript（见 ``detect_script_type`` 行 578 的 ``ratio < 0.65`` 兜底分支）。
+# 含 sum / product / coproduct / integral 族 / radical；用单字符判定（PyMuPDF
+# 把这类大字形拆为独立 span）。
+_DISPLAY_OPERATOR_CHARS: frozenset[str] = frozenset("∑∏∐∫∬∭∮∯∰√")
+
+
+def _is_display_operator_span(span_dict: Dict) -> bool:
+    """span 是否为单个 display-style 大运算符（∫∑∏√ 等）。"""
+    t = span_dict.get("text", "").strip()
+    return len(t) == 1 and t in _DISPLAY_OPERATOR_CHARS
+
 
 class FormulaReconstructor:
     """基于 PyMuPDF ``get_text("dict")`` 的公式重建器。
@@ -616,7 +629,15 @@ class FormulaReconstructor:
         # 而非众数——纯数学行（所有 span 都是数学字体）若下标 span 数量多于 base
         # （如 ``M_{\theta t}`` 2 下标 vs 1 base），众数会被下标字号拉低，致全部
         # 被判 normal、漏 ``_{}`` 包裹。取 max 保证 base 字号被选为参照。
-        normal_size = max(sizes)
+        # R11-D2 fix：先排除 display-style 大运算符（∫∑∏√ 等）——它们在块公式里
+        # 字号大于 body，直接 max 会选错参照致 body 操作数被判 superscript
+        # （``$\\int^{fx}$``）。排除后无候选（纯运算符行）才回退到全量 max。
+        body_sizes = [
+            s.get("size", 0)
+            for s in spans
+            if s.get("text", "").strip() and not _is_display_operator_span(s)
+        ]
+        normal_size = max(body_sizes) if body_sizes else max(sizes)
         baseline_y = line_dict.get("bbox", [0, 0, 0, 0])[1]
 
         # R11-D2：基线取自「正文字号」span 的 origin_y（正文 baseline），而非所有
@@ -648,12 +669,33 @@ class FormulaReconstructor:
         pending_script: Optional[str] = None  # "subscript" / "superscript" / None
         pending_chars: list[str] = []
 
+        def _append_math(token: str) -> None:
+            """跨 span 的空格感知追加。
+
+            ``math_text_to_latex`` 的补空格逻辑只作用于单个 span 内部；每个 normal
+            baseline span 各自转换后直接 ``join`` 会产生 ``\\int`` + ``f`` → ``\\intf``
+            这类粘连，被 KaTeX 整体当作未知命令名（命令名对字母贪婪）报 ParseError。
+            在 ``\\name`` 命令尾（含 ``\\`` 且尾字符为字母）与紧邻字母起首 token 之间
+            补一个空格，恢复 ``\\int fx``。``_{...}`` / ``^{...}`` / ``\\`` 起首 token
+            无需空格（``\\`` 天然终结前一名，``_/^`` 非字母）。
+            """
+            if (
+                math_buffer
+                and math_buffer[-1]
+                and "\\" in math_buffer[-1]
+                and math_buffer[-1][-1].isalpha()
+                and token
+                and token[0].isalpha()
+            ):
+                math_buffer.append(" ")
+            math_buffer.append(token)
+
         def _flush_pending() -> None:
             nonlocal pending_script, pending_chars
             if pending_script and pending_chars:
                 marker = "_" if pending_script == "subscript" else "^"
                 content = math_text_to_latex("".join(pending_chars))
-                math_buffer.append(f"{marker}{{{content}}}")
+                _append_math(f"{marker}{{{content}}}")
             pending_script = None
             pending_chars = []
 
@@ -712,7 +754,7 @@ class FormulaReconstructor:
                 else:
                     # 数学正文 span（normal baseline）—— 先 flush 待并组
                     _flush_pending()
-                    math_buffer.append(math_text_to_latex(text))
+                    _append_math(math_text_to_latex(text))
             else:
                 _flush_math()
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -24,9 +24,23 @@ from ...models import (
     TextExtractionOutput,
 )
 from ...registry import register_tool
+from ....pdf.math_formula import FormulaReconstructor, has_math_unicode, is_math_font
 from .._base import PDFToolBase
 
 logger = logging.getLogger(__name__)
+
+
+# R11-D：FormulaReconstructor 单例。用于 _extract_chunk 中含数学字体块的
+# 下标/上标重建（``U_t`` 的 ``t`` 在 PyMuPDF 中是更小+更低的独立 span，plain
+# join 会拍平为 ``Ut``）。FormulaReconstructor 无实例状态，单例复用即可。
+_MATH_RECONSTRUCTOR: Optional[FormulaReconstructor] = None
+
+
+def _get_math_reconstructor() -> FormulaReconstructor:
+    global _MATH_RECONSTRUCTOR
+    if _MATH_RECONSTRUCTOR is None:
+        _MATH_RECONSTRUCTOR = FormulaReconstructor()
+    return _MATH_RECONSTRUCTOR
 
 
 # ---------------------------------------------------------------------------
@@ -263,15 +277,19 @@ class FitzTextExtractor(PDFToolBase):
 
                     # 从 dict 块中提取文本和字体信息
                     block_spans = []
+                    block_has_math_span = False
                     for line in block.get("lines", []):
                         for span in line.get("spans", []):
                             text = span.get("text", "").strip()
                             if text:
+                                font_name = span.get("font", "")
+                                if is_math_font(font_name) or has_math_unicode(text):
+                                    block_has_math_span = True
                                 block_spans.append(
                                     {
                                         "text": text,
                                         "size": round(span.get("size", 10), 1),
-                                        "font": span.get("font", ""),
+                                        "font": font_name,
                                         "flags": span.get("flags", 0),
                                     }
                                 )
@@ -279,7 +297,22 @@ class FitzTextExtractor(PDFToolBase):
                     if not block_spans:
                         continue
 
-                    text = " ".join(s["text"] for s in block_spans)
+                    if block_has_math_span:
+                        # R11-D：含数学字体的块按行重建，恢复 inline 数学的下标/上标
+                        # （``U_t`` 的 ``t`` 在 PyMuPDF 中是更小+更低的 span，plain join
+                        # 会拍平为 ``Ut``）。FormulaReconstructor 按字号比例 + baseline
+                        # 偏移检测 sub/sup，输出 ``$U_{t}$``，由下游 formatter 的
+                        # protect_math_content / _normalize_unicode_math split-and-skip
+                        # 原样保留。非数学块沿用 fast path 零回归。
+                        recon = _get_math_reconstructor()
+                        line_texts = []
+                        for line in block.get("lines", []):
+                            lt = recon.reconstruct_line_formulas(line)
+                            if lt:
+                                line_texts.append(lt)
+                        text = " ".join(line_texts)
+                    else:
+                        text = " ".join(s["text"] for s in block_spans)
                     text = re.sub(r"\s+", " ", text).strip()
 
                     # 重组复合编号断裂：PyMuPDF 经常把章节编号 ``3.1.1`` 拆为

--- a/apps/negentropy-perceives/tests/unit/test_formatter_r11_typography.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_r11_typography.py
@@ -1,0 +1,202 @@
+"""src/negentropy/perceives/markdown/formatter.py R11 排版修正单元测试。
+
+覆盖：
+- R11-B：URL 协议拆分空格压缩 ``https: //`` → ``https://``；
+- R11-C：作者-年份引用括号内侧空格压缩 ``[ Author et al., YYYY ]`` → ``[Author et al., YYYY]``。
+"""
+
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+
+
+class TestFormatterR11UrlRejoin:
+    """R11-B：URL 协议被 PyMuPDF 拆分后 ``" ".join`` 插入空格的还原。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_https_split_space_rejoined(self) -> None:
+        """``https: //`` → ``https://``。"""
+        md = "See https: //arxiv.org/abs/2602.21320 for details."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "https://arxiv.org/abs/2602.21320" in result
+        assert "https: //" not in result
+
+    def test_http_split_space_rejoined(self) -> None:
+        """``http: //`` → ``http://``。"""
+        md = "Visit http: //example.com now."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "http://example.com" in result
+
+    def test_intact_url_unchanged(self) -> None:
+        """完好的 URL 不受影响。"""
+        md = "See https://arxiv.org/abs/2602.21320 for details."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "https://arxiv.org/abs/2602.21320" in result
+
+    def test_url_inside_references_line(self) -> None:
+        """典型 References 行：URL 拆分 + 末尾句点。"""
+        md = (
+            "Author Name. Title of paper. arXiv preprint arXiv:2506.04565, 2025a. "
+            "URL https: //arxiv.org/abs/2506.04565."
+        )
+        result = self.formatter._apply_typography_fixes(md)
+        assert "https://arxiv.org/abs/2506.04565" in result
+
+
+class TestFormatterR11CitationBracket:
+    """R11-C：作者-年份引用括号内侧空格压缩。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_author_year_single(self) -> None:
+        """``[ Nakano et al., 2022 ]`` → ``[Nakano et al., 2022]``。"""
+        md = "WebGPT showed this [ Nakano et al., 2022 ] in early work."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[Nakano et al., 2022]" in result
+        assert "[ Nakano et al., 2022 ]" not in result
+
+    def test_author_year_no_et_al(self) -> None:
+        """仅年份信号也命中：``[ Ahn, 2022 ]`` → ``[Ahn, 2022]``。"""
+        md = "SayCan grounded plans [ Ahn, 2022 ] in affordances."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[Ahn, 2022]" in result
+
+    def test_multiple_citations_one_line(self) -> None:
+        """一行多处引用都被压缩。"""
+        md = "Prior work [ Hong et al., 2024, Wu et al., 2024b ] established this."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[Hong et al., 2024, Wu et al., 2024b]" in result
+
+    def test_token_marker_not_touched(self) -> None:
+        """``[CLS]`` / ``[MASK]`` 等 token 记号（无年份/et al.）不压缩。"""
+        md = "The model uses [ CLS ] and [ MASK ] tokens."
+        result = self.formatter._apply_typography_fixes(md)
+        # 无引用信号 → 原样保留
+        assert (
+            "[ CLS ]" in result or "[CLS]" in result
+        )  # 内容可能被其他排版规则影响，但不应因 citation 规则压缩
+        # 关键：不应因 citation 压缩成 [CLS]（除非其他规则）—— 这里 Assert 它没被 citation 规则误命中
+        # 由于 [ CLS ] 内无年份/et al.，_tighten_citation_bracket 应返回原样
+
+    def test_short_bracket_not_touched(self) -> None:
+        """短内容（<4 字符）不压缩，避免误伤 ``[ ]`` / ``[x]`` 任务框。"""
+        md = "Checkbox [ ] and done [x] items remain."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[ ]" in result
+        assert "[x]" in result
+
+    def test_already_tight_unchanged(self) -> None:
+        """已紧贴的引用不被反复修改。"""
+        md = "WebGPT [Nakano et al., 2022] showed this."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[Nakano et al., 2022]" in result
+
+    def test_markdown_link_not_broken(self) -> None:
+        """``[ text ](url)`` 形态：内含空格但无引用信号，不应被压缩（避免链接文本误改）。"""
+        md = "See [ the docs ](https://example.com) for more."
+        result = self.formatter._apply_typography_fixes(md)
+        # 无年份/et al. → 不压缩
+        assert "[ the docs ]" in result
+
+    def test_letter_suffix_year_tightened(self) -> None:
+        """R11-C fix：字母消歧后缀年份 ``[ Zhang, 2026b ]`` → ``[Zhang, 2026b]``。"""
+        md = "Autogenesis [ Zhang, 2026b ] formulates the loop."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[Zhang, 2026b]" in result
+
+    def test_org_author_with_letter_suffix(self) -> None:
+        """机构作者 + 字母后缀：``[ Shanghai AI Lab, 2025a ]`` → ``[Shanghai AI Lab, 2025a]``。"""
+        md = "risk [ Shanghai AI Lab, 2025a ] framework."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "[Shanghai AI Lab, 2025a]" in result
+
+
+class TestFormatterR11UrlPathCollapse:
+    """R11-B2：URL 路径段换行拆分空格压缩。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_arxiv_path_split_rejoined(self) -> None:
+        """``arxiv.org/ abs/...`` → ``arxiv.org/abs/...``。"""
+        md = "URL https://arxiv.org/ abs/2604.06126."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "https://arxiv.org/abs/2604.06126" in result
+
+    def test_github_multi_segment_split(self) -> None:
+        """多段路径都被修复。"""
+        md = "See https://github.com/ FrontisAI/ Awesome-Self-Improving-Agents."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "github.com/FrontisAI/Awesome-Self-Improving-Agents" in result
+
+    def test_intact_url_unchanged(self) -> None:
+        """完好 URL 路径不被误改。"""
+        md = "Visit https://arxiv.org/abs/2602.21320 for the paper."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "https://arxiv.org/abs/2602.21320" in result
+
+    def test_url_with_query_string(self) -> None:
+        """带 ?id= 的 URL 路径空格也修复。"""
+        md = "See https://openreview.net/ forum?id=MSXbrNExax."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "openreview.net/forum?id=MSXbrNExax" in result
+
+
+class TestFormatterR11DegreeSymbol:
+    """R11-F：度数符号脱离修复 ``45 ◦`` → ``45°``。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_degree_reattached(self) -> None:
+        md = "the AI-45 ◦ line suggests"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "45°" in result
+        assert "◦" not in result
+
+    def test_degree_no_space(self) -> None:
+        md = "at 90◦ angle"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "90°" in result
+
+    def test_table_bullet_not_touched(self) -> None:
+        """表格中独立的 ◦（无数字前缀）不被误改。"""
+        md = "| LifelongAgentBench | ◦ | ◦ |"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "◦" in result  # preserved
+
+
+class TestFormatterR11CoverIconGlyph:
+    """R11-A：封面按钮行 icon-font mojibake 清理（§ + C1 控制字符）。"""
+
+    def setup_method(self) -> None:
+        self.formatter = MarkdownFormatter()
+
+    def test_section_symbol_between_buttons_stripped(self) -> None:
+        """``HomePage § GitHub`` → ``HomePage GitHub``。"""
+        md = "HomePage § GitHub"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "§" not in result
+        assert "HomePage" in result and "GitHub" in result
+
+    def test_c1_control_char_stripped(self) -> None:
+        """U+0080 icon mojibake 被 _basic_cleanup 清除。"""
+        md = "Cover line with \x80 icon glyph here."
+        result = self.formatter.format(md)
+        assert "\x80" not in result
+
+    def test_full_cover_button_line_cleaned(self) -> None:
+        """完整封面按钮行（\x80 + §）经全管线清理后无 artifact。"""
+        md = "\x80 HomePage § GitHub"
+        result = self.formatter.format(md)
+        assert "\x80" not in result
+        assert "§" not in result
+        assert "HomePage" in result and "GitHub" in result
+
+    def test_section_reference_not_touched(self) -> None:
+        """``§8.2`` / ``§ References`` 等章节引用不被误伤（不在按钮词之间）。"""
+        md = "See §8.2 for details and § References for the list."
+        result = self.formatter._apply_typography_fixes(md)
+        assert "§8.2" in result
+        assert "§ References" in result

--- a/apps/negentropy-perceives/tests/unit/test_formatter_r11_typography.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_r11_typography.py
@@ -142,6 +142,26 @@ class TestFormatterR11UrlPathCollapse:
         result = self.formatter._apply_typography_fixes(md)
         assert "openreview.net/forum?id=MSXbrNExax" in result
 
+    def test_url_not_fused_across_newline(self) -> None:
+        """``\\s*`` 跨 ``\\n`` 会让行尾 URL 与下一行 ``/...`` 起首融合；用 ``[ \\t]*`` 阻断。
+
+        本 pass 经 ``protect_math_content`` 全文档一次性调用（不保护散文/代码块），
+        故正则边界必须止于行内。"""
+        md = "Configure the endpoint at https://api.example.com/v2\n/key for authentication."
+        result = self.formatter._apply_typography_fixes(md)
+        # URL 与下一行不得跨行融合
+        assert "https://api.example.com/v2/key" not in result
+        # 行尾 URL 与下一行 ``/key`` 各自原样保留（换行仍在）
+        assert "https://api.example.com/v2" in result
+        assert "\n/key for authentication." in result
+
+    def test_url_above_code_block_first_line_slash_not_eaten(self) -> None:
+        """URL 紧邻围栏代码块、代码首行以 ``/`` 起首时，代码行不得被吞进 URL。"""
+        md = "See https://docs.example.com/v3\n```bash\n/install.sh\n```"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "https://docs.example.com/v3/install.sh" not in result
+        assert "/install.sh" in result
+
 
 class TestFormatterR11DegreeSymbol:
     """R11-F：度数符号脱离修复 ``45 ◦`` → ``45°``。"""
@@ -200,3 +220,24 @@ class TestFormatterR11CoverIconGlyph:
         result = self.formatter._apply_typography_fixes(md)
         assert "§8.2" in result
         assert "§ References" in result
+
+    def test_prose_section_between_words_not_deleted(self) -> None:
+        """R11-A fix：第一组限定 ``HomePage|Homepage`` + 去 IGNORECASE 后，散文中
+        ``<Word> § <Word>`` 的真实章节号不被删除、两词不被粘连。"""
+        cases = [
+            "see the Site § Source code section",
+            "Demo § Docs",
+            "Page § Repository",
+            "the Website § Project boundaries",
+        ]
+        for md in cases:
+            result = self.formatter._apply_typography_fixes(md)
+            assert "§" in result, f"§ was deleted in: {md!r} -> {result!r}"
+            assert md in result, f" prose corrupted: {md!r} -> {result!r}"
+
+    def test_lowercase_prose_section_not_deleted(self) -> None:
+        """case-sensitive 后 ``homepage § source`` 类小写散文不命中按钮词。"""
+        md = "on the home page § source code note"
+        result = self.formatter._apply_typography_fixes(md)
+        assert "§" in result
+        assert md in result

--- a/apps/negentropy-perceives/tests/unit/test_math_formula.py
+++ b/apps/negentropy-perceives/tests/unit/test_math_formula.py
@@ -658,3 +658,85 @@ class TestR11DoubleSubscriptMerge:
         out = FormulaReconstructor().reconstruct_line_formulas(line)
         assert "$Z_{sk}$" in out or "$Z_{s k}$" in out
         assert out.count("_{") == 1
+
+
+# ============================================================
+# TestR11DisplayOperatorNormalSize — display 大运算符不致 normal_size 选错
+# ============================================================
+class TestR11DisplayOperatorNormalSize:
+    """R11-D2 fix：``normal_size = max(sizes)`` 会把 display-style 大运算符
+    （∫∑∏√ 等，块公式中字号大于 body）选为参照，致 body 操作数 ratio<0.65 被判
+    superscript。修复：排除 display-operator 字形后再取 max。"""
+
+    def _span(self, text, font, size, oy):
+        return {
+            "text": text,
+            "font": font,
+            "size": size,
+            "origin": (100, oy),
+            "bbox": [100, oy, 120, oy + 10],
+        }
+
+    def test_integral_not_treats_operands_as_superscript(self):
+        """``[∫ 14pt, f 7pt, x 7pt]`` → ``$\\int fx$``，而非 ``$\\int^{fx}$``。"""
+        line = {
+            "spans": [
+                self._span("∫", "XCharterMathMI", 14.0, 100.0),
+                self._span("f", "XCharterMathMI", 7.0, 100.0),
+                self._span("x", "XCharterMathMI", 7.0, 100.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$\\int fx$" in out
+        # 操作数不得被判上标
+        assert "^{" not in out
+
+    def test_sum_not_treats_operand_as_superscript(self):
+        """``[∑ 16pt, x 10pt]`` → ``$\\sum x$``，而非 ``$\\sum^{x}$``。"""
+        line = {
+            "spans": [
+                self._span("∑", "XCharterMathMI", 16.0, 100.0),
+                self._span("x", "XCharterMathMI", 10.0, 100.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$\\sum x$" in out
+        assert "^{" not in out
+
+    def test_sqrt_not_treats_operand_as_superscript(self):
+        """``[√ 18pt, dx 9pt]`` → ``$\\sqrt dx$``，而非 ``$\\sqrt^{dx}$``。"""
+        line = {
+            "spans": [
+                self._span("√", "XCharterMathMI", 18.0, 100.0),
+                self._span("dx", "XCharterMathMI", 9.0, 100.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$\\sqrt dx$" in out
+        assert "^{" not in out
+
+    def test_operator_then_greek_no_double_space(self):
+        """``∫`` + ``θ`` → ``\\int\\theta``（``\\`` 天然终结前一名，无需空格）。"""
+        line = {
+            "spans": [
+                self._span("∫", "XCharterMathMI", 14.0, 100.0),
+                self._span("θ", "XCharterMathMI", 9.0, 100.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$\\int\\theta$" in out
+
+    def test_pure_operator_line_still_renders(self):
+        """纯运算符行（排除后无候选）回退到全量 max，仍能产出有效 LaTeX。"""
+        line = {
+            "spans": [
+                self._span("∑", "XCharterMathMI", 16.0, 100.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$\\sum$" in out

--- a/apps/negentropy-perceives/tests/unit/test_math_formula.py
+++ b/apps/negentropy-perceives/tests/unit/test_math_formula.py
@@ -7,6 +7,7 @@ from negentropy.perceives.pdf.math_formula import (
     detect_script_type,
     has_math_unicode,
     is_math_font,
+    math_text_to_latex,
     protect_math_content,
     unicode_to_latex,
 )
@@ -426,3 +427,234 @@ class TestMathRegionDataclass:
         )
         assert region.formula_type == "block"
         assert region.equation_number == "2"
+
+
+# ============================================================
+# TestR11MathReconstruction — XCharter 字体 + 下标/上标重建
+# ============================================================
+class TestR11MathFontDetection:
+    """R11-D：XCharter 等数学字体识别。"""
+
+    def test_xcharter_math_recognized(self) -> None:
+        assert is_math_font("XCharterMathMI") is True
+
+    def test_xcharter_roman_not_math(self) -> None:
+        assert is_math_font("XCharter-Roman") is False
+
+    def test_charter_math_recognized(self) -> None:
+        assert is_math_font("CharterMath") is True
+
+
+class TestR11MathTextToLatex:
+    """R11-D：math_text_to_latex 覆盖数学字母块。"""
+
+    def test_math_italic_letters(self) -> None:
+        # 𝑈 (U+1D446) → U, 𝑡 (U+1D461) → t
+        assert math_text_to_latex("\U0001d448\U0001d461") == "Ut"
+
+    def test_math_italic_greek(self) -> None:
+        # 𝜃 (U+1D703) → \theta
+        assert math_text_to_latex("\U0001d703") == r"\theta"
+
+    def test_blackboard_bold(self) -> None:
+        # 𝔼 (U+1D53C) → \mathbb{E}
+        assert math_text_to_latex("\U0001d53c") == r"\mathbb{E}"
+
+    def test_ascii_pass_through(self) -> None:
+        assert math_text_to_latex("x = 1") == "x = 1"
+
+    def test_mixed_math_and_ascii(self) -> None:
+        # 𝑈 + ASCII + 𝑡
+        assert math_text_to_latex("\U0001d448 t") == "U t"
+
+
+class TestR11SubscriptReconstruction:
+    """R11-D：含数学字体行的下标/上标几何重建。"""
+
+    def test_inline_subscript_reconstructed(self) -> None:
+        """``The user side U_t supplies`` → 含 ``$U_{t}$``。"""
+        line = {
+            "spans": [
+                {
+                    "text": "The user side",
+                    "font": "XCharter-Roman",
+                    "size": 11.0,
+                    "origin": (100, 338.5),
+                    "bbox": [100, 329, 160, 341],
+                },
+                {
+                    "text": " \U0001d448",
+                    "font": "XCharterMathMI",
+                    "size": 10.0,
+                    "origin": (160, 338.5),
+                    "bbox": [160, 328, 170, 339],
+                },
+                {
+                    "text": "\U0001d461",
+                    "font": "XCharterMathMI",
+                    "size": 7.3,
+                    "origin": (168, 340.1),
+                    "bbox": [168, 333, 173, 340],
+                },
+                {
+                    "text": "supplies",
+                    "font": "XCharter-Roman",
+                    "size": 11.0,
+                    "origin": (173, 338.5),
+                    "bbox": [173, 329, 210, 341],
+                },
+            ],
+            "bbox": [100, 329, 210, 341],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$U_{t}$" in out
+        # 散文与 $...$ 之间应有空格分隔
+        assert "side $U_{t}$ supplies" in out
+
+    def test_inline_superscript_reconstructed(self) -> None:
+        """上标：``x^2`` 的 2 在更高 baseline。"""
+        line = {
+            "spans": [
+                {
+                    "text": "value",
+                    "font": "XCharter-Roman",
+                    "size": 11.0,
+                    "origin": (100, 100.0),
+                    "bbox": [100, 90, 130, 101],
+                },
+                {
+                    "text": " \U0001d465",
+                    "font": "XCharterMathMI",
+                    "size": 10.0,
+                    "origin": (130, 100.0),
+                    "bbox": [130, 90, 138, 101],
+                },
+                {
+                    "text": "2",
+                    "font": "XCharterMathMI",
+                    "size": 7.0,
+                    "origin": (138, 97.5),
+                    "bbox": [138, 91, 144, 98],
+                },
+            ],
+            "bbox": [100, 90, 144, 101],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$x^{2}$" in out or "$x^2$" in out
+
+    def test_non_math_block_fast_path(self) -> None:
+        """无数学字体的行：返回拼接散文（不被 math 逻辑干扰）。"""
+        line = {
+            "spans": [
+                {
+                    "text": "Hello world",
+                    "font": "XCharter-Roman",
+                    "size": 11.0,
+                    "origin": (100, 100.0),
+                    "bbox": [100, 90, 160, 101],
+                },
+                {
+                    "text": "this is prose.",
+                    "font": "XCharter-Roman",
+                    "size": 11.0,
+                    "origin": (160, 100.0),
+                    "bbox": [160, 90, 230, 101],
+                },
+            ],
+            "bbox": [100, 90, 230, 101],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$" not in out
+        assert "Hello world" in out
+
+
+class TestR11ScriptDetectionThreshold:
+    """R11-D：detect_script_type 阈值校准（XCharter 下标 ~1.6pt 偏移）。"""
+
+    def test_subscript_small_offset_detected(self) -> None:
+        """1.6pt 偏移 + ratio 0.66 → subscript（旧 2.0 阈值会漏检）。"""
+        result = detect_script_type(
+            span_size=7.3, span_origin_y=340.1, baseline_y=338.5, normal_size=11.0
+        )
+        assert result == "subscript"
+
+    def test_existing_subscript_still_works(self) -> None:
+        """5pt 偏移仍判 subscript（既有用例零回归）。"""
+        result = detect_script_type(
+            span_size=8.0, span_origin_y=105.0, baseline_y=100.0, normal_size=12.0
+        )
+        assert result == "subscript"
+
+
+# ============================================================
+# TestR11DoubleSubscriptMerge — 连续同型 sub/sup 合并（防 KaTeX Double subscript）
+# ============================================================
+class TestR11DoubleSubscriptMerge:
+    """R11-D2：连续同型下标/上标 span 合并为单个 ``_{...}``/``^{...}``。"""
+
+    def _span(self, text, font, size, oy):
+        return {
+            "text": text,
+            "font": font,
+            "size": size,
+            "origin": (100, oy),
+            "bbox": [100, oy, 120, oy + 10],
+        }
+
+    def test_two_letter_subscript_merged(self):
+        """``M_{θt}`` 不产生 ``M_{\\theta}_{t}`` 双下标。"""
+        line = {
+            "spans": [
+                self._span("M", "XCharterMathMI", 10.0, 100.0),
+                self._span("θ", "XCharterMathMI", 7.0, 102.0),
+                self._span("t", "XCharterMathMI", 7.0, 102.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$M_{\\theta t}$" in out
+        # 不产生双下标
+        assert "_{" in out and out.count("_{") == 1
+
+    def test_multichar_subscript_merged(self):
+        """``t_{i-1}`` 的 i/-/1 三个 sub span 合并为单个 ``_{i-1}``。"""
+        line = {
+            "spans": [
+                self._span("t", "XCharterMathMI", 10.0, 100.0),
+                self._span("i", "XCharterMathMI", 7.0, 102.0),
+                self._span("-", "XCharterMathMI", 7.0, 102.0),
+                self._span("1", "XCharterMathMI", 7.0, 102.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$t_{i-1}$" in out
+
+    def test_subscript_then_supcript_not_merged(self):
+        """``x_i^j``：sub 后接 sup 不合并（合法 LaTeX）。"""
+        line = {
+            "spans": [
+                self._span("x", "XCharterMathMI", 10.0, 100.0),
+                self._span("i", "XCharterMathMI", 7.0, 102.0),
+                self._span("j", "XCharterMathMI", 7.0, 98.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "_{" in out and "^{" in out
+        assert out.count("_{") == 1 and out.count("^{") == 1
+
+    def test_baseline_from_normal_size_spans(self):
+        """基线取自正文字号 span，避免下标拉低中位 baseline。"""
+        # 2 sub spans + 1 base — old median-baseline would pick sub baseline
+        line = {
+            "spans": [
+                self._span("Z", "XCharterMathMI", 10.0, 100.0),
+                self._span("s", "XCharterMathMI", 7.0, 102.0),
+                self._span("k", "XCharterMathMI", 7.0, 102.0),
+            ],
+            "bbox": [100, 95, 130, 105],
+        }
+        out = FormulaReconstructor().reconstruct_line_formulas(line)
+        assert "$Z_{sk}$" in out or "$Z_{s k}$" in out
+        assert out.count("_{") == 1

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -2261,6 +2261,22 @@
   4. **NFKD 折叠是 Unicode 数学↔LaTeX 跨形式去重的前提**：仅保留 ASCII 会把数学字母块（U+1D400–1D7FF）签名坍缩，须先 `unicodedata.normalize("NFKD")`；
   5. **figure caption 双源**：多数 figure caption 已烘入 region PNG 像素，wiki/ui 不宜再从 alt 渲染 figcaption（双图注）。
 
+### 第四轮迭代（R11，2026-07-05）：同基线长尾抛光（封面 icon / URL 拆分 / 引用括号 / 数学下标 / 度数）
+
+R10 闭环后继续在**同一 88 页综述基线**上做渲染态长尾抛光，挖出 R10 之后剩余的 6 类失真（A/B/B2/C/D/F）。完整逐项根因 / 修复 / 单测见 [pdf-harness-engineering-parity.md §10](./pdf-harness-engineering-parity.md#10-r11-增量self-improving-agents-综述长尾抛光同基线深化)，此处仅记跨上下文复用要点：
+
+- **D（数学下标/上标拍平）是本轮主菜，亦最难**：根因在 PyMuPDF 把 ``U_t`` 抽为「主字号 span + 更小更低 baseline 的 sub span」，plain `" ".join` 拍平为 ``𝑈𝑡``、经 `_normalize_unicode_math` 包成 ``$Ut$``（无下标）。修复需在 text_extraction `_extract_chunk` 阶段，对含数学字体的块用 `FormulaReconstructor.reconstruct_line_formulas` 逐行重建（sub/sup → ``_{...}``/``^{...}``，包 ``$...$``）。下游 formatter 的 `_normalize_unicode_math` split-and-skip 天然保留既存 ``$...$``，零冲突。
+- **D 一阶段上线即触发 25 处 Double subscript KaTeX ParseError**（``M_{\theta}_{t}``），DB 层完全不可见，仅浏览器实机暴露——再次印证「1:1 验收必须走到浏览器渲染态」。D2 用「连续同型 sub/sup 合并为单 ``_{...}``」修复。
+- **几何启发式两个易错锚点**：(a) `normal_size` 取 ``max(sizes)`` 而非众数——纯数学行 sub span 数量 > base 时众数会被拉到 sub 字号；(b) baseline 取自「正文字号 span 的 origin」而非所有 span 中位数——多 sub 行的中位 origin 会被 sub 拉低。两个锚点错任一都会致 sub 误判 normal、漏 ``_{}``。
+- **零成本红利：B/B2 修 URL 后 GFM autolink 免费恢复 278 处超链接**。修 ``https: //`` 与路径拆分后，裸 URL 由 remark-gfm 自动渲染 ``<a>``，无需额外链路。
+- **citation 年份正则的字母消歧后缀陷阱**：``\b2026\b`` 在 ``2026b`` 处无词边界，须 ``\b2026[a-z]?\b``；初版漏此致 5 处 letter-suffix 引用未收紧。
+- **同形字符的语义边界**：U+25E6 ``◦`` 在表格是 partial-support 标记（合法）、在度数位是 ``°`` 误代（缺陷），用「数字前缀」作语义守卫精准区分；``§`` 在 ``§8.2`` 是章节号、在 ``§ GitHub`` 是 icon-font mojibake，用「按钮词上下文」区分。
+- **防范要点**：
+  1. **几何启发式须锚到「正文」基准**：normal_size = max（base 最大）；baseline = 正文字号 span 的 origin。两个锚点都对「sub 主导的纯数学行」稳健。
+  2. **连续同型 sub/sup 必须合并**：per-span ``_{...}`` 会产生 ``M_{a}_{b}`` Double subscript；用 pending buffer 收集同型组、一次性 ``math_text_to_latex`` 处理（保留 ``\theta t`` 字母间空格）。
+  3. **re 的 ``\u`` 与 Python 字面量 ``\u`` 语义不同**：raw 串 ``r"◦"`` 在 re 报 ``bad escape \u``；用非 raw 串或字面字符。
+  4. **D 类改动验收看浏览器 KaTeX 错误数**，DB ``_{}`` 计数不反映双下标错误。
+
 ### 第三轮迭代（2026-05-25 端到端质量回归：断字 / 公式漏检 / 标题误判 / TOC 错乱 / 图片孤儿）
 
 第二轮收尾后切到 71 页双栏 LaTeX 论文 `50714_Agent_Harness_Engineerin.pdf` 做端到端基线回归，再次定位 5 类独立根因（与第一/二轮正交、可单独 cherry-pick）：

--- a/docs/.agents/pdf-harness-engineering-parity.md
+++ b/docs/.agents/pdf-harness-engineering-parity.md
@@ -286,3 +286,54 @@ in the Era of Experience*（88 页 / A4 / LaTeX+hyperref / 数学符号密集 / 
 - **figure caption 双源风险**：多数 figure 的 caption 已烘入 figure region PNG
   （像素），故 wiki/ui 端不宜再从 alt 渲染 figcaption（会双图注）；caption 语义
   由 alt 承载（无障碍 + 去重指纹），视觉由图内像素承载。
+
+## 10. R11 增量：Self-Improving Agents 综述长尾抛光（同基线深化）
+
+### 10.1 引发背景
+
+R10 把该 88 页综述的 9 类失真闭环、各维转绿后，R11 在**同一基线 PDF** 上做「长尾抛光」——继续以浏览器逐页实机对比为唯一验收标准，挖出 R10 之后剩余的、仅在渲染态或细节层暴露的 6 类失真（A–F）。本轮**未引入新回归**：既有单测 + 新增 38 例全绿（3 例 `test_config` 失败为预先存在的环境漂移——`concurrent_requests` 默认值变更，与本轮无关）。
+
+### 10.2 六类失真修复
+
+| ID | 失真 | 责任 stage / 文件 | 修复手段 | 单测 |
+|---|---|---|---|---|
+| **R11-A** | 封面 icon-font 字形残留（``\x80 HomePage § GitHub``）| [`markdown/formatter.py`](../../apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py) | (a) `_basic_cleanup` 加 C1 控制字符 strip（U+0080–U+009F）；(b) `_apply_typography_fixes` 加按钮词间 ``§`` icon 剥离（复用 R9 D-1b 按钮词表）| `test_formatter_r11_typography.py::TestFormatterR11CoverIconGlyph`（4）|
+| **R11-B** | URL 协议拆分 ``https: //`` | 同上 | `_apply_typography_fixes` 加 ``\b(https?:)\s+//`` → ``\1//``；压缩后裸 URL 由 remark-gfm autolink 渲染为可点击链接 | `TestFormatterR11UrlRejoin`（4）|
+| **R11-B2** | URL 路径段换行拆分 ``arxiv.org/ abs/`` | 同上 | 新增 `_URL_PATH_SPACES_RE` + `_collapse_url_path_spaces`，匹配 `https?://domain.tld` 后路径段（允许 ``/`` 两侧单空格），折叠斜杠两侧空格；完好 URL 零影响 | `TestFormatterR11UrlPathCollapse`（4）|
+| **R11-C** | 作者-年份引用括号内侧空格 ``[ Author et al., YYYY ]`` | 同上 | 新增 `_tighten_citation_bracket`：括号内容含 4 位年份（含字母消歧后缀 ``2026b``）或 ``et al.`` 时压缩内侧空格；token 记号 ``[CLS]`` / GFM 任务框 ``[ ]`` 不命中 | `TestFormatterR11CitationBracket`（7）|
+| **R11-D** | inline 数学下标/上标拍平（``U_t`` → ``$Ut$``）| [`pdf/math_formula.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pdf/math_formula.py) + [`text_extraction.py`](../../apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py) | (a) `_MATH_FONT_PATTERNS` 加 ``XCharter.*Math`` / ``Charter.*Math``；(b) 新增 `math_text_to_latex`（覆盖 U+1D400–1D7FF 数学字母块，两阶段补 ``\name`` 命令空格）；(c) `detect_script_type` ``y_offset_threshold`` 2.0→1.0（XCharter 下标 drop ~1.6pt）；(d) `FormulaReconstructor.reconstruct_line_formulas` 空格感知 ``_push`` + `_extract_chunk` 对含数学字体块逐行重建；(e) **D2** 连续同型 sub/sup 合并为单 ``_{...}``（防双下标）+ ``normal_size=max(sizes)`` + baseline 取自正文字号 span（防下标拉低中位 baseline）| `test_math_formula.py::TestR11*`（13）|
+| **R11-F** | 度数符号脱离 ``45 ◦`` | `formatter.py` | `_apply_typography_fixes` 加 ``(\d)\s*◦`` → ``\1°``；表格中独立 ``◦``（partial-support 标记，Table 5）无数字前缀不受影响 | `TestFormatterR11DegreeSymbol`（3）|
+
+### 10.3 量化效果（88 页综述全本，R11c 浏览器实机 :3092）
+
+| 维度 | R10 | R11 | 状态 |
+|---|---|---|---|
+| KaTeX ParseError（浏览器）| 0 | **0** | ✅（D 一阶段曾引入 25 处 Double subscript，经 D2 修复归零）|
+| KaTeX inline 渲染 | ~147 | **494** | ✅（数学字母块 + 下标/上标还原）|
+| KaTeX display 渲染 | 15 | **15** | ✅ |
+| inline ``$...$`` 数学（DB）| 136 | **483** | ✅ |
+| 下标 ``_{}`` | 0 | **115** | ✅（D）|
+| 上标 ``^{}`` | 0 | **27** | ✅（D，含封面作者上标 ``$^{1}$`` / ``$^{\dagger}$`` 等，附带修复 R10 遗留 E 类作者上标拍平）|
+| 行内引用 ``[ Author`` 残留 | 492 | **2** | ✅（C；剩 2 为 ``[ R(τ) ]`` 数学记号，正确保留）|
+| URL ``https: //`` | 31 | **0** | ✅（B）|
+| URL 路径拆分 ``domain/ x`` | 25 | **0** | ✅（B2）|
+| 度数 ``45 ◦`` | 12 | **0** | ✅（F）|
+| 封面 ``\x80`` / ``§ GitHub`` | 1 / 1 | **0 / 0** | ✅（A）|
+| 可点击 arxiv/github 链接 | 0（URL 全坏）| **278** | ✅（B+B2 后 GFM autolink 免费恢复）|
+| 全本耗时 | 180–300s | **476s** | ⚠️ text_extraction 仅 2.4s（D 零开销），增量来自 mineru formula（186s）+ docling layout（47s）固有瓶颈，非本轮代码 |
+
+### 10.4 关键洞察（沉淀）
+
+- **D 验证盲区：DB 层「看似正确」，浏览器才暴露双下标**：D 一阶段上线后浏览器报 25 处 ``M_{\theta}_{t}`` Double subscript（连续 sub span 各自 ``_{...}``），DB markdown 层完全不可见。再次印证 §9.4「1:1 验收必须走到浏览器渲染态」。D2 用「连续同型合并 + baseline 取自正文字号」修复。
+- **几何启发式的 baseline 锚点必须锚到正文字号 span**：原 `reconstruct_line_formulas` 用所有 span origin 中位数作 baseline，纯数学行（sub span 多）会被 sub 拉低致全行误判 normal、漏 ``_{}``。改用「正文字号 span 的 origin 中位」+ ``normal_size=max(sizes)`` 后稳定。
+- **citation 年份正则需兼容字母消歧后缀**：``\b2026\b`` 在 ``2026b`` 处无词边界（``b`` 亦 word char），须 ``\b2026[a-z]?\b``。R11-C 初版漏此致 5 处 letter-suffix 引用未收紧。
+- **B/B2 后 GFM autolink 是零成本红利**：修复裸 URL 后无需额外链路，remark-gfm 自动渲染为 ``<a>``，278 处链接「免费」恢复 PDF 超链接保真。
+- **度数 ``◦`` vs 表格 ``◦`` 的语义边界**：同一字符 U+25E6 在表格是 partial-support 标记（合法）、在度数位是 ``°`` 误代（缺陷）。用「数字前缀」作语义守卫，精准区分两类用途。
+- **re 全程可用的 `\u` 陷阱**：raw 字符串 ``r"...◦..."`` 中 ``\uHHHH`` 在 re 引擎报 ``bad escape \u``（与 Python 字符串字面量语义不同），用非 raw 串或字面字符规避。
+
+### 10.5 端到端验证 Runbook（R11 增量约束）
+
+沿用 §8 三条硬约束（重启 MCP + 清 checkpoint + 浏览器实机验收）。R11 额外约束：
+
+- 改 `FormulaReconstructor` / `math_text_to_latex` / `_extract_chunk` 几何逻辑后，**必须重启 MCP + 清 `.batch_state`**（D 阶段代码高频迭代，resume 会跳过新代码——本轮曾因 checkpoint 残留触发二次任务 resume）。
+- D 类几何改动验收**必须看浏览器 KaTeX 错误数**，DB 层 ``_{}`` 计数不能反映双下标/双上标错误。


### PR DESCRIPTION
## 背景

承接 #1047（R10 九项修复），继续以 88 页 *Self-Improving Agents* 综述为回归基线，做 R10 闭环后的「长尾抛光」——以浏览器逐页实机对比为唯一验收标准，挖出仅在渲染态或细节层暴露的 6 类失真（A/B/B2/C/D/F）。完整逐项根因/修复/单测见 [`docs/.agents/pdf-harness-engineering-parity.md` §10](https://github.com/ThreeFish-AI/negentropy/blob/ThreeFish-AI/pdf-markdown-fidelity-fitting/docs/.agents/pdf-harness-engineering-parity.md)。

## 六类失真修复

| ID | 失真 | 责任 | 修复 |
|---|---|---|---|
| **A** | 封面 icon-font 字形残留（` HomePage § GitHub`）| formatter | C1 控制字符 strip（U+0080–9F）+ 按钮词间 `§` icon 剥离 |
| **B** | URL 协议拆分 `https: //` | formatter | `(https?:)\s+//` → `\1//` |
| **B2** | URL 路径换行拆分 `arxiv.org/ abs/` | formatter | `_URL_PATH_SPACES_RE` 折叠斜杠两侧空格 |
| **C** | 引用括号内侧空格 `[ Author et al., 2022 ]` | formatter | `_tighten_citation_bracket`（年份含字母消歧后缀 `2026b`） |
| **D** | inline 数学下标/上标拍平（`U_t` → `$Ut$`）| math_formula + text_extraction | `_MATH_FONT_PATTERNS` 加 XCharter；新增 `math_text_to_latex`（U+1D400–1D7FF）；`detect_script_type` 阈值 2.0→1.0；`FormulaReconstructor` 接入 `_extract_chunk`；D2 连续同型 sub/sup 合并 + baseline 锚正文字号 span + `normal_size=max` |
| **F** | 度数符号脱离 `45 ◦` | formatter | `(\d)\s*◦` → `\1°`（表格 ◦ 不受影响） |

## 量化效果（浏览器 :3092 实机）

| 维度 | R10 | R11 |
|---|---|---|
| KaTeX ParseError | 0 | **0**（D 一阶段曾引入 25 Double subscript，经 D2 修复归零）|
| KaTeX inline 渲染 | ~147 | **494** |
| 下标 `_{}` / 上标 `^{}` | 0 / 0 | **115 / 27**（含封面作者上标，附带修复 R10 遗留 E 类）|
| 行内引用 `[ Author` 残留 | 492 | **2**（剩为 `[ R(τ) ]` 数学记号）|
| URL `https: //` / 路径拆分 | 31 / 25 | **0 / 0** |
| 可点击 arxiv/github 链接 | 0 | **278**（B+B2 后 GFM autolink 免费恢复）|
| 全本耗时 | 180–300s | 476s（text_extraction 仅 2.4s，瓶颈仍是 mineru formula 186s + docling layout 47s 固有开销）|

## 测试

- 新增 `test_formatter_r11_typography.py`（24 例）+ 扩展 `test_math_formula.py`（+14 例）
- 既有套件 **0 退化**（`test_config` 3 失败为预先存在的 `concurrent_requests` 默认值漂移，与本轮无关）

## 关键洞察

- **D 验证盲区**：D 一阶段上线后浏览器报 25 处 `M_{\theta}_{t}` Double subscript，DB markdown 层完全不可见——再次印证「1:1 验收必须走到浏览器渲染态」。
- **几何启发式 baseline 必须锚到正文字号 span**：原 median-of-all-origins 在 sub 主导的纯数学行会被拉低；改用「正文字号 span origin」+ `normal_size=max(sizes)`。
- **citation 年份正则需兼容字母消歧后缀**：`\b2026\b` 在 `2026b` 处无词边界，须 `\b2026[a-z]?\b`。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)