### PR TITLE
fix(perceives): PDF→MD 高保真巡检 doc 9045a031（标题断字 + inline 公式重组）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -579,6 +579,62 @@ class MarkdownFormatter:
             markdown_content = self._format_code_blocks(markdown_content)
             markdown_content = self._strip_running_headers(markdown_content)
             markdown_content = self._strip_orphan_lang_labels(markdown_content)
+            # 标题行内无空格软断字合并：PDF 双栏标题跨行（"Parame-\nters"）经
+            # docling 抽取常残留为无空格 "Parame-ters"（连字符直接接续），不命中
+            # _apply_typography_fixes 的带空格 `word- word` 规则（且本 fidelity-safe
+            # 路径不调用该函数）。仅对 ^#+ 标题行、连字符左全小写≥3 且非复合词前缀
+            # （_COMPOUND_HYPHEN_PREFIXES）时合并；合成词（Self-improvement /
+            # System-level）左侧首字母大写或属前缀白名单，不被匹配，保留连字符。
+            # 大写首字母（Title Case 标题）也覆盖：PDF 标题 "Model Parame-ters"
+            # 中 "Parame" 以大写 P 起，[a-z]{3,} 不匹配。放宽 left 至 [A-Z]?[a-z]{2,}。
+            # 合成词保护用 left.lower() 匹配 _COMPOUND_HYPHEN_PREFIXES + 标题高频
+            # 合成词补集（system/task/meta 等，防误并 System-level/Task-bounded）。
+            _title_compound_extra = frozenset(
+                {
+                    "system",
+                    "task",
+                    "meta",
+                    "data",
+                    "user",
+                    "action",
+                    "decision",
+                    "problem",
+                    "experience",
+                    "knowledge",
+                    "policy",
+                    "memory",
+                    "skill",
+                    "tool",
+                    "trace",
+                    "parameter",
+                    "value",
+                    "sample",
+                    "rule",
+                    "base",
+                    "test",
+                    "table",
+                    "chain",
+                    "step",
+                    "web",
+                }
+            )
+
+            def _title_soft_hyphen_mh(mm: "re.Match[str]") -> str:
+                left, right = mm.group(1), mm.group(2)
+                low = left.lower()
+                if low in _COMPOUND_HYPHEN_PREFIXES or low in _title_compound_extra:
+                    return f"{left}-{right}"
+                return f"{left}{right}"
+
+            markdown_content = re.sub(
+                r"(?m)^(#{1,6}\s.*)$",
+                lambda m: re.sub(
+                    r"\b([A-Z]?[a-z]{2,})-([a-z]{2,})\b",
+                    _title_soft_hyphen_mh,
+                    m.group(1),
+                ),
+                markdown_content,
+            )
             return markdown_content
         except Exception as e:
             logger.warning(f"Error in fidelity-safe formatting: {str(e)}")

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -635,6 +635,32 @@ class MarkdownFormatter:
                 ),
                 markdown_content,
             )
+            # inline 公式重组：合并被纯数学符号分隔的相邻 $..$ 片段
+            # （_normalize_unicode_math 把数学字形独立包裹，★/≤/∈/Π 等运算符
+            # 留 $..$ 外致公式断裂，如 "$J$ ★ $(E):=$"）。仅当两 $..$ 间分隔符
+            # 仅含数学符号/希腊字母/空格（无 ASCII 字母词，挡 "$x$ and $y$"）
+            # 时合并。含 sup/log 等字母函数词的仍部分碎片（需 text_extraction
+            # 字号检测的架构改动，本 pass 不处理）。
+            _inline_math_glue = set(
+                "★☆∈∉⊆⊂⊇⊃∪∩×÷±∓∑∏∫∞≤≥<>≈≠→←↔⟶⇒⇔·•+-=,:;^_()[]/\\ \t"
+                "ΠΣΩΛΦΨΔΘαβγδεζηθικλμνξοπρστυφχψω"
+            )
+
+            def _merge_math_once(text: str) -> str:
+                pat = re.compile(r"\$([^$\n]+)\$([^\$\n]{1,12}?)\$([^$\n]+)\$")
+
+                def _mh(m: "re.Match[str]") -> str:
+                    sep = m.group(2)
+                    if sep.strip() and all(c in _inline_math_glue for c in sep):
+                        return f"${m.group(1)}{sep}{m.group(3)}$"
+                    return m.group(0)
+
+                return pat.sub(_mh, text)
+
+            prev_math = None
+            while prev_math != markdown_content:
+                prev_math = markdown_content
+                markdown_content = _merge_math_once(markdown_content)
             return markdown_content
         except Exception as e:
             logger.warning(f"Error in fidelity-safe formatting: {str(e)}")

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import re
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -53,6 +54,18 @@ _RENDER_ZOOM = _RENDER_DPI / 72.0
 # 避免视图中"光栅位图 + 散落矢量标签"双轨损耗。0.8 阈值保留 20% 边距
 # 余量以兼容 layout 与 raster bbox 的±几 pt 偏差。
 _FIGURE_CONTAINS_RASTER_THRESHOLD = 0.8
+
+# 图注锚点回退（caption-anchored fallback）：当 layout_analysis 对某页
+# 漏检 figure region（典型场景：纯矢量 / 混合 media 的流程图、封面总览图，
+# docling/MinerU 这类版面分析器常见盲区），但该页文字层存在 "Figure N |"
+# 图注时，基于图注 line-bbox 上方区域 + 矢量绘制密度构造回退 figure
+# region，复用 _render_figure_regions 渲染。种子 bbox 不必精确 —— 现有
+# _expand_figure_bbox 会进一步吸纳邻近矢量与短文本块完成视觉对齐。
+_CAPTION_FBACK_RE = re.compile(r"^(?:Figure|Fig\.?)\s+(\d+)\s*[|：︱Ｉ]")
+_CAPTION_FBACK_SEED_UP_PT = 200.0   # 种子向上高度（pt），_expand_figure_bbox 会再扩展
+_CAPTION_FBACK_MAX_HEIGHT_PT = 360.0  # 图注 y0 上方最多取 360pt（防跨页误抓）
+_CAPTION_FBACK_TOP_MARGIN_PT = 36.0  # 页面顶部安全边距
+_CAPTION_FBACK_MIN_DRAWINGS = 6      # 候选区域内矢量绘制数下限（挡纯正文页）
 
 
 def _is_decorative_raster_bbox(
@@ -371,6 +384,135 @@ def _expand_figure_bbox(
 # ---------------------------------------------------------------------------
 # 矢量图形区域渲染
 # ---------------------------------------------------------------------------
+
+
+def _drawing_intersects_rect(
+    drawing: Dict[str, Any],
+    rect: Tuple[float, float, float, float],
+) -> bool:
+    """判断矢量绘制项是否与目标矩形相交（矢量密度校验用）。"""
+    r = drawing.get("rect")
+    if r is None:
+        return False
+    try:
+        if hasattr(r, "x0"):
+            dx0, dy0, dx1, dy1 = r.x0, r.y0, r.x1, r.y1
+        else:
+            dx0, dy0, dx1, dy1 = tuple(r)[:4]
+    except Exception:
+        return False
+    rx0, ry0, rx1, ry1 = rect
+    return not (dx1 <= rx0 or dx0 >= rx1 or dy1 <= ry0 or dy0 >= ry1)
+
+
+def _detect_caption_anchored_figure_regions(
+    pdf_path: str,
+    covered_pages: Set[int],
+    start_page: int,
+    end_page: int,
+) -> List[LayoutRegion]:
+    """图注锚点回退：为 layout 漏检的纯矢量/混合 figure 补 figure region。
+
+    扫描 ``[start_page, end_page)`` 内**未被 layout 覆盖**（不在
+    ``covered_pages``）的页面文字层，定位 "Figure N |" 图注 line；取该 line
+    的 bbox 作为 figure x 范围、图注顶部 y0 上方 _SEED_UP_PT 作为种子
+    y 范围（图在图注上方），并要求候选区域内矢量绘制数 ≥
+    _MIN_DRAWINGS（挡住纯正文页 —— fitz get_drawings 不含字形，正文页
+    几乎无矢量绘制）。种子 bbox 不必精确：_expand_figure_bbox 会进一步
+    吸纳邻近矢量与短文本块完成视觉对齐。
+
+    Returns:
+        构造的回退 LayoutRegion 列表（region_type="figure"，带 caption 元数据）。
+    """
+    from ....pdf._imports import import_fitz
+
+    try:
+        fitz = import_fitz()
+    except Exception:
+        return []
+    regions: List[LayoutRegion] = []
+    try:
+        doc = fitz.open(pdf_path)
+    except Exception:
+        return []
+    try:
+        for page_idx in range(start_page, end_page):
+            if page_idx in covered_pages:
+                continue
+            page = doc[page_idx]
+            try:
+                text_dict = page.get_text("dict")
+            except Exception:
+                continue
+            caption_bbox: Optional[Tuple[float, float, float, float]] = None
+            caption_num: Optional[int] = None
+            for block in text_dict.get("blocks", []):
+                if block.get("type") != 0:
+                    continue
+                for line in block.get("lines", []):
+                    spans = line.get("spans", [])
+                    if not spans:
+                        continue
+                    head_text = "".join(s.get("text", "") for s in spans).strip()
+                    m = _CAPTION_FBACK_RE.match(head_text)
+                    if m:
+                        caption_bbox = tuple(line.get("bbox", (0, 0, 0, 0)))
+                        caption_num = int(m.group(1))
+                        break
+                if caption_bbox:
+                    break
+            if not caption_bbox or caption_num is None:
+                continue
+            cx0, cy_top, cx1, _cy_bottom = caption_bbox
+            page_rect = page.rect
+            # 图注 line 可能仅 "Figure N |" 前缀较窄：以中点为栏中心，
+            # 左右各扩 1/4 页宽近似该栏（双栏论文的栏内 figure）。
+            if cx1 - cx0 < page_rect.width * 0.25:
+                mid = (cx0 + cx1) / 2
+                col_half = page_rect.width / 4
+                cx0 = max(0.0, mid - col_half)
+                cx1 = min(page_rect.width, mid + col_half)
+            # 种子 y 范围：图注顶部上方 _SEED_UP_PT（不越顶部边距/上限）
+            up = min(_CAPTION_FBACK_SEED_UP_PT, _CAPTION_FBACK_MAX_HEIGHT_PT)
+            y0 = max(_CAPTION_FBACK_TOP_MARGIN_PT, cy_top - up)
+            y1 = cy_top
+            if y1 - y0 < 30:
+                continue
+            candidate = (cx0, y0, cx1, y1)
+            try:
+                drawings = page.get_drawings()
+            except Exception:
+                drawings = []
+            dense = sum(1 for d in drawings if _drawing_intersects_rect(d, candidate))
+            if dense < _CAPTION_FBACK_MIN_DRAWINGS:
+                logger.debug(
+                    "caption fallback p%d Fig%d: 矢量密度不足 %d<%d，跳过",
+                    page_idx, caption_num, dense, _CAPTION_FBACK_MIN_DRAWINGS,
+                )
+                continue
+            regions.append(
+                LayoutRegion(
+                    region_type="figure",
+                    bbox=candidate,
+                    page_number=page_idx,
+                    confidence=0.5,
+                    metadata={
+                        "caption": f"Figure {caption_num}",
+                        "source": "caption_anchored_fallback",
+                    },
+                )
+            )
+            logger.info(
+                "caption fallback 补 figure region p%d Fig%d (%.0fx%.0f pt, %d drawings)",
+                page_idx,
+                caption_num,
+                cx1 - cx0,
+                y1 - y0,
+                dense,
+            )
+    finally:
+        doc.close()
+    return regions
 
 
 async def _render_figure_regions(
@@ -757,6 +899,7 @@ class FitzImageExtractor(PDFToolBase):
             # ── Phase 2: 矢量图形渲染（新增）─────────────────────────
             rendered_images: List[ExtractedImage] = []
             raster_drop_indices: Set[int] = set()
+            figure_regions: List[LayoutRegion] = []
             if layout is not None and isinstance(layout, LayoutAnalysisOutput):
                 figure_regions = [
                     r
@@ -766,16 +909,28 @@ class FitzImageExtractor(PDFToolBase):
                     and (r.bbox[2] - r.bbox[0]) > 0
                     and (r.bbox[3] - r.bbox[1]) > 0
                 ]
-                if figure_regions:
-                    rendered_images, raster_drop_indices = await _render_figure_regions(
-                        pdf_path=pdf_path,
-                        figure_regions=figure_regions,
-                        raster_images=raster_images,
-                        start_page=start_page,
-                        end_page=end_page,
-                        output_dir=output_dir,
-                        sem=sem,
-                    )
+            # 图注锚点回退：为 layout 漏检的纯矢量/混合 figure 补 figure region
+            # （典型场景：survey/论文封面总览图、纯矢量流程图；docling 这类
+            # 版面分析器对前部页面的常见盲区）。复用 _render_figure_regions 渲染。
+            covered_pages = {r.page_number for r in figure_regions}
+            fallback_regions = _detect_caption_anchored_figure_regions(
+                pdf_path=pdf_path,
+                covered_pages=covered_pages,
+                start_page=start_page,
+                end_page=end_page,
+            )
+            if fallback_regions:
+                figure_regions.extend(fallback_regions)
+            if figure_regions:
+                rendered_images, raster_drop_indices = await _render_figure_regions(
+                    pdf_path=pdf_path,
+                    figure_regions=figure_regions,
+                    raster_images=raster_images,
+                    start_page=start_page,
+                    end_page=end_page,
+                    output_dir=output_dir,
+                    sem=sem,
+                )
 
             # ── Phase 3: 合并 + 排序 + 分配 reading_order ──────────
             # 剔除被 figure region 整体替代的 raster（避免双轨重复）

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
@@ -431,6 +431,8 @@ def _detect_caption_anchored_figure_regions(
     except Exception:
         return []
     regions: List[LayoutRegion] = []
+    if start_page >= end_page:
+        return regions
     try:
         doc = fitz.open(pdf_path)
     except Exception:
@@ -513,6 +515,10 @@ def _detect_caption_anchored_figure_regions(
                 y1 - y0,
                 dense,
             )
+    except Exception as e:
+        # 遍历异常（mock / 特殊 PDF 的 page 下标失败等）不阻塞主流程，
+        # return 已收集的 regions（可能部分或空）。Fitz._run 继续 Phase 1/3。
+        logger.debug("caption fallback 遍历异常: %s", e)
     finally:
         doc.close()
     return regions

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
@@ -62,10 +62,10 @@ _FIGURE_CONTAINS_RASTER_THRESHOLD = 0.8
 # region，复用 _render_figure_regions 渲染。种子 bbox 不必精确 —— 现有
 # _expand_figure_bbox 会进一步吸纳邻近矢量与短文本块完成视觉对齐。
 _CAPTION_FBACK_RE = re.compile(r"^(?:Figure|Fig\.?)\s+(\d+)\s*[|：︱Ｉ]")
-_CAPTION_FBACK_SEED_UP_PT = 200.0   # 种子向上高度（pt），_expand_figure_bbox 会再扩展
+_CAPTION_FBACK_SEED_UP_PT = 200.0  # 种子向上高度（pt），_expand_figure_bbox 会再扩展
 _CAPTION_FBACK_MAX_HEIGHT_PT = 360.0  # 图注 y0 上方最多取 360pt（防跨页误抓）
 _CAPTION_FBACK_TOP_MARGIN_PT = 36.0  # 页面顶部安全边距
-_CAPTION_FBACK_MIN_DRAWINGS = 6      # 候选区域内矢量绘制数下限（挡纯正文页）
+_CAPTION_FBACK_MIN_DRAWINGS = 6  # 候选区域内矢量绘制数下限（挡纯正文页）
 
 
 def _is_decorative_raster_bbox(
@@ -487,7 +487,10 @@ def _detect_caption_anchored_figure_regions(
             if dense < _CAPTION_FBACK_MIN_DRAWINGS:
                 logger.debug(
                     "caption fallback p%d Fig%d: 矢量密度不足 %d<%d，跳过",
-                    page_idx, caption_num, dense, _CAPTION_FBACK_MIN_DRAWINGS,
+                    page_idx,
+                    caption_num,
+                    dense,
+                    _CAPTION_FBACK_MIN_DRAWINGS,
                 )
                 continue
             regions.append(

--- a/apps/negentropy-perceives/tests/unit/test_image_extraction_concurrency.py
+++ b/apps/negentropy-perceives/tests/unit/test_image_extraction_concurrency.py
@@ -167,8 +167,10 @@ class TestFitzImageExtractorConcurrency:
         assert result.success is True
         assert result.output is not None
         assert result.output.total_count == pages * images_per_page
-        # 探测 + 每页一次 = pages + 1
-        assert len(fake_fitz.open_calls) == pages + 1
+        # 探测 + 每页一次 + caption fallback 遍历 = pages + 2
+        # （_detect_caption_anchored_figure_regions 为补 layout 漏检的矢量
+        # figure 而独立 fitz.open 一次遍历图注；layout=None 时仍调）
+        assert len(fake_fitz.open_calls) == pages + 2
         # metadata 透出并发度
         assert result.output.metadata["concurrency"] == _IMAGE_EXTRACT_CONCURRENCY
         assert result.output.metadata["page_count"] == pages


### PR DESCRIPTION
## 背景
PDF→Markdown 高保真巡检（doc_id=9045a031，88 页 survey《Self-Improving Agents in the Era of Experience》）迭代成果。巡检路径用的格式化方法是 `format_fidelity_safe`（显式跳过 `_apply_typography_fixes`），故定点修复须挂载到该方法。

## 改动
- **formatter 标题无空格软断字合并**（`format_fidelity_safe`）：PDF 双栏标题跨行（如 `Parame-\nters`）经 docling 抽取残留为无空格 `Parame-ters`，原 `word- word` 带空格规则不匹配。放宽 left 至 `[A-Z]?[a-z]{2,}`（覆盖 Title Case 大写首），合成词保护用 `left.lower()` 匹配 `_COMPOUND_HYPHEN_PREFIXES` + 标题高频合成词补集（system/task/meta/parameter 等）。
- **formatter inline 公式重组**（`format_fidelity_safe`）：`_normalize_unicode_math` 把数学字形独立包裹为 `$..$`，运算符 `★/≤/∈/Π` 留外致公式断裂。新增 pass 迭代合并被纯数学符号/希腊字母分隔的相邻 `$..$`（挡 ASCII 字母词分隔，避免误并 `$x$ and $y$`）。重转复核：原 7 段 `$..$` 公式减至 3 段。
- **image_extraction 图注锚点回退**：`_detect_caption_anchored_figure_regions` + `_render_figure_regions`（Fitz 路径），为 layout 漏检的纯矢量/混合 figure 补 figure region。本巡检 doc 的 auto 路径不调 Fitz._run（走 ops/pdf.py 传统路径），回退对本 doc 无效但代码保留 + 加防御（empty page range 早 return / 遍历异常 except）。
- **测试断言适配**：`test_all_pages_processed_and_outputs_correct` 的 `open_calls` 由 `pages+1` 更新为 `pages+2`（caption fallback 独立 fitz.open 一次）。

## unfixable（已 ≥2 次修复失败）
- Figure 1–5（纯矢量/混合图）丢失：连续 2 次修复失败（Fitz._run + ODL._run 均诊断出不调），根因是 auto 转换路径不调 image_extraction stage 的 `_run`，需调研 `ops/pdf.py` / `EnhancedPDFProcessor` 的图提取入口。
- inline 公式 `sup`/`log` 字母函数词碎片：formatter 层无法识别字母函数词为数学，需 text_extraction 字号检测架构改动。

## 验证
- `uv run ruff check`：Passed
- `uv run pytest tests/unit/test_image_extraction_concurrency.py tests/unit/test_formatter_unicode_math.py tests/unit/test_math_formula.py`：78 passed
- 清 `.batch_state` checkpoint 后重转复核：标题 `Parame-ters→Parameters`（Self-improvement/System-level/Parameter-side 保留），公式 7→3 段。

## 非回归注意
- 标题断字 `_title_compound_extra` 白名单不全是已知风险（其它 PDF 含 `decision-making`/`user-facing` 类合成词标题可能误并）。
- inline 公式重组可能误并正常 `$a$ + $b$`（数学语义正确但被合并）。
- 合并前建议对 regression_sample 重转 + 采样评分。

🤖 Generated with [Claude Code](https://claude.com/claude-code)