### PR TITLE
docs(transcript): 沉淀「人机交互」转录 UI 设计 ADR 与用户指引

### DIFF
--- a/docs/.agents/knowledge-map.md
+++ b/docs/.agents/knowledge-map.md
@@ -37,6 +37,7 @@
 - [Claude Code 集成（BuiltinTool）](../concepts/038-claude-code-integration.md) — Claude Code CLI 作为 ADK Agent 工具的接入方案
 - [Routine（长周期自主任务）](../concepts/039-the-routine-system.md) — Engine 编排 + Claude Code 执行的 Evaluator-Optimizer 自迭代闭环（含 Reflexion 反思记忆、LLM-as-Judge 评估、审批门控、停止护栏） · [预设模版](../concepts/user-guide/routine-presets.md) — 4 个开箱即用的场景模版（代码审计 / 测试增强 / 文档生成 / 架构清减），正交覆盖全部核心功能
 - [Routine 多 Agent 归因（一核五翼 Faculty 接入）](../concepts/040-routine-multi-agent-faculty.md) — 将 5 翼 Faculty 真正引入 Routine 编排链，使「人机交互」中「人」侧动作（审 Plan / 答问 / 门控 / 评估）由真实 Faculty Agent 产出并归因（agent_role）；FacultyBridge 同步桥接 + litellm 降级，前端 deriveHumanRole 语义投射平滑切换至后端字段
+- [人机交互转录 UI（Routine × Studio 统一架构）](../concepts/041-human-machine-interaction-transcript.md) — 回合制转录渲染器（`TranscriptItemsView` + `TranscriptPolicy`）统一 Routine Iterations Full View 与 Home/Studio 中栏对话；语义重映射（Routine 人=一核五翼 / 机=Claude Code；Studio 人=用户 / 机=一核五翼+Claude Code）、机制 vs 策略正交分解、`TranscriptItem` 视图模型与 per-agent 归因映射 · [实操手册](../concepts/user-guide/transcript-view.md) — 两处「人机交互」界面的实操指引（左右分栏语义 / 工具卡展开 / 思考引用 / 节点选中搜索 / FAQ）
 - [Skills](../concepts/design/skills.md)
 - [Negentropy Wiki Ops](../reference/wiki/ops.md)
 - [Wiki 独立部署与内容同步](../reference/wiki/deployment.md) — 纯静态 wiki 独立部署（Docker / 静态托管）+ 本地主站 Catalog 内容同步到远程 wiki 的 step-by-step 指引；含「本地 publish 自动发布到 GitHub Pages」（图片烘焙自包含 + 后端 spawn `publish-wiki-pages.sh` + buildId 幂等）

--- a/docs/concepts/040-routine-multi-agent-faculty.md
+++ b/docs/concepts/040-routine-multi-agent-faculty.md
@@ -7,6 +7,7 @@ sidebar_position: 4.0
 >
 > - 前置：[Claude Code 集成设计](./038-claude-code-integration.md) · [The Routine System](./039-the-routine-system.md)
 > - 理论：[Routine Agent 迭代模式调研](../research/110-routine-agent-iteration.md)
+> - 渲染：本文归因在 UI 侧的呈现见 [人机交互转录 UI ADR](./041-human-machine-interaction-transcript.md)（Routine Full View × Studio 中栏统一渲染器）
 
 ---
 

--- a/docs/concepts/041-human-machine-interaction-transcript.md
+++ b/docs/concepts/041-human-machine-interaction-transcript.md
@@ -1,0 +1,187 @@
+---
+sidebar_position: 4.1
+---
+# 人机交互转录 UI：Routine 与 Studio 的统一架构
+
+> Routine 迭代「Iterations Full View」与 Home/Studio 中栏的「人机交互」对话已统一为同一套**回合制转录渲染器**（`TranscriptItemsView` + `TranscriptPolicy`）。本文记录语义重映射、业界对照、机制 vs 策略正交分解与关键设计决策。
+>
+> - 前置：[The Routine System](./039-the-routine-system.md) · [Routine 多 Agent 归因（一核五翼 Faculty）](./040-routine-multi-agent-faculty.md) · [A2UI 协议](./a2ui.md)
+> - 理论：[Conversation Foundation](./conversation-foundation.md) · [AG-UI 协议调研](../research/070-ag-ui.md)
+
+---
+
+## 1. 背景与动机
+
+两处「人机交互」UI 长期**双轨割裂**：
+
+- **Routine Iterations Full View** 已有一套成熟的回合制转录 UI（`TranscriptView`）：按发言方左右分栏、per-agent 角色徽章、可展开的**按类型渲染工具卡**（shell / read / edit-diff / write / search / sub_agent）、≥3 连续工具折叠、thinking 折叠、在途 `WorkingIndicator`。
+- **Home/Studio 中栏** 则是另一套流式聊天渲染（`ChatStream` → `MessageBubble` / `AssistantReplyBubble`），观感与 Routine 不一致，且无 per-agent 显化。
+
+割裂带来三类成本：① 用户在两处切换时**认知摩擦**；② 设计语言**双份维护**；③ 工具调用渲染深度不一（Studio 浅、Routine 深）。目标：**让 Studio 中栏复用 Routine 的同一套转录渲染器**，仅做语义重映射，使「设计语言单一事实源」。
+
+## 2. 业界对照研究
+
+回合制（turn-based）人机交互 UI 是当前主流编码/会话 Agent 产品的公约数。三家范本的对齐要点：
+
+| 产品 | 回合组织 | 工具调用 | 思考片段 | 在途态 |
+|---|---|---|---|---|
+| **Conductor**<sup>[[1]](#ref1)</sup> | `data-turn-index` 分组、左右分栏 | 可展开卡 + diff/terminal 分节、≥3 折叠 | 可折叠 `thinking` 块 | Lottie `running` / `typing` / `waiting` |
+| **ChatGPT**<sup>[[2]](#ref2)</sup> | 单列时间线、Reasoning 折叠 | 工具卡折叠 + 参数/结果分节 | Reasoning 默认折叠 | 进度条 + 气泡内三点 |
+| **Claude.ai** | 单列、思考可展开 | 工具时间线 + 紧凑摘要 | Thinking 展开式 | 流式光标 + 状态文案 |
+
+**提炼共性**（本系统采纳）：① 按发言方**左右分栏**区分人/机；② 工具调用**可展开折叠**，按类型给差异化明细（diff / 命令 / 内容）；③ 思考片段**默认折叠**降噪；④ 在途态**脉冲指示**（Working… / Planning…）。详见 [Conversation Foundation](./conversation-foundation.md) 的「行业基线」节与 [AG-UI 协议调研](../research/070-ag-ui.md) 的事件模型分析。
+
+## 3. 语义重映射（核心差异）
+
+同一渲染器，两处「人/机」语义不同——这是唯一需要策略化的差异：
+
+| 维度 | Routine（Iterations Full View） | Studio（Home 中栏） |
+|---|---|---|
+| **人（居右）** | 一核五翼 6 Agent（审 Plan / 答问 / 门控 / 评估） | 真实用户输入 |
+| **机（居左）** | Claude Code（assistant / tool / cc_request） | 一核五翼 Agents + Claude Code（均带 per-agent 徽章） |
+| 编排者 | Negentropy Engine（gate / evaluation / result，居右） | 无独立编排者 |
+| 触发模型 | ADK 事件流 + Routine 编排 | AG-UI 事件流 + 用户直连 |
+
+> 直觉记忆：**Routine 里「人」是 Agent 团队、「机」是 Claude Code；Studio 里「人」是用户、「机」是 Agent 团队 + Claude Code。**
+
+## 4. 架构方案（机制 vs 策略正交分解）
+
+**单一渲染器 `TranscriptItemsView`**（纯展示，policy 化）+ **`TranscriptPolicy` 契约**（承载左右对齐 / 徽章 / 在途文案差异）+ **两个适配器**（各自把域数据归一化为 `TranscriptItem[]` IR）。
+
+```mermaid
+flowchart LR
+  subgraph ROUTINE["Routine 路径（Iterations Full View）"]
+    direction LR
+    R1["RoutineIterationEventDTO[]<br/>持久化 + live SSE"] --> R2["normalizeTranscript<br/>工具配对 / cc·human 提升"]
+    R2 --> R3["前置 task_dispatch<br/>（iteration.prompt 合成）"]
+    R3 --> R4["TranscriptItemsView<br/>ROUTINE_POLICY"]
+  end
+  subgraph STUDIO["Studio 路径（Home 中栏）"]
+    direction LR
+    S1["ConversationNode[]<br/>AG-UI 树"] --> S2["buildChatDisplayBlocks<br/>turn 分组 / 6 层去重 / 漂移修正"]
+    S2 --> S3["buildStudioTranscript<br/>ChatDisplayBlock → TranscriptItem"]
+    S3 --> S4["TranscriptItemsView<br/>STUDIO_POLICY + itemWrapper"]
+  end
+  R4 --> VIEW["共享渲染原语<br/>components/transcript/*"]
+  S4 --> VIEW
+  classDef routine fill:#3f3a1e,stroke:#fbbf24,color:#fef9c3;
+  classDef studio fill:#1e3a5f,stroke:#60a5fa,color:#e0f2fe;
+  classDef shared fill:#3b1e3f,stroke:#c084fc,color:#f3e8ff;
+  class R1,R2,R3,R4 routine;
+  class S1,S2,S3,S4 studio;
+  class VIEW shared;
+```
+
+`TranscriptPolicy` 契约（`components/transcript/policy.ts`）：
+
+```ts
+interface TranscriptPolicy {
+  align(item: TranscriptItem): "left" | "right";        // 物理对齐
+  turnGroup?(item: TranscriptItem): string;             // 换方间距的发言人分组（缺省回落 align）
+  roleHeaderFor(item, prev): AgentRole | null;          // 机侧 per-agent 徽章（null=不渲染）
+  workingLabel?(last): string;                          // 在途 WorkingIndicator 文案
+}
+```
+
+- **`ROUTINE_POLICY`**：`human_reply`/`task_dispatch`/`engine` 居右、其余居左；`turnGroup` 三分（cc / human / engine）；`roleHeaderFor` 恒 `null`（徽章内嵌在 Engine/Human/TaskDispatch 块中）。
+- **`STUDIO_POLICY`**：仅 `user` 居右、其余全居左；`roleHeaderFor` 在机侧 `role` 相邻变化时渲染徽章（分组降噪）；不设 `turnGroup`（回落 align）。
+
+薄壳 `TranscriptView`（Routine）与 `StudioTranscript`（Studio）各自归一化后委派给同一渲染器，**外部签名稳定、行为各表**。
+
+## 5. TranscriptItem 视图模型
+
+12 个 kind 的判别联合（`components/transcript/types.ts`）：
+
+| Kind | 用途 | Routine | Studio | 对齐 |
+|---|---|:-:|:-:|:-:|
+| `task_dispatch` | 开场任务下发（`iteration.prompt` 合成） | ✓ | — | 右 |
+| `user` | 真实用户文本 | — | ✓ | 右 |
+| `assistant` | 文本（可带 thinking / citations / streaming / role） | ✓ | ✓ | 左 |
+| `tool` | 单次工具调用（可展开 / running / progress / role） | ✓ | ✓ | 左 |
+| `tool_summary` | ≥3 连续工具折叠（透传 role） | ✓ | ✓ | 左 |
+| `cc_request` | 机→人请求（ExitPlanMode / AskUserQuestion） | ✓ | — | 左 |
+| `human_reply` | 人→机应答（approve / refine / answer / deny） | ✓ | — | 右 |
+| `engine` | Engine 编排产出（gate / evaluation / result） | ✓ | — | 右 |
+| `system` | Routine 系统事件（携带 DTO，可展开 payload） | ✓ | — | 左 |
+| `system_note` | Studio 纯文本系统/状态/摘要行 | — | ✓ | 左 |
+| `truncated` | 动作数超限截断哨兵 | ✓ | — | 左 |
+
+可选字段（全 additive）：`role: AgentRole`（机侧 + human_reply）、`nodeId: string`（Studio 选中/搜索）、`citations: Citation[]`（assistant，Studio 引用尾注）、`progress: ToolProgressSnapshot`（tool，Studio 流式进度）、`streaming` / `thinking`（assistant）。所有可选字段对 Routine 归一化输出恒空 → Routine 渲染逐像素等价。
+
+## 6. Agent 身份映射
+
+跨域单一事实源 `features/agent-identity/`。`AGENT_ROLE_META`（标签 / 图标 / 徽章配色）：
+
+| Role | 中文 | Lucide 图标 | 徽章配色（dark-safe） |
+|---|---|---|---|
+| `engine` | Negentropy | `Cpu` | slate |
+| `claude_code` | Claude Code | `Bot` | violet |
+| `perception` | 慧眼 | `Eye` | cyan |
+| `action` | 妙手 | `Hand` | orange |
+| `internalization` | 本心 | `BrainCircuit` | emerald |
+| `contemplation` | 元神 | `Sparkles` | indigo |
+| `influence` | 喉舌 | `Megaphone` | rose |
+
+`agentRoleFromAuthor(author)` 用大小写不敏感子串匹配（兼容 EN + 中文学名 + 别名前后缀）把 ADK `message.author` 派生为 `AgentRole`；未知回退 `engine`。后端 agent 名源自 `apps/negentropy/src/negentropy/agents/agent.py`：根 `NegentropyEngine` + 五翼 `PerceptionFaculty` / `InternalizationFaculty` / `ContemplationFaculty` / `ActionFaculty` / `InfluenceFaculty`。
+
+## 7. 关键决策与权衡
+
+1. **`turnGroup` 三分（Routine）**：`engine` 与 `human_reply`/`task_dispatch` 都居右，但语义不同（编排者 vs 人侧 Agent）。若仅按 `align` 二态判换方间距，连续的 human→engine 会被当同方（8px），丢失编排转折的视觉呼吸；按 speaker 三分（cc / human / engine）才正确触发 16px 换方间距。Studio 无此三分语义，回落 `align`。
+2. **`collapseToolRuns` 在 `tool_summary` 透传 `role`**：≥3 工具折叠后，Studio 的徽章分组逻辑（`roleHeaderFor`）需以折叠行首工具的 role 参与「上一条机侧 role」比较，避免折叠行后又重复刷同 role 徽章。Routine 的 tool 无 role，透传 `undefined` 无副作用。
+3. **`citations` 仅挂首个 text 段**：避免同回合格式化的引用尾注块重复出现。聚合走 `extractCitationsFromToolCalls`（`utils/citation-parser.ts`），匹配 `search_knowledge_base` / `search_knowledge_graph_with_papers` 的 `formatted_citation`。
+4. **Studio `itemWrapper` 挂 `data-testid="message-bubble"` + `data-message-role`**：旧 E2E「双气泡守卫」（防流式 dedup 双气泡）依赖该选择器；新 UI 把 text 段拆为独立气泡，但单文本回复仍恰好 1 气泡——选择器兼容让守卫零改动保留。
+5. **类型化工具明细**：`derive-tool-detail.ts` 按工具名分派到 `shell / read / edit / write / search / fetch / sub_agent / plan / generic` 九类，`tool-detail-sections.tsx` 各自渲染（shell 显 `$ cmd + output`，edit 显 diff，read/write 显等宽内容等）。这是 Routine 范式的深度复用，Studio 直接受益。
+6. **机制 vs 策略边界**：渲染原语（block 组件、`collapseToolRuns`、`status-shared`、`message-shared`）与域无关，落 `components/transcript/`；事件耦合的归一化（`normalize-transcript` 消费 `RoutineIterationEventDTO`）留 `app/interface/routine/`；跨包对 Routine 的 DTO 仅 `import type`（运行时零反向依赖）。
+
+## 8. 边缘 Case 与回归守卫
+
+| Case | 机制 | 位置 |
+|---|---|---|
+| 流式 dedup | 复用 `buildChatDisplayBlocks`（6 层去重 + 时钟漂移排序 + reasoning/agent-transfer）；`nodesFingerprint` 含子内容长度保证流式更新 | `StudioTranscript` / `chat-display.ts` |
+| ≥3 连续工具折叠 | `collapseToolRuns` 折叠非 running 工具；任何非 tool 项打断 flush；running 工具排除 | `collapse-tool-runs.ts` |
+| 引用聚合 | `replyCitations` 从 assistant-reply 的 tool-group 段提取（按 `rawName` 匹配原始工具名），仅挂首段 text | `build-studio-transcript.ts` |
+| 工具进度旁路 | `progressMap[tool.id]`（state_delta SSE）透传到 `tool.progress`，渲染细进度/阶段行 | `build-studio-transcript.ts` / `ExpandableToolCallRow` |
+| 节点选中 / 搜索 | `itemWrapper` 挂 `data-node-id` + 点击 ring + 搜索高亮 ring + `scrollIntoView` | `StudioTranscript` |
+| 在途指示器 | `pending && !lastIsStreamingAssistant` 时尾随 `WorkingIndicator`；label 由 `policy.workingLabel` 解析（cc_request+pending → Planning…，否则 Working…） | `TranscriptItemsView` |
+| CC 交互错误红显 | `AssistantText` 用 `CC_ERROR_RE` 检测「returned an error」等模式，红框 + ⚠ | `AssistantText.tsx` |
+| thinking 折叠 | 默认收起为「思考…」单行 + Brain 图标，点击展开 | `AssistantText` |
+| 空 assistant 丢弃 | 仅 `{raw}` 无 text 的 assistant 事件归一化时丢弃，防空气泡 | `normalize-transcript.ts` |
+| 持久化 + live 合并 | `mergeEvents` 按 `seq` 去重（持久化优先）+ 升序重排 | `IterationAuditDrawer.tsx` |
+
+## 9. 关键文件索引
+
+| 路径 | 角色 |
+|---|---|
+| `components/transcript/TranscriptItemsView.tsx` | SSOT 策略化渲染器 |
+| `components/transcript/policy.ts` | `TranscriptPolicy` + `ROUTINE_POLICY` + `STUDIO_POLICY` |
+| `components/transcript/types.ts` | `TranscriptItem` 视图模型（12 kind） |
+| `components/transcript/collapse-tool-runs.ts` | ≥3 工具折叠 |
+| `components/transcript/{AssistantText,ExpandableToolCallRow,ToolSummaryRow,CcRequestBlock,HumanReplyBlock,EngineMessageBlock,TaskDispatchBubble,UserBubble,SystemNoteRow,WorkingIndicator}.tsx` | block 原语 |
+| `components/transcript/{message-shared,status-shared,derive-tool-detail,tool-detail-sections}.ts(x)` | 共享明细/徽章/状态 |
+| `features/agent-identity/` | `AgentRole` / `AGENT_ROLE_META` / `agentRoleFromAuthor`（跨域 SSOT） |
+| `app/interface/routine/_components/transcript/{TranscriptView,normalize-transcript}.ts(x)` | Routine 适配器（薄壳 + 事件归一化） |
+| `app/interface/routine/_components/{IterationAuditDrawer,IterationEventTimeline}.tsx` | Routine Full View 容器 |
+| `components/ui/StudioTranscript.tsx` | Studio 外壳（滚动 / FAB / 空态 / 选中 / 搜索） |
+| `components/ui/studio-transcript/build-studio-transcript.ts` | Studio 适配器（block → TranscriptItem） |
+| `app/home-body.tsx` | 接入点（`<StudioTranscript>` 替换 `<ChatStream>`） |
+
+## 10. 演进路径
+
+沿用 [040 ADR](./040-routine-multi-agent-faculty.md) 的 Phase 路线：Phase 2 后端落地 `agent_role` 字段后，归一化层切 `ev.agent_role ?? deriveHumanRole(action)`，前端零扩散；Studio 侧 `agentRoleFromAuthor` 同样可平滑切到后端归因字段（当 ADK 事件流显式携带 agent 元数据时）。短期可演进项：① Routine/Studio 的 thinking 与 Reasoning Panel 统一（[0002 RFC](./0002-ui-interaction-enhancements.md)）；② 工具明细的 Mermaid / 大输出虚拟化。
+
+## 11. 风险评估
+
+| 编号 | 风险 | 影响 | 概率 | 对策 |
+|---|---|---|---|---|
+| R1 | Routine 渲染回归（迁移共享模块） | 高 | 低 | 44 项转录契约测试零改动全绿；`ROUTINE_POLICY.roleHeaderFor` 恒 null 保逐像素等价 |
+| R2 | 流式 key 抖动致重挂载 | 中 | 中 | item key `${kind}-${seq}-${id}`，`id` 源自稳定 nodeId；fingerprint memo 含子内容长度 |
+| R3 | per-agent 归因失真（author 字段不规范） | 中 | 低 | 子串匹配 + 中文学名兜底 + 未知回退 engine；Phase 2 切后端字段后消除 |
+| R4 | Studio 选择器破坏旧 E2E | 中 | 中 | `itemWrapper` 挂 `data-testid="message-bubble"` + `data-message-role`，双气泡守卫零改动保留 |
+| R5 | 跨包对 Routine DTO 的运行时耦合 | 低 | 低 | `import type` 擦除；共享包无运行时反向依赖 |
+
+---
+
+### 参考
+
+<a id="ref1"></a>[1] Conductor Team, "Conductor — Run multiple coding agents in parallel," *conductor.com*, 2025. [Online]. Available: https://conductor.com
+<a id="ref2"></a>[2] OpenAI, "Introducing ChatGPT & Canvas: agentic tool use," *openai.com*, 2025. [Online]. Available: https://openai.com

--- a/docs/concepts/a2ui.md
+++ b/docs/concepts/a2ui.md
@@ -213,6 +213,8 @@ flowchart TD
 
 ## 4. Chat 页落地方式
 
+> 中栏的回合制转录 UI（左右分栏 + per-agent 徽章 + 类型化工具卡）设计见 [人机交互转录 UI ADR](./041-human-machine-interaction-transcript.md)，实操见 [实操手册](./user-guide/transcript-view.md)。
+
 ### 4.1 为什么是聊天优先
 
 Chat 页的主任务是“阅读并参与对话”，不是“调试节点树”。如果把 turn、状态、结构性事件直接放在主车道，会破坏用户对“我说了什么、智能体回了什么”的基本心智。

--- a/docs/concepts/user-guide/chat-essentials.md
+++ b/docs/concepts/user-guide/chat-essentials.md
@@ -4,6 +4,8 @@ sidebar_position: 4
 # Home / 人与 Agent 对话 · 主模块特性手册
 
 > 本手册覆盖「Home 对话」**所有主模块特性**的最小操作指引。理论与对标参考 [conversation-foundation.md](../conversation-foundation.md)，协议事实参考 [framework.md](../framework.md) §9 与 [a2ui.md](../a2ui.md)，主用户手册参见 [user-guide.md](../../user-guide.md) §3。
+>
+> 中栏对话的**回合制转录渲染**（左右分栏 / per-agent 徽章 / 类型化工具卡 / 思考引用折叠）见 [transcript-view 实操手册](./transcript-view.md)，设计架构见 [人机交互转录 UI ADR](../041-human-machine-interaction-transcript.md)。
 
 ## 0. 入口
 

--- a/docs/concepts/user-guide/transcript-view.md
+++ b/docs/concepts/user-guide/transcript-view.md
@@ -1,0 +1,152 @@
+---
+sidebar_position: 4.5
+---
+# 人机交互转录对话 · 实操手册
+
+> 本手册覆盖 **两处「人机交互」回合制转录对话界面** 的实操：① Home / Studio **中栏**（你与一核五翼 + Claude Code 对话）；② Routine 任务 **Iterations Full View**（一核五翼 6 Agent 与 Claude Code 的协作审计）。设计架构见 [人机交互转录 UI ADR](../041-human-machine-interaction-transcript.md)，主对话特性（模型选择 / 附件 / 搜索 / 引用）见 [chat-essentials](./chat-essentials.md)。
+
+---
+
+## 0. 两处界面在哪
+
+| 界面 | 入口 | 谁在对话 |
+|---|---|---|
+| **Studio 中栏** | 打开 `/` 首页即 Home 对话 | **人 = 你**；**机 = 一核五翼 Agents + Claude Code** |
+| **Routine Full View** | Routine 详情 → 任一 Iteration 卡片 → 「Full View」抽屉 | **人 = 一核五翼 6 Agent**；**机 = Claude Code** |
+
+> 直觉：Studio 里你扮演「人」；Routine 审计里一核五翼 Agent 团队扮演「人」，Claude Code 是「机」。两者共用同一套转录渲染器，仅左右语义不同。
+
+## 1. 视觉布局：左 / 右分栏
+
+回合制转录用**对齐方向**区分人 / 机，比单纯头像更显「回合」节奏：
+
+```mermaid
+flowchart LR
+  subgraph STUDIO["Studio 中栏"]
+    direction TB
+    SU["👤 用户（你）"] -.居右.-> SUR["右侧气泡<br/>primary 浅底"]
+    SA["🤖 一核五翼 + Claude Code"] -.居左.-> SAL["左侧气泡 + per-agent 徽章<br/>+ 工具行 + 思考折叠"]
+  end
+  subgraph ROUTINE["Routine Full View"]
+    direction TB
+    RH["🧠 一核五翼 6 Agent + Engine"] -.居右.-> RHR["右侧气泡<br/>RoleHeader 徽章"]
+    RC["🛠️ Claude Code"] -.居左.-> RCL["左侧裸文 + 紧凑工具行<br/>+ 待决卡片"]
+  end
+  classDef studio fill:#1e3a5f,stroke:#60a5fa,color:#e0f2fe;
+  classDef routine fill:#3f3a1e,stroke:#fbbf24,color:#fef9c3;
+  class STUDIO studio;
+  class ROUTINE routine;
+```
+
+> 📷 *TODO 实操截图：Studio 中栏对话（用户居右 / 机侧居左带徽章 / 工具行 / 思考折叠）*
+
+> 📷 *TODO 实操截图：Routine Iterations Full View（task_dispatch / cc_request / human_reply / engine）*
+
+## 2. Studio 中栏实操
+
+### 2.1 发送指令与识别发言方
+
+**能做什么**：发送一条指令，看清谁的产出在哪。
+
+**怎么做**：
+1. 底部输入框打字 → Enter（或点 Send 上箭头）。你的消息**居右**显示（primary 浅底气泡）。
+2. 机的回复**居左**，每段产出上方挂一个**角色徽章**（图标 + 中文标签）。
+
+**徽章速查**：
+
+| 徽章 | Agent | 触发场景 |
+|---|---|---|
+| 🟦 Negentropy | 一核 NegentropyEngine | 总编排、综合回答（默认） |
+| 🟣 Claude Code | Claude Code | 代码 / 命令 / 工具调用类 |
+| 🟦 慧眼 | PerceptionFaculty | 信息检索（KB / Web / 记忆） |
+| 🟧 妙手 | ActionFaculty | 执行（代码 / 读写） |
+| 🟩 本心 | InternalizationFaculty | 知识结构化（记忆 / KG / 语料） |
+| 🟪 元神 | ContemplationFaculty | 思辨 / 规划 / 反思 |
+| 🟥 喉舌 | InfluenceFaculty | 价值输出 / 通知（预留） |
+
+> **同一 Agent 连续回合不重复显徽章**——只有切换到另一个 Agent 时才出现新徽章，降噪不丢信息。
+
+### 2.2 展开工具调用看明细
+
+**能做什么**：每个工具调用是一行紧凑徽章，点击就地展开**按类型差异化**的明细。
+
+**怎么做**：点击任一工具行（如 `Shell` / `Read` / `Edit` / `Write` / `Search`）→ 下方展开明细卡。
+
+| 工具类型 | 展开后看到 |
+|---|---|
+| `Shell` | `$ 命令` + 终端输出 |
+| `Read` / `Write` | 文件路径 + 等宽内容 |
+| `Edit` | 文件路径 + diff（`+` 绿 / `-` 红） |
+| `Search` | 查询串 + 命中结果 |
+| `Task` | 子代理类型 + 描述 + 产出 |
+| 兜底 | JSON 参数 + 原始输出 |
+
+**注意事项**：
+- **≥3 个连续工具自动折叠**为一行 summary（「N 个工具 · 工具名」），点击可还原展开。
+- 工具在运行中时，行尾显**蓝色脉冲点 + 进度百分比 / 阶段**（由后端 state_delta 推送）。
+- 工具出错时，行尾显红色 `error` 徽章，展开后明细框变红。
+
+### 2.3 思考片段、引用、在途指示
+
+- **思考片段**：机侧推理内容默认收起为「思考…」单行（Brain 图标），点击展开查看完整推理。
+- **引用尾注**：当机侧调用知识库检索时，回复正文末尾附 **IEEE 风格尾注**（`[1] Author, "Title," arXiv:ID, Year.`），正文内 `[N]` 可点击跳转尾注，尾注链接可跳源。
+- **在途指示**：机侧仍在工作时，转录流末尾显 `Working…`（或 `Planning…` 当等待你裁决时）脉冲三点。
+
+### 2.4 节点选中 / 搜索 / 回到底部
+
+- **节点选中**：点击任一回合 → 该节点高亮（ring），右栏 State 观测抽屉（`Cmd/Ctrl+J` 打开）同步聚焦该节点的状态切片。
+- **对话内搜索**（`Cmd/Ctrl+F`）：命中项黄色高亮 ring，自动滚动到第一个并支持上/下一个导航。
+- **回到底部 FAB**：上滑浏览历史时，底部浮现「回到底部」浮钮；新消息到达时若你已在底部则自动跟随。
+
+> 会话管理 / 模型选择 / 附件 / 提示词模板等**通用特性**参见 [chat-essentials](./chat-essentials.md)。
+
+## 3. Routine Full View 实操
+
+### 3.1 打开 Full View
+
+Routine 详情页 → Iteration 时间线卡片 → 点「Full View」→ 右侧抽屉展开该迭代的完整人机交互转录。
+
+### 3.2 阅读一条 Iteration 的对话流
+
+抽屉顶部 metadata bar（phase / status / verdict / score / turns / cost / agent 角色 count）→ 下方是按 seq 时序交织的人机回合：
+
+- **开场任务下发**（右）：`Negentropy → Claude Code` 的 `task_dispatch` 气泡，含目标 / 验收 / 反思 / 记忆注入（由 `iteration.prompt` 合成）。
+- **Claude Code 推理 / 工具**（左）：裸文 + 紧凑工具行（同 Studio 的工具卡范式）。
+- **待决卡片** `cc_request`（左，高亮）：CC 通过 `ExitPlanMode` / `AskUserQuestion` 向「人」提交 Plan / 问题，等待裁决；标题显 `Review plan` / `Answer question` / `Exit plan mode`，在途态显脉冲「等待裁决」。
+- **「人」侧应答** `human_reply`（右）：一核五翼 6 Agent 的裁决气泡，徽章按动作语义显化：
+  - **元神 Contemplation**：审 Plan（approve ✔ / refine 🔄）/ 批准退出 / 迭代评估。
+  - **本心 Internalization**：回答结构化问题。
+  - **妙手 Action**：命令门控（gate passed / Exit N）、拒绝工具。
+- **Engine 编排产出** `engine`（右）：gate / evaluation / result 三类消息，附 verdict / score / 成本徽章。
+
+### 3.3 LIVE 在途与持久化合并
+
+- 抽屉打开时**惰性加载**持久化事件 + **合并 live SSE**（按 `seq` 去重，持久化优先）。
+- 迭代进行中时，顶部显 `LIVE` 脉冲，新事件实时插入；末项 `Working…` 表示机侧仍在工作。
+- 最终态重渲染时补齐 gate / evaluation。
+
+> Routine 的概念与编排详见 [The Routine System](../039-the-routine-system.md) 与 [多 Agent 归因](../040-routine-multi-agent-faculty.md)；开箱预设见 [routine-presets](./routine-presets.md)。
+
+## 4. 常见疑问 FAQ
+
+**Q1：为什么 Studio 看不到 `cc_request` 待决卡片？**
+Studio 是用户直连 Agent，无 Routine 的 Plan 审批门；`ExitPlanMode` / `AskUserQuestion` 等交互在 Studio 走 Composer 层的审批 / @mention，不进转录流。
+
+**Q2：为什么同一 Agent 连续回合不重复显徽章？**
+分组降噪：徽章只在 `role` 切换时出现。一条 Agent 的多回合产出会用首条徽章统领，避免重复刷屏。
+
+**Q3：工具调用太多看不过来？**
+≥3 个连续工具自动折叠为 summary 行；需要时点击展开还原。运行中的工具不参与折叠（避免折叠实时态）。
+
+**Q4：Studio 里的一条 assistant 回复为何有时是多个气泡？**
+若一条回复含「文本 → 工具调用 → 文本」多段，会按段拆为多个气泡 + 工具行（保内联顺序），不是 dedup bug。单段文本回复恒为 1 气泡（双气泡守卫）。
+
+**Q5：Routine Full View 与 Studio 中栏的徽章含义一致吗？**
+一致——共享同一 `features/agent-identity` 注册表（慧眼 / 本心 / 元神 / 妙手 / 喉舌 / Negentropy / Claude Code）。差异仅在「谁扮演人」。
+
+## 5. 无障碍与深色模式
+
+- **图标 + 色彩双编码**：所有角色徽章与状态点同时用 Lucide 图标 + 配色，不仅依赖颜色（色弱友好）。
+- **深色模式高对比**：徽章配色均为 `dark:` 安全变体，深浅主题下皆有清晰对比度。
+- **`prefers-reduced-motion`**：在途指示器、流式脉冲、过渡动画在该偏好下降级，尊重用户设置。
+- **键盘可达**：工具行、待决卡片、可折叠片段均为 `<button>` 语义，支持 Tab 聚焦与 Enter 触发。


### PR DESCRIPTION
## 背景 / Context

PR #1049 已把 Routine 迭代「Iterations Full View」与 Home/Studio 中栏的「人机交互」对话 UI 统一为同一套回合制转录渲染器（`TranscriptItemsView` + `TranscriptPolicy` + 两个适配器）并合入 `feature/1.x.x`。但**研究对照、架构方案、用户指引**尚未沉淀为文档，存在知识断层。本 PR 把这套 UI 沉淀为两篇可检索的文档，并补齐知识索引与交叉链接，遵循 AGENTS.md 文档规范。

> 仅含文档（6 文件 / +345 行），无代码改动；基于 `origin/feature/1.x.x` 创建，干净 cherry-pick。

## 变更清单

### 交付物 1 · 设计 ADR — `docs/concepts/041-human-machine-interaction-transcript.md`（`sidebar_position: 4.1`，紧随 040）
- **背景与动机**：两处「人机交互」UI 此前双轨割裂（Routine `TranscriptView` / Studio `ChatStream`）。
- **业界对照研究**：Conductor · ChatGPT · Claude.ai 回合制 UI 范式对照 + IEEE 引用，提炼共性（左右分栏 / 工具卡折叠 / 思考折叠 / 在途脉冲）。
- **语义重映射表**（核心）：Routine 人=一核五翼 6Agent / 机=Claude Code；Studio 人=真实用户 / 机=一核五翼+Claude Code。
- **架构方案**（机制 vs 策略正交分解）：SSOT `TranscriptItemsView` + `TranscriptPolicy` 契约（`align`/`turnGroup`/`roleHeaderFor`/`workingLabel`）+ 两个适配器（`normalizeTranscript`、`buildStudioTranscript`），附两张 Mermaid 深色 `classDef` 流程图。
- **TranscriptItem 视图模型**：12 个 kind 的判别联合表 + 可选字段。
- **Agent 身份映射**：`author → AgentRole → 徽章` 表（慧眼/妙手/本心/元神/喉舌 + Negentropy + Claude Code）+ `agentRoleFromAuthor` 匹配规则。
- **关键决策与权衡**：`turnGroup` 三分、`collapseToolRuns` 在 `tool_summary` 透传 `role`、`citations` 仅挂首段、Studio `itemWrapper` 挂 `data-testid` 兼容双气泡守卫、类型化工具明细、机制 vs 策略边界。
- **边缘 Case 与回归守卫**表、**关键文件索引**表、**演进路径**、**风险评估**表。

### 交付物 2 · 用户指引 — `docs/concepts/user-guide/transcript-view.md`（`sidebar_position: 4.5`）
- 两处界面入口 → 左右分栏视觉布局（Mermaid + 文字）→ Studio 中栏实操（徽章速查 / 工具卡按类型展开 / ≥3 折叠 / 思考引用 / 在途指示 / 节点选中搜索 / FAB）→ Routine Full View 实操（task_dispatch / cc_request / human_reply / engine / LIVE）→ FAQ → 无障碍与深色模式。截图留 TODO 文字占位。

### 交付物 3 · 索引与交叉链接
- `docs/.agents/knowledge-map.md`「系统能力概览」节注册 041（含实操手册 inline，沿用 039/040 范式）。
- `040-routine-multi-agent-faculty.md` 铅块加「渲染：见 041」。
- `a2ui.md` §4 加「中栏转录 UI 见 041 / 实操手册」。
- `chat-essentials.md` 导语加 transcript-view / 041 交叉链接。

## 验证

- ✅ 所有内部链接已 `realpath + test -e` 校验通过（041 ADR 6 条、用户指引 5 条均 OK）。
- ✅ 遵循 AGENTS.md 文档规范：Mermaid 深色调色板 + `classDef`、相对路径直链、IEEE 引用、中文叙事 + 英文术语、frontmatter Pattern A。
- ✅ pre-commit hook 全绿（ruff/mypy/version-SSOT 对纯 docs 改动均 skip）。
- ✅ diff vs base 干净：仅 6 个 docs 文件 / +345 行，无代码改动、无 merge artifact。

## 关联

- 关联 PR：#1049（「人机交互」转录 UI 实现，已合入 `feature/1.x.x`）。
- 关联 ADR：[040 Routine 多 Agent 归因](../concepts/040-routine-multi-agent-faculty.md)（归因侧）、[a2ui](../concepts/a2ui.md)（协议侧）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>