### PR TITLE
fix(perceives): 修复 bandit B112 安全扫描失败（caption 回退路径补可观测性）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py
@@ -444,7 +444,10 @@ def _detect_caption_anchored_figure_regions(
             page = doc[page_idx]
             try:
                 text_dict = page.get_text("dict")
-            except Exception:
+            except Exception as e:
+                # 单页 get_text 失败仅记日志后跳过，不阻断其他页 caption 回退；
+                # except body 含日志语句即不再匹配 B112（裸 continue 才触发）。
+                logger.debug("get_text(dict) 失败 p%d: %s", page_idx, e)
                 continue
             caption_bbox: Optional[Tuple[float, float, float, float]] = None
             caption_num: Optional[int] = None


### PR DESCRIPTION
## 背景

GitHub Actions 运行 [#28742464327](https://github.com/ThreeFish-AI/negentropy/actions/runs/28742464327)（PR #1054）的 **Perceives CI** 整体失败：7 个 job 中 6 个通过，唯一失败点是 **Security Audit → "Run bandit security scan"**。

根因：bandit 在 `apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/image_extraction.py:447` 发现 1 个 **B112 (try_except_continue)** 问题（Low severity / High confidence），导致 bandit 退出码 1，CI 闸口失败。

## 根因

`_detect_caption_anchored_figure_regions` 内的 caption 回退路径写法为：

```python
try:
    text_dict = page.get_text("dict")
except Exception:
    continue                       # ← bandit B112 命中（裸 continue 静默吞错）
```

bandit B112 检测 `except` 块**仅含 `continue`** 的模式（静默吞掉异常）。该回退路径中单页解析失败确需跳过，但应保留可观测性。

## 修复

```python
try:
    text_dict = page.get_text("dict")
except Exception as e:
    # 单页 get_text 失败仅记日志后跳过，不阻断其他页 caption 回退；
    # except body 含日志语句即不再匹配 B112（裸 continue 才触发）。
    logger.debug("get_text(dict) 失败 p%d: %s", page_idx, e)
    continue
```

**设计依据（复用驱动，均为项目内先例）**：
- `logger.debug("get_text(dict) 失败 p%d: %s", page_idx, e)` ← **同文件 line 637** 完全相同的 get_text 失败日志模式，直接复用
- 加 `logger.debug` 后 except body 不再是裸 continue → bandit 1.9.4 的 B112 检测器（仅匹配 `body=[Continue]`）不再触发，**无需 `# nosec`**，零新增 warning
- 补足「单页解析失败」的可观测性，解决 B112 「静默吞错」的核心担忧

## 验证

### 本地
- `uv run bandit -r src/negentropy/perceives/` → `No issues identified` + `Low: 0` + exit 0 ✅
- `uv run ruff check / format --check` → 通过 ✅
- `uv run mypy` → `Success: no issues found` ✅
- pre-commit hooks（ruff lint/format、mypy for negentropy-perceives）→ 全 Passed ✅

### 远程
- 期望本 PR 触发的 Perceives CI 中 **Security Audit** job 转绿，PR #1054 合入此修复后亦随之转绿。

## 影响面

仅 1 个文件 4 增 1 删，纯日志增强，不改控制流（仍 continue 跳过该页），无功能回归风险。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>