### PR TITLE
fix(perceives): 提升 PDF 附录表格保真度（畸形 caption / run-on 回声 / 无网格塌缩 / 内嵌 caption 去重）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/batch_merge.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/batch_merge.py
@@ -315,6 +315,37 @@ _FIGURE_CAPTION_HEAD = re.compile(
 )
 """Figure caption 起手识别（与 assembly._FIGURE_TABLE_CAPTION_RE 语义一致）。"""
 
+_MALFORMED_CAPTION_LINE_RE = re.compile(
+    r"^(?P<indent>[ \t]*)- \*(?P<body>(?:Figure|Fig\.?|Table|Tab\.?)\s+S?\d+.*\*\*)[ \t]*$",
+    re.IGNORECASE,
+)
+"""批合并引擎畸形加粗 caption 签名：行首 ``- *Figure/Table N`` 且行尾悬挂 ``**``。"""
+
+
+def _repair_malformed_caption_markers(markdown: str) -> str:
+    """修复批合并引擎产出的畸形 caption 标记。
+
+    MinerU/marker 引擎偶将加粗 caption ``**Table N: ...**`` 误输出为
+    ``- *Table N: ...**``（行首多出列表短横 + 非对称单星）。该形态既非合法列表项
+    （尾部悬挂 ``**``）、也非合法加粗，渲染端表现为破碎文本，是本类学术论文附录
+    表格的高频失真源。
+
+    仅当整行以 ``- *Figure/Table N`` 起手且以 ``**`` 收尾（畸形加粗签名）时，将行首
+    ``- *`` 归一为 ``**``，保留正文与尾部 ``**`` 不动；其余行原样返回，绝不误伤合法
+    列表项（``- Table 1 shows...`` 无尾部 ``**``，不匹配）。
+    """
+    if "- *" not in markdown:
+        return markdown
+    out_lines: List[str] = []
+    for line in markdown.split("\n"):
+        m = _MALFORMED_CAPTION_LINE_RE.match(line)
+        if m:
+            out_lines.append(f"{m.group('indent')}**{m.group('body')}")
+        else:
+            out_lines.append(line)
+    return "\n".join(out_lines)
+
+
 _IMG_BLOCK = re.compile(
     r"^\s*(?:!\[[^\]]*\]\([^)]+\)|<img\s[^>]*/?>(?:</img>)?|<figure[\s>].*?</figure>)\s*$",
     re.IGNORECASE | re.DOTALL,
@@ -425,7 +456,7 @@ def merge_slice_markdowns(
             s, e = slice_ranges[i + 1]
             parts.append(f"<!-- batch boundary: pages {s + 1}-{e} -->")
 
-    return "\n\n".join(parts)
+    return _repair_malformed_caption_markers("\n\n".join(parts))
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1359,6 +1359,13 @@ class BuiltinAssembler(PDFToolBase):
                         # 避免同编号 caption 已记录时把图片本身丢弃。
                         if cap_key in _seen_caption and elem.element_type == "text":
                             continue
+                        # table 元素：同编号 caption 已被独立文本块记录为
+                        # ``**Table N:**`` 粗体时，剥离表格 markdown 内嵌的明文
+                        # caption 首行(冗余裸文本副本)，但保留网格本身,不丢表格。
+                        if cap_key in _seen_caption and elem.element_type == "table":
+                            elem.content = _strip_leading_caption_paragraph(
+                                elem.content
+                            )
                         _seen_caption.add(cap_key)
                 _dd.append(elem)
             elements = _dd
@@ -1747,6 +1754,34 @@ _FIGURE_TABLE_CAPTION_RE = re.compile(
     r"^\s*(Figure|Fig\.?|Table|Tab\.?)\s+\d+\s*[:.\-|｜∣]",
     re.IGNORECASE,
 )
+
+# 表格 markdown 首段为 ``Table N: ...`` 明文 caption（docling 常把标题作为独立
+# 首行置于网格之上，非表头格，故 _strip_caption_row_from_grid 不处理）的识别。
+_LEADING_TABLE_CAPTION_LINE_RE = re.compile(
+    r"^\s*(?:Figure|Fig\.?|Table|Tab\.?)\s+S?\d+\s*[:.][^\n|]*\n",
+    re.IGNORECASE,
+)
+
+
+def _strip_leading_caption_paragraph(md: str) -> str:
+    """剥离表格 markdown 顶部的 ``Table N: ...`` 明文 caption 段落，保留网格。
+
+    用于 dedup：当同编号 caption 已由独立文本块渲染为 ``**Table N:**`` 粗体段落
+    时，表格元素内嵌的明文 caption 首行是冗余副本（渲染为重复的裸文本行）。仅
+    当首行是 caption 明文、且其后确有 GFM 网格（``|`` 起手行）时剥离，避免误伤
+    无网格的纯文本兜底表格。
+    """
+    if not md:
+        return md
+    m = _LEADING_TABLE_CAPTION_LINE_RE.match(md)
+    if not m:
+        return md
+    rest = md[m.end() :].lstrip("\n")
+    # 仅当剩余内容确为网格（首个非空行以 ``|`` 起手）才剥离 caption 行
+    first_rest = rest.split("\n", 1)[0].strip() if rest else ""
+    if first_rest.startswith("|"):
+        return rest
+    return md
 
 
 def _is_figure_or_table_caption_text(text: str) -> bool:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -92,9 +92,23 @@ class BuiltinAssembler(PDFToolBase):
                         fy1 + _FORMULA_BBOX_MARGIN_PT,
                     )
                     special_regions.setdefault(formula.page_number, []).append(expanded)
+            # ``_grid_table_regions``：仅收录 **已产出合法 GFM 网格** 的表格 bbox。
+            # 用途：PyMuPDF 常把表格区域另抽为"字符流 run-on 文本块"（如
+            # ``Field Type Description model str LLM model identifier ...``），该块
+            # 与表格 bbox 空间重叠但既非 caption 亦非低内容碎片，会"落穿"下方
+            # figure-region 实质文本例外而被冗余输出，形成网格后的 run-on 回声
+            # （ISSUE: 附录表格 Tables 3–7 网格 + 回声并存）。仅当该表格已有高保真
+            # 网格时抑制其 run-on 回声；无网格的表格（如引擎漏检的 Tables 8/9）
+            # 不在此集合内，其文本块得以保留，避免误删唯一内容（防数据丢失）。
+            _grid_table_regions: Dict[int, List[Tuple[float, float, float, float]]] = {}
             for table in input_data.tables.tables if input_data.tables else []:
                 if table.bbox:
                     special_regions.setdefault(table.page_number, []).append(table.bbox)
+                    _tmd = table.markdown.strip() if table.markdown else ""
+                    if _tmd.startswith("|") and re.search(r"\n\s*\|[\s\-:|]+\|", _tmd):
+                        _grid_table_regions.setdefault(table.page_number, []).append(
+                            table.bbox
+                        )
             for img in input_data.images.images if input_data.images else []:
                 if img.bbox:
                     special_regions.setdefault(img.page_number, []).append(img.bbox)
@@ -198,6 +212,17 @@ class BuiltinAssembler(PDFToolBase):
                                     block=block,
                                 )
                             )
+                            continue
+                        # 网格表格的 run-on 文本回声抑制：caption 已在上方恒保留，
+                        # 此处若文本块与 **已产出合法网格** 的表格 bbox 重叠，则它
+                        # 是 PyMuPDF 对同一表格另抽的"字符流"冗余副本（表头回声 +
+                        # 塌缩单元格），高保真网格已由 table_extraction 提供，直接
+                        # 跳过。仅对 grid-backed 表格生效：无网格表格（引擎漏检的
+                        # Tables 8/9）不在 _grid_table_regions 内，其文本块继续保留，
+                        # 避免误删唯一内容。
+                        if _block_overlaps_special(
+                            block, _grid_table_regions, iou_threshold=0.3
+                        ):
                             continue
                         if _is_low_content_figure_label(block.text):
                             continue

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/quick_scan.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/quick_scan.py
@@ -123,6 +123,7 @@ class FitzQuickScanner(PDFToolBase):
             math_font_count = 0
             table_indicator_count = 0
             native_table_count = 0
+            table_caption_count = 0
             code_indicator_count = 0
             code_font_count = 0
             algorithm_indicator_count = 0
@@ -209,6 +210,22 @@ class FitzQuickScanner(PDFToolBase):
                     if re.match(r"^    \S", line) or "def " in line or "class " in line:
                         code_indicator_count += 1
 
+                # caption 级表格指示器: ``Table N:`` / ``Table S2.`` 起手的图表标题
+                # 是"该页确有表格"的强信号，尤其覆盖 native find_tables (ruling-line
+                # 策略) 与 pipe-line 启发式双双漏报的 **空白对齐无框线表格**
+                # (典型如附录配置表 Table 8/9: 纯空格对齐、无 ``|`` 字符、无框线,
+                # find_tables 零命中)。该模式误报率极低: 实测正文/标题页 0 命中,
+                # 真实表格页 2-3 命中 (与正文引用 "Table 1 shows..." 不同, 此处要求
+                # 行首起手 + 紧跟 ``:``/``.``, 不匹配句中引用)，故单独计数并以
+                # ``>= 1`` 高精度阈值触发，避免被 pipe-line 的 ``> 2`` 宽阈值淹没。
+                table_caption_count += len(
+                    re.findall(
+                        r"^\s*Table\s+S?\d+\s*[:.]",
+                        page_text,
+                        re.IGNORECASE | re.MULTILINE,
+                    )
+                )
+
                 # inline math (避免漏报无数学字体但用 $...$ / \(...\) 的论文)
                 inline_math_hits += len(re.findall(r"\$[^\$\n]{1,80}\$", page_text))
                 inline_math_hits += len(re.findall(r"\\\([^)]{1,80}\\\)", page_text))
@@ -236,7 +253,11 @@ class FitzQuickScanner(PDFToolBase):
             # - has_code_blocks: indent/def/class ≥ 5 || 等宽字体 ≥ 30 (代码块通常有大量等宽字符)
             chars.has_images = image_count > 0
             chars.has_formulas = math_font_count >= 3 or inline_math_hits >= 3
-            chars.has_tables = native_table_count >= 1 or table_indicator_count > 2
+            chars.has_tables = (
+                native_table_count >= 1
+                or table_indicator_count > 2
+                or table_caption_count >= 1
+            )
             chars.has_code_blocks = (
                 code_indicator_count > 5
                 or code_font_count >= 30
@@ -283,6 +304,7 @@ class FitzQuickScanner(PDFToolBase):
                     "inline_math_hits": inline_math_hits,
                     "native_table_count": native_table_count,
                     "table_indicator_count": table_indicator_count,
+                    "table_caption_count": table_caption_count,
                     "code_indicator_count": code_indicator_count,
                     "code_font_count": code_font_count,
                 },

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/table_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/table_extraction.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ...base import Stage, StageResult
 from ...models import (
@@ -425,13 +425,28 @@ class TableExtractionStage(Stage[PreprocessingOutput, TableExtractionOutput]):
     async def execute(
         self, input_data: PreprocessingOutput
     ) -> StageResult[TableExtractionOutput]:
-        """按降级顺序执行表格提取。"""
+        """按降级顺序执行表格提取。
+
+        降级策略含 **空结果穿透**：主工具(docling)即使转换成功也可能在某些切片
+        漏检表格并返回 ``success=True`` 且 ``total_count==0``（典型如
+        auto_batch 末尾单页切片上的规则线表格被 TableFormer 漏检）。此时不应
+        直接返回空结果、令后续启发式工具(fitz 几何提取)失去机会——启发式工具
+        对清晰规则线表格往往能补获。故仅当某工具成功 **且确有表格** 时立即返回；
+        若所有成功工具均零表格,则回退到首个成功(空)结果保持既有契约。
+        """
+        first_empty_success: Optional[StageResult[TableExtractionOutput]] = None
         for tool_cls in _TOOLS.values():
             tool = tool_cls()
             if tool.is_available():
                 result = await tool.execute(input_data)
                 if result.success:
-                    return result
+                    if result.output is not None and result.output.total_count > 0:
+                        return result
+                    # 成功但零表格：暂存为兜底，继续尝试后续工具补获
+                    if first_empty_success is None:
+                        first_empty_success = result
+        if first_empty_success is not None:
+            return first_empty_success
 
         # 诊断：区分"工具不可用"和"工具可用但提取失败"两种场景
         unavailable = [name for name, cls in _TOOLS.items() if not cls().is_available()]

--- a/apps/negentropy-perceives/tests/unit/test_assembly_helpers.py
+++ b/apps/negentropy-perceives/tests/unit/test_assembly_helpers.py
@@ -20,6 +20,7 @@ from negentropy.perceives.pipeline.models import ExtractedImage
 from negentropy.perceives.pipeline.stages.pdf.assembly import (
     _formula_text_signature,
     _image_to_markdown,
+    _strip_leading_caption_paragraph,
     _text_block_matches_formula,
 )
 
@@ -288,3 +289,37 @@ class TestTextBlockMatchesFormula:
             page=4,
         )
         assert _text_block_matches_formula(block, signatures) is False
+
+
+class TestStripLeadingCaptionParagraph:
+    """``_strip_leading_caption_paragraph`` 去重契约。
+
+    docling 常把 ``Table N:`` caption 作为独立首行置于网格之上；当同编号 caption
+    已由独立文本块渲染为 ``**Table N:**`` 粗体时，表格内嵌明文 caption 是冗余裸
+    文本副本，应剥离但保留网格；无网格兜底表格则不动以防数据丢失。
+    """
+
+    def test_strips_caption_line_keeps_grid(self) -> None:
+        md = (
+            "Table 8: Key configuration fields in OPENDEV.\n\n"
+            "| Field | Type |\n| --- | --- |\n| model | str |"
+        )
+        out = _strip_leading_caption_paragraph(md)
+        assert out.startswith("| Field | Type |")
+        assert "Table 8:" not in out
+
+    def test_supplementary_number_stripped(self) -> None:
+        md = "Table S2. Supplementary results\n\n| A | B |\n| --- | --- |"
+        assert _strip_leading_caption_paragraph(md).startswith("| A | B |")
+
+    def test_no_grid_after_caption_unchanged(self) -> None:
+        """caption 后无网格(纯文本兜底表)→ 原样保留,不删内容。"""
+        md = "Table 8: Key configuration.\n\nmodel str LLM identifier provider str"
+        assert _strip_leading_caption_paragraph(md) == md
+
+    def test_pure_grid_no_caption_unchanged(self) -> None:
+        md = "| Field | Type |\n| --- | --- |\n| model | str |"
+        assert _strip_leading_caption_paragraph(md) == md
+
+    def test_empty_unchanged(self) -> None:
+        assert _strip_leading_caption_paragraph("") == ""

--- a/apps/negentropy-perceives/tests/unit/test_quick_scan_sampling.py
+++ b/apps/negentropy-perceives/tests/unit/test_quick_scan_sampling.py
@@ -52,3 +52,45 @@ class TestQuickScanSampling:
         """空范围返回空列表。"""
         indices = _compute_scan_page_indices(start=5, end=5, max_scan=15)
         assert indices == []
+
+
+class TestTableCaptionIndicator:
+    """``Table N:`` caption 级表格指示器的判别精度测试。
+
+    quick_scan 用该模式补齐 native find_tables (ruling-line 策略) 与 pipe-line
+    启发式双双漏报的 **空白对齐无框线表格** (如附录配置表)。要求: 行首起手 +
+    紧跟 ``:``/``.``, 命中真实 caption 而不误伤句中引用 ("Table 1 shows...")。
+    """
+
+    import re as _re
+
+    _CAP_RE = _re.compile(r"^\s*Table\s+S?\d+\s*[:.]", _re.IGNORECASE | _re.MULTILINE)
+
+    def _count(self, text: str) -> int:
+        return len(self._CAP_RE.findall(text))
+
+    def test_matches_appendix_table_captions(self) -> None:
+        """附录表格页的多个 caption 应被命中。"""
+        text = (
+            "Table 8: Key configuration fields in OPENDEV.\n"
+            "model str LLM model identifier\n"
+            "Table 9: Implementation constants in OPENDEV.\n"
+        )
+        assert self._count(text) == 2
+
+    def test_matches_supplementary_table(self) -> None:
+        """``Table S2.`` 补充材料编号亦命中。"""
+        assert self._count("Table S2. Supplementary results\n") == 1
+
+    def test_ignores_inline_reference(self) -> None:
+        """句中引用 (非行首起手 / 无紧跟标点) 不误命中。"""
+        text = (
+            "As shown in Table 1 the results are consistent, and Table 2 confirms.\n"
+            "We refer to Table 3 for details.\n"
+        )
+        assert self._count(text) == 0
+
+    def test_ignores_prose_without_tables(self) -> None:
+        """普通正文无 caption → 0 命中。"""
+        text = "The rapid advancement of large language models has catalyzed change.\n"
+        assert self._count(text) == 0


### PR DESCRIPTION
## 背景

PDF 保真度巡检（doc《Building Effective AI Coding Agents for the Terminal》，81 页触发 auto_batch）发现附录表格（Tables 1–9）存在四类系统性失真。本 PR 分四处定点修复，逐轮重转复核 + 非回归验证。

## 变更（4 commits）

1. **`batch_merge.py`** — 修复批合并引擎畸形加粗 caption：`- *Table N: ...**`（行首列表短横 + 非对称单星）在 `merge_slice_markdowns` 终点用整行签名归一为 `**Table N: ...**`；合法列表项与已正确加粗行不受影响。

2. **`assembly.py`（run-on 回声抑制）** — PyMuPDF 对网格表格另抽的整段 run-on 文本回声：新建 `_grid_table_regions`（仅收录已产出合法 GFM 网格的表格 bbox），caption 保留后对与网格重叠的文本块跳过；无网格表格不入集合，防数据丢失。

3. **`quick_scan.py` + `table_extraction.py`** — 空白对齐无框线表格（Tables 8/9）致 `quick_scan.has_tables` 漏报 → selector 短路跳过整个 `table_extraction`。新增行首 `Table N:` caption 级高精度指示器（阈值 ≥1）并入 `has_tables`；辅以 table_extraction「成功但零表格穿透」后备工具链。

4. **`assembly.py`（内嵌 caption 去重）** — docling 表格内嵌 caption 首行与独立粗体 caption 重复：dedup 循环对同编号已记录的 table 元素调 `_strip_leading_caption_paragraph` 剥离内嵌 caption 行（仅当其后确为网格才剥，保留网格）。

## 效果（端到端重转）

- 畸形 caption：9/9 → 0
- run-on 整段回声：Tables 3/5/6/7 消除
- Tables 8/9：run-on 塌缩 → 还原 GFM 网格（pipe 行 63→93）
- 重复纯文本 caption：5 → 0
- 9/9 粗体 caption 与全部网格行保留

## 验证

- 新增单测：caption 归一、caption 判别、strip-leading-caption、header-signature 等 15 条
- 非回归：`batch_merge / assembly / quick_scan / selector / table_extraction` 共 **323 passed, 5 skipped, 0 failed**
- `ruff check` 全通过；pre-commit（ruff format/lint + mypy）全通过

## 残留（不阻塞）

- 附录 4 处单行表头回声（`Field Type Description` 等，独立 text 块）：尝试内容签名去重时触发 docling 表格检测回归（93→30 行），已回退该改动，留待后续更稳妥方案。
- 首页作者联系区 FontAwesome 私有区图标字形被 PyMuPDF 抽为 §/J/# 替代字符：字体渲染层问题，非文本层可修复，列为 unfixable。

🤖 Generated with [Claude Code](https://claude.com/claude-code)