### PR TITLE
fix(scheduler-ui): 修复分页页码越界空页并新增 All 时间窗

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/FilterBar.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/FilterBar.tsx
@@ -17,7 +17,14 @@ interface FilterBarProps {
   connected: boolean;
 }
 
-const WINDOWS: StatsWindow[] = ["1h", "24h", "7d"];
+const WINDOWS: StatsWindow[] = ["1h", "24h", "7d", "all"];
+/** pill 展示文案（"all" → "All"，其余原样）。 */
+const WINDOW_LABELS: Record<StatsWindow, string> = {
+  "1h": "1h",
+  "24h": "24h",
+  "7d": "7d",
+  all: "All",
+};
 
 function uniqueValues(items: Array<string | null | undefined>): string[] {
   return Array.from(new Set(items.filter((v): v is string => Boolean(v))));
@@ -97,7 +104,7 @@ export function FilterBar({
                 : "text-muted-foreground hover:text-foreground"
             }`}
           >
-            {w}
+            {WINDOW_LABELS[w]}
           </button>
         ))}
       </div>

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerFilterBar.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerFilterBar.tsx
@@ -34,11 +34,13 @@ interface SchedulerFilterBarProps {
   onExecutionStatusChange?: (s: ExecutionStatusFilter) => void;
 }
 
-/** 时间窗下拉选项（原 1h/24h/7d pills，改下拉以缩短控件宽度）。 */
+/** 时间窗下拉选项（原 1h/24h/7d pills，改下拉以缩短控件宽度）。
+ *  "All" = 不限时间，翻页浏览全部数据（executions/KPI/stats 均不下推 since 下界）。 */
 const TIME_WINDOWS: { value: StatsWindow; label: string }[] = [
   { value: "1h", label: "Last 1h" },
   { value: "24h", label: "Last 24h" },
   { value: "7d", label: "Last 7d" },
+  { value: "all", label: "All" },
 ];
 
 /** 执行状态下拉选项（"" = All）。 */

--- a/apps/negentropy-ui/app/interface/scheduler/page.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/page.tsx
@@ -53,13 +53,16 @@ const EXEC_PAGE_SIZE = 10;
 /** SSE 抖动合并到尾沿的去抖窗（对齐 Routine useRoutineLive）。 */
 const REFRESH_DEBOUNCE_MS = 500;
 
-/** 时间窗 → 起始 ISO 时间戳（对齐后端 `_window_to_delta`，让 executions 列表真正受时间窗约束）。 */
-const WINDOW_MS: Record<StatsWindow, number> = {
+/** 时间窗 → 起始 ISO 时间戳（对齐后端 `_window_to_delta`，让 executions 列表真正受时间窗约束）。
+ *  "all" 不在此表内（无时间下界），由 windowToSince 提前返回 null。 */
+const WINDOW_MS: Record<Exclude<StatsWindow, "all">, number> = {
   "1h": 3_600_000,
   "24h": 86_400_000,
   "7d": 604_800_000,
 };
-function windowToSince(window: StatsWindow): string {
+/** "all" → null（不下推 since，展示全量）；其余 → 时间窗下界 ISO 时间戳。 */
+function windowToSince(window: StatsWindow): string | null {
+  if (window === "all") return null;
   return new Date(Date.now() - WINDOW_MS[window]).toISOString();
 }
 
@@ -104,6 +107,8 @@ export default function SchedulerPage() {
           total: r.total ?? null,
         };
       },
+      // 深跳页单轮补齐上限，对齐后端 list_tasks 的 limit le=200（超出会 422）。
+      maxLimit: 200,
     }),
     [filters],
   );
@@ -120,7 +125,8 @@ export default function SchedulerPage() {
     role: string | null;
     scenario: string | null;
     agent: string | null;
-    since: string;
+    /** null = "all" 时间窗，不下推 since（后端返回全量）。 */
+    since: string | null;
     status: ExecutionStatusFilter;
   }
   const execFilters = useMemo<ExecFilters>(
@@ -154,6 +160,8 @@ export default function SchedulerPage() {
           total: r.total ?? null,
         };
       },
+      // 深跳页单轮补齐上限，对齐后端 list_executions 的 limit le=500（超出会 422）。
+      maxLimit: 500,
     }),
     [],
   );

--- a/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/pipelines/page.tsx
@@ -336,6 +336,16 @@ export default function KnowledgePipelinesPage() {
 
   // KB 分页总量来自服务端，KG 运行在每页始终展示
   const total = kbTotal;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // 页码越界收敛：total 缩小（cancel/retry 后 loadRuns 落在越界页）时把 page 夹回末页，
+  // 避免停留在空页。带 hasInitialLoad 守卫，防止初始 total===0 误把 page 夹到 1。
+  // setPage 触发既有 useEffect([page]) 以正确 offset 重取。
+  useEffect(() => {
+    if (!hasInitialLoad) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 由外部数据源（服务端 total 缩小）同步页码，属既有数据加载范式（同 useInfiniteList safePage / page.tsx ?task_key）
+    if (page > totalPages) setPage(totalPages);
+  }, [hasInitialLoad, page, totalPages]);
 
   const selectedKbRun =
     selected?.source === "kb" ? selected : undefined;
@@ -458,7 +468,7 @@ export default function KnowledgePipelinesPage() {
                   <div className="mt-4 border-t border-border pt-3">
                     <Pagination
                       page={page}
-                      totalPages={Math.max(1, Math.ceil(total / PAGE_SIZE))}
+                      totalPages={totalPages}
                       onPageChange={setPage}
                       total={total}
                       itemLabel="run"

--- a/apps/negentropy-ui/features/scheduler/types.ts
+++ b/apps/negentropy-ui/features/scheduler/types.ts
@@ -13,7 +13,8 @@ export type StatsGroupBy =
   | "owner"
   | "handler_kind"
   | "category";
-export type StatsWindow = "1h" | "24h" | "7d";
+/** 时间窗；"all" = 不限时间（后端不下推 since 下界，KPI/Stats/Executions 全量）。 */
+export type StatsWindow = "1h" | "24h" | "7d" | "all";
 
 export interface ScheduledTaskDTO {
   id: string;

--- a/apps/negentropy-ui/hooks/useInfiniteList.ts
+++ b/apps/negentropy-ui/hooks/useInfiniteList.ts
@@ -47,6 +47,14 @@ export interface CursorFetcher<T, F = unknown> {
     filters?: F;
     signal?: AbortSignal;
   }) => Promise<CursorPage<T>>;
+  /**
+   * 跳页顺序补齐时单轮请求的 limit 上限（对齐 [[OffsetFetcher.maxLimit]]）。默认 200。
+   * goToPage(n) 深跳会请求 `min(targetCount - acc.length, maxLimit)` 条/轮，
+   * 使「220 条跳页」由 22 轮（受 maxSequentialFetch=20 截断 → 只 200 条 → 空页）
+   * 收敛为 ⌈220/200⌉=2 轮，20 轮封顶下可达 `20×maxLimit` 条。
+   * 须 ≤ 对应后端端点的 limit 上限（executions le=500 / tasks le=200），否则 422。
+   */
+  maxLimit?: number;
 }
 
 /** 偏移型一段响应（count / total 归一为 total，必填）。 */
@@ -209,9 +217,14 @@ export function useInfiniteList<T, F = unknown>(
             total = r.total;
             hasMore = acc.length < r.total && r.items.length > 0;
           } else if (f.kind === "cursor") {
+            // 分批补齐（mirror offset 分支）：单轮请求 min(缺口, maxLimit) 条，
+            // 使深跳页由 O(缺口/pageSize) 轮收敛为 O(缺口/maxLimit) 轮，规避
+            // maxSequentialFetch 截断导致的「缓冲不足→空页」。loadMore 缺口恒 = pageSize，
+            // min(pageSize, maxLimit)=pageSize，仍恰好追加一页，语义不变。
+            const limit = Math.min(targetCount - acc.length, f.maxLimit ?? 200);
             const r = await f.fetchPage({
               cursor,
-              limit: pageSize,
+              limit,
               filters: filtersRef.current as F,
               signal: ac.signal,
             });
@@ -242,7 +255,9 @@ export function useInfiniteList<T, F = unknown>(
         }
       }
     },
-    [pageSize, maxSequentialFetch],
+    // pageSize 不再进入依赖：cursor 分批改用 f.maxLimit、offset 用 need+maxLimit，
+    // 函数体已不直接引用 pageSize（仅 loadMore/goToPage 的调用点用 pageSize 算 targetCount）。
+    [maxSequentialFetch],
   );
 
   // ── reset：清缓冲、回第 1 页、并触发首页加载 ─────────────────────────────
@@ -330,9 +345,17 @@ export function useInfiniteList<T, F = unknown>(
         ? Math.max(1, Math.ceil(total / pageSize))
         : Math.max(1, loadedPages + (buf.hasMore ? 1 : 0));
     const hasMore = total != null ? buf.items.length < total : buf.hasMore;
+    // safePage 钳制：常态对齐 totalPages；但当游标已耗尽（!buf.hasMore）而缓冲仍不足以填充
+    // currentPage（后端 COUNT 大于游标实际产出——如 COUNT 与取数间发生删除、或极端超 20×maxLimit），
+    // 收敛到实际已加载页数，杜绝落在空页。纯派生、无异步竞态（不 setState），
+    // 加载在途（hasMore 仍 true）时不夹，避免误伤「即将补齐」的深跳。
+    const safePage =
+      !buf.hasMore && buf.items.length < currentPage * pageSize
+        ? Math.min(currentPage, Math.max(1, loadedPages))
+        : Math.min(currentPage, totalPages);
     return {
       items: buf.items,
-      currentPage: Math.min(currentPage, totalPages),
+      currentPage: safePage,
       total,
       totalPages,
       loadedPages,

--- a/apps/negentropy-ui/tests/unit/hooks/useInfiniteList.test.tsx
+++ b/apps/negentropy-ui/tests/unit/hooks/useInfiniteList.test.tsx
@@ -96,6 +96,77 @@ describe("useInfiniteList — cursor 模式", () => {
     expect(result.current.hasMore).toBe(false);
   });
 
+  it("深跳页分批补齐：maxLimit 生效、单轮 limit=min(缺口,maxLimit)、目标页非空（回归越界空页 Bug）", async () => {
+    // 模拟后端游标端点：cursor=起始 index（"c<n>" 或 null），每轮返回 min(缺口, limit) 条，
+    // total=213（对齐 Bug 场景：22 页、每页 10）。maxLimit=100 → 跳第 22 页(220 条)应 ⌈220/100⌉=3 轮。
+    const TOTAL = 213;
+    const calls: { cursor: string | number | null; limit: number }[] = [];
+    const spy = vi.fn(
+      async ({ cursor, limit }: { cursor: string | number | null; limit: number }) => {
+        calls.push({ cursor, limit });
+        const start = cursor == null ? 0 : Number(cursor);
+        const items = makeRows(start, limit, TOTAL);
+        const nextStart = start + items.length;
+        return {
+          items,
+          nextCursor: nextStart < TOTAL ? String(nextStart) : null,
+          hasMore: nextStart < TOTAL,
+          total: TOTAL,
+        };
+      },
+    );
+    const fetcher: CursorFetcher<Row> = { kind: "cursor", fetchPage: spy, maxLimit: 100 };
+    const { result } = renderHook(() => useInfiniteList<Row>({ fetcher, pageSize: 10 }));
+
+    await waitFor(() => expect(result.current.items.length).toBe(10));
+    expect(result.current.totalPages).toBe(22);
+    // 首屏单轮 limit 恒 = pageSize（缺口=10 < maxLimit）。
+    expect(calls[0]).toEqual({ cursor: null, limit: 10 });
+
+    act(() => result.current.goToPage(22));
+    // 分批补齐至全量 213 条（旧实现受 20×10=200 封顶 → 第 22 页 slice(210,220) 空）。
+    await waitFor(() => expect(result.current.items.length).toBe(TOTAL));
+
+    // 第 22 页切片非空（Bug 修复核心断言）：213 条下末页 = slice(210,220) = 索引 210/211/212 共 3 条。
+    const start = (result.current.currentPage - 1) * 10;
+    expect(result.current.items.slice(start, start + 10).length).toBe(TOTAL - start);
+    expect(result.current.items.slice(start, start + 10).length).toBeGreaterThan(0);
+    expect(result.current.currentPage).toBe(22);
+
+    // 补齐轮次远少于 22（分批）：首屏 1 轮(10) + 跳页 ⌈203/100⌉=3 轮 → 总计 ≤ 5 轮。
+    expect(spy.mock.calls.length).toBeLessThanOrEqual(5);
+    // 跳页阶段任一轮 limit 不超过 maxLimit。
+    for (const c of calls) expect(c.limit).toBeLessThanOrEqual(100);
+  });
+
+  it("loadMore 分批下仍每轮恰好追加一页（缺口=pageSize < maxLimit）", async () => {
+    const { fetcher, spy } = cursorFetcher();
+    const { result } = renderHook(() => useInfiniteList<Row>({ fetcher, pageSize: 10 }));
+    await waitFor(() => expect(result.current.items.length).toBe(10));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.items.length).toBe(20));
+    // loadMore 目标 = 当前长度 + pageSize，缺口恒 = 10，故 limit=min(10, 200)=10。
+    expect(spy).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: "c1", limit: 10 }));
+  });
+
+  it("游标耗尽而缓冲不足以填充当前页时，currentPage 同步收敛到实际已加载页（safePage 兜底）", async () => {
+    // total 声称 50（5 页）但游标实际只产出 12 条后即 hasMore=false（COUNT 与取数间发生删除的极端）。
+    const spy = vi
+      .fn()
+      .mockResolvedValueOnce({ items: makeRows(0, 10), nextCursor: "c1", hasMore: true, total: 50 })
+      .mockResolvedValueOnce({ items: makeRows(10, 2), nextCursor: null, hasMore: false, total: 50 });
+    const fetcher: CursorFetcher<Row> = { kind: "cursor", fetchPage: spy };
+    const { result } = renderHook(() => useInfiniteList<Row>({ fetcher, pageSize: 10 }));
+    await waitFor(() => expect(result.current.items.length).toBe(10));
+    expect(result.current.totalPages).toBe(5); // 由 total=50 派生
+
+    act(() => result.current.goToPage(5));
+    await waitFor(() => expect(result.current.items.length).toBe(12));
+    // 游标已耗尽（hasMore=false），仅 12 条 = 2 页；currentPage 收敛到 2，不停留在空的第 5 页。
+    expect(result.current.currentPage).toBe(2);
+  });
+
   it("total 缺失时 totalPages 退化为已加载页数 + hasMore 兜底", async () => {
     const spy = vi.fn().mockResolvedValue({ items: makeRows(0, 10), nextCursor: "c1", hasMore: true, total: null });
     const { result } = renderHook(() =>

--- a/apps/negentropy/src/negentropy/interface/scheduler_api.py
+++ b/apps/negentropy/src/negentropy/interface/scheduler_api.py
@@ -167,11 +167,12 @@ def _serialize_execution(e: TaskExecution, task: ScheduledTask | None = None) ->
 
 
 @router.get("/kpis")
-async def get_kpis(window: Literal["1h", "24h", "7d"] = Query("24h")) -> dict[str, Any]:
-    """返回 Dashboard 顶部 6 卡片所需 KPI 指标。"""
+async def get_kpis(window: Literal["1h", "24h", "7d", "all"] = Query("24h")) -> dict[str, Any]:
+    """返回 Dashboard 顶部 6 卡片所需 KPI 指标。window="all" 不限时间（全量统计）。"""
 
     async def _compute():
-        since = _utcnow() - _window_to_delta(window)
+        # "all" → 不下推时间下界（全量）；其余按时间窗计算 since。
+        since = None if window == "all" else _utcnow() - _window_to_delta(window)
         async with AsyncSessionLocal() as db:
             total_tasks = (await db.execute(select(func.count(ScheduledTask.id)))).scalar() or 0
             enabled_tasks = (
@@ -181,13 +182,15 @@ async def get_kpis(window: Literal["1h", "24h", "7d"] = Query("24h")) -> dict[st
                 await db.execute(select(func.count(TaskExecution.id)).where(TaskExecution.status == "running"))
             ).scalar() or 0
 
-            # 窗口内 runs / success / failed / avg_latency
+            # 窗口内 runs / success / failed / avg_latency（"all" 时无时间下界）
             window_stmt = select(
                 func.count(TaskExecution.id),
                 func.sum(case((TaskExecution.status == "ok", 1), else_=0)),
                 func.sum(case((TaskExecution.status == "failed", 1), else_=0)),
                 func.avg(TaskExecution.duration_ms),
-            ).where(TaskExecution.started_at >= since)
+            )
+            if since is not None:
+                window_stmt = window_stmt.where(TaskExecution.started_at >= since)
             row = (await db.execute(window_stmt)).one()
             runs = int(row[0] or 0)
             success = int(row[1] or 0)
@@ -410,14 +413,15 @@ async def list_executions(
 @router.get("/stats")
 async def get_stats(
     group_by: Literal["role", "scenario", "agent", "owner", "handler_kind", "category"] = Query(...),
-    window: Literal["1h", "24h", "7d"] = Query("24h"),
+    window: Literal["1h", "24h", "7d", "all"] = Query("24h"),
 ) -> dict[str, Any]:
-    """按指定维度聚合执行历史，驱动 Dashboard 多维统计图。"""
+    """按指定维度聚合执行历史，驱动 Dashboard 多维统计图。window="all" 不限时间（全量聚合）。"""
 
     cache_key = f"stats:{group_by}:{window}"
 
     async def _compute():
-        since = _utcnow() - _window_to_delta(window)
+        # "all" → 不下推时间下界（全量）；其余按时间窗计算 since。
+        since = None if window == "all" else _utcnow() - _window_to_delta(window)
         column_map = {
             "role": ScheduledTask.role,
             "scenario": ScheduledTask.scenario,
@@ -438,10 +442,11 @@ async def get_stats(
                     func.avg(TaskExecution.duration_ms).label("avg_ms"),
                 )
                 .join(ScheduledTask, ScheduledTask.id == TaskExecution.task_id)
-                .where(TaskExecution.started_at >= since)
                 .group_by(group_col)
                 .order_by(func.count(TaskExecution.id).desc())
             )
+            if since is not None:
+                stmt = stmt.where(TaskExecution.started_at >= since)
             rows = (await db.execute(stmt)).all()
 
             # --- Label resolution: owner / agent 维度需将 ID 映射为可读名称 ---

--- a/apps/negentropy/tests/unit_tests/interface/test_scheduler_api.py
+++ b/apps/negentropy/tests/unit_tests/interface/test_scheduler_api.py
@@ -27,6 +27,26 @@ def test_window_to_delta_unknown_falls_back_to_24h():
     assert _window_to_delta("xyz") == timedelta(hours=24)
 
 
+def test_kpis_and_stats_accept_all_window():
+    """/kpis 与 /stats 的 window 参数应接受 "all"（不限时间全量统计）。
+
+    校验 FastAPI 端点签名的 Literal 已含 "all"——避免前端下发 window=all 被 422 拒绝。
+    注：本模块 `from __future__ import annotations` 使注解为字符串，需 get_type_hints 求值。
+    """
+    from typing import get_args, get_type_hints
+
+    import negentropy.interface.scheduler_api as api
+
+    kpis_hints = get_type_hints(api.get_kpis)["window"]
+    assert set(get_args(kpis_hints)) == {"1h", "24h", "7d", "all"}
+
+    stats_hints = get_type_hints(api.get_stats)["window"]
+    assert set(get_args(stats_hints)) == {"1h", "24h", "7d", "all"}
+
+    # 默认值不变，仍为 24h（回归保护）。
+    assert api.get_kpis.__defaults__[0].default == "24h"
+
+
 def test_router_exposes_all_endpoints():
     from negentropy.interface.scheduler_api import router
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Interface / Scheduler 页 Executions 表翻到最后几页时显示 "No executions match the current filter." 空页——根因是全站分页 hook `useInfiniteList` 在 cursor 模式下每轮仅取 `pageSize` 条、受 `maxSequentialFetch=20` 轮封顶，单次跳页最多补齐 200 条，而 `totalPages` 由后端精确 `total` 派生，深翻页缓冲不足即空页；同时用户希望在 1h/24h/7d 之外新增「All」以翻页浏览全部数据。
- 关联上下文/Issue/文档：用户截图复现（Last 1h 213 条、22 页、第 22 页空）；该隐患对所有 cursor 分页（Scheduler Tasks/Executions）共通。

# 核心变更
- **治本 `useInfiniteList`**：`CursorFetcher` 新增 `maxLimit`（镜像既有 `OffsetFetcher.maxLimit`），cursor 分支改为单轮 `min(缺口, maxLimit)` 分批补齐，深跳由 O(缺口/pageSize) 收敛为 O(缺口/maxLimit) 轮；返回值新增 `safePage` 同步兜底（游标耗尽仍不足填充当前页时收敛到实际已加载页，纯派生无竞态）。
- **Scheduler 两 fetcher** 显式设 `maxLimit`（tasks=200 / executions=500）对齐后端 `limit` 上限，避免 422。
- **新增 All 时间窗**：`StatsWindow` 加 `"all"`；`windowToSince` 返回 `null` 时不下推 `since`；Scheduler 与首页 Dashboard 两处筛选栏均加 All；后端 `get_kpis`/`get_stats` 的 window `Literal` 加 `"all"` 并条件应用 `since`（`_window_to_delta` 保持不变以护住既有测试）。
- **Knowledge Pipelines 页**（ad-hoc `useState` 分页）补页码越界 clamp（带 `hasInitialLoad` 守卫），防 `total` 缩小后卡空页。
- **扩展单测**：`useInfiniteList` 加深跳/`maxLimit`/loadMore/safePage 用例，`scheduler_api` 加 `window=all` 分支校验。

# 风险与回滚
- 主要风险：`StatsWindow` 拓宽影响首页 Dashboard 与 Scheduler 共享类型（已 typecheck 全绿）；后端 `window=all` 改动需部署到 live 引擎后生效，未部署前工作区代理到旧后端会短暂出现 `/kpis?window=all → 422` 横幅（executions 分页与 All 不依赖后端改动，不受影响）。
- 回滚方式：本 PR 改动内聚于单个 commit，`git revert` 即可整体回滚，无数据迁移、无破坏性操作。

# 验证证据
- 单元测试：前端 `useInfiniteList` 10/10、后端 `test_scheduler_api` 19/19 全通过。
- 集成测试：后端 `get_kpis`/`get_stats` 以 `window=all` 直连真实 DB 只读验证（runs=164146 全量、无异常）。
- E2E/Workflow：借已认证 Chrome 实机回归——Last 1h 214 条第 22 页显示 4 条、Last 24h 4735 条第 474 页显示 5 条均不再空页；All 窗 executions 164145 条全量可翻；切换窗口正确 reset 回第 1 页。
- 覆盖率/关键截图：typecheck 干净、ESLint `--max-warnings=0` 通过、pre-commit hooks（ruff/eslint）全通过。

# 影响范围
- 前端：`useInfiniteList` hook（全站分页 SSOT）、Scheduler page/FilterBar、首页 Dashboard FilterBar、Knowledge Pipelines page、scheduler types。
- 后端：`interface/scheduler_api.py` 的 `/kpis`、`/stats` 端点（window 加 all + 条件 since）。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并后在下次部署 live 引擎（主仓）时一并发布后端 `window=all` 改动，使 Stats/KPI 的 All 窗生效、消除临时 422 横幅。
