### PR TITLE
fix(perceives): PDF 保真巡检 — 跨页 figure 碎片孤儿抑制 + 散文误包 inline 数学解包

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -588,6 +588,12 @@ class MarkdownFormatter:
             # 已有 inline ``$..$`` 由 pass 内 split-and-skip 保护。
             markdown_content = self._normalize_unicode_math(markdown_content)
 
+            # 撤销「散文误包成 inline $...$」失真：_normalize_unicode_math 会把含数学
+            # 字形且与散文粘连的 token（作者上标 'Name¹·²·³'、关键词列表）整段包成
+            # $...$，连同 prose 一起吞入数学体渲染。此处仅对内容含 ≥2 个多字母 ASCII
+            # 散文词的 inline 块解包（真实数学极少含多个散文词），还原为 prose+<sup>。
+            markdown_content = self._unwrap_prose_math(markdown_content)
+
             # 还原块级数学公式占位符（须在 _cleanup_math_blocks 之后，
             # 这样数学块整体仍由本管线统一治理，但 LaTeX 主体内容不被修改）
             markdown_content = self._restore_math_blocks(
@@ -878,6 +884,45 @@ class MarkdownFormatter:
             self._normalize_unicode_math_line(line)
             for line in markdown_content.split("\n")
         )
+
+    # 散文误包判定：inline ``$...$`` 内容含 ≥此数量个「长度≥3 的 ASCII 字母词」
+    # 即判为散文被误吞入数学体。取 3：作者-单位行（多个人名）/ 关键词列表天然含
+    # ≥3 个散文词，而真实数学公式几乎不可能含 3 个以上多字母 ASCII 散文词
+    # （通常为单字母变量 / ``\name`` 命令 / 至多 1-2 个 ``\text{word}``），
+    # 保守阈值最大程度规避对数学密集文档的回归风险。
+    _PROSE_MATH_MIN_WORDS = 3
+    _PROSE_MATH_WORD_RE = re.compile(r"[A-Za-z]{3,}")
+
+    def _unwrap_prose_math(self, markdown_content: str) -> str:
+        """撤销把散文（作者-单位行 / 关键词等）误包成 inline ``$...$`` 数学的失真。
+
+        背景：``_normalize_unicode_math`` 按空白切 token，当某 token 同时含数学字形
+        与散文（如 PDF 抽取的作者上标 ``Name¹·²·³``，上标为数学字母块字形、与名字
+        粘连成单 token）时，整 token 判为 MATH，run 跨多个此类 token 合并，把
+        ``Fadi Dornaika`` 等 prose 连同 ``\\cdot`` / ``^{1,2,3}`` 一起包进单个
+        ``$...$``，渲染为 LaTeX 数学体而非 prose+上标。
+
+        本 pass 在归一化之后扫描 inline ``$...$``：内容含 ≥ ``_PROSE_MATH_MIN_WORDS``
+        个长度≥3 的 ASCII 词即判为误包，撤销 ``$`` 并把 ``^{...}`` → ``<sup>...</sup>``、
+        ``\\cdot`` → ``·``。
+
+        安全性：仅解包满足散文判定的 inline 块；块公式 / 代码块此时为占位符（无 ``$``），
+        正常 inline 数学（无 ≥2 散文词）原样保留。
+        """
+        if "$" not in markdown_content:
+            return markdown_content
+
+        def _maybe_unwrap(m: "re.Match[str]") -> str:
+            body = m.group(1)
+            if len(self._PROSE_MATH_WORD_RE.findall(body)) < self._PROSE_MATH_MIN_WORDS:
+                return m.group(0)
+            # ^{...} → <sup>...</sup>；裸 ^x → <sup>x</sup>；\cdot → ·
+            unwrapped = re.sub(r"\^\{([^{}]*)\}", r"<sup>\1</sup>", body)
+            unwrapped = re.sub(r"\^(\w)", r"<sup>\1</sup>", unwrapped)
+            unwrapped = unwrapped.replace(r"\cdot", "·")
+            return unwrapped
+
+        return re.sub(r"\$([^$\n]+)\$", _maybe_unwrap, markdown_content)
 
     def _normalize_unicode_math_line(self, line: str) -> str:
         stripped = line.lstrip()

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/image_ref_normalizer.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/image_ref_normalizer.py
@@ -117,13 +117,16 @@ def _append_orphan_images(
         if basename:
             referenced_basenames.add(basename)
 
+    redundant_basenames = _redundant_orphan_basenames(
+        markdown, images, referenced_basenames
+    ) | _adjacent_fragment_orphans(images, referenced_basenames)
+
     orphans = [
         img
         for img in images
         if img.filename
         and img.filename not in referenced_basenames
-        and img.filename
-        not in _redundant_orphan_basenames(markdown, images, referenced_basenames)
+        and img.filename not in redundant_basenames
     ]
     if not orphans:
         return markdown
@@ -209,6 +212,60 @@ def _redundant_orphan_basenames(
             continue
         if basename_to_page.get(fn) in dominant_pages:
             redundant.add(fn)
+    return redundant
+
+
+# 跨页 figure 过度分割碎片抑制：当某张图（完整 figure）已被正文 <img> 引用，
+# 其同页或相邻页(±1)的未引用 orphan 若像素面积 ≤ 该已放置图的 1/_FRAGMENT_RATIO，
+# 判为 docling 对同一 figure 的冗余局部裁切，抑制不追加到文末。
+# 取 0.5（即已放置图面积 ≥ orphan 2×）以仅捕获真正的子区域碎片，避免误伤
+# 同/邻页独立的小 figure（独立 figure 通常自带 caption 被正文引用，不会是 orphan）。
+_FRAGMENT_RATIO = 0.5
+
+
+def _adjacent_fragment_orphans(
+    images: Sequence[ImageMeta],
+    referenced_basenames: set[str],
+) -> set[str]:
+    """识别跨页/同页 figure 过度分割产出的 orphan 碎片。
+
+    场景：docling 将一张（常为跨页或结构复杂的）figure 同时输出为一张完整图
+    （被正文 ``<img>`` 引用）与若干局部裁切（无法匹配文本引用 → orphan）。
+    这些 orphan 追加到文末会与已内联的完整图视觉重复。
+
+    判定：orphan 与某张已引用图在同页或相邻页（|Δpage| ≤ 1），且已引用图像素
+    面积 ≥ orphan × ``1/_FRAGMENT_RATIO`` → orphan 判为冗余碎片，抑制。
+
+    安全性：需 width/height（像素）/page_number 均可用，否则 no-op（保留既有
+    loss-averse orphan 行为）；仅在确有同/邻页大图已放置且面积达碎片 N 倍时抑制，
+    不误伤多图正文页的合法孤立小图。
+    """
+    meta: dict[str, tuple[int, int, int]] = {}
+    for img in images:
+        fn = getattr(img, "filename", None)
+        if not fn:
+            continue
+        w = getattr(img, "width", None)
+        h = getattr(img, "height", None)
+        pg = getattr(img, "page_number", None)
+        if w and h and pg is not None:
+            meta[fn] = (int(w), int(h), int(pg))
+    if not meta:
+        return set()
+
+    placed = [(fn, m) for fn, m in meta.items() if fn in referenced_basenames]
+    if not placed:
+        return set()
+
+    redundant: set[str] = set()
+    for fn, (ow, oh, opg) in meta.items():
+        if fn in referenced_basenames or fn in redundant:
+            continue
+        orphan_area = ow * oh
+        for _pfn, (pw, ph, ppg) in placed:
+            if abs(ppg - opg) <= 1 and pw * ph >= orphan_area / _FRAGMENT_RATIO:
+                redundant.add(fn)
+                break
     return redundant
 
 


### PR DESCRIPTION
## 背景
PDF→Markdown 高保真巡检（doc_id=616e60d5，《Agentic AI: a comprehensive survey》）发现两处可修复缺陷，本 PR 做两处定点修复。

## 改动

### 1. 跨页 figure 过度分割 orphan 碎片抑制（`markdown/image_ref_normalizer.py`）
**缺陷**：docling 将跨页/复杂 figure 同时输出为一张完整图（已被正文 `<img>` 内联引用）与若干局部裁切（无法匹配文本引用 → orphan），`image_ref_normalizer` 此前把这些碎片追加到文末，与已内联图视觉重复。

**修复**：新增 `_adjacent_fragment_orphans`——当 orphan 与某已引用图同页或相邻页（|Δpage|≤1）且已引用图像素面积 ≥ orphan 的 2 倍时，判为冗余局部裁切并抑制。与既有 `_redundant_orphan_basenames`（同页 page-dominant ≥500k 抑制）并列、互补。

### 2. 散文误包 inline `$...$` 数学解包（`markdown/formatter.py`）
**缺陷**：`_normalize_unicode_math` 按空白切 token，当 token 同时含数学字形与散文（如作者上标 `Name¹·²·³`）时整 token 判为 MATH，run 跨多 token 合并，把人名连同 `\cdot` / `^{1,2,3}` 一起包进单个 `$...$`，渲染为 LaTeX 数学体而非 prose+上标。

**修复**：新增 `_unwrap_prose_math`——inline `$...$` 内容含 **≥3 个长度≥3 的 ASCII 散文词**时判为误包，撤销 `$` 并把 `^{...}`→`<sup>...</sup>`、`\cdot`→`·`。阈值取 3（作者-单位行多人名、关键词列表天然 ≥3 词；真实数学几乎不可能含 3 个以上多字母 ASCII 散文词）以最大程度规避对数学密集文档的回归。

## 验证
- 目标文档重转复核：缺陷均消除，9 figure 内联完整、99 表格行、46 标题、0 残留 prose-math、0 孤儿块；评分 94 → 99。
- `ruff check`：通过。
- `pytest tests/unit/test_image_ref_normalizer.py tests/unit/test_formatter_unicode_math.py`：54 passed。
- `pytest tests/unit/`：1947 passed, 3 failed（`test_config.py` 配置断言 `concurrent_requests==16` 实测 32，环境/CPU 相关，与本 PR 改动模块无依赖，属基线既有失败）。

## 非回归说明
跨文档 `regression_sample` 门控因隔离 worktree 作用域限制无法在本环境运行；建议合回前在可访问样本的环境补跑（重点验证数学密集型 PDF 的 inline 公式未被 `_unwrap_prose_math` 误解包）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)