### PR TITLE
chore(scheduler): PDF Fidelity Patrol 巡检节奏 3600s→600s

### DIFF
--- a/apps/negentropy/src/negentropy/db/migrations/versions/0091_pdf_fidelity_patrol_interval_600s.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0091_pdf_fidelity_patrol_interval_600s.py
@@ -1,0 +1,86 @@
+"""Retune: pdf_fidelity_patrol 巡检节奏 3600s(1h) → 600s(10min)。
+
+Revision ID: 0091
+Revises: 0090
+Create Date: 2026-07-07 00:00:00.000000+00:00
+
+设计动机：
+    「PDF→Markdown 高保真自拟合巡检」系统任务（``key=pdf_fidelity_patrol``）原节奏为每
+    ``interval_seconds=3600``（1h）触发一轮。为更高频推进高保真自拟合巡检闭环，将其收敛到
+    每 ``600s``（10min）一次。
+
+    该任务是**系统任务**（``is_system=TRUE``），Scheduler REST 端点 ``PUT /scheduler/tasks/{id}``
+    对系统任务显式拒绝改写；且节奏权威是 ``scheduled_tasks.interval_seconds`` 列（仅由 0076 种子
+    以 ``ON CONFLICT DO NOTHING`` 写入 3600，对已存在行无效）。故以本前向迁移 ``UPDATE`` 该行——
+    「单一事实源＝全部迁移的累积结果」，新旧 DB 均收敛到 600s。
+
+    额外：
+    - ``next_fire_at = NOW()`` —— 令新节奏于下一 tick 即时生效（缩短 interval 时 ``NOW()`` 恒 ≤ 旧
+      计划时刻，只把下一轮提前，符合「每 600s 检查」意图；叠加 handler「在跑即 SKIP」互斥与灰度门控
+      ``routine.enabled`` + ``routine.patrol_enabled``，无并发/雪崩风险）。
+    - 同步刷新 ``description`` 列的「每 1h」→「每 600s（10min）」，使 Scheduler UI 展示与真实节奏一致。
+
+幂等性：
+    精确 ``WHERE key = :key`` 的 ``UPDATE``；重跑安全。
+
+References:
+[1] 0076_seed_pdf_fidelity_patrol_task.py — 本任务的种子与节奏语义来源。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0091"
+down_revision: str | None = "0090"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+TABLE = f"{SCHEMA}.scheduled_tasks"
+
+TASK_KEY = "pdf_fidelity_patrol"
+
+_INTERVAL_NEW = 600.0  # 每 600s（10min）
+_INTERVAL_OLD = 3600.0  # 每 1h（0076 原值）
+
+# description 与 0076 种子保持同构，仅节奏措辞随 interval 同步。
+_DESC_NEW = (
+    "每 600s（10min）轮询一份生产 PDF 文档，启动 NegentropyEngine 巡检 Routine："
+    "视觉对比 Markdown↔PDF、改 perceives、重转、评分，拟合至满分；Perceives 改进经非回归"
+    "校验后以 PR 合回基线。灰度门控：routine.enabled + routine.patrol_enabled。"
+)
+_DESC_OLD = (
+    "每 1h 轮询一份生产 PDF 文档，启动 NegentropyEngine 巡检 Routine："
+    "视觉对比 Markdown↔PDF、改 perceives、重转、评分，拟合至满分；Perceives 改进经非回归"
+    "校验后以 PR 合回基线。灰度门控：routine.enabled + routine.patrol_enabled。"
+)
+
+_UPDATE_SQL = f"""
+    UPDATE {TABLE}
+       SET interval_seconds = :interval_seconds,
+           description       = :description,
+           next_fire_at      = NOW()
+     WHERE key = :key
+    """
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(_UPDATE_SQL).bindparams(
+            sa.bindparam("interval_seconds", value=_INTERVAL_NEW),
+            sa.bindparam("description", value=_DESC_NEW),
+            sa.bindparam("key", value=TASK_KEY),
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(_UPDATE_SQL).bindparams(
+            sa.bindparam("interval_seconds", value=_INTERVAL_OLD),
+            sa.bindparam("description", value=_DESC_OLD),
+            sa.bindparam("key", value=TASK_KEY),
+        )
+    )

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -1,6 +1,6 @@
 """``pdf_fidelity_patrol`` handler — PDF→Markdown 高保真自拟合巡检的**节奏权威**。
 
-由统一调度引擎按 ``interval``（默认 3600s / 1h）tick。每 tick（轻量、仅 DB + 短 IO）：
+由统一调度引擎按 ``interval``（默认 600s / 10min）tick。每 tick（轻量、仅 DB + 短 IO）：
 
 1. **确保巡检 Repository**：幂等 upsert 名为 ``negentropy`` 的 Repository（local_path 从
    ``settings.routine.patrol_repo_local_path`` 或 negentropy 包路径推导；无法确定则返回
@@ -10,8 +10,8 @@
    把文档标 done（合格）/unfixable（尽力）——保证文档必进 ``skip_ids``、被推进，不再死循环；
    cancelled 不沉淀（用户干预，文档保持可被重新选中）。
 3. **跳过并发**：存在 ``status='running'`` 的巡检 Routine → 本 tick SKIP（保证「上一轮结束后
-   再启下一轮」；ScheduledTask 的 ``interval`` 计 ``next_fire_at = 完成时刻 + 3600s``，叠加此
-   互斥即满足「巡检进行中则等待其结束 + 1h」语义）。
+   再启下一轮」；ScheduledTask 的 ``interval`` 计 ``next_fire_at = 完成时刻 + 600s``，叠加此
+   互斥即满足「巡检进行中则等待其结束 + 10min」语义）。
 4. **选下一份待检生产 PDF**：``knowledge_documents`` 中 ``content_type LIKE '%pdf%'`` 且
    ``markdown_extract_status='completed'``，排除记忆中已 done/unfixable 的 doc_id。
 5. **预取源 PDF**：``BlobStorage.download(content_uri)`` → 暂存到 ``patrol_input_dir/<doc_id>/``。
@@ -79,7 +79,7 @@ register_descriptor(
         handler_kind=PATROL_HANDLER_KIND,
         label="PDF Fidelity Patrol",
         description=(
-            "每 1h 轮询一份生产 PDF 文档，启动一个 NegentropyEngine 巡检 Routine："
+            "每 600s 轮询一份生产 PDF 文档，启动一个 NegentropyEngine 巡检 Routine："
             "视觉对比 Markdown↔PDF、改 perceives、重转、评分，拟合至满分；"
             "Perceives 改进经非回归校验后以 PR 合回基线。"
         ),


### PR DESCRIPTION
## 背景与动机

Scheduler 系统任务 **「PDF Fidelity Patrol（PDF→Markdown 高保真自拟合巡检）」**（`key=pdf_fidelity_patrol`）原节奏为每 **3600s（1h）** 触发一轮。本 PR 将其收敛为每 **600s（10min）** 检查一次，以更高频推进高保真自拟合巡检闭环。

## 为何走「新增迁移」而非改配置/调 API

- 该任务是**系统任务**（`is_system=TRUE`），REST 端点 `PUT /scheduler/tasks/{id}` 对系统任务显式拒绝改写。
- 节奏权威是 DB 列 `negentropy.scheduled_tasks.interval_seconds`，仅由种子迁移 `0076` 以 `ON CONFLICT DO NOTHING` 写入 `3600`，对**已存在**行无效；且 `0076` 已发布，按 Alembic 规范不得回改。
- ⇒ 唯一正确、可回滚的做法：**新增前向迁移 `0091` `UPDATE` 该行**（「单一事实源＝全部迁移的累积结果」，新旧 DB 均收敛到 600s）。

## 变更内容

- **新增 `0091_pdf_fidelity_patrol_interval_600s.py`**（`0090 → 0091`，单一线性 head）：
  - `interval_seconds` 3600 → **600**；
  - `next_fire_at = NOW()` —— 令新节奏于下一 tick 即时生效（缩短 interval 时 `NOW()` 恒 ≤ 旧计划时刻，仅把下一轮提前）；
  - 同步刷新 `description`「每 1h」→「每 600s（10min）」，使 Scheduler UI 展示与真实节奏一致；
  - `downgrade()` 对称还原（interval=3600 + 原 description）。
- **`pdf_fidelity_patrol.py`**：更新 docstring/descriptor 中 `3600s/1h → 600s/10min` 文案（纯注释/展示串，无行为变更），保持 SSOT 一致。

## 安全性

叠加 handler「在跑即 SKIP」互斥（`max_concurrency=1`）与灰度门控（`routine.enabled` + `routine.patrol_enabled`，后者默认 False），改小 interval 无并发/雪崩风险。

## 验证

- `alembic heads` 仅单 head `0091`；`history` 见 `0090 -> 0091`。
- 本地 **upgrade/downgrade 往返**：upgrade 后 `interval_seconds=600.0`、desc 含「每 600s」；downgrade 后 `interval_seconds=3600.0`、desc 复原「每 1h」；验证后将本地 DB 还原至 `0090`（不引入跨 checkout 版本漂移）。
- pre-commit（Ruff lint + format + 通用卫生检查）全绿。

🤖 Generated with [Claude Code](https://github.com/claude)