### PR TITLE
fix(perceives/pdf): 保真巡检 e669a5ea — 公式重复去重 + affiliation 上标 + figure 标签抑制

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -2321,16 +2321,22 @@ def _is_low_content_figure_label(text: str) -> bool:
         return True
     t = text.strip()
     words = re.findall(r"[A-Za-z]{3,}", text)
+    # 章节编号前缀要求编号后跟 ≥2 字母英文词（'4.2 Behavioral Evidence'/'A Related Work'），
+    # 避免把 '10 −1'（−1 非字母）、'1 B 300 M 20 M'（B/M 单字母）这类刻度/图例
+    # 噪声误判为 section 编号。
+    has_section_prefix = bool(re.match(r"^(?:\d+(?:\.\d+)*|[A-Z])\s+[A-Za-z]{2,}", t))
+    has_terminal_punct = bool(re.search(r"[.!?][\"')\]]*\s*$", t))
     # 信号 A + C：短碎片（≤2 个 ≥3 字母英文词）且非"章节编号前缀 / 句末标点"形态
     if len(words) <= 2:
-        # 章节编号前缀要求编号后跟 ≥2 字母英文词（'4.2 Behavioral Evidence'/'A Related Work'），
-        # 避免把 '10 −1'（−1 非字母）、'1 B 300 M 20 M'（B/M 单字母）这类刻度/图例
-        # 噪声误判为 section 编号。
-        has_section_prefix = bool(
-            re.match(r"^(?:\d+(?:\.\d+)*|[A-Z])\s+[A-Za-z]{2,}", t)
-        )
-        has_terminal_punct = bool(re.search(r"[.!?][\"')\]]*\s*$", t))
         if not has_section_prefix and not has_terminal_punct:
+            return True
+    elif 3 <= len(words) <= 6:
+        # 信号 D（多词图内标签 / 注释）：Figure 内的轴标题、图例短语、面板注释
+        # （"Compute Optimal Asymptotic Scaling data / model"、"Learning requires
+        # model scaling"）。判据：3-6 个 ≥3 字母英文词、≤60 字符、无章节编号前缀、
+        # 无句末标点（巡检 e669a5ea Fig 1）。真实 section 标题多带编号、真实段落
+        # 多带句末标点且更长，均不命中。仅作用于已落入 figure region 的文本块。
+        if not has_section_prefix and not has_terminal_punct and len(t) <= 60:
             return True
     # 信号 B：相邻纯数字序列（≥3 个）= 坐标轴刻度
     return bool(re.search(r"\d+(?:\.\d+)?(?:[\s,;]+\d+(?:\.\d+)?){2,}", text))

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1756,6 +1756,10 @@ class BuiltinAssembler(PDFToolBase):
             # 对"非已 fenced、``{``/``[`` 起 + 配对收尾 + ≥2 个 ``"key":`` 且括号
             # 配平"的段落，包裹为 ```json 代码块。检测保守，仅命中明显 JSON。
             markdown = _fence_json_text_paragraphs(markdown)
+            # 作者 affiliation 上标规范化：把 ``$,a$`` / affiliation 行内 ``$X$``
+            # 单字母标记从 inline 数学转为 ``<sup>X</sup>``，避免渲染为斜体字母
+            # （巡检 e669a5ea 作者块：``,a$ Daniel``、``$a$ Stanford University``）。
+            markdown = _normalize_affiliation_inline_math(markdown)
 
             # 4. 图片引用规范化
             images: List[ExtractedImage] = []
@@ -3140,6 +3144,43 @@ _INLINE_MATH_FALSEPOS_DENY = re.compile(
 )
 # 误判触发词：省略号被 LaTeX 化。
 _INLINE_MATH_FALSEPOS_TRIGGER = re.compile(r"\\l?dots\b")
+
+
+def _normalize_affiliation_inline_math(markdown: str) -> str:
+    """把作者 affiliation 上标标记从 inline 数学规范化为 ``<sup>X</sup>``。
+
+    PyMuPDF 把作者署名行里的上标 affiliation 字母（a/b/c/d）抽为 inline 数学
+    （``$,a$``、``$^{b}$``、affiliation 行 ``$a$ Stanford University``），UI 渲染
+    为斜体字母而非上标（巡检 e669a5ea 作者块）。``$^{b}$`` 经 KaTeX 仍渲染为上标
+    （视觉正确），故仅处理两种"视觉错误"形态，零误杀真公式：
+
+    形态 1 ``$,X$``（逗号 + 单字母）：合法数学无此写法 → ``<sup>X</sup>``。
+    形态 2 affiliation 行：以 ``$X$`` 起手 + 含 ≥2 个 ``$X$`` 单字母标记 + 机构
+    关键词（University/Institute/MIT/Google 等）的行，行内 ``$X$`` → ``<sup>X</sup>``。
+    一般散文 ``$X$`` 单字母变量（如"loss $L$"）不满足"起手 + ≥2 + 关键词"，不动。
+    """
+    # 形态 1：$,X$ → <sup>X</sup>
+    markdown = re.sub(r"\$,([a-zA-Z])\$", r"<sup>\1</sup>", markdown)
+    # 形态 2：affiliation 行内 $X$ → <sup>X</sup>
+    _AFFIL_KW = re.compile(
+        r"University|Institute|College|Laborator|\bLab\b|\bMIT\b|Google|Microsoft|"
+        r"Amazon|Apple|\bMeta\b|DeepMind|School|Hospital|Research",
+        re.IGNORECASE,
+    )
+    _SINGLE_LETTER_MATH = re.compile(r"\$([a-z])\$")
+
+    def _affil_line(m: "re.Match[str]") -> str:
+        line = m.group(0)
+        if not re.match(r"\s*\$[a-z]\$", line):
+            return line
+        if len(_SINGLE_LETTER_MATH.findall(line)) < 2:
+            return line
+        if not _AFFIL_KW.search(line):
+            return line
+        return _SINGLE_LETTER_MATH.sub(r"<sup>\1</sup>", line)
+
+    markdown = re.sub(r"[^\n]*\$[a-z]\$[^\n]*", _affil_line, markdown)
+    return markdown
 
 
 def _unwrap_ellipsis_falsepositive_inline_math(markdown: str) -> str:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1239,6 +1239,121 @@ class BuiltinAssembler(PDFToolBase):
                     e for i, e in enumerate(elements) if i not in _fragment_remove
                 ]
 
+            # 2.5.5c 公式线性文本碎片 run vs block formula 签名去重（巡检 e669a5ea eq(1)）
+            # PyMuPDF 把公式视觉区字形抽为一串独立 text 碎片（``$L(N,D)=L_0+A$`` /
+            # ``$N_{}\alpha+B$`` / ``$D\beta ,$ (1)``），与 marker/docling 的 block
+            # formula LaTeX 主体（``$$\cal L(N,D)=...$$``）并存重复。碎片 run 常被
+            # 解释散文与 block 隔开（不相邻），致 §2.5.5 紧邻残片链与 §2.4 编号文本
+            # 去重（<200 字符守卫）双双漏判。此法：①收集所有 block 签名（global）；
+            # ②扫描连续"碎片候选 run"（纯 ``$...$`` text 碎片 / inline formula /
+            # 前导 ``$...$ (N)`` 胶质文本，允许空白穿插）；③run 累积签名若与某 block
+            # 签名互为子串且覆盖率 ≥0.6 → 判为公式线性文本重复：剔除纯碎片 / inline
+            # 副本，剥离胶质文本前导（剥空则整体删），保留解释散文。希腊字母被签名
+            # 剥除致单碎片过短，故用 run 累积签名 + 覆盖率守卫兼顾命中与低误杀。
+            _LEADING_MATH_EQFRAG_RE = re.compile(r"^\$([^$]{1,60})\$\s*\(\d+\)\s*")
+
+            def _leading_frag_strip_len(content: str) -> int:
+                m = _LEADING_MATH_EQFRAG_RE.match(content)
+                if not m:
+                    return 0
+                inner = m.group(1)
+                if not (
+                    any(c in inner for c in _MATH_FRAG_CHARS)
+                    or re.search(r"\\[a-zA-Z]{2,}", inner)
+                ):
+                    return 0
+                return m.end()
+
+            # 碎片候选判定：返回 (sig, kind, strip_len) 或 None
+            #   kind="frag"：整元素为公式碎片（纯 $...$ text 碎片 / inline formula）→ 整体删
+            #   kind="lead"：前导 $...$ (N) 碎片 + 解释散文 → 剥前导留散文（剥空则整体删）
+            #   kind="blank"：空白 text（允许 run 内穿插，不单独成 run）
+            def _frag_candidate(
+                elem: _ContentElement,
+            ) -> Optional[Tuple[str, str, int]]:
+                if (
+                    elem.element_type == "formula"
+                    and elem.formula is not None
+                    and not (elem.content or "").strip().startswith("$$")
+                ):
+                    return (
+                        _formula_text_signature(elem.formula.latex or ""),
+                        "frag",
+                        0,
+                    )
+                if elem.element_type == "text" and elem.block is not None:
+                    c = (elem.content or "").strip()
+                    if not c:
+                        return ("", "blank", 0)
+                    sl = _leading_frag_strip_len(c)
+                    if sl > 0:
+                        return (_formula_text_signature(c[:sl]), "lead", sl)
+                    if _is_formula_text_fragment(c):
+                        return (_formula_text_signature(c), "frag", 0)
+                return None
+
+            # 收集所有 block formula 签名（global，不依赖与碎片的位置邻接）
+            _block_sigs: List[str] = [
+                _formula_text_signature(e.formula.latex or "")
+                for e in elements
+                if e.element_type == "formula"
+                and e.formula is not None
+                and (
+                    e.formula.formula_type == "block"
+                    or (e.content or "").strip().startswith("$$")
+                )
+            ]
+            _block_sigs = [s for s in _block_sigs if len(s) >= 6]
+            _run_remove: set[int] = set()
+            _run_strip: dict[int, int] = {}
+            if _block_sigs:
+                _i = 0
+                while _i < len(elements):
+                    _fc = _frag_candidate(elements[_i])
+                    if _fc is None or _fc[1] == "blank":
+                        _i += 1
+                        continue
+                    # 收集连续碎片 run（允许空白穿插；遇非碎片候选即断）
+                    _run: List[Tuple[int, str, str, int]] = [(_i, *_fc)]
+                    _k = _i + 1
+                    while _k < len(elements):
+                        _fc2 = _frag_candidate(elements[_k])
+                        if _fc2 is None:
+                            break
+                        if _fc2[1] == "blank":
+                            _k += 1
+                            continue
+                        _run.append((_k, *_fc2))
+                        _k += 1
+                    _combined = "".join(_s for _, _s, _, _ in _run if _s)
+                    _matched = False
+                    if len(_combined) >= 6:
+                        for _bsig in _block_sigs:
+                            if _combined in _bsig or _bsig in _combined:
+                                _shorter = min(len(_combined), len(_bsig))
+                                _longer = max(len(_combined), len(_bsig))
+                                if _shorter / _longer >= 0.6:
+                                    _matched = True
+                                    break
+                    if _matched:
+                        for _idx, _sig, _kind, _sl in _run:
+                            if _kind == "frag":
+                                _run_remove.add(_idx)
+                            else:  # lead：剥前导；剥空则整体删
+                                _full = (elements[_idx].content or "").strip()
+                                if _sl >= len(_full):
+                                    _run_remove.add(_idx)
+                                else:
+                                    _run_strip[_idx] = _sl
+                    _i = _k if _k > _i else _i + 1
+            for _idx, _sl in _run_strip.items():
+                _pe = elements[_idx]
+                _pc = (_pe.content or "").strip()
+                if len(_pc) >= _sl:
+                    _pe.content = _pc[_sl:]
+            if _run_remove:
+                elements = [e for _i, e in enumerate(elements) if _i not in _run_remove]
+
             # 2.5.6 公式序号 gap-consistency 推断回填（ISSUE-094 R9 D-2/D-3/D-4）：
             # Docling ``iterate_items`` 路径下抽取的公式 LaTeX 主体常不带
             # ``\\tag{N}`` / ``\\quad (N)`` 编号，UI 视图等式编号缺失。

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -1111,7 +1111,19 @@ class BuiltinAssembler(PDFToolBase):
                             + r")\s*\)",
                             elem.content,
                         )
-                        and any(c in elem.content for c in _math_chars)
+                        and (
+                            any(c in elem.content for c in _math_chars)
+                            or (
+                                # 补充信号：高 inline-math 密度（≥6 个 ``$`` 即 ≥3 个
+                                # ``$...$`` span）+ LaTeX 命令——覆盖无 UNICODE 数学符
+                                # 但满是 LaTeX 命令的公式线性文本副本（巡检 e669a5ea
+                                # eq(6)/(7)/(8)：``$D^*$ $_k=\Lambda1/2$ ... (6)``）。
+                                # ``$``≥6 + ``(N)`` 编号锚定 + <200 字符三重守卫，散文
+                                # 几乎不命中（散文 inline math 通常 ≤2 span）。
+                                elem.content.count("$") >= 6
+                                and re.search(r"\\[a-zA-Z]{2,}", elem.content)
+                            )
+                        )
                         and len(elem.content.strip()) < 200
                         and not elem.content.strip().startswith("#")
                     )


### PR DESCRIPTION
## 背景
PDF Fidelity Patrol 对生产文档《Why Larger Models Learn More》(doc_id=e669a5ea) 的 Markdown↔源 PDF 视觉保真度巡检，定位并修复 4 项可修复保真缺陷，文档已收敛（score 96，done）。

## 改动（assembly.py，4 提交）

### 1. 公式线性文本与 block formula 并存重复（双形态互补修复）
- **eq(1) 多元素 run 形态**（§2.5.5c，`c7003e9f`）：PyMuPDF 把公式视觉区抽为一串独立 text 碎片（`$L(N,D)=L_0+A$` / `$N_{}\alpha+B$` / `$D\beta ,(1)$`），与 marker/docling 的 block formula LaTeX 主体并存。新增 run-based 签名去重：收集所有 block 签名 → 扫连续碎片候选 run → 累积签名若与 block 签名互为子串且覆盖率≥0.6 则剔除碎片、剥离胶质文本前导，保留解释散文。
- **eq(6)/(7)/(8) 单元素高密度 span 形态**（§2.4，`e7d3c2fe`）：一个 text 元素含 ≥3 个 `$...$` span + LaTeX 命令（`\Lambda`/`\top`）+ `(N)` 编号，无 UNICODE 数学符致 §2.4 漏判。拓宽 math 信号为「UNICODE 数学符 OR (`$`≥6 且 LaTeX 命令)」。

### 2. 作者 affiliation 上标（`ad8735a4`）
PyMuPDF 把作者署名行上标 affiliation 字母抽为 inline 数学（`$,a$ Daniel`、`$a$ Stanford University`）渲染为斜体。新增 `_normalize_affiliation_inline_math` 最终 markdown 后处理：`$,X$`→`<sup>X</sup>`；affiliation 行（以 `$X$` 起手 + ≥2 标记 + 机构关键词）转 `<sup>`。`$^{X}$`（KaTeX 已渲染上标）与散文 `$X$` 变量不动，零误杀真公式。

### 3. Fig 1 图内矢量标签泄漏（`ccd9f8d1`）
图内标签（"Compute Optimal Asymptotic Scaling data / model"、"Learning requires model scaling"）被抽为独立 text block 落入 figure region，因 3-6 词逃逸现有 `_is_low_content_figure_label`（仅捕 ≤2 词/数字序列）。扩展信号 D：3-6 个 ≥3 字母英文词、≤60 字符、无章节编号、无句末标点 → 抑制。标签已烘入 figure bitmap，抑制文本副本消除"图+泄漏 prose"双存，不丢信息。

## 验证
- eq(1)/(6)/(7)/(8) inline 碎片剔除、27 个 display 公式总数不变；
- affiliation 上标转 `<sup>`、仅作者块命中、prose 单字母变量未误伤；
- Fig1 图内标签抑制、figure bitmap 保留、23 图 caption / 21 章节标题 / 正文段落全 intact；
- **401 assembly/formula/figure overlay 单测通过**；ruff format/lint/mypy 钩子通过。

## 非回归
全部改动为 assembly 层定点去重/规范化，守卫严格（`(N)` 编号锚定 + 签名覆盖率 + `<200` 字符 + figure-region 作用域），散文/真公式/真实标题不命中。

> 注：`tests/unit/test_config.py` 3 项失败（`concurrent_requests==16` 得 32）为 pre-existing 配置默认值/本地环境覆盖问题，与本 PR 改动无关（本 PR 仅改 assembly.py）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)