### PR TITLE
fix(perceives): PDF 保真巡检修复（figure heading 降级 + 标题连字符保护）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -153,6 +153,8 @@ _COMPOUND_HYPHEN_PREFIXES = frozenset(
         "dry",
         "wet",
         "raw",
+        # 合成词前缀（保护 Human-in-the-Loop 等 ``human-X`` 短语的 left）
+        "human",
     }
 )
 
@@ -668,10 +670,32 @@ class MarkdownFormatter:
                 }
             )
 
+            # 合成词后缀保护集：right 为常见学术合成词后缀时保留连字符，避免
+            # _title_soft_hyphen_mh 误并 Structure-grounded / Search-based /
+            # Orchestration-based 等合成词（其 left 不在 _COMPOUND_HYPHEN_PREFIXES，
+            # 但 right grounded/based/oriented/... 是稳定合成词后缀）。
+            _compound_hyphen_suffixes = frozenset(
+                {
+                    "grounded",
+                    "based",
+                    "oriented",
+                    "driven",
+                    "centric",
+                    "aware",
+                    "enabled",
+                    "guided",
+                    "informed",
+                    "centred",
+                    "level",
+                }
+            )
+
             def _title_soft_hyphen_mh(mm: "re.Match[str]") -> str:
                 left, right = mm.group(1), mm.group(2)
                 low = left.lower()
                 if low in _COMPOUND_HYPHEN_PREFIXES or low in _title_compound_extra:
+                    return f"{left}-{right}"
+                if right.lower() in _compound_hyphen_suffixes:
                     return f"{left}-{right}"
                 return f"{left}{right}"
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -729,6 +729,17 @@ class BuiltinAssembler(PDFToolBase):
                 # bullet 开头 → 列表项
                 elif heading_text.startswith("• ") or heading_text.startswith("- "):
                     is_bad = True
+                # Figure region 内的 heading → 图内分区文字（如 Figure 5 的
+                # "Planning for Agent Harness" 标签）被 docling 误提为 heading，
+                # 与带编号 section heading 文本重复、污染目录锚点。降级为正文
+                # 段落（内容保留、脱离标题层级）。真实 section 标题极少完全落入
+                # figure region（中心点包含检测）；即便被过大 region 误吞而降级，
+                # 作为段落保留亦优于重复 heading 破坏目录（ISSUE-094 figure-region
+                # trade-off，此处复用 _layout_figure_regions 的中心点+IoU 判定）。
+                elif elem.block and _block_overlaps_special(
+                    elem.block, _layout_figure_regions, iou_threshold=0.3
+                ):
+                    is_bad = True
                 if is_bad:
                     elem.element_type = "text"
                     elem.content = heading_text


### PR DESCRIPTION
## 背景

PDF→Markdown 高保真巡检 Routine（doc_id=c9f80764，《Code as Agent Harness》102 页综述）定点修复两处可修复保真缺陷。经多轮采样比对 + DEBUG 链路定位根因 + 重转复核 + 非回归门控验证。

## 改动

### 1. 降级 figure region 内误提的 heading（assembly.py）
docling 常把 figure 图内分区文字（如 Figure 5 的"Planning for Agent Harness"标签、Figure 8 的"Harness Control through the Plan, Execute, and Verify Loop"）误提为 H3 heading，与带编号 section heading 文本重复，污染目录锚点。

- 标题质量过滤链（2.1b）增加分支：heading 块 bbox 中心落入 `_layout_figure_regions`（中心点包含或 IoU≥0.3）时降级为正文段落
- 保守策略：仅降级不删除；真实 section 标题极少完全落入 figure region，即便被过大 region 误吞而降级，作为段落保留亦优于重复 heading 破坏目录（ISSUE-094 figure-region trade-off）

### 2. 标题合成词连字符保护（formatter.py）
section heading 连字符丢失（"Structure-grounded"→"Structuregrounded"、"Search-based"→"Searchbased"、"Orchestration-based"、"Human-in-the-Loop"→"Humanin-the-Loop"）。

**DEBUG 链路定位真正根因**：assembly 输出正确（已带连字符），但 `ops/pdf.py` L211 `format_fidelity_safe` 二次格式化时，formatter.py `_title_soft_hyphen_mh` 把 left 不在白名单的合成词连字符合并（"structure"不在 `_COMPOUND_HYPHEN_PREFIXES`）。assembly 内任何 heading 恢复均被此 pass 覆盖。

- `_title_soft_hyphen_mh` 增加合成词后缀保护集（grounded/based/oriented/driven/centric/aware/...）：right 为稳定合成词后缀时保留连字符
- `_COMPOUND_HYPHEN_PREFIXES` 增加 "human"（保护 Human-in-the-Loop）
- 软断字合并功能保留（right 非合成词后缀时仍合并，如 Parame-ters→Parameters）

## 验证
- 重转《Code as Agent Harness》：Figure 5/6/8 等图内误提 H3 全部降级；3.1.1–5.2.7 真实 section 标题完整；3.1.2/3.1.3/3.1.4/5.2.5 连字符全部恢复；含连字符 heading 均为合法合成词，无软断字残留
- 单测 `_title_soft_hyphen_mh`：4 目标 heading 恢复 + 软断字仍合并 + Self-improvement 仍保护
- pytest：formatter_hyphenation / assembly_helpers / formatter_r11_typography 等 102 测试全过
- ruff / mypy / format 全过

## unfixable 记录（引擎/布局固有限制，不在本 PR 范围）
- Table 4 双渲染：PyMuPDF 把"表格 cells + 段落"抽成混合文本块，空间去重无法分离（docling 列优先 vs PyMuPDF 行优先，剥离锚点无法对齐）
- Figure 内分区文字正文残留（ISSUE-094 trade-off）
- affiliation 上标混入机构标题、副标题 ALL CAPS→Title Case、3.4 主标题编号拆分（docling heading 检测）

🤖 Generated with [Claude Code](https://claude.com/claude-code)