### PR TITLE
style(negentropy-ui): 表格 UI 全局对齐 Routine/Scheduler 设计规范

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/TaskTable.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/TaskTable.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo } from "react";
 
+import { TextTooltip } from "@/components/ui/TextTooltip";
+
 import type { DashboardFilters, ScheduledTaskDTO } from "../_lib/types";
 
 interface TaskTableProps {
@@ -35,6 +37,13 @@ function relativeFromNow(iso: string | null): string {
   }
 }
 
+/** 触发器展示串（cron 表达式 / 间隔秒 / oneshot），对齐 SchedulerTaskTable.triggerText。 */
+function triggerText(t: ScheduledTaskDTO): string {
+  if (t.trigger_type === "cron") return t.cron_expr ?? "cron";
+  if (t.trigger_type === "interval") return `${t.interval_seconds}s`;
+  return "oneshot";
+}
+
 function StatusDots({ statuses }: { statuses: string[] }) {
   const slots = [0, 1, 2].map((i) => statuses[i] ?? null);
   return (
@@ -62,27 +71,39 @@ export function TaskTable({ tasks, filters, onSelect }: TaskTableProps) {
   const filtered = useMemo(() => applyClientFilters(tasks, filters), [tasks, filters]);
 
   return (
-    <div className="rounded-lg border border-border bg-card shadow-sm">
-      <div className="border-b border-border px-3 py-2 text-caption uppercase tracking-overline text-muted-foreground">
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="border-b border-border px-4 py-2.5 text-xs uppercase tracking-overline text-text-secondary">
         Tasks ({filtered.length})
       </div>
       <div className="max-h-[480px] overflow-auto">
-        <table className="w-full text-xs">
-          <thead className="sticky top-0 bg-card text-muted-foreground">
-            <tr className="border-b border-border">
-              <th className="px-3 py-2 text-left font-medium">Task</th>
-              <th className="px-3 py-2 text-left font-medium">Handler</th>
-              <th className="px-3 py-2 text-left font-medium">Trigger</th>
-              <th className="px-3 py-2 text-left font-medium">Last</th>
-              <th className="px-3 py-2 text-left font-medium">Next</th>
-              <th className="px-3 py-2 text-left font-medium">Recent</th>
-              <th className="px-3 py-2 text-left font-medium">Enabled</th>
+        <table className="w-full table-fixed text-sm">
+          {/* 固定列宽（合计 100%，随容器等比缩放；超长内容由 TextTooltip + truncate 恢复全文）：
+              Task 28 · Handler 16 · Trigger 16 · Last 11 · Next 11 · Recent 8 · Enabled 10。
+              7 列须与下方 7 个 <th> 严格对齐。colgroup 内不得夹带空白文本节点（hydration 报错）。 */}
+          <colgroup>
+            <col className="w-[28%]" />
+            <col className="w-[16%]" />
+            <col className="w-[16%]" />
+            <col className="w-[11%]" />
+            <col className="w-[11%]" />
+            <col className="w-[8%]" />
+            <col className="w-[10%]" />
+          </colgroup>
+          <thead className="sticky top-0 bg-card">
+            <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
+              <th className="px-4 py-2.5 font-medium">Task</th>
+              <th className="px-4 py-2.5 font-medium">Handler</th>
+              <th className="px-4 py-2.5 font-medium">Trigger</th>
+              <th className="px-4 py-2.5 font-medium">Last</th>
+              <th className="px-4 py-2.5 font-medium">Next</th>
+              <th className="px-4 py-2.5 font-medium">Recent</th>
+              <th className="px-4 py-2.5 font-medium">Enabled</th>
             </tr>
           </thead>
           <tbody>
             {filtered.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-3 py-6 text-center text-muted-foreground">
+                <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
                   No tasks match current filters.
                 </td>
               </tr>
@@ -91,27 +112,46 @@ export function TaskTable({ tasks, filters, onSelect }: TaskTableProps) {
                 <tr
                   key={t.id}
                   onClick={() => onSelect(t)}
-                  className="cursor-pointer border-b border-border last:border-b-0 hover:bg-muted/30"
+                  className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
                 >
-                  <td className="px-3 py-2">
-                    <div className="font-medium text-foreground">{t.display_name || t.key}</div>
-                    <div className="text-micro text-muted-foreground">{t.key}</div>
+                  <td className="px-4 py-3">
+                    {/* Task 双行：display_name（主）+ key（次），各行独立截断 + 悬浮全文。 */}
+                    <div className="font-medium text-foreground">
+                      <TextTooltip content={t.display_name || t.key}>
+                        <span className="block truncate">{t.display_name || t.key}</span>
+                      </TextTooltip>
+                    </div>
+                    <div className="font-mono text-xs text-text-secondary">
+                      <TextTooltip content={t.key}>
+                        <span className="block truncate">{t.key}</span>
+                      </TextTooltip>
+                    </div>
                   </td>
-                  <td className="px-3 py-2 text-muted-foreground">{t.handler_kind}</td>
-                  <td className="px-3 py-2 text-muted-foreground">
-                    {t.trigger_type === "cron" ? t.cron_expr : t.trigger_type === "interval" ? `${t.interval_seconds}s` : "oneshot"}
+                  <td className="px-4 py-3 text-text-secondary">
+                    <TextTooltip content={t.handler_kind}>
+                      <span className="block truncate">{t.handler_kind}</span>
+                    </TextTooltip>
                   </td>
-                  <td className="px-3 py-2 text-muted-foreground">{relativeFromNow(t.last_fire_at)}</td>
-                  <td className="px-3 py-2 text-muted-foreground">{relativeFromNow(t.next_fire_at)}</td>
-                  <td className="px-3 py-2">
+                  <td className="px-4 py-3 text-text-secondary">
+                    <TextTooltip content={triggerText(t)}>
+                      <span className="block truncate font-mono text-xs">{triggerText(t)}</span>
+                    </TextTooltip>
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary">
+                    <span className="block truncate">{relativeFromNow(t.last_fire_at)}</span>
+                  </td>
+                  <td className="px-4 py-3 text-text-secondary">
+                    <span className="block truncate">{relativeFromNow(t.next_fire_at)}</span>
+                  </td>
+                  <td className="px-4 py-3">
                     <StatusDots statuses={t.recent} />
                   </td>
-                  <td className="px-3 py-2">
+                  <td className="px-4 py-3">
                     <span
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-micro font-semibold ${
                         t.enabled
                           ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                          : "bg-border/50 text-text-muted"
+                          : "bg-muted text-text-secondary"
                       }`}
                     >
                       {t.enabled ? "Enabled" : "Disabled"}

--- a/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from "react-markdown";
 import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { JsonViewer } from "@/components/ui/JsonViewer";
 import { SortableCardWrapper, SortableDragHandle } from "@/components/ui/SortableCardWrapper";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import { useAuth } from "@/components/providers/AuthProvider";
 
 const MARKDOWN_CONTENT_CLASS = [
@@ -378,48 +379,68 @@ function SchemaSection({
       </div>
 
       {rows.length > 0 ? (
-        <div className="overflow-x-auto rounded-md border border-border">
-          <table className="min-w-[640px] w-full text-left text-xs">
-            <thead className="bg-muted">
-              <tr>
-                <th className="px-3 py-2 font-medium text-text-secondary">
-                  Field
-                </th>
-                <th className="px-3 py-2 font-medium text-text-secondary">
-                  Type
-                </th>
-                <th className="px-3 py-2 font-medium text-text-secondary">
-                  Required
-                </th>
-                <th className="px-3 py-2 font-medium text-text-secondary">
-                  Description
-                </th>
-                <th className="px-3 py-2 font-medium text-text-secondary">
-                  Constraints
-                </th>
+        <div className="overflow-hidden rounded-md border border-border bg-card">
+          <table className="w-full table-fixed text-sm">
+            {/* 固定列宽（合计 100%）：Field 22 · Type 14 · Required 10 · Description 32 · Constraints 22。
+                5 列须与下方 5 个 <th> 严格对齐；colgroup 内不得夹带空白文本节点。 */}
+            <colgroup>
+              <col className="w-[22%]" />
+              <col className="w-[14%]" />
+              <col className="w-[10%]" />
+              <col className="w-[32%]" />
+              <col className="w-[22%]" />
+            </colgroup>
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
+                <th className="px-4 py-2.5 font-medium">Field</th>
+                <th className="px-4 py-2.5 font-medium">Type</th>
+                <th className="px-4 py-2.5 font-medium">Required</th>
+                <th className="px-4 py-2.5 font-medium">Description</th>
+                <th className="px-4 py-2.5 font-medium">Constraints</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-border bg-card">
+            <tbody>
               {rows.map((row) => (
-                <tr key={row.path}>
-                  <td className="px-3 py-2 font-mono text-foreground">
-                    {row.path}
+                <tr
+                  key={row.path}
+                  className="border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
+                >
+                  <td className="px-4 py-3">
+                    <TextTooltip content={row.path}>
+                      <span className="block truncate font-mono text-xs text-foreground">
+                        {row.path}
+                      </span>
+                    </TextTooltip>
                   </td>
-                  <td className="px-3 py-2 text-text-secondary">
-                    {row.type}
+                  <td className="px-4 py-3 text-text-secondary">
+                    <TextTooltip content={row.type}>
+                      <span className="block truncate">{row.type}</span>
+                    </TextTooltip>
                   </td>
-                  <td className="px-3 py-2">
+                  <td className="px-4 py-3">
                     {row.required ? (
                       <span className="text-rose-600 dark:text-rose-400">Yes</span>
                     ) : (
                       <span className="text-text-muted">No</span>
                     )}
                   </td>
-                  <td className="px-3 py-2 text-text-secondary">
-                    {row.description || "-"}
+                  <td className="px-4 py-3 text-text-secondary">
+                    {row.description ? (
+                      <TextTooltip content={row.description}>
+                        <span className="block truncate">{row.description}</span>
+                      </TextTooltip>
+                    ) : (
+                      "-"
+                    )}
                   </td>
-                  <td className="px-3 py-2 text-text-muted">
-                    {row.constraints || "-"}
+                  <td className="px-4 py-3 text-text-muted">
+                    {row.constraints ? (
+                      <TextTooltip content={row.constraints}>
+                        <span className="block truncate">{row.constraints}</span>
+                      </TextTooltip>
+                    ) : (
+                      "-"
+                    )}
                   </td>
                 </tr>
               ))}

--- a/apps/negentropy-ui/app/knowledge/apis/_components/ApiDocPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/ApiDocPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ApiEndpoint, getMethodColor } from "@/features/knowledge/utils/api-specs";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import { CodeExample } from "./CodeExample";
 
 interface ApiDocPanelProps {
@@ -38,61 +39,78 @@ export function ApiDocPanel({ endpoint }: ApiDocPanelProps) {
           <h4 className="text-sm font-semibold text-foreground">
             参数
           </h4>
-          <div className="overflow-hidden rounded-lg border border-border">
-            <table className="w-full text-xs">
-              <thead className="bg-muted">
-                <tr>
-                  <th className="px-3 py-2 text-left font-medium text-text-secondary">
-                    名称
-                  </th>
-                  <th className="px-3 py-2 text-left font-medium text-text-secondary">
-                    位置
-                  </th>
-                  <th className="px-3 py-2 text-left font-medium text-text-secondary">
-                    类型
-                  </th>
-                  <th className="px-3 py-2 text-left font-medium text-text-secondary">
-                    必填
-                  </th>
-                  <th className="px-3 py-2 text-left font-medium text-text-secondary">
-                    描述
-                  </th>
+          <div className="overflow-hidden rounded-xl border border-border bg-card">
+            <table className="w-full table-fixed text-sm">
+              {/* 固定列宽（合计 100%）：名称 20 · 位置 10 · 类型 16 · 必填 8 · 描述 46。
+                  5 列须与下方 5 个 <th> 严格对齐；colgroup 内不得夹带空白文本节点。 */}
+              <colgroup>
+                <col className="w-[20%]" />
+                <col className="w-[10%]" />
+                <col className="w-[16%]" />
+                <col className="w-[8%]" />
+                <col className="w-[46%]" />
+              </colgroup>
+              <thead>
+                <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
+                  <th className="px-4 py-2.5 font-medium">名称</th>
+                  <th className="px-4 py-2.5 font-medium">位置</th>
+                  <th className="px-4 py-2.5 font-medium">类型</th>
+                  <th className="px-4 py-2.5 font-medium">必填</th>
+                  <th className="px-4 py-2.5 font-medium">描述</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-border">
+              <tbody>
                 {endpoint.parameters.map((param) => (
                   <tr
                     key={param.name}
-                    className="bg-card"
+                    className="border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
                   >
-                    <td className="px-3 py-2 font-mono text-foreground">
-                      {param.name}
-                    </td>
-                    <td className="px-3 py-2 text-text-secondary">
-                      {param.in}
-                    </td>
-                    <td className="px-3 py-2 text-text-secondary">
-                      {param.type}
-                      {param.enum && (
-                        <span className="ml-1 text-text-muted">
-                          ({param.enum.join(", ")})
+                    <td className="px-4 py-3">
+                      <TextTooltip content={param.name}>
+                        <span className="block truncate font-mono text-xs text-foreground">
+                          {param.name}
                         </span>
-                      )}
+                      </TextTooltip>
                     </td>
-                    <td className="px-3 py-2">
+                    <td className="px-4 py-3 text-text-secondary">
+                      <TextTooltip content={param.in}>
+                        <span className="block truncate">{param.in}</span>
+                      </TextTooltip>
+                    </td>
+                    <td className="px-4 py-3 text-text-secondary">
+                      <TextTooltip
+                        content={`${param.type}${param.enum ? ` (${param.enum.join(", ")})` : ""}`}
+                      >
+                        <span className="block truncate">
+                          {param.type}
+                          {param.enum && (
+                            <span className="text-text-muted">
+                              {" "}({param.enum.join(", ")})
+                            </span>
+                          )}
+                        </span>
+                      </TextTooltip>
+                    </td>
+                    <td className="px-4 py-3">
                       {param.required ? (
                         <span className="text-rose-500">是</span>
                       ) : (
                         <span className="text-text-muted">否</span>
                       )}
                     </td>
-                    <td className="px-3 py-2 text-text-secondary">
-                      {param.description}
-                      {param.default !== undefined && (
-                        <span className="ml-1 text-text-muted">
-                          (默认: {String(param.default)})
+                    <td className="px-4 py-3 text-text-secondary">
+                      <TextTooltip
+                        content={`${param.description}${param.default !== undefined ? ` (默认: ${String(param.default)})` : ""}`}
+                      >
+                        <span className="block truncate">
+                          {param.description}
+                          {param.default !== undefined && (
+                            <span className="text-text-muted">
+                              {" "}(默认: {String(param.default)})
+                            </span>
+                          )}
                         </span>
-                      )}
+                      </TextTooltip>
                     </td>
                   </tr>
                 ))}

--- a/apps/negentropy-ui/app/knowledge/base/_components/ContentExplorer.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ContentExplorer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import { KnowledgeItem } from "@/features/knowledge";
 
 interface ContentExplorerProps {
@@ -11,24 +11,8 @@ interface ContentExplorerProps {
 }
 
 export function ContentExplorer({ items, loading, error, offset = 0 }: ContentExplorerProps) {
-  const [expandedState, setExpandedState] = useState<{
-    id: string;
-    contextToken: string;
-  } | null>(null);
-
-  const contextToken = `${offset}:${items.length}:${items[0]?.id ?? "empty"}`;
-
-  const toggleRow = (id: string) => {
-    setExpandedState((prev) => {
-      if (prev?.id === id && prev.contextToken === contextToken) {
-        return null;
-      }
-      return { id, contextToken };
-    });
-  };
-
   return (
-    <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-border bg-card p-5 shadow-sm">
+    <div className="flex min-h-0 flex-1 flex-col rounded-xl border border-border bg-card p-5">
       <h2 className="shrink-0 text-sm font-semibold text-card-foreground">
         Knowledge Content
       </h2>
@@ -47,69 +31,45 @@ export function ContentExplorer({ items, loading, error, offset = 0 }: ContentEx
         <p className="mt-4 text-xs text-muted-foreground">No items found.</p>
       ) : (
         <div className="mt-4 min-h-0 flex-1 overflow-y-auto overflow-x-auto custom-scrollbar">
-          <table className="w-full text-left text-xs">
+          <table className="w-full table-fixed text-sm">
+            {/* 固定列宽（合计 100%）：# 10 · Content Preview 65 · Created At 25。
+                3 列须与下方 3 个 <th> 严格对齐；colgroup 内不得夹带空白文本节点。 */}
+            <colgroup>
+              <col className="w-[10%]" />
+              <col className="w-[65%]" />
+              <col className="w-[25%]" />
+            </colgroup>
             <thead className="sticky top-0 bg-card">
-              <tr className="border-b border-border text-muted-foreground">
-                <th className="pb-2 font-medium w-12">#</th>
-                <th className="pb-2 font-medium">Content Preview</th>
-                <th className="pb-2 font-medium">Created At</th>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
+                <th className="px-4 py-2.5 font-medium">#</th>
+                <th className="px-4 py-2.5 font-medium">Content Preview</th>
+                <th className="px-4 py-2.5 font-medium">Created At</th>
               </tr>
             </thead>
-            <tbody className="text-foreground">
-              {items.map((item, index) => {
-                const isExpanded =
-                  expandedState?.id === item.id &&
-                  expandedState.contextToken === contextToken;
-                return (
+            <tbody>
+              {items.map((item, index) => (
                 <tr
                   key={item.id}
-                  className={`border-b border-border last:border-0 transition-colors ${
-                    isExpanded ? "bg-muted/30" : "hover:bg-muted/50"
-                  }`}
+                  className="border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
                 >
-                  <td className="whitespace-nowrap py-2 pr-2 text-muted-foreground/70">
+                  <td className="px-4 py-3 tabular-nums text-text-secondary">
                     {offset + index + 1}
                   </td>
-                  <td className="max-w-[400px] py-2 pr-4 align-top">
-                    <button
-                      type="button"
-                      data-testid={`content-toggle-${item.id}`}
-                      aria-expanded={isExpanded}
-                      aria-controls={`content-body-${item.id}`}
-                      onClick={() => toggleRow(item.id)}
-                      className="w-full rounded-md border border-transparent px-2 py-1.5 text-left transition-colors hover:border-border/70 hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                    >
-                      <div className="relative">
-                        <div
-                          id={`content-body-${item.id}`}
-                          data-testid={`content-body-${item.id}`}
-                          className={`text-xs leading-5 break-words transition-all duration-200 ease-out ${
-                            isExpanded
-                              ? "max-h-[1000rem] scale-100 opacity-100 whitespace-pre-wrap"
-                              : "line-clamp-2 max-h-10 scale-[0.99] opacity-90"
-                          }`}
-                          title={isExpanded ? undefined : item.content}
-                        >
-                          {item.content}
-                        </div>
-                        {!isExpanded && (
-                          <div
-                            aria-hidden="true"
-                            className="pointer-events-none absolute inset-x-0 bottom-0 h-5 bg-gradient-to-t from-card to-transparent"
-                          />
-                        )}
-                      </div>
-                      <div className="mt-1 text-caption text-muted-foreground/80">
-                        {isExpanded ? "Collapse" : "Expand"}
-                      </div>
-                    </button>
+                  <td className="px-4 py-3">
+                    {/* 单行截断 + 悬浮全文（对齐 Routine/Scheduler 表格规范）。 */}
+                    <TextTooltip content={item.content}>
+                      <span className="block truncate text-foreground">{item.content}</span>
+                    </TextTooltip>
                   </td>
-                  <td className="whitespace-nowrap py-2 text-muted-foreground/70">
-                    {new Date(item.created_at).toLocaleString()}
+                  <td className="px-4 py-3">
+                    <TextTooltip content={new Date(item.created_at).toLocaleString()}>
+                      <span className="block truncate text-text-secondary">
+                        {new Date(item.created_at).toLocaleString()}
+                      </span>
+                    </TextTooltip>
                   </td>
                 </tr>
-                );
-              })}
+              ))}
             </tbody>
           </table>
         </div>

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -47,6 +47,7 @@ import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { Button } from "@/components/ui/Button";
 import { AnimatedList } from "@/components/ui/AnimatedList";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import { navPillClassName, navRailContainerClassName } from "@/components/ui/nav-styles";
 import {
   tableBodyClassName,
@@ -947,13 +948,19 @@ export default function KnowledgeBasePage() {
                                 className="col-span-3 min-w-0 text-left"
                                 onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id })}
                               >
-                                <p className="truncate text-sm font-medium" title={effectiveDocumentName(doc)}>
-                                  {effectiveDocumentName(doc)}
-                                </p>
+                                <TextTooltip content={effectiveDocumentName(doc)}>
+                                  <p className="truncate text-sm font-medium">
+                                    {effectiveDocumentName(doc)}
+                                  </p>
+                                </TextTooltip>
                               </button>
                               {/* Source */}
-                              <div className="col-span-1 truncate text-center text-xs text-muted-foreground" title={sourceType}>
-                                {sourceType}
+                              <div className="col-span-1 min-w-0 text-center">
+                                <TextTooltip content={sourceType}>
+                                  <div className="block truncate text-xs text-muted-foreground">
+                                    {sourceType}
+                                  </div>
+                                </TextTooltip>
                               </div>
                               {/* Size */}
                               <div className="col-span-1 text-center text-xs text-muted-foreground">

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -29,6 +29,7 @@ import { Check, Pencil, X } from "lucide-react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { Pagination } from "@/components/ui/Pagination";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import {
   tableBodyClassName,
@@ -560,13 +561,12 @@ export default function DocumentsPage() {
                         ) : (
                           <div className="min-w-0 flex-1 flex items-center gap-1">
                             <div className="min-w-0">
-                              <p
-                                className="font-medium text-foreground truncate"
-                                title={effectiveDocumentName(doc)}
-                              >
-                                {effectiveDocumentName(doc)}
-                              </p>
-                              <p className="text-xs text-muted-foreground truncate">
+                              <TextTooltip content={effectiveDocumentName(doc)}>
+                                <p className="truncate font-medium text-foreground">
+                                  {effectiveDocumentName(doc)}
+                                </p>
+                              </TextTooltip>
+                              <p className="truncate text-xs text-muted-foreground">
                                 {doc.content_type || "Unknown"}
                               </p>
                             </div>
@@ -593,16 +593,15 @@ export default function DocumentsPage() {
                       </div>
 
                       {/* 所属语料库 - col-span-2；库文档（corpus_id=null）显示 Library 徽标 */}
-                      <div className="col-span-2 flex justify-end">
+                      <div className="col-span-2 flex min-w-0 justify-end">
                         {doc.corpus_id ? (
-                          <span
-                            className="text-muted-foreground truncate text-xs"
-                            title={getCorpusName(doc.corpus_id) ?? undefined}
-                          >
-                            {getCorpusName(doc.corpus_id)}
-                          </span>
+                          <TextTooltip content={getCorpusName(doc.corpus_id) ?? ""}>
+                            <span className="block max-w-full truncate text-xs text-muted-foreground">
+                              {getCorpusName(doc.corpus_id)}
+                            </span>
+                          </TextTooltip>
                         ) : (
-                          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                             Library
                           </span>
                         )}
@@ -614,8 +613,12 @@ export default function DocumentsPage() {
                       </div>
 
                       {/* Created By - col-span-1 */}
-                      <div className="col-span-1 text-muted-foreground truncate text-xs text-center" title={doc.created_by_name || doc.created_by || ""}>
-                        {displayUser(doc.created_by, doc.created_by_name)}
+                      <div className="col-span-1 min-w-0 text-center">
+                        <TextTooltip content={doc.created_by_name || doc.created_by || ""}>
+                          <div className="block truncate text-xs text-muted-foreground">
+                            {displayUser(doc.created_by, doc.created_by_name)}
+                          </div>
+                        </TextTooltip>
                       </div>
 
                       {/* Created At - col-span-1 */}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/EntityListPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/EntityListPanel.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/features/knowledge";
 
 import { Pagination } from "@/components/ui/Pagination";
+import { TextTooltip } from "@/components/ui/TextTooltip";
 import { useInfiniteList, type OffsetFetcher } from "@/hooks/useInfiniteList";
 import { useInfiniteScrollSentinel, useScrollPageSync } from "@/hooks/useInfiniteScrollSentinel";
 
@@ -167,25 +168,24 @@ export function EntityListPanel({
             暂无实体数据
           </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
+          <div className="overflow-hidden rounded-xl border border-border bg-card">
+            <table className="w-full table-fixed text-sm">
+              {/* 固定列宽（合计 100%）：名称 32 · 类型 22 · 社区 18 · 置信度 14 · 提及 14。
+                  5 列须与下方 5 个 <th> 严格对齐；colgroup 内不得夹带空白文本节点。 */}
+              <colgroup>
+                <col className="w-[32%]" />
+                <col className="w-[22%]" />
+                <col className="w-[18%]" />
+                <col className="w-[14%]" />
+                <col className="w-[14%]" />
+              </colgroup>
               <thead>
-                <tr className="border-b border-border">
-                  <th className="py-2 px-2 text-left font-medium text-text-muted">
-                    名称
-                  </th>
-                  <th className="py-2 px-2 text-left font-medium text-text-muted">
-                    类型
-                  </th>
-                  <th className="py-2 px-2 text-left font-medium text-text-muted">
-                    社区
-                  </th>
-                  <th className="py-2 px-2 text-right font-medium text-text-muted">
-                    置信度
-                  </th>
-                  <th className="py-2 px-2 text-right font-medium text-text-muted">
-                    提及
-                  </th>
+                <tr className="border-b border-border text-left text-xs uppercase tracking-overline text-text-secondary">
+                  <th className="px-4 py-2.5 font-medium">名称</th>
+                  <th className="px-4 py-2.5 font-medium">类型</th>
+                  <th className="px-4 py-2.5 font-medium">社区</th>
+                  <th className="px-4 py-2.5 text-right font-medium">置信度</th>
+                  <th className="px-4 py-2.5 text-right font-medium">提及</th>
                 </tr>
               </thead>
               <tbody>
@@ -196,48 +196,57 @@ export function EntityListPanel({
                       i % ENTITY_PAGE_SIZE === 0 ? Math.floor(i / ENTITY_PAGE_SIZE) + 1 : undefined
                     }
                     onClick={() => onSelectEntity(entity.id)}
-                    className={`cursor-pointer border-b border-border hover:bg-muted ${
+                    className={`cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40 ${
                       selectedEntityId === entity.id
                         ? "bg-blue-50 dark:bg-blue-900/20"
                         : ""
                     }`}
                   >
-                    <td className="py-2 px-2 text-foreground font-medium">
-                      {entity.name}
+                    <td className="px-4 py-3">
+                      <TextTooltip content={entity.name}>
+                        <span className="block truncate font-medium text-foreground">
+                          {entity.name}
+                        </span>
+                      </TextTooltip>
                     </td>
-                    <td className="py-2 px-2">
-                      <span className="inline-flex items-center gap-1">
+                    <td className="px-4 py-3">
+                      {/* 类型：色点 + label，单行截断，全文悬浮。 */}
+                      <div className="flex min-w-0 items-center gap-1">
                         <span
-                          className="inline-block h-2 w-2 rounded-full"
+                          className="inline-block h-2 w-2 shrink-0 rounded-full"
                           style={{
                             backgroundColor:
                               ENTITY_TYPE_COLORS[entity.entity_type] ?? ENTITY_TYPE_COLORS.other,
                           }}
                         />
-                        <span className="text-text-secondary">
-                          {entity.entity_type}
-                        </span>
-                      </span>
+                        <TextTooltip content={entity.entity_type}>
+                          <span className="min-w-0 flex-1 truncate text-text-secondary">
+                            {entity.entity_type}
+                          </span>
+                        </TextTooltip>
+                      </div>
                     </td>
-                    <td className="py-2 px-2">
+                    <td className="px-4 py-3">
                       {entity.community_id != null ? (
-                        <span className="inline-flex items-center gap-1">
+                        <div className="flex min-w-0 items-center gap-1">
                           <span
-                            className="inline-block h-2 w-2 rounded-full"
+                            className="inline-block h-2 w-2 shrink-0 rounded-full"
                             style={{ backgroundColor: communityColor(entity.community_id) }}
                           />
-                          <span className="text-text-secondary">
-                            C-{entity.community_id}
-                          </span>
-                        </span>
+                          <TextTooltip content={`C-${entity.community_id}`}>
+                            <span className="min-w-0 flex-1 truncate text-text-secondary">
+                              C-{entity.community_id}
+                            </span>
+                          </TextTooltip>
+                        </div>
                       ) : (
-                        <span className="text-text-muted">-</span>
+                        <span className="text-text-muted">—</span>
                       )}
                     </td>
-                    <td className="py-2 px-2 text-right text-text-secondary">
+                    <td className="px-4 py-3 text-right tabular-nums text-text-secondary">
                       {entity.confidence.toFixed(2)}
                     </td>
-                    <td className="py-2 px-2 text-right text-text-secondary">
+                    <td className="px-4 py-3 text-right tabular-nums text-text-secondary">
                       {entity.mention_count}
                     </td>
                   </tr>

--- a/apps/negentropy-ui/components/ui/table-styles.ts
+++ b/apps/negentropy-ui/components/ui/table-styles.ts
@@ -1,26 +1,26 @@
 /**
- * 表格视觉令牌 —— 向 HeroUI Table 风格对齐（纯 Tailwind 实现，无第三方依赖）。
+ * 表格视觉令牌 —— 全局向 Routine / Scheduler 参考表格对齐（纯 Tailwind，无第三方依赖）。
  *
- * 设计参考：https://beta.heroui.com/docs/components/table
- * 关键收敛点：
- *  - 去除类 Excel 的竖向分隔线（`border-r`），HeroUI 表格无竖线，观感差异最大；
- *  - 弱化表头为小号大写眼纹（uppercase + tracking），降低视觉权重；
- *  - 行分隔线柔和、统一 hover 反馈；圆角容器收束整体。
+ * 设计参考：[[RoutineTable]] / [[SchedulerTaskTable]]（手写 `<table>` 黄金标准）。
+ * 关键收敛点（与 AGENTS.md「UI Table 设计规范」一致）：
+ *  - 容器 `rounded-xl`（非 2xl）、无投影，收束整体；
+ *  - 表头弱化为小号大写眼纹（text-xs + uppercase + tracking）、**无背景填充**（透出 card 底）；
+ *  - 行分隔线柔和（border/60）、统一 hover 反馈。
  *
  * 仅承载「视觉」类名;布局类（grid/flex/col-span 等）由各调用方组合，
  * 避免强抽象一个跨页通用的 DataTable 组件（两处表格的行内交互差异较大）。
  */
 
-/** 表格外层容器：圆角 + 边框 + 卡片底 + 轻投影。 */
+/** 表格外层容器：圆角 + 边框 + 卡片底（对齐参考表，去投影）。 */
 export const tableContainerClassName =
-  "overflow-hidden rounded-2xl border border-border bg-card shadow-sm";
+  "overflow-hidden rounded-xl border border-border bg-card";
 
 /** 表头行视觉（不含布局；调用方再组合 grid/flex）。 */
 export const tableHeaderClassName =
-  "border-b border-border bg-muted/40 px-4 py-3 text-caption font-medium uppercase tracking-overline text-text-muted";
+  "border-b border-border px-4 py-2.5 text-xs font-medium uppercase tracking-overline text-text-secondary";
 
-/** 表体：柔和的横向行分隔线。 */
-export const tableBodyClassName = "divide-y divide-border";
+/** 表体：柔和的横向行分隔线（与参考表 border-border/60 一致）。 */
+export const tableBodyClassName = "divide-y divide-border/60";
 
 /** 数据行视觉（不含布局/grid）：统一内边距与 hover 反馈。 */
 export const tableRowClassName = "px-4 py-3 transition-colors hover:bg-muted/40";

--- a/apps/negentropy-ui/tests/unit/knowledge/ContentExplorer.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/ContentExplorer.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { ContentExplorer } from "@/app/knowledge/base/_components/ContentExplorer";
 import type { KnowledgeItem } from "@/features/knowledge";
 
@@ -13,72 +12,38 @@ const makeItem = (id: string, content: string): KnowledgeItem => ({
 });
 
 describe("ContentExplorer", () => {
-  it("默认以折叠态渲染内容", () => {
+  it("渲染内容条目并按 offset 连续编号", () => {
     render(
       <ContentExplorer
-        items={[makeItem("item-1", "第一行内容，默认应为折叠状态展示。".repeat(8))]}
+        offset={10}
+        items={[makeItem("item-1", "短内容 A"), makeItem("item-2", "短内容 B")]}
       />,
     );
-
-    const toggle = screen.getByTestId("content-toggle-item-1");
-    const body = screen.getByTestId("content-body-item-1");
-
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    expect(body.className).toContain("line-clamp-2");
+    expect(screen.getByText("11")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("短内容 A")).toBeInTheDocument();
+    expect(screen.getByText("短内容 B")).toBeInTheDocument();
   });
 
-  it("支持点击展开/收起，且同一时间仅展开一行", async () => {
-    render(
-      <ContentExplorer
-        items={[
-          makeItem("item-1", "Chunk 1 内容。".repeat(12)),
-          makeItem("item-2", "Chunk 2 内容。".repeat(12)),
-        ]}
-      />,
-    );
+  it("内容单元格单行截断（truncate），超长全文经 Tooltip 恢复", () => {
+    const longContent = "很长的一段内容".repeat(40);
+    render(<ContentExplorer items={[makeItem("item-1", longContent)]} />);
 
-    const firstToggle = screen.getByTestId("content-toggle-item-1");
-    const secondToggle = screen.getByTestId("content-toggle-item-2");
-    const firstBody = screen.getByTestId("content-body-item-1");
-    const secondBody = screen.getByTestId("content-body-item-2");
-
-    await userEvent.click(firstToggle);
-    expect(firstToggle).toHaveAttribute("aria-expanded", "true");
-    expect(firstBody.className).toContain("whitespace-pre-wrap");
-    expect(firstBody.className).not.toContain("line-clamp-2");
-
-    await userEvent.click(secondToggle);
-    expect(firstToggle).toHaveAttribute("aria-expanded", "false");
-    expect(secondToggle).toHaveAttribute("aria-expanded", "true");
-    expect(secondBody.className).toContain("whitespace-pre-wrap");
-    expect(firstBody.className).toContain("line-clamp-2");
-
-    await userEvent.click(secondToggle);
-    expect(secondToggle).toHaveAttribute("aria-expanded", "false");
-    expect(secondBody.className).toContain("line-clamp-2");
+    const cell = screen.getByText(longContent);
+    expect(cell.className).toContain("truncate");
   });
 
-  it("数据更新后会重置展开状态", async () => {
-    const { rerender } = render(
-      <ContentExplorer
-        items={[
-          makeItem("item-1", "Chunk 1 内容。".repeat(12)),
-          makeItem("item-2", "Chunk 2 内容。".repeat(12)),
-        ]}
-      />,
-    );
+  it("空数据显示占位文案", () => {
+    render(<ContentExplorer items={[]} />);
+    expect(screen.getByText("No items found.")).toBeInTheDocument();
+  });
 
-    const firstToggle = screen.getByTestId("content-toggle-item-1");
-    await userEvent.click(firstToggle);
-    expect(firstToggle).toHaveAttribute("aria-expanded", "true");
+  it("loading 与 error 态各自正确呈现", () => {
+    const { rerender } = render(<ContentExplorer items={[]} loading />);
+    // loading 骨架（3 条脉冲块）
+    expect(document.querySelectorAll(".animate-pulse").length).toBe(3);
 
-    rerender(
-      <ContentExplorer
-        items={[makeItem("item-3", "新数据。".repeat(12))]}
-      />,
-    );
-
-    const newToggle = screen.getByTestId("content-toggle-item-3");
-    expect(newToggle).toHaveAttribute("aria-expanded", "false");
+    rerender(<ContentExplorer items={[]} error="boom" />);
+    expect(screen.getByText("boom")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 背景

`AGENTS.md` 新增了「UI Table 设计规范」（提交 `1f87dd62`）：**样式一致性、列宽固定、单行不折 + 省略号截断 + Tooltip 悬浮全文**。除 `Interface / Routine` 与 `Interface / Scheduler` 两页（已落地的「黄金标准」）外，项目其余表格散落着三种不一致写法（无固定列宽 / 内容自由折行溢出 / 无 Tooltip），视觉与交互熵增明显。本 PR 将全站表格收敛到统一范式。

## 基准范式（Source of Truth）

参考表格 `RoutineTable.tsx` / `SchedulerTaskTable.tsx` 的内联写法（**手写原生 `<table>`**，不用 shadcn Table / TanStack，刻意不用 `table-styles.ts`）：

- 容器 `overflow-hidden rounded-xl border border-border bg-card`
- `<table className="w-full table-fixed text-sm">` + `<colgroup>` 百分比列宽（合计 100%）
- 表头 `text-xs uppercase tracking-overline text-text-secondary`；`<th>` `px-4 py-2.5 font-medium`
- 数据行 `border-b border-border/60 ... hover:bg-muted/40`；`<td>` `px-4 py-3`
- 溢出文本经 `TextTooltip` 原语（溢出感知 + 强制单行）：Shape A `block truncate`、Shape B `flex min-w-0` + `min-w-0 flex-1 truncate`
- colgroup 内不夹空白文本节点（规避 hydration 报错）

## 改动清单

### A 组 — 原生 `<table>` 完整改造（三规范全缺）
| 表格 | 列宽（% 合计 100） | 保留的交互语义 |
|---|---|---|
| Dashboard `TaskTable` | Task 28·Handler 16·Trigger 16·Last 11·Next 11·Recent 8·Enabled 10 | sticky 表头 / 滚动区 / 标题栏 / 行可点 |
| `ApiDocPanel` 参数表 | 名称 20·位置 10·类型 16·必填 8·描述 46 | 静态表（不加 cursor） |
| `EntityListPanel` 实体表 | 名称 32·类型 22·社区 18·置信度 14·提及 14 | 行可点 / 选中高亮 / 无限滚动锚点 / 右对齐数值 |
| `McpServerCard` Schema 表 | Field 22·Type 14·Required 10·Description 32·Constraints 22 | 静态表（去 `min-w-[640px]`） |
| `ContentExplorer` | # 10·Preview 65·Created At 25 | Preview 简化为单行截断 + Tooltip（孤儿表，生产未挂载） |

### B 组 — div-grid 伪表格补差对齐
- `components/ui/table-styles.ts` 令牌向基准对齐：`rounded-2xl`→`rounded-xl`、去表头 `bg-muted/40`、`text-caption`→`text-xs`、`text-text-muted`→`text-text-secondary`、`divide-border`→`divide-border/60`（一处 SSoT 改动惠及两页）。
- `documents/page.tsx`（grid-cols-13）与 `knowledge/base/page.tsx`（grid-cols-12）长文本列 `title=` 原生提示升级为 `TextTooltip`，并补全 `truncate` 单行。

### C 组 — 不在范围
- `DocumentMarkdownRenderer`：文档正文 Markdown 表格（动态列、非应用数据表），跳过。

## 验证

- ✅ `pnpm typecheck`（`tsc --noEmit`）通过
- ✅ `pnpm lint`（`eslint . --max-warnings=0`）通过
- ✅ `pnpm test tests/unit/knowledge/`：29 文件 / 239 例全绿（含重写后的 `ContentExplorer.test.tsx` 4 例）
- ✅ dev server 启动、应用 webpack 编译通过；colgroup 写法对齐已在产的 `SchedulerTaskTable`（无 hydration 报错先例）
- ⏳ 深度数据驱动视觉回归（明暗双主题截图）需借已认证 Chrome + 运行中后端（主仓）执行；模式与黄金标准逐字一致，风险低。

## 复用资产
`@/components/ui/TextTooltip`（溢出感知单行 Tooltip）、`CopyButton`、`Skeleton` —— 未新造抽象，保证与黄金标准逐字一致。