### PR TITLE
fix(patrol): 修复未巡检 PDF 被「命名门控」误排，致 Scheduler 恒报「无待检」

### DIFF
--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -659,19 +659,21 @@ async def _has_running_patrol(db) -> bool:
 async def _select_next_pending_doc(db, *, skip_ids: set[str] | None = None) -> dict[str, Any] | None:
     """选最早入库、未巡检（``patrol_status IS NULL``）的 PDF 文档（content_type=pdf 且转换已完成）。
 
-    两道守卫（缺一不可）：
-      - **命名门控**：``display_name`` 或 ``metadata->>'title'`` 至少有一个非空，否则跳过。
-        巡检 Routine 名字在创建时刻定格（``_doc_display_title`` 三级解析），无更优名源时会兜底成
-        ``original_filename``（如 ``2603.05344v3.pdf``）——本门控从源头杜绝「原始文件名兜底」巡检。
-        新导入经 Fix B（Perceives 标题透传 + 回填）自动获得 ``metadata.title``；存量无标题文档待
-        用户改名 / 重新抽取后入选（绝不以原始文件名兜底发起巡检）。
+    巡检资格判定的两道正交守卫：
+      - **巡检态门控**（SSOT）：``patrol_status IS NULL`` = 未巡检入选；``in_progress``/``done``/
+        ``unfixable`` 均跳过（终态文档须用户「重置为未拟合」回 NULL 方可二次巡检）。
       - **一文一活跃巡检**（Fix A）：``NOT EXISTS`` 排除已有**非 cancelled** 巡检 Routine 的文档
         （``config->>'doc_id'`` 为 SSOT 指针）。排除 cancelled 使「取消」成为合法复位——被取消的冗余
-        Routine 不再阻塞同 doc 以当前有效名重建（见 ``_collapse_superseded_patrols``）。
+        Routine 不再阻塞同 doc 重建（见 ``_collapse_superseded_patrols``）；此门亦承担防重试死循环职责。
 
-    巡检态 SSOT 为 ``knowledge_documents.patrol_status`` 列（NULL=未巡检入选，``in_progress``/
-    ``done``/``unfixable`` 跳过）。``skip_ids`` 形参已废弃（过渡兼容，忽略），见迁移 0092 与
-    ``docs/.agents/pdf-fidelity-patrol-status.md``。
+    命名关注**正交下沉**至 ``_doc_display_title``（``display_name`` → ``metadata.title`` →
+    ``original_filename`` 三级兜底，复用纯函数 SSOT ``resolve_effective_display_name``）：巡检资格不因
+    缺名而被否决——仅剩原始文件名（含 arxiv-ID 如 ``2603.05344v3.pdf``）时仍发起巡检，Routine 名暂以
+    文件名兜底；待更优名源出现（用户改名 / Fix B 标题回填），``_collapse_superseded_patrols`` 自愈取消
+    旧 Routine、下一 tick 以更优名重建。历史「命名门控」（要求 display_name/metadata.title 非空）曾在此
+    预筛，致未巡检但无标题文档被永久跳过而 Scheduler 误报「无待检 PDF 文档」，已移除。
+
+    ``skip_ids`` 形参已废弃（过渡兼容，忽略），见迁移 0092 与 ``docs/.agents/pdf-fidelity-patrol-status.md``。
     """
     # TODO(phase2): 移除 skip_ids 形参（巡检态已迁至 patrol_status 列，Memory TAG_STATUS deprecate 后删）。
     del skip_ids  # 过渡期保留签名兼容，不再使用。
@@ -683,7 +685,6 @@ async def _select_next_pending_doc(db, *, skip_ids: set[str] | None = None) -> d
         "AND COALESCE(content_type,'') ILIKE '%pdf%' "
         "AND markdown_extract_status = 'completed' "
         "AND patrol_status IS NULL "
-        "AND COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL "
         "AND NOT EXISTS ("
         "  SELECT 1 FROM negentropy.routines r "
         "  WHERE r.config->>'patrol' = 'true' "

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -135,18 +135,19 @@ def test_select_next_pending_doc_reads_patrol_status_column():
 
 
 def test_select_next_pending_doc_sql_contains_per_doc_uniqueness_guard():
-    """Fix A + 命名门控：emitted SQL 必含「命名门控」+「一文一活跃巡检」NOT EXISTS 守卫（排除 cancelled）。
+    """Fix A：emitted SQL 必含「一文一活跃巡检」NOT EXISTS 守卫（排除 cancelled）；命名门控已移除（防回归）。
 
-    FakeDB 不解析 SQL，仅以串存在性守护不变量防回归——后续重构若误删命名门控 / NOT EXISTS /
-    把 cancelled 纳入阻塞，本断言即失败。真实 SQL 语义由集成测试覆盖。
+    FakeDB 不解析 SQL，仅以串存在性守护不变量防回归——后续重构若误删 NOT EXISTS / 把 cancelled 纳入
+    阻塞，或误加回「命名门控」（display_name/metadata.title 非空预筛，会误排未巡检但无标题文档致
+    Scheduler 误报「无待检」），本断言即失败。真实 SQL 语义由集成测试覆盖。
     """
     import asyncio
 
     db = _FakeDB(fetchone=None)
     asyncio.run(patrol._select_next_pending_doc(db, skip_ids=set()))
     stmt = db.executed[0][0]
-    # 命名门控：display_name 或 metadata->>'title' 至少一个非空（杜绝原始文件名兜底）
-    assert "COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL" in stmt
+    # 命名门控已移除：巡检资格不再预筛 display_name/metadata.title（命名下沉至 _doc_display_title）
+    assert "COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL" not in stmt
     assert "patrol_status IS NULL" in stmt  # 巡检态 SSOT 列（仅未巡检入选）
     assert "NOT EXISTS" in stmt
     assert "config->>'patrol'" in stmt

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -508,8 +508,8 @@ async def test_finalize_multiple_routines_same_doc_best_wins(db_engine):
 async def _seed_knowledge_pdf(db_engine, *, filename):
     """落库一条 knowledge_documents（pdf + completed）；返回其 id。
 
-    带 ``display_name``：命名门控（``_select_next_pending_doc``）要求文档至少有 display_name
-    或 metadata.title 之一，否则被跳过——测试文档须具名才可被选中（测试的是推进逻辑，非命名）。
+    带 ``display_name``：历史命名门控已移除（巡检资格不再预筛 display_name/metadata.title，命名
+    下沉至 ``_doc_display_title``），此处仍具名仅为测试可读性 / 与存量 fixture 一致。
     """
     from negentropy.config import settings
     from negentropy.models.perception import KnowledgeDocument
@@ -556,6 +556,38 @@ async def test_select_advances_after_done(db_engine):
     assert str(doc_a) in skip  # A 已 done → 进 skip_ids（推进核心信号）
     assert next_doc is not None  # 仍有待检文档（B 或其它 pending）
     assert str(next_doc["id"]) != str(doc_a)  # 推进：不再选中已合格的 A（修「始终卡 A」根因）
+
+
+async def test_select_next_pending_doc_includes_untitled_pdf(db_engine):
+    """回归：未巡检但 ``display_name``/``metadata.title`` 均空的 PDF 也应入选（命名门控已移除）。
+
+    复现并锁死「Scheduler 误报无待检 PDF 文档」根因——历史命名门控（display_name/metadata.title
+    非空预筛）把这类文档永久跳过。测试库累积且 selector 全局取最早一份（``skip_ids`` 已废弃不可
+    drain），故不直接断言 ``selector()==该 doc``，而是断言「该 no-title doc 满足 selector 的资格
+    谓词」（等价于 selector 在无更早 pending 时会选中它）。
+    """
+    # 无 display_name / 无 metadata.title（命名门控移除前的「被误排」形态）
+    doc_id = await _seed_pdf_document(db_engine, original_filename="patrol-untitled.pdf")
+
+    factory = _sf(db_engine)
+    async with factory() as db:
+        eligible = await db.execute(
+            text(
+                "SELECT 1 FROM negentropy.knowledge_documents "
+                "WHERE id = :d "
+                "  AND app_name = :app "
+                "  AND COALESCE(content_type,'') ILIKE '%pdf%' "
+                "  AND markdown_extract_status = 'completed' "
+                "  AND patrol_status IS NULL "
+                "  AND NOT EXISTS ("
+                "    SELECT 1 FROM negentropy.routines r "
+                "    WHERE r.config->>'patrol' = 'true' "
+                "      AND r.config->>'doc_id' = knowledge_documents.id::text "
+                "      AND r.status <> 'cancelled')"
+            ),
+            {"d": doc_id, "app": settings.app_name},
+        )
+        assert eligible.fetchone() is not None  # no-title 未巡检 PDF 资格通过（命名门控不再拦截）
 
 
 # ---------------------------------------------------------------------------

--- a/docs/.agents/pdf-fidelity-patrol-status.md
+++ b/docs/.agents/pdf-fidelity-patrol-status.md
@@ -99,9 +99,10 @@ sequenceDiagram
 1. `content_type ILIKE '%pdf%'`（PDF 文档）
 2. `markdown_extract_status = 'completed'`（转换完成）
 3. **`patrol_status IS NULL`**（4 态语义：仅未巡检入选；**替换**旧 `id NOT IN :skip` 的 Memory skip_ids 路径）
-4. 命名门控（`display_name` 或 `metadata->>'title'` 至少一个非空，杜绝原始文件名兜底）
-5. `NOT EXISTS` 非 cancelled 巡检 Routine（一文一活跃巡检并发互斥；与 `patrol_status` 正交保留）
+4. `NOT EXISTS` 非 cancelled 巡检 Routine（一文一活跃巡检并发互斥；与 `patrol_status` 正交保留）
 
+> **命名关注正交下沉**至 [`_doc_display_title`](../../apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py)（`display_name` → `metadata.title` → `original_filename` 三级兜底，复用 `resolve_effective_display_name`）：巡检资格不因缺名而被否决。历史「命名门控」（要求 `display_name`/`metadata.title` 非空）曾在此预筛，致未巡检但无标题文档被永久跳过而 Scheduler 误报「无待检 PDF 文档」，已移除——仅剩原始文件名（含 arxiv-ID 如 `2603.05344v3.pdf`）时仍发起巡检，Routine 名暂以文件名兜底，待更优名源出现（用户改名 / Fix B 标题回填）由 [`_collapse_superseded_patrols`](../../apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py) 自愈取消旧 Routine、下 tick 以更优名重建。
+>
 > `skip_ids` 形参保留为 Optional（过渡兼容，已忽略）；`get_skip_doc_ids()` 过渡期保留供测试，Phase 2 随 Memory TAG_STATUS deprecate 一并移除。
 
 ## 5. 「重置为未拟合」API


### PR DESCRIPTION
## 问题现象

Knowledge/Documents 页中 `Loop-Engineering-IEEE.pdf` 明明是「未巡检」状态，但 Scheduler `PDF Fidelity Patrol` 每轮巡检都报「无待检 PDF 文档 / no pending PDF documents」，从不为它派生拟合 Routine。

## 根因（线上库数据 + 源码双重证实）

待检文档选取器 `_select_next_pending_doc`（`pdf_fidelity_patrol.py`）的 WHERE 子句除正确的 `patrol_status IS NULL` 外，还附加了一道**「命名门控」**：

```sql
AND COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL
```

实测该文档 `display_name` 与 `metadata.title` **均为空**，被这道门永久跳过——而其余 5 道门（`patrol_status IS NULL` / `content_type ILIKE pdf` / `markdown_extract_status=completed` / `app_name` / `NOT EXISTS` 非 cancelled Routine）**全部通过**。

**爆炸半径**：线上库当前 2 份未巡检 PDF（`2603.05344v3.pdf`、`Loop-Engineering-IEEE.pdf`）无一例外都被这道门挡住，故 Scheduler 恒报「无待检」。

## 设计层根因（正交分解视角）

「命名门控」把两个本应正交的关注点耦合：
- **要不要巡检**（用户期望：仅 `done`/拟合成功 不巡检）
- **Routine 叫什么名字**（展示性关注）

而系统**本已解耦**命名——`_doc_display_title` 三级兜底（`display_name → metadata.title → original_filename`）+ `_collapse_superseded_patrols`「原始文件名兜底自愈」（更优名源出现时取消旧 Routine、下一 tick 以更优名重建）。故命名门控为 #1071 自身引入 collapse 自愈后的**遗留物**，其「Routine 名创建即定格、绝不可原始文件名兜底」的理由已自相矛盾。

## 改动（最小干预 · 仅命名门控）

| 文件 | 变更 |
|---|---|
| `pdf_fidelity_patrol.py` | 移除 `_select_next_pending_doc` 命名门控谓词；docstring 改述为正交分解语义 |
| `test_pdf_fidelity_patrol_handler.py` | 翻转单测断言（命名门控 存在→不存在，防回归） |
| `test_pdf_fidelity_patrol_integration.py` | 新增回归：未巡检且无 `display_name`/`title` 的 PDF 满足 selector 资格谓词；更新过时注释 |
| `pdf-fidelity-patrol-status.md` | selector 门控清单删除「命名门控」条目，补命名下沉说明 |

巡检资格仅由 `patrol_status IS NULL` + 「一文一活跃巡检」`NOT EXISTS` 决定；命名关注下沉到 `_doc_display_title`。防重试死循环是 `NOT EXISTS` 门 + reconcile 的职责，与命名门控无关——**不引入新的死循环风险**。

## 验证

- ✅ 单测 `test_pdf_fidelity_patrol_handler.py`：**22 passed**（含翻转后的命名门控防回归断言）
- ✅ 集成测试 `test_pdf_fidelity_patrol_integration.py`：**28 passed**（含新增 `test_select_next_pending_doc_includes_untitled_pdf` 回归）
- ✅ Ruff lint / format 全通过
- ✅ 线上库只读复跑 post-fix selector SQL：返回 `2603.05344v3.pdf`、`Loop-Engineering-IEEE.pdf`（此前均被误排）

## 副作用与边界

- **副作用**：仅剩原始文件名（含 arxiv-ID 如 `2603.05344v3.pdf`）作 Routine 名的文档也会被巡检——Routine 名为展示性，collapse 自愈会在更优名源出现后重建。已与用户确认接受（巡检正确性优先于 Routine 名美观）。
- **不触碰**：`patrol_status` 四态语义、`unfixable` 终态（仍需用户「重置为未拟合」才重巡）、`reset_patrol_status`、reconcile、collapse——均维持现状。

🤖 Generated with [Claude Code](https://github.com/anthropic)